### PR TITLE
app-shells/mpv-bash-completion: require mpv>=0.14.0 for 3.3.4

### DIFF
--- a/app-shells/mpv-bash-completion/mpv-bash-completion-3.3.4.ebuild
+++ b/app-shells/mpv-bash-completion/mpv-bash-completion-3.3.4.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 IUSE="luajit"
 
-COMMON_DEPEND="media-video/mpv[cli]"
+COMMON_DEPEND=">=media-video/mpv-0.14.0[cli]"
 RDEPEND="${COMMON_DEPEND}
 	>=app-shells/bash-completion-2.3-r1
 "


### PR DESCRIPTION
mpv-bash-completion-3.3.4 doesn't build otherwise.

Gentoo-Bug: https://bugs.gentoo.org/590794

Package-Manager: portage-2.3.0