### PR TITLE
dev-util/colm: KEYWORD ~arm, correct HOMEPAGE and HTTPS SRC_URI

### DIFF
--- a/dev-util/colm/colm-0.13.0.4.ebuild
+++ b/dev-util/colm/colm-0.13.0.4.ebuild
@@ -5,12 +5,12 @@
 EAPI=6
 
 DESCRIPTION="COmputer Language Manipulation"
-HOMEPAGE="http://www.complang.org/colm/"
-SRC_URI="http://www.colm.net/files/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.colm.net/open-source/colm/"
+SRC_URI="https://www.colm.net/files/${PN}/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm ~x86"
 IUSE=""
 
 DEPEND=""


### PR DESCRIPTION
* ~arm tested on armv7a RK3288
* HOMEPAGE was out of date
* SRC_URI is available over HTTPS

Package-Manager: portage-2.3.0