### PR TITLE
app-leechcraft: use Qt5, modernize the eclass and ebuilds.

### DIFF
--- a/app-leechcraft/laretz/laretz-9999.ebuild
+++ b/app-leechcraft/laretz/laretz-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="The Laretz sync server"
 HOMEPAGE="http://leechcraft.org"
@@ -10,7 +10,7 @@ HOMEPAGE="http://leechcraft.org"
 EGIT_REPO_URI="git://github.com/0xd34df00d/laretz.git"
 EGIT_PROJECT="laretz"
 
-inherit cmake-utils git-2
+inherit cmake-utils git-r3
 
 LICENSE="Boost-1.0"
 SLOT="0"

--- a/app-leechcraft/laretz/metadata.xml
+++ b/app-leechcraft/laretz/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-advancednotifications/lc-advancednotifications-9999.ebuild
+++ b/app-leechcraft/lc-advancednotifications/lc-advancednotifications-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,7 +13,7 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdeclarative:4"
+	dev-qt/qtdeclarative:5"
 RDEPEND="${DEPEND}"
 
 pkg_postinst() {

--- a/app-leechcraft/lc-advancednotifications/metadata.xml
+++ b/app-leechcraft/lc-advancednotifications/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<longdescription>Advanced Notifications module provides an extremely flexible and configurable
 		notifications framework for LeechCraft. More information is in the corresponding devel

--- a/app-leechcraft/lc-aggregator/lc-aggregator-9999.ebuild
+++ b/app-leechcraft/lc-aggregator/lc-aggregator-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -10,23 +10,22 @@ DESCRIPTION="Full-featured RSS/Atom feed reader for LeechCraft"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="debug mysql +sqlite postgres webaccess"
+IUSE="debug mysql +sqlite postgres"
 
 DEPEND="~app-leechcraft/lc-core-${PV}[postgres?,sqlite?]
-	dev-qt/qtwebkit:4"
+	dev-qt/qtcore:5
+	dev-qt/qtsql:5[sqlite?,postgres?,mysql?]
+	dev-qt/qtwebkit:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5"
 RDEPEND="${DEPEND}
 		virtual/leechcraft-downloader-http"
 
 REQUIRED_USE="|| ( mysql sqlite postgres )"
 
-src_configure() {
-	local mycmakeargs=(
-		$(cmake-utils_use_enale webaccess AGGREGATOR_WEBACCESS)
-	)
-	cmake-utils_src_configure
-}
-
-pkg_setup(){
+pkg_postinst(){
 	if use mysql; then
 		ewarn "Support for MySQL databases is experimental and is more likely"
 		ewarn "to contain bugs or mishandle your data than other storage"

--- a/app-leechcraft/lc-aggregator/metadata.xml
+++ b/app-leechcraft/lc-aggregator/metadata.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
 	</maintainer>
-	<use>
-		<flag name="webaccess">Enables web interface submodule for Aggregator</flag>
-	</use>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-anhero/lc-anhero-9999.ebuild
+++ b/app-leechcraft/lc-anhero/lc-anhero-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 

--- a/app-leechcraft/lc-anhero/metadata.xml
+++ b/app-leechcraft/lc-anhero/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-auscrie/lc-auscrie-9999.ebuild
+++ b/app-leechcraft/lc-auscrie/lc-auscrie-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 

--- a/app-leechcraft/lc-auscrie/metadata.xml
+++ b/app-leechcraft/lc-auscrie/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-azoth/lc-azoth-9999.ebuild
+++ b/app-leechcraft/lc-azoth/lc-azoth-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -15,24 +15,41 @@ IUSE="debug doc astrality +acetamide +adiumstyles +autoidler +autopaste +birthda
 		+juick +keeso +lastseen	+metacontacts media +murm +latex +nativeemoticons
 		+otroid +spell sarin shx +standardstyles +vader velvetbird +woodpecker +xmpp +xtazy"
 
-COMMON_DEPEND="~app-leechcraft/lc-core-${PV}
-		dev-libs/qjson
-		dev-qt/qtwebkit:4
-		autoidler? ( x11-libs/libXScrnSaver )
-		astrality? ( net-libs/telepathy-qt )
-		otroid? ( net-libs/libotr )
-		media? ( dev-qt/qt-mobility[multimedia] )
-		woodpecker? ( dev-libs/kqoauth )
-		xmpp? (
-			=net-libs/qxmpp-9999
-			media? ( =net-libs/qxmpp-9999[speex] )
-		)
-		xtazy? (
-			~app-leechcraft/lc-xtazy-${PV}
-			dev-qt/qtdbus:4
-		)
-		crypt? ( app-crypt/qca:2[qt4(+)] )
-		sarin? ( net-libs/tox )
+COMMON_DEPEND="
+	~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtsql:5
+	dev-qt/qtwebkit:5
+	dev-qt/qtxml:5
+	dev-qt/qtdbus:5
+	media? (
+		dev-qt/qtmultimedia:5
+	)
+	sarin? (
+		dev-qt/qtconcurrent:5
+	)
+	lastseen? (
+		dev-qt/qtconcurrent:5
+	)
+	otroid? (
+		dev-qt/qtconcurrent:5
+	)
+	autoidler? (
+		dev-qt/qtx11extras:5
+	)
+	autoidler? ( x11-libs/libXScrnSaver )
+	astrality? ( net-libs/telepathy-qt[qt5] )
+	otroid? ( net-libs/libotr )
+	woodpecker? ( dev-libs/kqoauth )
+	xmpp? (
+		>=net-libs/qxmpp-0.9.3[qt5]
+		media? ( >=net-libs/qxmpp-0.9.3[qt5,speex] )
+	)
+	xtazy? (
+		~app-leechcraft/lc-xtazy-${PV}
+	)
+	crypt? ( app-crypt/qca:2[qt5] )
+	sarin? ( net-libs/tox )
 "
 DEPEND="${COMMON_DEPEND}
 	doc? ( app-doc/doxygen[dot] )"
@@ -43,49 +60,52 @@ RDEPEND="${COMMON_DEPEND}
 	)
 	crypt? ( app-crypt/qca:2[gpg] )
 	latex? (
-		virtual/imagemagick-tools
+		|| (
+			media-gfx/imagemagick
+			media-gfx/graphicsmagick[imagemagick]
+		)
 		virtual/latex-base
 	)
 	spell? (
-		app-leechcraft/lc-rosenthal
+		~app-leechcraft/lc-rosenthal-${PV}
 	)"
 
 REQUIRED_USE="|| ( standardstyles adiumstyles )"
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake-utils_use_enable crypt CRYPT)
-		$(cmake-utils_use_with doc DOCS)
-		$(cmake-utils_use_enable acetamide AZOTH_ACETAMIDE)
-		$(cmake-utils_use_enable adiumstyles AZOTH_ADIUMSTYLES)
-		$(cmake-utils_use_enable astrality AZOTH_ASTRALITY)
-		$(cmake-utils_use_enable autoidler AZOTH_AUTOIDLER)
-		$(cmake-utils_use_enable autopaste AZOTH_AUTOPASTE)
-		$(cmake-utils_use_enable birthdaynotifier AZOTH_BIRTHDAYNOTIFIER)
-		$(cmake-utils_use_enable chathistory AZOTH_CHATHISTORY)
-		$(cmake-utils_use_enable depester AZOTH_DEPESTER)
-		$(cmake-utils_use_enable embedmedia AZOTH_EMBEDMEDIA)
-		$(cmake-utils_use_enable herbicide AZOTH_HERBICIDE)
-		$(cmake-utils_use_enable hili AZOTH_HILI)
-		$(cmake-utils_use_enable isterique AZOTH_ISTERIQUE)
-		$(cmake-utils_use_enable juick AZOTH_JUICK)
-		$(cmake-utils_use_enable keeso AZOTH_KEESO)
-		$(cmake-utils_use_enable lastseen AZOTH_LASTSEEN)
-		$(cmake-utils_use_enable metacontacts AZOTH_METACONTACTS)
-		$(cmake-utils_use_enable media MEDIACALLS)
-		$(cmake-utils_use_enable latex AZOTH_MODNOK)
-		$(cmake-utils_use_enable murm AZOTH_MURM)
-		$(cmake-utils_use_enable nativeemoticons AZOTH_NATIVEEMOTICONS)
-		$(cmake-utils_use_enable otroid AZOTH_OTROID)
-		$(cmake-utils_use_enable sarin AZOTH_SARIN)
-		$(cmake-utils_use_enable spell AZOTH_ROSENTHAL)
-		$(cmake-utils_use_enable shx AZOTH_SHX)
-		$(cmake-utils_use_enable standardstyles AZOTH_STANDARDSTYLES)
-		$(cmake-utils_use_enable vader AZOTH_VADER)
-		$(cmake-utils_use_enable velvetbird AZOTH_VELVETBIRD)
-		$(cmake-utils_use_enable woodpecker AZOTH_WOODPECKER)
-		$(cmake-utils_use_enable xmpp AZOTH_XOOX)
-		$(cmake-utils_use_enable xtazy AZOTH_XTAZY)
+		-DENABLE_CRYPT=$(usex crypt)
+		-DWITH_DOCS=$(usex doc)
+		-DENABLE_AZOTH_ACETAMIDE=$(usex acetamide)
+		-DENABLE_AZOTH_ADIUMSTYLES=$(usex adiumstyles)
+		-DENABLE_AZOTH_ASTRALITY=$(usex astrality)
+		-DENABLE_AZOTH_AUTOIDLER=$(usex autoidler)
+		-DENABLE_AZOTH_AUTOPASTE=$(usex autopaste)
+		-DENABLE_AZOTH_BIRTHDAYNOTIFIER=$(usex birthdaynotifier)
+		-DENABLE_AZOTH_CHATHISTORY=$(usex chathistory)
+		-DENABLE_AZOTH_DEPESTER=$(usex depester)
+		-DENABLE_AZOTH_EMBEDMEDIA=$(usex embedmedia)
+		-DENABLE_AZOTH_HERBICIDE=$(usex herbicide)
+		-DENABLE_AZOTH_HILI=$(usex hili)
+		-DENABLE_AZOTH_ISTERIQUE=$(usex isterique)
+		-DENABLE_AZOTH_JUICK=$(usex juick)
+		-DENABLE_AZOTH_KEESO=$(usex keeso)
+		-DENABLE_AZOTH_LASTSEEN=$(usex lastseen)
+		-DENABLE_AZOTH_METACONTACTS=$(usex metacontacts)
+		-DENABLE_MEDIACALLS=$(usex media)
+		-DENABLE_AZOTH_MODNOK=$(usex latex)
+		-DENABLE_AZOTH_MURM=$(usex murm)
+		-DENABLE_AZOTH_NATIVEEMOTICONS=$(usex nativeemoticons)
+		-DENABLE_AZOTH_OTROID=$(usex otroid)
+		-DENABLE_AZOTH_SARIN=$(usex sarin)
+		-DENABLE_AZOTH_ROSENTHAL=$(usex spell)
+		-DENABLE_AZOTH_SHX=$(usex shx)
+		-DENABLE_AZOTH_STANDARDSTYLES=$(usex standardstyles)
+		-DENABLE_AZOTH_VADER=$(usex vader)
+		-DENABLE_AZOTH_VELVETBIRD=$(usex velvetbird)
+		-DENABLE_AZOTH_WOODPECKER=$(usex woodpecker)
+		-DENABLE_AZOTH_XOOX=$(usex xmpp)
+		-DENABLE_AZOTH_XTAZY=$(usex xtazy)
 	)
 
 	cmake-utils_src_configure

