### PR TITLE
games-strategy/glob2: Fix building with GCC-6

### DIFF
--- a/games-strategy/glob2/files/glob2-0.9.4.4-gcc6.patch
+++ b/games-strategy/glob2/files/glob2-0.9.4.4-gcc6.patch
@@ -1,0 +1,49 @@
+Bug: https://bugs.gentoo.org/610382
+Upstream commit: https://bitbucket.org/giszmo/glob2/commits/c9dc715624318e4fea4abb24e04f0ebdd9cd8d2a
+
+# HG changeset patch
+# User Jonathan Wakely <jwakely@redhat.com>
+# Date 1485875296 0
+# Node ID c9dc715624318e4fea4abb24e04f0ebdd9cd8d2a
+# Parent  c4da01699846179d8bf21e8dae2b973158ec0775
+Fix last argument to ChooseMapScreen constructor
+
+Since C++14 'false' is not a valid null pointer constant, so cannot be passed
+to functions expecting pointer arguments.
+
+diff --git a/src/EditorMainMenu.cpp b/src/EditorMainMenu.cpp
+--- a/src/EditorMainMenu.cpp
++++ b/src/EditorMainMenu.cpp
+@@ -90,7 +90,7 @@
+ 		}
+ 		else if (par1==LOADMAP)
+ 		{
+-			ChooseMapScreen chooseMapScreen("maps", "map", false, "games", "game", false);
++			ChooseMapScreen chooseMapScreen("maps", "map", false, "games", "game", NULL);
+ 			int rc=chooseMapScreen.execute(globalContainer->gfx, 40);
+ 			if (rc==ChooseMapScreen::OK)
+ 			{
+diff --git a/src/LANMenuScreen.cpp b/src/LANMenuScreen.cpp
+--- a/src/LANMenuScreen.cpp
++++ b/src/LANMenuScreen.cpp
+@@ -62,7 +62,7 @@
+ 		}
+ 		else if(par1 == HOST)
+ 		{
+-			ChooseMapScreen cms("maps", "map", false, "games", "game", false);
++			ChooseMapScreen cms("maps", "map", false, "games", "game", NULL);
+ 			int rc = cms.execute(globalContainer->gfx, 40);
+ 			if(rc == ChooseMapScreen::OK)
+ 			{
+diff --git a/src/YOGClientLobbyScreen.cpp b/src/YOGClientLobbyScreen.cpp
+--- a/src/YOGClientLobbyScreen.cpp
++++ b/src/YOGClientLobbyScreen.cpp
+@@ -326,7 +326,7 @@
+ 
+ void YOGClientLobbyScreen::hostGame()
+ {
+-	ChooseMapScreen cms("maps", "map", false, "games", "game", false);
++	ChooseMapScreen cms("maps", "map", false, "games", "game", NULL);
+ 	int rc = cms.execute(globalContainer->gfx, 40);
+ 	if(rc == ChooseMapScreen::OK)
+ 	{

--- a/games-strategy/glob2/glob2-0.9.4.4-r1.ebuild
+++ b/games-strategy/glob2/glob2-0.9.4.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -27,7 +27,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 src_prepare() {
-	epatch "${FILESDIR}"/${P}-{gcc44,scons-blows,underlinking,gcc49}.patch
+	epatch "${FILESDIR}"/${P}-{gcc{44,49,6},scons-blows,underlinking}.patch
 }
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=610382
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch taken from [upstream commit ](https://bitbucket.org/giszmo/glob2/commits/c9dc715624318e4fea4abb24e04f0ebdd9cd8d2a).