### PR TITLE
media-video/mpv: depend on virtual/jack in 9999 when jack USE is enabled

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -74,7 +74,7 @@ COMMON_DEPEND="
 		libguess? ( >=app-i18n/libguess-1.0 )
 		uchardet? ( dev-libs/uchardet )
 	)
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	jpeg? ( virtual/jpeg:0 )
 	lcms? ( >=media-libs/lcms-2.6:2 )
 	libass? (


### PR DESCRIPTION
Instead of forcing Jack1 in the form of media-sound/jack-audio-connection-kit.
Quote from the upstream wiki [0]:

Jack 1 and Jack 2 are equivalent implementations of the same protocol.
...
Programs compiled against Jack 1 will work with Jack 2 without recompile
(and vice versa).

End quote.

[0]: https://github.com/jackaudio/jackaudio.github.com/wiki/Q_difference_jack1_jack2

Package-Manager: portage-2.2.27