### PR TITLE
kde-apps/kdecore-meta: Add khelpcenter to RDEPEND

### DIFF
--- a/kde-apps/kdecore-meta/kdecore-meta-15.12.3.ebuild
+++ b/kde-apps/kdecore-meta/kdecore-meta-15.12.3.ebuild
@@ -8,12 +8,13 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="kdecore - merge this to pull in the most basic applications"
 KEYWORDS=" ~amd64 ~x86"
-IUSE="minimal +wallpapers"
+IUSE="+handbook minimal +wallpapers"
 
 RDEPEND="
 	$(add_kdeapps_dep dolphin)
 	$(add_kdeapps_dep konsole)
 	$(add_kdeapps_dep kwrite)
+	handbook? ( $(add_kdeapps_dep khelpcenter '' 5.5.5-r1) )
 	wallpapers? ( $(add_kdeapps_dep kde-wallpapers '' 15.08.3) )
 	!minimal? ( $(add_kdeapps_dep kdebase-runtime-meta '' 15.08.3-r1) )
 "


### PR DESCRIPTION
Now that khelpcenter resides in kde-apps/, also depend on it from an
applications meta package. Helps portage resolve conflict for stable
users (and makes another revision for 15.12.3 stabilisation necessary).

@gentoo/kde 