### PR TITLE
app-cdr/b5i2iso: segfault patch, HOMEPAGE, Gentoo Prefix

### DIFF
--- a/app-cdr/b5i2iso/b5i2iso-0.2-r1.ebuild
+++ b/app-cdr/b5i2iso/b5i2iso-0.2-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+inherit toolchain-funcs
+
+DESCRIPTION="Convert CD images from b5i (BlindWrite) to iso"
+HOMEPAGE="https://web.archive.org/web/20100116120705/b5i2iso.berlios.de"
+SRC_URI="mirror://gentoo/${PN}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux ~x86-macos ~x64-macos"
+PATCHES=( "${FILESDIR}/${P}-segfault.patch" )
+
+S=${WORKDIR}/${PN}
+
+src_compile() {
+	$(tc-getCC) ${LDFLAGS} ${CFLAGS} src/${PN}.c -o ${PN}
+}
+
+src_install() {
+	dobin ${PN}
+}

--- a/app-cdr/b5i2iso/files/b5i2iso-0.2-segfault.patch
+++ b/app-cdr/b5i2iso/files/b5i2iso-0.2-segfault.patch
@@ -1,0 +1,18 @@
+--- b5i2iso/src/b5i2iso.c
++++ b5i2iso/src/b5i2iso.c
+@@ -1,3 +1,4 @@
++#include <errno.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -45,6 +46,10 @@
+    }
+ 
+ fsource = fopen(argv[1],"rb");
++if (fsource == NULL) {
++  printf("can't open %s: %s\n", argv[1], strerror(errno));
++  exit(EXIT_FAILURE);
++}
+ fdest = fopen(destfilename,"wb");
+ 
+ fseek(fsource, 2352, SEEK_CUR);

--- a/app-cdr/b5i2iso/metadata.xml
+++ b/app-cdr/b5i2iso/metadata.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+<maintainer type="person">
+    <email>yegortimoshenko@gmail.com</email>
+    <name>Yegor Timoshenko</name>
+</maintainer>  
 </pkgmetadata>


### PR DESCRIPTION
Segfault happens when you provide file that doesn't exist as an argument. As b5i2iso doesn't support flags, triggering this particular segfault is very easy:

```
$ b5i2iso -h
segmentation fault: 11
```

The patch included with the ebuild fixes that.