### PR TITLE
dev-util/electron: Drop gtk3 USE flag (#582698)

### DIFF
--- a/dev-util/electron/electron-0.36.12.ebuild
+++ b/dev-util/electron/electron-0.36.12.ebuild
@@ -54,7 +54,7 @@ LIBCC_S="${BRIGHTRAY_S}/vendor/libchromiumcontent"
 LICENSE="BSD"
 SLOT="0/$(get_version_component_range 2)"
 KEYWORDS="~amd64"
-IUSE="custom-cflags cups gnome gnome-keyring gtk3 hidpi kerberos lto neon pic +proprietary-codecs pulseaudio selinux +system-ffmpeg +tcmalloc"
+IUSE="custom-cflags cups gnome gnome-keyring hidpi kerberos lto neon pic +proprietary-codecs pulseaudio selinux +system-ffmpeg +tcmalloc"
 RESTRICT="!system-ffmpeg? ( proprietary-codecs? ( bindist ) )"
 
 # Native Client binaries are compiled with different set of flags, bug #452066.
@@ -100,8 +100,7 @@ RDEPEND=">=app-accessibility/speech-dispatcher-0.8:=
 	virtual/udev
 	x11-libs/cairo:=
 	x11-libs/gdk-pixbuf:=
-	gtk3? ( x11-libs/gtk+:3= )
-	!gtk3? ( x11-libs/gtk+:2= )
+	x11-libs/gtk+:2=
 	x11-libs/libdrm
 	x11-libs/libX11:=
 	x11-libs/libXcomposite:=
@@ -490,7 +489,6 @@ src_configure() {
 		$(gyp_use gnome use_gconf)
 		$(gyp_use gnome-keyring use_gnome_keyring)
 		$(gyp_use gnome-keyring linux_link_gnome_keyring)
-		$(gyp_use gtk3)
 		$(gyp_use hidpi enable_hidpi)
 		$(gyp_use kerberos)
 		$(gyp_use lto)

--- a/dev-util/electron/metadata.xml
+++ b/dev-util/electron/metadata.xml
@@ -11,7 +11,6 @@
 	</maintainer>
 	<longdescription>Electron is a cross platform application development framework based on web technologies based on Chromium</longdescription>
 	<use>
-		<flag name="gtk3">Use gtk3 instead of gtk2</flag>
 		<flag name="hidpi">Enable support for high-resolution screens (high dots per inch)</flag>
 		<flag name="lto">Build with link time optimization enabled</flag>
 		<flag name="pic">Disable optimized assembly code that is not PIC friendly</flag>


### PR DESCRIPTION
Upstream does not support GTK3 yet (unlike Chromium), so drop the
USE flag.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=582698

Package-Manager: portage-2.2.28