### PR TITLE
app-text/a2ps: Security revbump to fix CVE-2014-0466

### DIFF
--- a/app-text/a2ps/a2ps-4.14-r3.ebuild
+++ b/app-text/a2ps/a2ps-4.14-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,7 +6,7 @@ EAPI=4
 inherit autotools elisp-common eutils flag-o-matic
 
 DESCRIPTION="Any to PostScript filter"
-HOMEPAGE="http://www.inf.enst.fr/~demaille/a2ps/"
+HOMEPAGE="https://www.gnu.org/software/a2ps/"
 SRC_URI="mirror://gnu/${PN}/${P}.tar.gz
 	linguas_ja? ( mirror://gentoo/${P}-ja_nls.patch.gz )"
 

--- a/app-text/a2ps/a2ps-4.14-r4.ebuild
+++ b/app-text/a2ps/a2ps-4.14-r4.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools elisp-common flag-o-matic
 
 DESCRIPTION="Any to PostScript filter"
-HOMEPAGE="http://www.inf.enst.fr/~demaille/a2ps/"
+HOMEPAGE="https://www.gnu.org/software/a2ps/"
 SRC_URI="mirror://gnu/${PN}/${P}.tar.gz
 	linguas_ja? ( mirror://gentoo/${P}-ja_nls.patch.gz )"
 

--- a/app-text/a2ps/a2ps-4.14-r5.ebuild
+++ b/app-text/a2ps/a2ps-4.14-r5.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools elisp-common flag-o-matic
 
 DESCRIPTION="Any to PostScript filter"
-HOMEPAGE="http://www.inf.enst.fr/~demaille/a2ps/"
+HOMEPAGE="https://www.gnu.org/software/a2ps/"
 SRC_URI="mirror://gnu/${PN}/${P}.tar.gz
 	linguas_ja? ( mirror://gentoo/${P}-ja_nls.patch.gz )"
 

--- a/app-text/a2ps/a2ps-4.14-r5.ebuild
+++ b/app-text/a2ps/a2ps-4.14-r5.ebuild
@@ -1,0 +1,140 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit autotools elisp-common flag-o-matic
+
+DESCRIPTION="Any to PostScript filter"
+HOMEPAGE="http://www.inf.enst.fr/~demaille/a2ps/"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz
+	linguas_ja? ( mirror://gentoo/${P}-ja_nls.patch.gz )"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+IUSE="emacs latex linguas_ja nls static-libs userland_BSD userland_GNU vanilla"
+
+RESTRICT=test
+
+RDEPEND="app-text/ghostscript-gpl
+	app-text/libpaper
+	>=app-text/psutils-1.17
+	app-text/wdiff
+	emacs? ( virtual/emacs )
+	latex? ( virtual/latex-base )
+	nls? ( virtual/libintl )
+	userland_GNU? ( >=sys-apps/coreutils-6.10-r1 )
+	userland_BSD? ( sys-freebsd/freebsd-ubin )"
+DEPEND="${RDEPEND}
+	>=dev-util/gperf-2.7.2
+	virtual/yacc
+	nls? ( sys-devel/gettext )"
+
+SITEFILE=50${PN}-gentoo.el
+
+S=${WORKDIR}/${PN}-${PV:0:4}
+
+src_prepare() {
+	default
+
+	eapply "${FILESDIR}"/${PN}-4.13c-locale-gentoo.diff
+	use vanilla || eapply -p0 "${FILESDIR}"/${PN}-4.13-stdout.diff
+	if use linguas_ja; then
+		eapply "${WORKDIR}"/${P}-ja_nls.patch
+		# bug #335803
+		eapply -p0 "${FILESDIR}"/${P}-ja-cleanup.patch
+	else
+		eapply "${FILESDIR}"/${P}-cleanup.patch
+	fi
+
+	# fix fnmatch replacement, bug #134546
+	eapply "${FILESDIR}"/${PN}-4.13c-fnmatch-replacement.patch
+
+	# bug #122026
+	eapply "${FILESDIR}"/${P}-psset.patch
+
+	# fix emacs printing, bug #114627
+	eapply "${FILESDIR}"/a2ps-4.13c-emacs.patch
+
+	# fix chmod error, #167670
+	eapply "${FILESDIR}"/a2ps-4.13-manpage-chmod.patch
+
+	# add configure check for mempcpy, bug 216588
+	eapply "${FILESDIR}"/${P}-check-mempcpy.patch
+
+	# fix compilation error due to invalid stpcpy() prototype, bug 216588
+	eapply -p0 "${FILESDIR}"/${P}-fix-stpcpy-proto.patch
+
+	# fix compilation error due to obstack.h issue, bug 269638
+	eapply "${FILESDIR}"/${P}-ptrdiff_t.patch
+
+	# fix compilation error due to texinfo 5.x, bug 482748
+	eapply "${FILESDIR}"/${P}-texinfo-5.x.patch
+
+	# fix CVE-2014-0466, bug 506352
+	eapply "${FILESDIR}"/${P}-CVE-2014-0466.patch
+
+	# fix building with sys-devel/automake >= 1.12, bug 420503
+	rm -f {.,ogonkify}/aclocal.m4 || die
+	sed -i \
+		-e '/^AM_C_PROTOTYPES/d' \
+		-e '/^AUTOMAKE_OPTIONS.*ansi2knr/d' \
+		-e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' \
+		-e 's:AM_PROG_CC_STDC:AC_PROG_CC:' \
+		configure.in {contrib/sample,lib,src}/Makefile.am m4/protos.m4 || die
+
+	eautoreconf
+}
+
+src_configure() {
+	append-cppflags -DPROTOTYPES #420503
+
+	local myconf="COM_netscape=no COM_acroread=no"
+
+	use emacs || myconf="${myconf} EMACS=no"
+	use latex || myconf="${myconf} COM_latex=no"
+
+	export LANG=C LC_ALL=C
+
+	econf \
+		--enable-shared \
+		$(use_enable static-libs static) \
+		--sysconfdir="${EPREFIX}"/etc/a2ps \
+		$(use_enable nls) \
+		${myconf}
+}
+
+src_compile() {
+	# parallel make b0rked
+	emake -j1
+}
+
+src_install() {
+	emake \
+		DESTDIR="${D}" \
+		lispdir="${EPREFIX}${SITELISP}"/${PN} \
+		install
+
+	newdoc "${ED}"/usr/share/a2ps/README README.a2ps
+	newdoc "${ED}"/usr/share/a2ps/ppd/README README.a2ps.ppd
+	newdoc "${ED}"/usr/share/ogonkify/README README.ogonkify
+
+	rm -f "${ED}"/usr/share/{a2ps,a2ps/ppd,ogonkify}/README || die
+
+	prune_libtool_files
+
+	if use emacs; then
+		elisp-site-file-install "${FILESDIR}"/${SITEFILE} || die
+	fi
+
+	dodoc ANNOUNCE AUTHORS ChangeLog FAQ NEWS README* THANKS TODO
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/app-text/a2ps/files/a2ps-4.14-CVE-2014-0466.patch
+++ b/app-text/a2ps/files/a2ps-4.14-CVE-2014-0466.patch
@@ -1,0 +1,32 @@
+CVE-2014-0466: fixps does not invoke gs with -dSAFER
+
+A malicious PostScript file could delete files with the privileges of
+the invoking user.
+
+Author: Salvatore Bonaccorso <carnil@debian.org>
+Origin: https://bugs.debian.org/742902
+
+diff -urNad '--exclude=CVS' '--exclude=.svn' '--exclude=.git' '--exclude=.arch' '--exclude=.hg' '--exclude=_darcs' '--exclude=.bzr' a2ps~/contrib/fixps.in a2ps/contrib/fixps.in
+--- a2ps~/contrib/fixps.in	2014-03-30 12:24:50.000000000 +0200
++++ a2ps/contrib/fixps.in	2014-03-30 12:40:36.763249218 +0200
+@@ -389,7 +389,7 @@
+   	eval "$command" ;;
+       gs)
+         $verbose "$program: making a full rewrite of the file ($gs)." >&2
+-  	$gs -q -dNOPAUSE -dBATCH -sDEVICE=pswrite -sOutputFile=- -c save pop -f $file ;;
++  	$gs -q -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pswrite -sOutputFile=- -c save pop -f $file ;;
+     esac
+   )
+ fi
+diff -urNad '--exclude=CVS' '--exclude=.svn' '--exclude=.git' '--exclude=.arch' '--exclude=.hg' '--exclude=_darcs' '--exclude=.bzr' a2ps~/contrib/fixps.m4 a2ps/contrib/fixps.m4
+--- a2ps~/contrib/fixps.m4	2014-03-30 12:24:50.000000000 +0200
++++ a2ps/contrib/fixps.m4	2014-03-30 12:40:36.767249254 +0200
+@@ -307,7 +307,7 @@
+   	eval "$command" ;;
+       gs)
+         $verbose "$program: making a full rewrite of the file ($gs)." >&2
+-  	$gs -q -dNOPAUSE -dBATCH -sDEVICE=pswrite -sOutputFile=- -c save pop -f $file ;;
++  	$gs -q -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pswrite -sOutputFile=- -c save pop -f $file ;;
+     esac
+   )
+ fi


### PR DESCRIPTION
Upstream received no updates since 2007 so let's add Debian's patch to get rid of the B2 rated vulnerability.