### PR TITLE
media-tv/kodi: Various fixes

### DIFF
--- a/media-tv/kodi/files/kodi-16.1-gcc-6.patch
+++ b/media-tv/kodi/files/kodi-16.1-gcc-6.patch
@@ -1,0 +1,1405 @@
+diff --git a/lib/cximage-6.0/CxImage/ximabmp.cpp b/lib/cximage-6.0/CxImage/ximabmp.cpp
+index 726ff91..6c7c31b 100644
+--- a/lib/cximage-6.0/CxImage/ximabmp.cpp
++++ b/lib/cximage-6.0/CxImage/ximabmp.cpp
+@@ -46,7 +46,7 @@ bool CxImageBMP::Encode(CxFile * hFile)
+ 		bihtoh(&infohdr);
+ 
+ 		// Write the file header
+-		hFile->Write(&hdr,min(14,sizeof(BITMAPFILEHEADER)),1);
++		hFile->Write(&hdr,minimum(14,sizeof(BITMAPFILEHEADER)),1);
+ 		hFile->Write(&infohdr,sizeof(BITMAPINFOHEADER),1);
+ 		 //and DIB+ALPHA interlaced
+ 		BYTE *srcalpha = AlphaGetPointer();
+@@ -64,7 +64,7 @@ bool CxImageBMP::Encode(CxFile * hFile)
+ #endif //CXIMAGE_SUPPORT_ALPHA
+ 	{
+ 		// Write the file header
+-		hFile->Write(&hdr,min(14,sizeof(BITMAPFILEHEADER)),1);
++		hFile->Write(&hdr,minimum(14,sizeof(BITMAPFILEHEADER)),1);
+ 		//copy attributes
+ 		memcpy(pDib,&head,sizeof(BITMAPINFOHEADER));
+ 		bihtoh((BITMAPINFOHEADER*)pDib);
+@@ -86,7 +86,7 @@ bool CxImageBMP::Decode(CxFile * hFile)
+ 	BITMAPFILEHEADER   bf;
+ 	DWORD off = hFile->Tell(); //<CSC>
+   cx_try {
+-	if (hFile->Read(&bf,min(14,sizeof(bf)),1)==0) cx_throw("Not a BMP");
++	if (hFile->Read(&bf,minimum(14,sizeof(bf)),1)==0) cx_throw("Not a BMP");
+ 
+ 	bf.bfSize = my_ntohl(bf.bfSize); 
+ 	bf.bfOffBits = my_ntohl(bf.bfOffBits); 
+diff --git a/lib/cximage-6.0/CxImage/ximadef.h b/lib/cximage-6.0/CxImage/ximadef.h
+index fe383bf..5783749 100644
+--- a/lib/cximage-6.0/CxImage/ximadef.h
++++ b/lib/cximage-6.0/CxImage/ximadef.h
+@@ -53,11 +53,11 @@
+  #define CXIMAGE_SUPPORT_WINDOWS 0
+ #endif
+ 
+-#ifndef min
+-#define min(a,b) (((a)<(b))?(a):(b))
++#ifndef minimum
++#define minimum(a,b) (((a)<(b))?(a):(b))
+ #endif
+-#ifndef max
+-#define max(a,b) (((a)>(b))?(a):(b))
++#ifndef maximum
++#define maximum(a,b) (((a)>(b))?(a):(b))
+ #endif
+ 
+ #ifndef PI
+diff --git a/lib/cximage-6.0/CxImage/ximadsp.cpp b/lib/cximage-6.0/CxImage/ximadsp.cpp
+index 8425bb2..dbac785 100644
+--- a/lib/cximage-6.0/CxImage/ximadsp.cpp
++++ b/lib/cximage-6.0/CxImage/ximadsp.cpp
+@@ -389,8 +389,8 @@ RGBQUAD CxImage::RGBtoHSL(RGBQUAD lRGBColor)
+ 	G = lRGBColor.rgbGreen;
+ 	B = lRGBColor.rgbBlue;
+ 
+-	cMax = max( max(R,G), B);	/* calculate lightness */
+-	cMin = min( min(R,G), B);
++	cMax = maximum( maximum(R,G), B);	/* calculate lightness */
++	cMin = minimum( minimum(R,G), B);
+ 	L = (BYTE)((((cMax+cMin)*HSLMAX)+RGBMAX)/(2*RGBMAX));
+ 
+ 	if (cMax==cMin){			/* r=g=b --> achromatic case */
+@@ -489,9 +489,9 @@ RGBQUAD CxImage::YUVtoRGB(RGBQUAD lYUVColor)
+ 	G = (int)( Y - 0.344f * U - 0.714f * V);
+ 	B = (int)( Y + 1.770f * U);
+ 
+-	R= min(255,max(0,R));
+-	G= min(255,max(0,G));
+-	B= min(255,max(0,B));
++	R= minimum(255,maximum(0,R));
++	G= minimum(255,maximum(0,G));
++	B= minimum(255,maximum(0,B));
+ 	RGBQUAD rgb={(BYTE)B,(BYTE)G,(BYTE)R,0};
+ 	return rgb;
+ }
+@@ -510,9 +510,9 @@ RGBQUAD CxImage::RGBtoYUV(RGBQUAD lRGBColor)
+ 	U = (int)((B-Y) * 0.565f + 128);
+ 	V = (int)((R-Y) * 0.713f + 128);
+ 
+-	Y= min(255,max(0,Y));
+-	U= min(255,max(0,U));
+-	V= min(255,max(0,V));
++	Y= minimum(255,maximum(0,Y));
++	U= minimum(255,maximum(0,U));
++	V= minimum(255,maximum(0,V));
+ 	RGBQUAD yuv={(BYTE)V,(BYTE)U,(BYTE)Y,0};
+ 	return yuv;
+ }
+@@ -528,9 +528,9 @@ RGBQUAD CxImage::YIQtoRGB(RGBQUAD lYIQColor)
+ 	G = (int)( Y - 0.273f * I - 0.647f * Q);
+ 	B = (int)( Y - 1.104f * I + 1.701f * Q);
+ 
+-	R= min(255,max(0,R));
+-	G= min(255,max(0,G));
+-	B= min(255,max(0,B));
++	R= minimum(255,maximum(0,R));
++	G= minimum(255,maximum(0,G));
++	B= minimum(255,maximum(0,B));
+ 	RGBQUAD rgb={(BYTE)B,(BYTE)G,(BYTE)R,0};
+ 	return rgb;
+ }
+@@ -546,9 +546,9 @@ RGBQUAD CxImage::RGBtoYIQ(RGBQUAD lRGBColor)
+ 	I = (int)( 0.5960f * R - 0.2742f * G - 0.3219f * B + 128);
+ 	Q = (int)( 0.2109f * R - 0.5229f * G + 0.3120f * B + 128);
+ 
+-	Y= min(255,max(0,Y));
+-	I= min(255,max(0,I));
+-	Q= min(255,max(0,Q));
++	Y= minimum(255,maximum(0,Y));
++	I= minimum(255,maximum(0,I));
++	Q= minimum(255,maximum(0,Q));
+ 	RGBQUAD yiq={(BYTE)Q,(BYTE)I,(BYTE)Y,0};
+ 	return yiq;
+ }
+@@ -565,9 +565,9 @@ RGBQUAD CxImage::XYZtoRGB(RGBQUAD lXYZColor)
+ 	G = (int)( -0.969256f * X + 1.875992f * Y + 0.041556f * Z * k);
+ 	B = (int)(  0.055648f * X - 0.204043f * Y + 1.057311f * Z * k);
+ 
+-	R= min(255,max(0,R));
+-	G= min(255,max(0,G));
+-	B= min(255,max(0,B));
++	R= minimum(255,maximum(0,R));
++	G= minimum(255,maximum(0,G));
++	B= minimum(255,maximum(0,B));
+ 	RGBQUAD rgb={(BYTE)B,(BYTE)G,(BYTE)R,0};
+ 	return rgb;
+ }
+@@ -583,9 +583,9 @@ RGBQUAD CxImage::RGBtoXYZ(RGBQUAD lRGBColor)
+ 	Y = (int)( 0.212671f * R + 0.715160f * G + 0.072169f * B);
+ 	Z = (int)((0.019334f * R + 0.119193f * G + 0.950227f * B)*0.918483657f);
+ 
+-	//X= min(255,max(0,X));
+-	//Y= min(255,max(0,Y));
+-	//Z= min(255,max(0,Z));
++	//X= minimum(255,maximum(0,X));
++	//Y= minimum(255,maximum(0,Y));
++	//Z= minimum(255,maximum(0,Z));
+ 	RGBQUAD xyz={(BYTE)Z,(BYTE)Y,(BYTE)X,0};
+ 	return xyz;
+ }
+@@ -707,7 +707,7 @@ bool CxImage::Light(long brightness, long contrast)
+ 
+ 	BYTE cTable[256]; //<nipper>
+ 	for (int i=0;i<256;i++)	{
+-		cTable[i] = (BYTE)max(0,min(255,(int)((i-128)*c + brightness + 0.5f)));
++		cTable[i] = (BYTE)maximum(0,minimum(255,(int)((i-128)*c + brightness + 0.5f)));
+ 	}
+ 
+ 	return Lut(cTable);
+@@ -830,11 +830,11 @@ bool CxImage::Filter(long* kernel, long Ksize, long Kfactor, long Koffset)
+ 						}
+ 					}
+ 					if (Kfactor==0 || ksumcur==0){
+-						cPtr2[iY1] = (BYTE)min(255, max(0,(int)(b + Koffset)));
++						cPtr2[iY1] = (BYTE)minimum(255, maximum(0,(int)(b + Koffset)));
+ 					} else if (ksumtot == ksumcur) {
+-						cPtr2[iY1] = (BYTE)min(255, max(0,(int)(b/Kfactor + Koffset)));
++						cPtr2[iY1] = (BYTE)minimum(255, maximum(0,(int)(b/Kfactor + Koffset)));
+ 					} else {
+-						cPtr2[iY1] = (BYTE)min(255, max(0,(int)((b*ksumtot)/(ksumcur*Kfactor) + Koffset)));
++						cPtr2[iY1] = (BYTE)minimum(255, maximum(0,(int)((b*ksumtot)/(ksumcur*Kfactor) + Koffset)));
+ 					}
+ 				}
+ 			}
+@@ -863,17 +863,17 @@ bool CxImage::Filter(long* kernel, long Ksize, long Kfactor, long Koffset)
+ 						}
+ 					}
+ 					if (Kfactor==0 || ksumcur==0){
+-						c.rgbRed   = (BYTE)min(255, max(0,(int)(r + Koffset)));
+-						c.rgbGreen = (BYTE)min(255, max(0,(int)(g + Koffset)));
+-						c.rgbBlue  = (BYTE)min(255, max(0,(int)(b + Koffset)));
++						c.rgbRed   = (BYTE)minimum(255, maximum(0,(int)(r + Koffset)));
++						c.rgbGreen = (BYTE)minimum(255, maximum(0,(int)(g + Koffset)));
++						c.rgbBlue  = (BYTE)minimum(255, maximum(0,(int)(b + Koffset)));
+ 					} else if (ksumtot == ksumcur) {
+-						c.rgbRed   = (BYTE)min(255, max(0,(int)(r/Kfactor + Koffset)));
+-						c.rgbGreen = (BYTE)min(255, max(0,(int)(g/Kfactor + Koffset)));
+-						c.rgbBlue  = (BYTE)min(255, max(0,(int)(b/Kfactor + Koffset)));
++						c.rgbRed   = (BYTE)minimum(255, maximum(0,(int)(r/Kfactor + Koffset)));
++						c.rgbGreen = (BYTE)minimum(255, maximum(0,(int)(g/Kfactor + Koffset)));
++						c.rgbBlue  = (BYTE)minimum(255, maximum(0,(int)(b/Kfactor + Koffset)));
+ 					} else {
+-						c.rgbRed   = (BYTE)min(255, max(0,(int)((r*ksumtot)/(ksumcur*Kfactor) + Koffset)));
+-						c.rgbGreen = (BYTE)min(255, max(0,(int)((g*ksumtot)/(ksumcur*Kfactor) + Koffset)));
+-						c.rgbBlue  = (BYTE)min(255, max(0,(int)((b*ksumtot)/(ksumcur*Kfactor) + Koffset)));
++						c.rgbRed   = (BYTE)minimum(255, maximum(0,(int)((r*ksumtot)/(ksumcur*Kfactor) + Koffset)));
++						c.rgbGreen = (BYTE)minimum(255, maximum(0,(int)((g*ksumtot)/(ksumcur*Kfactor) + Koffset)));
++						c.rgbBlue  = (BYTE)minimum(255, maximum(0,(int)((b*ksumtot)/(ksumcur*Kfactor) + Koffset)));
+ 					}
+ 					tmp.BlindSetPixelColor(x,y,c);
+ 				}
+@@ -1078,8 +1078,8 @@ bool CxImage::Edge(long Ksize)
+ // 
+ void CxImage::Mix(CxImage & imgsrc2, ImageOpType op, long lXOffset, long lYOffset, bool bMixAlpha)
+ {
+-    long lWide = min(GetWidth(),imgsrc2.GetWidth()-lXOffset);
+-    long lHeight = min(GetHeight(),imgsrc2.GetHeight()-lYOffset);
++    long lWide = minimum(GetWidth(),imgsrc2.GetWidth()-lXOffset);
++    long lHeight = minimum(GetHeight(),imgsrc2.GetHeight()-lYOffset);
+ 
+ 	bool bEditAlpha = imgsrc2.AlphaIsValid() & bMixAlpha;
+ 
+@@ -1112,16 +1112,16 @@ void CxImage::Mix(CxImage & imgsrc2, ImageOpType op, long lXOffset, long lYOffse
+ 						if (bEditAlpha) rgbDest.rgbReserved = (BYTE)((rgb1.rgbReserved+rgb2.rgbReserved)/2);
+ 					break;
+ 					case OpAdd:
+-						rgbDest.rgbBlue = (BYTE)max(0,min(255,rgb1.rgbBlue+rgb2.rgbBlue));
+-						rgbDest.rgbGreen = (BYTE)max(0,min(255,rgb1.rgbGreen+rgb2.rgbGreen));
+-						rgbDest.rgbRed = (BYTE)max(0,min(255,rgb1.rgbRed+rgb2.rgbRed));
+-						if (bEditAlpha) rgbDest.rgbReserved = (BYTE)max(0,min(255,rgb1.rgbReserved+rgb2.rgbReserved));
++						rgbDest.rgbBlue = (BYTE)maximum(0,minimum(255,rgb1.rgbBlue+rgb2.rgbBlue));
++						rgbDest.rgbGreen = (BYTE)maximum(0,minimum(255,rgb1.rgbGreen+rgb2.rgbGreen));
++						rgbDest.rgbRed = (BYTE)maximum(0,minimum(255,rgb1.rgbRed+rgb2.rgbRed));
++						if (bEditAlpha) rgbDest.rgbReserved = (BYTE)maximum(0,minimum(255,rgb1.rgbReserved+rgb2.rgbReserved));
+ 					break;
+ 					case OpSub:
+-						rgbDest.rgbBlue = (BYTE)max(0,min(255,rgb1.rgbBlue-rgb2.rgbBlue));
+-						rgbDest.rgbGreen = (BYTE)max(0,min(255,rgb1.rgbGreen-rgb2.rgbGreen));
+-						rgbDest.rgbRed = (BYTE)max(0,min(255,rgb1.rgbRed-rgb2.rgbRed));
+-						if (bEditAlpha) rgbDest.rgbReserved = (BYTE)max(0,min(255,rgb1.rgbReserved-rgb2.rgbReserved));
++						rgbDest.rgbBlue = (BYTE)maximum(0,minimum(255,rgb1.rgbBlue-rgb2.rgbBlue));
++						rgbDest.rgbGreen = (BYTE)maximum(0,minimum(255,rgb1.rgbGreen-rgb2.rgbGreen));
++						rgbDest.rgbRed = (BYTE)maximum(0,minimum(255,rgb1.rgbRed-rgb2.rgbRed));
++						if (bEditAlpha) rgbDest.rgbReserved = (BYTE)maximum(0,minimum(255,rgb1.rgbReserved-rgb2.rgbReserved));
+ 					break;
+ 					case OpAnd:
+ 						rgbDest.rgbBlue = (BYTE)(rgb1.rgbBlue&rgb2.rgbBlue);
+@@ -1202,11 +1202,11 @@ void CxImage::Mix(CxImage & imgsrc2, ImageOpType op, long lXOffset, long lYOffse
+ 							double dSmallAmt = dSmall*((double)rgb2.rgbBlue);
+ 
+ 							if( lAverage < lThresh+1){
+-								rgbDest.rgbBlue = (BYTE)max(0,min(255,(int)(dLarge*((double)rgb1.rgbBlue) +
++								rgbDest.rgbBlue = (BYTE)maximum(0,minimum(255,(int)(dLarge*((double)rgb1.rgbBlue) +
+ 												dSmallAmt)));
+-								rgbDest.rgbGreen = (BYTE)max(0,min(255,(int)(dLarge*((double)rgb1.rgbGreen) +
++								rgbDest.rgbGreen = (BYTE)maximum(0,minimum(255,(int)(dLarge*((double)rgb1.rgbGreen) +
+ 												dSmallAmt)));
+-								rgbDest.rgbRed = (BYTE)max(0,min(255,(int)(dLarge*((double)rgb1.rgbRed) +
++								rgbDest.rgbRed = (BYTE)maximum(0,minimum(255,(int)(dLarge*((double)rgb1.rgbRed) +
+ 												dSmallAmt)));
+ 							}
+ 							else
+@@ -1274,9 +1274,9 @@ bool CxImage::ShiftRGB(long r, long g, long b)
+ #endif //CXIMAGE_SUPPORT_SELECTION
+ 				{
+ 					color = BlindGetPixelColor(x,y);
+-					color.rgbRed = (BYTE)max(0,min(255,(int)(color.rgbRed + r)));
+-					color.rgbGreen = (BYTE)max(0,min(255,(int)(color.rgbGreen + g)));
+-					color.rgbBlue = (BYTE)max(0,min(255,(int)(color.rgbBlue + b)));
++					color.rgbRed = (BYTE)maximum(0,minimum(255,(int)(color.rgbRed + r)));
++					color.rgbGreen = (BYTE)maximum(0,minimum(255,(int)(color.rgbGreen + g)));
++					color.rgbBlue = (BYTE)maximum(0,minimum(255,(int)(color.rgbBlue + b)));
+ 					BlindSetPixelColor(x,y,color);
+ 				}
+ 			}
+@@ -1284,9 +1284,9 @@ bool CxImage::ShiftRGB(long r, long g, long b)
+ 	} else {
+ 		for(DWORD j=0; j<head.biClrUsed; j++){
+ 			color = GetPaletteColor((BYTE)j);
+-			color.rgbRed = (BYTE)max(0,min(255,(int)(color.rgbRed + r)));
+-			color.rgbGreen = (BYTE)max(0,min(255,(int)(color.rgbGreen + g)));
+-			color.rgbBlue = (BYTE)max(0,min(255,(int)(color.rgbBlue + b)));
++			color.rgbRed = (BYTE)maximum(0,minimum(255,(int)(color.rgbRed + r)));
++			color.rgbGreen = (BYTE)maximum(0,minimum(255,(int)(color.rgbGreen + g)));
++			color.rgbBlue = (BYTE)maximum(0,minimum(255,(int)(color.rgbBlue + b)));
+ 			SetPaletteColor((BYTE)j,color);
+ 		}
+ 	}
+@@ -1310,7 +1310,7 @@ bool CxImage::Gamma(float gamma)
+ 
+ 	BYTE cTable[256]; //<nipper>
+ 	for (int i=0;i<256;i++)	{
+-		cTable[i] = (BYTE)max(0,min(255,(int)( pow((double)i, dinvgamma) / dMax)));
++		cTable[i] = (BYTE)maximum(0,minimum(255,(int)( pow((double)i, dinvgamma) / dMax)));
+ 	}
+ 
+ 	return Lut(cTable);
+@@ -1337,21 +1337,21 @@ bool CxImage::GammaRGB(float gammaR, float gammaG, float gammaB)
+ 	dMax = pow(255.0, dinvgamma) / 255.0;
+ 	BYTE cTableR[256];
+ 	for (i=0;i<256;i++)	{
+-		cTableR[i] = (BYTE)max(0,min(255,(int)( pow((double)i, dinvgamma) / dMax)));
++		cTableR[i] = (BYTE)maximum(0,minimum(255,(int)( pow((double)i, dinvgamma) / dMax)));
+ 	}
+ 
+ 	dinvgamma = 1/gammaG;
+ 	dMax = pow(255.0, dinvgamma) / 255.0;
+ 	BYTE cTableG[256];
+ 	for (i=0;i<256;i++)	{
+-		cTableG[i] = (BYTE)max(0,min(255,(int)( pow((double)i, dinvgamma) / dMax)));
++		cTableG[i] = (BYTE)maximum(0,minimum(255,(int)( pow((double)i, dinvgamma) / dMax)));
+ 	}
+ 
+ 	dinvgamma = 1/gammaB;
+ 	dMax = pow(255.0, dinvgamma) / 255.0;
+ 	BYTE cTableB[256];
+ 	for (i=0;i<256;i++)	{
+-		cTableB[i] = (BYTE)max(0,min(255,(int)( pow((double)i, dinvgamma) / dMax)));
++		cTableB[i] = (BYTE)maximum(0,minimum(255,(int)( pow((double)i, dinvgamma) / dMax)));
+ 	}
+ 
+ 	return Lut(cTableR, cTableG, cTableB);
+@@ -1442,11 +1442,11 @@ bool CxImage::Noise(long level)
+ 			{
+ 				color = BlindGetPixelColor(x,y);
+ 				n=(long)((rand()/(float)RAND_MAX - 0.5)*level);
+-				color.rgbRed = (BYTE)max(0,min(255,(int)(color.rgbRed + n)));
++				color.rgbRed = (BYTE)maximum(0,minimum(255,(int)(color.rgbRed + n)));
+ 				n=(long)((rand()/(float)RAND_MAX - 0.5)*level);
+-				color.rgbGreen = (BYTE)max(0,min(255,(int)(color.rgbGreen + n)));
++				color.rgbGreen = (BYTE)maximum(0,minimum(255,(int)(color.rgbGreen + n)));
+ 				n=(long)((rand()/(float)RAND_MAX - 0.5)*level);
+-				color.rgbBlue = (BYTE)max(0,min(255,(int)(color.rgbBlue + n)));
++				color.rgbBlue = (BYTE)maximum(0,minimum(255,(int)(color.rgbBlue + n)));
+ 				BlindSetPixelColor(x,y,color);
+ 			}
+ 		}
+@@ -1561,8 +1561,8 @@ bool CxImage::FFT2(CxImage* srcReal, CxImage* srcImag, CxImage* dstReal, CxImage
+ 
+ 	//DFT buffers
+ 	double *real2,*imag2;
+-	real2 = (double*)malloc(max(w,h) * sizeof(double));
+-	imag2 = (double*)malloc(max(w,h) * sizeof(double));
++	real2 = (double*)malloc(maximum(w,h) * sizeof(double));
++	imag2 = (double*)malloc(maximum(w,h) * sizeof(double));
+ 
+ 	/* Transform the rows */
+ 	real = (double *)malloc(w * sizeof(double));
+@@ -1617,7 +1617,7 @@ bool CxImage::FFT2(CxImage* srcReal, CxImage* srcImag, CxImage* dstReal, CxImage
+ 
+ 	/* converting from double to byte, there is a HUGE loss in the dynamics
+ 	  "nn" tries to keep an acceptable SNR, but 8bit=48dB: don't ask more */
+-	double nn=pow((double)2,(double)log((double)max(w,h))/(double)log((double)2)-4);
++	double nn=pow((double)2,(double)log((double)maximum(w,h))/(double)log((double)2)-4);
+ 	//reversed gain for reversed transform
+ 	if (direction==-1) nn=1/nn;
+ 	//bMagnitude : just to see it on the screen
+@@ -1626,15 +1626,15 @@ bool CxImage::FFT2(CxImage* srcReal, CxImage* srcImag, CxImage* dstReal, CxImage
+ 	for (j=0;j<h;j++) {
+ 		for (k=0;k<w;k++) {
+ 			if (bMagnitude){
+-				tmpReal->SetPixelIndex(k,j,(BYTE)max(0,min(255,(nn*(3+log(_cabs(grid[k][j])))))));
++				tmpReal->SetPixelIndex(k,j,(BYTE)maximum(0,minimum(255,(nn*(3+log(_cabs(grid[k][j])))))));
+ 				if (grid[k][j].x==0){
+-					tmpImag->SetPixelIndex(k,j,(BYTE)max(0,min(255,(128+(atan(grid[k][j].y/0.0000000001)*nn)))));
++					tmpImag->SetPixelIndex(k,j,(BYTE)maximum(0,minimum(255,(128+(atan(grid[k][j].y/0.0000000001)*nn)))));
+ 				} else {
+-					tmpImag->SetPixelIndex(k,j,(BYTE)max(0,min(255,(128+(atan(grid[k][j].y/grid[k][j].x)*nn)))));
++					tmpImag->SetPixelIndex(k,j,(BYTE)maximum(0,minimum(255,(128+(atan(grid[k][j].y/grid[k][j].x)*nn)))));
+ 				}
+ 			} else {
+-				tmpReal->SetPixelIndex(k,j,(BYTE)max(0,min(255,(128 + grid[k][j].x*nn))));
+-				tmpImag->SetPixelIndex(k,j,(BYTE)max(0,min(255,(128 + grid[k][j].y*nn))));
++				tmpReal->SetPixelIndex(k,j,(BYTE)maximum(0,minimum(255,(128 + grid[k][j].x*nn))));
++				tmpImag->SetPixelIndex(k,j,(BYTE)maximum(0,minimum(255,(128 + grid[k][j].y*nn))));
+ 			}
+ 		}
+ 	}
+@@ -1922,7 +1922,7 @@ bool CxImage::RepairChannel(CxImage *ch, float radius)
+ 
+ 			correction = ((1.0+iy*iy)*ixx - ix*iy*ixy + (1.0+ix*ix)*iyy)/(1.0+ix*ix+iy*iy);
+ 
+-			tmp.BlindSetPixelIndex(x,y,(BYTE)min(255,max(0,(xy0 + radius * correction + 0.5))));
++			tmp.BlindSetPixelIndex(x,y,(BYTE)minimum(255,maximum(0,(xy0 + radius * correction + 0.5))));
+ 		}
+ 	}
+ 
+@@ -1943,7 +1943,7 @@ bool CxImage::RepairChannel(CxImage *ch, float radius)
+ 
+ 			correction = ((1.0+iy*iy)*ixx - ix*iy*ixy + (1.0+ix*ix)*iyy)/(1.0+ix*ix+iy*iy);
+ 
+-			tmp.BlindSetPixelIndex(x,y,(BYTE)min(255,max(0,(xy0 + radius * correction + 0.5))));
++			tmp.BlindSetPixelIndex(x,y,(BYTE)minimum(255,maximum(0,(xy0 + radius * correction + 0.5))));
+ 		}
+ 	}
+ 	for (x=0;x<=w;x+=w){
+@@ -1963,7 +1963,7 @@ bool CxImage::RepairChannel(CxImage *ch, float radius)
+ 
+ 			correction = ((1.0+iy*iy)*ixx - ix*iy*ixy + (1.0+ix*ix)*iyy)/(1.0+ix*ix+iy*iy);
+ 
+-			tmp.BlindSetPixelIndex(x,y,(BYTE)min(255,max(0,(xy0 + radius * correction + 0.5))));
++			tmp.BlindSetPixelIndex(x,y,(BYTE)minimum(255,maximum(0,(xy0 + radius * correction + 0.5))));
+ 		}
+ 	}
+ 
+@@ -2621,8 +2621,8 @@ bool CxImage::SelectiveBlur(float radius, BYTE threshold, CxImage* iDst)
+ 	}
+ 
+ 	//build the difference mask
+-	BYTE thresh_dw = (BYTE)max( 0 ,(int)(128 - threshold));
+-	BYTE thresh_up = (BYTE)min(255,(int)(128 + threshold));
++	BYTE thresh_dw = (BYTE)maximum( 0 ,(int)(128 - threshold));
++	BYTE thresh_up = (BYTE)minimum(255,(int)(128 + threshold));
+ 	long kernel[]={-100,-100,-100,-100,801,-100,-100,-100,-100};
+ 	if (!Tmp.Filter(kernel,3,800,128)){
+ 		delete [] pPalette;
+@@ -2755,7 +2755,7 @@ bool CxImage::UnsharpMask(float radius /*= 5.0*/, float amount /*= 0.5*/, int th
+ 					if (abs(diff) < threshold){
+ 						dest_row[z] = cur_row[z];
+ 					} else {
+-						dest_row[z] = (BYTE)min(255, max(0,(int)(cur_row[z] + amount * diff)));
++						dest_row[z] = (BYTE)minimum(255, maximum(0,(int)(cur_row[z] + amount * diff)));
+ 					}
+ 				}
+ 			}
+@@ -2952,7 +2952,7 @@ bool CxImage::RedEyeRemove(float strength)
+ 				float a = 1.0f-5.0f*((float)((x-0.5f*(xmax+xmin))*(x-0.5f*(xmax+xmin))+(y-0.5f*(ymax+ymin))*(y-0.5f*(ymax+ymin))))/((float)((xmax-xmin)*(ymax-ymin)));
+ 				if (a<0) a=0;
+ 				color = BlindGetPixelColor(x,y);
+-				color.rgbRed = (BYTE)(a*min(color.rgbGreen,color.rgbBlue)+(1.0f-a)*color.rgbRed);
++				color.rgbRed = (BYTE)(a*minimum(color.rgbGreen,color.rgbBlue)+(1.0f-a)*color.rgbRed);
+ 				BlindSetPixelColor(x,y,color);
+ 			}
+ 		}
+@@ -2990,7 +2990,7 @@ bool CxImage::Saturate(const long saturation, const long colorspace)
+ 	case 1:
+ 		{
+ 			for (int i=0;i<256;i++)	{
+-				cTable[i] = (BYTE)max(0,min(255,(int)(i + saturation)));
++				cTable[i] = (BYTE)maximum(0,minimum(255,(int)(i + saturation)));
+ 			}
+ 			for(long y=ymin; y<ymax; y++){
+ 				info.nProgress = (long)(100*(y-ymin)/(ymax-ymin));
+@@ -3012,7 +3012,7 @@ bool CxImage::Saturate(const long saturation, const long colorspace)
+ 	case 2:
+ 		{
+ 			for (int i=0;i<256;i++)	{
+-				cTable[i] = (BYTE)max(0,min(255,(int)((i-128)*(100 + saturation)/100.0f + 128.5f)));
++				cTable[i] = (BYTE)maximum(0,minimum(255,(int)((i-128)*(100 + saturation)/100.0f + 128.5f)));
+ 			}
+ 			for(long y=ymin; y<ymax; y++){
+ 				info.nProgress = (long)(100*(y-ymin)/(ymax-ymin));
+@@ -3242,10 +3242,10 @@ int  CxImage::OptimalThreshold(long method, RECT * pBox, CxImage* pContrastMask)
+ 
+ 	long xmin,xmax,ymin,ymax;
+ 	if (pBox){
+-		xmin = max(pBox->left,0);
+-		xmax = min(pBox->right,head.biWidth);
+-		ymin = max(pBox->bottom,0);
+-		ymax = min(pBox->top,head.biHeight);
++		xmin = maximum(pBox->left,0);
++		xmax = minimum(pBox->right,head.biWidth);
++		ymin = maximum(pBox->bottom,0);
++		ymax = minimum(pBox->top,head.biHeight);
+ 	} else {
+ 		xmin = ymin = 0;
+ 		xmax = head.biWidth; ymax=head.biHeight;
+@@ -3463,7 +3463,7 @@ bool CxImage::AdaptiveThreshold(long method, long nBoxSize, CxImage* pContrastMa
+ 			r.top = r.bottom + nBoxSize;
+ 			int threshold = OptimalThreshold(method, &r, pContrastMask);
+ 			if (threshold <0) return false;
+-			mask.SetPixelIndex(x,y,(BYTE)max(0,min(255,nBias+((1.0f-fGlobalLocalBalance)*threshold + fGlobalLocalBalance*globalthreshold))));
++			mask.SetPixelIndex(x,y,(BYTE)maximum(0,minimum(255,nBias+((1.0f-fGlobalLocalBalance)*threshold + fGlobalLocalBalance*globalthreshold))));
+ 		}
+ 	}
+ 
+@@ -3538,8 +3538,8 @@ bool CxImage::FloodFill(const long xStart, const long yStart, const RGBQUAD cFil
+ 	if (IsIndexed()){ //--- Generic indexed image, no tolerance OR Grayscale image with tolerance
+ 		BYTE idxRef = GetPixelIndex(xStart,yStart);
+ 		BYTE idxFill = GetNearestIndex(cFillColor);
+-		BYTE idxMin = (BYTE)min(255, max(0,(int)(idxRef - nTolerance)));
+-		BYTE idxMax = (BYTE)min(255, max(0,(int)(idxRef + nTolerance)));
++		BYTE idxMin = (BYTE)minimum(255, maximum(0,(int)(idxRef - nTolerance)));
++		BYTE idxMax = (BYTE)minimum(255, maximum(0,(int)(idxRef + nTolerance)));
+ 
+ 		while(!q.empty())
+ 		{
+@@ -3575,12 +3575,12 @@ bool CxImage::FloodFill(const long xStart, const long yStart, const RGBQUAD cFil
+ 	} else { //--- RGB image
+ 		RGBQUAD cRef = GetPixelColor(xStart,yStart);
+ 		RGBQUAD cRefMin, cRefMax;
+-		cRefMin.rgbRed   = (BYTE)min(255, max(0,(int)(cRef.rgbRed   - nTolerance)));
+-		cRefMin.rgbGreen = (BYTE)min(255, max(0,(int)(cRef.rgbGreen - nTolerance)));
+-		cRefMin.rgbBlue  = (BYTE)min(255, max(0,(int)(cRef.rgbBlue  - nTolerance)));
+-		cRefMax.rgbRed   = (BYTE)min(255, max(0,(int)(cRef.rgbRed   + nTolerance)));
+-		cRefMax.rgbGreen = (BYTE)min(255, max(0,(int)(cRef.rgbGreen + nTolerance)));
+-		cRefMax.rgbBlue  = (BYTE)min(255, max(0,(int)(cRef.rgbBlue  + nTolerance)));
++		cRefMin.rgbRed   = (BYTE)minimum(255, maximum(0,(int)(cRef.rgbRed   - nTolerance)));
++		cRefMin.rgbGreen = (BYTE)minimum(255, maximum(0,(int)(cRef.rgbGreen - nTolerance)));
++		cRefMin.rgbBlue  = (BYTE)minimum(255, maximum(0,(int)(cRef.rgbBlue  - nTolerance)));
++		cRefMax.rgbRed   = (BYTE)minimum(255, maximum(0,(int)(cRef.rgbRed   + nTolerance)));
++		cRefMax.rgbGreen = (BYTE)minimum(255, maximum(0,(int)(cRef.rgbGreen + nTolerance)));
++		cRefMax.rgbBlue  = (BYTE)minimum(255, maximum(0,(int)(cRef.rgbBlue  + nTolerance)));
+ 
+ 		while(!q.empty())
+ 		{
+diff --git a/lib/cximage-6.0/CxImage/ximage.cpp b/lib/cximage-6.0/CxImage/ximage.cpp
+index e81d3c6..b715c45 100644
+--- a/lib/cximage-6.0/CxImage/ximage.cpp
++++ b/lib/cximage-6.0/CxImage/ximage.cpp
+@@ -460,7 +460,7 @@ bool CxImage::CreateFromArray(BYTE* pArray,DWORD dwWidth,DWORD dwHeight,DWORD dw
+ 				src+=4;
+ 			}
+ 		} else {
+-			memcpy(dst,src,min(info.dwEffWidth,dwBytesperline));
++			memcpy(dst,src,minimum(info.dwEffWidth,dwBytesperline));
+ 		}
+ 	}
+ 	return true;
+@@ -500,7 +500,7 @@ bool CxImage::CreateFromMatrix(BYTE** ppMatrix,DWORD dwWidth,DWORD dwHeight,DWOR
+ 					src+=4;
+ 				}
+ 			} else {
+-				memcpy(dst,src,min(info.dwEffWidth,dwBytesperline));
++				memcpy(dst,src,minimum(info.dwEffWidth,dwBytesperline));
+ 			}
+ 		}
+ 	}
+diff --git a/lib/cximage-6.0/CxImage/ximagif.cpp b/lib/cximage-6.0/CxImage/ximagif.cpp
+index b89e061..1a26170 100644
+--- a/lib/cximage-6.0/CxImage/ximagif.cpp
++++ b/lib/cximage-6.0/CxImage/ximagif.cpp
+@@ -478,7 +478,7 @@ bool CxImageGIF::Encode(CxFile * fp, CxImage ** pImages, int pagecount, bool bLo
+ 	ghost.EncodeHeader(fp);
+ 
+ 	if (m_loops!=1){
+-		ghost.SetLoops(max(0,m_loops-1));
++		ghost.SetLoops(maximum(0,m_loops-1));
+ 		ghost.EncodeLoopExtension(fp);
+ 	}
+ 
+@@ -1340,10 +1340,10 @@ void CxImageGIF::GetComment(char* sz_comment_out)
+ ////////////////////////////////////////////////////////////////////////////////
+ void CxImageGIF::GifMix(CxImage & imgsrc2, struct_image & imgdesc)
+ {
+-	long ymin = max(0,(long)(GetHeight()-imgdesc.t - imgdesc.h));
++	long ymin = maximum(0,(long)(GetHeight()-imgdesc.t - imgdesc.h));
+ 	long ymax = GetHeight()-imgdesc.t;
+ 	long xmin = imgdesc.l;
+-	long xmax = min(GetWidth(), (DWORD)(imgdesc.l + imgdesc.w));
++	long xmax = minimum(GetWidth(), (DWORD)(imgdesc.l + imgdesc.w));
+ 
+ 	long ibg2= imgsrc2.GetTransIndex();
+     BYTE i2;
+diff --git a/lib/cximage-6.0/CxImage/ximahist.cpp b/lib/cximage-6.0/CxImage/ximahist.cpp
+index a2aed03..814ab94 100644
+--- a/lib/cximage-6.0/CxImage/ximahist.cpp
++++ b/lib/cximage-6.0/CxImage/ximahist.cpp
+@@ -110,7 +110,7 @@ bool CxImage::HistogramStretch(long method, double threshold)
+ 	// calculate LUT
+ 	BYTE lut[256];
+ 	for (x = 0; x <256; x++){
+-		lut[x] = (BYTE)max(0,min(255,(255 * (x - minc) / (maxc - minc))));
++		lut[x] = (BYTE)maximum(0,minimum(255,(255 * (x - minc) / (maxc - minc))));
+ 	}
+ 
+ 	for (y=0; y<head.biHeight; y++)	{
+@@ -152,7 +152,7 @@ bool CxImage::HistogramStretch(long method, double threshold)
+ 		// calculate LUT
+ 		BYTE lut[256];
+ 		for (x = 0; x <256; x++){
+-			lut[x] = (BYTE)max(0,min(255,(255 * (x - minc) / (maxc - minc))));
++			lut[x] = (BYTE)maximum(0,minimum(255,(255 * (x - minc) / (maxc - minc))));
+ 		}
+ 
+ 		// normalize image
+@@ -225,7 +225,7 @@ bool CxImage::HistogramStretch(long method, double threshold)
+ 		BYTE range = maxR - minR;
+ 		if (range != 0)	{
+ 			for (x = 0; x <256; x++){
+-				lutR[x] = (BYTE)max(0,min(255,(255 * (x - minR) / range)));
++				lutR[x] = (BYTE)maximum(0,minimum(255,(255 * (x - minR) / range)));
+ 			}
+ 		} else lutR[minR] = minR;
+ 
+@@ -233,7 +233,7 @@ bool CxImage::HistogramStretch(long method, double threshold)
+ 		range = maxG - minG;
+ 		if (range != 0)	{
+ 			for (x = 0; x <256; x++){
+-				lutG[x] = (BYTE)max(0,min(255,(255 * (x - minG) / range)));
++				lutG[x] = (BYTE)maximum(0,minimum(255,(255 * (x - minG) / range)));
+ 			}
+ 		} else lutG[minG] = minG;
+ 			
+@@ -241,7 +241,7 @@ bool CxImage::HistogramStretch(long method, double threshold)
+ 		range = maxB - minB;
+ 		if (range != 0)	{
+ 			for (x = 0; x <256; x++){
+-				lutB[x] = (BYTE)max(0,min(255,(255 * (x - minB) / range)));
++				lutB[x] = (BYTE)maximum(0,minimum(255,(255 * (x - minB) / range)));
+ 			}
+ 		} else lutB[minB] = minB;
+ 
+@@ -292,7 +292,7 @@ bool CxImage::HistogramStretch(long method, double threshold)
+ 		// calculate LUT
+ 		BYTE lut[256];
+ 		for (x = 0; x <256; x++){
+-			lut[x] = (BYTE)max(0,min(255,(255 * (x - minc) / (maxc - minc))));
++			lut[x] = (BYTE)maximum(0,minimum(255,(255 * (x - minc) / (maxc - minc))));
+ 		}
+ 
+ 		for(y=0; y<head.biHeight; y++){
+diff --git a/lib/cximage-6.0/CxImage/ximaint.cpp b/lib/cximage-6.0/CxImage/ximaint.cpp
+index 989d76c..6bde6b0 100644
+--- a/lib/cximage-6.0/CxImage/ximaint.cpp
++++ b/lib/cximage-6.0/CxImage/ximaint.cpp
+@@ -26,8 +26,8 @@ void CxImage::OverflowCoordinates(long &x, long &y, OverflowMethod const ofMetho
+   switch (ofMethod) {
+     case OM_REPEAT:
+       //clip coordinates
+-      x=max(x,0); x=min(x, head.biWidth-1);
+-      y=max(y,0); y=min(y, head.biHeight-1);
++      x=maximum(x,0); x=minimum(x, head.biWidth-1);
++      y=maximum(y,0); y=minimum(y, head.biHeight-1);
+       break;
+     case OM_WRAP:
+       //wrap coordinates
+@@ -59,8 +59,8 @@ void CxImage::OverflowCoordinates(float &x, float &y, OverflowMethod const ofMet
+   switch (ofMethod) {
+     case OM_REPEAT:
+       //clip coordinates
+-      x=max(x,0); x=min(x, head.biWidth-1);
+-      y=max(y,0); y=min(y, head.biHeight-1);
++      x=maximum(x,0); x=minimum(x, head.biWidth-1);
++      y=maximum(y,0); y=minimum(y, head.biHeight-1);
+       break;
+     case OM_WRAP:
+       //wrap coordinates
+diff --git a/lib/cximage-6.0/CxImage/ximaiter.h b/lib/cximage-6.0/CxImage/ximaiter.h
+index 9788919..0437c33 100644
+--- a/lib/cximage-6.0/CxImage/ximaiter.h
++++ b/lib/cximage-6.0/CxImage/ximaiter.h
+@@ -140,7 +140,7 @@ inline void CImageIterator::SetY(int y)
+ inline void CImageIterator::SetRow(BYTE *buf, int n)
+ {
+ 	if (n<0) n = (int)ima->GetEffWidth();
+-	else n = min(n,(int)ima->GetEffWidth());
++	else n = minimum(n,(int)ima->GetEffWidth());
+ 
+ 	if ((IterImage!=NULL)&&(buf!=NULL)&&(n>0)) memcpy(IterImage,buf,n);
+ }
+@@ -148,7 +148,7 @@ inline void CImageIterator::SetRow(BYTE *buf, int n)
+ inline void CImageIterator::GetRow(BYTE *buf, int n)
+ {
+ 	if ((IterImage!=NULL)&&(buf!=NULL)&&(n>0))
+-		memcpy(buf,IterImage,min(n,(int)ima->GetEffWidth()));
++		memcpy(buf,IterImage,minimum(n,(int)ima->GetEffWidth()));
+ }
+ /////////////////////////////////////////////////////////////////////
+ inline BYTE* CImageIterator::GetRow()
+diff --git a/lib/cximage-6.0/CxImage/ximajbg.cpp b/lib/cximage-6.0/CxImage/ximajbg.cpp
+index 06fb9bf..6751a46 100644
+--- a/lib/cximage-6.0/CxImage/ximajbg.cpp
++++ b/lib/cximage-6.0/CxImage/ximajbg.cpp
+@@ -145,7 +145,7 @@ bool CxImageJBG::Encode(CxFile * hFile)
+ 	jbg_enc_init(&jbig_state, w, h, planes, &buffer, jbig_data_out, hFile);
+ 
+     //jbg_enc_layers(&jbig_state, 2);
+-    //jbg_enc_lrlmax(&jbig_state, 800, 600);
++    //jbg_enc_lrlmaximum(&jbig_state, 800, 600);
+ 
+ 	// Specify a few other options (each is ignored if negative)
+ 	int dl = -1, dh = -1, d = -1, l0 = -1, mx = -1;
+diff --git a/lib/cximage-6.0/CxImage/ximajpg.cpp b/lib/cximage-6.0/CxImage/ximajpg.cpp
+index 79ab75b..acb5708 100644
+--- a/lib/cximage-6.0/CxImage/ximajpg.cpp
++++ b/lib/cximage-6.0/CxImage/ximajpg.cpp
+@@ -89,7 +89,7 @@ bool CxImageJPG::GetExifThumbnail(const char *filename, const char *outname, int
+     {
+       if (image.GetWidth() > 256 || image.GetHeight() > 256)
+       { // resize the image
+-//        float amount = 256.0f / max(image.GetWidth(), image.GetHeight());
++//        float amount = 256.0f / maximum(image.GetWidth(), image.GetHeight());
+ //        image.Resample((long)(image.GetWidth() * amount), (long)(image.GetHeight() * amount), 0);
+       }
+       if (m_exifinfo.Orientation != 1)
+diff --git a/lib/cximage-6.0/CxImage/ximapal.cpp b/lib/cximage-6.0/CxImage/ximapal.cpp
+index b3bd3da..882491b 100644
+--- a/lib/cximage-6.0/CxImage/ximapal.cpp
++++ b/lib/cximage-6.0/CxImage/ximapal.cpp
+@@ -398,8 +398,8 @@ void CxImage::RGBtoBGR(BYTE *buffer, int length)
+ {
+ 	if (buffer && (head.biClrUsed==0)){
+ 		BYTE temp;
+-		length = min(length,(int)info.dwEffWidth);
+-		length = min(length,(int)(3*head.biWidth));
++		length = minimum(length,(int)info.dwEffWidth);
++		length = minimum(length,(int)(3*head.biWidth));
+ 		for (int i=0;i<length;i+=3){
+ 			temp = buffer[i]; buffer[i] = buffer[i+2]; buffer[i+2] = temp;
+ 		}
+@@ -444,7 +444,7 @@ void CxImage::SetPalette(DWORD n, BYTE *r, BYTE *g, BYTE *b)
+ 	if (!g) g = r;
+ 	if (!b) b = g;
+ 	RGBQUAD* ppal=GetPalette();
+-	DWORD m=min(n,head.biClrUsed);
++	DWORD m=minimum(n,head.biClrUsed);
+ 	for (DWORD i=0; i<m;i++){
+ 		ppal[i].rgbRed=r[i];
+ 		ppal[i].rgbGreen=g[i];
+@@ -457,7 +457,7 @@ void CxImage::SetPalette(rgb_color *rgb,DWORD nColors)
+ {
+ 	if ((!rgb)||(pDib==NULL)||(head.biClrUsed==0)) return;
+ 	RGBQUAD* ppal=GetPalette();
+-	DWORD m=min(nColors,head.biClrUsed);
++	DWORD m=minimum(nColors,head.biClrUsed);
+ 	for (DWORD i=0; i<m;i++){
+ 		ppal[i].rgbRed=rgb[i].r;
+ 		ppal[i].rgbGreen=rgb[i].g;
+@@ -469,7 +469,7 @@ void CxImage::SetPalette(rgb_color *rgb,DWORD nColors)
+ void CxImage::SetPalette(RGBQUAD* pPal,DWORD nColors)
+ {
+ 	if ((pPal==NULL)||(pDib==NULL)||(head.biClrUsed==0)) return;
+-	memcpy(GetPalette(),pPal,min(GetPaletteSize(),nColors*sizeof(RGBQUAD)));
++	memcpy(GetPalette(),pPal,minimum(GetPaletteSize(),nColors*sizeof(RGBQUAD)));
+ 	info.last_c_isvalid = false;
+ }
+ ////////////////////////////////////////////////////////////////////////////////
+@@ -654,10 +654,10 @@ void CxImage::SetClrImportant(DWORD ncolors)
+ 
+ 	switch(head.biBitCount){
+ 	case 1:
+-		head.biClrImportant = min(ncolors,2);
++		head.biClrImportant = minimum(ncolors,2);
+ 		break;
+ 	case 4:
+-		head.biClrImportant = min(ncolors,16);
++		head.biClrImportant = minimum(ncolors,16);
+ 		break;
+ 	case 8:
+ 		head.biClrImportant = ncolors;
+diff --git a/lib/cximage-6.0/CxImage/ximapng.cpp b/lib/cximage-6.0/CxImage/ximapng.cpp
+index a58441c..76fad8a 100644
+--- a/lib/cximage-6.0/CxImage/ximapng.cpp
++++ b/lib/cximage-6.0/CxImage/ximapng.cpp
+@@ -206,9 +206,9 @@ bool CxImagePNG::Decode(CxFile *hFile)
+ 	} else SetGrayPalette(); //<DP> needed for grayscale PNGs
+ 	
+ #ifdef USE_NEW_LIBPNG_API
+-	int nshift = max(0,(_bit_depth>>3)-1)<<3;
++	int nshift = maximum(0,(_bit_depth>>3)-1)<<3;
+ #else
+-	int nshift = max(0,(info_ptr->bit_depth>>3)-1)<<3;
++	int nshift = maximum(0,(info_ptr->bit_depth>>3)-1)<<3;
+ #endif
+ 
+ #ifdef USE_NEW_LIBPNG_API
+@@ -255,10 +255,10 @@ bool CxImagePNG::Decode(CxFile *hFile)
+ 			if (pal){
+ 				DWORD ip;
+ #ifdef USE_NEW_LIBPNG_API
+-				for (ip=0;ip<min(head.biClrUsed,(unsigned long)_num_trans);ip++)
++				for (ip=0;ip<minimum(head.biClrUsed,(unsigned long)_num_trans);ip++)
+ 					pal[ip].rgbReserved=_trans_alpha[ip];
+ #else
+-				for (ip=0;ip<min(head.biClrUsed,(unsigned long)info_ptr->num_trans);ip++)
++				for (ip=0;ip<minimum(head.biClrUsed,(unsigned long)info_ptr->num_trans);ip++)
+ #if PNG_LIBPNG_VER > 10399
+ 					pal[ip].rgbReserved=info_ptr->trans_alpha[ip];
+ #else
+@@ -737,9 +737,9 @@ bool CxImagePNG::Encode(CxFile *hFile)
+ #endif // CXIMAGE_SUPPORT_ALPHA	// <vho>
+ 
+ #ifdef USE_NEW_LIBPNG_API
+-	int row_size = max(info.dwEffWidth, (_width * _channels * _bit_depth / 8));
++	int row_size = maximum(info.dwEffWidth, (_width * _channels * _bit_depth / 8));
+ #else
+-	int row_size = max(info.dwEffWidth, info_ptr->width*info_ptr->channels*(info_ptr->bit_depth/8));
++	int row_size = maximum(info.dwEffWidth, info_ptr->width*info_ptr->channels*(info_ptr->bit_depth/8));
+ 	info_ptr->rowbytes = row_size;
+ #endif
+ 	BYTE *row_pointers = new BYTE[row_size];
+diff --git a/lib/cximage-6.0/CxImage/ximaraw.cpp b/lib/cximage-6.0/CxImage/ximaraw.cpp
+index fd86f96..1c4a8f6 100644
+--- a/lib/cximage-6.0/CxImage/ximaraw.cpp
++++ b/lib/cximage-6.0/CxImage/ximaraw.cpp
+@@ -216,7 +216,7 @@ bool CxImageRAW::Decode(CxFile *hFile)
+ 
+ 		DWORD size = dcr.width * (dcr.colors*dcr.opt.output_bps/8);
+ 		RGBtoBGR(ppm,size);
+-		memcpy(GetBits(dcr.height - 1 - row), ppm, min(size,GetEffWidth()));
++		memcpy(GetBits(dcr.height - 1 - row), ppm, minimum(size,GetEffWidth()));
+ 	}
+ 	free (ppm);
+ 
+@@ -298,7 +298,7 @@ bool CxImageRAW::GetExifThumbnail(const char *filename, const char *outname, int
+ 			// Resizing.
+       		if (image.GetWidth() > 256 || image.GetHeight() > 256)
+ 		    {
+-				float amount = 256.0f / max(image.GetWidth(), image.GetHeight());
++				float amount = 256.0f / maximum(image.GetWidth(), image.GetHeight());
+ 				image.Resample((long)(image.GetWidth() * amount), (long)(image.GetHeight() * amount), 0);
+ 		    }
+ 	      	
+diff --git a/lib/cximage-6.0/CxImage/ximasel.cpp b/lib/cximage-6.0/CxImage/ximasel.cpp
+index 3a7c9a1..50ed029 100644
+--- a/lib/cximage-6.0/CxImage/ximasel.cpp
++++ b/lib/cximage-6.0/CxImage/ximasel.cpp
+@@ -113,15 +113,15 @@ bool CxImage::SelectionAddRect(RECT r, BYTE level)
+ 	if (r.left<r.right) {r2.left=r.left; r2.right=r.right; } else {r2.left=r.right ; r2.right=r.left; }
+ 	if (r.bottom<r.top) {r2.bottom=r.bottom; r2.top=r.top; } else {r2.bottom=r.top ; r2.top=r.bottom; }
+ 
+-	if (info.rSelectionBox.top <= r2.top) info.rSelectionBox.top = max(0L,min(head.biHeight,r2.top+1));
+-	if (info.rSelectionBox.left > r2.left) info.rSelectionBox.left = max(0L,min(head.biWidth,r2.left));
+-	if (info.rSelectionBox.right <= r2.right) info.rSelectionBox.right = max(0L,min(head.biWidth,r2.right+1));
+-	if (info.rSelectionBox.bottom > r2.bottom) info.rSelectionBox.bottom = max(0L,min(head.biHeight,r2.bottom));
++	if (info.rSelectionBox.top <= r2.top) info.rSelectionBox.top = maximum(0L,minimum(head.biHeight,r2.top+1));
++	if (info.rSelectionBox.left > r2.left) info.rSelectionBox.left = maximum(0L,minimum(head.biWidth,r2.left));
++	if (info.rSelectionBox.right <= r2.right) info.rSelectionBox.right = maximum(0L,minimum(head.biWidth,r2.right+1));
++	if (info.rSelectionBox.bottom > r2.bottom) info.rSelectionBox.bottom = maximum(0L,minimum(head.biHeight,r2.bottom));
+ 
+-	long ymin = max(0L,min(head.biHeight,r2.bottom));
+-	long ymax = max(0L,min(head.biHeight,r2.top+1));
+-	long xmin = max(0L,min(head.biWidth,r2.left));
+-	long xmax = max(0L,min(head.biWidth,r2.right+1));
++	long ymin = maximum(0L,minimum(head.biHeight,r2.bottom));
++	long ymax = maximum(0L,minimum(head.biHeight,r2.top+1));
++	long xmin = maximum(0L,minimum(head.biWidth,r2.left));
++	long xmax = maximum(0L,minimum(head.biWidth,r2.right+1));
+ 
+ 	for (long y=ymin; y<ymax; y++)
+ 		memset(pSelection + xmin + y * head.biWidth, level, xmax-xmin);
+@@ -144,18 +144,18 @@ bool CxImage::SelectionAddEllipse(RECT r, BYTE level)
+ 	long xcenter = (r.right + r.left)/2;
+ 	long ycenter = (r.top + r.bottom)/2;
+ 
+-	if (info.rSelectionBox.left > (xcenter - xradius)) info.rSelectionBox.left = max(0L,min(head.biWidth,(xcenter - xradius)));
+-	if (info.rSelectionBox.right <= (xcenter + xradius)) info.rSelectionBox.right = max(0L,min(head.biWidth,(xcenter + xradius + 1)));
+-	if (info.rSelectionBox.bottom > (ycenter - yradius)) info.rSelectionBox.bottom = max(0L,min(head.biHeight,(ycenter - yradius)));
+-	if (info.rSelectionBox.top <= (ycenter + yradius)) info.rSelectionBox.top = max(0L,min(head.biHeight,(ycenter + yradius + 1)));
++	if (info.rSelectionBox.left > (xcenter - xradius)) info.rSelectionBox.left = maximum(0L,minimum(head.biWidth,(xcenter - xradius)));
++	if (info.rSelectionBox.right <= (xcenter + xradius)) info.rSelectionBox.right = maximum(0L,minimum(head.biWidth,(xcenter + xradius + 1)));
++	if (info.rSelectionBox.bottom > (ycenter - yradius)) info.rSelectionBox.bottom = maximum(0L,minimum(head.biHeight,(ycenter - yradius)));
++	if (info.rSelectionBox.top <= (ycenter + yradius)) info.rSelectionBox.top = maximum(0L,minimum(head.biHeight,(ycenter + yradius + 1)));
+ 
+-	long xmin = max(0L,min(head.biWidth,xcenter - xradius));
+-	long xmax = max(0L,min(head.biWidth,xcenter + xradius + 1));
+-	long ymin = max(0L,min(head.biHeight,ycenter - yradius));
+-	long ymax = max(0L,min(head.biHeight,ycenter + yradius + 1));
++	long xmin = maximum(0L,minimum(head.biWidth,xcenter - xradius));
++	long xmax = maximum(0L,minimum(head.biWidth,xcenter + xradius + 1));
++	long ymin = maximum(0L,minimum(head.biHeight,ycenter - yradius));
++	long ymax = maximum(0L,minimum(head.biHeight,ycenter + yradius + 1));
+ 
+ 	long y,yo;
+-	for (y=ymin; y<min(ycenter,ymax); y++){
++	for (y=ymin; y<minimum(ycenter,ymax); y++){
+ 		for (long x=xmin; x<xmax; x++){
+ 			yo = (long)(ycenter - yradius * sqrt(1-pow((float)(x - xcenter)/(float)xradius,2)));
+ 			if (yo<y) pSelection[x + y * head.biWidth] = level;
+@@ -268,10 +268,10 @@ bool CxImage::SelectionAddPolygon(POINT *points, long npoints, BYTE level)
+ 		RECT r2;
+ 		if (current->x < next->x) {r2.left=current->x; r2.right=next->x; } else {r2.left=next->x ; r2.right=current->x; }
+ 		if (current->y < next->y) {r2.bottom=current->y; r2.top=next->y; } else {r2.bottom=next->y ; r2.top=current->y; }
+-		if (localbox.top < r2.top) localbox.top = max(0L,min(head.biHeight-1,r2.top+1));
+-		if (localbox.left > r2.left) localbox.left = max(0L,min(head.biWidth-1,r2.left-1));
+-		if (localbox.right < r2.right) localbox.right = max(0L,min(head.biWidth-1,r2.right+1));
+-		if (localbox.bottom > r2.bottom) localbox.bottom = max(0L,min(head.biHeight-1,r2.bottom-1));
++		if (localbox.top < r2.top) localbox.top = maximum(0L,minimum(head.biHeight-1,r2.top+1));
++		if (localbox.left > r2.left) localbox.left = maximum(0L,minimum(head.biWidth-1,r2.left-1));
++		if (localbox.right < r2.right) localbox.right = maximum(0L,minimum(head.biWidth-1,r2.right+1));
++		if (localbox.bottom > r2.bottom) localbox.bottom = maximum(0L,minimum(head.biHeight-1,r2.bottom-1));
+ 
+ 		i++;
+ 	}
+@@ -385,10 +385,10 @@ bool CxImage::SelectionAddPolygon(POINT *points, long npoints, BYTE level)
+ 		for (x=localbox.left; x<=localbox.right; x++)
+ 			if (plocal[x + yoffset]!=1) pSelection[x + yoffset]=level;
+ 	}
+-	if (info.rSelectionBox.top <= localbox.top) info.rSelectionBox.top = min(head.biHeight,localbox.top + 1);
+-	if (info.rSelectionBox.left > localbox.left) info.rSelectionBox.left = min(head.biWidth,localbox.left);
+-	if (info.rSelectionBox.right <= localbox.right) info.rSelectionBox.right = min(head.biWidth,localbox.right + 1);
+-	if (info.rSelectionBox.bottom > localbox.bottom) info.rSelectionBox.bottom = min(head.biHeight,localbox.bottom);
++	if (info.rSelectionBox.top <= localbox.top) info.rSelectionBox.top = minimum(head.biHeight,localbox.top + 1);
++	if (info.rSelectionBox.left > localbox.left) info.rSelectionBox.left = minimum(head.biWidth,localbox.left);
++	if (info.rSelectionBox.right <= localbox.right) info.rSelectionBox.right = minimum(head.biWidth,localbox.right + 1);
++	if (info.rSelectionBox.bottom > localbox.bottom) info.rSelectionBox.bottom = minimum(head.biHeight,localbox.bottom);
+ 
+ 	free(plocal);
+ 	free(pix);
+diff --git a/lib/cximage-6.0/CxImage/ximath.cpp b/lib/cximage-6.0/CxImage/ximath.cpp
+index 37533e2..c2f0835 100644
+--- a/lib/cximage-6.0/CxImage/ximath.cpp
++++ b/lib/cximage-6.0/CxImage/ximath.cpp
+@@ -64,10 +64,10 @@ CxRect2 CxRect2::CrossSection(CxRect2 const &r2) const
+  */
+ {
+   CxRect2 cs;
+-  cs.botLeft.x=max(botLeft.x, r2.botLeft.x);
+-  cs.botLeft.y=max(botLeft.y, r2.botLeft.y);
+-  cs.topRight.x=min(topRight.x, r2.topRight.x);
+-  cs.topRight.y=min(topRight.y, r2.topRight.y);
++  cs.botLeft.x=maximum(botLeft.x, r2.botLeft.x);
++  cs.botLeft.y=maximum(botLeft.y, r2.botLeft.y);
++  cs.topRight.x=minimum(topRight.x, r2.topRight.x);
++  cs.topRight.y=minimum(topRight.y, r2.topRight.y);
+   if (cs.botLeft.x<=cs.topRight.x && cs.botLeft.y<=cs.topRight.y) {
+     return cs;
+   } else {
+diff --git a/lib/cximage-6.0/CxImage/ximatif.cpp b/lib/cximage-6.0/CxImage/ximatif.cpp
+index 658392a..22c4e67 100644
+--- a/lib/cximage-6.0/CxImage/ximatif.cpp
++++ b/lib/cximage-6.0/CxImage/ximatif.cpp
+@@ -470,9 +470,9 @@ bool CxImageTIF::Decode(CxFile * hFile)
+ 						if ( cb > 0.00304 ) cb = 1.055 * pow(cb,0.41667) - 0.055;
+ 							else            cb = 12.92 * cb;
+ 
+-						c.rgbRed  =(BYTE)max(0,min(255,(int)(cr*255)));
+-						c.rgbGreen=(BYTE)max(0,min(255,(int)(cg*255)));
+-						c.rgbBlue =(BYTE)max(0,min(255,(int)(cb*255)));
++						c.rgbRed  =(BYTE)maximum(0,minimum(255,(int)(cr*255)));
++						c.rgbGreen=(BYTE)maximum(0,minimum(255,(int)(cg*255)));
++						c.rgbBlue =(BYTE)maximum(0,minimum(255,(int)(cb*255)));
+ 
+ 						SetPixelColor(xi,yi,c);
+ #if CXIMAGE_SUPPORT_ALPHA
+diff --git a/lib/cximage-6.0/CxImage/ximatran.cpp b/lib/cximage-6.0/CxImage/ximatran.cpp
+index 64a71e7..dfbcddf 100644
+--- a/lib/cximage-6.0/CxImage/ximatran.cpp
++++ b/lib/cximage-6.0/CxImage/ximatran.cpp
+@@ -302,12 +302,12 @@ bool CxImage::RotateLeft(CxImage* iDst)
+ 			for (ys = 0; ys < newHeight; ys+=RBLOCK) {
+ 				if (head.biBitCount==24) {
+ 					//RGB24 optimized pixel access:
+-					for (x = xs; x < min(newWidth, xs+RBLOCK); x++){    //do rotation
++					for (x = xs; x < minimum(newWidth, xs+RBLOCK); x++){    //do rotation
+ 						info.nProgress = (long)(100*x/newWidth);
+ 						x2=newWidth-x-1;
+ 						dstPtr = (BYTE*) imgDest.BlindGetPixelPointer(x,ys);
+ 						srcPtr = (BYTE*) BlindGetPixelPointer(ys, x2);
+-						for (y = ys; y < min(newHeight, ys+RBLOCK); y++){
++						for (y = ys; y < minimum(newHeight, ys+RBLOCK); y++){
+ 							//imgDest.SetPixelColor(x, y, GetPixelColor(y, x2));
+ 							*(dstPtr) = *(srcPtr);
+ 							*(dstPtr+1) = *(srcPtr+1);
+@@ -318,19 +318,19 @@ bool CxImage::RotateLeft(CxImage* iDst)
+ 					}//for x
+ 				} else {
+ 					//anything else than 24bpp (and 1bpp): palette
+-					for (x = xs; x < min(newWidth, xs+RBLOCK); x++){
++					for (x = xs; x < minimum(newWidth, xs+RBLOCK); x++){
+ 						info.nProgress = (long)(100*x/newWidth); //<Anatoly Ivasyuk>
+ 						x2=newWidth-x-1;
+-						for (y = ys; y < min(newHeight, ys+RBLOCK); y++){
++						for (y = ys; y < minimum(newHeight, ys+RBLOCK); y++){
+ 							imgDest.SetPixelIndex(x, y, BlindGetPixelIndex(y, x2));
+ 						}//for y
+ 					}//for x
+ 				}//if (version selection)
+ #if CXIMAGE_SUPPORT_ALPHA
+ 				if (AlphaIsValid()) {
+-					for (x = xs; x < min(newWidth, xs+RBLOCK); x++){
++					for (x = xs; x < minimum(newWidth, xs+RBLOCK); x++){
+ 						x2=newWidth-x-1;
+-						for (y = ys; y < min(newHeight, ys+RBLOCK); y++){
++						for (y = ys; y < minimum(newHeight, ys+RBLOCK); y++){
+ 							imgDest.AlphaSet(x,y,BlindAlphaGet(y, x2));
+ 						}//for y
+ 					}//for x
+@@ -343,9 +343,9 @@ bool CxImage::RotateLeft(CxImage* iDst)
+ 					imgDest.info.rSelectionBox.right = newWidth-info.rSelectionBox.bottom;
+ 					imgDest.info.rSelectionBox.bottom = info.rSelectionBox.left;
+ 					imgDest.info.rSelectionBox.top = info.rSelectionBox.right;
+-					for (x = xs; x < min(newWidth, xs+RBLOCK); x++){
++					for (x = xs; x < minimum(newWidth, xs+RBLOCK); x++){
+ 						x2=newWidth-x-1;
+-						for (y = ys; y < min(newHeight, ys+RBLOCK); y++){
++						for (y = ys; y < minimum(newHeight, ys+RBLOCK); y++){
+ 							imgDest.SelectionSet(x,y,BlindSelectionGet(y, x2));
+ 						}//for y
+ 					}//for x
+@@ -447,12 +447,12 @@ bool CxImage::RotateRight(CxImage* iDst)
+ 			for (ys = 0; ys < newHeight; ys+=RBLOCK) {
+ 				if (head.biBitCount==24) {
+ 					//RGB24 optimized pixel access:
+-					for (y = ys; y < min(newHeight, ys+RBLOCK); y++){
++					for (y = ys; y < minimum(newHeight, ys+RBLOCK); y++){
+ 						info.nProgress = (long)(100*y/newHeight); //<Anatoly Ivasyuk>
+ 						y2=newHeight-y-1;
+ 						dstPtr = (BYTE*) imgDest.BlindGetPixelPointer(xs,y);
+ 						srcPtr = (BYTE*) BlindGetPixelPointer(y2, xs);
+-						for (x = xs; x < min(newWidth, xs+RBLOCK); x++){
++						for (x = xs; x < minimum(newWidth, xs+RBLOCK); x++){
+ 							//imgDest.SetPixelColor(x, y, GetPixelColor(y2, x));
+ 							*(dstPtr) = *(srcPtr);
+ 							*(dstPtr+1) = *(srcPtr+1);
+@@ -463,19 +463,19 @@ bool CxImage::RotateRight(CxImage* iDst)
+ 					}//for y
+ 				} else {
+ 					//anything else than BW & RGB24: palette
+-					for (y = ys; y < min(newHeight, ys+RBLOCK); y++){
++					for (y = ys; y < minimum(newHeight, ys+RBLOCK); y++){
+ 						info.nProgress = (long)(100*y/newHeight); //<Anatoly Ivasyuk>
+ 						y2=newHeight-y-1;
+-						for (x = xs; x < min(newWidth, xs+RBLOCK); x++){
++						for (x = xs; x < minimum(newWidth, xs+RBLOCK); x++){
+ 							imgDest.SetPixelIndex(x, y, BlindGetPixelIndex(y2, x));
+ 						}//for x
+ 					}//for y
+ 				}//if
+ #if CXIMAGE_SUPPORT_ALPHA
+ 				if (AlphaIsValid()){
+-					for (y = ys; y < min(newHeight, ys+RBLOCK); y++){
++					for (y = ys; y < minimum(newHeight, ys+RBLOCK); y++){
+ 						y2=newHeight-y-1;
+-						for (x = xs; x < min(newWidth, xs+RBLOCK); x++){
++						for (x = xs; x < minimum(newWidth, xs+RBLOCK); x++){
+ 							imgDest.AlphaSet(x,y,BlindAlphaGet(y2, x));
+ 						}//for x
+ 					}//for y
+@@ -488,9 +488,9 @@ bool CxImage::RotateRight(CxImage* iDst)
+ 					imgDest.info.rSelectionBox.right = info.rSelectionBox.top;
+ 					imgDest.info.rSelectionBox.bottom = newHeight-info.rSelectionBox.right;
+ 					imgDest.info.rSelectionBox.top = newHeight-info.rSelectionBox.left;
+-					for (y = ys; y < min(newHeight, ys+RBLOCK); y++){
++					for (y = ys; y < minimum(newHeight, ys+RBLOCK); y++){
+ 						y2=newHeight-y-1;
+-						for (x = xs; x < min(newWidth, xs+RBLOCK); x++){
++						for (x = xs; x < minimum(newWidth, xs+RBLOCK); x++){
+ 							imgDest.SelectionSet(x,y,BlindSelectionGet(y2, x));
+ 						}//for x
+ 					}//for y
+@@ -608,10 +608,10 @@ bool CxImage::Rotate(float angle, CxImage* iDst)
+ 	newP4.x = (float)(p4.x*cos_angle - p4.y*sin_angle);
+ 	newP4.y = (float)(p4.x*sin_angle + p4.y*cos_angle);
+ 
+-	leftTop.x = min(min(newP1.x,newP2.x),min(newP3.x,newP4.x));
+-	leftTop.y = min(min(newP1.y,newP2.y),min(newP3.y,newP4.y));
+-	rightBottom.x = max(max(newP1.x,newP2.x),max(newP3.x,newP4.x));
+-	rightBottom.y = max(max(newP1.y,newP2.y),max(newP3.y,newP4.y));
++	leftTop.x = minimum(minimum(newP1.x,newP2.x),minimum(newP3.x,newP4.x));
++	leftTop.y = minimum(minimum(newP1.y,newP2.y),minimum(newP3.y,newP4.y));
++	rightBottom.x = maximum(maximum(newP1.x,newP2.x),maximum(newP3.x,newP4.x));
++	rightBottom.y = maximum(maximum(newP1.y,newP2.y),maximum(newP3.y,newP4.y));
+ 	leftBottom.x = leftTop.x;
+ 	leftBottom.y = rightBottom.y;
+ 	rightTop.x = rightBottom.x;
+@@ -740,10 +740,10 @@ bool CxImage::Rotate2(float angle,
+ 	}//if
+ 
+ 	//(read new dimensions from location of corners)
+-	float minx = (float) min(min(newp[0].x,newp[1].x),min(newp[2].x,newp[3].x));
+-	float miny = (float) min(min(newp[0].y,newp[1].y),min(newp[2].y,newp[3].y));
+-	float maxx = (float) max(max(newp[0].x,newp[1].x),max(newp[2].x,newp[3].x));
+-	float maxy = (float) max(max(newp[0].y,newp[1].y),max(newp[2].y,newp[3].y));
++	float minx = (float) minimum(minimum(newp[0].x,newp[1].x),minimum(newp[2].x,newp[3].x));
++	float miny = (float) minimum(minimum(newp[0].y,newp[1].y),minimum(newp[2].y,newp[3].y));
++	float maxx = (float) maximum(maximum(newp[0].x,newp[1].x),maximum(newp[2].x,newp[3].x));
++	float maxy = (float) maximum(maximum(newp[0].y,newp[1].y),maximum(newp[2].y,newp[3].y));
+ 	int newWidth = (int) floor(maxx-minx+0.5f);
+ 	int newHeight= (int) floor(maxy-miny+0.5f);
+ 	float ssx=((maxx+minx)- ((float) newWidth-1))/2.0f;   //start for x
+@@ -1003,12 +1003,12 @@ bool CxImage::Resample(long newx, long newy, int mode, CxImage* iDst)
+ 				if (info.nEscape) break;
+ 				fY = y * yScale;
+ 				ifY = (int)fY;
+-				ifY1 = min(ymax, ifY+1);
++				ifY1 = minimum(ymax, ifY+1);
+ 				dy = fY - ifY;
+ 				for(long x=0; x<newx; x++){
+ 					fX = x * xScale;
+ 					ifX = (int)fX;
+-					ifX1 = min(xmax, ifX+1);
++					ifX1 = minimum(xmax, ifX+1);
+ 					dx = fX - ifX;
+ 					// Interpolate using the four nearest pixels in the source
+ 					if (head.biClrUsed){
+@@ -1328,9 +1328,9 @@ bool CxImage::DecreaseBpp(DWORD nbit, bool errordiffusion, RGBQUAD* ppal, DWORD
+ 				eb=(long)c.rgbBlue - (long)ce.rgbBlue;
+ 
+ 				c = GetPixelColor(x+1,y);
+-				c.rgbRed = (BYTE)min(255L,max(0L,(long)c.rgbRed + ((er*7)/16)));
+-				c.rgbGreen = (BYTE)min(255L,max(0L,(long)c.rgbGreen + ((eg*7)/16)));
+-				c.rgbBlue = (BYTE)min(255L,max(0L,(long)c.rgbBlue + ((eb*7)/16)));
++				c.rgbRed = (BYTE)minimum(255L,maximum(0L,(long)c.rgbRed + ((er*7)/16)));
++				c.rgbGreen = (BYTE)minimum(255L,maximum(0L,(long)c.rgbGreen + ((eg*7)/16)));
++				c.rgbBlue = (BYTE)minimum(255L,maximum(0L,(long)c.rgbBlue + ((eb*7)/16)));
+ 				SetPixelColor(x+1,y,c);
+ 				int coeff=1;
+ 				for(int i=-1; i<2; i++){
+@@ -1343,9 +1343,9 @@ bool CxImage::DecreaseBpp(DWORD nbit, bool errordiffusion, RGBQUAD* ppal, DWORD
+ 						coeff=1; break;
+ 					}
+ 					c = GetPixelColor(x+i,y+1);
+-					c.rgbRed = (BYTE)min(255L,max(0L,(long)c.rgbRed + ((er * coeff)/16)));
+-					c.rgbGreen = (BYTE)min(255L,max(0L,(long)c.rgbGreen + ((eg * coeff)/16)));
+-					c.rgbBlue = (BYTE)min(255L,max(0L,(long)c.rgbBlue + ((eb * coeff)/16)));
++					c.rgbRed = (BYTE)minimum(255L,maximum(0L,(long)c.rgbRed + ((er * coeff)/16)));
++					c.rgbGreen = (BYTE)minimum(255L,maximum(0L,(long)c.rgbGreen + ((eg * coeff)/16)));
++					c.rgbBlue = (BYTE)minimum(255L,maximum(0L,(long)c.rgbBlue + ((eb * coeff)/16)));
+ 					SetPixelColor(x+i,y+1,c);
+ 				}
+ 			}
+@@ -1566,10 +1566,10 @@ bool CxImage::Dither(long method)
+ 				}
+ 
+ 				nlevel = GetPixelIndex(x + 1, y) + (error * 8) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(x + 1, y, level);
+ 				nlevel = GetPixelIndex(x + 2, y) + (error * 4) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(x + 2, y, level);
+ 				int i;
+ 				for (i = -2; i < 3; i++) {
+@@ -1591,7 +1591,7 @@ bool CxImage::Dither(long method)
+ 						break;
+ 					}
+ 					nlevel = GetPixelIndex(x + i, y + 1) + (error * coeff) / TotalCoeffSum;
+-					level = (BYTE)min(255, max(0, (int)nlevel));
++					level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 					SetPixelIndex(x + i, y + 1, level);
+ 				}
+ 			}
+@@ -1620,10 +1620,10 @@ bool CxImage::Dither(long method)
+ 				}
+ 
+ 				nlevel = GetPixelIndex(x + 1, y) + (error * 8) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(x + 1, y, level);
+ 				nlevel = GetPixelIndex(x + 2, y) + (error * 4) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(x + 2, y, level);
+ 				int i;
+ 				for (i = -2; i < 3; i++) {
+@@ -1645,7 +1645,7 @@ bool CxImage::Dither(long method)
+ 						break;
+ 					}
+ 					nlevel = GetPixelIndex(x + i, y + 1) + (error * coeff) / TotalCoeffSum;
+-					level = (BYTE)min(255, max(0, (int)nlevel));
++					level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 					SetPixelIndex(x + i, y + 1, level);
+ 				}
+ 				for (i = -2; i < 3; i++) {
+@@ -1667,7 +1667,7 @@ bool CxImage::Dither(long method)
+ 						break;
+ 					}
+ 					nlevel = GetPixelIndex(x + i, y + 2) + (error * coeff) / TotalCoeffSum;
+-					level = (BYTE)min(255, max(0, (int)nlevel));
++					level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 					SetPixelIndex(x + i, y + 2, level);
+ 				}
+ 			}
+@@ -1696,10 +1696,10 @@ bool CxImage::Dither(long method)
+ 				}
+ 
+ 				nlevel = GetPixelIndex(x + 1, y) + (error * 7) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(x + 1, y, level);
+ 				nlevel = GetPixelIndex(x + 2, y) + (error * 5) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(x + 2, y, level);
+ 				int i;
+ 				for (i = -2; i < 3; i++) {
+@@ -1721,7 +1721,7 @@ bool CxImage::Dither(long method)
+ 						break;
+ 					}
+ 					nlevel = GetPixelIndex(x + i, y + 1) + (error * coeff) / TotalCoeffSum;
+-					level = (BYTE)min(255, max(0, (int)nlevel));
++					level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 					SetPixelIndex(x + i, y + 1, level);
+ 				}
+ 				for (i = -2; i < 3; i++) {
+@@ -1743,7 +1743,7 @@ bool CxImage::Dither(long method)
+ 						break;
+ 					}
+ 					nlevel = GetPixelIndex(x + i, y + 2) + (error * coeff) / TotalCoeffSum;
+-					level = (BYTE)min(255, max(0, (int)nlevel));
++					level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 					SetPixelIndex(x + i, y + 2, level);
+ 				}
+ 			}
+@@ -1772,10 +1772,10 @@ bool CxImage::Dither(long method)
+ 				}
+ 
+ 				nlevel = GetPixelIndex(x + 1, y) + (error * 5) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(x + 1, y, level);
+ 				nlevel = GetPixelIndex(x + 2, y) + (error * 3) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(x + 2, y, level);
+ 				int i;
+ 				for (i = -2; i < 3; i++) {
+@@ -1797,7 +1797,7 @@ bool CxImage::Dither(long method)
+ 						break;
+ 					}
+ 					nlevel = GetPixelIndex(x + i, y + 1) + (error * coeff) / TotalCoeffSum;
+-					level = (BYTE)min(255, max(0, (int)nlevel));
++					level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 					SetPixelIndex(x + i, y + 1, level);
+ 				}
+ 				for (i = -1; i < 2; i++) {
+@@ -1813,7 +1813,7 @@ bool CxImage::Dither(long method)
+ 						break;
+ 					}
+ 					nlevel = GetPixelIndex(x + i, y + 2) + (error * coeff) / TotalCoeffSum;
+-					level = (BYTE)min(255, max(0, (int)nlevel));
++					level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 					SetPixelIndex(x + i, y + 2, level);
+ 				}
+ 			}
+@@ -1845,76 +1845,76 @@ bool CxImage::Dither(long method)
+ 				int tmp_index_y = y;
+ 				int tmp_coeff = 32;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x - 3;
+ 				tmp_index_y = y + 1;
+ 				tmp_coeff = 12;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x - 1;
+ 				tmp_coeff = 26;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x + 1;
+ 				tmp_coeff = 30;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x + 3;
+ 				tmp_coeff = 16;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x - 2;
+ 				tmp_index_y = y + 2;
+ 				tmp_coeff = 12;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x;
+ 				tmp_coeff = 26;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x + 2;
+ 				tmp_coeff = 12;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x - 3;
+ 				tmp_index_y = y + 3;
+ 				tmp_coeff = 5;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x - 1;
+ 				tmp_coeff = 12;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x + 1;
+ 				tmp_coeff = 12;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 
+ 				tmp_index_x = x + 3;
+ 				tmp_coeff = 5;
+ 				nlevel = GetPixelIndex(tmp_index_x, tmp_index_y) + (error * tmp_coeff) / TotalCoeffSum;
+-				level = (BYTE)min(255, max(0, (int)nlevel));
++				level = (BYTE)minimum(255, maximum(0, (int)nlevel));
+ 				SetPixelIndex(tmp_index_x, tmp_index_y, level);
+ 			}
+ 		}
+@@ -1941,7 +1941,7 @@ bool CxImage::Dither(long method)
+ 			Bmatrix[i] = (BYTE)(dither);
+ 		}
+ 
+-		int scale = max(0,(8-2*order));
++		int scale = maximum(0,(8-2*order));
+ 		int level;
+ 		for (long y=0;y<head.biHeight;y++){
+ 			info.nProgress = (long)(100*y/head.biHeight);
+@@ -1981,7 +1981,7 @@ bool CxImage::Dither(long method)
+ 				}
+ 
+ 				nlevel = GetPixelIndex(x+1,y) + (error * 7)/16;
+-				level = (BYTE)min(255,max(0,(int)nlevel));
++				level = (BYTE)minimum(255,maximum(0,(int)nlevel));
+ 				SetPixelIndex(x+1,y,level);
+ 				for(int i=-1; i<2; i++){
+ 					switch(i){
+@@ -1993,7 +1993,7 @@ bool CxImage::Dither(long method)
+ 						coeff=1; break;
+ 					}
+ 					nlevel = GetPixelIndex(x+i,y+1) + (error * coeff)/16;
+-					level = (BYTE)min(255,max(0,(int)nlevel));
++					level = (BYTE)minimum(255,maximum(0,(int)nlevel));
+ 					SetPixelIndex(x+i,y+1,level);
+ 				}
+ 			}
+@@ -2031,7 +2031,7 @@ bool CxImage::CropRotatedRectangle( long topx, long topy, long width, long heigh
+ 	if ( fabs(angle)<0.0002 )
+ 		return Crop( topx, topy, topx+width, topy+height, iDst);
+ 
+-	startx = min(topx, topx - (long)(sin_angle*(double)height));
++	startx = minimum(topx, topx - (long)(sin_angle*(double)height));
+ 	endx   = topx + (long)(cos_angle*(double)width);
+ 	endy   = topy + (long)(cos_angle*(double)height + sin_angle*(double)width);
+ 	// check: corners of the rectangle must be inside
+@@ -2079,10 +2079,10 @@ bool CxImage::Crop(long left, long top, long right, long bottom, CxImage* iDst)
+ {
+ 	if (!pDib) return false;
+ 
+-	long startx = max(0L,min(left,head.biWidth));
+-	long endx = max(0L,min(right,head.biWidth));
+-	long starty = head.biHeight - max(0L,min(top,head.biHeight));
+-	long endy = head.biHeight - max(0L,min(bottom,head.biHeight));
++	long startx = maximum(0L,minimum(left,head.biWidth));
++	long endx = maximum(0L,minimum(right,head.biWidth));
++	long starty = head.biHeight - maximum(0L,minimum(top,head.biHeight));
++	long endy = head.biHeight - maximum(0L,minimum(bottom,head.biHeight));
+ 
+ 	if (startx==endx || starty==endy) return false;
+ 
+@@ -2443,8 +2443,8 @@ bool CxImage::CircleTransform(int type,long rmax,float Koeff)
+ 						nx=x+(x%32)-16;
+ 						ny=y;
+ 					}
+-//					nx=max(xmin,min(nx,xmax));
+-//					ny=max(ymin,min(ny,ymax));
++//					nx=maximum(xmin,minimum(nx,xmax));
++//					ny=maximum(ymin,minimum(ny,ymax));
+ 				}
+ 				else { nx=-1;ny=-1;}
+ 				if (head.biClrUsed==0){
+diff --git a/lib/cximage-6.0/CxImage/ximawnd.cpp b/lib/cximage-6.0/CxImage/ximawnd.cpp
+index 2ae2f93..9ddc05a 100644
+--- a/lib/cximage-6.0/CxImage/ximawnd.cpp
++++ b/lib/cximage-6.0/CxImage/ximawnd.cpp
+@@ -682,10 +682,10 @@ long CxImage::Draw(HDC hdc, long x, long y, long cx, long cy, RECT* pClipRect, b
+ 	RECT clipbox,paintbox;
+ 	GetClipBox(hdc,&clipbox);
+ 
+-	paintbox.top = min(clipbox.bottom,max(clipbox.top,y));
+-	paintbox.left = min(clipbox.right,max(clipbox.left,x));
+-	paintbox.right = max(clipbox.left,min(clipbox.right,x+cx));
+-	paintbox.bottom = max(clipbox.top,min(clipbox.bottom,y+cy));
++	paintbox.top = minimum(clipbox.bottom,maximum(clipbox.top,y));
++	paintbox.left = minimum(clipbox.right,maximum(clipbox.left,x));
++	paintbox.right = maximum(clipbox.left,minimum(clipbox.right,x+cx));
++	paintbox.bottom = maximum(clipbox.top,minimum(clipbox.bottom,y+cy));
+ 
+ 	long destw = paintbox.right - paintbox.left;
+ 	long desth = paintbox.bottom - paintbox.top;
+@@ -730,12 +730,12 @@ long CxImage::Draw(HDC hdc, long x, long y, long cx, long cy, RECT* pClipRect, b
+ 
+ 				for(yy=0;yy<desth;yy++){
+ 					dy = head.biHeight-(ymax-yy-y)*fy;
+-					sy = max(0L,(long)floor(dy));
++					sy = maximum(0L,(long)floor(dy));
+ 					psrc = info.pImage+sy*info.dwEffWidth;
+ 					pdst = pbase+yy*ew;
+ 					for(xx=0;xx<destw;xx++){
+ 						dx = (xx+xmin-x)*fx;
+-						sx = max(0L,(long)floor(dx));
++						sx = maximum(0L,(long)floor(dx));
+ #if CXIMAGE_SUPPORT_INTERPOLATION
+ 						if (bSmooth){
+ 							if (fx > 1 && fy > 1) { 
+@@ -813,7 +813,7 @@ long CxImage::Draw(HDC hdc, long x, long y, long cx, long cy, RECT* pClipRect, b
+ 				
+ 				for(yy=0;yy<desth;yy++){
+ 					dy = head.biHeight-(ymax-yy-y)*fy;
+-					sy = max(0L,(long)floor(dy));
++					sy = maximum(0L,(long)floor(dy));
+ 
+ 					alphaoffset = sy*head.biWidth;
+ 					pdst = pbase + yy*ew;
+@@ -821,7 +821,7 @@ long CxImage::Draw(HDC hdc, long x, long y, long cx, long cy, RECT* pClipRect, b
+ 
+ 					for(xx=0;xx<destw;xx++){
+ 						dx = (xx+xmin-x)*fx;
+-						sx = max(0L,(long)floor(dx));
++						sx = maximum(0L,(long)floor(dx));
+ 
+ 						if (bAlpha) a=pAlpha[alphaoffset+sx]; else a=255;
+ 						a =(BYTE)((a*(1+info.nAlphaMax))>>8);

--- a/media-tv/kodi/kodi-16.1-r1.ebuild
+++ b/media-tv/kodi/kodi-16.1-r1.ebuild
@@ -1,0 +1,301 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+# Does not work with py3 here
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="sqlite"
+
+inherit eutils linux-info python-single-r1 multiprocessing autotools toolchain-funcs
+
+CODENAME="Jarvis"
+case ${PV} in
+9999)
+	EGIT_REPO_URI="git://github.com/xbmc/xbmc.git"
+	inherit git-r3
+	;;
+*)
+	MY_PV=${PV/_p/_r}
+	MY_PV=${MY_PV//_alpha/a}
+	MY_PV=${MY_PV//_beta/b}
+	MY_PV=${MY_PV//_rc/rc}
+	MY_P="${PN}-${MY_PV}"
+	SRC_URI="https://github.com/xbmc/xbmc/archive/${MY_PV}-${CODENAME}.tar.gz -> ${MY_P}.tar.gz
+		!java? ( https://github.com/candrews/gentoo-kodi/raw/master/${MY_P}-generated-addons-r1.tar.xz )"
+	KEYWORDS="~amd64 ~x86"
+
+	S=${WORKDIR}/xbmc-${MY_PV}-${CODENAME}
+	;;
+esac
+
+DESCRIPTION="Kodi is a free and open source media-player and entertainment hub"
+HOMEPAGE="https://kodi.tv/ http://kodi.wiki/"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="airplay alsa bluetooth bluray caps cec css dbus debug gles java joystick midi mysql nfs +opengl profile pulseaudio rtmp +samba sftp systemd test +texturepacker udisks upnp upower +usb vaapi vdpau webserver +X zeroconf"
+# gles/vaapi: http://trac.kodi.tv/ticket/10552 #464306
+REQUIRED_USE="
+	|| ( gles opengl )
+	?? ( gles vaapi )
+	udisks? ( dbus )
+	upower? ( dbus )
+"
+
+COMMON_DEPEND="${PYTHON_DEPS}
+	app-arch/bzip2
+	app-arch/unzip
+	app-arch/zip
+	app-i18n/enca
+	airplay? ( app-pda/libplist )
+	dev-libs/boost:=
+	dev-libs/expat
+	dev-libs/fribidi
+	dev-libs/libcdio[-minimal]
+	cec? ( >=dev-libs/libcec-3.0 )
+	dev-libs/libpcre[cxx]
+	dev-libs/libxml2
+	dev-libs/libxslt
+	>=dev-libs/lzo-2.04
+	dev-libs/tinyxml[stl]
+	>=dev-libs/yajl-2
+	dev-python/simplejson[${PYTHON_USEDEP}]
+	media-fonts/corefonts
+	media-fonts/roboto
+	alsa? ( media-libs/alsa-lib )
+	media-libs/flac
+	media-libs/fontconfig
+	media-libs/freetype
+	media-libs/jasper:=
+	media-libs/jbigkit
+	>=media-libs/libass-0.9.7
+	bluray? ( >=media-libs/libbluray-0.7.0 )
+	css? ( media-libs/libdvdcss )
+	media-libs/libmad
+	media-libs/libmodplug
+	media-libs/libmpeg2
+	media-libs/libogg
+	media-libs/libpng:0=
+	media-libs/libsamplerate
+	joystick? ( media-libs/libsdl2 )
+	>=media-libs/taglib-1.8
+	media-libs/libvorbis
+	media-libs/tiff:0=
+	media-sound/dcadec
+	pulseaudio? ( media-sound/pulseaudio )
+	media-sound/wavpack
+	>=media-video/ffmpeg-2.6:=[encode]
+	rtmp? ( media-video/rtmpdump )
+	nfs? ( net-fs/libnfs:= )
+	webserver? ( net-libs/libmicrohttpd[messages] )
+	sftp? ( net-libs/libssh[sftp] )
+	net-misc/curl
+	samba? ( >=net-fs/samba-3.4.6[smbclient(+)] )
+	bluetooth? ( net-wireless/bluez )
+	dbus? ( sys-apps/dbus )
+	caps? ( sys-libs/libcap )
+	sys-libs/zlib
+	virtual/jpeg:0=
+	usb? ( virtual/libusb:1 )
+	mysql? ( virtual/mysql )
+	opengl? (
+		virtual/glu
+		virtual/opengl
+		>=media-libs/glew-1.5.6:=
+	)
+	gles? (
+		media-libs/mesa[gles2]
+	)
+	vaapi? ( x11-libs/libva[opengl] )
+	vdpau? (
+		|| ( >=x11-libs/libvdpau-1.1 >=x11-drivers/nvidia-drivers-180.51 )
+		media-video/ffmpeg[vdpau]
+	)
+	X? (
+		x11-apps/xdpyinfo
+		x11-apps/mesa-progs
+		x11-libs/libXinerama
+		x11-libs/libXrandr
+		x11-libs/libXrender
+	)
+	zeroconf? ( net-dns/avahi[dbus] )
+"
+RDEPEND="${COMMON_DEPEND}
+	!media-tv/xbmc
+	udisks? ( sys-fs/udisks:0 )
+	upower? (
+		systemd? ( sys-power/upower )
+		!systemd? ( sys-power/upower-pm-utils )
+	)"
+DEPEND="${COMMON_DEPEND}
+	app-arch/xz-utils
+	dev-lang/swig
+	dev-libs/crossguid
+	dev-util/gperf
+	texturepacker? ( media-libs/giflib )
+	X? ( x11-proto/xineramaproto )
+	dev-util/cmake
+	x86? ( dev-lang/nasm )
+	java? ( virtual/jre )
+	test? ( dev-cpp/gtest )
+	virtual/pkgconfig"
+# Force java for latest git version to avoid having to hand maintain the
+# generated addons package.  #488118
+[[ ${PV} == "9999" ]] && DEPEND+=" virtual/jre"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-9999-no-arm-flags.patch #400618887
+	"${FILESDIR}"/${PN}-9999-texturepacker.patch
+	"${FILESDIR}"/${PN}-16-ffmpeg3.patch
+	"${FILESDIR}"/${PN}-16.1-gcc-6.patch #592446
+)
+
+CONFIG_CHECK="~IP_MULTICAST"
+ERROR_IP_MULTICAST="
+In some cases Kodi needs to access multicast addresses.
+Please consider enabling IP_MULTICAST under Networking options.
+"
+
+pkg_setup() {
+	check_extra_config
+	python-single-r1_pkg_setup
+}
+
+src_unpack() {
+	[[ ${PV} == "9999" ]] && git-r3_src_unpack || default
+}
+
+src_prepare() {
+	default
+
+	# some dirs ship generated autotools, some dont
+	multijob_init
+	local d dirs=(
+		tools/depends/native/TexturePacker/src/configure
+		$(printf 'f:\n\t@echo $(BOOTSTRAP_TARGETS)\ninclude bootstrap.mk\n' | emake -f - f)
+	)
+	for d in "${dirs[@]}" ; do
+		[[ -e ${d} ]] && continue
+		pushd ${d/%configure/.} >/dev/null || die
+		AT_NOELIBTOOLIZE="yes" AT_TOPLEVEL_EAUTORECONF="yes" \
+		multijob_child_init eautoreconf
+		popd >/dev/null || die
+	done
+	multijob_finish
+	elibtoolize
+
+	# Cross-compiler support
+	# We need JsonSchemaBuilder and TexturePacker binaries for the host system
+	# Later we need libsquish for the target system
+	if tc-is-cross-compiler ; then
+		mkdir "${WORKDIR}"/${CBUILD} || die
+		pushd "${WORKDIR}"/${CBUILD} >/dev/null || die
+		einfo "Building host tools"
+		cp -a "$S"/{tools,xbmc} ./ || die
+		local tools=( JsonSchemaBuilder )
+		use texturepacker && tools+=( TexturePacker )
+		for tool in "${tools[@]}" ; do
+			tc-env_build emake -C tools/depends/native/$tool
+			mkdir "$S"/tools/depends/native/$tool/bin || die
+			ln -s "${WORKDIR}"/${CBUILD}/tools/depends/native/$tool/bin/$tool "$S"/tools/depends/native/$tool/bin/$tool || die
+		done
+		popd >/dev/null || die
+
+		emake -f codegenerator.mk
+
+		# Binary kodi.bin links against libsquish,
+		# so we need libsquish compiled for the target system
+		emake -C tools/depends/native/libsquish-native/ CXX=$(tc-getCXX)
+	elif [[ ${PV} == "9999" ]] || use java ; then #558798
+		tc-env_build emake -f codegenerator.mk
+	fi
+
+	# Disable internal func checks as our USE/DEPEND
+	# stuff handles this just fine already #408395
+	export ac_cv_lib_avcodec_ff_vdpau_vc1_decode_picture=yes
+
+	# Fix the final version string showing as "exported"
+	# instead of the SVN revision number.
+	export HAVE_GIT=no GIT_REV=${EGIT_VERSION:-exported}
+
+	# avoid long delays when powerkit isn't running #348580
+	sed -i \
+		-e '/dbus_connection_send_with_reply_and_block/s:-1:3000:' \
+		xbmc/linux/*.cpp || die
+
+	# Tweak autotool timestamps to avoid regeneration
+	find . -type f -exec touch -r configure {} + || die
+}
+
+src_configure() {
+	# Disable documentation generation
+	export ac_cv_path_LATEX=no
+	# Avoid help2man
+	export HELP2MAN=$(type -P help2man || echo true)
+	# No configure flage for this #403561
+	export ac_cv_lib_bluetooth_hci_devid=$(usex bluetooth)
+	# Requiring java is asine #434662
+	[[ ${PV} != "9999" ]] && export ac_cv_path_JAVA_EXE=$(which $(usex java java true))
+
+	econf \
+		--disable-ccache \
+		--disable-optimizations \
+		--with-ffmpeg=shared \
+		$(use_enable alsa) \
+		$(use_enable airplay) \
+		$(use_enable bluray libbluray) \
+		$(use_enable caps libcap) \
+		$(use_enable cec libcec) \
+		$(use_enable css dvdcss) \
+		$(use_enable dbus) \
+		$(use_enable debug) \
+		$(use_enable gles) \
+		$(use_enable joystick) \
+		$(use_enable midi mid) \
+		$(use_enable mysql) \
+		$(use_enable nfs) \
+		$(use_enable opengl gl) \
+		$(use_enable profile profiling) \
+		$(use_enable pulseaudio pulse) \
+		$(use_enable rtmp) \
+		$(use_enable samba) \
+		$(use_enable sftp ssh) \
+		$(use_enable usb libusb) \
+		$(use_enable test gtest) \
+		$(use_enable texturepacker) \
+		$(use_enable upnp) \
+		$(use_enable vaapi) \
+		$(use_enable vdpau) \
+		$(use_enable webserver) \
+		$(use_enable X x11) \
+		$(use_enable zeroconf avahi)
+}
+
+src_compile() {
+	emake V=1
+}
+
+src_install() {
+	default
+	rm "${ED%/}"/usr/share/doc/*/{LICENSE.GPL,copying.txt}* || die
+
+	domenu tools/Linux/kodi.desktop
+	newicon media/icon48x48.png kodi.png
+
+	# Remove fontconfig settings that are used only on MacOSX.
+	# Can't be patched upstream because they just find all files and install
+	# them into same structure like they have in git.
+	rm -rf "${ED%/}"/usr/share/kodi/system/players/dvdplayer/etc || die
+
+	# Replace bundled fonts with system ones.
+	rm "${ED%/}"/usr/share/kodi/addons/skin.confluence/fonts/Roboto-* || die
+	dosym /usr/share/fonts/roboto/Roboto-Regular.ttf \
+		/usr/share/kodi/addons/skin.confluence/fonts/Roboto-Regular.ttf
+	dosym /usr/share/fonts/roboto/Roboto-Bold.ttf \
+		/usr/share/kodi/addons/skin.confluence/fonts/Roboto-Bold.ttf
+
+	python_domodule tools/EventClients/lib/python/xbmcclient.py
+	python_newscript "tools/EventClients/Clients/Kodi Send/kodi-send.py" kodi-send
+}

--- a/media-tv/kodi/kodi-17.0_rc3-r1.ebuild
+++ b/media-tv/kodi/kodi-17.0_rc3-r1.ebuild
@@ -154,6 +154,8 @@ In some cases Kodi needs to access multicast addresses.
 Please consider enabling IP_MULTICAST under Networking options.
 "
 
+CMAKE_USE_DIR=${S}/project/cmake/
+
 pkg_setup() {
 	check_extra_config
 	python-single-r1_pkg_setup


### PR DESCRIPTION
* -16.1-r1, -17_rc3-r1, and -9999: Add systemd use flag to pull in correct upower dependency
* -16.1-r1: fix building with GCC 6
* -17_rc3-r1 and -9999: Depend on 'dbus' use flag in net-dns/avahi to include zeroconf support, see https://github.com/gentoo/gentoo/pull/3340
* -17_rc3-r1 and -9999: Always depend on dev-libs/libcdio
* -17_rc3-r1 and -9999: fontconfig settings path has changed
* -17_rc3-r1 and -9999: Set minimum version of media-fonts/noto appropriately
* -17_rc3-r1 and -9999: Use eautoreconf instead of autoreconf for parts of the build which still use autotools instead of cmake

https://bugs.gentoo.org/show_bug.cgi?id=583230
https://bugs.gentoo.org/show_bug.cgi?id=605578
https://bugs.gentoo.org/show_bug.cgi?id=605712
https://bugs.gentoo.org/show_bug.cgi?id=605716
https://bugs.gentoo.org/show_bug.cgi?id=605676
https://bugs.gentoo.org/show_bug.cgi?id=592446