### PR TITLE
media-sound/pasystray: add missing dep, add plasma USE flag

### DIFF
--- a/media-sound/pasystray/metadata.xml
+++ b/media-sound/pasystray/metadata.xml
@@ -16,5 +16,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="github">christophgysin/pasystray</remote-id>
+		<bugs-to>https://github.com/christophgysin/pasystray/issues</bugs-to>
 	</upstream>
 </pkgmetadata>

--- a/media-sound/pasystray/pasystray-0.6.0.ebuild
+++ b/media-sound/pasystray/pasystray-0.6.0.ebuild
@@ -1,19 +1,20 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit gnome2-utils autotools
+EAPI=6
+inherit gnome2-utils autotools vcs-snapshot xdg
 
 DESCRIPTION="PulseAudio system tray"
 HOMEPAGE="https://github.com/christophgysin/pasystray"
 SRC_URI="https://github.com/christophgysin/${PN}/archive/${P}.tar.gz"
 
-LICENSE="LGPL-2.1"
+LICENSE="LGPL-2.1+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="libnotify"
 
 RDEPEND="
+	>=dev-libs/glib-2.48.2
 	>=media-sound/pulseaudio-5.0-r3[glib,zeroconf]
 	>=net-dns/avahi-0.6
 	x11-libs/gtk+:3
@@ -23,23 +24,28 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
-DOCS="AUTHORS README.md TODO"
-S=${WORKDIR}/${PN}-${P}
-
 src_prepare() {
+	default
 	eautoreconf
 }
+
 src_configure() {
 	econf $(use_enable libnotify notify)
-	sed -i -e 's:volume:volume;:' "data/pasystray.desktop"
 }
 
-src_install() {
-	emake DESTDIR="${D}" install
-	dodoc ${DOCS}
-	doman man/pasystray.1
+pkg_preinst() {
+	xdg_pkg_preinst
+	gnome2_icon_savelist
 }
 
-pkg_preinst() {	gnome2_icon_savelist; }
-pkg_postinst() { gnome2_icon_cache_update; }
-pkg_postrm() { gnome2_icon_cache_update; }
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
- use vcs-snapshot instead of setting S
- add xdg-related functions
- don't set DOCS explicitely
- remove useless sed

Suggested-By: lmiphay@gmail.com
Gentoo-Bug: 605246
Package-Manager: Portage-2.3.4, Repoman-2.3.2

@lmiphay do you agree with these changes? Looks like someone else bumped to 0.6.0.