### PR TITLE
sys-firmware/seabios: add support for python3

### DIFF
--- a/sys-firmware/seabios/seabios-1.7.5-r1.ebuild
+++ b/sys-firmware/seabios/seabios-1.7.5-r1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python{2_7,3_{3,4,5}} )
 
 inherit eutils toolchain-funcs python-any-r1
 

--- a/sys-firmware/seabios/seabios-1.7.5.ebuild
+++ b/sys-firmware/seabios/seabios-1.7.5.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python{2_7,3_{3,4,5}} )
 
 inherit eutils toolchain-funcs python-any-r1
 

--- a/sys-firmware/seabios/seabios-1.8.2.ebuild
+++ b/sys-firmware/seabios/seabios-1.8.2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="5"
 
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python{2_7,3_{3,4,5}} )
 
 inherit eutils toolchain-funcs python-any-r1
 


### PR DESCRIPTION
Builds with python3_{3,4,5}