### PR TITLE
media-video/aegisub: adjust luajit dependency, drop unneeded patch

### DIFF
--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -58,7 +58,6 @@ REQUIRED_USE="
 # Unfortunately, luabins upstream is dead since 2011.
 # Thus unbundling luabins is not worth the effort.
 PATCHES=(
-	"${FILESDIR}/${PN}-3.2.2-fix-lua-regexp.patch"
 	"${FILESDIR}/${P}-unbundle-luajit.patch"
 	"${FILESDIR}/${P}-add-missing-pthread-flags.patch"
 	"${FILESDIR}/${PN}-3.2.2-respect-user-compiler-flags.patch"

--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -24,7 +24,7 @@ IUSE="alsa debug +ffmpeg +fftw openal oss portaudio pulseaudio spell"
 # However, most of these minimal versions date back to 2006-2010 yy.
 # Such version specifiers are meaningless nowadays, so they are omitted.
 RDEPEND="
-	>=dev-lang/luajit-2.0.4:2
+	>=dev-lang/luajit-2.0.4:2[lua52compat]
 	>=dev-libs/boost-1.50.0:=[icu,nls,threads]
 	>=dev-libs/icu-4.8.1.1:=
 	>=x11-libs/wxGTK-3.0.0:${WX_GTK_VER}[X,opengl,debug?]


### PR DESCRIPTION
I am currently working with upstream towards fixing all those problems we patch away in Gentoo. More fixes for 9999 to come. 3.2.2 will receive a revbump when we are done.