### PR TITLE
sys-apps/portage: Bump the live ebuild to EAPI=6

### DIFF
--- a/sys-apps/portage/portage-9999.ebuild
+++ b/sys-apps/portage/portage-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=(
 	pypy
@@ -10,7 +10,7 @@ PYTHON_COMPAT=(
 )
 PYTHON_REQ_USE='bzip2(+),threads(+)'
 
-inherit distutils-r1 git-r3 multilib
+inherit distutils-r1 git-r3
 
 DESCRIPTION="Portage is the package management and distribution system for Gentoo"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Portage"


### PR DESCRIPTION
Bump the live ebuild to EAPI=6 in order to make use of eapply_user
which is capable of applying -p1 user patches that add new files
correctly, unlike epatch_user.