### PR TITLE
media-video/dvgrab: fix building with GCC-6

### DIFF
--- a/media-video/dvgrab/dvgrab-3.5-r1.ebuild
+++ b/media-video/dvgrab/dvgrab-3.5-r1.ebuild
@@ -21,6 +21,10 @@ RDEPEND=">=sys-libs/libraw1394-1.1
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-3.5-gcc6.patch"
+)
+
 src_configure() {
 	econf \
 		$(use_with quicktime libquicktime) \

--- a/media-video/dvgrab/dvgrab-3.5-r1.ebuild
+++ b/media-video/dvgrab/dvgrab-3.5-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Digital Video (DV) grabber for GNU/Linux"
+HOMEPAGE="http://www.kinodv.org/"
+SRC_URI="mirror://sourceforge/kino/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE="jpeg quicktime"
+
+RDEPEND=">=sys-libs/libraw1394-1.1
+	>=media-libs/libdv-0.103
+	>=media-libs/libiec61883-1
+	>=sys-libs/libavc1394-0.5.1
+	jpeg? ( virtual/jpeg:0 )
+	quicktime? ( media-libs/libquicktime )"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+src_configure() {
+	econf \
+		$(use_with quicktime libquicktime) \
+		$(use_with jpeg libjpeg)
+}

--- a/media-video/dvgrab/files/dvgrab-3.5-gcc6.patch
+++ b/media-video/dvgrab/files/dvgrab-3.5-gcc6.patch
@@ -1,0 +1,25 @@
+commit 8dd729f2cf4cc5b99ad2e3961419cf71d2dfb843
+Author: Aaro Koskinen <aaro.koskinen@iki.fi>
+Date:   Sun May 15 22:44:23 2016 +0300
+
+    iec13818-1.h: fix build with GCC 6.1.0
+    
+    Fix the following build issue with GCC 6.1.0:
+    
+    iec13818-1.h:45:75: error: narrowing conversion of '255' from 'int' to 'char' inside { } [-Wnarrowing]
+     static char bitmask[8] = { 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff };
+                                                                               ^
+
+diff --git a/iec13818-1.h b/iec13818-1.h
+index 56a4aa0..e964288 100644
+--- a/iec13818-1.h
++++ b/iec13818-1.h
+@@ -42,7 +42,7 @@
+ #define BCD(c) ( ((((c) >> 4) & 0x0f) * 10) + ((c) & 0x0f) )
+ 
+ #define TOBYTES( n ) ( ( n + 7 ) / 8 )
+-static char bitmask[8] = { 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff };
++static unsigned char bitmask[8] = { 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff };
+ #define GETBITS( offset, len ) do { \
+ 	unsigned long value = 0; \
+ 	while ( len > 0 ) \


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/594548
Patch: https://github.com/ddennedy/dvgrab/commit/8dd729f2cf4cc5b99ad2e3961419cf71d2dfb843