### PR TITLE
net-analyzer/zabbix: Fix ebuild fault: file 'postinstall-en.txt' not found

### DIFF
--- a/net-analyzer/zabbix/zabbix-2.2.11.ebuild
+++ b/net-analyzer/zabbix/zabbix-2.2.11.ebuild
@@ -323,7 +323,6 @@ src_install() {
 	if use frontend; then
 		webapp_src_preinst
 		cp -R frontends/php/* "${D}/${MY_HTDOCSDIR}"
-		webapp_postinst_txt en "${FILESDIR}/"1.6.6/postinstall-en.txt
 		webapp_configfile \
 			"${MY_HTDOCSDIR}"/include/db.inc.php \
 			"${MY_HTDOCSDIR}"/include/config.inc.php

--- a/net-analyzer/zabbix/zabbix-2.2.5.ebuild
+++ b/net-analyzer/zabbix/zabbix-2.2.5.ebuild
@@ -325,7 +325,6 @@ src_install() {
 	if use frontend; then
 		webapp_src_preinst
 		cp -R frontends/php/* "${D}/${MY_HTDOCSDIR}"
-		webapp_postinst_txt en "${FILESDIR}/"1.6.6/postinstall-en.txt
 		webapp_configfile \
 			"${MY_HTDOCSDIR}"/include/db.inc.php \
 			"${MY_HTDOCSDIR}"/include/config.inc.php

--- a/net-analyzer/zabbix/zabbix-2.2.9.ebuild
+++ b/net-analyzer/zabbix/zabbix-2.2.9.ebuild
@@ -323,7 +323,6 @@ src_install() {
 	if use frontend; then
 		webapp_src_preinst
 		cp -R frontends/php/* "${D}/${MY_HTDOCSDIR}"
-		webapp_postinst_txt en "${FILESDIR}/"1.6.6/postinstall-en.txt
 		webapp_configfile \
 			"${MY_HTDOCSDIR}"/include/db.inc.php \
 			"${MY_HTDOCSDIR}"/include/config.inc.php

--- a/net-analyzer/zabbix/zabbix-2.4.5.ebuild
+++ b/net-analyzer/zabbix/zabbix-2.4.5.ebuild
@@ -323,7 +323,6 @@ src_install() {
 	if use frontend; then
 		webapp_src_preinst
 		cp -R frontends/php/* "${D}/${MY_HTDOCSDIR}"
-		webapp_postinst_txt en "${FILESDIR}/"1.6.6/postinstall-en.txt
 		webapp_configfile \
 			"${MY_HTDOCSDIR}"/include/db.inc.php \
 			"${MY_HTDOCSDIR}"/include/config.inc.php

--- a/net-analyzer/zabbix/zabbix-2.4.7.ebuild
+++ b/net-analyzer/zabbix/zabbix-2.4.7.ebuild
@@ -323,7 +323,6 @@ src_install() {
 	if use frontend; then
 		webapp_src_preinst
 		cp -R frontends/php/* "${D}/${MY_HTDOCSDIR}"
-		webapp_postinst_txt en "${FILESDIR}/"1.6.6/postinstall-en.txt
 		webapp_configfile \
 			"${MY_HTDOCSDIR}"/include/db.inc.php \
 			"${MY_HTDOCSDIR}"/include/config.inc.php


### PR DESCRIPTION
I've delete the reference to the old `files/1.6.6/postinstall-en.txt` file.
The `files/1.6.6/postinstall-en.txt` has been removed on the 178b4659cf9e6b59383077fc6cddf905de620fef .

----

I've encountered:

```
>>> Failed to emerge net-analyzer/zabbix-2.2.5, Log file:

>>>  '/var/tmp/portage/net-analyzer/zabbix-2.2.5/temp/build.log'

 * Messages for package net-analyzer/zabbix-2.2.5:

 * ebuild fault: file '/usr/portage/net-analyzer/zabbix/files/1.6.6/postinstall-en.txt' not found
 * Please report this as a bug at https://bugs.gentoo.org/
 * ERROR: net-analyzer/zabbix-2.2.5::gentoo failed (install phase):
 *   ebuild fault: file '/usr/portage/net-analyzer/zabbix/files/1.6.6/postinstall-en.txt' not found
 * 
 * Call stack:
 *     ebuild.sh, line   90:  Called src_install
 *   environment, line 5564:  Called webapp_postinst_txt 'en' '/usr/portage/net-analyzer/zabbix/files/1.6.6/postinstall-en.txt'
 *   environment, line 6823:  Called webapp_checkfileexists '/usr/portage/net-analyzer/zabbix/files/1.6.6/postinstall-en.txt'
 *   environment, line 6620:  Called die
 * The specific snippet of code:
 *           die "$msg";
 * 
 * If you need support, post the output of `emerge --info '=net-analyzer/zabbix-2.2.5::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=net-analyzer/zabbix-2.2.5::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/net-analyzer/zabbix-2.2.5/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/net-analyzer/zabbix-2.2.5/temp/environment'.
 * Working directory: '/var/tmp/portage/net-analyzer/zabbix-2.2.5/work/zabbix-2.2.5'
 * S: '/var/tmp/portage/net-analyzer/zabbix-2.2.5/work/zabbix-2.2.5'
```