### PR TITLE
app-office/scribus: Avoid excessive amounts of warnings

### DIFF
--- a/app-office/scribus/scribus-1.5.2-r2.ebuild
+++ b/app-office/scribus/scribus-1.5.2-r2.ebuild
@@ -157,7 +157,7 @@ src_install() {
 	# en_EN can be deleted always
 	for lang in ${IUSE_LINGUAS}; do
 		if ! use linguas_${lang}; then
-			_lang=$(translate_lang)
+			_lang=$(translate_lang ${lang})
 			safe_delete "${ED%/}"/usr/share/man/${_lang}
 		fi
 	done
@@ -205,8 +205,6 @@ safe_delete () {
 			ebegin "Deleting ${x}"
 			rm "${x}" || die
 			eend $?
-		else
-			ewarn "${x} not found"
 		fi
 	done
 }


### PR DESCRIPTION
I've seen a *huge* number of `ewarn` lines in my portage log for my most recent scribus update. Some of it during configure due to the fact that named resources simply don't exist. Some of it during install because someone forgot the argument to the `translate_lang` function.