### PR TITLE
media-sound/supercollider: fix incomplete qt5 dependencies

### DIFF
--- a/media-sound/supercollider/files/3.8.0-no-opengl.patch
+++ b/media-sound/supercollider/files/3.8.0-no-opengl.patch
@@ -1,0 +1,45 @@
+diff --git a/QtCollider/CMakeLists.txt b/QtCollider/CMakeLists.txt
+index 64f275b..f88c4a7 100644
+--- a/QtCollider/CMakeLists.txt
++++ b/QtCollider/CMakeLists.txt
+@@ -8,17 +8,16 @@ find_package(Qt5Network)
+ find_package(Qt5WebKit)
+ find_package(Qt5WebKitWidgets)
+ find_package(Qt5PrintSupport)
+-find_package(Qt5OpenGL)
+ find_package(Qt5Sensors)
+ find_package(Qt5Quick)
+ find_package(Qt5Qml)
+ find_package(Qt5Sql)
+ find_package(Qt5Positioning)
+-mark_as_advanced(Qt5Concurrent_DIR Qt5Core_DIR Qt5Gui_DIR Qt5LinguistTools_DIR Qt5Location_DIR Qt5Network_DIR Qt5OpenGL_DIR Qt5Positioning_DIR Qt5PrintSupport_DIR Qt5Qml_DIR Qt5Quick_DIR Qt5Sensors_DIR Qt5Sql_DIR Qt5WebKitWidgets_DIR Qt5WebKit_DIR Qt5Widgets_DIR Qt5X11Extras_DIR)
++mark_as_advanced(Qt5Concurrent_DIR Qt5Core_DIR Qt5Gui_DIR Qt5LinguistTools_DIR Qt5Location_DIR Qt5Network_DIR Qt5Positioning_DIR Qt5PrintSupport_DIR Qt5Qml_DIR Qt5Quick_DIR Qt5Sensors_DIR Qt5Sql_DIR Qt5WebKitWidgets_DIR Qt5WebKit_DIR Qt5Widgets_DIR Qt5X11Extras_DIR)
+ 
+ set (QT_COLLIDER_LIBS
+   Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network Qt5::WebKit Qt5::WebKitWidgets Qt5::PrintSupport
+-  Qt5::OpenGL Qt5::Sensors Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning
++  Qt5::Sensors Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning
+   ${MATH_LIBRARY})
+ 
+ if (APPLE)
+diff --git a/editors/sc-ide/CMakeLists.txt b/editors/sc-ide/CMakeLists.txt
+index f2347de..860d254 100644
+--- a/editors/sc-ide/CMakeLists.txt
++++ b/editors/sc-ide/CMakeLists.txt
+@@ -7,7 +7,6 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ find_package(Qt5Core)
+ find_package(Qt5Concurrent)
+ find_package(Qt5LinguistTools)
+-find_package(Qt5OpenGL)
+ find_package(Qt5Positioning)
+ find_package(Qt5PrintSupport)
+ find_package(Qt5Qml)
+@@ -18,7 +17,7 @@ find_package(Qt5WebKitWidgets)
+ find_package(Qt5Widgets)
+ 
+ set(QT_IDE_LIBRARIES
+-    Qt5::Core Qt5::Concurrent Qt5::WebKitWidgets Qt5::OpenGL Qt5::PrintSupport Qt5::Sensors Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning)
++    Qt5::Core Qt5::Concurrent Qt5::WebKitWidgets Qt5::PrintSupport Qt5::Sensors Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning)
+ 
+ if(${CMAKE_COMPILER_IS_GNUCXX})
+     add_definitions(-Wreorder)

