### PR TITLE
sys-apps/systemd: Update `noclean-tmp` patch

### DIFF
--- a/sys-apps/systemd/files/228-noclean-tmp.patch
+++ b/sys-apps/systemd/files/228-noclean-tmp.patch
@@ -1,0 +1,28 @@
+From b23c098d5787e06770872b19f83fffa14d8a7d14 Mon Sep 17 00:00:00 2001
+From: Mike Gilbert <floppym@gentoo.org>
+Date: Fri, 25 Sep 2015 10:26:18 -0400
+Subject: [PATCH] tmpfiles: Disable cleaning of /tmp and /var/tmp
+
+Bug: https://bugs.gentoo.org/490676
+---
+ tmpfiles.d/tmp.conf | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tmpfiles.d/tmp.conf b/tmpfiles.d/tmp.conf
+index 6bbd1aa..a361062 100644
+--- a/tmpfiles.d/tmp.conf
++++ b/tmpfiles.d/tmp.conf
+@@ -8,8 +8,8 @@
+ # See tmpfiles.d(5) for details
+ 
+ # Clear tmp directories separately, to make them easier to override
+-q /tmp 1777 root root 10d
+-q /var/tmp 1777 root root 30d
++q /tmp 1777 root root
++q /var/tmp 1777 root root
+ 
+ # Exclude namespace mountpoints created with PrivateTmp=yes
+ x /tmp/systemd-private-%b-*
+-- 
+2.4.10
+

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -145,7 +145,7 @@ src_prepare() {
 	# Bug 463376
 	sed -i -e 's/GROUP="dialout"/GROUP="uucp"/' rules/*.rules || die
 	epatch "${FILESDIR}/218-Dont-enable-audit-by-default.patch"
-	epatch "${FILESDIR}/226-noclean-tmp.patch"
+	epatch "${FILESDIR}/228-noclean-tmp.patch"
 	epatch_user
 	eautoreconf
 }


### PR DESCRIPTION
From `sys-apps/systemd-228` on, many `tmpfiles.d` definitions were
switched from `v` (subvolume) to `q` (subvolume with quota).

Package-Manager: portage-2.2.23