### PR TITLE
media-tv/kodi: Add dependency on dev-libs/libfmt

### DIFF
--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -57,6 +57,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=dev-libs/yajl-2
 	dev-python/pillow[${PYTHON_USEDEP}]
 	dev-libs/libcdio
+	dev-libs/libfmt
 	gles? ( media-libs/mesa[gles2] )
 	libusb? ( virtual/libusb:1 )
 	media-fonts/corefonts


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=611802

Ready for merging once #4143 has been merged.