### PR TITLE
Convert dosym uses to relative targets (whenever possible)

### DIFF
--- a/sys-apps/coreutils/coreutils-8.27-r1.ebuild
+++ b/sys-apps/coreutils/coreutils-8.27-r1.ebuild
@@ -156,7 +156,7 @@ src_install() {
 		# create a symlink for uname in /usr/bin/ since autotools require it
 		local x
 		for x in ${com} uname ; do
-			dosym /bin/${x} /usr/bin/${x}
+			dosym ../../bin/${x} /usr/bin/${x}
 		done
 	else
 		# For now, drop the man pages, collides with the ones of the system.


### PR DESCRIPTION
From the commit message:

> Use relative paths for symlink targets instead of absolute. Relative
> paths are more portable -- they work correctly when Gentoo is mounted
> in a subdirectory of the filesystem, and are not affected by bugs
> in Prefix support.

Let's start with one core package, and see how to proceed from there.

Most important question: do we want this to do in ~arch revbump, or to stable as well? Do we want to fix all old versions retroactively (since it is highly unlikely that it will break anything)?