### PR TITLE
sys-devel/llvm: Re add the code for Gentoo/FreeBSD.

### DIFF
--- a/sys-devel/llvm/llvm-3.7.1-r1.ebuild
+++ b/sys-devel/llvm/llvm-3.7.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -7,28 +7,34 @@ EAPI=5
 : ${CMAKE_MAKEFILE_GENERATOR:=ninja}
 PYTHON_COMPAT=( python2_7 )
 
-inherit check-reqs cmake-utils eutils flag-o-matic git-r3 multilib \
-	multilib-minimal python-single-r1 toolchain-funcs pax-utils
+inherit check-reqs cmake-utils eutils flag-o-matic multilib \
+	multilib-minimal python-single-r1 toolchain-funcs pax-utils prefix
 
 DESCRIPTION="Low Level Virtual Machine"
 HOMEPAGE="http://llvm.org/"
-SRC_URI=""
-EGIT_REPO_URI="http://llvm.org/git/llvm.git
-	https://github.com/llvm-mirror/llvm.git"
+SRC_URI="http://llvm.org/releases/${PV}/${P}.src.tar.xz
+	clang? ( http://llvm.org/releases/${PV}/compiler-rt-${PV}.src.tar.xz
+		http://llvm.org/releases/${PV}/cfe-${PV}.src.tar.xz
+		http://llvm.org/releases/${PV}/clang-tools-extra-${PV}.src.tar.xz )
+	lldb? ( http://llvm.org/releases/${PV}/lldb-${PV}.src.tar.xz )
+	!doc? ( http://dev.gentoo.org/~voyageur/distfiles/${PN}-3.7.0-manpages.tar.bz2 )"
 
 LICENSE="UoI-NCSA"
 SLOT="0/${PV}"
-KEYWORDS=""
-IUSE="clang debug +doc gold libedit +libffi lldb multitarget ncurses ocaml
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+IUSE="clang debug doc gold libedit +libffi lldb multitarget ncurses ocaml
 	python +static-analyzer test xml video_cards_radeon
 	kernel_Darwin kernel_FreeBSD"
 
 COMMON_DEPEND="
 	sys-libs/zlib:0=
 	clang? (
-		static-analyzer? ( dev-lang/perl:* )
+		python? ( ${PYTHON_DEPS} )
+		static-analyzer? (
+			dev-lang/perl:*
+			${PYTHON_DEPS}
+		)
 		xml? ( dev-libs/libxml2:2=[${MULTILIB_USEDEP}] )
-		${PYTHON_DEPS}
 	)
 	gold? ( >=sys-devel/binutils-2.22:*[cxx] )
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
@@ -37,7 +43,8 @@ COMMON_DEPEND="
 	ocaml? (
 		>=dev-lang/ocaml-4.00.0:0=
 		dev-ml/findlib
-		dev-ml/ocaml-ctypes )"
+		dev-ml/ocaml-ctypes
+		!!<=sys-devel/llvm-3.7.0-r1[ocaml] )"
 # configparser-3.2 breaks the build (3.3 or none at all are fine)
 DEPEND="${COMMON_DEPEND}
 	dev-lang/perl
@@ -67,6 +74,8 @@ PDEPEND="clang? ( =sys-devel/clang-${PV}-r100 )"
 # being exceeded. probably GC does not close them fast enough.
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	lldb? ( clang xml )"
+
+S=${WORKDIR}/${P/_}.src
 
 pkg_pretend() {
 	# in megs
@@ -102,6 +111,18 @@ pkg_pretend() {
 
 	local CHECKREQS_DISK_BUILD=${build_size}M
 	check-reqs_pkg_pretend
+
+	if [[ ${MERGE_TYPE} != binary ]]; then
+		echo 'int main() {return 0;}' > "${T}"/test.cxx || die
+		ebegin "Trying to build a C++11 test program"
+		if ! $(tc-getCXX) -std=c++11 -o /dev/null "${T}"/test.cxx; then
+			eerror "LLVM-${PV} requires C++11-capable C++ compiler. Your current compiler"
+			eerror "does not seem to support -std=c++11 option. Please upgrade your compiler"
+			eerror "to gcc-4.7 or an equivalent version supporting C++11."
+			die "Currently active compiler does not support -std=c++11"
+		fi
+		eend ${?}
+	fi
 }
 
 pkg_setup() {
@@ -109,33 +130,21 @@ pkg_setup() {
 }
 
 src_unpack() {
-	if use clang; then
-		git-r3_fetch "http://llvm.org/git/compiler-rt.git
-			https://github.com/llvm-mirror/compiler-rt.git"
-		git-r3_fetch "http://llvm.org/git/clang.git
-			https://github.com/llvm-mirror/clang.git"
-		git-r3_fetch "http://llvm.org/git/clang-tools-extra.git
-			https://github.com/llvm-mirror/clang-tools-extra.git"
-	fi
-	if use lldb; then
-		git-r3_fetch "http://llvm.org/git/lldb.git
-			https://github.com/llvm-mirror/lldb.git"
-	fi
-	git-r3_fetch
+	default
 
 	if use clang; then
-		git-r3_checkout http://llvm.org/git/compiler-rt.git \
-			"${S}"/projects/compiler-rt
-		git-r3_checkout http://llvm.org/git/clang.git \
-			"${S}"/tools/clang
-		git-r3_checkout http://llvm.org/git/clang-tools-extra.git \
-			"${S}"/tools/clang/tools/extra
+		mv "${WORKDIR}"/cfe-${PV/_}.src "${S}"/tools/clang \
+			|| die "clang source directory move failed"
+		mv "${WORKDIR}"/compiler-rt-${PV/_}.src "${S}"/projects/compiler-rt \
+			|| die "compiler-rt source directory move failed"
+		mv "${WORKDIR}"/clang-tools-extra-${PV/_}.src "${S}"/tools/clang/tools/extra \
+			|| die "clang-tools-extra source directory move failed"
 	fi
+
 	if use lldb; then
-		git-r3_checkout http://llvm.org/git/lldb.git \
-			"${S}"/tools/lldb
+		mv "${WORKDIR}"/lldb-${PV/_}.src "${S}"/tools/lldb \
+			|| die "lldb source directory move failed"
 	fi
-	git-r3_checkout
 }
 
 src_prepare() {
@@ -158,12 +167,12 @@ src_prepare() {
 	# https://llvm.org/bugs/show_bug.cgi?id=18341
 	epatch "${FILESDIR}"/cmake/0004-cmake-Do-not-install-libgtest.patch
 
-	# Allow custom cmake build types (like 'Gentoo')
-	epatch "${FILESDIR}"/cmake/${PN}-3.8-allow_custom_cmake_build_types.patch
-
 	# Fix llvm-config for shared linking and sane flags
 	# https://bugs.gentoo.org/show_bug.cgi?id=565358
-	epatch "${FILESDIR}"/llvm-3.9-llvm-config.patch
+	epatch "${FILESDIR}"/llvm-3.7-llvm-config.patch
+
+	# Fix msan with newer kernels, #569894
+	epatch "${FILESDIR}"/llvm-3.7-msan-fix.patch
 
 	# disable use of SDK on OSX, bug #568758
 	sed -i -e 's/xcrun/false/' utils/lit/lit/util.py || die
@@ -172,20 +181,39 @@ src_prepare() {
 		# Automatically select active system GCC's libraries, bugs #406163 and #417913
 		epatch "${FILESDIR}"/clang-3.5-gentoo-runtime-gcc-detection-v3.patch
 
+		epatch "${FILESDIR}"/clang-3.6-gentoo-install.patch
+
+		epatch "${FILESDIR}"/clang-3.4-darwin_prefix-include-paths.patch
+		eprefixify tools/clang/lib/Frontend/InitHeaderSearch.cpp
+
+		sed -i -e "s^@EPREFIX@^${EPREFIX}^" \
+			tools/clang/tools/scan-build/scan-build || die
+
 		# Install clang runtime into /usr/lib/clang
 		# https://llvm.org/bugs/show_bug.cgi?id=23792
-		epatch "${FILESDIR}"/cmake/clang-0001-Install-clang-runtime-into-usr-lib-without-suffix-3.8.patch
+		epatch "${FILESDIR}"/cmake/clang-0001-Install-clang-runtime-into-usr-lib-without-suffix.patch
 		epatch "${FILESDIR}"/cmake/compiler-rt-0001-cmake-Install-compiler-rt-into-usr-lib-without-suffi.patch
+
+		# Do not force -march flags on arm platforms
+		# https://bugs.gentoo.org/show_bug.cgi?id=562706
+		epatch "${FILESDIR}"/cmake/${PN}-3.7.0-compiler_rt_arm_march_flags.patch
 
 		# Make it possible to override CLANG_LIBDIR_SUFFIX
 		# (that is used only to find LLVMgold.so)
 		# https://llvm.org/bugs/show_bug.cgi?id=23793
 		epatch "${FILESDIR}"/cmake/clang-0002-cmake-Make-CLANG_LIBDIR_SUFFIX-overridable.patch
 
+		pushd projects/compiler-rt >/dev/null || die
+
+		# Fix msan with newer kernels, compiler-rt part, #569894
+		epatch "${FILESDIR}"/compiler-rt-3.7-msan-fix.patch
+
 		# Fix WX sections, bug #421527
-		find "${S}"/projects/compiler-rt/lib/builtins -type f -name \*.S -exec sed \
+		find lib/builtins -type f -name '*.S' -exec sed \
 			 -e '$a\\n#if defined(__linux__) && defined(__ELF__)\n.section .note.GNU-stack,"",%progbits\n#endif' \
-			 -i {} \; || die
+			 -i {} + || die
+
+		popd >/dev/null || die
 	fi
 
 	if use lldb; then
@@ -193,6 +221,15 @@ src_prepare() {
 		# https://llvm.org/bugs/show_bug.cgi?id=18841
 		sed -e 's/add_subdirectory(readline)/#&/' \
 			-i tools/lldb/scripts/Python/modules/CMakeLists.txt || die
+
+		# Fix Python paths, bugs #562436 and #562438
+		epatch "${FILESDIR}"/${PN}-3.7-lldb_python.patch
+		sed -e "s/GENTOO_LIBDIR/$(get_libdir)/" \
+			-i tools/lldb/scripts/Python/finishSwigPythonLLDB.py || die
+
+		# Fix build with ncurses[tinfo], #560474
+		# http://llvm.org/viewvc/llvm-project?view=revision&revision=247842
+		epatch "${FILESDIR}"/cmake/${PN}-3.7.0-lldb_tinfo.patch
 	fi
 
 	# User patches
@@ -224,7 +261,7 @@ multilib_src_configure() {
 		"${mycmakeargs[@]}"
 		-DLLVM_LIBDIR_SUFFIX=${libdir#lib}
 
-		-DLLVM_LINK_LLVM_DYLIB=ON
+		-DBUILD_SHARED_LIBS=ON
 		-DLLVM_ENABLE_TIMESTAMPS=OFF
 		-DLLVM_TARGETS_TO_BUILD="${targets}"
 		-DLLVM_BUILD_TESTS=$(usex test)
@@ -377,7 +414,7 @@ src_install() {
 
 	if use clang; then
 		# note: magic applied in multilib_src_install()!
-		CLANG_VERSION=3.9
+		CLANG_VERSION=${PV%.*}
 
 		MULTILIB_CHOST_TOOLS+=(
 			/usr/bin/clang
@@ -403,8 +440,8 @@ multilib_src_install() {
 	cmake-utils_src_install
 
 	if multilib_is_native_abi; then
-		# Install docs.
-		#use doc && dohtml -r "${S}"/docs/_build/html/
+		# Install man pages.
+		use doc || doman "${WORKDIR}"/${PN}-3.7.0-manpages/*.1
 
 		# Symlink the gold plugin.
 		if use gold; then
@@ -459,6 +496,31 @@ multilib_src_install_all() {
 	if use clang; then
 		pushd tools/clang >/dev/null || die
 
+		if use static-analyzer ; then
+			pushd tools/scan-build >/dev/null || die
+
+			dobin ccc-analyzer scan-build
+			dosym ccc-analyzer /usr/bin/c++-analyzer
+			doman scan-build.1
+
+			insinto /usr/share/llvm
+			doins scanview.css sorttable.js
+
+			popd >/dev/null || die
+		fi
+
+		if use static-analyzer ; then
+			pushd tools/scan-view >/dev/null || die
+
+			python_doscript scan-view
+
+			touch __init__.py || die
+			python_moduleinto clang
+			python_domodule *.py Resources
+
+			popd >/dev/null || die
+		fi
+
 		if use python ; then
 			pushd bindings/python/clang >/dev/null || die
 
@@ -474,14 +536,14 @@ multilib_src_install_all() {
 		popd >/dev/null || die
 
 		python_fix_shebang "${ED}"
-		if use static-analyzer; then
-			python_optimize "${ED}"usr/share/scan-view
+		if use lldb && use python; then
+			python_optimize
 		fi
 	fi
 }
 
 pkg_postinst() {
-	if use clang && ! has_version 'sys-libs/libomp'; then
+	if use clang && ! has_version sys-libs/libomp; then
 		elog "To enable OpenMP support in clang, install sys-libs/libomp."
 	fi
 }

--- a/sys-devel/llvm/llvm-3.8.0_rc1.ebuild
+++ b/sys-devel/llvm/llvm-3.8.0_rc1.ebuild
@@ -23,7 +23,8 @@ LICENSE="UoI-NCSA"
 SLOT="0/${PV}"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="clang debug doc gold libedit +libffi lldb multitarget ncurses ocaml
-	python +static-analyzer test xml video_cards_radeon kernel_Darwin"
+	python +static-analyzer test xml video_cards_radeon
+	kernel_Darwin kernel_FreeBSD"
 
 COMMON_DEPEND="
 	sys-libs/zlib:0=
@@ -416,6 +417,9 @@ src_install() {
 	fi
 
 	multilib-minimal_src_install
+
+	# Remove unnecessary headers on FreeBSD, bug #417171
+	use kernel_FreeBSD && use clang && rm "${ED}"usr/lib/clang/${PV}/include/{std,float,iso,limits,tgmath,varargs}*.h
 }
 
 multilib_src_install() {


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=417171

```
+	# Remove unnecessary headers on FreeBSD, bug #417171
+	use kernel_FreeBSD && use clang && rm "${ED}"usr/lib/clang/${PV}/include/{std,float,iso,limits,tgmath,varargs}*.h
```