### PR TITLE
Don't install cffi for PyPy

### DIFF
--- a/dev-python/bcrypt/bcrypt-2.0.0.ebuild
+++ b/dev-python/bcrypt/bcrypt-2.0.0.ebuild
@@ -23,9 +23,11 @@ IUSE=""
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	$(python_gen_cond_dep '>=dev-python/cffi-1.1:=[${PYTHON_USEDEP}]' 'python*')
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )
 	"
 RDEPEND="
 	$(python_gen_cond_dep '>=dev-python/cffi-1.1:=[${PYTHON_USEDEP}]' 'python*')
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )
 	>=dev-python/six-1.4.1[${PYTHON_USEDEP}]
 	!dev-python/py-bcrypt"
 

--- a/dev-python/cairocffi/cairocffi-0.5.3-r1.ebuild
+++ b/dev-python/cairocffi/cairocffi-0.5.3-r1.ebuild
@@ -18,7 +18,8 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="doc test"
 
-RDEPEND=">=dev-python/cffi-0.6:=[${PYTHON_USEDEP}]
+RDEPEND="
+	$(python_gen_cond_dep '>=dev-python/cffi-0.6:=[${PYTHON_USEDEP}]' 'python*')
 	x11-libs/cairo:0="
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
 	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )

--- a/dev-python/cairocffi/cairocffi-0.5.4.ebuild
+++ b/dev-python/cairocffi/cairocffi-0.5.4.ebuild
@@ -18,7 +18,8 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="doc test"
 
-RDEPEND=">=dev-python/cffi-0.6:=[${PYTHON_USEDEP}]
+RDEPEND="
+	$(python_gen_cond_dep '>=dev-python/cffi-0.6:=[${PYTHON_USEDEP}]' 'python*')
 	x11-libs/cairo:0="
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
 	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )

--- a/dev-python/cairocffi/cairocffi-0.6-r1.ebuild
+++ b/dev-python/cairocffi/cairocffi-0.6-r1.ebuild
@@ -21,7 +21,7 @@ IUSE="doc test"
 
 # xcffib is an optional extra excpet that the testsuite has it a hard coded unconditional component
 RDEPEND="
-	>=dev-python/cffi-0.6:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=dev-python/cffi-0.6:=[${PYTHON_USEDEP}]' 'python*')
 	x11-libs/cairo:0=
 	<dev-python/xcffib-0.3[${PYTHON_USEDEP}]
 	x11-libs/gdk-pixbuf[jpeg]"

--- a/dev-python/cairocffi/cairocffi-0.6.ebuild
+++ b/dev-python/cairocffi/cairocffi-0.6.ebuild
@@ -21,7 +21,7 @@ IUSE="doc test"
 
 # xcffib is an optional extra excpet that the testsuite has it a hard coded unconditional component
 RDEPEND="
-	>=dev-python/cffi-0.6:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=dev-python/cffi-0.6:=[${PYTHON_USEDEP}]' 'python*')
 	x11-libs/cairo:0=
 	<dev-python/xcffib-0.3[${PYTHON_USEDEP}]"
 

--- a/dev-python/cairocffi/cairocffi-0.7.1.ebuild
+++ b/dev-python/cairocffi/cairocffi-0.7.1.ebuild
@@ -21,10 +21,11 @@ KEYWORDS="~amd64 ~x86"
 IUSE="doc test"
 
 RDEPEND="
-	>=dev-python/cffi-1.1.0:=[$(python_gen_usedep 'python*')]
+	$(python_gen_cond_dep '>=dev-python/cffi-1.1.0:=[${PYTHON_USEDEP}]' 'python*')
 	>=dev-python/xcffib-0.3.2[${PYTHON_USEDEP}]
 	x11-libs/cairo:0=
-	x11-libs/gdk-pixbuf[jpeg]"
+	x11-libs/gdk-pixbuf[jpeg]
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )"
 
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
@@ -32,7 +33,8 @@ DEPEND="
 	test? (
 		${RDEPEND}
 		dev-python/pytest[${PYTHON_USEDEP}]
-	)"
+	)
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )"
 
 PATCHES=(
 	# Intersphinx cause the usual d'loading of objects.inv from TWO online sites

--- a/dev-python/cairocffi/cairocffi-0.7.2.ebuild
+++ b/dev-python/cairocffi/cairocffi-0.7.2.ebuild
@@ -21,10 +21,11 @@ KEYWORDS="~amd64 ~x86"
 IUSE="doc test"
 
 RDEPEND="
-	>=dev-python/cffi-1.1.0:=[$(python_gen_usedep 'python*')]
+	$(python_gen_cond_dep '>=dev-python/cffi-1.1.0:=[${PYTHON_USEDEP}]' 'python*')
 	>=dev-python/xcffib-0.3.2[${PYTHON_USEDEP}]
 	x11-libs/cairo:0=
-	x11-libs/gdk-pixbuf[jpeg]"
+	x11-libs/gdk-pixbuf[jpeg]
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )"
 
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
@@ -32,7 +33,8 @@ DEPEND="
 	test? (
 		${RDEPEND}
 		dev-python/pytest[${PYTHON_USEDEP}]
-	)"
+	)
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )"
 
 PATCHES=(
 	# Intersphinx cause the usual d'loading of objects.inv from TWO online sites

--- a/dev-python/cffi/cffi-0.8.6.ebuild
+++ b/dev-python/cffi/cffi-0.8.6.ebuild
@@ -3,7 +3,7 @@
 # $Id$
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_3,3_4} pypy )
+PYTHON_COMPAT=( python{2_7,3_3,3_4} )
 
 inherit distutils-r1
 

