### PR TITLE
sys-libs/argp-standalone: Revbump to build shared

### DIFF
--- a/sys-libs/argp-standalone/argp-standalone-1.3-r2.ebuild
+++ b/sys-libs/argp-standalone/argp-standalone-1.3-r2.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="Standalone argp library for use with uclibc"
+HOMEPAGE="http://www.lysator.liu.se/~nisse/misc/"
+SRC_URI="http://www.lysator.liu.se/~nisse/misc/argp-standalone-1.3.tar.gz"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~m68k ~mips ~ppc ~s390 ~sh ~x86"
+IUSE="static-libs"
+
+DEPEND="!sys-libs/glibc"
+
+PATCHES=(
+	"${FILESDIR}/${P}-throw-in-funcdef.patch"
+	"${FILESDIR}/${P}-shared.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	append-cflags "-fgnu89-inline"
+	econf \
+		$(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+	insinto /usr/include
+	doins argp.h
+}

--- a/sys-libs/argp-standalone/files/argp-standalone-1.3-shared.patch
+++ b/sys-libs/argp-standalone/files/argp-standalone-1.3-shared.patch
@@ -1,0 +1,49 @@
+--- a/Makefile.am	2009-05-28 15:19:50.000000000 +0200
++++ b/Makefile.am	2009-05-28 15:30:57.000000000 +0200
+@@ -21,20 +21,20 @@
+ AUTOMAKE_OPTIONS = foreign
+ SUBDIRS = . testsuite
+ 
+-LIBOBJS = @LIBOBJS@
++LTLIBOBJS = @LTLIBOBJS@
+ 
+-noinst_LIBRARIES = libargp.a
++lib_LTLIBRARIES = libargp.la
+ noinst_PROGRAMS = argp-test
+ noinst_HEADERS = argp.h argp-fmtstream.h argp-namefrob.h # argp-comp.h
+ 
+ EXTRA_DIST = mempcpy.c strchrnul.c strndup.c Versions
+ 
+ # Leaves out argp-fs-xinl.c and argp-xinl.c 
+-libargp_a_SOURCES = argp-ba.c argp-eexst.c argp-fmtstream.c \
++libargp_la_SOURCES = argp-ba.c argp-eexst.c argp-fmtstream.c \
+ 		    argp-help.c argp-parse.c argp-pv.c \
+ 		    argp-pvh.c
+ 
+-libargp_a_LIBADD = $(LIBOBJS)
++libargp_la_LIBADD = $(LTLIBOBJS)
+ 
+-argp_test_LDADD = libargp.a
++argp_test_LDADD = libargp.la
+ 
+--- a/configure.ac	2009-05-28 15:20:01.000000000 +0200
++++ b/configure.ac	2009-05-28 15:21:06.000000000 +0200
+@@ -17,6 +17,7 @@
+ AC_PROG_MAKE_SET
+ AC_PROG_RANLIB
+ AM_PROG_CC_STDC
++AC_PROG_LIBTOOL
+ 
+ if test "x$am_cv_prog_cc_stdc" = xno ; then
+   AC_ERROR([the C compiler doesn't handle ANSI-C])
+--- a/testsuite/Makefile.am	2009-05-28 15:21:33.000000000 +0200
++++ b/testsuite/Makefile.am	2009-05-28 15:21:41.000000000 +0200
+@@ -5,7 +5,7 @@
+ 
+ noinst_PROGRAMS = $(TS_PROGS) ex1 ex3 ex4
+ 
+-LDADD = ../libargp.a
++LDADD = -L../.libs -largp
+ 
+ EXTRA_DIST = $(TS_SH) run-tests
+ CLEANFILES = test.out


### PR DESCRIPTION
The patch is from Debian.

When patching elfutils to work under musl, elfutils refuses to link against a non-PIC library.