### PR TITLE
app-crypt/libu2f-server: Add libressl USE flag

### DIFF
--- a/app-crypt/libu2f-server/libu2f-server-1.0.1.ebuild
+++ b/app-crypt/libu2f-server/libu2f-server-1.0.1.ebuild
@@ -13,10 +13,11 @@ SRC_URI="https://developers.yubico.com/${PN}/Releases/${P}.tar.xz"
 LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="static-libs test"
+IUSE="libressl static-libs test"
 
 RDEPEND="
-	dev-libs/openssl:0=[${MULTILIB_USEDEP}]
+	!libressl? ( dev-libs/openssl:0=[${MULTILIB_USEDEP}] )
+	libressl? ( dev-libs/libressl:=[${MULTILIB_USEDEP}] )
 	dev-libs/hidapi[${MULTILIB_USEDEP}]
 	dev-libs/json-c[${MULTILIB_USEDEP}]
 "


### PR DESCRIPTION
In my tests, libu2f-server has worked fine with libressl; no patches are
necessary.