### PR TITLE
Xfce4 meta arm64

### DIFF
--- a/dev-libs/keybinder/keybinder-0.3.1-r200.ebuild
+++ b/dev-libs/keybinder/keybinder-0.3.1-r200.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/engla/keybinder/releases/download/v${PV}/${P}.tar.gz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~mips ~ppc ~ppc64 x86"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~mips ~ppc ~ppc64 x86"
 IUSE="+introspection lua python"
 
 RDEPEND=">=x11-libs/gtk+-2.20:2

--- a/dev-libs/libunique/libunique-1.1.6-r2.ebuild
+++ b/dev-libs/libunique/libunique-1.1.6-r2.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://wiki.gnome.org/Attic/LibUnique"
 
 LICENSE="LGPL-2.1"
 SLOT="1"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux ~x86-solaris"
 IUSE="debug dbus +introspection"
 
 RDEPEND="

--- a/x11-libs/vte/vte-0.46.1.ebuild
+++ b/x11-libs/vte/vte-0.46.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://wiki.gnome.org/action/show/Apps/Terminal/VTE"
 LICENSE="LGPL-2+"
 SLOT="2.91"
 IUSE="+crypt debug glade +introspection vala"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~arm-linux ~x86-linux ~x64-solaris ~x86-solaris"
 REQUIRED_USE="vala? ( introspection )"
 
 RDEPEND="

--- a/xfce-base/libxfcegui4/libxfcegui4-4.10.0-r1.ebuild
+++ b/xfce-base/libxfcegui4/libxfcegui4-4.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -11,7 +11,7 @@ SRC_URI="mirror://xfce/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~ia64-linux ~x86-linux ~x64-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~ia64-linux ~x86-linux ~x64-solaris"
 IUSE="startup-notification"
 
 RDEPEND="gnome-base/libglade

--- a/xfce-extra/xfce4-cpugraph-plugin/xfce4-cpugraph-plugin-1.0.5.ebuild
+++ b/xfce-extra/xfce4-cpugraph-plugin/xfce4-cpugraph-plugin-1.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -11,7 +11,7 @@ SRC_URI="mirror://xfce/src/panel-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="BSD-2 GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux"
 IUSE="debug"
 
 RDEPEND=">=x11-libs/gtk+-2.12:2

--- a/xfce-extra/xfce4-datetime-plugin/xfce4-datetime-plugin-0.7.0.ebuild
+++ b/xfce-extra/xfce4-datetime-plugin/xfce4-datetime-plugin-0.7.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://xfce/src/panel-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~ia64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=xfce-base/libxfce4ui-4.12:=[gtk3(+)]

--- a/xfce-extra/xfce4-netspeed-plugin/xfce4-netspeed-plugin-0.3.1.ebuild
+++ b/xfce-extra/xfce4-netspeed-plugin/xfce4-netspeed-plugin-0.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -11,7 +11,7 @@ SRC_URI="https://${PN}.googlecode.com/files/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE=""
 
 RDEPEND=">=dev-libs/glib-2:=


### PR DESCRIPTION
Add ~arm64 keyword to some Xfrce4 packages so we can have Xfrce4 on Raspberry Pi 3 in 64 bit mode.  Cortex-A53