### PR TITLE
media-sound/gst123: Resolve issue with configure and ncurses

### DIFF
--- a/media-sound/gst123/files/configure.ac.patch
+++ b/media-sound/gst123/files/configure.ac.patch
@@ -1,0 +1,14 @@
+--- configure.ac.orig	2016-01-20 21:39:22.900434965 +0800
++++ configure.ac	2016-01-20 21:39:07.422742473 +0800
+@@ -102,9 +102,9 @@
+ dnl
+ AC_DEFUN([AC_NCURSES_REQUIREMENTS],
+ [
+-    AC_PATH_PROG(NCURSES5_CONFIG,ncurses5-config,no)
++    AC_PATH_PROG(NCURSES5_CONFIG,ncurses6-config,no)
+     if test "$NCURSES5_CONFIG" = "no"; then
+-      AC_MSG_ERROR([You need to have ncurses5-config installed to build this package.
++      AC_MSG_ERROR([You need to have ncurses6-config installed to build this package.
+ 
+ Debian users: aptitude install libncurses-dev
+ ])

--- a/media-sound/gst123/gst123-0.3.3-r1.ebuild
+++ b/media-sound/gst123/gst123-0.3.3-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit eutils autotools
+
+DESCRIPTION="A more flexible command line player in the spirit of ogg123 and mpg123, based on gstreamer"
+HOMEPAGE="http://space.twc.de/~stefan/gst123.php"
+SRC_URI="http://space.twc.de/~stefan/gst123/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+CDEPEND="dev-libs/glib
+	media-libs/gst-plugins-base:1.0
+	media-libs/gstreamer:1.0
+	sys-libs/ncurses
+	x11-libs/gtk+:2
+	x11-libs/libX11"
+RDEPEND="${CDEPEND}
+	media-plugins/gst-plugins-meta:1.0"
+DEPEND="${CDEPEND}
+	virtual/pkgconfig"
+
+src_prepare() {
+	epatch "$FILESDIR"/configure.ac.patch
+	eautoreconf
+}


### PR DESCRIPTION
Fix src configure error after sys-libs/ncurses version upgrade to 6
This fixes https://bugs.gentoo.org/show_bug.cgi?id=558182