### PR TITLE
media-libs/slv2: depend on virtual/jack

### DIFF
--- a/media-libs/slv2/slv2-0.6.6-r2.ebuild
+++ b/media-libs/slv2/slv2-0.6.6-r2.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="amd64 ~ppc x86"
 IUSE="doc jack"
 
 RDEPEND=">=dev-libs/redland-1.0.6
-	jack? ( >=media-sound/jack-audio-connection-kit-0.107.0 )
+	jack? ( virtual/jack )
 	|| ( media-libs/lv2 media-libs/lv2core )"
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2