### PR TITLE
net-im/qtox: update to EAPI 6

### DIFF
--- a/net-im/qtox/qtox-1.3.0.ebuild
+++ b/net-im/qtox/qtox-1.3.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit eutils qmake-utils
 
@@ -54,10 +54,6 @@ pkg_pretend() {
 			fi
 		fi
 	fi
-}
-
-src_prepare() {
-	epatch_user
 }
 
 src_configure() {

--- a/net-im/qtox/qtox-1.4.0.ebuild
+++ b/net-im/qtox/qtox-1.4.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit eutils qmake-utils
 
@@ -55,10 +55,6 @@ pkg_pretend() {
 			fi
 		fi
 	fi
-}
-
-src_prepare() {
-	epatch_user
 }
 
 src_configure() {

--- a/net-im/qtox/qtox-9999.ebuild
+++ b/net-im/qtox/qtox-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit eutils qmake-utils git-r3
 
@@ -56,18 +56,11 @@ pkg_pretend() {
 	fi
 }
 
-src_prepare() {
-	epatch_user
-}
-
 src_configure() {
 	use gtk || local NO_GTK_SUPPORT="ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=NO ENABLE_SYSTRAY_GTK_BACKEND=NO"
 	use X || local NO_X_SUPPORT="DISABLE_PLATFORM_EXT=YES"
-	# filter_audio is disabled since it's not available in Gentoo, and
-	# support for it in qTox at the present is ~broken anyway
 	eqmake5 \
 			PREFIX="${D}/usr" \
-			DISABLE_FILTER_AUDIO=YES \
 			${NO_GTK_SUPPORT} \
 			${NO_X_SUPPORT}
 }


### PR DESCRIPTION
Also remove no longer needed part from live ebuild, since upstream
removed support for filter_audio completely.
https://github.com/tux3/qTox/commit/792103f8b0c76ecec576f7e57efb3edb71

Package-Manager: portage-2.2.28