### PR TITLE
profiles: Update kde package.use

### DIFF
--- a/profiles/targets/desktop/kde/package.use
+++ b/profiles/targets/desktop/kde/package.use
@@ -4,8 +4,34 @@
 
 # Resolve conflicts with slot 5 ebuilds
 kde-base/baloo minimal
+kde-apps/kde4-l10n minimal
 kde-apps/kwalletmanager:4 minimal
 kde-apps/libkipi:4 minimal
+kde-apps/libksane:4 minimal
+
+# Required by kde-frameworks/kauth
+sys-auth/polkit-qt qt5
+
+# Required by kde-frameworks/knotifications[dbus]
+dev-libs/libdbusmenu-qt qt5
+
+# Required by kde-frameworks/knotifyconfig[phonon]
+media-libs/phonon qt5
+
+# Required by media-libs/phonon[vlc]
+media-libs/phonon-vlc qt5
+
+# Required by kde-apps/kdenlive:5
+media-libs/mlt kdenlive qt5 melt -kde -qt4
+
+# Required by dev-qt/qtcore:5
+dev-libs/libpcre pcre16
+
+# Required by kde-frameworks/kcoreaddons
+dev-qt/qtcore icu
+
+# Required by kde-apps/kate[addons]
+dev-libs/libgit2 threads
 
 # Required by kde-base/pykde4
 dev-python/PyQt4 script sql webkit


### PR DESCRIPTION
Now that a lot of KDE Applications are only KF5-based, make some
adjustments to avoid portage autounmask clutter.

@gentoo/kde 