### PR TITLE
python-single-r1 for gnome packages

### DIFF
--- a/app-editors/gedit-plugins/gedit-plugins-3.20.0.ebuild
+++ b/app-editors/gedit-plugins/gedit-plugins-3.20.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{4,5} )
 PYTHON_REQ_USE="xml"
 VALA_MIN_API_VERSION="0.28"
 
-inherit eutils gnome2 multilib python-r1 vala
+inherit eutils gnome2 multilib python-single-r1 vala
 
 DESCRIPTION="Official plugins for gedit"
 HOMEPAGE="https://wiki.gnome.org/Apps/Gedit/ShippedPlugins"
@@ -22,7 +22,7 @@ IUSE="+python ${IUSE_plugins}"
 REQUIRED_USE="
 	charmap? ( python )
 	git? ( python )
-	python? ( ^^ ( $(python_gen_useflags '*') ) )
+	python? ( ${PYTHON_REQUIRED_USE} )
 	terminal? ( python )
 	zeitgeist? ( python )
 "
@@ -59,7 +59,7 @@ DEPEND="${RDEPEND}
 "
 
 pkg_setup() {
-	use python && [[ ${MERGE_TYPE} != binary ]] && python_setup
+	use python && [[ ${MERGE_TYPE} != binary ]] && python-single-r1_pkg_setup
 }
 
 src_prepare() {

--- a/app-editors/gedit-plugins/gedit-plugins-3.22.0.ebuild
+++ b/app-editors/gedit-plugins/gedit-plugins-3.22.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{4,5} )
 PYTHON_REQ_USE="xml"
 VALA_MIN_API_VERSION="0.28"
 
-inherit eutils gnome2 multilib python-r1 vala
+inherit eutils gnome2 multilib python-single-r1 vala
 
 DESCRIPTION="Official plugins for gedit"
 HOMEPAGE="https://wiki.gnome.org/Apps/Gedit/ShippedPlugins"
@@ -22,7 +22,7 @@ IUSE="+python ${IUSE_plugins}"
 REQUIRED_USE="
 	charmap? ( python )
 	git? ( python )
-	python? ( ^^ ( $(python_gen_useflags '*') ) )
+	python? ( ${PYTHON_REQUIRED_USE} )
 	terminal? ( python )
 	zeitgeist? ( python )
 "
@@ -59,7 +59,7 @@ DEPEND="${RDEPEND}
 "
 
 pkg_setup() {
-	use python && [[ ${MERGE_TYPE} != binary ]] && python_setup
+	use python && [[ ${MERGE_TYPE} != binary ]] && python-single-r1_pkg_setup
 }
 
 src_prepare() {

--- a/app-editors/gedit/gedit-3.20.2.ebuild
+++ b/app-editors/gedit/gedit-3.20.2.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{4,5} )
 VALA_MIN_API_VERSION="0.26"
 VALA_USE_DEPEND="vapigen"
 
-inherit eutils gnome2 multilib python-r1 vala virtualx
+inherit eutils gnome2 multilib python-single-r1 vala virtualx
 
 DESCRIPTION="A text editor for the GNOME desktop"
 HOMEPAGE="https://wiki.gnome.org/Apps/Gedit"
@@ -16,12 +16,7 @@ LICENSE="GPL-2+ CC-BY-SA-3.0"
 SLOT="0"
 
 IUSE="+introspection +python spell vala"
-# python-single-r1 would request disabling PYTHON_TARGETS on libpeas
-# we need to fix that
-REQUIRED_USE="
-	python? ( introspection )
-	python? ( ^^ ( $(python_gen_useflags '*') ) )
-"
+REQUIRED_USE="python? ( introspection ${PYTHON_REQUIRED_USE} )"
 
 KEYWORDS="~alpha amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
 
@@ -65,7 +60,7 @@ DEPEND="${COMMON_DEPEND}
 # yelp-tools, gnome-common needed to eautoreconf
 
 pkg_setup() {
-	use python && [[ ${MERGE_TYPE} != binary ]] && python_setup
+	use python && [[ ${MERGE_TYPE} != binary ]] && python-single-r1_pkg_setup
 }
 
 src_prepare() {

--- a/app-editors/gedit/gedit-3.22.0.ebuild
+++ b/app-editors/gedit/gedit-3.22.0.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{4,5} )
 VALA_MIN_API_VERSION="0.26"
 VALA_USE_DEPEND="vapigen"
 
-inherit eutils gnome2 multilib python-r1 vala virtualx
+inherit eutils gnome2 multilib python-single-r1 vala virtualx
 
 DESCRIPTION="A text editor for the GNOME desktop"
 HOMEPAGE="https://wiki.gnome.org/Apps/Gedit"
@@ -16,12 +16,7 @@ LICENSE="GPL-2+ CC-BY-SA-3.0"
 SLOT="0"
 
 IUSE="+introspection +python spell vala"
-# python-single-r1 would request disabling PYTHON_TARGETS on libpeas
-# we need to fix that
-REQUIRED_USE="
-	python? ( introspection )
-	python? ( ^^ ( $(python_gen_useflags '*') ) )
-"
+REQUIRED_USE="python? ( introspection ${PYTHON_REQUIRED_USE} )"
 
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
 
@@ -61,7 +56,7 @@ DEPEND="${COMMON_DEPEND}
 # yelp-tools, gnome-common needed to eautoreconf
 
 pkg_setup() {
-	use python && [[ ${MERGE_TYPE} != binary ]] && python_setup
+	use python && [[ ${MERGE_TYPE} != binary ]] && python-single-r1_pkg_setup
 }
 
 src_prepare() {


### PR DESCRIPTION
Using `python-single-r1.eclass` is much better than the current solution, which forces people to add pointless stuff to `package.use` that would be handled by `PYTHON_SINGLE_TARGET`.