### PR TITLE
games-simulation/openttd:  install data to /usr/share/games 

### DIFF
--- a/games-misc/opengfx/opengfx-0.5.4-r1.ebuild
+++ b/games-misc/opengfx/opengfx-0.5.4-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit eutils
+
+DESCRIPTION="OpenGFX data files for OpenTTD"
+HOMEPAGE="http://bundles.openttdcoop.org/opengfx/"
+SRC_URI="http://bundles.openttdcoop.org/opengfx/releases/${PV}/${P}-source.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
+IUSE=""
+RESTRICT="test" # nml version affects the checksums that the test uses (bug #451444)
+
+DEPEND=">=games-util/nml-0.4.0
+	games-util/grfcodec"
+RDEPEND=""
+
+S=${WORKDIR}/${P}-source
+
+PATCHES=(
+	"${FILESDIR}/${P}-Makefile.patch"
+)
+
+src_compile() {
+	emake GIMP=""  help  # print out the env to make bug reports better
+	emake GIMP="" _V="" bundle_tar
+}
+
+src_install() {
+	insinto "/usr/share/games/openttd/data/"
+	doins *.grf opengfx.obg
+	dodoc docs/{changelog.txt,readme.txt}
+}

--- a/games-misc/openmsx/openmsx-0.3.1-r2.ebuild
+++ b/games-misc/openmsx/openmsx-0.3.1-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 )
+inherit python-any-r1
+
+DESCRIPTION="An ambiguously named music replacement set for OpenTTD"
+HOMEPAGE="http://bundles.openttdcoop.org/openmsx/"
+SRC_URI="http://bundles.openttdcoop.org/openmsx/releases/${PV}/${P}-source.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ppc ~ppc64 ~x86"
+IUSE=""
+
+DEPEND="${PYTHON_DEPS}"
+
+S=${WORKDIR}/${P}-source
+
+pkg_setup() {
+	python-any-r1_pkg_setup
+}
+
+src_compile() {
+	emake _V= bundle || die
+}
+
+src_install() {
+	insinto "/usr/share/games/openttd/gm/${P}"
+	doins ${P}/{*.mid,openmsx.obm} || die
+	dodoc ${P}/{changelog.txt,readme.txt} || die
+}

--- a/games-misc/opensfx/opensfx-0.2.3-r1.ebuild
+++ b/games-misc/opensfx/opensfx-0.2.3-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+DESCRIPTION="OpenSFX data files for OpenTTD"
+HOMEPAGE="http://bundles.openttdcoop.org/opensfx/"
+SRC_URI="http://bundles.openttdcoop.org/${PN}/releases/${P}-source.tar.gz"
+
+LICENSE="CC-Sampling-Plus-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
+IUSE=""
+
+DEPEND="games-util/catcodec"
+RDEPEND=""
+
+S=${WORKDIR}/${P}-source
+
+src_install() {
+	insinto "/usr/share/games/openttd/data/"
+	doins opensfx.cat opensfx.obs
+	dodoc docs/{changelog.txt,readme.ptxt}
+}

--- a/games-simulation/openttd/openttd-1.6.1-r1.ebuild
+++ b/games-simulation/openttd/openttd-1.6.1-r1.ebuild
@@ -89,15 +89,9 @@ src_configure() {
 	# It's all built as C++, upstream uses CFLAGS internally.
 	CFLAGS="" ./configure \
 		--disable-strip \
-		--prefix-dir="${EPREFIX}" \
-		--binary-dir="/usr/bin" \
-		--data-dir="/usr/share/${PN}" \
+		--prefix-dir="${EPREFIX}/usr" \
+		--binary-dir="bin" \
 		--install-dir="${D}" \
-		--icon-dir=/usr/share/pixmaps \
-		--menu-dir=/usr/share/applications \
-		--icon-theme-dir=/usr/share/icons/hicolor \
-		--man-dir=/usr/share/man/man6 \
-		--doc-dir=/usr/share/doc/${PF} \
 		--menu-group="Game;Simulation;" \
 		${myopts[@]} \
 		$(use_with iconv) \


### PR DESCRIPTION
**@gentoo/games**

This resolves gentoo bug [#600272](https://bugs.gentoo.org/show_bug.cgi?id=600272)

Note that according to recent [QA policy](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Policies#Games) it is allowed to install games data files to /usr/share/games and this is the case. Besides that IMHO it's better to keep using this dir than mess with some sophisticated version dependencies on games-misc/open{gfx,msx,sfx}.

Also correctly bumped games-misc/open{gfx,msx,sfx} to EAPI 6 to avoid recurring of this issue later.