### PR TITLE
media-video/mpv: explicitly disable code with unclear license

### DIFF
--- a/media-video/mpv/mpv-0.14.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.14.0-r1.ebuild
@@ -172,6 +172,8 @@ src_configure() {
 		--confdir="${EPREFIX}"/etc/${PN}
 		--docdir="${EPREFIX}"/usr/share/doc/${PF}
 
+		--disable-gpl3		# Unclear license info. See Gentoo bug 571728.
+
 		$(usex cli '' '--disable-cplayer')
 		$(use_enable libmpv libmpv-shared)
 

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -169,6 +169,8 @@ src_configure() {
 		--confdir="${EPREFIX}"/etc/${PN}
 		--docdir="${EPREFIX}"/usr/share/doc/${PF}
 
+		--disable-gpl3		# Unclear license info. See Gentoo bug 571728.
+
 		$(usex cli '' '--disable-cplayer')
 		$(use_enable libmpv libmpv-shared)
 


### PR DESCRIPTION
Upstream provides very unclear license information
about the code hidden under --enable-gpl3 switch.
See Gentoo bug 571728 for more info.

This code is disabled by default, so there is no actual change in the
build. But since we have a report in Gentoo bugzilla, add a reference to
it.

Gentoo-Bug: 571278

Package-Manager: portage-2.2.26