### PR TITLE
games-emulation/dolphin: Replaced icon with png in 9999, #575420

### DIFF
--- a/games-emulation/dolphin/dolphin-9999.ebuild
+++ b/games-emulation/dolphin/dolphin-9999.ebuild
@@ -174,7 +174,7 @@ src_install() {
 		dodoc -r docs/ActionReplay docs/DSP docs/WiiMote
 	fi
 
-	doicon Installer/dolphin-emu.xpm
+	doicon Installer/dolphin-emu.png
 	make_desktop_entry "dolphin-emu" "Dolphin Emulator" "dolphin-emu" "Game;Emulator;"
 
 	prepgamesdirs


### PR DESCRIPTION
dolphin-emu.xpm doesn't exist anymore, available icons: dolphin-emu.svg, dolphin-emu.png
Not sure if I should doicon both?