### PR TITLE
media-plugins/audacious-plugins: Includes fixes for gl-spectrum and jack

### DIFF
--- a/media-plugins/audacious-plugins/audacious-plugins-3.7.1.ebuild
+++ b/media-plugins/audacious-plugins/audacious-plugins-3.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -94,6 +94,10 @@ src_prepare() {
 
 src_configure() {
 	mp3_warning
+
+	epatch "${FILESDIR}/${P}-jack-ng.patch"
+	epatch "${FILESDIR}/${P}-gl-spectrum-include-fix.patch"
+
 	if use qt5 ;then
 		notify="--disable-notify"
 	elif use libnotify ;then

--- a/media-plugins/audacious-plugins/files/audacious-plugins-3.7.1-gl-spectrum-include-fix.patch
+++ b/media-plugins/audacious-plugins/files/audacious-plugins-3.7.1-gl-spectrum-include-fix.patch
@@ -1,0 +1,11 @@
+--- src/gl-spectrum-qt/gl-spectrum.cc.orig	2015-11-08 20:23:48.365692141 +0900
++++ src/gl-spectrum-qt/gl-spectrum.cc	2015-11-08 20:24:56.260684278 +0900
+@@ -32,6 +32,9 @@
+ #include <QGLWidget>
+ #include <QGLFunctions>
+ 
++#include <GL/glu.h>
++#include <GL/glut.h>
++
+ #define NUM_BANDS 32
+ #define DB_RANGE 40

--- a/media-plugins/audacious-plugins/files/audacious-plugins-3.7.1-jack-ng.patch
+++ b/media-plugins/audacious-plugins/files/audacious-plugins-3.7.1-jack-ng.patch
@@ -1,0 +1,11 @@
+--- a/src/jack-ng/jack-ng.cc	2016-12-04 07:36:46.462043676 +0000
++++ b/src/jack-ng/jack-ng.cc	2016-12-04 07:37:18.375043441 +0000
+@@ -18,7 +18,7 @@
+  * implied. In no event shall the authors be liable for any damages arising from
+  * the use of this software.
+  */
+-
++#include <iterator>
+ #include <libaudcore/audstrings.h>
+ #include <libaudcore/i18n.h>
+ #include <libaudcore/interface.h>


### PR DESCRIPTION
Without the gl-spectrum patch this just doesn't compile.
The patch for jack is relevant if your're compiling with >=gcc-5.x
since <iterator> is no longer included by default.