### PR TITLE
eutils.eclass estack* use removal

### DIFF
--- a/eclass/chromium.eclass
+++ b/eclass/chromium.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -172,7 +172,8 @@ chromium_pkg_die() {
 	fi
 
 	# Prevent user problems like bug #348235.
-	eshopts_push -s extglob
+	local prev_shopt=$(shopt -p extglob)
+	shopt -s extglob
 	if is-flagq '-g?(gdb)?([1-9])'; then
 		ewarn
 		ewarn "You have enabled debug info (i.e. -g or -ggdb in your CFLAGS/CXXFLAGS)."
@@ -182,7 +183,7 @@ chromium_pkg_die() {
 		ewarn "Please try removing -g{,gdb} before reporting a bug."
 		ewarn
 	fi
-	eshopts_pop
+	${prev_shopt}
 
 	# ccache often causes bogus compile failures, especially when the cache gets
 	# corrupted.

--- a/eclass/darcs.eclass
+++ b/eclass/darcs.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -21,8 +21,6 @@
 # TODO:
 
 # support for tags
-
-inherit eutils # eshopts_{push,pop}
 
 # Don't download anything other than the darcs repository
 SRC_URI=""
@@ -194,9 +192,7 @@ darcs_src_unpack() {
 	# Use ${WORKDIR}/${P} rather than ${S} so user can point ${S} to something inside.
 	mkdir -p "${WORKDIR}/${P}"
 
-	eshopts_push -s dotglob	# get any dotfiles too.
-	rsync -rlpgo "${EDARCS_TOP_DIR}/${EDARCS_LOCALREPO}"/* "${WORKDIR}/${P}"
-	eshopts_pop
+	rsync -rlpgo "${EDARCS_TOP_DIR}/${EDARCS_LOCALREPO}"/. "${WORKDIR}/${P}"
 
 	einfo "Darcs repository contents are now in ${WORKDIR}/${P}"
 

--- a/eclass/eutils.eclass
+++ b/eclass/eutils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -835,13 +835,11 @@ make_desktop_entry() {
 	# Don't append another ";" when a valid category value is provided.
 	type=${type%;}${type:+;}
 
-	eshopts_push -s extglob
 	if [[ -n ${icon} && ${icon} != /* ]] && [[ ${icon} == *.xpm || ${icon} == *.png || ${icon} == *.svg ]]; then
 		ewarn "As described in the Icon Theme Specification, icon file extensions are not"
 		ewarn "allowed in .desktop files if the value is not an absolute path."
-		icon=${icon%.@(xpm|png|svg)}
+		icon=${icon%.*}
 	fi
-	eshopts_pop
 
 	cat <<-EOF > "${desktop}"
 	[Desktop Entry]

--- a/eclass/kernel-2.eclass
+++ b/eclass/kernel-2.eclass
@@ -925,7 +925,8 @@ unipatch() {
 	[ ! -d ${KPATCH_DIR} ] && mkdir -p ${KPATCH_DIR}
 
 	# We're gonna need it when doing patches with a predefined patchlevel
-	eshopts_push -s extglob
+	local prev_shopt=$(shopt -p extglob)
+	shopt -s extglob
 
 	# This function will unpack all passed tarballs, add any passed patches, and remove any passed patchnumbers
 	# usage can be either via an env var or by params
@@ -1101,7 +1102,7 @@ unipatch() {
 						eend 1
 						eerror "Failed to apply patch ${i/*\//}"
 						eerror "Please attach ${STDERR_T} to any bug you may post."
-						eshopts_pop
+						${prev_shopt}
 						die "Failed to apply ${i/*\//} on patch depth 1."
 					fi
 				fi
@@ -1125,7 +1126,7 @@ unipatch() {
 						eend 1
 						eerror "Failed to apply patch ${i/*\//}"
 						eerror "Please attach ${STDERR_T} to any bug you may post."
-						eshopts_pop
+						${prev_shopt}
 						die "Failed to apply ${i/*\//} on patch depth ${PATCH_DEPTH}."
 					fi
 				else
@@ -1135,7 +1136,7 @@ unipatch() {
 			if [ ${PATCH_DEPTH} -eq 5 ]; then
 				eerror "Failed to dry-run patch ${i/*\//}"
 				eerror "Please attach ${STDERR_T} to any bug you may post."
-				eshopts_pop
+				${prev_shopt}
 				die "Unable to dry-run patch on any patch depth lower than 5."
 			fi
 		done
@@ -1166,7 +1167,7 @@ unipatch() {
 
 	LC_ALL="${myLC_ALL}"
 	LANG="${myLANG}"
-	eshopts_pop
+	${prev_shopt}
 }
 
 # getfilevar accepts 2 vars as follows:

--- a/eclass/qmake-utils.eclass
+++ b/eclass/qmake-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -18,7 +18,7 @@ if [[ -z ${_QMAKE_UTILS_ECLASS} ]]; then
 _QMAKE_UTILS_ECLASS=1
 
 [[ ${EAPI:-0} == [012345] ]] && inherit multilib
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 # @FUNCTION: qt4_get_bindir
 # @DESCRIPTION:
@@ -115,9 +115,10 @@ qmake-utils_find_pro_file() {
 
 	# set nullglob to avoid expanding *.pro to the literal
 	# string "*.pro" when there are no matching files
-	eshopts_push -s nullglob
+	local prev_shopt=$(shopt -p nullglob)
+	shopt -s nullglob
 	local pro_files=(*.pro)
-	eshopts_pop
+	${prev_shopt}
 
 	case ${#pro_files[@]} in
 	0)
@@ -213,7 +214,10 @@ eqmake4() {
 				print fixed;
 			}'
 
-	[[ -n ${EQMAKE4_EXCLUDE} ]] && eshopts_push -o noglob
+	if [[ -n ${EQMAKE4_EXCLUDE} ]]; then
+		local prev_shopts=$(shopt -p -o noglob)
+		set -o noglob
+	fi
 
 	local file
 	while read file; do
@@ -239,7 +243,7 @@ eqmake4() {
 		fi
 	done < <(find . -type f -name '*.pr[io]' -printf '%P\n' 2>/dev/null)
 
-	[[ -n ${EQMAKE4_EXCLUDE} ]] && eshopts_pop
+	[[ -n ${EQMAKE4_EXCLUDE} ]] && ${prev_shopt}
 
 	"$(qt4_get_bindir)"/qmake \
 		-makefile \

--- a/eclass/qt4-build-multilib.eclass
+++ b/eclass/qt4-build-multilib.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -120,7 +120,8 @@ qt4-build-multilib_src_unpack() {
 	fi
 
 	if [[ ${PN} == qtwebkit ]]; then
-		eshopts_push -s extglob
+		local prev_shopt=$(shopt -p extglob)
+		shopt -s extglob
 		if is-flagq '-g?(gdb)?([1-9])'; then
 			ewarn
 			ewarn "You have enabled debug info (probably have -g or -ggdb in your CFLAGS/CXXFLAGS)."
@@ -129,7 +130,7 @@ qt4-build-multilib_src_unpack() {
 			ewarn "For more info check out https://bugs.gentoo.org/307861"
 			ewarn
 		fi
-		eshopts_pop
+		${prev_shopt}
 	fi
 
 	case ${QT4_BUILD_TYPE} in

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -143,7 +143,8 @@ qt5-build_src_unpack() {
 	fi
 
 	if [[ ${PN} == qtwebkit ]]; then
-		eshopts_push -s extglob
+		local prev_shopt=$(shopt -p extglob)
+		shopt -s extglob
 		if is-flagq '-g?(gdb)?([1-9])'; then
 			ewarn
 			ewarn "You have enabled debug info (probably have -g or -ggdb in your CFLAGS/CXXFLAGS)."
@@ -152,7 +153,7 @@ qt5-build_src_unpack() {
 			ewarn "For more info check out https://bugs.gentoo.org/307861"
 			ewarn
 		fi
-		eshopts_pop
+		${prev_shopt}
 	fi
 
 	case ${QT5_BUILD_TYPE} in
@@ -757,12 +758,13 @@ qt5_regenerate_global_qconfigs() {
 
 		# generate list of QT_CONFIG entries from the existing list,
 		# appending QCONFIG_ADD and excluding QCONFIG_REMOVE
-		eshopts_push -s nullglob
+		local prev_shopt=$(shopt -p nullglob)
+		shopt -s nullglob
 		for x in "${ROOT%/}${QT5_ARCHDATADIR}"/mkspecs/gentoo/*-qconfig.pri; do
 			qconfig_add+=" $(sed -n 's/^QCONFIG_ADD=\s*//p' "${x}")"
 			qconfig_remove+=" $(sed -n 's/^QCONFIG_REMOVE=\s*//p' "${x}")"
 		done
-		eshopts_pop
+		${prev_shopt}
 		for x in ${qt_config} ${qconfig_add}; do
 			if ! has "${x}" ${new_qt_config} ${qconfig_remove}; then
 				new_qt_config+=" ${x}"

--- a/eclass/readme.gentoo.eclass
+++ b/eclass/readme.gentoo.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -19,8 +19,6 @@
 
 if [[ -z ${_README_GENTOO_ECLASS} ]]; then
 _README_GENTOO_ECLASS=1
-
-inherit eutils
 
 case "${EAPI:-0}" in
 	0|1|2|3)
@@ -71,15 +69,15 @@ readme.gentoo_create_doc() {
 	debug-print-function ${FUNCNAME} "${@}"
 
 	if [[ -n "${DOC_CONTENTS}" ]]; then
-		eshopts_push
-		set -f
+		local prev_shopt=$(shopt -p -o noglob)
+		set -o noglob
 		if [[ -n "${DISABLE_AUTOFORMATTING}" ]]; then
 			echo "${DOC_CONTENTS}" > "${T}"/README.gentoo
 		else
 			echo -e ${DOC_CONTENTS} | fold -s -w 70 \
 				| sed 's/[[:space:]]*$//' > "${T}"/README.gentoo
 		fi
-		eshopts_pop
+		${prev_shopt}
 	elif [[ -f "${FILESDIR}/README.gentoo-${SLOT%/*}" ]]; then
 		cp "${FILESDIR}/README.gentoo-${SLOT%/*}" "${T}"/README.gentoo || die
 	elif [[ -f "${FILESDIR}/README.gentoo${README_GENTOO_SUFFIX}" ]]; then

--- a/eclass/rpm.eclass
+++ b/eclass/rpm.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -47,7 +47,8 @@ srcrpm_unpack() {
 	# no .src.rpm files, then nothing to do
 	[[ "$* " != *".src.rpm " ]] && return 0
 
-	eshopts_push -s nullglob
+	local prev_shopt=$(shopt -p nullglob)
+	shopt -s nullglob
 
 	# unpack everything
 	local a
@@ -56,7 +57,7 @@ srcrpm_unpack() {
 		rm -f "${a}"
 	done
 
-	eshopts_pop
+	${prev_shopt}
 
 	return 0
 }

--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -122,7 +122,8 @@ ruby_samelib() {
 }
 
 _ruby_atoms_samelib_generic() {
-	eshopts_push -o noglob
+	local prev_shopt=$(shopt -p -o noglob)
+	set -o noglob
 	echo "RUBYTARGET? ("
 	for token in $*; do
 		case "$token" in
@@ -135,7 +136,7 @@ _ruby_atoms_samelib_generic() {
 		esac
 	done
 	echo ")"
-	eshopts_pop
+	${prev_shopt}
 }
 
 # @FUNCTION: ruby_implementation_command

--- a/eclass/subversion.eclass
+++ b/eclass/subversion.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -207,7 +207,8 @@ subversion_fetch() {
 	addwrite "${ESVN_STORE_DIR}"
 
 	if [[ -n "${ESVN_UMASK}" ]]; then
-		eumask_push "${ESVN_UMASK}"
+		local prev_umask=$(umask)
+		umask "${ESVN_UMASK}"
 	fi
 
 	if [[ ! -d ${ESVN_STORE_DIR} ]]; then
@@ -331,7 +332,7 @@ subversion_fetch() {
 	fi
 
 	if [[ -n "${ESVN_UMASK}" ]]; then
-		eumask_pop
+		umask "${prev_umask}"
 	fi
 
 	einfo "   working copy: ${wc_path}"


### PR DESCRIPTION
estack* funcions are horribly broken and fail hard at EAPI 6. Instead of attempting to fix this ugly thing, it's better to stop using it and just use proper bash code with local variables.