### PR TITLE
dev-java/java-config-wrapper: add patch for functions.sh

### DIFF
--- a/dev-java/java-config-wrapper/files/use-new-path-for-functions.sh.patch
+++ b/dev-java/java-config-wrapper/files/use-new-path-for-functions.sh.patch
@@ -1,0 +1,21 @@
+--- src/shell/java-check-environment.orig	2016-02-18 14:15:04.280160760 -0200
++++ src/shell/java-check-environment	2016-02-18 14:15:59.931158298 -0200
+@@ -1,6 +1,6 @@
+ #!/bin/bash
+
+-source /etc/init.d/functions.sh
++source /lib/gentoo/functions.sh
+
+ # Used to update the global result.
+ update_result() {
+
+--- src/shell/java-1.5-fixer.orig	2016-02-18 14:15:18.989160109 -0200
++++ src/shell/java-1.5-fixer	2016-02-18 14:15:44.121158997 -0200
+@@ -1,6 +1,6 @@
+ #!/bin/bash
+
+-source "/etc/init.d/functions.sh"
++source "/lib/gentoo/functions.sh"
+
+ EXCLUDED_JARS="
+ /usr/share/hibernate-annotations-3.0/lib/hibernate-annotations.jar

--- a/dev-java/java-config-wrapper/java-config-wrapper-0.16-r2.ebuild
+++ b/dev-java/java-config-wrapper/java-config-wrapper-0.16-r2.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+inherit eutils
+
+DESCRIPTION="Wrapper for java-config"
+HOMEPAGE="https://www.gentoo.org/proj/en/java"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE=""
+
+DEPEND="!<dev-java/java-config-1.3
+	sys-apps/gentoo-functions"
+RDEPEND="app-portage/portage-utils"
+
+src_prepare() {
+	epatch "${FILESDIR}"/use-new-path-for-functions.sh.patch
+}
+
+src_install() {
+	dobin src/shell/* || die
+	dodoc AUTHORS || die
+}


### PR DESCRIPTION
@mgorny

Update java-check-environment and java-1.5-fixer to use new path for functions.sh

https://bugs.gentoo.org/show_bug.cgi?id=504124
https://bugs.gentoo.org/show_bug.cgi?id=504116