### PR TITLE
Modifications for CP_DEPEND, auto classpath generation

### DIFF
--- a/eclass/java-pkg-2.eclass
+++ b/eclass/java-pkg-2.eclass
@@ -76,6 +76,9 @@ java-pkg-2_src_prepare() {
 
 java-pkg-2_src_compile() {
 	if [[ -e "${EANT_BUILD_XML:=build.xml}" ]]; then
+		# auto generate classpath
+		java-pkg_gen-cp EANT_GENTOO_CLASSPATH
+
 		[[ "${EANT_FILTER_COMPILER}" ]] && \
 			java-pkg_filter-compiler ${EANT_FILTER_COMPILER}
 		local antflags="${EANT_BUILD_TARGET:=jar}"

--- a/eclass/java-pkg-simple.eclass
+++ b/eclass/java-pkg-simple.eclass
@@ -88,6 +88,9 @@ S="${WORKDIR}"
 java-pkg-simple_src_compile() {
 	local sources=sources.lst classes=target/classes apidoc=target/api
 
+	# auto generate classpath
+	java-pkg_gen-cp JAVA_GENTOO_CLASSPATH
+
 	# gather sources
 	find ${JAVA_SRC_DIR:-*} -name \*.java > ${sources}
 	mkdir -p ${classes} || die "Could not create target directory"

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -2886,3 +2886,28 @@ java-pkg_clean() {
 		find "${@}" '(' -name '*.class' -o -name '*.jar' ')' -type f -delete -print || die
 	fi
 }
+
+# @FUNCTION: java-pkg_gen-cp
+# @INTERNAL
+# @DESCRIPTION:
+# Java package generate classpath will create a classpath based on
+# special variable CP_DEPEND in the ebuild.
+#
+# @CODE
+# Parameters:
+# $1 - classpath variable either EANT_GENTOO_CLASSPATH or JAVA_GENTOO_CLASSPATH
+# @CODE
+java-pkg_gen-cp() {
+	debug-print-function ${FUNCNAME} "${@}"
+
+	if [[ ${CP_DEPEND} ]]; then
+		local cp="${!1}"
+		local p
+		for p in ${CP_DEPEND}; do
+			p="${p/-[0-9]*:/-}"
+			cp="${cp} ${p#*/}"
+		done
+		cp="${cp//:/-}"
+		[[ ${cp} ]] && export ${1}="${cp//-0/}"
+	fi
+}


### PR DESCRIPTION
@gentoo-java @chewi @monsieurp @fordfrog @austin987 Initial modifications for auto classpath via new variable CP_DEPEND. In most cases the COMMON_DEPEND/CDEPEND can just be renamed to CP_DEPEND. You do need to remove any manual classpath creation/variable setting from the ebuild. This should make it much easier to create and maintain ebuilds. It is a common mistake to have a slot in dep, but use a different slot in the classpath. This prevents such issues, and eliminates need for any variables shared between deps and classpath. This has NO effect unless CP_DEPEND variable is present in an ebuild. Thus should be 100% safe to commit, as it does not change any existing function. If the ebuild does not have CP_DEPEND, this will have no effect.

The function java-pkg_gen-cp may need to be modified code wise. I wanted to avoid using sed, awk, or anything external. Not sure if that effects performance, or uses more resources to do it all in bash. Feel free to tweak/recode the internal of java-pkg_gen-cp function. It is not intended to handle complex deps, no || or other. That is not used to commonly in shared depends now. I do not think that will be a problem going forward. If it is the function will need to be modified to handle more complex depend scenarios. But I do not believe we have any || in any classpath variables, which means the same for deps, so usage of such is not to likely.