### PR TITLE
net-vpn/i2pd: fix build with libressl #597798

### DIFF
--- a/net-vpn/i2pd/i2pd-2.13.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.13.0.ebuild
@@ -12,15 +12,16 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE="cpu_flags_x86_aes i2p-hardening libressl pch static +upnp"
 
-RDEPEND="!static? ( >=dev-libs/boost-1.49[threads]
+# if using libressl, require >=boost-1.65, see #597798
+RDEPEND="!static? ( dev-libs/boost[threads]
 			!libressl? ( dev-libs/openssl:0[-bindist] )
-			libressl? ( dev-libs/libressl )
+			libressl? ( dev-libs/libressl >=dev-libs/boost-1.65 )
 			upnp? ( net-libs/miniupnpc )
 		)"
 DEPEND="${RDEPEND}
-	static? ( >=dev-libs/boost-1.49[static-libs,threads]
+	static? ( dev-libs/boost[static-libs,threads]
 		!libressl? ( dev-libs/openssl:0[static-libs] )
-		libressl? ( dev-libs/libressl[static-libs] )
+		libressl? ( dev-libs/libressl[static-libs] >=dev-libs/boost-1.65 )
 		upnp? ( net-libs/miniupnpc[static-libs] ) )
 	i2p-hardening? ( >=sys-devel/gcc-4.7 )
 	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"

--- a/net-vpn/i2pd/i2pd-2.13.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.13.0.ebuild
@@ -10,19 +10,24 @@ SRC_URI="https://github.com/PurpleI2P/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="cpu_flags_x86_aes i2p-hardening libressl pch static +upnp"
+IUSE="cpu_flags_x86_aes i2p-hardening libressl static +upnp websocket"
 
 # if using libressl, require >=boost-1.65, see #597798
 RDEPEND="!static? ( dev-libs/boost[threads]
 			!libressl? ( dev-libs/openssl:0[-bindist] )
-			libressl? ( dev-libs/libressl >=dev-libs/boost-1.65 )
+			libressl? ( dev-libs/libressl:0
+						>=dev-libs/boost-1.65 )
+			sys-libs/zlib
 			upnp? ( net-libs/miniupnpc )
 		)"
 DEPEND="${RDEPEND}
 	static? ( dev-libs/boost[static-libs,threads]
 		!libressl? ( dev-libs/openssl:0[static-libs] )
-		libressl? ( dev-libs/libressl[static-libs] >=dev-libs/boost-1.65 )
+		libressl? ( dev-libs/libressl:0[static-libs]
+					>=dev-libs/boost-1.65 )
+		sys-libs/zlib[static-libs]
 		upnp? ( net-libs/miniupnpc[static-libs] ) )
+	websocket? ( dev-cpp/websocketpp )
 	i2p-hardening? ( >=sys-devel/gcc-4.7 )
 	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"
 
@@ -39,9 +44,10 @@ src_configure() {
 	mycmakeargs=(
 		-DWITH_AESNI=$(usex cpu_flags_x86_aes ON OFF)
 		-DWITH_HARDENING=$(usex i2p-hardening ON OFF)
-		-DWITH_PCH=$(usex pch ON OFF)
+		-DWITH_PCH=OFF
 		-DWITH_STATIC=$(usex static ON OFF)
 		-DWITH_UPNP=$(usex upnp ON OFF)
+		-DWITH_WEBSOCKETS=$(usex websocket ON OFF)
 		-DWITH_LIBRARY=ON
 		-DWITH_BINARY=ON
 	)

--- a/net-vpn/i2pd/i2pd-2.14.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.14.0.ebuild
@@ -12,15 +12,16 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE="cpu_flags_x86_aes i2p-hardening libressl pch static +upnp"
 
-RDEPEND="!static? ( >=dev-libs/boost-1.49[threads]
+# if using libressl, require >=boost-1.65, see #597798
+RDEPEND="!static? ( dev-libs/boost[threads]
 			!libressl? ( dev-libs/openssl:0[-bindist] )
-			libressl? ( dev-libs/libressl )
+			libressl? ( dev-libs/libressl >=dev-libs/boost-1.65 )
 			upnp? ( net-libs/miniupnpc )
 		)"
 DEPEND="${RDEPEND}
