### PR TITLE
sys-libs/musl: add upstream patch

### DIFF
--- a/sys-libs/musl/files/musl-1.1.15-CVE.patch
+++ b/sys-libs/musl/files/musl-1.1.15-CVE.patch
@@ -1,0 +1,68 @@
+From c3edc06d1e1360f3570db9155d6b318ae0d0f0f7 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Thu, 06 Oct 2016 22:34:58 +0000
+Subject: fix missing integer overflow checks in regexec buffer size computations
+
+most of the possible overflows were already ruled out in practice by
+regcomp having already succeeded performing larger allocations.
+however at least the num_states*num_tags multiplication can clearly
+overflow in practice. for safety, check them all, and use the proper
+type, size_t, rather than int.
+
+also improve comments, use calloc in place of malloc+memset, and
+remove bogus casts.
+---
+diff --git a/src/regex/regexec.c b/src/regex/regexec.c
+index 16c5d0a..dd52319 100644
+--- a/src/regex/regexec.c
++++ b/src/regex/regexec.c
+@@ -34,6 +34,7 @@
+ #include <wchar.h>
+ #include <wctype.h>
+ #include <limits.h>
++#include <stdint.h>
+ 
+ #include <regex.h>
+ 
+@@ -206,11 +207,24 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string,
+ 
+   /* Allocate memory for temporary data required for matching.	This needs to
+      be done for every matching operation to be thread safe.  This allocates
+-     everything in a single large block from the stack frame using alloca()
+-     or with malloc() if alloca is unavailable. */
++     everything in a single large block with calloc(). */
+   {
+-    int tbytes, rbytes, pbytes, xbytes, total_bytes;
++    size_t tbytes, rbytes, pbytes, xbytes, total_bytes;
+     char *tmp_buf;
++
++    /* Ensure that tbytes and xbytes*num_states cannot overflow, and that
++     * they don't contribute more than 1/8 of SIZE_MAX to total_bytes. */
++    if (num_tags > SIZE_MAX/(8 * sizeof(int) * tnfa->num_states))
++      goto error_exit;
++
++    /* Likewise check rbytes. */
++    if (tnfa->num_states+1 > SIZE_MAX/(8 * sizeof(*reach_next)))
++      goto error_exit;
++
++    /* Likewise check pbytes. */
++    if (tnfa->num_states > SIZE_MAX/(8 * sizeof(*reach_pos)))
++      goto error_exit;
++
+     /* Compute the length of the block we need. */
+     tbytes = sizeof(*tmp_tags) * num_tags;
+     rbytes = sizeof(*reach_next) * (tnfa->num_states + 1);
+@@ -221,10 +235,9 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string,
+       + (rbytes + xbytes * tnfa->num_states) * 2 + tbytes + pbytes;
+ 
+     /* Allocate the memory. */
+-    buf = xmalloc((unsigned)total_bytes);
++    buf = calloc(total_bytes, 1);
+     if (buf == NULL)
+       return REG_ESPACE;
+-    memset(buf, 0, (size_t)total_bytes);
+ 
+     /* Get the various pointers within tmp_buf (properly aligned). */
+     tmp_tags = (void *)buf;
+--
+cgit v0.9.0.3-65-g4555

--- a/sys-libs/musl/files/musl-1.1.15-assert.patch
+++ b/sys-libs/musl/files/musl-1.1.15-assert.patch
@@ -1,0 +1,43 @@
+From e738b8cbe64b6dd3ed9f47b6d4cd7eb2c422b38d Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Tue, 30 Aug 2016 20:39:54 +0000
+Subject: restore _Noreturn to __assert_fail
+
+this reverts commit 2c1f8fd5da3306fd7c8a2267467e44eb61f12dd4. without
+the _Noreturn attribute, the compiler cannot use asserts to perform
+reachability/range analysis. this leads to missed optimizations and
+spurious warnings.
+
+the original backtrace problem that prompted the removal of _Noreturn
+was not clearly documented at the time, but it seems to happen only
+when libc was built without -g, which also breaks many other
+backtracing cases.
+---
+diff --git a/include/assert.h b/include/assert.h
+index e679adb..d14ec94 100644
+--- a/include/assert.h
++++ b/include/assert.h
+@@ -16,7 +16,7 @@
+ extern "C" {
+ #endif
+ 
+-void __assert_fail (const char *, const char *, int, const char *);
++_Noreturn void __assert_fail (const char *, const char *, int, const char *);
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/src/exit/assert.c b/src/exit/assert.c
+index e87442a..49b0dc3 100644
+--- a/src/exit/assert.c
++++ b/src/exit/assert.c
+@@ -1,7 +1,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
+-void __assert_fail(const char *expr, const char *file, int line, const char *func)
++_Noreturn void __assert_fail(const char *expr, const char *file, int line, const char *func)
+ {
+ 	fprintf(stderr, "Assertion failed: %s (%s: %s: %d)\n", expr, file, func, line);
+ 	fflush(NULL);
+--
+cgit v0.9.0.3-65-g4555

--- a/sys-libs/musl/musl-1.1.15-r2.ebuild
+++ b/sys-libs/musl/musl-1.1.15-r2.ebuild
@@ -38,6 +38,11 @@ IUSE="crosscompile_opts_headers-only"
 QA_SONAME="/usr/lib/libc.so"
 QA_DT_NEEDED="/usr/lib/libc.so"
 
+PATCHES=(
+	"${FILESDIR}/${P}-assert.patch"
+	"${FILESDIR}/${P}-CVE.patch"
+	)
+
 is_crosscompile() {
 	[[ ${CHOST} != ${CTARGET} ]]
 }


### PR DESCRIPTION
The patch fixes the bug reported at

https://lists.freedesktop.org/archives/xcb/2016-October/010864.html

This pr makes #2496 obsolete.