### PR TITLE
kde-apps/kgpg: Raise app-crypt/gpgme minimum version to 1.4.3

### DIFF
--- a/kde-apps/kgpg/kgpg-17.04.2.ebuild
+++ b/kde-apps/kgpg/kgpg-17.04.2.ebuild
@@ -41,7 +41,7 @@ COMMON_DEPEND="
 	$(add_qt_dep qtwidgets)
 "
 DEPEND="${COMMON_DEPEND}
-	app-crypt/gpgme
+	>=app-crypt/gpgme-1.4.3
 "
 RDEPEND="${COMMON_DEPEND}
 	app-crypt/gnupg


### PR DESCRIPTION
`-- Found gpgme-config at /usr/bin/gpgme-config
-- The installed version of gpgme is too old: 1.3.2 (required: >= 1.4.3)
-- No usable gpgme flavours found.
CMake Error at cmake/FindGpgme.cmake:367 (message):
  Did not find GPGME
Call Stack (most recent call first):
  CMakeLists.txt:59 (find_package)
`

Set minimum version for gpgme for people who haven't pruned their packages in the last decade :wink: