### PR TITLE
dev-libs/uchardet: avoid using EAPI-6-deprecated function in src_prepare

### DIFF
--- a/dev-libs/uchardet/uchardet-0.0.5-r1.ebuild
+++ b/dev-libs/uchardet/uchardet-0.0.5-r1.ebuild
@@ -22,7 +22,7 @@ PATCHES=(
 )
 
 src_prepare() {
-	use test || comment_add_subdirectory test
+	use test || cmake_comment_add_subdirectory test
 	cmake-utils_src_prepare
 }
 


### PR DESCRIPTION
cmake_comment_add_subdirectory is EAPI-6-compatible,
while comment_add_subdirectory is not.

Currently both these functions do the same and
this is a ditto change, thus no revbump.

Package-Manager: portage-2.2.27