### PR TITLE
net-libs/tox: add slot to the ebuilds

### DIFF
--- a/net-libs/tox/tox-0_pre20160904.ebuild
+++ b/net-libs/tox/tox-0_pre20160904.ebuild
@@ -12,7 +12,7 @@ EGIT_COMMIT="755f084e8720b349026c85afbad58954cb7ff1d4"
 SRC_URI="https://github.com/irungentoo/toxcore/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3+"
-SLOT="0"
+SLOT="0/0.0"
 KEYWORDS="~amd64 ~x86"
 IUSE="+av daemon log-debug log-error log-info log-trace log-warn +no-log ntox static-libs test"
 

--- a/net-libs/tox/tox-9999.ebuild
+++ b/net-libs/tox/tox-9999.ebuild
@@ -13,7 +13,7 @@ EGIT_REPO_URI="https://github.com/irungentoo/toxcore.git
 	git://github.com/irungentoo/toxcore.git"
 
 LICENSE="GPL-3+"
-SLOT="0"
+SLOT="0/0.0"
 KEYWORDS=""
 IUSE="+av daemon log-debug log-error log-info log-trace log-warn +no-log ntox static-libs test"
 


### PR DESCRIPTION
As mentioned in the bug #601038