### PR TITLE
sys-fs/udev: Modified to create kvm group and install 65-kvm.rules

### DIFF
--- a/sys-fs/udev/metadata.xml
+++ b/sys-fs/udev/metadata.xml
@@ -8,6 +8,7 @@
 		<flag name="firmware-loader">Enable the userspace firmware loader (DEPRECATED, replaced by the in-kernel loader starting from 3.8)</flag>
 		<flag name="gudev">Build the gobject interface library</flag>
 		<flag name="kmod">Enable kernel module loading/unloading support using <pkg>sys-apps/kmod</pkg></flag>
+		<flag name="kvm">Create kvm group (GID 36) and install udev rule for kvm</flag>
 	</use>
 	<upstream>
 		<remote-id type="cpe">cpe:/a:kernel:udev</remote-id>


### PR DESCRIPTION
This is a minor modification to udev to add a kvm group, GID 36, and a udev rules file 65-kvm.rules for kvm usage by user apps.

Now it seems app-emulation/qemu already provides such file. This is needed by Android Studio and possibly other user space apps that need access to /dev/kvm. A stand alone ebuild could be created, but I think that is a bit over kill and more to maintain. Though extra stuff in udev ebuild could be seen as clutter etc.

I think it is better to add sys-fs/udev[kvm] to those packages, than to add another package and have it be a dependency for qemu, android-studio, and others. The udev rule is so small it does not even merit being stored in a stand alone file, but can be generated from within the ebuild. Less external files to maintain, etc. Though it is less visible that it exists inside the ebuild. Always pros and cons.

The only other thing being the minimal 1 line rules file, is creating the kvm group, GID 36 based on RedHat's default GID for kvm group. To have an ebuild just install 1 file and 1 group seems a bit over kill. Thus I stuck them into udev with a kvm use flag. The qemu package uses kernel_linux. The name of the USE flag is moot, but seems it is already USE flag controlled on qmenu. Thus doing the same just moving it to udev.

Refers to [Gentoo bug](https://bugs.gentoo.org/show_bug.cgi?id=596168#add_comment)

Package-Manager: portage-2.3.1
