### PR TITLE
x11-wm/enlightenment: DEPEND on >=dev-libs/efl-1.15.2

### DIFF
--- a/x11-wm/enlightenment/enlightenment-0.19.12.ebuild
+++ b/x11-wm/enlightenment/enlightenment-0.19.12.ebuild
@@ -51,8 +51,8 @@ RDEPEND="
 		>=x11-libs/pixman-0.31.1
 		>=x11-libs/libxkbcommon-0.3.1
 	)
-	>=dev-libs/efl-${PV}[X]
-	>=media-libs/elementary-${PV}
+	>=dev-libs/efl-1.15.2[X]
+	>=media-libs/elementary-1.15
 	x11-libs/xcb-util-keysyms"
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
\>=dev-libs/efl-1.15.2
All previous versions are blacklisted in configure
\>=media-libs/elementary-1.15
Fixes build failure

Package-Manager: portage-2.2.20.1