### PR TITLE
dev-python/ipaddr: add py3.5, fix dependencies

### DIFF
--- a/dev-python/ipaddr/ipaddr-2.1.11-r1.ebuild
+++ b/dev-python/ipaddr/ipaddr-2.1.11-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
+
+inherit distutils-r1
+
+DESCRIPTION="Python IP address manipulation library"
+HOMEPAGE="https://github.com/google/ipaddr-py https://pypi.python.org/pypi/ipaddr"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+
+DOCS=( README RELEASENOTES )
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+
+python_prepare() {
+	if python_is_python3; then
+		2to3 -n -w --no-diffs *.py || die
+	fi
+}
+
+python_test() {
+	PYTHONPATH=build/lib \
+		"${EPYTHON}" ipaddr_test.py || die "Tests fail with ${EPYTHON}"
+}

--- a/dev-python/ipaddr/metadata.xml
+++ b/dev-python/ipaddr/metadata.xml
@@ -10,7 +10,7 @@
     <name>Python</name>
   </maintainer>
   <upstream>
-    <remote-id type="google-code">ipaddr-py</remote-id>
+    <remote-id type="github">google/ipaddr</remote-id>
     <remote-id type="pypi">ipaddr</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
@SoapGentoo I got rid of the in-source build part as it didn't seem necessary. I also replaced PYTHON with EPYTHON for the tests like you taught me :D
```diff
--- ipaddr-2.1.11.ebuild        2016-11-26 14:53:54.187264218 +0100
+++ ipaddr-2.1.11-r1.ebuild     2017-01-16 15:17:37.643959101 +0100
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$

-EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4} pypy )
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )

 inherit distutils-r1

@@ -13,12 +13,11 @@

 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 x86 arm"
-IUSE=""
+KEYWORDS="~amd64 ~arm ~x86"

 DOCS=( README RELEASENOTES )

-DISTUTILS_IN_SOURCE_BUILD=1
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

 python_prepare() {
        if python_is_python3; then
@@ -28,5 +27,5 @@

 python_test() {
        PYTHONPATH=build/lib \
-               "${PYTHON}" ipaddr_test.py || die "Tests fail with ${EPYTHON}"
+               "${EPYTHON}" ipaddr_test.py || die "Tests fail with ${EPYTHON}"
 }
```