### PR TITLE
games-sports/trigger: Fix building with GCC-6

### DIFF
--- a/games-sports/trigger/files/trigger-0.6.1-gcc6.patch
+++ b/games-sports/trigger/files/trigger-0.6.1-gcc6.patch
@@ -1,0 +1,39 @@
+Bug: https://bugs.gentoo.org/617886
+
+--- a/src/pengine/tinyxmlparser.cpp
++++ b/src/pengine/tinyxmlparser.cpp
+@@ -326,14 +326,14 @@
+   if ( !p || !*p )
+   {
+     SetError( TIXML_ERROR_DOCUMENT_EMPTY );
+-    return false;
++    return NULL;
+   }
+ 
+     p = SkipWhiteSpace( p );
+   if ( !p )
+   {
+     SetError( TIXML_ERROR_DOCUMENT_EMPTY );
+-    return false;
++    return NULL;
+   }
+ 
+   while ( p && *p )
+@@ -541,7 +541,7 @@
+   if ( !p || !*p || *p != '<' )
+   {
+     if ( document ) document->SetError( TIXML_ERROR_PARSING_ELEMENT );
+-    return false;
++    return NULL;
+   }
+ 
+   p = SkipWhiteSpace( p+1 );
+@@ -551,7 +551,7 @@
+   if ( !p || !*p )
+   {
+     if ( document )  document->SetError( TIXML_ERROR_FAILED_TO_READ_ELEMENT_NAME );
+-    return false;
++    return NULL;
+   }
+ 
+     TIXML_STRING endTag ("</");

--- a/games-sports/trigger/trigger-0.6.1-r1.ebuild
+++ b/games-sports/trigger/trigger-0.6.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit eutils
 MY_PN=${PN}-rally
 MY_P=${MY_PN}-${PV}
 DESCRIPTION="Free OpenGL rally car racing game"
-HOMEPAGE="http://www.positro.net/trigger/"
+HOMEPAGE="http://trigger-rally.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${MY_PN}/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
@@ -28,6 +28,8 @@ DEPEND="${RDEPEND}
 	dev-util/ftjam"
 
 S=${WORKDIR}/${MY_P}
+
+PATCHES=( "${FILESDIR}"/${P}-gcc6.patch )
 
 pkg_setup() {
 	# Otherwise build fails with:


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=617886
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Upstream source has since been refactored.