### PR TITLE
media-libs/opencollada: Stabilization of v1.6.25

### DIFF
--- a/media-libs/opencollada/opencollada-1.6.25.ebuild
+++ b/media-libs/opencollada/opencollada-1.6.25.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/KhronosGroup/OpenCOLLADA/archive/v${PV}.tar.gz -> ${
 LICENSE="MIT"
 SLOT="0"
 
-KEYWORDS="~amd64 ~ppc64 ~x86"
+KEYWORDS="amd64 ~ppc64 x86"
 
 IUSE="expat static-libs"
 


### PR DESCRIPTION
This is a so-name update from 1.2 to 1.6, so packages depending on this will need to be recompiled. ppc64 still needs review.

@gentoo/proxy-maint