### PR TITLE
x11-misc/sddm: revbump. Fix pam activation, move qttest to DEPEND

### DIFF
--- a/x11-misc/sddm/sddm-0.13.0-r1.ebuild
+++ b/x11-misc/sddm/sddm-0.13.0-r1.ebuild
@@ -19,7 +19,6 @@ RDEPEND="dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtdeclarative:5
 	dev-qt/qtnetwork:5
-	dev-qt/qttest:5
 	>=x11-base/xorg-server-1.15.1
 	x11-libs/libxcb[xkb(-)]
 	consolekit? ( >=sys-auth/consolekit-0.9.4 )
@@ -30,6 +29,7 @@ RDEPEND="dev-qt/qtcore:5
 DEPEND="${RDEPEND}
 	dev-python/docutils
 	dev-qt/linguist-tools:5
+	dev-qt/qttest:5
 	virtual/pkgconfig"
 
 pkg_pretend() {
@@ -50,7 +50,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake-utils_use_no pam PAM)
+		$(cmake-utils_use_enable pam PAM)
 		$(cmake-utils_use_no systemd SYSTEMD)
 		-DBUILD_MAN_PAGES=ON
 		-DDBUS_CONFIG_FILENAME="org.freedesktop.sddm.conf"


### PR DESCRIPTION
PAM is now enabled through a boolean variable