### PR TITLE
app-i18n/enca: remove myself from maintainers

### DIFF
--- a/app-i18n/enca/metadata.xml
+++ b/app-i18n/enca/metadata.xml
@@ -2,16 +2,8 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>itumaykin+gentoo@gmail.com</email>
-		<name>Coacher</name>
-	</maintainer>
-	<maintainer type="person">
 		<email>maksbotan@gentoo.org</email>
 		<name>Maxim Koltsov</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">nijel/enca</remote-id>


### PR DESCRIPTION
As the last mpv version that uses enca faces removal
I no longer have interest in maintaining enca.

Package-Manager: Portage-2.3.6, Repoman-2.3.3