### PR TITLE
games-board/holdingnuts: set mycmakeargs to array

### DIFF
--- a/games-board/holdingnuts/holdingnuts-0.0.5-r2.ebuild
+++ b/games-board/holdingnuts/holdingnuts-0.0.5-r2.ebuild
@@ -35,9 +35,9 @@ src_prepare() {
 }
 
 src_configure() {
-	local mycmakeargs="-DWITH_AUDIO=$(usex alsa)
+	local mycmakeargs=(-DWITH_AUDIO=$(usex alsa)
 		-DENABLE_CLIENT=$(usex !dedicated)
-		-DWITH_DEBUG=$(usex debug)"
+		-DWITH_DEBUG=$(usex debug))
 	cmake-utils_src_configure
 }
 


### PR DESCRIPTION
This is required by EAPI 6

Bug: https://bugs.gentoo.org/show_bug.cgi?id=590524

@gentoo/games