### PR TITLE
app-crypt/gentoo-keys: Bump to EAPI 6, fix Gento-Bug 566782

### DIFF
--- a/app-crypt/gentoo-keys/gentoo-keys-201607021514-r1.ebuild
+++ b/app-crypt/gentoo-keys/gentoo-keys-201607021514-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 2014-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+DESCRIPTION="A Openpgp/gpg keyring of official Gentoo release media gpg keys"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Gentoo-keys"
+SRC_URI="https://dev.gentoo.org/~dolsen/releases/keyrings/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc64 ~ppc ~sparc ~x86 ~arm64 ~x86-fbsd ~amd64-fbsd ~m68k ~mips ~s390 ~sh"
+
+DEPEND=""
+RDEPEND=""
+
+S="${WORKDIR}"
+
+src_install(){
+	insinto /var/lib/gentoo/gkeys/keyrings
+	doins -r gentoo
+	fperms -R 700 /var/lib/gentoo/gkeys/keyrings/gentoo/release/
+}


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/566782

Package-Manager: Portage-2.3.6, Repoman-2.3.1