### PR TITLE
media-libs/gavl: Add patch for x32, bug #472288

### DIFF
--- a/media-libs/gavl/files/1.4.0-x32.diff
+++ b/media-libs/gavl/files/1.4.0-x32.diff
@@ -1,0 +1,29 @@
+------------------------------------------------------------------------
+r4209 | gmerlin | 2014-06-02 16:38:33 +0200 (Mon, 02 Jun 2014) | 2 lines
+
+* Compilation fix
+
+
+Index: gavl/cputest.c
+===================================================================
+--- gavl/cputest.c	(revision 4208)
++++ gavl/cputest.c	(revision 4209)
+@@ -69,6 +69,8 @@
+      int rval = 0;
+     int eax, ebx, ecx, edx;
+     int max_std_level, max_ext_level, std_caps=0, ext_caps=0;
++
++#ifndef ARCH_X86_64
+     long a, c;
+ 
+     __asm__ __volatile__ (
+@@ -94,6 +96,7 @@
+ 
+     if (a == c)
+         return 0; /* CPUID not supported */
++#endif // !ARCH_X86_64
+ 
+     cpuid(0, max_std_level, ebx, ecx, edx);
+ 
+
+------------------------------------------------------------------------

--- a/media-libs/gavl/gavl-1.4.0-r1.ebuild
+++ b/media-libs/gavl/gavl-1.4.0-r1.ebuild
@@ -23,6 +23,8 @@ DEPEND="doc? ( app-doc/doxygen )
 DOCS=( AUTHORS README TODO )
 
 src_prepare() {
+	epatch "${FILESDIR}/${PV}-x32.diff"
+
 	# AC_CONFIG_HEADERS, bug #467736
 	sed -i \
 		-e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' \


### PR DESCRIPTION
Package-Manager: portage-2.2.20.1