### PR TITLE
cmake-utils.eclass: Fix cross-compiling with cmake-3.4

### DIFF
--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -468,7 +468,7 @@ enable_cmake-utils_src_configure() {
 		if $(version_is_at_least 3.4.0 $(get_version_component_range 1-3 ${PV})) ; then
 			includes="<INCLUDES>"
 		fi
-	elif has_version \>=dev-util/cmake-3.4.0_rc1 ; then
+	elif ROOT=/ has_version \>=dev-util/cmake-3.4.0_rc1 ; then
 		includes="<INCLUDES>"
 	fi
 	cat > "${build_rules}" <<- _EOF_ || die


### PR DESCRIPTION
cmake-utils.eclass currently does not work with crossdev when using >=cmake-3.4 because it queries the cmake version inside the sysroot instead of the host - this patch fixes that.