### PR TITLE
dev-libs/libuv: add ~amd64-fbsd, ~x86-fbsd KEYWORDS

### DIFF
--- a/dev-libs/libuv/libuv-1.10.0.ebuild
+++ b/dev-libs/libuv/libuv-1.10.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/libuv/libuv/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD BSD-2 ISC MIT"
 SLOT="0/1"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="static-libs"
 RESTRICT="test"
 


### PR DESCRIPTION
dev-libs/libuv: add ~amd64-fbsd, ~x86-fbsd KEYWORDS

=dev-util/cmake-3.7.0 depends on it.

```
The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by dev-util/cmake-3.7.0::gentoo
# required by sys-libs/libcxx-3.9.0::gentoo
# required by sys-devel/llvm-3.9.0-r1::gentoo
# required by sys-devel/clang-3.9.0-r100::gentoo
# required by @system
# required by @world (argument)
=dev-libs/libuv-1.10.0 **
```
