### PR TITLE
Add missing `numpy` dependency

### DIFF
--- a/media-gfx/printrun/printrun-20140730.ebuild
+++ b/media-gfx/printrun/printrun-20140730.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -17,10 +17,11 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="dev-python/pyserial
-	dev-python/wxpython
+	dev-python/wxpython:2.8
 	dev-python/pyglet
 	dev-python/dbus-python
-	media-gfx/cairosvg"
+	media-gfx/cairosvg
+	dev-python/numpy"
 RDEPEND="${DEPEND}"
 
 PATCHES=(

--- a/media-gfx/printrun/printrun-20150310.ebuild
+++ b/media-gfx/printrun/printrun-20150310.ebuild
@@ -20,7 +20,8 @@ DEPEND="dev-python/pyserial
 	dev-python/wxpython:2.8
 	dev-python/pyglet
 	dev-python/dbus-python
-	media-gfx/cairosvg"
+	media-gfx/cairosvg
+	dev-python/numpy"
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/Printrun-${P}"

--- a/media-gfx/printrun/printrun-99999999.ebuild
+++ b/media-gfx/printrun/printrun-99999999.ebuild
@@ -20,5 +20,6 @@ DEPEND="dev-python/pyserial
 	dev-python/wxpython:2.8
 	dev-python/pyglet
 	dev-python/dbus-python
-	media-gfx/cairosvg"
+	media-gfx/cairosvg
+	dev-python/numpy"
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.1