### PR TITLE
eselect-python / python*: Replace python-wrapper with python-exec fully

### DIFF
--- a/app-eselect/eselect-python/eselect-python-99999999.ebuild
+++ b/app-eselect/eselect-python/eselect-python-99999999.ebuild
@@ -2,8 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-# Keep the EAPI low here because everything else depends on it.
-# We want to make upgrading simpler.
+EAPI=5
 
 if [[ ${PV} == "99999999" ]] ; then
 	inherit autotools git-r3
@@ -22,21 +21,26 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE=""
 
-RDEPEND=">=app-admin/eselect-1.2.3"
+# TODO: add appropriate >= dep on python-exec
+RDEPEND=">=app-admin/eselect-1.2.3
+	dev-lang/python-exec:2
+	!<dev-lang/python-2.7.10-r3:2.7
+	!<dev-lang/python-3.3.5-r3:3.3
+	!<dev-lang/python-3.4.3-r3:3.4
+	!<dev-lang/python-3.5.0-r2:3.5"
 
-src_unpack() {
-	if [[ ${PV} == "99999999" ]] ; then
-		git-r3_src_unpack
-		cd "${S}"
-		eautoreconf
-	else
-		unpack ${A}
-	fi
+src_prepare() {
+	[[ ${PV} == "99999999" ]] && eautoreconf
 }
 
 src_install() {
 	keepdir /etc/env.d/python
 	emake DESTDIR="${D}" install || die
+
+	local f
+	for f in python{,2,3}{,-config} 2to3 pydoc pyvenv; do
+		dosym ../lib/python-exec/python-exec2 /usr/bin/"${f}"
+	done
 }
 
 pkg_postinst() {

--- a/app-eselect/eselect-python/eselect-python-99999999.ebuild
+++ b/app-eselect/eselect-python/eselect-python-99999999.ebuild
@@ -8,6 +8,7 @@
 if [[ ${PV} == "99999999" ]] ; then
 	inherit autotools git-r3
 	EGIT_REPO_URI="git://anongit.gentoo.org/proj/${PN}.git"
+	EGIT_BRANCH="mgornys-hackery"
 else
 	SRC_URI="mirror://gentoo/${P}.tar.bz2
 		https://dev.gentoo.org/~floppym/dist/${P}.tar.bz2"

--- a/dev-lang/python-exec/python-exec-2.9999.ebuild
+++ b/dev-lang/python-exec/python-exec-2.9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 #if LIVE
 AUTOTOOLS_AUTORECONF=yes
 EGIT_REPO_URI="https://bitbucket.org/mgorny/${PN}.git"
-EGIT_BRANCH="python-exec2"
+EGIT_BRANCH="mgornys-eselect-python-hackery"
 
 inherit git-r3
 #endif

--- a/dev-lang/python/python-2.7.10-r3.ebuild
+++ b/dev-lang/python/python-2.7.10-r3.ebuild
@@ -304,7 +304,7 @@ src_install() {
 		-i "${ED}etc/conf.d/pydoc-${SLOT}" "${ED}etc/init.d/pydoc-${SLOT}" || die "sed failed"
 
 	# for python-exec
-	local vars=( EPYTHON PYTHON_SITEDIR )
+	local vars=( EPYTHON PYTHON_SITEDIR PYTHON_SCRIPTDIR )
 
 	# if not using a cross-compiler, use the fresh binary
 	if ! tc-is-cross-compiler; then
@@ -317,6 +317,25 @@ src_install() {
 	python_export "python${SLOT}" "${vars[@]}"
 	echo "EPYTHON='${EPYTHON}'" > epython.py || die
 	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${SLOT%.*}
+	mkdir -p "${D}${PYTHON_SCRIPTDIR}" || die
+	# python and pythonX
+	ln -s "../../../bin/python${SLOT}" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}" || die
+	ln -s "python${pymajor}" \
+		"${D}${PYTHON_SCRIPTDIR}/python" || die
+	# python-config and pythonX-config
+	ln -s "../../../bin/python${SLOT}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${SLOT}" \
+		"${D}${PYTHON_SCRIPTDIR}/2to3" || die
+	ln -s "../../../bin/pydoc${SLOT}" \
+		"${D}${PYTHON_SCRIPTDIR}/pydoc" || die
 }
 
 pkg_preinst() {

--- a/dev-lang/python/python-3.3.5-r3.ebuild
+++ b/dev-lang/python/python-3.3.5-r3.ebuild
@@ -291,7 +291,7 @@ src_install() {
 		-i "${ED}etc/conf.d/pydoc-${PYVER}" "${ED}etc/init.d/pydoc-${PYVER}" || die "sed failed"
 
 	# for python-exec
-	local vars=( EPYTHON PYTHON_SITEDIR )
+	local vars=( EPYTHON PYTHON_SITEDIR PYTHON_SCRIPTDIR )
 
 	# if not using a cross-compiler, use the fresh binary
 	if ! tc-is-cross-compiler; then
@@ -304,6 +304,27 @@ src_install() {
 	python_export "python${PYVER}" "${vars[@]}"
 	echo "EPYTHON='${EPYTHON}'" > epython.py || die
 	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	mkdir -p "${D}${PYTHON_SCRIPTDIR}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}" || die
+	ln -s "python${pymajor}" \
+		"${D}${PYTHON_SCRIPTDIR}/python" || die
+	# python-config and pythonX-config
+	ln -s "../../../bin/${abiver}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pydoc" || die
+	ln -s "../../../bin/pyvenv-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pyvenv" || die
 }
 
 pkg_preinst() {

--- a/dev-lang/python/python-3.4.3-r3.ebuild
+++ b/dev-lang/python/python-3.4.3-r3.ebuild
@@ -274,7 +274,7 @@ src_install() {
 		-i "${ED}etc/conf.d/pydoc-${PYVER}" "${ED}etc/init.d/pydoc-${PYVER}" || die "sed failed"
 
 	# for python-exec
-	local vars=( EPYTHON PYTHON_SITEDIR )
+	local vars=( EPYTHON PYTHON_SITEDIR PYTHON_SCRIPTDIR )
 
 	# if not using a cross-compiler, use the fresh binary
 	if ! tc-is-cross-compiler; then
@@ -287,6 +287,27 @@ src_install() {
 	python_export "python${PYVER}" "${vars[@]}"
 	echo "EPYTHON='${EPYTHON}'" > epython.py || die
 	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	mkdir -p "${D}${PYTHON_SCRIPTDIR}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}" || die
+	ln -s "python${pymajor}" \
+		"${D}${PYTHON_SCRIPTDIR}/python" || die
+	# python-config and pythonX-config
+	ln -s "../../../bin/${abiver}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pydoc" || die
+	ln -s "../../../bin/pyvenv-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pyvenv" || die
 }
 
 pkg_preinst() {

--- a/dev-lang/python/python-3.5.0-r2.ebuild
+++ b/dev-lang/python/python-3.5.0-r2.ebuild
@@ -277,7 +277,7 @@ src_install() {
 		-i "${ED}etc/conf.d/pydoc-${PYVER}" "${ED}etc/init.d/pydoc-${PYVER}" || die "sed failed"
 
 	# for python-exec
-	local vars=( EPYTHON PYTHON_SITEDIR )
+	local vars=( EPYTHON PYTHON_SITEDIR PYTHON_SCRIPTDIR )
 
 	# if not using a cross-compiler, use the fresh binary
 	if ! tc-is-cross-compiler; then
@@ -290,6 +290,27 @@ src_install() {
 	python_export "python${PYVER}" "${vars[@]}"
 	echo "EPYTHON='${EPYTHON}'" > epython.py || die
 	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	mkdir -p "${D}${PYTHON_SCRIPTDIR}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}" || die
+	ln -s "python${pymajor}" \
+		"${D}${PYTHON_SCRIPTDIR}/python" || die
+	# python-config and pythonX-config
+	ln -s "../../../bin/${abiver}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pydoc" || die
+	ln -s "../../../bin/pyvenv-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pyvenv" || die
 }
 
 pkg_preinst() {

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -45,6 +45,7 @@ sci-chemistry/pymol-apbs-plugin
 # Michał Górny <mgorny@gentoo.org> (11 Nov 2015)
 # Cleaned up Python versions masked for testing:
 # - python-config-X.Y compatibility removed,
+# - python-exec symlinks added (to replace eselect-python's wrapper),
 # - ABIFLAGS reintroduced for 3.3+.
 # Resulting API/ABI change can break reverse dependencies, especially
 # if upstream hardcodes paths or library names.


### PR DESCRIPTION
My new WiP fun. The idea is rather simple: Python implementations install appropriate symlinks (python, python2, python-config, ...) in PYTHON_SCRIPTDIR (/usr/lib/python-exec/*). Then, eselect-python installs appropriate python-exec symlinks in /usr/bin. And we can get rid of python-wrapper and inconsistent python[23] symlinks, and have them replaced with python-exec's regular wrapping.