### PR TITLE
media-video/openshot: add missing dep on dev-python/httplib2

### DIFF
--- a/media-video/openshot/openshot-2.0.6.ebuild
+++ b/media-video/openshot/openshot-2.0.6.ebuild
@@ -24,6 +24,7 @@ KEYWORDS="~amd64 ~x86"
 RDEPEND="
 	dev-python/PyQt5[webkit,${PYTHON_USEDEP}]
 	media-libs/libopenshot[${PYTHON_USEDEP}]
+	dev-python/httplib2[${PYTHON_USEDEP}]
 "
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=577558

Package-Manager: portage-2.2.27

@kensington 