### PR TITLE
net-libs/librsync: fix typo and patch for v0.9.7

### DIFF
--- a/net-libs/librsync/files/librsync-0.9.7-fix-testsuite.patch
+++ b/net-libs/librsync/files/librsync-0.9.7-fix-testsuite.patch
@@ -6,10 +6,10 @@ Last-Update: 2013-06-26
 +++ b/testsuite/Makefile.am
 @@ -29,7 +29,7 @@ isprefix_driver_LDADD = ../isprefix.o # XXX: should link replaced functions
  # failed.  Generally these tests should be ordered so that more basic
-  # tests are run first.
-   
-   -TESTS_ENVIRONMENT = $(SH) $(srcdir)/driver.sh
-   +TEST_LOG_COMPILER = $(SH) $(srcdir)/driver.sh
-    
-     TESTS = \
-      	signature.test mutate.test sources.test isprefix.test	\
+ # tests are run first.
+ 
+-TESTS_ENVIRONMENT = $(SH) $(srcdir)/driver.sh
++TEST_LOG_COMPILER = $(SH) $(srcdir)/driver.sh
+ 
+ TESTS = \
+ 	signature.test mutate.test sources.test isprefix.test	\

--- a/net-libs/librsync/librsync-0.9.7-r3.ebuild
+++ b/net-libs/librsync/librsync-0.9.7-r3.ebuild
@@ -25,7 +25,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-format-security.patch
 	"${FILESDIR}"/${P}-getopt.patch
 	"${FILESDIR}"/${P}-implicit-declaration.patch
-	"${FILESDIR}"/${P}-fix-testsuite.ebuild
+	"${FILESDIR}"/${P}-fix-testsuite.patch
 	)
 
 src_prepare() {


### PR DESCRIPTION
Fixed a typo in the ebuild and the testsuite patch for librsync 0.9.7.

Gentoo-bug: #575556