### PR TITLE
media-tv/me-tv: Fix building with GCC6 and -Werror=terminate (bug #613426)

### DIFF
--- a/media-tv/me-tv/files/me-tv-1.4.0.10-C++11-throw-in-destructors.patch
+++ b/media-tv/me-tv/files/me-tv-1.4.0.10-C++11-throw-in-destructors.patch
@@ -1,0 +1,35 @@
+--- a/server/data.cc
++++ b/server/data.cc
+@@ -68,7 +68,7 @@
+ 	}
+ }
+ 
+-Statement::~Statement()
++Statement::~Statement() NOEXCEPT
+ {
+ 	if (sqlite3_finalize(statement) != 0)
+ 	{
+--- a/server/data.h
++++ b/server/data.h
+@@ -26,6 +26,12 @@
+ #include <linux/dvb/frontend.h>
+ #include <glibmm.h>
+ 
++#if __cplusplus >= 201103L
++#define NOEXCEPT noexcept(false)
++#else
++#define NOEXCEPT
++#endif
++
+ typedef std::list<Glib::ustring> StringList;
+ 
+ namespace Data
+@@ -68,7 +74,7 @@
+ 
+ 	public:
+ 		Statement(Connection& connection, const Glib::ustring& command);
+-		~Statement();
++		~Statement() NOEXCEPT;
+ 
+ 		void reset();
+ 		guint step();

--- a/media-tv/me-tv/me-tv-1.4.0.10.ebuild
+++ b/media-tv/me-tv/me-tv-1.4.0.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -34,6 +34,7 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	append-cxxflags -std=c++11
 	epatch "${FILESDIR}"/${P}-gcc47.patch
+	epatch "${FILESDIR}"/${P}-C++11-throw-in-destructors.patch
 	eautoreconf
 }
 


### PR DESCRIPTION
Fixes building with `-Werror=terminate` in CXXFLAGS in C++11 dialect [bug #613426](https://bugs.gentoo.org/show_bug.cgi?id=613426).