### PR TITLE
dev-tex/latex-beamer: add missing dependencies

### DIFF
--- a/dev-tex/latex-beamer/latex-beamer-3.41.ebuild
+++ b/dev-tex/latex-beamer/latex-beamer-3.41.ebuild
@@ -14,7 +14,8 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc examples"
 
-DEPEND="dev-texlive/texlive-latex"
+DEPEND="dev-texlive/texlive-latex
+	doc? ( dev-tex/latex-beamer )"
 RDEPEND=">=dev-tex/pgf-1.10
 	dev-tex/xcolor
 	!dev-tex/translator"

--- a/dev-tex/latex-beamer/latex-beamer-3.41.ebuild
+++ b/dev-tex/latex-beamer/latex-beamer-3.41.ebuild
@@ -17,6 +17,7 @@ IUSE="doc examples"
 DEPEND="dev-texlive/texlive-latex
 	doc? ( dev-tex/latex-beamer )"
 RDEPEND=">=dev-tex/pgf-1.10
+	dev-texlive/texlive-latexextra
 	dev-tex/xcolor
 	!dev-tex/translator"
 


### PR DESCRIPTION
The doc flag now requires beamer.cls be installed, and beamer.cls now requires etoolbox (dev-texlive/texlive-latexextra)

Perhaps the dependency should be `>=dev-tex/latex-beamer-3.41`?