### PR TITLE
media-sound/qmmp: rebuild if version of Qt-5 changes.

### DIFF
--- a/media-sound/qmmp/qmmp-1.1.10.ebuild
+++ b/media-sound/qmmp/qmmp-1.1.10.ebuild
@@ -26,11 +26,11 @@ pulseaudio qsui qtmedia scrobbler sid sndfile soxr stereo tray udisks +vorbis wa
 REQUIRED_USE="gnome? ( dbus ) udisks? ( dbus )"
 
 RDEPEND="
-	dev-qt/qtcore:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	dev-qt/qtcore:5=
+	dev-qt/qtgui:5=
+	dev-qt/qtnetwork:5=
+	dev-qt/qtwidgets:5=
+	dev-qt/qtx11extras:5=
 	media-libs/taglib
 	x11-libs/libX11
 	aac? ( media-libs/faad2 )
@@ -42,7 +42,7 @@ RDEPEND="
 	)
 	cue? ( media-libs/libcue )
 	curl? ( net-misc/curl )
-	dbus? ( dev-qt/qtdbus:5 )
+	dbus? ( dev-qt/qtdbus:5= )
 	enca? ( app-i18n/enca )
 	ffmpeg? (
 		!libav? ( media-video/ffmpeg:= )
@@ -63,12 +63,12 @@ RDEPEND="
 	musepack? ( >=media-sound/musepack-tools-444 )
 	opus? ( media-libs/opusfile )
 	projectm? (
-		dev-qt/qtgui:5[-gles2]
-		dev-qt/qtopengl:5
+		dev-qt/qtgui:5=[-gles2]
+		dev-qt/qtopengl:5=
 		media-libs/libprojectm
 	)
 	pulseaudio? ( >=media-sound/pulseaudio-0.9.9 )
-	qtmedia? ( dev-qt/qtmultimedia:5 )
+	qtmedia? ( dev-qt/qtmultimedia:5= )
 	scrobbler? ( net-misc/curl )
 	sndfile? ( media-libs/libsndfile )
 	sid? ( >=media-libs/libsidplayfp-1.1.0 )
@@ -81,7 +81,7 @@ RDEPEND="
 	wavpack? ( media-sound/wavpack )
 "
 DEPEND="${RDEPEND}
-	dev-qt/linguist-tools:5
+	dev-qt/linguist-tools:5=
 "
 
 DOCS=( AUTHORS ChangeLog README )

--- a/media-sound/qmmp/qmmp-1.1.7-r1.ebuild
+++ b/media-sound/qmmp/qmmp-1.1.7-r1.ebuild
@@ -24,11 +24,11 @@ jack ladspa libav lyrics +mad midi mms modplug mplayer musepack notifier opus os
 pulseaudio qsui qtmedia scrobbler sid sndfile soxr stereo tray udisks +vorbis wavpack"
 
 RDEPEND="
-	dev-qt/qtcore:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	dev-qt/qtcore:5=
+	dev-qt/qtgui:5=
+	dev-qt/qtnetwork:5=
+	dev-qt/qtwidgets:5=
+	dev-qt/qtx11extras:5=
 	media-libs/taglib
 	x11-libs/libX11
 	aac? ( media-libs/faad2 )
@@ -40,7 +40,7 @@ RDEPEND="
 	)
 	cue? ( media-libs/libcue )
 	curl? ( net-misc/curl )
-	dbus? ( dev-qt/qtdbus:5 )
+	dbus? ( dev-qt/qtdbus:5= )
 	enca? ( app-i18n/enca )
 	ffmpeg? (
 		!libav? ( media-video/ffmpeg:= )
@@ -61,12 +61,12 @@ RDEPEND="
 	musepack? ( >=media-sound/musepack-tools-444 )
 	opus? ( media-libs/opusfile )
 	projectm? (
-		dev-qt/qtgui:5[-gles2]
-		dev-qt/qtopengl:5
+		dev-qt/qtgui:5=[-gles2]
+		dev-qt/qtopengl:5=
 		media-libs/libprojectm
 	)
 	pulseaudio? ( >=media-sound/pulseaudio-0.9.9 )
-	qtmedia? ( dev-qt/qtmultimedia:5 )
+	qtmedia? ( dev-qt/qtmultimedia:5= )
 	scrobbler? ( net-misc/curl )
 	sndfile? ( media-libs/libsndfile )
 	sid? ( >=media-libs/libsidplayfp-1.1.0 )
@@ -79,7 +79,7 @@ RDEPEND="
 	wavpack? ( media-sound/wavpack )
 "
 DEPEND="${RDEPEND}
-	dev-qt/linguist-tools:5
+	dev-qt/linguist-tools:5=
 "
 
 DOCS=( AUTHORS ChangeLog README )

--- a/media-sound/qmmp/qmmp-1.1.9.ebuild
+++ b/media-sound/qmmp/qmmp-1.1.9.ebuild
@@ -26,11 +26,11 @@ pulseaudio qsui qtmedia scrobbler sid sndfile soxr stereo tray udisks +vorbis wa
 REQUIRED_USE="gnome? ( dbus ) udisks? ( dbus )"
 
 RDEPEND="
-	dev-qt/qtcore:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	dev-qt/qtcore:5=
+	dev-qt/qtgui:5=
+	dev-qt/qtnetwork:5=
+	dev-qt/qtwidgets:5=
+	dev-qt/qtx11extras:5=
 	media-libs/taglib
 	x11-libs/libX11
 	aac? ( media-libs/faad2 )
@@ -42,7 +42,7 @@ RDEPEND="
 	)
 	cue? ( media-libs/libcue )
 	curl? ( net-misc/curl )
