### PR TITLE
www-client/firefox: force bash on emake install

### DIFF
--- a/www-client/firefox/firefox-50.0.ebuild
+++ b/www-client/firefox/firefox-50.0.ebuild
@@ -294,7 +294,7 @@ src_install() {
 			|| die
 	done
 
-	MOZ_MAKE_FLAGS="${MAKEOPTS}" \
+	MOZ_MAKE_FLAGS="${MAKEOPTS}" SHELL="${SHELL:-${EPREFIX%/}/bin/bash}" \
 	emake DESTDIR="${D}" install
 
 	# Install language packs


### PR DESCRIPTION
Hi, without this firefox fails to install if /bin/sh isn't bash.