### PR TITLE
dev-lang/pypy3 fixes for -O/-OO optimization

### DIFF
--- a/dev-python/pypy3-bin/files/python-3.5-distutils-OO-build.patch
+++ b/dev-python/pypy3-bin/files/python-3.5-distutils-OO-build.patch
@@ -1,0 +1,80 @@
+From 90507018442f9adabb586fd3d0a0206b9c2f2f50 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Sun, 5 Jun 2016 08:18:01 +0200
+Subject: [PATCH] distutils: make -OO enable both opt-1 and opt-2 optimization
+
+Bug: http://bugs.python.org/issue27226
+Bug: https://bugs.gentoo.org/585060
+---
+ distutils/command/build_py.py    |  8 ++++----
+ distutils/command/install_lib.py | 12 ++++++------
+ 2 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/distutils/command/build_py.py b/distutils/command/build_py.py
+index cf0ca57..838d4e4 100644
+--- a/distutils/command/build_py.py
++++ b/distutils/command/build_py.py
+@@ -315,9 +315,9 @@ class build_py (Command):
+                 if self.compile:
+                     outputs.append(importlib.util.cache_from_source(
+                         filename, optimization=''))
+-                if self.optimize > 0:
++                for opt in range(1, self.optimize + 1):
+                     outputs.append(importlib.util.cache_from_source(
+-                        filename, optimization=self.optimize))
++                        filename, optimization=opt))
+ 
+         outputs += [
+             os.path.join(build_dir, filename)
+@@ -387,8 +387,8 @@ class build_py (Command):
+         if self.compile:
+             byte_compile(files, optimize=0,
+                          force=self.force, prefix=prefix, dry_run=self.dry_run)
+-        if self.optimize > 0:
+-            byte_compile(files, optimize=self.optimize,
++        for opt in range(1, self.optimize + 1):
++            byte_compile(files, optimize=opt,
+                          force=self.force, prefix=prefix, dry_run=self.dry_run)
+ 
+ class build_py_2to3(build_py, Mixin2to3):
+diff --git a/distutils/command/install_lib.py b/distutils/command/install_lib.py
+index 6154cf0..049b662 100644
+--- a/distutils/command/install_lib.py
++++ b/distutils/command/install_lib.py
+@@ -24,8 +24,8 @@ class install_lib(Command):
+     #   2) compile .pyc only (--compile --no-optimize; default)
+     #   3) compile .pyc and "opt-1" .pyc (--compile --optimize)
+     #   4) compile "opt-1" .pyc only (--no-compile --optimize)
+-    #   5) compile .pyc and "opt-2" .pyc (--compile --optimize-more)
+-    #   6) compile "opt-2" .pyc only (--no-compile --optimize-more)
++    #   5) compile .pyc, "opt-1" and "opt-2" .pyc (--compile --optimize-more)
++    #   6) compile "opt-1" and "opt-2" .pyc (--no-compile --optimize-more)
+     #
+     # The UI for this is two options, 'compile' and 'optimize'.
+     # 'compile' is strictly boolean, and only decides whether to
+@@ -132,8 +132,8 @@ class install_lib(Command):
+             byte_compile(files, optimize=0,
+                          force=self.force, prefix=install_root,
+                          dry_run=self.dry_run)
+-        if self.optimize > 0:
+-            byte_compile(files, optimize=self.optimize,
++        for opt in range(1, self.optimize + 1):
++            byte_compile(files, optimize=opt,
+                          force=self.force, prefix=install_root,
+                          verbose=self.verbose, dry_run=self.dry_run)
+ 
+@@ -167,9 +167,9 @@ class install_lib(Command):
+             if self.compile:
+                 bytecode_files.append(importlib.util.cache_from_source(
+                     py_file, optimization=''))
+-            if self.optimize > 0:
++            for opt in range(1, self.optimize + 1):
+                 bytecode_files.append(importlib.util.cache_from_source(
+-                    py_file, optimization=self.optimize))
++                    py_file, optimization=opt))
+ 
+         return bytecode_files
+ 
+-- 
+2.8.3
+

--- a/dev-python/pypy3-bin/pypy3-bin-5.7.1-r1.ebuild
+++ b/dev-python/pypy3-bin/pypy3-bin-5.7.1-r1.ebuild
@@ -76,6 +76,7 @@ src_prepare() {
 	# apply CPython stdlib patches
 	pushd lib-python/3 > /dev/null || die
 	eapply "${FILESDIR}"/5.7.1_all_distutils_cxx.patch
+	eapply "${FILESDIR}"/python-3.5-distutils-OO-build.patch
 	popd > /dev/null || die
 
 	eapply_user

--- a/dev-python/pypy3/files/python-3.5-distutils-OO-build.patch
+++ b/dev-python/pypy3/files/python-3.5-distutils-OO-build.patch
@@ -1,0 +1,80 @@
+From 90507018442f9adabb586fd3d0a0206b9c2f2f50 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Sun, 5 Jun 2016 08:18:01 +0200
+Subject: [PATCH] distutils: make -OO enable both opt-1 and opt-2 optimization
+
+Bug: http://bugs.python.org/issue27226
+Bug: https://bugs.gentoo.org/585060
+---
+ distutils/command/build_py.py    |  8 ++++----
+ distutils/command/install_lib.py | 12 ++++++------
+ 2 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/distutils/command/build_py.py b/distutils/command/build_py.py
+index cf0ca57..838d4e4 100644
+--- a/distutils/command/build_py.py
++++ b/distutils/command/build_py.py
+@@ -315,9 +315,9 @@ class build_py (Command):
+                 if self.compile:
+                     outputs.append(importlib.util.cache_from_source(
+                         filename, optimization=''))
+-                if self.optimize > 0:
++                for opt in range(1, self.optimize + 1):
+                     outputs.append(importlib.util.cache_from_source(
+-                        filename, optimization=self.optimize))
++                        filename, optimization=opt))
+ 
+         outputs += [
+             os.path.join(build_dir, filename)
+@@ -387,8 +387,8 @@ class build_py (Command):
+         if self.compile:
+             byte_compile(files, optimize=0,
+                          force=self.force, prefix=prefix, dry_run=self.dry_run)
+-        if self.optimize > 0:
+-            byte_compile(files, optimize=self.optimize,
++        for opt in range(1, self.optimize + 1):
++            byte_compile(files, optimize=opt,
+                          force=self.force, prefix=prefix, dry_run=self.dry_run)
+ 
+ class build_py_2to3(build_py, Mixin2to3):
+diff --git a/distutils/command/install_lib.py b/distutils/command/install_lib.py
+index 6154cf0..049b662 100644
+--- a/distutils/command/install_lib.py
++++ b/distutils/command/install_lib.py
+@@ -24,8 +24,8 @@ class install_lib(Command):
+     #   2) compile .pyc only (--compile --no-optimize; default)
+     #   3) compile .pyc and "opt-1" .pyc (--compile --optimize)
+     #   4) compile "opt-1" .pyc only (--no-compile --optimize)
+-    #   5) compile .pyc and "opt-2" .pyc (--compile --optimize-more)
+-    #   6) compile "opt-2" .pyc only (--no-compile --optimize-more)
++    #   5) compile .pyc, "opt-1" and "opt-2" .pyc (--compile --optimize-more)
++    #   6) compile "opt-1" and "opt-2" .pyc (--no-compile --optimize-more)
+     #
+     # The UI for this is two options, 'compile' and 'optimize'.
+     # 'compile' is strictly boolean, and only decides whether to
+@@ -132,8 +132,8 @@ class install_lib(Command):
+             byte_compile(files, optimize=0,
+                          force=self.force, prefix=install_root,
+                          dry_run=self.dry_run)
+-        if self.optimize > 0:
+-            byte_compile(files, optimize=self.optimize,
++        for opt in range(1, self.optimize + 1):
++            byte_compile(files, optimize=opt,
+                          force=self.force, prefix=install_root,
+                          verbose=self.verbose, dry_run=self.dry_run)
+ 
+@@ -167,9 +167,9 @@ class install_lib(Command):
+             if self.compile:
+                 bytecode_files.append(importlib.util.cache_from_source(
+                     py_file, optimization=''))
+-            if self.optimize > 0:
++            for opt in range(1, self.optimize + 1):
+                 bytecode_files.append(importlib.util.cache_from_source(
+-                    py_file, optimization=self.optimize))
++                    py_file, optimization=opt))
+ 
+         return bytecode_files
+ 
+-- 
+2.8.3
+

--- a/dev-python/pypy3/pypy3-5.7.1-r1.ebuild
+++ b/dev-python/pypy3/pypy3-5.7.1-r1.ebuild
@@ -88,6 +88,7 @@ src_prepare() {
 	# apply CPython stdlib patches
 	pushd lib-python/3 > /dev/null || die
 	eapply "${FILESDIR}"/5.7.1_all_distutils_cxx.patch
+	eapply "${FILESDIR}"/python-3.5-distutils-OO-build.patch
 	popd > /dev/null || die
 
 	eapply_user

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -660,7 +660,7 @@ python_optimize() {
 				"${PYTHON}" -m compileall -q -f -d "${instpath}" "${d}"
 				"${PYTHON}" -OO -m compileall -q -f -d "${instpath}" "${d}"
 				;;
-			python*)
+			python*|pypy3)
 				# both levels of optimization are separate since 3.5
 				"${PYTHON}" -m compileall -q -f -d "${instpath}" "${d}"
 				"${PYTHON}" -O -m compileall -q -f -d "${instpath}" "${d}"


### PR DESCRIPTION
Since pypy3 now uses all three suffixes like Python 3.5+, we also need to byte-compile appropriately.