### PR TITLE
 sys-devel/autoconf-2.69-r3: add support for runstatedir

### DIFF
--- a/sys-devel/autoconf/autoconf-2.69-r3.ebuild
+++ b/sys-devel/autoconf/autoconf-2.69-r3.ebuild
@@ -32,6 +32,10 @@ RDEPEND="${DEPEND}
 	>=sys-devel/autoconf-wrapper-13"
 [[ ${PV} == "9999" ]] && DEPEND+=" >=sys-apps/texinfo-4.3"
 PDEPEND="emacs? ( app-emacs/autoconf-mode )"
+PATCHES=(
+        "${FILESDIR}"/${P}-texinfo.patch
+        "${FILESDIR}"/${P}-runstatedir.patch # https://bugs.gentoo.org/show_bug.cgi?id=589248
+)
 
 if [[ -z ${__EBLITS__} && -n ${FILESDIR} ]] ; then
 	source "${FILESDIR}"/eblits/main.eblit || die

--- a/sys-devel/autoconf/autoconf-2.69-r3.ebuild
+++ b/sys-devel/autoconf/autoconf-2.69-r3.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+inherit eutils
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="git://git.savannah.gnu.org/${PN}.git
+		http://git.savannah.gnu.org/r/${PN}.git"
+	# We need all the tags in order to figure out the right version.
+	# The git-r3 eclass doesn't support that, so have to stick to 2.
+	inherit git-2
+else
+	SRC_URI="mirror://gnu/${PN}/${P}.tar.xz
+		ftp://alpha.gnu.org/pub/gnu/${PN}/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~arm-linux ~x86-linux"
+fi
+
+DESCRIPTION="Used to create autoconfiguration files"
+HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
+
+LICENSE="GPL-3"
+SLOT="${PV}"
+IUSE="emacs"
+
+DEPEND=">=sys-devel/m4-1.4.16
+	>=dev-lang/perl-5.6"
+RDEPEND="${DEPEND}
+	!~sys-devel/${P}:2.5
+	>=sys-devel/autoconf-wrapper-13"
+[[ ${PV} == "9999" ]] && DEPEND+=" >=sys-apps/texinfo-4.3"
+PDEPEND="emacs? ( app-emacs/autoconf-mode )"
+
+if [[ -z ${__EBLITS__} && -n ${FILESDIR} ]] ; then
+	source "${FILESDIR}"/eblits/main.eblit || die
+fi
+src_prepare()   {
+	eapply_user
+	eblit-run src_prepare
+}
+src_configure() { eblit-run src_configure ; }
+src_install()   { eblit-run src_install   ; }

