### PR TITLE
dev-libs/unittest++: make tests optional

### DIFF
--- a/dev-libs/unittest++/unittest++-1.6.0.ebuild
+++ b/dev-libs/unittest++/unittest++-1.6.0.ebuild
@@ -16,5 +16,19 @@ SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+IUSE="test"
 
 S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	sed -i '/run unit tests as post build step/,/Running unit tests/d' \
+		CMakeLists.txt || die
+	use test || sed -i \
+		'/build the test runner/,/target_link_libraries(TestUnitTest++ UnitTest++/d' \
+		CMakeLists.txt || die
+	cmake-utils_src_prepare
+}
+
+src_test() {
+	"${BUILD_DIR}/TestUnitTest++" || die "Tests failed"
+}


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=576806

Package-Manager: portage-2.2.27

@kensington this doesn't fix the bug but at least now it should compile on hardened.