### PR TITLE
net-misc/i2pd: updates to daemon handling

### DIFF
--- a/net-misc/i2pd/files/i2pd-2.6.0-r2.confd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r2.confd
@@ -1,0 +1,9 @@
+I2PD_USER="${I2PD_USER:-i2pd}"
+I2PD_GROUP="${I2PD_GROUP:-i2pd}"
+I2PD_LOG="/var/log/i2pd.log"
+I2PD_PID="/var/run/i2pd.pid"
+I2PD_CFGDIR="/etc/i2pd/"
+# Options to i2pd
+I2PDOPTIONS="--daemon --service --pidfile=${I2PD_PID} \
+--log=file --logfile=${I2PD_LOG} \
+--conf=${I2PD_CFGDIR}i2pd.conf --tunconf=${I2PD_CFGDIR}tunnels.conf"

--- a/net-misc/i2pd/files/i2pd-2.6.0-r2.confd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r2.confd
@@ -1,10 +1,9 @@
 I2PD_USER="${I2PD_USER:-i2pd}"
 I2PD_GROUP="${I2PD_GROUP:-i2pd}"
 I2PD_LOG="/var/log/i2pd.log"
-I2PD_PID_DIR="/run/i2pd/"
 I2PD_PID="/run/i2pd/i2pd.pid"
-I2PD_CFGDIR="/etc/i2pd/"
+
 # Options to i2pd
-I2PDOPTIONS="--daemon --service --pidfile=${I2PD_PID} \
+I2PD_OPTIONS="--daemon --service --pidfile=${I2PD_PID} \
 --log=file --logfile=${I2PD_LOG} \
---conf=${I2PD_CFGDIR}i2pd.conf --tunconf=${I2PD_CFGDIR}tunnels.conf"
+--conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf"

--- a/net-misc/i2pd/files/i2pd-2.6.0-r2.confd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r2.confd
@@ -1,7 +1,8 @@
 I2PD_USER="${I2PD_USER:-i2pd}"
 I2PD_GROUP="${I2PD_GROUP:-i2pd}"
 I2PD_LOG="/var/log/i2pd.log"
-I2PD_PID="/var/run/i2pd.pid"
+I2PD_PID_DIR="/run/i2pd/"
+I2PD_PID="/run/i2pd/i2pd.pid"
 I2PD_CFGDIR="/etc/i2pd/"
 # Options to i2pd
 I2PDOPTIONS="--daemon --service --pidfile=${I2PD_PID} \

--- a/net-misc/i2pd/files/i2pd-2.6.0-r2.initd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r2.initd
@@ -1,0 +1,26 @@
+#!/sbin/runscript
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+description="C++ daemon for accessing the I2P network"
+
+depend() {
+	use dns logger netmount
+}
+
+start() {
+        ebegin "Starting ${SVCNAME}"
+        checkpath -f "${I2PD_LOG}" -o "${I2PD_USER}:${I2PD_GROUP}"
+        checkpath -f "${I2PD_PID}" -o "${I2PD_USER}:${I2PD_GROUP}"
+        start-stop-daemon -S -u "${I2PD_USER}:${I2PD_GROUP}" -p "${I2PD_PID}.pid" /usr/bin/i2pd -- ${I2PDOPTIONS}
+        sleep 1
+        [ -e "$I2PD_PID" -a -e /proc/$(cat "$I2PD_PID") ]
+        eend $?
+}
+
+stop() {
+        ebegin "Stopping ${SVCNAME}"
+        start-stop-daemon -K -p "${I2PD_PID}" -R SIGTERM/20 SIGKILL/20 -P
+        eend $?
+}

--- a/net-misc/i2pd/files/i2pd-2.6.0-r2.initd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r2.initd
@@ -1,38 +1,46 @@
-#!/sbin/runscript
-# Copyright 1999-2014 Gentoo Foundation
+#!/sbin/openrc-run
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 description="C++ daemon for accessing the I2P network"
 description_graceful="Graceful shutdown, takes 10 minutes"
 
+command="/usr/bin/i2pd"
+command_args="${I2PD_OPTIONS}"
+user="${I2PD_USER}:${I2PD_GROUP}"
+start_stop_daemon_args="
+    --user \"${user}\"
+    --pidfile \"${I2PD_PID}\"
+    --progress --retry 'SIGTERM/20 SIGKILL/20'
+"
+I2PD_PID_DIR=$(dirname "${I2PD_PID}")
+
 extra_started_commands="graceful"
 
 depend() {
-	use dns logger netmount
+    use dns logger netmount
 }
 
