### PR TITLE
Update some packages to use virtual/jack instead of jack-audio-connection-kit

### DIFF
--- a/media-sound/audacity/audacity-2.0.5-r2.ebuild
+++ b/media-sound/audacity/audacity-2.0.5-r2.ebuild
@@ -34,7 +34,7 @@ COMMON_DEPEND="x11-libs/wxGTK:2.8[X]
 	twolame? ( media-sound/twolame )
 	ffmpeg? ( virtual/ffmpeg )
 	alsa? ( media-libs/alsa-lib )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.103.0 )"
+	jack? ( virtual/jack )"
 # Crashes at  startup here...
 #	lv2? ( >=media-libs/slv2-0.6.0 )
 # Disabled upstream ATM

--- a/media-sound/audacity/audacity-2.1.3-r1.ebuild
+++ b/media-sound/audacity/audacity-2.1.3-r1.ebuild
@@ -29,7 +29,7 @@ RDEPEND=">=app-arch/zip-2.3
 		!libav? ( >=media-video/ffmpeg-1.2:= ) )
 	flac? ( >=media-libs/flac-1.2.0[cxx] )
 	id3tag? ( media-libs/libid3tag )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.103.0 )
+	jack? ( virtual/jack )
 	lame? ( >=media-sound/lame-3.70 )
 	lv2? ( media-libs/lv2 )
 	mad? ( >=media-libs/libmad-0.14.2b )

--- a/media-sound/helm/helm-0.4.1-r2.ebuild
+++ b/media-sound/helm/helm-0.4.1-r2.ebuild
@@ -15,7 +15,7 @@ IUSE=""
 
 RDEPEND="media-libs/alsa-lib
 	media-libs/lv2
-	media-sound/jack-audio-connection-kit
+	virtual/jack
 	virtual/opengl
 	x11-libs/libX11
 	x11-libs/libXext"

--- a/media-sound/hydrogen/hydrogen-0.9.5-r1.ebuild
+++ b/media-sound/hydrogen/hydrogen-0.9.5-r1.ebuild
@@ -18,7 +18,7 @@ RDEPEND="dev-qt/qtgui:4 dev-qt/qtcore:4
 	!archive? ( >=dev-libs/libtar-1.2.11-r3 )
 	>=media-libs/libsndfile-1.0.18
 	alsa? ( media-libs/alsa-lib )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	ladspa? ( media-libs/liblrdf )
 	lash? ( media-sound/lash )
 	portaudio? ( >=media-libs/portaudio-19_pre )"

--- a/media-sound/lash/lash-0.5.4-r3.ebuild
+++ b/media-sound/lash/lash-0.5.4-r3.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="alpha amd64 ~arm hppa ppc ppc64 sparc x86"
 IUSE="alsa debug gtk python static-libs" # doc
 
 RDEPEND="dev-libs/libxml2
-	media-sound/jack-audio-connection-kit
+	virtual/jack
 	>=sys-apps/util-linux-2.24.1-r3[${MULTILIB_USEDEP}]
 	alsa? ( media-libs/alsa-lib )
 	gtk? ( x11-libs/gtk+:2 )

--- a/media-sound/qmidiarp/qmidiarp-0.6.3-r1.ebuild
+++ b/media-sound/qmidiarp/qmidiarp-0.6.3-r1.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 	media-libs/alsa-lib
-	media-sound/jack-audio-connection-kit
+	virtual/jack
 	lv2? ( media-libs/lv2 )
 	osc? ( media-libs/liblo )"
 DEPEND="${RDEPEND}

--- a/media-sound/qmidiarp/qmidiarp-0.6.4-r1.ebuild
+++ b/media-sound/qmidiarp/qmidiarp-0.6.4-r1.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 	media-libs/alsa-lib
-	media-sound/jack-audio-connection-kit
+	virtual/jack
 	lv2? ( media-libs/lv2 )
 	osc? ( media-libs/liblo )"
 DEPEND="${RDEPEND}

--- a/media-sound/qtractor/qtractor-0.8.0-r1.ebuild
+++ b/media-sound/qtractor/qtractor-0.8.0-r1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	)
 	media-libs/alsa-lib
 	media-libs/libsndfile
-	media-sound/jack-audio-connection-kit
+	virtual/jack
 	media-libs/ladspa-sdk
 	>=media-libs/lilv-0.16.0
 	media-libs/lv2

--- a/media-sound/qtractor/qtractor-0.8.1-r1.ebuild
+++ b/media-sound/qtractor/qtractor-0.8.1-r1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	)
 	media-libs/alsa-lib
 	media-libs/libsndfile
-	media-sound/jack-audio-connection-kit
+	virtual/jack
 	media-libs/ladspa-sdk
 	>=media-libs/lilv-0.16.0
 	media-libs/lv2

--- a/media-sound/qtractor/qtractor-0.8.2-r1.ebuild
+++ b/media-sound/qtractor/qtractor-0.8.2-r1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	)
 	media-libs/alsa-lib
 	media-libs/libsndfile
-	media-sound/jack-audio-connection-kit
+	virtual/jack
 	media-libs/ladspa-sdk
 	>=media-libs/lilv-0.16.0
 	media-libs/lv2

--- a/media-sound/zynaddsubfx/zynaddsubfx-3.0.1-r1.ebuild
+++ b/media-sound/zynaddsubfx/zynaddsubfx-3.0.1-r1.ebuild
@@ -19,7 +19,7 @@ RDEPEND=">=dev-libs/mini-xml-2.2.1
 	media-libs/liblo
 	alsa? ( media-libs/alsa-lib )
 	fltk? ( >=x11-libs/fltk-1.3:1 )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	lash? ( media-sound/lash )"
 #	portaudio? ( media-libs/portaudio )"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
These are packages I have installed which currently prevent me from switching to using the new jack2 package, so I thought I might as well create a PR to fix them :)