### PR TITLE
sys-process/iotop: add ~arm64 keyword (tested on cortex-a53)

### DIFF
--- a/sys-process/iotop/iotop-0.6.ebuild
+++ b/sys-process/iotop/iotop-0.6.ebuild
@@ -15,7 +15,7 @@ SRC_URI="http://guichaz.free.fr/iotop/files/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm hppa ~ia64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm ~arm64 hppa ~ia64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 CONFIG_CHECK="~TASK_IO_ACCOUNTING ~TASK_DELAY_ACCT ~TASKSTATS ~VM_EVENT_COUNTERS"


### PR DESCRIPTION
Tested (in default `USE` flag configuration) as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) for the RPi3.