### PR TITLE
kde-frameworks/baloo: Backport fix for baloo crash if disabled

### DIFF
--- a/kde-frameworks/baloo/baloo-5.14.0-r1.ebuild
+++ b/kde-frameworks/baloo/baloo-5.14.0-r1.ebuild
@@ -32,3 +32,5 @@ DEPEND="
 RDEPEND="${DEPEND}
 	!kde-base/baloo:4[-minimal(-)]
 "
+
+PATCHES=( "${FILESDIR}/${P}-check-if-db-open.patch" )

--- a/kde-frameworks/baloo/files/baloo-5.14.0-check-if-db-open.patch
+++ b/kde-frameworks/baloo/files/baloo-5.14.0-check-if-db-open.patch
@@ -1,0 +1,28 @@
+From: Boudhayan Gupta <me@BaloneyGeek.com>
+Date: Tue, 22 Sep 2015 18:55:36 +0000
+Subject: Fail Baloo::File::load() if the Database is not open.
+X-Git-Url: http://quickgit.kde.org/?p=baloo.git&a=commitdiff&h=29fe68f2657df503926e629477a41f7d9435048f
+---
+Fail Baloo::File::load() if the Database is not open.
+Fixes crash if selecting multiple files in Dolphin with
+Baloo disabled.
+
+BUG: 353049
+REVIEW: 125352
+---
+
+
+--- a/src/lib/file.cpp
++++ b/src/lib/file.cpp
+@@ -98,6 +98,10 @@
+     Database *db = globalDatabaseInstance();
+     db->open(Database::OpenDatabase);
+ 
++    if (!db->isOpen()) {
++        return false;
++    }
++
+     quint64 id = filePathToId(QFile::encodeName(d->url));
+     if (!id) {
+         return false;
+


### PR DESCRIPTION
Upstream bug: https://bugs.kde.org/show_bug.cgi?id=353049

Package-Manager: portage-2.2.20.1