### PR TITLE
kde-apps/ktp-l10n: Add missing KF5DocTools handling to fix bug 562542

### DIFF
--- a/kde-apps/ktp-l10n/ktp-l10n-15.08.1.ebuild
+++ b/kde-apps/ktp-l10n/ktp-l10n-15.08.1.ebuild
@@ -80,6 +80,8 @@ src_prepare() {
 				# We only want messages
 				sed -e '/messages/!s/^add_subdirectory/# DONT/'\
 					-i "${SDIR}"/CMakeLists.txt || die
+				sed -e '/KF5DocTools/ s/^/#/'\
+					-i "${SDIR}"/CMakeLists.txt || die
 
 				# Remove everything except kdenetwork
 				if [[ -d "${SDIR}/messages" ]] ; then


### PR DESCRIPTION
Package-Manager: portage-2.2.23