### PR TITLE
dev-perl/Test-Warnings-0.26.0 and dependencies: add fbsd keywords, bug580268

### DIFF
--- a/dev-perl/CPAN-Meta-Check/CPAN-Meta-Check-0.13.0.ebuild
+++ b/dev-perl/CPAN-Meta-Check/CPAN-Meta-Check-0.13.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Verify requirements in a CPAN::Meta object"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="test"
 
 # CPAN::Meta::Prereqs -> perl-CPAN-Meta

--- a/dev-perl/Test-Deep/Test-Deep-1.120.0.ebuild
+++ b/dev-perl/Test-Deep/Test-Deep-1.120.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Extremely flexible deep comparison testing"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Test-Warnings/Test-Warnings-0.26.0.ebuild
+++ b/dev-perl/Test-Warnings/Test-Warnings-0.26.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION='Test for warnings and the lack of them'
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~ppc-aix ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="test suggested"
 
 # Test::Builder -> perl-Test-Simple


### PR DESCRIPTION
KEYWORDREQ Bug https://bugs.gentoo.org/show_bug.cgi?id=580268


```
>>> Test phase: dev-perl/Test-Deep-1.120.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/all.t ..................... ok
t/any.t ..................... ok
t/array_each.t .............. ok
t/array.t ................... ok
t/arraylength.t ............. ok
t/bagrecursion.t ............ ok
t/cache.t ................... ok
t/blessed.t ................. ok
t/boolean.t ................. ok
t/bag.t ..................... ok
t/circular.t ................ ok
t/code.t .................... ok
t/deep_utils.t .............. ok
t/class.t ................... ok
t/descend.t ................. ok
t/error.t ................... ok
t/hash.t .................... ok
t/hashkeys.t ................ ok
t/hash_each.t ............... ok
t/import.t .................. ok
t/ignore.t .................. ok
t/isa.t ..................... ok
t/memory.t .................. ok
t/none.t .................... ok
t/listmethods.t ............. ok
t/notest.t .................. ok
t/methods.t ................. ok
t/notest_extra.t ............ ok
t/number.t .................. ok
t/reftype.t ................. ok
t/regexpref.t ............... ok
t/regexp.t .................. ok
t/rt78288_blessed_object.t .. ok
t/scalar.t .................. ok
t/scalarref.t ............... ok
t/shallow.t ................. ok
t/string.t .................. ok
t/set.t ..................... ok
All tests successful.
Files=38, Tests=1203,  1 wallclock secs ( 0.16 usr  0.08 sys +  1.33 cusr  0.34 csys =  1.91 CPU)
Result: PASS
>>> Completed testing dev-perl/Test-Deep-1.120.0
```

```
>>> Test phase: dev-perl/CPAN-Meta-Check-0.13.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/10-basics.t .. ok
All tests successful.
Files=1, Tests=7,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.05 cusr  0.02 csys =  0.09 CPU)
Result: PASS
>>> Completed testing dev-perl/CPAN-Meta-Check-0.13.0
```

```
>>> Test phase: dev-perl/Test-Warnings-0.26.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/02-done_testing.t ................... ok
t/04-no-tests.t ....................... ok
t/03-subtest.t ........................ ok
t/01-basic.t .......................... ok
t/05-no-end-block.t ................... ok
t/06-skip-all.t ....................... skipped: Need Foo::Bar::Baz to continue!
t/07-no_plan.t ........................ ok
t/08-use-if.t ......................... ok
t/09-warnings-contents.t .............. ok
t/10-no-done_testing.t ................ ok
t/11-double-use.t ..................... ok
t/12-no-newline.t ..................... ok
t/13-propagate-warnings.t ............. ok
t/14-propagate-subname.t .............. ok
t/15-propagate-default.t .............. ok
t/16-propagate-ignore.t ............... ok
t/17-propagate-subname-colons.t ....... ok
t/18-propagate-subname-package.t ...... ok
t/19-propagate-nonexistent-subname.t .. ok
t/20-propagate-stub.t ................. ok
t/zzz-check-breaks.t .................. ok
t/00-report-prereqs.t ................. 1/1 #
# Versions for all modules listed in MYMETA.json (including optional ones):
#
# === Configure Requires ===
#
#     Module              Want    Have
#     ------------------- ---- -------
#     ExtUtils::MakeMaker  any 7.10_01
#
# === Build Requires ===
#
#     Module              Want    Have
#     ------------------- ---- -------
#     ExtUtils::MakeMaker  any 7.10_01
#
# === Test Requires ===
#
#     Module              Want     Have
#     ------------------- ---- --------
#     ExtUtils::MakeMaker  any  7.10_01
#     File::Spec           any     3.63
#     Test::More          0.94 1.001014
#     if                   any   0.0606
#
# === Test Recommends ===
#
#     Module           Want     Have
#     ------------ -------- --------
#     CPAN::Meta   2.120900 2.150005
#     Test::Tester    0.108    0.114
#
# === Test Suggests ===
#
#     Module                    Want  Have
#     ------------------------ ----- -----
#     CPAN::Meta::Check        0.011 0.013
#     CPAN::Meta::Requirements   any 2.140
#
# === Runtime Requires ===
#
#     Module        Want     Have
#     ------------- ---- --------
#     Carp           any     1.40
#     Exporter       any     5.72
#     Test::Builder  any 1.001014
#     parent         any    0.234
#     strict         any     1.11
#     warnings       any     1.36
#
t/00-report-prereqs.t ................. ok
All tests successful.
Files=22, Tests=65,  0 wallclock secs ( 0.06 usr  0.03 sys +  0.72 cusr  0.11 csys =  0.92 CPU)
Result: PASS
>>> Completed testing dev-perl/Test-Warnings-0.26.0
```
