### PR TITLE
profiles: mask nptl for x11-base/xorg-server and media-libs/mesa on musl.

### DIFF
--- a/profiles/hardened/linux/musl/package.use.mask
+++ b/profiles/hardened/linux/musl/package.use.mask
@@ -12,3 +12,7 @@ sys-fs/e2fsprogs nls
 
 # Broken
 dev-vcs/git gpg
+
+# See bug #576928
+media-libs/mesa nptl
+x11-base/xorg-server nptl


### PR DESCRIPTION
glx-tls is broken on musl. This results in failure to create glx contexts causing segmentation faults in most applications that dlopen libGL.

We can remove these masks when freedesktop bug 35268 is resolved.