### PR TITLE
dev-libs/{lib,}ucl: Avoid simultaneous installation

### DIFF
--- a/dev-libs/libucl/libucl-0.7.3.ebuild
+++ b/dev-libs/libucl/libucl-0.7.3.ebuild
@@ -14,7 +14,8 @@ SLOT="0"
 KEYWORDS="~x86 ~amd64"
 
 IUSE="lua +regex signatures static-libs urlfetch utils"
-DEPEND="lua? ( >=dev-lang/lua-5.1:= )
+DEPEND="!!dev-libs/ucl
+	lua? ( >=dev-lang/lua-5.1:= )
 	signatures? ( dev-libs/openssl:0 )
 	urlfetch? ( net-misc/curl )"
 RDEPEND="${DEPEND}"

--- a/dev-libs/ucl/ucl-1.03-r1.ebuild
+++ b/dev-libs/ucl/ucl-1.03-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,6 +13,8 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd"
 IUSE="static-libs"
+
+DEPEND="!!dev-libs/libucl"
 
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-CFLAGS.patch


### PR DESCRIPTION
Both libraries opts to use /usr/{include,lib}/libucl* which leads to a conflict. There unfortunately doesn't seem to be a resolution upstream; dev-libs/ucl is 12 years old and dev-libs/libucl has stated that no changes related to this will occur.

ping @gentoo/proxy-maint (co-maintainer)