### PR TITLE
app-admin/setools: update Homepage

### DIFF
--- a/app-admin/setools/setools-3.3.8-r5.ebuild
+++ b/app-admin/setools/setools-3.3.8-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools java-pkg-opt-2 python-r1 eutils toolchain-funcs
 
 DESCRIPTION="SELinux policy tools"
-HOMEPAGE="http://www.tresys.com/selinux/selinux_policy_tools.shtml"
+HOMEPAGE="https://github.com/TresysTechnology/setools/wiki"
 SRC_URI="http://oss.tresys.com/projects/setools/chrome/site/dists/${P}/${P}.tar.bz2
 	https://dev.gentoo.org/~swift/patches/setools/${P}-01-fedora-patches.tar.gz
 	https://dev.gentoo.org/~swift/patches/setools/${P}-03-gentoo-patches.tar.gz"

--- a/app-admin/setools/setools-3.3.8-r7.ebuild
+++ b/app-admin/setools/setools-3.3.8-r7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_4 )
 inherit autotools java-pkg-opt-2 python-r1 eutils toolchain-funcs
 
 DESCRIPTION="SELinux policy tools"
-HOMEPAGE="http://www.tresys.com/selinux/selinux_policy_tools.shtml"
+HOMEPAGE="https://github.com/TresysTechnology/setools/wiki"
 SRC_URI="http://oss.tresys.com/projects/setools/chrome/site/dists/${P}/${P}.tar.bz2
 	https://dev.gentoo.org/~perfinion/patches/setools/${P}-04-gentoo-patches.tar.bz2"
 


### PR DESCRIPTION
Hi,

Another Homepage fix. This time for setools.
The original Homepage of setools doesn't work anymore so i've fixed it. Version 4.0.1 and 9999 already have the github address.