### PR TITLE
sys-libs/libomp: fix a compile error on musl

### DIFF
--- a/sys-libs/libomp/files/libomp-3.9.0-glibc-detection.patch
+++ b/sys-libs/libomp/files/libomp-3.9.0-glibc-detection.patch
@@ -1,0 +1,13 @@
+diff --git a/runtime/src/kmp_i18n.c b/runtime/src/kmp_i18n.c
+index 546e693..07ad157 100644
+--- a/runtime/src/kmp_i18n.c
++++ b/runtime/src/kmp_i18n.c
+@@ -809,7 +809,7 @@ sys_error(
+                 int    strerror_r( int, char *, size_t );  // XSI version
+         */
+ 
+-        #if KMP_OS_LINUX
++        #if KMP_OS_LINUX && __GLIBC__
+ 
+             // GNU version of strerror_r.
+ 

--- a/sys-libs/libomp/libomp-3.9.0.ebuild
+++ b/sys-libs/libomp/libomp-3.9.0.ebuild
@@ -25,6 +25,8 @@ S="${WORKDIR}/${MY_P}.src"
 PATCHES=(
 	# backport of https://reviews.llvm.org/D24563
 	"${FILESDIR}"/${PN}-3.9.0-optional-aliases.patch
+	# backport of https://reviews.llvm.org/D25071
+	"${FILESDIR}"/${PN}-3.9.0-glibc-detection.patch
 )
 
 multilib_src_configure() {


### PR DESCRIPTION
glibc's strerror_r() returns a char*, while BSDs and musl's version returns a
int. libomp unconditionally assumes glibc's version on Linux, which is wrong.
This commit add detection for glibc so this package works on musl.

Package-Manager: portage-2.2.28