### PR TITLE
x11-apps/radeontop: kill video_cards_amdgpu USE flag

### DIFF
--- a/x11-apps/radeontop/radeontop-1.0.ebuild
+++ b/x11-apps/radeontop/radeontop-1.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/clbr/radeontop/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="nls video_cards_amdgpu"
+IUSE="nls"
 
 RDEPEND="
 	sys-libs/ncurses:0=
@@ -46,7 +46,7 @@ src_prepare() {
 src_configure() {
 	tc-export CC
 	export nls=$(usex nls 1 0)
-	export amdgpu=$(usex video_cards_amdgpu 1 0)
+	export amdgpu=1
 	export xcb=1
 	# Do not add -g or -s to CFLAGS
 	export plain=1

--- a/x11-apps/radeontop/radeontop-9999.ebuild
+++ b/x11-apps/radeontop/radeontop-9999.ebuild
@@ -11,7 +11,7 @@ EGIT_REPO_URI="https://github.com/clbr/radeontop.git"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="nls video_cards_amdgpu"
+IUSE="nls"
 
 RDEPEND="
 	sys-libs/ncurses:0=
@@ -31,7 +31,7 @@ DEPEND="${RDEPEND}
 src_configure() {
 	tc-export CC
 	export nls=$(usex nls 1 0)
-	export amdgpu=$(usex video_cards_amdgpu 1 0)
+	export amdgpu=1
 	export xcb=1
 	# Do not add -g or -s to CFLAGS
 	export plain=1


### PR DESCRIPTION
AMDGPU support requires no additional deps and we already have
sufficiently new version of libdrm in gentoo (>= 2.4.63). This
requirement for the newer libdrm version is the only reason why
upstream made amdgpu support optional.