### PR TITLE
net-misc/wicd: show inside network category

### DIFF
--- a/net-misc/wicd/files/wicd-1.7.2.4-fix-desktop-categories.patch
+++ b/net-misc/wicd/files/wicd-1.7.2.4-fix-desktop-categories.patch
@@ -4,7 +4,7 @@ diff -U 3 -dHrN wicd-1.7.2.4.orig/other/wicd.desktop wicd-1.7.2.4/other/wicd.des
 @@ -1,5 +1,5 @@
  [Desktop Entry]
 -Categories=Application;Network;
-+Categories=Network;Settings;Utility;
++Categories=Network;Settings;Utility;X-GNOME-NetworkSettings;
  Exec=wicd-gtk --no-tray
  GenericName=Network Manager
  Icon=wicd-gtk
@@ -14,7 +14,7 @@ diff -U 3 -dHrN wicd-1.7.2.4.orig/other/wicd-tray.desktop wicd-1.7.2.4/other/wic
 @@ -1,5 +1,5 @@
  [Desktop Entry]
 -Categories=Application;Network;
-+Categories=Network;Settings;Utility;
++Categories=Network;Settings;Utility;X-GNOME-NetworkSettings;
  Exec=wicd-gtk --tray
  GenericName=Network Manager
  Icon=wicd-gtk


### PR DESCRIPTION
MATE Control Center 1.12 shows Wicd inside 'Other' instead of 'Internet and Network' category.
Adding 'X-GNOME-NetworkSettings' or 'X-MATE-NetworkSettings' fixes this.
nm-applet uses 'X-GNOME-NetworkSettings'