### PR TITLE
media-gfx/digikam: Fix build w/ media-libs/lensfun-0.3.2, bug 566624

### DIFF
--- a/media-gfx/digikam/digikam-4.12.0.ebuild
+++ b/media-gfx/digikam/digikam-4.12.0.ebuild
@@ -71,6 +71,8 @@ S="${WORKDIR}/${MY_P}/core"
 RESTRICT=test
 # bug 366505
 
+PATCHES=( "${FILESDIR}/${PN}-4.14.0-lensfun.patch" ) # bug 566624
+
 src_prepare() {
 	# just to make absolutely sure
 	rm -rf "${WORKDIR}/${MY_P}/extra" || die

--- a/media-gfx/digikam/digikam-4.14.0.ebuild
+++ b/media-gfx/digikam/digikam-4.14.0.ebuild
@@ -72,6 +72,8 @@ S="${WORKDIR}/${MY_P}/core"
 RESTRICT=test
 # bug 366505
 
+PATCHES=( "${FILESDIR}/${PN}-4.14.0-lensfun.patch" ) # bug 566624
+
 src_prepare() {
 	# just to make absolutely sure
 	rm -rf "${WORKDIR}/${MY_P}/extra" || die

--- a/media-gfx/digikam/digikam-4.4.0-r1.ebuild
+++ b/media-gfx/digikam/digikam-4.4.0-r1.ebuild
@@ -82,6 +82,7 @@ RESTRICT=test
 PATCHES=(
 	"${FILESDIR}/${P}-libkexiv2.patch"
 	"${FILESDIR}/${P}-hang.patch"
+	"${FILESDIR}/${PN}-4.14.0-lensfun.patch" # bug 566624
 )
 
 src_prepare() {

--- a/media-gfx/digikam/files/digikam-4.14.0-lensfun.patch
+++ b/media-gfx/digikam/files/digikam-4.14.0-lensfun.patch
@@ -1,0 +1,26 @@
+From: Gilles Caulier <caulier.gilles@gmail.com>
+Date: Mon, 14 Dec 2015 21:41:55 +0000
+Subject: fix compilation with Lensfun 0.3.2
+X-Git-Url: http://quickgit.kde.org/?p=digikam.git&a=commitdiff&h=0f159981176faa6da701f112bfe557b79804d468
+---
+fix compilation with Lensfun 0.3.2
+It still compatible with older lensfun releases.
+BUGS: 356672
+FIXED-IN: 5.0.0
+---
+
+
+--- a/libs/dimg/filters/lens/lensfuniface.h
++++ b/libs/dimg/filters/lens/lensfuniface.h
+@@ -24,10 +24,7 @@
+ 
+ // Lib LensFun includes
+ 
+-extern "C"
+-{
+ #include <lensfun.h>
+-}
+ 
+ // Local includes
+ 
+


### PR DESCRIPTION
Patch from upstream applies to all three versions, unfortunately no digikam:4 left on my own systems but seems to have gotten enough ACKs as-is. Will test with a full build on occasion.

Package-Manager: portage-2.2.24