### PR TITLE
media-sound/fluidsynth: depend on virtual/jack, wrt #602880

### DIFF
--- a/media-sound/fluidsynth/fluidsynth-1.1.6-r1.ebuild
+++ b/media-sound/fluidsynth/fluidsynth-1.1.6-r1.ebuild
@@ -17,7 +17,7 @@ RDEPEND=">=dev-libs/glib-2.34.3:2[${MULTILIB_USEDEP}]
 	alsa? ( >=media-libs/alsa-lib-1.0.27.2[${MULTILIB_USEDEP}]
 		lash? ( >=media-sound/lash-0.5.4-r2[${MULTILIB_USEDEP}] ) )
 	dbus? ( >=sys-apps/dbus-1.6.18-r1[${MULTILIB_USEDEP}] )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.121.3-r1[${MULTILIB_USEDEP}] )
+	jack? ( virtual/jack[${MULTILIB_USEDEP}] )
 	ladspa? ( >=media-libs/ladspa-sdk-1.13-r2[${MULTILIB_USEDEP}]
 		>=media-libs/ladspa-cmt-1.16-r3[${MULTILIB_USEDEP}] )
 	pulseaudio? ( >=media-sound/pulseaudio-2.1-r1[${MULTILIB_USEDEP}] )


### PR DESCRIPTION
Gentoo-Bug: 602880
Package-Manager: Portage-2.3.5, Repoman-2.3.2