### PR TITLE
profiles: unmask Perl 5.26.0 and 5.26.1

### DIFF
--- a/dev-perl/App-pwhich/App-pwhich-1.150.0.ebuild
+++ b/dev-perl/App-pwhich/App-pwhich-1.150.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Perl-only 'which'"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/DateTime/DateTime-1.420.0.ebuild
+++ b/dev-perl/DateTime/DateTime-1.420.0.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="A date and time object"
 
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="~amd64 ~hppa ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~amd64 ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="test"
 
 CONFLICTS="

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -395,7 +395,6 @@ dev-perl/Test2-Suite
 >=dev-perl/Data-Validate-Domain-0.120.0
 dev-perl/Test2-Plugin-NoWarnings
 dev-perl/Params-ValidationCompiler
-dev-perl/Sub-Info
 dev-perl/Term-Table
 >=dev-perl/DateTime-Locale-1.60.0
 >=dev-perl/DateTime-TimeZone-2.20.0

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
->=dev-perl/Data-Validate-Domain-0.120.0
 dev-perl/Test2-Plugin-NoWarnings
 dev-perl/Params-ValidationCompiler
 >=dev-perl/DateTime-Locale-1.60.0

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
->=dev-perl/DateTime-1.370.0
 >=dev-perl/DateTime-Format-Strptime-1.710.0
 >=dev-perl/Log-Dispatch-2.590.0
 >=dev-perl/App-pwhich-1.150.0

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -382,65 +382,6 @@ dev-ruby/poltergeist
 
 # Andreas K. Hüttel <dilfridge@gentoo.org> (5 June 2017)
 # Masked for initial testing.
-=dev-lang/perl-5.26.0
-=dev-lang/perl-5.26.1
-=virtual/perl-Archive-Tar-2.240.0
-=virtual/perl-B-Debug-1.240.0
-=virtual/perl-CPAN-2.180.0
-=virtual/perl-CPAN-Meta-2.150.10
-=virtual/perl-Carp-1.420.0
-=virtual/perl-Compress-Raw-Bzip2-2.74.0
-=virtual/perl-Compress-Raw-Zlib-2.74.0
-=virtual/perl-DB_File-1.840.0
-=virtual/perl-Data-Dumper-2.167.0
-=virtual/perl-Devel-PPPort-3.350.0
-=virtual/perl-Digest-MD5-2.550.0
-=virtual/perl-Digest-SHA-5.960.0
-=virtual/perl-Encode-2.880.0
-=virtual/perl-ExtUtils-MakeMaker-7.240.0
-=virtual/perl-ExtUtils-ParseXS-3.340.0
-=virtual/perl-File-Spec-3.670.0
-=virtual/perl-Filter-Simple-0.930.0
-=virtual/perl-Getopt-Long-2.490.0
-=virtual/perl-HTTP-Tiny-0.70.0
-=virtual/perl-I18N-LangTags-0.420.0
-=virtual/perl-IO-1.380.0
-=virtual/perl-IO-Compress-2.74.0
-=virtual/perl-IO-Socket-IP-0.380.0
-=virtual/perl-IPC-Cmd-0.960.0
-=virtual/perl-JSON-PP-2.274.0.200_rc
-=virtual/perl-Locale-Maketext-1.280.0
-=virtual/perl-Math-BigInt-1.999.806-r1
-=virtual/perl-Math-BigInt-FastCalc-0.500.500
-=virtual/perl-Math-BigRat-0.261.100
-=virtual/perl-Math-Complex-1.590.100
-=virtual/perl-Module-Load-Conditional-0.680.0
-=virtual/perl-Module-Metadata-1.0.33
-=virtual/perl-Net-Ping-2.550.0
-=virtual/perl-Parse-CPAN-Meta-2.150.10
-=virtual/perl-Perl-OSType-1.10.0
-=virtual/perl-Pod-Simple-3.350.0
-=virtual/perl-Safe-2.400.0
-=virtual/perl-Scalar-List-Utils-1.460.200_rc
-=virtual/perl-Storable-2.620.0
-=virtual/perl-Sys-Syslog-0.350.0
-=virtual/perl-Term-ANSIColor-4.60.0
-=virtual/perl-Term-ReadLine-1.160.0
-=virtual/perl-Test-1.300.0
-=virtual/perl-Test-Harness-3.380.0
-=virtual/perl-Test-Simple-1.302.73
-=virtual/perl-Thread-Queue-3.120.0
-=virtual/perl-Thread-Semaphore-2.130.0
-=virtual/perl-Time-Local-1.250.0
-=virtual/perl-XSLoader-0.270.0
-=virtual/perl-bignum-0.470.0
-=virtual/perl-libnet-3.100.0
-=virtual/perl-parent-0.236.0
-=virtual/perl-podlators-4.90.0
-=virtual/perl-threads-2.150.0
-=virtual/perl-threads-shared-1.560.0
-=virtual/perl-version-0.991.700
-#
 # The following masks are technically not part of the Perl 5.26 block,
 # but with the unmasking of Perl 5.26 they become obsolete and can be
 # removed:

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
-dev-perl/Test2-Suite
 >=dev-perl/Data-Validate-Domain-0.120.0
 dev-perl/Test2-Plugin-NoWarnings
 dev-perl/Params-ValidationCompiler

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -387,7 +387,6 @@ dev-ruby/poltergeist
 # removed:
 #
 >=perl-core/ExtUtils-MakeMaker-7.180.0
