### PR TITLE
Make Samba and dependencies respect a python USE flag

### DIFF
--- a/net-fs/samba/samba-4.5.3.ebuild
+++ b/net-fs/samba/samba-4.5.3.ebuild
@@ -26,7 +26,7 @@ LICENSE="GPL-3"
 SLOT="0"
 
 IUSE="acl addc addns ads client cluster cups dmapi fam gnutls iprint
-ldap pam quota selinux syslog +system-mitkrb5 systemd test winbind zeroconf"
+ldap pam python quota selinux syslog +system-mitkrb5 systemd test winbind zeroconf"
 
 MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/samba-4.0/policy.h
@@ -40,7 +40,8 @@ MULTILIB_WRAPPED_HEADERS=(
 )
 
 # sys-apps/attr is an automagic dependency (see bug #489748)
-CDEPEND="${PYTHON_DEPS}
+CDEPEND="
+	python? ( ${PYTHON_DEPS} )
 	>=app-arch/libarchive-3.1.2[${MULTILIB_USEDEP}]
 	dev-lang/perl:=
 	dev-libs/libaio[${MULTILIB_USEDEP}]
@@ -49,13 +50,13 @@ CDEPEND="${PYTHON_DEPS}
 	dev-libs/popt[${MULTILIB_USEDEP}]
 	sys-libs/readline:=
 	virtual/libiconv
-	dev-python/subunit[${PYTHON_USEDEP},${MULTILIB_USEDEP}]
+	python? ( dev-python/subunit[${PYTHON_USEDEP},${MULTILIB_USEDEP}] )
 	sys-apps/attr[${MULTILIB_USEDEP}]
 	sys-libs/libcap
-	>=sys-libs/ldb-1.1.27[ldap(+)?,${MULTILIB_USEDEP}]
+	>=sys-libs/ldb-1.1.27[ldap(+)?,python(+)?,${MULTILIB_USEDEP}]
 	sys-libs/ncurses:0=[${MULTILIB_USEDEP}]
