### PR TITLE
media-libs/libgroove: update dependencies

### DIFF
--- a/media-libs/libgroove/libgroove-4.3.0-r1.ebuild
+++ b/media-libs/libgroove/libgroove-4.3.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -18,7 +18,7 @@ IUSE="+chromaprint libav +loudness +sound static-libs"
 DEPEND="libav? ( media-video/libav )
 	!libav? ( media-video/ffmpeg )
 	chromaprint? ( media-libs/chromaprint )
-	loudness? ( media-libs/libebur128[speex] )
+	loudness? ( media-libs/libebur128[speex(+)] )
 	sound? ( media-libs/libsdl2[sound] )"
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Allow building with >=media-libs/libebur128-1.2, which no longer has the
speex USE flag.