### PR TITLE
net-p2p/syncthing: fix licence & description, update metadata.xml

### DIFF
--- a/net-p2p/syncthing/metadata.xml
+++ b/net-p2p/syncthing/metadata.xml
@@ -14,7 +14,12 @@
     <email>djc@gentoo.org</email>
     <name>Dirkjan Ochtman</name>
   </maintainer>
+  <longdescription lang="en">
+	  Syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized.
+	  Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet.
+  </longdescription>
   <upstream>
     <remote-id type="github">syncthing/syncthing</remote-id>
+    <bugs-to>https://github.com/syncthing/syncthing/issues</bugs-to>
   </upstream>
 </pkgmetadata>

--- a/net-p2p/syncthing/syncthing-0.12.19.ebuild
+++ b/net-p2p/syncthing/syncthing-0.12.19.ebuild
@@ -9,11 +9,11 @@ EGIT_COMMIT=v${PV}
 
 inherit golang-vcs-snapshot systemd user
 
-DESCRIPTION="Syncthing is an open, trustworthy and decentralized cloud storage system"
-HOMEPAGE="http://syncthing.net"
+DESCRIPTION="Open Source Continuous File Synchronization"
+HOMEPAGE="https://syncthing.net"
 SRC_URI="https://${EGO_PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="MIT"
+LICENSE="MPL-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""


### PR DESCRIPTION
switch HOMEPAGE to use 'https://' (redirected by default to it),
description was taken from official repo description,
long description (taken from official site),
also bugs-to link was added