### PR TITLE
sys-devel/bc Add requirement on sys-apps/ed

### DIFF
--- a/sys-devel/bc/bc-1.07.1.ebuild
+++ b/sys-devel/bc/bc-1.07.1.ebuild
@@ -21,6 +21,7 @@ RDEPEND="!readline? ( libedit? ( dev-libs/libedit:= ) )
 		>=sys-libs/ncurses-5.2:=
 	)"
 DEPEND="${RDEPEND}
+	sys-apps/ed
 	sys-devel/flex"
 
 src_configure() {


### PR DESCRIPTION
Seems a script calls it directly and it failed because it wasn't installed on my system