### PR TITLE
mail-mta/opensmtpd: revbump to fix libressl and musl

### DIFF
--- a/mail-mta/opensmtpd/files/opensmtpd-6.0.2_p1-autoconf.patch
+++ b/mail-mta/opensmtpd/files/opensmtpd-6.0.2_p1-autoconf.patch
@@ -1,0 +1,46 @@
+From 9370e962bfa1032ab16c48c79977536eae665d75 Mon Sep 17 00:00:00 2001
+From: Freddy DISSAUX <dsx@pouet.bsdsx.fr>
+Date: Sat, 17 Sep 2016 08:50:14 +0200
+Subject: [PATCH] Fix expression, as explain in
+
+https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Generic-Declarations.html#Generic-Declarations
+
+"Unlike the other `AC_CHECK_*S' macros, when a symbol is not
+declared, HAVE_DECL_symbol is defined to `0' instead of
+leaving HAVE_DECL_symbol undeclared."
+---
+ openbsd-compat/defines.h        | 2 +-
+ openbsd-compat/openbsd-compat.h | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/openbsd-compat/defines.h b/openbsd-compat/defines.h
+index 0a94d76..bda39e9 100644
+--- a/openbsd-compat/defines.h
++++ b/openbsd-compat/defines.h
+@@ -85,7 +85,7 @@
+ # define STDERR_FILENO   2
+ #endif
+ 
+-#if defined(HAVE_DECL_O_NONBLOCK) && HAVE_DECL_O_NONBLOCK == 0
++#if !HAVE_DECL_O_NONBLOCK
+ # define O_NONBLOCK      00004	/* Non Blocking Open */
+ #endif
+ 
+diff --git a/openbsd-compat/openbsd-compat.h b/openbsd-compat/openbsd-compat.h
+index fd931d0..1ef2925 100644
+--- a/openbsd-compat/openbsd-compat.h
++++ b/openbsd-compat/openbsd-compat.h
+@@ -212,11 +212,11 @@ void errc(int, int, const char *, ...);
+ #define pledge(promises, paths) 0
+ #endif
+ 
+-#ifndef HAVE_DECL_AF_LOCAL
++#if !HAVE_DECL_AF_LOCAL
+ #define AF_LOCAL AF_UNIX
+ #endif
+ 
+-#ifndef HAVE_DECL_WAIT_MYPGRP
++#if !HAVE_DECL_WAIT_MYPGRP
+ #define WAIT_MYPGRP 0
+ #endif
+ 

--- a/mail-mta/opensmtpd/files/opensmtpd-6.0.2_p1-libressl.patch
+++ b/mail-mta/opensmtpd/files/opensmtpd-6.0.2_p1-libressl.patch
@@ -1,0 +1,101 @@
+From f948b923873a93472dea9b786cf60a3472b0ddc8 Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Wed, 11 Jan 2017 17:35:29 -0600
+Subject: [PATCH] fix compatibility with libressl
+
+These functions are exported by libcrypto from libressl, due to its
+similar OpenBSD compatibility layer, but they are not present in any
+header files. Thus, while we can use the existing compiled function,
+and do not need to provide our own, we do need to provide the prototype
+for it.
+
+This avoids implicit function declarations and the resulting crashes due
+to pointer truncation.
+
+The patch is based on an equivalent patch for OpenSSH from
+https://bugzilla.mindrot.org/show_bug.cgi?id=2465
+Also see
+https://github.com/libressl-portable/portable/issues/109
+
+Fixes #691
+---
+ openbsd-compat/defines.h        |  9 ---------
+ openbsd-compat/openbsd-compat.h | 25 +++++++++++++++----------
+ 2 files changed, 15 insertions(+), 19 deletions(-)
+
+diff --git a/openbsd-compat/defines.h b/openbsd-compat/defines.h
+index 2cbfbca..3ffcc81 100644
+--- a/openbsd-compat/defines.h
++++ b/openbsd-compat/defines.h
+@@ -422,15 +422,6 @@ typedef uint16_t	in_port_t;
+ #define INET6_ADDRSTRLEN 46
+ #endif
+ 
+-/*
+- * Platforms that have arc4random_uniform() and not arc4random_stir()
+- * shouldn't need the latter.
+- */
+-#if defined(HAVE_ARC4RANDOM) && defined(HAVE_ARC4RANDOM_UNIFORM) && \
+-    !defined(HAVE_ARC4RANDOM_STIR)
+-# define arc4random_stir()
+-#endif
+-
+ #ifndef HAVE_VA_COPY
+ # ifdef HAVE___VA_COPY
+ #  define va_copy(dest, src) __va_copy(dest, src)
+diff --git a/openbsd-compat/openbsd-compat.h b/openbsd-compat/openbsd-compat.h
+index a51385b..51f33bb 100644
+--- a/openbsd-compat/openbsd-compat.h
++++ b/openbsd-compat/openbsd-compat.h
+@@ -119,20 +119,25 @@ int	BSDoptind;		/* index into parent argv vector */
+ int getpeereid(int , uid_t *, gid_t *);
+ #endif 
+ 
+-#ifdef HAVE_ARC4RANDOM
+-# ifndef HAVE_ARC4RANDOM_STIR
+-#  define arc4random_stir()
+-# endif
+-#else
++#if !defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
+ unsigned int arc4random(void);
++#endif
++
++#if defined(HAVE_ARC4RANDOM_STIR)
+ void arc4random_stir(void);
+-#endif /* !HAVE_ARC4RANDOM */
++#elif defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
++/* Recent system/libressl implementation; no need for explicit stir */
++# define arc4random_stir()
++#else
++/* openbsd-compat/arc4random.c provides arc4random_stir() */
++void arc4random_stir(void);
++#endif
+ 
+-#ifndef HAVE_ARC4RANDOM_BUF
++#if !defined(HAVE_ARC4RANDOM_BUF) || defined(LIBRESSL_VERSION_NUMBER)
+ void arc4random_buf(void *, size_t);
+ #endif
+ 
+-#ifndef HAVE_ARC4RANDOM_UNIFORM
++#if !defined(HAVE_ARC4RANDOM_UNIFORM) || defined(LIBRESSL_VERSION_NUMBER)
+ uint32_t arc4random_uniform(uint32_t);
+ #endif
+ 
+@@ -174,7 +179,7 @@ int vasprintf(char **, const char *, va_list);
+ int vsnprintf(char *, size_t, const char *, va_list);
+ #endif
+ 
+-#ifndef HAVE_EXPLICIT_BZERO
++#if !defined(HAVE_EXPLICIT_BZERO) || defined(LIBRESSL_VERSION_NUMBER)
+ void explicit_bzero(void *p, size_t n);
+ #endif
+ 
+@@ -200,7 +205,7 @@ int pidfile(const char *basename);
+ struct passwd *pw_dup(const struct passwd *);
+ #endif
+ 
+-#ifndef HAVE_REALLOCARRAY
++#if !defined(HAVE_REALLOCARRAY) || defined(LIBRESSL_VERSION_NUMBER)
+ void *reallocarray(void *, size_t, size_t);
+ #endif
+ 

--- a/mail-mta/opensmtpd/files/opensmtpd-6.0.2_p1-musl.patch
+++ b/mail-mta/opensmtpd/files/opensmtpd-6.0.2_p1-musl.patch
@@ -1,0 +1,51 @@
+From 2ab442623e689532910b34ff0dbbc2167da02330 Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Wed, 11 Jan 2017 17:39:07 -0600
+Subject: [PATCH] fix musl compatibility (missing function prototypes)
+
+inet_net_pton is already compiled, but no prototype is provided.
+res_hnok is provided by the compatibility layer in libasr.
+
+These fixes avoid warnings about implicit function declaration.
+
+Fixes #758
+---
+ configure.ac                    | 1 +
+ openbsd-compat/openbsd-compat.h | 8 ++++++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 42e092f..e27c514 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -594,6 +594,7 @@ AC_CHECK_FUNCS([ \
+ 	pledge \
+ 	pw_dup \
+ 	reallocarray \
++	res_hnok \
+ 	setenv \
+ 	setlinebuf \
+ 	setproctitle \
+diff --git a/openbsd-compat/openbsd-compat.h b/openbsd-compat/openbsd-compat.h
+index a51385b..5d2e2c2 100644
+--- a/openbsd-compat/openbsd-compat.h
++++ b/openbsd-compat/openbsd-compat.h
+@@ -208,10 +208,18 @@ void *reallocarray(void *, size_t, size_t);
+ void errc(int, int, const char *, ...);
+ #endif
+ 
++#ifndef HAVE_INET_NET_PTON
++int inet_net_pton(int, const char *, void *, size_t);
++#endif
++
+ #ifndef HAVE_PLEDGE
+ #define pledge(promises, paths) 0
+ #endif
+ 
++#ifndef HAVE_RES_HNOK
++int res_hnok(const char *);
++#endif
++
+ #if !HAVE_DECL_AF_LOCAL
+ #define AF_LOCAL AF_UNIX
+ #endif

--- a/mail-mta/opensmtpd/opensmtpd-6.0.2_p1-r2.ebuild
+++ b/mail-mta/opensmtpd/opensmtpd-6.0.2_p1-r2.ebuild
@@ -1,0 +1,99 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit multilib user flag-o-matic eutils pam toolchain-funcs autotools systemd versionator
+
+DESCRIPTION="Lightweight but featured SMTP daemon from OpenBSD"
+HOMEPAGE="http://www.opensmtpd.org/"
+MY_P="${P}"
+if [ $(get_last_version_component_index) -eq 4 ]; then
+	MY_P="${PN}-$(get_version_component_range 4-)"
+fi
+SRC_URI="https://www.opensmtpd.org/archives/${MY_P/_}.tar.gz"
+
+LICENSE="ISC BSD BSD-1 BSD-2 BSD-4"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="libressl pam +mta"
+
+DEPEND="!libressl? ( dev-libs/openssl:0 )
+		libressl? ( dev-libs/libressl )
+		elibc_musl? ( sys-libs/fts-standalone )
+		sys-libs/zlib
+		pam? ( virtual/pam )
+		sys-libs/db:=
+		dev-libs/libevent
+		app-misc/ca-certificates
+		net-mail/mailbase
+		net-libs/libasr
+		!mail-mta/courier
+		!mail-mta/esmtp
+		!mail-mta/exim
+		!mail-mta/mini-qmail
+		!mail-mta/msmtp[mta]
+		!mail-mta/netqmail
+		!mail-mta/nullmailer
+		!mail-mta/postfix
+		!mail-mta/qmail-ldap
+		!mail-mta/sendmail
+		!mail-mta/ssmtp[mta]
+"
+RDEPEND="${DEPEND}"
+
+S=${WORKDIR}/${MY_P/_}
+
+src_prepare() {
+	# Use /run instead of /var/run
+	sed -i -e '/pidfile_path/s:_PATH_VARRUN:"/run/":' openbsd-compat/pidfile.c || die
+	epatch "${FILESDIR}"/${P}-autoconf.patch
+	epatch "${FILESDIR}"/${P}-libressl.patch
+	epatch "${FILESDIR}"/${P}-musl.patch
+	epatch_user
+	eautoreconf
+}
+
+src_configure() {
+	tc-export AR
+	AR="$(which "$AR")" econf \
+		--with-table-db \
+		--with-user-smtpd=smtpd \
+		--with-user-queue=smtpq \
+		--with-group-queue=smtpq \
+		--with-path-socket=/run \
+		--with-path-CAfile=/etc/ssl/certs/ca-certificates.crt \
+		--sysconfdir=/etc/opensmtpd \
+		$(use_with pam auth-pam)
+}
+
+src_install() {
+	default
+	newinitd "${FILESDIR}"/smtpd.initd smtpd
+	systemd_dounit "${FILESDIR}"/smtpd.{service,socket}
+	use pam && newpamd "${FILESDIR}"/smtpd.pam smtpd
+	dosym /usr/sbin/smtpctl /usr/sbin/makemap
+	dosym /usr/sbin/smtpctl /usr/sbin/newaliases
+	if use mta ; then
+		dodir /usr/sbin
+		dosym /usr/sbin/smtpctl /usr/sbin/sendmail
+		dosym /usr/sbin/smtpctl /usr/bin/sendmail
+		dosym /usr/sbin/smtpctl /usr/$(get_libdir)/sendmail
+	fi
+}
+
+pkg_preinst() {
+	enewgroup smtpd 25
+	enewuser smtpd 25 -1 /var/empty smtpd
+	enewgroup smtpq 252
+	enewuser smtpq 252 -1 /var/empty smtpq
+}
+
+pkg_postinst() {
+	einfo
+	einfo "Plugins for SQLite, MySQL, PostgreSQL, LDAP, socketmaps,"
+	einfo "Redis, and many other useful addons and filters are"
+	einfo "available in the mail-filter/opensmtpd-extras package."
+	einfo
+}


### PR DESCRIPTION
One patch is a backport from upstream. The other two have been submitted
upstream as pull requests.

Gentoo-Bug: 598822