### PR TITLE
dev-util/mingw64-runtime: fix build with USE="tools" with gcc7

### DIFF
--- a/dev-util/mingw64-runtime/files/mingw64-runtime-5.0.2-implicit-fallthrough.patch
+++ b/dev-util/mingw64-runtime/files/mingw64-runtime-5.0.2-implicit-fallthrough.patch
@@ -1,0 +1,41 @@
+diff --git a/mingw-w64-tools/gendef/src/gendef.c b/mingw-w64-tools/gendef/src/gendef.c
+index a935abfe..cefdd8cb 100644
+--- a/mingw-w64-tools/gendef/src/gendef.c
++++ b/mingw-w64-tools/gendef/src/gendef.c
+@@ -1031,13 +1031,16 @@ redo_switch:
+     PRDEBUG(" 0x%x illegal ", (unsigned int) b);
+ #endif
+     *aCode=c_ill; return 0;
+-  case c_4: sz++;
+-  case c_3: sz++;
+-  case c_lb:
+-  case c_2: sz++;
+-  case c_retn: case c_retf:
+-  case c_iret: case c_int3:
+-  case c_ad: case c_op:
++  case c_4: sz++; // fallthrough
++  case c_3: sz++; // fallthrough
++  case c_lb: // fallthrough
++  case c_2: sz++; // fallthrough
++  case c_retn: // fallthrough
++  case c_retf: // fallthrough
++  case c_iret: // fallthrough
++  case c_int3: // fallthrough
++  case c_ad: // fallthrough
++  case c_op: // fallthrough
+   case c_1: *aCode=tb1; return sz;
+   case c_lv:
+     if (oper_mode) sz+=4;
+diff --git a/mingw-w64-tools/genpeimg/src/genpeimg.c b/mingw-w64-tools/genpeimg/src/genpeimg.c
+index b2430bbc..6a37b1a0 100644
+--- a/mingw-w64-tools/genpeimg/src/genpeimg.c
++++ b/mingw-w64-tools/genpeimg/src/genpeimg.c
+@@ -203,7 +203,7 @@ pass_args (int argc, char **argv)
+ 	  goto error_point;
+ 	case 'h':
+ 	  if (h[2] == 0)
+-	    show_usage ();
++	    show_usage (); // fallthrough
+ 	default:
+ error_point:
+ 	  fprintf (stderr, "Unknown option ,%s'\n", h);

--- a/dev-util/mingw64-runtime/mingw64-runtime-5.0.2-r1.ebuild
+++ b/dev-util/mingw64-runtime/mingw64-runtime-5.0.2-r1.ebuild
@@ -30,6 +30,7 @@ S="${WORKDIR}/mingw-w64-v${PV}"
 PATCHES=(
 	"${FILESDIR}/${PN}-4.0.1-winpthreads.patch"
 	"${FILESDIR}/${PN}-4.0.1-build.patch"
+	"${FILESDIR}/${PN}-5.0.2-implicit-fallthrough.patch"
 )
 
 is_crosscompile() {


### PR DESCRIPTION
Included patch only changes code formatting and comments. See:
https://sourceforge.net/p/mingw-w64/bugs/616/

Package-Manager: Portage-2.3.6, Repoman-2.3.2