### PR TITLE
mono-env.eclass and net-nds/lat updates

### DIFF
--- a/eclass/mono-env.eclass
+++ b/eclass/mono-env.eclass
@@ -15,23 +15,22 @@ EXPORT_FUNCTIONS pkg_setup
 
 if [[ ! ${_MONO_ENV} ]]; then
 
+inherit xdg-utils
+
 mono-env_pkg_setup() {
+	xdg_environment_reset
+
 	# >=mono-0.92 versions using mcs -pkg:foo-sharp require shared memory, so we set the
 	# shared dir to ${T} so that ${T}/.wapi can be used during the install process.
 	export MONO_SHARED_DIR="${T}"
 
 	# export more variables as needed by other dotnet packages
 	export MONO_REGISTRY_PATH="${T}/registry"
-	export XDG_DATA_HOME="${T}/data"
 
 	# Building mono, nant and many other dotnet packages is known to fail if LC_ALL
 	# variable is not set to C. To prevent this all mono related packages will be
 	# build with LC_ALL=C (see bugs #146424, #149817)
 	export LC_ALL=C
-
-	# Monodevelop-using applications need this to be set or they will try to create config
-	# files in the user's ~ dir.
-	export XDG_CONFIG_HOME="${T}"
 
 	# Fix bug 83020:
 	# "Access Violations Arise When Emerging Mono-Related Packages with MONO_AOT_CACHE"

--- a/eclass/mono-env.eclass
+++ b/eclass/mono-env.eclass
@@ -11,11 +11,11 @@
 
 SRC_URI="http://download.mono-project.com/sources/${PN}/${P}.tar.bz2"
 
-EXPORT_FUNCTIONS pkg_setup
-
 if [[ ! ${_MONO_ENV} ]]; then
 
 inherit xdg-utils
+
+EXPORT_FUNCTIONS pkg_setup
 
 mono-env_pkg_setup() {
 	xdg_environment_reset

--- a/net-nds/lat/lat-1.2.3-r1.ebuild
+++ b/net-nds/lat/lat-1.2.3-r1.ebuild
@@ -51,8 +51,8 @@ src_install() {
 
 pkg_postinst() {
 	gnome2_pkg_postinst
-	if use avahi ; then
-		ewarn "You've enabled avahi support."
+	if use zeroconf ; then
+		ewarn "You've enabled zeroconf support."
 		ewarn "Make sure the avahi daemon is running before you try to start ${PN}"
 	fi
 }

--- a/net-nds/lat/lat-1.2.3-r1.ebuild
+++ b/net-nds/lat/lat-1.2.3-r1.ebuild
@@ -1,0 +1,58 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+GCONF_DEBUG=no
+
+inherit gnome2 mono
+
+DESCRIPTION="LDAP Administration Tool, allows you to browse LDAP-based directories and add/edit/delete entries"
+HOMEPAGE="http://sourceforge.net/projects/ldap-at/"
+SRC_URI="mirror://sourceforge/ldap-at/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="zeroconf"
+
+RDEPEND="
+	>=dev-lang/mono-1.1.13
+	>=dev-dotnet/gtk-sharp-2.12.21
+	>=dev-dotnet/gnome-sharp-2.24.2-r1
+	gnome-base/libgnome-keyring
+	sys-apps/dbus
+	zeroconf? ( net-dns/avahi[mono] )
+"
+DEPEND="${RDEPEND}
+	app-text/scrollkeeper
+	virtual/pkgconfig"
+
+src_prepare() {
+	# Fix tests, bug #295889
+	echo lat/plugins/ActiveDirectoryCoreViews/dialogs.glade >> po/POTFILES.in
+	echo lat/plugins/JpegAttributeViewer/dialog.glade >> po/POTFILES.in
+	echo lat/plugins/PosixCoreViews/dialogs.glade >> po/POTFILES.in
+}
+
+src_configure() {
+	econf $(use_enable zeroconf avahi)
+}
+
+src_compile() {
+	# bug #330203
+	emake -j1
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	dodoc AUTHORS ChangeLog NEWS README TODO
+}
+
+pkg_postinst() {
+	gnome2_pkg_postinst
+	if use avahi ; then
+		ewarn "You've enabled avahi support."
+		ewarn "Make sure the avahi daemon is running before you try to start ${PN}"
+	fi
+}

--- a/net-nds/lat/lat-1.2.3-r1.ebuild
+++ b/net-nds/lat/lat-1.2.3-r1.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 GCONF_DEBUG=no
 
-inherit gnome2 mono
+inherit gnome2 mono-env
 
 DESCRIPTION="LDAP Administration Tool, allows you to browse LDAP-based directories and add/edit/delete entries"
 HOMEPAGE="http://sourceforge.net/projects/ldap-at/"


### PR DESCRIPTION
Hi @gentoo/dotnet,

Here are a few changes to mono-env to re-use xdg-utils function which handles XDG_* environment variables and related directory creation. Also I fixed the lat ebuild as I wanted to try it at work but couldn't emerge it due to changes in gnome mono ebuilds. Finally, I bumped to ebuild to USE EAPI=5 and witch USE flag for zeroconf functionality.

