### PR TITLE
app-dicts/stardict-* fix HOMEPAGE,SRC_URI and bump EAPI

### DIFF
--- a/app-dicts/stardict-cdict-en-zh-big5/stardict-cdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-big5/stardict-cdict-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-cdict-en-zh-big5/stardict-cdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-big5/stardict-cdict-en-zh-big5-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Traditional Chinese (BIG5)"
 DICT_PREFIX="cdict-"
@@ -13,6 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_TW/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
-
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-cdict-en-zh-big5/stardict-cdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-big5/stardict-cdict-en-zh-big5-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="big5"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_TW.php"
+HOMEPAGE="http://download.huzheng.org/zh_TW/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Simplified Chinese (GB)"
 DICT_PREFIX="cdict-"

--- a/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="gb"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_CN.php"
+HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cdict-en-zh-gb/stardict-cdict-en-zh-gb-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_TW/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="big5"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_TW.php"
+HOMEPAGE="http://download.huzheng.org/zh_TW/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Traditional Chinese (BIG5)"
 TO_LANG="English"
 DICT_PREFIX="cedict-"

--- a/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-big5/stardict-cedict-zh-en-big5-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_TW/"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="gb"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_CN.php"
+HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Simplified Chinese (GB)"
 TO_LANG="English"
 DICT_PREFIX="cedict-"

--- a/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-cedict-zh-en-gb/stardict-cedict-zh-en-gb-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 DICT_PREFIX="dictd_www.dict.org_"
 
 inherit stardict

--- a/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
@@ -7,7 +7,7 @@ DICT_PREFIX="dictd_www.dict.org_"
 inherit stardict
 
 DESCRIPTION="Stardict Dictionary for Dictd.org's Devil's Dictionary"
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.dict.org.php"
+HOMEPAGE="http://download.huzheng.org/dict.org/"
 
 KEYWORDS="~amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
@@ -14,5 +14,3 @@ HOMEPAGE="http://download.huzheng.org/dict.org/"
 KEYWORDS="~amd64 ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
+++ b/app-dicts/stardict-dictd-devils/stardict-dictd-devils-2.4.2.ebuild
@@ -13,4 +13,3 @@ HOMEPAGE="http://download.huzheng.org/dict.org/"
 
 KEYWORDS="~amd64 ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
@@ -14,5 +14,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
@@ -13,4 +13,3 @@ inherit stardict
 HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="German"
 DICT_PREFIX="dictd_www.freedict.de_"

--- a/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-deu/stardict-freedict-eng-deu-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="dictd_www.freedict.de_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.freedict.de.php"
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 

--- a/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="dictd_www.freedict.de_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.freedict.de.php"
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="French"
 DICT_PREFIX="dictd_www.freedict.de_"

--- a/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-fra/stardict-freedict-eng-fra-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="dictd_www.freedict.de_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.freedict.de.php"
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Italian"
 DICT_PREFIX="dictd_www.freedict.de_"

--- a/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-ita/stardict-freedict-eng-ita-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Latin"
 DICT_PREFIX="dictd_www.freedict.de_"

--- a/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="dictd_www.freedict.de_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.freedict.de.php"
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-lat/stardict-freedict-eng-lat-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Russian"
 DICT_PREFIX="dictd_www.freedict.de_"

--- a/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="dictd_www.freedict.de_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.freedict.de.php"
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-rus/stardict-freedict-eng-rus-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="dictd_www.freedict.de_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.freedict.de.php"
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Spanish"
 DICT_PREFIX="dictd_www.freedict.de_"

--- a/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-spa/stardict-freedict-eng-spa-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="dictd_www.freedict.de_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.freedict.de.php"
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Swedish"
 DICT_PREFIX="dictd_www.freedict.de_"

--- a/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-swe/stardict-freedict-eng-swe-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/freedict.de/"
 
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-freedict-eng-tur/stardict-freedict-eng-tur-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-tur/stardict-freedict-eng-tur-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-eng-tur/stardict-freedict-eng-tur-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-tur/stardict-freedict-eng-tur-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Turkish"
 DICT_PREFIX="freedict-"

--- a/app-dicts/stardict-freedict-eng-tur/stardict-freedict-eng-tur-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-eng-tur/stardict-freedict-eng-tur-2.4.2.ebuild
@@ -8,5 +8,7 @@ DICT_PREFIX="freedict-"
 
 inherit stardict
 
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
+
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-freedict-tur-deu/stardict-freedict-tur-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-tur-deu/stardict-freedict-tur-deu-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-tur-deu/stardict-freedict-tur-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-tur-deu/stardict-freedict-tur-deu-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Turkish"
 TO_LANG="German"
 DICT_PREFIX="freedict-"

