### PR TITLE
x11-misc/driconf: Bump eapi, use newer python eclass, fix QA issues

### DIFF
--- a/x11-misc/driconf/driconf-0.9.1-r2.ebuild
+++ b/x11-misc/driconf/driconf-0.9.1-r2.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="xml"
+
+inherit distutils-r1 eutils
+
+DESCRIPTION="driconf is a GTK+2 GUI configurator for DRI"
+HOMEPAGE="https://dri.freedesktop.org/wiki/DriConf"
+SRC_URI="https://freedesktop.org/~fxkuehl/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE=""
+
+RDEPEND="x11-libs/gtk+:2
+	dev-python/pygtk:2[${PYTHON_USEDEP}]
+	x11-apps/xdriinfo"
+DEPEND="${RDEPEND}"
+
+DOCS="CHANGELOG COPYING PKG-INFO README TODO"
+
+PATCHES=( "${FILESDIR}"/${P}-glxinfo-unicode.patch
+	"${FILESDIR}"/${P}-update-toolbar-methods.patch
+	"${FILESDIR}"/${P}-driconf_simpleui.py.patch
+	"${FILESDIR}"/${P}-desktop-menu.patch
+	"${FILESDIR}"/${P}-drop-old-tooltips.patch
+)
+
+python_prepare_all() {
+	distutils-r1_python_prepare_all
+
+	# Fix install locations which breaks location policy - Josh_B
+	sed -i \
+		-e 's-/usr/local-/usr-g' \
+		driconf \
+		driconf.desktop \
+		driconf.py \
+		setup.cfg \
+		setup.py \
+		|| die "Sed failed!"
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+	domenu driconf.desktop
+}

--- a/x11-misc/driconf/files/driconf-0.9.1-desktop-menu.patch
+++ b/x11-misc/driconf/files/driconf-0.9.1-desktop-menu.patch
@@ -1,0 +1,9 @@
+--- a/driconf.desktop	2006-09-18 04:41:45.000000000 +0300
++++ b/driconf.desktop	2017-02-05 13:14:11.319444931 +0200
+@@ -5,5 +5,5 @@
+ Exec=driconf
+ Icon=/usr/local/share/driconf/driconf-icon.png
+ Type=Application
+-Categories=GNOME;Application;Settings;AdvancedSettings;
++Categories=GNOME;Settings;HardwareSettings;
+ StartupNotify=true

--- a/x11-misc/driconf/files/driconf-0.9.1-driconf_simpleui.py.patch
+++ b/x11-misc/driconf/files/driconf-0.9.1-driconf_simpleui.py.patch
@@ -1,7 +1,7 @@
 http://cvs.fedoraproject.org/viewvc/rpms/driconf/devel/
 
---- driconf_simpleui.py
-+++ driconf_simpleui.py
+--- a/driconf_simpleui.py
++++ b/driconf_simpleui.py
 @@ -266,8 +266,8 @@
                      j = i
                      break

