### PR TITLE
HTTPS for *.freedesktop.org

### DIFF
--- a/app-admin/elektra/elektra-0.7.1-r5.ebuild
+++ b/app-admin/elektra/elektra-0.7.1-r5.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit autotools autotools-multilib eutils multilib
 
 DESCRIPTION="Framework to store config parameters in hierarchical key-value pairs"
-HOMEPAGE="http://freedesktop.org/wiki/Software/Elektra"
+HOMEPAGE="https://freedesktop.org/wiki/Software/Elektra"
 SRC_URI="ftp://ftp.markus-raab.org/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/app-admin/elektra/elektra-0.8.12.ebuild
+++ b/app-admin/elektra/elektra-0.8.12.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit cmake-multilib eutils java-pkg-opt-2
 
 DESCRIPTION="Framework to store config parameters in hierarchical key-value pairs"
-HOMEPAGE="http://freedesktop.org/wiki/Software/Elektra"
+HOMEPAGE="https://freedesktop.org/wiki/Software/Elektra"
 SRC_URI="ftp://ftp.markus-raab.org/${PN}/releases/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/app-admin/elektra/elektra-0.8.15.ebuild
+++ b/app-admin/elektra/elektra-0.8.15.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit cmake-multilib eutils java-pkg-opt-2
 
 DESCRIPTION="Framework to store config parameters in hierarchical key-value pairs"
-HOMEPAGE="http://freedesktop.org/wiki/Software/Elektra"
+HOMEPAGE="https://freedesktop.org/wiki/Software/Elektra"
 SRC_URI="ftp://ftp.markus-raab.org/${PN}/releases/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/app-admin/elektra/elektra-9999.ebuild
+++ b/app-admin/elektra/elektra-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit cmake-multilib eutils java-pkg-opt-2 git-r3
 
 DESCRIPTION="Framework to store config parameters in hierarchical key-value pairs"
-HOMEPAGE="http://freedesktop.org/wiki/Software/Elektra"
+HOMEPAGE="https://freedesktop.org/wiki/Software/Elektra"
 EGIT_REPO_URI="git://github.com/ElektraInitiative/libelektra.git"
 
 LICENSE="BSD"

--- a/app-admin/gam-server/gam-server-0.1.10-r2.ebuild
+++ b/app-admin/gam-server/gam-server-0.1.10-r2.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Library providing the FAM File Alteration Monitor API"
 HOMEPAGE="https://www.gnome.org/~veillard/gamin/"
 SRC_URI="${SRC_URI}
 	mirror://gentoo/gamin-0.1.9-freebsd.patch.bz2
-	http://pkgconfig.freedesktop.org/releases/pkg-config-0.26.tar.gz" # pkg.m4 for eautoreconf
+	https://pkgconfig.freedesktop.org/releases/pkg-config-0.26.tar.gz" # pkg.m4 for eautoreconf
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/app-admin/packagekit-base/packagekit-base-1.0.11.ebuild
+++ b/app-admin/packagekit-base/packagekit-base-1.0.11.ebuild
@@ -16,7 +16,7 @@ MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Manage packages in a secure way using a cross-distro and cross-architecture API"
 HOMEPAGE="http://www.packagekit.org/"
-SRC_URI="http://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
+SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0/18"

--- a/app-admin/packagekit-qt/packagekit-qt-0.9.5.ebuild
+++ b/app-admin/packagekit-qt/packagekit-qt-0.9.5.ebuild
@@ -11,7 +11,7 @@ MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Qt PackageKit backend library"
 HOMEPAGE="http://www.packagekit.org/"
-SRC_URI="http://www.freedesktop.org/software/PackageKit/releases/${MY_P}.tar.xz"
+SRC_URI="https://www.freedesktop.org/software/PackageKit/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-crypt/p11-kit/p11-kit-0.20.7.ebuild
+++ b/app-crypt/p11-kit/p11-kit-0.20.7.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit eutils multilib-minimal
 
 DESCRIPTION="Provides a standard configuration setup for installing PKCS#11"
-HOMEPAGE="http://p11-glue.freedesktop.org/p11-kit.html"
-SRC_URI="http://p11-glue.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://p11-glue.freedesktop.org/p11-kit.html"
+SRC_URI="https://p11-glue.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/app-crypt/p11-kit/p11-kit-0.22.0.ebuild
+++ b/app-crypt/p11-kit/p11-kit-0.22.0.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit eutils multilib-minimal
 
 DESCRIPTION="Provides a standard configuration setup for installing PKCS#11"
-HOMEPAGE="http://p11-glue.freedesktop.org/p11-kit.html"
-SRC_URI="http://p11-glue.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://p11-glue.freedesktop.org/p11-kit.html"
+SRC_URI="https://p11-glue.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/app-crypt/p11-kit/p11-kit-0.22.1.ebuild
+++ b/app-crypt/p11-kit/p11-kit-0.22.1.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit eutils multilib-minimal
 
 DESCRIPTION="Provides a standard configuration setup for installing PKCS#11"
-HOMEPAGE="http://p11-glue.freedesktop.org/p11-kit.html"
-SRC_URI="http://p11-glue.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://p11-glue.freedesktop.org/p11-kit.html"
+SRC_URI="https://p11-glue.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/app-crypt/p11-kit/p11-kit-0.23.1.ebuild
+++ b/app-crypt/p11-kit/p11-kit-0.23.1.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit eutils multilib-minimal
 
 DESCRIPTION="Provides a standard configuration setup for installing PKCS#11"
-HOMEPAGE="http://p11-glue.freedesktop.org/p11-kit.html"
-SRC_URI="http://p11-glue.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://p11-glue.freedesktop.org/p11-kit.html"
+SRC_URI="https://p11-glue.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/app-crypt/p11-kit/p11-kit-0.23.2.ebuild
+++ b/app-crypt/p11-kit/p11-kit-0.23.2.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit eutils multilib-minimal
 
 DESCRIPTION="Provides a standard configuration setup for installing PKCS#11"
-HOMEPAGE="http://p11-glue.freedesktop.org/p11-kit.html"
-SRC_URI="http://p11-glue.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://p11-glue.freedesktop.org/p11-kit.html"
+SRC_URI="https://p11-glue.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/app-laptop/radeontool/radeontool-1.6.3.ebuild
+++ b/app-laptop/radeontool/radeontool-1.6.3.ebuild
@@ -7,8 +7,8 @@ inherit eutils toolchain-funcs
 
 DESCRIPTION="Manage the backlight, external video output and registers of ATI Radeon graphics cards"
 
-HOMEPAGE="http://cgit.freedesktop.org/~airlied/radeontool/"
-SRC_URI="http://people.freedesktop.org/~airlied/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://cgit.freedesktop.org/~airlied/radeontool/"
+SRC_URI="https://people.freedesktop.org/~airlied/${PN}/${P}.tar.bz2"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-misc/evemu/evemu-2.1.0.ebuild
+++ b/app-misc/evemu/evemu-2.1.0.ebuild
@@ -10,8 +10,8 @@ AUTOTOOLS_IN_SOURCE_BUILD=1
 inherit autotools-utils python-single-r1
 
 DESCRIPTION="Tools and bindings for kernel input event device emulation, data capture, and replay"
-HOMEPAGE="http://www.freedesktop.org/wiki/Evemu/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Evemu/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-3 GPL-3"
 SLOT="0"

--- a/app-misc/evemu/evemu-2.2.0.ebuild
+++ b/app-misc/evemu/evemu-2.2.0.ebuild
@@ -10,8 +10,8 @@ AUTOTOOLS_IN_SOURCE_BUILD=1
 inherit autotools-utils python-single-r1
 
 DESCRIPTION="Tools and bindings for kernel input event device emulation, data capture, and replay"
-HOMEPAGE="http://www.freedesktop.org/wiki/Evemu/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Evemu/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-3 GPL-3"
 SLOT="0"

--- a/app-misc/evtest/evtest-1.29.ebuild
+++ b/app-misc/evtest/evtest-1.29.ebuild
@@ -7,8 +7,8 @@ EAPI="4"
 inherit autotools eutils
 
 DESCRIPTION="test program for capturing input device events"
-HOMEPAGE="http://cgit.freedesktop.org/evtest/"
-SRC_URI="http://cgit.freedesktop.org/evtest/snapshot/${P}.tar.bz2
+HOMEPAGE="https://cgit.freedesktop.org/evtest/"
+SRC_URI="https://cgit.freedesktop.org/evtest/snapshot/${P}.tar.bz2
 	mirror://gentoo/${P}-mans.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-misc/evtest/evtest-1.30.ebuild
+++ b/app-misc/evtest/evtest-1.30.ebuild
@@ -7,8 +7,8 @@ EAPI="4"
 inherit autotools eutils
 
 DESCRIPTION="test program for capturing input device events"
-HOMEPAGE="http://cgit.freedesktop.org/evtest/"
-SRC_URI="http://cgit.freedesktop.org/evtest/snapshot/${PN}-${P}.tar.gz -> ${P}.tar.gz
+HOMEPAGE="https://cgit.freedesktop.org/evtest/"
+SRC_URI="https://cgit.freedesktop.org/evtest/snapshot/${PN}-${P}.tar.gz -> ${P}.tar.gz
 	mirror://gentoo/${P}-mans.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-misc/evtest/evtest-1.31.ebuild
+++ b/app-misc/evtest/evtest-1.31.ebuild
@@ -7,8 +7,8 @@ EAPI="4"
 inherit autotools eutils
 
 DESCRIPTION="test program for capturing input device events"
-HOMEPAGE="http://cgit.freedesktop.org/evtest/"
-SRC_URI="http://cgit.freedesktop.org/evtest/snapshot/${PN}-${P}.tar.gz -> ${P}.tar.gz
+HOMEPAGE="https://cgit.freedesktop.org/evtest/"
+SRC_URI="https://cgit.freedesktop.org/evtest/snapshot/${PN}-${P}.tar.gz -> ${P}.tar.gz
 	mirror://gentoo/${P}-mans.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-misc/geoclue/geoclue-0.12.99.ebuild
+++ b/app-misc/geoclue/geoclue-0.12.99.ebuild
@@ -6,8 +6,8 @@ EAPI=4
 inherit autotools eutils
 
 DESCRIPTION="A geoinformation D-Bus service"
-HOMEPAGE="http://freedesktop.org/wiki/Software/GeoClue"
-SRC_URI="http://freedesktop.org/~hadess/${P}.tar.gz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/GeoClue"
+SRC_URI="https://freedesktop.org/~hadess/${P}.tar.gz"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/app-misc/geoclue/geoclue-2.4.1.ebuild
+++ b/app-misc/geoclue/geoclue-2.4.1.ebuild
@@ -9,8 +9,8 @@ inherit gnome2 systemd user versionator
 
 MY_PV=$(get_version_component_range 1-2)
 DESCRIPTION="A geoinformation D-Bus service"
-HOMEPAGE="http://freedesktop.org/wiki/Software/GeoClue"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${MY_PV}/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/GeoClue"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${MY_PV}/${P}.tar.xz"
 
 LICENSE="LGPL-2"
 SLOT="2.0"

--- a/app-misc/geoclue/geoclue-2.4.3.ebuild
+++ b/app-misc/geoclue/geoclue-2.4.3.ebuild
@@ -9,8 +9,8 @@ inherit gnome2 systemd user versionator
 
 MY_PV=$(get_version_component_range 1-2)
 DESCRIPTION="A geoinformation D-Bus service"
-HOMEPAGE="http://freedesktop.org/wiki/Software/GeoClue"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${MY_PV}/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/GeoClue"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${MY_PV}/${P}.tar.xz"
 
 LICENSE="LGPL-2"
 SLOT="2.0"

--- a/app-misc/media-player-info/media-player-info-21-r1.ebuild
+++ b/app-misc/media-player-info/media-player-info-21-r1.ebuild
@@ -9,15 +9,15 @@ PYTHON_COMPAT=( python{3_3,3_4} )
 inherit eutils python-any-r1
 
 DESCRIPTION="A repository of data files describing media player capabilities"
-HOMEPAGE="http://cgit.freedesktop.org/media-player-info/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.gz"
+HOMEPAGE="https://cgit.freedesktop.org/media-player-info/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ppc ppc64 ~sh ~sparc x86"
 IUSE=""
 
