### PR TITLE
sci-biology/tophat: drop bundled python packages

### DIFF
--- a/sci-biology/tophat/files/tophat-2.1.1-Makefile.am.patch
+++ b/sci-biology/tophat/files/tophat-2.1.1-Makefile.am.patch
@@ -1,0 +1,751 @@
+--- tophat-2.1.1/src/Makefile.am.ori	2017-04-10 23:57:41.219738416 +0200
++++ tophat-2.1.1/src/Makefile.am	2017-04-10 23:59:04.012070076 +0200
+@@ -6,682 +6,7 @@
+ # - and tophat2.in added
+ EXTRA_DIST = \
+ tophat.py \
+-tophat2.sh \
+-intervaltree/__init__.py \
+-intervaltree/interval.py \
+-intervaltree/intervaltree.py \
+-intervaltree/node.py \
+-sortedcontainers/__init__.py \
+-sortedcontainers/sorteddict.py \
+-sortedcontainers/sortedlist.py \
+-sortedcontainers/sortedlistwithkey.py \
+-sortedcontainers/sortedset.py \
+-samtools-0.1.18/AUTHORS \
+-samtools-0.1.18/COPYING \
+-samtools-0.1.18/ChangeLog \
+-samtools-0.1.18/INSTALL \
+-samtools-0.1.18/Makefile \
+-samtools-0.1.18/Makefile.mingw \
+-samtools-0.1.18/NEWS \
+-samtools-0.1.18/bam.c \
+-samtools-0.1.18/bam.h \
+-samtools-0.1.18/bam2bcf.c \
+-samtools-0.1.18/bam2bcf.h \
+-samtools-0.1.18/bam2bcf_indel.c \
+-samtools-0.1.18/bam2depth.c \
+-samtools-0.1.18/bam_aux.c \
+-samtools-0.1.18/bam_cat.c \
+-samtools-0.1.18/bam_color.c \
+-samtools-0.1.18/bam_endian.h \
+-samtools-0.1.18/bam_import.c \
+-samtools-0.1.18/bam_index.c \
+-samtools-0.1.18/bam_lpileup.c \
+-samtools-0.1.18/bam_mate.c \
+-samtools-0.1.18/bam_md.c \
+-samtools-0.1.18/bam_pileup.c \
+-samtools-0.1.18/bam_plcmd.c \
+-samtools-0.1.18/bam_reheader.c \
+-samtools-0.1.18/bam_rmdup.c \
+-samtools-0.1.18/bam_rmdupse.c \
+-samtools-0.1.18/bam_sort.c \
+-samtools-0.1.18/bam_stat.c \
+-samtools-0.1.18/bam_tview.c \
+-samtools-0.1.18/bamtk.c \
+-samtools-0.1.18/bedidx.c \
+-samtools-0.1.18/bgzf.c \
+-samtools-0.1.18/bgzf.h \
+-samtools-0.1.18/bgzip.c \
+-samtools-0.1.18/cut_target.c \
+-samtools-0.1.18/errmod.c \
+-samtools-0.1.18/errmod.h \
+-samtools-0.1.18/faidx.c \
+-samtools-0.1.18/faidx.h \
+-samtools-0.1.18/kaln.c \
+-samtools-0.1.18/kaln.h \
+-samtools-0.1.18/khash.h \
+-samtools-0.1.18/klist.h \
+-samtools-0.1.18/knetfile.c \
+-samtools-0.1.18/knetfile.h \
+-samtools-0.1.18/kprobaln.c \
+-samtools-0.1.18/kprobaln.h \
+-samtools-0.1.18/kseq.h \
+-samtools-0.1.18/ksort.h \
+-samtools-0.1.18/kstring.c \
+-samtools-0.1.18/kstring.h \
+-samtools-0.1.18/phase.c \
+-samtools-0.1.18/razf.c \
+-samtools-0.1.18/razf.h \
+-samtools-0.1.18/razip.c \
+-samtools-0.1.18/sam.c \
+-samtools-0.1.18/sam.h \
+-samtools-0.1.18/sam_header.c \
+-samtools-0.1.18/sam_header.h \
+-samtools-0.1.18/sam_view.c \
+-samtools-0.1.18/sample.c \
+-samtools-0.1.18/sample.h \
+-samtools-0.1.18/samtools.1 \
+-samtools-0.1.18/bcftools/Makefile \
+-samtools-0.1.18/bcftools/README \
+-samtools-0.1.18/bcftools/bcf.c \
+-samtools-0.1.18/bcftools/bcf.h \
+-samtools-0.1.18/bcftools/bcf.tex \
+-samtools-0.1.18/bcftools/bcf2qcall.c \
+-samtools-0.1.18/bcftools/bcfutils.c \
+-samtools-0.1.18/bcftools/call1.c \
+-samtools-0.1.18/bcftools/em.c \
+-samtools-0.1.18/bcftools/fet.c \
+-samtools-0.1.18/bcftools/index.c \
+-samtools-0.1.18/bcftools/kfunc.c \
+-samtools-0.1.18/bcftools/kmin.c \
+-samtools-0.1.18/bcftools/kmin.h \
+-samtools-0.1.18/bcftools/main.c \
+-samtools-0.1.18/bcftools/mut.c \
+-samtools-0.1.18/bcftools/prob1.c \
+-samtools-0.1.18/bcftools/prob1.h \
+-samtools-0.1.18/bcftools/vcf.c \
+-samtools-0.1.18/bcftools/vcfutils.pl \
+-SeqAn-1.4.2/LICENSE \
+-SeqAn-1.4.2/README.rst \
+-SeqAn-1.4.2/seqan/align/align_base.h \
+-SeqAn-1.4.2/seqan/align/align_cols.h \
+-SeqAn-1.4.2/seqan/align/align_config.h \
+-SeqAn-1.4.2/seqan/align/align_iterator_base.h \
+-SeqAn-1.4.2/seqan/align/alignment_algorithm_tags.h \
+-SeqAn-1.4.2/seqan/align/alignment_operations.h \
+-SeqAn-1.4.2/seqan/align/align_metafunctions.h \
+-SeqAn-1.4.2/seqan/align/align_traceback.h \
+-SeqAn-1.4.2/seqan/align/dp_algorithm_impl.h \
+-SeqAn-1.4.2/seqan/align/dp_band.h \
+-SeqAn-1.4.2/seqan/align/dp_cell_affine.h \
+-SeqAn-1.4.2/seqan/align/dp_cell.h \
+-SeqAn-1.4.2/seqan/align/dp_cell_linear.h \
+-SeqAn-1.4.2/seqan/align/dp_formula_affine.h \
+-SeqAn-1.4.2/seqan/align/dp_formula.h \
+-SeqAn-1.4.2/seqan/align/dp_formula_linear.h \
+-SeqAn-1.4.2/seqan/align/dp_matrix.h \
+-SeqAn-1.4.2/seqan/align/dp_matrix_navigator.h \
+-SeqAn-1.4.2/seqan/align/dp_matrix_navigator_score_matrix.h \
+-SeqAn-1.4.2/seqan/align/dp_matrix_navigator_score_matrix_sparse.h \
+-SeqAn-1.4.2/seqan/align/dp_matrix_navigator_trace_matrix.h \
+-SeqAn-1.4.2/seqan/align/dp_matrix_sparse.h \
+-SeqAn-1.4.2/seqan/align/dp_meta_info.h \
+-SeqAn-1.4.2/seqan/align/dp_profile.h \
+-SeqAn-1.4.2/seqan/align/dp_scout.h \
+-SeqAn-1.4.2/seqan/align/dp_setup.h \
+-SeqAn-1.4.2/seqan/align/dp_traceback_adaptor.h \
+-SeqAn-1.4.2/seqan/align/dp_traceback_impl.h \
+-SeqAn-1.4.2/seqan/align/dp_trace_segment.h \
+-SeqAn-1.4.2/seqan/align/evaluate_alignment.h \
+-SeqAn-1.4.2/seqan/align/gap_anchor.h \
+-SeqAn-1.4.2/seqan/align/gapped_value_type.h \
+-SeqAn-1.4.2/seqan/align/gaps_anchor.h \
+-SeqAn-1.4.2/seqan/align/gaps_array.h \
+-SeqAn-1.4.2/seqan/align/gaps_base.h \
+-SeqAn-1.4.2/seqan/align/gaps_iterator_anchor.h \
+-SeqAn-1.4.2/seqan/align/gaps_iterator_array.h \
+-SeqAn-1.4.2/seqan/align/gaps_iterator_base.h \
+-SeqAn-1.4.2/seqan/align/global_alignment_banded.h \
+-SeqAn-1.4.2/seqan/align/global_alignment_hirschberg_impl.h \
+-SeqAn-1.4.2/seqan/align/global_alignment_myers_hirschberg_impl.h \
+-SeqAn-1.4.2/seqan/align/global_alignment_myers_impl.h \
+-SeqAn-1.4.2/seqan/align/global_alignment_specialized.h \
+-SeqAn-1.4.2/seqan/align/global_alignment_unbanded.h \
+-SeqAn-1.4.2/seqan/align.h \
+-SeqAn-1.4.2/seqan/align/INFO \
+-SeqAn-1.4.2/seqan/align/local_alignment_banded.h \
+-SeqAn-1.4.2/seqan/align/local_alignment_banded_waterman_eggert_impl.h \
+-SeqAn-1.4.2/seqan/align/local_alignment_enumeration_banded.h \
+-SeqAn-1.4.2/seqan/align/local_alignment_enumeration.h \
+-SeqAn-1.4.2/seqan/align/local_alignment_enumeration_unbanded.h \
+-SeqAn-1.4.2/seqan/align/local_alignment_unbanded.h \
+-SeqAn-1.4.2/seqan/align/local_alignment_waterman_eggert_impl.h \
+-SeqAn-1.4.2/seqan/align/matrix_base.h \
+-SeqAn-1.4.2/seqan/arg_parse/arg_parse_argument.h \
+-SeqAn-1.4.2/seqan/arg_parse/arg_parse_ctd_support.h \
+-SeqAn-1.4.2/seqan/arg_parse/arg_parse_doc.h \
+-SeqAn-1.4.2/seqan/arg_parse/arg_parse_exceptions.h \
+-SeqAn-1.4.2/seqan/arg_parse/arg_parse_option.h \
+-SeqAn-1.4.2/seqan/arg_parse/arg_parse_parse.h \
+-SeqAn-1.4.2/seqan/arg_parse/arg_parse_type_support.h \
+-SeqAn-1.4.2/seqan/arg_parse/argument_parser.h \
+-SeqAn-1.4.2/seqan/arg_parse.h \
+-SeqAn-1.4.2/seqan/arg_parse/INFO \
+-SeqAn-1.4.2/seqan/arg_parse/tool_doc.h \
+-SeqAn-1.4.2/seqan/arg_parse/xml_support.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_alignment_record.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_alignment_record_util.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_header_record.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_index_bai.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_index_base.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_io_context.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_reader.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_sam_conversion.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_stream.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_tags_dict.h \
+-SeqAn-1.4.2/seqan/bam_io/bam_writer.h \
+-SeqAn-1.4.2/seqan/bam_io/cigar.h \
+-SeqAn-1.4.2/seqan/bam_io.h \
+-SeqAn-1.4.2/seqan/bam_io/INFO \
+-SeqAn-1.4.2/seqan/bam_io/read_bam.h \
+-SeqAn-1.4.2/seqan/bam_io/read_sam.h \
+-SeqAn-1.4.2/seqan/bam_io/sam_reader.h \
+-SeqAn-1.4.2/seqan/bam_io/sam_writer.h \
+-SeqAn-1.4.2/seqan/bam_io/write_bam.h \
+-SeqAn-1.4.2/seqan/bam_io/write_sam.h \
+-SeqAn-1.4.2/seqan/bam_io/xam_reader.h \
+-SeqAn-1.4.2/seqan/bam_io/xam_writer.h \
+-SeqAn-1.4.2/seqan/basic/aggregate_concept.h \
+-SeqAn-1.4.2/seqan/basic/allocator_chunkpool.h \
+-SeqAn-1.4.2/seqan/basic/allocator_interface.h \
+-SeqAn-1.4.2/seqan/basic/allocator_multipool.h \
+-SeqAn-1.4.2/seqan/basic/allocator_simple.h \
+-SeqAn-1.4.2/seqan/basic/allocator_singlepool.h \
+-SeqAn-1.4.2/seqan/basic/allocator_to_std.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_adapt_builtins.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_bio.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_concept.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_math.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_profile.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_qualities.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_residue_funcs.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_residue.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_residue_tabs.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_simple_type.h \
+-SeqAn-1.4.2/seqan/basic/alphabet_storage.h \
+-SeqAn-1.4.2/seqan/basic/array_construct_destruct.h \
+-SeqAn-1.4.2/seqan/basic/basic_aggregate.h \
+-SeqAn-1.4.2/seqan/basic/basic_allocator.h \
+-SeqAn-1.4.2/seqan/basic/basic_alphabet.h \
+-SeqAn-1.4.2/seqan/basic/basic_concept.h \
+-SeqAn-1.4.2/seqan/basic/basic_container.h \
+-SeqAn-1.4.2/seqan/basic/basic_debug.h \
+-SeqAn-1.4.2/seqan/basic/basic_exception.h \
+-SeqAn-1.4.2/seqan/basic/basic_fundamental.h \
+-SeqAn-1.4.2/seqan/basic/basic_iterator.h \
+-SeqAn-1.4.2/seqan/basic/basic_math.h \
+-SeqAn-1.4.2/seqan/basic/basic_metaprogramming.h \
+-SeqAn-1.4.2/seqan/basic/basic_parallelism.h \
+-SeqAn-1.4.2/seqan/basic/basic_proxy.h \
+-SeqAn-1.4.2/seqan/basic/basic_smart_pointer.h \
+-SeqAn-1.4.2/seqan/basic/basic_tangle.h \
+-SeqAn-1.4.2/seqan/basic/basic_type.h \
+-SeqAn-1.4.2/seqan/basic/boost_preprocessor_subset.h \
+-SeqAn-1.4.2/seqan/basic/builtin_functions.h \
+-SeqAn-1.4.2/seqan/basic/concept_checking.h \
+-SeqAn-1.4.2/seqan/basic/container_concept.h \
+-SeqAn-1.4.2/seqan/basic/debug_helper.h \
+-SeqAn-1.4.2/seqan/basic/debug_test_system.h \
+-SeqAn-1.4.2/seqan/basic/fundamental_comparison.h \
+-SeqAn-1.4.2/seqan/basic/fundamental_concepts.h \
+-SeqAn-1.4.2/seqan/basic/fundamental_conversion.h \
+-SeqAn-1.4.2/seqan/basic/fundamental_metafunctions.h \
+-SeqAn-1.4.2/seqan/basic/fundamental_tags.h \
+-SeqAn-1.4.2/seqan/basic/fundamental_transport.h \
+-SeqAn-1.4.2/seqan/basic.h \
+-SeqAn-1.4.2/seqan/basic/holder_base.h \
+-SeqAn-1.4.2/seqan/basic/holder_simple.h \
+-SeqAn-1.4.2/seqan/basic/holder_tristate.h \
+-SeqAn-1.4.2/seqan/basic/hosted_type_interface.h \
+-SeqAn-1.4.2/seqan/basic/INFO \
+-SeqAn-1.4.2/seqan/basic/iterator_adaptor.h \
+-SeqAn-1.4.2/seqan/basic/iterator_adapt_pointer.h \
+-SeqAn-1.4.2/seqan/basic/iterator_adapt_std.h \
+-SeqAn-1.4.2/seqan/basic/iterator_base.h \
+-SeqAn-1.4.2/seqan/basic/iterator_concept.h \
+-SeqAn-1.4.2/seqan/basic/iterator_interface.h \
+-SeqAn-1.4.2/seqan/basic/iterator_position.h \
+-SeqAn-1.4.2/seqan/basic/macro_deprecated.h \
+-SeqAn-1.4.2/seqan/basic/math_functions.h \
+-SeqAn-1.4.2/seqan/basic/math_log_space_value.h \
+-SeqAn-1.4.2/seqan/basic/metaprogramming_control.h \
+-SeqAn-1.4.2/seqan/basic/metaprogramming_enable_if.h \
+-SeqAn-1.4.2/seqan/basic/metaprogramming_logic.h \
+-SeqAn-1.4.2/seqan/basic/metaprogramming_math.h \
+-SeqAn-1.4.2/seqan/basic/metaprogramming_type.h \
+-SeqAn-1.4.2/seqan/basic/pair_base.h \
+-SeqAn-1.4.2/seqan/basic/pair_bit_compressed.h \
+-SeqAn-1.4.2/seqan/basic/pair_packed.h \
+-SeqAn-1.4.2/seqan/basic/profiling.h \
+-SeqAn-1.4.2/seqan/basic/proxy_base.h \
+-SeqAn-1.4.2/seqan/basic/proxy_iterator.h \
+-SeqAn-1.4.2/seqan/basic/test_system.h \
+-SeqAn-1.4.2/seqan/basic/triple_base.h \
+-SeqAn-1.4.2/seqan/basic/triple_packed.h \
+-SeqAn-1.4.2/seqan/basic/tuple_base.h \
+-SeqAn-1.4.2/seqan/basic/tuple_bit_compressed.h \
+-SeqAn-1.4.2/seqan/basic/volatile_ptr.h \
+-SeqAn-1.4.2/seqan/consensus/consensus_base.h \
+-SeqAn-1.4.2/seqan/consensus/consensus_library.h \
+-SeqAn-1.4.2/seqan/consensus/consensus_realign.h \
+-SeqAn-1.4.2/seqan/consensus/consensus_score.h \
+-SeqAn-1.4.2/seqan/consensus.h \
+-SeqAn-1.4.2/seqan/consensus/INFO \
+-SeqAn-1.4.2/seqan/file/chunk_collector.h \
+-SeqAn-1.4.2/seqan/file/cstream.h \
+-SeqAn-1.4.2/seqan/file/file_base.h \
+-SeqAn-1.4.2/seqan/file/file_cstyle.h \
+-SeqAn-1.4.2/seqan/file/file_filereader.h \
+-SeqAn-1.4.2/seqan/file/file_filereaderiterator.h \
+-SeqAn-1.4.2/seqan/file/file_format_cgviz.h \
+-SeqAn-1.4.2/seqan/file/file_format_embl.h \
+-SeqAn-1.4.2/seqan/file/file_format_fasta_align.h \
+-SeqAn-1.4.2/seqan/file/file_format_fasta.h \
+-SeqAn-1.4.2/seqan/file/file_format_genbank.h \
+-SeqAn-1.4.2/seqan/file/file_format_guess.h \
+-SeqAn-1.4.2/seqan/file/file_format.h \
+-SeqAn-1.4.2/seqan/file/file_format_mmap.h \
+-SeqAn-1.4.2/seqan/file/file_format_raw.h \
+-SeqAn-1.4.2/seqan/file/file_forwards.h \
+-SeqAn-1.4.2/seqan/file/file_interface.h \
+-SeqAn-1.4.2/seqan/file/file_mapping.h \
+-SeqAn-1.4.2/seqan/file/file_page.h \
+-SeqAn-1.4.2/seqan/file.h \
+-SeqAn-1.4.2/seqan/file/INFO \
+-SeqAn-1.4.2/seqan/file/meta.h \
+-SeqAn-1.4.2/seqan/file/stream_algorithms.h \
+-SeqAn-1.4.2/seqan/file/stream.h \
+-SeqAn-1.4.2/seqan/file/string_external.h \
+-SeqAn-1.4.2/seqan/file/string_mmap.h \
+-SeqAn-1.4.2/seqan/find/find_abndm.h \
+-SeqAn-1.4.2/seqan/find/find_ahocorasick.h \
+-SeqAn-1.4.2/seqan/find/find_base.h \
+-SeqAn-1.4.2/seqan/find/find_begin.h \
+-SeqAn-1.4.2/seqan/find/find_bndm.h \
+-SeqAn-1.4.2/seqan/find/find_bom.h \
+-SeqAn-1.4.2/seqan/find/find_hamming_simple.h \
+-SeqAn-1.4.2/seqan/find/find_horspool.h \
+-SeqAn-1.4.2/seqan/find/find_multi.h \
+-SeqAn-1.4.2/seqan/find/find_multiple_bfam.h \
+-SeqAn-1.4.2/seqan/find/find_multiple_shiftand.h \
+-SeqAn-1.4.2/seqan/find/find_myers_ukkonen.h \
+-SeqAn-1.4.2/seqan/find/find_pattern_base.h \
+-SeqAn-1.4.2/seqan/find/find_pex.h \
+-SeqAn-1.4.2/seqan/find/find_score.h \
+-SeqAn-1.4.2/seqan/find/find_set_horspool.h \
+-SeqAn-1.4.2/seqan/find/find_shiftand.h \
+-SeqAn-1.4.2/seqan/find/find_shiftor.h \
+-SeqAn-1.4.2/seqan/find/find_simple.h \
+-SeqAn-1.4.2/seqan/find/find_wild_shiftand.h \
+-SeqAn-1.4.2/seqan/find/find_wumanber.h \
+-SeqAn-1.4.2/seqan/find.h \
+-SeqAn-1.4.2/seqan/find/INFO \
+-SeqAn-1.4.2/seqan/gff_io/gff_io_base.h \
+-SeqAn-1.4.2/seqan/gff_io/gff_io_context.h \
+-SeqAn-1.4.2/seqan/gff_io/gff_stream.h \
+-SeqAn-1.4.2/seqan/gff_io.h \
+-SeqAn-1.4.2/seqan/gff_io/INFO \
+-SeqAn-1.4.2/seqan/graph_algorithms/graph_algorithm.h \
+-SeqAn-1.4.2/seqan/graph_algorithms/graph_algorithm_heap_tree.h \
+-SeqAn-1.4.2/seqan/graph_algorithms/graph_algorithm_hmm.h \
+-SeqAn-1.4.2/seqan/graph_algorithms/graph_algorithm_lis_his.h \
+-SeqAn-1.4.2/seqan/graph_algorithms.h \
+-SeqAn-1.4.2/seqan/graph_algorithms/INFO \
+-SeqAn-1.4.2/seqan/graph_align/graph_algorithm_refine_aligngraph.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_algorithm_refine_align.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_algorithm_refine_annotation.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_algorithm_refine_exact.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_algorithm_refine_exact_iterative.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_algorithm_refine_fragment.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_algorithm_refine_inexact.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_algorithm_refine_scoring.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_impl_align_adapt.h \
+-SeqAn-1.4.2/seqan/graph_align/graph_impl_align.h \
+-SeqAn-1.4.2/seqan/graph_align.h \
+-SeqAn-1.4.2/seqan/graph_align/INFO \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_base.h \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_distance.h \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_guidetree.h \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_io.h \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_kmer.h \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_library.h \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_msa.h \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_progressive.h \
+-SeqAn-1.4.2/seqan/graph_msa/graph_align_tcoffee_refinement.h \
+-SeqAn-1.4.2/seqan/graph_msa.h \
+-SeqAn-1.4.2/seqan/graph_msa/INFO \
+-SeqAn-1.4.2/seqan/graph_types/graph_base.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_drawing.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_edgestump.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_idmanager.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_automaton.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_directed.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_fragment.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_hmm.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_oracle.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_tree.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_trie.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_undirected.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_impl_wordgraph.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_interface.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_iterator_adjacency.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_iterator_bfs.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_iterator_dfs.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_iterator_edge.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_iterator.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_iterator_outedge.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_iterator_vertex.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_property.h \
+-SeqAn-1.4.2/seqan/graph_types/graph_utility_parsing.h \
+-SeqAn-1.4.2/seqan/graph_types.h \
+-SeqAn-1.4.2/seqan/graph_types/INFO \
+-SeqAn-1.4.2/seqan/index/find_index_approx.h \
+-SeqAn-1.4.2/seqan/index/find_index_esa.h \
+-SeqAn-1.4.2/seqan/index/find_index.h \
+-SeqAn-1.4.2/seqan/index/find_index_qgram.h \
+-SeqAn-1.4.2/seqan/index/find_pigeonhole.h \
+-SeqAn-1.4.2/seqan/index/find_quasar.h \
+-SeqAn-1.4.2/seqan/index/find_swift.h \
+-SeqAn-1.4.2/seqan/index.h \
+-SeqAn-1.4.2/seqan/index/index_base.h \
+-SeqAn-1.4.2/seqan/index/index_bwt.h \
+-SeqAn-1.4.2/seqan/index/index_childtab.h \
+-SeqAn-1.4.2/seqan/index/index_dfi.h \
+-SeqAn-1.4.2/seqan/index/index_esa_algs.h \
+-SeqAn-1.4.2/seqan/index/index_esa_algs_multi.h \
+-SeqAn-1.4.2/seqan/index/index_esa_base.h \
+-SeqAn-1.4.2/seqan/index/index_esa_drawing.h \
+-SeqAn-1.4.2/seqan/index/index_esa_stree.h \
+-SeqAn-1.4.2/seqan/index/index_fm_compressed_sa.h \
+-SeqAn-1.4.2/seqan/index/index_fm_compressed_sa_iterator.h \
+-SeqAn-1.4.2/seqan/index/index_fm_doc.h \
+-SeqAn-1.4.2/seqan/index/index_fm_dox.h \
+-SeqAn-1.4.2/seqan/index/index_fm.h \
+-SeqAn-1.4.2/seqan/index/index_fm_lf_table.h \
+-SeqAn-1.4.2/seqan/index/index_fm_prefix_sum_table.h \
+-SeqAn-1.4.2/seqan/index/index_fm_rank_dictionary_bms.h \
+-SeqAn-1.4.2/seqan/index/index_fm_rank_dictionary_wt.h \
+-SeqAn-1.4.2/seqan/index/index_fm_rank_support_bit_string.h \
+-SeqAn-1.4.2/seqan/index/index_fm_rank_support_bit_string_iterator.h \
+-SeqAn-1.4.2/seqan/index/index_fm_right_array_binary_tree.h \
+-SeqAn-1.4.2/seqan/index/index_fm_right_array_binary_tree_iterator.h \
+-SeqAn-1.4.2/seqan/index/index_fm_sentinel_rank_dictionary.h \
+-SeqAn-1.4.2/seqan/index/index_fm_sparse_string.h \
+-SeqAn-1.4.2/seqan/index/index_fm_stree.h \
+-SeqAn-1.4.2/seqan/index/index_forwards.h \
+-SeqAn-1.4.2/seqan/index/index_lcp.h \
+-SeqAn-1.4.2/seqan/index/index_lcp_tree.h \
+-SeqAn-1.4.2/seqan/index/index_pizzachili_find.h \
+-SeqAn-1.4.2/seqan/index/index_pizzachili.h \
+-SeqAn-1.4.2/seqan/index/index_pizzachili_string.h \
+-SeqAn-1.4.2/seqan/index/index_qgram.h \
+-SeqAn-1.4.2/seqan/index/index_qgram_openaddressing.h \
+-SeqAn-1.4.2/seqan/index/index_sa_btree.h \
+-SeqAn-1.4.2/seqan/index/index_sa_bwtwalk.h \
+-SeqAn-1.4.2/seqan/index/index_sa_lss.h \
+-SeqAn-1.4.2/seqan/index/index_sa_mm.h \
+-SeqAn-1.4.2/seqan/index/index_sa_qsort.h \
+-SeqAn-1.4.2/seqan/index/index_shawarma.h \
+-SeqAn-1.4.2/seqan/index/index_shims.h \
+-SeqAn-1.4.2/seqan/index/index_skew3.h \
+-SeqAn-1.4.2/seqan/index/index_skew7.h \
+-SeqAn-1.4.2/seqan/index/index_skew7_multi.h \
+-SeqAn-1.4.2/seqan/index/index_wotd.h \
+-SeqAn-1.4.2/seqan/index/INFO \
+-SeqAn-1.4.2/seqan/index/pipe_merger3.h \
+-SeqAn-1.4.2/seqan/index/pipe_merger7.h \
+-SeqAn-1.4.2/seqan/index/pizzachili_api.h \
+-SeqAn-1.4.2/seqan/index/pump_extender3.h \
+-SeqAn-1.4.2/seqan/index/pump_extender7.h \
+-SeqAn-1.4.2/seqan/index/pump_lcp_core.h \
+-SeqAn-1.4.2/seqan/index/pump_separator7.h \
+-SeqAn-1.4.2/seqan/index/radix.h \
+-SeqAn-1.4.2/seqan/index/repeat_base.h \
+-SeqAn-1.4.2/seqan/index/shape_base.h \
+-SeqAn-1.4.2/seqan/index/shape_gapped.h \
+-SeqAn-1.4.2/seqan/index/shape_onegapped.h \
+-SeqAn-1.4.2/seqan/index/shape_predefined.h \
+-SeqAn-1.4.2/seqan/index/shape_threshold.h \
+-SeqAn-1.4.2/seqan/LICENSE \
+-SeqAn-1.4.2/seqan/map.h \
+-SeqAn-1.4.2/seqan/map/INFO \
+-SeqAn-1.4.2/seqan/map/map_adapter_stl.h \
+-SeqAn-1.4.2/seqan/map/map_base.h \
+-SeqAn-1.4.2/seqan/map/map_chooser.h \
+-SeqAn-1.4.2/seqan/map/map_skiplist.h \
+-SeqAn-1.4.2/seqan/map/map_vector.h \
+-SeqAn-1.4.2/seqan/map/sumlist.h \
+-SeqAn-1.4.2/seqan/map/sumlist_mini.h \
+-SeqAn-1.4.2/seqan/map/sumlist_skip.h \
+-SeqAn-1.4.2/seqan/misc/cmdparser/cmdoption.h \
+-SeqAn-1.4.2/seqan/misc/cmdparser/cmdparser_ctd_support.h \
+-SeqAn-1.4.2/seqan/misc/cmdparser/cmdparser.h \
+-SeqAn-1.4.2/seqan/misc/cmdparser/cmdparser_parse.h \
+-SeqAn-1.4.2/seqan/misc/cmdparser/cmdparser_type_support.h \
+-SeqAn-1.4.2/seqan/misc/cmdparser/INFO \
+-SeqAn-1.4.2/seqan/misc/edit_environment.h \
+-SeqAn-1.4.2/seqan/misc/INFO \
+-SeqAn-1.4.2/seqan/misc/misc_accumulators.h \
+-SeqAn-1.4.2/seqan/misc/misc_base.h \
+-SeqAn-1.4.2/seqan/misc/misc_bit_twiddling.h \
+-SeqAn-1.4.2/seqan/misc/misc_cmdparser.h \
+-SeqAn-1.4.2/seqan/misc/misc_dequeue.h \
+-SeqAn-1.4.2/seqan/misc/misc_interval_tree.h \
+-SeqAn-1.4.2/seqan/misc/misc_map.h \
+-SeqAn-1.4.2/seqan/misc/misc_memset.h \
+-SeqAn-1.4.2/seqan/misc/misc_name_store_cache.h \
+-SeqAn-1.4.2/seqan/misc/misc_parsing.h \
+-SeqAn-1.4.2/seqan/misc/misc_set.h \
+-SeqAn-1.4.2/seqan/misc/misc_sse2.h \
+-SeqAn-1.4.2/seqan/misc/misc_svg.h \
+-SeqAn-1.4.2/seqan/misc/misc_terminal.h \
+-SeqAn-1.4.2/seqan/misc/misc_union_find.h \
+-SeqAn-1.4.2/seqan/misc/priority_type_base.h \
+-SeqAn-1.4.2/seqan/misc/priority_type_heap.h \
+-SeqAn-1.4.2/seqan/modifier.h \
+-SeqAn-1.4.2/seqan/modifier/INFO \
+-SeqAn-1.4.2/seqan/modifier/modifier_alphabet_expansion.h \
+-SeqAn-1.4.2/seqan/modifier/modifier_alphabet.h \
+-SeqAn-1.4.2/seqan/modifier/modifier_functors.h \
+-SeqAn-1.4.2/seqan/modifier/modifier_iterator.h \
+-SeqAn-1.4.2/seqan/modifier/modifier_reverse.h \
+-SeqAn-1.4.2/seqan/modifier/modifier_shortcuts.h \
+-SeqAn-1.4.2/seqan/modifier/modifier_string.h \
+-SeqAn-1.4.2/seqan/modifier/modifier_view.h \
+-SeqAn-1.4.2/seqan/parallel.h \
+-SeqAn-1.4.2/seqan/parallel/INFO \
+-SeqAn-1.4.2/seqan/parallel/parallel_algorithms.h \
+-SeqAn-1.4.2/seqan/parallel/parallel_atomic_misc.h \
+-SeqAn-1.4.2/seqan/parallel/parallel_atomic_primitives.h \
+-SeqAn-1.4.2/seqan/parallel/parallel_macros.h \
+-SeqAn-1.4.2/seqan/parallel/parallel_splitting.h \
+-SeqAn-1.4.2/seqan/parallel/parallel_tags.h \
+-SeqAn-1.4.2/seqan/pipe.h \
+-SeqAn-1.4.2/seqan/pipe/INFO \
+-SeqAn-1.4.2/seqan/pipe/pipe_base.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_caster.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_counter.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_echoer.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_edit_environment.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_filter.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_iterator.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_joiner.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_namer.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_sampler.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_shifter.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_source.h \
+-SeqAn-1.4.2/seqan/pipe/pipe_tupler.h \
+-SeqAn-1.4.2/seqan/pipe/pool_base.h \
+-SeqAn-1.4.2/seqan/pipe/pool_mapper.h \
+-SeqAn-1.4.2/seqan/pipe/pool_sorter.h \
+-SeqAn-1.4.2/seqan/platform.h \
+-SeqAn-1.4.2/seqan/platform/INFO \
+-SeqAn-1.4.2/seqan/platform/platform_gcc.h \
+-SeqAn-1.4.2/seqan/platform/platform_icc.h \
+-SeqAn-1.4.2/seqan/platform/platform_mingw.h \
+-SeqAn-1.4.2/seqan/platform/platform_nvcc.h \
+-SeqAn-1.4.2/seqan/platform/platform_pgi.h \
+-SeqAn-1.4.2/seqan/platform/platform_solaris.h \
+-SeqAn-1.4.2/seqan/platform/platform_windows.h \
+-SeqAn-1.4.2/seqan/platform/windows_stdint.h \
+-SeqAn-1.4.2/seqan/random/ext_MersenneTwister.h \
+-SeqAn-1.4.2/seqan/random.h \
+-SeqAn-1.4.2/seqan/random/INFO \
+-SeqAn-1.4.2/seqan/random/random_base.h \
+-SeqAn-1.4.2/seqan/random/random_beta.h \
+-SeqAn-1.4.2/seqan/random/random_beta_kfunc.h \
+-SeqAn-1.4.2/seqan/random/random_geometric.h \
+-SeqAn-1.4.2/seqan/random/random_lognormal.h \
+-SeqAn-1.4.2/seqan/random/random_mt19937.h \
+-SeqAn-1.4.2/seqan/random/random_normal.h \
+-SeqAn-1.4.2/seqan/random/random_rng_functor.h \
+-SeqAn-1.4.2/seqan/random/random_shuffle.h \
+-SeqAn-1.4.2/seqan/random/random_uniform.h \
+-SeqAn-1.4.2/seqan/score.h \
+-SeqAn-1.4.2/seqan/score/INFO \
+-SeqAn-1.4.2/seqan/score/score_base.h \
+-SeqAn-1.4.2/seqan/score/score_edit.h \
+-SeqAn-1.4.2/seqan/score/score_matrix_data.h \
+-SeqAn-1.4.2/seqan/score/score_matrix.h \
+-SeqAn-1.4.2/seqan/score/score_matrix_io.h \
+-SeqAn-1.4.2/seqan/score/score_simple.h \
+-SeqAn-1.4.2/seqan/seeds/banded_chain_alignment.h \
+-SeqAn-1.4.2/seqan/seeds/banded_chain_alignment_impl.h \
+-SeqAn-1.4.2/seqan/seeds/banded_chain_alignment_profile.h \
+-SeqAn-1.4.2/seqan/seeds/banded_chain_alignment_scout.h \
+-SeqAn-1.4.2/seqan/seeds/banded_chain_alignment_traceback.h \
+-SeqAn-1.4.2/seqan/seeds/basic_iter_indirect.h \
+-SeqAn-1.4.2/seqan/seeds.h \
+-SeqAn-1.4.2/seqan/seeds/INFO \
+-SeqAn-1.4.2/seqan/seeds/seeds_base.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_combination.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_extension.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_global_chaining_base.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_global_chaining_gusfield.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_global_chaining.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_seed_base.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_seed_chained.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_seed_diagonal.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_seed_set_base.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_seed_set_non_scored.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_seed_set_scored.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_seed_set_unordered.h \
+-SeqAn-1.4.2/seqan/seeds/seeds_seed_simple.h \
+-SeqAn-1.4.2/seqan/seq_io/fai_index.h \
+-SeqAn-1.4.2/seqan/seq_io/genomic_region.h \
+-SeqAn-1.4.2/seqan/seq_io/guess_stream_format.h \
+-SeqAn-1.4.2/seqan/seq_io.h \
+-SeqAn-1.4.2/seqan/seq_io/INFO \
+-SeqAn-1.4.2/seqan/seq_io/read_embl.h \
+-SeqAn-1.4.2/seqan/seq_io/read_fasta_fastq.h \
+-SeqAn-1.4.2/seqan/seq_io/read_genbank.h \
+-SeqAn-1.4.2/seqan/seq_io/sequence_stream.h \
+-SeqAn-1.4.2/seqan/seq_io/sequence_stream_impl.h \
+-SeqAn-1.4.2/seqan/seq_io/simple_read_fasta.h \
+-SeqAn-1.4.2/seqan/seq_io/write_fasta_fastq.h \
+-SeqAn-1.4.2/seqan/sequence/adapt_array_pointer.h \
+-SeqAn-1.4.2/seqan/sequence/adapt_std_list.h \
+-SeqAn-1.4.2/seqan/sequence/adapt_std_string.h \
+-SeqAn-1.4.2/seqan/sequence/adapt_std_vector.h \
+-SeqAn-1.4.2/seqan/sequence.h \
+-SeqAn-1.4.2/seqan/sequence/INFO \
+-SeqAn-1.4.2/seqan/sequence/iter_concat_virtual.h \
+-SeqAn-1.4.2/seqan/sequence_journaled.h \
+-SeqAn-1.4.2/seqan/sequence_journaled/INFO \
+-SeqAn-1.4.2/seqan/sequence_journaled/journal_entries_sorted_array.h \
+-SeqAn-1.4.2/seqan/sequence_journaled/journal_entries_unbalanced_tree.h \
+-SeqAn-1.4.2/seqan/sequence_journaled/journal_entries_unbalanced_tree_iterator.h \
+-SeqAn-1.4.2/seqan/sequence_journaled/journal_entries_unbalanced_tree_node.h \
+-SeqAn-1.4.2/seqan/sequence_journaled/journal_entry.h \
+-SeqAn-1.4.2/seqan/sequence_journaled/sequence_journaled.h \
+-SeqAn-1.4.2/seqan/sequence_journaled/sequence_journaled_iterator.h \
+-SeqAn-1.4.2/seqan/sequence/segment_base.h \
+-SeqAn-1.4.2/seqan/sequence/segment_infix.h \
+-SeqAn-1.4.2/seqan/sequence/segment_prefix.h \
+-SeqAn-1.4.2/seqan/sequence/segment_suffix.h \
+-SeqAn-1.4.2/seqan/sequence/segment_utils.h \
+-SeqAn-1.4.2/seqan/sequence/sequence_concatenator.h \
+-SeqAn-1.4.2/seqan/sequence/sequence_forwards.h \
+-SeqAn-1.4.2/seqan/sequence/sequence_interface.h \
+-SeqAn-1.4.2/seqan/sequence/sequence_lexical.h \
+-SeqAn-1.4.2/seqan/sequence/sequence_shortcuts.h \
+-SeqAn-1.4.2/seqan/sequence/string_alloc.h \
+-SeqAn-1.4.2/seqan/sequence/string_array.h \
+-SeqAn-1.4.2/seqan/sequence/string_base.h \
+-SeqAn-1.4.2/seqan/sequence/string_block.h \
+-SeqAn-1.4.2/seqan/sequence/string_cstyle.h \
+-SeqAn-1.4.2/seqan/sequence/string_packed.h \
+-SeqAn-1.4.2/seqan/sequence/string_packed_old.h \
+-SeqAn-1.4.2/seqan/sequence/string_set_base.h \
+-SeqAn-1.4.2/seqan/sequence/string_set_concat_direct.h \
+-SeqAn-1.4.2/seqan/sequence/string_set_dependent_generous.h \
+-SeqAn-1.4.2/seqan/sequence/string_set_dependent_tight.h \
+-SeqAn-1.4.2/seqan/sequence/string_set_owner.h \
+-SeqAn-1.4.2/seqan/store.h \
+-SeqAn-1.4.2/seqan/store/INFO \
+-SeqAn-1.4.2/seqan/store/store_align.h \
+-SeqAn-1.4.2/seqan/store/store_align_intervals.h \
+-SeqAn-1.4.2/seqan/store/store_all.h \
+-SeqAn-1.4.2/seqan/store/store_annotation.h \
+-SeqAn-1.4.2/seqan/store/store_base.h \
+-SeqAn-1.4.2/seqan/store/store_contig.h \
+-SeqAn-1.4.2/seqan/store/store_intervaltree.h \
+-SeqAn-1.4.2/seqan/store/store_io_gff.h \
+-SeqAn-1.4.2/seqan/store/store_io.h \
+-SeqAn-1.4.2/seqan/store/store_io_sam.h \
+-SeqAn-1.4.2/seqan/store/store_io_ucsc.h \
+-SeqAn-1.4.2/seqan/store/store_library.h \
+-SeqAn-1.4.2/seqan/store/store_matepair.h \
+-SeqAn-1.4.2/seqan/store/store_read.h \
+-SeqAn-1.4.2/seqan/stream/adapt_cstdio.h \
+-SeqAn-1.4.2/seqan/stream/adapt_fstream.h \
+-SeqAn-1.4.2/seqan/stream/adapt_iostream.h \
+-SeqAn-1.4.2/seqan/stream/adapt_mmap.h \
+-SeqAn-1.4.2/seqan/stream/adapt_sstream.h \
+-SeqAn-1.4.2/seqan/stream/concept_stream.h \
+-SeqAn-1.4.2/seqan/stream/file_stream.h \
+-SeqAn-1.4.2/seqan/stream.h \
+-SeqAn-1.4.2/seqan/stream/INFO \
+-SeqAn-1.4.2/seqan/stream/is.h \
+-SeqAn-1.4.2/seqan/stream/lexical_cast.h \
+-SeqAn-1.4.2/seqan/stream/read_auto_format.h \
+-SeqAn-1.4.2/seqan/stream/read.h \
+-SeqAn-1.4.2/seqan/stream/read_sam.h \
+-SeqAn-1.4.2/seqan/stream/record_reader_base.h \
+-SeqAn-1.4.2/seqan/stream/record_reader_double.h \
+-SeqAn-1.4.2/seqan/stream/record_reader_double_mmap.h \
+-SeqAn-1.4.2/seqan/stream/record_reader_single.h \
+-SeqAn-1.4.2/seqan/stream/record_reader_single_mmap.h \
+-SeqAn-1.4.2/seqan/stream/stream_base.h \
+-SeqAn-1.4.2/seqan/stream/stream_bgzf.h \
+-SeqAn-1.4.2/seqan/stream/stream_bz2_file.h \
+-SeqAn-1.4.2/seqan/stream/stream_char_array.h \
+-SeqAn-1.4.2/seqan/stream/stream_gz_file.h \
+-SeqAn-1.4.2/seqan/stream/stream_put.h \
+-SeqAn-1.4.2/seqan/stream/tokenize.h \
+-SeqAn-1.4.2/seqan/stream/write.h \
+-SeqAn-1.4.2/seqan/system/file_async.h \
+-SeqAn-1.4.2/seqan/system/file_directory.h \
+-SeqAn-1.4.2/seqan/system/file_forwards.h \
+-SeqAn-1.4.2/seqan/system/file_sync.h \
+-SeqAn-1.4.2/seqan/system.h \
+-SeqAn-1.4.2/seqan/system/INFO \
+-SeqAn-1.4.2/seqan/system/system_base.h \
+-SeqAn-1.4.2/seqan/system/system_event.h \
+-SeqAn-1.4.2/seqan/system/system_forwards.h \
+-SeqAn-1.4.2/seqan/system/system_mutex.h \
+-SeqAn-1.4.2/seqan/system/system_sema.h \
+-SeqAn-1.4.2/seqan/system/system_thread.h \
+-SeqAn-1.4.2/seqan/version.h
++tophat2.sh
+ 
+ BAM_LIB = -lbam-0.1-legacy
+ AM_CPPFLAGS = -I/usr/include/bam-0.1-legacy/
+@@ -789,52 +114,49 @@
+ #-- program sources
+ 
+ prep_reads_SOURCES = prep_reads.cpp
+-prep_reads_LDADD = $(top_builddir)/src/libtophat.a $(BAM_LIB)
++prep_reads_LDADD = libtophat.a $(BAM_LIB)
+ prep_reads_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS) 
+ 
+ segment_juncs_SOURCES = segment_juncs.cpp
+-segment_juncs_LDADD = $(top_builddir)/src/libtophat.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
++segment_juncs_LDADD = libtophat.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
+ segment_juncs_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS) $(BOOST_LDFLAGS)
+ 
+ long_spanning_reads_SOURCES = long_spanning_reads.cpp
+-long_spanning_reads_LDADD = $(top_builddir)/src/libtophat.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
++long_spanning_reads_LDADD = libtophat.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
+ long_spanning_reads_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS) $(BOOST_LDFLAGS)
+ 
+ gtf_juncs_SOURCES = gtf_juncs.cpp
+-gtf_juncs_LDADD = $(top_builddir)/src/libtophat.a libgc.a $(BAM_LIB)
++gtf_juncs_LDADD = libtophat.a libgc.a $(BAM_LIB)
+ gtf_juncs_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
+ 
+ juncs_db_SOURCES = juncs_db.cpp
+-juncs_db_LDADD = $(top_builddir)/src/libtophat.a $(BAM_LIB)
++juncs_db_LDADD = libtophat.a $(BAM_LIB)
+ juncs_db_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
+ 
+ tophat_reports_SOURCES = tophat_reports.cpp
+-tophat_reports_LDADD = $(top_builddir)/src/libtophat.a  $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
++tophat_reports_LDADD = libtophat.a  $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
+ tophat_reports_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS) $(BOOST_LDFLAGS)
+ 
+ fix_map_ordering_SOURCES = fix_map_ordering.cpp
+-fix_map_ordering_LDADD = $(top_builddir)/src/libtophat.a $(BAM_LIB)
++fix_map_ordering_LDADD = libtophat.a $(BAM_LIB)
+ fix_map_ordering_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
+ 
+ bam2fastx_SOURCES = bam2fastx.cpp
+-bam2fastx_LDADD = $(top_builddir)/src/libgc.a $(BAM_LIB)
++bam2fastx_LDADD = libgc.a $(BAM_LIB)
+ bam2fastx_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
+ 
+ bam_merge_SOURCES = bam_merge.cpp
+-bam_merge_LDADD = $(top_builddir)/src/libtophat.a $(top_builddir)/src/libgc.a $(BAM_LIB)
++bam_merge_LDADD = libtophat.a libgc.a $(BAM_LIB)
+ bam_merge_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
+ 
+ sam_juncs_SOURCES = sam_juncs.cpp
+-sam_juncs_LDADD = $(top_builddir)/src/libtophat.a $(BAM_LIB)
++sam_juncs_LDADD = libtophat.a $(BAM_LIB)
+ sam_juncs_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
+ 
+ map2gtf_SOURCES = map2gtf.cpp
+-map2gtf_LDADD = $(top_builddir)/src/libtophat.a libgc.a $(BAM_LIB)
++map2gtf_LDADD = libtophat.a libgc.a $(BAM_LIB)
+ map2gtf_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
+ 
+ gtf_to_fasta_SOURCES = GTFToFasta.cpp FastaTools.cpp
+-gtf_to_fasta_LDADD = $(top_builddir)/src/libtophat.a libgc.a $(BAM_LIB)
++gtf_to_fasta_LDADD = libtophat.a libgc.a $(BAM_LIB)
+ gtf_to_fasta_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
+-
+-install-data-hook:
+-	cp -r intervaltree sortedcontainers $(DESTDIR)$(bindir)


### PR DESCRIPTION
I hit file collision on these files:

 * sci-biology/tophat-2.1.1-r3:0::gentoo
 *      /usr/lib64/python2.7/site-packages/sortedcontainers/__init__.py
 *      /usr/lib64/python2.7/site-packages/sortedcontainers/sorteddict.py
 *      /usr/lib64/python2.7/site-packages/sortedcontainers/sortedlist.py
 *      /usr/lib64/python2.7/site-packages/sortedcontainers/sortedset.py

Likewise, there is dev-python/intervaltree in portage tree.

Remove bundled code and rely on portage.

The sed hackery was lengthy so I made a patch file and deleted the corresponding
lines.