### PR TITLE
[sys-apps/systemd] Bug#561244: util-linux-2.27 needed

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -28,7 +28,7 @@ REQUIRED_USE="importd? ( curl gcrypt lzma )"
 
 MINKV="3.11"
 
-COMMON_DEPEND=">=sys-apps/util-linux-2.26:0=[${MULTILIB_USEDEP}]
+COMMON_DEPEND=">=sys-apps/util-linux-2.27:0=[${MULTILIB_USEDEP}]
 	sys-libs/libcap:0=[${MULTILIB_USEDEP}]
 	!<sys-libs/glibc-2.16
 	acl? ( sys-apps/acl:0= )


### PR DESCRIPTION
sys-apps/systemd depends since systemd/systemd@85fade1e on a newer version of sys-apps/util-linux and requires now at least release 2.27.
See also: https://bugs.gentoo.org/show_bug.cgi?id=561244