### PR TITLE
sci-geosciences/merkaartor: Only allow qrcode with Qt4

### DIFF
--- a/sci-geosciences/merkaartor/merkaartor-0.18.2.ebuild
+++ b/sci-geosciences/merkaartor/merkaartor-0.18.2.ebuild
@@ -17,8 +17,10 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="debug exif gps libproxy qrcode qt4 qt5"
 
-REQUIRED_USE="^^ ( qt4 qt5 )"
-
+REQUIRED_USE="
+	^^ ( qt4 qt5 )
+	qrcode? ( qt4 )
+"
 RDEPEND="
 	qt4? (
 		dev-qt/qtcore:4


### PR DESCRIPTION
media-gfx/zbar is only available for Qt4

emerging sci-geosciences/merkaartor-0.18.2[qrcode,qt5] fails with:
```
In file included from WalkingPapersAdapter.cpp:35:0:
/usr/include/zbar/QZBarImage.h: In constructor ‘zbar::QZBarImage::QZBarImage(const QImage&)’:
/usr/include/zbar/QZBarImage.h:57:38: error: ‘const class QImage’ has no member named ‘numBytes’
         unsigned long datalen = qimg.numBytes();
```
@Amynka
