### PR TITLE
games-arcade/fishsupper: Fix building with GCC-6

### DIFF
--- a/games-arcade/fishsupper/files/fishsupper-0.1.6-gcc6.patch
+++ b/games-arcade/fishsupper/files/fishsupper-0.1.6-gcc6.patch
@@ -1,0 +1,49 @@
+Bug: https://bugs.gentoo.org/610660
+
+--- a/src/Settings_screen.cpp
++++ b/src/Settings_screen.cpp
+@@ -217,3 +217,7 @@
+ 
+ // **************************************************
+ 
++const float FS::Settings_screen::bold = 1.0;
++const float FS::Settings_screen::faded = 0.2;
++
++// **************************************************
+--- a/src/Settings_screen.h
++++ b/src/Settings_screen.h
+@@ -71,8 +71,8 @@
+         static const int tick1_x = 252;
+         static const int tick_y_offset = 33;
+         static const int sprite_texture_start = FS_gfx::JOYSTICK;
+-        static const float bold = 1.0;
+-        static const float faded = 0.2;
++        static const float bold;
++        static const float faded;
+ 
+         Settings* settings_ptr;
+         int current_option;
+--- a/src/Star_particle_system.cpp
++++ b/src/Star_particle_system.cpp
+@@ -137,6 +137,10 @@
+ } // FS::Star_particle_system::launch_new_star
+ 
+ // **************************************************
++
++const float FS::Star_particle_system::lifespan = 1500.0;
++
++// **************************************************
+ // **************************************************
+ // **************************************************
+ // **************************************************
+--- a/src/Star_particle_system.h
++++ b/src/Star_particle_system.h
+@@ -77,7 +77,7 @@
+         static const int STAR_WIDTH = 30;
+         static const int STAR_HEIGHT = 30;
+         // This is a float so that we get floating-point division in update.
+-        static const float lifespan = 1500.0;   // in ms
++        static const float lifespan;   // in ms
+     
+         // A particle is basically a lightweight sprite.
+         // Unlike a usual sprite, we don't need to worry about

--- a/games-arcade/fishsupper/fishsupper-0.1.6.ebuild
+++ b/games-arcade/fishsupper/fishsupper-0.1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -22,7 +22,8 @@ DEPEND="${RDEPEND}
 
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-ovflfix.patch \
-		"${FILESDIR}"/${P}-asneeded.patch
+		"${FILESDIR}"/${P}-asneeded.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 	eautoreconf
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=610660
Package-Manager: Portage-2.3.6, Repoman-2.3.2

In-class initialization of static non-integral variables was never technically legal but accepted for floating point types, pre-C++11.  With the advent of `constexpr` in C++11, this is no longer the case.  The dialect neutral approach is to simply initialize out of class, in the corresponding .cpp file.