### PR TITLE
net-nds/openldap: fix modules libtool files prune

### DIFF
--- a/net-nds/openldap/openldap-2.4.44-r1.ebuild
+++ b/net-nds/openldap/openldap-2.4.44-r1.ebuild
@@ -680,7 +680,6 @@ multilib_src_test() {
 multilib_src_install() {
 	local lt="${BUILD_DIR}/libtool"
 	emake DESTDIR="${D}" SHELL="${EPREFIX}"/bin/bash install
-	use static-libs || prune_libtool_files --all
 
 	if ! use minimal && multilib_is_native_abi; then
 		# openldap modules go here
@@ -793,6 +792,8 @@ multilib_src_install() {
 		dosbin "${S}"/contrib/slapd-tools/statslog
 		newdoc "${S}"/contrib/slapd-tools/README README.statslog
 	fi
+
+	use static-libs || prune_libtool_files --all
 }
 
 multilib_src_install_all() {

--- a/net-nds/openldap/openldap-2.4.44.ebuild
+++ b/net-nds/openldap/openldap-2.4.44.ebuild
@@ -658,7 +658,6 @@ multilib_src_test() {
 multilib_src_install() {
 	local lt="${BUILD_DIR}/libtool"
 	emake DESTDIR="${D}" SHELL="${EPREFIX}"/bin/bash install
-	use static-libs || prune_libtool_files --all
 
 	if ! use minimal && multilib_is_native_abi; then
 		# openldap modules go here
@@ -770,6 +769,8 @@ multilib_src_install() {
 		dosbin "${S}"/contrib/slapd-tools/statslog
 		newdoc "${S}"/contrib/slapd-tools/README README.statslog
 	fi
+
+	use static-libs || prune_libtool_files --all
 }
 
 multilib_src_install_all() {

--- a/net-nds/openldap/openldap-2.4.45.ebuild
+++ b/net-nds/openldap/openldap-2.4.45.ebuild
@@ -712,7 +712,6 @@ multilib_src_test() {
 multilib_src_install() {
 	local lt="${BUILD_DIR}/libtool"
 	emake DESTDIR="${D}" SHELL="${EPREFIX}"/bin/bash install
-	use static-libs || prune_libtool_files --all
 
 	if ! use minimal && multilib_is_native_abi; then
 		# openldap modules go here
@@ -825,6 +824,8 @@ multilib_src_install() {
 		dosbin "${S}"/contrib/slapd-tools/statslog
 		newdoc "${S}"/contrib/slapd-tools/README README.statslog
 	fi
+
+	use static-libs || prune_libtool_files --all
 }
 
 multilib_src_install_all() {


### PR DESCRIPTION
the prune_libtool_files is run before the modules intall, that will
leave many la files in openldap module directory broken due to main
la file is gone, which will make revdep-rebuild or cave fix-linkage
keep rebuilding net-nds/openldap.

keep module la files removed by default will prevent user from using
.la file in modules config, which is working but should not been
encouraged, such as BUG:600484

Fixes: https://bugs.gentoo.org/537418