### PR TITLE
app-emacs/buffer-extension and friends: cosmetic fixes

### DIFF
--- a/app-emacs/basic-toolkit/basic-toolkit-0.3.ebuild
+++ b/app-emacs/basic-toolkit/basic-toolkit-0.3.ebuild
@@ -21,6 +21,6 @@ DEPEND="${RDEPEND}"
 SITEFILE="50${PN}-gentoo.el"
 
 src_compile() {
-	elisp-compile *.el || die
-	elisp-make-autoload-file || die
+	elisp-compile *.el
+	elisp-make-autoload-file
 }

--- a/app-emacs/buffer-extension/buffer-extension-0.1.ebuild
+++ b/app-emacs/buffer-extension/buffer-extension-0.1.ebuild
@@ -21,6 +21,6 @@ DEPEND="${RDEPEND}"
 SITEFILE="50${PN}-gentoo.el"
 
 src_compile() {
-	elisp-compile *.el || die
-	elisp-make-autoload-file || die
+	elisp-compile *.el
+	elisp-make-autoload-file
 }

--- a/app-emacs/cycle-buffer/cycle-buffer-2.16.ebuild
+++ b/app-emacs/cycle-buffer/cycle-buffer-2.16.ebuild
@@ -18,6 +18,6 @@ KEYWORDS="~amd64"
 SITEFILE="50${PN}-gentoo.el"
 
 src_compile() {
-	elisp-compile *.el || die
-	elisp-make-autoload-file || die
+	elisp-compile *.el
+	elisp-make-autoload-file
 }

--- a/app-emacs/revive/revive-2.23.ebuild
+++ b/app-emacs/revive/revive-2.23.ebuild
@@ -18,6 +18,6 @@ KEYWORDS="~amd64"
 SITEFILE="50${PN}-gentoo.el"
 
 src_compile() {
-	elisp-compile *.el || die
-	elisp-make-autoload-file || die
+	elisp-compile *.el
+	elisp-make-autoload-file
 }

--- a/app-emacs/windows/windows-2.49.ebuild
+++ b/app-emacs/windows/windows-2.49.ebuild
@@ -21,6 +21,6 @@ DEPEND="${RDEPEND}"
 SITEFILE="50${PN}-gentoo.el"
 
 src_compile() {
-	elisp-compile *.el || die
-	elisp-make-autoload-file || die
+	elisp-compile *.el
+	elisp-make-autoload-file
 }


### PR DESCRIPTION
Remove ` || die` because `elisp-*` functions in use die by themselves.