### PR TITLE
media-sound/mplayer : use virtual/jack instead of media-sound/jack-audio-connection-kit

### DIFF
--- a/media-video/mplayer/mplayer-1.2.1-r1.ebuild
+++ b/media-video/mplayer/mplayer-1.2.1-r1.ebuild
@@ -59,14 +59,14 @@ RDEPEND+="
 	sys-libs/ncurses:0=
 	app-arch/bzip2
 	sys-libs/zlib
-	>=media-video/ffmpeg-3.0:0=[vdpau?]
+	>=media-video/ffmpeg-2.6:0=[vdpau?]
 	a52? ( media-libs/a52dec )
 	aalib? ( media-libs/aalib )
 	alsa? ( media-libs/alsa-lib )
 	bidi? ( dev-libs/fribidi )
-	bluray? ( >=media-libs/libbluray-0.2.1:= )
+	bluray? ( >=media-libs/libbluray-0.2.1 )
 	bs2b? ( media-libs/libbs2b )
-	cdio? ( dev-libs/libcdio:0= dev-libs/libcdio-paranoia )
+	cdio? ( dev-libs/libcdio dev-libs/libcdio-paranoia )
 	cdparanoia? ( !cdio? ( media-sound/cdparanoia ) )
 	dga? ( x11-libs/libXxf86dga )
 	directfb? ( dev-libs/DirectFB )
@@ -89,7 +89,7 @@ RDEPEND+="
 	gif? ( media-libs/giflib:0= )
 	gsm? ( media-sound/gsm )
 	iconv? ( virtual/libiconv )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	jpeg? ( virtual/jpeg:0 )
 	jpeg2k? ( media-libs/openjpeg:0 )
 	ladspa? ( media-libs/ladspa-sdk )
@@ -157,9 +157,9 @@ RDEPEND+="
 SLOT="0"
 LICENSE="GPL-2"
 if [[ ${PV} != *9999* ]]; then
-	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+	KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 else
-	KEYWORDS="~alpha ~arm ~hppa ~ia64"
+	KEYWORDS="alpha arm hppa ia64 ppc ppc64 sparc"
 fi
 
 # faac codecs are nonfree
@@ -258,6 +258,12 @@ src_prepare() {
 
 	# Use sane default for >=virtual/udev-197
 	sed -i -e '/default_dvd_device/s:/dev/dvd:/dev/cdrom:' configure || die
+
+	if has_version '>=media-video/ffmpeg-2.9'; then
+		epatch "${FILESDIR}/${PN}-1.2_pre20150730-chan.patch"
+		epatch "${FILESDIR}/${PN}-1.2-get_buffer.patch"
+		epatch "${FILESDIR}/${PN}-1.2_pre20150730-encode.patch"
+	fi
 }
 
 src_configure() {

--- a/media-video/mplayer/mplayer-1.3.0-r2.ebuild
+++ b/media-video/mplayer/mplayer-1.3.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -59,14 +59,14 @@ RDEPEND+="
 	sys-libs/ncurses:0=
 	app-arch/bzip2
 	sys-libs/zlib
-	>=media-video/ffmpeg-2.6:0=[vdpau?]
+	>=media-video/ffmpeg-3.0:0=[vdpau?]
 	a52? ( media-libs/a52dec )
 	aalib? ( media-libs/aalib )
 	alsa? ( media-libs/alsa-lib )
 	bidi? ( dev-libs/fribidi )
-	bluray? ( >=media-libs/libbluray-0.2.1 )
+	bluray? ( >=media-libs/libbluray-0.2.1:= )
 	bs2b? ( media-libs/libbs2b )
-	cdio? ( dev-libs/libcdio dev-libs/libcdio-paranoia )
+	cdio? ( dev-libs/libcdio:0= dev-libs/libcdio-paranoia )
 	cdparanoia? ( !cdio? ( media-sound/cdparanoia ) )
 	dga? ( x11-libs/libXxf86dga )
 	directfb? ( dev-libs/DirectFB )
@@ -89,7 +89,7 @@ RDEPEND+="
 	gif? ( media-libs/giflib:0= )
 	gsm? ( media-sound/gsm )
 	iconv? ( virtual/libiconv )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	jpeg? ( virtual/jpeg:0 )
 	jpeg2k? ( media-libs/openjpeg:0 )
 	ladspa? ( media-libs/ladspa-sdk )
@@ -157,9 +157,9 @@ RDEPEND+="
 SLOT="0"
 LICENSE="GPL-2"
 if [[ ${PV} != *9999* ]]; then
-	KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 else
-	KEYWORDS="alpha arm hppa ia64 ppc ppc64 sparc"
+	KEYWORDS="~alpha ~arm ~hppa ~ia64"
 fi
 
 # faac codecs are nonfree
@@ -258,12 +258,6 @@ src_prepare() {
 
 	# Use sane default for >=virtual/udev-197
 	sed -i -e '/default_dvd_device/s:/dev/dvd:/dev/cdrom:' configure || die
-
-	if has_version '>=media-video/ffmpeg-2.9'; then
-		epatch "${FILESDIR}/${PN}-1.2_pre20150730-chan.patch"
-		epatch "${FILESDIR}/${PN}-1.2-get_buffer.patch"
-		epatch "${FILESDIR}/${PN}-1.2_pre20150730-encode.patch"
-	fi
 }
 
 src_configure() {

--- a/media-video/mplayer/mplayer-1.3.0-r3.ebuild
+++ b/media-video/mplayer/mplayer-1.3.0-r3.ebuild
@@ -89,7 +89,7 @@ RDEPEND+="
 	gif? ( media-libs/giflib:0= )
 	gsm? ( media-sound/gsm )
 	iconv? ( virtual/libiconv )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	jpeg? ( virtual/jpeg:0 )
 	jpeg2k? ( media-libs/openjpeg:0 )
 	ladspa? ( media-libs/ladspa-sdk )

--- a/media-video/mplayer/mplayer-9999.ebuild
+++ b/media-video/mplayer/mplayer-9999.ebuild
@@ -89,7 +89,7 @@ RDEPEND+="
 	gif? ( media-libs/giflib:0= )
 	gsm? ( media-sound/gsm )
 	iconv? ( virtual/libiconv )
-	jack? ( media-sound/jack-audio-connection-kit )
+	jack? ( virtual/jack )
 	jpeg? ( virtual/jpeg:0 )
 	jpeg2k? ( media-libs/openjpeg:0 )
 	ladspa? ( media-libs/ladspa-sdk )


### PR DESCRIPTION
virtual/jack should be used when it does not mater if it is jack1 or jack2.

for mplayer it does not mater. (I used it with jack1 and jack2)