### PR TITLE
net-libs/libaccounts-glib: Really disable broken tests

### DIFF
--- a/net-libs/libaccounts-glib/libaccounts-glib-1.18.ebuild
+++ b/net-libs/libaccounts-glib/libaccounts-glib-1.18.ebuild
@@ -4,8 +4,6 @@
 
 EAPI=5
 
-inherit autotools
-
 DESCRIPTION="Accounts SSO (Single Sign-On) management library for GLib applications"
 HOMEPAGE="https://01.org/gsso/"
 SRC_URI="http://dev.gentoo.org/~kensington/distfiles/${P}.tar.gz"
@@ -24,12 +22,9 @@ DEPEND="
 
 RDEPEND="$DEPEND"
 
-src_prepare() {
-	sed -i -e "/tests\/Makefile/d" configure.ac || die
-	eautoreconf
-}
-
 src_configure() {
 	export HAVE_GCOV_FALSE='#'
-	econf $(use_enable debug)
+	econf \
+		$(use_enable debug) \
+		--disable-tests
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=560656

Package-Manager: portage-2.2.20.1