### PR TITLE
app-shells/autojump: add FISH support, misc. clean ups

### DIFF
--- a/app-shells/autojump/autojump-22.2.4-r4.ebuild
+++ b/app-shells/autojump/autojump-22.2.4-r4.ebuild
@@ -39,6 +39,7 @@ src_compile() {
 
 src_install() {
 	dobin bin/autojump
+	python_replicate_script "${ED}"/usr/bin/autojump
 
 	insinto /etc/profile.d
 	doins bin/"${PN}".sh

--- a/app-shells/autojump/autojump-22.2.4-r4.ebuild
+++ b/app-shells/autojump/autojump-22.2.4-r4.ebuild
@@ -15,11 +15,11 @@ SRC_URI="https://github.com/joelthelion/${PN}/archive/release-v${PV}.tar.gz -> $
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~ppc ~ppc64"
-IUSE="python test"
+IUSE="ipython test"
 
 # Not all tests pass. Need investigation.
 RESTRICT="test"
-RDEPEND="python? ( ${PYTHON_DEPS} )"
+RDEPEND="ipython? ( ${PYTHON_DEPS} )"
 DEPEND="test? ( dev-python/flake8 dev-python/tox )"
 
 src_prepare() {
@@ -56,7 +56,7 @@ src_install() {
 	doins bin/_j
 
 	python_foreach_impl python_domodule bin/autojump_data.py bin/autojump_utils.py
-	if use python; then
+	if use ipython; then
 		python_foreach_impl python_domodule tools/autojump_ipython.py
 	fi
 
@@ -65,7 +65,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	if use python; then
+	if use ipython; then
 		elog 'This tool provides "j" for ipython, please add'
 		elog '"import autojump_ipython" to your ipy_user_conf.py.'
 		elog

--- a/app-shells/autojump/autojump-22.2.4-r4.ebuild
+++ b/app-shells/autojump/autojump-22.2.4-r4.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+
+inherit bash-completion-r1 python-r1 vcs-snapshot
+
+DESCRIPTION="change directory command that learns"
+HOMEPAGE="https://github.com/joelthelion/autojump"
+SRC_URI="https://github.com/joelthelion/${PN}/archive/release-v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~ppc ~ppc64"
+IUSE="python test"
+
+# Not all tests pass. Need investigation.
+RESTRICT="test"
+RDEPEND="python? ( ${PYTHON_DEPS} )"
+DEPEND="test? ( dev-python/flake8 dev-python/tox )"
+
+src_prepare() {
+	sed -e "s: \(/etc/profile.d\): \"${EPREFIX}\1\":" \
+		-e "s:/usr/local/share:/usr/share:" \
+		-i bin/autojump.sh || die
+
+	# upstream fixes to the autojump.fish script; the first patch is needed for
+	# the second patch to apply
+	epatch "${FILESDIR}/autojump-22.4.4-fix-autojump.fish-bugs.patch"
+	epatch "${FILESDIR}/autojump-22.4.4-fix-__aj_error-typo.patch"
+}
+
+src_compile() {
+	:
+}
+
+src_install() {
+	dobin bin/autojump
+
+	insinto /etc/profile.d
+	doins bin/"${PN}".sh
+
+	insinto /usr/share/"${PN}"/
+	doins bin/"${PN}.bash"
+	doins bin/"${PN}.zsh"
+	doins bin/"${PN}.fish"
+	insinto /usr/share/zsh/site-functions
+	doins bin/_j
+
+	python_foreach_impl python_domodule bin/autojump_argparse.py bin/autojump_data.py bin/autojump_utils.py
+	if use python; then
+		python_foreach_impl python_domodule tools/autojump_ipython.py
+		einfo 'This tool provides "j" for ipython, please add'
+		einfo '"import autojump_ipython" to your ipy_user_conf.py.'
+	fi
+
+	doman docs/"${PN}.1"
+	dodoc README.md
+}
+
+pkg_postinst() {
+	elog 'If you use app-shells/fish, add the following code to your'
+	elog 'config.fish to get autojump support:'
+	elog 'if test -f /usr/share/autojump/autojump.fish'
+	elog '    source /usr/share/autojump/autojump.fish'
+	elog 'end'
+}

--- a/app-shells/autojump/autojump-22.2.4-r4.ebuild
+++ b/app-shells/autojump/autojump-22.2.4-r4.ebuild
@@ -27,6 +27,10 @@ src_prepare() {
 		-e "s:/usr/local/share:/usr/share:" \
 		-i bin/autojump.sh || die
 
+	# autojump_argparse is only there for Python 2.6 compatibility
+	sed -e "s:autojump_argparse:argparse:" \
+		-i bin/autojump || die
+
 	# upstream fixes to the autojump.fish script; the first patch is needed for
 	# the second patch to apply
 	epatch "${FILESDIR}/autojump-22.4.4-fix-autojump.fish-bugs.patch"
@@ -51,7 +55,7 @@ src_install() {
 	insinto /usr/share/zsh/site-functions
 	doins bin/_j
 
-	python_foreach_impl python_domodule bin/autojump_argparse.py bin/autojump_data.py bin/autojump_utils.py
+	python_foreach_impl python_domodule bin/autojump_data.py bin/autojump_utils.py
 	if use python; then
 		python_foreach_impl python_domodule tools/autojump_ipython.py
 		einfo 'This tool provides "j" for ipython, please add'

--- a/app-shells/autojump/autojump-22.2.4-r4.ebuild
+++ b/app-shells/autojump/autojump-22.2.4-r4.ebuild
@@ -58,8 +58,6 @@ src_install() {
 	python_foreach_impl python_domodule bin/autojump_data.py bin/autojump_utils.py
 	if use python; then
 		python_foreach_impl python_domodule tools/autojump_ipython.py
-		einfo 'This tool provides "j" for ipython, please add'
-		einfo '"import autojump_ipython" to your ipy_user_conf.py.'
 	fi
 
 	doman docs/"${PN}.1"
@@ -67,6 +65,12 @@ src_install() {
 }
 
 pkg_postinst() {
+	if use python; then
+		elog 'This tool provides "j" for ipython, please add'
+		elog '"import autojump_ipython" to your ipy_user_conf.py.'
+		elog
+	fi
+
 	elog 'If you use app-shells/fish, add the following code to your'
 	elog 'config.fish to get autojump support:'
 	elog 'if test -f /usr/share/autojump/autojump.fish'

--- a/app-shells/autojump/files/autojump-22.4.4-fix-__aj_error-typo.patch
+++ b/app-shells/autojump/files/autojump-22.4.4-fix-__aj_error-typo.patch
@@ -1,0 +1,22 @@
+From d188d7e6757a4d0cad619b6d5ab729fdc59b1593 Mon Sep 17 00:00:00 2001
+From: Scott Olson <scott@scott-olson.org>
+Date: Mon, 6 Jul 2015 23:12:35 -0400
+Subject: [PATCH] Fix typo (__aj_error -> __aj_err).
+
+---
+ bin/autojump.fish | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bin/autojump.fish b/bin/autojump.fish
+index ead7ea1..b16ef01 100644
+--- a/bin/autojump.fish
++++ b/bin/autojump.fish
+@@ -91,7 +91,7 @@ function jo
+             case cygwin
+                 cygstart "" (cygpath -w -a (pwd))
+             case '*'
+-                __aj_error "Unknown operating system: \"$OSTYPE\""
++                __aj_err "Unknown operating system: \"$OSTYPE\""
+         end
+     else
+         __aj_err "autojump: directory '"$argv"' not found"

--- a/app-shells/autojump/files/autojump-22.4.4-fix-autojump.fish-bugs.patch
+++ b/app-shells/autojump/files/autojump-22.4.4-fix-autojump.fish-bugs.patch
@@ -1,0 +1,67 @@
+From f09d23e30d3159db18872a3e8f8f579ed9e77231 Mon Sep 17 00:00:00 2001
+From: David Frascone <David.Frascone@dishdigital.com>
+Date: Tue, 9 Jun 2015 14:32:38 -0600
+Subject: [PATCH] Fixed some bugs in fish script
+
+OSTYPE was not being set correctly.  It is in bash, not sh.
+    Since the value is unlikely to change, I read it once and
+    stored it globally
+Test logic was backward in jo function, causing error to always
+    be printed, unless you did NOT specify a directory name.
+---
+ bin/autojump.fish | 20 ++++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/bin/autojump.fish b/bin/autojump.fish
+index 2cf5001..19cb27e 100644
+--- a/bin/autojump.fish
++++ b/bin/autojump.fish
+@@ -5,6 +5,11 @@ if test -d ~/.autojump
+     set -x PATH ~/.autojump/bin $PATH
+ end
+ 
++# Set ostype, if not set
++if not set -q OSTYPE
++    set -gx OSTYPE (bash -c 'echo ${OSTYPE}')
++end
++
+ 
+ # enable tab completion
+ complete -x -c j -a '(autojump --complete (commandline -t))'
+@@ -34,7 +39,7 @@ end
+ # misc helper functions
+ function __aj_err
+     # TODO(ting|#247): set error file location
+-    echo $argv 1>&2; false
++    echo -e $argv 1>&2; false
+ end
+ 
+ # default autojump command
+@@ -73,11 +78,7 @@ end
+ function jo
+     set -l output (autojump $argv)
+     if test -d "$output"
+-        __aj_err "autojump: directory '"$argv"' not found"
+-        __aj_err "\n$output\n"
+-        __aj_err "Try `autojump --help` for more information."
+-    else
+-        switch (sh -c 'echo ${OSTYPE}')
++        switch $OSTYPE
+             case 'linux*'
+                 xdg-open (autojump $argv)
+             case 'darwin*'
+@@ -85,9 +86,12 @@ function jo
+             case cygwin
+                 cygstart "" (cygpath -w -a (pwd))
+             case '*'
+-                __aj_error "Unknown operating system: '"$OSTYPE"'"
++                __aj_error "Unknown operating system: \"$OSTYPE\""
+         end
+-        echo end
++    else
++        __aj_err "autojump: directory '"$argv"' not found"
++        __aj_err "\n$output\n"
++        __aj_err "Try `autojump --help` for more information."
+     end
+ end
+ 

--- a/app-shells/autojump/metadata.xml
+++ b/app-shells/autojump/metadata.xml
@@ -9,4 +9,7 @@
     <bugs-to>https://github.com/joelthelion/autojump/issues</bugs-to>
     <remote-id type="github">joelthelion/autojump</remote-id>
   </upstream>
+  <use>
+    <flag name="ipython">Add support for <pkg>dev-python/ipython</pkg></flag>
+  </use>
 </pkgmetadata>


### PR DESCRIPTION
This goal of this PR is to add FISH support.  This is done in the first commit, which required including two upstream patches (they can be removed with the next version bump, though).  The other three commits are pretty much just clean ups that I made while working on FISH support, so decided to include them here.

Note that I made FISH support unconditional, since zsh support is also unconditional, and it only installs a single file.

I'm not sure if the second patch is really required, but it seems like a good idea to me.  IIUIC, it will limit the autojump script to the python implementations listed in `PYTHON_COMPAT`, that is, it will cause the script to fail for unsupported Python implementations.

For easier comparison, here's a diff of the ebuild revisions:

    % git diff master.. -C -C ./*.ebuild
    diff --git a/app-shells/autojump/autojump-22.2.4-r3.ebuild b/app-shells/autojump/autojump-22.2.4-r4.ebuild
    similarity index 55%
    copy from app-shells/autojump/autojump-22.2.4-r3.ebuild
    copy to app-shells/autojump/autojump-22.2.4-r4.ebuild
    index 4b774f9..6c967ce 100644
    --- a/app-shells/autojump/autojump-22.2.4-r3.ebuild
    +++ b/app-shells/autojump/autojump-22.2.4-r4.ebuild
    @@ -26,6 +26,15 @@ src_prepare() {
     	sed -e "s: \(/etc/profile.d\): \"${EPREFIX}\1\":" \
     		-e "s:/usr/local/share:/usr/share:" \
     		-i bin/autojump.sh || die
    +
    +	# autojump_argparse is only there for Python 2.6 compatibility
    +	sed -e "s:autojump_argparse:argparse:" \
    +		-i bin/autojump || die
    +
    +	# upstream fixes to the autojump.fish script; the first patch is needed for
    +	# the second patch to apply
    +	epatch "${FILESDIR}/autojump-22.4.4-fix-autojump.fish-bugs.patch"
    +	epatch "${FILESDIR}/autojump-22.4.4-fix-__aj_error-typo.patch"
     }
     
     src_compile() {
    @@ -34,6 +43,7 @@ src_compile() {
     
     src_install() {
     	dobin bin/autojump
    +	python_replicate_script "${ED}"/usr/bin/autojump
     
     	insinto /etc/profile.d
     	doins bin/"${PN}".sh
    @@ -41,16 +51,29 @@ src_install() {
     	insinto /usr/share/"${PN}"/
     	doins bin/"${PN}.bash"
     	doins bin/"${PN}.zsh"
    +	doins bin/"${PN}.fish"
     	insinto /usr/share/zsh/site-functions
     	doins bin/_j
     
    -	python_foreach_impl python_domodule bin/autojump_argparse.py bin/autojump_data.py bin/autojump_utils.py
    +	python_foreach_impl python_domodule bin/autojump_data.py bin/autojump_utils.py
     	if use python; then
     		python_foreach_impl python_domodule tools/autojump_ipython.py
    -		einfo 'This tool provides "j" for ipython, please add'
    -		einfo '"import autojump_ipython" to your ipy_user_conf.py.'
     	fi
     
     	doman docs/"${PN}.1"
     	dodoc README.md
     }
    +
    +pkg_postinst() {
    +	if use python; then
    +		elog 'This tool provides "j" for ipython, please add'
    +		elog '"import autojump_ipython" to your ipy_user_conf.py.'
    +		elog
    +	fi
    +
    +	elog 'If you use app-shells/fish, add the following code to your'
    +	elog 'config.fish to get autojump support:'
    +	elog 'if test -f /usr/share/autojump/autojump.fish'
    +	elog '    source /usr/share/autojump/autojump.fish'
    +	elog 'end'
    +}