### PR TITLE
dev-db/percona-xtrabackup: add Michał Zając as maintainer, add missing dep on vim-core/DBD-mysql

### DIFF
--- a/dev-db/percona-xtrabackup/metadata.xml
+++ b/dev-db/percona-xtrabackup/metadata.xml
@@ -4,7 +4,10 @@
   <maintainer type="person">
     <email>hydrapolic@gmail.com</email>
     <name>Tomáš Mózes</name>
-    <description>Proxy maintainer</description>
+  </maintainer>
+  <maintainer type="person">
+    <email>manwe@manwe.pl</email>
+    <name>Michał Zając</name>
   </maintainer>
   <maintainer type="project">
     <email>proxy-maint@gentoo.org</email>

--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.4.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.4.ebuild
@@ -24,7 +24,8 @@ DEPEND="system-boost? ( =dev-libs/boost-1.59.0 )
 		net-misc/curl
 		sys-libs/zlib"
 RDEPEND="${DEPEND}
-		!dev-db/xtrabackup-bin"
+		!dev-db/xtrabackup-bin
+		dev-perl/DBD-mysql"
 
 src_configure() {
 	local my_args

--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.4.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.4.ebuild
@@ -15,6 +15,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="system-boost"
 
 DEPEND="system-boost? ( =dev-libs/boost-1.59.0 )
+		app-editors/vim-core
 		dev-libs/libaio
 		dev-libs/libev
 		dev-libs/libgcrypt:0=


### PR DESCRIPTION
Adding a co-maintainer as agreed via https://bugs.gentoo.org/265407.

Package-Manager: portage-2.3.0