### PR TITLE
App dicts eapi 6

### DIFF
--- a/app-dicts/aspell-af/aspell-af-0.50.0.ebuild
+++ b/app-dicts/aspell-af/aspell-af-0.50.0.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Afrikaans"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-be/aspell-be-0.01-r1.ebuild
+++ b/app-dicts/aspell-be/aspell-be-0.01-r1.ebuild
@@ -1,20 +1,21 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Belarusian"
 
-inherit eutils aspell-dict
-
-LICENSE="GPL-2"
-
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+inherit aspell-dict-r1
 
 SRC_URI="mirror://gnu/aspell/dict/be/aspell5-be-${PV}.tar.bz2"
+
+LICENSE="GPL-2"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE="classic"
 
 S="${WORKDIR}/aspell5-be-${PV}"
 
-src_unpack() {
-	unpack ${A}
-	use classic || epatch "${FILESDIR}"/aspell5-be-${PV}-official.patch
+src_prepare() {
+	use classic || local PATCHES=( "${FILESDIR}"/aspell5-be-${PV}-official.patch )
+	default
 }

--- a/app-dicts/aspell-bg/aspell-bg-4.1.0.ebuild
+++ b/app-dicts/aspell-bg/aspell-bg-4.1.0.ebuild
@@ -1,12 +1,13 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Bulgarian"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Bulgarian"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-br/aspell-br-0.50.2.ebuild
+++ b/app-dicts/aspell-br/aspell-br-0.50.2.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Breton"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-ca/aspell-ca-2.1.5.1.ebuild
+++ b/app-dicts/aspell-ca/aspell-ca-2.1.5.1.ebuild
@@ -1,10 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Catalan"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Catalan"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"

--- a/app-dicts/aspell-cs/aspell-cs-0.60.20040614.ebuild
+++ b/app-dicts/aspell-cs/aspell-cs-0.60.20040614.ebuild
@@ -1,15 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Czech"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Czech"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P="aspell6-cs-20040614-1"
+
+SRC_URI="mirror://gnu/aspell/dict/cs/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-FILENAME="aspell6-cs-20040614-1"
-SRC_URI="mirror://gnu/aspell/dict/cs/${FILENAME}.tar.bz2"
-S=${WORKDIR}/${FILENAME}
+S=${WORKDIR}/${MY_P}

--- a/app-dicts/aspell-cy/aspell-cy-0.50.3.ebuild
+++ b/app-dicts/aspell-cy/aspell-cy-0.50.3.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Welsh"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-da/aspell-da-1.7.42.ebuild
+++ b/app-dicts/aspell-da/aspell-da-1.7.42.ebuild
@@ -1,16 +1,17 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Danish"
 
-inherit aspell-dict
+inherit aspell-dict-r1
+
+HOMEPAGE="http://da.speling.org"
+SRC_URI="http://da.speling.org/filer/new_${P}.tar.bz2"
 
 LICENSE="GPL-2"
-HOMEPAGE="http://da.speling.org"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~ppc-macos"
 IUSE=""
-
-SRC_URI="http://da.speling.org/filer/new_${P}.tar.bz2"
 
 S="${WORKDIR}/new_${P}"

--- a/app-dicts/aspell-de-alt/aspell-de-alt-2.1.1-r1.ebuild
+++ b/app-dicts/aspell-de-alt/aspell-de-alt-2.1.1-r1.ebuild
@@ -1,23 +1,22 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="German (traditional orthography)"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit eutils aspell-dict
+ASPELL_LANG="German (traditional orthography)"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-src_unpack() {
-	unpack ${A}
-	cd "${S}"
-	epatch "${FILESDIR}/${P}-dict-name.patch"
-}
+PATCHES=( "${FILESDIR}/${P}-dict-name.patch" )
 
 src_install() {
-	aspell-dict_src_install
-	newdoc doc/README README.hk || die
-	dodoc doc/README.bj || die
+	aspell-dict-r1_src_install
+
+	newdoc doc/README README.hk
+	dodoc doc/README.bj
 }

--- a/app-dicts/aspell-de-alt/files/aspell-de-alt-2.1.1-dict-name.patch
+++ b/app-dicts/aspell-de-alt/files/aspell-de-alt-2.1.1-dict-name.patch
@@ -2,8 +2,8 @@ Aspell dictionaries should be named LANGUAGE[_REGION][-VARIETY][-SIZE],
 therefore this patch adds de-1901 and de_DE-1901 as such alias names.
 See also: http://www.iana.org/assignments/language-subtag-registry
 
---- Makefile.pre
-+++ Makefile.pre
+--- a/Makefile.pre
++++ b/Makefile.pre
 @@ -7,7 +7,8 @@
  data_files = de-alt.dat de-alt_phonet.dat de-alt_affix.dat
  doc_files = README COPYING Copyright
@@ -14,8 +14,8 @@ See also: http://www.iana.org/assignments/language-subtag-registry
  rws_files = de-alt.rws
  
  distdir=aspell6-${lang}-${version}
---- README
-+++ README
+--- a/README
++++ b/README
 @@ -1,4 +1,4 @@
 -GNU Aspell 0.60 German - Old Spelling (Deutsch - Alter Spelling) Dictionary Package
 +GNU Aspell 0.60 German - Old Spelling (Deutsch - alte Rechtschreibung) Dictionary Package
@@ -31,16 +31,16 @@ See also: http://www.iana.org/assignments/language-subtag-registry
  Whereas the names in parentheses are alternate names for the
  dictionary preceding the parentheses.
  
---- de-1901.alias
-+++ de-1901.alias
+--- a/de-1901.alias
++++ b/de-1901.alias
 @@ -0,0 +1 @@
 +add de-alt.multi
---- de_DE-1901.alias
-+++ de_DE-1901.alias
+--- a/de_DE-1901.alias
++++ b/de_DE-1901.alias
 @@ -0,0 +1 @@
 +add de-alt.multi
---- info
-+++ info
+--- a/info
++++ b/info
 @@ -1,5 +1,5 @@
  name_english German - Old Spelling
 -name_ascii Deutsch - Alter Spelling

--- a/app-dicts/aspell-de/aspell-de-0.60_pre20030222.ebuild
+++ b/app-dicts/aspell-de/aspell-de-0.60_pre20030222.ebuild
@@ -1,17 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="German and Swiss-German"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="German and Swiss-German"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P=aspell6-de-20030222-1
+
+SRC_URI="mirror://gnu/aspell/dict/de/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
 IUSE=""
 
-FILENAME=aspell6-de-20030222-1
-
-SRC_URI="mirror://gnu/aspell/dict/de/${FILENAME}.tar.bz2"
-S=${WORKDIR}/${FILENAME}
+S=${WORKDIR}/${MY_P}

--- a/app-dicts/aspell-el/aspell-el-0.50.3.ebuild
+++ b/app-dicts/aspell-el/aspell-el-0.50.3.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Greek"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-en/aspell-en-2016.11.20.0.ebuild
+++ b/app-dicts/aspell-en/aspell-en-2016.11.20.0.ebuild
@@ -4,14 +4,12 @@
 EAPI=6
 
 ASPELL_LANG="English (US, British, Canadian)"
-ASPOSTFIX="6"
+ASPELL_VERSION=6
 
-inherit aspell-dict versionator
+inherit aspell-dict-r1 versionator
+
+SRC_URI="mirror://gnu/aspell/dict/${ASPELL_SPELLANG}/${PN%-*}${ASPELL_VERSION}-${PN#*-}-$(replace_version_separator 3 '-').tar.bz2"
 
 LICENSE="myspell-en_CA-KevinAtkinson public-domain Princeton Ispell"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
-
 IUSE=""
-
-SRC_URI="mirror://gnu/aspell/dict/${SPELLANG}/${PN%-*}${ASPOSTFIX}-${PN#*-}-$(replace_version_separator 3 '-').tar.bz2"

--- a/app-dicts/aspell-en/aspell-en-2017.01.22.0.ebuild
+++ b/app-dicts/aspell-en/aspell-en-2017.01.22.0.ebuild
@@ -4,14 +4,12 @@
 EAPI=6
 
 ASPELL_LANG="English (US, British, Canadian)"
-ASPOSTFIX="6"
+ASPELL_VERSION=6
 
-inherit aspell-dict versionator
+inherit aspell-dict-r1 versionator
+
+SRC_URI="mirror://gnu/aspell/dict/${ASPELL_SPELLANG}/${PN%-*}${ASPELL_VERSION}-${PN#*-}-$(replace_version_separator 3 '-').tar.bz2"
 
 LICENSE="myspell-en_CA-KevinAtkinson public-domain Princeton Ispell"
-
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
-
 IUSE=""
-
-SRC_URI="mirror://gnu/aspell/dict/${SPELLANG}/${PN%-*}${ASPOSTFIX}-${PN#*-}-$(replace_version_separator 3 '-').tar.bz2"

--- a/app-dicts/aspell-eo/aspell-eo-2.1.20000225.2.ebuild
+++ b/app-dicts/aspell-eo/aspell-eo-2.1.20000225.2.ebuild
@@ -1,17 +1,20 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Esperanto"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Esperanto"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P=${P%.*}a-${PV##*.}
+MY_P=aspell${ASPELL_VERSION}-${MY_P/aspell-/}
+
+SRC_URI="mirror://gnu/aspell/dict/${ASPELL_SPELLANG}/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-MY_P=${P%.*}a-${PV##*.}
-MY_P=aspell${ASPOSTFIX}-${MY_P/aspell-/}
 S=${WORKDIR}/${MY_P}
-SRC_URI="mirror://gnu/aspell/dict/${SPELLANG}/${MY_P}.tar.bz2"

--- a/app-dicts/aspell-es/aspell-es-1.9a.ebuild
+++ b/app-dicts/aspell-es/aspell-es-1.9a.ebuild
@@ -1,16 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Spanish"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Spanish"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 MY_P="${P/aspell/aspell6}-1"
-S=${WORKDIR}/${MY_P}
-SRC_URI="mirror://gnu/aspell/dict/${SPELLANG}/${MY_P}.tar.bz2"
+
+SRC_URI="mirror://gnu/aspell/dict/${ASPELL_SPELLANG}/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
+
+S=${WORKDIR}/${MY_P}

--- a/app-dicts/aspell-et/aspell-et-0.1.21.1.ebuild
+++ b/app-dicts/aspell-et/aspell-et-0.1.21.1.ebuild
@@ -1,12 +1,13 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Estonian"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Estonian"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-fi/aspell-fi-0.7.0.ebuild
+++ b/app-dicts/aspell-fi/aspell-fi-0.7.0.ebuild
@@ -1,12 +1,13 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Finnish"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Finnish"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-fo/aspell-fo-0.51.0.ebuild
+++ b/app-dicts/aspell-fo/aspell-fo-0.51.0.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Faroese"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-fr/aspell-fr-0.60.ebuild
+++ b/app-dicts/aspell-fr/aspell-fr-0.60.ebuild
@@ -1,19 +1,22 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="French"
-ASPOSTFIX="6"
+ASPELL_VERSION=6
 
 # This is a hack to allow for using the French 0.50 dictionary until I have
 # the time to do this properly. Do not stabilise this.
 
-inherit aspell-dict
+inherit aspell-dict-r1
+
+MY_P="aspell-fr-0.50-3"
+
+SRC_URI="mirror://gnu/aspell/dict/fr/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~ppc-macos"
-
-FILENAME="aspell-fr-0.50-3"
-SRC_URI="mirror://gnu/aspell/dict/fr/${FILENAME}.tar.bz2"
 IUSE=""
 
-S=${WORKDIR}/${FILENAME}
+S=${WORKDIR}/${MY_P}

--- a/app-dicts/aspell-ga/aspell-ga-0.50.4.ebuild
+++ b/app-dicts/aspell-ga/aspell-ga-0.50.4.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Irish"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-gl/aspell-gl-0.5.2.ebuild
+++ b/app-dicts/aspell-gl/aspell-gl-0.5.2.ebuild
@@ -1,17 +1,20 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Galician"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Galician"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P=${P%.*}a-${PV##*.}
+MY_P=aspell${ASPELL_VERSION}-${MY_P/aspell-/}
+
+SRC_URI="mirror://gnu/aspell/dict/${ASPELL_SPELLANG}/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-MY_P=${P%.*}a-${PV##*.}
-MY_P=aspell${ASPOSTFIX}-${MY_P/aspell-/}
 S=${WORKDIR}/${MY_P}
-SRC_URI="mirror://gnu/aspell/dict/${SPELLANG}/${MY_P}.tar.bz2"

--- a/app-dicts/aspell-he/aspell-he-1.0.0.ebuild
+++ b/app-dicts/aspell-he/aspell-he-1.0.0.ebuild
@@ -1,12 +1,13 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Hebrew"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Hebrew"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-hr/aspell-hr-0.51.0.ebuild
+++ b/app-dicts/aspell-hr/aspell-hr-0.51.0.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Croatian"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-hu/aspell-hu-0.99.4.2.ebuild
+++ b/app-dicts/aspell-hu/aspell-hu-0.99.4.2.ebuild
@@ -1,17 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Hungarian"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Hungarian"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P="aspell6-hu-0.99.4.2-0"
+
+SRC_URI="mirror://gnu/aspell/dict/hu/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ppc ppc64 sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-FILENAME="aspell6-hu-0.99.4.2-0"
-SRC_URI="mirror://gnu/aspell/dict/hu/${FILENAME}.tar.bz2"
-
-S="${WORKDIR}/${FILENAME}"
+S="${WORKDIR}/${MY_P}"

--- a/app-dicts/aspell-hy/aspell-hy-0.10.0.ebuild
+++ b/app-dicts/aspell-hy/aspell-hy-0.10.0.ebuild
@@ -1,17 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Armenian"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Armenian"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P=aspell6-hy-0.10.0-0
+
+SRC_URI="mirror://gnu/aspell/dict/hy/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ppc ppc64 sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-FILENAME=aspell6-hy-0.10.0-0
-SRC_URI="mirror://gnu/aspell/dict/hy/${FILENAME}.tar.bz2"
-
-S="${WORKDIR}/${FILENAME}"
+S="${WORKDIR}/${MY_P}"

--- a/app-dicts/aspell-is/aspell-is-0.51.1.0.ebuild
+++ b/app-dicts/aspell-is/aspell-is-0.51.1.0.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Icelandic"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-it/aspell-it-2.4.20070901.ebuild
+++ b/app-dicts/aspell-it/aspell-it-2.4.20070901.ebuild
@@ -1,17 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Italian"
-ASPOSTFIX="6"
+ASPELL_VERSION=6
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
-LICENSE="GPL-2"
-
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE=
-
-MY_P=aspell${ASPOSTFIX}-${PN#aspell-}-${PV%.*}-${PV##*.}-0
+MY_P="aspell${ASPELL_VERSION}-${PN#aspell-}-${PV%.*}-${PV##*.}-0"
 
 SRC_URI="mirror://sourceforge/linguistico/${MY_P}.tar.bz2"
+
+LICENSE="GPL-2"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+IUSE=""
+
 S=${WORKDIR}/${MY_P}

--- a/app-dicts/aspell-la/aspell-la-6.0.20020503.0.ebuild
+++ b/app-dicts/aspell-la/aspell-la-6.0.20020503.0.ebuild
@@ -1,17 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Latin"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Latin"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P="aspell6-la-20020503-0"
+
+SRC_URI="mirror://gnu/aspell/dict/la/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-
-FILENAME="aspell6-la-20020503-0"
-SRC_URI="mirror://gnu/aspell/dict/la/${FILENAME}.tar.bz2"
 IUSE=""
 
-S=${WORKDIR}/${FILENAME}
+S=${WORKDIR}/${MY_P}

--- a/app-dicts/aspell-lt/aspell-lt-1.0.1.ebuild
+++ b/app-dicts/aspell-lt/aspell-lt-1.0.1.ebuild
@@ -1,16 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Lithuanian"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Lithuanian"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P="aspell6-lt-1.0-1"
+
+SRC_URI="mirror://gnu/aspell/dict/lt/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-
-FILENAME="aspell6-lt-1.0-1"
-SRC_URI="mirror://gnu/aspell/dict/lt/${FILENAME}.tar.bz2"
 IUSE=""
 
-S="${WORKDIR}/${FILENAME}"
+S="${WORKDIR}/${MY_P}"

--- a/app-dicts/aspell-nl/aspell-nl-0.50.2.ebuild
+++ b/app-dicts/aspell-nl/aspell-nl-0.50.2.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Dutch"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="freedist"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""

--- a/app-dicts/aspell-no/aspell-no-0.50.2.ebuild
+++ b/app-dicts/aspell-no/aspell-no-0.50.2.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Norwegian"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-pl/aspell-pl-6.0.20120418.0.ebuild
+++ b/app-dicts/aspell-pl/aspell-pl-6.0.20120418.0.ebuild
@@ -1,15 +1,20 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Polish"
-ASPOSTFIX="6"
-inherit versionator aspell-dict
+ASPELL_VERSION=6
+
+inherit versionator aspell-dict-r1
+
+MY_P="${PN/aspell/aspell6}-$(replace_version_separator 2 _ $(replace_version_separator 3 -))"
 
 HOMEPAGE="http://www.sjp.pl/slownik/"
+SRC_URI="http://www.sjp.pl/slownik/ort/sjp-${MY_P}.tar.bz2"
+
 LICENSE="GPL-2"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-FILENAME="${PN/aspell/aspell6}-$(replace_version_separator 2 _ $(replace_version_separator 3 -))"
-SRC_URI="http://www.sjp.pl/slownik/ort/sjp-${FILENAME}.tar.bz2"
-S="${WORKDIR}/${FILENAME}"
+S="${WORKDIR}/${MY_P}"

--- a/app-dicts/aspell-pt-br/aspell-pt-br-6.0.20090702.ebuild
+++ b/app-dicts/aspell-pt-br/aspell-pt-br-6.0.20090702.ebuild
@@ -1,19 +1,22 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Brazilian Portuguese"
-ASPOSTFIX=6
+ASPELL_VERSION=6
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
-FILENAME=aspell6-pt_BR-20090702-0
-SRC_URI="mirror://gnu/aspell/dict/pt_BR/${FILENAME}.tar.bz2"
+MY_P="aspell6-pt_BR-20090702-0"
+
+SRC_URI="mirror://gnu/aspell/dict/pt_BR/${MY_P}.tar.bz2"
 
 LICENSE="LGPL-2"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-S=${WORKDIR}/${FILENAME}
+S=${WORKDIR}/${MY_P}
 
 # Contains a conflict
 RDEPEND="!<app-dicts/aspell-pt-0.50.2-r1"

--- a/app-dicts/aspell-pt/aspell-pt-0.50.2-r1.ebuild
+++ b/app-dicts/aspell-pt/aspell-pt-0.50.2-r1.ebuild
@@ -1,9 +1,11 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Portuguese"
 
-inherit multilib aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
 
@@ -11,7 +13,8 @@ KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x8
 IUSE=""
 
 src_install() {
-	aspell-dict_src_install
-	rm "${D}"/usr/$(get_libdir)/aspell-0.60/pt_BR*
-	rm "${D}"/usr/$(get_libdir)/aspell-0.60/brazilian.alias
+	aspell-dict-r1_src_install
+
+	rm "${ED%/}"/usr/$(get_libdir)/aspell-0.60/pt_BR* || die
+	rm "${ED%/}"/usr/$(get_libdir)/aspell-0.60/brazilian.alias || die
 }

--- a/app-dicts/aspell-ro/aspell-ro-3.3.2.ebuild
+++ b/app-dicts/aspell-ro/aspell-ro-3.3.2.ebuild
@@ -1,13 +1,15 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Romanian"
-ASPOSTFIX="5"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Romanian"
+ASPELL_VERSION=5
+
+inherit aspell-dict-r1
 
 HOMEPAGE="http://aspell.net http://rospell.sourceforge.net/"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+IUSE=""

--- a/app-dicts/aspell-ru/aspell-ru-0.99.1-r1.ebuild
+++ b/app-dicts/aspell-ru/aspell-ru-0.99.1-r1.ebuild
@@ -1,25 +1,27 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Russian"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Russian"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+# very strange filename not supported by the gentoo naming scheme
+MY_P="aspell6-ru-0.99f7-1"
+
+SRC_URI="mirror://gnu/aspell/dict/ru/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-# very strange filename not supported by the gentoo naming scheme
-FILENAME=aspell6-ru-0.99f7-1
+S=${WORKDIR}/${MY_P}
 
-SRC_URI="mirror://gnu/aspell/dict/ru/${FILENAME}.tar.bz2"
-S=${WORKDIR}/${FILENAME}
+src_prepare() {
+	default
 
-src_unpack() {
-	unpack ${A}
-	cd "${S}"
-	einfo "Set default dictionary to ru-yeyo."
+	einfo "Setting default dictionary to ru-yeyo"
 	cp -v ru-yeyo.multi ru.multi || die
 }

--- a/app-dicts/aspell-sk/aspell-sk-2.01.2.ebuild
+++ b/app-dicts/aspell-sk/aspell-sk-2.01.2.ebuild
@@ -1,12 +1,13 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Slovak"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Slovak"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-sl/aspell-sl-0.50.0.ebuild
+++ b/app-dicts/aspell-sl/aspell-sl-0.50.0.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Slovenian"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-sr/aspell-sr-0.60.ebuild
+++ b/app-dicts/aspell-sr/aspell-sr-0.60.ebuild
@@ -1,16 +1,19 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Serbian"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Serbian"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
+
+MY_P="aspell6-sr-0.02"
+
+SRC_URI="http://srpski.org/aspell/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""
 
-FILENAME="aspell6-sr-0.02"
-SRC_URI="http://srpski.org/aspell/${FILENAME}.tar.bz2"
-S="${WORKDIR}/${FILENAME}"
+S="${WORKDIR}/${MY_P}"

--- a/app-dicts/aspell-sv/aspell-sv-0.51.0.ebuild
+++ b/app-dicts/aspell-sv/aspell-sv-0.51.0.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+EAPI=6
+
 ASPELL_LANG="Swedish"
 
-inherit aspell-dict
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""

--- a/app-dicts/aspell-uk/aspell-uk-1.4.0.0.ebuild
+++ b/app-dicts/aspell-uk/aspell-uk-1.4.0.0.ebuild
@@ -1,12 +1,13 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Ukrainian"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Ukrainian"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2 LGPL-2.1"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/app-dicts/aspell-vi/aspell-vi-0.01.1.1.ebuild
+++ b/app-dicts/aspell-vi/aspell-vi-0.01.1.1.ebuild
@@ -1,12 +1,13 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-ASPELL_LANG="Vietnamese"
-ASPOSTFIX="6"
+EAPI=6
 
-inherit aspell-dict
+ASPELL_LANG="Vietnamese"
+ASPELL_VERSION=6
+
+inherit aspell-dict-r1
 
 LICENSE="GPL-2"
-
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE=""

--- a/eclass/aspell-dict-r1.eclass
+++ b/eclass/aspell-dict-r1.eclass
@@ -1,0 +1,89 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: aspell-dict-r1.eclass
+# @MAINTAINER:
+# maintainer-needed@gentoo.org
+# @AUTHOR:
+# Original author: Seemant Kulleen
+#      -r1 author: David Seifert
+# @BLURB: An eclass to streamline the construction of ebuilds for new aspell dicts
+# @DESCRIPTION:
+# The aspell-dict-r1 eclass is designed to streamline the construction of
+# ebuilds for the new aspell dictionaries (from gnu.org) which support
+# aspell-0.50. Support for aspell-0.60 has been added by Sergey Ulanov.
+
+# @ECLASS-VARIABLE: ASPELL_LANG
+# @REQUIRED
+# @DESCRIPTION:
+# Pure cleartext string that is included into DESCRIPTION. This is the name
+# of the language, for instance "Hungarian". Needs to be defined before
+# inheriting the eclass.
+
+# @ECLASS-VARIABLE: ASPELL_VERSION
+# @DESCRIPTION:
+# What major version of aspell is this dictionary for? Valid values are 5, 6 or undefined.
+# This value is used to construct SRC_URI and *DEPEND strings. If defined to 6,
+# >=app-text/aspell-0.60 will be added to DEPEND and RDEPEND, otherwise,
+# >=app-text/aspell-0.50 is added to DEPEND and RDEPEND. If the value is to be overridden,
+# it needs to be overridden before inheriting the eclass.
+
+case ${EAPI:-0} in
+	[0-5])
+		die "aspell-dict-r1.eclass is banned in EAPI ${EAPI:-0}"
+		;;
+	6)
+		;;
+	*)
+		die "Unknown EAPI ${EAPI:-0}"
+		;;
+esac
+
+EXPORT_FUNCTIONS src_configure src_install
+
+if [[ ! ${_ASPELL_DICT_R1} ]]; then
+
+# aspell packages have an idiosyncratic versioning scheme, that is
+# the last separating version separator is replaced by a '-'.
+_ASPELL_P=aspell${ASPELL_VERSION}-${PN/aspell-/}-${PV%.*}-${PV##*.}
+
+# @ECLASS-VARIABLE: ASPELL_SPELLANG
+# @DESCRIPTION:
+# Short (readonly) form of the language code, generated from ${PN}
+# For instance, 'aspell-hu' yields the value 'hu'.
+readonly ASPELL_SPELLANG=${PN/aspell-/}
+S="${WORKDIR}/${_ASPELL_P}"
+
+DESCRIPTION="${ASPELL_LANG} language dictionary for aspell"
+HOMEPAGE="http://aspell.net"
+SRC_URI="mirror://gnu/aspell/dict/${ASPELL_SPELLANG}/${_ASPELL_P}.tar.bz2"
+unset _ASPELL_P
+
+IUSE=""
+SLOT="0"
+
+_ASPELL_MAJOR_VERSION=${ASPELL_VERSION:-5}
+[[ ${_ASPELL_MAJOR_VERSION} != [56] ]] && die "${ASPELL_VERSION} is not a valid version"
+
+RDEPEND=">=app-text/aspell-0.${_ASPELL_MAJOR_VERSION}0"
+DEPEND="${RDEPEND}"
+unset _ASPELL_MAJOR_VERSION
+
+# @FUNCTION: aspell-dict-r1_src_configure
+# @DESCRIPTION:
+# The aspell-dict-r1 src_configure function which is exported.
+aspell-dict-r1_src_configure() {
+	# non-autoconf based script, cannot be used with econf
+	./configure || die
+}
+
+# @FUNCTION: aspell-dict-r1_src_install
+# @DESCRIPTION:
+# The aspell-dict-r1 src_install function which is exported.
+aspell-dict-r1_src_install() {
+	default
+	[[ -s info ]] && dodoc info
+}
+
+_ASPELL_DICT_R1=1
+fi


### PR DESCRIPTION
@mgorny could you please check the eclass?

Concerning checks, I ran all old ebuilds and new ones and diff'ed their install images, the only differencing coming were:

**aspell-be**:
```
@@ -15,6 +15,7 @@
         └── doc
             └── aspell-be-0.01-r1
                 ├── info.bz2
-                └── README.bz2
+                ├── README.bz2
+                └── README.cp.bz2
```

and **aspell-he**
```
@@ -13,6 +13,7 @@
         └── doc
             └── aspell-he-1.0.0
                 ├── info.bz2
-                └── README.bz2
+                ├── README.bz2
+                └── README.iso.bz2
```
I think this is innocuous and can be left as is. All other ebuilds give identical install images before and after porting to EAPI 6.