### PR TITLE
net-p2p/litecoin*: Fixing dependency further bugs and slot op for boost 

### DIFF
--- a/net-p2p/litecoin-qt/litecoin-qt-0.10.2.2-r4.ebuild
+++ b/net-p2p/litecoin-qt/litecoin-qt-0.10.2.2-r4.ebuild
@@ -45,6 +45,7 @@ RDEPEND="
 	qt5? (
 		dev-qt/qtnetwork:5[ssl]
 		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
 		dbus? (
 			dev-qt/qtdbus:5
 		)

--- a/net-p2p/litecoin-qt/litecoin-qt-0.10.4.0.ebuild
+++ b/net-p2p/litecoin-qt/litecoin-qt-0.10.4.0.ebuild
@@ -45,6 +45,7 @@ RDEPEND="
 	qt5? (
 		dev-qt/qtnetwork:5[ssl]
 		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
 		dbus? (
 			dev-qt/qtdbus:5
 		)

--- a/net-p2p/litecoin-qt/litecoin-qt-0.10.4.0.ebuild
+++ b/net-p2p/litecoin-qt/litecoin-qt-0.10.4.0.ebuild
@@ -52,6 +52,7 @@ RDEPEND="
 	)
 "
 DEPEND="${RDEPEND}
+	qt5? ( dev-qt/linguist-tools:5 )
 	>=app-shells/bash-4.1
 "
 

--- a/net-p2p/litecoin-qt/litecoin-qt-0.10.4.0.ebuild
+++ b/net-p2p/litecoin-qt/litecoin-qt-0.10.4.0.ebuild
@@ -24,7 +24,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="dbus kde +qrcode qt5 upnp"
 
 RDEPEND="
-	dev-libs/boost[threads(+)]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/openssl:0[-bindist]
 	dev-libs/protobuf:=
 	qrcode? (

--- a/net-p2p/litecoind/litecoind-0.10.4.0.ebuild
+++ b/net-p2p/litecoind/litecoind-0.10.4.0.ebuild
@@ -22,7 +22,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="logrotate upnp +wallet"
 
 RDEPEND="
-	dev-libs/boost[threads(+)]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/openssl:0[-bindist]
 	logrotate? ( app-admin/logrotate )
 	upnp? ( net-libs/miniupnpc )


### PR DESCRIPTION
QT5 dependencies where missing and there was a slot operator request: bug 579874