### PR TITLE
sci-misc/boinc: Fixed boinc.init to work with >=sys-apps/openrc-0.20

### DIFF
--- a/sci-misc/boinc/files/boinc.init
+++ b/sci-misc/boinc/files/boinc.init
@@ -1,4 +1,7 @@
 #!/sbin/runscript
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
 
 extra_started_commands="attach"
 
@@ -59,7 +62,7 @@ start() {
 	fi
 
 	ebegin "Starting ${SVCNAME}"
-	su -m ${USER} -c "nice -n ${NICELEVEL} \"${BOINCBIN}\" ${ARGS} --daemon --dir \"${RUNTIMEDIR}\" --redirectio"
+	start-stop-daemon -S -N ${NICELEVEL} -u ${USER} -q -x "${BOINCBIN}" -- ${ARGS} --daemon --dir "${RUNTIMEDIR}" --redirectio
 	eend $?
 }
 
@@ -81,7 +84,7 @@ attach() {
 	password=$(cat "${RUNTIMEDIR}/gui_rpc_auth.cfg")
 
 	ebegin "${SVCNAME}: Attaching to project"
-	su -m ${USER} -c "boinccmd --passwd \"${password}\" --project_attach ${url} ${key}"
+	start-stop-daemon -u ${USER} -q -x boinccmd -- --passwd "${password}" --project_attach ${url} ${key}
 	eend $?
 
 	unset password url key
@@ -96,7 +99,7 @@ stop() {
 	password=$(cat "${RUNTIMEDIR}/gui_rpc_auth.cfg")
 
 	ebegin "Stopping ${SVCNAME}"
-	su -m ${USER} -c "boinccmd --passwd \"${password}\" --quit"
+	start-stop-daemon -u ${USER} -q -x boinccmd -- --passwd "${password}" --quit
 	eend $?
 
 	unset password


### PR DESCRIPTION
Gentoo-Bug: 574260

The boinc init script can no longer start, attach or stop the boinc
manager if openrc-0.20 and newer is used, because openrc no longer
passes $SHELL to init scripts.

To solve the issue the init script has been migrated to use
start-stop-daemon instead of using 'su' directly.

This change should have no impact for users of previous openrc
versions.

Package-Manager: portage-2.2.28

@SoapGentoo @jlec : Please have a look. I could reproduce the reported bug and the fix works ; at least with boinc-7.6.31.