### PR TITLE
dev-cpp/clucene-2.3.3.4-r6: MACRO_CHECK_GCC_VISIBILITY error on gcc-7.1.0

### DIFF
--- a/dev-cpp/clucene/files/clucene-2.3.3.4-gcc6.patch
+++ b/dev-cpp/clucene/files/clucene-2.3.3.4-gcc6.patch
@@ -16,7 +16,7 @@ index 2022aa3..020f913 100644
     exec_program(${CMAKE_C_COMPILER} ARGS --version OUTPUT_VARIABLE _gcc_version_info)
  
 -   string (REGEX MATCH "[345]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
-+   string (REGEX MATCH "[3456]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
++   string (REGEX MATCH "[34567]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
     if (NOT _gcc_version)
     
        # clang reports: clang version 1.1 (trunk 95754)


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/617870