### PR TITLE
media-sound/pms: drop dependency on glib

### DIFF
--- a/media-sound/pms/pms-9999.ebuild
+++ b/media-sound/pms/pms-9999.ebuild
@@ -16,7 +16,6 @@ IUSE="+regex doc"
 
 RDEPEND="
 	sys-libs/ncurses:0=[unicode]
-	dev-libs/glib:2
 	media-libs/libmpdclient
 "
 DEPEND="


### PR DESCRIPTION
As according to https://github.com/ambientsound/pms/pull/43