### PR TITLE
net-firewall/conntrack-tools: Always allow lazy binding

### DIFF
--- a/net-firewall/conntrack-tools/conntrack-tools-1.4.4.ebuild
+++ b/net-firewall/conntrack-tools/conntrack-tools-1.4.4.ebuild
@@ -3,7 +3,7 @@
 # $Id$
 
 EAPI=6
-inherit autotools eutils linux-info
+inherit autotools eutils flag-o-matic linux-info
 
 DESCRIPTION="Connection tracking userspace tools"
 HOMEPAGE="http://conntrack-tools.netfilter.org"
@@ -65,6 +65,11 @@ src_prepare() {
 	sed -i -e 's:/var/lock:/run/lock:' doc/stats/conntrackd.conf || die
 
 	eautoreconf
+}
+
+src_configure() {
+	append-ldflags -Wl,-z,lazy
+	econf
 }
 
 src_compile() {


### PR DESCRIPTION
The nfct utility calls dlopen() with RTLD_LAZY on conntrack helper
.so files in order to read the ctd_helper data structures.  nfct does
not contain all of the symbols required by these libraries, so linking
with `-z now` will cause dlopen() to fail and it will break the program.

Force this package to be linked with `-z lazy`.

Some discussion at:
https://groups.google.com/a/chromium.org/forum/#!topic/chromium-os-dev/TQ5TqoWegVs
