### PR TITLE
net-misc/sstp-client: Amend license, and update libtool .la handling

### DIFF
--- a/net-misc/sstp-client/sstp-client-1.0.10-r1.ebuild
+++ b/net-misc/sstp-client/sstp-client-1.0.10-r1.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="A client implementation of Secure Socket Tunneling Protocol (SSTP)"
 HOMEPAGE="http://sstp-client.sourceforge.net/"
 SRC_URI="mirror://sourceforge/sstp-client/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+-with-openssl-exception"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE="static"
@@ -29,7 +29,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	# set proper examples dir, --docdir overriding is src_configure does not work
+	# set proper examples dir, --docdir overriding in src_configure does not work
 	sed -i -e "/^docdir/s:@PACKAGE@:${PF}/examples:" Makefile.am || die 'sed on Makefile.am failed'
 
 	default
@@ -38,8 +38,8 @@ src_prepare() {
 
 src_configure() {
 	local PPPD_VER="$(best_version net-dialup/ppp)"
-	PPPD_VER=${PPPD_VER#*/*-} #reduce it to ${PV}-${PR}
-	PPPD_VER=${PPPD_VER%%[_-]*} # main version without beta/pre/patch/revision
+	PPPD_VER=${PPPD_VER#*/*-} 		# reduce it to ${PV}-${PR}
+	PPPD_VER=${PPPD_VER%%[_-]*}		# main version without beta/pre/patch/revision
 	econf \
 		--enable-ppp-plugin \
 		--enable-group=sstpc \
@@ -51,5 +51,5 @@ src_configure() {
 
 src_install() {
 	default
-	prune_libtool_files --modules
+	find "${D}" -name '*.la' -delete || die
 }


### PR DESCRIPTION
License was incorrectly specified as simply GPL-2, and after consultation
with QA, is now amended to 'GPL-2+-with-openssl-exception'.

Libtool archives are now removed with the 'find -delete' method as
recommended by QA policy guidelines.

Fixed typo in explanatory comment about exampes in src_prepare, and
tidied comments regarding PPPD variables for better readability.

Gentoo-Bug: #603966
Package-Manager: Portage-2.3.6, Repoman-2.3.1
Signed-off-by: Michael Everitt <m.j.everitt@iee.org>