### PR TITLE
net-print/hplip-plugin: Remove nvinson & proxy-maint from metadata.xml

### DIFF
--- a/net-print/hplip-plugin/metadata.xml
+++ b/net-print/hplip-plugin/metadata.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>nvinson234@gmail.com</email>
-		<name>Nicholas Vinson</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 </pkgmetadata>


### PR DESCRIPTION
Removing myself as the listed maintainer.
Removing proxy-maint as there are no other proxied maintainers listed.

Package-Manager: portage-2.3.0