### PR TITLE
x11-libs/gtk+: dev-libs/glib: Adding $(get_exeext) to MULTILIB_CHOST_…

### DIFF
--- a/x11-libs/gtk+/gtk+-3.18.9.ebuild
+++ b/x11-libs/gtk+/gtk+-3.18.9.ebuild
@@ -96,7 +96,7 @@ PDEPEND="
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gtk-query-immodules-3.0
+	/usr/bin/gtk-query-immodules-3.0$(get_exeext)
 )
 
 strip_builddir() {

--- a/x11-libs/gtk+/gtk+-3.20.9.ebuild
+++ b/x11-libs/gtk+/gtk+-3.20.9.ebuild
@@ -101,7 +101,7 @@ PDEPEND="
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gtk-query-immodules-3.0
+	/usr/bin/gtk-query-immodules-3.0$(get_exeext)
 )
 
 strip_builddir() {


### PR DESCRIPTION
…TOOLS

Gentoo-bug: https://bugs.gentoo.org/show_bug.cgi?id=588330

Package-Manager: portage-2.2.28

Tested with i686-w64-mingw32 and x86_64-pc-linux-gnu