### PR TITLE
games-roguelike/scourge: Fix building with GCC-6

### DIFF
--- a/games-roguelike/scourge/files/scourge-0.21.1-gcc6.patch
+++ b/games-roguelike/scourge/files/scourge-0.21.1-gcc6.patch
@@ -1,0 +1,34 @@
+Bug: https://bugs.gentoo.org/610492
+Upstream ticket: https://sourceforge.net/p/scourge/patches/3/
+
+--- a/src/equip.cpp
++++ b/src/equip.cpp
+@@ -595,7 +595,7 @@
+ 		}
+ 	}
+ 	if ( !found ) {
+-		specialSkill = false;
++		specialSkill = NULL;
+ 		canvas->setTooltip( "" );
+ 	}
+ 	glDisable( GL_BLEND );
+--- a/src/render/map.cpp
++++ b/src/render/map.cpp
+@@ -3154,7 +3154,7 @@
+ 			if ( shape )
+ 				return shape;
+ 		}
+-		return false;
++		return NULL;
+ 	}
+ 	if ( y1 == y2 ) {
+ 		if ( x1 > x2 ) SWAP( x1, x2 );
+@@ -3163,7 +3163,7 @@
+ 			if ( shape )
+ 				return shape;
+ 		}
+-		return false;
++		return NULL;
+ 	}
+ 
+ 

--- a/games-roguelike/scourge/scourge-0.21.1-r1.ebuild
+++ b/games-roguelike/scourge/scourge-0.21.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -31,6 +31,7 @@ S=${WORKDIR}/${PN}
 
 PATCHES=(
 	"${FILESDIR}"/${P}-gcc47.patch
+	"${FILESDIR}"/${P}-gcc6.patch
 	"${FILESDIR}"/${P}-automake-1.13.patch
 )
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=610492
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Upstream ticket: https://sourceforge.net/p/scourge/patches/3/