### PR TITLE
dev-cpp/eigen: fix pkgconfig, fixes  #575298

### DIFF
--- a/dev-cpp/eigen/eigen-3.2.8-r1.ebuild
+++ b/dev-cpp/eigen/eigen-3.2.8-r1.ebuild
@@ -32,10 +32,6 @@ src_prepare() {
 
 	sed -i -e "/Unknown build type/d" CMakeLists.txt || die
 
-	sed \
-		-e '/Cflags/s|:.*|: -I${CMAKE_INSTALL_PREFIX}/${INCLUDE_INSTALL_DIR}|g' \
-		-i eigen3.pc.in || die
-
 	cmake-utils_src_prepare
 }
 


### PR DESCRIPTION
@jlec The recent bump introduced a change to the pkgconfig file (https://bitbucket.org/eigen/eigen/commits/1db6cf71f62897825a643f5faca8a54adc90b41d#chg-eigen3.pc.in)
This causes build failures in dependencies, like https://bugs.gentoo.org/show_bug.cgi?id=575298