### PR TITLE
net-misc/i2pd: small updates to 2.6.0

### DIFF
--- a/net-misc/i2pd/files/i2pd-2.6.0-fix_incomplete_hosts.patch
+++ b/net-misc/i2pd/files/i2pd-2.6.0-fix_incomplete_hosts.patch
@@ -1,0 +1,70 @@
+diff --git a/AddressBook.cpp b/AddressBook.cpp
+index ad2d0c3..766d8c9 100644
+--- a/AddressBook.cpp
++++ b/AddressBook.cpp
+@@ -343,10 +343,11 @@ namespace client
+ 		}
+ 	}
+ 
+-	void AddressBook::LoadHostsFromStream (std::istream& f)
++	bool AddressBook::LoadHostsFromStream (std::istream& f)
+ 	{
+ 		std::unique_lock<std::mutex> l(m_AddressBookMutex);
+ 		int numAddresses = 0;
++		bool incomplete = false;
+ 		std::string s;
+ 		while (!f.eof ())
+ 		{
+@@ -370,15 +371,21 @@ namespace client
+ 					numAddresses++;
+ 				}	
+ 				else
++				{
+ 					LogPrint (eLogError, "Addressbook: malformed address ", addr, " for ", name);
+-			}		
++					incomplete = f.eof ();
++				}
++			}	
++			else
++				incomplete = f.eof ();
+ 		}
+ 		LogPrint (eLogInfo, "Addressbook: ", numAddresses, " addresses processed");
+ 		if (numAddresses > 0)
+ 		{	
+-			m_IsLoaded = true;
++			if (!incomplete) m_IsLoaded = true;
+ 			m_Storage->Save (m_Addresses);
+ 		}	
++		return !incomplete;
+ 	}	
+ 	
+ 	void AddressBook::LoadSubscriptions ()
+@@ -776,13 +783,12 @@ namespace client
+ 			i2p::data::GzipInflator inflator;
+ 			inflator.Inflate (s, uncompressed);
+ 			if (!uncompressed.fail ())
+-				m_Book.LoadHostsFromStream (uncompressed);
++				return m_Book.LoadHostsFromStream (uncompressed);
+ 			else
+ 				return false;
+ 		}	
+ 		else
+-			m_Book.LoadHostsFromStream (s);
+-		return true;	
++			return m_Book.LoadHostsFromStream (s);
+ 	}
+ 
+ 	AddressResolver::AddressResolver (std::shared_ptr<ClientDestination> destination):
+diff --git a/AddressBook.h b/AddressBook.h
+index 56f8145..61b82f4 100644
+--- a/AddressBook.h
++++ b/AddressBook.h
+@@ -66,7 +66,7 @@ namespace client
+ 			void InsertAddress (const std::string& address, const std::string& base64); // for jump service
+ 			void InsertAddress (std::shared_ptr<const i2p::data::IdentityEx> address);
+ 
+-			void LoadHostsFromStream (std::istream& f);
++			bool LoadHostsFromStream (std::istream& f);
+ 			void DownloadComplete (bool success, const i2p::data::IdentHash& subscription, const std::string& etag, const std::string& lastModified);
+ 			//This method returns the ".b32.i2p" address
+ 			std::string ToAddress(const i2p::data::IdentHash& ident) { return GetB32Address(ident); }

--- a/net-misc/i2pd/files/i2pd-2.6.0.confd
+++ b/net-misc/i2pd/files/i2pd-2.6.0.confd
@@ -1,0 +1,9 @@
+I2PD_USER="${I2PD_USER:-i2pd}"
+I2PD_GROUP="${I2PD_GROUP:-i2pd}"
+I2PD_LOG="/var/log/i2pd.log"
+I2PD_PID="/var/run/i2pd.pid"
+I2PD_CFGDIR="/etc/i2pd/"
+# Options to i2pd
+I2PDOPTIONS="--daemon --service --pidfile=${I2PD_PID} \
+--log=file --logfile=${I2PD_LOG} \
+--conf=${I2PD_CFGDIR}i2pd.conf --tunconf=${I2PD_CFGDIR}tunnels.conf"

