### PR TITLE
Apply libquicktime-1.2.4-ffmpeg29.patch when building libquicktime-1.2.4 against >=media-video/libav-12

### DIFF
--- a/media-libs/libquicktime/libquicktime-1.2.4-r1.ebuild
+++ b/media-libs/libquicktime/libquicktime-1.2.4-r1.ebuild
@@ -53,7 +53,10 @@ DOCS="ChangeLog README TODO"
 src_prepare() {
 	epatch "${FILESDIR}"/${P}+libav-9.patch \
 		"${FILESDIR}"/${P}-ffmpeg2.patch
-	has_version '>=media-video/ffmpeg-2.9' && epatch "${FILESDIR}"/${P}-ffmpeg29.patch
+	if has_version '>=media-video/ffmpeg-2.9' ||
+		has_version '>=media-video/libav-12'; then
+		epatch "${FILESDIR}"/${P}-ffmpeg29.patch
+	fi
 
 	for FILE in lqt_ffmpeg.c video.c audio.c ; do
 		sed -i -e "s:CODEC_ID_:AV_&:g" "${S}/plugins/ffmpeg/${FILE}" || die


### PR DESCRIPTION
See https://bugs.gentoo.org/show_bug.cgi?id=609186