### PR TITLE
dev-python/certifi: add ~amd64-fbsd, ~x86-fbsd KEYWORDS

### DIFF
--- a/dev-python/certifi/certifi-2016.9.26.ebuild
+++ b/dev-python/certifi/certifi-2016.9.26.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-freebsd ~x86-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~hppa-hpux ~ia64-hpux ~x86-interix ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND=""


### PR DESCRIPTION
dev-python/setuptools requires dev-python/certifi.

```
# emerge -pv app-portage/repoman

Calculating dependencies... done!
[ebuild  N     ] dev-python/setuptools-28.7.1::gentoo  USE="{-test}" PYTHON_TARGETS="python2_7 python3_4 (-pypy) (-pypy3) -python3_5" 631 KiB
[ebuild  N    *] dev-python/certifi-2016.9.26::gentoo  PYTHON_TARGETS="python2_7 python3_4 (-pypy) (-pypy3) -python3_5" 0 KiB
[ebuild  N     ] dev-python/lxml-3.6.4-r1::gentoo  USE="threads -doc -examples {-test}" PYTHON_TARGETS="python2_7 python3_4 -python3_5" 0 KiB
[ebuild  N     ] app-portage/repoman-2.3.0-r1::gentoo  PYTHON_TARGETS="python2_7 python3_4 (-pypy) -python3_5" 0 KiB

Total: 4 packages (4 new), Size of downloads: 631 KiB

The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by dev-python/setuptools-28.7.1::gentoo
# required by dev-python/lxml-3.6.4-r1::gentoo
# required by app-portage/repoman-2.3.0-r1::gentoo
# required by app-portage/repoman (argument)
=dev-python/certifi-2016.9.26 **
```
