### PR TITLE
app-text/po4a: fix sgml and tex module regexp's against perl-5.22

### DIFF
--- a/app-text/po4a/files/po4a-0.45-Port-our-regex-to-Perl-5.22-patch-by-Roderich-Schupp.patch
+++ b/app-text/po4a/files/po4a-0.45-Port-our-regex-to-Perl-5.22-patch-by-Roderich-Schupp.patch
@@ -1,0 +1,44 @@
+Fix sgml and tex regex against perl-5.22. See Gentoo-bug: 604428.
+Based on a patch from upstream git. Original commit info:
+From 44e5c2f02b3166536257bc9d6384d41dda386648 Mon Sep 17 00:00:00 2001
+From: Martin Quinson <martin.quinson@loria.fr>
+Date: Fri, 28 Aug 2015 19:01:17 +0200
+Subject: [PATCH] Port our regex to Perl 5.22 (patch by Roderich Schupp)
+
+---
+ lib/Locale/Po4a/Sgml.pm | 4 ++--
+ lib/Locale/Po4a/TeX.pm  | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lib/Locale/Po4a/Sgml.pm b/lib/Locale/Po4a/Sgml.pm
+index 742e003..3ad5e8d 100644
+--- a/lib/Locale/Po4a/Sgml.pm
++++ b/lib/Locale/Po4a/Sgml.pm
+@@ -672,9 +672,9 @@ sub parse_file {
+             }
+         }
+     }
+-    $prolog =~ s/<!--{PO4A-ent-beg-(.*?)}(.*?){PO4A-ent-end}-->/<!ENTITY % $1 SYSTEM "$2">/g;
++    $prolog =~ s/<!--\{PO4A-ent-beg-(.*?)\}(.*?)\{PO4A-ent-end\}-->/<!ENTITY % $1 SYSTEM "$2">/g;
+     # Unprotect undefined inclusions, and die of them
+-    $prolog =~ s/{PO4A-percent}/%/sg;
++    $prolog =~ s/\{PO4A-percent\}/%/sg;
+     if ($prolog =~ /%([^;\s]*);/) {
+         die wrap_mod("po4a::sgml",
+                      dgettext("po4a",
+diff --git a/lib/Locale/Po4a/TeX.pm b/lib/Locale/Po4a/TeX.pm
+index a78f94b..0faa465 100644
+--- a/lib/Locale/Po4a/TeX.pm
++++ b/lib/Locale/Po4a/TeX.pm
+@@ -1168,7 +1168,7 @@ sub parse {
+ #       environment contains an un-closed bracket)
+         if (   ($closed and ($line =~ /^\s*$/ or
+                              $line =~ /^\s*$RE_VERBATIM\s*$/))
+-            or (in_verbatim(@env) and $line =~ /^\s*\Q$ESCAPE\Eend{$env[-1]}\s*$/)
++            or (in_verbatim(@env) and $line =~ /^\s*\Q$ESCAPE\Eend\{$env[-1]\}\s*$/)
+            ) {
+             # An empty line. This indicates the end of the current
+             # paragraph.
+-- 
+2.10.2
+

--- a/app-text/po4a/po4a-0.45-r4.ebuild
+++ b/app-text/po4a/po4a-0.45-r4.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PLOCALES="af ca cs da de eo es et eu fr hr id it ja kn ko nb nl pl pt_BR pt ru sl sv uk vi zh_CN zh_HK"
+PLOCALES_BACKUP="en"
+
+# Needed because this package also installs to vendor_perl
+GENTOO_DEPEND_ON_PERL=noslotop
+inherit perl-module l10n
+
+DESCRIPTION="Tools for helping translation of documentation"
+HOMEPAGE="http://po4a.alioth.debian.org"
+SRC_URI="mirror://debian/pool/main/p/po4a/${PN}_${PV}.orig.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
+IUSE="test"
+
+RDEPEND="dev-perl/SGMLSpm
+	>=sys-devel/gettext-0.13
+	app-text/openjade
+	dev-libs/libxslt
+	dev-perl/Locale-gettext
+	dev-perl/TermReadKey
+	dev-perl/Text-WrapI18N"
+DEPEND="${RDEPEND}
+	>=dev-perl/Module-Build-0.380.0
+	app-text/docbook-xsl-stylesheets
+	app-text/docbook-xml-dtd:4.1.2
+	test? ( app-text/docbook-sgml-dtd
+		app-text/docbook-sgml-utils
+		virtual/tex-base )"
+
+# Running tests in parallel fails
+DIST_TEST="do"
+
+PATCHES=(
+	"${FILESDIR}/${P}-Port-our-regex-to-Perl-5.22-patch-by-Roderich-Schupp.patch"
+)
+
+src_prepare() {
+	# Check against locale files in ${S}/pod/bin for mismatches
+	# with languages listed in PLOCALES
+	local locales_path="$S/po/bin"
+	l10n_find_plocales_changes "$locales_path" "" ".po"
+
+	# Get rid of disabled locales
+	my_get_disabled_locales() {
+		PERL_RM_FILES=( "${PERL_RM_FILES[@]}" "po/bin/${1}.po" "po/pod/${1}.po" )
+	}
+
+	l10n_for_each_disabled_locale_do my_get_disabled_locales
+
+	einfo "Your LINGUAS lists the following languages: $LINGUAS"
+
+	perl-module_src_prepare
+}


### PR DESCRIPTION
Gentoo-Bug: 604428
Also bump to EAPI=6