### PR TITLE
dev-libs/glib: Create giomodule.cache parent directories if needed

### DIFF
--- a/dev-libs/glib/glib-2.46.2-r1.ebuild
+++ b/dev-libs/glib/glib-2.46.2-r1.ebuild
@@ -277,6 +277,10 @@ pkg_preinst() {
 		if [[ -e ${EROOT}${cache} ]]; then
 			cp "${EROOT}"${cache} "${ED}"/${cache} || die
 		else
+			if [[ ! -d "${ED}"/${cache%/*} ]] ; then
+				mkdir -p "${ED}"/${cache%/*} || die "Fail to create giomodule.cache parent directories"
+			fi
+
 			touch "${ED}"/${cache} || die
 		fi
 	}


### PR DESCRIPTION
Bug #570752

Package-Manager: portage-2.2.26