### PR TITLE
dev-libs/protobuf: enable python-3.6

### DIFF
--- a/dev-libs/protobuf/protobuf-3.3.0.ebuild
+++ b/dev-libs/protobuf/protobuf-3.3.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{4,5} )
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 inherit autotools elisp-common flag-o-matic python-r1 toolchain-funcs multilib-minimal
 
 # If you bump this package, also consider bumping the official language bindings!


### PR DESCRIPTION
The package build with python 3.6

 * Package:    dev-libs/protobuf-3.3.0
 * Repository: vivovl
 * Maintainer: vapier@gentoo.org tomboy64@sina.cn,proxy-maint@gentoo.org
 * USE:        abi_x86_32 abi_x86_64 amd64 elibc_glibc java kernel_linux python_targets_python3_6 test userland_GNU zlib
 * FEATURES:   compressdebug preserve-libs sandbox splitdebug test userpriv usersandbox

Testsuite summary for Protocol Buffers 3.3.0
TOTAL: 7
PASS:  7
SKIP:  0
XFAIL: 0
FAIL:  0
XPASS: 0
ERROR: 0

