### PR TITLE
dev-cpp/gtest: Fix test failure with sandbox and other bugs

### DIFF
--- a/dev-cpp/gtest/files/gtest-1.8.0-fix-doublefree.patch
+++ b/dev-cpp/gtest/files/gtest-1.8.0-fix-doublefree.patch
@@ -1,0 +1,98 @@
+Bug: https://bugs.gentoo.org/631698
+Upstream PR: https://github.com/google/googletest/pull/1339
+
+From 0663ce9024c9b78ddf6eb3fc1ceb45361ed91767 Mon Sep 17 00:00:00 2001
+From: Romain Geissler <romain.geissler@gmail.com>
+Date: Sat, 2 Dec 2017 22:47:20 +0100
+Subject: [PATCH] Fix double free when building Gtest/GMock in shared libraries
+ and linking a test executable with both.
+
+---
+ googlemock/CMakeLists.txt | 63 ++++++++++++++++++++++++++++++-----------------
+ 1 file changed, 40 insertions(+), 23 deletions(-)
+
+diff --git a/googlemock/CMakeLists.txt b/googlemock/CMakeLists.txt
+index 724fdd5f0..f7bad8afc 100644
+--- a/googlemock/CMakeLists.txt
++++ b/googlemock/CMakeLists.txt
+@@ -86,16 +86,23 @@ endif()
+ # Google Mock libraries.  We build them using more strict warnings than what
+ # are used for other targets, to ensure that Google Mock can be compiled by
+ # a user aggressive about warnings.
+-cxx_library(gmock
+-            "${cxx_strict}"
+-            "${gtest_dir}/src/gtest-all.cc"
+-            src/gmock-all.cc)
+-
+-cxx_library(gmock_main
+-            "${cxx_strict}"
+-            "${gtest_dir}/src/gtest-all.cc"
+-            src/gmock-all.cc
+-            src/gmock_main.cc)
++if (MSVC)
++  cxx_library(gmock
++              "${cxx_strict}"
++              "${gtest_dir}/src/gtest-all.cc"
++              src/gmock-all.cc)
++
++  cxx_library(gmock_main
++              "${cxx_strict}"
++              "${gtest_dir}/src/gtest-all.cc"
++              src/gmock-all.cc
++              src/gmock_main.cc)
++else()
++  cxx_library(gmock "${cxx_strict}" src/gmock-all.cc)
++  target_link_libraries(gmock gtest)
++  cxx_library(gmock_main "${cxx_strict}" src/gmock_main.cc)
++  target_link_libraries(gmock_main gmock)
++endif()
+ 
+ # If the CMake version supports it, attach header directory information
+ # to the targets for when we are part of a parent build (ie being pulled
+@@ -175,23 +182,33 @@ if (gmock_build_tests)
+   ############################################################
+   # C++ tests built with non-standard compiler flags.
+ 
+-  cxx_library(gmock_main_no_exception "${cxx_no_exception}"
+-    "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+-
+-  cxx_library(gmock_main_no_rtti "${cxx_no_rtti}"
+-    "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
++  if (MSVC)
++    cxx_library(gmock_main_no_exception "${cxx_no_exception}"
++      "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+ 
+-  if (NOT MSVC OR MSVC_VERSION LESS 1600)  # 1600 is Visual Studio 2010.
+-    # Visual Studio 2010, 2012, and 2013 define symbols in std::tr1 that
+-    # conflict with our own definitions. Therefore using our own tuple does not
+-    # work on those compilers.
+-    cxx_library(gmock_main_use_own_tuple "${cxx_use_own_tuple}"
++    cxx_library(gmock_main_no_rtti "${cxx_no_rtti}"
+       "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+ 
+-    cxx_test_with_flags(gmock_use_own_tuple_test "${cxx_use_own_tuple}"
+-      gmock_main_use_own_tuple test/gmock-spec-builders_test.cc)
++    if (MSVC_VERSION LESS 1600)  # 1600 is Visual Studio 2010.
++      # Visual Studio 2010, 2012, and 2013 define symbols in std::tr1 that
++      # conflict with our own definitions. Therefore using our own tuple does not
++      # work on those compilers.
++      cxx_library(gmock_main_use_own_tuple "${cxx_use_own_tuple}"
++        "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
++
++      cxx_test_with_flags(gmock_use_own_tuple_test "${cxx_use_own_tuple}"
++        gmock_main_use_own_tuple test/gmock-spec-builders_test.cc)
++    endif()
++  else()
++    cxx_library(gmock_main_no_exception "${cxx_no_exception}" src/gmock_main.cc)
++    target_link_libraries(gmock_main_no_exception gmock)
++
++    cxx_library(gmock_main_no_rtti "${cxx_no_rtti}" src/gmock_main.cc)
++    target_link_libraries(gmock_main_no_rtti gmock)
++
++    cxx_library(gmock_main_use_own_tuple "${cxx_use_own_tuple}" src/gmock_main.cc)
++    target_link_libraries(gmock_main_use_own_tuple gmock)
+   endif()
+-
+   cxx_test_with_flags(gmock-more-actions_no_exception_test "${cxx_no_exception}"
+     gmock_main_no_exception test/gmock-more-actions_test.cc)
+ 

--- a/dev-cpp/gtest/files/gtest-1.8.0-increase-clone-stack-size.patch
+++ b/dev-cpp/gtest/files/gtest-1.8.0-increase-clone-stack-size.patch
@@ -1,0 +1,14 @@
+Bug: https://bugs.gentoo.org/629620
+Upstream PR: https://github.com/google/googletest/pull/1274
+
+--- a/googletest/src/gtest-death-test.cc
++++ b/googletest/src/gtest-death-test.cc
+@@ -1070,7 +1070,7 @@
+ 
+   if (!use_fork) {
+     static const bool stack_grows_down = StackGrowsDown();
+-    const size_t stack_size = getpagesize();
++    const size_t stack_size = getpagesize() * 10;
+     // MMAP_ANONYMOUS is not defined on Mac, so we use MAP_ANON instead.
+     void* const stack = mmap(NULL, stack_size, PROT_READ | PROT_WRITE,
+                              MAP_ANON | MAP_PRIVATE, -1, 0);

--- a/dev-cpp/gtest/gtest-1.7.0-r1.ebuild
+++ b/dev-cpp/gtest/gtest-1.7.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"

--- a/dev-cpp/gtest/gtest-1.8.0-r1.ebuild
+++ b/dev-cpp/gtest/gtest-1.8.0-r1.ebuild
@@ -1,37 +1,34 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
 # Python is required for tests and some build tasks.
 PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy )
 
 inherit python-any-r1 cmake-multilib
 
-if [[ ${PV} == "9999" ]]; then
-	inherit git-r3
-	EGIT_REPO_URI="https://github.com/google/googletest"
-else
-	SRC_URI="https://github.com/google/googletest/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
-	S="${WORKDIR}"/googletest-release-${PV}
-fi
-
 DESCRIPTION="Google C++ Testing Framework"
 HOMEPAGE="https://github.com/google/googletest"
+SRC_URI="https://github.com/google/googletest/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="doc examples test"
 
 DEPEND="test? ( ${PYTHON_DEPS} )"
 RDEPEND="!dev-cpp/gmock"
 
 PATCHES=(
+	"${FILESDIR}"/${PN}-9999-fix-py-tests.patch
 	"${FILESDIR}"/${PN}-9999-fix-gcc6-undefined-behavior.patch
+	"${FILESDIR}"/${PN}-1.8.0-multilib-strict.patch
 	"${FILESDIR}"/${PN}-1.8.0-increase-clone-stack-size.patch
 	"${FILESDIR}"/${PN}-1.8.0-fix-doublefree.patch
 )
+
+S="${WORKDIR}"/googletest-release-${PV}
 
 pkg_setup() {
 	use test && python-any-r1_pkg_setup
@@ -41,22 +38,17 @@ multilib_src_configure() {
 	local mycmakeargs=(
 		-DBUILD_GMOCK=ON
 		-DBUILD_GTEST=ON
-		-DINSTALL_GMOCK=ON
-		-DINSTALL_GTEST=ON
+		-DLIB_INSTALL_DIR=$(get_libdir)
 		-Dgtest_build_samples=OFF
 		-Dgtest_disable_pthreads=OFF
-
-		# currently only static libs work
-		# due to numerous ODR violations
-		# https://github.com/google/googletest/issues/930
-		-DBUILD_SHARED_LIBS=OFF
+		-DBUILD_SHARED_LIBS=ON
 
 		# tests
 		-Dgmock_build_tests=$(usex test)
 		-Dgtest_build_tests=$(usex test)
 		-DPYTHON_EXECUTABLE="${PYTHON}"
 	)
-	cmake-utils_src_configure
+	cmake-utils_src_configure mycmakeargs
 }
 
 multilib_src_install_all() {

--- a/dev-cpp/gtest/gtest-1.8.0.ebuild
+++ b/dev-cpp/gtest/gtest-1.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/dev-cpp/gtest/gtest-1.8.0.ebuild
+++ b/dev-cpp/gtest/gtest-1.8.0.ebuild
@@ -24,6 +24,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9999-fix-py-tests.patch
 	"${FILESDIR}"/${PN}-9999-fix-gcc6-undefined-behavior.patch
 	"${FILESDIR}"/${PN}-1.8.0-multilib-strict.patch
+	"${FILESDIR}"/${PN}-1.8.0-increase-clone-stack-size.patch
 )
 
 S="${WORKDIR}"/googletest-release-${PV}

--- a/dev-cpp/gtest/gtest-1.8.0.ebuild
+++ b/dev-cpp/gtest/gtest-1.8.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/google/googletest/archive/release-${PV}.tar.gz -> ${
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE="examples test"
+IUSE="doc examples test"
 
 DEPEND="test? ( ${PYTHON_DEPS} )"
 RDEPEND="!dev-cpp/gmock"
@@ -52,6 +52,13 @@ multilib_src_configure() {
 
 multilib_src_install_all() {
 	einstalldocs
+
+	if use doc; then
+		docinto googletest
+		dodoc -r googletest/docs/*
+		docinto googlemock
+		dodoc -r googlemock/docs/*
+	fi
 
 	if use examples; then
 		docinto examples

--- a/dev-cpp/gtest/gtest-9999.ebuild
+++ b/dev-cpp/gtest/gtest-9999.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://github.com/google/googletest"
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="examples test"
+IUSE="doc examples test"
 
 DEPEND="test? ( ${PYTHON_DEPS} )"
 RDEPEND="!dev-cpp/gmock"
@@ -60,6 +60,13 @@ multilib_src_configure() {
 
 multilib_src_install_all() {
 	einstalldocs
+
+	if use doc; then
+		docinto googletest
+		dodoc -r googletest/docs/*
+		docinto googlemock
+		dodoc -r googlemock/docs/*
+	fi
 
 	if use examples; then
 		docinto examples

--- a/dev-cpp/gtest/gtest-9999.ebuild
+++ b/dev-cpp/gtest/gtest-9999.ebuild
@@ -29,6 +29,7 @@ RDEPEND="!dev-cpp/gmock"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-9999-fix-gcc6-undefined-behavior.patch
+	"${FILESDIR}"/${PN}-1.8.0-increase-clone-stack-size.patch
 )
 
 pkg_setup() {

--- a/dev-cpp/gtest/metadata.xml
+++ b/dev-cpp/gtest/metadata.xml
@@ -10,8 +10,7 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
-		<doc lang="en">https://code.google.com/p/googletest/w/list</doc>
-		<remote-id type="google-code">googletest</remote-id>
+		<doc lang="en">https://github.com/google/googletest/tree/master/googletest/docs</doc>
 		<remote-id type="github">google/googletest</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=629620

When usersandbox is included in FEATURES, some tests cause a segfault in libsandbox.so and fail.  Specifically, several `ASSERT_DEATH()` tests in `gtest-death-test_test` segfault in which they're run with `::testing::GTEST_FLAG(death_test_style)` set to `"threadsafe"`.

Edit: PR submitted upstream: https://github.com/google/googletest/pull/1274 and
Edit: PR updates metadata.xml to remove references to code.google.com.

Edit:  Also added a fix for https://github.com/google/googletest/issues/930, reported downstream with https://bugs.gentoo.org/631698.
  
  