### PR TITLE
games-board/pouetchess: Fix building with GCC-6 (bug #613428)

### DIFF
--- a/games-board/pouetchess/files/pouetchess-0.2.0-gcc6-cmath.patch
+++ b/games-board/pouetchess/files/pouetchess-0.2.0-gcc6-cmath.patch
@@ -1,0 +1,16 @@
+--- pouetchess_src_0.2.0/src/sxmlgui/MathUtils.h.old	2006-05-26 21:22:57.000000000 -0400
++++ pouetchess_src_0.2.0/src/sxmlgui/MathUtils.h	2017-03-21 18:01:15.569181229 -0400
+@@ -27,10 +27,13 @@
+   return (x < min) ? min : (x > max) ? max : x;
+ }
+ 
++// Not used anywhere and conflicts with C++11 std::round(float)
++#if __cplusplus < 201103L
+ inline int round(float f)
+ {
+   return int(f + 0.5f);
+ }
++#endif
+ 
+ inline float getNextRandom(){
+   return (float)rand()/(RAND_MAX + 1);

--- a/games-board/pouetchess/pouetchess-0.2.0-r1.ebuild
+++ b/games-board/pouetchess/pouetchess-0.2.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -27,7 +27,8 @@ src_prepare() {
 		"${FILESDIR}/${P}-sconstruct-sandbox.patch" \
 		"${FILESDIR}/${P}-nvidia_glext.patch" \
 		"${FILESDIR}/${P}-segfaults.patch" \
-		"${FILESDIR}/${P}-gcc43.patch"
+		"${FILESDIR}/${P}-gcc43.patch" \
+		"${FILESDIR}/${P}-gcc6-cmath.patch"
 	# Fix for LibSDL >= 1.2.10 detection
 	sed -i \
 		-e "s:sdlver.split('.') >= \['1','2','8'\]:sdlver.split('.') >= [1,2,8]:" \


### PR DESCRIPTION
Fixes [bug #613428](https://bugs.gentoo.org/show_bug.cgi?id=613428)
`error: 'constexpr float std::round(float)' conflicts with a previous declaration`