### PR TITLE
net-p2p/bitcoin-qt: Add dependency on qtcore[ssl] for Qt4

### DIFF
--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.10.2-r1.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.10.2-r1.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	qrcode? (
 		media-gfx/qrencode
 	)
-	qt4? ( dev-qt/qtgui:4 )
+	qt4? ( dev-qt/qtcore:4[ssl] dev-qt/qtgui:4 )
 	qt5? ( dev-qt/qtgui:5 dev-qt/qtnetwork:5 dev-qt/qtwidgets:5 )
 	dbus? (
 		qt4? ( dev-qt/qtdbus:4 )

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.10.2.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.10.2.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	qrcode? (
 		media-gfx/qrencode
 	)
-	qt4? ( dev-qt/qtgui:4 )
+	qt4? ( dev-qt/qtcore:4[ssl] dev-qt/qtgui:4 )
 	qt5? ( dev-qt/qtgui:5 dev-qt/qtnetwork:5 dev-qt/qtwidgets:5 )
 	dbus? (
 		qt4? ( dev-qt/qtdbus:4 )

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.11.0.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.11.0.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	qrcode? (
 		media-gfx/qrencode
 	)
-	qt4? ( dev-qt/qtgui:4 )
+	qt4? ( dev-qt/qtcore:4[ssl] dev-qt/qtgui:4 )
 	qt5? ( dev-qt/qtgui:5 dev-qt/qtnetwork:5 dev-qt/qtwidgets:5 )
 	dbus? (
 		qt4? ( dev-qt/qtdbus:4 )

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.11.1.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.11.1.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	qrcode? (
 		media-gfx/qrencode
 	)
-	qt4? ( dev-qt/qtgui:4 )
+	qt4? ( dev-qt/qtcore:4[ssl] dev-qt/qtgui:4 )
 	qt5? ( dev-qt/qtgui:5 dev-qt/qtnetwork:5 dev-qt/qtwidgets:5 )
 	dbus? (
 		qt4? ( dev-qt/qtdbus:4 )

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.11.2.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.11.2.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	qrcode? (
 		media-gfx/qrencode
 	)
-	qt4? ( dev-qt/qtgui:4 )
+	qt4? ( dev-qt/qtcore:4[ssl] dev-qt/qtgui:4 )
 	qt5? ( dev-qt/qtgui:5 dev-qt/qtnetwork:5 dev-qt/qtwidgets:5 )
 	dbus? (
 		qt4? ( dev-qt/qtdbus:4 )

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.12.0.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.12.0.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	qrcode? (
 		media-gfx/qrencode
 	)
-	qt4? ( dev-qt/qtgui:4 )
+	qt4? ( dev-qt/qtcore:4[ssl] dev-qt/qtgui:4 )
 	qt5? ( dev-qt/qtgui:5 dev-qt/qtnetwork:5 dev-qt/qtwidgets:5 )
 	dbus? (
 		qt4? ( dev-qt/qtdbus:4 )

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.12.1.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.12.1.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	qrcode? (
 		media-gfx/qrencode
 	)
-	qt4? ( dev-qt/qtgui:4 )
+	qt4? ( dev-qt/qtcore:4[ssl] dev-qt/qtgui:4 )
 	qt5? ( dev-qt/qtgui:5 dev-qt/qtnetwork:5 dev-qt/qtwidgets:5 )
 	dbus? (
 		qt4? ( dev-qt/qtdbus:4 )

--- a/net-p2p/bitcoin-qt/bitcoin-qt-9999.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-9999.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	qrcode? (
 		media-gfx/qrencode
 	)
-	qt4? ( dev-qt/qtgui:4 )
+	qt4? ( dev-qt/qtcore:4[ssl] dev-qt/qtgui:4 )
 	qt5? ( dev-qt/qtgui:5 dev-qt/qtnetwork:5 dev-qt/qtwidgets:5 )
 	dbus? (
 		qt4? ( dev-qt/qtdbus:4 )


### PR DESCRIPTION
@blueness Fixes bug 587880