### PR TITLE
dev-libs/ocl-icd: fix dev-lang/ruby dependency

### DIFF
--- a/dev-libs/ocl-icd/ocl-icd-2.2.3.ebuild
+++ b/dev-libs/ocl-icd/ocl-icd-2.2.3.ebuild
@@ -15,7 +15,8 @@ KEYWORDS="~amd64 ~x86"
 
 IUSE=""
 
-DEPEND="dev-lang/ruby"
+DEPEND="dev-lang/ruby
+        dev-ruby/rubygems"
 RDEPEND="app-eselect/eselect-opencl"
 
 src_prepare() {

--- a/dev-libs/ocl-icd/ocl-icd-2.2.8.ebuild
+++ b/dev-libs/ocl-icd/ocl-icd-2.2.8.ebuild
@@ -15,7 +15,8 @@ KEYWORDS="~amd64 ~x86"
 
 IUSE=""
 
-DEPEND="dev-lang/ruby"
+DEPEND="dev-lang/ruby
+        dev-ruby/rubygems"
 RDEPEND="app-eselect/eselect-opencl"
 
 src_prepare() {


### PR DESCRIPTION
Resolves bug #577266

version 2.2.3 and 2.2.8 fixed.