### PR TITLE
net-misc/openvswitch: Fix deps for pure systemd env.

### DIFF
--- a/net-misc/openvswitch/openvswitch-2.5.0.ebuild
+++ b/net-misc/openvswitch/openvswitch-2.5.0.ebuild
@@ -17,7 +17,11 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="debug modules monitor +ssl"
 
-RDEPEND=">=sys-apps/openrc-0.10.5
+RDEPEND="
+	|| (
+		>=sys-apps/openrc-0.10.5
+		sys-apps/systemd
+	)
 	ssl? ( dev-libs/openssl:= )
 	monitor? (
 		${PYTHON_DEPS}


### PR DESCRIPTION
net-misc/openvswitch: Fix runtime dependency for compilation on pure systemd environment.