### PR TITLE
kde-misc/krusader: Fix non-archive mimetypes

### DIFF
--- a/kde-misc/krusader/files/krusader-2.5.0-browse-iso.patch
+++ b/kde-misc/krusader/files/krusader-2.5.0-browse-iso.patch
@@ -1,0 +1,103 @@
+commit 101091f3521f75e301ae619ee0d698defcceca14
+Author: Martin Kostolný <clearmartin@zoho.com>
+Date:   Mon Dec 5 00:29:21 2016 +0100
+
+    Browse Archives As Folders option applied to iso files
+    
+    Differential Revision: https://phabricator.kde.org/D3429
+
+diff --git a/krusader/Panel/panelfunc.cpp b/krusader/Panel/panelfunc.cpp
+index bebc66d..ebcc5e2 100644
+--- a/krusader/Panel/panelfunc.cpp
++++ b/krusader/Panel/panelfunc.cpp
+@@ -130,7 +130,7 @@ bool ListPanelFunc::isSyncing(const QUrl &url)
+     return false;
+ }
+ 
+-void ListPanelFunc::openFileNameInternal(const QString &name, bool theFileCanBeExecutedOrOpenedWithOtherSoftware)
++void ListPanelFunc::openFileNameInternal(const QString &name, bool externallyExecutable)
+ {
+     if (name == "..") {
+         dirUp();
+@@ -153,15 +153,16 @@ void ListPanelFunc::openFileNameInternal(const QString &name, bool theFileCanBeE
+ 
+     QUrl arcPath = browsableArchivePath(name);
+     if (!arcPath.isEmpty()) {
+-        bool theArchiveMustBeBrowsedAsADirectory = (KConfigGroup(krConfig, "Archives").readEntry("ArchivesAsDirectories", _ArchivesAsDirectories) &&
+-                                                    KRarcHandler::arcSupported(mime)) || !theFileCanBeExecutedOrOpenedWithOtherSoftware;
+-        if (theArchiveMustBeBrowsedAsADirectory) {
++        bool browseAsDirectory = !externallyExecutable
++                || (KConfigGroup(krConfig, "Archives").readEntry("ArchivesAsDirectories", _ArchivesAsDirectories)
++                && (KRarcHandler::arcSupported(mime) || KrServices::isoSupported(mime)));
++        if (browseAsDirectory) {
+             openUrl(arcPath);
+             return;
+         }
+     }
+ 
+-    if (theFileCanBeExecutedOrOpenedWithOtherSoftware) {
++    if (externallyExecutable) {
+         if (KRun::isExecutableFile(url, mime)) {
+             runCommand(KShell::quoteArg(url.path()));
+             return;
+diff --git a/krusader/Panel/panelfunc.h b/krusader/Panel/panelfunc.h
+index 092224d..c31593b 100644
+--- a/krusader/Panel/panelfunc.h
++++ b/krusader/Panel/panelfunc.h
+@@ -137,7 +137,8 @@ protected slots:
+ protected:
+     QUrl cleanPath(const QUrl &url);
+     bool isSyncing(const QUrl &url);
+-    void openFileNameInternal(const QString &name, bool theFileCanBeExecutedOrOpenedWithOtherSoftware);
++    // when externallyExecutable == true, the file can be executed or opened with other software
++    void openFileNameInternal(const QString &name, bool externallyExecutable);
+     void openUrlInternal(const QUrl &url, const QString& makeCurrent,
+                          bool immediately, bool disableLock, bool manuallyEntered);
+     void runCommand(QString cmd);
+diff --git a/krusader/krservices.cpp b/krusader/krservices.cpp
+index dca4ae7..86bc0cf 100644
+--- a/krusader/krservices.cpp
++++ b/krusader/krservices.cpp
+@@ -32,8 +32,10 @@
+ QMap<QString, QString>* KrServices::slaveMap = 0;
+ #ifdef KRARC_QUERY_ENABLED
+ QSet<QString> KrServices::krarcArchiveMimetypes = QSet<QString>::fromList(KProtocolInfo::archiveMimetypes("krarc"));
++QSet<QString> KrServices::isoArchiveMimetypes = QSet<QString>::fromList(KProtocolInfo::archiveMimetypes("iso"));
+ #else
+ QSet<QString> KrServices::krarcArchiveMimetypes;
++QSet<QString> KrServices::isoArchiveMimetypes;
+ #endif
+ 
+ bool KrServices::cmdExist(QString cmdName)
+@@ -98,6 +100,11 @@ QString KrServices::registeredProtocol(QString mimetype)
+     return protocol;
+ }
+ 
++bool KrServices::isoSupported(QString mimetype)
++{
++    return isoArchiveMimetypes.contains(mimetype);
++}
++
+ void KrServices::clearProtocolCache()
+ {
+     if (slaveMap)
+diff --git a/krusader/krservices.h b/krusader/krservices.h
+index 14048e7..e9e805c 100644
+--- a/krusader/krservices.h
++++ b/krusader/krservices.h
+@@ -39,6 +39,7 @@ public:
+     static QString      chooseFullPathName(QStringList names, QString confName);
+     static QString      fullPathName(QString name, QString confName = QString());
+     static QString      registeredProtocol(QString mimetype);
++    static bool         isoSupported(QString mimetype);
+     static QString      urlToLocalPath(const QUrl &url);
+     static void         clearProtocolCache();
+     static bool         fileToStringList(QTextStream *stream, QStringList& target, bool keepEmptyLines = false);
+@@ -58,6 +59,7 @@ protected:
+ private:
+     static QMap<QString, QString>* slaveMap;
+     static QSet<QString> krarcArchiveMimetypes;
++    static QSet<QString> isoArchiveMimetypes;
+ 
+ };
+ 

--- a/kde-misc/krusader/files/krusader-2.5.0-fix-krarc-mime.patch
+++ b/kde-misc/krusader/files/krusader-2.5.0-fix-krarc-mime.patch
@@ -1,0 +1,27 @@
+commit e3fad5256a5cba9f908f1f5d951907c6194040b5
+Author: Martin T. H. Sandsmark <martin.sandsmark@kde.org>
+Date:   Sat Nov 19 13:14:00 2016 +0100
+
+    Remove non-archive mimetypes from krarc archive mime type list
+    
+    Putting non-archive mimetypes in the list of archive mimetypes confuses
+    other applications using KIO, like Dolphin. Getting Krusader to open
+    normal files as archives should be done by linking them in the Krusader
+    Protocol settings.
+    
+    BUG: 371765
+    REVIEW: 129434
+
+diff --git a/krArc/krarc.protocol b/krArc/krarc.protocol
+index 121a9d1..9783afd 100644
+--- a/krArc/krarc.protocol
++++ b/krArc/krarc.protocol
+@@ -1,7 +1,7 @@
+ [Protocol]
+ exec=kio_krarc
+ protocol=krarc
+-archiveMimetype=application/x-7z,application/x-7z-compressed,application/x-ace,application/x-ace-compressed,application/x-arj,application/x-arj-compressed,application/x-cpio,application/x-deb,application/x-debian-package,application/vnd.debian.binary-package,application/x-java-archive,application/x-lha,application/x-lha-compressed,application/x-rar,application/x-rar-compressed,application/x-rpm,application/x-source-rpm,application/zip,application/x-zip,application/x-zip-compressed,application/vnd.oasis.opendocument.chart,application/vnd.oasis.opendocument.database,application/vnd.oasis.opendocument.formula,application/vnd.oasis.opendocument.graphics,application/vnd.oasis.opendocument.presentation,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.text,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/x-cbz,application/x-cbr,application/epub+zip,application/x-webarchive,application/x-plasma
++archiveMimetype=application/x-7z,application/x-7z-compressed,application/x-ace,application/x-ace-compressed,application/x-arj,application/x-arj-compressed,application/x-cpio,application/x-lha,application/x-lha-compressed,application/x-rar,application/x-rar-compressed,application/zip,application/x-zip,application/x-zip-compressed
+ input=filesystem
+ output=filesystem
+ listing=Name,Type,Size,Date,Access,Owner,Group,Link

--- a/kde-misc/krusader/files/krusader-2.5.0-hardcode-krarc-mime.patch
+++ b/kde-misc/krusader/files/krusader-2.5.0-hardcode-krarc-mime.patch
@@ -1,0 +1,88 @@
+commit f57edb20c4fa4e53d6a245dcc81273b62e44f611
+Author: Martin Kostolný <clearmartin@zoho.com>
+Date:   Mon Dec 5 00:43:53 2016 +0100
+
+    Hard-code krarc.protocol mimetypes that were recently removed from protocol
+    
+    Differential Revision: https://phabricator.kde.org/D3566
+
+diff --git a/krusader/krservices.cpp b/krusader/krservices.cpp
+index 86bc0cf..b286066 100644
+--- a/krusader/krservices.cpp
++++ b/krusader/krservices.cpp
+@@ -30,14 +30,49 @@
+ #include "defaults.h"
+ 
+ QMap<QString, QString>* KrServices::slaveMap = 0;
++QSet<QString> KrServices::krarcArchiveMimetypes = KrServices::generateKrarcArchiveMimetypes();
+ #ifdef KRARC_QUERY_ENABLED
+-QSet<QString> KrServices::krarcArchiveMimetypes = QSet<QString>::fromList(KProtocolInfo::archiveMimetypes("krarc"));
+ QSet<QString> KrServices::isoArchiveMimetypes = QSet<QString>::fromList(KProtocolInfo::archiveMimetypes("iso"));
+ #else
+-QSet<QString> KrServices::krarcArchiveMimetypes;
+ QSet<QString> KrServices::isoArchiveMimetypes;
+ #endif
+ 
++QSet<QString> KrServices::generateKrarcArchiveMimetypes()
++{
++    // Hard-code these proven mimetypes openable by krarc protocol.
++    // They cannot be listed in krarc.protocol itself
++    // because it would baffle other file managers (like Dolphin).
++    QSet<QString> mimes;
++    mimes += QString("application/x-deb");
++    mimes += QString("application/x-debian-package");
++    mimes += QString("application/vnd.debian.binary-package");
++    mimes += QString("application/x-java-archive");
++    mimes += QString("application/x-rpm");
++    mimes += QString("application/x-source-rpm");
++    mimes += QString("application/vnd.oasis.opendocument.chart");
++    mimes += QString("application/vnd.oasis.opendocument.database");
++    mimes += QString("application/vnd.oasis.opendocument.formula");
++    mimes += QString("application/vnd.oasis.opendocument.graphics");
++    mimes += QString("application/vnd.oasis.opendocument.presentation");
++    mimes += QString("application/vnd.oasis.opendocument.spreadsheet");
++    mimes += QString("application/vnd.oasis.opendocument.text");
++    mimes += QString("application/vnd.openxmlformats-officedocument.presentationml.presentation");
++    mimes += QString("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
++    mimes += QString("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
++    mimes += QString("application/x-cbz");
++    mimes += QString("application/x-cbr");
++    mimes += QString("application/epub+zip");
++    mimes += QString("application/x-webarchive");
++    mimes += QString("application/x-plasma");
++    mimes += QString("application/vnd.rar");
++
++    #ifdef KRARC_QUERY_ENABLED
++    mimes += QSet<QString>::fromList(KProtocolInfo::archiveMimetypes("krarc"));
++    #endif
++
++    return mimes;
++}
++
+ bool KrServices::cmdExist(QString cmdName)
+ {
+     KConfigGroup group(krConfig, "Dependencies");
+diff --git a/krusader/krservices.h b/krusader/krservices.h
+index e9e805c..e54a0a6 100644
+--- a/krusader/krservices.h
++++ b/krusader/krservices.h
+@@ -32,9 +32,6 @@ class QFile;
+ class KrServices
+ {
+ public:
+-    KrServices() {}
+-    ~KrServices() {}
+-
+     static bool         cmdExist(QString cmdName);
+     static QString      chooseFullPathName(QStringList names, QString confName);
+     static QString      fullPathName(QString name, QString confName = QString());
+@@ -57,6 +54,9 @@ protected:
+     static QString    escape(QString name);
+ 
+ private:
++    KrServices() {}
++    ~KrServices() {}
++    static QSet<QString> generateKrarcArchiveMimetypes();
+     static QMap<QString, QString>* slaveMap;
+     static QSet<QString> krarcArchiveMimetypes;
+     static QSet<QString> isoArchiveMimetypes;

--- a/kde-misc/krusader/files/krusader-2.5.0-hardcode-krarc-mimes.patch
+++ b/kde-misc/krusader/files/krusader-2.5.0-hardcode-krarc-mimes.patch
@@ -1,0 +1,88 @@
+commit f57edb20c4fa4e53d6a245dcc81273b62e44f611
+Author: Martin Kostolný <clearmartin@zoho.com>
+Date:   Mon Dec 5 00:43:53 2016 +0100
+
+    Hard-code krarc.protocol mimetypes that were recently removed from protocol
+    
+    Differential Revision: https://phabricator.kde.org/D3566
+
+diff --git a/krusader/krservices.cpp b/krusader/krservices.cpp
+index 86bc0cf..b286066 100644
+--- a/krusader/krservices.cpp
++++ b/krusader/krservices.cpp
+@@ -30,14 +30,49 @@
+ #include "defaults.h"
+ 
+ QMap<QString, QString>* KrServices::slaveMap = 0;
++QSet<QString> KrServices::krarcArchiveMimetypes = KrServices::generateKrarcArchiveMimetypes();
+ #ifdef KRARC_QUERY_ENABLED
+-QSet<QString> KrServices::krarcArchiveMimetypes = QSet<QString>::fromList(KProtocolInfo::archiveMimetypes("krarc"));
+ QSet<QString> KrServices::isoArchiveMimetypes = QSet<QString>::fromList(KProtocolInfo::archiveMimetypes("iso"));
+ #else
+-QSet<QString> KrServices::krarcArchiveMimetypes;
+ QSet<QString> KrServices::isoArchiveMimetypes;
+ #endif
+ 
++QSet<QString> KrServices::generateKrarcArchiveMimetypes()
++{
++    // Hard-code these proven mimetypes openable by krarc protocol.
++    // They cannot be listed in krarc.protocol itself
++    // because it would baffle other file managers (like Dolphin).
++    QSet<QString> mimes;
++    mimes += QString("application/x-deb");
++    mimes += QString("application/x-debian-package");
++    mimes += QString("application/vnd.debian.binary-package");
++    mimes += QString("application/x-java-archive");
++    mimes += QString("application/x-rpm");
++    mimes += QString("application/x-source-rpm");
++    mimes += QString("application/vnd.oasis.opendocument.chart");
++    mimes += QString("application/vnd.oasis.opendocument.database");
++    mimes += QString("application/vnd.oasis.opendocument.formula");
++    mimes += QString("application/vnd.oasis.opendocument.graphics");
++    mimes += QString("application/vnd.oasis.opendocument.presentation");
++    mimes += QString("application/vnd.oasis.opendocument.spreadsheet");
++    mimes += QString("application/vnd.oasis.opendocument.text");
++    mimes += QString("application/vnd.openxmlformats-officedocument.presentationml.presentation");
++    mimes += QString("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
++    mimes += QString("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
++    mimes += QString("application/x-cbz");
++    mimes += QString("application/x-cbr");
++    mimes += QString("application/epub+zip");
++    mimes += QString("application/x-webarchive");
++    mimes += QString("application/x-plasma");
++    mimes += QString("application/vnd.rar");
++
++    #ifdef KRARC_QUERY_ENABLED
++    mimes += QSet<QString>::fromList(KProtocolInfo::archiveMimetypes("krarc"));
++    #endif
++
++    return mimes;
++}
++
+ bool KrServices::cmdExist(QString cmdName)
+ {
+     KConfigGroup group(krConfig, "Dependencies");
+diff --git a/krusader/krservices.h b/krusader/krservices.h
+index e9e805c..e54a0a6 100644
+--- a/krusader/krservices.h
++++ b/krusader/krservices.h
+@@ -32,9 +32,6 @@ class QFile;
+ class KrServices
+ {
+ public:
+-    KrServices() {}
+-    ~KrServices() {}
+-
+     static bool         cmdExist(QString cmdName);
+     static QString      chooseFullPathName(QStringList names, QString confName);
+     static QString      fullPathName(QString name, QString confName = QString());
+@@ -57,6 +54,9 @@ protected:
+     static QString    escape(QString name);
+ 
+ private:
++    KrServices() {}
++    ~KrServices() {}
++    static QSet<QString> generateKrarcArchiveMimetypes();
+     static QMap<QString, QString>* slaveMap;
+     static QSet<QString> krarcArchiveMimetypes;
+     static QSet<QString> isoArchiveMimetypes;

--- a/kde-misc/krusader/krusader-2.5.0-r1.ebuild
+++ b/kde-misc/krusader/krusader-2.5.0-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+KDE_HANDBOOK="forceoptional"
+inherit kde5
+
+DESCRIPTION="An advanced twin-panel (commander-style) file-manager with many extras"
+HOMEPAGE="https://krusader.org/"
+[[ ${KDE_BUILD_TYPE} = release ]] && SRC_URI="mirror://kde/stable/${PN}/${PV}/${P}.tar.xz"
+
+LICENSE="GPL-2+"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+DEPEND="
+	$(add_frameworks_dep karchive)
+	$(add_frameworks_dep kbookmarks)
+	$(add_frameworks_dep kcodecs)
+	$(add_frameworks_dep kcompletion)
+	$(add_frameworks_dep kconfig)
+	$(add_frameworks_dep kconfigwidgets)
+	$(add_frameworks_dep kcoreaddons)
+	$(add_frameworks_dep kguiaddons)
+	$(add_frameworks_dep ki18n)
+	$(add_frameworks_dep kiconthemes)
+	$(add_frameworks_dep kio)
+	$(add_frameworks_dep kitemviews)
+	$(add_frameworks_dep kjobwidgets)
+	$(add_frameworks_dep knotifications)
+	$(add_frameworks_dep kparts)
+	$(add_frameworks_dep kservice)
+	$(add_frameworks_dep ktextwidgets)
+	$(add_frameworks_dep kwallet)
+	$(add_frameworks_dep kwidgetsaddons)
+	$(add_frameworks_dep kwindowsystem)
+	$(add_frameworks_dep kxmlgui)
+	$(add_frameworks_dep solid)
+	$(add_qt_dep qtdbus)
+	$(add_qt_dep qtgui)
+	$(add_qt_dep qtprintsupport)
+	$(add_qt_dep qtwidgets)
+	$(add_qt_dep qtxml)
+	sys-apps/acl
+	sys-libs/zlib
+"
+RDEPEND="${DEPEND}
+	!kde-misc/krusader:4
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}"-fix-krarc-mime.patch
+	"${FILESDIR}/${P}"-browse-iso.patch
+	"${FILESDIR}/${P}"-hardcode-krarc-mime.patch
+)


### PR DESCRIPTION
Quoting upstream bug:
"Putting non-archive mimetypes in the list of archive mimetypes confuses
other applications using KIO, like Dolphin*. Getting Krusader to open
normal files as archives should be done by linking them in the Krusader
Protocol settings."

* e.g. opening OpenDocument files as archives

Package-Manager: portage-2.3.0