### PR TITLE
net-irc/polari: Add missing RDEPEND on net-im/telepathy-logger

### DIFF
--- a/net-irc/polari/polari-3.18.1-r1.ebuild
+++ b/net-irc/polari/polari-3.18.1-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+GCONF_DEBUG="no"
+
+inherit gnome2
+
+DESCRIPTION="An IRC client for Gnome"
+HOMEPAGE="https://wiki.gnome.org/Apps/Polari"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~arm"
+IUSE=""
+
+COMMON_DEPEND="
+	dev-libs/gjs
+	>=dev-libs/glib-2.43.4:2
+	>=dev-libs/gobject-introspection-0.9.6
+	net-libs/telepathy-glib[introspection]
+	>=x11-libs/gtk+-3.15.6:3[introspection]
+"
+RDEPEND="${COMMON_DEPEND}
+	>=net-irc/telepathy-idle-0.2
+	net-im/telepathy-logger[introspection]
+"
+DEPEND="${COMMON_DEPEND}
+	dev-libs/appstream-glib
+	>=dev-util/intltool-0.50
+	virtual/pkgconfig
+"


### PR DESCRIPTION
Also added `~arm` keyword as a result of personal testing on a RK3288
(armv7a) device.

Package-Manager: portage-2.2.26