### PR TITLE
dev-util/dput-ng: simplify the manpage installation logic

### DIFF
--- a/dev-util/dput-ng/dput-ng-1.10.ebuild
+++ b/dev-util/dput-ng/dput-ng-1.10.ebuild
@@ -72,13 +72,8 @@ src_install() {
 		doins -r skel/"${dir}"
 	done
 
-	insinto /usr/share/man/man5
-	doins man/dput.cf.5
-	rm man/dput.cf.5 || die
-
-	for file in man/*; do
-		doman "${file}"
-	done
+	# doman incorrectly treats "cf" in dput.cf.5 as a lang code
+	doman -i18n="" man/*
 
 	newbashcomp debian/"${PN}".bash-completion dput
 }


### PR DESCRIPTION
doman performs auto language detection based on the file name. This
causes problems with the 'dput.cf.5' man file since 'cf' is not a
language code. Set i18n to an empty string explicitly to disable
autodetection.

@gentoo/proxy-maint 