### PR TITLE
dev-libs/sway: revbump to 0.11-r2

### DIFF
--- a/dev-libs/sway/sway-0.11-r2.ebuild
+++ b/dev-libs/sway/sway-0.11-r2.ebuild
@@ -59,13 +59,7 @@ src_configure() {
 	cmake-utils_src_configure
 }
 
-src_install() {
-	cmake-utils_src_install
-
-	use !systemd && fperms u+s /usr/bin/sway
-}
-
-FILECAPS=( cap_sys_ptrace usr/bin/sway )
+FILECAPS=( -M 4711 cap_sys_ptrace,cap_sys_tty_config usr/bin/sway )
 
 pkg_postinst() {
 	fcaps_pkg_postinst

--- a/dev-libs/sway/sway-9999.ebuild
+++ b/dev-libs/sway/sway-9999.ebuild
@@ -59,13 +59,7 @@ src_configure() {
 	cmake-utils_src_configure
 }
 
-src_install() {
-	cmake-utils_src_install
-
-	use !systemd && fperms u+s /usr/bin/sway
-}
-
-FILECAPS=( cap_sys_ptrace usr/bin/sway )
+FILECAPS=( -M 4711 cap_sys_ptrace,cap_sys_tty_config usr/bin/sway )
 
 pkg_postinst() {
 	fcaps_pkg_postinst


### PR DESCRIPTION
It turned out fcaps strips the SUID bit from binaries and cap_sys_tty_config is apparently required now as well (see https://github.com/SirCmpwn/sway/issues/1022).

Gentoo-Bug: https://bugs.gentoo.org/604098