### PR TITLE
sys-apps/hdparm:

### DIFF
--- a/sys-apps/hdparm/hdparm-9.48.ebuild
+++ b/sys-apps/hdparm/hdparm-9.48.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/hdparm/${P}.tar.gz"
 
 LICENSE="BSD GPL-2" # GPL-2 only
 SLOT="0"
-KEYWORDS="~alpha amd64 arm hppa ~ia64 ~m68k ~mips ~ppc ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~arm-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 hppa ~ia64 ~m68k ~mips ~ppc ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~arm-linux ~x86-linux"
 IUSE="static"
 
 src_prepare() {


### PR DESCRIPTION
Added ~arm64 keyword after testing on a Raspberry Pi3
in 64 bit mode. Thats a Cortex-a53
Nobody will ever make an arm64 with an IDE interface,
so its probably the most worthless keyword ever.
hdparm -tT works.

Package-Manager: portage-2.2.28