--- a/dev-python/cffi/cffi-1.1.2.ebuild
+++ b/dev-python/cffi/cffi-1.1.2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="5"
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} pypy )
+PYTHON_COMPAT=( python{2_7,3_3,3_4} )
 
 inherit distutils-r1
 

--- a/dev-python/cffi/cffi-1.2.1.ebuild
+++ b/dev-python/cffi/cffi-1.2.1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="5"
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} pypy )
+PYTHON_COMPAT=( python{2_7,3_3,3_4} )
 
 inherit distutils-r1
 

--- a/dev-python/cryptography/cryptography-1.0.ebuild
+++ b/dev-python/cryptography/cryptography-1.0.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 # only works with >=pypy-2.6
-PYTHON_COMPAT=( python2_7 python3_{3,4} )
+PYTHON_COMPAT=( python2_7 python3_{3,4} pypy )
 
 inherit distutils-r1
 
@@ -27,6 +27,7 @@ RDEPEND="
 	>=dev-python/pyasn1-0.1.8[${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	>=dev-python/six-1.4.1[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )
 	"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]

--- a/dev-python/xcffib/xcffib-0.1.10.ebuild
+++ b/dev-python/xcffib/xcffib-0.1.10.ebuild
@@ -19,7 +19,7 @@ IUSE=""
 COMMON_DEPEND="x11-libs/libxcb"
 
 RDEPEND="
-	>=dev-python/cffi-0.8.2:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=dev-python/cffi-0.8.2:=[${PYTHON_USEDEP}]' 'python*')
 	dev-python/six[${PYTHON_USEDEP}]
 	${COMMON_DEPEND}"
 DEPEND="

--- a/dev-python/xcffib/xcffib-0.2.0.ebuild
+++ b/dev-python/xcffib/xcffib-0.2.0.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86"
 COMMON_DEPEND="x11-libs/libxcb"
 
 RDEPEND="
-	>=dev-python/cffi-0.8.2:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=dev-python/cffi-0.8.2:=[${PYTHON_USEDEP}]' 'python*')
 	dev-python/six[${PYTHON_USEDEP}]
 	${COMMON_DEPEND}"
 DEPEND="

--- a/dev-python/xcffib/xcffib-0.2.1.ebuild
+++ b/dev-python/xcffib/xcffib-0.2.1.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86"
 COMMON_DEPEND="x11-libs/libxcb"
 
 RDEPEND="
-	>=dev-python/cffi-0.8.2:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=dev-python/cffi-0.8.2:=[${PYTHON_USEDEP}]' 'python*')
 	dev-python/six[${PYTHON_USEDEP}]
 	${COMMON_DEPEND}"
 DEPEND="

--- a/dev-python/xcffib/xcffib-0.2.5.ebuild
+++ b/dev-python/xcffib/xcffib-0.2.5.ebuild
@@ -20,8 +20,9 @@ IUSE="test"
 COMMON_DEPEND="x11-libs/libxcb"
 
 RDEPEND="
-	>=dev-python/cffi-0.8.2:=[${PYTHON_USEDEP}]
-	<dev-python/cffi-1:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=dev-python/cffi-0.8.2:=[${PYTHON_USEDEP}]' 'python*')
+	$(python_gen_cond_dep '<dev-python/cffi-1:=[${PYTHON_USEDEP}]' 'python*')
+	$(python_gen_cond_dep '<virtual/pypy-2.6.0' pypy )
 	dev-python/six[${PYTHON_USEDEP}]
 	${COMMON_DEPEND}"
 DEPEND="

--- a/dev-python/xcffib/xcffib-0.3.2.ebuild
+++ b/dev-python/xcffib/xcffib-0.3.2.ebuild
@@ -20,7 +20,8 @@ IUSE="test"
 COMMON_DEPEND="x11-libs/libxcb"
 
 RDEPEND="
-	>=dev-python/cffi-0.1.1:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=dev-python/cffi-1.1:=[${PYTHON_USEDEP}]' 'python*')
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )
 	dev-python/six[${PYTHON_USEDEP}]
 	${COMMON_DEPEND}"
 DEPEND="

--- a/dev-python/xcffib/xcffib-0.3.4.ebuild
+++ b/dev-python/xcffib/xcffib-0.3.4.ebuild
@@ -20,7 +20,8 @@ IUSE="test"
 COMMON_DEPEND="x11-libs/libxcb"
 
 RDEPEND="
-	>=dev-python/cffi-0.1.1:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '>=dev-python/cffi-1.1:=[${PYTHON_USEDEP}]' 'python*')
+	$(python_gen_cond_dep '>=virtual/pypy-2.6.0' pypy )
 	dev-python/six[${PYTHON_USEDEP}]
 	${COMMON_DEPEND}"
 DEPEND="


### PR DESCRIPTION
Cffi shouldn't be installed for PyPy, PyPy ships with a version of cffi in its core, and we shouldn't be installing a (potentially different) version of cffi over top of it. This removes pypy from PYTHON_TARGETS for dev-python/cffi and adjusts the dependencies of all PyPy-compatible packages that require cffi, both fixing the cffi use flags and, when >=cffi-1.0 is required, ensuring a new enough version of PyPy is installed.

I've also re-added the PyPy target to dev-python/cryptography, also adding the PyPy version requirement, I noticed pypy was dropped by @jlec in 86ff0808ed5b321913e4458d2fa87466bc25d11a, though he noted the version requirement.