### PR TITLE
dev-python/*: fix HOMEPAGE

### DIFF
--- a/dev-python/Coffin/Coffin-2.0.1.ebuild
+++ b/dev-python/Coffin/Coffin-2.0.1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
 inherit distutils-r1
 
 DESCRIPTION="Jinja2 adapter for Django"
-HOMEPAGE="https://github.com/coffin/coffin"
+HOMEPAGE="https://pypi.python.org/pypi/Coffin"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/apse/apse-0.2-r3.ebuild
+++ b/dev-python/apse/apse-0.2-r3.ebuild
@@ -9,7 +9,7 @@ inherit distutils-r1
 MY_P="Apse-${PV}"
 
 DESCRIPTION="Approximate String Matching in Python"
-HOMEPAGE="http://www.personal.psu.edu/staff/i/u/iua1/python/apse/"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
 SRC_URI="http://www.personal.psu.edu/staff/i/u/iua1/python/${PN}/dist/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-python/dill/dill-0.2.5.ebuild
+++ b/dev-python/dill/dill-0.2.5.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_{3,4,5,6} pypy )
 inherit distutils-r1
 
 DESCRIPTION="Serialize all of python (almost)"
-HOMEPAGE="http://www.cacr.caltech.edu/~mmckerns/dill.htm"
+HOMEPAGE="https://pypi.python.org/pypi/dill"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tgz"
 
 LICENSE="BSD"

--- a/dev-python/enaml/enaml-0.9.8.ebuild
+++ b/dev-python/enaml/enaml-0.9.8.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1 virtualx flag-o-matic
 
 DESCRIPTION="Enthought Tool Suite: framework for writing declarative interfaces"
-HOMEPAGE="http://code.enthought.com/projects/enaml/ https://pypi.python.org/pypi/enaml"
+HOMEPAGE="https://github.com/nucleic/enaml https://pypi.python.org/pypi/enaml"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/flask-dashed/flask-dashed-0.1b_p2.ebuild
+++ b/dev-python/flask-dashed/flask-dashed-0.1b_p2.ebuild
@@ -11,7 +11,7 @@ MY_PV="${PV/_p/}"
 MY_P="${MY_PN}-${MY_PV}"
 
 DESCRIPTION="Admin app framework for flask"
-HOMEPAGE="http://pythonhosted.org/${MY_PN}/ https://pypi.python.org/pypi/${MY_PN}"
+HOMEPAGE="http://jeanphix.me/${MY_PN}/ https://pypi.python.org/pypi/${MY_PN}"
 SRC_URI="mirror://pypi/${MY_P:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/hgdistver/hgdistver-0.25.ebuild
+++ b/dev-python/hgdistver/hgdistver-0.25.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="utility lib to generate python package version infos from mercurial tags"
-HOMEPAGE="https://bitbucket.org/RonnyPfannschmidt/hgdistver/"
+HOMEPAGE="https://pypi.python.org/pypi/hgdistver"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/hgtools/hgtools-6.5.1.ebuild
+++ b/dev-python/hgtools/hgtools-6.5.1.ebuild
@@ -9,7 +9,7 @@ RESTRICT="test"
 inherit distutils-r1 eutils
 
 DESCRIPTION="Classes and setuptools plugin for Mercurial repositories"
-HOMEPAGE="https://bitbucket.org/jaraco/hgtools/"
+HOMEPAGE="https://pypi.python.org/pypi/hgtools https://github.com/jaraco/hgtools"
 SRC_URI="mirror://pypi/h/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-python/htmlgen/htmlgen-2.2.2-r1.ebuild
+++ b/dev-python/htmlgen/htmlgen-2.2.2-r1.ebuild
@@ -8,7 +8,7 @@ inherit eutils python-r1
 
 MY_P="HTMLgen"
 DESCRIPTION="HTMLgen - Python modules for the generation of HTML documents"
-HOMEPAGE="http://starship.python.net/crew/friedrich/HTMLgen/html/main.html"
+HOMEPAGE="http://soc.if.usp.br/manual/python-htmlgen/html/main.html"
 SRC_URI="http://starship.python.net/crew/friedrich/${MY_P}.tgz"
 
 LICENSE="BSD"

--- a/dev-python/jsmin/jsmin-2.2.1.ebuild
+++ b/dev-python/jsmin/jsmin-2.2.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy )
 inherit distutils-r1
 
 DESCRIPTION="JavaScript minifier"
-HOMEPAGE="https://bitbucket.org/dcs/jsmin/"
+HOMEPAGE="https://pypi.python.org/pypi/jsmin https://github.com/tikitu/jsmin/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 KEYWORDS="amd64 x86"

--- a/dev-python/kaa-base/kaa-base-0.6.0-r1.ebuild
+++ b/dev-python/kaa-base/kaa-base-0.6.0-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_REQ_USE="sqlite?,threads(+)"
 inherit distutils-r1
 
 DESCRIPTION="Basic Framework for all Kaa Python Modules"
-HOMEPAGE="http://freevo.sourceforge.net/kaa/"
+HOMEPAGE="http://www.freevo.org/ http://api.freevo.org/kaa-base/"
 SRC_URI="mirror://sourceforge/freevo/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-python/kaa-display/kaa-display-0.1.0-r1.ebuild
+++ b/dev-python/kaa-display/kaa-display-0.1.0-r1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="Python API providing Low level support for various displays, such as X11 or framebuffer"
-HOMEPAGE="http://freevo.sourceforge.net/kaa/"
+HOMEPAGE="http://www.freevo.org/ https://github.com/freevo/kaa-display"
 SRC_URI="mirror://sourceforge/freevo/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-python/kaa-imlib2/kaa-imlib2-0.2.3-r2.ebuild
+++ b/dev-python/kaa-imlib2/kaa-imlib2-0.2.3-r2.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="Imlib2 wrapper for Python"
-HOMEPAGE="http://freevo.sourceforge.net/kaa/"
+HOMEPAGE="http://www.freevo.org/ http://api.freevo.org/kaa-imlib2/"
 SRC_URI="mirror://sourceforge/freevo/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-python/kaa-metadata/kaa-metadata-0.7.7-r1.ebuild
+++ b/dev-python/kaa-metadata/kaa-metadata-0.7.7-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_REQ_USE="threads"
 inherit distutils-r1
 
 DESCRIPTION="Powerful media metadata parser for media files in Python, successor of MMPython"
-HOMEPAGE="http://freevo.sourceforge.net/kaa/"
+HOMEPAGE="http://www.freevo.org/ https://github.com/freevo/kaa-metadata"
 SRC_URI="mirror://sourceforge/freevo/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-python/kiwi/kiwi-1.9.39.2.ebuild
+++ b/dev-python/kiwi/kiwi-1.9.39.2.ebuild
@@ -7,8 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1 versionator virtualx
 
 DESCRIPTION="Kiwi is a pure Python framework and set of enhanced PyGTK widgets"
-HOMEPAGE="http://www.async.com.br/projects/kiwi/
-	https://launchpad.net/kiwi
+HOMEPAGE="https://launchpad.net/kiwi
 	https://pypi.python.org/pypi/kiwi-gtk"
 MY_PN="${PN}-gtk"
 MY_P="${MY_PN}-${PV}"

--- a/dev-python/kiwi/kiwi-1.9.40.ebuild
+++ b/dev-python/kiwi/kiwi-1.9.40.ebuild
@@ -7,8 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1 versionator virtualx
 
 DESCRIPTION="Kiwi is a pure Python framework and set of enhanced PyGTK widgets"
-HOMEPAGE="http://www.async.com.br/projects/kiwi/
-	https://launchpad.net/kiwi
+HOMEPAGE="https://launchpad.net/kiwi
 	https://pypi.python.org/pypi/kiwi-gtk"
 MY_PN="${PN}-gtk"
 MY_P="${MY_PN}-${PV}"

--- a/dev-python/lupy/lupy-0.2.1-r2.ebuild
+++ b/dev-python/lupy/lupy-0.2.1-r2.ebuild
@@ -10,7 +10,7 @@ MY_PN="Lupy"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Lupy is a is a full-text indexer and search engine written in Python"
-HOMEPAGE="http://divmod.org/projects/lupy https://pypi.python.org/pypi/Lupy"
+HOMEPAGE="https://pypi.python.org/pypi/Lupy"
 SRC_URI="mirror://sourceforge/lupy/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-python/mantissa/mantissa-0.7.0-r1.ebuild
+++ b/dev-python/mantissa/mantissa-0.7.0-r1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit twisted-r1
 
 DESCRIPTION="An extensible, multi-protocol, multi-user, interactive application server"
-HOMEPAGE="http://divmod.org/trac/wiki/DivmodMantissa https://pypi.python.org/pypi/Mantissa"
+HOMEPAGE="https://github.com/twisted/mantissa https://pypi.python.org/pypi/Mantissa"
 SRC_URI="mirror://pypi/${TWISTED_PN:0:1}/${TWISTED_PN}/${TWISTED_P}.tar.gz"
 
 KEYWORDS="amd64 x86"

--- a/dev-python/mantissa/mantissa-0.8.4.ebuild
+++ b/dev-python/mantissa/mantissa-0.8.4.ebuild
@@ -8,7 +8,7 @@ inherit twisted-r1
 
 MY_PN="${PN/m/M}"
 DESCRIPTION="An extensible, multi-protocol, multi-user, interactive application server"
-HOMEPAGE="https://github.com/twisted/mantissa"
+HOMEPAGE="https://github.com/twisted/mantissa https://pypi.python.org/pypi/Mantissa"
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_PN}-${PV}.tar.gz -> ${P}.tar.gz"
 
 KEYWORDS="~amd64 ~x86"

--- a/dev-python/nevow/nevow-0.11.1.ebuild
+++ b/dev-python/nevow/nevow-0.11.1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit twisted-r1
 
 DESCRIPTION="A web templating framework that provides LivePage, an automatic AJAX toolkit"
-HOMEPAGE="http://divmod.org/trac/wiki/DivmodNevow https://pypi.python.org/pypi/Nevow"
+HOMEPAGE="https://github.com/twisted/nevow https://pypi.python.org/pypi/Nevow"
 SRC_URI="mirror://pypi/${TWISTED_PN:0:1}/${TWISTED_PN}/${TWISTED_P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/nevow/nevow-0.14.2.ebuild
+++ b/dev-python/nevow/nevow-0.14.2.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit twisted-r1
 
 DESCRIPTION="A web templating framework that provides LivePage, an automatic AJAX toolkit"
-HOMEPAGE="http://divmod.org/trac/wiki/DivmodNevow https://pypi.python.org/pypi/Nevow"
+HOMEPAGE="https://github.com/twisted/nevow https://pypi.python.org/pypi/Nevow"
 SRC_URI="mirror://pypi/${TWISTED_PN:0:1}/${TWISTED_PN}/${TWISTED_P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/odfpy/odfpy-1.3.2.ebuild
+++ b/dev-python/odfpy/odfpy-1.3.2.ebuild
@@ -11,7 +11,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="Python API and tools to manipulate OpenDocument files"
-HOMEPAGE="https://joinup.ec.europa.eu/software/odfpy/home https://pypi.python.org/pypi/odfpy"
+HOMEPAGE="https://github.com/eea/odfpy https://pypi.python.org/pypi/odfpy"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0 GPL-2 LGPL-2.1"

--- a/dev-python/pgasync/pgasync-2.01-r1.ebuild
+++ b/dev-python/pgasync/pgasync-2.01-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="An asynchronous API to PostgreSQL for twisted"
-HOMEPAGE="http://www.jamwt.com/pgasync/"
+HOMEPAGE="https://github.com/jamwt/pgasync"
 SRC_URI="http://www.jamwt.com/pgasync/files/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/pylibacl/pylibacl-0.5.0-r1.ebuild
+++ b/dev-python/pylibacl/pylibacl-0.5.0-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="POSIX ACLs (Access Control Lists) for Python"
-HOMEPAGE="https://sourceforge.net/projects/pylibacl/ https://pypi.python.org/pypi/pylibacl"
+HOMEPAGE="http://pylibacl.k1024.org/ https://pypi.python.org/pypi/pylibacl"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-python/pyndex/pyndex-0.3.2a-r1.ebuild
+++ b/dev-python/pyndex/pyndex-0.3.2a-r1.ebuild
@@ -12,7 +12,7 @@ MY_PN="Pyndex"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Simple and fast Python full-text indexer (aka search engine) using Metakit as its back-end"
-HOMEPAGE="http://www.divmod.org/Pyndex/index.html"
+HOMEPAGE="https://sourceforge.net/projects/pyndex/"
 SRC_URI="mirror://sourceforge/pyndex/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-python/pyosd/pyosd-0.2.14-r1.ebuild
+++ b/dev-python/pyosd/pyosd-0.2.14-r1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="Python module for displaying text on your X display, like the 'On Screen Displays' used on TVs"
-HOMEPAGE="http://ichi2.net/pyosd/"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
 SRC_URI="http://ichi2.net/pyosd/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-python/python-levenshtein/python-levenshtein-0.11.2.ebuild
+++ b/dev-python/python-levenshtein/python-levenshtein-0.11.2.ebuild
@@ -11,7 +11,7 @@ MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Functions for fast computation of Levenshtein distance, and edit operations"
 HOMEPAGE="
-	https://github.com/miohtama/python-Levenshtein/tree/
+	https://github.com/ztane/python-Levenshtein/
 	https://pypi.python.org/pypi/python-Levenshtein/"
 SRC_URI="mirror://pypi/${PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 

--- a/dev-python/python-levenshtein/python-levenshtein-0.12.0.ebuild
+++ b/dev-python/python-levenshtein/python-levenshtein-0.12.0.ebuild
@@ -12,7 +12,7 @@ MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Functions for fast computation of Levenshtein distance, and edit operations"
 HOMEPAGE="
-	https://github.com/miohtama/python-Levenshtein/tree/
+	https://github.com/ztane/python-Levenshtein/
 	https://pypi.python.org/pypi/python-Levenshtein/"
 SRC_URI="mirror://pypi/${PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 

--- a/dev-python/reverend/reverend-0.4-r1.ebuild
+++ b/dev-python/reverend/reverend-0.4-r1.ebuild
@@ -11,7 +11,7 @@ MY_PN="Reverend"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Reverend - Simple Bayesian classifier"
-HOMEPAGE="http://divmod.org/trac/wiki/DivmodReverend https://pypi.python.org/pypi/Reverend"
+HOMEPAGE="https://pypi.python.org/pypi/Reverend"
 SRC_URI="mirror://sourceforge/reverend/${MY_P}.tar.gz mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-python/ropeide/ropeide-1.5.1-r2.ebuild
+++ b/dev-python/ropeide/ropeide-1.5.1-r2.ebuild
@@ -8,7 +8,7 @@ inherit distutils-r1
 PYTHON_REQ_USE="tk"
 
 DESCRIPTION="Python refactoring IDE"
-HOMEPAGE="http://rope.sourceforge.net/ropeide.html https://pypi.python.org/pypi/ropeide"
+HOMEPAGE="http://freecode.com/projects/ropeide https://pypi.python.org/pypi/ropeide"
 SRC_URI="mirror://sourceforge/rope/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-python/ropemacs/ropemacs-0.8.ebuild
+++ b/dev-python/ropemacs/ropemacs-0.8.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1 eutils readme.gentoo
 
 DESCRIPTION="Rope in Emacs"
-HOMEPAGE="http://rope.sourceforge.net/ropemacs.html
+HOMEPAGE="https://github.com/python-rope/ropemacs
 	https://pypi.python.org/pypi/ropemacs"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 

--- a/dev-python/rtgraph/rtgraph-0.70-r1.ebuild
+++ b/dev-python/rtgraph/rtgraph-0.70-r1.ebuild
@@ -7,8 +7,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="Widgets for graphing data in real-time using PyGTK, and UI components for controlling the graphs"
-HOMEPAGE="http://navi.cx/svn/misc/trunk/rtgraph/web/index.html"
-SRC_URI="http://navi.picogui.org/releases/${P}.tar.gz"
+HOMEPAGE="http://rtgraph.sourceforge.net/"
+SRC_URI="mirror://sourceforge/rtgraph/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-python/serpent/serpent-1.7.ebuild
+++ b/dev-python/serpent/serpent-1.7.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4} pypy )
 inherit distutils-r1
 
 DESCRIPTION="A simple serialization library based on ast.literal_eval"
-HOMEPAGE="https://pypi.python.org/packages/source/s/serpent/"
+HOMEPAGE="https://pypi.python.org/pypi/serpent https://github.com/irmen/Serpent"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/utidylib/utidylib-0.2-r2.ebuild
+++ b/dev-python/utidylib/utidylib-0.2-r2.ebuild
@@ -10,7 +10,7 @@ inherit distutils-r1
 MY_P="uTidylib-${PV}"
 
 DESCRIPTION="TidyLib Python wrapper"
-HOMEPAGE="https://sourceforge.net/projects/utidylib/"
+HOMEPAGE="https://cihar.com/software/utidylib/"
 #SRC_URI="mirror://berlios/${PN}/${MY_P}.zip"
 SRC_URI="mirror://gentoo/${MY_P}.zip"
 


### PR DESCRIPTION
Hi,

This PR fixes a bunch of dead HOMEPAGEs and in one case also add fixes the SRC_URI:
Some notes:

dev-python/apse:
dev-python/pyosd:
Homepage dead, no other site found, replaced it with the no_homepage wiki entry. In case of pyosd i found a pypi entry, however, without any download possibility and just a link to the dead homepage.
SRC_URI is also broken for both packages, sadly i couldn't find any (official) download possibility.

dev-python/kiwi:
dev-python/lupy:
dev-python/reverend:
Both had dead HOMEPAGE's but since the pypi site still works and i haven't found any replacements i just removed the dead one. 

dev-python/serpent:
dev-python/utidylib:
only fixes the older ebuilds, the newer one already have a updated HOMEPAGE

dev-python/enaml:
dev-python/jsmin:
dev-python/pylibacl:
dev-python/nevow:
dev-python/hgtools:
dev-python/python-levenshtein:
dev-python/ropemacs:
dev-python/hgdistver:
dev-python/odfpy:
dev-python/Coffin:
dev-python/dill:
dev-python/flask-dashed:
These packages have a pypi site which mostly also point to a new site. Updated the ebuilds accordingly.

dev-python/htmlgen:
* changed site, but not SRC_URI as the download section points again to the starship page.
* SRC_URI= still broken

dev-python/kaa-*:
* new site: www.freevo.org + links to github pages

dev-python/mantissa:
* replace dead homepage with github page, add pypi site to the latest ebuild

dev-python/pyndex:
* use correct sourceforge site

dev-python/ropeide:
* fix homepage, use freecode instead of sourceforge

dev-python/rtgraph:
* fix homepage, found hp on sourceforge, fix SRC_URI as well

dev-python/pgasync:
* fix homepage, found github page from author

Please review.