### PR TITLE
media-plugins/vdr-live: Fix building with GCC-6

### DIFF
--- a/media-plugins/vdr-live/files/vdr-live-0.3.0_p20130504-c++11.patch
+++ b/media-plugins/vdr-live/files/vdr-live-0.3.0_p20130504-c++11.patch
@@ -1,0 +1,153 @@
+Bug: https://bugs.gentoo.org/599752
+
+--- a/recman.cpp
++++ b/recman.cpp
+@@ -22,10 +22,10 @@
+ 	/**
+ 	 *  Implementation of class RecordingsManager:
+ 	 */
+-	weak_ptr< RecordingsManager > RecordingsManager::m_recMan;
+-	shared_ptr< RecordingsTree > RecordingsManager::m_recTree;
+-	shared_ptr< RecordingsList > RecordingsManager::m_recList;
+-	shared_ptr< DirectoryList > RecordingsManager::m_recDirs;
++	std::tr1::weak_ptr< RecordingsManager > RecordingsManager::m_recMan;
++	std::tr1::shared_ptr< RecordingsTree > RecordingsManager::m_recTree;
++	std::tr1::shared_ptr< RecordingsList > RecordingsManager::m_recList;
++	std::tr1::shared_ptr< DirectoryList > RecordingsManager::m_recDirs;
+ 	int RecordingsManager::m_recordingsState = 0;
+ 
+ 	// The RecordingsManager holds a VDR lock on the
+@@ -53,7 +53,7 @@
+ 	{
+ 		RecordingsManagerPtr recMan = EnsureValidData();
+ 		if (! recMan) {
+-			return RecordingsTreePtr(recMan, shared_ptr< RecordingsTree >());
++			return RecordingsTreePtr(recMan, std::tr1::shared_ptr< RecordingsTree >());
+ 		}
+ 		return RecordingsTreePtr(recMan, m_recTree);
+ 	}
+@@ -62,25 +62,25 @@
+ 	{
+ 		RecordingsManagerPtr recMan = EnsureValidData();
+ 		if (! recMan) {
+-			return RecordingsListPtr(recMan, shared_ptr< RecordingsList >());
++			return RecordingsListPtr(recMan, std::tr1::shared_ptr< RecordingsList >());
+ 		}
+-		return RecordingsListPtr(recMan, shared_ptr< RecordingsList >(new RecordingsList(m_recList, ascending)));
++		return RecordingsListPtr(recMan, std::tr1::shared_ptr< RecordingsList >(new RecordingsList(m_recList, ascending)));
+ 	}
+ 
+ 	RecordingsListPtr RecordingsManager::GetRecordingsList(time_t begin, time_t end, bool ascending) const
+ 	{
+ 		RecordingsManagerPtr recMan = EnsureValidData();
+ 		if (! recMan) {
+-			return RecordingsListPtr(recMan, shared_ptr< RecordingsList >());
++			return RecordingsListPtr(recMan, std::tr1::shared_ptr< RecordingsList >());
+ 		}
+-		return RecordingsListPtr(recMan, shared_ptr< RecordingsList >(new RecordingsList(m_recList, ascending)));
++		return RecordingsListPtr(recMan, std::tr1::shared_ptr< RecordingsList >(new RecordingsList(m_recList, ascending)));
+ 	}
+ 
+ 	DirectoryListPtr RecordingsManager::GetDirectoryList() const
+ 	{
+ 		RecordingsManagerPtr recMan = EnsureValidData();
+ 		if (!recMan) {
+-			return DirectoryListPtr(recMan, shared_ptr< DirectoryList >());
++			return DirectoryListPtr(recMan, std::tr1::shared_ptr< DirectoryList >());
+ 		}
+ 		return DirectoryListPtr(recMan, m_recDirs);
+ 	}
+@@ -260,21 +264,21 @@
+ 				m_recDirs.reset();
+ 			}
+ 			if (stateChanged || !m_recTree) {
+-				m_recTree = shared_ptr< RecordingsTree >(new RecordingsTree(recMan));
++				m_recTree = std::tr1::shared_ptr< RecordingsTree >(new RecordingsTree(recMan));
+ 			}
+ 			if (!m_recTree) {
+ 				esyslog("[LIVE]: creation of recordings tree failed!");
+ 				return RecordingsManagerPtr();
+ 			}
+ 			if (stateChanged || !m_recList) {
+-				m_recList = shared_ptr< RecordingsList >(new RecordingsList(RecordingsTreePtr(recMan, m_recTree)));
++				m_recList = std::tr1::shared_ptr< RecordingsList >(new RecordingsList(RecordingsTreePtr(recMan, m_recTree)));
+ 			}
+ 			if (!m_recList) {
+ 				esyslog("[LIVE]: creation of recordings list failed!");
+ 				return RecordingsManagerPtr();
+ 			}
+ 			if (stateChanged || !m_recDirs) {
+-				m_recDirs = shared_ptr< DirectoryList >(new DirectoryList(recMan));
++				m_recDirs = std::tr1::shared_ptr< DirectoryList >(new DirectoryList(recMan));
+ 			}
+ 			if (!m_recDirs) {
+ 				esyslog("[LIVE]: creation of directory list failed!");
+@@ -543,13 +547,13 @@
+ 	 *  Implementation of class RecordingsTreePtr:
+ 	 */
+ 	RecordingsTreePtr::RecordingsTreePtr() :
+-		shared_ptr<RecordingsTree>(),
++		std::tr1::shared_ptr<RecordingsTree>(),
+ 		m_recManPtr()
+ 	{
+ 	}
+ 
+ 	RecordingsTreePtr::RecordingsTreePtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< RecordingsTree > recTree) :
+-		shared_ptr<RecordingsTree>(recTree),
++		std::tr1::shared_ptr<RecordingsTree>(recTree),
+ 		m_recManPtr(recManPtr)
+ 	{
+ 	}
+@@ -587,7 +591,7 @@
+ 		}
+ 	}
+ 
+-	RecordingsList::RecordingsList(shared_ptr< RecordingsList > recList, bool ascending) :
++	RecordingsList::RecordingsList(std::tr1::shared_ptr< RecordingsList > recList, bool ascending) :
+ 		m_pRecVec(new RecVecType(recList->size()))
+ 	{
+ 		if (!m_pRecVec) {
+@@ -601,7 +605,7 @@
+ 		}
+ 	}
+ 
+-	RecordingsList::RecordingsList(shared_ptr< RecordingsList > recList, time_t begin, time_t end, bool ascending) :
++	RecordingsList::RecordingsList(std::tr1::shared_ptr< RecordingsList > recList, time_t begin, time_t end, bool ascending) :
+ 		m_pRecVec(new RecVecType())
+ 	{
+ 		if (end > begin) {
+@@ -643,8 +647,8 @@
+ 	/**
+ 	 *  Implementation of class RecordingsList:
+ 	 */
+-	RecordingsListPtr::RecordingsListPtr(RecordingsManagerPtr recManPtr, shared_ptr< RecordingsList > recList) :
+-		shared_ptr< RecordingsList >(recList),
++	RecordingsListPtr::RecordingsListPtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< RecordingsList > recList) :
++		std::tr1::shared_ptr< RecordingsList >(recList),
+ 		m_recManPtr(recManPtr)
+ 	{
+ 	}
+@@ -712,8 +716,8 @@
+ 	/**
+ 	 *  Implementation of class DirectoryListPtr:
+ 	 */
+-	DirectoryListPtr::DirectoryListPtr(RecordingsManagerPtr recManPtr, shared_ptr< DirectoryList > recDirs) :
+-		shared_ptr< DirectoryList >(recDirs),
++	DirectoryListPtr::DirectoryListPtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< DirectoryList > recDirs) :
++		std::tr1::shared_ptr< DirectoryList >(recDirs),
+ 		m_recManPtr(recManPtr)
+ 	{
+ 	}
+--- a/tasks.cpp
++++ b/tasks.cpp
+@@ -253,8 +253,8 @@
+ 		current->Action();
+ 		m_taskQueue.pop_front();
+ 	}*/
+-	for_each( m_taskQueue.begin(), m_taskQueue.end(), bind( &Task::Action, _1 ) );
+-	for_each( m_stickyTasks.begin(), m_stickyTasks.end(), bind( &Task::Action, _1 ) );
++	for_each( m_taskQueue.begin(), m_taskQueue.end(), std::tr1::bind( &Task::Action, _1 ) );
++	for_each( m_stickyTasks.begin(), m_stickyTasks.end(), std::tr1::bind( &Task::Action, _1 ) );
+ 	m_taskQueue.clear();
+ 	m_scheduleWait.Broadcast();
+ }

