### PR TITLE
HTTPS for launchpad.net

### DIFF
--- a/dev-python/oslo-i18n/oslo-i18n-2.7.0.ebuild
+++ b/dev-python/oslo-i18n/oslo-i18n-2.7.0.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1 vcs-snapshot
 MY_PN=${PN/-/.}
 
 DESCRIPTION="Oslo i18n library"
-HOMEPAGE="http://launchpad.net/oslo"
+HOMEPAGE="https://launchpad.net/oslo"
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_PN}-${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-python/oslo-i18n/oslo-i18n-3.5.0.ebuild
+++ b/dev-python/oslo-i18n/oslo-i18n-3.5.0.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1 vcs-snapshot
 MY_PN=${PN/-/.}
 
 DESCRIPTION="Oslo i18n library"
-HOMEPAGE="http://launchpad.net/oslo"
+HOMEPAGE="https://launchpad.net/oslo"
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_PN}-${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-python/oslo-utils/oslo-utils-2.4.0.ebuild
+++ b/dev-python/oslo-utils/oslo-utils-2.4.0.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1 vcs-snapshot
 MY_PN=${PN/-/.}
 
 DESCRIPTION="Oslo Utility library"
-HOMEPAGE="http://launchpad.net/oslo"
+HOMEPAGE="https://launchpad.net/oslo"
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_PN}-${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-python/oslo-utils/oslo-utils-3.8.0.ebuild
+++ b/dev-python/oslo-utils/oslo-utils-3.8.0.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1 vcs-snapshot
 MY_PN=${PN/-/.}
 
 DESCRIPTION="Oslo Utility library"
-HOMEPAGE="http://launchpad.net/oslo"
+HOMEPAGE="https://launchpad.net/oslo"
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_PN}-${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-python/oslotest/oslotest-1.10.0.ebuild
+++ b/dev-python/oslotest/oslotest-1.10.0.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_3 python3_4 )
 inherit distutils-r1
 
 DESCRIPTION="Oslo test framework"
-HOMEPAGE="http://launchpad.net/oslo"
+HOMEPAGE="https://launchpad.net/oslo"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-python/oslotest/oslotest-1.12.0.ebuild
+++ b/dev-python/oslotest/oslotest-1.12.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python{2_7,3_{3,4,5}} )
 inherit distutils-r1
 
 DESCRIPTION="Oslo test framework"
-HOMEPAGE="http://launchpad.net/oslo"
+HOMEPAGE="https://launchpad.net/oslo"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-python/oslotest/oslotest-2.4.0.ebuild
+++ b/dev-python/oslotest/oslotest-2.4.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python{2_7,3_{3,4,5}} )
 inherit distutils-r1
 
 DESCRIPTION="Oslo test framework"
-HOMEPAGE="http://launchpad.net/oslo"
+HOMEPAGE="https://launchpad.net/oslo"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/media-sound/aacplusenc/aacplusenc-0.17.5.ebuild
+++ b/media-sound/aacplusenc/aacplusenc-0.17.5.ebuild
@@ -8,7 +8,7 @@ inherit toolchain-funcs
 
 DESCRIPTION="High-Efficiency AAC (AAC+) Encoder"
 HOMEPAGE="http://teknoraver.net/software/mp4tools/"
-SRC_URI="http://ppa.launchpad.net/teknoraver/ppa/ubuntu/pool/main/a/${PN}/${PN}_${PV}.tar.gz"
+SRC_URI="https://launchpad.net/~teknoraver/+archive/ubuntu/ppa/+files/${PN}_${PV}.tar.gz"
 
 LICENSE="GPL-1"
 SLOT="0"


### PR DESCRIPTION
media-sound/aacplusenc was updated to use a new URL which
supports HTTPS on launchpad. Hashes were verified to ensure
they matched up correctly.

@jlec 