### PR TITLE
Optional replacement of system set packages with busybox (Bug #618096)

### DIFF
--- a/app-busybox/awk/awk-1.ebuild
+++ b/app-busybox/awk/awk-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox "

--- a/app-busybox/awk/awk-1.ebuild
+++ b/app-busybox/awk/awk-1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox awk"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox "
+
+src_install() {
+  einfo "Symlinking awk to ${ROOT}bin/busybox"
+  dodir /usr/bin
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"usr/bin/awk
+}

--- a/app-busybox/findutils/findutils-1.ebuild
+++ b/app-busybox/findutils/findutils-1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of findutils"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox !sys-apps/findutils "
+
+src_install() {
+  dodir /usr/bin
+
+  einfo "Symlinking find to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"/bin/busybox "${D}""${ROOT}"usr/bin/find
+
+  einfo "Symlinking xargs to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"/bin/busybox "${D}""${ROOT}"usr/bin/xargs
+}

--- a/app-busybox/findutils/findutils-1.ebuild
+++ b/app-busybox/findutils/findutils-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox !sys-apps/findutils "

--- a/app-busybox/grep/grep-1.ebuild
+++ b/app-busybox/grep/grep-1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of grep"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox !sys-apps/grep "
+
+src_install() {
+  dodir /bin
+
+  einfo "Symlinking grep to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"bin/grep
+
+  einfo "Symlinking egrep to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"bin/egrep
+
+  einfo "Symlinking fgrep to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"bin/fgrep
+}

--- a/app-busybox/grep/grep-1.ebuild
+++ b/app-busybox/grep/grep-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox !sys-apps/grep "

--- a/app-busybox/iputils/iputils-1.ebuild
+++ b/app-busybox/iputils/iputils-1.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd6
 
 DEPEND=" sys-apps/busybox !net-misc/iputils "
 
-pkg_postinst() {
+src_install() {
   dodir /bin
 
   einfo "Symlinking ping to ${ROOT}bin/busybox"

--- a/app-busybox/iputils/iputils-1.ebuild
+++ b/app-busybox/iputils/iputils-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox !net-misc/iputils "

--- a/app-busybox/iputils/iputils-1.ebuild
+++ b/app-busybox/iputils/iputils-1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of iputils"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox !net-misc/iputils "
+
+pkg_postinst() {
+  dodir /bin
+
+  einfo "Symlinking ping to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"bin/ping
+
+  einfo "Symlinking ping6 to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"bin/ping6
+}

--- a/app-busybox/less/less-1.ebuild
+++ b/app-busybox/less/less-1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of less"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox !sys-apps/less "
+
+src_install() {
+  einfo "Symlinking less to ${ROOT}bin/busybox"
+  dodir /usr/bin
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"usr/bin/less
+
+}

--- a/app-busybox/less/less-1.ebuild
+++ b/app-busybox/less/less-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox !sys-apps/less "

--- a/app-busybox/man/man-1.ebuild
+++ b/app-busybox/man/man-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox "

--- a/app-busybox/man/man-1.ebuild
+++ b/app-busybox/man/man-1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="Standard commands to read man pages"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox "
+RDEPEND="|| ( >=sys-apps/groff-1.19.2-r1 app-doc/heirloom-doctools )
+	!sys-apps/man-db
+  !sys-apps/man
+	"
+
+pkg_setup() {
+	enewgroup man 15
+	enewuser man 13 -1 /usr/share/man man
+}
+
+
+echoit() { echo "$@" ; "$@" ; }
+
+
+src_install() {
+  keepdir /var/cache/man
+  diropts -m0775 -g man
+  local mansects=$(grep ^MANSECT "${D}"/etc/man.conf | cut -f2-)
+  for x in ${mansects//:/ } ; do
+    keepdir /var/cache/man/cat${x}
+  done
+
+  dodir /usr/bin
+
+  einfo "Symlinking man to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"usr/bin/man
+}

--- a/app-busybox/psmisc/psmisc-1.ebuild
+++ b/app-busybox/psmisc/psmisc-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox !sys-process/psmisc "

--- a/app-busybox/psmisc/psmisc-1.ebuild
+++ b/app-busybox/psmisc/psmisc-1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of psmisc"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox !sys-process/psmisc "
+
+src_install() {
+  dodir /bin
+  dodir /usr/bin
+
+  einfo "Symlinking fuser to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"bin/fuser
+
+  einfo "Symlinking killall to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"usr/bin/killall
+
+  einfo "Symlinking pstree to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"usr/bin/pstree
+
+  einfo "Symlinking peekfd to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"usr/bin/peekfd
+
+}

--- a/app-busybox/sed/sed-1.ebuild
+++ b/app-busybox/sed/sed-1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of sed"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox !sys-apps/sed "
+
+src_install() {
+  dodir /bin
+
+  einfo "Symlinking sed to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"bin/sed
+
+}

--- a/app-busybox/sed/sed-1.ebuild
+++ b/app-busybox/sed/sed-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox !sys-apps/sed "

--- a/app-busybox/vi/vi-1.ebuild
+++ b/app-busybox/vi/vi-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox "

--- a/app-busybox/vi/vi-1.ebuild
+++ b/app-busybox/vi/vi-1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of vi"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox "
+
+src_install() {
+  dodir /usr/bin
+
+  einfo "Symlinking vi to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"/bin/busybox "${D}""${ROOT}"/usr/bin/vi
+}

--- a/app-busybox/wget/wget-1.ebuild
+++ b/app-busybox/wget/wget-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox !net-misc/wget "

--- a/app-busybox/wget/wget-1.ebuild
+++ b/app-busybox/wget/wget-1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of wget"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox !net-misc/wget "
+
+src_install() {
+  dodir /usr/bin
+
+  einfo "Symlinking wget to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"bin/busybox "${D}""${ROOT}"usr/bin/wget
+}

--- a/app-busybox/which/which-1.ebuild
+++ b/app-busybox/which/which-1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="2"
+
+inherit eutils toolchain-funcs user
+
+DESCRIPTION="busybox variant of which"
+HOMEPAGE="www.busybox.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+
+
+DEPEND=" sys-apps/busybox !sys-apps/which "
+
+src_install() {
+  dodir /usr/bin
+
+  einfo "Symlinking which to ${ROOT}bin/busybox"
+  ln -s "${ROOT}"/bin/busybox "${D}""${ROOT}"/usr/bin/which
+}

--- a/app-busybox/which/which-1.ebuild
+++ b/app-busybox/which/which-1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI="6"
 
 inherit eutils toolchain-funcs user
 
@@ -10,7 +10,7 @@ HOMEPAGE="www.busybox.org"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 
 
 DEPEND=" sys-apps/busybox !sys-apps/which "

--- a/virtual/awk/awk-0.ebuild
+++ b/virtual/awk/awk-0.ebuild
@@ -12,5 +12,5 @@ RDEPEND="
 		sys-apps/gawk
 		sys-apps/mawk
 		sys-apps/nawk
-		sys-apps/busybox
+		app-busybox/awk
 	)"

--- a/virtual/awk/awk-1.ebuild
+++ b/virtual/awk/awk-1.ebuild
@@ -12,6 +12,6 @@ RDEPEND="
 		>=sys-apps/gawk-4.0.1-r1
 		sys-apps/mawk
 		sys-apps/nawk
-		sys-apps/busybox
+		app-busybox/awk
 	)
 	!<sys-apps/gawk-4.0.1-r1" #before 4.0.1-r1 awk symlinks did belong to gawk #455696

--- a/virtual/editor/editor-0.ebuild
+++ b/virtual/editor/editor-0.ebuild
@@ -46,10 +46,11 @@ RDEPEND="|| ( app-editors/nano
 	app-misc/mc[edit]
 	dev-lisp/cmucl
 	mail-client/alpine[-onlyalpine]
-	sys-apps/ed )"
+	sys-apps/ed
+  app-busybox/vi
+  )"
 
 # Packages outside app-editors providing an editor:
 #	app-misc/mc: mcedit (#62643)
 #	dev-lisp/cmucl: hemlock
 #	mail-client/alpine: pico
