### PR TITLE
app-editors/gummi: drop base.eclass and fix whitespace

### DIFF
--- a/app-editors/gummi/gummi-0.6.6.ebuild
+++ b/app-editors/gummi/gummi-0.6.6.ebuild
@@ -4,11 +4,11 @@
 
 EAPI=5
 
-inherit autotools base eutils
+inherit autotools eutils
 
 DESCRIPTION="Simple LaTeX editor for GTK+ users"
 HOMEPAGE="https://github.com/alexandervdm/gummi"
-SRC_URI="https://github.com/alexandervdm/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz" 
+SRC_URI="https://github.com/alexandervdm/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
Just two minor fixes in 0.6.6 to make repoman happy. Note: This is currently being stabilized in bug #562894