### PR TITLE
net-libs/http-parser: respect ${EPREFIX}

### DIFF
--- a/net-libs/http-parser/http-parser-2.6.0.ebuild
+++ b/net-libs/http-parser/http-parser-2.6.0.ebuild
@@ -40,6 +40,6 @@ multilib_src_test() {
 }
 
 multilib_src_install() {
-	emake DESTDIR="${D}" PREFIX="/usr" LIBDIR="/usr/$(get_libdir)" install
+	emake DESTDIR="${D}" PREFIX="${EPREFIX}/usr" LIBDIR="${EPREFIX}/usr/$(get_libdir)" install
 	use static-libs && dolib.a libhttp_parser.a
 }


### PR DESCRIPTION
Build fails on prefix because `/usr/{bin,lib}` is outside `${EPREFIX}`.

Older version of `http-parser` work fine.