### PR TITLE
net-nntp/nzbget: fix init script

### DIFF
--- a/net-nntp/nzbget/files/nzbget.initd
+++ b/net-nntp/nzbget/files/nzbget.initd
@@ -11,7 +11,7 @@ start() {
 	start-stop-daemon --quiet --start --user "${NZBGET_USER}" \
 		--group "${NZBGET_GROUP}" --exec /usr/bin/nzbget -- \
 		--configfile "${NZBGET_CONFIGFILE}" --daemon \
-		${NZBGET_OPTS}
+		-- ${NZBGET_OPTS}
 	eend $?
 }
 


### PR DESCRIPTION
Adds a missing `--` which https://github.com/gentoo/gentoo/pull/611 was missing