### PR TITLE
mysql-{v2,multilib}.eclass: add libressl support and adjust core deps

### DIFF
--- a/dev-db/mariadb-galera/mariadb-galera-10.0.21-r1.ebuild
+++ b/dev-db/mariadb-galera/mariadb-galera-10.0.21-r1.ebuild
@@ -1,0 +1,137 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+MY_EXTRAS_VER="20150717-1707Z"
+WSREP_REVISION="25"
+HAS_TOOLS_PATCH="1"
+SUBSLOT="18"
+
+inherit toolchain-funcs mysql-multilib
+# only to make repoman happy. it is really set in the eclass
+IUSE="$IUSE"
+
+# REMEMBER: also update eclass/mysql*.eclass before committing!
+KEYWORDS="~amd64 ~x86"
+
+# When MY_EXTRAS is bumped, the index should be revised to exclude these.
+EPATCH_EXCLUDE=''
+
+DEPEND="|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )"
+RDEPEND="${RDEPEND}"
+
+# Please do not add a naive src_unpack to this ebuild
+# If you want to add a single patch, copy the ebuild to an overlay
+# and create your own mysql-extras tarball, looking at 000_index.txt
+
+# Official test instructions:
+# USE='client-libs community embedded extraengine perl server ssl static-libs tools' \
+# FEATURES='test userpriv -usersandbox' \
+# ebuild mariadb-galera-X.X.XX.ebuild \
+# digest clean package
+multilib_src_test() {
+
+	if ! multilib_is_native_abi ; then
+		einfo "Server tests not available on non-native abi".
+		return 0;
+	fi
+
+	local TESTDIR="${BUILD_DIR}/mysql-test"
+	local retstatus_unit
+	local retstatus_tests
+
+	# Bug #213475 - MySQL _will_ object strenously if your machine is named
+	# localhost. Also causes weird failures.
+	[[ "${HOSTNAME}" == "localhost" ]] && die "Your machine must NOT be named localhost"
+
+	if use server ; then
+
+		if [[ $UID -eq 0 ]]; then
+			die "Testing with FEATURES=-userpriv is no longer supported by upstream. Tests MUST be run as non-root."
+		fi
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		einfo ">>> Test phase [test]: ${CATEGORY}/${PF}"
+		addpredict /this-dir-does-not-exist/t9.MYI
+
+		# Run CTest (test-units)
+		cmake-utils_src_test
+		retstatus_unit=$?
+		[[ $retstatus_unit -eq 0 ]] || eerror "test-unit failed"
+
+		# Ensure that parallel runs don't die
+		export MTR_BUILD_THREAD="$((${RANDOM} % 100))"
+		# Enable parallel testing, auto will try to detect number of cores
+		# You may set this by hand.
+		# The default maximum is 8 unless MTR_MAX_PARALLEL is increased
+		export MTR_PARALLEL="${MTR_PARALLEL:-auto}"
+
+		# create directories because mysqladmin might right out of order
+		mkdir -p "${T}"/var-tests{,/log}
+
+		# Create a symlink to provided binaries so the tests can find them when client-libs is off
+		if ! use client-libs ; then
+			ln -srf /usr/bin/my_print_defaults "${BUILD_DIR}/client/my_print_defaults" || die
+			ln -srf /usr/bin/perror "${BUILD_DIR}/client/perror" || die
+			mysql-multilib_disable_test main.perror "String mismatch due to not building local perror"
+		fi
+
+		# These are failing in MariaDB 10.0 for now and are believed to be
+		# false positives:
+		#
+		# main.information_schema, binlog.binlog_statement_insert_delayed,
+		# main.mysqld--help, funcs_1.is_triggers, funcs_1.is_tables_mysql,
+		# funcs_1.is_columns_mysql, main.bootstrap
+		# fails due to USE=-latin1 / utf8 default
+		#
+		# main.mysql_client_test, main.mysql_client_test_nonblock
+		# main.mysql_client_test_comp:
+		# segfaults at random under Portage only, suspect resource limits.
+		#
+		# wsrep.variables:
+		# Expects the sys-cluster/galera library to be installed and configured
+		#
+		# wsrep.foreign_key:
+		# Issues a configuration deprecation warning which does not affect data
+		#
+
+		for t in main.mysql_client_test main.mysql_client_test_nonblock \
+			main.mysql_client_test_comp main.bootstrap \
+			binlog.binlog_statement_insert_delayed main.information_schema \
+			main.mysqld--help wsrep.variables wsrep.foreign_key \
+			funcs_1.is_triggers funcs_1.is_tables_mysql funcs_1.is_columns_mysql ; do
+				mysql-multilib_disable_test  "$t" "False positives in Gentoo"
+		done
+
+		# Run mysql tests
+		pushd "${TESTDIR}"
+
+		# run mysql-test tests
+		# The PATH addition is required for the galera suite to find the sst scripts
+		# Skipping galera tests for now until MDEV-7544 is resovled
+		WSREP_LOG_DIR="${T}/var-tests/wsrep" \
+		PATH="${BUILD_DIR}/scripts:${PATH}" \
+		perl mysql-test-run.pl --force --vardir="${T}/var-tests" --skip-test=galera
+		retstatus_tests=$?
+		[[ $retstatus_tests -eq 0 ]] || eerror "tests failed"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		popd
+
+		# Cleanup is important for these testcases.
+		pkill -9 -f "${S}/ndb" 2>/dev/null
+		pkill -9 -f "${S}/sql" 2>/dev/null
+
+		failures=""
+		[[ $retstatus_unit -eq 0 ]] || failures="${failures} test-unit"
+		[[ $retstatus_tests -eq 0 ]] || failures="${failures} tests"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		[[ -z "$failures" ]] || die "Test failures: $failures"
+		einfo "Tests successfully completed"
+	else
+
+		einfo "Skipping server tests due to minimal build."
+	fi
+}

