### PR TITLE
media-libs/openexr: revision bump to fix various compiling errors and unmask

### DIFF
--- a/media-libs/openexr/files/openexr-2.2.0-fix-cpuid-on-abi_x86_32.patch
+++ b/media-libs/openexr/files/openexr-2.2.0-fix-cpuid-on-abi_x86_32.patch
@@ -1,0 +1,63 @@
+diff -Naur a/IlmImf/ImfSystemSpecific.cpp b/IlmImf/ImfSystemSpecific.cpp
+--- a/IlmImf/ImfSystemSpecific.cpp	2016-06-14 01:19:15.070511555 +0930
++++ b/IlmImf/ImfSystemSpecific.cpp	2016-06-14 01:36:08.776496862 +0930
+@@ -35,6 +35,7 @@
+ #include "ImfSystemSpecific.h"
+ #include "ImfNamespace.h"
+ #include "OpenEXRConfig.h"
++#include <cpuid.h>
+ 
+ OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
+ 
+@@ -42,19 +43,15 @@
+ #if defined(IMF_HAVE_SSE2) &&  defined(__GNUC__)
+ 
+     // Helper functions for gcc + SSE enabled
+-    void cpuid(int n, int &eax, int &ebx, int &ecx, int &edx)
++    void cpuid(unsigned int n, unsigned int &eax, unsigned int &ebx, unsigned int &ecx, unsigned int &edx)
+     {
+-        __asm__ __volatile__ (
+-            "cpuid"
+-            : /* Output  */ "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) 
+-            : /* Input   */ "a"(n)
+-            : /* Clobber */);
++	__get_cpuid(n, &eax, &ebx, &ecx, &edx );
+     }
+ 
+ #else // IMF_HAVE_SSE2 && __GNUC__
+ 
+     // Helper functions for generic compiler - all disabled
+-    void cpuid(int n, int &eax, int &ebx, int &ecx, int &edx)
++    void cpuid(unsigned int n, unsigned int &eax, unsigned int &ebx, unsigned int &ecx, unsigned int &edx)
+     {
+         eax = ebx = ecx = edx = 0;
+     }
+@@ -64,7 +61,7 @@
+ 
+ #ifdef OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX
+ 
+-    void xgetbv(int n, int &eax, int &edx)
++    void xgetbv(unsigned int n, unsigned int &eax, unsigned int &edx)
+     {
+         __asm__ __volatile__ (
+             "xgetbv"
+@@ -75,7 +72,7 @@
+ 
+ #else //  OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX
+ 
+-    void xgetbv(int n, int &eax, int &edx)
++    void xgetbv(unsigned int n, unsigned int &eax, unsigned int &edx)
+     {
+         eax = edx = 0;
+     }
+@@ -94,8 +91,8 @@
+     f16c(false)
+ {
+     bool osxsave = false;
+-    int  max     = 0;
+-    int  eax, ebx, ecx, edx;
++    unsigned int  max     = 0;
++    unsigned int  eax, ebx, ecx, edx;
+ 
+     cpuid(0, max, ebx, ecx, edx);
+     if (max > 0)

--- a/media-libs/openexr/files/openexr-2.2.0-use-ull-for-64-bit-literals.patch
+++ b/media-libs/openexr/files/openexr-2.2.0-use-ull-for-64-bit-literals.patch
@@ -1,0 +1,60 @@
+From 57ecf581d053f5cacf2e8fc3c024490e0bbe536f Mon Sep 17 00:00:00 2001
+From: Brendan Bolles <brendan@fnordware.com>
+Date: Wed, 13 Aug 2014 19:54:10 -0700
+Subject: [PATCH] Use ULL for 64-bit literals
+
+On a 32-bit architecture, these literals are too big for just a long,
+they need to be ULL, since Int64 is unsigned.
+---
+ IlmImf/ImfFastHuf.cpp | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/IlmImf/ImfFastHuf.cpp b/IlmImf/ImfFastHuf.cpp
+index 86c84dc..01edad4 100644
+--- a/IlmImf/ImfFastHuf.cpp
++++ b/IlmImf/ImfFastHuf.cpp
+@@ -107,7 +107,7 @@ FastHufDecoder::FastHufDecoder
+     for (int i = 0; i <= MAX_CODE_LEN; ++i)
+     {
+         codeCount[i] = 0;
+-        base[i]      = 0xffffffffffffffffL;
++        base[i]      = 0xffffffffffffffffULL;
+         offset[i]    = 0;
+     }
+ 
+@@ -352,7 +352,7 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
+ 
+     for (int i = 0; i <= MAX_CODE_LEN; ++i)
+     {
+-        if (base[i] != 0xffffffffffffffffL)
++        if (base[i] != 0xffffffffffffffffULL)
+         {
+             _ljBase[i] = base[i] << (64 - i);
+         }
+@@ -362,7 +362,7 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
+             // Unused code length - insert dummy values
+             //
+ 
+-            _ljBase[i] = 0xffffffffffffffffL;
++            _ljBase[i] = 0xffffffffffffffffULL;
+         }
+     }
+ 
+@@ -417,7 +417,7 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
+ 
+     int minIdx = TABLE_LOOKUP_BITS;
+ 
+-    while (minIdx > 0 && _ljBase[minIdx] == 0xffffffffffffffffL)
++    while (minIdx > 0 && _ljBase[minIdx] == 0xffffffffffffffffULL)
+         minIdx--;
+ 
+     if (minIdx < 0)
+@@ -427,7 +427,7 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
+         // Set the min value such that the table is never tested.
+         //
+ 
+-        _tableMin = 0xffffffffffffffffL;
++        _tableMin = 0xffffffffffffffffULL;
+     }
+     else
+     {

--- a/media-libs/openexr/openexr-2.2.0-r1.ebuild
+++ b/media-libs/openexr/openexr-2.2.0-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit multilib-minimal
+
+DESCRIPTION="ILM's OpenEXR high dynamic-range image file format libraries"
+HOMEPAGE="http://openexr.com/"
+SRC_URI="http://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/22" # based on SONAME
+KEYWORDS="~amd64 -arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="examples static-libs"
+
+RDEPEND=">=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]
+	>=media-libs/ilmbase-${PV}:=[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	!!<media-libs/${P}"
+
+DOCS=( AUTHORS ChangeLog NEWS README )
+
+PATCHES=( "${FILESDIR}"/${P}-fix-cpuid-on-abi_x86_32.patch
+	  "${FILESDIR}"/${P}-use-ull-for-64-bit-literals.patch )
+
+src_prepare() {
+	# Fix path for testsuite
+	sed -i -e "s:/var/tmp/:${T}:" IlmImfTest/tmpDir.h || die
+	default
+}
+
+multilib_src_configure() {
+	local myconf=(
+		$(use_enable static-libs static)
+		$(use_enable examples imfexamples)
+	)
+	# Enable building out-of-source using sources in ${S}
+	ECONF_SOURCE=${S} \
+	econf "${myconf[@]}"
+}
+
+multilib_src_install() {
+	emake install DESTDIR="${D}" \
+		docdir="${EPREFIX}"/usr/share/doc/${PF}/pdf \
+		examplesdir="${EPREFIX}"/usr/share/doc/${PF}/examples
+}
+
+multilib_src_install_all() {
+	docompress -x /usr/share/doc/${PF}/examples
+	if ! use examples; then
+		rm -rf "${ED}"/usr/share/doc/${PF}/examples || die
+	fi
+	einstalldocs
+}

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -845,13 +845,6 @@ dev-python/south
 # please file a separate bug report
 <net-dialup/ppp-2.4.7
 
-# Samuli Suominen <ssuominen@gentoo.org> (23 Aug 2014)
-# Some compile problems with media-libs/openexr >= 2.2.0
-# See https://bugs.gentoo.org/520240 for more information
->=media-libs/ilmbase-2.2.0
->=media-libs/openexr-2.2.0
->=media-gfx/openexr_viewers-2.2.0
-
 # Robin H. Johnson <robbat2@gentoo.org> (04 Aug 2014)
 # Masked for testing, presently fails upstream testsuite:
 # FAIL:07:02:35 (00:00:00) db_dump/db_load(./TESTDIR.3/recd001.db:child killed: kill signal): expected 0, got 1


### PR DESCRIPTION
- Force uninstall because it tries to link against previously
  installed versions.
- Patch to fix 32 bit building.

The showstopper bug is worked around with openexr-2.2.0-r1, so let's
get this unmasked as new programs depend on this version.

Gentoo-Bug: 585846
Gentoo-Bug: 520648

Signed off by: Jonathan Scruggs (j.scruggs@gmail.com, irc: Dracwyrm)

@gentoo/media-video

NOTES: Compile tested on an unstable 64 bit only system and a stable system in a VM with ABI_X86="64 32" set -- OpenEXR was unmasked and compiled against the stable versions of depends.

