### PR TITLE
dev-vcs/git: Fix build on musl

### DIFF
--- a/dev-vcs/git/git-2.10.1.ebuild
+++ b/dev-vcs/git/git-2.10.1.ebuild
@@ -191,6 +191,8 @@ exportmakeopts() {
 		|| myopts+=" NO_PTHREADS=YesPlease"
 	use cvs \
 		|| myopts+=" NO_CVS=YesPlease"
+	use elibc_musl \
+		&& myopts+=" NO_REGEX=YesPlease"
 # Disabled until ~m68k-mint can be keyworded again
 #	if [[ ${CHOST} == *-mint* ]] ; then
 #		myopts+=" NO_MMAP=YesPlease"

--- a/dev-vcs/git/git-2.10.2.ebuild
+++ b/dev-vcs/git/git-2.10.2.ebuild
@@ -191,6 +191,8 @@ exportmakeopts() {
 		|| myopts+=" NO_PTHREADS=YesPlease"
 	use cvs \
 		|| myopts+=" NO_CVS=YesPlease"
+	use elibc_musl \
+		&& myopts+=" NO_REGEX=YesPlease"
 # Disabled until ~m68k-mint can be keyworded again
 #	if [[ ${CHOST} == *-mint* ]] ; then
 #		myopts+=" NO_MMAP=YesPlease"

--- a/dev-vcs/git/git-2.11.0.ebuild
+++ b/dev-vcs/git/git-2.11.0.ebuild
@@ -192,6 +192,8 @@ exportmakeopts() {
 		|| myopts+=" NO_PTHREADS=YesPlease"
 	use cvs \
 		|| myopts+=" NO_CVS=YesPlease"
+	use elibc_musl \
+		&& myopts+=" NO_REGEX=YesPlease"
 # Disabled until ~m68k-mint can be keyworded again
 #	if [[ ${CHOST} == *-mint* ]] ; then
 #		myopts+=" NO_MMAP=YesPlease"

--- a/dev-vcs/git/git-2.11.0_rc2.ebuild
+++ b/dev-vcs/git/git-2.11.0_rc2.ebuild
@@ -192,6 +192,8 @@ exportmakeopts() {
 		|| myopts+=" NO_PTHREADS=YesPlease"
 	use cvs \
 		|| myopts+=" NO_CVS=YesPlease"
+	use elibc_musl \
+		&& myopts+=" NO_REGEX=YesPlease"
 # Disabled until ~m68k-mint can be keyworded again
 #	if [[ ${CHOST} == *-mint* ]] ; then
 #		myopts+=" NO_MMAP=YesPlease"


### PR DESCRIPTION
@blueness could you merge/review this?

2.10.1+ introduce a configuration option which enables non-posix compatible
regex by default, which breaks compilation on musl.

I don't know if any other platforms, (uclibc, interix, hpux, solaris) are broken, but macos, freebsd, glibc have `REG_STARTEND` support.

https://github.com/git/git/commit/2f8952250a84313b74f96abb7b035874854cf202

Gentoo-Bug: https://bugs.gentoo.org/603710