### PR TITLE
dev-util/systemtap: make dependency on libvirt explicit (bug 605052)

### DIFF
--- a/dev-util/systemtap/metadata.xml
+++ b/dev-util/systemtap/metadata.xml
@@ -4,4 +4,7 @@
 <maintainer type="person">
   <email>swegener@gentoo.org</email>
 </maintainer>
+  <use>
+    <flag name="libvirt">Support probing of libvirt domains.</flag>
+  </use>
 </pkgmetadata>

--- a/dev-util/systemtap/systemtap-2.9-r1.ebuild
+++ b/dev-util/systemtap/systemtap-2.9-r1.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit linux-info autotools eutils python-single-r1
+
+DESCRIPTION="A linux trace/probe tool"
+HOMEPAGE="http://www.sourceware.org/systemtap/"
+SRC_URI="http://www.sourceware.org/${PN}/ftp/releases/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+IUSE="libvirt sqlite"
+
+RDEPEND=">=dev-libs/elfutils-0.142
+	sys-libs/libcap
+	${PYTHON_DEPS}
+	libvirt? ( >=app-emulation/libvirt-1.0.2 )
+	sqlite? ( dev-db/sqlite:3 )"
+DEPEND="${RDEPEND}
+	>=sys-devel/gettext-0.18.2"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+CONFIG_CHECK="~KPROBES ~RELAY ~DEBUG_FS"
+ERROR_KPROBES="${PN} requires support for KProbes Instrumentation (KPROBES) - this can be enabled in 'Instrumentation Support -> Kprobes'."
+ERROR_RELAY="${PN} works with support for user space relay support (RELAY) - this can be enabled in 'General setup -> Kernel->user space relay support (formerly relayfs)'."
+ERROR_DEBUG_FS="${PN} works best with support for Debug Filesystem (DEBUG_FS) - this can be enabled in 'Kernel hacking -> Debug Filesystem'."
+
+DOCS="AUTHORS HACKING NEWS README"
+
+pkg_setup() {
+	linux-info_pkg_setup
+	python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	python_fix_shebang .
+
+	sed -i \
+		-e 's:-Werror::g' \
+		configure.ac \
+		Makefile.am \
+		staprun/Makefile.am \
+		stapdyn/Makefile.am \
+		buildrun.cxx \
+		testsuite/systemtap.unprivileged/unprivileged_probes.exp \
+		testsuite/systemtap.unprivileged/unprivileged_myproc.exp \
+		testsuite/systemtap.base/stmt_rel_user.exp \
+		testsuite/systemtap.base/sdt_va_args.exp \
+		testsuite/systemtap.base/sdt_misc.exp \
+		testsuite/systemtap.base/sdt.exp \
+		scripts/kprobes_test/gen_code.py \
+		|| die "Failed to clean up sources"
+
+	epatch_user
+
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--docdir="${EPREFIX}/usr/share/doc/${PF}" \
+		--without-rpm \
+		--disable-server \
+		--disable-docs \
+		--disable-refdocs \
+		--disable-grapher \
+		$(use_enable libvirt virt) \
+		$(use_enable sqlite)
+}

--- a/profiles/arch/amd64/use.mask
+++ b/profiles/arch/amd64/use.mask
@@ -7,6 +7,10 @@
 
 # SECTION: Unmask
 
+# Christophe Lermytte <gentoo@lermytte.be> (10 Jan 2017)
+# libvirt (the package pulled in by this flag) exists for this arch
+-libvirt
+
 # cilk has been ported to this arch.
 -cilk
 

--- a/profiles/arch/x86/use.mask
+++ b/profiles/arch/x86/use.mask
@@ -5,6 +5,10 @@
 # Unmask the flag which corresponds to ARCH.
 -x86
 
+# Christophe Lermytte <gentoo@lermytte.be> (10 Jan 2017)
+# libvirt (the package pulled in by this flag) exists for this arch
+-libvirt
+
 # 2015/11/13 - Daniel Kuehn <lejonet@gentoo.org>
 # Unmask sssd USE-flag as it is tested on this arch in regards to bugs
 # 540540 and 525674

--- a/profiles/default/linux/package.use.mask
+++ b/profiles/default/linux/package.use.mask
@@ -2,6 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+# Christophe Lermytte <gentoo@lermytte.be> (10/01/2017)
+# systemtap can depend on libvirt wich is currently amd64/x86 only
+dev-util/systemtap libvirt
+
 # Ian Whyman <thev00d00@gentoo.org> (31/12/2016)
 # Handbrake needs libav-12 which is masked.
 media-video/handbrake libav


### PR DESCRIPTION
Tested if linking to libvirt is following the new USE flag (and not the mere presence of libvirt on the filesystem)

Maksed USE flag on non-amd64/x86 as libvirt does not have keywords for those (as guided by @jmbsvicetto on #gentoo-dev-help)
