### PR TITLE
app-emulation/virtualbox-modules: fix build with objtree != srctree

### DIFF
--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.0.16.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.0.16.ebuild
@@ -35,7 +35,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} KERNOUT=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.0.30.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.0.30.ebuild
@@ -35,7 +35,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} KERNOUT=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.1.10.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.1.10.ebuild
@@ -39,7 +39,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} KERNOUT=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.1.12.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.1.12.ebuild
@@ -35,7 +35,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} KERNOUT=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {


### PR DESCRIPTION
This was originaly reported [as bug 285866](https://bugs.gentoo.org/show_bug.cgi?id=285866), was fixed in all virtualbox-modules ebuilds with [PR 150](https://github.com/gentoo/gentoo-portage-rsync-mirror/pull/150) at first Gentoo Github mirror and again introduced in [commit 4eaf73cd](https://gitweb.gentoo.org/repo/gentoo/historical.git/commit/app-emulation/virtualbox-modules?id=4eaf73cd60bb6550c77d6f6df4409fb5e5205b37)