### PR TITLE
app-misc/ddcutil: Fix compile error with -O3 cflag

### DIFF
--- a/app-misc/ddcutil/ddcutil-0.8.4.ebuild
+++ b/app-misc/ddcutil/ddcutil-0.8.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit autotools linux-info udev user
+inherit autotools flag-o-matic linux-info udev user
 
 DESCRIPTION="Program for querying and changing monitor settings"
 HOMEPAGE="http://www.ddcutil.com/"
@@ -53,6 +53,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Bug 607818.
+	replace-flags -O3 -O2
+
 	# Python API is still very experimental.
 	local myeconfargs=(
 		$(use_enable usb-monitor usb)


### PR DESCRIPTION
DDCUtil doesn't compile with the -O3 cflag, so replace it with -O2

Signed-off by: Jonathan Scruggs <j.scruggs@gmail.com>

@SoapGentoo 