### PR TITLE
net-analyzer/pnp4nagios: EAPI=6, support >=rrdtool-1.6.0

### DIFF
--- a/net-analyzer/pnp4nagios/files/pnp4nagios-0.6.25-rrdtool-0.6.0-support.patch
+++ b/net-analyzer/pnp4nagios/files/pnp4nagios-0.6.25-rrdtool-0.6.0-support.patch
@@ -1,0 +1,93 @@
+From 0a539e1c7ab03ec015c27e4ad0fe16343a98c269 Mon Sep 17 00:00:00 2001
+From: Louis Sautier <sautier.louis@gmail.com>
+Date: Mon, 25 Apr 2016 12:31:49 +0200
+Subject: [PATCH] Use complete option arguments for compatibility with rrdtool
+ 1.6.0
+
+Since rrdtool switched to optparse, it seems that complete option
+arguments must be used:
+https://github.com/oetiker/rrdtool-1.x/commit/83530d3e43cebc32da157733d35c60bf4bb098da
+---
+ share/pnp/templates.dist/check_dns.php       | 2 +-
+ share/pnp/templates.dist/check_multi.php     | 2 +-
+ share/pnp/templates.dist/check_ping_tick.php | 2 +-
+ share/pnp/templates.dist/check_users.php     | 2 +-
+ share/pnp/templates.dist/default.php         | 6 +++---
+ 5 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/share/pnp/templates.dist/check_dns.php b/share/pnp/templates.dist/check_dns.php
+index b8ab048..dad209a 100644
+--- a/share/pnp/templates.dist/check_dns.php
++++ b/share/pnp/templates.dist/check_dns.php
+@@ -4,7 +4,7 @@
+ # Template for check_dns
+ #
+ 
+-$opt[1] = "--lower=$MIN[1] --vertical-label $UNIT[1]  --title \"DNS Response Time\" ";
++$opt[1] = "--lower-limit=$MIN[1] --vertical-label $UNIT[1]  --title \"DNS Response Time\" ";
+ 
+ 
+ $def[1] =  "DEF:var1=$RRDFILE[1]:$DS[1]:AVERAGE " ;
+diff --git a/share/pnp/templates.dist/check_multi.php b/share/pnp/templates.dist/check_multi.php
+index ba6bcd1..cd0794a 100644
+--- a/share/pnp/templates.dist/check_multi.php
++++ b/share/pnp/templates.dist/check_multi.php
+@@ -4,7 +4,7 @@
+ # Template for check_multi
+ # 
+ 
+-$opt[1] = "--lower=$MIN[1] --vertical-label num  --title \"Number of Checks\" ";
++$opt[1] = "--lower-limit=$MIN[1] --vertical-label num  --title \"Number of Checks\" ";
+ $ds_name[1] = "Executed Plugins";
+ 
+ $def[1] =  "DEF:var1=$RRDFILE[1]:$DS[1]:AVERAGE " ;
+diff --git a/share/pnp/templates.dist/check_ping_tick.php b/share/pnp/templates.dist/check_ping_tick.php
+index 865479f..f191049 100644
+--- a/share/pnp/templates.dist/check_ping_tick.php
++++ b/share/pnp/templates.dist/check_ping_tick.php
+@@ -6,7 +6,7 @@
+ # RTA
+ #
+ $ds_name[1] = "Round Trip Times";
+-$opt[1]  = "--lower=0 --vertical-label \"RTA\" --title \"Ping times\" ";
++$opt[1]  = "--lower-limit=0 --vertical-label \"RTA\" --title \"Ping times\" ";
+ $opt[1] .=  rrd::darkteint();
+ $def[1]  =  rrd::def("var1", $RRDFILE[1], $DS[1], "AVERAGE") ;
+ $def[1] .=  rrd::ticker("var1", $WARN[1], $CRIT[1]) ;
+diff --git a/share/pnp/templates.dist/check_users.php b/share/pnp/templates.dist/check_users.php
+index 9fe878d..c66fc01 100644
+--- a/share/pnp/templates.dist/check_users.php
++++ b/share/pnp/templates.dist/check_users.php
+@@ -4,7 +4,7 @@
+ # Template for check_users
+ #
+ 
+-$opt[1] = "--lower=$MIN[1] --vertical-label \"Users\"  --title \"Users\" ";
++$opt[1] = "--lower-limit=$MIN[1] --vertical-label \"Users\"  --title \"Users\" ";
+ 
+ 
+ $def[1] =  "DEF:var1=$RRDFILE[1]:$DS[1]:MAX " ;
+diff --git a/share/pnp/templates.dist/default.php b/share/pnp/templates.dist/default.php
+index 6fdf38c..823ee6a 100644
+--- a/share/pnp/templates.dist/default.php
++++ b/share/pnp/templates.dist/default.php
+@@ -47,7 +47,7 @@
+ 		$crit_min = $VAL['CRIT_MIN'];
+ 	}
+ 	if ( $VAL['MIN'] != "" && is_numeric($VAL['MIN']) ) {
+-		$lower = " --lower=" . $VAL['MIN'];
++		$lower = " --lower-limit=" . $VAL['MIN'];
+ 		$minimum = $VAL['MIN'];
+ 	}
+ 	if ( $VAL['MAX'] != "" && is_numeric($VAL['MAX']) ) {
+@@ -55,8 +55,8 @@
+ 	}
+ 	if ($VAL['UNIT'] == "%%") {
+ 		$vlabel = "%";
+-		$upper = " --upper=101 ";
+-		$lower = " --lower=0 ";
++		$upper = " --upper-limit=101 ";
++		$lower = " --lower-limit=0 ";
+ 	}
+ 	else {
+ 		$vlabel = $VAL['UNIT'];

--- a/net-analyzer/pnp4nagios/pnp4nagios-0.6.25-r3.ebuild
+++ b/net-analyzer/pnp4nagios/pnp4nagios-0.6.25-r3.ebuild
@@ -1,0 +1,110 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit depend.apache eutils
+
+DESCRIPTION="A performance data analyzer for nagios"
+HOMEPAGE="http://www.pnp4nagios.org/"
+SRC_URI="mirror://sourceforge/${PN}/PNP-0.6/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+# A lot of things (sync mode, for one) are broken with nagios-4.x.
+DEPEND="
+	dev-lang/php:*[filter,gd,json,simplexml,xml,zlib]
+	>=net-analyzer/rrdtool-1.2[graph,perl]
+	|| ( <net-analyzer/nagios-core-4 net-analyzer/icinga net-analyzer/icinga2 )"
+
+# A list of modules used in our Apache config file.
+APACHE_MODS="apache2_modules_alias,"       # "Alias" directive
+APACHE_MODS+="apache2_modules_authz_core," # "Require" directive
+APACHE_MODS+="apache2_modules_rewrite"     # "RewriteEngine" and friends
+
+RDEPEND="${DEPEND}
+	virtual/perl-Getopt-Long
+	virtual/perl-Time-HiRes
+	media-fonts/dejavu
+	apache2? ( >=www-servers/apache-2.4[${APACHE_MODS}] )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.6.14-makefile.patch"
+	"${FILESDIR}/${P}-rrdtool-0.6.0-support.patch"
+)
+
+# There is no want_apache2_4, but we needed to specify that manually
+# anyway to be able to include the list of modules.
+want_apache2
+
+pkg_setup() {
+	depend.apache_pkg_setup
+}
+
+src_configure() {
+	local var_dir=
+	local user_group=
+
+	if has_version net-analyzer/nagios-core; then
+		var_dir=/var/nagios/
+		user_group=nagios
+	elif has_version net-analyzer/icinga2; then
+		var_dir=/var/lib/icinga2/
+		user_group=icinga
+	else
+		var_dir=/var/lib/icinga/
+		user_group=icinga
+	fi
+
+	econf \
+		--sysconfdir=/etc/pnp \
+		--datarootdir=/usr/share/pnp \
+		--mandir=/usr/share/man \
+		--with-perfdata-dir=${var_dir}/perfdata \
+		--with-nagios-user=${user_group} \
+		--with-nagios-group=${user_group} \
+		--with-perfdata-logfile=${var_dir}/perfdata.log \
+		--with-perfdata-spool-dir=/var/spool/pnp
+}
+
+src_compile() {
+	# The default target just shows a help
+	emake all
+}
+
+src_install() {
+	emake DESTDIR="${D}" install install-config
+	newinitd "${FILESDIR}"/npcd.initd npcd
+	rm "${D}/usr/share/pnp/install.php" || \
+		die "unable to remove ${D}/usr/share/pnp/install.php"
+
+	if use apache2 ; then
+		insinto "${APACHE_MODULES_CONFDIR}"
+		newins "${FILESDIR}"/98_pnp4nagios-2.4.conf 98_pnp4nagios.conf
+
+		# Allow the apache user to read our config files. This same
+		# approach is used in net-analyzer/nagios-core.
+		chgrp -R apache "${D}/etc/pnp" \
+			|| die "failed to change group of ${ROOT}etc/pnp"
+	fi
+
+	# Bug 430358 - CVE-2012-3457
+	find "${D}/etc/pnp" -type f -exec chmod 0640 '{}' + || \
+		die "unable to set file permissions under ${D}/etc/pnp"
+
+	find "${D}/etc/pnp" -type d -exec chmod 0750 '{}' + || \
+		die "unable to set directory permissions under ${D}/etc/pnp"
+}
+
+pkg_postinst() {
+	elog "To enable the pnp4nagios web front-end, please visit"
+	elog "${ROOT}etc/conf.d/apache2 and add \"-D PNP -D PHP5\""
+	elog "to APACHE2_OPTS. Then pnp4nagios will be available at,"
+	elog
+	elog "  http://localhost/pnp4nagios"
+	elog
+}


### PR DESCRIPTION
@prometheanfire I committed straight to stable as the changes are very minor (using the right argument name).
I also bumped to EAPI=6, I didn't see anything that could be banned/deprecated but you should probably take a look in case i missed something.