### PR TITLE
XFCE: replace XFCE_PLUGINS with local USE flags

### DIFF
--- a/app-office/orage/metadata.xml
+++ b/app-office/orage/metadata.xml
@@ -5,4 +5,8 @@
     <email>xfce@gentoo.org</email>
     <name>XFCE Team</name>
   </maintainer>
+  <use>
+    <flag name='clock-panel-plugin'>Build the clock plugin for the XFCE
+      panel</flag>
+  </use>
 </pkgmetadata>

--- a/app-office/orage/orage-4.12.1-r1.ebuild
+++ b/app-office/orage/orage-4.12.1-r1.ebuild
@@ -12,15 +12,15 @@ SRC_URI="mirror://xfce/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
-IUSE="berkdb dbus libnotify +xfce_plugins_clock"
+IUSE="berkdb +clock-panel-plugin dbus libnotify"
 
 RDEPEND=">=dev-libs/libical-0.48:=
 	dev-libs/popt:=
 	>=x11-libs/gtk+-2.10:2=
 	berkdb? ( >=sys-libs/db-4:= )
+	clock-panel-plugin? ( >=xfce-base/xfce4-panel-4.10:= )
 	dbus? ( >=dev-libs/dbus-glib-0.100:= )
-	libnotify? ( >=x11-libs/libnotify-0.7:= )
-	xfce_plugins_clock? ( >=xfce-base/xfce4-panel-4.10:= )"
+	libnotify? ( >=x11-libs/libnotify-0.7:= )"
 DEPEND="${RDEPEND}
 	dev-util/intltool
 	sys-devel/gettext
