### PR TITLE
net-misc/livestreamer: update HOMEPAGE, #600456

### DIFF
--- a/net-misc/livestreamer/livestreamer-1.11.1.ebuild
+++ b/net-misc/livestreamer/livestreamer-1.11.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI="5"
 
 DESCRIPTION="CLI tool that pipes video streams from services like twitch.tv into a video player"
-HOMEPAGE="https://github.com/chrippa/livestreamer"
+HOMEPAGE="http://livestreamer.io/"
 SRC_URI="https://github.com/chrippa/livestreamer/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 PYTHON_COMPAT=( python{2_7,3_4} )

--- a/net-misc/livestreamer/livestreamer-1.12.1.ebuild
+++ b/net-misc/livestreamer/livestreamer-1.12.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI="5"
 
 DESCRIPTION="CLI tool that pipes video streams from services like twitch.tv into a video player"
-HOMEPAGE="https://github.com/chrippa/livestreamer"
+HOMEPAGE="http://livestreamer.io/"
 SRC_URI="https://github.com/chrippa/livestreamer/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 PYTHON_COMPAT=( python{2_7,3_4} )

--- a/net-misc/livestreamer/livestreamer-1.12.2.ebuild
+++ b/net-misc/livestreamer/livestreamer-1.12.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI="5"
 
 DESCRIPTION="CLI tool that pipes video streams from services like twitch.tv into a video player"
-HOMEPAGE="https://github.com/chrippa/livestreamer"
+HOMEPAGE="http://livestreamer.io/"
 SRC_URI="https://github.com/chrippa/livestreamer/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 PYTHON_COMPAT=( python{2_7,3_4} )


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=600456

Updated to livestreamer.io (without docs. subdomain). Github page says canonical version, which redirects to docs.

curl -LI http://livestreamer.io/