### PR TITLE
Fix avidemux-{2.6.20,9999} bugs

### DIFF
--- a/media-libs/avidemux-core/avidemux-core-2.6.20-r1.ebuild
+++ b/media-libs/avidemux-core/avidemux-core-2.6.20-r1.ebuild
@@ -54,6 +54,8 @@ DEPEND="
 S="${WORKDIR}/${MY_P}"
 CMAKE_USE_DIR="${S}/${PN/-/_}"
 
+PATCHES=("${FILESDIR}"/${P}-fix-cmake.patch  )
+
 src_prepare() {
 	cmake-utils_src_prepare
 

--- a/media-libs/avidemux-core/avidemux-core-2.6.20-r1.ebuild
+++ b/media-libs/avidemux-core/avidemux-core-2.6.20-r1.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="http://fixounet.free.fr/avidemux"
 # Multiple licenses because of all the bundled stuff.
 LICENSE="GPL-1 GPL-2 MIT PSF-2 public-domain"
 SLOT="2.6"
-IUSE="debug nls nvenc sdl system-ffmpeg vaapi vdpau video_cards_fglrx xv"
+IUSE="debug nls nvenc sdl system-ffmpeg vaapi vdpau xv"
 
 if [[ ${PV} == *9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/mean00/avidemux2.git"
@@ -35,10 +35,6 @@ DEPEND="
 	vaapi? ( x11-libs/libva:0 )
 	vdpau? ( x11-libs/libvdpau:0 )
 	nvenc? ( media-video/nvidia_video_sdk )
-	video_cards_fglrx? (
-		|| ( >=x11-drivers/ati-drivers-14.12-r3
-			x11-libs/xvba-video:0 )
-		)
 "
 RDEPEND="
 	$DEPEND
@@ -85,7 +81,6 @@ src_configure() {
 		-DSDL="$(usex sdl)"
 		-DLIBVA="$(usex vaapi)"
 		-DVDPAU="$(usex vdpau)"
-		-DXVBA="$(usex video_cards_fglrx)"
 		-DXVIDEO="$(usex xv)"
 		-DNVENC="$(usex nvenc)"
 	)

--- a/media-libs/avidemux-core/avidemux-core-9999.ebuild
+++ b/media-libs/avidemux-core/avidemux-core-9999.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="http://fixounet.free.fr/avidemux"
 # Multiple licenses because of all the bundled stuff.
 LICENSE="GPL-1 GPL-2 MIT PSF-2 public-domain"
 SLOT="2.6"
-IUSE="debug nls nvenc sdl system-ffmpeg vaapi vdpau video_cards_fglrx xv"
+IUSE="debug nls nvenc sdl system-ffmpeg vaapi vdpau xv"
 
 if [[ ${PV} == *9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/mean00/avidemux2.git"
@@ -35,10 +35,6 @@ DEPEND="
 	vaapi? ( x11-libs/libva:0 )
 	vdpau? ( x11-libs/libvdpau:0 )
 	nvenc? ( media-video/nvidia_video_sdk )
-	video_cards_fglrx? (
-		|| ( >=x11-drivers/ati-drivers-14.12-r3
-			x11-libs/xvba-video:0 )
-		)
 "
 RDEPEND="
 	$DEPEND
@@ -83,7 +79,6 @@ src_configure() {
 		-DSDL="$(usex sdl)"
 		-DLIBVA="$(usex vaapi)"
 		-DVDPAU="$(usex vdpau)"
-		-DXVBA="$(usex video_cards_fglrx)"
 		-DXVIDEO="$(usex xv)"
 		-DNVENC="$(usex nvenc)"
 	)

--- a/media-libs/avidemux-core/files/avidemux-core-2.6.20-fix-cmake.patch
+++ b/media-libs/avidemux-core/files/avidemux-core-2.6.20-fix-cmake.patch
@@ -1,0 +1,18 @@
+Bug: https://bugs.gentoo.org/625930
+Backported from https://github.com/mean00/avidemux2/commit/c5edc6cf7b3768ac1409c6cef69ab5980a86596a
+
+diff -Naur a/cmake/admCheckX264.cmake b/cmake/admCheckX264.cmake
+--- a/cmake/admCheckX264.cmake	2017-04-28 05:22:27.000000000 -0400
++++ b/cmake/admCheckX264.cmake	2017-10-01 01:38:33.249996381 -0400
+@@ -20,9 +20,9 @@
+ 				ELSE (x264_version LESS 67)
+                                         IF (x264_version GREATER 73)
+ 					        FIND_HEADER_AND_LIB(X264 x264.h x264 x264_encoder_open_${x264_version})
++                                        ELSE (x264_version GREATER 73)
++					        FIND_HEADER_AND_LIB(X264 x264.h x264 x264_encoder_open)
+                                         ENDIF (x264_version GREATER 73)
+-				ELSE (x264_version LESS 67)
+-					FIND_HEADER_AND_LIB(X264 x264.h x264 x264_encoder_open)
+ 				ENDIF (x264_version LESS 67)
+                                 IF(X264_FOUND)
+                                         SET(USE_X264 True CACHE BOOL "")

--- a/media-video/avidemux/avidemux-2.6.20.ebuild
+++ b/media-video/avidemux/avidemux-2.6.20.ebuild
@@ -81,6 +81,10 @@ src_configure() {
 	# See bug 432322.
 	use x86 && replace-flags -O0 -O1
 
+	# The build relies on an avidemux-core header that uses 'nullptr'
+	# which is from >=C++11.  Let's use the GCC-6 default C++ dialect.
+	append-cxxflags -std=c++14
+
 	local mycmakeargs=(
 		-DAVIDEMUX_SOURCE_DIR='${S}'
 		-DGETTEXT="$(usex nls)"

--- a/media-video/avidemux/avidemux-2.6.20.ebuild
+++ b/media-video/avidemux/avidemux-2.6.20.ebuild
@@ -46,7 +46,9 @@ src_prepare() {
 	default
 
 	processes="buildCli:avidemux/cli"
-	use qt4 && processes+=" buildQt4:avidemux/qt4"
+	if use qt4 || use qt5 ; then
+		processes+=" buildQt4:avidemux/qt4"
+	fi
 
 	for process in ${processes} ; do
 		CMAKE_USE_DIR="${S}"/${process#*:} cmake-utils_src_prepare

--- a/media-video/avidemux/avidemux-2.6.20.ebuild
+++ b/media-video/avidemux/avidemux-2.6.20.ebuild
@@ -5,7 +5,7 @@ EAPI="6"
 
 PLOCALES="ca cs de el es fr it ja pt_BR ru sr sr@latin tr"
 
-inherit cmake-utils l10n
+inherit cmake-utils l10n xdg-utils
 
 DESCRIPTION="Video editor designed for simple cutting, filtering and encoding tasks"
 HOMEPAGE="http://fixounet.free.fr/${PN}"
@@ -152,4 +152,12 @@ src_install() {
 	if use qt4 || use qt5 ; then
 		domenu ${PN}-2.6.desktop
 	fi
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
 }

--- a/media-video/avidemux/avidemux-2.6.20.ebuild
+++ b/media-video/avidemux/avidemux-2.6.20.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://fixounet.free.fr/${PN}"
 # Multiple licenses because of all the bundled stuff.
 LICENSE="GPL-1 GPL-2 MIT PSF-2 public-domain"
 SLOT="2.6"
-IUSE="debug opengl nls nvenc qt4 qt5 sdl vaapi vdpau video_cards_fglrx xv"
+IUSE="debug opengl nls nvenc qt4 qt5 sdl vaapi vdpau xv"
 
 if [[ ${PV} == *9999* ]] ; then
 	MY_P="${P}"
@@ -27,16 +27,13 @@ else
 fi
 
 DEPEND="
-	~media-libs/avidemux-core-${PV}:${SLOT}[nls?,sdl?,vaapi?,vdpau?,video_cards_fglrx?,xv?,nvenc?]
+	~media-libs/avidemux-core-${PV}:${SLOT}[nls?,sdl?,vaapi?,vdpau?,xv?,nvenc?]
 	opengl? ( virtual/opengl:0 )
 	qt4? ( >=dev-qt/qtgui-4.8.3:4 )
 	qt5? ( dev-qt/qtgui:5 )
 	vaapi? ( x11-libs/libva:0 )
 	nvenc? ( amd64? ( media-video/nvidia_video_sdk:0 ) )
-	video_cards_fglrx? (
-		|| ( >=x11-drivers/ati-drivers-14.12-r3
-			x11-libs/xvba-video:0 )
-		)"
+"
 RDEPEND="
 	$DEPEND
 	nls? ( virtual/libintl:0 )
@@ -88,7 +85,6 @@ src_configure() {
 		-DSDL="$(usex sdl)"
 		-DLIBVA="$(usex vaapi)"
 		-DVDPAU="$(usex vdpau)"
-		-DXVBA="$(usex video_cards_fglrx)"
 		-DXVIDEO="$(usex xv)"
 	)
 

--- a/media-video/avidemux/avidemux-2.6.20.ebuild
+++ b/media-video/avidemux/avidemux-2.6.20.ebuild
@@ -113,6 +113,13 @@ src_compile() {
 	done
 }
 
+src_test() {
+	for process in ${processes} ; do
+		local build="${WORKDIR}/${P}_build/${process%%:*}"
+		BUILD_DIR="${build}" cmake-utils_src_test
+	done
+}
+
 src_install() {
 	for process in ${processes} ; do
 		local build="${WORKDIR}/${P}_build/${process%%:*}"

--- a/media-video/avidemux/avidemux-9999.ebuild
+++ b/media-video/avidemux/avidemux-9999.ebuild
@@ -81,6 +81,10 @@ src_configure() {
 	# See bug 432322.
 	use x86 && replace-flags -O0 -O1
 
+	# The build relies on an avidemux-core header that uses 'nullptr'
+	# which is from >=C++11.  Let's use the GCC-6 default C++ dialect.
+	append-cxxflags -std=c++14
+
 	local mycmakeargs=(
 		-DAVIDEMUX_SOURCE_DIR='${S}'
 		-DGETTEXT="$(usex nls)"

--- a/media-video/avidemux/avidemux-9999.ebuild
+++ b/media-video/avidemux/avidemux-9999.ebuild
@@ -46,7 +46,9 @@ src_prepare() {
 	default
 
 	processes="buildCli:avidemux/cli"
-	use qt4 && processes+=" buildQt4:avidemux/qt4"
+	if use qt4 || use qt5 ; then
+		processes+=" buildQt4:avidemux/qt4"
+	fi
 
 	for process in ${processes} ; do
 		CMAKE_USE_DIR="${S}"/${process#*:} cmake-utils_src_prepare

--- a/media-video/avidemux/avidemux-9999.ebuild
+++ b/media-video/avidemux/avidemux-9999.ebuild
@@ -5,7 +5,7 @@ EAPI="6"
 
 PLOCALES="ca cs de el es fr it ja pt_BR ru sr sr@latin tr"
 
-inherit cmake-utils l10n
+inherit cmake-utils l10n xdg-utils
 
 DESCRIPTION="Video editor designed for simple cutting, filtering and encoding tasks"
 HOMEPAGE="http://fixounet.free.fr/${PN}"
@@ -152,4 +152,12 @@ src_install() {
 	if use qt4 || use qt5 ; then
 		domenu ${PN}-2.6.desktop
 	fi
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
 }

--- a/media-video/avidemux/avidemux-9999.ebuild
+++ b/media-video/avidemux/avidemux-9999.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://fixounet.free.fr/${PN}"
 # Multiple licenses because of all the bundled stuff.
 LICENSE="GPL-1 GPL-2 MIT PSF-2 public-domain"
 SLOT="2.6"
-IUSE="debug opengl nls nvenc qt4 qt5 sdl vaapi vdpau video_cards_fglrx xv"
+IUSE="debug opengl nls nvenc qt4 qt5 sdl vaapi vdpau xv"
 
 if [[ ${PV} == *9999* ]] ; then
 	MY_P="${P}"
@@ -27,16 +27,13 @@ else
 fi
 
 DEPEND="
-	~media-libs/avidemux-core-${PV}:${SLOT}[nls?,sdl?,vaapi?,vdpau?,video_cards_fglrx?,xv?,nvenc?]
+	~media-libs/avidemux-core-${PV}:${SLOT}[nls?,sdl?,vaapi?,vdpau?,xv?,nvenc?]
 	opengl? ( virtual/opengl:0 )
 	qt4? ( >=dev-qt/qtgui-4.8.3:4 )
 	qt5? ( dev-qt/qtgui:5 )
 	vaapi? ( x11-libs/libva:0 )
 	nvenc? ( amd64? ( media-video/nvidia_video_sdk:0 ) )
-	video_cards_fglrx? (
-		|| ( >=x11-drivers/ati-drivers-14.12-r3
-			x11-libs/xvba-video:0 )
-		)"
+"
 RDEPEND="
 	$DEPEND
 	nls? ( virtual/libintl:0 )
@@ -88,7 +85,6 @@ src_configure() {
 		-DSDL="$(usex sdl)"
 		-DLIBVA="$(usex vaapi)"
 		-DVDPAU="$(usex vdpau)"
-		-DXVBA="$(usex video_cards_fglrx)"
 		-DXVIDEO="$(usex xv)"
 	)
 

--- a/media-video/avidemux/avidemux-9999.ebuild
+++ b/media-video/avidemux/avidemux-9999.ebuild
@@ -113,6 +113,13 @@ src_compile() {
 	done
 }
 
+src_test() {
+	for process in ${processes} ; do
+		local build="${WORKDIR}/${P}_build/${process%%:*}"
+		BUILD_DIR="${build}" cmake-utils_src_test
+	done
+}
+
 src_install() {
 	for process in ${processes} ; do
 		local build="${WORKDIR}/${P}_build/${process%%:*}"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/625930
Bug: https://bugs.gentoo.org/623346

Other fixes:

When avidemux is built, there was a problem with the default `src_test` phase.  `BUILD_DIR` isn't properly set, leading to `_RESPECT_CMAKE_BUILD_DIR` somehow being set and `CMAKE_BUILD_DIR` being improperly initialized.  Eventually, this caused the build to omit creating the cli libs which caused further problems with avidemux-plugins.  I could restrict the test phase but future versions of avidemux may include them for ctest and it's not a problem just to include the necessary loop in `src_test`.

Fixed QA message about not running xdg_desktop_database_update in `pkg_postinst` and `pkg_postrm` for avidemux.

Removed support for ati-drivers which are no longer in the portage tree.

Edit: Also fixed building avidemux with GCC-5.