### PR TITLE
net-libs/librsync: fix testsuite for v0.9.7, bug #511954

### DIFF
--- a/net-libs/librsync/files/librsync-0.9.7-fix-testsuite.patch
+++ b/net-libs/librsync/files/librsync-0.9.7-fix-testsuite.patch
@@ -1,0 +1,15 @@
+Description: Fix running tests with the parallel harness
+Author: Andrey Rahmatullin <wrar@wrar.name>
+Last-Update: 2013-06-26
+
+--- a/testsuite/Makefile.am
++++ b/testsuite/Makefile.am
+@@ -29,7 +29,7 @@ isprefix_driver_LDADD = ../isprefix.o # XXX: should link replaced functions
+ # failed.  Generally these tests should be ordered so that more basic
+ # tests are run first.
+ 
+-TESTS_ENVIRONMENT = $(SH) $(srcdir)/driver.sh
++TEST_LOG_COMPILER = $(SH) $(srcdir)/driver.sh
+ 
+ TESTS = \
+ 	signature.test mutate.test sources.test isprefix.test	\

--- a/net-libs/librsync/librsync-0.9.7-r3.ebuild
+++ b/net-libs/librsync/librsync-0.9.7-r3.ebuild
@@ -25,6 +25,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-format-security.patch
 	"${FILESDIR}"/${P}-getopt.patch
 	"${FILESDIR}"/${P}-implicit-declaration.patch
+	"${FILESDIR}"/${P}-fix-testsuite.patch
 	)
 
 src_prepare() {


### PR DESCRIPTION
I added a patch (from Ubuntu lauchpad) to fix compilation with FEATURES="test".