### PR TITLE
dev-util/glade: Fix X 100% CPU usage when glade backgrounded

### DIFF
--- a/dev-util/glade/files/glade-3.20.0-context-save.patch
+++ b/dev-util/glade/files/glade-3.20.0-context-save.patch
@@ -1,0 +1,56 @@
+From ac55fa78566145ac44d48ba88ec1351db5b4a99d Mon Sep 17 00:00:00 2001
+From: Arnaud Rebillout <arnaud@preev.io>
+Date: Tue, 13 Jun 2017 15:03:02 +0700
+Subject: Fix use of GTK+ style context in GladeDesignLayout.
+
+It seems like modifying the style context in the 'draw' handler is not
+recommended, and we need to save/restore the context.
+
+Otherwise, for some widgets (GtkButton, GtkComboBox), the
+GladeDesignLayout gets trapped in draw-damage loop.
+
+See 0c076cc8828cd80f1f156a08569199675bf35165 for reference.
+---
+ gladeui/glade-design-layout.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/gladeui/glade-design-layout.c b/gladeui/glade-design-layout.c
+index b5970ce..17e9a60 100644
+--- a/gladeui/glade-design-layout.c
++++ b/gladeui/glade-design-layout.c
+@@ -1033,13 +1033,13 @@ draw_frame (GtkWidget *widget, cairo_t *cr, gboolean selected,
+   if (priv->widget_name)
+     {
+       GdkRectangle *rect = &priv->south_east;
+-
++      gtk_style_context_save (context);
+       gtk_style_context_add_class (context, "handle");
+       gtk_render_background (context, cr, rect->x, rect->y, rect->width, rect->height);
+       gtk_render_frame (context, cr, rect->x, rect->y, rect->width, rect->height);
+       gtk_render_layout (context, cr, rect->x + OUTLINE_WIDTH, rect->y + OUTLINE_WIDTH,
+                          priv->widget_name);
+-      gtk_style_context_remove_class (context, "handle");
++      gtk_style_context_restore (context);
+     }
+ }
+ 
+@@ -1084,6 +1084,7 @@ draw_selection (cairo_t *cr,
+   if (alloc.x < 0 || alloc.y < 0) return;
+ 
+   context = gtk_widget_get_style_context (parent);
++  gtk_style_context_save (context);
+   gtk_style_context_add_class (context, "selection");
+   r = color->red; g = color->green; b = color->blue;
+   gtk_widget_translate_coordinates (widget, parent, 0, 0, &x, &y);
+@@ -1122,7 +1123,7 @@ draw_selection (cairo_t *cr,
+ 
+   /* Draw Selection box */
+   gtk_render_frame (context, cr, x - left, y - top, w + left + right, h + top + bottom);
+-  gtk_style_context_remove_class (context, "selection");
++  gtk_style_context_restore (context);
+ }
+ 
+ #define DIMENSION_OFFSET 9
+-- 
+cgit v0.12
+

--- a/dev-util/glade/glade-3.20.0-r1.ebuild
+++ b/dev-util/glade/glade-3.20.0-r1.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+GNOME2_LA_PUNT="yes"
+PYTHON_COMPAT=( python2_7 )
+
+inherit gnome2 python-single-r1 versionator virtualx
+
+DESCRIPTION="A user interface designer for GTK+ and GNOME"
+HOMEPAGE="https://glade.gnome.org/"
+
+LICENSE="GPL-2+ FDL-1.1+"
+SLOT="3.10/6" # subslot = suffix of libgladeui-2.so
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+
+IUSE="debug +introspection python"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	dev-libs/atk[introspection?]
+	>=dev-libs/glib-2.32:2
+	>=dev-libs/libxml2-2.4.0:2
+	x11-libs/cairo:=
+	x11-libs/gdk-pixbuf:2[introspection?]
+	>=x11-libs/gtk+-3.20.0:3[introspection?]
+	x11-libs/pango[introspection?]
+	introspection? ( >=dev-libs/gobject-introspection-1.32:= )
+	python? (
+		${PYTHON_DEPS}
+		>=dev-python/pygobject-3.8:3[${PYTHON_USEDEP}] )
+"
+DEPEND="${RDEPEND}
+	app-text/docbook-xml-dtd:4.1.2
+	app-text/yelp-tools
+	dev-libs/libxslt
+	>=dev-util/gtk-doc-am-1.13
+	>=dev-util/intltool-0.41.0
+	dev-util/itstool
+	virtual/pkgconfig
+
+	dev-libs/gobject-introspection-common
+	gnome-base/gnome-common
+"
+# eautoreconf requires:
+#	dev-libs/gobject-introspection-common
+#	gnome-base/gnome-common
+
+PATCHES=(
+	"${FILESDIR}"/${P}-context-save.patch
+	# To avoid file collison with other slots, rename help module.
+	# Prevent the UI from loading glade:3's gladeui devhelp documentation.
+	"${FILESDIR}"/${PN}-3.14.1-doc-version.patch
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_configure() {
+	gnome2_src_configure \
+		--disable-static \
+		--enable-gladeui \
+		--enable-libtool-lock \
+		$(usex debug --enable-debug ' ') \
+		$(use_enable introspection) \
+		$(use_enable python)
+}
+
+src_test() {
+	virtx emake check
+}
+
+src_install() {
+	# modify Name in .desktop file to avoid confusion with other slots
+	sed -e 's:^\(Name.*=Glade\):\1 '$(get_version_component_range 1-2): \
+		-i data/glade.desktop || die "sed of data/glade.desktop failed"
+	# modify name in .devhelp2 file to avoid shadowing with glade:3 docs
+	sed -e 's:name="gladeui":name="gladeui-2":' \
+		-i doc/html/gladeui.devhelp2 || die "sed of gladeui.devhelp2 failed"
+	gnome2_src_install
+}
+
+pkg_postinst() {
+	gnome2_pkg_postinst
+	if ! has_version dev-util/devhelp ; then
+		elog "You may want to install dev-util/devhelp for integration API"
+		elog "documentation support."
+	fi
+}


### PR DESCRIPTION
Package-Manager: Portage-2.3.5, Repoman-2.3.2

---

This is a major bug. Report:
https://bugzilla.gnome.org/show_bug.cgi?id=763624

Patch committed from upstream master:
https://git.gnome.org/browse/glade/commit/?id=ac55fa78566145ac44d48ba88ec1351db5b4a99d

