### PR TITLE
Patch to use functions.sh provided by gentoo-functions package

### DIFF
--- a/dev-java/java-config-wrapper/files/use_gentoo-functions.patch
+++ b/dev-java/java-config-wrapper/files/use_gentoo-functions.patch
@@ -1,0 +1,14 @@
+--- java-config-wrapper-0.16/src/shell/java-check-environment
++++ java-config-wrapper-0.16/src/shell/java-check-environment
+@@ -1,6 +1,10 @@
+ #!/bin/bash
+ 
+-source /etc/init.d/functions.sh
++functions_script="/lib/gentoo/functions.sh"
++source ${functions_script} || {
++	echo "Could not source ${functions_script}!" 1>&2
++	exit 1
++}
+ 
+ # Used to update the global result.
+ update_result() {

--- a/dev-java/java-config-wrapper/java-config-wrapper-0.16-r1.ebuild
+++ b/dev-java/java-config-wrapper/java-config-wrapper-0.16-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+DESCRIPTION="Wrapper for java-config"
+HOMEPAGE="https://www.gentoo.org/proj/en/java"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm ~hppa ppc ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd"
+IUSE=""
+
+DEPEND="!<dev-java/java-config-1.3"
+RDEPEND="
+	app-portage/portage-utils
+	sys-apps/gentoo-functions"
+"
+src_prepare() {
+	epatch "${FILESDIR}"/use_gentoo-functions.patch
+}
+src_install() {
+	dobin src/shell/* || die
+	dodoc AUTHORS || die
+}


### PR DESCRIPTION
See:
https://bugs.gentoo.org/show_bug.cgi?id=504116
https://bugs.gentoo.org/show_bug.cgi?id=504124
https://504124.bugs.gentoo.org/attachment.cgi?id=373032

P.S. I have only tested if this patch can be applied to the corresponding source, because the changes themselves seem rather uncomplicated. I am a newbie to gentoo development, so, please, can anybody check if everything is ok?