### PR TITLE
dev-libs/libbsd-0.{7,8}.0: respect ${EPREFIX}

### DIFF
--- a/dev-libs/libbsd/libbsd-0.7.0.ebuild
+++ b/dev-libs/libbsd/libbsd-0.7.0.ebuild
@@ -17,7 +17,7 @@ IUSE="static-libs"
 DOCS="ChangeLog README TODO"
 
 pkg_setup() {
-	local f="${ROOT}/usr/$(get_libdir)/${PN}.a"
+	local f="${EROOT}/usr/$(get_libdir)/${PN}.a"
 	local m="You need to remove ${f} by hand or re-emerge sys-libs/glibc first."
 	if ! has_version ${CATEGORY}/${PN}; then
 		if [[ -e ${f} ]]; then

--- a/dev-libs/libbsd/libbsd-0.8.0.ebuild
+++ b/dev-libs/libbsd/libbsd-0.8.0.ebuild
@@ -17,7 +17,7 @@ IUSE="static-libs"
 DOCS="ChangeLog README TODO"
 
 pkg_setup() {
-	local f="${ROOT}/usr/$(get_libdir)/${PN}.a"
+	local f="${EROOT}/usr/$(get_libdir)/${PN}.a"
 	local m="You need to remove ${f} by hand or re-emerge sys-libs/glibc first."
 	if ! has_version ${CATEGORY}/${PN}; then
 		if [[ -e ${f} ]]; then


### PR DESCRIPTION
Error message wants re-emerge of prefix sys-libs/glibc because of file present in the host system - this doesn't make much sense, but we should check the prefix glibc for the existence of the file.