### PR TITLE
net-misc/openssh: Please drop special settings for Gentoo/FreeBSD 9.0 or later.

### DIFF
--- a/net-misc/openssh/openssh-7.1_p1-r2.ebuild
+++ b/net-misc/openssh/openssh-7.1_p1-r2.ebuild
@@ -207,12 +207,6 @@ src_configure() {
 	# The seccomp sandbox is broken on x32, so use the older method for now. #553748
 	use amd64 && [[ ${ABI} == "x32" ]] && myconf+=( --with-sandbox=rlimit )
 
-	# Special settings for Gentoo/FreeBSD 9.0 or later (see bug #391011)
-	if use elibc_FreeBSD && version_is_at_least 9.0 "$(uname -r|sed 's/\(.\..\).*/\1/')" ; then
-		myconf+=( --disable-utmp --disable-wtmp --disable-wtmpx )
-		append-ldflags -lutil
-	fi
-
 	econf "${myconf[@]}"
 }
 


### PR DESCRIPTION
Fixed in upstream.
I think it's no longer necessary.

FYI,
https://github.com/openssh/openssh-portable/commit/398c0ffe0ec149f0d12f23c158879712b5431af4
https://github.com/openssh/openssh-portable/commit/a2438bbd28eb35a8968d193ac89b30a90e96f719
