### PR TITLE
net-firewall/fwknop: enable client, server USEs by default

### DIFF
--- a/net-firewall/fwknop/fwknop-2.6.9-r1.ebuild
+++ b/net-firewall/fwknop/fwknop-2.6.9-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,7 +17,7 @@ SRC_URI="https://github.com/mrash/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="client extras firewalld gdbm gpg iptables nfqueue python server udp-server"
+IUSE="+client extras firewalld gdbm gpg +iptables nfqueue python +server udp-server"
 
 DEPEND="
 	client? ( net-misc/wget[ssl] )
@@ -36,9 +36,6 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 REQUIRED_USE="
-	firewalld? ( server )
-	gdbm? ( server )
-	iptables? ( server )
 	nfqueue? ( server )
 	python? ( ${PYTHON_REQUIRED_USE} )
 	server? ( ^^ ( firewalld iptables ) )

--- a/profiles/base/package.use
+++ b/profiles/base/package.use
@@ -1,11 +1,6 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-# Ilya Tumaykin <itumaykin+gentoo@gmail.com> (22 Jul 2017)
-# Override default +gdbm setting, which enables minor server-only
-# feature, but enforces server USE to all users via REQUIRED_USE.
-net-firewall/fwknop -gdbm
-
 # David Seifert <soap@gentoo.org> (17 Apr 2017)
 # Only python 3.5 supported
 kde-apps/kajongg:5 python_single_target_python3_5 python_targets_python3_5

--- a/profiles/hardened/linux/package.use
+++ b/profiles/hardened/linux/package.use
@@ -1,7 +1,0 @@
-# Copyright 2017 Gentoo Foundation
-# Distributed under the terms of the GNU General Public License v2
-
-# Ilya Tumaykin <itumaykin+gentoo@gmail.com> (22 Jul 2017)
-# Override default +gdbm setting, which enables minor server-only
-# feature, but enforces server USE to all users via REQUIRED_USE.
-net-firewall/fwknop -gdbm


### PR DESCRIPTION
This makes fwknop work out-of-the-box for all users without hitting REQUIRED_USE constraints due to gdbm USE requiring server USE. Since profiles/releases/make.defaults enable gdbm USE by default, it affects most of our current profiles. In order to override this setting one needs to override it per-profile as profiles/releases is inherited last.

CC @mgorny, @kensington.