### PR TITLE
dev-games/clanlib: Fix building with GCC-6

### DIFF
--- a/dev-games/clanlib/clanlib-0.8.1.ebuild
+++ b/dev-games/clanlib/clanlib-0.8.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -40,6 +40,7 @@ src_prepare() {
 		"${FILESDIR}"/${P}-gcc43.patch \
 		"${FILESDIR}"/${P}-gcc44.patch \
 		"${FILESDIR}"/${P}-gcc47.patch \
+		"${FILESDIR}"/${P}-gcc6.patch \
 		"${FILESDIR}"/${P}-libpng15.patch
 }
 

--- a/dev-games/clanlib/files/clanlib-0.8.1-gcc6.patch
+++ b/dev-games/clanlib/files/clanlib-0.8.1-gcc6.patch
@@ -1,0 +1,16 @@
+Bug: https://bugs.gentoo.org/596112
+
+--- a/Sources/Core/IOData/Generic/datafile_inputprovider.h
++++ b/Sources/Core/IOData/Generic/datafile_inputprovider.h
+@@ -142,9 +142,9 @@
+ 		void insert(const std::string &resource_id, int data_pos, int data_size)
+ 		{
+ 			cache.insert(
+-				std::make_pair<std::string const, std::pair<int, int> >(
++				std::pair<std::string const, std::pair<int, int> >(
+ 				resource_id,
+-				std::make_pair<int,int>(data_pos, data_size)));
++				std::pair<int,int>(data_pos, data_size)));
+ 		}
+ 
+ 	private:


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/596112
Package-Manager: Portage-2.3.10, Repoman-2.3.3

`std::make_pair` has changed in C++11/14 in that it takes its arguments by forwarding reference instead of by value and and applies `std::decay`.  This is not usually a problem but with full template specialization as well, the types of template arguments and types of function arguments become very dependent on one another.

But full template specialization defeats the purpose of using `std::make_pair` , as it only exists for automatic argument deduction AFAIK.   One might as well use `std::pair` directly, so that is what I did.

Tested with GCC-6.4.0 and GCC-5.4.0.

Upstream has since refactored the code.