### PR TITLE
eclass/java-utils-2: Added proposed function to remove *.class and *.jar files from source…

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -2824,3 +2824,12 @@ is-java-strict() {
 	[[ -n ${JAVA_PKG_STRICT} ]]
 	return $?
 }
+
+# @FUNCTION: java-pkg_clean
+# @DESCRIPTION:
+# java package cleaner function, will remove all *.class and *.jar files
+# removing any bundled dependencies
+java-pkg_clean() {
+	[[ -n "${JAVA_PKG_NO_CLEAN}" ]] &&
+		find '(' -name '*.class' -o -name '*.jar' ')' -type f -delete -print || die
+}


### PR DESCRIPTION
Added proposed function to remove *.class and *.jar files from sources. Long term should be called automatically all the time with optional override via JAVA_PKG_NO_CLEAN. Maybe even making that an array of files to keep and removing all the others. For now will standardize the usage of find delete/rm in ebuilds. There are lots of variations, not that it matters, but might as well make it standard as its used a fair amount.