### PR TITLE
net-libs/nodejs: respect system ld, binutils

### DIFF
--- a/net-libs/nodejs/nodejs-4.1.1.ebuild
+++ b/net-libs/nodejs/nodejs-4.1.1.ebuild
@@ -103,6 +103,9 @@ src_configure() {
 		*) die "Unrecognized ARCH ${ARCH}";;
 	esac
 
+	GYP_DEFINES="linux_use_gold_flags=0
+		linux_use_bundled_binutils=0
+		linux_use_bundled_gold=0" \
 	"${PYTHON}" configure \
 		--prefix="${EPREFIX}"/usr \
 		--dest-cpu=${myarch} \


### PR DESCRIPTION
In the current ebuild, nodejs linking will `-fuse-gold` instead of the system `ld` on 64 bit Linux.

This creates problems for prefix, when the flag is set and nodejs-bundled gold tries to link incompatible host libraries instead of prefix libraries.

Even if this does not cause problems for a normal Gentoo installation, the application should respect the linker that is set by the system and not override it.

(pinging @jlec, but this is a minor modification so I don't know if you've got comments for that)