### PR TITLE
net-nntp/sabnzbd add systemd service file

### DIFF
--- a/net-nntp/sabnzbd/files/disable_growl_by_default.patch
+++ b/net-nntp/sabnzbd/files/disable_growl_by_default.patch
@@ -1,0 +1,15 @@
+diff --git a/sabnzbd/cfg.py b/sabnzbd/cfg.py
+index 39e418b..509a962 100644
+--- a/sabnzbd/cfg.py
++++ b/sabnzbd/cfg.py
+@@ -238,8 +238,8 @@ no_ipv6 = OptionBool('misc', 'no_ipv6', False)
+ 
+ growl_server = OptionStr('growl', 'growl_server')
+ growl_password = OptionPassword('growl', 'growl_password')
+-growl_enable = OptionBool('growl', 'growl_enable', not sabnzbd.DARWIN_ML)
+-ntfosd_enable = OptionBool('growl', 'ntfosd_enable', not sabnzbd.WIN32 and not sabnzbd.DARWIN)
++growl_enable = OptionBool('growl', 'growl_enable', 0)
++ntfosd_enable = OptionBool('growl', 'ntfosd_enable', 0)
+ ncenter_enable = OptionBool('growl', 'ncenter_enable', sabnzbd.DARWIN)
+ notify_classes = OptionList('growl', 'notify_classes', NOTIFY_KEYS)
+ 

--- a/net-nntp/sabnzbd/files/sabnzbd_at.service
+++ b/net-nntp/sabnzbd/files/sabnzbd_at.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=SABnzbd binary newsreader
+
+[Service]
+ExecStart=/usr/bin/sabnzbd --logging 1 --browser 0
+User=%I
+Group=%I
+
+[Install]
+WantedBy=multi-user.target

--- a/net-nntp/sabnzbd/sabnzbd-0.7.20.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-0.7.20.ebuild
@@ -8,7 +8,7 @@ EAPI="4"
 PYTHON_DEPEND="2:2.6"
 PYTHON_USE_WITH="sqlite"
 
-inherit eutils python user
+inherit eutils python user systemd
 
 MY_P="${P/sab/SAB}"
 
@@ -66,6 +66,7 @@ src_prepare() {
 	epatch "${FILESDIR}"/use-system-configobj-and-feedparser.patch
 	epatch "${FILESDIR}"/growler-support-gntp-1.0.patch
 	epatch "${FILESDIR}"/par2cmdline.patch
+	epatch "${FILESDIR}"/disable_growl_by_default.patch
 
 	# remove bundled modules
 	rm -r sabnzbd/utils/{feedparser,configobj}.py || die
@@ -99,6 +100,8 @@ src_install() {
 	doins "${FILESDIR}/${PN}.ini"
 
 	dodoc {ABOUT,CHANGELOG,ISSUES,README}.txt Sample-PostProc.sh licenses/*
+
+	systemd_newunit "${FILESDIR}"/sabnzbd_at.service 'sabnzbd@.service'
 }
 
 pkg_postinst() {
@@ -110,6 +113,8 @@ pkg_postinst() {
 	einfo "to add a user to the sabnzbd group so it can edit sabnzbd files"
 	einfo ""
 	einfo "By default sabnzbd will listen on 127.0.0.1:8080"
+	einfo "As growl isn't default notification system on gentoo we disable it."
+	einfo "By default notifications are forwarded to the 23053 port(gntp)."
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Add systemd service file. Disable growl notifications
by default, so that connection refused error doesn't
show up on launch.