### PR TITLE
media-sound/clementine: Specify Qt version explicitly (Qt 4)

### DIFF
--- a/media-sound/clementine/clementine-1.2.2.ebuild
+++ b/media-sound/clementine/clementine-1.2.2.ebuild
@@ -96,6 +96,8 @@ PATCHES=(
 	"${FILESDIR}"/${P}-gcc49.patch
 )
 
+export QT_SELECT=4
+
 src_prepare() {
 	cmake-utils_src_prepare
 

--- a/media-sound/clementine/clementine-1.2.3.ebuild
+++ b/media-sound/clementine/clementine-1.2.3.ebuild
@@ -98,6 +98,8 @@ PATCHES=(
 	"${FILESDIR}/${P}-hide_boost_includes_from_q_moc.patch"
 )
 
+export QT_SELECT=4
+
 src_prepare() {
 	cmake-utils_src_prepare
 

--- a/media-sound/clementine/clementine-9999.ebuild
+++ b/media-sound/clementine/clementine-9999.ebuild
@@ -91,6 +91,8 @@ RESTRICT="test"
 [[ ${PV} == *9999* ]] || \
 S="${WORKDIR}/${P^}"
 
+export QT_SELECT=4
+
 src_prepare() {
 	cmake-utils_src_prepare
 


### PR DESCRIPTION
Qt 5 is selected as a default Qt version on my system (qtchooser allows that). Since Qt version is not specified in the ebuild, Clementine will try and fail to build with version 5.