### PR TITLE
Keyjava

### DIFF
--- a/dev-java/ant-core/ant-core-1.9.2.ebuild
+++ b/dev-java/ant-core/ant-core-1.9.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -22,7 +22,8 @@ SRC_URI="mirror://apache/ant/source/${MY_P}-src.tar.bz2
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm ppc64 x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 ~arm ~arm64 ppc64 x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~x64-freebsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris 
+~x86-solaris"
 
 DEPEND="|| ( >=virtual/jdk-1.5 dev-java/gcj-jdk )
 	!dev-java/ant-tasks

--- a/dev-java/ecj-gcj/ecj-gcj-4.4.2.ebuild
+++ b/dev-java/ecj-gcj/ecj-gcj-4.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -15,7 +15,7 @@ SRC_URI="http://download.eclipse.org/eclipse/downloads/drops4/${DMF}/${MY_PN}src
 
 LICENSE="EPL-1.0"
 SLOT="4.4"
-KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 IUSE="+native"
 
 RDEPEND="sys-devel/gcc:*[gcj]

--- a/dev-java/gcj-jdk/gcj-jdk-4.9.4.ebuild
+++ b/dev-java/gcj-jdk/gcj-jdk-4.9.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.gentoo.org/"
 SRC_URI=""
 
 LICENSE="GPL-2"
-KEYWORDS="~amd64 ~arm ~ppc64 ~x86 ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86 ~x86-linux"
 SLOT="0"
 IUSE="awt"
 

--- a/dev-java/icedtea-web/icedtea-web-1.6.2.ebuild
+++ b/dev-java/icedtea-web/icedtea-web-1.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -13,7 +13,7 @@ HOMEPAGE="http://icedtea.classpath.org"
 SRC_URI="http://icedtea.classpath.org/download/source/${P}.tar.gz"
 LICENSE="GPL-2 GPL-2-with-linking-exception LGPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 IUSE="doc javascript nsplugin tagsoup test"
 RESTRICT="test"
 

--- a/dev-java/icedtea/icedtea-3.2.0.ebuild
+++ b/dev-java/icedtea/icedtea-3.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 # Build written by Andrew John Hughes (gnu_andrew@member.fsf.org)
@@ -60,7 +60,7 @@ SRC_URI="
 	${DROP_URL}/jamvm/${JAMVM_TARBALL} -> ${JAMVM_GENTOO_TARBALL}"
 
 LICENSE="Apache-1.1 Apache-2.0 GPL-1 GPL-2 GPL-2-with-linking-exception LGPL-2 MPL-1.0 MPL-1.1 public-domain W3C"
-KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 
 IUSE="+alsa cacao +cups doc examples +gtk headless-awt infinality
 	jamvm +jbootstrap kerberos libressl nsplugin pax_kernel +pch

--- a/dev-java/icedtea/icedtea-7.2.6.8.ebuild
+++ b/dev-java/icedtea/icedtea-7.2.6.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 # Build written by Andrew John Hughes (gnu_andrew@member.fsf.org)
@@ -53,7 +53,7 @@ SRC_URI="
 	${DROP_URL}/jamvm/${JAMVM_TARBALL} -> ${JAMVM_GENTOO_TARBALL}"
 
 LICENSE="Apache-1.1 Apache-2.0 GPL-1 GPL-2 GPL-2-with-linking-exception LGPL-2 MPL-1.0 MPL-1.1 public-domain W3C"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 IUSE="+alsa cacao cjk +cups debug doc examples +gtk headless-awt infinality
 	jamvm javascript +jbootstrap kerberos libressl nsplugin nss pax_kernel

--- a/dev-java/javatoolkit/javatoolkit-0.3.0-r9.ebuild
+++ b/dev-java/javatoolkit/javatoolkit-0.3.0-r9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -15,7 +15,7 @@ SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd"
+KEYWORDS="amd64 ~arm ~arm64 ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd"
 IUSE=""
 
 python_prepare_all() {

--- a/dev-util/systemtap/systemtap-2.9.ebuild
+++ b/dev-util/systemtap/systemtap-2.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -14,7 +14,7 @@ SRC_URI="http://www.sourceware.org/${PN}/ftp/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
 IUSE="sqlite"
 
 RDEPEND=">=dev-libs/elfutils-0.142

--- a/media-libs/libart_lgpl/libart_lgpl-2.3.21-r3.ebuild
+++ b/media-libs/libart_lgpl/libart_lgpl-2.3.21-r3.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://www.levien.com/libart"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-interix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND=""

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -19,7 +19,13 @@ net-misc/curl curl_ssl_axtls curl_ssl_polarssl metalink
 dev-libs/efl physics
 
 # Needs testing.
-sys-devel/gcc gcj graphite regression-test
+sys-devel/gcc graphite regression-test
+# Roy Bamford <neddyseagoon@gentoo.org> (26 Jan 2017) 
+# removed gcj after using gcj-5.4.0 to bootstrap icedtea-7  
+
+# Roy Bamford <neddyseagoon@gentoo.org> (26 Jan 2017) 
+# gcj-6.3 won't bootstrap icedtea 7 though so mask it here
+>=sys-devel/gcc-6 gcj
 
 # Julian Ospald <hasufell@gentoo.org> (04 Jan 2014)
 # no keyword for media-libs/swfdec and media-libs/libtimidity

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -196,4 +196,5 @@ clvm
 opencl
 
 # No arm64 java support yet.
-java
+# java
+# Mask removed by Roy Bamford <neddyseagoon@gentoo.org> (26 Jan 2017)

--- a/sys-apps/baselayout-java/baselayout-java-0.1.0.ebuild
+++ b/sys-apps/baselayout-java/baselayout-java-0.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -12,7 +12,7 @@ SRC_URI="https://dev.gentoo.org/~sera/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ia64 ppc ppc64 x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 ~arm ~arm64 ~ia64 ppc ppc64 x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="!<dev-java/java-config-2.2"

--- a/virtual/jdk/jdk-1.7.0-r2.ebuild
+++ b/virtual/jdk/jdk-1.7.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,7 +6,7 @@ EAPI="6"
 
 DESCRIPTION="Virtual for Java Development Kit (JDK)"
 SLOT="1.7"
-KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 ~arm64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="|| (
 		dev-java/icedtea-bin:7

--- a/virtual/jre/jre-1.7.0-r2.ebuild
+++ b/virtual/jre/jre-1.7.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,6 +6,6 @@ EAPI="6"
 
 DESCRIPTION="Virtual for Java Runtime Environment (JRE)"
 SLOT="1.7"
-KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 ~arm64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="virtual/jdk:1.7"

--- a/virtual/jre/jre-1.8.0-r1.ebuild
+++ b/virtual/jre/jre-1.8.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -6,7 +6,7 @@ EAPI="6"
 
 DESCRIPTION="Virtual for Java Runtime Environment (JRE)"
 SLOT="1.8"
-KEYWORDS="amd64 ~arm ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc64-solaris ~x64-solaris"
+KEYWORDS="amd64 ~arm ~arm64 ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc64-solaris ~x64-solaris"
 
 RDEPEND="|| (
 		virtual/jdk:1.8


### PR DESCRIPTION
Keyword icedtea-7 and icedtea-8 for ~arm64.
Change use.mask to allow the use of the java USE flag on arm64
Change the USE=gcj package.use.mask to allow > gcj-6, so that icedtea-7 can be bootstrapped with gcj-5.4.0 on arm64

app-text/mupdf and media-libs/glfw are in their own PR.  They are not supposed to be here too.