### PR TITLE
app-text/asciidoc: move to readme.gentoo-r1 eclass

### DIFF
--- a/app-text/asciidoc/asciidoc-8.6.9-r3.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r3.ebuild
@@ -1,0 +1,81 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 pypy )
+inherit readme.gentoo-r1 python-single-r1
+
+DESCRIPTION="AsciiDoc is a plain text human readable/writable document format"
+HOMEPAGE="http://asciidoc.org/"
+SRC_URI="mirror://sourceforge/project/${PN}/${PN}/${PV}/${P}.tar.gz"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="examples graphviz highlight test"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND=">=app-text/docbook-xsl-stylesheets-1.75
+		dev-libs/libxslt
+		graphviz? ( media-gfx/graphviz )
+		app-text/docbook-xml-dtd:4.5
+		highlight? ( || ( dev-util/source-highlight \
+			dev-python/pygments[${PYTHON_USEDEP}] \
+			app-text/highlight )
+		)
+		${PYTHON_DEPS}
+"
+DEPEND="test? ( dev-util/source-highlight
+			media-sound/lilypond
+			media-gfx/imagemagick
+			dev-texlive/texlive-latex
+			app-text/dvipng
+			media-gfx/graphviz
+			${PYTHON_DEPS} )
+"
+
+DOC_CONTENTS="
+If you are going to use a2x, please also look at a2x(1) under
+REQUISITES for a list of runtime dependencies.
+"
+
+src_prepare() {
+	# Only needed for prefix - harmless (does nothing) otherwise
+	sed -i -e "s:^CONF_DIR=.*:CONF_DIR='${EPREFIX}/etc/asciidoc':" \
+		"${S}/asciidoc.py" || die
+}
+
+src_configure() {
+	econf --sysconfdir="${EPREFIX}"/usr/share
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	python_fix_shebang "${ED}"/usr/bin/*.py
+
+	readme.gentoo_create_doc
+	dodoc BUGS CHANGELOG README docbook-xsl/asciidoc-docbook-xsl.txt \
+			dblatex/dblatex-readme.txt filters/code/code-filter-readme.txt
+
+	# Below results in some files being installed twice in different locations, but they are in the right place,
+	# uncompressed, and there won't be any broken links. See bug #483336.
+	if use examples; then
+		cp -rL examples/website "${D}"/usr/share/doc/${PF}/examples || die
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+}
+
+src_test() {
+	cd tests || die
+	local -x ASCIIDOC_PY=../asciidoc.py
+	"${PYTHON}" test${PN}.py update || die
+	"${PYTHON}" test${PN}.py run || die
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
Package-Manager: portage-2.2.26
Signed-off-by: Marc Joliet <marcec@gmx.de>