### PR TITLE
x11-base/xorg-server: Add missing dependencies, #600192

### DIFF
--- a/x11-base/xorg-server/xorg-server-1.19.0.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.19.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -75,6 +75,7 @@ CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	wayland? (
 		>=dev-libs/wayland-1.3.0
 		media-libs/libepoxy
+		>=dev-libs/wayland-protocols-1.1
 	)
 	>=x11-apps/xinit-1.3.3-r1
 	systemd? (

--- a/x11-base/xorg-server/xorg-server-1.19.1.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.19.1.ebuild
@@ -75,6 +75,7 @@ CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	wayland? (
 		>=dev-libs/wayland-1.3.0
 		media-libs/libepoxy
+		>=dev-libs/wayland-protocols-1.1
 	)
 	>=x11-apps/xinit-1.3.3-r1
 	systemd? (

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -75,6 +75,7 @@ CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	wayland? (
 		>=dev-libs/wayland-1.3.0
 		media-libs/libepoxy
+		>=dev-libs/wayland-protocols-1.1
 	)
 	>=x11-apps/xinit-1.3.3-r1
 	systemd? (


### PR DESCRIPTION
See https://cgit.freedesktop.org/xorg/xserver/tree/configure.ac?h=server-1.19-branch&id=ad2facda30f453d749492c51d29f2626aee6326a#n2502
Gentoo bug: https://bugs.gentoo.org/600192

Package-Manager: Portage-2.3.3, Repoman-2.3.1

@gentoo/x11