### PR TITLE
media-video/mpv: fix live build

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -205,7 +205,6 @@ src_configure() {
 		--disable-vapoursynth-lazy
 		$(use_enable archive libarchive)
 
-		--enable-libavfilter
 		--enable-libavdevice
 
 		# Audio outputs


### PR DESCRIPTION
libavfilter was made mandatory upstream. We've always enabled it anyway.

Package-Manager: portage-2.2.27