### PR TITLE
app-backup/tsm: Fix bug #530900

### DIFF
--- a/app-backup/tsm/tsm-7.1.0.0-r1.ebuild
+++ b/app-backup/tsm/tsm-7.1.0.0-r1.ebuild
@@ -56,7 +56,7 @@ RDEPEND="
 	dev-libs/libxml2
 	=sys-fs/fuse-2*
 	acl? ( sys-apps/acl )
-	java? ( virtual/jre:1.6 )
+	java? ( virtual/jre:1.7 )
 "
 
 S="${WORKDIR}"


### PR DESCRIPTION
Was previously https://github.com/gentoo/gentoo-portage-rsync-mirror/pull/189. This fixes bug https://bugs.gentoo.org/show_bug.cgi?id=530900, which was accidental closed.