### PR TITLE
Qscintilla qt5

### DIFF
--- a/app-editors/juffed/juffed-0.10-r1.ebuild
+++ b/app-editors/juffed/juffed-0.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-qt/qtcore:4
 	dev-qt/qtgui:4
 	dev-qt/qtsingleapplication[qt4(+),X]
-	x11-libs/qscintilla:=
+	x11-libs/qscintilla:=[qt4(-)]
 "
 DEPEND="${RDEPEND}"
 

--- a/app-editors/qwriter/qwriter-0.1.9-r2.ebuild
+++ b/app-editors/qwriter/qwriter-0.1.9-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -20,7 +20,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="dev-qt/qtgui:4
-	x11-libs/qscintilla"
+	x11-libs/qscintilla:=[qt4(-)]"
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${MY_P}"

--- a/app-leechcraft/lc-popishu/lc-popishu-0.6.60-r1.ebuild
+++ b/app-leechcraft/lc-popishu/lc-popishu-0.6.60-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -9,9 +9,9 @@ inherit leechcraft
 DESCRIPTION="Popishu, the text editor with IDE features for LeechCraft"
 
 SLOT="0"
-KEYWORDS=" ~amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	x11-libs/qscintilla"
+	x11-libs/qscintilla[qt4(-)]"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-popishu/lc-popishu-0.6.65-r1.ebuild
+++ b/app-leechcraft/lc-popishu/lc-popishu-0.6.65-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -9,9 +9,9 @@ inherit leechcraft
 DESCRIPTION="Popishu, the text editor with IDE features for LeechCraft"
 
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS=" ~amd64 ~x86"
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	x11-libs/qscintilla"
+	x11-libs/qscintilla[qt4(-)]"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-popishu/lc-popishu-0.6.70-r1.ebuild
+++ b/app-leechcraft/lc-popishu/lc-popishu-0.6.70-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,5 +13,5 @@ KEYWORDS=" amd64 ~x86"
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	x11-libs/qscintilla"
+	x11-libs/qscintilla[qt4(-)]"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-popishu/lc-popishu-9999.ebuild
+++ b/app-leechcraft/lc-popishu/lc-popishu-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,5 +13,5 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	x11-libs/qscintilla"
+	x11-libs/qscintilla[qt4(-)]"
 RDEPEND="${DEPEND}"

--- a/dev-db/sqlitebrowser/sqlitebrowser-3.8.0-r1.ebuild
+++ b/dev-db/sqlitebrowser/sqlitebrowser-3.8.0-r1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-cpp/antlr-cpp:2
 	dev-db/sqlite:3
 	dev-libs/qcustomplot[qt5=]
