### PR TITLE
kde-base: Add >=cmake-3.4 configure fix for KDE PIM

### DIFF
--- a/kde-base/kmail/files/kdepim-4.14.10-fix-cmake-3.4.patch
+++ b/kde-base/kmail/files/kdepim-4.14.10-fix-cmake-3.4.patch
@@ -1,0 +1,23 @@
+From: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date: Sun, 13 Dec 2015 09:20:24 +0000
+Subject: Fix configure with >=cmake-3.4
+X-Git-Url: http://quickgit.kde.org/?p=kdepim.git&a=commitdiff&h=91275a772e51a4031b8f34bc83652b5e60478624
+---
+Fix configure with >=cmake-3.4
+
+REVIEW: 126334
+---
+
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,6 +3,8 @@
+ 
+ # where to look first for cmake modules. This line must be the first one or cmake will use the system's FindFoo.cmake
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules")
++
++include(CheckIncludeFiles)
+ 
+ ############### Build Options ###############
+ 
+

--- a/kde-base/kmail/kmail-4.14.10.ebuild
+++ b/kde-base/kmail/kmail-4.14.10.ebuild
@@ -74,6 +74,8 @@ KMEXTRA="
 
 KMLOADLIBS="kdepim-common-libs"
 
+PATCHES=( "${FILESDIR}/kdepim-4.14.10-fix-cmake-3.4.patch" )
+
 src_configure() {
 	# Bug 308903
 	use ppc64 && append-flags -mminimal-toc

--- a/kde-base/konsolekalendar/files/kdepim-4.14.10-fix-cmake-3.4.patch
+++ b/kde-base/konsolekalendar/files/kdepim-4.14.10-fix-cmake-3.4.patch
@@ -1,0 +1,23 @@
+From: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date: Sun, 13 Dec 2015 09:20:24 +0000
+Subject: Fix configure with >=cmake-3.4
+X-Git-Url: http://quickgit.kde.org/?p=kdepim.git&a=commitdiff&h=91275a772e51a4031b8f34bc83652b5e60478624
+---
+Fix configure with >=cmake-3.4
+
+REVIEW: 126334
+---
+
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,6 +3,8 @@
+ 
+ # where to look first for cmake modules. This line must be the first one or cmake will use the system's FindFoo.cmake
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules")
++
++include(CheckIncludeFiles)
+ 
+ ############### Build Options ###############
+ 
+

--- a/kde-base/konsolekalendar/konsolekalendar-4.14.10.ebuild
+++ b/kde-base/konsolekalendar/konsolekalendar-4.14.10.ebuild
@@ -46,3 +46,5 @@ KMEXTRACTONLY="
 "
 
 KMLOADLIBS="kdepim-common-libs"
+
+PATCHES=( "${FILESDIR}/kdepim-4.14.10-fix-cmake-3.4.patch" )

--- a/kde-base/korganizer/files/kdepim-4.14.10-fix-cmake-3.4.patch
+++ b/kde-base/korganizer/files/kdepim-4.14.10-fix-cmake-3.4.patch
@@ -1,0 +1,23 @@
+From: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date: Sun, 13 Dec 2015 09:20:24 +0000
+Subject: Fix configure with >=cmake-3.4
+X-Git-Url: http://quickgit.kde.org/?p=kdepim.git&a=commitdiff&h=91275a772e51a4031b8f34bc83652b5e60478624
+---
+Fix configure with >=cmake-3.4
+
+REVIEW: 126334
+---
+
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,6 +3,8 @@
+ 
+ # where to look first for cmake modules. This line must be the first one or cmake will use the system's FindFoo.cmake
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules")
++
++include(CheckIncludeFiles)
+ 
+ ############### Build Options ###############
+ 
+

--- a/kde-base/korganizer/korganizer-4.14.10.ebuild
+++ b/kde-base/korganizer/korganizer-4.14.10.ebuild
@@ -68,6 +68,8 @@ src_unpack() {
 }
 
 src_prepare() {
+	epatch "${FILESDIR}/kdepim-4.14.10-fix-cmake-3.4.patch"
+
 	use handbook && epatch "${FILESDIR}/${PN}-4.14.10-handbook.patch"
 
 	kde4-meta_src_prepare
@@ -76,8 +78,8 @@ src_prepare() {
 src_install() {
 	kde4-meta_src_install
 	# colliding with kdepim-common-libs
-	rm -rf "${ED}"/usr/share/kde4/servicetypes/calendarplugin.desktop
-	rm -rf "${ED}"/usr/share/kde4/servicetypes/calendardecoration.desktop
+	rm -rf "${ED}"usr/share/kde4/servicetypes/calendarplugin.desktop || die
+	rm -rf "${ED}"usr/share/kde4/servicetypes/calendardecoration.desktop || die
 }
 
 pkg_postinst() {


### PR DESCRIPTION
See also: https://bugs.gentoo.org/show_bug.cgi?id=566058
Tested-by: Vadim

Package-Manager: portage-2.2.24