### PR TITLE
dev-libs/glib: add multilib dependency on util-linux (bug #599586)

### DIFF
--- a/dev-libs/glib/glib-2.50.2.ebuild
+++ b/dev-libs/glib/glib-2.50.2.ebuild
@@ -30,6 +30,10 @@ REQUIRED_USE="
 
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux"
 
+# Added util-linux multilib dependency to have libmount support (which
+# is always turned on on linux systems, unless explicitly disabled, but
+# this ebuild does not do that anyway) (bug #599586)
+
 RDEPEND="
 	!<dev-util/gdbus-codegen-${PV}
 	>=dev-libs/libpcre-8.13:3[${MULTILIB_USEDEP},static-libs?]
@@ -37,6 +41,7 @@ RDEPEND="
 	>=virtual/libffi-3.0.13-r1[${MULTILIB_USEDEP}]
 	>=virtual/libintl-0-r2[${MULTILIB_USEDEP}]
 	>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]
+	kernel_linux? ( sys-apps/util-linux[${MULTILIB_USEDEP}] )
 	selinux? ( >=sys-libs/libselinux-2.2.2-r5[${MULTILIB_USEDEP}] )
 	xattr? ( >=sys-apps/attr-2.4.47-r1[${MULTILIB_USEDEP}] )
 	fam? ( >=virtual/fam-0-r1[${MULTILIB_USEDEP}] )
@@ -168,6 +173,7 @@ multilib_src_configure() {
 		$(usex debug --enable-debug=yes ' ') \
 		$(use_enable xattr) \
 		$(use_enable fam) \
+		$(use_enable kernel_linux libmount) \
 		$(use_enable selinux) \
 		$(use_enable static-libs static) \
 		$(use_enable systemtap dtrace) \


### PR DESCRIPTION
Starting with 2.50, libmount support is enabled by default on Linux
systems (unless overridden, which we don't do).

Open questions I have:
- should I revbump or modify existing?
- just the latest, 2.50.2, is fine?