### PR TITLE
net-libs/nghttp2: add missing dependency with USE="utils"

### DIFF
--- a/net-libs/nghttp2/nghttp2-1.18.1.ebuild
+++ b/net-libs/nghttp2/nghttp2-1.18.1.ebuild
@@ -32,6 +32,7 @@ RDEPEND="
 		!libressl? ( >=dev-libs/openssl-1.0.2:0[-bindist,${MULTILIB_USEDEP}] )
 		libressl? ( dev-libs/libressl[${MULTILIB_USEDEP}] )
 		>=sys-libs/zlib-1.2.3[${MULTILIB_USEDEP}]
+		net-dns/c-ares:=[${MULTILIB_USEDEP}]
 	)
 	xml? ( >=dev-libs/libxml2-2.7.7:2[${MULTILIB_USEDEP}] )"
 DEPEND="${RDEPEND}

--- a/net-libs/nghttp2/nghttp2-9999.ebuild
+++ b/net-libs/nghttp2/nghttp2-9999.ebuild
@@ -32,6 +32,7 @@ RDEPEND="
 		!libressl? ( >=dev-libs/openssl-1.0.2:0[-bindist,${MULTILIB_USEDEP}] )
 		libressl? ( dev-libs/libressl[${MULTILIB_USEDEP}] )
 		>=sys-libs/zlib-1.2.3[${MULTILIB_USEDEP}]
+		net-dns/c-ares:=[${MULTILIB_USEDEP}]
 	)
 	xml? ( >=dev-libs/libxml2-2.7.7:2[${MULTILIB_USEDEP}] )"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
net-libs/nghttp2 needs net-dns/c-ares when built with the "utils" USE
flag - add the missing dependency for both the latest 1.18.1 ebuild and
the -9999 ebuild

Signed-off-by: James Ausmus <james.ausmus@gmail.com>