### PR TITLE
[RFC] profiles: Update kde package.use, set qt5 where necessary

### DIFF
--- a/profiles/targets/desktop/kde/package.use
+++ b/profiles/targets/desktop/kde/package.use
@@ -28,3 +28,10 @@ media-libs/phonon designer
 
 # Enable crash-reporter here instead of in ebuild
 kde-apps/kdebase-runtime-meta crash-reporter
+
+# Required by KDE Applications 15.08
+app-crypt/qca qt5
+>=dev-libs/libdbusmenu-qt-0.9.3_pre20140619-r1 qt5
+>=media-libs/phonon-4.8.3 qt5
+>=media-libs/phonon-vlc-0.8.2 qt5
+sys-auth/polkit-qt qt5


### PR DESCRIPTION
Qt5 is now stable and KDE Applications 15.08 entering tree, for ~arch users
already being presented as upgrades from KDE SC 4.14.3. As a mixed Qt4/Qt5
release it is inevitable that they run into required package.use changes.
This adds a first set of required package.use entries to ease the update.
- arch users who want to avoid Qt5 already need to maintain a package.mask,
  so this will only require an additional USE=-qt5 in make.conf
- Adding USE=qt5 only to ~arch package versions where possible so stable
  isn't bugged immediately, though not strictly necessary w/ the above