### PR TITLE
app-accesibility/caribou: added python3.6 compat

### DIFF
--- a/app-accessibility/caribou/caribou-0.4.21.ebuild
+++ b/app-accessibility/caribou/caribou-0.4.21.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 GNOME2_LA_PUNT="yes"
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 PYTHON_REQ_USE="xml"
 
 inherit gnome2 python-r1


### PR DESCRIPTION
  Fixes Bug 629046 https://bugs.gentoo.org/show_bug.cgi?id=629046