### PR TITLE
www-servers/nginx: Fix typo for using stream upstream module

### DIFF
--- a/www-servers/nginx/nginx-1.10.0.ebuild
+++ b/www-servers/nginx/nginx-1.10.0.ebuild
@@ -526,7 +526,7 @@ src_configure() {
 				myconf+=( --without-stream_upstream_least_conn_module )
 				myconf+=( --without-stream_upstream_zone_module )
 			else
-				myconf+=( --without-stream_${stream}_module )
+				myconf+=( --without-stream_${mod}_module )
 			fi
 		fi
 	done


### PR DESCRIPTION
@gentoo/proxy-maint