### PR TITLE
net-misc/i2pd: revbump 2.6.0: housecleaning

### DIFF
--- a/net-misc/i2pd/files/i2pd-2.6.0.confd
+++ b/net-misc/i2pd/files/i2pd-2.6.0.confd
@@ -1,0 +1,9 @@
+I2PD_USER="${I2PD_USER:-i2pd}"
+I2PD_GROUP="${I2PD_GROUP:-i2pd}"
+I2PD_LOG="/var/log/i2pd.log"
+I2PD_PID="/var/run/i2pd.pid"
+I2PD_CFGDIR="/etc/i2pd/"
+# Options to i2pd
+I2PDOPTIONS="--daemon --service --pidfile=${I2PD_PID} \
+--log=file --logfile=${I2PD_LOG} \
+--conf=${I2PD_CFGDIR}i2pd.conf --tunconf=${I2PD_CFGDIR}tunnels.conf"

--- a/net-misc/i2pd/files/i2pd-2.6.0.service
+++ b/net-misc/i2pd/files/i2pd-2.6.0.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=C++ daemon for accessing the I2P network
+After=network.target
+
+[Service]
+Type=forking
+Restart=on-abnormal
+PIDFile=/var/run/i2pd.pid
+User=i2pd
+Group=i2pd
+PermissionsStartOnly=yes
+ExecStartPre=/bin/touch /var/run/i2pd.pid /var/log/i2pd.log
+ExecStartPre=/bin/chown i2pd:i2pd /var/run/i2pd.pid /var/log/i2pd.log
+ExecStart=/usr/bin/i2pd --daemon --service --pidfile=/var/run/i2pd.pid --log=file --logfile=/var/log/i2pd.log --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf
+
+[Install]
+WantedBy=multi-user.target
+

--- a/net-misc/i2pd/i2pd-2.6.0-r1.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r1.ebuild
@@ -13,14 +13,14 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE="cpu_flags_x86_aes i2p-hardening libressl pch static +upnp"
 
-RDEPEND="!static? ( >=dev-libs/boost-1.46[threads]
+RDEPEND="!static? ( >=dev-libs/boost-1.49[threads]
 			dev-libs/crypto++
 			!libressl? ( dev-libs/openssl:0 )
 			libressl? ( dev-libs/libressl )
 			upnp? ( net-libs/miniupnpc )
 		)"
 DEPEND="${RDEPEND}
-	static? ( >=dev-libs/boost-1.46[static-libs,threads]
+	static? ( >=dev-libs/boost-1.49[static-libs,threads]
 		dev-libs/crypto++[static-libs]
 		!libressl? ( dev-libs/openssl:0[-bindist,static-libs] )
 		libressl? ( dev-libs/libressl[static-libs] )
@@ -35,7 +35,6 @@ CMAKE_USE_DIR="${S}/build"
 
 src_prepare() {
 	eapply "${FILESDIR}/${PN}-2.5.1-fix_installed_components.patch"
-	eapply "${FILESDIR}/${PN}-2.5.1-disable_ipv6_in_i2pd_conf.patch"
 	eapply_user
 }
 
@@ -55,7 +54,6 @@ src_configure() {
 src_install() {
 	cmake-utils_src_install
 	dodoc README.md
-	doman "${FILESDIR}/${PN}.1"
 	keepdir /var/lib/i2pd/
 	insinto "/var/lib/i2pd"
 	doins -r "${S}/contrib/certificates"
@@ -64,22 +62,22 @@ src_install() {
 	fperms 700 /var/lib/i2pd/
 	dodir "/etc/${PN}"
 	insinto "/etc/${PN}"
-	doins "${S}/debian/${PN}.conf"
+	doins "${S}/docs/${PN}.conf"
 	doins "${S}/debian/subscriptions.txt"
-	doins "${FILESDIR}/tunnels.cfg"
+	doins "${S}/debian/tunnels.conf"
 	dodir /usr/share/i2pd
-	newconfd "${FILESDIR}/${PN}-2.5.1.confd" "${PN}"
+	newconfd "${FILESDIR}/${PN}-2.6.0.confd" "${PN}"
 	newinitd "${FILESDIR}/${PN}-2.5.1.initd" "${PN}"
-	systemd_newunit "${FILESDIR}/${PN}-2.5.1.service" "${PN}.service"
+	systemd_newunit "${FILESDIR}/${PN}-2.6.0.service" "${PN}.service"
 	doenvd "${FILESDIR}/99${PN}"
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}-2.5.0.logrotate" "${PN}"
 	fowners "${I2PD_USER}:${I2PD_GROUP}" "/etc/${PN}/${PN}.conf" \
 		"/etc/${PN}/subscriptions.txt" \
-		"/etc/${PN}/tunnels.cfg"
+		"/etc/${PN}/tunnels.conf"
 	fperms 600 "/etc/${PN}/${PN}.conf" \
 		"/etc/${PN}/subscriptions.txt" \
-		"/etc/${PN}/tunnels.cfg"
+		"/etc/${PN}/tunnels.conf"
 }
 
 pkg_setup() {


### PR DESCRIPTION
net-misc/i2pd: revbump 2.6.0: housecleaning

- rename tunnels.cfg to tunnels.conf, and switch to upstream version
- use docs/i2pd.conf instead of debian/i2pd.conf, patch disabling ipv6 is no longer needed
- remove the man page as obsolete; no replacement found
- update required boost version

@blueness : please don't merge until i've finished build- and runtesting
@khumarahn 