### PR TITLE
cifs-utils-6.7 fix heimdal testing

### DIFF
--- a/net-fs/cifs-utils/cifs-utils-6.7.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-6.7.ebuild
@@ -53,7 +53,7 @@ pkg_setup() {
 src_prepare() {
 	default
 
-	if has app-crypt/heimdal ; then
+	if has_version app-crypt/heimdal ; then
 		# https://bugs.gentoo.org/612584
 		eapply "${FILESDIR}/${PN}-6.7-heimdal.patch"
 	fi


### PR DESCRIPTION
we should use 'has_version' instead of 'has' here

```

       has <item> <item list>
              If item is in item list, then has returns 0. Otherwise, 1 is returned. There is another version, hasv, that will conditionally echo item.
              The item list is delimited by the IFS variable.  This variable has a default value of ' ', or a space.  It is a bash(1) setting.

       hasv <item> <item list>
              Like has, but also echoes item when has returns true.

       has_version [--host-root] <category/package-version>
              Check  to  see  if  category/package-version is installed on the system.  The parameter accepts all values that are acceptable in the DEPEND variable.  The function returns 0 if category/package-version is installed, 1
              otherwise. Beginning with EAPI 5, the --host-root option may be used in order to cause the query to apply to the host root instead of ${ROOT}.
```