### PR TITLE
app-text/asciidoc-9999: fix a typo

### DIFF
--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -92,7 +92,7 @@ src_install() {
 		dosym ../../../asciidoc/images /usr/share/doc/${PF}/examples
 	fi
 
-	readme.gentoo.create_doc
+	readme.gentoo_create_doc
 	dodoc BUGS CHANGELOG README docbook-xsl/asciidoc-docbook-xsl.txt \
 			dblatex/dblatex-readme.txt filters/code/code-filter-readme.txt
 }


### PR DESCRIPTION
Package-Manager: portage-2.2.24
Signed-off-by: Marc Joliet <marcec@gmx.de>