### PR TITLE
app-text/linuxdoc-tools: revbump to 0.9.71-r2 wrt bug 579490

### DIFF
--- a/app-text/linuxdoc-tools/files/linuxdoc-tools-0.9.71-fix-build-with-flex-2.6.1.patch
+++ b/app-text/linuxdoc-tools/files/linuxdoc-tools-0.9.71-fix-build-with-flex-2.6.1.patch
@@ -1,0 +1,35 @@
+From 8ac62cf2aa07576763af2ae2dff1bebcd8a80083 Mon Sep 17 00:00:00 2001
+From: Ilya Tumaykin <itumaykin@gmail.com>
+Date: Mon, 11 Apr 2016 19:53:56 +0300
+Subject: Fix compilation with >=flex-2.6.1
+
+flex devs reverted yyleng's type back to `int' in 2.6.1 [1].
+It was previously changed from `int' to `yy_size_t' in 2.5.36 [2,3].
+
+Adjust the related guard accordingly.
+
+See also https://bugs.gentoo.org/show_bug.cgi?id=579490
+
+[1]: https://github.com/westes/flex/commit/7a7c3dfe1bcb8230447ba1656f926b4b4cdfc457
+[2]: https://github.com/westes/flex/commit/9ba3187a537d6a58d345f2874d06087fd4050399
+[3]: https://gitlab.com/agmartin/linuxdoc-tools/commit/ada178bdcd05f57024934ea6a00cecfa95973509
+---
+ rtf-fix/rtf2rtf.l | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/rtf-fix/rtf2rtf.l b/rtf-fix/rtf2rtf.l
+index d1f6a66..274b6ee 100644
+--- a/rtf-fix/rtf2rtf.l
++++ b/rtf-fix/rtf2rtf.l
+@@ -73,9 +73,8 @@ int skipnewline = 0;
+
+ extern char *yytext;
+
+-#if   YY_FLEX_MAJOR_VERSION > 2 \
+- ||  (YY_FLEX_MAJOR_VERSION == 2 && YY_FLEX_MINOR_VERSION > 5) \
+- ||  (YY_FLEX_MAJOR_VERSION == 2 && YY_FLEX_MINOR_VERSION == 5 && YY_FLEX_SUBMINOR_VERSION > 35)
++#if (YY_FLEX_MAJOR_VERSION == 2 && YY_FLEX_MINOR_VERSION == 5 && YY_FLEX_SUBMINOR_VERSION > 35) \
++ || (YY_FLEX_MAJOR_VERSION == 2 && YY_FLEX_MINOR_VERSION == 6 && YY_FLEX_SUBMINOR_VERSION == 0)
+ extern yy_size_t yyleng;
+ #else
+ extern int yyleng;

--- a/app-text/linuxdoc-tools/files/linuxdoc-tools-0.9.71-fix-parallel-doc-build.patch
+++ b/app-text/linuxdoc-tools/files/linuxdoc-tools-0.9.71-fix-parallel-doc-build.patch
@@ -22,7 +22,7 @@ index adb85d0..f215678 100644
 +		BUILDDOC_FORMATS="$(BUILDDOC_FORMATS)" \
  		sh Makedoc.sh)
  endif
- 
+
 @@ -174,7 +175,7 @@ ifneq ($(BUILDDOC_FORMATS),)
  	mkdir -m 755 -p $(doc_ddir)
  	# cp -r doc/* $(doc_ddir)
@@ -55,7 +55,7 @@ index b7e2efb..da4be99 100644
  else
      # --with-installed-iso-entities: Use system prefix.
 @@ -88,45 +88,42 @@ fi
- 
+
  # Build actual documentation
  echo "- Building documentation for formats: ${BUILDDOC_FORMATS}" >&2
 +BUILDDOC_MAKE=""
@@ -112,7 +112,7 @@ index b7e2efb..da4be99 100644
 -				 --pass="\usepackage{times}" ./guide.sgml
 +		echo "- Add to build list: guide.dvi" >&2
 +		BUILDDOC_MAKE="${BUILDDOC_MAKE} guide.dvi"
- 
+
  		if [ -n "`which dvips`" ]; then
  		    echo "   + dvips" >&2
 @@ -137,9 +134,13 @@ for docformat in ${BUILDDOC_FORMATS}; do
@@ -135,13 +135,13 @@ index b7e2efb..da4be99 100644
 @@ -156,7 +157,9 @@ for docformat in ${BUILDDOC_FORMATS}; do
      esac
  done
