### PR TITLE
media-gfx/imv: add missing test deps, fix unused inherit, remove src_install

### DIFF
--- a/media-gfx/imv/imv-2.1.0-r1.ebuild
+++ b/media-gfx/imv/imv-2.1.0-r1.ebuild
@@ -4,15 +4,15 @@
 
 EAPI=6
 
-inherit fdo-mime git-r3
+inherit fdo-mime
 
 DESCRIPTION="Minimal image viewer designed for tiling window manager users"
 HOMEPAGE="https://github.com/eXeC64/imv"
-EGIT_REPO_URI="https://github.com/eXeC64/imv.git"
+SRC_URI="https://github.com/eXeC64/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="~amd64 ~x86"
 IUSE="test"
 
 RDEPEND="


### PR DESCRIPTION
- This package requires cmocka for testing.
- inherit on eutils is unused.
- Remove the src_install() as the default behavior already covers
  that. The default src_install() in EAPI 6 will also install docs
  properly, so revbump 2.1.0.

@gentoo/proxy-maint 
