### PR TITLE
app-misc/lirc-0.9.4: don't try to install doc/images

### DIFF
--- a/app-misc/lirc/lirc-0.9.4.ebuild
+++ b/app-misc/lirc/lirc-0.9.4.ebuild
@@ -72,8 +72,6 @@ src_install() {
 
 	if use doc ; then
 		dodoc -r doc/html
-		insinto /usr/share/doc/${PF}/images
-		doins doc/images/*
 	fi
 
 	keepdir /etc/lirc


### PR DESCRIPTION
upstream removed doc/images, so don't try to install it

https://bugs.gentoo.org/show_bug.cgi?id=587788