### PR TITLE
dev-ml/dose3: adjust extlib-dependency for dose-4.2

### DIFF
--- a/dev-ml/dose3/dose3-4.2.ebuild
+++ b/dev-ml/dose3/dose3-4.2.ebuild
@@ -19,7 +19,7 @@ IUSE="+ocamlopt +parmap zip bzip2 xml curl rpm4 test"
 RDEPEND="
 	>=dev-lang/ocaml-3.12:=[ocamlopt?]
 	dev-ml/cudf:=
-	dev-ml/extlib:=
+	>=dev-ml/extlib-1.7.0:=
 	dev-ml/ocaml-re:=
 	dev-ml/cppo:=
 	parmap? ( dev-ml/parmap:= )


### PR DESCRIPTION
Minimal adjustment for dev-ml/dose3-4.2. Trying to build against dev-ml/extlib-1.6.1 results in
```
>>> Emerging (1 of 1) dev-ml/dose3-4.2::gentoo
 * dose3-4.2.tar.gz SHA256 SHA512 WHIRLPOOL size ;-) ...                                                                                                                                                                                [ ok ]
>>> Unpacking source...
>>> Unpacking dose3-4.2.tar.gz to /tmp/portage/dev-ml/dose3-4.2/work
>>> Source unpacked in /tmp/portage/dev-ml/dose3-4.2/work
>>> Preparing source in /tmp/portage/dev-ml/dose3-4.2/work/dose3-4.2 ...
>>> Source prepared.
>>> Configuring source in /tmp/portage/dev-ml/dose3-4.2/work/dose3-4.2 ...
./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --libdir=/usr/lib64 --with-parmap --with-bz2 --with-ocamlgraph --with-xml
checking for x86_64-pc-linux-gnu-ocamlc... no
checking for ocamlc... ocamlc
OCaml version is 4.02.3
OCaml library path is /usr/lib64/ocaml
checking for x86_64-pc-linux-gnu-ocamlopt... no
checking for ocamlopt... ocamlopt
checking for x86_64-pc-linux-gnu-ocamlc.opt... no
checking for ocamlc.opt... ocamlc.opt
checking for x86_64-pc-linux-gnu-ocamlopt.opt... no
checking for ocamlopt.opt... ocamlopt.opt
checking for dynlink.cmxa... yes
checking for x86_64-pc-linux-gnu-ocaml... no
checking for ocaml... ocaml
checking for x86_64-pc-linux-gnu-ocamldep... no
checking for ocamldep... ocamldep
checking for x86_64-pc-linux-gnu-ocamlmktop... no
checking for ocamlmktop... ocamlmktop
checking for x86_64-pc-linux-gnu-ocamlmklib... no
checking for ocamlmklib... ocamlmklib
checking for x86_64-pc-linux-gnu-ocamldoc... no
checking for ocamldoc... ocamldoc
checking for x86_64-pc-linux-gnu-ocamlbuild... no
checking for ocamlbuild... ocamlbuild
checking OCaml Sys.os_type... Unix
checking for x86_64-pc-linux-gnu-ocamlc... ocamlc.opt
OCaml version is 4.02.3
OCAMLLIB previously set; preserving it.
OCaml library path is /usr/lib64/ocaml
checking for x86_64-pc-linux-gnu-ocamlopt... ocamlopt.opt
checking for x86_64-pc-linux-gnu-ocamlc.opt... ocamlc.opt
checking for x86_64-pc-linux-gnu-ocamlopt.opt... ocamlopt.opt
checking for dynlink.cmxa... yes
checking for x86_64-pc-linux-gnu-ocaml... ocaml
checking for x86_64-pc-linux-gnu-ocamldep... ocamldep
checking for x86_64-pc-linux-gnu-ocamlmktop... ocamlmktop
checking for x86_64-pc-linux-gnu-ocamlmklib... ocamlmklib
checking for x86_64-pc-linux-gnu-ocamldoc... ocamldoc
checking for x86_64-pc-linux-gnu-ocamlbuild... ocamlbuild
checking for cppo... yes
checking for x86_64-pc-linux-gnu-ocamlfind... no
checking for ocamlfind... ocamlfind
checking for OCaml findlib package cudf... found
checking for OCaml findlib package extlib... found
checking for OCaml findlib package re.pcre... found
checking for OCaml findlib package parmap... found
checking for OCaml findlib package bz2... found
checking for OCaml findlib package ocamlgraph... found
checking for OCaml findlib package expat... found
checking for OCaml findlib package xml-light... found
checking for x86_64-pc-linux-gnu-x86_64-pc-linux-gnu-gcc... no
checking for x86_64-pc-linux-gnu-gcc... x86_64-pc-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether x86_64-pc-linux-gnu-gcc accepts -g... yes
checking for x86_64-pc-linux-gnu-gcc option to accept ISO C89... none needed
checking how to run the C preprocessor... x86_64-pc-linux-gnu-gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
configure: creating ./config.status
config.status: creating Makefile.config
config.status: creating _tags
config.status: creating META
config.status: creating dose3.odocl
config.status: creating algo/algo.mlpack
config.status: creating common/versionInfo.ml
config.status: creating applications/dose-tests.list
>>> Source configured.
>>> Compiling source in /tmp/portage/dev-ml/dose3-4.2/work/dose3-4.2 ...
make -j1 -j1 
make: Circular all <- all dependency dropped.
/tmp/portage/dev-ml/dose3-4.2/work/dose3-4.2
cppo -V OCAML:4.02.3 myocamlbuild.ml.pp -o myocamlbuild.ml
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY common/common.otarget
Finished, 1 target (0 cached) in 00:00:00.
Finished, 76 targets (0 cached) in 00:00:04.
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY versioning/versioning.otarget
Finished, 0 targets (0 cached) in 00:00:00.
Finished, 15 targets (0 cached) in 00:00:00.
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY pef/pef.otarget
Finished, 0 targets (0 cached) in 00:00:00.
+ /usr/bin/ocamlyacc pef/packages_parser.mly
2 rules never reduced
13 reduce/reduce conflicts.
Finished, 31 targets (0 cached) in 00:00:02.
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY deb/debian.otarget
Finished, 0 targets (0 cached) in 00:00:00.
Finished, 38 targets (0 cached) in 00:00:03.
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY opencsw/csw.otarget
Finished, 0 targets (0 cached) in 00:00:00.
Finished, 11 targets (0 cached) in 00:00:00.
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY opam/opam.otarget
Finished, 0 targets (0 cached) in 00:00:00.
Finished, 13 targets (0 cached) in 00:00:01.
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY algo/algo.otarget
Finished, 0 targets (0 cached) in 00:00:00.
Finished, 43 targets (0 cached) in 00:00:04.
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY doseparseNoRpm/doseparseNoRpm.otarget
Finished, 0 targets (0 cached) in 00:00:00.
Finished, 20 targets (0 cached) in 00:00:01.
ocamlbuild  -j 10 -no-links -cflags -warn-error,FPSXY doseparse/doseparse.otarget
Finished, 0 targets (0 cached) in 00:00:00.
Finished, 20 targets (0 cached) in 00:00:01.
ocamlbuild  -j 10 applications/apps.otarget
Finished, 0 targets (0 cached) in 00:00:00.
+ ocamlfind ocamlc -c -w -24 -ccopt -O9 -package extlib -package re.pcre -package unix -package cudf -package bz2 -package ocamlgraph -package re.str -pp cppo -pp 'cppo -D HASPARMAP -D HASOCAMLGRAPH -D '\''OCAMLGRAPHVERSION 186'\''' -I applications -I doselibs -o applications/distcheck.cmo applications/distcheck.ml
File "applications/distcheck.ml", line 28, characters 33-65:
Error: Signature mismatch:
       ...
       Values do not match:
         val options :
           ?usage:string ->
           ?version:string ->
           ?suppress_usage:bool ->
           ?suppress_help:bool ->
           ?prog:string ->
           ?formatter:OptParse.Formatter.t -> unit -> OptParse.OptParser.t
       is not included in
         val options :
           ?usage:string ->
           ?status:int ->
           ?version:string ->
           ?suppress_usage:bool ->
           ?suppress_help:bool ->
           ?prog:string ->
           ?formatter:OptParse.Formatter.t -> unit -> OptParse.OptParser.t
       File "applications/distcheck.ml", line 28, characters 44-51:
         Actual declaration
Command exited with code 2.
Compilation unsuccessful after building 2 targets (0 cached) in 00:00:00.
Makefile:30: recipe for target 'apps' failed
make: *** [apps] Error 10
 * ERROR: dev-ml/dose3-4.2::gentoo failed (compile phase):
 *   emake failed
 *
 * If you need support, post the output of `emerge --info '=dev-ml/dose3-4.2::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=dev-ml/dose3-4.2::gentoo'`.
 * The complete build log is located at '/var/log/portage/dev-ml:dose3-4.2:20160121-145951.log'.
 * For convenience, a symlink to the build log is located at '/tmp/portage/dev-ml/dose3-4.2/temp/build.log'.
 * The ebuild environment file is located at '/tmp/portage/dev-ml/dose3-4.2/temp/environment'.
 * Working directory: '/tmp/portage/dev-ml/dose3-4.2/work/dose3-4.2'
 * S: '/tmp/portage/dev-ml/dose3-4.2/work/dose3-4.2'

>>> Failed to emerge dev-ml/dose3-4.2, Log file:

>>>  '/var/log/portage/dev-ml:dose3-4.2:20160121-145951.log'
 *
 * The following package has failed to build, install, or execute postinst:
 *
 *  (dev-ml/dose3-4.2:0/4.2::gentoo, ebuild scheduled for merge), Log file:
 *   '/var/log/portage/dev-ml:dose3-4.2:20160121-145951.log'
 *
```

No version bump necessary, since no actual changes to the resulting merge is made.