### PR TITLE
kde-misc/plasma-applet-redshift-control: add dep on kde-frameworks/pl…

### DIFF
--- a/kde-misc/plasma-applet-redshift-control/plasma-applet-redshift-control-1.0.17.ebuild
+++ b/kde-misc/plasma-applet-redshift-control/plasma-applet-redshift-control-1.0.17.ebuild
@@ -14,4 +14,6 @@ LICENSE="GPL-2+"
 KEYWORDS="~amd64"
 IUSE=""
 
-RDEPEND="x11-misc/redshift"
+DEPEND="$(add_frameworks_dep plasma)"
+RDEPEND="${DEPEND}
+	x11-misc/redshift"


### PR DESCRIPTION
…asma

While upgrading to KDE Plasma, I hit the following compilation failure:

    CMake Warning at CMakeLists.txt:13 (find_package):
      By not providing "FindKF5Plasma.cmake" in CMAKE_MODULE_PATH this project
      has asked CMake to find a package configuration file provided by
      "KF5Plasma", but CMake did not find one.

      Could not find a package configuration file provided by "KF5Plasma" with
      any of the following names:

        KF5PlasmaConfig.cmake
        kf5plasma-config.cmake

      Add the installation prefix of "KF5Plasma" to CMAKE_PREFIX_PATH or set
      "KF5Plasma_DIR" to a directory containing one of the above files.  If
      "KF5Plasma" provides a separate development package or SDK, be sure it has
      been installed.

    CMake Error at CMakeLists.txt:17 (plasma_install_package):
      Unknown CMake command "plasma_install_package".

KF5PlasmaConfig.cmake is provided by kde-frameworks/plasma, so
kde-misc/plasma-applet-redshift-control needs to depend on it.

Package-Manager: portage-2.2.26
Signed-off-by: Marc Joliet <marcec@gmx.de>