-	x11-libs/qscintilla
+	x11-libs/qscintilla:=
 	!qt5? (
 		dev-qt/qtcore:4
 		dev-qt/qtgui:4

--- a/dev-db/sqlitebrowser/sqlitebrowser-3.9.1-r1.ebuild
+++ b/dev-db/sqlitebrowser/sqlitebrowser-3.9.1-r1.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtnetwork:5
 	dev-qt/qtwidgets:5
-	x11-libs/qscintilla
+	>=x11-libs/qscintilla-2.9.3-r2:=[qt5(+)]
 "
 DEPEND="${RDEPEND}
 	dev-qt/linguist-tools:5

--- a/dev-db/sqliteman/sqliteman-1.2.2-r2.ebuild
+++ b/dev-db/sqliteman/sqliteman-1.2.2-r2.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-qt/qtcore:4
 	dev-qt/qtgui:4
 	dev-qt/qtsql:4[sqlite]
-	x11-libs/qscintilla"
+	x11-libs/qscintilla:=[qt4(-)]"
 DEPEND="${RDEPEND}"
 
 DOCS=( AUTHORS README )
@@ -27,7 +27,7 @@ PATCHES=( "${FILESDIR}/${P}-lpthread.patch" )
 
 src_prepare() {
 	# remove bundled lib
-	rm -rf "${S}"/${PN}/qscintilla2
+	rm -rf "${S}"/${PN}/qscintilla2 || die
 
 	cmake-utils_src_prepare
 }

--- a/dev-db/tora/tora-3.0.0_pre20140929-r2.ebuild
+++ b/dev-db/tora/tora-3.0.0_pre20140929-r2.ebuild
@@ -24,14 +24,13 @@ KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
 	dev-libs/ferrisloki
-	x11-libs/qscintilla
+	x11-libs/qscintilla:=[qt4(-)]
 	dev-qt/qtgui:4
 	dev-qt/qtsql:4[mysql?,postgres?]
 	dev-qt/qtxmlpatterns:4
 	=dev-db/oracle-instantclient-basic-11*
-	postgres? ( dev-db/postgresql )
+	postgres? ( dev-db/postgresql:* )
 "
-
 DEPEND="
 	virtual/pkgconfig
 	${RDEPEND}

--- a/dev-db/tora/tora-9999.ebuild
+++ b/dev-db/tora/tora-9999.ebuild
@@ -22,17 +22,19 @@ SLOT="0"
 LICENSE="GPL-2"
 KEYWORDS=""
 
-DEPEND="
-	virtual/pkgconfig
+RDEPEND="
 	dev-libs/ferrisloki
-	x11-libs/qscintilla
+	x11-libs/qscintilla:=[qt4(-)]
 	dev-qt/qtgui:4
 	dev-qt/qtsql:4[mysql?,postgres?]
 	dev-qt/qtxmlpatterns:4
 	oci8-instant-client? ( dev-db/oracle-instantclient-basic )
-	postgres? ( dev-db/postgresql )
+	postgres? ( dev-db/postgresql:* )
 "
-RDEPEND="${DEPEND}"
+DEPEND="
+	virtual/pkgconfig
+	${RDEPEND}
+"
 
 pkg_setup() {
 	if ( use oracle || use oci8-instant-client ) && [ -z "$ORACLE_HOME" ] ; then

--- a/dev-python/qscintilla-python/qscintilla-python-2.8.4-r1.ebuild
+++ b/dev-python/qscintilla-python/qscintilla-python-2.8.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -24,7 +24,7 @@ DEPEND="
 	>=dev-python/PyQt4-4.11[X,${PYTHON_USEDEP}]
 	dev-qt/qtcore:4
 	dev-qt/qtgui:4
-	~x11-libs/qscintilla-${PV}:=
+	~x11-libs/qscintilla-${PV}:=[qt4(-)]
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-python/qscintilla-python/qscintilla-python-2.9.2-r1.ebuild
+++ b/dev-python/qscintilla-python/qscintilla-python-2.9.2-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="mirror://sourceforge/pyqt/${MY_P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="alpha amd64 ~ia64 ~ppc ppc64 ~sparc x86"
 IUSE="debug"
 
 DEPEND="
@@ -24,7 +24,7 @@ DEPEND="
 	>=dev-python/PyQt4-4.11.3[X,${PYTHON_USEDEP}]
 	dev-qt/qtcore:4
 	dev-qt/qtgui:4
-	~x11-libs/qscintilla-${PV}:=
+	~x11-libs/qscintilla-${PV}:=[qt4(-)]
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-python/qscintilla-python/qscintilla-python-2.9.3-r1.ebuild
+++ b/dev-python/qscintilla-python/qscintilla-python-2.9.3-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="mirror://sourceforge/pyqt/${MY_P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="alpha amd64 ~ia64 ~ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="debug"
 
 DEPEND="
@@ -24,7 +24,7 @@ DEPEND="
 	>=dev-python/PyQt4-4.11.3[X,${PYTHON_USEDEP}]
 	dev-qt/qtcore:4
 	dev-qt/qtgui:4
-	~x11-libs/qscintilla-${PV}:=
+	~x11-libs/qscintilla-${PV}:=[qt4(-)]
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-util/kscope/kscope-1.9.4-r2.ebuild
+++ b/dev-util/kscope/kscope-1.9.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="dev-qt/qtcore:4
 	dev-qt/qtgui:4
-	x11-libs/qscintilla"
+	x11-libs/qscintilla:=[qt4(-)]"
 DEPEND="${RDEPEND}"
 
 DOCS="ChangeLog"

--- a/dev-util/monkeystudio/monkeystudio-1.9.0.4-r1.ebuild
+++ b/dev-util/monkeystudio/monkeystudio-1.9.0.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-qt/qtgui:4
 	dev-qt/qthelp:4
 	dev-qt/qtsql:4
-	x11-libs/qscintilla:=
+	x11-libs/qscintilla:=[qt4(-)]
 	plugins? ( dev-qt/qtwebkit:4 )
 "
 DEPEND="${RDEPEND}

--- a/dev-util/universalindentgui/universalindentgui-1.2.0-r2.ebuild
+++ b/dev-util/universalindentgui/universalindentgui-1.2.0-r2.ebuild
@@ -20,7 +20,7 @@ IUSE="debug examples html perl php python ruby xml"
 DEPEND="dev-qt/qtcore:4
 	dev-qt/qtgui:4
 	dev-qt/qtscript:4
-	x11-libs/qscintilla
+	x11-libs/qscintilla[qt4(-)]
 "
 RDEPEND="${DEPEND}
 	dev-util/astyle

--- a/media-gfx/openscad/openscad-2015.03-r1.ebuild
+++ b/media-gfx/openscad/openscad-2015.03-r1.ebuild
@@ -2,15 +2,13 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=6
+EAPI=5
 
-inherit eutils qmake-utils
-
-MY_PV="2015.03-2"
+inherit qt4-r2
 
 DESCRIPTION="The Programmers Solid 3D CAD Modeller"
 HOMEPAGE="http://www.openscad.org/"
-SRC_URI="http://files.openscad.org/${PN}-${MY_PV}.src.tar.gz"
+SRC_URI="http://files.openscad.org/${P}.src.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -20,35 +18,20 @@ IUSE=""
 CDEPEND="media-gfx/opencsg
 	sci-mathematics/cgal
 	dev-qt/qtcore:4
-	dev-qt/qtgui:4[-egl]
-	dev-qt/qtopengl:4[-egl]
+	dev-qt/qtgui:4
+	dev-qt/qtopengl:4
 	dev-cpp/eigen:3
-	dev-libs/glib:2
 	dev-libs/gmp:0
 	dev-libs/mpfr:0
 	dev-libs/boost:=
-	media-libs/fontconfig:1.0
-	media-libs/freetype:2
-	media-libs/glew
-	media-libs/harfbuzz
-	x11-libs/qscintilla"
+	x11-libs/qscintilla:=[qt4(-)]
+"
 DEPEND="${CDEPEND}"
 RDEPEND="${CDEPEND}"
-S="${WORKDIR}/${PN}-${MY_PV}"
 
 src_prepare() {
 	#Use our CFLAGS (specifically don't force x86)
 	sed -i "s/QMAKE_CXXFLAGS_RELEASE = .*//g" ${PN}.pro  || die
+
 	sed -i "s/\/usr\/local/\/usr/g" ${PN}.pro || die
-
-	eapply_user
-}
-
-src_configure() {
-	eqmake4 "${PN}.pro"
-}
-
-src_install() {
-	emake install INSTALL_ROOT="${D}"
-	einstalldocs
 }

--- a/media-gfx/openscad/openscad-2015.03_p2-r1.ebuild
+++ b/media-gfx/openscad/openscad-2015.03_p2-r1.ebuild
@@ -1,14 +1,16 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-inherit qt4-r2
+inherit eutils qmake-utils
+
+MY_PV="2015.03-2"
 
 DESCRIPTION="The Programmers Solid 3D CAD Modeller"
 HOMEPAGE="http://www.openscad.org/"
-SRC_URI="http://files.openscad.org/${P}.src.tar.gz"
+SRC_URI="http://files.openscad.org/${PN}-${MY_PV}.src.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -18,20 +20,35 @@ IUSE=""
 CDEPEND="media-gfx/opencsg
 	sci-mathematics/cgal
 	dev-qt/qtcore:4
-	dev-qt/qtgui:4
-	dev-qt/qtopengl:4
+	dev-qt/qtgui:4[-egl]
+	dev-qt/qtopengl:4[-egl]
 	dev-cpp/eigen:3
-	dev-libs/gmp:0
-	dev-libs/mpfr:0
+	dev-libs/glib:2
+	dev-libs/gmp:0=
+	dev-libs/mpfr:0=
 	dev-libs/boost:=
-	x11-libs/qscintilla
-"
+	media-libs/fontconfig:1.0
+	media-libs/freetype:2
+	media-libs/glew:*
+	media-libs/harfbuzz
+	x11-libs/qscintilla:=[qt4(-)]"
 DEPEND="${CDEPEND}"
 RDEPEND="${CDEPEND}"
+S="${WORKDIR}/${PN}-${MY_PV}"
 
 src_prepare() {
 	#Use our CFLAGS (specifically don't force x86)
 	sed -i "s/QMAKE_CXXFLAGS_RELEASE = .*//g" ${PN}.pro  || die
-
 	sed -i "s/\/usr\/local/\/usr/g" ${PN}.pro || die
+
+	eapply_user
+}
+
+src_configure() {
+	eqmake4 "${PN}.pro"
+}
+
+src_install() {
+	emake install INSTALL_ROOT="${D}"
+	einstalldocs
 }

--- a/sci-geosciences/qgis/qgis-2.12.2-r1.ebuild
+++ b/sci-geosciences/qgis/qgis-2.12.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -38,7 +38,7 @@ RDEPEND="
 	dev-qt/qtsql:4
 	dev-qt/qtwebkit:4
 	dev-qt/designer:4
-	x11-libs/qscintilla
+	x11-libs/qscintilla:=[qt4(-)]
 	|| (
 		( || ( <x11-libs/qwt-6.1.2:6[svg] >=x11-libs/qwt-6.1.2:6[svg,qt4] ) >=x11-libs/qwtpolar-1 )
 		( x11-libs/qwt:5[svg] <x11-libs/qwtpolar-1 )
@@ -50,6 +50,13 @@ RDEPEND="
 		dev-python/PyQt4[X,sql,svg,webkit,${PYTHON_USEDEP}]
 		dev-python/sip[${PYTHON_USEDEP}]
 		dev-python/qscintilla-python[${PYTHON_USEDEP}]
+		dev-python/python-dateutil[${PYTHON_USEDEP}]
+		dev-python/httplib2[${PYTHON_USEDEP}]
+		dev-python/jinja[${PYTHON_USEDEP}]
+		dev-python/markupsafe[${PYTHON_USEDEP}]
+		dev-python/pygments[${PYTHON_USEDEP}]
+		dev-python/pytz[${PYTHON_USEDEP}]
+		dev-python/six[${PYTHON_USEDEP}]
 		postgres? ( dev-python/psycopg:2[${PYTHON_USEDEP}] )
 		${PYTHON_DEPS}
 	)
@@ -62,6 +69,10 @@ DEPEND="${RDEPEND}
 	sys-devel/bison
 	sys-devel/flex"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-2.12.0-no-pyqtconfig.patch"
+)
+
 pkg_setup() {
 	python-single-r1_pkg_setup
 }
@@ -72,7 +83,14 @@ src_configure() {
 		"-DBUILD_SHARED_LIBS=ON"
 		"-DQGIS_LIB_SUBDIR=$(get_libdir)"
 		"-DQGIS_PLUGIN_SUBDIR=$(get_libdir)/qgis"
+		"-DWITH_INTERNAL_DATEUTIL=OFF"
+		"-DWITH_INTERNAL_HTTPLIB2=OFF"
+		"-DWITH_INTERNAL_JINJA2=OFF"
+		"-DWITH_INTERNAL_MARKUPSAFE=OFF"
+		"-DWITH_INTERNAL_PYGMENTS=OFF"
+		"-DWITH_INTERNAL_PYTZ=OFF"
 		"-DWITH_INTERNAL_QWTPOLAR=OFF"
+		"-DWITH_INTERNAL_SIX=OFF"
 		"-DPEDANTIC=OFF"
 		"-DWITH_APIDOC=OFF"
 		"-DWITH_SPATIALITE=ON"
@@ -118,8 +136,9 @@ src_install() {
 		doins -r "${WORKDIR}"/qgis_sample_data/*
 	fi
 
-	python_optimize "${D}"/usr/share/qgis/python/plugins \
-		"${D}"/$(python_get_sitedir)/qgis
+	python_optimize "${D}"/usr/share/qgis/python \
+		"${D}"/$(python_get_sitedir)/qgis \
+		"${D}"/$(python_get_sitedir)/pyspatialite
 
 	if use grass; then
 		python_fix_shebang "${D}"/usr/share/qgis/grass/scripts

--- a/sci-geosciences/qgis/qgis-2.18.2-r1.ebuild
+++ b/sci-geosciences/qgis/qgis-2.18.2-r1.ebuild
@@ -39,7 +39,7 @@ RDEPEND="
 	dev-qt/qtsvg:4
 	dev-qt/qtsql:4
 	dev-qt/qtwebkit:4
-	x11-libs/qscintilla:=
+	x11-libs/qscintilla:=[qt4(-)]
 	|| (
 		( || ( <x11-libs/qwt-6.1.2:6[svg] >=x11-libs/qwt-6.1.2:6[svg,qt4] ) >=x11-libs/qwtpolar-1 )
 		( x11-libs/qwt:5[svg] <x11-libs/qwtpolar-1 )

--- a/sci-mathematics/octave/octave-3.8.2-r2.ebuild
+++ b/sci-mathematics/octave/octave-3.8.2-r2.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	fftw? ( sci-libs/fftw:3.0= )
 	glpk? ( sci-mathematics/glpk:0= )
 	gnuplot? ( sci-visualization/gnuplot )
-	gui? ( x11-libs/qscintilla:0= )
+	gui? ( x11-libs/qscintilla:=[qt4(-)] )
 	hdf5? ( sci-libs/hdf5:0= )
 	graphicsmagick? ( media-gfx/graphicsmagick:=[cxx] )
 	imagemagick? ( media-gfx/imagemagick:=[cxx] )

--- a/sci-mathematics/octave/octave-4.2.0-r1.ebuild
+++ b/sci-mathematics/octave/octave-4.2.0-r1.ebuild
@@ -15,7 +15,7 @@ SLOT="0/${PV}"
 IUSE="curl doc fftw +glpk gnuplot graphicsmagick hdf5 +imagemagick java opengl openssl
 	portaudio postscript +qhull +qrupdate qt5 readline sndfile +sparse static-libs X zlib"
 REQUIRED_USE="?? ( graphicsmagick imagemagick )"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	app-arch/bzip2
@@ -50,7 +50,9 @@ RDEPEND="
 	qt5? (
 		dev-qt/qtcore:5
 		dev-qt/qtgui:5
-		dev-qt/qtnetwork:5 )
+		dev-qt/qtnetwork:5
+		>=x11-libs/qscintilla-2.9.3-r2:=[qt5(+)]
+	)
 	readline? ( sys-libs/readline:0= )
 	sndfile? ( media-libs/libsndfile )
 	sparse? (

--- a/x11-libs/qscintilla/qscintilla-2.8.4-r2.ebuild
+++ b/x11-libs/qscintilla/qscintilla-2.8.4-r2.ebuild
@@ -2,25 +2,25 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=6
+EAPI=5
 
 inherit flag-o-matic qmake-utils
 
-MY_P=QScintilla_gpl-${PV}
+MY_P=QScintilla-gpl-${PV}
 
 DESCRIPTION="A Qt port of Neil Hodgson's Scintilla C++ editor class"
 HOMEPAGE="http://www.riverbankcomputing.com/software/qscintilla/intro"
 SRC_URI="mirror://sourceforge/pyqt/${MY_P}.tar.gz"
 
-LICENSE="GPL-3"
-SLOT="0/12"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="designer doc"
+LICENSE="|| ( GPL-2 GPL-3 )"
+SLOT="0/11"
+KEYWORDS="alpha amd64 ~arm ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
+IUSE="designer doc +qt4"
 
 DEPEND="
-	dev-qt/qtcore:4
-	dev-qt/qtgui:4
-	designer? ( dev-qt/designer:4 )
+	>=dev-qt/qtcore-4.8.5:4
+	>=dev-qt/qtgui-4.8.5:4
+	designer? ( >=dev-qt/designer-4.8.5:4 )
 "
 RDEPEND="${DEPEND}"
 
@@ -43,37 +43,46 @@ src_unpack() {
 	fi
 }
 
-qsci_run_in() {
-	pushd "$1" >/dev/null || die
-	shift || die
-	"$@" || die
-	popd >/dev/null || die
-}
-
 src_configure() {
-	qsci_run_in Qt4Qt5 eqmake4
+	pushd Qt4Qt5 > /dev/null
+	eqmake4
+	popd > /dev/null
 
 	if use designer; then
 		# prevent building against system version (bug 466120)
 		append-cxxflags -I../Qt4Qt5
 		append-ldflags -L../Qt4Qt5
 
-		qsci_run_in designer-Qt4Qt5 eqmake4
+		pushd designer-Qt4Qt5 > /dev/null
+		eqmake4
+		popd > /dev/null
 	fi
 }
 
 src_compile() {
-	qsci_run_in Qt4Qt5 emake
+	pushd Qt4Qt5 > /dev/null
+	emake
+	popd > /dev/null
 
-	use designer && qsci_run_in designer-Qt4Qt5 emake
+	if use designer; then
+		pushd designer-Qt4Qt5 > /dev/null
+		emake
+		popd > /dev/null
+	fi
 }
 
 src_install() {
-	qsci_run_in Qt4Qt5 emake INSTALL_ROOT="${D}" install
+	pushd Qt4Qt5 > /dev/null
+	emake INSTALL_ROOT="${D}" install
+	popd > /dev/null
 
-	use designer && qsci_run_in designer-Qt4Qt5 emake INSTALL_ROOT="${D}" install
+	if use designer; then
+		pushd designer-Qt4Qt5 > /dev/null
+		emake INSTALL_ROOT="${D}" install
+		popd > /dev/null
+	fi
 
-	dodoc ChangeLog NEWS
+	dodoc NEWS
 
 	if use doc; then
 		docinto html

--- a/x11-libs/qscintilla/qscintilla-2.9.2-r1.ebuild
+++ b/x11-libs/qscintilla/qscintilla-2.9.2-r1.ebuild
@@ -1,26 +1,26 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit flag-o-matic qmake-utils
 
-MY_P=QScintilla-gpl-${PV}
+MY_P=QScintilla_gpl-${PV}
 
 DESCRIPTION="A Qt port of Neil Hodgson's Scintilla C++ editor class"
 HOMEPAGE="http://www.riverbankcomputing.com/software/qscintilla/intro"
 SRC_URI="mirror://sourceforge/pyqt/${MY_P}.tar.gz"
 
-LICENSE="|| ( GPL-2 GPL-3 )"
-SLOT="0/11"
-KEYWORDS="alpha amd64 ~arm ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
-IUSE="designer doc"
+LICENSE="GPL-3"
+SLOT="0/12"
+KEYWORDS="alpha amd64 ~arm ~ia64 ~ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
+IUSE="designer doc +qt4"
 
 DEPEND="
-	>=dev-qt/qtcore-4.8.5:4
-	>=dev-qt/qtgui-4.8.5:4
-	designer? ( >=dev-qt/designer-4.8.5:4 )
+	dev-qt/qtcore:4
+	dev-qt/qtgui:4
+	designer? ( dev-qt/designer:4 )
 "
 RDEPEND="${DEPEND}"
 
@@ -43,46 +43,37 @@ src_unpack() {
 	fi
 }
 
+qsci_run_in() {
+	pushd "$1" >/dev/null || die
+	shift || die
+	"$@" || die
+	popd >/dev/null || die
+}
+
 src_configure() {
-	pushd Qt4Qt5 > /dev/null
-	eqmake4
-	popd > /dev/null
+	qsci_run_in Qt4Qt5 eqmake4
 
 	if use designer; then
 		# prevent building against system version (bug 466120)
 		append-cxxflags -I../Qt4Qt5
 		append-ldflags -L../Qt4Qt5
 
-		pushd designer-Qt4Qt5 > /dev/null
-		eqmake4
-		popd > /dev/null
+		qsci_run_in designer-Qt4Qt5 eqmake4
 	fi
 }
 
 src_compile() {
-	pushd Qt4Qt5 > /dev/null
-	emake
-	popd > /dev/null
+	qsci_run_in Qt4Qt5 emake
 
-	if use designer; then
-		pushd designer-Qt4Qt5 > /dev/null
-		emake
-		popd > /dev/null
-	fi
+	use designer && qsci_run_in designer-Qt4Qt5 emake
 }
 
 src_install() {
-	pushd Qt4Qt5 > /dev/null
-	emake INSTALL_ROOT="${D}" install
-	popd > /dev/null
+	qsci_run_in Qt4Qt5 emake INSTALL_ROOT="${D}" install
 
-	if use designer; then
-		pushd designer-Qt4Qt5 > /dev/null
-		emake INSTALL_ROOT="${D}" install
-		popd > /dev/null
-	fi
+	use designer && qsci_run_in designer-Qt4Qt5 emake INSTALL_ROOT="${D}" install
 
-	dodoc NEWS
+	dodoc ChangeLog NEWS
 
 	if use doc; then
 		docinto html

--- a/x11-libs/qscintilla/qscintilla-2.9.3-r1.ebuild
+++ b/x11-libs/qscintilla/qscintilla-2.9.3-r1.ebuild
@@ -14,8 +14,8 @@ SRC_URI="mirror://sourceforge/pyqt/${MY_P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0/12"
-KEYWORDS="alpha amd64 ~arm ~ia64 ~ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
-IUSE="designer doc"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="designer doc +qt4"
 
 DEPEND="
 	dev-qt/qtcore:4

--- a/x11-libs/qscintilla/qscintilla-2.9.3-r2.ebuild
+++ b/x11-libs/qscintilla/qscintilla-2.9.3-r2.ebuild
@@ -1,0 +1,89 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit flag-o-matic qmake-utils
+
+MY_P=QScintilla_gpl-${PV}
+
+DESCRIPTION="A Qt port of Neil Hodgson's Scintilla C++ editor class"
+HOMEPAGE="http://www.riverbankcomputing.com/software/qscintilla/intro"
+SRC_URI="mirror://sourceforge/pyqt/${MY_P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0/12"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="designer doc +qt4 qt5"
+
+REQUIRED_USE="^^ ( qt4 qt5 )"
+
+RDEPEND="
+	qt4? (
+		dev-qt/qtcore:4
+		dev-qt/qtgui:4
+		designer? ( dev-qt/designer:4 )
+	)
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtprintsupport:5
+		dev-qt/qtwidgets:5
+		designer? ( dev-qt/designer:5 )
+	)"
+DEPEND="${RDEPEND}"
+
+S=${WORKDIR}/${MY_P}
+
+src_unpack() {
+	default
+
+	# Sub-slot sanity check
+	local subslot=${SLOT#*/}
+	local version=$(sed -nre 's:.*VERSION\s*=\s*([0-9\.]+):\1:p' "${S}"/Qt4Qt5/qscintilla.pro)
+	local major=${version%%.*}
+	if [[ ${subslot} != ${major} ]]; then
+		eerror
+		eerror "Ebuild sub-slot (${subslot}) does not match QScintilla major version (${major})"
+		eerror "Please update SLOT variable as follows:"
+		eerror "    SLOT=\"${SLOT%%/*}/${major}\""
+		eerror
+		die "sub-slot sanity check failed"
+	fi
+}
+
+qsci_run_in() {
+	pushd "$1" >/dev/null || die
+	shift || die
+	"$@" || die
+	popd >/dev/null || die
+}
+
+src_configure() {
+	local my_eqmake=eqmake$(usex qt5 5 4)
+	qsci_run_in Qt4Qt5 $my_eqmake
+
+	if use designer; then
+		# prevent building against system version (bug 466120)
+		append-cxxflags -I../Qt4Qt5
+		append-ldflags -L../Qt4Qt5
+
+		qsci_run_in designer-Qt4Qt5 $my_eqmake
+	fi
+}
+
+src_compile() {
+	qsci_run_in Qt4Qt5 emake
+
+	use designer && qsci_run_in designer-Qt4Qt5 emake
+}
+
+src_install() {
+	qsci_run_in Qt4Qt5 emake INSTALL_ROOT="${D}" install
+
+	use designer && qsci_run_in designer-Qt4Qt5 emake INSTALL_ROOT="${D}" install
+
+	use doc && HTML_DOCS=( doc/html-Qt4Qt5/. )
+	einstalldocs
+}


### PR DESCRIPTION
@kensington @pesa
This is to finally allow Qscintilla to be build for Qt5. It still doesn't do the dual-lib, which isn't officially supported, but it gives us the option to depend on it from Qt5 apps (such as Octave). Furthermore, I updated all revdeps to include protections for when we decide to start to only support Qt5 in Qscintilla.

The diff for qscintilla:
```
--- qscintilla-2.9.3-r1.ebuild
+++ qscintilla-2.9.3-r2.ebuild
@@ -15,14 +15,24 @@
 LICENSE="GPL-3"
 SLOT="0/12"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="designer doc +qt4"
+IUSE="designer doc +qt4 qt5"
 
-DEPEND="
-	dev-qt/qtcore:4
-	dev-qt/qtgui:4
-	designer? ( dev-qt/designer:4 )
-"
-RDEPEND="${DEPEND}"
+REQUIRED_USE="^^ ( qt4 qt5 )"
+
+RDEPEND="
+	qt4? (
+		dev-qt/qtcore:4
+		dev-qt/qtgui:4
+		designer? ( dev-qt/designer:4 )
+	)
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtprintsupport:5
+		dev-qt/qtwidgets:5
+		designer? ( dev-qt/designer:5 )
+	)"
+DEPEND="${RDEPEND}"
 
 S=${WORKDIR}/${MY_P}
 
@@ -51,14 +61,15 @@
 }
 
 src_configure() {
-	qsci_run_in Qt4Qt5 eqmake4
+	local my_eqmake=eqmake$(usex qt5 5 4)
+	qsci_run_in Qt4Qt5 $my_eqmake
 
 	if use designer; then
 		# prevent building against system version (bug 466120)
 		append-cxxflags -I../Qt4Qt5
 		append-ldflags -L../Qt4Qt5
 
-		qsci_run_in designer-Qt4Qt5 eqmake4
+		qsci_run_in designer-Qt4Qt5 $my_eqmake
 	fi
 }
 
@@ -73,10 +84,6 @@
 
 	use designer && qsci_run_in designer-Qt4Qt5 emake INSTALL_ROOT="${D}" install
 
-	dodoc ChangeLog NEWS
-
-	if use doc; then
-		docinto html
-		dodoc -r doc/html-Qt4Qt5/*
-	fi
+	use doc && HTML_DOCS=( doc/html-Qt4Qt5/. )
+	einstalldocs
 }
```