### PR TITLE
dev-cpp/gmock: Fix test failure with GCC-6

### DIFF
--- a/dev-cpp/gmock/files/gmock-1.7.0-gcc6.patch
+++ b/dev-cpp/gmock/files/gmock-1.7.0-gcc6.patch
@@ -1,0 +1,32 @@
+Bug: https://bugs.gentoo.org/602158
+Patch: https://github.com/google/googletest/issues/705#issuecomment-235067917
+
+--- a/include/gmock/gmock-spec-builders.h
++++ b/include/gmock/gmock-spec-builders.h
+@@ -1370,6 +1370,8 @@
+ template <>
+ class ActionResultHolder<void> : public UntypedActionResultHolderBase {
+  public:
++  explicit ActionResultHolder() {}
++
+   void GetValueAndDelete() const { delete this; }
+ 
+   virtual void PrintAsActionResult(::std::ostream* /* os */) const {}
+@@ -1381,7 +1383,7 @@
+       const typename Function<F>::ArgumentTuple& args,
+       const string& call_description) {
+     func_mocker->PerformDefaultAction(args, call_description);
+-    return NULL;
++    return new ActionResultHolder();
+   }
+ 
+   // Performs the given action and returns NULL.
+@@ -1390,7 +1392,7 @@
+       const Action<F>& action,
+       const typename Function<F>::ArgumentTuple& args) {
+     action.Perform(args);
+-    return NULL;
++    return new ActionResultHolder();
+   }
+ };
+ 

--- a/dev-cpp/gmock/gmock-1.7.0-r1.ebuild
+++ b/dev-cpp/gmock/gmock-1.7.0-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit libtool multilib-minimal python-any-r1
+inherit epatch libtool multilib-minimal python-any-r1
 
 DESCRIPTION="Google's C++ mocking framework"
 HOMEPAGE="https://github.com/google/googlemock"
@@ -34,6 +34,8 @@ src_unpack() {
 }
 
 src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc6.patch
+
 	sed -i -r \
 		-e '/^install-(data|exec)-local:/s|^.*$|&\ndisabled-&|' \
 		Makefile.in


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=602158
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Same issue from https://github.com/gentoo/gentoo/pull/5191.
Patch was taken from https://github.com/google/googletest/issues/705#issuecomment-235067917.