### PR TITLE
net-nntp/sabnzbd: Fix starting when default Python is not 2.x and more

### DIFF
--- a/net-nntp/sabnzbd/sabnzbd-1.1.0.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-1.1.0.ebuild
@@ -64,10 +64,10 @@ pkg_setup() {
 }
 
 src_prepare() {
-	epatch "${FILESDIR}"/1.1.x/0001-use-system-configobj-and-feedparser.patch
-	epatch "${FILESDIR}"/1.1.x/0002-assume-gntp-1.0.patch
-	epatch "${FILESDIR}"/1.1.x/0003-cfg-disable-growl-by-default.patch
-	epatch "${FILESDIR}"/1.1.x/0004-use-system-rarfile.patch
+	epatch "${FILESDIR}"/patches/0001-use-system-configobj-and-feedparser.patch
+	epatch "${FILESDIR}"/patches/0002-assume-gntp-1.0.patch
+	epatch "${FILESDIR}"/patches/0003-cfg-disable-growl-by-default.patch
+	epatch "${FILESDIR}"/patches/0004-use-system-rarfile.patch
 
 	# remove bundled modules
 	rm -r sabnzbd/utils/{feedparser,configobj,rarfile}.py || die

--- a/net-nntp/sabnzbd/sabnzbd-1.1.0.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-1.1.0.ebuild
@@ -80,9 +80,9 @@ src_install() {
 
 	dodir /usr/share/${PN}/sabnzbd
 	insinto /usr/share/${PN}/
+	python_convert_shebangs 2 SABnzbd.py
 	doins SABnzbd.py
 	fperms +x /usr/share/${PN}/SABnzbd.py
-	dobin "${FILESDIR}"/sabnzbd
 
 	for d in cherrypy email icons interfaces locale po sabnzbd tools util; do
 		insinto /usr/share/${PN}/${d}

--- a/net-nntp/sabnzbd/sabnzbd-1.1.1.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-1.1.1.ebuild
@@ -88,6 +88,7 @@ src_install() {
 	insopts -m 0755
 	doins SABnzbd.py
 
+	python_fix_shebang "${D}usr/share/${PN}"
 	python_optimize "${D}usr/share/${PN}"
 
 	newinitd "${FILESDIR}/${PN}.initd" "${PN}"

--- a/net-nntp/sabnzbd/sabnzbd-1.1.1.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-1.1.1.ebuild
@@ -117,7 +117,6 @@ pkg_postinst() {
 	einfo "By default, SABnzbd+ will listen on TCP port 8080."
 	einfo
 	einfo "As Growl is not the default notification system on Gentoo, we disable it."
-	einfo "By default, notifications are forwarded to TCP port 23053."
 
 	local replacing
 	for replacing in ${REPLACING_VERSIONS}; do

--- a/net-nntp/sabnzbd/sabnzbd-1.1.1.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-1.1.1.ebuild
@@ -88,8 +88,8 @@ src_install() {
 	insopts -m 0755
 	doins SABnzbd.py
 
-	python_fix_shebang "${D}usr/share/${PN}"
-	python_optimize "${D}usr/share/${PN}"
+	python_fix_shebang "${ED}usr/share/${PN}"
+	python_optimize "${ED}usr/share/${PN}"
 
 	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
 	newconfd "${FILESDIR}/${PN}.confd" "${PN}"


### PR DESCRIPTION
This pull request fixes two issues that popped up after the recent changes to SABnzbd+ ebuilds, adds support for Gentoo Prefix and removes a superfluous post-install message (I suggested this as a bonus to #2861, feel free to ignore this commit if you are against the change it suggests).

/cc @jsbronder (maintainer)