### PR TITLE
dev-libs/wlc: add missing virtual/libudev depend

### DIFF
--- a/dev-libs/wlc/wlc-0.0.7-r1.ebuild
+++ b/dev-libs/wlc/wlc-0.0.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,6 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="X static-libs systemd xwayland"
 
 RDEPEND="virtual/opengl
+	virtual/libudev
 	media-libs/mesa[wayland,gbm,gles2,egl]
 	x11-libs/libdrm
 	x11-libs/pixman
@@ -51,4 +52,7 @@ pkg_postinst() {
 	if use X && ! use xwayland; then
 		elog "xwayland use flag is required for X11 applications support"
 	fi
+	ewarn "This wlc version does not support displaying"
+	ewarn "Qt, EFL and Gtk+<3.22 applications natively (without Xwayland)."
+	ewarn "It is required for Gtk+ 3.22 applications though."
 }

--- a/dev-libs/wlc/wlc-0.0.8-r1.ebuild
+++ b/dev-libs/wlc/wlc-0.0.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,6 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="X static-libs systemd xwayland"
 
 RDEPEND="virtual/opengl
+	virtual/libudev
 	media-libs/mesa[wayland,gbm,gles2,egl]
 	x11-libs/libdrm
 	x11-libs/pixman
@@ -51,7 +52,4 @@ pkg_postinst() {
 	if use X && ! use xwayland; then
 		elog "xwayland use flag is required for X11 applications support"
 	fi
-	ewarn "This wlc version does not support displaying"
-	ewarn "Qt, EFL and Gtk+<3.22 applications natively (without Xwayland)."
-	ewarn "It is required for Gtk+ 3.22 applications though."
 }

--- a/dev-libs/wlc/wlc-9999.ebuild
+++ b/dev-libs/wlc/wlc-9999.ebuild
@@ -16,20 +16,21 @@ KEYWORDS=""
 IUSE="X static-libs systemd xwayland"
 
 RDEPEND="virtual/opengl
-		media-libs/mesa[wayland,gbm,gles2,egl]
-		x11-libs/libdrm
-		x11-libs/pixman
-		x11-libs/libxkbcommon
-		x11-misc/xkeyboard-config
-		dev-libs/libinput
-		dev-libs/wayland
-		X? ( x11-libs/libX11
-			 x11-libs/libxcb[xkb]
-			 x11-libs/xcb-util-image
-			 x11-libs/xcb-util-wm
-			 x11-libs/libXfixes )
-		xwayland? ( x11-base/xorg-server[wayland] )
-		systemd? ( sys-apps/systemd sys-apps/dbus )"
+	virtual/libudev
+	media-libs/mesa[wayland,gbm,gles2,egl]
+	x11-libs/libdrm
+	x11-libs/pixman
+	x11-libs/libxkbcommon
+	x11-misc/xkeyboard-config
+	dev-libs/libinput
+	dev-libs/wayland
+	X? ( x11-libs/libX11
+		 x11-libs/libxcb[xkb]
+		 x11-libs/xcb-util-image
+		 x11-libs/xcb-util-wm
+		 x11-libs/libXfixes )
+	xwayland? ( x11-base/xorg-server[wayland] )
+	systemd? ( sys-apps/systemd sys-apps/dbus )"
 
 DEPEND="${RDEPEND}
 	virtual/pkgconfig


### PR DESCRIPTION
It can cause trouble for some users: (SirCmpwn/sway#1138)
@gentoo/proxy-maint