### PR TITLE
x11-libs/gdk-pixbuf: Adding $(get_exeext) to MULTILIB_CHOST_TOOLS

### DIFF
--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.32.1.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.32.1.ebuild
@@ -43,7 +43,7 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gdk-pixbuf-query-loaders
+	/usr/bin/gdk-pixbuf-query-loaders$(get_exeext)
 )
 
 src_prepare() {

--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.32.3.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.32.3.ebuild
@@ -39,7 +39,7 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gdk-pixbuf-query-loaders
+	/usr/bin/gdk-pixbuf-query-loaders$(get_exeext)
 )
 
 src_prepare() {

--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.34.0.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.34.0.ebuild
@@ -38,7 +38,7 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gdk-pixbuf-query-loaders
+	/usr/bin/gdk-pixbuf-query-loaders$(get_exeext)
 )
 
 src_prepare() {


### PR DESCRIPTION
Gentoo-bug: https://bugs.gentoo.org/show_bug.cgi?id=588330

Package-Manager: portage-2.2.28

Tested with x86_64-pc-linux-gnu