### PR TITLE
Fix dev-ruby/travis deps

### DIFF
--- a/dev-ruby/travis/travis-1.8.2-r2.ebuild
+++ b/dev-ruby/travis/travis-1.8.2-r2.ebuild
@@ -7,6 +7,8 @@ USE_RUBY="ruby20 ruby21"
 RUBY_FAKEGEM_RECIPE_DOC="rdoc"
 RUBY_FAKEGEM_RECIPE_TEST="rspec"
 
+RUBY_FAKEGEM_GEMSPEC="travis.gemspec"
+
 inherit bash-completion-r1 ruby-fakegem
 
 DESCRIPTION="Travis CI Client (CLI and Ruby library) "
@@ -33,6 +35,10 @@ ruby_add_rdepend "
 	>dev-ruby/pusher-client-0.4
 	>=dev-ruby/typhoeus-0.6.8
 "
+
+all_ruby_prepare() {
+	sed -i -e '/typhoeus/s/~> 0.6/>= 0.6/' travis.gemspec || die
+}
 
 all_ruby_install() {
 	all_fakegem_install


### PR DESCRIPTION
Travis needs =typhoeus-0.6:
```
 travis
/usr/lib64/ruby/site_ruby/2.1.0/rubygems/dependency.rb:298:in `to_specs': Could not find 'typhoeus' (>= 0.6.8, ~> 0.6) - did find: [typhoeus-1.0.2] (Gem::LoadError)
```

@gentoo/ruby: works for, but please review!
