### PR TITLE
dev-util/electron: Build node executable, fix automagic cups dependency (#585116, #585490, #585464)

### DIFF
--- a/dev-util/electron/electron-0.36.12-r3.ebuild
+++ b/dev-util/electron/electron-0.36.12-r3.ebuild
@@ -128,7 +128,6 @@ DEPEND="${RDEPEND}
 	dev-perl/JSON
 	>=dev-util/gperf-3.0.3
 	dev-util/ninja
-	net-libs/nodejs[npm]
 	sys-apps/hwids[usb(+)]
 	>=sys-devel/bison-2.4.3
 	sys-devel/flex
@@ -261,6 +260,7 @@ src_prepare() {
 	# node patches
 	cd "${NODE_S}" || die
 	epatch "${FILESDIR}/node-gentoo-build-fixes.patch"
+	epatch "${FILESDIR}/node-external-snapshots.patch"
 	# make sure node uses the correct version of v8
 	rm -r deps/v8 || die
 	ln -s ../../../v8 deps/ || die
@@ -693,6 +693,7 @@ src_install() {
 	# Install Electron
 	insinto "${install_dir}"
 	exeinto "${install_dir}"
+	newexe out/R/nodebin node
 	doexe out/R/electron
 	doins out/R/libv8.so
 	doins out/R/libnode.so

--- a/dev-util/electron/files/brightray-gentoo-build-fixes-r1.patch
+++ b/dev-util/electron/files/brightray-gentoo-build-fixes-r1.patch
@@ -1,15 +1,15 @@
-From e2aabe2618ee91c3f6e817c72370573f45c8b20e Mon Sep 17 00:00:00 2001
+From 4ec57d1c20b841c6121a77f1539b0c759a031904 Mon Sep 17 00:00:00 2001
 From: Elvis Pranskevichus <elvis@magic.io>
 Date: Mon, 8 Feb 2016 15:14:58 -0500
 Subject: [PATCH] brightray build fixes
 
 ---
- brightray.gyp  | 32 +++++++++++++++++++++++++++++---
+ brightray.gyp  | 52 ++++++++++++++++++++++++++++++++++++++++++++++++----
  brightray.gypi | 21 ++++++++-------------
- 2 files changed, 37 insertions(+), 16 deletions(-)
+ 2 files changed, 56 insertions(+), 17 deletions(-)
 
 diff --git a/brightray.gyp b/brightray.gyp
-index d7120ea..b23c1eb 100644
+index d7120ea..d0fd603 100644
 --- a/brightray.gyp
 +++ b/brightray.gyp
 @@ -1,7 +1,7 @@
@@ -21,18 +21,19 @@ index d7120ea..b23c1eb 100644
    },
    'includes': [
      'filenames.gypi',
-@@ -9,6 +9,10 @@
+@@ -9,6 +9,11 @@
    'targets': [
      {
        'target_name': 'brightray',
 +      'dependencies': [
++        'cups',
 +        'gconf',
 +        '<(libchromiumcontent_src_dir)/chromiumcontent/chromiumcontent.gyp:chromiumcontent_all'
 +      ],
        'type': 'static_library',
        'include_dirs': [
          '.',
-@@ -100,8 +104,6 @@
+@@ -100,12 +105,9 @@
              }, {
                'link_settings': {
                  'libraries': [
@@ -41,7 +42,11 @@ index d7120ea..b23c1eb 100644
                    # Following libraries are required by libchromiumcontent:
                    '-lasound',
                    '-lcap',
-@@ -274,5 +276,29 @@
+-                  '-lcups',
+                   '-lrt',
+                   '-ldl',
+                   '-lresolv',
+@@ -274,5 +276,47 @@
          }],  # OS=="win"
        ],
      },
@@ -65,6 +70,24 @@ index d7120ea..b23c1eb 100644
 +            'libraries': [
 +              '<!@(<(pkg-config) --libs-only-l gconf-2.0)',
 +            ],
++          },
++        }],
++      ],
++    },
++    {
++      'target_name': 'cups',
++      'type': 'none',
++      'conditions': [
++        ['use_cups==1', {
++          'direct_dependent_settings': {
++            'defines': [
++              'USE_CUPS',
++            ],
++            'link_settings': {
++              'libraries': [
++                '-lcups',
++              ],
++            },
 +          },
 +        }],
 +      ],

--- a/dev-util/electron/files/electron-gentoo-build-fixes.patch
+++ b/dev-util/electron/files/electron-gentoo-build-fixes.patch
@@ -1,19 +1,28 @@
-From 174dd209209d8f67f534ad761d8adeeddc6bf5c0 Mon Sep 17 00:00:00 2001
+From 122f619bb04fa61f9d5757881a3031b00dee5339 Mon Sep 17 00:00:00 2001
 From: Elvis Pranskevichus <elvis@magic.io>
 Date: Mon, 8 Feb 2016 15:16:40 -0500
 Subject: [PATCH] electron build fixes
 
 ---
- atom.gyp       | 19 ++++++++-----------
- common.gypi    | 32 +++++++++++++++++++++++---------
- filenames.gypi |  1 -
- 3 files changed, 31 insertions(+), 21 deletions(-)
+ atom.gyp         | 55 ++++++++++++++++++++++++++++++++++++++++++++-----------
+ common.gypi      | 32 +++++++++++++++++++++++---------
+ filenames.gypi   |  1 -
+ tools/js2asar.py | 11 ++++++-----
+ 4 files changed, 73 insertions(+), 26 deletions(-)
 
 diff --git a/atom.gyp b/atom.gyp
-index 68a30cc..06109a9 100644
+index 5554adb..30ae39b 100644
 --- a/atom.gyp
 +++ b/atom.gyp
-@@ -177,7 +177,7 @@
+@@ -29,6 +29,7 @@
+       'type': 'executable',
+       'dependencies': [
+         'js2asar',
++        'nodebin',
+         '<(project_name)_lib',
+       ],
+       'sources': [
+@@ -177,7 +178,7 @@
            ],
          }, {
            'dependencies': [
@@ -22,7 +31,7 @@ index 68a30cc..06109a9 100644
            ],
          }],  # OS=="win"
          ['OS=="linux"', {
-@@ -194,7 +194,7 @@
+@@ -194,7 +195,7 @@
                    }, {
                      'copied_libraries': [
                        '<(PRODUCT_DIR)/lib/libnode.so',
@@ -31,7 +40,7 @@ index 68a30cc..06109a9 100644
                      ],
                    }],
                  ],
