### PR TITLE
dev-lang/php-fpm init correction

### DIFF
--- a/dev-lang/php/files/php-fpm-r4.init
+++ b/dev-lang/php/files/php-fpm-r4.init
@@ -13,7 +13,6 @@ extra_started_commands="reload"
 
 depend() {
 	need net
-	use apache2 lighttpd nginx
 }
 
 start() {


### PR DESCRIPTION
An httpd might use PHP-FPM, but PHP-FPM does NOT use any httpd. Don't start services in a backwards order.