-	>=sys-libs/talloc-2.1.8[python,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tdb-1.3.10[python,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.1.8[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
+	>=sys-libs/tdb-1.3.10[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
 	>=sys-libs/tevent-0.9.31-r1[${MULTILIB_USEDEP}]
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	pam? ( virtual/pam )
@@ -81,7 +82,7 @@ RDEPEND="${CDEPEND}
 
 REQUIRED_USE="addc? ( gnutls !system-mitkrb5 )
 	ads? ( acl gnutls ldap )
-	${PYTHON_REQUIRED_USE}"
+	python? ( ${PYTHON_REQUIRED_USE} )"
 
 S="${WORKDIR}/${MY_P}"
 
@@ -145,6 +146,7 @@ multilib_src_configure() {
 			$(use_enable iprint)
 			$(use_with ldap)
 			$(use_with pam)
+			$(use_enable python)
 			$(usex pam "--with-pammodulesdir=${EPREFIX}/$(get_libdir)/security" '')
 			$(use_with quota quotas)
 			$(use_with syslog)

--- a/sys-libs/ldb/files/ldb-1.1.29-no_python_tdb.patch
+++ b/sys-libs/ldb/files/ldb-1.1.29-no_python_tdb.patch
@@ -1,0 +1,29 @@
+Adds checking if python is disabled around test if python libraries are installed.
+
+This patch is a slightly cleaned up copy of 4.3.3-nopython-lib_tdb_wscript.patch
+from below package of patches used to disable python in the samba ebuild.
+
+https://dev.gentoo.org/~polynomial-c/samba-disable-python-patches-4.5.0_rc1.tar.xz
+
+--- lib/tdb/wscript
++++ lib/tdb/wscript
+@@ -77,16 +77,16 @@
+     conf.env.standalone_tdb = conf.IN_LAUNCH_DIR()
+     conf.env.building_tdb = True
+
++    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
++
+     if not conf.env.standalone_tdb:
+         if conf.CHECK_BUNDLED_SYSTEM_PKG('tdb', minversion=VERSION,
+                                      implied_deps='replace'):
+             conf.define('USING_SYSTEM_TDB', 1)
+             conf.env.building_tdb = False
+-            if conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytdb', 'tdb', minversion=VERSION):
++            if not conf.env.disable_python and conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytdb', 'tdb', minversion=VERSION):
+                 conf.define('USING_SYSTEM_PYTDB', 1)
+
+-    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
+-
+     if (conf.CONFIG_SET('HAVE_ROBUST_MUTEXES') and
+         conf.env.building_tdb and
+         not conf.env.disable_tdb_mutex_locking):

--- a/sys-libs/ldb/files/ldb-1.1.29-no_python_tevent.patch
+++ b/sys-libs/ldb/files/ldb-1.1.29-no_python_tevent.patch
@@ -1,0 +1,33 @@
+Adds checking if python is disabled around test if python libraries are installed.
+
+This patch is a slightly cleaned up copy of 4.2.7-nopython-lib_tevent_wscript.patch
+from below package of patches used to disable python in the samba ebuild.
+
+https://dev.gentoo.org/~polynomial-c/samba-disable-python-patches-4.5.0_rc1.tar.xz
+
+--- lib/tevent/wscript
++++ lib/tevent/wscript
+@@ -34,11 +34,13 @@
+
+     conf.env.standalone_tevent = conf.IN_LAUNCH_DIR()
+
++    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
++
+     if not conf.env.standalone_tevent:
+         if conf.CHECK_BUNDLED_SYSTEM_PKG('tevent', minversion=VERSION,
+                                      onlyif='talloc', implied_deps='replace talloc'):
+             conf.define('USING_SYSTEM_TEVENT', 1)
+-            if conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytevent', 'tevent', minversion=VERSION):
++            if not conf.env.disable_python and conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytevent', 'tevent', minversion=VERSION):
+                 conf.define('USING_SYSTEM_PYTEVENT', 1)
+
+     if conf.CHECK_FUNCS('epoll_create', headers='sys/epoll.h'):
+@@ -61,8 +63,6 @@
+     if not conf.CONFIG_SET('USING_SYSTEM_TEVENT'):
+         conf.DEFINE('TEVENT_NUM_SIGNALS', tevent_num_signals)
+
+-    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
+-
+     if not conf.env.disable_python:
+         # also disable if we don't have the python libs installed
+         conf.find_program('python', var='PYTHON')

--- a/sys-libs/ldb/ldb-1.1.29.ebuild
+++ b/sys-libs/ldb/ldb-1.1.29.ebuild
@@ -15,16 +15,16 @@ SRC_URI="http://www.samba.org/ftp/pub/${PN}/${P}.tar.gz"
 LICENSE="LGPL-3"
 SLOT="0/${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
-IUSE="doc +ldap"
+IUSE="doc +ldap python"
 
 RDEPEND="!elibc_FreeBSD? ( dev-libs/libbsd[${MULTILIB_USEDEP}] )
 	dev-libs/popt[${MULTILIB_USEDEP}]
-	>=sys-libs/talloc-2.1.8[python,${MULTILIB_USEDEP}]
-	>=sys-libs/tevent-0.9.31[python(+),${MULTILIB_USEDEP}]
-	>=sys-libs/tdb-1.3.12[python,${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.1.8[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tevent-0.9.31[python(+)?,${MULTILIB_USEDEP}]
+	>=sys-libs/tdb-1.3.12[python?,${MULTILIB_USEDEP}]
 	!!<net-fs/samba-3.6.0[ldb]
 	!!>=net-fs/samba-4.0.0[ldb]
-	${PYTHON_DEPS}
+	python? ( ${PYTHON_DEPS} )
 	ldap? ( net-nds/openldap )
 	"
 
@@ -33,7 +33,7 @@ DEPEND="dev-libs/libxslt
 	virtual/pkgconfig
 	${RDEPEND}"
 
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 WAF_BINARY="${S}/buildtools/bin/waf"
 
@@ -41,6 +41,8 @@ MULTILIB_WRAPPED_HEADERS=( /usr/include/pyldb.h )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.1.27-optional_packages.patch
+	"${FILESDIR}"/${PN}-1.1.29-no_python_tevent.patch
+	"${FILESDIR}"/${PN}-1.1.29-no_python_tdb.patch
 )
 
 pkg_setup() {
@@ -55,14 +57,12 @@ src_prepare() {
 multilib_src_configure() {
 	local myconf=(
 		$(usex ldap '' --disable-ldap) \
+		$(multilib_native_usex python '' --disable-python) \
 		--disable-rpath \
 		--disable-rpath-install --bundled-libraries=NONE \
 		--with-modulesdir="${EPREFIX}"/usr/$(get_libdir)/samba \
 		--builtin-libraries=NONE
 	)
-	if ! multilib_is_native_abi; then
-		myconf+=( --disable-python )
-	fi
 	waf-utils_src_configure "${myconf[@]}"
 }
 


### PR DESCRIPTION
This adds support for python USE flag to ldb and Samba and makes a minor cleanup in talloc and tevent.

If we are happy with these changes I can apply them to the earlier ebuilds where applicable in the various projects too.

I've also been talking to jra@samba about getting all these python patches upstream to the Samba repository. Discussion here [1]. I'm happy to do some of the legwork if necessary but they do require the original author polynomial-c@ to sign off before they can accept them. See [2]

[1] - https://lists.samba.org/archive/samba-technical/2017-January/117923.html
[2] - https://www.samba.org/samba/devel/copyright-policy.html