### PR TITLE
www-apps/blohg: fix HOMEPAGE

### DIFF
--- a/www-apps/blohg/blohg-0.13-r2.ebuild
+++ b/www-apps/blohg/blohg-0.13-r2.ebuild
@@ -14,7 +14,7 @@ fi
 inherit distutils-r1 ${GIT_ECLASS}
 
 DESCRIPTION="A Mercurial (or Git) based blogging engine"
-HOMEPAGE="http://blohg.org/ https://pypi.python.org/pypi/blohg"
+HOMEPAGE="https://github.com/rafaelmartins/blohg"
 
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 KEYWORDS="~amd64 ~x86"

--- a/www-apps/blohg/blohg-9999.ebuild
+++ b/www-apps/blohg/blohg-9999.ebuild
@@ -14,7 +14,7 @@ fi
 inherit distutils-r1 ${GIT_ECLASS}
 
 DESCRIPTION="A Mercurial (or Git) based blogging engine"
-HOMEPAGE="http://blohg.org/ https://pypi.python.org/pypi/blohg"
+HOMEPAGE="https://github.com/rafaelmartins/blohg"
 
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 KEYWORDS="~amd64 ~x86"


### PR DESCRIPTION
Hi, 

This PR fixes the Homepage of www-apps/blohg.
http://blohg.org clearly is about something else and https://pypi.python.org/pypi/blohg doesn't exist. I also couldn't find another pypi address. After all i changed the Homepage to the github page. (like the blohg-tumblelog package)

Please review