### PR TITLE
sys-libs/libcxx: switch the default to libcxxabi+libunwind

### DIFF
--- a/profiles/arch/amd64-fbsd/clang/package.use.mask
+++ b/profiles/arch/amd64-fbsd/clang/package.use.mask
@@ -1,8 +1,10 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
+# Disable libcxxabi since it collides with forced libcxxrt
 # Build libcxxrt over libgcc_s since that is what clang defaults to.
+sys-libs/libcxx libcxxabi libunwind
 sys-libs/libcxxrt libunwind
 
 # Needs to be fixed: cxx useflag enables plugins and gold.

--- a/profiles/default/bsd/package.use
+++ b/profiles/default/bsd/package.use
@@ -1,0 +1,8 @@
+# Copyright 1999-2017 Gentoo Foundation.
+# Distributed under the terms of the GNU General Public License, v2
+# $Id$
+
+# Michał Górny <mgorny@gentoo.org> (26 Jan 2017)
+# Preserve the old defaults on *BSD systems.
+sys-libs/libcxx -libcxxabi libcxxrt -libunwind
+sys-libs/libcxxrt -libunwind

--- a/sys-libs/libcxx/libcxx-4.0.0_rc2.ebuild
+++ b/sys-libs/libcxx/libcxx-4.0.0_rc2.ebuild
@@ -20,7 +20,7 @@ SRC_URI="http://www.llvm.org/pre-releases/${PV/_//}/${P/_/}.src.tar.xz"
 LICENSE="|| ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="elibc_glibc elibc_musl +libcxxabi libcxxrt libunwind +static-libs test"
+IUSE="elibc_glibc elibc_musl +libcxxabi libcxxrt +libunwind +static-libs test"
 REQUIRED_USE="libunwind? ( || ( libcxxabi libcxxrt ) )
 	?? ( libcxxabi libcxxrt )"
 

--- a/sys-libs/libcxx/libcxx-4.0.0_rc2.ebuild
+++ b/sys-libs/libcxx/libcxx-4.0.0_rc2.ebuild
@@ -20,7 +20,7 @@ SRC_URI="http://www.llvm.org/pre-releases/${PV/_//}/${P/_/}.src.tar.xz"
 LICENSE="|| ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="elibc_glibc elibc_musl libcxxabi +libcxxrt libunwind +static-libs test"
+IUSE="elibc_glibc elibc_musl +libcxxabi libcxxrt libunwind +static-libs test"
 REQUIRED_USE="libunwind? ( || ( libcxxabi libcxxrt ) )
 	?? ( libcxxabi libcxxrt )"
 

--- a/sys-libs/libcxx/libcxx-9999.ebuild
+++ b/sys-libs/libcxx/libcxx-9999.ebuild
@@ -33,7 +33,7 @@ if [[ ${PV} != 9999 ]] ; then
 else
 	KEYWORDS=""
 fi
-IUSE="elibc_glibc elibc_musl +libcxxabi libcxxrt libunwind +static-libs test"
+IUSE="elibc_glibc elibc_musl +libcxxabi libcxxrt +libunwind +static-libs test"
 REQUIRED_USE="libunwind? ( || ( libcxxabi libcxxrt ) )
 	?? ( libcxxabi libcxxrt )"
 

--- a/sys-libs/libcxx/libcxx-9999.ebuild
+++ b/sys-libs/libcxx/libcxx-9999.ebuild
@@ -33,7 +33,7 @@ if [[ ${PV} != 9999 ]] ; then
 else
 	KEYWORDS=""
 fi
-IUSE="elibc_glibc elibc_musl libcxxabi +libcxxrt libunwind +static-libs test"
+IUSE="elibc_glibc elibc_musl +libcxxabi libcxxrt libunwind +static-libs test"
 REQUIRED_USE="libunwind? ( || ( libcxxabi libcxxrt ) )
 	?? ( libcxxabi libcxxrt )"
 

--- a/sys-libs/libcxxabi/libcxxabi-4.0.0_rc2.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-4.0.0_rc2.ebuild
@@ -19,7 +19,7 @@ SRC_URI="http://www.llvm.org/pre-releases/${PV/_//}/${P/_/}.src.tar.xz
 LICENSE="|| ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="libunwind +static-libs test"
+IUSE="+libunwind +static-libs test"
 
 RDEPEND="
 	libunwind? (

--- a/sys-libs/libcxxabi/libcxxabi-9999.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-9999.ebuild
@@ -20,7 +20,7 @@ EGIT_REPO_URI="http://llvm.org/git/libcxxabi.git
 LICENSE="|| ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS=""
-IUSE="libunwind +static-libs test"
+IUSE="+libunwind +static-libs test"
 
 RDEPEND="
 	libunwind? (

--- a/sys-libs/libcxxrt/libcxxrt-9999.ebuild
+++ b/sys-libs/libcxxrt/libcxxrt-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -26,7 +26,7 @@ if [ "${PV%9999}" = "${PV}" ] ; then
 else
 	KEYWORDS=""
 fi
-IUSE="libunwind +static-libs"
+IUSE="+libunwind +static-libs"
 
 RDEPEND="libunwind? ( || ( >=sys-libs/libunwind-1.0.1-r1[static-libs?,${MULTILIB_USEDEP}]
 		sys-libs/llvm-libunwind[static-libs?,${MULTILIB_USEDEP}] ) )"


### PR DESCRIPTION
...preserving the old default for bsd profiles. The new default would apply to 4.0.0+.

libcxxabi because it is the default upstream, is more maintained, better tested and more portable. libunwind because this lets us kill dep on gcc entirely, and I think that's what people using libcxx usually want.

@gentoo/llvm @nigoro 