### PR TITLE
remove gnome dependency from plasma-pa

### DIFF
--- a/kde-plasma/plasma-pa/plasma-pa-5.10.4.ebuild
+++ b/kde-plasma/plasma-pa/plasma-pa-5.10.4.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	dev-libs/glib:2
 	gnome-base/gconf:2
 	media-libs/libcanberra
-	media-sound/pulseaudio[gnome]
+	media-sound/pulseaudio
 "
 
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
@gentoo/kde

Please remove the [gnome] use flag from the pulseaudio dependency.

For several kde updates plasma-pa is the only package wanting to pull in gnome on my kde installation. I did not notice any negative impact when removing the use flag from the pulseaudio dependency by hand for several versions/month now.