### PR TITLE
dev-util/cmake: Fixes FindCUDA in cmake-3.6.3

### DIFF
--- a/dev-util/cmake/cmake-3.6.3.ebuild
+++ b/dev-util/cmake/cmake-3.6.3.ebuild
@@ -53,6 +53,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.0.0-FindBoost-python.patch
 	"${FILESDIR}"/${PN}-3.0.2-FindLAPACK.patch
 	"${FILESDIR}"/${PN}-3.5.2-FindQt4.patch
+	"${FILESDIR}"/${PN}-3.6.3-FindCUDA.patch
 
 	# respect python eclasses
 	"${FILESDIR}"/${PN}-2.8.10.2-FindPythonLibs.patch

--- a/dev-util/cmake/files/cmake-3.6.3-FindCUDA.patch
+++ b/dev-util/cmake/files/cmake-3.6.3-FindCUDA.patch
@@ -1,0 +1,27 @@
+--- a/Modules/FindCUDA/run_nvcc.cmake	2016-12-17 16:46:54.370587130 +0000
++++ b/Modules/FindCUDA/run_nvcc.cmake	2016-12-17 16:53:10.161588315 +0000
+@@ -104,14 +104,17 @@
+ # Add the build specific configuration flags
+ list(APPEND CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS_${build_configuration}})
+ 
++# The following may cause an nvcc fatal: redefenition of compiler-bindir
++if(NOT @CMAKE_GENTOO_BUILD@ STREQUAL ON AND NOT @CMAKE_BUILD_TYPE@ STREQUAL Gentoo )
+ # Any -ccbin existing in CUDA_NVCC_FLAGS gets highest priority
+-list( FIND CUDA_NVCC_FLAGS "-ccbin" ccbin_found0 )
+-list( FIND CUDA_NVCC_FLAGS "--compiler-bindir" ccbin_found1 )
+-if( ccbin_found0 LESS 0 AND ccbin_found1 LESS 0 AND CUDA_HOST_COMPILER )
+-  if (CUDA_HOST_COMPILER STREQUAL "$(VCInstallDir)bin" AND DEFINED CCBIN)
+-    set(CCBIN -ccbin "${CCBIN}")
+-  else()
+-    set(CCBIN -ccbin "${CUDA_HOST_COMPILER}")
++  list( FIND CUDA_NVCC_FLAGS -ccbin ccbin_found0 )
++  list( FIND CUDA_NVCC_FLAGS --compiler-bindir ccbin_found1 )
++  if( ccbin_found0 LESS 0 AND ccbin_found1 LESS 0 AND CUDA_HOST_COMPILER )
++    if (CUDA_HOST_COMPILER STREQUAL "$(VCInstallDir)bin" AND DEFINED CCBIN)
++      set(CCBIN -ccbin "${CCBIN}")
++    else()
++      set(CCBIN -ccbin "${CUDA_HOST_COMPILER}")
++    endif()
+   endif()
+ endif()
+ 


### PR DESCRIPTION
Probably works across other 3.x versions as well.

Currently cmake ignores the -DCUDA_NVCC_FLAGS setting in ebuilds
and causes a nvcc fatal : redefinition of argument 'compiler-bindir'.
Removing these lines fixes the issue. Together with the
cuda.eclass that I proposed any ebuild with cuda build support
should build without issues (tested with flann-1.9.1::gentoo and
local pcl and opencv ebuilds)

This bug has already been reported here:
https://public.kitware.com/Bug/view.php?id=13674

Make sure that the ebuilds for cuda have something like this:

(...)
inherit cuda (...)
(...)

src_prepare() {
(...)
        use cuda && cuda_src_prepare
        cmake-utils_src_prepare
}

src_configure() {
(...)
        use cuda && mycmakeargs+=(
                -DCUDA_NVCC_FLAGS="${NVCCFLAGS},-arsch"
        )
        cmake-utils_src_configure
}

The PR for the cuda.eclass is here:
gentoo/gentoo#3013