### PR TITLE
kde-plasma/plasma-integration: fix missing dep on dev-qt/qtgui[dbus]

### DIFF
--- a/kde-plasma/plasma-integration/plasma-integration-5.9.0.ebuild
+++ b/kde-plasma/plasma-integration/plasma-integration-5.9.0.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 	$(add_frameworks_dep kxmlgui)
 	$(add_plasma_dep breeze)
 	$(add_qt_dep qtdbus)
-	$(add_qt_dep qtgui '' '' '5=')
+	$(add_qt_dep qtgui 'dbus' '' '5=')
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtx11extras)
 	x11-libs/libXcursor


### PR DESCRIPTION
Hi, 

kde-plasma/plasma-integration doesn't build if dev-qt/qtgui isn't build with dbus support.
This fixes bug #608306.
Please review.