### PR TITLE
media-sound/kid3: Backport fixes to 3.1.2

### DIFF
--- a/media-sound/kid3/files/kid3-3.1.2-fix-cmake.patch
+++ b/media-sound/kid3/files/kid3-3.1.2-fix-cmake.patch
@@ -1,0 +1,51 @@
+commit c126ad8142c51476c4a1b78ab9e6d7409656b312
+Author: Michael Palimaka <kensington@gentoo.org>
+Date:   Tue Aug 25 00:05:20 2015 +1000
+
+    Fix build with kdelibs-4.14.11.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3ab5d20..99cf392 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -473,6 +473,13 @@ else (UNIX AND NOT APPLE)
+   set(KID3_EXECUTABLE kid3)
+ endif (UNIX AND NOT APPLE)
+ 
++if (BUILD_KDE_APP)
++  if (NOT HAVE_QT5)
++    find_package(KDE4 REQUIRED)
++    include (KDE4Defaults)
++    add_definitions(${KDE4_ENABLE_EXCEPTIONS})
++  endif (NOT HAVE_QT5)
++endif (BUILD_KDE_APP)
+ 
+ configure_file(config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
+--- a/doc/de/CMakeLists.txt	2014-11-10 07:18:30.000000000 +0100
++++ b/doc/de/CMakeLists.txt	2016-01-22 23:52:37.366124271 +0100
+@@ -1,5 +1,4 @@
+ if (BUILD_KDE_APP)
+-  find_package(KDE4 REQUIRED)
+   kde4_create_handbook(index.docbook INSTALL_DESTINATION ${HTML_INSTALL_DIR}/de SUBDIR kid3)
+ endif (BUILD_KDE_APP)
+ 
+--- a/doc/en/CMakeLists.txt	2014-11-10 07:18:30.000000000 +0100
++++ b/doc/en/CMakeLists.txt	2016-01-22 23:52:29.269225496 +0100
+@@ -1,5 +1,4 @@
+ if (BUILD_KDE_APP)
+-  find_package(KDE4 REQUIRED)
+   kde4_create_handbook(index.docbook INSTALL_DESTINATION ${HTML_INSTALL_DIR}/en SUBDIR kid3)
+ endif (BUILD_KDE_APP)
+  
+--- a/src/app/CMakeLists.txt	2014-11-10 07:18:30.000000000 +0100
++++ b/src/app/CMakeLists.txt	2016-01-22 23:54:00.844080652 +0100
+@@ -18,8 +18,6 @@
+ 
+ if (BUILD_KDE_APP)
+   set(_cmakeInstallRpath "${CMAKE_INSTALL_RPATH}")
+-  find_package(KDE4 REQUIRED)
+-  include (KDE4Defaults)
+ 
+   if (BUILD_SHARED_LIBS)
+     # FindKDE4Internal.cmake will overwrite our RPATH if LIB_INSTALL_DIR (which

--- a/media-sound/kid3/kid3-3.1.2-r1.ebuild
+++ b/media-sound/kid3/kid3-3.1.2-r1.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+KDE_LINGUAS="cs de es et fi fr it nl pl ru sr sr@ijekavian sr@ijekavianlatin
+sr@Latn tr zh_CN zh_TW"
+KDE_REQUIRED="optional"
+KDE_HANDBOOK="optional"
+inherit kde4-base
+
+DESCRIPTION="A simple tag editor for KDE"
+HOMEPAGE="http://kid3.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="4"
+KEYWORDS="amd64 x86"
+IUSE="acoustid flac kde mp3 mp4 +phonon +taglib vorbis"
+
+REQUIRED_USE="flac? ( vorbis )"
+
+RDEPEND="
+	dev-qt/qtcore:4
+	dev-qt/qtdbus:4
+	dev-qt/qtgui:4
+	sys-libs/readline:0
+	acoustid? (
+		media-libs/chromaprint
+		virtual/ffmpeg
+	)
+	flac? (
+		media-libs/flac[cxx]
+		media-libs/libvorbis
+	)
+	mp3? ( media-libs/id3lib )
+	mp4? ( media-libs/libmp4v2:0 )
+	phonon? ( || (
+		media-libs/phonon[qt4]
+		dev-qt/qtphonon:4
+	) )
+	taglib? ( >=media-libs/taglib-1.9.1 )
+	vorbis? (
+		media-libs/libogg
+		media-libs/libvorbis
+	)
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.2.1-libdir.patch"
+	"${FILESDIR}/${PN}-3.1.2-fix-cmake.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_with acoustid CHROMAPRINT)
+		$(cmake-utils_use_with flac)
+		$(cmake-utils_use_with mp3 ID3LIB)
+		$(cmake-utils_use_with mp4 MP4V2)
+		$(cmake-utils_use_with phonon)
+		$(cmake-utils_use_with taglib)
+		$(cmake-utils_use_with vorbis)
+		"-DWITH_QT5=OFF"
+	)
+
+	if use kde; then
+		mycmakeargs+=("-DWITH_APPS=KDE;CLI")
+	else
+		mycmakeargs+=("-DWITH_APPS=Qt;CLI")
+	fi
+
+	kde4-base_src_configure
+}


### PR DESCRIPTION
Current stable had the same cmake and runtime issues as later versions.

Package-Manager: portage-2.2.26

@kensington 