### PR TITLE
media-video/ffmpeg: Fix bug #631352

### DIFF
--- a/media-video/ffmpeg/ffmpeg-2.8.10.ebuild
+++ b/media-video/ffmpeg/ffmpeg-2.8.10.ebuild
@@ -296,6 +296,24 @@ src_prepare() {
 	epatch_user
 }
 
+#Check if LDFLAGS contains any LTO flags
+#Must check in reverse!
+#If no LTO flags present, then this is a non-LTO build
+#If the last LTO flag is -fno-lto, that means this is a non-LTO build
+#otherwise, it is an LTO build
+#GCC treats LTO flags in the exact same way
+#Required for bug #631352
+is_lto() {
+	local x arr_ldflags len
+	arr_ldflags=(${LDFLAGS})
+	for ((i=${#arr_ldflags[@]}-1; i >= 0; i--)); do
+		x="${arr_ldflags[i]}"
+		[[ "${x}" == -flto* ]] && return 0
+		[[ "${x}" == -fno-lto ]] && return 1
+	done
+	return 1
+}
+
 multilib_src_configure() {
 	local myconf=( ${EXTRA_FFMPEG_CONF} )
 
@@ -374,8 +392,10 @@ multilib_src_configure() {
 		break
 	done
 
-	# LTO support, bug #566282
-	is-flagq "-flto*" && myconf+=( "--enable-lto" )
+	# LTO support, bug #566282, bug #631352
+	if is_lto; then
+		myconf+=( --enable-lto )
+	fi
 
 	# Mandatory configuration
 	myconf=(

--- a/media-video/ffmpeg/ffmpeg-2.8.11.ebuild
+++ b/media-video/ffmpeg/ffmpeg-2.8.11.ebuild
@@ -296,6 +296,24 @@ src_prepare() {
 	epatch_user
 }
 
+#Check if LDFLAGS contains any LTO flags
+#Must check in reverse!
+#If no LTO flags present, then this is a non-LTO build
+#If the last LTO flag is -fno-lto, that means this is a non-LTO build
+#otherwise, it is an LTO build
+#GCC treats LTO flags in the exact same way
+#Required for bug #631352
+is_lto() {
+	local x arr_ldflags len
+	arr_ldflags=(${LDFLAGS})
+	for ((i=${#arr_ldflags[@]}-1; i >= 0; i--)); do
+		x="${arr_ldflags[i]}"
+		[[ "${x}" == -flto* ]] && return 0
+		[[ "${x}" == -fno-lto ]] && return 1
+	done
+	return 1
+}
+
 multilib_src_configure() {
 	local myconf=( ${EXTRA_FFMPEG_CONF} )
 
@@ -374,8 +392,10 @@ multilib_src_configure() {
 		break
 	done
 
-	# LTO support, bug #566282
-	is-flagq "-flto*" && myconf+=( "--enable-lto" )
+	# LTO support, bug #566282, bug #631352
+	if is_lto; then
+		myconf+=( --enable-lto )
+	fi
 
 	# Mandatory configuration
 	myconf=(

--- a/media-video/ffmpeg/ffmpeg-3.2.4.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.2.4.ebuild
@@ -298,6 +298,24 @@ src_prepare() {
 	sed -i -e 's/sunos)/sunos) network_extralibs="-lsocket -lnsl"; add_cppflags -D__EXTENSIONS__; enable pic; disable symver ;; no-sunos)/' configure || die
 }
 
+#Check if LDFLAGS contains any LTO flags
+#Must check in reverse!
+#If no LTO flags present, then this is a non-LTO build
+#If the last LTO flag is -fno-lto, that means this is a non-LTO build
+#otherwise, it is an LTO build
+#GCC treats LTO flags in the exact same way
+#Required for bug #631352
+is_lto() {
+	local x arr_ldflags len
+	arr_ldflags=(${LDFLAGS})
+	for ((i=${#arr_ldflags[@]}-1; i >= 0; i--)); do
+		x="${arr_ldflags[i]}"
+		[[ "${x}" == -flto* ]] && return 0
+		[[ "${x}" == -fno-lto ]] && return 1
+	done
+	return 1
+}
+
 multilib_src_configure() {
 	local myconf=( ${EXTRA_FFMPEG_CONF} )
 
@@ -374,8 +392,10 @@ multilib_src_configure() {
 		break
 	done
 
-	# LTO support, bug #566282
-	is-flagq "-flto*" && myconf+=( "--enable-lto" )
+	# LTO support, bug #566282, bug #631352
+	if is_lto; then
+		myconf+=( --enable-lto )
+	fi
 
 	# Mandatory configuration
 	myconf=(

--- a/media-video/ffmpeg/ffmpeg-3.2.6.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.2.6.ebuild
@@ -300,6 +300,24 @@ src_prepare() {
 	sed -i -e 's/sunos)/sunos) network_extralibs="-lsocket -lnsl"; add_cppflags -D__EXTENSIONS__; enable pic; disable symver ;; no-sunos)/' configure || die
 }
 
+#Check if LDFLAGS contains any LTO flags
+#Must check in reverse!
+#If no LTO flags present, then this is a non-LTO build
+#If the last LTO flag is -fno-lto, that means this is a non-LTO build
+#otherwise, it is an LTO build
+#GCC treats LTO flags in the exact same way
+#Required for bug #631352
+is_lto() {
+	local x arr_ldflags len
+	arr_ldflags=(${LDFLAGS})
+	for ((i=${#arr_ldflags[@]}-1; i >= 0; i--)); do
+		x="${arr_ldflags[i]}"
+		[[ "${x}" == -flto* ]] && return 0
+		[[ "${x}" == -fno-lto ]] && return 1
+	done
+	return 1
+}
+
 multilib_src_configure() {
 	local myconf=( ${EXTRA_FFMPEG_CONF} )
 
@@ -376,8 +394,10 @@ multilib_src_configure() {
 		break
 	done
 
-	# LTO support, bug #566282
-	is-flagq "-flto*" && myconf+=( "--enable-lto" )
+	# LTO support, bug #566282, bug #631352
+	if is_lto; then
+		myconf+=( --enable-lto )
+	fi
 
 	# Mandatory configuration
 	myconf=(

--- a/media-video/ffmpeg/ffmpeg-3.2.7.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.2.7.ebuild
@@ -300,6 +300,24 @@ src_prepare() {
 	sed -i -e 's/sunos)/sunos) network_extralibs="-lsocket -lnsl"; add_cppflags -D__EXTENSIONS__; enable pic; disable symver ;; no-sunos)/' configure || die
 }
 
+#Check if LDFLAGS contains any LTO flags
+#Must check in reverse!
+#If no LTO flags present, then this is a non-LTO build
+#If the last LTO flag is -fno-lto, that means this is a non-LTO build
+#otherwise, it is an LTO build
+#GCC treats LTO flags in the exact same way
+#Required for bug #631352
+is_lto() {
+	local x arr_ldflags len
+	arr_ldflags=(${LDFLAGS})
+	for ((i=${#arr_ldflags[@]}-1; i >= 0; i--)); do
+		x="${arr_ldflags[i]}"
+		[[ "${x}" == -flto* ]] && return 0
+		[[ "${x}" == -fno-lto ]] && return 1
+	done
+	return 1
+}
+
 multilib_src_configure() {
 	local myconf=( ${EXTRA_FFMPEG_CONF} )
 
@@ -376,8 +394,10 @@ multilib_src_configure() {
 		break
 	done
 
-	# LTO support, bug #566282
-	is-flagq "-flto*" && myconf+=( "--enable-lto" )
+	# LTO support, bug #566282, bug #631352
+	if is_lto; then
+		myconf+=( --enable-lto )
+	fi
 
 	# Mandatory configuration
 	myconf=(

--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -305,6 +305,24 @@ src_prepare() {
 	echo 'include $(SRC_PATH)/ffbuild/libffmpeg.mak' >> Makefile || die
 }
 
+#Check if LDFLAGS contains any LTO flags
+#Must check in reverse!
+#If no LTO flags present, then this is a non-LTO build
+#If the last LTO flag is -fno-lto, that means this is a non-LTO build
+#otherwise, it is an LTO build
+#GCC treats LTO flags in the exact same way
+#Required for bug #631352
+is_lto() {
+	local x arr_ldflags len
+	arr_ldflags=(${LDFLAGS})
+	for ((i=${#arr_ldflags[@]}-1; i >= 0; i--)); do
+		x="${arr_ldflags[i]}"
+		[[ "${x}" == -flto* ]] && return 0
+		[[ "${x}" == -fno-lto ]] && return 1
+	done
+	return 1
+}
+
 multilib_src_configure() {
 	local myconf=( ${EXTRA_FFMPEG_CONF} )
 
@@ -375,8 +393,10 @@ multilib_src_configure() {
 		break
 	done
 
-	# LTO support, bug #566282
-	is-flagq "-flto*" && myconf+=( "--enable-lto" )
+	# LTO support, bug #566282, bug #631352
+	if is_lto; then
+		myconf+=( --enable-lto )
+	fi
 
 	# Mandatory configuration
 	myconf=(


### PR DESCRIPTION
The ebuilds for media-video/ffmpeg support LTO thanks to bug #566282,
but unfortunately this LTO support does not honour the -fno-lto flag.
Include suggestion from original bug in the ebuilds to fix this problem.

Ping @gentoo/media-video

Package-Manager: Portage-2.3.10, Repoman-2.3.3