### PR TITLE
dev-qt/qtgui: Fix QClipboard behaviour on XCB

### DIFF
--- a/dev-qt/qtgui/files/qtgui-5.7.1-qclipboard.patch
+++ b/dev-qt/qtgui/files/qtgui-5.7.1-qclipboard.patch
@@ -1,0 +1,39 @@
+From 291eba6f8099a0fec8fbd9cf8a1fb67e5c9f4f8d Mon Sep 17 00:00:00 2001
+From: Palo Kisa <palo.kisa@gmail.com>
+Date: Mon, 7 Nov 2016 18:27:17 +0100
+Subject: QClipboard: Fix emitting changed() in XCB
+
+In XCB environment the QClipboard::changed() was not delivered if the
+QClipboard::clear() was issued by other Qt app/process.
+
+If the QClipboard::clear() is used, then the owner in
+xcb_xfixes_selection_notify_event_t is XCB_NONE, so we need make the
+decission to handle this event by the selection_timestamp and our
+m_timestamp[mode].
+
+Task-number: QTBUG-56972
+Change-Id: If4c486ac02223eac506465cac7ff1a07bd02a187
+Reviewed-by: Lars Knoll <lars.knoll@qt.io>
+---
+ src/plugins/platforms/xcb/qxcbclipboard.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/platforms/xcb/qxcbclipboard.cpp b/src/plugins/platforms/xcb/qxcbclipboard.cpp
+index d44ebae..40abef4 100644
+--- a/src/plugins/platforms/xcb/qxcbclipboard.cpp
++++ b/src/plugins/platforms/xcb/qxcbclipboard.cpp
+@@ -723,8 +723,10 @@ void QXcbClipboard::handleXFixesSelectionRequest(xcb_xfixes_selection_notify_eve
+     if (mode > QClipboard::Selection)
+         return;
+ 
+-    // here we care only about the xfixes events that come from non Qt processes
+-    if (event->owner != XCB_NONE && event->owner != owner()) {
++    // Note1: Here we care only about the xfixes events that come from other processes.
++    // Note2: If the QClipboard::clear() is issued, event->owner is XCB_NONE,
++    // so we check selection_timestamp to not handle our own QClipboard::clear().
++    if (event->owner != owner() && event->selection_timestamp > m_timestamp[mode]) {
+         if (!m_xClipboard[mode]) {
+             m_xClipboard[mode].reset(new QXcbClipboardMime(mode, this));
+         } else {
+-- 
+cgit v1.0-4-g1e03

--- a/dev-qt/qtgui/qtgui-5.7.1-r1.ebuild
+++ b/dev-qt/qtgui/qtgui-5.7.1-r1.ebuild
@@ -1,0 +1,176 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="The GUI module and platform plugins for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+# TODO: linuxfb
+
+IUSE="accessibility dbus egl eglfs evdev +gif gles2 gtk
+	ibus jpeg libinput +png tslib tuio +udev +xcb"
+REQUIRED_USE="
+	|| ( eglfs xcb )
+	accessibility? ( dbus xcb )
+	eglfs? ( egl )
+	ibus? ( dbus )
+	libinput? ( udev )
+	xcb? ( gles2? ( egl ) )
+"
+
+RDEPEND="
+	dev-libs/glib:2
+	~dev-qt/qtcore-${PV}
+	media-libs/fontconfig
+	>=media-libs/freetype-2.6.1:2
+	>=media-libs/harfbuzz-1.0.6:=
+	>=sys-libs/zlib-1.2.5
+	virtual/opengl
+	dbus? ( ~dev-qt/qtdbus-${PV} )
+	egl? ( media-libs/mesa[egl] )
+	eglfs? (
+		media-libs/mesa[gbm]
+		x11-libs/libdrm
+	)
+	evdev? ( sys-libs/mtdev )
+	gtk? (
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/pango
+		!!x11-libs/cairo[qt4]
+	)
+	gles2? ( media-libs/mesa[gles2] )
+	jpeg? ( virtual/jpeg:0 )
+	libinput? (
+		dev-libs/libinput:=
+		x11-libs/libxkbcommon
+	)
+	png? ( media-libs/libpng:0= )
+	tslib? ( x11-libs/tslib )
+	tuio? ( ~dev-qt/qtnetwork-${PV} )
+	udev? ( virtual/libudev:= )
+	xcb? (
+		x11-libs/libICE
+		x11-libs/libSM
+		x11-libs/libX11
+		>=x11-libs/libXi-1.7.4
+		x11-libs/libXrender
+		>=x11-libs/libxcb-1.10:=[xkb]
+		>=x11-libs/libxkbcommon-0.4.1[X]
+		x11-libs/xcb-util-image
+		x11-libs/xcb-util-keysyms
+		x11-libs/xcb-util-renderutil
+		x11-libs/xcb-util-wm
+	)
+"
+DEPEND="${RDEPEND}
+	evdev? ( sys-kernel/linux-headers )
+	udev? ( sys-kernel/linux-headers )
+"
+PDEPEND="
+	ibus? ( app-i18n/ibus )
+"
+
+PATCHES=( "${FILESDIR}/${P}-qclipboard.patch" ) # QTBUG-56972, KDE bug #348390
+
+QT5_TARGET_SUBDIRS=(
+	src/gui
+	src/openglextensions
+	src/platformheaders
+	src/platformsupport
+	src/plugins/generic
+	src/plugins/imageformats
+	src/plugins/platforms
+	src/plugins/platforminputcontexts
+	src/plugins/platformthemes
+)
+
+QT5_GENTOO_CONFIG=(
+	accessibility:accessibility-atspi-bridge
+	egl
+	eglfs
+	eglfs:eglfs_egldevice:
+	eglfs:eglfs_gbm:
+	evdev
+	evdev:mtdev:
+	:fontconfig
+	:system-freetype:FREETYPE
+	!:no-freetype:
+	!gif:no-gif:
+	gles2::OPENGL_ES
+	gles2:opengles2:OPENGL_ES_2
+	gtk:gtk3:
+	!:no-gui:
+	:system-harfbuzz:HARFBUZZ
+	!:no-harfbuzz:
+	jpeg:system-jpeg:IMAGEFORMAT_JPEG
+	!jpeg:no-jpeg:
+	libinput
+	libinput:xkbcommon-evdev:
+	:opengl
+	png:png:
+	png:system-png:IMAGEFORMAT_PNG
+	!png:no-png:
+	tslib
+	udev:libudev:
+	xcb:xcb:
+	xcb:xcb-glx:
+	xcb:xcb-plugin:
+	xcb:xcb-render:
+	xcb:xcb-sm:
+	xcb:xcb-xlib:
+	xcb:xinput2:
+	xcb::XKB
+	xcb:xrender
+)
+
+src_prepare() {
+	# egl_x11 is activated when both egl and xcb are enabled
+	use egl && QT5_GENTOO_CONFIG+=(xcb:egl_x11) || QT5_GENTOO_CONFIG+=(egl:egl_x11)
+
+	# avoid automagic dep on qtdbus
+	use dbus || sed -i -e 's/contains(QT_CONFIG, dbus)/false/' \
+		src/platformsupport/platformsupport.pro || die
+
+	qt_use_disable_mod ibus dbus \
+		src/plugins/platforminputcontexts/platforminputcontexts.pro
+
+	# avoid automagic dep on qtnetwork
+	use tuio || sed -i -e '/SUBDIRS += tuiotouch/d' \
+		src/plugins/generic/generic.pro || die
+
+	qt5-build_src_prepare
+}
+
+src_configure() {
+	local myconf=(
+		$(usex dbus -dbus-linked '')
+		$(qt_use egl)
+		$(qt_use eglfs)
+		$(usex eglfs '-gbm -kms' '')
+		$(qt_use evdev)
+		$(qt_use evdev mtdev)
+		-fontconfig
+		-system-freetype
+		$(usex gif '' -no-gif)
+		$(qt_use gtk)
+		-system-harfbuzz
+		$(qt_use jpeg libjpeg system)
+		$(qt_use libinput)
+		$(qt_use libinput xkbcommon-evdev)
+		-opengl $(usex gles2 es2 desktop)
+		$(qt_use png libpng system)
+		$(qt_use tslib)
+		$(qt_use udev libudev)
+		$(qt_use xcb xcb system)
+		$(qt_use xcb xkbcommon-x11 system)
+		$(usex xcb '-xcb-xlib -xinput2 -xkb -xrender' '')
+	)
+	qt5-build_src_configure
+}


### PR DESCRIPTION
This fix is also in 5.6.3 and >=5.8.0.

See also:
https://bugreports.qt.io/browse/QTBUG-56972
https://bugs.kde.org/show_bug.cgi?id=348390

I think this is an important fix before 5.7.1 stabilisation.