### PR TITLE
profiles: Cleanup {kde,plasma} package.use

### DIFF
--- a/profiles/targets/desktop/kde/package.use
+++ b/profiles/targets/desktop/kde/package.use
@@ -5,9 +5,6 @@
 # Resolve conflicts with slot 5 ebuilds
 kde-base/baloo minimal
 kde-apps/kde4-l10n minimal
-kde-apps/kwalletmanager:4 minimal
-kde-apps/libkipi:4 minimal
-kde-apps/libksane:4 minimal
 
 # Required by kde-frameworks/kauth
 sys-auth/polkit-qt qt5

--- a/profiles/targets/desktop/plasma/package.use
+++ b/profiles/targets/desktop/plasma/package.use
@@ -54,9 +54,6 @@ net-libs/libproxy -kde
 <dev-util/kdevelop-4.8.0 -gdbui
 kde-apps/kde-wallpapers minimal
 kde-apps/kde4-l10n minimal
-kde-apps/kwalletmanager:4 minimal
-kde-apps/libkipi:4 minimal
-kde-apps/libksane:4 minimal
 kde-apps/solid-runtime -bluetooth
 kde-base/baloo minimal
 net-p2p/ktorrent:4 -plasma


### PR DESCRIPTION
USE=minimal is gone there.

@kensington 