--- a/dev-db/mariadb/mariadb-10.1.7_rc-r1.ebuild
+++ b/dev-db/mariadb/mariadb-10.1.7_rc-r1.ebuild
@@ -1,0 +1,127 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+MY_EXTRAS_VER="20150914-1946Z"
+WSREP_REVISION="25"
+SUBSLOT="18"
+HAS_TOOLS_PATCH="yes"
+
+inherit toolchain-funcs mysql-multilib
+# only to make repoman happy. it is really set in the eclass
+IUSE="$IUSE mroonga"
+
+# REMEMBER: also update eclass/mysql*.eclass before committing!
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~hppa ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+
+# When MY_EXTRAS is bumped, the index should be revised to exclude these.
+#EPATCH_EXCLUDE='20014_all_mariadb-innodb-compression.patch'
+
+DEPEND="|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )
+	mroonga? ( app-text/groonga-normalizer-mysql )"
+RDEPEND="${RDEPEND}"
+
+# Official test instructions:
+# USE='client-libs community embedded extraengine perl server ssl static-libs tools' \
+# FEATURES='test userpriv -usersandbox' \
+# ebuild mariadb-X.X.XX.ebuild \
+# digest clean package
+multilib_src_test() {
+
+	if ! multilib_is_native_abi ; then
+		einfo "Server tests not available on non-native abi".
+		return 0;
+	fi
+
+	local TESTDIR="${BUILD_DIR}/mysql-test"
+	local retstatus_unit
+	local retstatus_tests
+
+	if use server ; then
+
+		# Bug #213475 - MySQL _will_ object strenously if your machine is named
+		# localhost. Also causes weird failures.
+		[[ "${HOSTNAME}" == "localhost" ]] && die "Your machine must NOT be named localhost"
+
+		if [[ $UID -eq 0 ]]; then
+			die "Testing with FEATURES=-userpriv is no longer supported by upstream. Tests MUST be run as non-root."
+		fi
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		einfo ">>> Test phase [test]: ${CATEGORY}/${PF}"
+		addpredict /this-dir-does-not-exist/t9.MYI
+
+		# Run CTest (test-units)
+		cmake-utils_src_test
+		retstatus_unit=$?
+		[[ $retstatus_unit -eq 0 ]] || eerror "test-unit failed"
+
+		# Create a symlink to provided binaries so the tests can find them when client-libs is off
+		if ! use client-libs ; then
+			ln -srf /usr/bin/my_print_defaults "${BUILD_DIR}/client/my_print_defaults" || die
+			ln -srf /usr/bin/perror "${BUILD_DIR}/client/perror" || die
+			mysql-multilib_disable_test main.perror "String mismatch due to not building local perror"
+		fi
+
+		# Ensure that parallel runs don't die
+		export MTR_BUILD_THREAD="$((${RANDOM} % 100))"
+		# Enable parallel testing, auto will try to detect number of cores
+		# You may set this by hand.
+		# The default maximum is 8 unless MTR_MAX_PARALLEL is increased
+		export MTR_PARALLEL="${MTR_PARALLEL:-auto}"
+
+		# create directories because mysqladmin might run out of order
+		mkdir -p "${T}"/var-tests{,/log}
+
+		# These are failing in MariaDB 10.0 for now and are believed to be
+		# false positives:
+		#
+		# main.information_schema, binlog.binlog_statement_insert_delayed,
+		# main.mysqld--help, funcs_1.is_triggers, funcs_1.is_tables_mysql,
+		# funcs_1.is_columns_mysql main.bootstrap
+		# fails due to USE=-latin1 / utf8 default
+		#
+		# main.mysql_client_test, main.mysql_client_test_nonblock
+		# main.mysql_client_test_comp:
+		# segfaults at random under Portage only, suspect resource limits.
+		#
+		# plugins.cracklib_password_check
+		# Can randomly fail due to cracklib return message
+
+		for t in main.mysql_client_test main.mysql_client_test_nonblock \
+			main.mysql_client_test_comp main.bootstrap \
+			binlog.binlog_statement_insert_delayed main.information_schema \
+			main.mysqld--help plugins.cracklib_password_check \
+			funcs_1.is_triggers funcs_1.is_tables_mysql funcs_1.is_columns_mysql ; do
+				mysql-multilib_disable_test  "$t" "False positives in Gentoo"
+		done
+
+		# Run mysql tests
+		pushd "${TESTDIR}"
+
+		# run mysql-test tests
+		perl mysql-test-run.pl --force --vardir="${T}/var-tests" --reorder
+
+		retstatus_tests=$?
+		[[ $retstatus_tests -eq 0 ]] || eerror "tests failed"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		popd
+
+		# Cleanup is important for these testcases.
+		pkill -9 -f "${S}/ndb" 2>/dev/null
+		pkill -9 -f "${S}/sql" 2>/dev/null
+
+		failures=""
+		[[ $retstatus_unit -eq 0 ]] || failures="${failures} test-unit"
+		[[ $retstatus_tests -eq 0 ]] || failures="${failures} tests"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		[[ -z "$failures" ]] || die "Test failures: $failures"
+		einfo "Tests successfully completed"
+
+	else
+		einfo "Skipping server tests due to minimal build."
+	fi
+}

