### PR TITLE
mail-mta/postfix: Allow writing to /etc/mail/aliases.db

### DIFF
--- a/mail-mta/postfix/files/postfix.service
+++ b/mail-mta/postfix/files/postfix.service
@@ -12,6 +12,7 @@ ExecReload=/usr/sbin/postfix reload
 PrivateTmp=yes
 PrivateDevices=yes
 ProtectSystem=full
+ReadWritePaths=-/etc/mail/aliases.db
 CapabilityBoundingSet=~ CAP_NET_ADMIN CAP_SYS_ADMIN CAP_SYS_BOOT CAP_SYS_MODULE
 MemoryDenyWriteExecute=true
 


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=603458