### PR TITLE
net-misc/youtube-viewer: update HOMEPAGE, #600332

### DIFF
--- a/net-misc/youtube-viewer/youtube-viewer-3.1.9.ebuild
+++ b/net-misc/youtube-viewer/youtube-viewer-3.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -7,7 +7,7 @@ EAPI=5
 inherit gnome2-utils eutils perl-module vcs-snapshot
 
 DESCRIPTION="A command line utility for viewing youtube-videos in Mplayer"
-HOMEPAGE="https://trizen.googlecode.com"
+HOMEPAGE="http://trizenx.blogspot.nl/2012/03/gtk-youtube-viewer.html"
 SRC_URI="https://github.com/trizen/youtube-viewer/tarball/${PV} -> ${P}.tar.gz"
 
 LICENSE="|| ( Artistic GPL-1+ )"

--- a/net-misc/youtube-viewer/youtube-viewer-3.2.0.ebuild
+++ b/net-misc/youtube-viewer/youtube-viewer-3.2.0.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit eutils gnome2-utils perl-module vcs-snapshot
 
 DESCRIPTION="A command line utility for viewing youtube-videos in Mplayer"
-HOMEPAGE="https://trizen.googlecode.com"
+HOMEPAGE="http://trizenx.blogspot.nl/2012/03/gtk-youtube-viewer.html"
 SRC_URI="https://github.com/trizen/youtube-viewer/tarball/${PV} -> ${P}.tar.gz"
 
 LICENSE="|| ( Artistic GPL-1+ )"

--- a/net-misc/youtube-viewer/youtube-viewer-3.2.4.ebuild
+++ b/net-misc/youtube-viewer/youtube-viewer-3.2.4.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 inherit eutils gnome2-utils perl-module
 
 DESCRIPTION="A command line utility for viewing youtube-videos in Mplayer"
-HOMEPAGE="https://trizen.googlecode.com"
+HOMEPAGE="http://trizenx.blogspot.nl/2012/03/gtk-youtube-viewer.html"
 SRC_URI="https://github.com/trizen/youtube-viewer/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 SLOT="0"

--- a/net-misc/youtube-viewer/youtube-viewer-9999.ebuild
+++ b/net-misc/youtube-viewer/youtube-viewer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -7,7 +7,7 @@ EAPI=5
 inherit gnome2-utils eutils perl-module git-r3
 
 DESCRIPTION="A command line utility for viewing youtube-videos in Mplayer"
-HOMEPAGE="https://trizen.googlecode.com"
+HOMEPAGE="http://trizenx.blogspot.nl/2012/03/gtk-youtube-viewer.html"
 SRC_URI=""
 EGIT_REPO_URI="git://github.com/trizen/${PN}.git"
 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=600332

src link was already pointing to Github, and not Google Code, homepage updated to a non Google Code page (listed in the src Github page)