### PR TITLE
profiles: update package.use.mask on musl

### DIFF
--- a/profiles/hardened/linux/musl/package.use.mask
+++ b/profiles/hardened/linux/musl/package.use.mask
@@ -3,10 +3,14 @@
 # $Id$
 
 # See bug #504200
-sys-devel/gcc sanitize 
+sys-devel/gcc sanitize
+
+# llvm's sanitizers are also incompatible with musl
+sys-devel/llvm sanitize
 
 # These cause collisions with <libintl.h>
 # even with --without-included-gettext
+app-text/dos2unix nls
 sys-devel/gettext nls
 sys-fs/e2fsprogs nls
 


### PR DESCRIPTION
Mask "sanitize" for sys-devel/llvm and "nls" for app-text/dos2unix.