### PR TITLE
dev-perl/CPAN-Mini-Inject: De-stabilize

### DIFF
--- a/dev-perl/CPAN-Mini-Inject/CPAN-Mini-Inject-0.330.0-r1.ebuild
+++ b/dev-perl/CPAN-Mini-Inject/CPAN-Mini-Inject-0.330.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Inject modules into a CPAN::Mini mirror"
 
 SLOT="0"
-KEYWORDS="amd64 x86 ~ppc-aix"
+KEYWORDS="~amd64 ~x86 ~ppc-aix"
 IUSE=""
 
 # Disabled


### PR DESCRIPTION
- No Reverse dependencies
- Has not worked since 2011 due to missing dependencies which nobody
  noticed due to tests being disabled ( this will be remedied soon )

Package-Manager: Portage-2.3.8, Repoman-2.3.3