### PR TITLE
dev-python/neovim-python-client: add python 3.6 to PYTHON_COMPAT

### DIFF
--- a/dev-python/neovim-python-client/neovim-python-client-0.1.13.ebuild
+++ b/dev-python/neovim-python-client/neovim-python-client-0.1.13.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} )
 
 inherit distutils-r1
 
@@ -14,11 +14,13 @@ SRC_URI="https://github.com/neovim/python-client/archive/${PV}.tar.gz -> ${P}.ta
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
+IUSE="test"
 
 DEPEND="
 	>=dev-python/msgpack-0.4.0[${PYTHON_USEDEP}]
 	virtual/python-greenlet[${PYTHON_USEDEP}]
 	$(python_gen_cond_dep 'dev-python/trollius[${PYTHON_USEDEP}]' python2_7)
+	test? ( dev-python/nose[${PYTHON_USEDEP}] )
 "
 
 RDEPEND="
@@ -27,3 +29,7 @@ RDEPEND="
 "
 
 S="${WORKDIR}/python-client-${PV}"
+
+python_test() {
+	nosetests -d -v || die
+}


### PR DESCRIPTION
versions previous to neovim-python-client-0.1.13 don't work.