### PR TITLE
dev-tex/biblatex: add biber use flag

### DIFF
--- a/dev-tex/biblatex/biblatex-3.7-r1.ebuild
+++ b/dev-tex/biblatex/biblatex-3.7-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit latex-package
+
+DESCRIPTION="Reimplementation of the bibliographic facilities provided by LaTeX"
+HOMEPAGE="http://www.ctan.org/tex-archive/macros/latex/contrib/biblatex https://github.com/plk/biblatex/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tds.tgz"
+
+LICENSE="LPPL-1.3"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="+biber doc examples"
+
+DEPEND="dev-texlive/texlive-bibtexextra
+	dev-texlive/texlive-latexextra
+	dev-texlive/texlive-genericextra"
+RDEPEND="${DEPEND}
+	biber? ( ~dev-tex/biber-2.7 )"
+
+S="${WORKDIR}"
+TEXMF=/usr/share/texmf-site
+
+src_install() {
+	insinto "${TEXMF}"
+	doins -r bibtex tex
+
+	dodoc doc/latex/biblatex/{README,CHANGES.org}
+	if use doc ; then
+		pushd doc || die
+		latex-package_src_doinstall doc
+		popd || die
+	fi
+
+	if use examples ; then
+		dodoc -r doc/latex/biblatex/examples
+	fi
+}

--- a/dev-tex/biblatex/metadata.xml
+++ b/dev-tex/biblatex/metadata.xml
@@ -13,6 +13,9 @@
 		<email>tex@gentoo.org</email>
 		<name>Gentoo TeX Project</name>
 	</maintainer>
+	<use>
+		<flag name="biber">Install the unicode compatible backend processor</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">plk/biblatex</remote-id>
 		<remote-id type="sourceforge">biblatex</remote-id>


### PR DESCRIPTION
biber is the default backend for biblatex for several versions now and supersedes the old bibtex and bibtex8 backends. New revision as biber is not keyworded for arm and x86 yet (a bug for that will follow once this is merged).

At the same time this patch updates to EAPI 6