### PR TITLE
net-misc/chrony: add ~arm64 keyword (tested on RPi3/cortex-a53)

### DIFF
--- a/net-misc/chrony/chrony-3.1.ebuild
+++ b/net-misc/chrony/chrony-3.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://download.tuxfamily.org/${PN}/${P/_/-}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 
-KEYWORDS="~alpha ~amd64 ~hppa ~ppc64"
+KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ppc64"
 IUSE="caps +cmdmon html ipv6 libedit +ntp +phc pps readline +refclock +rtc selinux +adns"
 REQUIRED_USE="
 	?? ( libedit readline )


### PR DESCRIPTION
Tested (in default `USE` flag configuration) as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) for the RPi3.

> Actually, version on released image is v3.0, but I have built and tested the v3.1 on my own copy, and it also seems to work fine.