### PR TITLE
dev-db/sqliteman: Fix building with qscintilla-2.10

### DIFF
--- a/dev-db/sqliteman/files/sqliteman-1.2.2-qscintilla-2.10.patch
+++ b/dev-db/sqliteman/files/sqliteman-1.2.2-qscintilla-2.10.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/modules/FindQScintilla.cmake b/cmake/modules/FindQScintilla.cmake
+index c4592d0..7700ec4 100644
+--- a/cmake/modules/FindQScintilla.cmake
++++ b/cmake/modules/FindQScintilla.cmake
+@@ -21,7 +21,7 @@ IF(QT4_FOUND)
+     "${QT_INCLUDE_DIR}/Qsci" /usr/include /usr/include/Qsci
+     )
+ 
+-    SET(QSCINTILLA_NAMES ${QSCINTILLA_NAMES} qscintilla2 libqscintilla2)
++    SET(QSCINTILLA_NAMES ${QSCINTILLA_NAMES} qscintilla2 libqscintilla2 qscintilla2_qt4 libqscintilla2_qt4)
+     FIND_LIBRARY(QSCINTILLA_LIBRARY
+         NAMES ${QSCINTILLA_NAMES}
+         PATHS ${QT_LIBRARY_DIR}

--- a/dev-db/sqliteman/sqliteman-1.2.2-r3.ebuild
+++ b/dev-db/sqliteman/sqliteman-1.2.2-r3.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils
+
+DESCRIPTION="Powerful GUI manager for the Sqlite3 database"
+HOMEPAGE="http://sqliteman.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE=""
+
+RDEPEND="
+	dev-qt/qtcore:4
+	dev-qt/qtgui:4
+	dev-qt/qtsql:4[sqlite]
+	x11-libs/qscintilla:=[qt4(-)]"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-lpthread.patch"
+	"${FILESDIR}/${P}-qscintilla-2.10.patch"
+)
+
+src_prepare() {
+	# remove bundled lib
+	rm -rf "${S}"/${PN}/qscintilla2 || die
+
+	cmake-utils_src_prepare
+}


### PR DESCRIPTION
x11-libs/qscintilla-2.10 renames the qt4 libraries. 
Patch helping cmake find the libraries is lifted from [arch-commits](https://www.mail-archive.com/arch-commits@archlinux.org/msg313044.html).