### PR TITLE
dev-libs/sway: enable important USE flags by default.

### DIFF
--- a/dev-libs/sway/sway-0.6.ebuild
+++ b/dev-libs/sway/sway-0.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/SirCmpwn/sway/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="swaylock swaybg swaybar swaygrab swaymsg gdk-pixbuf zsh-completion wallpapers systemd"
+IUSE="+gdk-pixbuf +swaybar +swaybg swaygrab swaylock +swaymsg systemd wallpapers zsh-completion"
 
 RDEPEND="dev-libs/wlc[systemd=]
 		dev-libs/json-c

--- a/dev-libs/sway/sway-9999.ebuild
+++ b/dev-libs/sway/sway-9999.ebuild
@@ -14,7 +14,7 @@ EGIT_REPO_URI="https://github.com/SirCmpwn/sway.git"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS=""
-IUSE="swaylock swaybg swaybar swaygrab swaymsg gdk-pixbuf zsh-completion wallpapers systemd"
+IUSE="+gdk-pixbuf +swaybar +swaybg swaygrab swaylock +swaymsg systemd wallpapers zsh-completion"
 
 RDEPEND="=dev-libs/wlc-9999[systemd=]
 		dev-libs/json-c


### PR DESCRIPTION
According to upstream, these options are considered core
functionality, and are recommended to be enabled by default.

Disabling them results in a very minimal build; probably
not what most users would want, or expect.

Package-Manager: portage-2.2.28