### PR TITLE
net-libs/libpcap: Install portability.h on BSD

### DIFF
--- a/net-libs/libpcap/libpcap-1.8.1-r1.ebuild
+++ b/net-libs/libpcap/libpcap-1.8.1-r1.ebuild
@@ -80,6 +80,6 @@ multilib_src_install_all() {
 	# We need this to build pppd on G/FBSD systems
 	if [[ "${USERLAND}" == "BSD" ]]; then
 		insinto /usr/include
-		doins pcap-int.h
+		doins pcap-int.h portability.h
 	fi
 }

--- a/net-libs/libpcap/libpcap-9999.ebuild
+++ b/net-libs/libpcap/libpcap-9999.ebuild
@@ -72,6 +72,6 @@ multilib_src_install_all() {
 	# We need this to build pppd on G/FBSD systems
 	if [[ "${USERLAND}" == "BSD" ]]; then
 		insinto /usr/include
-		doins pcap-int.h
+		doins pcap-int.h portability.h
 	fi
 }


### PR DESCRIPTION
Part of pcap-int.h was split. And portability.h was newly made.

FYI, https://github.com/the-tcpdump-group/libpcap/commit/7cc3ed6dd1a3389fc64f0d2f7832dff4a5f05bcb

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=601334