### PR TITLE
Add blockers to kde-apps/ktp-l10n-16.04.3 and kde-apps/kdepim-l10n-16.04.3 on kde-apps/kde-l10n-16.04.2

### DIFF
--- a/kde-apps/kdepim-l10n/kdepim-l10n-16.04.3.ebuild
+++ b/kde-apps/kdepim-l10n/kdepim-l10n-16.04.3.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	sys-devel/gettext
 "
 RDEPEND="
-	!<kde-apps/kde-l10n-15.08.0-r1
+	!<kde-apps/kde-l10n-16.04.3
 	!<kde-apps/kde4-l10n-4.14.3-r1
 "
 

--- a/kde-apps/ktp-l10n/ktp-l10n-16.04.3.ebuild
+++ b/kde-apps/ktp-l10n/ktp-l10n-16.04.3.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	sys-devel/gettext
 "
 RDEPEND="
-	!<kde-apps/kde-l10n-15.08.0-r1
+	!<kde-apps/kde-l10n-16.04.3
 	!kde-apps/ktp-accounts-kcm:4
 	!kde-apps/ktp-approver:4
 	!kde-apps/ktp-auth-handler:4


### PR DESCRIPTION
Due to the sr language refactor, these packages can't be co-installed.  Add a blocker so portage handles this case correctly.

This is similar to the PR gentoo/kde#763.