### PR TITLE
net-libs/phodav-2.1: bug fix -> systemd_get_unitdir (line 51)

### DIFF
--- a/net-libs/phodav/phodav-2.1.ebuild
+++ b/net-libs/phodav/phodav-2.1.ebuild
@@ -48,7 +48,7 @@ src_install() {
 		if ! use systemd ; then
 			newinitd "${FILESDIR}/spice-webdavd.initd" spice-webdavd
 			udev_dorules "${FILESDIR}/70-spice-webdavd.rules"
-			rm -r "${D}$(systemd_get_unitdir)" || die
+			rm -r "${D}$(systemd_get_systemunitdir)" || die
 		fi
 	else
 		rm -r "${D}"{/usr/sbin,$(get_udevdir),$(systemd_get_systemunitdir)} || die


### PR DESCRIPTION
It was failing to install with:
 * ERROR: net-libs/phodav-2.1::gentoo failed (install phase):
 *   systemd_get_unitdir is banned in EAPI 6, use systemd_get_systemunitdir instead

according to this bug https://bugs.gentoo.org/show_bug.cgi?id=609390

changing line 51 to `rm -r "${D}$(systemd_get_systemunitdir)" || die` solved it.