### PR TITLE
media-video/vlc: Prefer qt5 to qt4 if both enabled

### DIFF
--- a/media-video/vlc/files/vlc-2.2.4-alsa-large-buffers.patch
+++ b/media-video/vlc/files/vlc-2.2.4-alsa-large-buffers.patch
@@ -1,0 +1,47 @@
+X-Git-Url: https://git.videolan.org/?p=vlc.git;a=blobdiff_plain;f=modules%2Faudio_output%2Falsa.c;h=4e9fd53592d048baa8b57f30df15ab5806139d07;hp=2d1f99e9cb743bca12c6bdf32cc84a92d07fda8b;hb=47f74a83c161173b0d15e95dab8ceb7c97de51b4;hpb=6ae2905ef7fbc7de3a3a4a1bdf8ad6df46ce570a
+
+diff --git a/modules/audio_output/alsa.c b/modules/audio_output/alsa.c
+index 2d1f99e..4e9fd53 100644
+--- a/modules/audio_output/alsa.c
++++ b/modules/audio_output/alsa.c
+@@ -495,6 +495,15 @@ static int Start (audio_output_t *aout, audio_sample_format_t *restrict fmt)
+     }
+     sys->rate = fmt->i_rate;
+ 
++#if 1 /* work-around for period-long latency outputs (e.g. PulseAudio): */
++    param = AOUT_MIN_PREPARE_TIME;
++    val = snd_pcm_hw_params_set_period_time_near (pcm, hw, &param, NULL);
++    if (val)
++    {
++        msg_Err (aout, "cannot set period: %s", snd_strerror (val));
++        goto error;
++    }
++#endif
+     /* Set buffer size */
+     param = AOUT_MAX_ADVANCE_TIME;
+     val = snd_pcm_hw_params_set_buffer_time_near (pcm, hw, &param, NULL);
+@@ -503,14 +512,22 @@ static int Start (audio_output_t *aout, audio_sample_format_t *restrict fmt)
+         msg_Err (aout, "cannot set buffer duration: %s", snd_strerror (val));
+         goto error;
+     }
+-
+-    param = AOUT_MIN_PREPARE_TIME;
++#if 0
++    val = snd_pcm_hw_params_get_buffer_time (hw, &param, NULL);
++    if (val)
++    {
++        msg_Warn (aout, "cannot get buffer time: %s", snd_strerror(val));
++        param = AOUT_MIN_PREPARE_TIME;
++    }
++    else
++        param /= 2;
+     val = snd_pcm_hw_params_set_period_time_near (pcm, hw, &param, NULL);
+     if (val)
+     {
+         msg_Err (aout, "cannot set period: %s", snd_strerror (val));
+         goto error;
+     }
++#endif
+ 
+     /* Commit hardware parameters */
+     val = snd_pcm_hw_params (pcm, hw);

