### PR TITLE
kde5.eclass: Block old kde4-l10n for kde-{frameworks,plasma}

### DIFF
--- a/eclass/kde5.eclass
+++ b/eclass/kde5.eclass
@@ -139,9 +139,10 @@ case ${KDE_AUTODEPS} in
 		RDEPEND+=" >=kde-frameworks/kf-env-3"
 		COMMONDEPEND+="	>=dev-qt/qtcore-${QT_MINIMAL}:5"
 
-		if [[ ${CATEGORY} = kde-plasma && ${PN} != polkit-kde-agent ]]; then
+		if [[ ${CATEGORY} = kde-frameworks || ${CATEGORY} = kde-plasma && ${PN} != polkit-kde-agent ]]; then
 			RDEPEND+="
 				!kde-apps/kde4-l10n[-minimal(-)]
+				!<kde-apps/kde4-l10n-15.08.0-r1
 			"
 		fi
 


### PR DESCRIPTION
Versions older than <kde-apps/kde4-l10n-15.08.0-r1 haven't been updated to keep
up with file collisions in current releases of kde-frameworks and kde-plasma.
Make sure everyone gets what they need. Fixes e.g. kde-plasma/kinfocenter-5.4.0
as reported in IRC but also https://bugs.gentoo.org/show_bug.cgi?id=559740