### PR TITLE
sys-devel/clang-runtime: add ~amd64-fbsd, ~x86-fbsd KEYWORDS

### DIFF
--- a/sys-devel/clang-runtime/clang-runtime-3.9.0.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-3.9.0.ebuild
@@ -10,7 +10,7 @@ SRC_URI=""
 
 LICENSE="metapackage"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="libcxx openmp"
 
 # compiler-rt is installed unconditionally


### PR DESCRIPTION
Fixed an issue of dependency

```
# emerge -pv sys-devel/llvm
!!! SYNC setting found in make.conf.
    This setting is Deprecated and no longer used.  Please ensure your 'sync-type' and 'sync-uri' are set correctly in /etc/portage/repos.conf/gentoo.conf

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild  N    #] sys-devel/clang-runtime-3.9.0::gentoo  USE="-libcxx -openmp" 0 KiB
[ebuild  N     ] dev-util/re2c-0.16::gentoo  0 KiB
[ebuild  N     ] dev-util/ninja-1.7.1::gentoo  USE="-doc -emacs {-test} -vim-syntax -zsh-completion" 0 KiB
[ebuild  N     ] net-misc/curl-7.50.3::gentoo  USE="ipv6 ssl -adns -http2 -idn (-kerberos) -ldap -metalink -rtmp -samba -ssh -static-libs {-test} -threads" CURL_SSL="openssl -axtls -gnutls -libressl -mbedtls -nss -polarssl (-winssl)" 0 KiB
[ebuild  N     ] dev-util/cmake-3.6.2::gentoo  USE="ncurses -doc -emacs -qt4 (-qt5) -system-jsoncpp {-test}" 0 KiB
[ebuild  N    #] sys-devel/llvm-3.9.0:0/3.9.0::gentoo  USE="(clang) libffi ncurses sanitize static-analyzer -debug -default-compiler-rt -default-libcxx -doc -gold -libedit (-lldb) -multitarget -ocaml -python {-test} -xml" LLVM_TARGETS="BPF (X86) -AArch64 -AMDGPU -ARM -Hexagon -MSP430 -Mips -NVPTX -PowerPC -Sparc -SystemZ -XCore" PYTHON_TARGETS="python2_7" 0 KiB
[ebuild  N    #] sys-devel/clang-3.9.0-r100:0/3.9.0::gentoo  USE="static-analyzer -debug -multitarget -python" LLVM_TARGETS="BPF (X86) -AArch64 -AMDGPU -ARM -Hexagon -MSP430 -Mips -NVPTX -PowerPC -Sparc -SystemZ -XCore" 0 KiB

Total: 7 packages (7 new), Size of downloads: 0 KiB

The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by sys-devel/llvm-3.9.0::gentoo
# required by sys-devel/clang-3.9.0-r100::gentoo
=sys-devel/clang-runtime-3.9.0 **
```