### PR TITLE
media-video/mpv: omit unneeded etc/* entries from DOCS array in 0.14.0-r1

### DIFF
--- a/media-video/mpv/mpv-0.14.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.14.0-r1.ebuild
@@ -23,7 +23,7 @@ else
 	inherit git-r3
 fi
 SRC_URI+=" https://waf.io/waf-${WAF_PV}"
-DOCS+=( README.md etc/example.conf etc/input.conf )
+DOCS+=( README.md )
 
 # See Copyright in source tarball and bug #506946. Waf is BSD, libmpv is ISC.
 LICENSE="GPL-2+ BSD ISC"


### PR DESCRIPTION
This is the backport of 8d842d6 to 0.14.0-r1 ebuild.
The resulting installed image isn't changed, thus no revbump.

Package-Manager: portage-2.2.27