### PR TITLE
sys-apps/systemd: Add patch for failing SECCOMP checks

### DIFF
--- a/sys-apps/systemd/files/231-001-core-do-not-fail-at-step-SECCOMP-if-there-is-no-kern.patch
+++ b/sys-apps/systemd/files/231-001-core-do-not-fail-at-step-SECCOMP-if-there-is-no-kern.patch
@@ -1,0 +1,251 @@
+From 83f12b27d14853e7c89a326f7cd31a6c739d378e Mon Sep 17 00:00:00 2001
+From: Felipe Sateler <fsateler@users.noreply.github.com>
+Date: Mon, 22 Aug 2016 16:40:58 -0300
+Subject: [PATCH] core: do not fail at step SECCOMP if there is no kernel
+ support (#4004)
+
+Fixes #3882
+
+Signed-off-by: Elias Probst <mail@eliasprobst.eu>
+---
+ src/core/execute.c        | 38 ++++++++++++++++++++++++++++++--------
+ src/core/main.c           |  6 ++++++
+ src/shared/seccomp-util.c | 10 ++++++++++
+ src/shared/seccomp-util.h |  2 ++
+ src/test/test-execute.c   | 11 ++++++++++-
+ 5 files changed, 58 insertions(+), 9 deletions(-)
+
+diff --git a/src/core/execute.c b/src/core/execute.c
+index 0af8eb5..55f15d7 100644
+--- a/src/core/execute.c
++++ b/src/core/execute.c
+@@ -1074,7 +1074,17 @@ static void rename_process_from_path(const char *path) {
+ 
+ #ifdef HAVE_SECCOMP
+ 
+-static int apply_seccomp(const ExecContext *c) {
++static bool skip_seccomp_unavailable(const Unit* u, const char* msg) {
++        if (!is_seccomp_available()) {
++                log_open();
++                log_unit_debug(u, "SECCOMP not detected in the kernel, skipping %s", msg);
++                log_close();
++                return true;
++        }
++        return false;
++}
++
++static int apply_seccomp(const Unit* u, const ExecContext *c) {
+         uint32_t negative_action, action;
+         scmp_filter_ctx *seccomp;
+         Iterator i;
+@@ -1083,6 +1093,9 @@ static int apply_seccomp(const ExecContext *c) {
+ 
+         assert(c);
+ 
++        if (skip_seccomp_unavailable(u, "syscall filtering"))
++                return 0;
++
+         negative_action = c->syscall_errno == 0 ? SCMP_ACT_KILL : SCMP_ACT_ERRNO(c->syscall_errno);
+ 
+         seccomp = seccomp_init(c->syscall_whitelist ? negative_action : SCMP_ACT_ALLOW);
+@@ -1123,13 +1136,16 @@ finish:
+         return r;
+ }
+ 
+-static int apply_address_families(const ExecContext *c) {
++static int apply_address_families(const Unit* u, const ExecContext *c) {
+         scmp_filter_ctx *seccomp;
+         Iterator i;
+         int r;
+ 
+         assert(c);
+ 
++        if (skip_seccomp_unavailable(u, "RestrictAddressFamilies="))
++                return 0;
++
+         seccomp = seccomp_init(SCMP_ACT_ALLOW);
+         if (!seccomp)
+                 return -ENOMEM;
+@@ -1244,12 +1260,15 @@ finish:
+         return r;
+ }
+ 
+-static int apply_memory_deny_write_execute(const ExecContext *c) {
++static int apply_memory_deny_write_execute(const Unit* u, const ExecContext *c) {
+         scmp_filter_ctx *seccomp;
+         int r;
+ 
+         assert(c);
+ 
++        if (skip_seccomp_unavailable(u, "MemoryDenyWriteExecute="))
++                return 0;
++
+         seccomp = seccomp_init(SCMP_ACT_ALLOW);
+         if (!seccomp)
+                 return -ENOMEM;
+@@ -1283,7 +1302,7 @@ finish:
+         return r;
+ }
+ 
+-static int apply_restrict_realtime(const ExecContext *c) {
++static int apply_restrict_realtime(const Unit* u, const ExecContext *c) {
+         static const int permitted_policies[] = {
+                 SCHED_OTHER,
+                 SCHED_BATCH,
+@@ -1296,6 +1315,9 @@ static int apply_restrict_realtime(const ExecContext *c) {
+ 
+         assert(c);
+ 
++        if (skip_seccomp_unavailable(u, "RestrictRealtime="))
++                return 0;
++
+         seccomp = seccomp_init(SCMP_ACT_ALLOW);
+         if (!seccomp)
+                 return -ENOMEM;
+@@ -2403,7 +2425,7 @@ static int exec_child(
+ 
+ #ifdef HAVE_SECCOMP
+                 if (use_address_families) {
+-                        r = apply_address_families(context);
++                        r = apply_address_families(unit, context);
+                         if (r < 0) {
+                                 *exit_status = EXIT_ADDRESS_FAMILIES;
+                                 return r;
+@@ -2411,7 +2433,7 @@ static int exec_child(
+                 }
+ 
+                 if (context->memory_deny_write_execute) {
+-                        r = apply_memory_deny_write_execute(context);
++                        r = apply_memory_deny_write_execute(unit, context);
+                         if (r < 0) {
+                                 *exit_status = EXIT_SECCOMP;
+                                 return r;
+@@ -2419,7 +2441,7 @@ static int exec_child(
+                 }
+ 
+                 if (context->restrict_realtime) {
+-                        r = apply_restrict_realtime(context);
++                        r = apply_restrict_realtime(unit, context);
+                         if (r < 0) {
+                                 *exit_status = EXIT_SECCOMP;
+                                 return r;
+@@ -2427,7 +2449,7 @@ static int exec_child(
+                 }
+ 
+                 if (use_syscall_filter) {
+-                        r = apply_seccomp(context);
++                        r = apply_seccomp(unit, context);
+                         if (r < 0) {
+                                 *exit_status = EXIT_SECCOMP;
+                                 return r;
+diff --git a/src/core/main.c b/src/core/main.c
+index 125cfb2..7d8322e 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -72,6 +72,9 @@
+ #include "process-util.h"
+ #include "raw-clone.h"
+ #include "rlimit-util.h"
++#ifdef HAVE_SECCOMP
++#include "seccomp-util.h"
++#endif
+ #include "selinux-setup.h"
+ #include "selinux-util.h"
+ #include "signal-util.h"
+@@ -1186,6 +1189,9 @@ static int enforce_syscall_archs(Set *archs) {
+         void *id;
+         int r;
+ 
++        if (!is_seccomp_available())
++                return 0;
++
+         seccomp = seccomp_init(SCMP_ACT_ALLOW);
+         if (!seccomp)
+                 return log_oom();
+diff --git a/src/shared/seccomp-util.c b/src/shared/seccomp-util.c
+index 8656d11..4667f50 100644
+--- a/src/shared/seccomp-util.c
++++ b/src/shared/seccomp-util.c
+@@ -21,6 +21,8 @@
+ #include <seccomp.h>
+ #include <stddef.h>
+ 
++#include "alloc-util.h"
++#include "fileio.h"
+ #include "macro.h"
+ #include "seccomp-util.h"
+ #include "string-util.h"
+@@ -89,6 +91,14 @@ int seccomp_add_secondary_archs(scmp_filter_ctx *c) {
+ 
+ }
+ 
++bool is_seccomp_available(void) {
++        _cleanup_free_ char* field = NULL;
++        static int cached_enabled = -1;
++        if (cached_enabled < 0)
++                cached_enabled = get_proc_field("/proc/self/status", "Seccomp", "\n", &field) == 0;
++        return cached_enabled;
++}
++
+ const SystemCallFilterSet syscall_filter_sets[] = {
+         {
+                 /* Clock */
+diff --git a/src/shared/seccomp-util.h b/src/shared/seccomp-util.h
+index be33eec..cca7c17 100644
+--- a/src/shared/seccomp-util.h
++++ b/src/shared/seccomp-util.h
+@@ -27,6 +27,8 @@ int seccomp_arch_from_string(const char *n, uint32_t *ret);
+ 
+ int seccomp_add_secondary_archs(scmp_filter_ctx *c);
+ 
++bool is_seccomp_available(void);
++
+ typedef struct SystemCallFilterSet {
+         const char *set_name;
+         const char *value;
+diff --git a/src/test/test-execute.c b/src/test/test-execute.c
+index 1d24115..05ec1d2 100644
+--- a/src/test/test-execute.c
++++ b/src/test/test-execute.c
+@@ -30,6 +30,9 @@
+ #include "mkdir.h"
+ #include "path-util.h"
+ #include "rm-rf.h"
++#ifdef HAVE_SECCOMP
++#include "seccomp-util.h"
++#endif
+ #include "test-helper.h"
+ #include "unit.h"
+ #include "util.h"
+@@ -132,21 +135,27 @@ static void test_exec_privatedevices(Manager *m) {
+ 
+ static void test_exec_systemcallfilter(Manager *m) {
+ #ifdef HAVE_SECCOMP
++        if (!is_seccomp_available())
++                return;
+         test(m, "exec-systemcallfilter-not-failing.service", 0, CLD_EXITED);
+         test(m, "exec-systemcallfilter-not-failing2.service", 0, CLD_EXITED);
+         test(m, "exec-systemcallfilter-failing.service", SIGSYS, CLD_KILLED);
+         test(m, "exec-systemcallfilter-failing2.service", SIGSYS, CLD_KILLED);
++
+ #endif
+ }
+ 
+ static void test_exec_systemcallerrornumber(Manager *m) {
+ #ifdef HAVE_SECCOMP
+-        test(m, "exec-systemcallerrornumber.service", 1, CLD_EXITED);
++        if (is_seccomp_available())
++                test(m, "exec-systemcallerrornumber.service", 1, CLD_EXITED);
+ #endif
+ }
+ 
+ static void test_exec_systemcall_system_mode_with_user(Manager *m) {
+ #ifdef HAVE_SECCOMP
++        if (!is_seccomp_available())
++                return;
+         if (getpwnam("nobody"))
+                 test(m, "exec-systemcallfilter-system-user.service", 0, CLD_EXITED);
+         else if (getpwnam("nfsnobody"))
+-- 
+2.9.3
+

--- a/sys-apps/systemd/systemd-231-r1.ebuild
+++ b/sys-apps/systemd/systemd-231-r1.ebuild
@@ -1,0 +1,449 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+if [[ ${PV} == 9999 ]]; then
+	EGIT_REPO_URI="https://github.com/systemd/systemd.git"
+	inherit git-r3
+else
+	SRC_URI="https://github.com/systemd/systemd/archive/v${PV}.tar.gz -> ${P}.tar.gz
+		!doc? ( https://dev.gentoo.org/~floppym/dist/${P}-man.tar.gz )"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+fi
+
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
+
+inherit autotools bash-completion-r1 linux-info multilib-minimal pam python-any-r1 systemd toolchain-funcs udev user
+
+DESCRIPTION="System and service manager for Linux"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
+
+LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
+SLOT="0/2"
+IUSE="acl apparmor audit cryptsetup curl doc elfutils +gcrypt gnuefi http
+	idn importd +kmod +lz4 lzma nat pam policykit
+	qrcode +seccomp selinux ssl sysv-utils test vanilla xkb"
+
+REQUIRED_USE="importd? ( curl gcrypt lzma )"
+
+MINKV="3.11"
+
+COMMON_DEPEND=">=sys-apps/util-linux-2.27.1:0=[${MULTILIB_USEDEP}]
+	sys-libs/libcap:0=[${MULTILIB_USEDEP}]
+	!<sys-libs/glibc-2.16
+	acl? ( sys-apps/acl:0= )
+	apparmor? ( sys-libs/libapparmor:0= )
+	audit? ( >=sys-process/audit-2:0= )
+	cryptsetup? ( >=sys-fs/cryptsetup-1.6:0= )
+	curl? ( net-misc/curl:0= )
+	elfutils? ( >=dev-libs/elfutils-0.158:0= )
+	gcrypt? ( >=dev-libs/libgcrypt-1.4.5:0=[${MULTILIB_USEDEP}] )
+	http? (
+		>=net-libs/libmicrohttpd-0.9.33:0=
+		ssl? ( >=net-libs/gnutls-3.1.4:0= )
+	)
+	idn? ( net-dns/libidn:0= )
+	importd? (
+		app-arch/bzip2:0=
+		sys-libs/zlib:0=
+	)
+	kmod? ( >=sys-apps/kmod-15:0= )
+	lz4? ( >=app-arch/lz4-0_p131:0=[${MULTILIB_USEDEP}] )
+	lzma? ( >=app-arch/xz-utils-5.0.5-r1:0=[${MULTILIB_USEDEP}] )
+	nat? ( net-firewall/iptables:0= )
+	pam? ( virtual/pam:= )
+	qrcode? ( media-gfx/qrencode:0= )
+	seccomp? ( sys-libs/libseccomp:0= )
+	selinux? ( sys-libs/libselinux:0= )
+	sysv-utils? (
+		!sys-apps/systemd-sysv-utils
+		!sys-apps/sysvinit )
+	xkb? ( >=x11-libs/libxkbcommon-0.4.1:0= )
+	abi_x86_32? ( !<=app-emulation/emul-linux-x86-baselibs-20130224-r9
+		!app-emulation/emul-linux-x86-baselibs[-abi_x86_32(-)] )"
+
+# baselayout-2.2 has /run
+RDEPEND="${COMMON_DEPEND}
+	>=sys-apps/baselayout-2.2
+	selinux? ( sec-policy/selinux-base-policy[systemd] )
+	!sys-auth/nss-myhostname
+	!<sys-kernel/dracut-044
+	!sys-fs/eudev
+	!sys-fs/udev"
+
+# sys-apps/dbus: the daemon only (+ build-time lib dep for tests)
+PDEPEND=">=sys-apps/dbus-1.8.8:0[systemd]
+	>=sys-apps/hwids-20150417[udev]
+	>=sys-fs/udev-init-scripts-25
+	policykit? ( sys-auth/polkit )
+	!vanilla? ( sys-apps/gentoo-systemd-integration )"
+
+# Newer linux-headers needed by ia64, bug #480218
+DEPEND="${COMMON_DEPEND}
+	app-arch/xz-utils:0
+	dev-util/gperf
+	>=dev-util/intltool-0.50
+	>=sys-apps/coreutils-8.16
+	>=sys-devel/binutils-2.23.1
+	>=sys-devel/gcc-4.6
+	>=sys-kernel/linux-headers-${MINKV}
+	virtual/pkgconfig
+	gnuefi? ( >=sys-boot/gnu-efi-3.0.2 )
+	test? ( >=sys-apps/dbus-1.6.8-r1:0 )
+	app-text/docbook-xml-dtd:4.2
+	app-text/docbook-xml-dtd:4.5
+	app-text/docbook-xsl-stylesheets
+	dev-libs/libxslt:0
+	doc? ( $(python_gen_any_dep 'dev-python/lxml[${PYTHON_USEDEP}]') )
+"
+
+python_check_deps() {
+	has_version --host-root "dev-python/lxml[${PYTHON_USEDEP}]"
+}
+
+pkg_pretend() {
+	local CONFIG_CHECK="~AUTOFS4_FS ~BLK_DEV_BSG ~CGROUPS
+		~DEVTMPFS ~DMIID ~EPOLL ~FANOTIFY ~FHANDLE
+		~INOTIFY_USER ~IPV6 ~NET ~NET_NS ~PROC_FS ~SECCOMP ~SIGNALFD ~SYSFS
+		~TIMERFD ~TMPFS_XATTR ~UNIX
+		~!FW_LOADER_USER_HELPER ~!GRKERNSEC_PROC ~!IDE ~!SYSFS_DEPRECATED
+		~!SYSFS_DEPRECATED_V2"
+
+	use acl && CONFIG_CHECK+=" ~TMPFS_POSIX_ACL"
+	kernel_is -lt 3 7 && CONFIG_CHECK+=" ~HOTPLUG"
+	kernel_is -lt 4 7 && CONFIG_CHECK+=" ~DEVPTS_MULTIPLE_INSTANCES"
+
+	if linux_config_exists; then
+		local uevent_helper_path=$(linux_chkconfig_string UEVENT_HELPER_PATH)
+			if [ -n "${uevent_helper_path}" ] && [ "${uevent_helper_path}" != '""' ]; then
+				ewarn "It's recommended to set an empty value to the following kernel config option:"
+				ewarn "CONFIG_UEVENT_HELPER_PATH=${uevent_helper_path}"
+			fi
+	fi
+
+	if [[ ${MERGE_TYPE} != binary ]]; then
+		if [[ $(gcc-major-version) -lt 4
+			|| ( $(gcc-major-version) -eq 4 && $(gcc-minor-version) -lt 6 ) ]]
+		then
+			eerror "systemd requires at least gcc 4.6 to build. Please switch the active"
+			eerror "gcc version using gcc-config."
+			die "systemd requires at least gcc 4.6"
+		fi
+	fi
+
+	if [[ ${MERGE_TYPE} != buildonly ]]; then
+		if kernel_is -lt ${MINKV//./ }; then
+			ewarn "Kernel version at least ${MINKV} required"
+		fi
+
+		check_extra_config
+	fi
+}
+
+pkg_setup() {
+	:
+}
+
+src_unpack() {
+	default
+	[[ ${PV} != 9999 ]] || git-r3_src_unpack
+}
+
+src_prepare() {
+	# Bug 463376
+	sed -i -e 's/GROUP="dialout"/GROUP="uucp"/' rules/*.rules || die
+
+	local PATCHES=(
+		"${FILESDIR}/218-Dont-enable-audit-by-default.patch"
+		"${FILESDIR}/228-noclean-tmp.patch"
+		# SECCOMP issue fixed in 232, so this patch can be dropped >231
+		"${FILESDIR}/231-001-core-do-not-fail-at-step-SECCOMP-if-there-is-no-kern.patch"
+	)
+	[[ -d "${WORKDIR}"/patches ]] && PATCHES+=( "${WORKDIR}"/patches )
+
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	# Keep using the one where the rules were installed.
+	MY_UDEVDIR=$(get_udevdir)
+	# Fix systems broken by bug #509454.
+	[[ ${MY_UDEVDIR} ]] || MY_UDEVDIR=/lib/udev
+
+	# Prevent conflicts with i686 cross toolchain, bug 559726
+	tc-export AR CC NM OBJCOPY RANLIB
+
+	use doc && python_setup
+
+	multilib-minimal_src_configure
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		# disable -flto since it is an optimization flag
+		# and makes distcc less effective
+		cc_cv_CFLAGS__flto=no
+		# disable -fuse-ld=gold since Gentoo supports explicit linker
+		# choice and forcing gold is undesired, #539998
+		# ld.gold may collide with user's LDFLAGS, #545168
+		# ld.gold breaks sparc, #573874
+		cc_cv_LDFLAGS__Wl__fuse_ld_gold=no
+
+		# Workaround for gcc-4.7, bug 554454.
+		cc_cv_CFLAGS__Werror_shadow=no
+
+		# Workaround for bug 516346
+		--enable-dependency-tracking
+
+		--disable-maintainer-mode
+		--localstatedir=/var
+		--with-pamlibdir=$(getpam_mod_dir)
+		# avoid bash-completion dep
+		--with-bashcompletiondir="$(get_bashcompdir)"
+		# make sure we get /bin:/sbin in $PATH
+		--enable-split-usr
+		# For testing.
+		--with-rootprefix="${ROOTPREFIX-/usr}"
+		--with-rootlibdir="${ROOTPREFIX-/usr}/$(get_libdir)"
+		# disable sysv compatibility
+		--with-sysvinit-path=
+		--with-sysvrcnd-path=
+		# no deps
+		--enable-efi
+		--enable-ima
+
+		# Optional components/dependencies
+		$(multilib_native_use_enable acl)
+		$(multilib_native_use_enable apparmor)
+		$(multilib_native_use_enable audit)
+		$(multilib_native_use_enable cryptsetup libcryptsetup)
+		$(multilib_native_use_enable curl libcurl)
+		$(multilib_native_use_enable elfutils)
+		$(use_enable gcrypt)
+		$(multilib_native_use_enable gnuefi)
+		$(multilib_native_use_enable http microhttpd)
+		$(usex http $(multilib_native_use_enable ssl gnutls) --disable-gnutls)
+		$(multilib_native_use_enable idn libidn)
+		$(multilib_native_use_enable importd)
+		$(multilib_native_use_enable importd bzip2)
+		$(multilib_native_use_enable importd zlib)
+		$(multilib_native_use_enable kmod)
+		$(use_enable lz4)
+		$(use_enable lzma xz)
+		$(multilib_native_use_enable nat libiptc)
+		$(multilib_native_use_enable pam)
+		$(multilib_native_use_enable policykit polkit)
+		$(multilib_native_use_enable qrcode qrencode)
+		$(multilib_native_use_enable seccomp)
+		$(multilib_native_use_enable selinux)
+		$(multilib_native_use_enable test tests)
+		$(multilib_native_use_enable test dbus)
+		$(multilib_native_use_enable xkb xkbcommon)
+		$(multilib_native_use_with doc python)
+
+		# hardcode a few paths to spare some deps
+		KILL=/bin/kill
+		QUOTAON=/usr/sbin/quotaon
+		QUOTACHECK=/usr/sbin/quotacheck
+
+		# TODO: we may need to restrict this to gcc
+		EFI_CC="$(tc-getCC)"
+
+		# dbus paths
+		--with-dbuspolicydir="${EPREFIX}/etc/dbus-1/system.d"
+		--with-dbussessionservicedir="${EPREFIX}/usr/share/dbus-1/services"
+		--with-dbussystemservicedir="${EPREFIX}/usr/share/dbus-1/system-services"
+
+		--with-ntp-servers="0.gentoo.pool.ntp.org 1.gentoo.pool.ntp.org 2.gentoo.pool.ntp.org 3.gentoo.pool.ntp.org"
+
+		# Breaks screen, tmux, etc.
+		--without-kill-user-processes
+	)
+
+	# Work around bug 463846.
+	tc-export CC
+
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_compile() {
+	local mymakeopts=(
+		udevlibexecdir="${MY_UDEVDIR}"
+	)
+
+	if multilib_is_native_abi; then
+		emake "${mymakeopts[@]}"
+	else
+		echo 'gentoo: $(BUILT_SOURCES)' | \
+		emake "${mymakeopts[@]}" -f Makefile -f - gentoo
+		echo 'gentoo: $(lib_LTLIBRARIES) $(pkgconfiglib_DATA)' | \
+		emake "${mymakeopts[@]}" -f Makefile -f - gentoo
+	fi
+}
+
+multilib_src_test() {
+	multilib_is_native_abi || return 0
+	default
+}
+
+multilib_src_install() {
+	local mymakeopts=(
+		# automake fails with parallel libtool relinking
+		# https://bugs.gentoo.org/show_bug.cgi?id=491398
+		-j1
+
+		udevlibexecdir="${MY_UDEVDIR}"
+		dist_udevhwdb_DATA=
+		DESTDIR="${D}"
+	)
+
+	if multilib_is_native_abi; then
+		emake "${mymakeopts[@]}" install
+	else
+		mymakeopts+=(
+			install-libLTLIBRARIES
+			install-pkgconfiglibDATA
+			install-includeHEADERS
+			# safe to call unconditionally, 'installs' empty list
+			install-pkgincludeHEADERS
+		)
+
+		emake "${mymakeopts[@]}"
+	fi
+}
+
+multilib_src_install_all() {
+	prune_libtool_files --modules
+	einstalldocs
+
+	if [[ ${PV} != 9999 ]]; then
+		use doc || doman "${WORKDIR}"/man/systemd.{directives,index}.7
+	fi
+
+	if use sysv-utils; then
+		for app in halt poweroff reboot runlevel shutdown telinit; do
+			dosym "..${ROOTPREFIX-/usr}/bin/systemctl" /sbin/${app}
+		done
+		dosym "..${ROOTPREFIX-/usr}/lib/systemd/systemd" /sbin/init
+	else
+		# we just keep sysvinit tools, so no need for the mans
+		rm "${D}"/usr/share/man/man8/{halt,poweroff,reboot,runlevel,shutdown,telinit}.8 \
+			|| die
+		rm "${D}"/usr/share/man/man1/init.1 || die
+	fi
+
+	# Preserve empty dirs in /etc & /var, bug #437008
+	keepdir /etc/binfmt.d /etc/modules-load.d /etc/tmpfiles.d \
+		/etc/systemd/ntp-units.d /etc/systemd/user /var/lib/systemd \
+		/var/log/journal/remote
+
+	# Symlink /etc/sysctl.conf for easy migration.
+	dosym ../sysctl.conf /etc/sysctl.d/99-sysctl.conf
+
+	# If we install these symlinks, there is no way for the sysadmin to remove them
+	# permanently.
+	rm "${D}"/etc/systemd/system/multi-user.target.wants/systemd-networkd.service || die
+	rm -f "${D}"/etc/systemd/system/multi-user.target.wants/systemd-resolved.service || die
+	rm -r "${D}"/etc/systemd/system/network-online.target.wants || die
+	rm -r "${D}"/etc/systemd/system/sockets.target.wants || die
+	rm -r "${D}"/etc/systemd/system/sysinit.target.wants || die
+}
+
+migrate_locale() {
+	local envd_locale_def="${EROOT%/}/etc/env.d/02locale"
+	local envd_locale=( "${EROOT%/}"/etc/env.d/??locale )
+	local locale_conf="${EROOT%/}/etc/locale.conf"
+
+	if [[ ! -L ${locale_conf} && ! -e ${locale_conf} ]]; then
+		# If locale.conf does not exist...
+		if [[ -e ${envd_locale} ]]; then
+			# ...either copy env.d/??locale if there's one
+			ebegin "Moving ${envd_locale} to ${locale_conf}"
+			mv "${envd_locale}" "${locale_conf}"
+			eend ${?} || FAIL=1
+		else
+			# ...or create a dummy default
+			ebegin "Creating ${locale_conf}"
+			cat > "${locale_conf}" <<-EOF
+				# This file has been created by the sys-apps/systemd ebuild.
+				# See locale.conf(5) and localectl(1).
+
+				# LANG=${LANG}
+			EOF
+			eend ${?} || FAIL=1
+		fi
+	fi
+
+	if [[ ! -L ${envd_locale} ]]; then
+		# now, if env.d/??locale is not a symlink (to locale.conf)...
+		if [[ -e ${envd_locale} ]]; then
+			# ...warn the user that he has duplicate locale settings
+			ewarn
+			ewarn "To ensure consistent behavior, you should replace ${envd_locale}"
+			ewarn "with a symlink to ${locale_conf}. Please migrate your settings"
+			ewarn "and create the symlink with the following command:"
+			ewarn "ln -s -n -f ../locale.conf ${envd_locale}"
+			ewarn
+		else
+			# ...or just create the symlink if there's nothing here
+			ebegin "Creating ${envd_locale_def} -> ../locale.conf symlink"
+			ln -n -s ../locale.conf "${envd_locale_def}"
+			eend ${?} || FAIL=1
+		fi
+	fi
+}
+
+pkg_postinst() {
+	newusergroup() {
+		enewgroup "$1"
+		enewuser "$1" -1 -1 -1 "$1"
+	}
+
+	enewgroup input
+	enewgroup systemd-journal
+	newusergroup systemd-bus-proxy
+	newusergroup systemd-coredump
+	newusergroup systemd-journal-gateway
+	newusergroup systemd-journal-remote
+	newusergroup systemd-journal-upload
+	newusergroup systemd-network
+	newusergroup systemd-resolve
+	newusergroup systemd-timesync
+
+	systemd_update_catalog
+
+	# Keep this here in case the database format changes so it gets updated
+	# when required. Despite that this file is owned by sys-apps/hwids.
+	if has_version "sys-apps/hwids[udev]"; then
+		udevadm hwdb --update --root="${ROOT%/}"
+	fi
+
+	udev_reload || FAIL=1
+
+	# Bug 465468, make sure locales are respect, and ensure consistency
+	# between OpenRC & systemd
+	migrate_locale
+
+	if [[ ${FAIL} ]]; then
+		eerror "One of the postinst commands failed. Please check the postinst output"
+		eerror "for errors. You may need to clean up your system and/or try installing"
+		eerror "systemd again."
+		eerror
+	fi
+
+	#if [[ $(readlink "${ROOT}"etc/resolv.conf) == */run/systemd/* ]]; then
+	#	ewarn "You should replace the resolv.conf symlink:"
+	#	ewarn "ln -snf ${ROOTPREFIX-/usr}/lib/systemd/resolv.conf ${ROOT}etc/resolv.conf"
+	#fi
+}
+
+pkg_prerm() {
+	# If removing systemd completely, remove the catalog database.
+	if [[ ! ${REPLACED_BY_VERSION} ]]; then
+		rm -f -v "${EROOT}"/var/lib/systemd/catalog/database
+	fi
+}


### PR DESCRIPTION
When running `sys-apps/systemd[seccomp]` on a Kernel without
`CONFIG_SECCOMP` enabled (e.g. when running a Gentoo container for
bootstrapping purposes on another OS buildhost), starting services with
defined SECCOMP filters will fail (`status=228/SECCOMP`) due to missing
runtime checks for SECCOMP availability.

Upstream fixed this in 83f12b27 which will be included in systemd-232.
See also:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=832893
- https://github.com/systemd/systemd/issues/3882
- https://github.com/systemd/systemd/pull/4004

Package-Manager: portage-2.2.28