### PR TITLE
x11-misc/bumblebee: Fix when unloading nvidia.

### DIFF
--- a/x11-drivers/nvidia-drivers/files/nvidia-rmmod.conf
+++ b/x11-drivers/nvidia-drivers/files/nvidia-rmmod.conf
@@ -1,3 +1,3 @@
 # Nvidia UVM support
 
-remove nvidia modprobe -r --ignore-remove nvidia-modeset nvidia-uvm nvidia
+remove nvidia modprobe -r --ignore-remove nvidia-drm nvidia-modeset nvidia-uvm nvidia

--- a/x11-misc/bumblebee/bumblebee-3.2.1.ebuild
+++ b/x11-misc/bumblebee/bumblebee-3.2.1.ebuild
@@ -31,6 +31,10 @@ DEPEND="${RDEPEND}
 
 REQUIRED_USE="|| ( video_cards_nouveau video_cards_nvidia )"
 
+src_prepare() {
+	epatch "${FILESDIR}/nvidia-modprobe.patch"
+}
+
 src_configure() {
 	DOC_CONTENTS="In order to use Bumblebee, add your user to 'bumblebee' group.
 		You may need to setup your /etc/bumblebee/bumblebee.conf"

--- a/x11-misc/bumblebee/files/nvidia-modprobe.patch
+++ b/x11-misc/bumblebee/files/nvidia-modprobe.patch
@@ -1,0 +1,14 @@
+diff --git a/src/module.c b/src/module.c
+index f7b99fa..f6d7144 100644
+--- a/src/module.c
++++ b/src/module.c
+@@ -96,7 +96,8 @@ int module_unload(char *driver) {
+     int retries = 30;
+     bb_log(LOG_INFO, "Unloading %s driver\n", driver);
+     char *mod_argv[] = {
+-      "rmmod",
++      "modprobe",
++      "-r",
+       driver,
+       NULL
+     };


### PR DESCRIPTION
Proposing fix for bumblebee, because this project updates very rarely, I propose the same patch proposed under https://github.com/Bumblebee-Project/Bumblebee/pull/751

This fixes nvidia unloading correctly when bumblebee stops rendering a primus/optimus offload.