--- a/dev-db/mysql-cluster/mysql-cluster-7.3.9-r2.ebuild
+++ b/dev-db/mysql-cluster/mysql-cluster-7.3.9-r2.ebuild
@@ -1,0 +1,135 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+MY_EXTRAS_VER="20150710-1911Z"
+SUBSLOT="18"
+
+inherit toolchain-funcs java-pkg-opt-2 mysql-multilib
+# only to make repoman happy. it is really set in the eclass
+IUSE="$IUSE"
+
+# REMEMBER: also update eclass/mysql*.eclass before committing!
+KEYWORDS="~amd64 ~x86"
+
+# When MY_EXTRAS is bumped, the index should be revised to exclude these.
+# This is often broken still
+#EPATCH_EXCLUDE=''
+
+DEPEND="|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )"
+RDEPEND="!media-sound/amarok[embedded]"
+
+# Please do not add a naive src_unpack to this ebuild
+# If you want to add a single patch, copy the ebuild to an overlay
+# and create your own mysql-extras tarball, looking at 000_index.txt
+
+# Official test instructions:
+# USE='cluster extraengine perl ssl community' \
+# FEATURES='test userpriv -usersandbox' \
+# ebuild mysql-cluster-X.X.XX.ebuild \
+# digest clean package
+multilib_src_test() {
+
+	if ! multilib_is_native_abi ; then
+		einfo "Server tests not available on non-native abi".
+		return 0;
+	fi
+
+	local TESTDIR="${CMAKE_BUILD_DIR}/mysql-test"
+	local retstatus_unit
+	local retstatus_tests
+
+	# Bug #213475 - MySQL _will_ object strenously if your machine is named
+	# localhost. Also causes weird failures.
+	[[ "${HOSTNAME}" == "localhost" ]] && die "Your machine must NOT be named localhost"
+
+	if ! use "minimal" ; then
+
+		if [[ $UID -eq 0 ]]; then
+			die "Testing with FEATURES=-userpriv is no longer supported by upstream. Tests MUST be run as non-root."
+		fi
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		einfo ">>> Test phase [test]: ${CATEGORY}/${PF}"
+		addpredict /this-dir-does-not-exist/t9.MYI
+
+		# Run CTest (test-units)
+		cmake-utils_src_test
+		retstatus_unit=$?
+		[[ $retstatus_unit -eq 0 ]] || eerror "test-unit failed"
+
+		# Ensure that parallel runs don't die
+		export MTR_BUILD_THREAD="$((${RANDOM} % 100))"
+		# Enable parallel testing, auto will try to detect number of cores
+		# You may set this by hand.
+		# The default maximum is 8 unless MTR_MAX_PARALLEL is increased
+		export MTR_PARALLEL="${MTR_PARALLEL:-auto}"
+
+		# create directories because mysqladmin might right out of order
+		mkdir -p "${T}"/var-tests{,/log}
+
+		# These are failing in MySQL 5.5/5.6 for now and are believed to be
+		# false positives:
+		#
+		# main.information_schema, binlog.binlog_statement_insert_delayed,
+		# main.mysqld--help-notwin, funcs_1.is_triggers funcs_1.is_tables_mysql,
+		# funcs_1.is_columns_mysql, binlog.binlog_mysqlbinlog_filter,
+		# perfschema.binlog_edge_mix, perfschema.binlog_edge_stmt,
+		# mysqld--help-notwin, funcs_1.is_triggers, funcs_1.is_tables_mysql, funcs_1.is_columns_mysql
+		# perfschema.binlog_edge_stmt, perfschema.binlog_edge_mix, binlog.binlog_mysqlbinlog_filter
+		# fails due to USE=-latin1 / utf8 default
+		#
+		# main.mysql_client_test:
+		# segfaults at random under Portage only, suspect resource limits.
+		#
+		for t in \
+			binlog.binlog_mysqlbinlog_filter \
+			binlog.binlog_statement_insert_delayed \
+			funcs_1.is_columns_mysql \
+			funcs_1.is_tables_mysql \
+			funcs_1.is_triggers \
+			main.information_schema \
+			main.mysqld--help-notwinfuncs_1.is_triggers \
+			main.mysql_client_test \
+			mysqld--help-notwin \
+			perfschema.binlog_edge_mix \
+			perfschema.binlog_edge_stmt \
+		; do
+				mysql-multilib_disable_test  "$t" "False positives in Gentoo"
+		done
+		# ndb.ndbinfo, ndb_binlog.ndb_binlog_index: latin1/utf8
+		for t in \
+			ndb.ndbinfo \
+			ndb_binlog.ndb_binlog_index ; do
+				mysql-multilib_disable_test  "$t" "False positives in Gentoo (NDB)"
+		done
+
+		# Run mysql tests
+		pushd "${TESTDIR}"
+
+		# run mysql-test tests
+		perl mysql-test-run.pl --force --vardir="${T}/var-tests"
+		retstatus_tests=$?
+		[[ $retstatus_tests -eq 0 ]] || eerror "tests failed"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		popd
+
+		# Cleanup is important for these testcases.
+		pkill -9 -f "${S}/ndb" 2>/dev/null
+		pkill -9 -f "${S}/sql" 2>/dev/null
+
+		failures=""
+		[[ $retstatus_unit -eq 0 ]] || failures="${failures} test-unit"
+		[[ $retstatus_tests -eq 0 ]] || failures="${failures} tests"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		[[ -z "$failures" ]] || die "Test failures: $failures"
+		einfo "Tests successfully completed"
+
+	else
+
+		einfo "Skipping server tests due to minimal build."
+	fi
+}

