### PR TITLE
app-emulation/virt-manager-9999: Upstream repo moved to github.

### DIFF
--- a/app-emulation/virt-manager/virt-manager-9999.ebuild
+++ b/app-emulation/virt-manager/virt-manager-9999.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-2
 	SRC_URI=""
 	KEYWORDS=""
-	EGIT_REPO_URI="git://git.fedorahosted.org/virt-manager.git"
+	EGIT_REPO_URI="https://github.com/virt-manager/virt-manager.git"
 else
 	SRC_URI="http://virt-manager.org/download/sources/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"


### PR DESCRIPTION
New repo: https://github.com/virt-manager/virt-manager
Reference:
https://git.fedorahosted.org/cgit/virt-manager.git/commit/?id=c7c6b1e5cd2b9b918fa7b2dd3a7ed648517ba436