### PR TITLE
dev-libs/libiconv: update to EAPI="6"

### DIFF
--- a/dev-libs/libiconv/libiconv-1.14-r2.ebuild
+++ b/dev-libs/libiconv/libiconv-1.14-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="4"
+EAPI="6"
 
 inherit libtool toolchain-funcs multilib-minimal
 
@@ -20,6 +20,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-no-gets.patch
+	eapply_user
 	elibtoolize
 }
 


### PR DESCRIPTION
Mostly for my own convenience; I need to apply some user patches to make
it work for mingw-w64, and that function doesn't show until EAPI 6 if I'm reading
the dev guide properly.

Package-Manager: Portage-2.3.6, Repoman-2.3.2