### PR TITLE
net-dns/pdns: add libressl support

### DIFF
--- a/net-dns/pdns/pdns-4.0.2.ebuild
+++ b/net-dns/pdns/pdns-4.0.2.ebuild
@@ -18,12 +18,13 @@ KEYWORDS="amd64 x86"
 # oracle: dito (need Oracle Client Libraries)
 # xdb: (almost) dead, surely not supported
 
-IUSE="botan debug doc geoip ldap lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
+IUSE="botan debug doc geoip ldap libressl lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
 
 REQUIRED_USE="mydns? ( mysql ) ?? ( lua luajit )"
 
 RDEPEND="
-	dev-libs/openssl:=
+	libressl? ( dev-libs/libressl:= )
+	!libressl? ( dev-libs/openssl:= )
 	>=dev-libs/boost-1.35:=
 	botan? ( =dev-libs/botan-1.10*[threads] )
 	lua? ( dev-lang/lua:= )

--- a/net-dns/pdns/pdns-4.0.3-r3.ebuild
+++ b/net-dns/pdns/pdns-4.0.3-r3.ebuild
@@ -18,12 +18,13 @@ KEYWORDS="~amd64 ~x86"
 # oracle: dito (need Oracle Client Libraries)
 # xdb: (almost) dead, surely not supported
 
-IUSE="botan debug doc geoip ldap lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
+IUSE="botan debug doc geoip ldap libressl lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
 
 REQUIRED_USE="mydns? ( mysql ) ?? ( lua luajit )"
 
 RDEPEND="
-	dev-libs/openssl:=
+	libressl? ( dev-libs/libressl:= )
+	!libressl? ( dev-libs/openssl:= )
 	>=dev-libs/boost-1.35:=
 	botan? ( =dev-libs/botan-1.10*[threads] )
 	lua? ( dev-lang/lua:= )

--- a/net-dns/pdns/pdns-4.0.3.ebuild
+++ b/net-dns/pdns/pdns-4.0.3.ebuild
@@ -18,12 +18,13 @@ KEYWORDS="~amd64 ~x86"
 # oracle: dito (need Oracle Client Libraries)
 # xdb: (almost) dead, surely not supported
 
-IUSE="botan debug doc geoip ldap lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
+IUSE="botan debug doc geoip ldap libressl lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
 
 REQUIRED_USE="mydns? ( mysql ) ?? ( lua luajit )"
 
 RDEPEND="
-	dev-libs/openssl:=
+	libressl? ( dev-libs/libressl:= )
+	!libressl? ( dev-libs/openssl:= )
 	>=dev-libs/boost-1.35:=
 	botan? ( =dev-libs/botan-1.10*[threads] )
 	lua? ( dev-lang/lua:= )

--- a/net-dns/pdns/pdns-4.0.4.ebuild
+++ b/net-dns/pdns/pdns-4.0.4.ebuild
@@ -18,12 +18,13 @@ KEYWORDS="~amd64 ~x86"
 # oracle: dito (need Oracle Client Libraries)
 # xdb: (almost) dead, surely not supported
 
-IUSE="botan debug doc geoip ldap lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
+IUSE="botan debug doc geoip ldap libressl lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
 
 REQUIRED_USE="mydns? ( mysql ) ?? ( lua luajit )"
 
 RDEPEND="
-	dev-libs/openssl:=
+	libressl? ( dev-libs/libressl:= )
+	!libressl? ( dev-libs/openssl:= )
 	>=dev-libs/boost-1.35:=
 	botan? ( =dev-libs/botan-1.10*[threads] )
 	lua? ( dev-lang/lua:= )

--- a/net-dns/pdns/pdns-4.1.0_rc1.ebuild
+++ b/net-dns/pdns/pdns-4.1.0_rc1.ebuild
@@ -18,12 +18,13 @@ KEYWORDS="~amd64 ~x86"
 # oracle: dito (need Oracle Client Libraries)
 # xdb: (almost) dead, surely not supported
 
-IUSE="botan debug doc geoip ldap lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
+IUSE="botan debug doc geoip ldap libressl lua luajit mydns mysql opendbx postgres protobuf remote sqlite systemd tools tinydns test"
 
 REQUIRED_USE="mydns? ( mysql ) ?? ( lua luajit )"
 
 RDEPEND="
-	dev-libs/openssl:=
+	libressl? ( dev-libs/libressl:= )
+	!libressl? ( dev-libs/openssl:= )
 	>=dev-libs/boost-1.35:=
 	botan? ( =dev-libs/botan-1.10*[threads] )
 	lua? ( dev-lang/lua:= )


### PR DESCRIPTION
PowerDNS Authoritative Server supports LibreSSL since version 4.0.2.
Compile-tested all versions on Gentoo Hardened musl amd64.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>