### PR TITLE
media-video/mpv: remove erroneous '.0' from ffmpeg dependency version

### DIFF
--- a/media-video/mpv/mpv-0.14.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.14.0-r1.ebuild
@@ -56,7 +56,7 @@ REQUIRED_USE="
 "
 
 COMMON_DEPEND="
-	!libav? ( >=media-video/ffmpeg-2.4.0:0=[encode?,threads,vaapi?,vdpau?] )
+	!libav? ( >=media-video/ffmpeg-2.4:0=[encode?,threads,vaapi?,vdpau?] )
 	libav? ( >=media-video/libav-11:0=[encode?,threads,vaapi?,vdpau?] )
 	sys-libs/zlib
 	alsa? ( >=media-libs/alsa-lib-1.0.18 )

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -56,7 +56,7 @@ REQUIRED_USE="
 "
 
 COMMON_DEPEND="
-	!libav? ( >=media-video/ffmpeg-2.4.0:0=[encode?,threads,vaapi?,vdpau?] )
+	!libav? ( >=media-video/ffmpeg-2.4:0=[encode?,threads,vaapi?,vdpau?] )
 	libav? ( >=media-video/libav-11:0=[encode?,threads,vaapi?,vdpau?] )
 	sys-libs/zlib
 	alsa? ( >=media-libs/alsa-lib-1.0.18 )


### PR DESCRIPTION
ffmpeg major releases don't have a '.0' minor suffix.

Further, =media-video/ffmpeg-2.4 was never present in the tree.
The first ffmpeg release from 2.4-series in the tree was 2.4.1.

Therefore it's safe to drop the erroneous '.0' minor suffix from
the ffmpeg dependency version without a revbump.

Package-Manager: portage-2.2.26