--- a/net-misc/i2pd/files/i2pd-2.6.0.initd
+++ b/net-misc/i2pd/files/i2pd-2.6.0.initd
@@ -1,0 +1,26 @@
+#!/sbin/runscript
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+description="C++ daemon for accessing the I2P network"
+
+depend() {
+	use dns logger netmount
+}
+
+start() {
+        ebegin "Starting ${SVCNAME}"
+        checkpath -f "${I2PD_LOG}" -o "${I2PD_USER}:${I2PD_GROUP}"
+        checkpath -f "${I2PD_PID}" -o "${I2PD_USER}:${I2PD_GROUP}"
+        start-stop-daemon -S -u "${I2PD_USER}:${I2PD_GROUP}" /usr/bin/i2pd -- ${I2PDOPTIONS}
+        sleep 1
+        [ -e "$I2PD_PID" -a -e /proc/$(cat "$I2PD_PID") ]
+        eend $?
+}
+
+stop() {
+        ebegin "Stopping ${SVCNAME}"
+        start-stop-daemon -K -p "${I2PD_PID}" -R SIGTERM/20 SIGKILL/20 -P
+        eend $?
+}

--- a/net-misc/i2pd/files/i2pd-2.6.0.service
+++ b/net-misc/i2pd/files/i2pd-2.6.0.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=C++ daemon for accessing the I2P network
+After=network.target
+
+[Service]
+Type=forking
+Restart=on-abnormal
+PIDFile=/var/run/i2pd.pid
+User=i2pd
+Group=i2pd
+PermissionsStartOnly=yes
+ExecStartPre=/bin/touch /var/run/i2pd.pid /var/log/i2pd.log
+ExecStartPre=/bin/chown i2pd:i2pd /var/run/i2pd.pid /var/log/i2pd.log
+ExecStart=/usr/bin/i2pd --daemon --service --pidfile=/var/run/i2pd.pid --log=file --logfile=/var/log/i2pd.log --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf
+
+[Install]
+WantedBy=multi-user.target
+

--- a/net-misc/i2pd/i2pd-2.6.0.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0.ebuild
@@ -35,7 +35,6 @@ CMAKE_USE_DIR="${S}/build"
 
 src_prepare() {
 	eapply "${FILESDIR}/${PN}-2.5.1-fix_installed_components.patch"
-	eapply "${FILESDIR}/${PN}-2.5.1-disable_ipv6_in_i2pd_conf.patch"
 	eapply_user
 }
 
