### PR TITLE
net-misc/eventd: restrict meson version to usable one

### DIFF
--- a/net-misc/eventd/eventd-0.23.0.ebuild
+++ b/net-misc/eventd/eventd-0.23.0.ebuild
@@ -51,6 +51,7 @@ COMMON_DEPEND="
 	zeroconf? ( net-dns/avahi[dbus] )
 "
 DEPEND="${COMMON_DEPEND}
+	<dev-util/meson-0.42.0
 	app-text/docbook-xml-dtd:4.5
 	app-text/docbook-xsl-stylesheets
 	dev-libs/libxslt


### PR DESCRIPTION
~~This also changes eventd.pc hence the revbump.~~

Closes: https://bugs.gentoo.org/631412
Package-Manager: Portage-2.3.11, Repoman-2.3.3