### PR TITLE
media-video/ffmpeg: add ~arm64 keyword after testing on RPi3/cortex-a53

### DIFF
--- a/media-video/ffmpeg/ffmpeg-3.2.2.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.2.2.ebuild
@@ -55,7 +55,7 @@ LICENSE="
 	samba? ( GPL-3 )
 "
 if [ "${PV#9999}" = "${PV}" ] ; then
-	KEYWORDS="~amd64 ~mips ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux"
+	KEYWORDS="~amd64 ~arm64 ~mips ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux"
 fi
 
 # Options to use as use_enable in the foo[:bar] form.


### PR DESCRIPTION
Tested (in default `USE`-flag configuration) as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) for the RPi3.