### PR TITLE
sys-kernel/ck-sources: resolve EAPI 5/6 regression

### DIFF
--- a/sys-kernel/ck-sources/ck-sources-4.10.2.ebuild
+++ b/sys-kernel/ck-sources/ck-sources-4.10.2.ebuild
@@ -55,4 +55,7 @@ src_prepare() {
 
 	# linux-info eclass cannot handle recursively expanded variables in Makefile #490328
 	sed -i -e 's/\(^EXTRAVERSION :=.*$\)/# \1/' "${S}/Makefile" || die
+
+	# EAPI 6: default action doesn't happen by default #612782
+	default
 }


### PR DESCRIPTION
Gentoo-Bug: #612782

Package-Manager: Portage-2.3.3, Repoman-2.3.1