### PR TITLE
eapi7-ver.eclass: Early testing of EAPI 7 version manipulation functions

### DIFF
--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -31,7 +31,7 @@ _version_parse_range() {
 	[[ $1 =~ ^([0-9]+)(-([0-9]*))?$ ]] || die
 	start=${BASH_REMATCH[1]}
 	[[ ${BASH_REMATCH[2]} ]] && end=${BASH_REMATCH[3]} || end=${start}
-	[[ ${start} -gt 0 ]] && [[ -z ${end} || ${start} -le ${end} ]] || die
+	[[ ${start} -ge 0 ]] && [[ -z ${end} || ${start} -le ${end} ]] || die
 }
 
 # RETURNS:
@@ -51,17 +51,24 @@ _version_split() {
 }
 
 version_cut() {
-	local start end
+	local start end istart iend
 	local -a comp
 
 	_version_parse_range "$1"
 	_version_split "${2-${PV}}"
 
 	local IFS=
-	if [[ ${end} ]]; then
-		echo "${comp[*]:(start-1)*2+1:(end-start)*2+1}"
+	if [[ ${start} -gt 0 ]]; then
+		istart=$(( (start-1)*2 + 1 ))
+		iend=$(( (end-start)*2 + 1 ))
 	else
-		echo "${comp[*]:(start-1)*2+1}"
+		istart=0
+		iend=$(( (end-start)*2 ))
+	fi
+	if [[ ${end} ]]; then
+		echo "${comp[*]:istart:iend}"
+	else
+		echo "${comp[*]:istart}"
 	fi
 }
 

