### PR TITLE
media-video/transcode: Apply transcode-1.1.7-ffmpeg29.patch when building transcode-1.1.7 against >=media-video/libav-12

### DIFF
--- a/media-video/transcode/transcode-1.1.7-r3.ebuild
+++ b/media-video/transcode/transcode-1.1.7-r3.ebuild
@@ -69,7 +69,8 @@ PATCHES=(
 )
 
 src_prepare() {
-	if has_version '>=media-video/ffmpeg-2.8' ; then
+	if has_version '>=media-video/ffmpeg-2.8' ||
+		has_version '>=media-video/libav-12'; then
 		PATCHES+=( "${FILESDIR}"/${P}-ffmpeg29.patch )
 	fi
 


### PR DESCRIPTION
Resolves https://bugs.gentoo.org/show_bug.cgi?id=609198