--- a/dev-db/mysql-connector-c/mysql-connector-c-6.1.6-r3.ebuild
+++ b/dev-db/mysql-connector-c/mysql-connector-c-6.1.6-r3.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+CMAKE_MIN_VERSION="2.8.12"
+
+inherit cmake-multilib eutils multilib
+
+MULTILIB_WRAPPED_HEADERS+=(
+	/usr/include/mysql/my_config.h
+)
+
+# wrap the config script
+MULTILIB_CHOST_TOOLS=( /usr/bin/mysql_config )
+
+DESCRIPTION="C client library for MariaDB/MySQL"
+HOMEPAGE="https://dev.mysql.com/downloads/connector/c/"
+LICENSE="GPL-2"
+
+SRC_URI="mirror://mysql/Downloads/Connector-C/${P}-src.tar.gz"
+S="${WORKDIR}/${P}-src"
+KEYWORDS="~amd64 ~ia64 ~ppc64 ~x86"
+
+SUBSLOT="18"
+SLOT="0/${SUBSLOT}"
+IUSE="libressl +ssl static-libs"
+
+CDEPEND="
+	sys-libs/zlib:=[${MULTILIB_USEDEP}]
+	ssl? (
+		!libressl? ( dev-libs/openssl:0=[${MULTILIB_USEDEP}] )
+		libressl? ( dev-libs/libressl:=[${MULTILIB_USEDEP}] )
+	)
+	"
+RDEPEND="${CDEPEND}
+	!dev-db/mysql[client-libs(+)]
+	!dev-db/mysql-cluster[client-libs(+)]
+	!dev-db/mariadb[client-libs(+)]
+	!dev-db/mariadb-connector-c[mysqlcompat]
+	!dev-db/mariadb-galera[client-libs(+)]
+	!dev-db/percona-server[client-libs(+)]
+	"
+DEPEND="${CDEPEND}"
+
+DOCS=( README Docs/ChangeLog )
+
+src_prepare() {
+	epatch "${FILESDIR}/openssl-cmake-detection.patch" \
+		"${FILESDIR}/conn-c-includes.patch" \
+		"${FILESDIR}/mysql_com.patch"
+	epatch_user
+}
+
+multilib_src_configure() {
+	mycmakeargs+=(
+		-DINSTALL_LAYOUT=RPM
+		-DINSTALL_LIBDIR=$(get_libdir)
+		-DWITH_DEFAULT_COMPILER_OPTIONS=OFF
+		-DWITH_DEFAULT_FEATURE_SET=OFF
+		-DENABLED_LOCAL_INFILE=ON
+		-DMYSQL_UNIX_ADDR="${EPREFIX}/var/run/mysqld/mysqld.sock"
+		-DWITH_ZLIB=system
+		-DENABLE_DTRACE=OFF
+		-DWITH_SSL=$(usex ssl system bundled)
+	)
+	cmake-utils_src_configure
+}
+
+multilib_src_install_all() {
+	if ! use static-libs ; then
+		find "${ED}" -name "*.a" -delete || die
+	fi
+}
+
+pkg_preinst() {
+	if [[ -z ${REPLACING_VERSIONS} && -e "${EROOT}usr/$(get_libdir)/libmysqlclient.so" ]] ; then
+		elog "Due to ABI changes when switching between different client libraries,"
+		elog "revdep-rebuild must find and rebuild all packages linking to libmysqlclient."
+		elog "Please run: revdep-rebuild --library libmysqlclient.so.${SUBSLOT}"
+		ewarn "Failure to run revdep-rebuild may cause issues with other programs or libraries"
+	fi
+}

--- a/dev-db/mysql/mysql-5.5.45-r1.ebuild
+++ b/dev-db/mysql/mysql-5.5.45-r1.ebuild
@@ -1,0 +1,126 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+MY_EXTRAS_VER="20150729-1849Z"
+MY_PV="${PV//_alpha_pre/-m}"
+MY_PV="${MY_PV//_/-}"
+
+# Build type
+BUILD="cmake"
+
+inherit toolchain-funcs mysql-v2
+# only to make repoman happy. it is really set in the eclass
+IUSE="$IUSE"
+
+# Define the mysql-extras source
+EGIT_REPO_URI="git://anongit.gentoo.org/proj/mysql-extras.git"
+
+# REMEMBER: also update eclass/mysql*.eclass before committing!
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+
+# When MY_EXTRAS is bumped, the index should be revised to exclude these.
+EPATCH_EXCLUDE=''
+
+DEPEND="|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )"
+RDEPEND="${RDEPEND}"
+
+# Please do not add a naive src_unpack to this ebuild
+# If you want to add a single patch, copy the ebuild to an overlay
+# and create your own mysql-extras tarball, looking at 000_index.txt
+
+# Official test instructions:
+# USE='embedded extraengine perl ssl static-libs community' \
+# FEATURES='test userpriv -usersandbox' \
+# ebuild mysql-X.X.XX.ebuild \
+# digest clean package
+src_test() {
+
+	local TESTDIR="${BUILD_DIR}/mysql-test"
+	local retstatus_unit
+	local retstatus_tests
+
+	# Bug #213475 - MySQL _will_ object strenously if your machine is named
+	# localhost. Also causes weird failures.
+	[[ "${HOSTNAME}" == "localhost" ]] && die "Your machine must NOT be named localhost"
+
+	if ! use "minimal" ; then
+
+		if [[ $UID -eq 0 ]]; then
+			die "Testing with FEATURES=-userpriv is no longer supported by upstream. Tests MUST be run as non-root."
+		fi
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		einfo ">>> Test phase [test]: ${CATEGORY}/${PF}"
+		addpredict /this-dir-does-not-exist/t9.MYI
+
+		# Run CTest (test-units)
+		cmake-utils_src_test
+		retstatus_unit=$?
+		[[ $retstatus_unit -eq 0 ]] || eerror "test-unit failed"
+
+		# Ensure that parallel runs don't die
+		export MTR_BUILD_THREAD="$((${RANDOM} % 100))"
+		# Enable parallel testing, auto will try to detect number of cores
+		# You may set this by hand.
+		# The default maximum is 8 unless MTR_MAX_PARALLEL is increased
+		export MTR_PARALLEL="${MTR_PARALLEL:-auto}"
+
+		# create directories because mysqladmin might right out of order
+		mkdir -p "${T}"/var-tests{,/log}
+
+		# create symlink for the tests to find mysql_tzinfo_to_sql
+		ln -s "${BUILD_DIR}/sql/mysql_tzinfo_to_sql" "${S}/sql/"
+
+		# These are failing in MySQL 5.5 for now and are believed to be
+		# false positives:
+		#
+		# main.information_schema, binlog.binlog_statement_insert_delayed,
+		# main.mysqld--help-notwin
+		# fails due to USE=-latin1 / utf8 default
+		#
+		# main.mysql_client_test:
+		# segfaults at random under Portage only, suspect resource limits.
+		#
+		# main.mysqlhotcopy_archive main.mysqlhotcopy_myisam
+		# fails due to bad cleanup of previous tests when run in parallel
+		# The tool is deprecated anyway
+		# Bug 532288
+
+		for t in main.mysql_client_test \
+			binlog.binlog_statement_insert_delayed main.information_schema \
+			main.mysqld--help-notwin main.mysqlhotcopy_archive main.mysqlhotcopy_myisam ; do
+				mysql-v2_disable_test  "$t" "False positives in Gentoo"
+		done
+
+		# Run mysql tests
+		pushd "${TESTDIR}"
+
+		# run mysql-test tests
+		perl mysql-test-run.pl --force --vardir="${T}/var-tests" \
+			--testcase-timeout=30 --reorder
+		retstatus_tests=$?
+		[[ $retstatus_tests -eq 0 ]] || eerror "tests failed"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		popd
+
+		# Cleanup is important for these testcases.
+		pkill -9 -f "${S}/ndb" 2>/dev/null
+		pkill -9 -f "${S}/sql" 2>/dev/null
+
+		failures=""
+		[[ $retstatus_unit -eq 0 ]] || failures="${failures} test-unit"
+		[[ $retstatus_tests -eq 0 ]] || failures="${failures} tests"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		[[ -z "$failures" ]] || die "Test failures: $failures"
+		einfo "Tests successfully completed"
+
+	else
+
+		einfo "Skipping server tests due to minimal build."
+	fi
+}

