### PR TITLE
sys-kernel/rt-sources: K_SECURITY_UNSUPPORTED="1" rather than "yes"

### DIFF
--- a/sys-kernel/rt-sources/rt-sources-3.14.65_p68.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-3.14.65_p68.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-3.14.72_p75.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-3.14.72_p75.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-3.18.29_p30.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-3.18.29_p30.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-3.18.36_p37.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-3.18.36_p37.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-4.1.20_p23.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-4.1.20_p23.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-4.1.27_p30.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-4.1.27_p30.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-4.4.12_p19.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-4.4.12_p19.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-4.4.9_p17.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-4.4.9_p17.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-4.6.1_p3.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-4.6.1_p3.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 

--- a/sys-kernel/rt-sources/rt-sources-4.6.2_p5.ebuild
+++ b/sys-kernel/rt-sources/rt-sources-4.6.2_p5.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.kernel.org/pub/linux/kernel/projects/rt/"
 inherit versionator
 
 CKV="$(get_version_component_range 1-3)"
-K_SECURITY_UNSUPPORTED="yes"
+K_SECURITY_UNSUPPORTED="1"
 K_DEBLOB_AVAILABLE="1"
 RT_PATCHSET="${PV/*_p}"
 


### PR DESCRIPTION
With respect to Gentoo bug #587910.

Version bumps and stablereqs will come when I have written a better update script which can handle stabilizations in a neat way.