### PR TITLE
kde-base/legacy-icons: Add missing slot 5 blockers

### DIFF
--- a/kde-base/legacy-icons/legacy-icons-4.11.22-r1.ebuild
+++ b/kde-base/legacy-icons/legacy-icons-4.11.22-r1.ebuild
@@ -20,8 +20,11 @@ IUSE=""
 DEPEND=""
 RDEPEND="
 	!<kde-apps/kwalletmanager-15.04.3-r1:4
+	!kde-apps/kwalletmanager:5
 	!<kde-apps/libkipi-15.08.3-r1:4
+	!kde-apps/libkipi:5
 	!<kde-apps/libksane-15.08.3-r1:4
+	!kde-apps/libksane:5
 	!<kde-base/systemsettings-4.11.22-r1:4
 	!=kde-frameworks/oxygen-icons-5.19.0:5
 	!=kde-frameworks/oxygen-icons-5.20.0:5


### PR DESCRIPTION
Gentoo-bug: 588362

@kensington 