### PR TITLE
One of bopm's upstream providers removed their blacklist.

### DIFF
--- a/net-misc/bopm/bopm-3.1.3-r2.ebuild
+++ b/net-misc/bopm/bopm-3.1.3-r2.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit eutils user
+
+DESCRIPTION="Blitzed Open Proxy Monitor"
+HOMEPAGE="http://github.com/blitzed-org/bopm"
+SRC_URI="http://static.blitzed.org/www.blitzed.org/${PN}/files/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~x86"
+IUSE=""
+
+RDEPEND=""
+DEPEND="${RDEPEND}"
+
+PATCHES=("${FILESDIR}"/remove-njabl.patch)
+
+pkg_setup() {
+	enewuser bopm
+}
+
+src_prepare() {
+	sed -i \
+		-e "s!/some/path/bopm.pid!/run/${PN}/${PN}.pid!" \
+		-e "s!/some/path/scan.log!/var/log/${PN}/scan.log!" \
+		bopm.conf.sample || die
+	default
+}
+
+src_configure() {
+	# bopm puts its example config file in datadir
+	# put it in its docs folder instead
+	econf \
+		--datadir="${EPREFIX}"/usr/share/doc/${PF} \
+		--localstatedir="${EPREFIX}"/var/log/${PN}
+}
+
+src_install() {
+	# Custom Makefile.am rules do not respect DESTDIR,
+	# thus override sysconfdir and localstatedir.
+	emake \
+		DESTDIR="${ED}" \
+		sysconfdir="${ED}"etc \
+		localstatedir="${ED}"var/log/bopm \
+		install
+
+	# Remove libopm related files, because bopm links statically to it
+	# If anybody wants libopm, please install net-libs/libopm
+	rm -r "${ED}"usr/$(get_libdir) "${ED}"usr/include || die
+
+	newinitd "${FILESDIR}"/bopm.init.d-r1 ${PN}
+	newconfd "${FILESDIR}"/bopm.conf.d-r1 ${PN}
+
+	einstalldocs
+
+	dodir /var/log/bopm
+	fperms 700 /var/log/bopm
+	fowners bopm:root /var/log/bopm
+
+	fperms 600 /etc/bopm.conf
+	fowners bopm:root /etc/bopm.conf
+}

--- a/net-misc/bopm/files/remove-njabl.patch
+++ b/net-misc/bopm/files/remove-njabl.patch
@@ -1,0 +1,28 @@
+Remove NJABL as an example blacklist.
+
+NJABL has been shut down and bopm upstream still lists it in its default
+configuration.
+---
+diff --git a/bopm.conf.sample b/bopm.conf.sample
+index 74483e1..bc05bf4 100644
+--- a/bopm.conf.sample
++++ b/bopm.conf.sample
+@@ -363,18 +363,6 @@ OPM {
+ #        };
+ 
+ 
+-	/* example: NJABL - please read http://www.njabl.org/use.html before
+-	 * uncommenting */
+-#	 blacklist {
+-#	    name = "dnsbl.njabl.org";
+-#	    type = "A record reply";
+-#	    reply {
+-#	       9 = "Open proxy";
+-#	    };
+-#	    ban_unknown = no;
+-#	    kline = "KLINE *@%h :Open proxy found on your host, please visit www.njabl.org/cgi-bin/lookup.cgi?query=%i";
+-#	};
+-
+ 	/*
+ 	 * You can report the insecure proxies you find to a DNSBL also!
+ 	 * The remaining directives in this section are only needed if you


### PR DESCRIPTION
This commit removes the dead njabl blacklist from bopm's config file.

Signed-off-by: Raymond Jennings <shentino@gmail.com>
Gentoo-Bug: https://bugs.gentoo.org/473754