### PR TITLE
games-emulation/desmume: Fix building with GCC-6 (bug #612940)

### DIFF
--- a/games-emulation/desmume/desmume-0.9.11-r1.ebuild
+++ b/games-emulation/desmume/desmume-0.9.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -28,4 +28,7 @@ DOCS=( AUTHORS ChangeLog README README.LIN )
 
 # fix QA compiler warning, see
 # https://sourceforge.net/p/desmume/patches/172/
-PATCHES=( "${FILESDIR}/${P}-fix-pointer-conversion-warning.diff" )
+PATCHES=(
+	"${FILESDIR}/${P}-fix-pointer-conversion-warning.diff"
+	"${FILESDIR}/${P}-gcc6.patch"
+)

--- a/games-emulation/desmume/files/desmume-0.9.11-gcc6.patch
+++ b/games-emulation/desmume/files/desmume-0.9.11-gcc6.patch
@@ -1,0 +1,47 @@
+--- a/src/wifi.cpp
++++ b/src/wifi.cpp
+@@ -314,9 +314,9 @@
+ 
+ #if (WIFI_LOGGING_LEVEL >= 1)
+ 	#if WIFI_LOG_USE_LOGC
+-		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) LOGC(8, "WIFI: "__VA_ARGS__);
++		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) LOGC(8, "WIFI: " __VA_ARGS__);
+ 	#else
+-		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) printf("WIFI: "__VA_ARGS__);
++		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) printf("WIFI: " __VA_ARGS__);
+ 	#endif
+ #else
+ #define WIFI_LOG(level, ...) {}
+--- a/src/MMU_timing.h
++++ b/src/MMU_timing.h
+@@ -155,8 +155,8 @@
+ 	enum { ASSOCIATIVITY = 1 << ASSOCIATIVESHIFT };
+ 	enum { BLOCKSIZE = 1 << BLOCKSIZESHIFT };
+ 	enum { TAGSHIFT = SIZESHIFT - ASSOCIATIVESHIFT };
+-	enum { TAGMASK = (u32)(~0 << TAGSHIFT) };
+-	enum { BLOCKMASK = ((u32)~0 >> (32 - TAGSHIFT)) & (u32)(~0 << BLOCKSIZESHIFT) };
++	enum { TAGMASK = (u32)(~0U << TAGSHIFT) };
++	enum { BLOCKMASK = ((u32)~0U >> (32 - TAGSHIFT)) & (u32)(~0U << BLOCKSIZESHIFT) };
+	enum { WORDSIZE = sizeof(u32) };
+ 	enum { WORDSPERBLOCK = (1 << BLOCKSIZESHIFT) / WORDSIZE };
+ 	enum { DATAPERWORD = WORDSIZE * ASSOCIATIVITY };
+--- a/src/ctrlssdl.cpp
++++ b/src/ctrlssdl.cpp
+@@ -200,7 +200,7 @@
+           break;
+         case SDL_JOYAXISMOTION:
+           /* Dead zone of 50% */
+-          if( (abs(event.jaxis.value) >> 14) != 0 )
++          if( ((u32)abs(event.jaxis.value) >> 14) != 0 )
+             {
+               key = ((event.jaxis.which & 15) << 12) | JOY_AXIS << 8 | ((event.jaxis.axis & 127) << 1);
+               if (event.jaxis.value > 0) {
+@@ -370,7 +370,7 @@
+          Note: button constants have a 1bit offset. */
+     case SDL_JOYAXISMOTION:
+       key_code = ((event->jaxis.which & 15) << 12) | JOY_AXIS << 8 | ((event->jaxis.axis & 127) << 1);
+-      if( (abs(event->jaxis.value) >> 14) != 0 )
++      if( ((u32)abs(event->jaxis.value) >> 14) != 0 )
+         {
+           if (event->jaxis.value > 0)
+             key_code |= 1;


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2

Fixes [bug #612940](https://bugs.gentoo.org/show_bug.cgi?id=612940).

Combination of upstream commits [d6677ef42fee4f9ef6885ca627766debb0ed4ffc](https://github.com/TASVideos/desmume/commit/d6677ef42fee4f9ef6885ca627766debb0ed4ffc)
 and [7dae5d220694a8a390b77753445bbc31d56f7fae](https://github.com/TASVideos/desmume/commit/7dae5d220694a8a390b77753445bbc31d56f7fae), and part of [0ce1df58c5d6dda5f11af2d4ee3f7fbb92026dd5](https://github.com/TASVideos/desmume/commit/0ce1df58c5d6dda5f11af2d4ee3f7fbb92026dd5).