### PR TITLE
dev-libs/apr-util: keep get_libname libs when .a

### DIFF
--- a/dev-libs/apr-util/apr-util-1.5.4-r1.ebuild
+++ b/dev-libs/apr-util/apr-util-1.5.4-r1.ebuild
@@ -105,7 +105,7 @@ src_install() {
 
 	find "${ED}" -name "*.la" -delete
 	find "${ED}usr/$(get_libdir)/apr-util-${SLOT}" -name "*.a" -delete
-	use static-libs || find "${ED}" -name "*.a" -delete
+	use static-libs || find "${ED}" -name "*.a" -not -name "*$(get_libname)" -delete
 
 	use doc && dohtml -r docs/dox/html/*
 


### PR DESCRIPTION
Cygwin uses .dll.a as shared library extension, do not remove along "*.a".

Package-Manager: portage-2.3.3