### PR TITLE
xfce-extra/xfce4-alsa-plugin: add ~arm64 keyword (tested on cortex-a53)

### DIFF
--- a/xfce-extra/xfce4-alsa-plugin/xfce4-alsa-plugin-0.1.1.ebuild
+++ b/xfce-extra/xfce4-alsa-plugin/xfce4-alsa-plugin-0.1.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/equeim/${PN}/archive/0.1.1.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 RDEPEND="


### PR DESCRIPTION
Tested (in default `USE` flag configuration under a desktop profile) as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) for the RPi3.