### PR TITLE
dev-db/tokumx: add blocker on dev-db/mongodb, bug #600410

### DIFF
--- a/dev-db/tokumx/tokumx-1.5.0-r2.ebuild
+++ b/dev-db/tokumx/tokumx-1.5.0-r2.ebuild
@@ -19,7 +19,7 @@ KEYWORDS="~amd64"
 IUSE="pax_kernel"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-RDEPEND="
+RDEPEND="!dev-db/mongodb
 	${PYTHON_DEPS}
 	dev-libs/jemalloc
 	>=dev-libs/boost-1.50[threads(+)]

--- a/dev-db/tokumx/tokumx-2.0.2.ebuild
+++ b/dev-db/tokumx/tokumx-2.0.2.ebuild
@@ -19,7 +19,7 @@ KEYWORDS="~amd64"
 IUSE="pax_kernel"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-RDEPEND="
+RDEPEND="!dev-db/mongodb
 	${PYTHON_DEPS}
 	dev-libs/jemalloc
 	!dev-libs/mongo-cxx-driver


### PR DESCRIPTION
https://bugs.gentoo.org/600410

Package-Manager: Portage-2.3.10, Repoman-2.3.3