### PR TITLE
kde-apps/kwalletd: Add missing DEPEND on dev-libs/libgcrypt

### DIFF
--- a/kde-apps/kwalletd/kwalletd-15.08.0.ebuild
+++ b/kde-apps/kwalletd/kwalletd-15.08.0.ebuild
@@ -12,6 +12,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="debug gpg"
 
 DEPEND="
+	dev-libs/libgcrypt:0=
 	gpg? (
 		app-crypt/gpgme
 		|| ( $(add_kdeapps_dep gpgmepp) $(add_kdebase_dep kdepimlibs) )

--- a/kde-apps/kwalletd/kwalletd-4.14.3-r1.ebuild
+++ b/kde-apps/kwalletd/kwalletd-4.14.3-r1.ebuild
@@ -12,6 +12,7 @@ KEYWORDS="amd64 ~arm ppc ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="debug gpg"
 
 DEPEND="
+	dev-libs/libgcrypt:0=
 	gpg? (
 		app-crypt/gpgme
 		$(add_kdebase_dep kdepimlibs)

--- a/kde-apps/kwalletd/kwalletd-4.14.3-r2.ebuild
+++ b/kde-apps/kwalletd/kwalletd-4.14.3-r2.ebuild
@@ -12,6 +12,7 @@ KEYWORDS="amd64 ~arm ppc ~ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="debug gpg"
 
 DEPEND="
+	dev-libs/libgcrypt:0=
 	gpg? (
 		app-crypt/gpgme
 		$(add_kdebase_dep kdepimlibs)


### PR DESCRIPTION
Package-Manager: portage-2.2.20.1