### PR TITLE
sci-biology/mira: Update flex-2.6.3 fix; add cmath header

### DIFF
--- a/sci-biology/mira/files/mira-4.0.2-cmath.patch
+++ b/sci-biology/mira/files/mira-4.0.2-cmath.patch
@@ -1,0 +1,14 @@
+--- mira-4.0.2/src/mira/ads.C.old	2017-01-12 06:10:05.132263855 -0800
++++ mira-4.0.2/src/mira/ads.C	2017-01-12 06:11:59.360549234 -0800
+@@ -31,10 +31,11 @@
+  * Routines for computing scores and some other classification number are
+  *  provided, too.
+  *
+  */
+ 
++#include <cmath>
+ 
+ #include "ads.H"
+ 
+ #include "errorhandling/errorhandling.H"
+ #include "util/dptools.H"

--- a/sci-biology/mira/mira-4.0.2.ebuild
+++ b/sci-biology/mira/mira-4.0.2.ebuild
@@ -41,7 +41,8 @@ src_prepare() {
 	find -name 'configure*' -or -name 'Makefile*' | xargs sed -i 's/flex++/flex -+/' || die
 	epatch \
 		"${FILESDIR}"/${PN}-3.4.0.2-boost-1.50.patch \
-		"${FILESDIR}"/${P}-cout.patch
+		"${FILESDIR}"/${P}-cout.patch \
+		"${FILESDIR}"/${P}-cmath.patch
 
 	sed \
 		-e "s:-O[23]::g" \
@@ -50,9 +51,10 @@ src_prepare() {
 
 	eautoreconf
 
-	# Remove C++ source files that were built with flex by upstream.
+	# Remove C++ source files that upstream built with flex.
 	local f
 	local PREBUILT_CXX_LEXER_FILES=(
+		"$S"/src/caf/caf_flexer.cc
 		"$S"/src/io/exp_flexer.cc
 		"$S"/src/mira/parameters_flexer.cc
 	)


### PR DESCRIPTION
    Another round of testing discovered that caf_flexer.cc is also a
    pre-generated lexer.  The commit updates the ebuild to remove that
    file as well.  The file abs.C fails to find the pow() function.
    Modern versions of C++ store the header for that function in cmath.
    The file is updated to include that header.

    Gentoo-bug: 585942

Package-Manager: Portage-2.3.3, Repoman-2.3.1