### PR TITLE
media-sound/cantata: Drop USE=kde,qt5, slotmove 4 -> 0

### DIFF
--- a/media-sound/cantata/cantata-2.0.1-r1.ebuild
+++ b/media-sound/cantata/cantata-2.0.1-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://github.com/CDrummond/cantata"
 SRC_URI="https://github.com/CDrummond/cantata/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
-SLOT="4"
+SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="cdda cddb http-server mtp musicbrainz replaygain taglib udisks"
 REQUIRED_USE="

--- a/media-sound/cantata/cantata-2.0.1-r1.ebuild
+++ b/media-sound/cantata/cantata-2.0.1-r1.ebuild
@@ -1,0 +1,120 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PLOCALES="cs de en_GB es fr hu ko pl ru zh_CN"
+inherit cmake-utils gnome2-utils l10n qmake-utils xdg
+
+DESCRIPTION="Featureful and configurable Qt client for the music player daemon (MPD)"
+HOMEPAGE="https://github.com/CDrummond/cantata"
+SRC_URI="https://github.com/CDrummond/cantata/releases/download/v${PV}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="4"
+KEYWORDS="~amd64 ~x86"
+IUSE="cdda cddb http-server mtp musicbrainz replaygain taglib udisks"
+REQUIRED_USE="
+	cdda? ( udisks || ( cddb musicbrainz ) )
+	cddb? ( cdda taglib )
+	mtp? ( taglib udisks )
+	musicbrainz? ( cdda taglib )
+	replaygain? ( taglib )
+"
+
+RDEPEND="
+	dev-db/sqlite:3
+	dev-qt/qtconcurrent:5
+	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtsql:5
+	dev-qt/qtsvg:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+	sys-libs/zlib
+	|| ( kde-frameworks/breeze-icons:5 kde-frameworks/oxygen-icons:* )
+	cdda? ( media-sound/cdparanoia )
+	cddb? ( media-libs/libcddb )
+	mtp? ( media-libs/libmtp )
+	musicbrainz? ( media-libs/musicbrainz:5 )
+	replaygain? (
+		media-libs/libebur128
+		media-sound/mpg123
+		virtual/ffmpeg
+	)
+	taglib? (
+		media-libs/taglib[asf(+),mp4(+)]
+		media-libs/taglib-extras
+		udisks? ( sys-fs/udisks:2 )
+	)
+"
+DEPEND="${RDEPEND}
+	dev-qt/linguist-tools:5
+"
+
+# cantata has no tests
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}/${P}-mpris-true.patch"
+	"${FILESDIR}/${P}-mpris-plasma57.patch"
+	"${FILESDIR}/${P}-qt5-no-X11.patch"
+)
+
+src_prepare() {
+	cmake-utils_src_prepare
+
+	# Unbundle 3rd party libs
+	rm -rf 3rdparty/qtsingleapplication/ || die
+	rm -rf 3rdparty/libebur128/ || die
+	# qjson ebuild does not support Qt5 yet
+	rm -rf 3rdparty/qjson/ || die
+
+	l10n_find_plocales_changes 'po' '' '.po'
+}
+
+src_configure() {
+	local langs="$(l10n_get_locales)"
+
+	local mycmakeargs=(
+		-DCANTATA_TRANSLATIONS="${langs// /;}"
+		-DENABLE_CDPARANOIA=$(usex cdda)
+		-DENABLE_CDDB=$(usex cddb)
+		-DENABLE_HTTP_SERVER=$(usex http-server)
+		-DENABLE_MTP=$(usex mtp)
+		-DENABLE_MUSICBRAINZ=$(usex musicbrainz)
+		-DENABLE_QT5=ON
+		-DLCONVERT_EXECUTABLE="$(qt5_get_bindir)/lconvert"
+		-DLRELEASE_EXECUTABLE="$(qt5_get_bindir)/lrelease"
+		-DENABLE_FFMPEG=$(usex replaygain)
+		-DENABLE_MPG123=$(usex replaygain)
+		-DENABLE_TAGLIB=$(usex taglib)
+		-DENABLE_TAGLIB_EXTRAS=$(usex taglib)
+		-DENABLE_DEVICES_SUPPORT=$(usex udisks)
+		-DENABLE_HTTP_STREAM_PLAYBACK=OFF
+		-DENABLE_REMOTE_DEVICES=OFF
+		-DENABLE_UDISKS2=ON
+		-DUSE_SYSTEM_MENU_ICON=OFF
+	)
+#	-DENABLE_KDE=$(usex kde)	# not yet ported to KF5
+
+	cmake-utils_src_configure
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+	xdg_pkg_preinst
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	xdg_pkg_postinst
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	xdg_pkg_postrm
+}

