### PR TITLE
net-im/telepathy-mission-control: Add ck2 alternative RDEPEND

### DIFF
--- a/net-im/telepathy-mission-control/telepathy-mission-control-5.16.3-r1.ebuild
+++ b/net-im/telepathy-mission-control/telepathy-mission-control-5.16.3-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+GCONF_DEBUG="no"
+GNOME2_LA_PUNT="yes"
+# Needed for tests and build #489466
+PYTHON_COMPAT=( python2_7 )
+
+inherit gnome2 python-any-r1
+
+DESCRIPTION="An account manager and channel dispatcher for the Telepathy framework"
+HOMEPAGE="http://cgit.freedesktop.org/telepathy/telepathy-mission-control/"
+SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~arm-linux ~x86-linux"
+IUSE="debug networkmanager" # test
+
+RDEPEND="
+	>=dev-libs/dbus-glib-0.82
+	>=dev-libs/glib-2.32:2
+	>=sys-apps/dbus-0.95
+	>=net-libs/telepathy-glib-0.20
+	networkmanager? ( >=net-misc/networkmanager-0.7 )
+"
+DEPEND="${RDEPEND}
+	${PYTHON_DEPS}
+	dev-libs/libxslt
+	>=dev-util/gtk-doc-am-1.17
+	virtual/pkgconfig
+"
+#	test? ( dev-python/twisted-words )"
+
+# Tests are broken, see upstream bug #29334 and #64212
+# upstream doesn't want it enabled everywhere (#29334#c12)
+RESTRICT="test"
+
+src_configure() {
+	# creds is not available
+	gnome2_src_configure \
+		--disable-static \
+		--disable-upower \
+		$(use_enable debug) \
+		$(use_with networkmanager connectivity nm)
+}


### PR DESCRIPTION
If built with --disable-upower, telepathy-mission-control will listen for
PrepareForSleep signal instead, which is now also available through
ConsoleKit2. ~~We can keep USE=upower for the time being, but get rid of
USE=systemd now since it is really only one option in case of USE=!upower.~~

References:
https://bugs.freedesktop.org/show_bug.cgi?id=70458
http://consolekit2.github.io/ConsoleKit2/#Manager::PrepareForSleep

This should be given thorough testing of course, preferably by someone who actually does suspend frequently.

**EDIT:** Removing ``USE=upower`` makes the ebuild even simpler, obsoletes ``systemd`` at the same time. Also it really means only 'legacy-upower' in reality and thus conflicts with other packages that require upower with the flag enabled.