### PR TITLE
Metadata fixes

### DIFF
--- a/app-admin/lastpass-cli/metadata.xml
+++ b/app-admin/lastpass-cli/metadata.xml
@@ -3,8 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>gokturk@binghamton.edu</email>
-		<name>Gokturk 'gokturk' Yuksek</name>
-		<description>Proxied maintainer; set to assignee in all bugs</description>
+		<name>Göktürk Yüksek</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-benchmarks/bonnie++/metadata.xml
+++ b/app-benchmarks/bonnie++/metadata.xml
@@ -4,17 +4,14 @@
 	<maintainer type="person">
 		<email>gokturk@binghamton.edu</email>
 		<name>Göktürk Yüksek</name>
-		<description>please assign bugs to</description>
 	</maintainer>
 	<maintainer type="person">
 		<email>bircoph@gentoo.org</email>
 		<name>Andrew Savchenko</name>
-		<description>please CC on bugs</description>
 	</maintainer>
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
-		<description>please CC on bugs</description>
 	</maintainer>
 	<longdescription>
 		Bonnie++ is based on the Bonnie hard drive benchmark by Tim Bray. This

--- a/app-benchmarks/filebench/metadata.xml
+++ b/app-benchmarks/filebench/metadata.xml
@@ -4,17 +4,14 @@
 	<maintainer type="person">
 		<email>gokturk@binghamton.edu</email>
 		<name>Göktürk Yüksek</name>
-		<description>please assign bugs to</description>
 	</maintainer>
 	<maintainer type="person">
 		<email>bircoph@gentoo.org</email>
 		<name>Andrew Savchenko</name>
-		<description>please CC on bugs</description>
 	</maintainer>
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
-		<description>please CC on bugs</description>
 	</maintainer>
 	<use>
 	  <flag name="auto-completion">

--- a/dev-libs/libaio/metadata.xml
+++ b/dev-libs/libaio/metadata.xml
@@ -3,8 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>gokturk@binghamton.edu</email>
-    <name>Gokturk Yuksek</name>
-    <description>Primary Maintainer, Assign bugs</description>
+    <name>Göktürk Yüksek</name>
   </maintainer>
   <maintainer type="project">
     <email>proxy-maint@gentoo.org</email>

--- a/dev-vcs/gitstats/metadata.xml
+++ b/dev-vcs/gitstats/metadata.xml
@@ -4,17 +4,14 @@
 	<maintainer type="person">
 		<email>gokturk@binghamton.edu</email>
 		<name>Göktürk Yüksek</name>
-		<description>Proxied Maintainer; assign all bugs to him</description>
 	</maintainer>
 	<maintainer type="person">
 		<email>amadio@gentoo.org</email>
 		<name>Guilherme Amadio</name>
-		<description>Proxy Maintainer; CC on all bugs</description>
 	</maintainer>
 	<maintainer type="person">
 		<email>NP-Hardass@gentoo.org</email>
 		<name>NP-Hardass</name>
-		<description>Proxy Maintainer; CC on all bugs</description>
 	</maintainer>
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>

--- a/net-fs/davfs2/metadata.xml
+++ b/net-fs/davfs2/metadata.xml
@@ -3,8 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>gokturk@binghamton.edu</email>
-		<name>Gokturk 'gokturk' Yuksek</name>
-		<description>Maintainer. Assign bugs on him</description>
+		<name>Göktürk Yüksek</name>
 	</maintainer>	
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>

--- a/sys-apps/rng-tools/metadata.xml
+++ b/sys-apps/rng-tools/metadata.xml
@@ -2,12 +2,11 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 <maintainer type="person">
-	<email>idella4@gentoo.org</email>
+	<email>gokturk@binghamton.edu</email>
+	<name>Göktürk Yüksek</name>
 </maintainer>
 <maintainer type="person">
-	<email>gokturk@binghamton.edu</email>
-	<name>Gokturk Yuksek</name>
-	<description>Proxy maintainer, CC him on bugs.</description>
+	<email>idella4@gentoo.org</email>
 </maintainer>
 <maintainer type="project">
 	<email>base-system@gentoo.org</email>

--- a/sys-fs/ext4magic/metadata.xml
+++ b/sys-fs/ext4magic/metadata.xml
@@ -3,13 +3,11 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>gokturk@binghamton.edu</email>
-		<name>Gokturk 'gokturk' Yuksek</name>
-		<description>Maintainer. Assign bugs on him</description>
+		<name>Göktürk Yüksek</name>
 	</maintainer>
 	<maintainer type="person">
 		<email>pinkbyte@gentoo.org</email>
 		<name>Sergey Popov</name>
-		<description>Proxy maintainer. CC him on bugs</description>
 	</maintainer>
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>


### PR DESCRIPTION
Since proxy-maint is following the bug-wranglers policy on deciding the bug assignee/CC, remove unnecessary <description> subtags from <maintainer> tags to simplify the metadata, and reorder maintainers to put the proxied maintainer on top where necessary. Also use consistent maintainer name across all the packages.