### PR TITLE
dev-python/pycups: enable python-3.6

### DIFF
--- a/dev-python/pycups/pycups-1.9.73-r1.ebuild
+++ b/dev-python/pycups/pycups-1.9.73-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
 inherit distutils-r1
 
 DESCRIPTION="Python bindings for the CUPS API"


### PR DESCRIPTION
The package build with python 3.6

 * Package:    dev-python/pycups-1.9.73-r1
 * Repository: vivovl
 * Maintainer: reavertm@gentoo.org printing@gentoo.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python2_7 python_targets_python3_6 userland_GNU
 * FEATURES:   compressdebug preserve-libs sandbox splitdebug test userpriv usersandbox

**ebuild has no tests, "app-admin/system-config-printer", the only user on this system work fine**