-	dbus? ( dev-qt/qtdbus:5 )
+	dbus? ( dev-qt/qtdbus:5= )
 	enca? ( app-i18n/enca )
 	ffmpeg? (
 		!libav? ( media-video/ffmpeg:= )
@@ -63,12 +63,12 @@ RDEPEND="
 	musepack? ( >=media-sound/musepack-tools-444 )
 	opus? ( media-libs/opusfile )
 	projectm? (
-		dev-qt/qtgui:5[-gles2]
-		dev-qt/qtopengl:5
+		dev-qt/qtgui:5=[-gles2]
+		dev-qt/qtopengl:5=
 		media-libs/libprojectm
 	)
 	pulseaudio? ( >=media-sound/pulseaudio-0.9.9 )
-	qtmedia? ( dev-qt/qtmultimedia:5 )
+	qtmedia? ( dev-qt/qtmultimedia:5= )
 	scrobbler? ( net-misc/curl )
 	sndfile? ( media-libs/libsndfile )
 	sid? ( >=media-libs/libsidplayfp-1.1.0 )
@@ -81,7 +81,7 @@ RDEPEND="
 	wavpack? ( media-sound/wavpack )
 "
 DEPEND="${RDEPEND}
-	dev-qt/linguist-tools:5
+	dev-qt/linguist-tools:5=
 "
 
 DOCS=( AUTHORS ChangeLog README )

--- a/media-sound/qmmp/qmmp-9999.ebuild
+++ b/media-sound/qmmp/qmmp-9999.ebuild
@@ -26,11 +26,11 @@ pulseaudio qsui qtmedia scrobbler sid sndfile soxr stereo tray udisks +vorbis wa
 REQUIRED_USE="gnome? ( dbus ) udisks? ( dbus )"
 
 RDEPEND="
-	dev-qt/qtcore:5
-	dev-qt/qtgui:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
+	dev-qt/qtcore:5=
+	dev-qt/qtgui:5=
+	dev-qt/qtnetwork:5=
+	dev-qt/qtwidgets:5=
+	dev-qt/qtx11extras:5=
 	media-libs/taglib
 	x11-libs/libX11
 	aac? ( media-libs/faad2 )
@@ -42,7 +42,7 @@ RDEPEND="
 	)
 	cue? ( media-libs/libcue )
 	curl? ( net-misc/curl )
-	dbus? ( dev-qt/qtdbus:5 )
+	dbus? ( dev-qt/qtdbus:5= )
 	enca? ( app-i18n/enca )
 	ffmpeg? (
 		!libav? ( media-video/ffmpeg:= )
@@ -63,12 +63,12 @@ RDEPEND="
 	musepack? ( >=media-sound/musepack-tools-444 )
 	opus? ( media-libs/opusfile )
 	projectm? (
-		dev-qt/qtgui:5[-gles2]
-		dev-qt/qtopengl:5
+		dev-qt/qtgui:5=[-gles2]
+		dev-qt/qtopengl:5=
 		media-libs/libprojectm
 	)
 	pulseaudio? ( >=media-sound/pulseaudio-0.9.9 )
-	qtmedia? ( dev-qt/qtmultimedia:5 )
+	qtmedia? ( dev-qt/qtmultimedia:5= )
 	scrobbler? ( net-misc/curl )
 	sndfile? ( media-libs/libsndfile )
 	sid? ( >=media-libs/libsidplayfp-1.1.0 )
@@ -81,7 +81,7 @@ RDEPEND="
 	wavpack? ( media-sound/wavpack )
 "
 DEPEND="${RDEPEND}
-	dev-qt/linguist-tools:5
+	dev-qt/linguist-tools:5=
 "
 
 DOCS=( AUTHORS ChangeLog README )


### PR DESCRIPTION
After upgrade from Qt-5.7.2 to Qt-5.9.2 global hotkeys plugin for qmmp stopped working. Rebuilding qmmp fixed issue for me. I think it might be a good idea to automate rebuild of qmmp on Qt-5 major version update.