### PR TITLE
app-text/texlive-core: fix texlive guide link

### DIFF
--- a/app-text/texlive-core/texlive-core-2012-r1.ebuild
+++ b/app-text/texlive-core/texlive-core-2012-r1.ebuild
@@ -337,7 +337,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2012-r3.ebuild
+++ b/app-text/texlive-core/texlive-core-2012-r3.ebuild
@@ -337,7 +337,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2012.ebuild
+++ b/app-text/texlive-core/texlive-core-2012.ebuild
@@ -333,7 +333,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2013-r1.ebuild
+++ b/app-text/texlive-core/texlive-core-2013-r1.ebuild
@@ -344,7 +344,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2013-r3.ebuild
+++ b/app-text/texlive-core/texlive-core-2013-r3.ebuild
@@ -344,7 +344,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2014-r1.ebuild
+++ b/app-text/texlive-core/texlive-core-2014-r1.ebuild
@@ -326,7 +326,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2014-r3.ebuild
+++ b/app-text/texlive-core/texlive-core-2014-r3.ebuild
@@ -326,7 +326,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2014-r4.ebuild
+++ b/app-text/texlive-core/texlive-core-2014-r4.ebuild
@@ -328,7 +328,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2014.ebuild
+++ b/app-text/texlive-core/texlive-core-2014.ebuild
@@ -324,7 +324,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"

--- a/app-text/texlive-core/texlive-core-2015.ebuild
+++ b/app-text/texlive-core/texlive-core-2015.ebuild
@@ -337,7 +337,7 @@ pkg_postinst() {
 	elog
 	ewarn "If you are migrating from an older TeX distribution"
 	ewarn "Please make sure you have read:"
-	ewarn "https://www.gentoo.org/proj/en/tex/texlive-migration-guide.xml"
+	ewarn "https://wiki.gentoo.org/wiki/Project:TeX/Tex_Live_Migration_Guide"
 	ewarn "in order to avoid possible problems"
 	elog
 	elog "TeXLive has been split in various ebuilds. If you are missing a"


### PR DESCRIPTION
Hi,

This PR updates texlive's guide link since the original only shows a 404.
I did run repoman but he only complained about a outdated EAPI at one ebuild. I also haven't made a reversion bump as i only changed the homepage.
Package belong to the **gentoo/tex** project and @aballier 

Please review.