### PR TITLE
Add ~arm64 keyword after testing on cortex-a53

### DIFF
--- a/xfce-extra/xfce4-taskmanager/xfce4-taskmanager-1.1.0.ebuild
+++ b/xfce-extra/xfce4-taskmanager/xfce4-taskmanager-1.1.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://xfce/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="alpha amd64 arm ~arm64 ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="debug gksu gtk3"
 
 RDEPEND="x11-libs/cairo:=


### PR DESCRIPTION
Add ~arm64 keyword for xfce4-taskmanager. Tested on cortex-a53 (as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit)).