### PR TITLE
sys-power/powertop: Fix build of the -9999 version

### DIFF
--- a/sys-power/powertop/powertop-9999.ebuild
+++ b/sys-power/powertop/powertop-9999.ebuild
@@ -96,6 +96,7 @@ pkg_setup() {
 
 src_prepare() {
 	if [[ ${PV} == "9999" ]] ; then
+		sh scripts/version
 		eautoreconf
 	else
 		default


### PR DESCRIPTION
Upstream has recently introduced a change [1] to the build scripts which
require running an extra wrapper when building from git. No change has
to be made for releases.

[1] https://github.com/fenrus75/powertop/commit/2daaaf54