### PR TITLE
dev-perl/Net-SSLeay: fix slot :0 on dev-libs/openssl

### DIFF
--- a/dev-perl/Net-SSLeay/Net-SSLeay-1.650.0-r1.ebuild
+++ b/dev-perl/Net-SSLeay/Net-SSLeay-1.650.0-r1.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
-RDEPEND="dev-libs/openssl"
+RDEPEND="dev-libs/openssl:0"
 DEPEND="${RDEPEND}"
 #	test? ( dev-perl/Test-Exception
 #		dev-perl/Test-Warn


### PR DESCRIPTION
Slot 0.9.8 is only for binary compatibility (does not even provide headers)
and SSLeay will not compile with only that SLOT installed.