### PR TITLE
app-arch/lzop: Fix building with GCC-6 and purge deprecated 'dohtml'

### DIFF
--- a/app-arch/lzop/files/lzop-1.03-gcc6.patch
+++ b/app-arch/lzop/files/lzop-1.03-gcc6.patch
@@ -1,0 +1,26 @@
+--- a/src/miniacc.h
++++ b/src/miniacc.h
+@@ -4469,12 +4469,12 @@
+ #if defined(__MSDOS__) && defined(__TURBOC__) && (__TURBOC__ < 0x0150)
+ #elif 1 && (ACC_CC_SUNPROC) && !defined(ACCCHK_CFG_PEDANTIC)
+ #else
+-    ACCCHK_ASSERT((1   << (8*SIZEOF_INT-1)) < 0)
++    ACCCHK_ASSERT((int)(1u   << (8*SIZEOF_INT-1)) < 0)
+ #endif
+     ACCCHK_ASSERT((1u  << (8*SIZEOF_INT-1)) > 0)
+ #if 1 && (ACC_CC_SUNPROC) && !defined(ACCCHK_CFG_PEDANTIC)
+ #else
+-    ACCCHK_ASSERT((1l  << (8*SIZEOF_LONG-1)) < 0)
++    ACCCHK_ASSERT((long)(1ul  << (8*SIZEOF_LONG-1)) < 0)
+ #endif
+     ACCCHK_ASSERT((1ul << (8*SIZEOF_LONG-1)) > 0)
+ #if defined(acc_int16e_t)
+@@ -4703,7 +4703,7 @@
+ #elif 1 && (ACC_CC_LCC || ACC_CC_LCCWIN32) && !defined(ACCCHK_CFG_PEDANTIC)
+ #elif 1 && (ACC_CC_SUNPROC) && !defined(ACCCHK_CFG_PEDANTIC)
+ #elif !(ACC_BROKEN_INTEGRAL_PROMOTION) && (SIZEOF_INT > 1)
+-    ACCCHK_ASSERT( (((unsigned char)128) << (int)(8*sizeof(int)-8)) < 0)
++    ACCCHK_ASSERT( (int)((unsigned int)((unsigned char)128) << (int)(8*sizeof(int)-8)) < 0)
+ #endif
+ #if (ACC_CC_BORLANDC && (__BORLANDC__ >= 0x0530) && (__BORLANDC__ < 0x0560))
+ #  pragma option pop

--- a/app-arch/lzop/lzop-1.03.ebuild
+++ b/app-arch/lzop/lzop-1.03.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -17,7 +17,10 @@ DEPEND="${RDEPEND}"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-x32.patch #575450
+	"${FILESDIR}"/${P}-gcc6.patch #594472
 )
+
+HTML_DOCS=( doc/lzop.html )
 
 src_test() {
 	einfo "compressing config.status to test"
@@ -30,5 +33,4 @@ src_test() {
 src_install() {
 	default
 	dodoc doc/lzop.{txt,ps}
-	dohtml doc/*.html
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594472
Package-Manager: Portage-2.3.5, Repoman-2.3.2

For GCC-6, signed overflow in a declared array's size is treated as a  non-constant (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69746).

This causes a conftest failure at configure time.  In particular:

```
src/miniacc.h:4475:24: warning: result of '1 << 31' requires 33 bits to represent, but 'int' only has 32 bits [-Wshift-overflow=]
     ACCCHK_ASSERT((1   << (8*SIZEOF_INT-1)) < 0)
                        ^
src/miniacc.h:1712:75: note: in definition of macro 'ACC_COMPILE_TIME_ASSERT_HEADER'
 \#    define ACC_COMPILE_TIME_ASSERT_HEADER(e)  extern int __acc_cta[1-2*!(e)];
                                                                           ^
src/miniacc.h:4475:5: note: in expansion of macro 'ACCCHK_ASSERT'
     ACCCHK_ASSERT((1   << (8*SIZEOF_INT-1)) < 0)
     ^~~~~~~~~~~~~
src/miniacc.h:1712:59: error: variably modified '__acc_cta' at file scope
 #    define ACC_COMPILE_TIME_ASSERT_HEADER(e)  extern int __acc_cta[1-2*!(e)];
                                                           ^
tst.c:134:33: note: in expansion of macro 'ACC_COMPILE_TIME_ASSERT_HEADER'
 #define ACCCHK_ASSERT(expr)     ACC_COMPILE_TIME_ASSERT_HEADER(expr)
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/miniacc.h:4475:5: note: in expansion of macro 'ACCCHK_ASSERT'
     ACCCHK_ASSERT((1   << (8*SIZEOF_INT-1)) < 0)
     ^~~~~~~~~~~~~
src/miniacc.h: In function 'test_acc_run_time_assert':
src/miniacc.h:4475:24: warning: result of '1 << 31' requires 33 bits to represent, but 'int' only has 32 bits [-Wshift-overflow=]
     ACCCHK_ASSERT((1   << (8*SIZEOF_INT-1)) < 0)
                        ^
src/miniacc.h:4475:5: note: in expansion of macro 'ACCCHK_ASSERT'
     ACCCHK_ASSERT((1   << (8*SIZEOF_INT-1)) < 0)
     ^~~~~~~~~~~~~
src/miniacc.h:4480:24: warning: result of '1l << 63' requires 65 bits to represent, but 'long int' only has 64 bits [-Wshift-overflow=]
     ACCCHK_ASSERT((1l  << (8*SIZEOF_LONG-1)) < 0)
                        ^
src/miniacc.h:4480:5: note: in expansion of macro 'ACCCHK_ASSERT'
     ACCCHK_ASSERT((1l  << (8*SIZEOF_LONG-1)) < 0)
     ^~~~~~~~~~~~~
src/miniacc.h:4709:42: warning: result of '128 << 24' requires 33 bits to represent, but 'int' only has 32 bits [-Wshift-overflow=]
     ACCCHK_ASSERT( (((unsigned char)128) << (int)(8*sizeof(int)-8)) < 0)
                                          ^
src/miniacc.h:4709:5: note: in expansion of macro 'ACCCHK_ASSERT'
     ACCCHK_ASSERT( (((unsigned char)128) << (int)(8*sizeof(int)-8)) < 0)
     ^~~~~~~~~~~~~
```
There exist two patches.  One from [Debian](https://sources.debian.net/src/lzop/1.03-4/debian/patches/static-assert.patch/) and one from [Patrick McLean on Gentoo Bug-Tracker](https://bugs.gentoo.org/show_bug.cgi?id=594472#c5) (via OpenSUSE et al.).  The patch from Debian uses C11's `_Static_assert()`.  The patch from Gentoo Bug-Tracker enables the originally intended bitwise-shifted expression while avoiding overflow. The latter is chosen.