### PR TITLE
dev-vcs/qsvn: Fix building with GCC-6 (bug #613326)

### DIFF
--- a/dev-vcs/qsvn/files/qsvn-0.8.3-gcc6.patch
+++ b/dev-vcs/qsvn/files/qsvn-0.8.3-gcc6.patch
@@ -1,0 +1,11 @@
+--- a/svnqt/contextdata.cpp
++++ b/svnqt/contextdata.cpp
+@@ -748,7 +748,7 @@
+ 
+     svn_config_get(cfg, &mimetypes_file,
+                    SVN_CONFIG_SECTION_MISCELLANY,
+-                   SVN_CONFIG_OPTION_MIMETYPES_FILE, false);
++                   SVN_CONFIG_OPTION_MIMETYPES_FILE, NULL);
+     if (mimetypes_file && *mimetypes_file) {
+         if ((err = svn_io_parse_mimetypes_file(&(m_ctx->mimetypes_map),
+              mimetypes_file, pool))) {

--- a/dev-vcs/qsvn/qsvn-0.8.3.ebuild
+++ b/dev-vcs/qsvn/qsvn-0.8.3.ebuild
@@ -27,6 +27,7 @@ S=${WORKDIR}/${P}/src
 PATCHES=(
 	"${FILESDIR}/${P}-static-lib.patch"
 	"${FILESDIR}/${P}-tests.patch"
+	"${FILESDIR}/${P}-gcc6.patch"
 )
 
 DOCS=( ../ChangeLog ../README )


### PR DESCRIPTION
Fixes [bug #613326](https://bugs.gentoo.org/show_bug.cgi?id=613326).
GCC-6 no longer allows implicit conversion from boolean `false` to null pointer.  Explicitly use NULL instead.