-#	sys-apps/busybox: vi

--- a/virtual/findutils/findutils-0.ebuild
+++ b/virtual/findutils/findutils-0.ebuild
@@ -3,8 +3,14 @@
 
 EAPI=5
 
-DESCRIPTION="Virtual for man"
+DESCRIPTION="Virtual for findutils"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
-RDEPEND="|| ( sys-apps/man-db sys-apps/man app-busybox/man )"
+
+
+RDEPEND="|| ( sys-apps/findutils
+ app-busybox/findutils
+ )"
+
+

--- a/virtual/grep/grep-0.ebuild
+++ b/virtual/grep/grep-0.ebuild
@@ -3,8 +3,14 @@
 
 EAPI=5
 
-DESCRIPTION="Virtual for man"
+DESCRIPTION="Virtual for grep"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
-RDEPEND="|| ( sys-apps/man-db sys-apps/man app-busybox/man )"
+
+
+RDEPEND="|| ( sys-apps/grep
+ app-busybox/grep
+ )"
+
+

--- a/virtual/iputils/iputils-0.ebuild
+++ b/virtual/iputils/iputils-0.ebuild
@@ -3,8 +3,14 @@
 
 EAPI=5
 
-DESCRIPTION="Virtual for man"
+DESCRIPTION="Virtual for iputils"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
-RDEPEND="|| ( sys-apps/man-db sys-apps/man app-busybox/man )"
+
+
+RDEPEND="|| ( net-misc/iputils
+ app-busybox/iputils
+ )"
+
+

