### PR TITLE
app-misc/pwsafe metadata update and EAPI bump

### DIFF
--- a/app-misc/pwsafe/metadata.xml
+++ b/app-misc/pwsafe/metadata.xml
@@ -22,5 +22,6 @@
       <name>Nicolas Dade</name>
     </maintainer>
     <remote-id type="sourceforge">pwsafe</remote-id>
+    <remote-id type="github">nsd20463/pwsafe</remote-id>
   </upstream>
 </pkgmetadata>

--- a/app-misc/pwsafe/pwsafe-0.2.0-r3.ebuild
+++ b/app-misc/pwsafe/pwsafe-0.2.0-r3.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+DESCRIPTION="A Password Safe compatible command-line password manager"
+HOMEPAGE="http://nsd.dyndns.org/pwsafe/"
+SRC_URI="http://nsd.dyndns.org/pwsafe/releases/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+IUSE="X readline"
+
+DEPEND="sys-libs/ncurses:0=
+	dev-libs/openssl:0=
+	readline? ( sys-libs/readline:0= )
+	X? ( x11-libs/libSM
+		x11-libs/libICE
+		x11-libs/libXmu
+		x11-libs/libX11 )"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	eapply -p0 "${FILESDIR}/${P}-cvs-1.57.patch"
+	eapply -p0 "${FILESDIR}/${P}-printf.patch"
+	eapply -p0 "${FILESDIR}/${P}-fake-readline.patch"
+	eapply -p0 "${FILESDIR}/${P}-man-page-option-syntax.patch"
+	eapply -p0 "${FILESDIR}/${P}-XChangeProperty.patch"
+	eapply_user
+}
+
+src_configure() {
+	econf $(use_with X x) $(use_with readline)
+}
+
+src_install() {
+	doman pwsafe.1
+	dobin pwsafe
+	dodoc README NEWS
+}


### PR DESCRIPTION
The first commit of this PR updates metadata.xml to include the Github upstream ID for pwsafe.

The second commit adds -r3, which bumps to EAPI 6, eliminates no-longer-needed eclass inherits, and adds slot operators to some dependencies.

Note that I am the proxied maintainer for this package. If there’s anything I need to do to associate my Github username with my name in the maintainers list, please let me know; I haven’t done any proxy work since the Git migration.