### PR TITLE
mail-mta/postfix: additional systemd hardening

### DIFF
--- a/mail-mta/postfix/files/postfix.service
+++ b/mail-mta/postfix/files/postfix.service
@@ -14,6 +14,12 @@ PrivateDevices=yes
 ProtectSystem=full
 CapabilityBoundingSet=~ CAP_NET_ADMIN CAP_SYS_ADMIN CAP_SYS_BOOT CAP_SYS_MODULE
 MemoryDenyWriteExecute=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Other distributions are doing the same thing, and these additions are recommended by systemd. See https://lwn.net/Articles/709755/