### PR TITLE
freebsd profile/eclass: Move special CFLAGS for sys-freebsd/* from profile to eclass.

### DIFF
--- a/eclass/freebsd.eclass
+++ b/eclass/freebsd.eclass
@@ -206,6 +206,9 @@ freebsd_src_unpack() {
 			export CPP="${WORKDIR}/workaround_clang-cpp/clang-cpp"
 		fi
 	fi
+
+	# Add a special CFLAGS required for multilib support.
+	use amd64-fbsd && export CFLAGS_x86_fbsd="${CFLAGS_x86_fbsd} -DCOMPAT_32BIT -B/usr/lib32 -L/usr/lib32"
 }
 
 freebsd_src_compile() {

--- a/profiles/arch/amd64-fbsd/make.defaults
+++ b/profiles/arch/amd64-fbsd/make.defaults
@@ -17,7 +17,7 @@ DEFAULT_ABI="amd64_fbsd"
 ABI="amd64_fbsd"
 
 # 32bit specific settings.
-CFLAGS_x86_fbsd="-m32 -DCOMPAT_32BIT -B/usr/lib32 -L/usr/lib32"
+CFLAGS_x86_fbsd="-m32"
 LDFLAGS_x86_fbsd="-m elf_i386_fbsd -L/usr/lib32"
 
 USE="mmx mmxext sse sse2"


### PR DESCRIPTION
Fix bug
https://bugs.gentoo.org/show_bug.cgi?id=596044