### PR TITLE
app-text/ebook-tools: add `lit2epub` USE flag

### DIFF
--- a/app-text/ebook-tools/ebook-tools-0.2.2-r1.ebuild
+++ b/app-text/ebook-tools/ebook-tools-0.2.2-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit cmake-utils multilib
+
+DESCRIPTION="Tools for accessing and converting various ebook file formats"
+HOMEPAGE="http://sourceforge.net/projects/ebook-tools"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~x86 ~amd64-fbsd"
+IUSE="+lit2epub"
+
+DEPEND="dev-libs/libxml2
+	dev-libs/libzip"
+RDEPEND="${DEPEND}
+	lit2epub? (
+		app-text/convertlit
+		app-arch/zip
+	)"
+
+DOCS=( INSTALL README TODO )
+
+src_prepare() {
+	default
+	use lit2epub || sed -i -e '\|lit2epub|d' -- 'src/tools/CMakeLists.txt' || die
+}

--- a/app-text/ebook-tools/metadata.xml
+++ b/app-text/ebook-tools/metadata.xml
@@ -8,4 +8,7 @@
 	<upstream>
 		<remote-id type="sourceforge">ebook-tools</remote-id>
 	</upstream>
+	<use>
+		<flag name="lit2epub">Install lit2epub script</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
This fixes [bug 530430](https://bugs.gentoo.org/show_bug.cgi?id=530430). Later we could make `lit2epub` non-optional and throw `app-text/convertlit` away.