### PR TITLE
Revert "mail-client/claws-mail-3.15.0-r0: amd64 stable"

### DIFF
--- a/mail-client/claws-mail/claws-mail-3.15.0.ebuild
+++ b/mail-client/claws-mail/claws-mail-3.15.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="http://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
 
 SLOT="0"
 LICENSE="GPL-3"
-KEYWORDS="~alpha amd64 ~hppa ~ppc ~ppc64 ~x86"
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~ppc64 ~x86"
 
 IUSE="archive bogofilter calendar clamav dbus debug doc gdata +gnutls gtk3 +imap ipv6 ldap +libcanberra +libindicate +libnotify networkmanager nls nntp +notification pda pdf perl +pgp python rss session sieve smime spamassassin spam-report spell startup-notification svg valgrind xface"
 REQUIRED_USE="libcanberra? ( notification )


### PR DESCRIPTION
This reverts commit 3a9a585d046ce6ef8ba5f4499b70c528e7462ca5.

Upsteam-Bug:
http://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=3855

Gentoo-Bug: 618376
Signed-off-by: Henning Schild <henning@hennsch.de>