-# http://cgit.freedesktop.org/media-player-info/commit/?id=d83dd01a0a1df6198ee08954da1c033b88a1004b
+# https://cgit.freedesktop.org/media-player-info/commit/?id=d83dd01a0a1df6198ee08954da1c033b88a1004b
 RDEPEND=">=virtual/udev-208"
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
@@ -35,7 +35,7 @@ src_prepare() {
 pkg_postinst() {
 	# Run for /lib/udev/hwdb.d/20-usb-media-players.hwdb
 	udevadm hwdb --update --root="${ROOT%/}"
-	# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+	# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 	if [[ ${ROOT} != "" ]] && [[ ${ROOT} != "/" ]]; then
 		return 0
 	fi

--- a/app-misc/media-player-info/media-player-info-22.ebuild
+++ b/app-misc/media-player-info/media-player-info-22.ebuild
@@ -8,15 +8,15 @@ PYTHON_COMPAT=( python3_{3,4,5} )
 inherit eutils python-any-r1
 
 DESCRIPTION="A repository of data files describing media player capabilities"
-HOMEPAGE="http://cgit.freedesktop.org/media-player-info/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.gz"
+HOMEPAGE="https://cgit.freedesktop.org/media-player-info/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86"
 IUSE=""
 
-# http://cgit.freedesktop.org/media-player-info/commit/?id=d83dd01a0a1df6198ee08954da1c033b88a1004b
+# https://cgit.freedesktop.org/media-player-info/commit/?id=d83dd01a0a1df6198ee08954da1c033b88a1004b
 RDEPEND=">=virtual/udev-208"
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
@@ -29,7 +29,7 @@ RESTRICT="binchecks strip"
 pkg_postinst() {
 	# Run for /lib/udev/hwdb.d/20-usb-media-players.hwdb
 	udevadm hwdb --update --root="${ROOT%/}"
-	# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+	# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 	if [[ ${ROOT} != "" ]] && [[ ${ROOT} != "/" ]]; then
 		return 0
 	fi

--- a/app-text/libabw/libabw-0.0.2.ebuild
+++ b/app-text/libabw/libabw-0.0.2.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit base eutils
 
 DESCRIPTION="Library parsing abiword documents"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libabw/"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libabw/"
 SRC_URI="http://dev-www.libreoffice.org/src//${P}.tar.xz"
 
 LICENSE="LGPL-2.1"

--- a/app-text/libabw/libabw-0.1.0.ebuild
+++ b/app-text/libabw/libabw-0.1.0.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit base eutils
 
 DESCRIPTION="Library parsing abiword documents"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libabw/"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libabw/"
 SRC_URI="http://dev-www.libreoffice.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="MPL-2.0"

--- a/app-text/libetonyek/libetonyek-0.0.3.ebuild
+++ b/app-text/libetonyek/libetonyek-0.0.3.ebuild
@@ -9,7 +9,7 @@ inherit base eutils
 [[ ${PV} == 9999 ]] && inherit autotools git-2
 
 DESCRIPTION="Library parsing Apple Keynote presentations"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libetonyek"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libetonyek"
 [[ ${PV} == 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.xz"
 
 LICENSE="|| ( GPL-2+ LGPL-2.1 MPL-1.1 )"

--- a/app-text/libmspub/libmspub-0.0.6.ebuild
+++ b/app-text/libmspub/libmspub-0.0.6.ebuild
@@ -9,7 +9,7 @@ EGIT_REPO_URI="git://anongit.freedesktop.org/git/libreoffice/${PN}/"
 inherit base eutils
 
 DESCRIPTION="Library parsing the Microsoft Publisher documents"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libmspub"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libmspub"
 [[ ${PV} == 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"

--- a/app-text/libspectre/libspectre-0.2.6.ebuild
+++ b/app-text/libspectre/libspectre-0.2.6.ebuild
@@ -6,8 +6,8 @@ EAPI=4
 inherit autotools eutils
 
 DESCRIPTION="A library for rendering Postscript documents"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libspectre"
-SRC_URI="http://libspectre.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libspectre"
+SRC_URI="https://libspectre.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-text/libspectre/libspectre-0.2.7.ebuild
+++ b/app-text/libspectre/libspectre-0.2.7.ebuild
@@ -6,8 +6,8 @@ EAPI=4
 inherit autotools eutils
 
 DESCRIPTION="A library for rendering Postscript documents"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libspectre"
-SRC_URI="http://libspectre.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libspectre"
+SRC_URI="https://libspectre.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-text/poppler-data/poppler-data-0.4.7.ebuild
+++ b/app-text/poppler-data/poppler-data-0.4.7.ebuild
@@ -5,8 +5,8 @@
 EAPI=5
 
 DESCRIPTION="Data files for poppler to support uncommon encodings without xpdfrc"
-HOMEPAGE="http://poppler.freedesktop.org/"
-SRC_URI="http://poppler.freedesktop.org/${P}.tar.gz"
+HOMEPAGE="https://poppler.freedesktop.org/"
+SRC_URI="https://poppler.freedesktop.org/${P}.tar.gz"
 
 LICENSE="BSD GPL-2 MIT"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~x64-solaris ~x86-solaris"

--- a/app-text/poppler/poppler-0.32.0.ebuild
+++ b/app-text/poppler/poppler-0.32.0.ebuild
@@ -12,13 +12,13 @@ if [[ "${PV}" == "9999" ]] ; then
 	KEYWORDS="alpha arm hppa ia64 ppc ppc64 sparc x86"
 	SLOT="0/9999"
 else
-	SRC_URI="http://poppler.freedesktop.org/${P}.tar.xz"
+	SRC_URI="https://poppler.freedesktop.org/${P}.tar.xz"
 	KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 	SLOT="0/51"   # CHECK THIS WHEN BUMPING!!! SUBSLOT IS libpoppler.so SOVERSION
 fi
 
 DESCRIPTION="PDF rendering library based on the xpdf-3.0 code base"
-HOMEPAGE="http://poppler.freedesktop.org/"
+HOMEPAGE="https://poppler.freedesktop.org/"
 
 LICENSE="GPL-2"
 IUSE="cairo cjk curl cxx debug doc +introspection +jpeg jpeg2k +lcms png qt4 qt5 tiff +utils"

--- a/app-text/poppler/poppler-0.38.0.ebuild
+++ b/app-text/poppler/poppler-0.38.0.ebuild
@@ -11,13 +11,13 @@ if [[ "${PV}" == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.freedesktop.org/git/${PN}/${PN}"
 	SLOT="0/9999"
 else
-	SRC_URI="http://poppler.freedesktop.org/${P}.tar.xz"
+	SRC_URI="https://poppler.freedesktop.org/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 	SLOT="0/57"   # CHECK THIS WHEN BUMPING!!! SUBSLOT IS libpoppler.so SOVERSION
 fi
 
 DESCRIPTION="PDF rendering library based on the xpdf-3.0 code base"
-HOMEPAGE="http://poppler.freedesktop.org/"
+HOMEPAGE="https://poppler.freedesktop.org/"
 
 LICENSE="GPL-2"
 IUSE="cairo cjk curl cxx debug doc +introspection +jpeg +jpeg2k +lcms png qt4 qt5 tiff +utils"

--- a/app-text/poppler/poppler-0.41.0.ebuild
+++ b/app-text/poppler/poppler-0.41.0.ebuild
@@ -11,13 +11,13 @@ if [[ "${PV}" == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.freedesktop.org/git/${PN}/${PN}"
 	SLOT="0/9999"
 else
-	SRC_URI="http://poppler.freedesktop.org/${P}.tar.xz"
+	SRC_URI="https://poppler.freedesktop.org/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 	SLOT="0/58"   # CHECK THIS WHEN BUMPING!!! SUBSLOT IS libpoppler.so SOVERSION
 fi
 
 DESCRIPTION="PDF rendering library based on the xpdf-3.0 code base"
-HOMEPAGE="http://poppler.freedesktop.org/"
+HOMEPAGE="https://poppler.freedesktop.org/"
 
 LICENSE="GPL-2"
 IUSE="cairo cjk curl cxx debug doc +introspection +jpeg +jpeg2k +lcms png qt4 qt5 tiff +utils"

--- a/app-text/poppler/poppler-0.42.0.ebuild
+++ b/app-text/poppler/poppler-0.42.0.ebuild
@@ -12,13 +12,13 @@ if [[ "${PV}" == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.freedesktop.org/git/${PN}/${PN}"
 	SLOT="0/9999"
 else
-	SRC_URI="http://poppler.freedesktop.org/${P}.tar.xz"
+	SRC_URI="https://poppler.freedesktop.org/${P}.tar.xz"
 	KEYWORDS="~alpha amd64 arm ~arm64 hppa ~ia64 ~mips ~ppc ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 	SLOT="0/59"   # CHECK THIS WHEN BUMPING!!! SUBSLOT IS libpoppler.so SOVERSION
 fi
 
 DESCRIPTION="PDF rendering library based on the xpdf-3.0 code base"
-HOMEPAGE="http://poppler.freedesktop.org/"
+HOMEPAGE="https://poppler.freedesktop.org/"
 
 LICENSE="GPL-2"
 IUSE="cairo cairo-qt cjk curl cxx debug doc +introspection +jpeg +jpeg2k +lcms nss png qt4 qt5 tiff +utils"

--- a/app-text/poppler/poppler-9999.ebuild
+++ b/app-text/poppler/poppler-9999.ebuild
@@ -12,13 +12,13 @@ if [[ "${PV}" == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.freedesktop.org/git/${PN}/${PN}"
 	SLOT="0/9999"
 else
-	SRC_URI="http://poppler.freedesktop.org/${P}.tar.xz"
+	SRC_URI="https://poppler.freedesktop.org/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 	SLOT="0/59"   # CHECK THIS WHEN BUMPING!!! SUBSLOT IS libpoppler.so SOVERSION
 fi
 
 DESCRIPTION="PDF rendering library based on the xpdf-3.0 code base"
-HOMEPAGE="http://poppler.freedesktop.org/"
+HOMEPAGE="https://poppler.freedesktop.org/"
 
 LICENSE="GPL-2"
 IUSE="cairo cairo-qt cjk curl cxx debug doc +introspection +jpeg +jpeg2k +lcms nss png qt4 qt5 tiff +utils"

--- a/app-text/rarian/rarian-0.8.1-r2.ebuild
+++ b/app-text/rarian/rarian-0.8.1-r2.ebuild
@@ -7,8 +7,8 @@ EAPI=4
 inherit eutils libtool
 
 DESCRIPTION="A documentation metadata library"
-HOMEPAGE="http://rarian.freedesktop.org/"
-SRC_URI="http://${PN}.freedesktop.org/Releases/${P}.tar.gz"
+HOMEPAGE="https://rarian.freedesktop.org/"
+SRC_URI="https://${PN}.freedesktop.org/Releases/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-cpp/gstreamermm/gstreamermm-0.10.11.ebuild
+++ b/dev-cpp/gstreamermm/gstreamermm-0.10.11.ebuild
@@ -8,7 +8,7 @@ GNOME2_LA_PUNT="yes"
 inherit flag-o-matic gnome2
 
 DESCRIPTION="C++ interface for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/bindings/cplusplus.html"
+HOMEPAGE="https://gstreamer.freedesktop.org/bindings/cplusplus.html"
 
 LICENSE="LGPL-2.1"
 SLOT="0.10"

--- a/dev-cpp/gstreamermm/gstreamermm-1.4.3.ebuild
+++ b/dev-cpp/gstreamermm/gstreamermm-1.4.3.ebuild
@@ -6,7 +6,7 @@ EAPI="5"
 inherit flag-o-matic gnome2
 
 DESCRIPTION="C++ interface for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/bindings/cplusplus.html"
+HOMEPAGE="https://gstreamer.freedesktop.org/bindings/cplusplus.html"
 
 LICENSE="LGPL-2.1"
 SLOT="1.0"

--- a/dev-embedded/scratchbox2/scratchbox2-2.0-r1.ebuild
+++ b/dev-embedded/scratchbox2/scratchbox2-2.0-r1.ebuild
@@ -10,8 +10,8 @@ MY_PN="${PN/cratch}"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="A cross-compilation toolkit designed to make embedded Linux application development easier"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/sbox2"
-SRC_URI="http://cgit.freedesktop.org/${MY_PN}/snapshot/${MY_P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/sbox2"
+SRC_URI="https://cgit.freedesktop.org/${MY_PN}/snapshot/${MY_P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-java/dbus-java/dbus-java-2.7-r1.ebuild
+++ b/dev-java/dbus-java/dbus-java-2.7-r1.ebuild
@@ -8,8 +8,8 @@ JAVA_PKG_IUSE="doc source"
 inherit eutils java-pkg-2
 
 DESCRIPTION="Java bindings for the D-Bus messagebus"
-HOMEPAGE="http://dbus.freedesktop.org/"
-SRC_URI="http://dbus.freedesktop.org/releases/dbus-java/${P}.tar.gz"
+HOMEPAGE="https://dbus.freedesktop.org/"
+SRC_URI="https://dbus.freedesktop.org/releases/dbus-java/${P}.tar.gz"
 
 LICENSE="|| ( GPL-2 AFL-2.1 )"
 SLOT="0"

--- a/dev-lang/orc/orc-0.4.23.ebuild
+++ b/dev-lang/orc/orc-0.4.23.ebuild
@@ -7,8 +7,8 @@ EAPI="5"
 inherit autotools-multilib flag-o-matic gnome2-utils
 
 DESCRIPTION="The Oil Runtime Compiler, a just-in-time compiler for array operations"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="BSD BSD-2"
 SLOT="0"

--- a/dev-lang/orc/orc-0.4.24.ebuild
+++ b/dev-lang/orc/orc-0.4.24.ebuild
@@ -6,8 +6,8 @@ EAPI="5"
 inherit autotools-multilib flag-o-matic gnome2-utils pax-utils
 
 DESCRIPTION="The Oil Runtime Compiler, a just-in-time compiler for array operations"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="BSD BSD-2"
 SLOT="0"

--- a/dev-lang/orc/orc-0.4.25.ebuild
+++ b/dev-lang/orc/orc-0.4.25.ebuild
@@ -6,8 +6,8 @@ EAPI="5"
 inherit autotools-multilib flag-o-matic gnome2-utils pax-utils
 
 DESCRIPTION="The Oil Runtime Compiler, a just-in-time compiler for array operations"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="BSD BSD-2"
 SLOT="0"

--- a/dev-libs/appstream-glib/appstream-glib-0.5.0.ebuild
+++ b/dev-libs/appstream-glib/appstream-glib-0.5.0.ebuild
@@ -9,8 +9,8 @@ GNOME2_LA_PUNT="yes"
 inherit bash-completion-r1 gnome2
 
 DESCRIPTION="Provides GObjects and helper methods to read and write AppStream metadata"
-HOMEPAGE="http://people.freedesktop.org/~hughsient/appstream-glib/"
-SRC_URI="http://people.freedesktop.org/~hughsient/${PN}/releases/${P}.tar.xz"
+HOMEPAGE="https://people.freedesktop.org/~hughsient/appstream-glib/"
+SRC_URI="https://people.freedesktop.org/~hughsient/${PN}/releases/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/8" # soname version

--- a/dev-libs/appstream-glib/appstream-glib-0.5.7.ebuild
+++ b/dev-libs/appstream-glib/appstream-glib-0.5.7.ebuild
@@ -9,8 +9,8 @@ GNOME2_LA_PUNT="yes"
 inherit bash-completion-r1 gnome2
 
 DESCRIPTION="Provides GObjects and helper methods to read and write AppStream metadata"
-HOMEPAGE="http://people.freedesktop.org/~hughsient/appstream-glib/"
-SRC_URI="http://people.freedesktop.org/~hughsient/${PN}/releases/${P}.tar.xz"
+HOMEPAGE="https://people.freedesktop.org/~hughsient/appstream-glib/"
+SRC_URI="https://people.freedesktop.org/~hughsient/${PN}/releases/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/8" # soname version

--- a/dev-libs/appstream-glib/appstream-glib-0.5.9.ebuild
+++ b/dev-libs/appstream-glib/appstream-glib-0.5.9.ebuild
@@ -9,8 +9,8 @@ GNOME2_LA_PUNT="yes"
 inherit bash-completion-r1 gnome2
 
 DESCRIPTION="Provides GObjects and helper methods to read and write AppStream metadata"
-HOMEPAGE="http://people.freedesktop.org/~hughsient/appstream-glib/"
-SRC_URI="http://people.freedesktop.org/~hughsient/${PN}/releases/${P}.tar.xz"
+HOMEPAGE="https://people.freedesktop.org/~hughsient/appstream-glib/"
+SRC_URI="https://people.freedesktop.org/~hughsient/${PN}/releases/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/8" # soname version

--- a/dev-libs/dbus-glib/dbus-glib-0.102.ebuild
+++ b/dev-libs/dbus-glib/dbus-glib-0.102.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit bash-completion-r1 eutils multilib-minimal
 
 DESCRIPTION="D-Bus bindings for glib"
-HOMEPAGE="http://dbus.freedesktop.org/"
-SRC_URI="http://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://dbus.freedesktop.org/"
+SRC_URI="https://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="|| ( GPL-2 AFL-2.1 )"
 SLOT="0"

--- a/dev-libs/dbus-glib/dbus-glib-0.104.ebuild
+++ b/dev-libs/dbus-glib/dbus-glib-0.104.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit bash-completion-r1 eutils multilib-minimal
 
 DESCRIPTION="D-Bus bindings for glib"
-HOMEPAGE="http://dbus.freedesktop.org/"
-SRC_URI="http://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://dbus.freedesktop.org/"
+SRC_URI="https://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="|| ( GPL-2 AFL-2.1 )"
 SLOT="0"

--- a/dev-libs/dbus-glib/dbus-glib-0.106.ebuild
+++ b/dev-libs/dbus-glib/dbus-glib-0.106.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit bash-completion-r1 eutils multilib-minimal
 
 DESCRIPTION="D-Bus bindings for glib"
-HOMEPAGE="http://dbus.freedesktop.org/"
-SRC_URI="http://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://dbus.freedesktop.org/"
+SRC_URI="https://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="|| ( GPL-2 AFL-2.1 )"
 SLOT="0"

--- a/dev-libs/glib/glib-2.44.1-r1.ebuild
+++ b/dev-libs/glib/glib-2.44.1-r1.ebuild
@@ -22,7 +22,7 @@ inherit autotools bash-completion-r1 gnome2 libtool eutils flag-o-matic	multilib
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="http://www.gtk.org/"
 SRC_URI="${SRC_URI}
-	http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
+	https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
 
 LICENSE="LGPL-2+"
 SLOT="2"

--- a/dev-libs/glib/glib-2.46.2-r1.ebuild
+++ b/dev-libs/glib/glib-2.46.2-r1.ebuild
@@ -22,7 +22,7 @@ inherit autotools bash-completion-r1 gnome2 libtool eutils flag-o-matic	multilib
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="http://www.gtk.org/"
 SRC_URI="${SRC_URI}
-	http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
+	https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
 
 LICENSE="LGPL-2+"
 SLOT="2"

--- a/dev-libs/glib/glib-2.46.2-r2.ebuild
+++ b/dev-libs/glib/glib-2.46.2-r2.ebuild
@@ -22,7 +22,7 @@ inherit autotools bash-completion-r1 gnome2 libtool eutils flag-o-matic	multilib
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="http://www.gtk.org/"
 SRC_URI="${SRC_URI}
-	http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
+	https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
 
 LICENSE="LGPL-2+"
 SLOT="2"

--- a/dev-libs/glib/glib-2.48.0.ebuild
+++ b/dev-libs/glib/glib-2.48.0.ebuild
@@ -22,7 +22,7 @@ inherit autotools bash-completion-r1 gnome2 libtool eutils flag-o-matic	multilib
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="http://www.gtk.org/"
 SRC_URI="${SRC_URI}
-	http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
+	https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
 
 LICENSE="LGPL-2+"
 SLOT="2"

--- a/dev-libs/libbsd/libbsd-0.8.2.ebuild
+++ b/dev-libs/libbsd/libbsd-0.8.2.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib-minimal
 
 DESCRIPTION="An library to provide useful functions commonly found on BSD systems"
-HOMEPAGE="http://libbsd.freedesktop.org/wiki/"
-SRC_URI="http://${PN}.freedesktop.org/releases/${P}.tar.xz"
+HOMEPAGE="https://libbsd.freedesktop.org/wiki/"
+SRC_URI="https://${PN}.freedesktop.org/releases/${P}.tar.xz"
 
 LICENSE="BSD BSD-2 BSD-4 ISC"
 SLOT="0"
@@ -31,7 +31,7 @@ pkg_setup() {
 multilib_src_configure() {
 	# The build system will install libbsd-ctor.a despite of USE="-static-libs"
 	# which is correct, see:
-	# http://cgit.freedesktop.org/libbsd/commit/?id=c5b959028734ca2281250c85773d9b5e1d259bc8
+	# https://cgit.freedesktop.org/libbsd/commit/?id=c5b959028734ca2281250c85773d9b5e1d259bc8
 	ECONF_SOURCE="${S}" econf $(use_enable static-libs static)
 }
 

--- a/dev-libs/libevdev/libevdev-1.3.ebuild
+++ b/dev-libs/libevdev/libevdev-1.3.ebuild
@@ -15,7 +15,7 @@ DESCRIPTION="Handler library for evdev events"
 if [[ ${PV} == 9999* ]] ; then
 	SRC_URI=""
 else
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 RESTRICT="test" # Tests need to run as root.

--- a/dev-libs/libevdev/libevdev-1.4.4.ebuild
+++ b/dev-libs/libevdev/libevdev-1.4.4.ebuild
@@ -15,7 +15,7 @@ DESCRIPTION="Handler library for evdev events"
 if [[ ${PV} == 9999* ]] ; then
 	SRC_URI=""
 else
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 RESTRICT="test" # Tests need to run as root.

--- a/dev-libs/libevdev/libevdev-1.4.5.ebuild
+++ b/dev-libs/libevdev/libevdev-1.4.5.ebuild
@@ -15,7 +15,7 @@ DESCRIPTION="Handler library for evdev events"
 if [[ ${PV} == 9999* ]] ; then
 	SRC_URI=""
 else
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 RESTRICT="test" # Tests need to run as root.

--- a/dev-libs/libevdev/libevdev-1.4.6.ebuild
+++ b/dev-libs/libevdev/libevdev-1.4.6.ebuild
@@ -15,7 +15,7 @@ DESCRIPTION="Handler library for evdev events"
 if [[ ${PV} == 9999* ]] ; then
 	SRC_URI=""
 else
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 RESTRICT="test" # Tests need to run as root.

--- a/dev-libs/libgamin/libgamin-0.1.10-r4.ebuild
+++ b/dev-libs/libgamin/libgamin-0.1.10-r4.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://www.gnome.org/~veillard/gamin/"
 SRC_URI="${SRC_URI}
 	mirror://gentoo/gamin-0.1.9-freebsd.patch.bz2
 	https://dev.gentoo.org/~grobian/patches/libgamin-0.1.10-opensolaris.patch.bz2
-	http://pkgconfig.freedesktop.org/releases/pkg-config-0.26.tar.gz" # pkg.m4 for eautoreconf
+	https://pkgconfig.freedesktop.org/releases/pkg-config-0.26.tar.gz" # pkg.m4 for eautoreconf
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/dev-libs/libgamin/libgamin-0.1.10-r5.ebuild
+++ b/dev-libs/libgamin/libgamin-0.1.10-r5.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://www.gnome.org/~veillard/gamin/"
 SRC_URI="${SRC_URI}
 	mirror://gentoo/gamin-0.1.9-freebsd.patch.bz2
 	https://dev.gentoo.org/~grobian/patches/libgamin-0.1.10-opensolaris.patch.bz2
-	http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
+	https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/dev-libs/libgusb/libgusb-0.2.7.ebuild
+++ b/dev-libs/libgusb/libgusb-0.2.7.ebuild
@@ -10,7 +10,7 @@ inherit eutils gnome2 multilib-minimal vala
 
 DESCRIPTION="GObject wrapper for libusb"
 HOMEPAGE="https://github.com/hughsie/libgusb"
-SRC_URI="http://people.freedesktop.org/~hughsient/releases/${P}.tar.xz"
+SRC_URI="https://people.freedesktop.org/~hughsient/releases/${P}.tar.xz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"

--- a/dev-libs/libgusb/libgusb-0.2.8.ebuild
+++ b/dev-libs/libgusb/libgusb-0.2.8.ebuild
@@ -10,7 +10,7 @@ inherit eutils gnome2 multilib-minimal vala
 
 DESCRIPTION="GObject wrapper for libusb"
 HOMEPAGE="https://github.com/hughsie/libgusb"
-SRC_URI="http://people.freedesktop.org/~hughsient/releases/${P}.tar.xz"
+SRC_URI="https://people.freedesktop.org/~hughsient/releases/${P}.tar.xz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"

--- a/dev-libs/libinput/libinput-0.9.0.ebuild
+++ b/dev-libs/libinput/libinput-0.9.0.ebuild
@@ -7,8 +7,8 @@ EAPI="5"
 inherit eutils
 
 DESCRIPTION="Library to handle input devices in Wayland"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libinput/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libinput/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 # License appears to be a variant of libtiff
 LICENSE="libtiff"

--- a/dev-libs/libinput/libinput-1.1.0.ebuild
+++ b/dev-libs/libinput/libinput-1.1.0.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils udev
 
 DESCRIPTION="Library to handle input devices in Wayland"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libinput/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libinput/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0/10"

--- a/dev-libs/libinput/libinput-1.1.5.ebuild
+++ b/dev-libs/libinput/libinput-1.1.5.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils udev
 
 DESCRIPTION="Library to handle input devices in Wayland"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libinput/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libinput/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0/10"

--- a/dev-libs/libinput/libinput-1.2.2.ebuild
+++ b/dev-libs/libinput/libinput-1.2.2.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils udev
 
 DESCRIPTION="Library to handle input devices in Wayland"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libinput/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libinput/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0/10"

--- a/dev-libs/libinput/libinput-1.2.3.ebuild
+++ b/dev-libs/libinput/libinput-1.2.3.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils udev
 
 DESCRIPTION="Library to handle input devices in Wayland"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libinput/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libinput/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0/10"

--- a/dev-libs/liblazy/liblazy-0.2.ebuild
+++ b/dev-libs/liblazy/liblazy-0.2.ebuild
@@ -3,8 +3,8 @@
 # $Id$
 
 DESCRIPTION="lib for D-Bus daemon messages, querying HAL or PolicyKit privileges"
-HOMEPAGE="http://freedesktop.org/wiki/Software/liblazy"
-SRC_URI="http://people.freedesktop.org/~homac/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://freedesktop.org/wiki/Software/liblazy"
+SRC_URI="https://people.freedesktop.org/~homac/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-libs/liboil/liboil-0.3.17-r1.ebuild
+++ b/dev-libs/liboil/liboil-0.3.17-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=4
 inherit eutils flag-o-matic multilib
 
 DESCRIPTION="Library of simple functions that are optimized for various CPUs"
-HOMEPAGE="http://liboil.freedesktop.org/"
-SRC_URI="http://liboil.freedesktop.org/download/${P}.tar.gz"
+HOMEPAGE="https://liboil.freedesktop.org/"
+SRC_URI="https://liboil.freedesktop.org/download/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0.3"

--- a/dev-libs/liboil/liboil-0.3.17-r2.ebuild
+++ b/dev-libs/liboil/liboil-0.3.17-r2.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils flag-o-matic multilib autotools-multilib
 
 DESCRIPTION="Library of simple functions that are optimized for various CPUs"
-HOMEPAGE="http://liboil.freedesktop.org/"
-SRC_URI="http://liboil.freedesktop.org/download/${P}.tar.gz"
+HOMEPAGE="https://liboil.freedesktop.org/"
+SRC_URI="https://liboil.freedesktop.org/download/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0.3"

--- a/dev-libs/liboil/liboil-0.3.17.ebuild
+++ b/dev-libs/liboil/liboil-0.3.17.ebuild
@@ -6,8 +6,8 @@ EAPI=2
 inherit eutils flag-o-matic multilib
 
 DESCRIPTION="Library of simple functions that are optimized for various CPUs"
-HOMEPAGE="http://liboil.freedesktop.org/"
-SRC_URI="http://liboil.freedesktop.org/download/${P}.tar.gz"
+HOMEPAGE="https://liboil.freedesktop.org/"
+SRC_URI="https://liboil.freedesktop.org/download/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0.3"

--- a/dev-libs/libpthread-stubs/libpthread-stubs-0.1.ebuild
+++ b/dev-libs/libpthread-stubs/libpthread-stubs-0.1.ebuild
@@ -9,7 +9,7 @@ EAPI=3
 inherit xorg-2
 
 DESCRIPTION="Pthread functions stubs for platforms missing them"
-SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~x86-fbsd ~x64-freebsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""

--- a/dev-libs/libpthread-stubs/libpthread-stubs-0.3-r1.ebuild
+++ b/dev-libs/libpthread-stubs/libpthread-stubs-0.3-r1.ebuild
@@ -8,7 +8,7 @@ XORG_MULTILIB=yes
 inherit xorg-2
 
 DESCRIPTION="Pthread functions stubs for platforms missing them"
-SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""

--- a/dev-libs/libpthread-stubs/libpthread-stubs-0.3.ebuild
+++ b/dev-libs/libpthread-stubs/libpthread-stubs-0.3.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 inherit xorg-2
 
 DESCRIPTION="Pthread functions stubs for platforms missing them"
-SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""

--- a/dev-libs/wayland-protocols/wayland-protocols-1.3.ebuild
+++ b/dev-libs/wayland-protocols/wayland-protocols-1.3.ebuild
@@ -14,13 +14,13 @@ fi
 inherit autotools-multilib $GIT_ECLASS
 
 DESCRIPTION="Wayland protocol files"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS=""
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/dev-libs/wayland-protocols/wayland-protocols-9999.ebuild
+++ b/dev-libs/wayland-protocols/wayland-protocols-9999.ebuild
@@ -14,13 +14,13 @@ fi
 inherit autotools-multilib $GIT_ECLASS
 
 DESCRIPTION="Wayland protocol files"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS=""
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/dev-libs/wayland/wayland-1.10.0-r1.ebuild
+++ b/dev-libs/wayland/wayland-1.10.0-r1.ebuild
@@ -14,13 +14,13 @@ fi
 inherit autotools-multilib toolchain-funcs $GIT_ECLASS
 
 DESCRIPTION="Wayland protocol libraries"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS=""
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/dev-libs/wayland/wayland-1.6.1.ebuild
+++ b/dev-libs/wayland/wayland-1.6.1.ebuild
@@ -14,12 +14,12 @@ fi
 inherit autotools-multilib toolchain-funcs $GIT_ECLASS
 
 DESCRIPTION="Wayland protocol libraries"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 fi
 
 LICENSE="MIT"

--- a/dev-libs/wayland/wayland-1.7.0.ebuild
+++ b/dev-libs/wayland/wayland-1.7.0.ebuild
@@ -14,12 +14,12 @@ fi
 inherit autotools-multilib toolchain-funcs $GIT_ECLASS
 
 DESCRIPTION="Wayland protocol libraries"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 fi
 
 LICENSE="MIT"

--- a/dev-libs/wayland/wayland-1.8.1.ebuild
+++ b/dev-libs/wayland/wayland-1.8.1.ebuild
@@ -14,12 +14,12 @@ fi
 inherit autotools-multilib toolchain-funcs $GIT_ECLASS
 
 DESCRIPTION="Wayland protocol libraries"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ ${PV} == 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 fi
 
 LICENSE="MIT"

--- a/dev-libs/wayland/wayland-1.9.0.ebuild
+++ b/dev-libs/wayland/wayland-1.9.0.ebuild
@@ -14,13 +14,13 @@ fi
 inherit autotools-multilib toolchain-funcs $GIT_ECLASS
 
 DESCRIPTION="Wayland protocol libraries"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS="arm hppa ppc64"
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~alpha amd64 arm hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh ~sparc x86"
 fi
 

--- a/dev-libs/wayland/wayland-9999.ebuild
+++ b/dev-libs/wayland/wayland-9999.ebuild
@@ -14,13 +14,13 @@ fi
 inherit autotools-multilib toolchain-funcs $GIT_ECLASS
 
 DESCRIPTION="Wayland protocol libraries"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS=""
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/dev-libs/weston/weston-1.10.0.ebuild
+++ b/dev-libs/weston/weston-1.10.0.ebuild
@@ -15,13 +15,13 @@ RESTRICT="test"
 inherit autotools readme.gentoo-r1 toolchain-funcs virtualx $GIT_ECLASS
 
 DESCRIPTION="Wayland reference compositor"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS=""
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~x86 ~arm-linux"
 fi
 

--- a/dev-libs/weston/weston-1.6.1.ebuild
+++ b/dev-libs/weston/weston-1.6.1.ebuild
@@ -15,12 +15,12 @@ RESTRICT="test"
 inherit autotools readme.gentoo toolchain-funcs virtualx $GIT_ECLASS
 
 DESCRIPTION="Wayland reference compositor"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 fi
 
 LICENSE="MIT CC-BY-SA-3.0"

--- a/dev-libs/weston/weston-1.7.0.ebuild
+++ b/dev-libs/weston/weston-1.7.0.ebuild
@@ -15,12 +15,12 @@ RESTRICT="test"
 inherit autotools readme.gentoo toolchain-funcs virtualx $GIT_ECLASS
 
 DESCRIPTION="Wayland reference compositor"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 fi
 
 LICENSE="MIT CC-BY-SA-3.0"

--- a/dev-libs/weston/weston-1.8.0.ebuild
+++ b/dev-libs/weston/weston-1.8.0.ebuild
@@ -15,13 +15,13 @@ RESTRICT="test"
 inherit autotools readme.gentoo toolchain-funcs virtualx $GIT_ECLASS
 
 DESCRIPTION="Wayland reference compositor"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS=""
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~x86 ~arm-linux"
 fi
 

--- a/dev-libs/weston/weston-1.9.0.ebuild
+++ b/dev-libs/weston/weston-1.9.0.ebuild
@@ -15,13 +15,13 @@ RESTRICT="test"
 inherit autotools readme.gentoo toolchain-funcs virtualx $GIT_ECLASS
 
 DESCRIPTION="Wayland reference compositor"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS="arm"
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="amd64 arm x86 ~arm-linux"
 fi
 

--- a/dev-libs/weston/weston-9999.ebuild
+++ b/dev-libs/weston/weston-9999.ebuild
@@ -15,13 +15,13 @@ RESTRICT="test"
 inherit autotools readme.gentoo-r1 toolchain-funcs virtualx $GIT_ECLASS
 
 DESCRIPTION="Wayland reference compositor"
-HOMEPAGE="http://wayland.freedesktop.org/"
+HOMEPAGE="https://wayland.freedesktop.org/"
 
 if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 	KEYWORDS=""
 else
-	SRC_URI="http://wayland.freedesktop.org/releases/${P}.tar.xz"
+	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~x86 ~arm-linux"
 fi
 

--- a/dev-ml/cairo-ocaml/cairo-ocaml-1.2.0.ebuild
+++ b/dev-ml/cairo-ocaml/cairo-ocaml-1.2.0.ebuild
@@ -8,7 +8,7 @@ inherit eutils findlib autotools
 
 DESCRIPTION="Ocaml bindings for the cairo vector graphics library"
 HOMEPAGE="http://www.cairographics.org/cairo-ocaml/"
-SRC_URI="http://cgit.freedesktop.org/cairo-ocaml/snapshot/${P}.tar.bz2"
+SRC_URI="https://cgit.freedesktop.org/cairo-ocaml/snapshot/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0/${PV}"

--- a/dev-python/dbus-python/dbus-python-1.2.0-r1.ebuild
+++ b/dev-python/dbus-python/dbus-python-1.2.0-r1.ebuild
@@ -10,8 +10,8 @@ PYTHON_REQ_USE="threads(+)"
 inherit autotools eutils python-r1
 
 DESCRIPTION="Python bindings for the D-Bus messagebus"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/DBusBindings http://dbus.freedesktop.org/doc/dbus-python/"
-SRC_URI="http://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/DBusBindings https://dbus.freedesktop.org/doc/dbus-python/"
+SRC_URI="https://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-python/dbus-python/dbus-python-1.2.4.ebuild
+++ b/dev-python/dbus-python/dbus-python-1.2.4.ebuild
@@ -10,8 +10,8 @@ PYTHON_REQ_USE="threads(+)"
 inherit autotools eutils python-r1
 
 DESCRIPTION="Python bindings for the D-Bus messagebus"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/DBusBindings http://dbus.freedesktop.org/doc/dbus-python/"
-SRC_URI="http://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/DBusBindings https://dbus.freedesktop.org/doc/dbus-python/"
+SRC_URI="https://dbus.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-python/gst-python/gst-python-0.10.22-r1.ebuild
+++ b/dev-python/gst-python/gst-python-0.10.22-r1.ebuild
@@ -9,8 +9,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools eutils python-r1 virtualx
 
 DESCRIPTION="A Python Interface to GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2"
 SLOT="0.10"

--- a/dev-python/gst-python/gst-python-1.2.1.ebuild
+++ b/dev-python/gst-python/gst-python-1.2.1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4} )
 inherit python-r1
 
 DESCRIPTION="A Python Interface to GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2"
 SLOT="1.0"

--- a/dev-python/gst-python/gst-python-1.4.0.ebuild
+++ b/dev-python/gst-python/gst-python-1.4.0.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4} )
 inherit python-r1
 
 DESCRIPTION="A Python Interface to GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2"
 SLOT="1.0"

--- a/dev-python/gst-python/gst-python-1.6.1.ebuild
+++ b/dev-python/gst-python/gst-python-1.6.1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 python{3_3,3_4,3_5} )
 inherit python-r1
 
 DESCRIPTION="A Python Interface to GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2"
 SLOT="1.0"

--- a/dev-python/gst-python/gst-python-1.6.2.ebuild
+++ b/dev-python/gst-python/gst-python-1.6.2.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 python{3_3,3_4,3_5} )
 inherit python-r1
 
 DESCRIPTION="A Python Interface to GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2"
 SLOT="1.0"

--- a/dev-python/pyxdg/pyxdg-0.25-r1.ebuild
+++ b/dev-python/pyxdg/pyxdg-0.25-r1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} pypy )
 inherit distutils-r1
 
 DESCRIPTION="A Python module to deal with freedesktop.org specifications"
-HOMEPAGE="http://freedesktop.org/wiki/Software/pyxdg http://cgit.freedesktop.org/xdg/pyxdg/"
-SRC_URI="http://people.freedesktop.org/~takluyver/${P}.tar.gz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/pyxdg https://cgit.freedesktop.org/xdg/pyxdg/"
+SRC_URI="https://people.freedesktop.org/~takluyver/${P}.tar.gz"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/dev-util/cppunit/cppunit-1.13.1.ebuild
+++ b/dev-util/cppunit/cppunit-1.13.1.ebuild
@@ -9,7 +9,7 @@ EGIT_REPO_URI="git://anongit.freedesktop.org/libreoffice/cppunit"
 inherit eutils flag-o-matic
 
 DESCRIPTION="C++ port of the famous JUnit framework for unit testing"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/cppunit"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/cppunit"
 [[ ${PV} = 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-util/cppunit/cppunit-1.13.2-r2.ebuild
+++ b/dev-util/cppunit/cppunit-1.13.2-r2.ebuild
@@ -9,7 +9,7 @@ EGIT_REPO_URI="git://anongit.freedesktop.org/libreoffice/cppunit"
 inherit eutils flag-o-matic multilib-minimal
 
 DESCRIPTION="C++ port of the famous JUnit framework for unit testing"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/cppunit"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/cppunit"
 [[ ${PV} = 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-util/cppunit/cppunit-9999.ebuild
+++ b/dev-util/cppunit/cppunit-9999.ebuild
@@ -9,7 +9,7 @@ EGIT_REPO_URI="git://anongit.freedesktop.org/libreoffice/cppunit"
 inherit eutils flag-o-matic multilib-minimal
 
 DESCRIPTION="C++ port of the famous JUnit framework for unit testing"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/cppunit"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/cppunit"
 [[ ${PV} = 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-util/desktop-file-utils/desktop-file-utils-0.21.ebuild
+++ b/dev-util/desktop-file-utils/desktop-file-utils-0.21.ebuild
@@ -6,8 +6,8 @@ EAPI=4
 inherit elisp-common eutils
 
 DESCRIPTION="Command line utilities to work with desktop menu entries"
-HOMEPAGE="http://freedesktop.org/wiki/Software/desktop-file-utils"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/desktop-file-utils"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/dev-util/desktop-file-utils/desktop-file-utils-0.22.ebuild
+++ b/dev-util/desktop-file-utils/desktop-file-utils-0.22.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit elisp-common eutils
 
 DESCRIPTION="Command line utilities to work with desktop menu entries"
-HOMEPAGE="http://freedesktop.org/wiki/Software/desktop-file-utils"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/desktop-file-utils"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/dev-util/pkgconfig-openbsd/pkgconfig-openbsd-20130507-r1.ebuild
+++ b/dev-util/pkgconfig-openbsd/pkgconfig-openbsd-20130507-r1.ebuild
@@ -14,7 +14,7 @@ PKG_M4_VERSION=0.28
 DESCRIPTION="A perl based version of pkg-config from OpenBSD"
 HOMEPAGE="http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/pkg-config/"
 SRC_URI="https://dev.gentoo.org/~ssuominen/${P}.tar.xz
-	pkg-config? ( http://pkgconfig.freedesktop.org/releases/pkg-config-${PKG_M4_VERSION}.tar.gz )"
+	pkg-config? ( https://pkgconfig.freedesktop.org/releases/pkg-config-${PKG_M4_VERSION}.tar.gz )"
 
 LICENSE="ISC"
 SLOT="0"

--- a/dev-util/pkgconfig-openbsd/pkgconfig-openbsd-20130507-r2.ebuild
+++ b/dev-util/pkgconfig-openbsd/pkgconfig-openbsd-20130507-r2.ebuild
@@ -14,7 +14,7 @@ PKG_M4_VERSION=0.28
 DESCRIPTION="A perl based version of pkg-config from OpenBSD"
 HOMEPAGE="http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/pkg-config/"
 SRC_URI="https://dev.gentoo.org/~ssuominen/${P}.tar.xz
-	pkg-config? ( http://pkgconfig.freedesktop.org/releases/pkg-config-${PKG_M4_VERSION}.tar.gz )"
+	pkg-config? ( https://pkgconfig.freedesktop.org/releases/pkg-config-${PKG_M4_VERSION}.tar.gz )"
 
 LICENSE="ISC"
 SLOT="0"

--- a/dev-util/pkgconfig/pkgconfig-0.28-r2.ebuild
+++ b/dev-util/pkgconfig/pkgconfig-0.28-r2.ebuild
@@ -13,11 +13,11 @@ if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-2
 else
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-	SRC_URI="http://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
+	SRC_URI="https://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
 fi
 
 DESCRIPTION="Package config system that manages compile/link flags"
-HOMEPAGE="http://pkgconfig.freedesktop.org/wiki/"
+HOMEPAGE="https://pkgconfig.freedesktop.org/wiki/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/pkgconfig/pkgconfig-0.28-r3.ebuild
+++ b/dev-util/pkgconfig/pkgconfig-0.28-r3.ebuild
@@ -18,11 +18,11 @@ if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
 else
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-	SRC_URI="http://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
+	SRC_URI="https://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
 fi
 
 DESCRIPTION="Package config system that manages compile/link flags"
-HOMEPAGE="http://pkgconfig.freedesktop.org/wiki/"
+HOMEPAGE="https://pkgconfig.freedesktop.org/wiki/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/pkgconfig/pkgconfig-0.29.1.ebuild
+++ b/dev-util/pkgconfig/pkgconfig-0.29.1.ebuild
@@ -18,11 +18,11 @@ if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
 else
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-	SRC_URI="http://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
+	SRC_URI="https://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
 fi
 
 DESCRIPTION="Package config system that manages compile/link flags"
-HOMEPAGE="http://pkgconfig.freedesktop.org/wiki/"
+HOMEPAGE="https://pkgconfig.freedesktop.org/wiki/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/pkgconfig/pkgconfig-0.29.ebuild
+++ b/dev-util/pkgconfig/pkgconfig-0.29.ebuild
@@ -18,11 +18,11 @@ if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
 else
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-	SRC_URI="http://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
+	SRC_URI="https://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
 fi
 
 DESCRIPTION="Package config system that manages compile/link flags"
-HOMEPAGE="http://pkgconfig.freedesktop.org/wiki/"
+HOMEPAGE="https://pkgconfig.freedesktop.org/wiki/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/pkgconfig/pkgconfig-9999.ebuild
+++ b/dev-util/pkgconfig/pkgconfig-9999.ebuild
@@ -18,11 +18,11 @@ if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
 else
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-	SRC_URI="http://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
+	SRC_URI="https://pkgconfig.freedesktop.org/releases/${MY_P}.tar.gz"
 fi
 
 DESCRIPTION="Package config system that manages compile/link flags"
-HOMEPAGE="http://pkgconfig.freedesktop.org/wiki/"
+HOMEPAGE="https://pkgconfig.freedesktop.org/wiki/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/eclass/eutils.eclass
+++ b/eclass/eutils.eclass
@@ -689,7 +689,7 @@ edos2unix() {
 #           a full path to an icon
 # type:     what kind of application is this?
 #           for categories:
-#           http://standards.freedesktop.org/menu-spec/latest/apa.html
+#           https://specifications.freedesktop.org/menu-spec/latest/apa.html
 #           if unset, function tries to guess from package's category
 # fields:	extra fields to append to the desktop file; a printf string
 # @CODE

--- a/eclass/gst-plugins10.eclass
+++ b/eclass/gst-plugins10.eclass
@@ -98,8 +98,8 @@ fi
 
 
 DESCRIPTION="${BUILD_GST_PLUGINS} plugin for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${GST_ORG_MODULE}/${GST_ORG_MODULE}-${PV}.tar.${GST_TARBALL_SUFFIX}"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${GST_ORG_MODULE}/${GST_ORG_MODULE}-${PV}.tar.${GST_TARBALL_SUFFIX}"
 
 LICENSE="GPL-2"
 case ${GST_ORG_PVP} in

--- a/eclass/gstreamer.eclass
+++ b/eclass/gstreamer.eclass
@@ -77,8 +77,8 @@ fi
 
 
 DESCRIPTION="${BUILD_GST_PLUGINS} plugin for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${GST_ORG_MODULE}/${GST_ORG_MODULE}-${PV}.tar.${GST_TARBALL_SUFFIX}"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${GST_ORG_MODULE}/${GST_ORG_MODULE}-${PV}.tar.${GST_TARBALL_SUFFIX}"
 
 LICENSE="GPL-2"
 case ${GST_ORG_PVP} in

--- a/gnome-extra/gnome-packagekit/gnome-packagekit-3.18.0.ebuild
+++ b/gnome-extra/gnome-packagekit/gnome-packagekit-3.18.0.ebuild
@@ -8,7 +8,7 @@ GCONF_DEBUG="no"
 inherit gnome2 virtualx
 
 DESCRIPTION="PackageKit client for the GNOME desktop"
-HOMEPAGE="http://www.freedesktop.org/software/PackageKit/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/gnome-extra/polkit-gnome/polkit-gnome-0.105-r1.ebuild
+++ b/gnome-extra/polkit-gnome/polkit-gnome-0.105-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 inherit gnome.org
 
 DESCRIPTION="A dbus session bus service that is used to bring up authentication dialogs"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/polkit"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/polkit"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/media-fonts/arphicfonts/arphicfonts-0.2.20080216.1-r2.ebuild
+++ b/media-fonts/arphicfonts/arphicfonts-0.2.20080216.1-r2.ebuild
@@ -7,7 +7,7 @@ inherit font eutils
 
 DESCRIPTION="Chinese TrueType Arphic Fonts"
 HOMEPAGE="http://www.arphic.com.tw/
-	http://www.freedesktop.org/wiki/Software/CJKUnifonts"
+	https://www.freedesktop.org/wiki/Software/CJKUnifonts"
 SRC_URI="mirror://gnu/non-gnu/chinese-fonts-truetype/gkai00mp.ttf.gz
 	mirror://gnu/non-gnu/chinese-fonts-truetype/bkai00mp.ttf.gz
 	mirror://gnu/non-gnu/chinese-fonts-truetype/bsmi00lp.ttf.gz

--- a/media-gfx/colorhug-client/colorhug-client-0.2.7.ebuild
+++ b/media-gfx/colorhug-client/colorhug-client-0.2.7.ebuild
@@ -9,7 +9,7 @@ inherit bash-completion-r1 eutils gnome2
 
 DESCRIPTION="Client tools for the ColorHug display colorimeter"
 HOMEPAGE="http://www.hughski.com/"
-SRC_URI="http://people.freedesktop.org/~hughsient/releases/${P}.tar.xz"
+SRC_URI="https://people.freedesktop.org/~hughsient/releases/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-gfx/colorhug-client/colorhug-client-0.2.8.ebuild
+++ b/media-gfx/colorhug-client/colorhug-client-0.2.8.ebuild
@@ -9,7 +9,7 @@ inherit bash-completion-r1 eutils gnome2
 
 DESCRIPTION="Client tools for the ColorHug display colorimeter"
 HOMEPAGE="http://www.hughski.com/"
-SRC_URI="http://people.freedesktop.org/~hughsient/releases/${P}.tar.xz"
+SRC_URI="https://people.freedesktop.org/~hughsient/releases/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-gfx/gnome-raw-thumbnailer/gnome-raw-thumbnailer-3.0.0.ebuild
+++ b/media-gfx/gnome-raw-thumbnailer/gnome-raw-thumbnailer-3.0.0.ebuild
@@ -9,8 +9,8 @@ inherit gnome2
 MY_P=${PN/gnome-}-${PV}
 
 DESCRIPTION="A lightweight and fast raw image thumbnailer for GNOME"
-HOMEPAGE="http://libopenraw.freedesktop.org/wiki/RawThumbnailer"
-SRC_URI="http://libopenraw.freedesktop.org/download/${MY_P}.tar.bz2"
+HOMEPAGE="https://libopenraw.freedesktop.org/wiki/RawThumbnailer"
+SRC_URI="https://libopenraw.freedesktop.org/download/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-gfx/icon-slicer/icon-slicer-0.3.ebuild
+++ b/media-gfx/icon-slicer/icon-slicer-0.3.ebuild
@@ -5,8 +5,8 @@
 EAPI=2
 
 DESCRIPTION="utility for generating icon themes and libXcursor cursor themes"
-HOMEPAGE="http://www.freedesktop.org/software/icon-slicer/"
-SRC_URI="http://www.freedesktop.org/software/icon-slicer/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/software/icon-slicer/"
+SRC_URI="https://www.freedesktop.org/software/icon-slicer/releases/${P}.tar.gz"
 
 KEYWORDS="alpha amd64 ~hppa ia64 ppc sparc x86"
 LICENSE="GPL-2"

--- a/media-libs/exempi/exempi-2.2.0.ebuild
+++ b/media-libs/exempi/exempi-2.2.0.ebuild
@@ -6,8 +6,8 @@ EAPI=4
 inherit autotools eutils
 
 DESCRIPTION="Exempi is a port of the Adobe XMP SDK to work on UNIX"
-HOMEPAGE="http://libopenraw.freedesktop.org/wiki/Exempi"
-SRC_URI="http://libopenraw.freedesktop.org/download/${P}.tar.gz"
+HOMEPAGE="https://libopenraw.freedesktop.org/wiki/Exempi"
+SRC_URI="https://libopenraw.freedesktop.org/download/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="2"

--- a/media-libs/exempi/exempi-2.2.1.ebuild
+++ b/media-libs/exempi/exempi-2.2.1.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit autotools eutils
 
 DESCRIPTION="Exempi is a port of the Adobe XMP SDK to work on UNIX"
-HOMEPAGE="http://libopenraw.freedesktop.org/wiki/Exempi"
-SRC_URI="http://libopenraw.freedesktop.org/download/${P}.tar.gz"
+HOMEPAGE="https://libopenraw.freedesktop.org/wiki/Exempi"
+SRC_URI="https://libopenraw.freedesktop.org/download/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="2"

--- a/media-libs/glu/glu-9.0.0-r1.ebuild
+++ b/media-libs/glu/glu-9.0.0-r1.ebuild
@@ -15,7 +15,7 @@ fi
 inherit autotools-multilib multilib ${GIT_ECLASS}
 
 DESCRIPTION="The OpenGL Utility Library"
-HOMEPAGE="http://cgit.freedesktop.org/mesa/glu/"
+HOMEPAGE="https://cgit.freedesktop.org/mesa/glu/"
 
 if [[ ${PV} = 9999* ]]; then
 	SRC_URI=""

--- a/media-libs/glu/glu-9999.ebuild
+++ b/media-libs/glu/glu-9999.ebuild
@@ -15,7 +15,7 @@ fi
 inherit autotools-multilib multilib ${GIT_ECLASS}
 
 DESCRIPTION="The OpenGL Utility Library"
-HOMEPAGE="http://cgit.freedesktop.org/mesa/glu/"
+HOMEPAGE="https://cgit.freedesktop.org/mesa/glu/"
 
 if [[ ${PV} = 9999* ]]; then
 	SRC_URI=""

--- a/media-libs/gnonlin/gnonlin-0.10.17.ebuild
+++ b/media-libs/gnonlin/gnonlin-0.10.17.ebuild
@@ -6,7 +6,7 @@ EAPI="4"
 
 DESCRIPTION="Gnonlin is a set of GStreamer elements to ease the creation of non-linear multimedia editors"
 HOMEPAGE="http://gnonlin.sourceforge.net"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.bz2"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2"
 SLOT="0.10"

--- a/media-libs/gst-plugins-bad/gst-plugins-bad-0.10.23-r3.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-0.10.23-r3.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-bad"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Less plugins for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 SRC_URI+=" https://dev.gentoo.org/~tetromino/distfiles/${PN}/${P}-h264-patches.tar.xz"
 
 LICENSE="LGPL-2"

--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.4.5.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.4.5.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-bad"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Less plugins for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2"
 KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"

--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.6.3.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.6.3.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-bad"
 inherit eutils flag-o-matic gstreamer virtualx
 
 DESCRIPTION="Less plugins for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2"
 KEYWORDS="~alpha amd64 ~arm hppa ~ia64 ~ppc ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"

--- a/media-libs/gst-plugins-base/gst-plugins-base-0.10.36-r2.ebuild
+++ b/media-libs/gst-plugins-base/gst-plugins-base-0.10.36-r2.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-base"
 inherit eutils gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2+ LGPL-2+"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"

--- a/media-libs/gst-plugins-base/gst-plugins-base-1.4.5.ebuild
+++ b/media-libs/gst-plugins-base/gst-plugins-base-1.4.5.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-base"
 inherit gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2+ LGPL-2+"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"

--- a/media-libs/gst-plugins-base/gst-plugins-base-1.6.1.ebuild
+++ b/media-libs/gst-plugins-base/gst-plugins-base-1.6.1.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-base"
 inherit gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2+ LGPL-2+"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"

--- a/media-libs/gst-plugins-base/gst-plugins-base-1.6.2.ebuild
+++ b/media-libs/gst-plugins-base/gst-plugins-base-1.6.2.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-base"
 inherit gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2+ LGPL-2+"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"

--- a/media-libs/gst-plugins-base/gst-plugins-base-1.6.3.ebuild
+++ b/media-libs/gst-plugins-base/gst-plugins-base-1.6.3.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-base"
 inherit gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2+ LGPL-2+"
 KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ~ia64 ~mips ~ppc ppc64 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"

--- a/media-libs/gst-plugins-good/gst-plugins-good-0.10.31-r1.ebuild
+++ b/media-libs/gst-plugins-good/gst-plugins-good-0.10.31-r1.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-good"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2.1+"
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-plugins-good/gst-plugins-good-1.4.5.ebuild
+++ b/media-libs/gst-plugins-good/gst-plugins-good-1.4.5.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-good"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Basepack of plugins for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2.1+"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-plugins-good/gst-plugins-good-1.6.1.ebuild
+++ b/media-libs/gst-plugins-good/gst-plugins-good-1.6.1.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-good"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Basepack of plugins for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2.1+"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-plugins-good/gst-plugins-good-1.6.2.ebuild
+++ b/media-libs/gst-plugins-good/gst-plugins-good-1.6.2.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-good"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Basepack of plugins for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2.1+"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-plugins-good/gst-plugins-good-1.6.3.ebuild
+++ b/media-libs/gst-plugins-good/gst-plugins-good-1.6.3.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-good"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Basepack of plugins for GStreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2.1+"
 KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ~ia64 ~mips ~ppc ppc64 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-plugins-ugly/gst-plugins-ugly-1.4.5.ebuild
+++ b/media-libs/gst-plugins-ugly/gst-plugins-ugly-1.4.5.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-ugly"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-plugins-ugly/gst-plugins-ugly-1.6.1.ebuild
+++ b/media-libs/gst-plugins-ugly/gst-plugins-ugly-1.6.1.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-ugly"
 inherit eutils flag-o-matic gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-plugins-ugly/gst-plugins-ugly-1.6.2.ebuild
+++ b/media-libs/gst-plugins-ugly/gst-plugins-ugly-1.6.2.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-ugly"
 inherit eutils gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-plugins-ugly/gst-plugins-ugly-1.6.3.ebuild
+++ b/media-libs/gst-plugins-ugly/gst-plugins-ugly-1.6.3.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE="gst-plugins-ugly"
 inherit eutils gstreamer
 
 DESCRIPTION="Basepack of plugins for gstreamer"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="~alpha amd64 ~arm hppa ~ia64 ~mips ~ppc ppc64 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd"

--- a/media-libs/gst-rtsp-server/gst-rtsp-server-0.10.8-r1.ebuild
+++ b/media-libs/gst-rtsp-server/gst-rtsp-server-0.10.8-r1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils gstreamer python-r1 vala
 
 DESCRIPTION="A GStreamer based RTSP server"
-HOMEPAGE="http://people.freedesktop.org/~wtay/"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${PN/-server/}-${PV}.tar.bz2"
+HOMEPAGE="https://people.freedesktop.org/~wtay/"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${PN/-server/}-${PV}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0.10"

--- a/media-libs/gst-rtsp-server/gst-rtsp-server-1.4.5.ebuild
+++ b/media-libs/gst-rtsp-server/gst-rtsp-server-1.4.5.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit eutils gstreamer
 
 DESCRIPTION="A GStreamer based RTSP server"
-HOMEPAGE="http://people.freedesktop.org/~wtay/"
+HOMEPAGE="https://people.freedesktop.org/~wtay/"
 
 LICENSE="LGPL-2"
 KEYWORDS="amd64 x86"

--- a/media-libs/gst-rtsp-server/gst-rtsp-server-1.6.2.ebuild
+++ b/media-libs/gst-rtsp-server/gst-rtsp-server-1.6.2.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit eutils gstreamer
 
 DESCRIPTION="A GStreamer based RTSP server"
-HOMEPAGE="http://people.freedesktop.org/~wtay/"
+HOMEPAGE="https://people.freedesktop.org/~wtay/"
 
 LICENSE="LGPL-2"
 KEYWORDS="amd64 x86"

--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.4.0.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.4.0.ebuild
@@ -9,7 +9,7 @@ inherit gnome2
 
 DESCRIPTION="SDK for making video editors and more"
 HOMEPAGE="http://wiki.pitivi.org/wiki/GES"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2+"
 SLOT="1.0"

--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.6.1.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.6.1.ebuild
@@ -9,7 +9,7 @@ inherit bash-completion-r1 gnome2
 
 DESCRIPTION="SDK for making video editors and more"
 HOMEPAGE="http://wiki.pitivi.org/wiki/GES"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2+"
 SLOT="1.0"

--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.6.2.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.6.2.ebuild
@@ -9,7 +9,7 @@ inherit bash-completion-r1 gnome2
 
 DESCRIPTION="SDK for making video editors and more"
 HOMEPAGE="http://wiki.pitivi.org/wiki/GES"
-SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2+"
 SLOT="1.0"

--- a/media-libs/gstreamer/gstreamer-0.10.36-r2.ebuild
+++ b/media-libs/gstreamer/gstreamer-0.10.36-r2.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit eutils multilib multilib-minimal pax-utils
 
 DESCRIPTION="Streaming media framework"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://${PN}.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://${PN}.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2+"
 SLOT="0.10"

--- a/media-libs/gstreamer/gstreamer-1.4.5.ebuild
+++ b/media-libs/gstreamer/gstreamer-1.4.5.ebuild
@@ -7,8 +7,8 @@ EAPI="5"
 inherit eutils multilib multilib-minimal pax-utils
 
 DESCRIPTION="Open source multimedia framework"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://${PN}.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://${PN}.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2+"
 SLOT="1.0"

--- a/media-libs/gstreamer/gstreamer-1.6.3.ebuild
+++ b/media-libs/gstreamer/gstreamer-1.6.3.ebuild
@@ -7,8 +7,8 @@ EAPI="5"
 inherit bash-completion-r1 eutils multilib multilib-minimal pax-utils
 
 DESCRIPTION="Open source multimedia framework"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
-SRC_URI="http://${PN}.freedesktop.org/src/${PN}/${P}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+SRC_URI="https://${PN}.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2+"
 SLOT="1.0"

--- a/media-libs/harfbuzz/harfbuzz-0.9.41.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-0.9.41.ebuild
@@ -12,8 +12,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils libtool multilib-minimal python-any-r1
 
 DESCRIPTION="An OpenType text shaping engine"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
-[[ ${PV} == 9999 ]] || SRC_URI="http://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
+[[ ${PV} == 9999 ]] || SRC_URI="https://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
 
 LICENSE="Old-MIT ISC icu"
 SLOT="0/0.9.18" # 0.9.18 introduced the harfbuzz-icu split; bug #472416

--- a/media-libs/harfbuzz/harfbuzz-1.1.3.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-1.1.3.ebuild
@@ -12,8 +12,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils libtool multilib-minimal python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
-[[ ${PV} == 9999 ]] || SRC_URI="http://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
+[[ ${PV} == 9999 ]] || SRC_URI="https://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
 
 LICENSE="Old-MIT ISC icu"
 SLOT="0/0.9.18" # 0.9.18 introduced the harfbuzz-icu split; bug #472416

--- a/media-libs/harfbuzz/harfbuzz-1.2.4.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-1.2.4.ebuild
@@ -12,8 +12,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils libtool multilib-minimal python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
-[[ ${PV} == 9999 ]] || SRC_URI="http://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
+[[ ${PV} == 9999 ]] || SRC_URI="https://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
 
 LICENSE="Old-MIT ISC icu"
 SLOT="0/0.9.18" # 0.9.18 introduced the harfbuzz-icu split; bug #472416

--- a/media-libs/harfbuzz/harfbuzz-1.2.5.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-1.2.5.ebuild
@@ -12,8 +12,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils libtool multilib-minimal python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
-[[ ${PV} == 9999 ]] || SRC_URI="http://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
+[[ ${PV} == 9999 ]] || SRC_URI="https://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
 
 LICENSE="Old-MIT ISC icu"
 SLOT="0/0.9.18" # 0.9.18 introduced the harfbuzz-icu split; bug #472416

--- a/media-libs/harfbuzz/harfbuzz-1.2.6.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-1.2.6.ebuild
@@ -12,8 +12,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils libtool multilib-minimal python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
-[[ ${PV} == 9999 ]] || SRC_URI="http://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
+[[ ${PV} == 9999 ]] || SRC_URI="https://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
 
 LICENSE="Old-MIT ISC icu"
 SLOT="0/0.9.18" # 0.9.18 introduced the harfbuzz-icu split; bug #472416

--- a/media-libs/harfbuzz/harfbuzz-9999.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-9999.ebuild
@@ -12,8 +12,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils libtool multilib-minimal python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
-[[ ${PV} == 9999 ]] || SRC_URI="http://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
+[[ ${PV} == 9999 ]] || SRC_URI="https://www.freedesktop.org/software/${PN}/release/${P}.tar.bz2"
 
 LICENSE="Old-MIT ISC icu"
 SLOT="0/0.9.18" # 0.9.18 introduced the harfbuzz-icu split; bug #472416

--- a/media-libs/icc-profiles-basiccolor-printing2009/icc-profiles-basiccolor-printing2009-1.2.0.ebuild
+++ b/media-libs/icc-profiles-basiccolor-printing2009/icc-profiles-basiccolor-printing2009-1.2.0.ebuild
@@ -5,7 +5,7 @@
 EAPI=4
 
 DESCRIPTION="ICC profiles for printing/offset"
-HOMEPAGE="http://www.freedesktop.org/wiki/OpenIcc/ProfilePackages"
+HOMEPAGE="https://www.freedesktop.org/wiki/OpenIcc/ProfilePackages"
 SRC_URI="mirror://sourceforge/openicc/basICColor-Profiles/${P}.tar.bz2"
 
 LICENSE="ZLIB"

--- a/media-libs/icc-profiles-openicc/icc-profiles-openicc-1.3.0.ebuild
+++ b/media-libs/icc-profiles-openicc/icc-profiles-openicc-1.3.0.ebuild
@@ -5,7 +5,7 @@
 EAPI=4
 
 DESCRIPTION="ICC color profiles by OpenICC"
-HOMEPAGE="http://www.freedesktop.org/wiki/OpenIcc/ProfilePackages"
+HOMEPAGE="https://www.freedesktop.org/wiki/OpenIcc/ProfilePackages"
 SRC_URI="mirror://sourceforge/openicc/OpenICC-Profiles/${P}.tar.bz2"
 
 LICENSE="ZLIB"

--- a/media-libs/icc-profiles-openicc/icc-profiles-openicc-1.3.1.ebuild
+++ b/media-libs/icc-profiles-openicc/icc-profiles-openicc-1.3.1.ebuild
@@ -5,7 +5,7 @@
 EAPI=4
 
 DESCRIPTION="ICC color profiles by OpenICC"
-HOMEPAGE="http://www.freedesktop.org/wiki/OpenIcc/ProfilePackages"
+HOMEPAGE="https://www.freedesktop.org/wiki/OpenIcc/ProfilePackages"
 SRC_URI="mirror://sourceforge/openicc/OpenICC-Profiles/${P}.tar.bz2"
 
 LICENSE="ZLIB"

--- a/media-libs/libcdr/libcdr-0.0.14.ebuild
+++ b/media-libs/libcdr/libcdr-0.0.14.ebuild
@@ -9,7 +9,7 @@ inherit base eutils
 [[ ${PV} == 9999 ]] && inherit autotools git-2
 
 DESCRIPTION="Library parsing the Corel cdr documents"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libcdr"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libcdr"
 [[ ${PV} == 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"

--- a/media-libs/libcdr/libcdr-0.0.16.ebuild
+++ b/media-libs/libcdr/libcdr-0.0.16.ebuild
@@ -9,7 +9,7 @@ inherit base eutils
 [[ ${PV} == 9999 ]] && inherit autotools git-2
 
 DESCRIPTION="Library parsing the Corel cdr documents"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libcdr"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libcdr"
 [[ ${PV} == 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.xz"
 
 LICENSE="MPL-2.0"

--- a/media-libs/libfreehand/libfreehand-0.0.0.ebuild
+++ b/media-libs/libfreehand/libfreehand-0.0.0.ebuild
@@ -9,7 +9,7 @@ inherit base eutils
 [[ ${PV} == 9999 ]] && inherit autotools git-2
 
 DESCRIPTION="Library for import of FreeHand drawings"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libfreehand/"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libfreehand/"
 [[ ${PV} == 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.xz"
 
 LICENSE="MPL-2.0"

--- a/media-libs/libopenraw/libopenraw-0.0.9.ebuild
+++ b/media-libs/libopenraw/libopenraw-0.0.9.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils gnome2-utils
 
 DESCRIPTION="A decoding library for RAW image formats"
-HOMEPAGE="http://libopenraw.freedesktop.org/wiki/"
-SRC_URI="http://${PN}.freedesktop.org/download/${P}.tar.bz2"
+HOMEPAGE="https://libopenraw.freedesktop.org/wiki/"
+SRC_URI="https://${PN}.freedesktop.org/download/${P}.tar.bz2"
 
 LICENSE="GPL-3 LGPL-3"
 SLOT="0"

--- a/media-libs/libtxc_dxtn/libtxc_dxtn-1.0.1-r1.ebuild
+++ b/media-libs/libtxc_dxtn/libtxc_dxtn-1.0.1-r1.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit autotools-multilib
 
 DESCRIPTION="Helper library for	S3TC texture (de)compression"
-HOMEPAGE="http://cgit.freedesktop.org/~mareko/libtxc_dxtn/"
-SRC_URI="http://people.freedesktop.org/~cbrill/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://cgit.freedesktop.org/~mareko/libtxc_dxtn/"
+SRC_URI="https://people.freedesktop.org/~cbrill/${PN}/${P}.tar.bz2"
 
 LICENSE="MIT"
 SLOT="0"

--- a/media-libs/libtxc_dxtn/libtxc_dxtn-1.0.1.ebuild
+++ b/media-libs/libtxc_dxtn/libtxc_dxtn-1.0.1.ebuild
@@ -7,8 +7,8 @@ EAPI=4
 inherit autotools-utils multilib
 
 DESCRIPTION="Helper library for	S3TC texture (de)compression"
-HOMEPAGE="http://cgit.freedesktop.org/~mareko/libtxc_dxtn/"
-SRC_URI="http://people.freedesktop.org/~cbrill/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://cgit.freedesktop.org/~mareko/libtxc_dxtn/"
+SRC_URI="https://people.freedesktop.org/~cbrill/${PN}/${P}.tar.bz2"
 
 LICENSE="MIT"
 SLOT="0"

--- a/media-libs/libvisio/libvisio-0.0.30.ebuild
+++ b/media-libs/libvisio/libvisio-0.0.30.ebuild
@@ -9,7 +9,7 @@ inherit base eutils
 [[ ${PV} == 9999 ]] && inherit autotools git-2
 
 DESCRIPTION="Library parsing the visio documents"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/libvisio"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libvisio"
 [[ ${PV} == 9999 ]] || SRC_URI="http://dev-www.libreoffice.org/src/${P}.tar.xz"
 
 LICENSE="|| ( GPL-2+ LGPL-2.1 MPL-1.1 )"

--- a/media-libs/qt-gstreamer/qt-gstreamer-1.2.0-r1.ebuild
+++ b/media-libs/qt-gstreamer/qt-gstreamer-1.2.0-r1.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 if [[ ${PV} != *9999* ]]; then
-	SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+	SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ppc ppc64 x86"
 else
 	GIT_ECLASS="git-r3"
@@ -16,7 +16,7 @@ fi
 inherit cmake-utils ${GIT_ECLASS} multibuild
 
 DESCRIPTION="QtGStreamer provides C++ bindings for GStreamer with a Qt-style API"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/qt-gstreamer.html"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/qt-gstreamer.html"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/media-libs/qt-gstreamer/qt-gstreamer-1.2.0-r2.ebuild
+++ b/media-libs/qt-gstreamer/qt-gstreamer-1.2.0-r2.ebuild
@@ -5,7 +5,7 @@
 EAPI=6
 
 if [[ ${PV} != *9999* ]]; then
-	SRC_URI="http://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
+	SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
 else
 	EGIT_REPO_URI=( "git://anongit.freedesktop.org/gstreamer/${PN}" )
@@ -15,7 +15,7 @@ fi
 inherit cmake-utils multibuild
 
 DESCRIPTION="C++ bindings for GStreamer with a Qt-style API"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/qt-gstreamer.html"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/qt-gstreamer.html"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/media-libs/waffle/waffle-1.5.1.ebuild
+++ b/media-libs/waffle/waffle-1.5.1.ebuild
@@ -13,12 +13,12 @@ fi
 inherit cmake-utils cmake-multilib ${GIT_ECLASS}
 
 DESCRIPTION="Library that allows selection of GL API and of window system at runtime"
-HOMEPAGE="http://people.freedesktop.org/~chadversary/waffle/"
+HOMEPAGE="https://people.freedesktop.org/~chadversary/waffle/"
 
 if [[ $PV = 9999* ]]; then
 	KEYWORDS=""
 else
-	SRC_URI="http://people.freedesktop.org/~chadversary/waffle/files/release/${P}/${P}.tar.xz"
+	SRC_URI="https://people.freedesktop.org/~chadversary/waffle/files/release/${P}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~x86"
 fi
 

--- a/media-libs/waffle/waffle-1.5.2.ebuild
+++ b/media-libs/waffle/waffle-1.5.2.ebuild
@@ -13,12 +13,12 @@ fi
 inherit cmake-utils cmake-multilib ${GIT_ECLASS}
 
 DESCRIPTION="Library that allows selection of GL API and of window system at runtime"
-HOMEPAGE="http://people.freedesktop.org/~chadversary/waffle/"
+HOMEPAGE="https://people.freedesktop.org/~chadversary/waffle/"
 
 if [[ $PV = 9999* ]]; then
 	KEYWORDS="arm"
 else
-	SRC_URI="http://people.freedesktop.org/~chadversary/waffle/files/release/${P}/${P}.tar.xz"
+	SRC_URI="https://people.freedesktop.org/~chadversary/waffle/files/release/${P}/${P}.tar.xz"
 	KEYWORDS="amd64 arm x86"
 fi
 

--- a/media-libs/waffle/waffle-9999.ebuild
+++ b/media-libs/waffle/waffle-9999.ebuild
@@ -13,12 +13,12 @@ fi
 inherit cmake-utils cmake-multilib ${GIT_ECLASS}
 
 DESCRIPTION="Library that allows selection of GL API and of window system at runtime"
-HOMEPAGE="http://people.freedesktop.org/~chadversary/waffle/"
+HOMEPAGE="https://people.freedesktop.org/~chadversary/waffle/"
 
 if [[ $PV = 9999* ]]; then
 	KEYWORDS=""
 else
-	SRC_URI="http://people.freedesktop.org/~chadversary/waffle/files/release/${P}/${P}.tar.xz"
+	SRC_URI="https://people.freedesktop.org/~chadversary/waffle/files/release/${P}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~x86"
 fi
 

--- a/media-libs/webrtc-audio-processing/webrtc-audio-processing-0.1-r1.ebuild
+++ b/media-libs/webrtc-audio-processing/webrtc-audio-processing-0.1-r1.ebuild
@@ -8,8 +8,8 @@ AUTOTOOLS_PRUNE_LIBTOOL_FILES=all
 inherit autotools-multilib
 
 DESCRIPTION="AudioProcessing library from the webrtc.org code base"
-HOMEPAGE="http://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing/"
-SRC_URI="http://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing/"
+SRC_URI="https://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/media-plugins/gst-plugins-amr/gst-plugins-amr-0.10.19-r1.ebuild
+++ b/media-plugins/gst-plugins-amr/gst-plugins-amr-0.10.19-r1.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE=gst-plugins-ugly
 inherit eutils gstreamer
 
 DESCRIPTION="GStreamer plugin for AMRNB/AMRWB codec"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="amd64 x86"

--- a/media-plugins/gst-plugins-amr/gst-plugins-amr-1.4.5.ebuild
+++ b/media-plugins/gst-plugins-amr/gst-plugins-amr-1.4.5.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE=gst-plugins-ugly
 inherit gstreamer
 
 DESCRIPTION="GStreamer plugin for AMRNB/AMRWB codec"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="amd64 x86"

--- a/media-plugins/gst-plugins-amr/gst-plugins-amr-1.6.1.ebuild
+++ b/media-plugins/gst-plugins-amr/gst-plugins-amr-1.6.1.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE=gst-plugins-ugly
 inherit gstreamer
 
 DESCRIPTION="GStreamer plugin for AMRNB/AMRWB codec"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="~amd64 ~x86"

--- a/media-plugins/gst-plugins-amr/gst-plugins-amr-1.6.2.ebuild
+++ b/media-plugins/gst-plugins-amr/gst-plugins-amr-1.6.2.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE=gst-plugins-ugly
 inherit gstreamer
 
 DESCRIPTION="GStreamer plugin for AMRNB/AMRWB codec"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="~amd64 ~x86"

--- a/media-plugins/gst-plugins-amr/gst-plugins-amr-1.6.3.ebuild
+++ b/media-plugins/gst-plugins-amr/gst-plugins-amr-1.6.3.ebuild
@@ -8,7 +8,7 @@ GST_ORG_MODULE=gst-plugins-ugly
 inherit gstreamer
 
 DESCRIPTION="GStreamer plugin for AMRNB/AMRWB codec"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="GPL-2"
 KEYWORDS="amd64 x86"

--- a/media-plugins/gst-plugins-ffmpeg/gst-plugins-ffmpeg-0.10.13_p201211-r5.ebuild
+++ b/media-plugins/gst-plugins-ffmpeg/gst-plugins-ffmpeg-0.10.13_p201211-r5.ebuild
@@ -13,8 +13,8 @@ PVP=(${PV//[-\._]/ })
 SLOT=${PVP[0]}.${PVP[1]}
 
 DESCRIPTION="FFmpeg based gstreamer plugin"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/gst-ffmpeg.html"
-#SRC_URI="http://gstreamer.freedesktop.org/src/${MY_PN}/${MY_P}.tar.bz2"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/gst-ffmpeg.html"
+#SRC_URI="https://gstreamer.freedesktop.org/src/${MY_PN}/${MY_P}.tar.bz2"
 SRC_URI="https://dev.gentoo.org/~tetromino/distfiles/${PN}/${MY_P}.tar.xz
 	https://dev.gentoo.org/~tetromino/distfiles/${PN}/${MY_P}-libav-9-patches.tar.xz"
 

--- a/media-plugins/gst-plugins-gl/gst-plugins-gl-0.10.3-r1.ebuild
+++ b/media-plugins/gst-plugins-gl/gst-plugins-gl-0.10.3-r1.ebuild
@@ -8,7 +8,7 @@ GST_TARBALL_SUFFIX="gz"
 inherit autotools eutils gstreamer
 
 DESCRIPTION="GStreamer OpenGL plugins"
-HOMEPAGE="http://gstreamer.freedesktop.org/"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/media-plugins/gst-plugins-libav/gst-plugins-libav-1.4.5-r1.ebuild
+++ b/media-plugins/gst-plugins-libav/gst-plugins-libav-1.4.5-r1.ebuild
@@ -7,8 +7,8 @@ inherit eutils flag-o-matic multilib-minimal
 
 MY_PN="gst-libav"
 DESCRIPTION="FFmpeg based gstreamer plugin"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/gst-libav.html"
-SRC_URI="http://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/gst-libav.html"
+SRC_URI="https://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="1.0"

--- a/media-plugins/gst-plugins-libav/gst-plugins-libav-1.4.5-r2.ebuild
+++ b/media-plugins/gst-plugins-libav/gst-plugins-libav-1.4.5-r2.ebuild
@@ -7,8 +7,8 @@ inherit eutils flag-o-matic multilib-minimal
 
 MY_PN="gst-libav"
 DESCRIPTION="FFmpeg based gstreamer plugin"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/gst-libav.html"
-SRC_URI="http://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/gst-libav.html"
+SRC_URI="https://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="1.0"

--- a/media-plugins/gst-plugins-libav/gst-plugins-libav-1.6.1.ebuild
+++ b/media-plugins/gst-plugins-libav/gst-plugins-libav-1.6.1.ebuild
@@ -8,8 +8,8 @@ inherit eutils flag-o-matic multilib-minimal
 
 MY_PN="gst-libav"
 DESCRIPTION="FFmpeg based gstreamer plugin"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/gst-libav.html"
-SRC_URI="http://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/gst-libav.html"
+SRC_URI="https://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="1.0"

--- a/media-plugins/gst-plugins-libav/gst-plugins-libav-1.6.2-r1.ebuild
+++ b/media-plugins/gst-plugins-libav/gst-plugins-libav-1.6.2-r1.ebuild
@@ -7,8 +7,8 @@ inherit eutils multilib-minimal
 
 MY_PN="gst-libav"
 DESCRIPTION="FFmpeg based gstreamer plugin"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/gst-libav.html"
-SRC_URI="http://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/gst-libav.html"
+SRC_URI="https://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="1.0"

--- a/media-plugins/gst-plugins-libav/gst-plugins-libav-1.6.2.ebuild
+++ b/media-plugins/gst-plugins-libav/gst-plugins-libav-1.6.2.ebuild
@@ -8,8 +8,8 @@ inherit eutils multilib-minimal
 
 MY_PN="gst-libav"
 DESCRIPTION="FFmpeg based gstreamer plugin"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/gst-libav.html"
-SRC_URI="http://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/gst-libav.html"
+SRC_URI="https://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="1.0"

--- a/media-plugins/gst-plugins-libav/gst-plugins-libav-1.6.3.ebuild
+++ b/media-plugins/gst-plugins-libav/gst-plugins-libav-1.6.3.ebuild
@@ -7,8 +7,8 @@ inherit eutils multilib-minimal autotools
 
 MY_PN="gst-libav"
 DESCRIPTION="FFmpeg based gstreamer plugin"
-HOMEPAGE="http://gstreamer.freedesktop.org/modules/gst-libav.html"
-SRC_URI="http://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
+HOMEPAGE="https://gstreamer.freedesktop.org/modules/gst-libav.html"
+SRC_URI="https://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="1.0"

--- a/media-plugins/gst-plugins-libnice/gst-plugins-libnice-0.1.13-r100.ebuild
+++ b/media-plugins/gst-plugins-libnice/gst-plugins-libnice-0.1.13-r100.ebuild
@@ -6,9 +6,9 @@ EAPI=5
 inherit eutils multilib-minimal toolchain-funcs
 
 DESCRIPTION="GStreamer plugin for ICE (RFC 5245) support"
-HOMEPAGE="http://nice.freedesktop.org/wiki/"
+HOMEPAGE="https://nice.freedesktop.org/wiki/"
 MY_P=libnice-${PV}
-SRC_URI="http://nice.freedesktop.org/releases/${MY_P}.tar.gz"
+SRC_URI="https://nice.freedesktop.org/releases/${MY_P}.tar.gz"
 
 LICENSE="|| ( MPL-1.1 LGPL-2.1 )"
 SLOT="1.0"

--- a/media-plugins/gst-plugins-libnice/gst-plugins-libnice-0.1.13.ebuild
+++ b/media-plugins/gst-plugins-libnice/gst-plugins-libnice-0.1.13.ebuild
@@ -6,9 +6,9 @@ EAPI=5
 inherit autotools eutils multilib-minimal toolchain-funcs
 
 DESCRIPTION="GStreamer plugin for ICE (RFC 5245) support"
-HOMEPAGE="http://nice.freedesktop.org/wiki/"
+HOMEPAGE="https://nice.freedesktop.org/wiki/"
 MY_P=libnice-${PV}
-SRC_URI="http://nice.freedesktop.org/releases/${MY_P}.tar.gz"
+SRC_URI="https://nice.freedesktop.org/releases/${MY_P}.tar.gz"
 
 LICENSE="|| ( MPL-1.1 LGPL-2.1 )"
 SLOT="0.10"

--- a/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-0.6.1.ebuild
+++ b/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-0.6.1.ebuild
@@ -9,7 +9,7 @@ inherit eutils multilib-minimal
 MY_PN="gstreamer-vaapi"
 DESCRIPTION="Hardware accelerated video decoding through VA-API plugin"
 HOMEPAGE="https://github.com/01org/gstreamer-vaapi"
-SRC_URI="http://www.freedesktop.org/software/vaapi/releases/${MY_PN}/${MY_PN}-${PV}.tar.bz2"
+SRC_URI="https://www.freedesktop.org/software/vaapi/releases/${MY_PN}/${MY_PN}-${PV}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="1.0"

--- a/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-0.7.0.ebuild
+++ b/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-0.7.0.ebuild
@@ -9,7 +9,7 @@ inherit eutils multilib-minimal
 MY_PN="gstreamer-vaapi"
 DESCRIPTION="Hardware accelerated video decoding through VA-API plugin"
 HOMEPAGE="https://github.com/01org/gstreamer-vaapi"
-SRC_URI="http://www.freedesktop.org/software/vaapi/releases/${MY_PN}/${MY_PN}-${PV}.tar.bz2"
+SRC_URI="https://www.freedesktop.org/software/vaapi/releases/${MY_PN}/${MY_PN}-${PV}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="1.0"

--- a/media-sound/paprefs/paprefs-0.9.10.ebuild
+++ b/media-sound/paprefs/paprefs-0.9.10.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit flag-o-matic
 
 DESCRIPTION="PulseAudio Preferences, configuration dialog for PulseAudio"
-HOMEPAGE="http://freedesktop.org/software/pulseaudio/paprefs"
-SRC_URI="http://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/software/pulseaudio/paprefs"
+SRC_URI="https://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-sound/pavucontrol/pavucontrol-2.0-r1.ebuild
+++ b/media-sound/pavucontrol/pavucontrol-2.0-r1.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit eutils
 
 DESCRIPTION="Pulseaudio Volume Control, GTK based mixer for Pulseaudio"
-HOMEPAGE="http://freedesktop.org/software/pulseaudio/pavucontrol/"
-SRC_URI="http://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/software/pulseaudio/pavucontrol/"
+SRC_URI="https://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-sound/pavucontrol/pavucontrol-3.0.ebuild
+++ b/media-sound/pavucontrol/pavucontrol-3.0.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit flag-o-matic
 
 DESCRIPTION="Pulseaudio Volume Control, GTK based mixer for Pulseaudio"
-HOMEPAGE="http://freedesktop.org/software/pulseaudio/pavucontrol/"
-SRC_URI="http://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/software/pulseaudio/pavucontrol/"
+SRC_URI="https://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-sound/pulseaudio/pulseaudio-7.1.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-7.1.ebuild
@@ -7,7 +7,7 @@ inherit autotools bash-completion-r1 eutils flag-o-matic gnome2-utils linux-info
 
 DESCRIPTION="A networked sound server with an advanced plugin system"
 HOMEPAGE="http://www.pulseaudio.org/"
-SRC_URI="http://freedesktop.org/software/pulseaudio/releases/${P}.tar.xz"
+SRC_URI="https://freedesktop.org/software/pulseaudio/releases/${P}.tar.xz"
 
 # libpulse-simple and libpulse link to libpulse-core; this is daemon's
 # library and can link to gdbm and other GPL-only libraries. In this
@@ -334,8 +334,8 @@ pkg_postinst() {
 		elog "incompatible with many expected pulseaudio features."
 		elog "On normal desktop systems, system-wide mode is STRONGLY DISCOURAGED."
 		elog "For more information, see"
-		elog "    http://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/"
-		elog "    http://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/"
+		elog "    https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/"
+		elog "    https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/"
 		elog "    https://wiki.gentoo.org/wiki/PulseAudio#Headless_server"
 		if use gnome ; then
 			elog

--- a/media-sound/pulseaudio/pulseaudio-8.0.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-8.0.ebuild
@@ -7,7 +7,7 @@ inherit autotools bash-completion-r1 eutils flag-o-matic gnome2-utils linux-info
 
 DESCRIPTION="A networked sound server with an advanced plugin system"
 HOMEPAGE="http://www.pulseaudio.org/"
-SRC_URI="http://freedesktop.org/software/pulseaudio/releases/${P}.tar.xz"
+SRC_URI="https://freedesktop.org/software/pulseaudio/releases/${P}.tar.xz"
 
 # libpulse-simple and libpulse link to libpulse-core; this is daemon's
 # library and can link to gdbm and other GPL-only libraries. In this
@@ -334,8 +334,8 @@ pkg_postinst() {
 		elog "incompatible with many expected pulseaudio features."
 		elog "On normal desktop systems, system-wide mode is STRONGLY DISCOURAGED."
 		elog "For more information, see"
-		elog "    http://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/"
-		elog "    http://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/"
+		elog "    https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/"
+		elog "    https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/"
 		elog "    https://wiki.gentoo.org/wiki/PulseAudio#Headless_server"
 		if use gnome ; then
 			elog

--- a/net-im/telepathy-connection-managers/telepathy-connection-managers-2-r2.ebuild
+++ b/net-im/telepathy-connection-managers/telepathy-connection-managers-2-r2.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 DESCRIPTION="Meta-package for Telepathy Connection Managers"
-HOMEPAGE="http://telepathy.freedesktop.org/"
+HOMEPAGE="https://telepathy.freedesktop.org/"
 SRC_URI=""
 LICENSE="metapackage"
 SLOT="0"

--- a/net-im/telepathy-logger/telepathy-logger-0.8.1.ebuild
+++ b/net-im/telepathy-logger/telepathy-logger-0.8.1.ebuild
@@ -9,8 +9,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit gnome2 python-any-r1 virtualx
 
 DESCRIPTION="Telepathy Logger is a session daemon that should be activated whenever telepathy is being used"
-HOMEPAGE="http://telepathy.freedesktop.org/wiki/Logger"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://telepathy.freedesktop.org/wiki/Logger"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1+"
 SLOT="0/3"

--- a/net-im/telepathy-logger/telepathy-logger-0.8.2.ebuild
+++ b/net-im/telepathy-logger/telepathy-logger-0.8.2.ebuild
@@ -9,8 +9,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit gnome2 python-any-r1 virtualx
 
 DESCRIPTION="Telepathy Logger is a session daemon that should be activated whenever telepathy is being used"
-HOMEPAGE="http://telepathy.freedesktop.org/wiki/Logger"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://telepathy.freedesktop.org/wiki/Logger"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1+"
 SLOT="0/3"

--- a/net-im/telepathy-mission-control/telepathy-mission-control-5.16.2.ebuild
+++ b/net-im/telepathy-mission-control/telepathy-mission-control-5.16.2.ebuild
@@ -11,8 +11,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit gnome2 python-any-r1
 
 DESCRIPTION="An account manager and channel dispatcher for the Telepathy framework"
-HOMEPAGE="http://cgit.freedesktop.org/telepathy/telepathy-mission-control/"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://cgit.freedesktop.org/telepathy/telepathy-mission-control/"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"

--- a/net-im/telepathy-mission-control/telepathy-mission-control-5.16.3.ebuild
+++ b/net-im/telepathy-mission-control/telepathy-mission-control-5.16.3.ebuild
@@ -11,8 +11,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit gnome2 python-any-r1
 
 DESCRIPTION="An account manager and channel dispatcher for the Telepathy framework"
-HOMEPAGE="http://cgit.freedesktop.org/telepathy/telepathy-mission-control/"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://cgit.freedesktop.org/telepathy/telepathy-mission-control/"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"

--- a/net-irc/telepathy-idle/telepathy-idle-0.2.0.ebuild
+++ b/net-irc/telepathy-idle/telepathy-idle-0.2.0.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit python-single-r1
 
 DESCRIPTION="Full-featured IRC connection manager for Telepathy"
-HOMEPAGE="http://cgit.freedesktop.org/telepathy/telepathy-idle"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://cgit.freedesktop.org/telepathy/telepathy-idle"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/net-libs/farstream/farstream-0.1.2-r2.ebuild
+++ b/net-libs/farstream/farstream-0.1.2-r2.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils python-single-r1
 
 DESCRIPTION="Audio/video conferencing framework specifically designed for instant messengers"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/Farstream"
-SRC_URI="http://freedesktop.org/software/farstream/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/Farstream"
+SRC_URI="https://freedesktop.org/software/farstream/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"

--- a/net-libs/farstream/farstream-0.2.7.ebuild
+++ b/net-libs/farstream/farstream-0.2.7.ebuild
@@ -10,8 +10,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit gnome2 python-any-r1
 
 DESCRIPTION="Audio/video conferencing framework specifically designed for instant messengers"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/Farstream"
-SRC_URI="http://freedesktop.org/software/farstream/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/Farstream"
+SRC_URI="https://freedesktop.org/software/farstream/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 KEYWORDS="~alpha amd64 ~arm hppa ~ia64 ~ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux"

--- a/net-libs/libmbim/libmbim-1.10.0.ebuild
+++ b/net-libs/libmbim/libmbim-1.10.0.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="~alpha amd64 arm ~mips x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="MBIM modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libmbim/"
+HOMEPAGE="https://cgit.freedesktop.org/libmbim/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libmbim/libmbim-1.12.2.ebuild
+++ b/net-libs/libmbim/libmbim-1.12.2.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="~alpha ~amd64 ~arm ~mips ppc64 ~x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="MBIM modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libmbim/"
+HOMEPAGE="https://cgit.freedesktop.org/libmbim/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libmbim/libmbim-1.12.4.ebuild
+++ b/net-libs/libmbim/libmbim-1.12.4.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="~alpha ~amd64 ~arm ~mips ~ppc64 ~x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="MBIM modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libmbim/"
+HOMEPAGE="https://cgit.freedesktop.org/libmbim/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libmbim/libmbim-1.6.0.ebuild
+++ b/net-libs/libmbim/libmbim-1.6.0.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="~alpha amd64 arm ~mips x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="MBIM modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libmbim/"
+HOMEPAGE="https://cgit.freedesktop.org/libmbim/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libmbim/libmbim-9999.ebuild
+++ b/net-libs/libmbim/libmbim-9999.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="~amd64 ~arm ~x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="MBIM modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libmbim/"
+HOMEPAGE="https://cgit.freedesktop.org/libmbim/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libnice/libnice-0.1.10.ebuild
+++ b/net-libs/libnice/libnice-0.1.10.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib-minimal
 
 DESCRIPTION="An implementation of the Interactice Connectivity Establishment standard (ICE)"
-HOMEPAGE="http://nice.freedesktop.org/wiki/"
-SRC_URI="http://nice.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://nice.freedesktop.org/wiki/"
+SRC_URI="https://nice.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="|| ( MPL-1.1 LGPL-2.1 )"
 SLOT="0"

--- a/net-libs/libnice/libnice-0.1.13.ebuild
+++ b/net-libs/libnice/libnice-0.1.13.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit autotools eutils multilib-minimal
 
 DESCRIPTION="An implementation of the Interactice Connectivity Establishment standard (ICE)"
-HOMEPAGE="http://nice.freedesktop.org/wiki/"
-SRC_URI="http://nice.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://nice.freedesktop.org/wiki/"
+SRC_URI="https://nice.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="|| ( MPL-1.1 LGPL-2.1 )"
 SLOT="0"

--- a/net-libs/libnice/libnice-0.1.8.ebuild
+++ b/net-libs/libnice/libnice-0.1.8.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib-minimal
 
 DESCRIPTION="An implementation of the Interactice Connectivity Establishment standard (ICE)"
-HOMEPAGE="http://nice.freedesktop.org/wiki/"
-SRC_URI="http://nice.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://nice.freedesktop.org/wiki/"
+SRC_URI="https://nice.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="|| ( MPL-1.1 LGPL-2.1 )"
 SLOT="0"

--- a/net-libs/libqmi/libqmi-1.0.0.ebuild
+++ b/net-libs/libqmi/libqmi-1.0.0.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/libqmi"
 else
 	KEYWORDS="~amd64 ~arm ~mips ~x86"
-	SRC_URI="http://cgit.freedesktop.org/libqmi/snapshot/${P}.tar.gz"
+	SRC_URI="https://cgit.freedesktop.org/libqmi/snapshot/${P}.tar.gz"
 fi
 
 DESCRIPTION="QMI modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libqmi/"
+HOMEPAGE="https://cgit.freedesktop.org/libqmi/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libqmi/libqmi-1.10.2.ebuild
+++ b/net-libs/libqmi/libqmi-1.10.2.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="QMI modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libqmi/"
+HOMEPAGE="https://cgit.freedesktop.org/libqmi/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libqmi/libqmi-1.12.6.ebuild
+++ b/net-libs/libqmi/libqmi-1.12.6.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="amd64 arm ~mips x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="QMI modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libqmi/"
+HOMEPAGE="https://cgit.freedesktop.org/libqmi/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libqmi/libqmi-1.14.0.ebuild
+++ b/net-libs/libqmi/libqmi-1.14.0.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="~amd64 ~arm ~mips ~x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="QMI modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libqmi/"
+HOMEPAGE="https://cgit.freedesktop.org/libqmi/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libqmi/libqmi-1.4.0.ebuild
+++ b/net-libs/libqmi/libqmi-1.4.0.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/libqmi"
 else
 	KEYWORDS="amd64 arm ~mips x86"
-	SRC_URI="http://www.freedesktop.org/software/libqmi/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/libqmi/${P}.tar.xz"
 fi
 
 DESCRIPTION="QMI modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libqmi/"
+HOMEPAGE="https://cgit.freedesktop.org/libqmi/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libqmi/libqmi-1.8.0.ebuild
+++ b/net-libs/libqmi/libqmi-1.8.0.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="amd64 arm ~mips x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="QMI modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libqmi/"
+HOMEPAGE="https://cgit.freedesktop.org/libqmi/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/libqmi/libqmi-9999.ebuild
+++ b/net-libs/libqmi/libqmi-9999.ebuild
@@ -10,11 +10,11 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 else
 	KEYWORDS="~amd64 ~arm ~x86"
-	SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="QMI modem protocol helper library"
-HOMEPAGE="http://cgit.freedesktop.org/libqmi/"
+HOMEPAGE="https://cgit.freedesktop.org/libqmi/"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/net-libs/telepathy-farstream/telepathy-farstream-0.6.2.ebuild
+++ b/net-libs/telepathy-farstream/telepathy-farstream-0.6.2.ebuild
@@ -8,8 +8,8 @@ GCONF_DEBUG="no"
 inherit gnome2
 
 DESCRIPTION="Telepathy client library that uses Farstream to handle Call channels"
-HOMEPAGE="http://telepathy.freedesktop.org"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://telepathy.freedesktop.org/"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/3"

--- a/net-libs/telepathy-glib/telepathy-glib-0.24.0.ebuild
+++ b/net-libs/telepathy-glib/telepathy-glib-0.24.0.ebuild
@@ -10,8 +10,8 @@ VALA_USE_DEPEND="vapigen"
 inherit eutils gnome2 python-single-r1 vala virtualx
 
 DESCRIPTION="GLib bindings for the Telepathy D-Bus protocol"
-HOMEPAGE="http://telepathy.freedesktop.org"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://telepathy.freedesktop.org/"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"

--- a/net-libs/telepathy-glib/telepathy-glib-0.24.1.ebuild
+++ b/net-libs/telepathy-glib/telepathy-glib-0.24.1.ebuild
@@ -11,8 +11,8 @@ VALA_USE_DEPEND="vapigen"
 inherit eutils gnome2 python-single-r1 vala virtualx
 
 DESCRIPTION="GLib bindings for the Telepathy D-Bus protocol"
-HOMEPAGE="http://telepathy.freedesktop.org"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://telepathy.freedesktop.org/"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"

--- a/net-libs/telepathy-qt/telepathy-qt-0.9.6.1.ebuild
+++ b/net-libs/telepathy-qt/telepathy-qt-0.9.6.1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit python-any-r1 cmake-utils virtualx multibuild
 
 DESCRIPTION="Qt bindings for the Telepathy D-Bus protocol"
-HOMEPAGE="http://telepathy.freedesktop.org/"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://telepathy.freedesktop.org/"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/net-misc/modemmanager/modemmanager-1.4.10.ebuild
+++ b/net-misc/modemmanager/modemmanager-1.4.10.ebuild
@@ -10,8 +10,8 @@ VALA_USE_DEPEND="vapigen"
 inherit gnome2 user readme.gentoo udev vala
 
 DESCRIPTION="Modem and mobile broadband management libraries"
-HOMEPAGE="http://cgit.freedesktop.org/ModemManager/ModemManager/"
-SRC_URI="http://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz"
+HOMEPAGE="https://cgit.freedesktop.org/ModemManager/ModemManager/"
+SRC_URI="https://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0/1" # subslot = dbus interface version, i.e. N in org.freedesktop.ModemManager${N}

--- a/net-misc/modemmanager/modemmanager-1.4.12.ebuild
+++ b/net-misc/modemmanager/modemmanager-1.4.12.ebuild
@@ -10,8 +10,8 @@ VALA_USE_DEPEND="vapigen"
 inherit gnome2 user readme.gentoo udev vala
 
 DESCRIPTION="Modem and mobile broadband management libraries"
-HOMEPAGE="http://cgit.freedesktop.org/ModemManager/ModemManager/"
-SRC_URI="http://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz"
+HOMEPAGE="https://cgit.freedesktop.org/ModemManager/ModemManager/"
+SRC_URI="https://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0/1" # subslot = dbus interface version, i.e. N in org.freedesktop.ModemManager${N}

--- a/net-misc/modemmanager/modemmanager-1.4.8.ebuild
+++ b/net-misc/modemmanager/modemmanager-1.4.8.ebuild
@@ -10,8 +10,8 @@ VALA_USE_DEPEND="vapigen"
 inherit gnome2 user readme.gentoo udev vala
 
 DESCRIPTION="Modem and mobile broadband management libraries"
-HOMEPAGE="http://cgit.freedesktop.org/ModemManager/ModemManager/"
-SRC_URI="http://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz"
+HOMEPAGE="https://cgit.freedesktop.org/ModemManager/ModemManager/"
+SRC_URI="https://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0/1" # subslot = dbus interface version, i.e. N in org.freedesktop.ModemManager${N}

--- a/net-print/cups-pk-helper/cups-pk-helper-0.2.5.ebuild
+++ b/net-print/cups-pk-helper/cups-pk-helper-0.2.5.ebuild
@@ -8,8 +8,8 @@ GCONF_DEBUG="no"
 inherit gnome2
 
 DESCRIPTION="PolicyKit helper to configure cups with fine-grained privileges"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/cups-pk-helper"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/cups-pk-helper"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/net-print/cups-pk-helper/cups-pk-helper-0.2.6.ebuild
+++ b/net-print/cups-pk-helper/cups-pk-helper-0.2.6.ebuild
@@ -8,8 +8,8 @@ GCONF_DEBUG="no"
 inherit gnome2
 
 DESCRIPTION="PolicyKit helper to configure cups with fine-grained privileges"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/cups-pk-helper"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/cups-pk-helper"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/net-voip/telepathy-gabble/telepathy-gabble-0.18.3.ebuild
+++ b/net-voip/telepathy-gabble/telepathy-gabble-0.18.3.ebuild
@@ -9,8 +9,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit gnome2 eutils python-any-r1
 
 DESCRIPTION="A Jabber/XMPP connection manager, with handling of single and multi user chats and voice calls"
-HOMEPAGE="http://telepathy.freedesktop.org"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://telepathy.freedesktop.org/"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/net-voip/telepathy-haze/telepathy-haze-0.8.0-r1.ebuild
+++ b/net-voip/telepathy-haze/telepathy-haze-0.8.0-r1.ebuild
@@ -9,7 +9,7 @@ inherit eutils python-single-r1
 
 DESCRIPTION="Telepathy connection manager providing libpurple supported protocols"
 HOMEPAGE="http://developer.pidgin.im/wiki/TelepathyHaze"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-voip/telepathy-haze/telepathy-haze-0.8.0.ebuild
+++ b/net-voip/telepathy-haze/telepathy-haze-0.8.0.ebuild
@@ -9,7 +9,7 @@ inherit python-single-r1
 
 DESCRIPTION="Telepathy connection manager providing libpurple supported protocols"
 HOMEPAGE="http://developer.pidgin.im/wiki/TelepathyHaze"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-voip/telepathy-rakia/telepathy-rakia-0.8.0.ebuild
+++ b/net-voip/telepathy-rakia/telepathy-rakia-0.8.0.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit python-single-r1
 
 DESCRIPTION="A SIP connection manager for Telepathy based around the Sofia-SIP library"
-HOMEPAGE="http://telepathy.freedesktop.org/"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://telepathy.freedesktop.org/"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/net-voip/telepathy-salut/telepathy-salut-0.8.1.ebuild
+++ b/net-voip/telepathy-salut/telepathy-salut-0.8.1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils python-any-r1
 
 DESCRIPTION="A link-local XMPP connection manager for Telepathy"
-HOMEPAGE="http://telepathy.freedesktop.org/wiki/CategorySalut"
-SRC_URI="http://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://telepathy.freedesktop.org/wiki/CategorySalut"
+SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/sys-apps/accountsservice/accountsservice-0.6.39.ebuild
+++ b/sys-apps/accountsservice/accountsservice-0.6.39.ebuild
@@ -8,8 +8,8 @@ GCONF_DEBUG="no"
 inherit eutils gnome2 systemd
 
 DESCRIPTION="D-Bus interfaces for querying and manipulating user account information"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/AccountsService/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/AccountsService/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-3+"
 SLOT="0"

--- a/sys-apps/accountsservice/accountsservice-0.6.40.ebuild
+++ b/sys-apps/accountsservice/accountsservice-0.6.40.ebuild
@@ -8,8 +8,8 @@ GCONF_DEBUG="no"
 inherit eutils gnome2 systemd
 
 DESCRIPTION="D-Bus interfaces for querying and manipulating user account information"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/AccountsService/"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/AccountsService/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-3+"
 SLOT="0"

--- a/sys-apps/dbus/dbus-1.10.6.ebuild
+++ b/sys-apps/dbus/dbus-1.10.6.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools eutils linux-info flag-o-matic python-any-r1 readme.gentoo systemd virtualx user multilib-minimal
 
 DESCRIPTION="A message bus system, a simple way for applications to talk to each other"
-HOMEPAGE="http://dbus.freedesktop.org/"
-SRC_URI="http://dbus.freedesktop.org/releases/dbus/${P}.tar.gz"
+HOMEPAGE="https://dbus.freedesktop.org/"
+SRC_URI="https://dbus.freedesktop.org/releases/dbus/${P}.tar.gz"
 
 LICENSE="|| ( AFL-2.1 GPL-2 )"
 SLOT="0"

--- a/sys-apps/dbus/dbus-1.10.8-r1.ebuild
+++ b/sys-apps/dbus/dbus-1.10.8-r1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools eutils linux-info flag-o-matic python-any-r1 readme.gentoo-r1 systemd virtualx user multilib-minimal
 
 DESCRIPTION="A message bus system, a simple way for applications to talk to each other"
-HOMEPAGE="http://dbus.freedesktop.org/"
-SRC_URI="http://dbus.freedesktop.org/releases/dbus/${P}.tar.gz"
+HOMEPAGE="https://dbus.freedesktop.org/"
+SRC_URI="https://dbus.freedesktop.org/releases/dbus/${P}.tar.gz"
 
 LICENSE="|| ( AFL-2.1 GPL-2 )"
 SLOT="0"

--- a/sys-apps/dbus/dbus-1.8.16.ebuild
+++ b/sys-apps/dbus/dbus-1.8.16.ebuild
@@ -7,8 +7,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools eutils linux-info flag-o-matic python-any-r1 readme.gentoo systemd virtualx user multilib-minimal
 
 DESCRIPTION="A message bus system, a simple way for applications to talk to each other"
-HOMEPAGE="http://dbus.freedesktop.org/"
-SRC_URI="http://dbus.freedesktop.org/releases/dbus/${P}.tar.gz"
+HOMEPAGE="https://dbus.freedesktop.org/"
+SRC_URI="https://dbus.freedesktop.org/releases/dbus/${P}.tar.gz"
 
 LICENSE="|| ( AFL-2.1 GPL-2 )"
 SLOT="0"

--- a/sys-apps/dbus/dbus-1.8.20.ebuild
+++ b/sys-apps/dbus/dbus-1.8.20.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools eutils linux-info flag-o-matic python-any-r1 readme.gentoo systemd virtualx user multilib-minimal
 
 DESCRIPTION="A message bus system, a simple way for applications to talk to each other"
-HOMEPAGE="http://dbus.freedesktop.org/"
-SRC_URI="http://dbus.freedesktop.org/releases/dbus/${P}.tar.gz"
+HOMEPAGE="https://dbus.freedesktop.org/"
+SRC_URI="https://dbus.freedesktop.org/releases/dbus/${P}.tar.gz"
 
 LICENSE="|| ( AFL-2.1 GPL-2 )"
 SLOT="0"

--- a/sys-apps/hwids/hwids-20141010.ebuild
+++ b/sys-apps/hwids/hwids-20141010.ebuild
@@ -59,7 +59,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20141110.ebuild
+++ b/sys-apps/hwids/hwids-20141110.ebuild
@@ -59,7 +59,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20141214.ebuild
+++ b/sys-apps/hwids/hwids-20141214.ebuild
@@ -59,7 +59,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20150107.ebuild
+++ b/sys-apps/hwids/hwids-20150107.ebuild
@@ -59,7 +59,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20150129.ebuild
+++ b/sys-apps/hwids/hwids-20150129.ebuild
@@ -59,7 +59,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20150417.ebuild
+++ b/sys-apps/hwids/hwids-20150417.ebuild
@@ -59,7 +59,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20150421-r1.ebuild
+++ b/sys-apps/hwids/hwids-20150421-r1.ebuild
@@ -67,7 +67,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20150421.ebuild
+++ b/sys-apps/hwids/hwids-20150421.ebuild
@@ -59,7 +59,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20150717-r1.ebuild
+++ b/sys-apps/hwids/hwids-20150717-r1.ebuild
@@ -67,7 +67,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20150717.ebuild
+++ b/sys-apps/hwids/hwids-20150717.ebuild
@@ -59,7 +59,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-20160306.ebuild
+++ b/sys-apps/hwids/hwids-20160306.ebuild
@@ -67,7 +67,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/hwids/hwids-99999999.ebuild
+++ b/sys-apps/hwids/hwids-99999999.ebuild
@@ -67,7 +67,7 @@ src_install() {
 pkg_postinst() {
 	if use udev; then
 		udevadm hwdb --update --root="${ROOT%/}"
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[ "${ROOT:-/}" = "/" ] && udevadm control --reload
 	fi
 }

--- a/sys-apps/systemd-readahead/systemd-readahead-216.ebuild
+++ b/sys-apps/systemd-readahead/systemd-readahead-216.ebuild
@@ -7,7 +7,7 @@ inherit systemd toolchain-funcs udev
 
 DESCRIPTION="Split of readahead systemd implementation"
 HOMEPAGE="https://dev.gentoo.org/~pacho/systemd-readahead.html"
-SRC_URI="http://www.freedesktop.org/software/systemd/systemd-${PV}.tar.xz"
+SRC_URI="https://www.freedesktop.org/software/systemd/systemd-${PV}.tar.xz"
 
 LICENSE="LGPL-2.1 MIT"
 SLOT="0"

--- a/sys-apps/systemd-sysv-utils/systemd-sysv-utils-208.ebuild
+++ b/sys-apps/systemd-sysv-utils/systemd-sysv-utils-208.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 MY_P=systemd-${PV}
 
 DESCRIPTION="sysvinit compatibility symlinks and manpages"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
-SRC_URI="http://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
+SRC_URI="https://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/systemd-sysv-utils/systemd-sysv-utils-212.ebuild
+++ b/sys-apps/systemd-sysv-utils/systemd-sysv-utils-212.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 MY_P=systemd-${PV}
 
 DESCRIPTION="sysvinit compatibility symlinks and manpages"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
-SRC_URI="http://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
+SRC_URI="https://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/systemd-sysv-utils/systemd-sysv-utils-215.ebuild
+++ b/sys-apps/systemd-sysv-utils/systemd-sysv-utils-215.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 MY_P=systemd-${PV}
 
 DESCRIPTION="sysvinit compatibility symlinks and manpages"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
-SRC_URI="http://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
+SRC_URI="https://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/systemd-sysv-utils/systemd-sysv-utils-216.ebuild
+++ b/sys-apps/systemd-sysv-utils/systemd-sysv-utils-216.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 MY_P=systemd-${PV}
 
 DESCRIPTION="sysvinit compatibility symlinks and manpages"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
-SRC_URI="http://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
+SRC_URI="https://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/systemd-sysv-utils/systemd-sysv-utils-217.ebuild
+++ b/sys-apps/systemd-sysv-utils/systemd-sysv-utils-217.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 MY_P=systemd-${PV}
 
 DESCRIPTION="sysvinit compatibility symlinks and manpages"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
-SRC_URI="http://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
+SRC_URI="https://www.freedesktop.org/software/systemd/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/systemd/systemd-218-r5.ebuild
+++ b/sys-apps/systemd/systemd-218-r5.ebuild
@@ -11,8 +11,8 @@ inherit autotools-utils bash-completion-r1 linux-info multilib \
 	user
 
 DESCRIPTION="System and service manager for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
-SRC_URI="http://www.freedesktop.org/software/systemd/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
+SRC_URI="https://www.freedesktop.org/software/systemd/${P}.tar.xz"
 
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"

--- a/sys-apps/systemd/systemd-226-r2.ebuild
+++ b/sys-apps/systemd/systemd-226-r2.ebuild
@@ -16,7 +16,7 @@ inherit autotools bash-completion-r1 linux-info multilib \
 	multilib-minimal pam systemd toolchain-funcs udev user
 
 DESCRIPTION="System and service manager for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"

--- a/sys-apps/systemd/systemd-228-r1.ebuild
+++ b/sys-apps/systemd/systemd-228-r1.ebuild
@@ -16,7 +16,7 @@ inherit autotools bash-completion-r1 linux-info multilib \
 	multilib-minimal pam systemd toolchain-funcs udev user
 
 DESCRIPTION="System and service manager for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"

--- a/sys-apps/systemd/systemd-229-r100.ebuild
+++ b/sys-apps/systemd/systemd-229-r100.ebuild
@@ -17,7 +17,7 @@ inherit autotools bash-completion-r1 linux-info \
 	multilib-minimal pam systemd toolchain-funcs udev user
 
 DESCRIPTION="System and service manager for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"

--- a/sys-apps/systemd/systemd-229.ebuild
+++ b/sys-apps/systemd/systemd-229.ebuild
@@ -17,7 +17,7 @@ inherit autotools bash-completion-r1 linux-info \
 	multilib-minimal pam systemd toolchain-funcs udev user
 
 DESCRIPTION="System and service manager for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -16,7 +16,7 @@ inherit autotools bash-completion-r1 linux-info \
 	multilib-minimal pam systemd toolchain-funcs udev user
 
 DESCRIPTION="System and service manager for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"

--- a/sys-apps/usbredir/usbredir-0.7.1.ebuild
+++ b/sys-apps/usbredir/usbredir-0.7.1.ebuild
@@ -21,7 +21,7 @@ DEPEND="${RDEPEND}
 DOCS="ChangeLog README* TODO *.txt"
 
 src_configure() {
-	# http://bugs.freedesktop.org/show_bug.cgi?id=54643
+	# https://bugs.freedesktop.org/show_bug.cgi?id=54643
 	append-cflags -Wno-error
 
 	econf $(use_enable static-libs static)

--- a/sys-apps/usbredir/usbredir-0.7.ebuild
+++ b/sys-apps/usbredir/usbredir-0.7.ebuild
@@ -21,7 +21,7 @@ DEPEND="${RDEPEND}
 DOCS="ChangeLog README* TODO *.txt"
 
 src_configure() {
-	# http://bugs.freedesktop.org/show_bug.cgi?id=54643
+	# https://bugs.freedesktop.org/show_bug.cgi?id=54643
 	append-cflags -Wno-error
 
 	econf $(use_enable static-libs static)

--- a/sys-apps/usbredir/usbredir-9999.ebuild
+++ b/sys-apps/usbredir/usbredir-9999.ebuild
@@ -8,7 +8,7 @@ inherit eutils flag-o-matic autotools git-2
 
 DESCRIPTION="A simple TCP daemon and set of libraries for the usbredir protocol (redirecting USB traffic)"
 HOMEPAGE="http://spice-space.org/page/UsbRedir"
-EGIT_REPO_URI="http://anongit.freedesktop.org/git/spice/usbredir.git"
+EGIT_REPO_URI="https://anongit.freedesktop.org/git/spice/usbredir.git"
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"
@@ -24,7 +24,7 @@ DOCS="ChangeLog README* TODO *.txt"
 EGIT_BOOTSTRAP="eautoreconf"
 
 src_configure() {
-	# http://bugs.freedesktop.org/show_bug.cgi?id=54643
+	# https://bugs.freedesktop.org/show_bug.cgi?id=54643
 	append-cflags -Wno-error
 	econf $(use_enable static-libs static)
 }

--- a/sys-auth/consolekit/consolekit-0.4.6.ebuild
+++ b/sys-auth/consolekit/consolekit-0.4.6.ebuild
@@ -9,8 +9,8 @@ MY_PN=ConsoleKit
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Framework for defining and tracking users, login sessions and seats"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/ConsoleKit"
-SRC_URI="http://www.freedesktop.org/software/${MY_PN}/dist/${MY_P}.tar.xz
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/ConsoleKit"
+SRC_URI="https://www.freedesktop.org/software/${MY_PN}/dist/${MY_P}.tar.xz
 	https://launchpad.net/debian/+archive/primary/+files/${PN}_${PV}-4.debian.tar.gz" # for logrotate file
 
 LICENSE="GPL-2"

--- a/sys-auth/consolekit/consolekit-1.0.0-r1.ebuild
+++ b/sys-auth/consolekit/consolekit-1.0.0-r1.ebuild
@@ -9,7 +9,7 @@ MY_PN=ConsoleKit2
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Framework for defining and tracking users, login sessions and seats"
-HOMEPAGE="https://github.com/ConsoleKit2/ConsoleKit2 http://www.freedesktop.org/wiki/Software/ConsoleKit"
+HOMEPAGE="https://github.com/ConsoleKit2/ConsoleKit2 https://www.freedesktop.org/wiki/Software/ConsoleKit"
 SRC_URI="https://github.com/${MY_PN}/${MY_PN}/releases/download/${PV}/${MY_P}.tar.bz2
 	https://launchpad.net/debian/+archive/primary/+files/${PN}_0.4.6-4.debian.tar.gz" # for logrotate file
 

--- a/sys-auth/consolekit/consolekit-1.0.1.ebuild
+++ b/sys-auth/consolekit/consolekit-1.0.1.ebuild
@@ -9,7 +9,7 @@ MY_PN=ConsoleKit2
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Framework for defining and tracking users, login sessions and seats"
-HOMEPAGE="https://github.com/ConsoleKit2/ConsoleKit2 http://www.freedesktop.org/wiki/Software/ConsoleKit"
+HOMEPAGE="https://github.com/ConsoleKit2/ConsoleKit2 https://www.freedesktop.org/wiki/Software/ConsoleKit"
 SRC_URI="https://github.com/${MY_PN}/${MY_PN}/releases/download/${PV}/${MY_P}.tar.bz2
 	https://launchpad.net/debian/+archive/primary/+files/${PN}_0.4.6-4.debian.tar.gz" # for logrotate file
 

--- a/sys-auth/consolekit/consolekit-1.1.0.ebuild
+++ b/sys-auth/consolekit/consolekit-1.1.0.ebuild
@@ -9,7 +9,7 @@ MY_PN=ConsoleKit2
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Framework for defining and tracking users, login sessions and seats"
-HOMEPAGE="https://github.com/ConsoleKit2/ConsoleKit2 http://www.freedesktop.org/wiki/Software/ConsoleKit"
+HOMEPAGE="https://github.com/ConsoleKit2/ConsoleKit2 https://www.freedesktop.org/wiki/Software/ConsoleKit"
 SRC_URI="https://github.com/${MY_PN}/${MY_PN}/releases/download/${PV}/${MY_P}.tar.bz2
 	https://launchpad.net/debian/+archive/primary/+files/${PN}_0.4.6-4.debian.tar.gz" # for logrotate file
 

--- a/sys-auth/consolekit/consolekit-9999.ebuild
+++ b/sys-auth/consolekit/consolekit-9999.ebuild
@@ -9,7 +9,7 @@ MY_PN=ConsoleKit2
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Framework for defining and tracking users, login sessions and seats"
-HOMEPAGE="https://github.com/ConsoleKit2/ConsoleKit2 http://www.freedesktop.org/wiki/Software/ConsoleKit"
+HOMEPAGE="https://github.com/ConsoleKit2/ConsoleKit2 https://www.freedesktop.org/wiki/Software/ConsoleKit"
 SRC_URI="https://launchpad.net/debian/+archive/primary/+files/${PN}_0.4.6-4.debian.tar.gz" # for logrotate file
 EGIT_REPO_URI="https://github.com/${MY_PN}/${MY_PN}.git"
 

--- a/sys-auth/fprintd/fprintd-0.2.0-r1.ebuild
+++ b/sys-auth/fprintd/fprintd-0.2.0-r1.ebuild
@@ -7,9 +7,9 @@ EAPI=4
 inherit autotools toolchain-funcs versionator
 
 DESCRIPTION="D-Bus service to access fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/fprintd/"
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/fprintd/"
 MY_PV="V_$(replace_all_version_separators _)"
-SRC_URI="http://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
+SRC_URI="https://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-auth/fprintd/fprintd-0.4.1.ebuild
+++ b/sys-auth/fprintd/fprintd-0.4.1.ebuild
@@ -7,9 +7,9 @@ EAPI=4
 inherit autotools toolchain-funcs versionator
 
 DESCRIPTION="D-Bus service to access fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/fprintd/"
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/fprintd/"
 MY_PV="V_$(replace_all_version_separators _)"
-SRC_URI="http://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
+SRC_URI="https://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-auth/fprintd/fprintd-0.5.0.ebuild
+++ b/sys-auth/fprintd/fprintd-0.5.0.ebuild
@@ -7,9 +7,9 @@ EAPI=4
 inherit autotools pam systemd versionator
 
 DESCRIPTION="D-Bus service to access fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/fprintd/"
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/fprintd/"
 MY_PV="V_$(replace_all_version_separators _)"
-SRC_URI="http://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
+SRC_URI="https://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-auth/fprintd/fprintd-0.5.1.ebuild
+++ b/sys-auth/fprintd/fprintd-0.5.1.ebuild
@@ -7,9 +7,9 @@ EAPI=4
 inherit autotools pam systemd versionator
 
 DESCRIPTION="D-Bus service to access fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/fprintd/"
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/fprintd/"
 MY_PV="V_$(replace_all_version_separators _)"
-SRC_URI="http://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
+SRC_URI="https://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-auth/fprintd/fprintd-0.6.0.ebuild
+++ b/sys-auth/fprintd/fprintd-0.6.0.ebuild
@@ -7,9 +7,9 @@ EAPI=5
 inherit autotools pam systemd versionator
 
 DESCRIPTION="D-Bus service to access fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/fprintd/"
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/fprintd/"
 MY_PV="V_$(replace_all_version_separators _)"
-SRC_URI="http://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
+SRC_URI="https://cgit.freedesktop.org/libfprint/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-auth/libfprint/libfprint-0.4.0.ebuild
+++ b/sys-auth/libfprint/libfprint-0.4.0.ebuild
@@ -8,8 +8,8 @@ inherit autotools eutils udev
 
 MY_PV="v_${PV//./_}"
 DESCRIPTION="library to add support for consumer fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/libfprint/"
-SRC_URI="http://cgit.freedesktop.org/${PN}/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/libfprint/"
+SRC_URI="https://cgit.freedesktop.org/${PN}/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/sys-auth/libfprint/libfprint-0.5.0-r1.ebuild
+++ b/sys-auth/libfprint/libfprint-0.5.0-r1.ebuild
@@ -8,8 +8,8 @@ inherit autotools eutils udev vcs-snapshot
 
 MY_PV="v_${PV//./_}"
 DESCRIPTION="library to add support for consumer fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/libfprint/"
-SRC_URI="http://cgit.freedesktop.org/${PN}/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/libfprint/"
+SRC_URI="https://cgit.freedesktop.org/${PN}/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/sys-auth/libfprint/libfprint-0.5.1-r1.ebuild
+++ b/sys-auth/libfprint/libfprint-0.5.1-r1.ebuild
@@ -8,8 +8,8 @@ inherit autotools eutils udev vcs-snapshot
 
 MY_PV="v_${PV//./_}"
 DESCRIPTION="library to add support for consumer fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/libfprint/"
-SRC_URI="http://cgit.freedesktop.org/${PN}/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/libfprint/"
+SRC_URI="https://cgit.freedesktop.org/${PN}/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2
 	https://dev.gentoo.org/~patrick/libfprint-0.5.1-add-vfs5011-driver.patch"
 
 LICENSE="LGPL-2.1"

--- a/sys-auth/libfprint/libfprint-0.6.0-r2.ebuild
+++ b/sys-auth/libfprint/libfprint-0.6.0-r2.ebuild
@@ -8,8 +8,8 @@ inherit autotools eutils udev vcs-snapshot
 
 MY_PV="V_${PV//./_}"
 DESCRIPTION="library to add support for consumer fingerprint readers"
-HOMEPAGE="http://cgit.freedesktop.org/libfprint/libfprint/"
-SRC_URI="http://cgit.freedesktop.org/${PN}/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2
+HOMEPAGE="https://cgit.freedesktop.org/libfprint/libfprint/"
+SRC_URI="https://cgit.freedesktop.org/${PN}/${PN}/snapshot/${MY_PV}.tar.bz2 -> ${P}.tar.bz2
 	https://dev.gentoo.org/~xmw/${P}_vfs0050.patch.gz"
 
 LICENSE="LGPL-2.1"

--- a/sys-auth/polkit/polkit-0.113-r1.ebuild
+++ b/sys-auth/polkit/polkit-0.113-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib pam pax-utils systemd user
 
 DESCRIPTION="Policy framework for controlling privileges for system-wide services"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/polkit"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/polkit"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/sys-auth/polkit/polkit-0.113.ebuild
+++ b/sys-auth/polkit/polkit-0.113.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib pam pax-utils systemd user
 
 DESCRIPTION="Policy framework for controlling privileges for system-wide services"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/polkit"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/polkit"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/sys-boot/gummiboot/gummiboot-45.ebuild
+++ b/sys-boot/gummiboot/gummiboot-45.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit eutils linux-info
 
 DESCRIPTION="Minimalistic UEFI bootloader"
-HOMEPAGE="http://freedesktop.org/wiki/Software/gummiboot/"
+HOMEPAGE="https://freedesktop.org/wiki/Software/gummiboot/"
 SRC_URI="https://dev.gentoo.org/~mgorny/dist/${P}.tar.xz"
 
 LICENSE="LGPL-2.1+"

--- a/sys-boot/gummiboot/gummiboot-9999.ebuild
+++ b/sys-boot/gummiboot/gummiboot-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit autotools eutils linux-info git-r3
 
 DESCRIPTION="Minimalistic UEFI bootloader"
-HOMEPAGE="http://freedesktop.org/wiki/Software/gummiboot/"
+HOMEPAGE="https://freedesktop.org/wiki/Software/gummiboot/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/${PN}"
 
 LICENSE="LGPL-2.1+"

--- a/sys-boot/plymouth/plymouth-0.8.8-r4.ebuild
+++ b/sys-boot/plymouth/plymouth-0.8.8-r4.ebuild
@@ -7,9 +7,9 @@ EAPI=5
 inherit autotools-utils readme.gentoo systemd toolchain-funcs
 
 DESCRIPTION="Graphical boot animation (splash) and logger"
-HOMEPAGE="http://cgit.freedesktop.org/plymouth/"
+HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 SRC_URI="
-	http://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2
+	https://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2
 	https://dev.gentoo.org/~aidecoe/distfiles/${CATEGORY}/${PN}/gentoo-logo.png"
 
 LICENSE="GPL-2"

--- a/sys-boot/plymouth/plymouth-0.8.8-r5.ebuild
+++ b/sys-boot/plymouth/plymouth-0.8.8-r5.ebuild
@@ -7,9 +7,9 @@ EAPI=5
 inherit autotools-utils readme.gentoo systemd toolchain-funcs
 
 DESCRIPTION="Graphical boot animation (splash) and logger"
-HOMEPAGE="http://cgit.freedesktop.org/plymouth/"
+HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 SRC_URI="
-	http://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2
+	https://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2
 	https://dev.gentoo.org/~aidecoe/distfiles/${CATEGORY}/${PN}/gentoo-logo.png"
 
 LICENSE="GPL-2"

--- a/sys-boot/plymouth/plymouth-0.9.0.ebuild
+++ b/sys-boot/plymouth/plymouth-0.9.0.ebuild
@@ -12,13 +12,13 @@ if [[ ${PV} == 9999 ]]; then
 	AUTOTOOLS_AUTORECONF="1"
 	inherit git-r3
 else
-	SRC_URI="${SRC_URI} http://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2"
+	SRC_URI="${SRC_URI} https://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2"
 fi
 
 inherit autotools-utils readme.gentoo systemd toolchain-funcs
 
 DESCRIPTION="Graphical boot animation (splash) and logger"
-HOMEPAGE="http://cgit.freedesktop.org/plymouth/"
+HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-boot/plymouth/plymouth-0.9.2.ebuild
+++ b/sys-boot/plymouth/plymouth-0.9.2.ebuild
@@ -12,13 +12,13 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/plymouth"
 	inherit git-r3
 else
-	SRC_URI="${SRC_URI} http://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2"
+	SRC_URI="${SRC_URI} https://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2"
 fi
 
 inherit autotools-utils readme.gentoo systemd toolchain-funcs
 
 DESCRIPTION="Graphical boot animation (splash) and logger"
-HOMEPAGE="http://cgit.freedesktop.org/plymouth/"
+HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-boot/plymouth/plymouth-9999.ebuild
+++ b/sys-boot/plymouth/plymouth-9999.ebuild
@@ -12,13 +12,13 @@ if [[ ${PV} == 9999 ]]; then
 	AUTOTOOLS_AUTORECONF="1"
 	inherit git-r3
 else
-	SRC_URI="${SRC_URI} http://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2"
+	SRC_URI="${SRC_URI} https://www.freedesktop.org/software/plymouth/releases/${P}.tar.bz2"
 fi
 
 inherit autotools-utils readme.gentoo systemd toolchain-funcs
 
 DESCRIPTION="Graphical boot animation (splash) and logger"
-HOMEPAGE="http://cgit.freedesktop.org/plymouth/"
+HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-firmware/amdgpu-ucode/amdgpu-ucode-20150803.ebuild
+++ b/sys-firmware/amdgpu-ucode/amdgpu-ucode-20150803.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info
 
 DESCRIPTION="Microcode for V.Islands Radeon GPUs and APUs"
-HOMEPAGE="http://people.freedesktop.org/~agd5f/radeon_ucode/"
+HOMEPAGE="https://people.freedesktop.org/~agd5f/radeon_ucode/"
 SRC_URI="mirror://gentoo/${P}.tar.xz"
 
 LICENSE="radeon-ucode"

--- a/sys-firmware/amdgpu-ucode/amdgpu-ucode-20160331.ebuild
+++ b/sys-firmware/amdgpu-ucode/amdgpu-ucode-20160331.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info
 
 DESCRIPTION="Microcode for C.Islands/V.Islands/A.Islands Radeon GPUs and APUs"
-HOMEPAGE="http://people.freedesktop.org/~agd5f/radeon_ucode/"
+HOMEPAGE="https://people.freedesktop.org/~agd5f/radeon_ucode/"
 SRC_URI="mirror://gentoo/${P}.tar.xz
 	legacy? ( mirror://gentoo/${P/amdgpu/radeon}.tar.xz )"
 

--- a/sys-firmware/nvidia-firmware/nvidia-firmware-325.15.ebuild
+++ b/sys-firmware/nvidia-firmware/nvidia-firmware-325.15.ebuild
@@ -12,7 +12,7 @@ X86_NV_PACKAGE="NVIDIA-Linux-x86-${PV}"
 EXTRACT_FIRMWARE_REV="845a51ab607df85fc0ed01f0b5b6d57850e37662"
 
 DESCRIPTION="Kernel and mesa firmware for nouveau (video accel and pgraph)"
-HOMEPAGE="http://nouveau.freedesktop.org/wiki/VideoAcceleration/"
+HOMEPAGE="https://nouveau.freedesktop.org/wiki/VideoAcceleration/"
 SRC_URI="${NV_URI}Linux-x86/${PV}/${X86_NV_PACKAGE}.run
 	https://raw.github.com/imirkin/re-vp2/${EXTRACT_FIRMWARE_REV}/extract_firmware.py -> nvidia_extract_firmware-${PV}.py"
 

--- a/sys-firmware/nvidia-firmware/nvidia-firmware-340.32.ebuild
+++ b/sys-firmware/nvidia-firmware/nvidia-firmware-340.32.ebuild
@@ -13,7 +13,7 @@ X86_NV_PACKAGE="NVIDIA-Linux-x86-${PV}"
 EXTRACT_FIRMWARE_REV="96641bfebb2547402b2145fcf0e3116410f0da87"
 
 DESCRIPTION="Kernel and mesa firmware for nouveau (video accel and pgraph)"
-HOMEPAGE="http://nouveau.freedesktop.org/wiki/VideoAcceleration/"
+HOMEPAGE="https://nouveau.freedesktop.org/wiki/VideoAcceleration/"
 SRC_URI="${NV_URI}Linux-x86/${PV}/${X86_NV_PACKAGE}.run
 	https://raw.github.com/imirkin/re-vp2/${EXTRACT_FIRMWARE_REV}/extract_firmware.py -> nvidia_extract_firmware-${PV}.py"
 

--- a/sys-firmware/radeon-ucode/radeon-ucode-20140204.ebuild
+++ b/sys-firmware/radeon-ucode/radeon-ucode-20140204.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info
 
 DESCRIPTION="IRQ microcode for r6xx/r7xx/Evergreen/N.Islands/S.Islands Radeon GPUs and APUs"
-HOMEPAGE="http://people.freedesktop.org/~agd5f/radeon_ucode/"
+HOMEPAGE="https://people.freedesktop.org/~agd5f/radeon_ucode/"
 SRC_URI="mirror://gentoo/${P}.tar.xz"
 
 LICENSE="radeon-ucode"

--- a/sys-firmware/radeon-ucode/radeon-ucode-20140430.ebuild
+++ b/sys-firmware/radeon-ucode/radeon-ucode-20140430.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info
 
 DESCRIPTION="IRQ microcode for r6xx/r7xx/Evergreen/N.Islands/S.Islands Radeon GPUs and APUs"
-HOMEPAGE="http://people.freedesktop.org/~agd5f/radeon_ucode/"
+HOMEPAGE="https://people.freedesktop.org/~agd5f/radeon_ucode/"
 SRC_URI="mirror://gentoo/${P}.tar.xz"
 
 LICENSE="radeon-ucode"

--- a/sys-firmware/radeon-ucode/radeon-ucode-20140823.ebuild
+++ b/sys-firmware/radeon-ucode/radeon-ucode-20140823.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info
 
 DESCRIPTION="IRQ microcode for r6xx/r7xx/Evergreen/N.Islands/S.Islands Radeon GPUs and APUs"
-HOMEPAGE="http://people.freedesktop.org/~agd5f/radeon_ucode/"
+HOMEPAGE="https://people.freedesktop.org/~agd5f/radeon_ucode/"
 SRC_URI="mirror://gentoo/${P}.tar.xz"
 
 LICENSE="radeon-ucode"

--- a/sys-firmware/radeon-ucode/radeon-ucode-20150511.ebuild
+++ b/sys-firmware/radeon-ucode/radeon-ucode-20150511.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info
 
 DESCRIPTION="IRQ microcode for r6xx/r7xx/Evergreen/N.Islands/S.Islands Radeon GPUs and APUs"
-HOMEPAGE="http://people.freedesktop.org/~agd5f/radeon_ucode/"
+HOMEPAGE="https://people.freedesktop.org/~agd5f/radeon_ucode/"
 SRC_URI="mirror://gentoo/${P}.tar.xz"
 
 LICENSE="radeon-ucode"

--- a/sys-firmware/radeon-ucode/radeon-ucode-20160331.ebuild
+++ b/sys-firmware/radeon-ucode/radeon-ucode-20160331.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info
 
 DESCRIPTION="IRQ microcode for r6xx/r7xx/Evergreen/N.Islands/S.Islands Radeon GPUs and APUs"
-HOMEPAGE="http://people.freedesktop.org/~agd5f/radeon_ucode/"
+HOMEPAGE="https://people.freedesktop.org/~agd5f/radeon_ucode/"
 SRC_URI="mirror://gentoo/${P}.tar.xz"
 
 LICENSE="radeon-ucode"

--- a/sys-fs/eudev/eudev-1.10-r2.ebuild
+++ b/sys-fs/eudev/eudev-1.10-r2.ebuild
@@ -72,7 +72,7 @@ pkg_pretend() {
 		ewarn
 		ewarn "As of 2013-01-29, ${P} provides the new interface renaming functionality,"
 		ewarn "as described in the URL below:"
-		ewarn "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+		ewarn "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
 		ewarn
 		ewarn "This functionality is enabled BY DEFAULT because eudev has no means of synchronizing"
 		ewarn "between the default or user-modified choice of sys-fs/udev.  If you wish to disable"
@@ -251,7 +251,7 @@ pkg_postinst() {
 	if use hwdb && has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		# reload database after it has be rebuilt, but only if we are not upgrading
 		# also pass if we are -9999 since who knows what hwdb related changes there might be
 		if [[ ${REPLACING_VERSIONS%-r*} == ${PV} || -z ${REPLACING_VERSIONS} ]] && \
@@ -280,7 +280,7 @@ pkg_postinst() {
 	elog "         https://www.gentoo.org/doc/en/udev-guide.xml"
 	elog
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -290,7 +290,7 @@ pkg_postinst() {
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
 		if [[ -z ${REPLACING_VERSIONS} ]]; then
-			# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+			# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 			if [[ ${ROOT} != "" ]] && [[ ${ROOT} != "/" ]]; then
 				return 0
 			fi

--- a/sys-fs/eudev/eudev-1.9-r2.ebuild
+++ b/sys-fs/eudev/eudev-1.9-r2.ebuild
@@ -72,7 +72,7 @@ pkg_pretend() {
 		ewarn
 		ewarn "As of 2013-01-29, ${P} provides the new interface renaming functionality,"
 		ewarn "as described in the URL below:"
-		ewarn "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+		ewarn "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
 		ewarn
 		ewarn "This functionality is enabled BY DEFAULT because eudev has no means of synchronizing"
 		ewarn "between the default or user-modified choice of sys-fs/udev.  If you wish to disable"
@@ -253,7 +253,7 @@ pkg_postinst() {
 	if use hwdb && has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		# reload database after it has be rebuilt, but only if we are not upgrading
 		# also pass if we are -9999 since who knows what hwdb related changes there might be
 		if [[ ${REPLACING_VERSIONS%-r*} == ${PV} || -z ${REPLACING_VERSIONS} ]] && \
@@ -282,7 +282,7 @@ pkg_postinst() {
 	elog "         https://www.gentoo.org/doc/en/udev-guide.xml"
 	elog
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -292,7 +292,7 @@ pkg_postinst() {
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
 		if [[ -z ${REPLACING_VERSIONS} ]]; then
-			# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+			# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 			if [[ ${ROOT} != "" ]] && [[ ${ROOT} != "/" ]]; then
 				return 0
 			fi

--- a/sys-fs/eudev/eudev-3.1.2.ebuild
+++ b/sys-fs/eudev/eudev-3.1.2.ebuild
@@ -69,7 +69,7 @@ pkg_pretend() {
 	ewarn
 	ewarn "As of 2013-01-29, ${P} provides the new interface renaming functionality,"
 	ewarn "as described in the URL below:"
-	ewarn "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+	ewarn "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
 	ewarn
 	ewarn "This functionality is enabled BY DEFAULT because eudev has no means of synchronizing"
 	ewarn "between the default or user-modified choice of sys-fs/udev.  If you wish to disable"
@@ -233,7 +233,7 @@ pkg_postinst() {
 	if use hwdb && has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		# reload database after it has be rebuilt, but only if we are not upgrading
 		# also pass if we are -9999 since who knows what hwdb related changes there might be
 		if [[ ${REPLACING_VERSIONS%-r*} == ${PV} || -z ${REPLACING_VERSIONS} ]] && \
@@ -253,7 +253,7 @@ pkg_postinst() {
 	elog "         https://www.gentoo.org/doc/en/udev-guide.xml"
 	elog
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -263,7 +263,7 @@ pkg_postinst() {
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
 		if [[ -z ${REPLACING_VERSIONS} ]]; then
-			# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+			# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 			if [[ ${ROOT} != "" ]] && [[ ${ROOT} != "/" ]]; then
 				return 0
 			fi

--- a/sys-fs/eudev/eudev-3.1.5.ebuild
+++ b/sys-fs/eudev/eudev-3.1.5.ebuild
@@ -61,7 +61,7 @@ pkg_pretend() {
 	ewarn
 	ewarn "As of 2013-01-29, ${P} provides the new interface renaming functionality,"
 	ewarn "as described in the URL below:"
-	ewarn "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+	ewarn "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
 	ewarn
 	ewarn "This functionality is enabled BY DEFAULT because eudev has no means of synchronizing"
 	ewarn "between the default or user-modified choice of sys-fs/udev.  If you wish to disable"
@@ -193,7 +193,7 @@ pkg_postinst() {
 	if use hwdb && has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		# reload database after it has be rebuilt, but only if we are not upgrading
 		# also pass if we are -9999 since who knows what hwdb related changes there might be
 		if [[ ${REPLACING_VERSIONS%-r*} == ${PV} || -z ${REPLACING_VERSIONS} ]] && \
@@ -222,7 +222,7 @@ pkg_postinst() {
 	elog "         https://www.gentoo.org/doc/en/udev-guide.xml"
 	elog
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -232,7 +232,7 @@ pkg_postinst() {
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
 		if [[ -z ${REPLACING_VERSIONS} ]]; then
-			# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+			# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 			if [[ ${ROOT} != "" ]] && [[ ${ROOT} != "/" ]]; then
 				return 0
 			fi

--- a/sys-fs/eudev/eudev-9999.ebuild
+++ b/sys-fs/eudev/eudev-9999.ebuild
@@ -61,7 +61,7 @@ pkg_pretend() {
 	ewarn
 	ewarn "As of 2013-01-29, ${P} provides the new interface renaming functionality,"
 	ewarn "as described in the URL below:"
-	ewarn "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+	ewarn "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
 	ewarn
 	ewarn "This functionality is enabled BY DEFAULT because eudev has no means of synchronizing"
 	ewarn "between the default or user-modified choice of sys-fs/udev.  If you wish to disable"
@@ -193,7 +193,7 @@ pkg_postinst() {
 	if use hwdb && has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		# reload database after it has be rebuilt, but only if we are not upgrading
 		# also pass if we are -9999 since who knows what hwdb related changes there might be
 		if [[ ${REPLACING_VERSIONS%-r*} == ${PV} || -z ${REPLACING_VERSIONS} ]] && \
@@ -222,7 +222,7 @@ pkg_postinst() {
 	elog "         https://www.gentoo.org/doc/en/udev-guide.xml"
 	elog
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -232,7 +232,7 @@ pkg_postinst() {
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
 		if [[ -z ${REPLACING_VERSIONS} ]]; then
-			# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+			# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 			if [[ ${ROOT} != "" ]] && [[ ${ROOT} != "/" ]]; then
 				return 0
 			fi

--- a/sys-fs/udev/udev-216.ebuild
+++ b/sys-fs/udev/udev-216.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = 9999* ]]; then
 	patchset=
 else
 	patchset=2
-	SRC_URI="http://www.freedesktop.org/software/systemd/systemd-${PV}.tar.xz"
+	SRC_URI="https://www.freedesktop.org/software/systemd/systemd-${PV}.tar.xz"
 	if [[ -n "${patchset}" ]]; then
 		SRC_URI+="
 			https://dev.gentoo.org/~ssuominen/${P}-patches-${patchset}.tar.xz
@@ -22,7 +22,7 @@ else
 fi
 
 DESCRIPTION="Linux dynamic and persistent device naming support (aka userspace devfs)"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="LGPL-2.1 MIT GPL-2"
 SLOT="0"
@@ -418,8 +418,8 @@ pkg_postinst() {
 	elog
 	elog "Starting from version >= 197 the new predictable network interface names are"
 	elog "used by default, see:"
-	elog "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
-	elog "http://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
+	elog "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+	elog "https://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
 	elog
 	elog "Example command to get the information for the new interface name before booting"
 	elog "(replace <ifname> with, for example, eth0):"
@@ -475,7 +475,7 @@ pkg_postinst() {
 		eend $?
 	fi
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -484,7 +484,7 @@ pkg_postinst() {
 	if has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[[ -z ${REPLACING_VERSIONS} ]] && udev_reload
 	fi
 }

--- a/sys-fs/udev/udev-225.ebuild
+++ b/sys-fs/udev/udev-225.ebuild
@@ -21,7 +21,7 @@ else
 fi
 
 DESCRIPTION="Linux dynamic and persistent device naming support (aka userspace devfs)"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="LGPL-2.1 MIT GPL-2"
 SLOT="0"
@@ -367,8 +367,8 @@ pkg_postinst() {
 	elog
 	elog "Starting from version >= 197 the new predictable network interface names are"
 	elog "used by default, see:"
-	elog "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
-	elog "http://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
+	elog "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+	elog "https://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
 	elog
 	elog "Example command to get the information for the new interface name before booting"
 	elog "(replace <ifname> with, for example, eth0):"
@@ -424,7 +424,7 @@ pkg_postinst() {
 		eend $?
 	fi
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -433,7 +433,7 @@ pkg_postinst() {
 	if has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[[ -z ${REPLACING_VERSIONS} ]] && udev_reload
 	fi
 }

--- a/sys-fs/udev/udev-228.ebuild
+++ b/sys-fs/udev/udev-228.ebuild
@@ -21,7 +21,7 @@ else
 fi
 
 DESCRIPTION="Linux dynamic and persistent device naming support (aka userspace devfs)"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="LGPL-2.1 MIT GPL-2"
 SLOT="0"
@@ -367,8 +367,8 @@ pkg_postinst() {
 	elog
 	elog "Starting from version >= 197 the new predictable network interface names are"
 	elog "used by default, see:"
-	elog "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
-	elog "http://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
+	elog "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+	elog "https://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
 	elog
 	elog "Example command to get the information for the new interface name before booting"
 	elog "(replace <ifname> with, for example, eth0):"
@@ -424,7 +424,7 @@ pkg_postinst() {
 		eend $?
 	fi
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -433,7 +433,7 @@ pkg_postinst() {
 	if has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[[ -z ${REPLACING_VERSIONS} ]] && udev_reload
 	fi
 }

--- a/sys-fs/udev/udev-229-r2.ebuild
+++ b/sys-fs/udev/udev-229-r2.ebuild
@@ -21,7 +21,7 @@ else
 fi
 
 DESCRIPTION="Linux dynamic and persistent device naming support (aka userspace devfs)"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="LGPL-2.1 MIT GPL-2"
 SLOT="0"
@@ -369,8 +369,8 @@ pkg_postinst() {
 	elog
 	elog "Starting from version >= 197 the new predictable network interface names are"
 	elog "used by default, see:"
-	elog "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
-	elog "http://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
+	elog "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+	elog "https://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
 	elog
 	elog "Example command to get the information for the new interface name before booting"
 	elog "(replace <ifname> with, for example, eth0):"
@@ -426,7 +426,7 @@ pkg_postinst() {
 		eend $?
 	fi
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -435,7 +435,7 @@ pkg_postinst() {
 	if has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[[ -z ${REPLACING_VERSIONS} ]] && udev_reload
 	fi
 }

--- a/sys-fs/udev/udev-9999.ebuild
+++ b/sys-fs/udev/udev-9999.ebuild
@@ -21,7 +21,7 @@ else
 fi
 
 DESCRIPTION="Linux dynamic and persistent device naming support (aka userspace devfs)"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="LGPL-2.1 MIT GPL-2"
 SLOT="0"
@@ -368,8 +368,8 @@ pkg_postinst() {
 	elog
 	elog "Starting from version >= 197 the new predictable network interface names are"
 	elog "used by default, see:"
-	elog "http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
-	elog "http://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
+	elog "https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames"
+	elog "https://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c"
 	elog
 	elog "Example command to get the information for the new interface name before booting"
 	elog "(replace <ifname> with, for example, eth0):"
@@ -425,7 +425,7 @@ pkg_postinst() {
 		eend $?
 	fi
 
-	# http://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
+	# https://cgit.freedesktop.org/systemd/systemd/commit/rules/50-udev-default.rules?id=3dff3e00e044e2d53c76fa842b9a4759d4a50e69
 	# https://bugs.gentoo.org/246847
 	# https://bugs.gentoo.org/514174
 	enewgroup input
@@ -434,7 +434,7 @@ pkg_postinst() {
 	if has_version 'sys-apps/hwids[udev]'; then
 		udevadm hwdb --update --root="${ROOT%/}"
 		# Only reload when we are not upgrading to avoid potential race w/ incompatible hwdb.bin and the running udevd
-		# http://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
+		# https://cgit.freedesktop.org/systemd/systemd/commit/?id=1fab57c209035f7e66198343074e9cee06718bda
 		[[ -z ${REPLACING_VERSIONS} ]] && udev_reload
 	fi
 }

--- a/sys-fs/udisks/udisks-1.0.5-r1.ebuild
+++ b/sys-fs/udisks/udisks-1.0.5-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils bash-completion-r1 linux-info udev systemd
 
 DESCRIPTION="Daemon providing interfaces to work with storage devices"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/udisks"
-SRC_URI="http://hal.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/udisks"
+SRC_URI="https://hal.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-fs/udisks/udisks-2.1.4.ebuild
+++ b/sys-fs/udisks/udisks-2.1.4.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit bash-completion-r1 eutils linux-info systemd udev
 
 DESCRIPTION="Daemon providing interfaces to work with storage devices"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/udisks"
-SRC_URI="http://udisks.freedesktop.org/releases/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/udisks"
+SRC_URI="https://udisks.freedesktop.org/releases/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="2"

--- a/sys-fs/udisks/udisks-2.1.6.ebuild
+++ b/sys-fs/udisks/udisks-2.1.6.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit bash-completion-r1 eutils linux-info systemd udev
 
 DESCRIPTION="Daemon providing interfaces to work with storage devices"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/udisks"
-SRC_URI="http://udisks.freedesktop.org/releases/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/udisks"
+SRC_URI="https://udisks.freedesktop.org/releases/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="2"

--- a/sys-fs/udisks/udisks-2.1.7.ebuild
+++ b/sys-fs/udisks/udisks-2.1.7.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit bash-completion-r1 eutils linux-info systemd udev
 
 DESCRIPTION="Daemon providing interfaces to work with storage devices"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/udisks"
-SRC_URI="http://udisks.freedesktop.org/releases/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/udisks"
+SRC_URI="https://udisks.freedesktop.org/releases/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="2"

--- a/sys-power/pm-quirks/pm-quirks-20100619.ebuild
+++ b/sys-power/pm-quirks/pm-quirks-20100619.ebuild
@@ -6,8 +6,8 @@ EAPI=3
 inherit multilib
 
 DESCRIPTION="Video Quirks database for pm-utils"
-HOMEPAGE="http://pm-utils.freedesktop.org/"
-SRC_URI="http://pm-utils.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://pm-utils.freedesktop.org/"
+SRC_URI="https://pm-utils.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-power/pm-utils/pm-utils-1.4.1-r6.ebuild
+++ b/sys-power/pm-utils/pm-utils-1.4.1-r6.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib
 
 DESCRIPTION="Suspend and hibernation utilities"
-HOMEPAGE="http://pm-utils.freedesktop.org/"
-SRC_URI="http://pm-utils.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://pm-utils.freedesktop.org/"
+SRC_URI="https://pm-utils.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-power/pm-utils/pm-utils-1.4.1-r7.ebuild
+++ b/sys-power/pm-utils/pm-utils-1.4.1-r7.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib
 
 DESCRIPTION="Suspend and hibernation utilities"
-HOMEPAGE="http://pm-utils.freedesktop.org/"
-SRC_URI="http://pm-utils.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://pm-utils.freedesktop.org/"
+SRC_URI="https://pm-utils.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-power/upower-pm-utils/upower-pm-utils-0.9.23-r2.ebuild
+++ b/sys-power/upower-pm-utils/upower-pm-utils-0.9.23-r2.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils systemd
 
 DESCRIPTION="The upstream upower 0.9 git branch for use with sys-power/pm-utils"
-HOMEPAGE="http://upower.freedesktop.org/"
-SRC_URI="http://upower.freedesktop.org/releases/upower-${PV}.tar.xz"
+HOMEPAGE="https://upower.freedesktop.org/"
+SRC_URI="https://upower.freedesktop.org/releases/upower-${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -47,7 +47,7 @@ S=${WORKDIR}/upower-${PV}
 src_prepare() {
 	sed -i -e '/DISABLE_DEPRECATED/d' configure || die
 
-	# http://bugs.freedesktop.org/show_bug.cgi?id=79565
+	# https://bugs.freedesktop.org/show_bug.cgi?id=79565
 	# https://bugzilla.xfce.org/show_bug.cgi?id=10931
 	# Same effect as Debian -no_deprecation_define.patch, they patch .h, we patch .pc
 	sed -i -e 's|Cflags: |&-DUPOWER_ENABLE_DEPRECATED |' upower-glib.pc.in || die

--- a/sys-power/upower/upower-0.99.2-r1.ebuild
+++ b/sys-power/upower/upower-0.99.2-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils systemd
 
 DESCRIPTION="D-Bus abstraction for enumerating power devices and querying history and statistics"
-HOMEPAGE="http://upower.freedesktop.org/"
-SRC_URI="http://${PN}.freedesktop.org/releases/${P}.tar.xz"
+HOMEPAGE="https://upower.freedesktop.org/"
+SRC_URI="https://${PN}.freedesktop.org/releases/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0/3" # based on SONAME of libupower-glib.so

--- a/sys-power/upower/upower-0.99.3.ebuild
+++ b/sys-power/upower/upower-0.99.3.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils systemd
 
 DESCRIPTION="D-Bus abstraction for enumerating power devices and querying history and statistics"
-HOMEPAGE="http://upower.freedesktop.org/"
-SRC_URI="http://${PN}.freedesktop.org/releases/${P}.tar.xz"
+HOMEPAGE="https://upower.freedesktop.org/"
+SRC_URI="https://${PN}.freedesktop.org/releases/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0/3" # based on SONAME of libupower-glib.so

--- a/sys-power/upower/upower-0.99.4.ebuild
+++ b/sys-power/upower/upower-0.99.4.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils systemd
 
 DESCRIPTION="D-Bus abstraction for enumerating power devices, querying history and statistics"
-HOMEPAGE="http://upower.freedesktop.org/"
-SRC_URI="http://${PN}.freedesktop.org/releases/${P}.tar.xz"
+HOMEPAGE="https://upower.freedesktop.org/"
+SRC_URI="https://${PN}.freedesktop.org/releases/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0/3" # based on SONAME of libupower-glib.so

--- a/x11-apps/transset/transset-1.0.1.ebuild
+++ b/x11-apps/transset/transset-1.0.1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit xorg-2
 
 DESCRIPTION="An utility for setting opacity property"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/xapps http://cgit.freedesktop.org/xorg/app/transset/"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/xapps https://cgit.freedesktop.org/xorg/app/transset/"
 
 LICENSE="SGI-B-2.0"
 KEYWORDS="amd64 x86"

--- a/x11-apps/xinput_calibrator/xinput_calibrator-0.7.5.ebuild
+++ b/x11-apps/xinput_calibrator/xinput_calibrator-0.7.5.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit autotools-utils flag-o-matic
 
 DESCRIPTION="A generic touchscreen calibration program for X.Org"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/xinput_calibrator"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/xinput_calibrator"
 SRC_URI="mirror://github/tias/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.7.4.ebuild
+++ b/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.7.4.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info xorg-2
 
 DESCRIPTION="Driver for Synaptics touchpads"
-HOMEPAGE="http://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
+HOMEPAGE="https://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
 
 KEYWORDS="amd64 arm ~mips ppc ppc64 x86"
 IUSE=""

--- a/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.7.8.ebuild
+++ b/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.7.8.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info xorg-2
 
 DESCRIPTION="Driver for Synaptics touchpads"
-HOMEPAGE="http://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
+HOMEPAGE="https://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
 
 KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
 IUSE=""

--- a/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.8.1.ebuild
+++ b/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.8.1.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info xorg-2
 
 DESCRIPTION="Driver for Synaptics touchpads"
-HOMEPAGE="http://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
+HOMEPAGE="https://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
 
 KEYWORDS="amd64 arm ~mips ppc ppc64 x86"
 IUSE="kernel_linux"

--- a/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.8.2.ebuild
+++ b/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.8.2.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info xorg-2
 
 DESCRIPTION="Driver for Synaptics touchpads"
-HOMEPAGE="http://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
+HOMEPAGE="https://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
 
 KEYWORDS="amd64 arm ~mips ppc ppc64 x86"
 IUSE="kernel_linux"

--- a/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.8.3.ebuild
+++ b/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-1.8.3.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit linux-info xorg-2
 
 DESCRIPTION="Driver for Synaptics touchpads"
-HOMEPAGE="http://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
+HOMEPAGE="https://cgit.freedesktop.org/xorg/driver/xf86-input-synaptics/"
 
 KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
 IUSE="kernel_linux"

--- a/x11-drivers/xf86-video-intel/xf86-video-intel-2.99.917_p20160403.ebuild
+++ b/x11-drivers/xf86-video-intel/xf86-video-intel-2.99.917_p20160403.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="X.Org driver for Intel cards"
 KEYWORDS="~amd64 ~x86 ~amd64-fbsd -x86-fbsd"
 IUSE="debug +dri3 +sna +udev uxa xvmc"
 COMMIT_ID="90792c933d9a6160e6646121cfe79ee857f70655"
-SRC_URI="http://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/${COMMIT_ID}.tar.xz -> ${P}.tar.xz"
+SRC_URI="https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/${COMMIT_ID}.tar.xz -> ${P}.tar.xz"
 
 S=${WORKDIR}/${COMMIT_ID}
 

--- a/x11-drivers/xf86-video-intel/xf86-video-intel-2.99.917_p20160407.ebuild
+++ b/x11-drivers/xf86-video-intel/xf86-video-intel-2.99.917_p20160407.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="X.Org driver for Intel cards"
 KEYWORDS="~amd64 ~x86 ~amd64-fbsd -x86-fbsd"
 IUSE="debug +dri3 +sna +udev uxa xvmc"
 COMMIT_ID="59d371a9b215fdcd6139279435af7e1f6803309e"
-SRC_URI="http://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/${COMMIT_ID}.tar.xz -> ${P}.tar.xz"
+SRC_URI="https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/${COMMIT_ID}.tar.xz -> ${P}.tar.xz"
 
 S=${WORKDIR}/${COMMIT_ID}
 

--- a/x11-drivers/xf86-video-intel/xf86-video-intel-2.99.917_p20160410.ebuild
+++ b/x11-drivers/xf86-video-intel/xf86-video-intel-2.99.917_p20160410.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="X.Org driver for Intel cards"
 KEYWORDS="~amd64 ~x86 ~amd64-fbsd -x86-fbsd"
 IUSE="debug +dri3 +sna +udev uxa xvmc"
 COMMIT_ID="a7526ea2e038f1f1bb92869f584d2fe4c8db1dce"
-SRC_URI="http://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/${COMMIT_ID}.tar.xz -> ${P}.tar.xz"
+SRC_URI="https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/${COMMIT_ID}.tar.xz -> ${P}.tar.xz"
 
 S=${WORKDIR}/${COMMIT_ID}
 

--- a/x11-drivers/xf86-video-intel/xf86-video-intel-2.99.917_p20160417.ebuild
+++ b/x11-drivers/xf86-video-intel/xf86-video-intel-2.99.917_p20160417.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="X.Org driver for Intel cards"
 KEYWORDS="~amd64 ~x86 ~amd64-fbsd -x86-fbsd"
 IUSE="debug +dri3 +sna +udev uxa xvmc"
 COMMIT_ID="81029be07380090195d165fab91d3e1fe1d84bb9"
-SRC_URI="http://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/${COMMIT_ID}.tar.xz -> ${P}.tar.xz"
+SRC_URI="https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/${COMMIT_ID}.tar.xz -> ${P}.tar.xz"
 
 S=${WORKDIR}/${COMMIT_ID}
 

--- a/x11-drivers/xf86-video-nouveau/xf86-video-nouveau-1.0.11.ebuild
+++ b/x11-drivers/xf86-video-nouveau/xf86-video-nouveau-1.0.11.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999* ]]; then
 fi
 
 DESCRIPTION="Accelerated Open Source driver for nVidia cards"
-HOMEPAGE="http://nouveau.freedesktop.org/"
+HOMEPAGE="https://nouveau.freedesktop.org/"
 
 KEYWORDS="amd64 ppc ppc64 x86"
 IUSE="glamor"

--- a/x11-drivers/xf86-video-nouveau/xf86-video-nouveau-1.0.12.ebuild
+++ b/x11-drivers/xf86-video-nouveau/xf86-video-nouveau-1.0.12.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == 9999* ]]; then
 fi
 
 DESCRIPTION="Accelerated Open Source driver for nVidia cards"
-HOMEPAGE="http://nouveau.freedesktop.org/"
+HOMEPAGE="https://nouveau.freedesktop.org/"
 
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 IUSE=""

--- a/x11-drivers/xf86-video-openchrome/xf86-video-openchrome-0.3.3.ebuild
+++ b/x11-drivers/xf86-video-openchrome/xf86-video-openchrome-0.3.3.ebuild
@@ -7,7 +7,7 @@ XORG_DRI="always"
 inherit xorg-2
 
 DESCRIPTION="X.Org driver for VIA/S3G cards"
-HOMEPAGE="http://www.freedesktop.org/wiki/Openchrome/"
+HOMEPAGE="https://www.freedesktop.org/wiki/Openchrome/"
 LICENSE="MIT"
 
 KEYWORDS="amd64 x86"

--- a/x11-libs/colord-gtk/colord-gtk-0.1.25.ebuild
+++ b/x11-libs/colord-gtk/colord-gtk-0.1.25.ebuild
@@ -9,8 +9,8 @@ VALA_USE_DEPEND="vapigen"
 inherit eutils vala
 
 DESCRIPTION="GTK support library for colord"
-HOMEPAGE="http://www.freedesktop.org/software/colord/"
-SRC_URI="http://www.freedesktop.org/software/colord/releases/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/software/colord/"
+SRC_URI="https://www.freedesktop.org/software/colord/releases/${P}.tar.xz"
 
 LICENSE="LGPL-3+"
 SLOT="0/1" # subslot = libcolord-gtk soname version

--- a/x11-libs/colord-gtk/colord-gtk-0.1.26.ebuild
+++ b/x11-libs/colord-gtk/colord-gtk-0.1.26.ebuild
@@ -9,8 +9,8 @@ VALA_USE_DEPEND="vapigen"
 inherit gnome2 vala
 
 DESCRIPTION="GTK support library for colord"
-HOMEPAGE="http://www.freedesktop.org/software/colord/"
-SRC_URI="http://www.freedesktop.org/software/colord/releases/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/software/colord/"
+SRC_URI="https://www.freedesktop.org/software/colord/releases/${P}.tar.xz"
 
 LICENSE="LGPL-3+"
 SLOT="0/1" # subslot = libcolord-gtk soname version

--- a/x11-libs/libdrm/libdrm-2.4.59.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.59.ebuild
@@ -8,11 +8,11 @@ XORG_MULTILIB=yes
 inherit xorg-2
 
 DESCRIPTION="X.Org libdrm library"
-HOMEPAGE="http://dri.freedesktop.org/"
+HOMEPAGE="https://dri.freedesktop.org/"
 if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/git/mesa/drm"
 else
-	SRC_URI="http://dri.freedesktop.org/${PN}/${P}.tar.bz2"
+	SRC_URI="https://dri.freedesktop.org/${PN}/${P}.tar.bz2"
 fi
 
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~arm-linux ~x86-linux ~sparc-solaris ~x64-solaris ~x86-solaris"

--- a/x11-libs/libdrm/libdrm-2.4.65.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.65.ebuild
@@ -8,11 +8,11 @@ XORG_MULTILIB=yes
 inherit xorg-2
 
 DESCRIPTION="X.Org libdrm library"
-HOMEPAGE="http://dri.freedesktop.org/"
+HOMEPAGE="https://dri.freedesktop.org/"
 if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/git/mesa/drm"
 else
-	SRC_URI="http://dri.freedesktop.org/${PN}/${P}.tar.bz2"
+	SRC_URI="https://dri.freedesktop.org/${PN}/${P}.tar.bz2"
 fi
 
 KEYWORDS="~alpha amd64 arm ~arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~arm-linux ~x86-linux"

--- a/x11-libs/libdrm/libdrm-2.4.66.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.66.ebuild
@@ -8,11 +8,11 @@ XORG_MULTILIB=yes
 inherit xorg-2
 
 DESCRIPTION="X.Org libdrm library"
-HOMEPAGE="http://dri.freedesktop.org/"
+HOMEPAGE="https://dri.freedesktop.org/"
 if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/git/mesa/drm"
 else
-	SRC_URI="http://dri.freedesktop.org/${PN}/${P}.tar.bz2"
+	SRC_URI="https://dri.freedesktop.org/${PN}/${P}.tar.bz2"
 fi
 
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~arm-linux ~x86-linux"

--- a/x11-libs/libdrm/libdrm-2.4.67.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.67.ebuild
@@ -8,11 +8,11 @@ XORG_MULTILIB=yes
 inherit xorg-2
 
 DESCRIPTION="X.Org libdrm library"
-HOMEPAGE="http://dri.freedesktop.org/"
+HOMEPAGE="https://dri.freedesktop.org/"
 if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/git/mesa/drm"
 else
-	SRC_URI="http://dri.freedesktop.org/${PN}/${P}.tar.bz2"
+	SRC_URI="https://dri.freedesktop.org/${PN}/${P}.tar.bz2"
 fi
 
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~arm-linux ~x86-linux"

--- a/x11-libs/libdrm/libdrm-9999.ebuild
+++ b/x11-libs/libdrm/libdrm-9999.ebuild
@@ -8,12 +8,12 @@ XORG_MULTILIB=yes
 inherit xorg-2
 
 DESCRIPTION="X.Org libdrm library"
-HOMEPAGE="http://dri.freedesktop.org/"
+HOMEPAGE="https://dri.freedesktop.org/"
 if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="git://anongit.freedesktop.org/git/mesa/drm"
 	KEYWORDS=""
 else
-	SRC_URI="http://dri.freedesktop.org/${PN}/${P}.tar.bz2"
+	SRC_URI="https://dri.freedesktop.org/${PN}/${P}.tar.bz2"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~arm-linux ~x86-linux"
 fi
 

--- a/x11-libs/libva-intel-driver/libva-intel-driver-1.3.0.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-1.3.0.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-intel-driver/libva-intel-driver-1.4.1.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-1.4.1.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-intel-driver/libva-intel-driver-1.5.0.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-1.5.0.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-intel-driver/libva-intel-driver-1.5.1.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-1.5.1.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-intel-driver/libva-intel-driver-1.6.0.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-1.6.0.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-intel-driver/libva-intel-driver-1.6.1.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-1.6.1.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-intel-driver/libva-intel-driver-1.6.2.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-1.6.2.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-intel-driver/libva-intel-driver-1.7.0.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-1.7.0.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-intel-driver/libva-intel-driver-9999.ebuild
+++ b/x11-libs/libva-intel-driver/libva-intel-driver-9999.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="HW video decode support for Intel integrated graphics"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva-vdpau-driver/libva-vdpau-driver-0.7.4-r2.ebuild
+++ b/x11-libs/libva-vdpau-driver/libva-vdpau-driver-0.7.4-r2.ebuild
@@ -8,8 +8,8 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib eutils
 
 DESCRIPTION="VDPAU Backend for Video Acceleration (VA) API"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
-SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-vdpau-driver/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
+SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-vdpau-driver/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-libs/libva-vdpau-driver/libva-vdpau-driver-0.7.4-r3.ebuild
+++ b/x11-libs/libva-vdpau-driver/libva-vdpau-driver-0.7.4-r3.ebuild
@@ -8,8 +8,8 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib eutils
 
 DESCRIPTION="VDPAU Backend for Video Acceleration (VA) API"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
-SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-vdpau-driver/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
+SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-vdpau-driver/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-libs/libva-vdpau-driver/libva-vdpau-driver-9999.ebuild
+++ b/x11-libs/libva-vdpau-driver/libva-vdpau-driver-9999.ebuild
@@ -14,12 +14,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM}
 
 DESCRIPTION="VDPAU Backend for Video Acceleration (VA) API"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva-vdpau-driver/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva-vdpau-driver/${P}.tar.bz2"
 fi
 
 LICENSE="GPL-2"

--- a/x11-libs/libva/libva-1.3.1.ebuild
+++ b/x11-libs/libva/libva-1.3.1.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-1.4.0.ebuild
+++ b/x11-libs/libva/libva-1.4.0.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-1.4.1.ebuild
+++ b/x11-libs/libva/libva-1.4.1.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-1.5.0.ebuild
+++ b/x11-libs/libva/libva-1.5.0.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-1.5.1.ebuild
+++ b/x11-libs/libva/libva-1.5.1.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-1.6.0.ebuild
+++ b/x11-libs/libva/libva-1.6.0.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-1.6.1.ebuild
+++ b/x11-libs/libva/libva-1.6.1.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-1.6.2.ebuild
+++ b/x11-libs/libva/libva-1.6.2.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-1.7.0.ebuild
+++ b/x11-libs/libva/libva-1.7.0.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libva/libva-9999.ebuild
+++ b/x11-libs/libva/libva-9999.ebuild
@@ -15,12 +15,12 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit autotools-multilib ${SCM} multilib
 
 DESCRIPTION="Video Acceleration (VA) API for Linux"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 if [ "${PV%9999}" != "${PV}" ] ; then # Live ebuild
 	SRC_URI=""
 	S="${WORKDIR}/${PN}"
 else
-	SRC_URI="http://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
+	SRC_URI="https://www.freedesktop.org/software/vaapi/releases/libva/${P}.tar.bz2"
 fi
 
 LICENSE="MIT"

--- a/x11-libs/libvdpau/libvdpau-1.1.1.ebuild
+++ b/x11-libs/libvdpau/libvdpau-1.1.1.ebuild
@@ -7,8 +7,8 @@ VIRTUALX_REQUIRED="test"
 inherit autotools-multilib flag-o-matic virtualx
 
 DESCRIPTION="VDPAU wrapper and trace libraries"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/VDPAU"
-SRC_URI="http://people.freedesktop.org/~aplattner/vdpau/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/VDPAU"
+SRC_URI="https://people.freedesktop.org/~aplattner/vdpau/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-libs/libxcb/libxcb-1.10.ebuild
+++ b/x11-libs/libxcb/libxcb-1.10.ebuild
@@ -12,10 +12,10 @@ XORG_MULTILIB=yes
 inherit python-any-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings library"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/libxcb"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="selinux xkb"

--- a/x11-libs/libxcb/libxcb-1.11-r1.ebuild
+++ b/x11-libs/libxcb/libxcb-1.11-r1.ebuild
@@ -13,10 +13,10 @@ XORG_EAUTORECONF=yes
 inherit python-any-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings library"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/libxcb"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc selinux test xkb"

--- a/x11-libs/libxcb/libxcb-1.11.1.ebuild
+++ b/x11-libs/libxcb/libxcb-1.11.1.ebuild
@@ -13,10 +13,10 @@ XORG_EAUTORECONF=yes
 inherit python-any-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings library"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/libxcb"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="~alpha amd64 arm ~arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc selinux test xkb"

--- a/x11-libs/libxcb/libxcb-1.11.ebuild
+++ b/x11-libs/libxcb/libxcb-1.11.ebuild
@@ -13,10 +13,10 @@ XORG_EAUTORECONF=yes
 inherit python-any-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings library"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/libxcb"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="selinux xkb"

--- a/x11-libs/libxcb/libxcb-1.9.1-r1.ebuild
+++ b/x11-libs/libxcb/libxcb-1.9.1-r1.ebuild
@@ -12,10 +12,10 @@ XORG_MULTILIB=yes
 inherit eutils python-single-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings library"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/libxcb"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="selinux xkb"
@@ -41,10 +41,10 @@ src_prepare() {
 		-i "${S}/tests/Makefile.am" \
 		-i "${S}/tests/Makefile.in" \
 		|| die "Could not patch tests/Makefile.am and tests/Makefile.in to fix tests"
-	# http://patchwork.freedesktop.org/patch/15185/
+	# https://patchwork.freedesktop.org/patch/15185/
 	# Sounds like this commit is missing:
 	# c_client.py: Handle multiple expr. in a bitcase
-	# http://cgit.freedesktop.org/xcb/libxcb/commit/?id=e602b65
+	# https://cgit.freedesktop.org/xcb/libxcb/commit/?id=e602b65
 	epatch "${FILESDIR}/${PN}-1.9.1-list-object-has-no-attribute-lenfield_name.patch"
 	# https://bugs.freedesktop.org/show_bug.cgi?id=71502
 	epatch "${FILESDIR}/${PN}-1.9.1-conflicting-types-for-xcb_ge_event_t.patch"

--- a/x11-libs/libxcb/libxcb-1.9.1.ebuild
+++ b/x11-libs/libxcb/libxcb-1.9.1.ebuild
@@ -12,10 +12,10 @@ XORG_MULTILIB=yes
 inherit python-single-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings library"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/libxcb"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="selinux xkb"

--- a/x11-libs/libxcb/libxcb-1.9.3-r1.ebuild
+++ b/x11-libs/libxcb/libxcb-1.9.3-r1.ebuild
@@ -12,10 +12,10 @@ XORG_MULTILIB=yes
 inherit python-any-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings library"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/libxcb"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="selinux xkb"

--- a/x11-libs/libxcb/libxcb-1.9.3.ebuild
+++ b/x11-libs/libxcb/libxcb-1.9.3.ebuild
@@ -12,10 +12,10 @@ XORG_MULTILIB=yes
 inherit python-single-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings library"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/libxcb"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="selinux xkb"

--- a/x11-libs/libxklavier/libxklavier-5.3-r1.ebuild
+++ b/x11-libs/libxklavier/libxklavier-5.3-r1.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit eutils gnome.org libtool xdg-utils
 
 DESCRIPTION="A library for the X Keyboard Extension (high-level API)"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/LibXklavier"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LibXklavier"
 
 LICENSE="LGPL-2"
 SLOT="0/16"

--- a/x11-libs/libxklavier/libxklavier-5.3.ebuild
+++ b/x11-libs/libxklavier/libxklavier-5.3.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 inherit eutils gnome.org libtool
 
 DESCRIPTION="A library for the X Keyboard Extension (high-level API)"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/LibXklavier"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LibXklavier"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/x11-libs/startup-notification/startup-notification-0.12-r1.ebuild
+++ b/x11-libs/startup-notification/startup-notification-0.12-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils xorg-2
 
 DESCRIPTION="Application startup notification and feedback library"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/startup-notification"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/startup-notification"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
 
 LICENSE="LGPL-2 MIT"
 SLOT="0"

--- a/x11-libs/startup-notification/startup-notification-0.12.ebuild
+++ b/x11-libs/startup-notification/startup-notification-0.12.ebuild
@@ -6,8 +6,8 @@ EAPI=4
 inherit xorg-2
 
 DESCRIPTION="Application startup notification and feedback library"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/startup-notification"
-SRC_URI="http://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/startup-notification"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.gz"
 
 LICENSE="LGPL-2 MIT"
 SLOT="0"

--- a/x11-libs/xcb-util-cursor/xcb-util-cursor-0.1.1-r1.ebuild
+++ b/x11-libs/xcb-util-cursor/xcb-util-cursor-0.1.1-r1.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 XORG_MODULE=/
-XORG_BASE_INDIVIDUAL_URI=http://xcb.freedesktop.org/dist
+XORG_BASE_INDIVIDUAL_URI=https://xcb.freedesktop.org/dist
 XORG_DOC=doc
 XORG_MULTILIB=yes
 inherit xorg-2
@@ -14,7 +14,7 @@ EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/util-cursor"
 EGIT_HAS_SUBMODULES=yes
 
 DESCRIPTION="X C-language Bindings sample implementations"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE="test"

--- a/x11-libs/xcb-util-cursor/xcb-util-cursor-0.1.2.ebuild
+++ b/x11-libs/xcb-util-cursor/xcb-util-cursor-0.1.2.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 XORG_MODULE=/
-XORG_BASE_INDIVIDUAL_URI=http://xcb.freedesktop.org/dist
+XORG_BASE_INDIVIDUAL_URI=https://xcb.freedesktop.org/dist
 XORG_DOC=doc
 XORG_MULTILIB=yes
 inherit xorg-2
@@ -14,7 +14,7 @@ EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/util-cursor"
 EGIT_HAS_SUBMODULES=yes
 
 DESCRIPTION="X C-language Bindings sample implementations"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="~alpha amd64 arm ~arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE="test"

--- a/x11-libs/xcb-util-image/xcb-util-image-0.4.0.ebuild
+++ b/x11-libs/xcb-util-image/xcb-util-image-0.4.0.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 XORG_MODULE=/
-XORG_BASE_INDIVIDUAL_URI=http://xcb.freedesktop.org/dist
+XORG_BASE_INDIVIDUAL_URI=https://xcb.freedesktop.org/dist
 XORG_DOC=doc
 XORG_MULTILIB=yes
 inherit xorg-2
@@ -13,7 +13,7 @@ inherit xorg-2
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/util-image"
 
 DESCRIPTION="X C-language Bindings sample implementations"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE="test"

--- a/x11-libs/xcb-util-keysyms/xcb-util-keysyms-0.4.0.ebuild
+++ b/x11-libs/xcb-util-keysyms/xcb-util-keysyms-0.4.0.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 XORG_MODULE=/
-XORG_BASE_INDIVIDUAL_URI=http://xcb.freedesktop.org/dist
+XORG_BASE_INDIVIDUAL_URI=https://xcb.freedesktop.org/dist
 XORG_DOC=doc
 XORG_MULTILIB=yes
 inherit xorg-2
@@ -13,7 +13,7 @@ inherit xorg-2
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/util-keysyms"
 
 DESCRIPTION="X C-language Bindings sample implementations"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE="test"

--- a/x11-libs/xcb-util-renderutil/xcb-util-renderutil-0.3.9-r1.ebuild
+++ b/x11-libs/xcb-util-renderutil/xcb-util-renderutil-0.3.9-r1.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 XORG_MODULE=/
-XORG_BASE_INDIVIDUAL_URI=http://xcb.freedesktop.org/dist
+XORG_BASE_INDIVIDUAL_URI=https://xcb.freedesktop.org/dist
 XORG_DOC=doc
 XORG_MULTILIB=yes
 inherit xorg-2
@@ -14,7 +14,7 @@ EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/util-renderutil"
 EGIT_HAS_SUBMODULES=yes
 
 DESCRIPTION="X C-language Bindings sample implementations"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE="test"

--- a/x11-libs/xcb-util-wm/xcb-util-wm-0.4.1-r1.ebuild
+++ b/x11-libs/xcb-util-wm/xcb-util-wm-0.4.1-r1.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 XORG_MODULE=/
-XORG_BASE_INDIVIDUAL_URI=http://xcb.freedesktop.org/dist
+XORG_BASE_INDIVIDUAL_URI=https://xcb.freedesktop.org/dist
 XORG_DOC=doc
 XORG_MULTILIB=yes
 inherit xorg-2
@@ -14,7 +14,7 @@ EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/util-wm"
 EGIT_HAS_SUBMODULES=yes
 
 DESCRIPTION="X C-language Bindings sample implementations"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE="test"

--- a/x11-libs/xcb-util/xcb-util-0.4.0.ebuild
+++ b/x11-libs/xcb-util/xcb-util-0.4.0.ebuild
@@ -5,7 +5,7 @@
 EAPI=5
 
 XORG_MODULE=/
-XORG_BASE_INDIVIDUAL_URI=http://xcb.freedesktop.org/dist
+XORG_BASE_INDIVIDUAL_URI=https://xcb.freedesktop.org/dist
 XORG_DOC=doc
 XORG_MULTILIB=yes
 inherit xorg-2
@@ -13,7 +13,7 @@ inherit xorg-2
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/util"
 
 DESCRIPTION="X C-language Bindings sample implementations"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE="test"

--- a/x11-libs/xpyb/xpyb-1.3.1-r2.ebuild
+++ b/x11-libs/xpyb/xpyb-1.3.1-r2.ebuild
@@ -10,9 +10,9 @@ AUTOTOOLS_AUTORECONF=1
 inherit flag-o-matic xorg-2 python-r1
 
 #EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/xpyb"
-SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 DESCRIPTION="XCB-based Python bindings for the X Window System"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="selinux"

--- a/x11-libs/xpyb/xpyb-1.3.1-r3.ebuild
+++ b/x11-libs/xpyb/xpyb-1.3.1-r3.ebuild
@@ -10,9 +10,9 @@ AUTOTOOLS_AUTORECONF=1
 inherit flag-o-matic xorg-2 python-r1
 
 #EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/xpyb"
-SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 DESCRIPTION="XCB-based Python bindings for the X Window System"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="selinux"

--- a/x11-libs/xvba-video/xvba-video-0.8.0-r3.ebuild
+++ b/x11-libs/xvba-video/xvba-video-0.8.0-r3.ebuild
@@ -11,10 +11,10 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit eutils autotools-multilib python-any-r1
 
 DESCRIPTION="XVBA Backend for Video Acceleration (VA) API"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 SRC_URI="http://dev.gentooexperimental.org/~scarabeus/xvba-driver-${PV}.tar.bz2"
 # No source release yet, the src_uri is theoretical at best right now
-#[[ ${PV} = 9999 ]] || SRC_URI="http://www.freedesktop.org/software/vaapi/releases/${PN}/${P}.tar.bz2"
+#[[ ${PV} = 9999 ]] || SRC_URI="https://www.freedesktop.org/software/vaapi/releases/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2+ MIT"
 SLOT="0"

--- a/x11-libs/xvba-video/xvba-video-9999.ebuild
+++ b/x11-libs/xvba-video/xvba-video-9999.ebuild
@@ -11,9 +11,9 @@ AUTOTOOLS_AUTORECONF="yes"
 inherit eutils autotools-multilib python-any-r1
 
 DESCRIPTION="XVBA Backend for Video Acceleration (VA) API"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/vaapi"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/vaapi"
 # No source release yet, the src_uri is theoretical at best right now
-[[ ${PV} = 9999 ]] || SRC_URI="http://www.freedesktop.org/software/vaapi/releases/${PN}/${P}.tar.bz2"
+[[ ${PV} = 9999 ]] || SRC_URI="https://www.freedesktop.org/software/vaapi/releases/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2+ MIT"
 SLOT="0"

--- a/x11-misc/colord/colord-1.2.12.ebuild
+++ b/x11-misc/colord/colord-1.2.12.ebuild
@@ -10,8 +10,8 @@ VALA_USE_DEPEND="vapigen"
 inherit autotools bash-completion-r1 check-reqs eutils gnome2 user systemd udev vala multilib-minimal
 
 DESCRIPTION="System service to accurately color manage input and output devices"
-HOMEPAGE="http://www.freedesktop.org/software/colord/"
-SRC_URI="http://www.freedesktop.org/software/colord/releases/${P}.tar.xz"
+HOMEPAGE="https://www.freedesktop.org/software/colord/"
+SRC_URI="https://www.freedesktop.org/software/colord/releases/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0/2" # subslot = libcolord soname version

--- a/x11-misc/driconf/driconf-0.9.1-r1.ebuild
+++ b/x11-misc/driconf/driconf-0.9.1-r1.ebuild
@@ -9,8 +9,8 @@ PYTHON_USE_WITH="xml"
 inherit distutils eutils
 
 DESCRIPTION="driconf is a GTK+2 GUI configurator for DRI"
-HOMEPAGE="http://dri.freedesktop.org/wiki/DriConf"
-SRC_URI="http://freedesktop.org/~fxkuehl/${PN}/${P}.tar.gz"
+HOMEPAGE="https://dri.freedesktop.org/wiki/DriConf"
+SRC_URI="https://freedesktop.org/~fxkuehl/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/lightdm/lightdm-1.10.5.ebuild
+++ b/x11-misc/lightdm/lightdm-1.10.5.ebuild
@@ -7,7 +7,7 @@ inherit autotools eutils pam readme.gentoo systemd
 
 TRUNK_VERSION="1.10"
 DESCRIPTION="A lightweight display manager"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/LightDM"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LightDM"
 SRC_URI="https://launchpad.net/${PN}/${TRUNK_VERSION}/${PV}/+download/${P}.tar.xz
 	mirror://gentoo/introspection-20110205.m4.tar.bz2"
 

--- a/x11-misc/lightdm/lightdm-1.16.7.ebuild
+++ b/x11-misc/lightdm/lightdm-1.16.7.ebuild
@@ -7,7 +7,7 @@ inherit autotools eutils pam readme.gentoo systemd versionator
 
 TRUNK_VERSION="$(get_version_component_range 1-2)"
 DESCRIPTION="A lightweight display manager"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/LightDM"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LightDM"
 SRC_URI="https://launchpad.net/${PN}/${TRUNK_VERSION}/${PV}/+download/${P}.tar.xz
 	mirror://gentoo/introspection-20110205.m4.tar.bz2"
 

--- a/x11-misc/lightdm/lightdm-1.17.5.ebuild
+++ b/x11-misc/lightdm/lightdm-1.17.5.ebuild
@@ -7,7 +7,7 @@ inherit autotools eutils pam readme.gentoo systemd versionator
 
 TRUNK_VERSION="$(get_version_component_range 1-2)"
 DESCRIPTION="A lightweight display manager"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/LightDM"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LightDM"
 SRC_URI="https://launchpad.net/${PN}/${TRUNK_VERSION}/${PV}/+download/${P}.tar.xz
 	mirror://gentoo/introspection-20110205.m4.tar.bz2"
 

--- a/x11-misc/lightdm/lightdm-1.17.6.ebuild
+++ b/x11-misc/lightdm/lightdm-1.17.6.ebuild
@@ -7,7 +7,7 @@ inherit autotools eutils pam readme.gentoo-r1 systemd versionator
 
 TRUNK_VERSION="$(get_version_component_range 1-2)"
 DESCRIPTION="A lightweight display manager"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/LightDM"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LightDM"
 SRC_URI="https://launchpad.net/${PN}/${TRUNK_VERSION}/${PV}/+download/${P}.tar.xz
 	mirror://gentoo/introspection-20110205.m4.tar.bz2"
 

--- a/x11-misc/lightdm/lightdm-1.18.0.ebuild
+++ b/x11-misc/lightdm/lightdm-1.18.0.ebuild
@@ -7,7 +7,7 @@ inherit autotools eutils pam readme.gentoo-r1 systemd versionator
 
 TRUNK_VERSION="$(get_version_component_range 1-2)"
 DESCRIPTION="A lightweight display manager"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/LightDM"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LightDM"
 SRC_URI="https://launchpad.net/${PN}/${TRUNK_VERSION}/${PV}/+download/${P}.tar.xz
 	mirror://gentoo/introspection-20110205.m4.tar.bz2"
 

--- a/x11-misc/lightdm/lightdm-1.18.1.ebuild
+++ b/x11-misc/lightdm/lightdm-1.18.1.ebuild
@@ -7,7 +7,7 @@ inherit autotools eutils pam readme.gentoo-r1 systemd versionator
 
 TRUNK_VERSION="$(get_version_component_range 1-2)"
 DESCRIPTION="A lightweight display manager"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/LightDM"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LightDM"
 SRC_URI="https://launchpad.net/${PN}/${TRUNK_VERSION}/${PV}/+download/${P}.tar.xz
 	mirror://gentoo/introspection-20110205.m4.tar.bz2"
 

--- a/x11-misc/shared-mime-info/shared-mime-info-1.4-r1.ebuild
+++ b/x11-misc/shared-mime-info/shared-mime-info-1.4-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils fdo-mime
 
 DESCRIPTION="The Shared MIME-info Database specification"
-HOMEPAGE="http://freedesktop.org/wiki/Software/shared-mime-info"
-SRC_URI="http://people.freedesktop.org/~hadess/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/shared-mime-info"
+SRC_URI="https://people.freedesktop.org/~hadess/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/shared-mime-info/shared-mime-info-1.4.ebuild
+++ b/x11-misc/shared-mime-info/shared-mime-info-1.4.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils fdo-mime
 
 DESCRIPTION="The Shared MIME-info Database specification"
-HOMEPAGE="http://freedesktop.org/wiki/Software/shared-mime-info"
-SRC_URI="http://people.freedesktop.org/~hadess/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/shared-mime-info"
+SRC_URI="https://people.freedesktop.org/~hadess/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/shared-mime-info/shared-mime-info-1.5.ebuild
+++ b/x11-misc/shared-mime-info/shared-mime-info-1.5.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils fdo-mime
 
 DESCRIPTION="The Shared MIME-info Database specification"
-HOMEPAGE="http://freedesktop.org/wiki/Software/shared-mime-info"
-SRC_URI="http://people.freedesktop.org/~hadess/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/shared-mime-info"
+SRC_URI="https://people.freedesktop.org/~hadess/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/shared-mime-info/shared-mime-info-1.6.ebuild
+++ b/x11-misc/shared-mime-info/shared-mime-info-1.6.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils fdo-mime
 
 DESCRIPTION="The Shared MIME-info Database specification"
-HOMEPAGE="http://freedesktop.org/wiki/Software/shared-mime-info"
-SRC_URI="http://people.freedesktop.org/~hadess/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/shared-mime-info"
+SRC_URI="https://people.freedesktop.org/~hadess/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/vdpauinfo/vdpauinfo-1.0.ebuild
+++ b/x11-misc/vdpauinfo/vdpauinfo-1.0.ebuild
@@ -5,8 +5,8 @@
 EAPI=5
 
 DESCRIPTION="Displays info about your card's VDPAU support"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/VDPAU"
-SRC_URI="http://people.freedesktop.org/~aplattner/vdpau/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/VDPAU"
+SRC_URI="https://people.freedesktop.org/~aplattner/vdpau/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-misc/wininfo/wininfo-0.7.ebuild
+++ b/x11-misc/wininfo/wininfo-0.7.ebuild
@@ -6,8 +6,8 @@ EAPI=2
 inherit eutils
 
 DESCRIPTION="An X app that follows your pointer providing information about the windows below"
-HOMEPAGE="http://freedesktop.org/Software/wininfo"
-SRC_URI="http://www.freedesktop.org/software/${PN}/${P}.tar.gz"
+HOMEPAGE="https://freedesktop.org/Software/wininfo"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-misc/xcompmgr/xcompmgr-1.1.6.ebuild
+++ b/x11-misc/xcompmgr/xcompmgr-1.1.6.ebuild
@@ -8,7 +8,7 @@ XORG_STATIC=no
 inherit xorg-2
 
 DESCRIPTION="X Compositing manager"
-HOMEPAGE="http://freedesktop.org/Software/xapps"
+HOMEPAGE="https://freedesktop.org/Software/xapps"
 SRC_URI="http://xorg.freedesktop.org/releases/individual/app/${P}.tar.bz2"
 
 LICENSE="BSD"

--- a/x11-misc/xcompmgr/xcompmgr-1.1.7.ebuild
+++ b/x11-misc/xcompmgr/xcompmgr-1.1.7.ebuild
@@ -8,7 +8,7 @@ XORG_STATIC=no
 inherit xorg-2
 
 DESCRIPTION="X Compositing manager"
-HOMEPAGE="http://freedesktop.org/Software/xapps"
+HOMEPAGE="https://freedesktop.org/Software/xapps"
 SRC_URI="http://xorg.freedesktop.org/releases/individual/app/${P}.tar.bz2"
 
 LICENSE="BSD"

--- a/x11-misc/xdg-user-dirs-gtk/xdg-user-dirs-gtk-0.10.ebuild
+++ b/x11-misc/xdg-user-dirs-gtk/xdg-user-dirs-gtk-0.10.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit gnome.org readme.gentoo
 
 DESCRIPTION="Integrates xdg-user-dirs into the Gnome desktop and Gtk+ applications"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/xdg-user-dirs"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/xdg-user-dirs"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/xdg-user-dirs/xdg-user-dirs-0.15.ebuild
+++ b/x11-misc/xdg-user-dirs/xdg-user-dirs-0.15.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit autotools eutils
 
 DESCRIPTION="A tool to help manage 'well known' user directories"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/xdg-user-dirs"
-SRC_URI="http://user-dirs.freedesktop.org/releases/${P}.tar.gz"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/xdg-user-dirs"
+SRC_URI="https://user-dirs.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -16,7 +16,7 @@ IUSE="gtk"
 
 RDEPEND=""
 # libxslt is mandatory because 0.15 tarball is broken, re:
-# http://bugs.freedesktop.org/show_bug.cgi?id=66251
+# https://bugs.freedesktop.org/show_bug.cgi?id=66251
 DEPEND="app-text/docbook-xml-dtd:4.3
 	dev-libs/libxslt
 	sys-devel/gettext"

--- a/x11-misc/xdg-utils/xdg-utils-1.1.0_rc2-r1.ebuild
+++ b/x11-misc/xdg-utils/xdg-utils-1.1.0_rc2-r1.ebuild
@@ -8,10 +8,10 @@ inherit eutils
 MY_P=${P/_/-}
 
 DESCRIPTION="Portland utils for cross-platform/cross-toolkit/cross-desktop interoperability"
-HOMEPAGE="http://portland.freedesktop.org/"
-SRC_URI="http://people.freedesktop.org/~rdieter/${PN}/${MY_P}.tar.gz
+HOMEPAGE="https://portland.freedesktop.org/"
+SRC_URI="https://people.freedesktop.org/~rdieter/${PN}/${MY_P}.tar.gz
 	https://dev.gentoo.org/~ssuominen/${P}-patchset-1.tar.xz"
-#SRC_URI="http://portland.freedesktop.org/download/${MY_P}.tar.gz"
+#SRC_URI="https://portland.freedesktop.org/download/${MY_P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-misc/xdg-utils/xdg-utils-1.1.0_rc2.ebuild
+++ b/x11-misc/xdg-utils/xdg-utils-1.1.0_rc2.ebuild
@@ -7,9 +7,9 @@ EAPI=5
 MY_P=${P/_/-}
 
 DESCRIPTION="Portland utils for cross-platform/cross-toolkit/cross-desktop interoperability"
-HOMEPAGE="http://portland.freedesktop.org/"
-SRC_URI="http://people.freedesktop.org/~rdieter/${PN}/${MY_P}.tar.gz"
-#SRC_URI="http://portland.freedesktop.org/download/${MY_P}.tar.gz"
+HOMEPAGE="https://portland.freedesktop.org/"
+SRC_URI="https://people.freedesktop.org/~rdieter/${PN}/${MY_P}.tar.gz"
+#SRC_URI="https://portland.freedesktop.org/download/${MY_P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-misc/xdg-utils/xdg-utils-1.1.1.ebuild
+++ b/x11-misc/xdg-utils/xdg-utils-1.1.1.ebuild
@@ -8,11 +8,11 @@ inherit autotools eutils
 MY_P=${P/_/-}
 
 DESCRIPTION="Portland utils for cross-platform/cross-toolkit/cross-desktop interoperability"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/xdg-utils/"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/xdg-utils/"
 #SRC_URI="https://dev.gentoo.org/~johu/distfiles/${P}.tar.xz"
-#SRC_URI="http://people.freedesktop.org/~rdieter/${PN}/${MY_P}.tar.gz
+#SRC_URI="https://people.freedesktop.org/~rdieter/${PN}/${MY_P}.tar.gz
 #	https://dev.gentoo.org/~ssuominen/${P}-patchset-1.tar.xz"
-SRC_URI="http://portland.freedesktop.org/download/${MY_P}.tar.gz"
+SRC_URI="https://portland.freedesktop.org/download/${MY_P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.14.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.14.ebuild
@@ -10,7 +10,7 @@ inherit xorg-2
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xkeyboard-config"
 
 DESCRIPTION="X keyboard configuration database"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/XKeyboardConfig"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/XKeyboardConfig"
 [[ ${PV} == *9999* ]] || SRC_URI="${XORG_BASE_INDIVIDUAL_URI}/data/${PN}/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"

--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.16.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.16.ebuild
@@ -10,7 +10,7 @@ inherit xorg-2
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xkeyboard-config"
 
 DESCRIPTION="X keyboard configuration database"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/XKeyboardConfig"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/XKeyboardConfig"
 [[ ${PV} == *9999* ]] || SRC_URI="${XORG_BASE_INDIVIDUAL_URI}/data/${PN}/${P}.tar.bz2"
 
 KEYWORDS="~alpha amd64 arm hppa ~ia64 ~mips ppc ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"

--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.17.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.17.ebuild
@@ -10,7 +10,7 @@ inherit xorg-2
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xkeyboard-config"
 
 DESCRIPTION="X keyboard configuration database"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/XKeyboardConfig"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/XKeyboardConfig"
 [[ ${PV} == *9999* ]] || SRC_URI="${XORG_BASE_INDIVIDUAL_URI}/data/${PN}/${P}.tar.bz2"
 
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"

--- a/x11-misc/xrestop/xrestop-0.4.ebuild
+++ b/x11-misc/xrestop/xrestop-0.4.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit autotools eutils
 
 DESCRIPTION="'Top' like statistics of X11 client's server side resource usage"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/xrestop"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/xrestop"
 SRC_URI="http://projects.o-hand.com/sources/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-proto/xcb-proto/xcb-proto-1.10.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.10.ebuild
@@ -10,10 +10,10 @@ XORG_MULTILIB=yes
 inherit python-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings protocol headers"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/proto"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""

--- a/x11-proto/xcb-proto/xcb-proto-1.11.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.11.ebuild
@@ -10,10 +10,10 @@ XORG_MULTILIB=yes
 inherit python-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings protocol headers"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/proto"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""

--- a/x11-proto/xcb-proto/xcb-proto-1.8-r3.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.8-r3.ebuild
@@ -10,10 +10,10 @@ XORG_MULTILIB=yes
 inherit python-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings protocol headers"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/proto"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""

--- a/x11-proto/xcb-proto/xcb-proto-1.9-r1.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.9-r1.ebuild
@@ -10,10 +10,10 @@ XORG_MULTILIB=yes
 inherit python-r1 xorg-2
 
 DESCRIPTION="X C-language Bindings protocol headers"
-HOMEPAGE="http://xcb.freedesktop.org/"
+HOMEPAGE="https://xcb.freedesktop.org/"
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/xcb/proto"
 [[ ${PV} != 9999* ]] && \
-	SRC_URI="http://xcb.freedesktop.org/dist/${P}.tar.bz2"
+	SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""

--- a/x11-themes/gnome-icon-theme/gnome-icon-theme-3.12.0.ebuild
+++ b/x11-themes/gnome-icon-theme/gnome-icon-theme-3.12.0.ebuild
@@ -8,7 +8,7 @@ GCONF_DEBUG="no"
 inherit gnome2
 
 DESCRIPTION="GNOME default icon theme"
-HOMEPAGE="https://www.gnome.org/ http://people.freedesktop.org/~jimmac/icons/#git"
+HOMEPAGE="https://www.gnome.org/ https://people.freedesktop.org/~jimmac/icons/#git"
 
 SRC_URI="${SRC_URI}
 	branding? ( http://www.mail-archive.com/tango-artists@lists.freedesktop.org/msg00043/tango-gentoo-v1.1.tar.gz )"

--- a/x11-themes/hicolor-icon-theme/hicolor-icon-theme-0.15.ebuild
+++ b/x11-themes/hicolor-icon-theme/hicolor-icon-theme-0.15.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit gnome2-utils
 
 DESCRIPTION="Fallback theme for the freedesktop icon theme specification"
-HOMEPAGE="http://freedesktop.org/wiki/Software/icon-theme"
-SRC_URI="http://icon-theme.freedesktop.org/releases/${P}.tar.xz"
+HOMEPAGE="https://freedesktop.org/wiki/Software/icon-theme"
+SRC_URI="https://icon-theme.freedesktop.org/releases/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-themes/sound-theme-freedesktop/sound-theme-freedesktop-0.8.ebuild
+++ b/x11-themes/sound-theme-freedesktop/sound-theme-freedesktop-0.8.ebuild
@@ -5,8 +5,8 @@
 EAPI="5"
 
 DESCRIPTION="Default freedesktop.org sound theme following the XDG theming specification"
-HOMEPAGE="http://www.freedesktop.org/wiki/Specifications/sound-theme-spec"
-SRC_URI="http://people.freedesktop.org/~mccann/dist/${P}.tar.bz2"
+HOMEPAGE="https://www.freedesktop.org/wiki/Specifications/sound-theme-spec"
+SRC_URI="https://people.freedesktop.org/~mccann/dist/${P}.tar.bz2"
 
 LICENSE="GPL-2 LGPL-2 CC-BY-3.0 CC-BY-SA-2.0"
 SLOT="0"


### PR DESCRIPTION
* Excluding xorg.freedesktop.org
* Excluding tango.freedesktop.org

The following modified ebuilds were found to have problems after modification
but the problems were determined to not be a regression.

Upstream tarball has a new hash:
* app-misc/evtest-1.29
* app-misc/evtest-1.30
* dev-embedded/scratchbox2-2.0-r1
* dev-ml/cairo-ocaml-1.2.0
* net-libs/libqmi-1.0.0
* sys-auth/libfprint-0.4.0
* sys-auth/libfprint-0.5.0
* sys-auth/libfprint-0.5.1

Upstream tarball has been deleted:
* dev-libs/liblazy-0.2
* dev-util/pkgconfig-openbsd-20130507-r1
* x11-libs/xvba-video-0.8.0-r3
* x11-misc/driconf-0.9.1-r1
* x11-misc/xdg-utils-1.1.0_rc2-r1