### PR TITLE
gnome-extra/cinnamon: fix missing rdep USE flag in 3.2.x

### DIFF
--- a/gnome-extra/cinnamon/cinnamon-3.2.0-r1.ebuild
+++ b/gnome-extra/cinnamon/cinnamon-3.2.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -95,7 +95,7 @@ RDEPEND="${COMMON_DEPEND}
 	x11-misc/xdg-utils
 	x11-libs/xapps
 
-	dev-python/dbus-python[python_targets_python2_7]
+	dev-python/dbus-python[${PYTHON_USEDEP}]
 	dev-python/gconf-python:2[python_targets_python2_7]
 	dev-python/lxml[python_targets_python2_7]
 	dev-python/pexpect[python_targets_python2_7]

--- a/gnome-extra/cinnamon/cinnamon-3.2.6.ebuild
+++ b/gnome-extra/cinnamon/cinnamon-3.2.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -95,7 +95,7 @@ RDEPEND="${COMMON_DEPEND}
 	x11-misc/xdg-utils
 	x11-libs/xapps
 
-	dev-python/dbus-python[python_targets_python2_7]
+	dev-python/dbus-python[${PYTHON_USEDEP}]
 	dev-python/gconf-python:2[python_targets_python2_7]
 	dev-python/lxml[python_targets_python2_7]
 	dev-python/pexpect[python_targets_python2_7]

--- a/gnome-extra/cinnamon/cinnamon-3.2.7.ebuild
+++ b/gnome-extra/cinnamon/cinnamon-3.2.7.ebuild
@@ -95,7 +95,7 @@ RDEPEND="${COMMON_DEPEND}
 	x11-misc/xdg-utils
 	x11-libs/xapps
 
-	dev-python/dbus-python[python_targets_python2_7]
+	dev-python/dbus-python[${PYTHON_USEDEP}]
 	dev-python/gconf-python:2[python_targets_python2_7]
 	dev-python/lxml[python_targets_python2_7]
 	dev-python/pexpect[python_targets_python2_7]


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/602480

If you prefer a different format (r1/2 version number suffixes or separate commits for the ebuilds), please let me know. :)