### PR TITLE
dev-libs/boost: Remove ancient boost debris

### DIFF
--- a/dev-libs/boost/boost-1.62.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.62.0-r1.ebuild
@@ -436,4 +436,9 @@ pkg_preinst() {
 			rm -f "${symlink}" || die
 		fi
 	done
+
+	# some ancient installs still have boost cruft lying around
+	# for unknown reasons, causing havoc for reverse dependencies
+	# Bug: 607734
+	rm -rf "${EROOT%/}"/usr/include/boost-1_[3-5]? || die
 }

--- a/dev-libs/boost/boost-1.63.0.ebuild
+++ b/dev-libs/boost/boost-1.63.0.ebuild
@@ -432,4 +432,9 @@ pkg_preinst() {
 			rm -f "${symlink}" || die
 		fi
 	done
+
+	# some ancient installs still have boost cruft lying around
+	# for unknown reasons, causing havoc for reverse dependencies
+	# Bug: 607734
+	rm -rf "${EROOT%/}"/usr/include/boost-1_[3-5]? || die
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=607734
Package-Manager: Portage-2.3.4, Repoman-2.3.2