### PR TITLE
cmake-utils.eclass: print feature summary

### DIFF
--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -422,6 +422,13 @@ _cmake_modify-cmakelists() {
 		Module          \${CMAKE_MODULE_LINKER_FLAGS}
 		Shared          \${CMAKE_SHARED_LINKER_FLAGS}\n")
 	_EOF_
+
+	if ! grep -iq FEATURE_SUMMARY "${CMAKE_USE_DIR}"/CMakeLists.txt; then
+		cat >> "${CMAKE_USE_DIR}"/CMakeLists.txt <<- _EOF_ || die
+			include(FeatureSummary)
+			FEATURE_SUMMARY(INCLUDE_QUIET_PACKAGES WHAT ALL)
+		_EOF_
+	fi
 }
 
 # temporary function for moving cmake cleanups from from src_configure -> src_prepare.


### PR DESCRIPTION
This will make print something like for each package build:
```
-- The following OPTIONAL packages have been found:

 * Git
 * EXPAT
 * FFTW3
 * GSL
 * PkgConfig
 * SQLITE3
 * Doxygen

-- The following REQUIRED packages have been found:

 * Threads
 * Boost (required version >= 1.39.0)

-- The following OPTIONAL packages have not been found:

 * MKL
```
which make it easy to look for missing dependencies.