### PR TITLE
net-p2p/classified-ads: add missing DEPEND on gettext for 0.10

### DIFF
--- a/net-p2p/classified-ads/classified-ads-0.10.ebuild
+++ b/net-p2p/classified-ads/classified-ads-0.10.ebuild
@@ -37,6 +37,7 @@ RDEPEND="dev-libs/openssl:0
 		virtual/libintl"
 
 DEPEND="${RDEPEND}
+	sys-devel/gettext
 	doc? ( app-doc/doxygen[dot] )
 	test? ( dev-libs/libgcrypt:0
 		dev-qt/qttest:5


### PR DESCRIPTION
Package-Manager: portage-2.2.28