### PR TITLE
[WIP] CPU_FLAGS_ARM

### DIFF
--- a/dev-cpp/eigen/eigen-3.3.1.ebuild
+++ b/dev-cpp/eigen/eigen-3.3.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://bitbucket.org/eigen/eigen/get/${PV}.tar.bz2 -> ${P}.tar.bz2"
 LICENSE="LGPL-2 GPL-3"
 SLOT="3"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="altivec c++11 cuda debug doc neon openmp test" #zvector vsx
+IUSE="altivec c++11 cpu_flags_arm_neon cuda debug doc openmp test" #zvector vsx
 
 IUSE_CPU_FLAGS=" avx avx2 f16c fma3 sse2 sse3 sse4_1 sse4_2 ssse3" #x87
 IUSE+=" ${IUSE_CPU_FLAGS// / cpu_flags_x86_}"
@@ -96,7 +96,7 @@ src_test() {
 		-DEIGEN_TEST_SSE4_1="$(usex cpu_flags_x86_sse4_1)"
 		-DEIGEN_TEST_SSE4_2="$(usex cpu_flags_x86_sse4_2)"
 		-DEIGEN_TEST_SSSE3="$(usex cpu_flags_x86_ssse3)"
-		-DEIGEN_TEST_NEON64="$(usex neon)"
+		-DEIGEN_TEST_NEON64="$(usex cpu_flags_arm_neon)"
 #		-DEIGEN_TEST_X87="$(usex cpu_flags_x86_x87)"
 	)
 	cmake-utils_src_configure

--- a/dev-cpp/eigen/eigen-3.3.2.ebuild
+++ b/dev-cpp/eigen/eigen-3.3.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://bitbucket.org/eigen/eigen/get/${PV}.tar.bz2 -> ${P}.tar.bz2"
 LICENSE="LGPL-2 GPL-3"
 SLOT="3"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="altivec c++11 cuda debug doc neon openmp test" #zvector vsx
+IUSE="altivec c++11 cpu_flags_arm_neon cuda debug doc openmp test" #zvector vsx
 
 IUSE_CPU_FLAGS=" avx avx2 f16c fma3 sse2 sse3 sse4_1 sse4_2 ssse3" #x87
 IUSE+=" ${IUSE_CPU_FLAGS// / cpu_flags_x86_}"
@@ -96,7 +96,7 @@ src_test() {
 		-DEIGEN_TEST_SSE4_1="$(usex cpu_flags_x86_sse4_1)"
 		-DEIGEN_TEST_SSE4_2="$(usex cpu_flags_x86_sse4_2)"
 		-DEIGEN_TEST_SSSE3="$(usex cpu_flags_x86_ssse3)"
-		-DEIGEN_TEST_NEON64="$(usex neon)"
+		-DEIGEN_TEST_NEON64="$(usex cpu_flags_arm_neon)"
 #		-DEIGEN_TEST_X87="$(usex cpu_flags_x86_x87)"
 	)
 	cmake-utils_src_configure

--- a/dev-cpp/eigen/eigen-3.3.3.ebuild
+++ b/dev-cpp/eigen/eigen-3.3.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://bitbucket.org/eigen/eigen/get/${PV}.tar.bz2 -> ${P}.tar.bz2"
 LICENSE="MPL-2.0"
 SLOT="3"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="altivec c++11 cuda debug doc neon openmp test" #zvector vsx
+IUSE="altivec c++11 cpu_flags_arm_neon cuda debug doc openmp test" #zvector vsx
 
 IUSE_CPU_FLAGS=" avx avx2 f16c fma3 sse2 sse3 sse4_1 sse4_2 ssse3" #x87
 IUSE+=" ${IUSE_CPU_FLAGS// / cpu_flags_x86_}"
@@ -92,7 +92,7 @@ src_test() {
 		-DEIGEN_TEST_SSE4_1="$(usex cpu_flags_x86_sse4_1)"
 		-DEIGEN_TEST_SSE4_2="$(usex cpu_flags_x86_sse4_2)"
 		-DEIGEN_TEST_SSSE3="$(usex cpu_flags_x86_ssse3)"
-		-DEIGEN_TEST_NEON64="$(usex neon)"
+		-DEIGEN_TEST_NEON64="$(usex cpu_flags_arm_neon)"
 #		-DEIGEN_TEST_X87="$(usex cpu_flags_x86_x87)"
 	)
 	cmake-utils_src_configure

--- a/dev-libs/OpenNI2/OpenNI2-2.2_beta2.ebuild
+++ b/dev-libs/OpenNI2/OpenNI2-2.2_beta2.ebuild
@@ -24,7 +24,7 @@ DESCRIPTION="OpenNI2 SDK"
 HOMEPAGE="http://structure.io/openni"
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="doc java neon opengl static-libs"
+IUSE="cpu_flags_arm_neon doc java opengl static-libs"
 
 RDEPEND="
 	virtual/libusb:1
