### PR TITLE
app-admin/salt: random_org unittest was moved to integration tests

### DIFF
--- a/app-admin/salt/salt-9999.ebuild
+++ b/app-admin/salt/salt-9999.ebuild
@@ -89,7 +89,7 @@ RESTRICT="x86? ( test )"
 python_prepare() {
 	# this test fails because it trys to "pip install distribute"
 	rm tests/unit/{modules,states}/zcbuildout_test.py \
-		tests/unit/modules/{rh_ip,win_network,random_org}_test.py || die
+		tests/unit/modules/{rh_ip,win_network}_test.py || die
 
 	# apparently libcloud does not know about this?
 	rm tests/unit/cloud/clouds/dimensiondata_test.py || die


### PR DESCRIPTION
Upstream moved the unittest `random_org_test.py` to the integration
tests in 671cebfa30, so it doesn't have to be removed by the ebuild
anymore which failed since upstream's changes.

Package-Manager: Portage-2.3.0, Repoman-2.3.1