### PR TITLE
sys-devel/llvm: add BPF backend to compiled targets

### DIFF
--- a/sys-devel/llvm/llvm-9999.ebuild
+++ b/sys-devel/llvm/llvm-9999.ebuild
@@ -215,7 +215,7 @@ multilib_src_configure() {
 	if use multitarget; then
 		targets=all
 	else
-		targets='host;CppBackend'
+		targets='host;BPF;CppBackend'
 		use video_cards_radeon && targets+=';AMDGPU'
 	fi
 


### PR DESCRIPTION
As part of 3.7.* releases, LLVM has officially added support for the
BPF backend. This backend emits instructions in the eBPF language,
that is used in the homonymous Linux kernel virtual machine. Users of
LLVM can write a program in C and have it compiled directly into BPF.

More info available in the commit that introduced the backend:
https://github.com/llvm-mirror/llvm/commit/4fe85c75482f9d11c5a1f92a1863ce30afad8d0d

This commit adds support for compiling this backend conditionally, if
the 'bpf' USE flag is enabled. Although one could use the
'multitarget' USE flag to generate all targets, it would come at the
cost of significantly increased compilation time.