### PR TITLE
app-text/po4a: Fix broken library path tweaks re bug #614122

### DIFF
--- a/app-text/po4a/files/po4a-0.45-614122-no-dot-inc.patch
+++ b/app-text/po4a/files/po4a-0.45-614122-no-dot-inc.patch
@@ -1,0 +1,26 @@
+From: Kent Fredric <kentfredric@gmail.com>
+Date: Tue, 13 Jun 2017 21:10:34 +1200
+Subject: [PATCH] Fix broken use of lib '.'
+
+   "'.'" is not "."
+
+Bug: https://bugs.gentoo.org/614122
+---
+ Build.PL | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Build.PL b/Build.PL
+index 43c6f80..9ee443b 100644
+--- a/Build.PL
++++ b/Build.PL
+@@ -1,6 +1,6 @@
+ #!/usr/bin/perl
+ 
+-use lib q('.');
++use lib q(.);
+ use Po4aBuilder;
+ 
+ my $build = Po4aBuilder->new
+-- 
+2.13.1
+

--- a/app-text/po4a/po4a-0.45-r3.ebuild
+++ b/app-text/po4a/po4a-0.45-r3.ebuild
@@ -55,6 +55,9 @@ src_prepare() {
 	einfo "Your LINGUAS lists the following languages: $LINGUAS"
 	einfo "Removing locale files not listed in it ..."
 
+	# Fix bad escaping of '.' in @INC modification
+	epatch "${FILESDIR}/${P}-614122-no-dot-inc.patch"
+
 	# perl_rm_files also updates the Manifest file
 	# and therefore silences Perl as to .po files we're about to clean
 	perl_rm_files "${locales_to_remove[@]}"

--- a/app-text/po4a/po4a-0.47-r1.ebuild
+++ b/app-text/po4a/po4a-0.47-r1.ebuild
@@ -35,6 +35,10 @@ DEPEND="${RDEPEND}
 # Running tests in parallel fails
 DIST_TEST="do"
 
+PATCHES=(
+	# Fix bad escaping of '.' in @INC modification
+	"${FILESDIR}/${PN}-0.45-614122-no-dot-inc.patch"
+)
 src_prepare() {
 	# Check against locale files in ${S}/pod/bin for mismatches
 	# with languages listed in PLOCALES


### PR DESCRIPTION
Mostly just looking for an Ack from some official maintainer, the change is otherwise kinda boring, but important.

The original code already had a "use lib" incantation that clearly
intended to imply ".", but ... did so by quoting it twice:

  q('.')   == "'.''"

That's too much '

Bug: https://bugs.gentoo.org/614122
Package-Manager: Portage-2.3.6, Repoman-2.3.2