### PR TITLE
app-text/aspell: fix building with Unicode support

### DIFF
--- a/app-text/aspell/aspell-0.60.6.1-r4.ebuild
+++ b/app-text/aspell/aspell-0.60.6.1-r4.ebuild
@@ -1,0 +1,96 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit autotools eutils flag-o-matic libtool toolchain-funcs
+
+DESCRIPTION="A spell checker replacement for ispell"
+HOMEPAGE="http://aspell.net/"
+SRC_URI="mirror://gnu/aspell/${P}.tar.gz"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+IUSE="nls unicode"
+
+PDEPEND="app-dicts/aspell-en"
+LANGS="af be bg br ca cs cy da de de-1901 el en eo es et fi fo fr ga gl he hr
+hu hy is it la lt nl no pl pt pt-BR ro ru sk sl sr sv uk vi"
+for lang in ${LANGS}; do
+	IUSE+=" l10n_${lang}"
+	# Need to keep linguas_* for now, since aspell uses gettext
+	IUSE+=" linguas_${lang/-/_}"
+	case ${lang} in
+		de-1901) dict="de-alt"  ;;
+		pt-BR)   dict="pt-br"   ;;
+		*)       dict="${lang}" ;;
+	esac
+	PDEPEND+=" l10n_${lang}? ( app-dicts/aspell-${dict} )"
+done
+unset dict lang LANGS
+
+COMMON_DEPEND="
+	>=sys-libs/ncurses-5.2:0=[unicode?]
+	nls? ( virtual/libintl )
+"
+DEPEND="${COMMON_DEPEND}
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+
+# English dictionary 0.5 is incompatible with aspell-0.6
+RDEPEND="${COMMON_DEPEND}
+	!=app-dicts/aspell-en-0.5*
+"
+
+src_prepare() {
+	# fix for bug #467602
+	if has_version ">=sys-devel/automake-1.13" ; then
+		sed -i -e 's/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g' \
+			"${S}"/configure.ac || die
+	fi
+
+	epatch \
+		"${FILESDIR}/${PN}-0.60.5-nls.patch" \
+		"${FILESDIR}/${PN}-0.60.5-solaris.patch" \
+		"${FILESDIR}/${PN}-0.60.6-darwin-bundles.patch" \
+		"${FILESDIR}/${PN}-0.60.6.1-clang.patch" \
+		"${FILESDIR}/${PN}-0.60.6.1-unicode.patch"
+
+	rm m4/lt* m4/libtool.m4
+	eautoreconf
+	elibtoolize --reverse-deps
+
+	# Parallel install of libtool libraries doesn't always work.
+	# https://lists.gnu.org/archive/html/libtool/2011-03/msg00003.html
+	# This has to be after automake has run so that we don't clobber
+	# the default target that automake creates for us.
+	echo 'install-filterLTLIBRARIES: install-libLTLIBRARIES' >> Makefile.in || die
+
+}
+
+src_configure() {
+	econf \
+		$(use_enable nls) \
+		$(use_enable unicode) \
+		--disable-static \
+		--sysconfdir="${EPREFIX}"/etc/aspell \
+		--enable-docdir="${EPREFIX}"/usr/share/doc/${PF}
+}
+
+src_install() {
+	default
+
+	dodoc README* TODO
+	dohtml -r manual/aspell{,-dev}.html
+	docinto examples
+	dodoc "${S}"/examples/*.c
+
+	# install ispell/aspell compatibility scripts
+	newbin scripts/ispell ispell-aspell
+	newbin scripts/spell spell-aspell
+
+	prune_libtool_files --modules
+}

--- a/app-text/aspell/files/aspell-0.60.6.1-unicode.patch
+++ b/app-text/aspell/files/aspell-0.60.6.1-unicode.patch
@@ -1,0 +1,195 @@
+--- Makefile.am
++++ Makefile.am
+@@ -121,7 +121,7 @@ EXTRA_DIST += common/*.hpp common/*.h\
+ # Aspell Program
+ #
+ 
+-AM_CPPFLAGS += -DLOCALEDIR="$(localedir)"
++AM_CPPFLAGS += -DLOCALEDIR="$(localedir)" $(NCURSES_CFLAGS)
+ 
+ bin_PROGRAMS = word-list-compress aspell prezip-bin
+ 
+@@ -129,7 +129,7 @@ word_list_compress_SOURCES = prog/compress.c
+ 
+ aspell_SOURCES = prog/aspell.cpp prog/check_funs.cpp prog/checker_string.cpp
+ 
+-aspell_LDADD = libaspell.la $(CURSES_LIB) $(LTLIBINTL)
++aspell_LDADD = libaspell.la $(NCURSES_LIBS) $(LTLIBINTL)
+ 
+ prezip_bin_SOURCES = prog/prezip.c
+ 
+--- configure.ac
++++ configure.ac
+@@ -52,14 +52,11 @@ dnl optional features
+ AC_ARG_ENABLE(win32-relocatable,
+   [  --enable-win32-relocatable])
+ 
+-AC_ARG_ENABLE(curses,           
+-  AS_HELP_STRING([--enable-curses=LIBFILE],[cursor control library]))
++AC_ARG_ENABLE([curses],
++  AS_HELP_STRING([--enable-curses],[cursor control library]))
+ 
+-AC_ARG_ENABLE(curses-include,           
+-  [  --enable-curses-include=DIR])
+-
+-AC_ARG_ENABLE(wide-curses,
+-  AS_HELP_STRING([--disable-wide-curses],[disable wide char utf8 cursor control]))
++AC_ARG_ENABLE([unicode],
++  AS_HELP_STRING([--enable-unicode],[enable Unicode support]))
+ 
+ AC_ARG_ENABLE(regex,
+   [  --disable-regex])
+@@ -312,133 +309,23 @@ AC_TRY_LINK(
+   [AC_MSG_RESULT(no)]
+ )
+ 
+-AC_SUBST(CURSES_LIB)
+-AC_SUBST(CURSES_INCLUDE)
+-
+ if test "$enable_curses" != "no"
+ then
+-  use_curses=t
+-  case "$enable_curses" in
+-    yes | ""                     )                             ;;
+-    /* | *lib* | *.a | -l* | -L* ) CURSES_LIB="$enable_curses" ;;
+-    *                            ) CURSES_LIB=-l$enable_curses ;;
+-  esac
+-  case "$enable_curses_include" in
+-    yes | no | "")                                         ;;
+-    -I*          ) CURSES_INCLUDE="$enable_curses_include" ;;
+-    *            ) CURSES_INCLUDE=-I$enable_curses_include ;;
+-  esac
+-fi
+-
+-if test "$use_curses"
+-then
+-
+-  ORIG_LIBS="$LIBS"
+-  ORIG_CPPFLAGS="$CPPFLAGS"
+-  CPPFLAGS="$CURSES_INCLUDE $ORIG_CPPFLAGS"
+-
+-  if test -z "$CURSES_LIB"
+-  then
+-
+-    AC_MSG_CHECKING(for working curses library)
+-
+-    if test "$enable_wide_curses" != "no" -a -n "$have_mblen"
+-    then
+-      LIBS="-lncursesw $ORIG_LIBS"
+-      AC_TRY_LINK(
+-        [#include <ncursesw/curses.h>], [initscr()],
+-        [CURSES_LIB=-lncursesw
+-         AC_DEFINE(CURSES_HEADER, <ncursesw/curses.h>, [Defined to curses header file])
+-         AC_DEFINE(TERM_HEADER, <ncursesw/term.h>, [Defined to term header file])])
+-    fi
+-
+-    if test -z "$CURSES_LIB"
+-    then
+-      LIBS="-lncurses $ORIG_LIBS"
+-      AC_TRY_LINK(
+-        [#include <ncurses/curses.h>], [initscr()],
+-        [CURSES_LIB=-lncurses
+-         AC_DEFINE(CURSES_HEADER, <ncurses/curses.h>, [Defined to curses header file])
+-         AC_DEFINE(TERM_HEADER, <ncurses/term.h>, [Defined to term header file])],
+-        [
+-      LIBS="-lncurses $ORIG_LIBS"
+-      AC_TRY_LINK(
+-        [#include <ncurses.h>], [initscr()],
+-        [CURSES_LIB=-lncurses
+-         AC_DEFINE(CURSES_HEADER, <ncurses.h>, [Defined to curses header file])
+-         AC_DEFINE(TERM_HEADER, <term.h>, [Defined to term header file])],
+-        [
+-      LIBS="-lcurses $ORIG_LIBS"
+-      AC_TRY_LINK(
+-        [#include <curses.h>], [initscr()],
+-        [CURSES_LIB=-lcurses
+-         AC_DEFINE(CURSES_HEADER, <curses.h>, [Defined to curses header file])
+-         AC_DEFINE(TERM_HEADER, <term.h>, [Defined to term header file])],
+-        [
+-      LIBS="-lncurses $ORIG_LIBS"
+-      AC_TRY_LINK(
+-        [#include <curses.h>], [initscr()],
+-        [CURSES_LIB=-lncurses
+-         AC_DEFINE(CURSES_HEADER, <curses.h>, [Defined to curses header file])
+-         AC_DEFINE(TERM_HEADER, <term.h>, [Defined to term header file])],
+-      ) ]) ]) ])
+-    fi
+-
+-    if test -n "$CURSES_LIB"
+-    then
+-      AC_MSG_RESULT([found in $CURSES_LIB])
+-    else
+-      AC_MSG_RESULT([not found])
+-    fi
+ 
+-  else
++    AS_IF([test "$enable_unicode" != "no"],
++          [AC_DEFINE([HAVE_WIDE_CURSES], [1], [Defined if curses library includes wide character support])
++           ncurses_library="ncursesw"],
++          [ncurses_library="ncurses"])
+ 
+-    AC_DEFINE(CURSES_HEADER, <curses.h>, [Defined to curses header file])
+-    AC_DEFINE(TERM_HEADER, <term.h>, [Defined to term header file])
++    PKG_CHECK_MODULES([NCURSES], ["$ncurses_library"])
+ 
+-  fi
++    AC_DEFINE([CURSES_HEADER], [<curses.h>], [Defined to curses header file])
++    AC_DEFINE([TERM_HEADER], [<term.h>], [Defined to term header file])
+ 
+-  if test -n "$CURSES_LIB"
+-  then
+-     LIBS="$CURSES_LIB $ORIG_LIBS"
+-
+-     if test "$enable_wide_curses" != "no"
+-     then
+-
+-       AC_MSG_CHECKING(for wide character support in curses libraray)
+-       if test -n "$have_mblen"
+-       then
+-         AC_TRY_LINK(
+-           [#include <wchar.h>
+-            #include CURSES_HEADER
+-           ],
+-           [wchar_t wch = 0;
+-            addnwstr(&wch, 1);],
+-           [AC_MSG_RESULT(yes)
+-            AC_DEFINE(HAVE_WIDE_CURSES, 1, [Defined if curses libraray includes wide character support])],
+-           [
+-
+-         AC_TRY_LINK(
+-           [#define _XOPEN_SOURCE_EXTENDED 1
+-            #include <wchar.h>
+-            #include CURSES_HEADER
+-           ],
+-           [wchar_t wch = 0;
+-            addnwstr(&wch, 1);],
+-           [AC_MSG_RESULT(yes)
+-            AC_DEFINE(HAVE_WIDE_CURSES, 1)
+-            AC_DEFINE(DEFINE_XOPEN_SOURCE_EXTENDED, 1, 
+-                      [Defined if _XOPEN_SOURCE_EXTENDED needs to be defined. 
+-                       (Can't define globally as that will cause problems with some systems)])
+-           ],
+-           [AC_MSG_RESULT(no)
+-            AC_MSG_WARN([Aspell will not be able to Display UTF-8 characters correctly.])])])
+-       else
+-         AC_MSG_RESULT([no, because "mblen" is not supported])
+-         AC_MSG_WARN([Aspell will not be able to Display UTF-8 characters correctly.])
+-       fi
+-
+-     fi
++    ORIG_CPPFLAGS="$CPPFLAGS"
++    ORIG_LIBS="$LIBS"
++    CPPFLAGS="$NCURSES_CFLAGS $ORIG_CPPFLAGS"
++    LIBS="$NCURSES_LIBS $ORIG_LIBS"
+  
+      AC_MSG_CHECKING(if standard curses include sequence will work)
+      AC_TRY_LINK(
+@@ -497,8 +384,6 @@ then
+ 
+      ]) ]) ])
+ 
+-  fi
+-
+   CPPFLAGS="$ORIG_CPPFLAGS"
+   LIBS="$ORIG_LIBS"
+ 


### PR DESCRIPTION
The current way of building *aspell* with Unicode support is only seemingly correct as the build finishes, but it is impossible to e.g. replace a highlighted word with one containing non-ASCII characters when using `aspell -c` with UTF-8 documents.

The problem is that `configure.ac` is designed to always set `CURSES_HEADER` to `<curses.h>` whenever `CURSES_LIB` is non-empty. This in turn causes wide character support detection to fail when `CURSES_LIB` is set to `-lncursesw` by current ebuilds:

```
configure:18664: checking for wide character support in curses libraray
configure:18682: x86_64-pc-linux-gnu-g++ -o conftest -O2 -pipe -fno-exceptions   -Wl,-O1 -Wl,--as-needed conftest.cpp -lncursesw  -ldl -ldl  >&5
conftest.cpp: In function 'int main()':
conftest.cpp:48:29: error: 'addnwstr' was not declared in this scope
             addnwstr(&wch, 1);
                             ^
configure:18682: $? = 1
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "GNU Aspell"
| #define PACKAGE_TARNAME "aspell"
| #define PACKAGE_VERSION "0.60.6.1"
| #define PACKAGE_STRING "GNU Aspell 0.60.6.1"
| #define PACKAGE_BUGREPORT ""
| #define PACKAGE_URL "http://www.gnu.org/software/aspell/"
| #define PACKAGE "aspell"
| #define VERSION "0.60.6.1"
| #define STDC_HEADERS 1
| #define HAVE_SYS_TYPES_H 1
| #define HAVE_SYS_STAT_H 1
| #define HAVE_STDLIB_H 1
| #define HAVE_STRING_H 1
| #define HAVE_MEMORY_H 1
| #define HAVE_STRINGS_H 1
| #define HAVE_INTTYPES_H 1
| #define HAVE_STDINT_H 1
| #define HAVE_UNISTD_H 1
| #define HAVE_DLFCN_H 1
| #define LT_OBJDIR ".libs/"
| #define HAVE_DLFCN_H 1
| #define HAVE_LIBDL 1
| #define FILTER_VERSION_CONTROL 1
| #define ENABLE_NLS 1
| #define HAVE_GETTEXT 1
| #define HAVE_DCGETTEXT 1
| #define HAVE_DLFCN_H 1
| #define HAVE_LIBDL 1
| #define USE_FILE_LOCKS 1
| #define HAVE_MMAP 1
| #define USE_FILE_INO 1
| #define USE_LOCALE 1
| #define USE_POSIX_REGEX 1
| #define HAVE_LANGINFO_CODESET 1
| #define USE_POSIX_MUTEX 1
| #define HAVE_MBLEN 1
| #define CURSES_HEADER <curses.h>
| #define TERM_HEADER <term.h>
| /* end confdefs.h.  */
| #include <wchar.h>
|             #include CURSES_HEADER
|
| int
| main ()
| {
| wchar_t wch = 0;
|             addnwstr(&wch, 1);
|   ;
|   return 0;
| }
```

So even when there is a Unicode-capable *ncurses* available, the compiler is looking for `curses.h` in `/usr/include` instead of `/usr/include/ncursesw` and wide character support is effectively disabled.

While it is possible to pass `--enable-curses-include=DIR` to `configure`, this only seems to fix `configure`-time detection of wide character support as the directory supplied using this option is not passed to the compiler while building actual *aspell* binaries and the build breaks on `prog/check_funs.cpp`. Looking back at `configure.ac`, there is a macro called `CURSES_INCLUDE` which is used during wide character support detection, but for some reason is not used anywhere inside `Makefile.am` (while `CURSES_LIB` is).

To overcome the obstacles described above, this pull request fixes `Makefile.am` and also handles `CURSES_INCLUDE` in the ebuilds similarly to `CURSES_LIB`. Applying these changes causes *aspell* to be properly built for all possible combinations of *ncurses*' `unicode` and `tinfo` USE flags. However, as in all situations with several problems happening simultaneously, please be advised that this might not be the best way to fix them all, especially given that I am no Autotools expert.
