### PR TITLE
dev-vcs/gitg: add support for Python 3.5

### DIFF
--- a/dev-vcs/gitg/gitg-3.18.0.ebuild
+++ b/dev-vcs/gitg/gitg-3.18.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 GCONF_DEBUG="no"
 GNOME2_LA_PUNT="yes"
-PYTHON_COMPAT=( python{3_3,3_4} )
+PYTHON_COMPAT=( python{3_3,3_4,3_5} )
 
 inherit gnome2 python-r1 vala
 


### PR DESCRIPTION
@EvaSDK Here is the pull request we discussed.