### PR TITLE
app-text/wgetpaste: Add wget SSL support

### DIFF
--- a/app-text/wgetpaste/wgetpaste-2.28-r1.ebuild
+++ b/app-text/wgetpaste/wgetpaste-2.28-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+DESCRIPTION="Command-line interface to various pastebins"
+HOMEPAGE="http://wgetpaste.zlin.dk/"
+SRC_URI="http://wgetpaste.zlin.dk/${P}.tar.bz2"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+IUSE="+ssl"
+
+DEPEND=""
+RDEPEND="net-misc/wget[ssl?]"
+
+src_prepare() {
+	sed -i -e "s:/etc:\"${EPREFIX}\"/etc:g" wgetpaste || die
+	default
+}
+
+src_install() {
+	dobin ${PN}
+	insinto /usr/share/zsh/site-functions
+	doins _wgetpaste
+}


### PR DESCRIPTION
Many of the paste bins wgetpaste supports require SSL.  This includes
the current default paste bin.  Without wget SSL support, these paste
bins are not accessible.  This change allows wgetpaste to depend on
ssl-enabled wget.

Package-Manager: Portage-2.3.3, Repoman-2.3.1