### PR TITLE
net-libs/nodejs: add optional support for dtrace-based tracing

### DIFF
--- a/net-libs/nodejs/metadata.xml
+++ b/net-libs/nodejs/metadata.xml
@@ -16,5 +16,6 @@
 	<use>
 	<flag name="npm">Enable NPM package manager</flag>
 	<flag name="snapshot">Enable snapshot creation for faster startup</flag>
+	<flag name="systemtap">Enable SystemTAP/DTrace tracing</flag>
 	</use>
 </pkgmetadata>

--- a/net-libs/nodejs/nodejs-7.2.0.ebuild
+++ b/net-libs/nodejs/nodejs-7.2.0.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz"
 LICENSE="Apache-1.1 Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86 ~amd64-linux ~x64-macos"
-IUSE="cpu_flags_x86_sse2 debug doc icu +npm +snapshot +ssl test"
+IUSE="cpu_flags_x86_sse2 debug doc icu +npm +snapshot +ssl systemtap test"
 
 RDEPEND="icu? ( >=dev-libs/icu-56:= )
 	npm? ( ${PYTHON_DEPS} )
@@ -109,7 +109,7 @@ src_configure() {
 	"${PYTHON}" configure \
 		--prefix="${EPREFIX}"/usr \
 		--dest-cpu=${myarch} \
-		--without-dtrace \
+		$(use_with systemtap dtrace) \
 		"${myconf[@]}" || die
 }
 


### PR DESCRIPTION
NodeJS supports dtrace-based tracing, that can be used by
dev-util/systemtap and, more recently, dev-util/bcc. This support is
forcibly disabled in nodejs ebuilds.

This commit adds a systemtap USE flag to be able to turn on this
support conditionally. The name of this flag matches the choice done
for other ebuilds, like dev-db/mysql or app-emulation/qemu. Despite
what has been done in those ebuilds, however, a dependency on
dev-util/systemtap is not added: this is because, as of late,
systemtap is not the only consumer of those traces anymore.

The change has been performed only on the ebuilds from the latest
stable version onwards.