### PR TITLE
games-strategy/ja2-stracciatella: Fix building with GCC-6

### DIFF
--- a/games-strategy/ja2-stracciatella/files/ja2-stracciatella-0.12.1_p7072-gcc6.patch
+++ b/games-strategy/ja2-stracciatella/files/ja2-stracciatella-0.12.1_p7072-gcc6.patch
@@ -1,0 +1,13 @@
+Bug: https://bugs.gentoo.org/600082
+
+--- a/Build/Laptop/BobbyRGuns.cc
++++ b/Build/Laptop/BobbyRGuns.cc
+@@ -700,7 +700,7 @@
+ 	//center picture in frame
+ 	ETRLEObject const& pTrav   = uiImage->SubregionProperties(0);
+ 	UINT32      const  usWidth = pTrav.usWidth;
+-	INT16       const  sCenX   = PosX + abs(BOBBYR_GRID_PIC_WIDTH - usWidth) / 2 - pTrav.sOffsetX;
++	INT16       const  sCenX   = PosX + (BOBBYR_GRID_PIC_WIDTH - usWidth) / 2 - pTrav.sOffsetX;
+ 	INT16       const  sCenY   = PosY + 8;
+ 
+ 	//blt the shadow of the item

--- a/games-strategy/ja2-stracciatella/ja2-stracciatella-0.12.1_p7072.ebuild
+++ b/games-strategy/ja2-stracciatella/ja2-stracciatella-0.12.1_p7072.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils games
 
 DESCRIPTION="A port of Jagged Alliance 2 to SDL"
-HOMEPAGE="http://tron.homeunix.org/ja2/"
+HOMEPAGE="https://ja2-stracciatella.github.io/"
 SRC_URI="https://dev.gentoo.org/~hasufell/distfiles/${P}.tar.xz
 	http://tron.homeunix.org/ja2/editor.slf.gz"
 
@@ -25,6 +25,7 @@ REQUIRED_USE="^^ ( ${LANGS//+/} )"
 
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-makefile.patch
+	epatch "${FILESDIR}"/${P}-gcc6.patch
 
 	sed \
 		-e "s:/some/place/where/the/data/is:${GAMES_DATADIR}/ja2:" \


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=600082
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Taking the `abs()` of an unsigned integral value was always pointless.  And as GCC-6 no longer defines `abs()` as a macro and C++11 doesn't define overloads for `unsigned`, it leads to ugly ambiguity errors for the signed overloads.  In such cases, it is safe to omit `abs` entirely, as the magnitude of an unsigned value implies that same value.

Upstream code has since been refactored.