### PR TITLE
dev-util/ctags: upstream patch for vim parser bug

### DIFF
--- a/dev-util/ctags/ctags-5.8-r2.ebuild
+++ b/dev-util/ctags/ctags-5.8-r2.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+inherit eutils
+
+DESCRIPTION="Exuberant Ctags creates tags files for code browsing in editors"
+HOMEPAGE="http://ctags.sourceforge.net"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz
+	ada? ( mirror://sourceforge/gnuada/ctags-ada-mode-4.3.11.tar.bz2 )"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+IUSE="ada"
+
+RDEPEND="app-eselect/eselect-ctags"
+
+src_prepare() {
+	epatch "${FILESDIR}/${PN}-5.6-ebuilds.patch"
+	# Upstream fix for python variables starting with def
+	epatch "${FILESDIR}/${P}-python-vars-starting-with-def.patch"
+	# Upstream fix for vim parser crash
+	epatch "${FILESDIR}/${P}-fix-vim-parser-bug.patch"
+
+	# Bug #273697
+	epatch "${FILESDIR}/${P}-f95-pointers.patch"
+
+	# enabling Ada support
+	if use ada ; then
+		cp "${WORKDIR}/${PN}-ada-mode-4.3.11/ada.c" "${S}" || die
+		epatch "${FILESDIR}/${P}-ada.patch"
+	fi
+}
+
+src_configure() {
+	econf \
+		--with-posix-regex \
+		--without-readlib \
+		--disable-etags \
+		--enable-tmpdir=/tmp
+}
+
+src_install() {
+	emake prefix="${D}"/usr mandir="${D}"/usr/share/man install
+
+	# namepace collision with X/Emacs-provided /usr/bin/ctags -- we
+	# rename ctags to exuberant-ctags (Mandrake does this also).
+	mv "${D}"/usr/bin/{ctags,exuberant-ctags} || die
+	mv "${D}"/usr/share/man/man1/{ctags,exuberant-ctags}.1 || die
+
+	dodoc FAQ NEWS README
+	dohtml EXTENDING.html ctags.html
+}
+
+pkg_postinst() {
+	eselect ctags update
+	elog "You can set the version to be started by /usr/bin/ctags through"
+	elog "the ctags eselect module. \"man ctags.eselect\" for details."
+}
+
+pkg_postrm() {
+	eselect ctags update
+}

--- a/dev-util/ctags/files/ctags-5.8-fix-vim-parser-bug.patch
+++ b/dev-util/ctags/files/ctags-5.8-fix-vim-parser-bug.patch
@@ -1,0 +1,15 @@
+# upstream commit http://sourceforge.net/p/ctags/code/812/ and universal-ctags
+# commit 7fb36a2f4690374526e9e7ef4f1e24800b6914ec
+--- a/vim.c
++++ b/vim.c
+@@ -419,6 +419,10 @@
+ 			while (*cp && !isspace ((int) *cp))
+ 				++cp; 
+ 		}
++		else
++		{
++			++cp;
++		}
+ 	} while ( *cp &&  !isalnum ((int) *cp) );
+ 
+ 	if ( ! *cp )


### PR DESCRIPTION
This is taken verbatim from upstream commit r812 (see
http://sourceforge.net/p/ctags/code/812/, or commit
7fb36a2f4690374526e9e7ef4f1e24800b6914ec in universal-ctags), which fixes
upstream bug 359 (see http://sourceforge.net/p/ctags/bugs/359/).  This isn't
the only bug fix since the last ctags release in 2009 (!), but it's one that I
actually hit and that is *super* annoying.

Signed-off-by: Marc Joliet <marcec@gmx.de>