### PR TITLE
games-roguelike/powder: Fix building with GCC-6

### DIFF
--- a/games-roguelike/powder/files/powder-117-gcc6.patch
+++ b/games-roguelike/powder/files/powder-117-gcc6.patch
@@ -1,0 +1,20 @@
+Bug: https://bugs.gentoo.org/598928
+
+--- a/source.txt
++++ b/source.txt
+@@ -13400,13 +13400,13 @@
+ 
+ BRANCH MAIN
+ {
+-    symbol	'\\207'
++    symbol	static_cast<u8>('\\207')
+     welcome	"%U <return> to the main dungeon."
+ }
+ 
+ BRANCH TRIDUDE
+ {
+-    symbol	'\\211'
++    symbol	static_cast<u8>('\\211')
+     welcome	"%U <enter> a cave made of metal."
+ }
+ 

--- a/games-roguelike/powder/powder-117-r1.ebuild
+++ b/games-roguelike/powder/powder-117-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -19,6 +19,8 @@ DEPEND="media-libs/libsdl[video]"
 RDEPEND=${DEPEND}
 
 S=${WORKDIR}/${MY_P}
+
+PATCHES=( "${FILESDIR}"/${PN}-117-gcc6.patch )
 
 src_compile() {
 	append-cxxflags -DCHANGE_WORK_DIRECTORY


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/598928
Package-Manager: Portage-2.3.10, Repoman-2.3.3

Fixes a simple narrowing conversion in a brace initialization in a file used to generate source code.

Dead upstream.