### PR TITLE
x11-wm/i3: remove git polling

### DIFF
--- a/x11-wm/i3/files/i3-4.13-remove-git-polling.patch
+++ b/x11-wm/i3/files/i3-4.13-remove-git-polling.patch
@@ -1,0 +1,19 @@
+diff -Naur a/configure.ac b/configure.ac
+--- a/configure.ac	2017-01-13 13:31:25.250216293 +0100
++++ b/configure.ac	2017-01-13 13:31:55.930217956 +0100
+@@ -146,15 +146,6 @@
+ 	print_BUILD_MANS=no
+ fi
+ 
+-git_dir=`git rev-parse --git-dir 2>/dev/null`
+-if test -n "$git_dir"; then
+-	srcdir=`dirname "$git_dir"`
+-	exclude_dir=`pwd | sed "s,^$srcdir,,g"`
+-	if ! grep -q "^$exclude_dir" "$git_dir/info/exclude"; then
+-		echo "$exclude_dir" >> "$git_dir/info/exclude"
+-	fi
+-fi
+-
+ echo \
+ "--------------------------------------------------------------------------------
+ build configured:

--- a/x11-wm/i3/i3-4.13-r1.ebuild
+++ b/x11-wm/i3/i3-4.13-r1.ebuild
@@ -37,6 +37,9 @@ RDEPEND="${CDEPEND}
 	dev-perl/JSON-XS"
 
 DOCS=( RELEASE-NOTES-${PV} )
+PATCHES=(
+	"${FILESDIR}/${P}-remove-git-polling.patch"
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Currently, there is a git command executed during configuration, and if there is (such in my case) a git repository in the hierarchy, it will try to leave the sandbox, which fails the build.

No revbump as this doesn't change the binary.