### PR TITLE
Update ragel-6.9.ebuild

### DIFF
--- a/dev-util/ragel/ragel-6.9.ebuild
+++ b/dev-util/ragel/ragel-6.9.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="vim-syntax"
-
+CXXFLAGS="-std=c++98"
 DEPEND=""
 RDEPEND=""
 

--- a/dev-util/ragel/ragel-6.9.ebuild
+++ b/dev-util/ragel/ragel-6.9.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="vim-syntax"
-CXXFLAGS="-std=c++98"
+CXXFLAGS="${CXXFLAGS} -std=c++98"
 DEPEND=""
 RDEPEND=""
 


### PR DESCRIPTION
ragel failed to build with default -std in GCC 6.1
Bug #582606
https://bugs.gentoo.org/show_bug.cgi?id=582606