### PR TITLE
app-admin/sysstat: remove invalid use of doc use flag

### DIFF
--- a/app-admin/sysstat/sysstat-11.3.4-r1.ebuild
+++ b/app-admin/sysstat/sysstat-11.3.4-r1.ebuild
@@ -89,5 +89,5 @@ src_install() {
 	newinitd "${FILESDIR}"/${PN}.init.d ${PN}
 	systemd_dounit ${PN}.service
 
-	use doc && rm -f "${D}"usr/share/doc/${PF}/COPYING
+	rm -f "${D}"usr/share/doc/${PF}/COPYING
 }


### PR DESCRIPTION
Gentoo-Bug: 586570
Package-Manager: portage-2.3.0_rc1

https://bugs.gentoo.org/show_bug.cgi?id=586570