### PR TITLE
sys-devel/clang: Harden build

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -122,6 +122,7 @@ media-gfx/nvidia-texture-tools cuda
 # Matthias Maier <tamiko@gentoo.org> (11 May 2017)
 # Globally mask pie use flag. Selectively unmask on specific profiles.
 sys-devel/gcc pie
+sys-devel/clang pie
 
 # Mike Gilbert <floppym@gentoo.org> (28 Apr 2017)
 # Needs sandbox-2.11 (masked)

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -29,6 +29,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Matthias Dahl <matthias.dahl@binary-island.eu> (21 Sep 2017)
+# Introduces by default enabled Stack Protector (strong) and FORTIFY_SOURCE
+# as well as support for default enabled PIE by USE flag.
+# Needs testing before it can be unmask.
+=sys-devel/clang-5.0.0-r1
+
 # Bernard Cafarelli <voyageur@gentoo.org> (20 Sep 2017)
 # Requires qt 5.8, not yet in tree. Bug #631570
 >=media-video/orion-1.6.0

--- a/profiles/releases/17.0/package.use.force
+++ b/profiles/releases/17.0/package.use.force
@@ -4,3 +4,4 @@
 # Andreas K. Hüttel <dilfridge@gentoo.org> (27 May 2017)
 # Force default-PIE build on 17.0 profiles.
 sys-devel/gcc pie
+sys-devel/clang pie

--- a/profiles/releases/17.0/package.use.mask
+++ b/profiles/releases/17.0/package.use.mask
@@ -4,6 +4,7 @@
 # Andreas K. Hüttel <dilfridge@gentoo.org> (27 May 2017)
 # Unmask default-PIE on 17.0 profiles.
 sys-devel/gcc -pie
+sys-devel/clang -pie
 
 # Andreas K. Hüttel <dilfridge@gentoo.org> (7 June 2017)
 # Qt-4 will never work with >=icu-59, see bug 618638 and bug 618640

