### PR TITLE
net-vpn/tor: enable use of /var/run/tor.pid with systemd

### DIFF
--- a/net-vpn/tor/files/tor-0.3.0.5_rc-systemd-service.patch
+++ b/net-vpn/tor/files/tor-0.3.0.5_rc-systemd-service.patch
@@ -1,0 +1,20 @@
+--- tor/contrib/dist/tor.service.in	2017-03-05 01:44:57.000000000 +0100
++++ tor/contrib/dist/tor.service.in.new	2017-04-18 13:42:27.497367982 +0200
+@@ -11,6 +11,9 @@
+ [Service]
+ Type=notify
+ NotifyAccess=all
++PermissionsStartOnly=true
++ExecStartPre=-/bin/mkdir @LOCALSTATEDIR@/run/tor
++ExecStartPre=/bin/chown tor:tor @LOCALSTATEDIR@/run/tor
+ ExecStartPre=@BINDIR@/tor -f @CONFDIR@/torrc --verify-config
+ ExecStart=@BINDIR@/tor -f @CONFDIR@/torrc
+ ExecReload=/bin/kill -HUP ${MAINPID}
+@@ -26,6 +27,7 @@
+ ProtectHome=yes
+ ProtectSystem=full
+ ReadOnlyDirectories=/
++ReadWriteDirectories=-@LOCALSTATEDIR@/run/tor
+ ReadWriteDirectories=-@LOCALSTATEDIR@/lib/tor
+ ReadWriteDirectories=-@LOCALSTATEDIR@/log/tor
+ NoNewPrivileges=yes

--- a/net-vpn/tor/tor-0.3.0.5_rc-r1.ebuild
+++ b/net-vpn/tor/tor-0.3.0.5_rc-r1.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+inherit flag-o-matic readme.gentoo-r1 systemd versionator user
+
+MY_PV="$(replace_version_separator 4 -)"
+MY_PF="${PN}-${MY_PV}"
+DESCRIPTION="Anonymizing overlay network for TCP"
+HOMEPAGE="http://www.torproject.org/"
+SRC_URI="https://www.torproject.org/dist/${MY_PF}.tar.gz
+	https://archive.torproject.org/tor-package-archive/${MY_PF}.tar.gz"
+S="${WORKDIR}/${MY_PF}"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-macos"
+IUSE="libressl scrypt seccomp selinux systemd tor-hardening test web"
+
+DEPEND="
+	app-text/asciidoc
+	dev-libs/libevent[ssl]
+	sys-libs/zlib
+	!libressl? ( dev-libs/openssl:0=[-bindist] )
+	libressl? ( dev-libs/libressl:0= )
+	scrypt? ( app-crypt/libscrypt )
+	seccomp? ( sys-libs/libseccomp )
+	systemd? ( sys-apps/systemd )"
+RDEPEND="${DEPEND}
+	selinux? ( sec-policy/selinux-tor )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.2.7.4-torrc.sample.patch
+	"${FILESDIR}"/${P}-systemd-service.patch
+)
+
+DOCS=( README ChangeLog ReleaseNotes doc/HACKING )
+
+pkg_setup() {
+	enewgroup tor
+	enewuser tor -1 -1 /var/lib/tor tor
+}
+
+src_configure() {
+	econf \
+		--localstatedir="${EPREFIX}/var" \
+		--enable-system-torrc \
+		--enable-asciidoc \
+		$(use_enable scrypt libscrypt) \
+		$(use_enable seccomp) \
+		$(use_enable systemd) \
+		$(use_enable tor-hardening gcc-hardening) \
+		$(use_enable tor-hardening linker-hardening) \
+		$(use_enable web tor2web-mode) \
+		$(use_enable test unittests) \
+		$(use_enable test coverage)
+}
+
+src_install() {
+	default
+	readme.gentoo_create_doc
+
+	newconfd "${FILESDIR}"/tor.confd tor
+	newinitd "${FILESDIR}"/tor.initd-r8 tor
+	systemd_dounit contrib/dist/tor.service
+
+	keepdir /var/lib/tor
+
+	fperms 750 /var/lib/tor
+	fowners tor:tor /var/lib/tor
+
+	insinto /etc/tor/
+	newins "${FILESDIR}"/torrc-r1 torrc
+}


### PR DESCRIPTION
Currently tor tries to use /var/run/tor/tor.pid via default config file. The installed upstream .service file, however, does not make any provision for that. The error is non-fatal, but visible via `journalctl`.

@candrews : In https://github.com/gentoo/gentoo/pull/3322 you commented 
> Note that /var/run/tor isn't used by anything (systemd or tor) so the tmpfiles.d file managing it is not necessary.

Does that still apply?

Note: No changes have been made to the ebuild; merely the patch was added.

@blueness 