### PR TITLE
dev-scheme/guile: fix guile-2.0.0 building with clang

### DIFF
--- a/dev-scheme/guile/files/guile-2.0.0-clang-apicontrol-texi.patch
+++ b/dev-scheme/guile/files/guile-2.0.0-clang-apicontrol-texi.patch
@@ -1,0 +1,12 @@
+--- a/doc/ref/api-control.texi	2016-06-23 03:35:29.973976657 -0500
++++ b/doc/ref/api-control.texi	2016-06-23 03:33:36.589969005 -0500
+@@ -1492,8 +1492,8 @@
+ @deftypefnx {C Function} void scm_wrong_type_arg (char *@var{subr}, int @var{argnum}, SCM @var{bad_value})
+ @deftypefnx {C Function} void scm_wrong_type_arg_msg (char *@var{subr}, int @var{argnum}, SCM @var{bad_value}, const char *@var{expected})
+ @deftypefnx {C Function} void scm_memory_error (char *@var{subr})
+-Throw an error with the various keys described above.
+ @deftypefnx {C Function} void scm_misc_error (const char *@var{subr}, const char *@var{message}, SCM @var{args})
++Throw an error with the various keys described above.
+ 
+ In @code{scm_wrong_num_args}, @var{proc} should be a Scheme symbol
+ which is the name of the procedure incorrectly invoked.  The other

--- a/dev-scheme/guile/guile-2.0.0.ebuild
+++ b/dev-scheme/guile/guile-2.0.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=3
-inherit eutils flag-o-matic elisp-common
+EAPI=6
+inherit flag-o-matic elisp-common
 
 DESCRIPTION="GNU Ubiquitous Intelligent Language for Extensions"
 HOMEPAGE="https://www.gnu.org/software/guile/"
@@ -29,11 +29,15 @@ DEPEND="${RDEPEND}
 SLOT="2"
 MAJOR="2.0"
 
+PATCHES=(
+	"${FILESDIR}/${P}-clang-apicontrol-texi.patch"
+	)
+
 src_configure() {
 	# see bug #178499
 	filter-flags -ftree-vectorize
 
-	#will fail for me if posix is disabled or without modules -- hkBst
+	# will fail for me if posix is disabled or without modules -- hkBst
 	econf \
 		--disable-error-on-warning \
 		--disable-static \
@@ -51,26 +55,15 @@ src_configure() {
 #		EMACS=no
 }
 
-src_compile()  {
-	emake || die "make failed"
-
-	# Above we have disabled the build system's Emacs support;
-	# for USE=emacs we compile (and install) the files manually
-	# if use emacs; then
-	# 	cd emacs
-	# 	make
-	# 	elisp-compile *.el || die
-	# fi
-}
-
 src_install() {
-	einstall || die "install failed"
+	default
 
-	dodoc AUTHORS ChangeLog GUILE-VERSION HACKING NEWS README THANKS || die
+	dodoc GUILE-VERSION HACKING
 
 	# texmacs needs this, closing bug #23493
 	dodir /etc/env.d
-	echo "GUILE_LOAD_PATH=\"${EPREFIX}/usr/share/guile/${MAJOR}\"" > "${ED}"/etc/env.d/50guile
+	echo "GUILE_LOAD_PATH=\"${EPREFIX}/usr/share/guile/${MAJOR}\"" \
+	> "${ED}"/etc/env.d/50guile || die
 
 	# necessary for registering slib, see bug 206896
 	keepdir /usr/share/guile/site


### PR DESCRIPTION
Also update to EAPI=6

There's https://bugs.gentoo.org/427346, but that's for 1.8.8. I haven't been able to get that to work, even with the FreeBSD patches. 2.0.0 has a .texi build error, but otherwise builds fine (patched here).

@Amynka 