### PR TITLE
media-sound/gst123:fixes src configure error

### DIFF
--- a/media-sound/gst123/files/configure.ac.patch
+++ b/media-sound/gst123/files/configure.ac.patch
@@ -1,0 +1,14 @@
+--- configure.ac.orig	2016-01-20 21:39:22.900434965 +0800
++++ configure.ac	2016-01-20 21:39:07.422742473 +0800
+@@ -102,9 +102,9 @@
+ dnl
+ AC_DEFUN([AC_NCURSES_REQUIREMENTS],
+ [
+-    AC_PATH_PROG(NCURSES5_CONFIG,ncurses5-config,no)
++    AC_PATH_PROG(NCURSES5_CONFIG,ncurses6-config,no)
+     if test "$NCURSES5_CONFIG" = "no"; then
+-      AC_MSG_ERROR([You need to have ncurses5-config installed to build this package.
++      AC_MSG_ERROR([You need to have ncurses6-config installed to build this package.
+ 
+ Debian users: aptitude install libncurses-dev
+ ])

--- a/media-sound/gst123/files/configure.patch
+++ b/media-sound/gst123/files/configure.patch
@@ -1,0 +1,22 @@
+--- configure.orig	2013-06-03 18:31:39.000000000 +0800
++++ configure	2016-01-20 21:44:48.681426755 +0800
+@@ -4538,8 +4538,8 @@
+ 
+ 
+ 
+-    # Extract the first word of "ncurses5-config", so it can be a program name with args.
+-set dummy ncurses5-config; ac_word=$2
++    # Extract the first word of "ncurses6-config", so it can be a program name with args.
++set dummy ncurses6-config; ac_word=$2
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+ $as_echo_n "checking for $ac_word... " >&6; }
+ if ${ac_cv_path_NCURSES5_CONFIG+:} false; then :
+@@ -4580,7 +4580,7 @@
+ 
+ 
+     if test "$NCURSES5_CONFIG" = "no"; then
+-      as_fn_error $? "You need to have ncurses5-config installed to build this package.
++      as_fn_error $? "You need to have ncurses6-config installed to build this package.
+ 
+ Debian users: aptitude install libncurses-dev
+ " "$LINENO" 5

--- a/media-sound/gst123/gst123-0.3.3-r1.ebuild
+++ b/media-sound/gst123/gst123-0.3.3-r1.ebuild
@@ -1,8 +1,10 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
+
+inherit eutils
 
 DESCRIPTION="A more flexible command line player in the spirit of ogg123 and mpg123, based on gstreamer"
 HOMEPAGE="http://space.twc.de/~stefan/gst123.php"
@@ -22,3 +24,8 @@ RDEPEND="${CDEPEND}
 	media-plugins/gst-plugins-meta:1.0"
 DEPEND="${CDEPEND}
 	virtual/pkgconfig"
+
+src_prepare() {
+	epatch "$FILESDIR"/configure.patch
+	epatch "$FILESDIR"/configure.ac.patch
+}


### PR DESCRIPTION
Fix src configure error after sys-libs/ncurses  version upgrade to 6
This fixes https://bugs.gentoo.org/show_bug.cgi?id=558182
