### PR TITLE
net-irc/irssi-xmpp: fix incompatible DEPEND >=net-irc/irssi-1

### DIFF
--- a/net-irc/irssi-xmpp/irssi-xmpp-0.52.ebuild
+++ b/net-irc/irssi-xmpp/irssi-xmpp-0.52.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -15,7 +15,7 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE=""
 
-DEPEND=">=net-irc/irssi-0.8.13
+DEPEND="<net-irc/irssi-1
 	>=net-libs/loudmouth-1.4.0[debug]"
 RDEPEND="${DEPEND}"
 

--- a/net-irc/irssi-xmpp/irssi-xmpp-0.53.ebuild
+++ b/net-irc/irssi-xmpp/irssi-xmpp-0.53.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="
-	>=net-irc/irssi-0.8.13
+	<net-irc/irssi-1
 	>=net-libs/loudmouth-1.4.0"
 
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Both net-irc/irssi-xmpp-0.53 and -0.52 are incompatible with >=net-irc/irssi-1.0.0 at least due to the renaming of use_ssl to use_tls in net-irc/irssi-1.0.0:
https://github.com/irssi/irssi/commit/2be7289085d6969e6774ce3909f0224b1d689f93


Gentoo-Bug: https://bugs.gentoo.org/604924
Package-Manager: portage-2.3.3