--- a/media-video/vlc/files/vlc-2.2.4-cxx0x.patch
+++ b/media-video/vlc/files/vlc-2.2.4-cxx0x.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac	2016-09-21 07:10:58.885508665 +0200
++++ b/configure.ac	2016-09-21 07:19:17.835725004 +0200
+@@ -3746,7 +3746,7 @@
+     PKG_CHECK_MODULES([QT], [Qt5Core >= 5.1.0 Qt5Widgets Qt5Gui], [
+       PKG_CHECK_MODULES([QTX11], [Qt5X11Extras], [
+           VLC_ADD_LIBS([qt4],[${QTX11_LIBS}])
+-          VLC_ADD_CXXFLAGS([qt4],[${QTX11_CFLAGS} -DQT5_HAS_X11])
++          VLC_ADD_CXXFLAGS([qt4],[${QTX11_CFLAGS} -DQT5_HAS_X11 -std=c++0x])
+           PKG_CHECK_MODULES([XI], [xi], [
+             VLC_ADD_LIBS([qt4], [${XI_LIBS}])
+             VLC_ADD_CXXFLAGS([qt4], [${XI_CFLAGS} -DHAVE_XI])

--- a/media-video/vlc/files/vlc-2.2.4-decoder-lock-scope.patch
+++ b/media-video/vlc/files/vlc-2.2.4-decoder-lock-scope.patch
@@ -1,0 +1,47 @@
+X-Git-Url: https://git.videolan.org/?p=vlc.git;a=blobdiff_plain;f=src%2Finput%2Fdecoder.c;h=fe3cd428c65c18bfbdadb55baf11521afdc2bfc7;hp=83aa5bf54e2c29ad93fae803117558e4fcd0f658;hb=6ae2905ef7fbc7de3a3a4a1bdf8ad6df46ce570a;hpb=5b2de76965ee8b1ab5e3257f8b6d71bbb4e9e3f9
+
+--- a/src/input/decoder.c
++++ b/src/input/decoder.c
+@@ -1162,7 +1162,10 @@
+         b_paused = p_owner->b_paused;
+ 
+         if (!p_audio)
++        {
++            vlc_mutex_unlock( &p_owner->lock );
+             break;
++        }
+ 
+         /* */
+         int i_rate = INPUT_RATE_DEFAULT;
+@@ -1180,6 +1183,9 @@
+ 
+         if( unlikely(p_owner->b_paused != b_paused) )
+             continue; /* race with input thread? retry... */
++
++        vlc_mutex_unlock( &p_owner->lock );
++
+         if( p_aout == NULL )
+             b_reject = true;
+ 
+@@ -1199,7 +1205,6 @@
+ 
+         break;
+     }
+-    vlc_mutex_unlock( &p_owner->lock );
+ }
+ 
+ static void DecoderDecodeAudio( decoder_t *p_dec, block_t *p_block )
+@@ -1961,11 +1966,10 @@
+ 
+         /* Parameters changed, restart the aout */
+         vlc_mutex_lock( &p_owner->lock );
+-
+-        aout_DecDelete( p_owner->p_aout );
+         p_owner->p_aout = NULL;
+-
+         vlc_mutex_unlock( &p_owner->lock );
++        aout_DecDelete( p_owner->p_aout );
++
+         input_resource_PutAout( p_owner->p_resource, p_aout );
+     }
+ 

--- a/media-video/vlc/files/vlc-2.2.4-qt57.patch
+++ b/media-video/vlc/files/vlc-2.2.4-qt57.patch
@@ -1,0 +1,284 @@
+As the 2.2 headers are still using vlc_atomics (picture)
+we cannot have a way to avoid collisions with early
+or late <atomic> inclusion when using GCC >= 4.7
+
+Conditionals in vlc_atomic won't work.
+
+Happens in ProjectM and Qt5.
+---
+ modules/gui/qt4/actions_manager.cpp                |  2 ++
+ modules/gui/qt4/adapters/seekpoints.cpp            |  4 +--
+ modules/gui/qt4/adapters/seekpoints.hpp            |  4 +--
+ modules/gui/qt4/components/controller.cpp          |  2 ++
+ .../gui/qt4/components/playlist/playlist_model.hpp |  4 +--
+ modules/gui/qt4/components/playlist/views.cpp      |  6 ++++
+ modules/gui/qt4/dialogs/messages.cpp               |  2 ++
+ modules/gui/qt4/dialogs/vlm.cpp                    |  4 ---
+ modules/gui/qt4/dialogs/vlm.hpp                    |  4 ++-
+ modules/gui/qt4/input_manager.cpp                  |  2 ++
+ modules/gui/qt4/input_manager.hpp                  |  3 +-
+ modules/gui/qt4/menus.cpp                          |  2 ++
+ modules/gui/qt4/qt4.hpp                            | 32 ++++++++++++++++++----
+ modules/gui/qt4/util/pictureflow.cpp               |  2 ++
+ modules/visualization/projectm.cpp                 |  4 +++
+ 15 files changed, 56 insertions(+), 21 deletions(-)
+
+diff --git a/modules/gui/qt4/actions_manager.cpp b/modules/gui/qt4/actions_manager.cpp
+index eff40d9..b7ca967 100644
+--- a/modules/gui/qt4/actions_manager.cpp
++++ b/modules/gui/qt4/actions_manager.cpp
+@@ -25,6 +25,8 @@
+ # include "config.h"
+ #endif
+ 
++#include "qt4.hpp"
++
+ #include <vlc_vout.h>
+ #include <vlc_keys.h>
+ 
+diff --git a/modules/gui/qt4/adapters/seekpoints.cpp b/modules/gui/qt4/adapters/seekpoints.cpp
+index fbf2957..a3564bb 100644
+--- a/modules/gui/qt4/adapters/seekpoints.cpp
++++ b/modules/gui/qt4/adapters/seekpoints.cpp
+@@ -19,14 +19,12 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+  *****************************************************************************/
+ 
++#include "seekpoints.hpp"
+ 
+ #include "recents.hpp"
+ #include "dialogs_provider.hpp"
+ #include "menus.hpp"
+ 
+-#include "seekpoints.hpp"
+-
+-#include "qt4.hpp"
+ #include "input_manager.hpp"
+ 
+ SeekPoints::SeekPoints( QObject *parent, intf_thread_t *p_intf_ ) :
+diff --git a/modules/gui/qt4/adapters/seekpoints.hpp b/modules/gui/qt4/adapters/seekpoints.hpp
+index 0083989..bbb9214 100644
+--- a/modules/gui/qt4/adapters/seekpoints.hpp
++++ b/modules/gui/qt4/adapters/seekpoints.hpp
+@@ -22,9 +22,7 @@
+ #ifndef SEEKPOINTS_HPP
+ #define SEEKPOINTS_HPP
+ 
+-#ifdef HAVE_CONFIG_H
+-#include "config.h"
+-#endif
++#include "qt4.hpp"
+ 
+ #include <vlc_common.h>
+ #include <vlc_interface.h>
+diff --git a/modules/gui/qt4/components/controller.cpp b/modules/gui/qt4/components/controller.cpp
+index d93e0db..c43d929 100644
+--- a/modules/gui/qt4/components/controller.cpp
++++ b/modules/gui/qt4/components/controller.cpp
+@@ -26,6 +26,8 @@
+ # include "config.h"
+ #endif
+ 
++#include "qt4.hpp"
++
+ #include <vlc_vout.h>                       /* vout_thread_t for FSC */
+ 
+ /* Widgets */
+diff --git a/modules/gui/qt4/components/playlist/playlist_model.hpp b/modules/gui/qt4/components/playlist/playlist_model.hpp
+index f9d1d0c..1f71ac9 100644
+--- a/modules/gui/qt4/components/playlist/playlist_model.hpp
++++ b/modules/gui/qt4/components/playlist/playlist_model.hpp
+@@ -25,9 +25,7 @@
+ #ifndef _PLAYLIST_MODEL_H_
+ #define _PLAYLIST_MODEL_H_
+ 
+-#ifdef HAVE_CONFIG_H
+-# include "config.h"
+-#endif
++#include "qt4.hpp"
+ 
+ #include <vlc_input.h>
+ #include <vlc_playlist.h>
+diff --git a/modules/gui/qt4/components/playlist/views.cpp b/modules/gui/qt4/components/playlist/views.cpp
+index 59f6535..0066205 100644
+--- a/modules/gui/qt4/components/playlist/views.cpp
++++ b/modules/gui/qt4/components/playlist/views.cpp
+@@ -21,6 +21,12 @@
+  * 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+  *****************************************************************************/
+ 
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
++#include "qt4.hpp"
++
+ #include "components/playlist/views.hpp"
+ #include "components/playlist/vlc_model.hpp"      /* VLCModel */
+ #include "components/playlist/sorting.h"          /* Columns List */
+diff --git a/modules/gui/qt4/dialogs/messages.cpp b/modules/gui/qt4/dialogs/messages.cpp
+index 30793a2..9c79c99 100644
+--- a/modules/gui/qt4/dialogs/messages.cpp
++++ b/modules/gui/qt4/dialogs/messages.cpp
+@@ -24,6 +24,8 @@
+ # include "config.h"
+ #endif
+ 
++#include "qt4.hpp"
++
+ #include "dialogs/messages.hpp"
+ 
+ #include <QPlainTextEdit>
+diff --git a/modules/gui/qt4/dialogs/vlm.cpp b/modules/gui/qt4/dialogs/vlm.cpp
+index 0da88cc..595f015 100644
+--- a/modules/gui/qt4/dialogs/vlm.cpp
++++ b/modules/gui/qt4/dialogs/vlm.cpp
+@@ -23,10 +23,6 @@
+  * Foundation, Inc., 51 Franklin street, Fifth Floor, Boston MA 02110-1301, USA.
+  *****************************************************************************/
+ 
+-#ifdef HAVE_CONFIG_H
+-# include "config.h"
+-#endif
+-
+ #include "dialogs/vlm.hpp"
+ 
+ #ifdef ENABLE_VLM
+diff --git a/modules/gui/qt4/dialogs/vlm.hpp b/modules/gui/qt4/dialogs/vlm.hpp
+index a3c6e5d..dcf7110 100644
+--- a/modules/gui/qt4/dialogs/vlm.hpp
++++ b/modules/gui/qt4/dialogs/vlm.hpp
+@@ -25,8 +25,10 @@
+ #ifndef QVLC_VLM_DIALOG_H_
+ #define QVLC_VLM_DIALOG_H_ 1
+ 
++#include "qt4.hpp"
++
+ #ifdef HAVE_CONFIG_H
+-# include "config.h"
++#include "config.h"
+ #endif
+ 
+ #ifdef ENABLE_VLM
+diff --git a/modules/gui/qt4/input_manager.cpp b/modules/gui/qt4/input_manager.cpp
+index fd45f4a..c50cb6c 100644
+--- a/modules/gui/qt4/input_manager.cpp
++++ b/modules/gui/qt4/input_manager.cpp
+@@ -30,6 +30,8 @@
+ # include "config.h"
+ #endif
+ 
++#include "qt4.hpp"
++
+ #include "input_manager.hpp"
+ #include "recents.hpp"
+ 
+diff --git a/modules/gui/qt4/input_manager.hpp b/modules/gui/qt4/input_manager.hpp
+index 7d3b76a..4fbecbb 100644
+--- a/modules/gui/qt4/input_manager.hpp
++++ b/modules/gui/qt4/input_manager.hpp
+@@ -29,9 +29,10 @@
+ # include "config.h"
+ #endif
+ 
++#include "qt4.hpp"
++
+ #include <vlc_input.h>
+ 
+-#include "qt4.hpp"
+ #include "util/singleton.hpp"
+ #include "adapters/variables.hpp"
+ 
+diff --git a/modules/gui/qt4/menus.cpp b/modules/gui/qt4/menus.cpp
+index 116e98c..46240b0 100644
+--- a/modules/gui/qt4/menus.cpp
++++ b/modules/gui/qt4/menus.cpp
+@@ -34,6 +34,8 @@
+ # include "config.h"
+ #endif
+ 
++#include "qt4.hpp"
++
+ #include <vlc_common.h>
+ #include <vlc_intf_strings.h>
+ #include <vlc_vout.h>                             /* vout_thread_t */
+diff --git a/modules/gui/qt4/qt4.hpp b/modules/gui/qt4/qt4.hpp
+index 44d7db6..5aec957 100644
+--- a/modules/gui/qt4/qt4.hpp
++++ b/modules/gui/qt4/qt4.hpp
+@@ -29,12 +29,7 @@
+ # include "config.h"
+ #endif
+ 
+-#include <vlc_common.h>    /* VLC_COMMON_MEMBERS for vlc_interface.h */
+-#include <vlc_interface.h> /* intf_thread_t */
+-#include <vlc_playlist.h>  /* playlist_t */
+-
+-#define QT_NO_CAST_TO_ASCII
+-#include <QString>
++#include <QtGlobal>
+ 
+ #if ( QT_VERSION < 0x040600 )
+ # error Update your Qt version to at least 4.6.0
+@@ -43,6 +38,31 @@
+ #define HAS_QT47 ( QT_VERSION >= 0x040700 )
+ #define HAS_QT5  ( QT_VERSION >= 0x050000 )
+ 
++#if HAS_QT5
++  #include <QtCore/qcompilerdetection.h>
++  #if defined(Q_COMPILER_ATOMICS) && \
++             ( __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7 ) )
++   #define VLC_ATOMIC_H
++   #include <atomic>
++   using namespace std;
++   #  define atomic_store(object,desired) \
++      do { \
++          *(object) = (desired); \
++          __sync_synchronize(); \
++      } while (0)
++
++   #  define atomic_load(object) \
++       (__sync_synchronize(), *(object))
++  #endif
++#endif
++
++#include <vlc_common.h>    /* VLC_COMMON_MEMBERS for vlc_interface.h */
++#include <vlc_interface.h> /* intf_thread_t */
++#include <vlc_playlist.h>  /* playlist_t */
++
++#define QT_NO_CAST_TO_ASCII
++#include <QString>
++
+ enum {
+     DialogEventTypeOffset = 0,
+     IMEventTypeOffset     = 100,
+diff --git a/modules/gui/qt4/util/pictureflow.cpp b/modules/gui/qt4/util/pictureflow.cpp
+index 9318953..a7e6a01 100644
+--- a/modules/gui/qt4/util/pictureflow.cpp
++++ b/modules/gui/qt4/util/pictureflow.cpp
+@@ -29,6 +29,8 @@
+   THE SOFTWARE.
+ */
+ 
++#include "qt4.hpp"
++
+ #include "pictureflow.hpp"
+ 
+ #include <QApplication>
+diff --git a/modules/visualization/projectm.cpp b/modules/visualization/projectm.cpp
+index e80fbf4..96d532d 100644
+--- a/modules/visualization/projectm.cpp
++++ b/modules/visualization/projectm.cpp
+@@ -30,6 +30,10 @@
+ #endif
+ 
+ #include <assert.h>
++#if defined(__GNUC__) && \
++           ( __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7 ) )
++  #define VLC_ATOMIC_H /* Ensure C atomics wont collide with old intrinsics */
++#endif
+ 
+ #include <vlc_common.h>
+ #include <vlc_plugin.h>
+-- 
+2.7.4

--- a/media-video/vlc/metadata.xml
+++ b/media-video/vlc/metadata.xml
@@ -56,7 +56,7 @@
 		<flag name="postproc">Enables image post-processing via libpostproc (part of FFmpeg).</flag>
 		<flag name="projectm">Enables the projectM visualization plugin.</flag>
 		<flag name="qt4" restrict="&gt;=media-video/vlc-0.9">Builds a Qt4 based frontend, a graphical interface.</flag>
-		<flag name="qt5" restrict="&gt;=media-video/vlc-2.2">Builds a Qt5 based frontend, a graphical interface.</flag>
+		<flag name="qt5" restrict="&gt;=media-video/vlc-2.2">Builds a Qt5 based frontend, a graphical interface (overrides qt4).</flag>
 		<flag name="rdp">Enables freerdp for RDP/Remote Desktop client support</flag>
 		<flag name="rtsp">Enables real audio and RTSP modules.</flag>
 		<flag name="run-as-root">Allows vlc to start for root. Don't enable this unless you have a very specific (e.g. embedded) need for it!</flag>

--- a/media-video/vlc/metadata.xml
+++ b/media-video/vlc/metadata.xml
@@ -47,7 +47,6 @@
 		<flag name="macosx-quartztext">Enables Mac OS X quartz text module.</flag>
 		<flag name="macosx-qtkit">Enables Mac OS X qtkit module: qtcapture (video) and qtsound (audio) module.</flag>
 		<flag name="matroska">Enables matroska support using reference libraries (fallback on other existing matroska support if disabled, i.e., matroska enabled FFmpeg)</flag>
-		<flag name="media-library">Build the (sqlite based) media library.</flag>
 		<flag name="mpeg">Add libmpeg2 support for mpeg-1 and mpeg-2 video streams</flag>
 		<flag name="omxil">Enables OpenMAX Integration Layer codec module.</flag>
 		<flag name="optimisememory">Enable optimisation for memory rather than performance.</flag>

--- a/media-video/vlc/vlc-2.2.1-r1.ebuild
+++ b/media-video/vlc/vlc-2.2.1-r1.ebuild
@@ -45,7 +45,7 @@ IUSE="a52 aalib alsa altivec atmo +audioqueue +avcodec
 	growl httpd ieee1394 jack jpeg kate kde libass libav libcaca libnotify
 	+libsamplerate libtiger linsys libtar lirc live lua
 	macosx-dialog-provider macosx-eyetv macosx-quartztext macosx-qtkit
-	matroska media-library cpu_flags_x86_mmx modplug mp3 mpeg
+	matroska cpu_flags_x86_mmx modplug mp3 mpeg
 	mtp musepack ncurses neon ogg omxil opencv opengl optimisememory opus
 	png postproc projectm pulseaudio +qt4 qt5 rdp rtsp run-as-root samba
 	schroedinger sdl sdl-image sftp shout sid skins speex cpu_flags_x86_sse svg +swscale

--- a/media-video/vlc/vlc-2.2.1-r1.ebuild
+++ b/media-video/vlc/vlc-2.2.1-r1.ebuild
@@ -121,9 +121,8 @@ RDEPEND="
 		)
 		projectm? ( media-libs/libprojectm:0 media-fonts/dejavu:0 )
 		pulseaudio? ( >=media-sound/pulseaudio-1:0 )
-		qt4? ( >=dev-qt/qtgui-4.6:4 >=dev-qt/qtcore-4.6:4 )
-		qt5? ( >=dev-qt/qtgui-5.1:5 >=dev-qt/qtcore-5.1:5 >=dev-qt/qtwidgets-5.1:5
-			>=dev-qt/qtx11extras-5.1:5 )
+		!qt5? ( qt4? ( dev-qt/qtcore:4 dev-qt/qtgui:4 ) )
+		qt5? ( dev-qt/qtcore:5 dev-qt/qtgui:5 dev-qt/qtwidgets:5 dev-qt/qtx11extras:5 )
 		rdp? ( >=net-misc/freerdp-1.0.1:0=[client] <net-misc/freerdp-2 )
 		samba? ( || ( ( >=net-fs/samba-3.4.6:0[smbclient] <net-fs/samba-4.0.0_alpha1:0[smbclient] )
 			>=net-fs/samba-4.0.0_alpha1:0[client] ) )
@@ -178,7 +177,7 @@ RDEPEND="${RDEPEND}
 "
 
 DEPEND="${RDEPEND}
-	kde? ( >=kde-base/kdelibs-4:4 )
+	!qt5? ( kde? ( kde-base/kdelibs:4 ) )
 	xcb? ( x11-proto/xproto:0 )
 	app-arch/xz-utils:0
 	x86?   ( dev-lang/yasm:* )
@@ -200,10 +199,10 @@ REQUIRED_USE="
 	libcaca? ( X )
 	libtar? ( skins )
 	libtiger? ( kate )
-	qt4? ( X !qt5 )
-	qt5? ( X !qt4 )
+	qt4? ( X )
+	qt5? ( X )
 	sdl? ( X )
-	skins? ( truetype X xml ^^ ( qt4 qt5 ) )
+	skins? ( truetype X xml || ( qt4 qt5 ) )
 	vaapi? ( avcodec X )
 	vdpau? ( xcb )
 	vlm? ( encode )
@@ -289,14 +288,16 @@ src_prepare() {
 
 	# If qtchooser is installed, it may break the build, because moc,rcc and uic binaries for wrong qt version may be used.
 	# Setting QT_SELECT environment variable will enforce correct binaries.
-	if use qt4; then
-		export QT_SELECT=qt4
-	elif use qt5; then
+	if use qt5; then
 		export QT_SELECT=qt5
+	elif use qt4; then
+		export QT_SELECT=qt4
 	fi
 }
 
 src_configure() {
+	local myconf
+
 	# Compatibility fix for Samba 4.
 	use samba && append-cppflags "-I/usr/include/samba-4.0"
 
@@ -316,13 +317,15 @@ src_configure() {
 				--with-default-monospace-font-family=Monospace"
 	fi
 
-	local qt_flag=""
-	if use qt4 ; then
-		qt_flag="--enable-qt=4"
-	elif use qt5 ; then
-		qt_flag="--enable-qt=5"
+	if use qt5 ; then
+		myconf+=" --enable-qt=5"
 	else
-		qt_flag="--disable-qt"
+		if use qt4 ; then
+			myconf+=" --enable-qt=4"
+		else
+			myconf+=" --disable-qt"
+		fi
+		use kde && myconf+=" --with-kde-solid"
 	fi
 
 	econf \
@@ -372,7 +375,6 @@ src_configure() {
 		$(use_enable jack) \
 		$(use_enable jpeg) \
 		$(use_enable kate) \
-		$(use_with kde kde-solid) \
 		$(use_enable libass) \
 		$(use_enable libcaca caca) \
 		$(use_enable libnotify notify) \
@@ -407,7 +409,6 @@ src_configure() {
 		$(use_enable postproc) \
 		$(use_enable projectm) \
 		$(use_enable pulseaudio pulse) \
-		${qt_flag} \
 		$(use_enable rdp freerdp) \
 		$(use_enable rtsp realrtsp) \
 		$(use_enable run-as-root) \
@@ -482,7 +483,7 @@ src_configure() {
 }
 
 src_test() {
-	Xemake check-TESTS
+	virtx emake check-TESTS
 }
 
 DOCS="AUTHORS THANKS NEWS README doc/fortunes.txt doc/intf-vcd.txt"
@@ -491,7 +492,7 @@ src_install() {
 	default
 
 	# Punt useless libtool's .la files
-	find "${D}" -name '*.la' -delete
+	find "${D}" -name '*.la' -delete || die
 }
 
 pkg_postinst() {

--- a/media-video/vlc/vlc-2.2.4.ebuild
+++ b/media-video/vlc/vlc-2.2.4.ebuild
@@ -230,6 +230,10 @@ PATCHES=(
 	# Bug #575072
 	"${FILESDIR}"/${PN}-2.2.4-relax_ffmpeg.patch
 	"${FILESDIR}"/${PN}-2.2.4-ffmpeg3.patch
+
+	# Bug #589396
+	"${FILESDIR}"/${PN}-2.2.4-qt57.patch
+	"${FILESDIR}"/${PN}-2.2.4-cxx0x.patch
 )
 
 DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt doc/intf-vcd.txt )

--- a/media-video/vlc/vlc-2.2.4.ebuild
+++ b/media-video/vlc/vlc-2.2.4.ebuild
@@ -15,7 +15,7 @@ if [ "${PV%9999}" != "${PV}" ] ; then
 	fi
 fi
 
-inherit eutils multilib autotools toolchain-funcs flag-o-matic versionator virtualx ${SCM}
+inherit autotools flag-o-matic toolchain-funcs versionator virtualx ${SCM}
 
 MY_PV="${PV/_/-}"
 MY_PV="${MY_PV/-beta/-test}"
@@ -62,15 +62,11 @@ RDEPEND="
 	aalib? ( media-libs/aalib:0 )
 	alsa? ( >=media-libs/alsa-lib-1.0.24:0 )
 	avcodec? (
-		!libav? (
-			>=media-video/ffmpeg-2.8:0=
-		)
+		!libav? ( >=media-video/ffmpeg-2.8:0= )
 		libav? ( >=media-video/libav-11:0= )
 	)
 	avformat? (
-		!libav? (
-			>=media-video/ffmpeg-2.8:0=
-		)
+		!libav? ( >=media-video/ffmpeg-2.8:0= )
 		libav? ( media-video/libav:0= )
 	)
 	bidi? ( >=dev-libs/fribidi-0.10.4:0 )
@@ -125,9 +121,8 @@ RDEPEND="
 	)
 	projectm? ( media-libs/libprojectm:0 media-fonts/dejavu:0 )
 	pulseaudio? ( >=media-sound/pulseaudio-1:0 )
-	qt4? ( >=dev-qt/qtgui-4.6:4 >=dev-qt/qtcore-4.6:4 )
-	qt5? ( >=dev-qt/qtgui-5.1:5 >=dev-qt/qtcore-5.1:5 >=dev-qt/qtwidgets-5.5.1-r1:5
-	>=dev-qt/qtx11extras-5.1:5 )
+	!qt5? ( qt4? ( dev-qt/qtcore:4 dev-qt/qtgui:4 ) )
+	qt5? ( dev-qt/qtcore:5 dev-qt/qtgui:5 dev-qt/qtwidgets:5 dev-qt/qtx11extras:5 )
 	rdp? ( >=net-misc/freerdp-1.0.1:0=[client] <net-misc/freerdp-2 )
 	samba? ( || ( ( >=net-fs/samba-3.4.6:0[smbclient] <net-fs/samba-4.0.0_alpha1:0[smbclient] )
 		>=net-fs/samba-4.0.0_alpha1:0[client] ) )
@@ -184,7 +179,7 @@ RDEPEND="${RDEPEND}
 "
 
 DEPEND="${RDEPEND}
-	kde? ( >=kde-base/kdelibs-4:4 )
+	!qt5? ( kde? ( kde-base/kdelibs:4 ) )
 	xcb? ( x11-proto/xproto:0 )
 	app-arch/xz-utils:0
 	x86?   ( dev-lang/yasm:* )
@@ -206,10 +201,10 @@ REQUIRED_USE="
 	libcaca? ( X )
 	libtar? ( skins )
 	libtiger? ( kate )
-	qt4? ( X !qt5 )
-	qt5? ( X !qt4 )
+	qt4? ( X )
+	qt5? ( X )
 	sdl? ( X )
-	skins? ( truetype X xml ^^ ( qt4 qt5 ) )
+	skins? ( truetype X xml || ( qt4 qt5 ) )
 	vaapi? ( avcodec X )
 	vdpau? ( xcb )
 	vlm? ( encode )
@@ -236,6 +231,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.2.4-relax_ffmpeg.patch
 	"${FILESDIR}"/${PN}-2.2.4-ffmpeg3.patch
 )
+
+DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt doc/intf-vcd.txt )
 
 S="${WORKDIR}/${MY_P}"
 
@@ -290,16 +287,18 @@ src_prepare() {
 	# Disable automatic running of tests.
 	find . -name 'Makefile.in' -exec sed -i 's/\(..*\)check-TESTS/\1/' {} \; || die
 
-	# If qtchooser is installed, it may break the build, because moc,rcc and uic binaries for wrong qt version may be used.
-	# Setting QT_SELECT environment variable will enforce correct binaries.
-	if use qt4; then
-		export QT_SELECT=qt4
-	elif use qt5; then
+	# If qtchooser is installed, it may break the build, because moc,rcc and uic binaries for wrong qt
+	# version may be used. Setting QT_SELECT environment variable will enforce correct binaries.
+	if use qt5; then
 		export QT_SELECT=qt5
+	elif use qt4; then
+		export QT_SELECT=qt4
 	fi
 }
 
 src_configure() {
+	local myconf
+
 	# Compatibility fix for Samba 4.
 	use samba && append-cppflags "-I/usr/include/samba-4.0"
 
@@ -319,13 +318,15 @@ src_configure() {
 				--with-default-monospace-font-family=Monospace"
 	fi
 
-	local qt_flag=""
-	if use qt4 ; then
-		qt_flag="--enable-qt=4"
-	elif use qt5 ; then
-		qt_flag="--enable-qt=5"
+	if use qt5 ; then
+		myconf+=" --enable-qt=5"
 	else
-		qt_flag="--disable-qt"
+		if use qt4 ; then
+			myconf+=" --enable-qt=4"
+		else
+			myconf+=" --disable-qt"
+		fi
+		use kde && myconf+=" --with-kde-solid"
 	fi
 
 	econf \
@@ -375,7 +376,6 @@ src_configure() {
 		$(use_enable jack) \
 		$(use_enable jpeg) \
 		$(use_enable kate) \
-		$(use_with kde kde-solid) \
 		$(use_enable libass) \
 		$(use_enable libcaca caca) \
 		$(use_enable libnotify notify) \
@@ -410,7 +410,6 @@ src_configure() {
 		$(use_enable postproc) \
 		$(use_enable projectm) \
 		$(use_enable pulseaudio pulse) \
-		${qt_flag} \
 		$(use_enable rdp freerdp) \
 		$(use_enable rtsp realrtsp) \
 		$(use_enable run-as-root) \
@@ -488,13 +487,11 @@ src_test() {
 	virtx emake check-TESTS
 }
 
-DOCS="AUTHORS THANKS NEWS README doc/fortunes.txt doc/intf-vcd.txt"
-
 src_install() {
 	default
 
 	# Punt useless libtool's .la files
-	find "${D}" -name '*.la' -delete
+	find "${D}" -name '*.la' -delete || die
 }
 
 pkg_postinst() {

--- a/media-video/vlc/vlc-2.2.4.ebuild
+++ b/media-video/vlc/vlc-2.2.4.ebuild
@@ -45,7 +45,7 @@ IUSE="a52 aalib alsa altivec atmo +audioqueue +avcodec
 	growl httpd ieee1394 jack jpeg kate kde libass libav libcaca libnotify
 	+libsamplerate libtiger linsys libtar lirc live lua
 	macosx-dialog-provider macosx-eyetv macosx-quartztext macosx-qtkit
-	matroska media-library cpu_flags_x86_mmx modplug mp3 mpeg
+	matroska cpu_flags_x86_mmx modplug mp3 mpeg
 	mtp musepack ncurses neon ogg omxil opencv opengl optimisememory opus
 	png postproc projectm pulseaudio +qt4 qt5 rdp rtsp run-as-root samba
 	schroedinger sdl sdl-image sftp shout sid skins speex cpu_flags_x86_sse svg +swscale

--- a/media-video/vlc/vlc-2.2.9999.ebuild
+++ b/media-video/vlc/vlc-2.2.9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI=6
 
 SCM=""
 if [ "${PV%9999}" != "${PV}" ] ; then
@@ -15,7 +15,7 @@ if [ "${PV%9999}" != "${PV}" ] ; then
 	fi
 fi
 
-inherit eutils multilib autotools toolchain-funcs flag-o-matic versionator virtualx ${SCM}
+inherit autotools flag-o-matic toolchain-funcs versionator virtualx ${SCM}
 
 MY_PV="${PV/_/-}"
 MY_PV="${MY_PV/-beta/-test}"
@@ -53,131 +53,130 @@ IUSE="a52 aalib alsa altivec atmo +audioqueue +avcodec
 	vlm vnc vorbis vpx wma-fixed +X x264 x265 +xcb xml xv zvbi zeroconf"
 
 RDEPEND="
-		!<media-video/ffmpeg-1.2:0
-		dev-libs/libgpg-error:0
-		net-dns/libidn:0
-		>=sys-libs/zlib-1.2.5.1-r2:0[minizip]
-		virtual/libintl:0
-		a52? ( >=media-libs/a52dec-0.7.4-r3:0 )
-		aalib? ( media-libs/aalib:0 )
-		alsa? ( >=media-libs/alsa-lib-1.0.24:0 )
-		avcodec? (
-			!libav? ( media-video/ffmpeg:0= )
-			libav? ( media-video/libav:0= )
-		)
-		avformat? (
-			!libav? ( media-video/ffmpeg:0= )
-			libav? ( media-video/libav:0= )
-		)
-		bidi? ( >=dev-libs/fribidi-0.10.4:0 )
-		bluray? ( >=media-libs/libbluray-0.3:0 )
-		cddb? ( >=media-libs/libcddb-1.2:0 )
-		chromaprint? ( >=media-libs/chromaprint-0.6:0 )
-		dbus? ( >=sys-apps/dbus-1.6:0 )
-		dc1394? ( >=sys-libs/libraw1394-2.0.1:0 >=media-libs/libdc1394-2.1:2 )
-		directfb? ( dev-libs/DirectFB:0 sys-libs/zlib:0 )
-		dts? ( >=media-libs/libdca-0.0.5:0 )
-		dvbpsi? ( >=media-libs/libdvbpsi-1.0.0:0= )
-		dvd? ( >=media-libs/libdvdread-4.9:0 >=media-libs/libdvdnav-4.9:0 )
-		elibc_glibc? ( >=sys-libs/glibc-2.8:2.2 )
-		faad? ( >=media-libs/faad2-2.6.1:0 )
-		fdk? ( media-libs/fdk-aac:0 )
-		flac? ( >=media-libs/libogg-1:0 >=media-libs/flac-1.1.2:0 )
-		fluidsynth? ( >=media-sound/fluidsynth-1.1.2:0 )
-		fontconfig? ( media-libs/fontconfig:1.0 )
-		gcrypt? ( >=dev-libs/libgcrypt-1.2.0:0= )
-		gme? ( media-libs/game-music-emu:0 )
-		gnome? ( gnome-base/gnome-vfs:2 dev-libs/glib:2 )
-		gnutls? ( >=net-libs/gnutls-3.0.20:0 )
-		gstreamer? ( >=media-libs/gst-plugins-base-1.4.5:1.0 )
-		ieee1394? ( >=sys-libs/libraw1394-2.0.1:0 >=sys-libs/libavc1394-0.5.3:0 )
-		jack? ( >=media-sound/jack-audio-connection-kit-0.99.0-r1:0 )
-		jpeg? ( virtual/jpeg:0 )
-		kate? ( >=media-libs/libkate-0.3:0 )
-		libass? ( >=media-libs/libass-0.9.8:0 media-libs/fontconfig:1.0 )
-		libcaca? ( >=media-libs/libcaca-0.99_beta14:0 )
-		libnotify? ( x11-libs/libnotify:0 x11-libs/gtk+:2 x11-libs/gdk-pixbuf:2 dev-libs/glib:2 )
-		libsamplerate? ( media-libs/libsamplerate:0 )
-		libtar? ( >=dev-libs/libtar-1.2.11-r3:0 )
-		libtiger? ( >=media-libs/libtiger-0.3.1:0 )
-		linsys? ( >=media-libs/zvbi-0.2.28:0 )
-		lirc? ( app-misc/lirc:0 )
-		live? ( >=media-plugins/live-2011.12.23:0 )
-		lua? ( >=dev-lang/lua-5.1:0 )
-		matroska? (	>=dev-libs/libebml-1:0= >=media-libs/libmatroska-1:0= )
-		modplug? ( >=media-libs/libmodplug-0.8.4:0 !~media-libs/libmodplug-0.8.8 )
-		mp3? ( media-libs/libmad:0 )
-		mpeg? ( >=media-libs/libmpeg2-0.3.2:0 )
-		mtp? ( >=media-libs/libmtp-1:0 )
-		musepack? ( >=media-sound/musepack-tools-444:0 )
-		ncurses? ( sys-libs/ncurses:0=[unicode] )
-		ogg? ( >=media-libs/libogg-1:0 )
-		opencv? ( >media-libs/opencv-2:0 )
-		opengl? ( virtual/opengl:0 >=x11-libs/libX11-1.3.99.901:0 )
-		opus? ( >=media-libs/opus-1.0.3:0 )
-		png? ( media-libs/libpng:0= sys-libs/zlib:0 )
-		postproc? (
-			!libav? ( >=media-video/ffmpeg-2.2:0= )
-			libav? ( media-libs/libpostproc:0= )
-		)
-		projectm? ( media-libs/libprojectm:0 media-fonts/dejavu:0 )
-		pulseaudio? ( >=media-sound/pulseaudio-1:0 )
-		qt4? ( >=dev-qt/qtgui-4.6:4 >=dev-qt/qtcore-4.6:4 )
-		qt5? ( >=dev-qt/qtgui-5.1:5 >=dev-qt/qtcore-5.1:5 >=dev-qt/qtwidgets-5.1:5  >=dev-qt/qtx11extras-5.1:5 )
-		rdp? ( >=net-misc/freerdp-1.0.1:0= )
-		samba? ( || ( >=net-fs/samba-3.4.6:0[smbclient] >=net-fs/samba-4:0[client] ) )
-		schroedinger? ( >=media-libs/schroedinger-1.0.10:0 )
-		sdl? ( >=media-libs/libsdl-1.2.10:0
-			sdl-image? ( >=media-libs/sdl-image-1.2.10:0 sys-libs/zlib:0 ) )
-		sftp? ( net-libs/libssh2:0 )
-		shout? ( >=media-libs/libshout-2.1:0 )
-		sid? ( media-libs/libsidplay:2 )
-		skins? ( x11-libs/libXext:0 x11-libs/libXpm:0 x11-libs/libXinerama:0 )
-		speex? ( media-libs/speex:0 )
-		svg? ( >=gnome-base/librsvg-2.9:2 >=x11-libs/cairo-1.13.1:0 )
-		swscale? (
-			!libav? ( media-video/ffmpeg:0= )
-			libav? ( media-video/libav:0= )
-		)
-		taglib? ( >=media-libs/taglib-1.9:0 sys-libs/zlib:0 )
-		theora? ( >=media-libs/libtheora-1.0_beta3:0 )
-		tremor? ( media-libs/tremor:0 )
-		truetype? ( media-libs/freetype:2 virtual/ttf-fonts:0
-			!fontconfig? ( media-fonts/dejavu:0 ) )
-		twolame? ( media-sound/twolame:0 )
-		udev? ( >=virtual/udev-142:0 )
-		upnp? ( net-libs/libupnp:0 )
-		v4l? ( media-libs/libv4l:0 )
-		vaapi? (
-			x11-libs/libva:0[X,drm]
-			!libav? ( media-video/ffmpeg:0=[vaapi] )
-			libav? ( media-video/libav:0=[vaapi] )
-		)
-		vcdx? ( >=dev-libs/libcdio-0.78.2:0 >=media-video/vcdimager-0.7.22:0 )
-		zeroconf? ( >=net-dns/avahi-0.6:0[dbus] )
+	dev-libs/libgpg-error:0
+	net-dns/libidn:0
+	sys-libs/zlib:0[minizip]
+	virtual/libintl:0
+	a52? ( >=media-libs/a52dec-0.7.4-r3:0 )
+	aalib? ( media-libs/aalib:0 )
+	alsa? ( >=media-libs/alsa-lib-1.0.24:0 )
+	avcodec? (
+		!libav? ( media-video/ffmpeg:0= )
+		libav? ( media-video/libav:0= )
+	)
+	avformat? (
+		!libav? ( media-video/ffmpeg:0= )
+		libav? ( media-video/libav:0= )
+	)
+	bidi? ( dev-libs/fribidi:0 )
+	bluray? ( >=media-libs/libbluray-0.3:0 )
+	cddb? ( >=media-libs/libcddb-1.2:0 )
+	chromaprint? ( >=media-libs/chromaprint-0.6:0 )
+	dbus? ( >=sys-apps/dbus-1.6:0 )
+	dc1394? ( >=sys-libs/libraw1394-2.0.1:0 >=media-libs/libdc1394-2.1:2 )
+	directfb? ( dev-libs/DirectFB:0 sys-libs/zlib:0 )
+	dts? ( >=media-libs/libdca-0.0.5:0 )
+	dvbpsi? ( >=media-libs/libdvbpsi-1.0.0:0= )
+	dvd? ( >=media-libs/libdvdread-4.9:0 >=media-libs/libdvdnav-4.9:0 )
+	elibc_glibc? ( >=sys-libs/glibc-2.8:2.2 )
+	faad? ( >=media-libs/faad2-2.6.1:0 )
+	fdk? ( media-libs/fdk-aac:0 )
+	flac? ( >=media-libs/libogg-1:0 >=media-libs/flac-1.1.2:0 )
+	fluidsynth? ( >=media-sound/fluidsynth-1.1.2:0 )
+	fontconfig? ( media-libs/fontconfig:1.0 )
+	gcrypt? ( >=dev-libs/libgcrypt-1.2.0:0= )
+	gme? ( media-libs/game-music-emu:0 )
+	gnome? ( gnome-base/gnome-vfs:2 dev-libs/glib:2 )
+	gnutls? ( >=net-libs/gnutls-3.0.20:0 )
+	gstreamer? ( >=media-libs/gst-plugins-base-1.4.5:1.0 )
+	ieee1394? ( >=sys-libs/libraw1394-2.0.1:0 >=sys-libs/libavc1394-0.5.3:0 )
+	jack? ( >=media-sound/jack-audio-connection-kit-0.99.0-r1:0 )
+	jpeg? ( virtual/jpeg:0 )
+	kate? ( >=media-libs/libkate-0.3:0 )
+	libass? ( >=media-libs/libass-0.9.8:0 media-libs/fontconfig:1.0 )
+	libcaca? ( >=media-libs/libcaca-0.99_beta14:0 )
+	libnotify? ( x11-libs/libnotify:0 x11-libs/gtk+:2 x11-libs/gdk-pixbuf:2 dev-libs/glib:2 )
+	libsamplerate? ( media-libs/libsamplerate:0 )
+	libtar? ( >=dev-libs/libtar-1.2.11-r3:0 )
+	libtiger? ( >=media-libs/libtiger-0.3.1:0 )
+	linsys? ( >=media-libs/zvbi-0.2.28:0 )
+	lirc? ( app-misc/lirc:0 )
+	live? ( >=media-plugins/live-2011.12.23:0 )
+	lua? ( >=dev-lang/lua-5.1:0 )
+	matroska? (	>=dev-libs/libebml-1:0= >=media-libs/libmatroska-1:0= )
+	modplug? ( >=media-libs/libmodplug-0.8.4:0 !~media-libs/libmodplug-0.8.8 )
+	mp3? ( media-libs/libmad:0 )
+	mpeg? ( >=media-libs/libmpeg2-0.3.2:0 )
+	mtp? ( >=media-libs/libmtp-1:0 )
+	musepack? ( >=media-sound/musepack-tools-444:0 )
+	ncurses? ( sys-libs/ncurses:0=[unicode] )
+	ogg? ( >=media-libs/libogg-1:0 )
+	opencv? ( >media-libs/opencv-2:0 )
+	opengl? ( virtual/opengl:0 >=x11-libs/libX11-1.3.99.901:0 )
+	opus? ( >=media-libs/opus-1.0.3:0 )
+	png? ( media-libs/libpng:0= sys-libs/zlib:0 )
+	postproc? (
+		!libav? ( >=media-video/ffmpeg-2.2:0= )
+		libav? ( media-libs/libpostproc:0= )
+	)
+	projectm? ( media-libs/libprojectm:0 media-fonts/dejavu:0 )
+	pulseaudio? ( >=media-sound/pulseaudio-1:0 )
+	!qt5? ( qt4? ( dev-qt/qtcore:4 dev-qt/qtgui:4 ) )
+	qt5? ( dev-qt/qtcore:5 dev-qt/qtgui:5 dev-qt/qtwidgets:5 dev-qt/qtx11extras:5 )
+	rdp? ( >=net-misc/freerdp-1.0.1:0= )
+	samba? ( || ( >=net-fs/samba-3.4.6:0[smbclient] >=net-fs/samba-4:0[client] ) )
+	schroedinger? ( >=media-libs/schroedinger-1.0.10:0 )
+	sdl? ( >=media-libs/libsdl-1.2.10:0
+		sdl-image? ( >=media-libs/sdl-image-1.2.10:0 sys-libs/zlib:0 ) )
+	sftp? ( net-libs/libssh2:0 )
+	shout? ( >=media-libs/libshout-2.1:0 )
+	sid? ( media-libs/libsidplay:2 )
+	skins? ( x11-libs/libXext:0 x11-libs/libXpm:0 x11-libs/libXinerama:0 )
+	speex? ( media-libs/speex:0 )
+	svg? ( >=gnome-base/librsvg-2.9:2 >=x11-libs/cairo-1.13.1:0 )
+	swscale? (
+		!libav? ( media-video/ffmpeg:0= )
+		libav? ( media-video/libav:0= )
+	)
+	taglib? ( >=media-libs/taglib-1.9:0 sys-libs/zlib:0 )
+	theora? ( >=media-libs/libtheora-1.0_beta3:0 )
+	tremor? ( media-libs/tremor:0 )
+	truetype? ( media-libs/freetype:2 virtual/ttf-fonts:0
+		!fontconfig? ( media-fonts/dejavu:0 ) )
+	twolame? ( media-sound/twolame:0 )
+	udev? ( >=virtual/udev-142:0 )
+	upnp? ( net-libs/libupnp:0 )
+	v4l? ( media-libs/libv4l:0 )
+	vaapi? (
+		x11-libs/libva:0[X,drm]
+		!libav? ( media-video/ffmpeg:0=[vaapi] )
+		libav? ( media-video/libav:0=[vaapi] )
+	)
+	vcdx? ( >=dev-libs/libcdio-0.78.2:0 >=media-video/vcdimager-0.7.22:0 )
+	zeroconf? ( >=net-dns/avahi-0.6:0[dbus] )
 "
 
 # Temporarily block non-live FFMPEG versions as they break vdpau, 9999 works;
 # thus we'll have to wait for a new release there.
 RDEPEND="${RDEPEND}
-		vdpau? (
-			>=x11-libs/libvdpau-0.6:0
-			!libav? ( >=media-video/ffmpeg-2.2:0= )
-			libav? ( >=media-video/libav-10:0= )
-		)
-		vnc? ( >=net-libs/libvncserver-0.9.9:0 )
-		vorbis? ( >=media-libs/libvorbis-1.1:0 )
-		vpx? ( media-libs/libvpx:0= )
-		X? ( x11-libs/libX11:0 )
-		x264? ( >=media-libs/x264-0.0.20090923:0= )
-		x265? ( media-libs/x265:0= )
-		xcb? ( >=x11-libs/libxcb-1.6:0 >=x11-libs/xcb-util-0.3.4:0 >=x11-libs/xcb-util-keysyms-0.3.4:0 )
-		xml? ( >=dev-libs/libxml2-2.5:2 )
-		zvbi? ( >=media-libs/zvbi-0.2.25:0 )
+	vdpau? (
+		x11-libs/libvdpau:0
+		!libav? ( media-video/ffmpeg:0= )
+		libav? ( >=media-video/libav-10:0= )
+	)
+	vnc? ( >=net-libs/libvncserver-0.9.9:0 )
+	vorbis? ( media-libs/libvorbis:0 )
+	vpx? ( media-libs/libvpx:0= )
+	X? ( x11-libs/libX11:0 )
+	x264? ( media-libs/x264:0= )
+	x265? ( media-libs/x265:0= )
+	xcb? ( x11-libs/libxcb:0 x11-libs/xcb-util:0 x11-libs/xcb-util-keysyms:0 )
+	xml? ( dev-libs/libxml2:2 )
+	zvbi? ( media-libs/zvbi:0 )
 "
 
 DEPEND="${RDEPEND}
-	kde? ( >=kde-base/kdelibs-4:4 )
+	!qt5? ( kde? ( kde-base/kdelibs:4 ) )
 	xcb? ( x11-proto/xproto:0 )
 	app-arch/xz-utils:0
 	dev-lang/yasm:*
@@ -198,14 +197,33 @@ REQUIRED_USE="
 	libcaca? ( X )
 	libtar? ( skins )
 	libtiger? ( kate )
-	qt4? ( X !qt5 )
-	qt5? ( X !qt4 )
+	qt4? ( X )
+	qt5? ( X )
 	sdl? ( X )
-	skins? ( truetype X ^^ ( qt4 qt5 ) )
+	skins? ( truetype X || ( qt4 qt5 ) )
 	vaapi? ( avcodec X )
 	vlm? ( encode )
 	xv? ( xcb )
 "
+
+PATCHES=(
+	# Fix build system mistake.
+	"${FILESDIR}"/${PN}-2.1.0-fix-libtremor-libs.patch
+
+	# Patch up incompatibilities and reconfigure autotools.
+	"${FILESDIR}"/${PN}-9999-libva-1.2.1-compat.patch
+
+	# Fix up broken audio when skipping using a fixed reversed bisected commit.
+	"${FILESDIR}"/${PN}-2.1.0-TomWij-bisected-PA-broken-underflow.patch
+
+	# Bug #541678
+	"${FILESDIR}"/qt4-select.patch
+
+	# Allow QT5.5 since Gentoo has a patched QTwidgets
+	"${FILESDIR}"/${PN}-2.2.2-qt5widgets.patch
+)
+
+DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt doc/intf-vcd.txt )
 
 S="${WORKDIR}/${MY_P}"
 
@@ -248,40 +266,30 @@ src_prepare() {
 	# We are not in a real git checkout due to the absence of a .git directory.
 	touch src/revision.txt || die
 
-	# Fix build system mistake.
-	epatch "${FILESDIR}"/${PN}-2.1.0-fix-libtremor-libs.patch
-
-	# Patch up incompatibilities and reconfigure autotools.
-	epatch "${FILESDIR}"/${PN}-9999-libva-1.2.1-compat.patch
-
-	# Fix up broken audio when skipping using a fixed reversed bisected commit.
-	epatch "${FILESDIR}"/${PN}-2.1.0-TomWij-bisected-PA-broken-underflow.patch
-
-	# Allow QT5.5 since Gentoo has a patched QTwidgets
-	epatch "${FILESDIR}"/${PN}-2.2.2-qt5widgets.patch
+	default
 
 	# Don't use --started-from-file when not using dbus.
 	if ! use dbus ; then
 		sed -i 's/ --started-from-file//' share/vlc.desktop.in || die
 	fi
 
-	epatch_user
-
 	eautoreconf
 
 	# Disable automatic running of tests.
 	find . -name 'Makefile.in' -exec sed -i 's/\(..*\)check-TESTS/\1/' {} \; || die
 
-	# If qtchooser is installed, it may break the build, because moc,rcc and uic binaries for wrong qt version may be used.
-	# Setting QT_SELECT environment variable will enforce correct binaries.
-	if use qt4; then
-		export QT_SELECT=qt4
-	elif use qt5; then
+	# If qtchooser is installed, it may break the build, because moc,rcc and uic binaries for wrong qt
+	# version may be used. Setting QT_SELECT environment variable will enforce correct binaries.
+	if use qt5; then
 		export QT_SELECT=qt5
+	elif use qt4; then
+		export QT_SELECT=qt4
 	fi
 }
 
 src_configure() {
+	local myconf
+
 	# Compatibility fix for Samba 4.
 	use samba && append-cppflags "-I/usr/include/samba-4.0"
 
@@ -301,9 +309,15 @@ src_configure() {
 				--with-default-monospace-font-family=Monospace"
 	fi
 
-	local qt_flag=""
-	if use qt4 || use qt5 ; then
-		qt_flag="--enable-qt"
+	if use qt5 ; then
+		myconf+=" --enable-qt=5"
+	else
+		if use qt4 ; then
+			myconf+=" --enable-qt=4"
+		else
+			myconf+=" --disable-qt"
+		fi
+		use kde && myconf+=" --with-kde-solid"
 	fi
 
 	econf \
@@ -354,7 +368,6 @@ src_configure() {
 		$(use_enable jack) \
 		$(use_enable jpeg) \
 		$(use_enable kate) \
-		$(use_with kde kde-solid) \
 		$(use_enable libass) \
 		$(use_enable libcaca caca) \
 		$(use_enable libnotify notify) \
@@ -389,7 +402,6 @@ src_configure() {
 		$(use_enable postproc) \
 		$(use_enable projectm) \
 		$(use_enable pulseaudio pulse) \
-		${qt_flag} \
 		$(use_enable rdp freerdp) \
 		$(use_enable rtsp realrtsp) \
 		$(use_enable run-as-root) \
@@ -464,16 +476,14 @@ src_configure() {
 }
 
 src_test() {
-	Xemake check-TESTS
+	virtx emake check-TESTS
 }
-
-DOCS="AUTHORS THANKS NEWS README doc/fortunes.txt doc/intf-vcd.txt"
 
 src_install() {
 	default
 
 	# Punt useless libtool's .la files
-	find "${D}" -name '*.la' -delete
+	find "${D}" -name '*.la' -delete || die
 }
 
 pkg_postinst() {

--- a/media-video/vlc/vlc-2.2.9999.ebuild
+++ b/media-video/vlc/vlc-2.2.9999.ebuild
@@ -45,7 +45,7 @@ IUSE="a52 aalib alsa altivec atmo +audioqueue +avcodec
 	growl gstreamer httpd ieee1394 jack jpeg kate kde libass libav libcaca libnotify
 	+libsamplerate libtiger linsys libtar lirc live lua
 	macosx-dialog-provider macosx-eyetv macosx-quartztext macosx-qtkit
-	matroska media-library cpu_flags_x86_mmx modplug mp3 mpeg
+	matroska cpu_flags_x86_mmx modplug mp3 mpeg
 	mtp musepack ncurses neon ogg omxil opencv opengl optimisememory opus
 	png +postproc projectm pulseaudio +qt4 qt5 rdp rtsp run-as-root samba
 	schroedinger sdl sdl-image sftp shout sid skins speex cpu_flags_x86_sse svg +swscale
@@ -224,6 +224,10 @@ PATCHES=(
 
 	# Bug #589396
 	"${FILESDIR}"/${PN}-2.2.4-cxx0x.patch
+
+	# Bug #594126
+	"${FILESDIR}"/${PN}-2.2.4-decoder-lock-scope.patch
+	"${FILESDIR}"/${PN}-2.2.4-alsa-large-buffers.patch
 )
 
 DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt doc/intf-vcd.txt )

--- a/media-video/vlc/vlc-2.2.9999.ebuild
+++ b/media-video/vlc/vlc-2.2.9999.ebuild
@@ -221,6 +221,9 @@ PATCHES=(
 
 	# Allow QT5.5 since Gentoo has a patched QTwidgets
 	"${FILESDIR}"/${PN}-2.2.2-qt5widgets.patch
+
+	# Bug #589396
+	"${FILESDIR}"/${PN}-2.2.4-cxx0x.patch
 )
 
 DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt doc/intf-vcd.txt )

--- a/media-video/vlc/vlc-9999.ebuild
+++ b/media-video/vlc/vlc-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="6"
+EAPI=6
 
 SCM=""
 if [ "${PV%9999}" != "${PV}" ] ; then
@@ -15,7 +15,7 @@ if [ "${PV%9999}" != "${PV}" ] ; then
 	fi
 fi
 
-inherit eutils multilib autotools toolchain-funcs flag-o-matic versionator virtualx ${SCM}
+inherit autotools flag-o-matic toolchain-funcs versionator virtualx ${SCM}
 
 MY_PV="${PV/_/-}"
 MY_PV="${MY_PV/-beta/-test}"
@@ -53,134 +53,130 @@ IUSE="a52 aalib alsa altivec +audioqueue +avcodec
 	vlm vnc vorbis vpx wma-fixed +X x264 x265 +xcb xml xv zvbi zeroconf"
 
 RDEPEND="
-		!<media-video/ffmpeg-1.2:0
-		dev-libs/libgpg-error:0
-		net-dns/libidn:0
-		>=sys-libs/zlib-1.2.5.1-r2:0[minizip]
-		virtual/libintl:0
-		a52? ( >=media-libs/a52dec-0.7.4-r3:0 )
-		aalib? ( media-libs/aalib:0 )
-		alsa? ( >=media-libs/alsa-lib-1.0.24:0 )
-		avcodec? (
-			!libav? ( media-video/ffmpeg:0= )
-			libav? ( media-video/libav:0= )
-		)
-		avformat? (
-			!libav? ( media-video/ffmpeg:0= )
-			libav? ( media-video/libav:0= )
-		)
-		bidi? ( >=dev-libs/fribidi-0.10.4:0 )
-		bluray? ( >=media-libs/libbluray-0.6.2:0 )
-		cddb? ( >=media-libs/libcddb-1.2:0 )
-		chromaprint? ( >=media-libs/chromaprint-0.6:0 )
-		chromecast? ( >=dev-libs/protobuf-2.5.0 )
-		dbus? ( >=sys-apps/dbus-1.6:0 )
-		dc1394? ( >=sys-libs/libraw1394-2.0.1:0 >=media-libs/libdc1394-2.1:2 )
-		directfb? ( dev-libs/DirectFB:0 sys-libs/zlib:0 )
-		dts? ( >=media-libs/libdca-0.0.5:0 )
-		dvbpsi? ( >=media-libs/libdvbpsi-1.2.0:0= )
-		dvd? ( >=media-libs/libdvdread-4.9:0 >=media-libs/libdvdnav-4.9:0 )
-		elibc_glibc? ( >=sys-libs/glibc-2.8:2.2 )
-		faad? ( >=media-libs/faad2-2.6.1:0 )
-		fdk? ( media-libs/fdk-aac:0 )
-		flac? ( >=media-libs/libogg-1:0 >=media-libs/flac-1.1.2:0 )
-		fluidsynth? ( >=media-sound/fluidsynth-1.1.2:0 )
-		fontconfig? ( media-libs/fontconfig:1.0 )
-		gcrypt? ( >=dev-libs/libgcrypt-1.6.0:0= )
-		gme? ( media-libs/game-music-emu:0 )
-		gnutls? ( >=net-libs/gnutls-3.2.0:0 )
-		gstreamer? ( >=media-libs/gst-plugins-base-1.4.5:1.0 )
-		ieee1394? ( >=sys-libs/libraw1394-2.0.1:0 >=sys-libs/libavc1394-0.5.3:0 )
-		jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0 )
-		jpeg? ( virtual/jpeg:0 )
-		kate? ( >=media-libs/libkate-0.3:0 )
-		libass? ( >=media-libs/libass-0.9.8:0 media-libs/fontconfig:1.0 )
-		libcaca? ( >=media-libs/libcaca-0.99_beta14:0 )
-		libnotify? ( x11-libs/libnotify:0 x11-libs/gtk+:2 x11-libs/gdk-pixbuf:2 dev-libs/glib:2 )
-		libsamplerate? ( media-libs/libsamplerate:0 )
-		libtar? ( >=dev-libs/libtar-1.2.11-r3:0 )
-		libtiger? ( >=media-libs/libtiger-0.3.1:0 )
-		linsys? ( >=media-libs/zvbi-0.2.28:0 )
-		lirc? ( app-misc/lirc:0 )
-		live? ( >=media-plugins/live-2011.12.23:0 )
-		lua? ( >=dev-lang/lua-5.1:0 )
-		matroska? (	>=dev-libs/libebml-1:0= >=media-libs/libmatroska-1:0= )
-		modplug? ( >=media-libs/libmodplug-0.8.4:0 !~media-libs/libmodplug-0.8.8 )
-		mp3? ( media-libs/libmad:0 )
-		mpeg? ( >=media-libs/libmpeg2-0.3.2:0 )
-		mtp? ( >=media-libs/libmtp-1:0 )
-		musepack? ( >=media-sound/musepack-tools-444:0 )
-		ncurses? ( sys-libs/ncurses:0=[unicode] )
-		ogg? ( >=media-libs/libogg-1:0 )
-		opencv? ( >media-libs/opencv-2:0 )
-		opengl? ( virtual/opengl:0 >=x11-libs/libX11-1.3.99.901:0 )
-		opus? ( >=media-libs/opus-1.0.3:0 )
-		png? ( media-libs/libpng:0= sys-libs/zlib:0 )
-		postproc? (
-			!libav? ( >=media-video/ffmpeg-3.1.3:0= )
-			libav? ( media-libs/libpostproc:0= )
-		)
-		projectm? ( media-libs/libprojectm:0 media-fonts/dejavu:0 )
-		pulseaudio? ( >=media-sound/pulseaudio-1:0 )
-		qt4? ( >=dev-qt/qtgui-4.6:4 >=dev-qt/qtcore-4.6:4 )
-		qt5? ( >=dev-qt/qtgui-5.2:5 >=dev-qt/qtcore-5.2:5 >=dev-qt/qtwidgets-5.2:5  >=dev-qt/qtx11extras-5.2:5 )
-		rdp? ( >=net-misc/freerdp-1.0.1:0= )
-		samba? ( || ( >=net-fs/samba-3.4.6:0[smbclient] >=net-fs/samba-4:0[client] ) )
-		schroedinger? ( >=media-libs/schroedinger-1.0.10:0 )
-		sdl? ( >=media-libs/libsdl-1.2.10:0
-			sdl-image? ( >=media-libs/sdl-image-1.2.10:0 sys-libs/zlib:0 ) )
-		sftp? ( net-libs/libssh2:0 )
-		shout? ( >=media-libs/libshout-2.1:0 )
-		sid? ( media-libs/libsidplay:2 )
-		skins? ( x11-libs/libXext:0 x11-libs/libXpm:0 x11-libs/libXinerama:0 )
-		speex? ( media-libs/speex:0 )
-		svg? ( >=gnome-base/librsvg-2.9:2 >=x11-libs/cairo-1.13.1:0 )
-		swscale? (
-			!libav? ( media-video/ffmpeg:0= )
-			libav? ( media-video/libav:0= )
-		)
-		taglib? ( >=media-libs/taglib-1.9:0 sys-libs/zlib:0 )
-		theora? ( >=media-libs/libtheora-1.0_beta3:0 )
-		tremor? ( media-libs/tremor:0 )
-		truetype? ( media-libs/freetype:2 virtual/ttf-fonts:0
-			!fontconfig? ( media-fonts/dejavu:0 ) )
-		twolame? ( media-sound/twolame:0 )
-		udev? ( >=virtual/udev-142:0 )
-		upnp? ( net-libs/libupnp:0 )
-		v4l? ( media-libs/libv4l:0 )
-		vaapi? (
-			x11-libs/libva:0[X,drm]
-			!libav? ( >=media-video/ffmpeg-3.1.3:0=[vaapi] )
-			libav? ( media-video/libav:0=[vaapi] )
-		)
-		vcd? ( >=dev-libs/libcdio-0.78.2:0 )
-		zeroconf? ( >=net-dns/avahi-0.6:0[dbus] )
+	dev-libs/libgpg-error:0
+	net-dns/libidn:0
+	sys-libs/zlib:0[minizip]
+	virtual/libintl:0
+	a52? ( >=media-libs/a52dec-0.7.4-r3:0 )
+	aalib? ( media-libs/aalib:0 )
+	alsa? ( >=media-libs/alsa-lib-1.0.24:0 )
+	avcodec? (
+		!libav? ( media-video/ffmpeg:0= )
+		libav? ( media-video/libav:0= )
+	)
+	avformat? (
+		!libav? ( media-video/ffmpeg:0= )
+		libav? ( media-video/libav:0= )
+	)
+	bidi? ( dev-libs/fribidi:0 )
+	bluray? ( >=media-libs/libbluray-0.6.2:0 )
+	cddb? ( >=media-libs/libcddb-1.2:0 )
+	chromaprint? ( >=media-libs/chromaprint-0.6:0 )
+	chromecast? ( >=dev-libs/protobuf-2.5.0 )
+	dbus? ( >=sys-apps/dbus-1.6:0 )
+	dc1394? ( >=sys-libs/libraw1394-2.0.1:0 >=media-libs/libdc1394-2.1:2 )
+	directfb? ( dev-libs/DirectFB:0 sys-libs/zlib:0 )
+	dts? ( >=media-libs/libdca-0.0.5:0 )
+	dvbpsi? ( >=media-libs/libdvbpsi-1.2.0:0= )
+	dvd? ( >=media-libs/libdvdread-4.9:0 >=media-libs/libdvdnav-4.9:0 )
+	elibc_glibc? ( >=sys-libs/glibc-2.8:2.2 )
+	faad? ( >=media-libs/faad2-2.6.1:0 )
+	fdk? ( media-libs/fdk-aac:0 )
+	flac? ( >=media-libs/libogg-1:0 >=media-libs/flac-1.1.2:0 )
+	fluidsynth? ( >=media-sound/fluidsynth-1.1.2:0 )
+	fontconfig? ( media-libs/fontconfig:1.0 )
+	gcrypt? ( >=dev-libs/libgcrypt-1.6.0:0= )
+	gme? ( media-libs/game-music-emu:0 )
+	gnutls? ( >=net-libs/gnutls-3.2.0:0 )
+	gstreamer? ( >=media-libs/gst-plugins-base-1.4.5:1.0 )
+	ieee1394? ( >=sys-libs/libraw1394-2.0.1:0 >=sys-libs/libavc1394-0.5.3:0 )
+	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0 )
+	jpeg? ( virtual/jpeg:0 )
+	kate? ( >=media-libs/libkate-0.3:0 )
+	libass? ( >=media-libs/libass-0.9.8:0 media-libs/fontconfig:1.0 )
+	libcaca? ( >=media-libs/libcaca-0.99_beta14:0 )
+	libnotify? ( x11-libs/libnotify:0 x11-libs/gtk+:2 x11-libs/gdk-pixbuf:2 dev-libs/glib:2 )
+	libsamplerate? ( media-libs/libsamplerate:0 )
+	libtar? ( >=dev-libs/libtar-1.2.11-r3:0 )
+	libtiger? ( >=media-libs/libtiger-0.3.1:0 )
+	linsys? ( >=media-libs/zvbi-0.2.28:0 )
+	lirc? ( app-misc/lirc:0 )
+	live? ( >=media-plugins/live-2011.12.23:0 )
+	lua? ( >=dev-lang/lua-5.1:0 )
+	matroska? (	>=dev-libs/libebml-1:0= >=media-libs/libmatroska-1:0= )
+	modplug? ( >=media-libs/libmodplug-0.8.4:0 !~media-libs/libmodplug-0.8.8 )
+	mp3? ( media-libs/libmad:0 )
+	mpeg? ( >=media-libs/libmpeg2-0.3.2:0 )
+	mtp? ( >=media-libs/libmtp-1:0 )
+	musepack? ( >=media-sound/musepack-tools-444:0 )
+	ncurses? ( sys-libs/ncurses:0=[unicode] )
+	ogg? ( >=media-libs/libogg-1:0 )
+	opencv? ( >media-libs/opencv-2:0 )
+	opengl? ( virtual/opengl:0 >=x11-libs/libX11-1.3.99.901:0 )
+	opus? ( >=media-libs/opus-1.0.3:0 )
+	png? ( media-libs/libpng:0= sys-libs/zlib:0 )
+	postproc? (
+		!libav? ( >=media-video/ffmpeg-3.1.3:0= )
+		libav? ( media-libs/libpostproc:0= )
+	)
+	projectm? ( media-libs/libprojectm:0 media-fonts/dejavu:0 )
+	pulseaudio? ( >=media-sound/pulseaudio-1:0 )
+	!qt5? ( qt4? ( dev-qt/qtcore:4 dev-qt/qtgui:4 ) )
+	qt5? ( dev-qt/qtcore:5 dev-qt/qtgui:5 dev-qt/qtwidgets:5 dev-qt/qtx11extras:5 )
+	rdp? ( >=net-misc/freerdp-1.0.1:0= )
+	samba? ( || ( >=net-fs/samba-3.4.6:0[smbclient] >=net-fs/samba-4:0[client] ) )
+	schroedinger? ( >=media-libs/schroedinger-1.0.10:0 )
+	sdl? ( >=media-libs/libsdl-1.2.10:0
+		sdl-image? ( >=media-libs/sdl-image-1.2.10:0 sys-libs/zlib:0 ) )
+	sftp? ( net-libs/libssh2:0 )
+	shout? ( >=media-libs/libshout-2.1:0 )
+	sid? ( media-libs/libsidplay:2 )
+	skins? ( x11-libs/libXext:0 x11-libs/libXpm:0 x11-libs/libXinerama:0 )
+	speex? ( media-libs/speex:0 )
+	svg? ( >=gnome-base/librsvg-2.9:2 >=x11-libs/cairo-1.13.1:0 )
+	swscale? (
+		!libav? ( media-video/ffmpeg:0= )
+		libav? ( media-video/libav:0= )
+	)
+	taglib? ( >=media-libs/taglib-1.9:0 sys-libs/zlib:0 )
+	theora? ( >=media-libs/libtheora-1.0_beta3:0 )
+	tremor? ( media-libs/tremor:0 )
+	truetype? ( media-libs/freetype:2 virtual/ttf-fonts:0
+		!fontconfig? ( media-fonts/dejavu:0 ) )
+	twolame? ( media-sound/twolame:0 )
+	udev? ( >=virtual/udev-142:0 )
+	upnp? ( net-libs/libupnp:0 )
+	v4l? ( media-libs/libv4l:0 )
+	vaapi? (
+		x11-libs/libva:0[X,drm]
+		!libav? ( >=media-video/ffmpeg-3.1.3:0=[vaapi] )
+		libav? ( media-video/libav:0=[vaapi] )
+	)
+	vcd? ( >=dev-libs/libcdio-0.78.2:0 )
+	zeroconf? ( >=net-dns/avahi-0.6:0[dbus] )
 "
 
 # Temporarily block non-live FFMPEG versions as they break vdpau, 9999 works;
 # thus we'll have to wait for a new release there.
 RDEPEND="${RDEPEND}
-		vdpau? (
-			>=x11-libs/libvdpau-0.6:0
-			!libav? (
-					>=media-video/ffmpeg-2.2:0=
-					<media-video/ffmpeg-2.9:0=
-			)
-			libav? ( >=media-video/libav-10:0= )
-		)
-		vnc? ( >=net-libs/libvncserver-0.9.9:0 )
-		vorbis? ( >=media-libs/libvorbis-1.1:0 )
-		vpx? ( media-libs/libvpx:0= )
-		X? ( x11-libs/libX11:0 )
-		x264? ( >=media-libs/x264-0.0.20090923:0= )
-		x265? ( media-libs/x265:0= )
-		xcb? ( >=x11-libs/libxcb-1.6:0 >=x11-libs/xcb-util-0.3.4:0 >=x11-libs/xcb-util-keysyms-0.3.4:0 )
-		xml? ( >=dev-libs/libxml2-2.5:2 )
-		zvbi? ( >=media-libs/zvbi-0.2.28:0 )
+	vdpau? (
+		x11-libs/libvdpau:0
+		!libav? ( media-video/ffmpeg:0= )
+		libav? ( >=media-video/libav-10:0= )
+	)
+	vnc? ( >=net-libs/libvncserver-0.9.9:0 )
+	vorbis? ( media-libs/libvorbis:0 )
+	vpx? ( media-libs/libvpx:0= )
+	X? ( x11-libs/libX11:0 )
+	x264? ( media-libs/x264:0= )
+	x265? ( media-libs/x265:0= )
+	xcb? ( x11-libs/libxcb:0 x11-libs/xcb-util:0 x11-libs/xcb-util-keysyms:0 )
+	xml? ( dev-libs/libxml2:2 )
+	zvbi? ( media-libs/zvbi:0 )
 "
 
 DEPEND="${RDEPEND}
-	kde? ( >=kde-base/kdelibs-4:4 )
+	!qt5? ( kde? ( kde-base/kdelibs:4 ) )
 	xcb? ( x11-proto/xproto:0 )
 	app-arch/xz-utils:0
 	dev-lang/yasm:*
@@ -200,14 +196,27 @@ REQUIRED_USE="
 	libcaca? ( X )
 	libtar? ( skins )
 	libtiger? ( kate )
-	qt4? ( X !qt5 )
-	qt5? ( X !qt4 )
+	qt4? ( X )
+	qt5? ( X )
 	sdl? ( X )
-	skins? ( truetype X ^^ ( qt4 qt5 ) )
+	skins? ( truetype X || ( qt4 qt5 ) )
 	vaapi? ( avcodec X )
 	vlm? ( encode )
 	xv? ( xcb )
 "
+
+PATCHES=(
+	# Fix build system mistake.
+	"${FILESDIR}"/${PN}-2.1.0-fix-libtremor-libs.patch
+
+	# Patch up incompatibilities and reconfigure autotools.
+	"${FILESDIR}"/${PN}-9999-libva-1.2.1-compat.patch
+
+	# Fix up broken audio when skipping using a fixed reversed bisected commit.
+	"${FILESDIR}"/${PN}-2.1.0-TomWij-bisected-PA-broken-underflow.patch
+)
+
+DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt )
 
 S="${WORKDIR}/${MY_P}"
 
@@ -252,15 +261,6 @@ src_prepare() {
 
 	default
 
-	# Fix build system mistake.
-	epatch "${FILESDIR}"/${PN}-2.1.0-fix-libtremor-libs.patch
-
-	# Patch up incompatibilities and reconfigure autotools.
-	epatch "${FILESDIR}"/${P}-libva-1.2.1-compat.patch
-
-	# Fix up broken audio when skipping using a fixed reversed bisected commit.
-	epatch "${FILESDIR}"/${PN}-2.1.0-TomWij-bisected-PA-broken-underflow.patch
-
 	# Don't use --started-from-file when not using dbus.
 	if ! use dbus ; then
 		sed -i 's/ --started-from-file//' share/vlc.desktop.in || die
@@ -271,16 +271,18 @@ src_prepare() {
 	# Disable automatic running of tests.
 	find . -name 'Makefile.in' -exec sed -i 's/\(..*\)check-TESTS/\1/' {} \; || die
 
-	# If qtchooser is installed, it may break the build, because moc,rcc and uic binaries for wrong qt version may be used.
-	# Setting QT_SELECT environment variable will enforce correct binaries.
-	if use qt4; then
-		export QT_SELECT=qt4
-	elif use qt5; then
+	# If qtchooser is installed, it may break the build, because moc,rcc and uic binaries for wrong qt
+	# version may be used. Setting QT_SELECT environment variable will enforce correct binaries.
+	if use qt5; then
 		export QT_SELECT=qt5
+	elif use qt4; then
+		export QT_SELECT=qt4
 	fi
 }
 
 src_configure() {
+	local myconf
+
 	# Compatibility fix for Samba 4.
 	use samba && append-cppflags "-I/usr/include/samba-4.0"
 
@@ -303,9 +305,12 @@ src_configure() {
 				--with-default-monospace-font-family=Monospace"
 	fi
 
-	local qt_flag=""
 	if use qt4 || use qt5 ; then
-		qt_flag="--enable-qt"
+		myconf+=" --enable-qt"
+	fi
+
+	if ! use qt5 && use kde ; then
+		myconf+=" --with-kde-solid"
 	fi
 
 	econf \
@@ -353,7 +358,6 @@ src_configure() {
 		$(use_enable jack) \
 		$(use_enable jpeg) \
 		$(use_enable kate) \
-		$(use_with kde kde-solid) \
 		$(use_enable libass) \
 		$(use_enable libcaca caca) \
 		$(use_enable libnotify notify) \
@@ -385,7 +389,6 @@ src_configure() {
 		$(use_enable postproc) \
 		$(use_enable projectm) \
 		$(use_enable pulseaudio pulse) \
-		${qt_flag} \
 		$(use_enable rdp freerdp) \
 		$(use_enable rtsp realrtsp) \
 		$(use_enable run-as-root) \
@@ -458,16 +461,14 @@ src_configure() {
 }
 
 src_test() {
-	Xemake check-TESTS
+	virtx emake check-TESTS
 }
-
-DOCS="AUTHORS THANKS NEWS README doc/fortunes.txt"
 
 src_install() {
 	default
 
 	# Punt useless libtool's .la files
-	find "${D}" -name '*.la' -delete
+	find "${D}" -name '*.la' -delete || die
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Drops another unnecessary REQUIRED_USE, but keeping Qt4 here for alleged scaling issues with Qt5...

Also fix build with >=Qt-5.7.0 for vlc-2.2.4 to be able to make progress with Qt-5.7 unmasking.

@gentoo/video @SDNick484 
