### PR TITLE
app-crypt/qca: drop some arches to testing

### DIFF
--- a/app-crypt/qca/qca-2.1.1.ebuild
+++ b/app-crypt/qca/qca-2.1.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://kde/stable/${PN}/${PV}/src/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"
 SLOT="2"
-KEYWORDS="alpha amd64 ~arm ~arm64 hppa ~ia64 ppc ~ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
 
 IUSE="botan debug doc examples gcrypt gpg libressl logger nss pkcs11 +qt4 qt5 sasl softstore +ssl test"
 REQUIRED_USE="|| ( qt4 qt5 )"


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2