### PR TITLE
app-emulation/virtualbox: Depend on docbook-sgml-dtd

### DIFF
--- a/app-emulation/virtualbox/virtualbox-5.0.16-r1.ebuild
+++ b/app-emulation/virtualbox/virtualbox-5.0.16-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -67,6 +67,7 @@ DEPEND="${RDEPEND}
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-fontsrecommended
 		dev-texlive/texlive-fontsextra
+		app-text/docbook-sgml-dtd:4.4
 	)
 	!headless? ( x11-libs/libXinerama )
 	java? ( >=virtual/jre-1.6:= )

--- a/app-emulation/virtualbox/virtualbox-5.0.30.ebuild
+++ b/app-emulation/virtualbox/virtualbox-5.0.30.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -67,6 +67,7 @@ DEPEND="${RDEPEND}
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-fontsrecommended
 		dev-texlive/texlive-fontsextra
+		app-text/docbook-sgml-dtd:4.4
 	)
 	!headless? ( x11-libs/libXinerama )
 	java? ( >=virtual/jre-1.6:= )

--- a/app-emulation/virtualbox/virtualbox-5.0.32.ebuild
+++ b/app-emulation/virtualbox/virtualbox-5.0.32.ebuild
@@ -67,6 +67,7 @@ DEPEND="${RDEPEND}
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-fontsrecommended
 		dev-texlive/texlive-fontsextra
+		app-text/docbook-sgml-dtd:4.4
 	)
 	!headless? ( x11-libs/libXinerama )
 	java? ( >=virtual/jre-1.6:= )

--- a/app-emulation/virtualbox/virtualbox-5.1.12.ebuild
+++ b/app-emulation/virtualbox/virtualbox-5.1.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -70,6 +70,7 @@ DEPEND="${RDEPEND}
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-fontsrecommended
 		dev-texlive/texlive-fontsextra
+		app-text/docbook-sgml-dtd:4.4
 	)
 	!headless? ( x11-libs/libXinerama )
 	java? ( >=virtual/jre-1.6:= )

--- a/app-emulation/virtualbox/virtualbox-5.1.14.ebuild
+++ b/app-emulation/virtualbox/virtualbox-5.1.14.ebuild
@@ -70,6 +70,7 @@ DEPEND="${RDEPEND}
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-fontsrecommended
 		dev-texlive/texlive-fontsextra
+		app-text/docbook-sgml-dtd:4.4
 	)
 	!headless? ( x11-libs/libXinerama )
 	java? ( >=virtual/jre-1.6:= )


### PR DESCRIPTION
Thanks to Yarda for [identifying this missing package](https://bugs.gentoo.org/show_bug.cgi?id=554932#c9) and to Akos Szalkai for [proposing](https://bugs.gentoo.org/show_bug.cgi?id=554932#c13) a [patch](https://bugs.gentoo.org/attachment.cgi?id=428356&action=diff).

Gentoo-Bug: [554932](https://bugs.gentoo.org/show_bug.cgi?id=554932)

I tested this and can confirm that building `app-emulation/virtualbox-5.1.14` failed without this dependency but succeeded with it.