### PR TITLE
dev-lang/luajit: add static-libs to IUSE, update EAPI=6

### DIFF
--- a/dev-lang/luajit/luajit-2.0.5-r1.ebuild
+++ b/dev-lang/luajit/luajit-2.0.5-r1.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit pax-utils toolchain-funcs versionator
+
+MY_PV="$(get_version_component_range 1-3)"
+MY_P="LuaJIT-${MY_PV}"
+if [[ -n $(get_version_component_range 4) ]]; then
+	HOTFIX="v${PV}"
+	HOTFIX="${HOTFIX/_p/_hotfix}.patch"
+fi
+
+DESCRIPTION="Just-In-Time Compiler for the Lua programming language"
+HOMEPAGE="http://luajit.org/"
+SRC_URI="http://luajit.org/download/${MY_P}.tar.gz
+	${HOTFIX:+http://luajit.org/download/${HOTFIX}}"
+
+LICENSE="MIT"
+# this should probably be pkgmoved to 2.0 for sake of consistency.
+SLOT="2"
+KEYWORDS="~amd64 ~arm ~ppc ~x86 ~amd64-linux ~x86-linux"
+IUSE="lua52compat static-libs"
+
+S="${WORKDIR}/${MY_P}"
+
+src_prepare(){
+	if [[ -n ${HOTFIX} ]]; then
+		eapply "${DISTDIR}/${HOTFIX}"
+	fi
+	default
+}
+
+_emake() {
+	emake \
+		Q= \
+		PREFIX="${EPREFIX}/usr" \
+		MULTILIB="$(get_libdir)" \
+		DESTDIR="${D}" \
+		HOST_CC="$(tc-getBUILD_CC)" \
+		STATIC_CC="$(tc-getCC)" \
+		DYNAMIC_CC="$(tc-getCC) -fPIC" \
+		TARGET_LD="$(tc-getCC)" \
+		TARGET_AR="$(tc-getAR) rcus" \
+		BUILDMODE="$(usex static-libs mixed dynamic)" \
+		TARGET_STRIP="true" \
+		INSTALL_LIB="${ED%/}/usr/$(get_libdir)" \
+		"$@"
+}
+
+src_compile() {
+	_emake XCFLAGS="$(usex lua52compat "-DLUAJIT_ENABLE_LUA52COMPAT" "")"
+}
+
+src_install(){
+	_emake install
+
+	pax-mark m "${ED}usr/bin/luajit-${MY_PV}"
+
+	HTML_DOCS="doc/." einstalldocs
+}


### PR DESCRIPTION
Mostly to help debug an issue with dev-lua/mpack[luajit] on elibc_musl.

For some reason it is attempting to link staticly, so disabling static libs programatically
is a bit less hackish for now than moving the library or rm'ing it.

Package-Manager: Portage-2.3.6, Repoman-2.3.2