### PR TITLE
sci-mathematics/rstudio: install systemd service unit for rstudio-ser…

### DIFF
--- a/sci-mathematics/rstudio/files/rstudio-0.99.486-systemd.patch
+++ b/sci-mathematics/rstudio/files/rstudio-0.99.486-systemd.patch
@@ -1,0 +1,22 @@
+diff -Naur /tmp/rstudio.org/work/rstudio-0.99.486/src/cpp/server/CMakeLists.txt ./work/rstudio-0.99.486/src/cpp/server/CMakeLists.txt
+--- /tmp/rstudio.org/work/rstudio-0.99.486/src/cpp/server/CMakeLists.txt	2015-12-10 19:29:24.408267862 +0100
++++ ./work/rstudio-0.99.486/src/cpp/server/CMakeLists.txt	2015-12-10 19:35:24.660194216 +0100
+@@ -208,17 +208,12 @@
+            DESTINATION ${DISTRO_SHARE}/${RSERVER_UPSTART_DIR})
+            
+     # install configured systemd profile
+-   set(RSERVER_SYSTEMD_DIR "extras/systemd")
++   set(RSERVER_SYSTEMD_DIR "lib/systemd/system")
+    set(RSERVER_SYSTEMD_PROFILE "${RSERVER_SYSTEMD_DIR}/rstudio-server.service")
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${RSERVER_SYSTEMD_PROFILE}.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/${RSERVER_SYSTEMD_PROFILE})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${RSERVER_SYSTEMD_PROFILE}
+            DESTINATION ${RSERVER_SYSTEMD_DIR})
+-   set(RSERVER_SYSTEMD_PROFILE_REDHAT "${RSERVER_SYSTEMD_DIR}/rstudio-server.redhat.service")
+-   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${RSERVER_SYSTEMD_PROFILE_REDHAT}.in
+-                  ${CMAKE_CURRENT_BINARY_DIR}/${RSERVER_SYSTEMD_PROFILE_REDHAT})
+-   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${RSERVER_SYSTEMD_PROFILE_REDHAT}
+-           DESTINATION ${RSERVER_SYSTEMD_DIR})
+ 
+ endif()
+ 

--- a/sci-mathematics/rstudio/files/rstudio-server.conf
+++ b/sci-mathematics/rstudio/files/rstudio-server.conf
@@ -32,4 +32,4 @@ rsession-which-r=/usr/bin/R
 # To limit the users who can login to RStudio to the members 
 # of a specific group, you use the auth-required-user-group 
 # setting
-auth-required-user-group=rstudio_users
+auth-required-user-group=rstudio-server

--- a/sci-mathematics/rstudio/files/rstudio-server.service.in
+++ b/sci-mathematics/rstudio/files/rstudio-server.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=RStudio Server
+
+[Service]
+Type=forking
+ExecStart=${CMAKE_INSTALL_PREFIX}/bin/rserver
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/sci-mathematics/rstudio/rstudio-0.99.486-r1.ebuild
+++ b/sci-mathematics/rstudio/rstudio-0.99.486-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -87,6 +87,16 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 #	test? ( dev-java/junit:4 )
 
+PATCHES=(
+		"${FILESDIR}/${PN}-0.98.490-prefs.patch"
+		"${FILESDIR}/${PN}-0.99.473-paths.patch"
+		"${FILESDIR}/${PN}-0.99.473-clang-pandoc.patch"
+		"${FILESDIR}/${PN}-0.98.490-linker_flags.patch"
+		"${FILESDIR}/${PN}-0.98.1091-boost-1.57.patch"
+		"${FILESDIR}/${PN}-0.99.473-qtsingleapplication.patch"
+		"${FILESDIR}/${PN}-0.99.486-systemd.patch"
+)
+
 src_unpack() {
 	unpack ${P}.tar.gz gwt-${GWT_VER}.zip
 	cd "${S}" || die
@@ -125,13 +135,7 @@ src_prepare() {
 
 	find . -name .gitignore -delete || die
 
-	epatch "${FILESDIR}"/${PN}-0.98.490-prefs.patch \
-		"${FILESDIR}"/${PN}-0.99.473-paths.patch \
-		"${FILESDIR}"/${PN}-0.99.473-clang-pandoc.patch \
-		"${FILESDIR}"/${PN}-0.98.490-linker_flags.patch \
-		"${FILESDIR}"/${PN}-0.98.1091-boost-1.57.patch \
-		"${FILESDIR}"/${PN}-0.99.473-qtsingleapplication.patch \
-		"${FILESDIR}"/${PN}-0.99.486-systemd.patch
+	epatch "${PATCHES[@]}"
 
 	# Enable CMake to install our .service file for systemd usage
 	mkdir -vp "${S}/src/cpp/server/lib/systemd/system" || die

--- a/sci-mathematics/rstudio/rstudio-0.99.486-r1.ebuild
+++ b/sci-mathematics/rstudio/rstudio-0.99.486-r1.ebuild
@@ -130,7 +130,12 @@ src_prepare() {
 		"${FILESDIR}"/${PN}-0.99.473-clang-pandoc.patch \
 		"${FILESDIR}"/${PN}-0.98.490-linker_flags.patch \
 		"${FILESDIR}"/${PN}-0.98.1091-boost-1.57.patch \
-		"${FILESDIR}"/${PN}-0.99.473-qtsingleapplication.patch
+		"${FILESDIR}"/${PN}-0.99.473-qtsingleapplication.patch \
+		"${FILESDIR}"/${PN}-0.99.486-systemd.patch
+
+	# Enable CMake to install our .service file for systemd usage
+	mkdir -vp "${S}/src/cpp/server/lib/systemd/system" || die
+	cp -v "${FILESDIR}/rstudio-server.service.in" "${S}/src/cpp/server/lib/systemd/system/" || die
 
 	# Adding -DDISTRO_SHARE=... to append-flags breaks cmake so using
 	# this sed hack for now. ~RMH


### PR DESCRIPTION
…ver into proper directory

===

rstudio provides a systemd .service file for rstudio-server from its package. Just that it goes (per default) into a remote part of the galaxy. This patch fixes this.