### PR TITLE
media-libs/openh264: Add epatch_user to all versions

### DIFF
--- a/media-libs/openh264/openh264-1.4.0-r1.ebuild
+++ b/media-libs/openh264/openh264-1.4.0-r1.ebuild
@@ -25,6 +25,7 @@ DOCS=( LICENSE CONTRIBUTORS README.md )
 src_prepare() {
 	epatch "${FILESDIR}"/pkgconfig-pathfix.patch
 	epatch "${FILESDIR}"/pkgconfig_install.patch
+	epatch_user
 	multilib_copy_sources
 }
 

--- a/media-libs/openh264/openh264-1.5.0.ebuild
+++ b/media-libs/openh264/openh264-1.5.0.ebuild
@@ -26,6 +26,7 @@ DOCS=( LICENSE CONTRIBUTORS README.md )
 
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-pkgconfig-pathfix.patch
+	epatch_user
 	multilib_copy_sources
 }
 

--- a/media-libs/openh264/openh264-1.7.0.ebuild
+++ b/media-libs/openh264/openh264-1.7.0.ebuild
@@ -26,6 +26,7 @@ DOCS=( LICENSE CONTRIBUTORS README.md )
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.7.0-pkgconfig-pathfix.patch
+	epatch_user
 	multilib_copy_sources
 }
 


### PR DESCRIPTION
I want to apply a local patch to openh264 but can't because it doesn't
call epatch_user.