### PR TITLE
net-p2p/deluge - Bump to 1.3.12

### DIFF
--- a/net-p2p/deluge/deluge-1.3.12.ebuild
+++ b/net-p2p/deluge/deluge-1.3.12.ebuild
@@ -27,6 +27,7 @@ SLOT="0"
 IUSE="geoip gtk libnotify setproctitle sound webinterface"
 
 DEPEND=">=net-libs/rb_libtorrent-0.14.9[python]
+	dev-python/setuptools[${PYTHON_USEDEP}]
 	dev-util/intltool"
 RDEPEND=">=net-libs/rb_libtorrent-0.14.9[python]
 	dev-python/chardet[${PYTHON_USEDEP}]


### PR DESCRIPTION
Bump to new version
Remove old
Fix setuptools dependency (gentoo bug #561398)