### PR TITLE
dev-vcs/git: fix dependencies (dev-lang/tk:0 and dev-libs/openssl:0)

### DIFF
--- a/dev-vcs/git/git-1.8.5.6.ebuild
+++ b/dev-vcs/git/git-1.8.5.6.ebuild
@@ -41,7 +41,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-1.8.5.6.ebuild
+++ b/dev-vcs/git/git-1.8.5.6.ebuild
@@ -45,7 +45,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-1.9.5.ebuild
+++ b/dev-vcs/git/git-1.9.5.ebuild
@@ -41,7 +41,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-1.9.5.ebuild
+++ b/dev-vcs/git/git-1.9.5.ebuild
@@ -45,7 +45,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.0.5.ebuild
+++ b/dev-vcs/git/git-2.0.5.ebuild
@@ -42,7 +42,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-2.0.5.ebuild
+++ b/dev-vcs/git/git-2.0.5.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.1.4.ebuild
+++ b/dev-vcs/git/git-2.1.4.ebuild
@@ -42,7 +42,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-2.1.4.ebuild
+++ b/dev-vcs/git/git-2.1.4.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.2.2.ebuild
+++ b/dev-vcs/git/git-2.2.2.ebuild
@@ -42,7 +42,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-2.2.2.ebuild
+++ b/dev-vcs/git/git-2.2.2.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.3.6.ebuild
+++ b/dev-vcs/git/git-2.3.6.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk:= )
+	tk? ( dev-lang/tk:0= )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.3.8.ebuild
+++ b/dev-vcs/git/git-2.3.8.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk:= )
+	tk? ( dev-lang/tk:0= )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.4.6.ebuild
+++ b/dev-vcs/git/git-2.4.6.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk:= )
+	tk? ( dev-lang/tk:0= )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.4.7.ebuild
+++ b/dev-vcs/git/git-2.4.7.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk:= )
+	tk? ( dev-lang/tk:0= )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.4.8.ebuild
+++ b/dev-vcs/git/git-2.4.8.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk:= )
+	tk? ( dev-lang/tk:0= )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-2.5.0.ebuild
+++ b/dev-vcs/git/git-2.5.0.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk:= )
+	tk? ( dev-lang/tk:0= )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-9999-r1.ebuild
+++ b/dev-vcs/git/git-9999-r1.ebuild
@@ -42,7 +42,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-9999-r1.ebuild
+++ b/dev-vcs/git/git-9999-r1.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-9999-r2.ebuild
+++ b/dev-vcs/git/git-9999-r2.ebuild
@@ -42,7 +42,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-9999-r2.ebuild
+++ b/dev-vcs/git/git-9999-r2.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-9999-r3.ebuild
+++ b/dev-vcs/git/git-9999-r3.ebuild
@@ -42,7 +42,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-9999-r3.ebuild
+++ b/dev-vcs/git/git-9999-r3.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )

--- a/dev-vcs/git/git-9999.ebuild
+++ b/dev-vcs/git/git-9999.ebuild
@@ -42,7 +42,7 @@ IUSE="+blksha1 +curl cgi doc emacs gnome-keyring +gpg gtk highlight +iconv media
 
 # Common to both DEPEND and RDEPEND
 CDEPEND="
-	dev-libs/openssl
+	dev-libs/openssl:0
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )

--- a/dev-vcs/git/git-9999.ebuild
+++ b/dev-vcs/git/git-9999.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	sys-libs/zlib
 	pcre? ( dev-libs/libpcre )
 	perl? ( dev-lang/perl:=[-build(-)] )
-	tk? ( dev-lang/tk )
+	tk? ( dev-lang/tk:0 )
 	curl? (
 		net-misc/curl
 		webdav? ( dev-libs/expat )


### PR DESCRIPTION
This fixes the repoman warnings. I chose not to revbump (although it would be strictly required to update the VDB), since I doubt any user doesn't have `:0` installed for any of those deps.

@robbat2 