### PR TITLE
Gnome xdg eclasses

### DIFF
--- a/eclass/gnome2-utils.eclass
+++ b/eclass/gnome2-utils.eclass
@@ -106,9 +106,9 @@ gnome2_environment_reset() {
 # This function should be called from pkg_preinst.
 gnome2_gconf_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" &> /dev/null
+	pushd "${ED}" &> /dev/null || die
 	export GNOME2_ECLASS_SCHEMAS=$(find 'etc/gconf/schemas/' -name '*.schemas' 2> /dev/null)
-	popd &> /dev/null
+	popd &> /dev/null || die
 }
 
 # @FUNCTION: gnome2_gconf_install
@@ -200,9 +200,9 @@ gnome2_gconf_uninstall() {
 # This function should be called from pkg_preinst.
 gnome2_icon_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" &> /dev/null
+	pushd "${ED}" &> /dev/null || die
 	export GNOME2_ECLASS_ICONS=$(find 'usr/share/icons' -maxdepth 1 -mindepth 1 -type d 2> /dev/null)
-	popd &> /dev/null
+	popd &> /dev/null || die
 }
 
 # @FUNCTION: gnome2_icon_cache_update
@@ -321,9 +321,9 @@ gnome2_omf_fix() {
 # This function should be called from pkg_preinst.
 gnome2_scrollkeeper_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" &> /dev/null
+	pushd "${ED}" &> /dev/null || die
 	export GNOME2_ECLASS_SCROLLS=$(find 'usr/share/omf' -type f -name "*.omf" 2> /dev/null)
-	popd &> /dev/null
+	popd &> /dev/null || die
 }
 
 # @FUNCTION: gnome2_scrollkeeper_update
@@ -356,9 +356,9 @@ gnome2_scrollkeeper_update() {
 # This function should be called from pkg_preinst.
 gnome2_schemas_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" &>/dev/null
+	pushd "${ED}" &>/dev/null || die
 	export GNOME2_ECLASS_GLIB_SCHEMAS=$(find 'usr/share/glib-2.0/schemas' -name '*.gschema.xml' 2>/dev/null)
-	popd &>/dev/null
+	popd &>/dev/null || die
 }
 
 # @FUNCTION: gnome2_schemas_update
@@ -392,9 +392,9 @@ gnome2_schemas_update() {
 # This function should be called from pkg_preinst.
 gnome2_gdk_pixbuf_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" 1>/dev/null
+	pushd "${ED}" 1>/dev/null || die
 	export GNOME2_ECLASS_GDK_PIXBUF_LOADERS=$(find usr/lib*/gdk-pixbuf-2.0 -type f 2>/dev/null)
-	popd 1>/dev/null
+	popd 1>/dev/null || die
 }
 
 # @FUNCTION: gnome2_gdk_pixbuf_update

--- a/eclass/gnome2-utils.eclass
+++ b/eclass/gnome2-utils.eclass
@@ -486,7 +486,7 @@ gnome2_disable_deprecation_warning() {
 		fi
 	done < <(find "${S}" -name "Makefile.in" \
 		-o -name "Makefile.am" -o -name "Makefile.decl" \
-		| sort; echo configure)
+		| sort; [[ -f "${S}"/configure ]] && echo configure)
 # TODO: sedding configure.ac can trigger maintainer mode; bug #439602
 #		-o -name "configure.ac" -o -name "configure.in" \
 #		| sort; echo configure)

--- a/eclass/gnome2-utils.eclass
+++ b/eclass/gnome2-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -15,7 +15,7 @@
 #  * GConf schemas management
 #  * scrollkeeper (old Gnome help system) management
 
-inherit eutils multilib
+inherit eutils multilib xdg-utils
 
 case "${EAPI:-0}" in
 	0|1|2|3|4|5) ;;
@@ -90,23 +90,13 @@ DEPEND=">=sys-apps/sed-4"
 # Reset various variables inherited from root's evironment to a reasonable
 # default for ebuilds to help avoid access violations and test failures.
 gnome2_environment_reset() {
+	xdg_environment_reset
+
 	# Respected by >=glib-2.30.1-r1
 	export G_HOME="${T}"
 
 	# GST_REGISTRY is to work around gst utilities trying to read/write /root
 	export GST_REGISTRY="${T}/registry.xml"
-
-	# XXX: code for resetting XDG_* directories should probably be moved into
-	# a separate function in a non-gnome eclass
-	export XDG_DATA_HOME="${T}/.local/share"
-	export XDG_CONFIG_HOME="${T}/.config"
-	export XDG_CACHE_HOME="${T}/.cache"
-	export XDG_RUNTIME_DIR="${T}/run"
-	mkdir -p "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_CACHE_HOME}" \
-		"${XDG_RUNTIME_DIR}"
-	# This directory needs to be owned by the user, and chmod 0700
-	# http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-	chmod 0700 "${XDG_RUNTIME_DIR}"
 }
 
 # @FUNCTION: gnome2_gconf_savelist

