### PR TITLE
net-nds/openldap: Add --with-yielding-select=yes when cross-compiling.

### DIFF
--- a/net-nds/openldap/openldap-2.4.38-r2.ebuild
+++ b/net-nds/openldap/openldap-2.4.38-r2.ebuild
@@ -434,6 +434,10 @@ multilib_src_configure() {
 			--disable-overlays
 			--disable-syslog
 		)
+
+		tc-is-cross-compiler && myconf+=(
+			--with-yielding-select=yes
+		)
 	fi
 
 	# basic functionality stuff


### PR DESCRIPTION
Specifically came across this while trying to build for Chrome OS. Please let me know if the correct thing to do is to apply this to every ebuild file in this directory?