### PR TITLE
dev-python/libvirt-python: python 3.5 + some metadata fixes

### DIFF
--- a/dev-python/libvirt-python/libvirt-python-1.3.5.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-1.3.5.ebuild
@@ -17,14 +17,14 @@ if [[ ${PV} = *9999* ]]; then
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
-	SRC_URI="http://libvirt.org/sources/python/${MY_P}.tar.gz"
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
 	KEYWORDS="amd64 x86"
 	RDEPEND="app-emulation/libvirt:0/${PV}"
 fi
 S="${WORKDIR}/${P%_rc*}"
 
 DESCRIPTION="libvirt Python bindings"
-HOMEPAGE="http://www.libvirt.org"
+HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
 IUSE="test"

--- a/dev-python/libvirt-python/libvirt-python-2.0.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-2.0.0.ebuild
@@ -17,14 +17,14 @@ if [[ ${PV} = *9999* ]]; then
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
-	SRC_URI="http://libvirt.org/sources/python/${MY_P}.tar.gz"
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 	RDEPEND="app-emulation/libvirt:0/${PV}"
 fi
 S="${WORKDIR}/${P%_rc*}"
 
 DESCRIPTION="libvirt Python bindings"
-HOMEPAGE="http://www.libvirt.org"
+HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
 IUSE="test"

--- a/dev-python/libvirt-python/libvirt-python-2.1.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-2.1.0.ebuild
@@ -17,14 +17,14 @@ if [[ ${PV} = *9999* ]]; then
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
-	SRC_URI="http://libvirt.org/sources/python/${MY_P}.tar.gz"
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
 	KEYWORDS="amd64 x86"
 	RDEPEND="app-emulation/libvirt:0/${PV}"
 fi
 S="${WORKDIR}/${P%_rc*}"
 
 DESCRIPTION="libvirt Python bindings"
-HOMEPAGE="http://www.libvirt.org"
+HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
 IUSE="test"

--- a/dev-python/libvirt-python/libvirt-python-2.2.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-2.2.0.ebuild
@@ -17,14 +17,14 @@ if [[ ${PV} = *9999* ]]; then
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
-	SRC_URI="http://libvirt.org/sources/python/${MY_P}.tar.gz"
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 	RDEPEND="app-emulation/libvirt:0/${PV}"
 fi
 S="${WORKDIR}/${P%_rc*}"
 
 DESCRIPTION="libvirt Python bindings"
-HOMEPAGE="http://www.libvirt.org"
+HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
 IUSE="test"

--- a/dev-python/libvirt-python/libvirt-python-2.3.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-2.3.0.ebuild
@@ -17,14 +17,14 @@ if [[ ${PV} = *9999* ]]; then
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
-	SRC_URI="http://libvirt.org/sources/python/${MY_P}.tar.gz"
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
 	KEYWORDS="amd64 x86"
 	RDEPEND="app-emulation/libvirt:0/${PV}"
 fi
 S="${WORKDIR}/${P%_rc*}"
 
 DESCRIPTION="libvirt Python bindings"
-HOMEPAGE="http://www.libvirt.org"
+HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
 IUSE="test"

--- a/dev-python/libvirt-python/libvirt-python-2.4.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-2.4.0.ebuild
@@ -17,14 +17,14 @@ if [[ ${PV} = *9999* ]]; then
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
-	SRC_URI="http://libvirt.org/sources/python/${MY_P}.tar.gz"
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 	RDEPEND="app-emulation/libvirt:0/${PV}"
 fi
 S="${WORKDIR}/${P%_rc*}"
 
 DESCRIPTION="libvirt Python bindings"
-HOMEPAGE="http://www.libvirt.org"
+HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
 IUSE="test"

