### PR TITLE
media-video/mpv: require samba[smbclient(+)] with 'samba' USE

### DIFF
--- a/media-video/mpv/mpv-0.18.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.18.0-r1.ebuild
@@ -95,7 +95,7 @@ COMMON_DEPEND="
 		media-libs/mesa[egl,gles2]
 	)
 	rubberband? ( >=media-libs/rubberband-1.8.0 )
-	samba? ( net-fs/samba )
+	samba? ( net-fs/samba[smbclient(+)] )
 	sdl? ( media-libs/libsdl2[sound,threads,video,X?,wayland?] )
 	v4l? ( media-libs/libv4l )
 	vaapi? ( >=x11-libs/libva-1.4.0[drm?,X?,wayland?] )

--- a/media-video/mpv/mpv-0.20.0.ebuild
+++ b/media-video/mpv/mpv-0.20.0.ebuild
@@ -95,7 +95,7 @@ COMMON_DEPEND="
 		media-libs/mesa[egl,gles2]
 	)
 	rubberband? ( >=media-libs/rubberband-1.8.0 )
-	samba? ( net-fs/samba )
+	samba? ( net-fs/samba[smbclient(+)] )
 	sdl? ( media-libs/libsdl2[sound,threads,video,X?,wayland?] )
 	v4l? ( media-libs/libv4l )
 	vaapi? ( >=x11-libs/libva-1.4.0[drm?,X?,wayland?] )

--- a/media-video/mpv/mpv-0.21.0.ebuild
+++ b/media-video/mpv/mpv-0.21.0.ebuild
@@ -95,7 +95,7 @@ COMMON_DEPEND="
 		media-libs/mesa[egl,gles2]
 	)
 	rubberband? ( >=media-libs/rubberband-1.8.0 )
-	samba? ( net-fs/samba )
+	samba? ( net-fs/samba[smbclient(+)] )
 	sdl? ( media-libs/libsdl2[sound,threads,video,X?,wayland?] )
 	v4l? ( media-libs/libv4l )
 	vaapi? ( >=x11-libs/libva-1.4.0[drm?,X?,wayland?] )

--- a/media-video/mpv/mpv-0.9.2-r1.ebuild
+++ b/media-video/mpv/mpv-0.9.2-r1.ebuild
@@ -101,7 +101,7 @@ RDEPEND="
 	openal? ( >=media-libs/openal-1.13 )
 	pulseaudio? ( media-sound/pulseaudio )
 	rubberband? ( >=media-libs/rubberband-1.8.0 )
-	samba? ( net-fs/samba )
+	samba? ( net-fs/samba[smbclient(+)] )
 	sdl? ( media-libs/libsdl2[threads] )
 	v4l? ( media-libs/libv4l )
 	wayland? (

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -95,7 +95,7 @@ COMMON_DEPEND="
 		media-libs/mesa[egl,gles2]
 	)
 	rubberband? ( >=media-libs/rubberband-1.8.0 )
-	samba? ( net-fs/samba )
+	samba? ( net-fs/samba[smbclient(+)] )
 	sdl? ( media-libs/libsdl2[sound,threads,video,X?,wayland?] )
 	v4l? ( media-libs/libv4l )
 	vaapi? ( >=x11-libs/libva-1.4.0[drm?,X?,wayland?] )


### PR DESCRIPTION
samba[smbclient] is required when building against samba-3.
samba-4 always installs libsmbclient.

Gentoo-Bug: https://bugs.gentoo.org/597600

Package-Manager: portage-2.3.2