### PR TITLE
x11-misc/wdm: EAPI bump 2 -> 6, fix #554672

### DIFF
--- a/x11-misc/wdm/files/wdm-1.28-remove-fakehome.patch
+++ b/x11-misc/wdm/files/wdm-1.28-remove-fakehome.patch
@@ -1,0 +1,12 @@
+Do not create /var/run/wdm
+Fixes https://bugs.gentoo.org/554672
+--- a/Makefile.in	2005-03-26 15:57:04.000000000 +0200
++++ b/Makefile.in	2017-02-06 18:57:16.196004491 +0200
+@@ -83,7 +83,6 @@
+ all-config: configs/Xclients configs/Xservers configs/Xservers.ws configs/Xsession configs/Xsetup_0 configs/wdm-config configs/wdmReconfig
+ 
+ install-config: $(DESTDIR)$(DMDIR)/GiveConsole $(DESTDIR)$(DMDIR)/TakeConsole $(DESTDIR)$(DMDIR)/Xaccess $(DESTDIR)$(DMDIR)/Xresources $(DESTDIR)$(DMDIR)/Xservers.fs $(DESTDIR)$(DMDIR)/Xsession.XFree86 $(DESTDIR)$(DMDIR)/Xsession.orig $(DESTDIR)$(DMDIR)/Xclients $(DESTDIR)$(DMDIR)/Xservers $(DESTDIR)$(DMDIR)/Xservers.ws $(DESTDIR)$(DMDIR)/Xsession $(DESTDIR)$(DMDIR)/Xsetup_0 $(DESTDIR)$(DMDIR)/wdm-config $(DESTDIR)$(DMDIR)/wdmReconfig $(DESTDIR)$(DMDIR)/wdm-config.in $(DESTDIR)$(DMDIR)/Xclients.in install-pam-$(USE_PAM) $(DESTDIR)$(DMDIR)/authdir
+-	install -d -m 0700 $(DESTDIR)$(FAKEHOME)
+ 
+ install-pam-no:
+ 

--- a/x11-misc/wdm/files/wdm-1.28-terminateServer.patch
+++ b/x11-misc/wdm/files/wdm-1.28-terminateServer.patch
@@ -1,7 +1,7 @@
-http://bugs.gentoo.org/290034
+https://bugs.gentoo.org/290034
 
---- configs/wdm-config.in
-+++ configs/wdm-config.in
+--- a/configs/wdm-config.in
++++ b/configs/wdm-config.in
 @@ -21,6 +21,7 @@
  DisplayManager*session:         @DMDIR@/Xsession
  DisplayManager*authComplain:    false

--- a/x11-misc/wdm/wdm-1.28-r4.ebuild
+++ b/x11-misc/wdm/wdm-1.28-r4.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit pam
+
+DESCRIPTION="WINGs Display Manager"
+HOMEPAGE="https://github.com/voins/wdm"
+SRC_URI="http://voins.program.ru/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="pam selinux truetype"
+
+COMMON_DEPEND=">=x11-wm/windowmaker-0.70.0
+	truetype? ( x11-libs/libXft )
+	x11-libs/libXmu
+	x11-libs/libXt
+	x11-libs/libXpm
+	pam? ( virtual/pam )"
+DEPEND="${COMMON_DEPEND}
+	sys-devel/gettext"
+RDEPEND="${COMMON_DEPEND}
+	pam? ( >=sys-auth/pambase-20080219.1 )"
+
+PATCHES=( "${FILESDIR}"/${P}-terminateServer.patch
+	"${FILESDIR}"/${P}-remove-fakehome.patch
+)
+
+src_configure() {
+	econf \
+		--with-wdmdir=/etc/X11/wdm \
+		$(use_enable pam) \
+		$(use_enable selinux)
+}
+
+src_install() {
+	default
+	rm -f "${D}"/etc/pam.d/wdm || die
+	pamd_mimic system-local-login wdm auth account password session
+}


### PR DESCRIPTION
Fixes following QA issue, Gentoo-bug: #554672
QA Notice: This ebuild installs into paths that should be created at runtime.
 To fix, simply do not install into these directories.  Instead, your package
 should create dirs on the fly at runtime as needed via init scripts/etc...

    var/run
    var/run/wdm

Package-Manager: Portage-2.3.3, Repoman-2.3.1