### PR TITLE
kde-plasma/plasma-workspace: Add back legacy (gtk2) session mgmt

### DIFF
--- a/kde-plasma/kwin/files/kwin-5.6.5-legacy-session-mgmt.patch
+++ b/kde-plasma/kwin/files/kwin-5.6.5-legacy-session-mgmt.patch
@@ -1,0 +1,140 @@
+commit 59740e7416bb2b3a9852212fa4b213e5ba76deb7
+Author: Andreas Hartmetz <ahartmetz@gmail.com>
+Date:   Thu Jun 23 19:40:40 2016 +0200
+
+    Revert "Remove saving and loading (and client matching by) WM_COMMAND."
+    
+    This reverts commit 2eac7634cc524bf5e425cf081a639a6b6407e380.
+    
+    CCBUG: 362671
+
+diff --git a/activities.cpp b/activities.cpp
+index 25eb1c1..42c5db8 100644
+--- a/activities.cpp
++++ b/activities.cpp
+@@ -169,7 +169,7 @@ void Activities::reallyStop(const QString &id)
+         const Client* c = (*it);
+         const QByteArray sessionId = c->sessionId();
+         if (sessionId.isEmpty()) {
+-            continue;
++            continue; //TODO support old wm_command apps too?
+         }
+ 
+         //qDebug() << sessionId;
+diff --git a/sm.cpp b/sm.cpp
+index 08810a4..ca1edea 100644
+--- a/sm.cpp
++++ b/sm.cpp
+@@ -109,8 +109,12 @@ void Workspace::storeSession(KConfig* config, SMSavePhase phase)
+     for (ClientList::Iterator it = clients.begin(); it != clients.end(); ++it) {
+         Client* c = (*it);
+         QByteArray sessionId = c->sessionId();
++        QByteArray wmCommand = c->wmCommand();
+         if (sessionId.isEmpty())
+-            continue;
++            // remember also applications that are not XSMP capable
++            // and use the obsolete WM_COMMAND / WM_SAVE_YOURSELF
++            if (wmCommand.isEmpty())
++                continue;
+         count++;
+         if (c->isActive())
+             active_client = count;
+@@ -140,6 +144,7 @@ void Workspace::storeClient(KConfigGroup &cg, int num, Client *c)
+     QString n = QString::number(num);
+     cg.writeEntry(QLatin1String("sessionId") + n, c->sessionId().constData());
+     cg.writeEntry(QLatin1String("windowRole") + n, c->windowRole().constData());
++    cg.writeEntry(QLatin1String("wmCommand") + n, c->wmCommand().constData());
+     cg.writeEntry(QLatin1String("resourceName") + n, c->resourceName().constData());
+     cg.writeEntry(QLatin1String("resourceClass") + n, c->resourceClass().constData());
+     cg.writeEntry(QLatin1String("geometry") + n, QRect(c->calculateGravitation(true), c->clientSize()));   // FRAME
+@@ -180,8 +185,12 @@ void Workspace::storeSubSession(const QString &name, QSet<QByteArray> sessionIds
+     for (ClientList::Iterator it = clients.begin(); it != clients.end(); ++it) {
+         Client* c = (*it);
+         QByteArray sessionId = c->sessionId();
++        QByteArray wmCommand = c->wmCommand();
+         if (sessionId.isEmpty())
+-            continue;
++            // remember also applications that are not XSMP capable
++            // and use the obsolete WM_COMMAND / WM_SAVE_YOURSELF
++            if (wmCommand.isEmpty())
++                continue;
+         if (!sessionIds.contains(sessionId))
+             continue;
+ 
+@@ -221,6 +230,7 @@ void Workspace::addSessionInfo(KConfigGroup &cg)
+         session.append(info);
+         info->sessionId = cg.readEntry(QLatin1String("sessionId") + n, QString()).toLatin1();
+         info->windowRole = cg.readEntry(QLatin1String("windowRole") + n, QString()).toLatin1();
++        info->wmCommand = cg.readEntry(QLatin1String("wmCommand") + n, QString()).toLatin1();
+         info->resourceName = cg.readEntry(QLatin1String("resourceName") + n, QString()).toLatin1();
+         info->resourceClass = cg.readEntry(QLatin1String("resourceClass") + n, QString()).toLower().toLatin1();
+         info->geometry = cg.readEntry(QLatin1String("geometry") + n, QRect());
+@@ -269,6 +279,7 @@ SessionInfo* Workspace::takeSessionInfo(Client* c)
+     SessionInfo *realInfo = 0;
+     QByteArray sessionId = c->sessionId();
+     QByteArray windowRole = c->windowRole();
++    QByteArray wmCommand = c->wmCommand();
+     QByteArray resourceName = c->resourceName();
+     QByteArray resourceClass = c->resourceClass();
+ 
+@@ -302,8 +313,10 @@ SessionInfo* Workspace::takeSessionInfo(Client* c)
+             if (info->resourceName == resourceName
+                     && info->resourceClass == resourceClass
+                     && sessionInfoWindowTypeMatch(c, info)) {
+-                realInfo = info;
+-                session.removeAll(info);
++                if (wmCommand.isEmpty() || info->wmCommand == wmCommand) {
++                    realInfo = info;
++                    session.removeAll(info);
++                }
+             }
+         }
+     }
+diff --git a/sm.h b/sm.h
+index 4c5fda6..529187d 100644
+--- a/sm.h
++++ b/sm.h
+@@ -41,6 +41,7 @@ class Client;
+ struct SessionInfo {
+     QByteArray sessionId;
+     QByteArray windowRole;
++    QByteArray wmCommand;
+     QByteArray wmClientMachine;
+     QByteArray resourceName;
+     QByteArray resourceClass;
+diff --git a/toplevel.cpp b/toplevel.cpp
+index af368b5..4a7ec6d 100644
+--- a/toplevel.cpp
++++ b/toplevel.cpp
+@@ -177,6 +177,19 @@ QByteArray Toplevel::sessionId() const
+     return result;
+ }
+ 
++/*!
++  Returns command property for this client,
++  taken either from its window or from the leader window.
++ */
++QByteArray Toplevel::wmCommand()
++{
++    QByteArray result = Xcb::StringProperty(window(), XCB_ATOM_WM_COMMAND);
++    if (result.isEmpty() && wmClientLeaderWin && wmClientLeaderWin != window())
++        result = Xcb::StringProperty(wmClientLeaderWin, XCB_ATOM_WM_COMMAND);
++    result.replace(0, ' ');
++    return result;
++}
++
+ void Toplevel::getWmClientMachine()
+ {
+     m_clientMachine->resolve(window(), wmClientLeader());
+diff --git a/toplevel.h b/toplevel.h
+index 3133851..91eee5f 100644
+--- a/toplevel.h
++++ b/toplevel.h
+@@ -274,6 +274,7 @@ public:
+     QByteArray sessionId() const;
+     QByteArray resourceName() const;
+     QByteArray resourceClass() const;
++    QByteArray wmCommand();
+     QByteArray wmClientMachine(bool use_localhost) const;
+     const ClientMachine *clientMachine() const;
+     Window wmClientLeader() const;

--- a/kde-plasma/kwin/kwin-5.6.5-r1.ebuild
+++ b/kde-plasma/kwin/kwin-5.6.5-r1.ebuild
@@ -1,0 +1,99 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+KDE_HANDBOOK="optional"
+KDE_TEST="optional"
+VIRTUALX_REQUIRED="test"
+inherit kde5
+
+DESCRIPTION="KDE window manager"
+LICENSE="GPL-2+"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="gles2 multimedia"
+
+# drop qtcore subslot operator when QT_MINIMAL >= 5.7.0
+COMMON_DEPEND="
+	$(add_frameworks_dep kactivities)
+	$(add_frameworks_dep kauth)
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kcrash)
+	$(add_frameworks_dep kdeclarative)
+	$(add_frameworks_dep kglobalaccel)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kidletime)
+	$(add_frameworks_dep kinit)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep knewstuff)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep kpackage)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep kwayland)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem X)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep plasma)
+	$(add_plasma_dep kdecoration)
+	$(add_plasma_dep kscreenlocker)
+	$(add_qt_dep qtcore '' '' '5=')
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative)
+	$(add_qt_dep qtgui 'gles2=,opengl(+)')
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	>=dev-libs/libinput-0.10
+	>=dev-libs/wayland-1.2
+	media-libs/fontconfig
+	media-libs/freetype
+	media-libs/libepoxy
+	media-libs/mesa[egl,gbm,gles2?,wayland]
+	virtual/libudev:=
+	x11-libs/libICE
+	x11-libs/libSM
+	x11-libs/libX11
+	x11-libs/libXi
+	x11-libs/libdrm
+	>=x11-libs/libxcb-1.10
+	>=x11-libs/libxkbcommon-0.4.1
+	x11-libs/xcb-util-cursor
+	x11-libs/xcb-util-image
+	x11-libs/xcb-util-keysyms
+"
+RDEPEND="${COMMON_DEPEND}
+	$(add_plasma_dep kde-cli-tools)
+	multimedia? (
+		|| (
+			$(add_qt_dep qtmultimedia 'gstreamer,qml')
+			$(add_qt_dep qtmultimedia 'gstreamer010,qml')
+		)
+	)
+	!<kde-apps/kdeartwork-meta-15.08.3-r1:4
+	!kde-base/kwin:4
+	!kde-base/systemsettings:4
+"
+DEPEND="${COMMON_DEPEND}
+	$(add_qt_dep designer)
+	$(add_qt_dep qtconcurrent)
+	x11-proto/xproto
+	test? (	x11-libs/xcb-util-wm )
+"
+
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-5.6.3-glibc-sysmacros.patch"
+	"${FILESDIR}/${PN}-5.6.5-legacy-session-mgmt.patch" # backport in 5.6 after release
+)
+
+src_prepare() {
+	kde5_src_prepare
+	use multimedia || eapply "${FILESDIR}/${PN}-gstreamer-optional.patch"
+}

