### PR TITLE
profiles/default/bsd/fbsd/x86/10.3/make.defaults: add CHOST_x86_fbsd.

### DIFF
--- a/profiles/default/bsd/fbsd/x86/10.3/make.defaults
+++ b/profiles/default/bsd/fbsd/x86/10.3/make.defaults
@@ -2,4 +2,5 @@
 # Distributed under the terms of the GNU General Public License, v2
 # $Id$
 
-CHOST="i486-gentoo-freebsd10.3"
+CHOST="i686-gentoo-freebsd10.3"
+CHOST_x86_fbsd="i686-gentoo-freebsd10.3"


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=596430