### PR TITLE
dev-perl/Any-Moose: Eliminate dependencies on Mouse

### DIFF
--- a/dev-perl/Any-Moose/Any-Moose-0.260.0-r1.ebuild
+++ b/dev-perl/Any-Moose/Any-Moose-0.260.0-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+DIST_AUTHOR=ETHER
+DIST_VERSION=0.26
+inherit perl-module
+
+DESCRIPTION="Use Moose or Mouse modules (DEPRECATED)"
+
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~ppc ~x86"
+IUSE="test"
+PERL_RM_FILES=(
+	"t/001-basic-mouse.t"
+	"t/002-other-modules-mouse.t"
+	"t/003-is_moose_loaded.t"
+	"t/004-x-modules-mouse.t"
+	"t/005-aliases-mouse.t"
+	"t/010-use_mouse_roles.t"
+	"t/012-use_mouse_util.t"
+)
+PATCHES=( "${FILESDIR}/nomouse.patch" )
+RDEPEND="dev-perl/Moose
+	virtual/perl-version"
+DEPEND="${RDEPEND}
+	>=virtual/perl-ExtUtils-MakeMaker-6.31
+	test? (
+		dev-perl/Moose
+		dev-perl/MooseX-Types
+	)
+"

--- a/dev-perl/Any-Moose/files/nomouse.patch
+++ b/dev-perl/Any-Moose/files/nomouse.patch
@@ -1,0 +1,13 @@
+diff -Naur Any-Moose-0.26/t/000-version.t Any-Moose-0.26b/t/000-version.t
+--- Any-Moose-0.26/t/000-version.t	2015-01-24 07:52:52.000000000 +0000
++++ Any-Moose-0.26b/t/000-version.t	2016-02-29 10:44:17.801967386 +0000
+@@ -3,8 +3,6 @@
+ use_ok 'Any::Moose';
+ 
+ show_version($_) for qw/
+-    Mouse
+-    MouseX::Types
+     Moose
+     Class::MOP
+     MooseX::Types
+


### PR DESCRIPTION
Short version:
- No runtime changes
- (R)?Deps now only pull Moose
- Tests that cry about Mouse missing nuked
- Circular Any::Moose -> MouseX::Types under FEATURES=test fixed
- EAPI6-and-stuff. 

This is preparation work for eventual removal of Any-Moose from tree,
as it is declared "Deprecated" by upstream, and people who want a
"Be fast by default but still work with Moose" solution are being encouraged
to use Moo instead.

Any-Moose will continue to auto-switch between Moose and Mouse
if Mouse is installed, but will not add any dependencies on Mouse
and will no longer test Mouse based tests, with the idea being to
just force the Moose path by default.

This is effectively what already happened for anyone who installed Moose first,
which is highly likely, because *nothing* in tree other than Any-Moose and
its children presently depend on Mouse.

However, we can't remove Any-Moose yet, because some packages still depend on it,
so this patch is intended to mitigate the damage of still pulling Mouse and MouseX::Types
into tree.

This also avoids a circular dependency mess under FEATURES="test"

But anyone who wants the runtime benefits of Any-Moose that *may* appear
if they're not using any Moose code, they can still get that benefit by installing
Mouse manually.

But otherwise, depending on Any-Moose should imply a dependency on Moose

Package-Manager: portage-2.2.27

/cc @monsieurp @akhuettel 