### PR TITLE
net-im/qtox: add updating icon cache and .desktop database

### DIFF
--- a/net-im/qtox/qtox-1.11.0.ebuild
+++ b/net-im/qtox/qtox-1.11.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit cmake-utils toolchain-funcs unpacker
+inherit cmake-utils gnome2-utils unpacker xdg-utils
 
 DESCRIPTION="Most feature-rich GUI for net-libs/tox using Qt5"
 HOMEPAGE="https://github.com/qTox/qTox"
@@ -55,4 +55,14 @@ src_configure() {
 	)
 
 	cmake-utils_src_configure
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
 }

--- a/net-im/qtox/qtox-9999.ebuild
+++ b/net-im/qtox/qtox-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit cmake-utils eutils git-r3
+inherit cmake-utils eutils git-r3 gnome2-utils xdg-utils
 
 DESCRIPTION="Most feature-rich GUI for net-libs/tox using Qt5"
 HOMEPAGE="https://github.com/qTox/qTox"
@@ -52,4 +52,14 @@ src_configure() {
 	)
 
 	cmake-utils_src_configure
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
 }


### PR DESCRIPTION
Also removed no longer needed toolchain-funcs from inherits.

Package-Manager: Portage-2.3.6, Repoman-2.3.1