### PR TITLE
sys-devel/llvm: Fix build fails on Gentoo/FreeBSD.

### DIFF
--- a/sys-devel/llvm/files/clang-3.8-compiler-rt-fbsd.patch
+++ b/sys-devel/llvm/files/clang-3.8-compiler-rt-fbsd.patch
@@ -1,0 +1,20 @@
+https://llvm.org/bugs/show_bug.cgi?id=26651
+https://github.com/llvm-mirror/compiler-rt/commit/6606c7b50cbb4ec7eab4ecbebbbaaa049734bbd3
+
+diff --git a/projects/compiler-rt/lib/tsan/CMakeLists.txt b/projects/compiler-rt/lib/tsan/CMakeLists.txt
+index c185cfa..a151c6c 100644
+--- a/projects/compiler-rt/lib/tsan/CMakeLists.txt
++++ b/projects/compiler-rt/lib/tsan/CMakeLists.txt
+@@ -192,7 +192,11 @@ endif()
+ add_dependencies(compiler-rt tsan)
+ 
+ # Make sure that non-platform-specific files don't include any system headers.
+-if(COMPILER_RT_HAS_SYSROOT_FLAG)
++# FreeBSD does not install a number of Clang-provided headers for the compiler
++# in the base system due to incompatibilities between FreeBSD's and Clang's
++# versions. As a workaround do not use --sysroot=. on FreeBSD until this is
++# addressed.                                                        
++if(COMPILER_RT_HAS_SYSROOT_FLAG AND NOT CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+   file(GLOB _tsan_generic_sources rtl/tsan*)
+   file(GLOB _tsan_platform_sources rtl/tsan*posix* rtl/tsan*mac*
+                                    rtl/tsan*linux*)

--- a/sys-devel/llvm/llvm-3.8.0-r2.ebuild
+++ b/sys-devel/llvm/llvm-3.8.0-r2.ebuild
@@ -170,6 +170,9 @@ src_prepare() {
 	# disable use of SDK on OSX, bug #568758
 	sed -i -e 's/xcrun/false/' utils/lit/lit/util.py || die
 
+	# Workaround, can be compiled with gcc on Gentoo/FreeBSD, bug #578064
+	use kernel_FreeBSD && [[ $(tc-getCC) == *gcc* ]] && append-cppflags "-D_GLIBCXX_USE_C99"
+
 	if use clang; then
 		# Automatically select active system GCC's libraries, bugs #406163 and #417913
 		eapply "${FILESDIR}"/clang-3.5-gentoo-runtime-gcc-detection-v3.patch
@@ -197,6 +200,10 @@ src_prepare() {
 		# (that is used only to find LLVMgold.so)
 		# https://llvm.org/bugs/show_bug.cgi?id=23793
 		eapply "${FILESDIR}"/cmake/clang-0002-cmake-Make-CLANG_LIBDIR_SUFFIX-overridable.patch
+
+		# Fix 'stdarg.h' file not found on Gentoo/FreeBSD, bug #578064
+		# https://llvm.org/bugs/show_bug.cgi?id=26651
+		eapply "${FILESDIR}"/clang-3.8-compiler-rt-fbsd.patch
 
 		pushd projects/compiler-rt >/dev/null || die
 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=578064