### PR TITLE
app-i18n/ibus: fix bug #600426 (failing pkg_postrm)

### DIFF
--- a/app-i18n/ibus/ibus-1.5.5.ebuild
+++ b/app-i18n/ibus/ibus-1.5.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -170,6 +170,5 @@ pkg_postrm() {
 	use gtk && gnome2_query_immodules_gtk2
 	use gtk3 && gnome2_query_immodules_gtk3
 	use gconf && gnome2_schemas_update
-	gnome2_schemas_savelist
 	gnome2_icon_cache_update
 }

--- a/app-i18n/ibus/ibus-1.5.8-r1.ebuild
+++ b/app-i18n/ibus/ibus-1.5.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -170,6 +170,5 @@ pkg_postrm() {
 	use gtk && gnome2_query_immodules_gtk2
 	use gtk3 && gnome2_query_immodules_gtk3
 	use gconf && gnome2_schemas_update
-	gnome2_schemas_savelist
 	gnome2_icon_cache_update
 }

--- a/app-i18n/ibus/ibus-1.5.9-r1.ebuild
+++ b/app-i18n/ibus/ibus-1.5.9-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -186,6 +186,5 @@ pkg_postrm() {
 	use gtk && gnome2_query_immodules_gtk2
 	use gtk3 && gnome2_query_immodules_gtk3
 	use gconf && gnome2_schemas_update
-	gnome2_schemas_savelist
 	gnome2_icon_cache_update
 }


### PR DESCRIPTION
Don't call gnome2_schemas_savelist() from pkg_postrm

See also bug #566956, which fixed this for newer ebuilds,
but 1.5.5 is latest stable on ia64 and sparc.

Package-Manager: portage-2.3.2