### PR TITLE
net-fs/nfs-utils: warn if client tracking will be broken

### DIFF
--- a/net-fs/nfs-utils/nfs-utils-1.2.9-r3.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-1.2.9-r3.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="4"
 
-inherit eutils flag-o-matic multilib autotools systemd
+inherit eutils flag-o-matic multilib autotools systemd linux-info
 
 DESCRIPTION="NFS client and server daemons"
 HOMEPAGE="http://linux-nfs.org/"
@@ -53,6 +53,16 @@ RDEPEND="${DEPEND_COMMON}
 "
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig"
+
+pkg_setup() {
+	linux-info_pkg_setup
+	if use nfsv4 && ! use nfsdcld && linux_config_exists && ! linux_chkconfig_present CRYPTO_MD5 ; then
+		ewarn "Your NFS server will be unable to track clients across server restarts!"
+		ewarn "Please enable the \"${HILITE}nfsdcld${NORMAL}\" USE flag to install the nfsdcltrack usermode"
+		ewarn "helper upcall program, or enable ${HILITE}CONFIG_CRYPTO_MD5${NORMAL} in your kernel to"
+		ewarn "support the legacy, in-kernel client tracker."
+	fi
+}
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.1.4-mtab-sym.patch

--- a/net-fs/nfs-utils/nfs-utils-1.3.1-r4.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-1.3.1-r4.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="5"
 
-inherit eutils flag-o-matic multilib autotools systemd
+inherit eutils flag-o-matic multilib autotools systemd linux-info
 
 DESCRIPTION="NFS client and server daemons"
 HOMEPAGE="http://linux-nfs.org/"
@@ -54,6 +54,16 @@ RDEPEND="${DEPEND_COMMON}
 "
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig"
+
+pkg_setup() {
+	linux-info_pkg_setup
+	if use nfsv4 && ! use nfsdcld && linux_config_exists && ! linux_chkconfig_present CRYPTO_MD5 ; then
+		ewarn "Your NFS server will be unable to track clients across server restarts!"
+		ewarn "Please enable the \"${HILITE}nfsdcld${NORMAL}\" USE flag to install the nfsdcltrack usermode"
+		ewarn "helper upcall program, or enable ${HILITE}CONFIG_CRYPTO_MD5${NORMAL} in your kernel to"
+		ewarn "support the legacy, in-kernel client tracker."
+	fi
+}
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.1.4-mtab-sym.patch

--- a/net-fs/nfs-utils/nfs-utils-1.3.1-r5.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-1.3.1-r5.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="5"
 
-inherit eutils flag-o-matic multilib autotools systemd
+inherit eutils flag-o-matic multilib autotools systemd linux-info
 
 DESCRIPTION="NFS client and server daemons"
 HOMEPAGE="http://linux-nfs.org/"
@@ -54,6 +54,16 @@ RDEPEND="${DEPEND_COMMON}
 "
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig"
+
+pkg_setup() {
+	linux-info_pkg_setup
+	if use nfsv4 && ! use nfsdcld && linux_config_exists && ! linux_chkconfig_present CRYPTO_MD5 ; then
+		ewarn "Your NFS server will be unable to track clients across server restarts!"
+		ewarn "Please enable the \"${HILITE}nfsdcld${NORMAL}\" USE flag to install the nfsdcltrack usermode"
+		ewarn "helper upcall program, or enable ${HILITE}CONFIG_CRYPTO_MD5${NORMAL} in your kernel to"
+		ewarn "support the legacy, in-kernel client tracker."
+	fi
+}
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.1.4-mtab-sym.patch

--- a/net-fs/nfs-utils/nfs-utils-1.3.2-r6.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-1.3.2-r6.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="5"
 
-inherit eutils flag-o-matic multilib autotools systemd
+inherit eutils flag-o-matic multilib autotools systemd linux-info
 
 DESCRIPTION="NFS client and server daemons"
 HOMEPAGE="http://linux-nfs.org/"
@@ -54,6 +54,16 @@ RDEPEND="${DEPEND_COMMON}
 "
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig"
+
+pkg_setup() {
+	linux-info_pkg_setup
+	if use nfsv4 && ! use nfsdcld && linux_config_exists && ! linux_chkconfig_present CRYPTO_MD5 ; then
+		ewarn "Your NFS server will be unable to track clients across server restarts!"
+		ewarn "Please enable the \"${HILITE}nfsdcld${NORMAL}\" USE flag to install the nfsdcltrack usermode"
+		ewarn "helper upcall program, or enable ${HILITE}CONFIG_CRYPTO_MD5${NORMAL} in your kernel to"
+		ewarn "support the legacy, in-kernel client tracker."
+	fi
+}
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.1.4-mtab-sym.patch

--- a/net-fs/nfs-utils/nfs-utils-1.3.3.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-1.3.3.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="5"
 
-inherit eutils flag-o-matic multilib autotools systemd
+inherit eutils flag-o-matic multilib autotools systemd linux-info
 
 DESCRIPTION="NFS client and server daemons"
 HOMEPAGE="http://linux-nfs.org/"
@@ -54,6 +54,16 @@ RDEPEND="${DEPEND_COMMON}
 "
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig"
+
+pkg_setup() {
+	linux-info_pkg_setup
+	if use nfsv4 && ! use nfsdcld && linux_config_exists && ! linux_chkconfig_present CRYPTO_MD5 ; then
+		ewarn "Your NFS server will be unable to track clients across server restarts!"
+		ewarn "Please enable the \"${HILITE}nfsdcld${NORMAL}\" USE flag to install the nfsdcltrack usermode"
+		ewarn "helper upcall program, or enable ${HILITE}CONFIG_CRYPTO_MD5${NORMAL} in your kernel to"
+		ewarn "support the legacy, in-kernel client tracker."
+	fi
+}
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.1.4-mtab-sym.patch


### PR DESCRIPTION
NFSDv4 supports client tracking across server restarts using two methods. The legacy method is in-kernel and requires `CONFIG_CRYPTO_MD5`, which is not automatically selected by `CONFIG_NFSD_V4` (see https://bugzilla.kernel.org/show_bug.cgi?id=52271). The newer method involves a usermode helper upcall program (`nfsdcltrack`), which is built and installed only when `USE="nfsdcld"`. If neither method is available, then the NFS server does not support tracking clients across restarts, and it emits a warning to the kernel log:

```
NFSD: unable to generate recoverydir name (-2).
NFSD: disabling legacy clientid tracking. Reboot recovery will not function correctly!
```

This commit introduces an `ewarn` in `pkg_setup` to warn the user if their configuration will not support client tracking due to neither of these options being enabled.