### PR TITLE
{sys-devel/gcc,dev-lang/gnat-gpl}: add a USE for building GCC with PGO

### DIFF
--- a/dev-lang/gnat-gpl/metadata.xml
+++ b/dev-lang/gnat-gpl/metadata.xml
@@ -26,6 +26,7 @@
 		<flag name="objc++">Build support for the Objective C++ language</flag>
 		<flag name="objc-gc">Build support for the Objective C code language
 			Garbage Collector</flag>
+		<flag name="pgo">Build GCC using Profile Guided Optimization (PGO)</flag>
 		<flag name="regression-test">Run the testsuite and install the results
 			(requires FEATURES=test)</flag>
 		<flag name="sanitize">Build support for various sanitizer functions (ASAN/TSAN/etc...)</flag>

--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -139,6 +139,7 @@ if [[ ${PN} != "kgcc64" && ${PN} != gcc-* ]] ; then
 	[[ -n ${D_VER}   ]] && IUSE+=" d"
 	[[ -n ${SPECS_VER} ]] && IUSE+=" nossp"
 	tc_version_is_at_least 3 && IUSE+=" doc gcj awt hardened multilib objc"
+	tc_version_is_at_least 3.3 && IUSE+=" pgo"
 	tc_version_is_at_least 4.0 && IUSE+=" objc-gc"
 	tc_version_is_between 4.0 4.9 && IUSE+=" mudflap"
 	tc_version_is_at_least 4.1 && IUSE+=" libssp objc++"
@@ -1569,7 +1570,11 @@ gcc_do_make() {
 		# resulting binaries natively ^^;
 		GCC_MAKE_TARGET=${GCC_MAKE_TARGET-all}
 	else
-		GCC_MAKE_TARGET=${GCC_MAKE_TARGET-bootstrap-lean}
+		if tc_version_is_at_least 3.3 && use pgo; then
+			GCC_MAKE_TARGET=${GCC_MAKE_TARGET-profiledbootstrap}
+		else
+			GCC_MAKE_TARGET=${GCC_MAKE_TARGET-bootstrap-lean}
+		fi
 	fi
 
 	# Older versions of GCC could not do profiledbootstrap in parallel due to

--- a/sys-devel/gcc/metadata.xml
+++ b/sys-devel/gcc/metadata.xml
@@ -27,6 +27,7 @@
     <flag name="objc++">Build support for the Objective C++ language</flag>
     <flag name="objc-gc">Build support for the Objective C code language Garbage
       Collector</flag>
+    <flag name="pgo">Build GCC using Profile Guided Optimization (PGO)</flag> 
     <flag name="regression-test">Run the testsuite and install the results (requires FEATURES=test)</flag>
     <flag name="sanitize">Build support for various sanitizer functions (ASAN/TSAN/etc...)</flag>
     <flag name="ssp">Build packages with stack smashing protector on by default</flag>


### PR DESCRIPTION
GCC as of version 3.3 supports building itself with PGO enabled.  Since the infrastructure was already present in `toolchain.eclass`, I simply modified it to expose the functionality via the `pgo` USE flag.  A check is present to ensure that GCC is new enough to enable this functionality, and it honours the previous check that cross compilation is not being performed.

Ping @gentoo/toolchain

Package-Manager: Portage-2.3.10, Repoman-2.3.3