### PR TITLE
media-sound/mpd: fix the systemd user service

### DIFF
--- a/media-sound/mpd/mpd-0.19.12.ebuild
+++ b/media-sound/mpd/mpd-0.19.12.ebuild
@@ -224,6 +224,8 @@ src_install() {
 	newinitd "${FILESDIR}"/${PN}2.init ${PN}
 
 	systemd_newuserunit systemd/${PN}.service ${PN}.service
+	sed -i '/WantedBy=/c WantedBy=default.target' \
+		"${ED}"/usr/lib/systemd/user/mpd.service || die "sed failed"
 
 	if use unicode; then
 		sed -i -e 's:^#filesystem_charset.*$:filesystem_charset "UTF-8":' \


### PR DESCRIPTION
In continuation of #587, multi-user.target doesn't exist in the user instance of systemd. Therefore, after enabling, the mpd.service wouldn't autostart. Replace multi-user.target with default.target in the user service file to make it work.