### PR TITLE
sci-mathematics/pari: Fix for '.' in @INC on perl 5.26 re bug #615016

### DIFF
--- a/sci-mathematics/pari/files/pari-2.3.5-no-dot-inc.patch
+++ b/sci-mathematics/pari/files/pari-2.3.5-no-dot-inc.patch
@@ -1,0 +1,61 @@
+From 4f1e00df5ea1e51042146f6277bb1af02f249cc3 Mon Sep 17 00:00:00 2001
+From: Kent Fredric <kentfredric@gmail.com>
+Date: Sun, 11 Jun 2017 10:31:03 +1200
+Subject: [PATCH] Fix for 5.26 removal of '.' in @INC
+
+Previous scripts assumed CWD was in @INC and that "PARI::822" was in
+wherever CWD was.
+
+This fixes both of those, and the latter, because its not obvious
+from the build system where one should assume CWD to be.
+
+Instead, the absolute path of the directory of these scripts is
+inserted into @INC
+---
+ src/desc/gen_member | 4 ++++
+ src/desc/gen_proto  | 4 ++++
+ src/desc/merge_822  | 4 ++++
+ 3 files changed, 12 insertions(+)
+
+diff --git a/src/desc/gen_member b/src/desc/gen_member
+index 2f3cf52..66dea2b 100755
+--- a/src/desc/gen_member
++++ b/src/desc/gen_member
+@@ -1,4 +1,8 @@
+ #!/usr/bin/perl -w
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ $class='member_functions';
+diff --git a/src/desc/gen_proto b/src/desc/gen_proto
+index 1b507fa..2fb4d3f 100755
+--- a/src/desc/gen_proto
++++ b/src/desc/gen_proto
+@@ -1,4 +1,8 @@
+ #!/usr/bin/perl -w
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ $class=$ARGV[0];
+diff --git a/src/desc/merge_822 b/src/desc/merge_822
+index a02d612..9ca8252 100755
+--- a/src/desc/merge_822
++++ b/src/desc/merge_822
+@@ -1,4 +1,8 @@
+ #!/usr/bin/perl -w
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ PARI::822::read(\%funcs,$_,1)
+-- 
+2.13.1
+

--- a/sci-mathematics/pari/files/pari-2.5.0-no-dot-inc.patch
+++ b/sci-mathematics/pari/files/pari-2.5.0-no-dot-inc.patch
@@ -1,0 +1,61 @@
+From 03df0cdd7228a412d2adfe9ee9c746b3ec69dd6b Mon Sep 17 00:00:00 2001
+From: Kent Fredric <kentfredric@gmail.com>
+Date: Sun, 11 Jun 2017 10:31:03 +1200
+Subject: [PATCH] Fix for 5.26 removal of '.' in @INC
+
+Previous scripts assumed CWD was in @INC and that "PARI::822" was in
+wherever CWD was.
+
+This fixes both of those, and the latter, because its not obvious
+from the build system where one should assume CWD to be.
+
+Instead, the absolute path of the directory of these scripts is
+inserted into @INC
+---
+ src/desc/doc_make  | 4 ++++
+ src/desc/gen_proto | 4 ++++
+ src/desc/merge_822 | 4 ++++
+ 3 files changed, 12 insertions(+)
+
+diff --git a/src/desc/doc_make b/src/desc/doc_make
+index 02dc90d..55296ed 100755
+--- a/src/desc/doc_make
++++ b/src/desc/doc_make
+@@ -1,4 +1,8 @@
+ #!/usr/bin/perl
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ PARI::822::read(\%funcs, "pari.desc");
+diff --git a/src/desc/gen_proto b/src/desc/gen_proto
+index 38c2daf..ffb4276 100755
+--- a/src/desc/gen_proto
++++ b/src/desc/gen_proto
+@@ -1,4 +1,8 @@
+ #!/usr/bin/perl -w
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ $class=$ARGV[0];
+diff --git a/src/desc/merge_822 b/src/desc/merge_822
+index 4c9217b..32b3cc9 100755
+--- a/src/desc/merge_822
++++ b/src/desc/merge_822
+@@ -1,4 +1,8 @@
+ #!/usr/bin/perl -w
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ open(IN, $ARGV[0]) || die "cannot find $ARGV[0]";
+-- 
+2.13.1
+

