### PR TITLE
kde4-functions.eclass: Exclude KDE PIM from 4.14.3 lowered deps logic

### DIFF
--- a/eclass/kde4-functions.eclass
+++ b/eclass/kde4-functions.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -294,7 +294,8 @@ add_kdeapps_dep() {
 		ver=${KDE_MINIMAL}
 	# if building kde-apps, live master or stable-live branch,
 	# use the final SC version since there are no further general releases.
-	elif [[ ${CATEGORY} == kde-apps || ${PV} == *9999 ]]; then
+	# except when it is kdepim split packages, which rely on same-version deps
+	elif [[ ${CATEGORY} == kde-apps || ${PV} == *9999 ]] && [[ ${KMNAME} != "kdepim" ]]; then
 		ver=4.14.3
 	else
 		ver=${PV}

--- a/kde-apps/kdepim-meta/kdepim-meta-4.14.10-r1.ebuild
+++ b/kde-apps/kdepim-meta/kdepim-meta-4.14.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -11,26 +11,26 @@ KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="nls"
 
 RDEPEND="
-	$(add_kdeapps_dep akonadiconsole)
-	$(add_kdeapps_dep akregator)
-	$(add_kdeapps_dep blogilo)
-	$(add_kdeapps_dep calendarjanitor)
-	$(add_kdeapps_dep kabcclient)
-	$(add_kdeapps_dep kaddressbook)
-	$(add_kdeapps_dep kalarm)
-	$(add_kdeapps_dep kdepim-icons)
-	$(add_kdeapps_dep kdepim-kresources)
-	$(add_kdeapps_dep kdepim-runtime)
-	$(add_kdeapps_dep kjots)
-	$(add_kdeapps_dep kleopatra)
-	$(add_kdeapps_dep kmail)
-	$(add_kdeapps_dep knode)
-	$(add_kdeapps_dep knotes)
-	$(add_kdeapps_dep konsolekalendar)
-	$(add_kdeapps_dep kontact)
-	$(add_kdeapps_dep korganizer)
-	$(add_kdeapps_dep ktimetracker)
-	$(add_kdeapps_dep ktnef)
+	$(add_kdeapps_dep akonadiconsole '' ${PV})
+	$(add_kdeapps_dep akregator '' ${PV})
+	$(add_kdeapps_dep blogilo '' ${PV})
+	$(add_kdeapps_dep calendarjanitor '' ${PV})
+	$(add_kdeapps_dep kabcclient '' ${PV})
+	$(add_kdeapps_dep kaddressbook '' ${PV})
+	$(add_kdeapps_dep kalarm '' ${PV})
+	$(add_kdeapps_dep kdepim-icons '' ${PV})
+	$(add_kdeapps_dep kdepim-kresources '' ${PV})
+	$(add_kdeapps_dep kdepim-runtime '' ${PV})
+	$(add_kdeapps_dep kjots '' ${PV})
+	$(add_kdeapps_dep kleopatra '' ${PV})
+	$(add_kdeapps_dep kmail '' ${PV})
+	$(add_kdeapps_dep knode '' ${PV})
+	$(add_kdeapps_dep knotes '' ${PV})
+	$(add_kdeapps_dep konsolekalendar '' ${PV})
+	$(add_kdeapps_dep kontact '' ${PV})
+	$(add_kdeapps_dep korganizer '' ${PV})
+	$(add_kdeapps_dep ktimetracker '' ${PV})
+	$(add_kdeapps_dep ktnef '' ${PV})
 	nls? (
 		$(add_kdeapps_dep kde4-l10n '' 4.14.3-r1)
 		$(add_kdeapps_dep kdepim-l10n '' 4.14.3-r1)


### PR DESCRIPTION
@gentoo/kde 