### PR TITLE
net-dns/knot: fix issues, add modules in use flags

### DIFF
--- a/net-dns/knot/files/2.5.3-link-with-libatomic.patch
+++ b/net-dns/knot/files/2.5.3-link-with-libatomic.patch
@@ -1,0 +1,117 @@
+From 5cf2d1acf87fa0ab18375534ca210f1cabf212b3 Mon Sep 17 00:00:00 2001
+From: Pierre-Olivier Mercier <nemunaire@nemunai.re>
+Date: Wed, 2 Aug 2017 23:16:43 +0200
+Subject: [PATCH] Link with libatomic on architectures that requires it
+
+---
+ configure.ac    | 10 +++++++++-
+ src/Makefile.am |  2 +-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 2a28214..5bd1798 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -504,8 +504,16 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <sched.h>]], [[cpuset_t* set = cpuset
+ AC_COMPILE_IFELSE(
+   [AC_LANG_PROGRAM([[#include <stdint.h>]],
+                    [[uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);]])],
+-  [AC_DEFINE(HAVE_ATOMIC, 1, [Define to 1 if you have '__atomic' functions.])]
++  [AC_DEFINE(HAVE_ATOMIC, 1, [Define to 1 if you have '__atomic' functions.])
++    AC_LINK_IFELSE(
++     [AC_LANG_PROGRAM([[#include <stdint.h>]],
++                      [[uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);]])],
++     [atomic_LIBS=""],
++     [atomic_LIBS="-latomic"]
++  )],
++  [atomic_LIBS=""]
+ )
++AC_SUBST([atomic_LIBS])
+ 
+ # Prepare CFLAG_VISIBILITY to be used where needed
+ gl_VISIBILITY()
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 948912e..bf28013 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -399,7 +399,7 @@ libknotd_la_CPPFLAGS = $(AM_CPPFLAGS) $(CFLAG_VISIBILITY) $(systemd_CFLAGS) \
+                        $(liburcu_CFLAGS) -DKNOTD_MOD_STATIC
+ libknotd_la_LDFLAGS  = $(AM_LDFLAGS) -export-symbols-regex '^knotd_'
+ libknotd_la_LIBADD   = libknot.la zscanner/libzscanner.la $(systemd_LIBS) \
+-                       $(liburcu_LIBS)
++                       $(liburcu_LIBS) $(atomic_LIBS)
+ 
+ ###################
+ # Knot DNS Daemon #
+--- a/src/Makefile.in	2017-08-05 18:09:14.029882010 +0200
++++ b/src/Makefile.in	2017-08-05 18:12:43.541190937 +0200
+@@ -379,7 +379,7 @@
+ @STATIC_MODULE_dnstap_TRUE@	contrib/dnstap/libdnstap.la
+ libknotd_la_DEPENDENCIES = libknot.la zscanner/libzscanner.la \
+ 	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) \
+-	$(am__DEPENDENCIES_2)
++	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_2)
+ am__libknotd_la_SOURCES_DIST = knot/conf/base.c knot/conf/base.h \
+ 	knot/conf/conf.c knot/conf/conf.h knot/conf/confdb.c \
+ 	knot/conf/confdb.h knot/conf/confio.c knot/conf/confio.h \
+@@ -937,6 +937,7 @@
+ am__quote = @am__quote@
+ am__tar = @am__tar@
+ am__untar = @am__untar@
++atomic_LIBS = @atomic_LIBS@
+ bindir = @bindir@
+ build = @build@
+ build_alias = @build_alias@
+@@ -1275,7 +1276,8 @@
+ 	$(am__append_11)
+ libknotd_la_LDFLAGS = $(AM_LDFLAGS) -export-symbols-regex '^knotd_'
+ libknotd_la_LIBADD = libknot.la zscanner/libzscanner.la \
+-	$(systemd_LIBS) $(liburcu_LIBS) $(am__append_12)
++	$(systemd_LIBS) $(liburcu_LIBS) $(atomic_LIBS) \
++	$(am__append_12)
+ @HAVE_DAEMON_TRUE@sbin_SCRIPTS = utils/pykeymgr/pykeymgr
+ @HAVE_DAEMON_TRUE@CLEAN_FILES = $(sbin_SCRIPTS)
+ @HAVE_DAEMON_TRUE@knotddir = $(includedir)/knot
+--- a/configure	2017-08-05 18:09:14.039882551 +0200
++++ b/configure	2017-08-05 18:12:18.779857706 +0200
+@@ -655,6 +655,7 @@
+ CODE_COVERAGE_ENABLED_TRUE
+ HAVE_VISIBILITY
+ CFLAG_VISIBILITY
++atomic_LIBS
+ libidn_LIBS
+ libidn_CFLAGS
+ libidn2_LIBS
+@@ -16347,10 +16358,32 @@
+ 
+ $as_echo "#define HAVE_ATOMIC 1" >>confdefs.h
+ 
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <stdint.h>
++int
++main ()
++{
++uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  atomic_LIBS=""
++else
++  atomic_LIBS="-latomic"
++
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++else
++  atomic_LIBS=""
+ 
+ fi
+ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ 
++
+ # Prepare CFLAG_VISIBILITY to be used where needed
+ 
+ 

--- a/net-dns/knot/files/knot-1.service
+++ b/net-dns/knot/files/knot-1.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Knot high-performance DNS Server
+After=network.target
+
+[Service]
+ExecStart=/usr/sbin/knotd
+ExecReload=/usr/sbin/knotc reload
+ExecStop=/usr/sbin/knotc stop
+PrivateTmp=true
+User=knot
+Group=knot
+RuntimeDirectory=knot
+RuntimeDirectoryMode=750
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/net-dns/knot/knot-2.5.3-r1.ebuild
+++ b/net-dns/knot/knot-2.5.3-r1.ebuild
@@ -24,7 +24,7 @@ KNOT_MODULES=(
 	"+synthrecord"
 	"+whoami"
 )
-IUSE="doc caps +fastparser idn systemd +utils ${KNOT_MODULES[@]}"
+IUSE="doc caps +fastparser idn libidn2 systemd +utils ${KNOT_MODULES[@]}"
 
 RDEPEND="
 	>=net-libs/gnutls-3.3:=
@@ -36,7 +36,10 @@ RDEPEND="
 		dev-libs/fstrm
 		dev-libs/protobuf-c
 	)
-	idn? ( || ( net-dns/libidn >=net-dns/libidn2-2.0.0 ) )
+	idn? (
+		!libidn2? ( net-dns/libidn )
+		libidn2? ( >=net-dns/libidn2-2.0.0 )
+	)
 	dev-libs/libedit
 	systemd? ( >=sys-apps/systemd-229 )
 "

--- a/net-dns/knot/knot-2.5.3-r1.ebuild
+++ b/net-dns/knot/knot-2.5.3-r1.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit systemd user
+
+DESCRIPTION="High-performance authoritative-only DNS server"
+HOMEPAGE="http://www.knot-dns.cz/"
+SRC_URI="https://secure.nic.cz/files/knot-dns/${P/_/-}.tar.xz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="dnstap doc caps +fastparser idn systemd"
+
+RDEPEND="
+	>=net-libs/gnutls-3.3:=
+	>=dev-db/lmdb-0.9.15
+	>=dev-libs/userspace-rcu-0.5.4
+	caps? ( >=sys-libs/libcap-ng-0.6.4 )
+	dnstap? (
+		dev-libs/fstrm
+		dev-libs/protobuf-c
+	)
+	idn? ( || ( net-dns/libidn >=net-dns/libidn2-2.0.0 ) )
+	dev-libs/libedit
+	systemd? ( sys-apps/systemd )
+"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	doc? ( dev-python/sphinx )
+"
+
+S="${WORKDIR}/${P/_/-}"
+
+src_configure() {
+	econf \
+		--with-storage="${EPREFIX}/var/lib/${PN}" \
+		--with-rundir="${EPREFIX}/var/run/${PN}" \
+		$(use_enable fastparser) \
+		$(use_enable dnstap) \
+		$(use_enable doc documentation) \
+		$(use_with idn libidn) \
+		--enable-systemd=$(usex systemd)
+}
+
+src_compile() {
+	default
+
+	if use doc; then
+		emake -C doc html
+		HTML_DOCS=( doc/_build/html/{*.html,*.js,_sources,_static} )
+	fi
+}
+
+src_test() {
+	emake check
+}
+
+src_install() {
+	default
+
+	rmdir "${D}var/run/${PN}" "${D}var/run/" || die
+	keepdir /var/lib/${PN}
+
+	newinitd "${FILESDIR}/knot.init" knot
+	systemd_dounit "${FILESDIR}/knot.service"
+
+	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	enewgroup knot 53
+	enewuser knot 53 -1 /var/lib/knot knot
+}

--- a/net-dns/knot/knot-2.5.3-r1.ebuild
+++ b/net-dns/knot/knot-2.5.3-r1.ebuild
@@ -17,6 +17,7 @@ IUSE="dnstap doc caps +fastparser idn systemd"
 RDEPEND="
 	>=net-libs/gnutls-3.3:=
 	>=dev-db/lmdb-0.9.15
+	dev-python/lmdb
 	>=dev-libs/userspace-rcu-0.5.4
 	caps? ( >=sys-libs/libcap-ng-0.6.4 )
 	dnstap? (

--- a/net-dns/knot/knot-2.5.3-r1.ebuild
+++ b/net-dns/knot/knot-2.5.3-r1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	)
 	idn? ( || ( net-dns/libidn >=net-dns/libidn2-2.0.0 ) )
 	dev-libs/libedit
-	systemd? ( sys-apps/systemd )
+	systemd? ( >=sys-apps/systemd-229 )
 "
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
@@ -66,7 +66,9 @@ src_install() {
 	keepdir /var/lib/${PN}
 
 	newinitd "${FILESDIR}/knot.init" knot
-	systemd_dounit "${FILESDIR}/knot.service"
+	if use systemd; then
+		systemd_newunit "${FILESDIR}/knot-1.service" knot
+	fi
 
 	find "${D}" -name '*.la' -delete || die
 }

--- a/net-dns/knot/knot-2.5.3-r1.ebuild
+++ b/net-dns/knot/knot-2.5.3-r1.ebuild
@@ -47,6 +47,10 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/${P/_/-}"
 
+PATCHES=(
+	"${FILESDIR}/${PV}-link-with-libatomic.patch"
+)
+
 src_configure() {
 	local my_conf=()
 	for u in "${KNOT_MODULES[@]//+/}"; do

--- a/net-dns/knot/knot-2.5.3-r1.ebuild
+++ b/net-dns/knot/knot-2.5.3-r1.ebuild
@@ -12,7 +12,19 @@ SRC_URI="https://secure.nic.cz/files/knot-dns/${P/_/-}.tar.xz"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="dnstap doc caps +fastparser idn systemd"
+
+KNOT_MODULES=(
+	"+dnsproxy"
+	"dnstap"
+	"+noudp"
+	"+onlinesign"
+	"rosedb"
+	"+rrl"
+	"+stats"
+	"+synthrecord"
+	"+whoami"
+)
+IUSE="doc caps +fastparser idn systemd +utils ${KNOT_MODULES[@]}"
 
 RDEPEND="
 	>=net-libs/gnutls-3.3:=
@@ -36,14 +48,21 @@ DEPEND="${RDEPEND}
 S="${WORKDIR}/${P/_/-}"
 
 src_configure() {
+	local my_conf=()
+	for u in "${KNOT_MODULES[@]//+/}"; do
+		my_conf+=("$(use_with $u module-$u)")
+	done
+
 	econf \
 		--with-storage="${EPREFIX}/var/lib/${PN}" \
 		--with-rundir="${EPREFIX}/var/run/${PN}" \
 		$(use_enable fastparser) \
 		$(use_enable dnstap) \
 		$(use_enable doc documentation) \
+		$(use_enable utils utilities) \
+		--enable-systemd=$(usex systemd) \
 		$(use_with idn libidn) \
-		--enable-systemd=$(usex systemd)
+		"${my_conf[@]}"
 }
 
 src_compile() {

--- a/net-dns/knot/metadata.xml
+++ b/net-dns/knot/metadata.xml
@@ -21,6 +21,10 @@
 			Use a zone file parser that is faster, but requires
 			more memory and CPU time to compile
 		</flag>
+		<flag name="libidn2">
+			If IDN support is enabled, use net-dns/libidn2 instead
+			of net-dns/libidn
+		</flag>
 		<flag name="noudp">
 			Enable the module which can send empty truncated
 			responses to UDP queries

--- a/net-dns/knot/metadata.xml
+++ b/net-dns/knot/metadata.xml
@@ -10,13 +10,43 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
+		<flag name="dnsproxy">
+			Enable the tiny DNS proxy module
+		</flag>
 		<flag name="dnstap">
 			Include support for the dnstap binary log format
-			(http://dnstap.info/).
+			(http://dnstap.info/)
 		</flag>
 		<flag name="fastparser">
-			Use a zone file parser that is faster, but requires more memory and
-			CPU time to compile.
+			Use a zone file parser that is faster, but requires
+			more memory and CPU time to compile
+		</flag>
+		<flag name="noudp">
+			Enable the module which can send empty truncated
+			responses to UDP queries
+		</flag>
+		<flag name="onlinesign">
+			Enable the module that sign zones on the fly instead of
+			pre-signing zone
+		</flag>
+		<flag name="rosedb">
+			Enable the module that staticaly override certain
+			responses
+		</flag>
+		<flag name="rrl">
+			Enable the response rate limiting module
+		</flag>
+		<flag name="stats">
+			Enable the server statistics module
+		</flag>
+		<flag name="synthrecord">
+			Enable the automatic forward/reverse records module
+		</flag>
+		<flag name="utils">
+			Install Knot utilities, such as kdig, kzonecheck, ...
+		</flag>
+		<flag name="whoami">
+			Enable the whoami response module
 		</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
* Add all knot modules in USE flags
* Add dev-python/lmdb dependency: https://bugs.gentoo.org/show_bug.cgi?id=623252
* Enhance security with systemd service file: https://bugs.gentoo.org/show_bug.cgi?id=606644
* Integrate MIPS compatibility patch, upstreamed: https://gitlab.labs.nic.cz/knot/knot-dns/commit/5cf2d1acf87fa0ab18375534ca210f1cabf212b3
* Also fix QA issue with /var/run/knot created by make install