### PR TITLE
dev-perl/XML-Simple dev-perl/XML-SAX-Expat: add -fbsd keywords

### DIFF
--- a/dev-perl/XML-SAX-Expat/XML-SAX-Expat-0.510.0.ebuild
+++ b/dev-perl/XML-SAX-Expat/XML-SAX-Expat-0.510.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="SAX2 Driver for Expat"
 LICENSE="|| ( Artistic GPL-2 )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~x86"
+KEYWORDS="~alpha ~amd64 ~x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="test"
 
 RDEPEND=">=dev-perl/XML-SAX-0.15-r1

--- a/dev-perl/XML-Simple/XML-Simple-2.220.0.ebuild
+++ b/dev-perl/XML-Simple/XML-Simple-2.220.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="An API for simple XML files"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~x86"
+KEYWORDS="~alpha ~amd64 ~x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="


### PR DESCRIPTION
Fix KEYWORDREQ bug, https://bugs.gentoo.org/show_bug.cgi?id=595562

```
>>> Test phase: dev-perl/XML-SAX-Expat-0.510.0
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00basic.t ... ok
t/98podsyn.t .. ok
t/99podcov.t .. ok
All tests successful.
Files=3, Tests=3,  0 wallclock secs ( 0.01 usr  0.03 sys +  0.07 cusr  0.12 csys =  0.23 CPU)
Result: PASS
>>> Completed testing dev-perl/XML-SAX-Expat-0.510.0
```

```
>>> Test phase: dev-perl/XML-Simple-2.220.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/1_XMLin.t ............. ok
# Package                        Version  1/7 )=========================#
#  perl                           5.24.0
#  XML::Simple                    2.22
#  Storable                       2.56
#  XML::Parser                    2.44
#  XML::SAX                       0.99
#  XML::NamespaceSupport          1.11
#  XML::SAX::PurePerl             0.99
#  XML::SAX::Expat                0.51 (default parser)
t/0_Config.t ............ ok
t/6_ObjIntf.t ........... ok
t/7_SaxStuff.t .......... ok
t/8_Namespaces.t ........ ok
t/2_XMLout.t ............ ok
t/9_Strict.t ............ ok
t/A_XMLParser.t ......... ok
t/release-pod-syntax.t .. skipped: these tests are for release candidate testing
t/B_Hooks.t ............. ok
t/4_MemShare.t .......... ok
t/5_MemCopy.t ........... ok
t/3_Storable.t .......... ok
All tests successful.
Files=13, Tests=501,  6 wallclock secs ( 0.06 usr  0.08 sys +  0.96 cusr  0.33 csys =  1.43 CPU)
Result: PASS
>>> Completed testing dev-perl/XML-Simple-2.220.0
```