### PR TITLE
dev-util/aap: install aap as executable, #517848

### DIFF
--- a/dev-util/aap/aap-1.091-r2.ebuild
+++ b/dev-util/aap/aap-1.091-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -37,6 +37,7 @@ src_install() {
 	python_domodule .
 
 	# Create a symbolic link for the executable
+	chmod +x "${ED}"/usr/share/aap/aap
 	dosym ../share/aap/aap /usr/bin/aap
 	python_fix_shebang "${ED}"/usr/share/aap/aap
 }


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=517848