### PR TITLE
dev-python/vertex: fix HOMEPAGE

### DIFF
--- a/dev-python/vertex/vertex-0.3.0-r1.ebuild
+++ b/dev-python/vertex/vertex-0.3.0-r1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit twisted-r1
 
 DESCRIPTION="An implementation of the Q2Q protocol"
-HOMEPAGE="http://divmod.org/trac/wiki/DivmodVertex https://pypi.python.org/pypi/Vertex"
+HOMEPAGE="https://github.com/twisted/vertex https://pypi.python.org/pypi/Vertex"
 SRC_URI="mirror://pypi/${TWISTED_PN:0:1}/${TWISTED_PN}/${TWISTED_P}.tar.gz"
 
 KEYWORDS="amd64 x86"

--- a/dev-python/vertex/vertex-0.3.1-r1.ebuild
+++ b/dev-python/vertex/vertex-0.3.1-r1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit twisted-r1
 
 DESCRIPTION="An implementation of the Q2Q protocol"
-HOMEPAGE="http://divmod.org/trac/wiki/DivmodVertex https://pypi.python.org/pypi/Vertex"
+HOMEPAGE="https://github.com/twisted/vertex https://pypi.python.org/pypi/Vertex"
 SRC_URI="mirror://pypi/${TWISTED_PN:0:1}/${TWISTED_PN}/${TWISTED_P}.tar.gz"
 
 KEYWORDS="~amd64 ~x86"


### PR DESCRIPTION
Hi,

The divmod.org address gives a 404, i've updated the Homepage and added the github address (which is also used at the pypi address.)

Please review.