### PR TITLE
media-video/mpv: explicitly inherit required eutils eclass in 0.17.0-r5

### DIFF
--- a/media-video/mpv/mpv-0.17.0-r5.ebuild
+++ b/media-video/mpv/mpv-0.17.0-r5.ebuild
@@ -9,7 +9,7 @@ PYTHON_REQ_USE='threads(+)'
 
 WAF_PV=1.8.12
 
-inherit fdo-mime gnome2-utils pax-utils python-any-r1 toolchain-funcs waf-utils
+inherit eutils fdo-mime gnome2-utils pax-utils python-any-r1 toolchain-funcs waf-utils
 
 DESCRIPTION="Media player based on MPlayer and mplayer2"
 HOMEPAGE="https://mpv.io/"


### PR DESCRIPTION
We already inherit eutils implicitly via inherited gnome2-utils eclass.
Since the ebuild uses epatch, it's better to inherit eutils explicitly.

Package-Manager: portage-2.3.0_rc1