### PR TITLE
media-video/ffmpeg: use get_exeext on fftools_*

### DIFF
--- a/media-video/ffmpeg/ffmpeg-3.2.6.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.2.6.ebuild
@@ -433,7 +433,7 @@ multilib_src_compile() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				emake V=1 tools/${i}
+				emake V=1 tools/${i}$(get_exeext)
 			fi
 		done
 	fi
@@ -445,7 +445,7 @@ multilib_src_install() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				dobin tools/${i}
+				dobin tools/${i}$(get_exeext)
 			fi
 		done
 	fi

--- a/media-video/ffmpeg/ffmpeg-3.2.7.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.2.7.ebuild
@@ -433,7 +433,7 @@ multilib_src_compile() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				emake V=1 tools/${i}
+				emake V=1 tools/${i}$(get_exeext)
 			fi
 		done
 	fi
@@ -445,7 +445,7 @@ multilib_src_install() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				dobin tools/${i}
+				dobin tools/${i}$(get_exeext)
 			fi
 		done
 	fi

--- a/media-video/ffmpeg/ffmpeg-3.3.3.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.3.3.ebuild
@@ -466,7 +466,7 @@ multilib_src_compile() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				emake V=1 tools/${i}
+				emake V=1 tools/${i}$(get_exeext)
 			fi
 		done
 
@@ -485,7 +485,7 @@ multilib_src_install() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				dobin tools/${i}
+				dobin tools/${i}$(get_exeext)
 			fi
 		done
 

--- a/media-video/ffmpeg/ffmpeg-3.3.4.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.3.4.ebuild
@@ -467,7 +467,7 @@ multilib_src_compile() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				emake V=1 tools/${i}
+				emake V=1 tools/${i}$(get_exeext)
 			fi
 		done
 
@@ -486,7 +486,7 @@ multilib_src_install() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				dobin tools/${i}
+				dobin tools/${i}$(get_exeext)
 			fi
 		done
 

--- a/media-video/ffmpeg/ffmpeg-3.4.ebuild
+++ b/media-video/ffmpeg/ffmpeg-3.4.ebuild
@@ -446,7 +446,7 @@ multilib_src_compile() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				emake V=1 tools/${i}
+				emake V=1 tools/${i}$(get_exeext)
 			fi
 		done
 
@@ -465,7 +465,7 @@ multilib_src_install() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				dobin tools/${i}
+				dobin tools/${i}$(get_exeext)
 			fi
 		done
 

--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -446,7 +446,7 @@ multilib_src_compile() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				emake V=1 tools/${i}
+				emake V=1 tools/${i}$(get_exeext)
 			fi
 		done
 
@@ -465,7 +465,7 @@ multilib_src_install() {
 	if multilib_is_native_abi; then
 		for i in "${FFTOOLS[@]}" ; do
 			if use fftools_${i} ; then
-				dobin tools/${i}
+				dobin tools/${i}$(get_exeext)
 			fi
 		done
 

--- a/media-video/ffmpeg/metadata.xml
+++ b/media-video/ffmpeg/metadata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>media-video@gentoo.org</email>
-  </maintainer>
-  <use>
+<maintainer type="project">
+	<email>media-video@gentoo.org</email>
+</maintainer>
+<use>
 	<flag name="amr">Enables Adaptive Multi-Rate Audio support</flag>
 	<flag name="amrenc">Enables Adaptive Multi-Rate Audio encoding support with <pkg>media-libs/vo-amrwbenc</pkg>.</flag>
 	<flag name="armv5te">Enables optimizations for armv5te processors.</flag>
@@ -56,10 +56,10 @@
 	<flag name="zeromq">Enables <pkg>net-libs/zeromq</pkg> support with the zmq/azmq filters.</flag>
 	<flag name="zimg">Enables <pkg>media-libs/zimg</pkg> based scale filter.</flag>
 	<flag name="zvbi">Enables <pkg>media-libs/zvbi</pkg> based teletext decoder.</flag>
-  </use>
-  <slots>
-    <slot name="0">For building against. This is the only slot that provides
-     headers and command line tools. Binary compatibility slots come and go
-     as required, so always pin dependencies to this slot when appropriate.</slot>
-  </slots>
+</use>
+<slots>
+	<slot name="0">For building against. This is the only slot that provides
+	headers and command line tools. Binary compatibility slots come and go
+	as required, so always pin dependencies to this slot when appropriate.</slot>
+</slots>
 </pkgmetadata>


### PR DESCRIPTION
Otherwise build will fail at building tools/aviocat instead of
tools/aviocat.exe and so on.

Package-Manager: Portage-2.3.11, Repoman-2.3.3