### PR TITLE
net-dns/dnsdist: add ~arm ~arm64 ~x86 keywords

### DIFF
--- a/net-dns/dnsdist/dnsdist-1.1.0-r1.ebuild
+++ b/net-dns/dnsdist/dnsdist-1.1.0-r1.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} == 9999 ]]; then
 	S="${WORKDIR}/${P}/pdns/dnsdistdist"
 else
 	SRC_URI="https://downloads.powerdns.com/releases/${P}.tar.bz2"
-	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+	KEYWORDS="~amd64 ~x86"
 fi
 
 LICENSE="GPL-2"

--- a/net-dns/dnsdist/dnsdist-1.1.0-r1.ebuild
+++ b/net-dns/dnsdist/dnsdist-1.1.0-r1.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} == 9999 ]]; then
 	S="${WORKDIR}/${P}/pdns/dnsdistdist"
 else
 	SRC_URI="https://downloads.powerdns.com/releases/${P}.tar.bz2"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 LICENSE="GPL-2"

--- a/net-dns/dnsdist/dnsdist-9999.ebuild
+++ b/net-dns/dnsdist/dnsdist-9999.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} == 9999 ]]; then
 	S="${WORKDIR}/${P}/pdns/dnsdistdist"
 else
 	SRC_URI="https://downloads.powerdns.com/releases/${P}.tar.bz2"
-	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+	KEYWORDS="~amd64 ~x86"
 fi
 
 LICENSE="GPL-2"

--- a/net-dns/dnsdist/dnsdist-9999.ebuild
+++ b/net-dns/dnsdist/dnsdist-9999.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} == 9999 ]]; then
 	S="${WORKDIR}/${P}/pdns/dnsdistdist"
 else
 	SRC_URI="https://downloads.powerdns.com/releases/${P}.tar.bz2"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Sorry to bother you so soon after the last changes of yesterday.

The architectures added with this change do work without problems.

Thanks a lot.