### PR TITLE
dev-perl/{Math-Base-Convert,Text-Soundex,SQL-Statement}: add ~x86-fbsd, fix bug 579670

### DIFF
--- a/dev-perl/Math-Base-Convert/Math-Base-Convert-0.110.0.ebuild
+++ b/dev-perl/Math-Base-Convert/Math-Base-Convert-0.110.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Very fast base to base conversion"
 
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~x86 ~x86-fbsd"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/SQL-Statement/SQL-Statement-1.410.0.ebuild
+++ b/dev-perl/SQL-Statement/SQL-Statement-1.410.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Small SQL parser and engine"
 
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~x86 ~x86-fbsd"
 IUSE="test minimal"
 
 RDEPEND="

--- a/dev-perl/Text-Soundex/Text-Soundex-3.50.0.ebuild
+++ b/dev-perl/Text-Soundex/Text-Soundex-3.50.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 
 DESCRIPTION="Implementation of the soundex algorithm"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~x86 ~x86-fbsd"
 IUSE="test minimal"
 
 RDEPEND="


### PR DESCRIPTION
KEYWORDREQ bug https://bugs.gentoo.org/show_bug.cgi?id=579670

FEATURES=test emerge -pv '>=dev-perl/Math-Base-Convert-0.110.0' '>=dev-perl/Text-Soundex-3.50.0' '>=dev-perl/SQL-Statement-1.409.0'

```
The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by >=dev-perl/Math-Base-Convert-0.110.0 (argument)
=dev-perl/Math-Base-Convert-0.110.0 **
# required by >=dev-perl/SQL-Statement-1.409.0 (argument)
=dev-perl/SQL-Statement-1.410.0 **
# required by >=dev-perl/Text-Soundex-3.50.0 (argument)
=dev-perl/Text-Soundex-3.50.0 **
```

```
>>> Test phase: dev-perl/Math-Base-Convert-0.110.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/ascii.t ................. ok
t/basefunct.t ............. ok
t/basemethods.t ........... ok
t/basemap.t ............... ok
t/benchmarkcalc.t ......... ok
t/backend.t ............... ok
t/benchmarkcnv.t .......... ok
t/longmultiply.t .......... ok
t/isnotp2.t ............... ok
t/convert.t ............... ok
t/frontend.t .............. ok
t/shiftright.t ............ ok
t/useFROMbaseto32wide.t ... ok
t/useFROMbaseShortcuts.t .. ok
t/validbase.t ............. ok
t/vetcontext.t ............ ok
t/vet.t ................... ok
t/useTObaseShortcuts.t .... ok
t/overload.t .............. ok
t/zstrings.t .............. ok
All tests successful.
Files=20, Tests=5350,  0 wallclock secs ( 0.31 usr  0.05 sys +  0.77 cusr  0.12 csys =  1.26 CPU)
Result: PASS
>>> Completed testing dev-perl/Math-Base-Convert-0.110.0
```

```
>>> Test phase: dev-perl/Text-Soundex-3.50.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
Running Mkbootstrap for Text::Soundex ()
chmod 644 "Soundex.bs"
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/basic.t .. ok
All tests successful.
Files=1, Tests=18,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.00 cusr  0.01 csys =  0.03 CPU)
Result: PASS
>>> Completed testing dev-perl/Text-Soundex-3.50.0
```

```
>>> Test phase: dev-perl/SQL-Statement-1.410.0
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t xt/*.t
===(       1;0  0/?  1/?  0/?  0/?  0/? )===============================# # Using required:
# #   SQL::Statement: 1.41
# # Using recommended:
t/00error.t ..... ok
t/03import.t .... ok
t/04idents.t .... ok
t/02execute.t ... ok
t/01prepare.t ... ok
t/09ops.t ....... ok
t/05simple.t .... ok
t/10limit.t ..... ok
t/14parse.t ..... ok
t/12eval.t ...... ok
t/08join.t ...... ok
t/17quoting.t ... ok
t/23dialects.t .. ok
t/06virtual.t ... ok
All tests successful.

Test Summary Report
-------------------
t/08join.t    (Wstat: 0 Tests: 321 Failed: 0)
  TODO passed:   289-291, 293-295, 314, 316, 318, 321
t/06virtual.t (Wstat: 0 Tests: 655 Failed: 0)
  TODO passed:   565-567
Files=14, Tests=1626,  1 wallclock secs ( 0.12 usr  0.13 sys +  2.45 cusr  0.51 csys =  3.21 CPU)
Result: PASS
>>> Completed testing dev-perl/SQL-Statement-1.410.0
```