### PR TITLE
media-libs/coin: Fix segfault with GCC-6

### DIFF
--- a/media-libs/coin/coin-3.1.3-r2.ebuild
+++ b/media-libs/coin/coin-3.1.3-r2.ebuild
@@ -45,6 +45,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-pkgconfig-partial.patch
 	"${FILESDIR}"/${P}-gcc-4.7.patch
 	"${FILESDIR}"/${P}-freetype251.patch
+	"${FILESDIR}"/${P}-memhandler-initialization.patch
 )
 
 DOCS=(

--- a/media-libs/coin/files/coin-3.1.3-memhandler-initialization.patch
+++ b/media-libs/coin/files/coin-3.1.3-memhandler-initialization.patch
@@ -1,0 +1,23 @@
+Bug: https://bugs.gentoo.org/show_bug.cgi?id=619378
+Patch http://pkgs.fedoraproject.org/cgit/rpms/Coin3.git/tree/0012-memhandler-initialization.patch?id=ca89ec7227943bdec800ee51b920f578fab87b05
+
+--- a/src/misc/SbHash.h
++++ b/src/misc/SbHash.h
+@@ -89,6 +89,8 @@
+     cc_memalloc_deallocate(entry->memhandler, ptr);
+   }
+   SbHashEntry(const Key & key, const Type & obj) : key(key), obj(obj) {}
++  SbHashEntry(const Key & key, const Type & obj, cc_memalloc *memhandler)
++		: key(key), obj(obj), memhandler(memhandler) {}
+
+   Key key;
+   Type obj;
+@@ -218,7 +220,7 @@
+     /* Key not already in the hash table; insert a new
+      * entry as the first element in the bucket
+      */
+-    entry = new (this->memhandler) SbHashEntry<Type, Key>(key, obj);
++    entry = new (this->memhandler) SbHashEntry<Type, Key>(key, obj, this->memhandler);
+     entry->next = this->buckets[i];
+     this->buckets[i] = entry;
+


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=619378
Package-Manager: Portage-2.3.6, Repoman-2.3.2

The code relies on setting the value of `memhandler` sub-object before its constructor is called.  IIRC, accessing a class object's memory before its constructor is called has always been undefined behavior but caused no problems before gcc-6.  Now with more aggressive dead store elimination in gcc-6, such pre-construction behavior can be ignored by the compiler and, since the rest of the code relies on such initialization, can cause a segfault at runtime.  The patch ensures that proper initialization of `memhandler` occur in the constructor.

See https://bugzilla.redhat.com/show_bug.cgi?id=1323159 for more information.

Patch taken from http://pkgs.fedoraproject.org/cgit/rpms/Coin3.git/tree/0012-memhandler-initialization.patch?id=ca89ec7227943bdec800ee51b920f578fab87b05

Upstream bug report: 
https://bitbucket.org/Coin3D/coin/issues/128/crash-in-cc_memalloc_deallocate