### PR TITLE
dev-python/snappy: add py3.5, EAPI=6, fix deps

### DIFF
--- a/dev-python/snappy/metadata.xml
+++ b/dev-python/snappy/metadata.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>python@gentoo.org</email>
-    <name>Python</name>
-  </maintainer>
-  <upstream>
-    <remote-id type="pypi">python-snappy</remote-id>
-  </upstream>
+	<maintainer type="project">
+		<email>python@gentoo.org</email>
+		<name>Python</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="pypi">python-snappy</remote-id>
+		<remote-id type="github">andrix/python-snappy</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/snappy/snappy-0.5-r3.ebuild
+++ b/dev-python/snappy/snappy-0.5-r3.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+
+inherit distutils-r1
+
+MY_PN=python-${PN}
+MY_P=${MY_PN}-${PV}
+
+DESCRIPTION="Python library for the snappy compression library from Google"
+HOMEPAGE="https://pypi.python.org/pypi/python-snappy"
+SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
+
+LICENSE="BSD"
+KEYWORDS="~amd64 ~arm ~x86"
+SLOT="0"
+
+RDEPEND=">=app-arch/snappy-1.0.2"
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	${RDEPEND}
+"
+
+S=${WORKDIR}/${MY_P}
+
+python_test() {
+	"${EPYTHON}" test_snappy.py -v || die "Tests fail with ${EPYTHON}"
+}


### PR DESCRIPTION
@SoapGentoo 
```diff
--- snappy-0.5-r2.ebuild        2016-11-02 00:24:50.417109883 +0100
+++ snappy-0.5-r3.ebuild        2017-01-20 22:33:30.491904088 +0100
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$

-EAPI=5
+EAPI=6

-PYTHON_COMPAT=( python2_7 python3_4 )
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )

 inherit distutils-r1

@@ -16,14 +16,17 @@
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"

 LICENSE="BSD"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="~amd64 ~arm ~x86"
 SLOT="0"

-DEPEND=">=app-arch/snappy-1.0.2"
-RDEPEND="${DEPEND}"
+RDEPEND=">=app-arch/snappy-1.0.2"
+DEPEND="
+       dev-python/setuptools[${PYTHON_USEDEP}]
+       ${RDEPEND}
+"

 S=${WORKDIR}/${MY_P}

 python_test() {
-       "${PYTHON}" test_snappy.py -v || die "Tests fail with ${EPYTHON}"
+       "${EPYTHON}" test_snappy.py -v || die "Tests fail with ${EPYTHON}"
 }

```