### PR TITLE
cmake-utils.eclass: rewrite `_ninjaopts_from_makeopts()`

### DIFF
--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -652,25 +652,71 @@ enable_cmake-utils_src_compile() {
 }
 
 _ninjaopts_from_makeopts() {
-	if [[ ${NINJAOPTS+set} == set ]]; then
-		return 0
-	fi
-	local ninjaopts=()
-	set -- ${MAKEOPTS}
-	while (( $# )); do
-		case $1 in
-			-j|-l|-k)
-				ninjaopts+=( $1 $2 )
-				shift 2
+	local makeopts="${1:-"${MAKEOPTS}"}" ninjaopts=()
+	local jobs= keep= load=
+
+	set -- ${makeopts}
+	while (( ${#} )) ; do
+		case "${1}" in
+			-j|--jobs)
+				if [[ -n ${2} ]] && [[ ${2} =~ ^[0-9]+$ ]] ; then
+					jobs=${2}
+					shift
+				else
+					# `man 1 make`:
+					# 	If the -j option is given without an argument, make will not limit
+					# 	the number of jobs that can run simultaneously.
+					jobs=99
+				fi
 				;;
-			-j*|-l*|-k*)
-				ninjaopts+=( $1 )
-				shift 1
+			-k|--keep-going)
+				# `man 1 make`:
+				# 	Continue as much as possible after an error
+				# `ninja --help`:
+				# 	keep going until N jobs fail
+				# ninja internals:
+				# 	ninja handles 0 as inifinity in this case
+				keep=0
 				;;
-			*) shift ;;
+			-l|--load-average)
+				if [[ -n ${2} ]] && [[ ${2} =~ ^[0-9]+\.?[0-9]*$ ]] ; then
+					# ninja internals:
+					# 	ninja supports floating-point numbers here
+					load=${2}
+					shift
+				else
+					# `man 1 make`:
+					#	With no argument, removes a previous load limit.
+					load=
+				fi
+				;;
+			-S|--no-keep-going|--stop)
+				# `make --help`:
+				#	Turns off -k
+				keep=
+				;;
+			-j*|--jobs=*|-l*|--load-average=*)
+				eshopts_push -s extglob
+
+				local arg="${1##*([^0-9])}"
+				case "${1##*(-)}" in
+					j*) jobs=${arg} ;;
+					l*) load=${arg} ;;
+				esac
+
+				eshopts_pop
+				;;
 		esac
+		shift
 	done
-	export NINJAOPTS="${ninjaopts[*]}"
+
+	ninjaopts+=( ${jobs:+"-j"} ${jobs} )
+	ninjaopts+=( ${keep:+"-k"} ${keep} )
+	ninjaopts+=( ${load:+"-l"} ${load} )
+
+	debug-print "${LINENO} ${ECLASS} ${FUNCNAME}: '${makeopts}' -> '${ninjaopts[*]}'"
+
+	NINJAOPTS="${ninjaopts[*]}"
 }
 
 # @FUNCTION: _cmake_ninja_src_make
@@ -682,14 +728,14 @@ _cmake_ninja_src_make() {
 
 	[[ -e build.ninja ]] || die "build.ninja not found. Error during configure stage."
 
-	_ninjaopts_from_makeopts
-
-	if [[ "${CMAKE_VERBOSE}" != "OFF" ]]; then
-		set -- ninja ${NINJAOPTS} -v "$@"
-	else
-		set -- ninja ${NINJAOPTS} "$@"
+	if [[ -z ${NINJAOPTS+x} ]] ; then
+		declare -g NINJAOPTS
+		_ninjaopts_from_makeopts
 	fi
 
+	[[ "${CMAKE_VERBOSE}" != "OFF" ]] && NINJAOPTS+=" -v"
+
+	set -- ninja ${NINJAOPTS} "$@"
 	echo "$@"
 	"$@" || die
 }

