### PR TITLE
app-benchmarks/bonnie++: eapi bump, fix #309319, #431684, #515334

### DIFF
--- a/app-benchmarks/bonnie++/bonnie++-1.97-r1.ebuild
+++ b/app-benchmarks/bonnie++/bonnie++-1.97-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+DESCRIPTION="Hard drive bottleneck testing benchmark suite"
+HOMEPAGE="http://www.coker.com.au/bonnie++/"
+SRC_URI="http://www.coker.com.au/bonnie++/experimental/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="debug"
+
+S="${WORKDIR}/${P}.1"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.96-compile-flags.patch" #426788
+	"${FILESDIR}"/${P}-zcav-array-indexing-fix.patch #309319
+)
+
+DOCS=( README.txt README-2.00 debian/changelog credits.txt )
+HTML_DOCS=( readme.html )
+
+src_configure() {
+	econf \
+		$(usex debug "--enable-debug" "") \
+		--disable-stripping
+}
+
+src_install() {
+	dobin bonnie++ zcav bon_csv2html bon_csv2txt
+	sed -i -e \
+		"s:/usr/share/doc/bonnie++:${EPREFIX}/usr/share/doc/${PF}/html:g" \
+		bonnie++.8 || die #431684
+	doman bon_csv2html.1 bon_csv2txt.1 bonnie++.8 zcav.8
+	einstalldocs
+}

--- a/app-benchmarks/bonnie++/files/bonnie++-1.97-zcav-array-indexing-fix.patch
+++ b/app-benchmarks/bonnie++/files/bonnie++-1.97-zcav-array-indexing-fix.patch
@@ -1,0 +1,35 @@
+From: Göktürk Yüksek <gokturk@binghamton.edu>
+Subject: [PATCH] Fix array indexing in Zcav::Read when max_loop > 1 and start_offset > 0
+
+In method Zcav::Read, the variable 'i' holds the block index. It is
+also used as an index to arrays of measurement values (read times and
+block counts) when (max_loops > 0). However, the blocks array and
+measurements arrays will be out of sync if some initial blocks are to
+be skipped (by having start_offset > 0). Using the same index value
+for arrays of different sizes causes segfaults. Fix it by substracting
+the start_offset properly when accessing the measurements arrays.
+
+X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=309319
+
+--- a/zcav_io.cpp
++++ b/zcav_io.cpp
+@@ -108,7 +108,7 @@
+     double total_read_time = 0.0;
+     bool nextLoop = false;
+     for( ; !nextLoop && (!max_size || i < max_size)
+-              && (loops == 0 || (m_times[i] && m_times[i][0] != -1.0))
++              && (loops == 0 || (m_times[i - start_offset] && m_times[i - start_offset][0] != -1.0))
+               && (!max_size || i < max_size); i++)
+     {
+       double read_time = access_data(i ? skip_rate - 1 : 0);
+@@ -135,8 +135,8 @@
+           m_times.push_back(new double[max_loops]);
+           m_count.push_back(0);
+         }
+-        m_times[i][loops] = read_time;
+-        m_count[i]++;
++        m_times[i - start_offset][loops] = read_time;
++        m_count[i - start_offset]++;
+       }
+     } // end loop for reading blocks
+ 


### PR DESCRIPTION
Also get rid if unnecessary DEPEND and RDEPEND since this package
has no external dependencies.

Remove src_compile phase that was added per #9073 14 years ago.
It's not reproducible anymore.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=9073
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=309319
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=431684
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=515334

Package-Manager: portage-2.2.26