### PR TITLE
sys-fs/mtools: fix musl build

### DIFF
--- a/sys-fs/mtools/mtools-4.0.18-r2.ebuild
+++ b/sys-fs/mtools/mtools-4.0.18-r2.ebuild
@@ -36,7 +36,7 @@ src_prepare() {
 
 src_configure() {
 	# 447688
-	use elibc_glibc || append-libs iconv
+	use !elibc_glibc && use !elibc_musl && append-libs "-liconv"
 	econf \
 		--sysconfdir="${EPREFIX}"/etc/mtools \
 		$(use_with X x)

--- a/sys-fs/mtools/mtools-4.0.18.ebuild
+++ b/sys-fs/mtools/mtools-4.0.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -32,7 +32,7 @@ src_prepare() {
 
 src_configure() {
 	# 447688
-	use elibc_glibc || append-libs iconv
+	use !elibc_glibc && use !elibc_musl && append-libs "-liconv"
 	econf \
 		--sysconfdir="${EPREFIX}"/etc/mtools \
 		$(use_with X x)


### PR DESCRIPTION
Closes https://bugs.gentoo.org/show_bug.cgi?id=626948

Package-Manager: Portage-2.3.6, Repoman-2.3.3