### PR TITLE
x11-misc/dsx: EAPI bump 2 -> 6, migrate to python-r1

### DIFF
--- a/x11-misc/dsx/dsx-0.1-r1.ebuild
+++ b/x11-misc/dsx/dsx-0.1-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 )
+inherit python-single-r1
+
+DESCRIPTION="command line selection of your X desktop environment"
+HOMEPAGE="https://www.gentoo.org/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+DEPEND="${PYTHON_DEPS}"
+RDEPEND="${DEPEND}
+	x11-apps/xinit"
+
+S="${WORKDIR}"
+
+src_prepare() {
+	cp "${FILESDIR}/${P}" "${PN}" || die
+	default
+}
+
+src_install() {
+	python_doscript "${WORKDIR}/${PN}"
+}


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/show_bug.cgi?id=599800
Package-Manager: Portage-2.3.3, Repoman-2.3.1