### PR TITLE
dev-qt/qtcore: v4.8 patch for libressl building

### DIFF
--- a/dev-qt/qtcore/files/qtcore-4.8.5-libressl.patch
+++ b/dev-qt/qtcore/files/qtcore-4.8.5-libressl.patch
@@ -1,0 +1,52 @@
+--- src/network/ssl/qsslsocket_openssl_symbols.cpp.orig	2015-11-25 01:38:42.103898399 -0500
++++ src/network/ssl/qsslsocket_openssl_symbols.cpp	2015-11-25 01:40:50.146247648 -0500
+@@ -224,13 +224,17 @@
+ #ifndef OPENSSL_NO_SSL2
+ DEFINEFUNC(const SSL_METHOD *, SSLv2_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ #endif
++#ifndef OPENSSL_NO_SSL3
+ DEFINEFUNC(const SSL_METHOD *, SSLv3_client_method, DUMMYARG, DUMMYARG, return 0, return)
++#endif
+ DEFINEFUNC(const SSL_METHOD *, SSLv23_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ DEFINEFUNC(const SSL_METHOD *, TLSv1_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ #ifndef OPENSSL_NO_SSL2
+ DEFINEFUNC(const SSL_METHOD *, SSLv2_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ #endif
++#ifndef OPENSSL_NO_SSL3
+ DEFINEFUNC(const SSL_METHOD *, SSLv3_server_method, DUMMYARG, DUMMYARG, return 0, return)
++#endif
+ DEFINEFUNC(const SSL_METHOD *, SSLv23_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ DEFINEFUNC(const SSL_METHOD *, TLSv1_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ #else
+@@ -818,13 +822,17 @@
+ #ifndef OPENSSL_NO_SSL2
+     RESOLVEFUNC(SSLv2_client_method)
+ #endif
++#ifndef OPENSSL_NO_SSL3
+     RESOLVEFUNC(SSLv3_client_method)
++#endif
+     RESOLVEFUNC(SSLv23_client_method)
+     RESOLVEFUNC(TLSv1_client_method)
+ #ifndef OPENSSL_NO_SSL2
+     RESOLVEFUNC(SSLv2_server_method)
+ #endif
++#ifndef OPENSSL_NO_SSL3
+     RESOLVEFUNC(SSLv3_server_method)
++#endif
+     RESOLVEFUNC(SSLv23_server_method)
+     RESOLVEFUNC(TLSv1_server_method)
+     RESOLVEFUNC(X509_NAME_entry_count)
+--- src/network/ssl/qsslsocket_openssl.cpp.orig	2015-11-25 01:44:55.235087906 -0500
++++ src/network/ssl/qsslsocket_openssl.cpp	2015-11-25 01:45:45.194443818 -0500
+@@ -263,7 +263,11 @@
+ #endif
+         break;
+     case QSsl::SslV3:
++#ifndef OPENSSL_NO_SSL3
+         ctx = q_SSL_CTX_new(client ? q_SSLv3_client_method() : q_SSLv3_server_method());
++#else
++        ctx = 0; // SSL 3 not supported by the system, but chosen deliberately -> error
++#endif
+         break;
+     case QSsl::SecureProtocols: // SslV2 will be disabled below
+     case QSsl::TlsV1SslV3: // SslV2 will be disabled below

--- a/dev-qt/qtcore/qtcore-4.8.7-r2.ebuild
+++ b/dev-qt/qtcore/qtcore-4.8.7-r2.ebuild
@@ -36,6 +36,7 @@ MULTILIB_WRAPPED_HEADERS=(
 PATCHES=(
 	"${FILESDIR}/${PN}-4.8.5-honor-ExcludeSocketNotifiers-in-glib-event-loop.patch" # bug 514968
 	"${FILESDIR}/${PN}-4.8.5-qeventdispatcher-recursive.patch" # bug 514968
+	"${FILESDIR}/${PN}-4.8.5-libressl.patch"
 	"${FILESDIR}/${PN}-4.8.6-moc-boost-1.60.patch" # bug 556104
 )
 


### PR DESCRIPTION
despite what v4 will go, it will still live with the new libressl
for sometime, make it building at least a non-blocking option.

credit to Andreas K. Hüttel <dilfridge@gentoo.org> from Bug: 436490

qtcore has USE libressl but can not build with it, now we fix it.