### PR TITLE
dev-tex/minted: compilation of documentation

### DIFF
--- a/dev-tex/minted/files/minted-2.1-remove-extra-curly-brace.patch
+++ b/dev-tex/minted/files/minted-2.1-remove-extra-curly-brace.patch
@@ -1,0 +1,15 @@
+# compilation of minted.dtx fails as there is an extra curly brace at line
+# 1390. While passing -interaction=batchmode (what latex-package.eclass does)
+# it compiles without warning but a return value of -1 and therefore is assumed
+# as failed by latex-package.eclass.
+--- minted.dtx	2015-09-09 22:40:04.000000000 +0200
++++ minted.dtx	2016-03-06 14:20:46.544180149 +0100
+@@ -1387,7 +1387,7 @@
+ %
+ %
+ % \begin{macro}{\minted@jobname}
+-% At various points, temporary files and directories will need to be named after the main |.tex| file.  The typical way to do this is to use |\jobname|.  However, if the file name contains spaces, then |\jobname| will contain the name wrapped in quotes (older versions of MiKTeX replace spaces with asterisks instead, and \texttt{XeTeX} apparently \href{http://tex.stackexchange.com/a/93829/10742}{allows double quotes within file names}, in which case names are wrapped in single quotes}).  While that is perfectly fine for working with \LaTeX\ internally, it causes problems with |\write18|, since quotes will end up in unwanted locations in shell commands.  It would be possible to strip the wrapping quotation marks when they are present, and maintain any spaces in the file name.  But it is simplest to create a ``sanitized'' version of |\jobname| in which spaces and asterisks are replaced by underscores, and double quotes are stripped.
++% At various points, temporary files and directories will need to be named after the main |.tex| file.  The typical way to do this is to use |\jobname|.  However, if the file name contains spaces, then |\jobname| will contain the name wrapped in quotes (older versions of MiKTeX replace spaces with asterisks instead, and \texttt{XeTeX} apparently \href{http://tex.stackexchange.com/a/93829/10742}{allows double quotes within file names}, in which case names are wrapped in single quotes).  While that is perfectly fine for working with \LaTeX\ internally, it causes problems with |\write18|, since quotes will end up in unwanted locations in shell commands.  It would be possible to strip the wrapping quotation marks when they are present, and maintain any spaces in the file name.  But it is simplest to create a ``sanitized'' version of |\jobname| in which spaces and asterisks are replaced by underscores, and double quotes are stripped.
+ %    \begin{macrocode}
+ \StrSubstitute{\jobname}{ }{_}[\minted@jobname]
+ \StrSubstitute{\minted@jobname}{*}{_}[\minted@jobname]

--- a/dev-tex/minted/minted-1.7.ebuild
+++ b/dev-tex/minted/minted-1.7.ebuild
@@ -23,6 +23,7 @@ RDEPEND="
 S="${WORKDIR}"/
 
 src_install() {
+	LATEX_DOC_ARGUMENTS='-shell-escape'
 	latex-package_src_install
 	dodoc README
 }

--- a/dev-tex/minted/minted-1.7.ebuild
+++ b/dev-tex/minted/minted-1.7.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://minted.googlecode.com/files/${PN}-v${PV}.zip"
 SLOT="0"
 LICENSE="BSD"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE=""
+IUSE="doc"
 
 DEPEND="app-arch/unzip"
 RDEPEND="

--- a/dev-tex/minted/minted-2.0.ebuild
+++ b/dev-tex/minted/minted-2.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/gpoore/minted/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 SLOT="0"
 LICENSE="BSD"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE=""
+IUSE="doc"
 
 DEPEND="app-arch/unzip"
 RDEPEND="

--- a/dev-tex/minted/minted-2.0.ebuild
+++ b/dev-tex/minted/minted-2.0.ebuild
@@ -23,6 +23,7 @@ RDEPEND="
 S="${WORKDIR}"/${P}/source
 
 src_install() {
+	LATEX_DOC_ARGUMENTS='-shell-escape'
 	latex-package_src_install
 	dodoc "${S}"/../*md
 }

--- a/dev-tex/minted/minted-2.1.ebuild
+++ b/dev-tex/minted/minted-2.1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/gpoore/minted/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 SLOT="0"
 LICENSE="BSD"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE=""
+IUSE="doc"
 
 DEPEND="app-arch/unzip"
 RDEPEND="

--- a/dev-tex/minted/minted-2.1.ebuild
+++ b/dev-tex/minted/minted-2.1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit latex-package
+inherit latex-package eutils
 
 DESCRIPTION="LaTeX package for source code syntax highlighting"
 HOMEPAGE="https://github.com/gpoore/minted"
@@ -22,7 +22,12 @@ RDEPEND="
 
 S="${WORKDIR}"/${P}/source
 
+src_prepare() {
+	epatch "${FILESDIR}/minted-2.1-remove-extra-curly-brace.patch"
+}
+
 src_install() {
+	LATEX_DOC_ARGUMENTS='-shell-escape'
 	latex-package_src_install
 	dodoc "${S}"/../*md
 }


### PR DESCRIPTION
* fix compilation of minted.dtx/documentation by
   - adding -shell-escape to pdflatex
   - add a patch to remove an extra }
* make documentation compilation optional