### PR TITLE
vala.eclass: version 0.24 has been dropped from the tree

### DIFF
--- a/eclass/vala.eclass
+++ b/eclass/vala.eclass
@@ -26,8 +26,8 @@ esac
 
 # @ECLASS-VARIABLE: VALA_MIN_API_VERSION
 # @DESCRIPTION:
-# Minimum vala API version (e.g. 0.22).
-VALA_MIN_API_VERSION=${VALA_MIN_API_VERSION:-0.22}
+# Minimum vala API version (e.g. 0.26).
+VALA_MIN_API_VERSION=${VALA_MIN_API_VERSION:-0.26}
 
 # @ECLASS-VARIABLE: VALA_MAX_API_VERSION
 # @DESCRIPTION:
@@ -50,13 +50,16 @@ vala_api_versions() {
 	local minimal_supported_minor_version minor_version
 
 	# Dependency atoms are not generated for Vala versions older than 0.${minimal_supported_minor_version}.
-	minimal_supported_minor_version="22"
+	minimal_supported_minor_version="26"
 
 	for ((minor_version = ${VALA_MAX_API_VERSION#*.}; minor_version >= ${VALA_MIN_API_VERSION#*.}; minor_version = minor_version - 2)); do
 		if ((minor_version >= minimal_supported_minor_version)); then
 			echo "0.${minor_version}"
 		fi
 	done
+
+	# For some reason 0.22 is still in the tree but 0.24 is not
+	echo "0.22"
 }
 
 # @FUNCTION: vala_depend


### PR DESCRIPTION
Fixes bug 583922.

Reported-by: Dave Kennedy <dave-kennedy@outlook.com>