### PR TITLE
Dropping autotools-utils from xorg-2

### DIFF
--- a/x11-apps/intel-gpu-tools/intel-gpu-tools-1.10.ebuild
+++ b/x11-apps/intel-gpu-tools/intel-gpu-tools-1.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -40,13 +40,13 @@ src_install() {
 	xorg-2_src_install
 	if use test-programs; then
 		local testprogram
-		pushd "${AUTOTOOLS_BUILD_DIR}"/tests || die
-			for testprogram in $(<multi-tests.txt) $(<single-tests.txt); do
-				if [[ -f ${testprogram} ]]; then
-					dobin "${testprogram}"
-				fi
-			done
-		popd
+		pushd tests >/dev/null || die
+		for testprogram in $(<multi-tests.txt) $(<single-tests.txt); do
+			if [[ -f ${testprogram} ]]; then
+				dobin "${testprogram}"
+			fi
+		done
+		popd >/dev/null || die
 	fi
 }
 

--- a/x11-apps/intel-gpu-tools/intel-gpu-tools-1.11-r1.ebuild
+++ b/x11-apps/intel-gpu-tools/intel-gpu-tools-1.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -40,13 +40,13 @@ src_install() {
 	xorg-2_src_install
 	if use test-programs; then
 		local testprogram
-		pushd "${AUTOTOOLS_BUILD_DIR}"/tests || die
-			for testprogram in $(<multi-tests.txt) $(<single-tests.txt); do
-				if [[ -f ${testprogram} ]]; then
-					dobin "${testprogram}"
-				fi
-			done
-		popd
+		pushd tests >/dev/null || die
+		for testprogram in $(<multi-tests.txt) $(<single-tests.txt); do
+			if [[ -f ${testprogram} ]]; then
+				dobin "${testprogram}"
+			fi
+		done
+		popd >/dev/null || die
 	fi
 }
 

--- a/x11-apps/intel-gpu-tools/intel-gpu-tools-1.12.ebuild
+++ b/x11-apps/intel-gpu-tools/intel-gpu-tools-1.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -40,13 +40,13 @@ src_install() {
 	xorg-2_src_install
 	if use test-programs; then
 		local testprogram
-		pushd "${AUTOTOOLS_BUILD_DIR}"/tests || die
-			for testprogram in $(<multi-tests.txt) $(<single-tests.txt); do
-				if [[ -f ${testprogram} ]]; then
-					dobin "${testprogram}"
-				fi
-			done
-		popd
+		pushd tests >/dev/null || die
+		for testprogram in $(<multi-tests.txt) $(<single-tests.txt); do
+			if [[ -f ${testprogram} ]]; then
+				dobin "${testprogram}"
+			fi
+		done
+		popd >/dev/null || die
 	fi
 }
 

--- a/x11-apps/xauth/xauth-1.0.9-r1.ebuild
+++ b/x11-apps/xauth/xauth-1.0.9-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=4
 
-inherit autotools-utils xorg-2
+inherit xorg-2
 
 DESCRIPTION="X authority file utility"
 
