### PR TITLE
app-crypt/nwipe: fix HOMEPAGE

### DIFF
--- a/app-crypt/nwipe/nwipe-0.14.ebuild
+++ b/app-crypt/nwipe/nwipe-0.14.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 
 DESCRIPTION="Securely erase disks using a variety of recognized methods"
-HOMEPAGE="https://sourceforge.net/projects/nwipe/"
+HOMEPAGE="http://www.andybev.com/index.php/Nwipe https://github.com/martijnvanbrummelen/nwipe/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This fixes the Homepage for nwipe.
I've added the Homepage from andybev (Author) and the the linked github page. I haven't touched the SRC_URI as on the github page the oldest version-tag would be 0.15.