### PR TITLE
kde-plasma/plasma-workspace: Make FILESDIR great again

### DIFF
--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-all-outputs-known.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-all-outputs-known.patch
@@ -1,0 +1,71 @@
+From: Marco Martin <notmart@gmail.com>
+Date: Wed, 09 Nov 2016 14:54:42 +0000
+Subject: make sure all outputs are known
+X-Git-Url: http://quickgit.kde.org/?p=plasma-workspace.git&a=commitdiff&h=b8d3e09b3687082037a6d280d2032617121ae5e5
+---
+make sure all outputs are known
+
+at startup, if a screen id is missing from the screenpool mapping
+containment::screen() will return -1 for a moment in the startup
+phase even if it has a valid lastScreen
+
+populate mappings of eventual missing stuff at screenpool ctor
+
+make sure destroyed containments don't get assigned a view
+
+reviewed-by: David Edmundson
+
+CCBUG:372099
+CCBUG:371858
+CCBUG:371991
+CCBUG:371819
+CCBUG:371734
+---
+
+
+--- a/shell/screenpool.cpp
++++ b/shell/screenpool.cpp
+@@ -49,6 +49,17 @@
+             m_idForConnector[connector] = key.toInt();
+         } else if (m_idForConnector.value(connector) != key.toInt()) {
+             m_configGroup.deleteEntry(key);
++        }
++    }
++
++    // if there are already connected unknown screens, map those
++    // all needs to be populated as soon as possible, otherwise
++    // containment->screen() will return an incorrect -1
++    // at startup, if it' asked before corona::addOutput()
++    // is performed, driving to the creation of a new containment
++    for (QScreen* screen : qGuiApp->screens()) {
++        if (!m_idForConnector.contains(screen->name())) {
++            insertScreenMapping(firstAvailableId(), screen->name());
+         }
+     }
+ }
+
+--- a/shell/shellcorona.cpp
++++ b/shell/shellcorona.cpp
+@@ -1178,7 +1178,12 @@
+ {
+     if (m_desktopContainments.contains(activity)) {
+         for (Plasma::Containment *cont : m_desktopContainments.value(activity)) {
+-            if (cont->screen() == screenNum && cont->activity() == activity) {
++            //in the case of a corrupt config file
++            //with multiple containments with same lastScreen
++            //it can happen two insertContainment happen for
++            //the same screen, leading to the old containment 
++            //to be destroyed
++            if (!cont->destroyed() && cont->screen() == screenNum && cont->activity() == activity) {
+                 return cont;
+             }
+         }
+@@ -1832,6 +1837,7 @@
+ //     qDebug() << "ShellCorona screenForContainment: " << containment << " Last screen is " << containment->lastScreen();
+ 
+     for (auto screen : qGuiApp->screens()) {
++        // containment->lastScreen() == m_screenPool->id(screen->name()) to check if the lastScreen refers to a screen that exists/it's known
+         if (containment->lastScreen() == m_screenPool->id(screen->name()) &&
+             (containment->activity() == m_activityController->currentActivity() ||
+             containment->containmentType() == Plasma::Types::PanelContainment || containment->containmentType() == Plasma::Types::CustomPanelContainment)) {
+

--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-dont-connect-twice.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-dont-connect-twice.patch
@@ -1,0 +1,44 @@
+commit 8a472f17ce11f3b79d740cdc21096d82b8683f3d
+Author: David Edmundson <kde@davidedmundson.co.uk>
+Date:   Thu Nov 10 10:28:16 2016 +0000
+
+    Avoid connecting to screen changed signals twice
+    
+    Summary:
+    load() can be called multiple times; either from setShell or
+    loadLookAndFeelDefaultLayout. We still only want addOutput once when a
+    screen is added
+    
+    Reviewers: #plasma, apol
+    
+    Reviewed By: apol
+    
+    Subscribers: plasma-devel
+    
+    Tags: #plasma
+    
+    Differential Revision: https://phabricator.kde.org/D3320
+    
+    CCBUG:372099
+    CCBUG:371858
+    CBUG:371991
+    CCBUG:371819
+    CCBUG:371734
+
+diff --git a/shell/shellcorona.cpp b/shell/shellcorona.cpp
+index af2f555..0007f0b 100644
+--- a/shell/shellcorona.cpp
++++ b/shell/shellcorona.cpp
+@@ -675,9 +675,9 @@ void ShellCorona::load()
+             addOutput(screen);
+         }
+     }
+-    connect(qGuiApp, &QGuiApplication::screenAdded, this, &ShellCorona::addOutput);
+-    connect(qGuiApp, &QGuiApplication::primaryScreenChanged, this, &ShellCorona::primaryOutputChanged);
+-    connect(qGuiApp, &QGuiApplication::screenRemoved, this, &ShellCorona::screenRemoved);
++    connect(qGuiApp, &QGuiApplication::screenAdded, this, &ShellCorona::addOutput, Qt::UniqueConnection);
++    connect(qGuiApp, &QGuiApplication::primaryScreenChanged, this, &ShellCorona::primaryOutputChanged, Qt::UniqueConnection);
++    connect(qGuiApp, &QGuiApplication::screenRemoved, this, &ShellCorona::screenRemoved, Qt::UniqueConnection);
+ 
+     if (!m_waitingPanels.isEmpty()) {
+         m_waitingPanelsTimer.start();

--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-screenpool-screenchange.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-screenpool-screenchange.patch
@@ -1,0 +1,95 @@
+commit 7154fb681adc73c482e862febc7ad008f77058dd
+Author: David Edmundson <kde@davidedmundson.co.uk>
+Date:   Thu Nov 10 10:29:27 2016 +0000
+
+    Load screenpool at the same time as we connect to screenchanged signals
+    
+    Summary:
+    Otherwise we have a gap during load (waiting querying kactivities))
+    between screen pool being created and us connecting to the screen
+    changed signals, which in turn are used to update screen pool.
+    
+    In particular the primary screen can get out of sync between the current
+    state and the screen pool.
+    
+    Test Plan: Based on Christopher Feck's research and initial patch
+    
+    Reviewers: #plasma
+    
+    Subscribers: mart, rwooninck, fvogt, cfeck, plasma-devel
+    
+    Tags: #plasma
+    
+    Differential Revision: https://phabricator.kde.org/D3319
+    
+        CCBUG:372099
+        CCBUG:371858
+        CBUG:371991
+        CCBUG:371819
+        CCBUG:371734
+
+diff --git a/shell/autotests/screenpooltest.cpp b/shell/autotests/screenpooltest.cpp
+index 5d0522f..5fc844a 100644
+--- a/shell/autotests/screenpooltest.cpp
++++ b/shell/autotests/screenpooltest.cpp
+@@ -51,6 +51,7 @@ void ScreenPoolTest::initTestCase()
+     cg.deleteGroup();
+     cg.sync();
+     m_screenPool = new ScreenPool(KSharedConfig::openConfig(), this);
++    m_screenPool->load();
+ }
+ 
+ void ScreenPoolTest::cleanupTestCase()
+diff --git a/shell/screenpool.cpp b/shell/screenpool.cpp
+index 011300d..b60cca1 100644
+--- a/shell/screenpool.cpp
++++ b/shell/screenpool.cpp
+@@ -30,6 +30,14 @@ ScreenPool::ScreenPool(KSharedConfig::Ptr config, QObject *parent)
+     connect(&m_configSaveTimer, &QTimer::timeout, this, [this](){
+         m_configGroup.sync();
+     });
++}
++
++void ScreenPool::load()
++{
++    m_primaryConnector = QString();
++    m_connectorForId.clear();
++    m_idForConnector.clear();
++
+     QScreen *primary = qGuiApp->primaryScreen();
+     if (primary) {
+         m_primaryConnector = primary->name();
+diff --git a/shell/screenpool.h b/shell/screenpool.h
+index 046d18b..9b3a9af 100644
+--- a/shell/screenpool.h
++++ b/shell/screenpool.h
+@@ -33,6 +33,7 @@ class ScreenPool : public QObject {
+ 
+ public:
+     ScreenPool(KSharedConfig::Ptr config, QObject *parent = nullptr);
++    void load();
+     ~ScreenPool() override;
+ 
+     QString primaryConnector() const;
+diff --git a/shell/shellcorona.cpp b/shell/shellcorona.cpp
+index 0007f0b..1475374 100644
+--- a/shell/shellcorona.cpp
++++ b/shell/shellcorona.cpp
+@@ -627,6 +627,8 @@ void ShellCorona::load()
+ 
+     disconnect(m_activityController, &KActivities::Controller::serviceStatusChanged, this, &ShellCorona::load);
+ 
++    m_screenPool->load();
++
+     //TODO: a kconf_update script is needed
+     QString configFileName(QStringLiteral("plasma-") + m_shell + QStringLiteral("-appletsrc"));
+ 
+@@ -1184,7 +1186,7 @@ Plasma::Containment *ShellCorona::createContainmentForActivity(const QString& ac
+             //in the case of a corrupt config file
+             //with multiple containments with same lastScreen
+             //it can happen two insertContainment happen for
+-            //the same screen, leading to the old containment 
++            //the same screen, leading to the old containment
+             //to be destroyed
+             if (!cont->destroyed() && cont->screen() == screenNum && cont->activity() == activity) {
+                 return cont;

--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-sync-app-w-applets-config.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-sync-app-w-applets-config.patch
@@ -1,0 +1,22 @@
+From: David Edmundson <kde@davidedmundson.co.uk>
+Date: Wed, 09 Nov 2016 15:11:52 +0000
+Subject: Sync app config in sync with applets config
+X-Git-Url: http://quickgit.kde.org/?p=plasma-workspace.git&a=commitdiff&h=329f00dc90f6645ff6e531542212ea73fb8ef274
+---
+Sync app config in sync with applets config
+---
+
+
+--- a/shell/shellcorona.cpp
++++ b/shell/shellcorona.cpp
+@@ -114,6 +114,9 @@
+     m_appConfigSyncTimer.setSingleShot(true);
+     m_appConfigSyncTimer.setInterval(s_configSyncDelay);
+     connect(&m_appConfigSyncTimer, &QTimer::timeout, this, &ShellCorona::syncAppConfig);
++    //we want our application config with screen mapping to always be in sync with the applets one, so a crash at any time will still
++    //leave containments pointing to the correct screens
++    connect(this, &Corona::configSynced, this, &ShellCorona::syncAppConfig);
+ 
+     m_waitingPanelsTimer.setSingleShot(true);
+     m_waitingPanelsTimer.setInterval(250);
+

--- a/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-systray-cpuload.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-5.8.3-systray-cpuload.patch
@@ -1,0 +1,177 @@
+From: Lindsay Roberts <m@lindsayr.com>
+Date: Mon, 10 Oct 2016 16:55:49 +0000
+Subject: Systray: Move all icon resolution to dataengine
+X-Git-Url: http://quickgit.kde.org/?p=plasma-workspace.git&a=commitdiff&h=749f60b89f4a166833fb64a5b593a801f63f9615
+---
+Systray: Move all icon resolution to dataengine
+
+Summary:
+Changes triggered by investigation into a long-running high CPU usage bug with system tray animations. The systray itself had icon name to icon resolution code, which was being triggered (twice) for every icon, every time any icon in the systray was updated. This code was spinning up a KIconLoader on each of these instances, and throwing it directly away. Each one triggered a large quantity of memory allocations and disk scans.
+
+This patch moves the extra bit of "appName" logic from the native part of the system tray to the statusnotifieritem datasource, which already had a stored 'customIconLoader' to handle icon theme paths, and removes the special lookup from the sytemtray applet completely. It also prefers icons provided by the dataengine to doing another lookup (contentious?). This removes all the extra CPU usage outside of the QML scene graph and graphics drivers locally.
+
+This is very much a looking for feedback item - there are things about the icon loading paths I almost certainly haven't appreciated yet, and perhaps preferring loading by icon name in the applet has a another purpose.
+
+BUG: 356479
+
+Test Plan: Have tested locally with kgpg and steam, the two apps I have that trigger the old code path. In neither case, however, did the appName logic produce a different result to the code with just the icon search path in statusnotifieritem.
+
+Reviewers: #plasma, davidedmundson, mart
+
+Reviewed By: #plasma, davidedmundson, mart
+
+Subscribers: davidedmundson, plasma-devel
+
+Tags: #plasma
+
+Differential Revision: https://phabricator.kde.org/D2986
+---
+
+
+--- a/applets/systemtray/package/contents/ui/ConfigEntries.qml
++++ b/applets/systemtray/package/contents/ui/ConfigEntries.qml
+@@ -75,7 +75,7 @@
+                 "index": i,
+                 "taskId": item.Id,
+                 "name": item.Title,
+-                "iconName": plasmoid.nativeInterface.resolveIcon(item.IconName, item.IconThemePath),
++                "iconName": item.IconName,
+                 "icon": item.Icon
+             });
+         }
+
+--- a/applets/systemtray/package/contents/ui/items/StatusNotifierItem.qml
++++ b/applets/systemtray/package/contents/ui/items/StatusNotifierItem.qml
+@@ -28,7 +28,7 @@
+     text: Title
+     mainText: ToolTipTitle != "" ? ToolTipTitle : Title
+     subText: ToolTipSubTitle
+-    icon: ToolTipIcon != "" ? ToolTipIcon : plasmoid.nativeInterface.resolveIcon(IconName != "" ? IconName : Icon, IconThemePath)
++    icon: ToolTipIcon != "" ? ToolTipIcon : Icon ? Icon : IconName
+     textFormat: Text.AutoText
+     category: Category
+ 
+@@ -48,7 +48,7 @@
+ 
+     PlasmaCore.IconItem {
+         id: iconItem
+-        source: plasmoid.nativeInterface.resolveIcon(IconName != "" ? IconName : Icon, IconThemePath)
++        source: Icon ? Icon : IconName
+         width: Math.min(parent.width, parent.height)
+         height: width
+         active: taskIcon.containsMouse
+
+--- a/applets/systemtray/systemtray.cpp
++++ b/applets/systemtray/systemtray.cpp
+@@ -37,36 +37,10 @@
+ #include <Plasma/PluginLoader>
+ #include <Plasma/ServiceJob>
+ 
+-#include <KIconLoader>
+-#include <KIconEngine>
+ #include <KActionCollection>
+ #include <KLocalizedString>
+ 
+ #include <plasma_version.h>
+-
+-/*
+- * An app may also load icons from their own directories, so we need a new iconloader that takes this into account
+- * This is wrapped into a subclass of iconengine so the iconloader lifespan matches the icon object
+- */
+-class AppIconEngine : public KIconEngine
+-{
+-public:
+-    AppIconEngine(const QString &variant, const QString &path, const QString &appName);
+-    ~AppIconEngine();
+-private:
+-    KIconLoader* m_loader;
+-};
+-
+-AppIconEngine::AppIconEngine(const QString &variant, const QString &path, const QString &appName) :
+-    KIconEngine(variant, m_loader = new KIconLoader(appName, QStringList()))
+-{
+-    m_loader->addAppDir(appName, path);
+-}
+-
+-AppIconEngine::~AppIconEngine()
+-{
+-    delete m_loader;
+-}
+ 
+ class PlasmoidModel: public QStandardItemModel
+ {
+@@ -167,32 +141,6 @@
+             emit appletDeleted(applet);
+         }
+     }
+-}
+-
+-QVariant SystemTray::resolveIcon(const QVariant &variant, const QString &iconThemePath)
+-{
+-    if (variant.canConvert<QString>()) {
+-        if (!iconThemePath.isEmpty()) {
+-            const QString path = iconThemePath;
+-            if (!path.isEmpty()) {
+-                // FIXME: If last part of path is not "icons", this won't work!
+-                auto tokens = path.splitRef('/', QString::SkipEmptyParts);
+-                if (tokens.length() >= 3 && tokens.takeLast() == QLatin1String("icons")) {
+-                    const QString appName = tokens.takeLast().toString();
+-
+-                    return QVariant(QIcon(new AppIconEngine(variant.toString(), path, appName)));
+-                } else {
+-                    qCWarning(SYSTEM_TRAY) << "Wrong IconThemePath" << path << ": too short or does not end with 'icons'";
+-                }
+-            }
+-
+-            //return just the string hoping that IconItem will know how to interpret it anyways as either a normal icon or a SVG from the theme
+-            return variant;
+-        }
+-    }
+-
+-    // Most importantly QIcons. Nothing to do for those.
+-    return variant;
+ }
+ 
+ void SystemTray::showPlasmoidMenu(QQuickItem *appletInterface, int x, int y)
+
+--- a/applets/systemtray/systemtray.h
++++ b/applets/systemtray/systemtray.h
+@@ -59,12 +59,6 @@
+     void cleanupTask(const QString &task);
+ 
+     //Invokable utilities
+-    /**
+-     * returns either a simple icon name or a custom path if the app is
+-     * using a custom theme
+-     */
+-    Q_INVOKABLE QVariant resolveIcon(const QVariant &variant, const QString &iconThemePath);
+-
+     /**
+      * Given an AppletInterface pointer, shows a proper context menu for it
+      */
+
+--- a/dataengines/statusnotifieritem/statusnotifieritemsource.cpp
++++ b/dataengines/statusnotifieritem/statusnotifieritemsource.cpp
+@@ -240,14 +240,19 @@
+             if (!m_customIconLoader) {
+                 m_customIconLoader = new KIconLoader(QString(), QStringList(), this);
+             }
++            // FIXME: If last part of path is not "icons", this won't work!
++            QString appName;
++            auto tokens = path.splitRef('/', QString::SkipEmptyParts);
++            if (tokens.length() >= 3 && tokens.takeLast() == QLatin1String("icons"))
++                appName = tokens.takeLast().toString();
+ 
+             //icons may be either in the root directory of the passed path or in a appdir format
+             //i.e hicolor/32x32/iconname.png
+ 
+-            m_customIconLoader->reconfigure(QString(), QStringList(path));
++            m_customIconLoader->reconfigure(appName, QStringList(path));
+ 
+             //add app dir requires an app name, though this is completely unused in this context
+-            m_customIconLoader->addAppDir(QStringLiteral("unused"), path);
++            m_customIconLoader->addAppDir(appName.size() ? appName : QStringLiteral("unused"), path);
+         }
+         setData(QStringLiteral("IconThemePath"), path);
+ 
+

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.8.3-r1.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.8.3-r1.ebuild
@@ -1,0 +1,175 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+KDE_HANDBOOK="forceoptional"
+KDE_TEST="forceoptional"
+VIRTUALX_REQUIRED="test"
+inherit kde5 multilib qmake-utils
+
+DESCRIPTION="KDE Plasma workspace"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="+calendar geolocation gps prison qalculate +semantic-desktop"
+
+COMMON_DEPEND="
+	$(add_frameworks_dep kactivities)
+	$(add_frameworks_dep kauth)
+	$(add_frameworks_dep kbookmarks)
+	$(add_frameworks_dep kcmutils)
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kcrash)
+	$(add_frameworks_dep kdbusaddons)
+	$(add_frameworks_dep kdeclarative)
+	$(add_frameworks_dep kdelibs4support)
+	$(add_frameworks_dep kdesu)
+	$(add_frameworks_dep kglobalaccel)
+	$(add_frameworks_dep kguiaddons)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kidletime)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kitemmodels)
+	$(add_frameworks_dep kitemviews)
+	$(add_frameworks_dep kjobwidgets)
+	$(add_frameworks_dep kjs)
+	$(add_frameworks_dep kjsembed)
+	$(add_frameworks_dep knewstuff)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep knotifyconfig)
+	$(add_frameworks_dep kpackage)
+	$(add_frameworks_dep krunner)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep ktexteditor)
+	$(add_frameworks_dep ktextwidgets)
+	$(add_frameworks_dep kwallet)
+	$(add_frameworks_dep kwayland)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep kxmlrpcclient)
+	$(add_frameworks_dep plasma)
+	$(add_frameworks_dep solid)
+	$(add_plasma_dep kscreenlocker)
+	$(add_plasma_dep kwin)
+	$(add_plasma_dep libksysguard)
+	$(add_qt_dep qtconcurrent)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtdeclarative 'widgets')
+	$(add_qt_dep qtgui 'jpeg')
+	$(add_qt_dep qtnetwork)
+	$(add_qt_dep qtscript)
+	$(add_qt_dep qtsql)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtx11extras)
+	$(add_qt_dep qtxml)
+	dev-libs/libdbusmenu-qt[qt5]
+	media-libs/phonon[qt5]
+	sys-libs/zlib
+	x11-libs/libICE
+	x11-libs/libSM
+	x11-libs/libX11
+	x11-libs/libXau
+	x11-libs/libxcb
+	x11-libs/libXfixes
+	x11-libs/libXrender
+	x11-libs/xcb-util
+	x11-libs/xcb-util-image
+	calendar? ( $(add_kdeapps_dep kholidays) )
+	geolocation? ( $(add_frameworks_dep networkmanager-qt) )
+	gps? ( sci-geosciences/gpsd )
+	prison? ( media-libs/prison:5 )
+	qalculate? ( sci-libs/libqalculate )
+	semantic-desktop? ( $(add_frameworks_dep baloo) )
+"
+RDEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kded)
+	$(add_kdeapps_dep kio-extras)
+	$(add_plasma_dep kde-cli-tools)
+	$(add_plasma_dep ksysguard)
+	$(add_plasma_dep milou)
+	$(add_plasma_dep plasma-integration)
+	$(add_qt_dep qdbus)
+	$(add_qt_dep qtgraphicaleffects)
+	$(add_qt_dep qtpaths)
+	$(add_qt_dep qtquickcontrols 'widgets')
+	app-text/iso-codes
+	x11-apps/mkfontdir
+	x11-apps/xmessage
+	x11-apps/xprop
+	x11-apps/xrdb
+	x11-apps/xset
+	x11-apps/xsetroot
+	!dev-libs/xembed-sni-proxy
+	!kde-base/freespacenotifier:4
+	!kde-base/libtaskmanager:4
+	!kde-base/kcminit:4
+	!kde-base/kdebase-startkde:4
+	!kde-base/klipper:4
+	!kde-base/krunner:4
+	!kde-base/ksmserver:4
+	!kde-base/ksplash:4
+	!kde-base/plasma-workspace:4
+"
+DEPEND="${COMMON_DEPEND}
+	x11-proto/xproto
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-5.4-startkde-script.patch"
+	# stable branch
+	"${FILESDIR}/${PN}-5.8.3-all-outputs-known.patch"
+	"${FILESDIR}/${PN}-5.8.3-sync-app-w-applets-config.patch"
+	"${FILESDIR}/${PN}-5.8.3-dont-connect-twice.patch"
+	"${FILESDIR}/${PN}-5.8.3-screenpool-screenchange.patch"
+	# master
+	"${FILESDIR}/${PN}-5.7.90-baloo-optional.patch"
+	"${FILESDIR}/${PN}-5.8.3-systray-cpuload.patch"
+)
+
+RESTRICT+=" test"
+
+src_prepare() {
+	kde5_src_prepare
+
+	sed -e "s|\`qtpaths|\`$(qt5_get_bindir)/qtpaths|" \
+		-i startkde/startkde.cmake startkde/startplasmacompositor.cmake || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_find_package calendar KF5Holidays)
+		$(cmake-utils_use_find_package geolocation KF5NetworkManagerQt)
+		$(cmake-utils_use_find_package gps libgps)
+		$(cmake-utils_use_find_package prison KF5Prison)
+		$(cmake-utils_use_find_package qalculate Qalculate)
+		$(cmake-utils_use_find_package semantic-desktop KF5Baloo)
+	)
+
+	kde5_src_configure
+}
+
+src_install() {
+	kde5_src_install
+
+	# startup and shutdown scripts
+	insinto /etc/plasma/startup
+	doins "${FILESDIR}/10-agent-startup.sh"
+
+	insinto /etc/plasma/shutdown
+	doins "${FILESDIR}/10-agent-shutdown.sh"
+}
+
+pkg_postinst () {
+	kde5_pkg_postinst
+
+	elog
+	elog "To enable gpg-agent and/or ssh-agent in Plasma sessions,"
+	elog "edit ${EPREFIX}/etc/plasma/startup/10-agent-startup.sh and"
+	elog "${EPREFIX}/etc/plasma/shutdown/10-agent-shutdown.sh"
+	elog
+}


### PR DESCRIPTION
Each of those closes several bugs.
Also adding a fix from master about too high cpuload with systray.
Dropped subslot operator from kde-frameworks/plasma.

@gentoo/kde @stikonas 