### PR TITLE
net-wireless/wpa_supplicant: enable MATCH_IFACE

### DIFF
--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.6-r1.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.6-r1.ebuild
@@ -132,6 +132,7 @@ src_configure() {
 
 	# Basic setup
 	Kconfig_style_config CTRL_IFACE
+	Kconfig_style_config MATCH_IFACE
 	Kconfig_style_config BACKEND file
 	Kconfig_style_config IBSS_RSN
 	Kconfig_style_config IEEE80211W


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=596606
See https://forums.gentoo.org/viewtopic-p-7974604.html#7974604