### PR TITLE
HTTPS (and canonicalize domain) for github.com

### DIFF
--- a/app-accessibility/espeakup/espeakup-9999.ebuild
+++ b/app-accessibility/espeakup/espeakup-9999.ebuild
@@ -15,7 +15,7 @@ fi
 inherit $vcs linux-info
 
 DESCRIPTION="espeakup is a small lightweight connector for espeak and speakup"
-HOMEPAGE="https://www.github.com/williamh/espeakup"
+HOMEPAGE="https://github.com/williamh/espeakup"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-admin/github-backup-utils/github-backup-utils-2.5.0.ebuild
+++ b/app-admin/github-backup-utils/github-backup-utils-2.5.0.ebuild
@@ -10,7 +10,7 @@ inherit python-any-r1
 
 DESCRIPTION="Backup and recovery utilities for GitHub Enterprise"
 HOMEPAGE="https://github.com/github/backup-utils"
-SRC_URI="http://github.com/github/backup-utils/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/github/backup-utils/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/app-admin/github-backup-utils/github-backup-utils-2.6.0.ebuild
+++ b/app-admin/github-backup-utils/github-backup-utils-2.6.0.ebuild
@@ -10,7 +10,7 @@ inherit python-any-r1
 
 DESCRIPTION="Backup and recovery utilities for GitHub Enterprise"
 HOMEPAGE="https://github.com/github/backup-utils"
-SRC_URI="http://github.com/github/backup-utils/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/github/backup-utils/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-haskell/mtl/mtl-2.1.3.1.ebuild
+++ b/dev-haskell/mtl/mtl-2.1.3.1.ebuild
@@ -10,7 +10,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Monad classes, using functional dependencies"
-HOMEPAGE="http://github.com/ekmett/mtl"
+HOMEPAGE="https://github.com/ekmett/mtl"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/multipart/multipart-0.1.2.ebuild
+++ b/dev-haskell/multipart/multipart-0.1.2.ebuild
@@ -10,7 +10,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="HTTP multipart split out of the cgi package"
-HOMEPAGE="https://www.github.com/silkapp/multipart"
+HOMEPAGE="https://github.com/silkapp/multipart"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/temporary-rc/temporary-rc-1.2.0.3.ebuild
+++ b/dev-haskell/temporary-rc/temporary-rc-1.2.0.3.ebuild
@@ -10,7 +10,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Portable temporary file and directory support for Windows and Unix"
-HOMEPAGE="https://www.github.com/feuerbach/temporary"
+HOMEPAGE="https://github.com/feuerbach/temporary"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/temporary/temporary-1.1.2.4.ebuild
+++ b/dev-haskell/temporary/temporary-1.1.2.4.ebuild
@@ -10,7 +10,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Portable temporary file and directory support for Windows and Unix, based on code from Cabal"
-HOMEPAGE="https://www.github.com/batterseapower/temporary"
+HOMEPAGE="https://github.com/batterseapower/temporary"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/temporary/temporary-1.2.0.3.ebuild
+++ b/dev-haskell/temporary/temporary-1.2.0.3.ebuild
@@ -10,7 +10,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Portable temporary file and directory support for Windows and Unix, based on code from Cabal"
-HOMEPAGE="https://www.github.com/batterseapower/temporary"
+HOMEPAGE="https://github.com/batterseapower/temporary"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-libs/dotconf/dotconf-1.3.ebuild
+++ b/dev-libs/dotconf/dotconf-1.3.ebuild
@@ -7,7 +7,7 @@ EAPI="3"
 inherit eutils
 
 DESCRIPTION="dot.conf configuration file parser"
-HOMEPAGE="https://www.github.com/williamh/dotconf"
+HOMEPAGE="https://github.com/williamh/dotconf"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 LICENSE="LGPL-2.1"
 

