### PR TITLE
dev-python/pandocfilters: Remove unnecessary dep on pandoc

### DIFF
--- a/dev-python/pandocfilters/pandocfilters-1.2.4.ebuild
+++ b/dev-python/pandocfilters/pandocfilters-1.2.4.ebuild
@@ -15,6 +15,3 @@ LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE=""
-
-RDEPEND="<=app-text/pandoc-1.15"
-DEPEND="${RDEPEND}"

--- a/dev-python/pandocfilters/pandocfilters-1.4.1.ebuild
+++ b/dev-python/pandocfilters/pandocfilters-1.4.1.ebuild
@@ -15,6 +15,3 @@ LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE=""
-
-RDEPEND=">=app-text/pandoc-1.16"
-DEPEND="${RDEPEND}"

--- a/dev-python/pandocfilters/pandocfilters-1.4.2-r1.ebuild
+++ b/dev-python/pandocfilters/pandocfilters-1.4.2-r1.ebuild
@@ -15,6 +15,3 @@ LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
-
-RDEPEND=">=app-text/pandoc-1.16"
-DEPEND="${RDEPEND}"


### PR DESCRIPTION
Remove the unnecessary dependency on app-text/pandoc. While this package
is providing filters that work with its output, it does not strictly use
pandoc in any way or require its presence.

Considering that pandoc is written in Haskell and this package is
an indirect unconditional dependency of dev-python/ipython now, remove
the dependency that causes users to install a number of additional
packages that they will not ever use or need.

@marbre 