### PR TITLE
sci-misc/boinc: Fix VSYSCALL check

### DIFF
--- a/sci-misc/boinc/boinc-7.2.42-r2.ebuild
+++ b/sci-misc/boinc/boinc-7.2.42-r2.ebuild
@@ -50,32 +50,24 @@ DEPEND="${RDEPEND}
 S="${WORKDIR}/${PN}-client_release-${MY_PV}-${PV}"
 
 pkg_setup() {
+	# Bug 578750
 	if use kernel_linux; then
 		linux-info_pkg_setup
 		if ! linux_config_exists; then
 			ewarn "Can't check the linux kernel configuration."
 			ewarn "You might be missing vsyscall support."
-		else
-			if   kernel_is -ge 4 4 \
-			  && linux_chkconfig_present LEGACY_VSYSCALL_NONE \
-			  && ! linux_chkconfig_present X86_VSYSCALL_EMULATION; then
-				ewarn "You do have neither x86 vsyscall emulation"
-				ewarn "nor legacy vsyscall support enabled."
-				ewarn "This will prevent some boinc projects from running."
-				ewarn "Please enable vsyscall emulation:"
-				ewarn "    CONFIG_X86_VSYSCALL_EMULATION=y"
-				ewarn "in /usr/src/linux/.config, to be found at"
-				ewarn "    Processor type and features --->"
-				ewarn "        [*] Enable vsyscall emulation"
-				ewarn "or set"
-				ewarn "    CONFIG_LEGACY_VSYSCALL_EMULATE=y"
-				ewarn "in /usr/src/linux/.config, to be found at"
-				ewarn "    Processor type and features --->"
-				ewarn "        vsyscall table for legacy applications (None) --->"
-				ewarn "            (X) Emulate"
-				ewarn "Alternatively, you can enable CONFIG_LEGACY_VSYSCALL_NATIVE."
-				ewarn "However, this has security implications and is not recommended."
-			fi
+		elif   kernel_is -ge 4 4 \
+		    && linux_chkconfig_present LEGACY_VSYSCALL_NONE; then
+			ewarn "You do not have vsyscall emulation enabled."
+			ewarn "This will prevent some boinc projects from running."
+			ewarn "Please enable vsyscall emulation:"
+			ewarn "    CONFIG_LEGACY_VSYSCALL_EMULATE=y"
+			ewarn "in /usr/src/linux/.config, to be found at"
+			ewarn "    Processor type and features --->"
+			ewarn "        vsyscall table for legacy applications (None) --->"
+			ewarn "            (X) Emulate"
+			ewarn "Alternatively, you can enable CONFIG_LEGACY_VSYSCALL_NATIVE."
+			ewarn "However, this has security implications and is not recommended."
 		fi
 	fi
 }

--- a/sci-misc/boinc/boinc-7.4.42-r4.ebuild
+++ b/sci-misc/boinc/boinc-7.4.42-r4.ebuild
@@ -50,32 +50,24 @@ DEPEND="${RDEPEND}
 S="${WORKDIR}/${PN}-client_release-${MY_PV}-${PV}"
 
 pkg_setup() {
+	# Bug 578750
 	if use kernel_linux; then
 		linux-info_pkg_setup
 		if ! linux_config_exists; then
 			ewarn "Can't check the linux kernel configuration."
 			ewarn "You might be missing vsyscall support."
-		else
-			if   kernel_is -ge 4 4 \
-			  && linux_chkconfig_present LEGACY_VSYSCALL_NONE \
-			  && ! linux_chkconfig_present X86_VSYSCALL_EMULATION; then
-				ewarn "You do have neither x86 vsyscall emulation"
-				ewarn "nor legacy vsyscall support enabled."
-				ewarn "This will prevent some boinc projects from running."
-				ewarn "Please enable vsyscall emulation:"
-				ewarn "    CONFIG_X86_VSYSCALL_EMULATION=y"
-				ewarn "in /usr/src/linux/.config, to be found at"
-				ewarn "    Processor type and features --->"
-				ewarn "        [*] Enable vsyscall emulation"
-				ewarn "or set"
-				ewarn "    CONFIG_LEGACY_VSYSCALL_EMULATE=y"
-				ewarn "in /usr/src/linux/.config, to be found at"
-				ewarn "    Processor type and features --->"
-				ewarn "        vsyscall table for legacy applications (None) --->"
-				ewarn "            (X) Emulate"
-				ewarn "Alternatively, you can enable CONFIG_LEGACY_VSYSCALL_NATIVE."
-				ewarn "However, this has security implications and is not recommended."
-			fi
+		elif   kernel_is -ge 4 4 \
+		    && linux_chkconfig_present LEGACY_VSYSCALL_NONE; then
+			ewarn "You do not have vsyscall emulation enabled."
+			ewarn "This will prevent some boinc projects from running."
+			ewarn "Please enable vsyscall emulation:"
+			ewarn "    CONFIG_LEGACY_VSYSCALL_EMULATE=y"
+			ewarn "in /usr/src/linux/.config, to be found at"
+			ewarn "    Processor type and features --->"
+			ewarn "        vsyscall table for legacy applications (None) --->"
+			ewarn "            (X) Emulate"
+			ewarn "Alternatively, you can enable CONFIG_LEGACY_VSYSCALL_NATIVE."
+			ewarn "However, this has security implications and is not recommended."
 		fi
 	fi
 }

