### PR TITLE
app-misc/lirc-0.9.4: add dependency on virtual/libusb:0

### DIFF
--- a/app-misc/lirc/lirc-0.9.4.ebuild
+++ b/app-misc/lirc/lirc-0.9.4.ebuild
@@ -48,6 +48,7 @@ RDEPEND="
 	iguanair? ( app-misc/iguanaIR )
 	ftdi? ( dev-embedded/libftdi:0 )
 	inputlirc? ( app-misc/inputlircd )
+	virtual/libusb:0
 "
 
 src_configure() {


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=587840