### PR TITLE
profiles and freebsd.eclass: add better clang support

### DIFF
--- a/eclass/freebsd.eclass
+++ b/eclass/freebsd.eclass
@@ -195,6 +195,17 @@ freebsd_src_unpack() {
 		export INSTALL_LINK="ln -f"
 		export INSTALL_SYMLINK="ln -fs"
 	fi
+
+	# When CC=clang, force use clang-cpp #478810, #595878
+	if [[ $(tc-getCC) == *clang* ]] ; then
+		if type -P clang-cpp > /dev/null ; then
+			export CPP=clang-cpp
+		else
+			mkdir "${WORKDIR}"/workaround_clang-cpp || die "Could not create ${WORKDIR}/workaround_clang-cpp"
+			ln -s "$(type -P clang)" "${WORKDIR}"/workaround_clang-cpp/clang-cpp || die "Could not create clang-cpp symlink."
+			export CPP="${WORKDIR}/workaround_clang-cpp/clang-cpp"
+		fi
+	fi
 }
 
 freebsd_src_compile() {

--- a/profiles/arch/amd64-fbsd/clang/profile.bashrc
+++ b/profiles/arch/amd64-fbsd/clang/profile.bashrc
@@ -4,5 +4,6 @@
 
 # Check if clang/clang++ exist before setting them so that we can more easily
 # switch to this profile and build stages.
-type -P clang > /dev/null && export CC=clang
-type -P clang++ > /dev/null && [ -f /usr/lib/libc++.so ] && export CXX=clang++
+# Some packages will require BUILD_{CC,CXX} variables, bug 595878.
+type -P clang > /dev/null && export CC=clang && export BUILD_CC=clang
+type -P clang++ > /dev/null && [ -f /usr/lib/libc++.so ] && export CXX=clang++ && export BUILD_CXX=clang++


### PR DESCRIPTION
@aballier, Please to review and merge if no problem.

https://bugs.gentoo.org/show_bug.cgi?id=595878

* Add CPP=clang-cpp for sys-freebsd/* packages. (freebsd.eclass)
* Some package require BUILD_{CC,CXX}  to compile to be successful. (profile)