### PR TITLE
net-analyzer/icinga2: Use upstream sysconfig

### DIFF
--- a/net-analyzer/icinga2/icinga2-2.6.3.ebuild
+++ b/net-analyzer/icinga2/icinga2-2.6.3.ebuild
@@ -121,7 +121,6 @@ src_install() {
 	einstalldocs
 
 	newinitd "${FILESDIR}"/icinga2.initd icinga2
-	newconfd "${FILESDIR}"/icinga2.confd icinga2
 
 	if use mysql ; then
 		docinto schema


### PR DESCRIPTION
Upstream ships a sysconfig file that's installed to /etc/conf.d/icinga2 but the newconfd writes an incomplete version that breaks the prepare-dirs command.

Gentoo-Bug: 589930

Package-Manager: Portage-2.3.6, Repoman-2.3.1