### PR TITLE
dev-python/libasyncns-python: fix build with glibc-2.25

### DIFF
--- a/dev-python/libasyncns-python/files/libasyncns-python-0.7.1-glibc-2.25.patch
+++ b/dev-python/libasyncns-python/files/libasyncns-python-0.7.1-glibc-2.25.patch
@@ -1,0 +1,14 @@
+https://sourceware.org/git/?p=glibc.git;a=patch;h=4f157746e0c713965d9143b52fef606312087c48
+
+diff --git a/libasyncns-python-0.7.1/libasyncns.c b/libasyncns-python-0.7.1/libasyncns.c
+index 99a73de..5e3da0b 100644
+--- a/libasyncns-python-0.7.1/libasyncns.c
++++ b/libasyncns-python-0.7.1/libasyncns.c
+@@ -134,7 +134,6 @@ PyMODINIT_FUNC initlibasyncns(void)
+ 	ADDNSCONST(ns_t_mailb);
+ 	ADDNSCONST(ns_t_maila);
+ 	ADDNSCONST(ns_t_any);
+-	ADDNSCONST(ns_t_zxfr);
+ 	ADDNSCONST(ns_t_max);
+ 	
+ 	ADDNSCONST(ns_c_invalid);

--- a/dev-python/libasyncns-python/libasyncns-python-0.7.1-r1.ebuild
+++ b/dev-python/libasyncns-python/libasyncns-python-0.7.1-r1.ebuild
@@ -18,6 +18,8 @@ IUSE=""
 DEPEND=">=net-libs/libasyncns-0.4"
 RDEPEND="${DEPEND}"
 
+PATCHES=( "${FILESDIR}/${PN}-0.7.1-glibc-2.25.patch" )
+
 python_compile() {
 	if [[ ${EPYTHON} != python3* ]]; then
 		local -x CFLAGS="${CFLAGS} -fno-strict-aliasing"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/609388