### PR TITLE
dev-python/m2crypto: add missing python_usedep for typing

### DIFF
--- a/dev-python/m2crypto/m2crypto-0.25.1-r2.ebuild
+++ b/dev-python/m2crypto/m2crypto-0.25.1-r2.ebuild
@@ -23,7 +23,7 @@ IUSE="libressl"
 RDEPEND="
 	!libressl? ( >=dev-libs/openssl-0.9.8:0= )
 	libressl? ( dev-libs/libressl:0= )
-	dev-python/typing
+	dev-python/typing[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}
 	>=dev-lang/swig-1.3.28:0


### PR DESCRIPTION
Thanks to Steffen Hau in gentoo-bug 597744 comment 10 for reporting.

Signed-off by: Jonathan Scruggs (j.scruggs@gmail.com)