### PR TITLE
cmake-utils.eclass: Set assembler correctly, #601292

### DIFF
--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -604,6 +604,7 @@ enable_cmake-utils_src_configure() {
 	# Wipe the default optimization flags out of CMake
 	if [[ ${CMAKE_BUILD_TYPE} != Gentoo ]] && ! has "${EAPI}" 2 3 4 5; then
 		cat >> ${common_config} <<- _EOF_ || die
+			SET (CMAKE_ASM_FLAGS_${CMAKE_BUILD_TYPE^^} "" CACHE STRING "")
 			SET (CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE^^} "" CACHE STRING "")
 			SET (CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE^^} "" CACHE STRING "")
 			SET (CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE^^} "" CACHE STRING "")

--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -517,7 +517,7 @@ enable_cmake-utils_src_configure() {
 		includes="<INCLUDES>"
 	fi
 	cat > "${build_rules}" <<- _EOF_ || die
-		SET (CMAKE_ASM_COMPILE_OBJECT "<CMAKE_C_COMPILER> <DEFINES> ${includes} ${CFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "ASM compile command" FORCE)
+		SET (CMAKE_ASM_COMPILE_OBJECT "<CMAKE_ASM_COMPILER> <DEFINES> ${includes} ${CPPFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "ASM compile command" FORCE)
 		SET (CMAKE_C_COMPILE_OBJECT "<CMAKE_C_COMPILER> <DEFINES> ${includes} ${CPPFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "C compile command" FORCE)
 		SET (CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> <DEFINES> ${includes} ${CPPFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "C++ compile command" FORCE)
 		SET (CMAKE_Fortran_COMPILE_OBJECT "<CMAKE_Fortran_COMPILER> <DEFINES> ${includes} ${FCFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "Fortran compile command" FORCE)
@@ -532,6 +532,8 @@ enable_cmake-utils_src_configure() {
 	# Bug 542530, export those instead of setting paths in toolchain file
 	local -x CC=$(tc-getCC) CXX=$(tc-getCXX) FC=$(tc-getFC)
 	local -x PKG_CONFIG=$(tc-getPKG_CONFIG)
+	# Bug 601292, set the compiler for assembly as well
+	local -x ASM=$(tc-getCC) ASMFLAGS=${CFLAGS}
 
 	if tc-is-cross-compiler; then
 		local sysname


### PR DESCRIPTION
Use <CMAKE_ASM_COMPILER> in the assembly compile command in order to fix
building assembly files. It turns out that <CMAKE_C_COMPILER> is no
longer correctly evaluated in that command once it is no longer set
explicitly in the toolchain file and passed through the environment
instead.

Pass ASM and ASMFLAGS (equal to CC and CFLAGS) appropriately to enforce
using the correct compiler.

@gentoo/kde 