--- a/dev-python/aadict/aadict-0.2.2.ebuild
+++ b/dev-python/aadict/aadict-0.2.2.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} pypy pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="An auto-attribute dict (and a couple of other useful dict functions)"
-HOMEPAGE="http://github.com/metagriffin/aadict http://pypi.python.org/pypi/aadict"
+HOMEPAGE="https://github.com/metagriffin/aadict http://pypi.python.org/pypi/aadict"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3+"

--- a/dev-python/bokeh/bokeh-0.10.0.ebuild
+++ b/dev-python/bokeh/bokeh-0.10.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
 inherit distutils-r1
 
 DESCRIPTION="Statistical and novel interactive HTML plots for Python"
-HOMEPAGE="http://bokeh.pydata.org/ http://github.com/bokeh/bokeh http://pypi.python.org/pypi/bokeh"
+HOMEPAGE="http://bokeh.pydata.org/ https://github.com/bokeh/bokeh http://pypi.python.org/pypi/bokeh"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/bokeh/bokeh-0.11.0.ebuild
+++ b/dev-python/bokeh/bokeh-0.11.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
 inherit distutils-r1
 
 DESCRIPTION="Statistical and novel interactive HTML plots for Python"
-HOMEPAGE="http://bokeh.pydata.org/ http://github.com/bokeh/bokeh http://pypi.python.org/pypi/bokeh"
+HOMEPAGE="http://bokeh.pydata.org/ https://github.com/bokeh/bokeh http://pypi.python.org/pypi/bokeh"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/bokeh/bokeh-0.11.1.ebuild
+++ b/dev-python/bokeh/bokeh-0.11.1.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
 inherit distutils-r1
 
 DESCRIPTION="Statistical and novel interactive HTML plots for Python"
-HOMEPAGE="http://bokeh.pydata.org/ http://github.com/bokeh/bokeh http://pypi.python.org/pypi/bokeh"
+HOMEPAGE="http://bokeh.pydata.org/ https://github.com/bokeh/bokeh http://pypi.python.org/pypi/bokeh"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/catkin_pkg/catkin_pkg-0.2.10.ebuild
+++ b/dev-python/catkin_pkg/catkin_pkg-0.2.10.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros-infrastructure/catkin_pkg"
+	EGIT_REPO_URI="https://github.com/ros-infrastructure/catkin_pkg"
 fi
 
 inherit ${SCM} distutils-r1
@@ -21,7 +21,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 else
 	SRC_URI="
 		http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/catkin_pkg/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/catkin_pkg/archive/${PV}.tar.gz -> ${P}.tar.gz
 		"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/catkin_pkg/catkin_pkg-9999.ebuild
+++ b/dev-python/catkin_pkg/catkin_pkg-9999.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros-infrastructure/catkin_pkg"
+	EGIT_REPO_URI="https://github.com/ros-infrastructure/catkin_pkg"
 fi
 
 inherit ${SCM} distutils-r1
@@ -21,7 +21,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 else
 	SRC_URI="
 		http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/catkin_pkg/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/catkin_pkg/archive/${PV}.tar.gz -> ${P}.tar.gz
 		"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/cycler/cycler-0.10.0.ebuild
+++ b/dev-python/cycler/cycler-0.10.0.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="Composable style cycles"
 HOMEPAGE="
 	http://matplotlib.org/cycler/
 	https://pypi.python.org/pypi/Cycler/
-	http://github.com/matplotlib/cycler"
+	https://github.com/matplotlib/cycler"
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${P}.tar.gz"
 
 SLOT="0"

--- a/dev-python/cycler/cycler-0.9.0.ebuild
+++ b/dev-python/cycler/cycler-0.9.0.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="Composable style cycles"
 HOMEPAGE="
 	http://tacaswell.github.io/cycler/
 	https://pypi.python.org/pypi/Cycler/
-	http://github.com/matplotlib/cycler"
+	https://github.com/matplotlib/cycler"
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${P}.tar.gz"
 
 SLOT="0"

