### PR TITLE
x11-misc/tintwizard: EAPI bump 3 -> 6, migrate to python-r1

### DIFF
--- a/x11-misc/tintwizard/tintwizard-0.3.4-r2.ebuild
+++ b/x11-misc/tintwizard/tintwizard-0.3.4-r2.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 )
+
+inherit python-single-r1
+
+DESCRIPTION="GUI wizard which generates config files for tint2 panels"
+HOMEPAGE="https://github.com/vanadey/tintwizard/"
+SRC_URI="https://tintwizard.googlecode.com/files/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+DEPEND="${PYTHON_DEPS}"
+RDEPEND="${DEPEND}
+	x11-misc/tint2
+	dev-python/pygtk:2[${PYTHON_USEDEP}]"
+
+S="${WORKDIR}"
+
+src_install() {
+	python_newscript tintwizard.py tintwizard
+	einstalldocs
+}


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=599800
Package-Manager: Portage-2.3.3, Repoman-2.3.1