### PR TITLE
dev-util/strace: Fix ebuilds to support musl libc

### DIFF
--- a/dev-util/strace/strace-4.13.ebuild
+++ b/dev-util/strace/strace-4.13.ebuild
@@ -42,6 +42,7 @@ src_prepare() {
 	use static && append-ldflags -static
 
 	export ac_cv_header_libaio_h=$(usex aio)
+	use elibc_musl && export ac_cv_header_stdc=no
 
 	# Stub out the -k test since it's known to be flaky. #545812
 	sed -i '1iexit 77' tests*/strace-k.test || die

--- a/dev-util/strace/strace-4.15.ebuild
+++ b/dev-util/strace/strace-4.15.ebuild
@@ -42,6 +42,7 @@ src_prepare() {
 	use static && append-ldflags -static
 
 	export ac_cv_header_libaio_h=$(usex aio)
+	use elibc_musl && export ac_cv_header_stdc=no
 
 	# Stub out the -k test since it's known to be flaky. #545812
 	sed -i '1iexit 77' tests*/strace-k.test || die

--- a/dev-util/strace/strace-4.16.ebuild
+++ b/dev-util/strace/strace-4.16.ebuild
@@ -42,6 +42,7 @@ src_prepare() {
 	use static && append-ldflags -static
 
 	export ac_cv_header_libaio_h=$(usex aio)
+	use elibc_musl && export ac_cv_header_stdc=no
 
 	# Stub out the -k test since it's known to be flaky. #545812
 	sed -i '1iexit 77' tests*/strace-k.test || die

--- a/dev-util/strace/strace-9999.ebuild
+++ b/dev-util/strace/strace-9999.ebuild
@@ -42,6 +42,7 @@ src_prepare() {
 	use static && append-ldflags -static
 
 	export ac_cv_header_libaio_h=$(usex aio)
+	use elibc_musl && export ac_cv_header_stdc=no
 
 	# Stub out the -k test since it's known to be flaky. #545812
 	sed -i '1iexit 77' tests*/strace-k.test || die


### PR DESCRIPTION
This change resolves a compilation error: typedef redefinition with
different types.