### PR TITLE
Fix app-admin/puppet-agent service unit for mcollective

### DIFF
--- a/app-admin/puppet-agent/files/mcollective.service
+++ b/app-admin/puppet-agent/files/mcollective.service
@@ -6,7 +6,7 @@ After=network.target
 Type=forking
 StandardOutput=syslog
 StandardError=syslog
-ExecStart=/usr/sbin/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg --pidfile=/var/run/puppetlabs/mcollective.pid --daemonize
+ExecStart=/usr/sbin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg --pidfile=/var/run/puppetlabs/mcollective.pid --daemonize
 ExecReload=/bin/kill -USR1 $MAINPID
 PIDFile=/var/run/puppetlabs/mcollective.pid
 


### PR DESCRIPTION
The mcollective.service unit uses a path in ExecStart that doesn't
exist. This commit updates the service unit to reference the path
actually included by the package.

Gentoo bug #595718