### PR TITLE
sci-libs/vtk-7 bundled six conflicts with dev-python/six (#612702)

### DIFF
--- a/sci-libs/vtk/vtk-7.1.0-r1.ebuild
+++ b/sci-libs/vtk/vtk-7.1.0-r1.ebuild
@@ -71,7 +71,11 @@ RDEPEND="
 	postgres? ( dev-db/postgresql:= )
 	python? (
 		${PYTHON_DEPS}
+		dev-python/autobahn[${PYTHON_USEDEP}]
 		dev-python/sip[${PYTHON_USEDEP}]
+		dev-python/six[${PYTHON_USEDEP}]
+		dev-python/twisted-core[${PYTHON_USEDEP}]
+		dev-python/zope-interface[${PYTHON_USEDEP}]
 	)
 	qt5? (
 		dev-qt/designer:5
@@ -95,9 +99,6 @@ RDEPEND="
 	virtual/opengl
 	web? (
 		${WEBAPP_DEPEND}
-		dev-python/autobahn[${PYTHON_USEDEP}]
-		dev-python/twisted-core[${PYTHON_USEDEP}]
-		dev-python/zope-interface[${PYTHON_USEDEP}]
 	)
 	xdmf2? ( sci-libs/xdmf2 )
 	x11-libs/libX11
@@ -154,7 +155,6 @@ src_configure() {
 		-DVTK_DATA_ROOT="${EPREFIX}/usr/share/${PN}/data"
 		-DVTK_CUSTOM_LIBRARY_SUFFIX=""
 		-DBUILD_SHARED_LIBS=ON
-		-DVTK_USE_SYSTEM_AUTOBAHN=ON
 		-DVTK_USE_SYSTEM_EXPAT=ON
 		-DVTK_USE_SYSTEM_FREETYPE=ON
 		-DVTK_USE_SYSTEM_FreeType=ON
@@ -169,11 +169,9 @@ src_configure() {
 		-DVTK_USE_SYSTEM_OGGTHEORA=ON
 		-DVTK_USE_SYSTEM_PNG=ON
 		-DVTK_USE_SYSTEM_TIFF=ON
-		-DVTK_USE_SYSTEM_TWISTED=ON
 		-DVTK_USE_SYSTEM_XDMF2=OFF
 		-DVTK_USE_SYSTEM_XDMF3=OFF
 		-DVTK_USE_SYSTEM_ZLIB=ON
-		-DVTK_USE_SYSTEM_ZOPE=ON
 		-DVTK_USE_SYSTEM_LIBRARIES=ON
 		# Use bundled diy2 (no gentoo package / upstream does not provide a Finddiy2.cmake or diy2Config.cmake / diy2-config.cmake)
 		-DVTK_USE_SYSTEM_DIY2=OFF
@@ -246,6 +244,10 @@ src_configure() {
 			-DVTK_PYTHON_INCLUDE_DIR="$(python_get_includedir)"
 			-DVTK_PYTHON_LIBRARY="$(python_get_library_path)"
 			-DVTK_PYTHON_SETUP_ARGS:STRING="--prefix=${EPREFIX} --root=${D}"
+			-DVTK_USE_SYSTEM_AUTOBAHN=ON
+			-DVTK_USE_SYSTEM_SIX=ON
+			-DVTK_USE_SYSTEM_TWISTED=ON
+			-DVTK_USE_SYSTEM_ZOPE=ON
 		)
 	fi
 


### PR DESCRIPTION
vtk seems to use a bundled version of six :-(.
Seemingly to build a bundled version of "autobahn", both are separately in portage...
I get on install:
```
 * Detected file collision(s):
 * 
 *      /usr/lib64/python2.7/site-packages/six.py
 * 
 * Searching all installed packages for file collisions...
 * 
 * Press Ctrl-C to Stop
 * 
 * dev-python/six-1.10.0:0::gentoo
 *      /usr/lib64/python2.7/site-packages/six.py
```
Sadly dev-python/six is used a lot by many other python deps, so I can not remove it.

And I test it this different settings of `python` and `web` USE-flags, and now it works for me.