### PR TITLE
net-print/cups-filters: depend on app-text/mupdf

### DIFF
--- a/net-print/cups-filters/cups-filters-9999.ebuild
+++ b/net-print/cups-filters/cups-filters-9999.ebuild
@@ -23,6 +23,7 @@ SLOT="0"
 IUSE="dbus +foomatic jpeg ldap perl png +postscript static-libs tiff zeroconf"
 
 RDEPEND="
+	app-text/mupdf
 	postscript? ( >=app-text/ghostscript-gpl-9.09[cups] )
 	>=app-text/poppler-0.32:=[cxx,jpeg?,lcms,tiff?,utils,xpdf-headers(+)]
 	>=app-text/qpdf-3.0.2:=


### PR DESCRIPTION
This fixes this build failure:
```
checking for gs... gs                                                                                                                
checking whether gs supports the ps2write device... yes                                                                              
checking for mutool... no                                                                                                            
configure: error: Required mutool binary is missing. Please install mutool.
```