### PR TITLE
ppc64: mask luajit USE on ppc64 userland

### DIFF
--- a/profiles/arch/powerpc/ppc64/64ul/use.mask
+++ b/profiles/arch/powerpc/ppc64/64ul/use.mask
@@ -1,5 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation; Distributed under the GPL v2
 
+# Ilya Tumaykin <itumaykin+gentoo@gmail.com> (06 May 2017)
+# There is no luajit support on ppc64 userland. Bug #608326.
+luajit
+
 # Anthony G. Basile <blueness@gentoo.org> (01 Aug 2015)
 # There is no luajit support on ppc64 userland.  Bug #554376.
 luajittex


### PR DESCRIPTION
Similarly to how it's done with luajittex.

Gentoo-Bug: 608326