### PR TITLE
app-editors/retext: enable python-3.6

### DIFF
--- a/app-editors/retext/retext-7.0.0.ebuild
+++ b/app-editors/retext/retext-7.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{4,5} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 
 PLOCALES="ca cs cy da de es et eu fr hu it ja pl pt pt_BR ru sk sr sr@latin uk zh_TW"
 

--- a/app-editors/retext/retext-7.0.1.ebuild
+++ b/app-editors/retext/retext-7.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{4,5} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 
 PLOCALES="ca cs cy da de es et eu fr hu it ja pl pt pt_BR ru sk sr sr@latin uk zh_TW"
 

--- a/app-editors/retext/retext-9999.ebuild
+++ b/app-editors/retext/retext-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python3_{4,5} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 
 PLOCALES="ca cs cy da de es et eu fr hu it ja pl pt pt_BR ru sk sr sr@latin uk zh_TW"
 


### PR DESCRIPTION
The package build and run fine with python 3.6

 * Package:    app-editors/retext-7.0.1
 * Repository: vivovl
 * Maintainer: mrueg@gentoo.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_6 spell test userland_GNU
 * FEATURES:   compressdebug preserve-libs sandbox splitdebug test userpriv usersandbox
----------------------------------------------------------------------
Ran 38 tests in 2.362s

OK