### PR TITLE
app-admin/grubconfig - revbump: eapi bump, update homepage, update src_uri, cleanups

### DIFF
--- a/app-admin/grubconfig/grubconfig-1.28-r1.ebuild
+++ b/app-admin/grubconfig/grubconfig-1.28-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 inherit multilib
 
 DESCRIPTION="Simple Tool to configure Grub-Bootloader"
-HOMEPAGE="http://www.tux.org/pub/people/kent-robotti/looplinux/"
+HOMEPAGE="https://web.archive.org/web/20100410042718/http://www.tux.org/pub/people/kent-robotti/looplinux"
 SRC_URI="http://www.tux.org/pub/people/kent-robotti/looplinux/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-admin/grubconfig/grubconfig-1.28-r1.ebuild
+++ b/app-admin/grubconfig/grubconfig-1.28-r1.ebuild
@@ -6,7 +6,7 @@ inherit multilib
 
 DESCRIPTION="Simple Tool to configure Grub-Bootloader"
 HOMEPAGE="https://web.archive.org/web/20100410042718/http://www.tux.org/pub/people/kent-robotti/looplinux"
-SRC_URI="http://www.tux.org/pub/people/kent-robotti/looplinux/${P}.tar.gz"
+SRC_URI="http://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-admin/grubconfig/grubconfig-1.28-r2.ebuild
+++ b/app-admin/grubconfig/grubconfig-1.28-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 DESCRIPTION="Simple Tool to configure Grub-Bootloader"
 HOMEPAGE="https://web.archive.org/web/20100410042718/http://www.tux.org/pub/people/kent-robotti/looplinux"
-SRC_URI="http://www.tux.org/pub/people/kent-robotti/looplinux/${P}.tar.gz"
+SRC_URI="http://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-admin/grubconfig/grubconfig-1.28-r2.ebuild
+++ b/app-admin/grubconfig/grubconfig-1.28-r2.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+DESCRIPTION="Simple Tool to configure Grub-Bootloader"
+HOMEPAGE="https://web.archive.org/web/20100410042718/http://www.tux.org/pub/people/kent-robotti/looplinux"
+SRC_URI="http://www.tux.org/pub/people/kent-robotti/looplinux/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="-* amd64 x86"
+IUSE=""
+
+RDEPEND=">=dev-util/dialog-0.7"
+
+src_prepare() {
+	sed -i \
+		-e "s:/usr/lib/grub:/$(get_libdir)/grub:g" \
+		grubconfig || die
+	eapply_user
+}
+
+src_install() {
+	dosbin grubconfig
+	dodoc README
+}


### PR DESCRIPTION
Hi, 

While fixing grubconfig's Homepage i tried to fix the whole ebuild. I've made a new reversion and bumped EAPI to 6 + some minor changes to the ebuild. Furthermore I've also updated the Homepage + SRC_URI. Since both are not available anymore i decided to use a archived Homepage from 2010 and added gentoo's mirror as SRC_URI.

After all i would suggest to even remove -r1...

Please review.