### PR TITLE
Fix CPU flag auto-detection in app-office/calligra (bug 584118)

### DIFF
--- a/app-office/calligra/calligra-2.9.11-r1.ebuild
+++ b/app-office/calligra/calligra-2.9.11-r1.ebuild
@@ -1,0 +1,236 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+# note: files that need to be checked for dependencies etc:
+# CMakeLists.txt, kexi/CMakeLists.txt kexi/migration/CMakeLists.txt
+# krita/CMakeLists.txt
+
+EAPI=5
+
+CHECKREQS_DISK_BUILD="4G"
+KDE_HANDBOOK="optional"
+KDE_LINGUAS_LIVE_OVERRIDE="true"
+OPENGL_REQUIRED="optional"
+WEBKIT_REQUIRED="optional"
+inherit check-reqs kde4-base versionator
+
+DESCRIPTION="KDE Office Suite"
+HOMEPAGE="http://www.calligra.org/"
+
+case ${PV} in
+	2.[456789].[789]?)
+		# beta or rc releases
+		SRC_URI="mirror://kde/unstable/${P}/${P}.tar.xz" ;;
+	2.[456789].?|2.[456789].??)
+		# stable releases
+		SRC_URI="mirror://kde/stable/${P}/${P}.tar.xz" ;;
+	2.[456789].9999)
+		# stable branch live ebuild
+		SRC_URI="" ;;
+	9999)
+		# master branch live ebuild
+		SRC_URI="" ;;
+esac
+
+LICENSE="GPL-2"
+SLOT="4"
+
+if [[ ${KDE_BUILD_TYPE} == release ]] ; then
+	KEYWORDS="amd64 ~arm x86"
+fi
+
+IUSE="attica color-management +crypt +eigen +exif fftw +fontconfig freetds
++glew +glib +gsf gsl import-filter +jpeg jpeg2k +kdcraw +lcms marble mysql
++okular openexr +pdf +pim postgres spacenav sybase test tiff +threads
++truetype vc xbase +xml"
+
+# Don't use Active, it's broken on desktops.
+CAL_FTS="author braindump flow gemini karbon kexi krita plan sheets stage words"
+for cal_ft in ${CAL_FTS}; do
+	IUSE+=" calligra_features_${cal_ft}"
+done
+unset cal_ft
+
+REQUIRED_USE="
+	calligra_features_author? ( calligra_features_words )
+	calligra_features_gemini? ( opengl )
+	calligra_features_krita? ( eigen exif lcms opengl )
+	calligra_features_plan? ( pim )
+	calligra_features_sheets? ( eigen )
+	calligra_features_stage? ( webkit )
+	vc? ( calligra_features_krita )
+	test? ( calligra_features_karbon )
+"
+
+RDEPEND="
+	dev-lang/perl
+	dev-libs/boost
+	dev-qt/qtcore:4[exceptions]
+	media-libs/libpng:0
+	sys-libs/zlib
+	virtual/libiconv
+	attica? ( dev-libs/libattica )
+	color-management? ( media-libs/opencolorio )
+	crypt? ( app-crypt/qca:2[qt4(+)] )
+	eigen? ( dev-cpp/eigen:3 )
+	exif? ( media-gfx/exiv2:= )
+	fftw? ( sci-libs/fftw:3.0 )
+	fontconfig? ( media-libs/fontconfig )
+	freetds? ( dev-db/freetds )
+	glib? ( dev-libs/glib:2 )
+	gsf? ( gnome-extra/libgsf )
+	gsl? ( sci-libs/gsl )
+	import-filter? (
+		app-text/libetonyek
+		app-text/libodfgen
+		app-text/libwpd:*
+		app-text/libwpg:*
+		app-text/libwps
+		dev-libs/librevenge
+		media-libs/libvisio
+	)
+	jpeg? ( virtual/jpeg:0 )
+	jpeg2k? ( media-libs/openjpeg:0 )
+	kdcraw? ( $(add_kdeapps_dep libkdcraw) )
+	lcms? (
+		media-libs/lcms:2
+		x11-libs/libX11
+	)
+	marble? ( $(add_kdeapps_dep marble) )
+	mysql? ( virtual/mysql )
+	okular? ( >=kde-apps/okular-4.4:4=[aqua=] )
+	opengl? (
+		media-libs/glew:0
+		virtual/glu
+	)
+	openexr? ( media-libs/openexr )
+	pdf? (
+		app-text/poppler:=
+		media-gfx/pstoedit
+	)
+	pim? ( $(add_kdeapps_dep kdepimlibs) )
+	postgres? (
+		dev-db/postgresql:*
+		dev-libs/libpqxx
+	)
+	spacenav? ( dev-libs/libspnav )
+	sybase? ( dev-db/freetds )
+	tiff? ( media-libs/tiff:0 )
+	truetype? ( media-libs/freetype:2 )
+	vc? ( <dev-libs/vc-1.0.0 )
+	xbase? ( dev-db/xbase )
+	calligra_features_kexi? (
+		>=dev-db/sqlite-3.8.7:3[extensions(+)]
+		dev-libs/icu:=
+	)
+	calligra_features_krita? (
+		dev-qt/qtdeclarative:4
+		net-misc/curl
+		x11-libs/libX11
+		x11-libs/libXi
+	)
+	calligra_features_words? ( dev-libs/libxslt )
+"
+DEPEND="${RDEPEND}
+	x11-misc/shared-mime-info
+"
+
+[[ ${PV} == 9999 ]] && LANGVERSION="2.9" || LANGVERSION="$(get_version_component_range 1-2)"
+PDEPEND=">=app-office/calligra-l10n-${LANGVERSION}"
+
+# bug 394273
+RESTRICT=test
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.9.1-no-arch-detection.patch
+)
+
+pkg_pretend() {
+	check-reqs_pkg_pretend
+}
+
+pkg_setup() {
+	kde4-base_pkg_setup
+	check-reqs_pkg_setup
+}
+
+src_prepare() {
+	if ! use webkit; then
+		sed -i CMakeLists.txt -e "/^find_package/ s/QtWebKit //" || die
+	fi
+	kde4-base_src_prepare
+}
+
+src_configure() {
+	local cal_ft myproducts
+
+	# applications
+	for cal_ft in ${CAL_FTS}; do
+		# Switch to ^^ when we switch to EAPI=6.
+		#local prod=${cal_ft^^}
+		local prod=$(tr '[:lower:]' '[:upper:]' <<<"${cal_ft}")
+		use calligra_features_${cal_ft} && myproducts+=( "${prod}" )
+	done
+
+	local mycmakeargs=( -DPRODUCTSET="${myproducts[*]}" )
+
+	# first write out things we want to hard-enable
+	mycmakeargs+=(
+		"-DWITH_Iconv=ON"            # available on all supported arches and many more
+	)
+
+	# default disablers
+	mycmakeargs+=(
+		"-DCREATIVEONLY=OFF"
+		"-DPACKAGERS_BUILD=OFF"
+		"-DWITH_Soprano=OFF"
+		"-DWITH_KActivities=OFF"	# deprecated Plasma 4 activities integration
+	)
+
+	# regular options
+	mycmakeargs+=(
+		$(cmake-utils_use_with attica LibAttica)
+		$(cmake-utils_use_with color-management OCIO)
+		$(cmake-utils_use_with crypt QCA2)
+		$(cmake-utils_use_with eigen Eigen3)
+		$(cmake-utils_use_with exif Exiv2)
+		$(cmake-utils_use_with fftw FFTW3)
+		$(cmake-utils_use_with fontconfig Fontconfig)
+		$(cmake-utils_use_with freetds FreeTDS)
+		$(cmake-utils_use_with glib GLIB2)
+		$(cmake-utils_use_with gsl GSL)
+		$(cmake-utils_use_with import-filter LibEtonyek)
+		$(cmake-utils_use_with import-filter LibOdfGen)
+		$(cmake-utils_use_with import-filter LibRevenge)
+		$(cmake-utils_use_with import-filter LibVisio)
+		$(cmake-utils_use_with import-filter LibWpd)
+		$(cmake-utils_use_with import-filter LibWpg)
+		$(cmake-utils_use_with import-filter LibWps)
+		$(cmake-utils_use_with jpeg JPEG)
+		$(cmake-utils_use_with jpeg2k OpenJPEG)
+		$(cmake-utils_use_with kdcraw Kdcraw)
+		$(cmake-utils_use_with lcms LCMS2)
+		$(cmake-utils_use_with marble CalligraMarble)
+		$(cmake-utils_use_with mysql MySQL)
+		$(cmake-utils_use_with okular Okular)
+		$(cmake-utils_use_with openexr OpenEXR)
+		$(cmake-utils_use opengl USEOPENGL)
+		$(cmake-utils_use_with pdf Poppler)
+		$(cmake-utils_use_with pdf Pstoedit)
+		$(cmake-utils_use_with pim KdepimLibs)
+		$(cmake-utils_use_with postgres CalligraPostgreSQL)
+		$(cmake-utils_use_build postgres pqxx)
+		$(cmake-utils_use_with spacenav Spnav)
+		$(cmake-utils_use_with sybase FreeTDS)
+		$(cmake-utils_use_with tiff TIFF)
+		$(cmake-utils_use_with threads Threads)
+		$(cmake-utils_use_with truetype Freetype)
+		$(cmake-utils_use_with vc Vc)
+		$(cmake-utils_use_with xbase XBase)
+	)
+
+	mycmakeargs+=( $(cmake-utils_use_build test cstester) )
+
+	kde4-base_src_configure
+}

