### PR TITLE
app-arch/lbzip2: add ~amd64-fbsd keywords.

### DIFF
--- a/app-arch/lbzip2/lbzip2-2.5.ebuild
+++ b/app-arch/lbzip2/lbzip2-2.5.ebuild
@@ -12,7 +12,7 @@ SRC_URI="http://archive.lbzip2.org/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="debug symlink"
 
 RDEPEND="symlink? ( !app-arch/pbzip2[symlink] )"


### PR DESCRIPTION
dev-util/catalyst requires app-arch/lbzip2.

```
cat catalyst-3.0_rc1.ebuild
<snip>
RDEPEND="
        >=dev-python/pydecomp-0.1[${PYTHON_USEDEP}]
        app-arch/lbzip2
```

lbzip2, test results)

```
gmake  check-TESTS
gmake[2]: Entering directory '/var/tmp/portage/app-arch/lbzip2-2.5/work/lbzip2-2.5_build/tests'
gmake[3]: Entering directory '/var/tmp/portage/app-arch/lbzip2-2.5/work/lbzip2-2.5_build/tests'
PASS: crc1.bz2
PASS: codelen20.bz2
PASS: 32767.bz2
PASS: concat.bz2
PASS: crc2.bz2
PASS: cve.bz2
PASS: cve2.bz2
PASS: empty.bz2
PASS: incomp-1.bz2
PASS: gap.bz2
PASS: incomp-2.bz2
PASS: load0.bz2
PASS: overrun.bz2
PASS: overrun2.bz2
PASS: rand.bz2
PASS: repet.bz2
PASS: trash.bz2
PASS: void.bz2
PASS: fib.bz2
PASS: ch255.bz2
gmake[4]: Entering directory '/var/tmp/portage/app-arch/lbzip2-2.5/work/lbzip2-2.5_build/tests'
gmake[4]: Nothing to be done for 'all'.
gmake[4]: Leaving directory '/var/tmp/portage/app-arch/lbzip2-2.5/work/lbzip2-2.5_build/tests'
============================================================================
Testsuite summary for lbzip2 2.5
============================================================================
# TOTAL: 20
# PASS:  20
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
