### PR TITLE
games-puzzle/cuyo: Fix building with GCC-6 (bug #614366)

### DIFF
--- a/games-puzzle/cuyo/cuyo-2.1.1.ebuild
+++ b/games-puzzle/cuyo/cuyo-2.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -26,7 +26,8 @@ S=${WORKDIR}/${MY_P}
 src_prepare() {
 	epatch \
 		"${FILESDIR}"/${P}-gcc44.patch \
-		"${FILESDIR}"/${P}-gentoo.patch
+		"${FILESDIR}"/${P}-gentoo.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 	eautoreconf
 }
 

--- a/games-puzzle/cuyo/files/cuyo-2.1.1-gcc6.patch
+++ b/games-puzzle/cuyo/files/cuyo-2.1.1-gcc6.patch
@@ -1,0 +1,45 @@
+--- a/src/pfaditerator.h
++++ b/src/pfaditerator.h
+@@ -21,6 +21,11 @@
+ #include "stringzeug.h"
+ 
+ 
++#if __cplusplus >= 201103L
++#define NOEXCEPT noexcept(false)
++#else
++#define NOEXCEPT
++#endif
+ 
+ 
+ /** Iteriert durch alle Pfade, an denen sich eine
+@@ -43,7 +48,7 @@
+ class PfadIterator {
+ public: 
+   PfadIterator(Str dat, bool auch_gz = false, bool setzDefault = false);
+-  ~PfadIterator();
++  ~PfadIterator() NOEXCEPT;
+   
+   /** Nächster Pfad */
+   PfadIterator & operator++();
+--- a/src/pfaditerator.cpp
++++ b/src/pfaditerator.cpp
+@@ -48,7 +48,7 @@
+      -1 und führen dann gleich ein ++ aus. */
+   ++(*this);
+ }
+-PfadIterator::~PfadIterator() {
++PfadIterator::~PfadIterator() NOEXCEPT {
+   /** Soll der default-Pfad gesetzt werden? */
+   if (mSetzDefault) {
+ 
+--- a/src/xpmladen.cpp
++++ b/src/xpmladen.cpp
+@@ -314,7 +314,7 @@
+   try {
+ 
+     /* Datei laden. Dabei werden gDatAnfang und gDatEnde gesetzt. */
+-    if (!ladeDatei(na)) return false;
++    if (!ladeDatei(na)) return NULL;
+ 
+ 
+     gDatBei = gDatAnfang;


### PR DESCRIPTION
Fixes [bug #614366](https://bugs.gentoo.org/show_bug.cgi?id=614366).

Marks a destructor `noexcept(false)` while compiling in c++11/14/17 and changes an unsupported "boolean `false` to null pointer" return into a return of `NULL`.