### PR TITLE
kde-apps/kwalletmanager: Fix empty/placeholder icons

### DIFF
--- a/kde-apps/kwalletmanager/files/kwalletmanager-16.04.3-icons.patch
+++ b/kde-apps/kwalletmanager/files/kwalletmanager-16.04.3-icons.patch
@@ -1,0 +1,30 @@
+From: Martin T. H. Sandsmark <martin.sandsmark@kde.org>
+Date: Sat, 27 Aug 2016 13:23:52 +0000
+Subject: Fix icon installation path
+X-Git-Url: http://quickgit.kde.org/?p=kwalletmanager.git&a=commitdiff&h=7bb9e92f26074ec892df4fe0a790567097221a9f
+---
+Fix icon installation path
+---
+
+merged with
+
+From: Martin T. H. Sandsmark <martin.sandsmark@kde.org>
+Date: Sat, 27 Aug 2016 13:32:04 +0000
+Subject: Fix icon names
+X-Git-Url: http://quickgit.kde.org/?p=kwalletmanager.git&a=commitdiff&h=5d35eb2c3b82979994b75c116d8c57ac8c8e398a
+---
+Fix icon names
+---
+
+
+--- a/icons/CMakeLists.txt
++++ b/icons/CMakeLists.txt
+@@ -1,2 +1,6 @@
+-ecm_install_icons( ICONS 22-actions-folder_closed.png  22-actions-folder_open.png DESTINATION ${DATA_INSTALL_DIR}/kwalletmanager5/icons   )
++ecm_install_icons(
++    ICONS 22-actions-wallet-closed.png 22-actions-wallet-open.png
++    DESTINATION ${ICON_INSTALL_DIR}
++    THEME hicolor
++)
+ 
+

--- a/kde-apps/kwalletmanager/kwalletmanager-16.04.3-r1.ebuild
+++ b/kde-apps/kwalletmanager/kwalletmanager-16.04.3-r1.ebuild
@@ -11,7 +11,7 @@ inherit kde5
 DESCRIPTION="KDE Wallet management tool"
 HOMEAGE="https://www.kde.org/applications/system/kwalletmanager
 https://utils.kde.org/projects/kwalletmanager"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="
@@ -42,3 +42,11 @@ RDEPEND="${DEPEND}
 	!<kde-apps/kwalletmanager-15.04.3-r1:4
 	!kde-base/legacy-icons
 "
+
+PATCHES=( "${FILESDIR}/${P}-icons.patch" )
+
+src_prepare() {
+	mv icons/22-actions-folder_open.png icons/22-actions-wallet-open.png || die
+	mv icons/22-actions-folder_closed.png icons/22-actions-wallet-closed.png || die
+	kde5_src_prepare
+}


### PR DESCRIPTION
systray appears broken since KF-5.25, icons inside application even longer, same fix would need to go to 16.08

@gentoo/kde 

EDIT: Fixed upstream in >=16.08.1