### PR TITLE
x11-libs/xcb-util-xrm: fix build on musl

### DIFF
--- a/x11-libs/xcb-util-xrm/xcb-util-xrm-1.2.ebuild
+++ b/x11-libs/xcb-util-xrm/xcb-util-xrm-1.2.ebuild
@@ -13,12 +13,16 @@ HOMEPAGE="http://xcb.freedesktop.org/"
 SRC_URI="https://github.com/Airblader/${PN}/releases/download/v${PV}/${P}.tar.bz2"
 
 KEYWORDS="amd64 ~arm x86"
-IUSE="test"
+IUSE="elibc_musl test"
 
-RDEPEND=">=x11-libs/libxcb-1.9.1[${MULTILIB_USEDEP}]
-	x11-libs/xcb-util[${MULTILIB_USEDEP}]"
+RDEPEND="
+	elibc_musl? ( sys-libs/queue )
+	>=x11-libs/libxcb-1.9.1[${MULTILIB_USEDEP}]
+	x11-libs/xcb-util[${MULTILIB_USEDEP}]
+"
 DEPEND="${RDEPEND}
-	test? ( x11-libs/libX11[${MULTILIB_USEDEP}] )"
+	test? ( x11-libs/libX11[${MULTILIB_USEDEP}] )
+"
 
 src_configure() {
 	xorg-2_src_configure


### PR DESCRIPTION
musl does not provide sys/queue.h, so adding sys-libs/queue as a dependency
on elibc_musl.

Since sys-libs/queue only exists in the musl overlay I thought it apropos to not
explicitly dep on ::musl. Will fix if this is wrong. Also should I revbump?
Package-Manager: Portage-2.3.6, Repoman-2.3.2