### PR TITLE
media-video/mpv: add support for python 3.5 to 0.14 series

### DIFF
--- a/media-video/mpv/mpv-0.14.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.14.0-r1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 PYTHON_REQ_USE='threads(+)'
 
 WAF_PV='1.8.12'


### PR DESCRIPTION
User @Coacher requested python 3.5 support for an older ebuild in PR #779, so here it is.
Tested build/runtime without problems, as expected.
