### PR TITLE
media-video/mpv: add missing mesa[egl,gles2] dep for RPI to 9999

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -90,7 +90,10 @@ COMMON_DEPEND="
 	openal? ( >=media-libs/openal-1.13 )
 	opengl? ( !aqua? ( virtual/opengl ) )
 	pulseaudio? ( media-sound/pulseaudio )
-	raspberry-pi? ( >=media-libs/raspberrypi-userland-0_pre20160305-r1 )
+	raspberry-pi? (
+		>=media-libs/raspberrypi-userland-0_pre20160305-r1
+		media-libs/mesa[egl,gles2]
+	)
 	rubberband? ( >=media-libs/rubberband-1.8.0 )
 	samba? ( net-fs/samba )
 	sdl? ( media-libs/libsdl2[sound,threads,video,X?,wayland?] )


### PR DESCRIPTION
Package-Manager: portage-2.2.28