### PR TITLE
sysbench/chkcrontab/filebeat stabilization

### DIFF
--- a/app-admin/filebeat/filebeat-5.4.3.ebuild
+++ b/app-admin/filebeat/filebeat-5.4.3.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/elastic/beats/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="amd64"
 
 DEPEND=">=dev-lang/go-1.8.1"
 RDEPEND="!app-admin/filebeat-bin"

--- a/app-benchmarks/sysbench/sysbench-1.0.7.ebuild
+++ b/app-benchmarks/sysbench/sysbench-1.0.7.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/akopytov/sysbench/archive/${PV}.tar.gz -> ${P}.tar.g
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="aio mysql postgres test"
 
 RDEPEND="aio? ( dev-libs/libaio )

--- a/app-misc/chkcrontab/chkcrontab-1.7.ebuild
+++ b/app-misc/chkcrontab/chkcrontab-1.7.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/lyda/chkcrontab/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="test"
 
 python_test() {


### PR DESCRIPTION
Stable on amd64 already, tested on x86:
https://bugs.gentoo.org/show_bug.cgi?id=624414
https://bugs.gentoo.org/show_bug.cgi?id=624420

Tested on amd64:
https://bugs.gentoo.org/show_bug.cgi?id=627304