### PR TITLE
sys-apps/s6: Add a static-libs USE flag

### DIFF
--- a/sys-apps/s6/s6-2.2.4.3-r1.ebuild
+++ b/sys-apps/s6/s6-2.2.4.3-r1.ebuild
@@ -1,10 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
-
-inherit multilib
+EAPI=6
 
 DESCRIPTION="skarnet.org's small and secure supervision software suite"
 HOMEPAGE="http://www.skarnet.org/software/s6/"
@@ -32,10 +30,15 @@ RDEPEND="
 	)
 	"
 
+DOCS=("examples/")
+HTML_DOCS=("doc/.")
+
 src_prepare()
 {
 	# Remove QA warning about LDFLAGS addition
 	sed -i "s~tryldflag LDFLAGS_AUTO -Wl,--hash-style=both~:~" "${S}/configure" || die
+
+	eapply_user
 }
 
 src_configure()
@@ -52,16 +55,4 @@ src_configure()
 		--sysdepdir=/usr/$(get_libdir)/${PN} \
 		--with-dynlib=/$(get_libdir) \
 		--with-sysdeps=/usr/$(get_libdir)/skalibs
-}
-
-src_compile()
-{
-	emake DESTDIR="${D}"
-}
-
-src_install()
-{
-	default
-	dodoc -r examples
-	dohtml -r doc/*
 }

--- a/sys-apps/s6/s6-2.2.4.3-r1.ebuild
+++ b/sys-apps/s6/s6-2.2.4.3-r1.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit multilib
+
+DESCRIPTION="skarnet.org's small and secure supervision software suite"
+HOMEPAGE="http://www.skarnet.org/software/s6/"
+SRC_URI="http://www.skarnet.org/software/${PN}/${P}.tar.gz"
+
+LICENSE="ISC"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="static static-libs"
+
+DEPEND=">=sys-devel/make-4.0
+	static? (
+		>=dev-lang/execline-2.1.4.5[static-libs]
+		>=dev-libs/skalibs-2.3.9.0[static-libs]
+	)
+	!static? (
+		>=dev-lang/execline-2.1.4.5
+		>=dev-libs/skalibs-2.3.9.0
+	)
+	"
+RDEPEND="
+	!static? (
+		>=dev-lang/execline-2.1.4.5
+		>=dev-libs/skalibs-2.3.9.0
+	)
+	"
+
+src_prepare()
+{
+	# Remove QA warning about LDFLAGS addition
+	sed -i "s~tryldflag LDFLAGS_AUTO -Wl,--hash-style=both~:~" "${S}/configure" || die
+}
+
+src_configure()
+{
+	econf \
+		$(use_enable !static shared) \
+		$(use_enable static-libs static) \
+		$(use_enable static allstatic) \
+		--bindir=/bin \
+		--sbindir=/sbin \
+		--dynlibdir=/$(get_libdir) \
+		--libdir=/usr/$(get_libdir)/${PN} \
+		--datadir=/etc \
+		--sysdepdir=/usr/$(get_libdir)/${PN} \
+		--with-dynlib=/$(get_libdir) \
+		--with-sysdeps=/usr/$(get_libdir)/skalibs
+}
+
+src_compile()
+{
+	emake DESTDIR="${D}"
+}
+
+src_install()
+{
+	default
+	dodoc -r examples
+	dohtml -r doc/*
+}


### PR DESCRIPTION
Please don't merge this; @williamh should review it first (cf. https://bugs.gentoo.org/show_bug.cgi?id=576678).

libs6 is used by other packages such as s6-rc, so it'd be useful to be
able to control the availability of libs6.a without depending on
USE=static.