### PR TITLE
net-misc/connman: add keepdir call

### DIFF
--- a/net-misc/connman/connman-1.33-r1.ebuild
+++ b/net-misc/connman/connman-1.33-r1.ebuild
@@ -76,6 +76,7 @@ src_install() {
 	if use doc; then
 		dodoc doc/*.txt
 	fi
+	keepdir /usr/lib/${PN}/scripts
 	keepdir /var/lib/${PN}
 	newinitd "${FILESDIR}"/${PN}.initd2 ${PN}
 	newconfd "${FILESDIR}"/${PN}.confd ${PN}


### PR DESCRIPTION
Add a keepdir for /usr/lib/connman/scripts.  If none of connman's
scripts are installed, upstream's build system will create and install
an empty directory.

Gentoo-bug: 596874

Package-Manager: portage-2.3.2