### PR TITLE
games-action/clanbomber: Fix building with GCC-6 (bug #613332)

### DIFF
--- a/games-action/clanbomber/clanbomber-2.1.1-r1.ebuild
+++ b/games-action/clanbomber/clanbomber-2.1.1-r1.ebuild
@@ -29,6 +29,7 @@ DOCS=( AUTHORS ChangeLog ChangeLog.hg IDEAS NEWS QUOTES README TODO )
 PATCHES=(
 		"${FILESDIR}"/${P}-automake112.patch
 		"${FILESDIR}"/${P}-boost150.patch
+		"${FILESDIR}"/${P}-gcc6.patch
 )
 
 src_prepare() {

--- a/games-action/clanbomber/files/clanbomber-2.1.1-gcc6.patch
+++ b/games-action/clanbomber/files/clanbomber-2.1.1-gcc6.patch
@@ -1,0 +1,19 @@
+--- a/src/Credits.h
++++ b/src/Credits.h
+@@ -47,7 +47,7 @@
+ 	int   speed;
+ 	bool  stopped;
+  private:
+-	static const float yoffset_start = 50;
++	static const float yoffset_start;
+ 	static const int normal_speed = 40;
+ 	static const int text_height = 40;
+ 	
+--- a/src/Credits.cpp
++++ b/src/Credits.cpp
+@@ -273,3 +273,5 @@
+       (*draw_list_iter)->show();
+     }
+ }
++
++const float Credits::yoffset_start = 50;


### PR DESCRIPTION
Fixes ([bug #613332](https://bugs.gentoo.org/show_bug.cgi?id=613332)).

Defining `static const` class data members is only supported for integral and enum types.  But before GCC-6, `static const float` was nonetheless quietly accepted.  Now with GCC-6/C++14 it is appropriately failing.  If building with C++11, use `constexpr float` instead, like [upstream](http://hg.savannah.nongnu.org/hgweb/clanbomber/rev/3fa8efe3e8c0#l1.5).