### PR TITLE
app-emulation/lxd: add myself as a co-maintainer

### DIFF
--- a/app-emulation/lxd/metadata.xml
+++ b/app-emulation/lxd/metadata.xml
@@ -5,6 +5,14 @@
 		<email>stasibear@gentoo.org</email>
 		<name>Erik Mackdanz</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>hsoft@hardcoded.net</email>
+		<name>Virgil Dupras</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription>
 		By combining the speed and density of containers with
 		the security of traditional virtual machines, LXD is


### PR DESCRIPTION
The current maintainer is unresponsive and I'd like to help keeping the
package alive. I already have commits to the package, notably a major
rewrite in 7c15f08e.

Details at https://bugs.gentoo.org/show_bug.cgi?id=626042

Package-Manager: Portage-2.3.6, Repoman-2.3.1