### PR TITLE
net-misc/dhcpcd-ui-0.7.5-r1: Add dependency on qtsvg:4

### DIFF
--- a/net-misc/dhcpcd-ui/dhcpcd-ui-0.7.5-r1.ebuild
+++ b/net-misc/dhcpcd-ui/dhcpcd-ui-0.7.5-r1.ebuild
@@ -31,7 +31,9 @@ DEPEND="
 	gtk3? ( x11-libs/gtk+:3 )
 	qt4?  ( dev-qt/qtgui:4 )"
 
-RDEPEND=">=net-misc/dhcpcd-6.4.4"
+RDEPEND="
+	>=net-misc/dhcpcd-6.4.4
+	qt4? ( dev-qt/qtsvg:4  )"
 
 pkg_setup() {
 	if use qt4 ; then


### PR DESCRIPTION
net-misc/dhcpcd-ui-0.7.5-r1: Add dependency on qtsvg:4

This adds the runtime dependency on dev-qt/qtsvg:4

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=599288