### PR TITLE
net-misc/curl: Drop polarssl support (bug #618356)

### DIFF
--- a/dev-python/pycurl/pycurl-7.43.0.ebuild
+++ b/dev-python/pycurl/pycurl-7.43.0.ebuild
@@ -29,7 +29,7 @@ IUSE="curl_ssl_gnutls curl_ssl_libressl curl_ssl_nss +curl_ssl_openssl examples 
 RDEPEND="
 	>=net-misc/curl-7.25.0-r1[ssl=]
 	ssl? (
-		net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,curl_ssl_nss(-)=,curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
+		net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,curl_ssl_nss(-)=,curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-)]
 		curl_ssl_gnutls? ( >=net-libs/gnutls-2.11.0 )
 	)"
 
@@ -41,7 +41,7 @@ DEPEND="${RDEPEND}
 		dev-python/flaky[${PYTHON_USEDEP}]
 		dev-python/nose[${PYTHON_USEDEP}]
 		dev-python/nose-show-skipped[${PYTHON_USEDEP}]
-		net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,curl_ssl_nss(-)=,curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-),kerberos]
+		net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,curl_ssl_nss(-)=,curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),kerberos]
 		>=dev-python/bottle-0.12.7[${PYTHON_USEDEP}]
 	)"
 # Needed for individual runs of testsuite by python impls.

--- a/net-misc/curl/curl-7.53.0.ebuild
+++ b/net-misc/curl/curl-7.53.0.ebuild
@@ -13,7 +13,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="adns http2 idn ipv6 kerberos ldap metalink rtmp samba ssh ssl static-libs test threads"
-IUSE+=" curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_polarssl curl_ssl_winssl"
+IUSE+=" curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
 IUSE+=" elibc_Winnt"
 
 #lead to lots of false negatives, bug #285669
@@ -42,10 +42,6 @@ RDEPEND="ldap? ( net-nds/openldap[${MULTILIB_USEDEP}] )
 		)
 		curl_ssl_nss? (
 			dev-libs/nss:0[${MULTILIB_USEDEP}]
-			app-misc/ca-certificates
-		)
-		curl_ssl_polarssl? (
-			net-libs/polarssl:0=[${MULTILIB_USEDEP}]
 			app-misc/ca-certificates
 		)
 	)
@@ -92,7 +88,6 @@ REQUIRED_USE="
 			curl_ssl_mbedtls
 			curl_ssl_nss
 			curl_ssl_openssl
-			curl_ssl_polarssl
 			curl_ssl_winssl
 		)
 	)"
@@ -142,9 +137,6 @@ multilib_src_configure() {
 		elif use curl_ssl_nss; then
 			einfo "SSL provided by nss"
 			myconf+=( --with-nss )
-		elif use curl_ssl_polarssl; then
-			einfo "SSL provided by polarssl"
-			myconf+=( --with-polarssl )
 		elif use curl_ssl_openssl; then
 			einfo "SSL provided by openssl"
 			myconf+=( --with-ssl --with-ca-path="${EPREFIX}"/etc/ssl/certs )

--- a/net-misc/curl/curl-7.53.1.ebuild
+++ b/net-misc/curl/curl-7.53.1.ebuild
@@ -13,7 +13,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="adns http2 idn ipv6 kerberos ldap metalink rtmp samba ssh ssl static-libs test threads"
-IUSE+=" curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_polarssl curl_ssl_winssl"
+IUSE+=" curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
 IUSE+=" elibc_Winnt"
 
 #lead to lots of false negatives, bug #285669
@@ -42,10 +42,6 @@ RDEPEND="ldap? ( net-nds/openldap[${MULTILIB_USEDEP}] )
 		)
 		curl_ssl_nss? (
 			dev-libs/nss:0[${MULTILIB_USEDEP}]
-			app-misc/ca-certificates
-		)
-		curl_ssl_polarssl? (
-			net-libs/polarssl:0=[${MULTILIB_USEDEP}]
 			app-misc/ca-certificates
 		)
 	)
@@ -92,7 +88,6 @@ REQUIRED_USE="
 			curl_ssl_mbedtls
 			curl_ssl_nss
 			curl_ssl_openssl
-			curl_ssl_polarssl
 			curl_ssl_winssl
 		)
 	)"
@@ -142,9 +137,6 @@ multilib_src_configure() {
 		elif use curl_ssl_nss; then
 			einfo "SSL provided by nss"
 			myconf+=( --with-nss )
-		elif use curl_ssl_polarssl; then
-			einfo "SSL provided by polarssl"
-			myconf+=( --with-polarssl )
 		elif use curl_ssl_openssl; then
 			einfo "SSL provided by openssl"
 			myconf+=( --with-ssl --with-ca-path="${EPREFIX}"/etc/ssl/certs )

--- a/net-misc/curl/curl-7.54.0.ebuild
+++ b/net-misc/curl/curl-7.54.0.ebuild
@@ -13,7 +13,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="adns http2 idn ipv6 kerberos ldap metalink rtmp samba ssh ssl static-libs test threads"
-IUSE+=" curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_polarssl curl_ssl_winssl"
+IUSE+=" curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
 IUSE+=" elibc_Winnt"
 
 #lead to lots of false negatives, bug #285669
@@ -42,10 +42,6 @@ RDEPEND="ldap? ( net-nds/openldap[${MULTILIB_USEDEP}] )
 		)
 		curl_ssl_nss? (
 			dev-libs/nss:0[${MULTILIB_USEDEP}]
-			app-misc/ca-certificates
-		)
-		curl_ssl_polarssl? (
-			net-libs/polarssl:0=[${MULTILIB_USEDEP}]
 			app-misc/ca-certificates
 		)
 	)
