### PR TITLE
app-emulation/lxd-2.14-r1: stabilize

### DIFF
--- a/app-emulation/lxd/lxd-2.14-r1.ebuild
+++ b/app-emulation/lxd/lxd-2.14-r1.ebuild
@@ -38,7 +38,7 @@ EGO_VENDOR=(
 ARCHIVE_URI="https://${EGO_PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="amd64"
 
 PLOCALES="de el fr it ja nl ru sr sv tr"
 IUSE="+daemon nls test"


### PR DESCRIPTION
Ref https://bugs.gentoo.org/show_bug.cgi?id=627980

Package-Manager: Portage-2.3.6, Repoman-2.3.1