### PR TITLE
bug 547630 (www-client/chromium-44.0.2376.0 Fails to Compile with +widevine)

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -366,6 +366,11 @@ dev-libs/elfutils threads
 # Build failures (bug 499072)
 =www-client/chromium-33* aura
 
+# Greg Turner <gmt@be-evil.net> (24 Aug 2015)
+# Arch profiles may undo this as appropriate to whitelist
+# chromium widevine-cdm support (bug 547630).
+www-client/chromium widevine
+
 # Andreas K. Huettel <dilfridge@gentoo.org> (4 Jan 2014)
 # Mask until dependencies are keyworded (bug 497068)
 dev-vcs/git mediawiki

--- a/profiles/default/linux/amd64/package.use.mask
+++ b/profiles/default/linux/amd64/package.use.mask
@@ -5,3 +5,7 @@
 # Mike Frysinger <vapier@gentoo.org> (21 Oct 2014)
 # This target supports ASAN/etc... #504200.
 sys-devel/gcc -sanitize
+
+# Greg Turner <gmt@be-evil.net> (24 Aug 2015)
+# Chromium supports widevine cdm on this target (#547630)
+www-client/chromium -widevine

--- a/profiles/default/linux/x86/package.use.mask
+++ b/profiles/default/linux/x86/package.use.mask
@@ -5,3 +5,7 @@
 # Mike Frysinger <vapier@gentoo.org> (21 Oct 2014)
 # This target supports ASAN/etc... #504200.
 sys-devel/gcc -sanitize
+
+# Greg Turner <gmt@be-evil.net> (24 Aug 2015)
+# Chromium supports widevine cdm on this target (#547630)
+www-client/chromium -widevine

--- a/www-client/chromium/chromium-45.0.2454.46.ebuild
+++ b/www-client/chromium/chromium-45.0.2454.46.ebuild
@@ -19,7 +19,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${P}
 LICENSE="BSD hotwording? ( no-source-code )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="cups gnome gnome-keyring hidpi hotwording kerberos neon pic +proprietary-codecs pulseaudio selinux +tcmalloc"
+IUSE="cups gnome gnome-keyring hidpi hotwording kerberos neon pic +proprietary-codecs pulseaudio selinux +tcmalloc widevine"
 RESTRICT="proprietary-codecs? ( bindist )"
 
 # Native Client binaries are compiled with different set of flags, bug #452066.
@@ -91,7 +91,8 @@ DEPEND="${RDEPEND}
 	sys-apps/hwids[usb(+)]
 	>=sys-devel/bison-2.4.3
 	sys-devel/flex
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	widevine? ( www-plugins/chrome-binary-plugins[widevine] )"
 
 # For nvidia-drivers blocker, see bug #413637 .
 RDEPEND+="
