### PR TITLE
media-libs/t1lib: Security revbump to fix multiple vulnerabilities

### DIFF
--- a/media-libs/t1lib/files/t1lib-5.1.2-CVE-2010-2642_2011-0433_2011-5244.patch
+++ b/media-libs/t1lib/files/t1lib-5.1.2-CVE-2010-2642_2011-0433_2011-5244.patch
@@ -1,0 +1,46 @@
+CVE-2010-2642, CVE-2011-0433 and CVE-2011-5244
+
+CVE-2010-2642:
+==============
+Upstream-Bug: https://bugzilla.gnome.org/show_bug.cgi?id=643882
+Upstream-Fix: https://git.gnome.org/browse/evince/commit/?id=efadec4ffcdde3373f6f4ca0eaac98dc963c4fd5
+
+
+CVE-2011-0433:
+==============
+Upstream-Bug: https://bugzilla.gnome.org/show_bug.cgi?id=640923
+Upstream-Fix: https://git.gnome.org/browse/evince/commit/?id=439c5070022eab6cef7266aab47f978058012c72
+
+
+CVE-2011-5244:
+==============
+Upstream-Bug: https://bugzilla.gnome.org/show_bug.cgi?id=643882
+Upstream-Fix: https://git.gnome.org/browse/evince/commit/?id=efadec4ffcdde3373f6f4ca0eaac98dc963c4fd5
+
+
+Origin: https://bugs.debian.org/652996
+
+diff --git a/lib/t1lib/parseAFM.c b/lib/t1lib/parseAFM.c
+index 6a31d7f..ba64541 100644
+--- a/lib/t1lib/parseAFM.c
++++ b/lib/t1lib/parseAFM.c
+@@ -199,7 +199,9 @@ static char *token(stream)
+     idx = 0;
+     
+     while (ch != EOF && ch != ' ' && ch != CR  && ch != LF &&
+-	   ch != CTRL_Z && ch != '\t' && ch != ':' && ch != ';'){
++	   ch != CTRL_Z && ch != '\t' && ch != ':' && ch != ';'
++     && idx < (MAX_NAME -1))
++    {
+       ident[idx++] = ch;
+       ch = fgetc(stream);
+     } /* while */
+@@ -235,7 +237,7 @@ static char *linetoken(stream)
+     while ((ch = fgetc(stream)) == ' ' || ch == '\t' ); 
+     
+     idx = 0;
+-    while (ch != EOF && ch != CR  && ch != LF && ch != CTRL_Z) 
++    while (ch != EOF && ch != CR  && ch != LF && ch != CTRL_Z && idx < (MAX_NAME - 1)) 
+     {
+         ident[idx++] = ch;
+         ch = fgetc(stream);

--- a/media-libs/t1lib/files/t1lib-5.1.2-CVE-2011-0764.patch
+++ b/media-libs/t1lib/files/t1lib-5.1.2-CVE-2011-0764.patch
@@ -1,0 +1,31 @@
+CVE-2011-0764
+
+Author: Marc Deslauriers <marc.deslauriers@canonical.com>
+Origin: https://bazaar.launchpad.net/~ubuntu-branches/ubuntu/wily/t1lib/wily/view/head:/debian/patches/CVE-2011-0764.diff
+
+--- t1lib-5.1.2.orig/lib/type1/type1.c	2011-12-13 14:24:14.280965637 -0600
++++ t1lib-5.1.2/lib/type1/type1.c	2011-12-13 14:25:25.893320747 -0600
+@@ -1700,6 +1700,7 @@
+   long pindex = 0;
+   
+   /* compute hinting for previous segment! */
++  if (ppoints == NULL) Error0i("RLineTo: No previous point!\n");
+   FindStems( currx, curry, currx-ppoints[numppoints-2].x, curry-ppoints[numppoints-2].y, dx, dy);
+ 
+   /* Allocate a new path point and pre-setup data */
+@@ -1728,6 +1729,7 @@
+   long pindex = 0;
+   
+   /* compute hinting for previous point! */
++  if (ppoints == NULL) Error0i("RRCurveTo: No previous point!\n");
+   FindStems( currx, curry, currx-ppoints[numppoints-2].x, curry-ppoints[numppoints-2].y, dx1, dy1);
+ 
+   /* Allocate three new path points and pre-setup data */
+@@ -1903,6 +1905,7 @@
+     FindStems( currx, curry, 0, 0, dx, dy);
+   }
+   else {
++    if (ppoints == NULL) Error0i("RMoveTo: No previous point!\n");
+     FindStems( currx, curry, ppoints[numppoints-2].x, ppoints[numppoints-2].y, dx, dy);
+   }
+   