--- a/dev-python/doctest-ignore-unicode/doctest-ignore-unicode-0.1.2.ebuild
+++ b/dev-python/doctest-ignore-unicode/doctest-ignore-unicode-0.1.2.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} pypy pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Add flag to ignore unicode literal prefixes in doctests"
-HOMEPAGE="https://pypi.python.org/pypi/doctest-ignore-unicode http://github.com/gnublade/doctest-ignore-unicode"
+HOMEPAGE="https://pypi.python.org/pypi/doctest-ignore-unicode https://github.com/gnublade/doctest-ignore-unicode"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 SLOT="0"

--- a/dev-python/flexx/flexx-0.2.ebuild
+++ b/dev-python/flexx/flexx-0.2.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1
 DESCRIPTION="Pure Python toolkit for creating GUI's using web technology"
 HOMEPAGE="
 	http://flexx.readthedocs.org
-	http://github.com/zoofio/flexx
+	https://github.com/zoofio/flexx
 	http://pypi.python.org/pypi/flexx"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.zip"
 

--- a/dev-python/flexx/flexx-0.3.1.ebuild
+++ b/dev-python/flexx/flexx-0.3.1.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1
 DESCRIPTION="Pure Python toolkit for creating GUI's using web technology"
 HOMEPAGE="
 	http://flexx.readthedocs.org
-	http://github.com/zoofio/flexx
+	https://github.com/zoofio/flexx
 	http://pypi.python.org/pypi/flexx"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.zip"
 

--- a/dev-python/flexx/flexx-0.3.ebuild
+++ b/dev-python/flexx/flexx-0.3.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1
 DESCRIPTION="Pure Python toolkit for creating GUI's using web technology"
 HOMEPAGE="
 	http://flexx.readthedocs.org
-	http://github.com/zoofio/flexx
+	https://github.com/zoofio/flexx
 	http://pypi.python.org/pypi/flexx"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.zip"
 

--- a/dev-python/httreplay/httreplay-0.2.0.ebuild
+++ b/dev-python/httreplay/httreplay-0.2.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} pypy pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="A HTTP replay library for testing."
-HOMEPAGE="http://github.com/agriffis/httreplay http://pypi.python.org/pypi/httreplay"
+HOMEPAGE="https://github.com/agriffis/httreplay http://pypi.python.org/pypi/httreplay"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/jsonschema/jsonschema-2.5.1-r2.ebuild
+++ b/dev-python/jsonschema/jsonschema-2.5.1-r2.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} pypy pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="An implementation of JSON-Schema validation for Python"
-HOMEPAGE="https://pypi.python.org/pypi/jsonschema http://github.com/Julian/jsonschema"
+HOMEPAGE="https://pypi.python.org/pypi/jsonschema https://github.com/Julian/jsonschema"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/locket/locket-0.2.0.ebuild
+++ b/dev-python/locket/locket-0.2.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5} )
 inherit distutils-r1
 
 DESCRIPTION="File-based locks for Python"
-HOMEPAGE="http://github.com/mwilliamson/locket.py"
+HOMEPAGE="https://github.com/mwilliamson/locket.py"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/oct2py/oct2py-3.3.3.ebuild
+++ b/dev-python/oct2py/oct2py-3.3.3.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Python to GNU Octave bridge"
 HOMEPAGE="
 	https://pypi.python.org/pypi/oct2py
 	http://pythonhosted.org/oct2py/
-	http://github.com/blink1073/oct2py"
+	https://github.com/blink1073/oct2py"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/partd/partd-0.3.2.ebuild
+++ b/dev-python/partd/partd-0.3.2.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5} )
 inherit distutils-r1
 
 DESCRIPTION="Appendable key-value storage"
-HOMEPAGE="http://github.com/dask/partd/"
+HOMEPAGE="https://github.com/dask/partd/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/pyrsistent/pyrsistent-0.11.12.ebuild
+++ b/dev-python/pyrsistent/pyrsistent-0.11.12.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} pypy pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Persistent/Functional/Immutable data structures"
-HOMEPAGE="http://github.com/tobgu/pyrsistent/ http://pypi.python.org/pypi/pyrsistent"
+HOMEPAGE="https://github.com/tobgu/pyrsistent/ http://pypi.python.org/pypi/pyrsistent"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/python-spidermonkey/python-spidermonkey-0.0.10.ebuild
+++ b/dev-python/python-spidermonkey/python-spidermonkey-0.0.10.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=(python2_7)
 inherit distutils-r1
 
 DESCRIPTION="JavaScript / Python bridge"
