### PR TITLE
dev-libs/sway: include stdint to be compatible with musl

### DIFF
--- a/dev-libs/sway/files/sway-0.13.0-disable-Wunused-result-diagnostic.patch
+++ b/dev-libs/sway/files/sway-0.13.0-disable-Wunused-result-diagnostic.patch
@@ -1,0 +1,22 @@
+From c8370c96991cb8af647e46e5067b6c6641eacec4 Mon Sep 17 00:00:00 2001
+From: Hummer12007 <hilobakho@gmail.com>
+Date: Mon, 3 Jul 2017 23:30:39 +0300
+Subject: [PATCH] Disable -Wunused-result diagnostic
+
+It caused unpredictable build failures with different build environments
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0257a99f..a4bf351b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,6 +10,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-parameter")
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result")
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+ if (CMAKE_COMPILER_IS_GNUCC)
+     if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0)

--- a/dev-libs/sway/files/sway-0.13.0-musl-stdint.patch
+++ b/dev-libs/sway/files/sway-0.13.0-musl-stdint.patch
@@ -1,0 +1,12 @@
+diff --git a/wayland/pango.c b/wayland/pango.c
+index 702ab15c..f9eec98c 100644
+--- a/wayland/pango.c
++++ b/wayland/pango.c
+@@ -5,6 +5,7 @@
+ #include <string.h>
+ #include <stdio.h>
+ #include <stdbool.h>
++#include <stdint.h>
+ #include "log.h"
+ 
+ PangoLayout *get_pango_layout(cairo_t *cairo, const char *font, const char *text,

--- a/dev-libs/sway/files/sway-0.13.0-policy-fixes.patch
+++ b/dev-libs/sway/files/sway-0.13.0-policy-fixes.patch
@@ -1,0 +1,76 @@
+From 4f905ecb9636561d91bc9b33919cd390bdcbc432 Mon Sep 17 00:00:00 2001
+From: Mykyta Holubakha <hilobakho@gmail.com>
+Date: Sat, 1 Jul 2017 20:21:12 +0300
+Subject: [PATCH 1/2] permit.c: check for NULL pointer dereference
+
+---
+ sway/commands/permit.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/sway/commands/permit.c b/sway/commands/permit.c
+index 66fa4e2a..7a5e06f7 100644
+--- a/sway/commands/permit.c
++++ b/sway/commands/permit.c
+@@ -65,11 +65,11 @@ struct cmd_results *cmd_permit(int argc, char **argv) {
+ 	}
+ 
+ 	struct feature_policy *policy = get_feature_policy(program);
+-	if (assign_perms) {
++	if (policy && assign_perms) {
+ 		policy->features |= get_features(argc, argv, &error);
++		sway_log(L_DEBUG, "Permissions granted to %s for features %d",
++				policy->program, policy->features);
+ 	}
+-	sway_log(L_DEBUG, "Permissions granted to %s for features %d",
+-			policy->program, policy->features);
+ 
+ 	free(program);
+ 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+
+From 7d8a84b58790454308bcac114d3f28a09c28928c Mon Sep 17 00:00:00 2001
+From: Mykyta Holubakha <hilobakho@gmail.com>
+Date: Sat, 1 Jul 2017 20:30:38 +0300
+Subject: [PATCH 2/2] Do not add empty policies
+
+Policy allocation failure is non-fatal
+---
+ sway/commands.c | 6 +++---
+ sway/security.c | 6 +++---
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/sway/commands.c b/sway/commands.c
+index 14be656a..d55d9a96 100644
+--- a/sway/commands.c
++++ b/sway/commands.c
+@@ -608,10 +608,10 @@ struct cmd_results *config_commands_command(char *exec) {
+ 	}
+ 	if (!policy) {
+ 		policy = alloc_command_policy(cmd);
+-		if (!policy) {
+-			sway_abort("Unable to allocate security policy");
++		sway_assert(policy, "Unable to allocate security policy");
++		if (policy) {
++			list_add(config->command_policies, policy);
+ 		}
+-		list_add(config->command_policies, policy);
+ 	}
+ 	policy->context = context;
+ 
+diff --git a/sway/security.c b/sway/security.c
+index 92de06c1..fcd70f9d 100644
+--- a/sway/security.c
++++ b/sway/security.c
+@@ -152,10 +152,10 @@ struct feature_policy *get_feature_policy(const char *name) {
+ 	}
+ 	if (!policy) {
+ 		policy = alloc_feature_policy(name);
+-		if (!policy) {
+-			sway_abort("Unable to allocate security policy");
++		sway_assert(policy, "Unable to allocate security policy");
++		if (policy) {
++			list_add(config->feature_policies, policy);
+ 		}
+-		list_add(config->feature_policies, policy);
+ 	}
+ 	return policy;
+ }

--- a/dev-libs/sway/sway-0.13.0-r1.ebuild
+++ b/dev-libs/sway/sway-0.13.0-r1.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit eutils cmake-utils
+
+DESCRIPTION="i3-compatible Wayland window manager"
+HOMEPAGE="http://swaywm.org/"
+
+SRC_URI="https://github.com/SirCmpwn/sway/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+swaybg +swaybar +swaymsg swaygrab swaylock +gdk-pixbuf zsh-completion wallpapers systemd"
+
+RDEPEND=">=dev-libs/wlc-0.0.8[systemd=]
+	dev-libs/json-c
+	dev-libs/libpcre
+	dev-libs/libinput
+	x11-libs/libxkbcommon
+	dev-libs/wayland
+	sys-libs/libcap
+	x11-libs/pango
+	x11-libs/cairo
+	swaylock? ( virtual/pam )
+	gdk-pixbuf? ( x11-libs/gdk-pixbuf[jpeg] )"
+
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	app-text/asciidoc"
+PATCHES=(
+	"${FILESDIR}/${PN}-0.13.0-disable-Wunused-result-diagnostic.patch"
+	"${FILESDIR}/${PN}-0.13.0-musl-stdint.patch"
+	"${FILESDIR}/${PN}-0.13.0-policy-fixes.patch"
+)
+
+src_prepare() {
+	cmake-utils_src_prepare
+
+	# remove bad CFLAGS that upstream is trying to add
+	sed -i -e '/FLAGS.*-Werror/d' CMakeLists.txt || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-Denable-swaybar=$(usex swaybar)
+		-Denable-swaybg=$(usex swaybg)
+		-Denable-swaygrab=$(usex swaygrab)
+		-Denable-swaylock=$(usex swaylock)
+		-Denable-swaymsg=$(usex swaymsg)
+
+		-Ddefault-wallpaper=$(usex wallpapers)
+
+		-Denable-gdk-pixbuf=$(usex gdk-pixbuf)
+		-Dzsh-completions=$(usex zsh-completion)
+
+		-DCMAKE_INSTALL_SYSCONFDIR="/etc"
+		-DVERSION="${PV}"
+	)
+
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+
+	use !systemd && fperms u+s /usr/bin/sway
+}
+
+pkg_postinst() {
+	if use swaygrab
+	then
+		optfeature "swaygrab screenshot support" media-gfx/imagemagick[png]
+		optfeature "swaygrab video capture support" virtual/ffmpeg
+	fi
+	optfeature "X11 applications support" dev-libs/wlc[xwayland] x11-base/xorg-server[wayland]
+}


### PR DESCRIPTION
See SirCmpwn/sway@4bf8b6b43b9640700eadd7c7d1a432dd91ef473d

Package-Manager: Portage-2.3.6, Repoman-2.3.2