### PR TITLE
Maintainer order

### DIFF
--- a/dev-go/ed25519/metadata.xml
+++ b/dev-go/ed25519/metadata.xml
@@ -4,7 +4,6 @@
 	<maintainer type="person">
 		<email>Marek.Szuba@cern.ch</email>
 		<name>Marek Szuba</name>
-		<description>Proxied maintainer; set to assignee in all bugs</description>
 	</maintainer>
 	<maintainer type="person">
 		<email>blueness@gentoo.org</email>

--- a/dev-go/goptlib/metadata.xml
+++ b/dev-go/goptlib/metadata.xml
@@ -4,7 +4,6 @@
 	<maintainer type="person">
 		<email>Marek.Szuba@cern.ch</email>
 		<name>Marek Szuba</name>
-		<description>Proxied maintainer; set to assignee in all bugs</description>
 	</maintainer>
 	<maintainer type="person">
 		<email>blueness@gentoo.org</email>

--- a/dev-go/siphash/metadata.xml
+++ b/dev-go/siphash/metadata.xml
@@ -4,7 +4,6 @@
 	<maintainer type="person">
 		<email>Marek.Szuba@cern.ch</email>
 		<name>Marek Szuba</name>
-		<description>Proxied maintainer; set to assignee in all bugs</description>
 	</maintainer>
 	<maintainer type="person">
 		<email>blueness@gentoo.org</email>

--- a/net-proxy/obfs4proxy/metadata.xml
+++ b/net-proxy/obfs4proxy/metadata.xml
@@ -4,7 +4,6 @@
 	<maintainer type="person">
 		<email>Marek.Szuba@cern.ch</email>
 		<name>Marek Szuba</name>
-		<description>Proxied maintainer; set to assignee in all bugs</description>
 	</maintainer>
 	<maintainer type="person">
 		<email>blueness@gentoo.org</email>

--- a/sys-auth/rtkit/metadata.xml
+++ b/sys-auth/rtkit/metadata.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Gentoo Proxy Maintainers Project</name>
-	</maintainer>
 	<maintainer type="person">
 		<email>Marek.Szuba@cern.ch</email>
 		<name>Marek Szuba</name>
-		<description>Proxied maintainer; set to assignee in all bugs</description>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Gentoo Proxy Maintainers Project</name>
 	</maintainer>
 	<longdescription lang="en">
 	RealtimeKit is a DBus service that provides applications with an interface

--- a/x11-misc/xystray/metadata.xml
+++ b/x11-misc/xystray/metadata.xml
@@ -4,7 +4,6 @@
 	<maintainer type="person">
                <email>Marek.Szuba@cern.ch</email>
                 <name>Marek Szuba</name>
-		<description>Proxied maintainer; set to assignee in all bugs</description>
 	</maintainer>
 	<maintainer type="project">
                 <email>proxy-maint@gentoo.org</email>


### PR DESCRIPTION
For sys-auth/rtkit, make sure the actual proxied maintainer (i.e. me) appears before the P-M project so that I get assigned rtkit bugs.

Also, remove the no longer needed P-M description from metadata of packages I maintain and which still had it.