### PR TITLE
media-libs/opensubdiv: Ebuild and metadata fixes

### DIFF
--- a/media-libs/opensubdiv/metadata.xml
+++ b/media-libs/opensubdiv/metadata.xml
@@ -33,8 +33,6 @@
 			Enable OpenCL support through
 			<pkg>virtual/opencl</pkg>.
 		</flag>
-		<flag name="tutorials">
-		</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">PixarAnimationStudios/OpenSubdiv</remote-id>

--- a/media-libs/opensubdiv/opensubdiv-3.1.0.ebuild
+++ b/media-libs/opensubdiv/opensubdiv-3.1.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${MY_PV}.t
 
 LICENSE="ZLIB"
 SLOT="0"
-IUSE="cuda doc examples opencl openmp ptex tbb test tutorials"
+IUSE="cuda doc opencl openmp ptex tbb test"
 
 RDEPEND="media-libs/glew:=
 	media-libs/glfw:=
@@ -49,8 +49,8 @@ src_configure() {
 		-DNO_OPENCL=$(usex !opencl)
 		-DNO_CUDA=$(usex !cuda)
 		-DNO_REGRESSION=$(usex !test)
-		-DNO_EXAMPLES=$(usex !examples)
-		-DNO_TUTORIALS=$(usex !tutorials)
+		-DNO_EXAMPLES=1 # broken
+		-DNO_TUTORIALS=1 # broken
 		-DGLEW_LOCATION="${EPREFIX}/usr/$(get_libdir)"
 		-DGLFW_LOCATION="${EPREFIX}/usr/$(get_libdir)"
 	)

--- a/media-libs/opensubdiv/opensubdiv-3.1.1.ebuild
+++ b/media-libs/opensubdiv/opensubdiv-3.1.1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${MY_PV}.t
 
 LICENSE="ZLIB"
 SLOT="0"
-IUSE="cuda doc examples opencl openmp ptex tbb tutorials"
+IUSE="cuda doc opencl openmp ptex tbb"
 
 RDEPEND="media-libs/glew:=
 	media-libs/glfw:=
@@ -54,8 +54,8 @@ src_configure() {
 		-DNO_OPENCL=$(usex !opencl)
 		-DNO_CUDA=$(usex !cuda)
 		-DNO_REGRESSION=1 # The don't work with certain settings
-		-DNO_EXAMPLES=$(usex !examples)
-		-DNO_TUTORIALS=$(usex !tutorials)
+		-DNO_EXAMPLES=1 # Broken
+		-DNO_TUTORIALS=1 # Broken
 		-DGLEW_LOCATION="${EPREFIX}/usr/$(get_libdir)"
 		-DGLFW_LOCATION="${EPREFIX}/usr/$(get_libdir)"
 	)

--- a/media-libs/opensubdiv/opensubdiv-3.3.0.ebuild
+++ b/media-libs/opensubdiv/opensubdiv-3.3.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${MY_PV}.t
 LICENSE="ZLIB"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="cuda doc examples opencl openmp ptex tbb tutorials"
+IUSE="cuda doc opencl openmp ptex tbb"
 
 RDEPEND="media-libs/glew:=
 	media-libs/glfw:=
@@ -21,7 +21,7 @@ RDEPEND="media-libs/glew:=
 
 DEPEND="${RDEPEND}
 	tbb? ( dev-cpp/tbb )
-	doc? ( 
+	doc? (
 		dev-python/docutils
 		app-doc/doxygen
 	)"
@@ -52,8 +52,8 @@ src_configure() {
 		-DNO_OPENCL=$(usex !opencl)
 		-DNO_CUDA=$(usex !cuda)
 		-DNO_REGRESSION=1 # They don't work with certain settings
-		-DNO_EXAMPLES=$(usex !examples)
-		-DNO_TUTORIALS=$(usex !tutorials)
+		-DNO_EXAMPLES=1 # Not needed.
+		-DNO_TUTORIALS=1 # They install illegally. Need to find a better solution.
 		-DGLEW_LOCATION="${EPREFIX}/usr/$(get_libdir)"
 		-DGLFW_LOCATION="${EPREFIX}/usr/$(get_libdir)"
 		-DCMAKE_INSTALL_DOCDIR="share/doc/${PF}"

--- a/media-libs/opensubdiv/opensubdiv-3.3.0.ebuild
+++ b/media-libs/opensubdiv/opensubdiv-3.3.0.ebuild
@@ -17,6 +17,7 @@ IUSE="cuda doc opencl openmp ptex tbb"
 RDEPEND="media-libs/glew:=
 	media-libs/glfw:=
 	cuda? ( dev-util/nvidia-cuda-toolkit:* )
+	opencl? ( virtual/opencl )
 	ptex? ( media-libs/ptex )"
 
 DEPEND="${RDEPEND}


### PR DESCRIPTION
* Complete the description of the tutorial use flag.
* Add in virtual opencl depend
* Remove examples and tutorials as they violate installation
  location rules.

Note: The opencl use flag is masked, so there is no need for a revision update. This is in prep for the use flag being unmasked at a later date.

Closes: https://bugs.gentoo.org/633756