### PR TITLE
kde-apps/kde-l10n: Fix LINGUAS="" | kde-frameworks/krunner: Pin kapptemplate blocker to slot 5

### DIFF
--- a/kde-apps/kde-l10n/kde-l10n-15.12.3-r1.ebuild
+++ b/kde-apps/kde-l10n/kde-l10n-15.12.3-r1.ebuild
@@ -75,7 +75,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	[[ -n ${A} ]] || return
+	[[ ${LINGUAS} = "" ]] && return
 
 	# add all linguas to cmake
 	cat <<-EOF > CMakeLists.txt || die
@@ -144,15 +144,15 @@ src_configure() {
 		fi
 		kde5_src_configure
 	}
-	[[ -n ${A} ]] && multibuild_foreach_variant myconfigure
+	[[ ${LINGUAS} != "" ]] && multibuild_foreach_variant myconfigure
 }
 
 src_compile() {
-	[[ -n ${A} ]] && multibuild_foreach_variant kde5_src_compile
+	[[ ${LINGUAS} != "" ]] && multibuild_foreach_variant kde5_src_compile
 }
 
 src_test() { :; }
 
 src_install() {
-	[[ -n ${A} ]] && multibuild_foreach_variant kde5_src_install
+	[[ ${LINGUAS} != "" ]] && multibuild_foreach_variant kde5_src_install
 }

--- a/kde-frameworks/krunner/krunner-5.21.0.ebuild
+++ b/kde-frameworks/krunner/krunner-5.21.0.ebuild
@@ -26,5 +26,5 @@ DEPEND="
 	$(add_qt_dep qtwidgets)
 "
 RDEPEND="${DEPEND}
-	!<kde-apps/kapptemplate-15.12.3-r1
+	!<kde-apps/kapptemplate-15.12.3-r1:5
 "

--- a/profiles/targets/desktop/kde/package.mask
+++ b/profiles/targets/desktop/kde/package.mask
@@ -21,4 +21,6 @@ kde-apps/kdewebdev-meta:5
 kde-apps/kde-apps-meta:5
 kde-apps/kde-meta:5
 kde-apps/kde-wallpapers:5
+kde-apps/khelpcenter:5
 kde-frameworks/oxygen-icons:5
+kde-plasma/plasma-meta:5


### PR DESCRIPTION
@gentoo/kde

Gentoo-bug: 580170
Gentoo-bug: 579534

Also added another commit that makes sure that kde-apps/khelpcenter:5 does not leak into kde profile.

Package-Manager: portage-2.2.27