### PR TITLE
games-sports/torcs: Fix building with GCC-6

### DIFF
--- a/games-sports/torcs/files/torcs-1.3.6-gcc6.patch
+++ b/games-sports/torcs/files/torcs-1.3.6-gcc6.patch
@@ -1,0 +1,11 @@
+--- a/src/drivers/olethros/geometry.cpp
++++ b/src/drivers/olethros/geometry.cpp
+@@ -27,6 +27,8 @@
+ #ifdef WIN32
+ #include <float.h>
+ #define isnan _isnan
++#elif __cplusplus >= 201103L
++using std::isnan;
+ #endif
+ 
+ 

--- a/games-sports/torcs/torcs-1.3.6-r1.ebuild
+++ b/games-sports/torcs/torcs-1.3.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -33,6 +33,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-flags.patch
 	"${FILESDIR}"/${P}-format.patch
 	"${FILESDIR}"/${P}-noXmuXt.patch
+	"${FILESDIR}"/${P}-gcc6.patch
 )
 
 src_prepare() {

--- a/games-sports/torcs/torcs-1.3.6.ebuild
+++ b/games-sports/torcs/torcs-1.3.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -33,7 +33,8 @@ src_prepare() {
 		"${FILESDIR}"/${P}-as-needed.patch \
 		"${FILESDIR}"/${P}-flags.patch \
 		"${FILESDIR}"/${P}-format.patch \
-		"${FILESDIR}"/${P}-noXmuXt.patch
+		"${FILESDIR}"/${P}-noXmuXt.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 	eautoreconf
 	ecvs_clean
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594670
Package-Manager: Portage-2.3.6, Repoman-2.3.2

`std::isnan` is first defined in C++11, while global `isnan` is from C's `<math.h>`.
From [Porting to GCC 6](https://gcc.gnu.org/gcc-6/porting_to.html):

> Some C libraries declare obsolete int isinf(double) or int isnan(double) functions in the <math.h> header. These functions conflict with standard C++ functions with the same name but a different return type (the C++ functions return bool). When the obsolete functions are declared by the C library the C++ library will use them and import them into namespace std instead of defining the correct signatures.

Regardless of which `isnan` function gets called (the C one which returns an `int` or the C++11 one which returns a `bool`)  the only point of use is in a boolean `if` evaluation, so the behavior would be the same.

There already are 2 patches submitted [upstream](https://sourceforge.net/p/torcs/support-requests/), both of which rely on `isnan` existing in `std` namespace which would fail in C++98.