### PR TITLE
dev-python/pep8: restore compatibility with flake8

### DIFF
--- a/dev-python/flake8/flake8-2.4.1-r1.ebuild
+++ b/dev-python/flake8/flake8-2.4.1-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+
+inherit distutils-r1
+
+DESCRIPTION="A wrapper around PyFlakes, pep8 & mccabe"
+HOMEPAGE="https://bitbucket.org/tarek/flake8 https://pypi.python.org/pypi/flake8"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="test"
+LICENSE="MIT"
+SLOT="0"
+
+# requires.txt inc. mccabe however that creates a circular dep
+RDEPEND=">=dev-python/pyflakes-0.8.1[${PYTHON_USEDEP}]
+	<dev-python/pyflakes-0.9[${PYTHON_USEDEP}]
+	>=dev-python/pep8-1.5.7[${PYTHON_USEDEP}]
+	!=dev-python/pep8-1.6.1[${PYTHON_USEDEP}]
+	!=dev-python/pep8-1.6.2[${PYTHON_USEDEP}]
+"
+PDEPEND=">=dev-python/mccabe-0.2.1[${PYTHON_USEDEP}]
+	<dev-python/mccabe-0.4[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? ( ${PDEPEND}
+		dev-python/nose[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep 'dev-python/mock[${PYTHON_USEDEP}]' python2_7) )"
+
+python_prepare_all() {
+	# This tests requires / assumes this version is already installed.
+	sed -e 's:test_register_extensions:_&:' -i flake8/tests/test_engine.py || die
+	# Gentoo has flake8 support restored in >=pep8-1.6.2-r1.
+	sed -e 's:, != 1.6.2::' -i setup.py || die
+	distutils-r1_python_prepare_all
+}
+
+python_test() {
+	esetup.py test
+}

--- a/dev-python/pep8/files/pep8-1.6.2-restore-flake8-compatibility.patch
+++ b/dev-python/pep8/files/pep8-1.6.2-restore-flake8-compatibility.patch
@@ -1,0 +1,69 @@
+commit 435d1cbf995a659a82d1d4b42d25e3459556ef21
+Author: Ian Lee <IanLee1521@gmail.com>
+Date:   Tue Mar 17 21:52:23 2015 -0700
+
+    Reverted fix for #368 which had unintended repurcussions in flake8 and other places.
+    
+    This fix reverts to the parsing of user config (~/.config/pep8), then local directory
+    config files, and finally overrides with cli options as was the behavior back in 1.5.7
+
+diff --git a/CHANGES.txt b/CHANGES.txt
+index 85eb043..5499abd 100644
+--- a/CHANGES.txt
++++ b/CHANGES.txt
+@@ -5,6 +5,12 @@ Changelog
+ 1.6.x (unreleased)
+ ------------------
+ 
++Changes:
++
++* Reverted the fix in #368, "options passed on command line are only ones
++  accepted" feature. This has many unintended consequences in pep8 and flake8
++  and needs to be reworked when I have more time.
++
+ 1.6.2 (2015-02-15)
+ ------------------
+ 
+diff --git a/pep8.py b/pep8.py
+index 9f40381..4d993da 100755
+--- a/pep8.py
++++ b/pep8.py
+@@ -1984,24 +1984,24 @@ def read_config(options, args, arglist, parser):
+ 
+     local_dir = os.curdir
+ 
++    if USER_CONFIG and os.path.isfile(USER_CONFIG):
++        if options.verbose:
++            print('user configuration: %s' % USER_CONFIG)
++        config.read(USER_CONFIG)
++
++    parent = tail = args and os.path.abspath(os.path.commonprefix(args))
++    while tail:
++        if config.read(os.path.join(parent, fn) for fn in PROJECT_CONFIG):
++            local_dir = parent
++            if options.verbose:
++                print('local configuration: in %s' % parent)
++            break
++        (parent, tail) = os.path.split(parent)
++
+     if cli_conf and os.path.isfile(cli_conf):
+         if options.verbose:
+             print('cli configuration: %s' % cli_conf)
+         config.read(cli_conf)
+-    else:
+-        if USER_CONFIG and os.path.isfile(USER_CONFIG):
+-            if options.verbose:
+-                print('user configuration: %s' % USER_CONFIG)
+-            config.read(USER_CONFIG)
+-
+-        parent = tail = args and os.path.abspath(os.path.commonprefix(args))
+-        while tail:
+-            if config.read(os.path.join(parent, fn) for fn in PROJECT_CONFIG):
+-                local_dir = parent
+-                if options.verbose:
+-                    print('local configuration: in %s' % parent)
+-                break
+-            (parent, tail) = os.path.split(parent)
+ 
+     pep8_section = parser.prog
+     if config.has_section(pep8_section):

--- a/dev-python/pep8/pep8-1.6.2-r1.ebuild
+++ b/dev-python/pep8/pep8-1.6.2-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+PYTHON_COMPAT=( python{2_7,3_3,3_4} pypy pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="Python style guide checker"
+HOMEPAGE="https://github.com/jcrocholl/pep8 https://pypi.python.org/pypi/pep8"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc"
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
+	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-restore-flake8-compatibility.patch" )
+
+python_compile_all() {
+	use doc && emake -C docs html
+}
+
+python_test() {
+	PYTHONPATH="${S}" "${PYTHON}" pep8.py -v --testsuite=testsuite || die
+	PYTHONPATH="${S}" "${PYTHON}" pep8.py --doctest -v || die
+}
+
+python_install_all() {
+	use doc && local HTML_DOCS=( docs/_build/html/. )
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
Hello.

pep8-1.6.0 introduced [a change](https://github.com/PyCQA/pep8/issues/368) that broke flake8. Upstream later [reverted this change](https://github.com/PyCQA/pep8/commit/435d1cbf995a659a82d1d4b42d25e3459556ef21) to restore broken compatibility with flake8, but it happened after pep8-1.6.2 release.

Upstream [does not want to rush to a new release](https://github.com/PyCQA/pep8/issues/427#issuecomment-129502134) so it would be nice to have this compatibility problem solved for Gentoo users in the meantime.

Also revbump flake8 to only exclude known bad versions of pep8 [as it is done upstream](https://gitlab.com/pycqa/flake8/commit/d41701df3be7e3d04ba1fcc1e178fd777c6ff352) to allow the patched version of pep8 to coexist with flake8.