### PR TITLE
{lxde-base, x11-themes}/metadata.xml: fix identation and remove trailing whitespace

### DIFF
--- a/lxde-base/metadata.xml
+++ b/lxde-base/metadata.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE catmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <catmetadata>
-  <longdescription lang="en">
-    The lxde-base category contains core packages for LXDE,
-    the Lightweight X11 Desktop Environment.
-  </longdescription>
-  <longdescription lang="es">
-    La categoría lxde-base contiene paquetes vitales para LXDE, el
-	entorno de escritorio ligero X11.
-  </longdescription>
+	<longdescription lang="en">
+		The lxde-base category contains core packages for LXDE,
+		the Lightweight X11 Desktop Environment.
+	</longdescription>
+	<longdescription lang="es">
+		La categoría lxde-base contiene paquetes vitales para LXDE, el
+		entorno de escritorio ligero X11.
+	</longdescription>
 </catmetadata>

--- a/x11-themes/metadata.xml
+++ b/x11-themes/metadata.xml
@@ -6,7 +6,7 @@
 		X11 applications.
 	</longdescription>
 	<longdescription lang="de">
-		Die Kategorie x11-themes enthält Themes und Styles für verschiedene 
+		Die Kategorie x11-themes enthält Themes und Styles für verschiedene
 		X11-Applikationen.
 	</longdescription>
 	<longdescription lang="es">
@@ -19,7 +19,7 @@
 	</longdescription>
 	<longdescription lang="nl">
 		De x11-themes categorie bevat thema's en stijlen voor verschillende
-		X11-applicaties. 
+		X11-applicaties.
 	</longdescription>
 	<longdescription lang="vi">
 		Nhóm x11-themes chứa các sắc thái (theme) khác nhau cho các ứng dụng X11.
@@ -32,7 +32,6 @@
 		para aplicações de X11.
 	</longdescription>
 	<longdescription lang="pl">
-        Kategoria x11-themes zawiera tematy graficzne i style dla aplikacji X11.
-    </longdescription>
+		Kategoria x11-themes zawiera tematy graficzne i style dla aplikacji X11.
+	</longdescription>
 </catmetadata>
-


### PR DESCRIPTION
Hi,

This PR fixes the metadata.xml files for the categories: lxde-base and x11-themes

Please review.