### PR TITLE
sys-devel/gcc: Added ~amd64-fbsd ~x86-fbsd keyword.

### DIFF
--- a/profiles/releases/freebsd-8.2/package.mask
+++ b/profiles/releases/freebsd-8.2/package.mask
@@ -33,3 +33,6 @@
 >sys-freebsd/boot0-8.2.99
 <sys-freebsd/freebsd-sources-8.2_alpha
 >sys-freebsd/freebsd-sources-8.2.99
+
+# Critical issue in freebsd-libexec, bug #573358.
+>=sys-devel/gcc-5.0

--- a/profiles/releases/freebsd-9.1/package.mask
+++ b/profiles/releases/freebsd-9.1/package.mask
@@ -43,3 +43,6 @@ sys-process/fuser-bsd
 # via libulog.
 # this package does not build anymore as it requires utmp
 sys-libs/libutempter
+
+# Critical issue in freebsd-libexec, bug #573358.
+>=sys-devel/gcc-5.0

--- a/sys-devel/gcc/gcc-5.3.0.ebuild
+++ b/sys-devel/gcc/gcc-5.3.0.ebuild
@@ -22,7 +22,7 @@ SSP_UCLIBC_STABLE="x86 amd64 mips ppc ppc64 arm"
 
 inherit toolchain
 
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
 
 RDEPEND=""
 DEPEND="${RDEPEND}


### PR DESCRIPTION
I was confirmed that emerge -e world --exclude sys-apps/portage 
using gcc-5.3.0 successfully completed.
Please add a keyword.

Tested on amd64-fbsd/10.2, amd64-fbsd/10.2/clang, x86-fbsd/10.2

Note
Since the 8.2 and 9.1 are very old, I was mask gcc-5 or later.