### PR TITLE
sys-auth/rtkit: fix compile-time dependencies

### DIFF
--- a/sys-auth/rtkit/rtkit-0.11-r1.ebuild
+++ b/sys-auth/rtkit/rtkit-0.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -19,9 +19,7 @@ RDEPEND="
 	sys-auth/polkit
 	sys-libs/libcap
 "
-DEPEND="${DEPEND}
-	app-arch/xz-utils
-"
+DEPEND="${RDEPEND}"
 
 pkg_setup() {
 	enewgroup rtkit

--- a/sys-auth/rtkit/rtkit-0.11-r2.ebuild
+++ b/sys-auth/rtkit/rtkit-0.11-r2.ebuild
@@ -19,9 +19,7 @@ RDEPEND="
 	sys-auth/polkit
 	sys-libs/libcap
 "
-DEPEND="${DEPEND}
-	app-arch/xz-utils
-"
+DEPEND="${RDEPEND}"
 
 PATCHES=(
 	# Fedora patches


### PR DESCRIPTION
Due to a typo, rtkit ebuilds never actually included RDEPEND into their
compile-dependencies. This could lead to build failures for some users.
Fix the typo.

Moreover, app-arch/xz-utils are (now) in the system set so no need to
explicitly depend on this package.

Package-Manager: portage-2.3.0_rc1