### PR TITLE
dev-qt/qtwebengine: := dep on app-arch/snappy

### DIFF
--- a/dev-libs/leveldb/leveldb-1.18-r1.ebuild
+++ b/dev-libs/leveldb/leveldb-1.18-r1.ebuild
@@ -16,7 +16,7 @@ IUSE="+snappy static-libs +tcmalloc kernel_FreeBSD"
 
 DEPEND="tcmalloc? ( dev-util/google-perftools )
 	snappy? (
-		app-arch/snappy
+		app-arch/snappy:=
 		static-libs? ( app-arch/snappy[static-libs] )
 	)"
 RDEPEND="${DEPEND}"

--- a/dev-qt/qtwebengine/qtwebengine-5.6.2.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.6.2.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE="bindist geolocation pax_kernel +system-ffmpeg +system-icu widgets"
 
 RDEPEND="
-	app-arch/snappy
+	app-arch/snappy:=
 	dev-libs/glib:2
 	dev-libs/nspr
 	dev-libs/nss

--- a/dev-qt/qtwebengine/qtwebengine-5.7.1-r1.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.7.1-r1.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE="alsa bindist geolocation pax_kernel pulseaudio +system-ffmpeg +system-icu widgets"
 
 RDEPEND="
-	app-arch/snappy
+	app-arch/snappy:=
 	dev-libs/glib:2
 	dev-libs/nspr
 	dev-libs/nss


### PR DESCRIPTION
libsnappy.so.1.1.5: cannot open shared object file: No such file or directory