### PR TITLE
net-libs/tox: add ebuild

### DIFF
--- a/net-libs/tox/files/confd
+++ b/net-libs/tox/files/confd
@@ -1,0 +1,2 @@
+TOX_GROUP=tox
+TOX_USER=tox

--- a/net-libs/tox/files/initd
+++ b/net-libs/tox/files/initd
@@ -1,0 +1,30 @@
+#!/sbin/runscript
+
+PIDDIR=/run/tox-bootstrapd
+PIDFILE="${PIDDIR}"/tox-bootstrap.pid
+
+depend() {
+	need net
+}
+
+start() {
+	ebegin "Starting tox-dht-bootstrap daemon"
+
+	checkpath -d -q -o "${TOX_USER}":"${TOX_GROUP}" "${PIDDIR}"
+
+	start-stop-daemon --start \
+		--pidfile "${PIDFILE}" \
+		--user="${TOX_USER}" --group="${TOX_GROUP}" \
+		--exec /usr/bin/tox-bootstrapd -- /etc/tox-bootstrapd.conf
+
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping tox-dht-bootstrap daemon"
+
+	start-stop-daemon --stop \
+		--pidfile "${PIDFILE}"
+
+	eend $?
+}

--- a/net-libs/tox/files/tox-bootstrapd.conf
+++ b/net-libs/tox/files/tox-bootstrapd.conf
@@ -1,0 +1,65 @@
+// Tox DHT bootstrap daemon configuration file.
+
+// Listening port (UDP).
+port = 33445
+
+// A key file is like a password, so keep it where no one can read it.
+// If there is no key file, a new one will be generated.
+// The daemon should have permission to read/write it.
+keys_file_path = "/var/lib/tox-bootstrapd/keys"
+
+// The PID file written to by the daemon.
+// Make sure that the user that daemon runs as has permissions to write to the
+// PID file.
+pid_file_path = "/var/run/tox-bootstrapd/tox-bootstrapd.pid"
+
+// Enable IPv6.
+enable_ipv6 = true
+
+// Fallback to IPv4 in case IPv6 fails.
+enable_ipv4_fallback = true
+
+// Automatically bootstrap with nodes on local area network.
+enable_lan_discovery = true
+
+enable_tcp_relay = true
+
+// While Tox uses 33445 port by default, 443 (https) and 3389 (rdp) ports are very
+// common among nodes, so it's encouraged to keep them in place.
+tcp_relay_ports = [443, 3389, 33445]
+
+// Reply to MOTD (Message Of The Day) requests.
+enable_motd = true
+
+// Just a message that is sent when someone requests MOTD.
+// Put anything you want, but note that it will be trimmed to fit into 255 bytes.
+motd = "tox-bootstrapd"
+
+// Any number of nodes the daemon will bootstrap itself off.
+//
+// Remember to replace the provided example with your own node list.
+// There is a maintained list of bootstrap nodes on Tox's wiki, if you need it
+// (https://wiki.tox.chat/users/nodes).
+//
+// You may leave the list empty or remove "bootstrap_nodes" completely,
+// in both cases this will be interpreted as if you don't want to bootstrap
+// from anyone.
+//
+// address = any IPv4 or IPv6 address and also any US-ASCII domain name.
+bootstrap_nodes = (
+  { // Example Node 1 (IPv4)
+    address = "127.0.0.1"
+    port = 33445
+    public_key = "728925473812C7AAC482BE7250BCCAD0B8CB9F737BF3D42ABD34459C1768F854"
+  },
+  { // Example Node 2 (IPv6)
+    address = "::1/128"
+    port = 33445
+    public_key = "3E78BACF0F84235B30054B54898F56793E1DEF8BD46B1038B9D822E8460FAB67"
+  },
+  { // Example Node 3 (US-ASCII domain name)
+    address = "example.org"
+    port = 33445
+    public_key = "8CD5A9BF0A6CE358BA36F7A653F99FA6B258FF756E490F52C1F98CC420F78858"
+  }
+)

--- a/net-libs/tox/files/tox-bootstrapd.service
+++ b/net-libs/tox/files/tox-bootstrapd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Tox DHT Bootstrap Daemon
+After=network.target
+
+[Service]
+User=tox
+Group=tox
+RuntimeDirectory=tox-bootstrapd
+PIDFile=/run/tox-bootstrapd/tox-bootstrapd.pid
+WorkingDirectory=/var/lib/tox-bootstrapd
+ExecStart=/usr/bin/tox-bootstrapd /etc/tox-bootstrapd.conf
+#CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/net-libs/tox/metadata.xml
+++ b/net-libs/tox/metadata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>zexavexxe@gmail.com</email>
+		<name>Zetok Zalbavar</name>
+		<description>Proxy maintainers. CC him on bugs</description>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<use>
+		<flag name="av">Adds support for audio and video.</flag>
+		<flag name="no-log">Log level: 0 (no debug info logged)</flag>
+		<flag name="log-error">Log level: 1</flag>
+		<flag name="log-warn">Log level: 2</flag>
+		<flag name="log-info">Log level: 3</flag>
+		<flag name="log-debug">Log level: 4</flag>
+		<flag name="log-trace">Log level: 5</flag>
+		<flag name="ntox">Enable the testing nTox client.</flag>
+		<flag name="daemon">Enable the DHT Bootstrap Daemon.</flag>
+	</use>
+</pkgmetadata>

