### PR TITLE
games-arcade/insaneodyssey: Fix building with GCC-6

### DIFF
--- a/games-arcade/insaneodyssey/files/insaneodyssey-000311-gcc6.patch
+++ b/games-arcade/insaneodyssey/files/insaneodyssey-000311-gcc6.patch
@@ -1,0 +1,21 @@
+Bug: https://bugs.gentoo.org/600894
+
+--- a/insaneodyssey/io.cpp
++++ b/insaneodyssey/io.cpp
+@@ -22,6 +22,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <cmath>
+ 
+ #include <SDL/SDL.h>
+ 
+@@ -894,7 +895,7 @@
+ 	else
+ 	{	
+ 	   if ( jumping )
+-	      yspeed = -jumpheight - abs(xspeed)/4;
++	      yspeed = -jumpheight - std::abs(xspeed)/4;
+ 	}
+ 
+     	short TempX = (x + width/2) / TILESIZE;

--- a/games-arcade/insaneodyssey/insaneodyssey-000311.ebuild
+++ b/games-arcade/insaneodyssey/insaneodyssey-000311.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -30,6 +30,9 @@ src_prepare() {
 		"${FILESDIR}"/${P}-datafiles.patch > "${T}"/datafiles.patch \
 		|| die
 		epatch "${T}"/datafiles.patch
+
+	epatch "${FILESDIR}"/${P}-gcc6.patch
+
 	sed -i \
 		-e "/lvl/s:^:${GAMES_DATADIR}/${PN}/:" \
 		-e "s:night:${GAMES_DATADIR}/${PN}/night:" \


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=600894
Package-Manager: Portage-2.3.6, Repoman-2.3.2

GCC-6 includes its own versions of `cstdlib` and `cmath` headers which wrap around the C versions but also add its own overloads.  This, and implementation as real functions instead of macros, can cause ambiguity errors in function calls like `abs(float)`.  In the case of `abs(float)`, It appears to suffice to include `<cmath>` and qualify the function in `std` namespace.  Tested with gcc-6.3.0 and gcc-5.4.0.

Not submitted upstream as it no longer exists.