### PR TITLE
x11-libs/gdk-pixbuf-loader-webp: New package

### DIFF
--- a/x11-libs/gdk-pixbuf-loader-webp/gdk-pixbuf-loader-webp-20160328234507.ebuild
+++ b/x11-libs/gdk-pixbuf-loader-webp/gdk-pixbuf-loader-webp-20160328234507.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+EGIT_REPO_URI="https://github.com/aruiz/webp-pixbuf-loader"
+EGIT_COMMIT=9b92950d49d7939f90ba7413deb7ec6b392b2054
+
+inherit git-r3 cmake-multilib gnome2-utils
+
+DESCRIPTION="WebP Image format GdkPixbuf loader"
+HOMEPAGE="https://github.com/aruiz/webp-pixbuf-loader"
+
+LICENSE="LGPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+DEPEND=">=media-libs/libwebp-0.4.3
+	>=x11-libs/gdk-pixbuf-2.22"
+RDEPEND="${DEPEND}"
+
+multilib_src_configure() {
+	local mycmakeargs=( -DINSTALL_LIB_DIR:PATH=$(get_libdir) )
+	cmake-utils_src_configure
+}
+
+pkg_preinst() {
+	gnome2_gdk_pixbuf_savelist
+}
+
+pkg_postinst() {
+	gnome2_gdk_pixbuf_update
+}
+
+pkg_postinst() {
+	gnome2_gdk_pixbuf_update
+}

--- a/x11-libs/gdk-pixbuf-loader-webp/metadata.xml
+++ b/x11-libs/gdk-pixbuf-loader-webp/metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>andy.kittner@gmail.com</email>
+		<name>Andy Kittner</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>graphics@gentoo.org</email>
+		<name>Gentoo Graphics Project</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<longdescription lang="en">
+		A gdk-pixbuf plugin that allows GTK applications to view webp images.
+	</longdescription>
+</pkgmetadata>


### PR DESCRIPTION
I created this ebuild for personal use and thought I'd share it since it has already been requested in bugzilla (https://bugs.gentoo.org/show_bug.cgi?id=575030)
Though I'm not sure about a few things

- Should this stay masked (repoman warns about unmasked live ebuild) or is this acceptable (there are no official upstream releases so I pinned it to a specific commit and used the commit date in UTC as version)

- metadata.xml / maintainers: I pieced that together from what I read in the wiki, I hope it's ok, otherwise feel free to hit me with a cluestick

NOTE: this requires the version bump for libwebp I just submitted (https://github.com/gentoo/gentoo/pull/2075) or at the very least a bump to libwebp-0.4.3