### PR TITLE
dev-perl/DateTime and deps, add ~x86-fbsd KEYWORDS, bug599552

### DIFF
--- a/dev-perl/B-Hooks-EndOfScope/B-Hooks-EndOfScope-0.200.0.ebuild
+++ b/dev-perl/B-Hooks-EndOfScope/B-Hooks-EndOfScope-0.200.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Execute code after a scope finished compilation"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~x86 ~ppc-aix ~x64-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~x86 ~ppc-aix ~x86-fbsd ~x64-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/DateTime/DateTime-1.360.0.ebuild
+++ b/dev-perl/DateTime/DateTime-1.360.0.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="A date and time object"
 
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~x86 ~ppc-aix ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~x86 ~ppc-aix ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 CONFLICTS="

--- a/dev-perl/Devel-Caller/Devel-Caller-2.60.0.ebuild
+++ b/dev-perl/Devel-Caller/Devel-Caller-2.60.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Meatier versions of caller"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm hppa ppc x86"
+KEYWORDS="~alpha amd64 ~arm hppa ppc x86 ~x86-fbsd"
 IUSE=""
 
 DEPEND="dev-perl/PadWalker"

--- a/dev-perl/Devel-LexAlias/Devel-LexAlias-0.50.0.ebuild
+++ b/dev-perl/Devel-LexAlias/Devel-LexAlias-0.50.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Alias lexical variables"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm hppa ppc x86"
+KEYWORDS="~alpha amd64 ~arm hppa ppc x86 ~x86-fbsd"
 IUSE=""
 
 DEPEND=">=dev-perl/Devel-Caller-2.03"

--- a/dev-perl/Perl-Tidy/Perl-Tidy-20160302.0.0.ebuild
+++ b/dev-perl/Perl-Tidy/Perl-Tidy-20160302.0.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://perltidy.sourceforge.net/ ${HOMEPAGE}"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ppc ~ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ppc ~ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE="examples"
 
 RDEPEND=""

--- a/dev-perl/Role-Tiny/Role-Tiny-2.0.1.ebuild
+++ b/dev-perl/Role-Tiny/Role-Tiny-2.0.1.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Roles. Like a nouvelle cuisine portion size slice of Moose"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm hppa ppc x86 ~ppc-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm hppa ppc x86 ~x86-fbsd ~ppc-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Specio/Specio-0.310.0.ebuild
+++ b/dev-perl/Specio/Specio-0.310.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 
 DESCRIPTION="Type constraints and coercions for Perl"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~x86"
+KEYWORDS="~alpha ~amd64 ~x86 ~x86-fbsd"
 IUSE="test"
 
 PATCHES=("${FILESDIR}/${PN}-${DIST_VERSION}-installskip.patch")

--- a/dev-perl/Test-Needs/Test-Needs-0.2.2.ebuild
+++ b/dev-perl/Test-Needs/Test-Needs-0.2.2.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 
 DESCRIPTION="Skip tests when modules not available"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~x86"
+KEYWORDS="~alpha ~amd64 ~x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Variable-Magic/Variable-Magic-0.600.0.ebuild
+++ b/dev-perl/Variable-Magic/Variable-Magic-0.600.0.ebuild
@@ -12,7 +12,7 @@ inherit perl-module
 DESCRIPTION="Associate user-defined magic to variables from Perl"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~x86 ~ppc-aix ~x64-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~x86 ~ppc-aix ~x86-fbsd ~x64-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/namespace-autoclean/namespace-autoclean-0.280.0.ebuild
+++ b/dev-perl/namespace-autoclean/namespace-autoclean-0.280.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Keep imports out of your namespace"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm hppa ~ppc ~x86 ~ppc-aix ~x86-freebsd ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm hppa ~ppc ~x86 ~ppc-aix ~x86-fbsd ~x86-freebsd ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/namespace-clean/namespace-clean-0.260.0.ebuild
+++ b/dev-perl/namespace-clean/namespace-clean-0.260.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Keep imports and functions out of your namespace"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~x64-macos"
+KEYWORDS="~alpha amd64 ~arm hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~x86-fbsd ~x64-macos"
 IUSE="test"
 
 RDEPEND="


### PR DESCRIPTION
KEYWORDREQ bug https://bugs.gentoo.org/show_bug.cgi?id=599552

FEATURES=test emerge -pv '>=dev-perl/DateTime-1.360.0' '>=dev-perl/Specio-0.310.0' '>=dev-perl/Test-Needs-0.2.2' '>=dev-perl/Devel-LexAlias-0.50.0' '>=dev-perl/Devel-Caller-2.60.0' '>=dev-perl/B-Hooks-EndOfScope-0.200.0' '>=dev-perl/Variable-Magic-0.600.0' '>=dev-perl/Role-Tiny-2.0.1' '>=dev-perl/namespace-autoclean-0.280.0' '>=dev-perl/Perl-Tidy-20160302.0.0' '>=dev-perl/namespace-clean-0.260.0' '>=dev-perl/Eval-Closure-0.130.0' '>=dev-perl/CPAN-Meta-Check-0.13.0' '>=dev-perl/PadWalker-2.200.0' '>=dev-perl/Sub-Identify-0.120.0' '>=dev-perl/Devel-StackTrace-2.0.0' '>=dev-perl/MRO-Compat-0.120.0-r1' '>=dev-perl/Sub-Exporter-Progressive-0.1.11' '>=dev-perl/DateTime-Locale-1.50.0'
```
The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by >=dev-perl/namespace-autoclean-0.280.0 (argument)
=dev-perl/namespace-autoclean-0.280.0 **
# required by >=dev-perl/Variable-Magic-0.600.0 (argument)
=dev-perl/Variable-Magic-0.600.0 **
# required by >=dev-perl/DateTime-1.360.0 (argument)
=dev-perl/DateTime-1.360.0 **
# required by >=dev-perl/Test-Needs-0.2.2 (argument)
=dev-perl/Test-Needs-0.2.2 **
# required by >=dev-perl/B-Hooks-EndOfScope-0.200.0 (argument)
=dev-perl/B-Hooks-EndOfScope-0.200.0 **
# required by >=dev-perl/Role-Tiny-2.0.1 (argument)
=dev-perl/Role-Tiny-2.0.1 **
# required by >=dev-perl/Devel-Caller-2.60.0 (argument)
=dev-perl/Devel-Caller-2.60.0 **
# required by >=dev-perl/Specio-0.310.0 (argument)
=dev-perl/Specio-0.310.0 **
# required by >=dev-perl/Devel-LexAlias-0.50.0 (argument)
=dev-perl/Devel-LexAlias-0.50.0 **
# required by >=dev-perl/namespace-clean-0.260.0 (argument)
=dev-perl/namespace-clean-0.260.0 **
# required by >=dev-perl/Perl-Tidy-20160302.0.0 (argument)
=dev-perl/Perl-Tidy-20160302.0.0 **
```

All tests successful.
https://gist.github.com/nigoro/2a5fa927efb4b45589e5139a1b109ff2
