### PR TITLE
app-admin/verynice - eapi bump, fix hp and src_uri

### DIFF
--- a/app-admin/verynice/verynice-1.1-r2.ebuild
+++ b/app-admin/verynice/verynice-1.1-r2.ebuild
@@ -1,14 +1,14 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit eutils systemd toolchain-funcs
 
 DESCRIPTION="A tool for dynamically adjusting the nice-level of processes"
-HOMEPAGE="http://thermal.cnde.iastate.edu/~sdh4/verynice/"
-SRC_URI="http://thermal.cnde.iastate.edu/~sdh4/verynice/down/${P}.tar.gz"
+HOMEPAGE="https://web.archive.org/web/20130621090315/http://thermal.cnde.iastate.edu/~sdh4/verynice/"
+SRC_URI="http://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -18,7 +18,7 @@ IUSE=""
 S=${WORKDIR}/${PN}
 
 src_prepare() {
-	epatch "${FILESDIR}"/${P}-build.patch
+	eapply "${FILESDIR}"/${P}-build.patch
 }
 
 src_compile() {


### PR DESCRIPTION
Hi,

This patch fixes verynice's homepage and src_uri. Since both links are down i decided to go once again with a archive.org link of the original homepage (which is also mentioned at the arch wiki). For the src_uri i simply used the gentoo mirror link.
Furthermore i bumped eapi to version 6 and replaced epatch with eapply. Since this was the only change regarding eapi i didn't made a revbump of the ebuild.

Please review