### PR TITLE
profiles/arch/amd64-fbsd/clang: Change to newway to use libc++ by default

### DIFF
--- a/profiles/arch/amd64-fbsd/clang/make.defaults
+++ b/profiles/arch/amd64-fbsd/clang/make.defaults
@@ -3,6 +3,6 @@
 # $Id$
 
 CFLAGS="-O2 -pipe"
-CXXFLAGS="-stdlib=libc++ ${CFLAGS}"
+CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
 FCFLAGS="${CFLAGS}"

--- a/profiles/arch/amd64-fbsd/clang/package.use.force
+++ b/profiles/arch/amd64-fbsd/clang/package.use.force
@@ -14,4 +14,4 @@ sys-libs/libcxx static-libs abi_x86_32
 net-misc/curl ssl curl_ssl_openssl
 
 # We obviously need clang
-sys-devel/llvm clang static-analyzer
+sys-devel/llvm clang static-analyzer default-compiler-rt default-libcxx

--- a/profiles/arch/amd64-fbsd/clang/profile.bashrc
+++ b/profiles/arch/amd64-fbsd/clang/profile.bashrc
@@ -5,4 +5,4 @@
 # Check if clang/clang++ exist before setting them so that we can more easily
 # switch to this profile and build stages.
 type -P clang > /dev/null && export CC=clang
-type -P clang++ > /dev/null && [ -f /usr/lib/libc++.so ] && export CXX="clang++ -stdlib=libc++"
+type -P clang++ > /dev/null && [ -f /usr/lib/libc++.so ] && export CXX=clang++


### PR DESCRIPTION
@aballier, Please to review and merge if no problem.
