### PR TITLE
games-simulation/openttd: require icu-layoutex alongside with recent icu

### DIFF
--- a/games-simulation/openttd/openttd-1.6.0.ebuild
+++ b/games-simulation/openttd/openttd-1.6.0.ebuild
@@ -17,7 +17,17 @@ RESTRICT="test" # needs a graphics set in order to test
 
 RDEPEND="!dedicated? (
 		media-libs/libsdl[sound,X,video]
-		icu? ( dev-libs/icu:= )
+		icu? (
+			|| (
+				(
+					dev-libs/icu-layoutex
+					dev-libs/icu-le-hb
+					>=dev-libs/icu-58.1
+				)
+				<dev-libs/icu-58.1
+			)
+			dev-libs/icu:=
+		)
 		truetype? (
 			media-libs/fontconfig
 			media-libs/freetype:2


### PR DESCRIPTION
Gentoo bug: [601302](https://bugs.gentoo.org/show_bug.cgi?id=601302)

I believe it's ok to make such change to a stable ebuild because even despite dev-libs/icu-layoutex is not stabilized yet there is a stable alternative and it's better to have a ebuild with a bit obscure deps than having a broken one.
No revbump is needed because this fixes a build-time issue causing compilation failure.