### PR TITLE
net-im/corebird: Really fix video playback (#618996)

### DIFF
--- a/net-im/corebird/corebird-1.5-r2.ebuild
+++ b/net-im/corebird/corebird-1.5-r2.ebuild
@@ -21,7 +21,7 @@ RDEPEND="dev-db/sqlite:3
 	dev-libs/json-glib
 	gstreamer? ( media-plugins/gst-plugins-meta:1.0[X]
 		media-libs/gst-plugins-base:1.0[X]
-		>=media-libs/gst-plugins-bad-1.6:1.0[X]
+		>=media-libs/gst-plugins-bad-1.6:1.0[X,gtk]
 		media-libs/gst-plugins-good:1.0
 		media-plugins/gst-plugins-libav:1.0
 		media-plugins/gst-plugins-soup:1.0


### PR DESCRIPTION
By adding the dependency use flag gst-plugins-bad[gtk].

Gentoo-Bug: https://bugs.gentoo.org/618996

Also, could the following bugs be closed now:

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=578450
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=591342