### PR TITLE
app-text/qpdf: fix configure so that it works when /bin/sh isn't bash

### DIFF
--- a/app-text/qpdf/qpdf-6.0.0-r1.ebuild
+++ b/app-text/qpdf/qpdf-6.0.0-r1.ebuild
@@ -34,7 +34,7 @@ src_prepare() {
 }
 
 src_configure() {
-	econf \
+	CONFIG_SHELL=/bin/bash econf \
 		$(use_enable static-libs static) \
 		$(use_enable test test-compare-images)
 }


### PR DESCRIPTION
I just added CONFIG_SHELL=/bin/bash, without this configure will fail when /bin/sh isn't bash.