### PR TITLE
dev-lang/gforth: keyword ~x64-macos

### DIFF
--- a/dev-lang/gforth/gforth-0.7.3.ebuild
+++ b/dev-lang/gforth/gforth-0.7.3.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://gnu/gforth/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~x86 ~x86-fbsd ~x86-linux ~ppc-macos ~sparc-solaris"
+KEYWORDS="~amd64 ~ppc ~x86 ~x86-fbsd ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris"
 IUSE="emacs"
 
 DEPEND="dev-libs/ffcall


### PR DESCRIPTION
/cc @cstrotm

gforth is stable on x64 macOS Gentoo Prefix.