### PR TITLE
fix gentoo java project homepage

### DIFF
--- a/app-eselect/eselect-java/eselect-java-0.2.0-r1.ebuild
+++ b/app-eselect/eselect-java/eselect-java-0.2.0-r1.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit autotools
 
 DESCRIPTION="A set of eselect modules for Java"
-HOMEPAGE="https://www.gentoo.org/proj/en/java/"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Java"
 SRC_URI="https://gitweb.gentoo.org/proj/${PN}.git/snapshot/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/app-eselect/eselect-java/eselect-java-0.2.0.ebuild
+++ b/app-eselect/eselect-java/eselect-java-0.2.0.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit autotools
 
 DESCRIPTION="A set of eselect modules for Java"
-HOMEPAGE="https://www.gentoo.org/proj/en/java/"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Java"
 SRC_URI="https://gitweb.gentoo.org/proj/${PN}.git/snapshot/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/dev-java/javatoolkit/javatoolkit-0.3.0-r9.ebuild
+++ b/dev-java/javatoolkit/javatoolkit-0.3.0-r9.ebuild
@@ -10,7 +10,7 @@ PYTHON_REQ_USE="xml(+)"
 inherit distutils-r1 eutils multilib prefix
 
 DESCRIPTION="Collection of Gentoo-specific tools for Java"
-HOMEPAGE="https://www.gentoo.org/proj/en/java/"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Java"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/sys-apps/baselayout-java/baselayout-java-0.1.0.ebuild
+++ b/sys-apps/baselayout-java/baselayout-java-0.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -7,7 +7,7 @@ EAPI=5
 inherit fdo-mime gnome2-utils
 
 DESCRIPTION="Baselayout for Java"
-HOMEPAGE="https://www.gentoo.org/proj/en/java/"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Java"
 SRC_URI="https://dev.gentoo.org/~sera/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This PR updates the HOMEPAGE on following 3 packages, since the original page only gives a 404.
app-eselect/eselect-java
dev-java/javatoolkit
sys-apps/baselayout-java
I did run repoman and thus had to update the copyright year of baselyout-java as well.
All packages belong to the **gentoo/java** project. Please assign this PR to their members.

Furthermore there a few other broken links regarding java:
* dev-java/ant-core-1.9.2 points to https://www.gentoo.org/proj/en/java/ant-guide.xml for it's ant guide. However the link is dead and i couldn't find another one on the wiki.
* www-servers/tomcat: all ebuild's have a broken link to the tomcat guide (were i could find a wiki page). However, since all links are out-commented i haven't touch those links.

Please review.