### PR TITLE
flag-o-matic.eclass: a complete rewrite of get-flag()

### DIFF
--- a/eclass/flag-o-matic.eclass
+++ b/eclass/flag-o-matic.eclass
@@ -534,22 +534,41 @@ strip-unsupported-flags() {
 # @USAGE: <flag>
 # @DESCRIPTION:
 # Find and echo the value for a particular flag.  Accepts shell globs.
+#
+# Example:
+# @CODE
+# CFLAGS="-march=i686 -O1"
+# get-flag -march # outputs "-march=i686"
+# get-flag march  # outputs "i686"
+# get-flag '-O*'  # outputs "-O1"
+# @CODE
 get-flag() {
-	local f var findflag="$1"
+	local var pattern="${1}"
+	# ensure ${needle} starts with a single dash
+	local needle="-${pattern#-}"
 
-	# this code looks a little flaky but seems to work for
-	# everything we want ...
-	# for example, if CFLAGS="-march=i686":
-	# `get-flag -march` == "-march=i686"
-	# `get-flag march` == "i686"
 	for var in $(all-flag-vars) ; do
-		for f in ${!var} ; do
-			if [ "${f/${findflag}}" != "${f}" ] ; then
-				printf "%s\n" "${f/-${findflag}=}"
+		local i flags=( ${!var} )
+
+		# reverse loop because last flag wins
+		for (( i = ${#flags[@]} - 1 ; i >= 0 ; i-- )) ; do
+			local flag="${flags[i]}"
+			# strip value as it's not needed for comparison
+			local haystack="${flag%%=*}"
+
+			# as long as ${needle} remains unquoted, wildcards will work
+			if [[ "${haystack}" == ${needle} ]] ; then
+				# preserve only value if only flag name was provided
+				local ret="${flag#-${pattern}=}"
+
+				# ${ret} might contain `-e` or `-n` which confuses echo
+				printf '%s\n' "${ret}"
+
 				return 0
 			fi
 		done
 	done
+
 	return 1
 }
 

--- a/eclass/tests/flag-o-matic.sh
+++ b/eclass/tests/flag-o-matic.sh
@@ -146,4 +146,74 @@ out=$(CC=clang test-flags-CC -finline-limit=1200)
 ftend
 fi
 
+clear-env() {
+	unset $(all-flag-vars)
+}
+
+fom-tbegin() {
+	clear-env
+	tbegin "${@}"
+}
+
+fom-run() {
+	out="$("$@")"
+	ret=${?}
+}
+
+fom-tend() {
+	local ret="${1:-"${?}"}" msg="${2:-"ret='${ret}' out='${out}'"}"
+	shift 2
+	tend ${ret} "${msg}" "${@}"
+	clear-env
+}
+
+fom-tbegin "get-flag() - match first from the end"
+CFLAGS='-O1 -O2'
+fom-run get-flag '-O*'
+[[ ${ret} == 0 && ${out} == '-O2' ]]
+fom-tend
+
+fom-tbegin "get-flag() - don't match substrings"
+CFLAGS='-W1,-O1'
+fom-run get-flag '-O*'
+[[ ${ret} != 0 ]]
+fom-tend
+
+fom-tbegin "get-flag() - check full string comparison"
+CFLAGS='-ggdb'
+fom-run get-flag '-g'
+[[ ${ret} != 0 ]]
+fom-tend
+
+fom-tbegin "get-flag() - return all"
+CFLAGS='-march=native'
+fom-run get-flag '-march'
+[[ ${ret} == 0 && ${out} == '-march=native' ]]
+fom-tend
+
+fom-tbegin "get-flag() - return value only"
+CFLAGS='-march=native'
+fom-run get-flag 'march'
+[[ ${ret} == 0 && ${out} == 'native' ]]
+fom-tend
+
+fom-tbegin "get-flag() - echo -e"
+CFLAGS='-n -e'
+fom-run get-flag '-e'
+[[ ${ret} == 0 && ${out} == '-e' ]]
+fom-tend
+
+fom-tbegin "get-flag() - echo -n"
+CFLAGS='-e -n'
+fom-run get-flag '-n'
+[[ ${ret} == 0 && ${out} == '-n' ]]
+fom-tend
+
+fom-tbegin "filter-mfpmath() - example"
+CFLAGS='-mfpmath=sse,386'
+filter-mfpmath 'sse'
+fom-run get-flag '-mfpmath'
+[[ ${ret} == 0 && ${out} == '-mfpmath=386' ]]
+fom-tend
+
 texit


### PR DESCRIPTION
- fix case:
  - `CFLAGS='-O1 -O2'`
  - `get-flag '-O*'`
  - before `-O1`
  - now `-O2`
- fix case:
  - `CFLAGS='-W1,-O1'`
  - `get-flag '-O*'`
  - before `-W1,O1`
  - now return 1

`get-flag march` == "i686" syntax still works.