### PR TITLE
app-misc/lirc: Correctly set the license to GPLv2+ (was incorrect set to GPLv2)

### DIFF
--- a/app-misc/lirc/lirc-0.9.0-r6.ebuild
+++ b/app-misc/lirc/lirc-0.9.0-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -16,7 +16,7 @@ else
 	SRC_URI="http://www.lirc.org/software/snapshots/${MY_P}.tar.bz2"
 fi
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ppc ppc64 x86"
 IUSE="debug doc hardware-carrier transmitter static-libs X"

--- a/app-misc/lirc/lirc-0.9.4a-r2.ebuild
+++ b/app-misc/lirc/lirc-0.9.4a-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,7 +18,7 @@ else
 	SRC_URI="http://www.lirc.org/software/snapshots/${MY_P}.tar.bz2"
 fi
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 IUSE="doc static-libs X audio irman ftdi inputlirc iguanair systemd usb"

--- a/app-misc/lirc/lirc-0.9.4c.ebuild
+++ b/app-misc/lirc/lirc-0.9.4c.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -20,7 +20,7 @@ else
 	SRC_URI="http://www.lirc.org/software/snapshots/${MY_P}.tar.bz2"
 fi
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 IUSE="audio doc ftdi gtk inputlirc static-libs systemd usb X"

--- a/app-misc/lirc/lirc-0.9.4d.ebuild
+++ b/app-misc/lirc/lirc-0.9.4d.ebuild
@@ -20,7 +20,7 @@ else
 	SRC_URI="http://www.lirc.org/software/snapshots/${MY_P}.tar.bz2"
 fi
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 IUSE="audio doc ftdi gtk inputlirc static-libs systemd usb X"


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=614142