### PR TITLE
sci-libs/hdf5: version bump to 1.8.17-r1 (security)

### DIFF
--- a/sci-libs/hdf5/files/hdf5-1.8.17-CVE-2016-4331.patch
+++ b/sci-libs/hdf5/files/hdf5-1.8.17-CVE-2016-4331.patch
@@ -1,0 +1,224 @@
+--- hdf5-1.8.17/src/H5Znbit.c	2016-04-26 05:43:33.000000000 -0700
++++ hdf5-1.8.18/src/H5Znbit.c	2016-11-04 11:41:07.000000000 -0700
+@@ -60,11 +60,11 @@
+                        unsigned char *buffer, size_t *j, int *buf_len, unsigned size);
+ static void H5Z_nbit_decompress_one_atomic(unsigned char *data, size_t data_offset,
+                     unsigned char *buffer, size_t *j, int *buf_len, parms_atomic p);
+-static void H5Z_nbit_decompress_one_array(unsigned char *data, size_t data_offset,
++static herr_t H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset,
+            unsigned char *buffer, size_t *j, int *buf_len, const unsigned parms[]);
+-static void H5Z_nbit_decompress_one_compound(unsigned char *data, size_t data_offset,
++static herr_t H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data_offset,
+               unsigned char *buffer, size_t *j, int *buf_len, const unsigned parms[]);
+-static void H5Z_nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer,
++static herr_t H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer,
+                                 const unsigned parms[]);
+ static void H5Z_nbit_compress_one_nooptype(unsigned char *data, size_t data_offset,
+                      unsigned char *buffer, size_t *j, int *buf_len, unsigned size);
+@@ -897,7 +897,8 @@
+             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed for nbit decompression")
+ 
+         /* decompress the buffer */
+-        H5Z_nbit_decompress(outbuf, d_nelmts, (unsigned char *)*buf, cd_values);
++        if(H5Z__nbit_decompress(outbuf, d_nelmts, (unsigned char *)*buf, cd_values) < 0)
++            HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, 0, "can't decompress buffer")
+     } /* end if */
+     /* output; compress */
+     else {
+@@ -1046,12 +1047,15 @@
+    }
+ }
+ 
+-static void
+-H5Z_nbit_decompress_one_array(unsigned char *data, size_t data_offset,
++static herr_t
++H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset,
+            unsigned char *buffer, size_t *j, int *buf_len, const unsigned parms[])
+ {
+    unsigned i, total_size, base_class, base_size, n, begin_index;
+    parms_atomic p;
++   herr_t ret_value = SUCCEED; /* Return value */
++
++   FUNC_ENTER_STATIC
+ 
+    total_size = parms[parms_index++];
+    base_class = parms[parms_index++];
+@@ -1062,7 +1066,12 @@
+            p.order = parms[parms_index++];
+            p.precision = parms[parms_index++];
+            p.offset = parms[parms_index++];
+-           n = total_size/p.size;
++
++           /* Check values of precision and offset */
++           if(p.precision > p.size * 8 || (p.precision + p.offset) > p.size * 8)
++              HGOTO_ERROR(H5E_PLINE, H5E_BADTYPE, FAIL, "invalid datatype precision/offset")
++
++           n = total_size / p.size;
+            for(i = 0; i < n; i++)
+               H5Z_nbit_decompress_one_atomic(data, data_offset + i*p.size,
+                                              buffer, j, buf_len, p);
+@@ -1072,8 +1081,9 @@
+            n = total_size/base_size; /* number of base_type elements inside the array datatype */
+            begin_index = parms_index;
+            for(i = 0; i < n; i++) {
+-              H5Z_nbit_decompress_one_array(data, data_offset + i*base_size,
+-                                            buffer, j, buf_len, parms);
++              if(H5Z__nbit_decompress_one_array(data, data_offset + i * base_size,
++                                            buffer, j, buf_len, parms) < 0)
++                 HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress array")
+               parms_index = begin_index;
+            }
+            break;
+@@ -1082,8 +1092,9 @@
+            n = total_size/base_size; /* number of base_type elements inside the array datatype */
+            begin_index = parms_index;
+            for(i = 0; i < n; i++) {
+-              H5Z_nbit_decompress_one_compound(data, data_offset + i*base_size,
+-                                               buffer, j, buf_len, parms);
++              if(H5Z__nbit_decompress_one_compound(data, data_offset + i * base_size,
++                                               buffer, j, buf_len, parms) < 0)
++                 HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress compound")
+               parms_index = begin_index;
+            }
+            break;
+@@ -1094,51 +1105,76 @@
+       default:
+           HDassert(0 && "This Should never be executed!");
+    } /* end switch */
++
++done:
++    FUNC_LEAVE_NOAPI(ret_value)
+ }
+ 
+-static void
+-H5Z_nbit_decompress_one_compound(unsigned char *data, size_t data_offset,
++static herr_t
++H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data_offset,
+               unsigned char *buffer, size_t *j, int *buf_len, const unsigned parms[])
+ {
+-   unsigned i, nmembers, member_offset, member_class, size;
++   unsigned i, nmembers, member_offset, member_class, member_size, used_size = 0, size;
+    parms_atomic p;
++   herr_t ret_value = SUCCEED; /* Return value */
+ 
+-   parms_index++; /* skip total size of compound datatype */
++   FUNC_ENTER_STATIC
++
++   size = parms[parms_index++];
+    nmembers = parms[parms_index++];
+ 
+    for(i = 0; i < nmembers; i++) {
+       member_offset = parms[parms_index++];
+       member_class = parms[parms_index++];
++
++      /* Check for overflow */
++      member_size = parms[parms_index];
++      used_size += member_size;
++      if(used_size > size)
++         HGOTO_ERROR(H5E_PLINE, H5E_BADTYPE, FAIL, "compound member offset overflowed compound size")
+       switch(member_class) {
+          case H5Z_NBIT_ATOMIC:
+-              p.size = parms[parms_index++];
++              p.size = member_size;
++              /* Advance past member size */
++              parms_index++;
+               p.order = parms[parms_index++];
+               p.precision = parms[parms_index++];
+               p.offset = parms[parms_index++];
++
++              /* Check values of precision and offset */
++              if(p.precision > p.size * 8 || (p.precision + p.offset) > p.size * 8)
++                 HGOTO_ERROR(H5E_PLINE, H5E_BADTYPE, FAIL, "invalid datatype precision/offset")
++
+               H5Z_nbit_decompress_one_atomic(data, data_offset + member_offset,
+                                              buffer, j, buf_len, p);
+               break;
+          case H5Z_NBIT_ARRAY:
+-              H5Z_nbit_decompress_one_array(data, data_offset + member_offset,
+-                                            buffer, j, buf_len, parms);
++              if(H5Z__nbit_decompress_one_array(data, data_offset + member_offset,
++                                            buffer, j, buf_len, parms) < 0)
++                 HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress array")
+               break;
+          case H5Z_NBIT_COMPOUND:
+-              H5Z_nbit_decompress_one_compound(data, data_offset+member_offset,
+-                                               buffer, j, buf_len, parms);
++              if(H5Z__nbit_decompress_one_compound(data, data_offset+member_offset,
++                                            buffer, j, buf_len, parms) < 0)
++                 HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress compound")
+               break;
+          case H5Z_NBIT_NOOPTYPE:
+-              size = parms[parms_index++];
++              /* Advance past member size */
++              parms_index++;
+               H5Z_nbit_decompress_one_nooptype(data, data_offset+member_offset,
+-                                               buffer, j, buf_len, size);
++                                               buffer, j, buf_len, member_size);
+               break;
+           default:
+               HDassert(0 && "This Should never be executed!");
+       } /* end switch */
+    }
++
++done:
++    FUNC_LEAVE_NOAPI(ret_value)
+ }
+ 
+-static void
+-H5Z_nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer,
++static herr_t
++H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer,
+                                 const unsigned parms[])
+ {
+    /* i: index of data, j: index of buffer,
+@@ -1146,6 +1182,9 @@
+    size_t i, j, size;
+    int buf_len;
+    parms_atomic p;
++   herr_t ret_value = SUCCEED; /* Return value */
++
++   FUNC_ENTER_STATIC
+ 
+    /* may not have to initialize to zeros */
+    for(i = 0; i < d_nelmts*parms[4]; i++) data[i] = 0;
+@@ -1161,6 +1200,11 @@
+            p.order = parms[5];
+            p.precision = parms[6];
+            p.offset = parms[7];
++
++           /* Check values of precision and offset */
++           if(p.precision > p.size * 8 || (p.precision + p.offset) > p.size * 8)
++              HGOTO_ERROR(H5E_PLINE, H5E_BADTYPE, FAIL, "invalid datatype precision/offset")
++
+            for(i = 0; i < d_nelmts; i++) {
+               H5Z_nbit_decompress_one_atomic(data, i*p.size, buffer, &j, &buf_len, p);
+            }
+@@ -1169,7 +1213,8 @@
+            size = parms[4];
+            parms_index = 4;
+            for(i = 0; i < d_nelmts; i++) {
+-              H5Z_nbit_decompress_one_array(data, i*size, buffer, &j, &buf_len, parms);
++              if(H5Z__nbit_decompress_one_array(data, i*size, buffer, &j, &buf_len, parms) < 0)
++                 HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress array")
+               parms_index = 4;
+            }
+            break;
+@@ -1177,13 +1222,17 @@
+            size = parms[4];
+            parms_index = 4;
+            for(i = 0; i < d_nelmts; i++) {
+-              H5Z_nbit_decompress_one_compound(data, i*size, buffer, &j, &buf_len, parms);
++              if(H5Z__nbit_decompress_one_compound(data, i*size, buffer, &j, &buf_len, parms) < 0)
++                 HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress compound")
+               parms_index = 4;
+            }
+            break;
+       default:
+           HDassert(0 && "This Should never be executed!");
+    } /* end switch */
++
++done:
++    FUNC_LEAVE_NOAPI(ret_value)
+ }
+ 
+ static void H5Z_nbit_compress_one_byte(unsigned char *data, size_t data_offset, int k, int begin_i,

--- a/sci-libs/hdf5/files/hdf5-1.8.17-CVE-2016-4333.patch
+++ b/sci-libs/hdf5/files/hdf5-1.8.17-CVE-2016-4333.patch
@@ -1,0 +1,25 @@
+--- hdf5-1.8.17/src/H5Odtype.c	2016-04-26 05:43:33.000000000 -0700
++++ hdf5-1.8.18/src/H5Odtype.c	2016-11-04 11:41:07.000000000 -0700
+@@ -310,7 +310,11 @@
+                     if(version == H5O_DTYPE_VERSION_1) {
+                         /* Decode the number of dimensions */
+                         ndims = *(*pp)++;
+-                        HDassert(ndims <= 4);
++
++                        /* Check that ndims is valid */
++                        if(ndims > 4)
++                            HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "invalid number of dimensions for array")
++
+                         *pp += 3;		/*reserved bytes */
+ 
+                         /* Skip dimension permutation */
+@@ -518,7 +522,8 @@
+             dt->shared->u.array.ndims = *(*pp)++;
+ 
+             /* Double-check the number of dimensions */
+-            HDassert(dt->shared->u.array.ndims <= H5S_MAX_RANK);
++            if(dt->shared->u.array.ndims > H5S_MAX_RANK)
++                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTLOAD, FAIL, "too many dimensions for array datatype")
+ 
+             /* Skip reserved bytes, if version has them */
+             if(version < H5O_DTYPE_VERSION_3)

