### PR TITLE
dev-python/pyenchant: add support for Python 3.5

### DIFF
--- a/dev-python/pyenchant/pyenchant-1.6.6.ebuild
+++ b/dev-python/pyenchant/pyenchant-1.6.6.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} pypy )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} pypy )
 
 inherit distutils-r1
 
@@ -15,12 +15,11 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="amd64 hppa ppc ppc64 sparc x86"
-IUSE=""
+IUSE="test"
 
-DEPEND="
-	>=app-text/enchant-${PV%.*}
-	dev-python/setuptools[${PYTHON_USEDEP}]"
-RDEPEND="${DEPEND}"
+RDEPEND=">=app-text/enchant-${PV%.*}"
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
+	test? ( ${RDEPEND} )"
 
 python_test() {
 	if [[ -n "$(LC_ALL="en_US.UTF-8" bash -c "" 2>&1)" ]]; then


### PR DESCRIPTION
Tests pass under py27, 34 and 35.
```diff
--- pyenchant-1.6.6.ebuild      2016-01-29 15:54:11.715155164 +0100
+++ pyenchant-1.6.6-r1.ebuild   2016-01-29 15:54:58.243701180 +0100
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} pypy )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} pypy )
 
 inherit distutils-r1
 
@@ -14,8 +14,7 @@
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 hppa ppc ppc64 sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 
 DEPEND="
        >=app-text/enchant-${PV%.*}
```