-@@ -202,9 +202,6 @@
+@@ -202,9 +203,6 @@
                'destination': '<(PRODUCT_DIR)',
                'files': [
                  '<@(copied_libraries)',
@@ -41,7 +50,7 @@ index 68a30cc..06109a9 100644
                  '<(libchromiumcontent_dir)/natives_blob.bin',
                  '<(libchromiumcontent_dir)/snapshot_blob.bin',
                ],
-@@ -242,8 +239,8 @@
+@@ -242,8 +240,8 @@
          '<@(lib_sources)',
        ],
        'include_dirs': [
@@ -51,7 +60,7 @@ index 68a30cc..06109a9 100644
          'vendor/brightray',
          'vendor/native_mate',
          # Include atom_natives.h.
-@@ -301,8 +298,8 @@
+@@ -301,8 +299,8 @@
              'vendor/node/deps/uv/uv.gyp:libuv',
              'vendor/node/deps/zlib/zlib.gyp:zlib',
              # Build with breakpad support.
@@ -62,7 +71,7 @@ index 68a30cc..06109a9 100644
            ],
          }],  # OS=="win"
          ['OS=="mac" and mas_build==0', {
-@@ -333,7 +330,7 @@
+@@ -333,7 +331,7 @@
                # Make binary search for libraries under current directory, so we
                # don't have to manually set $LD_LIBRARY_PATH:
                # http://serverfault.com/questions/279068/cant-find-so-in-the-same-directory-as-the-executable
@@ -71,7 +80,7 @@ index 68a30cc..06109a9 100644
                # Make native module dynamic loading work.
                '-rdynamic',
              ],
-@@ -344,10 +341,10 @@
+@@ -344,10 +342,10 @@
              '-Wno-reserved-user-defined-literal',
            ],
            'include_dirs': [
@@ -84,6 +93,62 @@ index 68a30cc..06109a9 100644
            ],
          }],  # OS=="linux"
        ],
