### PR TITLE
Use the built-in tinyxml instead of the system one

### DIFF
--- a/net-ftp/filezilla/filezilla-3.12.0.2-r1.ebuild
+++ b/net-ftp/filezilla/filezilla-3.12.0.2-r1.ebuild
@@ -21,12 +21,12 @@ IUSE="aqua dbus nls test"
 
 RDEPEND=">=app-eselect/eselect-wxwidgets-0.7-r1
 	>=dev-db/sqlite-3.7
-	>=dev-libs/tinyxml-2.6.1-r1[stl]
 	net-dns/libidn
 	>=net-libs/gnutls-3.1.12
 	aqua? ( >=x11-libs/wxGTK-3.0.2.0-r1:3.0[aqua] )
 	!aqua? ( >=x11-libs/wxGTK-3.0.2.0-r1:3.0[X] x11-misc/xdg-utils )
 	dbus? ( sys-apps/dbus )"
+#	>=dev-libs/tinyxml-2.6.1-r1[stl]
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	>=sys-devel/libtool-1.4
@@ -43,7 +43,7 @@ src_prepare() {
 
 src_configure() {
 	econf $(use_with dbus) $(use_enable nls locales) \
-		--with-tinyxml=system \
+		--with-tinyxml=builtin \
 		--disable-autoupdatecheck
 }
 


### PR DESCRIPTION
Due to https://sourceforge.net/p/tinyxml/patches/51/ not merged into the base, and https://trac.filezilla-project.org/ticket/5473 with corresponding modification on FileZilla's config, installing the tinyxml-2.6.2_r2 (the only available tinyxml) would trip the configure script.

Simple fix is to use the builtin tinyxml instead. Changing the tinyxml version to a different value that did not trip the detector seems not possible as tinyxml (1) is obsolete and no longer maintained, and to release a newer version to it is not our duty. Tinyxml2 might work, but not tested.

If tinyxml2 (that fixed the issue mentioned above) can serve as a drop-in replacement for tinyxml1 in this issue, changing the dev-libs/tinyxml to dev-libs/tinyxml2 would solve the problem and should be considered as a better solution than this PR is requesting.