### PR TITLE
sys-libs/libcxxrt: Fix building with GCC-6

### DIFF
--- a/sys-libs/libcxxrt/files/libcxxrt-0.0_p20150423-gcc6.patch
+++ b/sys-libs/libcxxrt/files/libcxxrt-0.0_p20150423-gcc6.patch
@@ -1,0 +1,92 @@
+--- a/src/memory.cc
++++ b/src/memory.cc
+@@ -71,8 +71,17 @@
+ }
+ 
+ 
++#if __cplusplus < 201103L
++#define NOEXCEPT throw()
++#define BADALLOC throw(std::bad_alloc)
++#else
++#define NOEXCEPT noexcept
++#define BADALLOC
++#endif
++
++
+ __attribute__((weak))
+-void* operator new(size_t size)
++void* operator new(size_t size) BADALLOC
+ {
+ 	if (0 == size)
+ 	{
+@@ -97,7 +106,7 @@
+ }
+ 
+ __attribute__((weak))
+-void* operator new(size_t size, const std::nothrow_t &) throw()
++void* operator new(size_t size, const std::nothrow_t &) NOEXCEPT
+ {
+ 	try {
+ 		return :: operator new(size);
+@@ -110,27 +119,21 @@
+ 
+ 
+ __attribute__((weak))
+-void operator delete(void * ptr)
+-#if __cplusplus < 201000L
+-throw()
+-#endif
++void operator delete(void * ptr) NOEXCEPT
+ {
+ 	free(ptr);
+ }
+ 
+ 
+ __attribute__((weak))
+-void * operator new[](size_t size)
+-#if __cplusplus < 201000L
+-throw(std::bad_alloc)
+-#endif
++void * operator new[](size_t size) BADALLOC
+ {
+ 	return ::operator new(size);
+ }
+ 
+ 
+ __attribute__((weak))
+-void * operator new[](size_t size, const std::nothrow_t &) throw()
++void * operator new[](size_t size, const std::nothrow_t &) NOEXCEPT
+ {
+ 	try {
+ 		return ::operator new[](size);
+@@ -143,12 +146,26 @@
+ 
+ 
+ __attribute__((weak))
+-void operator delete[](void * ptr)
+-#if __cplusplus < 201000L
+-throw()
+-#endif
++void operator delete[](void * ptr) NOEXCEPT
+ {
+ 	::operator delete(ptr);
+ }
+ 
++// C++14 additional delete operators
++
++#if __cplusplus >= 201402L
+ 
++__attribute__((weak))
++void operator delete(void * ptr, std::size_t) NOEXCEPT
++{
++	::operator delete(ptr);
++}
++
++
++__attribute__((weak))
++void operator delete[](void * ptr, std::size_t) NOEXCEPT
++{
++	::operator delete(ptr);
++}
++
++#endif

--- a/sys-libs/libcxxrt/files/libcxxrt-0.0_p20160922-gcc6.patch
+++ b/sys-libs/libcxxrt/files/libcxxrt-0.0_p20160922-gcc6.patch
@@ -1,0 +1,24 @@
+--- a/src/memory.cc
++++ b/src/memory.cc
+@@ -151,4 +151,21 @@ void operator delete[](void * ptr) NOEXCEPT
+ 	::operator delete(ptr);
+ }
+ 
++// C++14 additional delete operators
+ 
++#if __cplusplus >= 201402L
++
++__attribute__((weak))
++void operator delete(void * ptr, std::size_t) NOEXCEPT
++{
++	::operator delete(ptr);
++}
++
++
++__attribute__((weak))
++void operator delete[](void * ptr, std::size_t) NOEXCEPT
++{
++	::operator delete(ptr);
++}
++
++#endif

--- a/sys-libs/libcxxrt/libcxxrt-0.0_p20140322.ebuild
+++ b/sys-libs/libcxxrt/libcxxrt-0.0_p20140322.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -34,6 +34,8 @@ DEPEND="${RDEPEND}
 DOCS=( AUTHORS COPYRIGHT README )
 
 src_prepare() {
+	epatch "${FILESDIR}"/${PN}-0.0_p20150423-gcc6.patch
+
 	cp "${FILESDIR}/Makefile" src/ || die
 	cp "${FILESDIR}/Makefile.test" test/Makefile || die
 	multilib_copy_sources

--- a/sys-libs/libcxxrt/libcxxrt-0.0_p20150423-r1.ebuild
+++ b/sys-libs/libcxxrt/libcxxrt-0.0_p20150423-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -35,6 +35,8 @@ DEPEND="${RDEPEND}
 DOCS=( AUTHORS COPYRIGHT README )
 
 src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc6.patch
+
 	cp "${FILESDIR}/Makefile" src/ || die
 	cp "${FILESDIR}/Makefile.test" test/Makefile || die
 	multilib_copy_sources

--- a/sys-libs/libcxxrt/libcxxrt-0.0_p20160922.ebuild
+++ b/sys-libs/libcxxrt/libcxxrt-0.0_p20160922.ebuild
@@ -35,6 +35,8 @@ DEPEND="${RDEPEND}
 DOCS=( AUTHORS COPYRIGHT README )
 
 src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc6.patch
+
 	cp "${FILESDIR}/Makefile" src/ || die
 	cp "${FILESDIR}/Makefile.test" test/Makefile || die
 	multilib_copy_sources


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594138
Package-Manager: Portage-2.3.5, Repoman-2.3.2

Patches derive from https://github.com/pathscale/libcxxrt/commit/edda6268a7dae91ac98bf43863489bb75d79fc9c and https://github.com/pathscale/libcxxrt/commit/db54f535fc67703b2993b9b2d3fc7ede7a608936