### PR TITLE
sys-apps/irqbalance: misc. improvements to service unit

### DIFF
--- a/sys-apps/irqbalance/files/irqbalance.service.1
+++ b/sys-apps/irqbalance/files/irqbalance.service.1
@@ -1,0 +1,8 @@
+[Unit]
+Description=CPU Interrupt Balancer
+
+[Service]
+ExecStart=/usr/sbin/irqbalance --foreground
+
+[Install]
+WantedBy=multi-user.target

--- a/sys-apps/irqbalance/irqbalance-1.0.9-r1.ebuild
+++ b/sys-apps/irqbalance/irqbalance-1.0.9-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+AUTOTOOLS_AUTORECONF=true
+
+inherit autotools-utils systemd linux-info
+
+DESCRIPTION="Distribute hardware interrupts across processors on a multiprocessor system"
+HOMEPAGE="https://github.com/Irqbalance/irqbalance"
+SRC_URI="https://github.com/Irqbalance/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="caps +numa selinux"
+
+CDEPEND="dev-libs/glib:2
+	caps? ( sys-libs/libcap-ng )
+	numa? ( sys-process/numactl )
+"
+DEPEND="${CDEPEND}
+	virtual/pkgconfig
+"
+RDEPEND="${CDEPEND}
+	selinux? ( sec-policy/selinux-irqbalance )
+"
+
+pkg_setup() {
+	CONFIG_CHECK="~PCI_MSI"
+	linux-info_pkg_setup
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_with caps libcap-ng)
+		$(use_enable numa)
+		)
+	autotools-utils_src_configure
+}
+
+src_install() {
+	autotools-utils_src_install
+	newinitd "${FILESDIR}"/irqbalance.init.3 irqbalance
+	newconfd "${FILESDIR}"/irqbalance.confd-1 irqbalance
+	systemd_newunit "${FILESDIR}"/irqbalance.service.1 irqbalance.service
+}


### PR DESCRIPTION
This series of commits improve the sys-apps/irqbalance service unit in the following ways:

- Use `--foreground` instead of `--debug` for daemonization.  This option was added in https://github.com/Irqbalance/irqbalance/commit/827c08f289065df5db980a8c0fcd4bc31638172f waaay back in late 2011, and all versions in Gentoo that use the systemd service file support it.
- Use the file /etc/irqbalance.env as an `EnvironmentFile` if it exists, and use its `$IRQBALANCE_ARGS` variable in `ExecStart`.  This works whether the file exists or not.
- Create a revbump to sys-apps/irqbalance-1.0.9 that installs the upstream file `misc/irqbalance.env` into `/etc`.

Note that I haven't tested the revbump outside of running `ebuild install` and checking the contents of the `image/` directory. I did test the service unit changes with version 1.0.6, though (by applying them to my `irqbalance.service.d/` override).

Feel free to mention anything I might have overlooked, since I couldn't find any documentation on creating pull-requests (https://wiki.gentoo.org/wiki/Gentoo_git_workflow seems to be exclusively targeted at Gentoo developers).  I do have two concrete questions, though:

- Should I have used `repoman commit`?  I had already made my commits before thinking of it. I did run `repoman full .` before every commit, though.
- Should I sign the commits with my GPG key, or is that reserved for Gentoo developers?  The Gentoo git workflow mentions "user signatures" at one point, but that's it.