### PR TITLE
app-shells/mpv-bash-completion: use einstalldocs in src_install in 0.16

### DIFF
--- a/app-shells/mpv-bash-completion/mpv-bash-completion-0.16.ebuild
+++ b/app-shells/mpv-bash-completion/mpv-bash-completion-0.16.ebuild
@@ -30,6 +30,6 @@ src_compile() {
 }
 
 src_install() {
-	default
+	einstalldocs
 	newbashcomp ${PN} mpv
 }


### PR DESCRIPTION
mpv-bash-completion doesn't have any build system or Makefiles.
According to PMS, default in src_install phase is equivalent to
einstalldocs in this case [0].

Thus replace default with einstalldocs.

[0]: https://dev.gentoo.org/~ulm/pms/head/pms.html#x1-1040009.1.9

Package-Manager: portage-2.2.28