### PR TITLE
app-crypt/stan - homepage, src_uri, description fixes, revbump with ebuild cleanups

### DIFF
--- a/app-crypt/stan/stan-0.4.1-r1.ebuild
+++ b/app-crypt/stan/stan-0.4.1-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 src_prepare() {

--- a/app-crypt/stan/stan-0.4.1-r1.ebuild
+++ b/app-crypt/stan/stan-0.4.1-r1.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 src_prepare() {
 	eapply -p0 "${FILESDIR}/${P}-errno.patch"
 	# Update autotools deprecated file name and macro for bug 468750
-	mv configure.in configure.ac || die "configure rename failed"
+	mv configure.{in,ac} || die
 	sed -i \
 			-e "s/-O3/${CFLAGS}/" \
 			-e "s/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g" configure.ac || die

--- a/app-crypt/stan/stan-0.4.1-r1.ebuild
+++ b/app-crypt/stan/stan-0.4.1-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit autotools eutils
+
+DESCRIPTION="Stan analyzes binary streams and calculates statistical information"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="amd64 x86"
+IUSE=""
+
+src_prepare() {
+	eapply -p0 "${FILESDIR}/${P}-errno.patch"
+	# Update autotools deprecated file name and macro for bug 468750
+	mv configure.in configure.ac || die "configure rename failed"
+	sed -i \
+			-e "s/-O3/${CFLAGS}/" \
+			-e "s/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g" configure.ac || die
+	eautoreconf
+	default
+}

--- a/app-crypt/stan/stan-0.4.1.ebuild
+++ b/app-crypt/stan/stan-0.4.1.ebuild
@@ -5,9 +5,9 @@
 EAPI="2"
 inherit autotools eutils
 
-DESCRIPTION="Stan is a console application that analyzes binary streams and calculates statistical information"
-HOMEPAGE="http://www.roqe.org/stan/"
-SRC_URI="http://www.roqe.org/${PN}/${P}.tar.gz"
+DESCRIPTION="Stan analyzes binary streams and calculates statistical information"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes homepage, src_uri and description for app-crypt/stan. (description because repoman said it was too long ;) )
I've also created a new version (-r1) which bumps the ebuild to EAPI=6.

Please review