### PR TITLE
mail-filter/libdkim: Fix building with GCC-6

### DIFF
--- a/mail-filter/libdkim/files/libdkim-1.0.21-gcc6.patch
+++ b/mail-filter/libdkim/files/libdkim-1.0.21-gcc6.patch
@@ -1,0 +1,25 @@
+--- a/src/dkimverify.cpp
++++ b/src/dkimverify.cpp
+@@ -211,14 +211,14 @@
+ unsigned DecodeBase64(char *ptr)
+ {
+ 	static const unsigned char base64_table[256] = {
+-		-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+-		-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-1,-1,-1,
+-		-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,
+-		-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,-1,-1,-1,-1,-1,
+-		-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+-		-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+-		-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+-		-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
++		(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,
++		(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,62,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,63,52,53,54,55,56,57,58,59,60,61,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,
++		(unsigned char) -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,
++		(unsigned char) -1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,
++		(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,
++		(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,
++		(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,
++		(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1,(unsigned char) -1};
+ 
+ 	unsigned char *s = (unsigned char *)ptr;
+ 	unsigned char *d = (unsigned char *)ptr;

--- a/mail-filter/libdkim/libdkim-1.0.21-r3.ebuild
+++ b/mail-filter/libdkim/libdkim-1.0.21-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -32,6 +32,7 @@ src_prepare() {
 	cp  "${FILESDIR}"/debianize/* "${S}"
 	epatch "${FILESDIR}"/patches/*.patch
 	epatch "${FILESDIR}"/libdkim-extra-options.patch
+	epatch "${FILESDIR}"/${P}-gcc6.patch
 
 	# Bug 476772
 	if ! use static-libs; then


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594320
Package-Manager: Portage-2.3.5, Repoman-2.3.2

Patch submitted [upstream](https://sourceforge.net/p/libdkim/patches/6/). 

Package seems to be unmaintained upstream and has no portage maintainer, so a good candidate for purging.  If so, drop this PR.