### PR TITLE
dev-util/cgdb: fix DOCS files for 9999 version

### DIFF
--- a/dev-util/cgdb/cgdb-9999.ebuild
+++ b/dev-util/cgdb/cgdb-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -31,7 +31,7 @@ RDEPEND="
 	${COMMONDEPEND}
 	sys-devel/gdb"
 
-DOCS=( AUTHORS ChangeLog INSTALL NEWS README.md TODO )
+DOCS=( AUTHORS ChangeLog INSTALL NEWS README.md FAQ )
 
 src_prepare() {
 	default


### PR DESCRIPTION
TODO removed (provoked emerge faile because of a dodoc TODO unsuccessful)
FAQ added

Package-Manager: Portage-2.3.6, Repoman-2.3.2