### PR TITLE
sci-libs/scikits_learn: Missing dependencies + dies

### DIFF
--- a/sci-libs/scikits_learn/scikits_learn-0.14.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.14.1.ebuild
@@ -73,15 +73,15 @@ python_compile() {
 
 python_compile_all() {
 	if use doc; then
-		cd "${S}/doc"
+		cd "${S}/doc" || die
 		local d="${BUILD_DIR}"/lib
 		ln -s "${S}"/sklearn/datasets/{data,descr,images} \
-			"${d}"/sklearn/datasets
+			"${d}"/sklearn/datasets || die
 		VARTEXFONTS="${T}"/fonts \
 			MPLCONFIGDIR="${BUILD_DIR}" \
 			PYTHONPATH="${d}" \
 			emake html
-		rm -r "${d}"/sklearn/datasets/{data,desr,images}
+		rm -r "${d}"/sklearn/datasets/{data,desr,images} || die
 	fi
 }
 

--- a/sci-libs/scikits_learn/scikits_learn-0.14.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.14.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -25,12 +25,14 @@ RDEPEND="
 	sci-libs/scikits[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
-	dev-python/matplotlib[${PYTHON_USEDEP}]"
+	dev-python/matplotlib[${PYTHON_USEDEP}]
+	virtual/cblas"
 DEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/cblas
 	doc? (
 		dev-python/sphinx[${PYTHON_USEDEP}]
 		dev-python/matplotlib[${PYTHON_USEDEP}] )

--- a/sci-libs/scikits_learn/scikits_learn-0.14.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.14.1.ebuild
@@ -26,12 +26,14 @@ RDEPEND="
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
 	dev-python/matplotlib[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas"
 DEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas
 	doc? (
 		dev-python/sphinx[${PYTHON_USEDEP}]

--- a/sci-libs/scikits_learn/scikits_learn-0.15.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.15.1.ebuild
@@ -27,12 +27,14 @@ RDEPEND="
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	sci-libs/scikits[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas"
 DEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas
 	doc? (
 		dev-python/joblib[${PYTHON_USEDEP}]

--- a/sci-libs/scikits_learn/scikits_learn-0.15.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.15.1.ebuild
@@ -73,15 +73,15 @@ python_compile() {
 
 python_compile_all() {
 	if use doc; then
-		cd "${S}/doc"
+		cd "${S}/doc" || die
 		local d="${BUILD_DIR}"/lib
 		ln -s "${S}"/sklearn/datasets/{data,descr,images} \
-			"${d}"/sklearn/datasets
+			"${d}"/sklearn/datasets || die
 		VARTEXFONTS="${T}"/fonts \
 			MPLCONFIGDIR="${BUILD_DIR}" \
 			PYTHONPATH="${d}" \
 			emake html
-		rm -r "${d}"/sklearn/datasets/{data,desr,images}
+		rm -r "${d}"/sklearn/datasets/{data,desr,images} || die
 	fi
 }
 

--- a/sci-libs/scikits_learn/scikits_learn-0.15.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.15.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -26,12 +26,14 @@ RDEPEND="
 	dev-python/nose[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	sci-libs/scikits[${PYTHON_USEDEP}]
-	sci-libs/scipy[${PYTHON_USEDEP}]"
+	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/cblas"
 DEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/cblas
 	doc? (
 		dev-python/joblib[${PYTHON_USEDEP}]
 		dev-python/matplotlib[${PYTHON_USEDEP}]

--- a/sci-libs/scikits_learn/scikits_learn-0.15.2.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.15.2.ebuild
@@ -27,12 +27,14 @@ RDEPEND="
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	sci-libs/scikits[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas"
 DEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas
 	doc? (
 		dev-python/joblib[${PYTHON_USEDEP}]

--- a/sci-libs/scikits_learn/scikits_learn-0.15.2.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.15.2.ebuild
@@ -73,15 +73,15 @@ python_compile() {
 
 python_compile_all() {
 	if use doc; then
-		cd "${S}/doc"
+		cd "${S}/doc" || die
 		local d="${BUILD_DIR}"/lib
 		ln -s "${S}"/sklearn/datasets/{data,descr,images} \
-			"${d}"/sklearn/datasets
+			"${d}"/sklearn/datasets || die
 		VARTEXFONTS="${T}"/fonts \
 			MPLCONFIGDIR="${BUILD_DIR}" \
 			PYTHONPATH="${d}" \
 			emake html
-		rm -r "${d}"/sklearn/datasets/{data,desr,images}
+		rm -r "${d}"/sklearn/datasets/{data,desr,images} || die
 	fi
 }
 

--- a/sci-libs/scikits_learn/scikits_learn-0.15.2.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.15.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -26,12 +26,14 @@ RDEPEND="
 	dev-python/nose[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	sci-libs/scikits[${PYTHON_USEDEP}]
-	sci-libs/scipy[${PYTHON_USEDEP}]"
+	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/cblas"
 DEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/cblas
 	doc? (
 		dev-python/joblib[${PYTHON_USEDEP}]
 		dev-python/matplotlib[${PYTHON_USEDEP}]

--- a/sci-libs/scikits_learn/scikits_learn-0.16.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.16.1.ebuild
@@ -72,7 +72,7 @@ python_compile() {
 
 python_compile_all() {
 	if use doc; then
-		cd "${S}/doc"
+		cd "${S}/doc" || die
 		local d="${BUILD_DIR}"/lib
 		ln -s "${S}"/sklearn/datasets/{data,descr,images} \
 			"${d}"/sklearn/datasets
@@ -80,7 +80,7 @@ python_compile_all() {
 			MPLCONFIGDIR="${BUILD_DIR}" \
 			PYTHONPATH="${d}" \
 			emake html
-		rm -r "${d}"/sklearn/datasets/{data,desr,images}
+		rm -r "${d}"/sklearn/datasets/{data,desr,images} || die
 	fi
 }
 

--- a/sci-libs/scikits_learn/scikits_learn-0.16.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.16.1.ebuild
@@ -27,6 +27,7 @@ RDEPEND="
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	sci-libs/scikits[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas"
 DEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]

--- a/sci-libs/scikits_learn/scikits_learn-0.16.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.16.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -26,12 +26,14 @@ RDEPEND="
 	dev-python/nose[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	sci-libs/scikits[${PYTHON_USEDEP}]
-	sci-libs/scipy[${PYTHON_USEDEP}]"
+	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/cblas"
 DEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/cblas
 	doc? (
 		dev-python/joblib[${PYTHON_USEDEP}]
 		dev-python/matplotlib[${PYTHON_USEDEP}]

--- a/sci-libs/scikits_learn/scikits_learn-0.17.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.17.ebuild
@@ -81,15 +81,15 @@ python_compile() {
 
 python_compile_all() {
 	if use doc; then
-		cd "${S}/doc"
+		cd "${S}/doc" || die
 		local d="${BUILD_DIR}"/lib
 		ln -s "${S}"/sklearn/datasets/{data,descr,images} \
-			"${d}"/sklearn/datasets
+			"${d}"/sklearn/datasets || die
 		VARTEXFONTS="${T}"/fonts \
 			MPLCONFIGDIR="${BUILD_DIR}" \
 			PYTHONPATH="${d}" \
 			emake html
-		rm -r "${d}"/sklearn/datasets/{data,desr,images}
+		rm -r "${d}"/sklearn/datasets/{data,desr,images} || die
 	fi
 }
 

--- a/sci-libs/scikits_learn/scikits_learn-0.17.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.17.ebuild
@@ -27,6 +27,7 @@ RDEPEND="
 	>=dev-python/numpy-1.6.1[lapack,${PYTHON_USEDEP}]
 	sci-libs/scikits[${PYTHON_USEDEP}]
 	>=sci-libs/scipy-0.9[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas
 	virtual/python-funcsigs[${PYTHON_USEDEP}]
 	"
@@ -35,6 +36,7 @@ DEPEND="
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/blas
 	virtual/cblas
 	doc? (
 		dev-python/joblib[${PYTHON_USEDEP}]

--- a/sci-libs/scikits_learn/scikits_learn-0.17.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -27,6 +27,7 @@ RDEPEND="
 	>=dev-python/numpy-1.6.1[lapack,${PYTHON_USEDEP}]
 	sci-libs/scikits[${PYTHON_USEDEP}]
 	>=sci-libs/scipy-0.9[${PYTHON_USEDEP}]
+	virtual/cblas
 	virtual/python-funcsigs[${PYTHON_USEDEP}]
 	"
 DEPEND="
@@ -34,6 +35,7 @@ DEPEND="
 	dev-python/numpy[lapack,${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
+	virtual/cblas
 	doc? (
 		dev-python/joblib[${PYTHON_USEDEP}]
 		dev-python/matplotlib[${PYTHON_USEDEP}]


### PR DESCRIPTION
@jlec as discussed in IRC, scikit_learn is build against blas/cblas. Thus the dependencies should be added. I further added some missing dies.