--- a/app-leechcraft/lc-azoth/metadata.xml
+++ b/app-leechcraft/lc-azoth/metadata.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 <use>
 	<flag name="astrality">Build Astrality, support for protocols provided by Telepathy</flag>
 	<flag name="acetamide">Build Acetamide, the IRC protocol support</flag>

--- a/app-leechcraft/lc-bittorrent/lc-bittorrent-9999.ebuild
+++ b/app-leechcraft/lc-bittorrent/lc-bittorrent-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,15 +12,20 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug geoip"
 
-DEPEND="~app-leechcraft/lc-core-${PV}
-		net-libs/rb_libtorrent"
+DEPEND="
+	~app-leechcraft/lc-core-${PV}
+	net-libs/rb_libtorrent
+	dev-qt/qtxml:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}
-		virtual/leechcraft-task-show
-		geoip? ( dev-libs/geoip )"
+	virtual/leechcraft-task-show
+	geoip? ( dev-libs/geoip )
+"
 
 src_configure(){
-	local mycmakeargs="
-		$(cmake-utils_use_enable geoip BITTORRENT_GEOIP)
-	"
+	local mycmakeargs=(
+		-DENABLE_BITTORRENT_GEOIP=$(usex geoip)
+	)
 	cmake-utils_src_configure
 }

--- a/app-leechcraft/lc-bittorrent/metadata.xml
+++ b/app-leechcraft/lc-bittorrent/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-blasq/lc-blasq-9999.ebuild
+++ b/app-leechcraft/lc-blasq/lc-blasq-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,19 +12,28 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug +deathnote +rappor +spegnersi +vangog"
 
-DEPEND="~app-leechcraft/lc-core-${PV}
-		deathnote? ( dev-qt/qtxmlpatterns:4 )
-		spegnersi? ( dev-libs/kqoauth )
-		vangog? ( dev-libs/qjson )
-		"
+DEPEND="
+	~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtdeclarative:5
+	rappor? ( dev-qt/qtxml:5 )
+	deathnote? (
+		dev-qt/qtxml:5
+		dev-qt/qtxmlpatterns:5
+	)
+	spegnersi? ( dev-qt/qtxml:5 )
+	vangog? ( dev-qt/qtxml:5 )
+	spegnersi? ( dev-libs/kqoauth )
+"
 RDEPEND="${DEPEND}"
 
 src_configure(){
 	local mycmakeargs=(
-		$(cmake-utils_use_enable deathnote BLASQ_DEATHNOTE)
-		$(cmake-utils_use_enable rappor BLASQ_RAPPOR)
-		$(cmake-utils_use_enable spegnersi BLASQ_SPEGNERSI)
-		$(cmake-utils_use_enable vangog BLASQ_VANGOG)
+		-DENABLE_BLASQ_DEATHNOTE=$(usex deathnote)
+		-DENABLE_BLASQ_RAPPOR=$(usex rappor)
+		-DENABLE_BLASQ_SPEGNERSI=$(usex spegnersi)
+		-DENABLE_BLASQ_VANGOG=$(usex vangog)
 	)
 
 	cmake-utils_src_configure

--- a/app-leechcraft/lc-blasq/metadata.xml
+++ b/app-leechcraft/lc-blasq/metadata.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 <use>
 	<flag name="deathnote">Support LiveJournal FotoBilder service</flag>
 	<flag name="rappor">Support VKontakte service</flag>

--- a/app-leechcraft/lc-blogique/lc-blogique-9999.ebuild
+++ b/app-leechcraft/lc-blogique/lc-blogique-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,18 +12,26 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug +metida +hestia"
 
-DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtsql:4[sqlite]
-	metida? ( dev-qt/qtxmlpatterns:4 )
-	"
+DEPEND="
+	~app-leechcraft/lc-core-${PV}
+	dev-qt/qtsql:5
+	dev-qt/qtwebkit:5
+	dev-qt/qtxml:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtdeclarative:5
+	metida? (
+		dev-qt/qtnetwork:5
+		dev-qt/qtxmlpatterns:5
+	)
+"
 RDEPEND="${DEPEND}
 	virtual/leechcraft-wysiwyg-editor
 	"
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake-utils_use_enable metida BLOGIQUE_METIDA)
-		$(cmake-utils_use_enable hestia BLOGIQUE_HESTIA)
+		-DENABLE_BLOGIQUE_METIDA=$(usex metida)
+		-DENABLE_BLOGIQUE_HESTIA=$(usex hestia)
 	)
 
 	cmake-utils_src_configure

--- a/app-leechcraft/lc-blogique/metadata.xml
+++ b/app-leechcraft/lc-blogique/metadata.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 <use>
 	<flag name="metida">Support for the LiveJournal blogging platform</flag>
 	<flag name="hestia">Allows one to keep a local blog</flag>

--- a/app-leechcraft/lc-certmgr/lc-certmgr-9999.ebuild
+++ b/app-leechcraft/lc-certmgr/lc-certmgr-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,9 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="
+	~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-certmgr/metadata.xml
+++ b/app-leechcraft/lc-certmgr/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-core/lc-core-9999.ebuild
+++ b/app-leechcraft/lc-core/lc-core-9999.ebuild
@@ -2,12 +2,11 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 EGIT_REPO_URI="git://github.com/0xd34df00d/leechcraft.git"
-EGIT_PROJECT="leechcraft-${PV}"
 
-inherit eutils leechcraft
+inherit eutils confutils leechcraft
 
 DESCRIPTION="Core of LeechCraft, the modular network client"
 
@@ -15,20 +14,25 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug doc +sqlite postgres +qwt"
 
