### PR TITLE
dev-java/icedtea-3: add infinality patchset

### DIFF
--- a/dev-java/icedtea/files/8-fontconfig.patch
+++ b/dev-java/icedtea/files/8-fontconfig.patch
@@ -1,0 +1,12 @@
+diff -rupN a/make/lib/Awt2dLibraries.gmk b/make/lib/Awt2dLibraries.gmk
+--- a/make/lib/Awt2dLibraries.gmk	2015-07-13 20:50:59.000000000 +0300
++++ b/make/lib/Awt2dLibraries.gmk	2015-08-24 12:12:22.930330643 +0300
+@@ -824,7 +824,7 @@
+     LDFLAGS := $(subst -Xlinker -z -Xlinker defs,,$(LDFLAGS_JDKLIB)) $(LDFLAGS_CXX_JDK) \
+         $(call SET_SHARED_LIBRARY_ORIGIN), \
+     LDFLAGS_SUFFIX := $(BUILD_LIBFONTMANAGER_FONTLIB), \
+-    LDFLAGS_SUFFIX_linux := -lawt $(LIBM) $(LIBCXX) -ljava -ljvm -lc, \
++    LDFLAGS_SUFFIX_linux := -lfontconfig -lawt $(LIBM) $(LIBCXX) -ljava -ljvm -lc, \
+     LDFLAGS_SUFFIX_solaris := -lawt -lawt_headless -lc $(LIBM) $(LIBCXX) -ljava -ljvm, \
+     LDFLAGS_SUFFIX_aix := -lawt -lawt_headless $(LIBM) $(LIBCXX) -ljava -ljvm,\
+     LDFLAGS_SUFFIX_macosx := -lawt $(LIBM) $(LIBCXX) -undefined dynamic_lookup \

