### PR TITLE
dev-util/re2c and dev-util/ninja: keyword request for ~amd64-fbsd, ~x86-fbsd.

### DIFF
--- a/dev-util/ninja/ninja-1.6.0.ebuild
+++ b/dev-util/ninja/ninja-1.6.0.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/martine/ninja.git"
 else
 	SRC_URI="https://github.com/martine/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 fi
 
 DESCRIPTION="A small build system similar to make"

--- a/dev-util/ninja/ninja-9999.ebuild
+++ b/dev-util/ninja/ninja-9999.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/martine/ninja.git"
 else
 	SRC_URI="https://github.com/martine/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 fi
 
 DESCRIPTION="A small build system similar to make"

--- a/dev-util/re2c/re2c-0.14.3.ebuild
+++ b/dev-util/re2c/re2c-0.14.3.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 
 src_prepare() {
 	epatch_user


### PR DESCRIPTION
Packages for building >=sys-devel/llvm-3.7.0 is missing Gentoo/FreeBSD keyword.
Please add keyword.

sys-devel/llvm-3.7.0 DEPEND dev-util/ninja.
dev-util/ninja DEPEND dev-util/re2c.

```
# emerge -pv llvm clang
!!! SYNC setting found in make.conf.
    This setting is Deprecated and no longer used.  Please ensure your 'sync-type' and 'sync-uri' are set correctly in /etc/portage/repos.conf/gentoo.conf

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild  N    *] dev-util/re2c-0.14.3::gentoo  2517 KiB
[ebuild  N    *] dev-util/ninja-9999::gentoo  USE="-doc -emacs {-test} -vim-syntax -zsh-completion" 0 KiB
[ebuild     U  ] sys-devel/llvm-3.7.0-r1:0/3.7.0::gentoo [3.6.1:0/3.6::gentoo] USE="(clang) libffi ncurses python static-analyzer -debug -doc (-gold) -libedit -lldb% -multitarget -ocaml {-test} -xml" ABI_X86="(64) -32 (-x32)" PYTHON_TARGETS="python2_7 (-pypy)" VIDEO_CARDS="-radeon" 24699 KiB
[ebuild     U  ] sys-devel/clang-3.7.0-r100:0/3.6::gentoo [3.6.1-r100:0/3.6::gentoo] USE="python static-analyzer -debug -multitarget" ABI_X86="(64) -32 (-x32)" 0 KiB
[blocks b      ] <=sys-devel/clang-3.7.0-r99 ("<=sys-devel/clang-3.7.0-r99" is blocking sys-devel/llvm-3.7.0-r1)

Total: 4 packages (2 upgrades, 2 new), Size of downloads: 27215 KiB
Conflict: 1 block

The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by sys-devel/llvm-3.7.0-r1::gentoo
# required by sys-devel/clang-3.7.0-r100::gentoo
# required by clang (argument)
=dev-util/ninja-9999 **
# required by dev-util/ninja-9999::gentoo
# required by sys-devel/llvm-3.7.0-r1::gentoo
# required by sys-devel/clang-3.7.0-r100::gentoo
# required by clang (argument)
=dev-util/re2c-0.14.3 **

NOTE: The --autounmask-keep-masks option will prevent emerge
      from creating package.unmask or ** keyword changes.
```