### PR TITLE
kde-apps: Remove KDE_SCM="svn" from kde5.eclass inheriting ebuilds

### DIFF
--- a/kde-apps/kde-wallpapers/kde-wallpapers-15.08.3-r1.ebuild
+++ b/kde-apps/kde-wallpapers/kde-wallpapers-15.08.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,7 +6,6 @@ EAPI=5
 
 KMNAME="kde-wallpapers"
 KDE_AUTODEPS="false"
-KDE_SCM="svn"
 inherit kde5
 
 DESCRIPTION="KDE wallpapers"

--- a/kde-apps/kdeartwork-wallpapers/kdeartwork-wallpapers-15.08.3-r1.ebuild
+++ b/kde-apps/kdeartwork-wallpapers/kdeartwork-wallpapers-15.08.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -8,7 +8,6 @@ RESTRICT="binchecks strip"
 
 KMNAME="kdeartwork"
 KDE_AUTODEPS="false"
-KDE_SCM="svn"
 inherit kde5
 
 DESCRIPTION="Wallpapers from kde"

--- a/kde-apps/kdeartwork-weatherwallpapers/kdeartwork-weatherwallpapers-15.08.3-r1.ebuild
+++ b/kde-apps/kdeartwork-weatherwallpapers/kdeartwork-weatherwallpapers-15.08.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,7 +6,6 @@ EAPI=5
 
 KMNAME="kdeartwork"
 KDE_AUTODEPS="false"
-KDE_SCM="svn"
 inherit kde5
 
 DESCRIPTION="Weather aware wallpapers. Changes with weather outside"


### PR DESCRIPTION
Support is going to be dropped in eclass.

Package-Manager: portage-2.2.27

@kensington 