### PR TITLE
x11-drivers/xf86-input-mtrack: Fix x11 proto deps

### DIFF
--- a/x11-drivers/xf86-input-mtrack/xf86-input-mtrack-0.4.1-r1.ebuild
+++ b/x11-drivers/xf86-input-mtrack/xf86-input-mtrack-0.4.1-r1.ebuild
@@ -14,9 +14,9 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ~arm x86"
 
-RDEPEND="${RDEPEND}
+RDEPEND="
 	>=sys-libs/mtdev-1.0"
-DEPEND="${DEPEND}
+DEPEND="
 	>=sys-libs/mtdev-1.0
 	x11-proto/inputproto
 	x11-proto/randrproto
@@ -24,7 +24,6 @@ DEPEND="${DEPEND}
 	x11-proto/xineramaproto
 	x11-proto/xproto"
 
-DOCS=( "README.md" )
 PATCHES=( "${FILESDIR}"/${PN}-0.2.0-drop-mtrack-test.patch )
 
 pkg_postinst() {

--- a/x11-drivers/xf86-input-mtrack/xf86-input-mtrack-0.4.1-r1.ebuild
+++ b/x11-drivers/xf86-input-mtrack/xf86-input-mtrack-0.4.1-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit vcs-snapshot
+
+DESCRIPTION="Xorg Driver for Multitouch Trackpads"
+HOMEPAGE="https://github.com/p2rkw/xf86-input-mtrack"
+SRC_URI="https://github.com/p2rkw/xf86-input-mtrack/tarball/v${PV/_/-} -> ${P}.tar.gz"
+IUSE="debug"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 ~arm x86"
+
+RDEPEND="${RDEPEND}
+	>=sys-libs/mtdev-1.0"
+DEPEND="${DEPEND}
+	>=sys-libs/mtdev-1.0
+	x11-proto/inputproto
+	x11-proto/randrproto
+	x11-proto/videoproto
+	x11-proto/xineramaproto
+	x11-proto/xproto"
+
+DOCS=( "README.md" )
+PATCHES=( "${FILESDIR}"/${PN}-0.2.0-drop-mtrack-test.patch )
+
+pkg_postinst() {
+	elog
+	elog "To enable multitouch support add the following lines"
+	elog "to your xorg.conf:"
+	elog ""
+	elog "Section \"InputClass\""
+	elog "  MatchIsTouchpad \"true\""
+	elog "  Identifier      \"Touchpads\""
+	elog "  Driver          \"mtrack\""
+	elog "EndSection"
+	elog
+}


### PR DESCRIPTION
Should fix bug 615384 https://bugs.gentoo.org/show_bug.cgi?id=615384