### PR TITLE
app-backup/buttersink: dev-python/flake8 only required for tests

### DIFF
--- a/app-backup/buttersink/buttersink-0.6.8.ebuild
+++ b/app-backup/buttersink/buttersink-0.6.8.ebuild
@@ -11,6 +11,7 @@ HOMEPAGE="https://github.com/AmesCornish/buttersink"
 
 LICENSE="GPL-3"
 SLOT=0
+IUSE="test"
 
 # local tests would require root and cause sandbox issues with btrfs subvolume
 # operations, and network tests would require an SSH server with root login to
@@ -30,9 +31,9 @@ fi
 RDEPEND="${PYTHON_DEPS}
 	dev-python/boto[${PYTHON_USEDEP}]
 	dev-python/crcmod[${PYTHON_USEDEP}]
-	dev-python/flake8[${PYTHON_USEDEP}]
 	dev-python/psutil[${PYTHON_USEDEP}]
-	sys-fs/btrfs-progs"
+	sys-fs/btrfs-progs
+	test? ( dev-python/flake8[${PYTHON_USEDEP}] )"
 DEPEND="${RDEPEND}"
 
 python_prepare_all() {

--- a/app-backup/buttersink/buttersink-9999.ebuild
+++ b/app-backup/buttersink/buttersink-9999.ebuild
@@ -11,6 +11,7 @@ HOMEPAGE="https://github.com/AmesCornish/buttersink"
 
 LICENSE="GPL-3"
 SLOT=0
+IUSE="test"
 
 # local tests would require root and cause sandbox issues with btrfs subvolume
 # operations, and network tests would require an SSH server with root login to
@@ -30,9 +31,9 @@ fi
 RDEPEND="${PYTHON_DEPS}
 	dev-python/boto[${PYTHON_USEDEP}]
 	dev-python/crcmod[${PYTHON_USEDEP}]
-	dev-python/flake8[${PYTHON_USEDEP}]
 	dev-python/psutil[${PYTHON_USEDEP}]
-	sys-fs/btrfs-progs"
+	sys-fs/btrfs-progs
+	test? ( dev-python/flake8[${PYTHON_USEDEP}] )"
 DEPEND="${RDEPEND}"
 
 python_prepare_all() {


### PR DESCRIPTION
Noticed an unnecessary dependency in this ebuild.