### PR TITLE
sys-devel/clang-runtime: reslot and make it a suitable DEP for packages needing clang+compiler-rt

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -256,27 +256,6 @@ x11-drivers/xf86-video-ivtv
 # Bug #606132
 x11-drivers/xf86-video-v4l
 
-# Michał Górny <mgorny@gentoo.org> (24 Jan 2017)
-# Mask 4.0.0 RCs (then final) for initial testing, and updating most
-# important revdeps. Also revdeps that require 4.0.
-=app-vim/llvm-vim-4.0.0*
-=dev-ml/llvm-ocaml-4.0.0*
-=dev-python/clang-python-4.0.0*
-=dev-python/lit-4.0.0*
-=dev-util/lldb-4.0.0*
-=sys-devel/clang-4.0.0*
-=sys-devel/clang-runtime-4.0.0*
-=sys-devel/lld-4.0.0*
-=sys-devel/llvm-4.0.0*
-=sys-devel/llvmgold-4
-=sys-libs/compiler-rt-4.0.0*
-=sys-libs/compiler-rt-sanitizers-4.0.0*
-=sys-libs/libcxx-4.0.0*
-=sys-libs/libcxxabi-4.0.0*
-=sys-libs/libomp-4.0.0*
-=sys-libs/llvm-libunwind-4.0.0*
->=dev-libs/libclc-0.2.0_pre20170118
-
 # Matt Turner <mattst88@gentoo.org> (24 Jan 2017)
 # Depends on xorg-server-1.16, which is going away. Unresolved security bug
 # #602764. Maintainer no longer interested in package. Masked for removal in 30

--- a/sys-devel/clang-runtime/clang-runtime-3.9.0.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-3.9.0.ebuild
@@ -17,5 +17,6 @@ IUSE="libcxx openmp"
 
 # compiler-rt is installed unconditionally
 RDEPEND="
+	~sys-devel/clang-${PV}
 	libcxx? ( >=sys-libs/libcxx-${PV}[${MULTILIB_USEDEP}] )
 	openmp? ( >=sys-libs/libomp-${PV}[${MULTILIB_USEDEP}] )"

--- a/sys-devel/clang-runtime/clang-runtime-3.9.1.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-3.9.1.ebuild
@@ -17,5 +17,6 @@ IUSE="libcxx openmp"
 
 # compiler-rt is installed unconditionally
 RDEPEND="
+	~sys-devel/clang-${PV}
 	libcxx? ( >=sys-libs/libcxx-${PV}[${MULTILIB_USEDEP}] )
 	openmp? ( >=sys-libs/libomp-${PV}[${MULTILIB_USEDEP}] )"

--- a/sys-devel/clang-runtime/clang-runtime-4.0.0_rc2.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-4.0.0_rc2.ebuild
@@ -6,19 +6,20 @@ EAPI=6
 
 inherit multilib-build
 
+CLANG_PV=${PV%_*}
 DESCRIPTION="Meta-ebuild for clang runtime libraries"
 HOMEPAGE="http://clang.llvm.org/"
 SRC_URI=""
 
 LICENSE="metapackage"
-SLOT="${PV%_*}"
+SLOT="${CLANG_PV%%.*}"
 KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+compiler-rt libcxx openmp +sanitize"
 
 RDEPEND="
 	compiler-rt? (
-		~sys-libs/compiler-rt-${PV}:${SLOT}
-		sanitize? ( ~sys-libs/compiler-rt-sanitizers-${PV}:${SLOT} )
+		~sys-libs/compiler-rt-${PV}:${CLANG_PV}
+		sanitize? ( ~sys-libs/compiler-rt-sanitizers-${PV}:${CLANG_PV} )
 	)
 	libcxx? ( >=sys-libs/libcxx-${PV}[${MULTILIB_USEDEP}] )
 	openmp? ( >=sys-libs/libomp-${PV}[${MULTILIB_USEDEP}] )"

--- a/sys-devel/clang-runtime/clang-runtime-4.0.0_rc2.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-4.0.0_rc2.ebuild
@@ -17,6 +17,7 @@ KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+compiler-rt libcxx openmp +sanitize"
 
 RDEPEND="
