### PR TITLE
net-misc/remmina: libsecret and webkit-gtk fixes

### DIFF
--- a/net-misc/remmina/files/remmina-1.2.0_rc14-allow-disabling-libsecret.patch
+++ b/net-misc/remmina/files/remmina-1.2.0_rc14-allow-disabling-libsecret.patch
@@ -1,0 +1,22 @@
+From d22cc5aa53f6c7312fb1da7a2a507155bab8fabc Mon Sep 17 00:00:00 2001
+From: Diogo Pereira <sir.suriv@gmail.com>
+Date: Wed, 3 Aug 2016 01:15:52 +0100
+Subject: [PATCH] Allow disabling libsecret dependency
+
+---
+ remmina-plugins-gnome/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/remmina-plugins-gnome/CMakeLists.txt b/remmina-plugins-gnome/CMakeLists.txt
+index adf2d03..b392ad6 100644
+--- a/remmina-plugins-gnome/CMakeLists.txt
++++ b/remmina-plugins-gnome/CMakeLists.txt
+@@ -31,7 +31,7 @@
+ # files in the program, then also delete it here.
+ 
+ 
+-find_package(Libsecret)
++find_suggested_package(Libsecret)
+ if(LIBSECRET_FOUND)
+ 	set(REMMINA_PLUGINS_GNOME_SRCS
+ 		src/glibsecret_plugin.c

--- a/net-misc/remmina/remmina-1.2.0_rc14-r1.ebuild
+++ b/net-misc/remmina/remmina-1.2.0_rc14-r1.ebuild
@@ -1,0 +1,94 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit cmake-utils gnome2-utils versionator
+
+MY_PV_MAIN=$(get_version_component_range 1-3)
+MY_PV_RC=$(get_version_component_range 4)
+MY_PV="${MY_PV_MAIN}-${MY_PV_RC//rc/rcgit.}"
+
+if [[ ${PV} != 9999 ]]; then
+	SRC_URI="https://github.com/FreeRDP/Remmina/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+else
+	inherit git-r3
+	SRC_URI=""
+	EGIT_REPO_URI="git://github.com/FreeRDP/Remmina.git
+		https://github.com/FreeRDP/Remmina.git"
+fi
+
+DESCRIPTION="A GTK+ RDP, VNC, XDMCP and SSH client"
+HOMEPAGE="http://remmina.org/ https://github.com/FreeRDP/Remmina"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="ayatana crypt debug freerdp gnome-keyring nls ssh telepathy vte webkit zeroconf"
+REQUIRED_USE="ssh? ( vte )" #546886
+
+RDEPEND="
+	>=dev-libs/glib-2.31.18:2
+	>=net-libs/libvncserver-0.9.8.2
+	x11-libs/libxkbfile
+	x11-libs/gdk-pixbuf
+	x11-libs/gtk+:3
+	x11-libs/libX11
+	virtual/freedesktop-icon-theme
+	ayatana? ( dev-libs/libappindicator:3 )
+	crypt? ( dev-libs/libgcrypt:0= )
+	freerdp? ( >=net-misc/freerdp-2 )
+	gnome-keyring? ( app-crypt/libsecret )
+	ssh? ( net-libs/libssh[sftp] )
+	telepathy? ( net-libs/telepathy-glib )
+	vte? ( x11-libs/vte:2.91 )
+	webkit? ( net-libs/webkit-gtk:4 )
+	zeroconf? ( net-dns/avahi[gtk3] )
+"
+DEPEND="${RDEPEND}
+	dev-util/intltool
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+RDEPEND+="
+	x11-base/xorg-server[kdrive]
+	!net-misc/remmina-plugins
+"
+
+DOCS=( README.md )
+
+PATCHES=( "${FILESDIR}/${P}-allow-disabling-libsecret.patch" )
+
+S="${WORKDIR}/Remmina-${MY_PV}"
+
+src_configure() {
+	local mycmakeargs=(
+		-DWITH_APPINDICATOR=$(usex ayatana)
+		-DWITH_GCRYPT=$(usex crypt)
+		-DWITH_FREERDP=$(usex freerdp)
+		-DWITH_LIBSECRET=$(usex gnome-keyring)
+		-DWITH_GETTEXT=$(usex nls)
+		-DWITH_TRANSLATIONS=$(usex nls)
+		-DWITH_LIBSSH=$(usex ssh)
+		-DWITH_TELEPATHY=$(usex telepathy)
+		-DWITH_VTE=$(usex vte)
+		-DWITH_SURVEY=$(usex webkit)
+		-DWITH_AVAHI=$(usex zeroconf)
+		-DGTK_VERSION=3
+	)
+	cmake-utils_src_configure
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+
+	elog "XDMCP support requires x11-base/xorg-server[xephyr]."
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
- Patch build to properly allow disabling libsecret (FreeRDP/Remmina#942)
- Switch from libsecret to gnome-keyring USE flag
- Hard depend on net-libs/webkit-gtk:4

Gentoo-Bug: [590704](https://bugs.gentoo.org/590704)
Reported-by: @pacho2