### PR TITLE
net-analyzer/{bro,ipsumdump}: add ~x86

### DIFF
--- a/net-analyzer/bro/bro-2.4.1-r1.ebuild
+++ b/net-analyzer/bro/bro-2.4.1-r1.ebuild
@@ -13,21 +13,21 @@ SRC_URI="https://www.bro.org/downloads/release/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64"
-IUSE="+broccoli +broctl broker curl debug geoip ipv6 jemalloc mta +python -ruby tcmalloc static-libs +tools"
+KEYWORDS="~amd64 ~x86"
+IUSE="+broccoli +broctl -broker curl debug geoip ipv6 jemalloc +python -ruby tcmalloc static-libs +tools"
 
 RDEPEND="app-shells/bash:0
 	dev-libs/openssl:0
 	net-analyzer/ipsumdump
-	ipv6? ( net-analyzer/ipsumdump[ipv6] )
 	net-dns/bind-tools
 	net-libs/libpcap
 	sys-libs/zlib
 	broker? ( =dev-libs/actor-framework-0.13.2* )
+	broctl? ( virtual/mta )
 	curl? ( net-misc/curl )
 	geoip? ( dev-libs/geoip )
+	ipv6? ( net-analyzer/ipsumdump[ipv6] )
 	jemalloc? ( dev-libs/jemalloc )
-	mta? ( virtual/mta )
 	python? ( ${PYTHON_DEPS} )
 	ruby? ( >=dev-lang/ruby-1.8:= )
 	tcmalloc? ( dev-util/google-perftools )"

--- a/net-analyzer/bro/metadata.xml
+++ b/net-analyzer/bro/metadata.xml
@@ -13,11 +13,10 @@
     <use>
         <flag name="broccoli">Enable the Bro Client Communication Library</flag>
         <flag name="broctl">An interactive shell for managing Bro installations</flag>
-        <flag name="broker">Bro's (new) Messaging Library</flag>
+        <flag name="broker">Bro's new Messaging Library (experimental)</flag>
         <flag name="geoip">Enable support for Maxmind's GeoIP library</flag>
         <flag name="ipv6">Support for mobile IPv6</flag>
         <flag name="jemalloc">Support for the Jemalloc allocator</flag>
-        <flag name="mta">Enable Bro to send e-mails</flag>
         <flag name="python">Enable Python bindings</flag>
         <flag name="ruby">Enable Ruby bindings (deprecated)</flag>
         <flag name="tcmalloc">Enable Google's Performance Analysis Tools</flag>

--- a/net-analyzer/ipsumdump/ipsumdump-1.85.ebuild
+++ b/net-analyzer/ipsumdump/ipsumdump-1.85.ebuild
@@ -10,7 +10,7 @@ SRC_URI="http://read.seas.harvard.edu/~kohler/ipsumdump/${P}.tar.gz"
 
 LICENSE="the-Click-license"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86"
 IUSE="+ipv6 +nanotimestamp"
 
 RDEPEND="net-libs/libpcap"


### PR DESCRIPTION
minor fixes.

@gentoo/proxy-maint