### PR TITLE
media-sound/audacity: Fix incorrect dependency on media-libs/flac

### DIFF
--- a/media-sound/audacity/audacity-2.1.3-r1.ebuild
+++ b/media-sound/audacity/audacity-2.1.3-r1.ebuild
@@ -27,7 +27,7 @@ RDEPEND=">=app-arch/zip-2.3
 	alsa? ( media-libs/alsa-lib )
 	ffmpeg? ( libav? ( media-video/libav:= )
 		!libav? ( >=media-video/ffmpeg-1.2:= ) )
-	flac? ( >=media-libs/flac-1.2.0[cxx] )
+	flac? ( >=media-libs/flac-1.3.1[cxx] )
 	id3tag? ( media-libs/libid3tag )
 	jack? ( virtual/jack )
 	lame? ( >=media-sound/lame-3.70 )


### PR DESCRIPTION
See-Also: Gentoo-Bug #629920
Package-Manager: Portage-2.3.6, Repoman-2.3.1