### PR TITLE
Keyword media-sound/mumble for ~arm64

### DIFF
--- a/media-sound/mumble/mumble-1.2.19.ebuild
+++ b/media-sound/mumble/mumble-1.2.19.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://mumble.info/snapshot/${MY_P}.tar.gz"
 
 LICENSE="BSD MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+alsa +dbus debug g15 libressl oss pch portaudio pulseaudio speech zeroconf"
 
 RDEPEND=">=dev-libs/boost-1.41.0

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# NeddySeagoon <neddysegoon@gentoo.org> 24 Aug 2017
+# Support for g15daemon  still needs -9999 packages on all arches 
+media-sound/mumble g15
+
 # Michał Górny <mgorny@gentoo.org> (08 Aug 2017)
 # Required VIDEO_CARDS=i965/radeonsi, both masked in this profile.
 media-libs/mesa vulkan


### PR DESCRIPTION
Works between two users in the UK and a murmur server on the West coast of the USA. 