### PR TITLE
app-misc/elasticsearch: include license for bundled libs

### DIFF
--- a/app-misc/elasticsearch/elasticsearch-5.1.2.ebuild
+++ b/app-misc/elasticsearch/elasticsearch-5.1.2.ebuild
@@ -8,7 +8,7 @@ inherit eutils systemd user
 DESCRIPTION="Open Source, Distributed, RESTful, Search Engine"
 HOMEPAGE="https://www.elastic.co/products/elasticsearch"
 SRC_URI="https://artifacts.elastic.co/downloads/${PN}/${P}.tar.gz"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD-2 LGPL-3 MIT public-domain"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-misc/elasticsearch/elasticsearch-5.2.2.ebuild
+++ b/app-misc/elasticsearch/elasticsearch-5.2.2.ebuild
@@ -8,7 +8,7 @@ inherit eutils systemd user
 DESCRIPTION="Open Source, Distributed, RESTful, Search Engine"
 HOMEPAGE="https://www.elastic.co/products/elasticsearch"
 SRC_URI="https://artifacts.elastic.co/downloads/${PN}/${P}.tar.gz"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD-2 LGPL-3 MIT public-domain"
 SLOT="0"
 KEYWORDS="~amd64"
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2

https://bugs.gentoo.org/show_bug.cgi?id=617720