### PR TITLE
dev-python/uranium: fix dependency issue

### DIFF
--- a/dev-python/uranium/uranium-2.1.0_beta-r2.ebuild
+++ b/dev-python/uranium/uranium-2.1.0_beta-r2.ebuild
@@ -21,7 +21,7 @@ IUSE="doc test"
 
 RDEPEND="${PYTHON_DEPS}
 	dev-libs/libarcus:*[${PYTHON_USEDEP}]
-	dev-python/PyQt5[${PYTHON_USEDEP}]
+	dev-python/PyQt5[${PYTHON_USEDEP},declarative,network,svg]
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-qt/qtdeclarative:5
 	dev-qt/qtquickcontrols:5"


### PR DESCRIPTION
PyQt5 is required with support for declarative
Gentoo-Bug: 582796

Package-Manager: portage-2.2.28