### PR TITLE
dev-python/pypy: add missing build-time dependencies for v5.7.1+

### DIFF
--- a/dev-python/pypy/pypy-5.7.1.ebuild
+++ b/dev-python/pypy/pypy-5.7.1.ebuild
@@ -39,6 +39,7 @@ RDEPEND=">=sys-libs/zlib-1.1.3:0=
 DEPEND="${RDEPEND}
 	doc? ( dev-python/sphinx )
 	${PYTHON_DEPS}
+	dev-python/pycparser
 	test? ( dev-python/pytest )"
 
 S="${WORKDIR}/${MY_P}-src"

--- a/dev-python/pypy/pypy-5.8.0.ebuild
+++ b/dev-python/pypy/pypy-5.8.0.ebuild
@@ -39,6 +39,7 @@ RDEPEND=">=sys-libs/zlib-1.1.3:0=
 DEPEND="${RDEPEND}
 	doc? ( dev-python/sphinx )
 	${PYTHON_DEPS}
+	dev-python/pycparser
 	test? ( dev-python/pytest )"
 
 S="${WORKDIR}/${MY_P}-src"

--- a/dev-python/pypy/pypy-5.9.0.ebuild
+++ b/dev-python/pypy/pypy-5.9.0.ebuild
@@ -39,6 +39,7 @@ RDEPEND=">=sys-libs/zlib-1.1.3:0=
 DEPEND="${RDEPEND}
 	doc? ( dev-python/sphinx )
 	${PYTHON_DEPS}
+	dev-python/pycparser
 	test? ( dev-python/pytest )"
 
 S="${WORKDIR}/${MY_P}-src"

--- a/dev-python/pypy/pypy-9999.ebuild
+++ b/dev-python/pypy/pypy-9999.ebuild
@@ -40,6 +40,7 @@ RDEPEND=">=sys-libs/zlib-1.1.3:0=
 DEPEND="${RDEPEND}
 	doc? ( dev-python/sphinx )
 	${PYTHON_DEPS}
+	dev-python/pycparser
 	test? ( dev-python/pytest )"
 
 S="${WORKDIR}/${MY_P}-src"


### PR DESCRIPTION
PyPy seems to require pycparser for build since v5.7.1, as without it the build fails almost immediately. v5.6.0 does not exhibit such behavior, although I've only gotten a few minutes into its build.