### PR TITLE
sys-power/acpilight: add acpi support and service

### DIFF
--- a/sys-power/acpilight/acpilight-1.0-r1.ebuild
+++ b/sys-power/acpilight/acpilight-1.0-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_4 python3_5 )
+
+inherit python-r1 udev
+
+DESCRIPTION="Replacement for xbacklight that uses the ACPI interface to set brightness"
+HOMEPAGE="https://github.com/wavexx/acpilight/"
+SRC_URI="https://github.com/wavexx/acpilight/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="acpi"
+
+RDEPEND="virtual/udev
+	${PYTHON_DEPS}
+	!x11-apps/xbacklight
+	acpi? ( sys-power/acpid )"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+DOCS=( README.rst )
+
+src_install() {
+	python_foreach_impl python_doscript xbacklight
+	udev_dorules "${S}"/90-backlight.rules
+	doman xbacklight.1
+	einstalldocs
+	newinitd "${FILESDIR}"/acpilight.initd acpilight
+	newconfd "${FILESDIR}"/acpilight.confd acpilight
+	if use acpi; then
+		exeinto /etc/acpi/actions
+		doexe "${FILESDIR}"/acpi/actions/video_brightnessdown.sh
+		doexe "${FILESDIR}"/acpi/actions/video_brightnessup.sh
+		insinto /etc/acpi/events
+		doins "${FILESDIR}"/acpi/events/video_brightnessdown
+		doins "${FILESDIR}"/acpi/events/video_brightnessup
+	fi
+}
+
+pkg_postinst() {
+	udev_reload
+	einfo
+	elog "To use the xbacklight binary as a regular user, you must be a part of the video group"
+	einfo
+	elog "If this utility does not find any backlights to manipulate,"
+	elog "verify you have kernel support on the device and display driver enabled."
+	einfo
+}

--- a/sys-power/acpilight/files/acpi/actions/video_brightnessdown.sh
+++ b/sys-power/acpilight/files/acpi/actions/video_brightnessdown.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+inc=10
+logger "[ACPI] video_brightnessdown"
+xbacklight -$inc
+

--- a/sys-power/acpilight/files/acpi/actions/video_brightnessup.sh
+++ b/sys-power/acpilight/files/acpi/actions/video_brightnessup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+inc=10
+logger "[ACPI] video_brightnessup"
+xbacklight +$inc
+

--- a/sys-power/acpilight/files/acpi/events/video_brightnessdown
+++ b/sys-power/acpilight/files/acpi/events/video_brightnessdown
@@ -1,0 +1,3 @@
+event=video/brightnessdown
+action=/etc/acpi/actions/video_brightnessdown.sh
+

--- a/sys-power/acpilight/files/acpi/events/video_brightnessup
+++ b/sys-power/acpilight/files/acpi/events/video_brightnessup
@@ -1,0 +1,3 @@
+event=video/brightnessup
+action=/etc/acpi/actions/video_brightnessup.sh
+

--- a/sys-power/acpilight/files/acpilight.confd
+++ b/sys-power/acpilight/files/acpilight.confd
@@ -1,0 +1,13 @@
+# RESTORE_ON_START:
+# Restore brightness level when backlight starts
+# no - Do not restore state
+# yes - Restore state
+
+RESTORE_ON_START="yes"
+
+# SAVE_ON_STOP:
+# Save backlight level when backlight stops 
+# no - Do not save state
+# yes - Save state
+
+SAVE_ON_STOP="yes"

--- a/sys-power/acpilight/files/acpilight.initd
+++ b/sys-power/acpilight/files/acpilight.initd
@@ -1,0 +1,45 @@
+#!/sbin/openrc-run
+# $Id$
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+state_dir=/var/lib/acpilight
+
+extra_commands="save restore"
+
+depend() {
+	need localmount
+	after bootmisc modules isapnp coldplug hotplug
+}
+
+restore() {
+	ebegin "Restoring backlight level"
+	if [ ! -r "${state_dir}/state" ] ; then
+		ewarn "No backlight level in ${state_dir}/state"
+		eend 0
+		return 0
+	fi
+	xbacklight "$(cat "${state_dir}/state")"
+	eend 0
+}
+
+save() {
+	ebegin "Saving backlight level"
+	mkdir -p "${state_dir}"
+	xbacklight -get > "${state_dir}/state"
+	eend 0
+}
+
+start() {
+	if [ "${RESTORE_ON_START}" = "yes" ]; then
+		restore
+	fi
+	return 0
+}
+
+stop() {
+	if [ "${SAVE_ON_STOP}" = "yes" ]; then
+		save
+	fi
+	return 0
+}


### PR DESCRIPTION
Enabling acpi use flag on this ebuild will pull in a dependency on
sys-power/acpid and create two new actions and events for backlight
control buttons

Also add confd and initd files for saving and restoring backlight level
on startup and shut down