### PR TITLE
app-emulation/playonlinux: Fix Makefile (#621812)

### DIFF
--- a/app-emulation/playonlinux/files/playonlinux-4.2.11-fix-makefile.patch
+++ b/app-emulation/playonlinux/files/playonlinux-4.2.11-fix-makefile.patch
@@ -1,0 +1,21 @@
+diff -Naur playonlinux-orig/Makefile playonlinux/Makefile
+--- playonlinux-orig/Makefile	2017-06-14 19:31:55.746343655 -0700
++++ playonlinux/Makefile	2017-06-14 19:35:22.616281108 -0700
+@@ -28,8 +28,6 @@
+ PREFIX ?= /usr
+ DESTDIR ?= # root dir
+ 
+-CFLAGS += -lGL -lX11
+-
+ sharedir := $(DESTDIR)$(PREFIX)/share
+ bindir := $(DESTDIR)$(PREFIX)/bin
+ execdir := $(DESTDIR)$(PREFIX)/libexec
+@@ -46,7 +44,7 @@
+ 	$(RM) ./ChangeLog
+ 
+ build:
+-	$(CC) ./src/check_direct_rendering.c -o ./bin/playonlinux-check_dd
++	$(CC) ./src/check_direct_rendering.c -o ./bin/playonlinux-check_dd -lGL -lX11
+ 	$(PYTHON) ./python/*.py
+ 	$(PYTHON) ./python/lib/*.py
+ 	echo -e '#!/bin/bash\nGDK_BACKEND=x11 ${sharedir}/playonlinux/playonlinux "$$@"\nexit 0' > ./bin/playonlinux

--- a/app-emulation/playonlinux/playonlinux-4.2.11.ebuild
+++ b/app-emulation/playonlinux/playonlinux-4.2.11.ebuild
@@ -48,6 +48,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-4.2.4-pol-bash.patch"
 	"${FILESDIR}/${PN}-4.2.4-binary-plugin.patch"
 	"${FILESDIR}/${PN}-4.2.6-stop-update-warning.patch"
+	"${FILESDIR}/${PN}-4.2.11-fix-makefile.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
The upstream Makefile does not work if `LDFLAGS` includes `-Wl,--as-needed`, as is
the Gentoo default (bug #621812). Added a patch to fix this issue.

Note that I've also submitted a PR to the upstream Github so that this issue can be fixed in the next release, but would like to see the Gentoo ebuild work in the meantime.