### PR TITLE
sys-devel/llvm: remove CppBackend from 9999

### DIFF
--- a/sys-devel/llvm/llvm-9999.ebuild
+++ b/sys-devel/llvm/llvm-9999.ebuild
@@ -213,7 +213,7 @@ multilib_src_configure() {
 	if use multitarget; then
 		targets=all
 	else
-		targets='host;BPF;CppBackend'
+		targets='host;BPF'
 		use video_cards_radeon && targets+=';AMDGPU'
 	fi
 


### PR DESCRIPTION
Removed from LLVM SVN in r268631

Signed-off-by: Nick Sarnie <commendsarnex@gmail.com>