### PR TITLE
net-p2p/airdcpp-webclient: Fix incorrect configuration parameter name

### DIFF
--- a/net-p2p/airdcpp-webclient/airdcpp-webclient-2.1.0-r1.ebuild
+++ b/net-p2p/airdcpp-webclient/airdcpp-webclient-2.1.0-r1.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} pypy{,3} )
+
+inherit cmake-utils python-any-r1 user
+
+DESCRIPTION="Cross-platform Direct Connect client"
+HOMEPAGE="https://airdcpp-web.github.io/"
+SRC_URI="https://github.com/airdcpp-web/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+KEYWORDS="~amd64 ~x86"
+LICENSE="GPL-2+"
+SLOT="0"
+IUSE="nat-pmp +tbb +webui"
+
+RDEPEND="
+	app-arch/bzip2
+	dev-cpp/websocketpp
+	dev-libs/boost:=
+	dev-libs/geoip
+	dev-libs/leveldb:=
+	dev-libs/openssl:0=[-bindist]
+	net-libs/miniupnpc:=
+	sys-libs/zlib
+	virtual/libiconv
+	nat-pmp? ( net-libs/libnatpmp:= )
+	tbb? ( dev-cpp/tbb:= )
+"
+DEPEND="
+	virtual/pkgconfig
+	${PYTHON_DEPS}
+	${RDEPEND}
+"
+PDEPEND="webui? ( www-apps/airdcpp-webui )"
+
+# https://github.com/airdcpp-web/airdcpp-webclient/pull/248
+PATCHES=( "${FILESDIR}/${P}-disable-automagic.patch" )
+
+pkg_setup() {
+	python-any-r1_pkg_setup
+	enewgroup airdcppd
+	enewuser airdcppd -1 -1 /var/lib/airdcppd airdcppd
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DINSTALL_WEB_UI=OFF
+		-DENABLE_NATPMP=$(usex nat-pmp)
+		-DENABLE_TBB=$(usex tbb)
+	)
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+	newconfd "${FILESDIR}/airdcppd.confd" airdcppd
+	newinitd "${FILESDIR}/airdcppd.initd" airdcppd
+	keepdir /var/lib/airdcppd
+	fowners airdcppd:airdcppd /var/lib/airdcppd
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
+		elog "Run 'airdcppd --configure' to set up ports and authentication"
+	fi
+}

--- a/net-p2p/airdcpp-webclient/airdcpp-webclient-2.2.0-r1.ebuild
+++ b/net-p2p/airdcpp-webclient/airdcpp-webclient-2.2.0-r1.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} pypy{,3} )
+
+inherit cmake-utils python-any-r1 user
+
+DESCRIPTION="Cross-platform Direct Connect client"
+HOMEPAGE="https://airdcpp-web.github.io/"
+SRC_URI="https://github.com/airdcpp-web/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+KEYWORDS="~amd64 ~x86"
+LICENSE="GPL-2+"
+SLOT="0"
+IUSE="nat-pmp +tbb +webui"
+
+RDEPEND="
+	app-arch/bzip2
+	dev-cpp/websocketpp
+	dev-libs/boost:=
+	dev-libs/geoip
+	dev-libs/leveldb:=
+	dev-libs/openssl:0=[-bindist]
+	net-libs/miniupnpc:=
+	sys-libs/zlib:=
+	virtual/libiconv
+	nat-pmp? ( net-libs/libnatpmp:= )
+	tbb? ( dev-cpp/tbb:= )
+"
+DEPEND="
+	virtual/pkgconfig
+	${PYTHON_DEPS}
+	${RDEPEND}
+"
+PDEPEND="webui? ( www-apps/airdcpp-webui )"
+
+pkg_setup() {
+	python-any-r1_pkg_setup
+	enewgroup airdcppd
+	enewuser airdcppd -1 -1 /var/lib/airdcppd airdcppd
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DINSTALL_WEB_UI=OFF
+		-DENABLE_NATPMP=$(usex nat-pmp)
+		-DENABLE_TBB=$(usex tbb)
+	)
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+	newconfd "${FILESDIR}/airdcppd.confd" airdcppd
+	newinitd "${FILESDIR}/airdcppd.initd" airdcppd
+	keepdir /var/lib/airdcppd
+	fowners airdcppd:airdcppd /var/lib/airdcppd
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
+		elog "Run 'airdcppd --configure' to set up ports and authentication"
+	fi
+}

--- a/net-p2p/airdcpp-webclient/files/airdcppd.initd
+++ b/net-p2p/airdcpp-webclient/files/airdcppd.initd
@@ -1,10 +1,10 @@
 #!/sbin/openrc-run
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 AIRDCPPD_USER="${AIRDCPPD_USER:-${RC_SVCNAME}}"
 AIRDCPPD_GROUP="${AIRDCPPD_GROUP:-${RC_SVCNAME}}"
-AIRDCPPD_UMASK="${SYNCTHING_UMASK:-007}"
+AIRDCPPD_UMASK="${AIRDCPPD_UMASK:-007}"
 AIRDCPPD_HOME="$(getent passwd "${AIRDCPPD_USER}" | cut -d: -f6)"
 
 command="/usr/bin/airdcppd"


### PR DESCRIPTION
Setting the UMASK configuration parameter in the configuration file did not have any effect. That's because the UMASK configuration parameter name in the init script and conf file did not match.

Package-Manager: Portage-2.3.8, Repoman-2.3.1