### PR TITLE
app-misc/lirc-0.9.4a-r1 set localstatedir to /var so lirc correctly uses /var/run instead of /var/lib/run

### DIFF
--- a/app-misc/lirc/files/irexec-initd-0.9.4a-r1
+++ b/app-misc/lirc/files/irexec-initd-0.9.4a-r1
@@ -1,0 +1,28 @@
+#!/sbin/openrc-run
+# Copyright 2003 Martin Hierling <mad@cc.fh-lippe.de>
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+: ${IREXEC_USER:=root}
+
+depend() {
+	need lircd
+}
+
+start() {
+	if [ "x${IREXEC_USER}" = "xroot" -a "x${IREXEC_DISABLE_ROOT_WARNING}" != "xyes" ]; then
+		ewarn "Warning: Running irexec as root can open security holes"
+	fi
+
+	ebegin "Starting irexec"
+	start-stop-daemon --start --chuid ${IREXEC_USER} --user ${IREXEC_USER} --chdir / \
+		--exec /usr/bin/irexec -- --daemon ${IREXEC_OPTS}
+	eend $? "Failed to start irexec."
+}
+
+stop() {
+	ebegin "Stopping irexec"
+	start-stop-daemon --stop --exec /usr/bin/irexec --user ${IREXEC_USER}
+	eend $? "Failed to stop irexec."
+}
+

--- a/app-misc/lirc/files/lirc-0.9.4-doc-path-fix.patch
+++ b/app-misc/lirc/files/lirc-0.9.4-doc-path-fix.patch
@@ -1,0 +1,27 @@
+https://sourceforge.net/p/lirc/tickets/214/
+
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index 53d0f21..f833b4b 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -33,7 +33,6 @@ nodist_man_MANS         += man/xmode2.1 man/irxevent.1
+ manpage_html            += man-html/irxevent.html man-html/xmode2.html
+ endif
+ 
+-docdir                  = @datadir@/doc/@PACKAGE@
+ dist_doc_DATA           = irxevent.keys
+ 
+ if HAVE_DOXYGEN
+@@ -58,10 +57,10 @@ if HAVE_PYMOD_YAML
+ nodist_website_html_DATA  += table.html
+ endif
+ 
+-vardocsdir              = $(localstatedir)/lib/lirc/plugins
++vardocsdir              = $(docdir)/plugins
+ vardocs_DATA            = index.html html-source/lirc.css
+ 
+-varimagedir             = $(localstatedir)/lib/lirc/images
++varimagedir             = $(docdir)/images
+ varimage_DATA           = $(dist_image_DATA)
+ 
+ website_imagedir        = $(docdir)/lirc.org/images

