### PR TITLE
sys-libs/musl: revbump to improve the ldconfig script

### DIFF
--- a/sys-libs/musl/musl-1.1.15-r1.ebuild
+++ b/sys-libs/musl/musl-1.1.15-r1.ebuild
@@ -92,6 +92,7 @@ src_install() {
 
 	if [[ ${CATEGORY} != cross-* ]] ; then
 		local arch=$("${D}"usr/lib/libc.so 2>&1 | sed -n '1s/^musl libc (\(.*\))$/\1/p')
+		[[ -e "${D}"/lib/ld-musl-${arch}.so.1 ]] || die
 		cp "${FILESDIR}"/ldconfig.in "${T}" || die
 		sed -e "s|@@ARCH@@|${arch}|" "${T}"/ldconfig.in > "${T}"/ldconfig || die
 		into /

--- a/sys-libs/musl/musl-9999.ebuild
+++ b/sys-libs/musl/musl-9999.ebuild
@@ -92,6 +92,7 @@ src_install() {
 
 	if [[ ${CATEGORY} != cross-* ]] ; then
 		local arch=$("${D}"usr/lib/libc.so 2>&1 | sed -n '1s/^musl libc (\(.*\))$/\1/p')
+		[[ -e "${D}"/lib/ld-musl-${arch}.so.1 ]] || die
 		cp "${FILESDIR}"/ldconfig.in "${T}" || die
 		sed -e "s|@@ARCH@@|${arch}|" "${T}"/ldconfig.in > "${T}"/ldconfig || die
 		into /


### PR DESCRIPTION
@blueness 

For convenience:
```
--- ldconfig.in
+++ ldconfig
@@ -125,7 +125,7 @@
 drs=$(read_ldso_conf "$LDSO_CONF")
 drs=$(sanitize $drs)

-ARCH=@@ARCH@@
+ARCH=$(/usr/lib/libc.so 2>&1 | sed -n '1s/^musl libc (\(.*\))$/\1/p')
 LDSO_PATH="/lib/ld-musl-${ARCH}.so.1"
 if [[ ! -e $LDSO_PATH ]]; then
        echo "$LDSO_PATH not found" >&2```