### PR TITLE
media-video/mpv: allow build with older ffmpeg in 9999

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -180,6 +180,7 @@ src_configure() {
 		--disable-vapoursynth-lazy
 		$(use_enable archive libarchive)
 
+		--enable-unsupported-ffmpeg
 		--enable-libavdevice
 
 		# Audio outputs:


### PR DESCRIPTION
Package-Manager: portage-2.3.0_rc1