### PR TITLE
net-analyzer/sinfo: Fix building with GCC-6

### DIFF
--- a/net-analyzer/sinfo/files/sinfo-0.0.48-gcc6.patch
+++ b/net-analyzer/sinfo/files/sinfo-0.0.48-gcc6.patch
@@ -1,0 +1,24 @@
+Bug: https://bugs.gentoo.org/594990
+
+--- a/libmessageio/tcpmessageserverconnection.cc
++++ b/libmessageio/tcpmessageserverconnection.cc
+@@ -91,7 +91,7 @@
+ }
+ 
+ 
+-void TCPMessageServerConnection::queueAndSendMessageSlot(Message & message)
++void TCPMessageServerConnection::queueAndSendMessageSlot(const Message & message)
+ {
+ 
+   if (sendQueue.size()<maxSendQueueSize)
+--- a/libmessageio/tcpmessageserverconnection.h
++++ b/libmessageio/tcpmessageserverconnection.h
+@@ -32,7 +32,7 @@
+   void handleReadMessageSize(const boost::system::error_code& err, size_t length);
+   void handleReadMessage(const boost::system::error_code& err, size_t length);
+ 
+-  void queueAndSendMessageSlot(Message & message);
++  void queueAndSendMessageSlot(const Message & message);
+   std::list<Message>  sendQueue;
+   bool sendQueueCurrentlySending;
+   void startNewTransmission();

--- a/net-analyzer/sinfo/sinfo-0.0.48.ebuild
+++ b/net-analyzer/sinfo/sinfo-0.0.48.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -26,6 +26,7 @@ DEPEND="
 src_prepare() {
 	cp "${FILESDIR}"/${P}-acinclude.m4 acinclude.m4 || die
 	epatch "${FILESDIR}"/${PN}-0.0.47-tinfo.patch
+	epatch "${FILESDIR}"/${P}-gcc6.patch
 	eautoreconf
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=594990
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Build fails with `error: invalid initialization of non-const reference of type ‘Message&’ from an rvalue of type ‘Message’`.  The offending function doesn't need to modify its argument so it can take it by const reference instead of just reference.