### PR TITLE
'Port' kde-wallpapers to kf5, fix kde-base/kdebase-startkde RDEPEND

### DIFF
--- a/kde-apps/kde-wallpapers/files/kde-wallpapers-15.08.0-kf5-port.patch
+++ b/kde-apps/kde-wallpapers/files/kde-wallpapers-15.08.0-kf5-port.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt	2015-08-30 14:18:57.169314811 +0200
++++ b/CMakeLists.txt	2015-08-30 14:17:34.534347890 +0200
+@@ -1,5 +1,10 @@
+-find_package(KDE4 REQUIRED)
+-include(KDE4Defaults)
++cmake_minimum_required(VERSION 2.8.12)
++
++find_package(ECM 0.0.9 REQUIRED NO_MODULE)
++set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
++
++include(KDEInstallDirs)
++include(KDECMakeSettings)
+ 
+ install(DIRECTORY Ariya DESTINATION ${WALLPAPER_INSTALL_DIR} PATTERN .svn EXCLUDE)
+ 

--- a/kde-apps/kde-wallpapers/kde-wallpapers-15.08.0.ebuild
+++ b/kde-apps/kde-wallpapers/kde-wallpapers-15.08.0.ebuild
@@ -13,7 +13,10 @@ DESCRIPTION="KDE wallpapers"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+DEPEND="$(add_frameworks_dep extra-cmake-modules)"
 RDEPEND="!kde-apps/kde-wallpapers:4"
+
+PATCHES=( "${FILESDIR}/${PN}-15.08.0-kf5-port.patch" ) # bug 559156
 
 src_configure() {
 	local mycmakeargs=( -DWALLPAPER_INSTALL_DIR="${EPREFIX}/usr/share/wallpapers" )

--- a/kde-apps/kde-wallpapers/kde-wallpapers-15.08.1.ebuild
+++ b/kde-apps/kde-wallpapers/kde-wallpapers-15.08.1.ebuild
@@ -13,7 +13,10 @@ DESCRIPTION="KDE wallpapers"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+DEPEND="$(add_frameworks_dep extra-cmake-modules)"
 RDEPEND="!kde-apps/kde-wallpapers:4"
+
+PATCHES=( "${FILESDIR}/${PN}-15.08.0-kf5-port.patch" ) # bug 559156
 
 src_configure() {
 	local mycmakeargs=( -DWALLPAPER_INSTALL_DIR="${EPREFIX}/usr/share/wallpapers" )

--- a/kde-base/kdebase-startkde/kdebase-startkde-4.11.22.ebuild
+++ b/kde-base/kdebase-startkde/kdebase-startkde-4.11.22.ebuild
@@ -17,7 +17,7 @@ IUSE="+wallpapers"
 RDEPEND="
 	$(add_kdebase_dep kcminit)
 	$(add_kdeapps_dep kdebase-runtime-meta)
-	wallpapers? ( $(add_kdeapps_dep kde-wallpapers) )
+	wallpapers? ( || ( $(add_kdeapps_dep kde-wallpapers) kde-apps/kde-wallpapers:5 ) )
 	$(add_kdeapps_dep kfmclient)
 	$(add_kdeapps_dep knotify)
 	$(add_kdeapps_dep kreadconfig)


### PR DESCRIPTION
Fixes a bug and gets rid of giant kdelibs:4 dependency just to install wallpapers in kde-applications-15.08.

Prepare kde-base/kdebase-startkde for that as well.