### PR TITLE
[WIP] llvm-libunwind, live ebuild

### DIFF
--- a/sys-libs/llvm-libunwind/llvm-libunwind-9999.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-9999.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+: ${CMAKE_MAKEFILE_GENERATOR:=ninja}
+CMAKE_MIN_VERSION=3.4.3
+inherit cmake-utils git-r3
+
+DESCRIPTION="C++ runtime stack unwinder from LLVM"
+HOMEPAGE="https://github.com/llvm-mirror/libunwind"
+SRC_URI=""
+EGIT_REPO_URI="http://llvm.org/git/libunwind.git
+	https://github.com/llvm-mirror/libunwind.git"
+
+LICENSE="|| ( UoI-NCSA MIT )"
+SLOT="0"
+KEYWORDS=""
+IUSE="debug +static-libs"
+
+RDEPEND="!sys-libs/libunwind"
+# llvm-config and cmake files needed to get proper flags
+DEPEND="sys-devel/llvm"
+
+src_configure() {
+	local libdir=$(get_libdir)
+
+	local mycmakeargs=(
+		-DLLVM_LIBDIR_SUFFIX=${libdir#lib}
+		-DLIBUNWIND_ENABLE_ASSERTIONS=$(usex debug)
+		-DLIBUNWIND_ENABLE_STATIC=$(usex static-libs)
+	)
+
+	cmake-utils_src_configure
+}

--- a/sys-libs/llvm-libunwind/metadata.xml
+++ b/sys-libs/llvm-libunwind/metadata.xml
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>zhanglei.april@gmail.com</email>
-		<name>Lei Zhang</name>
-	</maintainer>
-	<maintainer type="person">
-		<email>blueness@gentoo.org</email>
-		<name>Anthony G. Basile</name>
-	</maintainer>
-	<maintainer type="person">
-		<email>mgorny@gentoo.org</email>
-		<name>Michał Górny</name>
+	<maintainer type="project">
+		<email>llvm@gentoo.org</email>
 	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
@zzlei, @blueness -- here's a little bit of un-hackery on my end. I've removed the likely-non-upstreamable patch at the cost of llvm dependency (it's unlikely this will be used without LLVM being installed anyway), and added USE=debug.

What needs to be done: someone needs to fix this damn thing upstream to install headers. Installing libraries without headers is just wrong.