### PR TITLE
kde-misc/krename: Use subslot operator for exiv2

### DIFF
--- a/kde-misc/krename/krename-4.0.9-r3.ebuild
+++ b/kde-misc/krename/krename-4.0.9-r3.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="amd64 x86"
 IUSE="debug exif pdf taglib truetype"
 
 RDEPEND="
-	exif? ( >=media-gfx/exiv2-0.13 )
+	exif? ( >=media-gfx/exiv2-0.13:= )
 	pdf? ( >=app-text/podofo-0.8 )
 	taglib? ( >=media-libs/taglib-1.5 )
 	truetype? ( media-libs/freetype:2 )


### PR DESCRIPTION
Package-Manager: portage-2.2.20.1