### PR TITLE
dev-tex/cpp2latex: Rewrite for EAPI=6, improved

### DIFF
--- a/dev-tex/cpp2latex/cpp2latex-2.3-r2.ebuild
+++ b/dev-tex/cpp2latex/cpp2latex-2.3-r2.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+DESCRIPTION="A program to convert C++ code to LaTeX source"
+HOMEPAGE="http://www.arnoldarts.de/cpp2latex/"
+SRC_URI="http://www.arnoldarts.de/files/cpp2latex/${P}.tar.gz"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+# first patch: bug #44585, second patch bug #227863
+PATCHES=(
+	"${FILESDIR}/${P}.patch"
+	"${FILESDIR}/${P}-gcc43.patch"
+	"${FILESDIR}/${P}-tests.patch"
+)

--- a/dev-tex/cpp2latex/files/cpp2latex-2.3.patch
+++ b/dev-tex/cpp2latex/files/cpp2latex-2.3.patch
@@ -1,5 +1,5 @@
---- main.cpp	Thu Mar  6 08:15:36 2003
-+++ main.cpp	Tue Jan 24 21:47:17 2006
+--- a/cpp2latex/main.cpp	Thu Mar  6 08:15:36 2003
++++ a/cpp2latex/main.cpp	Tue Jan 24 21:47:17 2006
 @@ -27,12 +27,14 @@
  #include <stdio.h>
  #include <getopt.h>


### PR DESCRIPTION
this is a PR with improvements as suggested for https://github.com/gentoo/gentoo/pull/2101
Thank you for your good suggestions.
patches renamed, to link the bug number for ever to the patch