### PR TITLE
dev-libs/openspecfun: Respect ${EPREFIX}

### DIFF
--- a/dev-libs/openspecfun/openspecfun-0.4-r1.ebuild
+++ b/dev-libs/openspecfun/openspecfun-0.4-r1.ebuild
@@ -20,5 +20,5 @@ src_prepare() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" prefix="/usr" install
+	emake DESTDIR="${D}" prefix="${EPREFIX}/usr" install
 }


### PR DESCRIPTION
Right now, building `dev-libs/openspecfun-0.4-r1` on a prefix system fails because of QA violations: the `DESTDIR` set falls outside the prefix.

This can easily be fixed by referencing `${ED}` instead of `${D}` as `DESTDIR` in the `emake` call.