### PR TITLE
dev-python/pyside-tools:  enable python-3.6

### DIFF
--- a/dev-python/pyside-tools/pyside-tools-0.2.15-r1.ebuild
+++ b/dev-python/pyside-tools/pyside-tools-0.2.15-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 CMAKE_IN_SOURCE_BUILD="1"
 CMAKE_MAKEFILE_GENERATOR="emake" # bug 558248
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 inherit cmake-utils python-r1 vcs-snapshot virtualx
 


### PR DESCRIPTION
dev-python/pyside-tools:  enable python-3.6

The package build with python 3.6

 * Package:    dev-python/pyside-tools-0.2.15-r1
 * Repository: vivovl
 * Maintainer: qt@gentoo.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python2_7 python_targets_python3_6 test userland_GNU
 * FEATURES:   compressdebug preserve-libs sandbox splitdebug test userpriv usersandbox

>>> Test phase: dev-python/pyside-tools-0.2.15-r1
 * python2_7: running testing
 * Scanning for an open DISPLAY to start Xvfb ...
 * Starting Xvfb on $DISPLAY=0 ...
>>> Working in BUILD_DIR: "/var/tmp/portage/dev-python/pyside-tools-0.2.15-r1/work/pyside-tools-0.2.15-python2_7"
ctest -j 8 --test-load 8
Test project /var/tmp/portage/dev-python/pyside-tools-0.2.15-r1/work/pyside-tools-0.2.15-python2_7
    Start 1: QWizard
    Start 2: RccTest
    Start 3: RccImageTest
1/3 Test #2: RccTest ..........................   Passed    0.35 sec
2/3 Test #1: QWizard ..........................   Passed    0.56 sec
3/3 Test #3: RccImageTest .....................   Passed    1.07 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   1.07 sec
 * Tests succeeded.
 * python3_6: running testing
 * Scanning for an open DISPLAY to start Xvfb ...
 * Starting Xvfb on $DISPLAY=0 ...
>>> Working in BUILD_DIR: "/var/tmp/portage/dev-python/pyside-tools-0.2.15-r1/work/pyside-tools-0.2.15-python3_6"
ctest -j 8 --test-load 8
Test project /var/tmp/portage/dev-python/pyside-tools-0.2.15-r1/work/pyside-tools-0.2.15-python3_6
    Start 1: QWizard
    Start 2: RccTest
    Start 3: RccImageTest
1/3 Test #1: QWizard ..........................   Passed    0.27 sec
2/3 Test #2: RccTest ..........................   Passed    0.31 sec
3/3 Test #3: RccImageTest .....................   Passed    0.52 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   0.52 sec
 * Tests succeeded.
