### PR TITLE
media-gfx/splash-themes-livedvd: Update rc_init-pre to use new path for functions.sh

### DIFF
--- a/media-gfx/splash-themes-livedvd/files/use-new-path-for-functions.sh.patch
+++ b/media-gfx/splash-themes-livedvd/files/use-new-path-for-functions.sh.patch
@@ -1,0 +1,11 @@
+--- scripts/rc_init-pre.orig	2016-02-18 13:31:23.610276701 -0200
++++ scripts/rc_init-pre	2016-02-18 13:31:57.405275206 -0200
+@@ -77,7 +77,7 @@
+   return 0
+ }
+
+-[ -r /etc/init.d/functions.sh ] && . /etc/init.d/functions.sh
++[ -r /lib/gentoo/functions.sh ] && . /lib/gentoo/functions.sh
+
+ if [ -z "${1}" ]; then
+   log err "no internal runlevel provided"

--- a/media-gfx/splash-themes-livedvd/splash-themes-livedvd-12.0-r2.ebuild
+++ b/media-gfx/splash-themes-livedvd/splash-themes-livedvd-12.0-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit eutils
+
+DESCRIPTION="Gentoo theme for gensplash consoles"
+HOMEPAGE="https://www.gentoo.org/"
+SRC_URI="https://dev.gentoo.org/~tampakrap/tarballs/${P}.tar.bz2"
+
+LICENSE="Artistic GPL-2 BitstreamVera"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RESTRICT="binchecks strip"
+
+DEPEND=">=media-gfx/splashutils-1.4.1[png]"
+RDEPEND="${DEPEND}
+	sys-apps/gentoo-functions"
+
+src_prepare() {
+	epatch "${FILESDIR}"/use-new-path-for-functions.sh.patch
+}
+
+src_install() {
+	dodir /etc/splash/livedvd-${PV}
+	insinto /etc/splash/livedvd-${PV}
+	doins -r *
+	insopts -m 0755
+	doins -r scripts
+}


### PR DESCRIPTION
@mgorny 
https://bugs.gentoo.org/show_bug.cgi?id=504406
https://bugs.gentoo.org/show_bug.cgi?id=504116