### PR TITLE
dev-libs/wlc: add xkb use to x11-libs/libxcb

### DIFF
--- a/dev-libs/wlc/wlc-0.0.5.ebuild
+++ b/dev-libs/wlc/wlc-0.0.5.ebuild
@@ -52,7 +52,7 @@ src_configure() {
 }
 
 pkg_postinst() {
-	if use X && !has_version 'x11-base/xorg-server[wayland]'
+	if use X && ! has_version 'x11-base/xorg-server[wayland]'
 	then
 		elog "You have enabled wlc's X11 support. To use Xwayland, you must emerge"
 		elog "'x11-base/xorg-server[wayland]'."

--- a/dev-libs/wlc/wlc-0.0.6.ebuild
+++ b/dev-libs/wlc/wlc-0.0.6.ebuild
@@ -53,7 +53,7 @@ src_configure() {
 }
 
 pkg_postinst() {
-	if use X && !use xwayland
+	if use X && ! use xwayland
 	then
 		elog "xwayland use flag is required for X11 applications support"
 	fi

--- a/dev-libs/wlc/wlc-0.0.7.ebuild
+++ b/dev-libs/wlc/wlc-0.0.7.ebuild
@@ -49,7 +49,7 @@ src_configure() {
 }
 
 pkg_postinst() {
-	if use X && !use xwayland; then
+	if use X && ! use xwayland; then
 		elog "xwayland use flag is required for X11 applications support"
 	fi
 	ewarn "This wlc version does not support displaying"

--- a/dev-libs/wlc/wlc-0.0.7.ebuild
+++ b/dev-libs/wlc/wlc-0.0.7.ebuild
@@ -25,7 +25,7 @@ RDEPEND="virtual/opengl
 	dev-libs/libinput
 	dev-libs/wayland
 	X? ( x11-libs/libX11
-		 x11-libs/libxcb
+		 x11-libs/libxcb[xkb]
 		 x11-libs/xcb-util-image
 		 x11-libs/xcb-util-wm
 		 x11-libs/libXfixes )

--- a/dev-libs/wlc/wlc-9999.ebuild
+++ b/dev-libs/wlc/wlc-9999.ebuild
@@ -53,7 +53,7 @@ src_configure() {
 }
 
 pkg_postinst() {
-	if use X && !use xwayland
+	if use X && ! use xwayland
 	then
 		elog "xwayland use flag is required for X11 applications support"
 	fi

--- a/dev-libs/wlc/wlc-9999.ebuild
+++ b/dev-libs/wlc/wlc-9999.ebuild
@@ -25,7 +25,7 @@ RDEPEND="virtual/opengl
 		dev-libs/libinput
 		dev-libs/wayland
 		X? ( x11-libs/libX11
-			 x11-libs/libxcb
+			 x11-libs/libxcb[xkb]
 			 x11-libs/xcb-util-image
 			 x11-libs/xcb-util-wm
 			 x11-libs/libXfixes )


### PR DESCRIPTION
It is required for libxkb to be present.

See https://bugs.gentoo.org/show_bug.cgi?id=605148