### PR TITLE
dev-perl/CGI-Fast dev-perl/FCGI: add fbsd keywords

### DIFF
--- a/dev-perl/CGI-Fast/CGI-Fast-2.110.0.ebuild
+++ b/dev-perl/CGI-Fast/CGI-Fast-2.110.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="CGI Interface for Fast CGI"
 
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/FCGI/FCGI-0.770.0.ebuild
+++ b/dev-perl/FCGI/FCGI-0.770.0.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Fast CGI module"
 
 LICENSE="FastCGI"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~hppa ppc ~ppc64 x86"
+KEYWORDS="amd64 ~arm ~hppa ppc ~ppc64 x86 ~amd64-fbsd ~x86-fbsd"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Test-NoWarnings/Test-NoWarnings-1.40.0-r3.ebuild
+++ b/dev-perl/Test-NoWarnings/Test-NoWarnings-1.40.0-r3.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Make sure you didn't emit any warnings while testing"
 
 SLOT="0"
 LICENSE="LGPL-2.1"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 RDEPEND="virtual/perl-Test-Simple"


### PR DESCRIPTION
KEYWORDREQ bug https://bugs.gentoo.org/show_bug.cgi?id=600256


FEATURES=test emerge -pv '>=dev-perl/CGI-Fast-2.110.0' '>=dev-perl/FCGI-0.770.0'

```
# required by dev-perl/CGI-4.250.0::gentoo[test]
# required by dev-perl/CGI-Fast-2.110.0::gentoo
# required by >=dev-perl/CGI-Fast-2.110.0 (argument)
=dev-perl/Test-NoWarnings-1.40.0-r3 **
# required by >=dev-perl/CGI-Fast-2.110.0 (argument)
=dev-perl/CGI-Fast-2.110.0 **
# required by >=dev-perl/FCGI-0.770.0 (argument)
=dev-perl/FCGI-0.770.0 **
```

Test results)

```
>>> Test phase: dev-perl/Test-NoWarnings-1.40.0-r3
gmake -j4 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01_compile.t ... ok
t/02_none.t ...... ok
t/03_end.t ....... ok
t/04_no_tests.t .. ok
t/05_no_end.t .... ok
t/06_fork.t ...... ok
All tests successful.
Files=6, Tests=46,  1 wallclock secs ( 0.02 usr  0.02 sys +  0.10 cusr  0.03 csys =  0.16 CPU)
Result: PASS
>>> Completed testing dev-perl/Test-NoWarnings-1.40.0-r3
```
```
>>> Test phase: dev-perl/FCGI-0.770.0
gmake -j4 test TEST_VERBOSE=0
Running Mkbootstrap for FCGI ()
chmod 644 "FCGI.bs"
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-Iblib/lib" "-Iblib/arch" test.pl
1..1
# Running under perl version 5.024001 for freebsd
# Current time local: Sat Dec  3 18:20:18 2016
# Current time GMT:   Sat Dec  3 09:20:18 2016
# Using Test.pm version 1.28_01
ok 1
>>> Completed testing dev-perl/FCGI-0.770.0
```
```
>>> Test phase: dev-perl/CGI-Fast-2.110.0
 * Removing un-needed t/006_changes.t
 * Fixing Manifest
 * Test::Harness Jobs=4
gmake -j4 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/001_basic.t .............. ok
t/004_fcgi_file_handles.t .. ok
t/002_import.t ............. ok
t/003_env_pollution.t ...... ok
t/005_no_file_handles.t .... ok
t/007_socket_perm.t ........ 1/? [Sat Dec  3 18:20:30 2016] 007_socket_perm.t: Use of uninitialized value in numeric ge (>=) at /var/tmp/portage/dev-perl/CGI-Fast-2.110.0/work/CGI-Fast-2.11/blib/lib/CGI/Fast.pm line 94.
[Sat Dec  3 18:20:30 2016] 007_socket_perm.t: Use of uninitialized value in numeric ge (>=) at /var/tmp/portage/dev-perl/CGI-Fast-2.110.0/work/CGI-Fast-2.11/blib/lib/CGI/Fast.pm line 94.
[Sat Dec  3 18:20:30 2016] 007_socket_perm.t: Use of uninitialized value in numeric ge (>=) at /var/tmp/portage/dev-perl/CGI-Fast-2.110.0/work/CGI-Fast-2.11/blib/lib/CGI/Fast.pm line 94.
t/007_socket_perm.t ........ ok
All tests successful.
Files=6, Tests=34,  0 wallclock secs ( 0.03 usr  0.01 sys +  0.25 cusr  0.07 csys =  0.36 CPU)
Result: PASS
>>> Completed testing dev-perl/CGI-Fast-2.110.0
```
