### PR TITLE
sys-block/whdd: export CC to build system

### DIFF
--- a/sys-block/whdd/whdd-3.0.ebuild
+++ b/sys-block/whdd/whdd-3.0.ebuild
@@ -7,6 +7,8 @@ EAPI=6
 DESCRIPTION="Diagnostic and recovery tool for block devices"
 HOMEPAGE="https://whdd.github.io"
 
+inherit toolchain-funcs
+
 if [[ ${PV} == 9999 ]]
 then
 	EGIT_REPO_URI="https://github.com/${PN}/${PN}"
@@ -26,3 +28,8 @@ DEPEND="
 	sys-libs/ncurses:0=[unicode]"
 RDEPEND="${DEPEND}
 	sys-apps/smartmontools"
+
+src_compile() {
+	tc_export CC
+	default
+}

--- a/sys-block/whdd/whdd-9999.ebuild
+++ b/sys-block/whdd/whdd-9999.ebuild
@@ -7,6 +7,8 @@ EAPI=6
 DESCRIPTION="Diagnostic and recovery tool for block devices"
 HOMEPAGE="https://whdd.github.io"
 
+inherit toolchain-funcs
+
 if [[ ${PV} == 9999 ]]
 then
 	EGIT_REPO_URI="https://github.com/${PN}/${PN}"
@@ -26,3 +28,8 @@ DEPEND="
 	sys-libs/ncurses:0=[unicode]"
 RDEPEND="${DEPEND}
 	sys-apps/smartmontools"
+
+src_compile() {
+	tc_export CC
+	default
+}


### PR DESCRIPTION
Use tc_export function from toolchain-funcs eclass to export CC as
environment variable.

This is needed because build system of whdd (>=3.0) has no configure
script, but straight makefile and Portage doesn't automatically export
CC and other build-related environment variables.