### PR TITLE
app-text/sigil: revbump for 0.9.3 to support Python 3.5

### DIFF
--- a/app-text/sigil/sigil-0.9.3.ebuild
+++ b/app-text/sigil/sigil-0.9.3.ebuild
@@ -1,12 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 CMAKE_MIN_VERSION="3.0"
 
-# Sigil supports Python 3.5 already. Include it when our deps support it.
-PYTHON_COMPAT=( python3_4 )
+PYTHON_COMPAT=( python3_4 python3_5 )
 
 inherit eutils cmake-utils python-single-r1
 

--- a/dev-python/cssutils/cssutils-0.9.10-r2.ebuild
+++ b/dev-python/cssutils/cssutils-0.9.10-r2.ebuild
@@ -20,8 +20,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~x86"
 IUSE="examples test"
 
-RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
-		"
+RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
 	test? ( dev-python/mock[${PYTHON_USEDEP}] )"
 
@@ -36,9 +35,7 @@ python_prepare_all() {
 
 python_test() {
 	ln -s "${S}/sheets" "${BUILD_DIR}/sheets" || die
-	# exclude tests that connect to the network
-	set --  nosetests \
-		-e test_parseUrl -e test_handlers -P "${BUILD_DIR}/lib/cssutils/tests"
+	set --  nosetests -P "${BUILD_DIR}/lib/cssutils/tests"
 	echo "$@"
 	"$@" || die "Testing failed with ${EPYTHON}"
 }

--- a/dev-python/cssutils/cssutils-1.0.1.ebuild
+++ b/dev-python/cssutils/cssutils-1.0.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
-PYTHON_COMPAT=( python{2_7,3_3,3_4} pypy )
+PYTHON_COMPAT=( python{2_7,3_{3,4,5}} pypy )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Only changes in all files was update of PYTHON_COMPAT to include python3_5.