### PR TITLE
app-arch/innoextract: fix build with cmake 3.5

### DIFF
--- a/app-arch/innoextract/files/innoextract-1.4-cmake-3.5.patch
+++ b/app-arch/innoextract/files/innoextract-1.4-cmake-3.5.patch
@@ -1,0 +1,31 @@
+From 01705758dd04d937160c99c8b87c6fa2057db894 Mon Sep 17 00:00:00 2001
+From: Daniel Scharrer <daniel@constexpr.org>
+Date: Tue, 23 Feb 2016 05:45:50 +0100
+Subject: [PATCH] CMake: Disable variable expansion for quoted strings in if()
+
+This makes the build system more rubust against stray variables
+coming from included CMake scripts provided by the system.
+
+Fixes build with CMake 3.5 (tested with 3.5.0-rc3).
+
+Fixes: issue #50
+---
+ CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 02e0308..8653b93 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,6 +2,11 @@ project(innoextract)
+ 
+ cmake_minimum_required(VERSION 2.8)
+ 
++if(POLICY CMP0054)
++	# CMake 3.1+: Only interpret if() arguments as variables or keywords when unquoted.
++	cmake_policy(SET CMP0054 NEW)
++endif()
++
+ 
+ # Define configuration options
+ 

--- a/app-arch/innoextract/innoextract-1.4.ebuild
+++ b/app-arch/innoextract/innoextract-1.4.ebuild
@@ -48,6 +48,8 @@ pkg_pretend() {
 
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-cmake.patch
+	epatch "${FILESDIR}"/${P}-cmake-3.5.patch
+	cmake-utils_src_prepare
 }
 
 src_configure() {

--- a/app-arch/innoextract/innoextract-1.5.ebuild
+++ b/app-arch/innoextract/innoextract-1.5.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit cmake-utils
+inherit eutils cmake-utils
 
 DESCRIPTION="A tool to unpack installers created by Inno Setup"
 HOMEPAGE="http://constexpr.org/innoextract/"
@@ -22,6 +22,11 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 DOCS=( README.md CHANGELOG )
+
+src_prepare() {
+	epatch "${FILESDIR}"/${PN}-1.4-cmake-3.5.patch
+	cmake-utils_src_prepare
+}
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
This will also be fixed in innoextract 1.6, which I'll release soon.

I think we should also consider stabilizing 1.5 - it's been in the tree for a while now without any complaints.