--- a/dev-db/mysql/mysql-5.6.26-r2.ebuild
+++ b/dev-db/mysql/mysql-5.6.26-r2.ebuild
@@ -1,0 +1,165 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+MY_EXTRAS_VER="20150717-1707Z"
+MY_PV="${PV//_alpha_pre/-m}"
+MY_PV="${MY_PV//_/-}"
+HAS_TOOLS_PATCH="1"
+SUBSLOT="18"
+
+inherit toolchain-funcs mysql-multilib
+# only to make repoman happy. it is really set in the eclass
+IUSE="$IUSE"
+
+# REMEMBER: also update eclass/mysql*.eclass before committing!
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+
+# When MY_EXTRAS is bumped, the index should be revised to exclude these.
+EPATCH_EXCLUDE=''
+
+DEPEND="|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )"
+RDEPEND="${RDEPEND}"
+
+# Please do not add a naive src_unpack to this ebuild
+# If you want to add a single patch, copy the ebuild to an overlay
+# and create your own mysql-extras tarball, looking at 000_index.txt
+
+# validate_password plugin uses exceptions when it shouldn't yet (until 5.7)
+# disable until we see what happens with it
+MYSQL_CMAKE_NATIVE_DEFINES="-DWITHOUT_VALIDATE_PASSWORD=1"
+
+# Official test instructions:
+# USE='server embedded extraengine perl ssl static-libs community' \
+# FEATURES='test userpriv -usersandbox' \
+# ebuild mysql-X.X.XX.ebuild \
+# digest clean package
+multilib_src_test() {
+
+	if ! multilib_is_native_abi ; then
+		einfo "Server tests not available on non-native abi".
+		return 0;
+	fi
+
+	local TESTDIR="${BUILD_DIR}/mysql-test"
+	local retstatus_unit
+	local retstatus_tests
+
+	# Bug #213475 - MySQL _will_ object strenously if your machine is named
+	# localhost. Also causes weird failures.
+	[[ "${HOSTNAME}" == "localhost" ]] && die "Your machine must NOT be named localhost"
+
+	if use server ; then
+
+		if [[ $UID -eq 0 ]]; then
+			die "Testing with FEATURES=-userpriv is no longer supported by upstream. Tests MUST be run as non-root."
+		fi
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		einfo ">>> Test phase [test]: ${CATEGORY}/${PF}"
+		addpredict /this-dir-does-not-exist/t9.MYI
+
+		# Run CTest (test-units)
+		cmake-utils_src_test
+		retstatus_unit=$?
+		[[ $retstatus_unit -eq 0 ]] || eerror "test-unit failed"
+
+		# Create a symlink to provided binaries so the tests can find them when client-libs is off
+		if ! use client-libs ; then
+			ln -srf /usr/bin/my_print_defaults "${BUILD_DIR}/client/my_print_defaults" || die
+			ln -srf /usr/bin/perror "${BUILD_DIR}/client/perror" || die
+			mysql-multilib_disable_test main.perror "String mismatch due to not building local perror"
+		fi
+
+		# Ensure that parallel runs don't die
+		export MTR_BUILD_THREAD="$((${RANDOM} % 100))"
+		# Enable parallel testing, auto will try to detect number of cores
+		# You may set this by hand.
+		# The default maximum is 8 unless MTR_MAX_PARALLEL is increased
+		export MTR_PARALLEL="${MTR_PARALLEL:-auto}"
+
+		# create directories because mysqladmin might right out of order
+		mkdir -p "${T}"/var-tests{,/log}
+
+		# create symlink for the tests to find mysql_tzinfo_to_sql
+		ln -s "${BUILD_DIR}/sql/mysql_tzinfo_to_sql" "${S}/sql/"
+
+		# These are failing in MySQL 5.5/5.6 for now and are believed to be
+		# false positives:
+		#
+		# main.information_schema, binlog.binlog_statement_insert_delayed,
+		# funcs_1.is_triggers funcs_1.is_tables_mysql,
+		# funcs_1.is_columns_mysql, binlog.binlog_mysqlbinlog_filter,
+		# perfschema.binlog_edge_mix, perfschema.binlog_edge_stmt,
+		# mysqld--help-notwin, funcs_1.is_triggers, funcs_1.is_tables_mysql, funcs_1.is_columns_mysql
+		# perfschema.binlog_edge_stmt, perfschema.binlog_edge_mix, binlog.binlog_mysqlbinlog_filter
+		# fails due to USE=-latin1 / utf8 default
+		#
+		# main.mysql_client_test:
+		# segfaults at random under Portage only, suspect resource limits.
+		#
+		# rpl.rpl_plugin_load
+		# fails due to included file not listed in expected result
+		# appears to be poor planning
+		#
+		# main.mysqlhotcopy_archive main.mysqlhotcopy_myisam
+		# fails due to bad cleanup of previous tests when run in parallel
+		# The tool is deprecated anyway
+		# Bug 532288
+		for t in \
+			binlog.binlog_mysqlbinlog_filter \
+			binlog.binlog_statement_insert_delayed \
+			funcs_1.is_columns_mysql \
+			funcs_1.is_tables_mysql \
+			funcs_1.is_triggers \
+			main.information_schema \
+			main.mysql_client_test \
+			main.mysqld--help-notwin \
+			perfschema.binlog_edge_mix \
+			perfschema.binlog_edge_stmt \
+			rpl.rpl_plugin_load \
+			main.mysqlhotcopy_archive main.mysqlhotcopy_myisam \
+		; do
+				mysql-multilib_disable_test  "$t" "False positives in Gentoo"
+		done
+
+		if ! use extraengine ; then
+			# bug 401673, 530766
+			for t in federated.federated_plugin ; do
+				mysql-multilib_disable_test  "$t" "Test $t requires USE=extraengine (Need federated engine)"
+			done
+		fi
+
+		# Run mysql tests
+		pushd "${TESTDIR}"
+
+		# Set file limits higher so tests run
+		ulimit -n 3000
+
+		# run mysql-test tests
+		perl mysql-test-run.pl --force --vardir="${T}/var-tests" \
+			--suite-timeout=5000 --reorder
+		retstatus_tests=$?
+		[[ $retstatus_tests -eq 0 ]] || eerror "tests failed"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		popd
+
+		# Cleanup is important for these testcases.
+		pkill -9 -f "${S}/ndb" 2>/dev/null
+		pkill -9 -f "${S}/sql" 2>/dev/null
+
+		failures=""
+		[[ $retstatus_unit -eq 0 ]] || failures="${failures} test-unit"
+		[[ $retstatus_tests -eq 0 ]] || failures="${failures} tests"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		[[ -z "$failures" ]] || die "Test failures: $failures"
+		einfo "Tests successfully completed"
+
+	else
+		einfo "Skipping server tests due to minimal build."
+	fi
+}

