### PR TITLE
dev-perl/{List-MoreUtils,Exporter-Tiny} and deps: add fbsd keywords, bug 543632

### DIFF
--- a/dev-perl/Exporter-Tiny/Exporter-Tiny-0.42.0.ebuild
+++ b/dev-perl/Exporter-Tiny/Exporter-Tiny-0.42.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="An exporter with the features of Sub::Exporter but only core dependencies"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/List-MoreUtils/List-MoreUtils-0.413.0.ebuild
+++ b/dev-perl/List-MoreUtils/List-MoreUtils-0.413.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Provide the missing functionality from List::Util"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="

--- a/virtual/perl-File-Path/perl-File-Path-2.90.0-r3.ebuild
+++ b/virtual/perl-File-Path/perl-File-Path-2.90.0-r3.ebuild
@@ -10,7 +10,7 @@ SRC_URI=""
 
 LICENSE=""
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd"
 IUSE=""
 
 RDEPEND="

--- a/virtual/perl-XSLoader/perl-XSLoader-0.200.0.ebuild
+++ b/virtual/perl-XSLoader/perl-XSLoader-0.200.0.ebuild
@@ -10,7 +10,7 @@ SRC_URI=""
 
 LICENSE=""
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-freebsd ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 RDEPEND="


### PR DESCRIPTION
KEYWORDREQ Bug,
https://bugs.gentoo.org/show_bug.cgi?id=543632

Additional Information

```
emerge -pv dev-perl/Exporter-Tiny dev-perl/List-MoreUtils

# required by dev-perl/List-MoreUtils-0.413.0::gentoo
# required by dev-perl/List-MoreUtils (argument)
=virtual/perl-XSLoader-0.200.0 **
# required by dev-perl/List-MoreUtils-0.413.0::gentoo
# required by dev-perl/List-MoreUtils (argument)
=virtual/perl-File-Path-2.90.0-r3 **
```

```
>>> Test phase: dev-perl/List-MoreUtils-0.413.0
 * Test::Harness Jobs=8
gmake -j8 test TEST_VERBOSE=0
Running Mkbootstrap for List::MoreUtils ()
chmod 644 "MoreUtils.bs"
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t t/pureperl/*.t t/xs/*.t xt/*.t
t/pureperl/ab.t ......... ok
t/pureperl/Import.t ..... ok
t/pureperl/XS.t ......... ok
t/xs/ab.t ............... ok
t/xs/XS.t ............... ok
t/xs/Import.t ........... ok
t/xs/Functions.t ........ ok
t/pureperl/Functions.t .. ok
All tests successful.
Files=8, Tests=6934,  1 wallclock secs ( 0.55 usr  0.09 sys +  1.02 cusr  1.05 csys =  2.71 CPU)
Result: PASS
>>> Completed testing dev-perl/List-MoreUtils-0.413.0
```
