### PR TITLE
media-video/mpv: cleanup luajit masks

### DIFF
--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -2,6 +2,11 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+# Ian Delaney <idella4@gentoo.org> (05 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# dev-lang/luajit lacks alpha keyword. See bug #488318.
+media-video/mpv luajit
+
 # Ian Delaney <idella4@gentoo.org> (28 Dec 2015)
 # dep of testsuite dev-util/cmocka requires keywording for alpha
 # via Bug 569558, then this can be taken out
@@ -185,10 +190,6 @@ net-im/telepathy-connection-managers sipe
 # Mark Wright <gienah@gentoo.org> (26 Oct 2013)
 # template-haskell not yet available
 dev-haskell/dataenc test
-
-# Tom Wijsman <TomWij@gentoo.org> (16 Oct 2013)
-# Mask luajit on ~media-video/mpv-0.2.0 because it only has amd64 x86 keywords. See bug #488318.
->=media-video/mpv-0.2.0 luajit
 
 # Pacho Ramos <pacho@gentoo.org> (20 Jul 2013)
 # Keywords pending, bug #476710

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -215,10 +215,6 @@ gnome-base/gnome classic extras
 # Missing keywords from dev-ml/lablgtk, bug #487722
 net-p2p/mldonkey gtk guionly
 
-# Tom Wijsman <TomWij@gentoo.org> (16 Oct 2013)
-# Mask luajit on ~media-video/mpv-0.2.0 because it only has amd64 x86 keywords. See bug #488318.
->=media-video/mpv-0.2.0 luajit
-
 # Pacho Ramos <pacho@gentoo.org> (22 Sep 2013)
 # Missing keywords, bug #484734
 media-sound/rhythmbox visualizer

--- a/profiles/arch/arm/package.use.stable.mask
+++ b/profiles/arch/arm/package.use.stable.mask
@@ -2,6 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+# Ian Delaney <idella4@gentoo.org> (05 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# dev-lang/luajit wasn't stabilized in the past, but now
+# it's ready for the next stable mpv release after the one below.
+=media-video/mpv-0.9.2-r1 luajit
+
 # Ian Delaney <idella4@gentoo.org> (04 Jan 2016)
 # on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
 # media-libs/libsdl2 wasn't stabilized in the past, but now

--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -156,10 +156,6 @@ gnome-base/gnome classic extras
 # template-haskell not yet available
 dev-haskell/dataenc test
 
-# Tom Wijsman <TomWij@gentoo.org> (16 Oct 2013)
-# Mask luajit on ~media-video/mpv-0.2.0 because it only has amd64 x86 keywords. See bug #488318.
->=media-video/mpv-0.2.0 luajit
-
 # Johannes Huber <johu@gentoo.org> (15 Sep 2013)
 # # Depends on kde-misc/networkmanagement, not keyworded yet.
 kde-apps/solid-runtime networkmanager

--- a/profiles/arch/powerpc/ppc32/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.stable.mask
@@ -18,6 +18,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Ian Delaney <idella4@gentoo.org> (05 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# Hopefully dev-lang/luajit goes stable before
+# the next stable version of mpv. See bug #570808.
+=media-video/mpv-0.9.2-r1 luajit
+
 # Pacho Ramos <pacho@gentoo.org> (15 May 2015)
 # Missing keywords
 net-misc/connman l2tp openconnect

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -2,6 +2,11 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+# Ian Delaney <idella4@gentoo.org> (05 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# dev-lang/luajit lacks ppc64 keyword. See bug #488318.
+media-video/mpv luajit
+
 # Jeroen Roovers <jer@gentoo.org> (26 Dec 2015)
 # Mask until >sys-cluster/ceph-0.94 goes stable
 net-analyzer/rrdtool rados

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -2,6 +2,11 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+# Ian Delaney <idella4@gentoo.org> (05 Jan 2016)
+# on behalf of Ilya Tumaykin <itumaykin+gentoo@gmail.com>
+# dev-lang/luajit lacks sparc keyword. See bug #488318.
+media-video/mpv luajit
+
 # Mike Frysinger <vapier@gentoo.org> (22 Dec 2015)
 # Needs keywording. #569254
 net-firewall/iptables nftables
@@ -169,10 +174,6 @@ net-im/telepathy-connection-managers sipe
 # Mark Wright <gienah@gentoo.org> (26 Oct 2013)
 # template-haskell not yet available
 dev-haskell/dataenc test
-
-# Tom Wijsman <TomWij@gentoo.org> (16 Oct 2013)
-# Mask luajit on ~media-video/mpv-0.2.0 because it only has amd64 x86 keywords. See bug #488318.
->=media-video/mpv-0.2.0 luajit
 
 # Chí-Thanh Christopher Nguyễn <chithanh@gentoo.org> (22 Aug 2013)
 # dev-libs/jemalloc is not keyworded


### PR DESCRIPTION
The idea here is to mask, where possible, luajit USE for the currently stable mpv version only, as opposed to all versions now, and cleanup stale USE masks on arches, where luajit is not keyworded.