### PR TITLE
xfce-extra/xfce4-mixer: add ~arm64 keyword (tested on RPi3/cortex-a53)

### DIFF
--- a/media-plugins/gst-plugins-alsa/gst-plugins-alsa-0.10.36-r1.ebuild
+++ b/media-plugins/gst-plugins-alsa/gst-plugins-alsa-0.10.36-r1.ebuild
@@ -7,7 +7,7 @@ EAPI="5"
 GST_ORG_MODULE=gst-plugins-base
 inherit gstreamer
 
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=media-libs/alsa-lib-1.0.27.2[${MULTILIB_USEDEP}]"

--- a/xfce-extra/xfce4-mixer/xfce4-mixer-4.11.0.ebuild
+++ b/xfce-extra/xfce4-mixer/xfce4-mixer-4.11.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://xfce/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm ~hppa ~mips ppc ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm ~arm64 ~hppa ~mips ppc ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="alsa debug +keybinder oss"
 
 COMMON_DEPEND=">=dev-libs/glib-2.24


### PR DESCRIPTION
Tested (in default `USE` flag configuration under a desktop profile) as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) for the RPi3.