### PR TITLE
x11-misc/lightdm-gtk-greeter: Fix building with GCC-6

### DIFF
--- a/x11-misc/lightdm-gtk-greeter/files/lightdm-gtk-greeter-2.0.1-gcc6.patch
+++ b/x11-misc/lightdm-gtk-greeter/files/lightdm-gtk-greeter-2.0.1-gcc6.patch
@@ -1,0 +1,84 @@
+Bug: https://bugs.gentoo.org/show_bug.cgi?id=619782
+Upstream commits: http://bazaar.launchpad.net/~lightdm-gtk-greeter-team/lightdm-gtk-greeter/trunk/revision/349
+                  http://bazaar.launchpad.net/~lightdm-gtk-greeter-team/lightdm-gtk-greeter/trunk/revision/350
+
+--- a/src/lightdm-gtk-greeter.c
++++ b/src/lightdm-gtk-greeter.c
+@@ -677,6 +677,9 @@
+ 
+ /* Clock */
+ 
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
++
+ static gboolean
+ clock_timeout_thread (void)
+ {
+@@ -697,6 +700,8 @@
+     return TRUE;
+ }
+ 
++#pragma GCC diagnostic pop
++
+ /* Message label */
+ 
+ static gboolean
+@@ -1932,11 +1937,11 @@
+     {
+         gtk_widget_show (GTK_WIDGET (username_entry));
+         gtk_widget_show (GTK_WIDGET (cancel_button));
+-        lightdm_greeter_authenticate (greeter, NULL);
++        lightdm_greeter_authenticate (greeter, NULL, NULL);
+     }
+     else if (g_strcmp0 (username, "*guest") == 0)
+     {
+-        lightdm_greeter_authenticate_as_guest (greeter);
++        lightdm_greeter_authenticate_as_guest (greeter, NULL);
+     }
+     else
+     {
+@@ -1956,7 +1961,7 @@
+             set_language (NULL);
+         }
+ 
+-        lightdm_greeter_authenticate (greeter, username);
++        lightdm_greeter_authenticate (greeter, username, NULL);
+     }
+ }
+ 
+@@ -1978,7 +1983,7 @@
+     if (lightdm_greeter_get_in_authentication (greeter))
+     {
+         cancelling = TRUE;
+-        lightdm_greeter_cancel_authentication (greeter);
++        lightdm_greeter_cancel_authentication (greeter, NULL);
+         set_message_label (LIGHTDM_MESSAGE_TYPE_INFO, NULL);
+     }
+ 
+@@ -2012,7 +2017,7 @@
+ 
+     language = get_language ();
+     if (language)
+-        lightdm_greeter_set_language (greeter, language);
++        lightdm_greeter_set_language (greeter, language, NULL);
+     g_free (language);
+ 
+     session = get_session ();
+@@ -2233,7 +2238,7 @@
+         start_session ();
+     else if (lightdm_greeter_get_in_authentication (greeter))
+     {
+-        lightdm_greeter_respond (greeter, gtk_entry_get_text (password_entry));
++        lightdm_greeter_respond (greeter, gtk_entry_get_text (password_entry), NULL);
+         /* If we have questions pending, then we continue processing
+          * those, until we are done. (Otherwise, authentication will
+          * not complete.) */
+@@ -2326,7 +2331,7 @@
+             }
+         }
+         else
+-            lightdm_greeter_authenticate_autologin (greeter);
++            lightdm_greeter_authenticate_autologin (greeter, NULL);
+     }
+ }
+ 

--- a/x11-misc/lightdm-gtk-greeter/lightdm-gtk-greeter-2.0.1-r1.ebuild
+++ b/x11-misc/lightdm-gtk-greeter/lightdm-gtk-greeter-2.0.1-r1.ebuild
@@ -30,6 +30,8 @@ RDEPEND="${COMMON_DEPEND}
 GENTOO_BG="gentoo-bg_65.jpg"
 
 src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc6.patch
+
 	# Ok, this has to be fixed in the tarball but I am too lazy to do it.
 	# I will fix this once I decide to update the tarball with a new gentoo
 	# background


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=619782
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch taken from upstream revisions [349](http://bazaar.launchpad.net/~lightdm-gtk-greeter-team/lightdm-gtk-greeter/trunk/revision/349) and [350](http://bazaar.launchpad.net/~lightdm-gtk-greeter-team/lightdm-gtk-greeter/trunk/revision/350).