### PR TITLE
Update chromium ebuild to compile with clang

### DIFF
--- a/www-client/chromium/chromium-58.0.3018.3.ebuild
+++ b/www-client/chromium/chromium-58.0.3018.3.ebuild
@@ -512,6 +512,10 @@ src_configure() {
 	tools/gn/bootstrap/bootstrap.py -v --gn-gen-args "${myconf_gn} use_allocator=\"none\"" || die
 	myconf_gn+=" use_allocator=$(usex tcmalloc \"tcmalloc\" \"none\")"
 	out/Release/gn gen --args="${myconf_gn}" out/Release || die
+	
+	if tc-is-clang; then
+		sed -i "s:../../../../../../../../../usr/bin/clang:clang:g" out/Release/clang_x64/toolchain.ninja
+	fi
 }
 
 eninja() {


### PR DESCRIPTION
For some reason a relative path is generated in out/Release/clang_x64/toolchain.ninja and the build fails when compiling third_party/brotli

I don't know enough about gn to fix the source so it doesn't generate these relative paths but this patch fixes it after its generated

The same happened in chromium-58.0.3013.3 too

[9973/25196] ../../../../../../../../../usr/bin/clang -MMD -MF clang_x64/obj/third_party/brotli/common/dictionary.o.d -DV8_DEPRECATION_WARNINGS -DUSE_UDEV -DUI_COMPOSITOR_IMAGE_TRANSPORT -DUSE_AURA=1 -DUSE_PANGO=1 -DUSE_CAIRO=1 -DUSE_GLIB=1 -DUSE_NSS_CERTS=1 -DUSE_X11=1 -DDISABLE_NACL -DFULL_SAFE_BROWSING -DSAFE_BROWSING_CSD -DSAFE_BROWSING_DB_LOCAL -DCHROMIUM_BUILD -DENABLE_MEDIA_ROUTER=1 -DCR_CLANG_REVISION=\"289944-2\" -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -I../.. -Iclang_x64/gen -I../../third_party/brotli/include -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -funwind-tables -fPIC -pipe -fcolor-diagnostics -fdebug-prefix-map=/var/tmp/portage/www-client/chromium-58.0.3018.3/work/chromium-58.0.3018.3=. -m64 -march=x86-64 -pthread -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-covered-switch-default -Wno-deprecated-register -Wno-unneeded-internal-declaration -Wno-inconsistent-missing-override -Wno-shift-negative-value -Wno-undefined-var-template -Wno-nonportable-include-path -Wno-address-of-packed-member -Wno-block-capture-autoreleasing -O2 -fno-ident -fdata-sections -ffunction-sections -g0 -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare  -c ../../third_party/brotli/common/dictionary.c -o clang_x64/obj/third_party/brotli/common/dictionary.o
FAILED: clang_x64/obj/third_party/brotli/common/dictionary.o 
../../../../../../../../../usr/bin/clang -MMD -MF clang_x64/obj/third_party/brotli/common/dictionary.o.d -DV8_DEPRECATION_WARNINGS -DUSE_UDEV -DUI_COMPOSITOR_IMAGE_TRANSPORT -DUSE_AURA=1 -DUSE_PANGO=1 -DUSE_CAIRO=1 -DUSE_GLIB=1 -DUSE_NSS_CERTS=1 -DUSE_X11=1 -DDISABLE_NACL -DFULL_SAFE_BROWSING -DSAFE_BROWSING_CSD -DSAFE_BROWSING_DB_LOCAL -DCHROMIUM_BUILD -DENABLE_MEDIA_ROUTER=1 -DCR_CLANG_REVISION=\"289944-2\" -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -I../.. -Iclang_x64/gen -I../../third_party/brotli/include -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -funwind-tables -fPIC -pipe -fcolor-diagnostics -fdebug-prefix-map=/var/tmp/portage/www-client/chromium-58.0.3018.3/work/chromium-58.0.3018.3=. -m64 -march=x86-64 -pthread -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-covered-switch-default -Wno-deprecated-register -Wno-unneeded-internal-declaration -Wno-inconsistent-missing-override -Wno-shift-negative-value -Wno-undefined-var-template -Wno-nonportable-include-path -Wno-address-of-packed-member -Wno-block-capture-autoreleasing -O2 -fno-ident -fdata-sections -ffunction-sections -g0 -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare  -c ../../third_party/brotli/common/dictionary.c -o clang_x64/obj/third_party/brotli/common/dictionary.o
../../../../../../../../../usr/bin/clang: No such file or directory