### PR TITLE
sys-fs/cryfs: Fixed inapplicable warning message

### DIFF
--- a/sys-fs/cryfs/cryfs-0.9.7.ebuild
+++ b/sys-fs/cryfs/cryfs-0.9.7.ebuild
@@ -24,7 +24,7 @@ if [[ "${PV}" == 9999 ]] ; then
 	KEYWORDS=""
 else
 	SRC_URI="https://github.com/cryfs/cryfs/releases/download/${PV}/${P}.tar.xz"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86"
 	S="${WORKDIR}"
 fi
 

--- a/sys-fs/cryfs/cryfs-0.9.7.ebuild
+++ b/sys-fs/cryfs/cryfs-0.9.7.ebuild
@@ -40,6 +40,9 @@ src_prepare() {
 	# remove tests that require internet access to comply with Gentoo policy
 	sed -i -e '/CurlHttpClientTest.cpp/d' -e '/FakeHttpClientTest.cpp/d' test/cpp-utils/CMakeLists.txt || die
 
+	# remove non-applicable warning caused by cmake-utils setting NDEBUG
+	sed -i -e '/WARNING! This is a debug build. Performance might be slow./d' src/cryfs-cli/Cli.cpp || die
+
 	cmake-utils_src_prepare
 }
 

--- a/sys-fs/cryfs/cryfs-9999.ebuild
+++ b/sys-fs/cryfs/cryfs-9999.ebuild
@@ -24,7 +24,7 @@ if [[ "${PV}" == 9999 ]] ; then
 	KEYWORDS=""
 else
 	SRC_URI="https://github.com/cryfs/cryfs/releases/download/${PV}/${P}.tar.xz"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86"
 	S="${WORKDIR}"
 fi
 

--- a/sys-fs/cryfs/cryfs-9999.ebuild
+++ b/sys-fs/cryfs/cryfs-9999.ebuild
@@ -40,6 +40,9 @@ src_prepare() {
 	# remove tests that require internet access to comply with Gentoo policy
 	sed -i -e '/CurlHttpClientTest.cpp/d' -e '/FakeHttpClientTest.cpp/d' test/cpp-utils/CMakeLists.txt || die
 
+	# remove non-applicable warning caused by cmake-utils setting NDEBUG
+	sed -i -e '/WARNING! This is a debug build. Performance might be slow./d' src/cryfs-cli/Cli.cpp || die
+
 	cmake-utils_src_prepare
 }
 


### PR DESCRIPTION
The Gentoo cmake-utils eclass defines NDEBUG, which makes a warning message appear on the help screen saying "WARNING! This is a debug build. Performance might be slow." which is inaccurate since a build log confirms that the proper CXXFLAGS are applied. Added a line to src_prepare() that removes this message with sed.

Also added ~x86 to KEYWORDS since I tested it in a chroot.