### PR TITLE
media-video/mpv: prepare sdl and rubberband for the next stable mpv version

### DIFF
--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -159,10 +159,6 @@ media-video/ffmpeg x265
 # Missing keywords on dev-python/rst2pdf, bug #515222
 media-video/mpv doc-pdf
 
-# Julian Ospald <hasufell@gentoo.org> (20 Apr 2014)
-# Missing keywords, bug #508226
-media-video/mpv sdl
-
 # Pacho Ramos <pacho@gentoo.org> (15 Mar 2014)
 # Missing keywords, bug #504672
 >=net-misc/vinagre-3.10 rdp

--- a/profiles/arch/alpha/package.use.stable.mask
+++ b/profiles/arch/alpha/package.use.stable.mask
@@ -17,7 +17,13 @@
 #
 
 #--- END OF EXAMPLES ---
-#
+
+# Ian Delaney <idella4@gentoo.org> (04 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# media-libs/libsdl2 wasn't stabilized in the past, but now
+# it's ready for the next stable mpv release after the one below.
+=media-video/mpv-0.9.2-r1 sdl
+
 # Tobias Klausmann <klausman@gentoo.org> (17 Sep 2015)
 # Move this mask here (from package.use.mask) until net-fs/libnfs goes stable.
 # Gilles Dartiguelongue <eva@gentoo.org> (09 Jun 2015)

--- a/profiles/arch/alpha/package.use.stable.mask
+++ b/profiles/arch/alpha/package.use.stable.mask
@@ -20,6 +20,12 @@
 
 # Ian Delaney <idella4@gentoo.org> (04 Jan 2016)
 # on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# Hopefully media-libs/rubberband goes stable before
+# the next stable version of mpv. See bug #570510.
+=media-video/mpv-0.9.2-r1 rubberband
+
+# Ian Delaney <idella4@gentoo.org> (04 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
 # media-libs/libsdl2 wasn't stabilized in the past, but now
 # it's ready for the next stable mpv release after the one below.
 =media-video/mpv-0.9.2-r1 sdl
@@ -29,13 +35,6 @@
 # Gilles Dartiguelongue <eva@gentoo.org> (09 Jun 2015)
 # net-fs/libnfs lacks alpha keyword, bug #551576
 gnome-base/gvfs nfs
-
-# Tobias Klausmann <klausman@gentoo.org> (16 Sep 2015)
-# Move this mask here (from package.use.mask) until rubberband goes stable.
-# Also see commit 0ccb06790085936e2da1832e5bf1d1b637d6c54a
-# Ben de Groot <yngwin@gentoo.org> (03 May 2015)
-# media-libs/rubberband lacks alpha keyword, bug #548446
-media-video/mpv rubberband
 
 # Tobias Klausmann <klausman@gentoo.org> (29 Jul 2015)
 # Mask webkit so the dep can stay ~alpha forever

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -150,10 +150,6 @@ mail-filter/opendkim opendbx
 # Unkeyworded deps, bug #507896
 dev-qt/qt-mobility messaging
 
-# Julian Ospald <hasufell@gentoo.org> (20 Apr 2014)
-# Missing keywords, bug #508226
-media-video/mpv sdl
-
 # S. Suominen <ssuominen@g.o> (17 Apr 2014)
 # First GTK+-3.x version of EasyTAG!
 # Keyword as reqiuired, ~arch is enough for now:

--- a/profiles/arch/arm/package.use.stable.mask
+++ b/profiles/arch/arm/package.use.stable.mask
@@ -2,6 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+# Ian Delaney <idella4@gentoo.org> (04 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# media-libs/libsdl2 wasn't stabilized in the past, but now
+# it's ready for the next stable mpv release after the one below.
+=media-video/mpv-0.9.2-r1 sdl
+
 # Michael Palimaka <kensington@gentoo.org> (28 Oct 2015)
 # KDE is not stable on arm
 media-video/vlc kde

--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -126,10 +126,6 @@ media-video/mpv doc-pdf
 # dependency sci-libs/vtk not keyworded on ppc yet
 media-libs/opencv vtk
 
-# Julian Ospald <hasufell@gentoo.org> (20 Apr 2014)
-# Missing keywords, bug #508226
-media-video/mpv sdl
-
 # Johannes Huber <johu@gentoo.org> (16 Apr 2014)
 # unkeyworded deps
 kde-apps/gwenview semantic-desktop

--- a/profiles/arch/powerpc/ppc32/package.use.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.mask
@@ -4,6 +4,11 @@
 
 # This file requires >=portage-2.1.1
 
+# Ian Delaney <idella4@gentoo.org> (04 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# media-libs/libsdl2 lacks ppc32 keyword. See bug #508226.
+media-video/mpv sdl
+
 # Anthony G. Basile <blueness@gentoo.org> (26 Oct 2015)
 # Mask x265 on vlc for bug #564138
 media-video/vlc x265

--- a/profiles/arch/powerpc/ppc64/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.stable.mask
@@ -18,6 +18,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Ian Delaney <idella4@gentoo.org> (04 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# media-libs/libsdl2 wasn't stabilized in the past, but now
+# it's ready for the next stable mpv release after the one below.
+=media-video/mpv-0.9.2-r1 sdl
+
 # Davide Pesavento <pesa@gentoo.org> (11 May 2015)
 # dev-qt/qtopenvg not yet stable
 dev-qt/qtdemo openvg


### PR DESCRIPTION
The idea is to mask sdl and rubberband USEs for the currently stable mpv version only, as opposed to all stable versions now. Since the introduction of the original USE masks, libsdl2 was stabilized and rubberband was keyworded and is currently being stabilized. I'd like to have these features available in the next stable release of mpv. Thus masks need to be adjusted for proper arch testing during the upcoming stabilization procedure.

@idella, please review and merge.

Since I've put Ian's name in the commits I expect this PR to be handled by him personally.