### PR TITLE
dev-python/pycups: add Python 3.5 support, missing dep, EAPI=6

### DIFF
--- a/dev-python/pycups/pycups-1.9.73-r1.ebuild
+++ b/dev-python/pycups/pycups-1.9.73-r1.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
+inherit distutils-r1
+
+DESCRIPTION="Python bindings for the CUPS API"
+HOMEPAGE="http://cyberelk.net/tim/data/pycups/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86"
+SLOT="0"
+IUSE="doc examples"
+
+RDEPEND="
+	net-print/cups
+"
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	${RDEPEND}
+"
+
+# epydoc kinda sucks and supports python2 only (it's dead too),
+# and since we're dealing with a binary module we need exact version
+# match. therefore, docbuilding *requires* any python2 being enabled.
+
+DEPEND="${RDEPEND}
+	doc? ( dev-python/epydoc[$(python_gen_usedep 'python2*')] )
+"
+
+REQUIRED_USE="doc? ( || ( $(python_gen_useflags 'python2*') ) )"
+
+pkg_setup() {
+	use doc && DISTUTILS_ALL_SUBPHASE_IMPLS=( python2.7 )
+}
+
+python_compile() {
+	python_is_python3 || local -x CFLAGS="${CFLAGS} -fno-strict-aliasing"
+	distutils-r1_python_compile
+}
+
+python_compile_all() {
+	if use doc; then
+		# we can't use Makefile since it relies on hardcoded paths
+		epydoc -o html --html cups || die "doc build failed"
+		HTML_DOCS=( html/. )
+	fi
+}
+
+python_install_all() {
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
@SoapGentoo I also re-ordered phases like you taught me :D
```diff
--- pycups-1.9.73.ebuild	2017-01-17 20:30:30.639713494 +0100
+++ pycups-1.9.73-r1.ebuild	2017-01-19 01:04:39.586318386 +0100
@@ -2,9 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4} pypy )
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
 inherit distutils-r1
 
 DESCRIPTION="Python bindings for the CUPS API"
@@ -12,14 +12,17 @@
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~sh sparc x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86"
 SLOT="0"
 IUSE="doc examples"
 
 RDEPEND="
 	net-print/cups
 "
-DEPEND="${RDEPEND}"
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	${RDEPEND}
+"
 
 # epydoc kinda sucks and supports python2 only (it's dead too),
 # and since we're dealing with a binary module we need exact version
@@ -35,21 +38,23 @@
 	use doc && DISTUTILS_ALL_SUBPHASE_IMPLS=( python2.7 )
 }
 
+python_compile() {
+	python_is_python3 || local -x CFLAGS="${CFLAGS} -fno-strict-aliasing"
+	distutils-r1_python_compile
+}
+
 python_compile_all() {
 	if use doc; then
 		# we can't use Makefile since it relies on hardcoded paths
 		epydoc -o html --html cups || die "doc build failed"
+		HTML_DOCS=( html/. )
 	fi
 }
 
-python_compile() {
-	python_is_python3 || local -x CFLAGS="${CFLAGS} -fno-strict-aliasing"
-	distutils-r1_python_compile
-}
-
 python_install_all() {
-	use doc && local HTML_DOCS=( html/ )
-	use examples && local EXAMPLES=( examples/ )
-
+	if use examples; then
+		docompress -x /usr/share/doc/${PF}/examples
+		dodoc -r examples
+	fi
 	distutils-r1_python_install_all
 }

```