### PR TITLE
media-libs/partio: Add patch to avoid naming conflicts

### DIFF
--- a/media-libs/partio/files/partio-1.1.0-Rename-partconv.patch
+++ b/media-libs/partio/files/partio-1.1.0-Rename-partconv.patch
@@ -1,0 +1,65 @@
+From 7042285af5491fd3c2727fa24a7fd44145c066e5 Mon Sep 17 00:00:00 2001
+From: Jonathan Scruggs <j.scruggs@gmail.com>
+Date: Sat, 23 Sep 2017 16:43:37 +0100
+Subject: [PATCH] Rename partconv to partconvert to avoid file collisions
+
+* partconv is the name of a program used by Crystal Space
+
+Closes: https://bugs.gentoo.org/631834
+---
+ README.md                                  | 2 +-
+ src/Makefile                               | 2 +-
+ src/tools/CMakeLists.txt                   | 6 +++---
+ src/tools/{partconv.cpp => partconvert.cpp} | 0
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+ rename src/tools/{partconv.cpp => partconvert.cpp} (100%)
+
+diff --git a/README.md b/README.md
+index 0a3ac19..4cd12c3 100644
+--- a/README.md
++++ b/README.md
+@@ -56,7 +56,7 @@ src/
+    doc/      Doxygen documentation and (the start of) a manual
+    tests/    Start of regression tests (I need more)
+    tools/    Useful tools 
+-             partconv <input format> <output format>
++             partconvert <input format> <output format>
+              partinfo <particle file>
+              partview <particle file>
+ 
+diff --git a/src/Makefile b/src/Makefile
+index 0ced80e..ca4f965 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -25,4 +25,4 @@ reader/BGEO.o: reader/BGEO.cpp Particle.h ParticleSimple.h \
+ reader/PDB.o: reader/PDB.cpp Particle.h ParticleSimple.h \
+   reader/../Particle.h reader/pdb.h
+ partinfo.o: partinfo.cpp Particle.h
+-partconv.o: partconf.cpp Particle.h
+\ No newline at end of file
++partconvert.o: partconf.cpp Particle.h
+diff --git a/src/tools/CMakeLists.txt b/src/tools/CMakeLists.txt
+index 7a6d26b..b4ed9ae 100644
+--- a/src/tools/CMakeLists.txt
++++ b/src/tools/CMakeLists.txt
+@@ -47,10 +47,10 @@ ENDIF(GLUT_FOUND AND OPENGL_FOUND)
+ ADD_EXECUTABLE(partinfo partinfo.cpp)
+ target_link_libraries(partinfo ${PARTIO_LIBRARIES})
+ 
+-ADD_EXECUTABLE(partconv partconv.cpp)
+-target_link_libraries(partconv ${PARTIO_LIBRARIES})
++ADD_EXECUTABLE(partconvert partconvert.cpp)
++target_link_libraries(partconvert ${PARTIO_LIBRARIES})
+ 
+ ADD_EXECUTABLE(partattr partattr.cpp)
+ target_link_libraries(partattr ${PARTIO_LIBRARIES})
+ 
+-install(TARGETS partattr partconv partinfo DESTINATION ${CMAKE_INSTALL_BINDIR})
++install(TARGETS partattr partconvert partinfo DESTINATION ${CMAKE_INSTALL_BINDIR})
+diff --git a/src/tools/partconv.cpp b/src/tools/partconvert.cpp
+similarity index 100%
+rename from src/tools/partconv.cpp
+rename to src/tools/partconvert.cpp
+-- 
+2.14.1
+

--- a/media-libs/partio/partio-1.1.0_p20170829.ebuild
+++ b/media-libs/partio/partio-1.1.0_p20170829.ebuild
@@ -29,6 +29,8 @@ DEPEND="${RDEPEND}
 	dev-lang/swig:*
 "
 
+PATCHES=( "${FILESDIR}/${PN}-1.1.0-Rename-partconv.patch" )
+
 src_prepare() {
 	cmake-utils_src_prepare
 


### PR DESCRIPTION
* partconv collides with a file from dev-games/crystalspace

Closes: https://bugs.gentoo.org/631834
Closes: #5776