### PR TITLE
dev-util/trinity: src_configure() no longer needed

### DIFF
--- a/dev-util/trinity/trinity-9999.ebuild
+++ b/dev-util/trinity/trinity-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit toolchain-funcs git-r3
 
@@ -24,10 +24,6 @@ src_prepare() {
 		-i Makefile || die
 
 	tc-export CC
-}
-
-src_configure() {
-	./configure.sh || die
 }
 
 src_compile() {


### PR DESCRIPTION
due to upstream commit b91a4ef77da which changed filename from
configure.sh to configure

bump EAPI=6

update Copyright

Signed-off-by: Toralf Förster <toralf.foerster@gmx.de>