### PR TITLE
kde-apps/kde-base-artwork: Slotmove from 5 to 4

### DIFF
--- a/kde-apps/kde-base-artwork/kde-base-artwork-15.08.0.ebuild
+++ b/kde-apps/kde-base-artwork/kde-base-artwork-15.08.0.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 KDE_SCM="svn"
-inherit kde5
+inherit kde4-base
 
 DESCRIPTION="KDE base artwork"
 IUSE=""

--- a/profiles/updates/3Q-2015
+++ b/profiles/updates/3Q-2015
@@ -12,3 +12,4 @@ slotmove =sys-libs/ncurses-5.9-r3 5 0
 slotmove =sys-libs/ncurses-5.9-r4 5 0
 slotmove ~sys-libs/ncurses-6.0 5 0
 move kde-base/baloo-widgets kde-apps/baloo-widgets
+slotmove =kde-apps/kde-base-artwork-15.08.0 5 4


### PR DESCRIPTION
Actually requires kdelibs:4 for configure and is a dead end upstream.

Package-Manager: portage-2.2.20.1