### PR TITLE
dev-python/ipython: Revision bump, backport bugfix

### DIFF
--- a/dev-python/ipython/files/ipython-4.2.0-Fix-use-backports.shutil_get_terminal_size.patch
+++ b/dev-python/ipython/files/ipython-4.2.0-Fix-use-backports.shutil_get_terminal_size.patch
@@ -1,0 +1,78 @@
+Patch imported from upstream to fix backports.shutil_get_terminal_size usage.
+Merged into master, not needed for future ipython releases.
+
+Patch for setup.py adjusted by Marius Brehler.
+
+
+From 05edbcc6dc9f9052f1f7255df83a6794ee4d582c Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Fri, 22 Apr 2016 13:30:53 +0200
+Subject: [PATCH 2/2] only use backports.shutil_get_terminal_size on Python 2
+
+removes the backport dependency on Python 3, where it's not needed.
+---
+ IPython/utils/terminal.py | 20 ++++++++------------
+ setup.py                  |  2 +-
+ 2 files changed, 9 insertions(+), 13 deletions(-)
+
+diff --git a/IPython/utils/terminal.py b/IPython/utils/terminal.py
+index 9e7be2a..a1f0f73 100644
+--- a/IPython/utils/terminal.py
++++ b/IPython/utils/terminal.py
+@@ -9,22 +9,18 @@
+ * Alexander Belchenko (e-mail: bialix AT ukr.net)
+ """
+ 
+-#-----------------------------------------------------------------------------
+-#  Copyright (C) 2008-2011  The IPython Development Team
+-#
+-#  Distributed under the terms of the BSD License.  The full license is in
+-#  the file COPYING, distributed as part of this software.
+-#-----------------------------------------------------------------------------
+-
+-#-----------------------------------------------------------------------------
+-# Imports
+-#-----------------------------------------------------------------------------
++# Copyright (c) IPython Development Team.
++# Distributed under the terms of the Modified BSD License.
+ 
+ import os
+ import struct
+ import sys
+ import warnings
+-import backports.shutil_get_terminal_size
++try:
++    from shutil import get_terminal_size as _get_terminal_size
++except ImportError:
++    # use backport on Python 2
++    from backports.shutil_get_terminal_size import get_terminal_size as _get_terminal_size
+ 
+ from . import py3compat
+ 
+@@ -122,4 +118,4 @@ def freeze_term_title():
+ 
+ 
+ def get_terminal_size(defaultx=80, defaulty=25):
+-    return backports.shutil_get_terminal_size.get_terminal_size((defaultx, defaulty))
++    return _get_terminal_size((defaultx, defaulty))
+diff --git a/setup.py b/setup.py
+index 7fae9ef..7e129a1 100755
+--- a/setup.py
++++ b/setup.py
+@@ -195,7 +195,6 @@ install_requires = [
+     'pickleshare',
+     'simplegeneric>0.8',
+     'traitlets',
+-    'backports.shutil_get_terminal_size',
+ ]
+ 
+ # Platform-specific dependencies:
+@@ -203,6 +202,7 @@ install_requires = [
+ # but requires pip >= 6. pip < 6 ignores these.
+ 
+ extras_require.update({
++    ':python_version == "2.7"': ['backports.shutil_get_terminal_size'],
+     ':sys_platform != "win32"': ['pexpect'],
+     ':sys_platform == "darwin"': ['appnope'],
+     ':sys_platform == "darwin" and platform_python_implementation == "CPython"': ['gnureadline'],
+

--- a/dev-python/ipython/ipython-4.2.0-r1.ebuild
+++ b/dev-python/ipython/ipython-4.2.0-r1.ebuild
@@ -30,6 +30,7 @@ CDEPEND="
 	dev-python/simplegeneric[${PYTHON_USEDEP}]
 	>=dev-python/traitlets-4.2.1[${PYTHON_USEDEP}]
 	>=dev-python/prompt_toolkit-1.0.0[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep 'dev-python/backports-shutil_get_terminal_size[${PYTHON_USEDEP}]' python2_7)
 	matplotlib? ( dev-python/matplotlib[${PYTHON_USEDEP}] )
 	mongodb? ( <dev-python/pymongo-3[${PYTHON_USEDEP}] )
 	wxwidgets? ( $(python_gen_cond_dep 'dev-python/wxpython:*[${PYTHON_USEDEP}]' python2_7) )"
@@ -71,6 +72,7 @@ PDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/2.1.0-substitute-files.patch
+	"${FILESDIR}/${P}"-Fix-use-backports.shutil_get_terminal_size.patch
 	)
 
 DISTUTILS_IN_SOURCE_BUILD=1


### PR DESCRIPTION
@jlec @SoapGentoo 

Bug: https://github.com/ipython/ipython/issues/9416
Fix: https://github.com/ipython/ipython/pull/9417

Unfortunately, ipython-4.2.0 is somehow broken. You can start the notebook server and open notebooks, but the execution of cells will fail. I backported the patch (and adjusted the setup.py file).