### PR TITLE
kde-base/pykde4: Fix build with GCC-5, bug 567022

### DIFF
--- a/kde-base/pykde4/files/pykde4-4.14.3-gcc-5.patch
+++ b/kde-base/pykde4/files/pykde4-4.14.3-gcc-5.patch
@@ -1,0 +1,25 @@
+Patch created by: Erik Zeek
+
+See also: https://bugs.gentoo.org/show_bug.cgi?id=567022
+
+--- a/CMakeLists.txt
++++ a/CMakeLists.txt
+@@ -166,7 +166,7 @@ add_sip_python_module(PyKDE4.kdeui sip/kdeui/kdeuimod.sip ${KDE4_KDEUI_LIBS} ${Q
+ 
+ file(GLOB kio_files_sip sip/kio/*.sip)
+ set(SIP_EXTRA_FILES_DEPEND ${kio_files_sip})
+-add_sip_python_module(PyKDE4.kio sip/kio/kiomod.sip ${KDE4_KIO_LIBS} ${KDE4_KFILE_LIBS})
++add_sip_python_module(PyKDE4.kio sip/kio/kiomod.sip ${KDE4_SOLID_LIBS} ${KDE4_KIO_LIBS} ${KDE4_KFILE_LIBS})
+ 
+ file(GLOB kutils_files_sip sip/kutils/*.sip)
+ set(SIP_EXTRA_FILES_DEPEND ${kutils_files_sip})
+@@ -190,7 +190,7 @@ add_sip_python_module(PyKDE4.knewstuff sip/knewstuff/knewstuffmod.sip ${KDE4_KNE
+ 
+ file(GLOB dnssd_files_sip sip/dnssd/*.sip)
+ set(SIP_EXTRA_FILES_DEPEND ${dnssd_files_sip})
+-add_sip_python_module(PyKDE4.dnssd sip/dnssd/dnssdmod.sip ${KDE4_KDNSSD_LIBS} ${QT_QTCORE_LIBRARY})
++add_sip_python_module(PyKDE4.dnssd sip/dnssd/dnssdmod.sip ${KDE4_KDNSSD_LIBS} ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
+ 
+ file(GLOB phonon_files_sip sip/phonon/*.sip)
+ set(SIP_EXTRA_FILES_DEPEND ${phonon_files_sip})
+

--- a/kde-base/pykde4/pykde4-4.14.3.ebuild
+++ b/kde-base/pykde4/pykde4-4.14.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -28,6 +28,8 @@ DEPEND="${RDEPEND}
 	dev-lang/python-exec:2[${PYTHON_USEDEP}]
 	sys-devel/libtool
 "
+
+PATCHES=( "${FILESDIR}/${P}-gcc-5.patch" )
 
 pkg_setup() {
 	kde4-base_pkg_setup


### PR DESCRIPTION
Built fine with GCC 5.3, no reason to believe it will break anything.

Thx to Erik Zeek for the patch.
Tested by: Me and a lot of other people

Package-Manager: portage-2.2.27