### PR TITLE
sys-fs/e2fsprogs: patch mke2fs.conf.in #598100

### DIFF
--- a/sys-fs/e2fsprogs/files/e2fsprogs-1.43-mke2fs-conf.patch
+++ b/sys-fs/e2fsprogs/files/e2fsprogs-1.43-mke2fs-conf.patch
@@ -1,0 +1,38 @@
+From d33e690fe7a6cbeb51349d9f2c7fb16a6ebec9c2 Mon Sep 17 00:00:00 2001
+From: Theodore Ts'o <tytso@mit.edu>
+Date: Mon, 24 Oct 2016 14:15:43 -0400
+Subject: mke2fs.conf: add back missing uninit_bg feature flag
+
+Commit 0da058af9f88: "mke2fs.conf: don't enable metadata_csum by
+default" removed metadata_csum without adding back the uninit_bg flag
+--- which had the net result of causing file systems to take a long
+time to mke2fs, since this caused all of the block group metadata to
+be initialized.
+
+Addresses-Google-Bug: 32342524
+
+Signed-off-by: Theodore Ts'o <tytso@mit.edu>
+---
+ misc/mke2fs.conf.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/misc/mke2fs.conf.in b/misc/mke2fs.conf.in
+index 78fe50a..812f7c7 100644
+--- a/misc/mke2fs.conf.in
++++ b/misc/mke2fs.conf.in
+@@ -11,11 +11,11 @@
+ 		features = has_journal
+ 	}
+ 	ext4 = {
+-		features = has_journal,extent,huge_file,flex_bg,64bit,dir_nlink,extra_isize
++		features = has_journal,extent,huge_file,flex_bg,uninit_bg,64bit,dir_nlink,extra_isize
+ 		inode_size = 256
+ 	}
+ 	ext4dev = {
+-		features = has_journal,extent,huge_file,flex_bg,inline_data,64bit,dir_nlink,extra_isize
++		features = has_journal,extent,huge_file,flex_bg,uninit_bg,inline_data,64bit,dir_nlink,extra_isize
+ 		inode_size = 256
+ 		options = test_fs=1
+ 	}
+-- 
+cgit v0.12


### PR DESCRIPTION
A commit prior to e2fsprogs 1.43 release accidentally removed a
mke2fs.conf flag and resulted in mke2fs becoming very slow (takes 5
minutes to format a 1.5TB disk as opposed to <1 minute). This just pulls
in the upstream patch.

More details and the original commit message can be found in the patch
file itself.

Gentoo-Bug: 598100