### PR TITLE
net-firewall/nftables: correct install utility function calls

### DIFF
--- a/net-firewall/nftables/metadata.xml
+++ b/net-firewall/nftables/metadata.xml
@@ -2,13 +2,13 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>mrueg@gentoo.org</email>
-		<name>Manuel Rüger</name>
-	</maintainer>
-	<maintainer type="person">
 		<email>nvinson234@gmail.com</email>
 		<name>Nicholas Vinson</name>
-		<description>Proxy maintainer to be assigned bugs</description>
+		<description>Proxied maintainer to be assigned bugs</description>
+	</maintainer>
+	<maintainer type="person">
+		<email>mrueg@gentoo.org</email>
+		<name>Manuel Rüger</name>
 	</maintainer>
 <maintainer type="project">
 		<email>base-system@gentoo.org</email>

--- a/net-firewall/nftables/nftables-0.5-r4.ebuild
+++ b/net-firewall/nftables/nftables-0.5-r4.ebuild
@@ -56,8 +56,8 @@ src_install() {
 	default
 
 	dodir /usr/libexec/${PN}
-	insinto /usr/libexec/${PN}
-	doins "${FILESDIR}"/libexec/${PN}.sh
+	exeinto /usr/libexec/${PN}
+	doexe "${FILESDIR}"/libexec/${PN}.sh
 
 	newconfd "${FILESDIR}"/${PN}.confd ${PN}
 	newinitd "${FILESDIR}"/${PN}.init-r2 ${PN}


### PR DESCRIPTION
Previous modification changed the cp command to:
    instinto /usr/libexec/${PN}
    doins "${FILESDIR}"/libexec/${PN}.sh

However, this change is incorrect as it strips the exec flag from ${PN}.sh.
This commit changes the instinto and doins to execinfo and doexec which fixes
the problem.

Gentoo-bug: 586000
Closes: 586000

Package-Manager: portage-2.3.0_rc1