### PR TITLE
kde-frameworks/kactivities: Fix dolphin context menu crash

### DIFF
--- a/kde-frameworks/kactivities/kactivities-5.17.0-r1.ebuild
+++ b/kde-frameworks/kactivities/kactivities-5.17.0-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit kde5
+
+DESCRIPTION="Framework for working with KDE activities"
+LICENSE="LGPL-2+"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+
+RDEPEND="
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdeclarative)
+	$(add_frameworks_dep kglobalaccel)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	dev-qt/qtdbus:5
+	dev-qt/qtdeclarative:5
+	dev-qt/qtgui:5
+	dev-qt/qtsql:5
+	dev-qt/qtwidgets:5
+	!<kde-base/kactivities-4.13.3-r1:4[-minimal(-)]
+"
+DEPEND="${RDEPEND}
+	>=dev-libs/boost-1.54
+"
+
+PATCHES=( "${FILESDIR}/${PN}-5.19.0-crash.patch" )

--- a/kde-frameworks/kactivities/kactivities-5.18.0-r1.ebuild
+++ b/kde-frameworks/kactivities/kactivities-5.18.0-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit kde5
+
+DESCRIPTION="Framework for working with KDE activities"
+LICENSE="LGPL-2+"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+
+RDEPEND="
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdeclarative)
+	$(add_frameworks_dep kglobalaccel)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	dev-qt/qtdbus:5
+	dev-qt/qtdeclarative:5
+	dev-qt/qtgui:5
+	dev-qt/qtsql:5
+	dev-qt/qtwidgets:5
+	!<kde-base/kactivities-4.13.3-r1:4[-minimal(-)]
+"
+DEPEND="${RDEPEND}
+	>=dev-libs/boost-1.54
+"
+
+PATCHES=( "${FILESDIR}/${PN}-5.19.0-crash.patch" )


### PR DESCRIPTION
Package-Manager: portage-2.2.27

@gentoo/kde 