### PR TITLE
Mask USE=gles2 where it disables full OpenGL

### DIFF
--- a/kde-plasma/kscreenlocker/kscreenlocker-5.10.5.1.ebuild
+++ b/kde-plasma/kscreenlocker/kscreenlocker-5.10.5.1.ebuild
@@ -30,7 +30,7 @@ COMMON_DEPEND="
 	$(add_frameworks_dep solid)
 	$(add_qt_dep qtdbus)
 	$(add_qt_dep qtdeclarative 'widgets')
-	$(add_qt_dep qtgui)
+	$(add_qt_dep qtgui '-gles2')
 	$(add_qt_dep qtnetwork)
 	$(add_qt_dep qtwidgets)
 	$(add_qt_dep qtx11extras)

--- a/profiles/targets/desktop/plasma/package.use.mask
+++ b/profiles/targets/desktop/plasma/package.use.mask
@@ -1,0 +1,19 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# USE=gles2 in the following packages disables full OpenGL
+# Upstream does not test for that case and packages frequently
+# fail to build or run if set.
+dev-python/PyQt5 gles2
+dev-qt/qt3d gles2
+dev-qt/qtdatavis3d gles2
+dev-qt/qtdeclarative gles2
+dev-qt/qtgui gles2
+dev-qt/qtmultimedia gles2
+dev-qt/qtopengl gles2
+dev-qt/qtprintsupport gles2
+dev-qt/qtwidgets gles2
+kde-apps/kdenlive gles2
+kde-frameworks/plasma gles2
+kde-plasma/kinfocenter gles2
+kde-plasma/kwin gles2


### PR DESCRIPTION
@gentoo/kde 