### PR TITLE
sci-physics/reduze: Fix building with GCC-6

### DIFF
--- a/sci-physics/reduze/files/reduze-2.0.9-gcc6.patch
+++ b/sci-physics/reduze/files/reduze-2.0.9-gcc6.patch
@@ -1,0 +1,58 @@
+--- a/reduze/amplitude.cpp
++++ b/reduze/amplitude.cpp
+@@ -782,7 +782,7 @@
+ 
+ 	ex resultLeadingNc = result;
+ 	for (exset::const_iterator it = found.begin(); it != found.end(); ++it) {
+-		VERIFY(is_a<function>(*it) && ex_to<function>(*it).get_name() == "Color");
++		VERIFY(is_a<GiNaC::function>(*it) && ex_to<GiNaC::function>(*it).get_name() == "Color");
+ 		VERIFY(is_a<lst>(it->op(0)));
+ 		ex res(1);
+ 		for (size_t i = 0; i < it->op(0).nops(); ++i)
+@@ -823,7 +823,7 @@
+ 	timer.restart();
+ 	exmap m;
+ 	for (exset::const_iterator it = found.begin(); it != found.end(); ++it) {
+-		VERIFY(is_a<function>(*it) && ex_to<function>(*it).get_name() == "Lorentz");
++		VERIFY(is_a<GiNaC::function>(*it) && ex_to<GiNaC::function>(*it).get_name() == "Lorentz");
+ 		VERIFY(is_a<lst>(it->op(0)));
+ 
+ 		ex res(1);
+--- a/reduze/files.cpp
++++ b/reduze/files.cpp
+@@ -420,7 +420,7 @@
+ 			get_filename_sectormappings(m.integralfamily()->name());
+ 	ofstream file(file_name.c_str());
+ 	if (!file)
+-		ABORT("Can't write to " << file);
++		ABORT("Can't write to " << file_name);
+ 	os << YAML::BeginMap << YAML::Key << "sectormappings" << YAML::Value;
+ 	os << m << YAML::EndMap;
+ 	file << os.c_str();
+@@ -617,7 +617,7 @@
+ 
+ bool is_readable_file(const string& filename) {
+ 	ifstream is(filename.c_str());
+-	bool ok = is;
++	bool ok = !is.fail();
+ 	is.close();
+ 	return ok;
+ }
+--- a/reduze/sectormappings.cpp
++++ b/reduze/sectormappings.cpp
+@@ -757,13 +757,13 @@
+ 	const Node& z_node = node["zero_sectors"];
+ 	for (Iterator n = z_node.begin(); n != z_node.end(); ++n)
+ 		for (Iterator s = n.second().begin(); s != n.second().end(); ++s)
+-			m.zero_sectors_.insert(*s);
++			m.zero_sectors_.insert((const int) *s);
+ 
+ 	if (node.FindValue("sectors_without_graph")) {
+ 		const Node& ng_node = node["sectors_without_graph"];
+ 		for (Iterator n = ng_node.begin(); n != ng_node.end(); ++n)
+ 			for (Iterator s = n.second().begin(); s != n.second().end(); ++s)
+-				m.sectors_without_graph_.insert(*s);
++				m.sectors_without_graph_.insert((const int) *s);
+ 	}
+ 
+ 	const Node& rel_node = node["sector_relations"];

--- a/sci-physics/reduze/files/reduze-2.1-gcc6.patch
+++ b/sci-physics/reduze/files/reduze-2.1-gcc6.patch
@@ -1,0 +1,29 @@
+--- a/reduze/files.cpp
++++ b/reduze/files.cpp
+@@ -723,7 +723,7 @@
+ 	string file_name_tmp = file_name + ".tmp";
+ 	ofstream file(file_name_tmp.c_str());
+ 	if (!file)
+-		ABORT("Can't write to " << file);
++		ABORT("Can't write to " << file_name_tmp);
+ 	Emitter os;
+ 	os << BeginMap;
+ 	os << Key << "crossings" << Value;
+@@ -752,7 +752,7 @@
+ 	string file_name_tmp = file_name + ".tmp";
+ 	ofstream file(file_name_tmp.c_str());
+ 	if (!file)
+-		ABORT("Can't write to " << file);
++		ABORT("Can't write to " << file_name_tmp);
+ 	os << YAML::BeginMap << YAML::Key << "sectormappings" << YAML::Value;
+ 	os << m << YAML::EndMap;
+ 	file << os.c_str();
+@@ -1036,7 +1036,7 @@
+ 
+ bool is_readable_file(const string& filename) {
+ 	ifstream is(filename.c_str());
+-	bool ok = is;
++	bool ok = !is.fail();
+ 	is.close();
+ 	return ok && !is_readable_directory(filename);
+ }

--- a/sci-physics/reduze/reduze-2.0.9.ebuild
+++ b/sci-physics/reduze/reduze-2.0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -25,6 +25,8 @@ DEPEND="${RDEPEND}
 DOCS=( ChangeLog README )
 
 src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc6.patch
+
 	# gentoo doc directory
 	sed -i \
 		-e "s:share/reduze:share/doc/${PF}:g" \

--- a/sci-physics/reduze/reduze-2.1.ebuild
+++ b/sci-physics/reduze/reduze-2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -21,6 +21,8 @@ RDEPEND=">=sci-mathematics/ginac-1.4.1
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	doc? ( app-doc/doxygen )"
+
+PATCHES=( "${FILESDIR}"/${P}-gcc6.patch )
 
 src_prepare() {
 	cmake-utils_src_prepare


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594900
Package-Manager: Portage-2.3.6, Repoman-2.3.2

No place for bug submissions or PRs upstream.

Note: Both ebuilds fail when built against 'sci-mathematics/ginac-1.7.2'.  This is an unrelated bug.