### PR TITLE
sci-misc/boinc: update icon cache (bug #636886)

### DIFF
--- a/sci-misc/boinc/boinc-7.8.1.ebuild
+++ b/sci-misc/boinc/boinc-7.8.1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 WX_GTK_VER=3.0
 
-inherit autotools eutils linux-info systemd user versionator wxwidgets
+inherit autotools eutils gnome2-utils linux-info systemd user versionator wxwidgets
 
 MY_PV=$(get_version_component_range 1-2)
 
@@ -67,7 +67,7 @@ pkg_setup() {
 			ewarn "Can't check the linux kernel configuration."
 			ewarn "You might be missing vsyscall support."
 		elif kernel_is -ge 4 4 \
-		    && linux_chkconfig_present LEGACY_VSYSCALL_NONE; then
+			&& linux_chkconfig_present LEGACY_VSYSCALL_NONE; then
 			ewarn "You do not have vsyscall emulation enabled."
 			ewarn "This will prevent some boinc projects from running."
 			ewarn "Please enable vsyscall emulation:"
@@ -134,6 +134,8 @@ src_install() {
 }
 
 pkg_preinst() {
+	gnome2_icon_savelist
+
 	enewgroup ${PN}
 	# note this works only for first install so we have to
 	# elog user about the need of being in video group
@@ -145,6 +147,8 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
+	gnome2_icon_cache_update
+
 	elog
 	elog "You are using the source compiled version of boinc."
 	use X && elog "The graphical manager can be found at /usr/bin/boincmgr"
@@ -178,4 +182,8 @@ pkg_postinst() {
 		elog "the correct OpenCL implementation for your graphic card."
 	fi
 	elog
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
 }


### PR DESCRIPTION
/usr/share/icons/hicolor/icon-theme.cache needs to be updated
every time users install or remove BOINC