### PR TITLE
www-servers/mongrel2: Fix build failure with mbedtls-2.3

### DIFF
--- a/www-servers/mongrel2/files/mongrel2-1.11.0-polarssl-platform-590512.patch
+++ b/www-servers/mongrel2/files/mongrel2-1.11.0-polarssl-platform-590512.patch
@@ -1,0 +1,22 @@
+# Fix missing include for newer mbedtls
+--- a/src/io.h       2016-08-04 15:55:53.124890328 -0700
++++ b/src/io.h      2015-12-31 01:25:07.000000000 -0800
+@@ -6,6 +6,7 @@
+ #endif
+ 
+ #include <stdlib.h>
++#include <mbedtls/platform.h>
+ #include <mbedtls/x509.h>
+ #include <mbedtls/ssl.h>
+ #include "server.h"
+--- a/src/server.h   2016-08-04 15:54:49.539498093 -0700
++++ b/src/server.h  2015-12-31 01:25:07.000000000 -0800
+@@ -39,6 +39,7 @@
+ #include "adt/darray.h"
+ #include "host.h"
+ #include "routing.h"
++#include <mbedtls/platform.h>
+ #include <mbedtls/ssl.h>
+ #include <mbedtls/entropy.h>
+ #include <mbedtls/x509.h>
+

--- a/www-servers/mongrel2/mongrel2-1.11.0-r1.ebuild
+++ b/www-servers/mongrel2/mongrel2-1.11.0-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+DESCRIPTION="A language agnostic web server focused on web applications"
+HOMEPAGE="http://mongrel2.org"
+SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+DEPEND="net-libs/zeromq
+	>=net-libs/mbedtls-2.1[havege]
+	dev-db/sqlite:3"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	cp "${FILESDIR}/systemtls.mak" Makefile || die
+	eapply "${FILESDIR}/${P}-polarssl-platform-590512.patch"
+	eapply_user
+}
+
+src_install() {
+	emake install PREFIX=/usr DESTDIR="${D}"
+	dodoc README examples/configs/mongrel2.conf
+}


### PR DESCRIPTION
Patch header-file include order to work with newer mbedtls versions

Gentoo-Bug: https://bugs.gentoo.org/590512

Package-Manager: portage-2.2.26