### PR TITLE
[RFC] dev-qt/qt{gui,wayland}: Drop USE=egl

### DIFF
--- a/dev-qt/qtwayland/metadata.xml
+++ b/dev-qt/qtwayland/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="egl">Use EGL instead of GLX to manage OpenGL contexts</flag>
 		<flag name="qml">Build QML/QtQuick bindings</flag>
 		<flag name="wayland-compositor">Build Qt compositor for wayland</flag>
 	</use>

--- a/dev-qt/qtwayland/qtwayland-5.6.2.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.6.2.ebuild
@@ -10,13 +10,13 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 arm hppa ~ppc ppc64 x86"
 fi
 
-IUSE="egl qml wayland-compositor xcomposite"
+IUSE="qml wayland-compositor xcomposite"
 
 DEPEND="
 	>=dev-libs/wayland-1.4.0
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[egl=]
-	media-libs/mesa[egl?]
+	~dev-qt/qtgui-${PV}[egl]
+	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	wayland-compositor? (
 		qml? ( ~dev-qt/qtdeclarative-${PV} )

--- a/dev-qt/qtwayland/qtwayland-5.7.1.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.7.1.ebuild
@@ -10,14 +10,14 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 x86"
 fi
 
-IUSE="egl xcomposite"
+IUSE="xcomposite"
 
 DEPEND="
 	>=dev-libs/wayland-1.4.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl=]
-	media-libs/mesa[egl?]
+	~dev-qt/qtgui-${PV}[egl]
+	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (
 		x11-libs/libX11

--- a/kde-frameworks/kwayland/kwayland-5.34.0.ebuild
+++ b/kde-frameworks/kwayland/kwayland-5.34.0.ebuild
@@ -20,7 +20,7 @@ DEPEND="
 	media-libs/mesa[egl]
 "
 RDEPEND="${DEPEND}
-	$(add_qt_dep qtwayland 'egl')
+	$(add_qt_dep qtwayland 'egl(+)')
 	!kde-plasma/kwayland
 "
 

--- a/kde-frameworks/kwayland/kwayland-5.37.0.ebuild
+++ b/kde-frameworks/kwayland/kwayland-5.37.0.ebuild
@@ -20,7 +20,7 @@ DEPEND="
 	media-libs/mesa[egl]
 "
 RDEPEND="${DEPEND}
-	$(add_qt_dep qtwayland 'egl')
+	$(add_qt_dep qtwayland 'egl(+)')
 "
 
 # All failing, I guess we need a virtual wayland server

--- a/profiles/targets/desktop/plasma/package.use
+++ b/profiles/targets/desktop/plasma/package.use
@@ -48,7 +48,6 @@ media-libs/mesa egl wayland
 
 # Required by kde-frameworks/kwayland
 dev-qt/qtgui:5 egl
-dev-qt/qtwayland:5 egl
 
 # Required by kde-apps/kdenlive
 >=media-libs/mlt-0.9.8-r2 ffmpeg kdenlive melt


### PR DESCRIPTION
This is not to say I would merge these changes to stable 5.7.1, but I would like to know what you think about it. For reference: https://bugs.gentoo.org/show_bug.cgi?id=627758#c3

In short, local `USE={egl,gles{,1,2,3}}` flags currently have conflicting implications wrt enabling additional support vs. disabling other. With egl I just picked the lowest hanging fruit to start with, and removal (building it unconditionally) in this case is the most convenient way (at least for a biased KDE team member).