### PR TITLE
sci-misc/mendeleydesktop: Fix several issues with 1.17.8

### DIFF
--- a/sci-misc/mendeleydesktop/files/mendeleydesktop-1.17_libdir.patch
+++ b/sci-misc/mendeleydesktop/files/mendeleydesktop-1.17_libdir.patch
@@ -1,0 +1,19 @@
+Patch to find libstdc++.
+
+https://bugs.funtoo.org/browse/FL-3519
+--- a/bin/mendeleydesktop
++++ b/bin/mendeleydesktop
+@@ -29,6 +29,13 @@ def library_paths():
+     paths.append("/usr/lib/x86_64-linux-gnu")
+     paths.append("/usr/lib/i386-linux-gnu")
+ 
++    gcc_libpath = subprocess.Popen(
++        '/usr/bin/gcc-config -L', shell=True, stdout=subprocess.PIPE,
++    ).stdout.read().decode('utf-8').replace('\n', '').split(':')
++    for path in gcc_libpath:
++        if len(path) > 0:
++            paths.append(path)
++
+     return paths
+ 
+ def library_version_from_path(lib_path):

--- a/sci-misc/mendeleydesktop/files/mendeleydesktop-1.17_qt5plugins.patch
+++ b/sci-misc/mendeleydesktop/files/mendeleydesktop-1.17_qt5plugins.patch
@@ -1,0 +1,15 @@
+Patch to find qt5 plugins.
+
+Patch by Marius Brehler <marbre@linux.sungazer.de>
+--- a/bin/mendeleydesktop
++++ b/bin/mendeleydesktop
+@@ -75,7 +83,7 @@ def get_paths():
+         else:
+             results['MENDELEY_BIN'] = results['MENDELEY_BASE'] + "/lib/mendeleydesktop/libexec/mendeleydesktop.i486"
+ 
+-        results['MENDELEY_BUNDLED_QT_PLUGIN'] = results['MENDELEY_BASE'] + "/lib/mendeleydesktop/plugins/"
++        results['MENDELEY_BUNDLED_QT_PLUGIN'] = "/usr/lib/qt5/plugins"
+ 
+     # Path to Mendeley Desktop and PDFNet libraries
+     results['MENDELEY_LIB'] = results['MENDELEY_BASE'] + "/lib/"
+ 

--- a/sci-misc/mendeleydesktop/files/mendeleydesktop-1.17_unix-distro-build.patch
+++ b/sci-misc/mendeleydesktop/files/mendeleydesktop-1.17_unix-distro-build.patch
@@ -1,0 +1,16 @@
+Patch to force --unix-distro-build.
+
+Patch by Marius Brehler <marbre@linux.sungazer.de>
+--- a/bin/mendeleydesktop
++++ b/bin/mendeleydesktop
+@@ -159,10 +167,7 @@ def mendeley_desktop_arguments():
+     """ Returns a list with the argumetns to be appended to Mendeley Desktop. """
+     extra_args = sys.argv[1:]
+ 
+-    if is_linux_distro_build():
+-        # Enable Linux distro specific changes (eg. in auto-update
+-        # handling)
+-        extra_args = extra_args + ["--unix-distro-build"]
++    extra_args = extra_args + ["--unix-distro-build"]
+ 
+     use_debugger = sys.argv.count("--debug") > 0

--- a/sci-misc/mendeleydesktop/mendeleydesktop-1.17.8-r1.ebuild
+++ b/sci-misc/mendeleydesktop/mendeleydesktop-1.17.8-r1.ebuild
@@ -64,19 +64,25 @@ src_unpack() {
 }
 
 src_prepare() {
+	# patch launcher script
+	epatch "${FILESDIR}/${PN}-1.17_libdir.patch"
+	epatch "${FILESDIR}/${PN}-1.17_qt5plugins.patch"
+	epatch "${FILESDIR}/${PN}-1.17_unix-distro-build.patch"
+
 	# remove bundled Qt libraries
 	rm -r lib/mendeleydesktop/plugins \
 		|| die "failed to remove plugin directory"
 	rm -r lib/qt || die "failed to remove qt libraries"
 
-	# force use of system Qt libraries
-	sed -i "s:sys\.argv\.count(\"--force-system-qt\") > 0:True:" \
-		bin/mendeleydesktop || die "failed to patch startup script"
+	# fix qt library path
+	sed -i \
+		-e "s:lib/qt5/plugins:$(get_libdir)/qt5/plugins:g" \
+		bin/mendeleydesktop || die "failed to patch plugin path"
 
 	# fix library paths
 	sed -i \
 		-e "s:lib/mendeleydesktop:$(get_libdir)/mendeleydesktop:g" \
-		-e "s:MENDELEY_BASE_PATH + \"/lib/\":MENDELEY_BASE_PATH + \"/$(get_libdir)/\":g" \
+		-e "s:MENDELEY_BASE'] + \"/lib/\":MENDELEY_BASE'] + \"/$(get_libdir)/\":g" \
 		bin/mendeleydesktop || die "failed to patch library path"
 
 	default
@@ -114,8 +120,7 @@ src_install() {
 	doins -r share/mendeleydesktop
 
 	# install launch script
-	into /opt
-	make_wrapper ${PN} "/opt/${PN}/bin/${PN} --unix-distro-build"
+	dosym /opt/mendeleydesktop/bin/mendeleydesktop /opt/bin/mendeleydesktop
 }
 
 pkg_postinst() {


### PR DESCRIPTION
@jlec @SoapGentoo @xmw 

Finally fixed the issues, introduced with the version bump to 1.17.8:
* Adopted Funtoos patch to determine the path to libstdc++. Could be moved to PATCHES array.
* Patch to set path to plugins. Could actually also be done with sed and is modified via sed, but didn't worked here. Cannot be moved to PATCHES array, as the path is modified again.
* Patch to force --unix-distro-build. A patch is required anyway to either force the is_linux_distro_build() function, but this way was much easier. Could be moved to PATCHES array.

The wrapper_script is actually not needed any longer, as the argument is stripped prior to calling the binary. Maybe the fixes could be done in a *nicer* way, but this brings back a functional mendeley version to the tree! Upgrading without the option to roll back (without a local overlay) wasn't really fun in our office.

https://bugs.gentoo.org/611792

Package-Manager: Portage-2.3.3, Repoman-2.3.1