### PR TITLE
net-misc/tor-0.3.0.1_alpha-r1: use upstream's systemd service unit

### DIFF
--- a/net-misc/tor/tor-0.3.0.1_alpha-r1.ebuild
+++ b/net-misc/tor/tor-0.3.0.1_alpha-r1.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+inherit flag-o-matic readme.gentoo-r1 systemd versionator user
+
+MY_PV="$(replace_version_separator 4 -)"
+MY_PF="${PN}-${MY_PV}"
+DESCRIPTION="Anonymizing overlay network for TCP"
+HOMEPAGE="http://www.torproject.org/"
+SRC_URI="https://www.torproject.org/dist/${MY_PF}.tar.gz
+	https://archive.torproject.org/tor-package-archive/${MY_PF}.tar.gz"
+S="${WORKDIR}/${MY_PF}"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-macos"
+IUSE="libressl scrypt seccomp selinux systemd tor-hardening test web"
+
+DEPEND="
+	app-text/asciidoc
+	dev-libs/libevent[ssl]
+	sys-libs/zlib
+	!libressl? ( dev-libs/openssl:0=[-bindist] )
+	libressl? ( dev-libs/libressl:0= )
+	scrypt? ( app-crypt/libscrypt )
+	seccomp? ( sys-libs/libseccomp )
+	systemd? ( sys-apps/systemd )"
+RDEPEND="${DEPEND}
+	selinux? ( sec-policy/selinux-tor )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.2.7.4-torrc.sample.patch
+)
+
+DOCS=( README ChangeLog ReleaseNotes doc/HACKING )
+
+pkg_setup() {
+	enewgroup tor
+	enewuser tor -1 -1 /var/lib/tor tor
+}
+
+src_configure() {
+	econf \
+		--localstatedir="${EPREFIX}/var" \
+		--enable-system-torrc \
+		--enable-asciidoc \
+		$(use_enable scrypt libscrypt) \
+		$(use_enable seccomp) \
+		$(use_enable systemd) \
+		$(use_enable tor-hardening gcc-hardening) \
+		$(use_enable tor-hardening linker-hardening) \
+		$(use_enable web tor2web-mode) \
+		$(use_enable test unittests) \
+		$(use_enable test coverage)
+}
+
+src_install() {
+	default
+	readme.gentoo_create_doc
+
+	newconfd "${FILESDIR}"/tor.confd tor
+	newinitd "${FILESDIR}"/tor.initd-r8 tor
+	systemd_dounit contrib/dist/tor.service
+
+	keepdir /var/lib/tor
+
+	fperms 750 /var/lib/tor
+	fowners tor:tor /var/lib/tor
+
+	insinto /etc/tor/
+	newins "${FILESDIR}"/torrc-r1 torrc
+}


### PR DESCRIPTION
Set localstatedir to /var (Gentoo sets it to /var/lib) because that's what users and upstream expects.
With it set to /var/lib/, tor expects to use directories such as /var/lib/lib/tor and /var/lib/log, which are clearly incorrect.

https://bugs.gentoo.org/show_bug.cgi?id=529212