### PR TITLE
Fix ftgl ebuilds

### DIFF
--- a/media-libs/ftgl/ftgl-2.1.3_rc5-r1.ebuild
+++ b/media-libs/ftgl/ftgl-2.1.3_rc5-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+inherit eutils flag-o-matic autotools
+
+MY_PV=${PV/_/-}
+MY_PV2=${PV/_/\~}
+MY_P=${PN}-${MY_PV}
+MY_P2=${PN}-${MY_PV2}
+
+DESCRIPTION="library to use arbitrary fonts in OpenGL applications"
+HOMEPAGE="http://ftgl.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.bz2"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
+IUSE="static-libs"
+
+DEPEND=">=media-libs/freetype-2.0.9
+	virtual/opengl
+	virtual/glu
+	media-libs/freeglut
+  dev-util/cppunit"
+RDEPEND=${DEPEND}
+
+S=${WORKDIR}/${MY_P2}
+
+src_prepare() {
+	epatch \
+		"${FILESDIR}"/${P}-gentoo.patch \
+		"${FILESDIR}"/${P}-underlink.patch
+	sed -e "s/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/" -i configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	strip-flags # ftgl is sensitive - bug #112820
+  append-cxxflags -std=c++11 # Fix build with latest cppunit
+	econf $(use_enable static-libs static)
+}
+
+src_install() {
+	DOCS="AUTHORS BUGS ChangeLog NEWS README TODO docs/projects_using_ftgl.txt" \
+		default
+	rm -rf "${D}"/usr/share/doc/ftgl || die
+	prune_libtool_files
+}

--- a/media-libs/ftgl/ftgl-2.1.3_rc5.ebuild
+++ b/media-libs/ftgl/ftgl-2.1.3_rc5.ebuild
@@ -21,7 +21,8 @@ IUSE="static-libs"
 DEPEND=">=media-libs/freetype-2.0.9
 	virtual/opengl
 	virtual/glu
-	media-libs/freeglut"
+	media-libs/freeglut
+	<dev-util/cppunit-1.14"
 RDEPEND=${DEPEND}
 
 S=${WORKDIR}/${MY_P2}


### PR DESCRIPTION
It appears, that ftgl links with cppunit, though there are no options to enable/disable this feature.
With cppunit >= 1.14 it also requires -std=c++11 or gnu++11. Don't know, is it good to provide such flag in pkg-config cflags, but it is not so yet.