### PR TITLE
app-text/libetonyek: Fix build w/ mdds-1.2.0

### DIFF
--- a/app-text/libetonyek/files/libetonyek-0.1.6-mdds-1.2.patch
+++ b/app-text/libetonyek/files/libetonyek-0.1.6-mdds-1.2.patch
@@ -1,0 +1,33 @@
+--- libetonyek-0.1.6.orig/configure.ac
++++ libetonyek-0.1.6/configure.ac
+@@ -24,8 +24,8 @@ AC_LANG([C++])
+ # Configure options
+ # =================
+ AC_ARG_WITH([mdds],
+-            AS_HELP_STRING([--with-mdds=1.0|0.x], [Specify which version of mdds to use (1.0 is the default)]),
+-            [], [with_mdds="1.0"])
++            AS_HELP_STRING([--with-mdds=1.2|0.x], [Specify which version of mdds to use (1.2 is the default)]),
++            [], [with_mdds="1.2"])
+ 
+ # ===========================
+ # Find required base packages
+@@ -47,7 +47,7 @@ AC_PROG_SED
+ 
+ AM_MISSING_PROG([GPERF], [gperf])
+ 
+-AS_IF([test "$with_mdds" = "1.0"], [AX_CXX_COMPILE_STDCXX_11([noext])])
++AS_IF([test "$with_mdds" = "1.2"], [AX_CXX_COMPILE_STDCXX_11([noext])])
+ 
+ # ===============
+ # Find librevenge
+@@ -138,8 +138,8 @@ AC_SUBST([GLM_CFLAGS])
+ # =========
+ # Find mdds
+ # =========
+-AS_IF([test "$with_mdds" = "1.0"], [
+-    PKG_CHECK_MODULES([MDDS], [mdds-1.0])
++AS_IF([test "$with_mdds" = "1.2"], [
++    PKG_CHECK_MODULES([MDDS], [mdds-1.2])
+ ], [
+     PKG_CHECK_MODULES([MDDS], [mdds])
+     AC_MSG_CHECKING([checking if mdds::flat_segment_tree can store values of any type])

--- a/app-text/libetonyek/libetonyek-0.1.6.ebuild
+++ b/app-text/libetonyek/libetonyek-0.1.6.ebuild
@@ -5,8 +5,8 @@
 EAPI=6
 
 EGIT_REPO_URI="git://anongit.freedesktop.org/git/libreoffice/libetonyek"
-inherit eutils
-[[ ${PV} == 9999 ]] && inherit autotools git-r3
+inherit autotools eutils
+[[ ${PV} == 9999 ]] && inherit git-r3
 
 DESCRIPTION="Library parsing Apple Keynote presentations"
 HOMEPAGE="https://wiki.documentfoundation.org/DLP/Libraries/libetonyek"
@@ -26,13 +26,15 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	dev-libs/boost
-	dev-util/mdds:1
+	>=dev-util/mdds-1.2.0:1
 	media-libs/glm
 	sys-devel/libtool
 	virtual/pkgconfig
 	doc? ( app-doc/doxygen )
 	test? ( dev-util/cppunit )
 "
+
+PATCHES=( "${FILESDIR}/${P}-mdds-1.2.patch" ) # patch taken from Debian
 
 pkg_pretend() {
 	if [[ $(gcc-major-version) -lt 4 ]] || {
@@ -44,9 +46,9 @@ pkg_pretend() {
 }
 
 src_prepare() {
-	eapply_user
+	default
 	[[ -d m4 ]] || mkdir "m4"
-	[[ ${PV} == 9999 ]] && eautoreconf
+	eautoreconf
 }
 
 src_configure() {

--- a/app-text/libetonyek/libetonyek-9999.ebuild
+++ b/app-text/libetonyek/libetonyek-9999.ebuild
@@ -44,7 +44,7 @@ pkg_pretend() {
 }
 
 src_prepare() {
-	eapply_user
+	default
 	[[ -d m4 ]] || mkdir "m4"
 	[[ ${PV} == 9999 ]] && eautoreconf
 }


### PR DESCRIPTION
Patch taken from Debian. See also:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=824584

Gentoo-bug: 584994

Package-Manager: portage-2.2.28

@gentoo/openoffice 