### PR TITLE
media-sound/pasystray: add ~arm keyword, #624812

### DIFF
--- a/media-sound/pasystray/pasystray-0.6.0-r2.ebuild
+++ b/media-sound/pasystray/pasystray-0.6.0-r2.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://github.com/christophgysin/${PN}/archive/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm ~x86"
 IUSE="libnotify zeroconf"
 
 RDEPEND="


### PR DESCRIPTION
Add ~arm keyword per request in: #624812
Compiling/working report thanks to: Conrad Kostecki

Gentoo-Bug: 624812