### PR TITLE
media-libs/ffmpegsource: update live ebuild

### DIFF
--- a/media-libs/ffmpegsource/ffmpegsource-9999.ebuild
+++ b/media-libs/ffmpegsource/ffmpegsource-9999.ebuild
@@ -2,20 +2,18 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-AUTOTOOLS_AUTORECONF=1
-
-inherit autotools-utils flag-o-matic git-r3
+inherit autotools eutils flag-o-matic git-r3
 
 DESCRIPTION="A libav/ffmpeg based source library for easy frame accurate access"
 HOMEPAGE="https://github.com/FFMS/ffms2"
-EGIT_REPO_URI="https://github.com/FFMS/ffms2.git"
+EGIT_REPO_URI="git://github.com/FFMS/ffms2.git"
 
 LICENSE="MIT"
 SLOT="0/4"
 KEYWORDS=""
-IUSE="libav static-libs"
+IUSE="libav"
 
 RDEPEND="
 	sys-libs/zlib
@@ -30,4 +28,14 @@ pkg_pretend() {
 	if [[ ${MERGE_TYPE} != "binary" ]] && ! test-flag-CXX -std=c++11; then
 		die "Your compiler lacks C++11 support. Use GCC>=4.7.0 or Clang>=3.3."
 	fi
+}
+
+src_prepare() {
+	default_src_prepare
+	eautoreconf
+}
+
+src_install() {
+	default_src_install
+	prune_libtool_files --modules
 }


### PR DESCRIPTION
Bump EAPI to 6, drop unused static-libs USE.

Package-Manager: portage-2.2.28