### PR TITLE
app-admin/supervisor: add myself as maintainer, various fixes

### DIFF
--- a/app-admin/supervisor/metadata.xml
+++ b/app-admin/supervisor/metadata.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>sautier.louis@gmail.com</email>
+		<name>Louis Sautier</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="pypi">supervisor</remote-id>
+		<remote-id type="github">Supervisor/supervisor</remote-id>
+		<bugs-to>https://github.com/Supervisor/supervisor/issues</bugs-to>
 	</upstream>
+	<longdescription lang="en">
+		Supervisor is a client/server system that allows its users to control a number of processes on UNIX-like operating systems.
+	</longdescription>
 </pkgmetadata>

--- a/app-admin/supervisor/supervisor-3.3.1-r1.ebuild
+++ b/app-admin/supervisor/supervisor-3.3.1-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )	# py2 only
+# xml.etree.ElementTree module required.
+PYTHON_REQ_USE="xml"
+
+inherit distutils-r1
+
+MY_PV="${PV/_beta/b}"
+
+DESCRIPTION="A system for controlling process state under UNIX"
+HOMEPAGE="http://supervisord.org/ https://pypi.python.org/pypi/supervisor"
+SRC_URI="mirror://pypi/${P:0:1}/${PN}/${PN}-${MY_PV}.tar.gz"
+
+LICENSE="repoze ZPL BSD HPND GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc test"
+
+RDEPEND="
+	dev-python/meld3[${PYTHON_USEDEP}]
+"
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
+	test? (
+		${RDEPEND}
+		dev-python/mock[${PYTHON_USEDEP}]
+	)
+"
+
+S="${WORKDIR}/${PN}-${MY_PV}"
+
+python_compile_all() {
+	use doc && emake -C docs html
+}
+
+python_test() {
+	esetup.py test
+}
+
+python_install_all() {
+	newinitd "${FILESDIR}/init.d-r1" supervisord
+	newconfd "${FILESDIR}/conf.d" supervisord
+	use doc && local HTML_DOCS=( docs/.build/html/. )
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
As discussed with @mgorny, I'm taking this package. DEPEND and RDEPEND weren't great so I fixed them, I also removed obsolete comments and bumped to EAPI 6.
```diff
--- supervisor-3.3.1.ebuild     2016-10-23 16:06:31.373728476 +0200
+++ supervisor-3.3.1-r1.ebuild  2016-12-02 00:50:36.336247340 +0100
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$

-EAPI="5"
+EAPI=6

 PYTHON_COMPAT=( python2_7 )    # py2 only
 # xml.etree.ElementTree module required.
@@ -21,17 +21,21 @@
 KEYWORDS="~amd64 ~x86"
 IUSE="doc test"

-# ALL versions of meld3 match to >=meld3-0.6.5
-RDEPEND="dev-python/meld3[${PYTHON_USEDEP}]
-       dev-python/setuptools[${PYTHON_USEDEP}]"
-DEPEND="${RDEPEND}
-       test? ( dev-python/mock[${PYTHON_USEDEP}] )
-       doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )"
+RDEPEND="
+       dev-python/meld3[${PYTHON_USEDEP}]
+"
+DEPEND="
+       dev-python/setuptools[${PYTHON_USEDEP}]
+       doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
+       test? (
+               ${RDEPEND}
+               dev-python/mock[${PYTHON_USEDEP}]
+       )
+"

 S="${WORKDIR}/${PN}-${MY_PV}"

 python_compile_all() {
-       # Somehow the test phase is called and run on invoking a doc build; harmless
        use doc && emake -C docs html
 }

```