### PR TITLE
dev-python/shiboken: Fix building with GCC-6

### DIFF
--- a/dev-python/shiboken/files/shiboken-1.2.2-gcc6.patch
+++ b/dev-python/shiboken/files/shiboken-1.2.2-gcc6.patch
@@ -1,0 +1,20 @@
+Bug: https://bugs.gentoo.org/619332
+PR: https://github.com/pyside/Shiboken/pull/84
+
+--- a/tests/libsample/simplefile.cpp
++++ b/tests/libsample/simplefile.cpp
+@@ -90,13 +90,13 @@ bool
+ SimpleFile::exists() const
+ {
+     std::ifstream ifile(p->m_filename);
+-    return ifile;
++    return static_cast<bool>(ifile);
+ }
+
+ bool
+ SimpleFile::exists(const char* filename)
+ {
+     std::ifstream ifile(filename);
+-    return ifile;
++    return static_cast<bool>(ifile);
+ }

--- a/dev-python/shiboken/shiboken-1.2.2.ebuild
+++ b/dev-python/shiboken/shiboken-1.2.2.ebuild
@@ -34,6 +34,7 @@ DEPEND="${RDEPEND}
 DOCS=( AUTHORS ChangeLog )
 PATCHES=(
 	"${FILESDIR}/${PV}-Fix-tests-with-Python-3.patch"
+	"${FILESDIR}/${P}-gcc6.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=619332
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Upstream PR: https://github.com/pyside/Shiboken/pull/84