### PR TITLE
sys-boot/gnu-efi: Add custom-cflags flag and prevent avx instructions

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -7,6 +7,15 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Matthias Dahl <matthias.dahl@binary-island.eu> (05 Jul 2017)
+# Both are not your typical garden-variety Linux programs and are
+# rather sensitive when it comes to compiler flags, resulting in
+# black screens, hangs or crashes. The average joe should have no
+# need or even advantage to set custom compiler flags at all.
+# Example: https://bugs.gentoo.org/619628
+sys-boot/gnu-efi custom-cflags
+sys-boot/refind custom-cflags
+
 # Michał Górny <mgorny@gentoo.org> (29 Jun 2017)
 # Upstream switched to CMake and no longer provides option to build
 # static and shared libs. The flag is preserved not to break USE

--- a/sys-boot/gnu-efi/gnu-efi-3.0.6-r1.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.6-r1.ebuild
@@ -19,7 +19,7 @@ SLOT="0"
 # IA64 build is broken in setjmp code:
 # https://sourceforge.net/p/gnu-efi/bugs/9/
 KEYWORDS="-* ~amd64 ~arm ~arm64 -ia64 ~x86"
-IUSE="abi_x86_32 abi_x86_64"
+IUSE="abi_x86_32 abi_x86_64 -custom-cflags"
 
 DEPEND="sys-apps/pciutils"
 RDEPEND=""
@@ -61,8 +61,15 @@ efimake() {
 src_compile() {
 	tc-export BUILD_CC AR AS CC LD
 
-	# https://bugs.gentoo.org/607992
-	filter-mfpmath sse
+	if use custom-cflags; then
+		# https://bugs.gentoo.org/607992
+		filter-mfpmath sse
+
+		# https://bugs.gentoo.org/619628
+		append-flags $(test-flags-CC -mno-avx)
+	else
+		unset CFLAGS CPPFLAGS LDFLAGS
+	fi
 
 	if [[ ${CHOST} == x86_64* ]]; then
 		use abi_x86_32 && CHOST=i686 ABI=x86 efimake


### PR DESCRIPTION
Building gnu-efi with custom compiler flags is risky at best and should generally be avoided.

Nevertheless, if custom flags are used, we need to make sure no avx instructions are generated as those cause a non-functional gnu-efi build. This is only required for >= 3.0.5 as prior to this, "-mno-sse" was used which also implied no avx.

Fixes bug #619628.