### PR TITLE
sys-power/powertop: NO_HZ_IDLE replaces deprecated NO_HZ Kernel option

### DIFF
--- a/sys-power/powertop/powertop-9999.ebuild
+++ b/sys-power/powertop/powertop-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -42,7 +42,7 @@ pkg_setup() {
 		~DEBUG_FS
 		~PERF_EVENTS
 		~TRACEPOINTS
-		~NO_HZ
+		~NO_HZ_IDLE
 		~HIGH_RES_TIMERS
 		~HPET_TIMER
 		~CPU_FREQ_STAT
@@ -56,7 +56,7 @@ pkg_setup() {
 	ERROR_KERNEL_DEBUG_FS="DEBUG_FS is not enabled in the kernel, you almost certainly need it"
 	ERROR_KERNEL_PERF_EVENTS="PERF_EVENTS should be enabled in the kernel for full powertop function"
 	ERROR_KERNEL_TRACEPOINTS="TRACEPOINTS should be enabled in the kernel for full powertop function"
-	ERROR_KERNEL_NO_HZ="NO_HZ should be enabled in the kernel for full powertop function"
+	ERROR_KERNEL_NO_HZ_IDLE="NO_HZ_IDLE should be enabled in the kernel for full powertop function"
 	ERROR_KERNEL_HIGH_RES_TIMERS="HIGH_RES_TIMERS should be enabled in the kernel for full powertop function"
 	ERROR_KERNEL_HPET_TIMER="HPET_TIMER should be enabled in the kernel for full powertop function"
 	ERROR_KERNEL_CPU_FREQ_STAT="CPU_FREQ_STAT should be enabled in the kernel for full powertop function"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=575418

Package-Manager: Portage-2.3.5, Repoman-2.3.2