--- a/x11-misc/driconf/files/driconf-0.9.1-drop-old-tooltips.patch
+++ b/x11-misc/driconf/files/driconf-0.9.1-drop-old-tooltips.patch
@@ -1,0 +1,61 @@
+diff -ur driconf-0.9.1-old/driconf_commonui.py driconf-0.9.1/driconf_commonui.py
+--- a/driconf_commonui.py	2006-09-18 04:03:43.000000000 +0200
++++ b/driconf_commonui.py	2011-01-09 21:09:43.000000000 +0100
+@@ -299,8 +299,7 @@
+             self.label.set_active (page.app.options.has_key (opt.name))
+             self.label.set_sensitive (page.app.device.config.writable)
+             self.label.connect ("clicked", self.checkOpt)
+-        tooltipString = str(opt)
+-        page.tooltips.set_tip (self.label, tooltipString)
++        self.label.set_tooltip_text (str(opt))
+         self.label.show()
+         page.table.attach (self.label, 0, 1, i, i+1,
+                            gtk.EXPAND|gtk.FILL, 0, 5, 5)
+@@ -316,10 +315,10 @@
+         self.resetButton.set_relief (gtk.RELIEF_NONE)
+         self.resetButton.set_sensitive (sensitive)
+         if removable:
+-            page.tooltips.set_tip(self.resetButton, _("Remove"))
++            self.resetButton.set_tooltip_text(_("Remove"))
+             self.resetButton.connect ("clicked", self.removeOpt)
+         else:
+-            page.tooltips.set_tip(self.resetButton, _("Reset to default value"))
++            self.resetButton.set_tooltip_text(_("Reset to default value"))
+             self.resetButton.connect ("clicked", self.resetOpt)
+         self.resetButton.show()
+         page.table.attach (self.resetButton, 2, 3, i, i+1, 0, 0, 5, 5)
+@@ -510,7 +509,6 @@
+         self.optSection = optSection
+         self.app = app
+         self.simple = simple
+-        self.tooltips = gtk.Tooltips()
+         self.table = gtk.Table (len(optSection.optList), 3)
+         self.optLines = []
+         for i in range (len(optSection.optList)):
+diff -ur driconf-0.9.1-old/driconf_complexui.py driconf-0.9.1/driconf_complexui.py
+--- a/driconf_complexui.py	2006-09-18 02:53:44.000000000 +0200
++++ b/driconf_complexui.py	2011-01-09 21:10:29.000000000 +0100
+@@ -41,11 +41,10 @@
+         self.set_label_widget (frameLabel)
+         self.driver = driver
+         self.app = app
+-        tooltips = gtk.Tooltips()
+         table = gtk.Table(2, 2)
+         self.execCheck = WrappingCheckButton (_("Apply only to this executable"))
+         self.execCheck.set_sensitive (app.device.config.writable)
+-        tooltips.set_tip (self.execCheck, _(
++        self.execCheck.set_tooltip_text (_(
+             "Leave this disabled to configure all applications.\n"
+             "Beware that some applications or games are just a shell script "
+             "that starts a real executable with a different name."))
+diff -ur driconf-0.9.1-old/driconf_simpleui.py driconf-0.9.1/driconf_simpleui.py
+--- a/driconf_simpleui.py	2006-09-18 02:49:54.000000000 +0200
++++ b/driconf_simpleui.py	2011-01-09 21:10:51.000000000 +0100
+@@ -342,7 +342,6 @@
+         self.set_policy (gtk.POLICY_NEVER, gtk.POLICY_AUTOMATIC)
+         self.driver = driver
+         self.app = app
+-        self.tooltips = gtk.Tooltips()
+         self.table = None
+         self.refreshOptions()
+ 

--- a/x11-misc/driconf/files/driconf-0.9.1-glxinfo-unicode.patch
+++ b/x11-misc/driconf/files/driconf-0.9.1-glxinfo-unicode.patch
@@ -1,7 +1,7 @@
 http://cvs.fedoraproject.org/viewvc/rpms/driconf/devel/
 
---- driconf_simpleui.py
-+++ driconf_simpleui.py
+--- a/driconf_simpleui.py
++++ b/driconf_simpleui.py
 @@ -450,11 +450,13 @@ class MainWindow (gtk.Window):
          else:
              screen = self.screens[0]

--- a/x11-misc/driconf/files/driconf-0.9.1-update-toolbar-methods.patch
+++ b/x11-misc/driconf/files/driconf-0.9.1-update-toolbar-methods.patch
@@ -1,7 +1,7 @@
 http://cvs.fedoraproject.org/viewvc/rpms/driconf/devel/
 
---- driconf_complexui.py
-+++ driconf_complexui.py
+--- a/driconf_complexui.py
++++ b/driconf_complexui.py
 @@ -838,42 +838,73 @@ class MainWindow (gtk.Window):
          self.paned.show()
          self.toolbar = gtk.Toolbar ()


### PR DESCRIPTION
Gentoo bug: https://bugs.gentoo.org/show_bug.cgi?id=352016

I noticed that SRC_URI is not alive anymore. What should be done about it?