### PR TITLE
net-analyzer/fail2ban: add py3.5, drop old patches, fix fbsd deps

### DIFF
--- a/net-analyzer/fail2ban/fail2ban-0.9.3-r1.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-0.9.3-r1.ebuild
@@ -17,8 +17,10 @@ SLOT="0"
 KEYWORDS="amd64 arm hppa ~ppc ppc64 ~sparc x86 ~x86-fbsd"
 IUSE="selinux systemd"
 
+# TODO support ipfw and ipfilter
 RDEPEND="
 	kernel_linux? ( net-firewall/iptables )
+	kernel_FreeBSD? ( sys-freebsd/freebsd-pf )
 	net-misc/whois
 	virtual/logger
 	virtual/mta

--- a/net-analyzer/fail2ban/fail2ban-0.9.3-r1.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-0.9.3-r1.ebuild
@@ -33,7 +33,7 @@ REQUIRED_USE="systemd? ( !python_single_target_pypy )"
 
 DOCS=( ChangeLog DEVELOP README.md THANKS TODO doc/run-rootless.txt )
 
-src_prepare() {
+python_prepare_all() {
 	# Replace /var/run with /run, but not in the top source directory
 	find . -mindepth 2 -type f -exec \
 		sed -i -e 's|/var\(/run/fail2ban\)|\1|g' {} + || die
@@ -44,15 +44,15 @@ src_prepare() {
 		"${FILESDIR}"/${PN}-0.9.2-initd.patch \
 		"${FILESDIR}"/${PN}-0.9.2-logrotate.patch
 
-	distutils-r1_src_prepare
+	distutils-r1_python_prepare_all
 }
 
 python_test() {
 	"${PYTHON}" "bin/${PN}-testcases" || die "tests failed with ${EPYTHON}"
 }
 
-src_install() {
-	distutils-r1_src_install
+python_install_all() {
+	distutils-r1_python_install_all
 
 	rm -r "${D}"/usr/share/doc/${PN} "${D}"/run || die
 

--- a/net-analyzer/fail2ban/fail2ban-0.9.3-r1.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-0.9.3-r1.ebuild
@@ -35,7 +35,8 @@ DOCS=( ChangeLog DEVELOP README.md THANKS TODO doc/run-rootless.txt )
 
 src_prepare() {
 	# Replace /var/run with /run, but not in the top source directory
-	sed -i -e 's|/var\(/run/fail2ban\)|\1|g' $( find . -mindepth 2 -type f ) || die
+	find . -mindepth 2 -type f -exec \
+		sed -i -e 's|/var\(/run/fail2ban\)|\1|g' {} + || die
 
 	# Fix bashisms and do not direct useful output to /dev/null (bug #536320)
 	# Remove global logrotate settings (bug #549856)
@@ -47,13 +48,13 @@ src_prepare() {
 }
 
 python_test() {
-	${EPYTHON} bin/${PN}-testcases
+	"${PYTHON}" "bin/${PN}-testcases" || die "tests failed with ${EPYTHON}"
 }
 
 src_install() {
 	distutils-r1_src_install
 
-	rm -rf "${D}"/usr/share/doc/${PN} "${D}"/run
+	rm -r "${D}"/usr/share/doc/${PN} "${D}"/run || die
 
 	# not FILESDIR
 	newconfd files/gentoo-confd ${PN}
@@ -96,7 +97,6 @@ pkg_postinst() {
 			elog "If you want to use ${PN}'s persistent database, then reinstall"
 			elog "dev-lang/python with USE=sqlite"
 		fi
-
 		if has_version sys-apps/systemd[-python]; then
 			elog "If you want to track logins through sys-apps/systemd's"
 			elog "journal backend, then reinstall sys-apps/systemd with USE=python"


### PR DESCRIPTION
Patches are no longer required as per:
https://github.com/fail2ban/fail2ban/commit/294a7790a9a32f98448e1e2a2d7a5cfdf741c35f
https://github.com/fail2ban/fail2ban/commit/869d99dd377ff45efa5796bb3be2500e41f32dc3

This is almost the same as https://github.com/gentoo/gentoo/pull/736, here's the diff between the normal and live ebuilds:
```diff
--- fail2ban-0.9.3-r1.ebuild	2016-01-31 16:30:10.166344845 +0100
+++ fail2ban-99999999.ebuild	2016-02-11 01:02:59.833721244 +0100
@@ -6,15 +6,15 @@
 PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} pypy )
 DISTUTILS_SINGLE_IMPL=1
 
-inherit distutils-r1 eutils systemd vcs-snapshot
+inherit distutils-r1 eutils systemd git-r3
 
 DESCRIPTION="scans log files and bans IPs that show malicious signs"
 HOMEPAGE="http://www.fail2ban.org/"
-SRC_URI="https://github.com/${PN}/${PN}/tarball/${PV} -> ${P}.tar.gz"
+EGIT_REPO_URI="https://github.com/${PN}/${PN}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+KEYWORDS=""
 IUSE="selinux systemd"
 
 RDEPEND="
@@ -37,23 +37,17 @@
 	# Replace /var/run with /run, but not in the top source directory
 	sed -i -e 's|/var\(/run/fail2ban\)|\1|g' $( find . -mindepth 2 -type f ) || die
 
-	# Fix bashisms and do not direct useful output to /dev/null (bug #536320)
-	# Remove global logrotate settings (bug #549856)
-	epatch \
-		"${FILESDIR}"/${PN}-0.9.2-initd.patch \
-		"${FILESDIR}"/${PN}-0.9.2-logrotate.patch
-
 	distutils-r1_src_prepare
 }
 
 python_test() {
-	${EPYTHON} bin/${PN}-testcases
+	${EPYTHON} bin/${PN}-testcases || die "tests failed with ${EPYTHON}"
 }
 
 src_install() {
 	distutils-r1_src_install
 
-	rm -rf "${D}"/usr/share/doc/${PN} "${D}"/run
+	rm -r "${D}"/usr/share/doc/${PN} "${D}"/run || die
 
 	# not FILESDIR
 	newconfd files/gentoo-confd ${PN}
@@ -96,7 +90,6 @@
 			elog "If you want to use ${PN}'s persistent database, then reinstall"
 			elog "dev-lang/python with USE=sqlite"
 		fi
-
 		if has_version sys-apps/systemd[-python]; then
 			elog "If you want to track logins through sys-apps/systemd's"
 			elog "journal backend, then reinstall sys-apps/systemd with USE=python"

```