### PR TITLE
x11-wm/i3: Fix dependency on virtualx deps and source of man pages

### DIFF
--- a/x11-wm/i3/i3-4.14.1.ebuild
+++ b/x11-wm/i3/i3-4.14.1.ebuild
@@ -5,8 +5,6 @@ EAPI=6
 
 AEVER=0.17
 
-VIRTUALX_REQUIRED=always
-
 inherit autotools virtualx
 
 DESCRIPTION="An improved dynamic tiling window manager"
@@ -101,7 +99,7 @@ src_compile() {
 
 src_install() {
 	emake -C "${CBUILD}" DESTDIR="${D}" install
-	doman "${CBUILD}"/man/*.1
+	doman "${S}"/man/*.1
 
 	use doc && einstalldocs
 


### PR DESCRIPTION
For 4.14 the VCS tarball had to be used, which doesn't contain the man
pages, after switching back to the dist tarballs for 4.14.1 install
source of man pages wasn't updated.
https://bugs.gentoo.org/634282

The virtualx eclass was set to always add the dependencies, which was
left over from debugging.
https://github.com/gentoo/gentoo/pull/5879#issuecomment-336597437

Package-Manager: Portage-2.3.11, Repoman-2.3.3