### PR TITLE
dev-python/jellyfish: add py3.5, doc, tests, EAPI=6

### DIFF
--- a/dev-python/jellyfish/jellyfish-0.5.6.ebuild
+++ b/dev-python/jellyfish/jellyfish-0.5.6.ebuild
@@ -1,9 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4} )
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+DISTUTILS_IN_SOURCE_BUILD=1
+
 inherit distutils-r1
 
 DESCRIPTION="Python module for doing approximate and phonetic matching of strings"
@@ -13,5 +15,30 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+IUSE="doc test"
 
-DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
+	test? (
+		dev-python/pytest-runner[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+		dev-python/unicodecsv[${PYTHON_USEDEP}]
+	)
+"
+
+python_compile() {
+	esetup.py build_ext --inplace
+	esetup.py build
+}
+
+python_compile_all() {
+	if use doc; then
+		esetup.py build_sphinx
+		HTML_DOCS=( build/sphinx/html/. )
+	fi
+}
+
+python_test() {
+	py.test jellyfish/test.py || die "tests failed with ${EPYTHON}"
+}


### PR DESCRIPTION
@SoapGentoo Another py3.5 package! I don't think I need a revbump but please tell me if I'm wrong :)