### PR TITLE
www-client/chromium: make use of `llvm-config --prefix` as clang_base_path

### DIFF
--- a/www-client/chromium/chromium-59.0.3071.104.ebuild
+++ b/www-client/chromium/chromium-59.0.3071.104.ebuild
@@ -393,7 +393,8 @@ src_configure() {
 	myconf_gn+=" fieldtrial_testing_like_official_build=true"
 
 	if tc-is-clang; then
-		myconf_gn+=" is_clang=true clang_base_path=\"/usr\" clang_use_chrome_plugins=false"
+		myconf_gn+=" is_clang=true clang_use_chrome_plugins=false"
+		myconf_gn+=" clang_base_path=\"$(llvm-config --prefix)\""
 	else
 		myconf_gn+=" is_clang=false"
 	fi

--- a/www-client/chromium/chromium-59.0.3071.86.ebuild
+++ b/www-client/chromium/chromium-59.0.3071.86.ebuild
@@ -393,7 +393,8 @@ src_configure() {
 	myconf_gn+=" fieldtrial_testing_like_official_build=true"
 
 	if tc-is-clang; then
-		myconf_gn+=" is_clang=true clang_base_path=\"/usr\" clang_use_chrome_plugins=false"
+		myconf_gn+=" is_clang=true clang_use_chrome_plugins=false"
+		myconf_gn+=" clang_base_path=\"$(llvm-config --prefix)\""
 	else
 		myconf_gn+=" is_clang=false"
 	fi

--- a/www-client/chromium/chromium-60.0.3112.24.ebuild
+++ b/www-client/chromium/chromium-60.0.3112.24.ebuild
@@ -396,7 +396,7 @@ src_configure() {
 
 	if tc-is-clang; then
 		myconf_gn+=" is_clang=true clang_use_chrome_plugins=false"
-		myconf_gn+=" clang_base_path=\"$(realpath $(dirname `which clang`)/..)\""
+		myconf_gn+=" clang_base_path=\"$(llvm-config --prefix)\""
 	else
 		myconf_gn+=" is_clang=false"
 	fi

--- a/www-client/chromium/chromium-60.0.3112.32.ebuild
+++ b/www-client/chromium/chromium-60.0.3112.32.ebuild
@@ -396,7 +396,7 @@ src_configure() {
 
 	if tc-is-clang; then
 		myconf_gn+=" is_clang=true clang_use_chrome_plugins=false"
-		myconf_gn+=" clang_base_path=\"$(realpath $(dirname `which clang`)/..)\""
+		myconf_gn+=" clang_base_path=\"$(llvm-config --prefix)\""
 	else
 		myconf_gn+=" is_clang=false"
 	fi

--- a/www-client/chromium/chromium-61.0.3124.4.ebuild
+++ b/www-client/chromium/chromium-61.0.3124.4.ebuild
@@ -397,7 +397,7 @@ src_configure() {
 
 	if tc-is-clang; then
 		myconf_gn+=" is_clang=true clang_use_chrome_plugins=false"
-		myconf_gn+=" clang_base_path=\"$(realpath $(dirname `which clang`)/..)\""
+		myconf_gn+=" clang_base_path=\"$(llvm-config --prefix)\""
 	else
 		myconf_gn+=" is_clang=false"
 	fi

--- a/www-client/chromium/chromium-61.0.3128.3.ebuild
+++ b/www-client/chromium/chromium-61.0.3128.3.ebuild
@@ -398,7 +398,7 @@ src_configure() {
 
 	if tc-is-clang; then
 		myconf_gn+=" is_clang=true clang_use_chrome_plugins=false"
-		myconf_gn+=" clang_base_path=\"$(realpath $(dirname `which clang`)/..)\""
+		myconf_gn+=" clang_base_path=\"$(llvm-config --prefix)\""
 	else
 		myconf_gn+=" is_clang=false"
 	fi


### PR DESCRIPTION
Use $(llvm-config --prefix) as clang_base_path instead of $(realpath $(dirname \`which clang\`)/..)