### PR TITLE
dev-ml/qcheck: fix remote-id in metadata.xml

### DIFF
--- a/dev-ml/qcheck/metadata.xml
+++ b/dev-ml/qcheck/metadata.xml
@@ -18,6 +18,6 @@
         <flag name="ounit">Enable integration with ounit</flag>
     </use>
     <upstream>
-        <remote-id type="github">OCamlPro/ocplib-endian</remote-id>
+        <remote-id type="github">c-cube/qcheck</remote-id>
     </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Package-Manager: portage-2.2.26
RepoMan-Options: --ignore-arches

@gentoo/proxy-maint