--- a/sys-devel/clang/clang-5.0.0-r1.ebuild
+++ b/sys-devel/clang/clang-5.0.0-r1.ebuild
@@ -1,0 +1,303 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+: ${CMAKE_MAKEFILE_GENERATOR:=ninja}
+# (needed due to CMAKE_BUILD_TYPE != Gentoo)
+CMAKE_MIN_VERSION=3.7.0-r1
+PYTHON_COMPAT=( python2_7 )
+
+inherit cmake-utils flag-o-matic llvm multilib-minimal \
+	python-single-r1 toolchain-funcs pax-utils versionator
+
+DESCRIPTION="C language family frontend for LLVM"
+HOMEPAGE="https://llvm.org/"
+SRC_URI="https://releases.llvm.org/${PV/_//}/cfe-${PV/_/}.src.tar.xz
+	https://releases.llvm.org/${PV/_//}/clang-tools-extra-${PV/_/}.src.tar.xz
+	test? ( https://releases.llvm.org/${PV/_//}/llvm-${PV/_/}.src.tar.xz )
+	!doc? ( https://dev.gentoo.org/~mgorny/dist/llvm/llvm-manpages-${PV}.tar.bz2 )"
+
+# Keep in sync with sys-devel/llvm
+ALL_LLVM_TARGETS=( AArch64 AMDGPU ARM BPF Hexagon Lanai Mips MSP430
+	NVPTX PowerPC Sparc SystemZ X86 XCore )
+ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
+LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/?}
+
+LICENSE="UoI-NCSA"
+SLOT="$(get_major_version)"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="debug default-compiler-rt default-libcxx +doc pie +static-analyzer
+	test xml z3 kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
+
+RDEPEND="
+	~sys-devel/llvm-${PV}:${SLOT}=[debug=,${LLVM_TARGET_USEDEPS// /,},${MULTILIB_USEDEP}]
+	static-analyzer? (
+		dev-lang/perl:*
+		z3? ( sci-mathematics/z3:0= )
+	)
+	xml? ( dev-libs/libxml2:2=[${MULTILIB_USEDEP}] )
+	${PYTHON_DEPS}"
+# configparser-3.2 breaks the build (3.3 or none at all are fine)
+DEPEND="${RDEPEND}
+	doc? ( dev-python/sphinx )
+	test? ( ~dev-python/lit-${PV}[${PYTHON_USEDEP}] )
+	xml? ( virtual/pkgconfig )
+	!!<dev-python/configparser-3.3.0.2
+	${PYTHON_DEPS}"
+RDEPEND="${RDEPEND}
+	!<sys-devel/llvm-4.0.0_rc:0
+	!sys-devel/clang:0"
+PDEPEND="
+	~sys-devel/clang-runtime-${PV}
+	default-compiler-rt? ( =sys-libs/compiler-rt-${PV%_*}* )
+	default-libcxx? ( sys-libs/libcxx )"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}
+	|| ( ${ALL_LLVM_TARGETS[*]} )"
+
+# We need extra level of indirection for CLANG_RESOURCE_DIR
+S=${WORKDIR}/x/y/cfe-${PV/_/}.src
+
+# least intrusive of all
+CMAKE_BUILD_TYPE=RelWithDebInfo
+
+# Multilib notes:
+# 1. ABI_* flags control ABIs libclang* is built for only.
+# 2. clang is always capable of compiling code for all ABIs for enabled
+#    target. However, you will need appropriate crt* files (installed
+#    e.g. by sys-devel/gcc and sys-libs/glibc).
+# 3. ${CHOST}-clang wrappers are always installed for all ABIs included
+#    in the current profile (i.e. alike supported by sys-devel/gcc).
+#
+# Therefore: use sys-devel/clang[${MULTILIB_USEDEP}] only if you need
+# multilib clang* libraries (not runtime, not wrappers).
+
+pkg_setup() {
+	LLVM_MAX_SLOT=${SLOT} llvm_pkg_setup
+	python-single-r1_pkg_setup
+}
+
+src_unpack() {
+	# create extra parent dir for CLANG_RESOURCE_DIR
+	mkdir -p x/y || die
+	cd x/y || die
+
+	default
+
+	mv clang-tools-extra-*.src "${S}"/tools/extra || die
+	if use test; then
+		mv llvm-*.src "${WORKDIR}"/llvm || die
+	fi
+}
+
+src_prepare() {
+	# fix finding compiler-rt libs
+	eapply "${FILESDIR}"/5.0.0/0001-Driver-Use-arch-type-to-find-compiler-rt-libraries-o.patch
+
+	cd tools/extra || die
+	# fix stand-alone test build for extra tools
+	eapply "${FILESDIR}"/5.0.0/extra/0002-test-Fix-clang-library-dir-in-LD_LIBRARY_PATH-For-st.patch
+	cd - >/dev/null || die
+
+	# enable "strong"-level Stack Protector by default
+	eapply "${FILESDIR}"/5.0.0/0003-Enable-Stack-Protector-by-default.patch
+
+	# enable PIE by default
+	use pie && eapply "${FILESDIR}"/5.0.0/0004-Enable-PIE-by-default.patch
+
+	# set _FORTIFY_SOURCE=2 macro by default
+	eapply "${FILESDIR}"/5.0.0/0005-Enable-FORTIFY_SOURCE-macro-by-default.patch
+
+	# User patches
+	eapply_user
+}
+
+multilib_src_configure() {
+	local llvm_version=$(llvm-config --version) || die
+	local clang_version=$(get_version_component_range 1-3 "${llvm_version}")
+
+	local mycmakeargs=(
+		# ensure that the correct llvm-config is used
+		-DLLVM_CONFIG="$(type -P "${CHOST}-llvm-config")"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${SLOT}"
+		# relative to bindir
+		-DCLANG_RESOURCE_DIR="../../../../lib/clang/${clang_version}"
+
+		-DBUILD_SHARED_LIBS=ON
+		-DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS// /;}"
+		-DLLVM_BUILD_TESTS=$(usex test)
+
+		# these are not propagated reliably, so redefine them
+		-DLLVM_ENABLE_EH=ON
+		-DLLVM_ENABLE_RTTI=ON
+
+		-DCMAKE_DISABLE_FIND_PACKAGE_LibXml2=$(usex !xml)
+		# libgomp support fails to find headers without explicit -I
+		# furthermore, it provides only syntax checking
+		-DCLANG_DEFAULT_OPENMP_RUNTIME=libomp
+
+		# override default stdlib and rtlib
+		-DCLANG_DEFAULT_CXX_STDLIB=$(usex default-libcxx libc++ "")
+		-DCLANG_DEFAULT_RTLIB=$(usex default-compiler-rt compiler-rt "")
+
+		-DCLANG_ENABLE_ARCMT=$(usex static-analyzer)
+		-DCLANG_ENABLE_STATIC_ANALYZER=$(usex static-analyzer)
+		# z3 is not multilib-friendly
+		-DCLANG_ANALYZER_BUILD_Z3=$(multilib_native_usex z3)
+	)
+	use test && mycmakeargs+=(
+		-DLLVM_MAIN_SRC_DIR="${WORKDIR}/llvm"
+		-DLIT_COMMAND="${EPREFIX}/usr/bin/lit"
+	)
+
+	if multilib_is_native_abi; then
+		mycmakeargs+=(
+			# normally copied from LLVM_INCLUDE_DOCS but the latter
+			# is lacking value in stand-alone builds
+			-DCLANG_INCLUDE_DOCS=$(usex doc)
+			-DCLANG_TOOLS_EXTRA_INCLUDE_DOCS=$(usex doc)
+		)
+		use doc && mycmakeargs+=(
+			-DLLVM_BUILD_DOCS=ON
+			-DLLVM_ENABLE_SPHINX=ON
+			-DCLANG_INSTALL_SPHINX_HTML_DIR="${EPREFIX}/usr/share/doc/${PF}/html"
+			-DCLANG-TOOLS_INSTALL_SPHINX_HTML_DIR="${EPREFIX}/usr/share/doc/${PF}/tools-extra"
+			-DSPHINX_WARNINGS_AS_ERRORS=OFF
+		)
+		use z3 && mycmakeargs+=(
+			-DZ3_INCLUDE_DIR="${EPREFIX}/usr/include/z3"
+		)
+	else
+		mycmakeargs+=(
+			-DLLVM_TOOL_CLANG_TOOLS_EXTRA_BUILD=OFF
+		)
+	fi
+
+	if tc-is-cross-compiler; then
+		[[ -x "/usr/bin/clang-tblgen" ]] \
+			|| die "/usr/bin/clang-tblgen not found or usable"
+		mycmakeargs+=(
+			-DCMAKE_CROSSCOMPILING=ON
+			-DCLANG_TABLEGEN=/usr/bin/clang-tblgen
+		)
+	fi
+
+	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
+	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
+	cmake-utils_src_configure
+}
+
+multilib_src_compile() {
+	cmake-utils_src_compile
+
+	# provide a symlink for tests
+	if [[ ! -L ${WORKDIR}/lib/clang ]]; then
+		mkdir -p "${WORKDIR}"/lib || die
+		ln -s "${BUILD_DIR}/$(get_libdir)/clang" "${WORKDIR}"/lib/clang || die
+	fi
+}
+
+multilib_src_test() {
+	# respect TMPDIR!
+	local -x LIT_PRESERVES_TMP=1
+	cmake-utils_src_make check-clang
+	# clang-tidy requires [static-analyzer] and tests are not split
+	# correctly, so they are all disabled when static-analyzer is off
+	if multilib_is_native_abi && use static-analyzer; then
+		cmake-utils_src_make check-clang-tools
+	fi
+}
+
+src_install() {
+	MULTILIB_WRAPPED_HEADERS=(
+		/usr/include/clang/Config/config.h
+	)
+
+	multilib-minimal_src_install
+
+	# Move runtime headers to /usr/lib/clang, where they belong
+	mv "${ED%/}"/usr/include/clangrt "${ED%/}"/usr/lib/clang || die
+	# move (remaining) wrapped headers back
+	mv "${ED%/}"/usr/include "${ED%/}"/usr/lib/llvm/${SLOT}/include || die
+
+	# Apply CHOST and version suffix to clang tools
+	# note: we use two version components here (vs 3 in runtime path)
+	local llvm_version=$(llvm-config --version) || die
+	local clang_version=$(get_version_component_range 1-2 "${llvm_version}")
+	local clang_full_version=$(get_version_component_range 1-3 "${llvm_version}")
+	local clang_tools=( clang clang++ clang-cl clang-cpp )
+	local abi i
+
+	# cmake gives us:
+	# - clang-X.Y
+	# - clang -> clang-X.Y
+	# - clang++, clang-cl, clang-cpp -> clang
+	# we want to have:
+	# - clang-X.Y
+	# - clang++-X.Y, clang-cl-X.Y, clang-cpp-X.Y -> clang-X.Y
+	# - clang, clang++, clang-cl, clang-cpp -> clang*-X.Y
+	# also in CHOST variant
+	for i in "${clang_tools[@]:1}"; do
+		rm "${ED%/}/usr/lib/llvm/${SLOT}/bin/${i}" || die
+		dosym "clang-${clang_version}" "/usr/lib/llvm/${SLOT}/bin/${i}-${clang_version}"
+		dosym "${i}-${clang_version}" "/usr/lib/llvm/${SLOT}/bin/${i}"
+	done
+
+	# now create target symlinks for all supported ABIs
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+		for i in "${clang_tools[@]}"; do
+			dosym "${i}-${clang_version}" \
+				"/usr/lib/llvm/${SLOT}/bin/${abi_chost}-${i}-${clang_version}"
+			dosym "${abi_chost}-${i}-${clang_version}" \
+				"/usr/lib/llvm/${SLOT}/bin/${abi_chost}-${i}"
+		done
+	done
+
+	# Remove unnecessary headers on FreeBSD, bug #417171
+	if use kernel_FreeBSD; then
+		rm "${ED}"usr/lib/clang/${clang_full_version}/include/{std,float,iso,limits,tgmath,varargs}*.h || die
+	fi
+}
+
+multilib_src_install() {
+	cmake-utils_src_install
+
+	# move headers to /usr/include for wrapping & ABI mismatch checks
+	# (also drop the version suffix from runtime headers)
+	rm -rf "${ED%/}"/usr/include || die
+	mv "${ED%/}"/usr/lib/llvm/${SLOT}/include "${ED%/}"/usr/include || die
+	mv "${ED%/}"/usr/lib/llvm/${SLOT}/$(get_libdir)/clang "${ED%/}"/usr/include/clangrt || die
+}
+
+multilib_src_install_all() {
+	python_fix_shebang "${ED}"
+	if use static-analyzer; then
+		python_optimize "${ED}"usr/lib/llvm/${SLOT}/share/scan-view
+	fi
+
+	# install pre-generated manpages
+	if ! use doc; then
+		insinto "/usr/lib/llvm/${SLOT}/share/man/man1"
+		doins "${WORKDIR}/x/y/llvm-manpages-${PV}/clang"/*.1
+	fi
+
+	docompress "/usr/lib/llvm/${SLOT}/share/man"
+	# match 'html' non-compression
+	use doc && docompress -x "/usr/share/doc/${PF}/tools-extra"
+	# +x for some reason; TODO: investigate
+	use static-analyzer && fperms a-x "/usr/lib/llvm/${SLOT}/share/man/man1/scan-build.1"
+}
+
+pkg_postinst() {
+	if [[ ${ROOT} == / && -f ${EPREFIX}/usr/share/eselect/modules/compiler-shadow.eselect ]] ; then
+		eselect compiler-shadow update all
+	fi
+}
+
+pkg_postrm() {
+	if [[ ${ROOT} == / && -f ${EPREFIX}/usr/share/eselect/modules/compiler-shadow.eselect ]] ; then
+		eselect compiler-shadow clean all
+	fi
+}

--- a/sys-devel/clang/files/5.0.0/0003-Enable-Stack-Protector-by-default.patch
+++ b/sys-devel/clang/files/5.0.0/0003-Enable-Stack-Protector-by-default.patch
@@ -1,0 +1,38 @@
+From facec87f38ad95ad3ad2b5f581c92bde19da4c6b Mon Sep 17 00:00:00 2001
+From: Matthias Dahl <matthias.dahl@binary-island.eu>
+Date: Wed, 20 Sep 2017 15:50:43 +0200
+Subject: [PATCH 1/3] Enable Stack Protector by default
+
+Enable "strong"-level Stack Protector by default.
+---
+ lib/Driver/ToolChains/Linux.cpp | 1 +
+ lib/Driver/ToolChains/Linux.h   | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/lib/Driver/ToolChains/Linux.cpp b/lib/Driver/ToolChains/Linux.cpp
+index 08a27fa7fed..fd35c2480be 100644
+--- a/lib/Driver/ToolChains/Linux.cpp
++++ b/lib/Driver/ToolChains/Linux.cpp
+@@ -811,6 +811,7 @@ void Linux::AddIAMCUIncludeArgs(const ArgList &DriverArgs,
+ }
+ 
+ bool Linux::isPIEDefault() const { return getSanitizerArgs().requiresPIE(); }
++unsigned Linux::GetDefaultStackProtectorLevel(bool KernelOrKext) const { return 2; }
+ 
+ SanitizerMask Linux::getSupportedSanitizers() const {
+   const bool IsX86 = getTriple().getArch() == llvm::Triple::x86;
+diff --git a/lib/Driver/ToolChains/Linux.h b/lib/Driver/ToolChains/Linux.h
+index 9778c1832cc..ddd46a1d587 100644
+--- a/lib/Driver/ToolChains/Linux.h
++++ b/lib/Driver/ToolChains/Linux.h
+@@ -36,6 +36,7 @@ public:
+   void AddIAMCUIncludeArgs(const llvm::opt::ArgList &DriverArgs,
+                            llvm::opt::ArgStringList &CC1Args) const override;
+   bool isPIEDefault() const override;
++  unsigned GetDefaultStackProtectorLevel(bool KernelOrKext) const override;
+   SanitizerMask getSupportedSanitizers() const override;
+   void addProfileRTLibs(const llvm::opt::ArgList &Args,
+                         llvm::opt::ArgStringList &CmdArgs) const override;
+-- 
+2.14.1
+

--- a/sys-devel/clang/files/5.0.0/0004-Enable-PIE-by-default.patch
+++ b/sys-devel/clang/files/5.0.0/0004-Enable-PIE-by-default.patch
@@ -1,0 +1,25 @@
+From 148f3660aba75658553128196524933738cb5965 Mon Sep 17 00:00:00 2001
+From: Matthias Dahl <matthias.dahl@binary-island.eu>
+Date: Wed, 20 Sep 2017 15:53:03 +0200
+Subject: [PATCH 2/3] Enable PIE by default
+
+---
+ lib/Driver/ToolChains/Linux.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/Driver/ToolChains/Linux.cpp b/lib/Driver/ToolChains/Linux.cpp
+index fd35c2480be..e0da31b4df7 100644
+--- a/lib/Driver/ToolChains/Linux.cpp
++++ b/lib/Driver/ToolChains/Linux.cpp
+@@ -810,7 +810,7 @@ void Linux::AddIAMCUIncludeArgs(const ArgList &DriverArgs,
+   }
+ }
+ 
+-bool Linux::isPIEDefault() const { return getSanitizerArgs().requiresPIE(); }
++bool Linux::isPIEDefault() const { return true; }
+ unsigned Linux::GetDefaultStackProtectorLevel(bool KernelOrKext) const { return 2; }
+ 
+ SanitizerMask Linux::getSupportedSanitizers() const {
+-- 
+2.14.1
+

--- a/sys-devel/clang/files/5.0.0/0005-Enable-FORTIFY_SOURCE-macro-by-default.patch
+++ b/sys-devel/clang/files/5.0.0/0005-Enable-FORTIFY_SOURCE-macro-by-default.patch
@@ -1,0 +1,35 @@
+From 68d39575cdff576b85907bea8e42b7ef26384dbb Mon Sep 17 00:00:00 2001
+From: Matthias Dahl <matthias.dahl@binary-island.eu>
+Date: Wed, 20 Sep 2017 16:17:31 +0200
+Subject: [PATCH 3/3] Enable FORTIFY_SOURCE macro by default
+
+FORTIFY_SOURCE only works for optimization levels > 0 and is currently not
+compatible with the address sanitizer, thus the macro is only set if the input
+language is C or C++ and the optimization level > 0 while the address sanitizer
+is not requested.
+---
+ lib/Frontend/CompilerInvocation.cpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/lib/Frontend/CompilerInvocation.cpp b/lib/Frontend/CompilerInvocation.cpp
+index 0d0869c815d..88c16534103 100644
+--- a/lib/Frontend/CompilerInvocation.cpp
++++ b/lib/Frontend/CompilerInvocation.cpp
+@@ -2694,6 +2694,14 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
+       !LangOpts.Sanitize.has(SanitizerKind::Address) &&
+       !LangOpts.Sanitize.has(SanitizerKind::Memory);
+ 
++  // Set the macro before the command line macros are being processed, so it can be
++  // properly unset if required to in case of incompatibilities.
++  if (Res.getCodeGenOpts().OptimizationLevel > 0 &&
++      (DashX.getLanguage() == InputKind::C || DashX.getLanguage() == InputKind::CXX) &&
++      !LangOpts.Sanitize.has(SanitizerKind::Address)) {
++    Res.getPreprocessorOpts().addMacroDef("_FORTIFY_SOURCE=2");
++  }
++
+   // FIXME: ParsePreprocessorArgs uses the FileManager to read the contents of
+   // PCH file and find the original header name. Remove the need to do that in
+   // ParsePreprocessorArgs and remove the FileManager
+-- 
+2.14.1
+


### PR DESCRIPTION
Bring clang more closely in line with Gentoo's gcc build by enabling "strong"-level Stack Protector and FORTIFY_SOURCE by default as well as add support for a default enabled PIE by USE flag.

This obviously needs further testing, so it is masked for now. My local tests though have been absolutely problem free.

I took the liberty to add this to the upcoming 17.0 profile, since that is still unofficial and in testing as well.