### PR TITLE
kde-apps/poxml: ANTLR hasn't been used for years so remove that stuff

### DIFF
--- a/kde-apps/poxml/poxml-4.14.3-r1.ebuild
+++ b/kde-apps/poxml/poxml-4.14.3-r1.ebuild
@@ -1,0 +1,13 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit kde4-base
+
+DESCRIPTION="KDE utility to translate DocBook XML files using gettext po files"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
+IUSE="debug"
+
+RDEPEND="!<=kde-base/kdesdk-misc-4.10.50:4"


### PR DESCRIPTION
As mentioned on #gentoo-kde.