### PR TITLE
sys-kernel/genkernel-next: Fix ZFS on LUKS #549736

### DIFF
--- a/sys-kernel/genkernel-next/files/68-fix-zfs-on-luks.patch
+++ b/sys-kernel/genkernel-next/files/68-fix-zfs-on-luks.patch
@@ -1,0 +1,20 @@
+diff --git a/defaults/linuxrc b/defaults/linuxrc
+index 1fd6155..d6da2c4 100755
+--- a/defaults/linuxrc
++++ b/defaults/linuxrc
+@@ -295,13 +295,14 @@ start_iscsi
+ sdelay
+ 
+ start_volumes
+-zfs_start_volumes
+ 
+ setup_keymap
+ 
+ # Initialize LUKS root device except for livecd's
+ is_livecd || start_luks
+ 
++zfs_start_volumes
++
+ # Initialize resume from hibernation
+ is_livecd || resume_init
+

--- a/sys-kernel/genkernel-next/genkernel-next-68-r1.ebuild
+++ b/sys-kernel/genkernel-next/genkernel-next-68-r1.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+SRC_URI="https://github.com/Sabayon/genkernel-next/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~x86"
+inherit bash-completion-r1
+inherit eutils
+
+DESCRIPTION="Gentoo automatic kernel building scripts, reloaded"
+HOMEPAGE="https://www.gentoo.org/"
+
+LICENSE="GPL-2"
+SLOT="0"
+
+IUSE="cryptsetup dmraid gpg iscsi mdadm plymouth selinux"
+DOCS=( AUTHORS )
+
+DEPEND="app-text/asciidoc
+	sys-fs/e2fsprogs
+	!sys-fs/eudev[-kmod,modutils]
+	selinux? ( sys-libs/libselinux )"
+RDEPEND="${DEPEND}
+	!sys-kernel/genkernel
+	cryptsetup? ( sys-fs/cryptsetup )
+	dmraid? ( >=sys-fs/dmraid-1.0.0_rc16 )
+	gpg? ( app-crypt/gnupg )
+	iscsi? ( sys-block/open-iscsi )
+	mdadm? ( sys-fs/mdadm )
+	plymouth? ( sys-boot/plymouth )
+	app-portage/portage-utils
+	app-arch/cpio
+	>=app-misc/pax-utils-0.6
+	!<sys-apps/openrc-0.9.9
+	sys-apps/util-linux
+	sys-block/thin-provisioning-tools
+	sys-fs/lvm2"
+
+src_prepare() {
+	default
+	epatch "${FILESDIR}/${PV}-fix-zfs-on-luks.patch"
+	sed -i "/^GK_V=/ s:GK_V=.*:GK_V=${PV}:g" "${S}/genkernel" || \
+		die "Could not setup release"
+}
+
+src_install() {
+	default
+
+	doman "${S}"/genkernel.8
+
+	newbashcomp "${S}"/genkernel.bash genkernel
+}


### PR DESCRIPTION
This patch fixes the usage of ZFS on LUKS by swapping the ordering of "zfs_start_volumes" and "start_luks" so that ZFS pools can be imported from LUKS-encrypted drives.

Previously, the pool would be imported before the disk was unlocked.