--- a/sci-mathematics/pari/files/pari-2.7.0-no-dot-inc.patch
+++ b/sci-mathematics/pari/files/pari-2.7.0-no-dot-inc.patch
@@ -1,0 +1,64 @@
+From 2864fe5b852e443d98af92d8929e359525ccb1a2 Mon Sep 17 00:00:00 2001
+From: Kent Fredric <kentfredric@gmail.com>
+Date: Sun, 11 Jun 2017 10:31:03 +1200
+Subject: [PATCH] Fix for 5.26 removal of '.' in @INC
+
+Previous scripts assumed CWD was in @INC and that "PARI::822" was in
+wherever CWD was.
+
+This fixes both of those, and the latter, because its not obvious
+from the build system where one should assume CWD to be.
+
+Instead, the absolute path of the directory of these scripts is
+inserted into @INC
+---
+ src/desc/doc_make  | 5 +++++
+ src/desc/gen_proto | 4 ++++
+ src/desc/merge_822 | 4 ++++
+ 3 files changed, 13 insertions(+)
+
+diff --git a/src/desc/doc_make b/src/desc/doc_make
+index 91b894e..ffbbb78 100755
+--- a/src/desc/doc_make
++++ b/src/desc/doc_make
+@@ -1,6 +1,11 @@
+ #!/usr/bin/perl
+ use warnings FATAL => 'all';
+ use strict;
++
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ my (%funcs, %Fun_by_sec);
+diff --git a/src/desc/gen_proto b/src/desc/gen_proto
+index ee55449..5ca0305 100755
+--- a/src/desc/gen_proto
++++ b/src/desc/gen_proto
+@@ -1,4 +1,8 @@
+ #!/usr/bin/perl -w
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ $class=$ARGV[0];
+diff --git a/src/desc/merge_822 b/src/desc/merge_822
+index 4c9217b..32b3cc9 100755
+--- a/src/desc/merge_822
++++ b/src/desc/merge_822
+@@ -1,4 +1,8 @@
+ #!/usr/bin/perl -w
++use File::Spec;
++use File::Basename qw( dirname );
++use lib dirname(File::Spec->rel2abs(__FILE__));
++
+ use PARI::822;
+ 
+ open(IN, $ARGV[0]) || die "cannot find $ARGV[0]";
+-- 
+2.13.1
+

