### PR TITLE
dev-python/ansicolor: add missing dev-python/setuptools DEPEND

### DIFF
--- a/dev-python/ansicolor/ansicolor-0.2.1.ebuild
+++ b/dev-python/ansicolor/ansicolor-0.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -18,3 +18,5 @@ SLOT="0"
 LICENSE="Apache-2.0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-python/ansicolor/ansicolor-0.2.4.ebuild
+++ b/dev-python/ansicolor/ansicolor-0.2.4.ebuild
@@ -18,3 +18,5 @@ SLOT="0"
 LICENSE="Apache-2.0"
 KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
 IUSE=""
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"


### PR DESCRIPTION
https://github.com/numerodix/ansicolor/blob/0.2.4/setup.py#L1