### PR TITLE
www-client/seamonkey: Add app-crypt/pinentry[qt5] alternative RDEPEND

### DIFF
--- a/www-client/seamonkey/seamonkey-2.39.ebuild
+++ b/www-client/seamonkey/seamonkey-2.39.ebuild
@@ -58,6 +58,7 @@ RDEPEND=">=dev-libs/nss-3.20.1
 			( >=app-crypt/gnupg-2.0
 				|| (
 					app-crypt/pinentry[gtk]
+					app-crypt/pinentry[qt5]
 					app-crypt/pinentry[qt4]
 				)
 			)

--- a/www-client/seamonkey/seamonkey-2.40.ebuild
+++ b/www-client/seamonkey/seamonkey-2.40.ebuild
@@ -61,6 +61,7 @@ RDEPEND=">=dev-libs/nss-3.20.1
 			( >=app-crypt/gnupg-2.0
 				|| (
 					app-crypt/pinentry[gtk]
+					app-crypt/pinentry[qt5]
 					app-crypt/pinentry[qt4]
 				)
 			)

--- a/www-client/seamonkey/seamonkey-2.42.3.0_p0.ebuild
+++ b/www-client/seamonkey/seamonkey-2.42.3.0_p0.ebuild
@@ -86,6 +86,7 @@ RDEPEND=">=dev-libs/nss-3.22.3
 			( >=app-crypt/gnupg-2.0
 				|| (
 					app-crypt/pinentry[gtk]
+					app-crypt/pinentry[qt5]
 					app-crypt/pinentry[qt4]
 				)
 			)

--- a/www-client/seamonkey/seamonkey-2.42.4.0_p1.ebuild
+++ b/www-client/seamonkey/seamonkey-2.42.4.0_p1.ebuild
@@ -86,6 +86,7 @@ RDEPEND=">=dev-libs/nss-3.22.3
 			( >=app-crypt/gnupg-2.0
 				|| (
 					app-crypt/pinentry[gtk]
+					app-crypt/pinentry[qt5]
 					app-crypt/pinentry[qt4]
 				)
 			)


### PR DESCRIPTION
What's fine for thunderbird and evolution can't be wrong for seamonkey. 

@Polynomial-C 