### PR TITLE
media-video/gaupol: add Python 3.5 support, tests, postrm

### DIFF
--- a/media-video/gaupol/gaupol-0.28.2-r1.ebuild
+++ b/media-video/gaupol/gaupol-0.28.2-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python{3_3,3_4} )
+PYTHON_COMPAT=( python{3_3,3_4,3_5} )
 
-inherit distutils-r1 fdo-mime gnome2-utils versionator
+inherit distutils-r1 fdo-mime gnome2-utils versionator virtualx
 
 MAJOR_MINOR_VERSION="$(get_version_component_range 1-2)"
 
@@ -17,7 +17,7 @@ SRC_URI="http://download.gna.org/${PN}/${MAJOR_MINOR_VERSION}/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="spell"
+IUSE="spell test"
 
 RDEPEND="app-text/iso-codes
 	dev-python/chardet[${PYTHON_USEDEP}]
@@ -29,7 +29,12 @@ RDEPEND="app-text/iso-codes
 	)"
 DEPEND="${RDEPEND}
 	dev-util/intltool
-	sys-devel/gettext"
+	sys-devel/gettext
+	test? (
+		dev-python/pytest[${PYTHON_USEDEP}]
+		dev-python/pytest-runner[${PYTHON_USEDEP}]
+	)
+"
 
 DOCS=( AUTHORS.md NEWS.md TODO.md README.md README.aeidon.md )
 
@@ -47,4 +52,14 @@ pkg_postinst() {
 		elog "Additionally, spell-checking requires a dictionary, any of"
 		elog "Aspell/Pspell, Ispell, MySpell, Uspell, Hspell or AppleSpell."
 	fi
+}
+
+python_test() {
+	virtx py.test
+}
+
+pkg_postrm() {
+	fdo-mime_desktop_database_update
+	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
 }

--- a/media-video/gaupol/metadata.xml
+++ b/media-video/gaupol/metadata.xml
@@ -5,8 +5,11 @@
 		<email>media-video@gentoo.org</email>
 		<name>Gentoo Video project</name>
 	</maintainer>
-<maintainer type="project">
+	<maintainer type="project">
 		<email>python@gentoo.org</email>
 		<name>Python</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">otsaloma/gaupol</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Tests work with 3.4 and 3.5. https://github.com/gentoo/gentoo/pull/742 needs to be merged first to add 3.5 for pyenchant. 