### PR TITLE
Add @OUTPUT, @DEFAULT_VALUE and @DEFAULT_ASSUMED vars

### DIFF
--- a/app-portage/eclass-manpages/files/eclass-to-manpage.awk
+++ b/app-portage/eclass-manpages/files/eclass-to-manpage.awk
@@ -27,6 +27,7 @@
 # The format of functions:
 # @FUNCTION: foo
 # @USAGE: <required arguments to foo> [optional arguments to foo]
+# @OUTPUT: <values emitted to STDOUT>
 # @RETURN: <whatever foo returns>
 # @MAINTAINER:
 # <optional; list of contacts, one per line>
@@ -217,6 +218,7 @@ function show_function_header() {
 function handle_function() {
 	func_name = $3
 	usage = ""
+	funcout = ""
 	funcret = ""
 	maintainer = ""
 	internal = 0
@@ -231,6 +233,8 @@ function handle_function() {
 	getline
 	if ($2 == "@USAGE:")
 		usage = eat_line()
+	if ($2 == "@OUTPUT:")
+		funcout = eat_line()
 	if ($2 == "@RETURN:")
 		funcret = eat_line()
 	if ($2 == "@MAINTAINER:")
@@ -256,6 +260,11 @@ function handle_function() {
 		if (desc != "")
 			print ""
 		print "Return value: " funcret
+	}
+	if (funcout != "") {
+		if (desc !="")
+			print ""
+		print "Outputs: " funcout
 	}
 
 	if (blurb == "")

--- a/app-portage/eclass-manpages/files/eclass-to-manpage.awk
+++ b/app-portage/eclass-manpages/files/eclass-to-manpage.awk
@@ -40,6 +40,7 @@
 # [@DEFAULT_UNSET]
 # [@INTERNAL]
 # [@REQUIRED]
+# @DEFAULT-ASSUMED: <interpreted value when not set>
 # @DEFAULT-VALUE: <initial value>
 # @DESCRIPTION:
 # <required; blurb about this variable>
@@ -50,6 +51,7 @@
 # [@DEFAULT_UNSET]
 # [@INTERNAL]
 # [@REQUIRED]
+# @DEFAULT-ASSUMED: <interpreted value when not set>
 # @DEFAULT-VALUE: <initial value>
 # @DESCRIPTION:
 # <required; blurb about this variable>
@@ -285,6 +287,7 @@ function _handle_variable() {
 	default_unset = 0
 	internal = 0
 	required = 0
+	default_assumed = ""
 	default_value = ""
 
 	# make sure people haven't specified this before (copy & paste error)
@@ -302,6 +305,10 @@ function _handle_variable() {
 			internal = 1
 		else if ($2 == "@REQUIRED")
 			required = 1
+		else if ($2 == "@DEFAULT-ASSUMED:") {
+			sub(/^# @[A-Z-]*:[[:space:]]*/,"")
+			default_assumed = $0
+		}
 		else if ($2 == "@DEFAULT-VALUE:") {
 			sub(/^# @[A-Z-]*:[[:space:]]*/,"")
 			default_value = $0
@@ -342,6 +349,10 @@ function _handle_variable() {
 		val = " " op " \\fI" val "\\fR"
 	if (required == 1)
 		val = val " (REQUIRED)"
+
+	if ( default_assumed != "" ) {
+		val = val " (UNSET -> \\fI" default_assumed "\\fR)"
+	}
 
 	if (internal == 1)
 		return ""


### PR DESCRIPTION
Read individual commits for details.

With these patches applied, the following diff to `perl-module.eclass` 
```diff
diff --git a/eclass/perl-module.eclass b/eclass/perl-module.eclass
index f97b3265fc..3790ce513c 100644
--- a/eclass/perl-module.eclass
+++ b/eclass/perl-module.eclass
@@ -33,6 +33,7 @@ esac
 
 # @ECLASS-VARIABLE: GENTOO_DEPEND_ON_PERL
 # @DEFAULT_UNSET
+# @DEFAULT_ASSUMED: yes
 # @DESCRIPTION:
 # This variable controls whether a runtime and build time dependency on
 # dev-lang/perl is automatically added by the eclass. It defaults to yes.
@@ -106,25 +107,29 @@ esac
 LICENSE="${LICENSE:-|| ( Artistic GPL-1+ )}"
 
 # @ECLASS-VARIABLE: DIST_NAME
+# @DEFAULT_VALUE: ${PN}
 # @DESCRIPTION:
 # (EAPI=6) This variable provides a way to override PN for the calculation of S,
-# SRC_URI, and HOMEPAGE. Defaults to PN.
+# SRC_URI, and HOMEPAGE.
 
 # @ECLASS-VARIABLE: DIST_VERSION
+# @DEFAULT_VALUE: ${PV}
 # @DESCRIPTION:
 # (EAPI=6) This variable provides a way to override PV for the calculation of S and SRC_URI.
-# Use it to provide the non-normalized, upstream version number. Defaults to PV.
+# Use it to provide the non-normalized, upstream version number.
 # Named MODULE_VERSION in EAPI=5.
 
 # @ECLASS-VARIABLE: DIST_A_EXT
+# @DEFAULT_VALUE: tar.gz
 # @DESCRIPTION:
 # (EAPI=6) This variable provides a way to override the distfile extension for the calculation of
-# SRC_URI. Defaults to tar.gz. Named MODULE_A_EXT in EAPI=5.
+# SRC_URI. Named MODULE_A_EXT in EAPI=5.
 
 # @ECLASS-VARIABLE: DIST_A
+# @DEFAULT_VALUE: ${DIST_NAME}-${DIST_VERSION}.${DIST_A_EXT}
 # @DESCRIPTION:
 # (EAPI=6) This variable provides a way to override the distfile name for the calculation of
-# SRC_URI. Defaults to ${DIST_NAME}-${DIST_VERSION}.${DIST_A_EXT} Named MODULE_A in EAPI=5.
+# SRC_URI. Named MODULE_A in EAPI=5.
 
 # @ECLASS-VARIABLE: DIST_AUTHOR
 # @DEFAULT_UNSET
@@ -312,10 +317,12 @@ perl-module_src_compile() {
 }
 
 # @ECLASS-VARIABLE: DIST_TEST
+# @DEFAULT_UNSET
+# @DEFAULT_ASSUMED: "do parallel"
 # @DESCRIPTION:
 # (EAPI=6) Variable that controls if tests are run in the test phase
-# at all, and if yes under which conditions. Defaults to "do parallel"
-# If neither "do" nor "parallel" is recognized, tests are skipped.
+# at all, and if yes under which conditions. If neither "do" nor "parallel"
+# is recognized, tests are skipped.
 # (In EAPI=5 the variable is called SRC_TEST, defaults to "skip", and
 # recognizes fewer options.)
 # The following space-separated keywords are recognized:
```

Renders as follows:
![snapshot_20170422_220034](https://cloud.githubusercontent.com/assets/44790/25303446/237ce4dc-27a7-11e7-8455-b59d47d8c6a3.png)
