### PR TITLE
dev-perl/XML-Parser: add {R,}DEPEND on virtual/perl-Scalar-List-Utils

### DIFF
--- a/dev-perl/XML-Parser/XML-Parser-2.440.0.ebuild
+++ b/dev-perl/XML-Parser/XML-Parser-2.440.0.ebuild
@@ -13,7 +13,9 @@ SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
-RDEPEND=">=dev-libs/expat-1.95.1-r1"
+RDEPEND=">=dev-libs/expat-1.95.1-r1
+	virtual/perl-Scalar-List-Utils
+"
 DEPEND="${RDEPEND}"
 
 SRC_TEST=do


### PR DESCRIPTION
Package-Manager: Portage-2.3.6, Repoman-2.3.1

In Prefix on Cygwin, during emerge of package `dev-perl/XML-Parser-2.440.0`, encountered this error message while updating a bunch of packages - including perl 5.24.1 to 5.24.2:
`Can't load '/tools/haubi/gentoo/ow04/usr/lib/perl5/vendor_perl/5.24.1/x86_64-cygwin/auto/List/Util/Util.dll' for module List::Util: No such file or directory at /tools/haubi/gentoo/ow04/usr/lib/perl5/5.24.2/XSLoader.pm line 96.`
Note the different version numbers `5.24.1` versus `5.24.2`.

Subsequent `perl-cleaner --reallyall` yields same error message: Admitted there is no `scanelf` ATM, which might have identified to emerge `perl-core/Scalar-List-Utils` earlier, but adding `virtual/perl-Scalar-List-Utils` as `{,R}DEPEND` to `dev-perl/XML-Parser` ensures proper update order here too.

Thoughts?