### PR TITLE
app-crypt/yubikey-neo-manager: add dev-python/pycrypto to RDEPEND

### DIFF
--- a/app-crypt/yubikey-neo-manager/yubikey-neo-manager-1.1.0-r1.ebuild
+++ b/app-crypt/yubikey-neo-manager/yubikey-neo-manager-1.1.0-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit distutils-r1
+
+DESCRIPTION="Cross platform personalization tool for the YubiKey NEO"
+HOMEPAGE="https://developers.yubico.com/yubikey-neo-manager/"
+SRC_URI="https://developers.yubico.com/${PN}/Releases/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+CDEPEND="
+	dev-python/pyside[webkit,${PYTHON_USEDEP}]
+	dev-python/pycrypto[${PYTHON_USEDEP}]
+	app-crypt/libu2f-host
+	app-crypt/libykneomgr
+	sys-auth/ykpers"
+
+DEPEND="
+	dev-python/docutils[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	>=dev-python/nose-1.0[${PYTHON_USEDEP}]
+	${CDEPEND}"
+
+RDEPEND="${CDEPEND}"
+
+DOCS=( NEWS README )
+
+python_test() {
+	nosetests || die
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+
+	doman scripts/neoman.1
+	domenu resources/neoman.desktop
+	doicon resources/neoman.xpm
+	newicon -s 128 resources/neoman-large.png neoman.png
+}

--- a/app-crypt/yubikey-neo-manager/yubikey-neo-manager-1.2.1-r1.ebuild
+++ b/app-crypt/yubikey-neo-manager/yubikey-neo-manager-1.2.1-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit distutils-r1
+
+DESCRIPTION="Cross platform personalization tool for the YubiKey NEO"
+HOMEPAGE="https://developers.yubico.com/yubikey-neo-manager/"
+SRC_URI="https://developers.yubico.com/${PN}/Releases/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+CDEPEND="
+	dev-python/pyside[webkit,${PYTHON_USEDEP}]
+	dev-python/pycrypto[${PYTHON_USEDEP}]
+	app-crypt/libu2f-host
+	app-crypt/libykneomgr
+	sys-auth/ykpers"
+
+DEPEND="
+	dev-python/docutils[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	>=dev-python/nose-1.0[${PYTHON_USEDEP}]
+	${CDEPEND}"
+
+RDEPEND="${CDEPEND}"
+
+DOCS=( NEWS README )
+
+python_test() {
+	nosetests || die
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+
+	doman scripts/neoman.1
+	domenu resources/neoman.desktop
+	doicon resources/neoman.xpm
+	newicon -s 128 resources/neoman-large.png neoman.png
+}

--- a/app-crypt/yubikey-neo-manager/yubikey-neo-manager-1.3.0-r1.ebuild
+++ b/app-crypt/yubikey-neo-manager/yubikey-neo-manager-1.3.0-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit distutils-r1
+
+DESCRIPTION="Cross platform personalization tool for the YubiKey NEO"
+HOMEPAGE="https://developers.yubico.com/yubikey-neo-manager/"
+SRC_URI="
+	mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
+	https://developers.yubico.com/${PN}/Releases/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+CDEPEND="
+	dev-python/pyside[webkit,${PYTHON_USEDEP}]
+	dev-python/pycrypto[${PYTHON_USEDEP}]
+	app-crypt/libu2f-host
+	app-crypt/libykneomgr
+	sys-auth/ykpers"
+
+DEPEND="
+	dev-python/docutils[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	>=dev-python/nose-1.0[${PYTHON_USEDEP}]
+	${CDEPEND}"
+
+RDEPEND="${CDEPEND}"
+
+DOCS=( NEWS README )
+
+python_test() {
+	nosetests || die
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+
+	doman scripts/neoman.1
+	domenu resources/neoman.desktop
+	doicon resources/neoman.xpm
+	newicon -s 128 resources/neoman-large.png neoman.png
+}


### PR DESCRIPTION
This package has a runtime dependency to pycrypto. Without that, it
fails with the following error:

  Traceback (most recent call last):
    File "/usr/lib/python-exec/python2.7/neoman", line 3, in <module>
      from neoman import main
    File "/usr/lib64/python2.7/site-packages/neoman/main.py", line 33, in <module>
      from neoman.view.main import MainWindow
    File "/usr/lib64/python2.7/site-packages/neoman/view/main.py", line 30, in <module>
      from neoman.model.applet import Applet
    File "/usr/lib64/python2.7/site-packages/neoman/model/applet.py", line 29, in <module>
      from Crypto.Signature import PKCS1_PSS
  ImportError: No module named Crypto.Signature

Package-Manager: portage-2.2.20.1