### PR TITLE
net-wireless/bluez: install the btmgmt tool

### DIFF
--- a/net-wireless/bluez/bluez-5.34.ebuild
+++ b/net-wireless/bluez/bluez-5.34.ebuild
@@ -156,6 +156,7 @@ multilib_src_install() {
 		# gatttool is only built with readline, bug #530776
 		use readline && dobin attrib/gatttool
 		dobin tools/hex2hcd
+		dobin tools/btmgmt
 
 		# Unittests are not that useful once installed
 		if use test ; then


### PR DESCRIPTION
The btmgmt tool is not installed by bluez. Recently it became necessary to power on the bluetooth, with kernels 4.1.6 and up the hciconfig tool no longer powers on the bluetooth correctly for LE devices to work (see http://www.spinics.net/lists/linux-bluetooth/msg64021.html).

I'm not entirely sure the patch is correct and is perhaps a version bump in place? Let me know and I'll fix it.