### PR TITLE
sci-misc/boinc: Fix bashisms in init script and enhance OpenCL support

### DIFF
--- a/sci-misc/boinc/boinc-7.2.44-r5.ebuild
+++ b/sci-misc/boinc/boinc-7.2.44-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-WX_GTK_VER=3.0
+WX_GTK_VER=2.8
 
 inherit autotools eutils linux-info systemd user versionator wxwidgets
 
@@ -42,7 +42,7 @@ RDEPEND="
 		virtual/jpeg:0=
 		x11-libs/gtk+:2
 		>=x11-libs/libnotify-0.7
-		x11-libs/wxGTK:${WX_GTK_VER}[X,opengl,webkit]
+		x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
 	)
 "
 DEPEND="${RDEPEND}
@@ -51,11 +51,6 @@ DEPEND="${RDEPEND}
 	app-text/docbook2X
 	X? ( virtual/imagemagick-tools[png,tiff] )
 "
-
-PATCHES=(
-	# >=x11-libs/wxGTK-3.0.2.0-r3 has webview removed, bug 587462
-	"${FILESDIR}"/fix_webview.patch
-)
 
 S="${WORKDIR}/${PN}-client_release-${MY_PV}-${PV}"
 
@@ -127,7 +122,8 @@ src_install() {
 	# cleanup cruft
 	rm -rf "${ED%/}"/etc || die "rm failed"
 
-	newinitd "${FILESDIR}"/${PN}.init ${PN}
+	sed -e "s/@libdir@/$(get_libdir)/" "${FILESDIR}"/${PN}.init.in > ${PN}.init || die
+	newinitd ${PN}.init ${PN}
 	newconfd "${FILESDIR}"/${PN}.conf ${PN}
 	systemd_dounit "${FILESDIR}"/${PN}.service
 }
@@ -168,4 +164,12 @@ pkg_postinst() {
 		elog "Run as root:"
 		elog "gpasswd -a boinc video"
 	fi
+	# Add information about BOINC supporting OpenCL
+	elog "BOINC supports OpenCL. To use it you have to eselect"
+	if use cuda; then
+		elog "nvidia as the OpenCL implementation, as you are using CUDA."
+	else
+		elog "the correct OpenCL implementation for your graphic card."
+	fi
+	elog
 }

--- a/sci-misc/boinc/boinc-7.6.33-r5.ebuild
+++ b/sci-misc/boinc/boinc-7.6.33-r5.ebuild
@@ -127,7 +127,8 @@ src_install() {
 	# cleanup cruft
 	rm -rf "${ED%/}"/etc || die "rm failed"
 
-	newinitd "${FILESDIR}"/${PN}.init ${PN}
+	sed -e "s/@libdir@/$(get_libdir)/" "${FILESDIR}"/${PN}.init.in > ${PN}.init || die
+	newinitd ${PN}.init ${PN}
 	newconfd "${FILESDIR}"/${PN}.conf ${PN}
 	systemd_dounit "${FILESDIR}"/${PN}.service
 }
@@ -167,5 +168,14 @@ pkg_postinst() {
 		elog "To be able to use CUDA you should add boinc user to video group."
 		elog "Run as root:"
 		elog "gpasswd -a boinc video"
+		elog
 	fi
+	# Add information about BOINC supporting OpenCL
+	elog "BOINC supports OpenCL. To use it you have to eselect"
+	if use cuda; then
+		elog "nvidia as the OpenCL implementation, as you are using CUDA."
+	else
+		elog "the correct OpenCL implementation for your graphic card."
+	fi
+	elog
 }

--- a/sci-misc/boinc/files/boinc.init.in
+++ b/sci-misc/boinc/files/boinc.init.in
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 extra_started_commands="attach resume suspend"
@@ -9,46 +9,84 @@ depend() {
 	use dns net ntp-client ntpd
 }
 
-
 create_work_directory() {
-	if [[ ! -d "${RUNTIMEDIR}" ]]; then
+	local sslcrt="/etc/ssl/certs/ca-certificates.crt"
+
+	if [ ! -d "${RUNTIMEDIR}" ]; then
 		einfo "Directory ${RUNTIMEDIR} does not exist, creating now."
-		mkdir -p "${RUNTIMEDIR}"
-		if [[ ! -d "${RUNTIMEDIR}" ]]; then
+		if ! mkdir -p "${RUNTIMEDIR}"; then
 			eeror "Directory ${RUNTIMEDIR} could not be created!"
 			return 1
 		fi
 
 		# ensure proper ownership
-		chown "${USER}:${GROUP}" "${RUNTIMEDIR}"
+		if ! chown "${USER}:${GROUP}" "${RUNTIMEDIR}"; then
+			eeror "Changing ownership of '${RUNTIMEDIR}' to '${USER}:${GROUP}' failed!"
+			return 1
+		fi
 	fi
 
-	if [[ ! -e "${RUNTIMEDIR}"/ca-bundle.crt ]]; then
-		ln -s /etc/ssl/certs/ca-certificates.crt "${RUNTIMEDIR}"/ca-bundle.crt
+	if [ ! -e "${RUNTIMEDIR}"/ca-bundle.crt ]; then
+		if [ ! -f "${sslcrt}" ]; then
+			eerror "'${sslcrt}' does not exist!"
+			return 1
+		fi
+
+		if ! ln -s "${sslcrt}" "${RUNTIMEDIR}"/ca-bundle.crt; then
+			eeror "Symlinking '${sslcrt}' failed!"
+			return 1
+		fi
 	fi
 
 	return 0
 }
 
