### PR TITLE
app-misc/physlock: create /etc/pam.d/physlock

### DIFF
--- a/app-misc/physlock/physlock-11.ebuild
+++ b/app-misc/physlock/physlock-11.ebuild
@@ -23,4 +23,5 @@ src_prepare() {
 
 src_install() {
 	emake DESTDIR="${D}" PREFIX=/usr install
+	insinto etc/pam.d; dosym login physlock
 }


### PR DESCRIPTION
physlock-11 requires /etc/pam.d/physlock, or it will spin completely out of control
