### PR TITLE
x11-terms/xterm: needs x11-apps/rgb for colors

### DIFF
--- a/x11-terms/xterm/xterm-314.ebuild
+++ b/x11-terms/xterm/xterm-314.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -29,7 +29,8 @@ COMMON_DEPEND="kernel_linux? ( sys-libs/libutempter )
 	unicode? ( x11-apps/luit )
 	Xaw3d? ( x11-libs/libXaw3d )"
 RDEPEND="${COMMON_DEPEND}
-	media-fonts/font-misc-misc"
+	media-fonts/font-misc-misc
+	x11-apps/rgb"
 DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	x11-proto/kbproto

--- a/x11-terms/xterm/xterm-320.ebuild
+++ b/x11-terms/xterm/xterm-320.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -29,7 +29,8 @@ COMMON_DEPEND="kernel_linux? ( sys-libs/libutempter )
 	unicode? ( x11-apps/luit )
 	Xaw3d? ( x11-libs/libXaw3d )"
 RDEPEND="${COMMON_DEPEND}
-	media-fonts/font-misc-misc"
+	media-fonts/font-misc-misc
+	x11-apps/rgb"
 DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	x11-proto/kbproto

--- a/x11-terms/xterm/xterm-325.ebuild
+++ b/x11-terms/xterm/xterm-325.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,7 +30,8 @@ COMMON_DEPEND="kernel_linux? ( sys-libs/libutempter )
 	Xaw3d? ( x11-libs/libXaw3d )
 	xinerama? ( x11-libs/libXinerama )"
 RDEPEND="${COMMON_DEPEND}
-	media-fonts/font-misc-misc"
+	media-fonts/font-misc-misc
+	x11-apps/rgb"
 DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	x11-proto/kbproto

--- a/x11-terms/xterm/xterm-326.ebuild
+++ b/x11-terms/xterm/xterm-326.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,7 +30,8 @@ COMMON_DEPEND="kernel_linux? ( sys-libs/libutempter )
 	Xaw3d? ( x11-libs/libXaw3d )
 	xinerama? ( x11-libs/libXinerama )"
 RDEPEND="${COMMON_DEPEND}
-	media-fonts/font-misc-misc"
+	media-fonts/font-misc-misc
+	x11-apps/rgb"
 DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	x11-proto/kbproto

--- a/x11-terms/xterm/xterm-327.ebuild
+++ b/x11-terms/xterm/xterm-327.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -30,7 +30,8 @@ COMMON_DEPEND="kernel_linux? ( sys-libs/libutempter )
 	Xaw3d? ( x11-libs/libXaw3d )
 	xinerama? ( x11-libs/libXinerama )"
 RDEPEND="${COMMON_DEPEND}
-	media-fonts/font-misc-misc"
+	media-fonts/font-misc-misc
+	x11-apps/rgb"
 DEPEND="${COMMON_DEPEND}
 	virtual/pkgconfig
 	x11-proto/kbproto


### PR DESCRIPTION
This package needs to runtime depend on x11-apps/rgb, because without it
installed there are no colors displayed in an xterm window - besides black.
Text in any other color is not shown.

x11-apps/rgb is currently pulled in by x11-base/xorg-server, but there are
also ways to run xterm on a system which do not use the Xorg server: for
example NX.

Gentoo-Bug: https://bugs.gentoo.org/545496
Package-Manager: Portage-2.3.3, Repoman-2.3.1