### PR TITLE
media-gfx/mypaint: TypeError: GLib.filename_to_utf8() takes exactly 2 arguments (4 given) - patch

### DIFF
--- a/media-gfx/mypaint/files/mypaint-1.2.0-filename_to_unicode.patch
+++ b/media-gfx/mypaint/files/mypaint-1.2.0-filename_to_unicode.patch
@@ -1,0 +1,25 @@
+diff -Naur mypaint-1.2.0-orig/lib/glib.py mypaint-1.2.0/lib/glib.py
+--- mypaint-1.2.0-orig/lib/glib.py	2016-08-22 22:51:16.019892497 +0200
++++ mypaint-1.2.0/lib/glib.py	2016-08-22 22:52:54.349890736 +0200
+@@ -35,7 +35,6 @@
+     :returns: the converted filename
+     :rtype: unicode
+ 
+-    >>> from gi.repository import GLib
+     >>> filename_to_unicode('/ascii/only/path')
+     u'/ascii/only/path'
+     >>> filename_to_unicode(None) is None
+@@ -54,7 +53,12 @@
+     # Other systems are dependent in opaque ways on the environment.
+     if not isinstance(opsysstring, str):
+         raise TypeError("Argument must be bytes")
+-    ustring = GLib.filename_to_utf8(opsysstring, -1, 0, 0)
++    # This function's annotation seems to vary quite a bit.
++    # See https://github.com/mypaint/mypaint/issues/634
++    try:
++        ustring, _, _ = GLib.filename_to_utf8(opsysstring, -1)
++    except TypeError:
++        ustring = GLib.filename_to_utf8(opsysstring, -1, 0, 0)
+     if ustring is None:
+         raise UnicodeDecodeError(
+             "GLib failed to convert %r to a UTF-8 string. "

--- a/media-gfx/mypaint/mypaint-1.2.0.ebuild
+++ b/media-gfx/mypaint/mypaint-1.2.0.ebuild
@@ -47,6 +47,8 @@ src_prepare() {
 	# multilib support
 	sed -i -e "s:lib\/${PN}:$(get_libdir)\/${PN}:" \
 		SConstruct SConscript || die
+		
+	epatch "${FILESDIR}"/${P}-filename_to_unicode.patch
 }
 
 src_compile() {


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=591180