### PR TITLE
dev-libs/nss: fix CAcert URL in metadata.xml

### DIFF
--- a/dev-libs/nss/metadata.xml
+++ b/dev-libs/nss/metadata.xml
@@ -7,7 +7,7 @@
 </maintainer>
 <use>
   <flag name="cacert">
-    Include root/class3 certs from CAcert (http://http://www.cacert.org/)
+    Include root/class3 certs from CAcert (http://www.cacert.org/)
   </flag>
   <flag name="nss-pem">Add support for libnsspem</flag>
   <flag name="utils">Install utilities included with the library</flag>


### PR DESCRIPTION
@axs-gentoo