### PR TITLE
x11-drivers/xf86-input-libinput: Fix bug #571474

### DIFF
--- a/x11-drivers/xf86-input-libinput/xf86-input-libinput-0.14.0.ebuild
+++ b/x11-drivers/xf86-input-libinput/xf86-input-libinput-0.14.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -14,4 +14,4 @@ IUSE=""
 RDEPEND=">=dev-libs/libinput-0.21.0:0="
 DEPEND="${RDEPEND}"
 
-DOCS=( "README.md" "conf/99-libinput.conf" )
+DOCS=( "README.md" )

--- a/x11-drivers/xf86-input-libinput/xf86-input-libinput-0.19.0.ebuild
+++ b/x11-drivers/xf86-input-libinput/xf86-input-libinput-0.19.0.ebuild
@@ -14,7 +14,7 @@ IUSE=""
 RDEPEND=">=dev-libs/libinput-1.2.0:0="
 DEPEND="${RDEPEND}"
 
-DOCS=( "README.md" "conf/60-libinput.conf" )
+DOCS=( "README.md" )
 
 pkg_pretend() {
 	CONFIG_CHECK="~TIMERFD"

--- a/x11-drivers/xf86-input-libinput/xf86-input-libinput-0.23.0.ebuild
+++ b/x11-drivers/xf86-input-libinput/xf86-input-libinput-0.23.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -14,7 +14,7 @@ IUSE=""
 RDEPEND=">=dev-libs/libinput-1.5.0:0="
 DEPEND="${RDEPEND}"
 
-DOCS=( "README.md" "conf/40-libinput.conf" )
+DOCS=( "README.md" )
 
 pkg_pretend() {
 	CONFIG_CHECK="~TIMERFD"


### PR DESCRIPTION
Gentoo bug: https://bugs.gentoo.org/571474

Package-Manager: Portage-2.3.3, Repoman-2.3.1