### PR TITLE
app-admin/passook - update Homepage

### DIFF
--- a/app-admin/passook/passook-20121001.ebuild
+++ b/app-admin/passook/passook-20121001.ebuild
@@ -7,7 +7,7 @@ EAPI=4
 inherit eutils prefix
 
 DESCRIPTION="Password generator capable of generating pronounceable and/or secure passwords"
-HOMEPAGE="http://mackers.com/misc/scripts/passook/"
+HOMEPAGE="https://github.com/mackers/passook"
 # snapshot of git://github.com/mackers/passook.git
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 


### PR DESCRIPTION
Hi,

passook's homepage isn't valid anymore (while it seems it still belongs to the author). However, since the code is hosted on github, i've changed the Homepage to the github address.
Please review