### PR TITLE
net-libs/rb_libtorrent: py3.3 is no longer in IUSE

### DIFF
--- a/net-libs/rb_libtorrent/rb_libtorrent-1.0.8.ebuild
+++ b/net-libs/rb_libtorrent/rb_libtorrent-1.0.8.ebuild
@@ -47,9 +47,7 @@ src_prepare() {
 }
 
 src_configure() {
-	if use python_targets_python3_3 ;then
-		boost_py3="--with-boost-python=3.3"
-	elif use python_targets_python3_4 ;then
+	if use python_targets_python3_4 ;then
 		boost_py3="--with-boost-python=3.4"
 	elif use python_targets_python3_5 ;then
 		boost_py3="--with-boost-python=3.5"


### PR DESCRIPTION
Commit 5344ba114 removed py3.3 from IUSE, but missed a manual check for py3.3 in src_configure, which breaks the build:

`ERROR: net-libs/rb_libtorrent-1.0.8::gentoo failed (configure phase):`
`  USE Flag 'python_targets_python3_3' not in IUSE for net-libs/rb_libtorrent-1.0.8`

 This patch removes the remaining check and lets the build succeed.
