### PR TITLE
app-admin/needrestart: should depend on >=sys-apps/sed-4.2.2

### DIFF
--- a/app-admin/needrestart/needrestart-2.8-r1.ebuild
+++ b/app-admin/needrestart/needrestart-2.8-r1.ebuild
@@ -21,13 +21,16 @@ SLOT="0"
 LICENSE="GPL-2+"
 
 RDEPEND="
+	>=sys-apps/sed-4.2.2
+	dev-perl/libintl-perl
 	dev-perl/Module-Find
 	dev-perl/Module-ScanDeps
 	dev-perl/Proc-ProcessTable
 	dev-perl/Sort-Naturally
-	dev-perl/Term-ProgressBar-Simple
+	dev-perl/TermReadKey
 "
 DEPEND="${RDEPEND}
+	sys-devel/gettext
 "
 
 PATCHES=(

--- a/app-admin/needrestart/needrestart-2.8.ebuild
+++ b/app-admin/needrestart/needrestart-2.8.ebuild
@@ -18,7 +18,7 @@ DESCRIPTION="Restart daemons after library updates"
 HOMEPAGE="https://fiasko-nw.net/~thomas/tag/needrestart.html https://github.com/liske/needrestart"
 
 SLOT="0"
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 
 RDEPEND="
 	dev-perl/Module-Find

--- a/app-admin/needrestart/needrestart-9999.ebuild
+++ b/app-admin/needrestart/needrestart-9999.ebuild
@@ -21,13 +21,16 @@ SLOT="0"
 LICENSE="GPL-2+"
 
 RDEPEND="
+	>=sys-apps/sed-4.2.2
+	dev-perl/libintl-perl
 	dev-perl/Module-Find
 	dev-perl/Module-ScanDeps
 	dev-perl/Proc-ProcessTable
 	dev-perl/Sort-Naturally
-	dev-perl/Term-ProgressBar-Simple
+	dev-perl/TermReadKey
 "
 DEPEND="${RDEPEND}
+	sys-devel/gettext
 "
 
 src_install() {

--- a/app-admin/needrestart/needrestart-9999.ebuild
+++ b/app-admin/needrestart/needrestart-9999.ebuild
@@ -18,7 +18,7 @@ DESCRIPTION="Restart daemons after library updates"
 HOMEPAGE="https://fiasko-nw.net/~thomas/tag/needrestart.html https://github.com/liske/needrestart"
 
 SLOT="0"
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 
 RDEPEND="
 	dev-perl/Module-Find


### PR DESCRIPTION
needrestart installs and uses scripts that call sed with '-z' option:
  https://github.com/liske/needrestart/blob/1a3b68a38e0691ca82e894ef591b23af666cc14d/lib/notify.d.sh#L34
  https://github.com/liske/needrestart/blob/1c17aa96ed455c6f10b496fa6a5c17daf96558ac/ex/notify.d/400-notify-send#L34
This option was introduced in sed-4.2.2: http://article.gmane.org/gmane.comp.lang.smalltalk.gnu.general/7873
Thus needrestart must depend on >=sys-apps/sed-4.2.2.

https://bugs.gentoo.org/show_bug.cgi?id=588416