### PR TITLE
kde-apps/kde-l10n: Disable KDEPim translations for languages with variants

### DIFF
--- a/kde-apps/kde-l10n/kde-l10n-15.12.3-r2.ebuild
+++ b/kde-apps/kde-l10n/kde-l10n-15.12.3-r2.ebuild
@@ -126,7 +126,7 @@ EOF
 
 	# Remove kdepim translations (part of kde-apps/kdepim-l10n)
 	for subdir in kdepim kdepimlibs kdepim-runtime pim; do
-		find -mindepth 5 -maxdepth 5 -type f -name CMakeLists.txt -exec \
+		find -mindepth 5 -maxdepth 6 -type f -name CMakeLists.txt -exec \
 			sed -i -e "/add_subdirectory( *${subdir} *)/ s/^/#DONT/" {} + || die
 	done
 

--- a/kde-apps/kde-l10n/kde-l10n-16.04.2.ebuild
+++ b/kde-apps/kde-l10n/kde-l10n-16.04.2.ebuild
@@ -87,7 +87,7 @@ EOF
 
 	# Remove kdepim translations (part of kde-apps/kdepim-l10n)
 	for subdir in kdepim kdepimlibs kdepim-runtime pim; do
-		find -mindepth 5 -maxdepth 5 -type f -name CMakeLists.txt -exec \
+		find -mindepth 5 -maxdepth 6 -type f -name CMakeLists.txt -exec \
 			sed -i -e "/add_subdirectory( *${subdir} *)/ s/^/#DONT/" {} + || die
 	done
 


### PR DESCRIPTION
Some languages have variants in subfolders (like sr/sr@latin).  The variants
don't have their CMakeLists.txt adjusted to disable KDEPim translations,
which then conflict with kde-apps/kdepim-l10n.  Instead search both folders
for an appropriate CMakeLists.txt file.

Package-Manager: portage-2.2.28

ping @gentoo/kde