### PR TITLE
net-im/qtox: depend on slotted net-libs/tox

### DIFF
--- a/net-im/qtox/qtox-1.5.0.ebuild
+++ b/net-im/qtox/qtox-1.5.0.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 			x11-libs/gtk+:2
 			x11-libs/cairo[X]
 			x11-libs/pango[X] )
-	net-libs/tox[av]
+	net-libs/tox:0/0.0[av]
 	X? ( x11-libs/libX11
 		x11-libs/libXScrnSaver )
 "

--- a/net-im/qtox/qtox-1.6.0.ebuild
+++ b/net-im/qtox/qtox-1.6.0.ebuild
@@ -39,7 +39,7 @@ RDEPEND="
 			x11-libs/gtk+:2
 			x11-libs/cairo[X]
 			x11-libs/pango[X] )
-	net-libs/tox[av]
+	net-libs/tox:0/0.0[av]
 	X? ( x11-libs/libX11
 		x11-libs/libXScrnSaver )
 "

--- a/net-im/qtox/qtox-9999.ebuild
+++ b/net-im/qtox/qtox-9999.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 			x11-libs/gtk+:2
 			x11-libs/cairo[X]
 			x11-libs/pango[X] )
-	net-libs/tox[av]
+	net-libs/tox:0/0.0[av]
 	X? ( x11-libs/libX11
 		x11-libs/libXScrnSaver )
 "


### PR DESCRIPTION
To make sure that it it's compiling against the right API version.
