### PR TITLE
dev-util/mingw64-runtime: Enforce libdir to gcc hardcoded path

### DIFF
--- a/dev-util/mingw64-runtime/mingw64-runtime-5.0.1.ebuild
+++ b/dev-util/mingw64-runtime/mingw64-runtime-5.0.1.ebuild
@@ -77,6 +77,7 @@ src_configure() {
 	CHOST=${CTARGET} econf \
 		--prefix=/usr/${CTARGET} \
 		--includedir=/usr/${CTARGET}/usr/include \
+		--libdir=/usr/${CTARGET}/usr/lib \
 		--with-headers \
 		--enable-sdk \
 		$(crt_with crt) \


### PR DESCRIPTION
cross-x86_64-w64-mingw32/gcc has the following default search dir:
  $ x86_64-w64-mingw32-gcc -print-search-dirs
  install: /usr/lib/gcc/x86_64-w64-mingw32/5.4.0/
  programs: =/usr/libexec/gcc/x86_64-w64-mingw32/5.4.0/:/usr/libexec/gcc/x86_64-w64-mingw32/5.4.0/:/usr/libexec/gcc/x86_64-w64-mingw32/:/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/:/usr/lib/gcc/x86_64-w64-mingw32/:/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/../../../../x86_64-w64-mingw32/bin/x86_64-w64-mingw32/5.4.0/:/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/../../../../x86_64-w64-mingw32/bin/
  libraries: =/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/:/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/../../../../x86_64-w64-mingw32/lib/x86_64-w64-mingw32/5.4.0/:/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/../../../../x86_64-w64-mingw32/lib/../lib/:/usr/x86_64-w64-mingw32/mingw/lib/x86_64-w64-mingw32/5.4.0/:/usr/x86_64-w64-mingw32/mingw/lib/../lib/:/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/../../../../x86_64-w64-mingw32/lib/:/usr/x86_64-w64-mingw32/mingw/lib/

This default does not contain /usr/x86_64-w64-mingw32/lib64 where libraries
installed with USE=libraries such as libpthread.dll.a are installed.

Applications that need to link with lib pthread cannot link properly unless
LDFLAGS are manually modified.

This patch append --libdir=/usr/${CTARGET}/usr/lib when cross compiling in
order to install such libraries in the default gcc search directory.

Package-Manager: portage-2.3.0