### PR TITLE
media-video/mpv: Remove no longer available flags

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -26,7 +26,7 @@ fi
 # See Copyright in source tarball and bug #506946. Waf is BSD, libmpv is ISC.
 LICENSE="GPL-2+ BSD ISC"
 SLOT="0"
-IUSE="+alsa bluray bs2b cdio +cli doc-pdf drm dvb +dvd egl +enca encode +iconv
+IUSE="+alsa bluray cdio +cli doc-pdf drm dvb +dvd egl +enca encode +iconv
 jack jpeg ladspa lcms +libass libav libcaca libguess libmpv lua luajit openal
 +opengl oss pulseaudio pvr raspberry-pi rubberband samba sdl selinux v4l vaapi
 vdpau vf-dlopen wayland +X xinerama +xscreensaver xv"
@@ -69,7 +69,6 @@ RDEPEND="
 	)
 	alsa? ( >=media-libs/alsa-lib-1.0.18 )
 	bluray? ( >=media-libs/libbluray-0.3.0 )
-	bs2b? ( media-libs/libbs2b )
 	cdio? (
 		dev-libs/libcdio
 		dev-libs/libcdio-paranoia
@@ -187,7 +186,6 @@ src_configure() {
 		$(use_enable enca)
 		$(use_enable ladspa)
 		$(use_enable rubberband)
-		$(use_enable bs2b libbs2b)
 		$(use_enable lcms lcms2)
 		--disable-vapoursynth	# vapoursynth is not packaged
 		--disable-vapoursynth-lazy

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -27,7 +27,7 @@ fi
 LICENSE="GPL-2+ BSD ISC"
 SLOT="0"
 IUSE="+alsa bluray cdio +cli doc-pdf drm dvb +dvd egl +enca encode +iconv
-jack jpeg ladspa lcms +libass libav libcaca libguess libmpv lua luajit openal
+jack jpeg lcms +libass libav libcaca libguess libmpv lua luajit openal
 +opengl oss pulseaudio pvr raspberry-pi rubberband samba sdl selinux v4l vaapi
 vdpau vf-dlopen wayland +X xinerama +xscreensaver xv"
 
@@ -83,7 +83,6 @@ RDEPEND="
 	iconv? ( virtual/libiconv )
 	jack? ( media-sound/jack-audio-connection-kit )
 	jpeg? ( virtual/jpeg:0 )
-	ladspa? ( media-libs/ladspa-sdk )
 	libass? (
 		>=media-libs/libass-0.12.1:=[enca?,fontconfig]
 		virtual/ttf-fonts
@@ -184,7 +183,6 @@ src_configure() {
 		$(use_enable dvd dvdnav)
 		$(use_enable cdio cdda)
 		$(use_enable enca)
-		$(use_enable ladspa)
 		$(use_enable rubberband)
 		$(use_enable lcms lcms2)
 		--disable-vapoursynth	# vapoursynth is not packaged


### PR DESCRIPTION
Several flags were removed in upstream. See mpv-player/mpv@d04d238 and mpv-player/mpv@091bfa3.