### PR TITLE
net-im/qtox: add installing .png icons (bug #578210) + new pkgconfig dep

### DIFF
--- a/net-im/qtox/qtox-1.3.0.ebuild
+++ b/net-im/qtox/qtox-1.3.0.ebuild
@@ -74,6 +74,11 @@ src_configure() {
 
 src_install() {
 	dobin "${S}/qtox"
+	# install all png icons
+	local ICONS=(16 22 24 32 36 48 64 72 96 128 192 256 512)
+	for i in "${ICONS[@]}"; do
+		newicon -s "${i}" "${S}/img/icons/qtox-${i}x${i}.png" "qtox.png"
+	done
 	doicon -s scalable "${S}/img/icons/qtox.svg"
 	domenu "${S}/qTox.desktop"
 }

--- a/net-im/qtox/qtox-9999.ebuild
+++ b/net-im/qtox/qtox-9999.ebuild
@@ -37,6 +37,7 @@ RDEPEND="
 			x11-libs/cairo[X]
 			x11-libs/pango[X] )
 	net-libs/tox[av]
+	virtual/pkgconfig
 	X? ( x11-libs/libX11
 		x11-libs/libXScrnSaver )
 "
@@ -72,6 +73,11 @@ src_configure() {
 
 src_install() {
 	dobin "${S}/qtox"
+	# install all png icons
+	local ICONS=(16 22 24 32 36 48 64 72 96 128 192 256 512)
+	for i in "${ICONS[@]}"; do
+		newicon -s "${i}" "${S}/img/icons/qtox-${i}x${i}.png" "qtox.png"
+	done
 	doicon -s scalable "${S}/img/icons/qtox.svg"
 	domenu "${S}/qTox.desktop"
 }


### PR DESCRIPTION
Not sure if that needs a revbump..?
And if so, the it would be for both ~ and -9999?