### PR TITLE
app-admin/rcm: update proxy maintainer contact info

### DIFF
--- a/app-admin/rcm/metadata.xml
+++ b/app-admin/rcm/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>fgtham+genbugs@gmail.com</email>
+		<email>fgtham@gmail.com</email>
 		<name>Florian Tham</name>
 		<description>Proxy maintainer - set to assignee on bugs</description>
 	</maintainer>


### PR DESCRIPTION
It was suggested to me to use an email addresses without '+' chars. I have updated my gentoo bugzilla account accordingly.