### PR TITLE
app-crypt/argon2: Fix build under multilib-strict

### DIFF
--- a/app-crypt/argon2/argon2-20161029-r1.ebuild
+++ b/app-crypt/argon2/argon2-20161029-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit multilib
+
+DESCRIPTION="Password hashing software that won the Password Hashing Competition (PHC)"
+HOMEPAGE="https://github.com/P-H-C/phc-winner-argon2"
+SRC_URI="https://github.com/P-H-C/phc-winner-argon2/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="|| ( Apache-2.0 CC0-1.0 )"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="static-libs"
+
+S="${WORKDIR}/phc-winner-${P}"
+PATCHES=(
+	"${FILESDIR}/${P}-makefile-soname-symlinks.patch"
+	)
+src_prepare() {
+	default
+	if ! use static-libs; then
+		sed -i -e 's/LIBRARIES = \$(LIB_SH) \$(LIB_ST)/LIBRARIES = \$(LIB_SH)/' Makefile || die "sed failed!"
+	fi
+	sed -i -e 's/-O3 //' Makefile || die "sed failed"
+	sed -i -e 's/-g //' Makefile || die "sed failed"
+	sed -i -e "s/-march=\$(OPTTARGET) /${CFLAGS} /" Makefile || die "sed failed"
+	sed -i -e 's/CFLAGS += -march=\$(OPTTARGET)//' Makefile || die "sed failed"
+}
+
+src_install() {
+	emake DESTDIR="${D}" LIBRARY_REL=$(get_libdir) install || die
+}

--- a/app-crypt/argon2/argon2-20161029-r1.ebuild
+++ b/app-crypt/argon2/argon2-20161029-r1.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=6
 
-inherit multilib-minimal
-
 DESCRIPTION="Password hashing software that won the Password Hashing Competition (PHC)"
 HOMEPAGE="https://github.com/P-H-C/phc-winner-argon2"
 SRC_URI="https://github.com/P-H-C/phc-winner-argon2/archive/${PV}.tar.gz -> ${P}.tar.gz"
@@ -27,9 +25,8 @@ src_prepare() {
 	sed -i -e 's/-g //' Makefile || die "sed failed"
 	sed -i -e "s/-march=\$(OPTTARGET) /${CFLAGS} /" Makefile || die "sed failed"
 	sed -i -e 's/CFLAGS += -march=\$(OPTTARGET)//' Makefile || die "sed failed"
-	multilib_copy_sources
 }
 
-multilib_src_install() {
+src_install() {
 	emake DESTDIR="${D}" LIBRARY_REL=$(get_libdir) install || die
 }

--- a/app-crypt/argon2/argon2-20161029-r1.ebuild
+++ b/app-crypt/argon2/argon2-20161029-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit multilib
+inherit multilib-minimal
 
 DESCRIPTION="Password hashing software that won the Password Hashing Competition (PHC)"
 HOMEPAGE="https://github.com/P-H-C/phc-winner-argon2"
@@ -27,8 +27,9 @@ src_prepare() {
 	sed -i -e 's/-g //' Makefile || die "sed failed"
 	sed -i -e "s/-march=\$(OPTTARGET) /${CFLAGS} /" Makefile || die "sed failed"
 	sed -i -e 's/CFLAGS += -march=\$(OPTTARGET)//' Makefile || die "sed failed"
+	multilib_copy_sources
 }
 
-src_install() {
+multilib_src_install() {
 	emake DESTDIR="${D}" LIBRARY_REL=$(get_libdir) install || die
 }


### PR DESCRIPTION
This fixes https://bugs.gentoo.org/show_bug.cgi?id=627856

Package-Manager: Portage-2.3.6, Repoman-2.3.3