### PR TITLE
sci-electronics/kicad: Limit boost version to max 1.60

### DIFF
--- a/sci-electronics/kicad/kicad-4.0.1-r1.ebuild
+++ b/sci-electronics/kicad/kicad-4.0.1-r1.ebuild
@@ -39,6 +39,7 @@ CDEPEND="x11-libs/wxGTK:${WX_GTK_VER}[X,opengl,webkit?]
 		dev-python/wxpython:${WX_GTK_VER}[opengl,${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
+	<dev-libs/boost-1.61[context,nls,threads,python?]
 	>=dev-libs/boost-1.56[context,nls,threads,python?]
 	github? ( dev-libs/openssl:0 )
 	media-libs/glew

--- a/sci-electronics/kicad/kicad-4.0.2-r1.ebuild
+++ b/sci-electronics/kicad/kicad-4.0.2-r1.ebuild
@@ -39,6 +39,7 @@ CDEPEND="x11-libs/wxGTK:${WX_GTK_VER}[X,opengl,webkit?]
 		dev-python/wxpython:${WX_GTK_VER}[opengl,${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
+	<dev-libs/boost-1.61[context,nls,threads,python?]
 	>=dev-libs/boost-1.56[context,nls,threads,python?]
 	github? ( dev-libs/openssl:0 )
 	media-libs/glew


### PR DESCRIPTION
Gentoo bug: #583640

Package-Manager: portage-2.3.0_rc1