-COMMON_DEPEND=">=dev-libs/boost-1.46
-	dev-qt/qtcore:4
-	dev-qt/qtdbus:4
-	dev-qt/qtdeclarative:4
-	dev-qt/qtgui:4
-	dev-qt/qtscript:4
-	dev-qt/qtsql:4[postgres?,sqlite?]
-	dev-qt/qtwebkit:4
-	dev-qt/qtdbus:4
-	qwt? ( x11-libs/qwt:6 )"
+COMMON_DEPEND=">=dev-libs/boost-1.62
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtxml:5
+	dev-qt/qtdeclarative:5
+	dev-qt/qtscript:5
+	dev-qt/qtsql:5[postgres?,sqlite?]
+	dev-qt/qtdbus:5
+	dev-qt/qtwebkit:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+	dev-qt/qtconcurrent:5
+	dev-qt/linguist-tools:5
+	qwt? ( x11-libs/qwt:6[qt5] )"
 DEPEND="${COMMON_DEPEND}
 	doc? ( app-doc/doxygen )"
 RDEPEND="${COMMON_DEPEND}
-	dev-qt/qtsvg:4
+	dev-qt/qtsvg:5
 	|| (
 		kde-frameworks/oxygen-icons
 		x11-themes/kfaenza
@@ -39,8 +43,8 @@ REQUIRED_USE="|| ( postgres sqlite )"
 src_configure() {
 	local mycmakeargs=(
 		-DWITH_PLUGINS=False
-		$(cmake-utils_use_with doc DOCS)
-		$(cmake-utils_use_with qwt QWT)
+		-DWITH_DOCS=$(usex doc)
+		-DWITH_QWT=$(usex qwt)
 	)
 	if [[ ${PV} != 9999 ]]; then
 		mycmakeargs+=( -DLEECHCRAFT_VERSION=${PV} )

--- a/app-leechcraft/lc-core/metadata.xml
+++ b/app-leechcraft/lc-core/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<longdescription>Core of LeechCraft, the opensource modular network client providing a full-featured web browser, BitTorrent client and much more.</longdescription> 
 	<use>

--- a/app-leechcraft/lc-cpuload/lc-cpuload-9999.ebuild
+++ b/app-leechcraft/lc-cpuload/lc-cpuload-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,7 +12,10 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="
+	~app-leechcraft/lc-core-${PV}
+	dev-qt/qtdeclarative:5
+"
 RDEPEND="${DEPEND}
 	virtual/leechcraft-quark-sideprovider
 "

--- a/app-leechcraft/lc-cpuload/metadata.xml
+++ b/app-leechcraft/lc-cpuload/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-cstp/lc-cstp-9999.ebuild
+++ b/app-leechcraft/lc-cstp/lc-cstp-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,6 +12,9 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}
-		virtual/leechcraft-task-show"
+	virtual/leechcraft-task-show"

--- a/app-leechcraft/lc-cstp/metadata.xml
+++ b/app-leechcraft/lc-cstp/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-dbusmanager/lc-dbusmanager-9999.ebuild
+++ b/app-leechcraft/lc-dbusmanager/lc-dbusmanager-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,6 +12,8 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}
-		dev-qt/qtdbus:4"
+DEPEND="
+	~app-leechcraft/lc-core-${PV}
+	dev-qt/qtdbus:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-dbusmanager/metadata.xml
+++ b/app-leechcraft/lc-dbusmanager/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-deadlyrics/lc-deadlyrics-9999.ebuild
+++ b/app-leechcraft/lc-deadlyrics/lc-deadlyrics-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,7 +12,11 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="
+	~app-leechcraft/lc-core-${PV}
+	dev-qt/qtxml:5
+"
 RDEPEND="${DEPEND}
-		virtual/leechcraft-search-show
-		virtual/leechcraft-downloader-http"
+	virtual/leechcraft-search-show
+	virtual/leechcraft-downloader-http
+"

--- a/app-leechcraft/lc-deadlyrics/metadata.xml
+++ b/app-leechcraft/lc-deadlyrics/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-devmon/lc-devmon-9999.ebuild
+++ b/app-leechcraft/lc-devmon/lc-devmon-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,6 +12,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}
+DEPEND="
+	~app-leechcraft/lc-core-${PV}
 	virtual/udev"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-devmon/metadata.xml
+++ b/app-leechcraft/lc-devmon/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-dolozhee/lc-dolozhee-9999.ebuild
+++ b/app-leechcraft/lc-dolozhee/lc-dolozhee-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,9 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-dolozhee/metadata.xml
+++ b/app-leechcraft/lc-dolozhee/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-eleeminator/lc-eleeminator-9999.ebuild
+++ b/app-leechcraft/lc-eleeminator/lc-eleeminator-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,5 +13,7 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	x11-libs/qtermwidget"
+	dev-qt/qtwidgets:5
+	x11-libs/qtermwidget
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-eleeminator/metadata.xml
+++ b/app-leechcraft/lc-eleeminator/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-fenet/lc-fenet-9999.ebuild
+++ b/app-leechcraft/lc-fenet/lc-fenet-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,8 +12,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="
-	~app-leechcraft/lc-core-${PV}
-	dev-libs/qjson
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
 "
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-fenet/metadata.xml
+++ b/app-leechcraft/lc-fenet/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-gacts/lc-gacts-9999.ebuild
+++ b/app-leechcraft/lc-gacts/lc-gacts-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,12 +13,7 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	x11-libs/libqxt"
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+"
 RDEPEND="${DEPEND}"
-
-src_configure() {
-	local mycmakeargs=(
-		-DWITH_GACTS_BUNDLED_QXT=OFF
-	)
-	cmake-utils_src_configure
-}

--- a/app-leechcraft/lc-gacts/metadata.xml
+++ b/app-leechcraft/lc-gacts/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-glance/lc-glance-9999.ebuild
+++ b/app-leechcraft/lc-glance/lc-glance-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-glance/metadata.xml
+++ b/app-leechcraft/lc-glance/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-gmailnotifier/lc-gmailnotifier-9999.ebuild
+++ b/app-leechcraft/lc-gmailnotifier/lc-gmailnotifier-9999.ebuild
@@ -1,19 +1,23 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
-DESCRIPTION="Notifier about new mail in a GMail inbox for LeechCraft"
+DESCRIPTION="Notifies about new mail in a GMail inbox for LeechCraft"
 
 SLOT="0"
 KEYWORDS=""
 IUSE="debug notify quark"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdeclarative:4"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtdeclarative:5[widgets]
+	dev-qt/qtxml:5
+"
 RDEPEND="${DEPEND}
 	quark? ( ~virtual/leechcraft-quark-sideprovider-${PV} )
 	notify? ( ~virtual/leechcraft-notifier-${PV} )"

--- a/app-leechcraft/lc-gmailnotifier/metadata.xml
+++ b/app-leechcraft/lc-gmailnotifier/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
 		<flag name="quark">Pull in a plugin to show GMail Notifier's quark</flag>

--- a/app-leechcraft/lc-historyholder/lc-historyholder-9999.ebuild
+++ b/app-leechcraft/lc-historyholder/lc-historyholder-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,6 +12,11 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtconcurrent:5
+	dev-qt/qtsql:5[sqlite]
+"
 RDEPEND="${DEPEND}
-		virtual/leechcraft-search-show"
+		~virtual/leechcraft-search-show-${PV}"

--- a/app-leechcraft/lc-historyholder/metadata.xml
+++ b/app-leechcraft/lc-historyholder/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-hotsensors/lc-hotsensors-9999.ebuild
+++ b/app-leechcraft/lc-hotsensors/lc-hotsensors-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -15,8 +15,10 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}[qwt]
-	~virtual/leechcraft-quark-sideprovider-${PV}
-	dev-qt/qtdeclarative:4
 	sys-apps/lm_sensors
-	"
-RDEPEND="${DEPEND}"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtdeclarative:5[widgets]
+"
+RDEPEND="${DEPEND}
+	~virtual/leechcraft-quark-sideprovider-${PV}"

--- a/app-leechcraft/lc-hotsensors/metadata.xml
+++ b/app-leechcraft/lc-hotsensors/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-hotstreams/lc-hotstreams-9999.ebuild
+++ b/app-leechcraft/lc-hotstreams/lc-hotstreams-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit eutils leechcraft toolchain-funcs
 
@@ -10,8 +10,12 @@ DESCRIPTION="Provides some cool radio streams to music players like LMP"
 
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-libs/qjson"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtconcurrent:5
+	dev-qt/qtxml:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-hotstreams/metadata.xml
+++ b/app-leechcraft/lc-hotstreams/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-htthare/lc-htthare-9999.ebuild
+++ b/app-leechcraft/lc-htthare/lc-htthare-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -10,6 +10,10 @@ DESCRIPTION="Simple HTTP server for Leechcraft"
 
 SLOT="0"
 KEYWORDS=""
+IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtgui:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-htthare/metadata.xml
+++ b/app-leechcraft/lc-htthare/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-imgaste/lc-imgaste-9999.ebuild
+++ b/app-leechcraft/lc-imgaste/lc-imgaste-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,8 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-imgaste/metadata.xml
+++ b/app-leechcraft/lc-imgaste/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-intermutko/lc-intermutko-9999.ebuild
+++ b/app-leechcraft/lc-intermutko/lc-intermutko-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,8 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-intermutko/metadata.xml
+++ b/app-leechcraft/lc-intermutko/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-kbswitch/lc-kbswitch-9999.ebuild
+++ b/app-leechcraft/lc-kbswitch/lc-kbswitch-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -10,8 +10,14 @@ DESCRIPTION="Provides plugin- or tab-grained keyboard layout control"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="debug"
+IUSE="debug quark"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+	dev-qt/qtdeclarative:5[widgets]
+"
 RDEPEND="${DEPEND}
-	x11-apps/setxkbmap"
+	x11-apps/setxkbmap
+	quark? ( ~virtual/leechcraft-quark-sideprovider-${PV} )"

--- a/app-leechcraft/lc-kbswitch/metadata.xml
+++ b/app-leechcraft/lc-kbswitch/metadata.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
 	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<use>
+		<flag name="quark">Provide sidebar quark</flag>
+	</use>
 </pkgmetadata>

--- a/app-leechcraft/lc-kinotify/lc-kinotify-9999.ebuild
+++ b/app-leechcraft/lc-kinotify/lc-kinotify-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,5 +13,7 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-		>=dev-qt/qtwebkit-4.6:4"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwebkit:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-kinotify/metadata.xml
+++ b/app-leechcraft/lc-kinotify/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-knowhow/lc-knowhow-9999.ebuild
+++ b/app-leechcraft/lc-knowhow/lc-knowhow-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,9 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-knowhow/metadata.xml
+++ b/app-leechcraft/lc-knowhow/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-krigstask/lc-krigstask-9999.ebuild
+++ b/app-leechcraft/lc-krigstask/lc-krigstask-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,7 +13,9 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdeclarative:4
-	x11-libs/libXcomposite"
+	x11-libs/libXcomposite
+	dev-qt/qtwidgets:5
+	dev-qt/qtdeclarative:5
+"
 RDEPEND="${DEPEND}
 	 ~virtual/leechcraft-quark-sideprovider-${PV}"

--- a/app-leechcraft/lc-krigstask/metadata.xml
+++ b/app-leechcraft/lc-krigstask/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-lackman/lc-lackman-9999.ebuild
+++ b/app-leechcraft/lc-lackman/lc-lackman-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,6 +13,11 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-		>=dev-qt/qtwebkit-4.6:4"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtsql:5[sqlite]
+	dev-qt/qtxml:5
+	dev-qt/qtxmlpatterns:5
+"
 RDEPEND="${DEPEND}
-		virtual/leechcraft-downloader-http"
+		~virtual/leechcraft-downloader-http-${PV}"

--- a/app-leechcraft/lc-lackman/metadata.xml
+++ b/app-leechcraft/lc-lackman/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-lastfmscrobble/lc-lastfmscrobble-9999.ebuild
+++ b/app-leechcraft/lc-lastfmscrobble/lc-lastfmscrobble-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,5 +13,8 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	media-libs/liblastfm[qt4(+)]"
+	media-libs/liblastfm[qt5]
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-lastfmscrobble/metadata.xml
+++ b/app-leechcraft/lc-lastfmscrobble/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-laughty/lc-laughty-9999.ebuild
+++ b/app-leechcraft/lc-laughty/lc-laughty-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,6 +13,9 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdbus:4"
+	dev-qt/qtnetwork:5
+	dev-qt/qtgui:5
+	dev-qt/qtdbus:5
+	"
 RDEPEND="${DEPEND}
-	virtual/leechcraft-notifier"
+	~virtual/leechcraft-notifier-${PV}"

--- a/app-leechcraft/lc-laughty/metadata.xml
+++ b/app-leechcraft/lc-laughty/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-launchy/lc-launchy-9999.ebuild
+++ b/app-leechcraft/lc-launchy/lc-launchy-9999.ebuild
@@ -2,17 +2,20 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft toolchain-funcs
 
-DESCRIPTION="Allows one to launch third-party applications from LeechCraft"
+DESCRIPTION="Allows launching external applications (and LeechCraft plugins) from LeechCraft"
 
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdeclarative:4"
+	dev-qt/qtnetwork:5
+	dev-qt/qtgui:5
+	dev-qt/qtdeclarative:5[widgets]
+"
 RDEPEND="${DEPEND}
 	~virtual/leechcraft-trayarea-${PV}"

--- a/app-leechcraft/lc-launchy/metadata.xml
+++ b/app-leechcraft/lc-launchy/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-lemon/lc-lemon-9999.ebuild
+++ b/app-leechcraft/lc-lemon/lc-lemon-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,10 +13,19 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	~virtual/leechcraft-quark-sideprovider-${PV}
-	dev-qt/qtbearer:4
-	dev-qt/qtdeclarative:4
+	x11-libs/qwt:6[qt5]
 	dev-libs/libnl:3
-	x11-libs/qwt:6
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtdeclarative:5[widgets]
 	"
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	~virtual/leechcraft-quark-sideprovider-${PV}"
+
+pkg_postinst() {
+	if has_version 'dev-qt/qtnetwork:5[-connman,-networkmanager]'; then
+		ewarn "dev-qt/qtnetwork:5 was built without any bearer plugins, so detecting network"
+		ewarn "devices may be crippled. Consider enabling either 'connman' or 'networkmanager'"
+		ewarn "USE flags if that is a problem for you."
+	fi
+}

--- a/app-leechcraft/lc-lemon/metadata.xml
+++ b/app-leechcraft/lc-lemon/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-lhtr/lc-lhtr-9999.ebuild
+++ b/app-leechcraft/lc-lhtr/lc-lhtr-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,7 +13,9 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	app-text/htmltidy
-	dev-qt/qtwebkit:4
-	"
+	app-text/tidy-html5
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtwebkit:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-lhtr/metadata.xml
+++ b/app-leechcraft/lc-lhtr/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-liznoo/lc-liznoo-9999.ebuild
+++ b/app-leechcraft/lc-liznoo/lc-liznoo-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -10,21 +10,15 @@ DESCRIPTION="UPower-based power manager for LeechCraft"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="debug systemd"
+IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
 	x11-libs/qwt:6
-	dev-qt/qtdbus:4
-	virtual/leechcraft-trayarea"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtdbus:5
+	dev-qt/qtconcurrent:5
+"
 RDEPEND="${DEPEND}
-	!systemd? ( || ( >=sys-power/upower-0.99 sys-power/upower-pm-utils ) )
-	systemd? ( || ( >=sys-power/upower-0.9.23 sys-power/upower-pm-utils ) )"
-
-pkg_postinst() {
-	if has_version '>=sys-power/upower-0.99'; then
-		ewarn "The new sys-power/upower version you have installed doesn't have hibernate"
-		ewarn "and suspend. If you need hibernate and suspend in ${PN}, and you use"
-		ewarn "systemd, you should downgrade sys-power/upower to 0.9.23 series. All others"
-		ewarn "should switch to sys-power/upower-pm-utils, also to 0.9.23 series."
-	fi
-}
+	~virtual/leechcraft-trayarea-${PV}
+	|| ( sys-power/upower sys-power/upower-pm-utils )"

--- a/app-leechcraft/lc-liznoo/metadata.xml
+++ b/app-leechcraft/lc-liznoo/metadata.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
 	</maintainer>
-	<use>
-		<flag name="systemd">Pull in correct UPower dependencies for systemd and non-systemd users.</flag>
-	</use>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-lmp/lc-lmp-9999.ebuild
+++ b/app-leechcraft/lc-lmp/lc-lmp-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -14,27 +14,32 @@ IUSE="debug +fradj +graffiti +guess +mpris +mtp +mp3tunes potorchu"
 
 # depend on gstreamer:0.10 to match current Qt deps
 DEPEND="~app-leechcraft/lc-core-${PV}
-		graffiti? ( media-libs/flac )
+		dev-qt/qtnetwork:5
+		dev-qt/qtwidgets:5
+		dev-qt/qtdeclarative:5[widgets]
+		dev-qt/qtsql:5[sqlite]
+		dev-qt/qtconcurrent:5
+		dev-qt/qtxml:5
+		media-libs/gstreamer:1.0
+
+		mpris? ( dev-qt/qtdbus:5 )
 		guess? ( app-i18n/libguess )
-		media-libs/gstreamer:0.10
 		media-libs/taglib
