### PR TITLE
dev-libs/libsigsegv: keyword ~x64-macos

### DIFF
--- a/dev-libs/libsigsegv/libsigsegv-2.11.ebuild
+++ b/dev-libs/libsigsegv/libsigsegv-2.11.ebuild
@@ -9,7 +9,7 @@ SRC_URI="mirror://gnu/libsigsegv/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x64-macos ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 src_configure () {


### PR DESCRIPTION
dev-libs/libsigsegv is stable on ~x64-macos. This is preliminary work to get dev-lisp/clisp ~x64-macos keyworded.