### PR TITLE
sys-apps/kbd: Add app-arch/gzip to RDEPEND (#606862)

### DIFF
--- a/sys-apps/kbd/kbd-2.0.3.ebuild
+++ b/sys-apps/kbd/kbd-2.0.3.ebuild
@@ -23,7 +23,8 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="nls pam test"
 
-RDEPEND="pam? ( virtual/pam )"
+RDEPEND="pam? ( virtual/pam )
+	app-arch/gzip"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	test? ( dev-libs/check )"

--- a/sys-apps/kbd/kbd-2.0.4.ebuild
+++ b/sys-apps/kbd/kbd-2.0.4.ebuild
@@ -23,7 +23,8 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="nls pam test"
 
-RDEPEND="pam? ( virtual/pam )"
+RDEPEND="pam? ( virtual/pam )
+	app-arch/gzip"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	test? ( dev-libs/check )"


### PR DESCRIPTION
Prevents errors on embedded profile or during bootstrap:
sh: gzip: command not found

Package-Manager: portage-2.3.1
X-Gentoo-Bug: 606862