### PR TITLE
dev-python/pytest-xdist: fix depend on dev-python/setuptools_scm

### DIFF
--- a/dev-python/pytest-xdist/pytest-xdist-1.14-r1.ebuild
+++ b/dev-python/pytest-xdist/pytest-xdist-1.14-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 python3_{3,4,5} pypy pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="Distributed testing and loop-on-failing modes"
+HOMEPAGE="https://pypi.python.org/pypi/pytest-xdist https://github.com/pytest-dev/pytest-xdist2"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.zip"
+
+SLOT="0"
+LICENSE="MIT"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE=""
+
+RDEPEND="
+	>=dev-python/execnet-1.1[${PYTHON_USEDEP}]
+	>=dev-python/pytest-2.4.2[${PYTHON_USEDEP}]
+	>=dev-python/py-1.4.22[${PYTHON_USEDEP}]
+"
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/setuptools_scm[${PYTHON_USEDEP}]
+"
+
+python_test() {
+	find -name __pycache__ -exec rm -r '{}' + || die
+	py.test -vv -x || die
+}


### PR DESCRIPTION
the [`setup.py`](https://github.com/pytest-dev/pytest-xdist/blob/eee72557f7e992f8c331363b31f38a74d9d98f11/setup.py#L24) require `dev-python/setuptools_scm` and not simply `dev-python/setuptools` (which was a silent failure as pip would download it, but in my case, fail because of `FEATURES='network-sandbox'`).

I revbump to `-r1` also.
