### PR TITLE
kde-plasma/plasma-nm: Fix RDEPEND !{kde-base => kde-misc}/plasma-nm

### DIFF
--- a/kde-plasma/plasma-nm/plasma-nm-5.4.0.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-5.4.0.ebuild
@@ -50,7 +50,7 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}
-	!kde-base/plasma-nm
+	!kde-misc/plasma-nm
 "
 
 src_configure() {


### PR DESCRIPTION
Package-Manager: portage-2.2.20.1