### PR TITLE
app-admin/stow: clear ebuild

### DIFF
--- a/app-admin/stow/files/99stow
+++ b/app-admin/stow/files/99stow
@@ -1,3 +1,0 @@
-LDPATH=/var/lib/lib
-PATH=/var/lib/bin
-MANPATH=/var/lib/share/man

--- a/app-admin/stow/stow-2.2.2.ebuild
+++ b/app-admin/stow/stow-2.2.2.ebuild
@@ -2,17 +2,15 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI=6
 
-inherit eutils
-
-DESCRIPTION="Manage installation of software in /var/lib/"
+DESCRIPTION="GNU Stow is a symlink farm manager."
 HOMEPAGE="https://www.gnu.org/software/stow/"
 SRC_URI="mirror://gnu/stow/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86 ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="test"
 
 DEPEND="dev-lang/perl
@@ -21,22 +19,3 @@ DEPEND="dev-lang/perl
 		dev-perl/Test-Output
 	)"
 RDEPEND="dev-lang/perl"
-
-src_install() {
-	emake DESTDIR="${D}" install || die "emake install failed."
-
-	# create new STOWDIR
-	dodir /var/lib/stow
-
-	# install env.d file to add STOWDIR to PATH and LDPATH
-	doenvd "${FILESDIR}"/99stow || die "doenvd failed"
-}
-
-pkg_postinst() {
-	elog "We now recommend that you use /var/lib/stow as your STOWDIR"
-	elog "instead of /usr/local in order to avoid conflicts with the"
-	elog "symlink from /usr/lib64 -> /usr/lib.  See Bug 246264 for"
-	elog "more details on this change."
-	elog "For your convenience, PATH has been updated to include"
-	elog "/var/lib/stow/bin."
-}


### PR DESCRIPTION
99stow is useless
clean src_install
EAPI bump
Add ~arm keyword
Not all using /var/lib/stow, so let the user chooses