### PR TITLE
profiles: Update plasma package.use

### DIFF
--- a/profiles/targets/desktop/plasma/package.use
+++ b/profiles/targets/desktop/plasma/package.use
@@ -52,7 +52,6 @@ net-libs/libproxy -kde
 
 # Allow certain KDE 4 components to be coinstalled with Plasma 5
 <dev-util/kdevelop-4.8.0 -gdbui
-kde-apps/kde-wallpapers minimal
 kde-apps/kde4-l10n minimal
 kde-apps/solid-runtime -bluetooth
 kde-base/baloo minimal
@@ -72,7 +71,8 @@ dev-db/sqlitebrowser -qt4
 >=dev-libs/quazip-0.7.1 -qt4
 >=kde-misc/kdiff3-0.9.98-r1 -kde -qt4
 >=media-libs/opencv-3.0.0 -qt4
-media-video/makemkv -qt4
+>=media-sound/cantata-2.0.1 -kde
+>=media-sound/mixxx-2.0.0-r1 -qt4
 >=media-video/smplayer-14.9.0.6690 -qt4
 media-video/vlc -qt4
 net-analyzer/wireshark -qt4


### PR DESCRIPTION
kde-apps/kde-wallpapers now has a proper stable upgrade
media-sound/cantata has qt5? ( !kde )
media-sound/mixxx just got ^^ ( qt4 qt5 ) support...
media-video/makemkv was fixed not to REQUIRED_USE (thx @chewi!)

@gentoo/kde