--- a/app-dicts/stardict-freedict-tur-deu/stardict-freedict-tur-deu-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-tur-deu/stardict-freedict-tur-deu-2.4.2.ebuild
@@ -8,5 +8,7 @@ DICT_PREFIX="freedict-"
 
 inherit stardict
 
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
+
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-freedict-tur-eng/stardict-freedict-tur-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-tur-eng/stardict-freedict-tur-eng-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-freedict-tur-eng/stardict-freedict-tur-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-tur-eng/stardict-freedict-tur-eng-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Turkish"
 TO_LANG="English"
 DICT_PREFIX="freedict-"

--- a/app-dicts/stardict-freedict-tur-eng/stardict-freedict-tur-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-freedict-tur-eng/stardict-freedict-tur-eng-2.4.2.ebuild
@@ -8,5 +8,7 @@ DICT_PREFIX="freedict-"
 
 inherit stardict
 
+HOMEPAGE="http://download.huzheng.org/freedict.de/"
+
 KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
@@ -16,6 +16,5 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="app-arch/unzip"
-RDEPEND=""
 
 S=${WORKDIR}/DucViet

--- a/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
@@ -7,7 +7,7 @@ TO_LANG="Vietnamese"
 
 inherit stardict
 
-HOMEPAGE="http://forum.vnoss.org/viewtopic.php?id=1818"
+HOMEPAGE="https://sourceforge.net/projects/ovdp/"
 SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/DucViet45K.zip"
 
 KEYWORDS="~amd64 ~x86"

--- a/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="German"
 TO_LANG="Vietnamese"
 

--- a/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-de-vi/stardict-hnd-de-vi-20050917.ebuild
@@ -8,7 +8,7 @@ TO_LANG="Vietnamese"
 inherit stardict
 
 HOMEPAGE="https://sourceforge.net/projects/ovdp/"
-SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/DucViet45K.zip"
+SRC_URI="mirror://gentoo/DucViet45K.zip"
 
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
@@ -7,7 +7,7 @@ TO_LANG="Vietnamese"
 
 inherit stardict
 
-HOMEPAGE="http://forum.vnoss.org/viewtopic.php?id=1818"
+HOMEPAGE="https://sourceforge.net/projects/ovdp/"
 SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/AnhViet109K.zip"
 
 KEYWORDS="~amd64 ~x86"

--- a/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
@@ -16,6 +16,5 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="app-arch/unzip"
-RDEPEND=""
 
 S=${WORKDIR}/AnhViet

--- a/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
@@ -8,7 +8,7 @@ TO_LANG="Vietnamese"
 inherit stardict
 
 HOMEPAGE="https://sourceforge.net/projects/ovdp/"
-SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/AnhViet109K.zip"
+SRC_URI="mirror://gentoo/AnhViet109K.zip"
 
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-en-vi/stardict-hnd-en-vi-20050917.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Vietnamese"
 

--- a/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
@@ -7,7 +7,7 @@ TO_LANG="Vietnamese"
 
 inherit stardict
 
-HOMEPAGE="http://forum.vnoss.org/viewtopic.php?id=1818"
+HOMEPAGE="https://sourceforge.net/projects/ovdp/"
 SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/PhapViet47K.zip"
 
 KEYWORDS="~amd64 ~x86"

--- a/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
@@ -8,7 +8,7 @@ TO_LANG="Vietnamese"
 inherit stardict
 
 HOMEPAGE="https://sourceforge.net/projects/ovdp/"
-SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/PhapViet47K.zip"
+SRC_URI="mirror://gentoo/PhapViet47K.zip"
 
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="French"
 TO_LANG="Vietnamese"
 

--- a/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-fr-vi/stardict-hnd-fr-vi-20050917.ebuild
@@ -16,6 +16,5 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="app-arch/unzip"
-RDEPEND=""
 
 S=${WORKDIR}/PhapViet

--- a/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
@@ -8,7 +8,7 @@ TO_LANG="Vietnamese"
 inherit stardict
 
 HOMEPAGE="https://sourceforge.net/projects/ovdp/"
-SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/NgaViet38K.zip"
+SRC_URI="mirror://gentoo/NgaViet38K.zip"
 
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Russian"
 TO_LANG="Vietnamese"
 

