### PR TITLE
dev-db/postgresql: Remove src_unpack() and obsolete base_src_unpack

### DIFF
--- a/dev-db/postgresql/postgresql-9999.ebuild
+++ b/dev-db/postgresql/postgresql-9999.ebuild
@@ -75,10 +75,6 @@ sys-devel/flex
 nls? ( sys-devel/gettext )
 xml? ( virtual/pkgconfig )
 "
-src_unpack() {
-	base_src_unpack
-	git-2_src_unpack
-}
 
 RDEPEND="${CDEPEND}
 !dev-db/postgresql-docs:${SLOT}


### PR DESCRIPTION
```
QA: install
QA Notice: command not found:

/var/tmp/portage/dev-db/postgresql-9999/temp/environment: line 5156: base_src_unpack: command not found
```

Works for me without ```git-2_src_unpack``` too.
