### PR TITLE
media-gfx/gnofract4d: Make building help explicit with a USE flag

### DIFF
--- a/media-gfx/gnofract4d/files/gnofract4d-3.14.1-xsl.patch
+++ b/media-gfx/gnofract4d/files/gnofract4d-3.14.1-xsl.patch
@@ -1,0 +1,13 @@
+diff --git a/doc/gnofract4d-manual/C/gnofract4d.xsl b/doc/gnofract4d-manual/C/gnofract4d.xsl
+index 4b0120d..f6e7f0c 100644
+--- a/doc/gnofract4d-manual/C/gnofract4d.xsl
++++ b/doc/gnofract4d-manual/C/gnofract4d.xsl
+@@ -3,7 +3,7 @@
+ 
+ 
+ <!-- Imports the DocBook HTML chunking stylesheets. --> 
+-<xsl:import href="/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/xhtml/docbook.xsl"/>
++<xsl:import href="/usr/share/sgml/docbook/xsl-stylesheets/xhtml/docbook.xsl"/>
+ <xsl:template match="guimenuitem">
+   <span class="guimenuitem"><xsl:call-template name="inline.charseq"/></span>
+ </xsl:template>

--- a/media-gfx/gnofract4d/gnofract4d-3.14.1-r1.ebuild
+++ b/media-gfx/gnofract4d/gnofract4d-3.14.1-r1.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+DISTUTILS_SINGLE_IMPL=1
+MY_PV=V_${PV//./_}
+
+inherit distutils-r1 fdo-mime
+
+DESCRIPTION="A program for drawing beautiful mathematically-based images known as fractals"
+HOMEPAGE="http://edyoung.github.io/gnofract4d/"
+SRC_URI="https://github.com/edyoung/${PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+help"
+
+RDEPEND="x11-libs/gtk+:2
+	media-libs/libpng:0=
+	virtual/jpeg:0
+	>=dev-python/pygtk-2[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	help? (	app-text/rarian
+		dev-libs/libxslt )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.14-desktop.patch
+	"${FILESDIR}"/${P}-xsl.patch
+)
+
+S="${WORKDIR}"/${PN}-${MY_PV}
+
+python_compile_all() {
+	if use help; then
+		ln -s "${BUILD_DIR}"/lib/fract4d/fract4dc.so fract4d/ || die
+		"${EPYTHON}" createdocs.py || die
+	fi
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+	rm -rf "${ED%/}"/usr/share/doc/${PN} || die
+	if ! use help; then
+		rm -rf "${ED%/}"/usr/share/gnome/help/${PN} || die
+	fi
+}
+
+pkg_postinst() {
+	fdo-mime_desktop_database_update
+	fdo-mime_mime_database_update
+}
+
+pkg_postrm() {
+	fdo-mime_desktop_database_update
+	fdo-mime_mime_database_update
+}

--- a/media-gfx/gnofract4d/metadata.xml
+++ b/media-gfx/gnofract4d/metadata.xml
@@ -6,6 +6,9 @@
 		<name>Gentoo Graphics Project</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="sourceforge">gnofract4d</remote-id>
+		<remote-id type="github">edyoung/gnofract4d</remote-id>
 	</upstream>
+  <use>
+    <flag name="help">Install user help.</flag>
+  </use>
 </pkgmetadata>


### PR DESCRIPTION
Fix creating commands reference for help

-----

createdocs.py needs the binary module fract4dc and the docs and formulas directories. A symlink seems the easiest solution.

Also fixing the path to docbook.xsl for Gentoo and update the upstream remote in metadata.
```
@@ -17,30 +17,37 @@
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="+help"
 
 RDEPEND="x11-libs/gtk+:2
 	media-libs/libpng:0=
 	virtual/jpeg:0
 	>=dev-python/pygtk-2[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
-	virtual/pkgconfig"
+	virtual/pkgconfig
+	help? (	app-text/rarian
+		dev-libs/libxslt )"
 
 PATCHES=(
-	"${FILESDIR}"/gnofract4d-3.14-desktop.patch
-	"${FILESDIR}"/gnofract4d-3.14-manual.patch
+	"${FILESDIR}"/${PN}-3.14-desktop.patch
+	"${FILESDIR}"/${P}-xsl.patch
 )
 
 S="${WORKDIR}"/${PN}-${MY_PV}
 
 python_compile_all() {
-	# Needs fixing to be able to generate commands.xml
-	"${EPYTHON}" createdocs.py || die
+	if use help; then
+		ln -s "${BUILD_DIR}"/lib/fract4d/fract4dc.so fract4d/ || die
+		"${EPYTHON}" createdocs.py || die
+	fi
 }
 
 python_install_all() {
 	distutils-r1_python_install_all
 	rm -rf "${ED%/}"/usr/share/doc/${PN} || die
+	if ! use help; then
+		rm -rf "${ED%/}"/usr/share/gnome/help/${PN} || die
+	fi
 }
 
 pkg_postinst() {
```
