### PR TITLE
x11-misc/trayer: Dont include libXmu

### DIFF
--- a/x11-misc/trayer/files/trayer-1.0-dont-include-libXmu.patch
+++ b/x11-misc/trayer/files/trayer-1.0-dont-include-libXmu.patch
@@ -1,0 +1,24 @@
+From 710efb0c8192e704a83fd3d4b8b3c0d6be984246 Mon Sep 17 00:00:00 2001
+From: Harri Nieminen <moikkis@gmail.com>
+Date: Sun, 26 Mar 2017 10:08:05 +0300
+Subject: [PATCH] Don't include libXmu
+
+---
+ systray/main.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/systray/main.c b/systray/main.c
+index dff5455..79cbe34 100644
+--- a/systray/main.c
++++ b/systray/main.c
+@@ -2,7 +2,6 @@
+ #include <unistd.h>
+ #include <string.h>
+ 
+-#include <X11/Xmu/WinUtil.h>
+ #include <gdk-pixbuf/gdk-pixbuf.h>
+ 
+ #include "panel.h"
+-- 
+2.12.1
+

--- a/x11-misc/trayer/trayer-1.0-r2.ebuild
+++ b/x11-misc/trayer/trayer-1.0-r2.ebuild
@@ -24,6 +24,8 @@ DEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=( "${FILESDIR}"/${P}-dont-include-libXmu.patch )
+
 src_prepare() {
 	default
 	# fix for as-needed, bug #141707

--- a/x11-misc/trayer/trayer-1.0-r3.ebuild
+++ b/x11-misc/trayer/trayer-1.0-r3.ebuild
@@ -26,6 +26,7 @@ DEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-dont-include-gdk-pixbuf-xlib.patch
+	"${FILESDIR}"/${P}-dont-include-libXmu.patch
 	"${FILESDIR}"/${P}-as-needed-and-pre-stripped.patch
 )
 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/613842
Package-Manager: Portage-2.3.5, Repoman-2.3.2