### PR TITLE
kde4-meta.eclass: Depend on same version of kontact

### DIFF
--- a/eclass/kde4-meta.eclass
+++ b/eclass/kde4-meta.eclass
@@ -28,7 +28,7 @@ case ${KMNAME} in
 		case ${PN} in
 			akregator|kaddressbook|kjots|kmail|knode|knotes|korganizer|ktimetracker)
 				IUSE+=" +kontact"
-				RDEPEND+=" kontact? ( $(add_kdeapps_dep kontact) )"
+				RDEPEND+=" kontact? ( $(add_kdeapps_dep kontact '' ${PV}) )"
 				;;
 		esac
 		;;


### PR DESCRIPTION
Since add_kdeapps_dep would otherwise set the min version to 4.14.3
which breaks 4.4.2015.06 with USE=kontact

@gentoo/kde 