### PR TITLE
dev-python/mysqlclient: adding py36 support

### DIFF
--- a/dev-python/mysqlclient/mysqlclient-1.3.10.ebuild
+++ b/dev-python/mysqlclient/mysqlclient-1.3.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{4,5} pypy )
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy )
 
 inherit distutils-r1
 


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=613722