### PR TITLE
Rdepend on sys-fs/lvm2 because of /opt/VirtualBox/VBoxVolInfo

### DIFF
--- a/app-emulation/virtualbox-bin/virtualbox-bin-4.3.32.103443.ebuild
+++ b/app-emulation/virtualbox-bin/virtualbox-bin-4.3.32.103443.ebuild
@@ -75,6 +75,7 @@ RDEPEND="!!app-emulation/virtualbox
 	x11-libs/libSM
 	x11-libs/libICE
 	x11-libs/libXdmcp
+	sys-fs/lvm2
 	python? ( ${PYTHON_DEPS} )"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"


### PR DESCRIPTION
$ emerge -v1 xxx
!!! existing preserved libs:
>>> package: sys-fs/lvm2-2.02.116
 *  - /lib64/libdevmapper.so.1.02
 *      used by /opt/VirtualBox/VBoxVolInfo (app-emulation/virtualbox-bin-4.3.32.103443)
Use emerge @preserved-rebuild to rebuild packages using these libraries

$ cat /var/lib/portage/preserved_libs_registry 
{
    "sys-fs/lvm2:0": [
        "sys-fs/lvm2-2.02.116", 
        "9802", 
        [
            "/lib64/libdevmapper.so.1.02"
        ]
    ]
}