### PR TITLE
x11-drivers/nvidia-drivers: fix typo in 381.22

### DIFF
--- a/x11-drivers/nvidia-drivers/nvidia-drivers-381.22.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-381.22.ebuild
@@ -92,7 +92,7 @@ nvidia_drivers_versions_check() {
 		die "Unexpected \${DEFAULT_ABI} = ${DEFAULT_ABI}"
 	fi
 
-	if use kernel_linux && kernel_is ge 4.12; then
+	if use kernel_linux && kernel_is ge 4 12; then
 		ewarn "Gentoo supports kernels which are supported by NVIDIA"
 		ewarn "which are limited to the following kernels:"
 		ewarn "<sys-kernel/gentoo-sources-4.12"


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/618886

The current version of this file has a typo that causes the pre-merge
checks to fail. This should fix it.