### PR TITLE
dev-python/smmap2: Prevent package to be installed parallel to smmap

### DIFF
--- a/dev-python/smmap2/smmap2-2.0.1-r1.ebuild
+++ b/dev-python/smmap2/smmap2-2.0.1-r1.ebuild
@@ -23,7 +23,8 @@ DEPEND="
 	test? (
 		dev-python/nose[${PYTHON_USEDEP}]
 	)"
-RDEPEND=""
+RDEPEND="
+	!dev-python/smmap[${PYTHON_USEDEP}]"
 
 python_test() {
 	nosetests -v || die "tests failed under ${EPYTHON}"


### PR DESCRIPTION
Also the core package name was changed to smmap2, the package is still
installed/imported as smmap.

Package-Manager: Portage-2.3.5, Repoman-2.3.1