--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.6.5.1-legacy-session-mgmt.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.6.5.1-legacy-session-mgmt.patch
@@ -1,0 +1,558 @@
+commit e4a76cd947759fd723935965ca30c00021601a45
+Author: Andreas Hartmetz <ahartmetz@gmail.com>
+Date:   Thu Jun 23 19:36:18 2016 +0200
+
+    Revert "Remove legacy session management support."
+    
+    This reverts commit 5f0ca1305db4a925dbdbf927f541497be334feff.
+    
+    Firefox and some GTK+ 2 applications still seem to use the old way.
+    For shame.
+    
+    BUG: 362671
+
+--- a/ksmserver/CMakeLists.txt
++++ b/ksmserver/CMakeLists.txt
+@@ -15,4 +15,5 @@ set(ksmserver_KDEINIT_SRCS
+     shutdowndlg.cpp
+     switchuserdialog.cpp
++    legacy.cpp
+     startup.cpp
+     shutdown.cpp
+--- /dev/null
++++ b/ksmserver/legacy.cpp
+@@ -0,0 +1,419 @@
++/*****************************************************************
++ksmserver - the KDE session management server
++
++Copyright 2000 Matthias Ettrich <ettrich@kde.org>
++Copyright 2005 Lubos Lunak <l.lunak@kde.org>
++
++relatively small extensions by Oswald Buddenhagen <ob6@inf.tu-dresden.de>
++
++some code taken from the dcopserver (part of the KDE libraries), which is
++Copyright 1999 Matthias Ettrich <ettrich@kde.org>
++Copyright 1999 Preston Brown <pbrown@kde.org>
++
++Permission is hereby granted, free of charge, to any person obtaining a copy
++of this software and associated documentation files (the "Software"), to deal
++in the Software without restriction, including without limitation the rights
++to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++copies of the Software, and to permit persons to whom the Software is
++furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in
++all copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
++AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
++AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
++CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++
++******************************************************************/
++
++#include <QtX11Extras/QX11Info>
++#include <QDebug>
++
++#include <config-workspace.h>
++
++#include <ksmserver_debug.h>
++
++#ifdef HAVE_SYS_TIME_H
++#include <sys/time.h>
++#endif
++
++#include "server.h"
++
++#include <unistd.h>
++
++
++#include <kconfig.h>
++#include <kconfiggroup.h>
++#include <KSharedConfig>
++#include <kshell.h>
++#include <kwindowsystem.h>
++
++#include <X11/Xlib.h>
++#include <X11/Xutil.h>
++#include <X11/Xatom.h>
++
++/*
++* Legacy session management
++*/
++
++#ifndef NO_LEGACY_SESSION_MANAGEMENT
++static WindowMap* windowMapPtr = 0;
++
++static Atom wm_save_yourself = XNone;
++static Atom wm_protocols = XNone;
++static Atom wm_client_leader = XNone;
++static Atom sm_client_id = XNone;
++
++static int winsErrorHandler(Display *, XErrorEvent *ev)
++{
++    if (windowMapPtr) {
++        WindowMap::Iterator it = windowMapPtr->find(ev->resourceid);
++        if (it != windowMapPtr->end())
++            (*it).type = SM_ERROR;
++    }
++    return 0;
++}
++
++void KSMServer::performLegacySessionSave()
++{
++    qCDebug(KSMSERVER) << "Saving legacy session apps";
++    if (state == ClosingSubSession)
++        return; //FIXME implement later
++
++    KSharedConfig::Ptr config = KSharedConfig::openConfig();
++    config->reparseConfiguration(); // config may have changed in the KControl module
++    KConfigGroup cg( config, "General" );
++
++    int wmSaveYourselfTimeout = cg.readEntry( "legacySaveTimeoutSecs", 4 ) * 1000;
++
++    // Setup error handler
++    legacyWindows.clear();
++    windowMapPtr = &legacyWindows;
++    XErrorHandler oldHandler = XSetErrorHandler(winsErrorHandler);
++    // Compute set of leader windows that need legacy session management
++    // and determine which style (WM_COMMAND or WM_SAVE_YOURSELF)
++    if( wm_save_yourself == (Atom)XNone ) {
++        Atom atoms[ 4 ];
++        const char* const names[]
++            = { "WM_SAVE_YOURSELF", "WM_PROTOCOLS", "WM_CLIENT_LEADER", "SM_CLIENT_ID" };
++        XInternAtoms( QX11Info::display(), const_cast< char** >( names ), 4,
++            False, atoms );
++        wm_save_yourself = atoms[ 0 ];
++        wm_protocols = atoms[ 1 ];
++        wm_client_leader = atoms[ 2 ];
++        sm_client_id = atoms[ 3 ];
++    }
++    const QList<WId> windows = KWindowSystem::windows();
++    for ( QList<WId>::ConstIterator it = windows.begin();
++        it != windows.end(); ++it) {
++        WId leader = windowWmClientLeader( *it );
++        if (!legacyWindows.contains(leader) && windowSessionId( *it, leader ).isEmpty()) {
++            SMType wtype = SM_WMCOMMAND;
++            int nprotocols = 0;
++            Atom *protocols = 0;
++            if( XGetWMProtocols(QX11Info::display(), leader, &protocols, &nprotocols)) {
++                for (int i=0; i<nprotocols; i++)
++                    if (protocols[i] == wm_save_yourself) {
++                        wtype = SM_WMSAVEYOURSELF;
++                        break;
++                    }
++                XFree((void*) protocols);
++            }
++            SMData data;
++            data.type = wtype;
++            XClassHint classHint;
++            if( XGetClassHint( QX11Info::display(), leader, &classHint ) ) {
++                data.wmclass1 = QString::fromLocal8Bit( classHint.res_name );
++                data.wmclass2 = QString::fromLocal8Bit( classHint.res_class );
++                XFree( classHint.res_name );
++                XFree( classHint.res_class );
++            }
++            legacyWindows.insert(leader, data);
++        }
++    }
++    // Open fresh display for sending WM_SAVE_YOURSELF
++    XSync(QX11Info::display(), False);
++    Display *newdisplay = XOpenDisplay(DisplayString(QX11Info::display()));
++    if (!newdisplay) {
++        windowMapPtr = NULL;
++        XSetErrorHandler(oldHandler);
++        return;
++    }
++    WId root = DefaultRootWindow(newdisplay);
++    XGrabKeyboard(newdisplay, root, False,
++                GrabModeAsync, GrabModeAsync, CurrentTime);
++    XGrabPointer(newdisplay, root, False, Button1Mask|Button2Mask|Button3Mask,
++                GrabModeAsync, GrabModeAsync, XNone, XNone, CurrentTime);
++    // Send WM_SAVE_YOURSELF messages
++    XEvent ev;
++    int awaiting_replies = 0;
++    for (WindowMap::Iterator it = legacyWindows.begin(); it != legacyWindows.end(); ++it) {
++        if ( (*it).type == SM_WMSAVEYOURSELF ) {
++            WId w = it.key();
++            awaiting_replies += 1;
++            memset(&ev, 0, sizeof(ev));
++            ev.xclient.type = ClientMessage;
++            ev.xclient.window = w;
++            ev.xclient.message_type = wm_protocols;
++            ev.xclient.format = 32;
++            ev.xclient.data.l[0] = wm_save_yourself;
++            ev.xclient.data.l[1] = QX11Info::appTime();
++            XSelectInput(newdisplay, w, PropertyChangeMask|StructureNotifyMask);
++            XSendEvent(newdisplay, w, False, 0, &ev);
++            qCDebug(KSMSERVER) << "sent >save yourself< to legacy app " << (*it).wmclass1 << (*it).wmclass2;
++        }
++    }
++    // Wait for change in WM_COMMAND with timeout
++    XFlush(newdisplay);
++    QTime start = QTime::currentTime();
++    while (awaiting_replies > 0) {
++        if (XPending(newdisplay)) {
++            /* Process pending event */
++            XNextEvent(newdisplay, &ev);
++            if ( ( ev.xany.type == UnmapNotify ) ||
++                ( ev.xany.type == PropertyNotify && ev.xproperty.atom == XA_WM_COMMAND ) ) {
++                WindowMap::Iterator it = legacyWindows.find( ev.xany.window );
++                if ( it != legacyWindows.end() && (*it).type != SM_WMCOMMAND ) {
++                    awaiting_replies -= 1;
++                    if ( (*it).type != SM_ERROR )
++                        (*it).type = SM_WMCOMMAND;
++                }
++            }
++        } else {
++            /* Check timeout */
++            int msecs = start.elapsed();
++            if (msecs >= wmSaveYourselfTimeout) {
++                qCDebug(KSMSERVER) << "legacy timeout expired";
++                break;
++            }
++            /* Wait for more events */
++            fd_set fds;
++            FD_ZERO(&fds);
++            int fd = ConnectionNumber(newdisplay);
++            FD_SET(fd, &fds);
++            struct timeval tmwait;
++            tmwait.tv_sec = (wmSaveYourselfTimeout - msecs) / 1000;
++            tmwait.tv_usec = ((wmSaveYourselfTimeout - msecs) % 1000) * 1000;
++            ::select(fd+1, &fds, NULL, &fds, &tmwait);
++        }
++    }
++    // Terminate work in new display
++    XAllowEvents(newdisplay, ReplayPointer, CurrentTime);
++    XAllowEvents(newdisplay, ReplayKeyboard, CurrentTime);
++    XSync(newdisplay, False);
++    XCloseDisplay(newdisplay);
++    // Restore old error handler
++    XSync(QX11Info::display(), False);
++    XSetErrorHandler(oldHandler);
++    for (WindowMap::Iterator it = legacyWindows.begin(); it != legacyWindows.end(); ++it) {
++        if ( (*it).type != SM_ERROR) {
++            WId w = it.key();
++            (*it).wmCommand = windowWmCommand(w);
++            (*it).wmClientMachine = windowWmClientMachine(w);
++        }
++    }
++    qCDebug(KSMSERVER) << "Done saving " << legacyWindows.count() << " legacy session apps";
++}
++
++/*!
++Stores legacy session management data
++*/
++void KSMServer::storeLegacySession( KConfig* config )
++{
++    if (state == ClosingSubSession)
++        return; //FIXME implement later
++    // Write LegacySession data
++    config->deleteGroup( QStringLiteral( "Legacy" ) + sessionGroup );
++    KConfigGroup group( config, QStringLiteral( "Legacy" ) + sessionGroup );
++    int count = 0;
++    for (WindowMap::ConstIterator it = legacyWindows.constBegin(); it != legacyWindows.constEnd(); ++it) {
++        if ( (*it).type != SM_ERROR) {
++            if( excludeApps.contains( (*it).wmclass1.toLower())
++                || excludeApps.contains( (*it).wmclass2.toLower()))
++                continue;
++            if ( !(*it).wmCommand.isEmpty() && !(*it).wmClientMachine.isEmpty() ) {
++                count++;
++                QString n = QString::number(count);
++                group.writeEntry( QStringLiteral("command")+n, (*it).wmCommand );
++                group.writeEntry( QStringLiteral("clientMachine")+n, (*it).wmClientMachine );
++            }
++        }
++    }
++    group.writeEntry( "count", count );
++}
++
++/*!
++Restores legacy session management data (i.e. restart applications)
++*/
++void KSMServer::restoreLegacySession( KConfig* config )
++{
++    if( config->hasGroup( QStringLiteral( "Legacy" ) + sessionGroup )) {
++        KConfigGroup group( config, QStringLiteral( "Legacy" ) + sessionGroup );
++        restoreLegacySessionInternal( &group );
++    } else if( wm == QStringLiteral( "kwin" ) ) { // backwards comp. - get it from kwinrc
++        KConfigGroup group( config, sessionGroup );
++        int count =  group.readEntry( "count", 0 );
++        for ( int i = 1; i <= count; i++ ) {
++            QString n = QString::number(i);
++            if ( group.readEntry( QStringLiteral("program")+n, QString() ) != wm )
++                continue;
++            QStringList restartCommand =
++                group.readEntry( QStringLiteral("restartCommand")+n, QStringList() );
++            for( QStringList::ConstIterator it = restartCommand.constBegin();
++                it != restartCommand.constEnd();
++                ++it ) {
++                if( (*it) == QStringLiteral( "-session" ) ) {
++                    ++it;
++                    if( it != restartCommand.constEnd()) {
++                        KConfig cfg( QStringLiteral( "session/" ) + wm +
++                                     QLatin1Char( '_' ) + (*it) );
++                        KConfigGroup group(&cfg, "LegacySession");
++                        restoreLegacySessionInternal( &group, ' ' );
++                    }
++                }
++            }
++        }
++    }
++}
++
++void KSMServer::restoreLegacySessionInternal( KConfigGroup* config, char sep )
++{
++    int count = config->readEntry( "count",0 );
++    for ( int i = 1; i <= count; i++ ) {
++        QString n = QString::number(i);
++        QStringList wmCommand = (sep == ',') ?
++                config->readEntry( QStringLiteral("command")+n, QStringList() ) :
++                KShell::splitArgs( config->readEntry( QStringLiteral("command")+n, QString() ) ); // close enough(?)
++        if( wmCommand.isEmpty())
++            continue;
++        if( isWM( wmCommand.first()))
++            continue;
++        startApplication( wmCommand,
++                        config->readEntry( QStringLiteral("clientMachine")+n, QString() ),
++                        config->readEntry( QStringLiteral("userId")+n, QString() ));
++    }
++}
++
++static QByteArray getQCStringProperty(WId w, Atom prop)
++{
++    Atom type;
++    int format, status;
++    unsigned long nitems = 0;
++    unsigned long extra = 0;
++    unsigned char *data = 0;
++    QByteArray result = "";
++    status = XGetWindowProperty( QX11Info::display(), w, prop, 0, 10000,
++                                false, XA_STRING, &type, &format,
++                                &nitems, &extra, &data );
++    if ( status == Success) {
++        if( data )
++            result = (char*)data;
++        XFree(data);
++    }
++    return result;
++}
++
++static QStringList getQStringListProperty(WId w, Atom prop)
++{
++    Atom type;
++    int format, status;
++    unsigned long nitems = 0;
++    unsigned long extra = 0;
++    unsigned char *data = 0;
++    QStringList result;
++
++    status = XGetWindowProperty( QX11Info::display(), w, prop, 0, 10000,
++                                false, XA_STRING, &type, &format,
++                                &nitems, &extra, &data );
++    if ( status == Success) {
++        if (!data)
++            return result;
++        for (int i=0; i<(int)nitems; i++) {
++            result << QLatin1String( (const char*)data + i );
++            while(data[i]) i++;
++        }
++        XFree(data);
++    }
++    return result;
++}
++
++QStringList KSMServer::windowWmCommand(WId w)
++{
++    QStringList ret = getQStringListProperty(w, XA_WM_COMMAND);
++    // hacks here
++    if( ret.count() == 1 ) {
++        QString command = ret.first();
++        // Mozilla is launched using wrapper scripts, so it's launched using "mozilla",
++        // but the actual binary is "mozilla-bin" or "<path>/mozilla-bin", and that's what
++        // will be also in WM_COMMAND - using this "mozilla-bin" doesn't work at all though
++        if( command.endsWith( QStringLiteral( "mozilla-bin" )))
++            return QStringList() << QStringLiteral( "mozilla" );
++        if( command.endsWith( QStringLiteral( "firefox-bin" )))
++            return QStringList() << QStringLiteral( "firefox" );
++        if( command.endsWith( QStringLiteral( "thunderbird-bin" )))
++            return QStringList() << QStringLiteral( "thunderbird" );
++        if( command.endsWith( QStringLiteral( "sunbird-bin" )))
++            return QStringList() << QStringLiteral( "sunbird" );
++        if( command.endsWith( QStringLiteral( "seamonkey-bin" )))
++            return QStringList() << QStringLiteral( "seamonkey" );
++    }
++    return ret;
++}
++
++QString KSMServer::windowWmClientMachine(WId w)
++{
++    QByteArray result = getQCStringProperty(w, XA_WM_CLIENT_MACHINE);
++    if (result.isEmpty()) {
++        result = "localhost";
++    } else {
++        // special name for the local machine (localhost)
++        char hostnamebuf[80];
++        if (gethostname (hostnamebuf, sizeof hostnamebuf) >= 0) {
++            hostnamebuf[sizeof(hostnamebuf)-1] = 0;
++            if (result == hostnamebuf)
++                result = "localhost";
++            if(char *dot = strchr(hostnamebuf, '.')) {
++                *dot = '\0';
++                if(result == hostnamebuf)
++                    result = "localhost";
++            }
++        }
++    }
++    return QLatin1String(result);
++}
++
++WId KSMServer::windowWmClientLeader(WId w)
++{
++    Atom type;
++    int format, status;
++    unsigned long nitems = 0;
++    unsigned long extra = 0;
++    unsigned char *data = 0;
++    Window result = w;
++    status = XGetWindowProperty( QX11Info::display(), w, wm_client_leader, 0, 10000,
++                                false, XA_WINDOW, &type, &format,
++                                &nitems, &extra, &data );
++    if (status  == Success ) {
++        if (data && nitems > 0)
++            result = *((Window*) data);
++        XFree(data);
++    }
++    return result;
++}
++
++
++/*
++Returns sessionId for this client,
++taken either from its window or from the leader window.
++*/
++QByteArray KSMServer::windowSessionId(WId w, WId leader)
++{
++    QByteArray result = getQCStringProperty(w, sm_client_id);
++    if (result.isEmpty() && leader != (WId)None && leader != w)
++        result = getQCStringProperty(leader, sm_client_id);
++    return result;
++}
++#endif
+diff --git a/ksmserver/server.cpp b/ksmserver/server.cpp
+--- a/ksmserver/server.cpp
++++ b/ksmserver/server.cpp
+@@ -959,6 +959,7 @@ void KSMServer::storeSession()
+     KConfigGroup cg2( config, "General");
+     cg2.writeEntry( "screenCount", ScreenCount(QX11Info::display()));
+ 
++    storeLegacySession(config.data());
+     config->sync();
+ }
+ 
+--- a/ksmserver/server.h
++++ b/ksmserver/server.h
+@@ -49,5 +49,6 @@ extern "C" {
+ #include <KConfigGroup>
+ #include <QTimer>
++#include <QTime>
+ #include <QMap>
+ 
+ 
+@@ -63,6 +64,16 @@ class KSMClient;
+ class OrgKdeKLauncherInterface;
+ class QDBusInterface;
+ 
++enum SMType { SM_ERROR, SM_WMCOMMAND, SM_WMSAVEYOURSELF };
++struct SMData
++    {
++    SMType type;
++    QStringList wmCommand;
++    QString wmClientMachine;
++    QString wmclass1, wmclass2;
++    };
++typedef QMap<WId,SMData> WindowMap;
++
+ class KSMServer : public QObject
+ {
+ Q_OBJECT
+@@ -147,4 +158,5 @@ private:
+     void startKilling();
+     void startKillingSubSession();
++    void performStandardKilling();
+     void completeKilling();
+     void completeKillingSubSession();
+@@ -177,4 +189,13 @@ private:
+     void setupXIOErrorHandler();
+ 
++    void performLegacySessionSave();
++    void storeLegacySession( KConfig* config );
++    void restoreLegacySession( KConfig* config );
++    void restoreLegacySessionInternal( KConfigGroup* config, char sep = ',' );
++    QStringList windowWmCommand(WId w);
++    QString windowWmClientMachine(WId w);
++    WId windowWmClientLeader(WId w);
++    QByteArray windowSessionId(WId w, WId leader);
++
+     bool checkStartupSuspend();
+     void finishStartup();
+@@ -184,6 +205,7 @@ private:
+     void runShutdownScripts();
+ 
+-    // public D-Bus interface
+- public Q_SLOTS:
++    // public dcop interface
++
++ public Q_SLOTS: //public dcop interface
+     void logout( int, int, int );
+     bool canShutdown();
+@@ -256,4 +278,6 @@ private:
+     QStringList excludeApps;
+ 
++    WindowMap legacyWindows;
++
+     OrgKdeKLauncherInterface* klauncherSignals;
+     QDBusInterface* kcminitSignals;
+--- a/ksmserver/shutdown.cpp
++++ b/ksmserver/shutdown.cpp
+@@ -192,5 +192,8 @@ void KSMServer::shutdown( KWorkSpace::ShutdownConfirm confirm,
+         state = Shutdown;
+         wmPhase1WaitingCount = 0;
+-        saveType = saveSession ? SmSaveBoth : SmSaveGlobal;
++        saveType = saveSession?SmSaveBoth:SmSaveGlobal;
++#ifndef NO_LEGACY_SESSION_MANAGEMENT
++        performLegacySessionSave();
++#endif
+         startProtection();
+         foreach( KSMClient* c, clients ) {
+@@ -248,5 +251,8 @@ void KSMServer::saveCurrentSession()
+     saveType = SmSaveLocal;
+     saveSession = true;
++#ifndef NO_LEGACY_SESSION_MANAGEMENT
++    performLegacySessionSave();
++#endif
+     foreach( KSMClient* c, clients ) {
+         c->resetState();
+         if( isWM( c ) )
+@@ -623,5 +629,9 @@ void KSMServer::saveSubSession(const QString &name, QStringList saveAndClose, QS
+     saveSession = true;
+     sessionGroup = QStringLiteral( "SubSession: " ) + name;
+ 
++#ifndef NO_LEGACY_SESSION_MANAGEMENT
++    //performLegacySessionSave(); FIXME
++#endif
++
+     startProtection();
+     foreach( KSMClient* c, clients ) {
+--- a/ksmserver/startup.cpp
++++ b/ksmserver/startup.cpp
+@@ -446,5 +446,7 @@ void KSMServer::autoStart2()
+     } else {
+         QTimer::singleShot(0, this, &KSMServer::kcmPhase2Done);
+     }
++    if( !defaultSession())
++        restoreLegacySession(KSharedConfig::openConfig().data());
+ 
+     qCDebug(KSMSERVER) << "Starting notification thread";

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.6.5.1-r2.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.6.5.1-r2.ebuild
@@ -1,0 +1,168 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+KDE_HANDBOOK="forceoptional"
+KDE_TEST="forceoptional"
+VIRTUALX_REQUIRED="test"
+inherit kde5 multilib qmake-utils
+
+DESCRIPTION="KDE Plasma workspace"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="+geolocation gps prison qalculate"
+
+COMMON_DEPEND="
+	$(add_frameworks_dep baloo)
+	$(add_frameworks_dep kactivities)
+	$(add_frameworks_dep kauth)
+	$(add_frameworks_dep kbookmarks)
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kcrash)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdeclarative)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kdesu)
+	$(add_frameworks_dep kglobalaccel)
+	$(add_frameworks_dep kguiaddons)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kidletime)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kitemviews)
+	$(add_frameworks_dep kjobwidgets)
+	$(add_frameworks_dep kjs)
+	$(add_frameworks_dep kjsembed)
+	$(add_frameworks_dep knewstuff)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep knotifyconfig)
+	$(add_frameworks_dep kpackage)
+	$(add_frameworks_dep krunner)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep ktexteditor)
+	$(add_frameworks_dep ktextwidgets)
+	$(add_frameworks_dep kwallet)
+	$(add_frameworks_dep kwayland)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep kxmlrpcclient)
+	$(add_frameworks_dep plasma)
+	$(add_frameworks_dep solid)
+	$(add_plasma_dep kscreenlocker)
+	$(add_plasma_dep kwin)
+	$(add_plasma_dep libksysguard)
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui 'jpeg')
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
+	dev-libs/libdbusmenu-qt[qt5]
+	media-libs/phonon[qt5]
+	sys-libs/zlib
+	x11-libs/libICE
+	x11-libs/libSM
+	x11-libs/libX11
+	x11-libs/libXau
+	x11-libs/libxcb
+	x11-libs/libXfixes
+	x11-libs/libXrender
+	x11-libs/xcb-util
+	x11-libs/xcb-util-image
+	geolocation? ( $(add_frameworks_dep networkmanager-qt) )
+	gps? ( sci-geosciences/gpsd )
+	prison? ( media-libs/prison:5 )
+	qalculate? ( sci-libs/libqalculate )
+"
+RDEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kded)
+	$(add_kdeapps_dep kio-extras)
+	$(add_plasma_dep kde-cli-tools)
+	$(add_plasma_dep ksysguard)
+	$(add_plasma_dep milou)
+	$(add_qt_dep qdbus)
+	$(add_qt_dep qtgraphicaleffects)
+	$(add_qt_dep qtpaths)
+	$(add_qt_dep qtquickcontrols 'widgets')
+	app-text/iso-codes
+	x11-apps/mkfontdir
+	x11-apps/xmessage
+	x11-apps/xprop
+	x11-apps/xrdb
+	x11-apps/xset
+	x11-apps/xsetroot
+	!dev-libs/xembed-sni-proxy
+	!kde-base/freespacenotifier:4
+	!kde-base/libtaskmanager:4
+	!kde-base/kcminit:4
+	!kde-base/kdebase-startkde:4
+	!kde-base/klipper:4
+	!kde-base/krunner:4
+	!kde-base/ksmserver:4
+	!kde-base/ksplash:4
+	!kde-base/plasma-workspace:4
+"
+DEPEND="${COMMON_DEPEND}
+	x11-proto/xproto
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-5.4-startkde-script.patch"
+	"${FILESDIR}/${PN}-5.6.0-rpath.patch"
+	"${FILESDIR}/${PN}-5.6.5-drop-kscreen-dep.patch"
+	"${FILESDIR}/${PN}-5.6.5.1-struts.patch"
+	"${FILESDIR}/${PN}-5.6.5.1-legacy-session-mgmt.patch" # backport in 5.6 after release
+)
+
+RESTRICT="test"
+
+S=${WORKDIR}/${PN}-5.6.5
+
+src_prepare() {
+	kde5_src_prepare
+
+	sed -e "s|\`qtpaths|\`$(qt5_get_bindir)/qtpaths|" \
+		-i startkde/startkde.cmake startkde/startplasmacompositor.cmake || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_find_package geolocation KF5NetworkManagerQt)
+		$(cmake-utils_use_find_package gps libgps)
+		$(cmake-utils_use_find_package prison KF5Prison)
+		$(cmake-utils_use_find_package qalculate Qalculate)
+	)
+
+	kde5_src_configure
+}
+
+src_install() {
+	kde5_src_install
+
+	# startup and shutdown scripts
+	insinto /etc/plasma/startup
+	doins "${FILESDIR}/10-agent-startup.sh"
+
+	insinto /etc/plasma/shutdown
+	doins "${FILESDIR}/10-agent-shutdown.sh"
+}
+
+pkg_postinst () {
+	kde5_pkg_postinst
+
+	echo
+	elog "To enable gpg-agent and/or ssh-agent in Plasma sessions,"
+	elog "edit ${EPREFIX}/etc/plasma/startup/10-agent-startup.sh and"
+	elog "${EPREFIX}/etc/plasma/shutdown/10-agent-shutdown.sh"
+	echo
+}


### PR DESCRIPTION
Upstream dropped it in 5.6 but later found out it was still in use by Mozilla applications et al., thus reverted in Plasma/5.6 branch but only after 5.6.5.1 release.

See also: https://bugs.kde.org/show_bug.cgi?id=362671

@gentoo/kde 