### PR TITLE
dev-libs/DirectFB: fix build with divine use flag

### DIFF
--- a/dev-libs/DirectFB/DirectFB-1.7.6.ebuild
+++ b/dev-libs/DirectFB/DirectFB-1.7.6.ebuild
@@ -76,7 +76,8 @@ src_prepare() {
 		"${FILESDIR}"/${PN}-1.7.1-build.patch \
 		"${FILESDIR}"/${PN}-1.6.3-setregion.patch \
 		"${FILESDIR}"/${PN}-1.6.3-atomic-fix-compiler-error-when-building-for-thumb2.patch \
-		"${FILESDIR}"/${PN}-1.7.6-cle266.patch
+		"${FILESDIR}"/${PN}-1.7.6-cle266.patch \
+		"${FILESDIR}"/${PN}-1.7.6-idivine.patch
 	sed -i \
 		-e '/#define RASPBERRY_PI/d' \
 		systems/egl/egl_system.c || die #497124

--- a/dev-libs/DirectFB/files/DirectFB-1.7.6-idivine.patch
+++ b/dev-libs/DirectFB/files/DirectFB-1.7.6-idivine.patch
@@ -1,0 +1,57 @@
+--- lib/divine/idivine.h.orig
++++ lib/divine/idivine.h
+@@ -0,0 +1,54 @@
++/*
++   (c) Copyright 2012-2013  DirectFB integrated media GmbH
++   (c) Copyright 2001-2013  The world wide DirectFB Open Source Community (directfb.org)
++   (c) Copyright 2000-2004  Convergence (integrated media) GmbH
++
++   All rights reserved.
++
++   Written by Denis Oliver Kropp <dok@directfb.org>,
++              Andreas Shimokawa <andi@directfb.org>,
++              Marek Pikarski <mass@directfb.org>,
++              Sven Neumann <neo@directfb.org>,
++              Ville Syrjälä <syrjala@sci.fi> and
++              Claudio Ciccani <klan@users.sf.net>.
++
++   This library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2 of the License, or (at your option) any later version.
++
++   This library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with this library; if not, write to the
++   Free Software Foundation, Inc., 59 Temple Place - Suite 330,
++   Boston, MA 02111-1307, USA.
++*/
++
++
++
++#ifndef __IDIVINE_H__
++#define __IDIVINE_H__
++
++#include <divine.h>
++
++/*
++ * private data struct of IDiVine
++ */
++typedef struct {
++     int                         ref;      /* reference counter */
++
++     DiVine                     *divine;
++} IDiVine_data;
++
++/*
++ * IDiVine constructor/destructor
++ */
++DFBResult IDiVine_Construct( IDiVine *thiz );
++
++void      IDiVine_Destruct ( IDiVine *thiz );
++
++#endif


### PR DESCRIPTION
Add a patch to create a header file, which was omitted from dist
tarball, but is present in upstream vcs.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=573584

The change does not warrant a revbump, as it does not affect any existing installation.