### PR TITLE
Fixed likwid-4.0.1 ebuild. source package name had changed

### DIFF
--- a/sys-apps/likwid/likwid-4.0.1.ebuild
+++ b/sys-apps/likwid/likwid-4.0.1.ebuild
@@ -31,6 +31,8 @@ FILECAPS=(
 	cap_sys_rawio usr/bin/likwid-{perfctr,bench,powermeter}
 )
 
+S=${WORKDIR}/likwid-likwid-${PV}
+
 src_prepare() {
 	# See Bug 558402
 	epatch "${FILESDIR}"/${P}-Makefile.patch \


### PR DESCRIPTION
Fixing bug 
https://bugs.gentoo.org/show_bug.cgi?id=558664

The source package name had changed by upstream.
