### PR TITLE
x11-themes/light-themes: fix ubuntu themes

### DIFF
--- a/x11-themes/light-themes/light-themes-17.04_p20161205.ebuild
+++ b/x11-themes/light-themes/light-themes-17.04_p20161205.ebuild
@@ -31,6 +31,7 @@ S="${WORKDIR}"
 src_prepare() {
 	cp -r Ambiance/ Ambiance-Gentoo || die
 	cp -r Radiance/ Radiance-Gentoo || die
+	ln -sfT ../../Ambiance-Gentoo/gtk-3.0/assets Radiance-Gentoo/gtk-3.0/assets || die
 	sed -i -e 's/Ambiance/Ambiance-Gentoo/g' Ambiance-Gentoo/index.theme \
 		Ambiance-Gentoo/metacity-1/metacity-theme-1.xml || die
 	sed -i -e 's/Radiance/Radiance-Gentoo/g' Radiance-Gentoo/index.theme \


### PR DESCRIPTION
The 'Radiance-Gentoo/gtk-3.0/assets' symlink points to '../../Ambiance/gtk-3.0/assets',
which causes gtk3 buttons to have purple shadows even with the orange-colored themes.