@@ -121,6 +122,9 @@ python_check_deps() {
 if ! has chromium_pkg_die ${EBUILD_DEATH_HOOKS}; then
 	EBUILD_DEATH_HOOKS+=" chromium_pkg_die";
 fi
+
+# TODO: flag-mask widevine in non-intel profiles in lieu of this
+REQUIRED_USE="|| ( x86 amd64 !widevine )"
 
 DISABLE_AUTOFORMATTING="yes"
 DOC_CONTENTS="
@@ -187,6 +191,9 @@ src_prepare() {
 	# fi
 
 	epatch "${FILESDIR}/${PN}-system-jinja-r7.patch"
+
+	# sneak around widevine cdm versioning minefield
+	epatch "${FILESDIR}/${PN}-45-widevine-version-hack.patch"
 
 	epatch_user
 
@@ -366,7 +373,8 @@ src_configure() {
 		$(gyp_use hotwording enable_hotwording)
 		$(gyp_use kerberos)
 		$(gyp_use pulseaudio)
-		$(gyp_use tcmalloc use_allocator tcmalloc none)"
+		$(gyp_use tcmalloc use_allocator tcmalloc none)
+		$(gyp_use widevine enable_widevine)"
 
 	# Use explicit library dependencies instead of dlopen.
 	# This makes breakages easier to detect by revdep-rebuild.
@@ -585,6 +593,10 @@ src_install() {
 
 	newman out/Release/chrome.1 chromium${CHROMIUM_SUFFIX}.1 || die
 	newman out/Release/chrome.1 chromium-browser${CHROMIUM_SUFFIX}.1 || die
+
+	if use widevine; then
+		doexe out/Release/libwidevinecdmadapter.so
+	fi
 
 	# Install icons and desktop entry.
 	local branding size

--- a/www-client/chromium/chromium-45.0.2454.46.ebuild
+++ b/www-client/chromium/chromium-45.0.2454.46.ebuild
@@ -123,9 +123,6 @@ if ! has chromium_pkg_die ${EBUILD_DEATH_HOOKS}; then
 	EBUILD_DEATH_HOOKS+=" chromium_pkg_die";
 fi
 
-# TODO: flag-mask widevine in non-intel profiles in lieu of this
-REQUIRED_USE="|| ( x86 amd64 !widevine )"
-
 DISABLE_AUTOFORMATTING="yes"
 DOC_CONTENTS="
 Some web pages may require additional fonts to display properly.

--- a/www-client/chromium/files/chromium-45-widevine-version-hack.patch
+++ b/www-client/chromium/files/chromium-45-widevine-version-hack.patch
@@ -1,0 +1,40 @@
+diff -urpN chromium-45.0.2454.85.orig/third_party/widevine/cdm/stub/widevine_cdm_version.h chromium-45.0.2454.85/third_party/widevine/cdm/stub/widevine_cdm_version.h
+--- chromium-45.0.2454.85.orig/third_party/widevine/cdm/stub/widevine_cdm_version.h	2015-08-22 12:01:59.000000000 -0700
++++ chromium-45.0.2454.85/third_party/widevine/cdm/stub/widevine_cdm_version.h	2015-09-07 15:56:23.565523620 -0700
+@@ -5,11 +5,4 @@
+ // This is a stand-in for a generated file that is available when the
+ // Widevine CDM is available.
+ 
+-#ifndef WIDEVINE_CDM_VERSION_H_
+-#define WIDEVINE_CDM_VERSION_H_
+-
+-#include "third_party/widevine/cdm/widevine_cdm_common.h"
+-
+-#define WIDEVINE_CDM_AVAILABLE
+-
+-#endif  // WIDEVINE_CDM_VERSION_H_
++#include "third_party/widevine/cdm/widevine_cdm_version.h"
+diff -urpN chromium-45.0.2454.85.orig/third_party/widevine/cdm/widevine_cdm_version.h chromium-45.0.2454.85/third_party/widevine/cdm/widevine_cdm_version.h
+--- chromium-45.0.2454.85.orig/third_party/widevine/cdm/widevine_cdm_version.h	2015-09-07 15:54:27.540799242 -0700
++++ chromium-45.0.2454.85/third_party/widevine/cdm/widevine_cdm_version.h	2015-09-07 15:53:51.289197885 -0700
+@@ -14,4 +14,20 @@
+ //  - WIDEVINE_CDM_VERSION_STRING (with the version of the CDM that's available
+ //    as a string, e.g., "1.0.123.456").
+ 
++#include "third_party/widevine/cdm/widevine_cdm_common.h"
++#define WIDEVINE_CDM_AVAILABLE 1
++
++// Gentoo uses purportedly "unsupported" widevine code-paths, designed for
++// (i.e.) Chrome for Windows, which presume the widevine cdm is a dynamic
++// component updated according to an end-user run-time mechanism and a policy
++// set by Google.
++//
++// Gentoo's chromium will instead load the CDM version provided by the
++// www-plugins/chrome-binary-plugins package. We don't yet know what version
++// this will be (unless we want to create a costly reverse dependency).  Until
++// upstream comes up with a better solution (it seems they're working on it),
++// we opt to lie, but to do so conspicuously, so as to avoid confusing humans.
++//
++#define WIDEVINE_CDM_VERSION_STRING "unsupported.gentoo.widevine-cdm.hack"
++
+ #endif  // WIDEVINE_CDM_VERSION_H_

--- a/www-client/chromium/metadata.xml
+++ b/www-client/chromium/metadata.xml
@@ -9,5 +9,6 @@
 		<flag name="pic">Disable optimized assembly code that is not PIC friendly</flag>
 		<flag name="proprietary-codecs">Enable proprietary codecs like H.264, MP3</flag>
 		<flag name="tcmalloc">Use bundled tcmalloc instead of system malloc</flag>
+		<flag name="widevine">Unsupported closed-source DRM capability (required by Netflix VOD)</flag>
 	</use>
 </pkgmetadata>

--- a/www-plugins/chrome-binary-plugins/chrome-binary-plugins-45.0.2454.85_p1.ebuild
+++ b/www-plugins/chrome-binary-plugins/chrome-binary-plugins-45.0.2454.85_p1.ebuild
@@ -80,9 +80,10 @@ src_install() {
 		doins libwidevinecdm.so
 		strings ./chrome | grep -C 1 " (version:" | tail -1 > widevine.version
 		doins widevine.version
-		einfo "Please note that if you intend to use this with www-clients/chromium,"
-		einfo "you'll need to enable the widevine USE flag there as well, in order to"
-		einfo "utilize the widevine USE flag that's been used here."
+		einfo "Please note that www-client/chromium only supports the widevine plugin"
+		einfo "when built with its widevine USE flag enabled.  Unfortunately, versions"
+		einfo "of www-client/chromium not offering the widevine USE flag can't use the"
+		einfo "plugin.  As of 08/2015, only the latest ebuilds in the beta SLOT do so."
 	fi
 
 	if use flash; then

--- a/www-plugins/chrome-binary-plugins/chrome-binary-plugins-46.0.2490.13_beta1.ebuild
+++ b/www-plugins/chrome-binary-plugins/chrome-binary-plugins-46.0.2490.13_beta1.ebuild
@@ -80,9 +80,10 @@ src_install() {
 		doins libwidevinecdm.so
 		strings ./chrome | grep -C 1 " (version:" | tail -1 > widevine.version
 		doins widevine.version
-		einfo "Please note that if you intend to use this with www-clients/chromium,"
-		einfo "you'll need to enable the widevine USE flag there as well, in order to"
-		einfo "utilize the widevine USE flag that's been used here."
+		einfo "Please note that www-client/chromium only supports the widevine plugin"
+		einfo "when built with its widevine USE flag enabled.  Unfortunately, versions"
+		einfo "of www-client/chromium not offering the widevine USE flag can't use the"
+		einfo "plugin.  As of 08/2015, only the latest ebuilds in the beta SLOT do so."
 	fi
 
 	if use flash; then

--- a/www-plugins/chrome-binary-plugins/chrome-binary-plugins-47.0.2498.0_alpha1.ebuild
+++ b/www-plugins/chrome-binary-plugins/chrome-binary-plugins-47.0.2498.0_alpha1.ebuild
@@ -80,9 +80,10 @@ src_install() {
 		doins libwidevinecdm.so
 		strings ./chrome | grep -C 1 " (version:" | tail -1 > widevine.version
 		doins widevine.version
-		einfo "Please note that if you intend to use this with www-clients/chromium,"
-		einfo "you'll need to enable the widevine USE flag there as well, in order to"
-		einfo "utilize the widevine USE flag that's been used here."
+		einfo "Please note that www-client/chromium only supports the widevine plugin"
+		einfo "when built with its widevine USE flag enabled.  Unfortunately, versions"
+		einfo "of www-client/chromium not offering the widevine USE flag can't use the"
+		einfo "plugin.  As of 08/2015, only the latest ebuilds in the beta SLOT do so."
 	fi
 
 	if use flash; then

--- a/www-plugins/chrome-binary-plugins/chrome-binary-plugins-9999.ebuild
+++ b/www-plugins/chrome-binary-plugins/chrome-binary-plugins-9999.ebuild
@@ -80,9 +80,10 @@ src_install() {
 		doins libwidevinecdm.so
 		strings ./chrome | grep -C 1 " (version:" | tail -1 > widevine.version
 		doins widevine.version
-		einfo "Please note that if you intend to use this with www-clients/chromium,"
-		einfo "you'll need to enable the widevine USE flag there as well, in order to"
-		einfo "utilize the widevine USE flag that's been used here."
+		einfo "Please note that www-client/chromium only supports the widevine plugin"
+		einfo "when built with its widevine USE flag enabled.  Unfortunately, versions"
+		einfo "of www-client/chromium not offering the widevine USE flag can't use the"
+		einfo "plugin.  As of 08/2015, only the latest ebuilds in the beta SLOT do so."
 	fi
 
 	if use flash; then


### PR DESCRIPTION
The "deepest" commit (0f15cb0 - github displays PR patches in reverse order relative to git, making a muddle out of PR patch-ordering discussion) includes the state-of-the-art collaboratively cooked-up recipe for chromium widevine enablement on gentoo.

The middle one (4b2faff) tries to implement the "TODO" from the ebuild and turn the REQUIRED_USE into a package.use.mask cascade.  I'm pretty unsure about this one, it needs some review.

The head commit (3c2a24c) updates the blurb of einfo that www-plugins/chrome-binary-plugins[widevine] spews to be a more clear, accurate and up-to-date.  The live gx86 behavior is quite confusing, encouraging the user to enable a local use-flag which no longer exists in the cited gx86 package.  0f15cb0 only partially fixes that; this goes the whole way).