### PR TITLE
dev-python/pickleshare: Depend on pathlib2 instead of pathlib

### DIFF
--- a/dev-python/pickleshare/pickleshare-0.7.4-r1.ebuild
+++ b/dev-python/pickleshare/pickleshare-0.7.4-r1.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="test"
 
 RDEPEND="
-	$(python_gen_cond_dep 'dev-python/pathlib[${PYTHON_USEDEP}]' 'python2*')
+	$(python_gen_cond_dep 'dev-python/pathlib2[${PYTHON_USEDEP}]' 'python2*')
 	>=dev-python/path-py-6.2[${PYTHON_USEDEP}]"
 
 DEPEND="${RDEPEND}


### PR DESCRIPTION
@mgorny 

This fixes bug  [619344](https://bugs.gentoo.org/619344) for the unstable 0.7.4 version.