### PR TITLE
sci-visualization/visit-2.12.3: added missing dependency

### DIFF
--- a/sci-visualization/visit/visit-2.12.3.ebuild
+++ b/sci-visualization/visit/visit-2.12.3.ebuild
@@ -24,6 +24,7 @@ RDEPEND="
 	netcdf? ( sci-libs/netcdf )
 	silo? ( sci-libs/silo )
 	=sci-libs/vtk-6.1.0*[imaging,mpi=,python,rendering,qt5,xdmf2?,${PYTHON_USEDEP}]
+	dev-qt/qtx11extras
 	sys-libs/zlib
 	x11-libs/qwt:6"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Visit build fails without dev-qt/qtx11extras, refer to bug #627306

[CMakeOutput.log.txt](https://github.com/gentoo/gentoo/files/1210796/CMakeOutput.log.txt)
[CMakeError.log.txt](https://github.com/gentoo/gentoo/files/1210794/CMakeError.log.txt)
[build.log.txt](https://github.com/gentoo/gentoo/files/1210798/build.log.txt)
[environment.txt](https://github.com/gentoo/gentoo/files/1210795/environment.txt)
[emerge_info.txt](https://github.com/gentoo/gentoo/files/1210797/emerge_info.txt)
