### PR TITLE
sys-firmware/b43-firmware: mask versions above 5.100.138

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -30,6 +30,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Maciej S. Szmigiero <mail@maciej.szmigiero.name> (15 Jan 2017)
+# Any version above 5.100.138 breaks b43 driver in various ways.
+# Also, b43 wiki page says to use 5.100.138.
+# Bug #541080.
+>=sys-firmware/b43-firmware-6.30.163.46
+
 # Ulrich Müller <ulm@gentoo.org> (13 Jan 2017)
 # No longer maintained as a separate package.
 # Use sci-mathematics/maxima with USE=emacs instead.


### PR DESCRIPTION
Any sys-firmware/b43-firmware version above 5.100.138 breaks b43 driver in various ways
(spontaneous disconnections, low throughput, cannot associate to an AP, etc).
Also, b43 wiki page says to use 5.100.138:
http://linuxwireless.org/en/users/Drivers/b43/#Other_distributions_not_mentioned_above

Let's hard mask 6.30.163.46 (next version after 5.100.138) and above so
users' wireless card don't suddenly break when they update world.

Gentoo-Bug: https://bugs.gentoo.org/541080