### PR TITLE
sci-physics/thepeg: Fix building with GCC-6

### DIFF
--- a/sci-physics/thepeg/files/thepeg-2.0.4-gcc6.patch
+++ b/sci-physics/thepeg/files/thepeg-2.0.4-gcc6.patch
@@ -1,0 +1,14 @@
+Bug: https://bugs.gentoo.org/599564
+
+--- a/Utilities/UnitIO.h
++++ b/Utilities/UnitIO.h
+@@ -25,6 +25,9 @@
+ 
+ namespace ThePEG {
+ 
++using std::isnan;
++using std::isinf;
++
+ /**
+  * The OUnit< class is used to
+  * facilitate output of unitful numbers to a

--- a/sci-physics/thepeg/thepeg-2.0.4.ebuild
+++ b/sci-physics/thepeg/thepeg-2.0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -37,7 +37,10 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/${MY_P}"
 
-PATCHES=( "${FILESDIR}"/${PN}-1.8.3-java.patch )
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.8.3-java.patch
+	"${FILESDIR}"/${PN}-2.0.4-gcc6.patch
+)
 
 src_prepare() {
 	find -name 'Makefile.am' -exec \


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/599564
Package-Manager: Portage-2.3.10, Repoman-2.3.3

GCC-6 doesn't implement `math.h` functions as macros anymore.  It does seem to include such symbols in `std` namespace however, even when compiling in c++98 mode.  It suffices to include using declarations for `std::isnan` and `std::isinf` in namespace scope in a header that gets included in the offending source files.   Tested with GCC-6.4.0 and GCC-5.4.0 with `USE="c++11"` and `USE="-c++11"`.