### PR TITLE
dev-cpp/pficommon: Fix building with GCC-6

### DIFF
--- a/dev-cpp/pficommon/files/pficommon-1.3.1.0-gcc6.patch
+++ b/dev-cpp/pficommon/files/pficommon-1.3.1.0-gcc6.patch
@@ -1,0 +1,350 @@
+--- a/src/network/cgi/inserter.cpp
++++ b/src/network/cgi/inserter.cpp
+@@ -50,8 +50,8 @@
+ 
+ tag_inserter::~tag_inserter()
+ {
+-  shared_ptr<tag_elem> elem(new tag_elem(name, attrs));
+-  vector<shared_ptr<html_elem> > children=b.leave();
++  pfi::lang::shared_ptr<tag_elem> elem(new tag_elem(name, attrs));
++  vector<pfi::lang::shared_ptr<html_elem> > children=b.leave();
+   for (int i=0;i<(int)children.size();i++)
+     elem->add_child(children[i]);
+   b.push(elem);
+@@ -59,12 +59,12 @@
+ 
+ text_inserter::text_inserter(const string &text, xhtml_builder &b)
+ {
+-  b.push(shared_ptr<html_elem>(new text_elem(text)));
++  b.push(pfi::lang::shared_ptr<html_elem>(new text_elem(text)));
+ }
+ 
+ prim_inserter::prim_inserter(const string &text, xhtml_builder &b)
+ {
+-  b.push(shared_ptr<html_elem>(new prim_elem(text)));
++  b.push(pfi::lang::shared_ptr<html_elem>(new prim_elem(text)));
+ }
+ 
+ } // cgi
+--- a/src/network/cgi/server.cpp
++++ b/src/network/cgi/server.cpp
+@@ -161,12 +161,12 @@
+       <<", thread-num="<<thread_num
+       <<", timeout="<<ssock->timeout()<<endl;
+ 
+-  ths=vector<shared_ptr<thread> >(thread_num);
+-  vector<shared_ptr<cgi, threading_model::multi_thread> > cgis(thread_num);
++  ths=vector<pfi::lang::shared_ptr<thread> >(thread_num);
++  vector<pfi::lang::shared_ptr<cgi, threading_model::multi_thread> > cgis(thread_num);
+ 
+   for (int i=0; i<thread_num; i++){
+-    cgis[i]=shared_ptr<cgi, threading_model::multi_thread>(dynamic_cast<cgi*>(c.clone()));
+-    ths[i]=shared_ptr<thread>(new thread(bind(&run_server::process, this, ssock, cgis[i])));
++    cgis[i]=pfi::lang::shared_ptr<cgi, threading_model::multi_thread>(dynamic_cast<cgi*>(c.clone()));
++    ths[i]=pfi::lang::shared_ptr<thread>(new thread(bind(&run_server::process, this, ssock, cgis[i])));
+     if (!ths[i]->start()){
+       ostringstream oss;
+       oss<<"unable to start thread"<<endl;
+@@ -185,7 +185,7 @@
+   ths.clear();
+ }
+ 
+-static shared_ptr<http::response> gen_resp(stringstream &ss)
++static pfi::lang::shared_ptr<http::response> gen_resp(stringstream &ss)
+ {
+   http::header head(ss);
+ 
+@@ -210,7 +210,7 @@
+     head.erase("status");
+   }
+   
+-  shared_ptr<http::response> resp(new http::response(code, reason));
++  pfi::lang::shared_ptr<http::response> resp(new http::response(code, reason));
+ 
+   head["Content-Type"]=content_type;
+ 
+@@ -232,10 +232,10 @@
+ }
+ 
+ void run_server::process(socket_type ssock,
+-			 shared_ptr<cgi, threading_model::multi_thread> cc)
++			 pfi::lang::shared_ptr<cgi, threading_model::multi_thread> cc)
+ {
+   for (;;){
+-    shared_ptr<stream_socket> sock(ssock->accept());
++    pfi::lang::shared_ptr<stream_socket> sock(ssock->accept());
+     if (!sock) continue;
+ 
+     if (ssock->timeout()>0 && !sock->set_timeout(ssock->timeout()))
+@@ -272,7 +272,7 @@
+ 
+       cc->exec(req.body(), sout, cerr, env);
+ 
+-      shared_ptr<http::response> resp=gen_resp(sout);
++      pfi::lang::shared_ptr<http::response> resp=gen_resp(sout);
+       resp->send(sock);
+     }
+     catch(const exception &e){
+--- a/src/network/http/base.cpp
++++ b/src/network/http/base.cpp
+@@ -61,7 +61,7 @@
+ {
+ }
+ 
+-void header::read_header(function<bool(string*)> f)
++void header::read_header(pfi::lang::function<bool(string*)> f)
+ {
+   string line, key, val;
+   if (!f(&line))
+@@ -124,7 +124,7 @@
+   return sock->getline(*str, line_limit);
+ }
+ 
+-header::header(shared_ptr<stream_socket> sock)
++header::header(pfi::lang::shared_ptr<stream_socket> sock)
+ {
+   read_header(bind(&socket_getline, sock.get(), _1, line_limit));
+ }
+@@ -211,7 +211,7 @@
+   return dat.end();
+ }
+ 
+-void header::send(shared_ptr<stream_socket> sock)
++void header::send(pfi::lang::shared_ptr<stream_socket> sock)
+ {
+   for (int i=0;i<(int)dat.size();i++){
+     string line=dat[i].first+": "+dat[i].second+"\r\n";
+@@ -228,7 +228,7 @@
+ public:
+   typedef C char_type;
+ 
+-  basic_httpbody_chunked_streambuf(shared_ptr<stream_socket> sock)
++  basic_httpbody_chunked_streambuf(pfi::lang::shared_ptr<stream_socket> sock)
+     : sock(sock)
+     , chunk_rest(0)
+     , buf(buf_size)
+@@ -321,7 +321,7 @@
+     iss>>hex>>chunk_rest;
+   }
+ 
+-  shared_ptr<stream_socket> sock;
++  pfi::lang::shared_ptr<stream_socket> sock;
+ 
+   int chunk_rest;
+ 
+@@ -334,7 +334,7 @@
+ public:
+   typedef C char_type;
+ 
+-  basic_httpbody_streambuf(shared_ptr<stream_socket> sock, int length)
++  basic_httpbody_streambuf(pfi::lang::shared_ptr<stream_socket> sock, int length)
+     : sock(sock)
+     , rest(length)
+     , buf(T::eof()){
+@@ -359,7 +359,7 @@
+   }
+ 
+ private:
+-  shared_ptr<stream_socket> sock;
++  pfi::lang::shared_ptr<stream_socket> sock;
+ 
+   int rest;
+   int buf;
+@@ -368,7 +368,7 @@
+ template <class C, class T=char_traits<C> >
+ class basic_httpbody_chunked_stream : public basic_iostream<C,T>{
+ public:
+-  basic_httpbody_chunked_stream(shared_ptr<stream_socket> sock)
++  basic_httpbody_chunked_stream(pfi::lang::shared_ptr<stream_socket> sock)
+     : basic_iostream<C,T>()
+     , buf(sock){
+     this->init(&buf);
+@@ -380,7 +380,7 @@
+ template <class C, class T=char_traits<C> >
+ class basic_httpbody_stream : public basic_iostream<C,T>{
+ public:
+-  basic_httpbody_stream(shared_ptr<stream_socket> sock, int len)
++  basic_httpbody_stream(pfi::lang::shared_ptr<stream_socket> sock, int len)
+     : basic_iostream<C,T>()
+     , buf(sock, len){
+     this->init(&buf);
+@@ -406,7 +406,7 @@
+ {
+ }
+ 
+-request::request(shared_ptr<stream_socket> sock)
++request::request(pfi::lang::shared_ptr<stream_socket> sock)
+   : method_("")
+   , uri_("/")
+   , version_(1,1)
+@@ -438,11 +438,11 @@
+ 
+   // body
+   if (cicmp(header_["Transfer-Encoding"],"chunked"))
+-    stream=shared_ptr<iostream>(new basic_httpbody_chunked_stream<char>(sock));
++    stream=pfi::lang::shared_ptr<iostream>(new basic_httpbody_chunked_stream<char>(sock));
+   else if (header_["Content-Length"]!="")
+-    stream=shared_ptr<iostream>(new basic_httpbody_stream<char>(sock, lexical_cast<int>(header_["Content-Length"])));
++    stream=pfi::lang::shared_ptr<iostream>(new basic_httpbody_stream<char>(sock, lexical_cast<int>(header_["Content-Length"])));
+   else
+-    stream=shared_ptr<iostream>(new socketstream(sock));
++    stream=pfi::lang::shared_ptr<iostream>(new socketstream(sock));
+ }
+ 
+ request::~request()
+@@ -474,7 +474,7 @@
+   return *stream;
+ }
+ 
+-void request::send(shared_ptr<stream_socket> sock)
++void request::send(pfi::lang::shared_ptr<stream_socket> sock)
+ {
+   stringstream *ss=dynamic_cast<stringstream*>(stream.get());
+   if (!ss) throw http_exception("body is not stringstream");
+@@ -499,7 +499,7 @@
+   if (sock->flush()>=0)
+     throw http_exception("flush failed");
+   if (dat.length()==0)
+-    stream=shared_ptr<iostream>(new socketstream(sock));
++    stream=pfi::lang::shared_ptr<iostream>(new socketstream(sock));
+ }
+ 
+ response::response()
+@@ -518,7 +518,7 @@
+ {
+ }
+ 
+-response::response(shared_ptr<stream_socket> sock)
++response::response(pfi::lang::shared_ptr<stream_socket> sock)
+ {
+   // status-line
+   {
+@@ -546,11 +546,11 @@
+ 
+   // body
+   if (cicmp(header_["Transfer-Encoding"],"chunked"))
+-    stream=shared_ptr<iostream>(new basic_httpbody_chunked_stream<char>(sock));
++    stream=pfi::lang::shared_ptr<iostream>(new basic_httpbody_chunked_stream<char>(sock));
+   else if (header_["Content-Length"]!="")
+-    stream=shared_ptr<iostream>(new basic_httpbody_stream<char>(sock, lexical_cast<int>(header_["Content-Length"])));
++    stream=pfi::lang::shared_ptr<iostream>(new basic_httpbody_stream<char>(sock, lexical_cast<int>(header_["Content-Length"])));
+   else
+-    stream=shared_ptr<iostream>(new socketstream(sock));
++    stream=pfi::lang::shared_ptr<iostream>(new socketstream(sock));
+ }
+ 
+ response::~response()
+@@ -582,7 +582,7 @@
+   return *stream;
+ }
+ 
+-void response::send(shared_ptr<stream_socket> sock)
++void response::send(pfi::lang::shared_ptr<stream_socket> sock)
+ {
+   stringstream *ss=dynamic_cast<stringstream*>(stream.get());
+   if (!ss) throw http_exception("body is not stringstream");
+@@ -607,7 +607,7 @@
+   if (sock->flush()>=0)
+     throw http_exception("flush failed");
+   if (dat.length()==0)
+-    stream=shared_ptr<iostream>(new socketstream(sock));
++    stream=pfi::lang::shared_ptr<iostream>(new socketstream(sock));
+ }
+ 
+ } // http
+--- a/src/network/rpc/base.cpp
++++ b/src/network/rpc/base.cpp
+@@ -59,20 +59,20 @@
+ {
+ }
+ 
+-void rpc_server::add(const string &name, shared_ptr<invoker_base> invoker)
++void rpc_server::add(const string &name, pfi::lang::shared_ptr<invoker_base> invoker)
+ {
+   funcs[name]=invoker;
+ }
+ 
+ bool rpc_server::serv(uint16_t port, int nthreads)
+ {
+-  shared_ptr<server_socket, threading_model::multi_thread> ssock(new server_socket());
++  pfi::lang::shared_ptr<server_socket, threading_model::multi_thread> ssock(new server_socket());
+   if (!ssock->create(port))
+     return false;
+ 
+-  vector<shared_ptr<thread> > ths(nthreads);
++  vector<pfi::lang::shared_ptr<thread> > ths(nthreads);
+   for (int i=0; i<nthreads; i++){
+-    ths[i]=shared_ptr<thread>(new thread(bind(&rpc_server::process, this, ssock)));
++    ths[i]=pfi::lang::shared_ptr<thread>(new thread(bind(&rpc_server::process, this, ssock)));
+     if (!ths[i]->start()) return false;
+   }
+   for (int i=0; i<nthreads; i++)
+@@ -80,10 +80,10 @@
+   return true;
+ }
+ 
+-void rpc_server::process(shared_ptr<server_socket, threading_model::multi_thread> ssock)
++void rpc_server::process(pfi::lang::shared_ptr<server_socket, threading_model::multi_thread> ssock)
+ {
+   for (;;){
+-    shared_ptr<stream_socket> sock(ssock->accept());
++    pfi::lang::shared_ptr<stream_socket> sock(ssock->accept());
+     if (!sock) continue;
+     sock->set_nodelay(true);
+ 
+@@ -139,11 +139,11 @@
+ {
+ }
+ 
+-shared_ptr<socketstream> rpc_client::get_connection()
++pfi::lang::shared_ptr<socketstream> rpc_client::get_connection()
+ {
+   for (int i=0;i<2;i++){
+     if (!ss || !(*ss)){
+-      ss=shared_ptr<socketstream>(new socketstream(host, port));
++      ss=pfi::lang::shared_ptr<socketstream>(new socketstream(host, port));
+       if (!(*ss)){
+ 	ss.reset();
+ 	continue;
+@@ -180,7 +180,7 @@
+   return ss;
+ }
+ 
+-void rpc_client::return_connection(shared_ptr<socketstream> css)
++void rpc_client::return_connection(pfi::lang::shared_ptr<socketstream> css)
+ {
+   ss=css;
+ }
+--- a/src/network/socket.cpp
++++ b/src/network/socket.cpp
+@@ -58,7 +58,7 @@
+ namespace pfi{
+ namespace network{
+ 
+-shared_ptr<dns_resolver, threading_model::multi_thread> stream_socket::resolver;
++pfi::lang::shared_ptr<dns_resolver, threading_model::multi_thread> stream_socket::resolver;
+ r_mutex stream_socket::resolver_m;
+ 
+ class sigign{
+@@ -88,7 +88,7 @@
+   close();
+ }
+ 
+-void stream_socket::set_dns_resolver(shared_ptr<dns_resolver, threading_model::multi_thread> r)
++void stream_socket::set_dns_resolver(pfi::lang::shared_ptr<dns_resolver, threading_model::multi_thread> r)
+ {
+   synchronized(resolver_m)
+     resolver=r;
+@@ -106,10 +106,10 @@
+       return false;
+   }
+ 
+-  shared_ptr<dns_resolver, threading_model::multi_thread> res;
++  pfi::lang::shared_ptr<dns_resolver, threading_model::multi_thread> res;
+   synchronized(resolver_m){
+     if (!resolver)
+-      set_dns_resolver(shared_ptr<dns_resolver, threading_model::multi_thread>
++      set_dns_resolver(pfi::lang::shared_ptr<dns_resolver, threading_model::multi_thread>
+ 		       (new normal_dns_resolver()));
+     res=resolver;
+   }

--- a/dev-cpp/pficommon/pficommon-1.3.1.0.ebuild
+++ b/dev-cpp/pficommon/pficommon-1.3.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -39,7 +39,8 @@ src_prepare() {
 	epatch "${FILESDIR}"/${P}-libdir.patch \
 		"${FILESDIR}"/${P}-soname.patch \
 		"${FILESDIR}"/${P}-postgresql.patch \
-		"${FILESDIR}"/${P}-gcc-4.7.patch
+		"${FILESDIR}"/${P}-gcc-4.7.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 }
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594540
Package-Manager: Portage-2.3.6, Repoman-2.3.2

The source's use of `function` and `shared_ptr` from its own `pfi::lang` namespace conflicts with that from `std` namespace.  The patch consists of simple, if not long-winded, qualifications to `pfi::lang` namespace. 
 Note: Upstream has since refactored their source but still has [other problems building with GCC-6](https://github.com/retrieva/pficommon/pull/181).