--- a/sci-misc/boinc/boinc-7.6.31-r3.ebuild
+++ b/sci-misc/boinc/boinc-7.6.31-r3.ebuild
@@ -50,32 +50,24 @@ DEPEND="${RDEPEND}
 S="${WORKDIR}/${PN}-client_release-${MY_PV}-${PV}"
 
 pkg_setup() {
+	# Bug 578750
 	if use kernel_linux; then
 		linux-info_pkg_setup
 		if ! linux_config_exists; then
 			ewarn "Can't check the linux kernel configuration."
 			ewarn "You might be missing vsyscall support."
-		else
-			if   kernel_is -ge 4 4 \
-			  && linux_chkconfig_present LEGACY_VSYSCALL_NONE \
-			  && ! linux_chkconfig_present X86_VSYSCALL_EMULATION; then
-				ewarn "You do have neither x86 vsyscall emulation"
-				ewarn "nor legacy vsyscall support enabled."
-				ewarn "This will prevent some boinc projects from running."
-				ewarn "Please enable vsyscall emulation:"
-				ewarn "    CONFIG_X86_VSYSCALL_EMULATION=y"
-				ewarn "in /usr/src/linux/.config, to be found at"
-				ewarn "    Processor type and features --->"
-				ewarn "        [*] Enable vsyscall emulation"
-				ewarn "or set"
-				ewarn "    CONFIG_LEGACY_VSYSCALL_EMULATE=y"
-				ewarn "in /usr/src/linux/.config, to be found at"
-				ewarn "    Processor type and features --->"
-				ewarn "        vsyscall table for legacy applications (None) --->"
-				ewarn "            (X) Emulate"
-				ewarn "Alternatively, you can enable CONFIG_LEGACY_VSYSCALL_NATIVE."
-				ewarn "However, this has security implications and is not recommended."
-			fi
+		elif   kernel_is -ge 4 4 \
+		    && linux_chkconfig_present LEGACY_VSYSCALL_NONE; then
+			ewarn "You do not have vsyscall emulation enabled."
+			ewarn "This will prevent some boinc projects from running."
+			ewarn "Please enable vsyscall emulation:"
+			ewarn "    CONFIG_LEGACY_VSYSCALL_EMULATE=y"
+			ewarn "in /usr/src/linux/.config, to be found at"
+			ewarn "    Processor type and features --->"
+			ewarn "        vsyscall table for legacy applications (None) --->"
+			ewarn "            (X) Emulate"
+			ewarn "Alternatively, you can enable CONFIG_LEGACY_VSYSCALL_NATIVE."
+			ewarn "However, this has security implications and is not recommended."
 		fi
 	fi
 }


### PR DESCRIPTION
Gentoo-Bug: 578750

The configuration options were misunderstood.

- CONFIG_X86_VSYSCALL_EMULATION only enables a dmesg message if any legacy application tries to use any vsyscall. If disabled, these applications simply segfault with no output in dmesg.
- To make the old calls available, either CONFIG_LEGACY_VSYSCALL_NATIVE or CONFIG_LEGACY_VSYSCALL_EMULATE must be used.

Therefore the ebuild was reverted to check against the CONFIG_LEGACY_VSYSCALL_NONE option, and warns the user if this is set.

Package-Manager: portage-2.2.28

@SoapGentoo @jlec I was not sure if the one-commit-per-ebuild-policy applies to such a case were all fixes are the same.