### PR TITLE
sci-electronics/systemc: Remove pkg_nofetch.

### DIFF
--- a/sci-electronics/systemc/systemc-2.3.0-r1.ebuild
+++ b/sci-electronics/systemc/systemc-2.3.0-r1.ebuild
@@ -21,12 +21,6 @@ AUTOTOOLS_IN_SOURCE_BUILD=1
 
 S="${WORKDIR}/${MY_P}"
 
-pkg_nofetch() {
-	elog "${PN} developers require end-users to accept their license agreement"
-	elog "by registering on their Web site (${HOMEPAGE})."
-	elog "Please download ${A} manually and place it in ${DISTDIR}."
-}
-
 src_prepare() {
 	# drop compiler check to enable use of CXX
 	epatch "${FILESDIR}"/${P}-config.patch

--- a/sci-electronics/systemc/systemc-2.3.1-r1.ebuild
+++ b/sci-electronics/systemc/systemc-2.3.1-r1.ebuild
@@ -21,12 +21,6 @@ AUTOTOOLS_IN_SOURCE_BUILD=1
 
 S="${WORKDIR}/${MY_P}"
 
-pkg_nofetch() {
-	elog "${PN} developers require end-users to accept their license agreement"
-	elog "by registering on their Web site (${HOMEPAGE})."
-	elog "Please download ${A} manually and place it in ${DISTDIR}."
-}
-
 src_prepare() {
 	for sfile in src/sysc/qt/md/*.s ; do
 		sed -i -e '$a \


### PR DESCRIPTION
Since we can fetch the tarballs, we no longer need to leave the function here.