### PR TITLE
x11-drivers/xf86-video-virtualbox: fix #579910

### DIFF
--- a/x11-drivers/xf86-video-virtualbox/files/xf86-video-virtualbox-5.1.22-sysmacros.patch
+++ b/x11-drivers/xf86-video-virtualbox/files/xf86-video-virtualbox-5.1.22-sysmacros.patch
@@ -1,0 +1,15 @@
+Fix bug #579910. Add sys/sysmacros.h header.
+
+https://bugs.gentoo.org/579910
+
+index 20ae130..2f3fac0 100644
+--- a/src/VBox/Runtime/r3/linux/sysfs.cpp
++++ b/src/VBox/Runtime/r3/linux/sysfs.cpp
+@@ -46,6 +46,7 @@
+ #include <sys/sysctl.h>
+ #include <sys/stat.h>
+ #include <sys/fcntl.h>
++#include <sys/sysmacros.h>
+ #include <errno.h>
+ 
+ 

--- a/x11-drivers/xf86-video-virtualbox/xf86-video-virtualbox-5.1.22.ebuild
+++ b/x11-drivers/xf86-video-virtualbox/xf86-video-virtualbox-5.1.22.ebuild
@@ -58,6 +58,9 @@ PATCHES=(
 
 	# xorg-1.19 patch from opensuse (bug #602784)
 	"${FILESDIR}/${PN}-5.1.10-xorg119.patch"
+
+	# fix bug #579946
+	"${FILESDIR}/${PN}-5.1.22-sysmacros.patch"
 )
 
 QA_TEXTRELS_x86="usr/lib/VBoxOGL.so"


### PR DESCRIPTION
It's patch fixing #579910 for version 5.1.22 of x11-drivers/xf86-video-virtualbox.

Assign-to: @Polynomial-C 