### PR TITLE
kde-apps/kde-wallpapers: Add transitional kde4-based ebuild w/ USE=minimal

### DIFF
--- a/kde-apps/kde-wallpapers/kde-wallpapers-15.08.3.ebuild
+++ b/kde-apps/kde-wallpapers/kde-wallpapers-15.08.3.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+KMNAME="kde-wallpapers"
+inherit kde4-base
+
+DESCRIPTION="KDE wallpapers"
+KEYWORDS="~amd64 ~x86"
+IUSE="+minimal"
+
+src_configure() {
+	local mycmakeargs=( -DWALLPAPER_INSTALL_DIR="${EPREFIX}/usr/share/wallpapers" )
+
+	kde4-base_src_configure
+}
+
+src_install() {
+	kde4-base_src_install
+
+	if use minimal ; then
+		rm -r "${ED}"usr/share/wallpapers/Autumn || die
+	fi
+}

--- a/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-5.5.0-r1.ebuild
+++ b/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-5.5.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,4 +13,4 @@ KEYWORDS=" ~amd64 ~x86"
 IUSE=""
 
 DEPEND="$(add_frameworks_dep extra-cmake-modules)"
-RDEPEND="!<kde-apps/kde-wallpapers-15.08.3-r1[-minimal(-)]"
+RDEPEND="!<kde-apps/kde-wallpapers-15.08.3[-minimal(-)]"

--- a/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-5.5.1-r1.ebuild
+++ b/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-5.5.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -9,8 +9,8 @@ KDE_DEBUG="false"
 inherit kde5
 
 DESCRIPTION="Additional wallpapers for the Plasma workspace"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS=" ~amd64 ~x86"
 IUSE=""
 
 DEPEND="$(add_frameworks_dep extra-cmake-modules)"
-RDEPEND="!<kde-apps/kde-wallpapers-15.08.3-r1[-minimal(-)]"
+RDEPEND="!<kde-apps/kde-wallpapers-15.08.3[-minimal(-)]"

--- a/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-5.5.2-r1.ebuild
+++ b/kde-plasma/plasma-workspace-wallpapers/plasma-workspace-wallpapers-5.5.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -9,8 +9,8 @@ KDE_DEBUG="false"
 inherit kde5
 
 DESCRIPTION="Additional wallpapers for the Plasma workspace"
-KEYWORDS=" ~amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="$(add_frameworks_dep extra-cmake-modules)"
-RDEPEND="!<kde-apps/kde-wallpapers-15.08.3-r1[-minimal(-)]"
+RDEPEND="!<kde-apps/kde-wallpapers-15.08.3[-minimal(-)]"

--- a/profiles/targets/desktop/plasma/package.use
+++ b/profiles/targets/desktop/plasma/package.use
@@ -67,6 +67,7 @@ dev-db/sqlitebrowser -qt4
 >=dev-games/openscenegraph-3.2.1-r1 -qt4
 >=dev-libs/qcustomplot-1.3.0 -qt4
 >=dev-libs/quazip-0.7.1 -qt4
+dev-util/cmake -qt4
 >=kde-misc/kdiff3-0.9.98-r1 -kde -qt4
 >=media-libs/mlt-0.9.8-r1 -kde -qt4
 >=media-libs/opencv-3.0.0 -qt4


### PR DESCRIPTION
Not having a stabilised non-conflicting kde-wallpapers release is creating a needless block on a future plasma-5 upgrade.

@kensington this adds another item to the kde4-stabilisation list