### PR TITLE
Add 3.6 to various PYTHON_COMPATs

### DIFF
--- a/app-misc/ca-certificates/ca-certificates-20161130.3.30.1.ebuild
+++ b/app-misc/ca-certificates/ca-certificates-20161130.3.30.1.ebuild
@@ -25,7 +25,7 @@
 #   https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS&component=CA%20Certificates&version=trunk
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 inherit eutils python-any-r1
 

--- a/app-misc/media-player-info/media-player-info-22.ebuild
+++ b/app-misc/media-player-info/media-player-info-22.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-PYTHON_COMPAT=( python3_{4,5} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 
 inherit eutils python-any-r1
 

--- a/app-text/iso-codes/iso-codes-3.74.ebuild
+++ b/app-text/iso-codes/iso-codes-3.74.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python3_{4,5} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 PLOCALES="af am ar as ast az be bg bn bn_IN br bs byn ca crh cs cy da de dz el en eo es et eu fa fi fo fr ga gez gl gu haw he hi hr hu hy ia id is it ja ka kk km kn ko kok ku lt lv mi mk ml mn mr ms mt nb ne nl nn nso oc or pa pl ps pt pt_BR ro ru rw si sk sl so sq sr sr@latin sv sw ta te th ti tig tk tl tr tt tt@iqtelif ug uk ve vi wa wal wo xh zh_CN zh_HK zh_TW zu"
 
 inherit eutils l10n python-any-r1

--- a/dev-util/ninja/ninja-1.7.2.ebuild
+++ b/dev-util/ninja/ninja-1.7.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 inherit bash-completion-r1 elisp-common python-any-r1 toolchain-funcs
 

--- a/x11-libs/libxcb/libxcb-1.12-r2.ebuild
+++ b/x11-libs/libxcb/libxcb-1.12-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 PYTHON_REQ_USE=xml
 
 XORG_DOC=doc

--- a/x11-misc/compton/compton-0.1_beta2.ebuild
+++ b/x11-misc/compton/compton-0.1_beta2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python3_{4,5} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 inherit toolchain-funcs python-r1
 
 DESCRIPTION="A compositor for X, and a fork of xcompmgr-dana"

--- a/x11-misc/compton/compton-9999.ebuild
+++ b/x11-misc/compton/compton-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{4,5} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 inherit toolchain-funcs python-r1 git-r3
 
 DESCRIPTION="A compositor for X, and a fork of xcompmgr-dana"

--- a/x11-proto/xcb-proto/xcb-proto-1.12-r2.ebuild
+++ b/x11-proto/xcb-proto/xcb-proto-1.12-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 XORG_MULTILIB=yes
 
 inherit python-r1 xorg-2


### PR DESCRIPTION
The following packages work fine with python 3.6, so I updated their PYTHON_COMPATs.
With these fixes I could depclean my ~amd64 systems of python-3.5 without issue.
