### PR TITLE
dev-libs/libclc: Add version 9999

### DIFF
--- a/dev-libs/libclc/libclc-0.0.1_pre20140101-r1.ebuild
+++ b/dev-libs/libclc/libclc-0.0.1_pre20140101-r1.ebuild
@@ -21,11 +21,11 @@ if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
 	SRC_URI="mirror://gentoo/${P}.tar.xz ${SRC_PATCHES}"
+	KEYWORDS="~amd64 ~ppc ~x86"
 fi
 
 LICENSE="|| ( MIT BSD )"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-libs/libclc/libclc-0.0.1_pre20141027.ebuild
+++ b/dev-libs/libclc/libclc-0.0.1_pre20141027.ebuild
@@ -21,11 +21,11 @@ if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
 	SRC_URI="mirror://gentoo/${P}.tar.xz ${SRC_PATCHES}"
+	KEYWORDS="~amd64 ~ppc ~x86"
 fi
 
 LICENSE="|| ( MIT BSD )"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-libs/libclc/libclc-0.1.0_pre20150305.ebuild
+++ b/dev-libs/libclc/libclc-0.1.0_pre20150305.ebuild
@@ -21,11 +21,11 @@ if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
 	SRC_URI="mirror://gentoo/${P}.tar.xz ${SRC_PATCHES}"
+	KEYWORDS="~amd64 ~ppc ~x86"
 fi
 
 LICENSE="|| ( MIT BSD )"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-libs/libclc/libclc-9999.ebuild
+++ b/dev-libs/libclc/libclc-9999.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+PYTHON_COMPAT=( python2_7 )
+
+EGIT_REPO_URI="http://llvm.org/git/${PN}.git"
+
+if [[ ${PV} = 9999* ]]; then
+	GIT_ECLASS="git-r3"
+	EXPERIMENTAL="true"
+fi
+
+inherit base python-any-r1 $GIT_ECLASS
+
+DESCRIPTION="OpenCL C library"
+HOMEPAGE="http://libclc.llvm.org/"
+
+if [[ $PV = 9999* ]]; then
+	SRC_URI="${SRC_PATCHES}"
+else
+	SRC_URI="mirror://gentoo/${P}.tar.xz ${SRC_PATCHES}"
+	KEYWORDS="~amd64 ~ppc ~x86"
+fi
+
+LICENSE="|| ( MIT BSD )"
+SLOT="0"
+IUSE=""
+
+RDEPEND="
+	>=sys-devel/clang-3.6
+	>=sys-devel/llvm-3.6"
+DEPEND="${RDEPEND}
+	${PYTHON_DEPS}"
+
+src_unpack() {
+	if [[ $PV = 9999* ]]; then
+		git-r3_src_unpack
+	else
+		default
+		mv ${PN}-*/ ${P} || die
+	fi
+}
+
+src_configure() {
+	./configure.py \
+		--with-llvm-config="${EPREFIX}/usr/bin/llvm-config" \
+		--prefix="${EPREFIX}/usr" || die
+}
+
+src_compile() {
+	emake VERBOSE=1
+}


### PR DESCRIPTION
Simply renaming an ebuild was not enough since KEYWORDS line was misplaced, and version 9999 was treated as a usual ebuild (no `**` keyword).