### PR TITLE
app-admin/webapp-config: respect EPREFIX during src_install

### DIFF
--- a/app-admin/webapp-config/webapp-config-1.52-r1.ebuild
+++ b/app-admin/webapp-config/webapp-config-1.52-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -36,7 +36,7 @@ python_install() {
 	# distutils does not provide for specifying two different script install
 	# locations. Since we only install one script here the following should
 	# be ok
-	distutils-r1_python_install --install-scripts="/usr/sbin"
+	distutils-r1_python_install --install-scripts="${EPREFIX}/usr/sbin"
 }
 
 python_install_all() {

--- a/app-admin/webapp-config/webapp-config-1.53-r2.ebuild
+++ b/app-admin/webapp-config/webapp-config-1.53-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -39,7 +39,7 @@ python_install() {
 	# distutils does not provide for specifying two different script install
 	# locations. Since we only install one script here the following should
 	# be ok
-	distutils-r1_python_install --install-scripts="/usr/sbin"
+	distutils-r1_python_install --install-scripts="${EPREFIX}/usr/sbin"
 }
 
 python_install_all() {

--- a/app-admin/webapp-config/webapp-config-1.54-r1.ebuild
+++ b/app-admin/webapp-config/webapp-config-1.54-r1.ebuild
@@ -35,7 +35,7 @@ python_install() {
 	# distutils does not provide for specifying two different script install
 	# locations. Since we only install one script here the following should
 	# be ok
-	distutils-r1_python_install --install-scripts="/usr/sbin"
+	distutils-r1_python_install --install-scripts="${EPREFIX}/usr/sbin"
 }
 
 python_install_all() {

--- a/app-admin/webapp-config/webapp-config-1.54-r2.ebuild
+++ b/app-admin/webapp-config/webapp-config-1.54-r2.ebuild
@@ -36,7 +36,7 @@ python_install() {
 	# distutils does not provide for specifying two different script install
 	# locations. Since we only install one script here the following should
 	# be ok
-	distutils-r1_python_install --install-scripts="/usr/sbin"
+	distutils-r1_python_install --install-scripts="${EPREFIX}/usr/sbin"
 }
 
 python_install_all() {

--- a/app-admin/webapp-config/webapp-config-9999.ebuild
+++ b/app-admin/webapp-config/webapp-config-9999.ebuild
@@ -40,7 +40,7 @@ python_install() {
 	# distutils does not provide for specifying two different script install
 	# locations. Since we only install one script here the following should
 	# be ok
-	distutils-r1_python_install --install-scripts="/usr/sbin"
+	distutils-r1_python_install --install-scripts="${EPREFIX}/usr/sbin"
 }
 
 python_install_all() {


### PR DESCRIPTION
It will not be enough because the application itself does not respect EPREFIX internally, namely /usr/portage/eclass/webapp.eclass file ignores EPREFIX:

 46 ETC_CONFIG="${ROOT}etc/vhosts/webapp-config"
 47 WEBAPP_CONFIG="${ROOT}usr/sbin/webapp-config"
 48 WEBAPP_CLEANER="${ROOT}usr/sbin/webapp-cleaner"

Do not know how to proceed further. Maybe EROOT is enough but I did not check other places in web-app's config code where that might be needed as well.