### PR TITLE
kde-apps/okular: Add missing DEPEND

### DIFF
--- a/kde-apps/okular/okular-16.12.0.ebuild
+++ b/kde-apps/okular/okular-16.12.0.ebuild
@@ -28,6 +28,7 @@ DEPEND="
 	$(add_frameworks_dep kjs)
 	$(add_frameworks_dep kparts)
 	$(add_frameworks_dep kwallet)
+	$(add_frameworks_dep kpty)
 	$(add_frameworks_dep threadweaver)
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtgui)


### PR DESCRIPTION
Gentoo-bug: 603084

Package-Manager: portage-2.3.0