### PR TITLE
dev-utils/strace: skip flaky -k test #545812 in stable

### DIFF
--- a/dev-util/strace/strace-4.9.ebuild
+++ b/dev-util/strace/strace-4.9.ebuild
@@ -40,6 +40,9 @@ src_prepare() {
 	use static && append-ldflags -static
 
 	export ac_cv_header_libaio_h=$(usex aio)
+	
+	# Stub out the -k test since it's known to be flaky. #545812
+	sed -i '1iexit 77' tests*/strace-k.test ||die
 }
 
 src_configure() {

--- a/dev-util/strace/strace-4.9.ebuild
+++ b/dev-util/strace/strace-4.9.ebuild
@@ -42,7 +42,7 @@ src_prepare() {
 	export ac_cv_header_libaio_h=$(usex aio)
 	
 	# Stub out the -k test since it's known to be flaky. #545812
-	sed -i '1iexit 77' tests*/strace-k.test ||die
+	sed -i '1iexit 77' tests*/strace-k.test || die
 }
 
 src_configure() {


### PR DESCRIPTION
Already fixed in 4.10. Apply same fix to current stable.