### PR TITLE
KDE: Fix some dependencies

### DIFF
--- a/kde-apps/dolphin/dolphin-4.14.3.ebuild
+++ b/kde-apps/dolphin/dolphin-4.14.3.ebuild
@@ -25,6 +25,7 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}
+	$(add_kdeapps_dep kdebase-kioslaves)
 	$(add_kdeapps_dep kfind)
 	thumbnail? (
 		$(add_kdeapps_dep thumbnailers)

--- a/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-15.08.1.ebuild
+++ b/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-15.08.1.ebuild
@@ -14,6 +14,7 @@ RDEPEND="
 	$(add_kdeapps_dep kcmshell)
 	$(add_kdeapps_dep kdebase-data)
 	$(add_kdeapps_dep kdebase-desktoptheme)
+	$(add_kdeapps_dep kdebase-kioslaves)
 	$(add_kdeapps_dep kdebase-menu)
 	$(add_kdeapps_dep kdebase-menu-icons)
 	$(add_kdeapps_dep kdebugdialog)
@@ -46,7 +47,6 @@ RDEPEND="
 	!minimal? (
 		$(add_kdeapps_dep attica)
 		$(add_kdeapps_dep kcontrol)
-		$(add_kdeapps_dep kdebase-kioslaves)
 		$(add_kdeapps_dep knetattach)
 	)
 "

--- a/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-4.14.3.ebuild
+++ b/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-4.14.3.ebuild
@@ -13,6 +13,7 @@ RDEPEND="
 	$(add_kdeapps_dep kcmshell)
 	$(add_kdeapps_dep kdebase-data)
 	$(add_kdeapps_dep kdebase-desktoptheme)
+	$(add_kdeapps_dep kdebase-kioslaves)
 	$(add_kdeapps_dep kdebase-menu)
 	$(add_kdeapps_dep kdebase-menu-icons)
 	$(add_kdeapps_dep kdebugdialog)
@@ -48,7 +49,6 @@ RDEPEND="
 	!minimal? (
 		$(add_kdeapps_dep attica)
 		$(add_kdeapps_dep kcontrol)
-		$(add_kdeapps_dep kdebase-kioslaves)
 		$(add_kdeapps_dep knetattach)
 	)
 "

--- a/kde-apps/kscd/kscd-15.08.1.ebuild
+++ b/kde-apps/kscd/kscd-15.08.1.ebuild
@@ -13,7 +13,6 @@ IUSE="debug"
 
 DEPEND="
 	$(add_kdeapps_dep libkcddb)
-	$(add_kdeapps_dep libkcompactdisc)
 	media-libs/musicbrainz:3
 "
 RDEPEND="${DEPEND}"

--- a/kde-apps/kscd/kscd-4.14.3.ebuild
+++ b/kde-apps/kscd/kscd-4.14.3.ebuild
@@ -13,7 +13,6 @@ IUSE="debug"
 
 DEPEND="
 	$(add_kdeapps_dep libkcddb)
-	$(add_kdeapps_dep libkcompactdisc)
 	media-libs/musicbrainz:3
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
- kdebase-kioslaves doesn't need to be kept behind !minimal after file collisions were removed
- it appears to be required at runtime for dolphin:4


- kscd does not use libkcompactdisc at all