### PR TITLE
media-sound/spotify: Add missing pax_kernel use flag

### DIFF
--- a/media-sound/spotify/spotify-1.0.14.ebuild
+++ b/media-sound/spotify/spotify-1.0.14.ebuild
@@ -16,7 +16,7 @@ SRC_URI="amd64? ( ${SRC_BASE}${MY_P}${MY_PV_AMD64}_amd64.deb )
 LICENSE="Spotify"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="gnome pulseaudio"
+IUSE="gnome pax_kernel pulseaudio"
 RESTRICT="mirror strip"
 
 DEPEND=""


### PR DESCRIPTION
Add missing pax_kenerl use flag. During the update to version 1.0.14 this flag went missing. It is used in src_install().