### PR TITLE
media-sound/teamspeak-client-bin: fetch restrict removed

### DIFF
--- a/media-sound/teamspeak-client-bin/teamspeak-client-bin-3.0.18.2.ebuild
+++ b/media-sound/teamspeak-client-bin/teamspeak-client-bin-3.0.18.2.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	alsa? ( media-libs/alsa-lib )
 	pulseaudio? ( media-sound/pulseaudio )"
 
-RESTRICT="fetch strip"
+RESTRICT="mirror strip"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
Permission for direct download of teamspeak software from teamspeak
mirrors has been granted for Gentoo Linux. Fetch restrict is gone
but we now need to restrict mirroring. Details of this special
permission are discussed in the Gentoo Bugzilla.

Permission email: https://bugs.gentoo.org/attachment.cgi?id=421386

Gentoo-Bug: 562532

Package-Manager: portage-2.2.20