### PR TITLE
net-wireless/uhd: Fix building with GCC-6

### DIFF
--- a/net-wireless/uhd/files/uhd-3.8.5-gcc6.patch
+++ b/net-wireless/uhd/files/uhd-3.8.5-gcc6.patch
@@ -1,0 +1,25 @@
+Bug: https://bugs.gentoo.org/611680
+Backported from: https://github.com/EttusResearch/uhd/commit/b6ad4c0531ef56f4e197cccd06f1d11fc89e4aab
+
+--- a/host/lib/usrp/dboard/db_cbx.cpp
++++ b/host/lib/usrp/dboard/db_cbx.cpp
+@@ -38,7 +38,7 @@ sbx_xcvr::cbx::~cbx(void){
+     /* NOP */
+ }
+ 
+-void sbx_xcvr::cbx::write_lo_regs(dboard_iface::unit_t unit, std::vector<boost::uint32_t> &regs)
++void sbx_xcvr::cbx::write_lo_regs(dboard_iface::unit_t unit, const std::vector<boost::uint32_t> &regs)
+ {
+     BOOST_FOREACH(boost::uint32_t reg, regs)
+     {
+--- a/host/lib/usrp/dboard/db_sbx_common.hpp
++++ b/host/lib/usrp/dboard/db_sbx_common.hpp
+@@ -225,7 +225,7 @@ class sbx_xcvr : public xcvr_dboard_base{
+         /*! This is the registered instance of the wrapper class, sbx_base. */
+         sbx_xcvr *self_base;
+     private:
+-        void write_lo_regs(dboard_iface::unit_t unit, std::vector<boost::uint32_t> &regs);
++        void write_lo_regs(dboard_iface::unit_t unit, const std::vector<boost::uint32_t> &regs);
+         max287x_iface::sptr _txlo;
+         max287x_iface::sptr _rxlo;
+     };

--- a/net-wireless/uhd/uhd-3.8.5.ebuild
+++ b/net-wireless/uhd/uhd-3.8.5.ebuild
@@ -34,7 +34,11 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}"/uhd-release_00$(get_version_component_range 1)_00$(get_version_component_range 2)_00$(get_version_component_range 3)/host
 
+PATCHES=( "${FILESDIR}"/${P}-gcc6.patch )
+
 src_prepare() {
+	cmake-utils_src_prepare
+
 	gnome2_environment_reset #534582
 
 	#this may not be needed in 3.4.3 and above, please verify


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/611680
Package-Manager: Portage-2.3.10, Repoman-2.3.3

The patch was cherry-picked from https://github.com/EttusResearch/uhd/commit/b6ad4c0531ef56f4e197cccd06f1d11fc89e4aab.