### PR TITLE
toolchain-funcs.eclass: Add tc-check-openmp() function

### DIFF
--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -421,6 +421,27 @@ tc-has-openmp() {
 	return ${ret}
 }
 
+# @FUNCTION: tc-check-openmp
+# @DESCRIPTION:
+# Test for OpenMP support with the current compiler and error out with
+# a clear error message, telling the user how to rectify the missing
+# OpenMP support that has been requested by the ebuild. Using this function
+# to test for OpenMP support should be preferred over tc-has-openmp and
+# printing a custom message, as it presents a uniform interface to the user.
+tc-check-openmp() {
+	if ! tc-has-openmp; then
+		eerror "Your current compiler does not support OpenMP!"
+
+		if tc-is-gcc; then
+			eerror "Enable OpenMP support by building sys-devel/gcc with USE=\"openmp\"."
+		elif tc-is-clang; then
+			eerror "OpenMP support in sys-devel/clang is provided by sys-libs/libomp."
+		fi
+
+		die "Active compiler does not have required support for OpenMP"
+	fi
+}
+
 # @FUNCTION: tc-has-tls
 # @USAGE: [-s|-c|-l] [toolchain prefix]
 # @DESCRIPTION:


### PR DESCRIPTION
Add a new function that can be used in `pkg_setup` and `pkg_pretend` to check for and fail with missing OpenMP support. This function provides a uniform interface, and gives better advice for missing support, and accounts for Clang, which pretty much no OpenMP check in the tree currently does.