### PR TITLE
sys-devel/make: default CXX to c++ instead of g++

### DIFF
--- a/sys-devel/make/files/make-4.2-default-cxx.patch
+++ b/sys-devel/make/files/make-4.2-default-cxx.patch
@@ -1,0 +1,13 @@
+diff --git a/default.c b/default.c
+index 3d865c7..e8b3ed6 100644
+--- a/default.c
++++ b/default.c
+@@ -530,7 +530,7 @@ static const char *default_variables[] =
+     "OBJC", "gcc",
+ #else
+     "CC", "cc",
+-    "CXX", "g++",
++    "CXX", "c++",
+     "OBJC", "cc",
+ #endif
+ 

--- a/sys-devel/make/make-4.2.1-r1.ebuild
+++ b/sys-devel/make/make-4.2.1-r1.ebuild
@@ -23,6 +23,7 @@ RDEPEND="${CDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.82-darwin-library_search-dylib.patch
+	"${FILESDIR}"/${PN}-4.2-default-cxx.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Bug #589894

Package-Manager: portage-2.2.28
