### PR TITLE
dev-util/vint: revbump to add setuptools to RDEPEND

### DIFF
--- a/dev-util/vint/vint-0.3.13-r1.ebuild
+++ b/dev-util/vint/vint-0.3.13-r1.ebuild
@@ -22,9 +22,9 @@ RDEPEND="
 	>=dev-python/pyyaml-3.11[${PYTHON_USEDEP}]
 	virtual/python-enum34[${PYTHON_USEDEP}]
 	virtual/python-pathlib[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}
-	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? (
 		>=dev-python/coverage-3.7.1[${PYTHON_USEDEP}]
 		>=dev-python/pytest-2.6.4[${PYTHON_USEDEP}]


### PR DESCRIPTION
See vint/linting/cli.py

Package-Manager: Portage-2.3.6, Repoman-2.3.2