### PR TITLE
dev-db/percona-xtrabackup: add missing dep on dev-libs/libev

### DIFF
--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.6-r1.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.6-r1.ebuild
@@ -20,6 +20,7 @@ DEPEND="
 	>=dev-libs/boost-1.59.0:=
 	dev-libs/libaio
 	dev-libs/libedit
+	dev-libs/libev
 	dev-libs/libevent:0=
 	dev-libs/libgcrypt:0=
 	dev-libs/libgpg-error

--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.7.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.7.ebuild
@@ -20,6 +20,7 @@ DEPEND="
 	>=dev-libs/boost-1.59.0:=
 	dev-libs/libaio
 	dev-libs/libedit
+	dev-libs/libev
 	dev-libs/libevent:0=
 	dev-libs/libgcrypt:0=
 	dev-libs/libgpg-error


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2

https://bugs.gentoo.org/show_bug.cgi?id=616750
Changing the stable too, because users who have it probably had the missing libev library before and they don't need to rebuild. For those unlucky, syncing the tree will allowed them to merge the package.