### PR TITLE
 app-portage/gentoolkit: fix eclean -n -d, #427020

### DIFF
--- a/app-portage/gentoolkit/files/0.3.0.9-eclean-package-names-with-destructive-472020.patch
+++ b/app-portage/gentoolkit/files/0.3.0.9-eclean-package-names-with-destructive-472020.patch
@@ -1,0 +1,14 @@
+# see https://bugs.gentoo.org/show_bug.cgi?id=472020
+--- pym/gentoolkit/eclean/search.py.orig	2013-06-01 17:12:58.619341697 +0200
++++ pym/gentoolkit/eclean/search.py		2013-06-01 17:57:21.384179193 +0200
+@@ -573,9 +570,9 @@
+ 		if dbapi.cpv_exists(cpv):
+ 			# exclusion because pkg still exists (in porttree or vartree)
+ 			del clean_me[cpv]
+ 			continue
+-		if portage.cpv_getkey(cpv) in cp_all:
++		if portage.cpv_getkey(cpv) in cp_all and port_dbapi.cpv_exists(cpv):
+ 			# exlusion because of --package-names
+ 			del clean_me[cpv]
+ 
+ 	return clean_me

--- a/app-portage/gentoolkit/gentoolkit-0.3.0.9-r3.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-0.3.0.9-r3.ebuild
@@ -1,0 +1,91 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+PYTHON_COMPAT=(python{2_7,3_3,3_4} pypy)
+PYTHON_REQ_USE="xml(+)"
+
+inherit distutils-r1
+
+DESCRIPTION="Collection of administration scripts for Gentoo"
+HOMEPAGE="https://www.gentoo.org/proj/en/portage/tools/index.xml"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+DEPEND="sys-apps/portage[${PYTHON_USEDEP}]"
+RDEPEND="${DEPEND}
+	!<=app-portage/gentoolkit-dev-0.2.7
+	|| ( >=sys-apps/coreutils-8.15 app-misc/realpath sys-freebsd/freebsd-bin )
+	sys-apps/gawk
+	sys-apps/gentoo-functions
+	sys-apps/grep"
+
+PATCHES=(
+	"${FILESDIR}"/${PV}-revdep-rebuild-py-504654-1.patch
+	"${FILESDIR}"/${PV}-revdep-rebuild-py-504654-2.patch
+	"${FILESDIR}"/${PV}-equery-508114.patch
+	"${FILESDIR}"/${PV}-equery-strip-XXXFLAGS.patch
+	"${FILESDIR}"/${PV}-revdep-rebuild-526400.patch
+	"${FILESDIR}"/${PV}-eclean-package-names-with-destructive-472020.patch
+)
+
+python_prepare_all() {
+	python_setup
+	echo VERSION="${PVR}" "${PYTHON}" setup.py set_version
+	VERSION="${PVR}" "${PYTHON}" setup.py set_version
+	mv ./bin/revdep-rebuild{,.py} || die
+	distutils-r1_python_prepare_all
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+
+	# Rename the python versions of revdep-rebuild, since we are not ready
+	# to switch to the python version yet. Link /usr/bin/revdep-rebuild to
+	# revdep-rebuild.sh. Leaving the python version available for potential
+	# testing by a wider audience.
+	dosym revdep-rebuild.sh /usr/bin/revdep-rebuild
+
+	# TODO: Fix this as it is now a QA violation
+	# Create cache directory for revdep-rebuild
+	keepdir /var/cache/revdep-rebuild
+	use prefix || fowners root:0 /var/cache/revdep-rebuild
+	fperms 0700 /var/cache/revdep-rebuild
+
+	# remove on Gentoo Prefix platforms where it's broken anyway
+	if use prefix; then
+		elog "The revdep-rebuild command is removed, the preserve-libs"
+		elog "feature of portage will handle issues."
+		rm "${ED}"/usr/bin/revdep-rebuild*
+		rm "${ED}"/usr/share/man/man1/revdep-rebuild.1
+		rm -rf "${ED}"/etc/revdep-rebuild
+		rm -rf "${ED}"/var
+	fi
+}
+
+pkg_postinst() {
+	# Only show the elog information on a new install
+	if [[ ! ${REPLACING_VERSIONS} ]]; then
+		elog
+		elog "For further information on gentoolkit, please read the gentoolkit"
+		elog "guide: https://www.gentoo.org/doc/en/gentoolkit.xml"
+		elog
+		elog "Another alternative to equery is app-portage/portage-utils"
+		elog
+		elog "Additional tools that may be of interest:"
+		elog
+		elog "    app-admin/eclean-kernel"
+		elog "    app-portage/diffmask"
+		elog "    app-portage/flaggie"
+		elog "    app-portage/install-mask"
+		elog "    app-portage/portpeek"
+		elog "    app-portage/smart-live-rebuild"
+	fi
+}


### PR DESCRIPTION
Running "eclean-pkg -n -d" keeps binpkgs even without a corresponding ebuild,
which is not what I expected from the documentation, which says:

  "Somewhere  in the middle, adding the --package-names option when using
  --destructive will protect files corresponding to all existing versions of
  installed packages."

I interpreted "existing versions of installed packages" to mean versions which
are installed and which also exist in the portage tree.  However, what eclean
does in findPackages() (with "-d -n") is the following three things:

- check whether the cat/pkg-ver is listed in an exclusion file,
- check whether the cat/pkg-ver exists in the vartree, meaning it only filters
  out the newest version, and
- check whether the cat/pkg exists.

The first point is irrelevant to this bug, and the second one is clear, since
that's what "-d" by itself is supposed to do. However, the third point means
that "eclean -d -n" will never delete binpkgs that belong to an installed
cat/pkg.

To fix this, it is necessary to change findPackages() to also check that the
package version exists, i.e., to change the relevant conditional from

    if portage.cpv_getkey(cpv) in cp_all:

to

    if portage.cpv_getkey(cpv) in cp_all and port_dbapi.cpv_exists(cpv):

which is exactly what the proposed patch does.

With this patch applied "eclean -d -n -p" reports almost 1 GB of packages to
remove, including versions of samba and udev that don't exist anymore. The
output appears to be the same as that of "eclean -p", save for a version of
gentoo-sources that doesn't exist anymore, but that I still have installed
(which I think verifies that the logic is correct).

My motivation for looking into this was that old firefox binpkgs were not being
deleted, despite the fact that the corresponding ebuilds did not exist anymore.
Furthermore, my weekly eclean cronjob kept reporting "Your packages directory
was already clean.". In contrast, "eclean-dist -n -d" has been working fine so
far and has, e.g., deleted all old firefox distfiles.

[ Note that this patch and the corresponding bug report are now over two years
  old, and that I have been running this patch on both of my systems for just
  as long.  Apparently there is a better way to do it (see the comment by Brian
  Dolbec in the bug report), but that hasn't happened yet, and it is unclear to
  me when it will. ]

Gentoo-bug: 427020
Signed-off-by: Marc Joliet <marcec@gmx.de>