### PR TITLE
dev-java/netbeans-java: fix  jar symlink breaking src_install()

### DIFF
--- a/dev-java/netbeans-java/netbeans-java-8.2-r1.ebuild
+++ b/dev-java/netbeans-java/netbeans-java-8.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -12,33 +12,33 @@ SLOT="8.2"
 SOURCE_URL="http://download.netbeans.org/netbeans/8.2/final/zip/netbeans-8.2-201609300101-src.zip"
 # jarjar-1.4 contains also asm libraries
 SRC_URI="${SOURCE_URL}
-	http://dev.gentoo.org/~fordfrog/distfiles/netbeans-8.2-build.xml.patch.bz2
-	http://hg.netbeans.org/binaries/839F93A5213FB3E233B09BFD6D6B95669F7043C0-aether-api-1.0.2.v20150114.jar
-	http://hg.netbeans.org/binaries/694F57282D92C434800F79218E64704E5947008A-apache-maven-3.0.5-bin.zip
-	http://hg.netbeans.org/binaries/F7BD95641780C2AAE8CB9BED1686441A1CE5E749-beansbinding-1.2.1-doc.zip
-	http://hg.netbeans.org/binaries/CD2211635F3011E300CA8FEDC1CE0E1CF61C175B-eclipselink.jar
-	http://hg.netbeans.org/binaries/A9A0648BD7D9FD2CDFBD22C25366E71DA72438DA-hibernate-release-4.3.1-lib.zip
-	http://hg.netbeans.org/binaries/562F0CFA47F0636EBB5A544968EE7A692FC5D26D-indexer-artifact-5.1.1.jar
-	http://hg.netbeans.org/binaries/E775F5BEB07F8303A9AD3DDC12E3128DD48AB03A-indexer-core-5.1.1-patched.jar
-	http://hg.netbeans.org/binaries/D87F53C99E4CD88F5416EDD5ABB77F2A1CCFB050-jarjar-1.4.jar
-	http://hg.netbeans.org/binaries/5BAB675816DBE0F64BB86004B108BF2A00292358-javax.persistence_2.1.0.v201304241213.jar
-	http://hg.netbeans.org/binaries/84E2020E5499015E9F40D1212C86918264B89EB1-jaxws-2.2.6.zip
-	http://hg.netbeans.org/binaries/D64C40E770C95C2A6994081C00CCD489C0AA20C9-jaxws-2.2.6-api.zip
-	http://hg.netbeans.org/binaries/8ECD169E9E308C258287E4F28B03B6D6F1E55F47-jaxws-api-doc.zip
-	http://hg.netbeans.org/binaries/A8BD39C5B88571B4D4697E78DD1A56566E44B1DD-JPAjavadocs04032013.zip
-	http://hg.netbeans.org/binaries/9EC77E2507F9CC01756964C71D91EFD8154A8C47-lucene-core-3.6.2.jar
-	http://hg.netbeans.org/binaries/A90682C6BC0B9E105BD260C9A041FEFEA9579E46-lucene-highlighter-3.6.2.jar
-	http://hg.netbeans.org/binaries/BF206C4AA93C74A739FBAF1F1C78E3AD5F167245-maven-dependency-tree-2.0.jar
-	http://hg.netbeans.org/binaries/5D007C6037A8501E73A3D3FB98A1F6AE5768C3DD-nb-javac-api.jar
-	http://hg.netbeans.org/binaries/5968566A351B28623DE4720B0ACB1E40338074D0-nb-javac-impl.jar
-	http://hg.netbeans.org/binaries/29AF1D338CBB76290D1A96F5A6610F1E8C319AE5-org.eclipse.persistence.jpa.jpql_2.5.2.v20140319-9ad6abd.jar
-	http://hg.netbeans.org/binaries/3CE04BDB48FE315736B1DCE407362C57DFAE286D-org.eclipse.persistence.jpa.modelgen_2.5.2.v20140319-9ad6abd.jar
-	http://hg.netbeans.org/binaries/7666B94C1004AFFFE88E5328BD70EBA6F60125F4-spring-framework-3.2.7.RELEASE.zip
-	http://hg.netbeans.org/binaries/91B55CDAC59BC4DDDF0AF9A54EAAE4304EDEF266-spring-framework-4.0.1.RELEASE.zip
-	http://hg.netbeans.org/binaries/BFCC4C322190D6E3DD2FA9F191C0359D380D87C5-wagon-file-2.10.jar
-	http://hg.netbeans.org/binaries/4EF309C09ABB5F8B2D0C6A4010205DB185729CDC-wagon-http-2.10-shaded.jar
-	http://hg.netbeans.org/binaries/3B96251214DF697E902C849EB0B4A0EFA2CD1A53-wagon-http-shared-2.10.jar
-	http://hg.netbeans.org/binaries/0CD9CDDE3F56BB5250D87C54592F04CBC24F03BF-wagon-provider-api-2.10.jar"
+	https://dev.gentoo.org/~fordfrog/distfiles/netbeans-8.2-build.xml.patch.bz2
+	https://hg.netbeans.org/binaries/839F93A5213FB3E233B09BFD6D6B95669F7043C0-aether-api-1.0.2.v20150114.jar
+	https://hg.netbeans.org/binaries/694F57282D92C434800F79218E64704E5947008A-apache-maven-3.0.5-bin.zip
+	https://hg.netbeans.org/binaries/F7BD95641780C2AAE8CB9BED1686441A1CE5E749-beansbinding-1.2.1-doc.zip
+	https://hg.netbeans.org/binaries/CD2211635F3011E300CA8FEDC1CE0E1CF61C175B-eclipselink.jar
+	https://hg.netbeans.org/binaries/A9A0648BD7D9FD2CDFBD22C25366E71DA72438DA-hibernate-release-4.3.1-lib.zip
+	https://hg.netbeans.org/binaries/562F0CFA47F0636EBB5A544968EE7A692FC5D26D-indexer-artifact-5.1.1.jar
+	https://hg.netbeans.org/binaries/E775F5BEB07F8303A9AD3DDC12E3128DD48AB03A-indexer-core-5.1.1-patched.jar
+	https://hg.netbeans.org/binaries/D87F53C99E4CD88F5416EDD5ABB77F2A1CCFB050-jarjar-1.4.jar
+	https://hg.netbeans.org/binaries/5BAB675816DBE0F64BB86004B108BF2A00292358-javax.persistence_2.1.0.v201304241213.jar
+	https://hg.netbeans.org/binaries/84E2020E5499015E9F40D1212C86918264B89EB1-jaxws-2.2.6.zip
+	https://hg.netbeans.org/binaries/D64C40E770C95C2A6994081C00CCD489C0AA20C9-jaxws-2.2.6-api.zip
+	https://hg.netbeans.org/binaries/8ECD169E9E308C258287E4F28B03B6D6F1E55F47-jaxws-api-doc.zip
+	https://hg.netbeans.org/binaries/A8BD39C5B88571B4D4697E78DD1A56566E44B1DD-JPAjavadocs04032013.zip
+	https://hg.netbeans.org/binaries/9EC77E2507F9CC01756964C71D91EFD8154A8C47-lucene-core-3.6.2.jar
+	https://hg.netbeans.org/binaries/A90682C6BC0B9E105BD260C9A041FEFEA9579E46-lucene-highlighter-3.6.2.jar
+	https://hg.netbeans.org/binaries/BF206C4AA93C74A739FBAF1F1C78E3AD5F167245-maven-dependency-tree-2.0.jar
+	https://hg.netbeans.org/binaries/5D007C6037A8501E73A3D3FB98A1F6AE5768C3DD-nb-javac-api.jar
+	https://hg.netbeans.org/binaries/5968566A351B28623DE4720B0ACB1E40338074D0-nb-javac-impl.jar
+	https://hg.netbeans.org/binaries/29AF1D338CBB76290D1A96F5A6610F1E8C319AE5-org.eclipse.persistence.jpa.jpql_2.5.2.v20140319-9ad6abd.jar
+	https://hg.netbeans.org/binaries/3CE04BDB48FE315736B1DCE407362C57DFAE286D-org.eclipse.persistence.jpa.modelgen_2.5.2.v20140319-9ad6abd.jar
+	https://hg.netbeans.org/binaries/7666B94C1004AFFFE88E5328BD70EBA6F60125F4-spring-framework-3.2.7.RELEASE.zip
+	https://hg.netbeans.org/binaries/91B55CDAC59BC4DDDF0AF9A54EAAE4304EDEF266-spring-framework-4.0.1.RELEASE.zip
+	https://hg.netbeans.org/binaries/BFCC4C322190D6E3DD2FA9F191C0359D380D87C5-wagon-file-2.10.jar
+	https://hg.netbeans.org/binaries/4EF309C09ABB5F8B2D0C6A4010205DB185729CDC-wagon-http-2.10-shaded.jar
+	https://hg.netbeans.org/binaries/3B96251214DF697E902C849EB0B4A0EFA2CD1A53-wagon-http-shared-2.10.jar
+	https://hg.netbeans.org/binaries/0CD9CDDE3F56BB5250D87C54592F04CBC24F03BF-wagon-provider-api-2.10.jar"
 LICENSE="|| ( CDDL GPL-2-with-linking-exception )"
 KEYWORDS="amd64 ~x86"
 IUSE=""
