### PR TITLE
Remove useless '-' prefix from IUSE entries

### DIFF
--- a/app-admin/ulogd/ulogd-2.0.5_p20161017.ebuild
+++ b/app-admin/ulogd/ulogd-2.0.5_p20161017.ebuild
@@ -15,7 +15,7 @@ SRC_URI="http://git.netfilter.org/${PN}2/snapshot/${COMMIT_ID}.tar.gz -> ${P}.ta
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ~ia64 ppc x86"
-IUSE="dbi doc json mysql nfacct +nfct +nflog pcap postgres sqlite -ulog"
+IUSE="dbi doc json mysql nfacct +nfct +nflog pcap postgres sqlite ulog"
 
 RDEPEND="
 	|| ( net-firewall/iptables net-firewall/nftables )

--- a/media-video/mpv/mpv-0.18.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.18.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,7 +30,7 @@ LICENSE="GPL-2+ BSD ISC"
 SLOT="0"
 IUSE="aqua +alsa archive bluray cdda +cli coreaudio doc drm dvb dvd +egl +enca
 	encode gbm +iconv jack jpeg lcms +libass libav libcaca libguess libmpv lua
-	luajit openal +opengl oss pulseaudio raspberry-pi rubberband samba -sdl
+	luajit openal +opengl oss pulseaudio raspberry-pi rubberband samba sdl
 	selinux test uchardet v4l vaapi vdpau vf-dlopen wayland +X xinerama
 	+xscreensaver +xv zsh-completion"
 

--- a/media-video/mpv/mpv-0.22.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.22.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,7 +30,7 @@ LICENSE="GPL-2+ BSD ISC"
 SLOT="0"
 IUSE="aqua +alsa archive bluray cdda +cli coreaudio doc drm dvb dvd +egl +enca
 	encode gbm +iconv jack jpeg lcms +libass libav libcaca libguess libmpv +lua
-	luajit openal +opengl oss pulseaudio raspberry-pi rubberband samba -sdl
+	luajit openal +opengl oss pulseaudio raspberry-pi rubberband samba sdl
 	selinux test tools +uchardet v4l vaapi vdpau vf-dlopen wayland +X xinerama
 	+xscreensaver +xv zsh-completion"
 

--- a/media-video/mpv/mpv-0.23.0.ebuild
+++ b/media-video/mpv/mpv-0.23.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,9 +30,9 @@ LICENSE="GPL-2+ BSD ISC"
 SLOT="0"
 IUSE="aqua +alsa archive bluray cdda +cli coreaudio doc drm dvb dvd +egl encode
 	gbm +iconv jack jpeg lcms +libass libav libcaca libmpv +lua luajit openal
-	+opengl oss pulseaudio raspberry-pi rubberband samba -sdl selinux test
-	tools +uchardet v4l vaapi vdpau vf-dlopen wayland +X xinerama +xscreensaver
-	+xv zsh-completion"
+	+opengl oss pulseaudio raspberry-pi rubberband samba sdl selinux test tools
+	+uchardet v4l vaapi vdpau vf-dlopen wayland +X xinerama +xscreensaver +xv
+	zsh-completion"
 
 REQUIRED_USE="
 	|| ( cli libmpv )

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,9 +30,9 @@ LICENSE="GPL-2+ BSD ISC"
 SLOT="0"
 IUSE="aqua +alsa archive bluray cdda +cli coreaudio doc drm dvb dvd +egl encode
 	gbm +iconv jack jpeg lcms +libass libav libcaca libmpv +lua luajit openal
-	+opengl oss pulseaudio raspberry-pi rubberband samba -sdl selinux test
-	tools +uchardet v4l vaapi vdpau vf-dlopen wayland +X xinerama +xscreensaver
-	+xv zsh-completion"
+	+opengl oss pulseaudio raspberry-pi rubberband samba sdl selinux test tools
+	+uchardet v4l vaapi vdpau vf-dlopen wayland +X xinerama +xscreensaver +xv
+	zsh-completion"
 
 REQUIRED_USE="
 	|| ( cli libmpv )


### PR DESCRIPTION
According to devmanual section on IUSE[1], '-' IUSE prefix is only good
for overriding repo-level USE settings (profiles/package.use), which we
don't have in Gentoo.

[1]: https://devmanual.gentoo.org/eclass-reference/ebuild/