### PR TITLE
dev-libs/libindicator: Reference upstream bug report for patch

### DIFF
--- a/dev-libs/libindicator/libindicator-12.10.1-r301.ebuild
+++ b/dev-libs/libindicator/libindicator-12.10.1-r301.ebuild
@@ -21,6 +21,7 @@ DEPEND="${RDEPEND}
 	test? ( dev-util/dbus-test-runner )"
 
 src_prepare() {
+	# https://bugs.launchpad.net/libindicator/+bug/1502925
 	epatch "${FILESDIR}"/${PN}-ldflags-spacing.patch
 	eautoreconf
 }


### PR DESCRIPTION
Patches should reference upstream bug reports so people can quickly
find discussion on a particular issue.

Package-Manager: portage-2.2.24