### PR TITLE
cmake-utils.eclass: Split multi-arg CC/CXX/FC correctly, #542530 [take 3]

### DIFF
--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -517,7 +517,7 @@ enable_cmake-utils_src_configure() {
 		includes="<INCLUDES>"
 	fi
 	cat > "${build_rules}" <<- _EOF_ || die
-		SET (CMAKE_ASM_COMPILE_OBJECT "<CMAKE_C_COMPILER> <DEFINES> ${includes} ${CFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "ASM compile command" FORCE)
+		SET (CMAKE_ASM_COMPILE_OBJECT "<CMAKE_ASM_COMPILER> <DEFINES> ${includes} ${CPPFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "ASM compile command" FORCE)
 		SET (CMAKE_C_COMPILE_OBJECT "<CMAKE_C_COMPILER> <DEFINES> ${includes} ${CPPFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "C compile command" FORCE)
 		SET (CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> <DEFINES> ${includes} ${CPPFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "C++ compile command" FORCE)
 		SET (CMAKE_Fortran_COMPILE_OBJECT "<CMAKE_Fortran_COMPILER> <DEFINES> ${includes} ${FCFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "Fortran compile command" FORCE)
@@ -532,6 +532,7 @@ enable_cmake-utils_src_configure() {
 	# space separated.
 	local toolchain_file=${BUILD_DIR}/gentoo_toolchain.cmake
 	cat > ${toolchain_file} <<- _EOF_ || die
+		SET (CMAKE_ASM_COMPILER "${myCC/ /;}")
 		SET (CMAKE_C_COMPILER "${myCC/ /;}")
 		SET (CMAKE_CXX_COMPILER "${myCXX/ /;}")
 		SET (CMAKE_Fortran_COMPILER "${myFC/ /;}")
@@ -539,6 +540,8 @@ enable_cmake-utils_src_configure() {
 		SET (CMAKE_RANLIB $(type -P $(tc-getRANLIB)) CACHE FILEPATH "Archive index generator" FORCE)
 	_EOF_
 
+	# We are using the C compiler for assembly by default.
+	local -x ASMFLAGS=${CFLAGS}
 	local -x PKG_CONFIG=$(tc-getPKG_CONFIG)
 
 	if tc-is-cross-compiler; then

--- a/eclass/cmake-utils.eclass
+++ b/eclass/cmake-utils.eclass
@@ -523,11 +523,18 @@ enable_cmake-utils_src_configure() {
 		SET (CMAKE_Fortran_COMPILE_OBJECT "<CMAKE_Fortran_COMPILER> <DEFINES> ${includes} ${FCFLAGS} <FLAGS> -o <OBJECT> -c <SOURCE>" CACHE STRING "Fortran compile command" FORCE)
 	_EOF_
 
+	local myCC=$(tc-getCC) myCXX=$(tc-getCXX) myFC=$(tc-getFC)
+
+	# !!! IMPORTANT NOTE !!!
+	# Single slash below is intentional. CMake is weird and wants the
+	# CMAKE_*_VARIABLES split into two elements: the first one with
+	# compiler path, and the second all with all command-line options,
+	# space separated.
 	local toolchain_file=${BUILD_DIR}/gentoo_toolchain.cmake
 	cat > ${toolchain_file} <<- _EOF_ || die
-		SET (CMAKE_C_COMPILER $(tc-getCC))
-		SET (CMAKE_CXX_COMPILER $(tc-getCXX))
-		SET (CMAKE_Fortran_COMPILER $(tc-getFC))
+		SET (CMAKE_C_COMPILER "${myCC/ /;}")
+		SET (CMAKE_CXX_COMPILER "${myCXX/ /;}")
+		SET (CMAKE_Fortran_COMPILER "${myFC/ /;}")
 		SET (CMAKE_AR $(type -P $(tc-getAR)) CACHE FILEPATH "Archive manager" FORCE)
 		SET (CMAKE_RANLIB $(type -P $(tc-getRANLIB)) CACHE FILEPATH "Archive index generator" FORCE)
 	_EOF_


### PR DESCRIPTION
Split multi-argument CC/CXX/FC into a CMake array consisting of one
element containing the compiler path (name) and the other containing all
command-line options, space-separated. This is how CMake splits
the environment variables CC/CXX/FC internally.

The alternative would be to set CC/CXX/FC directly, and let CMake handle
the splitting. However, changing that had unforeseen consequences like
assembler not being set correctly (#601292) which in turn was impossible
to set via environment variables due to bugs in CMake.

Therefore, splitting the values into CMAKE_*_COMPILER correctly seems
the simplest and safest way forward, at least until we can rely on fixed
CMake versions being sufficiently deployed.

@gentoo/kde 