### PR TITLE
media-sound/mpd: add a systemd user service

### DIFF
--- a/media-sound/mpd/mpd-0.19.11.ebuild
+++ b/media-sound/mpd/mpd-0.19.11.ebuild
@@ -223,6 +223,8 @@ src_install() {
 
 	newinitd "${FILESDIR}"/${PN}2.init ${PN}
 
+	systemd_newuserunit systemd/${PN}.service ${PN}.service
+
 	if use unicode; then
 		sed -i -e 's:^#filesystem_charset.*$:filesystem_charset "UTF-8":' \
 			"${ED}"/etc/mpd.conf || die "sed failed"


### PR DESCRIPTION
This allows a user to run mpd through systemd locally, instead of a system-wide global instance under the mpd user.

Note that I am not entirely sure this (ie. copying the existing system unit as a user unit) is a correct approach, but it works without complaints here and is basically what they are doing in arch: https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/mpd#n52

This probably warrants a version bump, which I can do and just omitted it for now for clarity.