### PR TITLE
x11-libs/libXfont{2,}: RDEPEND on sys-libs/zlib

### DIFF
--- a/x11-libs/libXfont/libXfont-1.4.9.ebuild
+++ b/x11-libs/libXfont/libXfont-1.4.9.ebuild
@@ -14,6 +14,7 @@ IUSE="bzip2 ipv6 truetype"
 
 RDEPEND="x11-libs/xtrans
 	x11-libs/libfontenc
+	sys-libs/zlib
 	truetype? ( >=media-libs/freetype-2 )
 	bzip2? ( app-arch/bzip2 )
 	x11-proto/xproto

--- a/x11-libs/libXfont/libXfont-1.5.1.ebuild
+++ b/x11-libs/libXfont/libXfont-1.5.1.ebuild
@@ -14,6 +14,7 @@ IUSE="bzip2 ipv6 truetype"
 
 RDEPEND="x11-libs/xtrans
 	x11-libs/libfontenc
+	sys-libs/zlib
 	truetype? ( >=media-libs/freetype-2 )
 	bzip2? ( app-arch/bzip2 )
 	x11-proto/xproto

--- a/x11-libs/libXfont/libXfont-1.5.2.ebuild
+++ b/x11-libs/libXfont/libXfont-1.5.2.ebuild
@@ -14,6 +14,7 @@ IUSE="bzip2 ipv6 truetype"
 
 RDEPEND="x11-libs/xtrans
 	x11-libs/libfontenc
+	sys-libs/zlib
 	truetype? ( >=media-libs/freetype-2 )
 	bzip2? ( app-arch/bzip2 )
 	x11-proto/xproto

--- a/x11-libs/libXfont2/libXfont2-2.0.1.ebuild
+++ b/x11-libs/libXfont2/libXfont2-2.0.1.ebuild
@@ -14,6 +14,7 @@ IUSE="bzip2 ipv6 truetype"
 
 RDEPEND="x11-libs/xtrans
 	x11-libs/libfontenc
+	sys-libs/zlib
 	truetype? ( >=media-libs/freetype-2 )
 	bzip2? ( app-arch/bzip2 )
 	x11-proto/xproto

--- a/x11-libs/libXfont2/libXfont2-9999.ebuild
+++ b/x11-libs/libXfont2/libXfont2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -15,6 +15,7 @@ IUSE="bzip2 ipv6 truetype"
 
 RDEPEND="x11-libs/xtrans
 	x11-libs/libfontenc
+	sys-libs/zlib
 	truetype? ( >=media-libs/freetype-2 )
 	bzip2? ( app-arch/bzip2 )
 	x11-proto/xproto


### PR DESCRIPTION
Gentoo bug: https://bugs.gentoo.org/545898
See: https://cgit.freedesktop.org/xorg/lib/libXfont/tree/configure.ac?id=libXfont2-2.0.1#n144
