### PR TITLE
app-admin/collectd: Revbump to fix multiple issues

### DIFF
--- a/app-admin/collectd/files/collectd-5.5.1-issue-1637.patch
+++ b/app-admin/collectd/files/collectd-5.5.1-issue-1637.patch
@@ -1,0 +1,68 @@
+From 7630585ca596af6334f89db26272d80f4ef02a8a Mon Sep 17 00:00:00 2001
+From: Ruben Kerkhof <ruben@rubenkerkhof.com>
+Date: Sat, 26 Mar 2016 18:18:44 +0100
+Subject: [PATCH 4/4] Fix building with xfsprogs 4.5.0
+
+commit 865a6c83250e3d4381596a0d937df31d563f97c6 upstream.
+
+xfsprogs 4.5.0 started to use off64_t in its headers,
+which is hidden behind _GNU_SOURCE
+
+Fixes #1637
+---
+ configure.ac      |  7 ++++++-
+ src/utils_mount.c | 13 ++++++++-----
+ 2 files changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 129b9d4..a2058d0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -593,7 +593,12 @@ AC_CHECK_HEADERS(linux/un.h, [], [],
+ #endif
+ ])
+ 
+-AC_CHECK_HEADERS(pwd.h grp.h sys/un.h ctype.h limits.h xfs/xqm.h fs_info.h fshelp.h paths.h mntent.h mnttab.h sys/fstyp.h sys/fs_types.h sys/mntent.h sys/mnttab.h sys/statfs.h sys/statvfs.h sys/vfs.h sys/vfstab.h sys/vmmeter.h kvm.h wordexp.h locale.h)
++AC_CHECK_HEADERS(pwd.h grp.h sys/un.h ctype.h limits.h fs_info.h fshelp.h paths.h mntent.h mnttab.h sys/fstyp.h sys/fs_types.h sys/mntent.h sys/mnttab.h sys/statfs.h sys/statvfs.h sys/vfs.h sys/vfstab.h sys/vmmeter.h kvm.h wordexp.h locale.h)
++
++AC_CHECK_HEADERS([xfs/xqm.h], [], [],
++[
++#define _GNU_SOURCE
++])
+ 
+ # For the dns plugin
+ AC_CHECK_HEADERS(arpa/nameser.h)
+diff --git a/src/utils_mount.c b/src/utils_mount.c
+index f2b7943..cf5e97a 100644
+--- a/src/utils_mount.c
++++ b/src/utils_mount.c
+@@ -21,18 +21,21 @@
+  *   Niki W. Waibel <niki.waibel@gmx.net>
+ **/
+ 
+-#include "collectd.h"
+-#include "utils_mount.h"
+-
+-#include "common.h" /* sstrncpy() et alii */
+-#include "plugin.h" /* ERROR() macro */
++#if HAVE_CONFIG_H
++# include "config.h"
++#endif
+ 
+ #if HAVE_XFS_XQM_H
++# define _GNU_SOURCE
+ # include <xfs/xqm.h>
+ #define XFS_SUPER_MAGIC_STR "XFSB"
+ #define XFS_SUPER_MAGIC2_STR "BSFX"
+ #endif
+ 
++#include "common.h"
++#include "plugin.h"
++#include "utils_mount.h"
++
+ #if HAVE_GETVFSSTAT
+ #  if HAVE_SYS_TYPES_H
+ #    include <sys/types.h>
+-- 
+2.7.4
+

--- a/app-admin/collectd/metadata.xml
+++ b/app-admin/collectd/metadata.xml
@@ -33,6 +33,7 @@
 		<flag name="collectd_plugins_apache">Build the apache input plugin (collects statistics from Apache's mod_status module)</flag>
 		<flag name="collectd_plugins_apcups">Build the apcups input plugin (reads various statistics about a connected uninterruptible power supply (UPS))</flag>
 		<flag name="collectd_plugins_ascent">Build the ascent input plugin (reads and parses the statistics page of Ascent)</flag>
+		<flag name="collectd_plugins_barometer">Build the barometer input plugin (reads sensor data from various Freescale and Bosch digital barometers)</flag>
 		<flag name="collectd_plugins_battery">Build the battery input plugin (collects the battery's charge, the drawn current and the battery's voltage)</flag>
 		<flag name="collectd_plugins_bind">Build the bind input plugin (collects statistics from bind instances)</flag>
 		<flag name="collectd_plugins_ceph">Build the Ceph input plugin (collects statistics from the Ceph distributed storage system)</flag>
@@ -145,6 +146,7 @@
 		<flag name="collectd_plugins_write_http">Build the write_http output plugin (sends metrics to a web-server using HTTP POST requests)</flag>
 		<flag name="collectd_plugins_write_kafka">Build the Kafka output plugin (sends metrics to Apache Kafka)</flag>
 		<flag name="collectd_plugins_write_log">Build the write_log output plugin (writes metrics to a file)</flag>
+		<flag name="collectd_plugins_write_mongodb">Build the MongoDB output plugin (writes metrics to a MongoDB)</flag>
 		<flag name="collectd_plugins_write_redis">Build the Redis output plugin (stores values in Redis)</flag>
 		<flag name="collectd_plugins_write_riemann">Build the Riemann output plugin (stores values in Riemann, a stream processing and monitoring system)</flag>
 		<flag name="collectd_plugins_write_sensu">Build the Sensu output plugin (sends metrics to Sensu Core, an open-source monitoring project)</flag>
@@ -154,5 +156,6 @@
 		<flag name="contrib">Install user-contributed files in the doc directory</flag>
 		<flag name="filecaps">When set collectd daemon will have set required capabilities to run most plugins even if run as unprivileged user</flag>
 		<flag name="java">Must be set (workaround for java-pkg-opt-2 eclass limitation) when you want java or genericjmx plugin</flag>
+		<flag name="udev">Enable optional udev usage in disk plugin; Required for smart plugin</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
- Fix building with sys-fs/xfsprogs-4.5.0 (upstream issues #1637)

- Workaround for[ bug #577846](https://bugs.gentoo.org/show_bug.cgi?id=577846) applied

  We are now enforcing <=sys-kernel/linux-headers-4.4 when building
  collectd_plugins_iptables until the problem gets fixed in
  non-collectd upstram.