@@ -30,6 +30,7 @@ src_configure() {
 
 src_test() {
 	# Address sandbox failure, bug #527574
+	local -x SANDBOX_WRITE=${SANDBOX_WRITE}
 	addwrite /proc/self/comm
-	autotools-utils_src_test
+	default
 }

--- a/x11-apps/xauth/xauth-1.0.9-r2.ebuild
+++ b/x11-apps/xauth/xauth-1.0.9-r2.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=4
 
-inherit autotools-utils xorg-2
+inherit xorg-2
 
 DESCRIPTION="X authority file utility"
 
@@ -29,6 +29,7 @@ src_configure() {
 
 src_test() {
 	# Address sandbox failure, bug #527574
+	local -x SANDBOX_WRITE=${SANDBOX_WRITE}
 	addwrite /proc/self/comm
-	autotools-utils_src_test
+	default
 }

--- a/x11-base/xorg-server/xorg-server-1.12.4-r5.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.12.4-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -192,7 +192,7 @@ src_install() {
 
 	if ! use minimal &&	use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.12.4-r7.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.12.4-r7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -180,7 +180,7 @@ src_install() {
 
 	if ! use minimal &&	use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.15.2-r2.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.15.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -203,7 +203,7 @@ src_install() {
 
 	if ! use minimal &&	use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.15.2-r4.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.15.2-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -190,7 +190,7 @@ src_install() {
 
 	if ! use minimal &&	use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.16.4-r5.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.16.4-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -203,7 +203,7 @@ src_install() {
 
 	if ! use minimal &&	use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.16.4.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.16.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -211,7 +211,7 @@ src_install() {
 
 	if ! use minimal &&	use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.17.4.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.17.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -211,7 +211,7 @@ src_install() {
 
 	if ! use minimal &&	use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.18.0.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.18.0.ebuild
@@ -208,7 +208,7 @@ src_install() {
 
 	if ! use minimal && use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.18.1.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.18.1.ebuild
@@ -208,7 +208,7 @@ src_install() {
 
 	if ! use minimal && use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.18.2.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.18.2.ebuild
@@ -208,7 +208,7 @@ src_install() {
 
 	if ! use minimal && use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-base/xorg-server/xorg-server-1.18.3.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.18.3.ebuild
@@ -208,7 +208,7 @@ src_install() {
 
 	if ! use minimal && use xorg; then
 		# Install xorg.conf.example into docs
-		dodoc "${AUTOTOOLS_BUILD_DIR}"/hw/xfree86/xorg.conf.example
+		dodoc hw/xfree86/xorg.conf.example
 	fi
 
 	newinitd "${FILESDIR}"/xdm-setup.initd-1 xdm-setup

--- a/x11-libs/glamor/glamor-0.6.0-r1.ebuild
+++ b/x11-libs/glamor/glamor-0.6.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -10,7 +10,7 @@ XORG_MODULE=driver/
 XORG_MODULE_REBUILD=yes
 S=${WORKDIR}/${PN}-egl-${PV}
 
-inherit xorg-2 autotools-utils toolchain-funcs
+inherit xorg-2 toolchain-funcs
 
 DESCRIPTION="OpenGL based 2D rendering acceleration library"
 SRC_URI="${XORG_BASE_INDIVIDUAL_URI}/${XORG_MODULE}${PN}-egl-${PV}.tar.bz2"
@@ -50,5 +50,5 @@ src_prepare() {
 
 src_install() {
 	# workaround parallel install failure, bug #488124.
-	autotools-utils_src_install -j1
+	xorg-2_src_install -j1
 }

--- a/x11-libs/glamor/glamor-0.6.0.ebuild
+++ b/x11-libs/glamor/glamor-0.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -10,7 +10,7 @@ XORG_MODULE=driver/
 XORG_MODULE_REBUILD=yes
 S=${WORKDIR}/${PN}-egl-${PV}
 
-inherit xorg-2 autotools-utils toolchain-funcs
+inherit xorg-2 toolchain-funcs
 
 DESCRIPTION="OpenGL based 2D rendering acceleration library"
 SRC_URI="${XORG_BASE_INDIVIDUAL_URI}/${XORG_MODULE}${PN}-egl-${PV}.tar.bz2"
@@ -49,5 +49,5 @@ src_prepare() {
 
 src_install() {
 	# workaround parallel install failure, bug #488124.
-	autotools-utils_src_install -j1
+	xorg-2_src_install -j1
 }

--- a/x11-libs/xpyb/xpyb-1.3.1-r2.ebuild
+++ b/x11-libs/xpyb/xpyb-1.3.1-r2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
 PYTHON_COMPAT=( python2_7 )
-AUTOTOOLS_AUTORECONF=1
+XORG_EAUTORECONF=yes
 
 inherit flag-o-matic xorg-2 python-r1
 

--- a/x11-libs/xpyb/xpyb-1.3.1-r3.ebuild
+++ b/x11-libs/xpyb/xpyb-1.3.1-r3.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 PYTHON_COMPAT=( python2_7 )
-AUTOTOOLS_AUTORECONF=1
+XORG_EAUTORECONF=yes
 
 inherit flag-o-matic xorg-2 python-r1
 

--- a/x11-proto/xcb-proto/xcb-proto-1.10.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,19 +30,11 @@ src_configure() {
 }
 
 multilib_src_configure() {
-	autotools-utils_src_configure
+	ECONF_SOURCE="${S}"
+	econf
 
 	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_configure
-	fi
-}
-
-multilib_src_compile() {
-	default
-
-	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_compile -C xcbgen \
-			top_builddir="${BUILD_DIR}"
+		python_foreach_impl run_in_build_dir econf
 	fi
 }
 
@@ -58,7 +50,6 @@ multilib_src_install() {
 	default
 
 	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_install -C xcbgen \
-			top_builddir="${BUILD_DIR}"
+		python_foreach_impl run_in_build_dir emake DESTDIR="${D}" install -C xcbgen
 	fi
 }

--- a/x11-proto/xcb-proto/xcb-proto-1.11.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,19 +30,11 @@ src_configure() {
 }
 
 multilib_src_configure() {
-	autotools-utils_src_configure
+	ECONF_SOURCE="${S}"
+	econf
 
 	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_configure
-	fi
-}
-
-multilib_src_compile() {
-	default
-
-	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_compile -C xcbgen \
-			top_builddir="${BUILD_DIR}"
+		python_foreach_impl run_in_build_dir econf
 	fi
 }
 
@@ -58,7 +50,6 @@ multilib_src_install() {
 	default
 
 	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_install -C xcbgen \
-			top_builddir="${BUILD_DIR}"
+		python_foreach_impl run_in_build_dir emake DESTDIR="${D}" install -C xcbgen
 	fi
 }

--- a/x11-proto/xcb-proto/xcb-proto-1.8-r3.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.8-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -28,19 +28,11 @@ src_configure() {
 }
 
 multilib_src_configure() {
-	autotools-utils_src_configure
+	ECONF_SOURCE="${S}"
+	econf
 
 	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_configure
-	fi
-}
-
-multilib_src_compile() {
-	default
-
-	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_compile -C xcbgen \
-			top_builddir="${BUILD_DIR}"
+		python_foreach_impl run_in_build_dir econf
 	fi
 }
 
@@ -48,8 +40,7 @@ multilib_src_install() {
 	default
 
 	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_install -C xcbgen \
-			top_builddir="${BUILD_DIR}"
+		python_foreach_impl run_in_build_dir emake DESTDIR="${D}" install -C xcbgen
 	fi
 }
 

--- a/x11-proto/xcb-proto/xcb-proto-1.9-r1.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.9-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -37,19 +37,11 @@ src_configure() {
 }
 
 multilib_src_configure() {
-	autotools-utils_src_configure
+	ECONF_SOURCE="${S}"
+	econf
 
 	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_configure
-	fi
-}
-
-multilib_src_compile() {
-	default
-
-	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_compile -C xcbgen \
-			top_builddir="${BUILD_DIR}"
+		python_foreach_impl run_in_build_dir econf
 	fi
 }
 
@@ -57,7 +49,6 @@ multilib_src_install() {
 	default
 
 	if multilib_is_native_abi; then
-		python_foreach_impl autotools-utils_src_install -C xcbgen \
-			top_builddir="${BUILD_DIR}"
+		python_foreach_impl run_in_build_dir emake DESTDIR="${D}" install -C xcbgen
 	fi
 }


### PR DESCRIPTION
The xorg-2 eclass currently uses the deprecated autotools-utils and
autotools-multilib eclasses, which are banned in EAPI 6.

This patchset attempts to remove any trace of autotools-utils from ebuilds
using xorg-2.

Note that I am touching stable ebuilds here to avoid forking an "xorg-3"
eclass. If there is a strong feeling that this is too dangerous, I can alter
my approach. I have build tested most packages using xorg-2, and only a few
had issues.