### PR TITLE
profiles/arch/powerpc: mask flags for unkeyworded depends

### DIFF
--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Jonathan Scruggs <j.scruggs@gmail.com> (10 Aug 2017)
+# dependencies not keyworded yet
+media-libs/openimageio field3d ptex
+
 # Arfrever Frehtes Taifersar Arahesis <arfrever.fta@gmail.com> (22 Aug 2017)
 # Dictionary Manager requires unkeyworded dev-qt/qtwebengine.
 app-i18n/fcitx-libpinyin dictmanager


### PR DESCRIPTION
This needs to be merged before my other PRs.

Packages being added to the main repo that are not arm and powerpc
keyworded.

Signed-off by: Jonathan Scruggs <j.scruggs@gmail.com>

@SoapGentoo 