### PR TITLE
sys-firmware/edk2-ovmf: HOMEPAGE (avoid redirect)

### DIFF
--- a/sys-firmware/edk2-ovmf/edk2-ovmf-2017_pre20170505.ebuild
+++ b/sys-firmware/edk2-ovmf/edk2-ovmf-2017_pre20170505.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils python-any-r1 readme.gentoo-r1
 
 DESCRIPTION="UEFI firmware for 64-bit x86 virtual machines"
-HOMEPAGE="http://www.tianocore.org/edk2 https://github.com/tianocore/edk2"
+HOMEPAGE="https://github.com/tianocore/edk2"
 
 # inherit git-r3
 # EGIT_REPO_URI="https://github.com/tianocore/edk2"


### PR DESCRIPTION
HOMEPAGE http://www.tianocore.org/edk2/ redirects to
https://github.com/tianocore/tianocore.github.io/wiki/EDK-II

Package-Manager: Portage-2.3.6, Repoman-2.3.3