### PR TITLE
x11-misc/xkeyboard-config: DEPEND on sys-devel/gettext

### DIFF
--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.14.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.14.ebuild
@@ -23,6 +23,7 @@ RDEPEND=">=x11-apps/xkbcomp-1.2.3
 	>=x11-libs/libX11-1.4.3"
 DEPEND="${RDEPEND}
 	dev-util/intltool
+	sys-devel/gettext
 	>=x11-proto/xproto-7.0.20"
 
 XORG_CONFIGURE_OPTIONS=(

--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.16.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.16.ebuild
@@ -23,6 +23,7 @@ RDEPEND=">=x11-apps/xkbcomp-1.2.3
 	>=x11-libs/libX11-1.4.3"
 DEPEND="${RDEPEND}
 	dev-util/intltool
+	sys-devel/gettext
 	>=x11-proto/xproto-7.0.20"
 
 XORG_CONFIGURE_OPTIONS=(

--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.17.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.17.ebuild
@@ -23,6 +23,7 @@ RDEPEND=">=x11-apps/xkbcomp-1.2.3
 	>=x11-libs/libX11-1.4.3"
 DEPEND="${RDEPEND}
 	dev-util/intltool
+	sys-devel/gettext
 	>=x11-proto/xproto-7.0.20"
 
 XORG_CONFIGURE_OPTIONS=(

--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.18.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.18.ebuild
@@ -23,6 +23,7 @@ RDEPEND="!<x11-apps/xkbcomp-1.2.3
 	!<x11-libs/libX11-1.4.3"
 DEPEND="${RDEPEND}
 	dev-util/intltool
+	sys-devel/gettext
 	>=x11-proto/xproto-7.0.20"
 
 XORG_CONFIGURE_OPTIONS=(

--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.19.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.19.ebuild
@@ -23,6 +23,7 @@ RDEPEND="!<x11-apps/xkbcomp-1.2.3
 	!<x11-libs/libX11-1.4.3"
 DEPEND="${RDEPEND}
 	dev-util/intltool
+	sys-devel/gettext
 	>=x11-proto/xproto-7.0.20"
 
 XORG_CONFIGURE_OPTIONS=(

--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.20.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.20.ebuild
@@ -23,6 +23,7 @@ RDEPEND="!<x11-apps/xkbcomp-1.2.3
 	!<x11-libs/libX11-1.4.3"
 DEPEND="${RDEPEND}
 	dev-util/intltool
+	sys-devel/gettext
 	>=x11-proto/xproto-7.0.20"
 
 XORG_CONFIGURE_OPTIONS=(


### PR DESCRIPTION
Gentoo bug: https://bugs.gentoo.org/326765
See: https://cgit.freedesktop.org/xkeyboard-config/tree/configure.ac?id=xkeyboard-config-2.20#n67

Package-Manager: Portage-2.3.3, Repoman-2.3.1