### PR TITLE
app-emulation/lxd: Remove static dependency to deprecated cgmanager module

### DIFF
--- a/app-emulation/lxd/files/lxd.service
+++ b/app-emulation/lxd/files/lxd.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Container hypervisor based on LXC
-After=cgmanager.service
-Requires=cgmanager.service
 
 [Service]
 ExecStart=/usr/sbin/lxd --group lxd

--- a/app-emulation/lxd/lxd-2.7.ebuild
+++ b/app-emulation/lxd/lxd-2.7.ebuild
@@ -24,7 +24,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 PLOCALES="de fr ja"
-IUSE="+daemon nls test"
+IUSE="+daemon nls test cgmanager"
 
 # IUSE and PLOCALES must be defined before l10n inherited
 inherit bash-completion-r1 golang-build l10n linux-info systemd user vcs-snapshot
@@ -44,10 +44,13 @@ DEPEND="
 "
 
 RDEPEND="
-	daemon? (
+	cgmanager? (
 		app-admin/cgmanager
-		app-arch/xz-utils
 		app-emulation/lxc[cgmanager,seccomp]
+	)
+	daemon? (
+		app-arch/xz-utils
+		app-emulation/lxc[seccomp]
 		net-dns/dnsmasq[dhcp,ipv6]
 		net-misc/rsync[xattr]
 		sys-apps/iproute2[ipv6]

--- a/app-emulation/lxd/metadata.xml
+++ b/app-emulation/lxd/metadata.xml
@@ -18,5 +18,6 @@
 		<flag name="daemon">
 			Build the system daemon, not just the client tool
 		</flag>
+		<flag name="cgmanager">Enable support for cgroup management using <pkg>app-admin/cgmanager</pkg></flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
As visible on LXC homepage cgmanager is deprecated and doesn't work correctly with last systemd version (see https://github.com/lxc/cgmanager/issues/32). I maintain cgmanager dependency as optional use flag for older system.

Package-Manager: Portage-2.3.0, Repoman-2.3.1