### PR TITLE
dev-python/ipython: break circular deps with USE=notebook

### DIFF
--- a/dev-python/ipython/ipython-5.3.0.ebuild
+++ b/dev-python/ipython/ipython-5.3.0.ebuild
@@ -36,10 +36,6 @@ CDEPEND="
 
 RDEPEND="${CDEPEND}
 	virtual/python-pathlib[${PYTHON_USEDEP}]
-	notebook? (
-		dev-python/notebook[${PYTHON_USEDEP}]
-		dev-python/ipywidgets[${PYTHON_USEDEP}]
-	)
 	nbconvert? ( dev-python/nbconvert[${PYTHON_USEDEP}] )"
 DEPEND="${CDEPEND}
 	>=dev-python/setuptools-18.5[${PYTHON_USEDEP}]
@@ -72,6 +68,10 @@ DEPEND="${CDEPEND}
 	)"
 
 PDEPEND="
+	notebook? (
+		dev-python/notebook[${PYTHON_USEDEP}]
+		dev-python/ipywidgets[${PYTHON_USEDEP}]
+	)
 	qt4? ( dev-python/qtconsole )
 	smp? ( dev-python/ipyparallel[${PYTHON_USEDEP}] )"
 

--- a/dev-python/ipython/ipython-5.4.1.ebuild
+++ b/dev-python/ipython/ipython-5.4.1.ebuild
@@ -32,10 +32,6 @@ CDEPEND="
 
 RDEPEND="${CDEPEND}
 	virtual/python-pathlib[${PYTHON_USEDEP}]
-	notebook? (
-		dev-python/notebook[${PYTHON_USEDEP}]
-		dev-python/ipywidgets[${PYTHON_USEDEP}]
-	)
 	nbconvert? ( dev-python/nbconvert[${PYTHON_USEDEP}] )"
 DEPEND="${CDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]
@@ -57,6 +53,10 @@ DEPEND="${CDEPEND}
 	)"
 
 PDEPEND="
+	notebook? (
+		dev-python/notebook[${PYTHON_USEDEP}]
+		dev-python/ipywidgets[${PYTHON_USEDEP}]
+	)
 	qt4? ( dev-python/qtconsole[${PYTHON_USEDEP}] )
 	qt5? ( dev-python/qtconsole[${PYTHON_USEDEP}] )
 	smp? ( dev-python/ipyparallel[${PYTHON_USEDEP}] )"

--- a/dev-python/ipython/ipython-6.1.0.ebuild
+++ b/dev-python/ipython/ipython-6.1.0.ebuild
@@ -31,10 +31,6 @@ CDEPEND="
 "
 
 RDEPEND="${CDEPEND}
-	notebook? (
-		dev-python/notebook[${PYTHON_USEDEP}]
-		dev-python/ipywidgets[${PYTHON_USEDEP}]
-	)
 	nbconvert? ( dev-python/nbconvert[${PYTHON_USEDEP}] )
 "
 
@@ -56,6 +52,10 @@ DEPEND="${CDEPEND}
 "
 
 PDEPEND="
+	notebook? (
+		dev-python/notebook[${PYTHON_USEDEP}]
+		dev-python/ipywidgets[${PYTHON_USEDEP}]
+	)
 	qt4? ( dev-python/qtconsole[${PYTHON_USEDEP}] )
 	qt5? ( dev-python/qtconsole[${PYTHON_USEDEP}] )
 	smp? ( dev-python/ipyparallel[${PYTHON_USEDEP}] )


### PR DESCRIPTION
ipython[notebook] creates a circular dependency as notebook depends on ipykernel which depends on ipython. Same for ipywidgets. Solve this by moving the conditional dep to PDEPEND.
nbconvert is mentioned in the bug as well, but it seems to be fine.

Gentoo-Bug: [626110](https://bugs.gentoo.org/show_bug.cgi?id=626110)

Package-Manager: Portage-2.3.6, Repoman-2.3.3