### PR TITLE
app-i18n/fcitx: patch POSIX-incompliant shell usage

### DIFF
--- a/app-i18n/fcitx/fcitx-4.2.9.1.ebuild
+++ b/app-i18n/fcitx/fcitx-4.2.9.1.ebuild
@@ -87,6 +87,9 @@ src_prepare() {
 		-e "/find_package(XkbFile REQUIRED)/a\\    endif(ENABLE_X11)" \
 		-i CMakeLists.txt
 
+	# https://github.com/fcitx/fcitx/issues/342
+	find . -name '*.sh' -exec sed 's:^#!/bin/sh$:#!/bin/bash:' -i {} \+
+
 	cmake-utils_src_prepare
 	xdg_environment_reset
 }

--- a/app-i18n/fcitx/fcitx-9999.ebuild
+++ b/app-i18n/fcitx/fcitx-9999.ebuild
@@ -82,6 +82,9 @@ src_prepare() {
 		-e "/find_package(XkbFile REQUIRED)/a\\    endif(ENABLE_X11)" \
 		-i CMakeLists.txt
 
+	# https://github.com/fcitx/fcitx/issues/342
+	find . -name '*.sh' -exec sed 's:^#!/bin/sh$:#!/bin/bash:' -i {} \+
+
 	cmake-utils_src_prepare
 	xdg_environment_reset
 }


### PR DESCRIPTION
https://github.com/fcitx/fcitx/issues/342

Upstream hasn't made a move within 14 days, so I think it's fair to patch it here in the meantime. Plus, fcitx-4.2.9.1 will need fixing anyway, even if they fix it in master. (The fix is also forwards-compatible)

This breaks builds when using e.g. `app-shells/dash` as `/bin/sh`. With the commit included it works for me.