### PR TITLE
media-fonts/source-han-sans: fix directory name

### DIFF
--- a/media-fonts/source-han-sans/source-han-sans-1.001.ebuild
+++ b/media-fonts/source-han-sans/source-han-sans-1.001.ebuild
@@ -28,7 +28,7 @@ RESTRICT="binchecks strip"
 
 src_install() {
 	for l in ja ko zh-CN zh-TW; do
-		use l10n_${l} && FONT_S="${S}/source-han-sans-${l}-${PV}" font_src_install
+		use l10n_${l} && FONT_S="${S}/source-han-sans-${l/-/_}-${PV}" font_src_install
 	done
 	dodoc source-han-sans-*-${PV}/*md source-han-sans-*-${PV}/*pdf
 }


### PR DESCRIPTION
The directories for zh-CN and zh-TW are named with underscores, not
hyphens.