### PR TITLE
dev-tex/harvard: update HOMEPAGE, #533822

### DIFF
--- a/dev-tex/harvard/harvard-2.0.5.ebuild
+++ b/dev-tex/harvard/harvard-2.0.5.ebuild
@@ -1,13 +1,12 @@
-# Copyright 1999-2006 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 inherit latex-package
 
 DESCRIPTION="The harvard family of bibliographic styles"
-HOMEPAGE="http://www.arch.su.edu.au/~peterw/latex/harvard/"
-SRC_URI="mirror://gentoo/${P}.tar.bz2
-	https://dev.gentoo.org/~dholm/files/${P}.tar.bz2"
+HOMEPAGE="https://www.ctan.org/pkg/harvard"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ppc x86"

--- a/dev-tex/harvard/metadata.xml
+++ b/dev-tex/harvard/metadata.xml
@@ -5,4 +5,7 @@
 	<email>tex@gentoo.org</email>
 	<name>Gentoo TeX Project</name>
 </maintainer>
+<upstream>
+	<remote-id type="ctan">harvard</remote-id>
+</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/533822
Gentoo-Bug: https://bugs.gentoo.org/470062

Added a revbump because added RDEPEND (similar to other latex packages). The package would not compile without pdflatex (and thus needs latexextra).

Was not sure whether to remove the regular 2.0.5.ebuild. This one does not build on a fresh stage3 environment.