### PR TITLE
media-libs/libwmf: revbump with security fixes

### DIFF
--- a/media-libs/libwmf/files/libwmf-0.2.8.4-CVE-2015-0848+CVE-2015-4588.patch
+++ b/media-libs/libwmf/files/libwmf-0.2.8.4-CVE-2015-0848+CVE-2015-4588.patch
@@ -1,0 +1,118 @@
+--- libwmf-0.2.8.4/src/ipa/ipa/bmp.h	2015-06-08 14:46:24.591876404 +0100
++++ libwmf-0.2.8.4/src/ipa/ipa/bmp.h	2015-06-08 14:46:35.345993247 +0100
+@@ -859,7 +859,7 @@
+ %
+ %
+ */
+-static void DecodeImage (wmfAPI* API,wmfBMP* bmp,BMPSource* src,unsigned int compression,unsigned char* pixels)
++static int DecodeImage (wmfAPI* API,wmfBMP* bmp,BMPSource* src,unsigned int compression,unsigned char* pixels)
+ {	int byte;
+ 	int count;
+ 	int i;
+@@ -870,12 +870,14 @@
+ 	U32 u;
+ 
+ 	unsigned char* q;
++	unsigned char* end;
+ 
+ 	for (u = 0; u < ((U32) bmp->width * (U32) bmp->height); u++) pixels[u] = 0;
+ 
+ 	byte = 0;
+ 	x = 0;
+ 	q = pixels;
++	end = pixels + bmp->width * bmp->height;
+ 
+ 	for (y = 0; y < bmp->height; )
+ 	{	count = ReadBlobByte (src);
+@@ -884,7 +886,10 @@
+ 		{	/* Encoded mode. */
+ 			byte = ReadBlobByte (src);
+ 			for (i = 0; i < count; i++)
+-			{	if (compression == 1)
++			{	
++				if (q == end)
++					return 0;
++			 	if (compression == 1)
+ 				{	(*(q++)) = (unsigned char) byte;
+ 				}
+ 				else
+@@ -896,13 +901,15 @@
+ 		else
+ 		{	/* Escape mode. */
+ 			count = ReadBlobByte (src);
+-			if (count == 0x01) return;
++			if (count == 0x01) return 1;
+ 			switch (count)
+ 			{
+ 			case 0x00:
+ 			 {	/* End of line. */
+ 				x = 0;
+ 				y++;
++				if (y >= bmp->height)
++					return 0;
+ 				q = pixels + y * bmp->width;
+ 				break;
+ 			 }
+@@ -910,13 +917,20 @@
+ 			 {	/* Delta mode. */
+ 				x += ReadBlobByte (src);
+ 				y += ReadBlobByte (src);
++				if (y >= bmp->height)
++					return 0;
++				if (x >= bmp->width)
++					return 0;
+ 				q = pixels + y * bmp->width + x;
+ 				break;
+ 			 }
+ 			default:
+ 			 {	/* Absolute mode. */
+ 				for (i = 0; i < count; i++)
+-				{	if (compression == 1)
++				{
++					if (q == end)
++						return 0;
++					if (compression == 1)
+ 					{	(*(q++)) = ReadBlobByte (src);
+ 					}
+ 					else
+@@ -943,7 +957,7 @@
+ 	byte = ReadBlobByte (src);  /* end of line */
+ 	byte = ReadBlobByte (src);
+ 
+-	return;
++	return 1;
+ }
+ 
+ /*
+@@ -1143,8 +1157,18 @@
+ 		}
+ 	}
+ 	else
+-	{	/* Convert run-length encoded raster pixels. */
+-		DecodeImage (API,bmp,src,(unsigned int) bmp_info.compression,data->image);
++	{
++		if (bmp_info.bits_per_pixel == 8)	/* Convert run-length encoded raster pixels. */
++		{
++			if (!DecodeImage (API,bmp,src,(unsigned int) bmp_info.compression,data->image))
++			{	WMF_ERROR (API,"corrupt bmp");
++				API->err = wmf_E_BadFormat;
++			}
++		}
++		else
++		{	WMF_ERROR (API,"Unexpected pixel depth");
++			API->err = wmf_E_BadFormat;
++		}
+ 	}
+ 
+ 	if (ERR (API))
+--- libwmf-0.2.8.4/src/ipa/ipa.h	2015-06-08 14:46:24.590876393 +0100
++++ libwmf-0.2.8.4/src/ipa/ipa.h	2015-06-08 14:46:35.345993247 +0100
+@@ -48,7 +48,7 @@
+ static unsigned short ReadBlobLSBShort (BMPSource*);
+ static unsigned long  ReadBlobLSBLong (BMPSource*);
+ static long           TellBlob (BMPSource*);
+-static void           DecodeImage (wmfAPI*,wmfBMP*,BMPSource*,unsigned int,unsigned char*);
++static int            DecodeImage (wmfAPI*,wmfBMP*,BMPSource*,unsigned int,unsigned char*);
+ static void           ReadBMPImage (wmfAPI*,wmfBMP*,BMPSource*);
+ static int            ExtractColor (wmfAPI*,wmfBMP*,wmfRGB*,unsigned int,unsigned int);
+ static void           SetColor (wmfAPI*,wmfBMP*,wmfRGB*,unsigned char,unsigned int,unsigned int);

--- a/media-libs/libwmf/files/libwmf-0.2.8.4-CVE-2015-4695.patch
+++ b/media-libs/libwmf/files/libwmf-0.2.8.4-CVE-2015-4695.patch
@@ -1,0 +1,56 @@
+--- libwmf-0.2.8.4/src/player/meta.h
++++ libwmf-0.2.8.4/src/player/meta.h
+@@ -1565,7 +1565,7 @@ static int meta_rgn_create (wmfAPI* API,
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -2142,7 +2142,7 @@ static int meta_dib_brush (wmfAPI* API,w
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -3067,7 +3067,7 @@ static int meta_pen_create (wmfAPI* API,
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -3181,7 +3181,7 @@ static int meta_brush_create (wmfAPI* AP
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -3288,7 +3288,7 @@ static int meta_font_create (wmfAPI* API
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -3396,7 +3396,7 @@ static int meta_palette_create (wmfAPI*
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");

--- a/media-libs/libwmf/files/libwmf-0.2.8.4-CVE-2015-4696.patch
+++ b/media-libs/libwmf/files/libwmf-0.2.8.4-CVE-2015-4696.patch
@@ -1,0 +1,23 @@
+--- libwmf-0.2.8.4/src/player/meta.h
++++ libwmf-0.2.8.4/src/player/meta.h
+@@ -2585,6 +2585,8 @@
+ 			polyrect.BR[i] = clip->rects[i].BR;
+ 		}
+ 
++		if (FR->region_clip) FR->region_clip (API,&polyrect);
++
+ 		wmf_free (API,polyrect.TL);
+ 		wmf_free (API,polyrect.BR);
+ 	}
+@@ -2593,9 +2595,10 @@
+ 		polyrect.BR = 0;
+ 
+ 		polyrect.count = 0;
++	
++		if (FR->region_clip) FR->region_clip (API,&polyrect);
+ 	}
+ 
+-	if (FR->region_clip) FR->region_clip (API,&polyrect);
+ 
+ 	return (changed);
+ }

--- a/media-libs/libwmf/libwmf-0.2.8.4-r6.ebuild
+++ b/media-libs/libwmf/libwmf-0.2.8.4-r6.ebuild
@@ -1,0 +1,113 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+AUTOTOOLS_AUTORECONF=true
+
+inherit autotools-utils gnome2-utils
+
+#The configure script finds the 5.50 ghostscript Fontmap file while run.
+#This will probably work, especially since the real one (6.50) in this case
+#is empty. However beware in case there is any trouble
+
+DESCRIPTION="library for converting WMF files"
+HOMEPAGE="http://wvware.sourceforge.net/"
+SRC_URI="mirror://sourceforge/wvware/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
+IUSE="X debug doc expat xml"
+
+RDEPEND="
+	app-text/ghostscript-gpl
+	media-fonts/urw-fonts
+	media-libs/freetype:2=
+	>=media-libs/libpng-1.4:0=
+	sys-libs/zlib
+	x11-libs/gdk-pixbuf:2[X?]
+	virtual/jpeg:0=
+	xml? (
+		expat? ( dev-libs/expat )
+		!expat? (  dev-libs/libxml2 )
+	)
+	X? ( x11-libs/libX11 )
+"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	X? (
+		x11-libs/libXt
+		x11-libs/libXpm
+	)"
+# plotutils are not really supported yet, so looks like that's it
+
+REQUIRED_USE="expat? ( xml )"
+
+DOCS=( README AUTHORS CREDITS ChangeLog NEWS TODO )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-intoverflow.patch
+	"${FILESDIR}"/${P}-build.patch
+	"${FILESDIR}"/${P}-pngfix.patch
+	"${FILESDIR}"/${P}-libpng-1.5.patch
+	"${FILESDIR}"/${P}-use-system-fonts.patch
+	"${FILESDIR}"/${P}-gdk-pixbuf.patch
+	"${FILESDIR}"/${P}-CVE-2015-0848+CVE-2015-4588.patch
+	"${FILESDIR}"/${P}-CVE-2015-4695.patch
+	"${FILESDIR}"/${P}-CVE-2015-4696.patch
+	)
+
+AUTOTOOLS_PRUNE_LIBTOOL_FILES='modules'
+
+src_prepare() {
+	if ! use doc ; then
+		sed -e 's:doc::' -i Makefile.am || die
+	fi
+	sed -i 's/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g' configure.ac || die
+
+	autotools-utils_src_prepare
+}
+
+src_configure() {
+	local myeconfargs=()
+	# NOTE: The gd that is included is gd-2.0.0. Even with --with-sys-gd, that gd is built
+	# and included in libwmf. Since nothing in-tree seems to use media-libs/libwmf[gd],
+	# we're explicitly disabling gd use w.r.t. bug 268161
+	if use expat; then
+		myeconfargs+=( --without-libxml2 )
+	else
+		myeconfargs+=( $(use_with xml libxml2) )
+	fi
+
+	myeconfargs+=(
+		--disable-static
+		$(use_enable debug)
+		$(use_with X x)
+		$(use_with expat)
+		--disable-gd
+		--with-sys-gd
+		--with-gsfontdir="${EPREFIX}"/usr/share/ghostscript/fonts
+		--with-fontdir="${EPREFIX}"/usr/share/fonts/urw-fonts/
+		--with-docdir="${EPREFIX}"/usr/share/doc/${PF}
+		)
+	autotools-utils_src_configure
+}
+
+src_install() {
+	MAKEOPTS+=" -j1"
+	autotools-utils_src_install
+}
+
+pkg_preinst() {
+	gnome2_gdk_pixbuf_savelist
+}
+
+pkg_postinst() {
+	gnome2_gdk_pixbuf_update
+}
+
+pkg_postrm() {
+	gnome2_gdk_pixbuf_update
+}


### PR DESCRIPTION
Fixed security issues:

CVE-2015-0848: heap overflow when decoding BMP images
CVE-2015-4695: heap buffer overread in meta.h
CVE-2015-4696: use-after-free flaw in meta.h
CVE-2015-4588: heap overflow within the RLE decoding of embedded BMP images

Gentoo bug:
https://bugs.gentoo.org/show_bug.cgi?id=548742

Patches imported from fedora:
http://pkgs.fedoraproject.org/cgit/libwmf.git/tree/