-		mpris? ( dev-qt/qtdbus:4 )
-		mtp? (
-			~app-leechcraft/lc-devmon-${PV}
-			media-libs/libmtp
-		)
-		potorchu? ( media-libs/libprojectm )
-		dev-qt/qtdeclarative:4"
-RDEPEND="${DEPEND}"
+		mtp? ( media-libs/libmtp )
+		potorchu? ( media-libs/libprojectm )"
+RDEPEND="${DEPEND}
+		mtp? ( ~app-leechcraft/lc-devmon-${PV} )
+		graffiti? ( media-libs/flac )"
 
 src_configure() {
-	local mycmakeargs="
-		$(cmake-utils_use_enable fradj LMP_FRADJ)
-		$(cmake-utils_use_enable graffiti LMP_GRAFFITI)
-		$(cmake-utils_use_enable guess LMP_LIBGUESS)
-		$(cmake-utils_use_enable mpris LMP_MPRIS)
-		$(cmake-utils_use_enable mtp LMP_MTPSYNC)
-		$(cmake-utils_use_enable mp3tunes LMP_MP3TUNES)
-		$(cmake-utils_use_enable potorchu LMP_POTORCHU)"
+	local mycmakeargs=(
+		-DENABLE_LMP_FRADJ=$(usex fradj)
+		-DENABLE_LMP_GRAFFITI=$(usex graffiti)
+		-DENABLE_LMP_LIBGUESS=$(usex guess)
+		-DENABLE_LMP_MPRIS=$(usex mpris)
+		-DENABLE_LMP_MTPSYNC=$(usex mtp)
+		-DENABLE_LMP_MP3TUNES=$(usex mp3tunes)
+		-DENABLE_LMP_POTORCHU=$(usex potorchu)
+	)
 	cmake-utils_src_configure
 }

--- a/app-leechcraft/lc-lmp/metadata.xml
+++ b/app-leechcraft/lc-lmp/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 <use>
 	<flag name="fradj">Build FrAdj, the equalizer effect module</flag>

--- a/app-leechcraft/lc-mellonetray/lc-mellonetray-9999.ebuild
+++ b/app-leechcraft/lc-mellonetray/lc-mellonetray-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,7 +13,10 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdeclarative:4
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtdeclarative:5
+	dev-qt/qtx11extras:5
 	x11-libs/libXdamage
 	x11-libs/libXrender"
 RDEPEND="${DEPEND}

--- a/app-leechcraft/lc-mellonetray/metadata.xml
+++ b/app-leechcraft/lc-mellonetray/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-monocle/lc-monocle-9999.ebuild
+++ b/app-leechcraft/lc-monocle/lc-monocle-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -15,7 +15,12 @@ IUSE="debug +djvu doc +fb2 +mobi +pdf +postscript"
 REQUIRED_USE="postscript? ( pdf )"
 
 CDEPEND="~app-leechcraft/lc-core-${PV}
-	pdf? ( app-text/poppler[qt4] )
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtconcurrent:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtxml:5
+	pdf? ( app-text/poppler[qt5] )
 	djvu? ( app-text/djvu )"
 
 RDEPEND="${CDEPEND}
@@ -26,12 +31,12 @@ DEPEND="${CDEPEND}
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake-utils_use_enable djvu MONOCLE_SEEN)
-		$(cmake-utils_use_with doc DOCS)
-		$(cmake-utils_use_enable fb2 MONOCLE_FXB)
-		$(cmake-utils_use_enable mobi MONOCLE_DIK)
-		$(cmake-utils_use_enable pdf MONOCLE_PDF)
-		$(cmake-utils_use_enable postscript MONOCLE_POSTRUS)
+		-DENABLE_MONOCLE_SEEN=$(usex djvu)
+		-DWITH_DOCS=$(usex doc)
+		-DENABLE_MONOCLE_FXB=$(usex fb2)
+		-DENABLE_MONOCLE_DIK=$(usex mobi)
+		-DENABLE_MONOCLE_PDF=$(usex pdf)
+		-DENABLE_MONOCLE_POSTRUS=$(usex postscript)
 	)
 	cmake-utils_src_configure
 }

--- a/app-leechcraft/lc-monocle/metadata.xml
+++ b/app-leechcraft/lc-monocle/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
 		<flag name="fb2">Enable support for FictionBook format</flag>

--- a/app-leechcraft/lc-musiczombie/lc-musiczombie-9999.ebuild
+++ b/app-leechcraft/lc-musiczombie/lc-musiczombie-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,12 +13,17 @@ KEYWORDS=""
 IUSE="debug acoustid"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtconcurrent:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtxml:5
 	acoustid? ( media-libs/chromaprint )"
 RDEPEND="${DEPEND}"
 
 src_configure() {
-	local mycmakeargs="
-		$(cmake-utils_use_with acoustid MUSICZOMBIE_CHROMAPRINT)
-	"
+	local mycmakeargs=(
+		-DWITH_MUSICZOMBIE_CHROMAPRINT=$(usex acoustid)
+	)
 	cmake-utils_src_configure
 }

--- a/app-leechcraft/lc-musiczombie/metadata.xml
+++ b/app-leechcraft/lc-musiczombie/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
 		<flag name="acoustid">Use <pkg>media-libs/chromaprint</pkg> for acoustic fingerprinting</flag>

--- a/app-leechcraft/lc-nacheku/lc-nacheku-9999.ebuild
+++ b/app-leechcraft/lc-nacheku/lc-nacheku-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-nacheku/metadata.xml
+++ b/app-leechcraft/lc-nacheku/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-netstoremanager/lc-netstoremanager-9999.ebuild
+++ b/app-leechcraft/lc-netstoremanager/lc-netstoremanager-9999.ebuild
@@ -2,27 +2,26 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=4
+EAPI=6
 
 inherit leechcraft
 
