### PR TITLE
net-irc/znc: update LICENSE for older ebuilds

### DIFF
--- a/net-irc/znc/znc-1.2-r1.ebuild
+++ b/net-irc/znc/znc-1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -21,7 +21,7 @@ else
 fi
 
 HOMEPAGE="http://znc.in"
-LICENSE="GPL-2"
+LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="daemon debug ipv6 perl python ssl sasl tcl"
 

--- a/net-irc/znc/znc-1.4-r1.ebuild
+++ b/net-irc/znc/znc-1.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -21,7 +21,7 @@ else
 fi
 
 HOMEPAGE="http://znc.in"
-LICENSE="GPL-2"
+LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="daemon debug ipv6 perl python ssl sasl tcl"
 

--- a/net-irc/znc/znc-1.4.ebuild
+++ b/net-irc/znc/znc-1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -21,7 +21,7 @@ else
 fi
 
 HOMEPAGE="http://znc.in"
-LICENSE="GPL-2"
+LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="daemon debug ipv6 perl python ssl sasl tcl"
 

--- a/net-irc/znc/znc-1.6.1-r1.ebuild
+++ b/net-irc/znc/znc-1.6.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -17,7 +17,7 @@ SRC_URI="http://znc.in/releases/${PN}-${MY_PV}.tar.gz
 KEYWORDS="~amd64 ~arm ~x86"
 
 HOMEPAGE="http://znc.in"
-LICENSE="GPL-2"
+LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="daemon debug ipv6 libressl perl python ssl sasl tcl test"
 

--- a/net-irc/znc/znc-9999.ebuild
+++ b/net-irc/znc/znc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -16,7 +16,7 @@ SRC_URI=""
 KEYWORDS=""
 
 HOMEPAGE="http://znc.in"
-LICENSE="GPL-2"
+LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="daemon debug ipv6 libressl perl python ssl sasl tcl"
 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/571366

Package-Manager: portage-2.2.28