### PR TITLE
eclass/java-utils-2.eclass: Added -r to xargs in java-pkg_addres

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -262,7 +262,7 @@ java-pkg_addres() {
 	shift 2
 
 	pushd "${dir}" > /dev/null || die "pushd ${dir} failed"
-	find -L -type f ! -path "./target/*" ! -path "./sources.lst" ! -name "MANIFEST.MF" ! -regex ".*\.\(class\|jar\|java\)" "${@}" -print0 | xargs -0 jar uf "${jar}" || die "jar failed"
+	find -L -type f ! -path "./target/*" ! -path "./sources.lst" ! -name "MANIFEST.MF" ! -regex ".*\.\(class\|jar\|java\)" "${@}" -print0 | xargs -r0 jar uf "${jar}" || die "jar failed"
 	popd > /dev/null || die "popd failed"
 }
 


### PR DESCRIPTION
@gentoo/java The -r option is necessary in case find does not output anything. Which
makes the jar uf command fail. This has no effect otherwise and should
be safe to add right away. It prevents potential issues/bug.