### PR TITLE
gnome-extra/chrome-gnome-shell: added patches to fix various issues.

### DIFF
--- a/gnome-extra/chrome-gnome-shell/chrome-gnome-shell-8-r1.ebuild
+++ b/gnome-extra/chrome-gnome-shell/chrome-gnome-shell-8-r1.ebuild
@@ -24,10 +24,16 @@ DEPEND="${PYTHON_DEPS}
 	sys-apps/coreutils
 "
 RDEPEND="${PYTHON_DEPS}
-	dev-python/requests[${PYTHON_USEDEP}]
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
 	gnome-base/gnome-shell
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}"-enabled-extensions-array.patch
+	"${FILESDIR}/${P}"-metadata-version.patch
+	"${FILESDIR}/${P}"-get_dbus_connection.patch
+)
 
 src_configure() {
 	local mycmakeargs=( -DBUILD_EXTENSION=OFF )

--- a/gnome-extra/chrome-gnome-shell/files/chrome-gnome-shell-8-enabled-extensions-array.patch
+++ b/gnome-extra/chrome-gnome-shell/files/chrome-gnome-shell-8-enabled-extensions-array.patch
@@ -1,0 +1,32 @@
+From 1de3c56c636adfdb74970bf9d7a5424af3830d92 Mon Sep 17 00:00:00 2001
+From: Yuri Konotopov <ykonotopov@gnome.org>
+Date: Mon, 23 Jan 2017 19:43:30 +0400
+Subject: [PATCH 3/6] connector: assume that "enabled-extensions" array can
+ contains duplicates
+
+See-Also: https://bugzilla.gnome.org/show_bug.cgi?id=777650
+Fixes: https://github.com/nE0sIghT/chrome-gnome-shell-mirror/issues/26
+---
+ connector/chrome-gnome-shell.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/connector/chrome-gnome-shell.py b/connector/chrome-gnome-shell.py
+index 719a347..0b92d83 100755
+--- a/connector/chrome-gnome-shell.py
++++ b/connector/chrome-gnome-shell.py
+@@ -424,9 +424,10 @@ class ChromeGNOMEShell(Gio.Application):
+                     continue
+ 
+                 if extension['enable']:
+-                    uuids.append(extension['uuid'])
++                    if not extension['uuid'] in uuids:
++                        uuids.append(extension['uuid'])
+                 elif extension['uuid'] in uuids:
+-                    uuids.remove(extension['uuid'])
++                    uuids = [value for value in uuids if value != extension['uuid']]
+ 
+             settings.set_strv(ENABLED_EXTENSIONS_KEY, uuids)
+ 
+-- 
+2.10.2
+

--- a/gnome-extra/chrome-gnome-shell/files/chrome-gnome-shell-8-get_dbus_connection.patch
+++ b/gnome-extra/chrome-gnome-shell/files/chrome-gnome-shell-8-get_dbus_connection.patch
@@ -1,0 +1,91 @@
+From dca4a3538f86d8e2e957945a691430573192716d Mon Sep 17 00:00:00 2001
+From: Yuri Konotopov <ykonotopov@gnome.org>
+Date: Tue, 24 Jan 2017 19:42:19 +0400
+Subject: [PATCH 6/6] connector: do not use get_dbus_connection after
+ GApplication was released.
+
+Fixes: https://github.com/nE0sIghT/chrome-gnome-shell-mirror/issues/27
+---
+ connector/chrome-gnome-shell.py | 22 +++++++++++++---------
+ 1 file changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/connector/chrome-gnome-shell.py b/connector/chrome-gnome-shell.py
+index 0f6e5f1..ac6740a 100755
+--- a/connector/chrome-gnome-shell.py
++++ b/connector/chrome-gnome-shell.py
+@@ -106,21 +106,26 @@ class ChromeGNOMEShell(Gio.Application):
+             self.hold()
+ 
+     # Is there any way to hook this to shutdown?
+-    def cleanup(self):
+-        debug('Cleanup')
++    def clean_release(self):
++        debug('Release')
+ 
+         if self.shellAppearedId:
+             Gio.bus_unwatch_name(self.shellAppearedId)
+ 
+         if self.shellSignalId:
+-            self.get_dbus_connection().signal_unsubscribe(self.shellSignalId)
++            dbus_connection = self.get_dbus_connection()
++
++            if dbus_connection is not None:
++                dbus_connection.signal_unsubscribe(self.shellSignalId)
++
++        self.release()
+ 
+     def default_exception_hook(self, exception_type, value, tb):
+         log_error("Uncaught exception of type %s occured" % exception_type)
+         traceback.print_tb(tb)
+         log_error("Exception: %s" % value)
+ 
+-        self.release()
++        self.clean_release()
+ 
+     def add_simple_action(self, name, callback, parameter_type):
+         action = Gio.SimpleAction.new(
+@@ -191,7 +196,7 @@ class ChromeGNOMEShell(Gio.Application):
+     # noinspection PyUnusedLocal
+     def on_service_timeout(self, data):
+         debug('On service timeout')
+-        self.release()
++        self.clean_release()
+ 
+         return False
+ 
+@@ -203,7 +208,7 @@ class ChromeGNOMEShell(Gio.Application):
+ 
+         if len(text_length_bytes) == 0:
+             debug('Release condition: %s' % str(condition))
+-            self.release()
++            self.clean_release()
+             return
+ 
+         # Unpack message length as 4 byte integer.
+@@ -255,14 +260,14 @@ class ChromeGNOMEShell(Gio.Application):
+     # noinspection PyUnusedLocal
+     def on_hup(self, source, condition, data):
+         debug('On hup: %s' % str(condition))
+-        self.release()
++        self.clean_release()
+ 
+         return False
+ 
+     # noinspection PyUnusedLocal
+     def on_sigint(self, data):
+         debug('On sigint')
+-        self.release()
++        self.clean_release()
+ 
+         return False
+ 
+@@ -545,6 +550,5 @@ if __name__ == '__main__':
+     app = ChromeGNOMEShell('--gapplication-service' in sys.argv)
+ 
+     app.run(sys.argv)
+-    app.cleanup()
+ 
+     debug('Quit')
+-- 
+2.10.2
+

--- a/gnome-extra/chrome-gnome-shell/files/chrome-gnome-shell-8-metadata-version.patch
+++ b/gnome-extra/chrome-gnome-shell/files/chrome-gnome-shell-8-metadata-version.patch
@@ -1,0 +1,28 @@
+From 48ded6911e60fb8415190b252ca420b994e6c525 Mon Sep 17 00:00:00 2001
+From: Yuri Konotopov <ykonotopov@gnome.org>
+Date: Mon, 23 Jan 2017 22:29:12 +0400
+Subject: [PATCH 4/6] connector: assume version 1 for extensions without
+ version in metadata
+
+Bug: https://github.com/nE0sIghT/chrome-gnome-shell-mirror/issues/27
+See-Also: https://git.gnome.org/browse/extensions-web/commit/?id=214f03ee90f0f391d3d4fdec23feedf45e3d0507
+---
+ connector/chrome-gnome-shell.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/connector/chrome-gnome-shell.py b/connector/chrome-gnome-shell.py
+index 0b92d83..0f6e5f1 100755
+--- a/connector/chrome-gnome-shell.py
++++ b/connector/chrome-gnome-shell.py
+@@ -506,7 +506,7 @@ class ChromeGNOMEShell(Gio.Application):
+                         http_request['installed'][uuid] = {
+                             'version': int(extensions[uuid]['version'])
+                         }
+-                    except ValueError:
++                    except (ValueError, KeyError):
+                         http_request['installed'][uuid] = {
+                             'version': 1
+                         }
+-- 
+2.10.2
+


### PR DESCRIPTION
[SIGSEGV](https://github.com/nE0sIghT/chrome-gnome-shell-mirror/issues/27) on browser exit and exception with extensions without "version" parameter in metadata. 
[Workaround for GNOME Shell bug](https://github.com/nE0sIghT/chrome-gnome-shell-mirror/issues/26) that can prevent disabling extensions.

Also sorted RDEPEND.