### PR TITLE
app-admin/puppetserver: fix 2.7.0 missing cli commands

### DIFF
--- a/app-admin/puppetserver/puppetserver-2.7.0-r1.ebuild
+++ b/app-admin/puppetserver/puppetserver-2.7.0-r1.ebuild
@@ -67,6 +67,9 @@ src_install() {
 	doins ext/cli/foreground
 	doins ext/cli/gem
 	doins ext/cli/ruby
+	doins ext/cli/reload
+	doins ext/cli/start
+	doins ext/cli/stop
 	insinto /opt/puppetlabs/server/apps/puppetserver/bin
 	doins ext/bin/puppetserver
 	insopts -m0644


### PR DESCRIPTION
The way the puppetserver systemd service unit starts and stops the server
has changed, and the additional cli commands are not installed by the 2.7.0
ebuild. This commit adds the missing files.

Fixes #600136
Related to #600130