### PR TITLE
games-emulation/dosbox: fix compiling with clang

### DIFF
--- a/games-emulation/dosbox/dosbox-0.74-r1.ebuild
+++ b/games-emulation/dosbox/dosbox-0.74-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+inherit eutils games
+
+DESCRIPTION="DOS emulator"
+HOMEPAGE="http://dosbox.sourceforge.net/"
+SRC_URI="mirror://sourceforge/dosbox/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
+IUSE="alsa debug hardened opengl"
+
+DEPEND="alsa? ( media-libs/alsa-lib )
+	debug? ( sys-libs/ncurses:0 )
+	opengl? ( virtual/glu virtual/opengl )
+	media-libs/libpng:0
+	media-libs/libsdl[joystick,video,X]
+	media-libs/sdl-net
+	media-libs/sdl-sound"
+RDEPEND=${DEPEND}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-clang.patch
+	"${FILESDIR}"/${P}-gcc46.patch
+)
+
+src_prepare() {
+	epatch "${PATCHES[@]}"
+}
+
+src_configure() {
+	egamesconf \
+		$(use_enable alsa alsa-midi) \
+		$(use_enable !hardened dynamic-core) \
+		$(use_enable !hardened dynamic-x86) \
+		$(use_enable debug) \
+		$(use_enable opengl)
+}
+
+src_install() {
+	default
+	make_desktop_entry dosbox DOSBox /usr/share/pixmaps/dosbox.ico
+	doicon src/dosbox.ico
+	prepgamesdirs
+}

--- a/games-emulation/dosbox/files/dosbox-0.74-clang.patch
+++ b/games-emulation/dosbox/files/dosbox-0.74-clang.patch
@@ -1,0 +1,48 @@
+Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=449060
+
+Two backports from Dosbox SVN needed for clang support:
+src/fpu/fpu_instructions_x86.h changes are revision 3841
+src/cpu/core_dynrec/risc_x64.h changes are revision 3894
+
+Index: src/fpu/fpu_instructions_x86.h
+===================================================================
+--- src/fpu/fpu_instructions_x86.h	(revision 3840)
++++ src/fpu/fpu_instructions_x86.h	(revision 3841)
+@@ -1161,12 +1161,12 @@
+ 
+ static void FPU_FLD_I16(PhysPt addr,Bitu store_to) {
+ 	fpu.p_regs[8].m1 = (Bit32u)mem_readw(addr);
+-	FPUD_LOAD(fild,WORD,)
++	FPUD_LOAD(fild,WORD,s)
+ }
+ 
+ static void FPU_FLD_I16_EA(PhysPt addr) {
+ 	fpu.p_regs[8].m1 = (Bit32u)mem_readw(addr);
+-	FPUD_LOAD_EA(fild,WORD,)
++	FPUD_LOAD_EA(fild,WORD,s)
+ }
+ 
+ static void FPU_FLD_I32(PhysPt addr,Bitu store_to) {
+@@ -1211,7 +1211,7 @@
+ }
+ 
+ static void FPU_FST_I16(PhysPt addr) {
+-	FPUD_STORE(fistp,WORD,)
++	FPUD_STORE(fistp,WORD,s)
+ 	mem_writew(addr,(Bit16u)fpu.p_regs[8].m1);
+ }
+ 
+Index: src/cpu/core_dynrec/risc_x64.h
+===================================================================
+--- src/cpu/core_dynrec/risc_x64.h	(revision 3893)
++++ src/cpu/core_dynrec/risc_x64.h	(revision 3894)
+@@ -85,7 +85,8 @@
+ 
+ static INLINE void gen_reg_memaddr(HostReg reg,void* data) {
+ 	Bit64s diff = (Bit64s)data-((Bit64s)cache.pos+5);
+-	if ((diff<0x80000000LL) && (diff>-0x80000000LL)) {
++//	if ((diff<0x80000000LL) && (diff>-0x80000000LL)) { //clang messes itself up on this...
++	if ( (diff>>63) == (diff>>31) ) { //signed bit extend, test to see if value fits in a Bit32s
+ 		cache_addb(0x05+(reg<<3));
+ 		// RIP-relative addressing is offset after the instruction 
+ 		cache_addd((Bit32u)(((Bit64u)diff)&0xffffffffLL)); 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/449060

Package-Manager: portage-2.2.26