### PR TITLE
dev-lang/python: enable profile guided optimization

### DIFF
--- a/dev-lang/python/metadata.xml
+++ b/dev-lang/python/metadata.xml
@@ -9,5 +9,6 @@
 	<flag name="threads">Enable threading support. (DON'T DISABLE THIS UNLESS YOU KNOW WHAT YOU'RE DOING)</flag>
 	<flag name="wide-unicode">Enable wide Unicode implementation which uses 4-byte Unicode characters. Switching of this USE flag changes ABI of Python and requires reinstallation of many Python modules. (DON'T DISABLE THIS UNLESS YOU KNOW WHAT YOU'RE DOING)</flag>
 	<flag name="wininst">Install Windows executables required to create an executable installer for MS Windows.</flag>
+	<flag name="pgo">Enable Profile Guided Optimization (PGO) in Python interpreter</flag>
 </use>
 </pkgmetadata>

--- a/dev-lang/python/python-2.7.12.ebuild
+++ b/dev-lang/python/python-2.7.12.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
 LICENSE="PSF-2"
 SLOT="2.7"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE="-berkdb build doc elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk +wide-unicode wininst +xml"
+IUSE="-berkdb build doc elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk +wide-unicode wininst +xml pgo"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
 # If you need to apply a patch which requires python for bootstrapping, please
@@ -213,7 +213,12 @@ src_compile() {
 	touch Include/graminit.h Python/graminit.c
 
 	cd "${BUILD_DIR}" || die
-	emake
+
+	if use pgo; then
+		emake profile-opt
+	else
+		emake
+	fi
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax_kernel]; then

--- a/dev-lang/python/python-2.7.13.ebuild
+++ b/dev-lang/python/python-2.7.13.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
 LICENSE="PSF-2"
 SLOT="2.7"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE="-berkdb build doc elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk +wide-unicode wininst +xml"
+IUSE="-berkdb build doc elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk +wide-unicode wininst +xml pgo"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
 # If you need to apply a patch which requires python for bootstrapping, please
@@ -213,7 +213,12 @@ src_compile() {
 	touch Include/graminit.h Python/graminit.c
 
 	cd "${BUILD_DIR}" || die
-	emake
+
+	if use pgo; then
+		emake profile-opt
+	else
+		emake
+	fi
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax_kernel]; then

--- a/dev-lang/python/python-2.7.14.ebuild
+++ b/dev-lang/python/python-2.7.14.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
 LICENSE="PSF-2"
 SLOT="2.7"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE="-berkdb build doc elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk +wide-unicode wininst +xml"
+IUSE="-berkdb build doc elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk +wide-unicode wininst +xml pgo"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
 # If you need to apply a patch which requires python for bootstrapping, please
@@ -213,7 +213,12 @@ src_compile() {
 	touch Include/graminit.h Python/graminit.c
 
 	cd "${BUILD_DIR}" || die
-	emake
+
+	if use pgo; then
+		emake profile-opt
+	else
+		emake
+	fi
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax_kernel]; then

--- a/dev-lang/python/python-3.4.5.ebuild
+++ b/dev-lang/python/python-3.4.5.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV%_rc*}/${MY_P}.tar.xz
 LICENSE="PSF-2"
 SLOT="3.4/3.4m"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml"
+IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml pgo"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
 # If you need to apply a patch which requires python for bootstrapping, please
@@ -177,7 +177,11 @@ src_compile() {
 
 	cd "${BUILD_DIR}" || die
 
-	emake CPPFLAGS= CFLAGS= LDFLAGS=
+    if use pgo; then
+		emake profile-opt CPPFLAGS= CFLAGS= LDFLAGS=
+	else
+		emake CPPFLAGS= CFLAGS= LDFLAGS=
+    fi
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax_kernel]; then

--- a/dev-lang/python/python-3.4.6.ebuild
+++ b/dev-lang/python/python-3.4.6.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV%_rc*}/${MY_P}.tar.xz
 LICENSE="PSF-2"
 SLOT="3.4/3.4m"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml"
+IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml pgo"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
 # If you need to apply a patch which requires python for bootstrapping, please
@@ -177,7 +177,11 @@ src_compile() {
 
 	cd "${BUILD_DIR}" || die
 
-	emake CPPFLAGS= CFLAGS= LDFLAGS=
+	if use pgo; then
+		emake profile-opt CPPFLAGS= CFLAGS= LDFLAGS=
+	else
+		emake CPPFLAGS= CFLAGS= LDFLAGS=
+	fi
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax_kernel]; then

--- a/dev-lang/python/python-3.5.3.ebuild
+++ b/dev-lang/python/python-3.5.3.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV%_rc*}/${MY_P}.tar.xz
 LICENSE="PSF-2"
 SLOT="3.5/3.5m"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml"
+IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml pgo"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
 # If you need to apply a patch which requires python for bootstrapping, please
@@ -175,7 +175,11 @@ src_compile() {
 
 	cd "${BUILD_DIR}" || die
 
-	emake CPPFLAGS= CFLAGS= LDFLAGS=
+	if use pgo; then
+		emake profile-opt CPPFLAGS= CFLAGS= LDFLAGS=
+	else
+		emake CPPFLAGS= CFLAGS= LDFLAGS=
+	fi
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax_kernel]; then

--- a/dev-lang/python/python-3.5.4.ebuild
+++ b/dev-lang/python/python-3.5.4.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV%_rc*}/${MY_P}.tar.xz
 LICENSE="PSF-2"
 SLOT="3.5/3.5m"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml"
+IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml pgo"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
 # If you need to apply a patch which requires python for bootstrapping, please
@@ -175,7 +175,11 @@ src_compile() {
 
 	cd "${BUILD_DIR}" || die
 
-	emake CPPFLAGS= CFLAGS= LDFLAGS=
+	if use pgo; then
+		emake profile-opt CPPFLAGS= CFLAGS= LDFLAGS=
+	else
+		emake CPPFLAGS= CFLAGS= LDFLAGS=
+	fi
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax_kernel]; then

--- a/dev-lang/python/python-3.6.1-r1.ebuild
+++ b/dev-lang/python/python-3.6.1-r1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
 LICENSE="PSF-2"
 SLOT="3.6/3.6m"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
-IUSE="build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml"
+IUSE="build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk wininst +xml pgo"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
 # If you need to apply a patch which requires python for bootstrapping, please
@@ -160,7 +160,11 @@ src_compile() {
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
 
-	emake CPPFLAGS= CFLAGS= LDFLAGS=
+	if use pgo; then
+		emake profile-opt CPPFLAGS= CFLAGS= LDFLAGS=
+	else
+		emake CPPFLAGS= CFLAGS= LDFLAGS=
+	fi
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax_kernel]; then


### PR DESCRIPTION
This solves bug #615412.  Add a USE flag for PGO
that is off by default, but if enabled, will trigger the appropriate
make target to do a PGO build of the Python interpreter.

Ping @gentoo/python

Package-Manager: Portage-2.3.10, Repoman-2.3.3