### PR TITLE
 dev-perl/Test-LeakTrace  dev-perl/XML-LibXML: add fbsd keywords

### DIFF
--- a/dev-perl/Test-LeakTrace/Test-LeakTrace-0.150.0.ebuild
+++ b/dev-perl/Test-LeakTrace/Test-LeakTrace-0.150.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION='Traces memory leaks'
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/XML-LibXML/XML-LibXML-2.12.800.ebuild
+++ b/dev-perl/XML-LibXML/XML-LibXML-2.12.800.ebuild
@@ -12,7 +12,7 @@ inherit perl-module
 DESCRIPTION="Perl binding for libxml2"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="test minimal"
 
 RDEPEND="


### PR DESCRIPTION
KEYWORDREQ Bug https://bugs.gentoo.org/show_bug.cgi?id=581590


```
>>> Test phase: dev-perl/Test-LeakTrace-0.150.0
gmake -j5 test TEST_VERBOSE=0
Running Mkbootstrap for Test::LeakTrace ()
chmod 644 "LeakTrace.bs"
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'inc', 'blib/lib', 'blib/arch')" t/*.t
t/00_compile.t ..... 1/1 # Testing Test::LeakTrace/0.15
t/00_compile.t ..... ok
t/01_info.t ........ ok
t/02_refs.t ........ ok
t/03_count.t ....... ok
t/04_test_funcs.t .. ok
t/05_script.t ...... ok
t/06_threads.t ..... skipped: require threads
t/07_eval.t ........ ok
t/08_leaktrace.t ... ok
t/09_info_more.t ... ok
t/10_bad_use.t ..... ok
t/11_logfp.t ....... ok
t/12_padstale.t .... ok
t/13_do.t .......... ok
All tests successful.
Files=14, Tests=126,  1 wallclock secs ( 0.04 usr  0.03 sys +  0.31 cusr  0.05 csys =  0.43 CPU)
Result: PASS
>>> Completed testing dev-perl/Test-LeakTrace-0.150.0
```

```
>>> Test phase: dev-perl/XML-LibXML-2.12.800
 * Removing un-needed t/pod.t
 * Removing un-needed t/style-trailing-space.t
 * Removing un-needed t/cpan-changes.t
 * Fixing Manifest
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
Running Mkbootstrap for XML::LibXML ()
chmod 644 "LibXML.bs"
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
===(       1;0  1/3    0/533    0/193    0/195   0/59 )=================#
#
# Compiled against libxml2 version: 20904
# Running libxml2 version:          20904
#
t/01basic.t ........................................ ok
t/05text.t ......................................... ok
t/04node.t ......................................... ok
t/03doc.t .......................................... ok
t/06elements.t ..................................... ok
t/07dtd.t .......................................... ok
t/08findnodes.t .................................... ok
t/09xpath.t ........................................ ok
t/02parse.t ........................................ ok
t/10ns.t ........................................... ok
t/11memory.t ....................................... skipped: These tests are for authors only!
t/13dtd.t .......................................... ok
t/14sax.t .......................................... ok
t/15nodelist.t ..................................... ok
t/16docnodes.t ..................................... ok
t/17callbacks.t .................................... ok
t/12html.t ......................................... ok
t/18docfree.t ...................................... ok
t/19die_on_invalid_utf8_rt_58848.t ................. ok
t/19encoding.t ..................................... ok
t/20extras.t ....................................... ok
t/21catalog.t ...................................... ok
t/23rawfunctions.t ................................. ok
t/24c14n.t ......................................... ok
t/25relaxng.t ...................................... ok
t/26schema.t ....................................... ok
t/27new_callbacks_simple.t ......................... ok
t/29id.t ........................................... ok
t/28new_callbacks_multiple.t ....................... ok
t/30keep_blanks.t .................................. ok
t/30xpathcontext.t ................................. ok
t/32xpc_variables.t ................................ ok
t/35huge_mode.t .................................... ok
t/31xpc_functions.t ................................ ok
t/40reader_mem_error.t ............................. ok
t/40reader.t ....................................... ok
t/41xinclude.t ..................................... ok
t/42common.t ....................................... ok
t/44extent.t ....................................... ok
t/45regex.t ........................................ ok
t/43options.t ...................................... ok
t/46err_column.t ................................... ok
t/47load_xml_callbacks.t ........................... ok
t/48_replaceNode_DTD_nodes_rT_80521.t .............. ok
t/48_memleak_rt_83744.t ............................ ok
t/48_removeChild_crashes_rt_80395.t ................ ok
t/48_reader_undef_warning_on_empty_str_rt106830.t .. ok
t/48_RH5_double_free_rt83779.t ..................... ok
t/48_rt55000.t ..................................... ok
t/48_rt93429_recover_2_in_html_parsing.t ........... ok
t/48importing_nodes_IDs_rt_69520.t ................. ok
t/48_SAX_Builder_rt_91433.t ........................ ok
t/49_load_html.t ................................... ok
t/49callbacks_returning_undef.t .................... skipped: URI::file is not available.
t/49global_extent.t ................................ ok
t/50devel.t ........................................ ok
t/51_parse_html_string_rt87089.t ................... ok
t/61error.t ........................................ ok
t/60struct_error.t ................................. ok
t/62overload.t ..................................... ok
t/71overloads.t .................................... ok
t/60error_prev_chain.t ............................. ok
t/90shared_clone_failed_rt_91800.t ................. skipped: no ithreads in this Perl
t/80registryleak.t ................................. ok
t/72destruction.t .................................. ok
t/90threads.t ...................................... skipped: no ithreads in this Perl
t/release-kwalitee.t ............................... skipped: These tests are for authors only!
t/90stack.t ........................................ ok
t/91unique_key.t ................................... ok
All tests successful.
Files=69, Tests=2514,  1 wallclock secs ( 0.37 usr  0.14 sys +  4.13 cusr  1.13 csys =  5.77 CPU)
Result: PASS
>>> Completed testing dev-perl/XML-LibXML-2.12.800
```
