### PR TITLE
dev-qt/qtchooser: add ~x86-fbsd keywords, bug 529196.

### DIFF
--- a/dev-qt/qtchooser/qtchooser-0_p20150102.ebuild
+++ b/dev-qt/qtchooser/qtchooser-0_p20150102.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://dev.gentoo.org/~pesa/distfiles/${P}.tar.xz"
 
 LICENSE="|| ( LGPL-2.1 GPL-3 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="qt5 test"
 
 DEPEND="qt5? ( test? (


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=529196

Test phase passed.
https://bugs.gentoo.org/show_bug.cgi?id=529196#c20