### PR TITLE
 x11-libs/vte version bump to 0.28.2-r208

### DIFF
--- a/x11-libs/vte/files/vte-0.28.2-repaint-after-change-scroll-region.patch
+++ b/x11-libs/vte/files/vte-0.28.2-repaint-after-change-scroll-region.patch
@@ -1,0 +1,86 @@
+https://git.gnome.org/browse/vte/commit/?id=88e8e89560a62d0981ce2b18974a230d0a07dbdd
+
+From 88e8e89560a62d0981ce2b18974a230d0a07dbdd Mon Sep 17 00:00:00 2001
+From: Micah Cowan <micah@cowan.name>
+Date: Tue, 22 Oct 2013 23:30:43 +0200
+Subject: widget: Fix invalidation region
+
+When the sequence handler moves the cursor into the restricted scrolling region,
+the bbox needs to be reset, too.
+Fixes glitches with interspersing writes to the bottom line with scrolls of the
+upper region, and also fixes missing screen redraws when using mosh.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=542087
+https://bugzilla.gnome.org/show_bug.cgi?id=686097
+
+diff --git a/src/vte.c b/src/vte.c
+index 9f6d7d8..a4d9d25 100644
+--- a/src/vte.c
++++ b/src/vte.c
+@@ -4077,6 +4077,7 @@ vte_terminal_process_incoming(VteTerminal *terminal)
+ 	long wcount, start, delta;
+ 	gboolean leftovers, modified, bottom, again;
+ 	gboolean invalidated_text;
++	gboolean in_scroll_region;
+ 	GArray *unichars;
+ 	struct _vte_incoming_chunk *chunk, *next_chunk, *achunk = NULL;
+ 
+@@ -4096,6 +4097,10 @@ vte_terminal_process_incoming(VteTerminal *terminal)
+ 	cursor = screen->cursor_current;
+ 	cursor_visible = terminal->pvt->cursor_visible;
+ 
++	in_scroll_region = screen->scrolling_restricted
++	    && (screen->cursor_current.row >= (screen->insert_delta + screen->scrolling_region.start))
++	    && (screen->cursor_current.row <= (screen->insert_delta + screen->scrolling_region.end));
++
+ 	/* We should only be called when there's data to process. */
+ 	g_assert(terminal->pvt->incoming ||
+ 		 (terminal->pvt->pending->len > 0));
+@@ -4194,6 +4199,8 @@ skip_chunk:
+ 		 * points to the first character which isn't part of this
+ 		 * sequence. */
+ 		if ((match != NULL) && (match[0] != '\0')) {
++			gboolean new_in_scroll_region;
++
+ 			/* Call the right sequence handler for the requested
+ 			 * behavior. */
+ 			_vte_terminal_handle_sequence(terminal,
+@@ -4204,12 +4211,21 @@ skip_chunk:
+ 			start = (next - wbuf);
+ 			modified = TRUE;
+ 
+-			/* if we have moved during the sequence handler, restart the bbox */
++			new_in_scroll_region = screen->scrolling_restricted
++			    && (screen->cursor_current.row >= (screen->insert_delta + screen->scrolling_region.start))
++			    && (screen->cursor_current.row <= (screen->insert_delta + screen->scrolling_region.end));
++
++			delta = screen->scroll_delta;	/* delta may have changed from sequence. */
++
++			/* if we have moved greatly during the sequence handler, or moved
++                         * into a scroll_region from outside it, restart the bbox.
++                         */
+ 			if (invalidated_text &&
+-					(screen->cursor_current.col > bbox_bottomright.x + VTE_CELL_BBOX_SLACK ||
+-					 screen->cursor_current.col < bbox_topleft.x - VTE_CELL_BBOX_SLACK     ||
+-					 screen->cursor_current.row > bbox_bottomright.y + VTE_CELL_BBOX_SLACK ||
+-					 screen->cursor_current.row < bbox_topleft.y - VTE_CELL_BBOX_SLACK)) {
++					((new_in_scroll_region && !in_scroll_region) ||
++					 (screen->cursor_current.col > bbox_bottomright.x + VTE_CELL_BBOX_SLACK ||
++					  screen->cursor_current.col < bbox_topleft.x - VTE_CELL_BBOX_SLACK     ||
++					  screen->cursor_current.row > bbox_bottomright.y + VTE_CELL_BBOX_SLACK ||
++					  screen->cursor_current.row < bbox_topleft.y - VTE_CELL_BBOX_SLACK))) {
+ 				/* Clip off any part of the box which isn't already on-screen. */
+ 				bbox_topleft.x = MAX(bbox_topleft.x, 0);
+ 				bbox_topleft.y = MAX(bbox_topleft.y, delta);
+@@ -4229,6 +4245,8 @@ skip_chunk:
+ 				bbox_bottomright.x = bbox_bottomright.y = -G_MAXINT;
+ 				bbox_topleft.x = bbox_topleft.y = G_MAXINT;
+ 			}
++
++			in_scroll_region = new_in_scroll_region;
+ 		} else
+ 		/* Second, we have a NULL match, and next points to the very
+ 		 * next character in the buffer.  Insert the character which
+-- 
+cgit v0.10.2
+

--- a/x11-libs/vte/vte-0.28.2-r208.ebuild
+++ b/x11-libs/vte/vte-0.28.2-r208.ebuild
@@ -1,0 +1,128 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+PYTHON_COMPAT=( python2_7 )
+
+inherit gnome2 python-r1
+
+DESCRIPTION="GNOME terminal widget"
+HOMEPAGE="https://wiki.gnome.org/Apps/Terminal/VTE"
+
+LICENSE="LGPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~x64-solaris ~x86-solaris"
+IUSE="debug +introspection python"
+
+RDEPEND="
+	>=dev-libs/glib-2.26:2
+	>=x11-libs/gtk+-2.20:2[introspection?]
+	>=x11-libs/pango-1.22.0
+
+	sys-libs/ncurses:0=
+	x11-libs/libX11
+	x11-libs/libXft
+
+	introspection? ( >=dev-libs/gobject-introspection-0.9.0:= )
+	python? (
+		${PYTHON_DEPS}
+		dev-python/pygtk:2[${PYTHON_USEDEP}]
+	)
+"
+DEPEND="${RDEPEND}
+	dev-util/gtk-doc-am
+	>=dev-util/intltool-0.35
+	virtual/pkgconfig
+	sys-devel/gettext
+"
+PDEPEND="x11-libs/gnome-pty-helper"
+
+PATCHES=(
+	# https://bugzilla.gnome.org/show_bug.cgi?id=663779
+	"${FILESDIR}"/${PN}-0.30.1-alt-meta.patch
+
+	# https://bugzilla.gnome.org/show_bug.cgi?id=652290
+	"${FILESDIR}"/${PN}-0.28.2-interix.patch
+
+	# Fix CVE-2012-2738, upstream bug #676090
+	"${FILESDIR}"/${PN}-0.28.2-limit-arguments.patch
+
+	# Fix https://bugzilla.gnome.org/show_bug.cgi?id=542087
+	# Patch from https://github.com/pld-linux/vte0/commit/1e8dce16b239e5d378b02e4d04a60e823df36257
+	"${FILESDIR}"/${PN}-0.28.2-repaint-after-change-scroll-region.patch
+)
+
+DOCS="AUTHORS ChangeLog HACKING NEWS README"
+
+src_prepare() {
+
+	prepare_python() {
+		mkdir -p "${BUILD_DIR}" || die
+	}
+	if use python; then
+		python_foreach_impl prepare_python
+	fi
+
+	gnome2_src_prepare
+}
+
+src_configure() {
+	configure_python() {
+		ECONF_SOURCE="${S}" gnome2_src_configure --enable-python
+	}
+
+	if use python; then
+		python_foreach_impl run_in_build_dir configure_python
+	fi
+
+	local myconf=""
+
+	if [[ ${CHOST} == *-interix* ]]; then
+		myconf="${myconf} --disable-Bsymbolic"
+
+		# interix stropts.h is empty...
+		export ac_cv_header_stropts_h=no
+	fi
+
+	# Do not disable gnome-pty-helper, bug #401389
+	gnome2_src_configure --disable-python \
+		--disable-deprecation \
+		--disable-glade-catalogue \
+		--disable-static \
+		$(use_enable debug) \
+		$(use_enable introspection) \
+		--with-gtk=2.0 \
+		${myconf}
+}
+
+src_compile() {
+	gnome2_src_compile
+
+	compile_python() {
+		cd "${BUILD_DIR}"/python || die
+		ln -s "${S}"/src/libvte.la "${BUILD_DIR}"/src/ || die
+		mkdir -p "${BUILD_DIR}"/src/.libs || die
+		ln -s "${S}"/src/.libs/libvte.so "${BUILD_DIR}"/src/.libs/ || die
+		emake CPPFLAGS="${CPPFLAGS} -I${S}/src"
+	}
+
+	if use python; then
+		python_foreach_impl run_in_build_dir compile_python
+	fi
+}
+
+src_install() {
+	gnome2_src_install
+
+	install_python() {
+		cd "${BUILD_DIR}"/python || die
+		emake install DESTDIR="${D}" \
+			CPPFLAGS="${CPPFLAGS} -I${S}/src"
+	}
+	if use python; then
+		python_foreach_impl run_in_build_dir install_python
+	fi
+
+	rm -v "${ED}usr/libexec/gnome-pty-helper" || die
+}


### PR DESCRIPTION
@gentoo/gnome
# Changes

```
- version bump
- included patch for vte2 fixing bug described below
- added call to epatch_user
```
# Bug details

If you are using gnome-terminal or xfce4-terminal, you may have hit a bug in vte3.
A fix is around since at least 2010, which found its way into some
(but not all) distribution packages, and even into upstream (3 years later,
but unchanged).
## Bugzilla and other links
- Original (?):
  https://bugzilla.gnome.org/show_bug.cgi?id=542087
- One of its duplicate:
  https://bugzilla.gnome.org/show_bug.cgi?id=686097
- reported mosh bug related to this problem:
  https://github.com/mobile-shell/mosh/issues/660
- vte upstream commit:
  https://git.gnome.org/browse/vte/commit/?id=88e8e89560a62d0981ce2b18974a230d0a07dbdd
- used backported patch for vte2:
  https://github.com/pld-linux/vte0/commit/1e8dce16b239e5d378b02e4d04a60e823df36257
