### PR TITLE
app-portage/elogviewer-2.6: update

### DIFF
--- a/app-portage/elogviewer/elogviewer-2.6-r2.ebuild
+++ b/app-portage/elogviewer/elogviewer-2.6-r2.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+PYTHON_COMPAT=(python{2_7,3_3,3_4})
+DISABLE_AUTOFORMATTING=true
+inherit distutils-r1 eutils readme.gentoo
+
+DESCRIPTION="Elog viewer for Gentoo"
+HOMEPAGE="https://sourceforge.net/projects/elogviewer"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~x86-fbsd"
+IUSE=""
+
+RDEPEND="|| (
+		dev-python/PyQt5[gui,widgets,${PYTHON_USEDEP}]
+		dev-python/PyQt4[${PYTHON_USEDEP},X]
+		dev-python/pyside[${PYTHON_USEDEP},X] )
+	>=sys-apps/portage-2.1
+	$(python_gen_cond_dep 'dev-python/enum34[${PYTHON_USEDEP}]' python{2_7,3_3})
+	!dev-python/PyQt5[-gui]
+	!dev-python/PyQt5[-widgets]
+	"
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]"
+
+DOC_CONTENTS="In order to use this software, you need to activate
+Portage's elog features.  Required is
+	PORTAGE_ELOG_SYSTEM=\"save\"
+and at least one of
+	PORTAGE_ELOG_CLASSES=\"warn error info log qa\"
+More information on the elog system can be found in /etc/make.conf.example
+
+To operate properly this software needs the directory
+${PORT_LOGDIR:-/var/log/portage}/elog created, belonging to group portage.
+To start the software as a user, add yourself to the portage group."
+
+src_install() {
+	mv elogviewer.py elogviewer
+	dobin elogviewer
+	doman elogviewer.1
+	make_desktop_entry ${PN} ${PN} ${PN} System
+	readme.gentoo_src_install
+}

--- a/app-portage/elogviewer/elogviewer-2.6-r2.ebuild
+++ b/app-portage/elogviewer/elogviewer-2.6-r2.ebuild
@@ -2,10 +2,13 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
-PYTHON_COMPAT=(python{2_7,3_3,3_4})
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_{3,4}} )
+
 DISABLE_AUTOFORMATTING=true
-inherit distutils-r1 eutils readme.gentoo
+
+inherit python-single-r1 eutils readme.gentoo-r1
 
 DESCRIPTION="Elog viewer for Gentoo"
 HOMEPAGE="https://sourceforge.net/projects/elogviewer"
@@ -16,15 +19,17 @@ SLOT="0"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~x86-fbsd"
 IUSE=""
 
-RDEPEND="|| (
+RDEPEND="
+	|| (
 		dev-python/PyQt5[gui,widgets,${PYTHON_USEDEP}]
 		dev-python/PyQt4[${PYTHON_USEDEP},X]
-		dev-python/pyside[${PYTHON_USEDEP},X] )
+		dev-python/pyside[${PYTHON_USEDEP},X]
+	)
 	>=sys-apps/portage-2.1
 	$(python_gen_cond_dep 'dev-python/enum34[${PYTHON_USEDEP}]' python{2_7,3_3})
 	!dev-python/PyQt5[-gui]
 	!dev-python/PyQt5[-widgets]
-	"
+"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]"
 
@@ -40,9 +45,14 @@ ${PORT_LOGDIR:-/var/log/portage}/elog created, belonging to group portage.
 To start the software as a user, add yourself to the portage group."
 
 src_install() {
-	mv elogviewer.py elogviewer
-	dobin elogviewer
-	doman elogviewer.1
+	python_newscript elogviewer.py elogviewer
+
 	make_desktop_entry ${PN} ${PN} ${PN} System
-	readme.gentoo_src_install
+
+	doman elogviewer.1
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
 }


### PR DESCRIPTION
- EAPI6
- readme.gentoo -> readme.gentoo-r1
- distutils-r1 -> python-single-r1
- proper src_install()
- minor fixes

Other things worth consideration:
- drop 2.1-r*
- drop 2.6
- drop sparc and x86-fbsd ARCHs

@fuzzyray @dol-sen 