### PR TITLE
www-apps/rt: Fix loading of Date::Manip w/ Factory TZ

### DIFF
--- a/www-apps/rt/rt-4.2.12-r1.ebuild
+++ b/www-apps/rt/rt-4.2.12-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -231,6 +231,10 @@ src_configure() {
 		web="apache"
 		depsconf+=" --with-MODPERL2"
 	fi
+	# Any loading Date::Manip from here on
+	# may fail if TZ=Factory as it is on gentoo install
+	# media ( affects install as well )
+	export TZ=UTC
 
 	./configure --enable-layout=Gentoo \
 		--with-bin-owner=rt \

--- a/www-apps/rt/rt-4.4.1.ebuild
+++ b/www-apps/rt/rt-4.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -236,6 +236,10 @@ src_configure() {
 		web="apache"
 		depsconf+=" --with-MODPERL2"
 	fi
+	# Any loading Date::Manip from here on
+	# may fail if TZ=Factory as it is on gentoo install
+	# media ( affects install as well )
+	export TZ=UTC
 
 	./configure --enable-layout=Gentoo \
 		--with-bin-owner=rt \


### PR DESCRIPTION
On machines where TZ=Factory ( via /etc/localtime , ENV is not sufficient to replicate ), such as ones freshly rolled out from gentoo install media, `use Date::Manip` fails.

This leads to a failure at configure and install time.

Ideally, end users will need to configure their machines properly.

But their Timezone being right should have no bearing on the ability
to build this package.

Package-Manager: Portage-2.3.8, Repoman-2.3.3