### PR TITLE
dev-python/pysrt: support Python 3.5, fix tests, take package

### DIFF
--- a/dev-python/pysrt/metadata.xml
+++ b/dev-python/pysrt/metadata.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>nikoli@gmx.us</email>
-  </maintainer>
-  <maintainer type="project">
-    <email>proxy-maint@gentoo.org</email>
-    <name>Proxy Maintainers</name>
-  </maintainer>
-  <upstream>
-    <remote-id type="pypi">pysrt</remote-id>
-    <remote-id type="github">byroot/pysrt</remote-id>
-  </upstream>
+	<maintainer type="person">
+		<email>sautier.louis@gmail.com</email>
+		<name>Louis Sautier</name>
+		<description>Proxied maintainer; set to assignee in all bugs</description>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="pypi">pysrt</remote-id>
+		<remote-id type="github">byroot/pysrt</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/pysrt/pysrt-1.0.1.ebuild
+++ b/dev-python/pysrt/pysrt-1.0.1.ebuild
@@ -1,31 +1,30 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 
 inherit distutils-r1
 
 DESCRIPTION="Python library used to edit or create SubRip files"
 HOMEPAGE="https://github.com/byroot/pysrt https://pypi.python.org/pypi/pysrt"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+# pypi tarballs don't include tests https://github.com/byroot/pysrt/issues/42
+SRC_URI="https://github.com/byroot/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="test"
 
-RDEPEND="
-	dev-python/chardet[${PYTHON_USEDEP}]
-"
-DEPEND="${RDEPEND}
+RDEPEND="dev-python/chardet[${PYTHON_USEDEP}]"
+DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
-	test? ( dev-python/nose[coverage(+),${PYTHON_USEDEP}] )
+	test? (
+		dev-python/nose[coverage(+),${PYTHON_USEDEP}]
+		${RDEPEND}
+	)
 "
-
-# https://github.com/byroot/pysrt/issues/42
-RESTRICT="test"
 
 python_test() {
 	nosetests --with-coverage --cover-package=pysrt \

--- a/dev-python/pysrt/pysrt-9999.ebuild
+++ b/dev-python/pysrt/pysrt-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 
 inherit distutils-r1 git-r3
 
@@ -16,12 +16,13 @@ SLOT="0"
 KEYWORDS=""
 IUSE="test"
 
-RDEPEND="
-	dev-python/chardet[${PYTHON_USEDEP}]
-"
-DEPEND="${RDEPEND}
+RDEPEND="dev-python/chardet[${PYTHON_USEDEP}]"
+DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
-	test? ( dev-python/nose[coverage(+),${PYTHON_USEDEP}] )
+	test? (
+		dev-python/nose[coverage(+),${PYTHON_USEDEP}]
+		${RDEPEND}
+	)
 "
 
 python_test() {


### PR DESCRIPTION
This adds support for Python 3.5 (tests pass). It fetches from github since pypi's releases don't include tests.
I believe @Nikoli is AWOL so I am taking this package. The pull request probably won't be merged for a few days so please reply if you'd like to keep it.