### PR TITLE
app-arch/libarchive: uses wincrypt in Cygwin, disable openssl

### DIFF
--- a/app-arch/libarchive/libarchive-3.3.1.ebuild
+++ b/app-arch/libarchive/libarchive-3.3.1.ebuild
@@ -57,6 +57,7 @@ multilib_src_configure() {
 		$(use_with lzo lzo2)
 		$(use_with nettle)
 		$(use_with zlib)
+		$(use_with !elibc_Cygwin openssl) # conflict with wincrypt.h
 	)
 	if multilib_is_native_abi ; then myconf+=(
 		--enable-bsdcat=$(tc-is-static-only && echo static || echo shared)


### PR DESCRIPTION
Including both openssl and wincrypt results in macro conflicts,
but wincrypt cannot be disabled ATM, disabling openssl instead.

Package-Manager: portage-2.3.3