### PR TITLE
dev-libs/libaio: link against -lc to pull the fortified functions #558406

### DIFF
--- a/dev-libs/libaio/files/libaio-0.3.110-link-stdlib.patch
+++ b/dev-libs/libaio/files/libaio-0.3.110-link-stdlib.patch
@@ -1,0 +1,21 @@
+From: Gokturk Yuksek <gokturk@binghamton.edu>
+Subject: [PATCH] Link against stdlib to resolve fortified functions
+
+When '-fstack-protector-strong' is included in CFLAGS, the function
+'__stack_chk_fail_local' needs to be pulled from libc. However, upstream
+uses '-nostdlib' to avoid linking against any C library or gcc libs. Remove
+'-nostdlib' and '-nostartfiles' to pull the required symbols from libc.
+
+Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=558406
+
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -4,7 +4,7 @@
+ usrlibdir=$(libdir)
+ 
+ CFLAGS ?= -g -fomit-frame-pointer -O2
+-CFLAGS += -nostdlib -nostartfiles -Wall -I. -fPIC
++CFLAGS += -Wall -I. -fPIC
+ CFLAGS += $(CPPFLAGS)
+ SO_CFLAGS=-shared $(CFLAGS)
+ L_CFLAGS=$(CFLAGS)

--- a/dev-libs/libaio/libaio-0.3.110.ebuild
+++ b/dev-libs/libaio/libaio-0.3.110.ebuild
@@ -21,7 +21,8 @@ src_prepare() {
 		"${FILESDIR}"/${PN}-0.3.109-x32.patch \
 		"${FILESDIR}"/${PN}-0.3.109-testcase-8.patch \
 		"${FILESDIR}"/${PN}-0.3.110-cppflags.patch \
-		"${FILESDIR}"/${PN}-0.3.110-optional-werror.patch
+		"${FILESDIR}"/${PN}-0.3.110-optional-werror.patch \
+		"${FILESDIR}"/${PN}-0.3.110-link-stdlib.patch #558406
 
 	local sed_args=(
 		-e "/^prefix=/s:/usr:${EPREFIX}/usr:"


### PR DESCRIPTION
When '-fstack-protector-strong' is included in CFLAGS, the function
'__stack_chk_fail_local' needs to be pulled from libc. However, upstream
uses -nostdlib to avoid linking against any C library or gcc libs. Link
against '-lc' and '-lgcc' to pull in the required symbols. Also pass
'-Wl,--as-needed' so the fuctions are pulled from the internal
libc_nonshared.a instead of linking against the shared library.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=558406
Debian-Bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764509

Package-Manager: portage-2.2.20.1