--- a/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
@@ -7,7 +7,7 @@ TO_LANG="Vietnamese"
 
 inherit stardict
 
-HOMEPAGE="http://forum.vnoss.org/viewtopic.php?id=1818"
+HOMEPAGE="https://sourceforge.net/projects/ovdp/"
 SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/NgaViet38K.zip"
 
 KEYWORDS="~amd64 ~x86"

--- a/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-ru-vi/stardict-hnd-ru-vi-20050917.ebuild
@@ -16,6 +16,5 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="app-arch/unzip"
-RDEPEND=""
 
 S=${WORKDIR}/NgaViet

--- a/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Vietnamese"
 TO_LANG="German"
 

--- a/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
@@ -7,7 +7,7 @@ TO_LANG="German"
 
 inherit stardict
 
-HOMEPAGE="http://forum.vnoss.org/viewtopic.php?id=1818"
+HOMEPAGE="https://sourceforge.net/projects/ovdp/"
 SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/VietDuc12K.zip"
 
 KEYWORDS="~amd64 ~x86"

--- a/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
@@ -8,7 +8,7 @@ TO_LANG="German"
 inherit stardict
 
 HOMEPAGE="https://sourceforge.net/projects/ovdp/"
-SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/VietDuc12K.zip"
+SRC_URI="mirror://gentoo/VietDuc12K.zip"
 
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-de/stardict-hnd-vi-de-20050917.ebuild
@@ -16,6 +16,5 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="app-arch/unzip"
-RDEPEND=""
 
 S=${WORKDIR}/VietDuc

--- a/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
@@ -7,7 +7,7 @@ TO_LANG="English"
 
 inherit stardict
 
-HOMEPAGE="http://forum.vnoss.org/viewtopic.php?id=1818"
+HOMEPAGE="https://sourceforge.net/projects/ovdp/"
 SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/VietAnh23K.zip"
 
 KEYWORDS="~amd64 ~x86"

--- a/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
@@ -16,6 +16,5 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="app-arch/unzip"
-RDEPEND=""
 
 S=${WORKDIR}/VietAnh

--- a/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Vietnamese"
 TO_LANG="English"
 

--- a/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-en/stardict-hnd-vi-en-20050917.ebuild
@@ -8,7 +8,7 @@ TO_LANG="English"
 inherit stardict
 
 HOMEPAGE="https://sourceforge.net/projects/ovdp/"
-SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/VietAnh23K.zip"
+SRC_URI="mirror://gentoo/VietAnh23K.zip"
 
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Vietnamese"
 TO_LANG="French"
 

--- a/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
@@ -8,7 +8,7 @@ TO_LANG="French"
 inherit stardict
 
 HOMEPAGE="https://sourceforge.net/projects/ovdp/"
-SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/VietPhap38K.zip"
+SRC_URI="mirror://gentoo/VietPhap38K.zip"
 
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
@@ -7,7 +7,7 @@ TO_LANG="French"
 
 inherit stardict
 
-HOMEPAGE="http://forum.vnoss.org/viewtopic.php?id=1818"
+HOMEPAGE="https://sourceforge.net/projects/ovdp/"
 SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/VietPhap38K.zip"
 
 KEYWORDS="~amd64 ~x86"

--- a/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-fr/stardict-hnd-vi-fr-20050917.ebuild
@@ -16,6 +16,5 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="app-arch/unzip"
-RDEPEND=""
 
 S=${WORKDIR}/VietPhap

--- a/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
@@ -16,6 +16,5 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="app-arch/unzip"
-RDEPEND=""
 
 S=${WORKDIR}/VietViet

--- a/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Vietnamese"
 TO_LANG="Vietnamese"
 

--- a/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
@@ -8,7 +8,7 @@ TO_LANG="Vietnamese"
 inherit stardict
 
 HOMEPAGE="https://sourceforge.net/projects/ovdp/"
-SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/VietViet30K.zip"
+SRC_URI="mirror://gentoo/VietViet30K.zip"
 
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
+++ b/app-dicts/stardict-hnd-vi-vi/stardict-hnd-vi-vi-20050917.ebuild
@@ -7,7 +7,7 @@ TO_LANG="Vietnamese"
 
 inherit stardict
 
-HOMEPAGE="http://forum.vnoss.org/viewtopic.php?id=1818"
+HOMEPAGE="https://sourceforge.net/projects/ovdp/"
 SRC_URI="http://james.dyndns.ws/pub/Dictionary/StarDict-James/VietViet30K.zip"
 
 KEYWORDS="~amd64 ~x86"

