### PR TITLE
dev-java/log4j: Corrected oracle-javamail usage on classpath

### DIFF
--- a/dev-java/log4j/log4j-1.2.17-r2.ebuild
+++ b/dev-java/log4j/log4j-1.2.17-r2.ebuild
@@ -46,7 +46,7 @@ EANT_DOC_TARGET=""
 
 src_compile() {
 	if use javamail; then
-		EANT_GENTOO_CLASSPATH+="javamail,jaf"
+		EANT_GENTOO_CLASSPATH+="oracle-javamail,jaf"
 		EANT_EXTRA_ARGS+=" -Djavamail-present=true"
 	fi
 	if use jms; then


### PR DESCRIPTION
@gentoo/java dev-java/log4j: Corrected oracle-javamail usage on classpath Fixes bug https://bugs.gentoo.org/563438