### PR TITLE
net-nds/389-ds-base: Revbump to add build patch provided by upstream

### DIFF
--- a/net-nds/389-ds-base/389-ds-base-1.3.5.15-r1.ebuild
+++ b/net-nds/389-ds-base/389-ds-base-1.3.5.15-r1.ebuild
@@ -51,6 +51,8 @@ pkg_setup() {
 }
 
 src_prepare() {
+	epatch "${FILESDIR}/389-ds-base-1.3.5-stdc.patch"
+
 	# as per 389 documentation, when 64bit, export USE_64
 	use amd64 && export USE_64=1
 

--- a/net-nds/389-ds-base/files/389-ds-base-1.3.5-stdc.patch
+++ b/net-nds/389-ds-base/files/389-ds-base-1.3.5-stdc.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 3e0f8aa..846e3b4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -29,6 +29,7 @@ AC_PROG_CXX
+ AC_PROG_CC
+ AM_PROG_CC_C_O
+ AM_PROG_AS
++AC_PROG_CC_STDC
+ # disable static libs by default - we only use a couple
+ AC_DISABLE_STATIC
+ AC_PROG_LIBTOOL
+


### PR DESCRIPTION
Adds AC_PROG_CC_STDC to configure.ac

Closes bug 602718

Acked-by: wibrown@redhat.com

Package-Manager: portage-2.3.2