### PR TITLE
net-nntp/sabnzbd: Disable wget logging in init script

### DIFF
--- a/net-nntp/sabnzbd/files/sabnzbd.initd
+++ b/net-nntp/sabnzbd/files/sabnzbd.initd
@@ -58,7 +58,7 @@ stop() {
 
 	ebegin "Stopping SABnzbd"
 
-	if [ "$(wget -q -t 1 -O - -T 10 "${url}")" = "ok" ]; then
+	if [ "$(wget -o /dev/null -t 1 -O - -T 10 "${url}")" = "ok" ]; then
 		signals="NULL/5/${signals}"
 	fi
 


### PR DESCRIPTION
Wget 1.19, which is now stable in Gentoo, introduced a logging-related [change](https://git.savannah.gnu.org/cgit/wget.git/commit/?id=dd5c549f6af8e1143e1a6ef66725eea4bcd9ad50) that causes the `wget` invocation inside SABnzbd's init script to log to `/wget-log`, `/wget-log.1` etc. during system shutdown.

Call `wget` with `-o /dev/null` instead of `-q` to completely suppress logging.

/cc @jsbronder (maintainer)