### PR TITLE
kde-frameworks/kpackage: Don't run test suite in parallel #606942

### DIFF
--- a/kde-frameworks/kpackage/kpackage-5.29.1.ebuild
+++ b/kde-frameworks/kpackage/kpackage-5.29.1.ebuild
@@ -28,3 +28,12 @@ src_configure() {
 
 	kde5_src_configure
 }
+
+src_test() {
+	# tests cannot be run in parallel #606942
+	local myctestargs=(
+		-j1
+	)
+
+	kde5_src_test
+}


### PR DESCRIPTION
Package-Manager: portage-2.3.1