+	~sys-devel/clang-${PV}:${SLOT}
 	compiler-rt? (
 		~sys-libs/compiler-rt-${PV}:${CLANG_PV}
 		sanitize? ( ~sys-libs/compiler-rt-sanitizers-${PV}:${CLANG_PV} )

--- a/sys-devel/clang-runtime/clang-runtime-9999.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-9999.ebuild
@@ -6,20 +6,21 @@ EAPI=6
 
 inherit multilib-build
 
+# Note: keep it matching clang-9999 version
+CLANG_PV=5.0.0
 DESCRIPTION="Meta-ebuild for clang runtime libraries"
 HOMEPAGE="http://clang.llvm.org/"
 SRC_URI=""
 
 LICENSE="metapackage"
-# Note: keep it matching clang-9999 version
-SLOT="5.0.0"
+SLOT="${CLANG_PV%%.*}"
 KEYWORDS=""
 IUSE="+compiler-rt libcxx openmp +sanitize"
 
 RDEPEND="
 	compiler-rt? (
-		~sys-libs/compiler-rt-${PV}:${SLOT}
-		sanitize? ( ~sys-libs/compiler-rt-sanitizers-${PV}:${SLOT} )
+		~sys-libs/compiler-rt-${PV}:${CLANG_PV}
+		sanitize? ( ~sys-libs/compiler-rt-sanitizers-${PV}:${CLANG_PV} )
 	)
 	libcxx? ( >=sys-libs/libcxx-${PV}[${MULTILIB_USEDEP}] )
 	openmp? ( >=sys-libs/libomp-${PV}[${MULTILIB_USEDEP}] )"

--- a/sys-devel/clang-runtime/clang-runtime-9999.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-9999.ebuild
@@ -18,6 +18,7 @@ KEYWORDS=""
 IUSE="+compiler-rt libcxx openmp +sanitize"
 
 RDEPEND="
+	~sys-devel/clang-${PV}:${SLOT}
 	compiler-rt? (
 		~sys-libs/compiler-rt-${PV}:${CLANG_PV}
 		sanitize? ( ~sys-libs/compiler-rt-sanitizers-${PV}:${CLANG_PV} )

--- a/sys-libs/libomp/libomp-4.0.0_rc2.ebuild
+++ b/sys-libs/libomp/libomp-4.0.0_rc2.ebuild
@@ -28,13 +28,13 @@ RDEPEND="hwloc? ( sys-apps/hwloc:0=[${MULTILIB_USEDEP}] )"
 # tests:
 # - dev-python/lit provides the test runner
 # - sys-devel/llvm provide test utils (e.g. FileCheck)
-# - sys-devel/clang provides the compiler to run tests
+# - sys-devel/clang-runtime pulls the compiler to run tests
 DEPEND="${RDEPEND}
 	dev-lang/perl
 	test? (
 		$(python_gen_any_dep 'dev-python/lit[${PYTHON_USEDEP}]')
 		sys-devel/llvm
-		>=sys-devel/clang-3.9.0
+		sys-devel/clang-runtime[compiler-rt]
 	)"
 
 S=${WORKDIR}/openmp-${PV/_/}.src
@@ -60,6 +60,7 @@ multilib_src_configure() {
 		-DLIBOMP_INSTALL_ALIASES=OFF
 		# disable unnecessary hack copying stuff back to srcdir
 		-DLIBOMP_COPY_EXPORTS=OFF
+		# use compiler-rt since clang does not link libatomic for libgcc
 		-DLIBOMP_TEST_COMPILER="$(type -P "${CHOST}-clang")"
 	)
 	cmake-utils_src_configure

--- a/sys-libs/libomp/libomp-9999.ebuild
+++ b/sys-libs/libomp/libomp-9999.ebuild
@@ -30,13 +30,13 @@ RDEPEND="hwloc? ( sys-apps/hwloc:0=[${MULTILIB_USEDEP}] )"
 # tests:
 # - dev-python/lit provides the test runner
 # - sys-devel/llvm provide test utils (e.g. FileCheck)
-# - sys-devel/clang provides the compiler to run tests
+# - sys-devel/clang-runtime pulls the compiler to run tests
 DEPEND="${RDEPEND}
 	dev-lang/perl
 	test? (
 		$(python_gen_any_dep 'dev-python/lit[${PYTHON_USEDEP}]')
 		sys-devel/llvm
-		>=sys-devel/clang-3.9.0
+		sys-devel/clang-runtime[compiler-rt]
 	)"
 
 # least intrusive of all
@@ -61,7 +61,8 @@ multilib_src_configure() {
 		-DLIBOMP_INSTALL_ALIASES=OFF
 		# disable unnecessary hack copying stuff back to srcdir
 		-DLIBOMP_COPY_EXPORTS=OFF
-		-DLIBOMP_TEST_COMPILER="$(type -P "${CHOST}-clang")"
+		# use compiler-rt since clang does not link libatomic for libgcc
+		-DLIBOMP_TEST_COMPILER="$(type -P "${CHOST}-clang") -rtlib=compiler-rt"
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
Long story short:
* make sys-devel/clang-runtime less slotted (like clang),
* add RDEP on sys-devel/clang to it,
* make sys-libs/libomp DEPEND on sys-devel/clang-runtime[compiler-rt] -- to get matching compiler and runtime.

This ain't perfect but I think the only reasonable alternative is to have in libomp:

```
DEPEND="
  || (
    ( ~clang-9999 ~compiler-rt-9999 )
    ...
    ( =clang-5.0.0* =compiler-rt-5.0.0* )
    ...
    ( =clang-4.0.1* =compiler-rt-4.0.1* )
    ( =clang-4.0.0* =compiler-rt-4.0.0* )
    <clang-4.0
  )"

Which seems like a real PITA to maintain.