### PR TITLE
app-admin/collectd: Fix REQUIRED_USE

### DIFF
--- a/app-admin/collectd/collectd-5.5.1-r2.ebuild
+++ b/app-admin/collectd/collectd-5.5.1-r2.ebuild
@@ -140,7 +140,7 @@ REQUIRED_USE="
 	collectd_plugins_genericjmx?		( java )
 	collectd_plugins_java?			( java )
 	collectd_plugins_python?		( ${PYTHON_REQUIRED_USE} )
-	collectd_plugins_smart			( udev )"
+	collectd_plugins_smart?			( udev )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.10.3-werror.patch


### PR DESCRIPTION
REQUIRED_USE of *udev* is only required when *smart* plugin was selected by
the user (forgotten "?"). So we were currently enforcing *udev* even if the user didn't selected the *smart* plugin.

/cc= @gentoo/proxy-maint