### PR TITLE
app-misc/c_rehash: Add support for .crt, .cer, or .crl files

### DIFF
--- a/app-misc/c_rehash/c_rehash-1.7-r1.ebuild
+++ b/app-misc/c_rehash/c_rehash-1.7-r1.ebuild
@@ -4,6 +4,8 @@
 
 EAPI=5
 
+inherit eutils
+
 DESCRIPTION="c_rehash script from OpenSSL"
 HOMEPAGE="http://www.openssl.org/"
 SRC_URI="http://cvs.pld-linux.org/cgi-bin/cvsweb.cgi/packages/openssl/openssl-c_rehash.sh?rev=${PV} -> openssl-c_rehash.sh.${PV}"
@@ -25,6 +27,10 @@ src_prepare() {
 		-e "s:SSL_CMD=/usr:SSL_CMD=${EPREFIX}/usr:" \
 		"${DISTDIR}"/openssl-c_rehash.sh.${PV} \
 		> "${WORKDIR}"/c_rehash || die #416717
+
+	# #573786 Add support for .crt, .cer, or .crl files as supported by OpenSSL
+	# version of c_rehash, see https://www.openssl.org/docs/manmaster/apps/c_rehash.html
+	epatch "${FILESDIR}/cer_crt_crl_support.patch"
 }
 
 src_install() {

--- a/app-misc/c_rehash/files/cer_crt_crl_support.patch
+++ b/app-misc/c_rehash/files/cer_crt_crl_support.patch
@@ -1,0 +1,12 @@
+diff -ruN c_rehash.orig/c_rehash c_rehash/c_rehash
+--- c_rehash.orig/c_rehash	2016-02-04 10:43:30.399103942 +0100
++++ c_rehash/c_rehash	2016-02-04 10:44:02.441922501 +0100
+@@ -140,7 +140,7 @@
+         fi
+     done
+ 
+-    ls -1 *.pem 2>/dev/null | while read FILE
++    ls -1 *.pem *.cer *.crt *.crl 2>/dev/null | while read FILE
+     do
+ 	check_file ${FILE}
+         local FILE_TYPE=${?}


### PR DESCRIPTION
Bugzilla: https://bugs.gentoo.org/show_bug.cgi?id=573786

See https://www.openssl.org/docs/manmaster/apps/c_rehash.html