### PR TITLE
sys-devel/autoconf: Add perl-5.26 patch re bug #613790

### DIFF
--- a/sys-devel/autoconf/autoconf-2.69-r3.ebuild
+++ b/sys-devel/autoconf/autoconf-2.69-r3.ebuild
@@ -36,5 +36,6 @@ src_prepare()   {
 	# usr/bin/libtool is provided by binutils-apple, need gnu libtool
 	[[ ${CHOST} == *-darwin* ]] && \
 		PATCHES+=( "${FILESDIR}"/${PN}-2.61-darwin.patch )
+	PATCHES+=( "${FILESDIR}"/${PN}-2.69-perl-5.26.patch )
 	toolchain-autoconf_src_prepare
 }

--- a/sys-devel/autoconf/files/autoconf-2.69-perl-5.26.patch
+++ b/sys-devel/autoconf/files/autoconf-2.69-perl-5.26.patch
@@ -1,0 +1,28 @@
+From e5654a5591884b92633c7785f325626711e7f7aa Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 29 Jan 2013 13:46:48 -0800
+Subject: [PATCH] autoscan: port to perl 5.17
+
+* bin/autoscan.in (scan_sh_file): Escape '{'.  This avoids a
+feature that is deprecated in Perl 5.17.  Reported by Ray Lauff in
+<http://lists.gnu.org/archive/html/bug-autoconf/2013-01/msg00059.html>.
+---
+ bin/autoscan.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bin/autoscan.in b/bin/autoscan.in
+index 993a750..db1df79 100644
+--- a/bin/autoscan.in
++++ b/bin/autoscan.in
+@@ -358,7 +358,7 @@ sub scan_sh_file ($)
+     {
+       # Strip out comments and variable references.
+       s/#.*//;
+-      s/\${[^\}]*}//g;
++      s/\$\{[^\}]*}//g;
+       s/@[^@]*@//g;
+ 
+       # Tokens in the code.
+-- 
+1.9.1
+


### PR DESCRIPTION
This fixes the unescaped "{" issue.

-r1 bump necessary as end users must have this patch applied to
their installs otherwise autoscan will be broken after upgrading
perl.

autoconf does not subslot dep on perl, so there are no guarantees
that a rebuild will happen to propagate this patch

Hence, -r1 fix

Bug: https://bugs.gentoo.org/613790

Package-Manager: Portage-2.3.4, Repoman-2.3.2