### PR TITLE
net-irc/inspircd: patch tmpnam call (bug #560362)

### DIFF
--- a/net-irc/inspircd/files/inspircd-2.0.20-deprecated-tmpnam-560362.patch
+++ b/net-irc/inspircd/files/inspircd-2.0.20-deprecated-tmpnam-560362.patch
@@ -1,0 +1,33 @@
+From 79d1a436bb5c7ab40e43130495c455ffc8c682a2 Mon Sep 17 00:00:00 2001
+From: Richard Bradfield <bradfirj@fstab.me>
+Date: Wed, 22 Jul 2015 01:18:03 +0100
+Subject: [PATCH] Replace deprecated tmpnam() call
+
+From Perl 5.22 onwards, POSIX::tmpnam() has been deprecated (without the
+usual 2 year deprecation cycle), using the File::Temp module instead
+preserves compatibility while allowing compilation on 5.22 and later.
+---
+ make/utilities.pm | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/make/utilities.pm b/make/utilities.pm
+index ae16ce3..baba584 100644
+--- a/make/utilities.pm
++++ b/make/utilities.pm
+@@ -29,6 +29,7 @@ use warnings FATAL => qw(all);
+ 
+ use Exporter 'import';
+ use POSIX;
++use File::Temp;
+ use Getopt::Long;
+ use Fcntl;
+ our @EXPORT = qw(make_rpath pkgconfig_get_include_dirs pkgconfig_get_lib_dirs pkgconfig_check_version translate_functions promptstring);
+@@ -404,7 +405,7 @@ sub translate_functions($$)
+ 			my $tmpfile;
+ 			do
+ 			{
+-				$tmpfile = tmpnam();
++				$tmpfile = File::Temp::tmpnam();
+ 			} until sysopen(TF, $tmpfile, O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW, 0700);
+ 			print "(Created and executed \e[1;32m$tmpfile\e[0m)\n";
+ 			print TF $1;

--- a/net-irc/inspircd/inspircd-2.0.20.ebuild
+++ b/net-irc/inspircd/inspircd-2.0.20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -37,7 +37,10 @@ src_prepare() {
 	# Patch the inspircd launcher with the inspircd user
 	sed -i -e "s/@UID@/${PN}/" "${S}/make/template/${PN}" || die
 
-	epatch "${FILESDIR}/${P}-fix-path-builds.patch"
+	epatch "${FILESDIR}"/${P}-fix-path-builds.patch
+	epatch "${FILESDIR}"/${P}-deprecated-tmpnam-560362.patch
+
+	epatch_user
 }
 
 src_configure() {


### PR DESCRIPTION
POSIX::tmpnam() was deprecated in Perl 5.22 which causes a failure in
./configure with various combinations of USE flags enabled on systems
with 5.22 installed.