### PR TITLE
sys-apps/usb_modeswitch: udev scripts need RW temporary directory

### DIFF
--- a/sys-apps/usb_modeswitch/files/usb_modeswitch.sh-tmpdir.patch
+++ b/sys-apps/usb_modeswitch/files/usb_modeswitch.sh-tmpdir.patch
@@ -1,0 +1,18 @@
+Script that this patch modifies and usb_modeswitch_dispatcher Tcl script
+that is being called by it both need a writable temporary directory which
+is a problematic requirement for example if usb_modeswitch is triggered
+by a module loaded during system startup.
+Fortunately, /run is available very early at boot so let's redirect them
+there instead.
+
+--- a/usb_modeswitch.sh	2016-11-29 17:29:47.000000000 +0100
++++ b/usb_modeswitch.sh	2016-11-30 01:11:51.747993839 +0100
+@@ -17,6 +17,8 @@
+ 	return 0
+ }
+ 
++export TMPDIR=/run
++
+ if [ $(expr "$1" : "--.*") ]; then
+ 	p_id=$4
+ 	if [ -z $p_id ]; then

--- a/sys-apps/usb_modeswitch/usb_modeswitch-2.4.0-r1.ebuild
+++ b/sys-apps/usb_modeswitch/usb_modeswitch-2.4.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -37,6 +37,7 @@ CONFIG_CHECK="~USB_SERIAL"
 
 src_prepare() {
 	sed -i -e '/install.*BIN/s:-s::' Makefile || die
+	epatch "${FILESDIR}/usb_modeswitch.sh-tmpdir.patch"
 }
 
 src_compile() {


### PR DESCRIPTION
/lib/udev/usb_modeswitch script and usb_modeswitch_dispatcher Tcl script
that it calls both need a writable temporary directory which is a
problematic requirement for example if usb_modeswitch is triggered by a
module loaded during system startup.
Fortunately, /run is available RW very early at boot so let's redirect them
there instead.

Fixes a case where system startup with an USB modem plugged in would often
result in this modem not being switched correctly if USB host controller
modules are loaded via the "modules" service.

Gentoo-Bug: https://bugs.gentoo.org/565262