### PR TITLE
app-text/kchmviewer: Fix icon and desktop entry not installed

### DIFF
--- a/app-text/kchmviewer/kchmviewer-7.7-r1.ebuild
+++ b/app-text/kchmviewer/kchmviewer-7.7-r1.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit eutils qmake-utils xdg-utils
+
+DESCRIPTION="Feature rich chm file viewer, based on Qt"
+HOMEPAGE="https://www.ulduzsoft.com/kchmviewer/"
+SRC_URI="mirror://sourceforge/kchmviewer/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="
+	dev-libs/chmlib
+	dev-libs/libzip:=
+	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtwebkit:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-force-qtwebkit.patch"
+	"${FILESDIR}/${P}-underlinking.patch"
+)
+
+src_configure() {
+	eqmake5
+}
+
+src_install() {
+	dodoc ChangeLog DBUS-bindings FAQ README
+	doicon packages/kchmviewer.png
+	dobin bin/kchmviewer
+	domenu packages/kchmviewer.desktop
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+}


### PR DESCRIPTION
Add missing eutils eclass. Also:
- Update HOMEPAGE
- Remove sed of desktop entry, trailing semi-colons now optional
- Use xdg-utils instead of fdo-mime

Package-Manager: Portage-2.3.6, Repoman-2.3.2

---

```
QA: install
QA Notice: command not found:

	/var/tmp/portage/app-text/kchmviewer-7.7/temp/environment: line 1244: doicon: command not found
	/var/tmp/portage/app-text/kchmviewer-7.7/temp/environment: line 1246: domenu: command not found
```
```
 Final size of build directory: 5756 KiB
 Final size of installed tree: 868 KiB

strip: x86_64-pc-linux-gnu-strip --strip-unneeded -R .comment -R .GCC.command.line -R .note.gnu.gold-version
   usr/bin/kchmviewer
ecompressdir: bzip2 -9 /usr/share/doc
 checking 7 files for package collisions
>>> Merging app-text/kchmviewer-7.7-r1 to /
--- /usr/
--- /usr/share/
--- /usr/share/doc/
>>> /usr/share/doc/kchmviewer-7.7-r1/
>>> /usr/share/doc/kchmviewer-7.7-r1/README.bz2
>>> /usr/share/doc/kchmviewer-7.7-r1/FAQ.bz2
>>> /usr/share/doc/kchmviewer-7.7-r1/DBUS-bindings.bz2
>>> /usr/share/doc/kchmviewer-7.7-r1/ChangeLog.bz2
--- /usr/share/pixmaps/
>>> /usr/share/pixmaps/kchmviewer.png
--- /usr/share/applications/
>>> /usr/share/applications/kchmviewer.desktop
--- /usr/bin/
>>> /usr/bin/kchmviewer
>>> Safely unmerging already-installed instance...
No package files given... Grabbing a set.
<<<          obj /usr/share/doc/kchmviewer-7.7/README.bz2
<<<          obj /usr/share/doc/kchmviewer-7.7/FAQ.bz2
<<<          obj /usr/share/doc/kchmviewer-7.7/DBUS-bindings.bz2
<<<          obj /usr/share/doc/kchmviewer-7.7/ChangeLog.bz2
--- replaced dir /usr/share/doc
--- replaced dir /usr/share
--- replaced obj /usr/bin/kchmviewer
--- replaced dir /usr/bin
--- replaced dir /usr
<<<          dir /usr/share/doc/kchmviewer-7.7
 Updating desktop mime database ...
>>> Regenerating /etc/ld.so.cache...
>>> Original instance of package unmerged safely.
 Updating .desktop files database ...
>>> app-text/kchmviewer-7.7-r1 merged.
```