### PR TITLE
x11-misc/x11vnc: Fix libvncserver USE flag dependencies

### DIFF
--- a/x11-misc/x11vnc/x11vnc-0.9.13_p20150111-r1.ebuild
+++ b/x11-misc/x11vnc/x11vnc-0.9.13_p20150111-r1.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 		!libressl? ( dev-libs/openssl:0= )
 		libressl? ( dev-libs/libressl:= )
 	)
-	>=net-libs/libvncserver-0.9.8
+	>=net-libs/libvncserver-0.9.8[ssl=]
 	xinerama? ( x11-libs/libXinerama )"
 DEPEND="${RDEPEND}
 	x11-libs/libXt

--- a/x11-misc/x11vnc/x11vnc-0.9.13_p20150111.ebuild
+++ b/x11-misc/x11vnc/x11vnc-0.9.13_p20150111.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	>=x11-libs/libXtst-1.1.0
 	avahi? ( >=net-dns/avahi-0.6.4 )
 	ssl? ( dev-libs/openssl:= )
-	>=net-libs/libvncserver-0.9.8
+	>=net-libs/libvncserver-0.9.8[ssl=]
 	xinerama? ( x11-libs/libXinerama )"
 DEPEND="${RDEPEND}
 	x11-libs/libXt

--- a/x11-misc/x11vnc/x11vnc-0.9.13_p20150627.ebuild
+++ b/x11-misc/x11vnc/x11vnc-0.9.13_p20150627.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="avahi crypt fbcon libressl ssl xinerama"
 
-RDEPEND=">=net-libs/libvncserver-0.9.8
+RDEPEND=">=net-libs/libvncserver-0.9.8[ssl=]
 		x11-libs/libX11
 		x11-libs/libXdamage
 		x11-libs/libXext

--- a/x11-misc/x11vnc/x11vnc-0.9.14.ebuild
+++ b/x11-misc/x11vnc/x11vnc-0.9.14.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="crypt fbcon libressl ssl xinerama zeroconf"
 
-RDEPEND=">=net-libs/libvncserver-0.9.8
+RDEPEND=">=net-libs/libvncserver-0.9.8[ssl=]
 	x11-libs/libX11
 	x11-libs/libXdamage
 	x11-libs/libXext


### PR DESCRIPTION
This pull request attempts to fix two issues:
- x11vnc requires libvncserver to be built with pthread support ([Gentoo bug 550916](https://bugs.gentoo.org/show_bug.cgi?id=550916)).  This fix is not required for `x11vnc-0.9.13_p20150627.ebuild` as the `-pthread` flag is coincidentally added by LibVNC/x11vnc@af7d19f (which in turn is reverted by LibVNC/x11vnc@02660c5, which is why version 0.9.14 also needs this fix).
- To detect whether SSL support should be disabled, x11vnc does not rely solely on `--without-{ssl,crypto}` configure switches, but instead also checks whether libvncserver was compiled with SSL support (this is done in multiple locations in `sslhelper.c`, e.g. on [line 689](https://github.com/LibVNC/x11vnc/blob/0.9.14/src/sslhelper.c#L689)).  This is obviously preposterous, but can be worked around by forcing the `ssl` USE flag for libvncserver to be set to the same value as for x11vnc.  To reproduce the issue, emerge libvncserver with `+ssl` and then try building x11vnc with `-ssl`; the build will fail with the error message `/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/../../../../x86_64-pc-linux-gnu/bin/ld: x11vnc-sslhelper.o: undefined reference to symbol 'SSL_CTX_ctrl'`.

/cc @Hello71 (proxy maintainer)
