### PR TITLE
dev-qt/qtscript: Restore x32 compatibility patch

### DIFF
--- a/dev-qt/qtscript/files/4.8.6-javascriptcore-x32.patch
+++ b/dev-qt/qtscript/files/4.8.6-javascriptcore-x32.patch
@@ -1,0 +1,53 @@
+From 4e7126ea1488f3e1df0b76cacf83cb73f9d4b54c Mon Sep 17 00:00:00 2001
+From: Allan Sandfeld Jensen <allan.jensen@digia.com>
+Date: Tue, 4 Mar 2014 10:46:18 +0100
+Subject: Fix build on x32
+
+Recognize x32 and disable JIT in this configuration.
+
+Task-number: QTBUG-35463
+Change-Id: Ie5bf64f22f3e58a9b3f12190cf790ad6c39f415e
+---
+ src/3rdparty/javascriptcore/JavaScriptCore/wtf/Platform.h | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Platform.h b/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Platform.h
+index 0b95639..85ed8a7 100644
+--- a/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Platform.h
++++ b/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Platform.h
+@@ -202,6 +202,11 @@
+ #if   defined(__x86_64__) \
+     || defined(_M_X64)
+ #define WTF_CPU_X86_64 1
++
++#if defined(__ILP32__)
++#define WTF_CPU_X32 1
++#endif
++
+ #endif
+ 
+ /* 64-bit mode on AIX */
+@@ -906,7 +911,7 @@
+ #endif
+ 
+ #if !defined(WTF_USE_JSVALUE64) && !defined(WTF_USE_JSVALUE32) && !defined(WTF_USE_JSVALUE32_64)
+-#if (CPU(X86_64) && (OS(UNIX) || OS(WINDOWS) || OS(SOLARIS) || OS(HPUX))) || (CPU(IA64) && !CPU(IA64_32)) || CPU(ALPHA) || CPU(AIX64) || CPU(SPARC64) || CPU(MIPS64) || CPU(AARCH64)
++#if (CPU(X86_64) && !CPU(X32) && (OS(UNIX) || OS(WINDOWS) || OS(SOLARIS) || OS(HPUX))) || (CPU(IA64) && !CPU(IA64_32)) || CPU(ALPHA) || CPU(AIX64) || CPU(SPARC64) || CPU(MIPS64) || CPU(AARCH64)
+ #define WTF_USE_JSVALUE64 1
+ #elif CPU(ARM) || CPU(PPC64)
+ #define WTF_USE_JSVALUE32 1
+@@ -923,6 +928,11 @@ on MinGW. See https://bugs.webkit.org/show_bug.cgi?id=29268 */
+ #define ENABLE_REPAINT_THROTTLING 0
+ #endif
+ 
++/* Disable JIT on x32 */
++#if CPU(X32)
++#define ENABLE_JIT 0
++#endif
++
+ #if !defined(ENABLE_JIT)
+ 
+ /* The JIT is tested & working on x86_64 Mac */
+-- 
+cgit v0.11.0
+

--- a/dev-qt/qtscript/qtscript-4.8.6-r2.ebuild
+++ b/dev-qt/qtscript/qtscript-4.8.6-r2.ebuild
@@ -26,6 +26,8 @@ QT4_TARGET_DIRECTORIES="src/script"
 QCONFIG_ADD="script"
 QCONFIG_DEFINE="QT_SCRIPT"
 
+PATCHES=( "${FILESDIR}/4.8.6-javascriptcore-x32.patch" )
+
 multilib_src_configure() {
 	local myconf=(
 		$(qt_use jit javascript-jit)

--- a/dev-qt/qtscript/qtscript-4.8.7.ebuild
+++ b/dev-qt/qtscript/qtscript-4.8.7.ebuild
@@ -23,6 +23,8 @@ QT4_TARGET_DIRECTORIES="src/script"
 QCONFIG_ADD="script"
 QCONFIG_DEFINE="QT_SCRIPT"
 
+PATCHES=( "${FILESDIR}/4.8.6-javascriptcore-x32.patch" )
+
 multilib_src_configure() {
 	local myconf=(
 		$(qt_use jit javascript-jit)


### PR DESCRIPTION
No revbump because the build failed in the only cases this patch matters (x32 target).
