### PR TITLE
app-text/asciidoc: remove vim-syntax from IUSE

### DIFF
--- a/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~spa
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="examples graphviz highlight test vim-syntax"
+IUSE="examples graphviz highlight test"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
@@ -44,15 +44,6 @@ REQUISITES for a list of runtime dependencies.
 "
 
 src_prepare() {
-	if ! use vim-syntax; then
-		sed -i -e '/^install/s/install-vim//' Makefile.in || die
-	else
-		sed -i\
-			-e "/^vimdir/s:@sysconfdir@/vim:${EPREFIX}/usr/share/vim/vimfiles:" \
-			-e 's:/etc/vim::' \
-			Makefile.in || die
-	fi
-
 	# Only needed for prefix - harmless (does nothing) otherwise
 	sed -i -e "s:^CONF_DIR=.*:CONF_DIR='${EPREFIX}/etc/asciidoc':" \
 		"${S}/asciidoc.py" || die
@@ -63,8 +54,6 @@ src_configure() {
 }
 
 src_install() {
-	use vim-syntax && dodir /usr/share/vim/vimfiles
-
 	emake DESTDIR="${D}" install
 
 	python_fix_shebang "${ED}"/usr/bin/*.py

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -22,7 +22,7 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="examples graphviz highlight test vim-syntax"
+IUSE="examples graphviz highlight test"
 
 REQUIRED_USE="highlight? ( ${PYTHON_REQUIRED_USE} )"
 
@@ -58,15 +58,6 @@ if [ "$PV" == "9999" ]; then
 fi
 
 src_prepare() {
-	if ! use vim-syntax; then
-		sed -i -e '/^install/s/install-vim//' Makefile.in || die
-	else
-		sed -i\
-			-e "/^vimdir/s:@sysconfdir@/vim:${EPREFIX}/usr/share/vim/vimfiles:" \
-			-e 's:/etc/vim::' \
-			Makefile.in || die
-	fi
-
 	# Only needed for prefix - harmless (does nothing) otherwise
 	sed -i -e "s:^CONF_DIR=.*:CONF_DIR='${EPREFIX}/etc/asciidoc':" \
 		"${S}/asciidoc.py" || die
@@ -88,8 +79,6 @@ src_compile() {
 }
 
 src_install() {
-	use vim-syntax && dodir /usr/share/vim/vimfiles
-
 	emake DESTDIR="${D}" install
 
 	python_fix_shebang "${ED}"/usr/bin/*.py


### PR DESCRIPTION
The vim-syntax USE flag is useless now, for the following reasons:

- The actions it controls have no effect, since the Makefile.in doesn't do
  anything vim-related anymore, as mentioned in the CHANGELOG.
- Vim comes with its own syntax file since version 7.4, which is maintained (by
  AsciiDoc upstream, according to its header) and was last updated in 2014,
  whereas the upstream syntax file has not been changed since 2013.

Gentoo-bug: 530808
Signed-off-by: Marc Joliet <marcec@gmx.de>