-HOMEPAGE="http://github.com/davisp/python-spidermonkey"
+HOMEPAGE="https://github.com/davisp/python-spidermonkey"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/python_orocos_kdl/python_orocos_kdl-1.3.0-r1.ebuild
+++ b/dev-python/python_orocos_kdl/python_orocos_kdl-1.3.0-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/orocos/orocos_kinematics_dynamics"
+	EGIT_REPO_URI="https://github.com/orocos/orocos_kinematics_dynamics"
 fi
 
 inherit ${SCM} python-r1 cmake-utils
@@ -18,7 +18,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 else
 	KEYWORDS="~amd64 ~arm"
-	SRC_URI="http://github.com/orocos/orocos_kinematics_dynamics/archive/v${PV}.tar.gz -> orocos_kinematics_dynamics-${PV}.tar.gz"
+	SRC_URI="https://github.com/orocos/orocos_kinematics_dynamics/archive/v${PV}.tar.gz -> orocos_kinematics_dynamics-${PV}.tar.gz"
 fi
 
 DESCRIPTION="Python bindings for KDL"

--- a/dev-python/python_orocos_kdl/python_orocos_kdl-9999.ebuild
+++ b/dev-python/python_orocos_kdl/python_orocos_kdl-9999.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/orocos/orocos_kinematics_dynamics"
+	EGIT_REPO_URI="https://github.com/orocos/orocos_kinematics_dynamics"
 fi
 
 inherit ${SCM} python-r1 cmake-utils
@@ -18,7 +18,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 else
 	KEYWORDS="~amd64 ~arm"
-	SRC_URI="http://github.com/orocos/orocos_kinematics_dynamics/archive/v${PV}.tar.gz -> orocos_kinematics_dynamics-${PV}.tar.gz"
+	SRC_URI="https://github.com/orocos/orocos_kinematics_dynamics/archive/v${PV}.tar.gz -> orocos_kinematics_dynamics-${PV}.tar.gz"
 fi
 
 DESCRIPTION="Python bindings for KDL"

--- a/dev-python/rosdistro/rosdistro-0.4.4.ebuild
+++ b/dev-python/rosdistro/rosdistro-0.4.4.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rosdistro/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rosdistro/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/rosdistro/rosdistro-0.4.5.ebuild
+++ b/dev-python/rosdistro/rosdistro-0.4.5.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rosdistro/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rosdistro/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/rosdistro/rosdistro-0.4.7.ebuild
+++ b/dev-python/rosdistro/rosdistro-0.4.7.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rosdistro/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rosdistro/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/rosdistro/rosdistro-9999.ebuild
+++ b/dev-python/rosdistro/rosdistro-9999.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rosdistro/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rosdistro/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/rospkg/rospkg-1.0.38.ebuild
+++ b/dev-python/rospkg/rospkg-1.0.38.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros-infrastructure/rospkg"
+	EGIT_REPO_URI="https://github.com/ros-infrastructure/rospkg"
 fi
 
 inherit ${SCM} distutils-r1
@@ -23,7 +23,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	EGIT_CHECKOUT_DIR="${S}"
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rospkg/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rospkg/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/rospkg/rospkg-1.0.39.ebuild
+++ b/dev-python/rospkg/rospkg-1.0.39.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros-infrastructure/rospkg"
+	EGIT_REPO_URI="https://github.com/ros-infrastructure/rospkg"
 fi
 
 inherit ${SCM} distutils-r1
@@ -23,7 +23,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	EGIT_CHECKOUT_DIR="${S}"
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rospkg/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rospkg/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/rospkg/rospkg-9999.ebuild
+++ b/dev-python/rospkg/rospkg-9999.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros-infrastructure/rospkg"
+	EGIT_REPO_URI="https://github.com/ros-infrastructure/rospkg"
 fi
 
 inherit ${SCM} distutils-r1
