### PR TITLE
app-benchmarks/sysbench: adding live ebuild

### DIFF
--- a/app-benchmarks/sysbench/sysbench-9999.ebuild
+++ b/app-benchmarks/sysbench/sysbench-9999.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+inherit git-r3
+
+DESCRIPTION="System performance benchmark"
+HOMEPAGE="https://github.com/akopytov/sysbench"
+
+EGIT_REPO_URI="https://github.com/akopytov/sysbench.git"
+EGIT_BRANCH="1.0"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS=""
+IUSE="aio mysql"
+
+DEPEND="aio? ( dev-libs/libaio )
+	mysql? ( virtual/libmysqlclient )"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+
+	sed -i -e "/^htmldir =/s:=.*:=/usr/share/doc/${PF}/html:" doc/Makefile.am || die
+
+	./autogen.sh || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable aio aio)
+		$(use_with mysql mysql)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	insinto /usr/share/${PN}/tests/db
+	doins sysbench/tests/db/*.lua || die
+}


### PR DESCRIPTION
Package-Manager: portage-2.3.0_rc1

The latest release is very old, according to the following blog post, 1.0 is really being worked on and should be released soon:
http://kaamos.me/blog//2016/03/08/towards-sysbench-1.0-history.html