### PR TITLE
media-sound/jalv: Add media-lib/suil[gtk] dependency when gtk2 is enabled

### DIFF
--- a/media-sound/jalv/jalv-1.6.0-r2.ebuild
+++ b/media-sound/jalv/jalv-1.6.0-r2.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_REQ_USE='threads(+)'
+
+inherit python-any-r1 qmake-utils waf-utils
+
+DESCRIPTION="Simple but fully featured LV2 host for Jack"
+HOMEPAGE="http://drobilla.net/software/jalv/"
+SRC_URI="http://download.drobilla.net/${P}.tar.bz2"
+
+LICENSE="ISC"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="gtk gtk2 gtkmm portaudio qt5"
+
+RDEPEND=">=media-libs/lv2-1.6.0
+	>=media-libs/lilv-0.24.0
+	>=dev-libs/serd-0.14.0
+	>=dev-libs/sord-0.12.0
+	>=media-libs/suil-0.6.0
+	>=media-libs/sratom-0.6.0
+	gtk? ( >=x11-libs/gtk+-3.0.0:3 )
+	gtk2? ( >=x11-libs/gtk+-2.18.0:2
+		>=media-libs/suil-0.6.0[gtk] )
+	gtkmm? ( >=dev-cpp/gtkmm-2.20.0:2.4 )
+	portaudio? ( media-libs/portaudio )
+	!portaudio? ( virtual/jack )
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+	)
+"
+DEPEND="${RDEPEND}
+	${PYTHON_DEPS}
+	virtual/pkgconfig"
+
+DOCS=( AUTHORS NEWS README )
+
+PATCHES=( "${FILESDIR}/${P}-qt-5.7.0.patch" )
+
+src_configure() {
+	use qt5 && export PATH="$(qt5_get_bindir):${PATH}"
+	waf-utils_src_configure \
+		"--docdir=/usr/share/doc/${PF}" \
+		--no-qt4 \
+		$(use qt5       || echo --no-qt5)       \
+		$(use gtk       || echo --no-gtk3)      \
+		$(use gtk2      || echo --no-gtk2)      \
+		$(use gtkmm     || echo --no-gtkmm)     \
+		$(use portaudio && echo --portaudio)
+}


### PR DESCRIPTION
Without the `media-libs/suil[gtk]` dependency I get the following error when trying to run some plugins through `jalv.gtk`
```
suil error: Unable to open wrap module /usr/lib64/suil-0/libsuil_x11_in_gtk2.so (/usr/lib64/suil-0/libsuil_x11_in_gtk2.so: cannot open shared object file: No such file or directory)
The program 'jalv.gtk' received an X Window System error.
This probably reflects a bug in the program.
The error was 'BadWindow (invalid Window parameter)'.
  (Details: serial 45 error_code 3 request_code 1 minor_code 0)
  (Note to programmers: normally, X errors are reported asynchronously;
   that is, you will receive the error a while after causing it.
   To debug your program, run it with the --sync command line
   option to change this behavior. You can then get a meaningful
   backtrace from your debugger if you break on the gdk_x_error() function.)
```

Enabling `media-libs/suil[gtk]` builds this missing module
```
$ equery f suil | grep -i gtk 
/usr/lib64/suil-0/libsuil_x11_in_gtk2.so
```

Since the USE flags don't match (`gtk2` for jalv vs `gtk` for suil) I knew no better way to do this than just adding the `media-libs/suil[gtk]` dependency within the `gtk2` USE conditional.