### PR TITLE
dev-python/dominate: fix license: s/GPL-3/GPL-3+/

### DIFF
--- a/dev-python/dominate/dominate-2.2.0.ebuild
+++ b/dev-python/dominate/dominate-2.2.0.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/Knio/dominate"
 # https://github.com/Knio/dominate/pull/69
 SRC_URI="https://github.com/Knio/${PN}/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="test"


### PR DESCRIPTION
From dominate/dom1core.py:
"[...] either version 3 of the License, or (at your option)
any later version."

@gentoo/proxy-maint 
