### PR TITLE
sys-apps/mlocate: Revbump - cleanup temporary files at cron.daily job

### DIFF
--- a/sys-apps/mlocate/files/mlocate.cron-r3
+++ b/sys-apps/mlocate/files/mlocate.cron-r3
@@ -1,0 +1,51 @@
+#! /bin/sh
+set -e
+
+# check if we run on battery and if so then don't run
+if which on_ac_power >/dev/null 2>&1; then
+	ON_BATTERY=0
+	on_ac_power >/dev/null 2>&1 || ON_BATTERY=$?
+	if [ "${ON_BATTERY}" -eq 1 ]; then
+			exit 0
+	fi
+fi
+
+# check if we are already running (lockfile)
+LOCKFILE="/var/lock/mlocate.daily.lock"
+if [ -e "${LOCKFILE}" ]; then
+	echo >&2 "Warning: \"${LOCKFILE}\" already present, not running updatedb."
+	exit 1
+fi
+touch "${LOCKFILE}"
+# trap the lockfile only if we really run the updatedb
+trap "rm -f ${LOCKFILE}" EXIT
+
+# source the user specified variables
+if [ -f /etc/mlocate-cron.conf ]; then
+	. /etc/mlocate-cron.conf
+fi
+
+# check the config file
+NODEVS=""
+if [ ! -f /etc/updatedb.conf ]; then
+	NODEVS=$(awk '$1 == "nodev" && $2 != "rootfs" { print $2 }' /proc/filesystems)
+fi
+
+# alter the priority of the updatedb process
+if [ -x /usr/bin/renice ]; then
+	/usr/bin/renice +${NICE:-19} -p $$ > /dev/null 2>&1
+fi
+if [ -x /usr/bin/ionice ] && /usr/bin/ionice -c3 true 2>/dev/null; then
+	/usr/bin/ionice -c${IONICE_CLASS:-2} -n${IONICE_PRIORITY:-7} -p $$ > /dev/null 2>&1
+fi
+
+# Cleanup old temp files from previous unsuccessful runs
+rm -f /var/lib/mlocate/mlocate.db.*
+
+# run the updatedb if possible
+if [ -x /usr/bin/updatedb ]; then
+	/usr/bin/updatedb -f "${NODEVS}"
+else
+	echo >&2 "Warning: \"/usr/bin/updatedb\" is not executable, unable to run updatedb."
+	exit 0
+fi

--- a/sys-apps/mlocate/mlocate-0.26-r2.ebuild
+++ b/sys-apps/mlocate/mlocate-0.26-r2.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+inherit eutils user toolchain-funcs
+
+DESCRIPTION="Merging locate is an utility to index and quickly search for files"
+HOMEPAGE="https://fedorahosted.org/mlocate/"
+SRC_URI="https://fedorahosted.org/releases/m/l/mlocate/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+IUSE="nls selinux"
+
+RDEPEND="!sys-apps/slocate
+	!sys-apps/rlocate
+	selinux? ( sec-policy/selinux-slocate )"
+DEPEND="app-arch/xz-utils
+	nls? ( sys-devel/gettext )
+"
+
+pkg_setup() {
+	enewgroup locate
+}
+
+src_configure() {
+	econf $(use_enable nls)
+}
+
+src_compile() {
+	emake groupname=locate AR="$(tc-getAR)"
+}
+
+src_install() {
+	emake groupname=locate DESTDIR="${D}" install
+	dodoc AUTHORS ChangeLog README NEWS
+
+	insinto /etc
+	doins "${FILESDIR}"/updatedb.conf
+	doins "${FILESDIR}"/mlocate-cron.conf
+	fperms 0644 /etc/{updatedb,mlocate-cron}.conf
+
+	insinto /etc/cron.daily
+	newins "${FILESDIR}"/mlocate.cron-r3 mlocate
+	fperms 0755 /etc/cron.daily/mlocate
+
+	fowners 0:locate /usr/bin/locate
+	fperms go-r,g+s /usr/bin/locate
+
+	keepdir /var/lib/mlocate
+	chown -R 0:locate "${ED}"/var/lib/mlocate
+	fperms 0750 /var/lib/mlocate
+}
+
+pkg_postinst() {
+	elog "The database for the locate command is generated daily by a cron job,"
+	elog "if you install for the first time you can run the updatedb command manually now."
+	elog
+	elog "Note that the /etc/updatedb.conf file is generic,"
+	elog "please customize it to your system requirements."
+}


### PR DESCRIPTION
During updating database mlocate creates tmp-file. If daily cron job has failed
(for example, after reboot), tmp-files are left on disk.

In my case, these files are left untouched from 2015:

```
mlocate # ls -lah
total 11G
drwxr-x---  2 root locate 4.0K Dec 12 09:54 .
drwxr-xr-x 28 root root   4.0K Dec 12 03:10 ..
-rw-r--r--  1 root locate    0 Jun 25  2014 .keep_sys-apps_mlocate-0
  w-r-----  1 root locate 3.3G Feb 18  2016 mlocate.db
-rw-------  1 root root   3.2G May 31  2016 mlocate.db.1kB9qO
-rw-------  1 root root    46M Apr  4  2015 mlocate.db.6YfuHK
-rw-------  1 root root   9.6M Mar 28  2015 mlocate.db.8wSfKt
-rw-------  1 root root    36M Mar 18  2015 mlocate.db.B7B5Ct
-rw-------  1 root root   8.4M Mar 21  2015 mlocate.db.IHV6Uq
-rw-------  1 root root    10M Nov  9 03:11 mlocate.db.MJnd4V
-rw-------  1 root root   784M Feb 28  2015 mlocate.db.OCoR3o
-rw-------  1 root root    89M Mar 26  2015 mlocate.db.Q0Fohg
-rw-------  1 root root   1.5G Sep 21  2015 mlocate.db.qFcfDv
-rw-------  1 root root    41M Apr  2  2015 mlocate.db.SwNF6V
-rw-------  1 root root   1.2G Aug 24 06:50 mlocate.db.tpq3rq
-rw-------  1 root root    47M Mar 24  2015 mlocate.db.YIPk9Y

```

11 Gb!!! Since I have separate /var partition, someday (and this day is today) I got "insufficient space on the device" error.

Added "rm -f /var/lib/mlocate/mlocate.db.*" command before updatedb to delete these orphaned files.

Package-Manager: portage-2.3.0