### PR TITLE
dev-python/python-discid: add py3.5, doc, tests, EAPI=6, fix deps

### DIFF
--- a/dev-python/python-discid/python-discid-1.1.0-r1.ebuild
+++ b/dev-python/python-discid/python-discid-1.1.0-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+
+inherit distutils-r1
+
+DESCRIPTION="Python bindings for libdiscid"
+HOMEPAGE="https://github.com/JonnyJD/python-discid"
+SRC_URI="https://github.com/JonnyJD/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="doc"
+
+RDEPEND=">=media-libs/libdiscid-0.2.2"
+DEPEND="
+	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	${RDEPEND}
+"
+
+python_prepare_all() {
+	# Skip broken Sphinx extension
+	# https://github.com/JonnyJD/python-discid/commit/fd714adc2d34b3b661b64cda53190b42a33d1670
+	sed -i "s/, 'sphinx.ext.intersphinx'//;/ext.data_doc/d" doc/conf.py || die
+	distutils-r1_python_prepare_all
+}
+
+python_compile_all() {
+	if use doc; then
+		cd doc || die
+		sphinx-build . _build/html || die
+		HTML_DOCS=( doc/_build/html/. )
+	fi
+}
+
+python_test() {
+	esetup.py test
+}


### PR DESCRIPTION
This should make @SoapGentoo happy!
```diff
--- python-discid-1.1.0.ebuild  2017-01-11 00:26:36.803358456 +0100
+++ python-discid-1.1.0-r1.ebuild       2017-01-16 12:01:50.891070862 +0100
@@ -2,19 +2,42 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$

-EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4} )
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+
 inherit distutils-r1

 DESCRIPTION="Python bindings for libdiscid"
 HOMEPAGE="https://github.com/JonnyJD/python-discid"
 SRC_URI="https://github.com/JonnyJD/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"

-LICENSE="LGPL-3"
+LICENSE="LGPL-3+"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="doc test"
+
+RDEPEND=">=media-libs/libdiscid-0.2.2"
+DEPEND="
+       doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
+       dev-python/setuptools[${PYTHON_USEDEP}]
+       ${DEPEND}
+"
+
+python_prepare_all() {
+       # Skip broken Sphinx extension
+       # https://github.com/JonnyJD/python-discid/commit/fd714adc2d34b3b661b64cda53190b42a33d1670
+       sed -i "s/, 'sphinx.ext.intersphinx'//;/ext.data_doc/d" doc/conf.py || die
+       distutils-r1_python_prepare_all
+}
+
+python_compile_all() {
+       if use doc; then
+               cd doc || die
+               sphinx-build . _build/html || die
+               HTML_DOCS=( doc/_build/html/. )
+       fi
+}

-DEPEND=">=media-libs/libdiscid-0.2.2
-       ${PYTHON_DEPS}"
-RDEPEND="${DEPEND}"
+python_test() {
+       esetup.py test
+}
```