### PR TITLE
dev-python/pandocfilters: Drop $Id$ line

### DIFF
--- a/dev-python/pandocfilters/pandocfilters-1.2.4.ebuild
+++ b/dev-python/pandocfilters/pandocfilters-1.2.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/dev-python/pandocfilters/pandocfilters-1.4.1.ebuild
+++ b/dev-python/pandocfilters/pandocfilters-1.4.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 


### PR DESCRIPTION
@jlec @SoapGentoo @jonasstein 

As annotated in https://bugs.gentoo.org/show_bug.cgi?id=626194. Wasn't fast enough to change the PR prior to its merge.