### PR TITLE
dev-python/httplib2: Use system certificate store (bug #624476)

### DIFF
--- a/dev-python/httplib2/files/httplib2-use-system-cacerts.patch
+++ b/dev-python/httplib2/files/httplib2-use-system-cacerts.patch
@@ -1,0 +1,59 @@
+From 437b5bba5dac2e43815a900dbc6ee093c675bb4c Mon Sep 17 00:00:00 2001
+From: Marc Deslauriers <marc.deslauriers@canonical.com>
+Date: Thu, 8 Oct 2015 12:15:44 -0700
+Subject: Use system ca certificates, not the bundled ones
+
+Forwarded: not-needed
+Bug-Ubuntu: https://launchpad.net/bugs/882027
+
+Patch-Name: use_system_cacerts.patch
+---
+ python2/httplib2/__init__.py | 5 ++---
+ python3/httplib2/__init__.py | 5 ++---
+ setup.py                     | 1 -
+ 3 files changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/python2/httplib2/__init__.py b/python2/httplib2/__init__.py
+index 6fa3cc6..e996d01 100644
+--- a/python2/httplib2/__init__.py
++++ b/python2/httplib2/__init__.py
+@@ -190,9 +190,8 @@ try:
+     import ca_certs_locater
+     CA_CERTS = ca_certs_locater.get()
+ except ImportError:
+-    # Default CA certificates file bundled with httplib2.
+-    CA_CERTS = os.path.join(
+-        os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt")
++    # Use system CA certificates
++    CA_CERTS = "/etc/ssl/certs/ca-certificates.crt"
+ 
+ # Which headers are hop-by-hop headers by default
+ HOP_BY_HOP = ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailers', 'transfer-encoding', 'upgrade']
+diff --git a/python3/httplib2/__init__.py b/python3/httplib2/__init__.py
+index 3ce019e..8383cc4 100644
+--- a/python3/httplib2/__init__.py
++++ b/python3/httplib2/__init__.py
+@@ -123,9 +123,8 @@ DEFAULT_MAX_REDIRECTS = 5
+ # Which headers are hop-by-hop headers by default
+ HOP_BY_HOP = ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailers', 'transfer-encoding', 'upgrade']
+ 
+-# Default CA certificates file bundled with httplib2.
+-CA_CERTS = os.path.join(
+-        os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt")
++# Use system CA certificates
++CA_CERTS = "/etc/ssl/certs/ca-certificates.crt"
+ 
+ def _get_end2end_headers(response):
+     hopbyhop = list(HOP_BY_HOP)
+diff --git a/setup.py b/setup.py
+index fb00ed2..2c31f44 100755
+--- a/setup.py
++++ b/setup.py
+@@ -61,7 +61,6 @@ A comprehensive HTTP client library, ``httplib2`` supports many features left ou
+         """,
+         package_dir=pkgdir,
+         packages=['httplib2'],
+-        package_data={'httplib2': ['*.txt']},
+         classifiers=[
+         'Development Status :: 4 - Beta',
+         'Environment :: Web Environment',

--- a/dev-python/httplib2/httplib2-0.10.3-r1.ebuild
+++ b/dev-python/httplib2/httplib2-0.10.3-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="A comprehensive HTTP client library"
+HOMEPAGE="https://pypi.python.org/pypi/httplib2 https://github.com/jcgregorio/httplib2"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
+IUSE=""
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+RDEPEND="app-misc/ca-certificates"
+
+# tests connect to random remote sites
+RESTRICT="test"
+
+PATCHES=( "${FILESDIR}"/${PN}-use-system-cacerts.patch )
+
+python_prepare_all() {
+	chmod o+r */*egg*/* || die
+	distutils-r1_python_prepare_all
+}
+
+python_test() {
+	if [[ ${EPYTHON} == python2.7 ]] ; then
+		cd python2 || die
+	else
+		cd python3 || die
+	fi
+
+	"${PYTHON}" httplib2test.py || die
+}


### PR DESCRIPTION
Use system certificate store.

Gentoo-Bug: https://bugs.gentoo.org/624476