### PR TITLE
gnome-extra/cinnamon-screensaver: Fix missing setproctitle RDEPEND

### DIFF
--- a/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-3.2.13.ebuild
+++ b/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-3.2.13.ebuild
@@ -47,6 +47,7 @@ RDEPEND="
 	!~gnome-extra/cinnamon-1.8.8.1
 	!systemd? ( sys-auth/consolekit )
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	dev-python/setproctitle[${PYTHON_USEDEP}]
 "
 DEPEND="${COMMON_DEPEND}
 	>=dev-util/intltool-0.35


### PR DESCRIPTION
dev-python/setproctitle RDEPEND has been removed from the gnome-extra/cinnamon-screensaver-3.2.13 ebuild (as compared to 3.2.6) but seems to be still required.

Gentoo-Bug: [605194](https://bugs.gentoo.org/605194)
Package-Manager: portage-2.3.0