### PR TITLE
net-fs/nfs-utils: Remove obsolete sed transformations of systemd units

### DIFF
--- a/net-fs/nfs-utils/nfs-utils-2.1.2_rc3.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-2.1.2_rc3.ebuild
@@ -155,9 +155,7 @@ src_install() {
 	if ! use nfsv41 ; then
 		rm "${ED}$(systemd_get_unitdir)"/nfs-blkmap.* || die
 	fi
-	sed -i -r \
-		-e "/^EnvironmentFile=/s:=.*:=${EPREFIX}/etc/conf.d/nfs:" \
-		-e '/^(After|Wants)=nfs-config.service$/d' \
+	sed -i \
 		-e 's:/usr/sbin/rpc.statd:/sbin/rpc.statd:' \
 		"${ED}$(systemd_get_unitdir)"/* || die
 


### PR DESCRIPTION
nfs-config.service and use of EnvironmentFile removed by:
http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=commit;h=2662e1ba98707014b6167e1e5bd3162d6d8f52af

Package-Manager: Portage-2.3.5, Repoman-2.3.2