### PR TITLE
toolchain.eclass: fix tc-enables-* with -ggdb3

### DIFF
--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -798,7 +798,7 @@ gcc-specs-stack-check() {
 # Return truth if the current compiler generates position-independent code (PIC)
 # which can be linked into executables.
 tc-enables-pie() {
-	local ret="$($(tc-getCC) ${CPPFLAGS} ${CFLAGS} -E -P - <<-EOF 2> /dev/null
+	local ret="$($(tc-getCC) ${CPPFLAGS} ${CFLAGS} -E -P - <<-EOF 2> /dev/null | grep '^true$'
 		#if defined(__PIE__)
 		true
 		#endif
@@ -816,7 +816,7 @@ tc-enables-pie() {
 #  -fstack-protector-strong
 #  -fstack-protector-all
 tc-enables-ssp() {
-	local ret="$($(tc-getCC) ${CPPFLAGS} ${CFLAGS} -E -P - <<-EOF 2> /dev/null
+	local ret="$($(tc-getCC) ${CPPFLAGS} ${CFLAGS} -E -P - <<-EOF 2> /dev/null | grep '^true$'
 		#if defined(__SSP__) || defined(__SSP_STRONG__) || defined(__SSP_ALL__)
 		true
 		#endif
@@ -833,7 +833,7 @@ tc-enables-ssp() {
 #  -fstack-protector-strong
 #  -fstack-protector-all
 tc-enables-ssp-strong() {
-	local ret="$($(tc-getCC) ${CPPFLAGS} ${CFLAGS} -E -P - <<-EOF 2> /dev/null
+	local ret="$($(tc-getCC) ${CPPFLAGS} ${CFLAGS} -E -P - <<-EOF 2> /dev/null | grep '^true$'
 		#if defined(__SSP_STRONG__) || defined(__SSP_ALL__)
 		true
 		#endif
@@ -849,7 +849,7 @@ tc-enables-ssp-strong() {
 # on level corresponding to any of the following options:
 #  -fstack-protector-all
 tc-enables-ssp-all() {
-	local ret="$($(tc-getCC) ${CPPFLAGS} ${CFLAGS} -E -P - <<-EOF 2> /dev/null
+	local ret="$($(tc-getCC) ${CPPFLAGS} ${CFLAGS} -E -P - <<-EOF 2> /dev/null | grep '^true$'
 		#if defined(__SSP_ALL__)
 		true
 		#endif


### PR DESCRIPTION
-ggdb3 builds debug information for macros into binaries. For this reason, the C preprocessor includes all #defines as-is in the output. The check in tc-enables-* expects only a fixed output of "true", which fails in this scenario.

To fix this, `tail -1` is used to look at only the final line of output from the preprocessor (which is either the expected "true", or something else).