### PR TITLE
dev-lang/rust: add dependency on cmake

### DIFF
--- a/dev-lang/rust/rust-1.19.0.ebuild
+++ b/dev-lang/rust/rust-1.19.0.ebuild
@@ -59,6 +59,7 @@ DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	>=dev-lang/perl-5.0
 	clang? ( sys-devel/clang )
+	>=dev-util/cmake-3.4.3
 "
 
 PDEPEND=">=app-eselect/eselect-rust-0.3_pre20150425


### PR DESCRIPTION
Without this, CMake isn't necessarily the correct version or isn't
installed at all. An error similar to the following will result:

    CMake Error at CMakeLists.txt:3 (cmake_minimum_required):
      CMake 3.4.3 or higher is required.

/cc @gentoo/rust @djc 