@@ -64,7 +63,7 @@ src_install() {
 	fperms 700 /var/lib/i2pd/
 	dodir "/etc/${PN}"
 	insinto "/etc/${PN}"
-	doins "${S}/debian/${PN}.conf"
+	doins "${S}/docs/${PN}.conf"
 	doins "${S}/debian/subscriptions.txt"
 	doins "${S}/debian/tunnels.conf"
 	dodir /usr/share/i2pd

--- a/net-misc/i2pd/i2pd-2.6.0.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0.ebuild
@@ -69,7 +69,7 @@ src_install() {
 	doins "${S}/debian/tunnels.conf"
 	dodir /usr/share/i2pd
 	newconfd "${FILESDIR}/${PN}-2.6.0.confd" "${PN}"
-	newinitd "${FILESDIR}/${PN}-2.5.1.initd" "${PN}"
+	newinitd "${FILESDIR}/${PN}-2.6.0.initd" "${PN}"
 	systemd_newunit "${FILESDIR}/${PN}-2.6.0.service" "${PN}.service"
 	doenvd "${FILESDIR}/99${PN}"
 	insinto /etc/logrotate.d

--- a/net-misc/i2pd/i2pd-2.6.0.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0.ebuild
@@ -55,7 +55,6 @@ src_configure() {
 src_install() {
 	cmake-utils_src_install
 	dodoc README.md
-	doman "${FILESDIR}/${PN}.1"
 	keepdir /var/lib/i2pd/
 	insinto "/var/lib/i2pd"
 	doins -r "${S}/contrib/certificates"

--- a/net-misc/i2pd/i2pd-2.6.0.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0.ebuild
@@ -35,6 +35,7 @@ CMAKE_USE_DIR="${S}/build"
 
 src_prepare() {
 	eapply "${FILESDIR}/${PN}-2.5.1-fix_installed_components.patch"
+	eapply "${FILESDIR}/${PN}-2.6.0-fix_incomplete_hosts.patch"
 	eapply_user
 }
 

--- a/net-misc/i2pd/i2pd-2.6.0.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0.ebuild
@@ -13,14 +13,14 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE="cpu_flags_x86_aes i2p-hardening libressl pch static +upnp"
 
-RDEPEND="!static? ( >=dev-libs/boost-1.46[threads]
+RDEPEND="!static? ( >=dev-libs/boost-1.49[threads]
 			dev-libs/crypto++
 			!libressl? ( dev-libs/openssl:0 )
 			libressl? ( dev-libs/libressl )
 			upnp? ( net-libs/miniupnpc )
 		)"
 DEPEND="${RDEPEND}
-	static? ( >=dev-libs/boost-1.46[static-libs,threads]
+	static? ( >=dev-libs/boost-1.49[static-libs,threads]
 		dev-libs/crypto++[static-libs]
 		!libressl? ( dev-libs/openssl:0[-bindist,static-libs] )
 		libressl? ( dev-libs/libressl[static-libs] )

--- a/net-misc/i2pd/i2pd-2.6.0.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0.ebuild
@@ -66,20 +66,20 @@ src_install() {
 	insinto "/etc/${PN}"
 	doins "${S}/debian/${PN}.conf"
 	doins "${S}/debian/subscriptions.txt"
-	doins "${FILESDIR}/tunnels.cfg"
+	doins "${S}/debian/tunnels.conf"
 	dodir /usr/share/i2pd
-	newconfd "${FILESDIR}/${PN}-2.5.1.confd" "${PN}"
+	newconfd "${FILESDIR}/${PN}-2.6.0.confd" "${PN}"
 	newinitd "${FILESDIR}/${PN}-2.5.1.initd" "${PN}"
-	systemd_newunit "${FILESDIR}/${PN}-2.5.1.service" "${PN}.service"
+	systemd_newunit "${FILESDIR}/${PN}-2.6.0.service" "${PN}.service"
 	doenvd "${FILESDIR}/99${PN}"
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}-2.5.0.logrotate" "${PN}"
 	fowners "${I2PD_USER}:${I2PD_GROUP}" "/etc/${PN}/${PN}.conf" \
 		"/etc/${PN}/subscriptions.txt" \
-		"/etc/${PN}/tunnels.cfg"
+		"/etc/${PN}/tunnels.conf"
 	fperms 600 "/etc/${PN}/${PN}.conf" \
 		"/etc/${PN}/subscriptions.txt" \
-		"/etc/${PN}/tunnels.cfg"
+		"/etc/${PN}/tunnels.conf"
 }
 
 pkg_setup() {


### PR DESCRIPTION
Hi, I suggest four small patches for the current ebuild in the tree.

1. renames tunnels.cfg to tunnels.conf, following upstream, and switches to default tunnels.conf, provided by upstream
2. removes -p option from start-stop-daemon in /etc/init.d/i2pd. with this option the daemon's state after start was "crashed". The daemon takes care of the pidfile, and we manually verify in the ebuild that the pid file has been created anyway.
3. switch to more recent and detailed upstream i2pd.conf. With this, patch that removes the invalid ipv6 line from the previous config file is not needed any more. Note that currently ipv6 is enabled by default in upstream config.
4. backport patch https://github.com/PurpleI2P/i2pd/commit/5c877de2c2f954c27471092fff73443a1c9af9d4 from upstream, which fixes a problem with addressbook. The problem caused no websites available on fresh installs. Discussion in Russian here: https://github.com/PurpleI2P/i2pd/issues/377

I kept all the changes in the same i2pd-2.6.0.ebuild, not sure if I should have created many revisions instead.