### PR TITLE
media-libs/aalib: revbump to fix undefined behavior

### DIFF
--- a/media-libs/aalib/aalib-1.4_rc5-r7.ebuild
+++ b/media-libs/aalib/aalib-1.4_rc5-r7.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit autotools-multilib eutils toolchain-funcs
+
+MY_P="${P/_/}"
+S="${WORKDIR}/${PN}-1.4.0"
+
+DESCRIPTION="A ASCII-Graphics Library"
+HOMEPAGE="http://aa-project.sourceforge.net/aalib/"
+SRC_URI="mirror://sourceforge/aa-project/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE="X slang gpm static-libs"
+
+RDEPEND="
+	X? ( >=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}] )
+	gpm? ( >=sys-libs/gpm-1.20.7-r2[${MULTILIB_USEDEP}] )
+	slang? ( >=sys-libs/slang-2.2.4-r1[${MULTILIB_USEDEP}] )
+	>=sys-libs/ncurses-5.9-r3:0=[${MULTILIB_USEDEP}]
+"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	X? ( x11-proto/xproto )
+"
+
+DOCS="ANNOUNCE AUTHORS ChangeLog NEWS README*"
+
+src_prepare() {
+	epatch "${FILESDIR}"/${PN}-1.4_rc4-gentoo.patch
+	epatch "${FILESDIR}"/${PN}-1.4_rc4-m4.patch
+	epatch "${FILESDIR}"/${PN}-1.4_rc5-fix-protos.patch #224267
+	epatch "${FILESDIR}"/${PN}-1.4_rc5-fix-aarender.patch #214142
+	epatch "${FILESDIR}"/${PN}-1.4_rc5-tinfo.patch #468566
+	epatch "${FILESDIR}"/${PN}-1.4_rc6-key-down-OOB.patch
+
+	sed -i -e 's:#include <malloc.h>:#include <stdlib.h>:g' "${S}"/src/*.c
+
+	# Fix bug #165617.
+	use gpm || sed -i \
+		's/gpm_mousedriver_test=yes/gpm_mousedriver_test=no/' "${S}/configure.in"
+
+	#467988 automake-1.13
+	mv configure.{in,ac} || die
+	sed -i 's/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g' configure.ac || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_with slang slang-driver)
+		$(use_with X x11-driver)
+		$(use_enable static-libs static)
+	)
+
+	PKG_CONFIG=$(tc-getPKG_CONFIG) \
+	autotools-multilib_src_configure
+}
+
+src_install() {
+	autotools-multilib_src_install
+	use static-libs || prune_libtool_files --all
+}

--- a/media-libs/aalib/files/aalib-1.4_rc6-key-down-OOB.patch
+++ b/media-libs/aalib/files/aalib-1.4_rc6-key-down-OOB.patch
@@ -1,0 +1,23 @@
+diff -Naur a/src/aalinuxkbd.c b/src/aalinuxkbd.c
+--- a/src/aalinuxkbd.c	2016-12-19 12:40:26.660039735 +0100
++++ b/src/aalinuxkbd.c	2016-12-19 12:42:21.692045971 +0100
+@@ -114,6 +114,7 @@
+ static int vtswitch_allowed;
+ 
+ static char key_down[128];
++static size_t key_down_size = 128;
+ static int closed = 1;
+ static int mypid;
+ 
+@@ -165,10 +166,7 @@
+ 
+ static void blank_key_down(void)
+ {
+-    int f;
+-
+-    for (f = 0; f < NR_KEYS; f++)
+-	key_down[f] = 0;
++    memset(key_down, 0, key_down_size);
+ }
+ 
+ 


### PR DESCRIPTION
During build, gcc generate this error and using `FEATURES=stricter`, it fails to merge
```
 * QA Notice: Package triggers severe warnings which indicate that it
 *            may exhibit random runtime failures.
 * /var/tmp/portage/media-libs/aalib-1.4_rc5-r6/work/aalib-1.4.0/src/aalinuxkbd.c:171:14: warning: iteration 128u invokes undefined behavior [-Waggressive-loop-optimizations]
```

There is also this message, but `media-libs/aalib` seems pretty dead development wise (15 years without release) and there is already a patchset in the tree
```
 * Please do not file a Gentoo bug and instead report the above QA
 * issues directly to the upstream developers of this software.
 * Homepage: http://aa-project.sourceforge.net/aalib/
```

So here goes a revdump with a patch, tested with `app-misc/bb` (but might need other tests)

The patch itself is simply a memset instead of a loop (not necessary but easier to read), and the range was reduced from 256 (current value of `NR_KEYS`) to 128 (the usable and used range)

Also, `KEYWORDS` is all `~` for now, which is the correct thing to do when revbump, right?