### PR TITLE
net-analyzer/pnp4nagios: Added missing needed php USE flag gd

### DIFF
--- a/net-analyzer/pnp4nagios/pnp4nagios-0.6.24.ebuild
+++ b/net-analyzer/pnp4nagios/pnp4nagios-0.6.24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -16,8 +16,7 @@ IUSE=""
 KEYWORDS="amd64 ppc ppc64 ~sparc x86"
 
 DEPEND="
-	dev-lang/php[json,simplexml,zlib,xml,filter]
-	>=dev-lang/php-5.3
+	dev-lang/php:*[gd,json,simplexml,zlib,xml,filter]
 	>=net-analyzer/rrdtool-1.2[graph,perl]
 	|| ( net-analyzer/nagios-core net-analyzer/icinga net-analyzer/icinga2 )"
 RDEPEND="${DEPEND}

--- a/net-analyzer/pnp4nagios/pnp4nagios-0.6.25.ebuild
+++ b/net-analyzer/pnp4nagios/pnp4nagios-0.6.25.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 
 # A lot of things (sync mode, for one) are broken with nagios-4.x.
 DEPEND="
-	>=dev-lang/php-5.3:*[json,simplexml,zlib,xml,filter]
+	>=dev-lang/php-5.3:*[gd,json,simplexml,zlib,xml,filter]
 	>=net-analyzer/rrdtool-1.2[graph,perl]
 	|| ( <net-analyzer/nagios-core-4 net-analyzer/icinga net-analyzer/icinga2 )"
 


### PR DESCRIPTION
php USE flag gd added to prevent the following error, it is necessary
"Fatal error: Call to undefined function imagefontwidth"
In 0.6.24 Updated copyright year, added :* slot for php, and dropped >=5.3