### PR TITLE
media-sound/ncmpcpp: fix building with boost 1.5.7 #565102

### DIFF
--- a/media-sound/ncmpcpp/files/circumvent-boost-1.57-bug.patch
+++ b/media-sound/ncmpcpp/files/circumvent-boost-1.57-bug.patch
@@ -1,0 +1,52 @@
+diff --git a/src/interfaces.h b/src/interfaces.h
+index 97329fb..37485b4 100644
+--- a/src/interfaces.h
++++ b/src/interfaces.h
+@@ -21,6 +21,8 @@
+ #ifndef NCMPCPP_INTERFACES_H
+ #define NCMPCPP_INTERFACES_H
+ 
++#include <boost/iterator/iterator_facade.hpp>
++using namespace boost::iterators::detail;
+ #include <boost/range/detail/any_iterator.hpp>
+ #include <boost/tuple/tuple.hpp>
+ #include <string>
+diff --git a/src/menu.h b/src/menu.h
+index c7410bc..f6d5ca0 100644
+--- a/src/menu.h
++++ b/src/menu.h
+@@ -23,6 +23,8 @@
+ 
+ #include <boost/iterator/indirect_iterator.hpp>
+ #include <boost/iterator/transform_iterator.hpp>
++#include <boost/iterator/iterator_facade.hpp>
++using namespace boost::iterators::detail;
+ #include <boost/range/detail/any_iterator.hpp>
+ #include <cassert>
+ #include <functional>
+diff --git a/src/search_engine.cpp b/src/search_engine.cpp
+index 222e93e..9140af0 100644
+--- a/src/search_engine.cpp
++++ b/src/search_engine.cpp
+@@ -19,6 +19,8 @@
+  ***************************************************************************/
+ 
+ #include <array>
++#include <boost/iterator/iterator_facade.hpp>
++using namespace boost::iterators::detail;
+ #include <boost/range/detail/any_iterator.hpp>
+ #include <iomanip>
+ 
+diff --git a/src/song_list.h b/src/song_list.h
+index 17c67de..0311a01 100644
+--- a/src/song_list.h
++++ b/src/song_list.h
+@@ -21,6 +21,8 @@
+ #ifndef NCMPCPP_SONG_LIST_H
+ #define NCMPCPP_SONG_LIST_H
+ 
++#include <boost/iterator/iterator_facade.hpp>
++using namespace boost::iterators::detail;
+ #include <boost/range/detail/any_iterator.hpp>
+ #include <boost/tuple/tuple.hpp>
+ #include "menu.h"

--- a/media-sound/ncmpcpp/ncmpcpp-0.7.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-0.7.ebuild
@@ -3,7 +3,7 @@
 # $Id$
 
 EAPI=5
-inherit eutils
+inherit eutils flag-o-matic
 
 DESCRIPTION="featureful ncurses based MPD client inspired by ncmpc"
 HOMEPAGE="http://ncmpcpp.rybczak.net/"
@@ -15,7 +15,6 @@ KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="clock curl outputs taglib unicode visualizer"
 
 RDEPEND="
-	!dev-libs/boost:0/1.57.0
 	>=media-libs/libmpdclient-2.1
 	dev-libs/boost:=[nls,threads]
 	sys-libs/ncurses:=[unicode?]
@@ -31,11 +30,13 @@ DEPEND="
 "
 
 src_prepare() {
+	epatch ${FILESDIR}/circumvent-boost-1.57-bug.patch
 	sed -i -e '/^docdir/d' {,doc/}Makefile{.am,.in} || die
 	sed -i -e 's|COPYING||g' Makefile{.am,.in} || die
 }
 
 src_configure() {
+	append-cxxflags -fpermissive
 	econf \
 		$(use_enable clock) \
 		$(use_enable outputs) \

--- a/media-sound/ncmpcpp/ncmpcpp-9999.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit autotools eutils git-r3
+inherit autotools eutils git-r3 flag-o-matic
 
 DESCRIPTION="featureful ncurses based MPD client inspired by ncmpc"
 HOMEPAGE="http://ncmpcpp.rybczak.net/"
@@ -16,7 +16,6 @@ KEYWORDS=""
 IUSE="clock curl outputs taglib unicode visualizer"
 
 RDEPEND="
-	!dev-libs/boost:0/1.57.0
 	>=media-libs/libmpdclient-2.1
 	dev-libs/boost:=[nls,threads]
 	sys-libs/ncurses:=[unicode?]
@@ -32,12 +31,14 @@ DEPEND="
 "
 
 src_prepare() {
+	epatch ${FILESDIR}/circumvent-boost-1.57-bug.patch
 	sed -i -e '/^docdir/d' {,doc/}Makefile.am || die
 	sed -i -e 's|COPYING||g' Makefile.am || die
 	eautoreconf
 }
 
 src_configure() {
+	append-cxxflags -fpermissive
 	econf \
 		$(use_enable clock) \
 		$(use_enable outputs) \


### PR DESCRIPTION
Hi, this fixes https://bugs.gentoo.org/show_bug.cgi?id=565102 by patching ncmpcpp and adding `-fpermissive` to `CXXFLAGS`.
