### PR TITLE
www-servers/tomcat: revbump on tomcat-instance-manager script

### DIFF
--- a/www-servers/tomcat/files/tomcat-instance-manager-r2.bash
+++ b/www-servers/tomcat/files/tomcat-instance-manager-r2.bash
@@ -1,0 +1,270 @@
+#!/bin/bash
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# Author: Ralph Sennhauser <sera@gentoo.org>
+
+die() {
+	echo "${@}"
+	exit 1
+}
+
+dir_is_empty() {
+	# usage:
+	#  dir_is_empty <some-dir>
+	#
+	# returns 2 if the dir does not even exist
+	# returns 1 if the dir is not empty
+	# returns 0 (success) if the dir exists and is empty
+
+	local dir=$1
+	local files
+
+	if [[ ! -e ${dir} ]] ; then
+		return 2
+	fi
+
+	shopt -s nullglob dotglob     # To include hidden files
+	files=( "${dir}"/* )
+	shopt -u nullglob dotglob
+
+	if [[ ${#files[@]} -eq 0 ]]; then
+		return 0
+	else
+		return 1
+	fi
+
+}
+
+usage() {
+	cat <<EOL
+Usage: ${BASH_SOURCE} <--create|--remove|--help> [--suffix s][--user u][--group g]
+
+  Options:
+    --help:
+      show this text.
+    --create:
+      create a new instance
+    --remove:
+      remove an existing instance.
+    --suffix SUFFIX:
+      a suffix for this instance. the suffix may not collide with an already
+      existing instance, defaults to empty.
+    --user USER:
+      the user for which to configure this instance for. The user needs to
+      exist already. defaults to tomcat.
+    --group GROUP:
+      the group for which to configure this instance for. The group needs to
+      exist already. defaults to tomcat.
+
+  Examples:
+    ${BASH_SOURCE} --create --suffix testing --user tacmot --group tacmot
+    ${BASH_SOURCE} --remove --suffix testing
+EOL
+}
+
+parse_argv() {
+	action="not specified"
+	instance_name="tomcat-@SLOT@"
+	instance_user="tomcat"
+	instance_group="tomcat"
+
+	while [[ -n $1 ]]; do
+		case $1 in
+			--help)
+				usage
+				exit 0;;
+			--suffix)
+				instance_name+="-$2"
+				shift; shift;;
+			--user)
+				instance_user="$2"
+				shift; shift;;
+			--group)
+				instance_group="$2"
+				shift; shift;;
+			--create)
+				action=create
+				shift;;
+			--remove)
+				action=remove
+				shift;;
+			--backup)
+				action=backup
+				shift;;
+			--restore)
+				action=restore
+				shift;;
+			--update)
+				action=update
+				shift;;
+			*)
+				echo "Invalid option '$1'"
+				usage
+				exit 2;;
+		esac
+	done
+
+	tomcat_home="/@GENTOO_PORTAGE_EPREFIX@usr/share/tomcat-@SLOT@"
+	instance_base="/@GENTOO_PORTAGE_EPREFIX@var/lib/${instance_name}"
+	instance_conf="/@GENTOO_PORTAGE_EPREFIX@etc/${instance_name}"
+	instance_logs="/@GENTOO_PORTAGE_EPREFIX@var/log/${instance_name}"
+	instance_temp="/@GENTOO_PORTAGE_EPREFIX@var/tmp/${instance_name}"
+
+	all_targets=(
+		"${instance_base}"
+		"${instance_logs}"
+		"${instance_temp}"
+		"/@GENTOO_PORTAGE_EPREFIX@etc/${instance_name}"
+		"/@GENTOO_PORTAGE_EPREFIX@etc/init.d/${instance_name}"
+		"/@GENTOO_PORTAGE_EPREFIX@etc/conf.d/${instance_name}"
+	)
+}
+	
+test_can_deploy() {
+	local no_deploy target
+	for target in "${all_targets[@]}"; do
+		if [[ -e "${target}" ]]; then
+			if ! dir_is_empty "${target}" ; then
+				echo "Error: '${target}' already exists and is not empty."
+				no_deploy=yes
+			fi
+		fi
+	done
+	if [[ -n "${no_deploy}" ]]; then
+		cat <<-EOL
+
+			To protect an existing installation no new instance was deployed. You can use
+			'${BASH_SOURCE} --remove'
+			to remove an existing instance first or run
+			'${BASH_SOURCE} --create --sufix <instance_suffix>'
+			to deploy an instance under a different name
+
+		EOL
+		usage
+		exit 1
+	fi
+
+	if ! getent passwd | cut -d: -f1 | grep -Fx "${instance_user}" > /dev/null; then
+		echo "Error: user '${instance_user}' doesn't exist."
+		exit 1
+	fi
+
+	if ! getent group | cut -d: -f1 | grep -Fx "${instance_group}" > /dev/null; then
+		echo "Error: group '${instance_group}' doesn't exist."
+		exit 1
+	fi
+}
+
+deploy_instance() {
+	test_can_deploy
+
+	mkdir -p "${instance_base}"/{work,webapps} || die
+	mkdir -p "${instance_logs}" || die
+	mkdir -p "${instance_temp}" || die
+	mkdir -p "${instance_conf}" || die
+
+	cp -r "${tomcat_home}"/webapps/ROOT "${instance_base}"/webapps || die
+
+	chown -R "${instance_user}":"${instance_group}" \
+		"${instance_base}" "${instance_logs}" "${instance_temp}" || die
+
+	find "${instance_base}"/webapps -type d -exec chmod 750 {} + || die
+	find "${instance_base}"/webapps -type f -exec chmod 640 {} + || die
+
+	# initial config #
+
+	cp -r "${tomcat_home}"/conf/* "${instance_conf}"/ || die
+
+	sed -i -e "s|\${catalina.base}/logs|${instance_logs}|" \
+		"${instance_conf}"/logging.properties || die
+	sed -i -e "s|directory=\"logs\"|directory=\"${instance_logs}\"|" \
+		"${instance_conf}"/server.xml || die
+
+	mkdir -p "${instance_conf}"/Catalina/localhost || die
+	cat > "${instance_conf}"/Catalina/localhost/host-manager.xml <<-'EOF'
+		<?xml version="1.0" encoding="UTF-8"?>
+		<Context docBase="${catalina.home}/webapps/host-manager"
+				antiResourceLocking="false" privileged="true" />
+	EOF
+
+	cat > "${instance_conf}"/Catalina/localhost/manager.xml <<-'EOF'
+		<?xml version="1.0" encoding="UTF-8"?>
+		<Context docBase="${catalina.home}/webapps/manager"
+				antiResourceLocking="false" privileged="true" />
+	EOF
+
+	if [[ -d "${tomcat_home}"/webapps/docs ]]; then
+		cat > "${instance_conf}"/Catalina/localhost/docs.xml <<-'EOF'
+			<?xml version="1.0" encoding="UTF-8"?>
+			<Context docBase="${catalina.home}/webapps/docs" />
+		EOF
+	fi
+
+	if [[ -d "${tomcat_home}"/webapps/examples ]]; then
+		cat > "${instance_conf}"/Catalina/localhost/examples.xml <<-'EOF'
+			<?xml version="1.0" encoding="UTF-8"?>
+			<Context docBase="${catalina.home}/webapps/examples" />
+		EOF
+	fi
+
+	chown -R "${instance_user}":"${instance_group}" "${instance_conf}" || die
+	find "${instance_conf}" -type d -exec chmod 750 {} + || die
+	find "${instance_conf}" -type f -exec chmod 640 {} + || die
+
+	# rc script #
+
+	cp "${tomcat_home}"/gentoo/tomcat.init \
+		"/@GENTOO_PORTAGE_EPREFIX@etc/init.d/${instance_name}" || die
+
+	sed -e "s|@INSTANCE_NAME@|${instance_name}|g" \
+		-e "s|@INSTANCE_USER@|${instance_user}|g" \
+		-e "s|@INSTANCE_GROUP@|${instance_group}|g" \
+		"${tomcat_home}"/gentoo/tomcat.conf \
+		> "/@GENTOO_PORTAGE_EPREFIX@etc/conf.d/${instance_name}" || die
+
+	# some symlinks for tomcat and netbeans #
+
+	ln -s "${instance_conf}" "${instance_base}"/conf || die
+	ln -s "${instance_temp}" "${instance_base}"/temp || die
+
+	# a note to update the default configuration #
+
+	cat <<-EOL
+		Successfully created instance '${instance_name}'
+		It's strongly recommended for production systems to go carefully through the
+		configuration files at '${instance_conf}'.
+		The generated initial configuration is close to upstreams default which
+		favours the demo aspect over hardening.
+	EOL
+}
+
+remove_instance() {
+	echo "The following files will be removed permanently:"
+	local target; for target in "${all_targets[@]}"; do
+		find ${target}
+	done
+
+	echo "Type 'yes' to continue"
+	read
+	if [[ ${REPLY} == yes ]]; then
+		rm -rv "${all_targets[@]}"
+	else 
+		echo "Aborting as requested ..."
+	fi
+}
+
+parse_argv "$@"
+
+if [[ ${action} == create ]]; then
+	deploy_instance
+elif [[ ${action} == remove ]]; then
+	remove_instance
+elif [[ ${action} == "not specified" ]]; then
+	echo "No action specified!"
+	usage
+	exit 1
+else
+	echo "${action} not yet implemented!"
+	usage
+	exit 1
+fi

--- a/www-servers/tomcat/tomcat-8.0.28-r1.ebuild
+++ b/www-servers/tomcat/tomcat-8.0.28-r1.ebuild
@@ -1,0 +1,147 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+JAVA_PKG_IUSE="doc source test"
+
+inherit eutils java-pkg-2 java-ant-2 prefix user
+
+MY_P="apache-${P}-src"
+
+DESCRIPTION="Tomcat Servlet-3.1/JSP-2.3 Container"
+HOMEPAGE="http://tomcat.apache.org/"
+SRC_URI="mirror://apache/${PN}/tomcat-8/v${PV}/src/${MY_P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="8"
+KEYWORDS="~amd64 ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="extra-webapps"
+
+RESTRICT="test" # can we run them on a production system?
+
+ECJ_SLOT="4.4"
+SAPI_SLOT="3.1"
+
+COMMON_DEP="dev-java/eclipse-ecj:${ECJ_SLOT}
+	dev-java/oracle-javamail:0
+	dev-java/tomcat-servlet-api:${SAPI_SLOT}"
+RDEPEND="${COMMON_DEP}
+	!<dev-java/tomcat-native-1.1.24
+	>=virtual/jre-1.7"
+DEPEND="${COMMON_DEP}
+	>=virtual/jdk-1.7
+	test? (
+		>=dev-java/ant-junit-1.9:0
+		dev-java/easymock:3.2
+	)"
+
+S=${WORKDIR}/${MY_P}
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+	enewgroup tomcat 265
+	enewuser tomcat 265 -1 /dev/null tomcat
+}
+
+java_prepare() {
+	find -name '*.jar' -type f -delete -print || die
+
+	# Remove bundled javamail, servlet-api
+	rm -rv java/javax/{el,mail,servlet} || die
+
+	epatch "${FILESDIR}/${P}-build.xml.patch"
+
+	# For use of catalina.sh in netbeans
+	sed -i -e "/^# ----- Execute The Requested Command/ a\
+		CLASSPATH=\`java-config --classpath ${PN}-${SLOT}\`" \
+		bin/catalina.sh || die
+}
+
+JAVA_ANT_REWRITE_CLASSPATH="true"
+
+EANT_BUILD_TARGET="deploy"
+EANT_GENTOO_CLASSPATH="eclipse-ecj-${ECJ_SLOT},oracle-javamail,tomcat-servlet-api-${SAPI_SLOT}"
+EANT_TEST_GENTOO_CLASSPATH="easymock-3.2"
+EANT_GENTOO_CLASSPATH_EXTRA="${S}/output/classes"
+EANT_NEEDS_TOOLS="true"
+EANT_EXTRA_ARGS="-Dversion=${PV}-gentoo -Dversion.number=${PV} -Dcompile.debug=false"
+
+# revisions of the scripts
+IM_REV="-r2"
+INIT_REV="-r1"
+
+src_compile() {
+	EANT_GENTOO_CLASSPATH_EXTRA+=":$(java-pkg_getjar --build-only ant-core ant.jar)"
+	java-pkg-2_src_compile
+}
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	local dest="/usr/share/${PN}-${SLOT}"
+
+	java-pkg_jarinto "${dest}"/bin
+	java-pkg_dojar output/build/bin/*.jar
+	exeinto "${dest}"/bin
+	doexe output/build/bin/*.sh
+
+	java-pkg_jarinto "${dest}"/lib
+	java-pkg_dojar output/build/lib/*.jar
+
+	dodoc RELEASE-NOTES RUNNING.txt
+	use doc && java-pkg_dojavadoc output/dist/webapps/docs/api
+	use source && java-pkg_dosrc java/*
+
+	### Webapps ###
+
+	insinto "${dest}"/webapps
+	doins -r output/build/webapps/{host-manager,manager,ROOT}
+	use extra-webapps && doins -r output/build/webapps/{docs,examples}
+
+	### Config ###
+
+	# create "logs" directory in $CATALINA_BASE
+	# and set correct perms, see #458890
+	dodir "${dest}"/logs
+	fperms 0750 "${dest}"/logs
+
+	# replace the default pw with a random one, see #92281
+	local randpw=$(echo ${RANDOM}|md5sum|cut -c 1-15)
+	sed -i -e "s|SHUTDOWN|${randpw}|" output/build/conf/server.xml || die
+
+	# prepend gentoo.classpath to common.loader, see #453212
+	sed -i -e 's/^common\.loader=/\0${gentoo.classpath},/' output/build/conf/catalina.properties || die
+
+	insinto "${dest}"
+	doins -r output/build/conf
+
+	### rc ###
+
+	cp "${FILESDIR}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} "${T}" || die
+	eprefixify "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash}
+	sed -i -e "s|@SLOT@|${SLOT}|g" "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} || die
+
+	insinto "${dest}"/gentoo
+	doins "${T}"/tomcat.conf
+	exeinto "${dest}"/gentoo
+	newexe "${T}"/tomcat${INIT_REV}.init tomcat.init
+	newexe "${T}"/tomcat-instance-manager${IM_REV}.bash tomcat-instance-manager.bash
+}
+
+pkg_postinst() {
+	elog "New ebuilds of Tomcat support running multiple instances. If you used prior version"
+	elog "of Tomcat (<7.0.32), you have to migrate your existing instance to work with new Tomcat."
+	elog "You can find more information at https://wiki.gentoo.org/wiki/Apache_Tomcat"
+
+	elog "To manage Tomcat instances, run:"
+	elog "  ${EPREFIX}/usr/share/${PN}-${SLOT}/gentoo/tomcat-instance-manager.bash --help"
+
+	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
+	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
+
+#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+}


### PR DESCRIPTION
This bump tweaks the behavior of test_can_deploy(), so that
it does not fail if a target directory exists AND is empty.

This can be extremely useful if the target directories are
mount points, which is very common for e.g. docker setups.

@chewi @monsieurp 

the diff of the script is here:
```diff
--- a/www-servers/tomcat/files/tomcat-instance-manager-r1.bash
+++ b/www-servers/tomcat/files/tomcat-instance-manager-r2.bash
@@ -1,11 +1,38 @@
 #!/bin/bash
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # Author: Ralph Sennhauser <sera@gentoo.org>
 
 die() {
 	echo "${@}"
 	exit 1
+}
+
+dir_is_empty() {
+	# usage:
+	#  dir_is_empty <some-dir>
+	#
+	# returns 2 if the dir does not even exist
+	# returns 1 if the dir is not empty
+	# returns 0 (success) if the dir exists and is empty
+
+	local dir=$1
+	local files
+
+	if [[ ! -e ${dir} ]] ; then
+		return 2
+	fi
+
+	shopt -s nullglob dotglob     # To include hidden files
+	files=( "${dir}"/* )
+	shopt -u nullglob dotglob
+
+	if [[ ${#files[@]} -eq 0 ]]; then
+		return 0
+	else
+		return 1
+	fi
+
 }
 
 usage() {
@@ -96,9 +123,11 @@
 test_can_deploy() {
 	local no_deploy target
 	for target in "${all_targets[@]}"; do
-		if [[ -e "${target}" ]]; then 
-			echo "Error: '${target}' already exists."
-			no_deploy=yes
+		if [[ -e "${target}" ]]; then
+			if ! dir_is_empty "${target}" ; then
+				echo "Error: '${target}' already exists and is not empty."
+				no_deploy=yes
+			fi
 		fi
 	done
 	if [[ -n "${no_deploy}" ]]; then
@@ -132,6 +161,7 @@
 	mkdir -p "${instance_base}"/{work,webapps} || die
 	mkdir -p "${instance_logs}" || die
 	mkdir -p "${instance_temp}" || die
+	mkdir -p "${instance_conf}" || die
 
 	cp -r "${tomcat_home}"/webapps/ROOT "${instance_base}"/webapps || die
 
@@ -143,7 +173,7 @@
 
 	# initial config #
 
-	cp -r "${tomcat_home}"/conf "${instance_conf}" || die
+	cp -r "${tomcat_home}"/conf/* "${instance_conf}"/ || die
 
 	sed -i -e "s|\${catalina.base}/logs|${instance_logs}|" \
 		"${instance_conf}"/logging.properties || die
```