-DESCRIPTION="Plugin for supporting and managing Internet data storages like Yandex.Disk"
+DESCRIPTION="LeechCraft plugin for supporting cloud data storages like Google Drive"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="+googledrive +yandexdisk"
+IUSE="+dropbox +googledrive"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	googledrive? (
-		dev-libs/qjson
-		sys-apps/file
-	)"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"
 
 src_configure(){
 	local mycmakeargs=(
-		$(cmake-utils_use_enable googledrive NETSTOREMANAGER_GOOGLEDRIVE)
-		$(cmake-utils_use_enable yandexdisk NETSTOREMANAGER_YANDEXDISK)
+		-DENABLE_NETSTOREMANAGER_DROPBOX=$(usex dropbox)
+		-DENABLE_NETSTOREMANAGER_GOOGLEDRIVE=$(usex googledrive)
 	)
 
 	cmake-utils_src_configure

--- a/app-leechcraft/lc-netstoremanager/metadata.xml
+++ b/app-leechcraft/lc-netstoremanager/metadata.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 <use>
-	<flag name="googledrive">Support Google Drive storage backend</flag>
-	<flag name="yandexdisk">Support Yandex.Disk storage backend</flag>
+	<flag name="dropbox">Build Dropbox storage backend</flag>
+	<flag name="googledrive">Build Google Drive storage backend</flag>
 </use>
 </pkgmetadata>

--- a/app-leechcraft/lc-networkmonitor/lc-networkmonitor-9999.ebuild
+++ b/app-leechcraft/lc-networkmonitor/lc-networkmonitor-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,8 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-networkmonitor/metadata.xml
+++ b/app-leechcraft/lc-networkmonitor/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-newlife/lc-newlife-9999.ebuild
+++ b/app-leechcraft/lc-newlife/lc-newlife-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,10 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+	dev-qt/qtsql:5[sqlite]
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-newlife/metadata.xml
+++ b/app-leechcraft/lc-newlife/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-ooronee/lc-ooronee-9999.ebuild
+++ b/app-leechcraft/lc-ooronee/lc-ooronee-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit eutils leechcraft
 
@@ -12,14 +12,19 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtdeclarative:5
+"
 RDEPEND="${DEPEND}
-	virtual/leechcraft-quark-sideprovider
+	~virtual/leechcraft-quark-sideprovider-${PV}
 "
 
 pkg_postinst() {
 	elog "Install at least some of the following additional LeechCraft modules for Ooronee to be useful:"
-	optfeature "upload images" app-leechcraft/lc-imgaste app-leechcraft/lc-blasq
+	optfeature "upload images to imagebins" app-leechcraft/lc-imgaste
+	optfeature "upload images to cloud hostings like Picasa or VKontante" app-leechcraft/lc-blasq
 	optfeature "search via OpenSearch" app-leechcraft/lc-seekthru
 	optfeature "search via Google" app-leechcraft/lc-pogooglue
 }

--- a/app-leechcraft/lc-ooronee/metadata.xml
+++ b/app-leechcraft/lc-ooronee/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-otlozhu/lc-otlozhu-9999.ebuild
+++ b/app-leechcraft/lc-otlozhu/lc-otlozhu-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,6 +13,16 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	~app-leechcraft/liblaretz-${PV}
-	>=dev-qt/qtgui-4.8:4"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+"
 RDEPEND="${DEPEND}"
+
+src_configure(){
+	local mycmakeargs=(
+		-DENABLE_OTLOZHU_SYNC=OFF
+	)
+
+	cmake-utils_src_configure
+}

--- a/app-leechcraft/lc-otlozhu/metadata.xml
+++ b/app-leechcraft/lc-otlozhu/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-pintab/lc-pintab-9999.ebuild
+++ b/app-leechcraft/lc-pintab/lc-pintab-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-pintab/metadata.xml
+++ b/app-leechcraft/lc-pintab/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-pogooglue/lc-pogooglue-9999.ebuild
+++ b/app-leechcraft/lc-pogooglue/lc-pogooglue-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -10,7 +10,9 @@ DESCRIPTION="Provides searching with Google to other LeechCraft plugins"
 
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-pogooglue/metadata.xml
+++ b/app-leechcraft/lc-pogooglue/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-popishu/lc-popishu-9999.ebuild
+++ b/app-leechcraft/lc-popishu/lc-popishu-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,5 +13,5 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	x11-libs/qscintilla[qt4(-)]"
+	x11-libs/qscintilla[qt5]"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-popishu/metadata.xml
+++ b/app-leechcraft/lc-popishu/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-poshuku/lc-poshuku-9999.ebuild
+++ b/app-leechcraft/lc-poshuku/lc-poshuku-9999.ebuild
@@ -1,49 +1,52 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI=6
 
-inherit confutils leechcraft
+inherit leechcraft
 
 DESCRIPTION="Poshuku, the full-featured web browser plugin for LeechCraft"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="+autosearch debug +dcac +cleanweb +fatape +filescheme +fua +idn +keywords +onlinebookmarks
-		+pcre postgres qrd +sqlite wyfv"
+IUSE="+autosearch debug +dcac +cleanweb +fatape +filescheme +foc +fua +idn +keywords +onlinebookmarks
+	  postgres qrd +speeddial +sqlite webengineview +webkitview"
 
 DEPEND="~app-leechcraft/lc-core-${PV}[postgres?,sqlite?]
-		dev-qt/qtwebkit:4
-		idn? ( net-dns/libidn )
-		onlinebookmarks? ( >=dev-libs/qjson-0.7.1-r1 )
-		pcre? ( >=dev-libs/libpcre-8.12 )
-		qrd? ( media-gfx/qrencode )
+	dev-qt/qtwidgets:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtxml:5
+	dev-qt/qtprintsupport:5
+	cleanweb? ( dev-qt/qtconcurrent:5 )
+	idn? ( net-dns/libidn )
+	qrd? ( media-gfx/qrencode )
+	webkitview? ( dev-qt/qtwebkit:5 )
+	webengineview? ( dev-qt/qtwebengine:5 )
 "
 RDEPEND="${DEPEND}
-		virtual/leechcraft-downloader-http"
+	virtual/leechcraft-downloader-http"
 
-REQUIRED_USE="pcre? ( cleanweb )"
-
-pkg_setup() {
-	confutils_require_any postgres sqlite
-}
+REQUIRED_USE="|| ( postgres sqlite )
+	|| ( webkitview webengineview )"
 
 src_configure() {
-	local mycmakeargs="
-		$(cmake-utils_use_enable autosearch POSHUKU_AUTOSEARCH)
-		$(cmake-utils_use_enable cleanweb POSHUKU_CLEANWEB)
-		$(cmake-utils_use_enable dcac POSHUKU_DCAC)
-		$(cmake-utils_use_enable fatape POSHUKU_FATAPE)
-		$(cmake-utils_use_enable filescheme POSHUKU_FILESCHEME)
-		$(cmake-utils_use_enable fua POSHUKU_FUA)
-		$(cmake-utils_use_enable idn IDN)
-		$(cmake-utils_use_enable keywords POSHUKU_KEYWORDS)
-		$(cmake-utils_use_enable onlinebookmarks POSHUKU_ONLINEBOOKMARKS)
-		$(cmake-utils_use_enable qrd POSHUKU_QRD)
-		$(cmake-utils_use_enable pcre POSHUKU_CLEANWEB_PCRE)
-		$(cmake-utils_use_enable wyfv POSHUKU_WYFV)
-		"
+	local mycmakeargs=(
+		-DENABLE_POSHUKU_AUTOSEARCH=$(usex autosearch)
+		-DENABLE_POSHUKU_CLEANWEB=$(usex cleanweb)
+		-DENABLE_POSHUKU_DCAC=$(usex dcac)
+		-DENABLE_POSHUKU_FATAPE=$(usex fatape)
+		-DENABLE_POSHUKU_FILESCHEME=$(usex filescheme)
+		-DENABLE_POSHUKU_FOC=$(usex foc)
+		-DENABLE_POSHUKU_FUA=$(usex fua)
+		-DENABLE_IDN=$(usex idn)
+		-DENABLE_POSHUKU_KEYWORDS=$(usex keywords)
+		-DENABLE_POSHUKU_ONLINEBOOKMARKS=$(usex onlinebookmarks)
+		-DENABLE_POSHUKU_QRD=$(usex qrd)
+		-DENABLE_POSHUKU_SPEEDDIAL=$(usex speeddial)
+		-DENABLE_POSHUKU_WEBKITVIEW=$(usex webkitview)
+		-DENABLE_POSHUKU_WEBENGINEVIEW=$(usex webengineview)
+	)
 
 	cmake-utils_src_configure
 }

--- a/app-leechcraft/lc-poshuku/metadata.xml
+++ b/app-leechcraft/lc-poshuku/metadata.xml
@@ -1,21 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 <use>
 	<flag name="autosearch">Provide automatic search suggestions for Poshuku.</flag>
 	<flag name="cleanweb">Build CleanWeb for ad blocking compatible with Firefox's AdBlock+.</flag>
 	<flag name="dcac">Build color inverter module providing a night mode.</flag>
 	<flag name="fatape">Build FatApe, GreaseMonkey userscripts support layer.</flag>
 	<flag name="filescheme">Build FileScheme for accessing local URLs.</flag>
+	<flag name="foc">Build FOC for Flash-on-Click functionality.</flag>
 	<flag name="fua">Build FUA for faking user agents for different hosts.</flag>
 	<flag name="keywords">Build Keywords for adjusting search shortcuts.</flag>
 	<flag name="onlinebookmarks">Build OnlineBookmarks for syncing bookmarks with social bookmarking services like Read It Later.</flag>
-	<flag name="pcre">Use <pkg>dev-libs/libpcre</pkg> for rules matching in CleanWeb instead of slower QRegExp.</flag>
 	<flag name="qrd">Build module for displaying the QR code of a web page.</flag>
-	<flag name="wyfv">Build WYFV for replacing Flash-based video players on some sites.</flag>
+	<flag name="speeddial">Build SpeedDial module.</flag>
+	<flag name="webengineview">Build WebEngine- (that is, Chromium-)based rendering backend.</flag>
+	<flag name="webkitview">Build WebKit-based rendering backend.</flag>
 </use>
 </pkgmetadata>

--- a/app-leechcraft/lc-qrosp/lc-qrosp-9999.ebuild
+++ b/app-leechcraft/lc-qrosp/lc-qrosp-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,6 +13,5 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-libs/qjson
-	dev-libs/qrosscore"
+	>=dev-libs/qrosscore-0.3.2"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-qrosp/metadata.xml
+++ b/app-leechcraft/lc-qrosp/metadata.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>
+

--- a/app-leechcraft/lc-rosenthal/lc-rosenthal-9999.ebuild
+++ b/app-leechcraft/lc-rosenthal/lc-rosenthal-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -10,8 +10,9 @@ DESCRIPTION="Spellchecking support for LeechCraft"
 
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtgui:5
 	app-text/hunspell"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-rosenthal/metadata.xml
+++ b/app-leechcraft/lc-rosenthal/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-sb2/lc-sb2-9999.ebuild
+++ b/app-leechcraft/lc-sb2/lc-sb2-9999.ebuild
@@ -2,18 +2,19 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
-DESCRIPTION="Sidebar with combined launcher and tab switcher, as well as tray area"
+DESCRIPTION="Sidebar for LeechCraft supporting quarks like tab switcher, tray area and so on"
 
 SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdeclarative:4
-	dev-libs/qjson
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+	dev-qt/qtdeclarative:5[widgets]
 "
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-sb2/metadata.xml
+++ b/app-leechcraft/lc-sb2/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-scroblibre/lc-scroblibre-9999.ebuild
+++ b/app-leechcraft/lc-scroblibre/lc-scroblibre-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,8 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-scroblibre/metadata.xml
+++ b/app-leechcraft/lc-scroblibre/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-secman/lc-secman-9999.ebuild
+++ b/app-leechcraft/lc-secman/lc-secman-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -10,7 +10,18 @@ DESCRIPTION="Security and personal data manager for LeechCraft"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="debug"
+IUSE="debug crypt"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	crypt? ( dev-libs/openssl:0 )
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"
+
+src_configure() {
+	local mycmakeargs=(
+		-DENABLE_SECMAN_SECURESTORAGE=$(usex crypt)
+	)
+
+	cmake-utils_src_configure
+}

--- a/app-leechcraft/lc-secman/metadata.xml
+++ b/app-leechcraft/lc-secman/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-seekthru/lc-seekthru-9999.ebuild
+++ b/app-leechcraft/lc-seekthru/lc-seekthru-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,7 +12,10 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+"
 RDEPEND="${DEPEND}
-		virtual/leechcraft-search-show
-		virtual/leechcraft-downloader-http"
+		~virtual/leechcraft-search-show-${PV}
+		~virtual/leechcraft-downloader-http-${PV}"

--- a/app-leechcraft/lc-seekthru/metadata.xml
+++ b/app-leechcraft/lc-seekthru/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-summary/lc-summary-9999.ebuild
+++ b/app-leechcraft/lc-summary/lc-summary-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-summary/metadata.xml
+++ b/app-leechcraft/lc-summary/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 <longdescription>Summary which shows all the downloads, events and statuses in LeechCraft.</longdescription> 
 </pkgmetadata>

--- a/app-leechcraft/lc-sysnotify/lc-sysnotify-9999.ebuild
+++ b/app-leechcraft/lc-sysnotify/lc-sysnotify-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,5 +13,7 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdbus:4"
+	dev-qt/qtgui:5
+	dev-qt/qtdbus:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-sysnotify/metadata.xml
+++ b/app-leechcraft/lc-sysnotify/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-tabsessmanager/lc-tabsessmanager-9999.ebuild
+++ b/app-leechcraft/lc-tabsessmanager/lc-tabsessmanager-9999.ebuild
@@ -2,15 +2,17 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
-DESCRIPTION="Provides session restore between LeechCraft runs and manual saves/restores"
+DESCRIPTION="Tabs sessions manager"
 
 SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-tabsessmanager/metadata.xml
+++ b/app-leechcraft/lc-tabsessmanager/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-tabslist/lc-tabslist-9999.ebuild
+++ b/app-leechcraft/lc-tabslist/lc-tabslist-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,5 +12,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-tabslist/metadata.xml
+++ b/app-leechcraft/lc-tabslist/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-touchstreams/lc-touchstreams-9999.ebuild
+++ b/app-leechcraft/lc-touchstreams/lc-touchstreams-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,7 +13,9 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	>=dev-libs/boost-1.52.0
-	dev-libs/qjson
-	dev-qt/qtwebkit:4"
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+	dev-qt/qtconcurrent:5
+"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-touchstreams/metadata.xml
+++ b/app-leechcraft/lc-touchstreams/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-tpi/lc-tpi-9999.ebuild
+++ b/app-leechcraft/lc-tpi/lc-tpi-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,6 +13,7 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtdeclarative:4
+	dev-qt/qtgui:5
+"
+RDEPEND="${DEPEND}
 	~virtual/leechcraft-quark-sideprovider-${PV}"
-RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-tpi/metadata.xml
+++ b/app-leechcraft/lc-tpi/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-vgrabber/lc-vgrabber-9999.ebuild
+++ b/app-leechcraft/lc-vgrabber/lc-vgrabber-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 

--- a/app-leechcraft/lc-vrooby/lc-vrooby-9999.ebuild
+++ b/app-leechcraft/lc-vrooby/lc-vrooby-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,15 +13,14 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-		dev-qt/qtdbus:4"
+	dev-qt/qtwidgets:5
+	dev-qt/qtdbus:5
+	dev-qt/qtdeclarative:5[widgets]
+"
 RDEPEND="${DEPEND}
-		sys-fs/udisks:2"
+	sys-fs/udisks:2"
 
-src_configure() {
-	local mycmakeargs=(
-		-DENABLE_VROOBY_UDISKS=OFF
-		-DENABLE_VROOBY_UDISKS2=ON
-		)
-
-	cmake-utils_src_configure
-}
+mycmakeargs=(
+	-DENABLE_VROOBY_UDISKS=OFF
+	-DENABLE_VROOBY_UDISKS2=ON
+	)

--- a/app-leechcraft/lc-vrooby/metadata.xml
+++ b/app-leechcraft/lc-vrooby/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-xproxy/lc-xproxy-9999.ebuild
+++ b/app-leechcraft/lc-xproxy/lc-xproxy-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 inherit leechcraft
 
@@ -12,7 +12,10 @@ SLOT="0"
 KEYWORDS=""
 IUSE="debug"
 
-DEPEND="~app-leechcraft/lc-core-${PV}"
+DEPEND="~app-leechcraft/lc-core-${PV}
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+"
 RDEPEND="${DEPEND}"
 
 pkg_postinst() {

--- a/app-leechcraft/lc-xproxy/metadata.xml
+++ b/app-leechcraft/lc-xproxy/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lc-xtazy/lc-xtazy-9999.ebuild
+++ b/app-leechcraft/lc-xtazy/lc-xtazy-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit leechcraft
 
@@ -13,5 +13,5 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-		dev-qt/qtdbus:4"
+		dev-qt/qtdbus:5"
 RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-xtazy/metadata.xml
+++ b/app-leechcraft/lc-xtazy/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-leechcraft/lcpackgen/lcpackgen-1.3.ebuild
+++ b/app-leechcraft/lcpackgen/lcpackgen-1.3.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 inherit cmake-utils
 

--- a/app-leechcraft/lcpackgen/metadata.xml
+++ b/app-leechcraft/lcpackgen/metadata.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>leechcraft@gentoo.org</email>
-    <name>LeechCraft</name>
-  </maintainer>
+  <maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
   <upstream>
     <remote-id type="github">0xd34df00d/lcpackgen</remote-id>
   </upstream>

--- a/app-leechcraft/leechcraft-meta/leechcraft-meta-9999.ebuild
+++ b/app-leechcraft/leechcraft-meta/leechcraft-meta-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 DESCRIPTION="Metapackage containing all ready-to-use LeechCraft plugins"
 HOMEPAGE="http://leechcraft.org/"
@@ -65,6 +65,10 @@ RDEPEND="
 		~app-leechcraft/lc-nacheku-${PV}
 		~app-leechcraft/lc-xtazy-${PV}
 		~app-leechcraft/lc-htthare-${PV}
+		~app-leechcraft/lc-hotsensors-${PV}
+		~app-leechcraft/lc-sb2-${PV}
+		~app-leechcraft/lc-intermutko-${PV}
+		~app-leechcraft/lc-ooronee-${PV}
 		de? (
 			~app-leechcraft/lc-devmon-${PV}
 			~app-leechcraft/lc-fenet-${PV}

--- a/app-leechcraft/leechcraft-meta/metadata.xml
+++ b/app-leechcraft/leechcraft-meta/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<longdescription>LeechCraft full package including all official plugins which are considered to be useful.</longdescription> 
 	<use>

--- a/app-leechcraft/liblaretz/liblaretz-0.1.0.ebuild
+++ b/app-leechcraft/liblaretz/liblaretz-0.1.0.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Shared library to be used by the Laretz sync server and its clients"
 HOMEPAGE="http://leechcraft.org"

--- a/app-leechcraft/liblaretz/liblaretz-9999.ebuild
+++ b/app-leechcraft/liblaretz/liblaretz-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Shared library to be used by the Laretz sync server and its clients"
 HOMEPAGE="http://leechcraft.org"
@@ -10,7 +10,7 @@ HOMEPAGE="http://leechcraft.org"
 EGIT_REPO_URI="git://github.com/0xd34df00d/laretz.git"
 EGIT_PROJECT="laretz"
 
-inherit cmake-utils git-2
+inherit cmake-utils git-r3
 
 LICENSE="Boost-1.0"
 SLOT="0"

--- a/app-leechcraft/liblaretz/metadata.xml
+++ b/app-leechcraft/liblaretz/metadata.xml
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">0xd34df00d/laretz</remote-id>

--- a/eclass/leechcraft.eclass
+++ b/eclass/leechcraft.eclass
@@ -4,7 +4,7 @@
 #
 # @ECLASS: leechcraft.eclass
 # @MAINTAINER:
-# leechcraft@gentoo.org
+# 0xd34df00d@gmail.com
 # @AUTHOR:
 # 0xd34df00d@gmail.com
 # NightNord@niifaq.ru
@@ -19,29 +19,28 @@
 #
 # Thanks for original eclass to Andrian Nord <NightNord@niifaq.ru>.
 #
-# Only EAPI >3 supported
+# Only EAPI >4 supported
 
 case ${EAPI:-0} in
-	4|5) ;;
+	4|5|6) ;;
 	0|1|2|3) die "EAPI not supported, bug ebuild mantainer" ;;
 	*) die "Unknown EAPI, bug eclass maintainers" ;;
 esac
 
