### PR TITLE
www-apps/otrs-5.0.16: solves bgo bug #610484, plus minor fix

### DIFF
--- a/www-apps/otrs/otrs-5.0.16.ebuild
+++ b/www-apps/otrs/otrs-5.0.16.ebuild
@@ -14,6 +14,8 @@ KEYWORDS="~amd64 ~x86"
 IUSE="apache2 fastcgi +gd ldap mod_perl +mysql pdf postgres soap"
 SLOT="0"
 
+REQUIRED_USE="|| ( mysql postgres )"
+
 DEPEND="media-libs/libpng:0"
 
 RDEPEND="dev-perl/Apache-Reload
@@ -69,11 +71,10 @@ pkg_setup() {
 	enewgroup apache 81
 	enewuser apache 81 -1 /var/www apache
 	enewuser otrs -1 -1 ${OTRS_HOME} apache
-	confutils_require_any mysql postgres
 }
 
 src_prepare() {
-	rm -r "${S}/scripts"/{auto_*,redhat*,suse*,*.spec} || die
+	rm -r "${S}/scripts"/auto_* || die
 
 	pushd Kernel >/dev/null || die
 	for i in *.dist; do


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=610484

compiled and emerged fine here

At testing I noticed that files rm-ed in src_prepare aren't in the current tarball anymore, so I edited that line as well.