### PR TITLE
media-video/mpv-9999: Fix build

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -23,7 +23,7 @@ else
 	inherit git-r3
 fi
 SRC_URI+=" https://waf.io/waf-${WAF_PV}"
-DOCS+=( README.md etc/example.conf etc/input.conf )
+DOCS+=( README.md etc/mpv.conf etc/input.conf )
 
 # See Copyright in source tarball and bug #506946. Waf is BSD, libmpv is ISC.
 LICENSE="GPL-2+ BSD ISC"


### PR DESCRIPTION
example.conf was renamed to mpv.conf in upstream.
Upstream commit https://github.com/mpv-player/mpv/commit/30fd858e5e7fdec58da8c89b1aa3614d624891bd