### PR TITLE
dev-perl/Glib-Object-Introspection: fix sandbox issue (bug #599128)

### DIFF
--- a/dev-perl/Glib-Object-Introspection/Glib-Object-Introspection-0.40.0.ebuild
+++ b/dev-perl/Glib-Object-Introspection/Glib-Object-Introspection-0.40.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 DIST_AUTHOR=XAOC
 DIST_VERSION=0.040
-inherit perl-module
+inherit perl-module xdg-utils
 
 DESCRIPTION="Dynamically create Perl language bindings"
 
@@ -26,3 +26,7 @@ DEPEND="
 	>=dev-perl/extutils-pkgconfig-1.0.0
 	${RDEPEND}
 "
+
+pkg_setup() {
+	xdg_environment_reset	# bug #599128
+}


### PR DESCRIPTION
I can't confirm if it worked solution, since I don't have such issue.
But I have applied a common solution, like in other resolutions.
