### PR TITLE
media-video/ffmpeg: Allow building libffmpeg for Chromium via USE flag

### DIFF
--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -96,7 +96,7 @@ FFMPEG_ENCODER_FLAG_MAP=(
 )
 
 IUSE="
-	alsa doc +encode jack oss pic static-libs test v4l
+	alsa chromium doc +encode jack oss pic static-libs test v4l
 	${FFMPEG_FLAG_MAP[@]%:*}
 	${FFMPEG_ENCODER_FLAG_MAP[@]%:*}
 "
@@ -289,6 +289,10 @@ RESTRICT="
 
 S=${WORKDIR}/${P/_/-}
 
+PATCHES=(
+	"${FILESDIR}"/chromium.patch
+)
+
 MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/libavutil/avconfig.h
 )
@@ -419,6 +423,20 @@ multilib_src_configure() {
 		"${myconf[@]}"
 	echo "${@}"
 	"${@}" || die
+
+	if multilib_is_native_abi && use chromium; then
+		einfo "Configuring for Chromium"
+		mkdir -p ../chromium || die
+		pushd ../chromium >/dev/null || die
+		set -- "${@}" \
+			--disable-shared \
+			--enable-static \
+			--enable-pic \
+			--extra-cflags="-DFF_API_CONVERGENCE_DURATION=0"
+		echo "${@}"
+		"${@}" || die
+		popd >/dev/null || die
+	fi
 }
 
 multilib_src_compile() {
@@ -430,6 +448,13 @@ multilib_src_compile() {
 				emake V=1 tools/${i}
 			fi
 		done
+
+		if use chromium; then
+			einfo "Compiling for Chromium"
+			pushd ../chromium >/dev/null || die
+			emake V=1 libffmpeg
+			popd >/dev/null || die
+		fi
 	fi
 }
 
@@ -442,6 +467,13 @@ multilib_src_install() {
 				dobin tools/${i}
 			fi
 		done
+
+		if use chromium; then
+			einfo "Installing for Chromium"
+			pushd ../chromium >/dev/null || die
+			emake V=1 DESTDIR="${D}" install-libffmpeg
+			popd >/dev/null || die
+		fi
 	fi
 }
 

--- a/media-video/ffmpeg/files/chromium.patch
+++ b/media-video/ffmpeg/files/chromium.patch
@@ -1,0 +1,45 @@
+Allow libffmpeg to be built for Chromium-based browsers
+https://patchwork.ffmpeg.org/patch/4500/
+
+diff --git a/Makefile b/Makefile
+index 29870d7..1e267e7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -65,6 +65,7 @@ all: all-yes
+ 
+ include $(SRC_PATH)/tools/Makefile
+ include $(SRC_PATH)/ffbuild/common.mak
++include $(SRC_PATH)/ffbuild/libffmpeg.mak
+ 
+ FF_EXTRALIBS := $(FFEXTRALIBS)
+ FF_DEP_LIBS  := $(DEP_LIBS)
+diff --git a/ffbuild/libffmpeg.mak b/ffbuild/libffmpeg.mak
+new file mode 100644
+index 0000000..992cf3c
+--- /dev/null
++++ b/ffbuild/libffmpeg.mak
+@@ -0,0 +1,21 @@
++LIBFFMPEG = $(SLIBPREF)ffmpeg$(SLIBSUF)
++LIBFFMPEG_LINK = $(LD) -shared -Wl,-soname,$(LIBFFMPEG) -Wl,-Bsymbolic -Wl,-z,now -Wl,-z,relro -Wl,-z,defs -Wl,--gc-sections $(LDFLAGS) $(LDLIBFLAGS) -o $(LIBFFMPEG)
++
++libffmpeg-: libavcodec/$(LIBPREF)avcodec$(LIBSUF) libavformat/$(LIBPREF)avformat$(LIBSUF) libavutil/$(LIBPREF)avutil$(LIBSUF) libswresample/$(LIBPREF)swresample$(LIBSUF)
++	$(LIBFFMPEG_LINK) -Wl,--whole-archive $^ -Wl,--no-whole-archive $(FFEXTRALIBS)
++
++libffmpeg-yes: libavcodec/$(SLIBPREF)avcodec$(SLIBSUF) libavformat/$(SLIBPREF)avformat$(SLIBSUF) libavutil/$(SLIBPREF)avutil$(SLIBSUF)
++	$(LIBFFMPEG_LINK) -Wl,--no-as-needed -lavcodec -lavformat -lavutil
++
++$(LIBFFMPEG): libffmpeg-$(CONFIG_SHARED)
++libffmpeg: $(LIBFFMPEG)
++
++install-libffmpeg: $(LIBFFMPEG)
++	$(Q)mkdir -p "$(SHLIBDIR)/chromium"
++	$(INSTALL) -m 755 $< "$(SHLIBDIR)/chromium/$<"
++	$(STRIP) "$(SHLIBDIR)/chromium/$<"
++
++uninstall-libffmpeg:
++	$(RM) "$(SHLIBDIR)/chromium/$(LIBFFMPEG)"
++
++.PHONY: libffmpeg libffmpeg-* install-libffmpeg
+-- 
+2.13.1
+

--- a/media-video/ffmpeg/metadata.xml
+++ b/media-video/ffmpeg/metadata.xml
@@ -17,6 +17,7 @@
 	<flag name="cdio">Enables audio CD grabbing with <pkg>dev-libs/libcdio</pkg>.</flag>
 	<flag name="celt">Adds Xiph CELT audio decoding support via <pkg>media-libs/celt</pkg></flag>
 	<flag name="chromaprint">Enables audio fingerprinting support with <pkg>media-libs/chromaprint</pkg>.</flag>
+	<flag name="chromium">Builds libffmpeg.so to enable media playback in Chromium-based browsers like Opera and Vivaldi.</flag>
 	<flag name="cpudetection">Enables runtime CPU detection (useful for bindist, compatibility on other CPUs)</flag>
 	<flag name="ebur128">Enables EBU R128 loudness normalization filter via <pkg>media-libs/libebur128</pkg></flag>
 	<flag name="faac">Use external faac library for AAC encoding</flag>


### PR DESCRIPTION
Chromium is built from source and therefore can be built against the
system ffmpeg. Google Chrome already ships with support for
proprietary codecs and has libffmpeg.so built in.

Opera and Vivaldi, on the other hand, do not support proprietary
codecs and actively encourage you to replace the libffmpeg.so they
provide. Official instructions involve downloading the huge Chromium
tarball and building tons of baggage that you don't actually need,
despite the fact that libffmpeg.so is really just the main ffmpeg
libraries combined.

In order to build this, I felt it was worthwhile leveraging our
existing feature-rich ffmpeg package rather than duplicating it or
creating some poor imitation. This commit shows what little extra code
is required.

It would be possible to link to the regular libraries directly instead
of buildling additional copies if it weren't for the fact that these
browsers are usually built with -DFF_API_CONVERGENCE_DURATION=0,
making the ABI incompatible, at least until libavcodec hits 59.

That aside, all Chromium versions between 59 and 61 (maybe earlier?)
use the 55.57.57 ffmpeg ABI found in the 3.x series. Having these
browsers optionally RDEPEND on ffmpeg:0/55.57.57[chromium] should
therefore not be a problem for the time being. They simply need to
provide a symlink.

I have tested this with current versions of vivaldi, vivaldi-snapshot,
opera, opera-beta, and opera-developer. None were able to play videos
on news.bbc.co.uk without Flash until swapping in this library.

It has been noted that Vivaldi could potentially be built from
source. I may explore this possibility but I believe this change is
still useful, especially as some lack sufficient hardware to build
these browsers from source.