### PR TITLE
profiles/use.desc: Improve "xinerama" description

### DIFF
--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -383,7 +383,7 @@ xemacs - Add support for XEmacs
 xface - Add xface support used to allow a small image of xface format to be included in an email via the header 'X-Face'
 xft - Build with support for XFT font renderer (x11-libs/libXft)
 xine - Add support for the XINE movie libraries
-xinerama - Add support for the xinerama X11 extension, which is mandatory if you work in multiple monitors setup
+xinerama - Add support for the (legacy) xinerama X11 extension
 xinetd - Add support for the xinetd super-server
 xml - Add support for XML files
 xmlrpc - Support for xml-rpc library


### PR DESCRIPTION
Remove the misleading "…is mandatory if you work in multiple monitors
setup", which hasn't been true since a while. Modern X systems do not
require Xinerama for mulithead any more. Therefore add a hint that it is a
legacy extension.

https://bugs.gentoo.org/634182