### PR TITLE
media-video/subliminal: restrict tests in 2.0.5

### DIFF
--- a/media-video/subliminal/subliminal-2.0.5-r1.ebuild
+++ b/media-video/subliminal/subliminal-2.0.5-r1.ebuild
@@ -51,6 +51,9 @@ DEPEND="${RDEPEND}
 	)
 "
 
+# Tests don't work in 2.0.5. Recheck in later versions. See Gentoo bug 630114.
+RESTRICT=test
+
 PATCHES=( "${FILESDIR}/${P}-add-missing-comma.patch" )
 
 S="${WORKDIR}/${PF}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/630114
Package-Manager: Portage-2.3.8, Repoman-2.3.3