### PR TITLE
kde-frameworks/ki18n: Add PYTHON_COMPAT=python3_5

### DIFF
--- a/kde-frameworks/ki18n/ki18n-5.22.1.ebuild
+++ b/kde-frameworks/ki18n/ki18n-5.22.1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit kde5 python-single-r1
 
 DESCRIPTION="Framework based on Gettext for internationalizing user interface text"


### PR DESCRIPTION
works for me, tests ok.

Package-Manager: portage-2.2.28