### PR TITLE
sys-libs/pam: Fix 404 in eerror msg for PAM 0.99 upgrade

### DIFF
--- a/sys-libs/pam/pam-1.2.1-r1.ebuild
+++ b/sys-libs/pam/pam-1.2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -55,7 +55,7 @@ check_old_modules() {
 		eerror "not be installed."
 		eerror "Please replace pam_stack usage with proper include directive usage,"
 		eerror "following the PAM Upgrade guide at the following URL"
-		eerror "  https://www.gentoo.org/proj/en/base/pam/upgrade-0.99.xml"
+		eerror "  https://wiki.gentoo.org/wiki/Project:PAM/Upgrade_to_0.99"
 		eerror ""
 
 		retval=1
@@ -70,7 +70,7 @@ check_old_modules() {
 		eerror "of PAM through https://bugs.gentoo.org/ providing information about its"
 		eerror "use cases."
 		eerror "Please also make sure to read the PAM Upgrade guide at the following URL:"
-		eerror "  https://www.gentoo.org/proj/en/base/pam/upgrade-0.99.xml"
+		eerror "  https://wiki.gentoo.org/wiki/Project:PAM/Upgrade_to_0.99"
 		eerror ""
 
 		retval=1

--- a/sys-libs/pam/pam-1.2.1.ebuild
+++ b/sys-libs/pam/pam-1.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -55,7 +55,7 @@ check_old_modules() {
 		eerror "not be installed."
 		eerror "Please replace pam_stack usage with proper include directive usage,"
 		eerror "following the PAM Upgrade guide at the following URL"
-		eerror "  https://www.gentoo.org/proj/en/base/pam/upgrade-0.99.xml"
+		eerror "  https://wiki.gentoo.org/wiki/Project:PAM/Upgrade_to_0.99"
 		eerror ""
 
 		retval=1
@@ -70,7 +70,7 @@ check_old_modules() {
 		eerror "of PAM through https://bugs.gentoo.org/ providing information about its"
 		eerror "use cases."
 		eerror "Please also make sure to read the PAM Upgrade guide at the following URL:"
-		eerror "  https://www.gentoo.org/proj/en/base/pam/upgrade-0.99.xml"
+		eerror "  https://wiki.gentoo.org/wiki/Project:PAM/Upgrade_to_0.99"
 		eerror ""
 
 		retval=1

--- a/sys-libs/pam/pam-1.3.0.ebuild
+++ b/sys-libs/pam/pam-1.3.0.ebuild
@@ -50,7 +50,7 @@ check_old_modules() {
 		eerror "not be installed."
 		eerror "Please replace pam_stack usage with proper include directive usage,"
 		eerror "following the PAM Upgrade guide at the following URL"
-		eerror "  https://www.gentoo.org/proj/en/base/pam/upgrade-0.99.xml"
+		eerror "  https://wiki.gentoo.org/wiki/Project:PAM/Upgrade_to_0.99"
 		eerror ""
 
 		retval=1
@@ -65,7 +65,7 @@ check_old_modules() {
 		eerror "of PAM through https://bugs.gentoo.org/ providing information about its"
 		eerror "use cases."
 		eerror "Please also make sure to read the PAM Upgrade guide at the following URL:"
-		eerror "  https://www.gentoo.org/proj/en/base/pam/upgrade-0.99.xml"
+		eerror "  https://wiki.gentoo.org/wiki/Project:PAM/Upgrade_to_0.99"
 		eerror ""
 
 		retval=1


### PR DESCRIPTION
Package-Manager: portage-2.3.0

Besides that, repoman shows a warning which I'm unable to fix - maybe someone else can take care of this:
```
  dependency.missingslot        2
   sys-libs/pam/pam-1.2.1.ebuild: RDEPEND: '>=sys-libs/db-4.8.30-r1[abi_x86_32(-)?,abi_x86_64(-)?,abi_x86_x32(-)?,abi_mips_n32(-)?,abi_mips_n64(-)?,abi_mips_o32(-)?,abi_ppc_32(-)?,abi_ppc_64(-)?,abi_s390_32(-)?,abi_s390_64(-)?]' matches more than one slot, please specify an explicit slot and/or use the := or :* slot operator
   sys-libs/pam/pam-1.2.1-r1.ebuild: RDEPEND: '>=sys-libs/db-4.8.30-r1[abi_x86_32(-)?,abi_x86_64(-)?,abi_x86_x32(-)?,abi_mips_n32(-)?,abi_mips_n64(-)?,abi_mips_o32(-)?,abi_ppc_32(-)?,abi_ppc_64(-)?,abi_s390_32(-)?,abi_s390_64(-)?]' matches more than one slot, please specify an explicit slot and/or use the := or :* slot operator
```