### PR TITLE
media-sound/spotify: Fix homepage URL

### DIFF
--- a/media-sound/spotify/spotify-0.9.17.1-r1.ebuild
+++ b/media-sound/spotify/spotify-0.9.17.1-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils fdo-mime gnome2-utils pax-utils unpacker
 
 DESCRIPTION="Spotify is a social music platform"
-HOMEPAGE="https://www.spotify.com/ch-de/download/previews/"
+HOMEPAGE="https://www.spotify.com/download/previews/"
 MY_PV="${PV}.g9b85d43.7-1"
 MY_P="${PN}-client_${MY_PV}"
 SRC_BASE="http://repository.spotify.com/pool/non-free/${PN:0:1}/${PN}/"


### PR DESCRIPTION
The URL link has a 'ch-de' localization tag, which
prints messages in German.

Package-Manager: portage-2.2.20.1