### PR TITLE
media-gfx/blender: Add glew slot to blender-2.72b-r4

### DIFF
--- a/media-gfx/blender/blender-2.72b-r4.ebuild
+++ b/media-gfx/blender/blender-2.72b-r4.ebuild
@@ -65,7 +65,7 @@ RDEPEND="
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-python/requests[${PYTHON_USEDEP}]
 	>=media-libs/freetype-2.0:2
-	media-libs/glew:=
+	media-libs/glew:0=
 	media-libs/libpng:0
 	media-libs/libsamplerate
 	sys-libs/zlib


### PR DESCRIPTION
Signed-off by: Jonathan Scruggs (j.scruggs@gmail.com)