### PR TITLE
dev-python/path-py: remove dead HOMEPAGE

### DIFF
--- a/dev-python/path-py/path-py-8.1.2.ebuild
+++ b/dev-python/path-py/path-py-8.1.2.ebuild
@@ -10,7 +10,7 @@ inherit distutils-r1
 MY_P="path.py-${PV}"
 
 DESCRIPTION="A module wrapper for os.path"
-HOMEPAGE="http://pythonhosted.org/path.py https://pypi.python.org/pypi/path.py https://github.com/jaraco/path.py"
+HOMEPAGE="https://pypi.python.org/pypi/path.py https://github.com/jaraco/path.py"
 SRC_URI="mirror://pypi/p/path.py/${MY_P}.tar.gz"
 
 SLOT="0"


### PR DESCRIPTION
Hi,

They pythonhosted site gives a 404. Since we already have two other Homepages, i've simply removed the dead one.

Please review.