### PR TITLE
app-crypt/qca: Add upstream fix to use Q_SLOTS/Q_SIGNALS

### DIFF
--- a/app-crypt/qca/files/qca-2.1.0.3-fix-signals-slots.patch
+++ b/app-crypt/qca/files/qca-2.1.0.3-fix-signals-slots.patch
@@ -1,0 +1,28 @@
+From: Jan Grulich <jgrulich@redhat.com>
+Date: Thu, 17 Sep 2015 14:14:24 +0000
+Subject: Use Q_SLOTS/Q_SIGNALS instead of slots/signals in all headers from include dir
+X-Git-Url: http://quickgit.kde.org/?p=qca.git&a=commitdiff&h=66b9754170759d9333d5fc1e348642814d0310dd
+---
+Use Q_SLOTS/Q_SIGNALS instead of slots/signals in all headers from include dir
+REVIEW:125289
+---
+
+
+--- a/include/QtCrypto/qca_safetimer.h
++++ b/include/QtCrypto/qca_safetimer.h
+@@ -44,12 +44,12 @@
+ 	void setSingleShot(bool singleShot);
+ 	int timerId() const;
+ 
+-public slots:
++public Q_SLOTS:
+ 	void start(int msec);
+ 	void start();
+ 	void stop();
+ 
+-signals:
++Q_SIGNALS:
+ 	void timeout();
+ 
+ protected:
+

--- a/app-crypt/qca/qca-2.1.0.3-r1.ebuild
+++ b/app-crypt/qca/qca-2.1.0.3-r1.ebuild
@@ -1,0 +1,124 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit cmake-utils multibuild qmake-utils
+
+MY_PN="${PN}-qt5"
+
+DESCRIPTION="Qt Cryptographic Architecture (QCA)"
+HOMEPAGE="http://delta.affinix.com/qca/"
+SRC_URI="mirror://kde/stable/${MY_PN}/${PV}/src/${MY_PN}-${PV}.tar.xz"
+
+LICENSE="LGPL-2.1"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
+
+IUSE="botan debug doc examples gcrypt gpg logger nss +openssl pkcs11 +qt4 qt5 sasl softstore test"
+REQUIRED_USE="|| ( qt4 qt5 )"
+
+RDEPEND="
+	!app-crypt/qca-cyrus-sasl
+	!app-crypt/qca-gnupg
+	!app-crypt/qca-logger
+	!app-crypt/qca-ossl
+	!app-crypt/qca-pkcs11
+	botan? ( dev-libs/botan )
+	gcrypt? ( dev-libs/libgcrypt:= )
+	gpg? ( app-crypt/gnupg )
+	nss? ( dev-libs/nss )
+	openssl? ( >=dev-libs/openssl-1.0.1:0 )
+	pkcs11? (
+		dev-libs/openssl:0
+		dev-libs/pkcs11-helper
+	)
+	qt4? ( dev-qt/qtcore:4 )
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtconcurrent:5
+		dev-qt/qtnetwork:5
+	)
+	sasl? ( dev-libs/cyrus-sasl:2 )
+"
+DEPEND="${RDEPEND}
+	doc? ( app-doc/doxygen )
+	test? (
+		qt4? ( dev-qt/qttest:4 )
+		qt5? ( dev-qt/qttest:5 )
+	)
+"
+
+S=${WORKDIR}/${MY_PN}-${PV}
+
+DOCS=( README TODO )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-disable-pgp-test.patch"
+	"${FILESDIR}/${P}-qt55.patch"
+	"${FILESDIR}/${P}-fix-signals-slots.patch"
+)
+
+qca_plugin_use() {
+	echo -DWITH_${2:-$1}_PLUGIN=$(usex "$1")
+}
+
+pkg_setup() {
+	MULTIBUILD_VARIANTS=( $(usev qt4) $(usev qt5) )
+}
+
+src_configure() {
+	myconfigure() {
+		local mycmakeargs=(
+			-DQCA_FEATURE_INSTALL_DIR="${EPREFIX}$(${MULTIBUILD_VARIANT}_get_mkspecsdir)/features"
+			-DQCA_PLUGINS_INSTALL_DIR="${EPREFIX}$(${MULTIBUILD_VARIANT}_get_plugindir)"
+			$(qca_plugin_use botan)
+			$(qca_plugin_use gcrypt)
+			$(qca_plugin_use gpg gnupg)
+			$(qca_plugin_use logger)
+			$(qca_plugin_use nss)
+			$(qca_plugin_use openssl ossl)
+			$(qca_plugin_use pkcs11)
+			$(qca_plugin_use sasl cyrus-sasl)
+			$(qca_plugin_use softstore)
+			$(cmake-utils_use_build test TESTS)
+		)
+
+		if [[ ${MULTIBUILD_VARIANT} == qt4 ]]; then
+			mycmakeargs+=(-DQT4_BUILD=ON)
+		fi
+
+		cmake-utils_src_configure
+	}
+
+	multibuild_foreach_variant myconfigure
+}
+
+src_compile() {
+	multibuild_foreach_variant cmake-utils_src_compile
+}
+
+src_test() {
+	mytest() {
+		local -x QCA_PLUGIN_PATH="${BUILD_DIR}/lib/qca"
+		cmake-utils_src_test
+	}
+
+	multibuild_foreach_variant mytest
+}
+
+src_install() {
+	multibuild_foreach_variant cmake-utils_src_install
+
+	if use doc; then
+		pushd "${BUILD_DIR}" >/dev/null || die
+		doxygen Doxyfile.in || die
+		dodoc -r apidocs/html
+		popd >/dev/null || die
+	fi
+
+	if use examples; then
+		dodoc -r "${S}"/examples
+	fi
+}


### PR DESCRIPTION
Fixes build of kde-plasma/plasma-nm-9999
RR: https://git.reviewboard.kde.org/r/125289/
Upstream Commit: 66b9754170759d9333d5fc1e348642814d0310dd

rdeps tested so far did not fail to build.

Package-Manager: portage-2.2.20.1