@@ -23,7 +23,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	EGIT_CHECKOUT_DIR="${S}"
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rospkg/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rospkg/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/vcstools/vcstools-0.1.38.ebuild
+++ b/dev-python/vcstools/vcstools-0.1.38.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/vcstools/vcstools/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/vcstools/vcstools/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-python/vcstools/vcstools-9999.ebuild
+++ b/dev-python/vcstools/vcstools-9999.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/vcstools/vcstools/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/vcstools/vcstools/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-util/catkin/catkin-0.6.16-r2.ebuild
+++ b/dev-util/catkin/catkin-0.6.16-r2.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros/catkin"
+	EGIT_REPO_URI="https://github.com/ros/catkin"
 fi
 
 PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 	KEYWORDS=""
 else
-	SRC_URI="http://github.com/ros/catkin/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/ros/catkin/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm"
 fi
 

--- a/dev-util/catkin/catkin-0.7.0.ebuild
+++ b/dev-util/catkin/catkin-0.7.0.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros/catkin"
+	EGIT_REPO_URI="https://github.com/ros/catkin"
 fi
 
 PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 	KEYWORDS=""
 else
-	SRC_URI="http://github.com/ros/catkin/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/ros/catkin/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm"
 fi
 

--- a/dev-util/catkin/catkin-0.7.1.ebuild
+++ b/dev-util/catkin/catkin-0.7.1.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros/catkin"
+	EGIT_REPO_URI="https://github.com/ros/catkin"
 fi
 
 PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 	KEYWORDS=""
 else
-	SRC_URI="http://github.com/ros/catkin/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/ros/catkin/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm"
 fi
 

--- a/dev-util/catkin/catkin-9999.ebuild
+++ b/dev-util/catkin/catkin-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SCM="git-r3"
-	EGIT_REPO_URI="http://github.com/ros/catkin"
+	EGIT_REPO_URI="https://github.com/ros/catkin"
 fi
 
 PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 	KEYWORDS=""
 else
-	SRC_URI="http://github.com/ros/catkin/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/ros/catkin/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm"
 fi
 

--- a/dev-util/metro/metro-1.5.1.ebuild
+++ b/dev-util/metro/metro-1.5.1.ebuild
@@ -7,7 +7,7 @@ PYTHON_DEPEND="2"
 inherit python
 
 DESCRIPTION="release metatool used for creating Gentoo and Funtoo releases"
-HOMEPAGE="https://www.github.com/funtoo/metro"
+HOMEPAGE="https://github.com/funtoo/metro"
 SRC_URI="http://www.funtoo.org/archive/metro/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/dev-util/rosdep/rosdep-0.11.4.ebuild
+++ b/dev-util/rosdep/rosdep-0.11.4.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rosdep/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rosdep/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-util/rosdep/rosdep-0.11.5.ebuild
+++ b/dev-util/rosdep/rosdep-0.11.5.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rosdep/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rosdep/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-util/rosdep/rosdep-9999.ebuild
+++ b/dev-util/rosdep/rosdep-9999.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/ros-infrastructure/rosdep/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/ros-infrastructure/rosdep/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-util/wstool/wstool-0.1.10.ebuild
+++ b/dev-util/wstool/wstool-0.1.10.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/vcstools/wstool/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/vcstools/wstool/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-util/wstool/wstool-0.1.12.ebuild
+++ b/dev-util/wstool/wstool-0.1.12.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/vcstools/wstool/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/vcstools/wstool/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-util/wstool/wstool-0.1.13.ebuild
+++ b/dev-util/wstool/wstool-0.1.13.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/vcstools/wstool/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/vcstools/wstool/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/dev-util/wstool/wstool-9999.ebuild
+++ b/dev-util/wstool/wstool-9999.ebuild
@@ -20,7 +20,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	KEYWORDS=""
 else
 	SRC_URI="http://download.ros.org/downloads/${PN}/${P}.tar.gz
