### PR TITLE
app-text/zathura: synctex need textlive-core-2015

### DIFF
--- a/app-text/zathura/zathura-0.3.4.ebuild
+++ b/app-text/zathura/zathura-0.3.4.ebuild
@@ -30,7 +30,7 @@ RDEPEND=">=dev-libs/girara-0.2.5:3=
 	>=x11-libs/gtk+-3.6:3
 	magic? ( sys-apps/file:= )
 	sqlite? ( dev-db/sqlite:3= )
-	synctex? ( app-text/texlive-core )"
+	synctex? ( >=app-text/texlive-core-2015 )"
 DEPEND="${RDEPEND}
 	sys-devel/gettext
 	virtual/pkgconfig

--- a/app-text/zathura/zathura-9999.ebuild
+++ b/app-text/zathura/zathura-9999.ebuild
@@ -30,7 +30,7 @@ RDEPEND=">=dev-libs/girara-0.2.5:3=
 	>=x11-libs/gtk+-3.6:3
 	magic? ( sys-apps/file:= )
 	sqlite? ( dev-db/sqlite:3= )
-	synctex? ( app-text/texlive-core )"
+	synctex? ( >=app-text/texlive-core-2015 )"
 DEPEND="${RDEPEND}
 	sys-devel/gettext
 	virtual/pkgconfig


### PR DESCRIPTION
zathura need a `synctex.pc` for `pkg-config` which is not available in the stable `app-text/texlive-core`. It is available in the next version, which is 2015.

btw, the current 9999 is not building, because of failing patch.