### PR TITLE
dev-python/docker-py: add py3.5, fix docs, deps, bump to EAPI=6

### DIFF
--- a/dev-python/docker-py/docker-py-2.0.1.ebuild
+++ b/dev-python/docker-py/docker-py-2.0.1.ebuild
@@ -2,10 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4} )
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 
-inherit distutils-r1 vcs-snapshot
+inherit distutils-r1
 
 DESCRIPTION="Python client for Docker"
 HOMEPAGE="https://github.com/docker/docker-py"
@@ -14,20 +14,7 @@ SRC_URI="https://github.com/docker/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="test" # doc
-
-DEPEND="
-	dev-python/setuptools[${PYTHON_USEDEP}]
-	test? (
-		>=dev-python/mock-1.0.1[${PYTHON_USEDEP}]
-		>=dev-python/pytest-2.9.1[${PYTHON_USEDEP}]
-		>=dev-python/pytest-cov-2.1.0[${PYTHON_USEDEP}]
-		>=dev-python/coverage-3.7.1[${PYTHON_USEDEP}]
-	)
-"
-# Doc require later sphinx version that is not packaged yet
-# doc? ( dev-python/recommonmark[${PYTHON_USEDEP}]
-#	        >=dev-python/sphinx-1.4.6[${PYTHON_USEDEP}] )
+IUSE="doc test"
 
 RDEPEND="
 	>=dev-python/docker-pycreds-0.2.1[${PYTHON_USEDEP}]
@@ -38,19 +25,27 @@ RDEPEND="
 	$(python_gen_cond_dep '>=dev-python/backports-ssl-match-hostname-3.5[${PYTHON_USEDEP}]' 'python2_7' 'python3_4' )
 	$(python_gen_cond_dep '>=dev-python/ipaddress-1.0.16[${PYTHON_USEDEP}]' 'python2_7' )
 "
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? (
+		${RDEPEND}
+		>=dev-python/mock-1.0.1[${PYTHON_USEDEP}]
+		dev-python/pytest-runner[${PYTHON_USEDEP}]
+		>=dev-python/pytest-2.9.1[${PYTHON_USEDEP}]
+	)
+	doc? (
+		dev-python/recommonmark[${PYTHON_USEDEP}]
+		>=dev-python/sphinx-1.4.6[${PYTHON_USEDEP}]
+	)
+"
 
-#python_compile_all() {
-	#if use doc; then
-	#	sphinx-build docs html || die "docs failed to build"
-	#fi
-#}
+python_compile_all() {
+	if use doc; then
+		sphinx-build docs html || die "docs failed to build"
+		HTML_DOCS=( html/. )
+	fi
+}
 
 python_test() {
 	py.test tests/unit/ || die "tests failed under ${EPYTHON}"
-}
-
-python_install_all() {
-	#use doc && local HTML_DOCS=( html/. )
-
-	distutils-r1_python_install_all
 }

--- a/dev-python/docker-py/metadata.xml
+++ b/dev-python/docker-py/metadata.xml
@@ -11,5 +11,6 @@
   </maintainer>
   <upstream>
     <remote-id type="github">docker/docker-py</remote-id>
+    <bugs-to>https://github.com/docker/docker-py/issues</bugs-to>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
The coverage-related packages are not required to run the unit tests.

@SoapGentoo 