### PR TITLE
dev-vcs/mercurial: License is GPL-2+

### DIFF
--- a/dev-vcs/mercurial/mercurial-3.8.4.ebuild
+++ b/dev-vcs/mercurial/mercurial-3.8.4.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Scalable distributed SCM"
 HOMEPAGE="https://www.mercurial-scm.org/"
 SRC_URI="https://www.mercurial-scm.org/release/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="bugzilla emacs gpg test tk"

--- a/dev-vcs/mercurial/mercurial-4.1.3.ebuild
+++ b/dev-vcs/mercurial/mercurial-4.1.3.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Scalable distributed SCM"
 HOMEPAGE="https://www.mercurial-scm.org/"
 SRC_URI="https://www.mercurial-scm.org/release/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="bugzilla emacs gpg test tk"

--- a/dev-vcs/mercurial/mercurial-4.3.2.ebuild
+++ b/dev-vcs/mercurial/mercurial-4.3.2.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Scalable distributed SCM"
 HOMEPAGE="https://www.mercurial-scm.org/"
 SRC_URI="https://www.mercurial-scm.org/release/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="bugzilla emacs gpg test tk"

--- a/dev-vcs/mercurial/mercurial-4.3.3.ebuild
+++ b/dev-vcs/mercurial/mercurial-4.3.3.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Scalable distributed SCM"
 HOMEPAGE="https://www.mercurial-scm.org/"
 SRC_URI="https://www.mercurial-scm.org/release/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="bugzilla emacs gpg test tk"

--- a/dev-vcs/mercurial/mercurial-4.3.ebuild
+++ b/dev-vcs/mercurial/mercurial-4.3.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Scalable distributed SCM"
 HOMEPAGE="https://www.mercurial-scm.org/"
 SRC_URI="https://www.mercurial-scm.org/release/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="bugzilla emacs gpg test tk"

--- a/dev-vcs/mercurial/mercurial-9999.ebuild
+++ b/dev-vcs/mercurial/mercurial-9999.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.mercurial-scm.org/"
 EHG_REPO_URI="http://selenic.com/repo/hg"
 EHG_REVISION="@"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS=""
 IUSE="bugzilla emacs gpg test tk zsh-completion"


### PR DESCRIPTION
For reference of the license, see the header in
https://www.mercurial-scm.org/repo/hg/file/tip/hg

and see https://www.mercurial-scm.org/wiki/License

Package-Manager: Portage-2.3.6, Repoman-2.3.3