### PR TITLE
Adding get_exeext

### DIFF
--- a/dev-libs/glib/glib-2.46.2-r3.ebuild
+++ b/dev-libs/glib/glib-2.46.2-r3.ebuild
@@ -73,7 +73,7 @@ PDEPEND="!<gnome-base/gvfs-1.6.4-r990
 # Earlier versions of gvfs do not work with glib
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gio-querymodules
+	/usr/bin/gio-querymodules$(get_exeext)
 )
 
 pkg_setup() {

--- a/dev-libs/glib/glib-2.48.1-r1.ebuild
+++ b/dev-libs/glib/glib-2.48.1-r1.ebuild
@@ -68,7 +68,7 @@ PDEPEND="!<gnome-base/gvfs-1.6.4-r990
 # Earlier versions of gvfs do not work with glib
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gio-querymodules
+	/usr/bin/gio-querymodules$(get_exeext)
 )
 
 pkg_setup() {

--- a/media-libs/fontconfig/fontconfig-2.11.1-r2.ebuild
+++ b/media-libs/fontconfig/fontconfig-2.11.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -38,7 +38,7 @@ PATCHES=(
 )
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/fc-cache
+	/usr/bin/fc-cache$(get_exeext)
 )
 
 pkg_setup() {

--- a/media-libs/fontconfig/fontconfig-2.12.0.ebuild
+++ b/media-libs/fontconfig/fontconfig-2.12.0.ebuild
@@ -32,7 +32,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.11.93-latin-update.patch # 130466 + make liberation default
 )
 
-MULTILIB_CHOST_TOOLS=( /usr/bin/fc-cache )
+MULTILIB_CHOST_TOOLS=( /usr/bin/fc-cache$(get_exeext) )
 
 pkg_setup() {
 	DOC_CONTENTS="Please make fontconfig configuration changes using

--- a/media-libs/fontconfig/fontconfig-2.12.1.ebuild
+++ b/media-libs/fontconfig/fontconfig-2.12.1.ebuild
@@ -32,7 +32,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.11.93-latin-update.patch # 130466 + make liberation default
 )
 
-MULTILIB_CHOST_TOOLS=( /usr/bin/fc-cache )
+MULTILIB_CHOST_TOOLS=( /usr/bin/fc-cache$(get_exeext) )
 
 pkg_setup() {
 	DOC_CONTENTS="Please make fontconfig configuration changes using

--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.32.1.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.32.1.ebuild
@@ -43,7 +43,7 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gdk-pixbuf-query-loaders
+	/usr/bin/gdk-pixbuf-query-loaders$(get_exeext)
 )
 
 src_prepare() {

--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.32.3.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.32.3.ebuild
@@ -39,7 +39,7 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gdk-pixbuf-query-loaders
+	/usr/bin/gdk-pixbuf-query-loaders$(get_exeext)
 )
 
 src_prepare() {

--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.34.0.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.34.0.ebuild
@@ -38,7 +38,7 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gdk-pixbuf-query-loaders
+	/usr/bin/gdk-pixbuf-query-loaders$(get_exeext)
 )
 
 src_prepare() {

--- a/x11-libs/gtk+/gtk+-3.18.9.ebuild
+++ b/x11-libs/gtk+/gtk+-3.18.9.ebuild
@@ -96,7 +96,7 @@ PDEPEND="
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gtk-query-immodules-3.0
+	/usr/bin/gtk-query-immodules-3.0$(get_exeext)
 )
 
 strip_builddir() {

--- a/x11-libs/gtk+/gtk+-3.20.9.ebuild
+++ b/x11-libs/gtk+/gtk+-3.20.9.ebuild
@@ -101,7 +101,7 @@ PDEPEND="
 "
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gtk-query-immodules-3.0
+	/usr/bin/gtk-query-immodules-3.0$(get_exeext)
 )
 
 strip_builddir() {


### PR DESCRIPTION
Added $(get_exeext) to MULTILIB_CHOST_TOOLS for the packages
dev-libs/glib
media-libs/fontconfig
x11-libs/gdk-pixbuf
x11-libs/gtk+