### PR TITLE
net-misc/mikutter: Block >=dev-ruby/memoist-0.16.

### DIFF
--- a/net-misc/mikutter/mikutter-3.4.2.ebuild
+++ b/net-misc/mikutter/mikutter-3.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -37,7 +37,7 @@ ruby_add_rdepend "dev-ruby/addressable
 	dev-ruby/httpclient
 	dev-ruby/json:0
 	dev-ruby/instance_storage
-	dev-ruby/memoist
+	<dev-ruby/memoist-0.16
 	>=dev-ruby/moneta-0.7
 	dev-ruby/nokogiri
 	>=dev-ruby/oauth-0.4.7

--- a/net-misc/mikutter/mikutter-3.5.4.ebuild
+++ b/net-misc/mikutter/mikutter-3.5.4.ebuild
@@ -37,7 +37,7 @@ ruby_add_rdepend "dev-ruby/addressable
 	dev-ruby/httpclient
 	dev-ruby/json:0
 	dev-ruby/instance_storage
-	dev-ruby/memoist
+	<dev-ruby/memoist-0.16
 	>=dev-ruby/moneta-0.7
 	dev-ruby/nokogiri
 	>=dev-ruby/oauth-0.5.1


### PR DESCRIPTION
Bugzilla: https://bugs.gentoo.org/show_bug.cgi?id=623746