### PR TITLE
net-analyzer/tsung: set gnuplot runtime dependencies #594340

### DIFF
--- a/net-analyzer/tsung/tsung-1.6.0.ebuild
+++ b/net-analyzer/tsung/tsung-1.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/net-analyzer/tsung/tsung-1.6.0.ebuild
+++ b/net-analyzer/tsung/tsung-1.6.0.ebuild
@@ -16,11 +16,16 @@ SRC_URI="http://tsung.erlang-projects.org/dist/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="gnuplot"
 
 DEPEND="dev-lang/erlang"
-RDEPEND=${DEPEND}
-
+RDEPEND="
+	gnuplot? (
+		sci-visualization/gnuplot
+		dev-perl/Template-Toolkit
+	)
+	${DEPEND}
+"
 src_configure() {
 	./configure --prefix="/usr" || die "econf failed"
 }


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=594340

Tsung ships with tools for making reports and graphs, but It needs sci-visualization/gnuplot and dev-perl/Template-Toolkit.  This change will add them as runtime dependency for that case.