### PR TITLE
app-arch/libarchive: fix v3.3.1 building with libressl

### DIFF
--- a/app-arch/libarchive/files/libarchive-3.3.0-libressl.patch
+++ b/app-arch/libarchive/files/libarchive-3.3.0-libressl.patch
@@ -1,0 +1,12 @@
+diff -Naur libarchive-3.3.0.orig/libarchive/archive_openssl_hmac_private.h libarchive-3.3.0/libarchive/archive_openssl_hmac_private.h
+--- libarchive-3.3.0.orig/libarchive/archive_openssl_hmac_private.h	2017-02-24 11:08:04.378701206 -0800
++++ libarchive-3.3.0/libarchive/archive_openssl_hmac_private.h	2017-02-24 11:08:57.275225258 -0800
+@@ -28,7 +28,7 @@
+ #include <openssl/hmac.h>
+ #include <openssl/opensslv.h>
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #include <stdlib.h> /* malloc, free */
+ #include <string.h> /* memset */
+ static inline HMAC_CTX *HMAC_CTX_new(void)

--- a/app-arch/libarchive/libarchive-3.3.1.ebuild
+++ b/app-arch/libarchive/libarchive-3.3.1.ebuild
@@ -35,6 +35,8 @@ DEPEND="${RDEPEND}
 		e2fsprogs? ( sys-fs/e2fsprogs )
 	)"
 
+PATCHES=( "${FILESDIR}"/${PN}-3.3.0-libressl.patch )
+
 src_prepare() {
 	default
 	elibtoolize  # is required for Solaris sol2_ld linker fix


### PR DESCRIPTION
This is the quick fix for libarchive building against libressl, from https://bugs.gentoo.org/show_bug.cgi?id=614460 by hexumg@gmail.com

As libarchive is a lower depend in paludis etc, it may break the base system if someone try to building with libressl, it'd be better to fix it.

And a pull request is opened to libarchive too: https://github.com/libarchive/libarchive/pull/902