### PR TITLE
dev-python/polib: add ~arm keyword

### DIFF
--- a/dev-python/polib/polib-1.0.7.ebuild
+++ b/dev-python/polib/polib-1.0.7.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~x86 ~arm"
 IUSE="doc"
 
 DEPEND="doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )"


### PR DESCRIPTION
Installs and runs fine on an rpi 3.

Gentoo-Bug: https://bugs.gentoo.org/578656

Package-Manager: portage-2.2.28