-		http://github.com/vcstools/wstool/archive/${PV}.tar.gz -> ${P}.tar.gz
+		https://github.com/vcstools/wstool/archive/${PV}.tar.gz -> ${P}.tar.gz
 	"
 	KEYWORDS="~amd64 ~arm"
 fi

--- a/eclass/go-mono.eclass
+++ b/eclass/go-mono.eclass
@@ -32,13 +32,13 @@ then
 elif [[ "${PV}" == "9999" ]]
 then
 	GO_MONO_P=${P}
-	EGIT_REPO_URI="http://github.com/mono/${GIT_PN}.git"
+	EGIT_REPO_URI="https://github.com/mono/${GIT_PN}.git"
 	SRC_URI=""
 	inherit autotools git
 elif [[ "${PV%.9999}" != "${PV}" ]]
 then
 	GO_MONO_P=${P}
-	EGIT_REPO_URI="http://github.com/mono/${GIT_PN}.git"
+	EGIT_REPO_URI="https://github.com/mono/${GIT_PN}.git"
 	EGIT_BRANCH="mono-$(get_version_component_range 1)-$(get_version_component_range 2)${GO_MONO_SUB_BRANCH}"
 	SRC_URI=""
 	inherit autotools git

--- a/games-action/minetest/minetest-0.4.13.ebuild
+++ b/games-action/minetest/minetest-0.4.13.ebuild
@@ -7,7 +7,7 @@ inherit cmake-utils eutils gnome2-utils user vcs-snapshot
 
 DESCRIPTION="An InfiniMiner/Minecraft inspired game"
 HOMEPAGE="http://minetest.net/"
-SRC_URI="http://github.com/minetest/minetest/tarball/${PV} -> ${P}.tar.gz"
+SRC_URI="https://github.com/minetest/minetest/tarball/${PV} -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1+ CC-BY-SA-3.0 OFL-1.1 Apache-2.0"
 SLOT="0"

--- a/games-action/minetest_game/minetest_game-0.4.13.ebuild
+++ b/games-action/minetest_game/minetest_game-0.4.13.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit vcs-snapshot
 
 DESCRIPTION="The main game for the Minetest game engine"
-HOMEPAGE="http://github.com/minetest/minetest_game"
-SRC_URI="http://github.com/minetest/minetest_game/tarball/${PV} -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/minetest/minetest_game"
+SRC_URI="https://github.com/minetest/minetest_game/tarball/${PV} -> ${P}.tar.gz"
 
 LICENSE="GPL-2 CC-BY-SA-3.0"
 SLOT="0"

--- a/games-action/minetest_game/minetest_game-0.4.14.ebuild
+++ b/games-action/minetest_game/minetest_game-0.4.14.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit vcs-snapshot
 
 DESCRIPTION="The main game for the Minetest game engine"
-HOMEPAGE="http://github.com/minetest/minetest_game"
+HOMEPAGE="https://github.com/minetest/minetest_game"
 SRC_URI="https://github.com/minetest/${PN}/tarball/${PV} -> ${P}.tar.gz"
 
 LICENSE="GPL-2 CC-BY-SA-3.0"

--- a/media-libs/opencollada/opencollada-9999.ebuild
+++ b/media-libs/opencollada/opencollada-9999.ebuild
@@ -30,7 +30,7 @@ if [[ ${PV} != *9999* ]]; then
 	SRC_URI="https://github.com/KhronosGroup/OpenCOLLADA/tarball/${COMMIT} -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~ppc64 ~x86"
 else
-	EGIT_REPO_URI="http://github.com/KhronosGroup/OpenCOLLADA.git"
+	EGIT_REPO_URI="https://github.com/KhronosGroup/OpenCOLLADA.git"
 fi
 
 RDEPEND="dev-libs/libpcre

