### PR TITLE
net-p2p/bitcoin{-qt,d}: Backport miniupnpc-14 support to older versions

### DIFF
--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.10.2-r1.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.10.2-r1.ebuild
@@ -38,6 +38,8 @@ DEPEND="${RDEPEND}
 REQUIRED_USE="${REQUIRED_USE} ^^ ( qt4 qt5 )"
 
 src_prepare() {
+	epatch "${FILESDIR}/miniupnpc-14.patch"
+
 	bitcoincore_prepare
 
 	local filt= yeslang= nolang=

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.10.2.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.10.2.ebuild
@@ -37,6 +37,8 @@ DEPEND="${RDEPEND}
 REQUIRED_USE="${REQUIRED_USE} ^^ ( qt4 qt5 )"
 
 src_prepare() {
+	epatch "${FILESDIR}/miniupnpc-14.patch"
+
 	bitcoincore_prepare
 
 	local filt= yeslang= nolang=

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.11.0.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.11.0.ebuild
@@ -36,6 +36,8 @@ DEPEND="${RDEPEND}
 REQUIRED_USE="${REQUIRED_USE} ^^ ( qt4 qt5 )"
 
 src_prepare() {
+	epatch "${FILESDIR}/miniupnpc-14.patch"
+
 	bitcoincore_prepare
 
 	local filt= yeslang= nolang=

--- a/net-p2p/bitcoin-qt/files/miniupnpc-14.patch
+++ b/net-p2p/bitcoin-qt/files/miniupnpc-14.patch
@@ -1,0 +1,28 @@
+commit 9f3e48e5219a09b5ddfd6883d1f0498910eff4b6 (origin-pull/6583/head)
+Author: Pavel Vasin <pavel@vasin.nl>
+Date:   Sun Aug 23 23:53:49 2015 +0300
+
+    add support for miniupnpc api version 14
+    
+    The value of new arg ttl is set to 2 as it's recommended default.
+
+diff --git a/src/net.cpp b/src/net.cpp
+index fb5726a..4c6331f 100644
+--- a/src/net.cpp
++++ b/src/net.cpp
+@@ -1120,10 +1120,14 @@ void ThreadMapPort()
+ #ifndef UPNPDISCOVER_SUCCESS
+     /* miniupnpc 1.5 */
+     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
+-#else
++#elif MINIUPNPC_API_VERSION < 14
+     /* miniupnpc 1.6 */
+     int error = 0;
+     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
++#else
++    /* miniupnpc 1.9.20150730 */
++    int error = 0;
++    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
+ #endif
+ 
+     struct UPNPUrls urls;

--- a/net-p2p/bitcoind/bitcoind-0.10.2-r1.ebuild
+++ b/net-p2p/bitcoind/bitcoind-0.10.2-r1.ebuild
@@ -33,6 +33,7 @@ pkg_setup() {
 }
 
 src_prepare() {
+	epatch "${FILESDIR}/miniupnpc-14.patch"
 	sed -i 's/have bitcoind &&//;s/^\(complete -F _bitcoind bitcoind\) bitcoin-cli$/\1/' contrib/${PN}.bash-completion
 	epatch "${FILESDIR}/0.10.0-openrc-compat.patch"
 	bitcoincore_src_prepare

--- a/net-p2p/bitcoind/bitcoind-0.10.2.ebuild
+++ b/net-p2p/bitcoind/bitcoind-0.10.2.ebuild
@@ -32,6 +32,7 @@ pkg_setup() {
 }
 
 src_prepare() {
+	epatch "${FILESDIR}/miniupnpc-14.patch"
 	epatch "${FILESDIR}/0.10.0-openrc-compat.patch"
 	bitcoincore_src_prepare
 }

--- a/net-p2p/bitcoind/bitcoind-0.11.0.ebuild
+++ b/net-p2p/bitcoind/bitcoind-0.11.0.ebuild
@@ -31,6 +31,7 @@ pkg_setup() {
 }
 
 src_prepare() {
+	epatch "${FILESDIR}/miniupnpc-14.patch"
 	sed -i 's/have bitcoind &&//;s/^\(complete -F _bitcoind bitcoind\) bitcoin-cli$/\1/' contrib/${PN}.bash-completion
 	bitcoincore_src_prepare
 }

--- a/net-p2p/bitcoind/files/miniupnpc-14.patch
+++ b/net-p2p/bitcoind/files/miniupnpc-14.patch
@@ -1,0 +1,28 @@
+commit 9f3e48e5219a09b5ddfd6883d1f0498910eff4b6 (origin-pull/6583/head)
+Author: Pavel Vasin <pavel@vasin.nl>
+Date:   Sun Aug 23 23:53:49 2015 +0300
+
+    add support for miniupnpc api version 14
+    
+    The value of new arg ttl is set to 2 as it's recommended default.
+
+diff --git a/src/net.cpp b/src/net.cpp
+index fb5726a..4c6331f 100644
+--- a/src/net.cpp
++++ b/src/net.cpp
+@@ -1120,10 +1120,14 @@ void ThreadMapPort()
+ #ifndef UPNPDISCOVER_SUCCESS
+     /* miniupnpc 1.5 */
+     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
+-#else
++#elif MINIUPNPC_API_VERSION < 14
+     /* miniupnpc 1.6 */
+     int error = 0;
+     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
++#else
++    /* miniupnpc 1.9.20150730 */
++    int error = 0;
++    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
+ #endif
+ 
+     struct UPNPUrls urls;


### PR DESCRIPTION
All earlier miniupnpc APIs have critical security bugs. Until non-vulnerable version(s) are stablised, this at least lets the user build old versions of Bitcoin Core against them successfully.