### PR TITLE
dev-libs/boost: Build Boost.Fiber only on amd64 and x86

### DIFF
--- a/dev-libs/boost/boost-1.62.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.62.0-r1.ebuild
@@ -186,6 +186,7 @@ src_configure() {
 			--without-context
 			--without-coroutine
 			--without-coroutine2
+			--without-fiber
 		)
 	use threads || OPTIONS+=(
 			--without-thread

--- a/dev-libs/boost/boost-1.63.0.ebuild
+++ b/dev-libs/boost/boost-1.63.0.ebuild
@@ -182,6 +182,7 @@ src_configure() {
 			--without-context
 			--without-coroutine
 			--without-coroutine2
+			--without-fiber
 		)
 	use threads || OPTIONS+=(
 			--without-thread

--- a/dev-libs/boost/metadata.xml
+++ b/dev-libs/boost/metadata.xml
@@ -9,39 +9,14 @@
 		<email>office@gentoo.org</email>
 		<description>Please CC on stabilisation bugs</description>
 	</maintainer>
-
 	<use>
-		<flag name="context">
-      Build and install the Boost.Context library and all other 
-      Boost libraries that depend on it
-    </flag>
-		<flag name="tools">
-      Build and install the boost tools (bcp, quickbook, inspect,
-      wave)
-    </flag>
-		<flag name="debug" restrict="&lt;dev-libs/boost-1.50.0-r3">
-      Build and install debug versions of the Boost libraries. These
-      libraries are not used by default, and should not be used unless
-      you're developing against Boost.
-    </flag>
-		<flag name="debug" restrict="&gt;dev-libs/boost-1.52.0-r2">
-      Build and install only the debug version of the Boost
-      libraries. Only enable this flag if you're developing against
-      boost.
-    </flag>
-		<flag name="threads">
-      Build multi-thread-compatible libraries instead of
-      single-threaded only.
-    </flag>
-		<flag name="nls">
-      Build libboost_locale. This library requires compatible C
-      library interfaces, which might not be provided by uClibc or
-      other embedded libraries.
-    </flag>
-		<flag name="doc">
-      Install the full API documentation documentation. This takes
-      over 200MB of extra disk space.
-    </flag>
+		<flag name="context">Build and install the Boost.Context (and Boost.Fiber) library and all other Boost libraries that depend on it</flag>
+		<flag name="tools">Build and install the boost tools (bcp, quickbook, inspect, wave)</flag>
+		<flag name="debug" restrict="&lt;dev-libs/boost-1.50.0-r3">Build and install debug versions of the Boost libraries. These libraries are not used by default, and should not be used unless you're developing against Boost.</flag>
+		<flag name="debug" restrict="&gt;dev-libs/boost-1.52.0-r2">Build and install only the debug version of the Boost libraries. Only enable this flag if you're developing against boost.</flag>
+		<flag name="threads">Build multi-thread-compatible libraries instead of single-threaded only.</flag>
+		<flag name="nls">Build libboost_locale. This library requires compatible C library interfaces, which might not be provided by uClibc or other embedded libraries.</flag>
+		<flag name="doc">Install the full API documentation documentation. This takes over 200MB of extra disk space.</flag>
 	</use>
 	<upstream>
 		<remote-id type="sourceforge">boost</remote-id>


### PR DESCRIPTION
Gentoo-bug: 605538

Package-Manager: Portage-2.3.3, Repoman-2.3.1