### PR TITLE
media-sound/jack2 fix typo in metadata

### DIFF
--- a/media-sound/jack2/metadata.xml
+++ b/media-sound/jack2/metadata.xml
@@ -9,7 +9,7 @@
     <flag name="pam">Add basic realtime configuration via <pkg>sys-auth/realtime-base</pkg></flag>
     <flag name="celt">Support CELT low delay audio codec (<pkg>media-libs/celt</pkg>)</flag>
     <flag name="opus">Support <pkg>media-libs/opus</pkg></flag>
-    <flag name="classic">Enable building of jackd"</flag>
+    <flag name="classic">Enable building of jackd</flag>
   </use>
   <upstream>
     <remote-id type="github">jackaudio/jack2</remote-id>


### PR DESCRIPTION
Small typo fix in media-sound/jack2's metadata