### PR TITLE
sci-geosciences/gpsbabel: Fix Qt5's lrelease

### DIFF
--- a/sci-geosciences/gpsbabel/gpsbabel-1.5.4-r1.ebuild
+++ b/sci-geosciences/gpsbabel/gpsbabel-1.5.4-r1.ebuild
@@ -79,7 +79,7 @@ src_configure() {
 
 	if use gui; then
 		pushd "${S}/gui" > /dev/null || die
-		lrelease *.ts || die
+		$(qt5_get_bindir)/lrelease *.ts || die
 		eqmake5
 		popd > /dev/null
 	fi


### PR DESCRIPTION
My `lrelease` in the default $PATH is a wrapper provided by qtchooser.
It fails when invoked directly.

The ebuild was already half-correct because it used a full path to Qt5's
lrelease when configuring the build :).

Note that the build still fails with my Qt 5.9:
```
tef_xml.cc: In function ‘void tef_start(xg_string, const QXmlStreamAttributes*)’:
tef_xml.cc:75:59: error: call of overloaded ‘compare(const char [8], Qt::CaseSensitivity)’ is ambiguous
     if (attr.name().compare("Comment", Qt::CaseInsensitive) == 0) {
                                                           ^
tef_xml.cc:75:59: note: candidates are:
In file included from /usr/include/qt5/QtCore/qobject.h:47:0,
                 from /usr/include/qt5/QtCore/qiodevice.h:45,
                 from /usr/include/qt5/QtCore/qxmlstream.h:43,
                 from /usr/include/qt5/QtCore/QXmlStreamAttributes:1,
                 from tef_xml.cc:26:
/usr/include/qt5/QtCore/qstring.h:1583:12: note: int QStringRef::compare(const QString&, Qt::CaseSensitivity) const
 inline int QStringRef::compare(const QString &s, Qt::CaseSensitivity cs) const Q_DECL_NOTHROW
            ^
/usr/include/qt5/QtCore/qstring.h:1514:9: note: int QStringRef::compare(const QByteArray&, Qt::CaseSensitivity) const
     int compare(const QByteArray &s, Qt::CaseSensitivity cs = Qt::CaseSensitive) const
         ^
```
...but that's for another time (and for upstream, anyway).