### PR TITLE
=dev-python/pyserial-2.7-r1: enable python 3.5 support

### DIFF
--- a/dev-python/pyserial/pyserial-2.7-r1.ebuild
+++ b/dev-python/pyserial/pyserial-2.7-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
-PYTHON_COMPAT=( python{2_7,3_3,3_4} pypy )
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} pypy )
 
 inherit distutils-r1
 


### PR DESCRIPTION
@gentoo/python I will need this for Cura.
@gentoo/proxy-maint