### PR TITLE
WIP media-plugins/kodi-vfs-sftp: SFTP VFS addon for Kodi

### DIFF
--- a/media-plugins/kodi-vfs-sftp/kodi-vfs-sftp-9999.ebuild
+++ b/media-plugins/kodi-vfs-sftp/kodi-vfs-sftp-9999.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils kodi-addon
+
+DESCRIPTION="SFTP VFS addon for Kodi"
+HOMEPAGE="https://github.com/notspiff/vfs.sftp"
+SRC_URI=""
+
+case ${PV} in
+9999)
+	SRC_URI=""
+	EGIT_REPO_URI="git://github.com/notspiff/vfs.sftp.git"
+	inherit git-r3
+	;;
+*)
+	KEYWORDS="~amd64 ~x86"
+	SRC_URI="https://github.com/notspiff/vfs.sftp/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/vfs.sftp-${PV}"
+	;;
+esac
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+DEPEND="
+	=dev-libs/libplatform-2*
+	net-libs/libssh[sftp]
+	=media-libs/kodi-platform-9999
+	=media-tv/kodi-9999
+	"

--- a/media-plugins/kodi-vfs-sftp/metadata.xml
+++ b/media-plugins/kodi-vfs-sftp/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+    <maintainer type="person">
+        <email>candrews@gentoo.org</email>
+        <name>Craig Andrews</name>
+    </maintainer>
+    <longdescription>SFTP VFS addon for Kodi</longdescription>
+    <upstream>
+        <remote-id type="github">notspiff/vfs.sftp</remote-id>
+    </upstream>
+</pkgmetadata>

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -28,7 +28,7 @@ SLOT="0"
 # use flag is called libusb so that it doesn't fool people in thinking that
 # it is _required_ for USB support. Otherwise they'll disable udev and
 # that's going to be worse.
-IUSE="airplay alsa bluetooth bluray caps cec +css dbus debug dvd gbm gles lcms libressl libusb lirc mysql nfs +opengl pulseaudio samba sftp systemd +system-ffmpeg test +udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
+IUSE="airplay alsa bluetooth bluray caps cec +css dbus debug dvd gbm gles lcms libressl libusb lirc mysql nfs +opengl pulseaudio samba systemd +system-ffmpeg test +udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	gbm? ( gles )
@@ -84,7 +84,6 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	libressl? ( dev-libs/libressl:0= )
 	pulseaudio? ( media-sound/pulseaudio )
 	samba? ( >=net-fs/samba-3.4.6[smbclient(+)] )
-	sftp? ( net-libs/libssh[sftp] )
 	>=sys-libs/zlib-1.2.11
 	udev? ( virtual/udev )
 	vaapi? (
@@ -245,7 +244,6 @@ src_configure() {
 		-DENABLE_PLIST=$(usex airplay)
 		-DENABLE_PULSEAUDIO=$(usex pulseaudio)
 		-DENABLE_SMBCLIENT=$(usex samba)
-		-DENABLE_SSH=$(usex sftp)
 		-DENABLE_UDEV=$(usex udev)
 		-DENABLE_UPNP=$(usex upnp)
 		-DENABLE_VAAPI=$(usex vaapi)


### PR DESCRIPTION
Adds support for SFTP to Kodi.
This functionality was originally part of Kodi itself, but was removed in Kodi 18.

Do not merge until https://github.com/xbmc/xbmc/pull/12005 is merged.