### PR TITLE
net-p2p/amule: various fixes

### DIFF
--- a/net-p2p/amule/amule-2.3.1-r1.ebuild
+++ b/net-p2p/amule/amule-2.3.1-r1.ebuild
@@ -19,6 +19,7 @@ KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="daemon debug geoip nls remote stats unicode upnp +X"
 
 DEPEND=">=dev-libs/crypto++-5
+	sys-libs/binutils-libs:0=
 	>=sys-libs/zlib-1.2.1
 	>=x11-libs/wxGTK-2.8.12:2.8[X?]
 	stats? ( >=media-libs/gd-2.0.26:=[jpeg] )

--- a/net-p2p/amule/amule-2.3.1-r1.ebuild
+++ b/net-p2p/amule/amule-2.3.1-r1.ebuild
@@ -1,0 +1,105 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit eutils wxwidgets user
+
+MY_P=${PN/m/M}-${PV}
+S="${WORKDIR}"/${MY_P}
+
+DESCRIPTION="aMule, the all-platform eMule p2p client"
+HOMEPAGE="http://www.amule.org/"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="daemon debug geoip nls remote stats unicode upnp +X"
+
+DEPEND=">=dev-libs/crypto++-5
+	>=sys-libs/zlib-1.2.1
+	>=x11-libs/wxGTK-2.8.12:2.8[X?]
+	stats? ( >=media-libs/gd-2.0.26:=[jpeg] )
+	geoip? ( dev-libs/geoip )
+	upnp? ( >=net-libs/libupnp-1.6.6 )
+	remote? ( >=media-libs/libpng-1.2.0:0=
+	unicode? ( >=media-libs/gd-2.0.26:= ) )
+	!net-p2p/imule"
+RDEPEND="${DEPEND}"
+
+pkg_setup() {
+	if use stats && ! use X; then
+		einfo "Note: You would need both the X and stats USE flags"
+		einfo "to compile aMule Statistics GUI."
+		einfo "I will now compile console versions only."
+	fi
+}
+
+pkg_preinst() {
+	if use daemon || use remote; then
+		enewgroup p2p
+		enewuser p2p -1 -1 /home/p2p p2p
+	fi
+}
+
+src_prepare() {
+	epatch "${FILESDIR}"/${PN}-2.2.6-fallocate.diff
+	# Bug 412371
+	epatch "${FILESDIR}"/${PN}-2.3.1-gcc47.patch
+}
+
+src_configure() {
+	local myconf
+
+	WX_GTK_VER="2.8"
+
+	if use X; then
+		einfo "wxGTK with X support will be used"
+		need-wxwidgets unicode
+	else
+		einfo "wxGTK without X support will be used"
+		need-wxwidgets base-unicode
+	fi
+
+	if use X ; then
+		use stats && myconf="${myconf}
+			--enable-wxcas
+			--enable-alc"
+		use remote && myconf="${myconf}
+			--enable-amule-gui"
+	else
+		myconf="
+			--disable-monolithic
+			--disable-amule-gui
+			--disable-wxcas
+			--disable-alc"
+	fi
+
+	econf \
+		--with-wx-config="${WX_CONFIG}" \
+		--enable-amulecmd \
+		$(use_enable debug) \
+		$(use_enable daemon amule-daemon) \
+		$(use_enable geoip) \
+		$(use_enable nls) \
+		$(use_enable remote webserver) \
+		$(use_enable stats cas) \
+		$(use_enable stats alcc) \
+		$(use_enable upnp) \
+		${myconf}
+}
+
+src_install() {
+	default
+
+	if use daemon; then
+		newconfd "${FILESDIR}"/amuled.confd amuled
+		newinitd "${FILESDIR}"/amuled.initd amuled
+	fi
+	if use remote; then
+		newconfd "${FILESDIR}"/amuleweb.confd amuleweb
+		newinitd "${FILESDIR}"/amuleweb.initd amuleweb
+	fi
+}

