### PR TITLE
[CI Test] media-libs/phonon: Drop ia64/sparc to testing

### DIFF
--- a/media-libs/phonon/phonon-4.7.2.ebuild
+++ b/media-libs/phonon/phonon-4.7.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,11 +6,10 @@ EAPI=5
 
 if [[ ${PV} != *9999* ]]; then
 	SRC_URI="mirror://kde/stable/phonon/${PV}/${P}.tar.xz"
-	KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+	KEYWORDS="alpha amd64 arm hppa ~ia64 ppc ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 else
 	SCM_ECLASS="git-r3"
 	EGIT_REPO_URI=( "git://anongit.kde.org/${PN}" )
-	KEYWORDS=""
 fi
 
 inherit cmake-utils multibuild ${SCM_ECLASS}


### PR DESCRIPTION
Package-Manager: Portage-2.3.3, Repoman-2.3.1