### PR TITLE
Enable selinux support for haveged

### DIFF
--- a/sys-apps/haveged/haveged-1.9.1-r1.ebuild
+++ b/sys-apps/haveged/haveged-1.9.1-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+inherit autotools-utils systemd
+
+DESCRIPTION="A simple entropy daemon using the HAVEGE algorithm"
+HOMEPAGE="http://www.issihosts.com/haveged/"
+SRC_URI="http://www.issihosts.com/haveged/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="amd64 arm x86"
+IUSE="selinux"
+
+DEPEND=""
+RDEPEND="
+	!<sys-apps/openrc-0.11.8
+	selinux? ( sec-policy/selinux-entropyd )"
+
+# threads are broken right now, but eventually
+# we should add $(use_enable threads)
+src_configure() {
+	local myeconfargs=(
+		--bindir=/usr/sbin
+		--enable-nistest
+		--disable-static
+		--disable-threads
+	)
+
+	autotools-utils_src_configure
+}
+
+src_install() {
+	autotools-utils_src_install
+
+	# Install gentoo ones instead
+	newinitd "${FILESDIR}"/haveged-init.d.3 haveged
+	newconfd "${FILESDIR}"/haveged-conf.d haveged
+
+	systemd_newunit "${FILESDIR}"/service.gentoo ${PN}.service
+	insinto /etc
+	doins "${FILESDIR}"/haveged.conf
+}

--- a/sys-apps/haveged/haveged-1.9.1-r1.ebuild
+++ b/sys-apps/haveged/haveged-1.9.1-r1.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
-inherit autotools-utils systemd
+inherit eutils systemd
 
 DESCRIPTION="A simple entropy daemon using the HAVEGE algorithm"
 HOMEPAGE="http://www.issihosts.com/haveged/"
@@ -22,18 +22,15 @@ RDEPEND="
 # threads are broken right now, but eventually
 # we should add $(use_enable threads)
 src_configure() {
-	local myeconfargs=(
+	econf \
 		--bindir=/usr/sbin
 		--enable-nistest
 		--disable-static
 		--disable-threads
-	)
-
-	autotools-utils_src_configure
 }
 
 src_install() {
-	autotools-utils_src_install
+	emake DESTDIR="${D}" install
 
 	# Install gentoo ones instead
 	newinitd "${FILESDIR}"/haveged-init.d.3 haveged


### PR DESCRIPTION
The hardened-refpolicy "entropyd" covers sys-apps/haveged entropy daemon as well, so this patch bumps haveged-1.9.1 to -r1 and adds dependency to selinux-entropyd when the "selinux" USE flag is in effect.

Build and run tested.
