### PR TITLE
kde-apps/kde-l10n: Add missing DEPEND

### DIFF
--- a/kde-apps/kde-l10n/kde-l10n-15.08.1.ebuild
+++ b/kde-apps/kde-l10n/kde-l10n-15.08.1.ebuild
@@ -12,6 +12,7 @@ HOMEPAGE="http://l10n.kde.org"
 
 DEPEND="
 	$(add_frameworks_dep ki18n)
+	dev-qt/linguist-tools:5
 	sys-devel/gettext
 "
 RDEPEND="


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=561066

Package-Manager: portage-2.2.20.1