### PR TITLE
RFC: Add transitional kdebase-meta:5 package for plasma profile migration

### DIFF
--- a/kde-apps/kde-apps-meta/kde-apps-meta-15.08.3-r1.ebuild
+++ b/kde-apps/kde-apps-meta/kde-apps-meta-15.08.3-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit kde5-meta-pkg
+
+DESCRIPTION="Meta package for the KDE Applications collection"
+KEYWORDS=" ~amd64 ~x86"
+IUSE="accessibility minimal nls pim sdk"
+
+[[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
+
+# KDE PIM 15.08.3 is not going to be in tree and
+# will conflict with other packages from 15.08.3
+# Raise kdeedu-meta dep whenever it hits portage
+RDEPEND="
+	$(add_kdeapps_dep kate)
+	$(add_kdeapps_dep kdeadmin-meta)
+	$(add_kdeapps_dep kdebase-meta)
+	$(add_kdeapps_dep kdeedu-meta '' 4.14.3)
+	$(add_kdeapps_dep kdegames-meta)
+	$(add_kdeapps_dep kdegraphics-meta)
+	$(add_kdeapps_dep kdemultimedia-meta)
+	$(add_kdeapps_dep kdenetwork-meta)
+	$(add_kdeapps_dep kdetoys-meta)
+	$(add_kdeapps_dep kdeutils-meta)
+	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta) )
+	nls? (
+		$(add_kdeapps_dep kde-l10n '' ${L10N_MINIMAL})
+		$(add_kdeapps_dep kde4-l10n 'minimal' ${L10N_MINIMAL})
+	)
+	pim? ( >=kde-apps/kdepim-meta-4.4.2015:4 )
+	sdk? (
+		$(add_kdeapps_dep kdesdk-meta)
+		$(add_kdeapps_dep kdewebdev-meta)
+	)
+	!minimal? ( $(add_kdeapps_dep kdeartwork-meta 'minimal') )
+"

--- a/kde-apps/kde-apps-meta/metadata.xml
+++ b/kde-apps/kde-apps-meta/metadata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+	<use>
+		<flag name="pim">Pull in KDE PIM suite</flag>
+		<flag name="sdk">Pull in developer-specific meta-packages</flag>
+	</use>
+</pkgmetadata>

--- a/kde-apps/kde-meta/kde-meta-15.08.3.ebuild
+++ b/kde-apps/kde-meta/kde-meta-15.08.3.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit kde5-meta-pkg
+
+DESCRIPTION="Merge this to pull in all KDE Plasma and Applications packages"
+KEYWORDS=" ~amd64 ~x86"
+IUSE=""
+
+RDEPEND="
+	$(add_kdeapps_dep kde-apps-meta)
+	$(add_plasma_dep plasma-meta)
+"

--- a/kde-apps/kde-meta/kde-meta-4.14.3-r1.ebuild
+++ b/kde-apps/kde-meta/kde-meta-4.14.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,7 +6,7 @@ EAPI=5
 inherit kde4-meta-pkg
 
 DESCRIPTION="KDE - merge this to pull in all split kde-base/* packages"
-KEYWORDS="amd64 ~arm ppc ppc64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="accessibility kdepim minimal nls sdk"
 
 RDEPEND="
@@ -23,7 +23,7 @@ RDEPEND="
 	$(add_kdeapps_dep kdeutils-meta)
 	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta) )
 	kdepim? ( $(add_kdeapps_dep kdepim-meta '' 4.4.11.1) )
