### PR TITLE
app-laptop/tpacpi-bat: permit user to configure number of batteries

### DIFF
--- a/app-laptop/tpacpi-bat/files/tpacpi-bat.confd.1
+++ b/app-laptop/tpacpi-bat/files/tpacpi-bat.confd.1
@@ -1,0 +1,19 @@
+# /etc/conf.d/tpacpi-bat: config file for /etc/init.d/tpacpi-bat
+
+# use '/etc/init.d/tpacpi-bat info' at any time to check the thresholds
+# currently used by the driver
+
+# list of batteries the script should manage
+# for example: BATS="1 2"
+BATS="1"
+
+# default thresholds for '/etc/init.d/tpacpi-bat start'
+TPACPI_BAT_THRESH_START="30"
+TPACPI_BAT_THRESH_STOP="85"
+# values to be used for '/etc/init.d/tpacpi-bat low'
+TPACPI_BAT_LOW_THRESH_START="${TPACPI_BAT_THRESH_START}"
+TPACPI_BAT_LOW_THRESH_STOP="${TPACPI_BAT_THRESH_STOP}"
+
+# values to be used for '/etc/init.d/tpacpi-bat high'
+TPACPI_BAT_HIGH_THRESH_START="95"
+TPACPI_BAT_HIGH_THRESH_STOP="99" #see bug #485526

--- a/app-laptop/tpacpi-bat/files/tpacpi-bat.initd.2
+++ b/app-laptop/tpacpi-bat/files/tpacpi-bat.initd.2
@@ -1,0 +1,76 @@
+#!/sbin/openrc-run
+# Copyright (C) 2012-2013 Christoph Junghans <ottxor@gentoo.org>
+#
+# Distributed under the terms of the GNU General Public License, v2 or later
+
+extra_started_commands="low high info"
+
+depend() {
+	after modules
+}
+
+start() {
+	local state1
+
+	ebegin "Making sure that module 'acpi_call' is loaded"
+	modprobe acpi_call
+	state1=$?
+	eend ${state1}
+
+	[ "${state1}" -ne "0" ] && return 1
+
+	ebegin "Starting ${SVCNAME}"
+	set_all ${TPACPI_BAT_THRESH_START} ${TPACPI_BAT_THRESH_STOP}
+	eend $?
+}
+
+stop() {
+	einfo "Nothing required to be done to stop ${SVCNAME}"
+}
+
+require_started() {
+	if ! service_started; then
+		"${RC_SERVICE}" start || return $?
+	fi
+}
+
+high() {
+	require_started
+
+	einfo "Switching ${SVCNAME} to high thesholds"
+	set_all ${TPACPI_BAT_HIGH_THRESH_START} ${TPACPI_BAT_HIGH_THRESH_STOP}
+}
+
+low() {
+	require_started
+
+	einfo "Switching ${SVCNAME} to low thesholds"
+	set_all ${TPACPI_BAT_LOW_THRESH_START} ${TPACPI_BAT_LOW_THRESH_STOP}
+}
+
+set_all() {
+	local tstart=$1
+	local tstop=$2
+	local bat
+
+	for bat in ${BATS}; do
+		ebegin "  setting thresholds for ${bat}: $tstart $tstop"
+		/usr/bin/tpacpi-bat -s startThreshold ${bat} ${tstart}
+		/usr/bin/tpacpi-bat -s stopThreshold ${bat} ${tstop}
+		eend $?
+	done
+}
+
+info() {
+	local tstart
+	local tstop
+	local bat
+
+	require_started
+
+	for bat in ${BATS}; do
+		tstart=$(/usr/bin/tpacpi-bat -g startThreshold ${bat})
+		tstop=$(/usr/bin/tpacpi-bat -g stopThreshold ${bat})
+		einfo "Battery ${bat}: ${tstart} ${tstop}"
+	done
+}

--- a/app-laptop/tpacpi-bat/tpacpi-bat-3.0-r1.ebuild
+++ b/app-laptop/tpacpi-bat/tpacpi-bat-3.0-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit eutils systemd
+
+if [ "${PV}" = "9999" ]; then
+	inherit git-2
+	EGIT_REPO_URI="git://github.com/teleshoes/tpacpi-bat.git https://github.com/teleshoes/tpacpi-bat.git"
+	KEYWORDS=""
+else
+	SRC_URI="https://github.com/teleshoes/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+fi
+DESCRIPTION="Control battery thresholds of recent ThinkPads, which are not supported by tp_smapi"
+HOMEPAGE="https://github.com/teleshoes/tpacpi-bat"
+
+LICENSE="GPL-3"
+SLOT="0"
+IUSE=""
+
+DEPEND=""
+RDEPEND="sys-power/acpi_call
+	dev-lang/perl"
+
+src_install() {
+	dodoc README battery_asl
+	dobin tpacpi-bat
+	newinitd "${FILESDIR}"/${PN}.initd.2 ${PN}
+	newconfd "${FILESDIR}"/${PN}.confd.1 ${PN}
+	systemd_newunit tpacpi.service ${PN}.service
+}


### PR DESCRIPTION
As there are several batteries on some laptops, the `$BATS` variable should be placed into `conf.d` instead of the init script. This is what this patch changes.

@junghans 