### PR TITLE
media-sound/alsa-utils: add acpi support

### DIFF
--- a/media-sound/alsa-utils/alsa-utils-1.1.3-r1.ebuild
+++ b/media-sound/alsa-utils/alsa-utils-1.1.3-r1.ebuild
@@ -1,0 +1,86 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit eutils systemd udev
+
+DESCRIPTION="Advanced Linux Sound Architecture Utils (alsactl, alsamixer, etc.)"
+HOMEPAGE="http://www.alsa-project.org/"
+SRC_URI="mirror://alsaproject/utils/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0.9"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86"
+IUSE="acpi bat doc +libsamplerate +ncurses nls selinux"
+
+CDEPEND=">=media-libs/alsa-lib-${PV}
+	libsamplerate? ( media-libs/libsamplerate )
+	ncurses? ( >=sys-libs/ncurses-5.7-r7:0= )
+	bat? ( sci-libs/fftw:= )"
+DEPEND="${CDEPEND}
+	virtual/pkgconfig
+	doc? ( app-text/xmlto )"
+RDEPEND="${CDEPEND}
+	selinux? ( sec-policy/selinux-alsa )
+	acpi? ( sys-power/acpid )"
+
+src_configure() {
+	local myconf
+	use doc || myconf='--disable-xmlto'
+
+	# --disable-alsaconf because it doesn't work with sys-apps/kmod wrt #456214
+	econf \
+		--disable-maintainer-mode \
+		$(use_enable bat) \
+		$(use_enable libsamplerate alsaloop) \
+		$(use_enable nls) \
+		$(use_enable ncurses alsamixer) \
+		--disable-alsaconf \
+		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)" \
+		--with-udev-rules-dir="${EPREFIX}/$(get_udevdir)"/rules.d \
+		--with-asound-state-dir="${EPREFIX}"/var/lib/alsa \
+		${myconf}
+}
+
+src_install() {
+	default
+	dodoc seq/*/README.*
+
+	newinitd "${FILESDIR}"/alsasound.initd-r6 alsasound
+	newconfd "${FILESDIR}"/alsasound.confd-r4 alsasound
+
+	insinto /etc/modprobe.d
+	newins "${FILESDIR}"/alsa-modules.conf-rc alsa.conf
+
+	keepdir /var/lib/alsa
+
+	# ALSA lib parser.c:1266:(uc_mgr_scan_master_configs) error: could not
+	# scan directory /usr/share/alsa/ucm: No such file or directory
+	# alsaucm: unable to obtain card list: No such file or directory
+	keepdir /usr/share/alsa/ucm
+
+	if use acpi; then
+		exeinto /etc/acpi/actions
+		doexe "${FILESDIR}"/acpi/actions/button_mute.sh
+		doexe "${FILESDIR}"/acpi/actions/button_volumedown.sh
+		doexe "${FILESDIR}"/acpi/actions/button_volumeup.sh
+		insinto /etc/acpi/events
+		doins "${FILESDIR}"/acpi/events/button_mute
+		doins "${FILESDIR}"/acpi/events/button_volumedown
+		doins "${FILESDIR}"/acpi/events/button_volumeup
+	fi
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		elog
+		elog "To take advantage of the init script, and automate the process of"
+		elog "saving and restoring sound-card mixer levels you should"
+		elog "add alsasound to the boot runlevel. You can do this as"
+		elog "root like so:"
+		elog "# rc-update add alsasound boot"
+		ewarn
+		ewarn "The ALSA core should be built into the kernel or loaded through other"
+		ewarn "means. There is no longer any modular auto(un)loading in alsa-utils."
+	fi
+}

--- a/media-sound/alsa-utils/files/acpi/actions/button_mute.sh
+++ b/media-sound/alsa-utils/files/acpi/actions/button_mute.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+logger "[ACPI] button_mute"
+amixer -q set Master toggle
+

--- a/media-sound/alsa-utils/files/acpi/actions/button_volumedown.sh
+++ b/media-sound/alsa-utils/files/acpi/actions/button_volumedown.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+inc=1dB
+logger "[ACPI] button_volumedown"
+amixer -q set Master $inc-
+

--- a/media-sound/alsa-utils/files/acpi/actions/button_volumeup.sh
+++ b/media-sound/alsa-utils/files/acpi/actions/button_volumeup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+inc=1dB
+logger "[ACPI] button_volumeup"
+amixer -q set Master $inc+
+

--- a/media-sound/alsa-utils/files/acpi/events/button_mute
+++ b/media-sound/alsa-utils/files/acpi/events/button_mute
@@ -1,0 +1,3 @@
+event=button/mute
+action=/etc/acpi/actions/button_mute.sh
+

--- a/media-sound/alsa-utils/files/acpi/events/button_volumedown
+++ b/media-sound/alsa-utils/files/acpi/events/button_volumedown
@@ -1,0 +1,3 @@
+event=button/volumedown
+action=/etc/acpi/actions/button_volumedown.sh
+

--- a/media-sound/alsa-utils/files/acpi/events/button_volumeup
+++ b/media-sound/alsa-utils/files/acpi/events/button_volumeup
@@ -1,0 +1,3 @@
+event=button/volumeup
+action=/etc/acpi/actions/button_volumeup.sh
+


### PR DESCRIPTION
Enabling acpi use flag on this ebuild will pull in a dependency on
sys-power/acpid and create three new actions and events for volume
control buttons