### PR TITLE
Unmask video_cards_vc4 for arm64, after testing on RPi3/cortex-a53

### DIFF
--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -154,6 +154,9 @@ slang
 tk
 vim-syntax
 
+# Unmask ARM-only video-cards
+-video_cards_vc4
+
 # 2006/02/05 - Donnie Berkholz <dberkholz@gentoo.org>
 # Modular X: mask for architectures on which they aren't available
 video_cards_apm


### PR DESCRIPTION
The `vc4` driver has been tested for at least basic usage under `arm64` on the cortex-a53 RPi3 as part of [this image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) ([vc4-fkms-v3d](https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=159853)).