### PR TITLE
sys-libs/zlib: fix zlib.pc generation for mingw-64

### DIFF
--- a/sys-libs/zlib/zlib-1.2.11.ebuild
+++ b/sys-libs/zlib/zlib-1.2.11.ebuild
@@ -69,7 +69,7 @@ multilib_src_compile() {
 	*-mingw*|mingw*)
 		emake -f win32/Makefile.gcc STRIP=true PREFIX=${CHOST}-
 		sed \
-			-e 's|@prefix@|${EPREFIX}/usr|g' \
+			-e 's|@prefix@|/usr|g' \
 			-e 's|@exec_prefix@|${prefix}|g' \
 			-e 's|@libdir@|${exec_prefix}/'$(get_libdir)'|g' \
 			-e 's|@sharedlibdir@|${exec_prefix}/'$(get_libdir)'|g' \
@@ -98,7 +98,8 @@ multilib_src_install() {
 			LIBRARY_PATH="${ED}/usr/$(get_libdir)" \
 			INCLUDE_PATH="${ED}/usr/include" \
 			SHARED_MODE=1
-		insinto /usr/share/pkgconfig
+		# overwrites zlib.pc created from win32/Makefile.gcc #620136
+		insinto /usr/$(get_libdir)/pkgconfig
 		doins zlib.pc
 		;;
 


### PR DESCRIPTION
Without this change two zlib.pc files are built on mingw-w64,
one in /usr/share/pkgconfig with the correct values and one in
/usr/lib/pkgconfig with incorrect path values pointing to the
build dir.

This places zlib.pc in a location mirroring the native install
and corrects the values.

Package-Manager: Portage-2.3.6, Repoman-2.3.2