### PR TITLE
dev-perl/Text-Diff: add ~x86-fbsd KEYWORDS

### DIFF
--- a/dev-perl/Text-Diff/Text-Diff-1.440.0.ebuild
+++ b/dev-perl/Text-Diff/Text-Diff-1.440.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Perform diffs on files and record sets"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND="


### PR DESCRIPTION
KEYWORDREQ bug https://bugs.gentoo.org/show_bug.cgi?id=580962

FEATURES=test emerge -pv '>=dev-perl/Algorithm-Diff-1.190.300' '>=dev-perl/Text-Diff-1.440.0' '>=dev-perl/Filter-1.550.0' '>=dev-perl/Spiffy-0.460.0' '>=dev-perl/Test-Base-0.880.0' '>=dev-perl/Test-YAML-1.60.0'

```
[ebuild  N     ] dev-perl/Algorithm-Diff-1.190.300::gentoo  34 KiB
[ebuild  N     ] dev-perl/Filter-1.550.0::gentoo  88 KiB
[ebuild  N     ] dev-perl/Spiffy-0.460.0::gentoo  33 KiB
[ebuild  N    *] dev-perl/Text-Diff-1.440.0::gentoo  29 KiB
[ebuild  N     ] dev-perl/Test-Base-0.880.0::gentoo  USE="{test}" 51 KiB
[ebuild  N     ] dev-perl/Test-YAML-1.60.0::gentoo  12 KiB

Total: 6 packages (6 new), Size of downloads: 245 KiB

The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by >=dev-perl/Text-Diff-1.440.0 (argument)
=dev-perl/Text-Diff-1.440.0 **
```

```
>>> Test phase: dev-perl/Text-Diff-1.440.0
 * Removing un-needed t/97_meta.t
 * Removing un-needed t/98_pod.t
 * Removing un-needed t/99_pmv.t
 * Fixing Manifest
 * Test::Harness Jobs=5
gmake -j5 test TEST_VERBOSE=0
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/general.t ..... ok
t/inputs.t ...... ok
t/keygen.t ...... ok
t/ext_format.t .. ok
t/outputs.t ..... ok
t/table.t ....... ok
All tests successful.
Files=6, Tests=33,  0 wallclock secs ( 0.02 usr  0.03 sys +  0.12 cusr  0.03 csys =  0.20 CPU)
Result: PASS
>>> Completed testing dev-perl/Text-Diff-1.440.0
```
