### PR TITLE
x11-wm/awesome: warning about nonexistent path in src_install

### DIFF
--- a/x11-wm/awesome/awesome-4.0-r1.ebuild
+++ b/x11-wm/awesome/awesome-4.0-r1.ebuild
@@ -69,7 +69,6 @@ src_configure() {
 
 src_install() {
 	cmake-utils_src_install
-	docompress -x /usr/share/doc/awesome/doc
 
 	pax-mark m "${ED%/}"/usr/bin/awesome
 

--- a/x11-wm/awesome/awesome-4.0.ebuild
+++ b/x11-wm/awesome/awesome-4.0.ebuild
@@ -64,7 +64,6 @@ src_configure() {
 
 src_install() {
 	cmake-utils_src_install
-	docompress -x /usr/share/doc/awesome/doc
 
 	pax-mark m "${ED%/}"/usr/bin/awesome
 

--- a/x11-wm/awesome/awesome-4.1.ebuild
+++ b/x11-wm/awesome/awesome-4.1.ebuild
@@ -69,7 +69,6 @@ src_configure() {
 
 src_install() {
 	cmake-utils_src_install
-	docompress -x /usr/share/doc/awesome/doc
 
 	pax-mark m "${ED%/}"/usr/bin/awesome
 

--- a/x11-wm/awesome/awesome-9999.ebuild
+++ b/x11-wm/awesome/awesome-9999.ebuild
@@ -68,7 +68,6 @@ src_configure() {
 
 src_install() {
 	cmake-utils_src_install
-	docompress -x /usr/share/doc/awesome/doc
 
 	pax-mark m "${ED%/}"/usr/bin/awesome
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.6, Repoman-2.3.1

This is a fix for [this](https://bugs.gentoo.org/show_bug.cgi?id=616716) bug.
This affects
* x11-wm/awesome-4.0
* x11-wm/awesome-4.0-r1
* x11-wm/awesome-4.1
* x11-wm/awesome-9999