### PR TITLE
app-crypt/gnupg: fix remaining ebuilds building with Clang

### DIFF
--- a/app-crypt/gnupg/gnupg-2.0.26-r3.ebuild
+++ b/app-crypt/gnupg/gnupg-2.0.26-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -84,6 +84,9 @@ src_configure() {
 	else
 		myconf+=( --enable-symcryptrun )
 	fi
+
+	# glib fails and picks up clang's internal stdint.h causing weird errors
+	[[ ${CC} == *clang ]] && export gl_cv_absolute_stdint_h=/usr/include/stdint.h
 
 	econf \
 		--docdir="${EPREFIX}/usr/share/doc/${PF}" \

--- a/app-crypt/gnupg/gnupg-2.0.28.ebuild
+++ b/app-crypt/gnupg/gnupg-2.0.28.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -84,7 +84,7 @@ src_configure() {
 	fi
 
 	# glib fails and picks up clang's internal stdint.h causing weird errors
-	[[ ${CC} == clang ]] && export gl_cv_absolute_stdint_h=/usr/include/stdint.h
+	[[ ${CC} == *clang ]] && export gl_cv_absolute_stdint_h=/usr/include/stdint.h
 
 	econf \
 		--docdir="${EPREFIX}/usr/share/doc/${PF}" \


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/458154

Package-Manager: portage-2.2.28

@alonbl @Flameeyes @krifisk @radhermit @robbat2 @ZeroChaos- 

I realize these ebuilds are stable, but the changes only affects users that can't build currently (clang), so that shouldn't be a problem. Revbumping for this oneliner (that doesn't patch the source) seems excessive.