--- a/media-libs/t1lib/files/t1lib-5.1.2-CVE-2011-1552_1553_1554.patch
+++ b/media-libs/t1lib/files/t1lib-5.1.2-CVE-2011-1552_1553_1554.patch
@@ -1,0 +1,133 @@
+CVE-2011-1552, CVE-2011-1553 and CVE-2011-1554
+
+Author: Jaroslav Škarvada <jskarvad@redhat.com>
+Origin: http://bugzilla.redhat.com/show_bug.cgi?id=692909
+
+--- t1lib-5.1.2.orig/lib/type1/lines.c	2007-12-23 09:49:42.000000000 -0600
++++ t1lib-5.1.2/lib/type1/lines.c	2012-01-17 14:15:08.000000000 -0600
+@@ -67,6 +67,10 @@
+ None.
+ */
+  
++#define  BITS         (sizeof(LONG)*8)
++#define  HIGHTEST(p)  (((p)>>(BITS-2)) != 0)  /* includes sign bit */
++#define  TOOBIG(xy)   ((xy < 0) ? HIGHTEST(-xy) : HIGHTEST(xy))
++
+ /*
+ :h2.StepLine() - Produces Run Ends for a Line After Checks
+  
+@@ -84,6 +88,9 @@
+        IfTrace4((LineDebug > 0), ".....StepLine: (%d,%d) to (%d,%d)\n",
+                                             x1, y1, x2, y2);
+  
++      if ( TOOBIG(x1) || TOOBIG(x2) || TOOBIG(y1) || TOOBIG(y2))
++              abort("Lines this big not supported", 49);
++
+        dy = y2 - y1;
+  
+ /*
+Index: t1lib-5.1.2/lib/type1/objects.c
+===================================================================
+--- t1lib-5.1.2.orig/lib/type1/objects.c	2007-12-23 09:49:42.000000000 -0600
++++ t1lib-5.1.2/lib/type1/objects.c	2012-01-17 14:15:08.000000000 -0600
+@@ -1137,12 +1137,13 @@
+     "Context:  out of them", /* 46 */
+     "MatrixInvert:  can't", /* 47 */
+     "xiStub called", /* 48 */
+-    "Illegal access type1 abort() message" /* 49 */
++    "Lines this big not supported", /* 49 */
++    "Illegal access type1 abort() message" /* 50 */
+   };
+ 
+-  /* no is valid from 1 to 48 */
+-  if ( (number<1)||(number>48))
+-    number=49;
++  /* no is valid from 1 to 49 */
++  if ( (number<1)||(number>49))
++    number=50;
+   return( err_msgs[number-1]);
+     
+ }
+Index: t1lib-5.1.2/lib/type1/type1.c
+===================================================================
+--- t1lib-5.1.2.orig/lib/type1/type1.c	2012-01-17 14:13:28.000000000 -0600
++++ t1lib-5.1.2/lib/type1/type1.c	2012-01-17 14:19:54.000000000 -0600
+@@ -1012,6 +1012,7 @@
+   double nextdtana = 0.0;   /* tangent of post-delta against horizontal line */ 
+   double nextdtanb = 0.0;   /* tangent of post-delta against vertical line */ 
+   
++  if (ppoints == NULL || numppoints < 1) Error0v("FindStems: No previous point!\n");
+  
+   /* setup default hinted position */
+   ppoints[numppoints-1].ax     = ppoints[numppoints-1].x;
+@@ -1289,7 +1290,7 @@
+ static int DoRead(CodeP)
+   int *CodeP;
+ {
+-  if (strindex >= CharStringP->len) return(FALSE); /* end of string */
++  if (!CharStringP || strindex >= CharStringP->len) return(FALSE); /* end of string */
+   /* We handle the non-documented Adobe convention to use lenIV=-1 to
+      suppress charstring encryption. */
+   if (blues->lenIV==-1) {
+@@ -1700,7 +1701,7 @@
+   long pindex = 0;
+   
+   /* compute hinting for previous segment! */
+-  if (ppoints == NULL) Error0i("RLineTo: No previous point!\n");
++  if (ppoints == NULL || numppoints < 2) Error0i("RLineTo: No previous point!\n");
+   FindStems( currx, curry, currx-ppoints[numppoints-2].x, curry-ppoints[numppoints-2].y, dx, dy);
+ 
+   /* Allocate a new path point and pre-setup data */
+@@ -1729,7 +1730,7 @@
+   long pindex = 0;
+   
+   /* compute hinting for previous point! */
+-  if (ppoints == NULL) Error0i("RRCurveTo: No previous point!\n");
++  if (ppoints == NULL || numppoints < 2) Error0i("RRCurveTo: No previous point!\n");
+   FindStems( currx, curry, currx-ppoints[numppoints-2].x, curry-ppoints[numppoints-2].y, dx1, dy1);
+ 
+   /* Allocate three new path points and pre-setup data */
+@@ -1788,7 +1789,9 @@
+   long tmpind;
+   double deltax = 0.0;
+   double deltay = 0.0;
+-  
++ 
++  if (ppoints == NULL || numppoints < 1) Error0i("DoClosePath: No previous point!");
++ 
+   /* If this ClosePath command together with the starting point of this
+      path completes to a segment aligned to a stem, we would miss
+      hinting for this point. --> Check and explicitly care for this! */
+@@ -1803,6 +1806,7 @@
+     deltax = ppoints[i].x - ppoints[numppoints-1].x;
+     deltay = ppoints[i].y - ppoints[numppoints-1].y;
+ 
++    if (ppoints == NULL || numppoints <= i + 1) Error0i("DoClosePath: No previous point!");
+     /* save nummppoints and reset to move point */
+     tmpind = numppoints;
+     numppoints = i + 1;
+@@ -1905,7 +1909,7 @@
+     FindStems( currx, curry, 0, 0, dx, dy);
+   }
+   else {
+-    if (ppoints == NULL) Error0i("RMoveTo: No previous point!\n");
++    if (ppoints == NULL || numppoints < 2) Error0i("RMoveTo: No previous point!\n");
+     FindStems( currx, curry, ppoints[numppoints-2].x, ppoints[numppoints-2].y, dx, dy);
+   }
+   
+@@ -2155,6 +2159,7 @@
+   DOUBLE cx, cy;
+   DOUBLE ex, ey;
+ 
++  if (ppoints == NULL || numppoints < 8) Error0v("FlxProc: No previous point!");
+ 
+   /* Our PPOINT list now contains 7 moveto commands which
+      are about to be consumed by the Flex mechanism. --> Remove these
+@@ -2324,6 +2329,7 @@
+ /*   Returns currentpoint on stack          */
+ static void FlxProc2()
+ {
++  if (ppoints == NULL || numppoints < 1) Error0v("FlxProc2: No previous point!");
+   /* Push CurrentPoint on fake PostScript stack */
+   PSFakePush( ppoints[numppoints-1].x);
+   PSFakePush( ppoints[numppoints-1].y);

--- a/media-libs/t1lib/files/t1lib-5.1.2-format-security.patch
+++ b/media-libs/t1lib/files/t1lib-5.1.2-format-security.patch
@@ -1,0 +1,39 @@
+fixes FTBFS with -Werror=format-security by using relevant "%s" format when
+    passing a variable string to a printf()
+
+
+Origin: https://bugs.debian.org/646470
+
+--- a/lib/type1/objects.c
++++ b/lib/type1/objects.c
+@@ -957,7 +957,7 @@
+  
+        sprintf(typemsg, "Wrong object type in %s; expected %s, found %s.\n",
+                   name, TypeFmt(expect), TypeFmt(obj->type));
+-       IfTrace0(TRUE,typemsg);
++       IfTrace1(TRUE, "%s", typemsg);
+  
+        ObjectPostMortem(obj);
+  
+--- a/lib/t1lib/t1subset.c
++++ b/lib/t1lib/t1subset.c
+@@ -759,7 +759,7 @@
+ 	     tr_len);
+     T1_PrintLog( "T1_SubsetFont()", err_warn_msg_buf,
+ 		 T1LOG_DEBUG);
+-    l+=sprintf( &(trailerbuf[l]), linebuf); /* contains the PostScript trailer */
++    l+=sprintf( &(trailerbuf[l]), "%s", linebuf); /* contains the PostScript trailer */
+   }
+   
+   /* compute size of output file */
+--- a/lib/type1/objects.h
++++ b/lib/type1/objects.h
+@@ -214,7 +214,7 @@
+ /*SHARED*/
+ /* NDW: personally, I want to see status and error messages! */
+ #define IfTrace0(condition,model)                                 \
+-        {if (condition) printf(model);}
++        {if (condition) fputs(model,stdout);}
+ #define IfTrace1(condition,model,arg0)                            \
+         {if (condition) printf(model,arg0);}
+ #define IfTrace2(condition,model,arg0,arg1)                       \

