### PR TITLE
media-libs/libtxc_dxtn: restore multilib-ness to 1.0.1-r2

### DIFF
--- a/media-libs/libtxc_dxtn/libtxc_dxtn-1.0.1-r2.ebuild
+++ b/media-libs/libtxc_dxtn/libtxc_dxtn-1.0.1-r2.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
 IUSE=""
 
-RDEPEND="media-libs/mesa"
+RDEPEND="media-libs/mesa[${MULTILIB_USEDEP}]"
 DEPEND="${RDEPEND}"
 
 RESTRICT="bindist"

--- a/media-libs/libtxc_dxtn/libtxc_dxtn-1.0.1-r2.ebuild
+++ b/media-libs/libtxc_dxtn/libtxc_dxtn-1.0.1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit ltprune
+inherit autotools eutils multilib-minimal
 
 DESCRIPTION="Helper library for	S3TC texture (de)compression"
 HOMEPAGE="https://cgit.freedesktop.org/~mareko/libtxc_dxtn/"
@@ -19,10 +19,11 @@ DEPEND="${RDEPEND}"
 
 RESTRICT="bindist"
 
-src_install() {
-	default
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf
+}
 
-	# libtxc_dxtn is installed as a module (plugin)
+multilib_src_install_all() {
 	prune_libtool_files --all
 }
 


### PR DESCRIPTION
The EAPI6 "migration" of libtxc_dxtn-1.0.1-r2 as originally implemented
causes media-libs/libtxc_txtn:0 to go from multilib to nonmultilib
for ~amd64.  This breaks any multilib dependencies, effectively masking
it if, for example, you have wine installed.

Bring it back in the standard(?) mgorny-approved(?) way: porting
to multilib-minimal.