### PR TITLE
Observable behaviour fixes for some app-leechcraft/ modules

### DIFF
--- a/app-leechcraft/lc-kbswitch/lc-kbswitch-9999.ebuild
+++ b/app-leechcraft/lc-kbswitch/lc-kbswitch-9999.ebuild
@@ -3,13 +3,13 @@
 
 EAPI=6
 
-inherit leechcraft
+inherit eutils leechcraft
 
 DESCRIPTION="Provides plugin- or tab-grained keyboard layout control"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="debug quark"
+IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
 	dev-qt/qtnetwork:5
@@ -19,4 +19,9 @@ DEPEND="~app-leechcraft/lc-core-${PV}
 "
 RDEPEND="${DEPEND}
 	x11-apps/setxkbmap
-	quark? ( ~virtual/leechcraft-quark-sideprovider-${PV} )"
+	"
+
+pkg_postinst() {
+	elog "Consider installing the following for additional features:"
+	optfeature "display layout indicator in LeechCraft tray" virtual/leechcraft-quark-sideprovider
+}

--- a/app-leechcraft/lc-kbswitch/metadata.xml
+++ b/app-leechcraft/lc-kbswitch/metadata.xml
@@ -9,7 +9,4 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
-	<use>
-		<flag name="quark">Provide sidebar quark</flag>
-	</use>
 </pkgmetadata>

--- a/app-leechcraft/lc-poshuku/lc-poshuku-9999.ebuild
+++ b/app-leechcraft/lc-poshuku/lc-poshuku-9999.ebuild
@@ -43,8 +43,8 @@ src_configure() {
 		-DENABLE_POSHUKU_ONLINEBOOKMARKS=$(usex onlinebookmarks)
 		-DENABLE_POSHUKU_QRD=$(usex qrd)
 		-DENABLE_POSHUKU_SPEEDDIAL=$(usex speeddial)
-		-DENABLE_POSHUKU_WEBKITVIEW=$(usex webkitview)
-		-DENABLE_POSHUKU_WEBENGINEVIEW=$(usex webengineview)
+		-DENABLE_POSHUKU_WEBKITVIEW=$(usex webkit)
+		-DENABLE_POSHUKU_WEBENGINEVIEW=$(usex webengine)
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
1. Don't introduce unnecessary RDEPENDs where a pkg_postinst message would do.
2. Fix flag names in $(usex) invocations.