### PR TITLE
net-proxy/squirm: Fix build with GCC-5

### DIFF
--- a/net-proxy/squirm/files/squirm-1.26-gcc5.patch
+++ b/net-proxy/squirm/files/squirm-1.26-gcc5.patch
@@ -1,0 +1,9 @@
+--- a/util.h	2005-08-19 09:31:06.000000000 +0200
++++ b/util.h	2016-11-21 21:06:59.311182893 +0100
+@@ -24,5 +24,5 @@
+   information.
+ */
+ 
+-inline void lower_case(char *str);
++extern inline void lower_case(char *str);
+ char *safe_strdup(const char *str);

--- a/net-proxy/squirm/squirm-1.26-r1.ebuild
+++ b/net-proxy/squirm/squirm-1.26-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI=6
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="A redirector for Squid"
 HOMEPAGE="http://squirm.foote.com.au"
@@ -16,17 +16,19 @@ KEYWORDS="~amd64 ppc x86"
 IUSE=""
 
 RDEPEND="net-proxy/squid"
+DEPEND="${RDEPEND}"
 
-src_prepare() {
-	epatch "${FILESDIR}"/${P}-gentoo.patch
-}
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+	"${FILESDIR}"/${P}-gcc5.patch
+)
 
 src_compile() {
 	emake CC="$(tc-getCC)" LDOPTS="${LDFLAGS}"
 }
 
 src_install() {
-	emake PREFIX="${ED}/opt/squirm" install
+	emake PREFIX="${ED%/}/opt/squirm" install
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Adding squid to DEPEND because squid user is expected at install

Gentoo-bug: 554800

Package-Manager: portage-2.3.0