### PR TITLE
net-nntp/nzbget: re-add a missing patch for old versions

### DIFF
--- a/net-nntp/nzbget/files/nzbget-14.0_pre1145-tinfo.patch
+++ b/net-nntp/nzbget/files/nzbget-14.0_pre1145-tinfo.patch
@@ -1,0 +1,18 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -46,6 +46,7 @@
+ AC_PATH_PROG(MAKE, make, $FALSE)
+ AC_PROG_INSTALL
+ 
++PKG_PROG_PKG_CONFIG()
+ 
+ dnl
+ dnl Do all tests with c++ compiler.
+@@ -291,6 +292,7 @@
+ 	if test "$FOUND" = "no"; then
+ 		AC_MSG_ERROR([Couldn't find curses headers (ncurses.h or curses.h)])
+ 	fi
++	PKG_CHECK_MODULES(ncurses,ncurses,LIBS="$LIBS $ncurses_LIBS",)
+ 	AC_SEARCH_LIBS([refresh], [ncurses curses],, 
+ 		AC_ERROR([Couldn't find curses library]))
+ else


### PR DESCRIPTION
@monsieurp I accidentally deleted a patch that was still used by older versions, can you commit this please?