### PR TITLE
sys-boot/raspberrypi-firmware: Include device trees, #630612

### DIFF
--- a/sys-boot/raspberrypi-firmware/raspberrypi-firmware-9999.ebuild
+++ b/sys-boot/raspberrypi-firmware/raspberrypi-firmware-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -44,6 +44,8 @@ src_install() {
 	insinto /boot
 	cd boot
 	doins bootcode.bin COPYING.linux fixup*.dat LICENCE.broadcom start*elf
+	doins *.dtb
+	doins -r overlays
 	newins "${FILESDIR}"/${PN}-0_p20130711-config.txt config.txt
 	newins "${FILESDIR}"/${PN}-0_p20130711-cmdline.txt cmdline.txt
 	newenvd "${FILESDIR}"/${PN}-0_p20130711-envd 90${PN}


### PR DESCRIPTION
Include device trees and overlays. See
https://www.raspberrypi.org/documentation/configuration/device-tree.md
for details.

Package-Manager: Portage-2.3.6, Repoman-2.3.1