### PR TITLE
dev-python/hyperlink: add missing setuptools dependency

### DIFF
--- a/dev-python/hyperlink/hyperlink-17.1.1.ebuild
+++ b/dev-python/hyperlink/hyperlink-17.1.1.ebuild
@@ -17,6 +17,7 @@ IUSE="test"
 
 RDEPEND=""
 DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? (
 		>=dev-python/pytest-2.9.2[${PYTHON_USEDEP}]
 		>=dev-python/pytest-cov-2.3.0[${PYTHON_USEDEP}]


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=626282