### PR TITLE
app-admin/logcheck: update elog doc link, #534460

### DIFF
--- a/app-admin/logcheck/logcheck-1.3.15-r1.ebuild
+++ b/app-admin/logcheck/logcheck-1.3.15-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -41,6 +41,6 @@ src_install() {
 pkg_postinst() {
 	chown -R logcheck:logcheck /etc/logcheck /var/lib/logcheck || die
 
-	elog "Please read the guide ad https://www.gentoo.org/doc/en/logcheck.xml"
+	elog "Please read the guide at https://wiki.gentoo.org/wiki/Logcheck"
 	elog "for installation instructions."
 }

--- a/app-admin/logcheck/logcheck-1.3.15-r2.ebuild
+++ b/app-admin/logcheck/logcheck-1.3.15-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -47,6 +47,6 @@ src_install() {
 pkg_postinst() {
 	chown -R logcheck:logcheck /etc/logcheck /var/lib/logcheck || die
 
-	elog "Please read the guide ad https://www.gentoo.org/doc/en/logcheck.xml"
+	elog "Please read the guide at https://wiki.gentoo.org/wiki/Logcheck"
 	elog "for installation instructions."
 }

--- a/app-admin/logcheck/logcheck-1.3.16.ebuild
+++ b/app-admin/logcheck/logcheck-1.3.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -47,6 +47,6 @@ src_install() {
 pkg_postinst() {
 	chown -R logcheck:logcheck /etc/logcheck /var/lib/logcheck || die
 
-	elog "Please read the guide ad https://www.gentoo.org/doc/en/logcheck.xml"
+	elog "Please read the guide at https://wiki.gentoo.org/wiki/Logcheck"
 	elog "for installation instructions."
 }

--- a/app-admin/logcheck/logcheck-1.3.17.ebuild
+++ b/app-admin/logcheck/logcheck-1.3.17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -47,6 +47,6 @@ src_install() {
 pkg_postinst() {
 	chown -R logcheck:logcheck /etc/logcheck /var/lib/logcheck || die
 
-	elog "Please read the guide ad https://www.gentoo.org/doc/en/logcheck.xml"
+	elog "Please read the guide at https://wiki.gentoo.org/wiki/Logcheck"
 	elog "for installation instructions."
 }


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=534460

link to Gentoo wiki now instead of old documentation pages