+@@ -355,6 +353,9 @@
+     {
+       'target_name': 'js2asar',
+       'type': 'none',
++      'dependencies': [
++        'nodebin'
++      ],
+       'actions': [
+         {
+           'action_name': 'js2asar',
+@@ -376,6 +377,7 @@
+           'action': [
+             'python',
+             'tools/js2asar.py',
++            '<(PRODUCT_DIR)/nodebin',
+             '<@(_outputs)',
+             '<@(_inputs)',
+           ],
+@@ -403,6 +405,37 @@
+         }
+       ],
+     },  # target atom_js2c
++    {
++      'target_name': 'nodebin',
++      'type': 'executable',
++      'sources': [
++        'vendor/node/src/node_main.cc',
++      ],
++      'dependencies': [
++        'vendor/node/node.gyp:node',
++      ],
++      'include_dirs': [
++        '.',
++        'vendor/native_mate',
++        # Include atom_natives.h.
++        '<(SHARED_INTERMEDIATE_DIR)',
++        # Include directories for uv and node.
++        'vendor/node/src',
++        'vendor/node/deps/http_parser',
++        'vendor/node/deps/uv/include',
++        # The `node.h` is using `#include"v8.h"`.
++        '<(libchromiumcontent_src_dir)/v8/include',
++        # The `node.h` is using `#include"ares.h"`.
++        'vendor/node/deps/cares/include',
++      ],
++      'link_settings': {
++        'ldflags': [
++          '-Wl,-rpath=\$$ORIGIN/',
++          # Make native module dynamic loading work.
++          '-rdynamic',
++        ],
++      },
++    },  # target nodebin
+   ],
+   'conditions': [
+     ['OS=="mac"', {
 diff --git a/common.gypi b/common.gypi
 index 7c41c36..97a3d3a 100644
 --- a/common.gypi
@@ -141,7 +206,7 @@ index 7c41c36..97a3d3a 100644
          'msvs_disabled_warnings': [
            4013,  # 'free' undefined; assuming extern returning int
 diff --git a/filenames.gypi b/filenames.gypi
-index abb1145..2330ccf 100644
+index f9e1955..84999a3 100644
 --- a/filenames.gypi
 +++ b/filenames.gypi
 @@ -498,7 +498,6 @@
@@ -152,6 +217,40 @@ index abb1145..2330ccf 100644
        'chromium_src/library_loaders/libspeechd.h',
        'chromium_src/net/test/embedded_test_server/stream_listen_socket.cc',
        'chromium_src/net/test/embedded_test_server/stream_listen_socket.h',
+diff --git a/tools/js2asar.py b/tools/js2asar.py
+index cb02e33..3d80a11 100755
+--- a/tools/js2asar.py
++++ b/tools/js2asar.py
+@@ -11,12 +11,13 @@ SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
+ 
+ 
+ def main():
+-  archive = sys.argv[1]
+-  js_source_files = sys.argv[2:]
++  node = sys.argv[1]
++  archive = sys.argv[2]
++  js_source_files = sys.argv[3:]
+ 
+   output_dir = tempfile.mkdtemp()
+   copy_js(js_source_files, output_dir)
+-  call_asar(archive, output_dir)
++  call_asar(node, archive, output_dir)
+   shutil.rmtree(output_dir)
+ 
+ 
+@@ -28,10 +29,10 @@ def copy_js(js_source_files, output_dir):
+     shutil.copy2(source_file, output_path)
+ 
+ 
+-def call_asar(archive, output_dir):
++def call_asar(node, archive, output_dir):
+   js_dir = os.path.join(output_dir, 'lib')
+   asar = os.path.join(SOURCE_ROOT, 'node_modules', 'asar', 'bin', 'asar')
+-  subprocess.check_call([find_node(), asar, 'pack', js_dir, archive])
++  subprocess.check_call([node, asar, 'pack', js_dir, archive])
+ 
+ 
+ def find_node():
 -- 
 2.7.3
 

--- a/dev-util/electron/files/node-external-snapshots.patch
+++ b/dev-util/electron/files/node-external-snapshots.patch
@@ -1,0 +1,116 @@
+From 2493dac20f0b4134bbf02ac48dffde6c2643608b Mon Sep 17 00:00:00 2001
+From: Elvis Pranskevichus <elvis@magic.io>
+Date: Sat, 11 Jun 2016 18:27:19 -0400
+Subject: [PATCH] Add support for external V8 snapshots
+
+---
+ src/node.cc | 86 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 86 insertions(+)
+
+diff --git a/src/node.cc b/src/node.cc
+index cbe1538..521708a 100644
+--- a/src/node.cc
++++ b/src/node.cc
+@@ -4037,6 +4037,90 @@ Environment* CreateEnvironment(Isolate* isolate,
+   return env;
+ }
+ 
++#include <sys/mman.h>
++
++const char kProcSelfExe[] = "/proc/self/exe";
++const char kNativesFileName[] = "natives_blob.bin";
++const char kSnapshotFileName[] = "snapshot_blob.bin";
++const char *g_mapped_natives = nullptr;
++const char *g_mapped_snapshot = nullptr;
++
++static char* SnapshotPath(const char* filename) {
++  char *path;
++  char *dir;
++  ssize_t r;
++
++  path = reinterpret_cast<char*>(malloc(4096 + strlen(filename) + 2));
++  if (path == nullptr) {
++    fprintf(stderr, "out of memory\n");
++    ABORT();
++  }
++
++  r = readlink(kProcSelfExe, path, 4096 + 1);
++  if (r == -1) {
++    perror("could not determine node executable directory");
++    ABORT();
++  }
++
++  path[r] = '\0';
++
++  dir = strrchr(path, '/');
++
++  strcpy(dir + 1, filename);
++
++  return path;
++}
++
++static void LoadV8Snapshot(const char* name, const char** addr, size_t *size) {
++  char *path = SnapshotPath(name);
++  int fd;
++  struct stat sb;
++
++  fd = open(path, O_RDONLY);
++
++  if (fd == -1) {
++    fprintf(stderr, "could not open snapshot file '%s': %s\n",
++            path, sys_errlist[errno]);
++    ABORT();
++  }
++
++  if (fstat(fd, &sb) == -1) {
++    fprintf(stderr, "could not stat snapshot file '%s': %s\n",
++            path, sys_errlist[errno]);
++    ABORT();
++  }
++
++  *size = sb.st_size;
++
++  *addr = reinterpret_cast<const char*>(
++            mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0));
++  if (*addr == MAP_FAILED) {
++    fprintf(stderr, "could not read snapshot file '%s': %s\n",
++            path, sys_errlist[errno]);
++    ABORT();
++  }
++
++  close(fd);
++  free(path);
++}
++
++static void LoadV8Snapshots() {
++  size_t natives_size;
++  size_t snapshot_size;
++
++  LoadV8Snapshot(kNativesFileName, &g_mapped_natives, &natives_size);
++  LoadV8Snapshot(kSnapshotFileName, &g_mapped_snapshot, &snapshot_size);
++
++  v8::StartupData natives;
++  natives.data = g_mapped_natives;
++  natives.raw_size = natives_size;
++  V8::SetNativesDataBlob(&natives);
++
++  v8::StartupData snapshot;
++  snapshot.data = g_mapped_snapshot;
++  snapshot.raw_size = snapshot_size;
++  V8::SetSnapshotDataBlob(&snapshot);
++}
+ 
+ // Entry point for new node instances, also called directly for the main
+ // node instance.
+@@ -4142,6 +4226,8 @@ int Start(int argc, char** argv) {
+   const char** exec_argv;
+   Init(&argc, const_cast<const char**>(argv), &exec_argc, &exec_argv);
+ 
++  LoadV8Snapshots();
++
+ #if HAVE_OPENSSL
+   // V8 on Windows doesn't have a good source of entropy. Seed it from
+   // OpenSSL's pool.
+-- 
+2.7.3
+

--- a/dev-util/electron/files/node-gentoo-build-fixes.patch
+++ b/dev-util/electron/files/node-gentoo-build-fixes.patch
@@ -1,12 +1,14 @@
-From 668a003706d57c3e7a460e2fce5d110fe9737a62 Mon Sep 17 00:00:00 2001
+From 56b57ea7f0c111bfd9c719060cf17346e638fdd1 Mon Sep 17 00:00:00 2001
 From: Elvis Pranskevichus <elvis@magic.io>
 Date: Wed, 10 Feb 2016 14:45:13 -0500
-Subject: [PATCH] Parametrize v8.gyp location
+Subject: [PATCH] Build fixes
 
 ---
  node.gyp         | 5 +++--
- tools/install.py | 3 +++
- 2 files changed, 6 insertions(+), 2 deletions(-)
+ src/node.cc      | 8 --------
+ src/node.js      | 2 ++
+ src/node_main.cc | 2 ++
+ 4 files changed, 7 insertions(+), 10 deletions(-)
 
 diff --git a/node.gyp b/node.gyp
 index d431210..fea5e07 100644
@@ -31,20 +33,77 @@ index d431210..fea5e07 100644
        ],
  
        'include_dirs': [
-diff --git a/tools/install.py b/tools/install.py
-index cb86c65..ee85e33 100755
---- a/tools/install.py
-+++ b/tools/install.py
-@@ -207,6 +207,9 @@ def run(args):
-   if os.environ.get('HEADERS_ONLY'):
-     if cmd == 'install': return headers(install)
-     if cmd == 'uninstall': return headers(uninstall)
-+  elif os.environ.get('NPM_ONLY'):
-+    if cmd == 'install': return npm_files(install)
-+    if cmd == 'uninstall': return npm_files(uninstall)
-   else:
-     if cmd == 'install': return files(install)
-     if cmd == 'uninstall': return files(uninstall)
+diff --git a/src/node.cc b/src/node.cc
+index 7df6053..cbe1538 100644
+--- a/src/node.cc
++++ b/src/node.cc
+@@ -4085,15 +4085,11 @@ static void StartNodeInstance(void* arg) {
+       SealHandleScope seal(isolate);
+       bool more;
+       do {
+-#if 0
+         v8::platform::PumpMessageLoop(default_platform, isolate);
+-#endif
+         more = uv_run(env->event_loop(), UV_RUN_ONCE);
+ 
+         if (more == false) {
+-#if 0
+           v8::platform::PumpMessageLoop(default_platform, isolate);
+-#endif
+           EmitBeforeExit(env);
+ 
+           // Emit `beforeExit` if the loop became alive either after emitting
+@@ -4153,10 +4149,8 @@ int Start(int argc, char** argv) {
+ #endif
+ 
+   const int thread_pool_size = 4;
+-#if 0
+   default_platform = v8::platform::CreateDefaultPlatform(thread_pool_size);
+   V8::InitializePlatform(default_platform);
+-#endif
+   V8::Initialize();
+ 
+   int exit_code = 1;
+@@ -4173,10 +4167,8 @@ int Start(int argc, char** argv) {
+   }
+   V8::Dispose();
+ 
+-#if 0
+   delete default_platform;
+   default_platform = nullptr;
+-#endif
+ 
+   delete[] exec_argv;
+   exec_argv = nullptr;
+diff --git a/src/node.js b/src/node.js
+index 37aa371..a835d0a 100644
+--- a/src/node.js
++++ b/src/node.js
+@@ -40,7 +40,9 @@
+     startup.globalConsole();
+     }  // not isRenderer
+ 
++    if (!process.env.ELECTRON_NODE_DISABLE_ASAR_SUPPORT) {
+     startup.initAsarSupport();
++    }
+ 
+     startup.processAssert();
+     startup.processConfig();
+diff --git a/src/node_main.cc b/src/node_main.cc
+index 58e747e..24949f3 100644
+--- a/src/node_main.cc
++++ b/src/node_main.cc
+@@ -40,8 +40,10 @@ int wmain(int argc, wchar_t *wargv[]) {
+ }
+ #else
+ // UNIX
++#include <stdlib.h>
+ int main(int argc, char *argv[]) {
+   setvbuf(stderr, NULL, _IOLBF, 1024);
++  putenv("ELECTRON_NODE_DISABLE_ASAR_SUPPORT=1");
+   return node::Start(argc, argv);
+ }
+ #endif
 -- 
 2.7.3
 


### PR DESCRIPTION
Electron and apps based on it cannot rely on system NodeJS
for compatibility reasons.  Fix this by building and using
a nodejs executable based on bundled nodejs code.

Additionally, fix automagic dependency on libcups.

Gentoo-Bug: https://bugs.gentoo.org/585116
Gentoo-Bug: https://bugs.gentoo.org/585490
Gentoo-Bug: https://bugs.gentoo.org/585464

Package-Manager: portage-2.2.28