### PR TITLE
media-plugins/vdr-skinnopacity: change dependency for imagemagick-6

### DIFF
--- a/media-plugins/vdr-skinnopacity/metadata.xml
+++ b/media-plugins/vdr-skinnopacity/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/media-plugins/vdr-skinnopacity/vdr-skinnopacity-1.1.3-r1.ebuild
+++ b/media-plugins/vdr-skinnopacity/vdr-skinnopacity-1.1.3-r1.ebuild
@@ -19,8 +19,12 @@ IUSE=""
 
 RDEPEND="net-misc/curl
 	dev-libs/libxml2
-	virtual/imagemagick-tools
-	media-plugins/vdr-epgsearch"
+	media-plugins/vdr-epgsearch
+	|| (
+		<media-gfx/imagemagick-7[jpeg,png,svg,tiff]
+		media-gfx/graphicsmagick[imagemagick,jpeg,png,svg,tiff]
+	)"
+
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 

--- a/media-plugins/vdr-skinnopacity/vdr-skinnopacity-1.1.3-r1.ebuild
+++ b/media-plugins/vdr-skinnopacity/vdr-skinnopacity-1.1.3-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 MY_P="${P/vdr-}"
 VERSION="1743"
@@ -34,7 +34,7 @@ src_prepare() {
 	vdr-plugin-2_src_prepare
 
 	if has_version media-gfx/graphicsmagick; then
-		sed -i -e 's:^IMAGELIB =.*:IMAGELIB = graphicsmagick:' Makefile
+		sed -i -e 's:^IMAGELIB =.*:IMAGELIB = graphicsmagick:' Makefile || die
 	fi
 }
 


### PR DESCRIPTION
Does not build with imagemagick >=7 because of API changes in imagemagick
But it builds & runs well with imagemagick-6* and all versions of media-gfx/graphicsmagick

Fixes Gentoo-Bug: #623562
