### PR TITLE
sys-power/acpilight: add init script

### DIFF
--- a/sys-power/acpilight/acpilight-1.0-r1.ebuild
+++ b/sys-power/acpilight/acpilight-1.0-r1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_4 python3_5 )
+
+inherit python-r1 udev
+
+DESCRIPTION="Replacement for xbacklight that uses the ACPI interface to set brightness"
+HOMEPAGE="https://github.com/wavexx/acpilight/"
+SRC_URI="https://github.com/wavexx/acpilight/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="virtual/udev
+	${PYTHON_DEPS}
+	!x11-apps/xbacklight"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+DOCS=( README.rst )
+
+src_install() {
+	python_foreach_impl python_doscript xbacklight
+	udev_dorules "${S}"/90-backlight.rules
+	doman xbacklight.1
+	einstalldocs
+	newinitd "${FILESDIR}"/acpilight.initd acpilight
+	newconfd "${FILESDIR}"/acpilight.confd acpilight
+}
+
+pkg_postinst() {
+	udev_reload
+	einfo
+	elog "To use the xbacklight binary as a regular user, you must be a part of the video group"
+	einfo
+	elog "If this utility does not find any backlights to manipulate,"
+	elog "verify you have kernel support on the device and display driver enabled."
+	einfo
+	elog "To take advantage of the init script, and automate the process of"
+	elog "saving and restoring the brightness level you should add acpilight"
+	elog "to the boot runlevel. You can do this as root like so:"
+	elog "# rc-update add acpilight boot"
+	einfo
+}

--- a/sys-power/acpilight/files/acpilight.confd
+++ b/sys-power/acpilight/files/acpilight.confd
@@ -1,0 +1,13 @@
+# RESTORE_ON_START:
+# Restore brightness level when acpilight starts
+# no - Do not restore state
+# yes - Restore state
+
+RESTORE_ON_START="yes"
+
+# SAVE_ON_STOP:
+# Save brightness level when acpilight stops
+# no - Do not save state
+# yes - Save state
+
+SAVE_ON_STOP="yes"

--- a/sys-power/acpilight/files/acpilight.initd
+++ b/sys-power/acpilight/files/acpilight.initd
@@ -1,0 +1,41 @@
+#!/sbin/openrc-run
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+state_dir=/var/lib/acpilight
+
+extra_commands="save restore"
+
+depend() {
+	need localmount
+	after bootmisc modules isapnp coldplug hotplug
+}
+
+restore() {
+	ebegin "Restoring brightness level"
+	if [ ! -r "${state_dir}/state" ] ; then
+		ewarn "No brightness level in ${state_dir}/state"
+		eend 0
+		return 0
+	fi
+	xbacklight "$(cat "${state_dir}/state")"
+	eend $?
+}
+
+save() {
+	ebegin "Saving brightness level"
+	mkdir -p "${state_dir}" && xbacklight -get > "${state_dir}/state"
+	eend $?
+}
+
+start() {
+	if [ "${RESTORE_ON_START}" = "yes" ]; then
+		restore
+	fi
+}
+
+stop() {
+	if [ "${SAVE_ON_STOP}" = "yes" ]; then
+		save
+	fi
+}


### PR DESCRIPTION
Adding acpilight init script to the default runlevel will enable saving
and restoring the backlight state on shutdown and startup