### PR TITLE
sys-apps/openrc: Stop adding tmpfiles.* to boot runlevel

### DIFF
--- a/sys-apps/openrc/openrc-0.23.2.ebuild
+++ b/sys-apps/openrc/openrc-0.23.2.ebuild
@@ -215,13 +215,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.24.2.ebuild
+++ b/sys-apps/openrc/openrc-0.24.2.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.25.ebuild
+++ b/sys-apps/openrc/openrc-0.25.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.26.2.ebuild
+++ b/sys-apps/openrc/openrc-0.26.2.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.26.3.ebuild
+++ b/sys-apps/openrc/openrc-0.26.3.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.27.2.ebuild
+++ b/sys-apps/openrc/openrc-0.27.2.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.28.ebuild
+++ b/sys-apps/openrc/openrc-0.28.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.29.ebuild
+++ b/sys-apps/openrc/openrc-0.29.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.30.ebuild
+++ b/sys-apps/openrc/openrc-0.30.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.31.ebuild
+++ b/sys-apps/openrc/openrc-0.31.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-9999.ebuild
+++ b/sys-apps/openrc/openrc-9999.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier


### PR DESCRIPTION
tmpfiles.setup and tmpfiles.dev are not part of OpenRC since version
0.23, resulting in symlinks pointing to non existing files.

See: https://gitweb.gentoo.org/proj/openrc.git/commit/?id=e0ac661419042cb39c1ccf93df2981504d1e6339

Package-Manager: Portage-2.3.6, Repoman-2.3.1