### PR TITLE
media-libs/mlt: Fix build with USE=gtk caused by wrong arch, bug 570508

### DIFF
--- a/kde-apps/kdenlive/kdenlive-15.12.0-r1.ebuild
+++ b/kde-apps/kdenlive/kdenlive-15.12.0-r1.ebuild
@@ -56,7 +56,10 @@ DEPEND="${RDEPEND}
 	sys-devel/gettext
 "
 
-PATCHES=( "${FILESDIR}/${PN}-15.12.0-kcrash.patch" )
+src_prepare() {
+	epatch "${FILESDIR}/${PN}-15.12.0-kcrash.patch"
+	kde5_src_prepare
+}
 
 src_configure() {
 	local mycmakeargs=(

--- a/media-libs/mlt/mlt-0.9.8-r1.ebuild
+++ b/media-libs/mlt/mlt-0.9.8-r1.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 PYTHON_COMPAT=( python2_7 )
 USE_RUBY="ruby19"
-inherit eutils toolchain-funcs linux-info multilib python-single-r1 ruby-single
+inherit eutils toolchain-funcs multilib python-single-r1 ruby-single
 
 DESCRIPTION="Open source multimedia framework for television broadcasting"
 HOMEPAGE="http://www.mltframework.org/"
@@ -88,7 +88,6 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )
 "
 
 pkg_setup() {
-	linux-info_pkg_setup
 	use python && python-single-r1_pkg_setup
 }
 
@@ -110,7 +109,7 @@ src_configure() {
 	local myconf="--enable-gpl
 		--enable-gpl3
 		--enable-motion-est
-		--target-arch=$(tc-arch-kernel)
+		--target-arch=$(tc-arch)
 		--disable-swfdec
 		$(use_enable debug)
 		$(use compressed-lumas && echo ' --luma-compress')


### PR DESCRIPTION
Use tc-arch instead of tc-arch-kernel

Package-Manager: portage-2.2.24

@gentoo/kde @gentoo/video