### PR TITLE
sys-cluster/teleport: fix src_test, restrict tests (bug 623430)

### DIFF
--- a/sys-cluster/teleport/teleport-2.2.0.ebuild
+++ b/sys-cluster/teleport/teleport-2.2.0.ebuild
@@ -21,6 +21,7 @@ fi
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE=""
+RESTRICT="test"
 
 DEPEND="
 	app-arch/zip
@@ -48,4 +49,8 @@ src_install() {
 
 	systemd_dounit "${FILESDIR}"/${PN}.service
 	systemd_install_serviced "${FILESDIR}"/${PN}.service.conf ${PN}.service
+}
+
+src_test() {
+	GOPATH="${S}" emake -C src/${EGO_PN%/*} test
 }

--- a/sys-cluster/teleport/teleport-2.2.1.ebuild
+++ b/sys-cluster/teleport/teleport-2.2.1.ebuild
@@ -21,6 +21,7 @@ fi
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE=""
+RESTRICT="test"
 
 DEPEND="
 	app-arch/zip
@@ -48,4 +49,8 @@ src_install() {
 
 	systemd_dounit "${FILESDIR}"/${PN}.service
 	systemd_install_serviced "${FILESDIR}"/${PN}.service.conf ${PN}.service
+}
+
+src_test() {
+	GOPATH="${S}" emake -C src/${EGO_PN%/*} test
 }

--- a/sys-cluster/teleport/teleport-9999.ebuild
+++ b/sys-cluster/teleport/teleport-9999.ebuild
@@ -49,3 +49,7 @@ src_install() {
 	systemd_dounit "${FILESDIR}"/${PN}.service
 	systemd_install_serviced "${FILESDIR}"/${PN}.service.conf ${PN}.service
 }
+
+src_test() {
+	GOPATH="${S}" emake -C src/${EGO_PN%/*} test
+}


### PR DESCRIPTION
src_test needs the same GOPATH as src_compile to run.  Some tests are
currently failing, so add RESTRICT=test until upstream devs can fix
tests.

Bug: https://bugs.gentoo.org/show_bug.cgi?id=623430

Package-Manager: Portage-2.3.6, Repoman-2.3.2