### PR TITLE
>=media-video/ffmpeg-3: Reintroduce libressl USE

### DIFF
--- a/media-video/ffmpeg/ffmpeg-3.2.4.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.2.4.ebuild
@@ -96,7 +96,7 @@ FFMPEG_ENCODER_FLAG_MAP=(
 )
 
 IUSE="
-	alsa doc +encode jack oss pic static-libs test v4l
+	alsa doc +encode jack libressl oss pic static-libs test v4l
 	${FFMPEG_FLAG_MAP[@]%:*}
 	${FFMPEG_ENCODER_FLAG_MAP[@]%:*}
 "
@@ -212,7 +212,10 @@ RDEPEND="
 	modplug? ( >=media-libs/libmodplug-0.8.8.4-r1[${MULTILIB_USEDEP}] )
 	openal? ( >=media-libs/openal-1.15.1[${MULTILIB_USEDEP}] )
 	opengl? ( >=virtual/opengl-7.0-r1[${MULTILIB_USEDEP}] )
-	openssl? ( >=dev-libs/openssl-1.0.1h-r2:0[${MULTILIB_USEDEP}] )
+	openssl? (
+		!libressl? ( >=dev-libs/openssl-1.0.1h-r2:0[${MULTILIB_USEDEP}] )
+		libressl? ( dev-libs/libressl[${MULTILIB_USEDEP}] )
+	)
 	opus? ( >=media-libs/opus-1.0.2-r2[${MULTILIB_USEDEP}] )
 	pulseaudio? ( >=media-sound/pulseaudio-2.1-r1[${MULTILIB_USEDEP}] )
 	librtmp? ( >=media-video/rtmpdump-2.4_p20131018[${MULTILIB_USEDEP}] )
@@ -280,6 +283,8 @@ REQUIRED_USE="
 RESTRICT="
 	gpl? ( openssl? ( bindist ) fdk? ( bindist ) )
 "
+
+PATCHES=( "${FILESDIR}"/${PN}-3.2-libressl.patch )
 
 S=${WORKDIR}/${P/_/-}
 

--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -96,7 +96,7 @@ FFMPEG_ENCODER_FLAG_MAP=(
 )
 
 IUSE="
-	alsa doc +encode jack oss pic static-libs test v4l
+	alsa doc +encode jack libressl oss pic static-libs test v4l
 	${FFMPEG_FLAG_MAP[@]%:*}
 	${FFMPEG_ENCODER_FLAG_MAP[@]%:*}
 "
@@ -213,7 +213,10 @@ RDEPEND="
 	modplug? ( >=media-libs/libmodplug-0.8.8.4-r1[${MULTILIB_USEDEP}] )
 	openal? ( >=media-libs/openal-1.15.1[${MULTILIB_USEDEP}] )
 	opengl? ( >=virtual/opengl-7.0-r1[${MULTILIB_USEDEP}] )
-	openssl? ( >=dev-libs/openssl-1.0.1h-r2:0[${MULTILIB_USEDEP}] )
+	openssl? (
+		!libressl? ( >=dev-libs/openssl-1.0.1h-r2:0[${MULTILIB_USEDEP}] )
+		libressl? ( dev-libs/libressl[${MULTILIB_USEDEP}] )
+	)
 	opus? ( >=media-libs/opus-1.0.2-r2[${MULTILIB_USEDEP}] )
 	pulseaudio? ( >=media-sound/pulseaudio-2.1-r1[${MULTILIB_USEDEP}] )
 	librtmp? ( >=media-video/rtmpdump-2.4_p20131018[${MULTILIB_USEDEP}] )
@@ -286,6 +289,8 @@ REQUIRED_USE="
 RESTRICT="
 	gpl? ( openssl? ( bindist ) fdk? ( bindist ) )
 "
+
+PATCHES=( "${FILESDIR}"/${PN}-3.2-libressl.patch )
 
 S=${WORKDIR}/${P/_/-}
 

--- a/media-video/ffmpeg/files/ffmpeg-3.2-libressl.patch
+++ b/media-video/ffmpeg/files/ffmpeg-3.2-libressl.patch
@@ -1,0 +1,57 @@
+diff -Naur ffmpeg-3.2.orig/libavformat/tls_openssl.c ffmpeg-3.2/libavformat/tls_openssl.c
+--- ffmpeg-3.2.orig/libavformat/tls_openssl.c	2016-10-28 10:20:46.872620829 -0700
++++ ffmpeg-3.2/libavformat/tls_openssl.c	2016-10-28 10:22:46.153045913 -0700
+@@ -43,7 +43,7 @@
+     TLSShared tls_shared;
+     SSL_CTX *ctx;
+     SSL *ssl;
+-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
+     BIO_METHOD* url_bio_method;
+ #endif
+ } TLSContext;
+@@ -68,7 +68,7 @@
+ 
+ static int url_bio_create(BIO *b)
+ {
+-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
+     BIO_set_init(b, 1);
+     BIO_set_data(b, NULL);
+     BIO_set_flags(b, 0);
+@@ -85,7 +85,7 @@
+     return 1;
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
+ #define GET_BIO_DATA(x) BIO_get_data(x);
+ #else
+ #define GET_BIO_DATA(x) (x)->ptr;
+@@ -133,7 +133,7 @@
+     return url_bio_bwrite(b, str, strlen(str));
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x1010000fL
++#if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(LIBRESSL_VERSION_NUMBER)
+ static BIO_METHOD url_bio_method = {
+     .type = BIO_TYPE_SOURCE_SINK,
+     .name = "urlprotocol bio",
+@@ -212,7 +212,7 @@
+         SSL_CTX_free(c->ctx);
+     if (c->tls_shared.tcp)
+         ffurl_close(c->tls_shared.tcp);
+-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
+     if (c->url_bio_method)
+         BIO_meth_free(c->url_bio_method);
+ #endif
+@@ -265,7 +265,7 @@
+         ret = AVERROR(EIO);
+         goto fail;
+     }
+-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
+     p->url_bio_method = BIO_meth_new(BIO_TYPE_SOURCE_SINK, "urlprotocol bio");
+     BIO_meth_set_write(p->url_bio_method, url_bio_bwrite);
+     BIO_meth_set_read(p->url_bio_method, url_bio_bread);


### PR DESCRIPTION
Add patch for ffmpeg-3.2.

I'm not sure why the use flag was dropped.