### PR TITLE
dev-python/geoip-python: add py3.5, fix CFLAGS, EAPI=6

### DIFF
--- a/dev-python/geoip-python/geoip-python-1.3.2-r1.ebuild
+++ b/dev-python/geoip-python/geoip-python-1.3.2-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy pypy3 )
+
+inherit distutils-r1
+
+MY_PN="geoip-api-python"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="Python bindings for GeoIP"
+HOMEPAGE="https://github.com/maxmind/geoip-api-python"
+SRC_URI="https://github.com/maxmind/${MY_PN}/archive/v${PV}.tar.gz -> ${MY_P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86 ~x86-fbsd"
+IUSE="examples test"
+
+RDEPEND=">=dev-libs/geoip-1.4.8"
+DEPEND="
+	${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? ( dev-python/nose[${PYTHON_USEDEP}] )
+"
+
+S="${WORKDIR}/${MY_P}"
+
+DOCS=( README.rst ChangeLog.md )
+
+python_test() {
+	esetup.py test
+}
+
+python_install_all() {
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+	distutils-r1_python_install_all
+}

--- a/dev-python/geoip-python/metadata.xml
+++ b/dev-python/geoip-python/metadata.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>python@gentoo.org</email>
-    <name>Python</name>
-  </maintainer>
-  <upstream>
-    <remote-id type="github">maxmind/geoip-api-python</remote-id>
-  </upstream>
+	<maintainer type="project">
+		<email>python@gentoo.org</email>
+		<name>Python</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">maxmind/geoip-api-python</remote-id>
+		<remote-id type="pypi">GeoIP</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
The -fno-strict-aliasing flag is correctly set by the build system
for Python 2 only.

@SoapGentoo 
```diff
--- geoip-python-1.3.2.ebuild	2017-01-20 23:08:26.381220626 +0100
+++ geoip-python-1.3.2-r1.ebuild	2017-01-20 23:04:23.660141695 +0100
@@ -1,9 +1,9 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4} pypy pypy3 )
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy pypy3 )
 
 inherit distutils-r1
 
@@ -16,29 +16,28 @@
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~ia64 ppc ~sparc x86 ~x86-fbsd"
+KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86 ~x86-fbsd"
 IUSE="examples test"
 
 RDEPEND=">=dev-libs/geoip-1.4.8"
-DEPEND="${RDEPEND}
-	test? ( dev-python/nose[${PYTHON_USEDEP}] )"
+DEPEND="
+	${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? ( dev-python/nose[${PYTHON_USEDEP}] )
+"
 
 S="${WORKDIR}/${MY_P}"
 
 DOCS=( README.rst ChangeLog.md )
 
-python_compile() {
-	if [[ python_is_python3 || "$EPYTHON}" == 'pypy3' ]]; then
-		local -x CFLAGS="${CFLAGS} -fno-strict-aliasing"
-	fi
-	distutils-r1_python_compile
-}
-
 python_test() {
 	esetup.py test
 }
 
 python_install_all() {
-	use examples && local EXAMPLES=( examples/. )
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
 	distutils-r1_python_install_all
 }

```