### PR TITLE
Fix EXAMPLES banned in EAPI 6

### DIFF
--- a/dev-python/dulwich/dulwich-0.12.0-r1.ebuild
+++ b/dev-python/dulwich/dulwich-0.12.0-r1.ebuild
@@ -41,6 +41,6 @@ python_test() {
 
 python_install_all() {
 	use doc && local HTML_DOCS=( docs/build/html/. )
-	use examples && local EXAMPLES=( examples/. )
+	use examples && dodoc -r examples
 	distutils-r1_python_install_all
 }

--- a/dev-python/elasticsearch-py/elasticsearch-py-2.2.0.ebuild
+++ b/dev-python/elasticsearch-py/elasticsearch-py-2.2.0.ebuild
@@ -80,7 +80,7 @@ python_compile_all() {
 
 python_install_all() {
 	use doc && HTML_DOCS=( docs/_build/html/. )
-	use examples && local EXAMPLES=( example/. )
+	use examples && dodoc -r example
 	doman docs/_build/man/*
 	distutils-r1_python_install_all
 }

--- a/dev-python/elasticsearch-py/elasticsearch-py-2.3.0.ebuild
+++ b/dev-python/elasticsearch-py/elasticsearch-py-2.3.0.ebuild
@@ -84,7 +84,7 @@ python_compile_all() {
 
 python_install_all() {
 	use doc && HTML_DOCS=( docs/_build/html/. )
-	use examples && local EXAMPLES=( example/. )
+	use examples && dodoc -r example
 	doman docs/_build/man/*
 	distutils-r1_python_install_all
 }

--- a/dev-python/nose/nose-9999.ebuild
+++ b/dev-python/nose/nose-9999.ebuild
@@ -83,7 +83,7 @@ python_install() {
 }
 
 python_install_all() {
-	use examples && local EXAMPLES=( examples/. )
+	use examples && dodoc -r examples
 	use doc && HTML_DOCS=( doc/.build/html/. )
 	distutils-r1_python_install_all
 }

--- a/dev-python/pysnmp/pysnmp-4.3.2.ebuild
+++ b/dev-python/pysnmp/pysnmp-4.3.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -37,7 +37,8 @@ python_compile_all() {
 
 python_install_all() {
 	use doc && local HTML_DOCS=( docs/build/html/* )
-	use examples && local EXAMPLES=( examples/. docs/mibs )
+	docinto examples
+	use examples && dodoc -r examples/* docs/mibs
 
 	distutils-r1_python_install_all
 }


### PR DESCRIPTION
I check the portage and find some ebuilds using banned EXAMPLES in EAPI 6, which will fail to emerge.

@gentoo/python