### PR TITLE
app-text/asciidoc fixups

### DIFF
--- a/app-text/asciidoc/asciidoc-8.6.9-r3.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r3.ebuild
@@ -70,10 +70,9 @@ src_install() {
 }
 
 src_test() {
-	cd tests || die
-	local -x ASCIIDOC_PY=../asciidoc.py
-	"${PYTHON}" test${PN}.py update || die
-	"${PYTHON}" test${PN}.py run || die
+	local -x ASCIIDOC_PY=asciidoc.py
+	"${PYTHON}" tests/test${PN}.py update || die
+	"${PYTHON}" tests/test${PN}.py run || die
 }
 
 pkg_postinst() {

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 PYTHON_COMPAT=( python2_7 pypy )
 
 [ "$PV" == "9999" ] && inherit git-r3 autotools
-inherit readme.gentoo python-single-r1
+inherit readme.gentoo-r1 python-single-r1
 
 DESCRIPTION="AsciiDoc is a plain text human readable/writable document format"
 HOMEPAGE="http://www.methods.co.nz/asciidoc/"
@@ -101,4 +101,8 @@ src_test() {
 	local -x ASCIIDOC_PY=asciidoc.py
 	"${PYTHON}" tests/test${PN}.py update || die
 	"${PYTHON}" tests/test${PN}.py run || die
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
 }

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -98,8 +98,7 @@ src_install() {
 }
 
 src_test() {
-	cd tests || die
-	local -x ASCIIDOC_PY=../asciidoc.py
-	"${PYTHON}" test${PN}.py update || die
-	"${PYTHON}" test${PN}.py run || die
+	local -x ASCIIDOC_PY=asciidoc.py
+	"${PYTHON}" tests/test${PN}.py update || die
+	"${PYTHON}" tests/test${PN}.py run || die
 }

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -6,13 +6,13 @@ EAPI=5
 
 PYTHON_COMPAT=( python2_7 pypy )
 
-[ "$PV" == "9999" ] && inherit mercurial autotools
+[ "$PV" == "9999" ] && inherit git-r3 autotools
 inherit readme.gentoo python-single-r1
 
 DESCRIPTION="AsciiDoc is a plain text human readable/writable document format"
 HOMEPAGE="http://www.methods.co.nz/asciidoc/"
 if [ "$PV" == "9999" ]; then
-	EHG_REPO_URI="https://asciidoc.googlecode.com/hg/"
+	EGIT_REPO_URI="https://github.com/asciidoc/asciidoc.git"
 	SRC_URI=""
 	KEYWORDS=""
 else

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -52,7 +52,6 @@ REQUISITES for a list of runtime dependencies.
 
 if [ "$PV" == "9999" ]; then
 	DEPEND="${DEPEND}
-		dev-util/aap
 		www-client/lynx
 		dev-util/source-highlight"
 fi
@@ -75,8 +74,12 @@ src_compile() {
 	default
 
 	if [ "$PV" == "9999" ]; then
-		cd doc || die
-		aap -f main.aap ../{CHANGELOG,README,BUGS} || die
+		# replicate build rules from doc/main.aap; this avoids a dependency on
+		# the A-A-P build tool
+		for f in CHANGELOG.txt BUGS.txt README.asciidoc; do
+			${PYTHON} asciidoc.py -f text.conf -n -b html4 -o - "$f" | \
+				lynx -dump -stdin > "${f%.*}" || die
+		done
 	fi
 }
 

--- a/app-text/asciidoc/asciidoc-9999.ebuild
+++ b/app-text/asciidoc/asciidoc-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=( python2_7 pypy )
 
@@ -58,6 +58,8 @@ if [ "$PV" == "9999" ]; then
 fi
 
 src_prepare() {
+	default
+
 	# Only needed for prefix - harmless (does nothing) otherwise
 	sed -i -e "s:^CONF_DIR=.*:CONF_DIR='${EPREFIX}/etc/asciidoc':" \
 		"${S}/asciidoc.py" || die


### PR DESCRIPTION
This PR contains a few fixup commits, mostly to the live ebuild.  In particular, this PR ought to fix https://bugs.gentoo.org/show_bug.cgi?id=599592.

Some questions:
- Should I squash all the live ebuild fixes together, or is this OK?
- Should I drop the Signed-Off-By lines?  I recall some discussion on gentoo-dev, but am not sure what the end result of that was.
- Did I overlook anything WRT EAPI 6?  I preferred switching to that for applying the patch rather than start using eutils.