--- a/dev-python/libvirt-python/libvirt-python-2.5.0-r1.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-2.5.0-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+
+MY_P="${P/_rc/-rc}"
+
+inherit eutils distutils-r1
+
+if [[ ${PV} = *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="git://libvirt.org/libvirt-python.git"
+	SRC_URI=""
+	KEYWORDS=""
+	RDEPEND="app-emulation/libvirt:=[-python(-)]"
+else
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+	RDEPEND="app-emulation/libvirt:0/${PV}"
+fi
+S="${WORKDIR}/${P%_rc*}"
+
+DESCRIPTION="libvirt Python bindings"
+HOMEPAGE="https://www.libvirt.org"
+LICENSE="LGPL-2"
+SLOT="0"
+IUSE="examples test"
+
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	test? ( dev-python/lxml[${PYTHON_USEDEP}]
+		dev-python/nose[${PYTHON_USEDEP}] )"
+
+python_test() {
+	esetup.py test
+}
+
+python_install_all() {
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+	distutils-r1_python_install_all
+}

--- a/dev-python/libvirt-python/libvirt-python-2.5.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-2.5.0.ebuild
@@ -17,14 +17,14 @@ if [[ ${PV} = *9999* ]]; then
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
-	SRC_URI="http://libvirt.org/sources/python/${MY_P}.tar.gz"
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 	RDEPEND="app-emulation/libvirt:0/${PV}"
 fi
 S="${WORKDIR}/${P%_rc*}"
 
 DESCRIPTION="libvirt Python bindings"
-HOMEPAGE="http://www.libvirt.org"
+HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
 IUSE="test"

--- a/dev-python/libvirt-python/libvirt-python-9999.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-9999.ebuild
@@ -17,14 +17,14 @@ if [[ ${PV} = *9999* ]]; then
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
-	SRC_URI="http://libvirt.org/sources/python/${MY_P}.tar.gz"
+	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 	RDEPEND="app-emulation/libvirt:0/${PV}"
 fi
 S="${WORKDIR}/${P%_rc*}"
 
 DESCRIPTION="libvirt Python bindings"
-HOMEPAGE="http://www.libvirt.org"
+HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
 IUSE="test"

--- a/dev-python/libvirt-python/libvirt-python-9999.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-9999.ebuild
@@ -2,9 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 
 MY_P="${P/_rc/-rc}"
 
@@ -27,7 +27,7 @@ DESCRIPTION="libvirt Python bindings"
 HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
-IUSE="test"
+IUSE="examples test"
 
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
@@ -36,4 +36,12 @@ DEPEND="${RDEPEND}
 
 python_test() {
 	esetup.py test
+}
+
+python_install_all() {
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+	distutils-r1_python_install_all
 }

--- a/dev-python/libvirt-python/metadata.xml
+++ b/dev-python/libvirt-python/metadata.xml
@@ -9,4 +9,8 @@
 		<email>virtualization@gentoo.org</email>
 		<name>Gentoo Virtualization Project</name>
 	</maintainer>
-	</pkgmetadata>
+	<upstream>
+		<remote-id type="github">libvirt/libvirt-python</remote-id>
+		<remote-id type="pypi">libvirt-python</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
@tamiko tests pass for 3.5
```diff
--- libvirt-python-2.5.0.ebuild 2017-01-19 23:14:13.950754685 +0100
+++ libvirt-python-2.5.0-r1.ebuild      2017-01-19 23:36:32.357209535 +0100
@@ -2,9 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$

-EAPI=5
+EAPI=6

-PYTHON_COMPAT=( python{2_7,3_4} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )

 MY_P="${P/_rc/-rc}"

@@ -27,16 +27,21 @@
 HOMEPAGE="https://www.libvirt.org"
 LICENSE="LGPL-2"
 SLOT="0"
-IUSE="test"
+IUSE="examples test"

 DEPEND="${RDEPEND}
        virtual/pkgconfig
        test? ( dev-python/lxml[${PYTHON_USEDEP}]
                dev-python/nose[${PYTHON_USEDEP}] )"

-# testsuite is currently not included in upstream tarball
-RESTRICT="test"
-
 python_test() {
        esetup.py test
 }
+
+python_install_all() {
+       if use examples; then
+               dodoc -r examples
+               docompress -x /usr/share/doc/${PF}/examples
+       fi
+       distutils-r1_python_install_all
+}
```