### PR TITLE
www-client/qutebrowser: fix .asciidoc files selection

### DIFF
--- a/www-client/qutebrowser/qutebrowser-9999.ebuild
+++ b/www-client/qutebrowser/qutebrowser-9999.ebuild
@@ -57,7 +57,7 @@ python_test() {
 
 python_install_all() {
 	doman doc/${PN}.1
-	dodoc {CHANGELOG,CONTRIBUTING,FAQ,README}.asciidoc
+	for DocFile in {doc/,./}*.asciidoc; do dodoc $DocFile; done
 
 	domenu ${PN}.desktop
 	doicon -s scalable icons/${PN}.svg


### PR DESCRIPTION
The source does not appear to have some `.asciidoc` files anymore. This would prevent `File not found` errors now and in future modification of those files by simply selecting all `.asciidoc` files.