### PR TITLE
net-proxy/shadowsocks-libev: add systemd files

### DIFF
--- a/net-proxy/shadowsocks-libev/files/shadowsocks-libev-local_at.service
+++ b/net-proxy/shadowsocks-libev/files/shadowsocks-libev-local_at.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Shadowsocks-Libev Client Service for %I
+After=network.target
+
+[Service]
+Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/ss-local -c /etc/shadowsocks-libev/%i.json
+
+[Install]
+WantedBy=multi-user.target

--- a/net-proxy/shadowsocks-libev/files/shadowsocks-libev-redir_at.service
+++ b/net-proxy/shadowsocks-libev/files/shadowsocks-libev-redir_at.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Shadowsocks-Libev Client Service Redir Mode for %I
+After=network.target
+
+[Service]
+Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/ss-redir -c /etc/shadowsocks-libev/%i.json
+
+[Install]
+WantedBy=multi-user.target

--- a/net-proxy/shadowsocks-libev/files/shadowsocks-libev-server_at.service
+++ b/net-proxy/shadowsocks-libev/files/shadowsocks-libev-server_at.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Shadowsocks-Libev Server Service for %I
+After=network.target
+
+[Service]
+Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/ss-server -c /etc/shadowsocks-libev/%i.json
+
+[Install]
+WantedBy=multi-user.target

--- a/net-proxy/shadowsocks-libev/files/shadowsocks-libev-tunnel_at.service
+++ b/net-proxy/shadowsocks-libev/files/shadowsocks-libev-tunnel_at.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Shadowsocks-Libev Client Service Tunnel Mode for %I
+After=network.target
+
+[Service]
+Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/ss-tunnel -c /etc/shadowsocks-libev/%i.json
+
+[Install]
+WantedBy=multi-user.target

--- a/net-proxy/shadowsocks-libev/files/shadowsocks.initd
+++ b/net-proxy/shadowsocks-libev/files/shadowsocks.initd
@@ -3,7 +3,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-SS_CONFIG="/etc/shadowsocks.json"
+SS_CONFIG="/etc/shadowsocks-libev/shadowsocks.json"
 
 SS_PIDFILE="/run/shadowsocks.pid"
 
@@ -26,10 +26,20 @@ checkconfig() {
         SS_COMMAND="/usr/bin/ss-server"
 	return 0
 	;;
+    redir)
+        SS_COMMAND="/usr/bin/ss-redir"
+	return 0
+	;;
+    tunnel)
+        SS_COMMAND="/usr/bin/ss-tunnel"
+	return 0
+	;;
     *)
     	eerror "please choose to run as server or client mode"
     	eerror "  server: rc-update add shadowsocks.server default"
     	eerror "  client: rc-update add shadowsocks.client default"
+    	eerror "  client: rc-update add shadowsocks.redir default"
+    	eerror "  client: rc-update add shadowsocks.tunnel default"
         return 1
     	;;
     esac

--- a/net-proxy/shadowsocks-libev/shadowsocks-libev-2.4.3-r1.ebuild
+++ b/net-proxy/shadowsocks-libev/shadowsocks-libev-2.4.3-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit eutils systemd
+
+DESCRIPTION="A lightweight secured scoks5 proxy for embedded devices and low end boxes"
+HOMEPAGE="https://github.com/shadowsocks/shadowsocks-libev"
+
+MY_PV="v${PV}"
+SRC_URI="https://github.com/shadowsocks/${PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug +openssl polarssl"
+
+DEPEND="openssl? ( dev-libs/openssl:= )
+	polarssl? ( net-libs/polarssl )
+	"
+RDEPEND="${DEPEND}"
+
+REQUIRED_USE=" ^^ ( openssl polarssl )"
+
+src_configure() {
+	econf \
+		$(use_enable debug assert) \
+		--with-crypto-library=$(usex openssl openssl polarssl)
+}
+
+src_install() {
+	default
+	prune_libtool_files --all
+
+	mkdir -p "${D}/etc/${PN}"
+	insinto "/etc/${PN}"
+	newins "${FILESDIR}/shadowsocks.json" shadowsocks.json
+
+	newinitd "${FILESDIR}/shadowsocks.initd" shadowsocks
+	dosym /etc/init.d/shadowsocks /etc/init.d/shadowsocks.server
+	dosym /etc/init.d/shadowsocks /etc/init.d/shadowsocks.client
+
+	systemd_newunit "${FILESDIR}/${PN}-local_at.service" "${PN}-local@.service"
+	systemd_newunit "${FILESDIR}/${PN}-server_at.service" "${PN}-server@.service"
+	systemd_newunit "${FILESDIR}/${PN}-redir_at.service" "${PN}-redir@.service"
+	systemd_newunit "${FILESDIR}/${PN}-tunnel_at.service" "${PN}-tunnel@.service"
+}
+
+pkg_setup() {
+	elog "You need to choose the mode"
+	elog "  server: rc-update add shadowsocks.server default"
+	elog "  client: rc-update add shadowsocks.client default"
+	elog "  redir:  rc-update add shadowsocks.redir default"
+	elog "  tunnel: rc-update add shadowsocks.tunnel default"
+}


### PR DESCRIPTION
@dlan17 

Now systemd users can use `systemctl enable shadowsocks-libev-local@xxx` to auto start `ss-local -c /etc/shadowsocks-libev/xxx.json`.