### PR TITLE
sys-process/htop: express lsof RDEPEND as a USE flag

### DIFF
--- a/sys-process/htop/htop-2.0.2-r1.ebuild
+++ b/sys-process/htop/htop-2.0.2-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit autotools linux-info
+
+DESCRIPTION="interactive process viewer"
+HOMEPAGE="http://hisham.hm/htop/"
+SRC_URI="http://hisham.hm/htop/releases/${PV}/${P}.tar.gz"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="files kernel_FreeBSD kernel_linux openvz unicode vserver"
+
+RDEPEND="sys-libs/ncurses:0=[unicode?]
+	files? ( sys-process/lsof )"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+DOCS=( ChangeLog README )
+
+CONFIG_CHECK="~TASKSTATS ~TASK_XACCT ~TASK_IO_ACCOUNTING ~CGROUPS"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.0.2-tinfo.patch"
+)
+
+src_prepare() {
+	rm missing || die
+
+	default
+	eautoreconf
+}
+
+src_configure() {
+	[[ $CBUILD != $CHOST ]] && export ac_cv_file__proc_{meminfo,stat}=yes #328971
+
+	local myeconfargs=()
+
+	myeconfargs+=(
+		# fails to build against recent hwloc versions
+		--disable-hwloc
+		--enable-taskstats
+		$(use_enable kernel_linux cgroup)
+		$(use_enable kernel_linux linux-affinity)
+		$(use_enable openvz)
+		$(use_enable unicode)
+		$(use_enable vserver)
+	)
+	econf ${myeconfargs[@]}
+}

--- a/sys-process/htop/metadata.xml
+++ b/sys-process/htop/metadata.xml
@@ -10,6 +10,7 @@
 		<name>Lars Wendler</name>
 	</maintainer>
 	<use>
+		<flag name="files">Allow htop to show what processes are accessing what files by using <pkg>sys-process/lsof</pkg>.</flag>
 		<flag name="oom">Add column to track the OOM-killer score of processes</flag>
 		<flag name="openvz">Enable openvz support</flag>
 		<flag name="vserver">Enable vserver support</flag>


### PR DESCRIPTION
Expressing a possible RDEPEND as an einfo isn't optimal for people
trying to roll out configs where everything works the same across many
machines.

Signed-off-by: Doug Goldstein <cardoe@gentoo.org>