### PR TITLE
dev-python/m2crypto: Add missing depend and switch to EAPI6

### DIFF
--- a/dev-python/m2crypto/m2crypto-0.25.1-r1.ebuild
+++ b/dev-python/m2crypto/m2crypto-0.25.1-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 PYTHON_REQ_USE="threads(+)"
@@ -17,12 +17,13 @@ SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_PN}-${PV}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~amd64"
 IUSE="libressl"
 
 RDEPEND="
 	!libressl? ( >=dev-libs/openssl-0.9.8:0= )
 	libressl? ( dev-libs/libressl:= )
+	dev-python/typing
 "
 DEPEND="${RDEPEND}
 	>=dev-lang/swig-1.3.28:0


### PR DESCRIPTION
Removing old ebuild as it doesn't have the dependency, so m2crypto
will not work right.
    
Apparently dev-python/typing is keyworded ~AMD64 only.

Closes Gentoo Bug: 597744

Signed off by: Jonathan Scruggs (j.scruggs@gmail.com)

@SoapGentoo 
@gentoo/proxy-maint

Just a note: dev-python/typing is keyworded ~amd64 only. This needs to be looked at to see if it works on other arches, otherwise m2crypto 0.24 will be the last version for other arches. I did confirm the upstream git log and 'typing' was added to the 0.25.0 release.