### PR TITLE
dev-python/matplotlib: Fix wrap_setup function

### DIFF
--- a/dev-python/matplotlib/matplotlib-2.0.2.ebuild
+++ b/dev-python/matplotlib/matplotlib-2.0.2.ebuild
@@ -209,6 +209,7 @@ python_configure() {
 wrap_setup() {
 	local -x MPLSETUPCFG=${BUILD_DIR}/setup.cfg
 	unset DISPLAY
+	"$@"
 }
 
 python_compile() {


### PR DESCRIPTION
Wrapper for python_compile() function only prepared environment for
the compile call, but never executed it.

Bug: https://bugs.gentoo.org/show_bug.cgi?id=624554