### PR TITLE
net-im/corebird: Fix embedded video playback

### DIFF
--- a/net-im/corebird/corebird-1.5-r1.ebuild
+++ b/net-im/corebird/corebird-1.5-r1.ebuild
@@ -46,9 +46,9 @@ src_prepare() {
 
 src_configure() {
 	local myeconfargs=(
-		$(use_enable gstreamer video)
+		$(usex gstreamer "" --disable-video)
 		--disable-gst-check
-		$(use_enable spellcheck)
+		$(usex spellcheck "" --disable-spellcheck)
 	)
 	gnome2_src_configure "${myeconfargs[@]}"
 }


### PR DESCRIPTION
This is only a temporary fix until I figure out the broken `configure.ac`s with upstream.

Gentoo-Bug: 618996