### PR TITLE
net-misc/bopm: Fix security bug with pid file

### DIFF
--- a/net-misc/bopm/bopm-3.1.3-r4.ebuild
+++ b/net-misc/bopm/bopm-3.1.3-r4.ebuild
@@ -20,6 +20,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${P}-remove-njabl.patch
 	"${FILESDIR}"/${P}-autotools.patch
+	"${FILESDIR}"/${P}-quarantine-bad-pid-file.patch
 )
 
 pkg_setup() {
@@ -52,7 +53,7 @@ src_install() {
 	# If anybody wants libopm, please install net-libs/libopm
 	rm -r "${ED}"usr/$(get_libdir) "${ED}"usr/include || die
 
-	newinitd "${FILESDIR}"/bopm.init.d-r1 ${PN}
+	newinitd "${FILESDIR}"/bopm.init.d-r2 ${PN}
 	newconfd "${FILESDIR}"/bopm.conf.d-r1 ${PN}
 
 	dodir /var/log/bopm

--- a/net-misc/bopm/files/bopm-3.1.3-quarantine-bad-pid-file.patch
+++ b/net-misc/bopm/files/bopm-3.1.3-quarantine-bad-pid-file.patch
@@ -1,0 +1,16 @@
+Bopm writes its own pid file, but this is handled by the init script via
+openrc-run.
+---
+diff --git a/bopm.conf.sample b/bopm.conf.sample
+index e26dc17..fa5ce1d 100644
+--- a/bopm.conf.sample
++++ b/bopm.conf.sample
+@@ -9,7 +9,7 @@ options {
+ 	 * Full path and filename for storing the process ID of the running
+ 	 * BOPM.
+ 	 */
+-	pidfile = "/run/bopm/bopm.pid";
++	pidfile = "/run/bopm/junk/bopm.pid";
+ 
+ 	/*
+ 	 * How many seconds to store the IP address of hosts which are

--- a/net-misc/bopm/files/bopm.init.d-r2
+++ b/net-misc/bopm/files/bopm.init.d-r2
@@ -12,5 +12,7 @@ depend() {
 }
 
 start_pre() {
-	checkpath -o ${BOPM_UID} -d "$(dirname "${PIDFILE}")"
+	checkpath -o 0:0 -d /run/bopm
+	checkpath -o ${BOPM_UID} -d /run/bopm/junk
+	checkpath -o ${BOPM_UID} -f /run/bopm/junk/bopm.pid
 }


### PR DESCRIPTION
In theory, someone who explots a hacked bopm could then use it to
attack root owned processes.

This puts the bopm-written PID file into a disposable junk directory
and lets start-stop-daemon do all the grunt work.

Closes: https://bugs.gentoo.org/631882