### PR TITLE
x11-libs/libxcb, x11-proto/xcb-proto: add support for python 3.5

### DIFF
--- a/x11-libs/libxcb/libxcb-1.11.1.ebuild
+++ b/x11-libs/libxcb/libxcb-1.11.1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 PYTHON_REQ_USE=xml
 
 XORG_DOC=doc

--- a/x11-proto/xcb-proto/xcb-proto-1.11.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.11.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 XORG_MULTILIB=yes
 
 inherit python-r1 xorg-2


### PR DESCRIPTION
Seems like #776 missed these changes.