### PR TITLE
media-sound/audacious: Fix building with -Werror=terminate using GCC-6

### DIFF
--- a/media-sound/audacious/audacious-3.7.1-r1.ebuild
+++ b/media-sound/audacious/audacious-3.7.1-r1.ebuild
@@ -41,6 +41,10 @@ DEPEND="${RDEPEND}
 
 PDEPEND="~media-plugins/audacious-plugins-${PV}"
 
+src_prepare() {
+	epatch "${FILESDIR}"/${P}-c++11-throw-in-dtors.patch
+}
+
 src_unpack() {
 	default
 	if use gtk3 ; then

--- a/media-sound/audacious/files/audacious-3.7.1-c++11-throw-in-dtors.patch
+++ b/media-sound/audacious/files/audacious-3.7.1-c++11-throw-in-dtors.patch
@@ -1,0 +1,39 @@
+Bug: https://bugs.gentoo.org/600882
+Upstream commit: https://github.com/audacious-media-player/audacious/commit/1cf1a81a16cc70b2d9c78994ad98e26db99943ed
+
+From 1cf1a81a16cc70b2d9c78994ad98e26db99943ed Mon Sep 17 00:00:00 2001
+From: John Lindgren <john.lindgren@aol.com>
+Date: Sun, 8 May 2016 22:39:00 -0400
+Subject: [PATCH] Fix compiler warning.
+
+---
+ src/libaudcore/objects.h    | 2 +-
+ src/libaudcore/stringbuf.cc | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libaudcore/objects.h b/src/libaudcore/objects.h
+index fd57f5e15..4b98cc624 100644
+--- a/src/libaudcore/objects.h
++++ b/src/libaudcore/objects.h
+@@ -250,7 +250,7 @@ class StringBuf
+     }
+ 
+     // only allowed for top (or null) string
+-    ~StringBuf ();
++    ~StringBuf () noexcept (false);
+ 
+     // only allowed for top (or null) string
+     void resize (int size);
+diff --git a/src/libaudcore/stringbuf.cc b/src/libaudcore/stringbuf.cc
+index 041b1e9de..fc646f6ab 100644
+--- a/src/libaudcore/stringbuf.cc
++++ b/src/libaudcore/stringbuf.cc
+@@ -139,7 +139,7 @@ EXPORT void StringBuf::resize (int len)
+     }
+ }
+ 
+-EXPORT StringBuf::~StringBuf ()
++EXPORT StringBuf::~StringBuf () noexcept (false)
+ {
+     if (m_data)
+     {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=600882
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Patch taken from https://github.com/audacious-media-player/audacious/commit/1cf1a81a16cc70b2d9c78994ad98e26db99943ed.

No need for conditional checks for the c++dialect as audacious forces `-std=gnu++11` in its build.