--- a/media-sound/supercollider/files/3.8.0-no-qtpositioning.patch
+++ b/media-sound/supercollider/files/3.8.0-no-qtpositioning.patch
@@ -1,0 +1,40 @@
+diff --git a/QtCollider/CMakeLists.txt b/QtCollider/CMakeLists.txt
+index 903d5a0..007b4f4 100644
+--- a/QtCollider/CMakeLists.txt
++++ b/QtCollider/CMakeLists.txt
+@@ -11,12 +11,11 @@ find_package(Qt5PrintSupport)
+ find_package(Qt5Quick)
+ find_package(Qt5Qml)
+ find_package(Qt5Sql)
+-find_package(Qt5Positioning)
+-mark_as_advanced(Qt5Concurrent_DIR Qt5Core_DIR Qt5Gui_DIR Qt5LinguistTools_DIR Qt5Location_DIR Qt5Network_DIR Qt5Positioning_DIR Qt5PrintSupport_DIR Qt5Qml_DIR Qt5Quick_DIR Qt5Sql_DIR Qt5WebKitWidgets_DIR Qt5WebKit_DIR Qt5Widgets_DIR Qt5X11Extras_DIR)
++mark_as_advanced(Qt5Concurrent_DIR Qt5Core_DIR Qt5Gui_DIR Qt5LinguistTools_DIR Qt5Location_DIR Qt5Network_DIR Qt5PrintSupport_DIR Qt5Qml_DIR Qt5Quick_DIR Qt5Sql_DIR Qt5WebKitWidgets_DIR Qt5WebKit_DIR Qt5Widgets_DIR Qt5X11Extras_DIR)
+ 
+ set (QT_COLLIDER_LIBS
+   Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network Qt5::WebKit Qt5::WebKitWidgets Qt5::PrintSupport
+-  Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning
++  Qt5::Quick Qt5::Qml Qt5::Sql
+   ${MATH_LIBRARY})
+ 
+ if (APPLE)
+diff --git a/editors/sc-ide/CMakeLists.txt b/editors/sc-ide/CMakeLists.txt
+index dbe2ad7..cdbb11e 100644
+--- a/editors/sc-ide/CMakeLists.txt
++++ b/editors/sc-ide/CMakeLists.txt
+@@ -7,7 +7,6 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ find_package(Qt5Core)
+ find_package(Qt5Concurrent)
+ find_package(Qt5LinguistTools)
+-find_package(Qt5Positioning)
+ find_package(Qt5PrintSupport)
+ find_package(Qt5Qml)
+ find_package(Qt5Quick)
+@@ -16,7 +15,7 @@ find_package(Qt5WebKitWidgets)
+ find_package(Qt5Widgets)
+ 
+ set(QT_IDE_LIBRARIES
+-    Qt5::Core Qt5::Concurrent Qt5::WebKitWidgets Qt5::PrintSupport Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning)
++    Qt5::Core Qt5::Concurrent Qt5::WebKitWidgets Qt5::PrintSupport Qt5::Quick Qt5::Qml Qt5::Sql)
+ 
+ if(${CMAKE_COMPILER_IS_GNUCXX})
+     add_definitions(-Wreorder)

--- a/media-sound/supercollider/files/3.8.0-no-qtsensors.patch
+++ b/media-sound/supercollider/files/3.8.0-no-qtsensors.patch
@@ -1,0 +1,55 @@
+diff --git a/QtCollider/CMakeLists.txt b/QtCollider/CMakeLists.txt
+index f88c4a7..903d5a0 100644
+--- a/QtCollider/CMakeLists.txt
++++ b/QtCollider/CMakeLists.txt
+@@ -8,16 +8,15 @@ find_package(Qt5Network)
+ find_package(Qt5WebKit)
+ find_package(Qt5WebKitWidgets)
+ find_package(Qt5PrintSupport)
+-find_package(Qt5Sensors)
+ find_package(Qt5Quick)
+ find_package(Qt5Qml)
+ find_package(Qt5Sql)
+ find_package(Qt5Positioning)
+-mark_as_advanced(Qt5Concurrent_DIR Qt5Core_DIR Qt5Gui_DIR Qt5LinguistTools_DIR Qt5Location_DIR Qt5Network_DIR Qt5Positioning_DIR Qt5PrintSupport_DIR Qt5Qml_DIR Qt5Quick_DIR Qt5Sensors_DIR Qt5Sql_DIR Qt5WebKitWidgets_DIR Qt5WebKit_DIR Qt5Widgets_DIR Qt5X11Extras_DIR)
++mark_as_advanced(Qt5Concurrent_DIR Qt5Core_DIR Qt5Gui_DIR Qt5LinguistTools_DIR Qt5Location_DIR Qt5Network_DIR Qt5Positioning_DIR Qt5PrintSupport_DIR Qt5Qml_DIR Qt5Quick_DIR Qt5Sql_DIR Qt5WebKitWidgets_DIR Qt5WebKit_DIR Qt5Widgets_DIR Qt5X11Extras_DIR)
+ 
+ set (QT_COLLIDER_LIBS
+   Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network Qt5::WebKit Qt5::WebKitWidgets Qt5::PrintSupport
+-  Qt5::Sensors Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning
++  Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning
+   ${MATH_LIBRARY})
+ 
+ if (APPLE)
+diff --git a/editors/sc-ide/CMakeLists.txt b/editors/sc-ide/CMakeLists.txt
+index 860d254..dbe2ad7 100644
+--- a/editors/sc-ide/CMakeLists.txt
++++ b/editors/sc-ide/CMakeLists.txt
+@@ -11,13 +11,12 @@ find_package(Qt5Positioning)
+ find_package(Qt5PrintSupport)
+ find_package(Qt5Qml)
+ find_package(Qt5Quick)
+-find_package(Qt5Sensors)
+ find_package(Qt5Sql)
+ find_package(Qt5WebKitWidgets)
+ find_package(Qt5Widgets)
+ 
+ set(QT_IDE_LIBRARIES
+-    Qt5::Core Qt5::Concurrent Qt5::WebKitWidgets Qt5::PrintSupport Qt5::Sensors Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning)
++    Qt5::Core Qt5::Concurrent Qt5::WebKitWidgets Qt5::PrintSupport Qt5::Quick Qt5::Qml Qt5::Sql Qt5::Positioning)
+ 
+ if(${CMAKE_COMPILER_IS_GNUCXX})
+     add_definitions(-Wreorder)
+diff --git a/lang/CMakeLists.txt b/lang/CMakeLists.txt
+index fe52223..427c587 100644
+--- a/lang/CMakeLists.txt
++++ b/lang/CMakeLists.txt
+@@ -389,7 +389,7 @@ elseif(WIN32)
+             SET(QT_PLUGINS_DIR "${QT_BIN_PATH}/../plugins" CACHE PATH "Location of qt plugins for windows")
+         endif()
+ 
+-        foreach(plugin ${Qt5Network_PLUGINS} ${Qt5Gui_PLUGINS} ${Qt5Sensors_PLUGINS} ${Qt5Sql_PLUGINS} ${Qt5PrintSupport_PLUGINS})
++        foreach(plugin ${Qt5Network_PLUGINS} ${Qt5Gui_PLUGINS} ${Qt5Sql_PLUGINS} ${Qt5PrintSupport_PLUGINS})
+             get_target_property(_loc ${plugin} LOCATION)
+             get_filename_component(_parent_dir ${_loc} DIRECTORY)
+             get_filename_component(_name_we ${_loc} NAME_WE)

