### PR TITLE
profiles: unmask qt5 USE flag on ppc

### DIFF
--- a/profiles/arch/powerpc/ppc32/use.mask
+++ b/profiles/arch/powerpc/ppc32/use.mask
@@ -5,10 +5,6 @@
 # Java is no longer supported on ppc.
 java
 
-# Ben de Groot <yngwin@gentoo.org> (01 Feb 2015)
-# please remove when keyworded
-qt5
-
 # Michał Górny <mgorny@gentoo.org> (27 Jun 2014)
 # Unmask multilib flag for the ABI.
 -abi_ppc_32


### PR DESCRIPTION
CI check.