### PR TITLE
 mail-filter/spamassassin: merge upstream patches + cleanup

### DIFF
--- a/mail-filter/spamassassin/files/spamassassin-3.4.0-dnsresolver-bug579222.patch
+++ b/mail-filter/spamassassin/files/spamassassin-3.4.0-dnsresolver-bug579222.patch
@@ -1,0 +1,30 @@
+# Fix for Gentoo bug 579222 in 3.4.0.  
+# Patch Sources:
+# https://svn.apache.org/viewvc/spamassassin/trunk/lib/Mail/SpamAssassin/DnsResolver.pm?r1=1603518&r2=1603517&pathrev=1603518&view=patch
+# https://svn.apache.org/viewvc/spamassassin/branches/3.4/lib/Mail/SpamAssassin/DnsResolver.pm?r1=1691992&r2=1691991&pathrev=1691992&view=patch
+
+--- spamassassin/trunk/lib/Mail/SpamAssassin/DnsResolver.pm	2014/06/18 16:47:04	1603517
++++ spamassassin/trunk/lib/Mail/SpamAssassin/DnsResolver.pm	2014/06/18 16:48:04	1603518
+@@ -204,8 +204,10 @@
+     @ns_addr_port = @{$self->{conf}->{dns_servers}};
+     dbg("dns: servers set by config to: %s", join(', ',@ns_addr_port));
+   } elsif ($res) {  # default as provided by Net::DNS, e.g. /etc/resolv.conf
+-    @ns_addr_port = map(untaint_var("[$_]:" . $res->{port}),
+-                        @{$res->{nameservers}});
++    my @ns = $res->UNIVERSAL::can('nameservers') ? $res->nameservers
++                                                 : @{$res->{nameservers}};
++    my $port = $res->UNIVERSAL::can('port') ? $res->port : $res->{port};
++    @ns_addr_port = map(untaint_var("[$_]:" . $port), @ns);
+     dbg("dns: servers obtained from Net::DNS : %s", join(', ',@ns_addr_port));
+   }
+   return @ns_addr_port;
+@@ -592,6 +592,9 @@
+   };
+ 
+   if ($packet) {
++    # RD flag needs to be set explicitly since Net::DNS 1.01, Bug 7223	
++    $packet->header->rd(1);
++
+   # my $udp_payload_size = $self->{res}->udppacketsize;
+     my $udp_payload_size = $self->{conf}->{dns_options}->{edns};
+     if ($udp_payload_size && $udp_payload_size > 512) {

--- a/mail-filter/spamassassin/files/spamassassin-3.4.1-dnsresolver-bug579222.patch
+++ b/mail-filter/spamassassin/files/spamassassin-3.4.1-dnsresolver-bug579222.patch
@@ -1,0 +1,14 @@
+# Fix for Gentoo bug 579222.  Patch Source: https://svn.apache.org/viewvc/spamassassin/branches/3.4/lib/Mail/SpamAssassin/DnsResolver.pm?r1=1691992&r2=1691991&pathrev=1691992&view=patch
+
+--- spamassassin/branches/3.4/lib/Mail/SpamAssassin/DnsResolver.pm	2015/07/20 18:23:18	1691991
++++ spamassassin/branches/3.4/lib/Mail/SpamAssassin/DnsResolver.pm	2015/07/20 18:24:48	1691992
+@@ -592,6 +592,9 @@
+   };
+ 
+   if ($packet) {
++    # RD flag needs to be set explicitly since Net::DNS 1.01, Bug 7223	
++    $packet->header->rd(1);
++
+   # my $udp_payload_size = $self->{res}->udppacketsize;
+     my $udp_payload_size = $self->{conf}->{dns_options}->{edns};
+     if ($udp_payload_size && $udp_payload_size > 512) {

--- a/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
@@ -1,0 +1,217 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit perl-module toolchain-funcs eutils systemd readme.gentoo
+
+MY_P=Mail-SpamAssassin-${PV//_/-}
+S=${WORKDIR}/${MY_P}
+DESCRIPTION="SpamAssassin is an extensible email filter which is used to identify spam"
+HOMEPAGE="http://spamassassin.apache.org/"
+SRC_URI="mirror://apache/spamassassin/source/${MY_P}.tar.bz2"
+
+LICENSE="Apache-2.0 GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos"
+IUSE="+berkdb qmail ssl doc ldap mysql postgres sqlite ipv6"
+
+REQUIRED_USE="|| ( berkdb mysql postgres sqlite )"
+
+DEPEND=">=dev-lang/perl-5.8.8-r8
+	virtual/perl-MIME-Base64
+	>=virtual/perl-Pod-Parser-1.510.0-r2
+	virtual/perl-Storable
+	virtual/perl-Time-HiRes
+	>=dev-perl/HTML-Parser-3.43
+	>=dev-perl/Mail-DKIM-0.37
+	>=dev-perl/Net-DNS-0.53
+	dev-perl/Digest-SHA1
+	dev-perl/libwww-perl
+	>=virtual/perl-Archive-Tar-1.23
+	app-crypt/gnupg
+	>=virtual/perl-IO-Zlib-1.04
+	>=dev-util/re2c-0.12.0
+	dev-perl/Mail-SPF
+	>=dev-perl/NetAddr-IP-4.0.1
+	dev-perl/Geo-IP
+	dev-perl/Encode-Detect
+	dev-perl/Net-Patricia
+	ssl? (
+		dev-perl/IO-Socket-SSL
+		dev-libs/openssl:0
+	)
+	berkdb? (
+		virtual/perl-DB_File
+	)
+	ldap? ( dev-perl/perl-ldap )
+	mysql? (
+		dev-perl/DBI
+		dev-perl/DBD-mysql
+	)
+	postgres? (
+		dev-perl/DBI
+		dev-perl/DBD-Pg
+	)
+	sqlite? (
+		dev-perl/DBI
+		dev-perl/DBD-SQLite
+	)
+	ipv6? (
+		|| ( dev-perl/IO-Socket-INET6
+			virtual/perl-IO-Socket-IP )
+	)"
+RDEPEND="${DEPEND}"
+
+SRC_TEST="do"
+
+src_prepare() {
+	epatch "${FILESDIR}/spamassassin-3.4.0-dnsresolver-bug579222.patch"
+	perl-module_src_prepare
+}
+
+src_configure() {
+	# - Set SYSCONFDIR explicitly so we can't get bitten by bug 48205 again
+	#	(just to be sure, nobody knows how it could happen in the first place).
+	myconf="SYSCONFDIR=${EPREFIX}/etc DATADIR=${EPREFIX}/usr/share/spamassassin"
+
+	# If ssl is enabled, spamc can be built with ssl support
+	if use ssl; then
+		myconf+=" ENABLE_SSL=yes"
+	else
+		myconf+=" ENABLE_SSL=no"
+	fi
+
+	# Set the path to the Perl executable explictly.  This will be used to
+	# create the initial sharpbang line in the scripts and might cause
+	# a versioned app name end in there, see
+	# <https://bugs.gentoo.org/show_bug.cgi?id=62276>
+	myconf+=" PERL_BIN=${EPREFIX}/usr/bin/perl"
+
+	# Add Gentoo tag to make it easy for the upstream devs to spot
+	# possible modifications or patches.
+	#version_tag="g${PV:6}${PR}"
+	#version_str="${PV//_/-}-${version_tag}"
+
+	# Create the Gentoo config file before Makefile.PL is called so it
+	# is copied later on.
+	#echo "version_tag ${version_tag}" > rules/11_gentoo.cf
+
+	# Setting the following env var ensures that no questions are asked.
+	perl-module_src_configure
+	# Configure spamc
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}" spamc/Makefile
+}
+
+src_compile() {
+	export PERL_MM_USE_DEFAULT=1
+
+	# Now compile all the stuff selected.
+	perl-module_src_compile
+
+	if use qmail; then
+		emake spamc/qmail-spamc
+	fi
+
+}
+
+src_install () {
+	perl-module_src_install
+
+	# Create the stub dir used by sa-update and friends
+	keepdir /var/lib/spamassassin
+
+	# Move spamd to sbin where it belongs.
+	dodir /usr/sbin
+	mv "${ED}"/usr/bin/spamd "${ED}"/usr/sbin/spamd  || die "move spamd failed"
+
+	if use qmail; then
+		dobin spamc/qmail-spamc
+	fi
+
+	ln -s mail/spamassassin "${ED}"/etc/spamassassin || die
+
+	# Disable plugin by default
+	sed -i -e 's/^loadplugin/\#loadplugin/g' "${ED}"/etc/mail/spamassassin/init.pre || die
+
+	# Add the init and config scripts.
+	newinitd "${FILESDIR}"/3.3.1-spamd.init spamd
+	newconfd "${FILESDIR}"/3.0.0-spamd.conf spamd
+
+	systemd_newunit "${FILESDIR}"/${PN}.service-r1 ${PN}.service
+	systemd_install_serviced "${FILESDIR}"/${PN}.service.conf
+
+	if use postgres; then
+		sed -i -e 's:@USEPOSTGRES@::' "${ED}/etc/init.d/spamd" || die
+
+		dodoc sql/*_pg.sql
+	else
+		sed -i -e '/@USEPOSTGRES@/d' "${ED}/etc/init.d/spamd" || die
+	fi
+
+	if use mysql; then
+		sed -i -e 's:@USEMYSQL@::' "${ED}/etc/init.d/spamd" || die
+
+		dodoc sql/*_mysql.sql
+	else
+		sed -i -e '/@USEMYSQL@/d' "${ED}/etc/init.d/spamd" || die
+	fi
+
+	dodoc NOTICE TRADEMARK CREDITS INSTALL.VMS UPGRADE USAGE \
+		sql/README.bayes sql/README.awl procmailrc.example sample-nonspam.txt \
+		sample-spam.txt spamd/PROTOCOL spamd/README.vpopmail \
+		spamd-apache2/README.apache
+
+	# Rename some docu files so they don't clash with others
+	newdoc spamd/README README.spamd
+	newdoc sql/README README.sql
+	newdoc ldap/README README.ldap
+
+	if use qmail; then
+		dodoc spamc/README.qmail
+	fi
+
+	cp "${FILESDIR}"/secrets.cf "${ED}"/etc/mail/spamassassin/secrets.cf.example || die
+	fperms 0400 /etc/mail/spamassassin/secrets.cf.example
+
+	cat <<-EOF > "${T}/local.cf.example"
+		# Sensitive data, such as database connection info, should be stored in
+		# /etc/mail/spamassassin/secrets.cf with appropriate permissions
+EOF
+
+	insinto /etc/mail/spamassassin/
+	doins "${T}/local.cf.example"
+}
+
+pkg_postinst() {
+	elog "If you plan on using the -u flag to spamd, please read the notes"
+	elog "in /etc/conf.d/spamd regarding the location of the pid file.\n"
+	elog "If you build ${PN} with optional dependancy support,"
+	elog "you can enable them in /etc/mail/spamassassin/init.pre\n"
+	elog "You need to configure your database to be able to use Bayes filter"
+	elog "with database backend, otherwise it will still use (and need) the"
+	elog "Berkeley DB support."
+	elog "Look at the sql/README.bayes file in the documentation directory"
+	elog "for how to configure it.\n"
+	elog "If you plan to use Vipul's Razor, note that versions up to and"
+	elog "including version 2.82 include a bug that will slow down the entire"
+	elog "perl interpreter.  Version 2.83 or later fixes this."
+	elog "If you do not plan to use this plugin, be sure to comment out"
+	elog "its loadplugin line in /etc/mail/spamassassin/v310.pre.\n"
+	elog "The DKIM plugin is now enabled by default for new installs,"
+	elog "if the perl module Mail::DKIM is installed."
+	elog "However, installation of SpamAssassin will not overwrite existing"
+	elog ".pre configuration files, so to use DKIM when upgrading from a"
+	elog "previous release that did not use DKIM, a directive:\n"
+	elog "loadplugin Mail::SpamAssassin::Plugin::DKIM"
+	elog "will need to be uncommented in file 'v312.pre', or added"
+	elog "to some other .pre file, such as local.pre.\n"
+	ewarn "Rules are no longer included with SpamAssassin out of the box".
+	ewarn "You will need to immediately run sa-update, or download"
+	ewarn "the additional rules .tgz package and run sa-update --install"
+	ewarn "with it, to get a ruleset.\n"
+	elog "If you run sa-update and receive a GPG validation error."
+	elog "Then you need to import an updated sa-update key."
+	elog "sa-update --import /usr/share/spamassassin/sa-update-pubkey.txt\n"
+}

--- a/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
@@ -187,9 +187,9 @@ EOF
 
 pkg_postinst() {
 	elog "If you plan on using the -u flag to spamd, please read the notes"
-	elog "in ${EROOT}/etc/conf.d/spamd regarding the location of the pid file.\n"
+	elog "in ${EROOT%/}/etc/conf.d/spamd regarding the location of the pid file.\n"
 	elog "If you build ${PN} with optional dependancy support,"
-	elog "you can enable them in ${EROOT}/etc/mail/spamassassin/init.pre\n"
+	elog "you can enable them in ${EROOT%/}/etc/mail/spamassassin/init.pre\n"
 	elog "You need to configure your database to be able to use Bayes filter"
 	elog "with database backend, otherwise it will still use (and need) the"
 	elog "Berkeley DB support."
@@ -199,7 +199,7 @@ pkg_postinst() {
 	elog "including version 2.82 include a bug that will slow down the entire"
 	elog "perl interpreter.  Version 2.83 or later fixes this."
 	elog "If you do not plan to use this plugin, be sure to comment out"
-	elog "its loadplugin line in ${EROOT}/etc/mail/spamassassin/v310.pre.\n"
+	elog "its loadplugin line in ${EROOT%/}/etc/mail/spamassassin/v310.pre.\n"
 	elog "The DKIM plugin is now enabled by default for new installs,"
 	elog "if the perl module Mail::DKIM is installed."
 	elog "However, installation of SpamAssassin will not overwrite existing"
@@ -214,5 +214,5 @@ pkg_postinst() {
 	ewarn "with it, to get a ruleset.\n"
 	elog "If you run sa-update and receive a GPG validation error."
 	elog "Then you need to import an updated sa-update key."
-	elog "sa-update --import ${EROOT}/usr/share/spamassassin/sa-update-pubkey.txt\n"
+	elog "sa-update --import ${EROOT%/}/usr/share/spamassassin/sa-update-pubkey.txt\n"
 }

--- a/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
@@ -172,15 +172,16 @@ src_install () {
 		dodoc spamc/README.qmail
 	fi
 
-	cp "${FILESDIR}"/secrets.cf "${ED}"/etc/mail/spamassassin/secrets.cf.example || die
-	fperms 0400 /etc/mail/spamassassin/secrets.cf.example
+	insinto /etc/mail/spamassassin/
+	insopts -m0400
+	newins "${FILESDIR}"/secrets.cf secrets.cf.example
 
 	cat <<-EOF > "${T}/local.cf.example"
 		# Sensitive data, such as database connection info, should be stored in
 		# /etc/mail/spamassassin/secrets.cf with appropriate permissions
 EOF
 
-	insinto /etc/mail/spamassassin/
+	insopts -m0644
 	doins "${T}/local.cf.example"
 }
 

--- a/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
@@ -187,9 +187,9 @@ EOF
 
 pkg_postinst() {
 	elog "If you plan on using the -u flag to spamd, please read the notes"
-	elog "in ${EROOT%/}/etc/conf.d/spamd regarding the location of the pid file.\n"
+	elog "in ${EROOT}etc/conf.d/spamd regarding the location of the pid file.\n"
 	elog "If you build ${PN} with optional dependancy support,"
-	elog "you can enable them in ${EROOT%/}/etc/mail/spamassassin/init.pre\n"
+	elog "you can enable them in ${EROOT}etc/mail/spamassassin/init.pre\n"
 	elog "You need to configure your database to be able to use Bayes filter"
 	elog "with database backend, otherwise it will still use (and need) the"
 	elog "Berkeley DB support."
@@ -199,7 +199,7 @@ pkg_postinst() {
 	elog "including version 2.82 include a bug that will slow down the entire"
 	elog "perl interpreter.  Version 2.83 or later fixes this."
 	elog "If you do not plan to use this plugin, be sure to comment out"
-	elog "its loadplugin line in ${EROOT%/}/etc/mail/spamassassin/v310.pre.\n"
+	elog "its loadplugin line in ${EROOT}etc/mail/spamassassin/v310.pre.\n"
 	elog "The DKIM plugin is now enabled by default for new installs,"
 	elog "if the perl module Mail::DKIM is installed."
 	elog "However, installation of SpamAssassin will not overwrite existing"
@@ -214,5 +214,5 @@ pkg_postinst() {
 	ewarn "with it, to get a ruleset.\n"
 	elog "If you run sa-update and receive a GPG validation error."
 	elog "Then you need to import an updated sa-update key."
-	elog "sa-update --import ${EROOT%/}/usr/share/spamassassin/sa-update-pubkey.txt\n"
+	elog "sa-update --import ${EROOT}usr/share/spamassassin/sa-update-pubkey.txt\n"
 }

--- a/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
@@ -187,9 +187,9 @@ EOF
 
 pkg_postinst() {
 	elog "If you plan on using the -u flag to spamd, please read the notes"
-	elog "in /etc/conf.d/spamd regarding the location of the pid file.\n"
+	elog "in ${EROOT}/etc/conf.d/spamd regarding the location of the pid file.\n"
 	elog "If you build ${PN} with optional dependancy support,"
-	elog "you can enable them in /etc/mail/spamassassin/init.pre\n"
+	elog "you can enable them in ${EROOT}/etc/mail/spamassassin/init.pre\n"
 	elog "You need to configure your database to be able to use Bayes filter"
 	elog "with database backend, otherwise it will still use (and need) the"
 	elog "Berkeley DB support."
@@ -199,7 +199,7 @@ pkg_postinst() {
 	elog "including version 2.82 include a bug that will slow down the entire"
 	elog "perl interpreter.  Version 2.83 or later fixes this."
 	elog "If you do not plan to use this plugin, be sure to comment out"
-	elog "its loadplugin line in /etc/mail/spamassassin/v310.pre.\n"
+	elog "its loadplugin line in ${EROOT}/etc/mail/spamassassin/v310.pre.\n"
 	elog "The DKIM plugin is now enabled by default for new installs,"
 	elog "if the perl module Mail::DKIM is installed."
 	elog "However, installation of SpamAssassin will not overwrite existing"
@@ -214,5 +214,5 @@ pkg_postinst() {
 	ewarn "with it, to get a ruleset.\n"
 	elog "If you run sa-update and receive a GPG validation error."
 	elog "Then you need to import an updated sa-update key."
-	elog "sa-update --import /usr/share/spamassassin/sa-update-pubkey.txt\n"
+	elog "sa-update --import ${EROOT}/usr/share/spamassassin/sa-update-pubkey.txt\n"
 }

--- a/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
@@ -178,7 +178,7 @@ src_install () {
 
 	cat <<-EOF > "${T}/local.cf.example" || die
 		# Sensitive data, such as database connection info, should be stored in
-		# /etc/mail/spamassassin/secrets.cf with appropriate permissions
+		# ${EPREFIX}/etc/mail/spamassassin/secrets.cf with appropriate permissions
 EOF
 
 	insopts -m0644

--- a/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.0-r2.ebuild
@@ -176,7 +176,7 @@ src_install () {
 	insopts -m0400
 	newins "${FILESDIR}"/secrets.cf secrets.cf.example
 
-	cat <<-EOF > "${T}/local.cf.example"
+	cat <<-EOF > "${T}/local.cf.example" || die
 		# Sensitive data, such as database connection info, should be stored in
 		# /etc/mail/spamassassin/secrets.cf with appropriate permissions
 EOF

--- a/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
@@ -1,0 +1,223 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit perl-module toolchain-funcs eutils systemd readme.gentoo
+
+MY_P=Mail-SpamAssassin-${PV//_/-}
+S=${WORKDIR}/${MY_P}
+DESCRIPTION="An extensible mail filter which can identify and tag spam"
+HOMEPAGE="http://spamassassin.apache.org/"
+SRC_URI="mirror://apache/spamassassin/source/${MY_P}.tar.bz2"
+
+LICENSE="Apache-2.0 GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos"
+IUSE="+bayes berkdb libressl qmail ssl doc ldap mysql postgres sqlite ipv6"
+
+# You can do without a database unless you need the Bayes features.
+REQUIRED_USE="bayes? ( || ( berkdb mysql postgres sqlite ) )"
+
+DEPEND=">=dev-lang/perl-5.8.8-r8
+	virtual/perl-MIME-Base64
+	>=virtual/perl-Pod-Parser-1.510.0-r2
+	virtual/perl-Storable
+	virtual/perl-Time-HiRes
+	>=dev-perl/HTML-Parser-3.43
+	>=dev-perl/Mail-DKIM-0.37
+	>=dev-perl/Net-DNS-0.53
+	dev-perl/Digest-SHA1
+	dev-perl/libwww-perl
+	>=virtual/perl-Archive-Tar-1.23
+	app-crypt/gnupg
+	>=virtual/perl-IO-Zlib-1.04
+	>=dev-util/re2c-0.12.0
+	dev-perl/Mail-SPF
+	>=dev-perl/NetAddr-IP-4.0.1
+	dev-perl/Geo-IP
+	dev-perl/Encode-Detect
+	dev-perl/Net-Patricia
+	ssl? (
+		dev-perl/IO-Socket-SSL
+		!libressl? ( dev-libs/openssl:0 )
+		libressl? ( dev-libs/libressl )
+	)
+	berkdb? (
+		virtual/perl-DB_File
+	)
+	ldap? ( dev-perl/perl-ldap )
+	mysql? (
+		dev-perl/DBI
+		dev-perl/DBD-mysql
+	)
+	postgres? (
+		dev-perl/DBI
+		dev-perl/DBD-Pg
+	)
+	sqlite? (
+		dev-perl/DBI
+		dev-perl/DBD-SQLite
+	)
+	ipv6? (
+		|| ( dev-perl/IO-Socket-INET6
+			virtual/perl-IO-Socket-IP )
+	)"
+RDEPEND="${DEPEND}"
+
+SRC_TEST="do"
+
+src_prepare() {
+	# Merged upstream
+	#epatch "${FILESDIR}/net-dns-0.76_compatibility.patch"
+	epatch "${FILESDIR}/spamassassin-3.4.1-dnsresolver-bug579222.patch"
+	perl-module_src_prepare
+}
+
+src_configure() {
+	# - Set SYSCONFDIR explicitly so we can't get bitten by bug 48205 again
+	#	(just to be sure, nobody knows how it could happen in the first place).
+	myconf="SYSCONFDIR=${EPREFIX}/etc"
+	myconf+=" DATADIR=${EPREFIX}/usr/share/spamassassin"
+
+	# If ssl is enabled, spamc can be built with ssl support.
+	if use ssl; then
+		myconf+=" ENABLE_SSL=yes"
+	else
+		myconf+=" ENABLE_SSL=no"
+	fi
+
+	# Set the path to the Perl executable explictly.  This will be used to
+	# create the initial sharpbang line in the scripts and might cause
+	# a versioned app name end in there, see
+	# <https://bugs.gentoo.org/show_bug.cgi?id=62276>
+	myconf+=" PERL_BIN=${EPREFIX}/usr/bin/perl"
+
+	# Setting the following env var ensures that no questions are asked.
+	perl-module_src_configure
+	# Configure spamc
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}" spamc/Makefile
+}
+
+src_compile() {
+	export PERL_MM_USE_DEFAULT=1
+
+	# Now compile all the stuff selected.
+	perl-module_src_compile
+
+	if use qmail; then
+		emake spamc/qmail-spamc
+	fi
+}
+
+src_install () {
+	perl-module_src_install
+
+	# Create the stub dir used by sa-update and friends
+	keepdir /var/lib/spamassassin
+
+	# Move spamd to sbin where it belongs.
+	dodir /usr/sbin
+	mv "${ED}"/usr/bin/spamd "${ED}"/usr/sbin/spamd  || die "move spamd failed"
+
+	if use qmail; then
+		dobin spamc/qmail-spamc
+	fi
+
+	ln -s mail/spamassassin "${ED}"/etc/spamassassin || die
+
+	# Disable plugin by default
+	sed -i -e 's/^loadplugin/\#loadplugin/g' \
+		"${ED}"/etc/mail/spamassassin/init.pre \
+		|| die "failed to disable plugins by default"
+
+	# Add the init and config scripts.
+	newinitd "${FILESDIR}"/3.3.1-spamd.init spamd
+	newconfd "${FILESDIR}"/3.0.0-spamd.conf spamd
+
+	systemd_newunit "${FILESDIR}"/${PN}.service-r1 ${PN}.service
+	systemd_install_serviced "${FILESDIR}"/${PN}.service.conf
+
+	if use postgres; then
+		sed -i -e 's:@USEPOSTGRES@::' "${ED}/etc/init.d/spamd" || die
+
+		dodoc sql/*_pg.sql
+	else
+		sed -i -e '/@USEPOSTGRES@/d' "${ED}/etc/init.d/spamd" || die
+	fi
+
+	if use mysql; then
+		sed -i -e 's:@USEMYSQL@::' "${ED}/etc/init.d/spamd" || die
+
+		dodoc sql/*_mysql.sql
+	else
+		sed -i -e '/@USEMYSQL@/d' "${ED}/etc/init.d/spamd" || die
+	fi
+
+	dodoc NOTICE TRADEMARK CREDITS INSTALL.VMS UPGRADE USAGE \
+		sql/README.bayes sql/README.awl procmailrc.example sample-nonspam.txt \
+		sample-spam.txt spamd/PROTOCOL spamd/README.vpopmail \
+		spamd-apache2/README.apache
+
+	# Rename some docu files so they don't clash with others
+	newdoc spamd/README README.spamd
+	newdoc sql/README README.sql
+	newdoc ldap/README README.ldap
+
+	if use qmail; then
+		dodoc spamc/README.qmail
+	fi
+
+	insinto /etc/mail/spamassassin/
+	insopts -m0400
+	newins "${FILESDIR}"/secrets.cf secrets.cf.example
+
+	cat <<-EOF > "${T}/local.cf.example"
+		# Sensitive data, such as database connection info, should be stored in
+		# /etc/mail/spamassassin/secrets.cf with appropriate permissions
+EOF
+
+	insopts -m0644
+	doins "${T}/local.cf.example"
+}
+
+pkg_postinst() {
+	elog "If you plan on using the -u flag to spamd, please read the notes"
+	elog "in /etc/conf.d/spamd regarding the location of the pid file."
+	elog
+	elog "If you build ${PN} with optional dependancy support,"
+	elog "you can enable them in /etc/mail/spamassassin/init.pre"
+	elog
+	elog "You need to configure your database to be able to use Bayes filter"
+	elog "with database backend, otherwise it will still use (and need) the"
+	elog "Berkeley DB support."
+	elog "Look at the sql/README.bayes file in the documentation directory"
+	elog "for how to configure it."
+	elog
+	elog "If you plan to use Vipul's Razor, note that versions up to and"
+	elog "including version 2.82 include a bug that will slow down the entire"
+	elog "perl interpreter.  Version 2.83 or later fixes this."
+	elog "If you do not plan to use this plugin, be sure to comment out"
+	elog "its loadplugin line in /etc/mail/spamassassin/v310.pre."
+	elog
+	elog "The DKIM plugin is now enabled by default for new installs,"
+	elog "if the perl module Mail::DKIM is installed."
+	elog "However, installation of SpamAssassin will not overwrite existing"
+	elog ".pre configuration files, so to use DKIM when upgrading from a"
+	elog "previous release that did not use DKIM, a directive:"
+	elog
+	elog "loadplugin Mail::SpamAssassin::Plugin::DKIM"
+	elog "will need to be uncommented in file 'v312.pre', or added"
+	elog "to some other .pre file, such as local.pre."
+	elog
+	ewarn "Rules are no longer included with SpamAssassin out of the box".
+	ewarn "You will need to immediately run sa-update, or download"
+	ewarn "the additional rules .tgz package and run sa-update --install"
+	ewarn "with it, to get a ruleset."
+	elog
+	elog "If you run sa-update and receive a GPG validation error."
+	elog "Then you need to import an updated sa-update key."
+	elog "sa-update --import /usr/share/spamassassin/sa-update-pubkey.txt"
+	elog
+}

--- a/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
@@ -184,10 +184,10 @@ EOF
 
 pkg_postinst() {
 	elog "If you plan on using the -u flag to spamd, please read the notes"
-	elog "in ${EROOT}/etc/conf.d/spamd regarding the location of the pid file."
+	elog "in ${EROOT%/}/etc/conf.d/spamd regarding the location of the pid file."
 	elog
 	elog "If you build ${PN} with optional dependancy support,"
-	elog "you can enable them in ${EROOT}/etc/mail/spamassassin/init.pre"
+	elog "you can enable them in ${EROOT%/}/etc/mail/spamassassin/init.pre"
 	elog
 	elog "You need to configure your database to be able to use Bayes filter"
 	elog "with database backend, otherwise it will still use (and need) the"
@@ -199,7 +199,7 @@ pkg_postinst() {
 	elog "including version 2.82 include a bug that will slow down the entire"
 	elog "perl interpreter.  Version 2.83 or later fixes this."
 	elog "If you do not plan to use this plugin, be sure to comment out"
-	elog "its loadplugin line in ${EROOT}/etc/mail/spamassassin/v310.pre."
+	elog "its loadplugin line in ${EROOT%/}/etc/mail/spamassassin/v310.pre."
 	elog
 	elog "The DKIM plugin is now enabled by default for new installs,"
 	elog "if the perl module Mail::DKIM is installed."
@@ -218,6 +218,6 @@ pkg_postinst() {
 	elog
 	elog "If you run sa-update and receive a GPG validation error."
 	elog "Then you need to import an updated sa-update key."
-	elog "sa-update --import ${EROOT}/usr/share/spamassassin/sa-update-pubkey.txt"
+	elog "sa-update --import ${EROOT%/}/usr/share/spamassassin/sa-update-pubkey.txt"
 	elog
 }

--- a/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
@@ -184,10 +184,10 @@ EOF
 
 pkg_postinst() {
 	elog "If you plan on using the -u flag to spamd, please read the notes"
-	elog "in /etc/conf.d/spamd regarding the location of the pid file."
+	elog "in ${EROOT}/etc/conf.d/spamd regarding the location of the pid file."
 	elog
 	elog "If you build ${PN} with optional dependancy support,"
-	elog "you can enable them in /etc/mail/spamassassin/init.pre"
+	elog "you can enable them in ${EROOT}/etc/mail/spamassassin/init.pre"
 	elog
 	elog "You need to configure your database to be able to use Bayes filter"
 	elog "with database backend, otherwise it will still use (and need) the"
@@ -199,7 +199,7 @@ pkg_postinst() {
 	elog "including version 2.82 include a bug that will slow down the entire"
 	elog "perl interpreter.  Version 2.83 or later fixes this."
 	elog "If you do not plan to use this plugin, be sure to comment out"
-	elog "its loadplugin line in /etc/mail/spamassassin/v310.pre."
+	elog "its loadplugin line in ${EROOT}/etc/mail/spamassassin/v310.pre."
 	elog
 	elog "The DKIM plugin is now enabled by default for new installs,"
 	elog "if the perl module Mail::DKIM is installed."
@@ -218,6 +218,6 @@ pkg_postinst() {
 	elog
 	elog "If you run sa-update and receive a GPG validation error."
 	elog "Then you need to import an updated sa-update key."
-	elog "sa-update --import /usr/share/spamassassin/sa-update-pubkey.txt"
+	elog "sa-update --import ${EROOT}/usr/share/spamassassin/sa-update-pubkey.txt"
 	elog
 }

--- a/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
@@ -173,7 +173,7 @@ src_install () {
 	insopts -m0400
 	newins "${FILESDIR}"/secrets.cf secrets.cf.example
 
-	cat <<-EOF > "${T}/local.cf.example"
+	cat <<-EOF > "${T}/local.cf.example" || die
 		# Sensitive data, such as database connection info, should be stored in
 		# /etc/mail/spamassassin/secrets.cf with appropriate permissions
 EOF

--- a/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
@@ -175,7 +175,7 @@ src_install () {
 
 	cat <<-EOF > "${T}/local.cf.example" || die
 		# Sensitive data, such as database connection info, should be stored in
-		# /etc/mail/spamassassin/secrets.cf with appropriate permissions
+		# ${EPREFIX}/etc/mail/spamassassin/secrets.cf with appropriate permissions
 EOF
 
 	insopts -m0644

--- a/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.1-r3.ebuild
@@ -184,10 +184,10 @@ EOF
 
 pkg_postinst() {
 	elog "If you plan on using the -u flag to spamd, please read the notes"
-	elog "in ${EROOT%/}/etc/conf.d/spamd regarding the location of the pid file."
+	elog "in ${EROOT}etc/conf.d/spamd regarding the location of the pid file."
 	elog
 	elog "If you build ${PN} with optional dependancy support,"
-	elog "you can enable them in ${EROOT%/}/etc/mail/spamassassin/init.pre"
+	elog "you can enable them in ${EROOT}etc/mail/spamassassin/init.pre"
 	elog
 	elog "You need to configure your database to be able to use Bayes filter"
 	elog "with database backend, otherwise it will still use (and need) the"
@@ -199,7 +199,7 @@ pkg_postinst() {
 	elog "including version 2.82 include a bug that will slow down the entire"
 	elog "perl interpreter.  Version 2.83 or later fixes this."
 	elog "If you do not plan to use this plugin, be sure to comment out"
-	elog "its loadplugin line in ${EROOT%/}/etc/mail/spamassassin/v310.pre."
+	elog "its loadplugin line in ${EROOT}etc/mail/spamassassin/v310.pre."
 	elog
 	elog "The DKIM plugin is now enabled by default for new installs,"
 	elog "if the perl module Mail::DKIM is installed."
@@ -218,6 +218,6 @@ pkg_postinst() {
 	elog
 	elog "If you run sa-update and receive a GPG validation error."
 	elog "Then you need to import an updated sa-update key."
-	elog "sa-update --import ${EROOT%/}/usr/share/spamassassin/sa-update-pubkey.txt"
+	elog "sa-update --import ${EROOT}usr/share/spamassassin/sa-update-pubkey.txt"
 	elog
 }


### PR DESCRIPTION
Reopen of pull request #1520 ...

> Almost the same as the files attached to https://bugs.gentoo.org/show_bug.cgi?id=579222, except the 3.4.0-r2 ebuild has a fix for a repoman flag (by specifying ":0" on openssl) and I've masked all the arches as well.

But this time from a dedicated branch, per @monsieurp's request.  (Which is what I should have done in the first place.)

CC: @gentoo/perl