### PR TITLE
sys-process/htop: from version 2 onwards, FreeBSD is supported natively

### DIFF
--- a/sys-process/htop/htop-2.0.0.ebuild
+++ b/sys-process/htop/htop-2.0.0.ebuild
@@ -28,17 +28,6 @@ PATCHES=(
 )
 
 pkg_setup() {
-	if use kernel_FreeBSD && ! [[ -f ${ROOT}/compat/linux/proc/stat && -f ${ROOT}/compat/linux/proc/meminfo ]]; then
-		echo
-		eerror "htop requires linprocfs mounted at /compat/linux/proc to build and function."
-		eerror "To mount it, type:"
-		[ -d /compat/linux/proc ] || eerror "mkdir -p /compat/linux/proc"
-		eerror "mount -t linprocfs none /compat/linux/proc"
-		eerror "Alternatively, place this information into /etc/fstab"
-		echo
-		die "htop needs /compat/linux/proc mounted"
-	fi
-
 	if ! has_version sys-process/lsof; then
 		ewarn "To use lsof features in htop(what processes are accessing"
 		ewarn "what files), you must have sys-process/lsof installed."
@@ -58,8 +47,6 @@ src_configure() {
 	[[ $CBUILD != $CHOST ]] && export ac_cv_file__proc_{meminfo,stat}=yes #328971
 
 	local myeconfargs=()
-
-	use kernel_FreeBSD && myeconfargs+=( --with-proc=/compat/linux/proc )
 
 	myeconfargs+=(
 		# fails to build against recent hwloc versions


### PR DESCRIPTION
This, essentialy, is the same as #836, which is closed because I had to force changes into another branch. (I also took opportunity to rebase it upon current upstream master branch.)