### PR TITLE
net-misc/connman: Update xtables patch for kernel versions >= 4.6.0

### DIFF
--- a/net-misc/connman/files/connman-1.31-xtables.patch
+++ b/net-misc/connman/files/connman-1.31-xtables.patch
@@ -30,12 +30,13 @@
  #define CHAIN_PREFIX "connman-"
 --- /dev/null	2016-03-18 06:21:16.372989086 -0700
 +++ connman-1.31/include/connman_xtables.h	2016-03-22 21:32:21.349504786 -0700
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,21 @@
 +#ifndef CONNMAN_XTABLES_H
 +#define CONNMAN_XTABLES_H
 +
 +#include <linux/version.h>
-+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0) || \
++    LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
 +#include <xtables.h>
 +#else
 +#ifdef __USE_MISC


### PR DESCRIPTION
Gentoo-bug: 583402

Package-Manager: portage-2.3.0_rc1