### PR TITLE
python-r1.eclass: Ensure that PYTHON_COMPAT is an array

### DIFF
--- a/eclass/python-any-r1.eclass
+++ b/eclass/python-any-r1.eclass
@@ -72,8 +72,8 @@ if [[ ! ${_PYTHON_ANY_R1} ]]; then
 # @CODE
 # PYTHON_COMPAT=( python{2_5,2_6,2_7} )
 # @CODE
-if ! declare -p PYTHON_COMPAT &>/dev/null; then
-	die 'PYTHON_COMPAT not declared.'
+if [[ $(declare -p PYTHON_COMPAT) != "declare -a"* ]]; then
+    die 'PYTHON_COMPAT must be an array.'
 fi
 
 # @ECLASS-VARIABLE: PYTHON_REQ_USE

--- a/eclass/python-r1.eclass
+++ b/eclass/python-r1.eclass
@@ -81,8 +81,8 @@ inherit multibuild python-utils-r1
 # @CODE
 # PYTHON_COMPAT=( python2_7 python3_{3,4} )
 # @CODE
-if ! declare -p PYTHON_COMPAT &>/dev/null; then
-	die 'PYTHON_COMPAT not declared.'
+if [[ $(declare -p PYTHON_COMPAT) != "declare -a"* ]]; then
+	die 'PYTHON_COMPAT must be an array.'
 fi
 
 # @ECLASS-VARIABLE: PYTHON_COMPAT_OVERRIDE

--- a/eclass/python-single-r1.eclass
+++ b/eclass/python-single-r1.eclass
@@ -95,8 +95,8 @@ if [[ ! ${_PYTHON_SINGLE_R1} ]]; then
 # @CODE
 # PYTHON_COMPAT=( python2_7 python3_{3,4} )
 # @CODE
-if ! declare -p PYTHON_COMPAT &>/dev/null; then
-	die 'PYTHON_COMPAT not declared.'
+if [[ $(declare -p PYTHON_COMPAT) != "declare -a"* ]]; then
+	die 'PYTHON_COMPAT must be an array.'
 fi
 
 # @ECLASS-VARIABLE: PYTHON_REQ_USE


### PR DESCRIPTION
As suggested by Arfrever.

Bug: https://bugs.gentoo.org/564258