-	nls? ( $(add_kdeapps_dep kde4-l10n) )
+	nls? ( $(add_kdeapps_dep kde4-l10n '' 4.14.3-r1) )
 	sdk? (
 		$(add_kdebase_dep kdebindings-meta)
 		$(add_kdeapps_dep kdesdk-meta)

--- a/kde-apps/kde-meta/kde-meta-4.14.3.ebuild
+++ b/kde-apps/kde-meta/kde-meta-4.14.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,7 +6,7 @@ EAPI=5
 inherit kde4-meta-pkg
 
 DESCRIPTION="KDE - merge this to pull in all split kde-base/* packages"
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ppc ppc64 x86 ~amd64-linux ~x86-linux"
 IUSE="accessibility kdepim minimal nls sdk"
 
 RDEPEND="
@@ -23,7 +23,7 @@ RDEPEND="
 	$(add_kdeapps_dep kdeutils-meta)
 	accessibility? ( $(add_kdeapps_dep kdeaccessibility-meta) )
 	kdepim? ( $(add_kdeapps_dep kdepim-meta '' 4.4.11.1) )
-	nls? ( $(add_kdeapps_dep kde4-l10n '' 4.14.3-r1) )
+	nls? ( $(add_kdeapps_dep kde4-l10n) )
 	sdk? (
 		$(add_kdebase_dep kdebindings-meta)
 		$(add_kdeapps_dep kdesdk-meta)

--- a/kde-apps/kde-meta/metadata.xml
+++ b/kde-apps/kde-meta/metadata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kde</herd>
+	<use>
+		<flag name="kdepim">Pull in KDE PIM</flag>
+		<flag name="sdk">Pull in developer-specific meta-packages</flag>
+	</use>
+</pkgmetadata>

--- a/kde-apps/kde-wallpapers/kde-wallpapers-15.08.3.ebuild
+++ b/kde-apps/kde-wallpapers/kde-wallpapers-15.08.3.ebuild
@@ -8,7 +8,7 @@ KMNAME="kde-wallpapers"
 inherit kde4-base
 
 DESCRIPTION="KDE wallpapers"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="+minimal"
 
 src_configure() {

--- a/kde-apps/kdebase-data/kdebase-data-15.08.3.ebuild
+++ b/kde-apps/kdebase-data/kdebase-data-15.08.3.ebuild
@@ -13,8 +13,8 @@ IUSE="+wallpapers"
 KEYWORDS=" ~amd64 ~x86"
 
 RDEPEND="
-	wallpapers? ( || ( $(add_kdeapps_dep kde-wallpapers) >=kde-apps/kde-wallpapers-15.08.0:5 ) )
 	x11-themes/hicolor-icon-theme
+	wallpapers? ( || ( $(add_kdeapps_dep kde-wallpapers '' 15.08.3) kde-apps/kde-wallpapers:5 ) )
 "
 
 KMEXTRA="

--- a/kde-apps/kdebase-meta/kdebase-meta-15.08.3-r1.ebuild
+++ b/kde-apps/kdebase-meta/kdebase-meta-15.08.3-r1.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit kde5-meta-pkg
+
+DESCRIPTION="Transitional package to pull in plasma-meta plus basic applications"
+KEYWORDS="~amd64 ~x86"
+IUSE="+display-manager minimal +wallpapers"
+
+RDEPEND="
+	$(add_kdeapps_dep dolphin)
+	$(add_kdeapps_dep konsole)
+	$(add_kdeapps_dep kwrite)
+	$(add_plasma_dep plasma-meta)
+	wallpapers? ( $(add_kdeapps_dep kde-wallpapers) )
+	!minimal? ( $(add_kdeapps_dep kdebase-runtime-meta 'minimal') )
+	!prefix? ( display-manager? ( || ( x11-misc/lightdm x11-misc/sddm ) ) )
+"

--- a/kde-apps/kdebase-meta/kdebase-meta-4.14.3-r2.ebuild
+++ b/kde-apps/kdebase-meta/kdebase-meta-4.14.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -25,7 +25,7 @@ RDEPEND="
 	$(add_kdeapps_dep libkonq)
 	$(add_kdeapps_dep nsplugins)
 	$(add_kdeapps_dep phonon-kde)
-	wallpapers? ( || ( $(add_kdeapps_dep kde-wallpapers) kde-apps/kde-wallpapers:5 ) )
+	wallpapers? ( $(add_kdeapps_dep kde-wallpapers '' 15.08.3) )
 	!minimal? (
 		$(add_kdebase_dep freespacenotifier '' 4.11)
 		$(add_kdebase_dep kcheckpass '' 4.11.22-r1)

--- a/kde-apps/kdebase-meta/metadata.xml
+++ b/kde-apps/kdebase-meta/metadata.xml
@@ -4,6 +4,7 @@
 	<herd>kde</herd>
 	<use>
 		<flag name="display-manager">Pull in a graphical display manager</flag>
+		<flag name="minimal">Disable install of various KDE SC 4 based packages</flag>
 		<flag name="wallpapers">Install the KDE wallpapers</flag>
 	</use>
 </pkgmetadata>

--- a/kde-apps/kdenetwork-meta/kdenetwork-meta-15.08.3-r1.ebuild
+++ b/kde-apps/kdenetwork-meta/kdenetwork-meta-15.08.3-r1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit kde5-meta-pkg
+
+DESCRIPTION="kdenetwork - merge this to pull in all kdenetwork-derived packages"
+KEYWORDS=" ~amd64 ~x86"
+IUSE="ppp"
+
+# FIXME: Add back when ready
+# $(add_kdeapps_dep plasma-telepathy-meta)
+RDEPEND="
+	$(add_kdeapps_dep kdenetwork-filesharing)
+	$(add_kdeapps_dep kget)
+	$(add_kdeapps_dep kopete)
+	$(add_kdeapps_dep krdc)
+	$(add_kdeapps_dep krfb)
+	$(add_kdeapps_dep zeroconf-ioslave)
+	ppp? ( $(add_kdeapps_dep kppp) )
+"

--- a/kde-base/kde-meta/metadata.xml
+++ b/kde-base/kde-meta/metadata.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-<pkgmetadata>
-	<herd>kde</herd>
-	<use>
-		<flag name="kdepim">Pull in KDE PIM</flag>
-		<flag name="sdk">Pull in developer-specific meta-packages</flag>
-	</use>
-</pkgmetadata>

--- a/kde-base/kdebase-startkde/kdebase-startkde-4.11.22.ebuild
+++ b/kde-base/kdebase-startkde/kdebase-startkde-4.11.22.ebuild
@@ -17,7 +17,6 @@ IUSE="+wallpapers"
 RDEPEND="
 	$(add_kdebase_dep kcminit)
 	$(add_kdeapps_dep kdebase-runtime-meta)
-	wallpapers? ( || ( $(add_kdeapps_dep kde-wallpapers) kde-apps/kde-wallpapers:5 ) )
 	$(add_kdeapps_dep kfmclient)
 	$(add_kdeapps_dep knotify)
 	$(add_kdeapps_dep kreadconfig)
@@ -37,6 +36,7 @@ RDEPEND="
 	x11-apps/xrdb
 	x11-apps/xsetroot
 	x11-apps/xset
+	wallpapers? ( $(add_kdeapps_dep kde-wallpapers '' 15.08.3) )
 "
 
 KMEXTRACTONLY="

--- a/profiles/targets/desktop/kde/package.mask
+++ b/profiles/targets/desktop/kde/package.mask
@@ -1,0 +1,23 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+# Mask to avoid conflicts in kde profile
+kde-apps/kdeaccessibility-meta:5
+kde-apps/kdeadmin-meta:5
+kde-apps/kdeartwork-meta:5
+kde-apps/kdebase-meta:5
+kde-apps/kdeedu-meta:5
+kde-apps/kdegames-meta:5
+kde-apps/kdegraphics-meta:5
+kde-apps/kdemultimedia-meta:5
+kde-apps/kdenetwork-meta:5
+kde-apps/kdepim-meta:5
+kde-apps/kdesdk-meta:5
+kde-apps/kdetoys-meta:5
+kde-apps/kdeutils-meta:5
+kde-apps/kdewebdev-meta:5
+kde-apps/kde-apps-meta:5
+kde-apps/kde-meta:5
+kde-apps/kde-wallpapers:5
+kde-frameworks/oxygen-icons:5

--- a/profiles/targets/desktop/plasma/package.use
+++ b/profiles/targets/desktop/plasma/package.use
@@ -39,7 +39,7 @@ kde-apps/kde-wallpapers minimal
 kde-apps/kde4-l10n minimal
 kde-apps/kdeartwork-meta minimal
 kde-apps/kdebase-kioslaves minimal
-kde-apps/kdebase-meta minimal
+kde-apps/kdebase-meta:4 minimal
 kde-apps/kdebase-runtime-meta -crash-reporter minimal
 kde-apps/kdesu -handbook
 kde-apps/knetattach -handbook

--- a/profiles/updates/1Q-2016
+++ b/profiles/updates/1Q-2016
@@ -1,2 +1,3 @@
 slotmove net-irc/kvirc 4 0
 move x11-apps/xtitle x11-misc/xtitle
+move kde-base/kde-meta kde-apps/kde-meta


### PR DESCRIPTION
In short, fix kde-apps/kdebase-meta:5 and introduce kde-apps/kde-meta:5 so both meta packages provide an equivalent package selection to their :4 counterparts and are scheduled for upgrade as soon as the user switches from kde to plasma profile.

- [x] pkgmove kde-base/kde-meta to kde-apps/kde-meta