### PR TITLE
x11-misc/compton: add support for python 3.5

### DIFF
--- a/x11-misc/compton/compton-0.1_beta2.ebuild
+++ b/x11-misc/compton/compton-0.1_beta2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python3_3 python3_4 )
+PYTHON_COMPAT=( python3_{3,4,5} )
 inherit toolchain-funcs python-r1
 
 DESCRIPTION="A compositor for X, and a fork of xcompmgr-dana"

--- a/x11-misc/compton/compton-9999.ebuild
+++ b/x11-misc/compton/compton-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python3_3 python3_4 )
+PYTHON_COMPAT=( python3_{3,4,5} )
 inherit toolchain-funcs python-r1 git-2
 
 DESCRIPTION="A compositor for X, and a fork of xcompmgr-dana"


### PR DESCRIPTION
I've been trying to purge python-3.4 from my system in favor of 3.5 and noticed that compton's python dependency is build-time only. It can be set to allow python 3.5 without problems.