### PR TITLE
dev-util/nvidia-cuda-toolkit: Add CUDA LLVM libraries to LDPATH

### DIFF
--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-7.5.18-r1.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-7.5.18-r1.ebuild
@@ -107,7 +107,7 @@ src_install() {
 	cat > "${T}"/99cuda <<- EOF
 		PATH=${ecudadir}/bin$(use profiler && echo ":${ecudadir}/libnvvp")
 		ROOTPATH=${ecudadir}/bin
-		LDPATH=${ecudadir}/lib64:${ecudadir}/lib
+		LDPATH=${ecudadir}/lib64:${ecudadir}/lib:${ecudadir}/nvvm/lib64
 	EOF
 	doenvd "${T}"/99cuda
 


### PR DESCRIPTION
@jlec This extends the library path to include the NVIDIA's optimizing compiler libraries for [LLVM](https://developer.nvidia.com/cuda-llvm-compiler). For exampled needed for the arrayfire [python bindings](https://github.com/arrayfire/arrayfire-python/wiki).

I had to pass --force to repoman, since the nvidia-cuda-toolkit-6.5.19* required `>=x11-drivers/nvidia-drivers-343.22[uvm]`, which were dropped with commit cf5f43793b. Raising the dependency to 346.96 wasn't enough and now it's quite late..