### PR TITLE
net-p2p/syncthing: Add ~arm keyword

### DIFF
--- a/net-p2p/syncthing/syncthing-0.12.19.ebuild
+++ b/net-p2p/syncthing/syncthing-0.12.19.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://${EGO_PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MPL-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~x86 ~arm"
 IUSE=""
 
 DEPEND=""


### PR DESCRIPTION
I've been using it on arm without incident, so I think it's time to add a keyword.

Package-Manager: portage-2.2.26

-----

Commit amended to reference preexisting keyword request on BGO.