### PR TITLE
sci-biology/cufflinks: Fix building with GCC-6

### DIFF
--- a/sci-biology/cufflinks/cufflinks-2.2.1-r2.ebuild
+++ b/sci-biology/cufflinks/cufflinks-2.2.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -22,6 +22,7 @@ RDEPEND="${DEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${P}-samtools-legacy.patch
 	"${FILESDIR}"/${P}-flags.patch
+	"${FILESDIR}"/${P}-gcc6.patch
 )
 
 src_prepare() {

--- a/sci-biology/cufflinks/files/cufflinks-2.2.1-gcc6.patch
+++ b/sci-biology/cufflinks/files/cufflinks-2.2.1-gcc6.patch
@@ -1,0 +1,14 @@
+--- a/src/lemon/error.h
++++ b/src/lemon/error.h
+@@ -67,9 +67,9 @@
+     }
+ 
+     ExceptionMember& operator=(const ExceptionMember& copy) {
+-      if (ptr.get() == 0) return;
++      if (ptr.get() == 0) return *this;
+       try {
+-	if (!copy.valid()) return;
++	if (!copy.valid()) return *this;
+  	*ptr = copy.get();
+       } catch (...) {}
+     }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594904
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Upstream PR: https://github.com/cole-trapnell-lab/cufflinks/pull/87