### PR TITLE
net-p2p/syncthing: add service files for relaysrv

### DIFF
--- a/net-p2p/syncthing/files/relaysrv.systemd.patch
+++ b/net-p2p/syncthing/files/relaysrv.systemd.patch
@@ -1,0 +1,13 @@
+diff --git src/github.com/syncthing/syncthing/cmd/relaysrv/etc/linux-systemd/syncthing-relaysrv.service src/github.com/syncthing/syncthing/cmd/relaysrv/etc/linux-systemd/syncthing-relaysrv.service
+index b9d3173..7f8e2c0 100644
+--- src/github.com/syncthing/syncthing/cmd/relaysrv/etc/linux-systemd/syncthing-relaysrv.service
++++ src/github.com/syncthing/syncthing/cmd/relaysrv/etc/linux-systemd/syncthing-relaysrv.service
+@@ -5,7 +5,7 @@ After=network.target
+ [Service]
+ User=syncthing-relaysrv
+ Group=syncthing-relaysrv
+-ExecStart=/usr/bin/relaysrv
++ExecStart=/usr/libexec/syncthing/relaysrv
+ WorkingDirectory=/var/lib/syncthing-relaysrv
+ 
+ PrivateTmp=true

--- a/net-p2p/syncthing/files/syncthing-relaysrv.confd
+++ b/net-p2p/syncthing/files/syncthing-relaysrv.confd
@@ -1,0 +1,3 @@
+# Options to pass to relaysrv
+# see relaysrv --help for more information
+SR_OPTS=

--- a/net-p2p/syncthing/files/syncthing-relaysrv.initd
+++ b/net-p2p/syncthing/files/syncthing-relaysrv.initd
@@ -1,0 +1,24 @@
+#!/sbin/openrc-run
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+SR_USER=syncthing-relaysrv
+SR_GROUP=syncthing-relaysrv
+SR_HOMEDIR=/var/lib/syncthing-relaysrv
+
+description="Relay service for syncthing"
+command="/usr/bin/relaysrv"
+command_args="${SR_OPTS}"
+pidfile="/run/relaysrv.pid"
+start_stop_daemon_args="--background
+  --user ${SR_USER}
+  --group ${SR_GROUP}
+  --chdir \"${SR_HOMEDIR}\"
+  --make-pidfile "
+
+depend() {
+  need net
+}
+
+start_pre() {
+  checkpath -q -d -o ${SR_USER}:${SR_GROUP} ${SR_HOMEDIR}
+}

--- a/net-p2p/syncthing/files/syncthing-relaysrv.initd
+++ b/net-p2p/syncthing/files/syncthing-relaysrv.initd
@@ -4,6 +4,8 @@
 SR_USER=syncthing-relaysrv
 SR_GROUP=syncthing-relaysrv
 SR_HOMEDIR=/var/lib/syncthing-relaysrv
+SR_LOGFILE=/var/log/syncthing/relaysrv.log
+
 
 description="Relay service for syncthing"
 command="/usr/libexec/syncthing/relaysrv"
@@ -13,7 +15,10 @@ start_stop_daemon_args="--background
   --user ${SR_USER}
   --group ${SR_GROUP}
   --chdir \"${SR_HOMEDIR}\"
-  --make-pidfile "
+  --make-pidfile
+  --stdout \"${SR_LOGFILE}\"
+  --stderr \"${SR_LOGFILE}\" 
+  "
 
 depend() {
   need net
@@ -21,4 +26,5 @@ depend() {
 
 start_pre() {
   checkpath -q -d -o ${SR_USER}:${SR_GROUP} ${SR_HOMEDIR}
+  checkpath -q -f -o ${SR_USER}:${SR_GROUP} ${SR_LOGFILE}
 }

--- a/net-p2p/syncthing/files/syncthing-relaysrv.initd
+++ b/net-p2p/syncthing/files/syncthing-relaysrv.initd
@@ -6,7 +6,7 @@ SR_GROUP=syncthing-relaysrv
 SR_HOMEDIR=/var/lib/syncthing-relaysrv
 
 description="Relay service for syncthing"
-command="/usr/bin/relaysrv"
+command="/usr/libexec/syncthing/relaysrv"
 command_args="${SR_OPTS}"
 pidfile="/run/relaysrv.pid"
 start_stop_daemon_args="--background

--- a/net-p2p/syncthing/files/syncthing-relaysrv.logrotate
+++ b/net-p2p/syncthing/files/syncthing-relaysrv.logrotate
@@ -2,5 +2,5 @@
     missingok
     notifempty
     sharedscripts
-	copytruncate
+    copytruncate
 }

--- a/net-p2p/syncthing/files/syncthing-relaysrv.logrotate
+++ b/net-p2p/syncthing/files/syncthing-relaysrv.logrotate
@@ -1,0 +1,6 @@
+/var/log/syncthing/relaysrv.log {
+    missingok
+    notifempty
+    sharedscripts
+	copytruncate
+}

--- a/net-p2p/syncthing/files/syncthing.logrotate
+++ b/net-p2p/syncthing/files/syncthing.logrotate
@@ -2,8 +2,5 @@
     missingok
     notifempty
     sharedscripts
-    postrotate
-        kill -0 $(</run/syncthing.pid) && \
-          /etc/init.d/syncthing restart > /dev/null 2>&1 || true
-    endscript
+    copytruncate
 }

