### PR TITLE
x11-drivers/ati-drivers: Fix compile and runtime errors. Bugs #548118 and #542320

### DIFF
--- a/x11-drivers/ati-drivers/files/15.9-fpu.patch
+++ b/x11-drivers/ati-drivers/files/15.9-fpu.patch
@@ -1,0 +1,39 @@
+--- a/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-13 13:55:29.000000000 -0400
++++ b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-13 14:56:24.000000000 -0400
+@@ -192,8 +192,13 @@
+ #include <linux/string.h>
+ #include <linux/gfp.h>
+ #include <linux/swap.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4,2,0)
+ #include "asm/i387.h"
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)
++#endif
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
++#include <asm/fpu/internal.h>
++#define __HAVE_ARCH_CMPXCHG 1
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)
+ #include <asm/fpu-internal.h>
+ #endif
+ 
+@@ -3528,8 +3533,12 @@ int ATI_API_CALL KCL_InstallInterruptHan
+ #else
+         //when MSI enabled. keep irq disabled when calling the action handler,
+         //exclude this IRQ from irq balancing (only on one CPU) 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0)
++        ((useMSI) ? (IRQF_NOBALANCING) : (IRQF_SHARED)),
++#else
+         ((useMSI) ? (IRQF_DISABLED) : (IRQF_SHARED)),    
+ #endif
++#endif
+         dev_name,
+         context);
+ }
+@@ -6465,7 +6474,7 @@ void ATI_API_CALL KCL_create_uuid(void *
+     generate_random_uuid((char *)buf);
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
++#if (!defined(CONFIG_X86_64) || LINUX_VERSION_CODE < KERNEL_VERSION(4,2,0)) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
+ static int KCL_fpu_save_init(struct task_struct *tsk)
+ {
+    struct fpu *fpu = &tsk->thread.fpu;

--- a/x11-drivers/ati-drivers/files/15.9-kcl_str.patch
+++ b/x11-drivers/ati-drivers/files/15.9-kcl_str.patch
@@ -1,0 +1,14 @@
+--- a/common/lib/modules/fglrx/build_mod/kcl_str.c	2015-09-13 13:47:30.000000000 -0400
++++ b/common/lib/modules/fglrx/build_mod/kcl_str.c	2015-09-13 13:49:42.000000000 -0400
+@@ -169,7 +169,11 @@ int ATI_API_CALL KCL_STR_Strnicmp(const
+                                   const char* s2,
+                                   KCL_TYPE_SizeSigned count)
+ {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
+     return strnicmp(s1, s2, count);
++#else
++    return strncasecmp(s1, s2, count);
++#endif
+ }
+ 
+ /** \brief Locate character in string

--- a/x11-drivers/ati-drivers/files/15.9-mtrr.patch
+++ b/x11-drivers/ati-drivers/files/15.9-mtrr.patch
@@ -1,0 +1,27 @@
+--- a/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-19 23:43:22.000000000 -0400
++++ b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-19 23:52:07.000000000 -0400
+@@ -3442,7 +3442,11 @@ int ATI_API_CALL KCL_MEM_MTRR_Support(vo
+ int ATI_API_CALL KCL_MEM_MTRR_AddRegionWc(unsigned long base, unsigned long size)
+ {
+ #ifdef CONFIG_MTRR
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
++    return arch_phys_wc_add(base, size);
++#else
+     return mtrr_add(base, size, MTRR_TYPE_WRCOMB, 1);
++#endif
+ #else /* !CONFIG_MTRR */
+     return -EPERM;
+ #endif /* !CONFIG_MTRR */
+@@ -3451,7 +3455,12 @@ int ATI_API_CALL KCL_MEM_MTRR_AddRegionW
+ int ATI_API_CALL KCL_MEM_MTRR_DeleteRegion(int reg, unsigned long base, unsigned long size)
+ {
+ #ifdef CONFIG_MTRR
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
++    arch_phys_wc_del(reg);
++    return reg;
++#else
+     return mtrr_del(reg, base, size);
++#endif
+ #else /* !CONFIG_MTRR */
+     return -EPERM;
+ #endif /* !CONFIG_MTRR */

--- a/x11-drivers/ati-drivers/files/15.9-preempt.patch
+++ b/x11-drivers/ati-drivers/files/15.9-preempt.patch
@@ -1,0 +1,103 @@
+--- a/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-08-30 17:36:02.000000000 -0400
++++ b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-08-30 17:39:36.000000000 -0400
+@@ -21,6 +21,8 @@
+ !!! since it requires changes to linux/init/main.c.
+ #endif /* !MODULE */
+ 
++#include <linux/preempt.h>
++
+ // ============================================================
+ #include <linux/version.h>
+ 
+@@ -4997,7 +4999,9 @@ static unsigned int kas_spin_unlock(kas_
+ unsigned long ATI_API_CALL KAS_GetExecutionLevel(void)
+ {
+     unsigned long ret;
++    preempt_disable();
+     ret = kas_GetExecutionLevel();
++    preempt_enable();
+     return ret;
+ }
+ 
+@@ -5022,8 +5026,10 @@ unsigned int ATI_API_CALL KAS_Ih_Execute
+     KCL_DEBUG5(FN_FIREGL_KAS,"0x%08X, 0x%08X\n", ih_routine, ih_context);
+ 
+     //Prevent simultaneous entry on some SMP systems.
++    preempt_disable();
+     if (test_and_set_bit(0, (void *)&(kasContext.in_interrupts[smp_processor_id()])))
+     {
++    	preempt_enable();
+         KCL_DEBUG1(FN_FIREGL_KAS, "The processor is handling the interrupt\n");
+         return IRQ_NONE;
+     }
+@@ -5036,9 +5042,9 @@ unsigned int ATI_API_CALL KAS_Ih_Execute
+ 
+     kasSetExecutionLevel(orig_level);
+     spin_unlock(&kasContext.lock_ih); 
+-
+     clear_bit(0, (void *)&(kasContext.in_interrupts[smp_processor_id()]));
+     KCL_DEBUG5(FN_FIREGL_KAS,"%d\n", ret);
++    preempt_enable();
+ 
+     return ret;
+ }
+@@ -5256,6 +5262,7 @@ unsigned int ATI_API_CALL KAS_Spinlock_A
+ 
+     KCL_DEBUG5(FN_FIREGL_KAS,"0x%08X\n", hSpinLock);
+ 
++    preempt_disable();
+     spin_lock_info.routine_type = spinlock_obj->routine_type;
+     spin_lock_info.plock = &(spinlock_obj->lock);
+ 
+@@ -5263,6 +5270,7 @@ unsigned int ATI_API_CALL KAS_Spinlock_A
+ 
+     spinlock_obj->acquire_type = spin_lock_info.acquire_type;
+     spinlock_obj->flags = spin_lock_info.flags;
++    preempt_enable();
+ 
+     KCL_DEBUG5(FN_FIREGL_KAS,"%d\n", ret);
+     return ret;
+@@ -6034,6 +6042,8 @@ unsigned int ATI_API_CALL KAS_Interlocke
+ 
+     KCL_DEBUG5(FN_FIREGL_KAS,"0x%08X, 0x%08X, 0x%08X\n", hListHead, hListEntry, phPrevEntry);
+ 
++    preempt_disable();
++
+     /* Protect the operation with spinlock */
+     spin_lock_info.routine_type = listhead_obj->routine_type;
+     spin_lock_info.plock = &(listhead_obj->lock);
+@@ -6041,6 +6051,7 @@ unsigned int ATI_API_CALL KAS_Interlocke
+     if (!kas_spin_lock(&spin_lock_info))
+     {
+         KCL_DEBUG_ERROR("Unable to grab list spinlock\n");
++	preempt_enable();
+         return 0; /* No spinlock - no operation */
+     }
+ 
+@@ -6065,6 +6076,7 @@ unsigned int ATI_API_CALL KAS_Interlocke
+     spin_unlock_info.flags = spin_lock_info.flags;
+ 
+     ret = kas_spin_unlock(&spin_unlock_info);
++    preempt_enable();
+     KCL_DEBUG5(FN_FIREGL_KAS,"%d", ret);
+     return ret;
+ }
+@@ -6153,8 +6165,10 @@ unsigned int ATI_API_CALL KAS_Interlocke
+     spin_lock_info.routine_type = listhead_obj->routine_type;
+     spin_lock_info.plock = &(listhead_obj->lock);
+ 
++    preempt_disable();
+     if (!kas_spin_lock(&spin_lock_info))
+     {
++        preempt_enable();
+         KCL_DEBUG_ERROR("Unable to grab list spinlock");
+         return 0; /* No spinlock - no operation */
+     }
+@@ -6178,6 +6192,7 @@ unsigned int ATI_API_CALL KAS_Interlocke
+     spin_unlock_info.flags = spin_lock_info.flags;
+ 
+     ret = kas_spin_unlock(&spin_unlock_info);
++    preempt_enable();
+     KCL_DEBUG5(FN_FIREGL_KAS,"%d", ret);
+     return ret;
+ }

--- a/x11-drivers/ati-drivers/files/15.9-remove-gpl-symbols.patch
+++ b/x11-drivers/ati-drivers/files/15.9-remove-gpl-symbols.patch
@@ -1,0 +1,74 @@
+--- a/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-18 23:57:02.000000000 -0400
++++ b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-18 23:57:11.000000000 -0400
+@@ -136,7 +136,6 @@
+ #include <asm/mman.h>
+ #include <asm/uaccess.h>
+ #include <asm/processor.h>
+-#include <asm/tlbflush.h> // for flush_tlb_page
+ #include <asm/cpufeature.h>
+ #ifdef CONFIG_MTRR
+ #include <asm/mtrr.h>
+@@ -251,6 +250,26 @@
+ #define WRITE_CR4(x)    write_cr4(x)
+ #endif
+ 
++#define __flush_tlb_one(addr) asm volatile("invlpg (%0)" ::"r" (addr) : "memory")
++#define __flush_tlb() native_write_cr3(native_read_cr3())
++
++static inline void __flush_tlb_all(void)
++{
++        if (cpu_has_pge)
++        {
++                unsigned long flags, cr4;
++                raw_local_irq_save(flags);
++                cr4 = native_read_cr4();
++                native_write_cr4(cr4 & ~X86_CR4_PGE);
++                native_write_cr4(cr4);
++                raw_local_irq_restore(flags);
++        }
++        else
++        {
++                __flush_tlb();
++        }
++}
++
+ // ============================================================
+ /* globals */
+ 
+@@ -6479,7 +6498,12 @@ static int KCL_fpu_save_init(struct task
+ void ATI_API_CALL KCL_fpu_begin(void)
+ {
+ #if defined(CONFIG_X86_64) || LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
++    preempt_disable();
++    __kernel_fpu_begin();
++#else
+     kernel_fpu_begin();
++#endif
+ #else
+ #ifdef TS_USEDFPU
+     struct thread_info *cur_thread = current_thread_info();
+@@ -6525,7 +6549,12 @@ void ATI_API_CALL KCL_fpu_begin(void)
+  */
+ void ATI_API_CALL KCL_fpu_end(void)
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
++    __kernel_fpu_end();
++    preempt_enable();
++#else
+     kernel_fpu_end();
++#endif
+ }
+ 
+ /** Create new directory entry under "/proc/...."
+--- a/common/lib/modules/fglrx/build_mod/kcl_acpi.c	2015-09-19 00:43:35.000000000 -0400
++++ b/common/lib/modules/fglrx/build_mod/kcl_acpi.c	2015-09-19 00:43:48.000000000 -0400
+@@ -868,7 +868,7 @@ void ATI_API_CALL KCL_ACPI_No_Hotplug(vo
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+     if(pdev)
+     {
+-#if (UTS_UBUNTU_RELEASE_ABI < 0 && LINUX_VERSION_CODE < KERNEL_VERSION(4,1,3)) || (UTS_UBUNTU_RELEASE_ABI >= 0 && UTS_UBUNTU_RELEASE_ABI < 26 && LINUX_VERSION_CODE <= KERNEL_VERSION(3,19,8))
++#if 0 && (UTS_UBUNTU_RELEASE_ABI < 0 && LINUX_VERSION_CODE < KERNEL_VERSION(4,1,3)) || (UTS_UBUNTU_RELEASE_ABI >= 0 && UTS_UBUNTU_RELEASE_ABI < 26 && LINUX_VERSION_CODE <= KERNEL_VERSION(3,19,8))
+        pci_ignore_hotplug(pdev);
+ #else
+        pdev->ignore_hotplug = 1;

--- a/x11-drivers/ati-drivers/files/15.9-sep_printf.patch
+++ b/x11-drivers/ati-drivers/files/15.9-sep_printf.patch
@@ -1,0 +1,11 @@
+--- a/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-14 15:14:36.000000000 -0400
++++ b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-14 16:18:58.000000000 -0400
+@@ -649,6 +649,8 @@ static int firegl_major_proc_read(struct
+     *eof = 1;
+ 
+     len = snprintf(buf, request, "%d\n", major);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
++    seq_printf(m, "%d\n", major);
+ #else
+     len = seq_printf(m, "%d\n", major);
+ #endif


### PR DESCRIPTION
Adds patches to fix bugs #542320 and #548118 without using GPL kernel exports.