### PR TITLE
eclass/cargo: Don't fail on missing directory

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -125,7 +125,7 @@ cargo_src_install() {
 		|| die "cargo install failed"
 	rm -f "${D}/usr/.crates.toml"
 
-	[ -d "${S}/man" ] && doman "${S}/man"
+	[ -d "${S}/man" ] && doman "${S}/man" || return 0
 }
 
 fi


### PR DESCRIPTION
Previously the cargo_src_install step fails when using
`cargo_src_install || die` and no man-directory is
included with the crate. This commit corrects this
behavior and ensures it does not die in those cases.

See this comment: https://bugs.gentoo.org/show_bug.cgi?id=604122#c15

Package-Manager: Portage-2.3.3