### PR TITLE
app-emulation/spice: Clean up XDG environment

### DIFF
--- a/app-emulation/spice/spice-0.13.2.ebuild
+++ b/app-emulation/spice/spice-0.13.2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python{2_7,3_4} )
 
-inherit eutils python-any-r1 readme.gentoo-r1
+inherit eutils python-any-r1 readme.gentoo-r1 xdg-utils
 
 DESCRIPTION="SPICE server"
 HOMEPAGE="http://spice-space.org/"
@@ -58,6 +58,8 @@ src_configure() {
 	# https://bugzilla.gnome.org/show_bug.cgi?id=744134
 	# https://bugzilla.gnome.org/show_bug.cgi?id=744135
 	addpredict /dev
+
+	xdg_environment_reset
 
 	local myconf="
 		$(use_enable static-libs static)


### PR DESCRIPTION
Fixes bug https://bugs.gentoo.org/show_bug.cgi?id=591462

Signed-off-by: Nick Sarnie <commendsarnex@gmail.com>

