### PR TITLE
dev-perl/mime-construct: add "Date" field to generated messages

### DIFF
--- a/dev-perl/mime-construct/files/mime-construct-add-date-header.patch
+++ b/dev-perl/mime-construct/files/mime-construct-add-date-header.patch
@@ -1,0 +1,18 @@
+--- a/mime-construct	2012-10-07 21:01:11.849644407 +0200
++++ b/mime-construct	2015-02-24 00:00:15.843791068 +0100
+@@ -28,6 +28,7 @@
+ #    - continue long header lines I construct
+ 
+ use Proc::WaitStat qw(close_die);
++use Email::Date::Format qw(email_date);
+ 
+ (my $Me = $0) =~ s-.*/--;
+ my # new line required for makemaker
+@@ -491,6 +492,7 @@
+ 
+     push @output, cont "To: ", join(", ", @to), "\n" if @to;
+     push @output, cont "Cc: ", join(", ", @cc), "\n" if @cc;
++    push @output, cont "Date: ", email_date, "\n";
+     push @output, cont "Subject: $subject\n" if $subject ne '';
+ 
+     push @output, $header if $header ne '';

--- a/dev-perl/mime-construct/mime-construct-1.1100.0-r1.ebuild
+++ b/dev-perl/mime-construct/mime-construct-1.1100.0-r1.ebuild
@@ -17,7 +17,10 @@ IUSE=""
 
 RDEPEND="
 	virtual/perl-MIME-Base64
+	dev-perl/Email-Date-Format
 	dev-perl/MIME-Types
 	dev-perl/Proc-WaitStat
 "
 DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}/${PN}-add-date-header.patch" )


### PR DESCRIPTION
Currently, mime-construct does not include the "Date" field in generated
messages.

The "Date" field is required according to the RFC 5322 and not every MTA or
SMTP client adds it when it is missing (for example mail-mta/msmtp does not
do it).

Mail clients often timestamp messages lacking this field as either
01.01.1970 or a date the message was first seen by a particular client
rather than as an actual posting date.

This issue was reported upstream a year ago but there was no response - the
software had last release in 2010 so it is probably no longer maintained.

That's why we have to add the missing field ourselves.

Gentoo-Bug: https://bugs.gentoo.org/583882
Package-Manager: Portage-2.3.3, Repoman-2.3.1
