### PR TITLE
dev-util/serialtalk: fix license: s/GPL-3/GPL-3+/

### DIFF
--- a/dev-util/serialtalk/serialtalk-1.2.ebuild
+++ b/dev-util/serialtalk/serialtalk-1.2.ebuild
@@ -17,7 +17,7 @@ fi
 DESCRIPTION="simple command-line tool to talk to serial devices"
 HOMEPAGE="https://github.com/BGO-OD/serialtalk"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 
 src_install() {

--- a/dev-util/serialtalk/serialtalk-9999.ebuild
+++ b/dev-util/serialtalk/serialtalk-9999.ebuild
@@ -17,7 +17,7 @@ fi
 DESCRIPTION="simple command-line tool to talk to serial devices"
 HOMEPAGE="https://github.com/BGO-OD/serialtalk"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 
 src_install() {


### PR DESCRIPTION
From src/serialtalk.cpp:
"[...] either version 3 of the License, or
(at your option) any later version."

@gentoo/proxy-maint 
