### PR TITLE
net-im/psi: fixed wrong path to new history patch

### DIFF
--- a/net-im/psi/psi-9999.ebuild
+++ b/net-im/psi/psi-9999.ebuild
@@ -126,7 +126,7 @@ src_prepare() {
 		fi
 
 		eapply "${WORKDIR}/psi-plus/patches"/*.diff
-		use sql && eapply "${PATCHES_DIR}/dev/psi-new-history.patch"
+		use sql && eapply "${WORKDIR}/psi-plus/patches/dev/psi-new-history.patch"
 
 		vergen="${WORKDIR}/psi-plus/admin/psi-plus-nightly-version"
 		features="$(use webkit && echo '--webkit') $(use webengine && echo '--webengine') $(use sql && echo '--sql')"


### PR DESCRIPTION
It seems that was left unnoticed after all the changes.