### PR TITLE
net-proxy/haproxy: Handle stopping multiple proc

### DIFF
--- a/net-proxy/haproxy/files/haproxy.initd-r3
+++ b/net-proxy/haproxy/files/haproxy.initd-r3
@@ -60,6 +60,17 @@ stop_pre() {
 	fi
 }
 
+stop() {
+	local _t _pid
+
+	_t="$(mktemp)"
+	for _pid in $(cat ${pidfile}) ; do
+		echo "${_pid}" > "${_t}"
+		pidfile="${_t}" openrc_default_stop
+	done
+	rm -f "${_t}"
+}
+
 reload() {
 	checkconfig || { eerror "Reloading failed, please fix your config(s) first"; return 1; }
 


### PR DESCRIPTION
When haproxy is configured to use more than 1 proc, it creates a PID
file listing all PID, with 1 PID per line. Since start-stop-daemon only
handle 1 PID per pidfile, we need to had some magic in the init script in
order to stop every process haproxy previously started.

See: https://bugs.gentoo.org/show_bug.cgi?id=584410

Package-Manager: portage-2.3.0