### PR TITLE
media-sound/pasystray: fix missing gint #620266

### DIFF
--- a/media-sound/pasystray/files/fix-missing-gint.patch
+++ b/media-sound/pasystray/files/fix-missing-gint.patch
@@ -1,0 +1,20 @@
+diff --git a/src/notify.c b/src/notify.c
+index adec0ca..8b54808 100644
+--- a/src/notify.c
++++ b/src/notify.c
+@@ -23,11 +23,13 @@
+ 
+ #ifndef HAVE_NOTIFY
+ 
++#include <glib.h>
++
+ #include "notify.h"
+ 
+ void notify_initialize(){}
+-notify_handle_t notify(const char* msg, const char* body, const char* icon){ return 0; }
+-void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon){}
++notify_handle_t notify(const char* msg, const char* body, const char* icon, gint value){ return 0; }
++void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon, gint value){}
+ 
+ #else
+ 

--- a/media-sound/pasystray/pasystray-0.6.0-r2.ebuild
+++ b/media-sound/pasystray/pasystray-0.6.0-r2.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit gnome2-utils autotools vcs-snapshot xdg
+
+DESCRIPTION="PulseAudio system tray"
+HOMEPAGE="https://github.com/christophgysin/pasystray"
+SRC_URI="https://github.com/christophgysin/${PN}/archive/${P}.tar.gz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="libnotify zeroconf"
+
+RDEPEND="
+	>=dev-libs/glib-2.48.2
+	>=media-sound/pulseaudio-5.0-r3[glib,zeroconf?]
+	zeroconf? ( >=net-dns/avahi-0.6 )
+	x11-libs/gtk+:3
+	x11-libs/libX11
+	libnotify? ( >=x11-libs/libnotify-0.7 )
+"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}/fix-missing-gint.patch" )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable libnotify notify) \
+		$(use_enable zeroconf avahi)
+}
+
+pkg_preinst() {
+	xdg_pkg_preinst
+	gnome2_icon_savelist
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
This PR addresses: https://bugs.gentoo.org/show_bug.cgi?id=620266

This fault has been previously fixed on trunk in these commits:

1. dd344cfd25328af8aab0deebd12287d37b25d218
2. 240f6204b7dd2aa725bc2fa33e1f823528a089aa

On the next release this patch must be dropped (fix-missing-gint.patch)