- 
+
 +${MAKE} TMPDIR="${TMPDIR}" DVIPS_PAPER="${DVIPS_PAPER}" ${BUILDDOC_MAKE}
 +
  # Remove temporary directory.
 -rm -rf $TMPDIR
 +rm -rf "${TMPDIR}"
- 
+
  exit 0
 diff --git a/doc/Makefile b/doc/Makefile
 new file mode 100644

--- a/app-text/linuxdoc-tools/files/linuxdoc-tools-0.9.71-upgrade-deprecated-latex-commands.patch
+++ b/app-text/linuxdoc-tools/files/linuxdoc-tools-0.9.71-upgrade-deprecated-latex-commands.patch
@@ -1,0 +1,24 @@
+From b0665954791978c9fede736bc7e0c19efe21f9e9 Mon Sep 17 00:00:00 2001
+From: Agustin Martin Domingo <agmartin@debian.org>
+Date: Tue, 5 Apr 2016 18:46:24 +0200
+Subject: fmt_latex2e.pl: Upgrade deprecated latex2e commands: {\em  } ->
+ \emph{} and {\tt } -> \texttt{}
+
+Signed-off-by: Agustin Martin Domingo <agmartin@debian.org>
+---
+ lib/fmt/fmt_latex2e.pl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/fmt/fmt_latex2e.pl b/lib/fmt/fmt_latex2e.pl
+index 69d8e62..a9b3c00 100644
+--- a/lib/fmt/fmt_latex2e.pl
++++ b/lib/fmt/fmt_latex2e.pl
+@@ -288,7 +288,7 @@ $latex2e->{postASP} = sub
+ 	print $urlnum . ": " . $urlid . "\n" if ( $global->{debug} );
+
+ 	$urldef = latex2e_defnam($urlnum) . "url";
+-	s/\\nameurl\{.*\}\{.*\}/{\\em $urlnam} {\\tt \\$urldef}/;
++	s/\\nameurl\{.*\}\{.*\}/\\emph{$urlnam} \\texttt{\\$urldef}/;
+ 	push @urlnames, $_;
+ 	push @urldefines, "\\urldef{\\$urldef} \\url{$urlid}\n";
+ 	$urlnum++;