--- a/app-office/calligra/calligra-2.9.11.ebuild
+++ b/app-office/calligra/calligra-2.9.11.ebuild
@@ -101,7 +101,7 @@ RDEPEND="
 	mysql? ( virtual/mysql )
 	okular? ( >=kde-apps/okular-4.4:4=[aqua=] )
 	opengl? (
-		media-libs/glew
+		media-libs/glew:0
 		virtual/glu
 	)
 	openexr? ( media-libs/openexr )

--- a/app-office/calligra/files/calligra-2.9.1-no-arch-detection.patch
+++ b/app-office/calligra/files/calligra-2.9.1-no-arch-detection.patch
@@ -1,0 +1,14 @@
+--- a/CMakeLists.txt	2016-12-07 12:48:03.771533639 -0200
++++ b/CMakeLists.txt	2016-12-07 12:49:07.534866207 -0200
+@@ -441,11 +441,6 @@
+         endif()
+         endmacro()
+     endif()
+-
+-    if (NOT PACKAGERS_BUILD)
+-      # Optimize the whole Calligra for current architecture
+-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Vc_DEFINITIONS}")
+-    endif ()
+ endif()
+ set(CMAKE_MODULE_PATH ${OLD_CMAKE_MODULE_PATH} )
+ 


### PR DESCRIPTION
Calligra auto-detects CPU flags via Vc's CMake macros. This applies a patch to respect the user's choices of CPU flags, to allow compilation on one system to run on another.

Please refer to the bug for more information: https://bugs.gentoo.org/584118