### PR TITLE
mate-base/mate-applets: don't run python_fix_shebang on a missing dir #567468

### DIFF
--- a/mate-base/mate-applets/mate-applets-1.8.0-r1.ebuild
+++ b/mate-base/mate-applets/mate-applets-1.8.0-r1.ebuild
@@ -82,7 +82,7 @@ src_test() {
 DOCS="AUTHORS ChangeLog NEWS README"
 
 src_install() {
-	python_fix_shebang invest-applet timer-applet/src
+	python_fix_shebang invest-applet
 	gnome2_src_install
 
 	local APPLETS="accessx-status battstat charpick command cpufreq drivemount

--- a/mate-base/mate-applets/mate-applets-1.8.1.ebuild
+++ b/mate-base/mate-applets/mate-applets-1.8.1.ebuild
@@ -84,7 +84,7 @@ src_test() {
 DOCS="AUTHORS ChangeLog NEWS README"
 
 src_install() {
-	python_fix_shebang invest-applet timer-applet/src
+	python_fix_shebang invest-applet
 	gnome2_src_install
 
 	local APPLETS="accessx-status battstat charpick command cpufreq drivemount


### PR DESCRIPTION
Ebuild tries to run python_fix_shebang on 'timer-applet/src' directory which
does not exist. This is likely a leftover from the 1.6 series ebuild [1].
Upstream removed the old timer-applet [2] and replaced it with a brand new
implementation written in C [3]. Remove 'timer-applet/src' from the list
of arguments for python_fix_shebang.

[1] https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/mate-base/mate-applets/mate-applets-1.6.2-r1.ebuild?hideattic=0&view=markup
[2] https://github.com/mate-desktop/mate-applets/commit/103274c655d5eed254b552ed5cf19265cd8f98f2
[3] https://github.com/mate-desktop/mate-applets/commit/9c4ef5136fed495e618610ba675a03de9efbe921

Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=567468

Package-Manager: portage-2.2.24