--- a/sci-libs/hdf5/hdf5-1.8.17-r1.ebuild
+++ b/sci-libs/hdf5/hdf5-1.8.17-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+FORTRAN_NEEDED=fortran
+AUTOTOOLS_AUTORECONF=1
+
+inherit autotools-utils eutils fortran-2 flag-o-matic toolchain-funcs multilib
+
+MY_P=${PN}-${PV/_p/-patch}
+
+DESCRIPTION="General purpose library and file format for storing scientific data"
+HOMEPAGE="http://www.hdfgroup.org/HDF5/"
+SRC_URI="https://support.hdfgroup.org/ftp/HDF5/releases/${MY_P}/src/${MY_P}.tar.bz2"
+
+LICENSE="NCSA-HDF"
+SLOT="0/${PV%%_p*}"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+IUSE="cxx debug examples fortran fortran2003 +hl mpi static-libs szip threads zlib"
+
+REQUIRED_USE="
+	threads? ( !cxx !mpi !fortran !hl )
+	fortran2003? ( fortran )"
+
+RDEPEND="
+	mpi? ( virtual/mpi[romio] )
+	szip? ( virtual/szip )
+	zlib? ( sys-libs/zlib:0= )"
+
+DEPEND="${RDEPEND}
+	sys-devel/libtool:2
+	>=sys-devel/autoconf-2.69"
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.8.9-static_libgfortran.patch
+	"${FILESDIR}"/${PN}-1.8.9-mpicxx.patch
+	"${FILESDIR}"/${PN}-1.8.13-no-messing-ldpath.patch
+	"${FILESDIR}"/${PN}-1.8.15-implicits.patch
+	"${FILESDIR}"/${P}-CVE-2016-4331.patch
+	"${FILESDIR}"/${P}-CVE-2016-4333.patch
+)
+
+pkg_setup() {
+	tc-export CXX CC AR # workaround for bug 285148
+	if use fortran; then
+		use fortran2003 && FORTRAN_STANDARD=2003
+		fortran-2_pkg_setup
+	fi
+	if use mpi; then
+		if has_version 'sci-libs/hdf5[-mpi]'; then
+			ewarn "Installing hdf5 with mpi enabled with a previous hdf5 with mpi disabled may fail."
+			ewarn "Try to uninstall the current hdf5 prior to enabling mpi support."
+		fi
+		export CC=mpicc
+		use fortran && export FC=mpif90
+		if use cxx ; then
+			export CXX=mpicxx
+			ewarn "USE='mpi cxx' requires a configuration unsupported by upstream. Use at your own risk."
+			ewarn "In particular, the C++ API is not parallel safe."
+		fi
+	elif has_version 'sci-libs/hdf5[mpi]'; then
+		ewarn "Installing hdf5 with mpi disabled while having hdf5 installed with mpi enabled may fail."
+		ewarn "Try to uninstall the current hdf5 prior to disabling mpi support."
+	fi
+}
+
+src_prepare() {
+	# respect gentoo examples directory
+	sed \
+		-e "s:hdf5_examples:doc/${PF}/examples:g" \
+		-i $(find . -name Makefile.am) $(find . -name "run*.sh.in") || die
+	sed \
+		-e '/docdir/d' \
+		-i config/commence.am || die
+	if ! use examples; then
+		sed -e '/^install:/ s/install-examples//' \
+			-i Makefile.am || die #409091
+	fi
+	# enable shared libs by default for h5cc config utility
+	sed -i -e "s/SHLIB:-no/SHLIB:-yes/g" tools/misc/h5cc.in	|| die
+	# bug #419677
+	use prefix && \
+		append-ldflags -Wl,-rpath,"${EPREFIX}"/usr/$(get_libdir) \
+		-Wl,-rpath,"${EPREFIX}"/$(get_libdir)
+	autotools-utils_src_prepare
+}
+
+src_configure() {
+	local myeconfargs=(
+		--enable-production
+		--docdir="${EPREFIX}"/usr/share/doc/${PF}
+		--enable-deprecated-symbols
+		$(use_enable prefix sharedlib-rpath)
+		$(use_enable debug debug all)
+		$(use_enable debug codestack)
+		$(use_enable cxx)
+		$(use_enable fortran)
+		$(use_enable fortran2003)
+		$(use_enable hl)
+		$(use_enable mpi parallel)
+		$(use_enable threads threadsafe)
+		$(use_with szip szlib)
+		$(use_with threads pthread)
+		$(use_with zlib)
+		$(use mpi && use cxx && echo --enable-unsupported)
+	)
+	autotools-utils_src_configure
+}


### PR DESCRIPTION
I noticed the Manifest file wasn't picked up and I'm assuming that's due to signed Manifests. 

* Fix Bug [#601408](https://bugs.gentoo.org/show_bug.cgi?id=601408) and [#601420](https://bugs.gentoo.org/show_bug.cgi?id=601420)
* CVE-2016-4331 patch is generated by a source diff between 1.8.17 and 1.8.18 releases
* CVE-2016-4333 patch is also generated by the same source tree diff method
* Passes the src_compile() phase without issues
* make test shows no failures