### PR TITLE
sys-devel/gdb: allow src_test to fail

### DIFF
--- a/sys-devel/gdb/gdb-7.10.1.ebuild
+++ b/sys-devel/gdb/gdb-7.10.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -167,7 +167,7 @@ src_configure() {
 }
 
 src_test() {
-	nonfatal emake check || ewarn "tests failed"
+	emake check || die 'tests failed'
 }
 
 src_install() {

--- a/sys-devel/gdb/gdb-7.11.1.ebuild
+++ b/sys-devel/gdb/gdb-7.11.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -166,7 +166,7 @@ src_configure() {
 }
 
 src_test() {
-	nonfatal emake check || ewarn "tests failed"
+	emake check || die 'tests failed'
 }
 
 src_install() {

--- a/sys-devel/gdb/gdb-7.11.ebuild
+++ b/sys-devel/gdb/gdb-7.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -167,7 +167,7 @@ src_configure() {
 }
 
 src_test() {
-	nonfatal emake check || ewarn "tests failed"
+	emake check || die 'tests failed'
 }
 
 src_install() {

--- a/sys-devel/gdb/gdb-7.12.ebuild
+++ b/sys-devel/gdb/gdb-7.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -166,7 +166,7 @@ src_configure() {
 }
 
 src_test() {
-	nonfatal emake check || ewarn "tests failed"
+	emake check || die 'tests failed'
 }
 
 src_install() {

--- a/sys-devel/gdb/gdb-7.9.1.ebuild
+++ b/sys-devel/gdb/gdb-7.9.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -162,7 +162,7 @@ src_configure() {
 }
 
 src_test() {
-	nonfatal emake check || ewarn "tests failed"
+	emake check || die 'tests failed'
 }
 
 src_install() {

--- a/sys-devel/gdb/gdb-9999.ebuild
+++ b/sys-devel/gdb/gdb-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -165,7 +165,7 @@ src_configure() {
 }
 
 src_test() {
-	nonfatal emake check || ewarn "tests failed"
+	emake check || die 'tests failed'
 }
 
 src_install() {


### PR DESCRIPTION
Currently, gdb doesn't fail to get merged, even if the tests fails. But the PMS requires that if `make check` or `make test` fails, `src_test` should also fail.

I've only tested it for 7.10.1, but it should work for the other versions too.

Also, updated the copyright, as repoman automatically did.