### PR TITLE
eclass/java-utils-2.eclass: Added call to eapply_user in src_prepare

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1867,6 +1867,15 @@ ejunit4() {
 # src_prepare Searches for bundled jars
 # Don't call directly, but via java-pkg-2_src_prepare!
 java-utils-2_src_prepare() {
+	if (( "${EAPI:-0}" >= "6" )); then
+		if declare -p PATCHES | grep -q "^declare -a "; then
+			[[ -n ${PATCHES[@]} ]] && eapply "${PATCHES[@]}"
+		else
+			[[ -n ${PATCHES} ]] && eapply ${PATCHES}
+		fi
+		eapply_user
+	fi
+
 	java-pkg_func-exists java_prepare && java_prepare
 
 	# Check for files in JAVA_RM_FILES array.


### PR DESCRIPTION
@gentoo-java @chewi @monsieurp @fordfrog @austin987 
This should allow java ebuilds to use EAPI=6, but does not mean the
eclass fully supports all EAPI=6 changes. The lack of such caused every
ebuild using EAPI=6 to fail without calling eapply_user in src_prepare.