### PR TITLE
media-fonts/hack: update github remote-id attributes

### DIFF
--- a/media-fonts/hack/hack-2.010.ebuild
+++ b/media-fonts/hack/hack-2.010.ebuild
@@ -6,8 +6,8 @@ EAPI="5"
 inherit font versionator
 
 DESCRIPTION="A typeface designed for source code"
-HOMEPAGE="https://github.com/chrissimpkins/Hack"
-SRC_URI="https://github.com/chrissimpkins/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-otf.zip"
+HOMEPAGE="https://github.com/source-foundry/Hack"
+SRC_URI="https://github.com/source-foundry/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-otf.zip"
 
 LICENSE="OFL-1.1"
 SLOT="0"

--- a/media-fonts/hack/hack-2.018.ebuild
+++ b/media-fonts/hack/hack-2.018.ebuild
@@ -6,8 +6,8 @@ EAPI="5"
 inherit font versionator
 
 DESCRIPTION="A typeface designed for source code"
-HOMEPAGE="https://github.com/chrissimpkins/Hack"
-SRC_URI="https://github.com/chrissimpkins/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-otf.zip"
+HOMEPAGE="https://github.com/source-foundry/Hack"
+SRC_URI="https://github.com/source-foundry/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-otf.zip"
 
 LICENSE="OFL-1.1"
 SLOT="0"

--- a/media-fonts/hack/hack-2.019.ebuild
+++ b/media-fonts/hack/hack-2.019.ebuild
@@ -6,8 +6,8 @@ EAPI="5"
 inherit font versionator
 
 DESCRIPTION="A typeface designed for source code"
-HOMEPAGE="https://github.com/chrissimpkins/Hack"
-SRC_URI="https://github.com/chrissimpkins/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-otf.tar.gz"
+HOMEPAGE="https://github.com/source-foundry/Hack"
+SRC_URI="https://github.com/source-foundry/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-otf.tar.gz"
 
 LICENSE="OFL-1.1"
 SLOT="0"

--- a/media-fonts/hack/hack-2.020-r1.ebuild
+++ b/media-fonts/hack/hack-2.020-r1.ebuild
@@ -6,8 +6,8 @@ EAPI="5"
 inherit font versionator
 
 DESCRIPTION="A typeface designed for source code"
-HOMEPAGE="https://github.com/chrissimpkins/Hack"
-SRC_URI="https://github.com/chrissimpkins/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-ttf.tar.xz"
+HOMEPAGE="https://github.com/source-foundry/Hack"
+SRC_URI="https://github.com/source-foundry/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-ttf.tar.xz"
 
 LICENSE="OFL-1.1"
 SLOT="0"

--- a/media-fonts/hack/hack-2.020.ebuild
+++ b/media-fonts/hack/hack-2.020.ebuild
@@ -6,8 +6,8 @@ EAPI="5"
 inherit font versionator
 
 DESCRIPTION="A typeface designed for source code"
-HOMEPAGE="https://github.com/chrissimpkins/Hack"
-SRC_URI="https://github.com/chrissimpkins/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-otf.tar.xz"
+HOMEPAGE="https://github.com/source-foundry/Hack"
+SRC_URI="https://github.com/source-foundry/Hack/releases/download/v${PV}/Hack-v$(replace_version_separator 1 '_' )-otf.tar.xz"
 
 LICENSE="OFL-1.1"
 SLOT="0"

--- a/media-fonts/hack/metadata.xml
+++ b/media-fonts/hack/metadata.xml
@@ -6,6 +6,6 @@
 		<name>Fonts</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">chrissimpkins/Hack</remote-id>
+		<remote-id type="github">source-foundry/Hack</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
This project has moved its URL's around, update here to reflect the
project and avoid a possible breaking URL in the future.

Package-Manager: Portage-2.3.6, Repoman-2.3.1