### PR TITLE
sys-block/open-iscsi: Remove unnecessary dependency on udev (bug #563082)

### DIFF
--- a/sys-block/open-iscsi/open-iscsi-2.0.873.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.873.ebuild
@@ -82,10 +82,8 @@ src_install() {
 	# udev pieces
 	insinto /lib/udev/rules.d
 	doins "${FILESDIR}"/99-iscsi.rules
-	insopts -m0755
-	insinto /etc/udev/scripts
-	doins "${FILESDIR}"/iscsidev.sh
-	insopts -m0644
+	exeinto /etc/udev/scripts
+	doexe "${FILESDIR}"/iscsidev.sh
 
 	newconfd "${FILESDIR}"/iscsid-conf.d iscsid
 	newinitd "${FILESDIR}"/iscsid-init.d iscsid

--- a/sys-block/open-iscsi/open-iscsi-2.0.873.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.873.ebuild
@@ -19,7 +19,6 @@ IUSE="debug slp"
 
 DEPEND="slp? ( net-libs/openslp )"
 RDEPEND="${DEPEND}
-	virtual/udev
 	sys-fs/lsscsi
 	sys-apps/util-linux"
 
@@ -79,6 +78,7 @@ src_install() {
 
 	insinto /etc/iscsi
 	newins "${FILESDIR}"/initiatorname.iscsi initiatorname.iscsi.example
+
 	# udev pieces
 	insinto /lib/udev/rules.d
 	doins "${FILESDIR}"/99-iscsi.rules


### PR DESCRIPTION
More info on bugzilla: [#563082](https://bugs.gentoo.org/show_bug.cgi?id=563082).