### PR TITLE
dev-util/android-studio: Unbundled some stuff, fixed bug

### DIFF
--- a/dev-util/android-studio/android-studio-2.2.0.12.145.3276617-r1.ebuild
+++ b/dev-util/android-studio/android-studio-2.2.0.12.145.3276617-r1.ebuild
@@ -3,7 +3,7 @@
 # $Id$
 
 EAPI=6
-inherit eutils versionator
+inherit eutils java-pkg-2 versionator
 
 RESTRICT="strip"
 QA_PREBUILT="opt/${PN}/bin/libbreakgen*.so opt/${PN}/bin/fsnotifier*"
@@ -25,9 +25,13 @@ IUSE="selinux"
 KEYWORDS="~amd64 ~x86"
 
 DEPEND="app-arch/zip"
+
+#	dev-java/guava:18
 RDEPEND=">=virtual/jdk-1.7
 	selinux? ( sec-policy/selinux-android )
 	>=app-arch/bzip2-1.0.6-r4
+	dev-java/commons-logging:0
+	dev-java/log4j:0
 	>=dev-libs/expat-2.1.0-r3
 	>=dev-libs/libffi-3.0.13-r1
 	>=media-libs/fontconfig-2.10.92
@@ -49,12 +53,32 @@ RDEPEND=">=virtual/jdk-1.7
 	>=x11-libs/libxshmfence-1.1"
 S=${WORKDIR}/${PN}
 
+java_prepare() {
+	eapply_user
+	# This is really a bundled jdk not a jre
+	rm -R "${S}/jre" || die "Could not remove bundled jdk posing as jre"
+
+	# Replace bundled jars with system
+	# has problems with newer jdom:0 not updated to jdom:2
+	cd "${S}/lib"
+	local JARS="commons-logging log4j"
+	local j
+	for j in ${JARS}; do
+		rm -v ${j/:*/}*.jar
+		java-pkg_jar-from ${j}
+	done
+}
+
 src_install() {
 	local dir="/opt/${PN}"
 
 	insinto "${dir}"
+	# Replaced bundled jre with system vm/jdk
+	# This is really a bundled jdk not a jre
+	dosym "/etc/java-config-2/current-system-vm" "${dir}/jre"
 	doins -r *
-	fperms 755 "${dir}/bin/studio.sh" "${dir}/bin/fsnotifier" "${dir}/bin/fsnotifier64"
+	fperms 755 "${dir}/bin/studio.sh" "${dir}/bin/fsnotifier" \
+		"${dir}/bin/fsnotifier64" "${dir}/gradle/gradle-2.14.1/bin/gradle"
 
 	newicon "bin/studio.png" "${PN}.png"
 	make_wrapper ${PN} ${dir}/bin/studio.sh


### PR DESCRIPTION
@perfinion guava can be used, I just did not want jdk 1.7. guava:18 needs a patch to work with java 1.8. I have said patch, but java is moving slowly these days.

@chewi might want to check out how I am replacing the jdk, symlink to /etc/java-config-2/current-system-vm. Not sure about that, but seemed the best approach.

1. Unbundled jdk posing as a jre, replaced with symlink to system vm/jdk
2. Unbundled a few jars for system installed, more can be done, as
   usually several deps in gentoo are outdated so need to be updated
3. Unbundling jre/jdk fixes bug #594584, otherwise that directory needs
   to be added to the list of fperms. Using system should be a better
   approach, and will be updated with security updates, etc.
4. Added gradle/gradle-*/bin/gradle to fperms for 755

Package-Manager: portage-2.3.1