### PR TITLE
 media-video/rtmpdump: add -std=gnu89 to CFLAGS to restore pre-GCC5 semantics

### DIFF
--- a/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
+++ b/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
@@ -38,6 +38,8 @@ src_unpack() {
 }
 
 src_prepare() {
+	# fix #571104 by restoring pre-GCC5 inline semantics
+	append-cflags -std=gnu89
 	# fix Makefile ( bug #298535 , bug #318353 and bug #324513 )
 	sed -i 's/\$(MAKEFLAGS)//g' Makefile \
 		|| die "failed to fix Makefile"

--- a/media-video/rtmpdump/rtmpdump-9999.ebuild
+++ b/media-video/rtmpdump/rtmpdump-9999.ebuild
@@ -32,6 +32,8 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# fix #571104 by restoring pre-GCC5 inline semantics
+	append-cflags -std=gnu89
 	# fix Makefile ( bug #298535 , bug #318353 and bug #324513 )
 	sed -i 's/\$(MAKEFLAGS)//g' Makefile \
 		|| die "failed to fix Makefile"


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=571104