### PR TITLE
net-libs/libsrsirc: Fix file collision

### DIFF
--- a/net-libs/libsrsirc/libsrsirc-0.0.14-r1.ebuild
+++ b/net-libs/libsrsirc/libsrsirc-0.0.14-r1.ebuild
@@ -17,12 +17,11 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 src_configure() {
-	econf \
-		$(use_enable static-libs static) \
-		$(use_with ssl)
+	econf $(use_enable static-libs static) $(use_with ssl)
 }
 
 src_install() {
 	default
 	find "${D}" -name '*.la' -delete || die
+	mv "${D}/usr/bin/icat" "${D}/usr/bin/icat-lsi" || die
 }


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/614778

This was the fix suggested by the author. I also had [these](http://paste.pr0.tips/5F) in mind.