### PR TITLE
app-arch/innoextract: don't apply patches twice

### DIFF
--- a/app-arch/innoextract/innoextract-1.4.ebuild
+++ b/app-arch/innoextract/innoextract-1.4.ebuild
@@ -51,11 +51,6 @@ pkg_pretend() {
 	fi
 }
 
-src_prepare() {
-	epatch "${PATCHES[@]}"
-	cmake-utils_src_prepare
-}
-
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_use lzma LZMA)

--- a/app-arch/innoextract/innoextract-1.5.ebuild
+++ b/app-arch/innoextract/innoextract-1.5.ebuild
@@ -27,11 +27,6 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.4-cmake-3.5.patch
 )
 
-src_prepare() {
-	epatch "${PATCHES[@]}"
-	cmake-utils_src_prepare
-}
-
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_use lzma LZMA)


### PR DESCRIPTION
The PATCHES variable is already handled by base.eclass.

This fixes https://bugs.gentoo.org/show_bug.cgi?id=577064