### PR TITLE
dev-python/tempita: add Python 3.5 support

### DIFF
--- a/dev-python/tempita/tempita-0.5.3-r1.ebuild
+++ b/dev-python/tempita/tempita-0.5.3-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} pypy )
+
+inherit distutils-r1
+
+MY_PN="Tempita"
+MY_P="${MY_PN}-${PV}dev"
+
+DESCRIPTION="A very small text templating language"
+HOMEPAGE="http://pythonpaste.org/tempita https://pypi.python.org/pypi/Tempita"
+SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+
+S="${WORKDIR}/${MY_PN}-${PV}dev"
+# Source for tests incomplete


### PR DESCRIPTION
@idella Just bumped the existing ebuild and marked all arches as unstable.