### PR TITLE
app-text/asciidoc-8.6.9-r2: fix docompress call

### DIFF
--- a/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r2.ebuild
@@ -77,8 +77,8 @@ src_install() {
 	# uncompressed, and there won't be any broken links. See bug #483336.
 	if use examples; then
 		cp -rL examples/website "${D}"/usr/share/doc/${PF}/examples || die
+		docompress -x /usr/share/doc/${PF}/examples
 	fi
-	docompress -x /usr/share/doc/${PF}/examples
 }
 
 src_test() {


### PR DESCRIPTION
Docompress should only be called when USE=examples.

Gentoo-bug: 555400
Signed-off-by: Marc Joliet <marcec@gmx.de>