### PR TITLE
Fixed efl configure options

### DIFF
--- a/dev-libs/efl/efl-1.18.4-r1.ebuild
+++ b/dev-libs/efl/efl-1.18.4-r1.ebuild
@@ -1,0 +1,293 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="5"
+
+MY_P=${P/_/-}
+
+if [[ "${PV}" == "9999" ]] ; then
+	EGIT_SUB_PROJECT="core"
+	EGIT_URI_APPEND="${PN}"
+elif [[ *"${PV}" == *"_pre"* ]] ; then
+	MY_P=${P%%_*}
+	SRC_URI="https://download.enlightenment.org/pre-releases/${MY_P}.tar.xz"
+else
+	SRC_URI="https://download.enlightenment.org/rel/libs/${PN}/${MY_P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x64-solaris ~x86-solaris"
+fi
+
+inherit enlightenment pax-utils
+
+DESCRIPTION="Enlightenment Foundation Libraries all-in-one package"
+
+LICENSE="BSD-2 GPL-2 LGPL-2.1 ZLIB"
+IUSE="+bmp debug drm +eet egl elput fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz +ico ibus jpeg2k libressl neon oldlua opengl ssl physics pixman +png postscript +ppm +psd pulseaudio raw scim sdl sound systemd tga tiff tslib unwind v4l valgrind wayland webp X xim xine xpm"
+
+REQUIRED_USE="
+	pulseaudio?	( sound )
+	drm?		( elput )
+	opengl?		( || ( X sdl wayland ) )
+	gles?		( || ( X wayland ) )
+	gles?		( !sdl )
+	gles?		( egl )
+	sdl?		( opengl )
+	wayland?	( egl !opengl gles )
+	xim?		( X )
+"
+
+RDEPEND="
+	elput? ( >=dev-libs/libinput-0.6.0 )
+	drm? (
+		media-libs/mesa[gbm]
+		>=x11-libs/libdrm-2.4
+		>=x11-libs/libxkbcommon-0.3.0
+	)
+	fontconfig? ( media-libs/fontconfig )
+	fribidi? ( dev-libs/fribidi )
+	gif? ( media-libs/giflib )
+	glib? ( dev-libs/glib:2 )
+	gnutls? ( net-libs/gnutls )
+	!gnutls? (
+		ssl? (
+			!libressl? ( dev-libs/openssl:0= )
+			libressl? ( dev-libs/libressl )
+		)
+	)
+	gstreamer? (
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+	)
+	harfbuzz? ( media-libs/harfbuzz )
+	ibus? ( app-i18n/ibus )
+	jpeg2k? ( media-libs/openjpeg:0 )
+	!oldlua? ( >=dev-lang/luajit-2.0.0 )
+	oldlua? ( dev-lang/lua:* )
+	physics? ( >=sci-physics/bullet-2.80 )
+	pixman? ( x11-libs/pixman )
+	postscript? ( app-text/libspectre )
+	png? ( media-libs/libpng:0= )
+	pulseaudio? ( media-sound/pulseaudio )
+	raw? ( media-libs/libraw )
+	scim? ( app-i18n/scim )
+	sdl? (
+		media-libs/libsdl2
+		virtual/opengl
+	)
+	sound? ( media-libs/libsndfile )
+	systemd? ( sys-apps/systemd )
+	tiff? ( media-libs/tiff:0= )
+	tslib? ( x11-libs/tslib )
+	unwind? ( sys-libs/libunwind )
+	valgrind? ( dev-util/valgrind )
+	wayland? (
+		>=dev-libs/wayland-1.8.0
+		>=x11-libs/libxkbcommon-0.3.1
+		media-libs/mesa[gles2,wayland]
+	)
+	webp? ( media-libs/libwebp )
+	X? (
+		x11-libs/libXcursor
+		x11-libs/libX11
+		x11-libs/libXcomposite
+		x11-libs/libXdamage
+		x11-libs/libXext
+		x11-libs/libXfixes
+		x11-libs/libXinerama
+		x11-libs/libXp
+		x11-libs/libXrandr
+		x11-libs/libXrender
+		x11-libs/libXtst
+		x11-libs/libXScrnSaver
+
+		opengl? (
+			x11-libs/libX11
+			x11-libs/libXrender
+			virtual/opengl
+		)
+
+		gles? (
+			x11-libs/libX11
+			x11-libs/libXrender
+			virtual/opengl
+		)
+	)
+	xine? ( >=media-libs/xine-lib-1.1.1 )
+	xpm? ( x11-libs/libXpm )
+
+	sys-apps/dbus
+	>=sys-apps/util-linux-2.20.0
+	app-text/poppler[cxx]
+	gnome-base/librsvg
+	sys-libs/zlib
+	virtual/jpeg:0=
+
+	!dev-libs/ecore
+	!dev-libs/edbus
+	!dev-libs/eet
+	!dev-libs/eeze
+	!dev-libs/efreet
+	!dev-libs/eina
+	!dev-libs/eio
+	!dev-libs/embryo
+	!dev-libs/eobj
+	!dev-libs/ephysics
+	!media-libs/edje
+	!media-libs/elementary
+	!media-libs/emotion
+	!media-libs/ethumb
+	!media-libs/evas
+	!media-plugins/emotion_generic_players
+	!media-plugins/evas_generic_loaders
+"
+#external lz4 support currently broken because of unstable ABI/API
+#	app-arch/lz4
+
+#soft blockers added above for binpkg users
+#hard blocks are needed for building
+CORE_EFL_CONFLICTS="
+	!!dev-libs/ecore
+	!!dev-libs/edbus
+	!!dev-libs/eet
+	!!dev-libs/eeze
+	!!dev-libs/efreet
+	!!dev-libs/eina
+	!!dev-libs/eio
+	!!dev-libs/embryo
+	!!dev-libs/eobj
+	!!dev-libs/ephysics
+	!!media-libs/edje
+	!!media-libs/emotion
+	!!media-libs/ethumb
+	!!media-libs/evas
+"
+
+DEPEND="
+	${CORE_EFL_CONFLICTS}
+
+	${RDEPEND}
+	doc? ( app-doc/doxygen )
+"
+
+S=${WORKDIR}/${MY_P}
+
+src_prepare() {
+	enlightenment_src_prepare
+
+	# Remove stupid sleep command.
+	# Also back out gnu make hack that causes regen of Makefiles.
+	# Delete var setting that causes the build to abort.
+	sed -i \
+		-e '/sleep 10/d' \
+		-e '/^#### Work around bug in automake check macro$/,/^#### Info$/d' \
+		-e '/BARF_OK=/s:=.*:=:' \
+		configure || die
+
+	# Upstream doesn't offer a configure flag. #611108
+	if ! use unwind ; then
+		sed -i \
+			-e 's:libunwind libunwind-generic:xxxxxxxxxxxxxxxx:' \
+			configure || die
+	fi
+}
+
+src_configure() {
+	if use ssl && use gnutls ; then
+		einfo "You enabled both USE=ssl and USE=gnutls, but only one can be used;"
+		einfo "gnutls has been selected for you."
+	fi
+	if use opengl && use gles ; then
+		einfo "You enabled both USE=opengl and USE=gles, but only one can be used;"
+		einfo "opengl has been selected for you."
+	fi
+
+	E_ECONF=(
+		--with-profile=$(usex debug debug release)
+		--with-crypto=$(usex gnutls gnutls $(usex ssl openssl none))
+		--with-x11=$(usex X xlib none)
+		$(use_with X x)
+		--with-opengl=$(usex opengl full $(usex gles es none))
+		--with-glib=$(usex glib)
+		--enable-i-really-know-what-i-am-doing-and-that-this-will-probably-break-things-and-i-will-fix-them-myself-and-send-patches-abb
+
+		$(use_enable bmp image-loader-bmp)
+		$(use_enable bmp image-loader-wbmp)
+		$(use_enable drm)
+		$(use_enable doc)
+		$(use_enable eet image-loader-eet)
+		$(use_enable egl)
+		$(use_enable elput)
+		$(use_enable fbcon fb)
+		$(use_enable fontconfig)
+		$(use_enable fribidi)
+		$(use_enable gif image-loader-gif)
+		$(use_enable gstreamer gstreamer1)
+		$(use_enable harfbuzz)
+		$(use_enable ico image-loader-ico)
+		$(use_enable ibus)
+		$(use_enable jpeg2k image-loader-jp2k)
+		$(use_enable neon)
+		$(use_enable nls)
+		$(use_enable oldlua lua-old)
+		$(use_enable physics)
+		$(use_enable pixman)
+		$(use_enable pixman pixman-font)
+		$(use_enable pixman pixman-rect)
+		$(use_enable pixman pixman-line)
+		$(use_enable pixman pixman-poly)
+		$(use_enable pixman pixman-image)
+		$(use_enable pixman pixman-image-scale-sample)
+		$(use_enable png image-loader-png)
+		$(use_enable postscript spectre)
+		$(use_enable ppm image-loader-pmaps)
+		$(use_enable psd image-loader-psd)
+		$(use_enable pulseaudio)
+		$(use_enable raw libraw)
+		$(use_enable scim)
+		$(use_enable sdl)
+		$(use_enable sound audio)
+		$(use_enable systemd)
+		$(use_enable tga image-loader-tga)
+		$(use_enable tiff image-loader-tiff)
+		$(use_enable tslib)
+		$(use_enable v4l v4l2)
+		$(use_enable valgrind)
+		$(use_enable wayland)
+		$(use_enable webp image-loader-webp)
+		$(use_enable xim)
+		$(use_enable xine)
+		$(use_enable xpm image-loader-xpm)
+		--enable-cserve
+		--enable-image-loader-generic
+		--enable-image-loader-jpeg
+
+		--disable-tizen
+		--disable-gesture
+		--disable-gstreamer
+		--enable-xinput2
+		--disable-xinput22
+		--enable-libmount
+
+		# external lz4 support currently broken because of unstable ABI/API
+		#--enable-liblz4
+	)
+
+	enlightenment_src_configure
+}
+
+src_compile() {
+	if host-is-pax && ! use oldlua ; then
+		# We need to build the lua code first so we can pax-mark it. #547076
+		local target='_e_built_sources_target_gogogo_'
+		printf '%s: $(BUILT_SOURCES)\n' "${target}" >> src/Makefile || die
+		emake -C src "${target}"
+		emake -C src bin/elua/elua
+		pax-mark m src/bin/elua/.libs/elua
+	fi
+	enlightenment_src_compile
+}
+
+src_install() {
+	MAKEOPTS+=" -j1"
+
+	enlightenment_src_install
+}

--- a/dev-libs/efl/metadata.xml
+++ b/dev-libs/efl/metadata.xml
@@ -10,6 +10,7 @@
 	<flag name="drm">Enable DRM engine</flag>
 	<flag name="eet">Enable Eet image loader</flag>
 	<flag name="egl">Enable EGL rendering</flag>
+	<flag name="elput">Enable internal generic input library</flag>
 	<flag name="fribidi">Enable bidirectional text support</flag>
 	<flag name="gles">Enable the OpenGL ES GL implementation</flag>
 	<flag name="glib">Enable <pkg>dev-libs/glib</pkg> support</flag>


### PR DESCRIPTION
When setting the `drm` use flag on efl 1.18.4, configure stage fails because the `--enable-drm` option now requires the `--enable-elput` new option.

This pull request adds this new option and sets up a new flag, `elput`, required by the use flag `drm`.

In addition, it fixes dependencies, adding `app-text/poppler[cxx]` as a requirement, makes the `dev-libs/libinput` requirement depending on the `elput` flag, and lower the minimum version to 0.6 as stated in the efl README file.

I'll provide a `diff` of `efl-1.18.4.ebuild` and `efl-1.18.4-r1.ebuild` to see the "real" differences, as well as a build log made from a stage3 archive.