### PR TITLE
media-video/mpv: add missing zsh-completion USE flag

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -33,7 +33,7 @@ IUSE="+alsa archive bluray cdda +cli doc drm dvb +dvd +egl +enca encode gbm
 	+iconv jack jpeg lcms +libass libav libcaca libguess libmpv lua luajit
 	openal +opengl oss pulseaudio raspberry-pi rubberband samba sdl selinux
 	test uchardet v4l vaapi vdpau vf-dlopen wayland +X xinerama +xscreensaver
-	xv"
+	xv zsh-completion"
 
 REQUIRED_USE="
 	|| ( cli libmpv )
@@ -52,6 +52,7 @@ REQUIRED_USE="
 	xinerama? ( X )
 	xscreensaver? ( X )
 	xv? ( X )
+	zsh-completion? ( cli )
 "
 
 COMMON_DEPEND="
@@ -179,7 +180,7 @@ src_configure() {
 
 		$(use_enable doc pdf-build)
 		$(use_enable vf-dlopen vf-dlopen-filters)
-		$(use_enable cli zsh-comp)
+		$(use_enable zsh-completion zsh-comp)
 		$(use_enable test)
 
 		$(use_enable iconv)


### PR DESCRIPTION
Zsh completion is a separate feature from CLI player.
Thus it should be controlled by a separate 'zsh-completion' USE.

Make 'zsh-completion' USE require 'cli' USE, since completions
for a shared library are not useful.

Package-Manager: portage-2.2.24