### PR TITLE
Fix static library build

### DIFF
--- a/sci-libs/metis/metis-5.1.0-r2.ebuild
+++ b/sci-libs/metis/metis-5.1.0-r2.ebuild
@@ -37,7 +37,7 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DGKLIB_PATH="${S}"/GKlib
-		-DSHARED=TRUE
+		-DSHARED="$(usex static-libs no yes)"
 		-DOPENMP="$(usex openmp)"
 	)
 	cmake-utils_src_configure


### PR DESCRIPTION
The `static-libs` USE flag was not used and static libraries could not
be built.