### PR TITLE
net-libs/librsync: add subslots and fix bug #573144

### DIFF
--- a/net-libs/librsync/files/librsync-2.0.0-search.patch
+++ b/net-libs/librsync/files/librsync-2.0.0-search.patch
@@ -1,0 +1,12 @@
+diff -Naur a/src/search.c b/src/search.c
+--- a/src/search.c	2015-11-29 21:43:12.000000000 +0100
++++ b/src/search.c	2016-01-31 19:11:54.847933060 +0100
+@@ -218,7 +218,7 @@
+ 	    r = m;
+     }
+ 
+-    if (l == r) {
++    if ((l == r) && (l <= bucket->r)) {
+ 	int i = sig->targets[l].i;
+ 	rs_block_sig_t *b = &(sig->block_sigs[i]);
+ 	if (weak_sum != b->weak_sum)

--- a/net-libs/librsync/librsync-0.9.7-r3.ebuild
+++ b/net-libs/librsync/librsync-0.9.7-r3.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://librsync.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
-SLOT="0"
+SLOT="0/1"
 KEYWORDS="alpha amd64 arm ~hppa ia64 ppc ppc64 s390 sh sparc x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="static-libs"
 

--- a/net-libs/librsync/librsync-2.0.0-r1.ebuild
+++ b/net-libs/librsync/librsync-2.0.0-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit cmake-utils
+
+DESCRIPTION="Remote delta-compression library"
+HOMEPAGE="http://librsync.sourcefrog.net/"
+SRC_URI="https://github.com/librsync/librsync/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0/2"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+
+RDEPEND="dev-libs/popt"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	# isprefix_test does not work in portage environment
+	sed -i '169 s/^/#/' CMakeLists.txt || die
+
+	# fix compiling with multilib-strict feature enabled
+	sed -i "242 s/lib/$(get_libdir)/" CMakeLists.txt || die
+
+	# fix bug 573144
+	epatch "${FILESDIR}/${P}-search.patch"
+
+	cmake-utils_src_prepare
+}

--- a/net-libs/librsync/librsync-2.0.0.ebuild
+++ b/net-libs/librsync/librsync-2.0.0.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="http://librsync.sourcefrog.net/"
 SRC_URI="https://github.com/librsync/librsync/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
-SLOT="0"
+SLOT="0/2"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 
 RDEPEND="dev-libs/popt"


### PR DESCRIPTION
I added subslots for both versions to allow automatic recompilation of dependent packages and I also put the upstream patch[¹] to fix bug #573144.

[¹] https://github.com/librsync/librsync/issues/50