### PR TITLE
x11-libs/libxcb: add support for python 3.5

### DIFF
--- a/x11-libs/libxcb/libxcb-1.11-r1.ebuild
+++ b/x11-libs/libxcb/libxcb-1.11-r1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 PYTHON_REQ_USE=xml
 
 XORG_DOC=doc


### PR DESCRIPTION
I've been trying to purge python-3.4 from my system in favor of 3.5 and noticed that libxcb's python dependency is build-time only. It can be set to allow python 3.5 without problems.
