### PR TITLE
media-sound/mpg123: depend on virtual/jack and drop old libtool depend

### DIFF
--- a/media-sound/mpg123/mpg123-1.18.1.ebuild
+++ b/media-sound/mpg123/mpg123-1.18.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -18,7 +18,7 @@ IUSE="cpu_flags_x86_3dnow cpu_flags_x86_3dnowext alsa altivec coreaudio int-qual
 RDEPEND="app-eselect/eselect-mpg123
 	>=sys-devel/libtool-2.2.6b
 	alsa? ( media-libs/alsa-lib )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	nas? ( media-libs/nas )
 	portaudio? ( media-libs/portaudio )
 	pulseaudio? ( media-sound/pulseaudio )

--- a/media-sound/mpg123/mpg123-1.22.4.ebuild
+++ b/media-sound/mpg123/mpg123-1.22.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -16,9 +16,9 @@ IUSE="cpu_flags_x86_3dnow cpu_flags_x86_3dnowext alsa altivec coreaudio int-qual
 
 # No MULTILIB_USEDEP here since we only build libmpg123 for non native ABIs.
 RDEPEND="app-eselect/eselect-mpg123
-	|| ( dev-libs/libltdl:0 <sys-devel/libtool-2.4.3-r2:2 )
+	dev-libs/libltdl:0
 	alsa? ( media-libs/alsa-lib )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	nas? ( media-libs/nas )
 	portaudio? ( media-libs/portaudio )
 	pulseaudio? ( media-sound/pulseaudio )

--- a/media-sound/mpg123/mpg123-1.23.6.ebuild
+++ b/media-sound/mpg123/mpg123-1.23.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -16,9 +16,9 @@ IUSE="cpu_flags_x86_3dnow cpu_flags_x86_3dnowext alsa altivec coreaudio int-qual
 
 # No MULTILIB_USEDEP here since we only build libmpg123 for non native ABIs.
 RDEPEND="app-eselect/eselect-mpg123
-	|| ( dev-libs/libltdl:0 <sys-devel/libtool-2.4.3-r2:2 )
+	dev-libs/libltdl:0
 	alsa? ( media-libs/alsa-lib )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	nas? ( media-libs/nas )
 	portaudio? ( media-libs/portaudio )
 	pulseaudio? ( media-sound/pulseaudio )

--- a/media-sound/mpg123/mpg123-1.23.7.ebuild
+++ b/media-sound/mpg123/mpg123-1.23.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -16,9 +16,9 @@ IUSE="cpu_flags_x86_3dnow cpu_flags_x86_3dnowext alsa altivec coreaudio int-qual
 
 # No MULTILIB_USEDEP here since we only build libmpg123 for non native ABIs.
 RDEPEND="app-eselect/eselect-mpg123
-	|| ( dev-libs/libltdl:0 <sys-devel/libtool-2.4.3-r2:2 )
+	dev-libs/libltdl:0
 	alsa? ( media-libs/alsa-lib )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	nas? ( media-libs/nas )
 	portaudio? ( media-libs/portaudio )
 	pulseaudio? ( media-sound/pulseaudio )

--- a/media-sound/mpg123/mpg123-1.23.8.ebuild
+++ b/media-sound/mpg123/mpg123-1.23.8.ebuild
@@ -16,9 +16,9 @@ IUSE="cpu_flags_x86_3dnow cpu_flags_x86_3dnowext alsa altivec coreaudio int-qual
 
 # No MULTILIB_USEDEP here since we only build libmpg123 for non native ABIs.
 RDEPEND="app-eselect/eselect-mpg123
-	|| ( dev-libs/libltdl:0 <sys-devel/libtool-2.4.3-r2:2 )
+	dev-libs/libltdl:0
 	alsa? ( media-libs/alsa-lib )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	nas? ( media-libs/nas )
 	portaudio? ( media-libs/portaudio )
 	pulseaudio? ( media-sound/pulseaudio )


### PR DESCRIPTION
This fixes bug #608390. I also did a repoman payment by removing the dependency on old (non-existing) libtool.