### PR TITLE
net-analyzer/icinga2: add support for console line-editing

### DIFF
--- a/net-analyzer/icinga2/icinga2-2.4.1-r3.ebuild
+++ b/net-analyzer/icinga2/icinga2-2.4.1-r3.ebuild
@@ -1,0 +1,158 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+inherit cmake-utils depend.apache eutils systemd toolchain-funcs user
+
+DESCRIPTION="Distributed, general purpose, network monitoring engine"
+HOMEPAGE="http://icinga.org/icinga2"
+SRC_URI="https://github.com/Icinga/icinga2/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+mysql postgres classicui console lto minimal nano-syntax +plugins studio +vim-syntax"
+
+DEPEND="
+	dev-libs/openssl:0
+	>=dev-libs/boost-1.41
+	sys-devel/bison
+	>=sys-devel/flex-2.5.35
+	console? ( dev-libs/libedit )
+	mysql? ( virtual/mysql )
+	postgres? ( dev-db/postgresql:= )"
+
+RDEPEND="
+	${DEPEND}
+	plugins? ( || (
+		net-analyzer/monitoring-plugins
+		net-analyzer/nagios-plugins
+	) )
+	classicui? ( net-analyzer/icinga[web] )
+	studio? ( x11-libs/wxGTK:2.9 )"
+
+REQUIRED_USE="!minimal? ( || ( mysql postgres ) )"
+
+want_apache2
+
+pkg_setup() {
+	depend.apache_pkg_setup
+	enewgroup icinga
+	enewgroup icingacmd
+	enewgroup nagios  # for plugins
+	enewuser icinga -1 -1 /var/lib/icinga2 "icinga,icingacmd,nagios"
+}
+
+src_configure() {
+	sed -i 's/FLAGS\}\ \-g/FLAGS\}\ \-lpthread\ /g' CMakeLists.txt || die
+	local mycmakeargs=(
+		-DICINGA2_UNITY_BUILD=FALSE
+		-DCMAKE_VERBOSE_MAKEFILE=ON
+		-DCMAKE_BUILD_TYPE=None
+		-DCMAKE_INSTALL_PREFIX=/usr
+		-DCMAKE_INSTALL_SYSCONFDIR=/etc
+		-DCMAKE_INSTALL_LOCALSTATEDIR=/var
+		-DICINGA2_SYSCONFIGFILE=/etc/conf.d/icinga2
+		-DICINGA2_USER=icinga
+		-DICINGA2_GROUP=icingacmd
+		-DICINGA2_COMMAND_USER=icinga
+		-DICINGA2_COMMAND_GROUP=icingacmd
+		-DINSTALL_SYSTEMD_SERVICE_AND_INITSCRIPT=yes
+	)
+	# default to off if minimal, allow the flags to be set otherwise
+	if use minimal; then
+		mycmakeargs+=(
+			-DICINGA2_WITH_MYSQL=OFF
+			-DICINGA2_WITH_PGSQL=OFF
+		)
+	else
+		mycmakeargs+=(
+			-DICINGA2_WITH_PGSQL=$(usex postgres ON OFF)
+			-DICINGA2_WITH_MYSQL=$(usex mysql ON OFF)
+		)
+	fi
+	# LTO
+	if use lto; then
+		mycmakeargs+=(
+			-DICINGA2_LTO_BUILD=ON
+		)
+	else
+		mycmakeargs+=(
+			-DICINGA2_LTO_BUILD=OFF
+		)
+	fi
+	# STUDIO
+	if use studio; then
+		mycmakeargs+=(
+			-DICINGA2_WITH_STUDIO=ON
+		)
+	else
+		mycmakeargs+=(
+			-DICINGA2_WITH_STUDIO=OFF
+		)
+	fi
+
+	cmake-utils_src_configure
+}
+
+src_install() {
+	BUILDDIR="${WORKDIR}"/icinga2-${PV}_build
+	cd "${BUILDDIR}" || die
+
+	emake DESTDIR="${D}" install
+
+	einstalldocs
+
+	newinitd "${FILESDIR}"/icinga2.initd icinga2
+	newconfd "${FILESDIR}"/icinga2.confd icinga2
+
+	if use mysql ; then
+		docinto schema
+		newdoc "${WORKDIR}"/icinga2-${PV}/lib/db_ido_mysql/schema/mysql.sql mysql.sql
+		docinto schema/upgrade
+		dodoc "${WORKDIR}"/icinga2-${PV}/lib/db_ido_mysql/schema/upgrade/*
+	elif use postgres ; then
+		docinto schema
+		newdoc "${WORKDIR}"/icinga2-${PV}/lib/db_ido_pgsql/schema/pgsql.sql pgsql.sql
+		docinto schema/upgrade
+		dodoc "${WORKDIR}"/icinga2-${PV}/lib/db_ido_pgsql/schema/upgrade/*
+	fi
+
+	keepdir /etc/icinga2
+	keepdir /var/lib/icinga2/api/zones
+	keepdir /var/lib/icinga2/api/repository
+	keepdir /var/lib/icinga2/api/log
+	keepdir /var/spool/icinga2/perfdata
+
+	rm -r "${D}/var/run" || die "failed to remove /var/run"
+	rm -r "${D}/var/cache" || die "failed to remove /var/cache"
+
+	fowners icinga:icinga /etc/icinga2
+	fowners icinga:icinga /var/lib/icinga2
+	fowners icinga:icinga /var/spool/icinga2
+	fowners icinga:icingacmd /var/lib/icinga2/api
+	fowners icinga:icinga /var/spool/icinga2/perfdata
+	fowners icinga:icingacmd /var/log/icinga2
+
+	fperms ug+rwX,o-rwx /etc/icinga2
+	fperms ug+rwX,o-rwx /var/lib/icinga2
+	fperms ug+rwX,o-rwx /var/spool/icinga2
+	fperms ug+rwX,o-rwx /var/log/icinga2
+
+	if use vim-syntax; then
+		insinto /usr/share/vim/vimfiles
+		doins -r "${WORKDIR}"/${P}/tools/syntax/vim/ftdetect
+		doins -r "${WORKDIR}"/${P}/tools/syntax/vim/syntax
+	fi
+
+	if use nano-syntax; then
+		insinto /usr/share/nano
+		doins "${WORKDIR}"/${P}/tools/syntax/nano/icinga2.nanorc
+	fi
+}
+
+pkg_postinst() {
+	elog "DB IDO schema upgrade required. http://docs.icinga.org/icinga2/snapshot/chapter-2.html#upgrading-the-mysql-database"
+	elog "You will need to update your configuration files, see https://dev.icinga.org/issues/5909"
+}

--- a/net-analyzer/icinga2/metadata.xml
+++ b/net-analyzer/icinga2/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="classicui">Adds support for the old interface</flag>
+		<flag name="console">Adds support for line-editing in the console</flag>
 		<flag name="lto">Adds support for link time optimization</flag>
 		<flag name="studio">Adds support for Icinga-studio</flag>
 		<flag name="nano-syntax">Adds support for syntax used in the nano editor</flag>


### PR DESCRIPTION
@prometheanfire 
```diff
--- icinga2-2.4.1-r2.ebuild     2016-01-18 17:31:59.313214688 +0100
+++ icinga2-2.4.1-r3.ebuild     2016-01-18 16:42:47.875030663 +0100
@@ -12,13 +12,14 @@
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="+mysql postgres classicui lto minimal nano-syntax +plugins studio +vim-syntax"
+IUSE="+mysql postgres classicui console lto minimal nano-syntax +plugins studio +vim-syntax"
 
 DEPEND="
        dev-libs/openssl:0
        >=dev-libs/boost-1.41
        sys-devel/bison
        >=sys-devel/flex-2.5.35
+       console? ( dev-libs/libedit )
        mysql? ( virtual/mysql )
        postgres? ( dev-db/postgresql:= )"
 
```