### PR TITLE
net-wireless/rfkill: remove git polling

### DIFF
--- a/net-wireless/rfkill/rfkill-0.5-r1.ebuild
+++ b/net-wireless/rfkill/rfkill-0.5-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit toolchain-funcs
+
+DESCRIPTION="Tool to read and control rfkill status through /dev/rfkill"
+HOMEPAGE="https://wireless.kernel.org/en/users/Documentation/rfkill"
+SRC_URI="https://www.kernel.org/pub/software/network/${PN}/${P}.tar.xz"
+
+LICENSE="ISC"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
+IUSE=""
+
+RDEPEND=""
+DEPEND=""
+
+src_prepare() {
+	default
+
+	sed -i "s|^SUFFIX=$|SUFFIX=-${PR}|" version.sh
+}
+
+src_compile() {
+	emake CC=$(tc-getCC) LD=$(tc-getLD) V=1 || die "Failed to compile"
+}
+
+src_install() {
+	emake install V=1 DESTDIR="${D}" || die "Failed to install"
+}


### PR DESCRIPTION
`net-wireless/rfkill` tries to get the git commit in use while building. By specifing a suffix (PR in this case) in `version.sh`, it works.

Rev bump may be unnecessary, because it doesn't change something to the final binary, except the version number.
