### PR TITLE
kernel-2.eclass: correct link to the deblob script

### DIFF
--- a/eclass/kernel-2.eclass
+++ b/eclass/kernel-2.eclass
@@ -640,7 +640,7 @@ if [[ ${ETYPE} == sources ]]; then
 			K_DEBLOB_TAG=${K_DEBLOB_TAG:--gnu}
 			DEBLOB_A="deblob-${DEBLOB_PV}"
 			DEBLOB_CHECK_A="deblob-check-${DEBLOB_PV}"
-			DEBLOB_HOMEPAGE="http://www.fsfla.org/svn/fsfla/software/linux-libre/releases/tags"
+			DEBLOB_HOMEPAGE="http://linux-libre.fsfla.org/pub/linux-libre/releases"
 			DEBLOB_URI_PATH="${DEBLOB_PV}${K_DEBLOB_TAG}"
 			if ! has "${EAPI:-0}" 0 1 ; then
 				DEBLOB_CHECK_URI="${DEBLOB_HOMEPAGE}/${DEBLOB_URI_PATH}/deblob-check -> ${DEBLOB_CHECK_A}"


### PR DESCRIPTION
An incorrect link was used when getting deblob script, which resulted in
an experience of things "constantly breaking".

Meanwhile, all that was required to make it work was to ask upstream
about the correct place to get the stuff from.