### PR TITLE
kde-plasma/plasma-workspace: Drop unused libXcomposite DEPEND

### DIFF
--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.6.5.1-unused-dep.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.6.5.1-unused-dep.patch
@@ -1,0 +1,20 @@
+commit a29bcad4fe0af53c0d8661cbd17eeb57b004342d
+Author: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date:   Wed Aug 17 18:02:19 2016 +0200
+
+    libtaskmanager: Drop unused X11_Xcomposite
+
+diff --git a/libtaskmanager/CMakeLists.txt b/libtaskmanager/CMakeLists.txt
+index 4f81330..8333d61 100644
+--- a/libtaskmanager/CMakeLists.txt
++++ b/libtaskmanager/CMakeLists.txt
+@@ -65,9 +65,6 @@ if (X11_FOUND)
+     if (X11_Xrender_FOUND)
+     target_link_libraries(taskmanager PRIVATE ${X11_Xrender_LIB})
+     endif ()
+-    if (X11_Xcomposite_FOUND)
+-    target_link_libraries(taskmanager PRIVATE ${X11_Xcomposite_LIB})
+-    endif ()
+ endif()
+ 
+ set_target_properties(taskmanager PROPERTIES 

--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.7.3-unused-dep.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.7.3-unused-dep.patch
@@ -1,0 +1,20 @@
+commit 1cc82e71749a907f9345a9b969d3d1e124ed9753
+Author: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date:   Wed Aug 17 17:58:17 2016 +0200
+
+    liblegacytaskmanager: Drop unused X11_Xcomposite
+
+diff --git a/liblegacytaskmanager/CMakeLists.txt b/liblegacytaskmanager/CMakeLists.txt
+index dab11b3..f13880b 100644
+--- a/liblegacytaskmanager/CMakeLists.txt
++++ b/liblegacytaskmanager/CMakeLists.txt
+@@ -65,9 +65,6 @@ if (X11_FOUND)
+     if (X11_Xrender_FOUND)
+     target_link_libraries(legacytaskmanager PRIVATE ${X11_Xrender_LIB})
+     endif ()
+-    if (X11_Xcomposite_FOUND)
+-    target_link_libraries(legacytaskmanager PRIVATE ${X11_Xcomposite_LIB})
+-    endif ()
+ endif()
+ 
+ set_target_properties(legacytaskmanager PROPERTIES

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.6.5.1-r2.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.6.5.1-r2.ebuild
@@ -123,6 +123,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.6.5-drop-kscreen-dep.patch"
 	"${FILESDIR}/${PN}-5.6.5.1-struts.patch"
 	"${FILESDIR}/${PN}-5.6.5.1-legacy-session-mgmt.patch" # backport in 5.6 after release
+	"${FILESDIR}/${PN}-5.6.5.1-unused-dep.patch"
 )
 
 RESTRICT="test"

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.7.5.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.7.5.ebuild
@@ -122,6 +122,7 @@ DEPEND="${COMMON_DEPEND}
 
 PATCHES=(
 	"${FILESDIR}/${PN}-5.4-startkde-script.patch"
+	"${FILESDIR}/${PN}-5.7.3-unused-dep.patch"
 	"${FILESDIR}/${PN}-5.7.5-klipper-autostart.patch"
 )
 


### PR DESCRIPTION
Reported-by: awilfox (irc)

@gentoo/kde @awilfox 