### PR TITLE
net-im/vacuum: Fix building with GCC-6 (bug #614084)

### DIFF
--- a/net-im/vacuum/files/vacuum-1.2.4-gcc6-not-string-literals.patch
+++ b/net-im/vacuum/files/vacuum-1.2.4-gcc6-not-string-literals.patch
@@ -1,0 +1,51 @@
+diff -Naur vacuum-1.2.4.old/src/plugins/messagearchiver/messagearchiver.cpp vacuum-1.2.4/src/plugins/messagearchiver/messagearchiver.cpp
+--- vacuum-1.2.4.old/src/plugins/messagearchiver/messagearchiver.cpp	2017-03-27 22:36:48.177650414 -0400
++++ vacuum-1.2.4/src/plugins/messagearchiver/messagearchiver.cpp	2017-03-27 22:37:22.198212428 -0400
+@@ -9,8 +9,8 @@
+ #define SESSIONS_FILE_NAME    "sessions.xml"
+ 
+ #define SHC_MESSAGE_BODY      "/message/body"
+-#define SHC_PREFS             "/iq[@type='set']/pref[@xmlns="NS_ARCHIVE"]"
+-#define SHC_PREFS_OLD         "/iq[@type='set']/pref[@xmlns="NS_ARCHIVE_OLD"]"
++#define SHC_PREFS             "/iq[@type='set']/pref[@xmlns=" NS_ARCHIVE "]"
++#define SHC_PREFS_OLD         "/iq[@type='set']/pref[@xmlns=" NS_ARCHIVE_OLD "]"
+ 
+ #define ADR_STREAM_JID        Action::DR_StreamJid
+ #define ADR_CONTACT_JID       Action::DR_Parametr1
+diff -Naur vacuum-1.2.4.old/src/plugins/privacylists/privacylists.cpp vacuum-1.2.4/src/plugins/privacylists/privacylists.cpp
+--- vacuum-1.2.4.old/src/plugins/privacylists/privacylists.cpp	2017-03-27 22:36:48.175650440 -0400
++++ vacuum-1.2.4/src/plugins/privacylists/privacylists.cpp	2017-03-27 22:37:48.508882851 -0400
+@@ -1,7 +1,7 @@
+ #include "privacylists.h"
+ 
+-#define SHC_PRIVACY         "/iq[@type='set']/query[@xmlns='"NS_JABBER_PRIVACY"']"
+-#define SHC_ROSTER          "/iq/query[@xmlns='"NS_JABBER_ROSTER"']"
++#define SHC_PRIVACY         "/iq[@type='set']/query[@xmlns='" NS_JABBER_PRIVACY "']"
++#define SHC_ROSTER          "/iq/query[@xmlns='" NS_JABBER_ROSTER "']"
+ 
+ #define PRIVACY_TIMEOUT     60000
+ #define AUTO_LISTS_TIMEOUT  2000
+diff -Naur vacuum-1.2.4.old/src/plugins/sessionnegotiation/sessionnegotiation.cpp vacuum-1.2.4/src/plugins/sessionnegotiation/sessionnegotiation.cpp
+--- vacuum-1.2.4.old/src/plugins/sessionnegotiation/sessionnegotiation.cpp	2017-03-27 22:36:48.174650453 -0400
++++ vacuum-1.2.4/src/plugins/sessionnegotiation/sessionnegotiation.cpp	2017-03-27 22:38:07.340651610 -0400
+@@ -4,7 +4,7 @@
+ #include <QTextDocument>
+ #include <QCryptographicHash>
+ 
+-#define SHC_STANZA_SESSION            "/message/feature[@xmlns='"NS_FEATURENEG"']"
++#define SHC_STANZA_SESSION            "/message/feature[@xmlns='" NS_FEATURENEG "']"
+ 
+ #define SFP_DISCLOSURE                "disclosure"
+ #define SFP_MULTISESSION              "multisession"
+diff -Naur vacuum-1.2.4.old/src/plugins/simplemessagestyle/simplemessagestyle.cpp vacuum-1.2.4/src/plugins/simplemessagestyle/simplemessagestyle.cpp
+--- vacuum-1.2.4.old/src/plugins/simplemessagestyle/simplemessagestyle.cpp	2017-03-27 22:36:48.173650466 -0400
++++ vacuum-1.2.4/src/plugins/simplemessagestyle/simplemessagestyle.cpp	2017-03-27 22:38:33.557335864 -0400
+@@ -15,7 +15,7 @@
+ #include <utils/options.h>
+ 
+ #define SCROLL_TIMEOUT                      100
+-#define SHARED_STYLE_PATH                   RESOURCES_DIR"/"RSR_STORAGE_SIMPLEMESSAGESTYLES"/"STORAGE_SHARED_DIR
++#define SHARED_STYLE_PATH                   RESOURCES_DIR "/" RSR_STORAGE_SIMPLEMESSAGESTYLES "/" STORAGE_SHARED_DIR
+ 
+ static const char *SenderColors[] =  {
+ 	"blue", "blueviolet", "brown", "cadetblue", "chocolate", "coral", "cornflowerblue", "crimson",

--- a/net-im/vacuum/vacuum-1.2.4.ebuild
+++ b/net-im/vacuum/vacuum-1.2.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -52,6 +52,8 @@ DEPEND="${RDEPEND}"
 DOCS="AUTHORS CHANGELOG README TRANSLATORS"
 
 src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc6-not-string-literals.patch
+
 	# Force usage of system libraries
 	rm -rf src/thirdparty/{idn,minizip,zlib}
 }


### PR DESCRIPTION
Fixes GCC-6 incorrectly parsing tokens as user-defined string literals ([bug #614084](https://bugs.gentoo.org/show_bug.cgi?id=614084)).