### PR TITLE
mail-client/trojita: Upstream has switched to app-crypt/gpgme

### DIFF
--- a/mail-client/trojita/trojita-9999.ebuild
+++ b/mail-client/trojita/trojita-9999.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	crypt? (
 		dev-libs/mimetic
-		kde-apps/gpgmepp:5
+		>=app-crypt/gpgme-1.8.0[cxx,qt5]
 	)
 	dbus? ( dev-qt/qtdbus:5 )
 	password? ( dev-libs/qtkeychain[qt5] )


### PR DESCRIPTION
There's also a requirement on 1.8.0+ because of some bugs in pthreads in
1.7.0 -- that one also comes from upstream.