### PR TITLE
games-rpg/arx-libertatis: fix build with cmake 3.5

### DIFF
--- a/games-rpg/arx-libertatis/arx-libertatis-1.1.2.ebuild
+++ b/games-rpg/arx-libertatis/arx-libertatis-1.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -35,6 +35,10 @@ DEPEND="${COMMON_DEPEND}
 	static? ( media-libs/glew[static-libs] )"
 
 DOCS=( README.md AUTHORS CHANGELOG )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-cmake-3.5.patch
+)
 
 src_configure() {
 	# editor does not build

--- a/games-rpg/arx-libertatis/files/arx-libertatis-1.1.2-cmake-3.5.patch
+++ b/games-rpg/arx-libertatis/files/arx-libertatis-1.1.2-cmake-3.5.patch
@@ -1,0 +1,34 @@
+From c4262bc600dc01d3ddbacc7811132b29ea46ad3b Mon Sep 17 00:00:00 2001
+From: Daniel Scharrer <daniel@constexpr.org>
+Date: Thu, 24 Mar 2016 22:47:44 +0100
+Subject: [PATCH] CMake: Disable variable expansion for quoted strings in if()
+
+This makes the build system more robust against stray variables
+coming from included CMake scripts provided by the system.
+
+Fixes build with CMake 3.5.
+
+This has been fixed in master with commit 60e43c.
+---
+ CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 93f1ee3..8347544 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,6 +13,11 @@ else()
+ 	cmake_minimum_required(VERSION 2.8)
+ endif()
+ 
++if(POLICY CMP0054)
++	# CMake 3.1+: Only interpret if() arguments as variables or keywords when unquoted.
++	cmake_policy(SET CMP0054 NEW)
++endif()
++
+ 
+ # Define configuration options
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
I sent the same fix for `app-arch/innoextract` but forgot that it would also be needed here.

As far as I know there is no Gentoo bug report for this yet.