### PR TITLE
dev-java/japitools: Various bug fixes and changes

### DIFF
--- a/dev-java/japitools/japitools-0.9.7-r3.ebuild
+++ b/dev-java/japitools/japitools-0.9.7-r3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 JAVA_PKG_IUSE="doc source"
 
@@ -22,12 +22,13 @@ RESTRICT="test"
 CDEPEND="dev-java/ant-core:0"
 
 RDEPEND="
+	dev-lang/perl
 	${CDEPEND}
-	>=virtual/jre-1.6"
+	>=virtual/jre-1.7"
 
 DEPEND="
 	${CDEPEND}
-	>=virtual/jdk-1.6"
+	>=virtual/jdk-1.7"
 
 S="${WORKDIR}/${P}"
 
@@ -35,7 +36,17 @@ JAVA_GENTOO_CLASSPATH="ant-core"
 
 JAVA_SRC_DIR="src"
 
+java_prepare() {
+	eapply_user
+	cd "${S}"/bin || die
+	rm *.bat || die
+	sed -e "s:../share/java:../share/${PN}/lib:" -i * \
+		|| die "Failed to correct the location of the jar file in perl scripts."
+}
+
 src_install() {
+	dobin bin/*
+
 	java-pkg-simple_src_install
 	java-pkg_register-ant-task
 }


### PR DESCRIPTION
@gentoo/java @chewi 
install bins, correct classpath in bins, add missing runtime dep
dev-lang/perl, switched EAPI to 6, updated java version to 1.7

Package-Manager: portage-2.3.0