--- a/eclass/gnome2-utils.eclass
+++ b/eclass/gnome2-utils.eclass
@@ -106,9 +106,9 @@ gnome2_environment_reset() {
 # This function should be called from pkg_preinst.
 gnome2_gconf_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" &> /dev/null || die
+	pushd "${ED}" > /dev/null || die
 	export GNOME2_ECLASS_SCHEMAS=$(find 'etc/gconf/schemas/' -name '*.schemas' 2> /dev/null)
-	popd &> /dev/null || die
+	popd > /dev/null || die
 }
 
 # @FUNCTION: gnome2_gconf_install
@@ -200,9 +200,9 @@ gnome2_gconf_uninstall() {
 # This function should be called from pkg_preinst.
 gnome2_icon_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" &> /dev/null || die
+	pushd "${ED}" > /dev/null || die
 	export GNOME2_ECLASS_ICONS=$(find 'usr/share/icons' -maxdepth 1 -mindepth 1 -type d 2> /dev/null)
-	popd &> /dev/null || die
+	popd > /dev/null || die
 }
 
 # @FUNCTION: gnome2_icon_cache_update
@@ -321,9 +321,9 @@ gnome2_omf_fix() {
 # This function should be called from pkg_preinst.
 gnome2_scrollkeeper_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" &> /dev/null || die
+	pushd "${ED}" > /dev/null || die
 	export GNOME2_ECLASS_SCROLLS=$(find 'usr/share/omf' -type f -name "*.omf" 2> /dev/null)
-	popd &> /dev/null || die
+	popd > /dev/null || die
 }
 
 # @FUNCTION: gnome2_scrollkeeper_update
@@ -356,9 +356,9 @@ gnome2_scrollkeeper_update() {
 # This function should be called from pkg_preinst.
 gnome2_schemas_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" &>/dev/null || die
+	pushd "${ED}" > /dev/null || die
 	export GNOME2_ECLASS_GLIB_SCHEMAS=$(find 'usr/share/glib-2.0/schemas' -name '*.gschema.xml' 2>/dev/null)
-	popd &>/dev/null || die
+	popd > /dev/null || die
 }
 
 # @FUNCTION: gnome2_schemas_update
@@ -392,9 +392,9 @@ gnome2_schemas_update() {
 # This function should be called from pkg_preinst.
 gnome2_gdk_pixbuf_savelist() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" 1>/dev/null || die
+	pushd "${ED}" > /dev/null || die
 	export GNOME2_ECLASS_GDK_PIXBUF_LOADERS=$(find usr/lib*/gdk-pixbuf-2.0 -type f 2>/dev/null)
-	popd 1>/dev/null || die
+	popd > /dev/null || die
 }
 
 # @FUNCTION: gnome2_gdk_pixbuf_update

--- a/eclass/gnome2.eclass
+++ b/eclass/gnome2.eclass
@@ -10,7 +10,7 @@
 # Exports portage base functions used by ebuilds written for packages using the
 # GNOME framework. For additional functions, see gnome2-utils.eclass.
 
-inherit eutils fdo-mime libtool gnome.org gnome2-utils
+inherit eutils libtool gnome.org gnome2-utils xdg
 
 case "${EAPI:-0}" in
 	4|5)
