### PR TITLE
media-plugins/gst-transcoder: Fix libdir for meson build

### DIFF
--- a/media-plugins/gst-transcoder/gst-transcoder-1.8.2-r1.ebuild
+++ b/media-plugins/gst-transcoder/gst-transcoder-1.8.2-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+PYTHON_COMPAT=( python{3_4,3_5} )
+
+inherit python-any-r1 xdg
+
+DESCRIPTION="GStreamer Transcoding API"
+HOMEPAGE="https://github.com/pitivi/gst-transcoder"
+SRC_URI="https://github.com/pitivi/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="
+	dev-libs/gobject-introspection:=
+	dev-libs/glib:2
+	>=media-libs/gstreamer-${PV}:1.0[introspection]
+	>=media-libs/gst-plugins-base-${PV}:1.0[introspection]
+"
+DEPEND="${RDEPEND}
+	${PYTHON_DEPS}
+	>=dev-util/meson-0.28.0
+	virtual/pkgconfig
+"
+
+src_configure() {
+	# Not a normal configure
+	# --buildtype=plain needed for honoring CFLAGS/CXXFLAGS and not
+	# defaulting to debug
+	./configure --prefix="${EPREFIX}/usr" --libdir="$(get_libdir)" --buildtype=plain || die
+}
+
+src_compile() {
+	addpredict /dev #590848
+	# We cannot use 'make' as it won't allow us to build verbosely
+	cd mesonbuild || die
+	ninja -v || die
+}

--- a/media-video/pitivi/pitivi-0.97.1.ebuild
+++ b/media-video/pitivi/pitivi-0.97.1.ebuild
@@ -31,7 +31,7 @@ COMMON_DEPEND="
 	>=x11-libs/cairo-1.10
 
 	>=media-libs/gstreamer-${GST_VER}:1.0[introspection]
-	>=media-plugins/gst-transcoder-1.8.1
+	>=media-plugins/gst-transcoder-1.8.2-r1
 "
 RDEPEND="${COMMON_DEPEND}
 	>=dev-libs/glib-2.30.0:2
@@ -80,8 +80,9 @@ src_configure() {
 	# --buildtype=plain needed for honoring CFLAGS/CXXFLAGS and not
 	# defaulting to debug
 	./configure \
-		--prefix=/usr \
+		--prefix="${EPREFIX}/usr" \
 		--buildtype=plain \
+		--libdir="$(get_libdir)" \
 		-Denable-tests=$(usex test true false) \
 		|| die
 }


### PR DESCRIPTION
dev-util/meson guesses libdir for the build incorrectly if /usr/bin/dpkg-architecture exists, see 
Gentoo-Bug: 591564

Use the known correct value for Gentoo instead of the default guess.
