### PR TITLE
media-video/mpv: reorder maintainers in metadata

### DIFF
--- a/media-video/mpv/metadata.xml
+++ b/media-video/mpv/metadata.xml
@@ -2,16 +2,15 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>yngwin@gentoo.org</email>
-		<description>Primary maintainer</description>
-	</maintainer>
-	<maintainer type="person">
-		<email>maksbotan@gentoo.org</email>
-	</maintainer>
-	<maintainer type="person">
 		<email>itumaykin+gentoo@gmail.com</email>
 		<name>Coacher</name>
 		<description>Proxied maintainer; set to assignee in all bugs</description>
+	</maintainer>
+	<maintainer type="person">
+		<email>yngwin@gentoo.org</email>
+	</maintainer>
+	<maintainer type="person">
+		<email>maksbotan@gentoo.org</email>
 	</maintainer>
 	<maintainer type="project">
 		<email>media-video@gentoo.org</email>


### PR DESCRIPTION
I don't mind if yngwin restores himself later to the first position in
the maintainers list. But until he's on devaway let's have bugs assigned
to me right away. I've also removed yngwin's description for now so it
won't confuse bug wranglers. Again I don't mind if he restores it.

See also https://bugs.gentoo.org/show_bug.cgi?id=586318#c1

Package-Manager: portage-2.3.0_rc1
RepoMan-Options: --force