### PR TITLE
net-fs/davfs2: add the missing indentation introduced by the glep67 conversion

### DIFF
--- a/net-fs/davfs2/metadata.xml
+++ b/net-fs/davfs2/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gokturk 'gokturk' Yuksek</name>
 		<description>Maintainer. Assign bugs on him</description>
 	</maintainer>	
-<maintainer type="project">
+	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>


### PR DESCRIPTION
The GLEP 67 conversion forgot to indent the maintainer tag when it converted
the herd proxy-maint to a project.

Package-Manager: portage-2.2.26