### PR TITLE
profiles: changes from i486 to i686 on Gentoo/FreeBSD.

### DIFF
--- a/profiles/arch/x86-fbsd/make.defaults
+++ b/profiles/arch/x86-fbsd/make.defaults
@@ -4,7 +4,7 @@
 # System-wide defaults for the G/FBSD Portage system
 
 ARCH="x86-fbsd"
-CFLAGS="-march=i486 -O2 -pipe"
+CFLAGS="-march=i686 -O2 -pipe"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
 FCFLAGS="${CFLAGS}"

--- a/profiles/default/bsd/fbsd/x86/10.2/make.defaults
+++ b/profiles/default/bsd/fbsd/x86/10.2/make.defaults
@@ -2,4 +2,4 @@
 # Distributed under the terms of the GNU General Public License, v2
 # $Id$
 
-CHOST="i486-gentoo-freebsd10.2"
+CHOST="i686-gentoo-freebsd10.2"

--- a/profiles/default/bsd/fbsd/x86/9.1/make.defaults
+++ b/profiles/default/bsd/fbsd/x86/9.1/make.defaults
@@ -2,4 +2,4 @@
 # Distributed under the terms of the GNU General Public License, v2
 # $Id$
 
-CHOST="i486-gentoo-freebsd9.1"
+CHOST="i686-gentoo-freebsd9.1"


### PR DESCRIPTION
@aballier, if you want to keep i486, feel free to close this pr.
