### PR TITLE
dev-games/aseprite: Correct patch for 1.1.4.1

### DIFF
--- a/dev-games/aseprite/aseprite-1.1.4.1.ebuild
+++ b/dev-games/aseprite/aseprite-1.1.4.1.ebuild
@@ -22,9 +22,9 @@ IUSE="debug test webp"
 RDEPEND="dev-libs/tinyxml
 	media-libs/allegro:0[X,png]
 	media-libs/freetype
-	media-libs/giflib
+	media-libs/giflib:=
 	webp? ( media-libs/libwebp )
-	media-libs/libpng:0
+	media-libs/libpng:0=
 	net-misc/curl
 	sys-libs/zlib
 	virtual/jpeg:0

--- a/dev-games/aseprite/files/aseprite-1.1.4.1_underlinking.patch
+++ b/dev-games/aseprite/files/aseprite-1.1.4.1_underlinking.patch
@@ -1,12 +1,28 @@
+From e7883b7d6428662077fa88c8dfa4e0fdee28ff46 Mon Sep 17 00:00:00 2001
+From: "Azamat H. Hackimov" <azamat.hackimov@gmail.com>
+Date: Fri, 22 Apr 2016 13:42:26 +0500
+Subject: [PATCH] Fixing underlinking for gcc 4.9
+
+Allegro4 backend uses XGrabPointer() from libX11.
+Added ${X11_LIBRARIES} for she to resolve underlinking.
+---
+ src/she/CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
 diff --git a/src/she/CMakeLists.txt b/src/she/CMakeLists.txt
-index eddf386..d1b8ce5 100644
+index cddf5bc..1841aa6 100644
 --- a/src/she/CMakeLists.txt
 +++ b/src/she/CMakeLists.txt
-@@ -205,6 +205,7 @@ endif()
- add_library(she ${SHE_SOURCES})
+@@ -242,7 +242,8 @@ if(USE_ALLEG4_BACKEND)
+   target_link_libraries(she
+     ${LOADPNG_LIBRARY}
+     ${LIBALLEGRO4_LINK_FLAGS}
+-    ${DXGUID_LIBRARIES})
++    ${DXGUID_LIBRARIES}
++    ${X11_LIBRARIES})
+ endif()
  
- target_link_libraries(she
-+  ${PLATFORM_LIBS}
-   gfx-lib
-   base-lib)
- 
+ if(USE_SKIA_BACKEND)
+-- 
+2.7.3
+


### PR DESCRIPTION
Fixes bug #580802. Added subslot checks for libpng and libgif.

Package-Manager: portage-2.2.26