### PR TITLE
app-vim/vimoutliner: update HOMEPAGE, #515092

### DIFF
--- a/app-vim/vimoutliner/metadata.xml
+++ b/app-vim/vimoutliner/metadata.xml
@@ -5,4 +5,7 @@
 		<email>vim@gentoo.org</email>
 		<name>Gentoo Vim Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">vimoutliner/vimoutliner</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/app-vim/vimoutliner/vimoutliner-0.3.4-r2.ebuild
+++ b/app-vim/vimoutliner/vimoutliner-0.3.4-r2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: easy and fast outlining"
-HOMEPAGE="http://www.vimoutliner.org/"
+HOMEPAGE="https://github.com/vimoutliner/vimoutliner"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 LICENSE="GPL-2"
 KEYWORDS="alpha amd64 ia64 ~mips ppc sparc x86"

--- a/app-vim/vimoutliner/vimoutliner-0.3.6.ebuild
+++ b/app-vim/vimoutliner/vimoutliner-0.3.6.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: easy and fast outlining"
-HOMEPAGE="http://www.vimoutliner.org/"
+HOMEPAGE="https://github.com/vimoutliner/vimoutliner"
 SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.zip -> ${P}.zip"
 LICENSE="GPL-2"
 KEYWORDS="~alpha ~amd64 ~ia64 ~mips ~ppc ~sparc ~x86"


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/515092

also added upstream remote id to metadata