### PR TITLE
cuda.eclass: fixes gcc-bindir -f

### DIFF
--- a/eclass/cuda.eclass
+++ b/eclass/cuda.eclass
@@ -47,7 +47,7 @@ cuda_gccdir() {
 	local gcc_bindir ver args="" flag ret
 
 	# Currently we only support the gnu compiler suite
-	if [[ $(tc-getCXX) != *g++* ]]; then
+	if  ! tc-is-gcc ; then
 		ewarn "Currently we only support the gnu compiler suite"
 		return 2
 	fi
@@ -55,7 +55,7 @@ cuda_gccdir() {
 	while [ "$1" ]; do
 		case $1 in
 			-f)
-				flag="--compiler-bindir="
+				flag="--compiler-bindir "
 				;;
 			*)
 				;;


### PR DESCRIPTION
Currently the check against *g++* doesn't work, thus the NVCCFLAGS
are never set accordingly.
The check for gnu is now made through tc-is-gcc.

Also the "" around the bindir are causing an "not a valid directory"
error while compiling with cuda support.

It now works as expected:
	with gcc-5.4.0 and cuda 7.5 NVCCFLAGS are set properly to
gcc-4.9.x

Also please check this PR as needed:
gentoo/gentoo#3014