@@ -92,7 +88,6 @@ REQUIRED_USE="
 			curl_ssl_mbedtls
 			curl_ssl_nss
 			curl_ssl_openssl
-			curl_ssl_polarssl
 			curl_ssl_winssl
 		)
 	)"
@@ -142,9 +137,6 @@ multilib_src_configure() {
 		elif use curl_ssl_nss; then
 			einfo "SSL provided by nss"
 			myconf+=( --with-nss )
-		elif use curl_ssl_polarssl; then
-			einfo "SSL provided by polarssl"
-			myconf+=( --with-polarssl )
 		elif use curl_ssl_openssl; then
 			einfo "SSL provided by openssl"
 			myconf+=( --with-ssl --with-ca-path="${EPREFIX}"/etc/ssl/certs )

--- a/profiles/arch/amd64-fbsd/clang/package.use.mask
+++ b/profiles/arch/amd64-fbsd/clang/package.use.mask
@@ -14,7 +14,7 @@ sys-devel/binutils cxx
 
 # Force openssl on curl since cmakes needs it and is in @system because of
 # libcxx on this profile. Mask the other ssl providers.
-net-misc/curl curl_ssl_axtls curl_ssl_gnutls curl_ssl_nss curl_ssl_polarssl
+net-misc/curl curl_ssl_axtls curl_ssl_gnutls curl_ssl_nss
 
 # Needs to be fixed: build fails with clang++
 # https://bugs.gentoo.org/show_bug.cgi?id=578506

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -68,7 +68,7 @@ net-misc/tlsdate seccomp
 # Mike Frysinger <vapier@gentoo.org> (20 Jul 2015)
 # Mart Raudsepp <leio@gentoo.org> (04 Feb 2017)
 # Needs deps tested.
-net-misc/curl curl_ssl_axtls curl_ssl_libressl curl_ssl_polarssl metalink
+net-misc/curl curl_ssl_axtls curl_ssl_libressl metalink
 
 # Mike Frysinger <vapier@gentoo.org> (16 Mar 2015)
 # Needs sci-physics/bullet tested #499974

--- a/profiles/default/linux/alpha/13.0/use.mask
+++ b/profiles/default/linux/alpha/13.0/use.mask
@@ -1,5 +1,3 @@
 # Anthony G. Basile <blueness@gentoo.org> (15 Apr 2012)
-# Pulls in net-libs/axtls or net-libs/polarssl which are
-# not keyworded for arch
+# Pulls in net-libs/axtls which is not keyworded for arch
 curl_ssl_axtls
-curl_ssl_polarssl

--- a/profiles/default/linux/ia64/13.0/use.mask
+++ b/profiles/default/linux/ia64/13.0/use.mask
@@ -1,8 +1,6 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 # Anthony G. Basile <blueness@gentoo.org> (15 Apr 2012)
-# Pulls in net-libs/axtls or net-libs/polarssl which are
-# not keyworded for arch
+# Pulls in net-libs/axtls which is not keyworded for arch
 curl_ssl_axtls
-curl_ssl_polarssl

--- a/profiles/desc/curl_ssl.desc
+++ b/profiles/desc/curl_ssl.desc
@@ -10,5 +10,4 @@ libressl - Use LibreSSL
 mbedtls - Use mbed TLS
 nss - Use Mozilla's Network Security Services 
 openssl - Use OpenSSL
-polarssl - Use PolarSSL
 winssl - Use WinSSL (only with elibc_Winnt) 

--- a/sci-misc/boinc/boinc-7.2.44-r4.ebuild
+++ b/sci-misc/boinc/boinc-7.2.44-r4.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	!sci-misc/boinc-bin
 	!app-admin/quickswitch
 	>=app-misc/ca-certificates-20080809
-	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
+	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-)]
 	sys-apps/util-linux
 	sys-libs/zlib
 	cuda? (

--- a/sci-misc/boinc/boinc-7.4.52-r4.ebuild
+++ b/sci-misc/boinc/boinc-7.4.52-r4.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	!sci-misc/boinc-bin
 	!app-admin/quickswitch
 	>=app-misc/ca-certificates-20080809
-	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
+	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-)]
 	sys-apps/util-linux
 	sys-libs/zlib
 	cuda? (

--- a/sci-misc/boinc/boinc-7.6.33-r4.ebuild
+++ b/sci-misc/boinc/boinc-7.6.33-r4.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	!sci-misc/boinc-bin
 	!app-admin/quickswitch
 	>=app-misc/ca-certificates-20080809
-	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),-curl_ssl_polarssl(-)]
+	net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,-curl_ssl_nss(-),curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-)]
 	sys-apps/util-linux
 	sys-libs/zlib
 	cuda? (


### PR DESCRIPTION
Drop polarssl support (curl_ssl_polarssl) in preparation for net-libs/polarssl removal.