### PR TITLE
dev-libs/wlc: fix missing RDEPEND and X configuration

### DIFF
--- a/dev-libs/wlc/wlc-0.0.3-r1.ebuild
+++ b/dev-libs/wlc/wlc-0.0.3-r1.ebuild
@@ -21,6 +21,7 @@ RDEPEND="virtual/opengl
 		x11-libs/libdrm
 		x11-libs/pixman
 		x11-libs/libxkbcommon
+		x11-misc/xkeyboard-config
 		dev-libs/libinput
 		dev-libs/wayland
 		X? ( x11-libs/libX11
@@ -41,10 +42,10 @@ src_configure() {
 
 		-DWLC_BUILD_STATIC=$(usex static-libs)
 
+		-DWLC_X11_SUPPORT=$(usex X)
+
 		$(cmake-utils_use_find_package systemd Systemd)
 		$(cmake-utils_use_find_package systemd Dbus)
-		$(cmake-utils_use_find_package X X11)
-		$(cmake-utils_use_find_package X XCB)
 	)
 
 	cmake-utils_src_configure

--- a/dev-libs/wlc/wlc-9999.ebuild
+++ b/dev-libs/wlc/wlc-9999.ebuild
@@ -21,6 +21,7 @@ RDEPEND="virtual/opengl
 		x11-libs/libdrm
 		x11-libs/pixman
 		x11-libs/libxkbcommon
+		x11-misc/xkeyboard-config
 		dev-libs/libinput
 		dev-libs/wayland
 		X? ( x11-libs/libX11


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/584462

Package-Manager: portage-2.3.0