### PR TITLE
media-sound/clementine-1.3.1-r3: build with stable dependencies

### DIFF
--- a/media-sound/clementine/clementine-1.3.1-r3.ebuild
+++ b/media-sound/clementine/clementine-1.3.1-r3.ebuild
@@ -41,8 +41,8 @@ COMMON_DEPEND="
 	>=media-libs/chromaprint-0.6
 	media-libs/gstreamer:1.0
 	media-libs/gst-plugins-base:1.0
-	media-libs/libechonest:=[qt4]
-	>=media-libs/libmygpo-qt-1.0.8
+	media-libs/libechonest:=[qt4(+)]
+	media-libs/libmygpo-qt
 	>=media-libs/taglib-1.8[mp4(+)]
 	sys-libs/zlib
 	dev-libs/crypto++


### PR DESCRIPTION
This patch allows building clementine-1.3.1-r3 with the currently stable versions of media-libs/libechonest and media-libs/libmygpo-qt. I've tested it and everything seems to work fine.

@Fat-Zer