### PR TITLE
app-misc/elasticsearch: Fix use of ulimit in init script

### DIFF
--- a/app-misc/elasticsearch/files/elasticsearch.init7
+++ b/app-misc/elasticsearch/files/elasticsearch.init7
@@ -63,11 +63,11 @@ start() {
 	ebegin "Starting ${SVCNAME}"
 
 	if [ -n "${MAX_LOCKED_MEMORY}" ]; then
-		rc_ulimit="${rc_ulimit} -l ${MAX_LOCKED_MEMORY}"
+		ulimit -l "${MAX_LOCKED_MEMORY}"
 	fi
 
 	if [ -n "${MAX_OPEN_FILES}" ]; then
-		rc_ulimit="${rc_ulimit} -n ${MAX_OPEN_FILES}"
+		ulimit -n "${MAX_OPEN_FILES}"
 	fi
 
 	checkpath -d -o "${ES_USER}:${ES_GROUP}" -m750 "/var/lib/elasticsearch"


### PR DESCRIPTION
rc_ulimit is meant to be use only in conf.d files

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=608950

Package-Manager: portage-2.2.26