### PR TITLE
Update cvc3 to EAPI 6 and add a patch to fix gcc 6

### DIFF
--- a/sci-mathematics/cvc3/cvc3-2.4.1-r1.ebuild
+++ b/sci-mathematics/cvc3/cvc3-2.4.1-r1.ebuild
@@ -1,0 +1,146 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+inherit elisp-common
+
+DESCRIPTION="CVC3 is a theorem prover for Satisfiability Modulo Theories (SMT) problems"
+HOMEPAGE="http://www.cs.nyu.edu/acsys/cvc3/index.html"
+SRC_URI="http://www.cs.nyu.edu/acsys/cvc3/releases/2.4.1/${P}.tar.gz"
+
+LICENSE="BSD MIT HPND zchaff? ( zchaff )"
+RESTRICT="mirror zchaff? ( bindist )"
+SLOT="0/${PV}"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc emacs isabelle test zchaff"
+
+RDEPEND="dev-libs/gmp:0=
+		isabelle? (
+			>=sci-mathematics/isabelle-2011.1-r1:=
+		)"
+DEPEND="${RDEPEND}
+		doc? (
+			app-doc/doxygen
+			media-gfx/graphviz
+		)
+		emacs? (
+			virtual/emacs
+		)"
+
+SITEFILE=50${PN}-gentoo.el
+
+src_prepare() {
+	sed -e 's#prefix=@prefix@#prefix=$(patsubst %/,%,$(DESTDIR))@prefix@#' \
+		-e 's#libdir=@libdir@#libdir=$(patsubst %/,%,$(DESTDIR))@libdir@#' \
+		-e 's#mandir=@mandir@#mandir=$(patsubst %/,%,$(DESTDIR))@mandir@#' \
+		-i "${S}/Makefile.local.in" \
+		|| die "Could not set DESTDIR in Makefile.local.in"
+
+	default
+}
+
+src_configure() {
+	# --enable-static disables building of shared libraries, statically
+	# links /usr/bin/cvc3 and installs static libraries.
+	# --enable-static --enable-sharedlibs behaves the same as just --enable-static
+	econf \
+		--enable-dynamic \
+		$(use_enable zchaff)
+
+	if use test; then
+		sed -e 's@LD_LIBS = @LD_LIBS = -L'"${S}"'/lib -Wl,-R'"${S}"'/lib @' \
+			-i "${S}/test/Makefile" \
+			|| die "Could not set library paths in test/Makefile"
+	fi
+}
+
+src_compile() {
+	emake
+
+	if use doc; then
+		emake -C doc
+	fi
+
+	if use emacs ; then
+		pushd "${S}/emacs" || die "Couldn't change directory to emacs"
+		elisp-compile *.el || die "emacs elisp compile failed"
+		popd >/dev/null || die "Failed to reverse directory change"
+	fi
+
+	if use test; then
+		emake -C test
+	fi
+}
+
+src_test() {
+	pushd test || die "Could not cd to test"
+	./bin/test || die "tests failed"
+	popd
+}
+
+src_install() {
+	use doc && local HTML_DOCS=( doc/html/*.{html,gif,png,css} )
+	default
+
+	if use emacs ; then
+		elisp-install ${PN} emacs/*.{el,elc}
+		cp "${FILESDIR}"/${SITEFILE} "${S}" || die "Failed to copy Emacs files"
+		elisp-site-file-install ${SITEFILE}
+	fi
+
+	if use isabelle; then
+		ISABELLE_HOME="$(isabelle getenv ISABELLE_HOME | cut -d'=' -f 2)" \
+			|| die "isabelle getenv ISABELLE_HOME failed"
+		[[ -n "${ISABELLE_HOME}" ]] || die "ISABELLE_HOME empty"
+		dodir "${ISABELLE_HOME}/contrib/${PN}-${PV}/etc"
+		cat <<- EOF >> "${S}/settings" || die "Failed to create Isabelle configuration for CVC3"
+			CVC3_COMPONENT="\$COMPONENT"
+			CVC3_HOME="${EPREFIX}/usr/bin"
+			CVC3_SOLVER="\$CVC3_HOME/cvc3"
+			CVC3_REMOTE_SOLVER="cvc3"
+			CVC3_INSTALLED="yes"
+		EOF
+		insinto "${ISABELLE_HOME}/contrib/${PN}-${PV}/etc"
+		doins "${S}/settings"
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+	if use isabelle; then
+		if [[ -f "${EROOT%/}etc/isabelle/components" ]]; then
+			if egrep "contrib/${PN}-[0-9.]*" "${EROOT%/}etc/isabelle/components"; then
+				sed -e "/contrib\/${PN}-[0-9.]*/d" \
+					-i "${EROOT%/}etc/isabelle/components" || die "Failed to remove old CVC3 registrations in Isabelle"
+			fi
+			cat <<- EOF >> "${EROOT%/}etc/isabelle/components" || die "Failed to register CVC3 with Isabelle"
+				contrib/${PN}-${PV}
+			EOF
+		fi
+	fi
+	if use zchaff; then
+		einfo "This copy of CVC3 is also configured to use the SAT solver zchaff whose"
+		einfo "copyright is owned by Princeton University and is more restrictive."
+		einfo "Specifically, it may be used for internal, noncommercial, research purposes"
+		einfo "only. See the copyright notices from the zchaff source files which are"
+		einfo "included in the LICENSE file."
+		einfo "To build CVC3 without these files, please build cvc3 without the zchaff"
+		einfo "use flag (note: zchaff is disabled by default):"
+		einfo "USE=-zchaff emerge sci-mathemathematics/cvc3"
+	fi
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+	if use isabelle; then
+		if [[ ! -f "${EROOT%/}}usr/bin/cvc3" && -f "${EROOT%/}etc/isabelle/components" ]]; then
+			# Note: this sed should only match the version of this ebuild
+			# Which is what we want as we do not want to remove the line
+			# of a new CVC3 being installed during an upgrade.
+			sed -e "/contrib\/${PN}-${PV}/d" \
+				-i "${EROOT%/}etc/isabelle/components" || die "Failed to unregister CVC3 from Isabelle"
+		fi
+	fi
+}

--- a/sci-mathematics/cvc3/cvc3-2.4.1-r1.ebuild
+++ b/sci-mathematics/cvc3/cvc3-2.4.1-r1.ebuild
@@ -31,6 +31,8 @@ DEPEND="${RDEPEND}
 
 SITEFILE=50${PN}-gentoo.el
 
+PATCHES=( "${FILESDIR}/${P}-gccv6-fix.patch" )
+
 src_prepare() {
 	sed -e 's#prefix=@prefix@#prefix=$(patsubst %/,%,$(DESTDIR))@prefix@#' \
 		-e 's#libdir=@libdir@#libdir=$(patsubst %/,%,$(DESTDIR))@libdir@#' \

--- a/sci-mathematics/cvc3/files/cvc3-2.4.1-gccv6-fix.patch
+++ b/sci-mathematics/cvc3/files/cvc3-2.4.1-gccv6-fix.patch
@@ -1,0 +1,76 @@
+commit 4eb28b907e89be05d92eb704115f821b9b848e60
+Author: Matthew Dawson <matthew@mjdsystems.ca>
+Date:   Sun Oct 16 22:06:03 2016 -0400
+
+    Fix gcc v6 compile failures.
+    
+     * Use std::hash<const char*> over std::hash<char *>, as throwing away the const is not allowed.
+     * Use Hash::hash by default in CDMap over std::hash, to get Hash::hash<CVC3::expr>
+
+diff --git a/src/expr/expr_value.cpp b/src/expr/expr_value.cpp
+index 0c85ff6..e4dd251 100644
+--- a/src/expr/expr_value.cpp
++++ b/src/expr/expr_value.cpp
+@@ -29,7 +29,7 @@ namespace CVC3 {
+ // Class ExprValue static members
+ ////////////////////////////////////////////////////////////////////////
+ 
+-std::hash<char*> ExprValue::s_charHash;
++std::hash<const char*> ExprValue::s_charHash;
+ std::hash<long int> ExprValue::s_intHash;
+ 
+ ////////////////////////////////////////////////////////////////////////
+diff --git a/src/include/cdmap.h b/src/include/cdmap.h
+index faf682a..c3b094c 100644
+--- a/src/include/cdmap.h
++++ b/src/include/cdmap.h
+@@ -43,9 +43,9 @@ namespace CVC3 {
+ // Auxiliary class: almost the same as CDO (see cdo.h), but on
+ // setNull() call it erases itself from the map.
+ 
+-template <class Key, class Data, class HashFcn = std::hash<Key> > class CDMap;
++template <class Key, class Data, class HashFcn = Hash::hash<Key> > class CDMap;
+ 
+-template <class Key, class Data, class HashFcn = std::hash<Key> >
++template <class Key, class Data, class HashFcn = Hash::hash<Key> >
+ class CDOmap :public ContextObj {
+   Key d_key;
+   Data d_data;
+diff --git a/src/include/expr_hash.h b/src/include/expr_hash.h
+index b2107d7..baa2eab 100644
+--- a/src/include/expr_hash.h
++++ b/src/include/expr_hash.h
+@@ -20,7 +20,6 @@
+  * hash_set over Expr class.
+  */
+ /*****************************************************************************/
+-
+ #ifndef _cvc3__expr_h_
+ #include "expr.h"
+ #endif
+diff --git a/src/include/expr_value.h b/src/include/expr_value.h
+index 95102b2..f53aa4d 100644
+--- a/src/include/expr_value.h
++++ b/src/include/expr_value.h
+@@ -179,7 +179,7 @@ protected:
+   // Static hash functions.  They don't depend on the context
+   // (ExprManager and such), so it is still thread-safe to have them
+   // static.
+-  static std::hash<char*> s_charHash;
++  static std::hash<const char*> s_charHash;
+   static std::hash<long int> s_intHash;
+ 
+   static size_t pointerHash(void* p) { return s_intHash((long int)p); }
+diff --git a/src/theory_core/theory_core.cpp b/src/theory_core/theory_core.cpp
+index df5289f..37ccab9 100644
+--- a/src/theory_core/theory_core.cpp
++++ b/src/theory_core/theory_core.cpp
+@@ -710,7 +710,7 @@ TheoryCore::TheoryCore(ContextManager* cm,
+     //    d_termTheorems(cm->getCurrentContext()),
+     d_predicates(cm->getCurrentContext()),
+     d_solver(NULL),
+-    d_simplifyInPlace(false),
++    d_simplifyInPlace(NULL),
+     d_currentRecursiveSimplifier(NULL),
+     d_resourceLimit(0),
+     d_timeBase(0),


### PR DESCRIPTION
I'm not sure if I did the EAPI bump correctly, especially in the src_install portion.  It works AFAIK, but let me know if you want any part of that reverted and I'll respin the series.