### PR TITLE
media-sound/audacity: update/add samplerate converter USE flag descriptions

### DIFF
--- a/media-sound/audacity/metadata.xml
+++ b/media-sound/audacity/metadata.xml
@@ -10,9 +10,9 @@
   <use>
     <flag name="id3tag">Enables ID3 tagging with id3tag library</flag>
     <flag name="libsoxr">
-      Uses <pkg>media-libs/soxr</pkg> as audio resampling library: Better
-      quality than the included resampler and much faster than libsamplerate
-      while keeping almost the same quality.
+      Uses <pkg>media-libs/soxr</pkg> as audio resampling library: Higher
+      quality and much faster than both the included resampler and
+      libsamplerate.
     </flag>
     <flag name="lv2">Add support for Ladspa V2</flag>
     <flag name="midi">Enables MIDI support</flag>

--- a/media-sound/audacity/metadata.xml
+++ b/media-sound/audacity/metadata.xml
@@ -14,6 +14,11 @@
       quality and much faster than both the included resampler and
       libsamplerate.
     </flag>
+    <flag name="libsamplerate">
+      Uses <pkg>media-libs/libsamplerate</pkg> as audio resampling library:
+      Higher quality than the included resampler but lower quality and much
+      slower than libsoxr.
+    </flag>
     <flag name="lv2">Add support for Ladspa V2</flag>
     <flag name="midi">Enables MIDI support</flag>
     <flag name="portmixer">Enable the internal portmixer feature</flag>


### PR DESCRIPTION
As per the comments in https://github.com/gentoo/gentoo/pull/292 I have updated the `libsoxr` USE flag description as well as added a local one for `libsamplerate`.