### PR TITLE
dev-python/lit: support python 3

### DIFF
--- a/dev-python/lit/files/lit-py3.patch
+++ b/dev-python/lit/files/lit-py3.patch
@@ -1,0 +1,46 @@
+From 50e946cf38ec22b58cf33818865a2e8a0ebb78ea Mon Sep 17 00:00:00 2001
+From: Brian Gesiak <modocache@gmail.com>
+Date: Wed, 22 Mar 2017 04:23:01 +0000
+Subject: [PATCH] lit: remove python2-isms
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Summary:
+`assert.assertItemEqual` went away in Python 3. Seeing how lists
+are ordered, comparing a list against each other should work just
+as well.
+
+Patch by @jbergstroem (Johan Bergström).
+
+Reviewers: modocache, gparker42
+
+Reviewed By: modocache
+
+Differential Revision: https://reviews.llvm.org/D31229
+---
+ tests/unit/TestRunner.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/unit/TestRunner.py b/tests/unit/TestRunner.py
+index ed0affa..79cc10f 100644
+--- a/tests/unit/TestRunner.py
++++ b/tests/unit/TestRunner.py
+@@ -89,7 +89,7 @@ def test_lists(self):
+         parsers = self.make_parsers()
+         self.parse_test(parsers)
+         list_parser = self.get_parser(parsers, 'MY_LIST:')
+-        self.assertItemsEqual(list_parser.getValue(),
++        self.assertEqual(list_parser.getValue(),
+                               ['one', 'two', 'three', 'four'])
+ 
+     def test_commands(self):
+@@ -106,7 +106,7 @@ def test_custom(self):
+         self.parse_test(parsers)
+         custom_parser = self.get_parser(parsers, 'MY_CUSTOM:')
+         value = custom_parser.getValue()
+-        self.assertItemsEqual(value, ['a', 'b', 'c'])
++        self.assertEqual(value, ['a', 'b', 'c'])
+ 
+     def test_bad_keywords(self):
+         def custom_parse(line_number, line, output):

--- a/dev-python/lit/lit-4.0.0-r1.ebuild
+++ b/dev-python/lit/lit-4.0.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python2_7 python3_4 python3_5 python3_6 )
 inherit distutils-r1
 
 MY_P=llvm-${PV/_/}
@@ -20,6 +20,7 @@ S=${WORKDIR}/${MY_P}.src/utils/lit
 
 # Tests require 'FileCheck' and 'not' utilities (from llvm)
 DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? (
 		dev-python/psutil[${PYTHON_USEDEP}]
 		sys-devel/llvm )"

--- a/dev-python/lit/lit-9999.ebuild
+++ b/dev-python/lit/lit-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 inherit distutils-r1 git-r3
 
 DESCRIPTION="A stand-alone install of the LLVM suite testing tool"
@@ -11,6 +11,10 @@ HOMEPAGE="http://llvm.org/"
 SRC_URI=""
 EGIT_REPO_URI="http://llvm.org/git/llvm.git
 	https://github.com/llvm-mirror/llvm.git"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-py3.patch"
+)
 
 LICENSE="UoI-NCSA"
 SLOT="0"
@@ -21,6 +25,7 @@ S=${WORKDIR}/${P}/utils/lit
 
 # Tests require 'FileCheck' and 'not' utilities (from llvm)
 DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? (
 		dev-python/psutil[${PYTHON_USEDEP}]
 		sys-devel/llvm )"


### PR DESCRIPTION
Add a patch upstream (by me) that removes usage of `assertItemsEqual` since it was dropped in Python 3.x. Also, add a missing dependency against `dev-python/setuptools`.

ping @mgorny.