### PR TITLE
sys-libs/libcxxabi, second iteration

### DIFF
--- a/sys-libs/libcxx/metadata.xml
+++ b/sys-libs/libcxx/metadata.xml
@@ -14,6 +14,7 @@
 		<name>LLVM Project</name>
 	</maintainer>
 	<use>
+		<flag name="libcxxabi">Build on top of <pkg>sys-libs/libcxxabi</pkg> instead of gcc's libsupc++ (avoids depending on gcc).</flag>
 		<flag name="libcxxrt">Build on top of <pkg>sys-libs/libcxxrt</pkg> instead of gcc's libsupc++ (avoids depending on gcc).</flag>
 		<flag name="libunwind">Use libunwind instead of libgcc_s for stack unwinding, thus avoiding dependence on gcc.</flag>
 	</use>

--- a/sys-libs/libcxxabi/libcxxabi-9999.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-9999.ebuild
@@ -1,0 +1,93 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+: ${CMAKE_MAKEFILE_GENERATOR:=ninja}
+EGIT_REPO_URI="http://llvm.org/git/libcxxabi.git
+	https://github.com/llvm-mirror/libcxxabi.git"
+CMAKE_MIN_VERSION=3.4.3
+PYTHON_COMPAT=( python2_7 )
+
+inherit cmake-multilib git-r3 python-any-r1
+
+DESCRIPTION="Low level support for a standard C++ library"
+HOMEPAGE="http://libcxxabi.llvm.org/"
+SRC_URI=""
+
+LICENSE="|| ( UoI-NCSA MIT )"
+SLOT="0"
+KEYWORDS=""
+IUSE="libunwind +static-libs test"
+
+RDEPEND="
+	libunwind? (
+		|| (
+			>=sys-libs/libunwind-1.0.1-r1[static-libs?,${MULTILIB_USEDEP}]
+			sys-libs/llvm-libunwind[static-libs?,${MULTILIB_USEDEP}]
+		)
+	)"
+DEPEND="${RDEPEND}
+	>=sys-devel/llvm-3.9.0
+	test? ( >=sys-devel/clang-3.9.0
+		~sys-libs/libcxx-${PV}[libcxxabi]
+		$(python_gen_any_dep 'dev-python/lit[${PYTHON_USEDEP}]') )"
+
+python_check_deps() {
+	has_version "dev-python/lit[${PYTHON_USEDEP}]"
+}
+
+pkg_setup() {
+	use test && python-any-r1_pkg_setup
+}
+
+src_unpack() {
+	# we need the headers
+	git-r3_fetch "http://llvm.org/git/libcxx.git
+		https://github.com/llvm-mirror/libcxx.git"
+	git-r3_fetch
+
+	git-r3_checkout http://llvm.org/git/libcxx.git \
+		"${WORKDIR}"/libcxx
+	git-r3_checkout
+}
+
+src_configure() {
+	NATIVE_LIBDIR=$(get_libdir)
+	cmake-multilib_src_configure
+}
+
+multilib_src_configure() {
+	local libdir=$(get_libdir)
+	local mycmakeargs=(
+		-DLLVM_LIBDIR_SUFFIX=${NATIVE_LIBDIR#lib}
+		-DLIBCXXABI_LIBDIR_SUFFIX=${libdir#lib}
+		-DLIBCXXABI_ENABLE_SHARED=ON
+		-DLIBCXXABI_ENABLE_STATIC=$(usex static-libs)
+		-DLIBCXXABI_USE_LLVM_UNWINDER=$(usex libunwind)
+		-DLLVM_INCLUDE_TESTS=$(usex test)
+
+		-DLIBCXXABI_LIBCXX_INCLUDES="${WORKDIR}"/libcxx/include
+	)
+	if use test; then
+		mycmakeargs+=(
+			-DLIT_COMMAND="${EPREFIX}"/usr/bin/lit
+		)
+	fi
+	cmake-utils_src_configure
+}
+
+multilib_src_test() {
+	local clang_path=$(type -P "${CHOST:+${CHOST}-}clang" 2>/dev/null)
+
+	[[ -n ${clang_path} ]] || die "Unable to find ${CHOST}-clang for tests"
+	sed -i -e "/cxx_under_test/s^\".*\"^\"${clang_path}\"^" test/lit.site.cfg || die
+
+	cmake-utils_src_make check-libcxxabi
+}
+
+multilib_src_install_all() {
+	insinto /usr/include/libcxxabi
+	doins -r include/.
+}

--- a/sys-libs/libcxxabi/metadata.xml
+++ b/sys-libs/libcxxabi/metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>llvm@gentoo.org</email>
+	</maintainer>
+	<use>
+		<flag name="libunwind">Use libunwind instead of libgcc_s for stack unwinding, thus avoiding dependency on gcc</flag>
+	</use>
+</pkgmetadata>


### PR DESCRIPTION
I've started afresh, and I think I've got a pretty good result. Tests are still in progress but I think it's ready to land. Major notes:

* it's based on latest ebuilds for LLVM suite, with all the fun ideas (no unnecessary multilib deps, llvm source checkouts and other slow stuff),
* it fetches libcxx sources for headers during build; however, testing requires libcxx built against it,
* libcxx gets libcxxabi support via additional USE=libcxxabi, based on USE=libcxxrt.