### PR TITLE
eutils.eclass: Allow to configure base patch location for epatch_user

### DIFF
--- a/eclass/eutils.eclass
+++ b/eclass/eutils.eclass
@@ -350,6 +350,12 @@ EPATCH_FORCE="no"
 # List of patches not to apply.	 Note this is only file names,
 # and not the full path.  Globs accepted.
 
+# @VARIABLE: EPATCH_USER_SOURCE
+# @DESCRIPTION:
+# Location for user patches, see the epatch_user function.
+# Should be set by the user. Don't set this in ebuilds.
+: ${EPATCH_USER_SOURCE:=${PORTAGE_CONFIGROOT%/}/etc/portage/patches}
+
 # @FUNCTION: epatch
 # @USAGE: [options] [patches] [dirs of patches]
 # @DESCRIPTION:
@@ -697,11 +703,11 @@ epatch_user() {
 	[[ -e ${applied} ]] && return 2
 
 	# don't clobber any EPATCH vars that the parent might want
-	local EPATCH_SOURCE check base=${PORTAGE_CONFIGROOT%/}/etc/portage/patches
+	local EPATCH_SOURCE check
 	for check in ${CATEGORY}/{${P}-${PR},${P},${PN}}{,:${SLOT}}; do
-		EPATCH_SOURCE=${base}/${CTARGET}/${check}
-		[[ -r ${EPATCH_SOURCE} ]] || EPATCH_SOURCE=${base}/${CHOST}/${check}
-		[[ -r ${EPATCH_SOURCE} ]] || EPATCH_SOURCE=${base}/${check}
+		EPATCH_SOURCE=${EPATCH_USER_SOURCE}/${CTARGET}/${check}
+		[[ -r ${EPATCH_SOURCE} ]] || EPATCH_SOURCE=${EPATCH_USER_SOURCE}/${CHOST}/${check}
+		[[ -r ${EPATCH_SOURCE} ]] || EPATCH_SOURCE=${EPATCH_USER_SOURCE}/${check}
 		if [[ -d ${EPATCH_SOURCE} ]] ; then
 			EPATCH_SOURCE=${EPATCH_SOURCE} \
 			EPATCH_SUFFIX="patch" \


### PR DESCRIPTION
This is particularly useful for people who run alternative
package managers and want to control their configuration.