### PR TITLE
sys-apps/ed: add ~amd64-fbsd keyword

### DIFF
--- a/sys-apps/ed/ed-1.12.ebuild
+++ b/sys-apps/ed/ed-1.12.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://fossies.org/linux/privat/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 DEPEND="sys-apps/texinfo"


### PR DESCRIPTION
sys-apps/ed is required to create a stage1.
Please add a keyword.

```
<snip>
[ebuild  N    ] sys-apps/ed-1.12 to /tmp/stage1root/
<snip>
The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by sys-freebsd/freebsd-bin-10.2::gentoo
# required by app-admin/perl-cleaner-2.20::gentoo
# required by dev-lang/perl-5.22.0::gentoo
# required by sys-devel/autoconf-2.69-r1::gentoo
# required by sys-devel/libtool-2.4.6-r1::gentoo
# required by sys-devel/libtool (argument)
=sys-apps/ed-1.12 **
```