### PR TITLE
sys-apps/gentoo-functions: omit consoletype when USE=prefix-chaining

### DIFF
--- a/sys-apps/gentoo-functions/gentoo-functions-0.11.ebuild
+++ b/sys-apps/gentoo-functions/gentoo-functions-0.11.ebuild
@@ -18,9 +18,10 @@ HOMEPAGE="https://www.gentoo.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE=""
+IUSE="prefix-chaining"
 
 src_prepare() {
+	use prefix-chaining && sed -e '/consoletype/d' -i Makefile
 	tc-export CC
 	append-lfs-flags
 }

--- a/sys-apps/gentoo-functions/gentoo-functions-9999.ebuild
+++ b/sys-apps/gentoo-functions/gentoo-functions-9999.ebuild
@@ -18,9 +18,10 @@ HOMEPAGE="https://www.gentoo.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE=""
+IUSE="prefix-chaining"
 
 src_prepare() {
+	use prefix-chaining && export PROGRAM_consoletype=
 	tc-export CC
 	append-lfs-flags
 }

--- a/sys-apps/gentoo-functions/metadata.xml
+++ b/sys-apps/gentoo-functions/metadata.xml
@@ -18,4 +18,7 @@
 <upstream>
 	<remote-id type="github">gentoo/gentoo-functions</remote-id>
 </upstream>
+<use>
+	<flag name="prefix-chaining">install in a chained Prefix environment</flag>
+</use>
 </pkgmetadata>


### PR DESCRIPTION
Package-Manager: portage-2.3.3