### PR TITLE
dev-python/parsedatetime: add missing RDEPEND

### DIFF
--- a/dev-python/parsedatetime/parsedatetime-2.1-r1.ebuild
+++ b/dev-python/parsedatetime/parsedatetime-2.1-r1.ebuild
@@ -18,6 +18,8 @@ IUSE="test"
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( dev-python/nose[${PYTHON_USEDEP}] )"
 
+RDEPEND="dev-python/future[${PYTHON_USEDEP}]"
+
 python_prepare() {
 	rm setup.cfg || die
 }

--- a/dev-python/parsedatetime/parsedatetime-2.4-r1.ebuild
+++ b/dev-python/parsedatetime/parsedatetime-2.4-r1.ebuild
@@ -18,6 +18,8 @@ IUSE="test"
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( dev-python/nose[${PYTHON_USEDEP}] )"
 
+RDEPEND="dev-python/future[${PYTHON_USEDEP}]"
+
 python_prepare() {
 	rm setup.cfg || die
 }


### PR DESCRIPTION
Fixes #621182.

Package-Manager: Portage-2.3.6, Repoman-2.3.2