### PR TITLE
media-libs/libopenshot-audio: add missing DEPEND on x11-libs/libXcursor

### DIFF
--- a/media-libs/libopenshot-audio/libopenshot-audio-0.1.2-r1.ebuild
+++ b/media-libs/libopenshot-audio/libopenshot-audio-0.1.2-r1.ebuild
@@ -18,13 +18,12 @@ RDEPEND="
 	media-libs/alsa-lib
 	media-libs/freetype
 	x11-libs/libX11
+	x11-libs/libXcursor
 	x11-libs/libXext
-"
-DEPEND="
 	x11-libs/libXinerama
 	x11-libs/libXrandr
-	${RDEPEND}
 "
+DEPEND="${RDEPEND}"
 
 src_prepare() {
 	# fix under-linking


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/594664