### PR TITLE
Arm64keyword

### DIFF
--- a/app-editors/hexedit/hexedit-1.2.13.ebuild
+++ b/app-editors/hexedit/hexedit-1.2.13.ebuild
@@ -11,8 +11,7 @@ SRC_URI="http://rigaux.org/${P}.src.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ~mips ppc ppc64 s390 sh sparc x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos 
-~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~mips ppc ppc64 s390 sh sparc x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 
 DEPEND="sys-libs/ncurses:="
 RDEPEND="${DEPEND}"

--- a/app-editors/hexedit/hexedit-1.2.13.ebuild
+++ b/app-editors/hexedit/hexedit-1.2.13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -11,7 +11,8 @@ SRC_URI="http://rigaux.org/${P}.src.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 s390 sh sparc x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~mips ppc ppc64 s390 sh sparc x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos 
+~x86-macos ~sparc-solaris ~x86-solaris"
 
 DEPEND="sys-libs/ncurses:="
 RDEPEND="${DEPEND}"

--- a/games-board/gnome-mines/gnome-mines-3.18.2.ebuild
+++ b/games-board/gnome-mines/gnome-mines-3.18.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,7 +13,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/Mines"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE=""
 
 COMMON_DEPEND="


### PR DESCRIPTION
Added ~arm64 to hexedit and gnome-mines to practice the workflow.
Neither have dependencies not already ~arm64
Works on Raspberry Pi3. Cortex-a53