### PR TITLE
sci-misc/boinc: Mask USE=X on arches with unkeyworded deps, use wxGTK 3.0

### DIFF
--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -277,3 +277,7 @@ dev-lisp/clisp hyperspec pari svm
 
 # missing keywords
 media-plugins/gst-plugins-meta dts dv lame libvisual modplug mms taglib vcd wavpack
+
+# Marius Brehler <marfbre@linux.sungazer.de> (13 Aug 2015)
+# missing keyword
+>=sci-misc/boinc-7.4.42-r1 X

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -321,3 +321,7 @@ net-libs/ortp srtp
 # Ultrabug <ultrabug@gentoo.org) (05 Sept 2011)
 # missing keyword for net-libs/zeromq
 app-admin/rsyslog zeromq
+
+# Marius Brehler <marfbre@linux.sungazer.de> (13 Aug 2015)
+# missing keyword
+>=sci-misc/boinc-7.4.42-r1 X

--- a/sci-misc/boinc/boinc-7.4.42-r1.ebuild
+++ b/sci-misc/boinc/boinc-7.4.42-r1.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 		virtual/jpeg:0=
 		x11-libs/gtk+:2
 		>=x11-libs/libnotify-0.7
-		x11-libs/wxGTK:2.8[X,opengl]
+		x11-libs/wxGTK:3.0[X,opengl,webkit]
 	)
 "
 DEPEND="${RDEPEND}
@@ -74,7 +74,7 @@ src_configure() {
 
 	# look for wxGTK
 	if use X; then
-		WX_GTK_VER="2.8"
+		WX_GTK_VER="3.0"
 		need-wxwidgets unicode
 		myeconfargs+=(--with-wx-config="${WX_CONFIG}")
 	else


### PR DESCRIPTION
This fixes bug https://bugs.gentoo.org/show_bug.cgi?id=556670. The arches ~ia64 and ~sparc were dropped, since wxGTK[webkit] is not supported on those platforms. Maybe an additional useflag should be added to boinc or the X useflag should be masked for the arches.