### PR TITLE
net-misc/remmina: elog optional runtime dependency

### DIFF
--- a/net-misc/remmina/remmina-1.2.0_rc14.ebuild
+++ b/net-misc/remmina/remmina-1.2.0_rc14.ebuild
@@ -83,6 +83,8 @@ pkg_preinst() {
 
 pkg_postinst() {
 	gnome2_icon_cache_update
+
+	elog "XDMCP support requires x11-base/xorg-server[xephyr]."
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Inform the user that XDMCP support requires Xephyr to be installed.

Gentoo-Bug: [572472](https://bugs.gentoo.org/572472)