### PR TITLE
dev-python/flask-appconfig: stop installing scripts to prevent collision

### DIFF
--- a/dev-python/flask-appconfig/flask-appconfig-0.11.1-r1.ebuild
+++ b/dev-python/flask-appconfig/flask-appconfig-0.11.1-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+
+inherit distutils-r1
+
+DESCRIPTION="Configures Flask applications in a canonical way"
+HOMEPAGE="https://github.com/mbr/flask-appconfig"
+# PyPI tarballs don't include tests
+# https://github.com/mbr/flask-appconfig/pull/4
+SRC_URI="https://github.com/mbr/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc test"
+
+RDEPEND="
+	dev-python/click[${PYTHON_USEDEP}]
+	dev-python/flask[${PYTHON_USEDEP}]
+	dev-python/six[${PYTHON_USEDEP}]
+"
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? (
+		dev-python/pytest-runner[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+		${RDEPEND}
+	)
+	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
+"
+
+python_prepare_all() {
+	sed -i "s/, 'sphinx.ext.intersphinx'//" docs/conf.py || die
+	# These conflict with recent flask versions, #589548
+	sed -i '/entry_points={/,/},$/d' setup.py || die
+	distutils-r1_python_prepare_all
+}
+
+python_compile_all() {
+	use doc && emake -C docs html
+}
+
+python_test() {
+	py.test || die "Tests failed with ${EPYTHON}"
+}
+
+python_install_all() {
+	use doc && local HTML_DOCS=( docs/_build/html/. )
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
The console script called `flask` causes a collision with dev-python/flask-0.11: https://bugs.gentoo.org/show_bug.cgi?id=589548
Upstream already removed the console_scripts entry point from recent versions:
https://github.com/mbr/flask-appconfig/commit/42b1fe09dbd19cb7c48dfce7f505d7db7e6dd0be

```diff
--- flask-appconfig-0.11.1.ebuild       2016-04-30 23:14:21.071874479 +0200
+++ flask-appconfig-0.11.1-r1.ebuild    2016-07-23 22:22:35.307056876 +0200
@@ -35,6 +35,8 @@
 
 python_prepare_all() {
        sed -i "s/, 'sphinx.ext.intersphinx'//" docs/conf.py || die
+       # These conflict with recent flask versions, #589548
+       sed -i '/entry_points={/,/},$/d' setup.py || die
        distutils-r1_python_prepare_all
 }
 
```