### PR TITLE
games-mud/kmuddy: Fix building with GCC-6

### DIFF
--- a/games-mud/kmuddy/files/kmuddy-1.0.1-gcc6.patch
+++ b/games-mud/kmuddy/files/kmuddy-1.0.1-gcc6.patch
@@ -1,0 +1,30 @@
+Bug: https://bugs.gentoo.org/612760
+Commits: https://cgit.kde.org/kmuddy.git/commit/kmuddy/dialogs/dlgappsettings.cpp?id=5def190b6b3baa7502999275aac469440ec261cc
+         https://cgit.kde.org/kmuddy.git/commit/plugins/mapper/dialogs/dlgmappathproperties.cpp?id=0255f21b46a0f83e2e455fd2ba5c015a3b46e98a
+
+--- a/kmuddy/dialogs/dlgappsettings.cpp
++++ b/kmuddy/dialogs/dlgappsettings.cpp
+@@ -554,7 +554,7 @@
+   //page 8
+    //layout ensures that the widget fills entire available space...
+   QHBoxLayout *keylayout = new QHBoxLayout (frmshortcuts);
+-  keys = new KShortcutsEditor (cActionManager::self()->getACol (), frmshortcuts, false);
++  keys = new KShortcutsEditor (cActionManager::self()->getACol (), frmshortcuts);
+   keylayout->addWidget (keys);
+ 
+   cActionManager::self()->invokeEvent ("dialog-create", 0, "app-prefs");
+--- a/plugins/mapper/dialogs/dlgmappathproperties.cpp
++++ b/plugins/mapper/dialogs/dlgmappathproperties.cpp
+@@ -242,9 +242,9 @@
+ {
+ 	properties.writeEntry("SrcBeforeCommand",txtSrcBefore->text().trimmed());
+ 	properties.writeEntry("SrcAfterCommand",txtSrcAfter->text().trimmed());
+-	properties.writeEntry("SrcDir",(int)getSrcDirection(),0);
+-	properties.writeEntry("DestDir",(int)getDestDirection(),0);
+-	properties.writeEntry("SpecialExit",chkSpecial->isChecked(),false);
++	properties.writeEntry("SrcDir",(int)getSrcDirection());
++	properties.writeEntry("DestDir",(int)getDestDirection());
++	properties.writeEntry("SpecialExit",chkSpecial->isChecked());
+ 	properties.writeEntry("SpecialCmdSrc",txtSpecialSrc->text().trimmed());
+ 
+ 	if (properties.hasKey("PathTwoWay"))

--- a/games-mud/kmuddy/kmuddy-1.0.1-r3.ebuild
+++ b/games-mud/kmuddy/kmuddy-1.0.1-r3.ebuild
@@ -25,6 +25,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-underlinking.patch
 	"${FILESDIR}"/${P}-tempnam.patch
 	"${FILESDIR}"/${P}-desktopvalidation.patch
+	"${FILESDIR}"/${P}-gcc6.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=612760
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch taken from upstream commits [5def190b6b3baa7502999275aac469440ec261cc](https://cgit.kde.org/kmuddy.git/commit/kmuddy/dialogs/dlgappsettings.cpp?id=5def190b6b3baa7502999275aac469440ec261cc) and [0255f21b46a0f83e2e455fd2ba5c015a3b46e98a](https://cgit.kde.org/kmuddy.git/commit/plugins/mapper/dialogs/dlgmappathproperties.cpp?id=0255f21b46a0f83e2e455fd2ba5c015a3b46e98a).