@@ -74,6 +74,8 @@ gnome2_src_unpack() {
 # Prepare environment for build, fix build of scrollkeeper documentation,
 # run elibtoolize.
 gnome2_src_prepare() {
+	xdg_src_prepare
+
 	# Prevent assorted access violations and test failures
 	gnome2_environment_reset
 
@@ -225,6 +227,7 @@ gnome2_src_install() {
 # @DESCRIPTION:
 # Finds Icons, GConf and GSettings schemas for later handling in pkg_postinst
 gnome2_pkg_preinst() {
+	xdg_pkg_preinst
 	gnome2_gconf_savelist
 	gnome2_icon_savelist
 	gnome2_schemas_savelist
@@ -237,9 +240,8 @@ gnome2_pkg_preinst() {
 # Handle scrollkeeper, GConf, GSettings, Icons, desktop and mime
 # database updates.
 gnome2_pkg_postinst() {
+	xdg_pkg_postinst
 	gnome2_gconf_install
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
 	gnome2_icon_cache_update
 	gnome2_schemas_update
 	gnome2_scrollkeeper_update
@@ -255,8 +257,7 @@ gnome2_pkg_postinst() {
 # @DESCRIPTION:
 # Handle scrollkeeper, GSettings, Icons, desktop and mime database updates.
 gnome2_pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_pkg_postrm
 	gnome2_icon_cache_update
 	gnome2_schemas_update
 	gnome2_scrollkeeper_update

--- a/eclass/gnome2.eclass
+++ b/eclass/gnome2.eclass
@@ -22,7 +22,8 @@ esac
 # @ECLASS-VARIABLE: G2CONF
 # @DEFAULT_UNSET
 # @DESCRIPTION:
-# Extra configure opts passed to econf
+# Extra configure opts passed to econf.
+# Deprecated, pass extra arguments to gnome2_src_configure.
 G2CONF=${G2CONF:-""}
 
 # @ECLASS-VARIABLE: GNOME2_LA_PUNT
@@ -93,10 +94,17 @@ gnome2_src_prepare() {
 # @DESCRIPTION:
 # Gnome specific configure handling
 gnome2_src_configure() {
+	# Deprecated for a long time now, see Gnome team policies
+	if [[ -n ${G2CONF} ]] ; then
+		eqawarn "G2CONF set, please review documentation at https://wiki.gentoo.org/wiki/Project:GNOME/Gnome_Team_Ebuild_Policies#G2CONF_and_src_configure"
+	fi
+
+	local g2conf=()
+
 	# Update the GNOME configuration options
 	if [[ ${GCONF_DEBUG} != 'no' ]] ; then
 		if use debug ; then
-			G2CONF="--enable-debug=yes ${G2CONF}"
+			g2conf+=( --enable-debug=yes )
 		fi
 	fi
 
@@ -109,54 +117,54 @@ gnome2_src_configure() {
 	# Preserve old behavior for older EAPI.
 	if grep -q "enable-gtk-doc" "${ECONF_SOURCE:-.}"/configure ; then
 		if has ${EAPI:-0} 4 && in_iuse doc ; then
-			G2CONF="$(use_enable doc gtk-doc) ${G2CONF}"
+			g2conf+=( $(use_enable doc gtk-doc) )
 		else
-			G2CONF="--disable-gtk-doc ${G2CONF}"
+			g2conf+=( --disable-gtk-doc )
 		fi
 	fi
 
 	# Pass --disable-maintainer-mode when needed
 	if grep -q "^[[:space:]]*AM_MAINTAINER_MODE(\[enable\])" \
 		"${ECONF_SOURCE:-.}"/configure.*; then
-		G2CONF="--disable-maintainer-mode ${G2CONF}"
+		g2conf+=( --disable-maintainer-mode )
 	fi
 
 	# Pass --disable-scrollkeeper when possible
 	if grep -q "disable-scrollkeeper" "${ECONF_SOURCE:-.}"/configure; then
-		G2CONF="--disable-scrollkeeper ${G2CONF}"
+		g2conf+=( --disable-scrollkeeper )
 	fi
 
 	# Pass --disable-silent-rules when possible (not needed for eapi5), bug #429308
 	if has ${EAPI:-0} 4; then
 		if grep -q "disable-silent-rules" "${ECONF_SOURCE:-.}"/configure; then
-			G2CONF="--disable-silent-rules ${G2CONF}"
+			g2conf+=( --disable-silent-rules )
 		fi
 	fi
 
 	# Pass --disable-schemas-install when possible
 	if grep -q "disable-schemas-install" "${ECONF_SOURCE:-.}"/configure; then
-		G2CONF="--disable-schemas-install ${G2CONF}"
+		g2conf+=( --disable-schemas-install )
 	fi
 
 	# Pass --disable-schemas-compile when possible
 	if grep -q "disable-schemas-compile" "${ECONF_SOURCE:-.}"/configure; then
-		G2CONF="--disable-schemas-compile ${G2CONF}"
+		g2conf+=( --disable-schemas-compile )
 	fi
 
 	# Pass --enable-compile-warnings=minimum as we don't want -Werror* flags, bug #471336
 	if grep -q "enable-compile-warnings" "${ECONF_SOURCE:-.}"/configure; then
-		G2CONF="--enable-compile-warnings=minimum ${G2CONF}"
+		g2conf+=( --enable-compile-warnings=minimum )
 	fi
 
 	# Pass --docdir with proper directory, bug #482646
 	if grep -q "^ *--docdir=" "${ECONF_SOURCE:-.}"/configure; then
-		G2CONF="--docdir="${EPREFIX}"/usr/share/doc/${PF} ${G2CONF}"
+		g2conf+=( --docdir="${EPREFIX}"/usr/share/doc/${PF} )
 	fi
 
 	# Avoid sandbox violations caused by gnome-vfs (bug #128289 and #345659)
 	addwrite "$(unset HOME; echo ~)/.gnome2"
 
-	econf ${G2CONF} "$@"
+	econf ${g2conf[@]} ${G2CONF} "$@"
 }
 
 # @FUNCTION: gnome2_src_compile

--- a/eclass/gstreamer.eclass
+++ b/eclass/gstreamer.eclass
@@ -23,7 +23,7 @@
 # plugin, consider adding media-plugins/gst-plugins-meta dependency, but
 # also list any packages that provide explicitly requested plugins.
 
-inherit eutils multilib multilib-minimal toolchain-funcs versionator
+inherit eutils multilib multilib-minimal toolchain-funcs versionator xdg-utils
 
 case "${EAPI:-0}" in
 	5)
@@ -132,11 +132,7 @@ DEPEND="${DEPEND} ${RDEPEND}"
 # >=dev-lang/orc-0.4.23 rely on environment variables to find a place to
 # allocate files to mmap.
 gstreamer_environment_reset() {
-	export XDG_RUNTIME_DIR="${T}/run"
-	mkdir -p "${XDG_RUNTIME_DIR}"
-	# This directory needs to be owned by the user, and chmod 0700
-	# http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-	chmod 0700 "${XDG_RUNTIME_DIR}"
+	xdg_environment_reset
 }
 
 # @FUNCTION: gstreamer_get_plugins

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -54,10 +54,10 @@ xdg_environment_reset() {
 	export XDG_CACHE_HOME="${T}/.cache"
 	export XDG_RUNTIME_DIR="${T}/run"
 	mkdir -p "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_CACHE_HOME}" \
-		"${XDG_RUNTIME_DIR}"
+		"${XDG_RUNTIME_DIR}" || die
 	# This directory needs to be owned by the user, and chmod 0700
 	# http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-	chmod 0700 "${XDG_RUNTIME_DIR}"
+	chmod 0700 "${XDG_RUNTIME_DIR}" || die
 
 	unset DBUS_SESSION_BUS_ADDRESS
 }

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -49,9 +49,9 @@ esac
 # Clean up environment for clean builds.
 xdg_environment_reset() {
 	# Prepare XDG base directories
-	export XDG_DATA_HOME="${T}/.local/share"
-	export XDG_CONFIG_HOME="${T}/.config"
-	export XDG_CACHE_HOME="${T}/.cache"
+	export XDG_DATA_HOME="${HOME}/.local/share"
+	export XDG_CONFIG_HOME="${HOME}/.config"
+	export XDG_CACHE_HOME="${HOME}/.cache"
 	export XDG_RUNTIME_DIR="${T}/run"
 	mkdir -p "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_CACHE_HOME}" \
 		"${XDG_RUNTIME_DIR}" || die

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -58,6 +58,8 @@ xdg_environment_reset() {
 	# This directory needs to be owned by the user, and chmod 0700
 	# http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 	chmod 0700 "${XDG_RUNTIME_DIR}"
+
+	unset DBUS_SESSION_BUS_ADDRESS
 }
 
 # @FUNCTION: xdg_desktopfiles_savelist

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -1,0 +1,127 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+# @ECLASS: xdg-utils.eclass
+# @MAINTAINER:
+# gnome@gentoo.org
+# @AUTHOR:
+# Original author: Gilles Dartiguelongue <eva@gentoo.org>
+# @BLURB: Auxiliary functions commonly used by XDG compliant packages.
+# @DESCRIPTION:
+# This eclass provides a set of auxiliary functions needed by most XDG
+# compliant packages.
+# It provides XDG stack related functions such as:
+#  * XDG .desktop files cache management
+#  * XDG mime information database management
+
+case "${EAPI:-0}" in
+	4|5|6) ;;
+	*) die "EAPI=${EAPI} is not supported" ;;
+esac
+
+# @ECLASS-VARIABLE: DESKTOP_DATABASE_UPDATE_BIN
+# @INTERNAL
+# @DESCRIPTION:
+# Path to update-desktop-database
+: ${DESKTOP_DATABASE_UPDATE_BIN:="/usr/bin/update-desktop-database"}
+
+# @ECLASS-VARIABLE: DESKTOP_DATABASE_DIR
+# @INTERNAL
+# @DESCRIPTION:
+# Directory where .desktop files database is stored
+: ${DESKTOP_DATABASE_DIR="/usr/share/applications"}
+
+# @ECLASS-VARIABLE: MIMEINFO_DATABASE_UPDATE_BIN
+# @INTERNAL
+# @DESCRIPTION:
+# Path to update-desktop-database
+: ${MIMEINFO_DATABASE_UPDATE_BIN:="/usr/bin/update-mime-database"}
+
+# @ECLASS-VARIABLE: MIMEINFO_DATABASE_DIR
+# @INTERNAL
+# @DESCRIPTION:
+# Directory where .desktop files database is stored
+: ${MIMEINFO_DATABASE_DIR:="/usr/share/mime"}
+
+# @FUNCTION: xdg_environment_reset
+# @DESCRIPTION:
+# Clean up environment for clean builds.
+xdg_environment_reset() {
+	# Prepare XDG base directories
+	export XDG_DATA_HOME="${T}/.local/share"
+	export XDG_CONFIG_HOME="${T}/.config"
+	export XDG_CACHE_HOME="${T}/.cache"
+	export XDG_RUNTIME_DIR="${T}/run"
+	mkdir -p "${XDG_DATA_HOME}" "${XDG_CONFIG_HOME}" "${XDG_CACHE_HOME}" \
+		"${XDG_RUNTIME_DIR}"
+	# This directory needs to be owned by the user, and chmod 0700
+	# http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+	chmod 0700 "${XDG_RUNTIME_DIR}"
+}
+
+# @FUNCTION: xdg_desktopfiles_savelist
+# @DESCRIPTION:
+# Find the .desktop files about to be installed and save their location
+# in the XDG_ECLASS_DESKTOPFILES environment variable.
+# This function should be called from pkg_preinst.
+xdg_desktopfiles_savelist() {
+	pushd "${D}" > /dev/null || die
+	export XDG_ECLASS_DESKTOPFILES=$(find 'usr/share/applications' -type f 2> /dev/null)
+	popd > /dev/null || die
+}
+
+# @FUNCTION: fdo-xdg_desktop_database_update
+# @DESCRIPTION:
+# Updates the .desktop files database.
+# Generates a list of mimetypes linked to applications that can handle them
+xdg_desktop_database_update() {
+	local updater="${EROOT}${DESKTOP_DATABASE_UPDATE_BIN}"
+
+	if [[ ! -x "${updater}" ]] ; then
+		debug-print "${updater} is not executable"
+		return
+	fi
+
+	if [[ -z "${XDG_ECLASS_DESKTOPFILES}" ]]; then
+		debug-print "No .desktop files to add to database"
+		return
+	fi
+
+	ebegin "Updating .desktop files database ..."
+	"${updater}" -q "${EROOT}${DESKTOP_DATABASE_DIR}"
+	eend $?
+}
+
+# @FUNCTION: xdg_mimeinfo_savelist
+# @DESCRIPTION:
+# Find the mime information files about to be installed and save their location
+# in the XDG_ECLASS_MIMEINFOFILES environment variable.
+# This function should be called from pkg_preinst.
+xdg_mimeinfo_savelist() {
+	pushd "${D}" > /dev/null || die
+	export XDG_ECLASS_MIMEINFOFILES=$(find 'usr/share/mime' -type f 2> /dev/null)
+	popd > /dev/null || die
+}
+
+# @FUNCTION: xdg_mimeinfo_database_update
+# @DESCRIPTION:
+# Update the mime database.
+# Creates a general list of mime types from several sources
+xdg_mimeinfo_database_update() {
+	local updater="${EROOT}${MIMEINFO_DATABASE_UPDATE_BIN}"
+
+	if [[ ! -x "${updater}" ]] ; then
+		debug-print "${updater} is not executable"
+		return
+	fi
+
+	if [[ -z "${XDG_ECLASS_MIMEINFOFILES}" ]]; then
+		debug-print "No mime info files to add to database"
+		return
+	fi
+
+	ebegin "Updating shared mime info database ..."
+	"${updater}" "${EROOT}${MIMEINFO_DATABASE_DIR}"
+	eend $?
+}

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -69,6 +69,10 @@ xdg_environment_reset() {
 xdg_desktop_database_update() {
 	local updater="${EROOT}${DESKTOP_DATABASE_UPDATE_BIN}"
 
+	if [[ ${EBUILD_PHASE} != post* ]] ; then
+		die "xdg_desktop_database_update must be used in pkg_post* phases."
+	fi
+
 	if [[ ! -x "${updater}" ]] ; then
 		debug-print "${updater} is not executable"
 		return
@@ -85,6 +89,10 @@ xdg_desktop_database_update() {
 # Creates a general list of mime types from several sources
 xdg_mimeinfo_database_update() {
 	local updater="${EROOT}${MIMEINFO_DATABASE_UPDATE_BIN}"
+
+	if [[ ${EBUILD_PHASE} != post* ]] ; then
+		die "xdg_mimeinfo_database_update must be used in pkg_post* phases."
+	fi
 
 	if [[ ! -x "${updater}" ]] ; then
 		debug-print "${updater} is not executable"

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -16,7 +16,7 @@
 #  * XDG mime information database management
 
 case "${EAPI:-0}" in
-	4|5|6) ;;
+	0|1|2|3|4|5|6) ;;
 	*) die "EAPI=${EAPI} is not supported" ;;
 esac
 

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -62,17 +62,6 @@ xdg_environment_reset() {
 	unset DBUS_SESSION_BUS_ADDRESS
 }
 
-# @FUNCTION: xdg_desktopfiles_savelist
-# @DESCRIPTION:
-# Find the .desktop files about to be installed and save their location
-# in the XDG_ECLASS_DESKTOPFILES environment variable.
-# This function should be called from pkg_preinst.
-xdg_desktopfiles_savelist() {
-	pushd "${D}" > /dev/null || die
-	export XDG_ECLASS_DESKTOPFILES=$(find 'usr/share/applications' -type f 2> /dev/null)
-	popd > /dev/null || die
-}
-
 # @FUNCTION: fdo-xdg_desktop_database_update
 # @DESCRIPTION:
 # Updates the .desktop files database.
@@ -85,25 +74,9 @@ xdg_desktop_database_update() {
 		return
 	fi
 
-	if [[ -z "${XDG_ECLASS_DESKTOPFILES}" ]]; then
-		debug-print "No .desktop files to add to database"
-		return
-	fi
-
 	ebegin "Updating .desktop files database ..."
 	"${updater}" -q "${EROOT}${DESKTOP_DATABASE_DIR}"
 	eend $?
-}
-
-# @FUNCTION: xdg_mimeinfo_savelist
-# @DESCRIPTION:
-# Find the mime information files about to be installed and save their location
-# in the XDG_ECLASS_MIMEINFOFILES environment variable.
-# This function should be called from pkg_preinst.
-xdg_mimeinfo_savelist() {
-	pushd "${D}" > /dev/null || die
-	export XDG_ECLASS_MIMEINFOFILES=$(find 'usr/share/mime' -type f 2> /dev/null)
-	popd > /dev/null || die
 }
 
 # @FUNCTION: xdg_mimeinfo_database_update
@@ -115,11 +88,6 @@ xdg_mimeinfo_database_update() {
 
 	if [[ ! -x "${updater}" ]] ; then
 		debug-print "${updater} is not executable"
-		return
-	fi
-
-	if [[ -z "${XDG_ECLASS_MIMEINFOFILES}" ]]; then
-		debug-print "No mime info files to add to database"
 		return
 	fi
 

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -78,7 +78,7 @@ xdg_desktop_database_update() {
 		return
 	fi
 
-	ebegin "Updating .desktop files database ..."
+	ebegin "Updating .desktop files database"
 	"${updater}" -q "${EROOT}${DESKTOP_DATABASE_DIR}"
 	eend $?
 }
@@ -99,7 +99,7 @@ xdg_mimeinfo_database_update() {
 		return
 	fi
 
-	ebegin "Updating shared mime info database ..."
+	ebegin "Updating shared mime info database"
 	"${updater}" "${EROOT}${MIMEINFO_DATABASE_DIR}"
 	eend $?
 }

--- a/eclass/xdg.eclass
+++ b/eclass/xdg.eclass
@@ -1,0 +1,61 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+# @ECLASS: xdg.eclass
+# @MAINTAINER:
+# freedesktop-bugs@gentoo.org
+# @AUTHOR:
+# Original author: Gilles Dartiguelongue <eva@gentoo.org>
+# @BLURB: Provides phases for XDG compliant packages.
+# @DESCRIPTION:
+# Utility eclass to update the desktop and shared mime info as laid
+# out in the freedesktop specs & implementations
+
+inherit xdg-utils
+
+case "${EAPI:-0}" in
+	4|5|6)
+		EXPORT_FUNCTIONS src_prepare pkg_preinst pkg_postinst pkg_postrm
+		;;
+	*) die "EAPI=${EAPI} is not supported" ;;
+esac
+
+DEPEND="
+	dev-util/desktop-file-utils
+	x11-misc/shared-mime-info
+"
+
+# @FUNCTION: xdg_src_prepare
+# @DESCRIPTION:
+# Prepare sources to work with XDG standards.
+xdg_src_prepare() {
+	xdg_environment_reset
+
+	has ${EAPI:-0} 6 && eapply_user
+}
+
+# @FUNCTION: xdg_pkg_preinst
+# @DESCRIPTION:
+# Finds .desktop and mime info files for later handling in pkg_postinst
+xdg_pkg_preinst() {
+	xdg_desktopfiles_savelist
+	xdg_mimeinfo_savelist
+}
+
+# @FUNCTION: xdg_pkg_postinst
+# @DESCRIPTION:
+# Handle desktop and mime info database updates.
+xdg_pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+# @FUNCTION: xdg_pkg_postrm
+# @DESCRIPTION:
+# Handle desktop and mime info database updates.
+xdg_pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+

--- a/eclass/xdg.eclass
+++ b/eclass/xdg.eclass
@@ -15,7 +15,7 @@
 inherit xdg-utils
 
 case "${EAPI:-0}" in
-	0|1|2|3|4|5|6)
+	4|5|6)
 		EXPORT_FUNCTIONS src_prepare pkg_preinst pkg_postinst pkg_postrm
 		;;
 	*) die "EAPI=${EAPI} is not supported" ;;
@@ -41,22 +41,19 @@ xdg_src_prepare() {
 # Locations are stored in XDG_ECLASS_DESKTOPFILES and XDG_ECLASS_MIMEINFOFILES
 # respectively.
 xdg_pkg_preinst() {
-	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
-	pushd "${ED}" > /dev/null || die
-
 	local f
+
 	XDG_ECLASS_DESKTOPFILES=()
 	while IFS= read -r -d '' f; do
 		XDG_ECLASS_DESKTOPFILES+=( ${f} )
-	done < <(find 'usr/share/applications' -type f -print0 2>/dev/null)
+	done < <(cd "${D}" && find 'usr/share/applications' -type f -print0 2>/dev/null)
 
 	XDG_ECLASS_MIMEINFOFILES=()
 	while IFS= read -r -d '' f; do
 		XDG_ECLASS_MIMEINFOFILES+=( ${f} )
-	done < <(find 'usr/share/mime' -type f -print0 2>/dev/null)
+	done < <(cd "${D}" && find 'usr/share/mime' -type f -print0 2>/dev/null)
 
 	export XDG_ECLASS_DESKTOPFILES XDG_ECLASS_MIMEINFOFILES
-	popd > /dev/null || die
 }
 
 # @FUNCTION: xdg_pkg_postinst

--- a/eclass/xdg.eclass
+++ b/eclass/xdg.eclass
@@ -15,7 +15,7 @@
 inherit xdg-utils
 
 case "${EAPI:-0}" in
-	4|5|6)
+	0|1|2|3|4|5|6)
 		EXPORT_FUNCTIONS src_prepare pkg_preinst pkg_postinst pkg_postrm
 		;;
 	*) die "EAPI=${EAPI} is not supported" ;;
@@ -41,8 +41,11 @@ xdg_src_prepare() {
 # Locations are stored in XDG_ECLASS_DESKTOPFILES and XDG_ECLASS_MIMEINFOFILES
 # respectively.
 xdg_pkg_preinst() {
-	export XDG_ECLASS_DESKTOPFILES=( $(cd "${D}" && find 'usr/share/applications' -type f -print0 2> /dev/null) )
-	export XDG_ECLASS_MIMEINFOFILES=( $(cd "${D}" && find 'usr/share/mime' -type f -print0 2> /dev/null) )
+	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
+	pushd "${ED}" > /dev/null || die
+	export XDG_ECLASS_DESKTOPFILES=( $(find 'usr/share/applications' -type f -print0 2> /dev/null) )
+	export XDG_ECLASS_MIMEINFOFILES=( $(find 'usr/share/mime' -type f -print0 2> /dev/null) )
+	popd > /dev/null || die
 }
 
 # @FUNCTION: xdg_pkg_postinst

--- a/eclass/xdg.eclass
+++ b/eclass/xdg.eclass
@@ -43,8 +43,19 @@ xdg_src_prepare() {
 xdg_pkg_preinst() {
 	has ${EAPI:-0} 0 1 2 && ! use prefix && ED="${D}"
 	pushd "${ED}" > /dev/null || die
-	export XDG_ECLASS_DESKTOPFILES=( $(find 'usr/share/applications' -type f -print0 2> /dev/null) )
-	export XDG_ECLASS_MIMEINFOFILES=( $(find 'usr/share/mime' -type f -print0 2> /dev/null) )
+
+	local f
+	XDG_ECLASS_DESKTOPFILES=()
+	while IFS= read -r -d '' f; do
+		XDG_ECLASS_DESKTOPFILES+=( ${f} )
+	done < <(find 'usr/share/applications' -type f -print0 2>/dev/null)
+
+	XDG_ECLASS_MIMEINFOFILES=()
+	while IFS= read -r -d '' f; do
+		XDG_ECLASS_MIMEINFOFILES+=( ${f} )
+	done < <(find 'usr/share/mime' -type f -print0 2>/dev/null)
+
+	export XDG_ECLASS_DESKTOPFILES XDG_ECLASS_MIMEINFOFILES
 	popd > /dev/null || die
 }
 
@@ -52,13 +63,13 @@ xdg_pkg_preinst() {
 # @DESCRIPTION:
 # Handle desktop and mime info database updates.
 xdg_pkg_postinst() {
-	if [[ -n "${XDG_ECLASS_DESKTOPFILES}" ]]; then
+	if [[ ${#XDG_ECLASS_DESKTOPFILES[@]} -gt 0 ]]; then
 		xdg_desktop_database_update
 	else
 		debug-print "No .desktop files to add to database"
 	fi
 
-	if [[ -n "${XDG_ECLASS_MIMEINFOFILES}" ]]; then
+	if [[ ${#XDG_ECLASS_MIMEINFOFILES[@]} -gt 0 ]]; then
 		xdg_mimeinfo_database_update
 	else
 		debug-print "No mime info files to add to database"
@@ -69,13 +80,13 @@ xdg_pkg_postinst() {
 # @DESCRIPTION:
 # Handle desktop and mime info database updates.
 xdg_pkg_postrm() {
-	if [[ -n "${XDG_ECLASS_DESKTOPFILES}" ]]; then
+	if [[ ${#XDG_ECLASS_DESKTOPFILES[@]} -gt 0 ]]; then
 		xdg_desktop_database_update
 	else
 		debug-print "No .desktop files to add to database"
 	fi
 
-	if [[ -n "${XDG_ECLASS_MIMEINFOFILES}" ]]; then
+	if [[ ${#XDG_ECLASS_MIMEINFOFILES[@]} -gt 0 ]]; then
 		xdg_mimeinfo_database_update
 	else
 		debug-print "No mime info files to add to database"

--- a/eclass/xdg.eclass
+++ b/eclass/xdg.eclass
@@ -32,7 +32,7 @@ DEPEND="
 xdg_src_prepare() {
 	xdg_environment_reset
 
-	has ${EAPI:-0} 6 && eapply_user
+	has ${EAPI:-0} 6 && default
 }
 
 # @FUNCTION: xdg_pkg_preinst

--- a/eclass/xdg.eclass
+++ b/eclass/xdg.eclass
@@ -37,25 +37,45 @@ xdg_src_prepare() {
 
 # @FUNCTION: xdg_pkg_preinst
 # @DESCRIPTION:
-# Finds .desktop and mime info files for later handling in pkg_postinst
+# Finds .desktop and mime info files for later handling in pkg_postinst.
+# Locations are stored in XDG_ECLASS_DESKTOPFILES and XDG_ECLASS_MIMEINFOFILES
+# respectively.
 xdg_pkg_preinst() {
-	xdg_desktopfiles_savelist
-	xdg_mimeinfo_savelist
+	export XDG_ECLASS_DESKTOPFILES=( $(cd "${D}" && find 'usr/share/applications' -type f -print0 2> /dev/null) )
+	export XDG_ECLASS_MIMEINFOFILES=( $(cd "${D}" && find 'usr/share/mime' -type f -print0 2> /dev/null) )
 }
 
 # @FUNCTION: xdg_pkg_postinst
 # @DESCRIPTION:
 # Handle desktop and mime info database updates.
 xdg_pkg_postinst() {
-	xdg_desktop_database_update
-	xdg_mimeinfo_database_update
+	if [[ -n "${XDG_ECLASS_DESKTOPFILES}" ]]; then
+		xdg_desktop_database_update
+	else
+		debug-print "No .desktop files to add to database"
+	fi
+
+	if [[ -n "${XDG_ECLASS_MIMEINFOFILES}" ]]; then
+		xdg_mimeinfo_database_update
+	else
+		debug-print "No mime info files to add to database"
+	fi
 }
 
 # @FUNCTION: xdg_pkg_postrm
 # @DESCRIPTION:
 # Handle desktop and mime info database updates.
 xdg_pkg_postrm() {
-	xdg_desktop_database_update
-	xdg_mimeinfo_database_update
+	if [[ -n "${XDG_ECLASS_DESKTOPFILES}" ]]; then
+		xdg_desktop_database_update
+	else
+		debug-print "No .desktop files to add to database"
+	fi
+
+	if [[ -n "${XDG_ECLASS_MIMEINFOFILES}" ]]; then
+		xdg_mimeinfo_database_update
+	else
+		debug-print "No mime info files to add to database"
+	fi
 }
 


### PR DESCRIPTION
History of XDG related discussions:
https://archives.gentoo.org/gentoo-dev/message/3aaccb913b3713b85db3467cd3403f1d
https://archives.gentoo.org/gentoo-dev/message/3014c27e20bbaf300caf9d498a04fbf4
https://archives.gentoo.org/gentoo-dev/message/db3db4151eb15f551ef2f1a1caa0f6ad

Re-reading these threads, I will change $T to $HOME in xdg_environment_reset like proposed by Mike.

Also stacked a couple of other changes for Gnome.

One problem for gnome and gstreamer eclass is that they should basically set a very common set of variables on top of XDG_* and I am not sure if it is better to copy/paste G_HOME & GST_REGISTRY or have the two eclasses call each other environment_reset function, given that gstreamer eclass has no utils variant to avoid importing phase functions.

@gentoo/gnome