### PR TITLE
games-arcade/tecnoballz: Fix building with GCC-6

### DIFF
--- a/games-arcade/tecnoballz/files/tecnoballz-0.92-gcc6.patch
+++ b/games-arcade/tecnoballz/files/tecnoballz-0.92-gcc6.patch
@@ -1,0 +1,45 @@
+Bug: https://bugs.gentoo.org/show_bug.cgi?id=610974
+Commit: https://github.com/brunonymous/tecnoballz/commit/29c5f137555897c8fb73b4780295524b214b24a2
+
+--- a/include/tiles_background.h
++++ b/include/tiles_background.h
+@@ -47,7 +47,7 @@
+     static tiles_background* tiles_background_singleton;
+     static Sint32 table_pos1[16];
+     static Sint32 table_pos2[16];
+-    static char couleurs[448];
++    static unsigned char couleurs[448];
+     static const Sint32 TILES_32_WIDTH = 32;
+     static const Sint32 TILES_32_HEIGHT = 32;
+     static const Sint32 TILES_64_WIDTH = 64;
+@@ -63,7 +63,7 @@
+      * or TILES_32x32_WITH_4_COLORS */
+     Uint32 type_of_tiles;
+     /** 4 color palette index */
+-    Uint32 palette_index;
++    Sint32 palette_index;
+ 
+     bitmap_data *current_tiles;
+     Uint32 *map_tiles;
+--- a/src/tiles_background.cc
++++ b/src/tiles_background.cc
+@@ -663,8 +663,8 @@
+ 
+     }
+   palette_index = pal_index;
+-  char *color = &couleurs[0];
+-  unsigned char *colPT = (unsigned char *) (color) + pal_index;
++  unsigned char *color = &couleurs[0];
++  unsigned char *colPT = (color) + pal_index;
+   SDL_Color *pal = display->get_palette ();
+   SDL_Color *lighted = pal + 1;
+   SDL_Color *dark = lighted + 128;
+@@ -702,7 +702,7 @@
+  * 4 * 4    : 16 composantes by palette
+  * 112 * 4  : 448 composantes
+ */
+-char
++unsigned char
+ tiles_background::couleurs[448] = {
+                                     0x00, 0x40, 0x20, 0x40, 0x00, 0x60, 0x40, 0x60, 0x00, 0x80, 0x60, 0x80,
+                                     0x00, 0xA0, 0x80, 0xA0, 0x00, 0x00, 0x20, 0x40, 0x00, 0x20,

--- a/games-arcade/tecnoballz/tecnoballz-0.92.ebuild
+++ b/games-arcade/tecnoballz/tecnoballz-0.92.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -21,6 +21,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-gcc43.patch \
+		"${FILESDIR}"/${P}-gcc6.patch \
 		"${FILESDIR}"/${P}-automake.patch
 	mv man/${PN}.fr.6 man/fr/${PN}.6 || die
 	# don't combine explicit and implicit rules for make 3.82 (bug #334629)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=610974
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch is cherry-picked from https://github.com/brunonymous/tecnoballz/commit/29c5f137555897c8fb73b4780295524b214b24a2.