### PR TITLE
media-gfx/nomacs: Add USE=jpeg, fix build with !opencv

### DIFF
--- a/media-gfx/nomacs/files/nomacs-3.4-no-opencv.patch
+++ b/media-gfx/nomacs/files/nomacs-3.4-no-opencv.patch
@@ -1,0 +1,11 @@
+--- a/src/DkLoader/DkBasicLoader.h
++++ b/src/DkLoader/DkBasicLoader.h
+@@ -258,7 +258,7 @@ class DllLoaderExport DkBasicLoader : public QObject {
+ 	bool readHeader(const unsigned char** dataPtr, int& fileCount, int& vecSize) const;
+ 	void getPatchSizeFromFileName(const QString& fileName, int& width, int& height) const;
+ #else
+-	bool loadOpenCVVecFile(const QString&, QSharedPointer<QByteArray> = QSharedPointer<QByteArray>(), QSize = QSize()) { return false; };
++	bool loadOpenCVVecFile(const QString&, QImage&, QSharedPointer<QByteArray> = QSharedPointer<QByteArray>(), QSize = QSize()) { return false; };
+ 	int mergeVecFiles(const QStringList&, QString&) const { return 0; };
+ 	bool readHeader(const unsigned char**, int&, int&) const { return false; };
+ 	void getPatchSizeFromFileName(const QString&, int&, int&) const {};

--- a/media-gfx/nomacs/nomacs-3.4.ebuild
+++ b/media-gfx/nomacs/nomacs-3.4.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/${PN}/${PN}/archive/3.4.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~amd64-linux"
-IUSE="opencv raw tiff zip"
+IUSE="+jpeg opencv raw tiff zip"
 
 REQUIRED_USE="
 	raw? ( opencv )
@@ -23,7 +23,7 @@ REQUIRED_USE="
 RDEPEND="
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
-	dev-qt/qtgui:5
+	dev-qt/qtgui:5[jpeg?]
 	dev-qt/qtnetwork:5
 	dev-qt/qtprintsupport:5
 	dev-qt/qtsvg:5
@@ -40,6 +40,8 @@ DEPEND="${RDEPEND}
 "
 
 S="${WORKDIR}/${P}/ImageLounge"
+
+PATCHES=( "${FILESDIR}/${P}-no-opencv.patch" ) # bug 592134
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
Gentoo-bug: 592118, 592134

@gentoo/qt @kensington 