### PR TITLE
dev-python/h5py: Fix dependecy on hdf5[hl]

### DIFF
--- a/dev-python/h5py/h5py-2.3.1.ebuild
+++ b/dev-python/h5py/h5py-2.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -18,7 +18,7 @@ KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
 IUSE="test examples mpi"
 
 RDEPEND="
-	sci-libs/hdf5:=[mpi=]
+	sci-libs/hdf5:=[mpi=,hl(+)]
 	dev-python/numpy[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]

--- a/dev-python/h5py/h5py-2.4.0.ebuild
+++ b/dev-python/h5py/h5py-2.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="test examples mpi"
 
 RDEPEND="
-	sci-libs/hdf5:=[mpi=]
+	sci-libs/hdf5:=[mpi=,hl(+)]
 	dev-python/numpy[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]

--- a/dev-python/h5py/h5py-2.5.0.ebuild
+++ b/dev-python/h5py/h5py-2.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc test examples mpi"
 
 RDEPEND="
-	sci-libs/hdf5:=[mpi=]
+	sci-libs/hdf5:=[mpi=,hl(+)]
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-python/six[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}

--- a/dev-python/h5py/h5py-2.6.0.ebuild
+++ b/dev-python/h5py/h5py-2.6.0.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc test examples mpi"
 
 RDEPEND="
-	sci-libs/hdf5:=[mpi=]
+	sci-libs/hdf5:=[mpi=,hl(+)]
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-python/six[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
With the stabilization of hdf5-1.8.18, rebuilding h5py fails as `hdf5_hl.h`, is included. This is only provided when hdf5 is build with the `hl` use flag. The `hl` use flag was introduced with hdf5-1.8.17.