### PR TITLE
app-backup/btrbk: add upstream info

### DIFF
--- a/app-backup/btrbk/metadata.xml
+++ b/app-backup/btrbk/metadata.xml
@@ -16,6 +16,16 @@
     <longdescription lang="en">
         Tool for creating snapshots and remote backups of btrfs subvolumes
     </longdescription>
+    <upstream>
+        <maintainer status="active">
+            <email>axel@tty0.ch</email>
+            <name>Axel Burri</name>
+        </maintainer>
+        <bugs-to>https://github.com/digint/btrbk/issues</bugs-to>
+        <changelog>https://raw.githubusercontent.com/digint/btrbk/master/ChangeLog</changelog>
+        <doc>https://github.com/digint/btrbk/blob/master/README.md</doc>
+        <remote-id type="github">digint/btrbk</remote-id>
+    </upstream>
     <use>
         <flag name='pv'>Use sys-apps/pv to enable progress bar functionality</flag>
     </use>


### PR DESCRIPTION
I'm a bit unclear - should I be specifying the minimum info, which would be:
```xml
    <upstream>
        <remote-id type="github">digint/btrbk</remote-id>
    </upstream>
```

or as much info as possible (as I've done in this PR, and repeat here):
```xml
    <upstream>
        <maintainer status="active">
            <email>axel@tty0.ch</email>
            <name>Axel Burri</name>
        </maintainer>
        <bugs-to>https://github.com/digint/btrbk/issues</bugs-to>
        <changelog>https://raw.githubusercontent.com/digint/btrbk/master/ChangeLog</changelog>
        <doc>https://github.com/digint/btrbk/blob/master/README.md</doc>
        <remote-id type="github">digint/btrbk</remote-id>
    </upstream>
```

@gentoo/proxy-maint - thanks in advance.