### PR TITLE
app-text/a2ps: Add patch for CVE-2001-1593 (bug #507024)

### DIFF
--- a/app-text/a2ps/a2ps-4.14-r6.ebuild
+++ b/app-text/a2ps/a2ps-4.14-r6.ebuild
@@ -1,0 +1,143 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit autotools elisp-common flag-o-matic
+
+DESCRIPTION="Any to PostScript filter"
+HOMEPAGE="https://www.gnu.org/software/a2ps/"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz
+	linguas_ja? ( mirror://gentoo/${P}-ja_nls.patch.gz )"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+IUSE="emacs latex linguas_ja nls static-libs userland_BSD userland_GNU vanilla"
+
+RESTRICT=test
+
+RDEPEND="app-text/ghostscript-gpl
+	app-text/libpaper
+	>=app-text/psutils-1.17
+	app-text/wdiff
+	emacs? ( virtual/emacs )
+	latex? ( virtual/latex-base )
+	nls? ( virtual/libintl )
+	userland_GNU? ( >=sys-apps/coreutils-6.10-r1 )
+	userland_BSD? ( sys-freebsd/freebsd-ubin )"
+DEPEND="${RDEPEND}
+	>=dev-util/gperf-2.7.2
+	virtual/yacc
+	nls? ( sys-devel/gettext )"
+
+SITEFILE=50${PN}-gentoo.el
+
+S=${WORKDIR}/${PN}-${PV:0:4}
+
+src_prepare() {
+	default
+
+	eapply "${FILESDIR}"/${PN}-4.13c-locale-gentoo.diff
+	use vanilla || eapply -p0 "${FILESDIR}"/${PN}-4.13-stdout.diff
+	if use linguas_ja; then
+		eapply "${WORKDIR}"/${P}-ja_nls.patch
+		# bug #335803
+		eapply -p0 "${FILESDIR}"/${P}-ja-cleanup.patch
+	else
+		eapply "${FILESDIR}"/${P}-cleanup.patch
+	fi
+
+	# fix fnmatch replacement, bug #134546
+	eapply "${FILESDIR}"/${PN}-4.13c-fnmatch-replacement.patch
+
+	# bug #122026
+	eapply "${FILESDIR}"/${P}-psset.patch
+
+	# fix emacs printing, bug #114627
+	eapply "${FILESDIR}"/a2ps-4.13c-emacs.patch
+
+	# fix chmod error, #167670
+	eapply "${FILESDIR}"/a2ps-4.13-manpage-chmod.patch
+
+	# add configure check for mempcpy, bug 216588
+	eapply "${FILESDIR}"/${P}-check-mempcpy.patch
+
+	# fix compilation error due to invalid stpcpy() prototype, bug 216588
+	eapply -p0 "${FILESDIR}"/${P}-fix-stpcpy-proto.patch
+
+	# fix compilation error due to obstack.h issue, bug 269638
+	eapply "${FILESDIR}"/${P}-ptrdiff_t.patch
+
+	# fix compilation error due to texinfo 5.x, bug 482748
+	eapply "${FILESDIR}"/${P}-texinfo-5.x.patch
+
+	# fix CVE-2014-0466, bug 506352
+	eapply "${FILESDIR}"/${P}-CVE-2014-0466.patch
+
+	# fix CVE-2001-1593, bug 507024
+	eapply "${FILESDIR}"/${P}-CVE-2001-1593.patch
+
+	# fix building with sys-devel/automake >= 1.12, bug 420503
+	rm -f {.,ogonkify}/aclocal.m4 || die
+	sed -i \
+		-e '/^AM_C_PROTOTYPES/d' \
+		-e '/^AUTOMAKE_OPTIONS.*ansi2knr/d' \
+		-e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' \
+		-e 's:AM_PROG_CC_STDC:AC_PROG_CC:' \
+		configure.in {contrib/sample,lib,src}/Makefile.am m4/protos.m4 || die
+
+	eautoreconf
+}
+
+src_configure() {
+	append-cppflags -DPROTOTYPES #420503
+
+	local myconf="COM_netscape=no COM_acroread=no"
+
+	use emacs || myconf="${myconf} EMACS=no"
+	use latex || myconf="${myconf} COM_latex=no"
+
+	export LANG=C LC_ALL=C
+
+	econf \
+		--enable-shared \
+		$(use_enable static-libs static) \
+		--sysconfdir="${EPREFIX}"/etc/a2ps \
+		$(use_enable nls) \
+		${myconf}
+}
+
+src_compile() {
+	# parallel make b0rked
+	emake -j1
+}
+
+src_install() {
+	emake \
+		DESTDIR="${D}" \
+		lispdir="${EPREFIX}${SITELISP}"/${PN} \
+		install
+
+	newdoc "${ED}"/usr/share/a2ps/README README.a2ps
+	newdoc "${ED}"/usr/share/a2ps/ppd/README README.a2ps.ppd
+	newdoc "${ED}"/usr/share/ogonkify/README README.ogonkify
+
+	rm -f "${ED}"/usr/share/{a2ps,a2ps/ppd,ogonkify}/README || die
+
+	prune_libtool_files
+
+	if use emacs; then
+		elisp-site-file-install "${FILESDIR}"/${SITEFILE} || die
+	fi
+
+	dodoc ANNOUNCE AUTHORS ChangeLog FAQ NEWS README* THANKS TODO
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/app-text/a2ps/files/a2ps-4.14-CVE-2001-1593.patch
+++ b/app-text/a2ps/files/a2ps-4.14-CVE-2001-1593.patch
@@ -1,0 +1,82 @@
+CVE-2001-1593: Fix insecure use of /tmp
+
+
+Author(s):
+
+ * Fri Jan 05 2001 Preston Brown <pbrown@redhat.com>
+
+followed the next month by a fix to that patch:
+
+ * Mon Feb 12 2001 Tim Waugh <twaugh@redhat.com>
+
+(see https://bugzilla.redhat.com/show_bug.cgi?id=1060630#c5)
+
+Origin:
+
+http://pkgs.fedoraproject.org/cgit/a2ps.git/plain/a2ps-4.13-security.patch
+
+--- a/lib/routines.c
++++ b/lib/routines.c
+@@ -242,3 +242,50 @@
+   /* Don't complain if you can't unlink.  Who cares of a tmp file? */
+   unlink (filename);
+ }
++
++/*
++ * Securely generate a temp file, and make sure it gets
++ * deleted upon exit.
++ */
++static char **	tempfiles;
++static unsigned	ntempfiles;
++
++static void
++cleanup_tempfiles()
++{
++	while (ntempfiles--)
++		unlink(tempfiles[ntempfiles]);
++}
++
++char *
++safe_tempnam(const char *pfx)
++{
++	char	*dirname, *filename;
++	int	fd;
++
++	if (!(dirname = getenv("TMPDIR")))
++		dirname = "/tmp";
++
++	tempfiles = (char **) realloc(tempfiles,
++			(ntempfiles+1) * sizeof(char *));
++	if (tempfiles == NULL)
++		return NULL;
++
++	filename = malloc(strlen(dirname) + strlen(pfx) + sizeof("/XXXXXX"));
++	if (!filename)
++		return NULL;
++
++	sprintf(filename, "%s/%sXXXXXX", dirname, pfx);
++
++	if ((fd = mkstemp(filename)) < 0) {
++		free(filename);
++		return NULL;
++	}
++	close(fd);
++
++	if (ntempfiles == 0)
++		atexit(cleanup_tempfiles);
++	tempfiles[ntempfiles++] = filename;
++
++	return filename;
++}
+--- a/lib/routines.h
++++ b/lib/routines.h
+@@ -255,7 +255,8 @@
+ /* If _STR_ is not defined, give it a tempname in _TMPDIR_ */
+ #define tempname_ensure(Str)				\
+ do {							\
+-  (Str) = (Str) ? (Str) : tempnam (NULL, "a2_");	\
++  (Str) = (Str) ? (Str) : safe_tempnam("a2_");	\
+ } while (0)
++char * safe_tempnam(const char *);
+ 
+ #endif


### PR DESCRIPTION
Upstream received no updates since 2007 so let's add Fedora's patch (Debian is carrying the same patch) to get rid of the vulnerability.