### PR TITLE
app-text/asciidoc: sync live ebuild, install README and BUGS again

### DIFF
--- a/app-text/asciidoc/asciidoc-8.6.9-r6.ebuild
+++ b/app-text/asciidoc/asciidoc-8.6.9-r6.ebuild
@@ -68,7 +68,7 @@ src_install() {
 	python_fix_shebang "${ED%/}"/usr/bin/*.py
 
 	readme.gentoo_create_doc
-	dodoc CHANGELOG docbook-xsl/asciidoc-docbook-xsl.txt \
+	dodoc BUGS CHANGELOG README docbook-xsl/asciidoc-docbook-xsl.txt \
 		dblatex/dblatex-readme.txt filters/code/code-filter-readme.txt
 
 	# Below results in some files being installed twice in different locations, but they are


### PR DESCRIPTION
There are two commits here:

- the first synchronises the live ebuild with 8.6.9-r5 (plus the changes in the other commit), and
- the second adds a new revision bump in order to install the files README and BUGS again (I found out that BUGS is referenced by the man page, so even the opinion is that README is useless, at least BUGS should be installed).

If these changes are OK I'd like to add a commit to remove the previous ~arch revisions with the goal of stabilising a new revision in a month or so.