### PR TITLE
mail-client/claws-mail: add ~arm64 keyword (tested on cortex-a53)

### DIFF
--- a/dev-libs/libdbusmenu/libdbusmenu-12.10.2-r2.ebuild
+++ b/dev-libs/libdbusmenu/libdbusmenu-12.10.2-r2.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://launchpad.net/${PN/lib}/${PV%.*}/${PV}/+download/${P}.tar.gz"
 
 LICENSE="LGPL-2.1 LGPL-3"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm ~arm64 hppa ~mips ppc ppc64 sparc x86"
 IUSE="debug gtk gtk3 +introspection"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/dev-libs/libindicate/libindicate-12.10.1-r2.ebuild
+++ b/dev-libs/libindicate/libindicate-12.10.1-r2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://launchpad.net/${PN}/${PV%.*}/${PV}/+download/${P}.tar.gz"
 
 LICENSE="LGPL-2.1 LGPL-3"
 SLOT="3"
-KEYWORDS="alpha amd64 ~arm hppa ~mips ppc ~ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm ~arm64 hppa ~mips ppc ~ppc64 sparc x86"
 IUSE="gtk +introspection"
 
 RESTRICT="test" # consequence of the -no-mono.patch

--- a/mail-client/claws-mail/claws-mail-3.14.1.ebuild
+++ b/mail-client/claws-mail/claws-mail-3.14.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
 
 SLOT="0"
 LICENSE="GPL-3"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
 
 IUSE="archive bogofilter calendar clamav dbus debug doc gdata +gnutls gtk3 +imap ipv6 ldap +libcanberra +libindicate +libnotify networkmanager nls nntp +notification pda pdf perl +pgp python rss session sieve smime spamassassin spam-report spell startup-notification valgrind webkit xface"
 REQUIRED_USE="libcanberra? ( notification )

--- a/media-libs/libcanberra/libcanberra-0.30-r5.ebuild
+++ b/media-libs/libcanberra/libcanberra-0.30-r5.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://0pointer.de/lennart/projects/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~sparc-solaris ~x86-solaris"
 IUSE="alsa gnome gstreamer +gtk +gtk3 oss pulseaudio +sound tdb udev"
 
 COMMON_DEPEND="

--- a/net-libs/libetpan/libetpan-1.7.2-r1.ebuild
+++ b/net-libs/libetpan/libetpan-1.7.2-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/dinhviethoa/${PN}/archive/${PV}.tar.gz -> ${P}.tar.g
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="berkdb debug gnutls ipv6 liblockfile libressl sasl ssl static-libs"
 
 DEPEND="berkdb? ( sys-libs/db:= )

--- a/x11-themes/sound-theme-freedesktop/sound-theme-freedesktop-0.8.ebuild
+++ b/x11-themes/sound-theme-freedesktop/sound-theme-freedesktop-0.8.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://people.freedesktop.org/~mccann/dist/${P}.tar.bz2"
 
 LICENSE="GPL-2 LGPL-2 CC-BY-3.0 CC-BY-SA-2.0"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x86-solaris"
 IUSE=""
 
 RDEPEND=""


### PR DESCRIPTION
Tested (in default `USE` flag configuration) as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) for the RPi3.