--- a/dev-db/percona-server/percona-server-5.6.26.74.0-r1.ebuild
+++ b/dev-db/percona-server/percona-server-5.6.26.74.0-r1.ebuild
@@ -1,0 +1,166 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+MY_EXTRAS_VER="20150717-1707Z"
+HAS_TOOLS_PATCH="1"
+SUBSLOT="18"
+
+inherit toolchain-funcs mysql-multilib
+# only to make repoman happy. it is really set in the eclass
+IUSE="$IUSE tokudb tokudb-backup-plugin"
+
+# REMEMBER: also update eclass/mysql*.eclass before committing!
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-fbsd ~x86-fbsd ~x86-linux"
+
+# When MY_EXTRAS is bumped, the index should be revised to exclude these.
+EPATCH_EXCLUDE=''
+
+DEPEND="|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )
+	tokudb? ( app-arch/snappy )
+	tokudb-backup-plugin? ( dev-util/valgrind )"
+RDEPEND="${RDEPEND}"
+
+REQUIRED_USE="tokudb? ( jemalloc ) tokudb-backup-plugin? ( tokudb )"
+
+# Please do not add a naive src_unpack to this ebuild
+# If you want to add a single patch, copy the ebuild to an overlay
+# and create your own mysql-extras tarball, looking at 000_index.txt
+
+# Official test instructions:
+# USE='extraengine perl ssl static-libs community' \
+# FEATURES='test userpriv -usersandbox' \
+# ebuild percona-server-X.X.XX.ebuild \
+# digest clean package
+multilib_src_test() {
+
+	if ! multilib_is_native_abi ; then
+		einfo "Server tests not available on non-native abi".
+		return 0;
+	fi
+
+	local TESTDIR="${CMAKE_BUILD_DIR}/mysql-test"
+	local retstatus_unit
+	local retstatus_tests
+
+	# Bug #213475 - MySQL _will_ object strenously if your machine is named
+	# localhost. Also causes weird failures.
+	[[ "${HOSTNAME}" == "localhost" ]] && die "Your machine must NOT be named localhost"
+
+	if use server ; then
+
+		if [[ $UID -eq 0 ]]; then
+			die "Testing with FEATURES=-userpriv is no longer supported by upstream. Tests MUST be run as non-root."
+		fi
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		einfo ">>> Test phase [test]: ${CATEGORY}/${PF}"
+		addpredict /this-dir-does-not-exist/t9.MYI
+
+		# Run CTest (test-units)
+		cmake-utils_src_test
+		retstatus_unit=$?
+		[[ $retstatus_unit -eq 0 ]] || eerror "test-unit failed"
+
+		# Ensure that parallel runs don't die
+		export MTR_BUILD_THREAD="$((${RANDOM} % 100))"
+		# Enable parallel testing, auto will try to detect number of cores
+		# You may set this by hand.
+		# The default maximum is 8 unless MTR_MAX_PARALLEL is increased
+		export MTR_PARALLEL="${MTR_PARALLEL:-auto}"
+
+		# create directories because mysqladmin might right out of order
+		mkdir -p "${T}"/var-tests{,/log}
+
+		# Create a symlink to provided binaries so the tests can find them when client-libs is off
+		if ! use client-libs ; then
+			ln -srf /usr/bin/my_print_defaults "${BUILD_DIR}/client/my_print_defaults" || die
+			ln -srf /usr/bin/perror "${BUILD_DIR}/client/perror" || die
+			mysql-multilib_disable_test main.perror "String mismatch due to not building local perror"
+		fi
+
+		# These are failing in Percona 5.6 for now and are believed to be
+		# false positives:
+		#
+		# main.information_schema, binlog.binlog_statement_insert_delayed,
+		# main.mysqld--help-notwin, binlog.binlog_mysqlbinlog_filter
+		# perfschema.binlog_edge_mix, perfschema.binlog_edge_stmt
+		# funcs_1.is_columns_mysql funcs_1.is_tables_mysql funcs_1.is_triggers
+		# engines/funcs.db_alter_character_set engines/funcs.db_alter_character_set_collate
+		# engines/funcs.db_alter_collate_ascii engines/funcs.db_alter_collate_utf8
+		# engines/funcs.db_create_character_set engines/funcs.db_create_character_set_collate
+		# fails due to USE=-latin1 / utf8 default
+		#
+		# main.mysql_client_test:
+		# segfaults at random under Portage only, suspect resource limits.
+		#
+		# main.percona_bug1289599
+		# Looks to be a syntax error in the test file itself
+		#
+		# main.variables main.myisam main.merge_recover
+		# fails due to ulimit not able to open enough files (needs 5000)
+		#
+		# main.mysqlhotcopy_archive main.mysqlhotcopy_myisam
+		# Called with bad parameters should be reported upstream
+		#
+		# innodb_stress.innodb_stress
+		# innodb_stress.innodb_stress_blob innodb_stress.innodb_stress_blob_nocompress
+		# innodb_stress.innodb_stress_crash innodb_stress.innodb_stress_crash_blob
+		# innodb_stress.innodb_stress_crash_blob_nocompress innodb_stress.innodb_stress_crash_nocompress
+		# innodb_stress.innodb_stress_nocompress
+		# Dependent on python2 being the system python
+
+		for t in main.mysql_client_test \
+			binlog.binlog_statement_insert_delayed main.information_schema \
+			main.mysqld--help-notwin binlog.binlog_mysqlbinlog_filter \
+			perfschema.binlog_edge_mix perfschema.binlog_edge_stmt \
+			funcs_1.is_columns_mysql funcs_1.is_tables_mysql funcs_1.is_triggers \
+			main.variables main.myisam main.merge_recover \
+			engines/funcs.db_alter_character_set engines/funcs.db_alter_character_set_collate \
+			engines/funcs.db_alter_collate_ascii engines/funcs.db_alter_collate_utf8 \
+			engines/funcs.db_create_character_set engines/funcs.db_create_character_set_collate \
+			main.percona_bug1289599 main.mysqlhotcopy_archive main.mysqlhotcopy_myisam ; do
+				mysql-multilib_disable_test  "$t" "False positives in Gentoo"
+		done
+
+		for t in innodb_stress.innodb_stress \
+			innodb_stress.innodb_stress_blob innodb_stress.innodb_stress_blob_nocompress \
+			innodb_stress.innodb_stress_crash innodb_stress.innodb_stress_crash_blob \
+			innodb_stress.innodb_stress_crash_blob_nocompress innodb_stress.innodb_stress_crash_nocompress \
+			innodb_stress.innodb_stress_nocompress ; do
+				mysql-multilib_disable_test "$t" "False positives due to python exception syntax"
+		done
+
+		# Run mysql tests
+		pushd "${TESTDIR}"
+
+		# Set file limits higher so tests run
+		ulimit -n 3000
+
+		# run mysql-test tests
+		perl mysql-test-run.pl --force --vardir="${T}/var-tests" \
+			--testcase-timeout=30 --reorder
+		retstatus_tests=$?
+		[[ $retstatus_tests -eq 0 ]] || eerror "tests failed"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		popd
+
+		# Cleanup is important for these testcases.
+		pkill -9 -f "${S}/ndb" 2>/dev/null
+		pkill -9 -f "${S}/sql" 2>/dev/null
+
+		failures=""
+		[[ $retstatus_unit -eq 0 ]] || failures="${failures} test-unit"
+		[[ $retstatus_tests -eq 0 ]] || failures="${failures} tests"
+		has usersandbox $FEATURES && eerror "Some tests may fail with FEATURES=usersandbox"
+
+		[[ -z "$failures" ]] || die "Test failures: $failures"
+		einfo "Tests successfully completed"
+
+	else
+
+		einfo "Skipping server tests due to minimal build."
+	fi
+}

