### PR TITLE
net-vpn/i2pd: drop pch use flag

### DIFF
--- a/net-vpn/i2pd/i2pd-2.15.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.15.0.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://github.com/PurpleI2P/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="cpu_flags_x86_aes i2p-hardening libressl pch static +upnp websocket"
+IUSE="cpu_flags_x86_aes i2p-hardening libressl static +upnp websocket"
 
 RDEPEND="!static? ( >=dev-libs/boost-1.49[threads]
 			!libressl? ( dev-libs/openssl:0[-bindist] )
@@ -39,7 +39,7 @@ src_configure() {
 	mycmakeargs=(
 		-DWITH_AESNI=$(usex cpu_flags_x86_aes ON OFF)
 		-DWITH_HARDENING=$(usex i2p-hardening ON OFF)
-		-DWITH_PCH=$(usex pch ON OFF)
+		-DWITH_PCH=OFF
 		-DWITH_STATIC=$(usex static ON OFF)
 		-DWITH_UPNP=$(usex upnp ON OFF)
 		-DWITH_WEBSOCKETS=$(usex websocket ON OFF)


### PR DESCRIPTION
`pch` is the use flag for precompiled headers. It is supposed to speed up the compilation, but its support in i2pd is "experimental" ( https://i2pd.readthedocs.io/en/latest/devs/building/unix/ ). And it does not work, see https://bugs.gentoo.org/630236 and https://github.com/PurpleI2P/i2pd/issues/951.

There is no real advantage of using `pch`, except the faster compilation. But i2pd is not a large package, it builds within 15 minutes on my 4 core arm server. So I suggest dropping the `pch` use flag in favor of stability.