### PR TITLE
dev-db/percona-xtrabackup: use older libedit (Bug #621654)

### DIFF
--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.7.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.7.ebuild
@@ -19,7 +19,7 @@ DEPEND="
 	app-editors/vim-core
 	>=dev-libs/boost-1.59.0:=
 	dev-libs/libaio
-	dev-libs/libedit
+	<dev-libs/libedit-20170329.3.1
 	dev-libs/libev
 	dev-libs/libevent:0=
 	dev-libs/libgcrypt:0=


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=621654

Package-Manager: Portage-2.3.6, Repoman-2.3.2