### PR TITLE
profiles: unmask x264 for arm64 after testing media-libs/x264 on cortex-a53

### DIFF
--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -223,3 +223,6 @@ clvm
 # Chí-Thanh Christopher Nguyễn <chithanh@gentoo.org> (22 Aug 2013)
 # virtual/opencl is not keyworded
 opencl
+
+# media-libs/x264 works
+-x264


### PR DESCRIPTION
Tested as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) for the RPi3. See also #3800