### PR TITLE
games-engines/odamex: Fix building with GCC-6

### DIFF
--- a/games-engines/odamex/files/odamex-0.7.0-gcc6.patch
+++ b/games-engines/odamex/files/odamex-0.7.0-gcc6.patch
@@ -1,0 +1,39 @@
+Bug: https://bugs.gentoo.org/610566
+Commit: https://github.com/odamex/odamex/commit/1d8121c78fe2db9befb05dd40ceb9b86062024e4
+
+From 1d8121c78fe2db9befb05dd40ceb9b86062024e4 Mon Sep 17 00:00:00 2001
+From: rice <russell@odamex.net>
+Date: Tue, 30 Aug 2016 08:37:15 +0000
+Subject: [PATCH] - Apply patch from bug 1177, thanks RjY!
+
+SVN r5444 (trunk)
+---
+ common/m_vectors.cpp | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/common/m_vectors.cpp b/common/m_vectors.cpp
+index b51e4e40..2eb48a04 100644
+--- a/common/m_vectors.cpp
++++ b/common/m_vectors.cpp
+@@ -541,16 +541,16 @@ void M_PerpendicularVec3(v3double_t *dest, const v3double_t *src)
+ {
+ 	// find the smallest component of the vector src
+ 	v3double_t tempvec;
+-	double minelem = src->x;
++	double minelem = fabs(src->x);
+ 	double *mincomponent = &(tempvec.x);
+-	if (abs(src->y) < minelem)
++	if (fabs(src->y) < minelem)
+ 	{
+-		minelem = abs(src->y);
++		minelem = fabs(src->y);
+ 		mincomponent = &(tempvec.y);
+ 	}
+-	if (abs(src->z) < minelem)
++	if (fabs(src->z) < minelem)
+ 	{
+-		minelem = abs(src->z);
++		minelem = fabs(src->z);
+ 		mincomponent = &(tempvec.z);
+ 	}
+ 	

--- a/games-engines/odamex/odamex-0.7.0.ebuild
+++ b/games-engines/odamex/odamex-0.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -40,7 +40,8 @@ src_prepare() {
 		"${FILESDIR}"/2-${P}-cmake-options.patch \
 		"${FILESDIR}"/3-${P}-wad-search-path.patch \
 		"${FILESDIR}"/4-${P}-odalauncher-bin-path.patch \
-		"${FILESDIR}"/${P}-miniupnpc.patch
+		"${FILESDIR}"/${P}-miniupnpc.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 
 	rm -r libraries/libminiupnpc || die
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=610566
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch taken from upstream commit https://github.com/odamex/odamex/commit/1d8121c78fe2db9befb05dd40ceb9b86062024e4