### PR TITLE
mail-filter/disspam: update SRC_URI and HOMEPAGE, #321647

### DIFF
--- a/mail-filter/disspam/disspam-0.14.ebuild
+++ b/mail-filter/disspam/disspam-0.14.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 DESCRIPTION="A Perl script that removes spam from POP3 mailboxes based on RBLs"
-HOMEPAGE="http://www.topfx.com/"
-SRC_URI="http://www.topfx.com/dist/${P}.tar.gz"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="https://fossies.org/linux/privat/old/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="Artistic"


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=321647

Changed SRC_URI: md5sum for current ebuild fetch download was the same as the one from the new SRC_URI

Opted for "no_homepage", only sort of homepage available on fossies.org had a version specifier in it; https://fossies.org/dox/disspam-0.14/index.html