### PR TITLE
dev-python/paramiko: fix EAPI 6 distutils EXAMPLES install, #595088

### DIFF
--- a/dev-python/paramiko/paramiko-2.0.2.ebuild
+++ b/dev-python/paramiko/paramiko-2.0.2.ebuild
@@ -33,7 +33,11 @@ python_test() {
 
 python_install_all() {
 	use doc && local HTML_DOCS=( docs/. )
-	use examples && local EXAMPLES=( demos/. )
 
 	distutils-r1_python_install_all
+
+	if use examples; then
+		insinto /usr/share/doc/${PF}/examples
+		doins demos/*
+	fi
 }


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=595088