### PR TITLE
dev-libs/sway: do not set LD_LIBRARY_PATH

### DIFF
--- a/dev-libs/sway/sway-9999.ebuild
+++ b/dev-libs/sway/sway-9999.ebuild
@@ -53,7 +53,6 @@ src_configure() {
 		-Dzsh-completions=$(usex zsh-completion)
 
 		-DCMAKE_INSTALL_SYSCONFDIR="/etc"
-		-DLD_LIBRARY_PATH="${EPREFIX}/usr/lib"
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
follows an upstream change (prior behavior could cause issues when
crosscompiling)

See https://github.com/SirCmpwn/sway/commit/138bcd0cfae78ced64b98274adf6531d3161d828