### PR TITLE
kde-apps/kdebase-runtime-meta: Add USE=webkit for plasma-runtime RDEPEND

### DIFF
--- a/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-16.04.3.ebuild
+++ b/kde-apps/kdebase-runtime-meta/kdebase-runtime-meta-16.04.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5-meta-pkg
 
 DESCRIPTION="Merge this to pull in all kdebase-runtime-derived packages"
 KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
-IUSE="+oldwallet pam"
+IUSE="+oldwallet pam +webkit"
 
 RDEPEND="
 	$(add_kdeapps_dep kcmshell '' 16.04.3)
@@ -35,11 +35,11 @@ RDEPEND="
 	$(add_kdeapps_dep ktraderclient '' 16.04.3)
 	$(add_kdeapps_dep kurifilter-plugins '' 16.04.3)
 	$(add_kdeapps_dep phonon-kde '' 16.04.3)
-	$(add_kdeapps_dep plasma-runtime '' 16.04.3)
 	$(add_kdeapps_dep renamedlg-plugins '' 16.04.3)
 	$(add_kdeapps_dep solid-runtime '-bluetooth' 16.04.3)
 	oldwallet? (
 		$(add_kdeapps_dep kwalletd '' 16.04.3)
 		pam? ( || ( $(add_plasma_dep kwallet-pam 'oldwallet') kde-apps/kwalletd-pam:4 ) )
 	)
+	webkit? ( $(add_kdeapps_dep plasma-runtime '' 16.04.3) )
 "

--- a/kde-apps/kdeedu-meta/kdeedu-meta-16.04.3.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-16.04.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5-meta-pkg
 DESCRIPTION="KDE educational apps - merge this to pull in all kdeedu-derived packages"
 HOMEPAGE="https://edu.kde.org"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="+webkit"
 
 RDEPEND="
 	$(add_kdeapps_dep analitza)
@@ -27,9 +27,7 @@ RDEPEND="
 	$(add_kdeapps_dep kiten)
 	$(add_kdeapps_dep klettres)
 	$(add_kdeapps_dep kmplot)
-	$(add_kdeapps_dep kqtquickcharts)
 	$(add_kdeapps_dep kstars)
-	$(add_kdeapps_dep ktouch)
 	$(add_kdeapps_dep kturtle)
 	$(add_kdeapps_dep kwordquiz)
 	$(add_kdeapps_dep libkeduvocdocument)
@@ -38,4 +36,8 @@ RDEPEND="
 	$(add_kdeapps_dep parley)
 	$(add_kdeapps_dep rocs)
 	$(add_kdeapps_dep step)
+	webkit? (
+		$(add_kdeapps_dep kqtquickcharts)
+		$(add_kdeapps_dep ktouch)
+	)
 "


### PR DESCRIPTION
kde-apps/plasma-runtime has WEBKIT_REQUIRED=always so make it optional.

@gentoo/kde 