### PR TITLE
x11-misc/sddm: Add patches for consolekit2 support

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -51,6 +51,10 @@ sys-devel/dragonegg
 =sys-devel/llvm-3.7.0*
 =sys-devel/clang-3.7.0*
 
+# Andreas Sturmlechner <andreas.sturmlechner@gmail.com> (24 Aug 2015)
+# Masked until >=sys-auth/consolekit-0.9.2 gets unmasked
+=x11-misc/sddm-0.11.0-r2
+
 # Matt Turner <mattst88@gentoo.org> (22 Aug 2015)
 # nouveau has been in the kernel since 2.6.33
 # Masked for removal in 30 days.

--- a/x11-misc/sddm/files/sddm-0.11.0-consolekit2.patch
+++ b/x11-misc/sddm/files/sddm-0.11.0-consolekit2.patch
@@ -1,0 +1,91 @@
+From 7a8024639ee3ae7e128a9dc3efce90a07b4d316c Mon Sep 17 00:00:00 2001
+From: Eric Koegel <eric.koegel@gmail.com>
+Date: Mon, 6 Jul 2015 11:16:38 +0300
+Subject: [PATCH] ConsoleKit2 support for system actions
+
+This adds support for calling ConsoleKit2's DBUS API for shutdown,
+reboot, suspend, and hibernate. It does so by using the exact same
+interface as login1, making it a shared seat manager backend.
+---
+ INSTALL                     |  4 ++--
+ src/daemon/PowerManager.cpp | 26 +++++++++++++++++---------
+ 2 files changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/INSTALL b/INSTALL
+index 77b6a8b..5d16710 100644
+--- a/INSTALL
++++ b/INSTALL
+@@ -30,8 +30,8 @@ its home set to `/var/lib/sddm` by default.
+ SDDM depends on PAM for authorization and XCB to communicate with the X server.
+ Apart from other things, it also depends on Qt for the user interface and event
+ loop management.
+-SDDM can optionally make use of logind (the systemd login manager API) or
+-upower to enable support for suspend, hibernate etc.
++SDDM can optionally make use of logind (the systemd login manager API), or
++ConsoleKit2, or upower to enable support for suspend, hibernate etc.
+ In order to build the man pages, you will need `rst2man` installed. It is
+ provided by the python `docutils` package
+ 
+diff --git a/src/daemon/PowerManager.cpp b/src/daemon/PowerManager.cpp
+index 3a4d25d..6329032 100644
+--- a/src/daemon/PowerManager.cpp
++++ b/src/daemon/PowerManager.cpp
+@@ -59,8 +59,8 @@ namespace SDDM {
+ 
+     class UPowerBackend : public PowerManagerBackend {
+     public:
+-        UPowerBackend() {
+-            m_interface = new QDBusInterface(UPOWER_SERVICE, UPOWER_PATH, UPOWER_OBJECT, QDBusConnection::systemBus());
++        UPowerBackend(const QString & service, const QString & path, const QString & interface) {
++            m_interface = new QDBusInterface(service, path, interface, QDBusConnection::systemBus());
+         }
+ 
+         ~UPowerBackend() {
+@@ -110,20 +110,24 @@ namespace SDDM {
+     };
+ 
+     /**********************************************/
+-    /* LOGIN1 BACKEND                             */
++    /* LOGIN1 && ConsoleKit2 BACKEND              */
+     /**********************************************/
+ 
+ #define LOGIN1_SERVICE  QStringLiteral("org.freedesktop.login1")
+ #define LOGIN1_PATH     QStringLiteral("/org/freedesktop/login1")
+ #define LOGIN1_OBJECT   QStringLiteral("org.freedesktop.login1.Manager")
+ 
+-    class Login1Backend : public PowerManagerBackend {
++#define CK2_SERVICE  QStringLiteral("org.freedesktop.ConsoleKit")
++#define CK2_PATH     QStringLiteral("/org/freedesktop/ConsoleKit/Manager")
++#define CK2_OBJECT   QStringLiteral("org.freedesktop.ConsoleKit.Manager")
++
++    class SeatManagerBackend : public PowerManagerBackend {
+     public:
+-        Login1Backend() {
+-            m_interface = new QDBusInterface(LOGIN1_SERVICE, LOGIN1_PATH, LOGIN1_OBJECT, QDBusConnection::systemBus());
++        SeatManagerBackend(const QString & service, const QString & path, const QString & interface) {
++            m_interface = new QDBusInterface(service, path, interface, QDBusConnection::systemBus());
+         }
+ 
+-        ~Login1Backend() {
++        ~SeatManagerBackend() {
+             delete m_interface;
+         }
+ 
+@@ -194,11 +198,15 @@ namespace SDDM {
+ 
+         // check if login1 interface exists
+         if (interface->isServiceRegistered(LOGIN1_SERVICE))
+-            m_backends << new Login1Backend();
++            m_backends << new SeatManagerBackend(LOGIN1_SERVICE, LOGIN1_PATH, LOGIN1_OBJECT);
++
++        // check if ConsoleKit2 interface exists
++        if (interface->isServiceRegistered(CK2_SERVICE))
++            m_backends << new SeatManagerBackend(CK2_SERVICE, CK2_PATH, CK2_OBJECT);
+ 
+         // check if upower interface exists
+         if (interface->isServiceRegistered(UPOWER_SERVICE))
+-            m_backends << new UPowerBackend();
++            m_backends << new UPowerBackend(UPOWER_SERVICE, UPOWER_PATH, UPOWER_OBJECT);
+     }
+ 
+     PowerManager::~PowerManager() {

--- a/x11-misc/sddm/files/sddm-0.11.0-upower.patch
+++ b/x11-misc/sddm/files/sddm-0.11.0-upower.patch
@@ -1,0 +1,11 @@
+--- a/src/daemon/PowerManager.cpp	2015-08-17 00:52:12.786176023 +0200
++++ b/src/daemon/PowerManager.cpp	2015-08-17 00:53:30.259207476 +0200
+@@ -209,7 +209,7 @@
+ #endif // HAVE_CONSOLEKIT2
+ 
+         // check if upower interface exists
+-        if (interface->isServiceRegistered(UPOWER_SERVICE))
++//        if (interface->isServiceRegistered(UPOWER_SERVICE))
+             m_backends << new UPowerBackend(UPOWER_SERVICE, UPOWER_PATH, UPOWER_OBJECT);
+     }
+ 

--- a/x11-misc/sddm/sddm-0.11.0-r2.ebuild
+++ b/x11-misc/sddm/sddm-0.11.0-r2.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+inherit cmake-utils toolchain-funcs user
+
+DESCRIPTION="Simple Desktop Display Manager"
+HOMEPAGE="https://github.com/sddm/sddm"
+SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+KEYWORDS="~amd64 ~arm ~x86"
+
+LICENSE="GPL-2+ MIT CC-BY-3.0 public-domain"
+SLOT="0"
+IUSE="consolekit systemd +upower"
+REQUIRED_USE="?? ( upower systemd )"
+
+RDEPEND="
+	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
+	dev-qt/qtdeclarative:5
+	dev-qt/linguist-tools:5
+	dev-qt/qttest:5
+	sys-libs/pam
+	>=x11-base/xorg-server-1.15.1
+	x11-libs/libxcb[xkb(-)]
+	consolekit? ( >=sys-auth/consolekit-0.9.4 )
+	systemd? ( sys-apps/systemd:= )
+	upower? ( || ( sys-power/upower sys-power/upower-pm-utils ) )"
+DEPEND="${RDEPEND}
+	>=sys-devel/gcc-4.7.0
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}-consolekit2.patch"
+	"${FILESDIR}/${P}-dbus-config.patch"
+)
+
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != binary  && $(tc-getCC) == *gcc* ]]; then
+		if [[ $(gcc-major-version) -lt 4 || $(gcc-major-version) == 4 && $(gcc-minor-version) -lt 7 ]] ; then
+			die 'The active compiler needs to be gcc 4.7 (or newer)'
+		fi
+	fi
+}
+
+pkg_setup() {
+	enewgroup ${PN}
+	enewuser ${PN} -1 -1 /var/lib/sddm ${PN}
+}
+
+src_prepare() {
+	cmake-utils_src_prepare
+
+	use consolekit && epatch "${FILESDIR}/${PN}-0.10.0-consolekit.patch"
+	use upower && epatch "${FILESDIR}/${P}-upower.patch"
+
+	# respect user's cflags
+	sed -e 's|-Wall -march=native||' \
+		-e 's|-O2||' \
+		-i CMakeLists.txt || die 'sed failed'
+}
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_no systemd SYSTEMD)
+		-DDBUS_CONFIG_FILENAME:STRING="org.freedesktop.sddm.conf"
+	)
+	cmake-utils_src_configure
+}
+
+pkg_postinst() {
+	ewarn "Add the sddm user manually to the video group"
+	ewarn "if you experience flickering or other rendering issues of sddm-greeter"
+	ewarn "see https://github.com/gentoo/qt/pull/52"
+}


### PR DESCRIPTION
USE=consolekit now means real consolekit2 support instead of a postinst message

ck2 patches taken from pending https://github.com/sddm/sddm/pull/438
carried over existing upower patch though not sure if still required or why it was introduced
dropped keywords as long as sys-auth/consolekit is masked

Package-Manager: portage-2.2.20.1