--- a/virtual/pager/pager-0.ebuild
+++ b/virtual/pager/pager-0.ebuild
@@ -12,4 +12,5 @@ RDEPEND="|| ( sys-apps/less
 	sys-apps/most
 	sys-apps/util-linux[ncurses]
 	app-text/lv
-	app-editors/vim[vim-pager] )"
+	app-editors/vim[vim-pager]
+  app-busybox/less )"

--- a/virtual/psmisc/psmisc-0.ebuild
+++ b/virtual/psmisc/psmisc-0.ebuild
@@ -3,8 +3,14 @@
 
 EAPI=5
 
-DESCRIPTION="Virtual for man"
+DESCRIPTION="Virtual for psmisc"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
-RDEPEND="|| ( sys-apps/man-db sys-apps/man app-busybox/man )"
+
+
+RDEPEND="|| ( sys-process/psmisc
+ app-busybox/psmisc
+ )"
+
+

--- a/virtual/sed/sed-0.ebuild
+++ b/virtual/sed/sed-0.ebuild
@@ -3,8 +3,14 @@
 
 EAPI=5
 
-DESCRIPTION="Virtual for man"
+DESCRIPTION="Virtual for sed"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
-RDEPEND="|| ( sys-apps/man-db sys-apps/man app-busybox/man )"
+
+
+RDEPEND="|| ( sys-apps/sed
+ app-busybox/sed
+ )"
+
+

--- a/virtual/wget/wget-0.ebuild
+++ b/virtual/wget/wget-0.ebuild
@@ -3,8 +3,14 @@
 
 EAPI=5
 
-DESCRIPTION="Virtual for man"
+DESCRIPTION="Virtual for wget"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
-RDEPEND="|| ( sys-apps/man-db sys-apps/man app-busybox/man )"
+
+
+RDEPEND="|| ( net-misc/wget
+ app-busybox/wget
+ )"
+
+

--- a/virtual/which/which-0.ebuild
+++ b/virtual/which/which-0.ebuild
@@ -3,8 +3,14 @@
 
 EAPI=5
 
-DESCRIPTION="Virtual for man"
+DESCRIPTION="Virtual for which"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
-RDEPEND="|| ( sys-apps/man-db sys-apps/man app-busybox/man )"
+
+
+RDEPEND="|| ( sys-apps/which
+ app-busybox/which
+ )"
+
+


### PR DESCRIPTION
I have tried these replacements for a while and they seem to be working fine. There are several advantages with tracing busybox symlinks (ownership via package manager, ability to do virtual dependencies knowing that the symlink is there, ...)