### PR TITLE
app-admin/passwordsafe: take over as proxy-maintainer

### DIFF
--- a/app-admin/passwordsafe/metadata.xml
+++ b/app-admin/passwordsafe/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>hendrik@consetetur.de</email>
+		<name>Hendrik v. Raven (lorem_ipsum)</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<use>
 		<flag name="minimal">Avoid collision with <pkg>app-misc/pwsafe</pkg></flag>
 		<flag name="yubikey">Enable support for Yubikey</flag>


### PR DESCRIPTION
mrueg dropped this to maintainer-needed recently, I am using it on a daily basis and would like to take care of it as proxy-maintainer