### PR TITLE
dev-ruby/hoe: Move rdoc to DEPEND since it's called by the ebuild

### DIFF
--- a/dev-ruby/hoe/hoe-3.14.1.ebuild
+++ b/dev-ruby/hoe/hoe-3.14.1.ebuild
@@ -22,7 +22,7 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
-ruby_add_bdepend "test? ( >=dev-ruby/minitest-5.5:5 )"
+ruby_add_bdepend "test? ( >=dev-ruby/minitest-5.5:5 ) >=dev-ruby/rdoc-4.0"
 
 ruby_add_rdepend ">=dev-ruby/rake-0.8.7 >=dev-ruby/rdoc-4.0"
 


### PR DESCRIPTION
@gentoo/ruby 