### PR TITLE
Remove redeclaration of ttyname with a different signature.

### DIFF
--- a/app-crypt/mit-krb5/files/mit-krb5-1.14.2-redeclared_ttyname_error.patch
+++ b/app-crypt/mit-krb5/files/mit-krb5-1.14.2-redeclared_ttyname_error.patch
@@ -1,0 +1,22 @@
+Fixes the redeclaration of ttyname which was preventing
+enabling clang fortify.
+
+The error was;
+
+main.c:858:15: error: redeclaration of 'ttyname' must have the 'overloadable' attribute
+    char *p, *ttyname();
+              ^
+/build/samus/usr/include/unistd.h:784:14: note: previous overload of function is here
+extern char *ttyname (int __fd) __THROW __CLANG_NO_MANGLE (ttyname);
+
+--- clients/ksu/main.c
++++ clients/ksu/main.c
+@@ -855,7 +855,7 @@
+ 
+ static char * ontty()
+ {
+-    char *p, *ttyname();
++    char *p;
+     static char buf[MAXPATHLEN + 5];
+     int result;
+ 

--- a/app-crypt/mit-krb5/mit-krb5-1.14.2.ebuild
+++ b/app-crypt/mit-krb5/mit-krb5-1.14.2.ebuild
@@ -58,6 +58,7 @@ MULTILIB_CHOST_TOOLS=(
 src_prepare() {
 	epatch "${FILESDIR}/${PN}-1.12_warn_cflags.patch"
 	epatch "${FILESDIR}/${PN}-config_LDFLAGS.patch"
+	epatch "${FILESDIR}/${PN}-${PV}-redeclared_ttyname_error.patch"
 
 	eautoreconf
 }

--- a/app-crypt/mit-krb5/mit-krb5-1.14.3.ebuild
+++ b/app-crypt/mit-krb5/mit-krb5-1.14.3.ebuild
@@ -58,6 +58,7 @@ MULTILIB_CHOST_TOOLS=(
 src_prepare() {
 	epatch "${FILESDIR}/${PN}-1.12_warn_cflags.patch"
 	epatch "${FILESDIR}/${PN}-config_LDFLAGS.patch"
+	epatch "${FILESDIR}/${PN}-1.14.2-redeclared_ttyname_error.patch"
 
 	eautoreconf
 }

--- a/app-crypt/mit-krb5/mit-krb5-1.14.4.ebuild
+++ b/app-crypt/mit-krb5/mit-krb5-1.14.4.ebuild
@@ -58,6 +58,7 @@ MULTILIB_CHOST_TOOLS=(
 src_prepare() {
 	epatch "${FILESDIR}/${PN}-1.12_warn_cflags.patch"
 	epatch "${FILESDIR}/${PN}-config_LDFLAGS.patch"
+	epatch "${FILESDIR}/${PN}-1.14.2-redeclared_ttyname_error.patch"
 
 	# Make sure we always use the system copies.
 	rm -rf util/{et,ss,verto}


### PR DESCRIPTION
Original declaration is in unistd.h. This caused compile error
when using clang fortify.