### PR TITLE
x11-misc/qt5ct: require >=qtgui-5.7 for dbus support wrt bug 619496

### DIFF
--- a/x11-misc/qt5ct/qt5ct-0.32.ebuild
+++ b/x11-misc/qt5ct/qt5ct-0.32.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dbus? (
 		dev-qt/qtdbus:5
-		dev-qt/qtgui:5[dbus]
+		>=dev-qt/qtgui-5.7:5[dbus]
 	)
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Gentoo-bug: 619496
Package-Manager: Portage-2.3.6, Repoman-2.3.2