--- a/eclass/tests/cmake-utils_ninjaopts_from_makeopts.sh
+++ b/eclass/tests/cmake-utils_ninjaopts_from_makeopts.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+source tests-common.sh
+
+EAPI=6
+
+inherit cmake-utils
+
+# --------------------------------------------------------------------------------------------------
+
+estack_pop() {
+	[[ $# -eq 0 || $# -gt 2 ]] && die "estack_pop: incorrect # of arguments"
+
+	# We use the fugly _estack_xxx var names to avoid collision with
+	# passing back the return value.  If we used "local i" and the
+	# caller ran `estack_pop ... i`, we'd end up setting the local
+	# copy of "i" rather than the caller's copy.  The _estack_xxx
+	# garbage is preferable to using $1/$2 everywhere as that is a
+	# bit harder to read.
+	local _estack_name="_ESTACK_$1_" ; shift
+	local _estack_retvar=$1 ; shift
+	eval local _estack_i=\${#${_estack_name}\[@\]}
+	# Don't warn -- let the caller interpret this as a failure
+	# or as normal behavior (akin to `shift`)
+	[[ $(( --_estack_i )) -eq -1 ]] && return 1
+
+	if [[ -n ${_estack_retvar} ]] ; then
+		eval ${_estack_retvar}=\"\${${_estack_name}\[${_estack_i}\]}\"
+	fi
+	eval unset \"${_estack_name}\[${_estack_i}\]\"
+}
+
+estack_push() {
+	[[ $# -eq 0 ]] && die "estack_push: incorrect # of arguments"
+	local stack_name="_ESTACK_$1_" ; shift
+	eval ${stack_name}+=\( \"\$@\" \)
+}
+
+eshopts_push() {
+	if [[ $1 == -[su] ]] ; then
+		estack_push eshopts "$(shopt -p)"
+		[[ $# -eq 0 ]] && return 0
+		shopt "$@" || die "${FUNCNAME}: bad options to shopt: $*"
+	else
+		estack_push eshopts $-
+		[[ $# -eq 0 ]] && return 0
+		set "$@" || die "${FUNCNAME}: bad options to set: $*"
+	fi
+}
+
+eshopts_pop() {
+	local s
+	estack_pop eshopts s || die "${FUNCNAME}: unbalanced push"
+	if [[ ${s} == "shopt -"* ]] ; then
+		eval "${s}" || die "${FUNCNAME}: sanity: invalid shopt options: ${s}"
+	else
+		set +$-     || die "${FUNCNAME}: sanity: invalid shell settings: $-"
+		set -${s}   || die "${FUNCNAME}: sanity: unable to restore saved shell settings: ${s}"
+	fi
+}
+
+# --------------------------------------------------------------------------------------------------
+
+test-ninjaopts() {
+	local expect="${1}" given="${2}"
+	tbegin "'${given}'"
+	local ret=0
+
+	local out="$(
+		NINJAOPTS=
+		_ninjaopts_from_makeopts "${given}"
+		printf '%s\n' "${NINJAOPTS}"
+	)"
+	if [[ ${out} != ${expect} ]] ; then
+		eerror "Self-test failed:"
+		eindent
+		eerror "MAKEOPTS: '${given}'"
+		eerror "Expected: '${expect}'"
+		eerror "Actual:   '${out}'"
+		eoutdent
+		ret=1
+	fi
+
+	tend ${ret}
+	return ${ret}
+}
+
+section() {
+	local args=( "${@:1:((${#}-1))}" ) flag="${!#}"
+	if [[ ${flag} == '{' ]] ; then
+		einfo "'${args[*]}'"
+		eindent
+	elif [[ ${flag} == '}' ]] ; then
+		eoutdent
+	else
+		eerror "Bad flag: '${flag}'"
+	fi
+}
+
+section Empty {
+	test-ninjaopts ''	''
+	test-ninjaopts ''	'        '
+section }
+
+section Jobs only {
+	test-ninjaopts '-j 1'	'-j 1'
+	test-ninjaopts '-j 2'	'-j2'
+	test-ninjaopts '-j 3'	'--jobs=3'
+	test-ninjaopts '-j 4'	'--jobs 4'
+
+	section Unlimited jobs {
+		test-ninjaopts '-j 99'	'-j'
+		test-ninjaopts '-j 99'	'--jobs'
+	section }
+section }
+
+section Keep only {
+	test-ninjaopts '-k 0'	'-k'
+	test-ninjaopts '-k 0'	'--keep-going'
+section }
+
+section Keep/stop only {
+	test-ninjaopts ''	'-S'
+	test-ninjaopts ''	'--no-keep-going'
+	test-ninjaopts ''	'--stop'
+
+	section Keep before stop {
+		test-ninjaopts ''	'-k -S'
+		test-ninjaopts ''	'-k --no-keep-going'
+		test-ninjaopts ''	'-k --stop'
+	section }
+	section Keep after stop {
+		test-ninjaopts '-k 0'	'-S -k'
+		test-ninjaopts '-k 0'	'--no-keep-going -k'
+		test-ninjaopts '-k 0'	'--stop -k'
+	section }
+section }
+
+section Load only {
+	test-ninjaopts '-l 1'	'-l 1'
+	test-ninjaopts '-l 2'	'-l2'
+	test-ninjaopts '-l 3'	'--load-average=3'
+	test-ninjaopts '-l 4'	'--load-average 4'
+
+	section Floating point numbers {
+		test-ninjaopts '-l 1.12345'	'-l 1.12345'
+		test-ninjaopts '-l 2.12345'	'-l2.12345'
+		test-ninjaopts '-l 3.12345'	'--load-average=3.12345'
+		test-ninjaopts '-l 4.12345'	'--load-average 4.12345'
+	section }
+
+	section No argument {
+		test-ninjaopts ''	'-l 5 -l'
+		test-ninjaopts ''	'--load-average=5 --load-average'
+	section }
+section }
+
+section Some mixups {
+	test-ninjaopts '-j 2 -k 0'			'-k -j 2'
+	test-ninjaopts '-j 18 -k 0'			'-k -l -j -j 99 -k -j18 -l17 -l -k'
+	test-ninjaopts '-j 99 -k 0'			'-k -l -j -j 75 -k -j18 -l17 -l -k -j'
+	test-ninjaopts '-j 18 -k 0 -l 1'	'-k -l -j -j 99 -k -j18 -l17 -l -k -l1'
+	test-ninjaopts '-j 18 -k 0 -l 1'	'-k -l -j -j 99 -k -j18 -l17 -l -k -l 1'
+section }
+
+texit


### PR DESCRIPTION
Based on https://github.com/gentoo/gentoo/pull/1228

Changes from the previous version:
- tests were added
- `-S` option was implemented which is a complement to `-k`
- API of the function was changed to:
```
Usage: _ninjaopts_from_makeopts [ MAKEOPTS ]
Return: NINJAOPTS
```

Due to the API change it was required to update `_cmake_ninja_src_make()` and when doing so I also simplified unnecessarily complicated `CMAKE_VERBOSE` handling.

@gentoo/kde @kensington

I'm also going to ping #gentoo-dev, don't worry.