--- a/eclass/mysql-multilib.eclass
+++ b/eclass/mysql-multilib.eclass
@@ -192,7 +192,7 @@ fi
 LICENSE="GPL-2"
 SLOT="0/${SUBSLOT:-0}"
 
-IUSE="+community cluster debug embedded extraengine jemalloc latin1
+IUSE="+community cluster debug embedded extraengine jemalloc latin1 libressl
 	+perl profiling selinux ssl systemtap static static-libs tcmalloc test"
 
 ### Begin readline/libedit
@@ -271,7 +271,10 @@ REQUIRED_USE="
 # These are used for both runtime and compiletime
 # MULTILIB_USEDEP only set for libraries used by the client library
 DEPEND="
-	ssl? ( >=dev-libs/openssl-1.0.0:0=[${MULTILIB_USEDEP},static-libs?] )
+	ssl? (
+		!libressl? ( >=dev-libs/openssl-1.0.0:0=[${MULTILIB_USEDEP},static-libs?] )
+		libressl? ( dev-libs/libressl[${MULTILIB_USEDEP},static-libs?] )
+	)
 	kernel_linux? (
 		sys-process/procps:0=
 		dev-libs/libaio:0=
@@ -287,18 +290,27 @@ DEPEND="
 if [[ ${HAS_TOOLS_PATCH} ]] ; then
 	DEPEND+="
 		client-libs? (
-			ssl? ( >=dev-libs/openssl-1.0.0:0=[${MULTILIB_USEDEP},static-libs?] )
+			ssl? (
+				!libressl? ( >=dev-libs/openssl-1.0.0:0=[${MULTILIB_USEDEP},static-libs?] )
+				libressl? ( dev-libs/libressl[${MULTILIB_USEDEP},static-libs?] )
+			)
 			>=sys-libs/zlib-1.2.3:0=[${MULTILIB_USEDEP},static-libs?]
 		)
 		!client-libs? (
-			ssl? ( >=dev-libs/openssl-1.0.0:0=[static-libs?] )
+			ssl? (
+				!libressl? ( >=dev-libs/openssl-1.0.0:0=[static-libs?] )
+				libressl? ( dev-libs/libressl[static-libs?] )
+			)
 			>=sys-libs/zlib-1.2.3:0=[static-libs?]
 		)
 		tools? ( sys-libs/ncurses:0= ) embedded? ( sys-libs/ncurses:0= )
 	"
 else
 	DEPEND+="
-		ssl? ( >=dev-libs/openssl-1.0.0:0=[${MULTILIB_USEDEP},static-libs?] )
+		ssl? (
+			!libressl? ( >=dev-libs/openssl-1.0.0:0=[${MULTILIB_USEDEP},static-libs?] )
+			libressl? ( dev-libs/libressl[${MULTILIB_USEDEP},static-libs?] )
+		)
 		>=sys-libs/zlib-1.2.3:0=[${MULTILIB_USEDEP},static-libs?]
 		sys-libs/ncurses:0=[${MULTILIB_USEDEP}]
 	"

--- a/eclass/mysql-v2.eclass
+++ b/eclass/mysql-v2.eclass
@@ -208,10 +208,10 @@ SLOT="0"
 
 case "${BUILD}" in
 	"autotools")
