### PR TITLE
media-video/aegisub: drop useless slot operator on luajit dependency

### DIFF
--- a/media-video/aegisub/aegisub-3.2.2.ebuild
+++ b/media-video/aegisub/aegisub-3.2.2.ebuild
@@ -27,7 +27,7 @@ IUSE="alsa debug +ffmpeg +fftw openal oss portaudio pulseaudio spell"
 # However, most of these minimal versions date back to 2006-2010 yy.
 # Such version specifiers are meaningless nowadays, so they are omitted.
 RDEPEND="
-	>=dev-lang/luajit-2.0.3:2=
+	>=dev-lang/luajit-2.0.3:2
 	>=dev-libs/boost-1.50.0:=[icu,nls,threads]
 	>=dev-libs/icu-4.8.1.1:=
 	>=x11-libs/wxGTK-3.0.0:${WX_GTK_VER}[X,opengl,debug?]

--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -24,7 +24,7 @@ IUSE="alsa debug +ffmpeg +fftw openal oss portaudio pulseaudio spell"
 # However, most of these minimal versions date back to 2006-2010 yy.
 # Such version specifiers are meaningless nowadays, so they are omitted.
 RDEPEND="
-	>=dev-lang/luajit-2.0.4:2=
+	>=dev-lang/luajit-2.0.4:2
 	>=dev-libs/boost-1.50.0:=[icu,nls,threads]
 	>=dev-libs/icu-4.8.1.1:=
 	>=x11-libs/wxGTK-3.0.0:${WX_GTK_VER}[X,opengl,debug?]


### PR DESCRIPTION
dev-lang/luajit does not have sub-slots and we require SLOT 2 only.

Package-Manager: portage-2.2.24