### PR TITLE
dev-qt/qtwebengine: Port chromium patches, fix hardened build.

### DIFF
--- a/dev-qt/qtwebengine/files/qtwebengine-5.7.0-fix-system-ffmpeg.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.7.0-fix-system-ffmpeg.patch
@@ -1,0 +1,13 @@
+diff -Naur qtwebengine-opensource-src-5.7.0.orig/src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h qtwebengine-opensource-src-5.7.0/src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h
+--- qtwebengine-opensource-src-5.7.0.orig/src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h	2016-11-23 13:01:20.929772871 -0800
++++ qtwebengine-opensource-src-5.7.0/src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h	2016-11-23 13:02:18.879462854 -0800
+@@ -24,7 +24,9 @@
+ // Disable deprecated features which result in spammy compile warnings.  This
+ // list of defines must mirror those in the 'defines' section of BUILD.gn file &
+ // ffmpeg.gyp file or the headers below will generate different structures!
++#if !defined(USE_SYSTEM_FFMPEG)
+ #define FF_API_CONVERGENCE_DURATION 0
++#endif
+ // Upstream libavcodec/utils.c still uses the deprecated
+ // av_dup_packet(), causing deprecation warnings.
+ // The normal fix for such things is to disable the feature as below,

--- a/dev-qt/qtwebengine/files/qtwebengine-5.7.0-gcc6.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.7.0-gcc6.patch
@@ -1,0 +1,106 @@
+From cffcf22082879939bbcfa89e88057beda829a0a7 Mon Sep 17 00:00:00 2001
+From: David Faure <david.faure@kdab.com>
+Date: Sat, 3 Sep 2016 18:01:40 +0200
+Subject: gcc6: set -fno-delete-null-pointer-checks for all files
+
+Not just v8, as v8_no_delete_null_pointer_checks does.
+This is necessary e.g. for PaintLayer::enclosingSelfPaintingLayer
+which also compares this with null.
+
+I'll remove v8_no_delete_null_pointer_checks in a later commit
+to avoid a temporary breakage until qtwebengine is updated.
+
+Change-Id: I8782fadc8fab125b5394bd60857e70c6ae75f9b0
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+(cherry picked from commit c42f53ec3ca90bfd98577988462ed51464feebe3)
+---
+ chromium/build/common.gypi | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/3rdparty/chromium/build/common.gypi b/src/3rdparty/chromium/build/common.gypi
+index b6a0284..d768ab3 100644
+--- a/src/3rdparty/chromium/build/common.gypi
++++ b/src/3rdparty/chromium/build/common.gypi
+@@ -4702,6 +4706,9 @@
+               '-Wl,--disable-new-dtags',
+             ],
+           }],
++          [ 'no_delete_null_pointer_checks==1', {
++              'cflags_cc': [ '-fno-delete-null-pointer-checks' ],
++          }],
+           ['clang==0', {
+             'target_conditions': [
+               ['_toolset=="target"', {
+-- 
+cgit v1.0-4-g1e03
+
+From ae73e50e7d8c1371ed293c10150646a2719f4598 Mon Sep 17 00:00:00 2001
+From: Allan Sandfeld Jensen <allan.jensen@theqtcompany.com>
+Date: Wed, 14 Sep 2016 17:40:50 +0200
+Subject: FIXUP: gcc6: set -fno-delete-null-pointer-checks for all files
+
+Set a default and pull in the value from configuration, and
+remove the old v8 only version.
+
+Change-Id: Ica9f971baa28c717178eb2acd074607424792e1d
+Reviewed-by: David Faure <david.faure@kdab.com>
+---
+ chromium/build/common.gypi       | 4 ++++
+ chromium/v8/build/toolchain.gypi | 7 -------
+ 2 files changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/src/3rdparty/chromium/build/common.gypi b/src/3rdparty/chromium/build/common.gypi
+index d768ab3..8a1df22 100644
+--- a/src/3rdparty/chromium/build/common.gypi
++++ b/src/3rdparty/chromium/build/common.gypi
+@@ -727,6 +727,9 @@
+       # By default include non-appstore-compliant code.
+       'appstore_compliant_code%': 0,
+ 
++      # Enable this to turn off the delete-null-pointer-checks optimization in GCC 6+
++      'no_delete_null_pointer_checks%': 0,
++
+       'conditions': [
+         # A flag for POSIX platforms
+         ['OS=="win"', {
+@@ -1271,6 +1274,7 @@
+     'enable_hangout_services_extension%' : '<(enable_hangout_services_extension)',
+     'proprietary_codecs%': '<(proprietary_codecs)',
+     'appstore_compliant_code%': '<(appstore_compliant_code)',
++    'no_delete_null_pointer_checks%': '<(no_delete_null_pointer_checks)',
+     'use_goma%': '<(use_goma)',
+     'gomadir%': '<(gomadir)',
+     'use_lto%': '<(use_lto)',
+-- 
+cgit v1.0-4-g1e03
+
+From d6c8a2cf8fa374e6d1c0a578391b57112c047fa4 Mon Sep 17 00:00:00 2001
+From: David Faure <david.faure@kdab.com>
+Date: Mon, 5 Sep 2016 15:25:02 +0200
+Subject: Enable -fno_delete_null_pointer_checks for g++ 6 on all of chromium
+
+This is necessary e.g. for PaintLayer::enclosingSelfPaintingLayer
+which also compares this with null.
+
+Change-Id: I85d69432a0d7eeb0d8df8f395821880e36180dcc
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+---
+ src/core/config/linux.pri | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/config/linux.pri b/src/core/config/linux.pri
+index 9264932..a318e17 100644
+--- a/src/core/config/linux.pri
++++ b/src/core/config/linux.pri
+@@ -29,6 +29,8 @@ use?(nss) {
+         use_openssl_certs=1
+ }
+ 
++gcc:!clang: greaterThan(QT_GCC_MAJOR_VERSION, 5): GYP_CONFIG += no_delete_null_pointer_checks=1
++ 
+ contains(QT_CONFIG, system-zlib): use?(system_minizip): GYP_CONFIG += use_system_zlib=1
+ contains(QT_CONFIG, system-png): GYP_CONFIG += use_system_libpng=1
+ contains(QT_CONFIG, system-jpeg): GYP_CONFIG += use_system_libjpeg=1
+-- 
+cgit v1.0-4-g1e03
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.7.0-icu58.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.7.0-icu58.patch
@@ -1,0 +1,51 @@
+diff -Naur qtwebengine-opensource-src-5.7.0.orig/src/3rdparty/chromium/third_party/WebKit/Source/platform/text/TextBreakIterator.cpp qtwebengine-opensource-src-5.7.0/src/3rdparty/chromium/third_party/WebKit/Source/platform/text/TextBreakIterator.cpp
+--- qtwebengine-opensource-src-5.7.0.orig/src/3rdparty/chromium/third_party/WebKit/Source/platform/text/TextBreakIterator.cpp	2016-11-15 17:07:38.680665385 -0800
++++ qtwebengine-opensource-src-5.7.0/src/3rdparty/chromium/third_party/WebKit/Source/platform/text/TextBreakIterator.cpp	2016-11-15 17:12:17.564001354 -0800
+@@ -26,6 +26,9 @@
+ #include "wtf/StdLibExtras.h"
+ #include "wtf/text/CharacterNames.h"
+ 
++#include <unicode/uchar.h>
++#include <unicode/uvernum.h>
++
+ namespace blink {
+ 
+ unsigned numGraphemeClusters(const String& string)
+@@ -122,13 +125,18 @@
+     { B(0, 0, 0, 0, 0, 0, 0, 0), B(0, 0, 0, 0, 0, 0, 0, 0), 0, B(0, 0, 0, 0, 0, 0, 0, 0), 0, 0, 0, B(0, 0, 0, 0, 0, 0, 0, 0), 0, 0, 0, B(0, 0, 0, 0, 0, 0, 0, 0) }, // DEL
+ };
+ 
++#if U_ICU_VERSION_MAJOR_NUM >= 58
++#define BA_LB_COUNT (U_LB_COUNT - 3)
++#else
++#define BA_LB_COUNT U_LB_COUNT
++#endif
+ // Line breaking table for CSS word-break: break-all. This table differs from
+ // asciiLineBreakTable in:
+ // - Indices are Line Breaking Classes defined in UAX#14 Unicode Line Breaking
+ //   Algorithm: http://unicode.org/reports/tr14/#DescriptionOfProperties
+ // - 1 indicates additional break opportunities. 0 indicates to fallback to
+ //   normal line break, not "prohibit break."
+-static const unsigned char breakAllLineBreakClassTable[][U_LB_COUNT / 8 + 1] = {
++static const unsigned char breakAllLineBreakClassTable[][BA_LB_COUNT / 8 + 1] = {
+     // XX AI AL B2 BA BB BK CB    CL CM CR EX GL HY ID IN    IS LF NS NU OP PO PR QU    SA SG SP SY ZW NL WJ H2    H3 JL JT JV CP CJ HL RI
+     { B(0, 0, 0, 0, 0, 0, 0, 0), B(0, 0, 0, 0, 0, 0, 0, 0), B(0, 0, 0, 0, 0, 0, 0, 0), B(0, 0, 0, 0, 0, 0, 0, 0), B(0, 0, 0, 0, 0, 0, 0, 0) }, // XX
+     { B(0, 1, 1, 0, 1, 0, 0, 0), B(0, 0, 0, 0, 0, 1, 0, 0), B(0, 0, 0, 1, 1, 0, 1, 0), B(1, 0, 0, 0, 0, 0, 0, 0), B(0, 0, 0, 0, 0, 0, 1, 0) }, // AI
+@@ -178,7 +186,7 @@
+ #undef AL
+ 
+ static_assert(WTF_ARRAY_LENGTH(asciiLineBreakTable) == asciiLineBreakTableLastChar - asciiLineBreakTableFirstChar + 1, "asciiLineBreakTable should be consistent");
+-static_assert(WTF_ARRAY_LENGTH(breakAllLineBreakClassTable) == U_LB_COUNT, "breakAllLineBreakClassTable should be consistent");
++static_assert(WTF_ARRAY_LENGTH(breakAllLineBreakClassTable) == BA_LB_COUNT, "breakAllLineBreakClassTable should be consistent");
+ 
+ static inline bool shouldBreakAfter(UChar lastCh, UChar ch, UChar nextCh)
+ {
+@@ -209,7 +217,7 @@
+ 
+ static inline bool shouldBreakAfterBreakAll(ULineBreak lastLineBreak, ULineBreak lineBreak)
+ {
+-    if (lineBreak >= 0 && lineBreak < U_LB_COUNT && lastLineBreak >= 0 && lastLineBreak < U_LB_COUNT) {
++    if (lineBreak >= 0 && lineBreak < BA_LB_COUNT && lastLineBreak >= 0 && lastLineBreak < BA_LB_COUNT) {
+         const unsigned char* tableRow = breakAllLineBreakClassTable[lastLineBreak];
+         return tableRow[lineBreak / 8] & (1 << (lineBreak % 8));
+     }

--- a/dev-qt/qtwebengine/files/qtwebengine-5.7.0-undef-madv_free.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.7.0-undef-madv_free.patch
@@ -1,0 +1,33 @@
+From fa8cdb3a32c377b6290d0a92d2522186bcd48293 Mon Sep 17 00:00:00 2001
+From: Allan Sandfeld Jensen <allan.jensen@theqtcompany.com>
+Date: Tue, 9 Aug 2016 16:21:29 +0200
+Subject: Do not depend on Linux 4.5
+
+Avoid using MADV_FREE that was only recently added to Linux. It will fail when
+run on older Linux kernels.
+
+Change-Id: I9b0369fb31402f088b2327c12f70dd39f5e4c8c0
+Reviewed-by: Peter Varga <pvarga@inf.u-szeged.hu>
+---
+ chromium/third_party/WebKit/Source/wtf/allocator/PageAllocator.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/3rdparty/chromium/third_party/WebKit/Source/wtf/PageAllocator.cpp b/src/3rdparty/chromium/third_party/WebKit/Source/wtf/PageAllocator.cpp
+index 12c9a7b..1639013 100644
+--- a/src/3rdparty/chromium/third_party/WebKit/Source/wtf/PageAllocator.cpp
++++ b/src/3rdparty/chromium/third_party/WebKit/Source/wtf/PageAllocator.cpp
+@@ -39,6 +39,11 @@
+
+ #include <sys/mman.h>
+ 
++#if OS(LINUX) && defined(MADV_FREE)
++// Added in Linux 4.5, but we don't want to depend on 4.5 at runtime
++#undef MADV_FREE
++#endif
++
+ #ifndef MADV_FREE
+ #define MADV_FREE MADV_DONTNEED
+ #endif
+-- 
+cgit v1.0-4-g1e03
+

--- a/dev-qt/qtwebengine/files/qtwebengine-paxmark-mksnapshot.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-paxmark-mksnapshot.patch
@@ -1,0 +1,46 @@
+--- qtwebengine-opensource-src-5.6.0-orig/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-03-04 01:48:36.000000000 +1100
++++ qtwebengine-opensource-src-5.6.0/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-05-01 19:15:44.052770543 +1000
+@@ -33,6 +33,7 @@
+     'embed_script%': "",
+     'v8_extra_library_files%': [],
+     'mksnapshot_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot<(EXECUTABLE_SUFFIX)',
++    'mksnapshot_u_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot_u<(EXECUTABLE_SUFFIX)',
+     'remove_v8base_debug_symbols%': 0,
+   },
+   'includes': ['../../build/toolchain.gypi', '../../build/features.gypi'],
+@@ -1913,7 +1914,7 @@
+         ]
+     },
+     {
+-      'target_name': 'mksnapshot',
++      'target_name': 'mksnapshot_u',
+       'type': 'executable',
+       'dependencies': ['v8_base', 'v8_nosnapshot', 'v8_libplatform'],
+       'include_dirs+': [
+@@ -1936,5 +1937,26 @@
+         }],
+       ],
+     },
++    {
++      'target_name': 'mksnapshot',
++      'type': 'executable',
++      'dependencies': ['mksnapshot_u'],
++      'actions': [
++        {
++          'action_name': 'paxmark_m_mksnapshot',
++          'inputs': [
++            '<(mksnapshot_u_exec)',
++          ],
++          'outputs': [
++            '<(mksnapshot_exec)',
++          ],
++          'action': [
++            'sh',
++            '-c',
++            'cp <(mksnapshot_u_exec) <(mksnapshot_exec) && paxmark.sh m <(mksnapshot_exec)',
++          ],
++        },
++      ],
++    },
+   ],
+ }

--- a/dev-qt/qtwebengine/metadata.xml
+++ b/dev-qt/qtwebengine/metadata.xml
@@ -8,6 +8,7 @@
 	<use>
 		<flag name="geolocation">Enable physical position determination
 			via <pkg>dev-qt/qtpositioning</pkg></flag>
+		<flag name="pax_kernel">Enable building under a PaX enabled kernel</flag>
 		<flag name="system-ffmpeg">Use the system-wide <pkg>media-video/ffmpeg</pkg>
 			instead of bundled.</flag>
 		<flag name="system-icu">Use the system-wide <pkg>dev-libs/icu</pkg>

--- a/dev-qt/qtwebengine/qtwebengine-5.6.2.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.6.2.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	media-libs/mesa
 	media-libs/opus
 	media-libs/speex
-	net-libs/libsrtp:=
+	net-libs/libsrtp:0=
 	sys-apps/dbus
 	sys-apps/pciutils
 	sys-libs/libcap

--- a/dev-qt/qtwebengine/qtwebengine-5.6.2.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.6.2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 PYTHON_COMPAT=( python2_7 )
-inherit python-any-r1 qt5-build
+inherit pax-utils python-any-r1 qt5-build
 
 DESCRIPTION="Library for rendering dynamic web content in Qt5 C++ and QML applications"
 
@@ -12,7 +12,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~x86"
 fi
 
-IUSE="bindist geolocation +system-ffmpeg +system-icu widgets"
+IUSE="bindist geolocation pax_kernel +system-ffmpeg +system-icu widgets"
 
 RDEPEND="
 	app-arch/snappy
@@ -68,9 +68,12 @@ DEPEND="${RDEPEND}
 	dev-util/ninja
 	dev-util/re2c
 	sys-devel/bison
+	pax_kernel? ( sys-apps/elfix )
 "
 
 src_prepare() {
+	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-paxmark-mksnapshot.patch" )
+
 	if use system-icu; then
 		# ensuire build against system headers - bug #601264
 		rm -r src/3rdparty/chromium/third_party/icu/source || die
@@ -94,4 +97,10 @@ src_configure() {
 		$(usex system-icu 'WEBENGINE_CONFIG+=use_system_icu' '')
 	)
 	qt5-build_src_configure
+}
+
+src_install() {
+	qt5-build_src_install
+
+	pax-mark m "${D%/}${QT5_LIBEXECDIR}"/QtWebEngineProcess
 }

--- a/dev-qt/qtwebengine/qtwebengine-5.7.0.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.7.0.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	media-libs/mesa
 	media-libs/opus
 	media-libs/speex
-	net-libs/libsrtp:=
+	net-libs/libsrtp:0=
 	sys-apps/dbus
 	sys-apps/pciutils
 	sys-libs/libcap

--- a/dev-qt/qtwebengine/qtwebengine-5.7.0.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.7.0.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 PYTHON_COMPAT=( python2_7 )
-inherit python-any-r1 qt5-build
+inherit pax-utils python-any-r1 qt5-build
 
 DESCRIPTION="Library for rendering dynamic web content in Qt5 C++ and QML applications"
 
@@ -12,7 +12,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~x86"
 fi
 
-IUSE="bindist geolocation +system-ffmpeg +system-icu widgets"
+IUSE="bindist geolocation pax_kernel +system-ffmpeg +system-icu widgets"
 
 RDEPEND="
 	app-arch/snappy
@@ -68,6 +68,7 @@ DEPEND="${RDEPEND}
 	dev-util/ninja
 	dev-util/re2c
 	sys-devel/bison
+	pax_kernel? ( sys-apps/elfix )
 "
 
 PATCHES=(
@@ -78,6 +79,8 @@ PATCHES=(
 )
 
 src_prepare() {
+	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-paxmark-mksnapshot.patch" )
+
 	if use system-icu; then
 		# ensuire build against system headers - bug #601264
 		rm -r src/3rdparty/chromium/third_party/icu/source || die
@@ -101,4 +104,10 @@ src_configure() {
 		$(usex system-icu 'WEBENGINE_CONFIG+=use_system_icu' '')
 	)
 	qt5-build_src_configure
+}
+
+src_install() {
+	qt5-build_src_install
+
+	pax-mark m "${D%/}${QT5_LIBEXECDIR}"/QtWebEngineProcess
 }

--- a/dev-qt/qtwebengine/qtwebengine-5.7.0.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.7.0.ebuild
@@ -70,6 +70,13 @@ DEPEND="${RDEPEND}
 	sys-devel/bison
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-5.7.0-fix-system-ffmpeg.patch"
+	"${FILESDIR}/${PN}-5.7.0-gcc6.patch"
+	"${FILESDIR}/${PN}-5.7.0-icu58.patch"
+	"${FILESDIR}/${PN}-5.7.0-undef-madv_free.patch"
+)
+
 src_prepare() {
 	if use system-icu; then
 		# ensuire build against system headers - bug #601264


### PR DESCRIPTION
Interestingly, 5.6.0 (based on an older version of chromium) doesn't seem to need the icu patch or the madv_free patch.

The hardened patch is in a different commit because I'm not entirely sure if this is the approach we should be using.