### PR TITLE
app-i18n/enca: use common notation in string comparisons in 1.19-r1

### DIFF
--- a/app-i18n/enca/enca-1.19-r1.ebuild
+++ b/app-i18n/enca/enca-1.19-r1.ebuild
@@ -41,7 +41,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	# Workaround GCC-4.8 brokenness. See Gentoo bug 501386.
-	if tc-is-gcc && [[ $(gcc-version) = '4.8' ]]; then
+	if tc-is-gcc && [[ $(gcc-version) == "4.8" ]]; then
 		replace-flags -O[3-9] -O2
 	fi
 


### PR DESCRIPTION
Prevents me from trying to remember why it wasn't done the usual way.
The reason is still unknown, because this is a ditto change:
https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html

Package-Manager: Portage-2.3.3, Repoman-2.3.1