### PR TITLE
net-misc/i2pd: bugfix & housecleaning 

### DIFF
--- a/net-misc/i2pd/files/i2pd-2.6.0-r3.confd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r3.confd
@@ -1,7 +1,7 @@
-I2PD_USER="${I2PD_USER:-i2pd}"
-I2PD_GROUP="${I2PD_GROUP:-i2pd}"
-I2PD_LOG="/var/log/i2pd.log"
-I2PD_PID="/run/i2pd/i2pd.pid"
+I2PD_USER=i2pd
+I2PD_GROUP=i2pd
+I2PD_LOG=/var/log/i2pd.log
+I2PD_PID=/run/i2pd/i2pd.pid
 
 # Options to i2pd
 I2PD_OPTIONS="--daemon --service --pidfile=${I2PD_PID} \

--- a/net-misc/i2pd/files/i2pd-2.6.0-r3.confd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r3.confd
@@ -3,6 +3,9 @@ I2PD_GROUP=i2pd
 I2PD_LOG=/var/log/i2pd.log
 I2PD_PID=/run/i2pd/i2pd.pid
 
+# max number of open files (for floodfill)
+rc_ulimit="-n 4096"
+
 # Options to i2pd
 I2PD_OPTIONS="--daemon --service --pidfile=${I2PD_PID} \
 --log=file --logfile=${I2PD_LOG} \

--- a/net-misc/i2pd/files/i2pd-2.6.0-r3.initd
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r3.initd
@@ -12,7 +12,7 @@ user="${I2PD_USER}:${I2PD_GROUP}"
 start_stop_daemon_args="
     --user \"${user}\"
     --pidfile \"${I2PD_PID}\"
-    --progress --retry 'SIGTERM/20 SIGKILL/20'
+    --progress --retry 'SIGTERM/20/SIGKILL/20'
 "
 I2PD_PID_DIR=$(dirname "${I2PD_PID}")
 
@@ -41,6 +41,6 @@ graceful() {
     ebegin "Gracefully stopping i2pd, this takes 10 minutes"
     mark_service_stopping
     eval start-stop-daemon --stop ${start_stop_daemon_args} \
-        --exec "${command}" --retry 'SIGINT/620 SIGTERM/20 SIGKILL/20'
+        --exec "${command}" --retry 'SIGINT/620/SIGTERM/20/SIGKILL/20'
     eend $? && mark_service_stopped
 }

--- a/net-misc/i2pd/files/i2pd-2.6.0-r3.logrotate
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r3.logrotate
@@ -1,0 +1,11 @@
+/var/log/i2pd.log {
+        rotate 4
+        weekly
+        missingok
+        notifempty
+        create 640 i2pd i2pd
+        postrotate
+                /bin/kill -HUP $(cat /run/i2pd/i2pd.pid)
+        endscript
+}
+

--- a/net-misc/i2pd/files/i2pd-2.6.0-r3.service
+++ b/net-misc/i2pd/files/i2pd-2.6.0-r3.service
@@ -8,6 +8,7 @@ Restart=on-abnormal
 PIDFile=/run/i2pd/i2pd.pid
 User=i2pd
 Group=i2pd
