### PR TITLE
dev-tex/currvita: Add texi2dvi dependency

### DIFF
--- a/dev-tex/currvita/currvita-0.9i-r1.ebuild
+++ b/dev-tex/currvita/currvita-0.9i-r1.ebuild
@@ -16,8 +16,10 @@ KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86
 
 IUSE=""
 
-DEPEND="dev-texlive/texlive-langgerman"
-RDEPEND="${DEPEND}"
+RDEPEND="dev-texlive/texlive-langgerman"
+DEPEND="${RDEPEND}
+	virtual/texi2dvi
+"
 
 S="${WORKDIR}/${PN}"
 


### PR DESCRIPTION
Without it, emerging dies with:

    # emerge currvita
    ...
    >>> Install currvita-0.9i-r1 into /var/tmp/portage/dev-tex/currvita-0.9i-r1/image/ category dev-tex
     * Making documentation: ./cvtest.tex
     * ERROR: dev-tex/currvita-0.9i-r1::gentoo failed (install phase):
     *   (no error message)
     *
     * Call stack:
     *     ebuild.sh, line  133:  Called src_install
     *   environment, line 2158:  Called latex-package_src_install
     *   environment, line 1482:  Called latex-package_src_doinstall 'all'
     *   environment, line 1473:  Called latex-package_src_doinstall 'styles' 'fonts' 'bin' 'doc'
     *   environment, line 1464:  Called latex-package_src_doinstall 'tex' 'dtx' 'dvi' 'ps' 'pdf'
     *   environment, line 1429:  Called die
     * The specific snippet of code:
     *                       texi2dvi -q -c --language=latex $i &> /dev/null || die;
    ...

There are some notes from 2010 and 2011 about this sort of thing in an
automake context [here][1].

I haven't revbumped, because folks who were missing texi2dvi earlier
would not have been able to install the package with the older ebuild.

[1]: https://bugs.gentoo.org/show_bug.cgi?id=346993
