### PR TITLE
app-misc/media-player-info: add support for python 3.5

### DIFF
--- a/app-misc/media-player-info/media-player-info-22.ebuild
+++ b/app-misc/media-player-info/media-player-info-22.ebuild
@@ -3,7 +3,7 @@
 # $Id$
 
 EAPI=5
-PYTHON_COMPAT=( python{3_3,3_4} )
+PYTHON_COMPAT=( python3_{3,4,5} )
 
 inherit eutils python-any-r1
 


### PR DESCRIPTION
I've been trying to purge python-3.4 from my system in favor of 3.5 and noticed that media-player-info's python dependency is build-time only. It can be set to allow python 3.5 without problems.