-	static? ( >=dev-libs/boost-1.49[static-libs,threads]
+	static? ( dev-libs/boost[static-libs,threads]
 		!libressl? ( dev-libs/openssl:0[static-libs] )
-		libressl? ( dev-libs/libressl[static-libs] )
+		libressl? ( dev-libs/libressl[static-libs] >=dev-libs/boost-1.65 )
 		upnp? ( net-libs/miniupnpc[static-libs] ) )
 	i2p-hardening? ( >=sys-devel/gcc-4.7 )
 	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"

--- a/net-vpn/i2pd/i2pd-2.14.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.14.0.ebuild
@@ -10,19 +10,24 @@ SRC_URI="https://github.com/PurpleI2P/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="cpu_flags_x86_aes i2p-hardening libressl pch static +upnp"
+IUSE="cpu_flags_x86_aes i2p-hardening libressl static +upnp websocket"
 
 # if using libressl, require >=boost-1.65, see #597798
 RDEPEND="!static? ( dev-libs/boost[threads]
 			!libressl? ( dev-libs/openssl:0[-bindist] )
-			libressl? ( dev-libs/libressl >=dev-libs/boost-1.65 )
+			libressl? ( dev-libs/libressl:0
+						>=dev-libs/boost-1.65 )
+			sys-libs/zlib
 			upnp? ( net-libs/miniupnpc )
 		)"
 DEPEND="${RDEPEND}
 	static? ( dev-libs/boost[static-libs,threads]
 		!libressl? ( dev-libs/openssl:0[static-libs] )
-		libressl? ( dev-libs/libressl[static-libs] >=dev-libs/boost-1.65 )
+		libressl? ( dev-libs/libressl:0[static-libs]
+					>=dev-libs/boost-1.65 )
+		sys-libs/zlib[static-libs]
 		upnp? ( net-libs/miniupnpc[static-libs] ) )
+	websocket? ( dev-cpp/websocketpp )
 	i2p-hardening? ( >=sys-devel/gcc-4.7 )
 	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"
 
@@ -39,9 +44,10 @@ src_configure() {
 	mycmakeargs=(
 		-DWITH_AESNI=$(usex cpu_flags_x86_aes ON OFF)
 		-DWITH_HARDENING=$(usex i2p-hardening ON OFF)
-		-DWITH_PCH=$(usex pch ON OFF)
+		-DWITH_PCH=OFF
 		-DWITH_STATIC=$(usex static ON OFF)
 		-DWITH_UPNP=$(usex upnp ON OFF)
+		-DWITH_WEBSOCKETS=$(usex websocket ON OFF)
 		-DWITH_LIBRARY=ON
 		-DWITH_BINARY=ON
 	)

--- a/net-vpn/i2pd/i2pd-2.15.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.15.0.ebuild
@@ -15,15 +15,19 @@ IUSE="cpu_flags_x86_aes i2p-hardening libressl static +upnp websocket"
 # if using libressl, require >=boost-1.65, see #597798
 RDEPEND="!static? ( dev-libs/boost[threads]
 			!libressl? ( dev-libs/openssl:0[-bindist] )
-			libressl? ( dev-libs/libressl >=dev-libs/boost-1.65 )
+			libressl? ( dev-libs/libressl:0
+						>=dev-libs/boost-1.65 )
+			sys-libs/zlib
 			upnp? ( net-libs/miniupnpc )
-			websocket? ( dev-cpp/websocketpp )
 		)"
 DEPEND="${RDEPEND}
 	static? ( dev-libs/boost[static-libs,threads]
 		!libressl? ( dev-libs/openssl:0[static-libs] )
-		libressl? ( dev-libs/libressl[static-libs] >=dev-libs/boost-1.65 )
+		libressl? ( dev-libs/libressl:0[static-libs]
+					>=dev-libs/boost-1.65 )
+		sys-libs/zlib[static-libs]
 		upnp? ( net-libs/miniupnpc[static-libs] ) )
+	websocket? ( dev-cpp/websocketpp )
 	i2p-hardening? ( >=sys-devel/gcc-4.7 )
 	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"
 

--- a/net-vpn/i2pd/i2pd-2.15.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.15.0.ebuild
@@ -12,16 +12,17 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE="cpu_flags_x86_aes i2p-hardening libressl static +upnp websocket"
 
-RDEPEND="!static? ( >=dev-libs/boost-1.49[threads]
+# if using libressl, require >=boost-1.65, see #597798
+RDEPEND="!static? ( dev-libs/boost[threads]
 			!libressl? ( dev-libs/openssl:0[-bindist] )
-			libressl? ( dev-libs/libressl )
+			libressl? ( dev-libs/libressl >=dev-libs/boost-1.65 )
 			upnp? ( net-libs/miniupnpc )
 			websocket? ( dev-cpp/websocketpp )
 		)"
 DEPEND="${RDEPEND}
-	static? ( >=dev-libs/boost-1.49[static-libs,threads]
+	static? ( dev-libs/boost[static-libs,threads]
 		!libressl? ( dev-libs/openssl:0[static-libs] )
-		libressl? ( dev-libs/libressl[static-libs] )
+		libressl? ( dev-libs/libressl[static-libs] >=dev-libs/boost-1.65 )
 		upnp? ( net-libs/miniupnpc[static-libs] ) )
 	i2p-hardening? ( >=sys-devel/gcc-4.7 )
 	|| ( >=sys-devel/gcc-4.7 >=sys-devel/clang-3.3 )"


### PR DESCRIPTION
i2pd had a building problem with libressl:
https://bugs.gentoo.org/597798
https://github.com/PurpleI2P/i2pd/issues/686

The issue was a boost/asio problem, which has been fixed in boost-1.65. This PR adds a requirement for >=boost-1.65 in case of using libressl.