### PR TITLE
app-text/referencer: fix bug 601174

### DIFF
--- a/app-text/referencer/files/referencer-1.2.2-lib_path.patch
+++ b/app-text/referencer/files/referencer-1.2.2-lib_path.patch
@@ -1,0 +1,21 @@
+From: Dominik Kriegner <dominik.kriegner@gmail.com>
+Date: Tue, 29 Nov 2016 09:56:00 +0000
+Subject: [PATCH] fix build issue
+Patch's original author is Askhat Bakarov on arch
+https://aur.archlinux.org/cgit/aur.git/commit/?h=referencer&id=961f2b5e4b286f27f610e5267465c63021b8a50f
+
+Project-Bug-URL: https://bugs.launchpad.net/referencer/+bug/1645639
+Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=601174
+merged upstream: http://bazaar.launchpad.net/~referencer-devs/referencer/trunk/revision/939
+
+--- a/src/Document.C	2014-01-27 03:43:00.000000000 +0700
++++ b/src/Document.C	2016-11-03 16:25:00.698676538 +0700
+@@ -297,7 +297,7 @@
+ 
+ 			lib_path = lib_path->get_parent();
+ 			up_dir_level += "../";
+-			if (lib_path == 0) {
++			if (!lib_path) {
+ 				doc_is_relative_to_library = false;
+ 				break;
+ 			}

--- a/app-text/referencer/referencer-1.2.2.ebuild
+++ b/app-text/referencer/referencer-1.2.2.ebuild
@@ -1,11 +1,11 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI="6"
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit fdo-mime eutils python-single-r1 flag-o-matic
+inherit xdg-utils eutils python-single-r1 flag-o-matic
 
 DESCRIPTION="Application to organise documents or references, and to generate BibTeX files"
 HOMEPAGE="https://launchpad.net/referencer"
@@ -13,16 +13,15 @@ SRC_URI="https://launchpad.net/${PN}/1./${PV}/+download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
 IUSE=""
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+KEYWORDS="~amd64 ~x86"
 
-RDEPEND="${PYTHON_DEPS}
-	>=app-text/poppler-0.12.3-r3:=[cairo]
+RDEPEND=">=app-text/poppler-0.12.3-r3:=[cairo]
 	>=dev-cpp/gtkmm-2.8:*
 	>=dev-cpp/libglademm-2.6.0
 	>=dev-cpp/gconfmm-2.14.0
 	>=dev-libs/boost-1.52.0-r4"
+
 DEPEND="${RDEPEND}
 	>=app-text/gnome-doc-utils-0.3.2
 	virtual/pkgconfig
@@ -31,7 +30,10 @@ DEPEND="${RDEPEND}
 	dev-util/intltool
 	app-text/rarian"
 
+PATCHES="${FILESDIR}/${PN}-${PV}-lib_path.patch"
+
 src_prepare () {
+	default
 	python_fix_shebang plugins
 }
 
@@ -41,9 +43,11 @@ src_configure() {
 }
 
 pkg_postinst() {
-	fdo-mime_mime_database_update
+	xdg_mimeinfo_database_update
+	xdg_desktop_database_update
 }
 
 pkg_postrm() {
-	fdo-mime_mime_database_update
+	xdg_mimeinfo_database_update
+	xdg_desktop_database_update
 }


### PR DESCRIPTION
* update ebuild to EAPI 6
* add patch to fix the compile error in 601174
* move from fdo-mime to xdg-utils eclass (suggested by repoman)

Package-Manager: Portage-2.3.10, Repoman-2.3.3