### PR TITLE
games-strategy/endless-sky: fix SRC_URI to point to upstream's repo

### DIFF
--- a/games-strategy/endless-sky/endless-sky-0.8.11.ebuild
+++ b/games-strategy/endless-sky/endless-sky-0.8.11.ebuild
@@ -8,7 +8,7 @@ inherit eutils scons-utils
 
 DESCRIPTION="Space exploration, trading & combat game in the tradition of Terminal Velocity."
 HOMEPAGE="https://endless-sky.github.io"
-SRC_URI="https://github.com/tomboy-64/endless-sky/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/endless-sky/endless-sky/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="CC-BY-SA-4.0 CC-BY-SA-3.0 GPL-3+ public-domain"
 SLOT="0"


### PR DESCRIPTION
Package-Manager: portage-2.2.26
RepoMan-Options: --ignore-arches