### PR TITLE
dev-db/postgis: fix URL of online manual in elog

### DIFF
--- a/dev-db/postgis/postgis-2.2.2.ebuild
+++ b/dev-db/postgis/postgis-2.2.2.ebuild
@@ -141,5 +141,5 @@ pkg_postinst() {
 	postgresql-config update
 
 	elog "To finish installing PostGIS, follow the directions detailed at:"
-	elog "http://postgis.net/docs/manual-${MY_PV}/postgis_installation.html#create_new_db_extensions"
+	elog "http://postgis.net/docs/manual-${PGIS}/postgis_installation.html#create_new_db_extensions"
 }


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/573812

Package-Manager: portage-2.3.0