### PR TITLE
net-misc/openconnect: Reintroduce libressl USE.

### DIFF
--- a/net-misc/openconnect/files/openconnect-7.07-libressl.patch
+++ b/net-misc/openconnect/files/openconnect-7.07-libressl.patch
@@ -1,0 +1,77 @@
+From d4a8afc2e8693628f2de554e717458e08bcc2fcf Mon Sep 17 00:00:00 2001
+From: Aric Belsito <lluixhi@gmail.com>
+Date: Thu, 3 Nov 2016 11:37:23 -0700
+Subject: [PATCH] Fix LibreSSL Build.
+
+From Voidlinux:
+
+From d51ab5615e11af4a2c160b2b8240e5d9f3c15422 Mon Sep 17 00:00:00 2001
+From: Duncaen <duncaen@voidlinux.eu>
+Date: Wed, 13 Jul 2016 15:21:16 +0200
+Subject: [PATCH] openconnect: update to 7.07.
+---
+ openssl-esp.c | 4 ++--
+ openssl.c     | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/openssl-esp.c b/openssl-esp.c
+index 2c1aa49..bd4dce3 100644
+--- a/openssl-esp.c
++++ b/openssl-esp.c
+@@ -27,7 +27,7 @@
+ #include <openssl/evp.h>
+ #include <openssl/rand.h>
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #define EVP_CIPHER_CTX_free(c) do {				\
+ 				    EVP_CIPHER_CTX_cleanup(c);	\
+@@ -85,7 +85,7 @@ static int init_esp_ciphers(struct openconnect_info *vpninfo, struct esp *esp,
+ 	}
+ 	EVP_CIPHER_CTX_set_padding(esp->cipher, 0);
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	esp->hmac = malloc(sizeof(*esp->hmac));
+ 	esp->pkt_hmac = malloc(sizeof(*esp->pkt_hmac));
+ 	if (!esp->hmac || &esp->pkt_hmac) {
+diff --git a/openssl.c b/openssl.c
+index 785fd2a..6007cef 100644
+--- a/openssl.c
++++ b/openssl.c
+@@ -36,11 +36,11 @@
+ #include <openssl/ui.h>
+ #include <openssl/rsa.h>
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #define X509_up_ref(x) 	CRYPTO_add(&(x)->references, 1, CRYPTO_LOCK_X509)
+ #endif
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #define EVP_MD_CTX_new EVP_MD_CTX_create
+ #define EVP_MD_CTX_free EVP_MD_CTX_destroy
+ #define X509_STORE_CTX_get0_chain(ctx) ((ctx)->chain)
+@@ -991,7 +991,7 @@ static int set_peer_cert_hash(struct openconnect_info *vpninfo)
+ 	return 0;
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10002000L
++#if OPENSSL_VERSION_NUMBER < 0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
+ static int match_hostname_elem(const char *hostname, int helem_len,
+ 			       const char *match, int melem_len)
+ {
+@@ -1653,7 +1653,7 @@ int openconnect_open_https(struct openconnect_info *vpninfo)
+ 	 * 4fcdd66fff5fea0cfa1055c6680a76a4303f28a2
+ 	 * cd6bd5ffda616822b52104fee0c4c7d623fd4f53
+ 	 */
+-#if OPENSSL_VERSION_NUMBER >= 0x10001070
++#if OPENSSL_VERSION_NUMBER >= 0x10001070 || defined(LIBRESSL_VERSION_NUMBER)
+ 	if (string_is_hostname(vpninfo->hostname))
+ 		SSL_set_tlsext_host_name(https_ssl, vpninfo->hostname);
+ #endif
+-- 
+2.10.2
+

--- a/net-misc/openconnect/openconnect-9999.ebuild
+++ b/net-misc/openconnect/openconnect-9999.ebuild
@@ -25,16 +25,19 @@ HOMEPAGE="http://www.infradead.org/openconnect.html"
 
 LICENSE="LGPL-2.1 GPL-2"
 SLOT="0/5"
-IUSE="doc +gnutls gssapi java libproxy lz4 nls smartcard static-libs stoken"
+IUSE="doc +gnutls gssapi java libproxy libressl lz4 nls smartcard static-libs stoken"
 
-DEPEND="dev-libs/libxml2
+DEPEND="
+	dev-libs/libxml2
 	sys-libs/zlib
 	!gnutls? (
-		>=dev-libs/openssl-1.0.1h:0[static-libs?]
+		!libressl? ( >=dev-libs/openssl-1.0.1h:0=[static-libs?] )
+		libressl? ( dev-libs/libressl:0=[static-libs?] )
 	)
 	gnutls? (
-		>=net-libs/gnutls-3:0=[static-libs?] dev-libs/nettle
 		app-misc/ca-certificates
+		dev-libs/nettle
+		>=net-libs/gnutls-3:0=[static-libs?]
 	)
 	gssapi? ( virtual/krb5 )
 	libproxy? ( net-libs/libproxy )
@@ -91,6 +94,7 @@ src_configure() {
 	# liboath not in portage
 	econf \
 		--with-vpnc-script="${EPREFIX}/etc/openconnect/openconnect.sh" \
+		--without-openssl-version-check \
 		$(use_enable static-libs static) \
 		$(use_enable nls ) \
 		$(use_with !gnutls openssl) \


### PR DESCRIPTION
Patch from voidlinux.

The libressl USE flag works on openconnect-7.06 without modification, but openconnect-7.06_p20160614 requires a patch, as does openconnect-7.07.

@floppym Is this okay? You removed the USE flag before because of a bug report.