### PR TITLE
profiles: hardfloat arm profiles have CHOST set incorrectly

### DIFF
--- a/profiles/arch/arm/armv6j/make.defaults
+++ b/profiles/arch/arm/armv6j/make.defaults
@@ -1,4 +1,4 @@
-CHOST="armv6j-hardfloat-linux-gnueabi"
+CHOST="armv6j-unknown-linux-gnueabihf"
 CFLAGS="-O2 -pipe -march=armv6j"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"

--- a/profiles/arch/arm/armv7a/make.defaults
+++ b/profiles/arch/arm/armv7a/make.defaults
@@ -1,4 +1,4 @@
-CHOST="armv7a-hardfloat-linux-gnueabi"
+CHOST="armv7a-unknown-linux-gnueabihf"
 CFLAGS="-O2 -pipe -march=armv7-a"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"

--- a/profiles/default/linux/uclibc/arm/armv6j/make.defaults
+++ b/profiles/default/linux/uclibc/arm/armv6j/make.defaults
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation.
+# Copyright 1999-2017 Gentoo Foundation.
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-CHOST="armv6j-hardfloat-linux-uclibceabi"
+CHOST="armv6j-unknown-linux-uclibceabihf"
 CFLAGS="-O2 -pipe -march=armv6j -mfpu=vfp -mfloat-abi=hard"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"

--- a/profiles/default/linux/uclibc/arm/armv7a/make.defaults
+++ b/profiles/default/linux/uclibc/arm/armv7a/make.defaults
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation.
+# Copyright 1999-2017 Gentoo Foundation.
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-CHOST="armv7a-hardfloat-linux-uclibceabi"
+CHOST="armv7a-unknown-linux-uclibceabihf"
 CFLAGS="-O2 -pipe -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"

--- a/profiles/hardened/linux/musl/arm/armv7a/make.defaults
+++ b/profiles/hardened/linux/musl/arm/armv7a/make.defaults
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation.
+# Copyright 1999-2017 Gentoo Foundation.
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-CHOST="armv7a-hardfloat-linux-musleabi"
+CHOST="armv7a-unknown-linux-musleabihf"
 CFLAGS="-O2 -pipe -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"


### PR DESCRIPTION
Gentoo-bug: 602440, 602092, 595834

Currently our use of noncompliant CHOST triples causes various compatibility issues, the number of issues is likely to grow as more arm-specific code is written in various projects we package.

In my opinion there should probably be no news post and no effort to fix already running systems. Asking end users to change their CHOST would likely be disastrous. Not fixing running systems will mean though that we will continue to get bug reports for systems installed from stage3s prior to this commit, which would need to be wont-fixed based on their CHOST.

I think it's best to get this fixed ASAP since the number of arm installs is growing daily. Discussion welcome.