### PR TITLE
app-office/libreoffice: fix ebuild bug building with clang

### DIFF
--- a/app-office/libreoffice/libreoffice-5.1.4.2.ebuild
+++ b/app-office/libreoffice/libreoffice-5.1.4.2.ebuild
@@ -265,9 +265,7 @@ pkg_pretend() {
 	if [[ ${MERGE_TYPE} != binary ]]; then
 		check-reqs_pkg_pretend
 
-		if [[ $(tc-getCC) == clang ]] ; then
-			: # ignore clang, which works
-		elif [[ $(gcc-major-version) -lt 4 ]] || {
+		if [[ $(gcc-major-version) -lt 4 ]] || {
 				[[ $(gcc-major-version) -eq 4 && $(gcc-minor-version) -lt 7 ]]; } then
 			eerror "Compilation with gcc older than 4.7 is not supported"
 			die "Too old gcc found."

--- a/app-office/libreoffice/libreoffice-5.1.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-5.1.9999.ebuild
@@ -264,9 +264,7 @@ pkg_pretend() {
 	if [[ ${MERGE_TYPE} != binary ]]; then
 		check-reqs_pkg_pretend
 
-		if [[ $(tc-getCC) == clang ]] ; then
-			: # ignore clang, which works
-		elif [[ $(gcc-major-version) -lt 4 ]] || {
+		if [[ $(gcc-major-version) -lt 4 ]] || {
 				[[ $(gcc-major-version) -eq 4 && $(gcc-minor-version) -lt 7 ]]; } then
 			eerror "Compilation with gcc older than 4.7 is not supported"
 			die "Too old gcc found."

--- a/app-office/libreoffice/libreoffice-5.2.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-5.2.9999.ebuild
@@ -259,9 +259,7 @@ pkg_pretend() {
 	if [[ ${MERGE_TYPE} != binary ]]; then
 		check-reqs_pkg_pretend
 
-		if [[ $(tc-getCC) == clang ]] ; then
-			: # ignore clang, which works
-		elif [[ $(gcc-major-version) -lt 4 ]] || {
+		if [[ $(gcc-major-version) -lt 4 ]] || {
 				[[ $(gcc-major-version) -eq 4 && $(gcc-minor-version) -lt 7 ]]; } then
 			eerror "Compilation with gcc older than 4.7 is not supported"
 			die "Too old gcc found."

--- a/app-office/libreoffice/libreoffice-9999.ebuild
+++ b/app-office/libreoffice/libreoffice-9999.ebuild
@@ -259,9 +259,7 @@ pkg_pretend() {
 	if [[ ${MERGE_TYPE} != binary ]]; then
 		check-reqs_pkg_pretend
 
-		if [[ $(tc-getCC) == clang ]] ; then
-			: # ignore clang, which works
-		elif [[ $(gcc-major-version) -lt 4 ]] || {
+		if [[ $(gcc-major-version) -lt 4 ]] || {
 				[[ $(gcc-major-version) -eq 4 && $(gcc-minor-version) -lt 7 ]]; } then
 			eerror "Compilation with gcc older than 4.7 is not supported"
 			die "Too old gcc found."


### PR DESCRIPTION
This fixes a bug that misidentifies clang as gcc in a compiler test.

Gentoo-Bug: 598948
Suggested-By: Jason Schulz <jason@schulz.name>