### PR TITLE
media-libs/libextractor: ffmpeg 2.9+ fix

### DIFF
--- a/media-libs/libextractor/files/libextractor-1.3-ffmpeg-2.9.patch
+++ b/media-libs/libextractor/files/libextractor-1.3-ffmpeg-2.9.patch
@@ -1,0 +1,52 @@
+Description: Replace deprecated FFmpeg API
+Author: Andreas Cadhalpun <Andreas.Cadhalpun@googlemail.com>
+Last-Update: <2015-11-28>
+
+--- libextractor-1.3.orig/src/plugins/thumbnailffmpeg_extractor.c
++++ libextractor-1.3/src/plugins/thumbnailffmpeg_extractor.c
+@@ -153,7 +153,7 @@ seek_cb (void *opaque,
+ static size_t 
+ create_thumbnail (int src_width, int src_height, 
+ 		  int src_stride[],
+-		  enum PixelFormat src_pixfmt, 
++		  enum AVPixelFormat src_pixfmt,
+ 		  const uint8_t * const src_data[],
+ 		  int dst_width, int dst_height,
+ 		  uint8_t **output_data, 
+@@ -189,7 +189,7 @@ create_thumbnail (int src_width, int src
+   if (NULL == 
+       (scaler_ctx =
+        sws_getContext (src_width, src_height, src_pixfmt,
+-		       dst_width, dst_height, PIX_FMT_RGB24, 
++		       dst_width, dst_height, AV_PIX_FMT_RGB24,
+ 		       SWS_BILINEAR, NULL, NULL, NULL)))
+     {
+ #if DEBUG
+@@ -214,7 +214,7 @@ create_thumbnail (int src_width, int src
+       return 0;
+     }
+   if (NULL == (dst_buffer =
+-	       av_malloc (avpicture_get_size (PIX_FMT_RGB24, dst_width, dst_height))))
++	       av_malloc (avpicture_get_size (AV_PIX_FMT_RGB24, dst_width, dst_height))))
+     {
+ #if DEBUG
+       fprintf (stderr,
+@@ -229,7 +229,7 @@ create_thumbnail (int src_width, int src
+       return 0;
+     }
+   avpicture_fill ((AVPicture *) dst_frame, dst_buffer,
+-                  PIX_FMT_RGB24, dst_width, dst_height);
++                  AV_PIX_FMT_RGB24, dst_width, dst_height);
+   sws_scale (scaler_ctx,
+              src_data, 
+              src_stride,
+@@ -272,7 +272,7 @@ create_thumbnail (int src_width, int src
+     }
+   encoder_codec_ctx->width = dst_width;
+   encoder_codec_ctx->height = dst_height;
+-  encoder_codec_ctx->pix_fmt = PIX_FMT_RGB24;
++  encoder_codec_ctx->pix_fmt = AV_PIX_FMT_RGB24;
+   opts = NULL;
+   if (avcodec_open2 (encoder_codec_ctx, encoder_codec, &opts) < 0)
+     {
+

--- a/media-libs/libextractor/libextractor-1.3-r1.ebuild
+++ b/media-libs/libextractor/libextractor-1.3-r1.ebuild
@@ -1,0 +1,117 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+inherit eutils flag-o-matic multilib toolchain-funcs
+
+DESCRIPTION="A library used to extract metadata from files of arbitrary type"
+HOMEPAGE="https://www.gnu.org/software/libextractor/"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 ~arm ppc ppc64 x86"
+IUSE="+archive +bzip2 ffmpeg flac gif gsf gtk jpeg mp4 +magic midi mpeg tidy tiff vorbis +zlib" # test
+
+RESTRICT="test"
+
+RDEPEND="app-text/iso-codes
+	>=dev-libs/glib-2
+	media-gfx/exiv2
+	sys-devel/libtool
+	virtual/libiconv
+	virtual/libintl
+	archive? ( app-arch/libarchive )
+	bzip2? ( app-arch/bzip2 )
+	ffmpeg? ( virtual/ffmpeg )
+	flac? (
+		media-libs/flac
+		media-libs/libogg
+		)
+	gif? ( media-libs/giflib )
+	gsf? ( gnome-extra/libgsf )
+	gtk? ( x11-libs/gtk+:3 )
+	jpeg? ( virtual/jpeg )
+	mp4? ( media-libs/libmp4v2:0 )
+	magic? ( sys-apps/file )
+	midi? ( media-libs/libsmf )
+	mpeg? ( media-libs/libmpeg2 )
+	tidy? ( app-text/htmltidy )
+	tiff? ( media-libs/tiff:0 )
+	vorbis? (
+		media-libs/libogg
+		media-libs/libvorbis
+		)
+	zlib? ( sys-libs/zlib )
+	!<app-crypt/pkcrack-1.2.2-r1
+	!sci-biology/glimmer
+	!sci-chemistry/pdb-extract"
+DEPEND="${RDEPEND}
+	sys-devel/gettext
+	virtual/pkgconfig"
+# test? ( app-forensics/zzuf )
+
+DOCS="AUTHORS ChangeLog NEWS README TODO"
+
+src_prepare() {
+	epatch "${FILESDIR}"/${P}-giflib-5.patch #571902
+	epatch "${FILESDIR}"/${P}-ffmpeg-2.9.patch
+
+	# m4/ax_create_pkgconfig_info.m4 is passing environment LDFLAGS to Libs:
+	sed -i \
+		-e '/^ax_create_pkgconfig_ldflags=/s:$LDFLAGS ::' \
+		-e 's:tidy/tidy.h:tidy.h:' \
+		configure src/plugins/html_extractor.c || die
+
+	use tidy || { sed -i -e 's:tidy.h:dIsAbLe&:' configure || die; }
+}
+
+src_configure() {
+	e_ac_cv() {
+		export ac_cv_"$@"
+	}
+
+	e_ac_cv {lib_rpm_rpmReadPackageFile,prog_HAVE_ZZUF}=no
+
+	if use flac; then
+		e_ac_cv header_FLAC_all_h=yes
+		e_ac_cv lib_FLAC_FLAC__stream_decoder_init_stream=yes
+	else
+		e_ac_cv header_FLAC_all_h=no
+		e_ac_cv lib_FLAC_FLAC__stream_decoder_init_stream=no
+		e_ac_cv lib_FLAC_FLAC__stream_decoder_init_ogg_stream=no
+	fi
+
+	e_ac_cv header_archive_h=$(usex archive)
+	e_ac_cv header_bzlib_h=$(usex bzip2)
+	e_ac_cv header_gif_lib_h=$(usex gif)
+	e_ac_cv header_jpeglib_h=$(usex jpeg)
+	e_ac_cv header_magic_h=$(usex magic)
+	e_ac_cv header_mpeg2dec_mpeg2_h=$(usex mpeg)
+	e_ac_cv header_tiffio_h=$(usex tiff)
+	e_ac_cv header_vorbis_vorbisfile_h=$(usex vorbis)
+	e_ac_cv header_zlib_h=$(usex zlib)
+	e_ac_cv lib_mp4v2_MP4ReadProvider=$(usex mp4)
+	e_ac_cv lib_smf_smf_load_from_memory=$(usex midi)
+
+	# gstreamer support is for 1.0, no 0.10 support
+	econf \
+		--disable-static \
+		--enable-experimental \
+		--enable-glib \
+		$(use_enable gsf) \
+		--disable-gsf-gnome \
+		$(use_enable ffmpeg) \
+		--with-gtk_version=$(usex gtk 3.0.0 false) \
+		--without-gstreamer
+}
+
+src_compile() {
+	emake -j1
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -exec sed -i -e "/^dependency_libs/s:=.*:='':" {} +
+}


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=575774

This is merely the work done in https://bugs.gentoo.org/show_bug.cgi?id=575774#c4 as an easy to apply pull request.