### PR TITLE
sci-biology/express: Fix building with GCC-6

### DIFF
--- a/sci-biology/express/express-1.5.1.ebuild
+++ b/sci-biology/express/express-1.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -26,6 +26,7 @@ S="${WORKDIR}/${P}-src"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-buildsystem.patch
+	"${FILESDIR}"/${P}-gcc6.patch
 )
 
 src_configure() {

--- a/sci-biology/express/files/express-1.5.1-gcc6.patch
+++ b/sci-biology/express/files/express-1.5.1-gcc6.patch
@@ -1,0 +1,19 @@
+Bug: https://bugs.gentoo.org/610692
+
+--- a/src/targets.cpp
++++ b/src/targets.cpp
+@@ -113,12 +113,12 @@
+ 
+   double ll = LOG_1;
+   double tot_mass = mass(with_pseudo);
+-  double tot_eff_len = cached_effective_length(lib.bias_table);
++  double tot_eff_len = cached_effective_length(static_cast<bool>(lib.bias_table));
+   if (neighbors) {
+     foreach (const Target* neighbor, *neighbors) {
+       tot_mass = log_add(tot_mass, neighbor->mass(with_pseudo));
+       tot_eff_len = log_add(tot_eff_len,
+-                            neighbor->cached_effective_length(lib.bias_table));
++                            neighbor->cached_effective_length(static_cast<bool>(lib.bias_table)));
+     }
+   }
+   ll += tot_mass - tot_eff_len;


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=610692
Package-Manager: Portage-2.3.6, Repoman-2.3.2

`boost::shared_ptr` requires explicit cast to `bool`.

No point in submitting upstream as the project [officially ended development](https://pachterlab.github.io/eXpress/).