### PR TITLE
sys-devel/llvm: Drop musl patches for 5.0+

### DIFF
--- a/sys-devel/llvm/llvm-5.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-5.0.9999.ebuild
@@ -81,9 +81,6 @@ src_prepare() {
 	# https://bugs.gentoo.org/show_bug.cgi?id=565358
 	eapply "${FILESDIR}"/9999/0007-llvm-config-Clean-up-exported-values-update-for-shar.patch
 
-	# support building llvm against musl-libc
-	use elibc_musl && eapply "${FILESDIR}"/9999/musl-fixes.patch
-
 	# disable use of SDK on OSX, bug #568758
 	sed -i -e 's/xcrun/false/' utils/lit/lit/util.py || die
 

--- a/sys-devel/llvm/llvm-9999.ebuild
+++ b/sys-devel/llvm/llvm-9999.ebuild
@@ -83,9 +83,6 @@ src_prepare() {
 	# https://bugs.gentoo.org/show_bug.cgi?id=565358
 	eapply "${FILESDIR}"/9999/0007-llvm-config-Clean-up-exported-values-update-for-shar.patch
 
-	# support building llvm against musl-libc
-	use elibc_musl && eapply "${FILESDIR}"/9999/musl-fixes.patch
-
 	# disable use of SDK on OSX, bug #568758
 	sed -i -e 's/xcrun/false/' utils/lit/lit/util.py || die
 


### PR DESCRIPTION
No longer necessary and doesn't apply, see: [D33883](https://reviews.llvm.org/D33883) and [D28476](https://reviews.llvm.org/D28476)