### PR TITLE
app-admin/puppetdb: fix 4.3.0 missing cli commands #600130

### DIFF
--- a/app-admin/puppetdb/puppetdb-4.3.0-r1.ebuild
+++ b/app-admin/puppetdb/puppetdb-4.3.0-r1.ebuild
@@ -65,6 +65,9 @@ src_install() {
 	doins ext/cli/foreground
 	doins ext/cli/anonymize
 	doins ext/cli/import
+	doins ext/cli/reload
+	doins ext/cli/start
+	doins ext/cli/stop
 	insinto /opt/puppetlabs/server/apps/puppetdb/bin
 	doins ext/bin/puppetdb
 	insopts -m0644


### PR DESCRIPTION
Puppetdb-4.3.0 changed the way the systemd unit works, which now calls
puppetdb {start|stop|reload}. These commands are distributed as extra
scripts, and so need to be installed.

Fixes #600130