### PR TITLE
app-editors/atom: Build fixes (#582748)

### DIFF
--- a/app-editors/atom/atom-1.7.3-r1.ebuild
+++ b/app-editors/atom/atom-1.7.3-r1.ebuild
@@ -114,6 +114,7 @@ DEPEND="
 	>=net-libs/nodejs-5.9.0:=[npm]
 	>=app-text/hunspell-1.3.3:=
 	=dev-libs/libgit2-0.23*:=[ssh]
+	>=gnome-base/libgnome-keyring-3.12:=
 	>=dev-libs/oniguruma-5.9.5:=
 	>=dev-util/ctags-5.8
 	dev-util/electron:0/36
@@ -269,7 +270,7 @@ src_prepare() {
 }
 
 src_configure() {
-	local binmod _s
+	local binmod _s nodegyp="/usr/$(get_libdir)/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js"
 
 	_s="${WORKDIR}/$(package_dir nodegit)"
 	cd "${_s}" || die
@@ -283,14 +284,14 @@ src_configure() {
 		einfo "Configuring ${binmod}..."
 		_s="${WORKDIR}/$(package_dir ${binmod})"
 		cd "${_s}" || die
-		node-gyp --nodedir=/usr/include/electron/node/ configure || die
+		"${nodegyp}" --nodedir=/usr/include/electron/node/ configure || die
 		# Unclobber MAKEFLAGS
 		sed -i -e '/MAKEFLAGS=-r/d' build/Makefile || die
 	done
 }
 
 src_compile() {
-	local binmod _s x
+	local binmod _s x nodegyp="/usr/$(get_libdir)/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js"
 
 	mkdir -p "${S}/build/modules/" || die
 
@@ -298,7 +299,7 @@ src_compile() {
 		einfo "Building ${binmod}..."
 		_s="${WORKDIR}/$(package_dir ${binmod})"
 		cd "${_s}" || die
-		node-gyp --nodedir=/usr/include/electron/node/ --verbose build || die
+		"${nodegyp}" --nodedir=/usr/include/electron/node/ --verbose build || die
 		x=${binmod##node-}
 		mkdir -p "${S}/build/modules/${x}"
 		cp build/Release/*.node "${S}/build/modules/${x}"

--- a/app-editors/atom/files/gyp-unbundle.py
+++ b/app-editors/atom/files/gyp-unbundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 


### PR DESCRIPTION
Fixed node-gyp invocation and added gnome-keyring dependency.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=582748
Package-Manager: portage-2.2.28