### PR TITLE
dev-python/cython: add emacs USE flag for installing cython-mode

### DIFF
--- a/dev-python/cython/cython-0.23.4-r1.ebuild
+++ b/dev-python/cython/cython-0.23.4-r1.ebuild
@@ -1,0 +1,82 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1 flag-o-matic toolchain-funcs elisp-common
+
+MY_PN="Cython"
+MY_P="${MY_PN}-${PV/_/}"
+
+DESCRIPTION="A Python to C compiler"
+HOMEPAGE="http://www.cython.org/ https://pypi.python.org/pypi/Cython"
+SRC_URI="http://www.cython.org/release/${MY_P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+
+IUSE="doc examples emacs test"
+
+RDEPEND="
+	emacs? ( virtual/emacs )
+"
+# On testing, setuptools invokes an error in running the testsuite cited in a number of recent bugs
+# spanning several packages. This bug has been fixed in the recent release of version 9.1
+DEPEND="${RDEPEND}
+	>=dev-python/setuptools-9.1[${PYTHON_USEDEP}]
+	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
+	test? ( dev-python/numpy[${PYTHON_USEDEP}] )"
+
+SITEFILE=50cython-gentoo.el
+S="${WORKDIR}/${MY_PN}-${PV%_*}"
+
+python_compile() {
+	if ! python_is_python3; then
+		local CFLAGS="${CFLAGS}"
+		local CXXFLAGS="${CXXFLAGS}"
+		append-flags -fno-strict-aliasing
+	fi
+
+	# Python gets confused when it is in sys.path before build.
+	local PYTHONPATH=
+	export PYTHONPATH
+
+	distutils-r1_python_compile
+}
+
+python_compile_all() {
+	use emacs && elisp-compile Tools/cython-mode.el
+
+	use doc && unset XDG_CONFIG_HOME && emake -C docs html
+}
+
+python_test() {
+	tc-export CC
+	"${PYTHON}" runtests.py -vv --work-dir "${BUILD_DIR}"/tests \
+		|| die "Tests fail with ${EPYTHON}"
+}
+
+python_install_all() {
+	local DOCS=( CHANGES.rst README.txt ToDo.txt USAGE.txt )
+	use doc && local HTML_DOCS=( docs/build/html/. )
+	use examples && local EXAMPLES=( Demos/. )
+	distutils-r1_python_install_all
+
+	if use emacs; then
+		elisp-install ${PN} Tools/cython-mode.*
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/dev-python/cython/files/50cython-gentoo.el
+++ b/dev-python/cython/files/50cython-gentoo.el
@@ -1,0 +1,11 @@
+;;; site-lisp configuration for cython-mode
+
+(add-to-list 'load-path "@SITELISP@")
+
+(autoload  'cython-mode "cython-mode" "Major mode for editing Cython files" t)
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.pyx\\'" . cython-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.pxd\\'" . cython-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.pxi\\'" . cython-mode))


### PR DESCRIPTION
This is to resolve Bug#557308 (https://bugs.gentoo.org/show_bug.cgi?id=557308)
The current ebuild does not install cython-mode for emacs even if emacs use flag is set. This pull request is to correct that by adding emacs use flag along with the appropriate installation commands.

Package-Manager: Portage 2.2.26