### PR TITLE
dev-perl/Archive-Zip dev-perl/Test-MockModule and deps: add ~x86-fbsd keywords

### DIFF
--- a/dev-perl/Archive-Zip/Archive-Zip-1.570.0.ebuild
+++ b/dev-perl/Archive-Zip/Archive-Zip-1.570.0.ebuild
@@ -12,7 +12,7 @@ inherit perl-module
 DESCRIPTION="A wrapper that lets you read Zip archive members as if they were files"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/SUPER/SUPER-1.201.411.170.ebuild
+++ b/dev-perl/SUPER/SUPER-1.201.411.170.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 
 DESCRIPTION="control superclass method dispatch"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~x86"
+KEYWORDS="~amd64 ~arm ~hppa ~x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Sub-Identify/Sub-Identify-0.120.0.ebuild
+++ b/dev-perl/Sub-Identify/Sub-Identify-0.120.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Retrieve names of code references"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ppc ~ppc64 x86 ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm ~hppa ppc ~ppc64 x86 ~x86-fbsd ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Test-MockModule/Test-MockModule-0.110.0.ebuild
+++ b/dev-perl/Test-MockModule/Test-MockModule-0.110.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Override subroutines in a module for unit testing"
 
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~arm ~hppa ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="


### PR DESCRIPTION
KEYWORDREQ bug https://bugs.gentoo.org/show_bug.cgi?id=569868

```
$ emerge -pv =dev-perl/Archive-Zip-1.570.0 =dev-perl/Test-MockModule-0.110.0
<snip>
# required by dev-perl/Test-MockModule-0.110.0::gentoo
# required by =dev-perl/Test-MockModule-0.110.0 (argument)
=dev-perl/SUPER-1.201.411.170 **
# required by =dev-perl/Archive-Zip-1.570.0 (argument)
=dev-perl/Archive-Zip-1.570.0 **
# required by dev-perl/SUPER-1.201.411.170::gentoo
# required by dev-perl/Test-MockModule-0.110.0::gentoo
# required by =dev-perl/Test-MockModule-0.110.0 (argument)
=dev-perl/Sub-Identify-0.120.0 **
# required by =dev-perl/Test-MockModule-0.110.0 (argument)
=dev-perl/Test-MockModule-0.110.0 **
```

```
>>> Test phase: dev-perl/Sub-Identify-0.120.0
 * Removing un-needed t/pod.t
 * Fixing Manifest
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
Running Mkbootstrap for Sub::Identify ()
chmod 644 "Identify.bs"
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01basic.t .................. ok
t/03proto.t .................. ok
t/04codelocation-pureperl.t .. ok
t/02errors.t ................. ok
t/04codelocation.t ........... ok
t/05constant-pureperl.t ...... ok
t/06codelocxs.t .............. ok
t/06codelocxs-pureperl.t ..... ok
t/05constant.t ............... ok
t/10pureperl-basic.t ......... ok
t/20attributes.t ............. ok
t/21attributes-pureperl.t .... ok
t/30signatures.t ............. ok
All tests successful.
Files=13, Tests=143,  0 wallclock secs ( 0.06 usr  0.05 sys +  0.41 cusr  0.16 csys =  0.68 CPU)
Result: PASS
>>> Completed testing dev-perl/Sub-Identify-0.120.0
```

```
>>> Test phase: dev-perl/SUPER-1.201.411.170
 * Test::Harness Jobs=5
t/1.t ................... ok
t/bugs.t ................ ok
t/follow_inheritance.t .. ok
t/deep_inheritance.t .... ok
t/get_all_parents.t ..... ok
t/keep_going.t .......... ok
t/keep_going_manual.t ... ok
All tests successful.
Files=7, Tests=45,  0 wallclock secs ( 0.02 usr  0.02 sys +  0.18 cusr  0.09 csys =  0.30 CPU)
Result: PASS
>>> Completed testing dev-perl/SUPER-1.201.411.170
```

```
>>> Test phase: dev-perl/Test-MockModule-0.110.0
 * Removing un-needed t/pod_coverage.t
 * Removing un-needed t/pod.t
 * Fixing Manifest
 * Test::Harness Jobs=5
t/inheritance.t .. ok
t/mockmodule.t ... ok
All tests successful.
Files=2, Tests=59,  0 wallclock secs ( 0.03 usr  0.01 sys +  0.06 cusr  0.03 csys =  0.13 CPU)
Result: PASS
>>> Completed testing dev-perl/Test-MockModule-0.110.0
```

```
>>> Test phase: dev-perl/Archive-Zip-1.570.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01_compile.t ................ ok
t/04_readmember.t ............. ok
t/05_tree.t ................... ok
t/07_filenames_of_0.t ......... ok
t/02_main.t ................... ok
t/06_update.t ................. ok
t/08_readmember_record_sep.t .. ok
t/09_output_record_sep.t ...... ok
t/11_explorer.t ............... ok
t/10_chmod.t .................. ok
t/12_bug_47223.t .............. skipped: Only required on Win32.
t/13_bug_46303.t .............. ok
t/15_decrypt.t ................ ok
t/14_leading_separator.t ...... ok
t/16_decrypt.t ................ ok
t/17_101092.t ................. ok
t/19_bug_101240.t ............. ok
t/20_bug_github11.t ........... ok
t/18_bug_92205.t .............. ok
t/21_zip64.t .................. ok
t/23_closed_handle.t .......... ok
t/22_deflated_dir.t ........... ok
t/03_ex.t ..................... ok
All tests successful.
Files=23, Tests=293,  1 wallclock secs ( 0.14 usr  0.10 sys +  3.95 cusr  1.40 csys =  5.59 CPU)
Result: PASS
>>> Completed testing dev-perl/Archive-Zip-1.570.0
```
