### PR TITLE
dev-util/weka: add missing rdep on libsvm and the use flag "svm" #565550

### DIFF
--- a/dev-util/weka/metadata.xml
+++ b/dev-util/weka/metadata.xml
@@ -8,4 +8,10 @@
 	<upstream>
 		<remote-id type="sourceforge">weka</remote-id>
 	</upstream>
+	<use>
+		<flag name="svm">
+			Enable support for Support Vector Machines (SVM)
+			through sci-libs/libsvm
+		</flag>
+	</use>
 </pkgmetadata>

--- a/dev-util/weka/weka-3.6.12-r1.ebuild
+++ b/dev-util/weka/weka-3.6.12-r1.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+JAVA_PKG_IUSE="doc source"
+
+inherit eutils java-pkg-2 java-ant-2 versionator
+
+MY_P="${PN}-$(replace_all_version_separators '-')"
+DESCRIPTION="A Java data mining package"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.zip"
+HOMEPAGE="http://www.cs.waikato.ac.nz/ml/weka/"
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc ~x86"
+DEPEND=">=virtual/jdk-1.6
+	app-arch/unzip
+	>=dev-java/javacup-0.11a_beta20060608:0"
+RDEPEND=">=virtual/jre-1.6
+	>=dev-java/javacup-0.11a_beta20060608:0
+	svm? ( sci-libs/libsvm:0[java] )"
+IUSE="svm"
+
+S="${WORKDIR}/${MY_P}"
+
+EANT_BUILD_TARGET="exejar"
+EANT_DOC_TARGET="docs"
+JAVA_ANT_IGNORE_SYSTEM_CLASSES="true"
+
+weka_get_max_memory() {
+	if use amd64; then
+		echo 512m
+	else
+		echo 256m
+	fi
+}
+
+java_prepare() {
+	unzip -qq "${PN}-src.jar" -d . || die "Failed to unpack the source"
+	rm -v *.jar lib/*.jar || die
+	rm -rf doc || die
+	java-pkg_jar-from --into lib javacup
+	epatch "${FILESDIR}"/${P}-build.xml.patch
+	sed -i -e "s/256m/$(weka_get_max_memory)/g" build.xml || die
+}
+
+src_install() {
+	java-pkg_dojar dist/${PN}.jar
+	java-pkg_dolauncher weka --main "${PN}.gui.GUIChooser"
+
+	# Really need a virtual to list all available drivers and pull the ones
+	# instaled
+	java-pkg_register-optional-dependency hsqldb,jdbc-mysql,mckoi-1
+	use svm && java-pkg_register-dependency libsvm
+
+	use source && java-pkg_dosrc src/main/java/weka/
+
+	dodoc README || die
+	if use doc; then
+		java-pkg_dojavadoc doc/
+		insinto /usr/share/doc/${PF}
+		doins WekaManual.pdf || die
+	fi
+
+	dodir /usr/share/${PN}/data/
+	insinto /usr/share/${PN}/data/
+	doins data/*
+
+	newicon "${S}/weka.gif" "${PN}".png
+	#make_desktop_entry "${PN}" "Waikato Environment for Knowledge Analysis" "${PN}" "Education;Science;ArtificialIntelligence;" "Comment=Start Weka"
+}

--- a/dev-util/weka/weka-3.6.6-r2.ebuild
+++ b/dev-util/weka/weka-3.6.6-r2.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+JAVA_PKG_IUSE="doc source"
+
+inherit eutils java-pkg-2 java-ant-2 versionator
+
+MY_P="${PN}-$(replace_all_version_separators '-')"
+DESCRIPTION="A Java data mining package"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.zip"
+HOMEPAGE="http://www.cs.waikato.ac.nz/ml/weka/"
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc ~x86"
+DEPEND=">=virtual/jdk-1.5
+	app-arch/unzip
+	>=dev-java/javacup-0.11a_beta20060608:0"
+RDEPEND=">=virtual/jre-1.5
+	>=dev-java/javacup-0.11a_beta20060608:0
+	svm? ( sci-libs/libsvm:0[java] )"
+IUSE="svm"
+
+S="${WORKDIR}/${MY_P}"
+
+EANT_BUILD_TARGET="exejar"
+EANT_DOC_TARGET="docs"
+JAVA_ANT_IGNORE_SYSTEM_CLASSES="true"
+
+weka_get_max_memory() {
+	if use amd64; then
+		echo 512m
+	else
+		echo 256m
+	fi
+}
+
+java_prepare() {
+	unzip -qq "${PN}-src.jar" -d . || die "Failed to unpack the source"
+	rm -v *.jar lib/*.jar || die
+	rm -rf doc || die
+	java-pkg_jar-from --into lib javacup
+	epatch "${FILESDIR}"/${P}-build.xml.patch
+	sed -i -e "s/256m/$(weka_get_max_memory)/g" build.xml || die
+}
+
+src_install() {
+	java-pkg_dojar dist/${PN}.jar
+	java-pkg_dolauncher weka --main "${PN}.gui.GUIChooser"
+
+	# Really need a virtual to list all available drivers and pull the ones
+	# instaled
+	java-pkg_register-optional-dependency hsqldb,jdbc-mysql,mckoi-1
+	use svm && java-pkg_register-dependency libsvm
+
+	use source && java-pkg_dosrc src/main/java/weka/
+
+	dodoc README || die
+	if use doc; then
+		java-pkg_dojavadoc doc/
+		insinto /usr/share/doc/${PF}
+		doins WekaManual.pdf || die
+	fi
+
+	dodir /usr/share/${PN}/data/
+	insinto /usr/share/${PN}/data/
+	doins data/*
+
+	newicon "${S}/weka.gif" "${PN}".png
+	make_desktop_entry "${PN}" "Waikato Environment for Knowledge Analysis" "${PN}" "Education;Science;ArtificialIntelligence;" "Comment=Start Weka"
+}


### PR DESCRIPTION
Weka only ships a wrapper class for the actual libsvm package. Add a use
flag named "svm" and pull in sci-libs/libsvm[java] for proper SVM support
when the use flag is enabled.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=565550
Upstream-URL: https://weka.wikispaces.com/LibSVM

Package-Manager: portage-2.2.20.1