### PR TITLE
app-emulation/lxd: depend on lxc >= 2.0.7

### DIFF
--- a/app-emulation/lxd/lxd-2.14.ebuild
+++ b/app-emulation/lxd/lxd-2.14.ebuild
@@ -64,7 +64,7 @@ DEPEND="
 RDEPEND="
 	daemon? (
 		app-arch/xz-utils
-		app-emulation/lxc[seccomp]
+		>=app-emulation/lxc-2.0.7[seccomp]
 		net-dns/dnsmasq[dhcp,ipv6]
 		net-misc/rsync[xattr]
 		sys-apps/iproute2[ipv6]


### PR DESCRIPTION
Previously and without a ~amd64 flag on app-emulation/lxc, we would end up with v1.0.8 installed and
that's bad because LXD would constantly segfault. LXD's README
(https://github.com/lxc/lxd#building-from-source) specifies that LXC 2.0+ is required, so that's
what we should require.

Fixes #621830

lxc 2.0.7 has been stabilized since I opened the bug, but I still think it's a good idea to be
more specific in our dependency declaration.

Package-Manager: Portage-2.3.6, Repoman-2.3.1