-		IUSE="big-tables debug embedded minimal +perl selinux ssl static test"
+		IUSE="big-tables debug embedded libressl minimal +perl selinux ssl static test"
 		;;
 	"cmake")
-		IUSE="debug embedded minimal +perl selinux ssl static static-libs test"
+		IUSE="debug embedded libressl minimal +perl selinux ssl static static-libs test"
 		;;
 esac
 
@@ -269,7 +269,10 @@ REQUIRED_USE="${REQUIRED_USE} minimal? ( !cluster !extraengine !embedded ) stati
 # Be warned, *DEPEND are version-dependant
 # These are used for both runtime and compiletime
 DEPEND="
-	ssl? ( >=dev-libs/openssl-0.9.6d:0 )
+	ssl? (
+		!libressl? ( >=dev-libs/openssl-0.9.6d:0 )
+		libressl? ( dev-libs/libressl )
+	)
 	kernel_linux? ( sys-process/procps )
 	>=sys-apps/sed-4
 	>=sys-apps/texinfo-4.7-r1
@@ -322,7 +325,10 @@ if mysql_version_is_at_least "5.5.7" ; then
 		jemalloc? ( dev-libs/jemalloc[static-libs?] )
 		tcmalloc? ( dev-util/google-perftools )
 		>=sys-libs/zlib-1.2.3[static-libs?]
-		ssl? ( >=dev-libs/openssl-0.9.6d[static-libs?] )
+		ssl? (
+			!libressl? ( >=dev-libs/openssl-0.9.6d:0[static-libs?] )
+			libressl? ( dev-libs/libressl[static-libs?] )
+		)
 		systemtap? ( >=dev-util/systemtap-1.3 )
 		kernel_linux? ( dev-libs/libaio )
 	"

--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -5,6 +5,12 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in package.use.mask
 
+# Julian Ospald <hasufell@gentoo.org> (20 sep 2015)
+# dev-libs/libressl is not in stable arch yet,
+# remove this entry once it is!
+dev-db/mariadb libressl
+dev-db/mysql libressl
+
 # Johannes Huber <johu@gentoo.org> (27 Aug 2015)
 # Needs KF 5 stable, bug #558460
 net-irc/quassel qt5

--- a/virtual/libmysqlclient/libmysqlclient-18-r1.ebuild
+++ b/virtual/libmysqlclient/libmysqlclient-18-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for MySQL client libraries"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE=""
+SLOT="0/18"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+IUSE="libressl static-libs"
+
+DEPEND=""
+RDEPEND="
+	|| (
+		dev-db/mysql-connector-c:${SLOT}[libressl=,static-libs?,${MULTILIB_USEDEP}]
+		dev-db/mariadb:${SLOT}[client-libs(+),libressl=,static-libs?,${MULTILIB_USEDEP}]
+		dev-db/mysql:${SLOT}[client-libs(+),libressl=,static-libs?,${MULTILIB_USEDEP}]
+		dev-db/percona-server:${SLOT}[client-libs(+),libressl=,static-libs?,${MULTILIB_USEDEP}]
+		dev-db/mariadb-galera:${SLOT}[client-libs(+),libressl=,static-libs?,${MULTILIB_USEDEP}]
+		dev-db/mysql-cluster:${SLOT}[client-libs(+),libressl=,static-libs?,${MULTILIB_USEDEP}]
+	)"

--- a/virtual/mysql/mysql-5.6-r7.ebuild
+++ b/virtual/mysql/mysql-5.6-r7.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for MySQL database server"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE=""
+SLOT="0/18"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+IUSE="embedded libressl static static-libs"
+
+DEPEND=""
+RDEPEND="
+	virtual/libmysqlclient[static-libs?,${MULTILIB_USEDEP}]
+	embedded? (
+		|| (
+			=dev-db/mariadb-10.1*[client-libs(+),embedded,libressl=,static=]
+			=dev-db/mariadb-10.0*[client-libs(+),embedded,libressl=,static=]
+			=dev-db/mysql-${PV}*[client-libs(+),embedded,libressl=,static=]
+			=dev-db/percona-server-${PV}*[client-libs(+),embedded,libressl=,static=]
+			=dev-db/mariadb-galera-10.0*[client-libs(+),embedded,libressl=,static=]
+			=dev-db/mysql-cluster-7.3*[client-libs(+),embedded,libressl=,static=]
+		)
+	)
+	!embedded? (
+		|| (
+			=dev-db/mariadb-10.1*[-embedded,libressl=,static=]
+			=dev-db/mariadb-10.0*[-embedded,libressl=,static=]
+			=dev-db/mysql-${PV}*[-embedded,libressl=,static=]
+			=dev-db/percona-server-${PV}*[-embedded,libressl=,static=]
+			=dev-db/mariadb-galera-10.0*[-embedded,libressl=,static=]
+			=dev-db/mysql-cluster-7.3*[-embedded,libressl=,static=]
+		)
+	)
+"


### PR DESCRIPTION
Since mysql eclass is tightly integrated in several packages, we
have to adjust these in one blow, revbump the latest ones in/to
unstable arch, fix the virtuals to propagate the libressl USE flag
and mask libressl USE flag for stable arch of these packages, because
dev-libs/libressl is not in stable arch yet.

https://bugs.gentoo.org/show_bug.cgi?id=560936