### PR TITLE
x11-misc/xystray: Fix the Makefile patch to support gcc-5

### DIFF
--- a/x11-misc/xystray/files/xystray-1.0-ldflags.patch
+++ b/x11-misc/xystray/files/xystray-1.0-ldflags.patch
@@ -5,7 +5,7 @@
 +LIBS=-lX11 -lXt  -L/usr/X11/lib
  xystray: Xystray.o xystray.o
 -	$(CC) $(LDFLAGS) $^ -o $@
-+	$(CC) $(LDFLAGS) $(LIBS) $^ -o $@
++	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
  
  clean:
  	rm Xystray.o xystray.o


### PR DESCRIPTION
As reported in Gentoo bug #581192, the original Makefile patch caused linking errors when gcc-5 was used. This time $LIBS is at the end of linker arguments, which has been confirmed to fix the problem.
