### PR TITLE
xfce-extra/thunar-volman: add ~arm64 keyword (tested on cortex-a53)

### DIFF
--- a/xfce-extra/thunar-volman/thunar-volman-0.8.1.ebuild
+++ b/xfce-extra/thunar-volman/thunar-volman-0.8.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://xfce/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm ~arm64 ia64 ppc ppc64 sparc x86"
 IUSE="debug libnotify"
 
 COMMON_DEPEND=">=dev-libs/glib-2.30


### PR DESCRIPTION
Tested (in default `USE` flag configuration) as part of [this bootable Gentoo image](https://github.com/sakaki-/gentoo-on-rpi3-64bit) for the RPi3.