### PR TITLE
sys-fs/duperemove: add patch

### DIFF
--- a/sys-fs/duperemove/duperemove-0.11_beta4.ebuild
+++ b/sys-fs/duperemove/duperemove-0.11_beta4.ebuild
@@ -23,6 +23,8 @@ DEPEND="${RDEPEND}"
 
 S=${WORKDIR}/${P/_/.}
 
+PATCHES=( "${FILESDIR}/${P}-sysmacros.patch" )
+
 src_compile() {
 	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS} -Wall"
 }

--- a/sys-fs/duperemove/files/duperemove-0.11_beta4-sysmacros.patch
+++ b/sys-fs/duperemove/files/duperemove-0.11_beta4-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/dbfile.c  2016-09-27 22:28:49.000000000 +0200
++++ b/dbfile.c  2017-08-17 18:23:30.768591897 +0200
+@@ -8,6 +8,7 @@
+ #include <inttypes.h>
+ #include <stddef.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ 
+ #include "csum.h"
+ #include "filerec.h"


### PR DESCRIPTION
See the following links for details
* https://bugs.gentoo.org/show_bug.cgi?id=607376
* https://github.com/markfasheh/duperemove/pull/169