### PR TITLE
net-libs/c-client: use epatch for a gzipped patch

### DIFF
--- a/net-libs/c-client/c-client-2007f-r5.ebuild
+++ b/net-libs/c-client/c-client-2007f-r5.ebuild
@@ -76,7 +76,7 @@ src_prepare() {
 		-i src/osdep/unix/Makefile || die "Respecting build flags"
 
 	use topal && eapply "${FILESDIR}/${P}-topal.patch"
-	use chappa && eapply "${DISTDIR}/${P}-chappa-${CHAPPA_PL}-all.patch.gz"
+	use chappa && epatch "${DISTDIR}/${P}-chappa-${CHAPPA_PL}-all.patch.gz"
 
 	elibtoolize
 }


### PR DESCRIPTION
eapply supports only plaintext patches, so this causes the build to fail with USE +chappa