### PR TITLE
Remove maintainership

### DIFF
--- a/dev-python/httmock/metadata.xml
+++ b/dev-python/httmock/metadata.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>hydrapolic@gmail.com</email>
-		<name>Tomas Mozes</name>
-		<description>Proxy maintainer</description>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">patrys/httmock</remote-id>
 	</upstream>

--- a/dev-python/jenkins-autojobs/metadata.xml
+++ b/dev-python/jenkins-autojobs/metadata.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>hydrapolic@gmail.com</email>
-    <name>Tomas Mozes</name>
-    <description>Proxy maintainer</description>
-  </maintainer>
-  <maintainer type="project">
-    <email>proxy-maint@gentoo.org</email>
-    <name>Proxy Maintainers</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <upstream>
     <remote-id type="github">gvalkov/jenkins-autojobs</remote-id>
   </upstream>

--- a/dev-python/jenkins-webapi/metadata.xml
+++ b/dev-python/jenkins-webapi/metadata.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>hydrapolic@gmail.com</email>
-		<name>Tomas Mozes</name>
-		<description>Proxy maintainer</description>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">gvalkov/jenkins-webapi</remote-id>
 	</upstream>

--- a/dev-python/jenkinsapi/metadata.xml
+++ b/dev-python/jenkinsapi/metadata.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>hydrapolic@gmail.com</email>
-		<name>Tomas Mozes</name>
-		<description>Proxy maintainer</description>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">salimfadhley/jenkinsapi</remote-id>
 	</upstream>


### PR DESCRIPTION
I don't use these packages anymore, so I really don't have motivation to update them. Apart of that, some of them need several new dependencies to introduce.

dev-python/httmock
dev-python/jenkins-autojobs
dev-python/jenkins-webapi
dev-python/jenkinsapi