### PR TITLE
net-firewall/ipsec-tools: fix dependency on ipsec-tools.service

### DIFF
--- a/net-firewall/ipsec-tools/files/racoon.service
+++ b/net-firewall/ipsec-tools/files/racoon.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Racoon IKEv1 key management daemon for IPSEC
 After=syslog.target network.target
-Requires=ipsec.service
+Requires=ipsec-tools.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
After change for bug #567010 dependencies between systemd units were broken. This patch fixes this.