### PR TITLE
net-news/liferea: fixed typo in src_configure

### DIFF
--- a/net-news/liferea/liferea-1.10.19-r1.ebuild
+++ b/net-news/liferea/liferea-1.10.19-r1.ebuild
@@ -50,8 +50,8 @@ src_prepare() {
 
 src_configure() {
 	gnome2_src_configure \
-		--disable-schemas-compile
-		$(use_enable ayatana libindicate)
+		--disable-schemas-compile \
+		$(use_enable ayatana libindicate) \
 		$(use_enable libnotify)
 }
 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=603466