--- a/sys-devel/autoconf/files/autoconf-2.69-runstatedir.patch
+++ b/sys-devel/autoconf/files/autoconf-2.69-runstatedir.patch
@@ -1,0 +1,103 @@
+From: Eric Blake <eblake@redhat.com>
+Date: Thu, 12 Sep 2013 21:11:29 +0000 (-0600)
+Subject: AC_INIT: add --runstatedir option to configure
+X-Git-Url: http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commitdiff_plain;h=a197431414088a417b407b9b20583b2e8f7363bd
+
+AC_INIT: add --runstatedir option to configure
+
+http://lwn.net/Articles/436012/ documents that many distros
+are now preferring to use /run rather than /var/run for
+storage of pid files and other per-process temporary files
+that must not be cleaned out during arbitrary TMPDIR sweeps.
+As such, the GNU Coding Standards were recently changed to
+recommend a new configure option to make it easy to choose
+this directory at configure time.  This patch adds support
+for the option to all configure scripts built by autoconf.
+
+* general.m4 (_AC_INIT_PARSE_ARGS): Add new directory option.
+(_AC_INIT_HELP): Document it.
+* doc/autoconf.texi (Installation Directory Variables): Document
+new option.
+(Site Defaults): Mention typical use within a distro.
+* NEWS: Mention the addition.
+
+Signed-off-by: Eric Blake <eblake@redhat.com>
+---
+
+diff --git a/doc/autoconf.texi b/doc/autoconf.texi
+index 26e7b17..4932067 100644
+--- a/doc/autoconf.texi
++++ b/doc/autoconf.texi
+@@ -2826,7 +2826,18 @@ usually has a subdirectory per locale.
+ 
+ @defvar localstatedir
+ @ovindex localstatedir
+-The directory for installing modifiable single-machine data.
++The directory for installing modifiable single-machine data.  Content in
++this directory typically survives a reboot.
++@end defvar
++
++@defvar runstatedir
++@ovindex runstatedir
++The directory for installing temporary modifiable single-machine data.
++Content in this directory survives as long as the process is running
++(such as pid files), as contrasted with @file{/tmp} that may be
++periodically cleaned.  Conversely, this directory is typically cleaned
++on a reboot.  By default, this is a subdirectory of
++@code{localstatedir}.
+ @end defvar
+ 
+ @defvar mandir
+@@ -22606,6 +22617,7 @@ test "$prefix" = NONE && prefix=/usr/share/local/gnu
+ test "$exec_prefix" = NONE && exec_prefix=/usr/local/gnu
+ test "$sharedstatedir" = '$@{prefix@}/com' && sharedstatedir=/var
+ test "$localstatedir" = '$@{prefix@}/var' && localstatedir=/var
++test "$runstatedir" = '$@{localstatedir@}/run' && runstatedir=/run
+ 
+ # Give Autoconf 2.x generated configure scripts a shared default
+ # cache file for feature test results, architecture-specific.
+diff --git a/lib/autoconf/general.m4 b/lib/autoconf/general.m4
+index 70b0168..1ce9922 100644
+--- a/lib/autoconf/general.m4
++++ b/lib/autoconf/general.m4
+@@ -586,6 +586,7 @@ AC_SUBST([datadir],        ['${datarootdir}'])dnl
+ AC_SUBST([sysconfdir],     ['${prefix}/etc'])dnl
+ AC_SUBST([sharedstatedir], ['${prefix}/com'])dnl
+ AC_SUBST([localstatedir],  ['${prefix}/var'])dnl
++AC_SUBST([runstatedir],    ['${localstatedir}/run'])dnl
+ AC_SUBST([includedir],     ['${prefix}/include'])dnl
+ AC_SUBST([oldincludedir],  ['/usr/include'])dnl
+ AC_SUBST([docdir],         [m4_ifset([AC_PACKAGE_TARNAME],
+@@ -812,6 +813,15 @@ do
+   | -silent | --silent | --silen | --sile | --sil)
+     silent=yes ;;
+ 
++  -runstatedir | --runstatedir | --runstatedi | --runstated \
++  | --runstate | --runstat | --runsta | --runst | --runs \
++  | --run | --ru | --r)
++    ac_prev=runstatedir ;;
++  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
++  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
++  | --run=* | --ru=* | --r=*)
++    runstatedir=$ac_optarg ;;
++
+   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
+     ac_prev=sbindir ;;
+   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
+@@ -921,7 +931,7 @@ fi
+ for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
+ 		datadir sysconfdir sharedstatedir localstatedir includedir \
+ 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
+-		libdir localedir mandir
++		libdir localedir mandir runstatedir
+ do
+   eval ac_val=\$$ac_var
+   # Remove trailing slashes.
+@@ -1058,6 +1068,7 @@ Fine tuning of the installation directories:
+   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
+   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
+   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
++  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
+   --libdir=DIR            object code libraries [EPREFIX/lib]
+   --includedir=DIR        C header files [PREFIX/include]
+   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/sys-devel/autoconf/files/autoconf-2.69-texinfo.patch
+++ b/sys-devel/autoconf/files/autoconf-2.69-texinfo.patch
@@ -1,0 +1,77 @@
+Description: Fix build error with texinfo 5.1.
+ Backported from a patch applied upstream.
+Forwarded: http://old.nabble.com/CVS-Texinfo-fails-to-build-the-Autoconf-manual-%28from-git%29-td34167051.html
+Bug-Debian: http://bugs.debian.org/711297
+Author: Patrice Dumas, Eric Blake
+Last-Update: 2013-08-11
+
+diff --git i/doc/autoconf.texi w/doc/autoconf.texi 
+index 78a2c67..506d966 100644 
+--- i/doc/autoconf.texi 
++++ w/doc/autoconf.texi 
+@@ -15,7 +15,7 @@
+ @c The ARG is an optional argument.  To be used for macro arguments in
+ @c their documentation (@defmac).
+ @macro ovar{varname}
+-@r{[}@var{\varname\}@r{]}@c
++@r{[}@var{\varname\}@r{]}
+ @end macro
+ 
+ @c @dvar(ARG, DEFAULT)
+@@ -23,7 +23,7 @@
+ @c The ARG is an optional argument, defaulting to DEFAULT.  To be used
+ @c for macro arguments in their documentation (@defmac).
+ @macro dvar{varname, default}
+-@r{[}@var{\varname\} = @samp{\default\}@r{]}@c
++@r{[}@var{\varname\} = @samp{\default\}@r{]}
+ @end macro
+ 
+ @c Handling the indexes with Texinfo yields several different problems.
+@@ -8013,10 +8013,10 @@
+ @code{ac_cv_f77_libs} or @code{ac_cv_fc_libs}, respectively.
+ @end defmac
+ 
+-@defmac AC_F77_DUMMY_MAIN (@ovar{action-if-found}, @dvar{action-if-not-found, @
+-  AC_MSG_FAILURE})
+-@defmacx AC_FC_DUMMY_MAIN (@ovar{action-if-found}, @dvar{action-if-not-found, @
+-  AC_MSG_FAILURE})
++@defmac AC_F77_DUMMY_MAIN (@ovar{action-if-found}, @
++  @dvar{action-if-not-found, AC_MSG_FAILURE})
++@defmacx AC_FC_DUMMY_MAIN (@ovar{action-if-found}, @
++  @dvar{action-if-not-found, AC_MSG_FAILURE})
+ @acindex{F77_DUMMY_MAIN}
+ @cvindex F77_DUMMY_MAIN
+ @acindex{FC_DUMMY_MAIN}
+@@ -8267,8 +8267,8 @@
+ @code{ac_cv_fc_pp_srcext_@var{ext}} variables, respectively.
+ @end defmac
+ 
+-@defmac AC_FC_PP_DEFINE (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_PP_DEFINE (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_PP_DEFINE}
+ @caindex fc_pp_define
+ 
+@@ -8286,8 +8286,8 @@
+ variable.
+ @end defmac
+ 
+-@defmac AC_FC_FREEFORM (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_FREEFORM (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_FREEFORM}
+ @caindex fc_freeform
+ 
+@@ -8313,8 +8313,8 @@
+ the @code{ac_cv_fc_freeform} variable.
+ @end defmac
+ 
+-@defmac AC_FC_FIXEDFORM (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_FIXEDFORM (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_FIXEDFORM}
+ @caindex fc_fixedform
+ 


### PR DESCRIPTION
Backported from autoconf 2.70

https://bugs.gentoo.org/show_bug.cgi?id=589248
