### PR TITLE
net-p2p/torrentinfo: add Python 3.5

### DIFF
--- a/net-p2p/torrentinfo/torrentinfo-1.8.6.ebuild
+++ b/net-p2p/torrentinfo/torrentinfo-1.8.6.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 
 inherit distutils-r1
 
@@ -16,11 +16,9 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="test"
 
-RDEPEND=""
-DEPEND="${RDEPEND}
-	test? ( dev-python/nose[${PYTHON_USEDEP}] )
-"
+DEPEND="test? ( dev-python/nose[${PYTHON_USEDEP}] )"
 
 python_test() {
-	nosetests -v test/tests.py || die "Tests fail with ${EPYTHON}"
+	# tests sometimes fail, see bug #493682
+	nosetests test/tests.py || die "tests failed with ${EPYTHON}"
 }


### PR DESCRIPTION
@idella 
The tests still fail but I found the fix and made a PR upstream: https://github.com/Fuuzetsu/torrentinfo/pull/16