### PR TITLE
media-libs/libepoxy: add support for python 3.5

### DIFF
--- a/media-libs/libepoxy/libepoxy-1.3.1.ebuild
+++ b/media-libs/libepoxy/libepoxy-1.3.1.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = 9999* ]]; then
 	GIT_ECLASS="git-r3"
 fi
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 PYTHON_REQ_USE='xml(+)'
 inherit autotools-multilib ${GIT_ECLASS} python-any-r1
 

--- a/media-libs/libepoxy/libepoxy-9999.ebuild
+++ b/media-libs/libepoxy/libepoxy-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = 9999* ]]; then
 	GIT_ECLASS="git-r3"
 fi
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 PYTHON_REQ_USE='xml(+)'
 inherit autotools-multilib ${GIT_ECLASS} python-any-r1
 


### PR DESCRIPTION
I've been trying to purge python-3.4 from my system in favor of 3.5 and noticed that libepoxy's python dependency is build-time only. It can be set to allow python 3.5 without problems.