### PR TITLE
Update mpv-9999.ebuild, remove Opengl dependencies, aqua flag.

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -36,13 +36,11 @@ IUSE+=" cpu_flags_x86_sse4_1"
 
 REQUIRED_USE="
 	|| ( cli libmpv )
-	aqua? ( opengl )
 	cuda? ( !libav || ( opengl egl ) )
 	egl? ( || ( gbm X wayland ) )
 	gbm? ( drm egl )
 	lcms? ( || ( opengl egl ) )
 	luajit? ( lua )
-	opengl? ( || ( aqua X !cli? ( libmpv ) ) )
 	test? ( || ( opengl egl ) )
 	tools? ( cli )
 	uchardet? ( iconv )


### PR DESCRIPTION
OpenGL doesn't require X.
aqua don't exists in GNU/Linux, it's OS X library and masked flag in gentoo.