### PR TITLE
x11-terms/xterm: HOMEPAGE and SRC_URI use https

### DIFF
--- a/x11-terms/xterm/xterm-327.ebuild
+++ b/x11-terms/xterm/xterm-327.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils flag-o-matic multilib
 
 DESCRIPTION="Terminal Emulator for X Windows"
-HOMEPAGE="http://invisible-island.net/xterm/"
-SRC_URI="ftp://invisible-island.net/${PN}/${P}.tgz"
+HOMEPAGE="https://invisible-island.net/xterm/"
+SRC_URI="ftp://ftp.invisible-island.net/${PN}/${P}.tgz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-terms/xterm/xterm-328.ebuild
+++ b/x11-terms/xterm/xterm-328.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils flag-o-matic multilib
 
 DESCRIPTION="Terminal Emulator for X Windows"
-HOMEPAGE="http://invisible-island.net/xterm/"
-SRC_URI="ftp://invisible-island.net/${PN}/${P}.tgz"
+HOMEPAGE="https://invisible-island.net/xterm/"
+SRC_URI="ftp://ftp.invisible-island.net/${PN}/${P}.tgz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-terms/xterm/xterm-329.ebuild
+++ b/x11-terms/xterm/xterm-329.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils flag-o-matic multilib
 
 DESCRIPTION="Terminal Emulator for X Windows"
-HOMEPAGE="http://invisible-island.net/xterm/"
-SRC_URI="ftp://invisible-island.net/${PN}/${P}.tgz"
+HOMEPAGE="https://invisible-island.net/xterm/"
+SRC_URI="ftp://ftp.invisible-island.net/${PN}/${P}.tgz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-terms/xterm/xterm-330.ebuild
+++ b/x11-terms/xterm/xterm-330.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils flag-o-matic multilib
 
 DESCRIPTION="Terminal Emulator for X Windows"
-HOMEPAGE="http://invisible-island.net/xterm/"
-SRC_URI="ftp://invisible-island.net/${PN}/${P}.tgz"
+HOMEPAGE="https://invisible-island.net/xterm/"
+SRC_URI="ftp://ftp.invisible-island.net/${PN}/${P}.tgz"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
Should also fix https://bugs.gentoo.org/627318

Package-Manager: Portage-2.3.6, Repoman-2.3.3