### PR TITLE
games-puzzle/enigma: Fix building with GCC-6

### DIFF
--- a/games-puzzle/enigma/enigma-1.21-r2.ebuild
+++ b/games-puzzle/enigma/enigma-1.21-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -31,7 +31,8 @@ RDEPEND="${COMMON_DEPS}
 
 src_prepare() {
 	cp /usr/share/gettext/config.rpath .
-	epatch "${FILESDIR}"/${P}-build.patch
+	epatch "${FILESDIR}"/${P}-build.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 	sed -i \
 		-e "s:DOCDIR:\"/usr/share/doc/${P}/html\":" \
 		src/main.cc || die

--- a/games-puzzle/enigma/files/enigma-1.21-gcc6.patch
+++ b/games-puzzle/enigma/files/enigma-1.21-gcc6.patch
@@ -1,0 +1,25 @@
+Bug: https://bugs.gentoo.org/610778
+
+From e0f31f63ba4252ced7128d3ceec2bc668e8681f4 Mon Sep 17 00:00:00 2001
+From: Legimet <legimet.calc@gmail.com>
+Date: Sat, 13 Aug 2016 23:41:27 -0400
+Subject: [PATCH] Fix build error with GCC 6, caused by comparing
+ basic_ifstream to NULL
+
+---
+ src/lev/Proxy.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lev/Proxy.cc b/src/lev/Proxy.cc
+index 6d58c0ba..69f54a20 100644
+--- a/src/lev/Proxy.cc
++++ b/src/lev/Proxy.cc
+@@ -933,7 +933,7 @@ namespace enigma { namespace lev {
+                     } else if (haveLocalCopy) {
+                         // plain file
+                         basic_ifstream<char> ifs(absExtPath.c_str(), ios::binary | ios::in);
+-                        if (ifs != NULL)
++                        if (ifs)
+                             Readfile(ifs, extCode);
+                         else
+                             haveLocalCopy = false;


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=610778
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch taken from https://github.com/Enigma-Game/Enigma/commit/2aaa39e7d131159aa33086e0262bc85fedd03246