### PR TITLE
app-doc/zeal: revbump with equal slot added to dev-qt/qtcore dep to t…

### DIFF
--- a/app-doc/zeal/zeal-0.3.1-r1.ebuild
+++ b/app-doc/zeal/zeal-0.3.1-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit qmake-utils gnome2-utils fdo-mime
+
+DESCRIPTION="Offline documentation browser inspired by Dash"
+HOMEPAGE="https://zealdocs.org/"
+SRC_URI="https://github.com/zealdocs/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	app-arch/libarchive
+	dev-qt/qtcore:5=
+	dev-qt/qtconcurrent:5
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtsql:5[sqlite]
+	dev-qt/qtwebkit:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+	>=x11-libs/xcb-util-keysyms-0.3.9
+"
+
+RDEPEND="
+	${DEPEND}
+	x11-themes/hicolor-icon-theme
+"
+
+src_configure() {
+	eqmake5 PREFIX="${EPREFIX}/usr"
+}
+
+src_install() {
+	emake INSTALL_ROOT="${D}" PREFIX="${EPREFIX}/usr" install
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	fdo-mime_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	fdo-mime_desktop_database_update
+}


### PR DESCRIPTION
…rigger rebuild automatically when qt slot changes

to fix the `zeal: /usr/lib64/libQt5Core.so.5: version 'Qt_5.7' not found (required by zeal)`