### PR TITLE
net-p2p/i2p: fix enewuser unsupported use

### DIFF
--- a/net-p2p/i2p/i2p-0.9.25-r1.ebuild
+++ b/net-p2p/i2p/i2p-0.9.25-r1.ebuild
@@ -58,7 +58,7 @@ pkg_setup() {
 	java-pkg-2_pkg_setup
 
 	enewgroup i2p
-	enewuser i2p -1 -1 "${I2P_CONFIG_HOME}" i2p -m
+	enewuser i2p -1 -1 "${I2P_CONFIG_HOME}" i2p
 }
 
 src_unpack() {

--- a/net-p2p/i2p/i2p-0.9.26.ebuild
+++ b/net-p2p/i2p/i2p-0.9.26.ebuild
@@ -64,7 +64,7 @@ pkg_setup() {
 	java-pkg-2_pkg_setup
 
 	enewgroup i2p
-	enewuser i2p -1 -1 "${I2P_CONFIG_HOME}" i2p -m
+	enewuser i2p -1 -1 "${I2P_CONFIG_HOME}" i2p
 }
 
 src_unpack() {


### PR DESCRIPTION
Simply remove the `-m` flag to the `enewuser` call, it was legacy anyway and it is not required (already handled by the keep file in the i2p home).

Fix [gbugs#592628](https://bugs.gentoo.org/show_bug.cgi?id=592628).

btw, is it necessary to do a revbump here? If it was before the `user.eclass` changes, it also works, and it is a minor fix.

Patch is by @gsora.
