### PR TITLE
sys-boot/systemrescuecd-x86-grub: create grub menu entries for systemrescuecd-x86

### DIFF
--- a/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.default
+++ b/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.default
@@ -1,0 +1,21 @@
+# Here you can set custom bootoptions for the SystemRescueCD
+#
+# You can add for example in a space separated list:
+#  setkmap=xx: which defines the keymap to load (example: setkmap=de)
+#  dostartx: load the X.Org graphical environment and launch Xfce
+#  docache: causes the iso file to be fully loaded into memory
+#           this requires 400MB of memory to cache everything
+#  doload=xxx: loads needed kernel modules (example: doload=3c59x,e1000)
+#  noload=xxx: prevents loading kernel modules
+#  nomodeset: do not load the Kernel-Mode-Setting video driver
+#
+# Example:
+#  SRCD_BOOTOPTIONS="setkmap=de docache dostartx"
+#
+# For all available bootoptions see:
+#  http://www.sysresccd.org/Sysresccd-manual-en_Booting_the_CD-ROM
+#
+# Note:
+#  After changing this, you must update your grub configuration file, to take effect
+
+SRCD_BOOTOPTIONS=""

--- a/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.grub
+++ b/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.grub
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+. /usr/share/grub/grub-mkconfig_lib
+
+if [ -r /etc/default/systemrescuecd ] ; then
+  . /etc/default/systemrescuecd
+fi
+
+# srcd = path of newest link to iso of systemrescuecd, created by the ebuild
+#        of systemrescuecd-x86
+srcd="/usr/share/systemrescuecd/systemrescuecd-x86-newest.iso"
+
+longname="SystemRescueCD"
+bootops=")"
+
+if [ ! -z "${SRCD_BOOTOPTIONS}" ]; then
+	bootops=" with bootoptions)"
+fi
+
+if [ -f "${srcd}" ]; then
+
+	device=$(${grub_probe} --target=device "${srcd}")
+	path=$(make_system_path_relative_to_its_root "${srcd}")
+	grub_string=$(prepare_grub_to_access_device "${device}" | grub_add_tab | grub_add_tab)
+
+	gettext_printf "Found %s on %s\n" "${longname}" "${device}" >&2
+	onstr=$(gettext_printf "(on %s)" "${device}")
+
+	cat << EOF
+submenu "${longname}" --class submenu {
+	menuentry "${longname} (32bit standard${bootops}" --class rescue {
+${grub_string}
+		set isofile=${srcd}
+		loopback loop \${isofile}
+		linux (loop)/isolinux/rescue32 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
+		initrd (loop)/isolinux/initram.igz
+	}
+	menuentry "${longname} (64bit standard${bootops}" --class rescue {
+${grub_string}
+		set isofile=${srcd}
+		loopback loop \${isofile}
+		linux (loop)/isolinux/rescue64 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
+		initrd (loop)/isolinux/initram.igz
+	}
+	menuentry "${longname} (32bit alternative${bootops}" --class rescue {
+${grub_string}
+		set isofile=${srcd}
+		loopback loop \${isofile}
+		linux (loop)/isolinux/altker32 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
+		initrd (loop)/isolinux/initram.igz
+	}
+	menuentry "${longname} (64bit alternative${bootops}" --class rescue {
+${grub_string}
+		set isofile=${srcd}
+		loopback loop \${isofile}
+		linux (loop)/isolinux/altker64 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
+		initrd (loop)/isolinux/initram.igz
+	}
+}
+EOF
+
+fi

--- a/sys-boot/systemrescuecd-x86-grub/metadata.xml
+++ b/sys-boot/systemrescuecd-x86-grub/metadata.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<name>Michael Lange</name>
+		<email>gentoobugs@milaw.biz</email>
+		<description>Accepts only mails from Gentoo's Bugzilla</description>
+	</maintainer>
+	<maintainer>
+		<name>Michał Górny</name>
+		<email>mgorny@gentoo.org</email>
+	</maintainer>
+	<longdescription>
+		This package adds menu entries in GRUB for the SystemRescueCD. You can
+		add custom bootoptions for SystemRescueCD in a special config file.
+	</longdescription>
+</pkgmetadata>

--- a/sys-boot/systemrescuecd-x86-grub/systemrescuecd-x86-grub-0.1.ebuild
+++ b/sys-boot/systemrescuecd-x86-grub/systemrescuecd-x86-grub-0.1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+DESCRIPTION="Grub menu entries for the .iso image of systemrescuecd-x86"
+HOMEPAGE="http://www.sysresccd.org/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT=0
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+S=${WORKDIR}
+
+RDEPEND="app-admin/systemrescuecd-x86
+	sys-boot/grub"
+
+src_install() {
+	exeinto /etc/grub.d
+	newexe "${FILESDIR}"/systemrescuecd.grub 39_systemrescuecd
+
+	insinto /etc/default
+	newins "${FILESDIR}"/systemrescuecd.default systemrescuecd
+}
+
+pkg_postinst() {
+	elog "To add the menu entries for systemrescuecd to grub, you should now run"
+	elog "	grub-mkconfig -o /boot/grub/grub.cfg"
+	elog "You can set custom bootoptions in /etc/default/systemrescuecd"
+}


### PR DESCRIPTION
Hi,

this PR will add the boot entries in grub for the SystemRescueCD, after the user will update the file grub.cfg via command-line. It will also give the user the ability to add custom boot options. The entries for the custom boot options will only be added to grub.cfg, if SRCD_BOOTOPTIONS in /etc/default/systemrescuecd is not empty.
