### PR TITLE
urwid with eapi6

### DIFF
--- a/dev-python/urwid/urwid-1.3.1.ebuild
+++ b/dev-python/urwid/urwid-1.3.1.ebuild
@@ -27,7 +27,7 @@ PATCHES=( "${FILESDIR}"/${PN}-1.1.0-sphinx.patch )
 
 python_compile_all() {
 	if use doc ; then
-		if [[ ${EPYTHON} == python3* ]] ; then
+		if python_is_python3; then
 			2to3 -nw --no-diffs docs/conf.py || die
 		fi
 		cd docs
@@ -36,7 +36,7 @@ python_compile_all() {
 }
 
 python_compile() {
-	if [[ ${EPYTHON} == python2* ]] ; then
+	if ! python_is_python3; then
 		local CFLAGS="${CFLAGS} -fno-strict-aliasing"
 		export CFLAGS
 	fi

--- a/dev-python/urwid/urwid-1.3.1.ebuild
+++ b/dev-python/urwid/urwid-1.3.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
 PYTHON_REQ_USE="ncurses"
@@ -49,7 +49,7 @@ python_test() {
 }
 
 python_install_all() {
-	use examples && local EXAMPLES=( examples/. )
+	use examples && dodoc -r examples
 	use doc && local HTML_DOCS=( docs/_build/html/. )
 
 	distutils-r1_python_install_all


### PR DESCRIPTION
This is the follow-up for #1291, I bump the EAPI for urwid 1.3.1. Looks I could not at @gentoo/python.