### PR TITLE
net-nntp/nzbget: bump to 20.0_pre2108, improve init script

### DIFF
--- a/net-nntp/nzbget/files/nzbget.initd
+++ b/net-nntp/nzbget/files/nzbget.initd
@@ -1,28 +1,28 @@
 #!/sbin/openrc-run
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 extra_started_commands="reload"
 
-start() {
-	ebegin "Starting ${RC_SVCNAME}"
-	checkpath -d -m 0755 -o "${NZBGET_USER}":"${NZBGET_GROUP}" /run/nzbget
-	start-stop-daemon --quiet --start --user "${NZBGET_USER}" \
-		--group "${NZBGET_GROUP}" --exec /usr/bin/nzbget -- \
-		--configfile "${NZBGET_CONFIGFILE}" --daemon \
-		${NZBGET_OPTS}
-	eend $?
+description="A command-line based binary newsgrabber supporting .nzb files"
+pidfile=/run/nzbget/nzbget.pid
+command=/usr/bin/nzbget
+command_args="--configfile \"${NZBGET_CONFIGFILE}\" \
+  --daemon --option LockFile=${pidfile} \
+  ${NZBGET_OPTS}"
+start_stop_daemon_args="--user \"${NZBGET_USER}\" \
+  --group \"${NZBGET_GROUP}\""
+
+depend() {
+  need localmount net
 }
 
-stop() {
-	ebegin "Stopping ${RC_SVCNAME}"
-	start-stop-daemon --stop --exec /usr/bin/nzbget -- \
-		--configfile "${NZBGET_CONFIGFILE}" --daemon \
-		${NZBGET_OPTS}
+start_pre() {
+  checkpath -d -m 0755 -o "${NZBGET_USER}":"${NZBGET_GROUP}" /run/nzbget
 }
 
 reload() {
-	ebegin "Reloading ${RC_SVCNAME}"
-	/usr/bin/nzbget --configfile "${NZBGET_CONFIGFILE}" --reload >/dev/null
-	eend $?
+  ebegin "Reloading ${RC_SVCNAME}"
+  ${command} --configfile "${NZBGET_CONFIGFILE}" --reload >/dev/null
+  eend $?
 }

--- a/net-nntp/nzbget/nzbget-20.0_pre2108-r1.ebuild
+++ b/net-nntp/nzbget/nzbget-20.0_pre2108-r1.ebuild
@@ -58,7 +58,6 @@ src_prepare() {
 
 	sed \
 		-e 's:^MainDir=.*:MainDir=/var/lib/nzbget:' \
-		-e 's:^LockFile=.*:LockFile=/run/nzbget/nzbget.pid:' \
 		-e 's:^LogFile=.*:LogFile=/var/log/nzbget/nzbget.log:' \
 		-e 's:^WebDir=.*:WebDir=/usr/share/nzbget/webui:' \
 		-e 's:^ConfigTemplate=.*:ConfigTemplate=/usr/share/nzbget/nzbget.conf:' \


### PR DESCRIPTION
I didn't change anything to the ebuild. However, I noticed that the init script's stop command didn't work any more so I rewrote it to use nzbget's PID file.
@swegener can you test it and let me know if it works correctly for you?