--- a/media-libs/t1lib/files/t1lib-do-not-install-t1lib_doc-r1.patch
+++ b/media-libs/t1lib/files/t1lib-do-not-install-t1lib_doc-r1.patch
@@ -1,0 +1,19 @@
+--- old/doc/Makefile.in.orig	2008-05-04 17:55:52.000000000 +0400
++++ new/doc/Makefile.in	2008-05-04 17:55:58.000000000 +0400
+@@ -89,16 +89,6 @@
+ 
+ 
+ install: dummy
+-	if (test -f t1lib_doc.ps) \
+-	then \
+-	  $(MKINSTALLDIRS) $(DESTDIR)@T1LIB_DATA_DIR@/doc; \
+-	  $(INSTALL_DATA) t1lib_doc.ps $(DESTDIR)@T1LIB_DATA_DIR@/doc; \
+-	fi;
+-	if (test -f t1lib_doc.pdf) \
+-	then \
+-	  $(MKINSTALLDIRS) $(DESTDIR)@T1LIB_DATA_DIR@/doc; \
+-	  $(INSTALL_DATA) t1lib_doc.pdf $(DESTDIR)@T1LIB_DATA_DIR@/doc; \
+-	fi;
+ 
+ 
+ uninstall: dummy

--- a/media-libs/t1lib/t1lib-5.1.2-r1.ebuild
+++ b/media-libs/t1lib/t1lib-5.1.2-r1.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+inherit flag-o-matic libtool toolchain-funcs
+
+DESCRIPTION="A Type 1 Font Rasterizer Library for UNIX/X11"
+HOMEPAGE="ftp://metalab.unc.edu/pub/Linux/libs/graphics/"
+SRC_URI="ftp://sunsite.unc.edu/pub/Linux/libs/graphics/${P}.tar.gz"
+
+LICENSE="LGPL-2 GPL-2"
+SLOT="5"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="X doc static-libs"
+
+RDEPEND="X? (
+		x11-libs/libXaw
+		x11-libs/libX11
+		x11-libs/libXt
+	)"
+DEPEND="${RDEPEND}
+	doc? ( virtual/latex-base )
+	X? (
+		x11-libs/libXfont
+		x11-proto/xproto
+		x11-proto/fontsproto
+	)"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.1.1-parallel.patch
+	"${FILESDIR}"/${PN}-do-not-install-t1lib_doc-r1.patch
+	"${FILESDIR}"/${PN}-5.1.2-format-security.patch
+	"${FILESDIR}"/${PN}-5.1.2-CVE-2010-2642_2011-0433_2011-5244.patch
+	"${FILESDIR}"/${PN}-5.1.2-CVE-2011-0764.patch
+	"${FILESDIR}"/${PN}-5.1.2-CVE-2011-1552_1553_1554.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e "s:dvips:#dvips:" "${S}"/doc/Makefile.in
+	sed -i -e "s:\./\(t1lib\.config\):/etc/t1lib/\1:" "${S}"/xglyph/xglyph.c
+	# Needed for sane .so versionning on fbsd. Please don't drop.
+	elibtoolize
+}
+
+src_configure() {
+	econf \
+		--datadir="${EPREFIX}/etc" \
+		$(use_enable static-libs static) \
+		$(use_with X x)
+}
+
+src_compile() {
+	local myopt=""
+	tc-export CC
+
+	use alpha && append-flags -mieee
+
+	if ! use doc; then
+		myopt="without_doc"
+	else
+		VARTEXFONTS=${T}/fonts
+	fi
+
+	emake ${myopt}
+}
+
+src_install() {
+	default
+
+	if ! use static-libs; then
+		find "${ED}"usr/lib* -name '*.la' -o -name '*.a' -delete || die
+	fi
+
+	dodoc Changes README*
+	if use doc; then
+		cd doc
+		insinto /usr/share/doc/${PF}
+		doins *.pdf *.dvi
+	fi
+}


### PR DESCRIPTION
# EBuild changes:
- Migrated to EAPI=6

- Fix for CVE-2010-2642, CVE-2011-0433 and CVE-2011-5244 added

- Fix for CVE-2011-0764 added

- Fix for CVE-2011-1552, CVE-2011-1553 and CVE-2011-1554 added

- Fixes for building with -Werror=format-security added

Gentoo-Bug: https://bugs.gentoo.org/358667
