### PR TITLE
net-im/qtox: make live ebuild depend on net-libs/tox:0/0.1

### DIFF
--- a/net-im/qtox/qtox-9999.ebuild
+++ b/net-im/qtox/qtox-9999.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 			x11-libs/gtk+:2
 			x11-libs/cairo[X]
 			x11-libs/pango[X] )
-	net-libs/tox:0/0.0[av]
+	net-libs/tox:0/0.1[av]
 	X? ( x11-libs/libX11
 		x11-libs/libXScrnSaver )
 "


### PR DESCRIPTION
Updated to upstream changes.

Depends on #3117 / #3140