### PR TITLE
app-text/zathura: add synctex patch for 9999

### DIFF
--- a/app-text/zathura/files/zathura-9999-synctex.patch
+++ b/app-text/zathura/files/zathura-9999-synctex.patch
@@ -1,0 +1,51 @@
+From f0a86c6ef7c43eec07b0ddc7c002dba506ca1e26 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <petr.pisar@atlas.cz>
+Date: Sat, 9 Jan 2016 09:48:53 +0100
+Subject: [PATCH] Use synctex_editor only if WITH_SYNCTEX
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without installed synctex, the build fails like:
+
+zathura/main.c: In function ‘main’:
+zathura/main.c:254:26: error: ‘synctex_editor’ undeclared (first use in this function)
+       plugin_path, argv, synctex_editor, embed);
+                          ^
+zathura/main.c:254:26: note: each undeclared identifier is reported only once for each function it appears in
+Makefile:103: recipe for target 'build/release/zathura/main.o' failed
+
+This patch fixes it.
+
+<https://bugs.gentoo.org/show_bug.cgi?id=571346>
+---
+ zathura/main.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/zathura/main.c b/zathura/main.c
+index 060382a..9c0d0d3 100644
+--- a/zathura/main.c
++++ b/zathura/main.c
+@@ -250,11 +250,16 @@ main(int argc, char* argv[])
+ 
+   /* Create zathura session */
+   zathura_t* zathura = init_zathura(config_dir, data_dir, cache_dir,
+-#ifdef GDK_WINDOWING_X11
+-      plugin_path, argv, synctex_editor, embed);
++      plugin_path, argv,
++#ifdef WITH_SYNCTEX
++      synctex_editor
+ #else
+-      plugin_path, argv, synctex_editor);
++      NULL
++#endif
++#ifdef GDK_WINDOWING_X11
++      , embed
+ #endif
++  );
+   if (zathura == NULL) {
+     girara_error("Could not initialize zathura.");
+     return -1;
+-- 
+2.4.10
+


### PR DESCRIPTION
app-text/zathura-9999 fail to build because of missing synctex patch, copying the one from 0.3.4 seems to works.

On a side note, synctex require `app-text/texlive-core-2015`, not simply `app-text/texlive-core`, otherwise, there is some missing pkg-config files.