--- a/media-sound/cantata/cantata-2.0.1.ebuild
+++ b/media-sound/cantata/cantata-2.0.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://github.com/CDrummond/cantata"
 SRC_URI="https://github.com/CDrummond/cantata/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
-SLOT="4"
+SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="cdda cddb http-server kde mtp musicbrainz qt5 replaygain taglib udisks"
 REQUIRED_USE="

--- a/media-sound/cantata/files/cantata-2.0.1-mpris-plasma57.patch
+++ b/media-sound/cantata/files/cantata-2.0.1-mpris-plasma57.patch
@@ -1,0 +1,46 @@
+Work-around KDE 5.7 MPRIS issues. 
+
+diff --git a/gui/mainwindow.cpp b/gui/mainwindow.cpp
+index cc2b532..37eec9e 100644
+--- a/gui/mainwindow.cpp
++++ b/gui/mainwindow.cpp
+@@ -1410,8 +1410,8 @@ void MainWindow::setRating()
+     }
+ }
+ 
+-void MainWindow::readSettings()
+-{    
++void MainWindow::initMpris()
++{
+     #ifdef QT_QTDBUS_FOUND
+     if (Settings::self()->mpris()) {
+         if (!mpris) {
+@@ -1424,6 +1424,16 @@ void MainWindow::readSettings()
+         mpris=0;
+     }
+     CurrentCover::self()->setEnabled(mpris || Settings::self()->showPopups() || 0!=Settings::self()->playQueueBackground() || Settings::self()->showCoverWidget());
++    #endif
++}
++
++void MainWindow::readSettings()
++{    
++    #ifdef QT_QTDBUS_FOUND
++    // It appears as if the KDE MPRIS code does not like the MPRIS interface to be setup before the window is visible.
++    // to work-around this, initMpris in the next event loop iteration.
++    // See #863
++    QTimer::singleShot(0, this, SLOT(initMpris()));
+     #else
+     CurrentCover::self()->setEnabled(Settings::self()->showPopups() || 0!=Settings::self()->playQueueBackground() || Settings::self()->showCoverWidget());
+     #endif
+diff --git a/gui/mainwindow.h b/gui/mainwindow.h
+index 6d6e960..aa3a80a 100644
+--- a/gui/mainwindow.h
++++ b/gui/mainwindow.h
+@@ -268,6 +268,7 @@ public Q_SLOTS:
+ private Q_SLOTS:
+     void toggleContext();
+     void toggleMenubar();
++    void initMpris();
+ 
+ private:
+     int prevPage;

--- a/media-sound/cantata/files/cantata-2.0.1-mpris-true.patch
+++ b/media-sound/cantata/files/cantata-2.0.1-mpris-true.patch
@@ -1,0 +1,100 @@
+Always return true for MPRIS CanPlay, CanPause, etc.
+
+diff --git a/dbus/mpris.cpp b/dbus/mpris.cpp
+index 4736d19..45a539a 100644
+--- a/dbus/mpris.cpp
++++ b/dbus/mpris.cpp
+@@ -65,6 +65,31 @@ Mpris::~Mpris()
+     QDBusConnection::sessionBus().unregisterService("org.mpris.MediaPlayer2.cantata");
+ }
+ 
++void Mpris::Pause()
++{
++    if (MPDState_Playing==MPDStatus::self()->state()) {
++        StdActions::self()->playPauseTrackAction->trigger();
++    }
++}
++
++void Mpris::Play()
++{
++    MPDStatus * const status = MPDStatus::self();
++    if (status->playlistLength() && MPDState_Playing!=status->state()) {
++        StdActions::self()->playPauseTrackAction->trigger();
++    }
++}
++
++QString Mpris::PlaybackStatus() const
++{
++    switch(MPDStatus::self()->state()) {
++    case MPDState_Playing: return QLatin1String("Playing");
++    case MPDState_Paused: return QLatin1String("Paused");
++    default:
++    case MPDState_Stopped: return QLatin1String("Stopped");
++    }
++}
++
+ qlonglong Mpris::Position() const
+ {
+     // Cant use MPDStatus, as we dont poll for track position, but use a timer instead!
+diff --git a/dbus/mpris.h b/dbus/mpris.h
+index 64a4fbe..a1578b9 100644
+--- a/dbus/mpris.h
++++ b/dbus/mpris.h
+@@ -71,37 +71,15 @@ class Mpris : public QObject
+     // org.mpris.MediaPlayer2.Player
+     void Next() { StdActions::self()->nextTrackAction->trigger(); }
+     void Previous() { StdActions::self()->prevTrackAction->trigger(); }
+-    void Pause() {
+-        if (MPDState_Playing==MPDStatus::self()->state()) {
+-            StdActions::self()->playPauseTrackAction->trigger();
+-        }
+-    }
+-
++    void Pause();
+     void PlayPause() { StdActions::self()->playPauseTrackAction->trigger(); }
+     void Stop() { StdActions::self()->stopPlaybackAction->trigger(); }
+     void StopAfterCurrent() { StdActions::self()->stopAfterCurrentTrackAction->trigger(); }
+-
+-    void Play() {
+-        MPDStatus * const status = MPDStatus::self();
+-
+-        if (status->playlistLength() && MPDState_Playing!=status->state()) {
+-           StdActions::self()->playPauseTrackAction->trigger();
+-        }
+-    }
+-
++    void Play();
+     void Seek(qlonglong pos) { emit setSeekId(-1, pos/1000000); }
+     void SetPosition(const QDBusObjectPath &, qlonglong pos) {emit setSeekId(-1, pos/1000000); }
+     void OpenUri(const QString &) { }
+-
+-    QString PlaybackStatus() {
+-        switch(MPDStatus::self()->state()) {
+-        case MPDState_Playing: return QLatin1String("Playing");
+-        case MPDState_Paused: return QLatin1String("Paused");
+-        default:
+-        case MPDState_Stopped: return QLatin1String("Stopped");
+-        }
+-    }
+-
++    QString PlaybackStatus() const;
+     QString LoopStatus() { return MPDStatus::self()->repeat() ? QLatin1String("Playlist") : QLatin1String("None"); }
+     void SetLoopStatus(const QString &s) { emit setRepeat(QLatin1String("None")!=s); }
+     QVariantMap Metadata() const;
+@@ -115,11 +93,11 @@ class Mpris : public QObject
+     double MinimumRate() const { return 1.0; }
+     double MaximumRate() const { return 1.0; }
+     bool CanControl() const { return true; }
+-    bool CanPlay() const { return MPDState_Playing!=MPDStatus::self()->state() && MPDStatus::self()->playlistLength()>0; }
+-    bool CanPause() const { return MPDState_Playing==MPDStatus::self()->state(); }
+-    bool CanSeek() const { return -1!=MPDStatus::self()->songId(); }
+-    bool CanGoNext() const { return MPDState_Stopped!=MPDStatus::self()->state() && MPDStatus::self()->playlistLength()>1; }
+-    bool CanGoPrevious() const { return MPDState_Stopped!=MPDStatus::self()->state() && MPDStatus::self()->playlistLength()>1; }
++    bool CanPlay() const { return true; }
++    bool CanPause() const { return true; }
++    bool CanSeek() const { return true; }
++    bool CanGoNext() const { return true; }
++    bool CanGoPrevious() const { return true; }
+ 
+     // org.mpris.MediaPlayer2
+     bool CanQuit() const { return true; }

--- a/media-sound/cantata/files/cantata-2.0.1-qt5-no-X11.patch
+++ b/media-sound/cantata/files/cantata-2.0.1-qt5-no-X11.patch
@@ -1,0 +1,14 @@
+diff --git a/support/CMakeLists.txt b/support/CMakeLists.txt
+index fcdaf5c..f6160f0 100644
+--- a/support/CMakeLists.txt
++++ b/support/CMakeLists.txt
+@@ -89,7 +89,7 @@ if (NOT ENABLE_UBUNTU AND NOT ENABLE_WEB)
+ 
+     add_library(support STATIC ${SUPPORT_MOC_SRCS} ${SUPPORT_SRCS} ${SUPPORT_UI_HDRS} ${SUPPORT_RC_SRCS})
+ 
+-    if (X11_FOUND)
++    if (NOT ENABLE_QT5 AND X11_FOUND)
+         target_link_libraries(support ${X11_LIBRARIES})
+-    endif (X11_FOUND)
++    endif (NOT ENABLE_QT5 AND X11_FOUND)
+ endif (NOT ENABLE_UBUNTU AND NOT ENABLE_WEB)

--- a/profiles/updates/4Q-2016
+++ b/profiles/updates/4Q-2016
@@ -15,3 +15,4 @@ move kde-base/kmenuedit kde-plasma/kmenuedit
 move kde-base/khotkeys kde-plasma/khotkeys
 move kde-base/kinfocenter kde-plasma/kinfocenter
 move kde-base/ksysguard kde-plasma/ksysguard
+slotmove media-sound/cantata 4 0


### PR DESCRIPTION
Build with Qt5 unconditionally, works well enough.
Add fixes for MPRIS and >=Plasma-5.7
X not used with Qt5 - upstream commit c934ae9ed5b8aeb3d8ff6a6b108b3cfe4fb30dea

@gentoo/kde 
