### PR TITLE
mail-filter/mapson: Fix building with GCC-6

### DIFF
--- a/mail-filter/mapson/files/mapson-3.3-gcc6.patch
+++ b/mail-filter/mapson/files/mapson-3.3-gcc6.patch
@@ -1,0 +1,287 @@
+--- a/accept-confirmation.cpp
++++ b/accept-confirmation.cpp
+@@ -52,7 +52,7 @@
+     for (rc = read(fd, tmp, sizeof(tmp)); rc > 0; rc = read(fd, tmp, sizeof(tmp)))
+       mail.append(tmp, rc);
+     if (rc < 0)
+-      throw system_error(string("Failed to read mail file '") + filename + "'");
++      throw mapson_system_error(string("Failed to read mail file '") + filename + "'");
+     deliver(mail);
+     unlink(filename.c_str());
+   }
+--- a/address-db.cpp
++++ b/address-db.cpp
+@@ -26,7 +26,7 @@
+ 
+   fd = open(filename.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+   if (fd < 0)
+-    throw system_error(string("Can't open address db '") +
++    throw mapson_system_error(string("Can't open address db '") +
+                       filename + "' for reading");
+   fd_sentry sentry(fd);
+ 
+@@ -36,7 +36,7 @@
+   lock.l_start  = 0;
+   lock.l_len    = 0;
+   if (fcntl(fd, F_SETLKW, &lock) != 0)
+-    throw system_error(string("Can't lock file '") + filename + "'");
++    throw mapson_system_error(string("Can't lock file '") + filename + "'");
+ 
+   // Read the file into memory.
+ 
+@@ -47,7 +47,7 @@
+        rc = read(fd, buffer, sizeof(buffer)))
+     data.append(buffer, rc);
+   if (rc < 0)
+-    throw system_error(string("Failed to read address db '") +
++    throw mapson_system_error(string("Failed to read address db '") +
+                       filename + "' into memory");
+ 
+   // Success. Don't close the file descriptor.
+@@ -107,7 +107,7 @@
+   {
+     ssize_t rc = write(fd, data.data()+len, data.size()-len);
+     if (rc < 0)
+-      throw system_error(string("Failed writing to the address db '") + filename + "'");
++      throw mapson_system_error(string("Failed writing to the address db '") + filename + "'");
+     else
+       len += rc;
+   }
+--- a/config.cpp
++++ b/config.cpp
+@@ -70,9 +70,9 @@
+     string tmp = string(name) + "=" + value;
+     char* env = strdup(tmp.c_str());
+     if (env == 0)
+-      throw system_error("strdup() failed");
++      throw mapson_system_error("strdup() failed");
+     if (putenv(env) != 0)
+-      throw system_error("putenv() failed");
++      throw mapson_system_error("putenv() failed");
+   }
+ }
+ 
+@@ -84,7 +84,7 @@
+ 
+   pwd_sentry sentry(getpwuid(getuid()));
+   if (sentry.pwd == 0)
+-    throw system_error("Can't get my user name");
++    throw mapson_system_error("Can't get my user name");
+   log_file.assign(sentry.pwd->pw_dir).append("/.mapson/log");
+   spool_dir.assign(sentry.pwd->pw_dir).append("/.mapson/spool");
+   address_db.assign(sentry.pwd->pw_dir).append("/.mapson/address-db");
+--- a/deliver.cpp
++++ b/deliver.cpp
+@@ -31,11 +31,11 @@
+ 
+     FILE* fh = popen(config->mailbox.c_str()+1, "w");
+     if (fh == NULL)
+-      throw system_error(string("Can't start delivery pipe '") + config->mailbox + "'");
++      throw mapson_system_error(string("Can't start delivery pipe '") + config->mailbox + "'");
+     int len = fwrite(mail.data(), mail.size(), 1, fh);
+     pclose(fh);
+     if (len != 1)
+-      throw system_error(string("Failed to pipe to MTA process '") + config->mailbox + "'");
++      throw mapson_system_error(string("Failed to pipe to MTA process '") + config->mailbox + "'");
+   }
+   else
+   {
+@@ -43,7 +43,7 @@
+ 
+     int fd = open(config->mailbox.c_str(), O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
+     if (fd < 0)
+-      throw system_error(string("Can't open mailbox file '") + config->mailbox + "' for writing");
++      throw mapson_system_error(string("Can't open mailbox file '") + config->mailbox + "' for writing");
+     fd_sentry sentry(fd);
+ 
+     struct flock lock;
+@@ -52,13 +52,13 @@
+     lock.l_start  = 0;
+     lock.l_len    = 0;
+     if (fcntl(fd, F_SETLKW, &lock) != 0)
+-      throw system_error(string("Can't lock file '") + config->mailbox + "'");
++      throw mapson_system_error(string("Can't lock file '") + config->mailbox + "'");
+ 
+     for (size_t len = 0; len < mail.size(); )
+     {
+       ssize_t rc = write(fd, mail.data()+len, mail.size()-len);
+       if (rc < 0)
+-        throw system_error(string("Failed writing to the mailbox file '") + config->mailbox + "'");
++        throw mapson_system_error(string("Failed writing to the mailbox file '") + config->mailbox + "'");
+       else
+         len += rc;
+     }
+--- a/lines2regex.cpp
++++ b/lines2regex.cpp
+@@ -29,7 +29,7 @@
+     if (errno == ENOENT)
+       return "";
+     else
+-      throw system_error(string("Can't open regex db '") +
++      throw mapson_system_error(string("Can't open regex db '") +
+                         filename + "' for reading");
+   }
+   fd_sentry sentry(fd);
+@@ -40,7 +40,7 @@
+   lock.l_start  = 0;
+   lock.l_len    = 0;
+   if (fcntl(fd, F_SETLKW, &lock) != 0)
+-    throw system_error(string("Can't lock file '") + filename + "'");
++    throw mapson_system_error(string("Can't lock file '") + filename + "'");
+ 
+   // Read the file into memory.
+ 
+@@ -52,7 +52,7 @@
+        rc = read(fd, buffer, sizeof(buffer)))
+     data.append(buffer, rc);
+   if (rc < 0)
+-    throw system_error(string("Failed to read regex db '") +
++    throw mapson_system_error(string("Failed to read regex db '") +
+                       filename + "' into memory");
+ 
+   // Walk through the lines and compile the regexes.
+--- a/log.cpp
++++ b/log.cpp
+@@ -30,10 +30,10 @@
+   char buf[64];
+   time_t tstamp = time(0);
+   if (tstamp == static_cast<time_t>(-1))
+-    throw system_error("time(2) failed");
++    throw mapson_system_error("time(2) failed");
+   struct tm* tmtime = localtime(&tstamp);
+   if (tmtime == 0)
+-    throw system_error("localtime(3) failed");
++    throw mapson_system_error("localtime(3) failed");
+   strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tmtime);
+   return buf;
+ }
+@@ -42,7 +42,7 @@
+ {
+   fileh.file = fopen(file, "a");
+   if (fileh.file == 0)
+-    throw system_error(string("Could not open log file ") + file);
++    throw mapson_system_error(string("Could not open log file ") + file);
+ 
+   struct flock lock;
+   lock.l_type = F_WRLCK;
+@@ -50,7 +50,7 @@
+   lock.l_start  = 0;
+   lock.l_len    = 0;
+   if (fcntl(fileno(fileh.file), F_SETLKW, &lock) != 0)
+-    throw system_error(string("Can't lock file '") + file + "'");
++    throw mapson_system_error(string("Can't lock file '") + file + "'");
+ }
+ 
+ void _debug(const char* fmt, ...)
+--- a/mapson.cpp
++++ b/mapson.cpp
+@@ -62,7 +62,7 @@
+ 
+       fd = open(argv[i], O_RDONLY, 0);
+       if (fd < 0)
+-        throw system_error("Can't open file for reading");
++        throw mapson_system_error("Can't open file for reading");
+       fd_sentry sentry(fd);
+       string mail;
+       for (rc = read(fd, buffer, sizeof(buffer));
+@@ -72,7 +72,7 @@
+         mail.append(buffer, rc);
+       }
+       if (rc < 0)
+-        throw system_error("Failed to read from file");
++        throw mapson_system_error("Failed to read from file");
+ 
+       // Extract the mail addresses.
+ 
+@@ -196,7 +196,7 @@
+     mail.append(buffer, rc);
+   }
+   if (rc < 0)
+-    throw system_error("Failed to read mail from standard input");
++    throw mapson_system_error("Failed to read mail from standard input");
+ 
+   // Check whether the mail contains a valid cookie. If it does,
+   // mail will be replaced with the original e-mail, that was
+--- a/parse-config-file.cpp
++++ b/parse-config-file.cpp
+@@ -55,7 +55,7 @@
+ 
+   std::ifstream file(filename);
+   if (!file)
+-    throw system_error(std::string("parse_config_file() failed to open '") + filename + "'");
++    throw mapson_system_error(std::string("parse_config_file() failed to open '") + filename + "'");
+ 
+   // Now we read line by line and process each one seperately.
+ 
+--- a/request-confirmation.cpp
++++ b/request-confirmation.cpp
+@@ -157,7 +157,7 @@
+   string filename = config->request_for_confirmation_file;
+   int fd = multi_open(filename, O_RDONLY, S_IRUSR | S_IWUSR);
+   if (fd < 0)
+-    throw system_error(string("Can't open request-mail template file '") + filename + "' for reading");
++    throw mapson_system_error(string("Can't open request-mail template file '") + filename + "' for reading");
+   fd_sentry sentry(fd);
+ 
+   // Read the file into memory.
+@@ -167,7 +167,7 @@
+   for (rc = read(fd, buffer, sizeof(buffer)); rc > 0; rc = read(fd, buffer, sizeof(buffer)))
+     mail_template.append(buffer, rc);
+   if (rc < 0)
+-    throw system_error(string("Failed to read request-mail template file '") + filename + "' into memory");
++    throw mapson_system_error(string("Failed to read request-mail template file '") + filename + "' into memory");
+ 
+   // Expand variables in the template.
+ 
+@@ -180,11 +180,11 @@
+   debug(("Executing mail transport agent '%s'.", config->mta.c_str()));
+   FILE* fh = popen(config->mta.c_str(), "w");
+   if (fh == NULL)
+-    throw system_error(string("Can't start MTA '") + config->mta + "'");
++    throw mapson_system_error(string("Can't start MTA '") + config->mta + "'");
+   if (fwrite(mail_template.data(), mail_template.size(), 1, fh) != 1)
+   {
+     pclose(fh);
+-    throw system_error(string("Failed to pipe to MTA process '") + config->mta + "'");
++    throw mapson_system_error(string("Failed to pipe to MTA process '") + config->mta + "'");
+   }
+   pclose(fh);
+ }
+--- a/spool.cpp
++++ b/spool.cpp
+@@ -44,13 +44,13 @@
+   info("Spooling e-mail '%s' as '%s'.", config->message_id.c_str(), filename.c_str());
+   int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+   if (fd < 0)
+-    throw system_error(string("Can't open spool file '") + filename + "' for writing");
++    throw mapson_system_error(string("Can't open spool file '") + filename + "' for writing");
+   fd_sentry sentry(fd);
+   for (size_t len = 0; len < mail.size(); )
+   {
+     ssize_t rc = write(fd, mail.data()+len, mail.size()-len);
+     if (rc < 0)
+-      throw system_error(string("Failed writing to the spool file '") + filename + "'");
++      throw mapson_system_error(string("Failed writing to the spool file '") + filename + "'");
+     else
+       len += rc;
+   }
+--- a/system-error.hpp
++++ b/system-error.hpp
+@@ -23,14 +23,14 @@
+ #include <string>
+ #include <cstring>
+ 
+-class system_error : public std::runtime_error
++class mapson_system_error : public std::runtime_error
+ {
+ public:
+-  system_error() : runtime_error(str())
++  mapson_system_error() : runtime_error(str())
+   {
+   }
+ 
+-  explicit system_error(std::string const & msg)
++  explicit mapson_system_error(std::string const & msg)
+     : runtime_error(msg + ": " + str())
+   {
+   }

--- a/mail-filter/mapson/mapson-3.3.ebuild
+++ b/mail-filter/mapson/mapson-3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -15,6 +15,10 @@ IUSE="debug"
 
 RDEPEND="virtual/mta"
 DEPEND="${RDEPEND}"
+
+src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc6.patch
+}
 
 src_configure() {
 	econf $(use_with debug)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594382
Package-Manager: Portage-2.3.5, Repoman-2.3.2

Upstream PR: https://sourceforge.net/p/mapson/code/merge-requests/1/

Long-winded patch but maintains semantics and should be compatible with all C++ dialects.

No upstream release since 2010.  Last upstream revision is from 2014.