### PR TITLE
games-arcade/retrobattle: Fix building with GCC-6 (bug #614398)

### DIFF
--- a/games-arcade/retrobattle/files/retrobattle-1.0.0-gcc6.patch
+++ b/games-arcade/retrobattle/files/retrobattle-1.0.0-gcc6.patch
@@ -1,0 +1,22 @@
+--- a/src/GameLogic.h
++++ b/src/GameLogic.h
+@@ -52,8 +52,8 @@
+   /* Fixed interval time-based animation */
+   static const int maximumFrameRate = 60;
+   static const int minimumFrameRate = 15;
+-  static const float updateInterval = 1.0 / maximumFrameRate;
+-  static const float maxCyclesPerFrame = maximumFrameRate / minimumFrameRate;
++  static const float updateInterval;
++  static const float maxCyclesPerFrame;
+ 
+   float lastFrameTime;
+   float cyclesLeftOver;
+--- a/src/GameLogic.cc
++++ b/src/GameLogic.cc
+@@ -206,3 +206,6 @@
+ {
+   sprintf(buf, "%s/data/gfx/%s", datadir, file);
+ }
++
++const float GameLogic::updateInterval = 1.0 / maximumFrameRate;
++const float GameLogic::maxCyclesPerFrame = maximumFrameRate / minimumFrameRate;

--- a/games-arcade/retrobattle/retrobattle-1.0.0.ebuild
+++ b/games-arcade/retrobattle/retrobattle-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -22,7 +22,7 @@ RDEPEND="${DEPEND}"
 S=${WORKDIR}/${MY_P}/src
 
 src_prepare() {
-	epatch "${FILESDIR}"/${P}-{build,sound}.patch
+	epatch "${FILESDIR}"/${P}-{build,sound,gcc6}.patch
 }
 
 src_install() {


### PR DESCRIPTION
Fixes [bug #614398](https://bugs.gentoo.org/show_bug.cgi?id=614398).

Defines the relevant offending `static const float` members in the corresponding source file instead of in the header's class definition.