### PR TITLE
media-video/qgifer: opencv3 slot depedency

### DIFF
--- a/media-video/qgifer/metadata.xml
+++ b/media-video/qgifer/metadata.xml
@@ -12,7 +12,7 @@
 	</longdescription>
 	<use>
 		<flag name="imagemagick">Use imagemagick for image operations</flag>
-		<flag name="opencv3">Use opencv-3.* for video operations instead opencv-2.*</flag>
+		<flag name="opencv3">Use media-libs/opencv:0/3.0 for video operations instead media-libs/opencv:0/2.4</flag>
 	</use>
 	<upstream>
 		<remote-id type="sourceforge">qgifer</remote-id>

--- a/media-video/qgifer/qgifer-0.2.1-r2.ebuild
+++ b/media-video/qgifer/qgifer-0.2.1-r2.ebuild
@@ -17,30 +17,30 @@ KEYWORDS="~amd64 ~x86"
 IUSE="debug imagemagick opencv3"
 
 RDEPEND="media-libs/giflib:0
-    dev-qt/qtcore:4
-    dev-qt/qtgui:4
-    imagemagick? ( media-gfx/imagemagick:0 )
-    !opencv3? ( media-libs/opencv:0/2.4[ffmpeg] )
-    opencv3? ( media-libs/opencv:0/3.0[ffmpeg] )
-    virtual/ffmpeg:0"
+	dev-qt/qtcore:4
+	dev-qt/qtgui:4
+	imagemagick? ( media-gfx/imagemagick:0 )
+	!opencv3? ( media-libs/opencv:0/2.4[ffmpeg] )
+	opencv3? ( media-libs/opencv:0/3.0[ffmpeg] )
+	virtual/ffmpeg:0"
 
 DEPEND="${RDEPEND}
-    >=dev-util/cmake-2.8:0"
+	>=dev-util/cmake-2.8:0"
 
 S="${WORKDIR}/${P}-source"
 
 src_prepare() {
-    epatch "${FILESDIR}"/${P}-desktop.patch
+	epatch "${FILESDIR}"/${P}-desktop.patch
 
-    if use opencv3 ; then
-        epatch "${FILESDIR}"/${P}-opencv3.patch
-    fi
+	if use opencv3 ; then
+		epatch "${FILESDIR}"/${P}-opencv3.patch
+	fi
 }
 
 src_configure() {
-    local mycmakeargs
+	local mycmakeargs
 
-    use debug && mycmakeargs=( -DRELEASE_MODE=OFF )
+	use debug && mycmakeargs=( -DRELEASE_MODE=OFF )
 
-    cmake-utils_src_configure
+	cmake-utils_src_configure
 }

--- a/media-video/qgifer/qgifer-0.2.1-r2.ebuild
+++ b/media-video/qgifer/qgifer-0.2.1-r2.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+inherit cmake-utils
+
+DESCRIPTION="A video-based animated GIF creator"
+HOMEPAGE="https://sourceforge.net/projects/qgifer/"
+SRC_URI="mirror://sourceforge/${PN}/${P}-source.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+IUSE="debug imagemagick opencv3"
+
+RDEPEND="media-libs/giflib:0
+    dev-qt/qtcore:4
+    dev-qt/qtgui:4
+    imagemagick? ( media-gfx/imagemagick:0 )
+    !opencv3? ( media-libs/opencv:0/2.4[ffmpeg] )
+    opencv3? ( media-libs/opencv:0/3.0[ffmpeg] )
+    virtual/ffmpeg:0"
+
+DEPEND="${RDEPEND}
+    >=dev-util/cmake-2.8:0"
+
+S="${WORKDIR}/${P}-source"
+
+src_prepare() {
+    epatch "${FILESDIR}"/${P}-desktop.patch
+
+    if use opencv3 ; then
+        epatch "${FILESDIR}"/${P}-opencv3.patch
+    fi
+}
+
+src_configure() {
+    local mycmakeargs
+
+    use debug && mycmakeargs=( -DRELEASE_MODE=OFF )
+
+    cmake-utils_src_configure
+}


### PR DESCRIPTION
I've fixed dependency to be from specific slot rather than version number. Seems to be more gentoo way.
Just fixing my commit issue from bugzilla by Amadeusz Żołnowski