### PR TITLE
media-libs/libfpx: Fix building with GCC-6

### DIFF
--- a/media-libs/libfpx/files/libfpx-1.2.0.13-export-symbols.patch
+++ b/media-libs/libfpx/files/libfpx-1.2.0.13-export-symbols.patch
@@ -1,8 +1,8 @@
 * At least the Darwin linker doesn't like double symbols during the
   final linking stage...
 
---- jpeg/jpegconf.h
-+++ jpeg/jpegconf.h
+--- a/jpeg/jpegconf.h
++++ b/jpeg/jpegconf.h
 @@ -27,6 +27,6 @@
  #   pragma warning(disable : 4244)
  #   pragma warning(disable : 4142)

--- a/media-libs/libfpx/files/libfpx-1.3.1_p6-gcc6.patch
+++ b/media-libs/libfpx/files/libfpx-1.3.1_p6-gcc6.patch
@@ -1,0 +1,35 @@
+--- a/oless/h/page.hxx
++++ b/oless/h/page.hxx
+@@ -47,6 +47,7 @@
+ {
+ public:
+     void * operator new(size_t size, size_t sizeData);
++    void operator delete(void *ptr);
+ 
+     CMSFPage(CMSFPage *pmpNext);
+     inline ~CMSFPage();
+@@ -133,6 +134,24 @@
+ }
+ 
+ //+---------------------------------------------------------------------------
++//
++//  Member: CMSFPage::operator delete, public
++//
++//  Synopsis: Overloaded delete operator for CMSFPage.
++//
++//  Arguments:  [ptr] -- Pointer to CMSFPage object
++//
++//----------------------------------------------------------------------------
++
++inline void CMSFPage::operator delete(void *ptr)
++{
++    if (ptr) {
++        free(ptr);
++        ptr = NULL;
++    }
++}
++
++//+---------------------------------------------------------------------------
+ //
+ //  Member: CMSFPage::GetNext, public
+ //

--- a/media-libs/libfpx/libfpx-1.3.1_p6.ebuild
+++ b/media-libs/libfpx/libfpx-1.3.1_p6.ebuild
@@ -15,10 +15,13 @@ IUSE="static-libs"
 
 S=${WORKDIR}/${P/_p/-}
 
-src_prepare() {
-	epatch "${FILESDIR}"/${PN}-1.2.0.13-export-symbols.patch
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.2.0.13-export-symbols.patch
+	"${FILESDIR}"/${P}-gcc6.patch
+)
 
-	eapply_user
+src_prepare() {
+	default
 
 	# we're not windows, even though we don't define __unix by default
 	[[ ${CHOST} == *-darwin* ]] && append-flags -D__unix


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594094
Package-Manager: Portage-2.3.5, Repoman-2.3.2

In the offending code, a class-specific placement new method is defined for `class CMSFPage`.  A call is made to placement new in `CMSFPageTable::GetNewPage()`.  This calls the class-specific placement new method.  Previous to C++14, if an exception was thrown from placement new, non-placement delete was called for cleanup.  This was later disallowed in C++14.  Furthermore, though the class defined placement new calls the C function `malloc()`,  it would have implicitly called `delete` instead of `free()` for cleanup.  Though `delete` is often implemented with `free()` and generally won't result in an error, it is considered undefined behavior.

The proposed solution is to define a class-specific placement delete method that implements `free()`.
Tested with gcc-6.3.0 and gcc-5.4.0.