### PR TITLE
Fix bug# 596904 and update ebuild to use EAPI 6

### DIFF
--- a/dev-libs/beecrypt/beecrypt-4.2.1-r4.ebuild
+++ b/dev-libs/beecrypt/beecrypt-4.2.1-r4.ebuild
@@ -1,0 +1,89 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils multilib autotools java-pkg-opt-2 python-single-r1
+
+DESCRIPTION="general-purpose cryptography library"
+HOMEPAGE="https://sourceforge.net/projects/beecrypt/"
+SRC_URI="mirror://sourceforge/beecrypt/${P}.tar.gz"
+
+LICENSE="GPL-2 LGPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ~ia64 ppc ~ppc64 ~s390 ~sh ~sparc x86 ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos"
+IUSE="+threads java cxx python static-libs doc"
+
+COMMONDEPEND="!<app-arch/rpm-4.2.1
+	cxx? ( >=dev-libs/icu-2.8:= )
+	python? ( ${PYTHON_DEPS} )"
+
+DEPEND="${COMMONDEPEND}
+	java? ( >=virtual/jdk-1.4 )
+	doc? ( app-doc/doxygen
+		virtual/latex-base
+		dev-texlive/texlive-fontsextra
+	)"
+RDEPEND="${COMMONDEPEND}
+	java? ( >=virtual/jre-1.4 )"
+
+DOCS="BUGS README BENCHMARKS NEWS"
+
+REQUIRED_USE="cxx? ( threads )
+	python? ( ${PYTHON_REQUIRED_USE} )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-build-system.patch
+	"${FILESDIR}"/${P}-gcc-4.7.patch
+
+	#Fixes bug 596904
+	"${FILESDIR}"/${P}-c++11-allow-throw-in-destructors.patch
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+	use java && java-pkg-opt-2_pkg_setup
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# cpluscplus needs threads support
+	econf \
+		--disable-expert-mode \
+		$(use_enable static-libs static) \
+		$(use_enable threads) \
+		$(use_with python python "${PYTHON}") \
+		$(use_with cxx cplusplus) \
+		$(use_with java)
+}
+
+src_compile() {
+	default
+
+	if use doc; then
+		cd include/beecrypt || die
+		doxygen || die "doxygen failed"
+	fi
+}
+
+src_test() {
+	export BEECRYPT_CONF_FILE="${T}/beecrypt-test.conf"
+	echo "provider.1=${S}/c++/provider/.libs/base.so" > "${BEECRYPT_CONF_FILE}"
+	emake check
+	emake bench
+}
+
+src_install() {
+	use doc && HTML_DOCS=( docs/html/. )
+	default
+	use python && rm -f "${D%/}$(python_get_sitedir)"/_bc.*a
+
+	use static-libs || find "${ED}" -name '*.la' -delete
+}

--- a/dev-libs/beecrypt/files/beecrypt-4.2.1-c++11-allow-throw-in-destructors.patch
+++ b/dev-libs/beecrypt/files/beecrypt-4.2.1-c++11-allow-throw-in-destructors.patch
@@ -1,0 +1,26 @@
+--- beecrypt-4.2.1/include/beecrypt/c++/lang/Object.h.old	2016-10-12 18:40:10.878868563 -0400
++++ beecrypt-4.2.1/include/beecrypt/c++/lang/Object.h	2016-10-12 19:17:22.508857979 -0400
+@@ -145,7 +145,11 @@
+ 					waiter*       prev;
+ 
+ 					waiter(bc_threadid_t owner, unsigned int lock_count);
++#if __cplusplus < 201103L
+ 					~waiter();
++#else
++					~waiter() noexcept(false);
++#endif
+ 				};
+ 
+ 				waiter* _lock_head;
+--- beecrypt-4.2.1/c++/lang/Object.cxx.old	2016-10-12 18:40:39.024665316 -0400
++++ beecrypt-4.2.1/c++/lang/Object.cxx	2016-10-12 19:14:41.630529720 -0400
+@@ -767,6 +767,9 @@
+ }
+ 
+ Object::FairMonitor::waiter::~waiter()
++#if __cplusplus >= 201103L
++noexcept(false)
++#endif
+ {
+ 	#if WIN32
+ 	if (!CloseHandle(event))

--- a/dev-libs/beecrypt/files/beecrypt-4.2.1-gcc-4.7.patch
+++ b/dev-libs/beecrypt/files/beecrypt-4.2.1-gcc-4.7.patch
@@ -1,5 +1,5 @@
---- include/beecrypt/c++/util/AbstractSet.h
-+++ include/beecrypt/c++/util/AbstractSet.h
+--- a/include/beecrypt/c++/util/AbstractSet.h
++++ b/include/beecrypt/c++/util/AbstractSet.h
 @@ -56,7 +56,7 @@
  					if (c->size() != size())
  						return false;


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=596904 and updates the package to use EAPI 6.