--- a/net-p2p/syncthing/metadata.xml
+++ b/net-p2p/syncthing/metadata.xml
@@ -18,6 +18,11 @@
 	  Syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized.
 	  Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet.
   </longdescription>
+  <use>
+	<flag name="tools">
+	  Install discosrv, relaysrv and other tools to /usr/libexec/synsthing/.
+	</flag>
+  </use>
   <upstream>
     <remote-id type="github">syncthing/syncthing</remote-id>
     <bugs-to>https://github.com/syncthing/syncthing/issues</bugs-to>

--- a/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
+++ b/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
@@ -24,6 +24,10 @@ RDEPEND=""
 pkg_setup() {
 	enewgroup ${PN}
 	enewuser ${PN} -1 -1 /var/lib/${PN} ${PN}
+
+	# separate user for relaysrv
+	enewgroup ${PN}-relaysrv
+	enewuser ${PN}-relaysrv -1 -1 /var/lib/${PN}-relaysrv ${PN}-relaysrv
 }
 
 src_compile() {
@@ -51,6 +55,12 @@ src_install() {
 	fowners ${PN}:${PN} /var/{lib,log}/${PN}
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}.logrotate" ${PN}
+
+	# for relaysrv
+	systemd_dounit "${S}"/src/${EGO_PN}/cmd/relaysrv/etc/linux-systemd/${PN}-relaysrv.service
+	newconfd "${FILESDIR}/${PN}-relaysrv.confd" ${PN}-relaysrv
+	newinitd "${FILESDIR}/${PN}-relaysrv.initd" ${PN}-relaysrv
+	keepdir /var/lib/${PN}-relaysrv
 }
 
 pkg_postinst() {

--- a/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
+++ b/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
@@ -34,6 +34,13 @@ pkg_setup() {
 	fi
 }
 
+src_prepare() {
+	ls -al *
+	# patching location of relaysrv binary
+	epatch "${FILESDIR}/relaysrv.systemd.patch"
+	eapply_user
+}
+
 src_compile() {
 	export GOPATH="${S}:$(get_golibdir_gopath)"
 	cd src/${EGO_PN}

--- a/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
+++ b/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
@@ -37,11 +37,16 @@ pkg_setup() {
 src_compile() {
 	export GOPATH="${S}:$(get_golibdir_gopath)"
 	cd src/${EGO_PN}
+
+	# if we pass "build" to build.go, it builds only syncthing itself, and places the
+	# binary in the root folder.
+	# if we do not pass "build", all the tools are built, and all binaries are placed 
+	# in folder ./bin
+	ST_BUILD="build"
 	if use tools ; then
-		go run build.go -version "v${PV}" -no-upgrade || die "build failed"
-	else
-		go run build.go -version "v${PV}" -no-upgrade build || die "build failed"
+		ST_BUILD=""
 	fi
+	go run build.go -version "v${PV}" -no-upgrade ${ST_BUILD} || die "build failed"
 }
 
 src_test() {
@@ -58,7 +63,7 @@ src_install() {
 		dobin bin/syncthing
 		exeinto /usr/libexec/syncthing
 		for exe in bin/* ; do
-			[ "${exe}" = "bin/syncthing" ] || doexe ${exe}
+			[ "${exe}" = "bin/syncthing" ] || doexe "${exe}"
 		done
 	else
 		dobin syncthing

--- a/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
+++ b/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
@@ -16,24 +16,32 @@ SRC_URI="https://${EGO_PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 LICENSE="MPL-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~arm"
-IUSE=""
+IUSE="tools"
 
 DEPEND=""
 RDEPEND=""
+
+DOCS="README.md AUTHORS CONTRIBUTING.md"
 
 pkg_setup() {
 	enewgroup ${PN}
 	enewuser ${PN} -1 -1 /var/lib/${PN} ${PN}
 
-	# separate user for relaysrv
-	enewgroup ${PN}-relaysrv
-	enewuser ${PN}-relaysrv -1 -1 /var/lib/${PN}-relaysrv ${PN}-relaysrv
+	if use tools ; then
+		# separate user for relaysrv
+		enewgroup ${PN}-relaysrv
+		enewuser ${PN}-relaysrv -1 -1 /var/lib/${PN}-relaysrv ${PN}-relaysrv
+	fi
 }
 
 src_compile() {
 	export GOPATH="${S}:$(get_golibdir_gopath)"
 	cd src/${EGO_PN}
-	go run build.go -version "v${PV}" -no-upgrade || die "build failed"
+	if use tools ; then
+		go run build.go -version "v${PV}" -no-upgrade || die "build failed"
+	else
+		go run build.go -version "v${PV}" -no-upgrade build || die "build failed"
+	fi
 }
 
 src_test() {
@@ -44,23 +52,39 @@ src_test() {
 src_install() {
 	cd src/${EGO_PN}
 	doman man/*.[157]
-	dobin bin/*
-	dodoc README.md AUTHORS CONTRIBUTING.md
+
+	# binaries
+	if use tools ; then
+		dobin bin/syncthing
+		exeinto /usr/libexec/syncthing
+		for exe in bin/* ; do
+			[ "${exe}" = "bin/syncthing" ] || doexe ${exe}
+		done
+	else
+		dobin syncthing
+	fi
+
+	# openrc and systemd service files
 	systemd_dounit "${S}"/src/${EGO_PN}/etc/linux-systemd/system/${PN}@.service \
 		"${S}"/src/${EGO_PN}/etc/linux-systemd/system/${PN}-resume.service
 	systemd_douserunit "${S}"/src/${EGO_PN}/etc/linux-systemd/user/${PN}.service
 	newconfd "${FILESDIR}/${PN}.confd" ${PN}
 	newinitd "${FILESDIR}/${PN}.initd" ${PN}
+
 	keepdir /var/{lib,log}/${PN}
 	fowners ${PN}:${PN} /var/{lib,log}/${PN}
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}.logrotate" ${PN}
 
-	# for relaysrv
-	systemd_dounit "${S}"/src/${EGO_PN}/cmd/relaysrv/etc/linux-systemd/${PN}-relaysrv.service
-	newconfd "${FILESDIR}/${PN}-relaysrv.confd" ${PN}-relaysrv
-	newinitd "${FILESDIR}/${PN}-relaysrv.initd" ${PN}-relaysrv
-	keepdir /var/lib/${PN}-relaysrv
+	if use tools ; then
+		# openrc and systemd service files
+		systemd_dounit "${S}"/src/${EGO_PN}/cmd/relaysrv/etc/linux-systemd/${PN}-relaysrv.service
+		newconfd "${FILESDIR}/${PN}-relaysrv.confd" ${PN}-relaysrv
+		newinitd "${FILESDIR}/${PN}-relaysrv.initd" ${PN}-relaysrv
+		
+		keepdir /var/lib/${PN}-relaysrv
+		fowners ${PN}-relaysrv:${PN}-relaysrv /var/{lib,log}/${PN}
+	fi
 }
 
 pkg_postinst() {

--- a/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
+++ b/net-p2p/syncthing/syncthing-0.13.7-r1.ebuild
@@ -35,9 +35,9 @@ pkg_setup() {
 }
 
 src_prepare() {
-	ls -al *
 	# patching location of relaysrv binary
 	epatch "${FILESDIR}/relaysrv.systemd.patch"
+	
 	eapply_user
 }
 
@@ -96,6 +96,9 @@ src_install() {
 		
 		keepdir /var/lib/${PN}-relaysrv
 		fowners ${PN}-relaysrv:${PN}-relaysrv /var/{lib,log}/${PN}
+	
+		insinto /etc/logrotate.d
+		newins "${FILESDIR}/syncthing-relaysrv.logrotate" syncthing-relaysrv
 	fi
 }
 


### PR DESCRIPTION
Hi,

the relay service for syncthing used to be a separate program, and we have the ebuild for it in the tree,
`net-p2p/syncthing-relaysrv`. Recently upstream merged it with syncthing, and our recent ebuilds install in pacticular the binary `/usr/bin/relaysrv`.

This PR adds openrc and systemd service files for relaysrv to `net-p2p/syncthing`. If you agree with me and this PR gets merged, the next step would be to remove `net-p2p/syncthing-relaysrv` from the tree.

@sbraz @djc 