@@ -232,7 +232,7 @@ src_install() {
 	rm dom4j-1.6.1.jar && java-pkg_jar-from --into "${instdir}" dom4j-1 dom4j.jar dom4j-1.6.1.jar
 	rm javassist-3.18.1-GA.jar && java-pkg_jar-from --into "${instdir}" javassist-3 javassist.jar javassist-3.18.1-GA.jar
 	rm jboss-logging-3.1.3.GA.jar && java-pkg_jar-from --into "${instdir}" jboss-logging jboss-logging.jar jboss-logging-3.1.3.GA.jar
-	rm jboss-transaction-api_1.2_spec-1.0.0.Final.jar && java-pkg_jar-from --into "${instdir}" glassfish-transaction-api jta.jar jboss-transaction-api_1.2_spec-1.0.0.Final.jar
+	rm jboss-transaction-api_1.2_spec-1.0.0.Final.jar && java-pkg_jar-from --into "${instdir}" glassfish-transaction-api glassfish-transaction-api.jar jboss-transaction-api_1.2_spec-1.0.0.Final.jar
 	rm jtidy-r8-20060801.jar && java-pkg_jar-from --into "${instdir}" jtidy jtidy.jar jtidy-r8-20060801.jar
 	rm log4j-1.2.12.jar && java-pkg_jar-from --into "${instdir}" log4j log4j.jar log4j-1.2.12.jar
 	rm slf4j-api-1.6.1.jar && java-pkg_jar-from --into "${instdir}" slf4j-api slf4j-api.jar slf4j-api-1.6.1.jar


### PR DESCRIPTION
I was trying to compile netbeans-8.2  and got error mentioned in bug referenced, fix seems trivial at least
 - fix glassfish-transaction-api jar symlink
 - change to https per repoman suggestion
Gentoo-Bug: 623114
