### PR TITLE
app-backup/snapper: update to reflect renamed README.md

### DIFF
--- a/app-backup/snapper/snapper-9999.ebuild
+++ b/app-backup/snapper/snapper-9999.ebuild
@@ -36,7 +36,7 @@ DEPEND="${RDEPEND}
 	sys-devel/gettext
 	virtual/pkgconfig"
 
-DOCS=( AUTHORS README package/snapper.changes )
+DOCS=( AUTHORS README.md package/snapper.changes )
 
 PATCHES=( "${FILESDIR}"/cron-confd.patch )
 


### PR DESCRIPTION
I have also create a bug report: https://bugs.gentoo.org/show_bug.cgi?id=576556

The ebuild compiles with the renamed README.md