### PR TITLE
app-arch/lzip: add ~amd64-fbsd keyword, bug 502018.

### DIFF
--- a/app-arch/lzip/lzip-1.18_pre1.ebuild
+++ b/app-arch/lzip/lzip-1.18_pre1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="http://download.savannah.gnu.org/releases-noredirect/${PN}/${P/_/-}.tar
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 S="${WORKDIR}/${P/_/-}"
 


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=502018

Test phase passed.
```
>>> Test phase: app-arch/lzip-1.18_pre1
gmake -j8   -j1 check
testing lzip-1.18-pre1...............................
tests completed successfully.
>>> Completed testing app-arch/lzip-1.18_pre1
```