### PR TITLE
media-video/aegisub: add missing pthread flags

### DIFF
--- a/media-video/aegisub/aegisub-3.2.2.ebuild
+++ b/media-video/aegisub/aegisub-3.2.2.ebuild
@@ -63,6 +63,7 @@ REQUIRED_USE="
 PATCHES=(
 	"${FILESDIR}/${P}-fix-lua-regexp.patch"
 	"${FILESDIR}/${P}-unbundle-luajit.patch"
+	"${FILESDIR}/${P}-add-missing-pthread-flags.patch"
 	"${FILESDIR}/${P}-respect-user-compiler-flags.patch"
 )
 

--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -60,6 +60,7 @@ REQUIRED_USE="
 PATCHES=(
 	"${FILESDIR}/${PN}-3.2.2-fix-lua-regexp.patch"
 	"${FILESDIR}/${P}-unbundle-luajit.patch"
+	"${FILESDIR}/${P}-add-missing-pthread-flags.patch"
 	"${FILESDIR}/${P}-respect-user-compiler-flags.patch"
 )
 

--- a/media-video/aegisub/files/aegisub-3.2.2-add-missing-pthread-flags.patch
+++ b/media-video/aegisub/files/aegisub-3.2.2-add-missing-pthread-flags.patch
@@ -1,0 +1,16 @@
+diff --git a/tools/Makefile b/tools/Makefile
+index 81bcef3..f9a6cd3 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -7,8 +7,9 @@ PROGRAM += $(d)osx-bundle-restart-helper
+ endif
+ 
+ repack-thes-dict_OBJ  := $(d)repack-thes-dict.o $(TOP)lib/libaegisub.a
+-repack-thes-dict_LIBS := $(LIBS_BOOST) $(LIBS_ICU)
+-repack-thes-dict_CPPFLAGS := -I$(TOP) -I$(TOP)libaegisub/include $(CFLAGS_ICU)
++repack-thes-dict_LIBS := $(LIBS_BOOST) $(LIBS_ICU) $(LIBS_PTHREAD)
++repack-thes-dict_CPPFLAGS := -I$(TOP) -I$(TOP)libaegisub/include \
++	$(CFLAGS_ICU) $(CFLAGS_PTHREAD)
+ 
+ PROGRAM += $(d)repack-thes-dict
+ 

--- a/media-video/aegisub/files/aegisub-9999-add-missing-pthread-flags.patch
+++ b/media-video/aegisub/files/aegisub-9999-add-missing-pthread-flags.patch
@@ -1,0 +1,14 @@
+diff --git a/tools/Makefile b/tools/Makefile
+index d9f64b8..f9a6cd3 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -8,7 +8,8 @@ endif
+ 
+ repack-thes-dict_OBJ  := $(d)repack-thes-dict.o $(TOP)lib/libaegisub.a
+ repack-thes-dict_LIBS := $(LIBS_BOOST) $(LIBS_ICU) $(LIBS_PTHREAD)
+-repack-thes-dict_CPPFLAGS := -I$(TOP) -I$(TOP)libaegisub/include $(CFLAGS_ICU)
++repack-thes-dict_CPPFLAGS := -I$(TOP) -I$(TOP)libaegisub/include \
++	$(CFLAGS_ICU) $(CFLAGS_PTHREAD)
+ 
+ PROGRAM += $(d)repack-thes-dict
+ 


### PR DESCRIPTION
This also fixes build with GCC-5.

Gentoo-Bug: 568878