### PR TITLE
net-irc/znc: Update/rewrite ebuild for 9999

### DIFF
--- a/net-irc/znc/files/README.gentoo
+++ b/net-irc/znc/files/README.gentoo
@@ -4,10 +4,6 @@ If znc was compiled with the 'daemon' use flag, you may run
     emerge --config znc
 to configure it.
 
-To generate a new SSL certificate, run:
-    znc --system-wide-config-as znc --makepem -d /var/lib/znc
-as root.
-
 If migrating from a user-based install, you can copy the existing
 configuration files:
      mkdir /var/lib/znc
@@ -16,7 +12,3 @@ configuration files:
      chown -R znc:znc /var/lib/znc
 You may also adjust the location of the files and the user running znc
 in /etc/conf.d/znc instead.
-
-To run as a daemon, please make sure that your configuration contains
-    PidFile = /run/znc/znc.pid
-or that the PidFile value matches the one in /etc/conf.d/znc.

--- a/net-irc/znc/files/README.gentoo
+++ b/net-irc/znc/files/README.gentoo
@@ -1,8 +1,6 @@
 To run znc as a user, run 'znc --makeconf' to create a configuration file.
 
-If znc was compiled with the 'daemon' use flag, you may run
-    emerge --config znc
-to configure it.
+To configure the system-wide daemon, you may run 'emerge --config znc'.
 
 If migrating from a user-based install, you can copy the existing
 configuration files:

--- a/net-irc/znc/files/znc.initd-r2
+++ b/net-irc/znc/files/znc.initd-r2
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/net-irc/znc/files/znc.initd-r2
+++ b/net-irc/znc/files/znc.initd-r2
@@ -1,0 +1,41 @@
+#!/sbin/openrc-run
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+extra_commands="config"
+extra_started_commands="reload save"
+command="/usr/bin/znc"
+command_args="--datadir \"${ZNC_DATADIR}\" --foreground"
+command_background="yes"
+pidfile="${ZNC_PIDFILE:-/run/znc/znc.pid}"
+user=${ZNC_USER:-znc}
+group=${ZNC_GROUP:-znc}
+start_stop_daemon_args="--chdir \"${ZNC_DATADIR}\" --user ${user} --group ${group} ${ZNC_SSDARGS}"
+retry="${ZNC_TERMTIMEOUT}"
+
+required_dirs="${ZNC_DATADIR}"
+
+depend() {
+	use dns logger
+}
+
+start_pre() {
+	checkpath -d -m 0770 -o ${user}:${group} "$(dirname ${pidfile})"
+}
+
+stop_post() {
+	rm -f "${pidfile}"
+}
+
+reload() {
+	ebegin "Reloading ZNC Configuration File from Disk"
+	start-stop-daemon --signal SIGHUP --pidfile "${pidfile}"
+	eend $?
+}
+
+save() {
+	ebegin "Saving ZNC Configuration File to Disk"
+	start-stop-daemon --signal SIGUSR1 --pidfile "${pidfile}"
+	eend $?
+}

--- a/net-irc/znc/znc-9999.ebuild
+++ b/net-irc/znc/znc-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python{3_4,3_5} )
 PLOCALES="ru"
-CMAKE_MAKEFILE_GENERATOR=ninja
+: ${CMAKE_MAKEFILE_GENERATOR:=ninja}
 
 inherit cmake-utils l10n python-single-r1 readme.gentoo-r1 systemd user
 

--- a/net-irc/znc/znc-9999.ebuild
+++ b/net-irc/znc/znc-9999.ebuild
@@ -18,23 +18,18 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI=${EGIT_REPO_URI:-"https://github.com/znc/znc.git"}
 	SRC_URI=""
-	SWIG_DEPEND="
-		perl? ( >=dev-lang/swig-3.0.0 )
-		python? ( >=dev-lang/swig-3.0.0 )
-	"
 else
 	SRC_URI="
 		http://znc.in/releases/archive/${P}.tar.gz
 		test? ( ${GTEST_URL} )
 	"
 	KEYWORDS="~amd64 ~arm ~x86"
-	SWIG_DEPEND=""
 fi
 
 HOMEPAGE="http://znc.in"
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="daemon +ipv6 +icu libressl nls perl python +ssl sasl tcl test +zlib"
+IUSE="+ipv6 +icu libressl nls perl python +ssl sasl tcl test +zlib"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} icu )"
 
@@ -53,44 +48,45 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
-	${SWIG_DEPEND}
 	nls? ( sys-devel/gettext )
 	virtual/pkgconfig
