### PR TITLE
sys-fs/cryptsetup-1.7.3: add libressl patch

### DIFF
--- a/sys-fs/cryptsetup/cryptsetup-1.7.3.ebuild
+++ b/sys-fs/cryptsetup/cryptsetup-1.7.3.ebuild
@@ -57,6 +57,7 @@ pkg_setup() {
 
 src_prepare() {
 	sed -i '/^LOOPDEV=/s:$: || exit 0:' tests/{compat,mode}-test || die
+	epatch "${FILESDIR}/libressl.patch"
 	epatch_user && eautoreconf
 
 	if use python ; then

--- a/sys-fs/cryptsetup/files/libressl.patch
+++ b/sys-fs/cryptsetup/files/libressl.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/crypto_backend/crypto_openssl.c b/lib/crypto_backend/crypto_openssl.c
+index c19fd9b..b1e14b6 100644
+--- a/lib/crypto_backend/crypto_openssl.c
++++ b/lib/crypto_backend/crypto_openssl.c
+@@ -73,7 +73,7 @@ const char *crypt_backend_version(void)
+ /*
+  * Compatible wrappers for OpenSSL < 1.1.0
+  */
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ static EVP_MD_CTX *EVP_MD_CTX_new(void)
+ {
+ 	EVP_MD_CTX *md = malloc(sizeof(*md));


### PR DESCRIPTION
Hi all,

this is a tiny patch to re-enable compiling against libressl.

This has been merged by upstream and won't be needed in future versions:
https://gitlab.com/cryptsetup/cryptsetup/merge_requests/12
But in the meantime it'll allow libressl users to update.

I didn't make a new revision version because people who already have installed this aren't affected (they use openssl) and people who need it can't have installed it yet.

Let me know if you want me to change anything. 