### PR TITLE
sys-apps/systemd: Raise libseccomp min. version dependency

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -55,7 +55,7 @@ COMMON_DEPEND=">=sys-apps/util-linux-2.27.1:0=[${MULTILIB_USEDEP}]
 	nat? ( net-firewall/iptables:0= )
 	pam? ( virtual/pam:= )
 	qrcode? ( media-gfx/qrencode:0= )
-	seccomp? ( sys-libs/libseccomp:0= )
+	seccomp? ( >=sys-libs/libseccomp-2.3.1:0= )
 	selinux? ( sys-libs/libselinux:0= )
 	sysv-utils? (
 		!sys-apps/systemd-sysv-utils


### PR DESCRIPTION
As of [6abfd30372](https://github.com/systemd/systemd/commit/6abfd30372) (upcoming release 232), systemd requires
`>=sys-apps/libseccomp-2.3.1`

Package-Manager: portage-2.3.0