### PR TITLE
Fix vmware-bundle eclass for Workstation 12 bundles

### DIFF
--- a/eclass/vmware-bundle.eclass
+++ b/eclass/vmware-bundle.eclass
@@ -71,7 +71,7 @@ vmware-bundle_extract-component() {
 	tail -c+$((offset+component_manifestOffset+1)) "${component}" 2> /dev/null |
 		head -c$((component_manifestSize)) | xsltproc "${T}"/list-component-files.xsl - |
 		while read -r file_offset file_compressedSize file_uncompressedSize file_path ; do
-			if [[ ${file_path} ]] ; then
+			if [[ ${file_path} ]] && [[ ${file_compressedSize} -gt 0 ]]; then
 				echo -n '.'
 				file_path="${dest}/${file_path}"
 				mkdir -p "$(dirname "${file_path}")" || die


### PR DESCRIPTION
For some reason in the Workstation 12 bundles some files are listed multiple times, with all but one of them having a compressed size of 0, which results in gzip failing to extract them.
This addresses this issue by skipping all files with a compressed size of 0.