### PR TITLE
media-sound/vorbis-tools: multiple vulnerabilities fixed

### DIFF
--- a/media-sound/vorbis-tools/files/vorbis-tools-1.4.0-CVE-2014-9638.patch
+++ b/media-sound/vorbis-tools/files/vorbis-tools-1.4.0-CVE-2014-9638.patch
@@ -1,0 +1,92 @@
+Patches taken as references: 
+https://github.com/mark4o/opus-tools/commit/8c412e619b83eb6dd32191909cf6672e93e5802e
+https://trac.xiph.org/attachment/ticket/2212/0001-oggenc-Fix-large-alloca-on-bad-AIFF-input.patch
+To fix bug report:
+http://www.openwall.com/lists/oss-security/2015/08/29/1
+    https://bugs.gentoo.org/show_bug.cgi?id=559170
+https://bugs.gentoo.org/show_bug.cgi?id=537422
+--- oggenc/audio.h
++++ oggenc/audio.h
+@@ -25,7 +25,7 @@
+ 
+ typedef struct {
+     short format;
+-    short channels;
++    unsigned short channels;
+     int samplerate;
+     int bytespersec;
+     short align;
+@@ -44,7 +44,7 @@
+ } wavfile;
+ 
+ typedef struct {
+-    short channels;
++    unsigned short channels;
+     int totalframes;
+     short samplesize;
+     int rate;
+--- oggenc/audio.c	
++++ oggenc/audio.c
+@@ -245,8 +245,8 @@
+ int aiff_open(FILE *in, oe_enc_opt *opt, unsigned char *buf, int buflen)
+ {
+     int aifc; /* AIFC or AIFF? */
+-    unsigned int len;
+-    unsigned char *buffer;
++    unsigned int len,readlen;
++    unsigned char buffer[22];
+     unsigned char buf2[8];
+     aiff_fmt format;
+     aifffile *aiff = malloc(sizeof(aifffile));
+@@ -269,9 +269,9 @@
+         return 0; /* Weird common chunk */
+     }
+
+-    buffer = alloca(len);
+-
+-    if(fread(buffer,1,len,in) < len)
++    readlen = len < sizeof(buffer) ? len : sizeof(buffer);
++    if(fread(buffer,1,readlen,in) < readlen ||
++        (len > readlen && !seek_forward(in, len-readlen)))
+     {
+         fprintf(stderr, _("Warning: Unexpected EOF in reading AIFF header\n"));
+         return 0;
+@@ -277,11 +277,18 @@
+         return 0;
+     }
+ 
+-    format.channels = READ_U16_BE(buffer);
++    format.channels = (short)READ_U16_BE(buffer);
+     format.totalframes = READ_U32_BE(buffer+2);
+     format.samplesize = READ_U16_BE(buffer+6);
+     format.rate = (int)read_IEEE80(buffer+8);
+ 
++    if(format.channels <=0)
++    {
++    	fprintf(stderr, _("ERROR: Invalid channel count in AIFF header\n"));
++	return 0;
++
++    }
++
+     aiff->bigendian = 1;
+ 
+     if(aifc)
+@@ -449,11 +449,17 @@
+     }
+
+     format.format =      READ_U16_LE(buf);
+-    format.channels =    READ_U16_LE(buf+2);
++    format.channels =    (short)READ_U16_LE(buf+2);
+     format.samplerate =  READ_U32_LE(buf+4);
+     format.bytespersec = READ_U32_LE(buf+8);
+     format.align =       READ_U16_LE(buf+12);
+     format.samplesize =  READ_U16_LE(buf+14);
++
++    if(format.channels == 0)
++    {
++      fprintf(stderr, _("ERROR: Zero channels in WAV header\n"));
++      return 0;
++    }
+
+     if(format.format == -2) /* WAVE_FORMAT_EXTENSIBLE */
+     {

--- a/media-sound/vorbis-tools/files/vorbis-tools-1.4.0-CVE-2014-9640.patch
+++ b/media-sound/vorbis-tools/files/vorbis-tools-1.4.0-CVE-2014-9640.patch
@@ -1,0 +1,24 @@
+Patch taken from: 
+https://trac.xiph.org/changeset/19117
+To fix bug report:
+https://bugs.gentoo.org/show_bug.cgi?id=537422
+--- vorbis-tools-1.4.0/oggenc/oggenc.c	
++++ vorbis-tools-1.4.0/oggenc/oggenc.c
+@@ -97,6 +97,8 @@
+               .3,-1,
+               0,0,0.f,
+               0, 0, 0, 0, 0};
++    input_format raw_format = {NULL, 0, raw_open, wav_close, "raw", 
++        N_("RAW file reader")};
+ 
+     int i;
+ 
+@@ -239,8 +241,6 @@
+ 
+         if(opt.rawmode)
+         {
+-            input_format raw_format = {NULL, 0, raw_open, wav_close, "raw", 
+-                N_("RAW file reader")};
+ 
+             enc_opts.rate=opt.raw_samplerate;
+             enc_opts.channels=opt.raw_channels;

--- a/media-sound/vorbis-tools/vorbis-tools-1.4.0-r4.ebuild
+++ b/media-sound/vorbis-tools/vorbis-tools-1.4.0-r4.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+inherit autotools eutils
+
+DESCRIPTION="tools for using the Ogg Vorbis sound file format"
+HOMEPAGE="http://www.vorbis.com"
+SRC_URI="http://downloads.xiph.org/releases/vorbis/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+IUSE="flac kate nls +ogg123 speex"
+
+RDEPEND=">=media-libs/libvorbis-1.3.0
+	flac? ( media-libs/flac )
+	kate? ( media-libs/libkate )
+	ogg123? (
+		>=media-libs/libao-1.0.0
+		net-misc/curl
+	)
+	speex? ( media-libs/speex )"
+DEPEND="${RDEPEND}
+	nls? ( sys-devel/gettext )
+	virtual/pkgconfig"
+
+DOCS="AUTHORS CHANGES README"
+
+src_prepare() {
+	epatch "${FILESDIR}"/${P}-underlinking.patch
+	epatch "${FILESDIR}"/${P}-format-security.patch
+	epatch "${FILESDIR}"/${P}-CVE-2014-9640.patch
+	epatch "${FILESDIR}"/${P}-CVE-2014-9638.patch
+	sed -i -e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' configure.ac || die #515220
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable nls) \
+		$(use_enable ogg123) \
+		$(use_with flac) \
+		$(use_with speex) \
+		$(use_with kate)
+}


### PR DESCRIPTION
Bug reports:

https://bugs.gentoo.org/show_bug.cgi?id=537422
