### PR TITLE
net-im/toxic: depend on slotted net-libs/tox

### DIFF
--- a/net-im/toxic/toxic-0.7.1.ebuild
+++ b/net-im/toxic/toxic-0.7.1.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="+X +av notifications"
 
 RDEPEND="
-	net-libs/tox[av?]
+	net-libs/tox:0/0.0[av?]
 	dev-libs/libconfig
 	media-gfx/qrencode
 	net-misc/curl


### PR DESCRIPTION
To make sure that it's compiling against the right API version.

Package-Manager: portage-2.3.0