### PR TITLE
dev-python/jpype: Fix building with -Werror=terminate using GCC-6

### DIFF
--- a/dev-python/jpype/files/jpype-gcc6-noexcept.patch
+++ b/dev-python/jpype/files/jpype-gcc6-noexcept.patch
@@ -1,0 +1,57 @@
+Bug: https://bugs.gentoo.org/show_bug.cgi?id=608920
+Upstream commit: https://github.com/originell/jpype/commit/3a4fb98938afd9c03070086d1b8fda8841410fa3
+
+From c3578c3488de35236f73b6eb27428b1f1526c45b Mon Sep 17 00:00:00 2001
+From: Peter-Levine <plevine457@gmail.com>
+Date: Sat, 11 Feb 2017 23:31:27 -0500
+Subject: [PATCH] Mark destructor that throws as noexcept(false) for >=C++11
+
+---
+ native/common/include/jp_field.h | 2 +-
+ native/common/include/jpype.h    | 6 ++++++
+ native/common/jp_field.cpp       | 2 +-
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/native/common/include/jp_field.h b/native/common/include/jp_field.h
+index d28b795..f93752c 100644
+--- a/native/common/include/jp_field.h
++++ b/native/common/include/jp_field.h
+@@ -38,7 +38,7 @@ public :
+ 	/**
+ 	 * destructor
+ 	 */
+-	virtual ~JPField();
++	virtual ~JPField() NO_EXCEPT_FALSE;
+ 	
+ public :
+ 	bool isStatic() const;
+diff --git a/native/common/include/jpype.h b/native/common/include/jpype.h
+index 7db5832..a492d06 100644
+--- a/native/common/include/jpype.h
++++ b/native/common/include/jpype.h
+@@ -64,6 +64,12 @@
+     #define PyUnicode_FromFormat PyString_FromFormat
+ #endif
+ 
++// Define this and use to allow destructors to throw in C++11 or later
++#if __cplusplus >= 201103L
++#define NO_EXCEPT_FALSE noexcept(false)
++#else
++#define NO_EXCEPT_FALSE
++#endif
+ 
+ #include <map>
+ #include <string>
+diff --git a/native/common/jp_field.cpp b/native/common/jp_field.cpp
+index 8c75e58..5ef9d8c 100644
+--- a/native/common/jp_field.cpp
++++ b/native/common/jp_field.cpp
+@@ -63,7 +63,7 @@ JPField::JPField(const JPField& fld)
+ 	TRACE_OUT;
+ }
+ 
+-JPField::~JPField()
++JPField::~JPField() NO_EXCEPT_FALSE
+ {
+ 	TRACE_IN("JPField::~JPField");
+ 	JPEnv::getJava()->DeleteGlobalRef(m_Field);

--- a/dev-python/jpype/jpype-0.6.1.ebuild
+++ b/dev-python/jpype/jpype-0.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -21,6 +21,8 @@ S="${WORKDIR}/${P}"
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	>=virtual/jdk-1.6"
+
+PATCHES=( "${FILESDIR}"/${PN}-gcc6-noexcept.patch )
 
 python_compile() {
 	if ! python_is_python3; then

--- a/dev-python/jpype/jpype-0.6.2.ebuild
+++ b/dev-python/jpype/jpype-0.6.2.ebuild
@@ -22,6 +22,8 @@ DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	>=virtual/jdk-1.6"
 
+PATCHES=( "${FILESDIR}"/${PN}-gcc6-noexcept.patch )
+
 python_compile() {
 	if ! python_is_python3; then
 		local CXXFLAGS="${CXXFLAGS} -fno-strict-aliasing"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=608920
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Upstream PR: https://github.com/originell/jpype/pull/207
Upstream commit: https://github.com/originell/jpype/commit/3a4fb98938afd9c03070086d1b8fda8841410fa3