--- a/media-plugins/vdr-live/vdr-live-0.3.0_p20130504-r2.ebuild
+++ b/media-plugins/vdr-live/vdr-live-0.3.0_p20130504-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -28,6 +28,11 @@ VDR_RCADDON_FILE="${FILESDIR}/rc-addon-0.3.sh"
 
 KEEP_I18NOBJECT="yes"
 
+PATCHES=(
+	"${FILESDIR}"/${P}_vdr-2.1.2.diff
+	"${FILESDIR}"/${P}-c++11.patch
+)
+
 make_live_cert() {
 	# TODO: still true?
 	# ssl-cert eclass creates a "invalid" cert, create our own one
@@ -51,12 +56,9 @@ make_live_cert() {
 	chown vdr:vdr "${ROOT}"/etc/vdr/plugins/live/live{,-key}.pem
 }
 
-src_configure() {
-	# tmp. disabled gcc -std=c++11, due massiv compile errors
-	filter-flags -std=c++11
-}
-
 src_prepare() {
+	default
+
 	# new Makefile handling ToDp
 #	cp "${FILESDIR}/live.mk" "${S}/Makefile"
 
@@ -64,8 +66,6 @@ src_prepare() {
 	rm "${S}"/po/{ca_ES,da_DK,el_GR,et_EE,hr_HR,hu_HU,nl_NL,nn_NO,pt_PT,ro_RO,ru_RU,sl_SI,sv_SE,tr_TR}.po
 
 	vdr-plugin-2_src_prepare
-
-	epatch "${FILESDIR}/${P}_vdr-2.1.2.diff"
 
 	if ! use pcre; then
 		sed -i "s:^HAVE_LIBPCRECPP:#HAVE_LIBPCRECPP:" Makefile || die


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/599752
Package-Manager: Portage-2.3.10, Repoman-2.3.3

The build pull both `std` and `std::tr1` namespaces into the same scope, and names in C++11/14 `std`namespace clash with those of `std::tr1` namespace.  Qualifying those names with `std::tr1` fixes the issue.

Upstream has since refactored their code.