### PR TITLE
games-action/btanks: Fix building with -Werror=terminate in GCC-6

### DIFF
--- a/games-action/btanks/btanks-0.9.8083.ebuild
+++ b/games-action/btanks/btanks-0.9.8083.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -28,7 +28,8 @@ src_prepare() {
 	rm -rf sdlx/gfx
 	epatch "${FILESDIR}"/${P}-scons-blows.patch \
 		"${FILESDIR}"/${P}-gcc46.patch \
-		"${FILESDIR}"/${P}-gcc47.patch
+		"${FILESDIR}"/${P}-gcc47.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 }
 
 src_compile() {

--- a/games-action/btanks/files/btanks-0.9.8083-gcc6.patch
+++ b/games-action/btanks/files/btanks-0.9.8083-gcc6.patch
@@ -1,0 +1,34 @@
+Bug: https://bugs.gentoo.org/609692
+
+--- a/mrt/timespy.cpp
++++ b/mrt/timespy.cpp
+@@ -43,7 +43,7 @@
+ 		throw_io(("gettimeofday"));
+ }
+ 
+-TimeSpy::~TimeSpy() {
++TimeSpy::~TimeSpy() DTOR_NOEXCEPT {
+ 	struct timeval now;
+ 	if (gettimeofday(&now, NULL) == -1)
+ 		throw_io(("gettimeofday"));
+--- a/mrt/timespy.h
++++ b/mrt/timespy.h
+@@ -37,11 +37,17 @@
+ #include "fmt.h"
+ #include "export_mrt.h"
+ 
++#if __cplusplus >= 201103L
++#define DTOR_NOEXCEPT noexcept(false)
++#else
++#define DTOR_NOEXCEPT
++#endif
++
+ namespace mrt {
+ class MRTAPI TimeSpy {
+ public: 
+ 	TimeSpy(const std::string &message);
+-	~TimeSpy();
++	~TimeSpy() DTOR_NOEXCEPT;
+ private: 
+ 	TimeSpy(const TimeSpy&);
+ 	const TimeSpy& operator=(const TimeSpy&);


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=609692
Package-Manager: Portage-2.3.6, Repoman-2.3.2

In C++11/14,  destructors default to `noexcept(true)` and all throw statements become calls to `std::terminate()`.  Destructors need to be marked `noexcept(false)` to enable C++98 throwing behavior.

Project is dead upstream with no means to submit patches or pull requests.