+fix_lib_symlinks() {
+	local src="$1"
+	local tgt="$2"
 
-cuda_check() {
-	local libtarget="${RUNTIMEDIR}/libcudart.so"
-	local libsource="$(ls -t /opt/cuda/lib*/libcudart.so 2>/dev/null | head -n 1)"
+	# If the source does not exist, we can not do anything
+	if [ ! -f "${src}" ] ; then
+		return 1
+	fi
 
-	# Remove a broken symlink
-	if [[ -h "${libtarget}" ]] \
-	&& [[ "${libsource}" != "$(readlink "${libtarget}")" ]]; then
-		rm -f "${libtarget}"
+	# Check whether the symlink is already there and in order
+	if [ -L "${tgt}" ] ; then
+		if [ -f "${tgt}" ] ; then
+			return 0
+		fi
+
+		# Remove broken symlink
+		if ! rm -f "${tgt}"; then
+			eeror "Removing '${tgt}' failed!"
+			return 1
+		fi
 	fi
 
 	# symlink the correct path
-	if [[ -n "${libsource}" ]] \
-	&& [[ -f "${libsource}" ]] \
-	&& [[ ! -h "${libtarget}" ]]; then
-		ln -snf "$libsource" "${libtarget}"
+	if ! ln -snf "${src}" "${tgt}"; then
+		eeror "Symlinking '${src}' to '${tgt}' failed!"
+		return 1
 	fi
+
+	return 0
 }
 
+cuda_check() {
+	local libsource="/opt/cuda/@libdir@/libcudart.so"
+	local libtarget="${RUNTIMEDIR}/libcudart.so"
+
+	fix_lib_symlinks "${libsource}" "${libtarget}" || return 1
+	return 0
+}
+
+opencl_check() {
+	local libsource="/usr/@libdir@/libOpenCL.so"
+	local libtarget="${RUNTIMEDIR}/libOpenCL.so"
+
+	fix_lib_symlinks "${libsource}" "${libtarget}" || return 1
+	return 0
+}
 
 env_check() {
 	# Make sure the configuration is sane
@@ -64,26 +102,25 @@ env_check() {
 	# to be empty by the user.
 
 	# If the client was not found (how?) something is seriously wrong
-	if [[ ! -x "$BOINCBIN" ]]; then
+	if [ ! -x "${BOINCBIN}" ]; then
 		eerror "No boinc_client found!"
 		return 1
 	fi
 
 	# The boinccmd is crucial, or we can not attach, suspend or resume
 	# the boinc client
-	if [[ ! -x "$BOINCCMD" ]]; then
-		eerror "No boinccmd_program found!"
+	if [ ! -x "${BOINCCMD}" ]; then
+		eerror "No boinccmd program found!"
 		return 1
 	fi
 
 	return 0
 }
 
-
 need_passwd_arg() {
 	local vers=$(${BOINCBIN} --version | tr -d .)
-	[ -z "$vers" ] && vers="00"
-	[ $(expr substr "$vers" 1 2) -lt 74 ] && return 0
+	[ -z "${vers}" ] && vers="00"
+	[ $(expr substr "${vers}" 1 2) -lt 74 ] && return 0
 
 	# From version 7.4 on, the default is to read
 	# gui_rpc_auth.cfg for the password.
@@ -91,13 +128,13 @@ need_passwd_arg() {
 	return 1
 }
 
-
 start_pre() {
 	env_check || return 1
 	create_work_directory || return 1
-	cuda_check
+	cuda_check || einfo "CUDA not supported"
+	opencl_check || einfo "OpenCL not supported"
 
-	if [[ ! -f "${RUNTIMEDIR}/lockfile" ]]; then
+	if [ ! -f "${RUNTIMEDIR}/lockfile" ]; then
 		einfo "File \"${RUNTIMEDIR}/lockfile\" does not exist, assuming first run."
 		einfo "You need to setup an account on the BOINC project homepage beforehand!"
 		einfo "Go to http://boinc.berkeley.edu/ and locate your project."
@@ -111,9 +148,8 @@ start_pre() {
 	return 0
 }
 
-
 start() {
-	if [[ "${ALLOW_REMOTE_RPC}" = "yes" ]]; then
+	if [ "${ALLOW_REMOTE_RPC}" = "yes" ]; then
 		ARGS="${ARGS} --allow_remote_gui_rpc"
 	fi
 
@@ -122,11 +158,10 @@ start() {
 	ebegin "Starting ${RC_SVCNAME}"
 	start-stop-daemon --start --nicelevel ${NICELEVEL} \
 		--user "${USER}:${GROUP}" --quiet --make-pidfile \
-		--pidfile "$BOINC_PIDFILE" --background \
+		--pidfile "${BOINC_PIDFILE}" --background \
 		--exec "${BOINCBIN}" -- ${ARGS}
 	eend $?
 }
-
 
 attach() {
 	local password=""
@@ -157,10 +192,9 @@ attach() {
 		-- ${password} --project_attach ${url} ${key}
 	eend $?
 
-	sleep 10s
+	sleep 10
 	tail "${RUNTIMEDIR}/stdoutdae.txt"
 }
-
 
 stop() {
 	local password=""
@@ -174,11 +208,10 @@ stop() {
 
 	ebegin "Stopping ${RC_SVCNAME}"
 	start-stop-daemon --stop --quiet --progress \
-		--retry $stop_timeout \
+		--retry ${stop_timeout} \
 		--pidfile "${BOINC_PIDFILE}"
 	eend $?
 }
-
 
 resume() {
 	env_check || return 1
@@ -189,21 +222,16 @@ resume() {
 		password="--passwd \"$(cat "${RUNTIMEDIR}/gui_rpc_auth.cfg")\""
 	fi
 
-	local master_urls=( \
-		$(cd "${RUNTIMEDIR}" ; \
+	for url in $(cd "${RUNTIMEDIR}" ; \
 		  "${BOINCCMD}" ${password} --get_project_status | \
-		  sed -n 's/\s*master URL: //p') \
-	)
-
-	for url in "${master_urls[@]}"; do
-		ebegin "Resuming $url"
+		  sed -n 's/\s*master URL: //p'); do
+		ebegin "Resuming ${url}"
 		start-stop-daemon --user "${USER}:${GROUP}" --quiet \
 			--chdir "${RUNTIMEDIR}" --exec "${BOINCCMD}" \
 			-- ${password} --project ${url} resume
 		eend $?
 	done
 }
-
 
 suspend() {
 	env_check || return 1
@@ -214,14 +242,10 @@ suspend() {
 		password="--passwd \"$(cat "${RUNTIMEDIR}/gui_rpc_auth.cfg")\""
 	fi
 
-	local master_urls=( \
-		$(cd "${RUNTIMEDIR}" ; \
+	for url in $(cd "${RUNTIMEDIR}" ; \
 		  "${BOINCCMD}" ${password} --get_project_status | \
-		  sed -n 's/\s*master URL: //p') \
-	)
-
-	for url in "${master_urls[@]}"; do
-		ebegin "Suspending $url"
+		  sed -n 's/\s*master URL: //p'); do
+		ebegin "Suspending ${url}"
 		start-stop-daemon --user "${USER}:${GROUP}" --quiet \
 			--chdir "${RUNTIMEDIR}" --exec "${BOINCCMD}" \
 			-- ${password} --project ${url} suspend

--- a/sci-misc/boinc/metadata.xml
+++ b/sci-misc/boinc/metadata.xml
@@ -19,7 +19,7 @@
   Use nvidia cuda toolkit for speeding up computations.
   NOTE: works only for subset of nvidia graphic cards so make sure your card
   is supported before opening a bug about it.
-  </flag>
+    </flag>
   </use>
   <upstream>
     <remote-id type="github">BOINC/boinc</remote-id>


### PR DESCRIPTION
This commit fixes the following issues:

 - https://bugs.gentoo.org/show_bug.cgi?id=620818
   The previous init script consisted of many bashisms that have been removed.

 - BOINC supports OpenCL unconditionally. This commit adds a USE flag "opencl",
   so that users can have virtual/opencl being added in RDEPEND.

 - For OpenCL to work, the currently used libOpenCL.so must be symlinked into
   the BOINC working directory, just like libcudart.so. The init script has been
   updated to take care of symlinking libOpenCL.so.

Package-Manager: Portage-2.3.6, Repoman-2.3.2

@jlec @SoapGentoo : Please have a look whether the changes are in order to you
@mgorny : Could you please check, whether my substitutions for the bashisms are in order this way?