### PR TITLE
media-gfx/splash-themes-livecd: Update rc_init-pre to use new path for functions.sh

### DIFF
--- a/media-gfx/splash-themes-livecd/files/use-new-path-for-functions.sh.patch
+++ b/media-gfx/splash-themes-livecd/files/use-new-path-for-functions.sh.patch
@@ -1,0 +1,11 @@
+--- scripts/rc_init-pre.orig	2016-02-18 13:31:23.610276701 -0200
++++ scripts/rc_init-pre	2016-02-18 13:31:57.405275206 -0200
+@@ -77,7 +77,7 @@
+   return 0
+ }
+ 
+-[ -r /etc/init.d/functions.sh ] && . /etc/init.d/functions.sh
++[ -r /lib/gentoo/functions.sh ] && . /lib/gentoo/functions.sh
+ 
+ if [ -z "${1}" ]; then
+   log err "no internal runlevel provided"

--- a/media-gfx/splash-themes-livecd/splash-themes-livecd-2007.0-r3.ebuild
+++ b/media-gfx/splash-themes-livecd/splash-themes-livecd-2007.0-r3.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+inherit eutils
+
+MY_P="gentoo-livecd-${PV}"
+MY_REV="0.9.6"
+DESCRIPTION="Gentoo theme for gensplash consoles"
+HOMEPAGE="https://www.gentoo.org/"
+SRC_URI="mirror://gentoo/${PN}/${MY_P}-${MY_REV}.tar.bz2"
+
+SLOT=${PV}
+LICENSE="Artistic GPL-2 BitstreamVera"
+KEYWORDS="amd64 ~ppc x86"
+IUSE=""
+RESTRICT="binchecks strip"
+
+RDEPEND=">=media-gfx/splashutils-1.5.4[png]
+	sys-apps/gentoo-functions"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/${MY_P}"
+
+pkg_setup() {
+	if ! built_with_use media-gfx/splashutils mng
+	then
+		ewarn "MNG support is missing from splashutils.  You will not see the"
+		ewarn "service icons as services are starting."
+	fi
+}
+
+src_prepare() {
+	epatch "${FILESDIR}"/use-new-path-for-functions.sh.patch
+}
+
+src_install() {
+	dodir /etc/splash/livecd-${PV}
+	cp -r "${S}"/* "${D}"/etc/splash/livecd-${PV} || die
+}


### PR DESCRIPTION
@mgorny 
https://bugs.gentoo.org/show_bug.cgi?id=504394
https://bugs.gentoo.org/show_bug.cgi?id=504116