### PR TITLE
various homepage fixes

### DIFF
--- a/app-misc/livecd-tools/livecd-tools-2.0.4.ebuild
+++ b/app-misc/livecd-tools/livecd-tools-2.0.4.ebuild
@@ -15,7 +15,7 @@ fi
 inherit eutils
 
 DESCRIPTION="Gentoo LiveCD tools for autoconfiguration of hardware"
-HOMEPAGE="http://wolf31o2.org/projects/livecd-tools"
+HOMEPAGE="https://www.gentoo.org"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/app-misc/livecd-tools/livecd-tools-2.1.ebuild
+++ b/app-misc/livecd-tools/livecd-tools-2.1.ebuild
@@ -15,7 +15,7 @@ fi
 inherit eutils
 
 DESCRIPTION="Gentoo LiveCD tools for autoconfiguration of hardware"
-HOMEPAGE="http://wolf31o2.org/projects/livecd-tools"
+HOMEPAGE="https://www.gentoo.org"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/app-misc/livecd-tools/livecd-tools-9999.ebuild
+++ b/app-misc/livecd-tools/livecd-tools-9999.ebuild
@@ -15,7 +15,7 @@ fi
 inherit eutils
 
 DESCRIPTION="Gentoo LiveCD tools for autoconfiguration of hardware"
-HOMEPAGE="http://wolf31o2.org/projects/livecd-tools"
+HOMEPAGE="https://www.gentoo.org"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/dev-python/pyds/pyds-0.7.3-r1.ebuild
+++ b/dev-python/pyds/pyds-0.7.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/dev-python/pyds/pyds-0.7.3-r1.ebuild
+++ b/dev-python/pyds/pyds-0.7.3-r1.ebuild
@@ -10,8 +10,8 @@ inherit distutils-r1
 MY_P="PyDS-${PV}"
 
 DESCRIPTION="Python Desktop Server"
-HOMEPAGE="http://pyds.muensterland.org/"
-SRC_URI="http://simon.bofh.ms/~gb/${MY_P}.tar.gz"
+HOMEPAGE="https://wiki.python.org/moin/PyDS"
+SRC_URI="mirror://gentoo/${MY_P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/media-gfx/monica/monica-3.7.ebuild
+++ b/media-gfx/monica/monica-3.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/media-gfx/monica/monica-3.7.ebuild
+++ b/media-gfx/monica/monica-3.7.ebuild
@@ -2,12 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=4
+EAPI=6
 inherit eutils toolchain-funcs
 
 DESCRIPTION="Monica is a Monitor Calibration Tool"
-HOMEPAGE="http://www.pcbypaul.com/software/monica.html"
-SRC_URI="http://www.pcbypaul.com/software/dl/${P}.tar.bz2"
+HOMEPAGE="http://freecode.com/projects/monica"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"

--- a/net-analyzer/nettop/nettop-0.2.3-r2.ebuild
+++ b/net-analyzer/nettop/nettop-0.2.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/net-analyzer/nettop/nettop-0.2.3-r2.ebuild
+++ b/net-analyzer/nettop/nettop-0.2.3-r2.ebuild
@@ -7,8 +7,8 @@ EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="top like program for network activity"
-SRC_URI="http://srparish.net/scripts/${P}.tar.gz"
-HOMEPAGE="http://srparish.net/software/"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
 
 SLOT="0"
 LICENSE="BSD"

--- a/sys-libs/libmath++/libmath++-0.0.4-r1.ebuild
+++ b/sys-libs/libmath++/libmath++-0.0.4-r1.ebuild
@@ -9,8 +9,8 @@ AUTOTOOLS_IN_SOURCE_BUILD=1 # bug #474098
 inherit autotools-utils
 
 DESCRIPTION="template based math library, written in C++, for symbolic and numeric calculus applications"
-HOMEPAGE="http://rm-rf.in/libmath%2B%2B/"
-SRC_URI="http://upstream.rm-rf.in/libmath%2B%2B/${P}.tar.gz"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="1"


### PR DESCRIPTION
Hi,

I decided to fix some old Bugs regarding wrong Homepages:
net-analyzer/nettop (Bug: [353666](https://bugs.gentoo.org/show_bug.cgi?id=353666)) 
dev-python/pyds (Bug: [367783](https://bugs.gentoo.org/show_bug.cgi?id=367783))
media-gfx/monica (Bug: [434186](https://bugs.gentoo.org/show_bug.cgi?id=434186))
app-misc/livecd-tools (Bug: [460064](https://bugs.gentoo.org/show_bug.cgi?id=460064))
sys-libs/libmath++ (Bug: [472070](https://bugs.gentoo.org/show_bug.cgi?id=472070))

For the package livecd-tools i choose to use gentoo's homepage since the project was from a gentoo dev.

Please review.

Furthermore i found another bug which could be closed:
https://bugs.gentoo.org/show_bug.cgi?id=415305 - package shoutcast-server-bin isn't available in gentoo anymore