### PR TITLE
sys-apps/yarn: added rdepend blocker to avoid collision with dev-util/cmdtest

### DIFF
--- a/sys-apps/yarn/yarn-0.18.0.ebuild
+++ b/sys-apps/yarn/yarn-0.18.0.ebuild
@@ -13,7 +13,8 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-RDEPEND="net-libs/nodejs"
+RDEPEND="!dev-util/cmdtest
+	net-libs/nodejs"
 DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/dist"

--- a/sys-apps/yarn/yarn-9999.ebuild
+++ b/sys-apps/yarn/yarn-9999.ebuild
@@ -15,7 +15,8 @@ SLOT="0"
 KEYWORDS=""
 IUSE=""
 
-RDEPEND="net-libs/nodejs"
+RDEPEND="!dev-util/cmdtest
+	net-libs/nodejs"
 DEPEND="${RDEPEND}"
 
 src_install() {


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=602168