### PR TITLE
app-emulation/virt-viewer: fix 5.0 minimum spice-gtk dependency

### DIFF
--- a/app-emulation/virt-viewer/virt-viewer-5.0.ebuild
+++ b/app-emulation/virt-viewer/virt-viewer-5.0.ebuild
@@ -18,7 +18,7 @@ RDEPEND=">=app-emulation/libvirt-0.10.0[sasl?]
 	app-emulation/libvirt-glib
 	>=dev-libs/libxml2-2.6
 	x11-libs/gtk+:3
-	spice? ( >=net-misc/spice-gtk-0.31[sasl?,gtk3] )
+	spice? ( >=net-misc/spice-gtk-0.33[sasl?,gtk3] )
 	vnc? ( >=net-libs/gtk-vnc-0.5.0[sasl?,gtk3] )"
 DEPEND="${RDEPEND}
 	dev-lang/perl


### PR DESCRIPTION
checking for SPICE_GTK... no
configure: error: Package requirements (spice-client-gtk-3.0 >= 0.33
                                     spice-client-glib-2.0 >= 0.33) were not met:

Requested 'spice-client-gtk-3.0 >= 0.33' but version of spice-client-gtk-3.0 is 0.31
Requested 'spice-client-glib-2.0 >= 0.33' but version of spice-client-glib-2.0 is 0.31

