### PR TITLE
x11-base/xorg-server: added xcsecurity use flag

### DIFF
--- a/x11-base/xorg-server/metadata.xml
+++ b/x11-base/xorg-server/metadata.xml
@@ -11,6 +11,7 @@
 	<flag name="kdrive">Build the kdrive X servers</flag>
 	<flag name="tslib">Build with tslib support for touchscreen devices</flag>
 	<flag name="unwind">Enable libunwind usage for backtraces</flag>
+	<flag name="xcsecurity">Build Security extension</flag>
 	<flag name="xnest">Build the Xnest server</flag>
 	<flag name="xephyr">Build the Xephyr server</flag>
 	<flag name="xorg">Build the Xorg X server (HIGHLY RECOMMENDED)</flag>

--- a/x11-base/xorg-server/xorg-server-1.19.3.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.19.3.ebuild
@@ -12,7 +12,7 @@ SLOT="0/${PV}"
 KEYWORDS="alpha amd64 ~arm ~arm64 ~hppa ia64 ~mips ~ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux"
 
 IUSE_SERVERS="dmx kdrive wayland xephyr xnest xorg xvfb"
-IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux +suid systemd tslib +udev unwind"
+IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux +suid systemd tslib +udev unwind xcsecurity"
 
 CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	!libressl? ( dev-libs/openssl:0= )
@@ -184,6 +184,7 @@ src_configure() {
 		$(use_enable !minimal dri)
 		$(use_enable !minimal dri2)
 		$(use_enable !minimal glx)
+		$(use_enable xcsecurity)
 		$(use_enable xephyr)
 		$(use_enable xnest)
 		$(use_enable xorg)

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -12,7 +12,7 @@ SLOT="0/${PV}"
 KEYWORDS=""
 
 IUSE_SERVERS="dmx kdrive wayland xephyr xnest xorg xvfb"
-IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux +suid systemd +udev unwind"
+IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux +suid systemd +udev unwind xcsecurity"
 
 CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	!libressl? ( dev-libs/openssl:0= )
@@ -178,6 +178,7 @@ src_configure() {
 		$(use_enable !minimal dri)
 		$(use_enable !minimal dri2)
 		$(use_enable !minimal glx)
+		$(use_enable xcsecurity)
 		$(use_enable xephyr)
 		$(use_enable xnest)
 		$(use_enable xorg)


### PR DESCRIPTION
to be able to use XSecurity extension, say, with firejail --x11=xorg