### PR TITLE
dev-php/pecl-xdiff: Add upstream metadata

### DIFF
--- a/dev-php/pecl-xdiff/metadata.xml
+++ b/dev-php/pecl-xdiff/metadata.xml
@@ -2,4 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <herd>php</herd>
+  <upstream>
+    <remote-id type="github">php/pecl-text-xdiff</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/dev-php/pecl-xdiff/pecl-xdiff-1.5.2-r2.ebuild
+++ b/dev-php/pecl-xdiff/pecl-xdiff-1.5.2-r2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=4
+EAPI=5
 
 PHP_EXT_NAME="xdiff"
 PHP_EXT_PECL_PKG="xdiff"


### PR DESCRIPTION
Upstream development has moved to github (away from
svn.php.net),

Also bumped EAPI to v5 to appease repoman.

Package-Manager: portage-2.2.24