### PR TITLE
kde-apps/kdeartwork-kscreensaver: Fix eigen dependency slot

### DIFF
--- a/kde-apps/kdeartwork-kscreensaver/kdeartwork-kscreensaver-15.08.3.ebuild
+++ b/kde-apps/kdeartwork-kscreensaver/kdeartwork-kscreensaver-15.08.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/kde-apps/kdeartwork-kscreensaver/kdeartwork-kscreensaver-15.08.3.ebuild
+++ b/kde-apps/kdeartwork-kscreensaver/kdeartwork-kscreensaver-15.08.3.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	xscreensaver? ( x11-misc/xscreensaver )
 "
 DEPEND="${RDEPEND}
-	eigen? ( dev-cpp/eigen:2 )
+	eigen? ( dev-cpp/eigen:3 )
 "
 
 PATCHES=(
@@ -40,7 +40,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DKSCREENSAVER_SOUND_SUPPORT=ON
 		-DOPENGL=ON
-		$(cmake-utils_use_with eigen Eigen2)
+		$(cmake-utils_use_with eigen Eigen3)
 		$(cmake-utils_use_with kexiv2)
 		$(cmake-utils_use_with xscreensaver)
 	)

--- a/kde-apps/kdeartwork-kscreensaver/kdeartwork-kscreensaver-4.14.3.ebuild
+++ b/kde-apps/kdeartwork-kscreensaver/kdeartwork-kscreensaver-4.14.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/kde-apps/kdeartwork-kscreensaver/kdeartwork-kscreensaver-4.14.3.ebuild
+++ b/kde-apps/kdeartwork-kscreensaver/kdeartwork-kscreensaver-4.14.3.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	xscreensaver? ( x11-misc/xscreensaver )
 "
 DEPEND="${RDEPEND}
-	eigen? ( dev-cpp/eigen:2 )
+	eigen? ( dev-cpp/eigen:3 )
 "
 
 PATCHES=(
@@ -40,7 +40,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DKSCREENSAVER_SOUND_SUPPORT=ON
 		-DOPENGL=ON
-		$(cmake-utils_use_with eigen Eigen2)
+		$(cmake-utils_use_with eigen Eigen3)
 		$(cmake-utils_use_with kexiv2)
 		$(cmake-utils_use_with xscreensaver)
 	)


### PR DESCRIPTION
The package was changed to depend on dev-cpp/eigen:3 on Apr 20 2014
https://websvn.kde.org/?revision=1384805&view=revision
