### PR TITLE
dd-rescue-1.99-r1: (musl) loff_t and __WORDSIZE includes

### DIFF
--- a/sys-fs/dd-rescue/dd-rescue-1.99-r1.ebuild
+++ b/sys-fs/dd-rescue/dd-rescue-1.99-r1.ebuild
@@ -1,0 +1,87 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit toolchain-funcs flag-o-matic multilib autotools
+
+MY_PN=${PN/-/_}
+MY_P=${MY_PN}-${PV}
+
+DESCRIPTION="Similar to dd but can copy from source with errors"
+HOMEPAGE="http://www.garloff.de/kurt/linux/ddrescue/"
+SRC_URI="http://www.garloff.de/kurt/linux/ddrescue/${MY_P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="cpu_flags_x86_avx2 lzo cpu_flags_x86_sse4_2 static xattr"
+
+RDEPEND="lzo? ( dev-libs/lzo )
+	xattr? ( sys-apps/attr )"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	epatch "${FILESDIR}/${MY_PN}-1.99-test_fix.patch"
+	epatch "${FILESDIR}/${MY_PN}-1.99-musl.patch"
+
+	sed -i \
+		-e 's:-ldl:$(LDFLAGS) -ldl:' \
+		-e 's:-shared:$(CFLAGS) $(LDFLAGS) -shared:' \
+		Makefile
+	eautoreconf
+}
+
+src_configure() {
+	use static && append-ldflags -static
+	# OpenSSL is only used by a random helper tool we don't install.
+	ac_cv_header_attr_xattr_h=$(usex xattr) \
+	ac_cv_header_openssl_evp_h=no \
+	ac_cv_lib_lzo2_lzo1x_1_compress=$(usex lzo) \
+	econf
+}
+
+_emake() {
+	local arch
+	case ${ARCH} in
+	x86)   arch=i386;;
+	amd64) arch=x86_64;;
+	arm)   arch=arm;;
+	arm64) arch=aarch64;;
+	esac
+
+	local os=$(usex kernel_linux Linux IDK)
+
+	# The Makefile is a mess.  Override a few vars rather than patch it.
+	emake \
+		MACH="${arch}" \
+		OS="${os}" \
+		HAVE_SSE42=$(usex cpu_flags_x86_sse4_2 1 0) \
+		HAVE_AVX2=$(usex cpu_flags_x86_avx2 1 0) \
+		RPM_OPT_FLAGS="${CFLAGS} ${CPPFLAGS}" \
+		CFLAGS_OPT='$(CFLAGS)' \
+		LDFLAGS="${LDFLAGS} -Wl,-rpath,${EPREFIX}/usr/$(get_libdir)/${PN}" \
+		CC="$(tc-getCC)" \
+		"$@"
+}
+
+src_compile() {
+	_emake
+}
+
+src_test() {
+	_emake check
+}
+
+src_install() {
+	# easier to install by hand than trying to make sense of the Makefile.
+	dobin dd_rescue
+	dodir /usr/$(get_libdir)/${PN}
+	cp -pPR libddr_*.so "${ED}"/usr/$(get_libdir)/${PN}/ || die
+	dodoc README.dd_rescue
+	doman dd_rescue.1
+	use lzo && doman ddr_lzo.1
+}

--- a/sys-fs/dd-rescue/files/dd_rescue-1.99-musl.patch
+++ b/sys-fs/dd-rescue/files/dd_rescue-1.99-musl.patch
@@ -1,0 +1,90 @@
+--- a/ffs.h	2016-02-09 03:37:14.422639513 +0000
++++ b/ffs.h	2016-02-09 03:38:59.843641094 +0000
+@@ -27,7 +27,8 @@
+ #ifdef HAVE_ENDIAN_H
+ #include <endian.h>
+ #endif
+-
++/* __WORDSIZE */
++#include <sys/reg.h>
+ 
+ #ifdef HAVE_FFS
+ # define myffs(x) ffs(x)
+--- a/fiemap.h	2016-02-09 03:45:05.550646582 +0000
++++ b/fiemap.h	2016-02-09 03:45:56.683647349 +0000
+@@ -31,3 +31,4 @@
+ 
+ #endif	/* _FIEMAPH */
+ 
++#include <sys/reg.h>
+--- a/libddr_hash.c	2016-02-09 03:49:16.334650345 +0000
++++ b/libddr_hash.c	2016-02-09 03:50:01.309651020 +0000
+@@ -32,6 +32,7 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <fcntl.h>
++#include <sys/reg.h>
+ 
+ #include <netinet/in.h>	/* For ntohl/htonl */
+ #include <endian.h>
+--- a/libddr_lzo.c	2016-02-09 03:52:31.775653278 +0000
++++ b/libddr_lzo.c	2016-02-09 03:52:53.537653604 +0000
+@@ -26,6 +26,7 @@
+ #include <errno.h>
+ #include <netinet/in.h>
+ #include <sys/stat.h>
++#include <sys/reg.h>
+ #include <signal.h>
+ #include <lzo/lzo1x.h>
+ #include <lzo/lzo1y.h>
+--- a/libddr_null.c	2016-02-09 03:54:04.110654663 +0000
++++ b/libddr_null.c	2016-02-09 03:54:18.018654872 +0000
+@@ -10,6 +10,7 @@
+ #include "ddr_ctrl.h"
+ #include <string.h>
+ #include <stdlib.h>
++#include <sys/reg.h>
+ 
+ /* fwd decl */
+ extern ddr_plugin_t ddr_plug;
+--- a/sha512.h	2016-02-09 03:55:33.209656000 +0000
++++ b/sha512.h	2016-02-09 03:56:39.923657001 +0000
+@@ -2,6 +2,8 @@
+ #define _SHA512_H
+ 
+ #include "hash.h"
++/* __WORDSIZE */
++#include <sys/reg.h>
+ 
+ void sha512_init(hash_t *ctx);
+ void sha384_init(hash_t *ctx);
+--- a/fmt_no.h	2016-02-09 04:52:13.760707026 +0000
++++ b/fmt_no.h	2016-02-09 04:52:50.874707583 +0000
+@@ -1,4 +1,6 @@
+ /** Decl for int to str conversion with highlighting */
++#define _GNU_SOURCE
++#include <fcntl.h>
+ 
+ #ifndef _FMT_NO_H
+ #define _FMT_NO_H
+--- a/fstrim.h	2016-02-09 04:55:43.871710178 +0000
++++ b/fstrim.h	2016-02-09 04:56:11.270710590 +0000
+@@ -1,3 +1,6 @@
++#define _GNU_SOURCE
++#include <fcntl.h>
++
+ #ifndef _FSTRIM_H
+ #define _FSTRIM_H
+ 
+--- a/ddr_ctrl.h	2016-02-09 04:58:08.442712348 +0000
++++ b/ddr_ctrl.h	2016-02-09 04:58:50.842712984 +0000
+@@ -7,6 +7,9 @@
+  *  License: GNU GPLv2 or v3
+  */
+ 
++#define _GNU_SOURCE
++#include <fcntl.h>
++
+ #ifndef _DDR_CTRL_H
+ #define _DDR_CTRL_H
+ 


### PR DESCRIPTION
Tested on glibc 2.19-r1 and musl 1.1.12. If it looks OK I'll try to upstream[1] it.
[1] http://sourceforge.net/projects/ddrescue/