### PR TITLE
net-misc/i2pd: update ownership of configs in /etc/i2pd and housecleaning

### DIFF
--- a/net-misc/i2pd/files/i2pd-2.6.0-r3.logrotate
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r3.logrotate
@@ -1,0 +1,11 @@
+/var/log/i2pd.log {
+        rotate 4
+        weekly
+        missingok
+        notifempty
+        create 640 i2pd i2pd
+        postrotate
+                /bin/kill -HUP $(cat /run/i2pd/i2pd.pid)
+        endscript
+}
+

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -65,7 +65,6 @@ src_install() {
 	doins "${S}/docs/${PN}.conf"
 	doins "${S}/debian/subscriptions.txt"
 	doins "${S}/debian/tunnels.conf"
-	dodir /usr/share/i2pd
 	newconfd "${FILESDIR}/${PN}-2.6.0-r2.confd" "${PN}"
 	newinitd "${FILESDIR}/${PN}-2.6.0-r2.initd" "${PN}"
 	systemd_newunit "${FILESDIR}/${PN}-2.6.0-r2.service" "${PN}.service"

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -72,12 +72,6 @@ src_install() {
 	doenvd "${FILESDIR}/99${PN}"
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}-2.5.0.logrotate" "${PN}"
-	fowners "${I2PD_USER}:${I2PD_GROUP}" "/etc/${PN}/${PN}.conf" \
-		"/etc/${PN}/subscriptions.txt" \
-		"/etc/${PN}/tunnels.conf"
-	fperms 600 "/etc/${PN}/${PN}.conf" \
-		"/etc/${PN}/subscriptions.txt" \
-		"/etc/${PN}/tunnels.conf"
 }
 
 pkg_setup() {

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -28,8 +28,8 @@ DEPEND="${RDEPEND}
 	i2p-hardening? ( >=sys-devel/gcc-4.7 )
 	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"
 
-I2PD_USER="${I2PD_USER:-i2pd}"
-I2PD_GROUP="${I2PD_GROUP:-i2pd}"
+I2PD_USER=i2pd
+I2PD_GROUP=i2pd
 
 CMAKE_USE_DIR="${S}/build"
 
@@ -53,27 +53,38 @@ src_configure() {
 
 src_install() {
 	cmake-utils_src_install
+
+	# config
+	insinto "/etc/i2pd"
+	doins "${S}/docs/i2pd.conf"
+	doins "${S}/debian/subscriptions.txt"
+	doins "${S}/debian/tunnels.conf"
+
+	# doc
 	dodoc README.md
+
+	# working directory
 	keepdir /var/lib/i2pd/
-	insinto "/var/lib/i2pd"
+	insinto /var/lib/i2pd
 	doins -r "${S}/contrib/certificates"
 	dosym /etc/i2pd/subscriptions.txt /var/lib/i2pd/subscriptions.txt
 	fowners "${I2PD_USER}:${I2PD_GROUP}" /var/lib/i2pd/
 	fperms 700 /var/lib/i2pd/
-	dodir "/etc/${PN}"
-	insinto "/etc/${PN}"
-	doins "${S}/docs/${PN}.conf"
-	doins "${S}/debian/subscriptions.txt"
-	doins "${S}/debian/tunnels.conf"
-	newconfd "${FILESDIR}/${PN}-2.6.0-r2.confd" "${PN}"
-	newinitd "${FILESDIR}/${PN}-2.6.0-r2.initd" "${PN}"
-	systemd_newunit "${FILESDIR}/${PN}-2.6.0-r2.service" "${PN}.service"
-	doenvd "${FILESDIR}/99${PN}"
+	
+	# add /var/lib/i2pd/certificates to CONFIG_PROTECT
+	doenvd "${FILESDIR}/99i2pd"
+
+	# openrc and systemd daemon routines
+	newconfd "${FILESDIR}/i2pd-2.6.0-r2.confd" i2pd
+	newinitd "${FILESDIR}/i2pd-2.6.0-r2.initd" i2pd
+	systemd_newunit "${FILESDIR}/i2pd-2.6.0-r2.service" i2pd.service
+	
+	# logrotate
 	insinto /etc/logrotate.d
-	newins "${FILESDIR}/${PN}-2.5.0.logrotate" "${PN}"
+	newins "${FILESDIR}/i2pd-2.5.0.logrotate" i2pd
 }
 
 pkg_setup() {
 	enewgroup "${I2PD_GROUP}"
-	enewuser "${I2PD_USER}" -1 -1 "/var/lib/run/${PN}" "${I2PD_GROUP}"
+	enewuser "${I2PD_USER}" -1 -1 /var/lib/run/i2pd "${I2PD_GROUP}"
 }

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -81,7 +81,7 @@ src_install() {
 	
 	# logrotate
 	insinto /etc/logrotate.d
-	newins "${FILESDIR}/i2pd-2.5.0.logrotate" i2pd
+	newins "${FILESDIR}/i2pd-2.6.0-r3.logrotate" i2pd
 }
 
 pkg_setup() {


### PR DESCRIPTION
Hi,

This is another update for i2pd ebuild. This time it addresses two issues, both minor:
* Config files in `/etc/i2pd` are owned by `i2pd`. I don't see a reason why the daemon may want write access to these files. I asked upstream https://github.com/PurpleI2P/i2pd/issues/469, and they say that write access is not needed.
* We create a folder `/usr/share/i2pd`, which is not used. Debian people seem to save certificates there, and create a symlink to the working folder `/var/lib/i2pd`. We save certificates directly in `/var/lib/i2pd`.

And I also tried to structure the ebuild, so that it is easier to read and maintain.

@tomboy-64, @blueness, I would appreciate any comments. I am still new in this business.