-start() {
-        ebegin "Starting ${SVCNAME}"
-        checkpath -f "${I2PD_LOG}" -o "${I2PD_USER}:${I2PD_GROUP}"
-        checkpath -d -m 0750 -o "${I2PD_USER}:${I2PD_GROUP}" "${I2PD_PID_DIR}"
-        start-stop-daemon --start --user "${I2PD_USER}:${I2PD_GROUP}" --pidfile "${I2PD_PID}" \
-                --exec /usr/bin/i2pd -- ${I2PDOPTIONS}
-        eend $?
-}
-
-stop() {
-        ebegin "Stopping ${SVCNAME}"
-        start-stop-daemon --stop --user "${I2PD_USER}:${I2PD_GROUP}" --pidfile "${I2PD_PID}" \
-                --exec /usr/bin/i2pd --retry SIGTERM/20 SIGKILL/20 --progress
-        eend $?
+start_pre() {
+    if [ -z "${I2PD_USER}" ] || \
+       [ -z "${I2PD_GROUP}" ] || \
+       [ -z "${I2PD_PID}" ] || \
+       [ -z "${I2PD_LOG}" ] || \
+       [ -z "${I2PD_OPTIONS}" ] ; then
+        eerror "Not all variables I2PD_USER, I2PD_GROUP, I2PD_PID, I2PD_OPTIONS, I2PD_LOG are defined."
+        eerror "Check your /etc/conf.d/i2pd."
+        return 1
+    fi
+    checkpath -f -o "${user}" "${I2PD_LOG}"
+    checkpath -d -m 0750 -o "${user}" "${I2PD_PID_DIR}"
 }
 
 graceful() {
-        # on SIGINT, i2pd stops accepting tunnels and shuts down in 600 seconds 
-        ebegin "Gracefully stopping i2pd, this takes 10 minutes"
-        mark_service_stopping
-        start-stop-daemon --stop --user "${I2PD_USER}:${I2PD_GROUP}" --pidfile "${I2PD_PID}" \
-                --exec /usr/bin/i2pd --retry SIGINT/620 SIGTERM/20 SIGKILL/20 --progress
-        eend $? && mark_service_stopped
+    # on SIGINT, i2pd stops accepting tunnels and shuts down in 600 seconds
+    ebegin "Gracefully stopping i2pd, this takes 10 minutes"
+    mark_service_stopping
+    eval start-stop-daemon --stop ${start_stop_daemon_args} \
+        --exec "${command}" --retry 'SIGINT/620 SIGTERM/20 SIGKILL/20'
+    eend $? && mark_service_stopped
 }

--- a/net-misc/i2pd/files/i2pd-2.6.0-r2.initd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r2.initd
@@ -4,6 +4,9 @@
 # $Id$
 
 description="C++ daemon for accessing the I2P network"
+description_graceful="Graceful shutdown, takes 10 minutes"
+
+extra_started_commands="graceful"
 
 depend() {
 	use dns logger netmount
@@ -12,15 +15,24 @@ depend() {
 start() {
         ebegin "Starting ${SVCNAME}"
         checkpath -f "${I2PD_LOG}" -o "${I2PD_USER}:${I2PD_GROUP}"
-        checkpath -f "${I2PD_PID}" -o "${I2PD_USER}:${I2PD_GROUP}"
-        start-stop-daemon -S -u "${I2PD_USER}:${I2PD_GROUP}" -p "${I2PD_PID}.pid" /usr/bin/i2pd -- ${I2PDOPTIONS}
-        sleep 1
-        [ -e "$I2PD_PID" -a -e /proc/$(cat "$I2PD_PID") ]
+        checkpath -d -m 0750 -o "${I2PD_USER}:${I2PD_GROUP}" "${I2PD_PID_DIR}"
+        start-stop-daemon --start --user "${I2PD_USER}:${I2PD_GROUP}" --pidfile "${I2PD_PID}" \
+                --exec /usr/bin/i2pd -- ${I2PDOPTIONS}
         eend $?
 }
 
 stop() {
         ebegin "Stopping ${SVCNAME}"
-        start-stop-daemon -K -p "${I2PD_PID}" -R SIGTERM/20 SIGKILL/20 -P
+        start-stop-daemon --stop --user "${I2PD_USER}:${I2PD_GROUP}" --pidfile "${I2PD_PID}" \
+                --exec /usr/bin/i2pd --retry SIGTERM/20 SIGKILL/20 --progress
         eend $?
+}
+
+graceful() {
+        # on SIGINT, i2pd stops accepting tunnels and shuts down in 600 seconds 
+        ebegin "Gracefully stopping i2pd, this takes 10 minutes"
+        mark_service_stopping
+        start-stop-daemon --stop --user "${I2PD_USER}:${I2PD_GROUP}" --pidfile "${I2PD_PID}" \
+                --exec /usr/bin/i2pd --retry SIGINT/620 SIGTERM/20 SIGKILL/20 --progress
+        eend $? && mark_service_stopped
 }

--- a/net-misc/i2pd/files/i2pd-2.6.0-r2.service
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r2.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=C++ daemon for accessing the I2P network
+After=network.target
+
+[Service]
+Type=forking
+Restart=on-abnormal
+PIDFile=/var/run/i2pd.pid
+User=i2pd
+Group=i2pd
+PermissionsStartOnly=yes
+ExecStartPre=/bin/touch /var/run/i2pd.pid /var/log/i2pd.log
+ExecStartPre=/bin/chown i2pd:i2pd /var/run/i2pd.pid /var/log/i2pd.log
+ExecStart=/usr/bin/i2pd --daemon --service --pidfile=/var/run/i2pd.pid --log=file --logfile=/var/log/i2pd.log --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf
+
+[Install]
+WantedBy=multi-user.target
+

--- a/net-misc/i2pd/files/i2pd-2.6.0-r2.service
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r2.service
@@ -5,13 +5,15 @@ After=network.target
 [Service]
 Type=forking
 Restart=on-abnormal
-PIDFile=/var/run/i2pd.pid
+PIDFile=/run/i2pd/i2pd.pid
 User=i2pd
 Group=i2pd
 PermissionsStartOnly=yes
-ExecStartPre=/bin/touch /var/run/i2pd.pid /var/log/i2pd.log
-ExecStartPre=/bin/chown i2pd:i2pd /var/run/i2pd.pid /var/log/i2pd.log
-ExecStart=/usr/bin/i2pd --daemon --service --pidfile=/var/run/i2pd.pid --log=file --logfile=/var/log/i2pd.log --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf
+ExecStartPre=/bin/mkdir -p /run/i2pd
+ExecStartPre=/bin/chown i2pd:i2pd /run/i2pd
+ExecStartPre=/bin/touch /run/i2pd/i2pd.pid /var/log/i2pd.log
+ExecStartPre=/bin/chown i2pd:i2pd /run/i2pd/i2pd.pid /var/log/i2pd.log
+ExecStart=/usr/bin/i2pd --daemon --service --pidfile=/run/i2pd/i2pd.pid --log=file --logfile=/var/log/i2pd.log --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/net-misc/i2pd/i2pd-2.6.0-r2.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r2.ebuild
@@ -1,0 +1,86 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit eutils systemd user cmake-utils
+
+DESCRIPTION="A C++ daemon for accessing the I2P anonymous network"
+HOMEPAGE="https://github.com/PurpleI2P/i2pd"
+SRC_URI="https://github.com/PurpleI2P/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="cpu_flags_x86_aes i2p-hardening libressl pch static +upnp"
+
+RDEPEND="!static? ( >=dev-libs/boost-1.49[threads]
+			dev-libs/crypto++
+			!libressl? ( dev-libs/openssl:0 )
+			libressl? ( dev-libs/libressl )
+			upnp? ( net-libs/miniupnpc )
+		)"
+DEPEND="${RDEPEND}
+	static? ( >=dev-libs/boost-1.49[static-libs,threads]
+		dev-libs/crypto++[static-libs]
+		!libressl? ( dev-libs/openssl:0[-bindist,static-libs] )
+		libressl? ( dev-libs/libressl[static-libs] )
+		upnp? ( net-libs/miniupnpc[static-libs] ) )
+	i2p-hardening? ( >=sys-devel/gcc-4.7 )
+	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"
+
+I2PD_USER="${I2PD_USER:-i2pd}"
+I2PD_GROUP="${I2PD_GROUP:-i2pd}"
+
+CMAKE_USE_DIR="${S}/build"
+
+src_prepare() {
+	eapply "${FILESDIR}/${PN}-2.5.1-fix_installed_components.patch"
+	eapply_user
+}
+
+src_configure() {
+	mycmakeargs=(
+		-DWITH_AESNI=$(usex cpu_flags_x86_aes ON OFF)
+		-DWITH_HARDENING=$(usex i2p-hardening ON OFF)
+		-DWITH_PCH=$(usex pch ON OFF)
+		-DWITH_STATIC=$(usex static ON OFF)
+		-DWITH_UPNP=$(usex upnp ON OFF)
+		-DWITH_LIBRARY=ON
+		-DWITH_BINARY=ON
+	)
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+	dodoc README.md
+	keepdir /var/lib/i2pd/
+	insinto "/var/lib/i2pd"
+	doins -r "${S}/contrib/certificates"
+	dosym /etc/i2pd/subscriptions.txt /var/lib/i2pd/subscriptions.txt
+	fowners "${I2PD_USER}:${I2PD_GROUP}" /var/lib/i2pd/
+	fperms 700 /var/lib/i2pd/
+	dodir "/etc/${PN}"
+	insinto "/etc/${PN}"
+	doins "${S}/docs/${PN}.conf"
+	doins "${S}/debian/subscriptions.txt"
+	doins "${S}/debian/tunnels.conf"
+	dodir /usr/share/i2pd
+	newconfd "${FILESDIR}/${PN}-2.6.0.confd" "${PN}"
+	newinitd "${FILESDIR}/${PN}-2.5.1.initd" "${PN}"
+	systemd_newunit "${FILESDIR}/${PN}-2.6.0.service" "${PN}.service"
+	doenvd "${FILESDIR}/99${PN}"
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}/${PN}-2.5.0.logrotate" "${PN}"
+	fowners "${I2PD_USER}:${I2PD_GROUP}" "/etc/${PN}/${PN}.conf" \
+		"/etc/${PN}/subscriptions.txt" \
+		"/etc/${PN}/tunnels.conf"
+	fperms 600 "/etc/${PN}/${PN}.conf" \
+		"/etc/${PN}/subscriptions.txt" \
+		"/etc/${PN}/tunnels.conf"
+}
+
+pkg_setup() {
+	enewgroup "${I2PD_GROUP}"
+	enewuser "${I2PD_USER}" -1 -1 "/var/lib/run/${PN}" "${I2PD_GROUP}"
+}

--- a/net-misc/i2pd/i2pd-2.6.0-r2.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r2.ebuild
@@ -66,9 +66,9 @@ src_install() {
 	doins "${S}/debian/subscriptions.txt"
 	doins "${S}/debian/tunnels.conf"
 	dodir /usr/share/i2pd
-	newconfd "${FILESDIR}/${PN}-2.6.0.confd" "${PN}"
-	newinitd "${FILESDIR}/${PN}-2.5.1.initd" "${PN}"
-	systemd_newunit "${FILESDIR}/${PN}-2.6.0.service" "${PN}.service"
+	newconfd "${FILESDIR}/${PN}-2.6.0-r2.confd" "${PN}"
+	newinitd "${FILESDIR}/${PN}-2.6.0-r2.initd" "${PN}"
+	systemd_newunit "${FILESDIR}/${PN}-2.6.0-r2.service" "${PN}.service"
 	doenvd "${FILESDIR}/99${PN}"
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}-2.5.0.logrotate" "${PN}"


### PR DESCRIPTION
Hi, this pull request implements graceful shutdown in openrc on
```
rc-service i2pd graceful
```
Graceful shutdown respects commitments for existing tunnels. It takes 10 minutes.

It also fixes a pid file bug in openrc. Currently openrc starts the service by
```
checkpath -f /var/run/i2pd.pid -o i2pd:i2pd
start-stop-daemon -S -u i2pd:i2pd -p /var/run/i2pd.pid /usr/bin/i2pd -- ${I2PDOPTIONS}
```
I observe that the above works as follows: the first command creates a file `/var/run/i2pd.pid` with correct permissions. The second command _deletes_ this file, starts the daemon and expects it to create the pid file. The daemon cannot create it, because it is run as `i2pd:i2pd`, and has no write access to `/var/run`. The whole thing is weird, and the daemon does not start.

I wanted to fix the pid file problem in my previous pull requests by not using `-p` option in start-stop-daemon, which worked OK, because the pid file was not deleted, but that was not accepted by the reviewer. This time I have a better solution, as I found in some other ebuilds in the tree: to create a folder `/run/i2pd` with correct permissions, and expect the daemon to create the pid file there. I tested it for both openrc and systemd, seems to work well.

I updated systemd service for compatibility, so that pid file is the same as in openrc. Also I made some cosmetic changes, like using longer names for start-stop-daemon options, and using more matching options in stopping routines, and migrating from `/var/run` to `/run`.