### PR TITLE
net-libs/ptlib: Fix building with GCC-6

### DIFF
--- a/net-libs/ptlib/files/ptlib-2.10.11-gcc6.patch
+++ b/net-libs/ptlib/files/ptlib-2.10.11-gcc6.patch
@@ -1,0 +1,29 @@
+--- a/src/ptlib/unix/svcproc.cxx
++++ b/src/ptlib/unix/svcproc.cxx
+@@ -217,7 +217,7 @@
+     pid_t pid;
+ 
+     {
+-      ifstream pidfile(pidfilename);
++      ifstream pidfile(static_cast<const char*>(pidfilename));
+       if (!pidfile.is_open()) {
+         cout << "Could not open pid file: \"" << pidfilename << "\""
+                 " - " << strerror(errno) << endl;
+@@ -384,7 +384,7 @@
+   // Run as a daemon, ie fork
+ 
+   if (!pidfilename) {
+-    ifstream pidfile(pidfilename);
++    ifstream pidfile(static_cast<const char*>(pidfilename));
+     if (pidfile.is_open()) {
+       pid_t pid;
+       pidfile >> pid;
+@@ -412,7 +412,7 @@
+       cout << "Daemon started with pid " << pid << endl;
+       if (!pidfilename) {
+         // Write out the child pid to magic file in /var/run (at least for linux)
+-        ofstream pidfile(pidfilename);
++        ofstream pidfile(static_cast<const char*>(pidfilename));
+         if (pidfile.is_open())
+           pidfile << pid;
+         else

--- a/net-libs/ptlib/ptlib-2.10.11.ebuild
+++ b/net-libs/ptlib/ptlib-2.10.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -60,7 +60,8 @@ src_prepare() {
 		"${FILESDIR}/${PN}-2.10.9-pkgconfig_ldflags.patch" \
 		"${FILESDIR}/${PN}-2.10.9-respect_cxxflags.patch" \
 		"${FILESDIR}/${PN}-2.10.10-mga-bison-parameter.patch" \
-		"${FILESDIR}/${PN}-2.10.10-respect_cflags_cxxflags.patch"
+		"${FILESDIR}/${PN}-2.10.10-respect_cflags_cxxflags.patch" \
+		"${FILESDIR}/${P}-gcc6.patch"
 
 	if ! use telnet; then
 		epatch "${FILESDIR}/${PN}-2.10.9-disable-telnet-symbols.patch"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=595690
Package-Manager: Portage-2.3.5, Repoman-2.3.2

C++11 defines the constructor `explicit ifstream::ifstream( const string& filename, ios_base::openmode mode)`.  C++98 already has a similar constructor that takes a `const char *`.  Post-C++11, when constructing from an object that can be implicitly converted to either a string or a char*, it is an ambiguity.  Since the C++98 behavior is to convert to a `const char*`, explicitly casting to it works in any C++ dialect.  A similar situation exists for `ostream`.