### PR TITLE
dev-util/ragel: Bump EAPI and add patches to fix test suite and gcc 6 compiles

### DIFF
--- a/dev-util/ragel/files/ragel-6.9+gcc-6.patch
+++ b/dev-util/ragel/files/ragel-6.9+gcc-6.patch
@@ -1,0 +1,41 @@
+--- ragel-6.9/ragel/common.cpp	2014-10-13 14:00:59.000000000 -0400
++++ ragel-6.9/ragel/common.cpp	2016-05-09 16:46:17.706100194 -0400
+@@ -34,7 +34,7 @@
+ 	{ "int",      0,       "int",     true,   true,  false,  INT_MIN,   INT_MAX,    sizeof(int) },
+ 	{ "unsigned", "int",   "uint",    false,  true,  false,  0,         UINT_MAX,   sizeof(unsigned int) },
+ 	{ "long",     0,       "long",    true,   true,  false,  LONG_MIN,  LONG_MAX,   sizeof(long) },
+-	{ "unsigned", "long",  "ulong",   false,  true,  false,  0,         ULONG_MAX,  sizeof(unsigned long) }
++	{ "unsigned", "long",  "ulong",   false,  true,  false,  0,         (long long)ULONG_MAX,  sizeof(unsigned long) }
+ };
+ 
+ #define S8BIT_MIN  -128
+@@ -87,7 +87,7 @@
+ 	{ "int32",   0,  "int32",   true,   true,  false,  S32BIT_MIN, S32BIT_MAX,  4 },
+ 	{ "uint32",  0,  "uint32",  false,  true,  false,  U32BIT_MIN, U32BIT_MAX,  4 },
+ 	{ "int64",   0,  "int64",   true,   true,  false,  S64BIT_MIN, S64BIT_MAX,  8 },
+-	{ "uint64",  0,  "uint64",  false,  true,  false,  U64BIT_MIN, U64BIT_MAX,  8 },
++	{ "uint64",  0,  "uint64",  false,  true,  false,  U64BIT_MIN, (long long)U64BIT_MAX,  8 },
+ 	{ "rune",    0,  "int32",   true,   true,  true,   S32BIT_MIN, S32BIT_MAX,  4 }
+ };
+ 
+@@ -116,7 +116,7 @@
+ 	{ "int",     0,  "int",     true,   true,  false,  INT_MIN,   INT_MAX,     4 },
+ 	{ "uint",    0,  "uint",    false,  true,  false,  0,         UINT_MAX,    4 },
+ 	{ "long",    0,  "long",    true,   true,  false,  LONG_MIN,  LONG_MAX,    8 },
+-	{ "ulong",   0,  "ulong",   false,  true,  false,  0,         ULONG_MAX,   8 }
++	{ "ulong",   0,  "ulong",   false,  true,  false,  0,         (long long)ULONG_MAX,   8 }
+ };
+ 
+ HostType hostTypesOCaml[] =
+--- ragel-6.9/ragel/rbxgoto.cpp	2014-10-13 14:00:59.000000000 -0400
++++ ragel-6.9/ragel/rbxgoto.cpp	2016-05-09 17:29:07.925220151 -0400
+@@ -658,7 +658,8 @@
+ 	out <<
+ 		"	begin\n"
+ 		"		" << P() << " += 1\n"
+-		"		" << rbxGoto(ret, "_out") << "\n" 
++		"		";
++		rbxGoto(ret, "_out") << "\n"
+ 		"	end\n";
+ }
+ 

--- a/dev-util/ragel/files/ragel-fix-atoi3-test.patch
+++ b/dev-util/ragel/files/ragel-fix-atoi3-test.patch
@@ -1,0 +1,11 @@
+--- a/test/atoi3.rl	2014-10-13 14:00:59.000000000 -0400
++++ b/test/atoi3.rl	2016-12-06 23:26:25.309623462 -0500
+@@ -12,7 +12,7 @@
+         neg = true;
+     }
+     action add_digit {
+-		val = val * 10 + (fc - "0"[0]);
++		val = val * 10 + (fc.to_i - ?0.ord);
+     }
+     action finish {
+ 		val = -1 * val if neg

--- a/dev-util/ragel/ragel-6.9-r1.ebuild
+++ b/dev-util/ragel/ragel-6.9-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+DESCRIPTION="Compiles finite state machines from regular languages into executable code"
+HOMEPAGE="http://www.colm.net/open-source/ragel/"
+SRC_URI="http://www.colm.net/files/ragel/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="vim-syntax test"
+
+DEPEND="test? (
+	amd64? ( dev-lang/go )
+	arm? ( dev-lang/go )
+	arm64? ( dev-lang/go )
+	ppc64? ( dev-lang/go )
+	x86? ( dev-lang/go )
+	amd64-fbsd? ( dev-lang/go )
+	x86-fbsd? ( dev-lang/go )
+	x64-macos? ( dev-lang/go )
+	x64-solaris? ( dev-lang/go )
+)"
+RDEPEND=""
+
+PATCHES=( "${FILESDIR}/ragel-6.9+gcc-6.patch"
+	"${FILESDIR}/ragel-fix-atoi3-test.patch" )
+
+src_test() {
+	cd "${S}"/test || die "Failed to change directory to test"
+	./runtests || die "Tests failed"
+}
+
+src_install() {
+	default
+
+	if use vim-syntax; then
+		insinto /usr/share/vim/vimfiles/syntax
+		doins ragel.vim
+	fi
+}


### PR DESCRIPTION
This bumps the EAPI to 6 and adds patches to fix the test suite against
ruby >1.9.  This also fixes the gcc 6 compile failures, with the patch
based off the one submitted to bug #582606.

Package-Manager: portage-2.2.28

I wasn't sure how to add the go dependency for the test suite.  It isn't necessary to run the test suite, so the other arches should be fine.  However, on arches with go I figured it be best to force the dependency.  Let me know if a different solution is preferred.  Or any other changes :)

Fixed bug https://bugs.gentoo.org/show_bug.cgi?id=582606