### PR TITLE
=app-misc/neofetch-1.9: fixed missing keywords

### DIFF
--- a/app-misc/neofetch/neofetch-1.9.ebuild
+++ b/app-misc/neofetch/neofetch-1.9.ebuild
@@ -8,6 +8,7 @@ HOMEPAGE="https://github.com/dylanaraps/neofetch"
 SRC_URI="https://github.com/dylanaraps/${PN}/archive/${PV}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
+KEYWORDS="~amd64 ~x86"
 IUSE="X"
 
 DEPEND="app-shells/bash:*


### PR DESCRIPTION
Gentoo-Bugs: 598896
Package-Manager: Portage 2.3.0