### PR TITLE
app-misc/scrub: EAPI=6 bump, update description

### DIFF
--- a/app-misc/scrub/metadata.xml
+++ b/app-misc/scrub/metadata.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>dev-zero@gentoo.org</email>
-    <name>Tiziano Müller</name>
-  </maintainer>
-  <upstream>
-    <remote-id type="github">chaos/scrub</remote-id>
-  </upstream>
+	<maintainer type="person">
+		<email>dev-zero@gentoo.org</email>
+		<name>Tiziano Müller</name>
+	</maintainer>
+	<longdescription>Scrub overwrites files, hard disks, and other devices with repeating patterns intended to make recovering data from these devices more difficult.
+	</longdescription>
+	<upstream>
+		<remote-id type="github">chaos/scrub</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/app-misc/scrub/scrub-2.5.2-r1.ebuild
+++ b/app-misc/scrub/scrub-2.5.2-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+DESCRIPTION="Overwrite files, directories or blockdevices with iterative patterns."
+HOMEPAGE="https://github.com/chaos/scrub"
+SRC_URI="https://github.com/chaos/${PN}/archive/${PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~sparc ~x86"
+IUSE=""
+
+DEPEND=""
+RDEPEND=""

--- a/app-misc/scrub/scrub-2.6.1-r1.ebuild
+++ b/app-misc/scrub/scrub-2.6.1-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+DESCRIPTION="Overwrite files, directories or blockdevices with iterative patterns."
+HOMEPAGE="https://github.com/chaos/scrub"
+SRC_URI="https://github.com/chaos/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~sparc ~x86"
+IUSE=""
+
+DEPEND=""
+RDEPEND=""


### PR DESCRIPTION
fixes https://bugs.gentoo.org/show_bug.cgi?id=533226