### PR TITLE
virtual/commonlisp: keywords from dev-lisp/sbcl

### DIFF
--- a/virtual/commonlisp/commonlisp-0.ebuild
+++ b/virtual/commonlisp/commonlisp-0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 DESCRIPTION="Virtual for Common Lisp"
 SLOT="0"
-KEYWORDS="alpha amd64 ia64 ppc ~sparc x86"
+KEYWORDS="alpha amd64 ia64 ppc ~sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~x86-solaris"
 
 RDEPEND="|| ( dev-lisp/sbcl
 	dev-lisp/clisp


### PR DESCRIPTION
Keyword Gentoo Prefix keywords. See: https://github.com/gentoo/gentoo/blob/a4f5cb73c86e5092123294e2b222fb9e3c693602/dev-lisp/sbcl/sbcl-1.3.17.ebuild#L41