### PR TITLE
dev-perl/Devel-CheckBin: add ~x86-fbsd KEYWORDS

### DIFF
--- a/dev-perl/Devel-CheckBin/Devel-CheckBin-0.40.0.ebuild
+++ b/dev-perl/Devel-CheckBin/Devel-CheckBin-0.40.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 
 DESCRIPTION="check that a command is available"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="


### PR DESCRIPTION
KEYWORDREQ bug https://bugs.gentoo.org/show_bug.cgi?id=579720

FEATURES=test emerge -pv '>=dev-perl/Devel-CheckBin-0.40.0' '>=dev-perl/Sub-Name-0.150.0'

```
[ebuild  N    *] dev-perl/Devel-CheckBin-0.40.0::gentoo  USE="{test}" 10 KiB
[ebuild  N     ] dev-perl/Sub-Name-0.150.0::gentoo  USE="{test} -suggested" 76 KiB

Total: 2 packages (2 new), Size of downloads: 85 KiB

The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by >=dev-perl/Devel-CheckBin-0.40.0 (argument)
=dev-perl/Devel-CheckBin-0.40.0 **
```

```
>>> Test phase: dev-perl/Devel-CheckBin-0.40.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00_compile.t .. ok
t/01_can_run.t .. skipped: Skip: freebsd
t/02_can_run.t .. ok
All tests successful.
Files=3, Tests=3,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.34 cusr  0.05 csys =  0.43 CPU)
Result: PASS
>>> Completed testing dev-perl/Devel-CheckBin-0.40.0
```

