### PR TITLE
dev-lang/go: add ~amd64-fbsd, ~x86-fbsd keyword, bug #575510

### DIFF
--- a/dev-lang/go/go-1.6-r2.ebuild
+++ b/dev-lang/go/go-1.6-r2.ebuild
@@ -39,7 +39,7 @@ else
 	case ${PV} in
 		*9999*|*_rc*) ;;
 		*)
-			KEYWORDS="-* ~amd64 ~arm64"
+			KEYWORDS="-* ~amd64 ~arm64 ~amd64-fbsd ~x86-fbsd"
 			;;
 	esac
 fi


### PR DESCRIPTION
KEYWORDREQ Bug https://bugs.gentoo.org/show_bug.cgi?id=575510

I have confirmed that test is passed on amd64-fbsd/10.2 and x86-fbsd/10.2.
Please add KEYWORDS="~amd64-fbsd ~x86-fbsd" to go-1.6-r2.ebuild.

```
# FEATURES=test emerge dev-lang/go
<snip>
ALL TESTS PASSED
>>> Completed testing dev-lang/go-1.6-r2
<snip>
```