### PR TITLE
media-video/aegisub: remove uneeded virtual/os-headers build dependency

### DIFF
--- a/media-video/aegisub/aegisub-3.2.2_p20160518-r1.ebuild
+++ b/media-video/aegisub/aegisub-3.2.2_p20160518-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -46,7 +46,6 @@ DEPEND="${RDEPEND}
 	dev-util/intltool
 	sys-devel/gettext
 	virtual/pkgconfig
-	oss? ( virtual/os-headers )
 	test? (
 		~dev-cpp/gtest-1.7.0
 		dev-lua/busted

--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -47,7 +47,6 @@ DEPEND="${RDEPEND}
 	dev-util/intltool
 	sys-devel/gettext
 	virtual/pkgconfig
-	oss? ( virtual/os-headers )
 	test? (
 		~dev-cpp/gtest-1.7.0
 		dev-lua/busted


### PR DESCRIPTION
Aegisub doesn't use kernel headers for OSS support or anything else.

Package-Manager: Portage-2.3.3, Repoman-2.3.1