--- a/media-sound/supercollider/supercollider-3.8.0.ebuild
+++ b/media-sound/supercollider/supercollider-3.8.0.ebuild
@@ -16,38 +16,50 @@ IUSE="avahi cpu_flags_x86_sse cpu_flags_x86_sse2 debug emacs +fftw gedit +gpl3 j
 REQUIRED_USE="^^ ( jack portaudio )"
 RESTRICT="mirror"
 
-# Both alsa and readline will be automatically checked in cmake but
-# there are no options for these. Thus the functionality cannot be
-# controlled through USE flags. Therefore hard-enabled.
 RDEPEND="
 	media-libs/alsa-lib
 	sys-libs/readline:0=
+	x11-libs/libX11
 	x11-libs/libXt
 	avahi? ( net-dns/avahi )
 	fftw? ( sci-libs/fftw:3.0= )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	portaudio? ( media-libs/portaudio )
 	qt5? (
 		dev-qt/qtcore:5
 		dev-qt/qtgui:5
-		dev-qt/qtpositioning:5
-		dev-qt/qtsensors:5
+		dev-qt/qtnetwork:5
+		dev-qt/qtprintsupport:5
 		dev-qt/qtwebkit:5
+		dev-qt/qtwidgets:5
 	)
 	sndfile? ( media-libs/libsndfile )
-	wiimote? ( app-misc/cwiid )"
+	wiimote? ( app-misc/cwiid )
+"
 DEPEND="${RDEPEND}
 	dev-libs/icu
 	virtual/pkgconfig
 	emacs? ( virtual/emacs )
 	gedit? ( app-editors/gedit )
-	vim? ( app-editors/vim )"
+	vim? ( app-editors/vim )
+	qt5? (
+		dev-qt/linguist-tools:5
+		dev-qt/qtdeclarative:5
+		dev-qt/qtconcurrent:5
+	)
+"
 
 S="${WORKDIR}/SuperCollider-Source"
 
+PATCHES=(
+	"${FILESDIR}"/${PV}-no-opengl.patch
+	"${FILESDIR}"/${PV}-no-qtsensors.patch
+	"${FILESDIR}"/${PV}-no-qtpositioning.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
-		AUDIOAPI=$(usex jack jack portaudio)
+		-DAUDIOAPI=$(usex jack jack portaudio)
 		-DINSTALL_HELP=ON
 		-DNATIVE=ON
 		-DSYSTEM_BOOST=OFF
@@ -58,6 +70,7 @@ src_configure() {
 		-DNO_LIBSNDFILE=$(usex !sndfile)
 		-DSC_QT=$(usex qt5)
 		-DSCLANG_SERVER=$(usex server)
+		-DSUPERNOVA=$(usex server)
 		-DLIBSCSYNTH=$(usex !static-libs)
 		-DSSE=$(usex cpu_flags_x86_sse)
 		-DSSE2=$(usex cpu_flags_x86_sse2)

--- a/media-sound/supercollider/supercollider-3.8.0.ebuild
+++ b/media-sound/supercollider/supercollider-3.8.0.ebuild
@@ -35,6 +35,7 @@ RDEPEND="
 	)
 	sndfile? ( media-libs/libsndfile )
 	wiimote? ( app-misc/cwiid )
+	server? ( !app-admin/supernova )
 "
 DEPEND="${RDEPEND}
 	dev-libs/icu


### PR DESCRIPTION
This is a fix for 
https://bugs.gentoo.org/show_bug.cgi?id=621020
It turns out qt5 has even more dependencies than mentioned in the ticket.