### PR TITLE
app-admin/socklog: Bump to EAPI=6 Gentoo-Bug: 618574

### DIFF
--- a/app-admin/socklog/socklog-2.1.0.ebuild
+++ b/app-admin/socklog/socklog-2.1.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="3"
+EAPI=6
 
 inherit eutils toolchain-funcs flag-o-matic
 
@@ -16,20 +16,22 @@ IUSE="static"
 
 RDEPEND=">=sys-process/runit-1.4.0"
 
+PATCHES=( "${FILESDIR}"/${PN}-2.1.0-headers.patch )
+
 S=${WORKDIR}/admin/${P}/src
 
 src_prepare() {
-	epatch "${FILESDIR}"/${PN}-2.1.0-headers.patch
+	default
 	use static && append-ldflags -static
-	echo "$(tc-getCC) ${CFLAGS} ${CPPFLAGS}" > conf-cc
-	echo "$(tc-getCC) ${CFLAGS} ${LDFLAGS}" > conf-ld
+	echo "$(tc-getCC) ${CFLAGS} ${CPPFLAGS}" > conf-cc || die
+	echo "$(tc-getCC) ${CFLAGS} ${LDFLAGS}" > conf-ld || die
 }
 
 src_install() {
-	dobin tryto uncat socklog-check || die
-	dosbin socklog socklog-conf || die
+	dobin tryto uncat socklog-check
+	dosbin socklog socklog-conf
 
-	cd ..
+	cd .. || die
 	dodoc package/CHANGES
 	dohtml doc/*.html
 	doman man/*


### PR DESCRIPTION
Should resolve https://bugs.gentoo.org/618574

Package-Manager: Portage-2.3.10, Repoman-2.3.3