### PR TITLE
media-libs/vo-aacenc: USE="neon" fails without CFLAGS="-mfpu=neon"

### DIFF
--- a/media-libs/vo-aacenc/vo-aacenc-0.1.3.ebuild
+++ b/media-libs/vo-aacenc/vo-aacenc-0.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -11,7 +11,7 @@ if [[ ${PV} == *9999 ]] ; then
 	AUTOTOOLS_AUTORECONF=yes
 fi
 
-inherit autotools-multilib ${SCM}
+inherit autotools-multilib ${SCM} flag-o-matic
 
 DESCRIPTION="VisualOn AAC encoder library"
 HOMEPAGE="http://sourceforge.net/projects/opencore-amr/"
@@ -34,6 +34,8 @@ IUSE="examples static-libs neon"
 AUTOTOOLS_PRUNE_LIBTOOL_FILES=all
 
 src_configure() {
+	use neon && append-cflags -mfpu=neon
+
 	local myeconfargs=(
 		"$(use_enable examples example)"
 		"$(use_enable neon armv7neon)"

--- a/media-libs/vo-aacenc/vo-aacenc-9999.ebuild
+++ b/media-libs/vo-aacenc/vo-aacenc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -11,7 +11,7 @@ if [[ ${PV} == *9999 ]] ; then
 	AUTOTOOLS_AUTORECONF=yes
 fi
 
-inherit autotools-multilib ${SCM}
+inherit autotools-multilib ${SCM} flag-o-matic
 
 DESCRIPTION="VisualOn AAC encoder library"
 HOMEPAGE="http://sourceforge.net/projects/opencore-amr/"
@@ -34,6 +34,8 @@ IUSE="examples static-libs neon"
 AUTOTOOLS_PRUNE_LIBTOOL_FILES=all
 
 src_configure() {
+	use neon && append-cflags -mfpu=neon
+
 	local myeconfargs=(
 		"$(use_enable examples example)"
 		"$(use_enable neon armv7neon)"


### PR DESCRIPTION
We're resolving this by appending -mfpu=neon to the cflags whenever the neon USE flag is set.

I'm seeking feedback on this proposed change, as it feels incorrect to me but I can't see a better way to resolve this. The approach taken here matches up with what I'm seeing in the libav ebuild as well as the mozconfig eclass (thunderbird, firefox, seamonkey). 

It's notable that like -mcpu, -mfpu has a wide range of acceptable inputs (neon, neon-fp16, neon-vpfv4, neon-fp-armv8) and we're simply selecting the most general one.

At the same time though, it feels like encouraging people to add a specific fpu to their global CFLAGs would be likely to cause adverse effects in other packages (as they'd have less "sane" global settings).

This change has been tested on an RK3288 (armv7a) device, and without it this ebuild will not compile.