### PR TITLE
net-analyzer/netdata-1.4.0-r1: fix build w/newer glibc

### DIFF
--- a/net-analyzer/netdata/files/netdata-1.4.0-glibc-sysmacros.patch
+++ b/net-analyzer/netdata/files/netdata-1.4.0-glibc-sysmacros.patch
@@ -1,0 +1,21 @@
+From 471d1b5404cd60ea638450e39554ae2878fd5b0d Mon Sep 17 00:00:00 2001
+From: Costa Tsaousis <costa@tsaousis.gr>
+Date: Tue, 20 Dec 2016 20:31:24 +0200
+Subject: [PATCH] added sys/sysmacros.h; fixes #1408
+
+---
+ src/common.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/common.h b/src/common.h
+index c92c049..70cb4d6 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -64,6 +64,7 @@
+ #include <sys/syscall.h>
+ #include <sys/time.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h> // #1408
+ #include <sys/wait.h>
+ #include <time.h>
+ #include <unistd.h>

--- a/net-analyzer/netdata/netdata-1.4.0-r1.ebuild
+++ b/net-analyzer/netdata/netdata-1.4.0-r1.ebuild
@@ -62,6 +62,10 @@ FILECAPS=(
 	'cap_dac_read_search,cap_sys_ptrace+ep' 'usr/libexec/netdata/plugins.d/apps.plugin'
 )
 
+PATCHES=(
+	"${FILESDIR}"/${P}-glibc-sysmacros.patch
+)
+
 pkg_setup() {
 	linux-info_pkg_setup
 


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=603182

Since this change only impacts building, and does not impact runtime behavior, it doesn't require a revbump.