+LimitNOFILE=4096
 PermissionsStartOnly=yes
 ExecStartPre=/bin/mkdir -p /run/i2pd
 ExecStartPre=/bin/chown i2pd:i2pd /run/i2pd

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -65,7 +65,6 @@ src_install() {
 	doins "${S}/docs/${PN}.conf"
 	doins "${S}/debian/subscriptions.txt"
 	doins "${S}/debian/tunnels.conf"
-	dodir /usr/share/i2pd
 	newconfd "${FILESDIR}/${PN}-2.6.0-r2.confd" "${PN}"
 	newinitd "${FILESDIR}/${PN}-2.6.0-r2.initd" "${PN}"
 	systemd_newunit "${FILESDIR}/${PN}-2.6.0-r2.service" "${PN}.service"

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -91,7 +91,7 @@ src_install() {
 	
 	# logrotate
 	insinto /etc/logrotate.d
-	newins "${FILESDIR}/i2pd-2.5.0.logrotate" i2pd
+	newins "${FILESDIR}/i2pd-2.6.0-r3.logrotate" i2pd
 }
 
 pkg_setup() {

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -85,7 +85,7 @@ src_install() {
 
 	# openrc and systemd daemon routines
 	newconfd "${FILESDIR}/i2pd-2.6.0-r3.confd" i2pd
-	newinitd "${FILESDIR}/i2pd-2.6.0-r2.initd" i2pd
+	newinitd "${FILESDIR}/i2pd-2.6.0-r3.initd" i2pd
 	systemd_newunit "${FILESDIR}/i2pd-2.6.0-r2.service" i2pd.service
 	
 	# logrotate

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -72,12 +72,16 @@ src_install() {
 	doenvd "${FILESDIR}/99${PN}"
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}-2.5.0.logrotate" "${PN}"
-	fowners "${I2PD_USER}:${I2PD_GROUP}" "/etc/${PN}/${PN}.conf" \
-		"/etc/${PN}/subscriptions.txt" \
-		"/etc/${PN}/tunnels.conf"
-	fperms 600 "/etc/${PN}/${PN}.conf" \
-		"/etc/${PN}/subscriptions.txt" \
-		"/etc/${PN}/tunnels.conf"
+
+	# grant i2pd group read and write access to config files
+	fowners "root:${I2PD_GROUP}" \
+		/etc/i2pd/i2pd.conf \
+		/etc/i2pd/tunnels.conf \
+		/etc/i2pd/subscriptions.txt
+	fperms 660 \
+		/etc/i2pd/i2pd.conf \
+		/etc/i2pd/tunnels.conf \
+		/etc/i2pd/subscriptions.txt
 }
 
 pkg_setup() {

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -33,6 +33,8 @@ I2PD_GROUP=i2pd
 
 CMAKE_USE_DIR="${S}/build"
 
+DOCS=( README.md docs/i2pd.conf debian/tunnels.conf debian/subscriptions.txt )
+
 src_prepare() {
 	eapply "${FILESDIR}/${PN}-2.5.1-fix_installed_components.patch"
 	eapply_user
@@ -69,9 +71,6 @@ src_install() {
 		/etc/i2pd/i2pd.conf \
 		/etc/i2pd/tunnels.conf \
 		/etc/i2pd/subscriptions.txt
-
-	# doc
-	dodoc README.md
 
 	# working directory
 	keepdir /var/lib/i2pd

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -53,25 +53,13 @@ src_configure() {
 
 src_install() {
 	cmake-utils_src_install
-	dodoc README.md
-	keepdir /var/lib/i2pd/
-	insinto "/var/lib/i2pd"
-	doins -r "${S}/contrib/certificates"
-	dosym /etc/i2pd/subscriptions.txt /var/lib/i2pd/subscriptions.txt
-	fowners "${I2PD_USER}:${I2PD_GROUP}" /var/lib/i2pd/
-	fperms 700 /var/lib/i2pd/
-	dodir "/etc/${PN}"
-	insinto "/etc/${PN}"
-	doins "${S}/docs/${PN}.conf"
-	doins "${S}/debian/subscriptions.txt"
-	doins "${S}/debian/tunnels.conf"
-	newconfd "${FILESDIR}/${PN}-2.6.0-r2.confd" "${PN}"
-	newinitd "${FILESDIR}/${PN}-2.6.0-r2.initd" "${PN}"
-	systemd_newunit "${FILESDIR}/${PN}-2.6.0-r2.service" "${PN}.service"
-	doenvd "${FILESDIR}/99${PN}"
-	insinto /etc/logrotate.d
-	newins "${FILESDIR}/${PN}-2.5.0.logrotate" "${PN}"
 
+	# config
+	insinto /etc/i2pd
+	doins docs/i2pd.conf
+	doins debian/tunnels.conf
+	doins debian/subscriptions.txt
+	
 	# grant i2pd group read and write access to config files
 	fowners "root:${I2PD_GROUP}" \
 		/etc/i2pd/i2pd.conf \
@@ -81,9 +69,32 @@ src_install() {
 		/etc/i2pd/i2pd.conf \
 		/etc/i2pd/tunnels.conf \
 		/etc/i2pd/subscriptions.txt
+
+	# doc
+	dodoc README.md
+
+	# working directory
+	keepdir /var/lib/i2pd
+	insinto /var/lib/i2pd
+	doins -r contrib/certificates
+	dosym /etc/i2pd/subscriptions.txt /var/lib/i2pd/subscriptions.txt
+	fowners "${I2PD_USER}:${I2PD_GROUP}" /var/lib/i2pd/
+	fperms 700 /var/lib/i2pd/
+	
+	# add /var/lib/i2pd/certificates to CONFIG_PROTECT
+	doenvd "${FILESDIR}/99i2pd"
+
+	# openrc and systemd daemon routines
+	newconfd "${FILESDIR}/i2pd-2.6.0-r2.confd" i2pd
+	newinitd "${FILESDIR}/i2pd-2.6.0-r2.initd" i2pd
+	systemd_newunit "${FILESDIR}/i2pd-2.6.0-r2.service" i2pd.service
+	
+	# logrotate
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}/i2pd-2.5.0.logrotate" i2pd
 }
 
 pkg_setup() {
 	enewgroup "${I2PD_GROUP}"
-	enewuser "${I2PD_USER}" -1 -1 "/var/lib/run/${PN}" "${I2PD_GROUP}"
+	enewuser "${I2PD_USER}" -1 -1 /var/lib/run/i2pd "${I2PD_GROUP}"
 }

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -28,8 +28,8 @@ DEPEND="${RDEPEND}
 	i2p-hardening? ( >=sys-devel/gcc-4.7 )
 	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"
 
-I2PD_USER="${I2PD_USER:-i2pd}"
-I2PD_GROUP="${I2PD_GROUP:-i2pd}"
+I2PD_USER=i2pd
+I2PD_GROUP=i2pd
 
 CMAKE_USE_DIR="${S}/build"
 
@@ -85,7 +85,7 @@ src_install() {
 	doenvd "${FILESDIR}/99i2pd"
 
 	# openrc and systemd daemon routines
-	newconfd "${FILESDIR}/i2pd-2.6.0-r2.confd" i2pd
+	newconfd "${FILESDIR}/i2pd-2.6.0-r3.confd" i2pd
 	newinitd "${FILESDIR}/i2pd-2.6.0-r2.initd" i2pd
 	systemd_newunit "${FILESDIR}/i2pd-2.6.0-r2.service" i2pd.service
 	

--- a/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
+++ b/net-misc/i2pd/i2pd-2.6.0-r3.ebuild
@@ -86,7 +86,7 @@ src_install() {
 	# openrc and systemd daemon routines
 	newconfd "${FILESDIR}/i2pd-2.6.0-r3.confd" i2pd
 	newinitd "${FILESDIR}/i2pd-2.6.0-r3.initd" i2pd
-	systemd_newunit "${FILESDIR}/i2pd-2.6.0-r2.service" i2pd.service
+	systemd_newunit "${FILESDIR}/i2pd-2.6.0-r3.service" i2pd.service
 	
 	# logrotate
 	insinto /etc/logrotate.d


### PR DESCRIPTION
This PR replaces https://github.com/gentoo/gentoo/pull/1222 after receiving a lot of feedback from @tomboy-64 and @blueness.

* 3e8340f: config files are now owned by `root:i2pd`, `i2pd` group has write access. I would be in favour of not allowing `i2pd` group write access, because then the daemon has it being run as  `i2pd:i2pd`. On the other hand, this way users with membership in `i2pd` can change config, which is good. Though, they still cannot restart the service so the changes take effect...
* 51b5ab8: we remove unused /usr/share/i2pd
* 1a7027b: restructure the install section of the ebuild, purely cosmetic
* 0337b1c: fix pid file location for logrotate (this is a bugfix)
* bab5896: make i2pd user and group static (not depending on environment variables). I tend to think that we need this, because systemd service uses static names anyway, so we did not guarantee that the environment variables `I2PD_USER` and `I2PD_GROUP` were correctly used for systemd users. Also, this way it is simpler.
* 2effb25: save virgin copies of config files in `/usr/share/doc/i2pd-2.6.0-r3/`, along with `README.md`, which was already placed there
* 55a3684: remove spaces in retry for start-stop-daemon, as in https://github.com/OpenRC/openrc/issues/76
* 6dda70b: increase max number of open files (`ulimit -n`) to 4096. The default value of 1024 is not enough for floodfill: daemon becomes unresponsive, and webconsole `http://localhost:7070` does not open.