### PR TITLE
dev-python/oauth2: add py3.5, fix tests

### DIFF
--- a/dev-python/oauth2/files/1.9.0_p1-exclude-tests.patch
+++ b/dev-python/oauth2/files/1.9.0_p1-exclude-tests.patch
@@ -1,5 +1,5 @@
---- setup.py.bak	2015-09-19 14:03:27.000000000 +0200
-+++ setup.py	2015-09-19 14:03:43.000000000 +0200
+--- a/setup.py
++++ b/setup.py
 @@ -45,7 +45,7 @@
          "Natural Language :: English",
          "License :: OSI Approved :: MIT License"

--- a/dev-python/oauth2/metadata.xml
+++ b/dev-python/oauth2/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="pypi">oauth2</remote-id>
+		<remote-id type="github">joestump/python-oauth2</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/oauth2/oauth2-1.9.0_p1-r1.ebuild
+++ b/dev-python/oauth2/oauth2-1.9.0_p1-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
+
+inherit distutils-r1
+
+MY_P="${P/_p/.post}"
+
+DESCRIPTION="Library for OAuth version 1.0"
+HOMEPAGE="https://pypi.python.org/pypi/oauth2"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${MY_P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~x64-macos"
+IUSE="test"
+
+RDEPEND="dev-python/httplib2[${PYTHON_USEDEP}]"
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? ( ${RDEPEND}
+		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/pytest-runner[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+	)"
+
+# https://github.com/joestump/python-oauth2/pull/212
+PATCHES=( "${FILESDIR}/${PV}-exclude-tests.patch" )
+S="${WORKDIR}/${MY_P}"
+
+python_test() {
+	# Skip tests which require network access
+	py.test -k "not (test_access_token_post or test_access_token_get \
+		or test_two_legged_post or test_two_legged_get)" || die \
+		"tests failed with ${EPYTHON}"
+}


### PR DESCRIPTION
@SoapGentoo I guess it would have been cleaner to do that to PV instead of P buit i didn't touch it: `MY_P="${P/_p/.post}"`
```diff
--- oauth2-1.9.0_p1.ebuild      2016-11-26 14:53:54.187264218 +0100
+++ oauth2-1.9.0_p1-r1.ebuild   2017-01-18 10:58:48.669675407 +0100
@@ -1,10 +1,10 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$

-EAPI=5
+EAPI=6

-PYTHON_COMPAT=( python2_7 python3_4 pypy )
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )

 inherit distutils-r1

@@ -16,20 +16,25 @@

 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 x86 ~x64-macos"
+KEYWORDS="~amd64 ~x86 ~x64-macos"
 IUSE="test"

 RDEPEND="dev-python/httplib2[${PYTHON_USEDEP}]"
 DEPEND="
        dev-python/setuptools[${PYTHON_USEDEP}]
        test? ( ${RDEPEND}
-               dev-python/coverage[${PYTHON_USEDEP}]
                dev-python/mock[${PYTHON_USEDEP}]
+               dev-python/pytest-runner[${PYTHON_USEDEP}]
+               dev-python/pytest[${PYTHON_USEDEP}]
        )"

+# https://github.com/joestump/python-oauth2/pull/212
 PATCHES=( "${FILESDIR}/${PV}-exclude-tests.patch" )
 S="${WORKDIR}/${MY_P}"

 python_test() {
-       esetup.py test
+       # Skip tests which require network access
+       py.test -k "not (test_access_token_post or test_access_token_get \
+               or test_two_legged_post or test_two_legged_get)" || die \
+               "tests failed with ${EPYTHON}"
 }
```