### PR TITLE
Use TLS encrypted git checkouts where possible

### DIFF
--- a/app-admin/pass/pass-9999.ebuild
+++ b/app-admin/pass/pass-9999.ebuild
@@ -8,7 +8,7 @@ inherit bash-completion-r1 git-2 elisp-common
 
 DESCRIPTION="Stores, retrieves, generates, and synchronizes passwords securely using gpg, pwgen, and git"
 HOMEPAGE="http://www.passwordstore.org/"
-EGIT_REPO_URI="http://git.zx2c4.com/password-store"
+EGIT_REPO_URI="https://git.zx2c4.com/password-store"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-libs/freetype/freetype-9999.ebuild
+++ b/media-libs/freetype/freetype-9999.ebuild
@@ -57,10 +57,10 @@ PATCHES=(
 src_fetch() {
 	if [[ "${PV}" = 9999 ]] ; then
 		local EGIT_REPO_URI
-		EGIT_REPO_URI="http://git.savannah.gnu.org/r/freetype/freetype2.git"
+		EGIT_REPO_URI="https://git.savannah.gnu.org/r/freetype/freetype2.git"
 		git-r3_src_fetch
 		if use utils ; then
-			EGIT_REPO_URI="http://git.savannah.gnu.org/r/freetype/freetype2-demos.git"
+			EGIT_REPO_URI="https://git.savannah.gnu.org/r/freetype/freetype2-demos.git"
 			git-r3_src_fetch
 		fi
 	else

--- a/media-sound/ardour/ardour-9999.ebuild
+++ b/media-sound/ardour/ardour-9999.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Digital Audio Workstation"
 HOMEPAGE="http://ardour.org/"
 
 if [[ ${PV} == *9999* ]]; then
-	EGIT_REPO_URI="http://git.ardour.org/ardour/ardour.git"
+	EGIT_REPO_URI="git://git.ardour.org/ardour/ardour.git"
 	inherit git-r3
 else
 	KEYWORDS="~amd64 ~x86"

--- a/sys-libs/suacomp/suacomp-9999.ebuild
+++ b/sys-libs/suacomp/suacomp-9999.ebuild
@@ -8,7 +8,7 @@ inherit toolchain-funcs flag-o-matic git-2
 
 DESCRIPTION="library wrapping the interix lib-c to make it less buggy"
 HOMEPAGE="http://suacomp.sf.net"
-EGIT_REPO_URI="http://git.code.sf.net/p/suacomp/git"
+EGIT_REPO_URI="https://git.code.sf.net/p/suacomp/git"
 
 LICENSE="BEER-WARE"
 SLOT="0"


### PR DESCRIPTION
Whilst cleaning up some data obtained from the Gentoo package repository for use with Wikidata, I checked the few remaining uses of the http:// protocol for checking out source code. In some of these cases, upstream developers have enabled a https:// protocol alternative which is more secure.