### PR TITLE
kde-apps/konsole: USE=X requires kdelibs4support[X]

### DIFF
--- a/kde-apps/konsole/konsole-16.04.3.ebuild
+++ b/kde-apps/konsole/konsole-16.04.3.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	$(add_frameworks_dep kconfig)
 	$(add_frameworks_dep kconfigwidgets)
 	$(add_frameworks_dep kcoreaddons)
-	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kdelibs4support 'X?')
 	$(add_frameworks_dep kguiaddons)
 	$(add_frameworks_dep kjobwidgets)
 	$(add_frameworks_dep ki18n)


### PR DESCRIPTION
Gentoo-bug: 591074

@gentoo/kde 