### PR TITLE
gnome2-utils: fix stderr noise

### DIFF
--- a/eclass/gnome2-utils.eclass
+++ b/eclass/gnome2-utils.eclass
@@ -480,6 +480,7 @@ gnome2_disable_deprecation_warning() {
 	# The sort is important to ensure .am is listed before the respective .in for
 	# maintainer mode regeneration not kicking in due to .am being newer than .in
 	while read makefile ; do
+		[[ -f ${makefile} ]] || continue
 		if ! grep -qE "(DISABLE_DEPRECATED|GSEAL_ENABLE)" "${makefile}"; then
 			continue
 		fi


### PR DESCRIPTION
Fixes stderr-spew in webkit-gtk-2.8.5, like (whitespace manipulated for legibility):

	>>> Preparing source in /var/tmp/portage/net-libs/webkit-gtk-2.8.5/work/webkitgtk-2.8.5 ...
	 * Applying webkit-gtk-2.8.5-fix-ia64-build.patch ... [ ok ]
	 * Applying webkit-gtk-2.8.5-fix-alpha-build.patch ... [ ok ]
	 * Applying webkit-gtk-2.8.5-webkit2gtkinjectedbundle-j1.patch ... [ ok ]
	 * Fixing OMF Makefiles ... [ ok ]
	 * Disabling deprecation warnings ...
>	grep: configure: No such file or directory [ ok ]
	>>> Source prepared.

The message appears to be completely harmless manifestation of a probably (and, in the above
instance, actually) harmless circumstance.  But it's as useless as harmless and distracting.

After some good old-fashioned O(log(lines-of-potentially-culpable-source-code)) track-downification
this turned out to be coming from gnome2-utils.eclass's gnome2_disable_deprecation_warning, which
simply assumed there would be a configure file to grep, probably failing to fail erroneously,....
erroneously.

Whatever... it's late.... famous last words, probably, but, just trust me: the code is wrong &
this makes it right.

Signed-off-by: Gregory M. Turner <gmt@be-evil.net>