### PR TITLE
dev-dotnet/libgdiplus: fix incorrect logic with USE=cairo

### DIFF
--- a/dev-dotnet/libgdiplus/libgdiplus-4.2-r1.ebuild
+++ b/dev-dotnet/libgdiplus/libgdiplus-4.2-r1.ebuild
@@ -35,7 +35,7 @@ src_configure() {
 	econf \
 		--disable-dependency-tracking \
 		--disable-static \
-		$(use_with cairo pango)
+		$(usex cairo "" "--with-pango")
 }
 
 src_install () {


### PR DESCRIPTION
This fixes the issue raised by @aleclearmind [here](https://bugs.gentoo.org/show_bug.cgi?id=432224#c20), sorry about the mess.