### PR TITLE
dev-db/percona-xtrabackup: require <dev-libs/boost-1.65.0 (Bug #630946)

### DIFF
--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.7.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.7.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 DEPEND="
 	app-arch/lz4:0=
 	app-editors/vim-core
-	>=dev-libs/boost-1.59.0:=
+	<dev-libs/boost-1.65.0:=
 	dev-libs/libaio
 	<dev-libs/libedit-20170329.3.1
 	dev-libs/libev

--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.8.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.8.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 DEPEND="
 	app-arch/lz4:0=
 	app-editors/vim-core
-	>=dev-libs/boost-1.59.0:=
+	<dev-libs/boost-1.65.0:=
 	dev-libs/libaio
 	<dev-libs/libedit-20170329.3.1
 	dev-libs/libev


### PR DESCRIPTION
https://bugs.gentoo.org/630946

Package-Manager: Portage-2.3.8, Repoman-2.3.2