### PR TITLE
mail-client/mailx: Fix compilation with musl (Bug #575098)

### DIFF
--- a/mail-client/mailx/files/mailx-8.1.2.20050715-musl.patch
+++ b/mail-client/mailx/files/mailx-8.1.2.20050715-musl.patch
@@ -1,0 +1,19 @@
+--- a/mailx-8.1.2-0.20050715cvs.orig/EXT/vis.h
++++ b/mailx-8.1.2-0.20050715cvs.orig/EXT/vis.h
+@@ -70,9 +70,6 @@
+  */
+ #define	UNVIS_END	1	/* no more characters */
+ 
+-#include <sys/cdefs.h>
+-
+-__BEGIN_DECLS
+ char	*vis(char *, int, int, int);
+ int	strvis(char *, const char *, int);
+ int	strnvis(char *, const char *, size_t, int)
+@@ -84,6 +81,4 @@ int	unvis(char *, char, int *, int);
+ ssize_t strnunvis(char *, const char *, size_t)
+ /*		__attribute__ ((__bounded__(__string__,1,3)))*/;
+ 
+-__END_DECLS
+-
+ #endif /* !_VIS_H_ */

--- a/mail-client/mailx/mailx-8.1.2.20050715-r7.ebuild
+++ b/mail-client/mailx/mailx-8.1.2.20050715-r7.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit eutils
+
+MX_MAJ_VER=${PV%.*}
+MX_MIN_VER=${PV##*.}
+MY_PV=${MX_MAJ_VER}-0.${MX_MIN_VER}cvs
+S=${WORKDIR}/${PN}-${MY_PV}.orig
+debian_patch=${PN}_${MY_PV}-1.diff.gz
+
+DESCRIPTION="The /bin/mail program, which is used to send mail via shell scripts"
+HOMEPAGE="http://www.debian.org/"
+SRC_URI="mirror://gentoo/mailx_${MY_PV}.orig.tar.gz
+	mirror://gentoo/${debian_patch}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos"
+IUSE=""
+
+DEPEND=">=net-libs/liblockfile-1.03
+	virtual/mta
+	mail-client/mailx-support"
+
+RDEPEND="${DEPEND}
+	!mail-client/nail
+	!net-mail/mailutils"
+
+src_prepare() {
+	epatch "${DISTDIR}/${debian_patch}"
+	epatch "${FILESDIR}/${P}-musl.patch"
+	epatch "${FILESDIR}/${P}-nostrip.patch"
+	sed -i -e "s: -O2: \$(EXTRAFLAGS):g" Makefile || die
+	epatch "${FILESDIR}/${P}-offsetof.patch"
+	eapply_user
+}
+
+src_compile() {
+	emake CC=$(tc-getCC) EXTRAFLAGS="${CFLAGS}"
+}
+
+src_install() {
+	dobin mail
+
+	doman mail.1
+
+	dosym mail /usr/bin/Mail
+	dosym mail /usr/bin/mailx
+	dosym mail.1 /usr/share/man/man1/Mail.1
+
+	insinto /usr/share/mailx/
+	doins misc/mail.help misc/mail.tildehelp
+	insinto /etc
+	doins misc/mail.rc
+
+	# compatibility link
+	dosym /usr/bin/mail /bin/mail
+}
+
+pkg_postinst() {
+	elog "mail command now lives in /usr/bin."
+	elog "Please adjust your scripts."
+}


### PR DESCRIPTION
Maybe the elog message and compatibility symlink can also be removed now after 4 years.