### PR TITLE
app-text/linuxdoc-tools: add remote-id to metadata

### DIFF
--- a/app-text/linuxdoc-tools/metadata.xml
+++ b/app-text/linuxdoc-tools/metadata.xml
@@ -15,4 +15,7 @@
 		documentation), then you should check SGMLTools-Lite, OpenJade,
 		and docbook-tools.
 	</longdescription>
+	<upstream>
+		<remote-id type="gitlab">agmartin/linuxdoc-tools</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Now that Gentoo bug 563578 is fixed this can be done.

Package-Manager: portage-2.2.26