### PR TITLE
kde-plasma/kactivities-workspace: Fix bogus deps

### DIFF
--- a/kde-plasma/kactivities-workspace/kactivities-workspace-5.5.0.ebuild
+++ b/kde-plasma/kactivities-workspace/kactivities-workspace-5.5.0.ebuild
@@ -47,4 +47,11 @@ src_prepare() {
 	# Remove conflict with kde-frameworks/kactivities
 	sed -e "/add_subdirectory.*imports/ s/^/#DONT/" \
 		-i src/workspace/CMakeLists.txt || die
+
+	# Fix bogus deps (bug #585044)
+	sed -e "s/KF5KCMUtils/KF5Service/" \
+		-e "/Declarative/d" \
+		-e "/KF5::KCMUtils/d" \
+		-i src/workspace/settings/CMakeLists.txt || die
+
 }


### PR DESCRIPTION
Gentoo-bug: 585044

Builds fine for me, though I can not test it anymore for lack of Plasma-5.5.5 :(

@gentoo/kde