### PR TITLE
dev-python/urwid: add Python 3.5 support

### DIFF
--- a/dev-python/urwid/urwid-1.3.1.ebuild
+++ b/dev-python/urwid/urwid-1.3.1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 python3_{3,4} )
+PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
 PYTHON_REQ_USE="ncurses"
 
 inherit distutils-r1


### PR DESCRIPTION
I emerge it with `test` USE flag and tests all passed, I also tested some of its examples, some are working, some are not working due to syntax error, but which also fail on Python 3.4 and only work on Python 2.7, so I think it's OK to enable Python 3.5 support on it.

@alunduil