### PR TITLE
kde-apps/kdemultimedia-meta: Allow to depend on kde-apps/audiocd-kio:4

### DIFF
--- a/kde-apps/kdemultimedia-meta/kdemultimedia-meta-16.12.0.ebuild
+++ b/kde-apps/kdemultimedia-meta/kdemultimedia-meta-16.12.0.ebuild
@@ -17,7 +17,7 @@ IUSE="+ffmpeg nls"
 [[ ${KDE_BUILD_TYPE} = live ]] && L10N_MINIMAL=${KDE_APPS_MINIMAL}
 
 RDEPEND="
-	$(add_kdeapps_dep audiocd-kio)
+	|| ( $(add_kdeapps_dep audiocd-kio) kde-apps/audiocd-kio:4 )
 	$(add_kdeapps_dep dragon)
 	$(add_kdeapps_dep juk)
 	$(add_kdeapps_dep kdenlive)


### PR DESCRIPTION
Right now, audiocd-kio:5 is used by nothing but live rdeps, so be nice
to those amarok and kaudiocreator users.

Gentoo-bug: 603042

Package-Manager: portage-2.3.0