### PR TITLE
net-misc/seafile-client: Fix Qt5 selection

### DIFF
--- a/net-misc/seafile-client/files/seafile-client-6.0.4-select-qt5.patch
+++ b/net-misc/seafile-client/files/seafile-client-6.0.4-select-qt5.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4261fba..24fbbda 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -158,11 +158,8 @@ SET(QT_VERSION_MAJOR 5)
+ # have to keep using QtWebKit on windows because QtWebEngine can't be
+ # compiled in msys2/mingw (QtWebEnigne is based on chrome, which has to be
+ # compiled with MSVC.)
+-FIND_PROGRAM(qmake_executable NAMES qmake qmake.exe)
+-EXECUTE_PROCESS(COMMAND
+-    bash -c "${qmake_executable} --version | grep -iE '^using qt version [0-9.]+' | awk '{print $4}'"
+-    OUTPUT_VARIABLE DETECTED_QT_VERSION
+-    OUTPUT_STRIP_TRAILING_WHITESPACE)
++FIND_PACKAGE(Qt5Core)
++SET(DETECTED_QT_VERSION ${Qt5Core_VERSION})
+ MESSAGE("qt5 version: ${DETECTED_QT_VERSION}")
+ IF(WIN32 OR DETECTED_QT_VERSION VERSION_LESS 5.6.0)
+     ADD_DEFINITIONS(-DSEAFILE_USE_WEBKIT)

--- a/net-misc/seafile-client/seafile-client-6.0.4-r2.ebuild
+++ b/net-misc/seafile-client/seafile-client-6.0.4-r2.ebuild
@@ -32,7 +32,8 @@ DEPEND="${RDEPEND}
 	test? ( dev-qt/qttest:5 )"
 
 src_prepare() {
-	eapply "${FILESDIR}/${P}-only-use-qttest-when-needed.patch"
+	eapply "${FILESDIR}/${P}-select-qt5.patch"
+	eapply "${FILESDIR}/${P}-only-use-qttest-where-needed.patch"
 	cmake-utils_src_prepare
 	if use shibboleth ; then
 		if ! has_version "dev-qt/qtwebengine:5[widgets]" ; then
@@ -42,7 +43,6 @@ src_prepare() {
 }
 
 src_configure() {
-	export QT_SELECT=qt5
 	local mycmakeargs=(
 		-DBUILD_SHIBBOLETH_SUPPORT="$(usex shibboleth)"
 		-DBUILD_TESTING="$(usex test)"


### PR DESCRIPTION
Followup to #4489.
Also fixes wrong path to ` ${P}-only-use-qttest-where-needed.patch` 😊.