### PR TITLE
games-strategy/asc: Fix building with -Werror=terminate

### DIFF
--- a/games-strategy/asc/asc-2.6.0.0-r1.ebuild
+++ b/games-strategy/asc/asc-2.6.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -36,6 +36,8 @@ DEPEND="${RDEPEND}
 	dev-lang/perl
 	virtual/pkgconfig
 	app-arch/zip"
+
+PATCHES=( "${FILESDIR}/"/${P}-gcc6-nothrow-in-dtors.patch )
 
 src_unpack() {
 	local f

--- a/games-strategy/asc/files/asc-2.6.0.0-gcc6-nothrow-in-dtors.patch
+++ b/games-strategy/asc/files/asc-2.6.0.0-gcc6-nothrow-in-dtors.patch
@@ -1,0 +1,32 @@
+Bug: https://bugs.gentoo.org/612934
+Upstream Bug: https://sourceforge.net/p/asc-hq/patches/2/
+
+--- a/source/basestrm.cpp
++++ b/source/basestrm.cpp
+@@ -1728,7 +1728,6 @@
+       }
+    } catch ( ... ) {
+       displayLogMessage( 9, ASCString("~tn_c_lzw_filestream : caught exception") );
+-      throw;
+    }
+ }
+ 
+--- a/source/simplestream.cpp
++++ b/source/simplestream.cpp
+@@ -43,6 +43,7 @@
+  #endif
+ #endif
+ 
++#include "util/messaginghub.h"
+ 
+ tnbufstream::tnbufstream (  )
+ {
+@@ -270,7 +271,7 @@
+ 
+    int res = fclose( fp );
+    if ( res != 0 ) 
+-      throw  tfileerror ( getDeviceName() + " : " + strerror(errno));
++      displayLogMessage( 9, ASCString( getDeviceName() + " : " + strerror(errno) ) );
+       
+    _mode = uninitialized;
+ 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=612934
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Reported upstream: https://sourceforge.net/p/asc-hq/patches/2/