### PR TITLE
dev-db/sqldeveloper: Use jtds:1.3, auto select 1.8 JVM, other fixes

### DIFF
--- a/dev-db/sqldeveloper/files/sqldeveloper-r1
+++ b/dev-db/sqldeveloper/files/sqldeveloper-r1
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# skip their stupid [ -f `which java` ] test, which will always fail on Gentoo
+export APP_SKIP_J2SE_TEST=1
+export GENTOO_VM=$( eval $(gjl --get-vm -p sqldeveloper) && echo ${gjl_vm} )
+export JAVA_HOME=$(java-config -o)
+
+cd /opt/sqldeveloper/sqldeveloper/bin && exec bash sqldeveloper $@

--- a/dev-db/sqldeveloper/sqldeveloper-4.1.3.20.78-r1.ebuild
+++ b/dev-db/sqldeveloper/sqldeveloper-4.1.3.20.78-r1.ebuild
@@ -1,0 +1,98 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit eutils java-pkg-2
+
+DESCRIPTION="Oracle SQL Developer is a graphical tool for database development"
+HOMEPAGE="http://www.oracle.com/technetwork/developer-tools/sql-developer/overview/index.html"
+SRC_URI="${P}-no-jre.zip"
+
+RESTRICT="fetch"
+
+LICENSE="OTN"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+IUSE="mssql mysql sybase"
+
+DEPEND="mssql? ( dev-java/jtds:1.3 )
+	mysql? ( dev-java/jdbc-mysql:0 )
+	sybase? ( dev-java/jtds:1.3 )"
+RDEPEND=">=virtual/jdk-1.8
+	${DEPEND}"
+
+S="${WORKDIR}/${PN}"
+
+QA_PREBUILT="
+opt/${PN}/netbeans/platform/modules/lib/amd64/linux/*.so
+opt/${PN}/netbeans/platform/modules/lib/i386/linux/*.so
+"
+
+pkg_nofetch() {
+	eerror "Please go to"
+	eerror "	${HOMEPAGE}"
+	eerror "and download"
+	eerror "	Oracle SQL Developer for other platforms"
+	eerror "		${SRC_URI}"
+	eerror "and move it to ${DISTDIR}"
+}
+
+src_prepare() {
+	# we don't need these, do we?
+	find ./ \( -iname "*.exe" -or -iname "*.dll" -or -iname "*.bat" \) -exec rm {} +
+
+	# they both use jtds, enabling one of them also enables the other one
+	if use mssql && ! use sybase; then
+		einfo "You requested MSSQL support, this also enables Sybase support."
+	fi
+	if use sybase && ! use mssql; then
+		einfo "You requested Sybase support, this also enables MSSQL support."
+	fi
+
+	if use mssql || use sybase; then
+		echo "AddJavaLibFile $(java-pkg_getjars jtds-1.3)" >> sqldeveloper/bin/sqldeveloper.conf || die
+	fi
+
+	if use mysql; then
+		echo "AddJavaLibFile $(java-pkg_getjars jdbc-mysql)" >> sqldeveloper/bin/sqldeveloper.conf || die
+	fi
+}
+
+src_install() {
+	dodir /opt/${PN}
+	# NOTE For future version to get that line (what to copy) go to the unpacked sources dir
+	# using `bash` and press Meta+_ (i.e. Meta+Shift+-) -- that is a builtin bash feature ;-)
+	cp -r {configuration,d{ataminer,ropins,vt},e{quinox,xternal},ide,j{avavm,d{bc,ev},lib,views},modules,netbeans,ords,rdbms,s{leepycat,ql{developer,j},vnkit}} \
+		"${D}"/opt/${PN}/ || die "Install failed"
+
+	newbin "${FILESDIR}"/${PN}-r1 ${PN}
+
+	newicon icon.png ${PN}-32x32.png
+	make_desktop_entry ${PN} "Oracle SQL Developer" ${PN}-32x32
+
+	# This is normally called automatically by java-pkg_dojar, which
+	# hasn't been used above. We need to create package.env to help the
+	# launcher select the correct VM.
+	java-pkg_do_write_
+}
+
+pkg_postinst() {
+	# this temporary fixes FileNotFoundException with datamodeler
+	# this is more like a workaround than permanent fix
+	mkdir -p /opt/sqldeveloper/sqldeveloper/extensions/oracle.datamodeler/log || die
+	touch /opt/sqldeveloper/sqldeveloper/extensions/oracle.datamodeler/log/datamodeler.log || die
+	chmod -R 1777 /opt/sqldeveloper/sqldeveloper/extensions/oracle.datamodeler/log/datamodeler.log || die
+
+	# this fixes another datamodeler FileNotFoundException
+	# also more like a workaround than permanent fix
+	chmod 1777 /opt/sqldeveloper/sqldeveloper/extensions/oracle.datamodeler/types/dr_custom_scripts.xml || die
+
+	echo
+	einfo "If you want to use the TNS connection type you need to set up the"
+	einfo "TNS_ADMIN environment variable to point to the directory your"
+	einfo "tnsnames.ora resides in."
+	echo
+}


### PR DESCRIPTION
Java team needs to remove Java 6 ASAP and jtds:1.2 is holding this back. Upstream suggests 1.2 but 1.3 is reported to work. I wasn't able to test against a real database but it did at least try to connect.

Asking users to manually switch their JVM before using this isn't very polite and not usually necessary thanks to Gentoo's launcher scripts. Those scripts cannot feasibly be used here but we can at
least write package.env and use gjl to select the JVM intelligently.

Other fixes:

 * Remove java-config from RDEPEND, it's implied by java-pkg-2 eclass.
 * RDEPEND on virtual/jre, not virtual/jdk, build tools are unneeded.
 * Add some missing dies and remove some unnecessary dies.
 * Use newicon instead of mv + doicon.
 * Use exec in launcher to prevent lingering process.

@wschlich, please review this and I'll get it merged. We can stabilise this and jtds at the same time to allow the older versions to be cleared. Some other things for you to consider for later:

 * Respect EPREFIX.
 * Remove the global mask on the sybase USE flag that should only be applied to dev-lang/php.
 * Unbundle the ridiculous number of jars that are installed with this. We have packaged many of them.