### PR TITLE
dev-libs/openssl:  Fixed compile errors for linux-ppc64le

### DIFF
--- a/dev-libs/openssl/files/gentoo.config-1.0.1
+++ b/dev-libs/openssl/files/gentoo.config-1.0.1
@@ -101,6 +101,7 @@ linux)
 		mips*el*)     machine="generic32 -DL_ENDIAN";;
 		mips*)        machine="generic32 -DB_ENDIAN";;
 		powerpc64*le) machine="generic64 -DL_ENDIAN";;
+		powerpc64le*) machine=ppc64le;;
 		powerpc64*)   machine=ppc64;;
 		powerpc*le)   machine="generic32 -DL_ENDIAN";;
 		powerpc*)     machine=ppc;;


### PR DESCRIPTION
When compiling openssl for ppc64le, it's must use configuration for " linux-ppc64le"