### PR TITLE
media-sound/qtractor: add dev-qt/qtx11extras as a dependency

### DIFF
--- a/media-sound/qtractor/qtractor-0.7.0.ebuild
+++ b/media-sound/qtractor/qtractor-0.7.0.ebuild
@@ -26,6 +26,7 @@ RDEPEND="
 		dev-qt/qtgui:5
 		dev-qt/qtwidgets:5
 		dev-qt/qtxml:5
+		dev-qt/qtx11extras:5
 	)
 	media-libs/alsa-lib
 	media-libs/libsndfile

--- a/media-sound/qtractor/qtractor-0.7.1.ebuild
+++ b/media-sound/qtractor/qtractor-0.7.1.ebuild
@@ -26,6 +26,7 @@ RDEPEND="
 		dev-qt/qtgui:5
 		dev-qt/qtwidgets:5
 		dev-qt/qtxml:5
+		dev-qt/qtx11extras:5
 	)
 	media-libs/alsa-lib
 	media-libs/libsndfile


### PR DESCRIPTION
without it qtractor fails to compile with USE=qt5 with the error:
Project ERROR: Unknown module(s) in QT: x11extras