### PR TITLE
net-firewall/nftables: backport null payload desc fix

### DIFF
--- a/net-firewall/nftables/files/nftables-0.6-null-payload-desc-fix.patch
+++ b/net-firewall/nftables/files/nftables-0.6-null-payload-desc-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/src/payload.c b/src/payload.c
+index ac0e917..9ba980a 100644
+--- a/src/payload.c
++++ b/src/payload.c
+@@ -85,6 +85,9 @@ static void payload_expr_pctx_update(struct proto_ctx *ctx,
+ 	base = ctx->protocol[left->payload.base].desc;
+ 	desc = proto_find_upper(base, proto);
+ 
++	if (!desc)
++		return;
++
+ 	assert(desc->base <= PROTO_BASE_MAX);
+ 	if (desc->base == base->base) {
+ 		assert(base->length > 0);

--- a/net-firewall/nftables/nftables-0.6-r2.ebuild
+++ b/net-firewall/nftables/nftables-0.6-r2.ebuild
@@ -28,7 +28,10 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/v${PV}"
 
-PATCHES=( "${FILESDIR}/${PN}-0.5-pdf-doc.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}-0.5-pdf-doc.patch"
+	"${FILESDIR}/${P}-null-payload-desc-fix.patch"
+)
 
 pkg_setup() {
 	if kernel_is ge 3 13; then


### PR DESCRIPTION
nftables-0.6 handling of payload context descriptions was changed from
version 0.5.  This change causes the code to segfault when the desc
variable in payload_expr_pctx_update() is set to null.  The issue
appears to be fixed with upstream commit
3503738f77cdbe521da1054a37f59ac2e442b4cf.  Therefore, backporting that
commit to 0.6 to fix this issue.

Gentoo-bug: 588192

Package-Manager: portage-2.3.0