### PR TITLE
sys-boot/grub-2.02_beta3-r2: use microcode initrd if present to facilitate early intel microcode updates

### DIFF
--- a/sys-boot/grub/files/grub-intel-microcode.patch
+++ b/sys-boot/grub/files/grub-intel-microcode.patch
@@ -1,0 +1,24 @@
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in 
+@@ -67,6 +67,12 @@
+ 	;;
+ esac
+ 
++intel_ucode=
++if test -e "/boot/microcode.cpio" ; then
++    gettext_printf "Found Intel Microcode\n" >&2
++    intel_ucode="$(make_system_path_relative_to_its_root /boot/microcode.cpio)"
++fi
++
+ title_correction_code=
+ 
+ linux_entry ()
+@@ -140,7 +146,7 @@
+     message="$(gettext_printf "Loading initial ramdisk ...")"
+     sed "s/^/$submenu_indentation/" << EOF
+ 	echo	'$(echo "$message" | grub_quote)'
+-	initrd	${rel_dirname}/${initrd}
++	initrd	${intel_ucode} ${rel_dirname}/${initrd}
+ EOF
+   fi
+   sed "s/^/$submenu_indentation/" << EOF

--- a/sys-boot/grub/grub-2.02_beta3-r2.ebuild
+++ b/sys-boot/grub/grub-2.02_beta3-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 if [[ ${PV} == 9999  ]]; then
 	PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
-	inherit autotools python-any-r1
+	inherit python-any-r1
 fi
 
 inherit autotools bash-completion-r1 flag-o-matic multibuild pax-utils toolchain-funcs versionator
@@ -33,6 +33,9 @@ fi
 PATCHES=(
 	"${FILESDIR}"/gfxpayload.patch
 	"${FILESDIR}"/grub-2.02_beta2-KERNEL_GLOBS.patch
+	"${FILESDIR}"/2.02_beta3-10_linux-UUID.patch
+	"${FILESDIR}"/2.02_beta3-sysmacros.patch
+	"${FILESDIR}"/2.02_beta3-gcc6-ld-no-pie.patch
 	"${FILESDIR}"/grub-intel-microcode.patch
 )
 
@@ -149,12 +152,8 @@ src_prepare() {
 		sed -i -e 's/^\* GRUB:/* GRUB2:/' -e 's/(grub)/(grub2)/' docs/grub.texi || die
 	fi
 
-	if [[ ${PV} == 9999 ]]; then
-		python_setup
-		bash autogen.sh || die
-		autopoint() { :; }
-		eautoreconf
-	fi
+	autopoint() { :; }
+	eautoreconf
 }
 
 grub_do() {


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=587422