### PR TITLE
dev-cpp/antlr-cpp: fix configure so that it works when /bin/sh isn't …

### DIFF
--- a/dev-cpp/antlr-cpp/antlr-cpp-2.7.7-r1.ebuild
+++ b/dev-cpp/antlr-cpp/antlr-cpp-2.7.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -67,7 +67,7 @@ EOF
 }
 
 multilib_src_configure() {
-	econf \
+	CONFIG_SHELL="/bin/bash" econf \
 		--disable-csharp \
 		--enable-cxx \
 		--disable-examples \

--- a/dev-cpp/antlr-cpp/antlr-cpp-3.5.2-r1.ebuild
+++ b/dev-cpp/antlr-cpp/antlr-cpp-3.5.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 EAPI=6


### PR DESCRIPTION
…bash

I just added CONFIG_SHELL=/bin/bash, without this configure will fail when /bin/sh isn't bash.
This isn't needed for antlr-cpp-3.5.2-r1.