--- a/net-irc/inspircd/inspircd-2.0.20.ebuild
+++ b/net-irc/inspircd/inspircd-2.0.20.ebuild
@@ -8,7 +8,7 @@ inherit eutils multilib toolchain-funcs user
 
 DESCRIPTION="Inspire IRCd - The Stable, High-Performance Modular IRCd"
 HOMEPAGE="https://inspircd.github.com/"
-SRC_URI="https://www.github.com/inspircd/inspircd/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/inspircd/inspircd/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-irc/inspircd/inspircd-2.0.21.ebuild
+++ b/net-irc/inspircd/inspircd-2.0.21.ebuild
@@ -8,7 +8,7 @@ inherit toolchain-funcs user
 
 DESCRIPTION="Inspire IRCd - The Stable, High-Performance Modular IRCd"
 HOMEPAGE="https://inspircd.github.com/"
-SRC_URI="https://www.github.com/inspircd/inspircd/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/inspircd/inspircd/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/whatportis/whatportis-0.2.ebuild
+++ b/net-misc/whatportis/whatportis-0.2.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
 inherit distutils-r1
 
 DESCRIPTION="A command to search port names and numbers"
-HOMEPAGE="http://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
+HOMEPAGE="https://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/net-misc/whatportis/whatportis-0.3.ebuild
+++ b/net-misc/whatportis/whatportis-0.3.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
 inherit distutils-r1
 
 DESCRIPTION="A command to search port names and numbers"
-HOMEPAGE="http://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
+HOMEPAGE="https://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/net-misc/whatportis/whatportis-0.4.ebuild
+++ b/net-misc/whatportis/whatportis-0.4.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5} )
 inherit distutils-r1
 
 DESCRIPTION="A command to search port names and numbers"
-HOMEPAGE="http://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
+HOMEPAGE="https://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/net-misc/whatportis/whatportis-0.5.ebuild
+++ b/net-misc/whatportis/whatportis-0.5.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python{2_7,3_{3,4,5}} )
 inherit distutils-r1
 
 DESCRIPTION="A command to search port names and numbers"
-HOMEPAGE="http://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
+HOMEPAGE="https://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/net-misc/whatportis/whatportis-0.6.ebuild
+++ b/net-misc/whatportis/whatportis-0.6.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python{2_7,3_{3,4,5}} )
 inherit distutils-r1 eutils
 
 DESCRIPTION="A command to search port names and numbers"
-HOMEPAGE="http://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
+HOMEPAGE="https://github.com/ncrocfer/whatportis http://pypi.python.org/pypi/whatportis"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/www-client/pybugz/pybugz-0.12.1.ebuild
+++ b/www-client/pybugz/pybugz-0.12.1.ebuild
@@ -19,7 +19,7 @@ fi
 inherit bash-completion-r1 distutils-r1
 
 DESCRIPTION="Command line interface to (Gentoo) Bugzilla"
-HOMEPAGE="https://www.github.com/williamh/pybugz"
+HOMEPAGE="https://github.com/williamh/pybugz"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="zsh-completion"

--- a/www-client/pybugz/pybugz-9999.ebuild
+++ b/www-client/pybugz/pybugz-9999.ebuild
@@ -19,7 +19,7 @@ fi
 inherit bash-completion-r1 distutils-r1
 
 DESCRIPTION="Command line interface to (Gentoo) Bugzilla"
-HOMEPAGE="https://www.github.com/williamh/pybugz"
+HOMEPAGE="https://github.com/williamh/pybugz"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="zsh-completion"


### PR DESCRIPTION
All links to www.github.com were changed to github.com (preferred by GitHub).

During the automated testing of all modified packages the following SRC_URIs
were discovered to have changed upstream. Upon closer inspection they were
all confirmed to not be regressions. They will all continue to work when
served from the mirrors.

* dev-python/catkin_pkg-0.2.10 (upstream tarball changed)
* dev-python/rosdistro-0.4.4 (upstream tarball changed)
* dev-util/rosdep-0.11.4 (upstream tarball changed)
* dev-util/wstool-0.1.12 (upstream tarball changed)
* dev-util/wstool-0.1.13 (upstream tarball changed)

@jlec 