### PR TITLE
dev-perl/Net-OpenID-Common: Fix collsion with old Net-OpenID-Consumer

### DIFF
--- a/dev-perl/Net-OpenID-Common/Net-OpenID-Common-1.200.0.ebuild
+++ b/dev-perl/Net-OpenID-Common/Net-OpenID-Common-1.200.0.ebuild
@@ -23,6 +23,7 @@ RDEPEND="
 	virtual/perl-Math-BigInt
 	virtual/perl-Time-Local
 	dev-perl/XML-Simple
+	!<dev-perl/Net-OpenID-Consumer-1.30.99
 "
 DEPEND="${RDEPEND}
 	virtual/perl-ExtUtils-MakeMaker


### PR DESCRIPTION
Net-OpenID-Consumer was split into two dists, Net-OpenID-Common and Net-OpenID-Consumer,
  and so Net-OpenID-Commons files collide with the old version of Net-OpenID-Consumer.

Gentoo-Bug: https://bugs.gentoo.org/576170

Package-Manager: portage-2.2.27

@akhuettel @monsieurp 