### PR TITLE
media-video/mpv: fix 0.15.0 build with vaapi USE wrt bug 572386

### DIFF
--- a/media-video/mpv/files/mpv-0.15.0-fix-vaapi-build-on-older-ffmpeg.patch
+++ b/media-video/mpv/files/mpv-0.15.0-fix-vaapi-build-on-older-ffmpeg.patch
@@ -1,0 +1,23 @@
+commit a8abb53a5d00d023aa6cb753ccaa6810e1640338
+Author: wm4 <wm4@nowhere>
+Date:   Wed Jan 20 15:35:15 2016 +0100
+
+    vaapi: fix compilation on older FFmpeg/Libav
+    
+    They don't define FF_PROFILE_VP9_0.
+    
+    Fixes #2737.
+
+diff --git a/video/decode/vaapi.c b/video/decode/vaapi.c
+index edc95f5..313a901 100644
+--- a/video/decode/vaapi.c
++++ b/video/decode/vaapi.c
+@@ -109,7 +109,7 @@ static const struct va_native_display disp_x11 = {
+ #endif
+
+ #define HAS_HEVC VA_CHECK_VERSION(0, 38, 0)
+-#define HAS_VP9 VA_CHECK_VERSION(0, 38, 1)
++#define HAS_VP9 (VA_CHECK_VERSION(0, 38, 1) && defined(FF_PROFILE_VP9_0))
+
+ #define PE(av_codec_id, ff_profile, vdp_profile)                \
+     {AV_CODEC_ID_ ## av_codec_id, FF_PROFILE_ ## ff_profile,    \

--- a/media-video/mpv/mpv-0.15.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.15.0-r1.ebuild
@@ -163,6 +163,7 @@ src_prepare() {
 	chmod +x "${S}"/waf || die
 
 	epatch "${FILESDIR}/${P}-fix-null-pointer-dereference.patch"
+	epatch "${FILESDIR}/${P}-fix-vaapi-build-on-older-ffmpeg.patch"
 	epatch_user
 }
 


### PR DESCRIPTION
Upstream issue: https://github.com/mpv-player/mpv/issues/2737

Gentoo-Bug: 572386

Package-Manager: portage-2.2.26