### PR TITLE
www-servers/tomcat: fix startup via catalina.sh

### DIFF
--- a/www-servers/tomcat/tomcat-8.0.26-r1.ebuild
+++ b/www-servers/tomcat/tomcat-8.0.26-r1.ebuild
@@ -1,0 +1,147 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+JAVA_PKG_IUSE="doc source test"
+
+inherit eutils java-pkg-2 java-ant-2 prefix user
+
+MY_P="apache-${P}-src"
+
+DESCRIPTION="Tomcat Servlet-3.1/JSP-2.3 Container"
+HOMEPAGE="http://tomcat.apache.org/"
+SRC_URI="mirror://apache/${PN}/tomcat-8/v${PV}/src/${MY_P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="8"
+KEYWORDS="amd64 x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="extra-webapps"
+
+RESTRICT="test" # can we run them on a production system?
+
+ECJ_SLOT="4.4"
+SAPI_SLOT="3.1"
+
+COMMON_DEP="dev-java/eclipse-ecj:${ECJ_SLOT}
+	dev-java/oracle-javamail:0
+	dev-java/tomcat-servlet-api:${SAPI_SLOT}"
+RDEPEND="${COMMON_DEP}
+	!<dev-java/tomcat-native-1.1.24
+	>=virtual/jre-1.7"
+DEPEND="${COMMON_DEP}
+	>=virtual/jdk-1.7
+	test? (
+		>=dev-java/ant-junit-1.9:0
+		dev-java/easymock:3.2
+	)"
+
+S=${WORKDIR}/${MY_P}
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+	enewgroup tomcat 265
+	enewuser tomcat 265 -1 /dev/null tomcat
+}
+
+java_prepare() {
+	find -name '*.jar' -type f -delete -print || die
+
+	# Remove bundled javamail, servlet-api
+	rm -rv java/javax/{el,mail,servlet} || die
+
+	epatch "${FILESDIR}/${P}-build.xml.patch"
+
+	# For use of catalina.sh in netbeans
+	sed -i -e "/^# ----- Execute The Requested Command/ a\
+		CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
+		bin/catalina.sh || die
+}
+
+JAVA_ANT_REWRITE_CLASSPATH="true"
+
+EANT_BUILD_TARGET="deploy"
+EANT_GENTOO_CLASSPATH="eclipse-ecj-${ECJ_SLOT},oracle-javamail,tomcat-servlet-api-${SAPI_SLOT}"
+EANT_TEST_GENTOO_CLASSPATH="easymock-3.2"
+EANT_GENTOO_CLASSPATH_EXTRA="${S}/output/classes"
+EANT_NEEDS_TOOLS="true"
+EANT_EXTRA_ARGS="-Dversion=${PV}-gentoo -Dversion.number=${PV} -Dcompile.debug=false"
+
+# revisions of the scripts
+IM_REV="-r1"
+INIT_REV="-r1"
+
+src_compile() {
+	EANT_GENTOO_CLASSPATH_EXTRA+=":$(java-pkg_getjar --build-only ant-core ant.jar)"
+	java-pkg-2_src_compile
+}
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	local dest="/usr/share/${PN}-${SLOT}"
+
+	java-pkg_jarinto "${dest}"/bin
+	java-pkg_dojar output/build/bin/*.jar
+	exeinto "${dest}"/bin
+	doexe output/build/bin/*.sh
+
+	java-pkg_jarinto "${dest}"/lib
+	java-pkg_dojar output/build/lib/*.jar
+
+	dodoc RELEASE-NOTES RUNNING.txt
+	use doc && java-pkg_dojavadoc output/dist/webapps/docs/api
+	use source && java-pkg_dosrc java/*
+
+	### Webapps ###
+
+	insinto "${dest}"/webapps
+	doins -r output/build/webapps/{host-manager,manager,ROOT}
+	use extra-webapps && doins -r output/build/webapps/{docs,examples}
+
+	### Config ###
+
+	# create "logs" directory in $CATALINA_BASE
+	# and set correct perms, see #458890
+	dodir "${dest}"/logs
+	fperms 0750 "${dest}"/logs
+
+	# replace the default pw with a random one, see #92281
+	local randpw=$(echo ${RANDOM}|md5sum|cut -c 1-15)
+	sed -i -e "s|SHUTDOWN|${randpw}|" output/build/conf/server.xml || die
+
+	# prepend gentoo.classpath to common.loader, see #453212
+	sed -i -e 's/^common\.loader=/\0${gentoo.classpath},/' output/build/conf/catalina.properties || die
+
+	insinto "${dest}"
+	doins -r output/build/conf
+
+	### rc ###
+
+	cp "${FILESDIR}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} "${T}" || die
+	eprefixify "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash}
+	sed -i -e "s|@SLOT@|${SLOT}|g" "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} || die
+
+	insinto "${dest}"/gentoo
+	doins "${T}"/tomcat.conf
+	exeinto "${dest}"/gentoo
+	newexe "${T}"/tomcat${INIT_REV}.init tomcat.init
+	newexe "${T}"/tomcat-instance-manager${IM_REV}.bash tomcat-instance-manager.bash
+}
+
+pkg_postinst() {
+	elog "New ebuilds of Tomcat support running multiple instances. If you used prior version"
+	elog "of Tomcat (<7.0.32), you have to migrate your existing instance to work with new Tomcat."
+	elog "You can find more information at https://wiki.gentoo.org/wiki/Apache_Tomcat"
+
+	elog "To manage Tomcat instances, run:"
+	elog "  ${EPREFIX}/usr/share/${PN}-${SLOT}/gentoo/tomcat-instance-manager.bash --help"
+
+	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
+	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
+
+#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+}

--- a/www-servers/tomcat/tomcat-8.0.28-r2.ebuild
+++ b/www-servers/tomcat/tomcat-8.0.28-r2.ebuild
@@ -31,6 +31,7 @@ RDEPEND="${COMMON_DEP}
 	!<dev-java/tomcat-native-1.1.24
 	>=virtual/jre-1.7"
 DEPEND="${COMMON_DEP}
+	app-admin/pwgen
 	>=virtual/jdk-1.7
 	test? (
 		>=dev-java/ant-junit-1.9:0
@@ -110,7 +111,7 @@ src_install() {
 	fperms 0750 "${dest}"/logs
 
 	# replace the default pw with a random one, see #92281
-	local randpw=$(echo ${RANDOM}|md5sum|cut -c 1-15)
+	local randpw="$(pwgen -s -B 15 1)"
 	sed -i -e "s|SHUTDOWN|${randpw}|" output/build/conf/server.xml || die
 
 	# prepend gentoo.classpath to common.loader, see #453212

--- a/www-servers/tomcat/tomcat-8.0.28-r2.ebuild
+++ b/www-servers/tomcat/tomcat-8.0.28-r2.ebuild
@@ -1,0 +1,147 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+JAVA_PKG_IUSE="doc source test"
+
+inherit eutils java-pkg-2 java-ant-2 prefix user
+
+MY_P="apache-${P}-src"
+
+DESCRIPTION="Tomcat Servlet-3.1/JSP-2.3 Container"
+HOMEPAGE="http://tomcat.apache.org/"
+SRC_URI="mirror://apache/${PN}/tomcat-8/v${PV}/src/${MY_P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="8"
+KEYWORDS="~amd64 ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="extra-webapps"
+
+RESTRICT="test" # can we run them on a production system?
+
+ECJ_SLOT="4.4"
+SAPI_SLOT="3.1"
+
+COMMON_DEP="dev-java/eclipse-ecj:${ECJ_SLOT}
+	dev-java/oracle-javamail:0
+	dev-java/tomcat-servlet-api:${SAPI_SLOT}"
+RDEPEND="${COMMON_DEP}
+	!<dev-java/tomcat-native-1.1.24
+	>=virtual/jre-1.7"
+DEPEND="${COMMON_DEP}
+	>=virtual/jdk-1.7
+	test? (
+		>=dev-java/ant-junit-1.9:0
+		dev-java/easymock:3.2
+	)"
+
+S=${WORKDIR}/${MY_P}
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+	enewgroup tomcat 265
+	enewuser tomcat 265 -1 /dev/null tomcat
+}
+
+java_prepare() {
+	find -name '*.jar' -type f -delete -print || die
+
+	# Remove bundled javamail, servlet-api
+	rm -rv java/javax/{el,mail,servlet} || die
+
+	epatch "${FILESDIR}/${P}-build.xml.patch"
+
+	# For use of catalina.sh in netbeans
+	sed -i -e "/^# ----- Execute The Requested Command/ a\
+		CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
+		bin/catalina.sh || die
+}
+
+JAVA_ANT_REWRITE_CLASSPATH="true"
+
+EANT_BUILD_TARGET="deploy"
+EANT_GENTOO_CLASSPATH="eclipse-ecj-${ECJ_SLOT},oracle-javamail,tomcat-servlet-api-${SAPI_SLOT}"
+EANT_TEST_GENTOO_CLASSPATH="easymock-3.2"
+EANT_GENTOO_CLASSPATH_EXTRA="${S}/output/classes"
+EANT_NEEDS_TOOLS="true"
+EANT_EXTRA_ARGS="-Dversion=${PV}-gentoo -Dversion.number=${PV} -Dcompile.debug=false"
+
+# revisions of the scripts
+IM_REV="-r2"
+INIT_REV="-r1"
+
+src_compile() {
+	EANT_GENTOO_CLASSPATH_EXTRA+=":$(java-pkg_getjar --build-only ant-core ant.jar)"
+	java-pkg-2_src_compile
+}
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	local dest="/usr/share/${PN}-${SLOT}"
+
+	java-pkg_jarinto "${dest}"/bin
+	java-pkg_dojar output/build/bin/*.jar
+	exeinto "${dest}"/bin
+	doexe output/build/bin/*.sh
+
+	java-pkg_jarinto "${dest}"/lib
+	java-pkg_dojar output/build/lib/*.jar
+
+	dodoc RELEASE-NOTES RUNNING.txt
+	use doc && java-pkg_dojavadoc output/dist/webapps/docs/api
+	use source && java-pkg_dosrc java/*
+
+	### Webapps ###
+
+	insinto "${dest}"/webapps
+	doins -r output/build/webapps/{host-manager,manager,ROOT}
+	use extra-webapps && doins -r output/build/webapps/{docs,examples}
+
+	### Config ###
+
+	# create "logs" directory in $CATALINA_BASE
+	# and set correct perms, see #458890
+	dodir "${dest}"/logs
+	fperms 0750 "${dest}"/logs
+
+	# replace the default pw with a random one, see #92281
+	local randpw=$(echo ${RANDOM}|md5sum|cut -c 1-15)
+	sed -i -e "s|SHUTDOWN|${randpw}|" output/build/conf/server.xml || die
+
+	# prepend gentoo.classpath to common.loader, see #453212
+	sed -i -e 's/^common\.loader=/\0${gentoo.classpath},/' output/build/conf/catalina.properties || die
+
+	insinto "${dest}"
+	doins -r output/build/conf
+
+	### rc ###
+
+	cp "${FILESDIR}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} "${T}" || die
+	eprefixify "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash}
+	sed -i -e "s|@SLOT@|${SLOT}|g" "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} || die
+
+	insinto "${dest}"/gentoo
+	doins "${T}"/tomcat.conf
+	exeinto "${dest}"/gentoo
+	newexe "${T}"/tomcat${INIT_REV}.init tomcat.init
+	newexe "${T}"/tomcat-instance-manager${IM_REV}.bash tomcat-instance-manager.bash
+}
+
+pkg_postinst() {
+	elog "New ebuilds of Tomcat support running multiple instances. If you used prior version"
+	elog "of Tomcat (<7.0.32), you have to migrate your existing instance to work with new Tomcat."
+	elog "You can find more information at https://wiki.gentoo.org/wiki/Apache_Tomcat"
+
+	elog "To manage Tomcat instances, run:"
+	elog "  ${EPREFIX}/usr/share/${PN}-${SLOT}/gentoo/tomcat-instance-manager.bash --help"
+
+	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
+	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
+
+#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+}


### PR DESCRIPTION
@gentoo/java 

revbump, because installed files change

This fixes starting tomcat for me via
```sh
/usr/share/tomcat-8/bin/catalina.sh run
```

before that, it fails with
```
26-Oct-2015 19:31:32.826 WARNING [main] org.apache.catalina.startup.ClassLoaderFactory.validateFile Problem with directory [/${gentoo.classpath}], exists: [false], isDirectory: [false], canRead: [false]
26-Oct-2015 19:31:33.052 SEVERE [main] org.apache.tomcat.util.digester.Digester.startElement Begin event threw error
 java.lang.NoClassDefFoundError: javax/servlet/http/HttpServletRequest

[... more java errors ...]
```

ebuild diff:
```diff
--- tomcat-8.0.28-r1.ebuild	2015-10-26 20:16:10.218085628 +0100
+++ tomcat-8.0.28-r2.ebuild	2015-10-26 20:27:34.014052452 +0100
@@ -55,7 +55,7 @@
 
 	# For use of catalina.sh in netbeans
 	sed -i -e "/^# ----- Execute The Requested Command/ a\
-		CLASSPATH=\`java-config --classpath ${PN}-${SLOT}\`" \
+		CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
 		bin/catalina.sh || die
 }
 
```
Also applied to stable ebuild (and revbumped).