### PR TITLE
games-simulation/crrcsim: Fix building with GCC-6

### DIFF
--- a/games-simulation/crrcsim/crrcsim-0.9.13.ebuild
+++ b/games-simulation/crrcsim/crrcsim-0.9.13.ebuild
@@ -20,7 +20,10 @@ RDEPEND="media-libs/libsdl[X,sound,joystick,opengl,video]
 	portaudio? ( media-libs/portaudio )"
 DEPEND="${RDEPEND}"
 
-PATCHES=( "${FILESDIR}"/${P}-buildsystem.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-buildsystem.patch
+	"${FILESDIR}"/${P}-gcc6.patch
+)
 
 src_prepare() {
 	default

--- a/games-simulation/crrcsim/files/crrcsim-0.9.13-gcc6.patch
+++ b/games-simulation/crrcsim/files/crrcsim-0.9.13-gcc6.patch
@@ -1,0 +1,14 @@
+Bug: https://bugs.gentoo.org/610560
+Upstream commit: https://sourceforge.net/p/crrcsim/code/ci/28ed9ba57011371cab8b637550acc716b973c47d
+
+--- a/src/mod_video/crrc_animation.cpp
++++ b/src/mod_video/crrc_animation.cpp
+@@ -84,7 +84,7 @@
+       else
+       {
+         std::cerr << "createAnimation: unknown animation type \'"
+-                  << type << "\'" << std::cerr;
++                  << type << "\'" << std::endl;
+       }
+       
+       if (anim != NULL)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=610560
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch was cherry-picked from upstream commit https://sourceforge.net/p/crrcsim/code/ci/28ed9ba57011371cab8b637550acc716b973c47d.