### PR TITLE
media-gfx/fim: Fix building with GCC-6

### DIFF
--- a/media-gfx/fim/files/fim-0.4_rc3-gcc6.patch
+++ b/media-gfx/fim/files/fim-0.4_rc3-gcc6.patch
@@ -1,0 +1,44 @@
+Bug: https://bugs.gentoo.org/595832
+Commit: http://svn.savannah.gnu.org/viewvc/fbi-improved?view=revision&revision=735
+
+--- a/src/fim.cpp
++++ b/src/fim.cpp
+@@ -114,7 +114,7 @@
+     {"device",     required_argument, NULL, 'd',"specify a {framebuffer device}","{framebuffer device}",
+ "Framebuffer device to use. Default is the one your vc is mapped to (as in fbi)."
+     },
+-    {"dump-reference-help",      optional_argument /*no_argument*/,       NULL, 0xd15cbab3,"dump reference info","[=man]",
++    {"dump-reference-help",      optional_argument /*no_argument*/,       NULL, 0x6472690a,"dump reference info","[=man]",
+ "Will dump to stdout the language reference help."
+     },
+     {"dump-default-fimrc",      no_argument,       NULL, 'D',"dump on standard output the default configuration",NULL,
+@@ -182,7 +182,7 @@
+ /* FIXME: shall document this */
+ #endif /* FIM_WITH_LIBIMLIB2 */
+     },
+-    {"offset",      required_argument,       NULL,  0xFFD8FFE0,"will open the first image file at the specified offset","{bytes-offset}",
++    {"offset",      required_argument,       NULL,  0x6f66660a, "will open the first image file at the specified offset","{bytes-offset}",
+ "Will use the specified \\fBoffset\\fP (in bytes) for opening the specified files (useful for viewing images on damaged file systems; however, since the internal variables representation is sizeof(int) bytes based, you have a limited offset range: using already chopped image files may be a workaround to this limitation)."
+     },/* NEW */
+     {"text-reading",      no_argument,       NULL, 'P',"proceed scrolling as reading through a text document",NULL,
+@@ -979,9 +979,8 @@
+ 		    cc.pre_autocmd_add(FIM_VID_SCALE_STYLE"='1';" "autocmd \"" FIM_ACM_POSTSCALE "\" \"\" \"" FIM_FLT_DISPLAY "'resize';\";");
+ 	#endif /* FIM_AUTOCMDS */
+ 		    break;
+-		case 0xFFD8FFE0:
+-		    //fbi's
+-	 	    // NEW
++		case 0x6f66660a:
++		    //fim's
+ 	#ifdef FIM_AUTOCMDS
+ 		{
+ 			int ipeppe_offset;
+@@ -1191,7 +1190,7 @@
+ 			}
+ #endif /* FIM_WANT_OUTPUT_DEVICE_STRING_CASE_INSENSITIVE */
+ 		    break;
+-		case 0xd15cbab3:
++		case 0x6472690a:
+ 		    //fim's
+ 		{
+ 			args_t args;

--- a/media-gfx/fim/fim-0.4_rc3-r2.ebuild
+++ b/media-gfx/fim/fim-0.4_rc3-r2.ebuild
@@ -39,6 +39,7 @@ S=${WORKDIR}/${P/_rc/-rc}
 
 src_prepare() {
 	epatch "${FILESDIR}/${P}-poppler031.patch"
+	epatch "${FILESDIR}/${PN}-0.4_rc3-gcc6.patch"
 }
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/595832
Package-Manager: Portage-2.3.10, Repoman-2.3.3

Patch taken from [upstream revision 735](http://svn.savannah.gnu.org/viewvc/fbi-improved?view=revision&revision=735).