### PR TITLE
gnome-extra/cinnamon-screensaver: fix blocker with USE=systemd in 3.4.1

### DIFF
--- a/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-3.4.1.ebuild
+++ b/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-3.4.1.ebuild
@@ -36,7 +36,7 @@ COMMON_DEPEND="
 	x11-libs/libXxf86vm
 	x11-themes/adwaita-icon-theme
 
-	sys-auth/elogind
+	!systemd? ( sys-auth/elogind )
 
 	${PYTHON_DEPS}
 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=622630
