### PR TITLE
app-emulation/virtualbox-modules: Fix build against kernel 4.12

### DIFF
--- a/app-emulation/virtualbox-modules/files/virtualbox-modules-5.0.40-page-table.patch
+++ b/app-emulation/virtualbox-modules/files/virtualbox-modules-5.0.40-page-table.patch
@@ -1,0 +1,51 @@
+--- a/vboxdrv/r0drv/linux/memobj-r0drv-linux.c	2017-03-08 07:08:13.000000000 -0500
++++ b/vboxdrv/r0drv/linux/memobj-r0drv-linux.c	2017-08-18 23:33:00.984836616 -0400
+@@ -901,6 +901,9 @@
+     union
+     {
+         pgd_t       Global;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
++        p4d_t       Four;
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
+         pud_t       Upper;
+ #endif
+@@ -918,7 +921,23 @@
+         return NULL;
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
++    u.Four  = *p4d_offset(&u.Global, ulAddr);
++    if (RT_UNLIKELY(p4d_none(u.Four)))
++        return NULL;
++    if (p4d_large(u.Four))
++    {
++        pPage = p4d_page(u.Four);
++        AssertReturn(pPage, NULL);
++        pfn   = page_to_pfn(pPage);      /* doing the safe way... */
++        AssertCompile(P4D_SHIFT - PAGE_SHIFT < 31);
++        pfn  += (ulAddr >> PAGE_SHIFT) & ((UINT32_C(1) << (P4D_SHIFT - PAGE_SHIFT)) - 1);
++        return pfn_to_page(pfn);
++    }
++    u.Upper = *pud_offset(&u.Four, ulAddr);
++#else /* < 4.12 */
+     u.Upper = *pud_offset(&u.Global, ulAddr);
++#endif /* < 4.12 */
+     if (RT_UNLIKELY(pud_none(u.Upper)))
+         return NULL;
+ # if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 25)
+
+--- a/vboxdrv//r0drv/linux/the-linux-kernel.h	2017-08-18 23:23:26.275868285 -0400
++++ b/vboxdrv/r0drv/linux/the-linux-kernel.h	2017-08-18 23:36:59.188823490 -0400
+@@ -149,6 +149,11 @@
+ # include <asm/tlbflush.h>
+ #endif
+ 
++/* for set_pages_x() */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
++# include <asm/set_memory.h>
++#endif
++
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
+ # include <asm/smap.h>
+ #else

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.0.40.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.0.40.ebuild
@@ -47,6 +47,11 @@ src_prepare() {
 		epatch "${FILESDIR}"/${PN}-4.1.4-pax-const.patch
 	fi
 
+	if kernel_is -ge 4 12 0 ; then
+		# patch for 5-level page table introduced in 4.12
+		epatch "${FILESDIR}"/${PN}-5.0.40-page-table.patch
+	fi
+
 	default
 }
 


### PR DESCRIPTION
Addresses bug 627822. 

A number of users are already using the included patch with success with 5.1.22. I modified it to work with 5.0.40 and decided to open a PR for it.