### PR TITLE
Fix RDEPEND on sys-fs/btrfs-progs for app-backup/btrbk

### DIFF
--- a/app-backup/btrbk/btrbk-0.23.3.ebuild
+++ b/app-backup/btrbk/btrbk-0.23.3.ebuild
@@ -25,7 +25,7 @@ DEPEND=""
 RDEPEND="dev-lang/perl
 	net-misc/openssh
 	pv? ( sys-apps/pv )
-	>=sys-fs/btrfs-progs-3.18.2"
+	>=sys-fs/btrfs-progs-3.18.2 <sys-fs/btrfs-progs-4.8.3"
 
 src_install() {
 	emake DESTDIR="${D}" DOCDIR="/usr/share/doc/${PF}" SYSTEMDDIR="$(systemd_get_systemunitdir)" install

--- a/app-backup/btrbk/btrbk-0.24.0.ebuild
+++ b/app-backup/btrbk/btrbk-0.24.0.ebuild
@@ -25,7 +25,7 @@ DEPEND=""
 RDEPEND="dev-lang/perl
 	net-misc/openssh
 	pv? ( sys-apps/pv )
-	>=sys-fs/btrfs-progs-3.18.2"
+	>=sys-fs/btrfs-progs-3.18.2 <sys-fs/btrfs-progs-4.12"
 
 src_install() {
 	emake DESTDIR="${D}" DOCDIR="/usr/share/doc/${PF}" SYSTEMDDIR="$(systemd_get_systemunitdir)" install

--- a/app-backup/btrbk/btrbk-0.25.0.ebuild
+++ b/app-backup/btrbk/btrbk-0.25.0.ebuild
@@ -25,7 +25,7 @@ DEPEND=""
 RDEPEND="dev-lang/perl
 	net-misc/openssh
 	pv? ( sys-apps/pv )
-	>=sys-fs/btrfs-progs-3.18.2"
+	>=sys-fs/btrfs-progs-3.18.2 <sys-fs/btrfs-progs-4.12"
 
 src_install() {
 	emake DESTDIR="${D}" DOCDIR="/usr/share/doc/${PF}" SYSTEMDDIR="$(systemd_get_systemunitdir)" install


### PR DESCRIPTION
**btrbk <= v0.25.0** fails while parsing the output `btrfs subvolume show` which was changed in **btrfs-progs >= 4.12**. See btrbk commit: [6cf5d59](digint/btrbk@6cf5d59) for details.

For completeness, this patchset also fixes RDEPEND on btrbk-0.23.3, which had similar issues for btrfs-progs >= 4.8.3

This is fixed in btrbk-0.25.1 (not yet in portage tree)