### PR TITLE
sys-boot/gnu-efi-3.0.0: Update the license of the gnu-efi.

### DIFF
--- a/sys-boot/gnu-efi/gnu-efi-3.0.2.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.2.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Library for build EFI Applications"
 HOMEPAGE="http://gnu-efi.sourceforge.net/"
 SRC_URI="mirror://sourceforge/gnu-efi/${P}.tar.bz2"
 
-LICENSE="BSD"
+LICENSE="BSD BSD-2"
 SLOT="0"
 KEYWORDS="-* ~amd64 ia64 ~x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0.2.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -10,7 +10,7 @@ DESCRIPTION="Library for build EFI Applications"
 HOMEPAGE="http://gnu-efi.sourceforge.net/"
 SRC_URI="mirror://sourceforge/gnu-efi/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="BSD"
 SLOT="0"
 KEYWORDS="-* ~amd64 ia64 ~x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0.3.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -10,7 +10,7 @@ DESCRIPTION="Library for build EFI Applications"
 HOMEPAGE="http://gnu-efi.sourceforge.net/"
 SRC_URI="mirror://sourceforge/gnu-efi/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="BSD"
 SLOT="0"
 # IA64 build is broken in setjmp code:
 # https://sourceforge.net/p/gnu-efi/bugs/9/

--- a/sys-boot/gnu-efi/gnu-efi-3.0.3.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.3.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Library for build EFI Applications"
 HOMEPAGE="http://gnu-efi.sourceforge.net/"
 SRC_URI="mirror://sourceforge/gnu-efi/${P}.tar.bz2"
 
-LICENSE="BSD"
+LICENSE="BSD BSD-2"
 SLOT="0"
 # IA64 build is broken in setjmp code:
 # https://sourceforge.net/p/gnu-efi/bugs/9/

--- a/sys-boot/gnu-efi/gnu-efi-3.0a-r1.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0a-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2007 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -8,7 +8,7 @@ DESCRIPTION="Library for build EFI Applications"
 HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="ftp://ftp.hpl.hp.com/pub/linux-ia64/gnu-efi-3.0a.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="BSD"
 SLOT="0"
 KEYWORDS="ia64 x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0a-r1.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0a-r1.ebuild
@@ -8,7 +8,7 @@ DESCRIPTION="Library for build EFI Applications"
 HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="ftp://ftp.hpl.hp.com/pub/linux-ia64/gnu-efi-3.0a.tar.gz"
 
-LICENSE="BSD"
+LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="ia64 x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0g.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0g.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Library for build EFI Applications"
 HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="mirror://sourceforge/gnu-efi/${MY_P}.orig.tar.gz"
 
-LICENSE="BSD"
+LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ia64 ~x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0g.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0g.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -10,7 +10,7 @@ DESCRIPTION="Library for build EFI Applications"
 HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="mirror://sourceforge/gnu-efi/${MY_P}.orig.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ia64 ~x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0i.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0i.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -10,7 +10,7 @@ HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="mirror://sourceforge/gnu-efi/${MY_P}.orig.tar.gz
 	mirror://debian/pool/main/g/gnu-efi/gnu-efi_3.0i-2.diff.gz"
 
-LICENSE="GPL-2"
+LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ia64 ~x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0i.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0i.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="mirror://sourceforge/gnu-efi/${MY_P}.orig.tar.gz
 	mirror://debian/pool/main/g/gnu-efi/gnu-efi_3.0i-2.diff.gz"
 
-LICENSE="BSD"
+LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ia64 ~x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0s.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0s.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="mirror://sourceforge/gnu-efi/${MY_P}.orig.tar.gz
 	mirror://debian/pool/main/g/gnu-efi/${PN}_${DEB_VER}.diff.gz"
 
-LICENSE="BSD"
+LICENSE="BSD BSD-2"
 SLOT="0"
 KEYWORDS="amd64 ia64 x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0s.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0s.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,7 +13,7 @@ HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="mirror://sourceforge/gnu-efi/${MY_P}.orig.tar.gz
 	mirror://debian/pool/main/g/gnu-efi/${PN}_${DEB_VER}.diff.gz"
 
-LICENSE="GPL-2"
+LICENSE="BSD"
 SLOT="0"
 KEYWORDS="amd64 ia64 x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0u.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0u.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,7 +13,7 @@ HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="mirror://sourceforge/gnu-efi/${MY_P}.orig.tar.gz
 	mirror://debian/pool/main/g/gnu-efi/${PN}_${DEB_VER}.diff.gz"
 
-LICENSE="GPL-2"
+LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~ia64 ~x86"
 IUSE=""

--- a/sys-boot/gnu-efi/gnu-efi-3.0u.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0u.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://developer.intel.com/technology/efi"
 SRC_URI="mirror://sourceforge/gnu-efi/${MY_P}.orig.tar.gz
 	mirror://debian/pool/main/g/gnu-efi/${PN}_${DEB_VER}.diff.gz"
 
-LICENSE="BSD"
+LICENSE="BSD BSD-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ia64 ~x86"
 IUSE=""


### PR DESCRIPTION
License of gnu-efi is the BSD license from version 3.0.0.
however, current license field of ebuild is GPL-2.
therefore, I fixed the license from GPL-2 to the BSD license.
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=584934

Package-Manager: portage-2.3.0