--- a/net-p2p/amule/amule-2.3.1-r1.ebuild
+++ b/net-p2p/amule/amule-2.3.1-r1.ebuild
@@ -79,6 +79,7 @@ src_configure() {
 	fi
 
 	econf \
+		--with-denoise-level=0 \
 		--with-wx-config="${WX_CONFIG}" \
 		--enable-amulecmd \
 		$(use_enable debug) \

--- a/net-p2p/amule/files/amuled.initd
+++ b/net-p2p/amule/files/amuled.initd
@@ -22,12 +22,13 @@ start() {
 	fi
 
 	ebegin "Starting aMule Daemon"
-	env HOME="${AMULEHOME}" start-stop-daemon --start \
+	start-stop-daemon --start \
 		--quiet --background \
 		--make-pidfile --pidfile /var/run/amuled.pid \
-		-c ${AMULEUSER} \
-		-x /usr/bin/amuled >${LOG}
-	
+		--env HOME="${AMULEHOME}" \
+		--user ${AMULEUSER} \
+		--exec /usr/bin/amuled >${LOG}
+
 	sleep 2
 	if ! pgrep -u ${AMULEUSER} amuled > /dev/null; then
 		eerror "aMule daemon can't be started! Check logfile: ${LOG}"
@@ -37,7 +38,7 @@ start() {
 
 stop() {
 	ebegin "Stopping aMule daemon -- please wait"
-	start-stop-daemon --oknodo --stop --pidfile /var/run/amuled.pid &>/dev/null
+	start-stop-daemon --stop --pidfile /var/run/amuled.pid 2>&1 >/dev/null
 	eend $?
 }
 

--- a/net-p2p/amule/files/amuleweb.initd
+++ b/net-p2p/amule/files/amuleweb.initd
@@ -26,12 +26,13 @@ start() {
 	OPTIONS="-h ${AMULEHOST} -p ${AMULEPORT} -P ${AMULEPWD} -A ${WEBPWD} -t ${TEMPLATE} -q"
 
 	ebegin "Starting aMule WebServer"
-	env HOME="${AMULEHOME}" start-stop-daemon --start \
-		--quiet -b \
+	start-stop-daemon --start \
+		--quiet --background \
 		--make-pidfile --pidfile /var/run/amuleweb.pid \
-		-c ${AMULEUSER} \
-		-x /usr/bin/amuleweb -- ${OPTIONS} &>${LOG}
-	
+		--env HOME="${AMULEHOME}" \
+		--user ${AMULEUSER} \
+		--exec /usr/bin/amuleweb -- ${OPTIONS} 2>&1 >${LOG}
+
 	sleep 1
 	if ! pgrep -u ${AMULEUSER} amuleweb > /dev/null; then
 		eerror "aMule daemon can't be started! Check logfile: ${LOG}"
@@ -43,7 +44,7 @@ start() {
 
 stop() {
 	ebegin "Stopping aMule WebServer"
-	start-stop-daemon --oknodo --stop --pidfile /var/run/amuleweb.pid &>/dev/null
+	start-stop-daemon --stop --pidfile /var/run/amuleweb.pid 2>&1 >/dev/null
 	eend $?
 }
 


### PR DESCRIPTION
Changes:
- port to EAPI=5
- remove unused flag-o-matic inherit
- add dependency on sys-libs/binutils-libs

```
--- amule-2.3.1.ebuild	2015-08-16 00:39:49.148676544 +0300
+++ amule-2.3.1-r1.ebuild	2015-10-26 22:48:04.418342061 +0300
@@ -2,9 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="2"
+EAPI=5
 
-inherit eutils flag-o-matic wxwidgets user
+inherit eutils wxwidgets user
 
 MY_P=${PN/m/M}-${PV}
 S="${WORKDIR}"/${MY_P}
@@ -15,16 +15,17 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="daemon debug geoip nls remote stats unicode upnp +X"
 
 DEPEND=">=dev-libs/crypto++-5
 	>=sys-libs/zlib-1.2.1
-	stats? ( >=media-libs/gd-2.0.26[jpeg] )
+	sys-libs/binutils-libs:0=
+	stats? ( >=media-libs/gd-2.0.26:=[jpeg] )
 	geoip? ( dev-libs/geoip )
 	upnp? ( >=net-libs/libupnp-1.6.6 )
-	remote? ( >=media-libs/libpng-1.2.0
-	unicode? ( >=media-libs/gd-2.0.26 ) )
+	remote? ( >=media-libs/libpng-1.2.0:0=
+	unicode? ( >=media-libs/gd-2.0.26:= ) )
 	X? ( >=x11-libs/wxGTK-2.8.12:2.8[X] )
 	!X? ( >=x11-libs/wxGTK-2.8.12:2.8 )
 	!net-p2p/imule"
@@ -90,11 +91,11 @@
 		$(use_enable stats cas) \
 		$(use_enable stats alcc) \
 		$(use_enable upnp) \
-		${myconf} || die
+		${myconf}
 }
 
 src_install() {
-	emake DESTDIR="${D}" install || die
+	emake DESTDIR="${D}" install
 
 	if use daemon; then
 		newconfd "${FILESDIR}"/amuled.confd amuled
```