### PR TITLE
net-firewall/iptables: Update systemd file targets

### DIFF
--- a/net-firewall/iptables/files/systemd/ip6tables-restore.service.2
+++ b/net-firewall/iptables/files/systemd/ip6tables-restore.service.2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Store and restore ip6tables firewall rules
+ConditionPathExists=/var/lib/ip6tables/rules-save
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/ip6tables-restore /var/lib/ip6tables/rules-save
+ExecStop=/bin/sh -c "/sbin/ip6tables-save --counters > /var/lib/ip6tables/rules-save"
+
+[Install]
+WantedBy=basic.target

--- a/net-firewall/iptables/files/systemd/iptables-restore.service.2
+++ b/net-firewall/iptables/files/systemd/iptables-restore.service.2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Store and restore iptables firewall rules
+ConditionPathExists=/var/lib/iptables/rules-save
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/iptables-restore /var/lib/iptables/rules-save
+ExecStop=/bin/sh -c "/sbin/iptables-save --counters > /var/lib/iptables/rules-save"
+
+[Install]
+WantedBy=basic.target

--- a/net-firewall/iptables/iptables-1.6.0-r2.ebuild
+++ b/net-firewall/iptables/iptables-1.6.0-r2.ebuild
@@ -1,0 +1,117 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="5"
+
+# Force users doing their own patches to install their own tools
+AUTOTOOLS_AUTO_DEPEND=no
+
+inherit eutils multilib systemd toolchain-funcs autotools flag-o-matic
+
+DESCRIPTION="Linux kernel (2.4+) firewall, NAT and packet mangling tools"
+HOMEPAGE="http://www.netfilter.org/projects/iptables/"
+SRC_URI="http://www.netfilter.org/projects/iptables/files/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+# Subslot tracks libxtables as that's the one other packages generally link
+# against and iptables changes.  Will have to revisit if other sonames change.
+SLOT="0/11"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+IUSE="conntrack ipv6 netlink nftables pcap static-libs"
+
+RDEPEND="
+	conntrack? ( net-libs/libnetfilter_conntrack )
+	netlink? ( net-libs/libnfnetlink )
+	nftables? (
+		>=net-libs/libmnl-1.0
+		>=net-libs/libnftnl-1.0.5
+	)
+	pcap? ( net-libs/libpcap )
+"
+DEPEND="${RDEPEND}
+	virtual/os-headers
+	virtual/pkgconfig
+	nftables? (
+		sys-devel/flex
+		virtual/yacc
+	)
+"
+
+src_prepare() {
+	# use the saner headers from the kernel
+	rm -f include/linux/{kernel,types}.h
+
+	# Only run autotools if user patched something
+	epatch_user && eautoreconf || elibtoolize
+}
+
+src_configure() {
+	# Some libs use $(AR) rather than libtool to build #444282
+	tc-export AR
+
+	# Hack around struct mismatches between userland & kernel for some ABIs. #472388
+	use amd64 && [[ ${ABI} == "x32" ]] && append-flags -fpack-struct
+
+	sed -i \
+		-e "/nfnetlink=[01]/s:=[01]:=$(usex netlink 1 0):" \
+		-e "/nfconntrack=[01]/s:=[01]:=$(usex conntrack 1 0):" \
+		configure || die
+
+	econf \
+		--sbindir="${EPREFIX}/sbin" \
+		--libexecdir="${EPREFIX}/$(get_libdir)" \
+		--enable-devel \
+		--enable-shared \
+		$(use_enable nftables) \
+		$(use_enable pcap bpf-compiler) \
+		$(use_enable pcap nfsynproxy) \
+		$(use_enable static-libs static) \
+		$(use_enable ipv6)
+}
+
+src_compile() {
+	# Deal with parallel build errors.
+	use nftables && emake -C iptables xtables-config-parser.h
+	emake V=1
+}
+
+src_install() {
+	default
+	dodoc INCOMPATIBILITIES iptables/iptables.xslt
+
+	# all the iptables binaries are in /sbin, so might as well
+	# put these small files in with them
+	into /
+	dosbin iptables/iptables-apply
+	dosym iptables-apply /sbin/ip6tables-apply
+	doman iptables/iptables-apply.8
+
+	insinto /usr/include
+	doins include/iptables.h $(use ipv6 && echo include/ip6tables.h)
+	insinto /usr/include/iptables
+	doins include/iptables/internal.h
+
+	keepdir /var/lib/iptables
+	newinitd "${FILESDIR}"/${PN}.init iptables
+	newconfd "${FILESDIR}"/${PN}-1.4.13.confd iptables
+	if use ipv6 ; then
+		keepdir /var/lib/ip6tables
+		newinitd "${FILESDIR}"/iptables.init ip6tables
+		newconfd "${FILESDIR}"/ip6tables-1.4.13.confd ip6tables
+	fi
+
+	insinto $(systemd_get_systemunitdir)
+	newins "${FILESDIR}"/systemd/iptables-restore.service.2	\
+		iptables-restore.service
+
+	if use ipv6 ; then
+		newins "${FILESDIR}"/systemd/ip6tables-restore.service.2	\
+			ipt6tables-restore.service
+	fi
+
+	# Move important libs to /lib #332175
+	gen_usr_ldscript -a ip{4,6}tc iptc xtables
+
+	prune_libtool_files
+}


### PR DESCRIPTION
Change the systemd unit files to use

    Before=network-pre.target
    Wants=network-pre.target

as this better aligns with systemd documentation for this type of
service.  Special thanks to Shaun Bouckaert for triggering this review.
He originally asked (via email) about how the connman systemd unit file
handled its dependencies which prompted me to check this package as
well.  As for connman, v1.33-r1 seems to be aligned with systemd
documentation.

Package-Manager: portage-2.3.2