### PR TITLE
dev-embedded/stlink: multlib check fix, bug #630932

### DIFF
--- a/dev-embedded/stlink/stlink-1.4.0.ebuild
+++ b/dev-embedded/stlink/stlink-1.4.0.ebuild
@@ -29,6 +29,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DSTLINK_UDEV_RULES_DIR="$(get_udevdir)"/rules.d
 		-DSTLINK_MODPROBED_DIR="${EPREFIX}/etc/modprobe.d"
+		-DCMAKE_LIBRARY_PATH=/usr/$(get_libdir)
 	)
 
 	cmake-utils_src_configure

--- a/dev-embedded/stlink/stlink-9999.ebuild
+++ b/dev-embedded/stlink/stlink-9999.ebuild
@@ -29,6 +29,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DSTLINK_UDEV_RULES_DIR="$(get_udevdir)"/rules.d
 		-DSTLINK_MODPROBED_DIR="${EPREFIX}/etc/modprobe.d"
+		-DCMAKE_LIBRARY_PATH=/usr/$(get_libdir)
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
Install stlink libraries in the correct location, fixes the package, which would fail to install because of failing multilib_strict_check.