### PR TITLE
sys-freebsd: Fix FreeBSD 11.0 ebuilds.

### DIFF
--- a/sys-freebsd/freebsd-sources/freebsd-sources-11.0.ebuild
+++ b/sys-freebsd/freebsd-sources/freebsd-sources-11.0.ebuild
@@ -136,7 +136,7 @@ src_install() {
 
 	insinto "/usr/src/sys"
 	doins -r "${S}/".
-	if use zfs ; then
+	if use dtrace ; then
 		insinto "/usr/src/cddl"
 		doins -r "${WORKDIR}/cddl/".
 	fi

--- a/sys-freebsd/freebsd-ubin/freebsd-ubin-11.0.ebuild
+++ b/sys-freebsd/freebsd-ubin/freebsd-ubin-11.0.ebuild
@@ -144,13 +144,14 @@ setup_multilib_vars() {
 }
 
 src_compile() {
+	local MULTIBUILD_VARIANTS="${DEFAULT_ABI}"
 	# Preparing to build addr2line, elfcopy, m4
 	for dir in libelftc libpe libopenbsd ; do
 		cd "${WORKDIR}/lib/${dir}" || die
-		freebsd_src_compile -j1
+		multibuild_foreach_variant freebsd_multilib_multibuild_wrapper freebsd_src_compile -j1
 	done
 
-	local MULTIBUILD_VARIANTS=( $(multilib_get_enabled_abis) )
+	MULTIBUILD_VARIANTS=( $(multilib_get_enabled_abis) )
 	multibuild_foreach_variant freebsd_multilib_multibuild_wrapper setup_multilib_vars freebsd_src_compile -j1
 }
 


### PR DESCRIPTION
Fix following errors.

freebsd-sources
```
install: /var/tmp/portage/sys-freebsd/freebsd-sources-11.0/work/cddl/.: No such file or directory
!!! doins: /var/tmp/portage/sys-freebsd/freebsd-sources-11.0/work/cddl/. does not exist
```

freebsd-ubin

```
x86_64-gentoo-freebsd10.0-gcc -O2 -pipe -DEXTENDED -I/var/tmp/portage/sys-freebsd/freebsd-ubin-11.0/work/usr.bin/m4 -I/var/tmp/portage/sys-freebsd/freebsd-ubin-11.0/work/usr.bin/m4/../../lib/libopenbsd -std=gnu99 -fstack-protector-strong -Wsystem-headers -Wall -Wno-format-y2k -W -Wno-unused-parameter -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wno-uninitialized -Wno-pointer-sign -Wno-error=unused-function -Wno-error=enum-compare -Wno-error=logical-not-parentheses -Wno-error=bool-compare -Wno-error=uninitialized -Wno-error=array-bounds -Wno-error=clobbered -Wno-error=cast-align -Wno-error=extra -Wno-error=attributes -Wno-error=inline -Wno-error=unused-but-set-variable -Wno-error=unused-value -Wno-error=strict-aliasing -Wno-error=address  -o m4 eval.o expr.o look.o main.o misc.o gnum4.o trace.o parser.o tokenizer.o    -ly -lfl  -lm -L/var/tmp/portage/sys-freebsd/freebsd-ubin-11.0/work/usr.bin-amd64_fbsd/var/tmp/portage/sys-freebsd/freebsd-ubin-11.0/work/lib/libopenbsd -lopenbsd
/usr/lib/gcc/x86_64-gentoo-freebsd10.0/5.3.0/../../../../x86_64-gentoo-freebsd10.0/bin/ld: cannot find -lopenbsd
collect2: error: ld returned 1 exit status
*** [m4] Error code 1

make[1]: stopped in /var/tmp/portage/sys-freebsd/freebsd-ubin-11.0/work/usr.bin/m4
1 error
```