### PR TITLE
app-editors/fte: fix cpp14 compilation errors; bug #595048

### DIFF
--- a/app-editors/fte/files/fte-cpp14.patch
+++ b/app-editors/fte/files/fte-cpp14.patch
@@ -1,0 +1,17 @@
+Fix C++14 compilation errors. Add casting int literals to char in config
+generator to avoid narrowing conversions.
+Gentoo bug: https://bugs.gentoo.org/show_bug.cgi?id=595048
+
+--- a/src/mkdefcfg.pl
++++ b/src/mkdefcfg.pl
+@@ -24,8 +24,8 @@
+ 
+     @c = split(//, $buf);
+     for ($i = 0; $i < $len; $i++) {
+-        $out .= sprintf("0x%02X", ord($c[$i]));
+-        if ($n++ % 10) {
++        $out .= sprintf("(char)0x%02X", ord($c[$i]));
++        if ($n++ % 5) {
+             $out .= ", ";
+         } else {
+             $out .= ",\n";

--- a/app-editors/fte/fte-20051115-r3.ebuild
+++ b/app-editors/fte/fte-20051115-r3.ebuild
@@ -47,7 +47,8 @@ src_prepare() {
 		"${FILESDIR}"/fte-gcc34 \
 		"${FILESDIR}"/${PN}-new_keyword.patch \
 		"${FILESDIR}"/${PN}-slang.patch \
-		"${FILESDIR}"/${PN}-interix.patch
+		"${FILESDIR}"/${PN}-interix.patch \
+		"${FILESDIR}"/${PN}-cpp14.patch # bug #595048
 
 	[[ -e /usr/include/linux/keyboard.h ]] && \
 		sed /usr/include/linux/keyboard.h -e '/wait.h/d' > src/hacked_keyboard.h

--- a/app-editors/fte/fte-20110708-r1.ebuild
+++ b/app-editors/fte/fte-20110708-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI=6
 
 inherit eutils toolchain-funcs
 
@@ -20,7 +20,7 @@ IUSE="gpm slang X"
 S="${WORKDIR}/${PN}"
 
 RDEPEND="
-	>=sys-libs/ncurses-5.2
+	sys-libs/ncurses:0=
 	X? (
 		x11-libs/libXdmcp
 		x11-libs/libXau
@@ -31,6 +31,8 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	slang? ( >=sys-libs/slang-2.1.3 )
 	app-arch/unzip"
+
+HTML_DOCS=( doc/. )
 
 set_targets() {
 	export TARGETS=""
@@ -48,9 +50,12 @@ src_prepare() {
 	# epatch "${FILESDIR}"/${PN}-new_keyword.patch
 	# epatch "${FILESDIR}"/${PN}-slang.patch
 	# epatch "${FILESDIR}"/${PN}-interix.patch
+	default
 
-	[[ -e /usr/include/linux/keyboard.h ]] && \
-		sed /usr/include/linux/keyboard.h -e '/wait.h/d' > src/hacked_keyboard.h
+	if [[ -e /usr/include/linux/keyboard.h ]]; then
+		sed /usr/include/linux/keyboard.h \
+			-e '/wait.h/d'>src/hacked_keyboard.h || die
+	fi
 
 	sed \
 		-e "s:<linux/keyboard.h>:\"hacked_keyboard.h\":" \
@@ -109,8 +114,7 @@ src_install() {
 
 	dobin "${FILESDIR}"/${PN}
 
-	dodoc BUGS README TODO
-	dohtml doc/*
+	einstalldocs
 
 	insinto /usr/share/${PN}
 	doins -r config/*


### PR DESCRIPTION
Change config generating Perl script to cast int literals to char in default
config file to avoid narrowing conversions.
Gentoo bug: https://bugs.gentoo.org/show_bug.cgi?id=595048