### PR TITLE
media-libs/libextractor: fix build with USE=tidy

### DIFF
--- a/media-libs/libextractor/libextractor-1.3-r1.ebuild
+++ b/media-libs/libextractor/libextractor-1.3-r1.ebuild
@@ -63,6 +63,7 @@ src_prepare() {
 	sed -i \
 		-e '/^ax_create_pkgconfig_ldflags=/s:$LDFLAGS ::' \
 		-e 's:tidy/tidy.h:tidy.h:' \
+		-e 's:tidy/buffio.h:buffio.h:' \
 		configure src/plugins/html_extractor.c || die
 
 	if ! use tidy; then


### PR DESCRIPTION
@mgorny, haven't revbumped this ebuild, which has been committed straight to stable...