@@ -53,7 +53,7 @@ src_prepare() {
 }
 
 src_compile() {
-	use neon && export CFLAGS="${CFLAGS} -DXN_NEON"
+	use cpu_flags_arm_neon && export CFLAGS="${CFLAGS} -DXN_NEON"
 	emake \
 		CC="$(tc-getCC)" \
 		CXX="$(tc-getCXX)" \

--- a/dev-libs/OpenNI2/OpenNI2-9999.ebuild
+++ b/dev-libs/OpenNI2/OpenNI2-9999.ebuild
@@ -24,7 +24,7 @@ DESCRIPTION="OpenNI2 SDK"
 HOMEPAGE="http://structure.io/openni"
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="doc java neon opengl static-libs"
+IUSE="cpu_flags_arm_neon doc java opengl static-libs"
 
 RDEPEND="
 	virtual/libusb:1
@@ -51,7 +51,7 @@ src_prepare() {
 }
 
 src_compile() {
-	use neon && export CFLAGS="${CFLAGS} -DXN_NEON"
+	use cpu_flags_arm_neon && export CFLAGS="${CFLAGS} -DXN_NEON"
 	emake \
 		CC="$(tc-getCC)" \
 		CXX="$(tc-getCXX)" \

--- a/dev-libs/efl/efl-1.17.0-r1.ebuild
+++ b/dev-libs/efl/efl-1.17.0-r1.ebuild
@@ -22,7 +22,7 @@ inherit enlightenment pax-utils
 DESCRIPTION="Enlightenment Foundation Libraries all-in-one package"
 
 LICENSE="BSD-2 GPL-2 LGPL-2.1 ZLIB"
-IUSE="+bmp debug drm +eet egl fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz +ico ibus jpeg2k libressl neon oldlua opengl ssl physics pixman +png +ppm +psd pulseaudio scim sdl sound systemd tga tiff tslib unwind v4l valgrind wayland webp X xim xine xpm"
+IUSE="+bmp cpu_flags_arm_neon debug drm +eet egl fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz +ico ibus jpeg2k libressl oldlua opengl ssl physics pixman +png +ppm +psd pulseaudio scim sdl sound systemd tga tiff tslib unwind v4l valgrind wayland webp X xim xine xpm"
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x64-solaris ~x86-solaris"
 
 REQUIRED_USE="
@@ -207,6 +207,7 @@ src_configure() {
 
 		$(use_enable bmp image-loader-bmp)
 		$(use_enable bmp image-loader-wbmp)
+		$(use_enable cpu_flags_arm_neon neon)
 		$(use_enable drm)
 		$(use_enable doc)
 		$(use_enable eet image-loader-eet)
@@ -220,7 +221,6 @@ src_configure() {
 		$(use_enable ico image-loader-ico)
 		$(use_enable ibus)
 		$(use_enable jpeg2k image-loader-jp2k)
-		$(use_enable neon)
 		$(use_enable nls)
 		$(use_enable oldlua lua-old)
 		$(use_enable physics)

--- a/dev-libs/efl/efl-1.18.4.ebuild
+++ b/dev-libs/efl/efl-1.18.4.ebuild
@@ -21,7 +21,7 @@ inherit enlightenment pax-utils
 DESCRIPTION="Enlightenment Foundation Libraries all-in-one package"
 
 LICENSE="BSD-2 GPL-2 LGPL-2.1 ZLIB"
-IUSE="+bmp debug drm +eet egl fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz +ico ibus jpeg2k libressl neon oldlua opengl ssl physics pixman +png postscript +ppm +psd pulseaudio raw scim sdl sound systemd tga tiff tslib unwind v4l valgrind wayland webp X xim xine xpm"
+IUSE="+bmp cpu_flags_arm_neon debug drm +eet egl fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz +ico ibus jpeg2k libressl oldlua opengl ssl physics pixman +png postscript +ppm +psd pulseaudio raw scim sdl sound systemd tga tiff tslib unwind v4l valgrind wayland webp X xim xine xpm"
 
 REQUIRED_USE="
 	pulseaudio?	( sound )
@@ -208,6 +208,7 @@ src_configure() {
 
 		$(use_enable bmp image-loader-bmp)
 		$(use_enable bmp image-loader-wbmp)
+		$(use_enable cpu_flags_arm_neon neon)
 		$(use_enable drm)
 		$(use_enable doc)
 		$(use_enable eet image-loader-eet)
@@ -221,7 +222,6 @@ src_configure() {
 		$(use_enable ico image-loader-ico)
 		$(use_enable ibus)
 		$(use_enable jpeg2k image-loader-jp2k)
-		$(use_enable neon)
 		$(use_enable nls)
 		$(use_enable oldlua lua-old)
 		$(use_enable physics)

--- a/dev-libs/efl/efl-9999.ebuild
+++ b/dev-libs/efl/efl-9999.ebuild
@@ -21,7 +21,7 @@ inherit enlightenment pax-utils
 DESCRIPTION="Enlightenment Foundation Libraries all-in-one package"
 
 LICENSE="BSD-2 GPL-2 LGPL-2.1 ZLIB"
-IUSE="+bmp debug drm +eet egl fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz +ico ibus jpeg2k libressl neon oldlua opengl ssl physics pixman +png postscript +ppm +psd pulseaudio raw scim sdl sound systemd tga tiff tslib unwind v4l valgrind wayland webp X xim xine xpm"
+IUSE="+bmp cpu_flags_arm_neon debug drm +eet egl fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz +ico ibus jpeg2k libressl oldlua opengl ssl physics pixman +png postscript +ppm +psd pulseaudio raw scim sdl sound systemd tga tiff tslib unwind v4l valgrind wayland webp X xim xine xpm"
 
 REQUIRED_USE="
 	pulseaudio?	( sound )
@@ -208,6 +208,7 @@ src_configure() {
 
 		$(use_enable bmp image-loader-bmp)
 		$(use_enable bmp image-loader-wbmp)
+		$(use_enable cpu_flags_arm_neon neon)
 		$(use_enable drm)
 		$(use_enable doc)
 		$(use_enable eet image-loader-eet)
@@ -221,7 +222,6 @@ src_configure() {
 		$(use_enable ico image-loader-ico)
 		$(use_enable ibus)
 		$(use_enable jpeg2k image-loader-jp2k)
-		$(use_enable neon)
 		$(use_enable nls)
 		$(use_enable oldlua lua-old)
 		$(use_enable physics)

--- a/games-board/stockfish/metadata.xml
+++ b/games-board/stockfish/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Matthias Maier</name>
 	</maintainer>
 	<use>
-		<flag name="armv7">Build for armv7; enables PIE</flag>
 		<flag name="general-32">Generic unoptimized 32-bits build</flag>
 		<flag name="general-64">Generic unoptimized 64-bits build</flag>
 		<flag name="optimize">Enable upstream -O3 optimizations (default enabled)</flag>

--- a/games-board/stockfish/stockfish-8.ebuild
+++ b/games-board/stockfish/stockfish-8.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://stockfish.s3.amazonaws.com/${P}-src.zip"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE="armv7 cpu_flags_x86_avx2 cpu_flags_x86_popcnt cpu_flags_x86_sse debug
+IUSE="cpu_flags_arm_v7 cpu_flags_x86_avx2 cpu_flags_x86_popcnt cpu_flags_x86_sse debug
 	general-32 general-64 +optimize"
 
 DEPEND="|| ( app-arch/unzip	app-arch/zip )"
@@ -47,7 +47,7 @@ src_compile() {
 	use cpu_flags_x86_avx2 && my_arch=x86-64-bmi2
 
 	# other architectures
-	use armv7 && my_arch=armv7
+	use cpu_flags_arm_v7 && my_arch=armv7
 	use ppc && my_arch=ppc
 	use ppc64 && my_arch=ppc64
 

--- a/media-libs/speex/metadata.xml
+++ b/media-libs/speex/metadata.xml
@@ -9,7 +9,6 @@
     <remote-id type="cpe">cpe:/a:xiph:speex</remote-id>
   </upstream>
   <use>
-    <flag name="armv5te">Enables optimizations for armv5te processors.</flag>
     <flag name="utils">Enables speex commandline utilities (speexenc, speexdec).</flag>
     <flag name="vbr">Enable VBR support.</flag>
   </use>

--- a/media-libs/speex/speex-1.2.0-r1.ebuild
+++ b/media-libs/speex/speex-1.2.0-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://downloads.xiph.org/releases/speex/${MY_P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
-IUSE="armv5te cpu_flags_x86_sse static-libs utils +vbr"
+IUSE="cpu_flags_arm_v5te cpu_flags_x86_sse static-libs utils +vbr"
 
 RDEPEND="
 	utils? (
@@ -45,8 +45,8 @@ multilib_src_configure() {
 	# --enable-fixed-point
 	ECONF_SOURCE="${S}" econf \
 		$(use_enable static-libs static) \
-		$(usex arm $(usex armv5te '--disable-arm4-asm' '--enable-arm4-asm') '--disable-arm4-asm') \
-		$(use_enable armv5te arm5e-asm) \
+		$(usex arm $(usex cpu_flags_arm_v5te '--disable-arm4-asm' '--enable-arm4-asm') '--disable-arm4-asm') \
+		$(use_enable cpu_flags_arm_v5te arm5e-asm) \
 		$(use_enable cpu_flags_x86_sse sse) \
 		$(use_enable vbr) \
 		$(use_with utils speexdsp) \


### PR DESCRIPTION
Done so far:
- [x] .desc and USE_EXPAND for CPU_FLAGS_ARM
- [x] profile masks/forces
- [ ] packages
- [ ] cleanup of old flags from profiles

@aballier, @leio, @gentoo/arm

Help would much appreciated.

@aballier, could you please convert ffmpeg and libav? I don't want to figure out those arrays ;-).

Could also someone shed some light on why the profiles are doing what they're doing? Like why most of the flags are masked on most of arch profiles, and e.g. armv5te profile unmasks (but does not force) armv5te?