### PR TITLE
sci-geosciences/josm: Require Java 8 for 99999

### DIFF
--- a/sci-geosciences/josm/josm-99999.ebuild
+++ b/sci-geosciences/josm/josm-99999.ebuild
@@ -22,8 +22,8 @@ SLOT="0"
 [[ ${PV} == "99999" ]] || \
 KEYWORDS="~amd64 ~x86"
 
-DEPEND=">=virtual/jdk-1.7"
-RDEPEND=">=virtual/jre-1.7"
+DEPEND=">=virtual/jdk-1.8"
+RDEPEND=">=virtual/jre-1.8"
 
 IUSE=""
 


### PR DESCRIPTION
Gentoo-Bug: 589970