### PR TITLE
dev-libs/sway: revbump to 0.11-r3

### DIFF
--- a/dev-libs/sway/files/sway-0.11-r3-keep-cap.patch
+++ b/dev-libs/sway/files/sway-0.11-r3-keep-cap.patch
@@ -1,0 +1,84 @@
+From ea1313d80d5ee1623b00c8cdf6e7ff8a7e14c2ae Mon Sep 17 00:00:00 2001
+From: Mykyta Holubakha <hilobakho@gmail.com>
+Date: Thu, 12 Jan 2017 04:25:03 +0200
+Subject: [PATCH 1/2] Keep CAP_SYS_PTRACE with suid binary
+
+---
+ sway/main.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/sway/main.c b/sway/main.c
+index e8a02e7..6c74aab 100644
+--- a/sway/main.c
++++ b/sway/main.c
+@@ -10,6 +10,9 @@
+ #include <unistd.h>
+ #include <getopt.h>
+ #include <sys/capability.h>
++#ifdef __linux__
++#include <sys/prctl.h>
++#endif
+ #include "sway/extensions.h"
+ #include "sway/layout.h"
+ #include "sway/config.h"
+@@ -289,6 +292,18 @@ int main(int argc, char **argv) {
+ 		return 0;
+ 	}
+ 
++#ifdef __linux__
++	bool suid = false;
++	if (getuid() != geteuid() || getgid() != getegid()) {
++		// Retain capabilities after setuid()
++		if (prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0)) {
++			sway_log(L_ERROR, "Cannot keep caps after setuid()");
++			exit(EXIT_FAILURE);
++		}
++		suid = true;
++	}
++#endif
++
+ 	// we need to setup logging before wlc_init in case it fails.
+ 	if (debug) {
+ 		init_log(L_DEBUG);
+@@ -311,6 +326,19 @@ int main(int argc, char **argv) {
+ 	}
+ 	register_extensions();
+ 
++#ifdef __linux__
++	if (suid) {
++		// Drop every cap except CAP_SYS_PTRACE
++		cap_t caps = cap_init();
++		cap_value_t keep = CAP_SYS_PTRACE;
++		if (cap_set_flag(caps, CAP_PERMITTED, 1, &keep, CAP_SET) ||
++			cap_set_flag(caps, CAP_EFFECTIVE, 1, &keep, CAP_SET) ||
++			cap_set_proc(caps)) {
++			sway_log(L_ERROR, "Failed to drop extra capabilities");
++			exit(EXIT_FAILURE);
++		}
++	}
++#endif
+ 	// handle SIGTERM signals
+ 	signal(SIGTERM, sig_handler);
+ 
+
+From d9ba61d7e91c5aceef1a6a736dc65f0594b9be2a Mon Sep 17 00:00:00 2001
+From: Mykyta Holubakha <hilobakho@gmail.com>
+Date: Thu, 12 Jan 2017 04:35:09 +0200
+Subject: [PATCH 2/2] Log capability dropping
+
+---
+ sway/main.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sway/main.c b/sway/main.c
+index 6c74aab..7bf71b5 100644
+--- a/sway/main.c
++++ b/sway/main.c
+@@ -331,6 +331,7 @@ int main(int argc, char **argv) {
+ 		// Drop every cap except CAP_SYS_PTRACE
+ 		cap_t caps = cap_init();
+ 		cap_value_t keep = CAP_SYS_PTRACE;
++		sway_log(L_INFO, "Dropping extra capabilities");
+ 		if (cap_set_flag(caps, CAP_PERMITTED, 1, &keep, CAP_SET) ||
+ 			cap_set_flag(caps, CAP_EFFECTIVE, 1, &keep, CAP_SET) ||
+ 			cap_set_proc(caps)) {

--- a/dev-libs/sway/sway-0.11-r3.ebuild
+++ b/dev-libs/sway/sway-0.11-r3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=6
 
-inherit eutils cmake-utils fcaps
+inherit eutils cmake-utils
 
 DESCRIPTION="i3-compatible Wayland window manager"
 HOMEPAGE="http://swaywm.org/"
@@ -32,6 +32,8 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	app-text/asciidoc"
 
+PATCHES=( "${FILESDIR}/sway-0.11-r3-keep-cap.patch" )
+
 src_prepare() {
 	cmake-utils_src_prepare
 
@@ -54,15 +56,19 @@ src_configure() {
 
 		-DCMAKE_INSTALL_SYSCONFDIR="/etc"
 		-DLD_LIBRARY_PATH="${EPREFIX}/usr/lib"
+		-DGIT_COMMIT_HASH="${PVR}" # specify version info, may change in future
 	)
 
 	cmake-utils_src_configure
 }
 
-FILECAPS=( -M 4711 cap_sys_ptrace,cap_sys_tty_config usr/bin/sway )
+src_install() {
+	cmake-utils_src_install
+
+	use !systemd && fperms u+s /usr/bin/sway
+}
 
 pkg_postinst() {
-	fcaps_pkg_postinst
 	if use swaygrab
 	then
 		optfeature "swaygrab screenshot support" media-gfx/imagemagick[png]

--- a/dev-libs/sway/sway-9999.ebuild
+++ b/dev-libs/sway/sway-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 
-inherit git-r3 eutils cmake-utils fcaps
+inherit git-r3 eutils cmake-utils
 
 DESCRIPTION="i3-compatible Wayland window manager"
 HOMEPAGE="http://swaywm.org/"
@@ -29,7 +29,7 @@ RDEPEND="=dev-libs/wlc-9999[systemd=]
 		gdk-pixbuf? ( x11-libs/gdk-pixbuf[jpeg] )"
 
 DEPEND="${RDEPEND}
-	virtual/pkgconfig
+		virtual/pkgconfig
 		app-text/asciidoc"
 
 src_prepare() {
@@ -59,10 +59,13 @@ src_configure() {
 	cmake-utils_src_configure
 }
 
-FILECAPS=( -M 4711 cap_sys_ptrace,cap_sys_tty_config usr/bin/sway )
+src_install() {
+	cmake-utils_src_install
+
+	use !systemd && fperms u+s /usr/bin/sway
+}
 
 pkg_postinst() {
-	fcaps_pkg_postinst
 	if use swaygrab
 	then
 		optfeature "swaygrab screenshot support" media-gfx/imagemagick[png]


### PR DESCRIPTION
Backport capability fixes (SirCmpwn/sway#1043)
Drop capabilities from binary (caps and suid combined caused issues).
Fix version info string.

The second applies to live ebuild as well.