### PR TITLE
dev-db/postgresql: Change systemd unit type to notify

### DIFF
--- a/dev-db/postgresql/files/postgresql.service-9.6
+++ b/dev-db/postgresql/files/postgresql.service-9.6
@@ -1,0 +1,56 @@
+# It's not recommended to modify this file in-place, because it will be
+# overwritten during package upgrades. If you want to customize, the
+# best way is to create file
+# "/etc/systemd/system/postgresql-@SLOT@.service.d/*.conf"
+# containing your changes
+
+# For example, if you want to change the server's port number to 5433,
+# create a file named
+# "/etc/systemd/system/postgresql-@SLOT@.service.d/port.conf"
+# containing:
+#       [Service]
+#       Environment=PGPORT=5433
+# This will override the setting appearing below.
+
+[Unit]
+Description=PostgreSQL database server
+After=network.target
+
+[Service]
+Type=notify
+
+User=postgres
+Group=postgres
+
+# Port number for server to listen on
+Environment=PGPORT=5432
+
+# Location of configuration files
+Environment=PGDATA=/etc/postgresql-@SLOT@
+
+# Where the data directory is located
+Environment=DATA_DIR=/var/lib/postgresql/@SLOT@/data
+
+# Where to send early-startup messages from the server (before the logging
+# options of postgresql.conf take effect)
+# This is normally controlled by the global default set by systemd
+# StandardOutput=syslog
+
+ExecStartPre=/usr/bin/postgresql-@SLOT@-check-db-dir
+ExecStart=/usr/@LIBDIR@/postgresql-@SLOT@/bin/postgres -p ${PGPORT} -D ${DATA_DIR}
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=mixed
+KillSignal=SIGINT
+
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec=300
+
+# Disable OOM kill on the postmaster
+OOMScoreAdjust=-1000
+
+# Make sure the required runtimedir is present
+RuntimeDirectory=postgresql
+RuntimeDirectoryMode=1775
+
+[Install]
+WantedBy=multi-user.target

--- a/dev-db/postgresql/postgresql-9.6.3-r1.ebuild
+++ b/dev-db/postgresql/postgresql-9.6.3-r1.ebuild
@@ -5,15 +5,17 @@ EAPI="5"
 
 PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 
-inherit eutils flag-o-matic git-2 linux-info multilib pam prefix \
-		python-single-r1 systemd user versionator
+inherit eutils flag-o-matic linux-info multilib pam prefix python-single-r1 \
+		systemd user versionator
 
-KEYWORDS=""
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~ppc-macos ~x86-solaris"
 
-# Bump when rc released.
-SLOT="10"
+SLOT="$(get_version_component_range 1-2)"
 
-EGIT_REPO_URI="git://git.postgresql.org/git/postgresql.git"
+MY_PV=${PV/_/}
+S="${WORKDIR}/${PN}-${MY_PV}"
+
+SRC_URI="mirror://postgresql/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
 
 LICENSE="POSTGRESQL GPL-2"
 DESCRIPTION="PostgreSQL RDBMS"
@@ -21,7 +23,7 @@ HOMEPAGE="http://www.postgresql.org/"
 
 LINGUAS="af cs de en es fa fr hr hu it ko nb pl pt_BR ro ru sk sl sv tr
 		 zh_CN zh_TW"
-IUSE="kerberos kernel_linux ldap libressl nls pam perl -pg_legacytimestamp python
+IUSE="doc kerberos kernel_linux ldap libressl nls pam perl -pg_legacytimestamp python
 	  +readline selinux +server systemd ssl static-libs tcl threads uuid xml zlib"
 
 for lingua in ${LINGUAS}; do
@@ -55,30 +57,40 @@ ssl? (
 )
 server? ( systemd? ( sys-apps/systemd ) )
 tcl? ( >=dev-lang/tcl-8:0= )
-uuid? ( dev-libs/ossp-uuid )
 xml? ( dev-libs/libxml2 dev-libs/libxslt )
 zlib? ( sys-libs/zlib )
 "
 
