### PR TITLE
Libreoffice2

### DIFF
--- a/dev-perl/X11-Protocol/X11-Protocol-0.560.0-r1.ebuild
+++ b/dev-perl/X11-Protocol/X11-Protocol-0.560.0-r1.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Client-side interface to the X11 Protocol"
 
 LICENSE="${LICENSE} MIT"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="x11-libs/libXrender

--- a/mate-base/mate-common/mate-common-1.18.0.ebuild
+++ b/mate-base/mate-common/mate-common-1.18.0.ebuild
@@ -8,7 +8,7 @@ inherit mate-desktop.org
 if [[ ${PV} == 9999 ]]; then
 	inherit autotools
 else
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Common files for development of MATE packages"

--- a/x11-themes/gtk-engines-murrine/gtk-engines-murrine-0.98.2-r1.ebuild
+++ b/x11-themes/gtk-engines-murrine/gtk-engines-murrine-0.98.2-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://www.cimitan.com/murrine/"
 
 LICENSE="LGPL-2.1 LGPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~arm ppc ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 ppc ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="+themes animation-rtl"
 
 RDEPEND=">=x11-libs/gtk+-2.24.23:2[${MULTILIB_USEDEP}]

--- a/x11-themes/gtk-engines/gtk-engines-2.20.2-r2.ebuild
+++ b/x11-themes/gtk-engines/gtk-engines-2.20.2-r2.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.gtk.org/"
 
 LICENSE="LGPL-2.1"
 SLOT="2"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x86-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x86-macos ~x64-solaris ~x86-solaris"
 IUSE="accessibility lua"
 
 RDEPEND="

--- a/x11-themes/mate-themes-meta/mate-themes-meta-3-r2.ebuild
+++ b/x11-themes/mate-themes-meta/mate-themes-meta-3-r2.ebuild
@@ -7,7 +7,7 @@ if [[ ${PV} == 9999 ]]; then
 	MATE_THEMES_V=".9999"
 else
 	MATE_THEMES_V="*"
-	KEYWORDS="amd64 ~arm x86"
+	KEYWORDS="amd64 ~arm ~arm64 x86"
 fi
 
 DESCRIPTION="Meta package to facilitate easy use of x11-themes/mate-themes"

--- a/x11-themes/mate-themes/mate-themes-3.22.11.ebuild
+++ b/x11-themes/mate-themes/mate-themes-3.22.11.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV#${MATE_GTK_V}.} == 9999 ]]; then
 	EGIT_BRANCH="gtk${MATE_GTK_V}"
 else
 	SRC_URI="http://pub.mate-desktop.org/releases/themes/${MATE_GTK_V}/${P}.tar.xz"
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 HOMEPAGE="http://mate-desktop.org"

--- a/x11-themes/murrine-themes/murrine-themes-0.98.0-r1.ebuild
+++ b/x11-themes/murrine-themes/murrine-themes-0.98.0-r1.ebuild
@@ -23,7 +23,7 @@ http://gnome-look.org/CONTENT/content-files/93558-Murreza.tar.gz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~x86-fbsd"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~x86-fbsd"
 IUSE=""
 
 RDEPEND=">=x11-themes/gtk-engines-murrine-0.98.0"


### PR DESCRIPTION
dev-perl/X11-Protocol-0.560.0-r1 is required by libreoffice-5.4.2.2
Added ~arm64 keyword so ~arm64 users can build libreoffice-5.4.2.2