### PR TITLE
dev-python/docopt: enable pypy build targets

### DIFF
--- a/dev-python/docopt/docopt-0.6.2-r1.ebuild
+++ b/dev-python/docopt/docopt-0.6.2-r1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
+PYTHON_COMPAT=( python2_7 python3_{3,4,5} pypy pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Notes:
- Tested via app-text/grip
- There is no bugs.gentoo.org issue related to this pull request