### PR TITLE
dev-python/sphinx: <1.5.1 is incompatible with docutils 0.13

### DIFF
--- a/dev-python/sphinx/sphinx-1.1.3-r8.ebuild
+++ b/dev-python/sphinx/sphinx-1.1.3-r8.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 python3_{4,5} pypy{,3} )
+PYTHON_COMPAT=( python2_7 pypy )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 eutils versionator
@@ -18,32 +18,28 @@ SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="doc latex test"
 
+# Split the jinja dep to allow different slots to satisfy it
 RDEPEND="
-	=dev-python/alabaster-0.7*[${PYTHON_USEDEP}]
-	>=dev-python/docutils-0.11[${PYTHON_USEDEP}]
+	<dev-python/docutils-0.13[${PYTHON_USEDEP}]
 	>=dev-python/jinja-2.3[${PYTHON_USEDEP}]
-	>=dev-python/pygments-2.0.1-r1[${PYTHON_USEDEP}]
-	>=dev-python/six-1.4[${PYTHON_USEDEP}]
-	>=dev-python/Babel-1.3[${PYTHON_USEDEP}]
-	!=dev-python/Babel-2.0[${PYTHON_USEDEP}]
-	>=dev-python/snowballstemmer-1.1[${PYTHON_USEDEP}]
-	>=dev-python/sphinx_rtd_theme-0.1[${PYTHON_USEDEP}]
-	<dev-python/sphinx_rtd_theme-2.0[${PYTHON_USEDEP}]
+	>=dev-python/pygments-1.2[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
 	latex? (
 		dev-texlive/texlive-latexextra
 		app-text/dvipng
 	)"
-DEPEND="${RDEPEND}
-	dev-python/setuptools[${PYTHON_USEDEP}]
-	test? (
-		dev-python/nose[${PYTHON_USEDEP}]
-		$(python_gen_cond_dep 'dev-python/mock[${PYTHON_USEDEP}]' python2_7 pypy)
-	)"
+DEPEND="${DEPEND}
+	test? ( dev-python/nose[${PYTHON_USEDEP}] )"
 
 S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-python3.patch
+	"${FILESDIR}"/${P}-docutils-manpage.patch
+)
 
 python_compile() {
 	distutils-r1_python_compile
@@ -52,26 +48,23 @@ python_compile() {
 	# Note that the tests usually do it for us. However, I don't want
 	# to trust USE=test really running all the tests, especially
 	# with FEATURES=test-fail-continue.
-	pushd "${BUILD_DIR}"/lib > /dev/null || die
+	cd "${BUILD_DIR}"/lib || die
 	"${PYTHON}" -m sphinx.pycode.__init__ \
 		|| die "Grammar generation failed."
-	popd > /dev/null || die
 }
 
 python_compile_all() {
-	use doc && emake -C doc SPHINXBUILD='"${PYTHON}" "${S}/sphinx-build.py"' html
+	use doc && emake -C doc SPHINXBUILD="${PYTHON} -m sphinx.__init__" html
 }
 
 python_test() {
-	mkdir -p "${BUILD_DIR}/sphinx_tempdir" || die
-	export SPHINX_TEST_TEMPDIR="${BUILD_DIR}/sphinx_tempdir"
 	cp -r -l tests "${BUILD_DIR}"/ || die
 
-	if $(python_is_python3); then
+	if [[ ${EPYTHON} == python3* ]]; then
 		2to3 -w --no-diffs "${BUILD_DIR}"/tests || die
 	fi
 
-	nosetests -w "${BUILD_DIR}"/tests -v \
+	nosetests -w "${BUILD_DIR}"/tests \
 		|| die "Tests fail with ${EPYTHON}"
 }
 

--- a/dev-python/sphinx/sphinx-1.2.2-r1.ebuild
+++ b/dev-python/sphinx/sphinx-1.2.2-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 python3_{4,5} pypy pypy3 )
+PYTHON_COMPAT=( python{2_7,3_4} pypy )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 eutils versionator
@@ -18,15 +18,14 @@ SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="doc latex test"
 
