### PR TITLE
dev-python/pygtk: Fix build on macOS, bugs 370079 and 400843

### DIFF
--- a/dev-python/pygtk/files/pygtk-2.24.0-quartz-objc.patch
+++ b/dev-python/pygtk/files/pygtk-2.24.0-quartz-objc.patch
@@ -1,0 +1,45 @@
+From: Anders F Bjorklund <afb@users.sourceforge.net>
+Date: Mon, 4 Apr 2011 21:34:20 +0200
+Subject: [PATCH] use objective-c for quartz
+
+https://bugzilla.gnome.org/show_bug.cgi?id=646743
+---
+ configure.ac    | 5 +++++
+ gtk/Makefile.am | 5 +++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 84c78f6c..27192f9c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -445,6 +445,11 @@ case $gdk_target in
+         ;;
+ esac
+ 
++if test "x$gdk_target" = "xquartz"; then
++  AM_CONDITIONAL(USE_QUARTZ, true)
++else
++  AM_CONDITIONAL(USE_QUARTZ, false)
++fi
+ 
+ dnl checks to see if numpy is installed.
+ AC_ARG_ENABLE(numpy,
+diff --git a/gtk/Makefile.am b/gtk/Makefile.am
+index 7bb5d0c8..44d68700 100644
+--- a/gtk/Makefile.am
++++ b/gtk/Makefile.am
+@@ -9,6 +9,11 @@ INCLUDES = \
+ 	$(PYGOBJECT_CFLAGS) \
+ 	-I$(srcdir)/gtk
+ 
++if USE_QUARTZ
++# same as in gtk+/gdk/quartz/Makefile.am
++INCLUDES += "-xobjective-c"
++endif
++
+ # defs files
+ defsdir = $(pkgdatadir)/$(PLATFORM_VERSION)/defs
+ defs_DATA =
+-- 
+2.12.0
+

--- a/dev-python/pygtk/pygtk-2.24.0-r4.ebuild
+++ b/dev-python/pygtk/pygtk-2.24.0-r4.ebuild
@@ -47,6 +47,9 @@ src_prepare() {
 	# Fix broken tests, https://bugzilla.gnome.org/show_bug.cgi?id=709304
 	epatch "${FILESDIR}/${P}-test_dialog.patch"
 
+	# Fix build on Darwin
+	epatch "${FILESDIR}/${PN}-2.24.0-quartz-objc.patch"
+
 	# Examples is handled "manually"
 	sed -e 's/\(SUBDIRS = .* \)examples/\1/' \
 		-i Makefile.am Makefile.in || die


### PR DESCRIPTION
This applies a [patch](https://git.gnome.org//browse/pygtk/commit/?id=f655433394b10ccea585f54f38a9531304b4b084) from upstream to fix the build, but with a typo fix (`$gdktarget -> $gdk_target`).

Please see bugs [370079](https://bugs.gentoo.org/370079) and [400843](https://bugs.gentoo.org/400843) for more information.
