### PR TITLE
net-dns/libidn2: add DEPEND on help2man, #602970

### DIFF
--- a/net-dns/libidn2/libidn2-0.11.ebuild
+++ b/net-dns/libidn2/libidn2-0.11.ebuild
@@ -13,6 +13,8 @@ LICENSE="GPL-2+ LGPL-3+"
 SLOT="0"
 KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 x86"
 IUSE="static-libs"
+DEPEND="sys-apps/help2man"
+RDEPEND=""
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.10-examples.patch


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/602970
