### PR TITLE
media-plugins/kodi-vfs-sacd: SACD VFS addon for Kodi

### DIFF
--- a/media-plugins/kodi-vfs-sacd/kodi-vfs-sacd-9999.ebuild
+++ b/media-plugins/kodi-vfs-sacd/kodi-vfs-sacd-9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils kodi-addon
+
+DESCRIPTION="SACD VFS addon for Kodi"
+HOMEPAGE="https://github.com/notspiff/vfs.sacd"
+SRC_URI=""
+
+case ${PV} in
+9999)
+	SRC_URI=""
+	EGIT_REPO_URI="git://github.com/notspiff/vfs.sacd.git"
+	inherit git-r3
+	;;
+*)
+	KEYWORDS="~amd64 ~x86"
+	SRC_URI="https://github.com/notspiff/vfs.sacd/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/vfs.sacd-${PV}"
+	;;
+esac
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+DEPEND="
+	=dev-libs/libplatform-2*
+	=media-libs/kodi-platform-9999
+	=media-tv/kodi-9999
+	"

--- a/media-plugins/kodi-vfs-sacd/metadata.xml
+++ b/media-plugins/kodi-vfs-sacd/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+    <maintainer type="person">
+        <email>candrews@integralblue.com</email>
+        <name>Craig Andrews</name>
+    </maintainer>
+    <maintainer type="project">
+        <email>proxy-maint@gentoo.org</email>
+        <name>Proxy Maintainers</name>
+    </maintainer>
+    <longdescription>SACD VFS addon for Kodi</longdescription>
+    <upstream>
+        <remote-id type="github">notspiff/vfs.sacd</remote-id>
+    </upstream>
+</pkgmetadata>


### PR DESCRIPTION
Adds support for playing SACD to Kodi.

Package-Manager: Portage-2.3.6, Repoman-2.3.2