### PR TITLE
mate-extra/mate-power-manager: fix incorrect RDEPEND on gnome-keyring #548536

### DIFF
--- a/mate-extra/mate-power-manager/mate-power-manager-1.8.0-r1.ebuild
+++ b/mate-extra/mate-power-manager/mate-power-manager-1.8.0-r1.ebuild
@@ -39,7 +39,7 @@ COMMON_DEPEND="app-text/rarian:0
 	>=x11-libs/libnotify-0.7:0
 	x11-libs/pango:0
 	applet? ( >=mate-base/mate-panel-1.8:0 )
-	gnome-keyring? ( >=gnome-base/gnome-keyring-3:0 )
+	gnome-keyring? ( >=gnome-base/libgnome-keyring-3:0 )
 	unique? ( >=dev-libs/libunique-0.9.4:1 )"
 
 RDEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
mate-power-manager depends on libgnome-keyring but gnome-keyring is
incorrectly specified in RDEPEND instead.

Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=548536

Package-Manager: portage-2.2.24