### PR TITLE
Remove local definitions for global USE=vala and USE=introspeciton

### DIFF
--- a/app-crypt/libsecret/metadata.xml
+++ b/app-crypt/libsecret/metadata.xml
@@ -5,7 +5,4 @@
 		<email>gnome@gentoo.org</email>
 		<name>Gentoo GNOME Desktop</name>
 	</maintainer>
-	<use>
-		<flag name="vala">Enable bindings for <pkg>dev-lang/vala</pkg></flag>
-	</use>
 </pkgmetadata>

--- a/app-emulation/libguestfs/metadata.xml
+++ b/app-emulation/libguestfs/metadata.xml
@@ -24,7 +24,6 @@
 modifying virtual machine (VM) disk images</longdescription>
 <use>
 	<flag name="fuse">Enable image mount support via fuse</flag>
-	<flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
 	<flag name="erlang">Build Erlang bindings</flag>
 	<flag name="systemtap">Use <pkg>dev-util/systemtap</pkg> to inspect VM via "probes" way</flag>
 	<flag name="inspect-icons">Use <pkg>media-gfx/icoutils</pkg>for acces icon file in image and inspect it</flag>

--- a/app-i18n/fcitx/metadata.xml
+++ b/app-i18n/fcitx/metadata.xml
@@ -12,7 +12,6 @@
 	<use>
 		<flag name="autostart">Enable XDG-compatible autostart of Fcitx</flag>
 		<flag name="enchant">Enable Enchant backend (using <pkg>app-text/enchant</pkg>) for spelling hinting</flag>
-		<flag name="introspection">Enable support for GObject Introspection</flag>
 		<flag name="gtk">Install input method module for GTK+ 2</flag>
 		<flag name="gtk2">Install input method module for GTK+ 2</flag>
 		<flag name="gtk3">Install input method module for GTK+ 3</flag>

--- a/app-i18n/ibus/metadata.xml
+++ b/app-i18n/ibus/metadata.xml
@@ -13,8 +13,6 @@ developers to develop input method easily.
   <use>
     <flag name="gconf">Enable support for <pkg>gnome-base/gconf</pkg></flag>
     <flag name="gtk3">Enable support for gtk+3</flag>
-    <flag name="vala">Enable support for <pkg>dev-lang/vala</pkg></flag>
-    <flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
     <flag name="deprecated">install the deprecated ibus python library</flag>
   </use>
   <upstream>

--- a/app-i18n/libskk/metadata.xml
+++ b/app-i18n/libskk/metadata.xml
@@ -5,9 +5,6 @@
     <email>cjk@gentoo.org</email>
     <name>Cjk</name>
   </maintainer>
-  <use>
-    <flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
-  </use>
   <upstream>
     <remote-id type="github">ueno/libskk</remote-id>
   </upstream>

--- a/app-text/gtkspell/metadata.xml
+++ b/app-text/gtkspell/metadata.xml
@@ -5,9 +5,6 @@
 		<email>gnome@gentoo.org</email>
 		<name>Gentoo GNOME Desktop</name>
 	</maintainer>
-	<use>
-		<flag name="vala">Enable bindings for <pkg>dev-lang/vala</pkg></flag>
-	</use>
 	<upstream>
 		<remote-id type="sourceforge">gtkspell</remote-id>
 	</upstream>

--- a/app-text/liblangtag/metadata.xml
+++ b/app-text/liblangtag/metadata.xml
@@ -5,9 +5,6 @@
     <email>office@gentoo.org</email>
     <name>Gentoo Office project</name>
   </maintainer>
-  <use>
-    <flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
-  </use>
   <upstream>
     <remote-id type="bitbucket">tagoh/liblangtag</remote-id>
   </upstream>

--- a/dev-libs/keybinder/metadata.xml
+++ b/dev-libs/keybinder/metadata.xml
@@ -5,9 +5,6 @@
     <email>ssuominen@gentoo.org</email>
     <name>Samuli Suominen</name>
   </maintainer>
-  <use>
-    <flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
-  </use>
   <upstream>
     <remote-id type="github">engla/keybinder</remote-id>
   </upstream>

--- a/dev-libs/libdbusmenu/metadata.xml
+++ b/dev-libs/libdbusmenu/metadata.xml
@@ -8,7 +8,6 @@
 	<use>
 		<flag name="gtk" restrict="&gt;=dev-libs/libdbusmenu-12.10.2-r2">Enable support for GTK+2</flag>
 		<flag name="gtk3">Enable support for GTK+3</flag>
-		<flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
 	</use>
 	<upstream>
 		<remote-id type="launchpad">dbusmenu</remote-id>

--- a/dev-libs/libindicate/metadata.xml
+++ b/dev-libs/libindicate/metadata.xml
@@ -5,9 +5,6 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
-	<use>
-		<flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
-	</use>
 	<upstream>
 		<remote-id type="launchpad">libindicate</remote-id>
 	</upstream>

--- a/dev-libs/libunique/metadata.xml
+++ b/dev-libs/libunique/metadata.xml
@@ -8,8 +8,4 @@
 <longdescription lang="en">
 Unique is a library for writing single instance application. If you launch a single instance application twice, the second instance will either just quit or will send a message to the running instance.
 </longdescription>
-<use>
-  <flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg>
-    for introspection</flag>
-</use>
 </pkgmetadata>

--- a/gnome-base/libgnome-keyring/metadata.xml
+++ b/gnome-base/libgnome-keyring/metadata.xml
@@ -5,7 +5,4 @@
 	<email>gnome@gentoo.org</email>
 	<name>Gentoo GNOME Desktop</name>
 </maintainer>
-<use>
-	<flag name="vala">Enable bindings for <pkg>dev-lang/vala</pkg></flag>
-</use>
 </pkgmetadata>