@@ -31,7 +31,7 @@ src_configure() {
 	local myconf=(
 		--libexecdir="${EPREFIX}/usr/$(get_libdir)"
 		--docdir="${EPREFIX}"/usr/share/doc/${PF}/html
-		$(use_enable xfce_plugins_clock libxfce4panel)
+		$(use_enable clock-panel-plugin libxfce4panel)
 		$(use_enable dbus)
 		$(use_enable libnotify)
 		$(use_with berkdb bdb4)

--- a/app-office/orage/orage-4.12.1-r1.ebuild
+++ b/app-office/orage/orage-4.12.1-r1.ebuild
@@ -27,11 +27,6 @@ DEPEND="${RDEPEND}
 	>=sys-devel/libtool-2.2.6
 	virtual/pkgconfig"
 
-pkg_setup() {
-	# PM doesn't let directory to be replaced by a symlink, see src_install()
-	rm -rf "${EROOT}"/usr/share/${PN}/doc || die
-}
-
 src_configure() {
 	local myconf=(
 		--libexecdir="${EPREFIX}/usr/$(get_libdir)"
@@ -46,14 +41,15 @@ src_configure() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" install \
-		docdir="${EPREFIX}"/usr/share/doc/${PF}/html \
-		imagesdir="${EPREFIX}"/usr/share/doc/${PF}/html/images
-
-	# Create compability symlink for retarded path hardcoding in src/{mainbox,parameters}.c
-	dosym /usr/share/doc/${PF}/html /usr/share/${PN}/doc/C
-
+	default
 	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_preinst() {
+	# Replacing directory by symlink is unreliable
+	if [[ -L ${EROOT}/usr/share/orage/doc/C ]]; then
+		rm -f "${EROOT}/usr/share/orage/doc/C" || die
+	fi
 }
 
 pkg_postinst() {

--- a/app-office/orage/orage-4.12.1-r1.ebuild
+++ b/app-office/orage/orage-4.12.1-r1.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit gnome2-utils
+
+DESCRIPTION="A time managing application (and panel plug-in) for the Xfce desktop environment"
+HOMEPAGE="https://git.xfce.org/apps/orage/"
+SRC_URI="mirror://xfce/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="berkdb dbus libnotify +xfce_plugins_clock"
+
+RDEPEND=">=dev-libs/libical-0.48:=
+	dev-libs/popt:=
+	>=x11-libs/gtk+-2.10:2=
+	berkdb? ( >=sys-libs/db-4:= )
+	dbus? ( >=dev-libs/dbus-glib-0.100:= )
+	libnotify? ( >=x11-libs/libnotify-0.7:= )
+	xfce_plugins_clock? ( >=xfce-base/xfce4-panel-4.10:= )"
+DEPEND="${RDEPEND}
+	dev-util/intltool
+	sys-devel/gettext
+	>=sys-devel/libtool-2.2.6
+	virtual/pkgconfig"
+
+pkg_setup() {
+	# PM doesn't let directory to be replaced by a symlink, see src_install()
+	rm -rf "${EROOT}"/usr/share/${PN}/doc || die
+}
+
+src_configure() {
+	local myconf=(
+		--libexecdir="${EPREFIX}/usr/$(get_libdir)"
+		--docdir="${EPREFIX}"/usr/share/doc/${PF}/html
+		$(use_enable xfce_plugins_clock libxfce4panel)
+		$(use_enable dbus)
+		$(use_enable libnotify)
+		$(use_with berkdb bdb4)
+	)
+
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install \
+		docdir="${EPREFIX}"/usr/share/doc/${PF}/html \
+		imagesdir="${EPREFIX}"/usr/share/doc/${PF}/html/images
+
+	# Create compability symlink for retarded path hardcoding in src/{mainbox,parameters}.c
+	dosym /usr/share/doc/${PF}/html /usr/share/${PN}/doc/C
+
+	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+}

--- a/xfce-base/thunar/metadata.xml
+++ b/xfce-base/thunar/metadata.xml
@@ -5,4 +5,8 @@
     <email>xfce@gentoo.org</email>
     <name>XFCE Team</name>
   </maintainer>
+  <use>
+    <flag name='trash-panel-plugin'>Build the trash status indicator plugin for
+      the XFCE panel</flag>
+  </use>
 </pkgmetadata>

--- a/xfce-base/thunar/thunar-1.6.12.ebuild
+++ b/xfce-base/thunar/thunar-1.6.12.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://xfce/src/xfce/${PN}/${PV%.*}/${MY_P}.tar.bz2"
 LICENSE="GPL-2 LGPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
-IUSE="+dbus exif libnotify pcre test udisks +xfce_plugins_trash"
+IUSE="+dbus exif libnotify pcre test +trash-panel-plugin udisks"
 
 GVFS_DEPEND=">=gnome-base/gvfs-1.18.3"
 COMMON_DEPEND=">=dev-lang/perl-5.6
@@ -28,22 +28,22 @@ COMMON_DEPEND=">=dev-lang/perl-5.6
 	exif? ( >=media-libs/libexif-0.6.19:= )
 	libnotify? ( >=x11-libs/libnotify-0.7:= )
 	pcre? ( >=dev-libs/libpcre-6:= )
-	udisks? ( virtual/libgudev:= )
-	xfce_plugins_trash? ( >=xfce-base/xfce4-panel-4.10:= )"
+	trash-panel-plugin? ( >=xfce-base/xfce4-panel-4.10:= )
+	udisks? ( virtual/libgudev:= )"
 RDEPEND="${COMMON_DEPEND}
 	>=dev-util/desktop-file-utils-0.20-r1
 	x11-misc/shared-mime-info
 	dbus? ( ${GVFS_DEPEND} )
+	trash-panel-plugin? ( ${GVFS_DEPEND} )
 	udisks? (
 		virtual/udev
 		${GVFS_DEPEND}[udisks,udev]
-		)
-	xfce_plugins_trash? ( ${GVFS_DEPEND} )"
+		)"
 DEPEND="${COMMON_DEPEND}
 	dev-util/intltool
 	sys-devel/gettext
 	virtual/pkgconfig"
-REQUIRED_USE="xfce_plugins_trash? ( dbus )"
+REQUIRED_USE="trash-panel-plugin? ( dbus )"
 
 S=${WORKDIR}/${MY_P}
 
@@ -56,7 +56,7 @@ src_configure() {
 		$(use_enable libnotify notifications)
 		$(use_enable exif)
 		$(use_enable pcre)
-		$(use_enable xfce_plugins_trash tpa-plugin)
+		$(use_enable trash-panel-plugin tpa-plugin)
 	)
 
 	econf "${myconf[@]}"

--- a/xfce-extra/xfce4-power-manager/metadata.xml
+++ b/xfce-extra/xfce4-power-manager/metadata.xml
@@ -5,4 +5,8 @@
     <email>xfce@gentoo.org</email>
     <name>XFCE Team</name>
   </maintainer>
+  <use>
+    <flag name='panel-plugin'>Build the power management plugin for
+      the XFCE panel</flag>
+  </use>
 </pkgmetadata>

--- a/xfce-extra/xfce4-power-manager/xfce4-power-manager-1.6.0-r1.ebuild
+++ b/xfce-extra/xfce4-power-manager/xfce4-power-manager-1.6.0-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://xfce/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
-IUSE="debug kernel_linux networkmanager policykit systemd +xfce_plugins_power"
+IUSE="debug kernel_linux networkmanager +panel-plugin policykit systemd"
 
 COMMON_DEPEND=">=dev-libs/glib-2.42:=
 	>=sys-power/upower-0.99.0
@@ -26,11 +26,11 @@ COMMON_DEPEND=">=dev-libs/glib-2.42:=
 	>=xfce-base/xfconf-4.12:=
 	>=xfce-base/libxfce4ui-4.12:=[gtk3(+)]
 	>=xfce-base/libxfce4util-4.12:=
+	panel-plugin? ( >=xfce-base/xfce4-panel-4.12:= )
 	policykit? (
 		>=sys-auth/polkit-0.112
 		!systemd? ( sys-auth/consolekit )
-	)
-	xfce_plugins_power? ( >=xfce-base/xfce4-panel-4.12:= )"
+	)"
 RDEPEND="${COMMON_DEPEND}
 	networkmanager? ( net-misc/networkmanager )"
 DEPEND="${COMMON_DEPEND}
@@ -50,7 +50,7 @@ src_configure() {
 	local myconf=(
 		$(use_enable policykit polkit)
 		$(use_enable networkmanager network-manager)
-		$(use_enable xfce_plugins_power xfce4panel)
+		$(use_enable panel-plugin xfce4panel)
 	)
 
 	econf "${myconf[@]}"

--- a/xfce-extra/xfce4-power-manager/xfce4-power-manager-1.6.0-r1.ebuild
+++ b/xfce-extra/xfce4-power-manager/xfce4-power-manager-1.6.0-r1.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit linux-info gnome2-utils
+
+DESCRIPTION="Power manager for the Xfce desktop environment"
+HOMEPAGE="https://goodies.xfce.org/projects/applications/xfce4-power-manager"
+SRC_URI="mirror://xfce/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
+IUSE="debug kernel_linux networkmanager policykit systemd +xfce_plugins_power"
+
+COMMON_DEPEND=">=dev-libs/glib-2.42:=
+	>=sys-power/upower-0.99.0
+	sys-power/pm-utils
+	>=x11-libs/gtk+-3.14:3=
+	>=x11-libs/libnotify-0.7:=
+	x11-libs/libX11:=
+	x11-libs/libXScrnSaver:=
+	>=x11-libs/libXrandr-1.2:=
+	x11-libs/libXext:=
+	x11-libs/libXtst:=
+	>=xfce-base/xfconf-4.12:=
+	>=xfce-base/libxfce4ui-4.12:=[gtk3(+)]
+	>=xfce-base/libxfce4util-4.12:=
+	policykit? (
+		>=sys-auth/polkit-0.112
+		!systemd? ( sys-auth/consolekit )
+	)
+	xfce_plugins_power? ( >=xfce-base/xfce4-panel-4.12:= )"
+RDEPEND="${COMMON_DEPEND}
+	networkmanager? ( net-misc/networkmanager )"
+DEPEND="${COMMON_DEPEND}
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig
+	x11-proto/xproto"
+
+pkg_setup() {
+	if use kernel_linux; then
+		CONFIG_CHECK="~TIMER_STATS"
+		linux-info_pkg_setup
+	fi
+}
+
+src_configure() {
+	local myconf=(
+		$(use_enable policykit polkit)
+		$(use_enable networkmanager network-manager)
+		$(use_enable xfce_plugins_power xfce4panel)
+	)
+
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
The global XFCE_PLUGINS USE_EXPAND provides 3 different flags, each one used in exactly one package. This is not really a proper case for USE_EXPAND. Replace it with local flags in ~arch.