--- a/app-text/linuxdoc-tools/files/linuxdoc-tools-0.9.71-upgrade-deprecated-perl-regexs.patch
+++ b/app-text/linuxdoc-tools/files/linuxdoc-tools-0.9.71-upgrade-deprecated-perl-regexs.patch
@@ -1,0 +1,53 @@
+From cd05ec78c8374980362347a226d9c0cc5f6bb624 Mon Sep 17 00:00:00 2001
+From: Agustin Martin Domingo <agmartin@debian.org>
+Date: Tue, 5 Apr 2016 18:43:13 +0200
+Subject: fmt_latex2e.pl: Handle perl 5.22 deprecation of unescaped left brace
+ in regular expressions.
+
+This is to deal with new perl 5.22 warnings like
+
+ Unescaped left brace in regex is deprecated, passed through in regex;
+ marked by <-- HERE in m/\\nameurl{ <-- HERE (.*)}{(.*)}/
+ at /usr/share/linuxdoc-tools/fmt/fmt_latex2e.pl line 287.
+
+For consistency, right brackets are also escaped, although they
+currently don't trigger any warning.
+
+Signed-off-by: Agustin Martin Domingo <agmartin@debian.org>
+---
+ lib/fmt/fmt_latex2e.pl | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lib/fmt/fmt_latex2e.pl b/lib/fmt/fmt_latex2e.pl
+index 050cf06..69d8e62 100644
+--- a/lib/fmt/fmt_latex2e.pl
++++ b/lib/fmt/fmt_latex2e.pl
+@@ -284,11 +284,11 @@ $latex2e->{postASP} = sub
+       push @texlines, $_;
+       # and check for nameurl
+       if ( /\\nameurl/ ){
+-	($urlid, $urlnam) = ($_ =~ /\\nameurl{(.*)}{(.*)}/);
++	($urlid, $urlnam) = ($_ =~ /\\nameurl\{(.*)\}\{(.*)\}/);
+ 	print $urlnum . ": " . $urlid . "\n" if ( $global->{debug} );
+
+ 	$urldef = latex2e_defnam($urlnum) . "url";
+-	s/\\nameurl{.*}{.*}/{\\em $urlnam} {\\tt \\$urldef}/;
++	s/\\nameurl\{.*\}\{.*\}/{\\em $urlnam} {\\tt \\$urldef}/;
+ 	push @urlnames, $_;
+ 	push @urldefines, "\\urldef{\\$urldef} \\url{$urlid}\n";
+ 	$urlnum++;
+@@ -367,12 +367,12 @@ $latex2e->{postASP} = sub
+ 	    $_ = $_ . "\\makeindex\n" if ($latex2e->{makeindex});
+ 	  }
+ 	  # Set correct DTD name
+-	  elsif (/^\\usepackage{\@LINUXDOC_DTD\@-sgml}/) {
++	  elsif (/^\\usepackage\{\@LINUXDOC_DTD\@-sgml\}/) {
+ 	    my $dtd = $global->{"dtd"};
+ 	    s/\@LINUXDOC_DTD\@/$dtd/;
+ 	  }
+ 	  # Set correct babel options
+-	  elsif (/^\\usepackage\[\@BABELOPTIONS\@\]{babel}/) {
++	  elsif (/^\\usepackage\[\@BABELOPTIONS\@\]\{babel\}/) {
+ 	    if ( $babeloptions ) {
+ 	      s/\@BABELOPTIONS\@/$babeloptions/;
+ 	    } else {

--- a/app-text/linuxdoc-tools/linuxdoc-tools-0.9.71-r2.ebuild
+++ b/app-text/linuxdoc-tools/linuxdoc-tools-0.9.71-r2.ebuild
@@ -1,0 +1,93 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+AUTOTOOLS_AUTORECONF=1
+AUTOTOOLS_IN_SOURCE_BUILD=1
+# Source tarball has SHA1 of release in the name of the second topmost directory
+GIT_SHA1="5a46c4ced4ef899b398bcedf8ccd29d6f2584100"
+
+inherit autotools-utils latex-package perl-module sgml-catalog toolchain-funcs
+
+DESCRIPTION="A toolset for processing LinuxDoc DTD SGML files"
+HOMEPAGE="https://gitlab.com/agmartin/linuxdoc-tools"
+SRC_URI="https://gitlab.com/agmartin/${PN}/repository/archive.tar.gz?ref=upstream/${PV} -> ${P}.tar.gz"
+
+LICENSE="MIT SGMLUG"
+SLOT="0"
+KEYWORDS="~amd64 ~ia64 ~ppc ~x86 ~x86-fbsd"
+IUSE="doc"
+
+RDEPEND="
+	|| ( app-text/openjade app-text/opensp )
+	app-text/sgml-common
+	dev-lang/perl:=
+	|| ( sys-apps/gawk sys-apps/mawk )
+	sys-apps/groff
+"
+DEPEND="${RDEPEND}
+	sys-devel/flex
+	doc? (
+		dev-texlive/texlive-fontsrecommended
+		virtual/latex-base
+	)
+"
+
+DOCS=( ChangeLog README )
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-parallel-doc-build.patch"
+	"${FILESDIR}/${P}-upgrade-deprecated-perl-regexs.patch"
+	"${FILESDIR}/${P}-upgrade-deprecated-latex-commands.patch"
+	"${FILESDIR}/${P}-fix-build-with-flex-2.6.1.patch"
+)
+
+S="${WORKDIR}/${PN}-upstream/${PV}-${GIT_SHA1}"
+
+src_prepare() {
+	# Use Gentoo doc install path.
+	sed -i \
+		-e "s%/share/doc/${PN}%/share/doc/${PF}%" \
+		Makefile.in || die
+
+	autotools-utils_src_prepare
+}
+
+src_configure() {
+	perl_set_version
+	tc-export CC
+	local myeconfargs=(
+		--disable-docs
+		--with-texdir="${TEXMF}/tex/latex/${PN}"
+		--with-perllibdir="${VENDOR_ARCH}"
+		--with-installed-iso-entities
+	)
+	use doc && myeconfargs+=(--enable-docs="txt pdf html")
+
+	autotools-utils_src_configure
+}
+
+src_compile() {
+	autotools-utils_src_compile
+}
+
+src_install() {
+	# Prevent access violations from bitmap font files generation.
+	export VARTEXFONTS="${T}/fonts"
+
+	autotools-utils_src_install
+}
+
+sgml-catalog_cat_include "/etc/sgml/linuxdoc.cat" "/usr/share/${PN}/${PN}.catalog"
+
+pkg_postinst() {
+	latex-package_pkg_postinst
+	sgml-catalog_pkg_postinst
+}
+
+pkg_postrm() {
+	latex-package_pkg_postrm
+	sgml-catalog_pkg_postrm
+}


### PR DESCRIPTION
Backport a couple of upstream fixes on the way.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=579490
Package-Manager: portage-2.2.28