### PR TITLE
dev-ruby/hashicorp-checkpoint: add ruby23 support, drop ~x86

### DIFF
--- a/dev-ruby/hashicorp-checkpoint/hashicorp-checkpoint-0.1.4-r1.ebuild
+++ b/dev-ruby/hashicorp-checkpoint/hashicorp-checkpoint-0.1.4-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+USE_RUBY="ruby20 ruby21 ruby22 ruby23"
+
+RUBY_FAKEGEM_RECIPE_TEST="rspec3"
+RUBY_FAKEGEM_RECIPE_DOC="rdoc"
+RUBY_FAKEGEM_EXTRADOC="README.md"
+
+inherit ruby-fakegem
+
+DESCRIPTION="Internal HashiCorp service to check version information"
+HOMEPAGE="http://www.hashicorp.com"
+
+LICENSE="MPL-2.0"
+SLOT="0"
+KEYWORDS="~amd64"
+
+ruby_add_bdepend "
+	test? ( dev-ruby/rspec-its )
+"


### PR DESCRIPTION
We need this for vagrant with ruby23 support (Bug #596402). Dropping x86 because rspec and rspec-its dropped them in new releases. Either way, vagrant is only on amd64 because newer ruby deps dropped x86 too. Once we clean older vagrant versions, we can drop r0 here too.

Package-Manager: portage-2.3.1
