### PR TITLE
media-gfx/enblend: Fix sandbox access violations

### DIFF
--- a/media-gfx/enblend/enblend-4.2.0_p20161007.ebuild
+++ b/media-gfx/enblend/enblend-4.2.0_p20161007.ebuild
@@ -67,7 +67,12 @@ src_configure() {
 }
 
 src_compile() {
+	# To allow icon resizing with renderers (no way to disable)
+	addpredict /dev/dri
+
+	# To compile fonts in the temp directory
 	export VARTEXFONTS="${T}/fonts"
+
 	# forcing -j1 as every parallel compilation process needs about 1 GB RAM.
 	cmake-utils_src_compile -j1
 }


### PR DESCRIPTION
The new version of ImageMagick needs access to /dev/dri for image
rendering, thus causing the installation of enblend to fail.

Signed-off by: Jonathan Scruggs (j.scruggs@gmail.com)

@gentoo/proxy-maint