->=dev-perl/Net-Twitter-4.10.420
 >=perl-core/Math-BigInt-1.999.726
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -382,12 +382,6 @@ dev-ruby/poltergeist
 
 # Andreas K. Hüttel <dilfridge@gentoo.org> (5 June 2017)
 # Masked for initial testing.
-# The following masks are technically not part of the Perl 5.26 block,
-# but with the unmasking of Perl 5.26 they become obsolete and can be
-# removed:
-#
->=perl-core/ExtUtils-MakeMaker-7.180.0
->=perl-core/Math-BigInt-1.999.726
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -395,7 +395,6 @@ dev-perl/Test2-Suite
 >=dev-perl/Data-Validate-Domain-0.120.0
 dev-perl/Test2-Plugin-NoWarnings
 dev-perl/Params-ValidationCompiler
-dev-perl/Term-Table
 >=dev-perl/DateTime-Locale-1.60.0
 >=dev-perl/DateTime-TimeZone-2.20.0
 >=dev-perl/DateTime-1.370.0

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -380,11 +380,6 @@ net-im/skypetab-ng
 www-client/phantomjs
 dev-ruby/poltergeist
 
-# Andreas K. Hüttel <dilfridge@gentoo.org> (5 June 2017)
-# Masked for initial testing.
-=perl-core/Test-Simple-1.302.96
-=virtual/perl-Test-Simple-1.302.96
-
 # Thomas Deutschmann <whissi@gentoo.org> (24 May 2017)
 # Broken runscript/changed behavior causing lvm2 to fail
 # on boot. Bug #617578

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -382,7 +382,6 @@ dev-ruby/poltergeist
 
 # Andreas K. Hüttel <dilfridge@gentoo.org> (5 June 2017)
 # Masked for initial testing.
->=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
 

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
-dev-perl/Params-ValidationCompiler
 >=dev-perl/DateTime-Locale-1.60.0
 >=dev-perl/DateTime-TimeZone-2.20.0
 >=dev-perl/DateTime-1.370.0

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
-dev-perl/Test2-Plugin-NoWarnings
 dev-perl/Params-ValidationCompiler
 >=dev-perl/DateTime-Locale-1.60.0
 >=dev-perl/DateTime-TimeZone-2.20.0

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
->=dev-perl/Log-Dispatch-2.590.0
 >=dev-perl/App-pwhich-1.150.0
 
 # Thomas Deutschmann <whissi@gentoo.org> (24 May 2017)

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
->=dev-perl/App-pwhich-1.150.0
 
 # Thomas Deutschmann <whissi@gentoo.org> (24 May 2017)
 # Broken runscript/changed behavior causing lvm2 to fail

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
->=dev-perl/DateTime-Format-Strptime-1.710.0
 >=dev-perl/Log-Dispatch-2.590.0
 >=dev-perl/App-pwhich-1.150.0
 

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
->=dev-perl/DateTime-Locale-1.60.0
 >=dev-perl/DateTime-TimeZone-2.20.0
 >=dev-perl/DateTime-1.370.0
 >=dev-perl/DateTime-Format-Strptime-1.710.0

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -391,7 +391,6 @@ dev-ruby/poltergeist
 >=dev-perl/Math-BigInt-GMP-1.600.0
 =perl-core/Test-Simple-1.302.96
 =virtual/perl-Test-Simple-1.302.96
->=dev-perl/DateTime-TimeZone-2.20.0
 >=dev-perl/DateTime-1.370.0
 >=dev-perl/DateTime-Format-Strptime-1.710.0
 >=dev-perl/Log-Dispatch-2.590.0


### PR DESCRIPTION
Repoman checking 5.26 release and friends.

Post-merge checklist:

- [ ] Keyword `hppa` `dev-perl/Data-ValidateDomain`
- [ ] Keyword `alpha arm arm64 hppa ia64 ppc ppc64 s390 sh sparc x86-fbsd` `dev-perl/DateTime-Locale`
- [ ] Keyword `alpha arm arm64 hppa ia64 m68k ppc ppc64 s390 sh sparc x86-fbsd` `dev-perl/DateTime-TimeZone`
- [ ] Keyword ` alpha arm arm64 hppa ia64 m68k ppc ppc64 s390 sh sparc x86-fbsd` `dev-perl/DateTime`
- [ ] Keyword `alpha arm hppa ia64 ppc ppc64 sparc` `dev-perl/DateTime-Format-Strptime`
- [ ] Keyword `alpha ia64 ppc ppc64 sparc` `dev-perl/Log-Dispatch`
- [ ] Keyword `alpha arm arm64 hppa ia64 ppc ppc64` `dev-perl/App-pwhich`
