### PR TITLE
app-shells/bash-completion: add patch to fix bug 543100

### DIFF
--- a/app-shells/bash-completion/bash-completion-2.1-r94.ebuild
+++ b/app-shells/bash-completion/bash-completion-2.1-r94.ebuild
@@ -21,11 +21,6 @@ RDEPEND=">=app-shells/bash-4.3_p30-r1
 	!app-eselect/eselect-bashcomp"
 PDEPEND=">=app-shells/gentoo-bashcomp-20140911"
 
-# Bug 543100
-PATCHES=(
-	"${FILESDIR}"/${P}-escape-characters.patch
-)
-
 # Remove unwanted completions.
 STRIP_COMPLETIONS=(
 	# Included in util-linux, bug #468544
@@ -41,7 +36,8 @@ STRIP_COMPLETIONS=(
 
 src_prepare() {
 	epatch "${WORKDIR}"/bashcomp2-pre1/*.patch
-	epatch "${PATCHES[@]}"
+	# Bug 543100
+	epatch "${FILESDIR}"/${P}-escape-characters.patch
 }
 
 src_test() { :; } # Skip testsuite because of interactive shell wrt #477066

--- a/app-shells/bash-completion/bash-completion-2.1_p20141224-r1.ebuild
+++ b/app-shells/bash-completion/bash-completion-2.1_p20141224-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -41,6 +41,8 @@ STRIP_COMPLETIONS=(
 
 src_prepare() {
 	epatch "${WORKDIR}/${BASHCOMP_P}/${P}"-*.patch
+	# Bug 543100
+	epatch "${FILESDIR}/${PN}-2.1-escape-characters.patch"
 }
 
 src_test() { :; } # Skip testsuite because of interactive shell wrt #477066


### PR DESCRIPTION
@monsieurp
The patch was added for 2.1-r94 in fab2a7c5536a218bd909b2c7265e9c69296316dc but not for the most recent version

Package-Manager: portage-2.2.27
RepoMan-Options: --force