### PR TITLE
app-admin/needrestart-2.8: Fix QA Notice: make jobserver unavailable: using -j1.

### DIFF
--- a/app-admin/needrestart/files/needrestart-parallelmake.patch
+++ b/app-admin/needrestart/files/needrestart-parallelmake.patch
@@ -1,0 +1,17 @@
+https://github.com/liske/needrestart/pull/34
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index c432772..8cc2fe0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -64,5 +64,5 @@ po/needrestart-notify/messages.pot: ex/notify.d/*-*
+ 
+ 
+ mo-files:
+-	make -C po/needrestart
+-	make -C po/needrestart-notify
++	$(MAKE) -C po/needrestart
++	$(MAKE) -C po/needrestart-notify

--- a/app-admin/needrestart/needrestart-2.8.ebuild
+++ b/app-admin/needrestart/needrestart-2.8.ebuild
@@ -30,6 +30,10 @@ RDEPEND="
 DEPEND="${RDEPEND}
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-parallelmake.patch # https://bugs.gentoo.org/show_bug.cgi?id=588216
+)
+
 src_install() {
 	default
 	doman man/*.1


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=588216