### PR TITLE
kde-apps/ktouch: Add missing DEPEND

### DIFF
--- a/kde-apps/ktouch/files/ktouch-16.12.0-deps.patch
+++ b/kde-apps/ktouch/files/ktouch-16.12.0-deps.patch
@@ -10,7 +10,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 7a0099c..3175453 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -25,32 +25,32 @@ include(ECMSetupVersion)
+@@ -25,32 +25,33 @@ include(ECMSetupVersion)
  include(FeatureSummary)
  
  find_package(Qt5 5.5 REQUIRED COMPONENTS
@@ -46,9 +46,9 @@ index 7a0099c..3175453 100644
      ItemViews
      KCMUtils
 -    TextEditor
--    WindowSystem
 +    TextWidgets
 +    WidgetsAddons
+     WindowSystem
 +    XmlGui
  )
  
@@ -57,7 +57,7 @@ diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index 6633f35..1003a0b 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -131,16 +131,14 @@ target_link_libraries(ktouch
+@@ -131,16 +132,15 @@ target_link_libraries(ktouch
          Qt5::Sql
          Qt5::XmlPatterns
          Qt5::X11Extras
@@ -71,8 +71,8 @@ index 6633f35..1003a0b 100644
          KF5::I18n
          KF5::KCMUtils
 -        KF5::TextEditor
--        KF5::WindowSystem
 +        KF5::TextWidgets
+         KF5::WindowSystem
          KF5::CoreAddons
          ${ktouch_X11_DEPS}
  )

--- a/kde-apps/ktouch/ktouch-16.12.0-r1.ebuild
+++ b/kde-apps/ktouch/ktouch-16.12.0-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.kde.org/applications/education/ktouch/"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE=""
 
-DEPEND="
+COMMON_DEPEND="
 	$(add_frameworks_dep kcmutils)
 	$(add_frameworks_dep kcompletion)
 	$(add_frameworks_dep kconfig)
@@ -37,7 +37,10 @@ DEPEND="
 	x11-libs/libX11
 	x11-libs/libxcb
 "
-RDEPEND="${DEPEND}
+DEPEND="${COMMON_DEPEND}
+	$(add_frameworks_dep kwindowsystem)
+"
+RDEPEND="${COMMON_DEPEND}
 	$(add_kdeapps_dep kqtquickcharts)
 "
 


### PR DESCRIPTION
Gentoo-bug: 602982

Reported-by: Ulrich Müller