### PR TITLE
sci-misc/boinc: Support CURL_SSL="gnutls"

### DIFF
--- a/sci-misc/boinc/boinc-7.2.44-r4.ebuild
+++ b/sci-misc/boinc/boinc-7.2.44-r4.ebuild
@@ -18,9 +18,9 @@ RESTRICT="mirror"
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="X cuda curl_ssl_libressl +curl_ssl_openssl static-libs"
+IUSE="X cuda curl_ssl_gnutls curl_ssl_libressl +curl_ssl_openssl static-libs"
 
-REQUIRED_USE="^^ ( curl_ssl_libressl curl_ssl_openssl ) "
+REQUIRED_USE="^^ ( curl_ssl_gnutls curl_ssl_libressl curl_ssl_openssl ) "
 
 # libcurl must not be using an ssl backend boinc does not support.
 # If the libcurl ssl backend changes, boinc should be recompiled.
@@ -28,7 +28,7 @@ RDEPEND="
 	!sci-misc/boinc-bin
 	!app-admin/quickswitch
 	>=app-misc/ca-certificates-20080809
-	net-misc/curl[-curl_ssl_gnutls(-),curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
+	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
 	sys-apps/util-linux
 	sys-libs/zlib
 	cuda? (

--- a/sci-misc/boinc/boinc-7.4.52-r4.ebuild
+++ b/sci-misc/boinc/boinc-7.4.52-r4.ebuild
@@ -18,9 +18,9 @@ RESTRICT="mirror"
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="X cuda curl_ssl_libressl +curl_ssl_openssl static-libs"
+IUSE="X cuda curl_ssl_gnutls curl_ssl_libressl +curl_ssl_openssl static-libs"
 
-REQUIRED_USE="^^ ( curl_ssl_libressl curl_ssl_openssl ) "
+REQUIRED_USE="^^ ( curl_ssl_gnutls curl_ssl_libressl curl_ssl_openssl ) "
 
 # libcurl must not be using an ssl backend boinc does not support.
 # If the libcurl ssl backend changes, boinc should be recompiled.
@@ -28,7 +28,7 @@ RDEPEND="
 	!sci-misc/boinc-bin
 	!app-admin/quickswitch
 	>=app-misc/ca-certificates-20080809
-	net-misc/curl[-curl_ssl_gnutls(-),curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
+	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
 	sys-apps/util-linux
 	sys-libs/zlib
 	cuda? (

--- a/sci-misc/boinc/boinc-7.6.33-r4.ebuild
+++ b/sci-misc/boinc/boinc-7.6.33-r4.ebuild
@@ -18,9 +18,9 @@ RESTRICT="mirror"
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="X cuda curl_ssl_libressl +curl_ssl_openssl static-libs"
+IUSE="X cuda curl_ssl_gnutls curl_ssl_libressl +curl_ssl_openssl static-libs"
 
-REQUIRED_USE="^^ ( curl_ssl_libressl curl_ssl_openssl ) "
+REQUIRED_USE="^^ ( curl_ssl_gnutls curl_ssl_libressl curl_ssl_openssl ) "
 
 # libcurl must not be using an ssl backend boinc does not support.
 # If the libcurl ssl backend changes, boinc should be recompiled.
@@ -28,7 +28,7 @@ RDEPEND="
 	!sci-misc/boinc-bin
 	!app-admin/quickswitch
 	>=app-misc/ca-certificates-20080809
-	net-misc/curl[-curl_ssl_gnutls(-),curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
+	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
 	sys-apps/util-linux
 	sys-libs/zlib
 	cuda? (

--- a/sci-misc/boinc/files/boinc.init
+++ b/sci-misc/boinc/files/boinc.init
@@ -184,14 +184,16 @@ resume() {
 	env_check || return 1
 
 	local password=""
-	local master_urls=( \
-		$("${BOINCCMD}" --get_project_status | \
-		  sed -n 's/\s*master URL: //p') \
-	)
 
 	if need_passwd_arg; then
 		password="--passwd \"$(cat "${RUNTIMEDIR}/gui_rpc_auth.cfg")\""
 	fi
+
+	local master_urls=( \
+		$(cd "${RUNTIMEDIR}" ; \
+		  "${BOINCCMD}" ${password} --get_project_status | \
+		  sed -n 's/\s*master URL: //p') \
+	)
 
 	for url in "${master_urls[@]}"; do
 		ebegin "Resuming $url"
@@ -207,14 +209,16 @@ suspend() {
 	env_check || return 1
 
 	local password=""
-	local master_urls=( \
-		$("${BOINCCMD}" --get_project_status | \
-		  sed -n 's/\s*master URL: //p') \
-	)
 
 	if need_passwd_arg; then
 		password="--passwd \"$(cat "${RUNTIMEDIR}/gui_rpc_auth.cfg")\""
 	fi
+
+	local master_urls=( \
+		$(cd "${RUNTIMEDIR}" ; \
+		  "${BOINCCMD}" ${password} --get_project_status | \
+		  sed -n 's/\s*master URL: //p') \
+	)
 
 	for url in "${master_urls[@]}"; do
 		ebegin "Suspending $url"


### PR DESCRIPTION
Gentoo-Bug: 619032

Enabling gnutls USE flag on curl broke boinc ability to
connect to WorldCommunityGrid (WCG) servers.

This situation seems to have changed, as I have no problem
connecting to WCG using CURL_SSL="gnutls" any more.

Further both suspend and resume do not work any more.
The reason is, that fetching the project URLs requires password
authentication now.

The init script was fixed to use the appropriate authentication.

Package-Manager: portage-2.3.6

@jlec @SoapGentoo Please have a look whether you are fine with this.