### PR TITLE
net-misc/seafile-client: Don't require QtTest

### DIFF
--- a/net-misc/seafile-client/files/seafile-client-6.0.4-only-use-qttest-where-needed.patch
+++ b/net-misc/seafile-client/files/seafile-client-6.0.4-only-use-qttest-where-needed.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 20860a6..4261fba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -176,7 +176,7 @@ ELSE()
+ ENDIF()
+ 
+ SET(USE_QT_LIBRARIES
+-    Core Gui Widgets LinguistTools Network Test
++    Core Gui Widgets LinguistTools Network
+     )
+ IF (BUILD_SHIBBOLETH_SUPPORT)
+     SET(USE_QT_LIBRARIES ${USE_QT_LIBRARIES} ${WEBENGINE_CORE} ${WEBKIT_NAME} ${WEBKIT_WIDGETS_NAME})
+@@ -814,7 +814,9 @@ IF (BUILD_TESTING)
+         SET_TARGET_PROPERTIES(${testname} PROPERTIES
+           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests )
+ 
+-        QT5_USE_MODULES(${testname} ${USE_QT_LIBRARIES})
++        INCLUDE_DIRECTORIES(${Qt5Test_INCLUDE_DIRS})
++
++        QT5_USE_MODULES(${testname} ${USE_QT_LIBRARIES} Test)
+ 
+         ADD_TEST(${testname} ${CMAKE_CURRENT_BINARY_DIR}/tests/${testname})
+ 

--- a/net-misc/seafile-client/seafile-client-6.0.4-r1.ebuild
+++ b/net-misc/seafile-client/seafile-client-6.0.4-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/haiwen/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="shibboleth"
+IUSE="shibboleth test"
 
 RDEPEND="net-libs/libsearpc
 	=net-libs/ccnet-${PV}
@@ -28,9 +28,11 @@ RDEPEND="net-libs/libsearpc
 	dev-qt/qtdbus:5
 	shibboleth? ( || ( dev-qt/qtwebengine:5[widgets] dev-qt/qtwebkit:5 ) )"
 DEPEND="${RDEPEND}
-	dev-qt/linguist-tools:5"
+	dev-qt/linguist-tools:5
+	test? ( dev-qt/qttest:5 )"
 
 src_prepare() {
+	eapply "${FILESDIR}/${P}-only-use-qttest-when-needed.patch"
 	cmake-utils_src_prepare
 	if use shibboleth ; then
 		if ! has_version "dev-qt/qtwebengine:5[widgets]" ; then
@@ -43,6 +45,7 @@ src_configure() {
 	export QT_SELECT=qt5
 	local mycmakeargs=(
 		-DBUILD_SHIBBOLETH_SUPPORT="$(usex shibboleth)"
+		-DBUILD_TESTING="$(usex test)"
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
Closes: #615838

https://bugs.gentoo.org/show_bug.cgi?id=615838