### PR TITLE
www-client/firefox: specify SHELL on initial emake command in src_con…

### DIFF
--- a/www-client/firefox/firefox-46.0.ebuild
+++ b/www-client/firefox/firefox-46.0.ebuild
@@ -218,6 +218,7 @@ src_configure() {
 	fi
 
 	# workaround for funky/broken upstream configure...
+	SHELL="${SHELL:-${EPREFIX%/}/bin/bash}" \
 	emake -f client.mk configure
 }
 


### PR DESCRIPTION
…figure

Bug: http://bugs.gentoo.org/577776
Otherwise this doesn't build with dash as default shell. 