### PR TITLE
x11-misc/sddm : launch consolekit session properly

### DIFF
--- a/x11-misc/sddm/files/sddm-0.14.0-consolekit.patch
+++ b/x11-misc/sddm/files/sddm-0.14.0-consolekit.patch
@@ -5,5 +5,5 @@
      exec xmessage -center -buttons OK:0 -default OK "Sorry, $DESKTOP_SESSION is no valid session."
  else
 -    exec $@
-+    exec ck-launch-session $@
++    exec ck-launch-session dbus-launch --sh-syntax --exit-with-session $@
  fi


### PR DESCRIPTION
ck-launch-session is not enough to launch a consolekit session properly. Withouth dbus-launch, external device mounting won't be authorized by udisks2. This tiny change makes sure the session is launched properly.