### PR TITLE
Fix asciidoc deps

### DIFF
--- a/app-text/asciidoc/asciidoc-8.6.9-r1.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 pypy )
 
 inherit python-single-r1
 
-DESCRIPTION="A text document format for writing short documents, articles, books and UNIX man pages"
+DESCRIPTION="AsciiDoc is a plain text human readable/writable document format"
 HOMEPAGE="http://asciidoc.org/"
 SRC_URI="mirror://sourceforge/project/${PN}/${PN}/${PV}/${P}.tar.gz"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"

--- a/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
@@ -1,0 +1,82 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 pypy )
+
+inherit python-single-r1
+
+DESCRIPTION="A text document format for writing short documents, articles, books and UNIX man pages"
+HOMEPAGE="http://asciidoc.org/"
+SRC_URI="mirror://sourceforge/project/${PN}/${PN}/${PV}/${P}.tar.gz"
+KEYWORDS="~amd64 ~x86"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="examples graphviz highlight test vim-syntax"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
+		dev-libs/libxslt
+		graphviz? ( media-gfx/graphviz )
+		app-text/docbook-xml-dtd:4.5
+		app-text/dblatex
+		|| ( www-client/w3m www-client/lynx )
+		highlight? ( || ( dev-python/pygments[${PYTHON_USEDEP}] dev-util/source-highlight ) )
+		${PYTHON_DEPS}
+"
+DEPEND="test? ( dev-util/source-highlight
+			media-sound/lilypond
+			media-gfx/imagemagick
+			dev-texlive/texlive-latex
+			app-text/dvipng
+			media-gfx/graphviz
+			${PYTHON_DEPS} )
+"
+
+src_prepare() {
+	if ! use vim-syntax; then
+		sed -i -e '/^install/s/install-vim//' Makefile.in || die
+	else
+		sed -i\
+			-e "/^vimdir/s:@sysconfdir@/vim:${EPREFIX}/usr/share/vim/vimfiles:" \
+			-e 's:/etc/vim::' \
+			Makefile.in || die
+	fi
+
+	# Only needed for prefix - harmless (does nothing) otherwise
+	sed -i -e "s:^CONF_DIR=.*:CONF_DIR='${EPREFIX}/etc/asciidoc':" \
+		"${S}/asciidoc.py" || die
+}
+
+src_configure() {
+	econf --sysconfdir="${EPREFIX}"/usr/share
+}
+
+src_install() {
+	use vim-syntax && dodir /usr/share/vim/vimfiles
+
+	emake DESTDIR="${D}" install
+
+	python_fix_shebang "${ED}"/usr/bin/*.py
+
+	dodoc BUGS CHANGELOG README docbook-xsl/asciidoc-docbook-xsl.txt \
+			dblatex/dblatex-readme.txt filters/code/code-filter-readme.txt
+
+	# Below results in some files being installed twice in different locations, but they are in the right place,
+	# uncompressed, and there won't be any broken links. See bug #483336.
+	if use examples; then
+		cp -rL examples/website "${D}"/usr/share/doc/${PF}/examples || die
+	fi
+	docompress -x /usr/share/doc/${PF}/examples
+}
+
+src_test() {
+	cd tests || die
+	local -x ASCIIDOC_PY=../asciidoc.py
+	"${PYTHON}" test${PN}.py update || die
+	"${PYTHON}" test${PN}.py run || die
+}

--- a/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
@@ -25,7 +25,7 @@ RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
 		app-text/docbook-xml-dtd:4.5
 		app-text/dblatex
 		|| ( www-client/w3m www-client/lynx )
-		highlight? ( || ( dev-python/pygments[${PYTHON_USEDEP}] dev-util/source-highlight ) )
+		highlight? ( || ( dev-python/pygments[${PYTHON_USEDEP}] dev-util/source-highlight app-text/highlight ) )
 		${PYTHON_DEPS}
 "
 DEPEND="test? ( dev-util/source-highlight

--- a/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 pypy )
 
 inherit python-single-r1
 
-DESCRIPTION="A text document format for writing short documents, articles, books and UNIX man pages"
+DESCRIPTION="AsciiDoc is a plain text human readable/writable document format"
 HOMEPAGE="http://asciidoc.org/"
 SRC_URI="mirror://sourceforge/project/${PN}/${PN}/${PV}/${P}.tar.gz"
 KEYWORDS="~amd64 ~x86"

--- a/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
@@ -25,7 +25,7 @@ RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
 		app-text/docbook-xml-dtd:4.5
 		app-text/dblatex
 		|| ( www-client/w3m www-client/lynx )
-		highlight? ( || ( dev-python/pygments[${PYTHON_USEDEP}] dev-util/source-highlight app-text/highlight ) )
+		highlight? ( || ( dev-util/source-highlight dev-python/pygments[${PYTHON_USEDEP}] app-text/highlight ) )
 		${PYTHON_DEPS}
 "
 DEPEND="test? ( dev-util/source-highlight

--- a/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
@@ -25,7 +25,10 @@ RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
 		app-text/docbook-xml-dtd:4.5
 		app-text/dblatex
 		|| ( www-client/w3m www-client/lynx )
-		highlight? ( || ( dev-util/source-highlight dev-python/pygments[${PYTHON_USEDEP}] app-text/highlight ) )
+		highlight? ( || ( dev-util/source-highlight \
+			dev-python/pygments[${PYTHON_USEDEP}] \
+			app-text/highlight )
+		)
 		${PYTHON_DEPS}
 "
 DEPEND="test? ( dev-util/source-highlight

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -32,7 +32,7 @@ RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
 		app-text/docbook-xml-dtd:4.5
 		app-text/dblatex
 		|| ( www-client/w3m www-client/lynx )
-		highlight? ( || ( dev-python/pygments[${PYTHON_USEDEP}] dev-util/source-highlight ) )
+		highlight? ( || ( dev-python/pygments[${PYTHON_USEDEP}] dev-util/source-highlight app-text/highlight ) )
 		${PYTHON_DEPS}
 "
 DEPEND="test? ( dev-util/source-highlight

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -17,7 +17,7 @@ if [ "$PV" == "9999" ]; then
 	KEYWORDS=""
 else
 	SRC_URI="mirror://sourceforge/project/${PN}/${PN}/${PV}/${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+	KEYWORDS="~amd64 ~x86"
 fi
 
 LICENSE="GPL-2"
@@ -30,6 +30,8 @@ RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
 		dev-libs/libxslt
 		graphviz? ( media-gfx/graphviz )
 		app-text/docbook-xml-dtd:4.5
+		app-text/dblatex
+		|| ( www-client/w3m www-client/lynx )
 		highlight? ( || ( dev-python/pygments[${PYTHON_USEDEP}] dev-util/source-highlight ) )
 		${PYTHON_DEPS}
 "

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 pypy )
 [ "$PV" == "9999" ] && inherit mercurial autotools
 inherit python-single-r1
 
-DESCRIPTION="A text document format for writing short documents, articles, books and UNIX man pages"
+DESCRIPTION="AsciiDoc is a plain text human readable/writable document format"
 HOMEPAGE="http://www.methods.co.nz/asciidoc/"
 if [ "$PV" == "9999" ]; then
 	EHG_REPO_URI="https://asciidoc.googlecode.com/hg/"

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -32,7 +32,7 @@ RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
 		app-text/docbook-xml-dtd:4.5
 		app-text/dblatex
 		|| ( www-client/w3m www-client/lynx )
-		highlight? ( || ( dev-python/pygments[${PYTHON_USEDEP}] dev-util/source-highlight app-text/highlight ) )
+		highlight? ( || ( dev-util/source-highlight dev-python/pygments[${PYTHON_USEDEP}] app-text/highlight ) )
 		${PYTHON_DEPS}
 "
 DEPEND="test? ( dev-util/source-highlight

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -32,7 +32,10 @@ RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
 		app-text/docbook-xml-dtd:4.5
 		app-text/dblatex
 		|| ( www-client/w3m www-client/lynx )
-		highlight? ( || ( dev-util/source-highlight dev-python/pygments[${PYTHON_USEDEP}] app-text/highlight ) )
+		highlight? ( || ( dev-util/source-highlight \
+			dev-python/pygments[${PYTHON_USEDEP}] \
+			app-text/highlight )
+		)
 		${PYTHON_DEPS}
 "
 DEPEND="test? ( dev-util/source-highlight

--- a/app-text/asciidoc/metadata.xml
+++ b/app-text/asciidoc/metadata.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<herd>proxy-maintainers</herd>
 	<maintainer>
-		<email>djc@gentoo.org</email>
-		<name>Dirkjan Ochtman</name>
+		<email>marcec@gmx.de</email>
+		<name>Marc Joliet</name>
+		<description>Proxied maintainer. Assign bugs to him.</description>
 	</maintainer>
 	<use>
 		<flag name="highlight">Enable source code highlighting</flag>


### PR DESCRIPTION
(This is a continuation of PR #291, which is thus obsolete.)

This small patch series attempts to fix some dependency issues with app-text/asciidoc, as detailed in bug #366763. It revbumps app-text/asciidoc to add a dependency on dblatex and on www-client/w3m or www-client/lynx, one of which is needed for the text output of a2x to work (i.e., `a2x -f text`).  I will probably add app-text/highlight as another alternative to dev-python/pygments after I've tested it.

Furthermore, I have added myself as proxy-maintainer at the suggestion of @djc and removed him as maintainer.