### PR TITLE
x11-base/xorg-drivers: Install xf86-video-intel for VIDEO_CARDS=i915.

### DIFF
--- a/x11-base/xorg-drivers/xorg-drivers-1.19.ebuild
+++ b/x11-base/xorg-drivers/xorg-drivers-1.19.ebuild
@@ -45,6 +45,7 @@ IUSE_VIDEO_CARDS="
 	video_cards_glint
 	video_cards_i128
 	video_cards_i740
+	video_cards_i915
 	video_cards_i965
 	video_cards_intel
 	video_cards_mach64
@@ -120,6 +121,7 @@ PDEPEND="
 	video_cards_glint?         ( x11-drivers/xf86-video-glint )
 	video_cards_i128?          ( x11-drivers/xf86-video-i128 )
 	video_cards_i740?          ( x11-drivers/xf86-video-i740 )
+	video_cards_i915?          ( x11-drivers/xf86-video-intel )
 	video_cards_i965?          ( >=x11-base/xorg-server-${PV}[glamor] )
 	video_cards_intel?         ( !video_cards_i965? ( x11-drivers/xf86-video-intel ) )
 	video_cards_mach64?        ( x11-drivers/xf86-video-mach64 )

--- a/x11-base/xorg-drivers/xorg-drivers-9999.ebuild
+++ b/x11-base/xorg-drivers/xorg-drivers-9999.ebuild
@@ -45,6 +45,7 @@ IUSE_VIDEO_CARDS="
 	video_cards_glint
 	video_cards_i128
 	video_cards_i740
+	video_cards_i915
 	video_cards_i965
 	video_cards_intel
 	video_cards_mach64
@@ -120,6 +121,7 @@ PDEPEND="
 	video_cards_glint?         ( x11-drivers/xf86-video-glint )
 	video_cards_i128?          ( x11-drivers/xf86-video-i128 )
 	video_cards_i740?          ( x11-drivers/xf86-video-i740 )
+	video_cards_i915?          ( x11-drivers/xf86-video-intel )
 	video_cards_i965?          ( >=x11-base/xorg-server-${PV}[glamor] )
 	video_cards_intel?         ( !video_cards_i965? ( x11-drivers/xf86-video-intel ) )
 	video_cards_mach64?        ( x11-drivers/xf86-video-mach64 )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/608654