### PR TITLE
net-misc/wget: lift the REQUIRED_USE constraints for libressl

### DIFF
--- a/net-misc/wget/wget-1.16.3-r2.ebuild
+++ b/net-misc/wget/wget-1.16.3-r2.ebuild
@@ -15,18 +15,16 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="debug gnutls idn ipv6 libressl nls ntlm pcre +ssl static test uuid zlib"
-REQUIRED_USE="
-	ntlm? ( !gnutls ssl )
-	libressl? ( !gnutls ssl )
-	gnutls? ( !libressl ssl )
-"
+REQUIRED_USE=" ntlm? ( !gnutls ssl ) gnutls? ( ssl )"
 
 LIB_DEPEND="idn? ( net-dns/libidn[static-libs(+)] )
 	pcre? ( dev-libs/libpcre[static-libs(+)] )
 	ssl? (
 		gnutls? ( net-libs/gnutls[static-libs(+)] )
-		libressl? ( dev-libs/libressl[static-libs(+)] )
-		!gnutls? ( !libressl? ( dev-libs/openssl:0[static-libs(+)] ) )
+		!gnutls? (
+			!libressl? ( dev-libs/openssl:0[static-libs(+)] )
+			libressl? ( !dev-libs/libressl[static-libs(+)] )
+		)
 	)
 	uuid? ( sys-apps/util-linux[static-libs(+)] )
 	zlib? ( sys-libs/zlib[static-libs(+)] )"


### PR DESCRIPTION
'libressl' USE flag is only for switching the openssl-provider
and shouldn't introduce additional REQUIRED_USE complexity.

@vapier we decided to make this more simple, so it also matches the behavior of the rest of the tree