### PR TITLE
media-video/mpv: add support for python 3.5

### DIFF
--- a/media-video/mpv/mpv-0.15.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.15.0-r1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 PYTHON_REQ_USE='threads(+)'
 
 WAF_PV='1.8.12'

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 PYTHON_REQ_USE='threads(+)'
 
 WAF_PV='1.8.12'


### PR DESCRIPTION
I've been trying to purge python-3.4 from my system in favor of 3.5 and noticed that mpv's python dependency is build-time only. It can be set to allow python 3.5 without problems.