### PR TITLE
sys-apps/sandbox: Stop sandbox-2.11 from ignoring LD_LIBRARY_PATH

### DIFF
--- a/sys-apps/sandbox/files/sandbox-2.11-keep-ld_library_path.patch
+++ b/sys-apps/sandbox/files/sandbox-2.11-keep-ld_library_path.patch
@@ -1,0 +1,13 @@
+Bug: https://bugs.gentoo.org/580726
+
+--- a/libsandbox/libsandbox.c
++++ b/libsandbox/libsandbox.c
+@@ -1225,7 +1225,7 @@
+ 		if (mod_cnt) {
+ 			str_list_for_each_item(envp, entry, count) {
+ 				for (i = 0; i < num_vars; ++i)
+-					if (is_env_var(entry, vars[i].name, vars[i].len)) {
++					if (i != 12 && is_env_var(entry, vars[i].name, vars[i].len)) {
+ 						(*mod_cnt)++;
+ 						goto skip;
+ 					}

--- a/sys-apps/sandbox/sandbox-2.11-r5.ebuild
+++ b/sys-apps/sandbox/sandbox-2.11-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 #
@@ -37,6 +37,7 @@ src_prepare() {
 	epatch "${FILESDIR}"/${P}-exec-prelink.patch #599894
 	epatch "${FILESDIR}"/${PN}-2.10-fix-opendir.patch #553092
 	epatch "${FILESDIR}"/${P}-symlinkat-renameat.patch #612202
+	epatch "${FILESDIR}"/${P}-keep-ld_library_path.patch #580726
 	epatch_user
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/580726
Package-Manager: Portage-2.3.6, Repoman-2.3.2

Sandbox commit [55087abd8dc9802cf68cade776fe612a3f19f6a1](https://gitweb.gentoo.org/proj/sandbox.git/commit/?id=55087abd8dc9802cf68cade776fe612a3f19f6a1) is for the purpose of preventing a loop or deadlock caused by a package implementing its own libc memory allocation functions, which themselves may call on a sandbox wrapped system calls, whose implementation depends on further calls to such memory functions.  If any binaries export such symbols, sandbox assumes the worst and prevents loading of libsandbox.so and instead opts for ptrace.

In preventing the loading of libsandbox, it removes all variables whose `env_pair.name` field matches the name of an environment variable from the environment, for all `env_pair`s of `vars[]` in `char **sb_check_envp(char **envp, size_t *mod_cnt, bool insert)` in "libsandbox/libsandbox.c".  This includes not just the usual environment variables prefixed with 'SANDBOX_' but also `LD_PRELOAD` and `LD_LIBRARY_PATH`.  `LD_PRELOAD` clearly should be removed.  But `LD_LIBRARY_PATH` would only seem to be trouble if used with `LD_PRELOAD`.  As such it makes sense to me to prevent the removal of `LD_LIBRARY_PATH`.

Given the fact that the the positions of the `env_pair`s in `vars[]` are intended to be hard-coded (from libsandbox.c:  `/* Indices matter -- see init below */`), this commit uses the index of the `env_pair` corresponding to  `LD_LIBRARY_PATH` to prevent its removal.

Tested with www-client/seamonkey-2.49.3.0_p0.