### PR TITLE
sys-apps/pcmciautils: flex-2.6.3 compatibility fix

### DIFF
--- a/sys-apps/pcmciautils/files/pcmciautils-018_p8-flex-2.6.3-fix.patch
+++ b/sys-apps/pcmciautils/files/pcmciautils-018_p8-flex-2.6.3-fix.patch
@@ -1,0 +1,27 @@
+--- pcmciautils-018/src/lex_config.l.old	2017-01-07 08:59:11.657675837 -0800
++++ pcmciautils-018/src/lex_config.l	2017-01-07 08:59:55.554017208 -0800
+@@ -1,8 +1,8 @@
+ /* Special state for handling include files */
+ %x src
+-%option noinput nounput
++%option noinput nounput noyywrap
+ 
+ %{
+ /*
+  * Startup tool for non statically mapped PCMCIA sockets
+  *
+@@ -75,14 +75,10 @@ module		/* skip */ ;
+ 
+ .		return yytext[0];
+ 
+ %%
+ 
+-#ifndef yywrap
+-int yywrap() { return 1; }
+-#endif
+-
+ /*======================================================================
+ 
+     Stuff to parse basic data types
+ 
+ ======================================================================*/

--- a/sys-apps/pcmciautils/pcmciautils-018_p8-r1.ebuild
+++ b/sys-apps/pcmciautils/pcmciautils-018_p8-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
-inherit eutils flag-o-matic linux-info toolchain-funcs udev
+EAPI=6
+inherit flag-o-matic linux-info toolchain-funcs udev
 
 DEB_REV=${PV#*_p}
 MY_PV=${PV%_p*}
@@ -51,11 +51,14 @@ pkg_setup() {
 	use debug && append-cppflags -DDEBUG
 }
 
-src_prepare() {
-	epatch \
-		"${WORKDIR}"/debian/patches/no-modprobe-rules.patch \
-		"${WORKDIR}"/debian/patches/remove-libsysfs-dep.patch
+PATCHES=(
+	"${WORKDIR}"/debian/patches/no-modprobe-rules.patch
+	"${WORKDIR}"/debian/patches/remove-libsysfs-dep.patch
+	"${FILESDIR}"/${P}-flex-2.6.3-fix.patch
+)
 
+src_prepare() {
+	default
 	sed -i \
 		-e '/CFLAGS/s:-fomit-frame-pointer::' \
 		-e '/dir/s:sbin:bin:g' \


### PR DESCRIPTION
Fixes yywrap errors caused by behavior changes in flex-2.6.3.

Gentoo-bug: 604606

Package-Manager: Portage-2.3.3, Repoman-2.3.1