### PR TITLE
x11-misc/slop: fixed no-opengl patch

### DIFF
--- a/x11-misc/slop/files/slop-4.3.21-no-opengl.patch
+++ b/x11-misc/slop/files/slop-4.3.21-no-opengl.patch
@@ -1,7 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 62cc1a6..f5d66e5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -67,14 +67,8 @@ endif()
+@@ -71,14 +71,8 @@ endif()
  
  # Obtain library paths and make sure they exist.
  set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmakemodules" )
@@ -16,3 +17,23 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
  
  set( CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} ${CMAKE_IMLIB2_CXX_FLAGS}" )
+diff --git a/src/x.hpp b/src/x.hpp
+index 2478414..f35e722 100644
+--- a/src/x.hpp
++++ b/src/x.hpp
+@@ -26,7 +26,6 @@
+ #include <X11/Xlib.h>
+ #include <X11/cursorfont.h>
+ #include <X11/extensions/shape.h>
+-#include <X11/extensions/Xrandr.h>
+ 
+ #include <stdlib.h>
+ #include <cstring>
+@@ -97,7 +96,6 @@ public:
+     std::vector<bool>   m_mouse;
+     bool                mouseDown( unsigned int button );
+     bool                m_keypressed;
+-    XRRScreenResources* m_res;
+ private:
+     slop::CursorType    m_currentCursor;
+     bool                m_good;


### PR DESCRIPTION
```
23:20 <@tamiko> palo: Please fix a dependency in x11-misc/slop for me: x11-misc/slop[-opengl] depends on x11-libs/libXrandr as well.
```

It does not depend on it as it seems. The no-opengl patch seem to be false, so I change the no-opengl patch.