### PR TITLE
net-p2p/airdcpp-webclient: add missing depend on net-libs/libnatpmp

### DIFF
--- a/net-p2p/airdcpp-webclient/airdcpp-webclient-0.16.5.ebuild
+++ b/net-p2p/airdcpp-webclient/airdcpp-webclient-0.16.5.ebuild
@@ -23,6 +23,7 @@ RDEPEND="
 	dev-cpp/tbb
 	virtual/libiconv
 	net-libs/miniupnpc
+	net-libs/libnatpmp
 	dev-libs/leveldb
 	dev-cpp/websocketpp
 	dev-libs/boost


### PR DESCRIPTION
Can someone push this simple fix? @monsieurp for instance :)