### PR TITLE
net-misc/youtube-dl: add ZSH completion

### DIFF
--- a/net-misc/youtube-dl/youtube-dl-2016.04.13-r1.ebuild
+++ b/net-misc/youtube-dl/youtube-dl-2016.04.13-r1.ebuild
@@ -80,8 +80,13 @@ src_test() {
 src_install() {
 	python_domodule youtube_dl
 	dobin bin/${PN}
+
 	dodoc README.txt
 	doman ${PN}.1
+
 	newbashcomp ${PN}.bash-completion ${PN}
+	insinto /usr/share/zsh/site-functions
+	newins ${PN}.zsh _${PN}.zsh
+
 	python_fix_shebang "${ED}"
 }


### PR DESCRIPTION
Gentoo-Bug: 533672

@jer-gentoo 

There is also a _fish_ completion, but I don't know where should it go.