### PR TITLE
net-irc/irker: Drop python3 support

### DIFF
--- a/net-irc/irker/irker-2.16.ebuild
+++ b/net-irc/irker/irker-2.16.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4} )
+PYTHON_COMPAT=( python2_7 )
 PYTHON_REQ_USE="ssl"
 
 inherit python-single-r1 systemd eutils

--- a/net-irc/irker/irker-2.17.ebuild
+++ b/net-irc/irker/irker-2.17.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-PYTHON_COMPAT=( python{2_7,3_4} )
+PYTHON_COMPAT=( python2_7 )
 PYTHON_REQ_USE="ssl"
 
 inherit python-single-r1 systemd eutils

--- a/net-irc/irker/irker-2.18.ebuild
+++ b/net-irc/irker/irker-2.18.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python2_7 )
 PYTHON_REQ_USE="ssl"
 
 inherit python-single-r1 systemd


### PR DESCRIPTION
irk and irkerhook.py do not support python3 yet.

```
  $ python3.4 ./irk
  Traceback (most recent call last):
    File "./irk", line 52, in <module>
      main()
    File "./irk", line 40, in main
      target = sys.argv[1]
  IndexError: list index out of range
```

```
  $ python3.4 ./irkerhook.py
    File "./irkerhook.py", line 459
      print message
                  ^
  SyntaxError: Missing parentheses in call to 'print'
```

Package-Manager: Portage-2.3.5, Repoman-2.3.1