### PR TITLE
app-portage/gentoolkit: enable python-3.6

### DIFF
--- a/app-portage/gentoolkit/gentoolkit-0.3.2-r1.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-0.3.2-r1.ebuild
@@ -10,7 +10,7 @@ inherit distutils-r1
 
 DESCRIPTION="Collection of administration scripts for Gentoo"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Portage-Tools"
-SRC_URI="http://dev.gentoo.org/~dolsen/releases/gentoolkit/${P}.tar.gz"
+SRC_URI="https://dev.gentoo.org/~dolsen/releases/gentoolkit/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-portage/gentoolkit/gentoolkit-0.3.3.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-0.3.3.ebuild
@@ -10,7 +10,7 @@ inherit distutils-r1
 
 DESCRIPTION="Collection of administration scripts for Gentoo"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Portage-Tools"
-SRC_URI="http://dev.gentoo.org/~fuzzyray/distfiles/${P}.tar.gz"
+SRC_URI="https://dev.gentoo.org/~fuzzyray/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-portage/gentoolkit/gentoolkit-0.4.0.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-0.4.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="6"
 
-PYTHON_COMPAT=(python{2_7,3_4,3_5} pypy)
+PYTHON_COMPAT=(python{2_7,3_4,3_5,3_6} pypy)
 PYTHON_REQ_USE="xml(+),threads(+)"
 
 inherit distutils-r1


### PR DESCRIPTION
The package build and run fine with python 3.6

 * Package:    app-portage/gentoolkit-0.4.0
 * Repository: vivovl
 * Maintainer: tools-portage@gentoo.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_6 userland_GNU
 * FEATURES:   compressdebug preserve-libs sandbox splitdebug test userpriv usersandbox