### PR TITLE
virtual/bitcoin-leveldb: correct the || deps order

### DIFF
--- a/virtual/bitcoin-leveldb/bitcoin-leveldb-0-r1.ebuild
+++ b/virtual/bitcoin-leveldb/bitcoin-leveldb-0-r1.ebuild
@@ -15,8 +15,8 @@ KEYWORDS="amd64 arm arm64 ~ppc ~ppc64 x86 amd64-linux x86-linux"
 DEPEND=""
 RDEPEND="
 	|| (
-		=dev-libs/leveldb-1.15.0-r1
-		=dev-libs/leveldb-1.17
-		=dev-libs/leveldb-1.18
 		=dev-libs/leveldb-1.18-r1
+		=dev-libs/leveldb-1.18
+		=dev-libs/leveldb-1.17
+		=dev-libs/leveldb-1.15.0-r1
 	)"


### PR DESCRIPTION
so the newer versions of leveldb are prefered