### PR TITLE
media-video/mpv: Delete rpi-gles option

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -226,7 +226,6 @@ src_configure() {
 		$(use_enable drm)
 		$(use_enable jpeg)
 		$(use_enable raspberry-pi rpi)
-		$(use_enable raspberry-pi rpi-gles)
 
 		# hwaccels
 		$(use_enable vaapi vaapi-hwaccel)


### PR DESCRIPTION
There is no such option anymore, see: https://github.com/mpv-player/mpv/commit/58ba2a9087dfa6bf6a81177c77f86e01acd33286
Current ebuild doesn't build on latest git master.

If something is wrong in my PR, consider it as bug report at least. I don't have RPi, so I'm not sure this is 100% correct patch.