### PR TITLE
x11-misc/synergy: install libns.so for SSL encryption

### DIFF
--- a/x11-misc/synergy/synergy-1.7.5-r2.ebuild
+++ b/x11-misc/synergy/synergy-1.7.5-r2.ebuild
@@ -91,6 +91,8 @@ src_test() {
 
 src_install () {
 	dobin bin/${PN}{c,s} bin/syntool
+	insinto /usr/$(get_libdir)/${PN}
+	doins bin/plugins/libns.so
 
 	if use qt4 ; then
 		newbin bin/${PN} qsynergy
@@ -113,6 +115,10 @@ pkg_preinst() {
 
 pkg_postinst() {
 	use qt4 && gnome2_icon_cache_update
+	einfo
+	einfo "To enable encryption for Pro users, link or copy"
+	einfo "/usr/$(get_libdir)/${PN}/libns.so to ~/.synergy/plugins/libns.so"
+	einfo
 }
 
 pkg_postrm() {

--- a/x11-misc/synergy/synergy-1.7.6-r1.ebuild
+++ b/x11-misc/synergy/synergy-1.7.6-r1.ebuild
@@ -91,6 +91,8 @@ src_test() {
 
 src_install () {
 	dobin bin/${PN}{c,s} bin/syntool
+	insinto /usr/$(get_libdir)/${PN}
+	doins bin/plugins/libns.so
 
 	if use qt4 ; then
 		newbin bin/${PN} qsynergy
@@ -113,6 +115,10 @@ pkg_preinst() {
 
 pkg_postinst() {
 	use qt4 && gnome2_icon_cache_update
+	einfo
+	einfo "To enable encryption for Pro users, link or copy"
+	einfo "/usr/$(get_libdir)/${PN}/libns.so to ~/.synergy/plugins/libns.so"
+	einfo
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Since version 1.7, synergy use their own plugin(libns.so) to enable encryption for Pro users. If libns.so is missing, synergy will download from its server, but the downloaded library is linked against libssl.so.10, which does not exist on my system.

I've tested my changes and encryption works.

ref: https://wiki.archlinux.org/index.php/synergy#Enable_Encryption

@gentoo/proxy-maint

Package-Manager: portage-2.2.26