### PR TITLE
sys-process/latencytop: Fix build with recent ncurses

### DIFF
--- a/sys-process/latencytop/files/latencytop-0.5-03-clean-up-build-system.patch
+++ b/sys-process/latencytop/files/latencytop-0.5-03-clean-up-build-system.patch
@@ -30,7 +30,7 @@ index de24551..9a3cc05 100644
 +override CFLAGS   += -Wno-sign-compare
 +override CPPFLAGS += `$(PKG_CONFIG) --cflags glib-2.0`
 +LDFLAGS ?= -Wl,--as-needed
-+LDADD    = `$(PKG_CONFIG) --libs glib-2.0` -lncursesw
++LDADD    = `$(PKG_CONFIG) --libs glib-2.0` `$(PKG_CONFIG) --libs ncursesw`
  
  OBJS= latencytop.o text_display.o translate.o fsync.o
  


### PR DESCRIPTION
...because the `tinfow` was not getting linked:

```
x86_64-pc-linux-gnu-gcc -O2 -pipe -march=native -ggdb -Wno-sign-compare -Wl,-O1 -Wl,--as-needed latencytop.o text_display.o translate.o fsync.o -o latencytop `x86_64-pc-linux-gnu-pkg-config --libs glib-2.0` -lncursesw
/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/../../../../x86_64-pc-linux-gnu/bin/ld: text_display.o: undefined reference to symbol 'curs_set'
/lib64/libtinfow.so.6: error adding symbols: DSO missing from command line
```