--- a/sci-mathematics/pari/pari-2.3.5.ebuild
+++ b/sci-mathematics/pari/pari-2.3.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=3
@@ -43,6 +43,7 @@ src_prepare() {
 	epatch "${FILESDIR}/"${PN}-2.3.2-strip.patch
 	epatch "${FILESDIR}/"${PN}-2.3.2-ppc-powerpc-arch-fix.patch
 	epatch "${FILESDIR}/"${PN}-2.3.5-doc-make.patch
+	epatch "${FILESDIR}/"${PN}-2.3.5-no-dot-inc.patch
 
 	# disable default building of docs during install
 	sed -i \

--- a/sci-mathematics/pari/pari-2.5.0-r3.ebuild
+++ b/sci-mathematics/pari/pari-2.5.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -40,6 +40,8 @@ src_prepare() {
 	epatch "${FILESDIR}/${PN}"-2.5.0-mp.c.patch
 	# OS X: add -install_name to the linker option
 	epatch "${FILESDIR}/${PN}"-2.5.0-macos.patch
+	# Fix Perl 5.26
+	epatch "${FILESDIR}/"${PN}-2.5.0-no-dot-inc.patch
 
 	# disable default building of docs during install
 	sed -i \

--- a/sci-mathematics/pari/pari-2.5.1-r1.ebuild
+++ b/sci-mathematics/pari/pari-2.5.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -41,6 +41,8 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-2.5.0-mp.c.patch
 	# OS X: add -install_name to the linker option
 	epatch "${FILESDIR}"/${PN}-2.5.0-macos.patch
+	# Fix Perl 5.26
+	epatch "${FILESDIR}/"${PN}-2.5.0-no-dot-inc.patch
 	# from debian, fies bug #423617
 	epatch "${FILESDIR}"/${PN}-2.5.1-gcc47.patch
 	# fix automagic

--- a/sci-mathematics/pari/pari-2.5.1.ebuild
+++ b/sci-mathematics/pari/pari-2.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -40,6 +40,8 @@ src_prepare() {
 	epatch "${FILESDIR}/${PN}"-2.5.0-mp.c.patch
 	# OS X: add -install_name to the linker option
 	epatch "${FILESDIR}/${PN}"-2.5.0-macos.patch
+	# Fix Perl 5.26
+	epatch "${FILESDIR}/"${PN}-2.5.0-no-dot-inc.patch
 	# from debian, fies bug #423617
 	epatch "${FILESDIR}/${PN}"-2.5.1-gcc47.patch
 

--- a/sci-mathematics/pari/pari-2.5.2.ebuild
+++ b/sci-mathematics/pari/pari-2.5.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -41,6 +41,8 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-2.5.0-mp.c.patch
 	# OS X: add -install_name to the linker option
 	epatch "${FILESDIR}"/${PN}-2.5.0-macos.patch
+	# Fix Perl 5.26
+	epatch "${FILESDIR}/"${PN}-2.5.0-no-dot-inc.patch
 	# fix automagic
 	epatch "${FILESDIR}"/${PN}-2.5.1-no-automagic.patch
 

--- a/sci-mathematics/pari/pari-2.5.3.ebuild
+++ b/sci-mathematics/pari/pari-2.5.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -41,6 +41,8 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-2.5.0-mp.c.patch
 	# OS X: add -install_name to the linker option
 	epatch "${FILESDIR}"/${PN}-2.5.0-macos.patch
+	# Fix Perl 5.26
+	epatch "${FILESDIR}/"${PN}-2.5.0-no-dot-inc.patch
 	# fix automagic
 	epatch "${FILESDIR}"/${PN}-2.5.1-no-automagic.patch
 

--- a/sci-mathematics/pari/pari-2.5.4.ebuild
+++ b/sci-mathematics/pari/pari-2.5.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -42,6 +42,8 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-2.5.0-mp.c.patch
 	# OS X: add -install_name to the linker option
 	epatch "${FILESDIR}"/${PN}-2.5.0-macos.patch
+	# Fix Perl 5.26
+	epatch "${FILESDIR}/"${PN}-2.5.0-no-dot-inc.patch
 	# fix automagic
 	epatch "${FILESDIR}"/${PN}-2.5.1-no-automagic.patch
 	# sage-on-gentoo trac 13902: Slowdown for PARI integer determinant

--- a/sci-mathematics/pari/pari-2.7.0.ebuild
+++ b/sci-mathematics/pari/pari-2.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -42,6 +42,8 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-2.7.0-no-automagic.patch
 	# sage-on-gentoo trac 15654: PARI discriminant speed depends on stack size
 	epatch "${FILESDIR}"/${PN}-2.7.0-slow-discriminant.patch
+	# Fix Perl 5.26
+	epatch "${FILESDIR}/"${PN}-2.7.0-no-dot-inc.patch
 
 	# disable default building of docs during install
 	sed -i \

--- a/sci-mathematics/pari/pari-2.7.1.ebuild
+++ b/sci-mathematics/pari/pari-2.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -42,6 +42,8 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-2.7.0-no-automagic.patch
 	# sage-on-gentoo trac 15654: PARI discriminant speed depends on stack size
 	epatch "${FILESDIR}"/${PN}-2.7.0-slow-discriminant.patch
+	# Fix Perl 5.26
+	epatch "${FILESDIR}/"${PN}-2.7.0-no-dot-inc.patch
 	# fix building docs with perl-5.22
 	epatch "${FILESDIR}"/${PN}-2.7.1-perl-5.22-doc.patch
 


### PR DESCRIPTION
Perl 5.26 removes implied cwd from library loading paths, and
subsequently Pari's compile fails due to reliance on this implication.

These patches rectify that by constructing a library path the same
as the scripts directory, and inserting that into `@INC`

Of course, we still need the oldest pari because dev-perl/Math-Pari
needs the old version.

And of course, the files in question have minor changes over the
handful of versions, necessitating 3 *mostly* identical but slightly
different patches for the relevant versions.

I haven't filed this issue upstream, as their bug reporting stuff
looked dizzyingly confusing.

Bug: https://bugs.gentoo.org/615016
Package-Manager: Portage-2.3.6, Repoman-2.3.2