### PR TITLE
x11-misc/pypanel: EAPI bump 3 -> 6, port to new python eclasses

### DIFF
--- a/x11-misc/pypanel/pypanel-2.4-r2.ebuild
+++ b/x11-misc/pypanel/pypanel-2.4-r2.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit distutils-r1
+
+MY_PN=${PN/pyp/PyP}
+MY_P=${MY_PN}-${PV}
+
+DESCRIPTION="A lightweight panel/taskbar for X11 window managers"
+HOMEPAGE="http://pypanel.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE=""
+
+RDEPEND="x11-libs/libXft
+	dev-python/python-xlib[${PYTHON_USEDEP}]
+	media-libs/imlib2[X]"
+DEPEND="${RDEPEND}"
+
+S=${WORKDIR}/${MY_P}


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/599778

Package-Manager: Portage-2.3.3, Repoman-2.3.1