### PR TITLE
sys-apps/install-xattr: support EPREFIX and tidy

### DIFF
--- a/sys-apps/install-xattr/install-xattr-0.4.ebuild
+++ b/sys-apps/install-xattr/install-xattr-0.4.ebuild
@@ -8,14 +8,16 @@ HOMEPAGE="https://dev.gentoo.org/~blueness/install-xattr/"
 
 inherit toolchain-funcs
 
+S="${WORKDIR}/${PN}"
+
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.gentoo.org/proj/elfix.git"
-	KEYWORDS=""
-	inherit git-2
+	EGIT_CHECKOUT_DIR="${S}"
+	S+=/misc/${PN}
+	inherit git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~blueness/install-xattr/${P}.tar.bz2"
 	KEYWORDS="arm64"
-	S=${WORKDIR}/${PN}
 fi
 
 LICENSE="GPL-3"
@@ -23,23 +25,11 @@ SLOT="0"
 
 src_prepare() {
 	tc-export CC
-}
-
-src_compile() {
-	if [[ ${PV} == "9999" ]] ; then
-		cd "${WORKDIR}/${P}/misc/${PN}" || die
-	fi
-	default
-}
-
-src_install() {
-	if [[ ${PV} == "9999" ]] ; then
-		cd "${WORKDIR}/${P}/misc/${PN}" || die
-	fi
-	default
+	sed -e "s|^\\(PREFIX = \\)\\(/usr\\)$|\\1${EPREFIX}\\2|" \
+		-i Makefile || die "sed Makefile failed"
 }
 
 # We need to fix how tests are done
 src_test() {
-	true
+	return 0
 }

--- a/sys-apps/install-xattr/install-xattr-0.5.ebuild
+++ b/sys-apps/install-xattr/install-xattr-0.5.ebuild
@@ -8,13 +8,16 @@ HOMEPAGE="https://dev.gentoo.org/~blueness/install-xattr/"
 
 inherit toolchain-funcs
 
+S="${WORKDIR}/${PN}"
+
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.gentoo.org/proj/elfix.git"
-	inherit git-2
+	EGIT_CHECKOUT_DIR="${S}"
+	S+=/misc/${PN}
+	inherit git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~blueness/install-xattr/${P}.tar.bz2"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86"
-	S=${WORKDIR}/${PN}
 fi
 
 LICENSE="GPL-3"
@@ -22,23 +25,11 @@ SLOT="0"
 
 src_prepare() {
 	tc-export CC
-}
-
-src_compile() {
-	if [[ ${PV} == "9999" ]] ; then
-		cd "${WORKDIR}/${P}/misc/${PN}" || die
-	fi
-	default
-}
-
-src_install() {
-	if [[ ${PV} == "9999" ]] ; then
-		cd "${WORKDIR}/${P}/misc/${PN}" || die
-	fi
-	default
+	sed -e "s|^\\(PREFIX = \\)\\(/usr\\)$|\\1${EPREFIX}\\2|" \
+		-i Makefile || die "sed Makefile failed"
 }
 
 # We need to fix how tests are done
 src_test() {
-	true
+	return 0
 }

--- a/sys-apps/install-xattr/install-xattr-9999.ebuild
+++ b/sys-apps/install-xattr/install-xattr-9999.ebuild
@@ -8,13 +8,16 @@ HOMEPAGE="https://dev.gentoo.org/~blueness/install-xattr/"
 
 inherit toolchain-funcs
 
+S="${WORKDIR}/${PN}"
+
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.gentoo.org/proj/elfix.git"
-	inherit git-2
+	EGIT_CHECKOUT_DIR="${S}"
+	S+=/misc/${PN}
+	inherit git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~blueness/install-xattr/${P}.tar.bz2"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
-	S=${WORKDIR}/${PN}
 fi
 
 LICENSE="GPL-3"
@@ -22,23 +25,11 @@ SLOT="0"
 
 src_prepare() {
 	tc-export CC
-}
-
-src_compile() {
-	if [[ ${PV} == "9999" ]] ; then
-		cd "${WORKDIR}/${P}/misc/${PN}" || die
-	fi
-	default
-}
-
-src_install() {
-	if [[ ${PV} == "9999" ]] ; then
-		cd "${WORKDIR}/${P}/misc/${PN}" || die
-	fi
-	default
+	sed -e "s|^\\(PREFIX = \\)\\(/usr\\)$|\\1${EPREFIX}\\2|" \
+		-i Makefile || die "sed Makefile failed"
 }
 
 # We need to fix how tests are done
 src_test() {
-	true
+	return 0
 }


### PR DESCRIPTION
As implemented install-xattr ebuilds fail on prefix due
to a hard-coded path in the (also hard-coded) Makefile.
Patch that up; while we're at it, tidy up the ebuilds
a bit.

Signed-off-by: Gregory M. Turner <gmt@be-evil.net>