### PR TITLE
net-analyzer/ifstatus: Fix building with GCC-6

### DIFF
--- a/net-analyzer/ifstatus/files/ifstatus-1.1.0-gcc6.patch
+++ b/net-analyzer/ifstatus/files/ifstatus-1.1.0-gcc6.patch
@@ -1,12 +1,14 @@
 --- a/Interface.h
 +++ b/Interface.h
-@@ -57,7 +57,8 @@
+@@ -57,7 +57,11 @@
  
  	InterfaceData & operator=(InterfaceData & rInterfaceData);
  	InterfaceData operator-(InterfaceData & rInterfaceData);
--	
+	
++#if __cplusplus >= 201103L
 +	InterfaceData & operator=(InterfaceData && rInterfaceData) = default;
 +	InterfaceData(const InterfaceData&) = default;
++#endif
  private:
  
  	unsigned long long m_ullReceived[eTotalTypes];


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=618234 https://bugs.gentoo.org/show_bug.cgi?id=594510
Package-Manager: Portage-2.3.5, Repoman-2.3.2

Sorry.  I had previously forgot to conditionally declare the defaulted member functions only for >=C++11.  This should work and was tested on GCC-6.3.0 and GCC-5.4.0.