### PR TITLE
sci-electronics/klayout: Fix "error: throw will always call terminate()" (bug #612978)

### DIFF
--- a/sci-electronics/klayout/files/klayout-0.24.9-c++11-no-throw-in-destuctor.patch
+++ b/sci-electronics/klayout/files/klayout-0.24.9-c++11-no-throw-in-destuctor.patch
@@ -1,0 +1,34 @@
+# Fixes "error: throw will always call terminate() [-Werror=terminate]". Gentoo bug 612978.
+
+--- a/src/tlAssert.h.old
++++ b/src/tlAssert.h
+@@ -27,6 +27,16 @@
+ 
+ #include "config.h"
+ 
++// For >=C++11, mark assertion_failed() with attribute [[noreturn]] and call std::terminate().
++// Or else, throw int(0) to tell the compiler that the assertion will not return.
++#if __cplusplus < 201103L
++#define ATTRIB_ASSERT KLAYOUT_DLL
++#define END_ASSERT throw int(0)
++#else
++#define ATTRIB_ASSERT [[noreturn]] KLAYOUT_DLL
++#define END_ASSERT std::terminate()
++#endif
++ 
+ namespace tl
+ {
+ 
+@@ -34,10 +44,10 @@
+  *  @brief The corresponding assert macro
+  */
+ 
+-KLAYOUT_DLL void assertion_failed (const char *filename, unsigned int line, const char *condition);
++ATTRIB_ASSERT void assertion_failed (const char *filename, unsigned int line, const char *condition);
+ 
+ //  the throw int(0) instruction will tell the compiler that the assertion will not return
+-#define tl_assert(COND) if (!(COND)) { tl::assertion_failed (__FILE__, __LINE__, #COND); throw int(0); }
++#define tl_assert(COND) if (!(COND)) { tl::assertion_failed (__FILE__, __LINE__, #COND); END_ASSERT; }
+ 
+ } // namespace tl
+ 

--- a/sci-electronics/klayout/klayout-0.24.9.ebuild
+++ b/sci-electronics/klayout/klayout-0.24.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -27,6 +27,8 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 all_ruby_prepare() {
+	epatch "${FILESDIR}"/${P}-c++11-no-throw-in-destuctor.patch
+
 	# now we generate the stub build configuration file for the home-brew build system
 	cp "${FILESDIR}/${PN}-0.23.10-Makefile.conf.linux-gentoo" "${S}/config/Makefile.conf.linux-gentoo" || die
 }


### PR DESCRIPTION
Fixes [bug 612978](https://bugs.gentoo.org/show_bug.cgi?id=612978).
Benign bug.  Made an [upstream PR](https://github.com/Peter-Levine/klayout/pull/1) but upstream tries to force its own CXXFLAGS and might not even consider a bug in a build that allows for "-Werror=terminate" to be valid.