--- a/dev-java/icedtea/files/8-infinality.patch
+++ b/dev-java/icedtea/files/8-infinality.patch
@@ -1,0 +1,259 @@
+diff -rupN a/src/share/native/sun/font/freetypeScaler.c b/src/share/native/sun/font/freetypeScaler.c
+--- a/src/share/native/sun/font/freetypeScaler.c	2014-09-14 16:28:06.108295959 +0200
++++ b/src/share/native/sun/font/freetypeScaler.c	2014-09-14 16:28:45.569693174 +0200
+@@ -23,6 +23,9 @@
+  * questions.
+  */
+ 
++/* Use Infinality patches as default */
++#define INFINALITY
++
+ #include "jni.h"
+ #include "jni_util.h"
+ #include "jlong.h"
+@@ -38,6 +41,10 @@
+ #include FT_SIZES_H
+ #include FT_OUTLINE_H
+ #include FT_SYNTHESIS_H
++#ifdef INFINALITY
++#include FT_LCD_FILTER_H
++#include <fontconfig/fontconfig.h>
++#endif
+ 
+ #include "fontscaler.h"
+ 
+@@ -676,6 +683,147 @@ static void CopyFTSubpixelVToSubpixel(co
+     }
+ }
+ 
++#ifdef INFINALITY
++typedef struct {
++    FT_Render_Mode ftRenderMode;
++    int ftLoadFlags;
++    FT_LcdFilter ftLcdFilter;
++} RenderingProperties;
++
++static FcPattern* matchedPattern(const FcChar8* family, double ptSize) {
++    /*
++      we will create pattern to find our family and size in
++      fontconfig configuration, and then will return it's
++      properties:
++    */
++    FcPattern* fcPattern = 0;
++    fcPattern = FcPatternCreate();
++    FcValue fcValue;
++    fcValue.type = FcTypeString;
++    fcValue.u.s = family;
++    FcPatternAdd(fcPattern, FC_FAMILY, fcValue, FcTrue);
++    FcPatternAddBool(fcPattern, FC_SCALABLE, FcTrue);
++    FcPatternAddDouble(fcPattern, FC_SIZE, ptSize);
++    // TODO FcPatternAddInteger(pattern, FC_WEIGHT, weight_value);
++    // TODO FcPatternAddInteger(pattern, FC_SLANT, slant_value);
++    // TODO FcPatternAddDouble(pattern, FC_PIXEL_SIZE, size_value);
++    // TODO FcPatternAddInteger(pattern, FC_WIDTH, stretch); 100 in most cases
++    FcConfigSubstitute(0, fcPattern, FcMatchPattern);
++    FcConfigSubstitute(0, fcPattern, FcMatchFont);
++    FcDefaultSubstitute(fcPattern);
++    FcResult res;
++
++    FcPattern *pattern = 0;
++    pattern = FcFontMatch(0, fcPattern, &res);
++    FcPatternDestroy(fcPattern);
++    return pattern;
++}
++
++static void readFontconfig(const FcChar8* family, double ptSize, jint aaType, RenderingProperties* rp) {
++
++    FcPattern *pattern = matchedPattern(family, ptSize);
++
++    int ftLoadFalgs = FT_LOAD_DEFAULT;
++    FT_Render_Mode ftRenderMode;
++    FT_LcdFilter ftLcdFilter;
++    char horizontal = 1;
++    FcBool b;
++
++    // subpixel order:
++    if (aaType == TEXT_AA_ON)
++        ftRenderMode = FT_RENDER_MODE_NORMAL;
++    else if (aaType == TEXT_AA_OFF)
++        ftRenderMode = FT_RENDER_MODE_MONO;
++    else if (FcPatternGetBool(pattern, FC_ANTIALIAS, 0, &b) == FcResultMatch)
++        if (b) {
++            int subpixel = FC_RGBA_UNKNOWN;
++            FcPatternGetInteger(pattern, FC_RGBA, 0, &subpixel);
++            if (subpixel == FC_RGBA_UNKNOWN)
++                subpixel = FC_RGBA_NONE;
++                switch (subpixel) {
++                case FC_RGBA_NONE:
++                    ftRenderMode = FT_RENDER_MODE_NORMAL;
++                    break;
++                case FC_RGBA_RGB:
++                case FC_RGBA_BGR:
++                    ftRenderMode = FT_RENDER_MODE_LCD;
++                    horizontal = 1;
++                    break;
++                case FC_RGBA_VRGB:
++                case FC_RGBA_VBGR:
++                    ftRenderMode = FT_RENDER_MODE_LCD_V;
++                    horizontal = 0;
++                    break;
++                default:
++                    break;
++                }
++            } else {
++                ftRenderMode = FT_RENDER_MODE_NORMAL;
++            }
++
++    // loading mode:
++    if (aaType == TEXT_AA_OFF)
++        ftLoadFalgs |= FT_LOAD_TARGET_MONO;
++    else {
++        int hint_style = FC_HINT_NONE;
++        FcPatternGetInteger(pattern, FC_HINT_STYLE, 0, &hint_style);
++        switch (hint_style) {
++        case FC_HINT_NONE:
++            ftLoadFalgs |= FT_LOAD_NO_HINTING;
++            break;
++        case FC_HINT_SLIGHT:
++            ftLoadFalgs |= FT_LOAD_TARGET_LIGHT;
++            break;
++        case FC_HINT_MEDIUM:
++            ftLoadFalgs |= FT_LOAD_TARGET_NORMAL;
++            break;
++        case FC_HINT_FULL:
++            if (aaType == TEXT_AA_ON)
++                ftLoadFalgs |= FT_LOAD_TARGET_NORMAL;
++            else
++                ftLoadFalgs |= horizontal ? FT_LOAD_TARGET_LCD : FT_LOAD_TARGET_LCD_V;
++            break;
++        default:
++            // what else to use as default?
++            ftLoadFalgs |= FT_LOAD_TARGET_NORMAL;
++            break;
++        }
++    }
++
++    // autohinting:
++    if (FcPatternGetBool(pattern, FC_AUTOHINT, 0, &b) == FcResultMatch)
++        if (b)
++            ftLoadFalgs |= FT_LOAD_FORCE_AUTOHINT;
++
++    // LCD filter:
++    int filter = FC_LCD_DEFAULT;
++    FcPatternGetInteger(pattern, FC_LCD_FILTER, 0, &filter);
++    switch (filter) {
++    case FC_LCD_NONE:
++        ftLcdFilter = FT_LCD_FILTER_NONE;
++        break;
++    case FC_LCD_DEFAULT:
++        ftLcdFilter = FT_LCD_FILTER_DEFAULT;
++        break;
++    case FC_LCD_LIGHT:
++        ftLcdFilter = FT_LCD_FILTER_LIGHT;
++        break;
++    case FC_LCD_LEGACY:
++        ftLcdFilter = FT_LCD_FILTER_LEGACY;
++        break;
++    default:
++        // new unknown lcd filter type?! will use default one:
++        ftLcdFilter = FT_LCD_FILTER_DEFAULT;
++        break;
++    }
++
++    FcPatternDestroy(pattern);
++
++    rp->ftRenderMode = ftRenderMode;
++    rp->ftLoadFlags = ftLoadFalgs;
++    rp->ftLcdFilter = ftLcdFilter;
++}
++#endif
+ 
+ /*
+  * Class:     sun_font_FreetypeFontScaler
+@@ -691,7 +839,9 @@ Java_sun_font_FreetypeFontScaler_getGlyp
+     UInt16 width, height;
+     GlyphInfo *glyphInfo;
+     int glyph_index;
++#ifndef INFINALITY
+     int renderFlags = FT_LOAD_RENDER, target;
++#endif
+     FT_GlyphSlot ftglyph;
+ 
+     FTScalerContext* context =
+@@ -709,6 +859,11 @@ Java_sun_font_FreetypeFontScaler_getGlyp
+         return ptr_to_jlong(getNullGlyphImage());
+     }
+ 
++#ifdef INFINALITY
++    RenderingProperties renderingProperties;
++    readFontconfig((const FcChar8 *) scalerInfo->face->family_name,
++                   context->ptsz, context->aaType, &renderingProperties);
++#else
+     /* if algorithmic styling is required then we do not request bitmap */
+     if (context->doBold || context->doItalize) {
+         renderFlags =  FT_LOAD_DEFAULT;
+@@ -731,10 +886,17 @@ Java_sun_font_FreetypeFontScaler_getGlyp
+         target = FT_LOAD_TARGET_LCD_V;
+     }
+     renderFlags |= target;
++#endif
+ 
+     glyph_index = FT_Get_Char_Index(scalerInfo->face, glyphCode);
+ 
++#ifdef INFINALITY
++    FT_Library_SetLcdFilter(scalerInfo->library, renderingProperties.ftLcdFilter);
++    error = FT_Load_Glyph(scalerInfo->face, glyphCode, renderingProperties.ftLoadFlags);
++#else
+     error = FT_Load_Glyph(scalerInfo->face, glyphCode, renderFlags);
++#endif
++
+     if (error) {
+         //do not destroy scaler yet.
+         //this can be problem of particular context (e.g. with bad transform)
+@@ -753,9 +915,13 @@ Java_sun_font_FreetypeFontScaler_getGlyp
+ 
+     /* generate bitmap if it is not done yet
+      e.g. if algorithmic styling is performed and style was added to outline */
++#ifdef INFINALITY
++    FT_Render_Glyph(ftglyph, renderingProperties.ftRenderMode);
++#else
+     if (ftglyph->format == FT_GLYPH_FORMAT_OUTLINE) {
+         FT_Render_Glyph(ftglyph, FT_LOAD_TARGET_MODE(target));
+     }
++#endif
+ 
+     width  = (UInt16) ftglyph->bitmap.width;
+     height = (UInt16) ftglyph->bitmap.rows;
+@@ -969,7 +1135,9 @@ Java_sun_font_FreetypeFontScaler_getGlyp
+ static FT_Outline* getFTOutline(JNIEnv* env, jobject font2D,
+         FTScalerContext *context, FTScalerInfo* scalerInfo,
+         jint glyphCode, jfloat xpos, jfloat ypos) {
++#ifndef INFINALITY
+     int renderFlags;
++#endif
+     int glyph_index;
+     FT_Error error;
+     FT_GlyphSlot ftglyph;
+@@ -984,11 +1152,22 @@ static FT_Outline* getFTOutline(JNIEnv*
+         return NULL;
+     }
+ 
++#ifdef INFINALITY
++    RenderingProperties renderingProperties;
++    readFontconfig((const FcChar8 *) scalerInfo->face->family_name,
++                   context->ptsz, context->aaType, &renderingProperties);
++#else
+     renderFlags = FT_LOAD_NO_HINTING | FT_LOAD_NO_BITMAP;
++#endif
+ 
+     glyph_index = FT_Get_Char_Index(scalerInfo->face, glyphCode);
+ 
++#ifdef INFINALITY
++    error = FT_Load_Glyph(scalerInfo->face, glyphCode, renderingProperties.ftLoadFlags);
++#else
+     error = FT_Load_Glyph(scalerInfo->face, glyphCode, renderFlags);
++#endif
++
+     if (error) {
+         return NULL;
+     }

--- a/dev-java/icedtea/icedtea-3.0.0-r1.ebuild
+++ b/dev-java/icedtea/icedtea-3.0.0-r1.ebuild
@@ -1,0 +1,389 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+# Build written by Andrew John Hughes (gnu_andrew@member.fsf.org)
+
+EAPI="5"
+SLOT="8"
+
+inherit check-reqs gnome2-utils java-pkg-2 java-vm-2 multiprocessing pax-utils prefix versionator virtualx
+
+ICEDTEA_VER=$(get_version_component_range 1-3)
+ICEDTEA_BRANCH=$(get_version_component_range 1-2)
+ICEDTEA_PKG=icedtea-${ICEDTEA_VER}
+ICEDTEA_PRE=$(get_version_component_range _)
+CORBA_TARBALL="37af47894175.tar.xz"
+JAXP_TARBALL="4ed5441e40e1.tar.xz"
+JAXWS_TARBALL="a81c04154cc5.tar.xz"
+JDK_TARBALL="3334efeacd83.tar.xz"
+LANGTOOLS_TARBALL="dd581e8047e6.tar.xz"
+OPENJDK_TARBALL="8ed8d26a3f9a.tar.xz"
+NASHORN_TARBALL="697c5f792bec.tar.xz"
+HOTSPOT_TARBALL="5e587a29a6aa.tar.xz"
+
+CACAO_TARBALL="cacao-c182f119eaad.tar.xz"
+JAMVM_TARBALL="jamvm-ec18fb9e49e62dce16c5094ef1527eed619463aa.tar.gz"
+
+CORBA_GENTOO_TARBALL="icedtea-${ICEDTEA_BRANCH}-corba-${CORBA_TARBALL}"
+JAXP_GENTOO_TARBALL="icedtea-${ICEDTEA_BRANCH}-jaxp-${JAXP_TARBALL}"
+JAXWS_GENTOO_TARBALL="icedtea-${ICEDTEA_BRANCH}-jaxws-${JAXWS_TARBALL}"
+JDK_GENTOO_TARBALL="icedtea-${ICEDTEA_BRANCH}-jdk-${JDK_TARBALL}"
+LANGTOOLS_GENTOO_TARBALL="icedtea-${ICEDTEA_BRANCH}-langtools-${LANGTOOLS_TARBALL}"
+OPENJDK_GENTOO_TARBALL="icedtea-${ICEDTEA_BRANCH}-openjdk-${OPENJDK_TARBALL}"
+NASHORN_GENTOO_TARBALL="icedtea-${ICEDTEA_BRANCH}-nashorn-${NASHORN_TARBALL}"
+HOTSPOT_GENTOO_TARBALL="icedtea-${ICEDTEA_BRANCH}-hotspot-${HOTSPOT_TARBALL}"
+
+CACAO_GENTOO_TARBALL="icedtea-${CACAO_TARBALL}"
+JAMVM_GENTOO_TARBALL="icedtea-${JAMVM_TARBALL}"
+
+DROP_URL="http://icedtea.classpath.org/download/drops"
+ICEDTEA_URL="${DROP_URL}/icedtea${SLOT}/${ICEDTEA_VER}"
+
+DESCRIPTION="A harness to build OpenJDK using Free Software build tools and dependencies"
+HOMEPAGE="http://icedtea.classpath.org"
+SRC_PKG="${ICEDTEA_PKG}.tar.xz"
+SRC_URI="
+	http://icedtea.classpath.org/download/source/${SRC_PKG}
+	${ICEDTEA_URL}/openjdk.tar.xz -> ${OPENJDK_GENTOO_TARBALL}
+	${ICEDTEA_URL}/corba.tar.xz -> ${CORBA_GENTOO_TARBALL}
+	${ICEDTEA_URL}/jaxp.tar.xz -> ${JAXP_GENTOO_TARBALL}
+	${ICEDTEA_URL}/jaxws.tar.xz -> ${JAXWS_GENTOO_TARBALL}
+	${ICEDTEA_URL}/jdk.tar.xz -> ${JDK_GENTOO_TARBALL}
+	${ICEDTEA_URL}/hotspot.tar.xz -> ${HOTSPOT_GENTOO_TARBALL}
+	${ICEDTEA_URL}/nashorn.tar.xz -> ${NASHORN_GENTOO_TARBALL}
+	${ICEDTEA_URL}/langtools.tar.xz -> ${LANGTOOLS_GENTOO_TARBALL}
+	${DROP_URL}/cacao/${CACAO_TARBALL} -> ${CACAO_GENTOO_TARBALL}
+	${DROP_URL}/jamvm/${JAMVM_TARBALL} -> ${JAMVM_GENTOO_TARBALL}"
+
+LICENSE="Apache-1.1 Apache-2.0 GPL-1 GPL-2 GPL-2-with-linking-exception LGPL-2 MPL-1.0 MPL-1.1 public-domain W3C"
+KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+
+IUSE="+alsa cacao cjk +cups debug doc examples +gtk headless-awt infinality
+	jamvm +jbootstrap libressl nsplugin pax_kernel
+	pulseaudio sctp selinux smartcard +source +sunec test +webstart zero"
+
+REQUIRED_USE="gtk? ( !headless-awt )"
+
+# Ideally the following were optional at build time.
+ALSA_COMMON_DEP="
+	>=media-libs/alsa-lib-1.0"
+CUPS_COMMON_DEP="
+	>=net-print/cups-1.2.12"
+X_COMMON_DEP="
+	>=media-libs/giflib-4.1.6:=
+	>=media-libs/libpng-1.2:0=
+	>=x11-libs/libX11-1.1.3
+	>=x11-libs/libXext-1.1.1
+	>=x11-libs/libXi-1.1.3
+	>=x11-libs/libXrender-0.9.4
+	>=x11-libs/libXtst-1.0.3
+	x11-libs/libXcomposite"
+X_DEPEND="
+	>=x11-libs/libXau-1.0.3
+	>=x11-libs/libXdmcp-1.0.2
+	>=x11-libs/libXinerama-1.0.2
+	x11-proto/inputproto
+	>=x11-proto/xextproto-7.1.1
+	x11-proto/xineramaproto
+	x11-proto/xproto"
+
+# The Javascript requirement is obsolete; OpenJDK 8+ has Nashorn
+# Kerberos will be added following PR1537
+COMMON_DEP="
+	>=dev-libs/glib-2.26:2
+	>=dev-util/systemtap-1
+	media-libs/fontconfig
+	>=media-libs/freetype-2.5.3:2=[infinality?]
+	>=media-libs/lcms-2.5
+	>=sys-libs/zlib-1.2.3:=
+	virtual/jpeg:0=
+	sctp? ( net-misc/lksctp-tools )
+	smartcard? ( sys-apps/pcsc-lite )
+	sunec? ( >=dev-libs/nss-3.16.1-r1 )"
+
+# Gtk+ will move to COMMON_DEP in time; PR1982
+# gsettings-desktop-schemas will be needed for native proxy support; PR1976
+RDEPEND="${COMMON_DEP}
+	!dev-java/icedtea:0
+	!dev-java/icedtea-web:7
+	media-fonts/dejavu
+	alsa? ( ${ALSA_COMMON_DEP} )
+	cjk? (
+		media-fonts/arphicfonts
+		media-fonts/baekmuk-fonts
+		media-fonts/lklug
+		media-fonts/lohit-fonts
+		media-fonts/sazanami
+	)
+	cups? ( ${CUPS_COMMON_DEP} )
+	gtk? (
+		>=dev-libs/atk-1.30.0
+		>=x11-libs/cairo-1.8.8:=
+		x11-libs/gdk-pixbuf:2
+		>=x11-libs/gtk+-2.8:2=
+		>=x11-libs/pango-1.24.5
+	)
+	!headless-awt? ( ${X_COMMON_DEP} )
+	selinux? ( sec-policy/selinux-java )"
+
+# ca-certificates, perl and openssl are used for the cacerts keystore generation
+# perl is needed for running the SystemTap tests
+# lsb-release is used to obtain distro information for the version & crash dump output
+# attr is needed for xattr.h which defines the extended attribute syscalls used by NIO2
+# x11-libs/libXt is needed for headers only (Intrinsic.h, IntrinsicP.h, Shell.h, StringDefs.h)
+# Ant is no longer needed under the new build system
+DEPEND="${COMMON_DEP} ${ALSA_COMMON_DEP} ${CUPS_COMMON_DEP} ${X_COMMON_DEP} ${X_DEPEND}
+	|| (
+		dev-java/icedtea-bin:8
+		dev-java/icedtea-bin:7
+		dev-java/icedtea:8
+		dev-java/icedtea:7
+	)
+	app-arch/cpio
+	app-arch/unzip
+	app-arch/zip
+	app-misc/ca-certificates
+	dev-lang/perl
+	!libressl? ( dev-libs/openssl )
+	libressl? ( dev-libs/libressl )
+	sys-apps/attr
+	sys-apps/lsb-release
+	x11-libs/libXt
+	virtual/pkgconfig
+	pax_kernel? ( sys-apps/elfix )"
+
+PDEPEND="webstart? ( >=dev-java/icedtea-web-1.6.1:0 )
+	nsplugin? ( >=dev-java/icedtea-web-1.6.1:0[nsplugin] )
+	pulseaudio? ( dev-java/icedtea-sound )"
+
+S="${WORKDIR}"/${ICEDTEA_PKG}
+
+icedtea_check_requirements() {
+	local CHECKREQS_DISK_BUILD
+
+	if use doc; then
+		CHECKREQS_DISK_BUILD="9000M"
+	else
+		CHECKREQS_DISK_BUILD="8500M"
+	fi
+
+	check-reqs_pkg_${EBUILD_PHASE}
+}
+
+pkg_pretend() {
+	icedtea_check_requirements
+}
+
+pkg_setup() {
+	icedtea_check_requirements
+
+	JAVA_PKG_WANT_BUILD_VM="
+		icedtea-8 icedtea-bin-8
+		icedtea-7 icedtea-bin-7"
+	JAVA_PKG_WANT_SOURCE="1.5"
+	JAVA_PKG_WANT_TARGET="1.5"
+
+	java-vm-2_pkg_setup
+	java-pkg-2_pkg_setup
+}
+
+src_unpack() {
+	unpack ${SRC_PKG}
+}
+
+java_prepare() {
+	# For bootstrap builds as the sandbox control file might not yet exist.
+	addpredict /proc/self/coredump_filter
+
+	# icedtea doesn't like some locales. #330433 #389717
+	export LANG="C" LC_ALL="C"
+}
+
+src_configure() {
+	local cacao_config config hotspot_port jamvm_config use_cacao use_jamvm use_zero zero_config
+	local vm=$(java-pkg_get-current-vm)
+
+	# gcj-jdk ensures ecj is present.
+	if use jbootstrap || has "${vm}" gcj-jdk; then
+		use jbootstrap || einfo "bootstrap is necessary when building with ${vm}, ignoring USE=\"-jbootstrap\""
+		config+=" --enable-bootstrap"
+	else
+		config+=" --disable-bootstrap"
+	fi
+
+	# Use Zero if requested
+	if use zero; then
+		use_zero="yes"
+	fi
+
+	# Use JamVM if requested
+	if use jamvm; then
+		use_jamvm="yes"
+	fi
+
+	# Use CACAO if requested
+	if use cacao; then
+		use_cacao="yes"
+	fi
+
+	# Are we on a architecture with a HotSpot port?
+	# In-tree JIT ports are available for amd64, arm, arm64, ppc64 (be&le), SPARC and x86.
+	if { use amd64 || use arm64 || use ppc64 || use sparc || use x86; }; then
+		hotspot_port="yes"
+	fi
+
+	# Always use HotSpot as the primary VM if available. #389521 #368669 #357633 ...
+	# Otherwise use Zero for now until alternate VMs are working
+	if test "x${hotspot_port}" != "xyes"; then
+			use_zero="yes"
+	fi
+
+	# Turn on JamVM if needed (non-HS archs) or requested
+	if test "x${use_jamvm}" = "xyes"; then
+		if test "x${hotspot_port}" = "xyes"; then
+			ewarn 'Enabling JamVM on an architecture with HotSpot support; issues may result.'
+			ewarn 'If so, please rebuild with USE="-jamvm"'
+		fi
+		ewarn 'JamVM is known to still have issues with IcedTea 3.x; please rebuild with USE="-jamvm"'
+		jamvm_config="--enable-jamvm"
+	fi
+
+	# Turn on CACAO if needed (non-HS archs) or requested
+	if test "x${use_cacao}" = "xyes"; then
+		if test "x${hotspot_port}" = "xyes"; then
+			ewarn 'Enabling CACAO on an architecture with HotSpot support; issues may result.'
+			ewarn 'If so, please rebuild with USE="-cacao"'
+		fi
+		ewarn 'CACAO is known to still have issues with IcedTea 3.x; please rebuild with USE="-cacao"'
+		cacao_config="--enable-cacao"
+	fi
+
+	# Turn on Zero if needed (non-HS/CACAO archs) or requested
+	if test "x${use_zero}" = "xyes"; then
+		if test "x${hotspot_port}" = "xyes"; then
+			ewarn 'Enabling Zero on an architecture with HotSpot support; performance will be significantly reduced.'
+		fi
+		zero_config="--enable-zero"
+	fi
+
+	# https://bugs.openjdk.java.net/browse/JDK-8067132
+	export DISTRIBUTION_PATCHES="${SLOT}-ccache.patch"
+	ln -snf "${FILESDIR}"/${SLOT}-ccache.patch . || die
+
+	if use infinality; then
+		export OPENJDK_PATCHES="${SLOT}-fontconfig.patch ${SLOT}-infinality.patch"
+		ln -snf "${FILESDIR}/${SLOT}-fontconfig.patch" . || die
+		ln -snf "${FILESDIR}/${SLOT}-infinality.patch" . || die
+	fi
+
+	# IcedTea itself doesn't handle ccache yet.
+	if has ccache ${FEATURES}; then
+		ewarn 'ccache has been known to break IcedTea. Disable it before filing bugs.'
+		export enable_ccache=yes
+	else
+		export enable_ccache=no
+	fi
+
+	config+=" --with-parallel-jobs=$(makeopts_jobs)"
+
+	unset JAVA_HOME JDK_HOME CLASSPATH JAVAC JAVACFLAGS
+
+	econf ${config} \
+		--with-openjdk-src-zip="${DISTDIR}/${OPENJDK_GENTOO_TARBALL}" \
+		--with-corba-src-zip="${DISTDIR}/${CORBA_GENTOO_TARBALL}" \
+		--with-jaxp-src-zip="${DISTDIR}/${JAXP_GENTOO_TARBALL}" \
+		--with-jaxws-src-zip="${DISTDIR}/${JAXWS_GENTOO_TARBALL}" \
+		--with-jdk-src-zip="${DISTDIR}/${JDK_GENTOO_TARBALL}" \
+		--with-hotspot-src-zip="${DISTDIR}/${HOTSPOT_GENTOO_TARBALL}" \
+		--with-langtools-src-zip="${DISTDIR}/${LANGTOOLS_GENTOO_TARBALL}" \
+		--with-nashorn-src-zip="${DISTDIR}/${NASHORN_GENTOO_TARBALL}" \
+		--with-cacao-src-zip="${DISTDIR}/${CACAO_GENTOO_TARBALL}" \
+		--with-jamvm-src-zip="${DISTDIR}/${JAMVM_GENTOO_TARBALL}" \
+		--with-jdk-home="$(java-config -O)" \
+		--prefix="${EPREFIX}/usr/$(get_libdir)/icedtea${SLOT}" \
+		--mandir="${EPREFIX}/usr/$(get_libdir)/icedtea${SLOT}/man" \
+		--docdir="${EPREFIX}/usr/share/doc/${PF}" \
+		--htmldir="${EPREFIX}/usr/share/doc/${PF}/html" \
+		--with-pkgversion="Gentoo ${PF}" \
+		--disable-downloading --disable-Werror --disable-tests \
+		--enable-system-lcms --enable-system-jpeg \
+		--enable-system-zlib --disable-systemtap-tests \
+		$(use_enable !headless-awt system-gif) \
+		$(use_enable !headless-awt system-png) \
+		$(use_enable !debug optimizations) \
+		$(use_enable doc docs) \
+		$(use_with pax_kernel pax "${EPREFIX}/usr/sbin/paxmark.sh") \
+		$(use_enable sunec) \
+		${zero_config} ${cacao_config} ${jamvm_config}
+}
+
+src_compile() {
+	# OpenJDK is quite picky about ccache and dies if you attempt to use
+	# it via wrapper symlinks like Gentoo normally does.
+	PATH=$(sed 's#[^:]*/ccache/bin:##g' <<< "${PATH}") emake
+}
+
+src_test() {
+	# Use Xvfb for tests
+	unset DISPLAY
+
+	Xemake check
+}
+
+src_install() {
+	default
+
+	local dest="/usr/$(get_libdir)/icedtea${SLOT}"
+	local ddest="${ED}${dest#/}"
+
+	if ! use alsa; then
+		rm -v "${ddest}"/jre/lib/$(get_system_arch)/libjsoundalsa.* || die
+	fi
+
+	# Ensures Headless-AwtGraphicsEnvironment is used.
+	# Hack; we should get IcedTea to support passing --disable-headful
+	if use headless-awt; then
+		rm -vr "${ddest}"/jre/lib/$(get_system_arch)/lib*{[jx]awt,splashscreen}* \
+		   "${ddest}"/{,jre/}bin/policytool "${ddest}"/bin/appletviewer || die
+	fi
+
+	if ! use examples; then
+		rm -r "${ddest}"/demo "${ddest}"/sample || die
+	fi
+
+	if ! use source; then
+		rm -v "${ddest}"/src.zip || die
+	fi
+
+	# provided by icedtea-web but we need it in JAVA_HOME to work with run-java-tool
+	if use webstart || use nsplugin; then
+		dosym /usr/libexec/icedtea-web/itweb-settings ${dest}/bin/itweb-settings
+		dosym /usr/libexec/icedtea-web/itweb-settings ${dest}/jre/bin/itweb-settings
+	fi
+	if use webstart; then
+		dosym /usr/libexec/icedtea-web/javaws ${dest}/bin/javaws
+		dosym /usr/libexec/icedtea-web/javaws ${dest}/jre/bin/javaws
+	fi
+	dosym /usr/share/doc/${PF} /usr/share/doc/${PN}${SLOT}
+
+	# Fix the permissions.
+	find "${ddest}" \! -type l \( -perm /111 -exec chmod 755 {} \; -o -exec chmod 644 {} \; \) || die
+
+	# We need to generate keystore - bug #273306
+	einfo "Generating cacerts file from certificates in ${EPREFIX}/usr/share/ca-certificates/"
+	mkdir "${T}/certgen" && cd "${T}/certgen" || die
+	cp "${FILESDIR}/generate-cacerts.pl" . && chmod +x generate-cacerts.pl || die
+	for c in "${EPREFIX}"/usr/share/ca-certificates/*/*.crt; do
+		openssl x509 -text -in "${c}" >> all.crt || die
+	done
+	./generate-cacerts.pl "${ddest}/bin/keytool" all.crt || die
+	cp -vRP cacerts "${ddest}/jre/lib/security/" || die
+	chmod 644 "${ddest}/jre/lib/security/cacerts" || die
+
+	set_java_env "${FILESDIR}/icedtea.env"
+	java-vm_sandbox-predict /proc/self/coredump_filter
+}
+
+pkg_preinst() { gnome2_icon_savelist; }
+pkg_postinst() { gnome2_icon_cache_update; }
+pkg_postrm() { gnome2_icon_cache_update; }


### PR DESCRIPTION
With dev-java/icedtea:8 fonts smoothing (in Netbeans IDE for example) looks terrible.
None of "awt.useSystemAAFontSettings" values helps.

With this change fonts looks almost same as in icedtea:7 with infinality use flag.

Infinality patches are from https://aur.archlinux.org/packages/jdk8-openjdk-infinality/

#### Icedtea:7 with infinality
![Icedtea:7 with infinality](http://i.imgur.com/CASsoEp.png)
#### Icedtea:8 without infinality
![Icedtea:8 without infinality](http://i.imgur.com/6ktfG6O.png)
#### Icedtea:8 with infinality
![Icedtea:8 with infinality](http://i.imgur.com/bZsJOVI.png)