### PR TITLE
media-gfx/scour: Fix Python dependencies and support tests

### DIFF
--- a/media-gfx/scour/scour-0.35-r1.ebuild
+++ b/media-gfx/scour/scour-0.35-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+inherit distutils-r1
+
+DESCRIPTION="Take an SVG file and produce a cleaner and more concise file"
+HOMEPAGE="http://www.codedread.com/scour/"
+SRC_URI="https://github.com/codedread/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~x86"
+IUSE=""
+
+RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/six[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}"
+
+python_test() {
+	"${EPYTHON}" testscour.py || die "Tests fail with ${EPYTHON}"
+}


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2

---

- six is needed at run-time as well, ensure it is installed for matching Python versions
- remove python3_3 from PYTHON_COMPAT, no longer in the tree

```
--- scour-0.35.ebuild
+++ scour-0.35-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=(python{2_7,3_3,3_4,3_5})
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="Take an SVG file and produce a cleaner and more concise file"
@@ -15,4 +15,5 @@
 KEYWORDS="~amd64 ~hppa ~x86"
 IUSE=""
 
-DEPEND="dev-python/six"
+RDEPEND="dev-python/six[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}"

```