### PR TITLE
=app-arch/lha-114i-r7: fails with automake-1.13 - error: 'AM_CONFIG_HEADER': this macro is obsolete

### DIFF
--- a/app-arch/lha/files/lha-114i-fix-getopt_long-declaration.patch
+++ b/app-arch/lha/files/lha-114i-fix-getopt_long-declaration.patch
@@ -1,0 +1,11 @@
+--- src/getopt_long.c.orig      2013-12-18 16:05:59.789413528 -0600
++++ src/getopt_long.c   2013-12-18 16:06:01.200420472 -0600
+@@ -64,7 +64,7 @@
+ 
+ #ifndef USE_GNU
+ #include <stdio.h>
+-#include <getopt_long.h>
++#include "getopt_long.h"
+ 
+ char *optarg;
+ int optind;

--- a/app-arch/lha/lha-114i-r8.ebuild
+++ b/app-arch/lha/lha-114i-r8.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+#Id$
+
+EAPI=5
+inherit autotools eutils flag-o-matic
+
+MY_P=${PN}-1.14i-ac20050924p1
+
+DESCRIPTION="Utility for creating and opening lzh archives"
+HOMEPAGE="http://lha.sourceforge.jp"
+SRC_URI="mirror://sourceforge.jp/${PN}/22231/${MY_P}.tar.gz"
+
+LICENSE="lha"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~m68k-mint"
+IUSE=""
+
+S=${WORKDIR}/${MY_P}
+
+src_prepare() {
+        epatch "${FILESDIR}"/${P}-file-list-from-stdin.patch
+        epatch "${FILESDIR}"/${P}-fix-getopt_long-declaration.patch
+
+        sed -e '/^AM_C_PROTOTYPES/d' \
+                -e 's/^AM_CONFIG_HEADER/AC_CONFIG_HEADERS/' \
+                -i configure.ac || die #423125, 467544
+
+        eautoreconf
+}
+
+src_configure() {
+        append-cppflags -DPROTOTYPES #423125
+
+        if [[ ${CHOST} == *-interix* ]]; then
+                export ac_cv_header_inttypes_h=no
+                export ac_cv_func_iconv=no
+        fi
+
+        econf
+}
+
+src_install() {
+        emake \
+                DESTDIR="${D}" \
+                mandir="${EPREFIX}"/usr/share/man/ja \
+                install
+
+        dodoc ChangeLog Hacking_of_LHa
+}


### PR DESCRIPTION
Fixes bug #467544