### PR TITLE
media-libs/opencollada: Remove expat support.

### DIFF
--- a/media-libs/opencollada/opencollada-1.6.36.ebuild
+++ b/media-libs/opencollada/opencollada-1.6.36.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 
 KEYWORDS="~amd64 ~ppc64 ~x86"
 
-IUSE="expat static-libs"
+IUSE="static-libs"
 
 # This is still needed to have so version numbers
 MY_SOVERSION="$(get_version_component_range 1-2)"
@@ -24,8 +24,7 @@ RDEPEND="dev-libs/libpcre
 	dev-libs/zziplib
 	media-libs/lib3ds
 	sys-libs/zlib
-	expat? ( dev-libs/expat )
-	!expat? ( dev-libs/libxml2 )"
+	dev-libs/libxml2"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
@@ -50,8 +49,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DUSE_SHARED=ON
 		-DUSE_STATIC=$(usex static-libs)
-		-DUSE_EXPAT=$(usex expat)
-		-DUSE_LIBXML=$(usex !expat)
+		-DUSE_LIBXML=ON
 		-Dsoversion=${MY_SOVERSION}
 	)
 


### PR DESCRIPTION
DAEValidator is set to replace COLLADAValidator. However, it only
supports libxml2 and not expat like COLLADAValidator did.

No need for revision bump as expat did not compile forcing users to
unset it.

Also, from upstream:
USE_EXPAT (OFF) - Use expat parser. Unsupported currently. Do not use.

Signed-off by: Jonathan Scruggs (j.scruggs@gmail.com)