### PR TITLE
media-gfx/exact-image: Fix building with GCC-6

### DIFF
--- a/media-gfx/exact-image/exact-image-0.8.1-r3.ebuild
+++ b/media-gfx/exact-image/exact-image-0.8.1-r3.ebuild
@@ -47,7 +47,8 @@ pkg_setup() {
 src_prepare() {
 	eapply \
 		"${FILESDIR}"/${PN}-0.7.5-libpng14.patch \
-		"${FILESDIR}"/${P}-libpng15.patch
+		"${FILESDIR}"/${P}-libpng15.patch \
+		"${FILESDIR}"/${P}-gcc6.patch
 	eapply_user
 
 	# fix python hardcoded path wrt bug #327171

--- a/media-gfx/exact-image/files/exact-image-0.8.1-gcc6.patch
+++ b/media-gfx/exact-image/files/exact-image-0.8.1-gcc6.patch
@@ -1,0 +1,139 @@
+Bug: https://bugs.gentoo.org/600380
+
+--- a/bardecode/code25i.hh
++++ b/bardecode/code25i.hh
+@@ -20,6 +20,12 @@
+ 
+ #include "scanner_utils.hh"
+ 
++#if __cplusplus >= 201103L
++#define STATIC_CONST_DOUBLE static constexpr double
++#else
++#define STATIC_CONST_DOUBLE static const double
++#endif
++
+ namespace BarDecode
+ {
+     struct code25i_t
+@@ -37,11 +43,11 @@
+ 	#define w_hq 1.5
+ 	#define tol 0.2
+ #else
+-        static const double n_lq = 15;
+-        static const double n_hq = 5.3;
+-        static const double w_lq = 5.2;
+-        static const double w_hq = 1.5;
+-        static const double tol = 0.2;
++        STATIC_CONST_DOUBLE n_lq = 15;
++        STATIC_CONST_DOUBLE n_hq = 5.3;
++        STATIC_CONST_DOUBLE w_lq = 5.2;
++        STATIC_CONST_DOUBLE w_hq = 1.5;
++        STATIC_CONST_DOUBLE tol = 0.2;
+ #endif
+         static const usize_t min_quiet_usize = 5;
+         //static const usize_t min_quiet_usize = 10;
+--- a/codecs/bmp.cc
++++ b/codecs/bmp.cc
+@@ -473,7 +473,7 @@
+ 	  std::cerr << "scanline " << row << " Seek error: " << stream->tellg() << " vs " << offset << std::endl;
+ 	}
+ 	
+-	if (stream->read ((char*)row_data, file_stride) < 0) {
++	if (!static_cast<bool>(stream->read ((char*)row_data, file_stride))) {
+ 	  std::cerr << "scanline " << row << ": Read error\n";
+ 	}
+ 	
+--- a/codecs/dcraw.h
++++ b/codecs/dcraw.h
+@@ -3958,22 +3958,22 @@
+     -2,+0,+0,-1,0,0x06, -2,+0,+0,+0,1,0x02, -2,+0,+0,+1,0,0x03,
+     -2,+1,-1,+0,0,0x04, -2,+1,+0,-1,1,0x04, -2,+1,+0,+0,0,0x06,
+     -2,+1,+0,+1,0,0x02, -2,+2,+0,+0,1,0x04, -2,+2,+0,+1,0,0x04,
+-    -1,-2,-1,+0,0,0x80, -1,-2,+0,-1,0,0x01, -1,-2,+1,-1,0,0x01,
+-    -1,-2,+1,+0,1,0x01, -1,-1,-1,+1,0,0x88, -1,-1,+1,-2,0,0x40,
++    -1,-2,-1,+0,0,(signed char) 0x80, -1,-2,+0,-1,0,0x01, -1,-2,+1,-1,0,0x01,
++    -1,-2,+1,+0,1,0x01, -1,-1,-1,+1,0,(signed char) 0x88, -1,-1,+1,-2,0,0x40,
+     -1,-1,+1,-1,0,0x22, -1,-1,+1,+0,0,0x33, -1,-1,+1,+1,1,0x11,
+     -1,+0,-1,+2,0,0x08, -1,+0,+0,-1,0,0x44, -1,+0,+0,+1,0,0x11,
+     -1,+0,+1,-2,1,0x40, -1,+0,+1,-1,0,0x66, -1,+0,+1,+0,1,0x22,
+     -1,+0,+1,+1,0,0x33, -1,+0,+1,+2,1,0x10, -1,+1,+1,-1,1,0x44,
+     -1,+1,+1,+0,0,0x66, -1,+1,+1,+1,0,0x22, -1,+1,+1,+2,0,0x10,
+     -1,+2,+0,+1,0,0x04, -1,+2,+1,+0,1,0x04, -1,+2,+1,+1,0,0x04,
+-    +0,-2,+0,+0,1,0x80, +0,-1,+0,+1,1,0x88, +0,-1,+1,-2,0,0x40,
++    +0,-2,+0,+0,1,(signed char) 0x80, +0,-1,+0,+1,1,(signed char) 0x88, +0,-1,+1,-2,0,0x40,
+     +0,-1,+1,+0,0,0x11, +0,-1,+2,-2,0,0x40, +0,-1,+2,-1,0,0x20,
+     +0,-1,+2,+0,0,0x30, +0,-1,+2,+1,1,0x10, +0,+0,+0,+2,1,0x08,
+     +0,+0,+2,-2,1,0x40, +0,+0,+2,-1,0,0x60, +0,+0,+2,+0,1,0x20,
+     +0,+0,+2,+1,0,0x30, +0,+0,+2,+2,1,0x10, +0,+1,+1,+0,0,0x44,
+     +0,+1,+1,+2,0,0x10, +0,+1,+2,-1,1,0x40, +0,+1,+2,+0,0,0x60,
+-    +0,+1,+2,+1,0,0x20, +0,+1,+2,+2,0,0x10, +1,-2,+1,+0,0,0x80,
+-    +1,-1,+1,+1,0,0x88, +1,+0,+1,+2,0,0x08, +1,+0,+2,-1,0,0x40,
++    +0,+1,+2,+1,0,0x20, +0,+1,+2,+2,0,0x10, +1,-2,+1,+0,0,(signed char) 0x80,
++    +1,-1,+1,+1,0,(signed char) 0x88, +1,+0,+1,+2,0,0x08, +1,+0,+2,-1,0,0x40,
+     +1,+0,+2,+1,0,0x10
+   }, chood[] = { -1,-1, -1,0, -1,+1, 0,+1, +1,+1, +1,0, +1,-1, 0,-1 };
+   ushort (*brow[5])[4], *pix;
+@@ -6341,11 +6341,11 @@
+ 	{ 10793,-3791,-1146,-7498,15177,2488,-1390,1577,7321 } },
+     { "OLYMPUS C80", 0, 0,
+ 	{ 8606,-2509,-1014,-8238,15714,2703,-942,979,7760 } },
+-    { "OLYMPUS E-10", 0, 0xffc0,
++    { "OLYMPUS E-10", 0, (short) 0xffc0,
+ 	{ 12745,-4500,-1416,-6062,14542,1580,-1934,2256,6603 } },
+-    { "OLYMPUS E-1", 0, 0xfff0,
++    { "OLYMPUS E-1", 0, (short) 0xfff0,
+ 	{ 11846,-4767,-945,-7027,15878,1089,-2699,4122,8311 } },
+-    { "OLYMPUS E-20", 0, 0xffc0,
++    { "OLYMPUS E-20", 0, (short) 0xffc0,
+ 	{ 13173,-4732,-1499,-5807,14036,1895,-2045,2452,7142 } },
+     { "OLYMPUS E-300", 0, 0,
+ 	{ 7828,-1761,-348,-5788,14071,1830,-2853,4518,6557 } },
+@@ -6353,7 +6353,7 @@
+ 	{ 8961,-2473,-1084,-7979,15990,2067,-2319,3035,8249 } },
+     { "OLYMPUS E-3", 0, 0xf99,
+ 	{ 9487,-2875,-1115,-7533,15606,2010,-1618,2100,7389 } },
+-    { "OLYMPUS E-400", 0, 0xfff0,
++    { "OLYMPUS E-400", 0, (short) 0xfff0,
+ 	{ 6169,-1483,-21,-7107,14761,2536,-2904,3580,8568 } },
+     { "OLYMPUS E-410", 0, 0xf6a,
+ 	{ 8856,-2582,-1026,-7761,15766,2082,-2009,2575,7469 } },
+@@ -6399,23 +6399,23 @@
+ 	{ 9186,-2678,-907,-8693,16517,2260,-1129,1094,8524 } },
+     { "PENTAX K2000", 0, 0,
+ 	{ 11057,-3604,-1155,-5152,13046,2329,-282,375,8104 } },
+-    { "Panasonic DMC-FZ8", 0, 0xf7f0,
++    { "Panasonic DMC-FZ8", 0, (short) 0xf7f0,
+ 	{ 8986,-2755,-802,-6341,13575,3077,-1476,2144,6379 } },
+     { "Panasonic DMC-FZ18", 0, 0,
+ 	{ 9932,-3060,-935,-5809,13331,2753,-1267,2155,5575 } },
+     { "Panasonic DMC-FZ28", 15, 0xfff,
+ 	{ 10109,-3488,-993,-5412,12812,2916,-1305,2140,5543 } },
+-    { "Panasonic DMC-FZ30", 0, 0xf94c,
++    { "Panasonic DMC-FZ30", 0, (short) 0xf94c,
+ 	{ 10976,-4029,-1141,-7918,15491,2600,-1670,2071,8246 } },
+-    { "Panasonic DMC-FZ50", 0, 0xfff0,	/* aka "LEICA V-LUX1" */
++    { "Panasonic DMC-FZ50", 0, (short) 0xfff0,	/* aka "LEICA V-LUX1" */
+ 	{ 7906,-2709,-594,-6231,13351,3220,-1922,2631,6537 } },
+     { "Panasonic DMC-L10", 15, 0xf96,
+ 	{ 8025,-1942,-1050,-7920,15904,2100,-2456,3005,7039 } },
+-    { "Panasonic DMC-L1", 0, 0xf7fc,	/* aka "LEICA DIGILUX 3" */
++    { "Panasonic DMC-L1", 0, (short) 0xf7fc,	/* aka "LEICA DIGILUX 3" */
+ 	{ 8054,-1885,-1025,-8349,16367,2040,-2805,3542,7629 } },
+     { "Panasonic DMC-LC1", 0, 0,	/* aka "LEICA DIGILUX 2" */
+ 	{ 11340,-4069,-1275,-7555,15266,2448,-2960,3426,7685 } },
+-    { "Panasonic DMC-LX1", 0, 0xf7f0,	/* aka "LEICA D-LUX2" */
++    { "Panasonic DMC-LX1", 0, (short) 0xf7f0,	/* aka "LEICA D-LUX2" */
+ 	{ 10704,-4187,-1230,-8314,15952,2501,-920,945,8927 } },
+     { "Panasonic DMC-LX2", 0, 0,	/* aka "LEICA D-LUX3" */
+ 	{ 8048,-2810,-623,-6450,13519,3272,-1700,2146,7049 } },
+--- a/codecs/raw.cc
++++ b/codecs/raw.cc
+@@ -66,7 +66,7 @@
+   if (!image.getRawData())
+     return false;
+ 
+-  return stream->write ((char*)image.getRawData(), image.stride()*image.h)
++  return static_cast<bool>(stream->write ((char*)image.getRawData(), image.stride()*image.h))
+     /* ==
+        (size_t) image.stride()*image.h*/;
+ }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=600380
Package-Manager: Portage-2.3.6, Repoman-2.3.2

This fixes GCC-6 porting issues related to narrowing conversions in brace initialization and invalid implicit conversion from stream object to `bool.

There was also the problem of `static const` in-class initialization of non-integral types.  This is relaxed for floating-point types with GCC using C++98 but not C++11/14.  The dialect-neutral way of handling this is to declare such variables as `static const` in-class in the header but define and initialize them as `const` in a relevant source file.  All attempts as such failed with ODR violations at link-time.   Resorting to `constexpr` with conditional dialect-dependent `#define`s sufficed.

Upstream doesn't provide any official means of commit or patch submission.  Furthermore, having tested later versions, the GCC-6/GCC-5 related bugs become more egregious (eg., use of `goto`s leading to errors of the type `error: jump to label 'foo' from here crosses initialization of 'bar x'`).