--- a/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
@@ -9,7 +9,7 @@ DICT_PREFIX="jmdict-"
 inherit stardict
 
 HOMEPAGE="http://download.huzheng.org/ja/"
-SRC_URI="mirror://sourceforge/stardict/${P}.tar.bz2"
+SRC_URI="http://download.huzheng.org/ja/${P}.tar.bz2"
 
 LICENSE="GDLS"
 KEYWORDS="~amd64 ~ppc sparc x86"

--- a/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
@@ -16,4 +16,3 @@ SRC_URI="http://download.huzheng.org/ja/${P}.tar.bz2"
 LICENSE="GDLS"
 KEYWORDS="~amd64 ~ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
@@ -17,5 +17,3 @@ LICENSE="GDLS"
 KEYWORDS="~amd64 ~ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Japanese"
 DICT_PREFIX="jmdict-"

--- a/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-en-ja/stardict-jmdict-en-ja-2.4.2-r1.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="jmdict-"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_ja.php"
+HOMEPAGE="http://download.huzheng.org/ja/"
 SRC_URI="mirror://sourceforge/stardict/${P}.tar.bz2"
 
 LICENSE="GDLS"

--- a/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
@@ -9,7 +9,7 @@ DICT_PREFIX="jmdict-"
 inherit stardict
 
 HOMEPAGE="http://download.huzheng.org/ja/"
-SRC_URI="mirror://sourceforge/stardict/${P}.tar.bz2"
+SRC_URI="http://download.huzheng.org/ja/${P}.tar.bz2"
 
 LICENSE="GDLS"
 KEYWORDS="~amd64 ~ppc sparc x86"

--- a/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
@@ -16,4 +16,3 @@ SRC_URI="http://download.huzheng.org/ja/${P}.tar.bz2"
 LICENSE="GDLS"
 KEYWORDS="~amd64 ~ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
@@ -17,5 +17,3 @@ LICENSE="GDLS"
 KEYWORDS="~amd64 ~ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="jmdict-"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_ja.php"
+HOMEPAGE="http://download.huzheng.org/ja/"
 SRC_URI="mirror://sourceforge/stardict/${P}.tar.bz2"
 
 LICENSE="GDLS"

--- a/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
+++ b/app-dicts/stardict-jmdict-ja-en/stardict-jmdict-ja-en-2.4.2-r1.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Japanese"
 TO_LANG="English"
 DICT_PREFIX="jmdict-"

--- a/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 KEYWORDS="~amd64 ~arm ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="gb"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_CN.php"
+HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-en-zh-gb/stardict-langdao-en-zh-gb-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Simplified Chinese (GB)"
 DICT_PREFIX="langdao-ec-"

--- a/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc sparc x86"
 IUSE=""
-

--- a/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 KEYWORDS="~amd64 ~arm ~ppc sparc x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Simplified Chinese (GB)"
 TO_LANG="English"
 DICT_PREFIX="langdao-ce-"

--- a/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-langdao-zh-en-gb/stardict-langdao-zh-en-gb-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="gb"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_CN.php"
+HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc sparc x86"
 IUSE=""

--- a/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
+++ b/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
+++ b/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
@@ -14,5 +14,3 @@ HOMEPAGE="http://download.huzheng.org/mova.org/"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
+++ b/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 DICT_PREFIX="dictd_www.mova.org_"
 
 inherit stardict

--- a/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
+++ b/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
@@ -13,4 +13,3 @@ HOMEPAGE="http://download.huzheng.org/mova.org/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
+++ b/app-dicts/stardict-mova-smiley/stardict-mova-smiley-2.4.2.ebuild
@@ -7,7 +7,7 @@ DICT_PREFIX="dictd_www.mova.org_"
 inherit stardict
 
 DESCRIPTION="Stardict Dictionary for Mova.org's Smiley Dictionary"
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.mova.org.php"
+HOMEPAGE="http://download.huzheng.org/mova.org/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="gb"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_CN.php"
+HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-oxford-en-zh-gb/stardict-oxford-en-zh-gb-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Simplified Chinese (GB)"
 DICT_PREFIX="oxford-"

--- a/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/Quick/"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="French"
 DICT_PREFIX="quick_"

--- a/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/Quick/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-fra/stardict-quick-eng-fra-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="quick_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_Quick.php"
+HOMEPAGE="http://download.huzheng.org/Quick/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/Quick/"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/Quick/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Japanese Romaji"
 DICT_PREFIX="quick_"

