### PR TITLE
dev-libs/msgpack: Fix building with GCC-6

### DIFF
--- a/dev-libs/msgpack/files/msgpack-1.1.0-gcc6.patch
+++ b/dev-libs/msgpack/files/msgpack-1.1.0-gcc6.patch
@@ -1,0 +1,22 @@
+Bug: https://bugs.gentoo.org/623492
+Backported from: https://github.com/msgpack/msgpack-c/commit/66a5fcf8f1a9e57b02904a6ac55a86a9c74ea1de
+
+--- a/include/msgpack/adaptor/detail/cpp11_msgpack_tuple.hpp
++++ b/include/msgpack/adaptor/detail/cpp11_msgpack_tuple.hpp
+@@ -46,13 +46,14 @@
+     public:
+         using base = std::tuple<Types...>;
+ 
+-        using base::base;
+ 
+-        tuple() = default;
+         tuple(tuple const&) = default;
+         tuple(tuple&&) = default;
+ 
+         template<typename... OtherTypes>
++        tuple(OtherTypes&&... other):base(std::forward<OtherTypes>(other)...) {}
++
++        template<typename... OtherTypes>
+         tuple(tuple<OtherTypes...> const& other):base(static_cast<std::tuple<OtherTypes...> const&>(other)) {}
+         template<typename... OtherTypes>
+         tuple(tuple<OtherTypes...> && other):base(static_cast<std::tuple<OtherTypes...> &&>(other)) {}

--- a/dev-libs/msgpack/msgpack-1.1.0.ebuild
+++ b/dev-libs/msgpack/msgpack-1.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -30,6 +30,7 @@ DOCS=( README.md )
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.0.0-cflags.patch
 	"${FILESDIR}"/${PN}-1.0.0-static.patch
+	"${FILESDIR}"/${P}-gcc6.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=623492
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch was back-ported from https://github.com/msgpack/msgpack-c/commit/66a5fcf8f1a9e57b02904a6ac55a86a9c74ea1de.