### PR TITLE
app-portage/cpuinfo2cpuflags: Added ~amd64-fbsd ~x86-fbsd keyword.

### DIFF
--- a/app-portage/cpuinfo2cpuflags/cpuinfo2cpuflags-2.ebuild
+++ b/app-portage/cpuinfo2cpuflags/cpuinfo2cpuflags-2.ebuild
@@ -10,5 +10,5 @@ SRC_URI="https://bitbucket.org/mgorny/cpuinfo2cpuflags/downloads/${P}.tar.bz2"
 
 LICENSE="BSD-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~x86 ~amd64-fbsd ~x86-fbsd ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
 IUSE=""


### PR DESCRIPTION
app-portage/cpuinfo2cpuflags-2 works on Gentoo/FreeBSD.
Please add KEYWORDS.

```
$ cpuinfo2cpuflags-x86
CPU_FLAGS_X86: aes avx avx2 fma3 mmx mmxext popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3
```