### PR TITLE
media-libs/libsfml: various mingw-w64 fixes.

### DIFF
--- a/media-libs/libsfml/files/libsfml-2.4.2-no-install-extlibs-mingw.patch
+++ b/media-libs/libsfml/files/libsfml-2.4.2-no-install-extlibs-mingw.patch
@@ -1,0 +1,74 @@
+--- SFML-2.4.2/CMakeLists.txt	2017-02-08 05:29:16.000000000 -0600
++++ SFML-2.4.2.new/CMakeLists.txt	2017-06-05 22:12:39.166300154 -0500
+@@ -305,24 +305,26 @@
+ # install 3rd-party libraries and tools
+ if(SFML_OS_WINDOWS)
+ 
+-    # install the binaries of SFML dependencies
+-    if(ARCH_32BITS)
+-        install(DIRECTORY extlibs/bin/x86/ DESTINATION bin)
+-        if(SFML_COMPILER_MSVC AND SFML_MSVC_VERSION LESS 14)
+-            install(DIRECTORY extlibs/libs-msvc/x86/ DESTINATION lib)
+-        elseif(SFML_COMPILER_MSVC)
+-            install(DIRECTORY extlibs/libs-msvc-universal/x86/ DESTINATION lib)
+-        else()
+-            install(DIRECTORY extlibs/libs-mingw/x86/ DESTINATION lib)
+-        endif()
+-    elseif(ARCH_64BITS)
+-        install(DIRECTORY extlibs/bin/x64/ DESTINATION bin)
+-        if(SFML_COMPILER_MSVC AND SFML_MSVC_VERSION LESS 14)
+-            install(DIRECTORY extlibs/libs-msvc/x64/ DESTINATION lib)
+-        elseif(SFML_COMPILER_MSVC)
+-            install(DIRECTORY extlibs/libs-msvc-universal/x64/ DESTINATION lib)
+-        else()
+-            install(DIRECTORY extlibs/libs-mingw/x64/ DESTINATION lib)
++    if(NOT SFML_USE_SYSTEM_DEPS)
++        # install the binaries of SFML dependencies
++        if(ARCH_32BITS)
++            install(DIRECTORY extlibs/bin/x86/ DESTINATION bin)
++            if(SFML_COMPILER_MSVC AND SFML_MSVC_VERSION LESS 14)
++                install(DIRECTORY extlibs/libs-msvc/x86/ DESTINATION lib)
++            elseif(SFML_COMPILER_MSVC)
++                install(DIRECTORY extlibs/libs-msvc-universal/x86/ DESTINATION lib)
++            else()
++                install(DIRECTORY extlibs/libs-mingw/x86/ DESTINATION lib)
++            endif()
++        elseif(ARCH_64BITS)
++            install(DIRECTORY extlibs/bin/x64/ DESTINATION bin)
++            if(SFML_COMPILER_MSVC AND SFML_MSVC_VERSION LESS 14)
++                install(DIRECTORY extlibs/libs-msvc/x64/ DESTINATION lib)
++            elseif(SFML_COMPILER_MSVC)
++                install(DIRECTORY extlibs/libs-msvc-universal/x64/ DESTINATION lib)
++            else()
++                install(DIRECTORY extlibs/libs-mingw/x64/ DESTINATION lib)
++            endif()
+         endif()
+     endif()
+ 
+@@ -379,9 +381,11 @@
+         install(DIRECTORY "${CMAKE_BINARY_DIR}/lib/\$ENV{CONFIGURATION}/" DESTINATION lib${LIB_SUFFIX})
+     endif()
+ 
+-    # since the iOS libraries are built as static, we must install the SFML dependencies
+-    # too so that the end user can easily link them to its final application
+-    install(FILES extlibs/libs-ios/libfreetype.a extlibs/libs-ios/libjpeg.a DESTINATION lib)
++    if(NOT SFML_USE_SYSTEM_DEPS)
++        # since the iOS libraries are built as static, we must install the SFML dependencies
++        # too so that the end user can easily link them to its final application
++        install(FILES extlibs/libs-ios/libfreetype.a extlibs/libs-ios/libjpeg.a DESTINATION lib)
++    endif()
+ 
+ elseif(SFML_OS_ANDROID)
+ 
+@@ -389,7 +393,9 @@
+     install(DIRECTORY extlibs/libs-android/${ANDROID_ABI} DESTINATION extlibs/lib)
+     install(FILES extlibs/Android.mk DESTINATION extlibs)
+ 
+-    # install Android.mk so the NDK knows how to set up SFML
+-    install(FILES src/SFML/Android.mk DESTINATION .)
++    if(NOT SFML_USE_SYSTEM_DEPS)
++        # install Android.mk so the NDK knows how to set up SFML
++        install(FILES src/SFML/Android.mk DESTINATION .)
++    endif()
+ 
+ endif()

