### PR TITLE
sys-freebsd/freebsd-libexec: Add a workaround for gcc-5.0 or later.

### DIFF
--- a/sys-freebsd/freebsd-libexec/freebsd-libexec-10.2.ebuild
+++ b/sys-freebsd/freebsd-libexec/freebsd-libexec-10.2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit bsdmk freebsd pam multilib multibuild multilib-build
+inherit bsdmk freebsd pam multilib multibuild multilib-build toolchain-funcs
 
 DESCRIPTION="FreeBSD libexec things"
 SLOT="0"
@@ -53,6 +53,9 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# gcc-5.0 or later, Workaround for critical issue. bug 573358.
+	[[ "$(gcc-major-version)" -ge 5 ]] && replace-flags -O[2-9] -O1
+
 	if [[ ! -e "${WORKDIR}/include" ]]; then
 		ln -s /usr/include "${WORKDIR}/include" || die "Symlinking /usr/include.."
 	fi


### PR DESCRIPTION
Details, please see Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=573358