### PR TITLE
dev-util/trinity: add missing eapply_user

### DIFF
--- a/dev-util/trinity/trinity-9999.ebuild
+++ b/dev-util/trinity/trinity-9999.ebuild
@@ -24,6 +24,7 @@ src_prepare() {
 		-i Makefile || die
 
 	tc-export CC
+	eapply_user
 }
 
 src_compile() {


### PR DESCRIPTION
the EAPI=6 bump in commit fa94229 missed that change

Signed-off-by: Toralf Förster <toralf.foerster@gmx.de>