### PR TITLE
games-arcade/wop: Fix GCC-6 build (bug #612526) and update ebuild to EAPI 6

### DIFF
--- a/games-arcade/wop/files/wop-0.4.3-Makefile.patch
+++ b/games-arcade/wop/files/wop-0.4.3-Makefile.patch
@@ -1,5 +1,5 @@
---- Makefile.orig	2007-04-23 18:27:32 +0000
-+++ Makefile	2007-04-23 18:27:50 +0000
+--- a/Makefile.orig	2007-04-23 18:27:32 +0000
++++ b/Makefile	2007-04-23 18:27:50 +0000
 @@ -3,22 +3,22 @@
  sinclude Makefile.local
  
@@ -32,8 +32,8 @@
  snapshot-src:
  	ln -s . wop;                                           \
  	tar cjvf wop-`date +%F`.tar.bz2                        \
---- src/Makefile.orig	2006-02-13 10:14:01.000000000 +0100
-+++ src/Makefile	2007-04-27 18:36:22.000000000 +0200
+--- a/src/Makefile.orig	2006-02-13 10:14:01.000000000 +0100
++++ b/src/Makefile	2007-04-27 18:36:22.000000000 +0200
 @@ -18,7 +18,7 @@
              -DUSE_SDL -DNEW=new\(std::nothrow\) \
              -I../sdlwidgets \

--- a/games-arcade/wop/files/wop-0.4.3-gcc43.patch
+++ b/games-arcade/wop/files/wop-0.4.3-gcc43.patch
@@ -1,5 +1,5 @@
---- src/scusibot.cpp.old	2010-01-05 15:41:23.000000000 +0100
-+++ src/scusibot.cpp	2010-01-05 15:41:46.000000000 +0100
+--- a/src/scusibot.cpp.old	2010-01-05 15:41:23.000000000 +0100
++++ b/src/scusibot.cpp	2010-01-05 15:41:46.000000000 +0100
 @@ -5,6 +5,7 @@
  #include "stationarygun.hpp"
  #include "global.hpp"
@@ -8,8 +8,8 @@
  
  ScusiBot::ScusiBot()
  	: m_event( Event::EMPTY ), m_count( 0 ), m_state( IDLE ) {
---- src/gameinfowindow.cpp.old	2010-01-05 15:45:09.000000000 +0100
-+++ src/gameinfowindow.cpp	2010-01-05 15:46:08.000000000 +0100
+--- a/src/gameinfowindow.cpp.old	2010-01-05 15:45:09.000000000 +0100
++++ b/src/gameinfowindow.cpp	2010-01-05 15:46:08.000000000 +0100
 @@ -10,6 +10,8 @@
  #include "avatarworm.hpp"
  #include "wopsprites.hpp"
@@ -19,8 +19,8 @@
  #include "scorekeeper.hpp"
  #include "wopgui.hpp"
  
---- src/map.cpp.old	2010-01-05 15:46:35.000000000 +0100
-+++ src/map.cpp	2010-01-05 15:47:06.000000000 +0100
+--- a/src/map.cpp.old	2010-01-05 15:46:35.000000000 +0100
++++ b/src/map.cpp	2010-01-05 15:47:06.000000000 +0100
 @@ -9,6 +9,8 @@
  #include "world.hpp"
  #include "wopsettings.hpp"

--- a/games-arcade/wop/files/wop-0.4.3-gcc6.patch
+++ b/games-arcade/wop/files/wop-0.4.3-gcc6.patch
@@ -1,6 +1,6 @@
 diff -Naur wop-0.4.3.old/src/global.cpp wop-0.4.3/src/global.cpp
---- wop-0.4.3.old/src/global.cpp	2017-03-16 18:48:49.114967592 -0400
-+++ wop-0.4.3/src/global.cpp	2017-03-16 18:48:55.592903512 -0400
+--- a/src/global.cpp	2017-03-16 18:48:49.114967592 -0400
++++ b/src/global.cpp	2017-03-16 18:48:55.592903512 -0400
 @@ -44,10 +44,10 @@
  #define GREEN(s)                 s
  #define RED(s)                   s

--- a/games-arcade/wop/files/wop-0.4.3-gcc6.patch
+++ b/games-arcade/wop/files/wop-0.4.3-gcc6.patch
@@ -1,0 +1,18 @@
+diff -Naur wop-0.4.3.old/src/global.cpp wop-0.4.3/src/global.cpp
+--- wop-0.4.3.old/src/global.cpp	2017-03-16 18:48:49.114967592 -0400
++++ wop-0.4.3/src/global.cpp	2017-03-16 18:48:55.592903512 -0400
+@@ -44,10 +44,10 @@
+ #define GREEN(s)                 s
+ #define RED(s)                   s
+ #else
+-#define BLACK(s)                 "\033[0;1m"s"\033[0m"
+-#define BLINKINK_BLACK_ON_RED(s) "\033[05;1;41m"s"\033[0m"
+-#define GREEN(s)                 "\033[32m"s"\033[0m"
+-#define RED(s)                   "\033[31m"s"\033[0m"
++#define BLACK(s)                 "\033[0;1m" s "\033[0m"
++#define BLINKINK_BLACK_ON_RED(s) "\033[05;1;41m" s "\033[0m"
++#define GREEN(s)                 "\033[32m" s "\033[0m"
++#define RED(s)                   "\033[31m" s "\033[0m"
+ #endif
+ 
+ /**********************************************************/

--- a/games-arcade/wop/wop-0.4.3-r1.ebuild
+++ b/games-arcade/wop/wop-0.4.3-r1.ebuild
@@ -37,7 +37,8 @@ src_prepare() {
 		woprc \
 		|| die "sed failed"
 	epatch "${FILESDIR}"/${P}-Makefile.patch \
-		"${FILESDIR}"/${P}-gcc43.patch
+		"${FILESDIR}"/${P}-gcc43.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 }
 
 src_compile() {

--- a/games-arcade/wop/wop-0.4.3-r2.ebuild
+++ b/games-arcade/wop/wop-0.4.3-r2.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit eutils toolchain-funcs
+
+MY_DATA_V="2005-12-21"
+MY_DATA_P="${PN}data-${MY_DATA_V}"
+DESCRIPTION="Worms of Prey - A multi-player, real-time clone of Worms"
+HOMEPAGE="http://wormsofprey.org/"
+SRC_URI="http://wormsofprey.org/download/${P}-src.tar.bz2
+	http://wormsofprey.org/download/${MY_DATA_P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~x86-fbsd"
+IUSE=""
+
+RDEPEND="media-libs/libsdl
+	media-libs/sdl-image
+	media-libs/sdl-mixer
+	media-libs/sdl-net
+	media-libs/sdl-ttf"
+DEPEND="${RDEPEND}
+	x11-misc/makedepend"
+
+MY_DATA_S=${WORKDIR}/${MY_DATA_P}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Makefile.patch
+	"${FILESDIR}"/${P}-gcc43.patch
+	"${FILESDIR}"/${P}-gcc6.patch
+)
+
+src_prepare() {
+	default
+
+	# patch global woprc with the correct data files location and install it
+	sed -i \
+		-e "s:^data =.*$:data = /usr/share/${PN}:" \
+		woprc \
+		|| die "sed failed"
+}
+
+src_compile() {
+	emake CXX=$(tc-getCXX)
+}
+
+src_install() {
+	dobin bin/${PN}
+	insinto /usr/share/${PN}
+	doins -r "${MY_DATA_S}"/.
+	insinto /etc
+	doins woprc
+	newicon "${MY_DATA_S}"/images/misc/icons/wop16.png ${PN}.png
+	make_desktop_entry wop "Worms of Prey"
+	dodoc AUTHORS ChangeLog README{,-Libraries.txt} REVIEWS
+}


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=612526