-# Portage has only >= minimum required versions of all rdeps making
-# setting of version borders unnecessary
+# Split the jinja dep to allow different slots to satisfy it
 RDEPEND="
-	dev-python/docutils[${PYTHON_USEDEP}]
-	dev-python/jinja[${PYTHON_USEDEP}]
-	dev-python/pygments[${PYTHON_USEDEP}]
+	<dev-python/docutils-0.13[${PYTHON_USEDEP}]
+	>=dev-python/jinja-2.3[${PYTHON_USEDEP}]
+	>=dev-python/pygments-1.2[${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	latex? (
 		dev-texlive/texlive-latexextra
@@ -45,8 +44,7 @@ python_compile() {
 	# to trust USE=test really running all the tests, especially
 	# with FEATURES=test-fail-continue.
 	pushd "${BUILD_DIR}"/lib > /dev/null || die
-	"${PYTHON}" -m sphinx.pycode.__init__ \
-		|| die "Grammar generation failed."
+	"${PYTHON}" -m sphinx.pycode.__init__ || die "Grammar generation failed."
 	popd > /dev/null || die
 }
 

--- a/dev-python/sphinx/sphinx-1.2.3-r1.ebuild
+++ b/dev-python/sphinx/sphinx-1.2.3-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_4} pypy )
+PYTHON_COMPAT=( python2_7 python3_{4,5} pypy pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 eutils versionator
@@ -18,14 +18,15 @@ SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="doc latex test"
 
-# Split the jinja dep to allow different slots to satisfy it
+# Portage has only >= minimum required versions of all rdeps making
+# setting of version borders unnecessary
 RDEPEND="
-	>=dev-python/docutils-0.7[${PYTHON_USEDEP}]
-	>=dev-python/jinja-2.3[${PYTHON_USEDEP}]
-	>=dev-python/pygments-1.2[${PYTHON_USEDEP}]
+	<dev-python/docutils-0.13[${PYTHON_USEDEP}]
+	dev-python/jinja[${PYTHON_USEDEP}]
+	dev-python/pygments[${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	latex? (
 		dev-texlive/texlive-latexextra
@@ -44,7 +45,8 @@ python_compile() {
 	# to trust USE=test really running all the tests, especially
 	# with FEATURES=test-fail-continue.
 	pushd "${BUILD_DIR}"/lib > /dev/null || die
-	"${PYTHON}" -m sphinx.pycode.__init__ || die "Grammar generation failed."
+	"${PYTHON}" -m sphinx.pycode.__init__ \
+		|| die "Grammar generation failed."
 	popd > /dev/null || die
 }
 

--- a/dev-python/sphinx/sphinx-1.3.1-r2.ebuild
+++ b/dev-python/sphinx/sphinx-1.3.1-r2.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 pypy )
+PYTHON_COMPAT=( python2_7 python3_{4,5} pypy)
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 eutils versionator
@@ -18,27 +18,31 @@ SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="doc latex test"
 
-# Split the jinja dep to allow different slots to satisfy it
-RDEPEND=">=dev-python/docutils-0.7[${PYTHON_USEDEP}]
+RDEPEND="
+	=dev-python/alabaster-0.7*[${PYTHON_USEDEP}]
+	>=dev-python/docutils-0.11[${PYTHON_USEDEP}]
+	<dev-python/docutils-0.13[${PYTHON_USEDEP}]
 	>=dev-python/jinja-2.3[${PYTHON_USEDEP}]
-	>=dev-python/pygments-1.2[${PYTHON_USEDEP}]
-	dev-python/setuptools[${PYTHON_USEDEP}]
+	>=dev-python/pygments-2.0.1-r1[${PYTHON_USEDEP}]
+	>=dev-python/six-1.4[${PYTHON_USEDEP}]
+	>=dev-python/Babel-1.3[${PYTHON_USEDEP}]
+	>=dev-python/snowballstemmer-1.1[${PYTHON_USEDEP}]
+	dev-python/sphinx_rtd_theme[${PYTHON_USEDEP}]
 	latex? (
 		dev-texlive/texlive-latexextra
 		app-text/dvipng
 	)"
-DEPEND="${DEPEND}
-	test? ( dev-python/nose[${PYTHON_USEDEP}] )"
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? (
+		dev-python/nose[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep 'dev-python/mock[${PYTHON_USEDEP}]' python2_7 pypy)
+	)"
 
 S="${WORKDIR}/${MY_P}"
-
-PATCHES=(
-	"${FILESDIR}"/${P}-python3.patch
-	"${FILESDIR}"/${P}-docutils-manpage.patch
-)
 
 python_compile() {
 	distutils-r1_python_compile
@@ -47,23 +51,26 @@ python_compile() {
 	# Note that the tests usually do it for us. However, I don't want
 	# to trust USE=test really running all the tests, especially
 	# with FEATURES=test-fail-continue.
-	cd "${BUILD_DIR}"/lib || die
+	pushd "${BUILD_DIR}"/lib > /dev/null || die
 	"${PYTHON}" -m sphinx.pycode.__init__ \
 		|| die "Grammar generation failed."
+	popd > /dev/null || die
 }
 
 python_compile_all() {
-	use doc && emake -C doc SPHINXBUILD="${PYTHON} -m sphinx.__init__" html
+	use doc && emake -C doc SPHINXBUILD='"${PYTHON}" "${S}/sphinx-build.py"' html
 }
 
 python_test() {
+	mkdir -p "${BUILD_DIR}/sphinx_tempdir" || die
+	export SPHINX_TEST_TEMPDIR="${BUILD_DIR}/sphinx_tempdir"
 	cp -r -l tests "${BUILD_DIR}"/ || die
 
-	if [[ ${EPYTHON} == python3* ]]; then
+	if $(python_is_python3); then
 		2to3 -w --no-diffs "${BUILD_DIR}"/tests || die
 	fi
 
-	nosetests -w "${BUILD_DIR}"/tests \
+	nosetests -w "${BUILD_DIR}"/tests -v \
 		|| die "Tests fail with ${EPYTHON}"
 }
 

--- a/dev-python/sphinx/sphinx-1.3.5-r1.ebuild
+++ b/dev-python/sphinx/sphinx-1.3.5-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 python3_{4,5} pypy)
+PYTHON_COMPAT=( python2_7 python3_{4,5} pypy{,3} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 eutils versionator
@@ -18,18 +18,21 @@ SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="doc latex test"
 
 RDEPEND="
 	=dev-python/alabaster-0.7*[${PYTHON_USEDEP}]
 	>=dev-python/docutils-0.11[${PYTHON_USEDEP}]
+	<dev-python/docutils-0.13[${PYTHON_USEDEP}]
 	>=dev-python/jinja-2.3[${PYTHON_USEDEP}]
 	>=dev-python/pygments-2.0.1-r1[${PYTHON_USEDEP}]
 	>=dev-python/six-1.4[${PYTHON_USEDEP}]
 	>=dev-python/Babel-1.3[${PYTHON_USEDEP}]
+	!=dev-python/Babel-2.0[${PYTHON_USEDEP}]
 	>=dev-python/snowballstemmer-1.1[${PYTHON_USEDEP}]
-	dev-python/sphinx_rtd_theme[${PYTHON_USEDEP}]
+	>=dev-python/sphinx_rtd_theme-0.1[${PYTHON_USEDEP}]
+	<dev-python/sphinx_rtd_theme-2.0[${PYTHON_USEDEP}]
 	latex? (
 		dev-texlive/texlive-latexextra
 		app-text/dvipng


### PR DESCRIPTION
As described in https://github.com/sphinx-doc/sphinx/issues/3212 and encountered in https://github.com/cschwan/sage-on-gentoo/issues/451#issuecomment-274865253, Sphinx prior to 1.5.1 is incompatible with docutils 0.13.1 due to imbalanced stack operations between `visit_image` and `depart_image`. This can lead to error messages of the form

    AssertionError: len(context) = 1

where the actual number may be any positive integer. The affected runs will likely have broken document structure, too, as a consequence of the incompatibility. The ebuilds should reflect this incompatibility.