### PR TITLE
dev-db/sqlitestudio: DEPEND+=dev-qt/qtconcurrent:5

### DIFF
--- a/dev-db/sqlitestudio/sqlitestudio-3.0.7.ebuild
+++ b/dev-db/sqlitestudio/sqlitestudio-3.0.7.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 	tcl? ( dev-lang/tcl:= )
 "
 DEPEND="${RDEPEND}
+	$(add_qt_dep qtconcurrent)
 	>=sys-devel/gcc-4.8:*
 	test? ( $(add_qt_dep qttest) )
 "

--- a/dev-db/sqlitestudio/sqlitestudio-3.1.1.ebuild
+++ b/dev-db/sqlitestudio/sqlitestudio-3.1.1.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	dev-qt/designer:5
+	dev-qt/qtconcurrent:5
 	test? ( dev-qt/qttest:5 )
 "
 


### PR DESCRIPTION
- Add missing build-time dependency dev-qt/qtconcurrent:5

Gentoo-Bug: 590028