### PR TITLE
dev-tex/europecv: update HOMEPAGE, #473568

### DIFF
--- a/dev-tex/europecv/europecv-20060424-r2.ebuild
+++ b/dev-tex/europecv/europecv-20060424-r2.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 inherit latex-package
 
-DESCRIPTION="LaTeX class for the standard model for curricula vitae as recommended by the European Commission"
-HOMEPAGE="http://www.ctan.org/tex-archive/help/Catalogue/entries/europecv.html"
+DESCRIPTION="LaTeX class for the standard model for curricula vitae as recommended by the EC"
+HOMEPAGE="http://www.ctan.org/pkg/europecv"
 # Downloaded from:
 # ftp://cam.ctan.org/tex-archive/macros/latex/contrib/europecv.zip
 SRC_URI="mirror://gentoo/${P}.zip"

--- a/dev-tex/europecv/metadata.xml
+++ b/dev-tex/europecv/metadata.xml
@@ -5,4 +5,7 @@
 	<email>tex@gentoo.org</email>
 	<name>Gentoo TeX Project</name>
 </maintainer>
+<upstream>
+	<remote-id type="ctan">europecv</remote-id>
+</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/473568

also set upstream remote-id and made description smaller to make repoman happy