### PR TITLE
net-misc/knutclient: Fix building with GCC-6

### DIFF
--- a/net-misc/knutclient/files/knutclient-1.0.5-gcc6.patch
+++ b/net-misc/knutclient/files/knutclient-1.0.5-gcc6.patch
@@ -1,0 +1,18 @@
+Forwarded: no
+Description: Fix the build with gcc 6
+Author: Adrian Bunk <bunk@stusta.de>
+Bug-Debian: https://bugs.debian.org/811882
+
+--- a/src/knutprefdlg.cpp
++++ b/src/knutprefdlg.cpp
+@@ -957,9 +957,9 @@
+ 
+   QHBoxLayout *setFontLayout = new QHBoxLayout();
+   QStringList fontsList;
+   KFontChooser::getFontList(fontsList, KFontChooser::SmoothScalableFonts);
+-  m_fontWidget = new KFontChooser(mainPageWidget, false, fontsList);
++  m_fontWidget = new KFontChooser(mainPageWidget, KFontChooser::NoDisplayFlags, fontsList);
+   setFontLayout->addWidget (m_fontWidget ,0);
+   topLayout->addLayout(setFontLayout);
+ 
+   topLayout->addStretch( 20 );

--- a/net-misc/knutclient/knutclient-1.0.5.ebuild
+++ b/net-misc/knutclient/knutclient-1.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -17,7 +17,11 @@ SLOT="4"
 KEYWORDS="~amd64 ~x86"
 IUSE="debug"
 
-PATCHES=( "${FILESDIR}/${P}-desktop.patch" )
+PATCHES=(
+	"${FILESDIR}/${P}-desktop.patch"
+	"${FILESDIR}/${P}-gcc6.patch"
+)
+
 DOCS=( ChangeLog )
 
 S=${WORKDIR}/${MY_P}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=612936
Package-Manager: Portage-2.3.5, Repoman-2.3.2

Patch taken from https://sources.debian.net/data/main/k/knutclient/1.0.5-2/debian/patches/gcc6-fix.patch