### PR TITLE
net-wireless/yatebts: Fix building with GCC-6

### DIFF
--- a/net-wireless/yatebts/files/yatebts-5.0.0-gcc6.patch
+++ b/net-wireless/yatebts/files/yatebts-5.0.0-gcc6.patch
@@ -1,0 +1,31 @@
+--- a/mbts/GPRS/MSInfo.cpp
++++ b/mbts/GPRS/MSInfo.cpp
+@@ -638,7 +638,7 @@
+         if (msPCHDowns.size() > 1) {
+             std::ostringstream os;
+             msDumpChannels(os);
+-            GPRSLOG(INFO,GPRS_MSG|GPRS_CHECK_OK) << "Multislot assignment for "<<this<<os;
++            GPRSLOG(INFO,GPRS_MSG|GPRS_CHECK_OK) << "Multislot assignment for "<<this<<(!os.fail());
+         }
+ 
+ 	} else {
+--- a/mbts/SGSNGGSN/Sgsn.cpp
++++ b/mbts/SGSNGGSN/Sgsn.cpp
+@@ -149,7 +149,7 @@
+ 	clearConn(GprsConnNone,SigConnLost);
+ 	std::ostringstream ss;
+ 	sgsnInfoDump(this,ss);
+-	SGSNLOGF(INFO,GPRS_OK|GPRS_MSG,"SGSN","Removing SgsnInfo:"<<ss);
++	SGSNLOGF(INFO,GPRS_OK|GPRS_MSG,"SGSN","Removing SgsnInfo:"<<(!ss.fail()));
+ 	sSgsnInfoList.remove(this);
+ 	GmmInfo *gmm = getGmm();
+ 	if (gmm && (gmm->getSI() == this)) {
+@@ -252,7 +252,7 @@
+ {
+ 	std::ostringstream ss;
+ 	gmmInfoDump(gmm,ss,0);
+-	SGSNLOGF(INFO,GPRS_OK|GPRS_MSG,"SGSN","Removing gmm:"<<ss);
++	SGSNLOGF(INFO,GPRS_OK|GPRS_MSG,"SGSN","Removing gmm:"<<(!ss.fail()));
+ 	SgsnInfo *si;
+ 	RN_FOR_ALL(SgsnInfoList_t,sSgsnInfoList,si) {
+ 		// The second test here should be redundant.

--- a/net-wireless/yatebts/yatebts-5.0.0.ebuild
+++ b/net-wireless/yatebts/yatebts-5.0.0.ebuild
@@ -37,6 +37,7 @@ src_prepare() {
 	replace-flags -ggdb1 -g
 	#epatch "${FILESDIR}"/${PN}-4.0.0-dont-mess-with-cflags.patch
 	epatch "${FILESDIR}"/${PN}-sgsnggsn-inetutils-hostname-fix.diff
+	epatch "${FILESDIR}"/${P}-gcc6.patch
 	eautoreconf
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594786
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Please see http://yate.null.ro/mantis/view.php?id=416#bugnotes for info about the bug and patch.