### PR TITLE
dev-libs/libcdio-paranoia: Re-enable symbol versions, #616054

### DIFF
--- a/dev-libs/libcdio-paranoia/libcdio-paranoia-0.94_p1-r1.ebuild
+++ b/dev-libs/libcdio-paranoia/libcdio-paranoia-0.94_p1-r1.ebuild
@@ -47,9 +47,14 @@ multilib_src_configure() {
 		$(use_enable cxx)
 		--disable-cpp-progs
 		--with-cd-paranoia-name=libcdio-paranoia
+		# upstream accidentally default-disabled it
+		# reenable it to preserve ABI compat with previous versions
+		# https://bugs.gentoo.org/616054
+		# https://savannah.gnu.org/bugs/index.php?50978
+		--enable-ld-version-script
 	)
 	# Darwin linker doesn't get this
-	[[ ${CHOST} == *-darwin* ]] && myeconfargs+=( --without-versioned-libs )
+	[[ ${CHOST} == *-darwin* ]] && myeconfargs+=( --disable-ld-version-script )
 	ECONF_SOURCE="${S}" \
 	econf "${myeconfargs[@]}"
 }


### PR DESCRIPTION
Re-enable ld symbol versioning that has been accidentally disabled
by default upstream, as a result of OSX compatibility fixing. This
restores the previous ABI and fixes breakage when upgrading.