-inherit cmake-utils toolchain-funcs versionator
+inherit cmake-utils
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="git://github.com/0xd34df00d/leechcraft.git
 	               https://github.com/0xd34df00d/leechcraft.git"
-	EGIT_PROJECT="leechcraft"
 
-	inherit git-2
+	inherit git-r3
 else
 	DEPEND="app-arch/xz-utils"
-	SRC_URI="http://dist.leechcraft.org/LeechCraft/${PV}/leechcraft-${PV}.tar.xz"
+	SRC_URI="https://dist.leechcraft.org/LeechCraft/${PV}/leechcraft-${PV}.tar.xz"
 	S="${WORKDIR}/leechcraft-${PV}"
 fi
 
-HOMEPAGE="http://leechcraft.org/"
+HOMEPAGE="https://leechcraft.org/"
 LICENSE="Boost-1.0"
 
 # @ECLASS-VARIABLE: LEECHCRAFT_PLUGIN_CATEGORY
@@ -57,27 +56,3 @@ elif [[ ${PN} != lc-core ]]; then
 else
 	CMAKE_USE_DIR="${S}"/src
 fi
-
-EXPORT_FUNCTIONS "pkg_pretend"
-
-# @FUNCTION: leechcraft_pkg_pretend
-# @DESCRIPTION:
-# Determine active compiler version and refuse to build
-# if it is not satisfied at least to minimal version,
-# supported by upstream developers
-leechcraft_pkg_pretend() {
-	debug-print-function ${FUNCNAME} "$@"
-
-	if [[ ${MERGE_TYPE} != binary ]]; then
-		# All in-tree versions require at least gcc 4.6
-		[[ $(gcc-major-version) -lt 4 ]] || \
-				( [[ $(gcc-major-version) -eq 4 && $(gcc-minor-version) -lt 6 ]] ) \
-			&& die "Sorry, but gcc 4.6 or higher is required."
-		# 0.6.65 monocle and all later plugins require at least gcc 4.8
-		if version_is_at_least 0.6.66 || ( [[ ${PN} == lc-monocle ]] && version_is_at_least 0.6.65 ); then
-			[[ $(gcc-major-version) -lt 4 ]] || \
-					( [[ $(gcc-major-version) -eq 4 && $(gcc-minor-version) -lt 8 ]] ) \
-				&& die "Sorry, but gcc 4.8 or higher is required."
-		fi
-	fi
-}

