### PR TITLE
net-p2p/retroshare: Qt4 & REQUIRED_USE cleanup

### DIFF
--- a/net-p2p/retroshare/retroshare-0.6.9999.ebuild
+++ b/net-p2p/retroshare/retroshare-0.6.9999.ebuild
@@ -14,11 +14,9 @@ LICENSE="GPL-2 GPL-3 Apache-2.0 LGPL-2.1"
 SLOT="0"
 KEYWORDS=""
 
-IUSE="cli feedreader +gui qt4 +qt5 voip"
+IUSE="cli feedreader +gui voip"
 REQUIRED_USE="
 	|| ( cli gui )
-	gui? ( ^^ ( qt4 qt5 ) )
-	cli? ( ^^ ( qt4 qt5 ) )
 	feedreader? ( gui )
 	voip? ( gui )"
 
@@ -26,6 +24,12 @@ RDEPEND="
 	app-arch/bzip2
 	dev-db/sqlcipher
 	dev-libs/openssl:0
+	dev-qt/qtcore:5
+	dev-qt/qtmultimedia:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtscript:5
+	dev-qt/qtxml:5
 	gnome-base/libgnome-keyring
 	net-libs/libmicrohttpd
 	net-libs/libupnp:0
@@ -35,39 +39,16 @@ RDEPEND="
 		dev-libs/libxslt
 		net-misc/curl
 	)
-	qt4? (
-		gui? (
-			dev-qt/designer:4
-			dev-qt/qtgui:4
-			x11-libs/libX11
-			x11-libs/libXScrnSaver
-		)
-		dev-qt/qtcore:4
-	)
-	qt5? (
-		gui? (
-			dev-qt/designer:5
-			dev-qt/qtgui:5
-			dev-qt/qtwidgets:5
-			dev-qt/qtx11extras:5
-			x11-libs/libX11
-			x11-libs/libXScrnSaver
-		)
-		dev-qt/qtcore:5
-		dev-qt/qtmultimedia:5
-		dev-qt/qtnetwork:5
-		dev-qt/qtprintsupport:5
-		dev-qt/qtscript:5
-		dev-qt/qtxml:5
+	gui? (
+		dev-qt/designer:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+		dev-qt/qtx11extras:5
+		x11-libs/libX11
+		x11-libs/libXScrnSaver
 	)
 	voip? (
-		qt5? (
-			media-libs/opencv[-qt4(-)]
-		)
-		qt4? (
-			media-libs/opencv
-			dev-qt/qt-mobility[multimedia]
-		)
+		media-libs/opencv[-qt4(-)]
 		media-libs/speex
 		virtual/ffmpeg[encode]
 	)"
@@ -103,8 +84,7 @@ src_prepare() {
 src_configure() {
 	for dir in ${rs_src_dirs} ; do
 		pushd "${S}/${dir}" >/dev/null || die
-		use qt4 && eqmake4
-		use qt5 && eqmake5
+		eqmake5
 		popd >/dev/null || die
 	done
 }


### PR DESCRIPTION
Qt4 is going away, let's use the opportunity to simplify the ebuild and reduce possible conflicts.