### PR TITLE
games-simulation/openrct2: drop patches from live build

### DIFF
--- a/games-simulation/openrct2/openrct2-9999.ebuild
+++ b/games-simulation/openrct2/openrct2-9999.ebuild
@@ -52,11 +52,6 @@ DEPEND="${RDEPEND}
 	test? ( dev-cpp/gtest )
 "
 
-PATCHES=(
-	"${FILESDIR}/${PN}-0.1.0-remove-external-gtest.patch"
-	"${FILESDIR}/${PN}-0.1.0-respect-libdir.patch"
-)
-
 if [[ ${PV} == 9999 ]]; then
 src_unpack() {
 	default
@@ -73,6 +68,7 @@ src_configure() {
 		-DWITH_TESTS="$(usex test)"
 		-DDOWNLOAD_TITLE_SEQUENCES=OFF
 		-DDISABLE_RCT2_TESTS=ON
+		-DSYSTEM_GTEST=ON
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
Both patches are now upstream

Package-Manager: Portage-2.3.6, Repoman-2.3.3