### PR TITLE
sci-libs/scikits_learn: using system joblib for cross_validation module

### DIFF
--- a/sci-libs/scikits_learn/scikits_learn-0.17.1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.17.1.ebuild
@@ -61,7 +61,8 @@ python_prepare_all() {
 	rm -r sklearn/externals/joblib/* || die
 	echo "from joblib import *" > sklearn/externals/joblib/__init__.py
 	sed -i -e '/joblib\/test/d' sklearn/externals/setup.py || die
-	sed -i -e 's/..externals.joblib/joblib/g' \
+	sed -i -e 's/..externals.joblib/ joblib/g' \
+		sklearn/cross_validation.py \
 		sklearn/decomposition/tests/test_sparse_pca.py \
 		sklearn/metrics/pairwise.py || die
 


### PR DESCRIPTION
This fixes a number of `ImportError`s. e.g.:

```
In [5]: from sklearn.feature_selection.rfe import RFE
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-5-0b52b7ab401c> in <module>()
----> 1 from sklearn.feature_selection.rfe import RFE

/usr/lib64/python2.7/site-packages/sklearn/feature_selection/__init__.py in <module>()
     18 from .variance_threshold import VarianceThreshold
     19 
---> 20 from .rfe import RFE
     21 from .rfe import RFECV
     22 

/usr/lib64/python2.7/site-packages/sklearn/feature_selection/rfe.py in <module>()
     15 from ..base import clone
     16 from ..base import is_classifier
---> 17 from ..cross_validation import check_cv
     18 from ..cross_validation import _safe_split, _score
     19 from ..metrics.scorer import check_scoring

/usr/lib64/python2.7/site-packages/sklearn/cross_validation.py in <module>()
     27                                check_array, column_or_1d)
     28 from .utils.multiclass import type_of_target
---> 29 from .externals.joblib import Parallel, delayed, logger
     30 from .externals.six import with_metaclass
     31 from .externals.six.moves import zip

ImportError: cannot import name logger

In [6]: from sklearn.externals.joblib import logger
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-6-d69951653dff> in <module>()
----> 1 from sklearn.externals.joblib import logger

ImportError: cannot import name logger

In [7]: from joblib import logger
```