### PR TITLE
dev-libs/msgpack: fix -Wimplicit-fallthrough

### DIFF
--- a/dev-libs/msgpack/files/msgpack-2.0.0-gcc7-implicit-fallthrough.patch
+++ b/dev-libs/msgpack/files/msgpack-2.0.0-gcc7-implicit-fallthrough.patch
@@ -1,0 +1,1798 @@
+diff -aurP msgpack-2.0.0/erb/v1/cpp03_define_array.hpp.erb msgpack-2.0.0.new/erb/v1/cpp03_define_array.hpp.erb
+--- msgpack-2.0.0/erb/v1/cpp03_define_array.hpp.erb	2016-06-18 18:20:36.000000000 -0500
++++ msgpack-2.0.0.new/erb/v1/cpp03_define_array.hpp.erb	2017-08-01 17:20:57.803000361 -0500
+@@ -66,7 +66,9 @@
+             msgpack::object *ptr = o.via.array.ptr;
+             switch(size) {
+             default:<%(i).downto(0) {|j|%>
+-            case <%=j+1%>: ptr[<%=j%>].convert(a<%=j%>);<%}%>
++            case <%=j+1%>: ptr[<%=j%>].convert(a<%=j%>);
++            // fallthrough
++<%}%>
+             }
+         }
+     }
+diff -aurP msgpack-2.0.0/include/msgpack/unpack_template.h msgpack-2.0.0.new/include/msgpack/unpack_template.h
+--- msgpack-2.0.0/include/msgpack/unpack_template.h	2016-05-27 21:10:28.000000000 -0500
++++ msgpack-2.0.0.new/include/msgpack/unpack_template.h	2017-08-01 17:20:49.389000738 -0500
+@@ -248,6 +248,7 @@
+ 
+             _fixed_trail_again:
+                 ++p;
++                // fallthrough
+ 
+             default:
+                 if((size_t)(pe - p) < trail) { goto _out; }
+diff -aurP msgpack-2.0.0/include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp msgpack-2.0.0.new/include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp
+--- msgpack-2.0.0/include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp	2016-06-24 21:16:43.000000000 -0500
++++ msgpack-2.0.0.new/include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp	2017-08-01 17:23:32.690993409 -0500
+@@ -67,6 +67,8 @@
+             switch(size) {
+             default:
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -105,7 +107,9 @@
+             switch(size) {
+             default:
+             case 2: ptr[1].convert(a1);
++            // fallthrough
+             case 1: ptr[0].convert(a0);
++            // fallthrough
+             }
+         }
+     }
+@@ -147,8 +151,14 @@
+             switch(size) {
+             default:
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -193,9 +203,13 @@
+             switch(size) {
+             default:
+             case 4: ptr[3].convert(a3);
++            // fallthrough
+             case 3: ptr[2].convert(a2);
++            // fallthrough
+             case 2: ptr[1].convert(a1);
++            // fallthrough
+             case 1: ptr[0].convert(a0);
++            // fallthrough
+             }
+         }
+     }
+@@ -243,10 +257,20 @@
+             switch(size) {
+             default:
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -297,11 +321,23 @@
+             switch(size) {
+             default:
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -355,12 +391,26 @@
+             switch(size) {
+             default:
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -417,13 +467,29 @@
+             switch(size) {
+             default:
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -483,14 +549,32 @@
+             switch(size) {
+             default:
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -553,15 +637,35 @@
+             switch(size) {
+             default:
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -627,16 +731,38 @@
+             switch(size) {
+             default:
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -705,17 +831,41 @@
+             switch(size) {
+             default:
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -787,18 +937,44 @@
+             switch(size) {
+             default:
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -873,19 +1049,47 @@
+             switch(size) {
+             default:
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -963,20 +1167,50 @@
+             switch(size) {
+             default:
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1057,21 +1291,53 @@
+             switch(size) {
+             default:
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1155,22 +1421,56 @@
+             switch(size) {
+             default:
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1257,23 +1557,59 @@
+             switch(size) {
+             default:
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1363,24 +1699,62 @@
+             switch(size) {
+             default:
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1473,25 +1847,65 @@
+             switch(size) {
+             default:
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1587,26 +2001,68 @@
+             switch(size) {
+             default:
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1705,27 +2161,71 @@
+             switch(size) {
+             default:
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1827,28 +2327,74 @@
+             switch(size) {
+             default:
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -1953,29 +2499,77 @@
+             switch(size) {
+             default:
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -2083,30 +2677,80 @@
+             switch(size) {
+             default:
+             case 25: ptr[24].convert(a24);
++            // fallthrough
++
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -2217,31 +2861,83 @@
+             switch(size) {
+             default:
+             case 26: ptr[25].convert(a25);
++            // fallthrough
++
+             case 25: ptr[24].convert(a24);
++            // fallthrough
++
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -2355,32 +3051,86 @@
+             switch(size) {
+             default:
+             case 27: ptr[26].convert(a26);
++            // fallthrough
++
+             case 26: ptr[25].convert(a25);
++            // fallthrough
++
+             case 25: ptr[24].convert(a24);
++            // fallthrough
++
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -2497,33 +3247,89 @@
+             switch(size) {
+             default:
+             case 28: ptr[27].convert(a27);
++            // fallthrough
++
+             case 27: ptr[26].convert(a26);
++            // fallthrough
++
+             case 26: ptr[25].convert(a25);
++            // fallthrough
++
+             case 25: ptr[24].convert(a24);
++            // fallthrough
++
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -2643,34 +3449,92 @@
+             switch(size) {
+             default:
+             case 29: ptr[28].convert(a28);
++            // fallthrough
++
+             case 28: ptr[27].convert(a27);
++            // fallthrough
++
+             case 27: ptr[26].convert(a26);
++            // fallthrough
++
+             case 26: ptr[25].convert(a25);
++            // fallthrough
++
+             case 25: ptr[24].convert(a24);
++            // fallthrough
++
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -2793,35 +3657,95 @@
+             switch(size) {
+             default:
+             case 30: ptr[29].convert(a29);
++            // fallthrough
++
+             case 29: ptr[28].convert(a28);
++            // fallthrough
++
+             case 28: ptr[27].convert(a27);
++            // fallthrough
++
+             case 27: ptr[26].convert(a26);
++            // fallthrough
++
+             case 26: ptr[25].convert(a25);
++            // fallthrough
++
+             case 25: ptr[24].convert(a24);
++            // fallthrough
++
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -2947,36 +3871,98 @@
+             switch(size) {
+             default:
+             case 31: ptr[30].convert(a30);
++            // fallthrough
++
+             case 30: ptr[29].convert(a29);
++            // fallthrough
++
+             case 29: ptr[28].convert(a28);
++            // fallthrough
++
+             case 28: ptr[27].convert(a27);
++            // fallthrough
++
+             case 27: ptr[26].convert(a26);
++            // fallthrough
++
+             case 26: ptr[25].convert(a25);
++            // fallthrough
++
+             case 25: ptr[24].convert(a24);
++            // fallthrough
++
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }
+@@ -3105,37 +4091,101 @@
+             switch(size) {
+             default:
+             case 32: ptr[31].convert(a31);
++            // fallthrough
++
+             case 31: ptr[30].convert(a30);
++            // fallthrough
++
+             case 30: ptr[29].convert(a29);
++            // fallthrough
++
+             case 29: ptr[28].convert(a28);
++            // fallthrough
++
+             case 28: ptr[27].convert(a27);
++            // fallthrough
++
+             case 27: ptr[26].convert(a26);
++            // fallthrough
++
+             case 26: ptr[25].convert(a25);
++            // fallthrough
++
+             case 25: ptr[24].convert(a24);
++            // fallthrough
++
+             case 24: ptr[23].convert(a23);
++            // fallthrough
++
+             case 23: ptr[22].convert(a22);
++            // fallthrough
++
+             case 22: ptr[21].convert(a21);
++            // fallthrough
++
+             case 21: ptr[20].convert(a20);
++            // fallthrough
++
+             case 20: ptr[19].convert(a19);
++            // fallthrough
++
+             case 19: ptr[18].convert(a18);
++            // fallthrough
++
+             case 18: ptr[17].convert(a17);
++            // fallthrough
++
+             case 17: ptr[16].convert(a16);
++            // fallthrough
++
+             case 16: ptr[15].convert(a15);
++            // fallthrough
++
+             case 15: ptr[14].convert(a14);
++            // fallthrough
++
+             case 14: ptr[13].convert(a13);
++            // fallthrough
++
+             case 13: ptr[12].convert(a12);
++            // fallthrough
++
+             case 12: ptr[11].convert(a11);
++            // fallthrough
++
+             case 11: ptr[10].convert(a10);
++            // fallthrough
++
+             case 10: ptr[9].convert(a9);
++            // fallthrough
++
+             case 9: ptr[8].convert(a8);
++            // fallthrough
++
+             case 8: ptr[7].convert(a7);
++            // fallthrough
++
+             case 7: ptr[6].convert(a6);
++            // fallthrough
++
+             case 6: ptr[5].convert(a5);
++            // fallthrough
++
+             case 5: ptr[4].convert(a4);
++            // fallthrough
++
+             case 4: ptr[3].convert(a3);
++            // fallthrough
++
+             case 3: ptr[2].convert(a2);
++            // fallthrough
++
+             case 2: ptr[1].convert(a1);
++            // fallthrough
++
+             case 1: ptr[0].convert(a0);
++            // fallthrough
++
+             }
+         }
+     }

--- a/dev-libs/msgpack/msgpack-2.0.0.ebuild
+++ b/dev-libs/msgpack/msgpack-2.0.0.ebuild
@@ -29,6 +29,10 @@ DEPEND="
 
 DOCS=( README.md )
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.0.0-gcc7-implicit-fallthrough.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 	    -DMSGPACK_ENABLE_CXX=$(usex cxx)


### PR DESCRIPTION
Patches taken from upstream and rebased against this particular
release. Future releases should not require this patch, and it
only affects formatting.

Package-Manager: Portage-2.3.6, Repoman-2.3.3