### PR TITLE
net-analyzer/nmap: Remove redundant 'lua' USE desc from metadata.xml

### DIFF
--- a/net-analyzer/nmap/metadata.xml
+++ b/net-analyzer/nmap/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="system-lua">Use <pkg>dev-lang/lua</pkg> instead of the bundled liblua</flag>
-		<flag name="lua">Include support for the Nmap Scripting Engine (NSE)</flag>
 		<flag name="ncat">Install the ncat utility</flag>
 		<flag name="ndiff">Install the ndiff utility</flag>
 		<flag name="nmap-update">Install nmap-update, which uses <pkg>dev-vcs/subversion</pkg> to update nmap scripts in your home directory</flag>


### PR DESCRIPTION
Commit 69de1ee4995efdb9e0e5561a42565a0fb8051dfa removed the last nmap
version that employed USE="lua", and excess entries in metadata.xml are
now fatal QA errors.

Package-Manager: Portage-2.3.3, Repoman-2.3.1