### PR TITLE
app-backup/btrbk: add "~alpha ~arm ~arm64 ~mips ~ppc64 ~sparc" to KEYWORDS

### DIFF
--- a/app-backup/btrbk/btrbk-0.23.3.ebuild
+++ b/app-backup/btrbk/btrbk-0.23.3.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == "9999" ]] ; then
 	KEYWORDS=""
 else
 	SRC_URI="https://digint.ch/download/btrbk/releases/${P}.tar.xz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~mips ~ppc64 ~sparc ~x86"
 fi
 
 DESCRIPTION="Tool for creating snapshots and remote backups of btrfs subvolumes"

--- a/app-backup/btrbk/btrbk-9999.ebuild
+++ b/app-backup/btrbk/btrbk-9999.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == "9999" ]] ; then
 	KEYWORDS=""
 else
 	SRC_URI="https://digint.ch/download/btrbk/releases/${P}.tar.xz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~mips ~ppc64 ~sparc ~x86"
 fi
 
 DESCRIPTION="Tool for creating snapshots and remote backups of btrfs subvolumes"


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=588854