### PR TITLE
net-nntp/sabnzbd: Install conf.d file with default mode 0644

### DIFF
--- a/net-nntp/sabnzbd/sabnzbd-1.1.1-r1.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-1.1.1-r1.ebuild
@@ -84,9 +84,8 @@ src_install() {
 		doins -r ${d}/*
 	done
 
-	insinto "/usr/share/${PN}"
-	insopts -m 0755
-	doins SABnzbd.py
+	exeinto "/usr/share/${PN}"
+	doexe SABnzbd.py
 
 	python_fix_shebang "${ED%/}/usr/share/${PN}"
 	python_optimize "${ED%/}/usr/share/${PN}"


### PR DESCRIPTION
Calling `insopts` before installing `SABnzbd.py` changes `INSOPTIONS`, which is used by the subsequent call to `newconfd` and results in installing the `conf.d` file with mode 0755.  It is not a serious issue, but we can kill two birds with one stone by shrinking the code responsible for installing `SABnzbd.py`.

/cc @jsbronder (maintainer)