### PR TITLE
dev-libs/glib: Adding $(get_exeext) to MULTILIB_CHOST_TOOLS

### DIFF
--- a/dev-libs/glib/glib-2.48.2.ebuild
+++ b/dev-libs/glib/glib-2.48.2.ebuild
@@ -68,7 +68,7 @@ PDEPEND="!<gnome-base/gvfs-1.6.4-r990
 # Earlier versions of gvfs do not work with glib
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gio-querymodules
+	/usr/bin/gio-querymodules$(get_exeext)
 )
 
 pkg_setup() {

--- a/dev-libs/glib/glib-2.50.0.ebuild
+++ b/dev-libs/glib/glib-2.50.0.ebuild
@@ -68,7 +68,7 @@ PDEPEND="!<gnome-base/gvfs-1.6.4-r990
 # Earlier versions of gvfs do not work with glib
 
 MULTILIB_CHOST_TOOLS=(
-	/usr/bin/gio-querymodules
+	/usr/bin/gio-querymodules$(get_exeext)
 )
 
 pkg_setup() {


### PR DESCRIPTION
Gentoo-bug: https://bugs.gentoo.org/show_bug.cgi?id=588330

Package-Manager: portage-2.3.0