### PR TITLE
app-admin/logrotate: Install a systemd timer, bug #525418

### DIFF
--- a/app-admin/logrotate/logrotate-3.12.2-r1.ebuild
+++ b/app-admin/logrotate/logrotate-3.12.2-r1.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit systemd
+
+DESCRIPTION="Rotates, compresses, and mails system logs"
+HOMEPAGE="https://github.com/logrotate/logrotate"
+SRC_URI="https://github.com/${PN}/${PN}/releases/download/${PV}/${P}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE="acl +cron selinux"
+
+CDEPEND="
+	>=dev-libs/popt-1.5
+	selinux? ( sys-libs/libselinux )
+	acl? ( virtual/acl )"
+
+DEPEND="${CDEPEND}
+	>=sys-apps/sed-4"
+
+RDEPEND="${CDEPEND}
+	selinux? ( sec-policy/selinux-logrotate )
+	cron? ( virtual/cron )"
+
+install_cron_file() {
+	exeinto /etc/cron.daily
+	newexe "${S}"/examples/logrotate.cron "${PN}"
+}
+
+PATCHES=(
+	"${FILESDIR}/${P}-ignore-hidden.patch"
+	"${FILESDIR}/${P}-fbsd.patch"
+)
+
+DOCS=( ChangeLog.md README.md examples/logrotate-default )
+
+src_prepare() {
+	default
+
+	sed -i 's#/usr/sbin/logrotate#/usr/bin/logrotate#' "${S}"/examples/logrotate.{cron,service} || die
+}
+
+src_configure() {
+	econf \
+		--sbindir=/usr/bin \
+		$(use_with acl) \
+		$(use_with selinux)
+}
+
+src_test() {
+	emake test
+}
+
+src_install() {
+	default
+
+	insinto /etc
+	doins "${FILESDIR}"/logrotate.conf
+
+	use cron && install_cron_file
+
+	systemd_dounit examples/logrotate.{service,timer}
+
+	keepdir /etc/logrotate.d
+}
+
+pkg_postinst() {
+	elog "The ${PN} binary is now installed under /usr/bin. Please"
+	elog "update your links"
+	elog
+	if [[ -z ${REPLACING_VERSIONS} ]] ; then
+		elog "If you wish to have logrotate e-mail you updates, please"
+		elog "emerge virtual/mailx and configure logrotate in"
+		elog "/etc/logrotate.conf appropriately"
+		elog
+		elog "Additionally, /etc/logrotate.conf may need to be modified"
+		elog "for your particular needs.  See man logrotate for details."
+	fi
+}


### PR DESCRIPTION
Also:
- Don't autoreconf
- Remove unused eclasses
- Only install logrotate-default as doc

X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=525418
Package-Manager: Portage-2.3.6, Repoman-2.3.2

---

```
--- logrotate-3.12.2.ebuild
+++ logrotate-3.12.2-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit autotools eutils toolchain-funcs flag-o-matic
+inherit systemd
 
 DESCRIPTION="Rotates, compresses, and mails system logs"
 HOMEPAGE="https://github.com/logrotate/logrotate"
@@ -11,7 +11,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="acl +cron selinux"
 
 CDEPEND="
@@ -27,7 +27,6 @@
 	cron? ( virtual/cron )"
 
 install_cron_file() {
-	sed -i 's#/usr/sbin/logrotate#/usr/bin/logrotate#' "${S}"/examples/logrotate.cron || die
 	exeinto /etc/cron.daily
 	newexe "${S}"/examples/logrotate.cron "${PN}"
 }
@@ -39,7 +38,8 @@
 
 src_prepare() {
 	default
-	eautoreconf
+	
+	sed -i 's#/usr/sbin/logrotate#/usr/bin/logrotate#' "${S}"/examples/logrotate.{cron,service} || die
 }
 
 src_configure() {
@@ -58,12 +58,14 @@
 	insinto /usr
 	dobin logrotate
 	doman logrotate.8
-	dodoc ChangeLog.md examples/logrotate*
+	dodoc ChangeLog.md examples/logrotate-default
 
 	insinto /etc
 	doins "${FILESDIR}"/logrotate.conf
 
 	use cron && install_cron_file
+	
+	systemd_dounit examples/logrotate.{service,timer}
 
 	keepdir /etc/logrotate.d
 }
```
