### PR TITLE
games-emulation/pcsx2: fixed compilation with gcc 5

### DIFF
--- a/games-emulation/pcsx2/files/pcsx2-1.4.0-gcc5.patch
+++ b/games-emulation/pcsx2/files/pcsx2-1.4.0-gcc5.patch
@@ -1,0 +1,26 @@
+From 71991f24ef75b7da678d8de8d593bf82677d2708 Mon Sep 17 00:00:00 2001
+From: Yuri Konotopov <ykonotopov@gnome.org>
+Date: Mon, 9 Jan 2017 18:37:44 +0400
+Subject: [PATCH] x86emitter: gcc 5 compilation fix
+
+---
+ common/src/x86emitter/cpudetect.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/common/src/x86emitter/cpudetect.cpp b/common/src/x86emitter/cpudetect.cpp
+index 717ca89..cf94d7f 100644
+--- a/common/src/x86emitter/cpudetect.cpp
++++ b/common/src/x86emitter/cpudetect.cpp
+@@ -16,6 +16,9 @@
+ #include "PrecompiledHeader.h"
+ #include "cpudetect_internal.h"
+ #include "internal.h"
++#if defined(__GNUC__)
++#include "x86intrin.h"
++#endif
+ 
+ using namespace x86Emitter;
+ 
+-- 
+2.10.2
+

--- a/games-emulation/pcsx2/pcsx2-1.4.0.ebuild
+++ b/games-emulation/pcsx2/pcsx2-1.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -43,6 +43,8 @@ DEPEND="${RDEPEND}
 "
 
 S="${WORKDIR}/${PN}-${MY_PV}"
+
+PATCHES=( "${FILESDIR}"/"${P}"-gcc5.patch )
 
 clean_locale() {
 	rm -R "${S}"/locales/"${1}" || die


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=605162