### PR TITLE
app-misc/lirc-0.9.4a: workaround parallel make bug

### DIFF
--- a/app-misc/lirc/lirc-0.9.4a.ebuild
+++ b/app-misc/lirc/lirc-0.9.4a.ebuild
@@ -58,6 +58,14 @@ src_configure() {
 		$(use_with X x)
 }
 
+# Defined src_compile as a workaround for a parallel make issue
+# See https://bugs.gentoo.org/show_bug.cgi?id=588864
+# and https://sourceforge.net/p/lirc/tickets/210/
+src_compile() {
+	emake lib
+	emake
+}
+
 src_install() {
 	default
 


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=588864

My understanding is that an ebuild revbump is not necessary as this change only resolves a build failure (it doesn't change dependencies, impact runtime behavior, change installed files, or anything else).