### PR TITLE
net-vpn/openvpn-2.4.2: keyword ~x64-macos

### DIFF
--- a/net-vpn/openvpn/openvpn-2.4.2.ebuild
+++ b/net-vpn/openvpn/openvpn-2.4.2.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://openvpn.net/"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ~ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux"
+KEYWORDS="alpha amd64 ~arm hppa ~ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~sparc-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x64-macos"
 
 IUSE="down-root examples inotify iproute2 libressl lz4 +lzo mbedtls pam"
 IUSE+=" pkcs11 +plugins polarssl selinux +ssl static systemd test userland_BSD"
@@ -126,6 +126,11 @@ pkg_postinst() {
 	if path_exists -o "${EROOT%/}"/etc/openvpn/*/local.conf ; then
 		ewarn "WARNING: The openvpn init script has changed"
 		ewarn ""
+	fi
+
+	if use x64-macos ; then
+	   elog "You might want to install tuntaposx for TAP interface support:"
+	   elog "http://tuntaposx.sourceforge.net"
 	fi
 
 	elog "The openvpn init script expects to find the configuration file"


### PR DESCRIPTION
/cc @mrueg @chutz 

OpenVPN works on macOS Gentoo Prefix, so it makes sense to keyword it. macOS doesn't have a built-in TAP device, so I've added macOS-specific instructions on how to get TAP to work.