### PR TITLE
sys-apps/fwupd: fix dependencies, use xdg-utils to fix sandbox violation

### DIFF
--- a/sys-apps/fwupd/fwupd-0.9.5-r1.ebuild
+++ b/sys-apps/fwupd/fwupd-0.9.5-r1.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python3_4 python3_5 python3_6 )
+
+inherit meson python-single-r1 xdg-utils
+
+DESCRIPTION="Aims to make updating firmware on Linux automatic, safe and reliable"
+HOMEPAGE="http://www.fwupd.org"
+SRC_URI="https://github.com/hughsie/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="colorhug dell doc elf +man systemd uefi uefi_labels"
+REQUIRED_USE="uefi_labels? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	app-crypt/gpgme
+	dev-db/sqlite
+	>=dev-libs/appstream-glib-0.6.13[introspection]
+	>=dev-libs/glib-2.45.8:2
+	dev-libs/libgpg-error
+	dev-libs/libgudev
+	>=dev-libs/libgusb-0.2.9[introspection]
+	>=net-libs/libsoup-2.51.92:2.4
+	>=sys-auth/polkit-0.103
+	colorhug? ( >=x11-misc/colord-1.2.12:0= )
+	dell? (
+		sys-libs/efivar
+		>=sys-libs/libsmbios-2.3.0
+	)
+	elf? ( virtual/libelf:0= )
+	systemd? ( >=sys-apps/systemd-231 )
+	!systemd? ( >=sys-auth/consolekit-1.0.0 )
+	uefi? ( >=sys-apps/fwupdate-5 )
+	uefi_labels? (
+		${PYTHON_DEPS}
+		dev-python/pycairo[${PYTHON_USEDEP}]
+		dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]
+		dev-python/pillow[${PYTHON_USEDEP}]
+		x11-libs/pango
+		x11-libs/cairo
+		media-libs/freetype
+		media-libs/fontconfig
+		media-fonts/dejavu
+		media-fonts/source-han-sans
+	)
+"
+DEPEND="
+	${RDEPEND}
+	app-arch/gcab
+	app-arch/libarchive
+	virtual/pkgconfig
+	doc? ( dev-util/gtk-doc )
+	man? ( app-text/docbook-sgml-utils )
+"
+
+REQUIRED_USE="dell? ( uefi )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.9-polkit_its_files.patch"
+)
+
+src_configure() {
+	xdg_environment_reset
+	local emesonargs=(
+		-Denable-colorhug="$(usex colorhug true false)"
+		-Denable-consolekit="$(usex systemd false true)"
+		-Denable-dell="$(usex dell true false)"
+		-Denable-doc="$(usex doc true false)"
+		-Denable-man="$(usex man true false)"
+		-Denable-libelf="$(usex elf true false)"
+		-Denable-systemd="$(usex systemd true false)"
+		# requires libtbtfwu which is not packaged yet
+		-Denable-thunderbolt=false
+		-Denable-uefi="$(usex uefi true false)"
+		-Denable-uefi-labels="$(usex uefi_labels true false)"
+	)
+	meson_src_configure
+}

--- a/sys-apps/fwupd/metadata.xml
+++ b/sys-apps/fwupd/metadata.xml
@@ -13,6 +13,7 @@
       <pkg>dev-libs/libelf</pkg> package.</flag>
     <flag name="man">Build and install man pages</flag>
     <flag name="uefi">Enable UEFI support</flag>
+    <flag name="uefi_labels">Enable UEFI labels support</flag>
   </use>
   <upstream>
     <remote-id type="github">hughsie/fwupd</remote-id>


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=619618
https://bugs.gentoo.org/show_bug.cgi?id=622180
https://bugs.gentoo.org/show_bug.cgi?id=619704
https://bugs.gentoo.org/show_bug.cgi?id=621760