### PR TITLE
media-sound/tagtool: update SRC_URI and HOMEPAGE, #509202

### DIFF
--- a/media-sound/tagtool/tagtool-0.12.3-r1.ebuild
+++ b/media-sound/tagtool/tagtool-0.12.3-r1.ebuild
@@ -7,8 +7,8 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="Audio Tag Tool Ogg/Mp3 Tagger"
-HOMEPAGE="http://pwp.netcabo.pt/paol/tagtool"
-SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://sourceforge.net/projects/tagtool/"
+SRC_URI="https://sourceforge.net/projects/${PN}/files/${PN}/${PV}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=509202

and also rewrote sourceforge mirror SRC_URI to regular one