### PR TITLE
eutils -> epunt_cxx... for GNOME pkgs

### DIFF
--- a/dev-libs/glib/glib-2.44.1-r1.ebuild
+++ b/dev-libs/glib/glib-2.44.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 # Until bug #537330 glib is a reverse dependency of pkgconfig and, then
@@ -15,7 +15,7 @@ GCONF_DEBUG="yes"
 # pkg-config
 GNOME2_LA_PUNT="yes"
 
-inherit autotools bash-completion-r1 gnome2 libtool eutils flag-o-matic	multilib \
+inherit autotools bash-completion-r1 epatch epunt-cxx gnome2 libtool flag-o-matic multilib \
 	pax-utils python-r1 toolchain-funcs versionator virtualx linux-info multilib-minimal
 
 DESCRIPTION="The GLib library of C routines"

--- a/dev-libs/glib/glib-2.48.2.ebuild
+++ b/dev-libs/glib/glib-2.48.2.ebuild
@@ -11,7 +11,7 @@ PYTHON_COMPAT=( python2_7 )
 # pkg-config
 GNOME2_LA_PUNT="yes"
 
-inherit autotools bash-completion-r1 eutils flag-o-matic gnome2 libtool linux-info \
+inherit autotools bash-completion-r1 epunt-cxx flag-o-matic gnome2 libtool linux-info \
 	multilib multilib-minimal pax-utils python-r1  toolchain-funcs versionator virtualx
 
 DESCRIPTION="The GLib library of C routines"

--- a/dev-libs/glib/glib-2.50.3.ebuild
+++ b/dev-libs/glib/glib-2.50.3.ebuild
@@ -11,7 +11,7 @@ PYTHON_COMPAT=( python2_7 )
 # pkg-config
 GNOME2_LA_PUNT="yes"
 
-inherit autotools bash-completion-r1 eutils flag-o-matic gnome2 libtool linux-info \
+inherit autotools bash-completion-r1 epunt-cxx flag-o-matic gnome2 libtool linux-info \
 	multilib multilib-minimal pax-utils python-r1  toolchain-funcs versionator virtualx
 
 DESCRIPTION="The GLib library of C routines"

--- a/dev-libs/libxml2/libxml2-2.9.4-r1.ebuild
+++ b/dev-libs/libxml2/libxml2-2.9.4-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 PYTHON_COMPAT=( python2_7 python3_{4,5} )
 PYTHON_REQ_USE="xml"
 
-inherit libtool flag-o-matic eutils python-r1 autotools prefix multilib-minimal
+inherit libtool flag-o-matic ltprune python-r1 autotools prefix multilib-minimal
 
 DESCRIPTION="Version 2 of the library to manipulate XML files"
 HOMEPAGE="http://www.xmlsoft.org/"

--- a/dev-libs/libxml2/libxml2-2.9.4.ebuild
+++ b/dev-libs/libxml2/libxml2-2.9.4.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 PYTHON_COMPAT=( python2_7 python3_{4,5} )
 PYTHON_REQ_USE="xml"
 
-inherit libtool flag-o-matic eutils python-r1 autotools prefix multilib-minimal
+inherit libtool flag-o-matic ltprune python-r1 autotools prefix multilib-minimal
 
 DESCRIPTION="Version 2 of the library to manipulate XML files"
 HOMEPAGE="http://www.xmlsoft.org/"

--- a/dev-libs/libxslt/libxslt-1.1.28-r5.ebuild
+++ b/dev-libs/libxslt/libxslt-1.1.28-r5.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 PYTHON_COMPAT=( python2_7 )
 PYTHON_REQ_USE="xml"
 
-inherit autotools eutils python-r1 toolchain-funcs multilib-minimal
+inherit autotools epatch ltprune python-r1 toolchain-funcs multilib-minimal
 
 DESCRIPTION="XSLT libraries and tools"
 HOMEPAGE="http://www.xmlsoft.org/"

--- a/dev-libs/libxslt/libxslt-1.1.29-r1.ebuild
+++ b/dev-libs/libxslt/libxslt-1.1.29-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 PYTHON_COMPAT=( python2_7 )
 PYTHON_REQ_USE="xml"
 
-inherit autotools eutils python-r1 toolchain-funcs multilib-minimal
+inherit autotools ltprune python-r1 toolchain-funcs multilib-minimal
 
 DESCRIPTION="XSLT libraries and tools"
 HOMEPAGE="http://www.xmlsoft.org/"

--- a/dev-libs/libxslt/libxslt-1.1.29.ebuild
+++ b/dev-libs/libxslt/libxslt-1.1.29.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 PYTHON_COMPAT=( python2_7 )
 PYTHON_REQ_USE="xml"
 
-inherit autotools eutils python-r1 toolchain-funcs multilib-minimal
+inherit autotools ltprune python-r1 toolchain-funcs multilib-minimal
 
 DESCRIPTION="XSLT libraries and tools"
 HOMEPAGE="http://www.xmlsoft.org/"


### PR DESCRIPTION
Update the listed packages to use split eclasses instead of eutils. The set of eclasses is adjusted to match the functions used in ebuilds. For the initial package set, I will be focusing on packages using epunt_cxx since 1) there are not many packages using it; 2) I'd like to remove the implicit inherit early in order to move epunt-cxx.eclass to elt-patches package.