### PR TITLE
net-p2p/ppcoind: Fix building with GCC-6 and bump to use EAPI 6

### DIFF
--- a/net-p2p/ppcoind/files/ppcoind-0.4.0-boost_chrono.patch
+++ b/net-p2p/ppcoind/files/ppcoind-0.4.0-boost_chrono.patch
@@ -1,0 +1,10 @@
+--- a/src/makefile.unix
++++ b/src/makefile.unix
+@@ -30,6 +30,7 @@
+    -l boost_filesystem$(BOOST_LIB_SUFFIX) \
+    -l boost_program_options$(BOOST_LIB_SUFFIX) \
+    -l boost_thread$(BOOST_LIB_SUFFIX) \
++   -l boost_chrono$(BOOST_LIB_SUFFIX) \
+    -l db_cxx$(BDB_LIB_SUFFIX) \
+    -l ssl \
+    -l crypto

--- a/net-p2p/ppcoind/files/ppcoind-0.4.0-gcc6.patch
+++ b/net-p2p/ppcoind/files/ppcoind-0.4.0-gcc6.patch
@@ -1,0 +1,11 @@
+--- a/src/net.cpp
++++ b/src/net.cpp
+@@ -51,7 +51,7 @@ CAddress addrLocalHost(CService("0.0.0.0", 0), nLocalServices);
+ CAddress addrSeenByPeer(CService("0.0.0.0", 0), nLocalServices);
+ static CNode* pnodeLocalHost = NULL;
+ uint64 nLocalHostNonce = 0;
+-array<int, THREAD_MAX> vnThreadsRunning;
++boost::array<int, THREAD_MAX> vnThreadsRunning;
+ static SOCKET hListenSocket = INVALID_SOCKET;
+ CAddrMan addrman;
+ 

--- a/net-p2p/ppcoind/ppcoind-0.4.0-r1.ebuild
+++ b/net-p2p/ppcoind/ppcoind-0.4.0-r1.ebuild
@@ -1,0 +1,116 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DB_VER="4.8"
+
+inherit db-use eutils systemd user
+
+MyPV="${PV/_/-}"
+MyPN="ppcoin"
+MyP="${MyPN}-${MyPV}"
+
+DESCRIPTION="Cryptocurrency forked from Bitcoin which aims to be energy efficiency"
+HOMEPAGE="http://peercoin.net/"
+SRC_URI="mirror://sourceforge/${MyPN}/${MyP}-linux.tar.gz -> ${MyP}.tar.gz"
+
+LICENSE="MIT ISC GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="examples ipv6 logrotate upnp"
+
+RDEPEND="
+	dev-libs/boost:=[threads(+)]
+	dev-libs/openssl:0[-bindist]
+	logrotate? (
+		app-admin/logrotate
+	)
+	upnp? (
+		net-libs/miniupnpc
+	)
+	sys-libs/db:$(db_ver_to_slot "${DB_VER}")[cxx]
+"
+DEPEND="${RDEPEND}
+	>=app-shells/bash-4.1
+	sys-apps/sed
+"
+
+DOCS=( ../README README.md )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${P}-boost_chrono.patch
+)
+
+S="${WORKDIR}/${MyP}-linux/src"
+
+pkg_setup() {
+	local UG='ppcoin'
+	enewgroup "${UG}"
+	enewuser "${UG}" -1 -1 /var/lib/ppcoin "${UG}"
+}
+
+src_configure() {
+	OPTS=()
+
+	OPTS+=("DEBUGFLAGS=")
+	OPTS+=("CXXFLAGS=${CXXFLAGS}")
+	OPTS+=("LDFLAGS=${LDFLAGS}")
+
+	if use upnp; then
+		OPTS+=("USE_UPNP=1")
+	else
+		OPTS+=("USE_UPNP=-")
+	fi
+
+	use ipv6 || OPTS+=("USE_IPV6=-")
+
+	OPTS+=("USE_SYSTEM_LEVELDB=1")
+	OPTS+=("BDB_INCLUDE_PATH=$(db_includedir "${DB_VER}")")
+	OPTS+=("BDB_LIB_SUFFIX=-${DB_VER}")
+
+	emake CC="$(tc-getCC)" CXX="$(tc-getCXX)" -C src -f makefile.unix "${OPTS[@]}" ${PN}
+}
+
+#Tests are broken
+#src_test() {
+#	cd src || die
+#	emake CC="$(tc-getCC)" CXX="$(tc-getCXX)" -f makefile.unix "${OPTS[@]}" test_ppcoin
+#	./test_ppcoin || die 'Tests failed'
+#}
+
+src_install() {
+	dobin src/${PN}
+
+	insinto /etc/ppcoin
+	doins "${FILESDIR}/ppcoin.conf"
+	fowners ppcoin:ppcoin /etc/ppcoin/ppcoin.conf
+	fperms 600 /etc/ppcoin/ppcoin.conf
+
+	newconfd "${FILESDIR}/ppcoin.confd" ${PN}
+	newinitd "${FILESDIR}/ppcoin.initd-r1" ${PN}
+	systemd_dounit "${FILESDIR}/ppcoin.service"
+
+	keepdir /var/lib/ppcoin/.ppcoin
+	fperms 700 /var/lib/ppcoin
+	fowners ppcoin:ppcoin /var/lib/ppcoin/
+	fowners ppcoin:ppcoin /var/lib/ppcoin/.ppcoin
+	dosym /etc/ppcoin/ppcoin.conf /var/lib/ppcoin/.ppcoin/ppcoin.conf
+
+	newman contrib/debian/manpages/bitcoind.1 ppcoind.1
+	newman contrib/debian/manpages/bitcoin.conf.5 ppcoin.conf.5
+
+	einstalldocs
+
+	if use examples; then
+		docinto examples
+		dodoc -r contrib/{bitrpc,gitian-descriptors,gitian-downloader,pyminer,wallettools}
+
+	fi
+
+	if use logrotate; then
+		insinto /etc/logrotate.d
+		newins "${FILESDIR}/ppcoind.logrotate" ppcoind
+	fi
+}

--- a/net-p2p/ppcoind/ppcoind-0.4.0.ebuild
+++ b/net-p2p/ppcoind/ppcoind-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -45,6 +45,8 @@ pkg_setup() {
 }
 
 src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc6.patch
+
 	if has_version '>=dev-libs/boost-1.52'; then
 		sed -i 's/\(-l db_cxx\)/-l boost_chrono$(BOOST_LIB_SUFFIX) \1/' src/makefile.unix
 	fi


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594404
Package-Manager: Portage-2.3.5, Repoman-2.3.2

Upstream PR: https://github.com/peercoin/peercoin/pull/122