### PR TITLE
media-video/obs-studio: Fix build, patch a runtime crash, and adjust dependencies.

### DIFF
--- a/media-video/obs-studio/files/obs-studio-20.0.1-fix-curl-crash.patch
+++ b/media-video/obs-studio/files/obs-studio-20.0.1-fix-curl-crash.patch
@@ -1,0 +1,46 @@
+From 379137d039e8db4a4f5f4dd8b56aaa21600fe962 Mon Sep 17 00:00:00 2001
+From: Thomas De Schampheleire <thomas.de_schampheleire@nokia.com>
+Date: Tue, 19 Sep 2017 15:33:55 +0200
+Subject: [PATCH] file-updater: fix crash due to network timeout
+
+If there is no network connection, OBS crashes after 5 minutes idling
+with following crash:
+
+*** longjmp causes uninitialized stack frame ***: obs terminated
+======= Backtrace: =========
+/lib64/libc.so.6(+0x6f1e3)[0x7f8f95f901e3]
+/lib64/libc.so.6(__fortify_fail+0x37)[0x7f8f96018ba7]
+/lib64/libc.so.6(+0xf7add)[0x7f8f96018add]
+/lib64/libc.so.6(__longjmp_chk+0x29)[0x7f8f96018a39]
+/usr/lib64/libcurl.so.4(+0xa5d5)[0x7f8f979b75d5]
+/lib64/libpthread.so.0(+0x10e30)[0x7f8f962cae30]
+/lib64/libc.so.6(__poll+0x2d)[0x7f8f95fff46d]
+/usr/lib64/libglib-2.0.so.0(+0x4a64c)[0x7f8f91b5564c]
+/usr/lib64/libglib-2.0.so.0(g_main_context_iteration+0x2c)[0x7f8f91b5575c]
+/usr/lib64/libQt5Core.so.5(_ZN20QEventDispatcherGlib13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE+0x5f)[0x7f8f9706c1ff]
+/usr/lib64/libQt5Core.so.5(_ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE+0xfa)[0x7f8f9701defa]
+/usr/lib64/libQt5Core.so.5(_ZN16QCoreApplication4execEv+0x9c)[0x7f8f970258fc]
+obs(main+0x5ac)[0x4773dc]
+/lib64/libc.so.6(__libc_start_main+0xf0)[0x7f8f95f41700]
+obs(_start+0x29)[0x478389]
+
+Internet search [1] revealed that this is a libcurl bug that can be worked
+around by asking curl not to install signal handlers.
+
+[1] https://stackoverflow.com/a/10755612
+---
+ deps/file-updater/file-updater/file-updater.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/deps/file-updater/file-updater/file-updater.c b/deps/file-updater/file-updater/file-updater.c
+index ec639aeee..b8d649e05 100644
+--- a/deps/file-updater/file-updater/file-updater.c
++++ b/deps/file-updater/file-updater/file-updater.c
+@@ -117,6 +117,7 @@ static bool do_http_request(struct update_info *info, const char *url,
+ 	curl_easy_setopt(info->curl, CURLOPT_WRITEFUNCTION, http_write);
+ 	curl_easy_setopt(info->curl, CURLOPT_WRITEDATA, info);
+ 	curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, true);
++	curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1);
+ 
+ 	if (!info->remote_url) {
+ 		// We only care about headers from the main package file

--- a/media-video/obs-studio/files/obs-studio-ImageMagick-header-path.patch
+++ b/media-video/obs-studio/files/obs-studio-ImageMagick-header-path.patch
@@ -1,0 +1,70 @@
+From affb84f98477bb490554f56bf82ebffcefa0ec42 Mon Sep 17 00:00:00 2001
+From: Jimi Huotari <chiitoo@gentoo.org>
+Date: Tue, 5 Sep 2017 23:30:24 +0300
+Subject: [PATCH 1/3] libobs: Fix ImageMagick header path
+
+Since ImageMagick 7, the header path has been changed.  This commit
+implements a check for the version being used, and includes the
+header as is appropriate.
+
+Special thanks to Hu.
+
+Mantis-Bug: https://obsproject.com/mantis/view.php?id=966
+
+Gentoo-Bug: https://bugs.gentoo.org/627520
+---
+ libobs/CMakeLists.txt             | 6 ++++++
+ libobs/graphics/graphics-magick.c | 6 ++++++
+ libobs/obsconfig.h.in             | 3 +++
+ 3 files changed, 15 insertions(+)
+
+diff --git a/libobs/CMakeLists.txt b/libobs/CMakeLists.txt
+index cd2b80e1..e91f366a 100644
+--- a/libobs/CMakeLists.txt
++++ b/libobs/CMakeLists.txt
+@@ -31,6 +31,12 @@ option(LIBOBS_PREFER_IMAGEMAGICK "Prefer ImageMagick over ffmpeg for image loadi
+ if(NOT FFMPEG_AVCODEC_FOUND OR (ImageMagick_MagickCore_FOUND AND LIBOBS_PREFER_IMAGEMAGICK))
+ 	message(STATUS "Using ImageMagick for image loading in libobs")
+ 
++	if(${ImageMagick_VERSION_STRING} LESS 7)
++		set(LIBOBS_IMAGEMAGICK_DIR_STYLE LIBOBS_IMAGEMAGICK_DIR_STYLE_6L)
++	elseif(${ImageMagick_VERSION_STRING} GREATER_EQUAL 7)
++		set(LIBOBS_IMAGEMAGICK_DIR_STYLE LIBOBS_IMAGEMAGICK_DIR_STYLE_7GE)
++	endif()
++
+ 	set(libobs_image_loading_SOURCES
+ 		graphics/graphics-magick.c)
+ 	set(libobs_image_loading_LIBRARIES
+diff --git a/libobs/graphics/graphics-magick.c b/libobs/graphics/graphics-magick.c
+index c106bfa6..6e4e1e96 100644
+--- a/libobs/graphics/graphics-magick.c
++++ b/libobs/graphics/graphics-magick.c
+@@ -1,8 +1,14 @@
+ #include "graphics.h"
++#include "obsconfig.h"
+ 
+ #define MAGICKCORE_QUANTUM_DEPTH 16
+ #define MAGICKCORE_HDRI_ENABLE   0
++
++#if LIBOBS_IMAGEMAGICK_DIR_STYLE == LIBOBS_IMAGEMAGICK_DIR_STYLE_6L
+ #include <magick/MagickCore.h>
++#elif LIBOBS_IMAGEMAGICK_DIR_STYLE == LIBOBS_IMAGEMAGICK_DIR_STYLE_7GE
++#include <MagickCore/MagickCore.h>
++#endif
+ 
+ void gs_init_image_deps()
+ {
+diff --git a/libobs/obsconfig.h.in b/libobs/obsconfig.h.in
+index f86962d5..cc1f4005 100644
+--- a/libobs/obsconfig.h.in
++++ b/libobs/obsconfig.h.in
+@@ -17,3 +17,6 @@
+ #define OBS_UNIX_STRUCTURE @OBS_UNIX_STRUCTURE@
+ #define BUILD_CAPTIONS @BUILD_CAPTIONS@
+ #define HAVE_DBUS @HAVE_DBUS@
++#define LIBOBS_IMAGEMAGICK_DIR_STYLE_6L 6
++#define LIBOBS_IMAGEMAGICK_DIR_STYLE_7GE 7
++#define LIBOBS_IMAGEMAGICK_DIR_STYLE @LIBOBS_IMAGEMAGICK_DIR_STYLE@
+-- 
+2.14.1
+

--- a/media-video/obs-studio/obs-studio-18.0.2.ebuild
+++ b/media-video/obs-studio/obs-studio-18.0.2.ebuild
@@ -21,7 +21,7 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="+alsa fdk imagemagick jack pulseaudio truetype v4l"
 
-DEPEND="
+COMMON_DEPEND="
 	>=dev-libs/jansson-2.5
 	dev-qt/qtcore:5
 	dev-qt/qtdeclarative:5
@@ -49,7 +49,18 @@ DEPEND="
 	)
 	v4l? ( media-libs/libv4l )
 "
-RDEPEND="${DEPEND}"
+DEPEND="${COMMON_DEPEND}
+	imagemagick? (
+		|| (
+			<media-gfx/imagemagick-7
+			(
+				>=media-gfx/imagemagick-7
+				>=dev-util/cmake-3.9
+			)
+		)
+	)
+"
+RDEPEND="${COMMON_DEPEND}"
 
 PATCHES="${FILESDIR}/${PN}-ImageMagick-header-path.patch"
 

--- a/media-video/obs-studio/obs-studio-18.0.2.ebuild
+++ b/media-video/obs-studio/obs-studio-18.0.2.ebuild
@@ -51,6 +51,8 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES="${FILESDIR}/${PN}-ImageMagick-header-path.patch"
+
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 
 src_configure() {

--- a/media-video/obs-studio/obs-studio-19.0.2.ebuild
+++ b/media-video/obs-studio/obs-studio-19.0.2.ebuild
@@ -21,7 +21,7 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="+alsa fdk imagemagick jack pulseaudio truetype v4l"
 
-DEPEND="
+COMMON_DEPEND="
 	>=dev-libs/jansson-2.5
 	dev-qt/qtcore:5
 	dev-qt/qtdeclarative:5
@@ -49,7 +49,18 @@ DEPEND="
 	)
 	v4l? ( media-libs/libv4l )
 "
-RDEPEND="${DEPEND}"
+DEPEND="${COMMON_DEPEND}
+	imagemagick? (
+		|| (
+			<media-gfx/imagemagick-7
+			(
+				>=media-gfx/imagemagick-7
+				>=dev-util/cmake-3.9
+			)
+		)
+	)
+"
+RDEPEND="${COMMON_DEPEND}"
 
 PATCHES="${FILESDIR}/${PN}-ImageMagick-header-path.patch"
 

--- a/media-video/obs-studio/obs-studio-19.0.2.ebuild
+++ b/media-video/obs-studio/obs-studio-19.0.2.ebuild
@@ -51,6 +51,8 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES="${FILESDIR}/${PN}-ImageMagick-header-path.patch"
+
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 
 src_configure() {

--- a/media-video/obs-studio/obs-studio-20.0.1-r1.ebuild
+++ b/media-video/obs-studio/obs-studio-20.0.1-r1.ebuild
@@ -1,0 +1,121 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils gnome2-utils
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/jp9000/obs-studio.git"
+	EGIT_SUBMODULES=()
+else
+	SRC_URI="https://github.com/jp9000/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+DESCRIPTION="Software for Recording and Streaming Live Video Content"
+HOMEPAGE="https://obsproject.com"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="+alsa fdk imagemagick jack pulseaudio truetype v4l"
+
+COMMON_DEPEND="
+	>=dev-libs/jansson-2.5
+	dev-qt/qtcore:5
+	dev-qt/qtdeclarative:5
+	dev-qt/qtgui:5
+	dev-qt/qtmultimedia:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtquickcontrols:5
+	dev-qt/qtsql:5
+	dev-qt/qttest:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+	media-video/ffmpeg:=[x264]
+	net-misc/curl
+	x11-libs/libXcomposite
+	x11-libs/libXinerama
+	x11-libs/libXrandr
+	alsa? ( media-libs/alsa-lib )
+	fdk? ( media-libs/fdk-aac:= )
+	imagemagick? ( media-gfx/imagemagick:= )
+	jack? ( virtual/jack )
+	pulseaudio? ( media-sound/pulseaudio )
+	truetype? (
+		media-libs/fontconfig
+		media-libs/freetype
+	)
+	v4l? ( media-libs/libv4l )
+"
+DEPEND="${COMMON_DEPEND}
+	imagemagick? (
+		|| (
+			<media-gfx/imagemagick-7
+			(
+				>=media-gfx/imagemagick-7
+				>=dev-util/cmake-3.9
+			)
+		)
+	)
+"
+RDEPEND="${COMMON_DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-20.0.1-fix-curl-crash.patch"
+	"${FILESDIR}/${PN}-ImageMagick-header-path.patch"
+)
+
+CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
+
+src_configure() {
+	local libdir=$(get_libdir)
+	local mycmakeargs=(
+		-DDISABLE_ALSA=$(usex !alsa)
+		-DDISABLE_FREETYPE=$(usex !truetype)
+		-DDISABLE_JACK=$(usex !jack)
+		-DDISABLE_LIBFDK=$(usex !fdk)
+		-DDISABLE_PULSEAUDIO=$(usex !pulseaudio)
+		-DDISABLE_V4L2=$(usex !v4l)
+		-DLIBOBS_PREFER_IMAGEMAGICK=$(usex imagemagick)
+		-DOBS_MULTIARCH_SUFFIX=${libdir#lib}
+		-DOBS_VERSION_OVERRIDE=${PV}
+		-DUNIX_STRUCTURE=1
+	)
+	cmake-utils_src_configure
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+
+	if ! use alsa && ! use pulseaudio; then
+		elog
+		elog "For the audio capture features to be available,"
+		elog "either the 'alsa' or the 'pulseaudio' USE-flag needs to"
+		elog "be enabled."
+		elog
+	fi
+
+	if ! has_version "sys-apps/dbus"; then
+		elog
+		elog "The 'sys-apps/dbus' package is not installed, but"
+		elog "could be used for disabling hibernating, screensaving,"
+		elog "and sleeping.  Where it is not installed,"
+		elog "'xdg-screensaver reset' is used instead"
+		elog "(if 'x11-misc/xdg-utils' is installed)."
+		elog
+	fi
+
+	if ! has_version "media-libs/speex"; then
+		elog
+		elog "For the speexdsp-based noise suppression filter"
+		elog "to be available, the 'media-libs/speex' package needs"
+		elog "to be installed."
+		elog
+	fi
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+}

--- a/media-video/obs-studio/obs-studio-20.0.1.ebuild
+++ b/media-video/obs-studio/obs-studio-20.0.1.ebuild
@@ -21,7 +21,7 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="+alsa fdk imagemagick jack pulseaudio truetype v4l"
 
-DEPEND="
+COMMON_DEPEND="
 	>=dev-libs/jansson-2.5
 	dev-qt/qtcore:5
 	dev-qt/qtdeclarative:5
@@ -49,7 +49,18 @@ DEPEND="
 	)
 	v4l? ( media-libs/libv4l )
 "
-RDEPEND="${DEPEND}"
+DEPEND="${COMMON_DEPEND}
+	imagemagick? (
+		|| (
+			<media-gfx/imagemagick-7
+			(
+				>=media-gfx/imagemagick-7
+				>=dev-util/cmake-3.9
+			)
+		)
+	)
+"
+RDEPEND="${COMMON_DEPEND}"
 
 PATCHES="${FILESDIR}/${PN}-ImageMagick-header-path.patch"
 

--- a/media-video/obs-studio/obs-studio-20.0.1.ebuild
+++ b/media-video/obs-studio/obs-studio-20.0.1.ebuild
@@ -51,6 +51,8 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES="${FILESDIR}/${PN}-ImageMagick-header-path.patch"
+
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 
 src_configure() {

--- a/media-video/obs-studio/obs-studio-9999.ebuild
+++ b/media-video/obs-studio/obs-studio-9999.ebuild
@@ -21,7 +21,7 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="+alsa fdk imagemagick jack pulseaudio truetype v4l"
 
-DEPEND="
+COMMON_DEPEND="
 	>=dev-libs/jansson-2.5
 	dev-qt/qtcore:5
 	dev-qt/qtdeclarative:5
@@ -49,7 +49,18 @@ DEPEND="
 	)
 	v4l? ( media-libs/libv4l )
 "
-RDEPEND="${DEPEND}"
+DEPEND="${COMMON_DEPEND}
+	imagemagick? (
+		|| (
+			<media-gfx/imagemagick-7
+			(
+				>=media-gfx/imagemagick-7
+				>=dev-util/cmake-3.9
+			)
+		)
+	)
+"
+RDEPEND="${COMMON_DEPEND}"
 
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 


### PR DESCRIPTION
Since ImageMagick 7, the headers have been under a different directory, and the build with ImageMagick support will fail when the old path is used.  This commit patches in detection for the version being used, while also choosing the path accordingly.

Gentoo-Bug: https://bugs.gentoo.org/627520

Upstream Pull Request: jp9000/obs-studio#1018

Add 'COMMON_DEPEND' to ease moving things around, and keep 'RDEPEND.suspect' happy.  Also protect against incompatible combinations of CMake (<3.9) and ImageMagick (>=7).

Special thanks to Hu and NP-Hardass!