+	perl? ( >=dev-lang/swig-3.0.0 )
+	python? ( >=dev-lang/swig-3.0.0 )
 "
 
 pkg_setup() {
 	if use python; then
 		python-single-r1_pkg_setup
 	fi
-	if use daemon; then
-		enewgroup ${PN}
-		enewuser ${PN} -1 -1 /var/lib/${PN} ${PN}
-		# The home directory was previously set to /dev/null
-		# This caused a bug with the systemd unit
-		# https://bugs.gentoo.org/521916
-		esethome ${PN} /var/lib/${PN}
-	fi
+	enewgroup ${PN}
+	enewuser ${PN} -1 -1 /var/lib/${PN} ${PN}
+	# The home directory was previously set to /dev/null
+	# This caused a bug with the systemd unit
+	# https://bugs.gentoo.org/521916
+	esethome ${PN} /var/lib/${PN}
 }
 
 src_prepare() {
 	l10n_find_plocales_changes "${S}/src/po" "${PN}." '.po'
 	remove_locale() {
-		# Some languages can miss some modules
+		# Some language/module pairs can be missing
 		rm src/po/${PN}.${1}.po modules/po/*.${1}.po || true
 	}
 	l10n_for_each_disabled_locale_do remove_locale
+
+	# Let SWIG rebuild modperl/modpython to make user patching easier.
+	# Not "| true" to report an error if names the pregenerated files change upstream.
+	if [[ ${PV} != *9999* ]]; then
+		rm modules/modperl/generated.tar.gz
+		rm modules/modpython/generated.tar.gz
+	fi
+
 	cmake-utils_src_prepare
 }
 
 src_configure() {
-	local want_swig
-	if [[ ${PV} == *9999* ]]; then
-		want_swig=yes
-	else
-		want_swig=no
-	fi
 	local mycmakeargs=(
-		-DWANT_SYSTEMD="$(usex daemon)"
+		-DWANT_SYSTEMD=yes  # Causes -DSYSTEMD_DIR to be used.
 		-DSYSTEMD_DIR="$(systemd_get_systemunitdir)"
 		-DWANT_ICU="$(usex icu)"
 		-DWANT_IPV6="$(usex ipv6)"
@@ -101,7 +97,6 @@ src_configure() {
 		-DWANT_OPENSSL="$(usex ssl)"
 		-DWANT_TCL="$(usex tcl)"
 		-DWANT_ZLIB="$(usex zlib)"
-		-DWANT_SWIG="${want_swig}"
 	)
 	if use test; then
 		export GTEST_ROOT="${WORKDIR}/googletest-release-${GTEST_VER}/googletest"
@@ -119,10 +114,8 @@ src_test() {
 src_install() {
 	cmake-utils_src_install
 	dodoc NOTICE
-	if use daemon; then
-		newinitd "${FILESDIR}"/znc.initd-r2 znc
-		newconfd "${FILESDIR}"/znc.confd-r1 znc
-	fi
+	newinitd "${FILESDIR}"/znc.initd-r2 znc
+	newconfd "${FILESDIR}"/znc.confd-r1 znc
 	DOC_CONTENTS=$(<"${FILESDIR}/README.gentoo") || die
 	DISABLE_AUTOFORMATTING=1
 	readme.gentoo_create_doc
@@ -141,30 +134,25 @@ pkg_postinst() {
 }
 
 pkg_config() {
-	if use daemon; then
-		if [[ -e "${EROOT%/}/var/lib/znc" ]]; then
-			ewarn "${EROOT%/}/var/lib/znc already exists, aborting to avoid damaging"
-			ewarn "any existing configuration. If you are sure you want"
-			ewarn "to generate a new configuration, remove the folder"
-			ewarn "and try again."
-		else
-			einfo "Press any key to interactively create a new configuration file"
-			einfo "for znc."
-			einfo "To abort, press Control-C"
-			read
-			mkdir -p "${EROOT%/}/var/lib/znc" || die
-			chown -R ${PN}:${PN} "${EROOT%/}/var/lib/znc" ||
-				die "Setting permissions failed"
-			start-stop-daemon --start --user ${PN}:${PN} --env ZNC_NO_LAUNCH_AFTER_MAKECONF=1 \
-				"${EROOT%/}"/usr/bin/znc -- --makeconf --datadir "${EROOT%/}/var/lib/znc" ||
-				die "Config failed"
-			echo
-			einfo "To start znc, run '/etc/init.d/znc start'"
-			einfo "or add znc to a runlevel:"
-			einfo "  rc-update add znc default"
-		fi
+	if [[ -e "${EROOT%/}/var/lib/znc" ]]; then
+		ewarn "${EROOT%/}/var/lib/znc already exists, aborting to avoid damaging"
+		ewarn "any existing configuration. If you are sure you want"
+		ewarn "to generate a new configuration, remove the folder"
+		ewarn "and try again."
 	else
-		ewarn "To configure znc as a system-wide daemon you have to"
-		ewarn "enable the 'daemon' use flag."
+		einfo "Press any key to interactively create a new configuration file"
+		einfo "for znc."
+		einfo "To abort, press Control-C"
+		read
+		mkdir -p "${EROOT%/}/var/lib/znc" || die
+		chown -R ${PN}:${PN} "${EROOT%/}/var/lib/znc" ||
+			die "Setting permissions failed"
+		start-stop-daemon --start --user ${PN}:${PN} --env ZNC_NO_LAUNCH_AFTER_MAKECONF=1 \
+			"${EROOT%/}"/usr/bin/znc -- --makeconf --datadir "${EROOT%/}/var/lib/znc" ||
+			die "Config failed"
+		echo
+		einfo "To start znc, run '/etc/init.d/znc start'"
+		einfo "or add znc to a runlevel:"
+		einfo "  rc-update add znc default"
 	fi
 }

--- a/net-irc/znc/znc-9999.ebuild
+++ b/net-irc/znc/znc-9999.ebuild
@@ -16,9 +16,8 @@ DESCRIPTION="An advanced IRC Bouncer"
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI=${EGIT_REPO_URI:-"git://github.com/znc/znc.git"}
+	EGIT_REPO_URI=${EGIT_REPO_URI:-"https://github.com/znc/znc.git"}
 	SRC_URI=""
-	KEYWORDS=""
 	SWIG_DEPEND="
 		perl? ( >=dev-lang/swig-3.0.0 )
 		python? ( >=dev-lang/swig-3.0.0 )


### PR DESCRIPTION
* Copy from znc-1.6.4.ebuild at PR #3232 as the base
* Drop custom patches, redo the same functionality using a new internal
  feature in upstream ZNC, and using start-stop-daemon (znc/znc#1245).
* Switch to CMake
* Add a new feature from upstream with `nls` USE-flag
* Add 9999 sauce on top, from the old znc-9999.ebuild and from znc-1.4-r1.ebuild
* Test (with FEATURES=test) as 9999, and as one of nightly tarballs

@Whissi 