### PR TITLE
app-text/q-text-as-data: Require Python w/ SQLite.

### DIFF
--- a/app-text/q-text-as-data/q-text-as-data-1.5.0.ebuild
+++ b/app-text/q-text-as-data/q-text-as-data-1.5.0.ebuild
@@ -5,6 +5,7 @@
 EAPI="5"
 # Does not yet support py3
 PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="sqlite"
 
 inherit python-r1
 


### PR DESCRIPTION
q needs sqlite3 module.