### PR TITLE
sys-devel/llvm: a few feature enhancements

### DIFF
--- a/sys-devel/llvm/files/clang-3.8-default-libs.patch
+++ b/sys-devel/llvm/files/clang-3.8-default-libs.patch
@@ -1,0 +1,106 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ad2ac42..18dcfbe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -196,6 +196,24 @@ set(GCC_INSTALL_PREFIX "" CACHE PATH "Directory where gcc is installed." )
+ set(DEFAULT_SYSROOT "" CACHE PATH
+   "Default <path> to all compiler invocations for --sysroot=<path>." )
+ 
++set(CLANG_DEFAULT_CXX_STDLIB "" CACHE STRING
++  "Default C++ stdlib to use (libstdc++ or libc++)")
++if (NOT(CLANG_DEFAULT_CXX_STDLIB STREQUAL "" OR
++        CLANG_DEFAULT_CXX_STDLIB STREQUAL "libstdc++" OR
++        CLANG_DEFAULT_CXX_STDLIB STREQUAL "libc++"))
++  message(WARNING "Resetting default C++ stdlib to use platform default")
++  set(CLANG_DEFAULT_CXX_STDLIB "")
++endif()
++
++set(CLANG_DEFAULT_RTLIB "" CACHE STRING
++  "Default runtime library to use (libgcc or compiler-rt)")
++if (NOT(CLANG_DEFAULT_RTLIB STREQUAL "" OR
++        CLANG_DEFAULT_RTLIB STREQUAL "libgcc" OR
++        CLANG_DEFAULT_RTLIB STREQUAL "compiler-rt"))
++  message(WARNING "Resetting default rtlib to use platform default")
++  set(CLANG_DEFAULT_RTLIB "")
++endif()
++
+ set(CLANG_DEFAULT_OPENMP_RUNTIME "libomp" CACHE STRING
+   "Default OpenMP runtime used by -fopenmp.")
+ 
+diff --git a/include/clang/Config/config.h.cmake b/include/clang/Config/config.h.cmake
+index b7486f3..eb8aa27 100644
+--- a/include/clang/Config/config.h.cmake
++++ b/include/clang/Config/config.h.cmake
+@@ -8,6 +8,12 @@
+ /* Bug report URL. */
+ #define BUG_REPORT_URL "${BUG_REPORT_URL}"
+ 
++/* Default C++ stdlib to use. */
++#define CLANG_DEFAULT_CXX_STDLIB "${CLANG_DEFAULT_CXX_STDLIB}"
++
++/* Default runtime library to use. */
++#define CLANG_DEFAULT_RTLIB "${CLANG_DEFAULT_RTLIB}"
++
+ /* Default OpenMP runtime used by -fopenmp. */
+ #define CLANG_DEFAULT_OPENMP_RUNTIME "${CLANG_DEFAULT_OPENMP_RUNTIME}"
+ 
+diff --git a/lib/Driver/ToolChain.cpp b/lib/Driver/ToolChain.cpp
+index cbbd485..3af7f8a 100644
+--- a/lib/Driver/ToolChain.cpp
++++ b/lib/Driver/ToolChain.cpp
+@@ -9,6 +9,7 @@
+ 
+ #include "Tools.h"
+ #include "clang/Basic/ObjCRuntime.h"
++#include "clang/Config/config.h"
+ #include "clang/Driver/Action.h"
+ #include "clang/Driver/Driver.h"
+ #include "clang/Driver/DriverDiagnostic.h"
+@@ -520,29 +521,29 @@ void ToolChain::addProfileRTLibs(const llvm::opt::ArgList &Args,
+ 
+ ToolChain::RuntimeLibType ToolChain::GetRuntimeLibType(
+     const ArgList &Args) const {
+-  if (Arg *A = Args.getLastArg(options::OPT_rtlib_EQ)) {
+-    StringRef Value = A->getValue();
+-    if (Value == "compiler-rt")
+-      return ToolChain::RLT_CompilerRT;
+-    if (Value == "libgcc")
+-      return ToolChain::RLT_Libgcc;
+-    getDriver().Diag(diag::err_drv_invalid_rtlib_name)
+-      << A->getAsString(Args);
+-  }
++  const Arg* A = Args.getLastArg(options::OPT_rtlib_EQ);
++  StringRef LibName = A ? A->getValue() : CLANG_DEFAULT_RTLIB;
++
++  if (LibName == "compiler-rt")
++    return ToolChain::RLT_CompilerRT;
++  if (LibName == "libgcc")
++    return ToolChain::RLT_Libgcc;
++  if (A)
++    getDriver().Diag(diag::err_drv_invalid_rtlib_name) << A->getAsString(Args);
+ 
+   return GetDefaultRuntimeLibType();
+ }
+ 
+ ToolChain::CXXStdlibType ToolChain::GetCXXStdlibType(const ArgList &Args) const{
+-  if (Arg *A = Args.getLastArg(options::OPT_stdlib_EQ)) {
+-    StringRef Value = A->getValue();
+-    if (Value == "libc++")
+-      return ToolChain::CST_Libcxx;
+-    if (Value == "libstdc++")
+-      return ToolChain::CST_Libstdcxx;
+-    getDriver().Diag(diag::err_drv_invalid_stdlib_name)
+-      << A->getAsString(Args);
+-  }
++  const Arg* A = Args.getLastArg(options::OPT_stdlib_EQ);
++  StringRef LibName = A ? A->getValue() : CLANG_DEFAULT_CXX_STDLIB;
++
++  if (LibName == "libc++")
++    return ToolChain::CST_Libcxx;
++  if (LibName == "libstdc++")
++    return ToolChain::CST_Libstdcxx;
++  if (A)
++    getDriver().Diag(diag::err_drv_invalid_stdlib_name) << A->getAsString(Args);
+ 
+   return ToolChain::CST_Libstdcxx;
+ }

--- a/sys-devel/llvm/files/clang-3.8-musl-support.patch
+++ b/sys-devel/llvm/files/clang-3.8-musl-support.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/Driver/Tools.cpp b/lib/Driver/Tools.cpp
+index b7ac24f..dcd9eb5 100644
+--- a/lib/Driver/Tools.cpp
++++ b/lib/Driver/Tools.cpp
+@@ -8632,6 +8632,9 @@ static std::string getLinuxDynamicLinker(const ArgList &Args,
+       return "/system/bin/linker64";
+     else
+       return "/system/bin/linker";
++  } else if (ToolChain.getTriple().getEnvironment() == llvm::Triple::Musl) {
++    return
++      "/lib/ld-musl-" + ToolChain.getTriple().getArchName().str() + ".so.1";
+   } else if (Arch == llvm::Triple::x86 || Arch == llvm::Triple::sparc ||
+              Arch == llvm::Triple::sparcel)
+     return "/lib/ld-linux.so.2";

--- a/sys-devel/llvm/files/llvm-3.8-musl-fixes.patch
+++ b/sys-devel/llvm/files/llvm-3.8-musl-fixes.patch
@@ -1,0 +1,33 @@
+diff --git a/include/llvm/Analysis/TargetLibraryInfo.def b/include/llvm/Analysis/TargetLibraryInfo.def
+index 7798e3c..ade2b96 100644
+--- a/include/llvm/Analysis/TargetLibraryInfo.def
++++ b/include/llvm/Analysis/TargetLibraryInfo.def
+@@ -27,6 +27,15 @@
+ #define TLI_DEFINE_STRING_INTERNAL(string_repr) string_repr,
+ #endif
+ 
++// avoid name conflicts with musl-libc
++#undef fopen64
++#undef fseeko64
++#undef ftello64
++#undef fstat64
++#undef lstat64
++#undef stat64
++#undef tmpfile64
++
+ /// void *new(unsigned int);
+ TLI_DEFINE_ENUM_INTERNAL(msvc_new_int)
+ TLI_DEFINE_STRING_INTERNAL("??2@YAPAXI@Z")
+diff --git a/lib/Support/DynamicLibrary.cpp b/lib/Support/DynamicLibrary.cpp
+index 9a7aeb5..e98ad80 100644
+--- a/lib/Support/DynamicLibrary.cpp
++++ b/lib/Support/DynamicLibrary.cpp
+@@ -143,7 +143,7 @@ void* DynamicLibrary::SearchForAddressOfSymbol(const char *symbolName) {
+ // On linux we have a weird situation. The stderr/out/in symbols are both
+ // macros and global variables because of standards requirements. So, we
+ // boldly use the EXPLICIT_SYMBOL macro without checking for a #define first.
+-#if defined(__linux__) and !defined(__ANDROID__)
++#if defined(__linux__) && defined(__GLIBC__)
+   {
+     EXPLICIT_SYMBOL(stderr);
+     EXPLICIT_SYMBOL(stdout);

--- a/sys-devel/llvm/files/llvm-3.8-musl-support.patch
+++ b/sys-devel/llvm/files/llvm-3.8-musl-support.patch
@@ -1,0 +1,32 @@
+diff --git a/include/llvm/ADT/Triple.h b/include/llvm/ADT/Triple.h
+index e01db0a..5d85897 100644
+--- a/include/llvm/ADT/Triple.h
++++ b/include/llvm/ADT/Triple.h
+@@ -173,6 +173,7 @@ public:
+     EABI,
+     EABIHF,
+     Android,
++    Musl,
+ 
+     MSVC,
+     Itanium,
+diff --git a/lib/Support/Triple.cpp b/lib/Support/Triple.cpp
+index 11afcf7..c04c4bf 100644
+--- a/lib/Support/Triple.cpp
++++ b/lib/Support/Triple.cpp
+@@ -200,6 +200,7 @@ const char *Triple::getEnvironmentTypeName(EnvironmentType Kind) {
+   case EABI: return "eabi";
+   case EABIHF: return "eabihf";
+   case Android: return "android";
++  case Musl: return "musl";
+   case MSVC: return "msvc";
+   case Itanium: return "itanium";
+   case Cygnus: return "cygnus";
+@@ -454,6 +455,7 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
+     .StartsWith("code16", Triple::CODE16)
+     .StartsWith("gnu", Triple::GNU)
+     .StartsWith("android", Triple::Android)
++    .StartsWith("musl", Triple::Musl)
+     .StartsWith("msvc", Triple::MSVC)
+     .StartsWith("itanium", Triple::Itanium)
+     .StartsWith("cygnus", Triple::Cygnus)

--- a/sys-devel/llvm/llvm-3.8.1-r1.ebuild
+++ b/sys-devel/llvm/llvm-3.8.1-r1.ebuild
@@ -24,7 +24,7 @@ SLOT="0/3.8.0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="clang debug doc gold libedit +libffi lldb multitarget ncurses ocaml
 	python +static-analyzer test xml video_cards_radeon
-	elibc_musl +sanitizer libcxx compiler-rt
+	elibc_musl +sanitize libcxx compiler-rt
 	kernel_Darwin kernel_FreeBSD"
 
 COMMON_DEPEND="
@@ -303,8 +303,8 @@ multilib_src_configure() {
 			-DCLANG_DEFAULT_RTLIB=$(usex compiler-rt compiler-rt "")
 
 			# compiler-rt's test cases depend on sanitizer
-			-DCOMPILER_RT_BUILD_SANITIZERS=$(usex sanitizer)
-			-DCOMPILER_RT_INCLUDE_TESTS=$(usex sanitizer)
+			-DCOMPILER_RT_BUILD_SANITIZERS=$(usex sanitize)
+			-DCOMPILER_RT_INCLUDE_TESTS=$(usex sanitize)
 		)
 	fi
 

--- a/sys-devel/llvm/llvm-3.8.1-r1.ebuild
+++ b/sys-devel/llvm/llvm-3.8.1-r1.ebuild
@@ -24,6 +24,7 @@ SLOT="0/3.8.0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="clang debug doc gold libedit +libffi lldb multitarget ncurses ocaml
 	python +static-analyzer test xml video_cards_radeon
+	elibc_musl +sanitizer libcxx compiler-rt
 	kernel_Darwin kernel_FreeBSD"
 
 COMMON_DEPEND="
@@ -169,6 +170,12 @@ src_prepare() {
 	# https://bugs.gentoo.org/show_bug.cgi?id=578392
 	eapply "${FILESDIR}"/llvm-3.8-soversion.patch
 
+	# support building llvm against musl-libc
+	use elibc_musl && eapply "${FILESDIR}"/llvm-3.8-musl-fixes.patch
+
+	# support "musl" as a valid environment type in llvm
+	eapply "${FILESDIR}"/llvm-3.8-musl-support.patch
+
 	# disable use of SDK on OSX, bug #568758
 	sed -i -e 's/xcrun/false/' utils/lit/lit/util.py || die
 
@@ -185,6 +192,14 @@ src_prepare() {
 
 		eapply "${FILESDIR}"/clang-3.4-darwin_prefix-include-paths.patch
 		eprefixify tools/clang/lib/Frontend/InitHeaderSearch.cpp
+
+		pushd "${S}"/tools/clang || die
+		# be able to specify default values for -stdlib and -rtlib at build time
+		eapply "${FILESDIR}"/clang-3.8-default-libs.patch
+
+		# enable clang to recognize musl-libc
+		eapply "${FILESDIR}"/clang-3.8-musl-support.patch
+		popd || die
 
 		sed -i -e "s^@EPREFIX@^${EPREFIX}^" \
 			tools/clang/tools/scan-build/bin/scan-build || die
@@ -282,6 +297,14 @@ multilib_src_configure() {
 			# libgomp support fails to find headers without explicit -I
 			# furthermore, it provides only syntax checking
 			-DCLANG_DEFAULT_OPENMP_RUNTIME=libomp
+
+			# override default stdlib and rtlib
+			-DCLANG_DEFAULT_CXX_STDLIB=$(usex libcxx libc++ "")
+			-DCLANG_DEFAULT_RTLIB=$(usex compiler-rt compiler-rt "")
+
+			# compiler-rt's test cases depend on sanitizer
+			-DCOMPILER_RT_BUILD_SANITIZERS=$(usex sanitizer)
+			-DCOMPILER_RT_INCLUDE_TESTS=$(usex sanitizer)
 		)
 	fi
 

--- a/sys-devel/llvm/metadata.xml
+++ b/sys-devel/llvm/metadata.xml
@@ -20,14 +20,14 @@
    4. LLVM does not imply things that you would expect from a high-level virtual machine. It does not require garbage collection or run-time code generation (In fact, LLVM makes a great static compiler!). Note that optional LLVM components can be used to build high-level virtual machines and other systems that need these services.</longdescription>
 	<use>
 		<flag name="clang">Build the clang C/C++ compiler</flag>
+		<flag name="compiler-rt">Use compiler-rt instead of libgcc as the default rtlib for clang</flag>
 		<flag name="doc">Build and install the HTML documentation and regenerate the man pages</flag>
 		<flag name="gold">Build the gold linker plugin</flag>
+		<flag name="libcxx">Use libc++ instead of libstdc++ as the default stdlib for clang</flag>
 		<flag name="lldb">Build the lldb debugger</flag>
 		<flag name="multitarget">Build all host targets (default: host only)</flag>
 		<flag name="ncurses">Support querying terminal properties using ncurses' terminfo</flag>
-		<flag name="static-analyzer">Install the Clang static analyzer (requires USE=clang)</flag>
 		<flag name="sanitize">Build compiler-rt's sanitizers</flag>
-		<flag name="libcxx">Use libc++ instead of libstdc++ as the default stdlib for clang</flag>
-		<flag name="compiler-rt">Use compiler-rt instead of libgcc as the default rtlib for clang</flag>
+		<flag name="static-analyzer">Install the Clang static analyzer (requires USE=clang)</flag>
 	</use>
 </pkgmetadata>

--- a/sys-devel/llvm/metadata.xml
+++ b/sys-devel/llvm/metadata.xml
@@ -26,7 +26,7 @@
 		<flag name="multitarget">Build all host targets (default: host only)</flag>
 		<flag name="ncurses">Support querying terminal properties using ncurses' terminfo</flag>
 		<flag name="static-analyzer">Install the Clang static analyzer (requires USE=clang)</flag>
-		<flag name="sanitizer">Build compiler-rt's sanitizers</flag>
+		<flag name="sanitize">Build compiler-rt's sanitizers</flag>
 		<flag name="libcxx">Use libc++ instead of libstdc++ as the default stdlib for clang</flag>
 		<flag name="compiler-rt">Use compiler-rt instead of libgcc as the default rtlib for clang</flag>
 	</use>

--- a/sys-devel/llvm/metadata.xml
+++ b/sys-devel/llvm/metadata.xml
@@ -26,5 +26,8 @@
 		<flag name="multitarget">Build all host targets (default: host only)</flag>
 		<flag name="ncurses">Support querying terminal properties using ncurses' terminfo</flag>
 		<flag name="static-analyzer">Install the Clang static analyzer (requires USE=clang)</flag>
+		<flag name="sanitizer">Build compiler-rt's sanitizers</flag>
+		<flag name="libcxx">Use libc++ instead of libstdc++ as the default stdlib for clang</flag>
+		<flag name="compiler-rt">Use compiler-rt instead of libgcc as the default rtlib for clang</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
- add support for building llvm against musl
- enable clang to build binaries against musl
- introduce USE flag "sanitizer" to control the building of compiler-rt's
  sanitizers (they cause problem on musl)
- be able to override default values of -stdlib and -rtlib for clang
  * USE="libcxx" implies -stdlib=lib++ (originally libstdc++)
  * USE="compiler-rt" implies -rtlib=compiler-rt (originally libgcc)