### PR TITLE
net-misc/i2pd: adjust systemd .service to point to /usr/bin/i2pd

### DIFF
--- a/net-misc/i2pd/files/i2pd-2.4.0.service
+++ b/net-misc/i2pd/files/i2pd-2.4.0.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=C++ daemon for accessing the I2P network
+After=network.target
+
+[Service]
+Type=forking
+Restart=on-abnormal
+PIDFile=/var/run/i2pd.pid
+User=i2pd
+Group=i2pd
+PermissionsStartOnly=yes
+ExecStartPre=/bin/touch /var/run/i2pd.pid /var/log/i2pd.log
+ExecStartPre=/bin/chown i2pd:i2pd /run/i2pd.pid /var/log/i2pd.log
+ExecStart=/usr/bin/i2pd --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.cfg
+
+[Install]
+WantedBy=multi-user.target
+

--- a/net-misc/i2pd/i2pd-2.4.0-r1.ebuild
+++ b/net-misc/i2pd/i2pd-2.4.0-r1.ebuild
@@ -68,7 +68,7 @@ src_install() {
 	dodir /usr/share/i2pd
 	newconfd "${FILESDIR}/${PN}.confd" "${PN}"
 	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
-	systemd_dounit "${FILESDIR}/${PN}.service"
+	systemd_newunit "${FILESDIR}/${PN}-2.4.0.service" "${PN}.service"
 	doenvd "${FILESDIR}/99${PN}"
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}.logrotate" "${PN}"

--- a/net-misc/i2pd/metadata.xml
+++ b/net-misc/i2pd/metadata.xml
@@ -15,6 +15,6 @@
 		</flag>
 	</use>
 	<upstream>
-		<remote-id type="github">PrivacySolutions/i2pd</remote-id>
+		<remote-id type="github">PurpleI2P/i2pd</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-misc/i2pd/metadata.xml
+++ b/net-misc/i2pd/metadata.xml
@@ -9,6 +9,10 @@
 		<email>blueness@gentoo.org</email>
 		<name>Anthony G. Basile</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>tomboy64@sina.cn</email>
+		<name>Proxy maintainer. Please subscribe to bugs.</name>
+	</maintainer>
 	<use>
 		<flag name="i2p-hardening">
 			Compile with hardening on vanilla compilers/linkers


### PR DESCRIPTION
Package-Manager: portage-2.2.26
RepoMan-Options: --ignore-arches

Oversight on my part when updating i2pd.

@klondi 
@blueness 
@gentoo/proxy-maint