### PR TITLE
games-arcade/criticalmass: Fix building with GCC-6

### DIFF
--- a/games-arcade/criticalmass/criticalmass-1.0.2.ebuild
+++ b/games-arcade/criticalmass/criticalmass-1.0.2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit autotools eutils games
+inherit autotools eutils flag-o-matic games
 
 DESCRIPTION="SDL/OpenGL space shoot'em up game"
 HOMEPAGE="http://criticalmass.sourceforge.net/"
@@ -30,6 +30,11 @@ src_prepare() {
 		"${FILESDIR}"/${P}-libpng15.patch
 	rm -rf curl
 	eautoreconf
+}
+
+src_configure() {
+	append-cxxflags -std=gnu++98 # Bug 612758
+	default
 }
 
 src_install() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=612758
Package-Manager: Portage-2.3.6, Repoman-2.3.2

This project has the atrocious behavior of declaring the directive`using namespace std;` in no less than 10 header files.  Furthermore, it declares the directive  `using namespace __gnu_cxx` and makes heavy use of `__gnu_cxx::hash` which clashes with C++11/14's `std::hash`.  A working patch that enables semantically equivalent C++98 behavior would be gigantic and, IMHO, not worth it for a project that has been dead for ~10 years.

Debian [appends "-std=gnu++98" to the CXXFLAGS](https://sources.debian.net/src/criticalmass/1:1.0.0-5/debian/patches/gcc6.patch/) and it makes sense for a project that's so dependent on c++98 behavior and dead upstream.