### PR TITLE
profiles: mask dev-lang/ruby:1.9 for removal

### DIFF
--- a/profiles/base/use.mask
+++ b/profiles/base/use.mask
@@ -15,6 +15,7 @@ cuda
 ruby_targets_ruby18
 ruby_targets_jruby
 ruby_targets_ree18
+ruby_targets_ruby19
 
 # masking here and unmasking in default/linux/
 kmod

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -34,7 +34,7 @@
 # Ruby 1.9 is no longer maintained upstream since January
 # 2015, bug 536852.
 # Masked for removal in 30 days.
-=dev-ruby/ruby-1.9*
+=dev-lang/ruby-1.9*
 
 # Michael Palimaka <kensington@gentoo.org (9 Oct 2015)
 # Dead upstream. No consumers. Collides with other packages.

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -30,6 +30,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Hans de Graaff <graaff@gentoo.org> (11 Oct 2015)
+# Ruby 1.9 is no longer maintained upstream since January
+# 2015, bug 536852.
+# Masked for removal in 30 days.
+=dev-ruby/ruby-1.9*
+
 # Michael Palimaka <kensington@gentoo.org (9 Oct 2015)
 # Dead upstream. No consumers. Collides with other packages.
 # Bug #560932 and bug #557006. Masked for removal in 30 days.


### PR DESCRIPTION
Pull request to test for any remaining QA issues with the masking of ruby 1.9. I'll merge this myself if successful.