### PR TITLE
media-gfx/ufraw: add explicit jpeg2k support (bug #470836)

### DIFF
--- a/media-gfx/ufraw/files/ufraw-0.22-jasper-automagic.patch
+++ b/media-gfx/ufraw/files/ufraw-0.22-jasper-automagic.patch
@@ -1,0 +1,21 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -159,8 +159,16 @@
+ have_jpeg=${ac_cv_lib_jpeg_jpeg_CreateCompress:-no}
+ 
+ # Check for libjasper.
+-AC_CHECK_LIB(jasper, jas_image_decode)
+-have_jasper=${ac_cv_lib_jasper_jas_image_decode:-no}
++AC_ARG_ENABLE([jasper],
++  AS_HELP_STRING([--enable-jasper], [enable JPEG2000 support]))
++
++have_jasper=no
++AS_IF([test "x$enable_jasper" = "xyes"], [
++  AC_SEARCH_LIBS([jas_image_decode], [jasper], [have_jasper=yes], [
++    AC_MSG_ERROR([unable to find the jas_image_decode() function])
++  ])
++])
++
+ 
+ # Check for tiff headers and library.
+ PKG_CHECK_MODULES(LIBTIFF, libtiff-4,

--- a/media-gfx/ufraw/ufraw-0.22.ebuild
+++ b/media-gfx/ufraw/ufraw-0.22.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="alpha ~amd64 arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~x64-solaris ~x86-solaris"
-IUSE="contrast fits gimp gnome gtk openmp timezone"
+IUSE="contrast fits gimp gnome gtk jpeg2k openmp timezone"
 
 REQUIRED_USE="gimp? ( gtk )"
 
@@ -29,12 +29,14 @@ RDEPEND="
 	gtk? ( >=x11-libs/gtk+-2.6:2
 		>=media-gfx/gtkimageview-1.5 )
 	gimp? ( >=media-gfx/gimp-2 )
+	jpeg2k? ( media-libs/jasper:= )
 "
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-0.17-cfitsio-automagic.patch
+	epatch "${FILESDIR}"/${PN}-0.22-jasper-automagic.patch
 	eautoreconf
 }
 
@@ -45,6 +47,7 @@ src_configure() {
 		$(use_with gimp) \
 		$(use_enable gnome mime) \
 		$(use_with gtk) \
+		$(use_enable jpeg2k jasper) \
 		$(use_enable openmp) \
 		$(use_enable timezone dst-correction)
 }


### PR DESCRIPTION
Upstream links to libjasper when available. This commit patches
configure.ac to make libjasper support explicit and adds a jpeg2k
USE flag to enable/disable it.

Package-Manager: portage-2.3.2