+# uuid flags -- depend on sys-apps/util-linux for Linux libcs, or if no
+# supported libc in use depend on dev-libs/ossp-uuid. For BSD systems,
+# the libc includes UUID functions.
+UTIL_LINUX_LIBC=( elibc_{glibc,uclibc,musl} )
+BSD_LIBC=( elibc_{Free,Net,Open}BSD )
+
+nest_usedep() {
+	local front back
+	while [[ ${#} -gt 1 ]]; do
+		front+="${1}? ( "
+		back+=" )"
+		shift
+	done
+	echo "${front}${1}${back}"
+}
+
+IUSE+=" ${UTIL_LINUX_LIBC[@]} ${BSD_LIBC[@]}"
+CDEPEND+="
+uuid? (
+	${UTIL_LINUX_LIBC[@]/%/? ( sys-apps/util-linux )}
+	$(nest_usedep ${UTIL_LINUX_LIBC[@]/#/!} ${BSD_LIBC[@]/#/!} dev-libs/ossp-uuid)
+)"
+
 DEPEND="${CDEPEND}
 !!<sys-apps/sandbox-2.0
->=dev-lang/perl-5.8
-app-text/docbook-dsssl-stylesheets
-app-text/docbook-sgml-dtd:4.2
-app-text/docbook-xml-dtd:4.2
-app-text/docbook-xsl-stylesheets
-app-text/openjade
-dev-libs/libxml2
-dev-libs/libxslt
 sys-devel/bison
 sys-devel/flex
 nls? ( sys-devel/gettext )
 xml? ( virtual/pkgconfig )
 "
-src_unpack() {
-	base_src_unpack
-	git-2_src_unpack
-}
 
 RDEPEND="${CDEPEND}
 !dev-db/postgresql-docs:${SLOT}
@@ -87,17 +99,8 @@ RDEPEND="${CDEPEND}
 selinux? ( sec-policy/selinux-postgresql )
 "
 
-pkg_pretend() {
-	ewarn "You are using a live ebuild that uses the current source code as it is"
-	ewarn "available from PostgreSQL's Git repository at emerge time. Given such,"
-	ewarn "the GNU Makefiles may be altered by upstream without notice and the"
-	ewarn "documentation for this live version is not readily available"
-	ewarn "online. Ergo, the ebuild maintainers will not support building a"
-	ewarn "client-only and/or document-free version."
-}
-
 pkg_setup() {
-	CONFIG_CHECK="~SYSVIPC" linux-info_pkg_setup
+	use server && CONFIG_CHECK="~SYSVIPC" linux-info_pkg_setup
 
 	enewgroup postgres 70
 	enewuser postgres 70 /bin/sh /var/lib/postgresql postgres
@@ -117,6 +120,12 @@ src_prepare() {
 	# install program is used for modules utilizing PGXS in both
 	# hardened and non-hardened environments. (Bug #528786)
 	sed 's/@install_bin@/install -c/' -i src/Makefile.global.in || die
+
+	use server || epatch "${FILESDIR}/${PN}-${SLOT}.1-no-server.patch"
+
+	# Fix bug 486556 where the server would crash at start up because of
+	# an infinite loop caused by a self-referencing symlink.
+	epatch "${FILESDIR}/postgresql-9.2-9.4-tz-dir-overflow.patch"
 
 	if use pam ; then
 		sed -e "s/\(#define PGSQL_PAM_SERVICE \"postgresql\)/\1-${SLOT}/" \
@@ -139,6 +148,17 @@ src_configure() {
 
 	local PO="${EPREFIX%/}"
 
+	local i uuid_config=""
+	if use uuid; then
+		for i in ${UTIL_LINUX_LIBC[@]}; do
+			use ${i} && uuid_config="--with-uuid=e2fs"
+		done
+		for i in ${BSD_LIBC[@]}; do
+			use ${i} && uuid_config="--with-uuid=bsd"
+		done
+		[[ -z $uuid_config ]] && uuid_config="--with-uuid=ossp"
+	fi
+
 	econf \
 		--prefix="${PO}/usr/$(get_libdir)/postgresql-${SLOT}" \
 		--datadir="${PO}/usr/share/postgresql-${SLOT}" \
@@ -158,7 +178,7 @@ src_configure() {
 		$(use_with ssl openssl) \
 		$(usex server "$(use_with systemd)" '--without-systemd') \
 		$(use_with tcl) \
-		$(use_with uuid ossp-uuid) \
+		${uuid_config} \
 		$(use_with xml libxml) \
 		$(use_with xml libxslt) \
 		$(use_with zlib) \
@@ -166,34 +186,34 @@ src_configure() {
 }
 
 src_compile() {
-	emake world
+	emake
+	emake -C contrib
 }
 
 src_install() {
-	emake DESTDIR="${D}" install-world
+	emake DESTDIR="${D}" install
+	emake DESTDIR="${D}" install -C contrib
 
 	dodoc README HISTORY doc/{TODO,bug.template}
+
+	# man pages are already built, but if we have the target make them,
+	# they'll be generated from source before being installed so we
+	# manually install man pages.
+	# We use ${SLOT} instead of doman for postgresql.eselect
+	insinto /usr/share/postgresql-${SLOT}/man/
+	doins -r doc/src/sgml/man{1,3,7}
+	if ! use server; then
+		# Remove man pages for non-existent binaries
+		for m in {initdb,pg_{controldata,ctl,resetxlog},post{gres,master}}; do
+			rm "${ED}/usr/share/postgresql-${SLOT}/man/man1/${m}.1"
+		done
+	fi
+	docompress /usr/share/postgresql-${SLOT}/man/man{1,3,7}
 
 	insinto /etc/postgresql-${SLOT}
 	newins src/bin/psql/psqlrc.sample psqlrc
 
 	use static-libs || find "${ED}" -name '*.a' -delete
-
-	sed -e "s|@SLOT@|${SLOT}|g" -e "s|@LIBDIR@|$(get_libdir)|g" \
-		"${FILESDIR}/${PN}.confd-9.3" | newconfd - ${PN}-${SLOT}
-
-	sed -e "s|@SLOT@|${SLOT}|g" -e "s|@LIBDIR@|$(get_libdir)|g" \
-		"${FILESDIR}/${PN}.init-9.3-r1" | newinitd - ${PN}-${SLOT}
-
-	if use systemd ; then
-		sed -e "s|@SLOT@|${SLOT}|g" -e "s|@LIBDIR@|$(get_libdir)|g" \
-			"${FILESDIR}/${PN}.service-9.6" | \
-			systemd_newunit - ${PN}-${SLOT}.service
-	fi
-
-	newbin "${FILESDIR}"/${PN}-check-db-dir ${PN}-${SLOT}-check-db-dir
-
-	use pam && pamd_mimic system-auth ${PN}-${SLOT} auth account session
 
 	local f bn
 	for f in $(find "${ED}/usr/$(get_libdir)/postgresql-${SLOT}/bin" \
@@ -217,22 +237,46 @@ src_install() {
 		done
 	done
 
-	if use prefix ; then
-		keepdir /run/postgresql
-		fperms 0775 /run/postgresql
+	if use doc ; then
+		docinto html
+		dodoc doc/src/sgml/html/*
+
+		docinto sgml
+		dodoc doc/src/sgml/*.{sgml,dsl}
+	fi
+
+	if use server; then
+		sed -e "s|@SLOT@|${SLOT}|g" -e "s|@LIBDIR@|$(get_libdir)|g" \
+			"${FILESDIR}/${PN}.confd-9.3" | newconfd - ${PN}-${SLOT}
+
+		sed -e "s|@SLOT@|${SLOT}|g" -e "s|@LIBDIR@|$(get_libdir)|g" \
+			"${FILESDIR}/${PN}.init-9.3-r1" | newinitd - ${PN}-${SLOT}
+
+		if use systemd; then
+			sed -e "s|@SLOT@|${SLOT}|g" -e "s|@LIBDIR@|$(get_libdir)|g" \
+				"${FILESDIR}/${PN}.service-9.6" | \
+				systemd_newunit - ${PN}-${SLOT}.service
+		fi
+
+		newbin "${FILESDIR}"/${PN}-check-db-dir ${PN}-${SLOT}-check-db-dir
+
+		use pam && pamd_mimic system-auth ${PN}-${SLOT} auth account session
+
+		if use prefix ; then
+			keepdir /run/postgresql
+			fperms 0775 /run/postgresql
+		fi
 	fi
 }
 
 pkg_preinst() {
 	# Find all of the slot-specific symlinks, if any, in /usr/bin (e.g.,
-	# /usr/bin/psql97). They may have been created by the
+	# /usr/bin/psql96). They may have been created by the
 	# postgresql.eselect module, but they're handled within this ebuild
 	# now. It's alright if we momentarily delete /usr/bin/psql as it
-	# will be recreated by the eselect module in pkg_ppostinst().  We
-	# only worry about the 9.7 slot as that's the last slot that had its
-	# slot-specific links generated by eselect.
-	#
-	# This can be removed when 10 is the lowest slot in the tree.
+	# will be recreated by the eselect module in pkg_ppostinst(). This
+	# is only necessary for 9.7 and earlier. 10 and later were never
+	# handled in this manner.
 	local canonicalise
 	if type -p realpath > /dev/null; then
 		canonicalise=realpath
@@ -247,7 +291,9 @@ pkg_preinst() {
 	# First remove any symlinks in /usr/bin that may have been created
 	# by the old eselect
 	for l in $(find "${ROOT%/}/usr/bin" -mindepth 1 -maxdepth 1 -type l) ; do
-		[[ $(${canonicalise} "${l}") == *postgresql-9.7* ]] && rm "${l}"
+		if [[ $(${canonicalise} "${l}") == *postgresql-${SLOT}* ]] ; then
+			rm "${l}" || ewarn "Couldn't remove ${l}"
+		fi
 	done
 
 	# Then move the symlinks created by the ebuild to their proper place.
@@ -263,27 +309,29 @@ pkg_postinst() {
 	elog "If you need a global psqlrc-file, you can place it in:"
 	elog "    ${EROOT%/}/etc/postgresql-${SLOT}/"
 
-	elog
-	elog "Gentoo specific documentation:"
-	elog "https://wiki.gentoo.org/wiki/PostgreSQL"
-	elog
-	elog "Official documentation:"
-	elog "${EROOT%/}/usr/share/doc/${PF}/html"
-	elog
-	elog "The default location of the Unix-domain socket is:"
-	elog "    ${EROOT%/}/run/postgresql/"
-	elog
-	elog "Before initializing the database, you may want to edit PG_INITDB_OPTS"
-	elog "so that it contains your preferred locale, and other options, in:"
-	elog "    ${EROOT%/}/etc/conf.d/postgresql-${SLOT}"
-	elog
-	elog "Then, execute the following command to setup the initial database"
-	elog "environment:"
-	elog "    emerge --config =${CATEGORY}/${PF}"
+	if use server ; then
+		elog
+		elog "Gentoo specific documentation:"
+		elog "https://wiki.gentoo.org/wiki/PostgreSQL"
+		elog
+		elog "Official documentation:"
+		elog "http://www.postgresql.org/docs/${SLOT}/static/index.html"
+		elog
+		elog "The default location of the Unix-domain socket is:"
+		elog "    ${EROOT%/}/run/postgresql/"
+		elog
+		elog "Before initializing the database, you may want to edit PG_INITDB_OPTS"
+		elog "so that it contains your preferred locale in:"
+		elog "    ${EROOT%/}/etc/conf.d/postgresql-${SLOT}"
+		elog
+		elog "Then, execute the following command to setup the initial database"
+		elog "environment:"
+		elog "    emerge --config =${CATEGORY}/${PF}"
+	fi
 }
 
 pkg_prerm() {
-	if [[ -z ${REPLACED_BY_VERSION} ]] ; then
+	if use server && [[ -z ${REPLACED_BY_VERSION} ]] ; then
 		ewarn "Have you dumped and/or migrated the ${SLOT} database cluster?"
 		ewarn "\thttps://wiki.gentoo.org/wiki/PostgreSQL/QuickStart#Migrating_PostgreSQL"
 
@@ -298,6 +346,8 @@ pkg_postrm() {
 }
 
 pkg_config() {
+	use server || die "USE flag 'server' not enabled. Nothing to configure."
+
 	[[ -f "${EROOT%/}/etc/conf.d/postgresql-${SLOT}" ]] \
 		&& source "${EROOT%/}/etc/conf.d/postgresql-${SLOT}"
 	[[ -z "${PGDATA}" ]] && PGDATA="${EROOT%/}/etc/postgresql-${SLOT}/"
@@ -418,17 +468,17 @@ pkg_config() {
 }
 
 src_test() {
-	einfo ">>> Test phase [check]: ${CATEGORY}/${PF}"
-
-	if [[ ${UID} -ne 0 ]] ; then
+	if use server && [[ ${UID} -ne 0 ]] ; then
 		emake check
 
 		einfo "If you think other tests besides the regression tests are necessary, please"
 		einfo "submit a bug including a patch for this ebuild to enable them."
 	else
+		use server || \
+			ewarn 'Tests cannot be run without the "server" use flag enabled.'
 		[[ ${UID} -eq 0 ]] || \
-			ewarn "Tests cannot be run as root. Enable 'userpriv' in FEATURES."
+			ewarn 'Tests cannot be run as root. Enable "userpriv" in FEATURES.'
 
-		ewarn "Skipping."
+		ewarn 'Skipping.'
 	fi
 }


### PR DESCRIPTION
Add systemd USE flag to control required configure option and
dependency.

Package-Manager: Portage-2.3.5, Repoman-2.3.2

---

PostgreSQL 9.6 added configure option --with-systemd to enable calling sd_notify() at server start and stop
https://www.postgresql.org/docs/9.6/static/release-9-6.html#AEN131350

Changes to systemd unit based on:
https://www.postgresql.org/docs/9.6/static/server-start.html

Replaces use of pg_ctl, default logs now sent to journal instead of postmaster.log.

```
--- postgresql.service
+++ postgresql.service-9.6
@@ -17,7 +17,7 @@
 After=network.target
 
 [Service]
-Type=forking
+Type=notify
 
 User=postgres
 Group=postgres
@@ -37,9 +37,10 @@
 # StandardOutput=syslog
 
 ExecStartPre=/usr/bin/postgresql-@SLOT@-check-db-dir
-ExecStart=/usr/@LIBDIR@/postgresql-@SLOT@/bin/pg_ctl start -D ${DATA_DIR} -s -l ${DATA_DIR}/postmaster.log -o "-p ${PGPORT} -D ${PGDATA} --data-directory=${DATA_DIR}" -w -t 300
-ExecStop=/usr/@LIBDIR@/postgresql-@SLOT@/bin/pg_ctl stop -D ${DATA_DIR} -s -m fast
-ExecReload=/usr/@LIBDIR@/postgresql-@SLOT@/bin/pg_ctl reload -D ${DATA_DIR} -s
+ExecStart=/usr/@LIBDIR@/postgresql-@SLOT@/bin/postgres -p ${PGPORT} -D ${DATA_DIR}
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=mixed
+KillSignal=SIGINT
```

```
--- postgresql-9.6.2-r1.ebuild
+++ postgresql-9.6.2-r2.ebuild
@@ -24,7 +24,7 @@
 LINGUAS="af cs de en es fa fr hr hu it ko nb pl pt_BR ro ru sk sl sv tr
 		 zh_CN zh_TW"
 IUSE="doc kerberos kernel_linux ldap libressl nls pam perl -pg_legacytimestamp python
-	  +readline selinux +server ssl static-libs tcl threads uuid xml zlib"
+	  +readline selinux +server systemd ssl static-libs tcl threads uuid xml zlib"
 
 for lingua in ${LINGUAS}; do
 	IUSE+=" linguas_${lingua}"
@@ -55,6 +55,7 @@
 	!libressl? ( >=dev-libs/openssl-0.9.6-r1:0= )
 	libressl? ( dev-libs/libressl:= )
 )
+systemd? ( sys-apps/systemd )
 tcl? ( >=dev-lang/tcl-8:0= )
 xml? ( dev-libs/libxml2 dev-libs/libxslt )
 zlib? ( sys-libs/zlib )
@@ -175,6 +176,7 @@
 		$(use_with python) \
 		$(use_with readline) \
 		$(use_with ssl openssl) \
+		$(use_with systemd) \
 		$(use_with tcl) \
 		${uuid_config} \
 		$(use_with xml libxml) \
@@ -251,7 +253,7 @@
 			"${FILESDIR}/${PN}.init-9.3-r1" | newinitd - ${PN}-${SLOT}
 
 		sed -e "s|@SLOT@|${SLOT}|g" -e "s|@LIBDIR@|$(get_libdir)|g" \
-			"${FILESDIR}/${PN}.service" | \
+			"${FILESDIR}/${PN}.service-9.6" | \
 			systemd_newunit - ${PN}-${SLOT}.service
```
