### PR TITLE
Fix smartmontools ebuild warning - 

### DIFF
--- a/sys-apps/smartmontools/smartmontools-6.4-r1.ebuild
+++ b/sys-apps/smartmontools/smartmontools-6.4-r1.ebuild
@@ -14,7 +14,7 @@ else
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~x64-macos"
 fi
 
-DESCRIPTION="Self-Monitoring, Analysis and Reporting Technology System (S.M.A.R.T.) monitoring tools"
+DESCRIPTION="Tools to monitor storage systems to provide advanced warning of disk degradation"
 HOMEPAGE="https://www.smartmontools.org"
 
 LICENSE="GPL-2"
@@ -72,8 +72,8 @@ src_install() {
 		newconfd "${FILESDIR}"/smartd.confd smartd
 
 		# Move drivedb.h file out of PM's sight (bug #575292)
-		mv "${ED}"${db_path}/drivedb.h "${T}" || die
-		keepdir ${db_path}
+		mv "${ED}${db_path}/drivedb.h" "${T}" || die
+		keepdir "${db_path}"
 
 		exeinto /etc/cron.monthly
 		doexe "${FILESDIR}"/${PN}-update-drivedb
@@ -85,14 +85,14 @@ pkg_postinst() {
 		local db_path="/var/db/${PN}"
 
 		if [[ -f "${db_path}/drivedb.h" ]] ; then
-			ewarn "WARNING! The drive database file has been replaced with the version that"
-			ewarn "got shipped with this release of ${PN}. You may want to update the"
+			ewarn "WARNING! The existing copy of the drive database has been replaced with the version that"
+			ewarn "was shipped with this release of ${PN}. You may want to update the"
 			ewarn "database by running the following command as root:"
 			ewarn ""
 			ewarn "/usr/sbin/update-smart-drivedb"
 		fi
 
 		# Move drivedb.h to /var/db/${PN} (bug #575292)
-		mv "${T}"/drivedb.h ${db_path} || die
+		mv "${T}"/drivedb.h "${db_path}" || die
 	fi
 }

--- a/sys-apps/smartmontools/smartmontools-6.4.ebuild
+++ b/sys-apps/smartmontools/smartmontools-6.4.ebuild
@@ -14,8 +14,8 @@ else
 	KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~x64-macos"
 fi
 
-DESCRIPTION="Self-Monitoring, Analysis and Reporting Technology System (S.M.A.R.T.) monitoring tools"
-HOMEPAGE="http://smartmontools.sourceforge.net/"
+DESCRIPTION="Tools to monitor storage systems to provide advanced warning of disk degradation"
+HOMEPAGE="https://www.smartmontools.org"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/smartmontools/smartmontools-6.5.ebuild
+++ b/sys-apps/smartmontools/smartmontools-6.5.ebuild
@@ -14,7 +14,7 @@ else
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~x64-macos"
 fi
 
-DESCRIPTION="Self-Monitoring, Analysis and Reporting Technology System (S.M.A.R.T.) monitoring tools"
+DESCRIPTION="Tools to monitor storage systems to provide advanced warning of disk degradation"
 HOMEPAGE="https://www.smartmontools.org"
 
 LICENSE="GPL-2"
@@ -68,13 +68,13 @@ src_install() {
 		newinitd "${FILESDIR}"/smartd-r1.rc smartd
 		newconfd "${FILESDIR}"/smartd.confd smartd
 
-		keepdir ${db_path}
+		keepdir "${db_path}"
 		if use update_drivedb ; then
 			# Move drivedb.h file out of PM's sight (bug #575292)
-			mv "${ED}"${db_path}/drivedb.h "${T}" || die
+			mv "${ED}${db_path}/drivedb.h" "${T}" || die
 
 			exeinto /etc/cron.monthly
-			doexe "${FILESDIR}"/${PN}-update-drivedb
+			doexe "${FILESDIR}/${PN}-update-drivedb"
 		fi
 	fi
 }
@@ -84,16 +84,21 @@ pkg_postinst() {
 		local db_path="/var/db/${PN}"
 
 		if [[ -f "${db_path}/drivedb.h" ]] ; then
-			ewarn "WARNING! The drive database file has been replaced with the version that"
-			ewarn "got shipped with this release of ${PN}. You may want to update the"
-			ewarn "database by running the following command as root:"
+			ewarn "WARNING! The existing copy of the drive database has been replaced with the version that"
+			ewarn "was shipped with this release of ${PN}. You may want to update the"
+			ewarn "database by: "
+
+			if ! use update_drivedb ; then
+				ewarn "re-merging ${PN} with USE='update_drivedb', then"
+			fi
+			ewarn "running the following command as root:"
 			ewarn ""
 			ewarn "/usr/sbin/update-smart-drivedb"
 		fi
 
 		if use update_drivedb ; then
 			# Move drivedb.h to /var/db/${PN} (bug #575292)
-			mv "${T}"/drivedb.h ${db_path} || die
+			mv "${T}"/drivedb.h "${db_path}" || die
 		fi
 	fi
 }

--- a/sys-apps/smartmontools/smartmontools-9999.ebuild
+++ b/sys-apps/smartmontools/smartmontools-9999.ebuild
@@ -14,7 +14,7 @@ else
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~arm-linux ~ia64-linux ~x86-linux ~x64-macos"
 fi
 
-DESCRIPTION="Self-Monitoring, Analysis and Reporting Technology System (S.M.A.R.T.) monitoring tools"
+DESCRIPTION="Tools to monitor storage systems to provide advanced warning of disk degradation"
 HOMEPAGE="https://www.smartmontools.org"
 
 LICENSE="GPL-2"
@@ -68,13 +68,13 @@ src_install() {
 		newinitd "${FILESDIR}"/smartd-r1.rc smartd
 		newconfd "${FILESDIR}"/smartd.confd smartd
 
-		keepdir ${db_path}
+		keepdir "${db_path}"
 		if use update_drivedb ; then
 			# Move drivedb.h file out of PM's sight (bug #575292)
-			mv "${ED}"${db_path}/drivedb.h "${T}" || die
+			mv "${ED}${db_path}/drivedb.h" "${T}" || die
 
 			exeinto /etc/cron.monthly
-			doexe "${FILESDIR}"/${PN}-update-drivedb
+			doexe "${FILESDIR}/${PN}-update-drivedb"
 		fi
 	fi
 }
@@ -84,16 +84,21 @@ pkg_postinst() {
 		local db_path="/var/db/${PN}"
 
 		if [[ -f "${db_path}/drivedb.h" ]] ; then
-			ewarn "WARNING! The drive database file has been replaced with the version that"
-			ewarn "got shipped with this release of ${PN}. You may want to update the"
-			ewarn "database by running the following command as root:"
+			ewarn "WARNING! The existing copy of the drive database has been replaced with the version that"
+			ewarn "was shipped with this release of ${PN}. You may want to update the"
+			ewarn "database by: "
+
+			if ! use update_drivedb ; then
+				ewarn "re-merging ${PN} with USE='update_drivedb', then"
+			fi
+			ewarn "running the following command as root:"
 			ewarn ""
 			ewarn "/usr/sbin/update-smart-drivedb"
 		fi
 
 		if use update_drivedb ; then
 			# Move drivedb.h to /var/db/${PN} (bug #575292)
-			mv "${T}"/drivedb.h ${db_path} || die
+			mv "${T}"/drivedb.h "${db_path}" || die
 		fi
 	fi
 }


### PR DESCRIPTION
- fix name of command to update the drivedb (make a variable, so that it is common between usages)
- update warning about updating the drivedb, so that it notices the useflag
- fix description so that it's short enough (from the smartmontools website) -- repoman
- quote some variables -- shellcheck
- update the copy of the warning 

Gentoo bug: https://bugs.gentoo.org/show_bug.cgi?id=587372