### PR TITLE
app-misc/ddate: Allow building for ARM

### DIFF
--- a/app-misc/ddate/ddate-0.2.1.ebuild
+++ b/app-misc/ddate/ddate-0.2.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/bo0ts/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm ~x86"
 IUSE=""
 
 RDEPEND="!<sys-apps/util-linux-2.20


### PR DESCRIPTION
Other arches would most likely work as well, but I haven’t tested.