### PR TITLE
profiles: FreeBSD 10.0 or later, python3 force set USE=threads on amd64-fbsd.

### DIFF
--- a/profiles/default/bsd/fbsd/amd64/10.1/package.use.force
+++ b/profiles/default/bsd/fbsd/amd64/10.1/package.use.force
@@ -1,4 +1,2 @@
 # >=dev-lang/python-3.2 requires threads, #494744
-=dev-lang/python-3.2* threads
-=dev-lang/python-3.3* threads
-
+=dev-lang/python-3* threads

--- a/profiles/default/bsd/fbsd/amd64/10.2/package.use.force
+++ b/profiles/default/bsd/fbsd/amd64/10.2/package.use.force
@@ -1,4 +1,2 @@
 # >=dev-lang/python-3.2 requires threads, #494744
-=dev-lang/python-3.2* threads
-=dev-lang/python-3.3* threads
-
+=dev-lang/python-3* threads


### PR DESCRIPTION
I was confirmed that this problem occurs in python 3.4.
I have changed the version specified.

FYI,
https://bugs.gentoo.org/show_bug.cgi?id=494744