### PR TITLE
dev-python/{cssutils,pypeg2}, www-client/qutebrowser: python 3.6 support

### DIFF
--- a/dev-python/cssutils/cssutils-1.0.1-r1.ebuild
+++ b/dev-python/cssutils/cssutils-1.0.1-r1.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} pypy )
+
+inherit distutils-r1
+
+DESCRIPTION="A CSS Cascading Style Sheets library"
+HOMEPAGE="https://pypi.python.org/pypi/cssutils/ https://bitbucket.org/cthedot/cssutils http://cthedot.de/cssutils/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 arm ppc x86"
+IUSE="test"
+
+RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}
+	test? (
+		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/nose[${PYTHON_USEDEP}]
+	)"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-pypy-test-backport.patch
+)
+
+python_prepare_all() {
+	# Disable test failing with dev-python/pyxml installed.
+	if has_version dev-python/pyxml; then
+		sed -e "s/test_linecol/_&/" -i src/tests/test_errorhandler.py
+	fi
+
+	# requires old pbr, does it really?
+	sed \
+		-e '/tests_require/d' \
+		-i setup.py || die
+
+	EPATCH_OPTS="--binary"
+
+	distutils-r1_python_prepare_all
+}
+
+python_test() {
+	ln -s "${S}/sheets" "${BUILD_DIR}/sheets" || die
+	# esetup.py test
+	# exclude tests that connect to the network
+	set --  nosetests \
+		-e test_parseUrl -e test_handlers -P "${BUILD_DIR}/lib/cssutils/tests"
+	echo "$@"
+	"$@" || die "Testing failed with ${EPYTHON}"
+}

--- a/dev-python/pypeg2/pypeg2-2.15.2.ebuild
+++ b/dev-python/pypeg2/pypeg2-2.15.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 inherit distutils-r1
 

--- a/www-client/qutebrowser/qutebrowser-0.9.1.ebuild
+++ b/www-client/qutebrowser/qutebrowser-0.9.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{3_4,3_5} )
+PYTHON_COMPAT=( python{3_4,3_5,3_6} )
 
 inherit gnome2-utils distutils-r1 eutils fdo-mime
 

--- a/www-client/qutebrowser/qutebrowser-9999.ebuild
+++ b/www-client/qutebrowser/qutebrowser-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{3_4,3_5} )
+PYTHON_COMPAT=( python{3_4,3_5,3_6} )
 
 inherit gnome2-utils distutils-r1 eutils fdo-mime
 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=612502