### PR TITLE
net-misc/radvd: systemd hardening

### DIFF
--- a/net-misc/radvd/files/radvd.service
+++ b/net-misc/radvd/files/radvd.service
@@ -4,12 +4,23 @@ Documentation=man:radvd(8)
 After=network.target
 
 [Service]
+User=radvd
+Group=radvd
 Type=forking
-ExecStart=/usr/sbin/radvd --username radvd --logmethod stderr --debug 0
+ExecStartPre=/usr/sbin/radvd --configtest
+ExecStart=/usr/sbin/radvd --logmethod stderr --debug 0
 ExecReload=/usr/sbin/radvd --configtest ; \
            /bin/kill -HUP $MAINPID
 CPUSchedulingPolicy=idle
 PIDFile=/run/radvd/radvd.pid
+RuntimeDirectory=radvd
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE  CAP_NET_RAW
+AmbientCapabilities=CAP_NET_BIND_SERVICE  CAP_NET_RAW
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectSystem=full
+ProtectHome=yes
+NoNewPrivileges=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Improve the systemd unit by having radvd never run as root, restricting capabilities as much as possible, and limiting file system access.

https://bugs.gentoo.org/show_bug.cgi?id=587588