### PR TITLE
sys-libs/libuuid: Fix error on 64-bit systems

### DIFF
--- a/sys-libs/libuuid/libuuid-1.0.3.ebuild
+++ b/sys-libs/libuuid/libuuid-1.0.3.ebuild
@@ -29,5 +29,5 @@ src_configure() {
 
 src_install() {
 	default
-	rm "${ED}"/usr/lib{,32,64}/*.la || die
+	rm -f "${ED}"/usr/lib{,32,64}/*.la || die
 }

--- a/sys-libs/libuuid/libuuid-1.0.3.ebuild
+++ b/sys-libs/libuuid/libuuid-1.0.3.ebuild
@@ -29,5 +29,5 @@ src_configure() {
 
 src_install() {
 	default
-	rm "${ED}"/usr/lib/*.la || die
+	rm "${ED}"/usr/lib{,32,64}/*.la || die
 }


### PR DESCRIPTION
The current ebuild ignores the fact that a lib64 directory may exist instead of a lib directory, and attempts to remove *.la from it anyway. Adding this expression will remove *.la from lib, lib32 and lib64 directories, thus fixing the error.