### PR TITLE
python-single-r1.eclass: Make Py2.7 the default impl for Py2-only ebu…

### DIFF
--- a/app-text/asciidoc/asciidoc-8.6.9-r5.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python2_7 pypy )
 
 inherit python-single-r1 readme.gentoo-r1
 

--- a/profiles/base/package.use
+++ b/profiles/base/package.use
@@ -1,6 +1,15 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# David Seifert <soap@gentoo.org> (18 Mar 2017)
+# These py2-only packages also support pypy, enable
+# Python 2.7 as the default implementation, preparing
+# for the eventual switch to py3 in PYTHON_SINGLE_TARGET
+app-text/asciidoc python_single_target_python2_7
+dev-vcs/git-bz python_single_target_python2_7
+gnome-base/libglade python_single_target_python2_7
+sci-chemistry/pdb-tools python_single_target_python2_7
+
 # Only python3 supported
 dev-libs/libixion python_single_target_python3_4
 dev-libs/liborcus python_single_target_python3_4


### PR DESCRIPTION
…ilds