### PR TITLE
sys-apps/rng-tools: open entropy src with O_NOCTTY flag wrt bug #556456.

### DIFF
--- a/sys-apps/rng-tools/files/rng-tools-5-fix-noctty.patch
+++ b/sys-apps/rng-tools/files/rng-tools-5-fix-noctty.patch
@@ -1,0 +1,45 @@
+From: Gokturk Yuksek <gokturk@binghamton.edu>
+Subject: [PATCH] Fix rngd to open the entropy source with 'O_NOCTTY' flag
+
+When start-stop-daemon starts a rngd instance configured to use a tty
+device as its entropy source, the application crashes due to not being
+able to read from the entropy device. This is caused by
+start-stop-daemon calling setsid() before executing rngd, which
+disassociates the controlling terminal. When rngd attempts to open a
+hardware entropy source that's a tty device, per POSIX rules, the
+device becomes the controlling terminal for the process. Then rngd
+calls daemon(), which internally calls setsid(), and consequently
+disassociates the controlling terminal for the child. Meanwhile the
+parent rngd process exits. This results in tty device hanging up. By
+looking at the strace logs attached to the bug, it can be observed
+that although the parent rngd process is able to read() from the
+entropy source successfully, further attempts to read() by the child
+rngd process return 0. This complies with the POSIX, which states that
+read() calls on a hung up terminal shall return 0.
+
+Note that when rngd is started without start-stop-daemon, this problem
+does not happen because at the time of opening the entropy source rngd
+already has a controlling terminal.
+
+Prevent the entropy source from becoming the controlling terminal by
+passing 'O_NOCTTY' flag to open() when opening an entropy source. This
+flag prevents a tty device from becoming the controlling terminal for
+a process without a controlling terminal at the time of open().
+
+Thanks to John Bowler <jbowler@acm.org> for debugging the problem and
+pinpointing the issue as well as confirming the fix.
+
+Gentoo-Bug-URL: https://bugs.gentoo.org/556456
+Reported-By: John Bowler <jbowler@acm.org>
+
+--- rngd_entsource.c
++++ rngd_entsource.c
+@@ -175,7 +175,7 @@
+  */
+ int init_entropy_source(struct rng *ent_src)
+ {
+-	ent_src->rng_fd = open(ent_src->rng_name, O_RDONLY);
++	ent_src->rng_fd = open(ent_src->rng_name, O_RDONLY | O_NOCTTY);
+ 	if (ent_src->rng_fd == -1) {
+ 		return 1;
+ 	}

--- a/sys-apps/rng-tools/files/rngd-initd-r1-4.1
+++ b/sys-apps/rng-tools/files/rngd-initd-r1-4.1
@@ -9,9 +9,6 @@ depend() {
 	provide entropy
 }
 
-# Do NOT add /dev/tpm to this.
-DEFAULT_DEVICE="/dev/hw_random* /dev/hwrandom* /dev/i810_rng /dev/hwrng*"
-
 command=/usr/sbin/rngd
 pidfile="/var/run/${SVCNAME}.pid"
 command_args="--pid-file ${pidfile} --background --random-step ${STEP:-64} ${NO_TPM:+--no-tpm=1} \

--- a/sys-apps/rng-tools/rng-tools-5-r2.ebuild
+++ b/sys-apps/rng-tools/rng-tools-5-r2.ebuild
@@ -26,6 +26,7 @@ src_prepare() {
 	epatch "${FILESDIR}"/${P}-fix-textrels-on-PIC-x86.patch #469962
 	epatch "${FILESDIR}"/${P}-man-fill-watermark.patch #555094
 	epatch "${FILESDIR}"/${P}-man-rng-device.patch #555106
+	epatch "${FILESDIR}"/${P}-fix-noctty.patch #556456
 	eautoreconf
 
 	sed -i '/^AR /d' Makefile.in || die

--- a/sys-apps/rng-tools/rng-tools-5-r2.ebuild
+++ b/sys-apps/rng-tools/rng-tools-5-r2.ebuild
@@ -21,7 +21,7 @@ RDEPEND="${DEPEND}
 	selinux? ( sec-policy/selinux-rngd )"
 
 src_prepare() {
-	echo 'bin_PROGRAMS = randstat' >> contrib/Makefile.am
+	echo 'bin_PROGRAMS = randstat' >> contrib/Makefile.am || die
 	epatch "${FILESDIR}"/test-for-argp.patch
 	epatch "${FILESDIR}"/${P}-fix-textrels-on-PIC-x86.patch #469962
 	epatch "${FILESDIR}"/${P}-man-fill-watermark.patch #555094

--- a/sys-apps/rng-tools/rng-tools-5-r2.ebuild
+++ b/sys-apps/rng-tools/rng-tools-5-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit eutils autotools systemd toolchain-funcs
+
+DESCRIPTION="Daemon to use hardware random number generators"
+HOMEPAGE="http://gkernel.sourceforge.net/"
+SRC_URI="mirror://sourceforge/gkernel/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~x86"
+IUSE="selinux"
+
+DEPEND="dev-libs/libgcrypt:0
+	dev-libs/libgpg-error"
+RDEPEND="${DEPEND}
+	selinux? ( sec-policy/selinux-rngd )"
+
+src_prepare() {
+	echo 'bin_PROGRAMS = randstat' >> contrib/Makefile.am
+	epatch "${FILESDIR}"/test-for-argp.patch
+	epatch "${FILESDIR}"/${P}-fix-textrels-on-PIC-x86.patch #469962
+	epatch "${FILESDIR}"/${P}-man-fill-watermark.patch #555094
+	epatch "${FILESDIR}"/${P}-man-rng-device.patch #555106
+	eautoreconf
+
+	sed -i '/^AR /d' Makefile.in || die
+	tc-export AR
+}
+
+src_install() {
+	default
+	newinitd "${FILESDIR}"/rngd-initd-r1-4.1 rngd
+	newconfd "${FILESDIR}"/rngd-confd-4.1 rngd
+	systemd_dounit "${FILESDIR}"/rngd.service
+}


### PR DESCRIPTION
This revision patches the source file 'rngd_entsource.c', adding O_NOCTTY
flag to the open() call that opens the entropy source for rngd.

Package-Manager: portage-2.2.20.1