### PR TITLE
x11-libs/xcb-util-image: Added return to allow clang compile correctly

### DIFF
--- a/x11-libs/xcb-util-image/files/clang.patch
+++ b/x11-libs/xcb-util-image/files/clang.patch
@@ -1,0 +1,12 @@
+Index: xcb-util-image-0.4.0/image/xcb_bitops.h
+===================================================================
+--- xcb-util-image-0.4.0.orig/image/xcb_bitops.h
++++ xcb-util-image-0.4.0/image/xcb_bitops.h
+@@ -207,6 +207,7 @@ xcb_host_byte_order(void) {
+       return XCB_IMAGE_ORDER_LSB_FIRST;
+   }
+   assert(0);
++  return -1;
+ }
+ 
+ #endif /* __XCB_BITOPS_H__ */

--- a/x11-libs/xcb-util-image/xcb-util-image-0.4.0.ebuild
+++ b/x11-libs/xcb-util-image/xcb-util-image-0.4.0.ebuild
@@ -26,6 +26,7 @@ DEPEND="${RDEPEND}
 	test? ( >=dev-libs/check-0.9.11[${MULTILIB_USEDEP}] )"
 
 src_configure() {
+	epatch "${FILESDIR}/clang.patch"
 	XORG_CONFIGURE_OPTIONS=(
 		$(use_with doc doxygen)
 	)


### PR DESCRIPTION
Signed-off-by: Pablo Cholaky waltercool@slash.cl

Compiling xcb-util-image with clang 3.9.0 will return error, unless you specify a return type. The original pull request I sent was here: https://github.com/gentoo/musl/pull/12

Attaching build.log correct and fail.
[fail.txt](https://github.com/gentoo/gentoo/files/514405/fail.txt)
[work.txt](https://github.com/gentoo/gentoo/files/514404/work.txt)
