### PR TITLE
dev-util/pkgconfig: rename 'internal-glib' to 'build'

### DIFF
--- a/dev-util/pkgconfig/pkgconfig-0.29.2.ebuild
+++ b/dev-util/pkgconfig/pkgconfig-0.29.2.ebuild
@@ -25,9 +25,9 @@ HOMEPAGE="https://pkgconfig.freedesktop.org/wiki/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="elibc_FreeBSD elibc_glibc hardened internal-glib"
+IUSE="build elibc_FreeBSD elibc_glibc hardened"
 
-RDEPEND="!internal-glib? ( >=dev-libs/glib-2.34.3[${MULTILIB_USEDEP}] )
+RDEPEND="!build? ( >=dev-libs/glib-2.34.3[${MULTILIB_USEDEP}] )
 	!dev-util/pkgconf[pkg-config]
 	!dev-util/pkg-config-lite
 	!dev-util/pkgconfig-openbsd[pkg-config]
@@ -61,7 +61,7 @@ src_prepare() {
 multilib_src_configure() {
 	local myconf
 
-	if use internal-glib; then
+	if use build; then
 		myconf+=' --with-internal-glib'
 		# non-glibc platforms use GNU libiconv, but configure needs to
 		# know about that not to get confused when it finds something

--- a/dev-util/pkgconfig/pkgconfig-9999.ebuild
+++ b/dev-util/pkgconfig/pkgconfig-9999.ebuild
@@ -25,9 +25,9 @@ HOMEPAGE="https://pkgconfig.freedesktop.org/wiki/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="elibc_FreeBSD elibc_glibc hardened internal-glib"
+IUSE="build elibc_FreeBSD elibc_glibc hardened"
 
-RDEPEND="!internal-glib? ( >=dev-libs/glib-2.34.3[${MULTILIB_USEDEP}] )
+RDEPEND="!build? ( >=dev-libs/glib-2.34.3[${MULTILIB_USEDEP}] )
 	!dev-util/pkgconf[pkg-config]
 	!dev-util/pkg-config-lite
 	!dev-util/pkgconfig-openbsd[pkg-config]
@@ -61,7 +61,7 @@ src_prepare() {
 multilib_src_configure() {
 	local myconf
 
-	if use internal-glib; then
+	if use build; then
 		myconf+=' --with-internal-glib'
 		# non-glibc platforms use GNU libiconv, but configure needs to
 		# know about that not to get confused when it finds something


### PR DESCRIPTION
This avoids a circular dependency on dev-libs/glib during catalyst stage1 builds.

CC: @gentoo/freedesktop @gentoo/releng 