### PR TITLE
x11-libs/gdk-pixbuf-2.36.0-r1: Adding "included-loaders" use flag

### DIFF
--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.36.0-r1.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.36.0-r1.ebuild
@@ -1,0 +1,124 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+GNOME2_LA_PUNT="yes"
+
+inherit flag-o-matic gnome2 multilib libtool multilib-minimal
+
+DESCRIPTION="Image loading library for GTK+"
+HOMEPAGE="https://git.gnome.org/browse/gdk-pixbuf"
+
+LICENSE="LGPL-2+"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="X debug include-loaders +introspection jpeg jpeg2k tiff test"
+
+COMMON_DEPEND="
+	>=dev-libs/glib-2.37.6:2[${MULTILIB_USEDEP}]
+	>=media-libs/libpng-1.4:0=[${MULTILIB_USEDEP}]
+	introspection? ( >=dev-libs/gobject-introspection-0.9.3:= )
+	jpeg? ( virtual/jpeg:0=[${MULTILIB_USEDEP}] )
+	jpeg2k? ( media-libs/jasper:=[${MULTILIB_USEDEP}] )
+	tiff? ( >=media-libs/tiff-3.9.2:0=[${MULTILIB_USEDEP}] )
+	X? ( x11-libs/libX11[${MULTILIB_USEDEP}] )
+"
+DEPEND="${COMMON_DEPEND}
+	>=dev-util/gtk-doc-am-1.20
+	>=sys-devel/gettext-0.19
+	virtual/pkgconfig
+"
+# librsvg blocker is for the new pixbuf loader API, you lose icons otherwise
+RDEPEND="${COMMON_DEPEND}
+	!<gnome-base/gail-1000
+	!<gnome-base/librsvg-2.31.0
+	!<x11-libs/gtk+-2.21.3:2
+	!<x11-libs/gtk+-2.90.4:3
+"
+
+MULTILIB_CHOST_TOOLS=(
+	/usr/bin/gdk-pixbuf-query-loaders$(get_exeext)
+)
+
+# See https://bugzilla.gnome.org/show_bug.cgi?id=756590
+PATCHES=( "${FILESDIR}"/${PN}-2.32.3-fix-lowmem-uclibc.patch )
+
+src_prepare() {
+	# This will avoid polluting the pkg-config file with versioned libpng,
+	# which is causing problems with libpng14 -> libpng15 upgrade
+	# See upstream bug #667068
+	# First check that the pattern is present, to catch upstream changes on bumps,
+	# because sed doesn't return failure code if it doesn't do any replacements
+	grep -q  'l in libpng16' configure || die "libpng check order has changed upstream"
+	sed -e 's:l in libpng16:l in libpng libpng16:' -i configure || die
+	[[ ${CHOST} == *-solaris* ]] && append-libs intl
+
+	gnome2_src_prepare
+}
+
+multilib_src_configure() {
+	# png always on to display icons
+	ECONF_SOURCE="${S}" \
+	gnome2_src_configure \
+		$(usex debug --enable-debug=yes "") \
+		$(usex include-loaders --with-included-loaders=yes "") \
+		$(use_with jpeg libjpeg) \
+		$(use_with jpeg2k libjasper) \
+		$(use_with tiff libtiff) \
+		$(multilib_native_use_enable introspection) \
+		$(use_with X x11) \
+		--with-libpng
+
+	# work-around gtk-doc out-of-source brokedness
+	if multilib_is_native_abi; then
+		ln -s "${S}"/docs/reference/${PN}/html docs/reference/${PN}/html || die
+	fi
+}
+
+multilib_src_install() {
+	# Parallel install fails when no gdk-pixbuf is already installed, bug #481372
+	MAKEOPTS="${MAKEOPTS} -j1" gnome2_src_install
+}
+
+pkg_preinst() {
+	gnome2_pkg_preinst
+
+	multilib_pkg_preinst() {
+		# Make sure loaders.cache belongs to gdk-pixbuf alone
+		# But if --with-included-loaders is set, then there is no libdir and no loaders.cache
+
+		if [[ -d "${ED}/usr/$(get_libdir)/${PN}-2.0/2.10.0/" ]] ; then
+			local cache="usr/$(get_libdir)/${PN}-2.0/2.10.0/loaders.cache"
+			if [[ -e ${EROOT}${cache} ]]; then
+				cp "${EROOT}"${cache} "${ED}"/${cache} || die
+			else
+				touch "${ED}"/${cache} || die
+			fi
+		fi
+	}
+
+	multilib_foreach_abi multilib_pkg_preinst
+}
+
+pkg_postinst() {
+	# causes segfault if set, see bug 375615
+	unset __GL_NO_DSO_FINALIZER
+
+	multilib_foreach_abi gnome2_pkg_postinst
+
+	# Migration snippet for when this was handled by gtk+
+	if [ -e "${EROOT}"usr/lib/gtk-2.0/2.*/loaders ]; then
+		elog "You need to rebuild ebuilds that installed into" "${EROOT}"usr/lib/gtk-2.0/2.*/loaders
+		elog "to do that you can use qfile from portage-utils:"
+		elog "emerge -va1 \$(qfile -qC ${EPREFIX}/usr/lib/gtk-2.0/2.*/loaders)"
+	fi
+}
+
+pkg_postrm() {
+	gnome2_pkg_postrm
+
+	if [[ -z ${REPLACED_BY_VERSION} ]]; then
+		rm -f "${EROOT}"usr/lib*/${PN}-2.0/2.10.0/loaders.cache || die
+	fi
+}

--- a/x11-libs/gdk-pixbuf/metadata.xml
+++ b/x11-libs/gdk-pixbuf/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
+  <maintainer type="project">
 	<email>gnome@gentoo.org</email>
 	<name>Gentoo GNOME Desktop</name>
-</maintainer>
+  </maintainer>
+  <use>
+    <flag name="include-loaders" restrict="&gt;=x11-libs/gdk-pixbuf-2.36.0-r1">
+    Build loaders into gdk-pixbuf</flag>
+  </use>
 </pkgmetadata>


### PR DESCRIPTION
The new use flag enables the "--with-included-loaders=yes" configure switch.
In this case no libdir is built and pkg_preinst will fail without the proposed modifications.

Package-Manager: portage-2.3.0