### PR TITLE
Fix packages broken by GCC 5 moving from -std=gnu89 to -std=gnu11 by default

### DIFF
--- a/dev-libs/glib/glib-1.2.10-r6.ebuild
+++ b/dev-libs/glib/glib-1.2.10-r6.ebuild
@@ -57,6 +57,7 @@ multilib_src_configure() {
 	# this package doesn't contain any significant binaries, build the
 	# whole thing with -fPIC (23 Apr 2004 agriffis)
 	append-flags -fPIC
+	append-cflags -std=gnu89
 
 	ECONF_SOURCE="${S}" \
 	gnome2_src_configure \

--- a/net-wireless/spectools/spectools-2011.08.1_p20140618-r1.ebuild
+++ b/net-wireless/spectools/spectools-2011.08.1_p20140618-r1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit autotools eutils toolchain-funcs udev
+inherit autotools eutils flag-o-matic toolchain-funcs udev
 
 MY_PN=${PN}
 MY_PV=${PV/\./-}
@@ -41,6 +41,11 @@ src_prepare() {
 	epatch "${FILESDIR}"/${P}-tinfo.patch
 	mv configure.{in,ac} || die
 	eautoreconf
+}
+
+src_configure() {
+	append-cflags -std=gnu89
+	default
 }
 
 # Please note that upstream removed the --with-gtk-version option

--- a/sci-biology/embassy-vienna/embassy-vienna-1.7.2.650.ebuild
+++ b/sci-biology/embassy-vienna/embassy-vienna-1.7.2.650.ebuild
@@ -8,8 +8,13 @@ EBO_DESCRIPTION="Vienna RNA package - RNA folding"
 
 AUTOTOOLS_AUTORECONF=1
 
-inherit emboss-r1
+inherit emboss-r1 flag-o-matic
 
 KEYWORDS="amd64 ~ppc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
 PATCHES=( "${FILESDIR}"/${P}_fix-build-system.patch )
+
+src_configure() {
+	append-cflags -std=gnu89
+	emboss-r1_src_configure
+}

--- a/x11-libs/gtk+/gtk+-1.2.10-r13.ebuild
+++ b/x11-libs/gtk+/gtk+-1.2.10-r13.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 GNOME_TARBALL_SUFFIX="gz"
 GNOME2_LA_PUNT="yes"
 
-inherit autotools eutils gnome2 toolchain-funcs multilib-minimal
+inherit autotools eutils flag-o-matic gnome2 toolchain-funcs multilib-minimal
 
 DESCRIPTION="The GIMP Toolkit"
 HOMEPAGE="http://www.gtk.org/"
@@ -36,6 +36,7 @@ DEPEND="${RDEPEND}
 MULTILIB_CHOST_TOOLS=(/usr/bin/gtk-config)
 
 src_prepare() {
+	append-cflags -std=gnu89
 	epatch "${FILESDIR}"/${P}-m4.patch
 	epatch "${FILESDIR}"/${P}-automake.patch
 	epatch "${FILESDIR}"/${P}-cleanup.patch


### PR DESCRIPTION
I've fixed a number of ebuilds that implicitly assumed -std=gnu89 and failed with missing symbols with GCC 5 changing the default C standard.