### PR TITLE
 media-sound/vorbis-tools: fix security bug 559170

### DIFF
--- a/media-sound/vorbis-tools/files/vorbis-tools-1.4.0-aiff-buffer-overflow.patch
+++ b/media-sound/vorbis-tools/files/vorbis-tools-1.4.0-aiff-buffer-overflow.patch
@@ -1,0 +1,31 @@
+Patch taken from: 
+https://trac.xiph.org/attachment/ticket/2212/0001-oggenc-Fix-large-alloca-on-bad-AIFF-input.patch
+To fix bug report:
+http://www.openwall.com/lists/oss-security/2015/08/29/1
+    https://bugs.gentoo.org/show_bug.cgi?id=559170
+--- oggenc/audio.c
++++ oggenc/audio.c
+@@ -245,8 +245,8 @@
+ int aiff_open(FILE *in, oe_enc_opt *opt, unsigned char *buf, int buflen)
+ {
+     int aifc; /* AIFC or AIFF? */
+-    unsigned int len;
+-    unsigned char *buffer;
++    unsigned int len,readlen;
++    unsigned char buffer[22];
+     unsigned char buf2[8];
+     aiff_fmt format;
+     aifffile *aiff = malloc(sizeof(aifffile));
+@@ -269,9 +269,9 @@
+         return 0; /* Weird common chunk */
+     }
+ 
+-    buffer = alloca(len);
+-
+-    if(fread(buffer,1,len,in) < len)
++    readlen = len < sizeof(buffer) ? len : sizeof(buffer);
++    if(fread(buffer,1,readlen,in) < readlen ||
++        (len > readlen && !seek_forward(in, len-readlen)))
+     {
+         fprintf(stderr, _("Warning: Unexpected EOF in reading AIFF header\n"));
+         return 0;

--- a/media-sound/vorbis-tools/vorbis-tools-1.4.0-r3.ebuild
+++ b/media-sound/vorbis-tools/vorbis-tools-1.4.0-r3.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+inherit autotools eutils
+
+DESCRIPTION="tools for using the Ogg Vorbis sound file format"
+HOMEPAGE="http://www.vorbis.com"
+SRC_URI="http://downloads.xiph.org/releases/vorbis/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+IUSE="flac kate nls +ogg123 speex"
+
+RDEPEND=">=media-libs/libvorbis-1.3.0
+	flac? ( media-libs/flac )
+	kate? ( media-libs/libkate )
+	ogg123? (
+		>=media-libs/libao-1.0.0
+		net-misc/curl
+	)
+	speex? ( media-libs/speex )"
+DEPEND="${RDEPEND}
+	nls? ( sys-devel/gettext )
+	virtual/pkgconfig"
+
+DOCS="AUTHORS CHANGES README"
+
+src_prepare() {
+	epatch "${FILESDIR}"/${P}-underlinking.patch
+	epatch "${FILESDIR}"/${P}-format-security.patch
+	epatch "${FILESDIR}"/${P}-aiff-buffer-overflow.patch
+	sed -i -e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' configure.ac || die #515220
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable nls) \
+		$(use_enable ogg123) \
+		$(use_with flac) \
+		$(use_with speex) \
+		$(use_with kate)
+}


### PR DESCRIPTION
Bug:
https://bugs.gentoo.org/show_bug.cgi?id=559170

Added security patch from: 
https://trac.xiph.org/attachment/ticket/2212/0001-oggenc-Fix-large-alloca-on-bad-AIFF-input.patch


Repoman 2.3.1 (portage-2.3.6)
