### PR TITLE
Fix irssi-xmpp src_prepare error.

### DIFF
--- a/net-irc/irssi-xmpp/irssi-xmpp-0.53.ebuild
+++ b/net-irc/irssi-xmpp/irssi-xmpp-0.53.ebuild
@@ -22,6 +22,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	sed -e "s/{MAKE} doc-install/{MAKE}/" \
 		-i Makefile || die #322355
+	default_src_prepare
 }
 
 src_compile() {


### PR DESCRIPTION
Otherwise we get this:

 * Messages for package net-irc/irssi-xmpp-0.53:

 * ERROR: net-irc/irssi-xmpp-0.53::gentoo failed (prepare phase):
 *   eapply_user (or default) must be called in src_prepare()!
 * 
 * Call stack:
 *            ebuild.sh, line  780:  Called __ebuild_main 'prepare'
 *   phase-functions.sh, line 1005:  Called __dyn_prepare
 *   phase-functions.sh, line  380:  Called die
 * The specific snippet of code:
 *   		die "eapply_user (or default) must be called in src_prepare()!"
 * 
 * If you need support, post the output of `emerge --info '=net-irc/irssi-xmpp-0.53::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=net-irc/irssi-xmpp-0.53::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/net-irc/irssi-xmpp-0.53/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/net-irc/irssi-xmpp-0.53/temp/environment'.
 * Working directory: '/var/tmp/portage/net-irc/irssi-xmpp-0.53/work/irssi-xmpp-0.53'
 * S: '/var/tmp/portage/net-irc/irssi-xmpp-0.53/work/irssi-xmpp-0.53'
