### PR TITLE
dev-python/nose: Bump to EAPI 6

### DIFF
--- a/dev-python/nose/nose-1.3.7-r1.ebuild
+++ b/dev-python/nose/nose-1.3.7-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=( python2_7 python3_{3,4,5} pypy pypy3 )
 PYTHON_REQ_USE="threads(+)"
@@ -82,7 +82,7 @@ python_install() {
 }
 
 python_install_all() {
-	use examples && local EXAMPLES=( examples/. )
+	use examples && dodoc -r examples
 	use doc && HTML_DOCS=( doc/.build/html/. )
 	distutils-r1_python_install_all
 }


### PR DESCRIPTION
Follow up for #1299, use EAPI 6 with nose-1.3.7-r1.ebuild.

Package-Manager: portage-2.2.26

@gentoo/python