--- a/gnome-extra/gucharmap/metadata.xml
+++ b/gnome-extra/gucharmap/metadata.xml
@@ -5,7 +5,4 @@
 	<email>gnome@gentoo.org</email>
 	<name>Gentoo GNOME Desktop</name>
 </maintainer>
-<use>
-	<flag name="vala">Enable bindings for <pkg>dev-lang/vala</pkg></flag>
-</use>
 </pkgmetadata>

--- a/media-libs/gegl/metadata.xml
+++ b/media-libs/gegl/metadata.xml
@@ -5,10 +5,8 @@
 		<email>sping@gentoo.org</email>
 	</maintainer>
 	<use>
-		<flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection.</flag>
 		<flag name="lensfun">Enable support for <pkg>media-libs/lensfun</pkg>.</flag>
 		<flag name="umfpack">Enable sparse solving via <pkg>sci-libs/umfpack</pkg>.</flag>
-		<flag name="vala">Enable bindings for <pkg>dev-lang/vala</pkg></flag>
 		<flag name="webp">Enable support for <pkg>media-libs/libwebp</pkg></flag>
 	</use>
 </pkgmetadata>

--- a/media-libs/mash/metadata.xml
+++ b/media-libs/mash/metadata.xml
@@ -5,8 +5,4 @@
   <email>gnome@gentoo.org</email>
   <name>Gentoo GNOME Desktop</name>
 </maintainer>
-<use>
-  <flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg>
-    for introspection</flag>
-</use>
 </pkgmetadata>

--- a/media-libs/memphis/metadata.xml
+++ b/media-libs/memphis/metadata.xml
@@ -5,8 +5,4 @@
     <email>sci-geosciences@gentoo.org</email>
     <name>Gentoo Geosciences Project</name>
   </maintainer>
-  <use>
-    <flag name="introspection">Use dev-libs/gobject-introspection for introspection</flag>
-    <flag name="vala">Add support for Vala</flag>
-  </use>
 </pkgmetadata>

--- a/net-libs/telepathy-glib/metadata.xml
+++ b/net-libs/telepathy-glib/metadata.xml
@@ -5,7 +5,4 @@
 		<email>gnome@gentoo.org</email>
 		<name>Gentoo GNOME Desktop</name>
 	</maintainer>
-	<use>
-		<flag name="vala">Enable bindings for <pkg>dev-lang/vala</pkg></flag>
-	</use>
 </pkgmetadata>

--- a/net-misc/spice-gtk/metadata.xml
+++ b/net-misc/spice-gtk/metadata.xml
@@ -19,8 +19,6 @@
 			usbredir acl helper</flag>
     <flag name="usbredir">Use <pkg>sys-apps/usbredir</pkg> to redirect USB
 			devices to another machine over TCP</flag>
-    <flag name="vala">Generate <pkg>dev-lang/vala</pkg> bindings using
-			vapigen and regenerate .vala files using valac</flag>
     <flag name="webdav">Support for folder-sharing between guest and client
 		using <pkg>net-libs/phodav</pkg></flag>
   </use>

--- a/sys-fs/eudev/metadata.xml
+++ b/sys-fs/eudev/metadata.xml
@@ -7,8 +7,6 @@
   <use>
     <flag name="gudev">enable libudev gobject interface</flag>
     <flag name="hwdb">read vendor/device string database and add it to udev database</flag>
-    <flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg>
-  	for introspection</flag>
     <flag name="keymap">map custom hardware's multimedia keys</flag>
     <flag name="kmod">enable module loading through libkmod</flag>
     <flag name="modutils">enable module loading support - use modutils calls if kmod not enabled</flag>

--- a/sys-fs/udisks/metadata.xml
+++ b/sys-fs/udisks/metadata.xml
@@ -7,7 +7,6 @@
 	<use>
 		<flag name="cryptsetup">Enable <pkg>sys-fs/cryptsetup</pkg> support</flag>
 		<flag name="gptfdisk">Pull in <pkg>sys-apps/gptfdisk</pkg> for sgdisk command as used by partitioning functionality</flag>
-		<flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
 		<flag name="remote-access">Control whether connections from other clients over LAN are allowed</flag>
 		<flag name="systemd">Support <pkg>sys-apps/systemd</pkg>'s logind</flag>
 	</use>

--- a/x11-libs/libdesktop-agnostic/metadata.xml
+++ b/x11-libs/libdesktop-agnostic/metadata.xml
@@ -8,7 +8,6 @@
   <use>
     <flag name="gconf">Enable GConf as configuration backend</flag>
     <flag name="glade">Install the Glade catalog for the desktop-agnotstic GTK widgets.</flag>
-    <flag name="introspection">Use dev-libs/gobject-introspection for introspection</flag>
   </use>
   <upstream>
     <remote-id type="launchpad">libdesktop-agnostic</remote-id>

--- a/x11-libs/libxklavier/metadata.xml
+++ b/x11-libs/libxklavier/metadata.xml
@@ -4,7 +4,4 @@
   <maintainer type="project">
     <email>freedesktop-bugs@gentoo.org</email>
   </maintainer>
-  <use>
-    <flag name="introspection">Use <pkg>dev-libs/gobject-introspection</pkg> for introspection</flag>
-  </use>
 </pkgmetadata>

--- a/x11-misc/lightdm/metadata.xml
+++ b/x11-misc/lightdm/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="gtk">Pull in the gtk+ greeter</flag>
-		<flag name="introspection">Use dev-libs/gobject-introspection for introspection</flag>
 		<flag name="kde">Pull in the kde greeter</flag>
 	</use>
 	<longdescription lang="en">


### PR DESCRIPTION
23 packages had local use definitions that matched up perfectly with
the global definitions. Remove them as they're not necessary. This
is a metadata only change.