### PR TITLE
net-irc/inspircd: Revbump to 2.0.24-r1.

### DIFF
--- a/net-irc/inspircd/files/inspircd-r3.confd
+++ b/net-irc/inspircd/files/inspircd-r3.confd
@@ -1,0 +1,33 @@
+# Distributed under the terms of the GNU General Public License v2
+
+# Location of configuration file. Modify if you don't like the standard
+# one.
+#
+#INSPIRCD_CONFIGFILE="/etc/inspircd/inspircd.conf"
+
+# File used to store the PID file. Usually you won't need to touch it.
+# If you are changing PID file do not forget to set new PID file in
+# INSPIRCD_CONFIGFILE as well.
+#
+#INSPIRCD_PIDFILE="/run/inspircd/inspircd.pid"
+
+# User to run InspIRCd as
+#
+#INSPIRCD_USER="inspircd"
+#INSPIRCD_GROUP="inspircd"
+
+# You can use this configuration option to pass additional options to the
+# start-stop-daemon, see start-stop-daemon(8) for more details.
+# Per default we start InspIRCd without any output (quiet)
+# as user $INSPIRCD_USER and wait 1000ms after we have started the service
+# to ensure that the daemon is really up and running.
+#INSPIRCD_SSDARGS="--quiet --user \"${INSPIRCD_USER}\" --wait 1000"
+
+# The termination timeout (start-stop-daemon parameter "retry") ensures
+# that the service will be terminated within a given time (25 + 5 seconds
+# per default) when you are stopping the service.
+#INSPIRCD_TERMTIMEOUT="TERM/25/KILL/5"
+
+# Options to collectd
+# See `/usr/bin/inspircd --help` for more details
+#INSPIRCD_OPTS=""

--- a/net-irc/inspircd/files/inspircd-r3.initd
+++ b/net-irc/inspircd/files/inspircd-r3.initd
@@ -1,0 +1,48 @@
+#!/sbin/openrc-run
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+: ${INSPIRCD_USER:="inspircd"}
+: ${INSPIRCD_GROUP:="inspircd"}
+: ${INSPIRCD_CONFIGFILE:="/etc/inspircd/inspircd.conf"}
+: ${INSPIRCD_PIDFILE:="/run/inspircd/inspircd.pid"}
+: ${INSPIRCD_SSDARGS:="--quiet --wait 1000"}
+: ${INSPIRCD_TERMTIMEOUT:="TERM/25/KILL/5"}
+: ${INSPIRCD_OPTS:=""}
+
+command="/usr/bin/inspircd"
+command_args="${INSPIRCD_OPTS} --config \"${INSPIRCD_CONFIGFILE}\""
+command_user="${INSPIRCD_USER}"
+start_stop_daemon_args="${INSPIRCD_SSDARGS}"
+pidfile="${INSPIRCD_PIDFILE}"
+retry="${INSPIRCD_TERMTIMEOUT}"
+
+required_files="${INSPIRCD_CONFIGFILE}"
+
+name="InspIRCd"
+
+description="InspIRCd is a modular Internet Relay Chat (IRC) server."
+
+extra_commands="version"
+extra_started_commands="rehash"
+
+depend() {
+	use dns
+	provide ircd
+}
+
+start_pre() {
+	checkpath --directory --mode 0750 --owner ${INSPIRCD_USER}:${INSPIRCD_GROUP} "$(dirname "${INSPIRCD_PIDFILE}")"
+}
+
+rehash() {
+	ebegin "Rehashing InspIRCd"
+	start-stop-daemon --signal HUP --pidfile "${pidfile}"
+	eend $?
+}
+
+version() {
+	ebegin "Retrieve InspIRCd version"
+	${command} --version
+	eend $?
+}

--- a/net-irc/inspircd/inspircd-2.0.24-r1.ebuild
+++ b/net-irc/inspircd/inspircd-2.0.24-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="6"
 
-inherit toolchain-funcs user
+inherit toolchain-funcs user versionator
 
 DESCRIPTION="Inspire IRCd - The Stable, High-Performance Modular IRCd"
 HOMEPAGE="https://inspircd.github.com/"
@@ -27,6 +27,7 @@ RDEPEND="
 	tre? ( dev-libs/tre )"
 DEPEND="${RDEPEND}"
 
+DOCS=( docs/. )
 PATCHES=( "${FILESDIR}"/${P}-fix-path-builds.patch )
 
 pkg_setup() {
@@ -83,16 +84,17 @@ src_install() {
 	insinto "/usr/include/${PN}"
 	doins -r include/.
 
+	einstalldocs
+
 	diropts -o"${PN}" -g"${PN}" -m0700
 	dodir "/var/lib/${PN}"
 	dodir "/var/lib/${PN}/data"
 
-	newinitd "${FILESDIR}/${PN}-r2.initd" "${PN}"
-	newconfd "${FILESDIR}/${PN}.confd" "${PN}"
+	newinitd "${FILESDIR}/${PN}-r3.initd" "${PN}"
+	newconfd "${FILESDIR}/${PN}-r3.confd" "${PN}"
 
 	keepdir "/var/log/${PN}"
 
-	dodoc -r docs/*
 	rm -r "${D%/}/etc/${PN}" || die
 	dodir "/etc/${PN}"
 	dodir "/etc/${PN}/aliases"
@@ -108,6 +110,14 @@ pkg_postinst() {
 		elog "/usr/share/doc/${PN}"
 		elog "Read the ${PN}.conf.example file carefully before "
 		elog "starting the service."
-		elog
 	fi
+	local pv=""
+	for pv in ${REPLACING_VERSIONS}; do
+		if ! version_is_at_least "2.0.24-r1" "${pv}"; then
+			elog "Starting with 2.0.24-r1 the daemon is no longer started"
+			elog "with the --logfile option and you are thus expected to define"
+			elog "logging in the InspIRCd configuration file if you want it."
+			break
+		fi
+	done
 }


### PR DESCRIPTION
Install documentation with proper permissions, it was previously only
viewable by the root user.
Remove --logfile option when starting the daemon via OpenRC, this
prevents double-logging when the user has configured logging by the more
featureful InspIRCd configuration file.

Closes: https://bugs.gentoo.org/617686