--- a/virtual/leechcraft-browser/leechcraft-browser-9999.ebuild
+++ b/virtual/leechcraft-browser/leechcraft-browser-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 DESCRIPTION="Virtual for LeechCraft plugins providing a web browser"
 HOMEPAGE=""

--- a/virtual/leechcraft-browser/metadata.xml
+++ b/virtual/leechcraft-browser/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/virtual/leechcraft-downloader-http/leechcraft-downloader-http-9999.ebuild
+++ b/virtual/leechcraft-downloader-http/leechcraft-downloader-http-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 DESCRIPTION="Virtual for LeechCraft plugins providing HTTP downloading"
 HOMEPAGE=""
@@ -13,5 +13,5 @@ SLOT="0"
 KEYWORDS=""
 IUSE=""
 
-RDEPEND="app-leechcraft/lc-cstp"
+RDEPEND="~app-leechcraft/lc-cstp-${PV}"
 DEPEND=""

--- a/virtual/leechcraft-downloader-http/metadata.xml
+++ b/virtual/leechcraft-downloader-http/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/virtual/leechcraft-notifier/leechcraft-notifier-9999.ebuild
+++ b/virtual/leechcraft-notifier/leechcraft-notifier-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="5"
+EAPI="6"
 
 DESCRIPTION="Virtual for LeechCraft plugins capable of visually notifying the user"
 HOMEPAGE=""
@@ -11,6 +11,10 @@ SRC_URI=""
 LICENSE=""
 SLOT="0"
 KEYWORDS=""
+IUSE=""
 
-RDEPEND="|| ( app-leechcraft/lc-kinotify app-leechcraft/lc-dbusmanager )"
+RDEPEND="|| (
+		~app-leechcraft/lc-kinotify-${PV}
+		~app-leechcraft/lc-dbusmanager-${PV}
+	)"
 DEPEND=""

--- a/virtual/leechcraft-notifier/metadata.xml
+++ b/virtual/leechcraft-notifier/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/virtual/leechcraft-quark-sideprovider/leechcraft-quark-sideprovider-9999.ebuild
+++ b/virtual/leechcraft-quark-sideprovider/leechcraft-quark-sideprovider-9999.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
-DESCRIPTION="Virtual for LeechCraft plugins, displaying quarks in small size somewhere near screen end"
+DESCRIPTION="Virtual for LeechCraft plugins displaying quarks near window edges"
 HOMEPAGE=""
 SRC_URI=""
 
@@ -13,5 +13,5 @@ SLOT="0"
 KEYWORDS=""
 IUSE=""
 
-RDEPEND="app-leechcraft/lc-sb2"
+RDEPEND="~app-leechcraft/lc-sb2-${PV}"
 DEPEND=""

--- a/virtual/leechcraft-quark-sideprovider/metadata.xml
+++ b/virtual/leechcraft-quark-sideprovider/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/virtual/leechcraft-search-show/leechcraft-search-show-9999.ebuild
+++ b/virtual/leechcraft-search-show/leechcraft-search-show-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 DESCRIPTION="Virtual for LeechCraft plugins providing UI for search plugins"
 HOMEPAGE=""
@@ -13,5 +13,5 @@ SLOT="0"
 KEYWORDS=""
 IUSE=""
 
-RDEPEND="app-leechcraft/lc-summary"
+RDEPEND="~app-leechcraft/lc-summary-${PV}"
 DEPEND=""

--- a/virtual/leechcraft-search-show/metadata.xml
+++ b/virtual/leechcraft-search-show/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/virtual/leechcraft-storage-device-manager/leechcraft-storage-device-manager-9999.ebuild
+++ b/virtual/leechcraft-storage-device-manager/leechcraft-storage-device-manager-9999.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=4
 
-DESCRIPTION="Virtual for LeechCraft plugins that add support for managing removable storage devices"
+DESCRIPTION="Virtual for LeechCraft plugins for managing removable storage devices"
 HOMEPAGE=""
 SRC_URI=""
 

--- a/virtual/leechcraft-storage-device-manager/metadata.xml
+++ b/virtual/leechcraft-storage-device-manager/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/virtual/leechcraft-task-show/leechcraft-task-show-9999.ebuild
+++ b/virtual/leechcraft-task-show/leechcraft-task-show-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 DESCRIPTION="Virtual for plugins that can show IDownloads and IJobHolders"
 HOMEPAGE=""
@@ -13,5 +13,5 @@ SLOT="0"
 KEYWORDS=""
 IUSE=""
 
-RDEPEND="app-leechcraft/lc-summary"
+RDEPEND="~app-leechcraft/lc-summary-${PV}"
 DEPEND=""

--- a/virtual/leechcraft-task-show/metadata.xml
+++ b/virtual/leechcraft-task-show/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>leechcraft@gentoo.org</email>
-	<name>LeechCraft</name>
-</maintainer>
+<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 <longdescription>Virtual for plugins that can show IDownloads and IJobHolders</longdescription> 
 </pkgmetadata>

--- a/virtual/leechcraft-trayarea/leechcraft-trayarea-9999.ebuild
+++ b/virtual/leechcraft-trayarea/leechcraft-trayarea-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 DESCRIPTION="Virtual for LeechCraft plugins providing a tray area"
 HOMEPAGE=""
@@ -13,5 +13,5 @@ SLOT="0"
 KEYWORDS=""
 IUSE=""
 
-RDEPEND="app-leechcraft/lc-sb2"
+RDEPEND="~app-leechcraft/lc-sb2-${PV}"
 DEPEND=""

--- a/virtual/leechcraft-trayarea/metadata.xml
+++ b/virtual/leechcraft-trayarea/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>

--- a/virtual/leechcraft-wysiwyg-editor/leechcraft-wysiwyg-editor-9999.ebuild
+++ b/virtual/leechcraft-wysiwyg-editor/leechcraft-wysiwyg-editor-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI="4"
+EAPI="6"
 
 DESCRIPTION="Virtual for LeechCraft plugins providing WYSIWYG text editor"
 HOMEPAGE=""

--- a/virtual/leechcraft-wysiwyg-editor/metadata.xml
+++ b/virtual/leechcraft-wysiwyg-editor/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>0xd34df00d@gmail.com</email>
+		<name>Georg Rudoy</name>
+	</maintainer>
 	<maintainer type="project">
-		<email>leechcraft@gentoo.org</email>
-		<name>LeechCraft</name>
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
Indeed, a huge one.

1. Moved everything to EAPI 6 and some other changes to modernize the ebuilds.
2. Moved to Qt5.
3. Dropped some obsolete stuff like checks whether gcc ≥ 4.6 is used.
4. Dropped mentions of the leechcraft project in favour of my own name and proxy-maint as a backup.