### PR TITLE
dev-libs/wlc: add missing license, add missing build dependency on pkgconfig

### DIFF
--- a/dev-libs/wlc/wlc-0.0.2.ebuild
+++ b/dev-libs/wlc/wlc-0.0.2.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/Cloudef/wlc"
 
 SRC_URI="https://github.com/Cloudef/wlc/releases/download/v${PV}/${P}.tar.bz2"
 
-LICENSE="MIT"
+LICENSE="MIT ZLIB"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="X static-libs systemd"
@@ -31,6 +31,7 @@ RDEPEND="virtual/opengl
 		systemd? ( sys-apps/systemd sys-apps/dbus )"
 
 DEPEND="${RDEPEND}
+	virtual/pkgconfig
 		dev-libs/wayland-protocols"
 
 src_configure() {

--- a/dev-libs/wlc/wlc-9999.ebuild
+++ b/dev-libs/wlc/wlc-9999.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/Cloudef/wlc"
 
 EGIT_REPO_URI="https://github.com/Cloudef/wlc.git"
 
-LICENSE="MIT"
+LICENSE="MIT ZLIB"
 SLOT="0"
 KEYWORDS=""
 IUSE="X static-libs systemd"
@@ -31,6 +31,7 @@ RDEPEND="virtual/opengl
 		systemd? ( sys-apps/systemd sys-apps/dbus )"
 
 DEPEND="${RDEPEND}
+	virtual/pkgconfig
 		dev-libs/wayland-protocols"
 
 src_configure() {


### PR DESCRIPTION
This package bundles the source for another package with ZLIB license.
It's also missing a build dependency on pkgconfig.

@gentoo/proxy-maint 