### PR TITLE
kde-frameworks/ki18n: Add missing test DEPEND

### DIFF
--- a/kde-frameworks/ki18n/ki18n-5.26.0.ebuild
+++ b/kde-frameworks/ki18n/ki18n-5.26.0.ebuild
@@ -21,7 +21,10 @@ RDEPEND="
 	virtual/libintl
 "
 DEPEND="${RDEPEND}
-	test? ( $(add_qt_dep qtconcurrent) )
+	test? (
+		$(add_qt_dep qtconcurrent)
+		$(add_qt_dep qtdeclarative)
+	)
 "
 
 pkg_setup() {

--- a/kde-frameworks/ki18n/ki18n-5.28.0.ebuild
+++ b/kde-frameworks/ki18n/ki18n-5.28.0.ebuild
@@ -21,7 +21,10 @@ RDEPEND="
 	virtual/libintl
 "
 DEPEND="${RDEPEND}
-	test? ( $(add_qt_dep qtconcurrent) )
+	test? (
+		$(add_qt_dep qtconcurrent)
+		$(add_qt_dep qtdeclarative)
+	)
 "
 
 pkg_setup() {


### PR DESCRIPTION
Gentoo-bug: 600202

(sync with kde overlay fix)

@gentoo/kde 