### PR TITLE
profiles: Mask x11-drivers/ati-drivers for removal.

### DIFF
--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -149,7 +149,7 @@ app-editors/gvim -luajit -racket
 
 # Kacper Kowalik <xarthisius@gentoo.org> (09 Aug 2013)
 # Works on amd64
-sys-apps/hwloc -cuda -gl -opencl
+sys-apps/hwloc -cuda -gl
 
 # Michał Górny <mgorny@gentoo.org> (22 Jul 2013)
 # Meaningless on amd64 (it controls the 32-bit x86 JIT).

--- a/profiles/arch/amd64/use.mask
+++ b/profiles/arch/amd64/use.mask
@@ -116,7 +116,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_via
 -video_cards_virtualbox
 -video_cards_vmware

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -139,7 +139,7 @@ app-editors/gvim -luajit -racket
 
 # Kacper Kowalik <xarthisius@gentoo.org> (09 Aug 2013)
 # Works on x86
-sys-apps/hwloc -cuda -gl -opencl
+sys-apps/hwloc -cuda -gl
 
 # Pacho Ramos <pacho@gentoo.org> (20 Jul 2013)
 # Keywords missing, bug #478104

--- a/profiles/arch/x86/use.mask
+++ b/profiles/arch/x86/use.mask
@@ -134,7 +134,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 -video_cards_geode
 -video_cards_via

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -5,6 +5,11 @@
 # This file requires >=portage-2.1.1
 # New entries go on top.
 
+# Matt Turner <mattst88@gentoo.org> (26 Jan 2017)
+# x11-drivers/ati-drivers is masked for removal.
+media-gfx/blender opencl
+media-libs/opensubdiv opencl
+
 # Ian Stakenvicius (25 Jan 2017)
 # rust on mozilla packages is experimental
 www-client/firefox rust

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -30,6 +30,15 @@
 
 #--- END OF EXAMPLES ---
 
+# Matt Turner <mattst88@gentoo.org> (26 Jan 2017)
+# Dead and replaced by media-libs/mesa[video_cards_radeonsi]
+# (or the proprietary amdgpu-pro, which is not in tree).
+# Masked for removal in 30 days.
+# Bug #582406
+x11-drivers/ati-drivers
+x11-libs/amd-adl-sdk
+x11-libs/xvba-video
+
 # Michał Górny <mgorny@gentoo.org> (26 Jan 2017)
 # Pre-release, masked for testing. Major changes since 2.0.4,
 # including dropped support for BlueZ 4.

--- a/profiles/prefix/darwin/macos/10.10/x64/use.mask
+++ b/profiles/prefix/darwin/macos/10.10/x64/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.10/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.10/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.11/x64/use.mask
+++ b/profiles/prefix/darwin/macos/10.11/x64/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.11/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.11/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.12/x64/use.mask
+++ b/profiles/prefix/darwin/macos/10.12/x64/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.12/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.12/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.4/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.4/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.5/x64/use.mask
+++ b/profiles/prefix/darwin/macos/10.5/x64/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.5/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.5/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.6/x64/use.mask
+++ b/profiles/prefix/darwin/macos/10.6/x64/use.mask
@@ -28,7 +28,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.6/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.6/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.7/x64/use.mask
+++ b/profiles/prefix/darwin/macos/10.7/x64/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.7/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.7/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.8/x64/use.mask
+++ b/profiles/prefix/darwin/macos/10.8/x64/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.8/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.8/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.9/x64/use.mask
+++ b/profiles/prefix/darwin/macos/10.9/x64/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available

--- a/profiles/prefix/darwin/macos/10.9/x86/use.mask
+++ b/profiles/prefix/darwin/macos/10.9/x86/use.mask
@@ -26,7 +26,6 @@
 -input_devices_vmmouse
 -input_devices_wacom
 -video_cards_nvidia
--video_cards_fglrx
 -video_cards_vmware
 
 # Modular X: mask for architectures on which they aren't available


### PR DESCRIPTION
Would like to give last rites to x11-drivers/ati-drivers. This has a few consequences, such as masking USE=opencl on sys-apps/hwloc, media-gfx/blender, and media-libs/opensubdiv; also giving last rites to x11-libs/amd-adl-sdk and x11-libs/xvba-video since they are not useful without ati-drivers; and USE masking video_cards_fglrx.

Please review.

@blueness and @mrueg (for x11-libs/amd-adl-sdk)
@gentoo/x11 (for x11-libs/xvba-video)
@gentoo/cluster (for sys-apps/hwloc)
@gentoo/graphics and @dracwyrm and @redchillipadi (for media-gfx/blender and media-libs/opensubdiv)
@jkarlson (for x11-drivers/ati-drivers)
@gentoo/proxy-maint 