--- a/media-libs/libsfml/libsfml-2.4.2-r1.ebuild
+++ b/media-libs/libsfml/libsfml-2.4.2-r1.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils versionator
+
+MY_P="SFML-${PV}"
+
+DESCRIPTION="Simple and Fast Multimedia Library (SFML)"
+HOMEPAGE="http://www.sfml-dev.org/ https://github.com/SFML/SFML"
+SRC_URI="https://github.com/SFML/SFML/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="ZLIB"
+SLOT="0/$(get_version_component_range 1-2)"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug doc examples"
+
+RDEPEND="
+	media-libs/flac
+	media-libs/freetype:2
+	media-libs/libpng:0=
+	media-libs/libogg
+	media-libs/libvorbis
+	media-libs/openal
+	sys-libs/zlib
+	virtual/jpeg:0
+	kernel_linux? (
+		virtual/libudev:0
+	)
+	virtual/opengl
+	!kernel_Winnt? (
+		x11-libs/libX11
+		x11-libs/libXrandr
+		x11-libs/libxcb
+		x11-libs/xcb-util-image
+	)
+"
+DEPEND="
+	${RDEPEND}
+	doc? ( app-doc/doxygen )
+"
+
+DOCS=( changelog.txt readme.txt )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.2-no-docs.patch
+	"${FILESDIR}"/${PN}-2.4.2-no-install-extlibs-mingw.patch
+)
+
+S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	sed -i "s:DESTINATION .*:DESTINATION /usr/share/doc/${PF}:" \
+		doc/CMakeLists.txt || die
+
+	find examples -name CMakeLists.txt -delete || die
+	cmake-utils_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DSFML_BUILD_DOC=$(usex doc)
+		-DSFML_INSTALL_PKGCONFIG_FILES=TRUE
+	)
+
+	if use kernel_Winnt; then
+		mycmakeargs+=( -DSFML_USE_SYSTEM_DEPS=TRUE )
+	fi
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+
+	insinto /usr/share/cmake/Modules
+	doins cmake/Modules/FindSFML.cmake
+
+	if use examples ; then
+		docompress -x /usr/share/doc/${PF}/examples
+		dodoc -r examples
+	fi
+}


### PR DESCRIPTION
Fixes the following:

* cross-compiling for windows does not require x11 and udev, so wrapped in use
  flags

* since we RDEP on build deps, apply a patch accepted for upstream to prevent
  installtion of extlibs when SFML_USE_SYSTEM_DEPS is set

* sets SFML_USE_SYSTEM_DEPS to true (no effect on native builds)

* remove explicit dep on media-libs/mesa as this is provided by virtual/opengl
  in native compilation, and hopefully someday dev-util/mingw64-runtime will be
  an accepted provider for virtual/opengl and virtual/glu, as it provides the
  needed headers and libraries for the mingw-w64 platform.

Package-Manager: Portage-2.3.6, Repoman-2.3.2