### PR TITLE
Updated HOMEPAGE links http->https

### DIFF
--- a/app-emacs/emacs-wget/emacs-wget-0.5.0-r1.ebuild
+++ b/app-emacs/emacs-wget/emacs-wget-0.5.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Wget interface for Emacs"
-HOMEPAGE="http://www.emacswiki.org/emacs/EmacsWget"
+HOMEPAGE="https://www.emacswiki.org/emacs/EmacsWget"
 SRC_URI="http://pop-club.hp.infoseek.co.jp/emacs/emacs-wget/${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/emacs-wiki-blog/emacs-wiki-blog-0.5.ebuild
+++ b/app-emacs/emacs-wiki-blog/emacs-wiki-blog-0.5.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 inherit elisp
 
 DESCRIPTION="Emacs-Wiki add-on for maintaining a weblog"
-HOMEPAGE="http://www.emacswiki.org/emacs/EmacsWikiBlog"
+HOMEPAGE="https://www.emacswiki.org/emacs/EmacsWikiBlog"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/app-emacs/erobot/erobot-2.1.0-r1.ebuild
+++ b/app-emacs/erobot/erobot-2.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Battle-bots for Emacs!"
-HOMEPAGE="http://www.emacswiki.org/emacs/EmacsRobots"
+HOMEPAGE="https://www.emacswiki.org/emacs/EmacsRobots"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="GPL-2+"

--- a/dev-util/electron/electron-0.36.12-r5.ebuild
+++ b/dev-util/electron/electron-0.36.12-r5.ebuild
@@ -32,7 +32,7 @@ LIBCHROMIUMCONTENT_P="libchromiumcontent-${LIBCHROMIUMCONTENT_COMMIT}"
 ASAR_P="asar-${ASAR_VERSION}"
 
 DESCRIPTION="Cross platform application development framework based on web technologies"
-HOMEPAGE="http://electron.atom.io/"
+HOMEPAGE="https://electron.atom.io/"
 SRC_URI="
 	https://commondatastorage.googleapis.com/chromium-browser-official/${CHROMIUM_P}.tar.xz
 	https://github.com/electron/electron/archive/v${PV}.tar.gz -> ${P}.tar.gz

--- a/dev-util/electron/electron-0.37.8-r2.ebuild
+++ b/dev-util/electron/electron-0.37.8-r2.ebuild
@@ -33,7 +33,7 @@ LIBCHROMIUMCONTENT_P="libchromiumcontent-${LIBCHROMIUMCONTENT_COMMIT}"
 ASAR_P="asar-${ASAR_VERSION}"
 
 DESCRIPTION="Cross platform application development framework based on web technologies"
-HOMEPAGE="http://electron.atom.io/"
+HOMEPAGE="https://electron.atom.io/"
 SRC_URI="
 	https://commondatastorage.googleapis.com/chromium-browser-official/${CHROMIUM_P}.tar.xz
 	https://github.com/electron/electron/archive/v${PV}.tar.gz -> ${P}.tar.gz

--- a/dev-util/electron/electron-1.3.13-r1.ebuild
+++ b/dev-util/electron/electron-1.3.13-r1.ebuild
@@ -33,7 +33,7 @@ LIBCHROMIUMCONTENT_P="libchromiumcontent-${LIBCHROMIUMCONTENT_COMMIT}"
 ASAR_P="asar-${ASAR_VERSION}"
 
 DESCRIPTION="Cross platform application development framework based on web technologies"
-HOMEPAGE="http://electron.atom.io/"
+HOMEPAGE="https://electron.atom.io/"
 SRC_URI="
 	https://commondatastorage.googleapis.com/chromium-browser-official/${CHROMIUM_P}.tar.xz
 	https://github.com/electron/electron/archive/v${PV}.tar.gz -> ${P}.tar.gz


### PR DESCRIPTION
Updated HOMEPAGE links http->https
found with https://repology.org/repository/gentoo/problems