### PR TITLE
sys-libs/libcxxabi: fix a compile error on musl

### DIFF
--- a/sys-libs/libcxxabi/libcxxabi-3.9.0.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-3.9.0.ebuild
@@ -18,7 +18,7 @@ SRC_URI="http://llvm.org/releases/${PV}/${P}.src.tar.xz
 LICENSE="|| ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="libunwind +static-libs test"
+IUSE="elibc_musl libunwind +static-libs test"
 
 RDEPEND="
 	libunwind? (
@@ -78,6 +78,9 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DLIT_COMMAND="${EPREFIX}"/usr/bin/lit
 		)
+	fi
+	if use elibc_musl; then
+		local -x CPPFLAGS="${CPPFLAGS} -D_LIBCPP_HAS_MUSL_LIBC=1"
 	fi
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
This fix is actually applied to libcxx's source, on which libcxxabi depends.
