### PR TITLE
x11-drivers/xf86-video-vmware:  Fix RDEPEND for G/FBSD and add amd64-fbsd KEYWORDS

### DIFF
--- a/profiles/arch/amd64-fbsd/package.use.mask
+++ b/profiles/arch/amd64-fbsd/package.use.mask
@@ -45,3 +45,7 @@ x11-drivers/nvidia-drivers multilib
 # requires nvidia-cg-toolkit which is not available on bsd
 # see http://developer.nvidia.com/cg-toolkit-download
 media-libs/libprojectm video_cards_nvidia
+
+# x11-drivers/xf86-video-vmware works fine without KMS- and 3D support.
+# Other packages will not work. keep video_cards_vmware in use.mask.
+x11-base/xorg-drivers -video_cards_vmware

--- a/profiles/arch/amd64-fbsd/todo/package.use.mask
+++ b/profiles/arch/amd64-fbsd/todo/package.use.mask
@@ -145,10 +145,6 @@ x11-base/xorg-drivers video_cards_sis
 # x11-drivers/xf86-video-tdfx
 x11-base/xorg-drivers video_cards_tdfx
 
-# x11-drivers/xf86-video-vmware
-# x11-libs/libdrm[libkms,video_cards_vmware]
-x11-base/xorg-drivers video_cards_vmware
-
 # >=sys-auth/polkit-qt-0.103.0
 # >=kde-misc/polkit-kde-kcmodules-0.98_pre20101127
 # >=sys-auth/polkit-kde-agent-0.99

--- a/x11-drivers/xf86-video-vmware/xf86-video-vmware-13.1.0.ebuild
+++ b/x11-drivers/xf86-video-vmware/xf86-video-vmware-13.1.0.ebuild
@@ -8,9 +8,11 @@ XORG_DRI=always
 inherit xorg-2
 
 DESCRIPTION="VMware SVGA video driver"
-KEYWORDS="amd64 x86 ~x86-fbsd"
-IUSE=""
+KEYWORDS="amd64 x86 ~amd64-fbsd ~x86-fbsd"
+IUSE="kernel_linux"
 
-RDEPEND="x11-libs/libdrm[libkms,video_cards_vmware]
-	media-libs/mesa[xa]"
+RDEPEND="kernel_linux? (
+		x11-libs/libdrm[libkms,video_cards_vmware]
+		media-libs/mesa[xa]
+	)"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Fix KEYWORDREQ bug: https://bugs.gentoo.org/show_bug.cgi?id=477604