### PR TITLE
eclass/cuda.eclass: Fix passing compiler and linker options

### DIFF
--- a/eclass/cuda.eclass
+++ b/eclass/cuda.eclass
@@ -110,7 +110,7 @@ cuda_sanitize() {
 	NVCCFLAGS+=" $(cuda_gccdir -f)"
 
 	# Tell nvcc which flags should be used for underlying C compiler
-	NVCCFLAGS+=" --compiler-options=\"${CXXFLAGS}\" --linker-options=\"${rawldflags// /,}\""
+	NVCCFLAGS+=" --compiler-options \"${CXXFLAGS}\" --linker-options \"${rawldflags// /,}\""
 
 	debug-print "Using ${NVCCFLAGS} for cuda"
 	export NVCCFLAGS


### PR DESCRIPTION
As documented in 'nvcc --help', the correct syntax is:
--compiler-options <options>,...           (-Xcompiler)
--linker-options <options>,...             (-Xlinker)

@jlec @mgorny As discussed in PR #3013.