### PR TITLE
kde-apps/kdenlive Bumped mlt dependency version

### DIFF
--- a/kde-apps/kdenlive/kdenlive-17.04.2.ebuild
+++ b/kde-apps/kdenlive/kdenlive-17.04.2.ebuild
@@ -45,7 +45,7 @@ RDEPEND="
 	$(add_qt_dep qtsvg)
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtxml)
-	>=media-libs/mlt-6.0.0[ffmpeg,kdenlive,melt,qt5,sdl,xml]
+	>=media-libs/mlt-6.4.0[ffmpeg,kdenlive,melt,qt5,sdl,xml]
 	virtual/ffmpeg[encode,sdl,X]
 	virtual/opengl
 	freesound? ( $(add_qt_dep qtwebkit) )


### PR DESCRIPTION
I get the following error when building kdenlive with an older version of MLT 
`CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:138 (message):
  Could NOT find MLT: Found unsuitable version "6.2.0", but required is at
  least "6.4.0" (found /usr/lib64/libmlt.so)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:376 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindMLT.cmake:59 (find_package_handle_standard_args)
  CMakeLists.txt:105 (find_package)
`

bumping to >=6.4.0 fixes the issue and pulls in MLT before kdenlive