### PR TITLE
net-irc/weechat: Add buflist plugin in USE flags

### DIFF
--- a/net-irc/weechat/metadata.xml
+++ b/net-irc/weechat/metadata.xml
@@ -9,6 +9,7 @@
 	</maintainer>
 	<use>
 		<flag name="alias">Enable plugin for alias control.</flag>
+		<flag name="buflist">Enable buflist plugin.</flag>
 		<flag name="charset">Enable encoding conversions.</flag>
 		<flag name="exec">Enable exec plugin.</flag>
 		<flag name="fifo">Enable FIFO support (sh pipes).</flag>

--- a/net-irc/weechat/weechat-1.8-r1.ebuild
+++ b/net-irc/weechat/weechat-1.8-r1.ebuild
@@ -21,7 +21,7 @@ LICENSE="GPL-3"
 SLOT="0"
 
 NETWORKS="+irc"
-PLUGINS="+alias +charset +exec +fifo +logger +relay +scripts +spell +trigger +xfer"
+PLUGINS="+alias +buflist +charset +exec +fifo +logger +relay +scripts +spell +trigger +xfer"
 # dev-lang/v8 was dropped from Gentoo so we can't enable javascript support
 SCRIPT_LANGS="guile lua +perl +python ruby tcl"
 LANGS=" cs de es fr hu it ja pl pt pt_BR ru tr"
@@ -124,6 +124,7 @@ src_configure() {
 		-DENABLE_TESTS=$(usex test)
 		-DENABLE_TRIGGER=$(usex trigger)
 		-DENABLE_XFER=$(usex xfer)
+		-DENABLE_BUFLIST=$(usex buflist)
 	)
 
 	if use python; then


### PR DESCRIPTION
Starting from revision 1.8, weechat integrates a new plugin: [buflist](https://github.com/weechat/weechat/commit/edfeb60e32688777073a9f2d89071c86f5313710#diff-67e997bcfdac55191033d57a16d1408aR143).

This PR appends it to the `PLUGIN` list in the ebuild, as it can be disabled like others plugins.