### PR TITLE
net-firewall/fwknop: add GitHub repo to HOMEPAGE

### DIFF
--- a/net-firewall/fwknop/fwknop-2.6.7-r1.ebuild
+++ b/net-firewall/fwknop/fwknop-2.6.7-r1.ebuild
@@ -15,7 +15,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools-utils distutils-r1 linux-info readme.gentoo systemd
 
 DESCRIPTION="Single Packet Authorization and Port Knocking application"
-HOMEPAGE="http://www.cipherdyne.org/fwknop/"
+HOMEPAGE="http://www.cipherdyne.org/fwknop/ https://github.com/mrash/fwknop"
 SRC_URI="https://github.com/mrash/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-firewall/fwknop/fwknop-2.6.7-r2.ebuild
+++ b/net-firewall/fwknop/fwknop-2.6.7-r2.ebuild
@@ -15,7 +15,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools-utils distutils-r1 linux-info readme.gentoo systemd
 
 DESCRIPTION="Single Packet Authorization and Port Knocking application"
-HOMEPAGE="http://www.cipherdyne.org/fwknop/"
+HOMEPAGE="http://www.cipherdyne.org/fwknop/ https://github.com/mrash/fwknop"
 SRC_URI="https://github.com/mrash/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
As cipherdyne.org tends to be down sometimes.