### PR TITLE
net-ftp/lftp: Add LibreSSL Support

### DIFF
--- a/net-ftp/lftp/lftp-4.7.2.ebuild
+++ b/net-ftp/lftp/lftp-4.7.2.ebuild
@@ -13,13 +13,9 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~sparc-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 
-IUSE="convert-mozilla-cookies +gnutls idn ipv6 nls openssl socks5 +ssl verify-file"
+IUSE="convert-mozilla-cookies +gnutls idn ipv6 libressl nls socks5 +ssl verify-file"
 LFTP_LINGUAS=( cs de es fr it ja ko pl pt_BR ru uk zh_CN zh_HK zh_TW )
 IUSE+=" ${LFTP_LINGUAS[@]/#/linguas_}"
-
-REQUIRED_USE="
-	ssl? ( ^^ ( openssl gnutls ) )
-"
 
 RDEPEND="
 	>=sys-libs/ncurses-5.1:=
@@ -34,7 +30,10 @@ RDEPEND="
 	)
 	ssl? (
 		gnutls? ( >=net-libs/gnutls-1.2.3:0= )
-		openssl? ( dev-libs/openssl:0= )
+		!gnutls? (
+			!libressl? ( dev-libs/openssl:0= )
+			libressl? ( dev-libs/libressl:0= )
+		)
 	)
 	verify-file? (
 		dev-perl/String-CRC32
@@ -71,10 +70,10 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_enable nls) \
-		$(use_with gnutls) \
+		$(usex ssl "$(use_with gnutls)" '--without-gnutls') \
 		$(use_with idn libidn) \
 		$(use_enable ipv6) \
-		$(use_with openssl openssl "${EPREFIX}"/usr) \
+		$(usex ssl "$(use_with !gnutls openssl ${EPREFIX}/usr)" '--without-openssl') \
 		$(use_with socks5 socksdante "${EPREFIX}"/usr) \
 		--enable-packager-mode \
 		--sysconfdir="${EPREFIX}"/etc/${PN} \

--- a/net-ftp/lftp/lftp-9999.ebuild
+++ b/net-ftp/lftp/lftp-9999.ebuild
@@ -13,13 +13,9 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS=""
 
-IUSE="convert-mozilla-cookies +gnutls idn nls openssl socks5 +ssl verify-file"
+IUSE="convert-mozilla-cookies +gnutls idn libressl nls socks5 +ssl verify-file"
 LFTP_LINGUAS=( cs de es fr it ja ko pl pt_BR ru uk zh_CN zh_HK zh_TW )
 IUSE+=" ${LFTP_LINGUAS[@]/#/linguas_}"
-
-REQUIRED_USE="
-	ssl? ( ^^ ( openssl gnutls ) )
-"
 
 RDEPEND="
 	>=sys-libs/ncurses-5.1:=
@@ -34,7 +30,10 @@ RDEPEND="
 	)
 	ssl? (
 		gnutls? ( >=net-libs/gnutls-1.2.3:= )
-		openssl? ( dev-libs/openssl:0= )
+		!gnutls? (
+			!libressl? ( dev-libs/openssl:0= )
+			libressl? ( dev-libs/libressl:0= )
+		)
 	)
 	verify-file? (
 		dev-perl/String-CRC32
@@ -71,9 +70,9 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_enable nls) \
-		$(use_with gnutls) \
+		$(usex ssl "$(use_with gnutls)" '--without-gnutls') \
 		$(use_with idn libidn) \
-		$(use_with openssl openssl "${EPREFIX}"/usr) \
+		$(usex ssl "$(use_with !gnutls openssl ${EPREFIX}/usr)" '--without-openssl') \
 		$(use_with socks5 socksdante "${EPREFIX}"/usr) \
 		--enable-packager-mode \
 		--sysconfdir="${EPREFIX}"/etc/${PN} \


### PR DESCRIPTION
Adds LibreSSL support to net-ftp/lftp ebuild and rearranges use flags so
the ssl use flag implies a LibreSSL or OpenSSL dependency, and the gnutls
use flag does not require the ssl use flag.

Fixes Gentoo Bug 565388.