### PR TITLE
media-sound/alsa-tools: Adds support for gcc-5.4.0

### DIFF
--- a/media-sound/alsa-tools/alsa-tools-1.0.29.ebuild
+++ b/media-sound/alsa-tools/alsa-tools-1.0.29.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -65,6 +65,7 @@ pkg_setup() {
 
 src_prepare() {
 	epatch "${FILESDIR}"/envy24control-config-dir.patch
+	epatch "${FILESDIR}"/${P}-output_tram_line-static.patch
 
 	epatch_user
 

--- a/media-sound/alsa-tools/files/alsa-tools-1.0.29-output_tram_line-static.patch
+++ b/media-sound/alsa-tools/files/alsa-tools-1.0.29-output_tram_line-static.patch
@@ -1,0 +1,11 @@
+--- a/as10k1/as10k1.c	2016-12-04 15:13:07.122841673 +0000
++++ b/as10k1/as10k1.c	2016-12-04 15:13:50.982841350 +0000
+@@ -366,7 +366,7 @@
+ 	exit(1);
+ }
+ 
+-inline void output_tram_line( struct list_head *line_head, int type){
++static inline void output_tram_line( struct list_head *line_head, int type){
+         
+         struct tram *tram_sym;
+         struct list_head *entry;


### PR DESCRIPTION
Previously alsa-tools 1.0.29 (as of now latest stable) wouldn't
compile on either clang or >=gcc-5.4.0.
By making output_tram_line static we can successfully compile
on either compiler (>=gcc-4.8.x included).