### PR TITLE
dev-ruby/ffi: Use $(get_modname) instead of .so

### DIFF
--- a/dev-ruby/ffi/ffi-1.9.17.ebuild
+++ b/dev-ruby/ffi/ffi-1.9.17.ebuild
@@ -46,7 +46,7 @@ each_ruby_configure() {
 
 each_ruby_compile() {
 	emake -Cext/ffi_c V=1
-	cp ext/ffi_c/ffi_c.so lib/ || die
+	cp ext/ffi_c/ffi_c$(get_modname) lib/ || die
 
 	${RUBY} -S rake -f gen/Rakefile || die "types.conf generation failed"
 }


### PR DESCRIPTION
Required on prefix for macOS, where the extension is .bundle.

Package-Manager: Portage-2.3.3, Repoman-2.3.1