### PR TITLE
media-gfx/slic3r: bugfix

### DIFF
--- a/dev-perl/Growl-GNTP/Growl-GNTP-0.210.0-r1.ebuild
+++ b/dev-perl/Growl-GNTP/Growl-GNTP-0.210.0-r1.ebuild
@@ -21,12 +21,9 @@ RDEPEND="
 	>=virtual/perl-Digest-MD5-2.360.0
 	>=virtual/perl-Digest-SHA-5.450.0
 	virtual/perl-IO
-	dev-perl/IO-Socket-PortState
 "
 DEPEND="${RDEPEND}
-	dev-perl/Module-Build-Tiny
-	virtual/perl-File-Spec
-	virtual/perl-CPAN-Meta"
+	>=dev-perl/Module-Build-Tiny-0.35.0"
 
 src_test() {
 	my_test_control=${DIST_TEST_OVERRIDE:-${DIST_TEST:-do parallel}}

--- a/media-gfx/slic3r/slic3r-1.2.9-r1.ebuild
+++ b/media-gfx/slic3r/slic3r-1.2.9-r1.ebuild
@@ -15,8 +15,10 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="+gui test"
 
-# check Build.PL for dependencies
-RDEPEND="!=dev-lang/perl-5.16*
+# Slic3r is a fragile application.
+# In order to produce reasonably good results we require
+# latest dependencies.
+RDEPEND=">=dev-lang/perl-5.22
 	>=dev-libs/boost-1.55[threads]
 	dev-perl/Class-XSAccessor
 	>=dev-perl/Encode-Locale-0.50.0


### PR DESCRIPTION
Slic3r depends on recent perl packages. Instabilities have been reported with stable (e.g. for recent perl outdated) packages.
Additionally a small dep-fix for Growl-GNTP.

@kentfredric 
@gentoo/proxy-maint