### PR TITLE
net-misc/remmina: warn about encrypted VNC deps

### DIFF
--- a/net-misc/remmina/remmina-1.2.0_rc15.ebuild
+++ b/net-misc/remmina/remmina-1.2.0_rc15.ebuild
@@ -76,6 +76,7 @@ pkg_postinst() {
 	gnome2_icon_cache_update
 
 	elog "XDMCP support requires x11-base/xorg-server[xephyr]."
+	elog "Encrypted VNC connections require net-libs/libvncserver[gcrypt]."
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Add a post-install message informing the user that encrypted VNC
connections require net-libs/libvncserver built with the gcrypt flag.

Gentoo-Bug: [594750](https://bugs.gentoo.org/594750)