### PR TITLE
www-servers/h2o: remove the optional dependency on ruby:2.1

### DIFF
--- a/www-servers/h2o/h2o-2.2.2.ebuild
+++ b/www-servers/h2o/h2o-2.2.2.ebuild
@@ -24,7 +24,6 @@ DEPEND="${RDEPEND}
 			dev-lang/ruby:2.4
 			dev-lang/ruby:2.3
 			dev-lang/ruby:2.2
-			dev-lang/ruby:2.1
 		)
 	)"
 

--- a/www-servers/h2o/h2o-9999.ebuild
+++ b/www-servers/h2o/h2o-9999.ebuild
@@ -24,7 +24,6 @@ DEPEND="${RDEPEND}
 			dev-lang/ruby:2.4
 			dev-lang/ruby:2.3
 			dev-lang/ruby:2.2
-			dev-lang/ruby:2.1
 		)
 	)"
 


### PR DESCRIPTION
As Ruby 2.1.x has now been masked for removal.

Package-Manager: Portage-2.3.6, Repoman-2.3.1