### PR TITLE
meson.eclass: include pkg-config in the cross file

### DIFF
--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -125,6 +125,7 @@ _meson_create_cross_file() {
 	ar = '${AR}'
 	c = '${CC}'
 	cpp = '${CXX}'
+	pkgconfig = '${PKG_CONFIG}'
 	strip = '${STRIP}'
 
 	[host_machine]
@@ -155,6 +156,7 @@ meson_src_configure() {
 	local -x AR=$(tc-getAR)
 	local -x CC=$(tc-getCC)
 	local -x CXX=$(tc-getCXX)
+	local -x PKG_CONFIG=$(tc-getPKG_CONFIG)
 	local -x STRIP=$(tc-getSTRIP)
 
 	if tc-is-cross-compiler; then
@@ -166,6 +168,7 @@ meson_src_configure() {
 		AR=$(tc-getBUILD_AR)
 		CC=$(tc-getBUILD_CC)
 		CXX=$(tc-getBUILD_CXX)
+		PKG_CONFIG=$(tc-getBUILD_PKG_CONFIG)
 		STRIP=$(tc-getBUILD_STRIP)
 	fi
 


### PR DESCRIPTION
This fixes cross-compiling current systemd.