--- a/app-misc/lirc/lirc-0.9.4a-r1.ebuild
+++ b/app-misc/lirc/lirc-0.9.4a-r1.ebuild
@@ -1,0 +1,131 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit eutils flag-o-matic systemd
+
+DESCRIPTION="decode and send infra-red signals of many commonly used remote controls"
+HOMEPAGE="http://www.lirc.org/"
+
+LIRC_DRIVER_DEVICE="/dev/lirc0"
+
+MY_P=${PN}-${PV/_/}
+
+if [[ "${PV/_pre/}" = "${PV}" ]]; then
+	SRC_URI="mirror://sourceforge/lirc/${MY_P}.tar.bz2"
+else
+	SRC_URI="http://www.lirc.org/software/snapshots/${MY_P}.tar.bz2"
+fi
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE="doc static-libs X audio irman ftdi inputlirc iguanair systemd usb"
+
+S="${WORKDIR}/${MY_P}"
+
+REQUIRED_USE="
+	iguanair? ( irman )
+"
+DEPEND="
+	doc? ( app-doc/doxygen )
+"
+
+RDEPEND="
+	X? (
+		x11-libs/libX11
+		x11-libs/libSM
+		x11-libs/libICE
+	)
+	systemd? ( sys-apps/systemd )
+	audio? (
+		>media-libs/portaudio-18
+		media-libs/alsa-lib
+	)
+	irman? ( media-libs/libirman )
+	iguanair? ( app-misc/iguanaIR )
+	ftdi? ( dev-embedded/libftdi:0 )
+	inputlirc? ( app-misc/inputlircd )
+	usb? ( virtual/libusb:0 )
+"
+
+PATCHES=(
+	"${FILESDIR}"/lirc-0.9.4-doc-path-fix.patch # https://bugs.gentoo.org/show_bug.cgi?id=589246 https://sourceforge.net/p/lirc/tickets/214/
+)
+
+src_configure() {
+	filter-flags -Wl,-O1
+	econf \
+		--docdir=/usr/share/doc/${PF} \
+		--localstatedir=/var \
+		$(use_enable static-libs static) \
+		$(use_with X x)
+}
+
+src_install() {
+	default
+
+	newinitd "${FILESDIR}"/lircd-0.8.6-r2 lircd
+	newinitd "${FILESDIR}"/lircmd lircmd
+	newconfd "${FILESDIR}"/lircd.conf.4 lircd
+
+	insinto /etc/modprobe.d/
+	newins "${FILESDIR}"/modprobed.lirc lirc.conf
+
+	newinitd "${FILESDIR}"/irexec-initd-0.9.4a-r1 irexec
+	newconfd "${FILESDIR}"/irexec-confd irexec
+
+	keepdir /etc/lirc
+	if [[ -e "${D}"/etc/lirc/lircd.conf ]]; then
+		newdoc "${D}"/etc/lirc/lircd.conf lircd.conf.example
+	fi
+
+	if ! use static-libs; then
+		rm "${D}/usr/$(get_libdir)/liblirc_client.la" || die
+	fi
+
+	# Avoid QA notice
+	rm -d "${D}"/var/run/lirc || die
+	rm -d "${D}"/var/run || die
+}
+
+pkg_preinst() {
+	local dir="${EROOT}/etc/modprobe.d"
+	if [[ -a "${dir}"/lirc && ! -a "${dir}"/lirc.conf ]]; then
+		elog "Renaming ${dir}/lirc to lirc.conf"
+		mv -f "${dir}/lirc" "${dir}/lirc.conf" || die
+	fi
+
+	# copy the first file that can be found
+	if [[ -f "${EROOT}"/etc/lirc/lircd.conf ]]; then
+		cp "${EROOT}"/etc/lirc/lircd.conf "${T}"/lircd.conf || die
+	elif [[ -f "${EROOT}"/etc/lircd.conf ]]; then
+		cp "${EROOT}"/etc/lircd.conf "${T}"/lircd.conf || die
+		MOVE_OLD_LIRCD_CONF=1
+	elif [[ -f "${D}"/etc/lirc/lircd.conf ]]; then
+		cp "${D}"/etc/lirc/lircd.conf "${T}"/lircd.conf || die
+	fi
+
+	# stop portage from touching the config file
+	if [[ -e "${D}"/etc/lirc/lircd.conf ]]; then
+		rm -f "${D}"/etc/lirc/lircd.conf || die
+	fi
+}
+
+pkg_postinst() {
+	# copy config file to new location
+	# without portage knowing about it
+	# so it will not delete it on unmerge or ever touch it again
+	if [[ -e "${T}"/lircd.conf ]]; then
+		cp "${T}"/lircd.conf "${EROOT}"/etc/lirc/lircd.conf || die
+		if [[ "$MOVE_OLD_LIRCD_CONF" = "1" ]]; then
+			elog "Moved /etc/lircd.conf to /etc/lirc/lircd.conf"
+			rm -f "${EROOT}"/etc/lircd.conf || die
+		fi
+	fi
+
+	einfo "The new default location for lircd.conf is inside of"
+	einfo "/etc/lirc/ directory"
+}


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=589246