### PR TITLE
dev-libs/protobuf-c: Slot operator on dev-libs/protobuf atom added

### DIFF
--- a/dev-libs/protobuf-c/protobuf-c-1.0.2-r1.ebuild
+++ b/dev-libs/protobuf-c/protobuf-c-1.0.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -9,7 +9,7 @@ inherit autotools-multilib
 MY_PV=${PV/_/-}
 MY_P=${PN}-${MY_PV}
 
-DESCRIPTION="code generator and runtime libraries to use Protocol Buffers (protobuf) from pure C"
+DESCRIPTION="Protocol Buffers implementation in C"
 HOMEPAGE="https://github.com/protobuf-c/protobuf-c/"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${MY_PV}/${MY_P}.tar.gz"
 

--- a/dev-libs/protobuf-c/protobuf-c-1.1.1.ebuild
+++ b/dev-libs/protobuf-c/protobuf-c-1.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -9,7 +9,7 @@ inherit autotools-multilib
 MY_PV=${PV/_/-}
 MY_P=${PN}-${MY_PV}
 
-DESCRIPTION="code generator and runtime libraries to use Protocol Buffers (protobuf) from pure C"
+DESCRIPTION="Protocol Buffers implementation in C"
 HOMEPAGE="https://github.com/protobuf-c/protobuf-c/"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${MY_PV}/${MY_P}.tar.gz"
 

--- a/dev-libs/protobuf-c/protobuf-c-1.2.1-r1.ebuild
+++ b/dev-libs/protobuf-c/protobuf-c-1.2.1-r1.ebuild
@@ -14,11 +14,12 @@ HOMEPAGE="https://github.com/protobuf-c/protobuf-c/"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${MY_PV}/${MY_P}.tar.gz"
 
 LICENSE="BSD-2"
-SLOT="0"
+# Subslot == SONAME version
+SLOT="0/1.0.0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
 IUSE="static-libs test"
 
-RDEPEND=">=dev-libs/protobuf-2.6.0[${MULTILIB_USEDEP}]"
+RDEPEND=">=dev-libs/protobuf-2.6.0:0=[${MULTILIB_USEDEP}]"
 DEPEND="${RDEPEND}
 	test? ( ${AUTOTOOLS_DEPEND} )
 	virtual/pkgconfig[${MULTILIB_USEDEP}]"

--- a/dev-libs/protobuf-c/protobuf-c-1.2.1-r1.ebuild
+++ b/dev-libs/protobuf-c/protobuf-c-1.2.1-r1.ebuild
@@ -9,7 +9,7 @@ inherit autotools multilib-minimal
 MY_PV=${PV/_/-}
 MY_P=${PN}-${MY_PV}
 
-DESCRIPTION="code generator and runtime libraries to use Protocol Buffers (protobuf) from pure C"
+DESCRIPTION="Protocol Buffers implementation in C"
 HOMEPAGE="https://github.com/protobuf-c/protobuf-c/"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${MY_PV}/${MY_P}.tar.gz"
 


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=580872