### PR TITLE
dev-util/trinity: add "default" to src_prepare()

### DIFF
--- a/dev-util/trinity/trinity-9999.ebuild
+++ b/dev-util/trinity/trinity-9999.ebuild
@@ -24,6 +24,7 @@ src_prepare() {
 		-i Makefile || die
 
 	tc-export CC
+	default
 }
 
 src_compile() {


### PR DESCRIPTION
accidently missed in the EAPI=6 bump of commit fa94229

Signed-off-by: Toralf Förster <toralf.foerster@gmx.de>