### PR TITLE
app-editors/atom: Fix apm under Node 5+ (#584000)

### DIFF
--- a/app-editors/atom/atom-1.7.4-r1.ebuild
+++ b/app-editors/atom/atom-1.7.4-r1.ebuild
@@ -279,6 +279,7 @@ src_prepare() {
 	cd "${S}" || die
 
 	epatch "${FILESDIR}/atom-apm-path.patch"
+	epatch "${FILESDIR}/asar-require.patch"
 
 	sed -i -e "s|{{ATOM_SUFFIX}}|${suffix}|g" \
 		"${S}/build/app.asar/src/config-schema.js" || die

--- a/app-editors/atom/files/asar-require.patch
+++ b/app-editors/atom/files/asar-require.patch
@@ -1,0 +1,45 @@
+diff --git a/usr/share/atom/resources/app/apm/node_modules/asar-require/lib/require.js b/usr/share/atom/resources/app/apm/node_modules/asar-require/lib/require.js
+index 47cb1bb..67895d5 100644
+--- a/usr/share/atom/resources/app/apm/node_modules/asar-require/lib/require.js
++++ b/usr/share/atom/resources/app/apm/node_modules/asar-require/lib/require.js
+@@ -1,5 +1,7 @@
+ (function() {
+-  var asar, asarStatsToFsStats, fakeTime, fs, gid, nextInode, path, readFileSync, realpathSync, splitPath, statSync, uid;
++  var asar, asarStatsToFsStats, fakeTime, fs, gid, nextInode, path, readFileSync, realpathSync, splitPath, statSync, uid;
++
++  var module, module_findPath, _e;
+
+   asar = require('asar');
+
+@@ -7,6 +9,12 @@
+
+   path = require('path');
+
++  try {
++    module = require('module');
++  } catch (_e) {
++    module = null;
++  }
++
+   splitPath = function(p) {
+     var index;
+     if (typeof p !== 'string') {
+@@ -124,5 +132,18 @@
+     }
+     return path.join(realpathSync(asarPath), filePath);
+   };
++
++  if (module && module._findPath) {
++    module_findPath = module._findPath;
++
++    module._findPath = function(request, paths, isMain) {
++      var asarPath, filePath, isAsar, _ref;
++      _ref = splitPath(request), isAsar = _ref[0], asarPath = _ref[1], filePath = _ref[2];
++      if (isAsar) {
++        return request;
++      }
++      return module_findPath.apply(this, arguments);
++    }
++  }
+
+ }).call(this);


### PR DESCRIPTION
apm monkey-patches Node's module system to add support for module loading
from "asar" archives.  Add a case to make this work under Node 5+.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=584000

Package-Manager: portage-2.2.28