### PR TITLE
x11-base/xorg-server: Missing dep on wayland-protocols

### DIFF
--- a/x11-base/xorg-server/xorg-server-1.19.0.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.19.0.ebuild
@@ -74,6 +74,7 @@ CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	unwind? ( sys-libs/libunwind )
 	wayland? (
 		>=dev-libs/wayland-1.3.0
+		>=dev-libs/wayland-protocols-1.4
 		media-libs/libepoxy
 	)
 	>=x11-apps/xinit-1.3.3-r1


### PR DESCRIPTION
xorg-server's ``configure.ac`` says:
```
  XWAYLANDMODULES="wayland-client >= 1.3.0 wayland-protocols >= 1.1 $LIBDRM epoxy"
```
There was no dep on the xwayland-protocols, so let's add one which
requires the latest stable one.