### PR TITLE
dev-libs/botan: enable python-3.6

### DIFF
--- a/dev-libs/botan/botan-2.1.0.ebuild
+++ b/dev-libs/botan/botan-2.1.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 inherit multilib python-r1 toolchain-funcs
 

--- a/dev-libs/botan/metadata.xml
+++ b/dev-libs/botan/metadata.xml
@@ -3,8 +3,8 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>lloyd@randombit.net</email>
-	    	<name>Jack Lloyd </name>
-    		<description>Ebuild contributor and botan author</description>
+			<name>Jack Lloyd </name>
+			<description>Ebuild contributor and botan author</description>
 	</maintainer>
 	<maintainer type="project">
 		<email>crypto@gentoo.org</email>


### PR DESCRIPTION
The package build with python 3.6

 * Package:    dev-libs/botan-1.10.16
 * Repository: gentoo
 * Maintainer: lloyd@randombit.net crypto@gentoo.org,proxy-maint@gentoo.org
 * USE:        abi_x86_64 amd64 bzip2 elibc_glibc kernel_linux ssl threads userland_GNU zlib
 * FEATURES:   compressdebug preserve-libs sandbox splitdebug test userpriv usersandbox

[...]

All tests passed!
>>> Completed testing dev-libs/botan-1.10.16