### PR TITLE
eclass/rpm.eclass: add xz support to rpm_src_unpack

### DIFF
--- a/eclass/rpm.eclass
+++ b/eclass/rpm.eclass
@@ -51,7 +51,7 @@ srcrpm_unpack() {
 
 	# unpack everything
 	local a
-	for a in *.tar.{gz,bz2} *.t{gz,bz2} *.zip *.ZIP ; do
+	for a in *.tar.{gz,bz2,xz} *.t{gz,bz2} *.zip *.ZIP ; do
 		unpack "./${a}"
 		rm -f "${a}"
 	done


### PR DESCRIPTION
Needed for new src.rpm from sys-apps/hwinfo-21.23 which extracts to tar.xz.