### PR TITLE
media-video/mpv: always install HTML doc wrt bug 589702

### DIFF
--- a/media-video/mpv/files/0.18.1/mpv-0.18.1-add-htmldir-option.patch
+++ b/media-video/mpv/files/0.18.1/mpv-0.18.1-add-htmldir-option.patch
@@ -1,0 +1,34 @@
+commit f95cde60ff02e897088d35052426964a3db90eb7
+Author: Chris Mayo <aklhfex@gmail.com>
+Date:   Tue Jul 26 07:55:54 2016 +0100
+
+build: add --htmldir option
+
+Defaults to docdir but makes it possible to install html documentation
+separately.
+
+diff --git a/wscript b/wscript
+index 9269d95..309efd3 100644
+--- a/wscript
++++ b/wscript
+@@ -942,6 +942,7 @@ _INSTALL_DIRS_LIST = [
+     ('datadir', '${PREFIX}/share',    'data files'),
+     ('mandir',  '${DATADIR}/man',     'man pages '),
+     ('docdir',  '${DATADIR}/doc/mpv', 'documentation files'),
++    ('htmldir', '${DOCDIR}',          'html documentation files'),
+     ('zshdir',  '${DATADIR}/zsh/site-functions', 'zsh completion functions'),
+
+     ('confloaddir', '${CONFDIR}', 'configuration files load directory'),
+diff --git a/wscript_build.py b/wscript_build.py
+index 13d89ce..257be27 100644
+--- a/wscript_build.py
++++ b/wscript_build.py
+@@ -19,7 +19,7 @@ def _build_html(ctx):
+         target       = 'DOCS/man/mpv.html',
+         source       = 'DOCS/man/mpv.rst',
+         rule         = '${RST2HTML} ${SRC} ${TGT}',
+-        install_path = ctx.env.DOCDIR)
++        install_path = ctx.env.HTMLDIR)
+
+     _add_rst_manual_dependencies(ctx)
+

--- a/media-video/mpv/mpv-0.18.1-r1.ebuild
+++ b/media-video/mpv/mpv-0.18.1-r1.ebuild
@@ -135,6 +135,7 @@ PATCHES=(
 	"${FILESDIR}/${PV}/${P}-fix-audio-uninit-crash.patch"
 	"${FILESDIR}/${PV}/${P}-fix-high-CPU-on-wayland.patch"
 	"${FILESDIR}/${PV}/${P}-handle-ffmpeg-ABI-changes.patch"
+	"${FILESDIR}/${PV}/${P}-add-htmldir-option.patch"
 )
 
 pkg_pretend() {
@@ -153,6 +154,7 @@ src_configure() {
 	local mywafargs=(
 		--confdir="${EPREFIX}/etc/${PN}"
 		--docdir="${EPREFIX}/usr/share/doc/${PF}"
+		--htmldir="${EPREFIX}/usr/share/doc/${PF}/html"
 
 		$(usex cli '' '--disable-cplayer')
 		$(use_enable libmpv libmpv-shared)
@@ -162,8 +164,8 @@ src_configure() {
 		--disable-static-build
 		--disable-optimize		# Don't add '-O2' to CFLAGS.
 		--disable-debug-build	# Don't add '-g' to CFLAGS.
+		--enable-html-build
 
-		$(use_enable doc html-build)
 		$(use_enable doc pdf-build)
 		$(use_enable vf-dlopen vf-dlopen-filters)
 		$(use_enable zsh-completion zsh-comp)
@@ -282,7 +284,7 @@ pkg_postinst() {
 
 	local softvol_0_18_1=0
 	for rv in ${REPLACING_VERSIONS}; do
-		version_compare ${rv} 0.18.1
+		version_compare ${rv} 0.18.1-r1
 		[[ $? -eq 1 ]] && softvol_0_18_1=1
 	done
 
@@ -296,7 +298,7 @@ pkg_postinst() {
 		elog "This means that volume controls don't change the system volume,"
 		elog "e.g. per-application volume with PulseAudio."
 		elog "If you want to restore the old behaviour, please refer to"
-		elog "https://bugs.gentoo.org/show_bug.cgi?id=588492#c4"
+		elog "https://bugs.gentoo.org/show_bug.cgi?id=588492#c7"
 		echo
 	fi
 

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -144,6 +144,7 @@ src_configure() {
 	local mywafargs=(
 		--confdir="${EPREFIX}/etc/${PN}"
 		--docdir="${EPREFIX}/usr/share/doc/${PF}"
+		--htmldir="${EPREFIX}/usr/share/doc/${PF}/html"
 
 		$(usex cli '' '--disable-cplayer')
 		$(use_enable libmpv libmpv-shared)
@@ -153,8 +154,8 @@ src_configure() {
 		--disable-static-build
 		--disable-optimize		# Don't add '-O2' to CFLAGS.
 		--disable-debug-build	# Don't add '-g' to CFLAGS.
+		--enable-html-build
 
-		$(use_enable doc html-build)
 		$(use_enable doc pdf-build)
 		$(use_enable vf-dlopen vf-dlopen-filters)
 		$(use_enable zsh-completion zsh-comp)

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -273,7 +273,7 @@ pkg_postinst() {
 
 	local softvol_0_18_1=0
 	for rv in ${REPLACING_VERSIONS}; do
-		version_compare ${rv} 0.18.1
+		version_compare ${rv} 0.18.1-r1
 		[[ $? -eq 1 ]] && softvol_0_18_1=1
 	done
 
@@ -287,7 +287,7 @@ pkg_postinst() {
 		elog "This means that volume controls don't change the system volume,"
 		elog "e.g. per-application volume with PulseAudio."
 		elog "If you want to restore the old behaviour, please refer to"
-		elog "https://bugs.gentoo.org/show_bug.cgi?id=588492#c4"
+		elog "https://bugs.gentoo.org/show_bug.cgi?id=588492#c7"
 		echo
 	fi
 


### PR DESCRIPTION
CC @gentoo/proxy-maint