### PR TITLE
dev-lang/ruby: Fix build for ABI=x32

### DIFF
--- a/dev-lang/ruby/files/ruby-2.0.0_p647-SVNr39186-asm-volatile.diff
+++ b/dev-lang/ruby/files/ruby-2.0.0_p647-SVNr39186-asm-volatile.diff
@@ -1,0 +1,23 @@
+------------------------------------------------------------------------
+r39186 | kosaki | 2013-02-10 06:41:01 +0100 (Sun, 10 Feb 2013) | 1 line
+
+* gc.h (SET_MACHINE_STACK_END): use __volatile__ instead of volatile.
+
+Index: gc.h
+===================================================================
+--- gc.h	(revision 39185)
++++ gc.h	(revision 39186)
+@@ -3,9 +3,9 @@
+ #define RUBY_GC_H 1
+
+ #if defined(__x86_64__) && defined(__GNUC__) && !defined(__native_client__)
+-#define SET_MACHINE_STACK_END(p) __asm__ volatile ("movq\t%%rsp, %0" : "=r" (*(p)))
++#define SET_MACHINE_STACK_END(p) __asm__ __volatile__ ("movq\t%%rsp, %0" : "=r" (*(p)))
+ #elif defined(__i386) && defined(__GNUC__) && !defined(__native_client__)
+-#define SET_MACHINE_STACK_END(p) __asm__ volatile ("movl\t%%esp, %0" : "=r" (*(p)))
++#define SET_MACHINE_STACK_END(p) __asm__ __volatile__ ("movl\t%%esp, %0" : "=r" (*(p)))
+ #else
+ NOINLINE(void rb_gc_set_stack_end(VALUE **stack_end_p));
+ #define SET_MACHINE_STACK_END(p) rb_gc_set_stack_end(p)
+
+------------------------------------------------------------------------

--- a/dev-lang/ruby/files/ruby-2.0.0_p647-SVNr40636-asm-ilp32.diff
+++ b/dev-lang/ruby/files/ruby-2.0.0_p647-SVNr40636-asm-ilp32.diff
@@ -1,0 +1,22 @@
+------------------------------------------------------------------------
+r40636 | akr | 2013-05-10 17:49:56 +0200 (Fri, 10 May 2013) | 5 lines
+
+* gc.h (SET_MACHINE_STACK_END): Add !defined(_ILP32) to a defining
+  condition to avoid compilation error on x32.
+  https://sites.google.com/site/x32abi/
+
+Index: gc.h
+===================================================================
+--- gc.h	(revision 40635)
++++ gc.h	(revision 40636)
+@@ -2,7 +2,7 @@
+ #ifndef RUBY_GC_H
+ #define RUBY_GC_H 1
+
+-#if defined(__x86_64__) && defined(__GNUC__) && !defined(__native_client__)
++#if defined(__x86_64__) && !defined(_ILP32) && defined(__GNUC__) && !defined(__native_client__)
+ #define SET_MACHINE_STACK_END(p) __asm__ __volatile__ ("movq\t%%rsp, %0" : "=r" (*(p)))
+ #elif defined(__i386) && defined(__GNUC__) && !defined(__native_client__)
+ #define SET_MACHINE_STACK_END(p) __asm__ __volatile__ ("movl\t%%esp, %0" : "=r" (*(p)))
+
+------------------------------------------------------------------------

--- a/dev-lang/ruby/ruby-2.0.0_p648.ebuild
+++ b/dev-lang/ruby/ruby-2.0.0_p648.ebuild
@@ -65,6 +65,8 @@ src_prepare() {
 
 	EPATCH_EXCLUDE="${excluded_patches}" EPATCH_FORCE="yes" EPATCH_SUFFIX="patch" \
 		epatch "${WORKDIR}/patches"
+	epatch "${FILESDIR}/${P}-SVNr39186-asm-volatile.diff"
+	epatch "${FILESDIR}/${P}-SVNr40636-asm-ilp32.diff"
 
 	# We can no longer unbundle all of rake because rubygems now depends
 	# on this. We leave the actual rake code around to bootstrap

--- a/dev-lang/ruby/ruby-2.1.9.ebuild
+++ b/dev-lang/ruby/ruby-2.1.9.ebuild
@@ -62,6 +62,7 @@ PDEPEND="
 src_prepare() {
 	EPATCH_FORCE="yes" EPATCH_SUFFIX="patch" \
 		epatch "${WORKDIR}/patches"
+	epatch "${FILESDIR}/${P}-asm-ilp32+volatile.diff"
 
 	# We can no longer unbundle all of rake because rubygems now depends
 	# on this. We leave the actual rake code around to bootstrap


### PR DESCRIPTION
Bug: #480238
Bug: #419851

From: http://git.meleeweb.net/gentoo/portage.git/tree/dev-lang/ruby