### PR TITLE
dev-python/meld3: add py3.5, EAPI=6, fix license, deps and tests

### DIFF
--- a/dev-python/meld3/meld3-1.0.2.ebuild
+++ b/dev-python/meld3/meld3-1.0.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4} pypy )
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
 
 inherit distutils-r1
 
@@ -11,17 +11,12 @@ DESCRIPTION="meld3 is an HTML/XML templating engine"
 HOMEPAGE="https://github.com/supervisor/meld3 https://pypi.python.org/pypi/meld3"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
-LICENSE="ZPL"
+LICENSE="repoze"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
-RDEPEND="${DEPEND}"
-
-# tests use a local path.
-RESTRICT=test
 
 python_test() {
-	PYTHONPATH=. "${PYTHON}" ${PN}/test_${PN}.py || die "Tests failed under ${EPYTHON}"
+	esetup.py test
 }

--- a/dev-python/meld3/metadata.xml
+++ b/dev-python/meld3/metadata.xml
@@ -7,6 +7,7 @@
   </maintainer>
   <upstream>
     <remote-id type="pypi">meld3</remote-id>
-    <remote-id type="github">supervisor/meld3</remote-id>
+    <remote-id type="github">Supervisor/meld3</remote-id>
+    <bugs-to>https://github.com/Supervisor/meld3/issues</bugs-to>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
@SoapGentoo I'm not 100% sure we need a revbump since the setuptools RDEPEND doesn't seem like a big deal (everyone has it installed I guess).
Tests pass with Python 2.7, 3.4 and 3.5.