### PR TITLE
sys-power/apcupsd: systemd depend on network

### DIFF
--- a/sys-power/apcupsd/files/apcupsd.service
+++ b/sys-power/apcupsd/files/apcupsd.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=APC UPS Monitor
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/sbin/apcupsd -b


### PR DESCRIPTION
Update the systemd service file to match the openrc dependency on the
network to be up.