--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -51,7 +51,7 @@ _version_split() {
 }
 
 version_cut() {
-	local start end istart iend
+	local start end istart
 	local -a comp
 
 	_version_parse_range "$1"
@@ -59,14 +59,12 @@ version_cut() {
 
 	local IFS=
 	if [[ ${start} -gt 0 ]]; then
-		istart=$(( (start-1)*2 + 1 ))
-		iend=$(( (end-start)*2 + 1 ))
+		istart=$(( start*2 - 1 ))
 	else
 		istart=0
-		iend=$(( (end-start)*2 ))
 	fi
 	if [[ ${end} ]]; then
-		echo "${comp[*]:istart:iend}"
+		echo "${comp[*]:istart:end*2-istart}"
 	else
 		echo "${comp[*]:istart}"
 	fi

--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -40,14 +40,9 @@ _version_parse_range() {
 _version_split() {
 	local v=$1 LC_ALL=C
 
-	comp=("")
+	comp=()
 
-	# get first component
-	[[ ${v} =~ ^([A-Za-z]*|[0-9]*) ]] || die
-	comp+=("${BASH_REMATCH[1]}")
-	v=${v:${#BASH_REMATCH[0]}}
-
-	# get remaining separators and components
+	# get separators and components
 	while [[ ${v} ]]; do
 		[[ ${v} =~ ^([^A-Za-z0-9]*)([A-Za-z]*|[0-9]*) ]] || die
 		comp+=("${BASH_REMATCH[@]:1:2}")

--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -28,10 +28,10 @@ case ${EAPI:-0} in
 esac
 
 _version_parse_range() {
-	[[ $1 =~ ^([0-9]+)(-([0-9]*))?$ ]] || die
-	start=${BASH_REMATCH[1]}
-	[[ ${BASH_REMATCH[2]} ]] && end=${BASH_REMATCH[3]} || end=${start}
-	[[ ${start} -ge 0 ]] && [[ -z ${end} || ${start} -le ${end} ]] || die
+	[[ ${1} == [0-9]* ]] || die
+	start=${1%-*}
+	[[ ${1} == *-* ]] && end=${1#*-} || end=${start}
+	[[ ${start} -ge 0 && ( -z ${end} || ${start} -le ${end} ) ]] || die
 }
 
 # RETURNS:

--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -34,12 +34,17 @@ _version_parse_range() {
 	[[ ${start} -gt 0 ]] && [[ -z ${end} || ${start} -le ${end} ]] || die
 }
 
+# RETURNS:
+# comp=( s0 c1 s1 c2 s2... )
+# where s - separator, c - component
 _version_split() {
 	local v=$1 LC_ALL=C
 
+	comp=("")
+
 	# get first component
 	[[ ${v} =~ ^([A-Za-z]*|[0-9]*) ]] || die
-	comp=("${BASH_REMATCH[1]}")
+	comp+=("${BASH_REMATCH[1]}")
 	v=${v:${#BASH_REMATCH[0]}}
 
 	# get remaining separators and components
@@ -59,9 +64,9 @@ version_cut() {
 
 	local IFS=
 	if [[ ${end} ]]; then
-		echo "${comp[*]:(start-1)*2:(end-start)*2+1}"
+		echo "${comp[*]:(start-1)*2+1:(end-start)*2+1}"
 	else
-		echo "${comp[*]:(start-1)*2}"
+		echo "${comp[*]:(start-1)*2+1}"
 	fi
 }
 
@@ -74,7 +79,7 @@ version_rs() {
 	while [[ $# -ge 2 ]]; do
 		_version_parse_range "$1"
 		[[ ${end} && ${end} -le $((${#comp[@]}/2)) ]] || end=$((${#comp[@]}/2))
-		for (( i = start*2 - 1; i < end*2; i+=2 )); do
+		for (( i = start*2; i <= end*2; i+=2 )); do
 			comp[i]=$2
 		done
 		shift 2

--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -51,7 +51,7 @@ _version_split() {
 }
 
 version_cut() {
-	local start end istart
+	local start end
 	local -a comp
 
 	_version_parse_range "$1"
@@ -59,14 +59,12 @@ version_cut() {
 
 	local IFS=
 	if [[ ${start} -gt 0 ]]; then
-		istart=$(( start*2 - 1 ))
-	else
-		istart=0
+		start=$(( start*2 - 1 ))
 	fi
 	if [[ ${end} ]]; then
-		echo "${comp[*]:istart:end*2-istart}"
+		echo "${comp[*]:start:end*2-start}"
 	else
-		echo "${comp[*]:istart}"
+		echo "${comp[*]:start}"
 	fi
 }
 

--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -43,10 +43,16 @@ _version_split() {
 	comp=()
 
 	# get separators and components
+	local s c
 	while [[ ${v} ]]; do
-		[[ ${v} =~ ^([^A-Za-z0-9]*)([A-Za-z]*|[0-9]*) ]] || die
-		comp+=("${BASH_REMATCH[@]:1:2}")
-		v=${v:${#BASH_REMATCH[0]}}
+		# cut the separator
+		s="${v%%[a-zA-Z0-9]*}"
+		v=${v:${#s}}
+		# cut the next component; it can be either digits or letters
+		[[ ${v} == [0-9]* ]] && c=${v%%[^0-9]*} || c=${v%%[^a-zA-Z]*}
+		v=${v:${#c}}
+
+		comp+=( "${s}" "${c}" )
 	done
 }
 

--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -1,0 +1,85 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: eapi7-ver.eclass
+# @MAINTAINER:
+# PMS team <pms@gentoo.org>
+# @AUTHOR:
+# Ulrich Müller <ulm@gentoo.org>
+# Michał Górny <mgorny@gentoo.org>
+# @BLURB: Testing implementation of EAPI 7 version manipulators
+# @DESCRIPTION:
+# A stand-alone implementation of the version manipulation functions
+# aimed for EAPI 7. Intended to be used for wider testing of
+# the proposed functions and to allow ebuilds to switch to the new
+# model early, with minimal change needed for actual EAPI 7.
+#
+# https://bugs.gentoo.org/482170
+#
+# Note: version comparison function is not included currently.
+
+case ${EAPI:-0} in
+	0|1|2|3|4|5)
+		die "${ECLASS}: EAPI=${EAPI:-0} not supported";;
+	6)
+		;;
+	*)
+		die "${ECLASS}: EAPI=${EAPI} unknown";;
+esac
+
+_version_parse_range() {
+	[[ $1 =~ ^([0-9]+)(-([0-9]*))?$ ]] || die
+	start=${BASH_REMATCH[1]}
+	[[ ${BASH_REMATCH[2]} ]] && end=${BASH_REMATCH[3]} || end=${start}
+	[[ ${start} -gt 0 ]] && [[ -z ${end} || ${start} -le ${end} ]] || die
+}
+
+_version_split() {
+	local v=$1 LC_ALL=C
+
+	# get first component
+	[[ ${v} =~ ^([A-Za-z]*|[0-9]*) ]] || die
+	comp=("${BASH_REMATCH[1]}")
+	v=${v:${#BASH_REMATCH[0]}}
+
+	# get remaining separators and components
+	while [[ ${v} ]]; do
+		[[ ${v} =~ ^([^A-Za-z0-9]*)([A-Za-z]*|[0-9]*) ]] || die
+		comp+=("${BASH_REMATCH[@]:1:2}")
+		v=${v:${#BASH_REMATCH[0]}}
+	done
+}
+
+version_cut() {
+	local start end
+	local -a comp
+
+	_version_parse_range "$1"
+	_version_split "${2-${PV}}"
+
+	local IFS=
+	if [[ ${end} ]]; then
+		echo "${comp[*]:(start-1)*2:(end-start)*2+1}"
+	else
+		echo "${comp[*]:(start-1)*2}"
+	fi
+}
+
+version_rs() {
+	local start end i
+	local -a comp
+
+	(( $# & 1 )) && _version_split "${@: -1}" || _version_split "${PV}"
+
+	while [[ $# -ge 2 ]]; do
+		_version_parse_range "$1"
+		[[ ${end} && ${end} -le $((${#comp[@]}/2)) ]] || end=$((${#comp[@]}/2))
+		for (( i = start*2 - 1; i < end*2; i+=2 )); do
+			comp[i]=$2
+		done
+		shift 2
+	done
+
+	local IFS=
+	echo "${comp[*]}"
+}

--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -76,7 +76,7 @@ version_rs() {
 
 	while [[ $# -ge 2 ]]; do
 		_version_parse_range "$1"
-		[[ ${end} && ${end} -le $((${#comp[@]}/2)) ]] || end=$((${#comp[@]}/2))
+		[[ ${end} && ${end} -le $((${#comp[@]}/2)) ]] || end=$((${#comp[@]}/2 - 1))
 		for (( i = start*2; i <= end*2; i+=2 )); do
 			comp[i]=$2
 		done

--- a/eclass/tests/eapi7-ver.sh
+++ b/eclass/tests/eapi7-ver.sh
@@ -29,13 +29,14 @@ teq 2.3 version_cut 2- 1.2.3
 teq 1.2.3 version_cut 1- 1.2.3
 teq 3b version_cut 3-4 1.2.3b_alpha4
 teq alpha version_cut 5 1.2.3b_alpha4
-#teq 1.2 version_cut 1-2 .1.2.3
+teq 1.2 version_cut 1-2 .1.2.3
 #teq .1.2 version_cut 0-2 .1.2.3
 teq 2.3 version_cut 2-3 1.2.3.
 teq 2.3. version_cut 2- 1.2.3.
 
 teq 1.23-b_alpha4 version_rs 3 - 2 "" 1.2.3b_alpha4
 teq a1b_2-c-3-d4e5 version_rs 3-5 _ 4-6 - a1b2c3d4e5
+teq .1-2.3 version_rs 1 - .1.2.3
 
 txf version_cut foo 1.2.3
 #txf version_rs 5-3 _ a1b2c3d4e5

--- a/eclass/tests/eapi7-ver.sh
+++ b/eclass/tests/eapi7-ver.sh
@@ -30,13 +30,14 @@ teq 1.2.3 version_cut 1- 1.2.3
 teq 3b version_cut 3-4 1.2.3b_alpha4
 teq alpha version_cut 5 1.2.3b_alpha4
 teq 1.2 version_cut 1-2 .1.2.3
-#teq .1.2 version_cut 0-2 .1.2.3
+teq .1.2 version_cut 0-2 .1.2.3
 teq 2.3 version_cut 2-3 1.2.3.
 teq 2.3. version_cut 2- 1.2.3.
 
 teq 1.23-b_alpha4 version_rs 3 - 2 "" 1.2.3b_alpha4
 teq a1b_2-c-3-d4e5 version_rs 3-5 _ 4-6 - a1b2c3d4e5
 teq .1-2.3 version_rs 1 - .1.2.3
+teq -1.2.3 version_rs 0 - .1.2.3
 
 txf version_cut foo 1.2.3
 #txf version_rs 5-3 _ a1b2c3d4e5

--- a/eclass/tests/eapi7-ver.sh
+++ b/eclass/tests/eapi7-ver.sh
@@ -40,4 +40,5 @@ teq .1-2.3 version_rs 1 - .1.2.3
 teq -1.2.3 version_rs 0 - .1.2.3
 
 txf version_cut foo 1.2.3
-#txf version_rs 5-3 _ a1b2c3d4e5
+txf version_rs -3 _ a1b2c3d4e5
+txf version_rs 5-3 _ a1b2c3d4e5

--- a/eclass/tests/eapi7-ver.sh
+++ b/eclass/tests/eapi7-ver.sh
@@ -24,6 +24,7 @@ txf() {
 	tend ${?} "function did not die"
 }
 
+teq 1 version_cut 1 1.2.3
 teq 1.2 version_cut 1-2 1.2.3
 teq 2.3 version_cut 2- 1.2.3
 teq 1.2.3 version_cut 1- 1.2.3
@@ -35,7 +36,10 @@ teq 2.3 version_cut 2-3 1.2.3.
 teq 2.3. version_cut 2- 1.2.3.
 teq 2.3. version_cut 2-4 1.2.3.
 
+teq 1-2.3 version_rs 1 - 1.2.3
 teq 1.2-3 version_rs 2 - 1.2.3
+teq 1-2-3.4 version_rs 1-2 - 1.2.3.4
+teq 1.2-3-4 version_rs 2- - 1.2.3.4
 teq 1.2.3 version_rs 2 . 1.2-3
 teq 1.2.3.a version_rs 3 . 1.2.3a
 teq 1.2-alpha-4 version_rs 2-3 - 1.2_alpha4

--- a/eclass/tests/eapi7-ver.sh
+++ b/eclass/tests/eapi7-ver.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+source tests-common.sh
+
+inherit eapi7-ver
+
+teq() {
+	local expected=${1}; shift
+
+	tbegin "${*} -> ${expected}"
+	local got=$("${@}")
+	[[ ${got} == ${expected} ]]
+	tend ${?} "returned: ${got}"
+}
+
+txf() {
+	tbegin "XFAIL: ${*}"
+	local got=$("${@}" 2>&1)
+	[[ ${got} == die:* ]]
+	tend ${?} "function did not die"
+}
+
+teq 1.2 version_cut 1-2 1.2.3
+teq 2.3 version_cut 2- 1.2.3
+teq 1.2.3 version_cut 1- 1.2.3
+teq 3b version_cut 3-4 1.2.3b_alpha4
+teq alpha version_cut 5 1.2.3b_alpha4
+#teq 1.2 version_cut 1-2 .1.2.3
+#teq .1.2 version_cut 0-2 .1.2.3
+teq 2.3 version_cut 2-3 1.2.3.
+teq 2.3. version_cut 2- 1.2.3.
+
+teq 1.23-b_alpha4 version_rs 3 - 2 "" 1.2.3b_alpha4
+teq a1b_2-c-3-d4e5 version_rs 3-5 _ 4-6 - a1b2c3d4e5
+
+txf version_cut foo 1.2.3
+#txf version_rs 5-3 _ a1b2c3d4e5

--- a/eclass/tests/eapi7-ver.sh
+++ b/eclass/tests/eapi7-ver.sh
@@ -33,11 +33,17 @@ teq 1.2 version_cut 1-2 .1.2.3
 teq .1.2 version_cut 0-2 .1.2.3
 teq 2.3 version_cut 2-3 1.2.3.
 teq 2.3. version_cut 2- 1.2.3.
+teq 2.3. version_cut 2-4 1.2.3.
 
+teq 1.2-3 version_rs 2 - 1.2.3
+teq 1.2.3 version_rs 2 . 1.2-3
+teq 1.2.3.a version_rs 3 . 1.2.3a
+teq 1.2-alpha-4 version_rs 2-3 - 1.2_alpha4
 teq 1.23-b_alpha4 version_rs 3 - 2 "" 1.2.3b_alpha4
 teq a1b_2-c-3-d4e5 version_rs 3-5 _ 4-6 - a1b2c3d4e5
 teq .1-2.3 version_rs 1 - .1.2.3
 teq -1.2.3 version_rs 0 - .1.2.3
+teq 1.2.3. version_rs 3 . 1.2.3
 
 txf version_cut foo 1.2.3
 txf version_rs -3 _ a1b2c3d4e5

--- a/eclass/tests/eapi7-ver:benchmark.sh
+++ b/eclass/tests/eapi7-ver:benchmark.sh
@@ -11,6 +11,7 @@ inherit eapi7-ver
 cutting() {
 	local x
 	for x in {1..1000}; do
+		version_cut 1 1.2.3
 		version_cut 1-2 1.2.3
 		version_cut 2- 1.2.3
 		version_cut 1- 1.2.3
@@ -27,7 +28,10 @@ cutting() {
 replacing() {
 	local x
 	for x in {1..1000}; do
+		version_rs 1 - 1.2.3
 		version_rs 2 - 1.2.3
+		version_rs 1-2 - 1.2.3.4
+		version_rs 2- - 1.2.3.4
 		version_rs 2 . 1.2-3
 		version_rs 3 . 1.2.3a
 		version_rs 2-3 - 1.2_alpha4

--- a/eclass/tests/eapi7-ver:benchmark.sh
+++ b/eclass/tests/eapi7-ver:benchmark.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+source tests-common.sh
+
+inherit eapi7-ver
+
+cutting() {
+	local x
+	for x in {1..1000}; do
+		version_cut 1-2 1.2.3
+		version_cut 2- 1.2.3
+		version_cut 1- 1.2.3
+		version_cut 3-4 1.2.3b_alpha4
+		version_cut 5 1.2.3b_alpha4
+		version_cut 1-2 .1.2.3
+		version_cut 0-2 .1.2.3
+		version_cut 2-3 1.2.3.
+		version_cut 2- 1.2.3.
+		version_cut 2-4 1.2.3.
+	done >/dev/null
+}
+
+replacing() {
+	local x
+	for x in {1..1000}; do
+		version_rs 2 - 1.2.3
+		version_rs 2 . 1.2-3
+		version_rs 3 . 1.2.3a
+		version_rs 2-3 - 1.2_alpha4
+		version_rs 3 - 2 "" 1.2.3b_alpha4
+		version_rs 3-5 _ 4-6 - a1b2c3d4e5
+		version_rs 1 - .1.2.3
+		version_rs 0 - .1.2.3
+		version_rs 3 . 1.2.3
+	done >/dev/null
+}
+
+get_times() {
+	echo "${*}"
+	local real=()
+	local user=()
+
+	for x in {1..5}; do
+		while read tt tv; do
+			case ${tt} in
+				real) real+=( ${tv} );;
+				user) user+=( ${tv} );;
+			esac
+		done < <( ( time -p "${@}" ) 2>&1 )
+	done
+
+	[[ ${#real[@]} == 5 ]] || die "Did not get 5 real times"
+	[[ ${#user[@]} == 5 ]] || die "Did not get 5 user times"
+
+	local sum
+	for v in real user; do
+		vr="${v}[*]"
+		sum=$(dc -e "${!vr} + + + + 3 k 5 / p")
+
+		vr="${v}[@]"
+		printf '%s %4.2f %4.2f %4.2f %4.2f %4.2f %4.2f\n' \
+			"${v}" "${!vr}" "${sum}"
+	done
+}
+
+export LC_ALL=C
+
+get_times cutting
+get_times replacing


### PR DESCRIPTION
Here's a early implementation from @ulm, modified by me to be in eclass+tests form.

TODO:
* [x] get more tests,
* [x] get some benchmark,
  * [x] try a non-regexp implementation and see which one is faster,
* [x] document it,
* [ ] test it on some real packages.