### PR TITLE
sys-apps/ifplugd: revision bump

### DIFF
--- a/sys-apps/ifplugd/files/ifplugd-0.28-interface.patch
+++ b/sys-apps/ifplugd/files/ifplugd-0.28-interface.patch
@@ -1,5 +1,5 @@
---- src/interface.c	2004/12/19 00:08:01	114
-+++ src/interface.c	2006/03/07 13:15:11	133
+--- a/src/interface.c	2004/12/19 00:08:01	114
++++ b/src/interface.c	2006/03/07 13:15:11	133
 @@ -22,9 +22,9 @@
  #include <config.h>
  #endif

--- a/sys-apps/ifplugd/files/ifplugd-0.28-musl.patch
+++ b/sys-apps/ifplugd/files/ifplugd-0.28-musl.patch
@@ -1,0 +1,19 @@
+--- a/src/ethtool-local.h
++++ b/src/ethtool-local.h
+@@ -21,10 +21,12 @@
+  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+  */
+ 
+-typedef unsigned long long u64;
+-typedef __uint32_t u32;        
+-typedef __uint16_t u16;        
+-typedef __uint8_t u8;          
++#include <stdint.h>
++
++typedef uint64_t u64;
++typedef uint32_t u32;
++typedef uint16_t u16;
++typedef uint8_t u8;
+ 
+ #include "ethtool-kernel.h"
+ 

--- a/sys-apps/ifplugd/files/ifplugd-0.28-nlapi.diff
+++ b/sys-apps/ifplugd/files/ifplugd-0.28-nlapi.diff
@@ -1,6 +1,6 @@
 diff -urN src/nlapi.c src/nlapi.c
---- src/nlapi.c	2004-12-20 08:39:14.682706517 -0500
-+++ src/nlapi.c	2004-12-20 08:39:50.185734092 -0500
+--- a/src/nlapi.c	2004-12-20 08:39:14.682706517 -0500
++++ b/src/nlapi.c	2004-12-20 08:39:50.185734092 -0500
 @@ -86,7 +86,7 @@
          for (; bytes > 0; p = NLMSG_NEXT(p, bytes)) {
              struct callback_info *c;

--- a/sys-apps/ifplugd/files/ifplugd-0.28-strictalias.patch
+++ b/sys-apps/ifplugd/files/ifplugd-0.28-strictalias.patch
@@ -1,5 +1,5 @@
---- src/interface.c.orig	2007-03-23 13:29:40.000000000 +0000
-+++ src/interface.c	2007-03-23 13:30:05.000000000 +0000
+--- a/src/interface.c.orig	2007-03-23 13:29:40.000000000 +0000
++++ b/src/interface.c	2007-03-23 13:30:05.000000000 +0000
 @@ -89,6 +89,10 @@
  
  interface_status_t interface_detect_beat_mii(int fd, char *iface) {

--- a/sys-apps/ifplugd/ifplugd-0.28-r10.ebuild
+++ b/sys-apps/ifplugd/ifplugd-0.28-r10.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+DESCRIPTION="Brings up/down ethernet ports automatically with cable detection"
+HOMEPAGE="http://0pointer.de/lennart/projects/ifplugd/"
+SRC_URI="http://0pointer.de/lennart/projects/ifplugd/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~arm ~amd64 ~hppa ~ppc ~x86"
+IUSE="doc selinux"
+
+DEPEND="virtual/pkgconfig
+	doc? ( www-client/lynx )
+	>=dev-libs/libdaemon-0.5"
+RDEPEND=">=dev-libs/libdaemon-0.5
+	>=sys-apps/baselayout-1.12
+	selinux? ( sec-policy/selinux-ifplugd )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-nlapi.diff"
+	"${FILESDIR}/${P}-interface.patch"
+	"${FILESDIR}/${P}-strictalias.patch"
+	"${FILESDIR}/${P}-noip.patch"
+	"${FILESDIR}/${P}-musl.patch"
+	)
+DOCS=( doc/README doc/SUPPORTED_DRIVERS )
+HTML_DOCS=( doc/README.html doc/style.css )
+
+src_configure() {
+	econf \
+		$(use_enable doc lynx) \
+		--with-initdir=/etc/init.d \
+		--disable-xmltoman \
+		--disable-subversion
+}
+
+src_install() {
+	default
+
+	# Remove init.d configuration as we no longer use it
+	rm -rf "${ED}/etc/ifplugd" "${ED}/etc/init.d/${PN}" || die
+
+	exeinto "/etc/${PN}"
+	newexe "${FILESDIR}/${PN}.action" "${PN}.action"
+}


### PR DESCRIPTION
the pkg_postinst is deleted since it seems that the upstream init script has not been used after 2009, and the einfo is also inaccurate.