### PR TITLE
media-libs/fontconfig: Adding $(get_exeext) to MULTILIB_CHOST_TOOLS

### DIFF
--- a/media-libs/fontconfig/fontconfig-2.11.1-r2.ebuild
+++ b/media-libs/fontconfig/fontconfig-2.11.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -38,7 +38,7 @@ PATCHES=(
 )
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/fc-cache
+	/usr/bin/fc-cache$(get_exeext)
 )
 
 pkg_setup() {

--- a/media-libs/fontconfig/fontconfig-2.12.0.ebuild
+++ b/media-libs/fontconfig/fontconfig-2.12.0.ebuild
@@ -32,7 +32,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.11.93-latin-update.patch # 130466 + make liberation default
 )
 
-MULTILIB_CHOST_TOOLS=( /usr/bin/fc-cache )
+MULTILIB_CHOST_TOOLS=( /usr/bin/fc-cache$(get_exeext) )
 
 pkg_setup() {
 	DOC_CONTENTS="Please make fontconfig configuration changes using

--- a/media-libs/fontconfig/fontconfig-2.12.1.ebuild
+++ b/media-libs/fontconfig/fontconfig-2.12.1.ebuild
@@ -32,7 +32,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.11.93-latin-update.patch # 130466 + make liberation default
 )
 
-MULTILIB_CHOST_TOOLS=( /usr/bin/fc-cache )
+MULTILIB_CHOST_TOOLS=( /usr/bin/fc-cache$(get_exeext) )
 
 pkg_setup() {
 	DOC_CONTENTS="Please make fontconfig configuration changes using


### PR DESCRIPTION
Gentoo-bug: https://bugs.gentoo.org/show_bug.cgi?id=588330

Package-Manager: portage-2.2.28

Tested with i686-w64-mingw32 and x86_64-pc-linux-gnu