### PR TITLE
dev-libs/mongo-c-driver: fix building with libressl (bug #618988)

### DIFF
--- a/dev-libs/mongo-c-driver/mongo-c-driver-1.6.2.ebuild
+++ b/dev-libs/mongo-c-driver/mongo-c-driver-1.6.2.ebuild
@@ -44,7 +44,7 @@ src_configure() {
 		--disable-examples \
 		--docdir="${EPREFIX}/usr/share/doc/${P}" \
 		$(use_enable sasl) \
-		$(use_enable ssl ssl openssl) \
+		$(use_enable ssl ssl $(usex libressl libressl openssl)) \
 		$(use_enable debug) \
 		$(use_enable static-libs static)
 }


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=618988