### PR TITLE
net-libs/libgfbgraph is missing use flag on deps

### DIFF
--- a/net-libs/libgfbgraph/libgfbgraph-0.2.2.ebuild
+++ b/net-libs/libgfbgraph/libgfbgraph-0.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -17,10 +17,10 @@ IUSE="+introspection"
 
 RDEPEND="
 	dev-libs/glib:2
-	dev-libs/json-glib
+	dev-libs/json-glib[introspection]
 	net-libs/libsoup:2.4
 	net-libs/gnome-online-accounts
-	net-libs/rest:0.7
+	net-libs/rest:0.7[introspection]
 	introspection? ( >=dev-libs/gobject-introspection-1.30 )
 "
 DEPEND="${RDEPEND}

--- a/net-libs/libgfbgraph/libgfbgraph-0.2.3.ebuild
+++ b/net-libs/libgfbgraph/libgfbgraph-0.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -17,10 +17,10 @@ IUSE="+introspection"
 
 RDEPEND="
 	dev-libs/glib:2
-	dev-libs/json-glib
+	dev-libs/json-glib[introspection]
 	net-libs/libsoup:2.4
 	net-libs/gnome-online-accounts
-	net-libs/rest:0.7
+	net-libs/rest:0.7[introspection]
 	introspection? ( >=dev-libs/gobject-introspection-1.30:= )
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Introspection use flag is required to compile
libgfbgraph with glib-json and rest even if
the introspection use flag is disable on
libgfbgraph.

This issue only appears if introspection isn't
set globally to enabled. If GNOME packages don't
follow the convention of listing all use flags
in their dependencies and rely on a global use
flag you can simply ignore this change.

Issue tracked here:
https://bugs.funtoo.org/browse/FL-3647
No equivalent issue was found on the Gentoo
bugtracker.

I've run repoman full and it gave me a clean pass 
on the commit.