### PR TITLE
net-p2p/syncthing: update tools names in metadata

### DIFF
--- a/net-p2p/syncthing/metadata.xml
+++ b/net-p2p/syncthing/metadata.xml
@@ -19,7 +19,7 @@
   </longdescription>
   <use>
     <flag name="tools">
-      Install discosrv, relaysrv and other tools to /usr/libexec/synsthing/.
+      Install stdiscosrv, strelaysrv and other tools to /usr/libexec/synsthing/.
     </flag>
   </use>
   <upstream>


### PR DESCRIPTION
@sbraz @djc 
Hi, I looked at the repo and realized that we didn't change relaysrv to strelaysrv in the metadata. I hope upstream is not changing the names again soon.