--- a/net-libs/tox/tox-0_p20160201.ebuild
+++ b/net-libs/tox/tox-0_p20160201.ebuild
@@ -1,0 +1,78 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit autotools eutils git-r3 user systemd
+
+DESCRIPTION="Encrypted P2P, messaging, and audio/video calling platform"
+HOMEPAGE="https://tox.chat"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/irungentoo/toxcore.git
+	git://github.com/irungentoo/toxcore.git"
+EGIT_COMMIT="94cc8b11ff473064526737936f64b6f9a19c239d"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+av daemon log-debug log-error log-info log-trace log-warn +no-log ntox static-libs test"
+
+REQUIRED_USE="^^ ( no-log log-trace log-debug log-info log-warn log-error )"
+
+RDEPEND="
+	av? ( media-libs/libvpx
+		media-libs/opus )
+	daemon? ( dev-libs/libconfig )
+	ntox? ( sys-libs/ncurses )
+	>=dev-libs/libsodium-0.6.1[asm,urandom]"
+DEPEND="${RDEPEND}
+	test? ( dev-libs/check )
+	virtual/pkgconfig"
+
+src_prepare() {
+	epatch_user
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(usex log-trace "--enable-logging --with-log-level=TRACE" "") \
+		$(usex log-debug "--enable-logging --with-log-level=DEBUG" "") \
+		$(usex log-info "--enable-logging --with-log-level=INFO" "") \
+		$(usex log-warn "--enable-logging --with-log-level=WARNING" "") \
+		$(usex log-error "--enable-logging --with-log-level=ERROR" "") \
+		$(use_enable av) \
+		$(use_enable test tests) \
+		$(use_enable ntox) \
+		$(use_enable daemon) \
+		$(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	if use daemon; then
+		newinitd "${FILESDIR}"/initd tox-dht-daemon
+		newconfd "${FILESDIR}"/confd tox-dht-daemon
+		insinto /etc
+		doins "${FILESDIR}"/tox-bootstrapd.conf
+		systemd_dounit "${FILESDIR}"/tox-bootstrapd.service
+	fi
+
+	prune_libtool_files
+}
+
+pkg_postinst() {
+	if use daemon; then
+		enewgroup ${PN}
+		enewuser ${PN} -1 -1 -1 ${PN}
+		if [[ -f ${EROOT}var/lib/tox-dht-bootstrap/key ]]; then
+			ewarn "Backwards compatability with the bootstrap daemon might have been"
+			ewarn "broken a while ago. To resolve this issue, REMOVE the following files:"
+			ewarn "    /var/lib/tox-dht-bootstrap/key"
+			ewarn "    /etc/tox-bootstrapd.conf"
+			ewarn "    /run/tox-dht-bootstrap/tox-dht-bootstrap.pid"
+			ewarn "Then just re-emerge net-libs/tox"
+		fi
+	fi
+}

--- a/net-libs/tox/tox-9999.ebuild
+++ b/net-libs/tox/tox-9999.ebuild
@@ -1,0 +1,77 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit autotools eutils git-r3 user systemd
+
+DESCRIPTION="Encrypted P2P, messaging, and audio/video calling platform"
+HOMEPAGE="https://tox.chat"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/irungentoo/toxcore.git
+	git://github.com/irungentoo/toxcore.git"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS=""
+IUSE="+av daemon log-debug log-error log-info log-trace log-warn +no-log ntox static-libs test"
+
+REQUIRED_USE="^^ ( no-log log-trace log-debug log-info log-warn log-error )"
+
+RDEPEND="
+	av? ( media-libs/libvpx
+		media-libs/opus )
+	daemon? ( dev-libs/libconfig )
+	ntox? ( sys-libs/ncurses )
+	>=dev-libs/libsodium-0.6.1[asm,urandom]"
+DEPEND="${RDEPEND}
+	test? ( dev-libs/check )
+	virtual/pkgconfig"
+
+src_prepare() {
+	epatch_user
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(usex log-trace "--enable-logging --with-log-level=TRACE" "") \
+		$(usex log-debug "--enable-logging --with-log-level=DEBUG" "") \
+		$(usex log-info "--enable-logging --with-log-level=INFO" "") \
+		$(usex log-warn "--enable-logging --with-log-level=WARNING" "") \
+		$(usex log-error "--enable-logging --with-log-level=ERROR" "") \
+		$(use_enable av) \
+		$(use_enable test tests) \
+		$(use_enable ntox) \
+		$(use_enable daemon) \
+		$(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	if use daemon; then
+		newinitd "${FILESDIR}"/initd tox-dht-daemon
+		newconfd "${FILESDIR}"/confd tox-dht-daemon
+		insinto /etc
+		doins "${FILESDIR}"/tox-bootstrapd.conf
+		systemd_dounit "${FILESDIR}"/tox-bootstrapd.service
+	fi
+
+	prune_libtool_files
+}
+
+pkg_postinst() {
+	if use daemon; then
+		enewgroup ${PN}
+		enewuser ${PN} -1 -1 -1 ${PN}
+		if [[ -f ${EROOT}var/lib/tox-dht-bootstrap/key ]]; then
+			ewarn "Backwards compatability with the bootstrap daemon might have been"
+			ewarn "broken a while ago. To resolve this issue, REMOVE the following files:"
+			ewarn "    /var/lib/tox-dht-bootstrap/key"
+			ewarn "    /etc/tox-bootstrapd.conf"
+			ewarn "    /run/tox-dht-bootstrap/tox-dht-bootstrap.pid"
+			ewarn "Then just re-emerge net-libs/tox"
+		fi
+	fi
+}


### PR DESCRIPTION
Almost in unmodified form from https://github.com/zetok/gentoo-overlay-tox/blob/0955c2a1e373fc07bcb2fefe710bbaa69698ecd9/net-libs/tox/tox-9999.ebuild - I removed maintainer part of `metadata.xml`, since they have resigned from being a maintainer.