### PR TITLE
app-text/searchmonkey: Fix building with GCC-6 and EAPI bump

### DIFF
--- a/app-text/searchmonkey/files/searchmonkey-2.0.0-gcc6.patch
+++ b/app-text/searchmonkey/files/searchmonkey-2.0.0-gcc6.patch
@@ -1,0 +1,14 @@
+Bug: https://bugs.gentoo.org/602166
+
+diff -Naur a/mainwindow.cpp b/mainwindow.cpp
+--- a/mainwindow.cpp	2017-07-31 18:06:33.206668001 -0400
++++ b/mainwindow.cpp	2017-07-31 18:07:09.685940997 -0400
+@@ -781,7 +781,7 @@
+  ******************************************************************************/
+ void MainWindow::find  () throw() {
+ 
+-	auto autoSettingsReset asr(sui);  // dtor calls sui->reset()
++	autoSettingsReset asr(sui);  // dtor calls sui->reset()
+ 
+ 	bool modeAdvanced = ui->actionAdvanced->isChecked();
+ 	qDebug() << "modeAdvanced-" << modeAdvanced;

--- a/app-text/searchmonkey/searchmonkey-2.0.0-r1.ebuild
+++ b/app-text/searchmonkey/searchmonkey-2.0.0-r1.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 
-inherit qt4-r2
+inherit eutils qmake-utils
 
 MY_PN=${PN}2
 MY_P=${PN}_v${PV}
@@ -15,7 +15,7 @@ SRC_URI="mirror://sourceforge/project/${PN}/S${MY_PN:1}/${PV}%20%5Bstable%5D/${M
 
 LICENSE="GPL-3"
 SLOT="2"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="
@@ -30,6 +30,10 @@ PATCHES=(
 	"${FILESDIR}"/${P}-gcc4.7.patch
 	"${FILESDIR}"/${P}-gcc6.patch
 )
+
+src_compile() {
+	eqmake4
+}
 
 src_install() {
 	newbin ${PN} ${MY_PN}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=602166
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Failed to build with GCC-6 due to deprecated (and utterly pointless) use of the `auto` keyword in the pre-C++11 context.

Project is dead and no place to submit upstream.