### PR TITLE
dev-perl/*: Drop ia64 keywords for isolated packages

### DIFF
--- a/dev-perl/Algorithm-Annotate/Algorithm-Annotate-0.100.0-r1.ebuild
+++ b/dev-perl/Algorithm-Annotate/Algorithm-Annotate-0.100.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Represent a series of changes in annotate form"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND=">=dev-perl/Algorithm-Diff-1.150.0"

--- a/dev-perl/Algorithm-C3/Algorithm-C3-0.100.0.ebuild
+++ b/dev-perl/Algorithm-C3/Algorithm-C3-0.100.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A module for merging hierarchies using the C3 algorithm"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~ppc-aix ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86 ~ppc-aix ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Algorithm-Dependency/Algorithm-Dependency-1.110.0-r1.ebuild
+++ b/dev-perl/Algorithm-Dependency/Algorithm-Dependency-1.110.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Toolkit for implementing dependency systems"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 hppa ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND=">=dev-perl/Params-Util-0.31

--- a/dev-perl/Alien-wxWidgets/Alien-wxWidgets-0.670.0-r1.ebuild
+++ b/dev-perl/Alien-wxWidgets/Alien-wxWidgets-0.670.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit wxwidgets perl-module
 DESCRIPTION="Building, finding and using wxWidgets binaries"
 
 SLOT="0"
-KEYWORDS="amd64 ~ia64 x86"
+KEYWORDS="amd64 x86"
 IUSE="gstreamer opengl test"
 
 RDEPEND="

--- a/dev-perl/Alien-wxWidgets/Alien-wxWidgets-0.680.0.ebuild
+++ b/dev-perl/Alien-wxWidgets/Alien-wxWidgets-0.680.0.ebuild
@@ -11,7 +11,7 @@ inherit wxwidgets perl-module
 DESCRIPTION="Building, finding and using wxWidgets binaries"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="gstreamer opengl test"
 
 RDEPEND="

--- a/dev-perl/AnyEvent/AnyEvent-7.120.0.ebuild
+++ b/dev-perl/AnyEvent/AnyEvent-7.120.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Provides a uniform interface to various event loops"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ppc ppc64 sparc x86 ~x86-solaris"
+KEYWORDS="alpha amd64 arm ppc ppc64 sparc x86 ~x86-solaris"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/AnyEvent/AnyEvent-7.130.0.ebuild
+++ b/dev-perl/AnyEvent/AnyEvent-7.130.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Provides a uniform interface to various event loops"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-solaris"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Apache-LogFormat-Compiler/Apache-LogFormat-Compiler-0.350.0.ebuild
+++ b/dev-perl/Apache-LogFormat-Compiler/Apache-LogFormat-Compiler-0.350.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Compile an Apache log format string to perl-code"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 # POSIX -> perl

--- a/dev-perl/App-CLI/App-CLI-0.313.0-r1.ebuild
+++ b/dev-perl/App-CLI/App-CLI-0.313.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Dispatcher module for command line interface programs"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 RDEPEND=">=virtual/perl-Getopt-Long-2.35

--- a/dev-perl/AppConfig/AppConfig-1.710.0.ebuild
+++ b/dev-perl/AppConfig/AppConfig-1.710.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl5 module for reading configuration files and parsing command line arguments"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~x86-solaris"
+KEYWORDS="alpha amd64 arm ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Array-RefElem/Array-RefElem-1.0.0-r1.ebuild
+++ b/dev-perl/Array-RefElem/Array-RefElem-1.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Set up array elements as aliases"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Array-Window/Array-Window-1.20.0-r1.ebuild
+++ b/dev-perl/Array-Window/Array-Window-1.20.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Array::Window - Calculate windows/subsets/pages of arrays"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE="test"
 
 RDEPEND="dev-perl/Params-Util"

--- a/dev-perl/AtExit/AtExit-2.10.0-r1.ebuild
+++ b/dev-perl/AtExit/AtExit-2.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,5 +10,5 @@ inherit perl-module
 DESCRIPTION="atexit() function to register exit-callbacks"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/dev-perl/AtExit/AtExit-2.30.0.ebuild
+++ b/dev-perl/AtExit/AtExit-2.30.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="atexit() function to register exit-callbacks"
 LICENSE="|| ( Artistic Artistic-2 )"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Audio-CD-disc-cover/Audio-CD-disc-cover-0.05-r1.ebuild
+++ b/dev-perl/Audio-CD-disc-cover/Audio-CD-disc-cover-0.05-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # This appears it should really be entitled Audio-CD
 # There are * QA Notice: errors on building however the HOMEPAGE gives no source repo in which to file
@@ -16,7 +16,7 @@ SRC_URI="http://www.vanhemert.co.uk/files/${MY_P}.tar.gz"
 IUSE=""
 SLOT="0"
 LICENSE="|| ( Artistic GPL-2 )"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 
 DEPEND=">=dev-perl/URI-1.10
 	>=dev-perl/HTML-Parser-3.15

--- a/dev-perl/Audio-Mixer/Audio-Mixer-0.700.0-r1.ebuild
+++ b/dev-perl/Audio-Mixer/Audio-Mixer-0.700.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl extension for Sound Mixer control"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 # Dont' enable tests unless your working without a sandbox - expects to write to /dev/mixer

--- a/dev-perl/Authen-DigestMD5/Authen-DigestMD5-0.40.0-r1.ebuild
+++ b/dev-perl/Authen-DigestMD5/Authen-DigestMD5-0.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="SASL DIGEST-MD5 authentication (RFC2831)"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Authen-NTLM/Authen-NTLM-1.90.0-r1.ebuild
+++ b/dev-perl/Authen-NTLM/Authen-NTLM-1.90.0-r1.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="An NTLM authentication module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86"
+KEYWORDS="alpha amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc x86"
 IUSE="test"
 
 RDEPEND=">=virtual/perl-MIME-Base64-3.00

--- a/dev-perl/Authen-PAM/Authen-PAM-0.160.0-r1.ebuild
+++ b/dev-perl/Authen-PAM/Authen-PAM-0.160.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Interface to PAM library"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 sh sparc x86"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 s390 sh sparc x86"
 IUSE=""
 
 RDEPEND="virtual/pam"

--- a/dev-perl/Authen-Simple-Passwd/Authen-Simple-Passwd-0.600.0.ebuild
+++ b/dev-perl/Authen-Simple-Passwd/Authen-Simple-Passwd-0.600.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Simple Passwd authentication"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Authen-Simple/Authen-Simple-0.500.0.ebuild
+++ b/dev-perl/Authen-Simple/Authen-Simple-0.500.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Simple Authentication"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/BSD-Resource/BSD-Resource-1.290.800.ebuild
+++ b/dev-perl/BSD-Resource/BSD-Resource-1.290.800.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl module for BSD process resource limit and priority functions"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/BSD-Resource/BSD-Resource-1.290.900.ebuild
+++ b/dev-perl/BSD-Resource/BSD-Resource-1.290.900.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl module for BSD process resource limit and priority functions"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/BSD-Resource/BSD-Resource-1.291.100.ebuild
+++ b/dev-perl/BSD-Resource/BSD-Resource-1.291.100.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl module for BSD process resource limit and priority functions"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/BerkeleyDB/BerkeleyDB-0.550.0.ebuild
+++ b/dev-perl/BerkeleyDB/BerkeleyDB-0.550.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module eutils db-use
 DESCRIPTION="This module provides Berkeley DB interface for Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86"
 IUSE=""
 
 # Install DB_File if you want older support. BerkleyDB no longer

--- a/dev-perl/Bit-Vector-Minimal/Bit-Vector-Minimal-1.300.0-r1.ebuild
+++ b/dev-perl/Bit-Vector-Minimal/Bit-Vector-Minimal-1.300.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Object-oriented wrapper around vec()"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Bit-Vector/Bit-Vector-7.400.0.ebuild
+++ b/dev-perl/Bit-Vector/Bit-Vector-7.400.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Efficient bit vector, set of integers and big int math library"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Boulder/Boulder-1.300.0-r1.ebuild
+++ b/dev-perl/Boulder/Boulder-1.300.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="An API for hierarchical tag/value structures"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/XML-Parser"

--- a/dev-perl/Business-FedEx-DirectConnect/Business-FedEx-DirectConnect-1.10.0-r1.ebuild
+++ b/dev-perl/Business-FedEx-DirectConnect/Business-FedEx-DirectConnect-1.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Interface to FedEx Ship Manager Direct"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 x86"
+KEYWORDS="amd64 x86"
 IUSE=""
 
 RDEPEND="dev-perl/libwww-perl

--- a/dev-perl/CBOR-XS/CBOR-XS-1.600.0.ebuild
+++ b/dev-perl/CBOR-XS/CBOR-XS-1.600.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Concise Binary Object Representation (CBOR, RFC7049)"
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/CDDB-File/CDDB-File-1.50.0-r1.ebuild
+++ b/dev-perl/CDDB-File/CDDB-File-1.50.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Parse a CDDB/freedb data file"
 
 LICENSE="|| ( GPL-3 GPL-2 )" # GPL-2+
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc x86"
+KEYWORDS="alpha amd64 ppc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/CDDB/CDDB-1.222.0-r1.ebuild
+++ b/dev-perl/CDDB/CDDB-1.222.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="high-level interface to cddb/freedb protocol"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
 SRC_TEST=no

--- a/dev-perl/CDDB_get/CDDB_get-2.280.0-r1.ebuild
+++ b/dev-perl/CDDB_get/CDDB_get-2.280.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -13,7 +13,7 @@ HOMEPAGE="http://armin.emx.at/cddb/ ${HOMEPAGE}"
 
 LICENSE="|| ( Artistic GPL-2 )" # "as perl, either GPL-2 or Artistic"
 SLOT="2"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/CGI-Compile/CGI-Compile-0.210.0.ebuild
+++ b/dev-perl/CGI-Compile/CGI-Compile-0.210.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Compile .cgi scripts to a code reference like ModPerl::Registry"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/CGI-Compile/CGI-Compile-0.220.0.ebuild
+++ b/dev-perl/CGI-Compile/CGI-Compile-0.220.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Compile .cgi scripts to a code reference like ModPerl::Registry"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/CGI-Emulate-PSGI/CGI-Emulate-PSGI-0.220.0.ebuild
+++ b/dev-perl/CGI-Emulate-PSGI/CGI-Emulate-PSGI-0.220.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="PSGI adapter for CGI"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/CGI-FastTemplate/CGI-FastTemplate-1.90.0-r1.ebuild
+++ b/dev-perl/CGI-FastTemplate/CGI-FastTemplate-1.90.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,5 +10,5 @@ inherit perl-module
 DESCRIPTION="The Perl CGI::FastTemplate Module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""

--- a/dev-perl/CGI-Simple/CGI-Simple-1.115.0.ebuild
+++ b/dev-perl/CGI-Simple/CGI-Simple-1.115.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A Simple totally OO CGI interface that is CGI.pm compliant"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~hppa ppc ppc64 sparc x86"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Cache-Simple-TimedExpiry/Cache-Simple-TimedExpiry-0.270.0-r1.ebuild
+++ b/dev-perl/Cache-Simple-TimedExpiry/Cache-Simple-TimedExpiry-0.270.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A lightweight cache with timed expiration"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Canary-Stability/Canary-Stability-2006.ebuild
+++ b/dev-perl/Canary-Stability/Canary-Stability-2006.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Canary to check perl compatibility for schmorp's modules"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm ~hppa ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Canary-Stability/Canary-Stability-2011.0.0.ebuild
+++ b/dev-perl/Canary-Stability/Canary-Stability-2011.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Canary to check perl compatibility for schmorp's modules"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Carp-Assert-More/Carp-Assert-More-1.140.0.ebuild
+++ b/dev-perl/Carp-Assert-More/Carp-Assert-More-1.140.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="convenience wrappers around Carp::Assert"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="amd64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND="virtual/perl-Scalar-List-Utils

--- a/dev-perl/Carp-Assert/Carp-Assert-0.210.0.ebuild
+++ b/dev-perl/Carp-Assert/Carp-Assert-0.210.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Executable comments in carp"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="amd64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Carp-Clan/Carp-Clan-6.40.0-r1.ebuild
+++ b/dev-perl/Carp-Clan/Carp-Clan-6.40.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Report errors from perspective of caller of a clan of modules"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Carp-Clan/Carp-Clan-6.60.0.ebuild
+++ b/dev-perl/Carp-Clan/Carp-Clan-6.60.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Report errors from perspective of caller of a clan of modules"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ~ia64 ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Class-Accessor-Lite/Class-Accessor-Lite-0.80.0.ebuild
+++ b/dev-perl/Class-Accessor-Lite/Class-Accessor-Lite-0.80.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A minimalistic variant of Class::Accessor"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Class-Accessor/Class-Accessor-0.340.0-r1.ebuild
+++ b/dev-perl/Class-Accessor/Class-Accessor-0.340.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Automated accessor generation"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="dev-perl/Sub-Name"

--- a/dev-perl/Class-C3-XS/Class-C3-XS-0.130.0-r1.ebuild
+++ b/dev-perl/Class-C3-XS/Class-C3-XS-0.130.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="XS speedups for Class::C3"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86 ~x86-solaris"
+KEYWORDS="amd64 ppc sparc x86 ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Class-C3-XS/Class-C3-XS-0.140.0.ebuild
+++ b/dev-perl/Class-C3-XS/Class-C3-XS-0.140.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="XS speedups for Class::C3"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86 ~x86-solaris"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Class-C3/Class-C3-0.310.0.ebuild
+++ b/dev-perl/Class-C3/Class-C3-0.310.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A pragma to use the C3 method resolution order algortihm"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~ppc-aix ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86 ~ppc-aix ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Class-Container/Class-Container-0.120.0-r1.ebuild
+++ b/dev-perl/Class-Container/Class-Container-0.120.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Class-Container module for perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""
 
 RDEPEND=">=dev-perl/Params-Validate-0.24-r1

--- a/dev-perl/Class-Data-Inheritable/Class-Data-Inheritable-0.80.0-r1.ebuild
+++ b/dev-perl/Class-Data-Inheritable/Class-Data-Inheritable-0.80.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Inheritable, overridable class data"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 export OPTIMIZE="${CFLAGS}"

--- a/dev-perl/Class-Default/Class-Default-1.510.0-r1.ebuild
+++ b/dev-perl/Class-Default/Class-Default-1.510.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Static calls apply to a default instantiation"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ~ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ~mips ~ppc sparc x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Class-ErrorHandler/Class-ErrorHandler-0.30.0.ebuild
+++ b/dev-perl/Class-ErrorHandler/Class-ErrorHandler-0.30.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Automated accessor generation"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 DEPEND="

--- a/dev-perl/Class-ErrorHandler/Class-ErrorHandler-0.40.0.ebuild
+++ b/dev-perl/Class-ErrorHandler/Class-ErrorHandler-0.40.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Automated accessor generation"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Class-ISA/Class-ISA-0.36-r1.ebuild
+++ b/dev-perl/Class-ISA/Class-ISA-0.36-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ inherit perl-module
 DESCRIPTION="Report the search path thru an ISA tree"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~x86-solaris"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86 ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Class-Inspector/Class-Inspector-1.280.0-r1.ebuild
+++ b/dev-perl/Class-Inspector/Class-Inspector-1.280.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Provides information about Classes"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Class-Inspector/Class-Inspector-1.310.0.ebuild
+++ b/dev-perl/Class-Inspector/Class-Inspector-1.310.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Provides information about Classes"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-perl/Class-Load/Class-Load-0.200.0-r1.ebuild
+++ b/dev-perl/Class-Load/Class-Load-0.200.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A working (require q{Class::Name}) and more"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Class-Load/Class-Load-0.230.0.ebuild
+++ b/dev-perl/Class-Load/Class-Load-0.230.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A working (require q{Class::Name}) and more"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 sparc x86"
 IUSE="test"
 
 # uses Scalar-Util

--- a/dev-perl/Class-Load/Class-Load-0.240.0.ebuild
+++ b/dev-perl/Class-Load/Class-Load-0.240.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A working (require q{Class::Name}) and more"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 # uses Scalar-Util

--- a/dev-perl/Class-Loader/Class-Loader-2.30.0-r1.ebuild
+++ b/dev-perl/Class-Loader/Class-Loader-2.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Load modules and create objects on demand"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/Class-MakeMethods/Class-MakeMethods-1.10.0-r1.ebuild
+++ b/dev-perl/Class-MakeMethods/Class-MakeMethods-1.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Automated method creation module for Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc s390 sh sparc x86 ~ppc-aix ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ppc s390 sh sparc x86 ~ppc-aix ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Class-ReturnValue/Class-ReturnValue-0.550.0-r1.ebuild
+++ b/dev-perl/Class-ReturnValue/Class-ReturnValue-0.550.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="A return-value object that lets you treat it as as a boolean, array or object"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/Devel-StackTrace"

--- a/dev-perl/Class-Spiffy/Class-Spiffy-0.150.0-r1.ebuild
+++ b/dev-perl/Class-Spiffy/Class-Spiffy-0.150.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Spiffy Perl Interface Framework For You"
 
 SLOT="0"
-KEYWORDS="~amd64 hppa ia64 ~ppc ppc64 sparc x86"
+KEYWORDS="~amd64 hppa ~ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Class-Virtual/Class-Virtual-0.60.0-r1.ebuild
+++ b/dev-perl/Class-Virtual/Class-Virtual-0.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Base class for virtual base classes"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86 ~x86-solaris"
+KEYWORDS="amd64 ~ppc sparc x86 ~x86-solaris"
 IUSE=""
 
 RDEPEND="dev-perl/Class-Data-Inheritable

--- a/dev-perl/Class-Virtual/Class-Virtual-0.70.0.ebuild
+++ b/dev-perl/Class-Virtual/Class-Virtual-0.70.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Base class for virtual base classes"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86 ~x86-solaris"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~x86-solaris"
 IUSE="test"
 
 RDEPEND=">=dev-perl/Class-Data-Inheritable-0.20.0

--- a/dev-perl/Class-WhiteHole/Class-WhiteHole-0.40.0-r1.ebuild
+++ b/dev-perl/Class-WhiteHole/Class-WhiteHole-0.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="base class to treat unhandled method calls as errors"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc ppc64 sparc x86 ~x86-solaris"
+KEYWORDS="amd64 ~ppc ppc64 sparc x86 ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Class-XPath/Class-XPath-1.400.0-r1.ebuild
+++ b/dev-perl/Class-XPath/Class-XPath-1.400.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="adds xpath matching to object trees"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 sparc x86"
+KEYWORDS="amd64 sparc x86"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Clone/Clone-0.380.0.ebuild
+++ b/dev-perl/Clone/Clone-0.380.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Recursively copy Perl datatypes"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Clone/Clone-0.390.0.ebuild
+++ b/dev-perl/Clone/Clone-0.390.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Recursively copy Perl datatypes"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Compress-Bzip2/Compress-Bzip2-2.220.0.ebuild
+++ b/dev-perl/Compress-Bzip2/Compress-Bzip2-2.220.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Interface to Bzip2 compression library"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~mips sparc x86 ~ppc-aix"
+KEYWORDS="amd64 ~mips sparc x86 ~ppc-aix"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Compress-Bzip2/Compress-Bzip2-2.240.0.ebuild
+++ b/dev-perl/Compress-Bzip2/Compress-Bzip2-2.240.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Interface to Bzip2 compression library"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~mips ~sparc ~x86 ~ppc-aix"
+KEYWORDS="~amd64 ~mips ~sparc ~x86 ~ppc-aix"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Compress-Bzip2/Compress-Bzip2-2.260.0.ebuild
+++ b/dev-perl/Compress-Bzip2/Compress-Bzip2-2.260.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Interface to Bzip2 compression library"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~mips ~sparc ~x86 ~ppc-aix"
+KEYWORDS="~amd64 ~mips ~sparc ~x86 ~ppc-aix"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Config-ApacheFormat/Config-ApacheFormat-1.200.0-r1.ebuild
+++ b/dev-perl/Config-ApacheFormat/Config-ApacheFormat-1.200.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="use Apache format config files"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/Class-MethodMaker

--- a/dev-perl/Config-Simple/Config-Simple-4.590.0-r1.ebuild
+++ b/dev-perl/Config-Simple/Config-Simple-4.590.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Config::Simple - simple configuration file class"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ~ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
+KEYWORDS="amd64 ppc ~ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Config-Tiny/Config-Tiny-2.230.0.ebuild
+++ b/dev-perl/Config-Tiny/Config-Tiny-2.230.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Read/Write .ini style files with as little code as possible"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/ConfigReader/ConfigReader-0.500.0-r1.ebuild
+++ b/dev-perl/ConfigReader/ConfigReader-0.500.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ DESCRIPTION="Read directives from a configuration file"
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 src_install() {

--- a/dev-perl/Convert-ASCII-Armour/Convert-ASCII-Armour-1.400.0-r1.ebuild
+++ b/dev-perl/Convert-ASCII-Armour/Convert-ASCII-Armour-1.400.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Convert binary octets into ASCII armoured messages"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 RDEPEND="virtual/perl-IO-Compress

--- a/dev-perl/Convert-BinHex/Convert-BinHex-1.123.0-r1.ebuild
+++ b/dev-perl/Convert-BinHex/Convert-BinHex-1.123.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,5 +11,5 @@ DESCRIPTION="Extract data from Macintosh BinHex files"
 
 SLOT="0"
 LICENSE="GPL-1"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86"
 IUSE=""

--- a/dev-perl/Convert-BinHex/Convert-BinHex-1.125.0.ebuild
+++ b/dev-perl/Convert-BinHex/Convert-BinHex-1.125.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Extract data from Macintosh BinHex files"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Convert-UUlib/Convert-UUlib-1.400.0-r1.ebuild
+++ b/dev-perl/Convert-UUlib/Convert-UUlib-1.400.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="A Perl interface to the uulib library"
 
 LICENSE="Artistic GPL-2" # needs both
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 m68k ppc ppc64 s390 sh sparc x86"
+KEYWORDS="alpha amd64 arm hppa m68k ppc ppc64 s390 sh sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Convert-UUlib/Convert-UUlib-1.500.0-r1.ebuild
+++ b/dev-perl/Convert-UUlib/Convert-UUlib-1.500.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A Perl interface to the uulib library"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="system-uulib test"
 
 RDEPEND="

--- a/dev-perl/Cookie-Baker/Cookie-Baker-0.60.0.ebuild
+++ b/dev-perl/Cookie-Baker/Cookie-Baker-0.60.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Cookie string generator / parser"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Crypt-Blowfish/Crypt-Blowfish-2.140.0-r1.ebuild
+++ b/dev-perl/Crypt-Blowfish/Crypt-Blowfish-2.140.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Crypt::Blowfish module for perl"
 
 LICENSE="|| ( Artistic GPL-2 )"
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Crypt-CAST5_PP/Crypt-CAST5_PP-1.40.0-r1.ebuild
+++ b/dev-perl/Crypt-CAST5_PP/Crypt-CAST5_PP-1.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="CAST5 block cipher in pure Perl"
 
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="amd64 hppa ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Crypt-CBC/Crypt-CBC-2.330.0-r1.ebuild
+++ b/dev-perl/Crypt-CBC/Crypt-CBC-2.330.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Encrypt Data with Cipher Block Chaining Mode"
 
 LICENSE="Artistic"
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="virtual/perl-Digest-MD5"

--- a/dev-perl/Crypt-DES/Crypt-DES-2.70.0.ebuild
+++ b/dev-perl/Crypt-DES/Crypt-DES-2.70.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Crypt::DES module for perl"
 
 LICENSE="DES"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ~mips ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ~mips ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 export OPTIMIZE="${CFLAGS}"

--- a/dev-perl/Crypt-DES_EDE3/Crypt-DES_EDE3-0.10.0-r1.ebuild
+++ b/dev-perl/Crypt-DES_EDE3/Crypt-DES_EDE3-0.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Triple-DES EDE encryption/decryption"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 RDEPEND="dev-perl/Crypt-DES"

--- a/dev-perl/Crypt-IDEA/Crypt-IDEA-1.100.0.ebuild
+++ b/dev-perl/Crypt-IDEA/Crypt-IDEA-1.100.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Parse and save PGP packet streams"
 
 LICENSE="Crypt-IDEA"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Crypt-PasswdMD5/Crypt-PasswdMD5-1.400.0.ebuild
+++ b/dev-perl/Crypt-PasswdMD5/Crypt-PasswdMD5-1.400.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 
 DESCRIPTION="Provides interoperable MD5-based crypt() functions"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 ~arm ~mips ~ppc ~ppc64 ~sparc x86"
 
 DEPEND="dev-perl/Module-Build"
 

--- a/dev-perl/Crypt-Rijndael/Crypt-Rijndael-1.130.0.ebuild
+++ b/dev-perl/Crypt-Rijndael/Crypt-Rijndael-1.130.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Crypt::CBC compliant Rijndael encryption module"
 
 LICENSE="LGPL-3"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm hppa ia64 ~ppc ~ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm hppa ~ppc ~ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/Crypt-SSLeay/Crypt-SSLeay-0.720.0-r1.ebuild
+++ b/dev-perl/Crypt-SSLeay/Crypt-SSLeay-0.720.0-r1.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="OpenSSL support for LWP"
 
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="libressl test"
 
 RDEPEND="

--- a/dev-perl/Crypt-SSLeay/Crypt-SSLeay-0.720.0-r2.ebuild
+++ b/dev-perl/Crypt-SSLeay/Crypt-SSLeay-0.720.0-r2.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="OpenSSL support for LWP"
 
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="libressl test"
 
 RDEPEND="

--- a/dev-perl/Crypt-Twofish/Crypt-Twofish-2.170.0-r1.ebuild
+++ b/dev-perl/Crypt-Twofish/Crypt-Twofish-2.170.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="The Twofish Encryption Algorithm"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="amd64 ~ppc ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Curses/Curses-1.320.0.ebuild
+++ b/dev-perl/Curses/Curses-1.320.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Curses interface modules for Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 ~s390 ~sh sparc x86 ~sparc-solaris ~x86-solaris"
 IUSE="+unicode"
 
 DEPEND=">=sys-libs/ncurses-5:0=[unicode?]"

--- a/dev-perl/Curses/Curses-1.330.0.ebuild
+++ b/dev-perl/Curses/Curses-1.330.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Curses interface modules for Perl"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-solaris ~x86-solaris"
 IUSE="+unicode"
 
 DEPEND=">=sys-libs/ncurses-5:0=[unicode?]"

--- a/dev-perl/Curses/Curses-1.360.0.ebuild
+++ b/dev-perl/Curses/Curses-1.360.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Curses interface modules for Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ~ia64 ppc ppc64 ~s390 ~sh sparc x86 ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 ~s390 ~sh sparc x86 ~sparc-solaris ~x86-solaris"
 IUSE="+unicode test"
 
 RDEPEND=">=sys-libs/ncurses-5:0=[unicode?]

--- a/dev-perl/CursesWidgets/CursesWidgets-1.997.0-r1.ebuild
+++ b/dev-perl/CursesWidgets/CursesWidgets-1.997.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -13,7 +13,7 @@ SRC_URI+=" http://www.digitalmages.com/perl/CursesWidgets/downloads/${PN}-${MODU
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="amd64 ia64 ppc s390 sparc x86"
+KEYWORDS="amd64 ppc s390 sparc x86"
 IUSE=""
 
 RDEPEND=">=sys-libs/ncurses-5

--- a/dev-perl/DBIx-ContextualFetch/DBIx-ContextualFetch-1.30.0-r1.ebuild
+++ b/dev-perl/DBIx-ContextualFetch/DBIx-ContextualFetch-1.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Add contextual fetches to DBI"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc ppc64 sparc x86 ~x86-solaris"
+KEYWORDS="amd64 ~ppc ppc64 sparc x86 ~x86-solaris"
 IUSE="test"
 
 RDEPEND=">=dev-perl/DBI-1.37"

--- a/dev-perl/Daemon-Generic/Daemon-Generic-0.840.0.ebuild
+++ b/dev-perl/Daemon-Generic/Daemon-Generic-0.840.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Framework to provide start/stop/reload for a daemon"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Data-Buffer/Data-Buffer-0.40.0-r1.ebuild
+++ b/dev-perl/Data-Buffer/Data-Buffer-0.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Read/write buffer class"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/Data-DumpXML/Data-DumpXML-1.60.0-r1.ebuild
+++ b/dev-perl/Data-DumpXML/Data-DumpXML-1.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Dump arbitrary data structures as XML"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86 ~sparc-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86 ~sparc-solaris"
 IUSE=""
 
 RDEPEND=">=virtual/perl-MIME-Base64-2

--- a/dev-perl/Data-Hierarchy/Data-Hierarchy-0.340.0-r1.ebuild
+++ b/dev-perl/Data-Hierarchy/Data-Hierarchy-0.340.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Data::Hierarchy - Handle data in a hierarchical structure"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~mips ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ~mips ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Data-ShowTable/Data-ShowTable-4.600.0.ebuild
+++ b/dev-perl/Data-ShowTable/Data-ShowTable-4.600.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="routines to display tabular data in several formats"
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/Data-Structure-Util/Data-Structure-Util-0.150.0.ebuild
+++ b/dev-perl/Data-Structure-Util/Data-Structure-Util-0.150.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Change nature of data within a structure"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Date-Calc/Date-Calc-6.400.0.ebuild
+++ b/dev-perl/Date-Calc/Date-Calc-6.400.0.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Gregorian calendar date calculations"
 
 LICENSE="${LICENSE} LGPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 ~s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Date-Pcalc/Date-Pcalc-6.100.0-r1.ebuild
+++ b/dev-perl/Date-Pcalc/Date-Pcalc-6.100.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Gregorian calendar date calculations"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm64 ~hppa ~ia64 ~m68k ppc ~ppc64 ~s390 ~sh ~sparc x86"
+KEYWORDS="~alpha amd64 ~arm64 ~hppa ~m68k ppc ~ppc64 ~s390 ~sh ~sparc x86"
 IUSE=""
 
 DEPEND=">=dev-perl/Bit-Vector-7

--- a/dev-perl/DelimMatch/DelimMatch-1.06-r1.ebuild
+++ b/dev-perl/DelimMatch/DelimMatch-1.06-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://search.cpan.org/~nwalsh/"
 
 LICENSE="|| ( Artistic GPL-1+ )"
 SLOT="0"
-KEYWORDS="alpha amd64 ~hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ~hppa ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Devel-GlobalDestruction/Devel-GlobalDestruction-0.140.0.ebuild
+++ b/dev-perl/Devel-GlobalDestruction/Devel-GlobalDestruction-0.140.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION='Returns the equivalent of ${^GLOBAL_PHASE} eq DESTRUCT for older perls'
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~x86-fbsd ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~x86-fbsd ~x86-solaris"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Devel-Leak/Devel-Leak-0.30.0.ebuild
+++ b/dev-perl/Devel-Leak/Devel-Leak-0.30.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,6 +10,6 @@ inherit perl-module
 DESCRIPTION="Utility for looking for perl objects that are not reclaimed"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/Devel-StackTrace-AsHTML/Devel-StackTrace-AsHTML-0.150.0.ebuild
+++ b/dev-perl/Devel-StackTrace-AsHTML/Devel-StackTrace-AsHTML-0.150.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Displays stack trace in HTML"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Devel-Symdump/Devel-Symdump-2.150.0.ebuild
+++ b/dev-perl/Devel-Symdump/Devel-Symdump-2.150.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit versionator perl-module
 DESCRIPTION="Dump symbol names or the symbol table"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Devel-Symdump/Devel-Symdump-2.170.0.ebuild
+++ b/dev-perl/Devel-Symdump/Devel-Symdump-2.170.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit versionator perl-module
 DESCRIPTION="Dump symbol names or the symbol table"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Devel-Symdump/Devel-Symdump-2.180.0.ebuild
+++ b/dev-perl/Devel-Symdump/Devel-Symdump-2.180.0.ebuild
@@ -10,7 +10,7 @@ inherit versionator perl-module
 DESCRIPTION="Dump symbol names or the symbol table"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Device-SerialPort/Device-SerialPort-1.40.0-r1.ebuild
+++ b/dev-perl/Device-SerialPort/Device-SerialPort-1.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A Serial port Perl Module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ~mips ppc sparc x86"
+KEYWORDS="alpha amd64 ~arm hppa ~mips ppc sparc x86"
 IUSE=""
 
 #From the module:

--- a/dev-perl/Digest-MD2/Digest-MD2-2.30.0-r1.ebuild
+++ b/dev-perl/Digest-MD2/Digest-MD2-2.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl interface to the MD2 Algorithm"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/Digest-Nilsimsa/Digest-Nilsimsa-0.60.0-r1.ebuild
+++ b/dev-perl/Digest-Nilsimsa/Digest-Nilsimsa-0.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,5 +11,5 @@ DESCRIPTION="Digest::Nilsimsa - Perl version of Nilsimsa code"
 
 LICENSE="GPL-2 LGPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""

--- a/dev-perl/Email-Address/Email-Address-1.907.0.ebuild
+++ b/dev-perl/Email-Address/Email-Address-1.907.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="RFC 2822 Address Parsing and Creation"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Email-Address/Email-Address-1.908.0.ebuild
+++ b/dev-perl/Email-Address/Email-Address-1.908.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="RFC 2822 Address Parsing and Creation"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Email-Date-Format/Email-Date-Format-1.2.0-r1.ebuild
+++ b/dev-perl/Email-Date-Format/Email-Date-Format-1.2.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Produce RFC 822 date strings"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Email-Date-Format/Email-Date-Format-1.5.0.ebuild
+++ b/dev-perl/Email-Date-Format/Email-Date-Format-1.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Produce RFC 822 date strings"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Email-FolderType/Email-FolderType-0.814.0.ebuild
+++ b/dev-perl/Email-FolderType/Email-FolderType-0.814.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Determine the type of a mail folder"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND="dev-perl/Module-Pluggable"

--- a/dev-perl/Email-MIME-Encodings/Email-MIME-Encodings-1.315.0-r1.ebuild
+++ b/dev-perl/Email-MIME-Encodings/Email-MIME-Encodings-1.315.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A unified interface to MIME encoding and decoding"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86 ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=">=virtual/perl-MIME-Base64-3.07"

--- a/dev-perl/Encode-compat/Encode-compat-0.70.0-r1.ebuild
+++ b/dev-perl/Encode-compat/Encode-compat-0.70.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Encode.pm emulation layer"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 LICENSE="Artistic"
 

--- a/dev-perl/Eval-LineNumbers/Eval-LineNumbers-0.340.0.ebuild
+++ b/dev-perl/Eval-LineNumbers/Eval-LineNumbers-0.340.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ DESCRIPTION="Add line numbers to hereis blocks that contain perl source code"
 
 LICENSE="|| ( Artistic GPL-1 GPL-2 GPL-3 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Event-RPC/Event-RPC-1.50.0.ebuild
+++ b/dev-perl/Event-RPC/Event-RPC-1.50.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Event based transparent Client/Server RPC framework"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="|| ( dev-perl/Event dev-perl/glib-perl )

--- a/dev-perl/Event-RPC/Event-RPC-1.80.0.ebuild
+++ b/dev-perl/Event-RPC/Event-RPC-1.80.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Event based transparent Client/Server RPC framework"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 # Note: Storable not listed in final alternation like it is

--- a/dev-perl/Event/Event-1.240.0.ebuild
+++ b/dev-perl/Event/Event-1.240.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Fast, generic event loop"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ppc ppc64 sparc x86 ~x86-solaris"
+KEYWORDS="alpha amd64 arm ppc ppc64 sparc x86 ~x86-solaris"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/Event/Event-1.260.0.ebuild
+++ b/dev-perl/Event/Event-1.260.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Fast, generic event loop"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-solaris"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/Exception-Class/Exception-Class-1.390.0.ebuild
+++ b/dev-perl/Exception-Class/Exception-Class-1.390.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A module that allows you to declare real exception classes in Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Exception-Class/Exception-Class-1.410.0.ebuild
+++ b/dev-perl/Exception-Class/Exception-Class-1.410.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="A module that allows you to declare real exception classes in Perl"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Exception-Class/Exception-Class-1.420.0.ebuild
+++ b/dev-perl/Exception-Class/Exception-Class-1.420.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="A module that allows you to declare real exception classes in Perl"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Exporter-Cluster/Exporter-Cluster-0.310.0-r1.ebuild
+++ b/dev-perl/Exporter-Cluster/Exporter-Cluster-0.310.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Extension for easy multiple module imports"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 x86"
+KEYWORDS="amd64 x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Exporter-Lite/Exporter-Lite-0.20.0-r1.ebuild
+++ b/dev-perl/Exporter-Lite/Exporter-Lite-0.20.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Lightweight exporting of variables"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc sparc x86 ~x86-linux ~ppc-macos ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc sparc x86 ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Exporter-Lite/Exporter-Lite-0.80.0.ebuild
+++ b/dev-perl/Exporter-Lite/Exporter-Lite-0.80.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Lightweight exporting of variables"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~mips ~ppc ~sparc ~x86 ~x86-linux ~ppc-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~hppa ~mips ~ppc ~sparc ~x86 ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/ExtUtils-AutoInstall/ExtUtils-AutoInstall-0.630.0-r1.ebuild
+++ b/dev-perl/ExtUtils-AutoInstall/ExtUtils-AutoInstall-0.630.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Allows module writers to specify a more sophisticated form of dependency information"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 # TESTS BAD. Wants to write to cpan's config on the live system

--- a/dev-perl/ExtUtils-Config/ExtUtils-Config-0.7.0.ebuild
+++ b/dev-perl/ExtUtils-Config/ExtUtils-Config-0.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 EAPI=5
 MODULE_AUTHOR=LEONT
@@ -8,7 +8,7 @@ inherit perl-module
 DESCRIPTION='A wrapper for perl'\''s configuration'
 LICENSE=" || ( Artistic GPL-2 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ~ia64 ppc ~ppc64 ~sparc x86"
+KEYWORDS="alpha amd64 arm hppa ppc ~ppc64 ~sparc x86"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/ExtUtils-Config/ExtUtils-Config-0.8.0.ebuild
+++ b/dev-perl/ExtUtils-Config/ExtUtils-Config-0.8.0.ebuild
@@ -7,7 +7,7 @@ inherit perl-module
 
 DESCRIPTION="A wrapper for perl's configuration"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 ~arm ~hppa ppc ppc64 ~sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/ExtUtils-F77/ExtUtils-F77-1.180.0.ebuild
+++ b/dev-perl/ExtUtils-F77/ExtUtils-F77-1.180.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Facilitate use of FORTRAN from Perl/XS code"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="alpha amd64 arm hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/ExtUtils-F77/ExtUtils-F77-1.190.0.ebuild
+++ b/dev-perl/ExtUtils-F77/ExtUtils-F77-1.190.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Facilitate use of FORTRAN from Perl/XS code"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/ExtUtils-F77/ExtUtils-F77-1.200.0.ebuild
+++ b/dev-perl/ExtUtils-F77/ExtUtils-F77-1.200.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Facilitate use of FORTRAN from Perl/XS code"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND="virtual/perl-File-Spec"

--- a/dev-perl/ExtUtils-Helpers/ExtUtils-Helpers-0.22.0.ebuild
+++ b/dev-perl/ExtUtils-Helpers/ExtUtils-Helpers-0.22.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 EAPI=5
 MODULE_AUTHOR=LEONT
@@ -8,7 +8,7 @@ inherit perl-module
 DESCRIPTION='Various portability utilities for module builders'
 LICENSE=" || ( Artistic GPL-2 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ~ia64 ppc ~ppc64 ~sparc x86"
+KEYWORDS="alpha amd64 arm hppa ppc ~ppc64 ~sparc x86"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/ExtUtils-Helpers/ExtUtils-Helpers-0.26.0.ebuild
+++ b/dev-perl/ExtUtils-Helpers/ExtUtils-Helpers-0.26.0.ebuild
@@ -7,7 +7,7 @@ inherit perl-module
 
 DESCRIPTION="Various portability utilities for module builders"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 ~arm ~hppa ppc ppc64 ~sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/ExtUtils-InstallPaths/ExtUtils-InstallPaths-0.10.0.ebuild
+++ b/dev-perl/ExtUtils-InstallPaths/ExtUtils-InstallPaths-0.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 EAPI=5
 MODULE_AUTHOR=LEONT
@@ -8,7 +8,7 @@ inherit perl-module
 DESCRIPTION='Build.PL install path logic made easy'
 LICENSE=" || ( Artistic GPL-2 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ~ia64 ppc ~ppc64 ~sparc x86"
+KEYWORDS="alpha amd64 arm hppa ppc ~ppc64 ~sparc x86"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/ExtUtils-InstallPaths/ExtUtils-InstallPaths-0.11.0.ebuild
+++ b/dev-perl/ExtUtils-InstallPaths/ExtUtils-InstallPaths-0.11.0.ebuild
@@ -7,7 +7,7 @@ inherit perl-module
 
 DESCRIPTION="Build.PL install path logic made easy"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 ~arm ~hppa ppc ppc64 ~sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/ExtUtils-XSBuilder/ExtUtils-XSBuilder-0.280.0-r1.ebuild
+++ b/dev-perl/ExtUtils-XSBuilder/ExtUtils-XSBuilder-0.280.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Modules to parse C header files and create XS glue code"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/Parse-RecDescent

--- a/dev-perl/FCGI-ProcManager/FCGI-ProcManager-0.250.0.ebuild
+++ b/dev-perl/FCGI-ProcManager/FCGI-ProcManager-0.250.0.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="A FastCGI process manager"
 
 SLOT="0"
 LICENSE="LGPL-2.1"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/FCGI-ProcManager/FCGI-ProcManager-0.280.0.ebuild
+++ b/dev-perl/FCGI-ProcManager/FCGI-ProcManager-0.280.0.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="A FastCGI process manager"
 
 SLOT="0"
 LICENSE="LGPL-2.1"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/FCGI/FCGI-0.770.0.ebuild
+++ b/dev-perl/FCGI/FCGI-0.770.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Fast CGI module"
 
 LICENSE="FastCGI"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ppc ~ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd"
+KEYWORDS="~alpha amd64 ~arm ~hppa ppc ~ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Festival-Client-Async/Festival-Client-Async-0.30.300-r1.ebuild
+++ b/dev-perl/Festival-Client-Async/Festival-Client-Async-0.30.300-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,5 +10,5 @@ inherit perl-module
 DESCRIPTION="Festival-Async -  Non-blocking interface to a Festival server"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 sparc x86"
+KEYWORDS="amd64 sparc x86"
 IUSE=""

--- a/dev-perl/File-Copy-Recursive/File-Copy-Recursive-0.380.0-r1.ebuild
+++ b/dev-perl/File-Copy-Recursive/File-Copy-Recursive-0.380.0-r1.ebuild
@@ -10,6 +10,6 @@ inherit perl-module
 DESCRIPTION="uses File::Copy to recursively copy dirs"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 SRC_TEST="do"

--- a/dev-perl/File-Flock/File-Flock-2014.10.0.ebuild
+++ b/dev-perl/File-Flock/File-Flock-2014.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="flock() wrapper.  Auto-create locks"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE="test"
 
 SRC_TEST="do"

--- a/dev-perl/File-HomeDir/File-HomeDir-1.0.0-r1.ebuild
+++ b/dev-perl/File-HomeDir/File-HomeDir-1.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Get home directory for self or other user"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~hppa ia64 ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~hppa ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="+xdg"
 
 RDEPEND="virtual/perl-File-Spec

--- a/dev-perl/File-HomeDir/File-HomeDir-1.2.0.ebuild
+++ b/dev-perl/File-HomeDir/File-HomeDir-1.2.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Get home directory for self or other user"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~x86-fbsd ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~x86-fbsd ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="+xdg test"
 
 RDEPEND="

--- a/dev-perl/File-MMagic/File-MMagic-1.300.0-r1.ebuild
+++ b/dev-perl/File-MMagic/File-MMagic-1.300.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,5 +12,5 @@ SRC_TEST="do"
 
 SLOT="0"
 LICENSE="File-MMagic"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86 ~x86-fbsd"
 IUSE=""

--- a/dev-perl/File-NCopy/File-NCopy-0.360.0-r1.ebuild
+++ b/dev-perl/File-NCopy/File-NCopy-0.360.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Copy file, file Copy file[s] | dir[s], dir"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="virtual/perl-File-Spec"

--- a/dev-perl/File-Path-Expand/File-Path-Expand-1.20.0-r1.ebuild
+++ b/dev-perl/File-Path-Expand/File-Path-Expand-1.20.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Expand filenames"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/File-ReadBackwards/File-ReadBackwards-1.50.0-r1.ebuild
+++ b/dev-perl/File-ReadBackwards/File-ReadBackwards-1.50.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="The Perl File-ReadBackwards Module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~ppc ppc64 sparc x86 ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~ppc ppc64 sparc x86 ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/File-Remove/File-Remove-1.520.0-r1.ebuild
+++ b/dev-perl/File-Remove/File-Remove-1.520.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Remove files and directories"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ~arm arm64 hppa m68k ~mips ppc ppc64 s390 sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND=">=virtual/perl-File-Spec-0.84"

--- a/dev-perl/File-Remove/File-Remove-1.550.0.ebuild
+++ b/dev-perl/File-Remove/File-Remove-1.550.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Remove files and directories"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/File-Remove/File-Remove-1.570.0.ebuild
+++ b/dev-perl/File-Remove/File-Remove-1.570.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Remove files and directories"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ~arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ~arm ~arm64 hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/File-RsyncP/File-RsyncP-0.740.0.ebuild
+++ b/dev-perl/File-RsyncP/File-RsyncP-0.740.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ HOMEPAGE="http://perlrsync.sourceforge.net/ ${HOMEPAGE}"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~arm ia64 ~ppc ~ppc64 sparc x86"
+KEYWORDS="amd64 ~arm ~ppc ~ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="net-misc/rsync"

--- a/dev-perl/File-Share/File-Share-0.250.0.ebuild
+++ b/dev-perl/File-Share/File-Share-0.250.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Extend File::ShareDir to local libraries"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
 IUSE="test"
 
 RDEPEND=">=dev-perl/File-ShareDir-1.30.0"

--- a/dev-perl/File-ShareDir-Install/File-ShareDir-Install-0.110.0.ebuild
+++ b/dev-perl/File-ShareDir-Install/File-ShareDir-Install-0.110.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Install shared files"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 arm hppa ~ia64 ppc ~ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 arm hppa ppc ~ppc64 ~sparc x86"
 IUSE="test"
 
 PERL_RM_FILES=( "Build.PL" ) # Using MBTiny is stupid this high up

--- a/dev-perl/File-ShareDir/File-ShareDir-1.102.0.ebuild
+++ b/dev-perl/File-ShareDir/File-ShareDir-1.102.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Locate per-dist and per-module shared files"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 hppa ~ia64 ~ppc ~ppc64 ~sparc x86 ~ppc-aix ~x86-solaris"
+KEYWORDS="~alpha amd64 hppa ~ppc ~ppc64 ~sparc x86 ~ppc-aix ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/File-Slurp-Tiny/File-Slurp-Tiny-0.4.0.ebuild
+++ b/dev-perl/File-Slurp-Tiny/File-Slurp-Tiny-0.4.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A simple, sane and efficient file slurper"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/File-Slurp/File-Slurp-9999.190.0-r1.ebuild
+++ b/dev-perl/File-Slurp/File-Slurp-9999.190.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Efficient Reading/Writing of Complete Files"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm arm64 hppa m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/File-Slurper/File-Slurper-0.0.800.ebuild
+++ b/dev-perl/File-Slurper/File-Slurper-0.0.800.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A simple, sane and efficient module to slurp a file"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ppc ~ppc64 ~s390 ~sh ~sparc x86"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~m68k ppc ~ppc64 ~s390 ~sh ~sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/File-Slurper/File-Slurper-0.9.0.ebuild
+++ b/dev-perl/File-Slurper/File-Slurper-0.9.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="A simple, sane and efficient module to slurp a file"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/File-Sync/File-Sync-0.110.0.ebuild
+++ b/dev-perl/File-Sync/File-Sync-0.110.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl access to fsync() and sync() function calls"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/File-Tail/File-Tail-1.200.0.ebuild
+++ b/dev-perl/File-Tail/File-Tail-1.200.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl extension for reading from continously updated files"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/File-Tail/File-Tail-1.300.0.ebuild
+++ b/dev-perl/File-Tail/File-Tail-1.300.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl extension for reading from continously updated files"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/File-Tempdir/File-Tempdir-0.20.0-r1.ebuild
+++ b/dev-perl/File-Tempdir/File-Tempdir-0.20.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="This module provide an object interface to tempdir() from File::Temp"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/File-Type/File-Type-0.220.0-r1.ebuild
+++ b/dev-perl/File-Type/File-Type-0.220.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Determine file type using magic"
 
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 hppa ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/File-chmod/File-chmod-0.420.0.ebuild
+++ b/dev-perl/File-chmod/File-chmod-0.420.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Implements symbolic and ls chmod modes"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86 ~amd64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ppc sparc x86 ~amd64-linux ~x86-linux ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/FileHandle-Unget/FileHandle-Unget-0.162.800.ebuild
+++ b/dev-perl/FileHandle-Unget/FileHandle-Unget-0.162.800.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="A FileHandle which supports ungetting of multiple bytes"
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE="test"
 
 RDEPEND=">=virtual/perl-Scalar-List-Utils-1.140.0"

--- a/dev-perl/Filesys-Notify-Simple/Filesys-Notify-Simple-0.120.0.ebuild
+++ b/dev-perl/Filesys-Notify-Simple/Filesys-Notify-Simple-0.120.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Simple and dumb file system watcher"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="dev-perl/Filter"

--- a/dev-perl/Font-AFM/Font-AFM-1.200.0-r1.ebuild
+++ b/dev-perl/Font-AFM/Font-AFM-1.200.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Parse Adobe Font Metric files"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/FreezeThaw/FreezeThaw-0.500.100-r1.ebuild
+++ b/dev-perl/FreezeThaw/FreezeThaw-0.500.100-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="converting Perl structures to strings and back"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/GD-Graph3d/GD-Graph3d-0.630.0-r1.ebuild
+++ b/dev-perl/GD-Graph3d/GD-Graph3d-0.630.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Create 3D Graphs with GD and GD::Graph"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ia64 ppc ppc64 sparc x86 ~x86-fbsd ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm ppc ppc64 sparc x86 ~x86-fbsd ~x86-solaris"
 IUSE=""
 
 RDEPEND=">=dev-perl/GD-1.18

--- a/dev-perl/GDGraph/GDGraph-1.490.0.ebuild
+++ b/dev-perl/GDGraph/GDGraph-1.490.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl5 module to create charts using the GD module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ia64 ppc ppc64 sparc x86 ~x86-fbsd ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm ppc ppc64 sparc x86 ~x86-fbsd ~x86-solaris"
 IUSE=""
 
 RDEPEND="dev-perl/GDTextUtil

--- a/dev-perl/GDGraph/GDGraph-1.510.0.ebuild
+++ b/dev-perl/GDGraph/GDGraph-1.510.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl5 module to create charts using the GD module"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/GDGraph/GDGraph-1.520.0.ebuild
+++ b/dev-perl/GDGraph/GDGraph-1.520.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl5 module to create charts using the GD module"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/GDGraph/GDGraph-1.540.0.ebuild
+++ b/dev-perl/GDGraph/GDGraph-1.540.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl5 module to create charts using the GD module"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/GDTextUtil/GDTextUtil-0.860.0-r1.ebuild
+++ b/dev-perl/GDTextUtil/GDTextUtil-0.860.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Text utilities for use with GD"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ia64 ppc ppc64 sparc x86 ~x86-fbsd ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm ppc ppc64 sparc x86 ~x86-fbsd ~x86-solaris"
 IUSE=""
 
 RDEPEND="dev-perl/GD"

--- a/dev-perl/Gentoo-PerlMod-Version/Gentoo-PerlMod-Version-0.8.1.ebuild
+++ b/dev-perl/Gentoo-PerlMod-Version/Gentoo-PerlMod-Version-0.8.1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Convert arbitrary Perl Modules' versions into normalised Gentoo versions"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm ~mips ppc ppc64 sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Getopt-ArgvFile/Getopt-ArgvFile-1.110.0-r1.ebuild
+++ b/dev-perl/Getopt-ArgvFile/Getopt-ArgvFile-1.110.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="This module is a simple supplement to other option handling modules
 
 SLOT="0"
 LICENSE="|| ( Artistic Artistic-2 )" # Artistic+
-KEYWORDS="amd64 ia64 ppc ~ppc64 sparc x86"
+KEYWORDS="amd64 ppc ~ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Getopt-Mixed/Getopt-Mixed-1.120.0.ebuild
+++ b/dev-perl/Getopt-Mixed/Getopt-Mixed-1.120.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Getopt::Mixed is used for parsing mixed options"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Graph/Graph-0.970.400.ebuild
+++ b/dev-perl/Graph/Graph-0.970.400.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Data structure and ops for directed graphs"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Gtk2-Ex-Simple-List/Gtk2-Ex-Simple-List-0.500.0-r1.ebuild
+++ b/dev-perl/Gtk2-Ex-Simple-List/Gtk2-Ex-Simple-List-0.500.0-r1.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="A simple interface to Gtk2's complex MVC list widget"
 
 LICENSE="|| ( LGPL-2.1 LGPL-3 )" # LGPL-2.1+
 SLOT="0"
-KEYWORDS="amd64 ia64 sparc x86"
+KEYWORDS="amd64 sparc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/HTML-Clean/HTML-Clean-0.800.0-r1.ebuild
+++ b/dev-perl/HTML-Clean/HTML-Clean-0.800.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Cleans up HTML code for web browsers, not humans"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 s390 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 s390 sparc x86"
 IUSE=""
 
 RDEPEND="!<app-text/html-xml-utils-5.3"

--- a/dev-perl/HTML-Form/HTML-Form-6.30.0-r1.ebuild
+++ b/dev-perl/HTML-Form/HTML-Form-6.30.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Class that represents an HTML form element"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/HTML-HTMLDoc/HTML-HTMLDoc-0.100.0-r1.ebuild
+++ b/dev-perl/HTML-HTMLDoc/HTML-HTMLDoc-0.100.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl interface to the htmldoc program for producing PDF-Files from HTML-Content"
 
 SLOT="0"
-KEYWORDS="amd64 ~arm ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~arm ~ppc sparc x86"
 IUSE=""
 
 RDEPEND="app-text/htmldoc"

--- a/dev-perl/HTML-LinkExtractor/HTML-LinkExtractor-0.130.0-r1.ebuild
+++ b/dev-perl/HTML-LinkExtractor/HTML-LinkExtractor-0.130.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A bare-bones HTML parser, similar to HTML::Parser, but with a couple important distinctions"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 DEPEND="dev-perl/HTML-Parser"

--- a/dev-perl/HTML-SimpleParse/HTML-SimpleParse-0.120.0-r1.ebuild
+++ b/dev-perl/HTML-SimpleParse/HTML-SimpleParse-0.120.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A bare-bones HTML parser, similar to HTML::Parser, but with a couple important distinctions"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/HTML-Strip/HTML-Strip-2.90.0.ebuild
+++ b/dev-perl/HTML-Strip/HTML-Strip-2.90.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Extension for stripping HTML markup from text"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc ppc64 sparc x86"
+KEYWORDS="amd64 ~ppc ppc64 sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/HTML-Table/HTML-Table-2.08a-r1.ebuild
+++ b/dev-perl/HTML-Table/HTML-Table-2.08a-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ DESCRIPTION="produces HTML tables"
 
 LICENSE="|| ( Artistic GPL-2 )"
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc ~ppc64 sparc x86"
+KEYWORDS="amd64 ~ppc ~ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/HTML-TokeParser-Simple/HTML-TokeParser-Simple-3.160.0-r1.ebuild
+++ b/dev-perl/HTML-TokeParser-Simple/HTML-TokeParser-Simple-3.160.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Easy to use HTML::TokeParser interface"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ~ppc64 sparc x86 ~amd64-linux ~arm-linux ~x86-linux"
+KEYWORDS="amd64 ppc ~ppc64 sparc x86 ~amd64-linux ~arm-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-perl/HTML-Parser-3.25"

--- a/dev-perl/HTTP-Body/HTTP-Body-1.220.0.ebuild
+++ b/dev-perl/HTTP-Body/HTTP-Body-1.220.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="HTTP Body Parser"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 # HTTP::Headers -> HTTP-Message

--- a/dev-perl/HTTP-Cache-Transparent/HTTP-Cache-Transparent-1.100.0-r1.ebuild
+++ b/dev-perl/HTTP-Cache-Transparent/HTTP-Cache-Transparent-1.100.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Cache the result of http get-requests persistently"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE="test"
 
 RDEPEND="dev-perl/libwww-perl

--- a/dev-perl/HTTP-Cache-Transparent/HTTP-Cache-Transparent-1.400.0.ebuild
+++ b/dev-perl/HTTP-Cache-Transparent/HTTP-Cache-Transparent-1.400.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Cache the result of http get-requests persistently"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="dev-perl/libwww-perl

--- a/dev-perl/HTTP-Headers-Fast/HTTP-Headers-Fast-0.200.0.ebuild
+++ b/dev-perl/HTTP-Headers-Fast/HTTP-Headers-Fast-0.200.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Faster implementation of HTTP::Headers"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/HTTP-Headers-Fast/HTTP-Headers-Fast-0.210.0.ebuild
+++ b/dev-perl/HTTP-Headers-Fast/HTTP-Headers-Fast-0.210.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Faster implementation of HTTP::Headers"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/HTTP-Request-AsCGI/HTTP-Request-AsCGI-1.200.0.ebuild
+++ b/dev-perl/HTTP-Request-AsCGI/HTTP-Request-AsCGI-1.200.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Set up a CGI environment from an HTTP::Request"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="examples"
 
 RDEPEND="

--- a/dev-perl/HTTP-Response-Encoding/HTTP-Response-Encoding-0.60.0-r1.ebuild
+++ b/dev-perl/HTTP-Response-Encoding/HTTP-Response-Encoding-0.60.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Adds encoding() to HTTP::Response"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="test"
 
 RDEPEND="dev-perl/libwww-perl"

--- a/dev-perl/HTTP-Server-Simple-PSGI/HTTP-Server-Simple-PSGI-0.160.0.ebuild
+++ b/dev-perl/HTTP-Server-Simple-PSGI/HTTP-Server-Simple-PSGI-0.160.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="PSGI handler for HTTP::Server::Simple"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/HTTP-Server-Simple/HTTP-Server-Simple-0.510.0.ebuild
+++ b/dev-perl/HTTP-Server-Simple/HTTP-Server-Simple-0.510.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Lightweight HTTP Server"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~alpha amd64 ~arm ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/HTTP-Server-Simple/HTTP-Server-Simple-0.520.0.ebuild
+++ b/dev-perl/HTTP-Server-Simple/HTTP-Server-Simple-0.520.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Lightweight HTTP Server"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~alpha amd64 ~arm ~ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/HTTPD-User-Manage/HTTPD-User-Manage-1.660.0-r1.ebuild
+++ b/dev-perl/HTTPD-User-Manage/HTTPD-User-Manage-1.660.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl module for managing access control of web servers"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 sparc x86"
+KEYWORDS="amd64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Hash-MultiValue/Hash-MultiValue-0.160.0.ebuild
+++ b/dev-perl/Hash-MultiValue/Hash-MultiValue-0.160.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Store multiple values per key"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc x86"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Heap/Heap-0.800.0-r1.ebuild
+++ b/dev-perl/Heap/Heap-0.800.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,5 +10,5 @@ inherit perl-module
 DESCRIPTION="Heap - Perl extensions for keeping data partially sorted"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE=""

--- a/dev-perl/IO-All/IO-All-0.860.0.ebuild
+++ b/dev-perl/IO-All/IO-All-0.860.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="unified IO operations"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ~sparc x86"
+KEYWORDS="~alpha amd64 arm ~hppa ppc ~sparc x86"
 IUSE=""
 
 # needs Scalar::Util

--- a/dev-perl/IO-Event/IO-Event-0.813.0.ebuild
+++ b/dev-perl/IO-Event/IO-Event-0.813.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Tied Filehandles for Nonblocking IO with Object Callbacks"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/IO-Handle-Util/IO-Handle-Util-0.10.0.ebuild
+++ b/dev-perl/IO-Handle-Util/IO-Handle-Util-0.10.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Functions for working with IO::Handle like objects"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/IO-Multiplex/IO-Multiplex-1.160.0.ebuild
+++ b/dev-perl/IO-Multiplex/IO-Multiplex-1.160.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Manage IO on many file handles "
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 sparc x86 ~x86-fbsd"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/IO-Tee/IO-Tee-0.640.0-r1.ebuild
+++ b/dev-perl/IO-Tee/IO-Tee-0.640.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Multiplex output to multiple output handles"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/IO-Tty/IO-Tty-1.120.0.ebuild
+++ b/dev-perl/IO-Tty/IO-Tty-1.120.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="IO::Tty and IO::Pty modules for Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/IPC-Run/IPC-Run-0.940.0.ebuild
+++ b/dev-perl/IPC-Run/IPC-Run-0.940.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="system() and background procs w/ piping, redirs, ptys"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86 ~x86-linux"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86 ~x86-linux"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/IPC-ShareLite/IPC-ShareLite-0.170.0-r1.ebuild
+++ b/dev-perl/IPC-ShareLite/IPC-ShareLite-0.170.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="IPC::ShareLite module for perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86 ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86 ~x86-solaris"
 IUSE="test"
 
 DEPEND="test? ( virtual/perl-Test-Simple )"

--- a/dev-perl/IPC-Signal/IPC-Signal-1.0.0-r1.ebuild
+++ b/dev-perl/IPC-Signal/IPC-Signal-1.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,5 +10,5 @@ inherit perl-module
 DESCRIPTION="Translate signal names to/from numbers"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE=""

--- a/dev-perl/Ima-DBI/Ima-DBI-0.350.0-r1.ebuild
+++ b/dev-perl/Ima-DBI/Ima-DBI-0.350.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Add contextual fetches to DBI"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc ppc64 sparc x86 ~x86-solaris"
+KEYWORDS="amd64 ~ppc ppc64 sparc x86 ~x86-solaris"
 IUSE=""
 
 RDEPEND="dev-perl/DBI

--- a/dev-perl/Inline-C/Inline-C-0.760.0.ebuild
+++ b/dev-perl/Inline-C/Inline-C-0.760.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="C Language Support for Inline"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ~sparc x86"
+KEYWORDS="~alpha amd64 arm ~hppa ppc ~sparc x86"
 IUSE="test"
 
 DIST_TEST="do" # parallelism thwarted by race conditions

--- a/dev-perl/Inline/Inline-0.500.0-r1.ebuild
+++ b/dev-perl/Inline/Inline-0.500.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Write Perl subroutines in other languages"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~mips ppc ppc64 ~s390 ~sh sparc x86"
 IUSE="test"
 
 RDEPEND="virtual/perl-Digest-MD5

--- a/dev-perl/Inline/Inline-0.800.0.ebuild
+++ b/dev-perl/Inline/Inline-0.800.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Write Perl subroutines in other languages"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/JSON-RPC/JSON-RPC-0.960.0-r1.ebuild
+++ b/dev-perl/JSON-RPC/JSON-RPC-0.960.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl implementation of JSON-RPC 1.1 protocol"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/libwww-perl

--- a/dev-perl/JSON-RPC/JSON-RPC-1.60.0.ebuild
+++ b/dev-perl/JSON-RPC/JSON-RPC-1.60.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="JSON RPC 2.0 Server Implementation"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test minimal"
 
 # Plack::Request,Plack::Test -> Plack

--- a/dev-perl/JSON-XS/JSON-XS-3.30.0.ebuild
+++ b/dev-perl/JSON-XS/JSON-XS-3.30.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="JSON::XS - JSON serialising/deserialising, done correctly and fast"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x64-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/LWP-Online/LWP-Online-1.80.0-r2.ebuild
+++ b/dev-perl/LWP-Online/LWP-Online-1.80.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit perl-module
 DESCRIPTION="Does your process have access to the web"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 # https://rt.cpan.org/Public/Bug/Display.html?id=112728
 PATCHES=("${FILESDIR}/${DIST_VERSION}-no-network.patch")

--- a/dev-perl/LWP-Protocol-http10/LWP-Protocol-http10-6.30.0.ebuild
+++ b/dev-perl/LWP-Protocol-http10/LWP-Protocol-http10-6.30.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Legacy HTTP/1.0 support for LWP"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Lingua-EN-Numbers-Ordinate/Lingua-EN-Numbers-Ordinate-1.40.0.ebuild
+++ b/dev-perl/Lingua-EN-Numbers-Ordinate/Lingua-EN-Numbers-Ordinate-1.40.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Convert cardinal numbers(3) to ordinal numbers(3rd)"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Lingua-PT-Stemmer/Lingua-PT-Stemmer-0.20.0.ebuild
+++ b/dev-perl/Lingua-PT-Stemmer/Lingua-PT-Stemmer-0.20.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Portuguese language stemming"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE="test"
 RDEPEND=""
 DEPEND="${RDEPEND}

--- a/dev-perl/Lingua-Stem-Fr/Lingua-Stem-Fr-0.20.0-r1.ebuild
+++ b/dev-perl/Lingua-Stem-Fr/Lingua-Stem-Fr-0.20.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl French Stemming"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Lingua-Stem-It/Lingua-Stem-It-0.20.0-r1.ebuild
+++ b/dev-perl/Lingua-Stem-It/Lingua-Stem-It-0.20.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Porter's stemming algorithm for Italian"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Lingua-Stem-Ru/Lingua-Stem-Ru-0.40.0.ebuild
+++ b/dev-perl/Lingua-Stem-Ru/Lingua-Stem-Ru-0.40.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Porter's stemming algorithm for Russian (KOI8-R only)"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE="test"
 RDEPEND="
 	virtual/perl-Carp

--- a/dev-perl/Lingua-Stem-Snowball-Da/Lingua-Stem-Snowball-Da-1.10.0-r1.ebuild
+++ b/dev-perl/Lingua-Stem-Snowball-Da/Lingua-Stem-Snowball-Da-1.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Porters stemming algorithm for Denmark"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Linux-Pid/Linux-Pid-0.40.0-r1.ebuild
+++ b/dev-perl/Linux-Pid/Linux-Pid-0.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Interface to Linux getpp?id functions"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Locale-PO/Locale-PO-0.270.0.ebuild
+++ b/dev-perl/Locale-PO/Locale-PO-0.270.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl module for manipulating .po entries from GNU gettext"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ppc ppc64 ~s390 ~sh sparc x86"
+KEYWORDS="alpha amd64 arm hppa ~m68k ppc ppc64 ~s390 ~sh sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Log-Dispatch-Array/Log-Dispatch-Array-1.3.0.ebuild
+++ b/dev-perl/Log-Dispatch-Array/Log-Dispatch-Array-1.3.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="log events to an array (reference)"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Log-Dispatch/Log-Dispatch-2.580.0.ebuild
+++ b/dev-perl/Log-Dispatch/Log-Dispatch-2.580.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="Dispatches messages to one or more outputs"
 
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix"
 IUSE="test"
 
 PERL_RM_FILES=(

--- a/dev-perl/Log-Log4perl/Log-Log4perl-1.480.0.ebuild
+++ b/dev-perl/Log-Log4perl/Log-Log4perl-1.480.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ DESCRIPTION="Log4j implementation for Perl"
 HOMEPAGE="http://log4perl.sourceforge.net/"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Log-Log4perl/Log-Log4perl-1.490.0.ebuild
+++ b/dev-perl/Log-Log4perl/Log-Log4perl-1.490.0.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Log4j implementation for Perl"
 HOMEPAGE="http://log4perl.sourceforge.net/"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/MD5/MD5-2.30.0-r1.ebuild
+++ b/dev-perl/MD5/MD5-2.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="The Perl MD5 Module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND="virtual/perl-Digest-MD5"

--- a/dev-perl/MIME-Types/MIME-Types-2.120.0.ebuild
+++ b/dev-perl/MIME-Types/MIME-Types-2.120.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Definition of MIME types"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 # uses List::Util

--- a/dev-perl/MIME-Types/MIME-Types-2.130.0.ebuild
+++ b/dev-perl/MIME-Types/MIME-Types-2.130.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Definition of MIME types"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 # uses List::Util

--- a/dev-perl/MIME-tools/MIME-tools-5.507.0.ebuild
+++ b/dev-perl/MIME-tools/MIME-tools-5.507.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A Perl module for parsing and creating MIME entities"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm64 hppa ia64 ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="alpha amd64 ~arm64 hppa ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/MIME-tools/MIME-tools-5.509.0.ebuild
+++ b/dev-perl/MIME-tools/MIME-tools-5.509.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="A Perl module for parsing and creating MIME entities"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/MLDBM/MLDBM-2.50.0.ebuild
+++ b/dev-perl/MLDBM/MLDBM-2.50.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A multidimensional/tied hash Perl Module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ia64 ppc ppc64 ~s390 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 ~arm ppc ppc64 ~s390 sparc x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/MP3-Info/MP3-Info-1.240.0-r1.ebuild
+++ b/dev-perl/MP3-Info/MP3-Info-1.240.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A Perl module to manipulate/fetch info from MP3 files"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Mail-IMAPClient/Mail-IMAPClient-3.370.0.ebuild
+++ b/dev-perl/Mail-IMAPClient/Mail-IMAPClient-3.370.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="IMAP client module for Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ppc ~ppc64 ~s390 ~sh sparc x86"
+KEYWORDS="alpha amd64 arm ppc ~ppc64 ~s390 ~sh sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Mail-IMAPClient/Mail-IMAPClient-3.380.0.ebuild
+++ b/dev-perl/Mail-IMAPClient/Mail-IMAPClient-3.380.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="IMAP client module for Perl"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 IUSE="test ntlm md5 ssl zlib"
 
 PATCHES=(

--- a/dev-perl/Mail-IMAPClient/Mail-IMAPClient-3.390.0.ebuild
+++ b/dev-perl/Mail-IMAPClient/Mail-IMAPClient-3.390.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="IMAP client module for Perl"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 IUSE="test ntlm md5 ssl zlib"
 
 PATCHES=(

--- a/dev-perl/Mail-Sendmail/Mail-Sendmail-0.790.0-r1.ebuild
+++ b/dev-perl/Mail-Sendmail/Mail-Sendmail-0.790.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,5 +11,5 @@ DESCRIPTION="Simple platform independent mailer"
 
 LICENSE="Mail-Sendmail"
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86"
 IUSE=""

--- a/dev-perl/Math-Round/Math-Round-0.70.0.ebuild
+++ b/dev-perl/Math-Round/Math-Round-0.70.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl extension for rounding numbers"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE=""
 RDEPEND=""
 DEPEND="${RDEPEND}

--- a/dev-perl/Math-VecStat/Math-VecStat-0.80.0-r1.ebuild
+++ b/dev-perl/Math-VecStat/Math-VecStat-0.80.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Some basic numeric stats on vectors"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 sparc x86 ~amd64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="amd64 sparc x86 ~amd64-linux ~x86-linux ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Module-Build-Tiny/Module-Build-Tiny-0.39.0.ebuild
+++ b/dev-perl/Module-Build-Tiny/Module-Build-Tiny-0.39.0.ebuild
@@ -8,7 +8,7 @@ inherit perl-module
 
 DESCRIPTION='A tiny replacement for Module::Build'
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ~ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 ~sparc x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Module-Install/Module-Install-1.160.0.ebuild
+++ b/dev-perl/Module-Install/Module-Install-1.160.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Standalone, extensible Perl module installer"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ia64 ~ppc ~ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~alpha amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Module-Pluggable/Module-Pluggable-5.200.0.ebuild
+++ b/dev-perl/Module-Pluggable/Module-Pluggable-5.200.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Automatically give your module the ability to have plugins"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Module-Refresh/Module-Refresh-0.170.0-r1.ebuild
+++ b/dev-perl/Module-Refresh/Module-Refresh-0.170.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Refresh %INC files when updated on disk"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ppc ppc64 ~sparc x86 ~x86-fbsd"
+KEYWORDS="~alpha amd64 ~arm ~hppa ppc ppc64 ~sparc x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Module-ScanDeps/Module-ScanDeps-1.200.0.ebuild
+++ b/dev-perl/Module-ScanDeps/Module-ScanDeps-1.200.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Recursively scan Perl code for dependencies"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ia64 ~ppc ~ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~alpha amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Module-ScanDeps/Module-ScanDeps-1.230.0.ebuild
+++ b/dev-perl/Module-ScanDeps/Module-ScanDeps-1.230.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Recursively scan Perl code for dependencies"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~alpha amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Net-IP/Net-IP-1.260.0-r1.ebuild
+++ b/dev-perl/Net-IP/Net-IP-1.260.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl extension for manipulating IPv4/IPv6 addresses"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 PATCHES=( "${FILESDIR}/initip-0.patch" )

--- a/dev-perl/Net-Ident/Net-Ident-1.240.0.ebuild
+++ b/dev-perl/Net-Ident/Net-Ident-1.240.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,5 +10,5 @@ inherit perl-module
 DESCRIPTION="lookup the username on the remote end of a TCP/IP connection"
 
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="amd64 hppa ppc ppc64 sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""

--- a/dev-perl/Net-Jabber/Net-Jabber-2.0.0-r1.ebuild
+++ b/dev-perl/Net-Jabber/Net-Jabber-2.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Jabber Perl library"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/XML-Stream

--- a/dev-perl/Net-Kismet/Net-Kismet-0.04-r1.ebuild
+++ b/dev-perl/Net-Kismet/Net-Kismet-0.04-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ HOMEPAGE="http://www.kismetwireless.net"
 
 SLOT="0"
 LICENSE="Artistic"
-KEYWORDS="amd64 ia64 ppc x86"
+KEYWORDS="amd64 ppc x86"
 IUSE=""
 SRC_TEST="do parallel"
 

--- a/dev-perl/Net-RawIP/Net-RawIP-0.250.0-r1.ebuild
+++ b/dev-perl/Net-RawIP/Net-RawIP-0.250.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl Net::RawIP - Raw IP packets manipulation Module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE=""
 
 RDEPEND="net-libs/libpcap"

--- a/dev-perl/Net-SNMP/Net-SNMP-6.0.1-r1.ebuild
+++ b/dev-perl/Net-SNMP/Net-SNMP-6.0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="A SNMP Perl Module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ~mips ppc ppc64 sparc x86 ~ppc-aix ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ~mips ppc ppc64 sparc x86 ~ppc-aix ~sparc-solaris ~x86-solaris"
 # Package warrants IUSE examples
 IUSE=""
 

--- a/dev-perl/Net-SNMP/Net-SNMP-6.0.1-r2.ebuild
+++ b/dev-perl/Net-SNMP/Net-SNMP-6.0.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A SNMP Perl Module"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~sparc-solaris ~x86-solaris"
 # Package warrants IUSE examples
 IUSE="examples test minimal"
 

--- a/dev-perl/Net-SNPP/Net-SNPP-1.170.0-r1.ebuild
+++ b/dev-perl/Net-SNPP/Net-SNPP-1.170.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="libnet SNPP component"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
 RDEPEND="virtual/perl-libnet"

--- a/dev-perl/Net-Server/Net-Server-2.8.0.ebuild
+++ b/dev-perl/Net-Server/Net-Server-2.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module eutils
 DESCRIPTION="Extensible, general Perl server engine"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 ~arm hppa ~mips ppc ppc64 sparc x86 ~x86-fbsd"
 IUSE="ipv6"
 
 RDEPEND="dev-perl/IO-Multiplex

--- a/dev-perl/Net-Subnet/Net-Subnet-1.30.0.ebuild
+++ b/dev-perl/Net-Subnet/Net-Subnet-1.30.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Fast IP-in-subnet matcher for IPv4 and IPv6, CIDR or mask"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 
 RDEPEND="
 	>=dev-perl/Socket6-0.250.0

--- a/dev-perl/Net-Telnet-Cisco/Net-Telnet-Cisco-1.100.0-r1.ebuild
+++ b/dev-perl/Net-Telnet-Cisco/Net-Telnet-Cisco-1.100.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Automate telnet sessions w/ routers&switches"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ~ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ~mips ~ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/Net-Telnet

--- a/dev-perl/Net-Telnet/Net-Telnet-3.40.0.ebuild
+++ b/dev-perl/Net-Telnet/Net-Telnet-3.40.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="interact with TELNET port or other TCP ports in Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ~mips ppc ppc64 sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 ~arm hppa ~mips ppc ppc64 sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 RDEPEND=">=virtual/perl-libnet-1.70.300"

--- a/dev-perl/Net-XMPP/Net-XMPP-1.20.0-r1.ebuild
+++ b/dev-perl/Net-XMPP/Net-XMPP-1.20.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="XMPP Perl Library"
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND=">=dev-perl/XML-Stream-1.22

--- a/dev-perl/Net-XMPP/Net-XMPP-1.50.0.ebuild
+++ b/dev-perl/Net-XMPP/Net-XMPP-1.50.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="XMPP Perl Library"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test examples"
 
 RDEPEND="

--- a/dev-perl/Number-Format/Number-Format-1.750.0.ebuild
+++ b/dev-perl/Number-Format/Number-Format-1.750.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Package for formatting numbers for display"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc x86"
+KEYWORDS="amd64 ppc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Ogg-Vorbis-Header/Ogg-Vorbis-Header-0.30.0-r1.ebuild
+++ b/dev-perl/Ogg-Vorbis-Header/Ogg-Vorbis-Header-0.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="An object-oriented interface to Ogg Vorbis information and comment 
 
 SLOT="0"
 LICENSE="|| ( GPL-2 GPL-3 ) LGPL-2" # GPL-2+
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/PAR-Dist/PAR-Dist-0.490.0-r1.ebuild
+++ b/dev-perl/PAR-Dist/PAR-Dist-0.490.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Create and manipulate PAR distributions"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm hppa ia64 ~m68k ~ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm hppa ~m68k ~ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 DEPEND="

--- a/dev-perl/PDF-Create/PDF-Create-1.290.0.ebuild
+++ b/dev-perl/PDF-Create/PDF-Create-1.290.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Create PDF documents in Perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE="test examples"
 
 RDEPEND="

--- a/dev-perl/PDF-Create/PDF-Create-1.410.0.ebuild
+++ b/dev-perl/PDF-Create/PDF-Create-1.410.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Create PDF documents in Perl"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
 IUSE="test examples"
 
 RDEPEND="

--- a/dev-perl/PDF-Create/PDF-Create-1.420.0.ebuild
+++ b/dev-perl/PDF-Create/PDF-Create-1.420.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Create PDF documents in Perl"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
 IUSE="test examples"
 
 RDEPEND="

--- a/dev-perl/PGPLOT/PGPLOT-2.210.0.ebuild
+++ b/dev-perl/PGPLOT/PGPLOT-2.210.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="allow subroutines in the PGPLOT graphics library to be called from Perl"
 
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~ppc ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 # Tests require active X display

--- a/dev-perl/POSIX-strftime-Compiler/POSIX-strftime-Compiler-0.410.0.ebuild
+++ b/dev-perl/POSIX-strftime-Compiler/POSIX-strftime-Compiler-0.410.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="GNU C library compatible strftime for loggers and servers"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test minimal examples"
 
 # POSIX -> perl

--- a/dev-perl/Parallel-ForkManager/Parallel-ForkManager-1.170.0.ebuild
+++ b/dev-perl/Parallel-ForkManager/Parallel-ForkManager-1.170.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A simple parallel processing fork manager"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86 ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~ppc sparc x86 ~sparc-solaris ~x86-solaris"
 IUSE="test minimal examples"
 
 RDEPEND="

--- a/dev-perl/Parallel-ForkManager/Parallel-ForkManager-1.180.0.ebuild
+++ b/dev-perl/Parallel-ForkManager/Parallel-ForkManager-1.180.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="A simple parallel processing fork manager"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86 ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86 ~sparc-solaris ~x86-solaris"
 IUSE="test minimal"
 
 RDEPEND="

--- a/dev-perl/Params-Classify/Params-Classify-0.13.0-r1.ebuild
+++ b/dev-perl/Params-Classify/Params-Classify-0.13.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Argument type classification"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~s390 ~sh ~sparc ~x86 ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm ~hppa ~s390 ~sh ~sparc ~x86 ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/PatchReader/PatchReader-0.9.6-r1.ebuild
+++ b/dev-perl/PatchReader/PatchReader-0.9.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Module for reading diff-compatible patch files"
 
 LICENSE="|| ( Artistic GPL-2 )"
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86 ~x86-fbsd"
 IUSE=""
 
 RDEPEND="virtual/perl-File-Temp"

--- a/dev-perl/Path-Class/Path-Class-0.360.0.ebuild
+++ b/dev-perl/Path-Class/Path-Class-0.360.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Cross-platform path specification manipulation"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Pegex/Pegex-0.630.0.ebuild
+++ b/dev-perl/Pegex/Pegex-0.630.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Acmeist PEG Parser Framework"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Perl6-Junction/Perl6-Junction-1.600.0.ebuild
+++ b/dev-perl/Perl6-Junction/Perl6-Junction-1.600.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl6 style Junction operators in Perl5"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/PerlIO-eol/PerlIO-eol-0.140.0-r1.ebuild
+++ b/dev-perl/PerlIO-eol/PerlIO-eol-0.140.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="PerlIO::eol - PerlIO layer for normalizing line endings"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/PerlIO-gzip/PerlIO-gzip-0.190.0.ebuild
+++ b/dev-perl/PerlIO-gzip/PerlIO-gzip-0.190.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="PerlIO layer to gzip/gunzip"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"
 IUSE=""
 
 DEPEND="sys-libs/zlib"

--- a/dev-perl/PerlIO-utf8_strict/PerlIO-utf8_strict-0.7.0.ebuild
+++ b/dev-perl/PerlIO-utf8_strict/PerlIO-utf8_strict-0.7.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 DESCRIPTION="Fast and correct UTF-8 IO"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 # r: strict, warnings -> perl
 RDEPEND="

--- a/dev-perl/PerlIO-via-symlink/PerlIO-via-symlink-0.50.0-r1.ebuild
+++ b/dev-perl/PerlIO-via-symlink/PerlIO-via-symlink-0.50.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="PerlIO::via::symlink -  PerlIO layer for symlinks"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 DEPEND="dev-perl/Module-Install

--- a/dev-perl/Plack/Plack-1.3.900.ebuild
+++ b/dev-perl/Plack/Plack-1.3.900.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl Superglue for Web frameworks and Web Servers (PSGI toolkit)"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test minimal examples"
 PATCHES=(
 	"${FILESDIR}/${P}-issue-545.patch"

--- a/dev-perl/Pod-Coverage/Pod-Coverage-0.230.0-r1.ebuild
+++ b/dev-perl/Pod-Coverage/Pod-Coverage-0.230.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Checks if the documentation of a module is comprehensive"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/PostScript-Simple/PostScript-Simple-0.90.0.ebuild
+++ b/dev-perl/PostScript-Simple/PostScript-Simple-0.90.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="Allows you to have a simple method of writing PostScript files from
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="amd64 hppa ppc sparc x86"
 IUSE="test examples"
 
 RDEPEND=""

--- a/dev-perl/Proc-ProcessTable/Proc-ProcessTable-0.530.0.ebuild
+++ b/dev-perl/Proc-ProcessTable/Proc-ProcessTable-0.530.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Unix process table information"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 sparc x86"
 IUSE="examples"
 
 PATCHES=(

--- a/dev-perl/Proc-WaitStat/Proc-WaitStat-1.0.0-r1.ebuild
+++ b/dev-perl/Proc-WaitStat/Proc-WaitStat-1.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Interpret and act on wait() status values"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ~sparc x86"
+KEYWORDS="amd64 ppc ~sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/IPC-Signal"

--- a/dev-perl/Readonly-XS/Readonly-XS-1.50.0-r1.ebuild
+++ b/dev-perl/Readonly-XS/Readonly-XS-1.50.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Companion module for Readonly.pm, to speed up read-only scalar variables"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 IUSE=""
 
 RDEPEND="dev-perl/Readonly"

--- a/dev-perl/Readonly/Readonly-2.0.0.ebuild
+++ b/dev-perl/Readonly/Readonly-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Facility for creating read-only scalars, arrays, hashes"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ~ia64 ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/Readonly/Readonly-2.10.0.ebuild
+++ b/dev-perl/Readonly/Readonly-2.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Facility for creating read-only scalars, arrays, hashes"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/Regexp-Common/Regexp-Common-2013031301.0.0.ebuild
+++ b/dev-perl/Regexp-Common/Regexp-Common-2013031301.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Provide commonly requested regular expressions"
 
 LICENSE="|| ( Artistic Artistic-2 MIT BSD )"
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Regexp-Common/Regexp-Common-2016020301.0.0.ebuild
+++ b/dev-perl/Regexp-Common/Regexp-Common-2016020301.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="Provide commonly requested regular expressions"
 
 LICENSE="|| ( Artistic Artistic-2 MIT BSD )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/Regexp-Common/Regexp-Common-2016060801.0.0.ebuild
+++ b/dev-perl/Regexp-Common/Regexp-Common-2016060801.0.0.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="Provide commonly requested regular expressions"
 
 LICENSE="|| ( Artistic Artistic-2 MIT BSD )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/Regexp-Common/Regexp-Common-2017040401.0.0.ebuild
+++ b/dev-perl/Regexp-Common/Regexp-Common-2017040401.0.0.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="Provide commonly requested regular expressions"
 
 LICENSE="|| ( Artistic Artistic-2 MIT BSD )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/Regexp-Shellish/Regexp-Shellish-0.930.0-r1.ebuild
+++ b/dev-perl/Regexp-Shellish/Regexp-Shellish-0.930.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Regexp::Shellish - Shell-like regular expressions"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~mips ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ~mips ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Router-Simple/Router-Simple-0.170.0.ebuild
+++ b/dev-perl/Router-Simple/Router-Simple-0.170.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Simple HTTP router"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/SNMP_Session/SNMP_Session-1.13-r2.ebuild
+++ b/dev-perl/SNMP_Session/SNMP_Session-1.13-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/sleinen/snmp-session"
 
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 sparc x86 ~sparc-solaris ~x86-solaris"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-Socket6.patch

--- a/dev-perl/SVN-Simple/SVN-Simple-0.280.0-r1.ebuild
+++ b/dev-perl/SVN-Simple/SVN-Simple-0.280.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="SVN::Simple::Edit - Simple interface to SVN::Delta::Editor"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="amd64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 RDEPEND=">=dev-vcs/subversion-0.31[perl]"

--- a/dev-perl/Scalar-Properties/Scalar-Properties-1.100.860-r1.ebuild
+++ b/dev-perl/Scalar-Properties/Scalar-Properties-1.100.860-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="run-time properties on scalar variables"
 
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 ~ppc sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="amd64 hppa ~ppc sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Search-Xapian/Search-Xapian-1.2.23.0-r1.ebuild
+++ b/dev-perl/Search-Xapian/Search-Xapian-1.2.23.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ SRC_URI+=" http://oligarchy.co.uk/xapian/${VERSION}/${P}.tar.gz"
 DESCRIPTION="Perl XS frontend to the Xapian C++ search library"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
 IUSE="examples test"
 
 RDEPEND="dev-libs/xapian:0/1.2.22

--- a/dev-perl/Search-Xapian/Search-Xapian-1.2.23.0.ebuild
+++ b/dev-perl/Search-Xapian/Search-Xapian-1.2.23.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -13,7 +13,7 @@ DESCRIPTION="Perl XS frontend to the Xapian C++ search library"
 
 LICENSE="|| ( Artistic GPL-1 GPL-2 GPL-3 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm ~mips ppc ppc64 sparc x86"
 IUSE="examples"
 
 RDEPEND="dev-libs/xapian:0/1.2.22

--- a/dev-perl/Sereal-Decoder/Sereal-Decoder-3.15.0.ebuild
+++ b/dev-perl/Sereal-Decoder/Sereal-Decoder-3.15.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Fast, compact, powerful binary deserialization"
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Sereal-Encoder/Sereal-Encoder-3.15.0.ebuild
+++ b/dev-perl/Sereal-Encoder/Sereal-Encoder-3.15.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Fast, compact, powerful binary serialization"
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Sereal/Sereal-3.15.0.ebuild
+++ b/dev-perl/Sereal/Sereal-3.15.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Fast, compact, powerful binary (de-)serialization"
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Set-Scalar/Set-Scalar-1.290.0.ebuild
+++ b/dev-perl/Set-Scalar/Set-Scalar-1.290.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Scalar set operations"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ppc ~ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 arm hppa ~m68k ppc ~ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Snowball-Norwegian/Snowball-Norwegian-1.200.0-r1.ebuild
+++ b/dev-perl/Snowball-Norwegian/Snowball-Norwegian-1.200.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Porters stemming algorithm for Norwegian"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Snowball-Swedish/Snowball-Swedish-1.200.0-r1.ebuild
+++ b/dev-perl/Snowball-Swedish/Snowball-Swedish-1.200.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Porters stemming algorithm for Swedish"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Sort-Tree/Sort-Tree-1.90.0-r1.ebuild
+++ b/dev-perl/Sort-Tree/Sort-Tree-1.90.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Organize list of objects into parent/child order"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 x86"
+KEYWORDS="amd64 x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Sort-Versions/Sort-Versions-1.620.0.ebuild
+++ b/dev-perl/Sort-Versions/Sort-Versions-1.620.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A perl 5 module for sorting of revision-like numbers"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Stat-lsMode/Stat-lsMode-0.500.0-r1.ebuild
+++ b/dev-perl/Stat-lsMode/Stat-lsMode-0.500.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="The Perl Stat-lsMode Module"
 
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 hppa ppc ppc64 sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Statistics-Descriptive-Discrete/Statistics-Descriptive-Discrete-0.70.0-r1.ebuild
+++ b/dev-perl/Statistics-Descriptive-Discrete/Statistics-Descriptive-Discrete-0.70.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Statistics-Descriptive-Discrete module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/Stream-Buffered/Stream-Buffered-0.30.0.ebuild
+++ b/dev-perl/Stream-Buffered/Stream-Buffered-0.30.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Temporary buffer to save bytes"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND="virtual/perl-IO"

--- a/dev-perl/String-Ediff/String-Ediff-0.90.0-r1.ebuild
+++ b/dev-perl/String-Ediff/String-Ediff-0.90.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Produce common sub-string indices for two strings"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Sub-Override/Sub-Override-0.90.0.ebuild
+++ b/dev-perl/Sub-Override/Sub-Override-0.90.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl extension for easily overriding subroutines"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ~ppc64 sparc x86 ~amd64-linux ~arm-linux ~x86-linux"
+KEYWORDS="amd64 ppc ~ppc64 sparc x86 ~amd64-linux ~arm-linux ~x86-linux"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/Term-ProgressBar/Term-ProgressBar-2.170.0.ebuild
+++ b/dev-perl/Term-ProgressBar/Term-ProgressBar-2.170.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl module for Term-ProgressBar"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86 ~x86-linux"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86 ~x86-linux"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Term-ReadLine-Gnu/Term-ReadLine-Gnu-1.310.0.ebuild
+++ b/dev-perl/Term-ReadLine-Gnu/Term-ReadLine-Gnu-1.310.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="GNU Readline XS library wrapper"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ppc sparc x86"
+KEYWORDS="~alpha amd64 ~arm ppc sparc x86"
 IUSE=""
 
 RDEPEND=">=sys-libs/readline-6.2:0="

--- a/dev-perl/Term-ReadLine-Perl/Term-ReadLine-Perl-1.30.300-r1.ebuild
+++ b/dev-perl/Term-ReadLine-Perl/Term-ReadLine-Perl-1.30.300-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ inherit perl-module
 DESCRIPTION="Quick implementation of readline utilities"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 RDEPEND="dev-perl/TermReadKey"

--- a/dev-perl/Test-ClassAPI/Test-ClassAPI-1.60.0-r1.ebuild
+++ b/dev-perl/Test-ClassAPI/Test-ClassAPI-1.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Provides basic first-pass API testing for large class trees"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND=">=virtual/perl-File-Spec-0.83

--- a/dev-perl/Test-Differences/Test-Differences-0.640.0.ebuild
+++ b/dev-perl/Test-Differences/Test-Differences-0.640.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Test strings and data structures and show differences if not ok"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86"
 IUSE="test"
 PERL_RM_FILES=(
 	"t/boilerplate.t"

--- a/dev-perl/Test-Distribution/Test-Distribution-2.0.0-r1.ebuild
+++ b/dev-perl/Test-Distribution/Test-Distribution-2.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="perform tests on all modules of a distribution"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-fbsd"
+KEYWORDS="~alpha amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc x86 ~x86-fbsd"
 IUSE=""
 
 RDEPEND=">=dev-perl/Pod-Coverage-0.20

--- a/dev-perl/Test-LongString/Test-LongString-0.170.0.ebuild
+++ b/dev-perl/Test-LongString/Test-LongString-0.170.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A library to test long strings"
 
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ia64 ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="amd64 ~arm ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 RDEPEND="virtual/perl-Test-Simple"

--- a/dev-perl/Test-MockTime/Test-MockTime-0.150.0.ebuild
+++ b/dev-perl/Test-MockTime/Test-MockTime-0.150.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Replaces actual time with simulated time"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Test-Most/Test-Most-0.340.0.ebuild
+++ b/dev-perl/Test-Most/Test-Most-0.340.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Most commonly needed test functions and features"
 
 SLOT="0"
-KEYWORDS="alpha ~amd64 hppa ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha ~amd64 hppa ppc ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Test-Output/Test-Output-1.30.0.ebuild
+++ b/dev-perl/Test-Output/Test-Output-1.30.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Utilities to test STDOUT and STDERR messages"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~m68k ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Test-Output/Test-Output-1.31.0.ebuild
+++ b/dev-perl/Test-Output/Test-Output-1.31.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Utilities to test STDOUT and STDERR messages"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Test-Pod-Coverage/Test-Pod-Coverage-1.100.0.ebuild
+++ b/dev-perl/Test-Pod-Coverage/Test-Pod-Coverage-1.100.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Check for pod coverage in your distribution"
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Test-Regexp/Test-Regexp-2017040101.0.0.ebuild
+++ b/dev-perl/Test-Regexp/Test-Regexp-2017040101.0.0.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="Provide commonly requested regular expressions"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 DEPEND="

--- a/dev-perl/Test-TCP/Test-TCP-2.170.0.ebuild
+++ b/dev-perl/Test-TCP/Test-TCP-2.170.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Testing TCP program"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Test-Taint/Test-Taint-1.60.0-r1.ebuild
+++ b/dev-perl/Test-Taint/Test-Taint-1.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Tools to test taintedness"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 ~s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Test-Time/Test-Time-0.40.0.ebuild
+++ b/dev-perl/Test-Time/Test-Time-0.40.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Overrides the time() and sleep() core functions for testing"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Text-Aspell/Text-Aspell-0.90.0-r1.ebuild
+++ b/dev-perl/Text-Aspell/Text-Aspell-0.90.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl interface to the GNU Aspell Library"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 # Disabling tests for now - see bug #147897 --ian

--- a/dev-perl/Text-Autoformat/Text-Autoformat-1.740.0.ebuild
+++ b/dev-perl/Text-Autoformat/Text-Autoformat-1.740.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Automatic text wrapping and reformatting"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test examples"
 
 RDEPEND="

--- a/dev-perl/Text-German/Text-German-0.60.0-r1.ebuild
+++ b/dev-perl/Text-German/Text-German-0.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="German grundform reduction"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Text-Kakasi/Text-Kakasi-2.40.0-r1.ebuild
+++ b/dev-perl/Text-Kakasi/Text-Kakasi-2.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="This module provides libkakasi interface for Perl"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND=">=app-i18n/kakasi-2.3.4"

--- a/dev-perl/Text-Levenshtein/Text-Levenshtein-0.130.0.ebuild
+++ b/dev-perl/Text-Levenshtein/Text-Levenshtein-0.130.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="An implementation of the Levenshtein edit distance"
 
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Text-Levenshtein/Text-Levenshtein-0.50.0-r1.ebuild
+++ b/dev-perl/Text-Levenshtein/Text-Levenshtein-0.50.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="An implementation of the Levenshtein edit distance"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Text-LevenshteinXS/Text-LevenshteinXS-0.30.0-r1.ebuild
+++ b/dev-perl/Text-LevenshteinXS/Text-LevenshteinXS-0.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="An XS implementation of the Levenshtein edit distance"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Text-Quoted/Text-Quoted-2.60.0-r1.ebuild
+++ b/dev-perl/Text-Quoted/Text-Quoted-2.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Extract the structure of a quoted mail message"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND="dev-perl/Text-Autoformat"

--- a/dev-perl/Text-Quoted/Text-Quoted-2.90.0.ebuild
+++ b/dev-perl/Text-Quoted/Text-Quoted-2.90.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Extract the structure of a quoted mail message"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 ~ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 RDEPEND="dev-perl/Text-Autoformat

--- a/dev-perl/Text-Reform/Text-Reform-1.200.0-r1.ebuild
+++ b/dev-perl/Text-Reform/Text-Reform-1.200.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Manual text wrapping and reformatting"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ppc64 s390 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 s390 sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Text-Shellwords/Text-Shellwords-1.80.0-r1.ebuild
+++ b/dev-perl/Text-Shellwords/Text-Shellwords-1.80.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Parses lines of text and returns a set of tokens using the same rules as the Unix shell"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Text-Unaccent/Text-Unaccent-1.80.0-r1.ebuild
+++ b/dev-perl/Text-Unaccent/Text-Unaccent-1.80.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Removes accents from a string"
 
 LICENSE="|| ( GPL-2 GPL-3 )" #GPL-2+
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="alpha amd64 hppa ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Tie-Array-Sorted/Tie-Array-Sorted-1.410.0-r1.ebuild
+++ b/dev-perl/Tie-Array-Sorted/Tie-Array-Sorted-1.410.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="An array which is kept sorted"
 
 LICENSE="|| ( GPL-2 GPL-3 )" # GPL-2+
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Tie-StrictHash/Tie-StrictHash-1.0.0-r1.ebuild
+++ b/dev-perl/Tie-StrictHash/Tie-StrictHash-1.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A hash with strict-like semantics"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 x86"
+KEYWORDS="amd64 x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Time-Duration/Time-Duration-1.200.0.ebuild
+++ b/dev-perl/Time-Duration/Time-Duration-1.200.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Rounded or exact English expression of durations"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-linux"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-linux"
 IUSE="test"
 
 RDEPEND="virtual/perl-Exporter"

--- a/dev-perl/Time-Duration/Time-Duration-1.60.0-r1.ebuild
+++ b/dev-perl/Time-Duration/Time-Duration-1.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Rounded or exact English expression of durations"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~x86-linux"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 s390 sh sparc x86 ~x86-linux"
 IUSE="test"
 
 DEPEND=""

--- a/dev-perl/Time-TZOffset/Time-TZOffset-0.40.0.ebuild
+++ b/dev-perl/Time-TZOffset/Time-TZOffset-0.40.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Show timezone offset strings like +0900"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Tk-CursorControl/Tk-CursorControl-0.400.0-r1.ebuild
+++ b/dev-perl/Tk-CursorControl/Tk-CursorControl-0.400.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit eutils perl-module
 DESCRIPTION="Manipulate the mouse cursor programmatically"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 sparc x86"
+KEYWORDS="amd64 sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/Tk"

--- a/dev-perl/Tk-JPEG-Lite/Tk-JPEG-Lite-2.14.30-r1.ebuild
+++ b/dev-perl/Tk-JPEG-Lite/Tk-JPEG-Lite-2.14.30-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="lite JPEG loader for Tk::Photo"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 RDEPEND="virtual/jpeg

--- a/dev-perl/Tk-TableMatrix/Tk-TableMatrix-1.230.0-r1.ebuild
+++ b/dev-perl/Tk-TableMatrix/Tk-TableMatrix-1.230.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -13,7 +13,7 @@ DESCRIPTION="Perl module for Tk-TableMatrix"
 
 LICENSE="Artistic"
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""
 
 DEPEND="dev-perl/Tk"

--- a/dev-perl/Tree-DAG_Node/Tree-DAG_Node-1.290.0.ebuild
+++ b/dev-perl/Tree-DAG_Node/Tree-DAG_Node-1.290.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ DESCRIPTION="(Super)class for representing nodes in a tree"
 
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Tree-DAG_Node/Tree-DAG_Node-1.60.0-r1.ebuild
+++ b/dev-perl/Tree-DAG_Node/Tree-DAG_Node-1.60.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="(Super)class for representing nodes in a tree"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm arm64 hppa ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/Types-Serialiser/Types-Serialiser-1.0.0.ebuild
+++ b/dev-perl/Types-Serialiser/Types-Serialiser-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="simple data types for common serialisation formats"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm ~ppc ~ppc64 ~sparc x86 ~x64-macos ~x86-solaris"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/UNIVERSAL-require/UNIVERSAL-require-0.180.0.ebuild
+++ b/dev-perl/UNIVERSAL-require/UNIVERSAL-require-0.180.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="UNIVERSAL::require - require() modules from a variable"
 
 SLOT="0"
-KEYWORDS="amd64 ~ia64 ~ppc sparc x86 ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="amd64 ~ppc sparc x86 ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Unix-Syslog/Unix-Syslog-1.100.0-r1.ebuild
+++ b/dev-perl/Unix-Syslog/Unix-Syslog-1.100.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,5 +11,5 @@ DESCRIPTION="A Perl module which provides access to the system logger"
 
 SLOT="0"
 LICENSE="Artistic-2"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86"
 IUSE=""

--- a/dev-perl/Video-Frequencies/Video-Frequencies-0.03-r1.ebuild
+++ b/dev-perl/Video-Frequencies/Video-Frequencies-0.03-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/ivtv/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc x86"
+KEYWORDS="amd64 ppc x86"
 IUSE=""
 
 export OPTIMIZE="$CFLAGS"

--- a/dev-perl/Video-Info/Video-Info-0.993.0-r1.ebuild
+++ b/dev-perl/Video-Info/Video-Info-0.993.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Perl extension for getting video info"
 
 LICENSE="Aladdin"
 SLOT="0"
-KEYWORDS="amd64 ~ia64 ~ppc sparc x86"
+KEYWORDS="amd64 ~ppc sparc x86"
 IUSE=""
 
 DEPEND="dev-perl/Class-MakeMethods"

--- a/dev-perl/Video-ivtv/Video-ivtv-0.13-r1.ebuild
+++ b/dev-perl/Video-ivtv/Video-ivtv-0.13-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/ivtv/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc x86"
+KEYWORDS="amd64 ppc x86"
 IUSE=""
 
 export OPTIMIZE="$CFLAGS"

--- a/dev-perl/WeakRef/WeakRef-0.10.0-r1.ebuild
+++ b/dev-perl/WeakRef/WeakRef-0.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="An API to the Perl weak references"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/X11-FreeDesktop-DesktopEntry/X11-FreeDesktop-DesktopEntry-0.40.0-r1.ebuild
+++ b/dev-perl/X11-FreeDesktop-DesktopEntry/X11-FreeDesktop-DesktopEntry-0.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="An interface to Freedesktop.org .desktop files"
 
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc x86"
+KEYWORDS="amd64 ppc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/X500-DN/X500-DN-0.290.0-r1.ebuild
+++ b/dev-perl/X500-DN/X500-DN-0.290.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ inherit perl-module
 DESCRIPTION="handle X.500 DNs (Distinguished Names), parse and format them"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ia64 ppc ~s390 ~sh sparc x86"
+KEYWORDS="alpha amd64 arm ppc ~s390 ~sh sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/Parse-RecDescent"

--- a/dev-perl/XML-AutoWriter/XML-AutoWriter-0.400.0-r1.ebuild
+++ b/dev-perl/XML-AutoWriter/XML-AutoWriter-0.400.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="DOCTYPE based XML output"
 
 LICENSE="|| ( Artistic GPL-1+ BSD )"
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 sparc x86"
+KEYWORDS="amd64 hppa sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/XML-Parser"

--- a/dev-perl/XML-Catalog/XML-Catalog-1.30.0.ebuild
+++ b/dev-perl/XML-Catalog/XML-Catalog-1.30.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Resolve public identifiers and remap system identifiers"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/XML-Parser

--- a/dev-perl/XML-DTDParser/XML-DTDParser-2.10.0-r1.ebuild
+++ b/dev-perl/XML-DTDParser/XML-DTDParser-2.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Quick and dirty DTD Parser"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/XML-Dumper/XML-Dumper-0.810.0-r1.ebuild
+++ b/dev-perl/XML-Dumper/XML-Dumper-0.810.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl module for dumping Perl objects from/to XML"
 
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="amd64 hppa ppc sparc x86"
 IUSE=""
 
 RDEPEND=">=dev-perl/XML-Parser-2.16"

--- a/dev-perl/XML-Elemental/XML-Elemental-2.110.0-r1.ebuild
+++ b/dev-perl/XML-Elemental/XML-Elemental-2.110.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="an XML::Parser style and generic classes for simplistic and perlish
 
 LICENSE="Artistic"
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+KEYWORDS="amd64 hppa sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
 IUSE=""
 
 DEPEND="dev-perl/XML-Parser

--- a/dev-perl/XML-Encoding/XML-Encoding-2.90.0.ebuild
+++ b/dev-perl/XML-Encoding/XML-Encoding-2.90.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl Module that parses encoding map XML files"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE="test"
 
 RDEPEND=">=dev-perl/XML-Parser-2.180.0"

--- a/dev-perl/XML-Filter-DOMFilter-LibXML/XML-Filter-DOMFilter-LibXML-0.40.0.ebuild
+++ b/dev-perl/XML-Filter-DOMFilter-LibXML/XML-Filter-DOMFilter-LibXML-0.40.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="SAX Filter allowing DOM processing of selected subtrees"
 
 LICENSE="Artistic"
 SLOT="0"
-KEYWORDS="amd64 hppa ia64 sparc x86"
+KEYWORDS="amd64 hppa sparc x86"
 IUSE="test"
 
 RDEPEND=">=dev-perl/XML-LibXML-1.53"

--- a/dev-perl/XML-Generator/XML-Generator-1.40.0-r1.ebuild
+++ b/dev-perl/XML-Generator/XML-Generator-1.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl XML::Generator - A module to help in generating XML documents"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 ~s390 ~sh sparc x86"
 IUSE=""
 
 DEPEND="dev-libs/expat"

--- a/dev-perl/XML-Grove/XML-Grove-0.46_alpha-r2.ebuild
+++ b/dev-perl/XML-Grove/XML-Grove-0.46_alpha-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -14,7 +14,7 @@ SRC_URI="mirror://cpan/authors/id/K/KM/KMACLEOD/${MY_P}.tar.gz"
 
 LICENSE="Artistic"
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""
 
 DEPEND=">=dev-perl/libxml-perl-0.07-r1"

--- a/dev-perl/XML-LibXML-Iterator/XML-LibXML-Iterator-1.40.0-r1.ebuild
+++ b/dev-perl/XML-LibXML-Iterator/XML-LibXML-Iterator-1.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Iterator class for XML::LibXML parsed documents"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 DEPEND="dev-perl/XML-LibXML

--- a/dev-perl/XML-NodeFilter/XML-NodeFilter-0.10.0-r1.ebuild
+++ b/dev-perl/XML-NodeFilter/XML-NodeFilter-0.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Generic XML::NodeFilter Class"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 SRC_TEST=do

--- a/dev-perl/XML-RSS-Parser/XML-RSS-Parser-4.0.0-r1.ebuild
+++ b/dev-perl/XML-RSS-Parser/XML-RSS-Parser-4.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ DESCRIPTION="A liberal object-oriented parser for RSS feeds"
 
 LICENSE="Artistic"
 SLOT="0"
-KEYWORDS="amd64 ia64 sparc x86"
+KEYWORDS="amd64 sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/Class-ErrorHandler

--- a/dev-perl/XML-SimpleObject/XML-SimpleObject-0.530.0-r1.ebuild
+++ b/dev-perl/XML-SimpleObject/XML-SimpleObject-0.530.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="A Perl XML Simple package"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 ppc sparc x86"
 IUSE=""
 
 RDEPEND=">=dev-perl/XML-Parser-2.30

--- a/dev-perl/XML-Stream/XML-Stream-1.240.0.ebuild
+++ b/dev-perl/XML-Stream/XML-Stream-1.240.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 EAPI=5
 
@@ -11,7 +11,7 @@ DESCRIPTION="Creates and XML Stream connection and parses return data"
 SLOT="0"
 LICENSE="LGPL-2"
 
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm hppa ppc ppc64 sparc x86"
 
 IUSE="ssl"
 

--- a/dev-perl/XML-Writer/XML-Writer-0.625.0.ebuild
+++ b/dev-perl/XML-Writer/XML-Writer-0.625.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="XML Writer Perl Module"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-linux ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-linux ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/XML-XQL/XML-XQL-0.680.0-r1.ebuild
+++ b/dev-perl/XML-XQL/XML-XQL-0.680.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A Perl module that allows you to perform XQL queries on XML trees"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 hppa ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND=">=dev-perl/libxml-perl-0.07-r1

--- a/dev-perl/XML-XSLT/XML-XSLT-0.480.0-r1.ebuild
+++ b/dev-perl/XML-XSLT/XML-XSLT-0.480.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="A Perl module to parse XSL Transformational sheets"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE=""
 
 RDEPEND=">=dev-perl/XML-Parser-2.29

--- a/dev-perl/XML-XUpdate-LibXML/XML-XUpdate-LibXML-0.6.0-r1.ebuild
+++ b/dev-perl/XML-XUpdate-LibXML/XML-XUpdate-LibXML-0.6.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ HOMEPAGE="http://search.cpan.org/~pajas/"
 
 SLOT="0"
 LICENSE="|| ( Artistic GPL-2 )"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/YAML-LibYAML/YAML-LibYAML-0.630.0.ebuild
+++ b/dev-perl/YAML-LibYAML/YAML-LibYAML-0.630.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Perl YAML Serialization using XS and libyaml"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ~sparc x86"
+KEYWORDS="~alpha amd64 arm ~hppa ppc ~sparc x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/YAML-LibYAML/YAML-LibYAML-0.640.0.ebuild
+++ b/dev-perl/YAML-LibYAML/YAML-LibYAML-0.640.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Perl YAML Serialization using XS and libyaml"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~sparc ~x86"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/YAML-Syck/YAML-Syck-1.290.0.ebuild
+++ b/dev-perl/YAML-Syck/YAML-Syck-1.290.0.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Fast, lightweight YAML loader and dumper"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/YAML-Syck/YAML-Syck-1.300.0.ebuild
+++ b/dev-perl/YAML-Syck/YAML-Syck-1.300.0.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Fast, lightweight YAML loader and dumper"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x86-solaris"
 IUSE=""
 
 SRC_TEST="do"

--- a/dev-perl/YAML-Tiny/YAML-Tiny-1.690.0.ebuild
+++ b/dev-perl/YAML-Tiny/YAML-Tiny-1.690.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Read/Write YAML files with as little code as possible"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/asa/asa-1.30.0.ebuild
+++ b/dev-perl/asa/asa-1.30.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Lets your class/object say it works like something else"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/capitalization/capitalization-0.30.0-r1.ebuild
+++ b/dev-perl/capitalization/capitalization-0.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="no capitalization on method names"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86"
+KEYWORDS="alpha amd64 hppa ppc sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/Devel-Symdump"

--- a/dev-perl/common-sense/common-sense-3.740.0.ebuild
+++ b/dev-perl/common-sense/common-sense-3.740.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Save a tree AND a kitten, use common::sense!"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm ~ppc ~ppc64 ~sparc x86 ~x64-macos ~x86-solaris"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/frontier-rpc/frontier-rpc-0.07_beta4-r1.ebuild
+++ b/dev-perl/frontier-rpc/frontier-rpc-0.07_beta4-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI+=" http://perl-xml.sourceforge.net/xml-rpc/${MY_P}.tar.gz"
 HOMEPAGE+=" http://perl-xml.sourceforge.net/xml-rpc/"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm hppa ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/gnome2-canvas/gnome2-canvas-1.2.0-r1.ebuild
+++ b/dev-perl/gnome2-canvas/gnome2-canvas-1.2.0-r1.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Perl interface to the Gnome Canvas"
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ~ppc sparc x86"
+KEYWORDS="alpha amd64 ~ppc sparc x86"
 IUSE=""
 
 RDEPEND="x11-libs/gtk+:2

--- a/dev-perl/gtk2-trayicon/gtk2-trayicon-0.60.0-r1.ebuild
+++ b/dev-perl/gtk2-trayicon/gtk2-trayicon-0.60.0-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://gtk2-perl.sf.net/ ${HOMEPAGE}"
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="amd64 ia64 ~ppc ~sparc x86"
+KEYWORDS="amd64 ~ppc ~sparc x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/gtk2-traymanager/gtk2-traymanager-0.50.0-r1.ebuild
+++ b/dev-perl/gtk2-traymanager/gtk2-traymanager-0.50.0-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://gtk2-perl.sf.net/ ${HOMEPAGE}"
 
 SLOT="0"
 LICENSE="LGPL-2"
-KEYWORDS="amd64 ia64 ppc x86"
+KEYWORDS="amd64 ppc x86"
 IUSE=""
 
 RDEPEND="x11-libs/gtk+:2

--- a/dev-perl/libvorbis-perl/libvorbis-perl-0.50.0-r1.ebuild
+++ b/dev-perl/libvorbis-perl/libvorbis-perl-0.50.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Ogg::Vorbis - Perl extension for Ogg Vorbis streams"
 
 SLOT="0"
 LICENSE="|| ( Artistic GPL-2 )"
-KEYWORDS="amd64 ia64 ppc sparc x86"
+KEYWORDS="amd64 ppc sparc x86"
 IUSE=""
 
 RDEPEND="media-libs/libogg

--- a/dev-perl/mecab-perl/mecab-perl-0.996.ebuild
+++ b/dev-perl/mecab-perl/mecab-perl-0.996.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ SRC_URI="http://dev.gentoo.org/~dilfridge/distfiles/${P}.tar.gz"
 
 LICENSE="|| ( BSD LGPL-2.1 GPL-2 )"
 SLOT="0"
-KEYWORDS="amd64 ~ia64 x86"
+KEYWORDS="amd64 x86"
 IUSE=""
 
 DEPEND="~app-text/mecab-${PV}"

--- a/dev-perl/mime-construct/mime-construct-1.1100.0-r1.ebuild
+++ b/dev-perl/mime-construct/mime-construct-1.1100.0-r1.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="construct and optionally mail MIME messages"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/mime-construct/mime-construct-1.900.0-r1.ebuild
+++ b/dev-perl/mime-construct/mime-construct-1.900.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="construct and optionally mail MIME messages"
 
 LICENSE="|| ( GPL-2 GPL-3 )" # GPL-2+
 SLOT="0"
-KEYWORDS="amd64 ia64 ppc ~sparc x86"
+KEYWORDS="amd64 ppc ~sparc x86"
 IUSE=""
 
 RDEPEND="dev-perl/MIME-Types

--- a/dev-perl/pcsc-perl/pcsc-perl-1.4.14.ebuild
+++ b/dev-perl/pcsc-perl/pcsc-perl-1.4.14.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://ludovic.rousseau.free.fr/softwares/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~sh ~sparc ~x86"
 IUSE=""
 
 DEPEND=">=sys-apps/pcsc-lite-1.6.0"

--- a/dev-perl/prefork/prefork-1.40.0-r1.ebuild
+++ b/dev-perl/prefork/prefork-1.40.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Optimized module loading for forking or non-forking processes"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm arm64 hppa ia64 m68k ~mips ppc ~ppc64 s390 sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 ~arm arm64 hppa m68k ~mips ppc ~ppc64 s390 sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 DEPEND=">=virtual/perl-File-Spec-0.80


### PR DESCRIPTION
See also #4586

DO NOT MERGE.

Just a different approach for clearing up things.

Atm, mostly testing my graph analyzer works.

Package-Manager: Portage-2.3.5, Repoman-2.3.2