### PR TITLE
media-tv/mythtv: Fix building with GCC-6

### DIFF
--- a/media-tv/mythtv/files/mythtv-gcc6.patch
+++ b/media-tv/mythtv/files/mythtv-gcc6.patch
@@ -1,0 +1,12 @@
+Bug: https://bugs.gentoo.org/621060
+Commit: https://code.mythtv.org/trac/changeset/28b7db2ed0cd165388f0bc396786e4b17f6c5774/mythtv
+
+--- mythtv/libs/libmythtv/visualisations/videovisualcircles.cpp
++++ mythtv/libs/libmythtv/visualisations/videovisualcircles.cpp
+@@ -24,5 +24,5 @@
+     for (int i = 0; i < count; i++, rad += m_range, red += incr, green -= incr)
+     {
+-        double mag = abs((m_magnitudes[i] + m_magnitudes[i + count]) / 2.0);
++        double mag = qAbs((m_magnitudes[i] + m_magnitudes[i + count]) / 2.0);
+         if (mag > 1.0)
+         {

--- a/media-tv/mythtv/mythtv-0.27.6_p20160318-r1.ebuild
+++ b/media-tv/mythtv/mythtv-0.27.6_p20160318-r1.ebuild
@@ -159,6 +159,7 @@ src_prepare() {
 
 	epatch "${FILESDIR}/libdir-27.patch"
 	epatch "${FILESDIR}/${PN}-0.27.6-libvpx-1.5.0.patch"
+	epatch "${FILESDIR}/${PN}-gcc6.patch"
 
 	epatch_user
 }

--- a/media-tv/mythtv/mythtv-0.28-r1.ebuild
+++ b/media-tv/mythtv/mythtv-0.28-r1.ebuild
@@ -159,6 +159,7 @@ src_prepare() {
 	echo "setting.extra -= -ldconfig" >> "${S}"/programs/mythfrontend/mythfrontend.pro
 
 #	epatch "${FILESDIR}/libdir-27.patch"
+	epatch "${FILESDIR}/${PN}-gcc6.patch"
 
 	epatch_user
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=621060
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Based on upstream commit from https://code.mythtv.org/trac/changeset/28b7db2ed0cd165388f0bc396786e4b17f6c5774/mythtv