### PR TITLE
media-gfx/inkscape-0.92.1-r2: fix gcc-7 build, #631344

### DIFF
--- a/media-gfx/inkscape/files/inkscape-0.92.1-gcc7.patch
+++ b/media-gfx/inkscape/files/inkscape-0.92.1-gcc7.patch
@@ -1,0 +1,93 @@
+--- a/src/ui/tools/flood-tool.cpp
++++ b/src/ui/tools/flood-tool.cpp
+@@ -21,6 +21,7 @@
+ #include "config.h"
+ #endif
+ 
++#include <cmath>
+ #include "trace/potrace/inkscape-potrace.h"
+ #include <2geom/pathvector.h>
+ #include <gdk/gdkkeysyms.h>
+@@ -196,6 +197,21 @@ inline unsigned char * get_trace_pixel(guchar *trace_px, int x, int y, int width
+ }
+ 
+ /**
++ * \brief Check whether two unsigned integers are close to each other
++ *
++ * \param[in] a The 1st unsigned int
++ * \param[in] b The 2nd unsigned int
++ * \param[in] d The threshold for comparison
++ *
++ * \return true if |a-b| <= d; false otherwise
++ */
++static bool compare_guint32(guint32 const a, guint32 const b, guint32 const d)
++{
++    const int difference = std::abs(static_cast<int>(a) - static_cast<int>(b));
++    return difference <= d;
++}
++
++/**
+  * Compare a pixel in a pixel buffer with another pixel to determine if a point should be included in the fill operation.
+  * @param check The pixel in the pixel buffer to check.
+  * @param orig The original selected pixel to use as the fill target color.
+@@ -206,7 +222,6 @@ inline unsigned char * get_trace_pixel(guchar *trace_px, int x, int y, int width
+  */
+ static bool compare_pixels(guint32 check, guint32 orig, guint32 merged_orig_pixel, guint32 dtc, int threshold, PaintBucketChannels method)
+ {
+-    int diff = 0;
+     float hsl_check[3] = {0,0,0}, hsl_orig[3] = {0,0,0};
+ 
+     guint32 ac = 0, rc = 0, gc = 0, bc = 0;
+@@ -232,27 +247,35 @@ static bool compare_pixels(guint32 check, guint32 orig, guint32 merged_orig_pixe
+     
+     switch (method) {
+         case FLOOD_CHANNELS_ALPHA:
+-            return abs(static_cast<int>(ac) - ao) <= threshold;
++            return compare_guint32(ac, ao, threshold);
+         case FLOOD_CHANNELS_R:
+-            return abs(static_cast<int>(ac ? unpremul_alpha(rc, ac) : 0) - (ao ? unpremul_alpha(ro, ao) : 0)) <= threshold;
++            return compare_guint32(ac ? unpremul_alpha(rc, ac) : 0,
++                                   ao ? unpremul_alpha(ro, ao) : 0,
++                                   threshold);
+         case FLOOD_CHANNELS_G:
+-            return abs(static_cast<int>(ac ? unpremul_alpha(gc, ac) : 0) - (ao ? unpremul_alpha(go, ao) : 0)) <= threshold;
++            return compare_guint32(ac ? unpremul_alpha(gc, ac) : 0,
++                                   ao ? unpremul_alpha(go, ao) : 0,
++                                   threshold);
+         case FLOOD_CHANNELS_B:
+-            return abs(static_cast<int>(ac ? unpremul_alpha(bc, ac) : 0) - (ao ? unpremul_alpha(bo, ao) : 0)) <= threshold;
++            return compare_guint32(ac ? unpremul_alpha(bc, ac) : 0,
++                                   ao ? unpremul_alpha(bo, ao) : 0,
++                                   threshold);
+         case FLOOD_CHANNELS_RGB:
+-            guint32 amc, rmc, bmc, gmc;
+-            //amc = 255*255 - (255-ac)*(255-ad); amc = (amc + 127) / 255;
+-            //amc = (255-ac)*ad + 255*ac; amc = (amc + 127) / 255;
+-            amc = 255; // Why are we looking at desktop? Cairo version ignores destop alpha
+-            rmc = (255-ac)*rd + 255*rc; rmc = (rmc + 127) / 255;
+-            gmc = (255-ac)*gd + 255*gc; gmc = (gmc + 127) / 255;
+-            bmc = (255-ac)*bd + 255*bc; bmc = (bmc + 127) / 255;
+-
+-            diff += abs(static_cast<int>(amc ? unpremul_alpha(rmc, amc) : 0) - (amop ? unpremul_alpha(rmop, amop) : 0));
+-            diff += abs(static_cast<int>(amc ? unpremul_alpha(gmc, amc) : 0) - (amop ? unpremul_alpha(gmop, amop) : 0));
+-            diff += abs(static_cast<int>(amc ? unpremul_alpha(bmc, amc) : 0) - (amop ? unpremul_alpha(bmop, amop) : 0));
+-            return ((diff / 3) <= ((threshold * 3) / 4));
+-        
++            {
++                guint32 amc, rmc, bmc, gmc;
++                //amc = 255*255 - (255-ac)*(255-ad); amc = (amc + 127) / 255;
++                //amc = (255-ac)*ad + 255*ac; amc = (amc + 127) / 255;
++                amc = 255; // Why are we looking at desktop? Cairo version ignores destop alpha
++                rmc = (255-ac)*rd + 255*rc; rmc = (rmc + 127) / 255;
++                gmc = (255-ac)*gd + 255*gc; gmc = (gmc + 127) / 255;
++                bmc = (255-ac)*bd + 255*bc; bmc = (bmc + 127) / 255;
++
++                int diff = 0; // The total difference between each of the 3 color components
++                diff += std::abs(static_cast<int>(amc ? unpremul_alpha(rmc, amc) : 0) - static_cast<int>(amop ? unpremul_alpha(rmop, amop) : 0));
++                diff += std::abs(static_cast<int>(amc ? unpremul_alpha(gmc, amc) : 0) - static_cast<int>(amop ? unpremul_alpha(gmop, amop) : 0));
++                diff += std::abs(static_cast<int>(amc ? unpremul_alpha(bmc, amc) : 0) - static_cast<int>(amop ? unpremul_alpha(bmop, amop) : 0));
++                return ((diff / 3) <= ((threshold * 3) / 4));
++            }
+         case FLOOD_CHANNELS_H:
+             return ((int)(fabs(hsl_check[0] - hsl_orig[0]) * 100.0) <= threshold);
+         case FLOOD_CHANNELS_S:

--- a/media-gfx/inkscape/inkscape-0.92.1-r2.ebuild
+++ b/media-gfx/inkscape/inkscape-0.92.1-r2.ebuild
@@ -1,0 +1,174 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="xml"
+
+inherit autotools eutils flag-o-matic gnome2-utils fdo-mime toolchain-funcs python-single-r1
+
+MY_P=${P/_/}
+
+DESCRIPTION="A SVG based generic vector-drawing program"
+HOMEPAGE="https://inkscape.org/"
+SRC_URI="https://inkscape.global.ssl.fastly.net/media/resources/file/${P}.tar.bz2"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+IUSE="cdr dia dbus exif gnome imagemagick openmp postscript inkjar jpeg latex"
+IUSE+=" lcms nls spell static-libs visio wpg"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+WPG_DEPS="
+	|| (
+		( app-text/libwpg:0.3 dev-libs/librevenge )
+		( app-text/libwpd:0.9 app-text/libwpg:0.2 )
+	)
+"
+COMMON_DEPEND="
+	${PYTHON_DEPS}
+	>=app-text/poppler-0.26.0:=[cairo]
+	>=dev-cpp/glibmm-2.48
+	>=dev-cpp/gtkmm-2.18.0:2.4
+	>=dev-cpp/cairomm-1.9.8
+	>=dev-libs/boehm-gc-6.4
+	>=dev-libs/glib-2.28
+	>=dev-libs/libsigc++-2.0.12
+	>=dev-libs/libxml2-2.6.20
+	>=dev-libs/libxslt-1.0.15
+	dev-libs/popt
+	dev-python/lxml[${PYTHON_USEDEP}]
+	media-gfx/potrace
+	media-gfx/scour[${PYTHON_USEDEP}]
+	media-libs/fontconfig
+	media-libs/freetype:2
+	media-libs/libpng:0
+	sci-libs/gsl:=
+	x11-libs/libX11
+	>=x11-libs/gtk+-2.10.7:2
+	>=x11-libs/pango-1.24
+	cdr? (
+		media-libs/libcdr
+		${WPG_DEPS}
+	)
+	dbus? ( dev-libs/dbus-glib )
+	exif? ( media-libs/libexif )
+	gnome? ( >=gnome-base/gnome-vfs-2.0 )
+	imagemagick? ( media-gfx/imagemagick:=[cxx] )
+	jpeg? ( virtual/jpeg:0 )
+	lcms? ( media-libs/lcms:2 )
+	spell? (
+		app-text/aspell
+		app-text/gtkspell:2
+	)
+	visio? (
+		media-libs/libvisio
+		${WPG_DEPS}
+	)
+	wpg? ( ${WPG_DEPS} )
+"
+
+# These only use executables provided by these packages
+# See share/extensions for more details. inkscape can tell you to
+# install these so we could of course just not depend on those and rely
+# on that.
+RDEPEND="${COMMON_DEPEND}
+	dev-python/numpy[${PYTHON_USEDEP}]
+	media-gfx/uniconvertor
+	dia? ( app-office/dia )
+	latex? (
+		media-gfx/pstoedit[plotutils]
+		app-text/dvipsk
+		app-text/texlive
+	)
+	postscript? ( app-text/ghostscript-gpl )
+"
+
+DEPEND="${COMMON_DEPEND}
+	>=dev-libs/boost-1.36
+	>=dev-util/intltool-0.40
+	>=sys-devel/gettext-0.17
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.92.1-gcc7.patch"
+	"${FILESDIR}/${PN}-0.92.1-automagic.patch"
+	"${FILESDIR}/${PN}-0.91_pre3-cppflags.patch"
+	"${FILESDIR}/${PN}-0.92.1-desktop.patch"
+	"${FILESDIR}/${PN}-0.91_pre3-exif.patch"
+	"${FILESDIR}/${PN}-0.91_pre3-sk-man.patch"
+	"${FILESDIR}/${PN}-0.48.4-epython.patch"
+)
+
+S=${WORKDIR}/${MY_P}
+
+RESTRICT="test"
+
+pkg_pretend() {
+	if use openmp; then
+		tc-has-openmp || die "Please switch to an openmp compatible compiler"
+	fi
+}
+
+src_prepare() {
+	default
+
+	sed -i "s#@EPYTHON@#${EPYTHON}#" \
+		src/extension/implementation/script.cpp || die
+
+	eautoreconf
+
+	# bug 421111
+	python_fix_shebang share/extensions
+}
+
+src_configure() {
+	# aliasing unsafe wrt #310393
+	append-flags -fno-strict-aliasing
+
+	econf \
+		$(use_enable static-libs static) \
+		$(use_enable nls) \
+		$(use_enable openmp) \
+		$(use_enable exif) \
+		$(use_enable jpeg) \
+		$(use_enable lcms) \
+		--enable-poppler-cairo \
+		$(use_enable wpg) \
+		$(use_enable visio) \
+		$(use_enable cdr) \
+		$(use_enable dbus dbusapi) \
+		$(use_enable imagemagick magick) \
+		$(use_with gnome gnome-vfs) \
+		$(use_with inkjar) \
+		$(use_with spell gtkspell) \
+		$(use_with spell aspell)
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
+src_install() {
+	default
+
+	prune_libtool_files
+	python_optimize "${ED}"/usr/share/${PN}/extensions
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	fdo-mime_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	fdo-mime_desktop_database_update
+}


### PR DESCRIPTION
adding the patch from
https://gitlab.com/inkscape/inkscape/commit/3876176ec28cac3b70f0b330b760aaa561236ee7
as proposed in 
https://bugs.gentoo.org/631344