### PR TITLE
dev-libs/concurrencykit: add blocker on sys-cluster/charm

### DIFF
--- a/dev-libs/concurrencykit/concurrencykit-0.5.2.ebuild
+++ b/dev-libs/concurrencykit/concurrencykit-0.5.2.ebuild
@@ -14,4 +14,8 @@ LICENSE="Apache-2.0 BSD-2"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
+# libck.so name collision #616762
+# these packages have nothing in common
+RDEPEND="!sys-cluster/charm"
+
 S="${WORKDIR}/${MY_P}"

--- a/dev-libs/concurrencykit/concurrencykit-0.6.0.ebuild
+++ b/dev-libs/concurrencykit/concurrencykit-0.6.0.ebuild
@@ -14,4 +14,8 @@ LICENSE="Apache-2.0 BSD-2"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
+# libck.so name collision #616762
+# these packages have nothing in common
+RDEPEND="!sys-cluster/charm"
+
 S="${WORKDIR}/${MY_P}"


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2

https://bugs.gentoo.org/show_bug.cgi?id=616762
Modifying the stable releases. There are no users that have both packages, those who have concurrencykit will not be able to install charm and vice versa. Will report upstream.