--- a/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-eng-jpn/stardict-quick-eng-jpn-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="quick_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_Quick.php"
+HOMEPAGE="http://download.huzheng.org/Quick/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
@@ -15,5 +15,3 @@ HOMEPAGE="http://download.huzheng.org/Quick/"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
@@ -14,4 +14,3 @@ HOMEPAGE="http://download.huzheng.org/Quick/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
@@ -8,7 +8,7 @@ DICT_PREFIX="quick_"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_Quick.php"
+HOMEPAGE="http://download.huzheng.org/Quick/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-jpn-eng/stardict-quick-jpn-eng-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Japanese Romaji"
 TO_LANG="English"
 DICT_PREFIX="quick_"

--- a/app-dicts/stardict-quick-ru-en/stardict-quick-ru-en-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-ru-en/stardict-quick-ru-en-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-quick-ru-en/stardict-quick-ru-en-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-ru-en/stardict-quick-ru-en-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Russian"
 TO_LANG="English"
 DICT_PREFIX=""

--- a/app-dicts/stardict-quick-ru-en/stardict-quick-ru-en-2.4.2.ebuild
+++ b/app-dicts/stardict-quick-ru-en/stardict-quick-ru-en-2.4.2.ebuild
@@ -10,7 +10,7 @@ DICT_SUFFIX="quick_rus-eng"
 inherit stardict
 
 DESCRIPTION="Quick but still useful Russian to English dictionary"
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_dictd-www.mova.org.php"
+HOMEPAGE="http://download.huzheng.org/Quick/"
 
 KEYWORDS="amd64 x86"
 IUSE=""

--- a/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_TW/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Traditional Chinese (BIG5)"
 DICT_PREFIX="xdict-ec-"

--- a/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="big5"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_TW.php"
+HOMEPAGE="http://download.huzheng.org/zh_TW/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-big5/stardict-xdict-en-zh-big5-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_TW/"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="English"
 TO_LANG="Simplified Chinese (GB)"
 DICT_PREFIX="xdict-ec-"

--- a/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="gb"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_GB.php"
+HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-en-zh-gb/stardict-xdict-en-zh-gb-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_TW/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
-

--- a/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Traditional Chinese (BIG5)"
 TO_LANG="English"
 DICT_PREFIX="xdict-ce-"

--- a/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="big5"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_TW.php"
+HOMEPAGE="http://download.huzheng.org/zh_TW/"
 
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-big5/stardict-xdict-zh-en-big5-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_TW/"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
@@ -16,5 +16,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""

--- a/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
@@ -9,7 +9,7 @@ DICT_SUFFIX="gb"
 
 inherit stardict
 
-HOMEPAGE="http://stardict.sourceforge.net/Dictionaries_zh_CN.php"
+HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""

--- a/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+EAPI=6
+
 FROM_LANG="Simplified Chinese (GB)"
 TO_LANG="English"
 DICT_PREFIX="xdict-ce-"

--- a/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
+++ b/app-dicts/stardict-xdict-zh-en-gb/stardict-xdict-zh-en-gb-2.4.2.ebuild
@@ -15,4 +15,3 @@ HOMEPAGE="http://download.huzheng.org/zh_CN/"
 
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
 IUSE=""
-


### PR DESCRIPTION
Hi,

This PR fixes HOMEPAGE,SRC_URI (where available) and bumps EAPI.
Some notes about the changes:

1. Basically all dictionaries (and way more) are available on http://download.huzheng.org/ which is linked from the official stardict homepage. However, i didn't add SRC_URI for most dictionaries because usually the stardict.eclass would download them. This needs to be fixed in the eclass first. (only exception are stardict-jmdict dictionaries)
2. stardict-hnd* are available on https://sourceforge.net/projects/ovdp/, but since the files there are newer than our files i changed SRC_URI to our mirror.
3. app-dict/stardict-hnd-vi-vi is the only dictionary where i haven't found an official homepage. For now it has the same homepage as the the other stardict-hnd* dictionaries. However, i can change that to our no_homepage wiki entry.

Since the dictionaries would need way more attention I've tried to keep my changes simple in order not to make an reversion bump. However, if there is interest, i would try to fix the dictionaries even further, and would begin with the eclass itself. The ebuilds and eclass are pretty simple so i think I'm able to handle it :)

This PR would also fix Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=533632
