### PR TITLE
net-firewall/nftables: Remove bashism from nftables.sh

### DIFF
--- a/net-firewall/nftables/files/libexec/nftables.sh
+++ b/net-firewall/nftables/files/libexec/nftables.sh
@@ -100,7 +100,7 @@ use_legacy() {
     major_ver=$(uname -r | cut -d '.' -f1)
     minor_ver=$(uname -r | cut -d '.' -f2)
 
-    [[ $major_ver -ge 4 || $major_ver -eq 3 && $minor_ver -ge 18 ]] && return 1
+    [ $major_ver -ge 4 -o $major_ver -eq 3 -a $minor_ver -ge 18 ] && return 1
     return 0
 }
 

--- a/net-firewall/nftables/files/nftables-0.5-pdf-doc.patch
+++ b/net-firewall/nftables/files/nftables-0.5-pdf-doc.patch
@@ -1,0 +1,52 @@
+Update configure script to include option to enable and disable PDF man page
+generation.
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -27,10 +27,16 @@
+ 	      AS_IF([test "x$enable_debug" = "xno"], [with_debug=no], [with_debug=yes]),
+ 	      [with_debug=yes])
+ AC_SUBST(with_debug)
+ AM_CONDITIONAL([BUILD_DEBUG], [test "x$with_debug" != xno])
+ 
++AC_ARG_ENABLE([pdf-doc],
++	      AS_HELP_STRING([--enable-pdf-doc], [Enable PDF documentation]),
++	      AS_IF([test "x$enable_pdf_doc" = "xno"], [enable_pdf_doc=no],
++	      [enable_pdf_doc=yes]), [enable_pdf_doc=no])
++AM_CONDITIONAL([BUILD_PDF], [test "x$enable_pdf_doc" == "xyes" ])
++
+ # Checks for programs.
+ AC_PROG_CC
+ AC_PROG_MKDIR_P
+ AC_PROG_INSTALL
+ AC_PROG_SED
+@@ -61,15 +67,15 @@
+ 	)]
+ )
+ AC_SUBST(DB2MAN)
+ AM_CONDITIONAL([BUILD_MAN], [test -n "$DB2MAN"])
+ 
+-AC_CHECK_PROG(DBLATEX, [dblatex], [found], [no])
+-AS_IF([test "$DBLATEX" == "no"],
+-	[AC_MSG_WARN([dblatex not found, no PDF manpages will be built])]
+-)
+-AM_CONDITIONAL([BUILD_PDF], [test "$DBLATEX" == "found"])
++AM_COND_IF([BUILD_PDF], [
++	AC_CHECK_PROG(DBLATEX, [dblatex], [found], [no])
++	AS_IF([test "$DBLATEX" == "no"],
++	      [AC_MSG_ERROR([dblatex not found])])
++])
+ 
+ # Checks for libraries.
+ PKG_CHECK_MODULES([LIBMNL], [libmnl >= 1.0.3])
+ PKG_CHECK_MODULES([LIBNFTNL], [libnftnl >= 1.0.5])
+ 
+@@ -134,6 +140,7 @@
+ 
+ echo "
+ nft configuration:
+   cli support:			${with_cli}
+   enable debugging:		${with_debug}
+-  use mini-gmp:			${with_mini_gmp}"
++  use mini-gmp:			${with_mini_gmp}
++  enable pdf documentation:	${enable_pdf_doc}"

--- a/net-firewall/nftables/nftables-0.5-r3.ebuild
+++ b/net-firewall/nftables/nftables-0.5-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,7 +13,7 @@ SRC_URI="http://git.netfilter.org/nftables/snapshot/v${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="debug gmp +readline"
+IUSE="debug doc gmp +readline"
 
 RDEPEND=">=net-libs/libmnl-1.0.3
 	>=net-libs/libnftnl-1.0.5
@@ -21,8 +21,10 @@ RDEPEND=">=net-libs/libmnl-1.0.3
 	readline? ( sys-libs/readline:0= )"
 DEPEND="${RDEPEND}
 	>=app-text/docbook2X-0.8.8-r4
+	doc? ( >=app-text/dblatex-0.3.7 )
 	sys-devel/bison
-	sys-devel/flex"
+	sys-devel/flex
+	virtual/pkgconfig"
 
 S="${WORKDIR}"/v${PV}
 
@@ -36,6 +38,7 @@ pkg_setup() {
 }
 
 src_prepare() {
+	epatch -p1 "${FILESDIR}/${P}-pdf-doc.patch"
 	epatch_user
 	eautoreconf
 }
@@ -44,6 +47,7 @@ src_configure() {
 	econf \
 		--sbindir="${EPREFIX}"/sbin \
 		$(use_enable debug) \
+		$(use_enable doc pdf-doc) \
 		$(use_with readline cli) \
 		$(use_with !gmp mini_gmp)
 }
@@ -52,7 +56,8 @@ src_install() {
 	default
 
 	dodir /usr/libexec/${PN}
-	cp -p "${FILESDIR}"/libexec/${PN}.sh "${D}"/usr/libexec/${PN}/${PN}.sh
+	insinto /usr/libexec/${PN}
+	doins "${FILESDIR}"/libexec/${PN}.sh
 
 	newconfd "${FILESDIR}"/${PN}.confd ${PN}
 	newinitd "${FILESDIR}"/${PN}.init-r2 ${PN}

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -535,3 +535,7 @@ app-admin/rsyslog zeromq
 # Ian Whyman <thev00d00@gentoo.org> (22 May 2016)
 # RPI support on arm
 dev-libs/libcec -raspberry-pi
+
+# Nicholas Vinson <nvinso234@gmail.com> (13 June 2016)
+# net-firewall/nftables[doc] requires dblatex whish is not keyworded
+net-firewall/nftables doc


### PR DESCRIPTION
Remove [[ ... ]] bashism from use_legacy() function.

Gentoo-bug: 585800

Package-Manager: portage-2.3.0_rc1