### PR TITLE
dev-ros/rosunit remove python3 as upstream doesn't support it

### DIFF
--- a/dev-ros/actionlib/actionlib-1.11.9.ebuild
+++ b/dev-ros/actionlib/actionlib-1.11.9.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 CATKIN_HAS_MESSAGES=yes
 ROS_REPO_URI="https://github.com/ros/actionlib"
 KEYWORDS="~amd64 ~arm"
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
+PYTHON_COMPAT=( python2_7 pypy )
 CATKIN_MESSAGES_TRANSITIVE_DEPS="dev-ros/actionlib_msgs dev-ros/std_msgs"
 
 inherit ros-catkin

--- a/dev-ros/actionlib/actionlib-9999.ebuild
+++ b/dev-ros/actionlib/actionlib-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 CATKIN_HAS_MESSAGES=yes
 ROS_REPO_URI="https://github.com/ros/actionlib"
 KEYWORDS="~amd64 ~arm"
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
+PYTHON_COMPAT=( python2_7 pypy )
 CATKIN_MESSAGES_TRANSITIVE_DEPS="dev-ros/actionlib_msgs dev-ros/std_msgs"
 
 inherit ros-catkin

--- a/dev-ros/rostest/rostest-1.13.0.ebuild
+++ b/dev-ros/rostest/rostest-1.13.0.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 ROS_REPO_URI="https://github.com/ros/ros_comm"
 KEYWORDS="~amd64 ~arm"
 ROS_SUBDIR=tools/${PN}
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
+PYTHON_COMPAT=( python2_7 pypy )
 
 inherit ros-catkin
 

--- a/dev-ros/rostest/rostest-9999.ebuild
+++ b/dev-ros/rostest/rostest-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 ROS_REPO_URI="https://github.com/ros/ros_comm"
 KEYWORDS="~amd64 ~arm"
 ROS_SUBDIR=tools/${PN}
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
+PYTHON_COMPAT=( python2_7 pypy )
 
 inherit ros-catkin
 

--- a/dev-ros/rosunit/rosunit-1.14.0.ebuild
+++ b/dev-ros/rosunit/rosunit-1.14.0.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 
 ROS_REPO_URI="https://github.com/ros/ros"
 KEYWORDS="~amd64 ~arm"
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
+PYTHON_COMPAT=( python2_7 pypy )
 ROS_SUBDIR=tools/${PN}
 
 inherit ros-catkin

--- a/dev-ros/rosunit/rosunit-9999.ebuild
+++ b/dev-ros/rosunit/rosunit-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 
 ROS_REPO_URI="https://github.com/ros/ros"
 KEYWORDS="~amd64 ~arm"
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
+PYTHON_COMPAT=( python2_7 pypy )
 ROS_SUBDIR=tools/${PN}
 
 inherit ros-catkin


### PR DESCRIPTION
see https://github.com/ros/ros/issues/148