### PR TITLE
net-p2p/torrentinfo: add myself as maintainer, fix tests, add py3.6, pypy{,3}

### DIFF
--- a/net-p2p/torrentinfo/files/torrentinfo-1.8.6-fix-tests.patch
+++ b/net-p2p/torrentinfo/files/torrentinfo-1.8.6-fix-tests.patch
@@ -1,0 +1,23 @@
+From 26ad58f68927186a1216ca8ae4596a8132191dcf Mon Sep 17 00:00:00 2001
+From: Louis Sautier <sautier.louis@gmail.com>
+Date: Sat, 30 Jan 2016 15:06:35 +0100
+Subject: [PATCH] Fix #15 by making the output predictably sorted
+
+Fixes https://github.com/Fuuzetsu/torrentinfo/issues/15
+---
+ src/torrentinfo.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/torrentinfo.py b/src/torrentinfo.py
+index a8ffea4..07b653b 100755
+--- a/src/torrentinfo.py
++++ b/src/torrentinfo.py
+@@ -569,7 +569,7 @@ def list_files(config, torrent, detailed=False):
+ 
+             config.formatter.string_format(TextFormatter.NORMAL, config, '\n')
+             if detailed:
+-                for kwrd in filestorrent[index]:
++                for kwrd in sorted(filestorrent[index], reverse=True):
+                     start_line(config, kwrd, 3, postfix='\n')
+                     dump(filestorrent[index][kwrd], config, 4)
+             else:

--- a/net-p2p/torrentinfo/metadata.xml
+++ b/net-p2p/torrentinfo/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>sautier.louis@gmail.com</email>
+		<name>Louis Sautier</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<maintainer>
 			<email>fuuzetsu@fuuzetsu.co.uk</email>

--- a/net-p2p/torrentinfo/torrentinfo-1.8.6-r1.ebuild
+++ b/net-p2p/torrentinfo/torrentinfo-1.8.6-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} pypy{,3} )
+
+inherit distutils-r1
+
+DESCRIPTION="A torrent file parser"
+HOMEPAGE="https://github.com/Fuuzetsu/torrentinfo"
+SRC_URI="https://github.com/Fuuzetsu/torrentinfo/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? ( dev-python/nose[${PYTHON_USEDEP}] )
+"
+
+PATCHES=( "${FILESDIR}/${P}-fix-tests.patch" )
+
+python_test() {
+	nosetests test/tests.py || die "tests failed with ${EPYTHON}"
+}


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=493682
@gktrk Adding myself as maintainer following your email.
```diff
--- torrentinfo-1.8.6.ebuild    2017-03-06 08:55:41.032651068 +0100
+++ torrentinfo-1.8.6-r1.ebuild 2017-03-06 10:42:47.004150342 +0100
@@ -1,8 +1,8 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2

-EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} pypy{,3} )

 inherit distutils-r1

@@ -10,14 +10,18 @@
 HOMEPAGE="https://github.com/Fuuzetsu/torrentinfo"
 SRC_URI="https://github.com/Fuuzetsu/torrentinfo/archive/v${PV}.tar.gz -> ${P}.tar.gz"

-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="test"

-DEPEND="test? ( dev-python/nose[${PYTHON_USEDEP}] )"
+DEPEND="
+       dev-python/setuptools[${PYTHON_USEDEP}]
+       test? ( dev-python/nose[${PYTHON_USEDEP}] )
+"
+
+PATCHES=( "${FILESDIR}/${P}-fix-tests.patch" )

 python_test() {
-       # tests sometimes fail, see bug #493682
        nosetests test/tests.py || die "tests failed with ${EPYTHON}"
 }
```