### PR TITLE
x11-wm/i3: Add GLOB_TILDE patch for musl

### DIFF
--- a/x11-wm/i3/files/i3-musl-GLOB_TILDE.patch
+++ b/x11-wm/i3/files/i3-musl-GLOB_TILDE.patch
@@ -1,0 +1,86 @@
+From: Natanael Copa <ncopa@alpinelinux.org>
+Patch-Source: https://git.alpinelinux.org/cgit/aports/tree/community/i3wm/musl.patch
+Project-Bug-URL: https://github.com/i3/i3/issues/1859
+Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=609306
+
+Musl doesn't implement GLOB_TILDE, which is used by i3 when expanding paths.
+
+This patch replaces usage of GLOB_TILDE in glob() by replacing tilde
+with the content of $HOME - if set - manually.
+
+As mentioned in the i3 bugtracker this is an issue that should be solved by musl.
+
+A patch has been sent to musl upstream, but it hasn't been merged yet:
+http://www.openwall.com/lists/musl/2017/01/17/1
+---
+--- i3-4.11/i3bar/src/main.c
++++ i3-4.11/i3bar/src/main.c
+@@ -45,14 +45,20 @@ void debuglog(char *fmt, ...) {
+  *
+  */
+ char *expand_path(char *path) {
+-    static glob_t globbuf;
+-    if (glob(path, GLOB_NOCHECK | GLOB_TILDE, NULL, &globbuf) < 0) {
+-        ELOG("glob() failed\n");
+-        exit(EXIT_FAILURE);
++    char *home, *expanded;
++
++    if (strncmp(path, "~/", 2) == 0) {
++        home = getenv("HOME");
++        if (home != NULL) {
++            /* new length: sum - 1 (omit '~') + 1 (for '\0') */
++            expanded = scalloc(strlen(home)+strlen(path), 1);
++            strcpy(expanded, home);
++            strcat(expanded, path+1);
++            return expanded;
++        }
+     }
+-    char *result = sstrdup(globbuf.gl_pathc > 0 ? globbuf.gl_pathv[0] : path);
+-    globfree(&globbuf);
+-    return result;
++
++    return sstrdup(path);
+ }
+
+ void print_usage(char *elf_name) {
+--- i3-4.11/libi3/resolve_tilde.c
++++ i3-4.11/libi3/resolve_tilde.c
+@@ -19,27 +19,18 @@
+  *
+  */
+ char *resolve_tilde(const char *path) {
+-    static glob_t globbuf;
+-    char *head, *tail, *result;
++    char *home, *expanded;
+
+-    tail = strchr(path, '/');
+-    head = sstrndup(path, tail ? (size_t)(tail - path) : strlen(path));
+-
+-    int res = glob(head, GLOB_TILDE, NULL, &globbuf);
+-    free(head);
+-    /* no match, or many wildcard matches are bad */
+-    if (res == GLOB_NOMATCH || globbuf.gl_pathc != 1)
+-        result = sstrdup(path);
+-    else if (res != 0) {
+-        err(EXIT_FAILURE, "glob() failed");
+-    } else {
+-        head = globbuf.gl_pathv[0];
+-        result = scalloc(strlen(head) + (tail ? strlen(tail) : 0) + 1, 1);
+-        strncpy(result, head, strlen(head));
+-        if (tail)
+-            strncat(result, tail, strlen(tail));
++    if (strncmp(path, "~/", 2) == 0) {
++        home = getenv("HOME");
++        if (home != NULL) {
++            /* new length: sum - 1 (omit '~') + 1 (for '\0') */
++            expanded = scalloc(strlen(home)+strlen(path), 1);
++            strcpy(expanded, home);
++            strcat(expanded, path+1);
++            return expanded;
++        }
+     }
+-    globfree(&globbuf);
+
+-    return result;
++    return sstrdup(path);
+ }

--- a/x11-wm/i3/i3-4.13-r1.ebuild
+++ b/x11-wm/i3/i3-4.13-r1.ebuild
@@ -38,6 +38,7 @@ RDEPEND="${CDEPEND}
 DOCS=( RELEASE-NOTES-${PV} )
 PATCHES=(
 	"${FILESDIR}/${P}-remove-git-polling.patch"
+	"${FILESDIR}/${PN}-musl-GLOB_TILDE.patch"
 )
 
 src_prepare() {

--- a/x11-wm/i3/i3-9999.ebuild
+++ b/x11-wm/i3/i3-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -36,6 +36,10 @@ RDEPEND="${CDEPEND}
 	dev-lang/perl
 	dev-perl/AnyEvent-I3
 	dev-perl/JSON-XS"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-musl-GLOB_TILDE.patch"
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Fixes bug [609306](https://bugs.gentoo.org/show_bug.cgi?id=609306).