### PR TITLE
games-puzzle/brainparty: Fix build with GCC-6 and update ebuild to EAPI 6

### DIFF
--- a/games-puzzle/brainparty/brainparty-0.61-r1.ebuild
+++ b/games-puzzle/brainparty/brainparty-0.61-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit eutils
+
+DESCRIPTION="A puzzle-solving, brain-stretching game for all ages"
+HOMEPAGE="http://www.tuxradar.com/brainparty"
+SRC_URI="https://launchpad.net/brainparty/trunk/${PV}/+download/${PN}${PV}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+DEPEND="media-libs/libsdl[sound,opengl,video]
+	media-libs/sdl-mixer[vorbis]
+	media-libs/sdl-ttf
+	media-libs/sdl-image[png]
+	media-libs/sdl-gfx"
+RDEPEND=${DEPEND}
+
+S=${WORKDIR}/${PN}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-savegame.patch
+	"${FILESDIR}"/${P}-gcc49.patch
+	"${FILESDIR}"/${P}-gnu_cxx-hash.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i \
+		-e 's/$(LIBS) $(OSXCOMPAT) $(OBJFILES)/$(OSXCOMPAT) $(OBJFILES) $(LIBS)/' \
+		-e 's/CXXFLAGS = .*/CXXFLAGS+=-c/' \
+		-e '/^CXX =/d' \
+		-e '/-o brainparty/s/INCLUDES) /&$(LDFLAGS) /' \
+		Makefile || die
+	sed -i \
+		"/^int main(/ a\\\\tchdir(\"/usr/share/${PN}\");\n" \
+		main.cpp || die
+}
+
+src_install() {
+	dobin brainparty
+	insinto "/usr/share/${PN}/Content"
+	doins -r Content/.
+	newicon Content/icon.bmp ${PN}.bmp
+	make_desktop_entry brainparty "Brain Party" /usr/share/pixmaps/${PN}.bmp
+}

--- a/games-puzzle/brainparty/brainparty-0.61.ebuild
+++ b/games-puzzle/brainparty/brainparty-0.61.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -34,7 +34,8 @@ src_prepare() {
 		main.cpp || die
 	epatch \
 		"${FILESDIR}"/${P}-savegame.patch \
-		"${FILESDIR}"/${P}-gcc49.patch
+		"${FILESDIR}"/${P}-gcc49.patch \
+		"${FILESDIR}"/${P}-gnu_cxx-hash.patch
 
 }
 

--- a/games-puzzle/brainparty/files/brainparty-0.61-gnu_cxx-hash.patch
+++ b/games-puzzle/brainparty/files/brainparty-0.61-gnu_cxx-hash.patch
@@ -1,0 +1,11 @@
+--- a/WordList.h
++++ b/WordList.h
+@@ -35,7 +35,7 @@
+ 	};
+ }
+ 
+-typedef hash_set<string, hash<string> > string_hash_set;
++typedef hash_set<string, __gnu_cxx::hash<string> > string_hash_set;
+ 
+ class WordList {
+ private:


### PR DESCRIPTION
Fix https://bugs.gentoo.org/show_bug.cgi?id=612654 and update ebuild to EAPI 6.