### PR TITLE
media-video/aegisub: rebuild on hunspell SLOT changes

### DIFF
--- a/media-video/aegisub/aegisub-3.2.2_p20160518-r2.ebuild
+++ b/media-video/aegisub/aegisub-3.2.2_p20160518-r2.ebuild
@@ -39,7 +39,7 @@ RDEPEND="
 	openal? ( media-libs/openal )
 	portaudio? ( =media-libs/portaudio-19* )
 	pulseaudio? ( media-sound/pulseaudio )
-	spell? ( app-text/hunspell )
+	spell? ( app-text/hunspell:= )
 	uchardet? ( dev-libs/uchardet )
 "
 DEPEND="${RDEPEND}

--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	openal? ( media-libs/openal )
 	portaudio? ( =media-libs/portaudio-19* )
 	pulseaudio? ( media-sound/pulseaudio )
-	spell? ( app-text/hunspell )
+	spell? ( app-text/hunspell:= )
 	uchardet? ( dev-libs/uchardet )
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Those hunspell sub-slots weren't there when aegisub ebuilds were added.

Package-Manager: Portage-2.3.3, Repoman-2.3.1