### PR TITLE
sys-freebsd/freebsd-sources: Fix the issue that can not build bmake.

### DIFF
--- a/sys-freebsd/freebsd-sources/files/freebsd-ubin-10.3-bmake-workaround.patch
+++ b/sys-freebsd/freebsd-sources/files/freebsd-ubin-10.3-bmake-workaround.patch
@@ -1,0 +1,13 @@
+diff --git a/usr.bin/bmake/Makefile b/usr.bin/bmake/Makefile
+index 6c6d8c2..22fec7a 100644
+--- a/usr.bin/bmake/Makefile
++++ b/usr.bin/bmake/Makefile
+@@ -5,7 +5,7 @@
+ 
+ .sinclude "Makefile.inc"
+ 
+-SRCTOP?= ${.CURDIR:H:H}
++SRCTOP= ${.CURDIR:H:H}
+ 
+ # look here first for config.h
+ CFLAGS+= -I${.CURDIR}

--- a/sys-freebsd/freebsd-sources/freebsd-sources-10.3-r3.ebuild
+++ b/sys-freebsd/freebsd-sources/freebsd-sources-10.3-r3.ebuild
@@ -71,6 +71,10 @@ pkg_setup() {
 src_prepare() {
 	local conf="${S}/$(tc-arch-kernel)/conf/${KERN_BUILD}"
 
+	cd "${WORKDIR}" || die
+	epatch "${FILESDIR}/freebsd-ubin-10.3-bmake-workaround.patch"
+	cd "${S}" || die
+
 	# This replaces the gentoover patch, it doesn't need reapply every time.
 	sed -i -e 's:^REVISION=.*:REVISION="'${PVR}'":' \
 		-e 's:^BRANCH=.*:BRANCH="Gentoo":' \


### PR DESCRIPTION
This problem occurs when upgrading from 9.x.
```
>>> Compiling source in /var/tmp/portage/sys-freebsd/freebsd-sources-10.3-r3/work/sys ...
Warning: Object directory not changed from original /var/tmp/portage/sys-freebsd/freebsd-sources-10.3-r3/work/usr.bin/bmake
make: don't know how to make arch.c. Stop
 * ERROR: sys-freebsd/freebsd-sources-10.3-r3 failed (compile phase):
 *   make failed
```