### PR TITLE
app-text/fbreader: add optional patch for Qt5 support.

### DIFF
--- a/app-text/fbreader/fbreader-0.99.4-r3.ebuild
+++ b/app-text/fbreader/fbreader-0.99.4-r3.ebuild
@@ -1,0 +1,95 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit eutils multilib flag-o-matic
+
+DESCRIPTION="E-Book Reader. Supports many e-book formats"
+HOMEPAGE="http://www.fbreader.org/"
+SRC_URI="http://www.fbreader.org/files/desktop/${PN}-sources-${PV}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
+IUSE="debug"
+
+RDEPEND="
+	app-arch/bzip2
+	dev-libs/expat
+	dev-libs/liblinebreak
+	dev-libs/fribidi
+	dev-db/sqlite
+	net-misc/curl
+	sys-libs/zlib
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtnetwork:5[ssl]
+"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	# Still use linebreak instead of new unibreak
+	sed -e "s:-lunibreak:-llinebreak:" \
+		-i makefiles/config.mk zlibrary/text/Makefile || die "fixing libunibreak failed"
+
+	# Let portage decide about the compiler
+	sed -e "/^CC = /d" \
+		-i makefiles/arch/desktop.mk || die "removing CC line failed"
+
+	# let portage strip the binary
+	sed -e '/@strip/d' \
+		-i fbreader/desktop/Makefile || die
+
+	# Respect *FLAGS
+	sed -e "s/^CFLAGS = -pipe/CFLAGS +=/" \
+		-i makefiles/arch/desktop.mk || die "CFLAGS sed failed"
+	sed -e "/^	CFLAGS +=/ d" \
+		-i makefiles/config.mk || die "CFLAGS sed failed"
+	sed -e "/^	LDFLAGS += -s$/ d" \
+		-i makefiles/config.mk || die "sed failed"
+	sed -e "/^LDFLAGS =$/ d" \
+		-i makefiles/arch/desktop.mk || die "sed failed"
+
+	echo "TARGET_ARCH = desktop" > makefiles/target.mk
+	echo "LIBDIR = /usr/$(get_libdir)" >> makefiles/target.mk
+
+	echo "UI_TYPE = qt4" >> makefiles/target.mk
+	sed -e 's:MOC = moc-qt4:MOC = /usr/bin/moc:' \
+		-i makefiles/arch/desktop.mk || die "updating desktop.mk failed"
+
+	if use debug; then
+		echo "TARGET_STATUS = debug" >> makefiles/target.mk
+	else
+		echo "TARGET_STATUS = release" >> makefiles/target.mk
+	fi
+
+	# bug #452636
+	eapply "${FILESDIR}"/${P}.patch
+	# bug #515698
+	eapply "${FILESDIR}"/${P}-qreal-cast.patch
+	# bug #516794
+	eapply "${FILESDIR}"/${P}-mimetypes.patch
+	# bug #437262
+	eapply "${FILESDIR}"/${P}-ld-bfd.patch
+	# bug #592588
+	eapply -p0 "${FILESDIR}"/${P}-gcc6.patch
+
+	eapply "${FILESDIR}"/${P}-qt5.patch
+	append-cflags -std=c++11
+
+	eapply_user
+}
+
+src_compile() {
+	# bug #484516
+	emake -j1
+}
+
+src_install() {
+	default
+	dosym FBReader /usr/bin/fbreader
+}

--- a/app-text/fbreader/files/fbreader-0.99.4-qt5.patch
+++ b/app-text/fbreader/files/fbreader-0.99.4-qt5.patch
@@ -1,0 +1,573 @@
+diff --git a/makefiles/arch/desktop.mk b/makefiles/arch/desktop.mk
+index 4267113..3b46102 100644
+--- a/makefiles/arch/desktop.mk
++++ b/makefiles/arch/desktop.mk
+@@ -12,29 +12,11 @@ AR = ar rsu
+ LD = g++
+
+ CFLAGS += -fno-exceptions -Wall -Wno-ctor-dtor-privacy -W -DLIBICONV_PLUG
+-EXTERNAL_INCLUDE = $(shell pkg-config --cflags fribidi) 
++EXTERNAL_INCLUDE = $(shell pkg-config --cflags fribidi)
+
+-ifeq "$(UI_TYPE)" "qt"
+-  MOC = moc-qt3
+-  QTINCLUDE = -I /usr/include/qt3
+-else
+-  MOC = $(shell pkg-config QtCore --variable=moc_location)
+-  QTINCLUDE = -I $(shell pkg-config --cflags QtCore)
+-endif
+-
+-GTKINCLUDE = $(shell pkg-config --cflags gtk+-2.0 libpng xft)
+-
+-ifeq "$(UI_TYPE)" "qt"
+-  UILIBS = -lqt-mt
+-endif
+-
+-ifeq "$(UI_TYPE)" "qt4"
+-  UILIBS = $(shell pkg-config --libs QtCore QtGui QtNetwork)
+-endif
+-
+-ifeq "$(UI_TYPE)" "gtk"
+-  UILIBS = $(shell pkg-config --libs gtk+-2.0 gio-2.0) -lpng -ljpeg
+-endif
++MOC = /usr/lib/qt5/bin/moc
++QTINCLUDE = $(shell pkg-config --cflags Qt5Gui Qt5Widgets Qt5Network)
++UILIBS = $(shell pkg-config --libs Qt5Gui Qt5Widgets Qt5Network)
+
+ RM = rm -rvf
+ RM_QUIET = rm -rf
+diff --git a/zlibrary/ui/src/qt4/network/ZLQtNetworkManager.cpp b/zlibrary/ui/src/qt4/network/ZLQtNetworkManager.cpp
+index 47067d3..119a5ee 100644
+--- a/zlibrary/ui/src/qt4/network/ZLQtNetworkManager.cpp
++++ b/zlibrary/ui/src/qt4/network/ZLQtNetworkManager.cpp
+@@ -24,7 +24,9 @@
+ #include <QtCore/QDir>
+ #include <QtCore/QList>
+ #include <QtCore/QTimer>
++#include <QtCore/QUrlQuery>
+
++#include <QtNetwork/QNetworkCookie>
+ #include <QtNetwork/QNetworkRequest>
+ #include <QtNetwork/QNetworkReply>
+ #include <QtNetwork/QNetworkProxy>
+@@ -149,12 +151,12 @@ void ZLQtNetworkManager::prepareReply(ZLQtNetworkReplyScope &scope, QNetworkRequ
+ 	QNetworkReply *reply = NULL;
+ 	if (!scope.request->postParameters().empty()) {
+ 		QByteArray data;
+-		QUrl tmp;
++		QUrlQuery tmp;
+ 		typedef std::pair<std::string, std::string> string_pair;
+ 		foreach (const string_pair &pair, scope.request->postParameters()) {
+ 			tmp.addQueryItem(QString::fromStdString(pair.first), QString::fromStdString(pair.second));
+ 		}
+-		data = tmp.encodedQuery();
++		data = tmp.query(QUrl::FullyEncoded).toUtf8(); //encodedQuery();
+ 		reply = const_cast<QNetworkAccessManager&>(myManager).post(networkRequest, data);
+ 	} else {
+ 		reply = const_cast<QNetworkAccessManager&>(myManager).get(networkRequest);
+diff --git a/zlibrary/ui/src/qt4/tree/ZLQtItemsListWidget.cpp b/zlibrary/ui/src/qt4/tree/ZLQtItemsListWidget.cpp
+index a3e5b35..ab41684 100644
+--- a/zlibrary/ui/src/qt4/tree/ZLQtItemsListWidget.cpp
++++ b/zlibrary/ui/src/qt4/tree/ZLQtItemsListWidget.cpp
+@@ -17,14 +17,14 @@
+  * 02110-1301, USA.
+  */
+
+-#include <QtGui/QVBoxLayout>
+-#include <QtGui/QHBoxLayout>
+ #include <QtGui/QPixmap>
+ #include <QtGui/QPalette>
+ #include <QtGui/QPainter>
+ #include <QtGui/QPaintEvent>
+-#include <QtGui/QScrollBar>
+ #include <QtCore/QTimer>
++#include <QtWidgets/QVBoxLayout>
++#include <QtWidgets/QHBoxLayout>
++#include <QtWidgets/QScrollBar>
+
+ #include <QtCore/QDebug>
+
+diff --git a/zlibrary/ui/src/qt4/tree/ZLQtPreviewWidget.cpp b/zlibrary/ui/src/qt4/tree/ZLQtPreviewWidget.cpp
+index 472f05f..b9809c8 100644
+--- a/zlibrary/ui/src/qt4/tree/ZLQtPreviewWidget.cpp
++++ b/zlibrary/ui/src/qt4/tree/ZLQtPreviewWidget.cpp
+@@ -17,10 +17,10 @@
+  * 02110-1301, USA.
+  */
+
+-#include <QtGui/QVBoxLayout>
+-#include <QtGui/QHBoxLayout>
+-#include <QtGui/QScrollBar>
+-#include <QtGui/QGraphicsDropShadowEffect>
++#include <QtWidgets/QVBoxLayout>
++#include <QtWidgets/QHBoxLayout>
++#include <QtWidgets/QScrollBar>
++#include <QtWidgets/QGraphicsDropShadowEffect>
+
+ #include <QtCore/QDebug>
+
+diff --git a/zlibrary/ui/src/qt4/tree/ZLQtSearchField.cpp b/zlibrary/ui/src/qt4/tree/ZLQtSearchField.cpp
+index 1cddaf9..2b65cc1 100644
+--- a/zlibrary/ui/src/qt4/tree/ZLQtSearchField.cpp
++++ b/zlibrary/ui/src/qt4/tree/ZLQtSearchField.cpp
+@@ -18,9 +18,9 @@
+  */
+
+ #include <QtCore/QDebug>
+-#include <QtGui/QStyle>
+-#include <QtGui/QCompleter>
+-#include <QtGui/QStringListModel>
++#include <QtCore/QStringListModel>
++#include <QtWidgets/QStyle>
++#include <QtWidgets/QCompleter>
+
+ #include <ZLibrary.h>
+ #include <ZLFile.h>
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtTreeDialog.cpp b/zlibrary/ui/src/qt4/dialogs/ZLQtTreeDialog.cpp
+index 6de2c72..d942d47 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtTreeDialog.cpp
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtTreeDialog.cpp
+@@ -19,12 +19,12 @@
+ 
+ #include <algorithm>
+ 
+-#include <QtGui/QSplitter>
+-#include <QtGui/QVBoxLayout>
+-#include <QtGui/QHBoxLayout>
+-#include <QtGui/QScrollBar>
+ #include <QtGui/QResizeEvent>
+ #include <QtCore/QDebug>
++#include <QtWidgets/QSplitter>
++#include <QtWidgets/QVBoxLayout>
++#include <QtWidgets/QHBoxLayout>
++#include <QtWidgets/QScrollBar>
+ 
+ #include <ZLFile.h>
+ #include <ZLibrary.h>
+diff --git a/zlibrary/ui/src/qt4/tree/ZLQtItemsListWidget.h b/zlibrary/ui/src/qt4/tree/ZLQtItemsListWidget.h
+index 4f09cfc..51f1545 100644
+--- a/zlibrary/ui/src/qt4/tree/ZLQtItemsListWidget.h
++++ b/zlibrary/ui/src/qt4/tree/ZLQtItemsListWidget.h
+@@ -20,12 +20,12 @@
+ #ifndef __ZLQTITEMSLISTWIDGET_H__
+ #define __ZLQTITEMSLISTWIDGET_H__
+ 
+-#include <QtGui/QWidget>
+-#include <QtGui/QFrame>
+-#include <QtGui/QPushButton>
+-#include <QtGui/QLabel>
+-#include <QtGui/QVBoxLayout>
+-#include <QtGui/QScrollArea>
++#include <QtWidgets/QWidget>
++#include <QtWidgets/QFrame>
++#include <QtWidgets/QPushButton>
++#include <QtWidgets/QLabel>
++#include <QtWidgets/QVBoxLayout>
++#include <QtWidgets/QScrollArea>
+ 
+ #include <ZLTreeTitledNode.h>
+ 
+diff --git a/zlibrary/ui/src/qt4/application/LineEditParameter.cpp b/zlibrary/ui/src/qt4/application/LineEditParameter.cpp
+index dfcbc0b..bd2689e 100644
+--- a/zlibrary/ui/src/qt4/application/LineEditParameter.cpp
++++ b/zlibrary/ui/src/qt4/application/LineEditParameter.cpp
+@@ -17,9 +17,9 @@
+  * 02110-1301, USA.
+  */
+ 
+-#include <QtGui/QBoxLayout>
+-#include <QtGui/QLineEdit>
+-#include <QtGui/QToolBar>
++#include <QtWidgets/QBoxLayout>
++#include <QtWidgets/QLineEdit>
++#include <QtWidgets/QToolBar>
+ #include <QtGui/QKeyEvent>
+ 
+ #include "ZLQtApplicationWindow.h"
+diff --git a/zlibrary/ui/src/qt4/application/ZLQtApplicationWindow.cpp b/zlibrary/ui/src/qt4/application/ZLQtApplicationWindow.cpp
+index 6241514..e0b143b 100644
+--- a/zlibrary/ui/src/qt4/application/ZLQtApplicationWindow.cpp
++++ b/zlibrary/ui/src/qt4/application/ZLQtApplicationWindow.cpp
+@@ -17,17 +17,17 @@
+  * 02110-1301, USA.
+  */
+ 
+-#include <QtGui/QApplication>
++#include <QtWidgets/QApplication>
+ #include <QtGui/QPixmap>
+ #include <QtGui/QImage>
+ #include <QtGui/QIcon>
+-#include <QtGui/QToolBar>
+-#include <QtGui/QMenuBar>
+-#include <QtGui/QMenu>
+-#include <QtGui/QToolButton>
+-#include <QtGui/QLayout>
++#include <QtWidgets/QToolBar>
++#include <QtWidgets/QMenuBar>
++#include <QtWidgets/QMenu>
++#include <QtWidgets/QToolButton>
++#include <QtWidgets/QLayout>
+ #include <QtGui/QWheelEvent>
+-#include <QtGui/QDockWidget>
++#include <QtWidgets/QDockWidget>
+ #include <QtCore/QObjectList>
+ 
+ #include <ZLibrary.h>
+diff --git a/zlibrary/ui/src/qt4/application/ZLQtApplicationWindow.h b/zlibrary/ui/src/qt4/application/ZLQtApplicationWindow.h
+index 3b4fd3a..42ff2c8 100644
+--- a/zlibrary/ui/src/qt4/application/ZLQtApplicationWindow.h
++++ b/zlibrary/ui/src/qt4/application/ZLQtApplicationWindow.h
+@@ -22,8 +22,8 @@
+ 
+ #include <map>
+ 
+-#include <QtGui/QMainWindow>
+-#include <QtGui/QAction>
++#include <QtWidgets/QMainWindow>
++#include <QtWidgets/QAction>
+ #include <QtGui/QCursor>
+ 
+ class QDockWidget;
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtDialog.cpp b/zlibrary/ui/src/qt4/dialogs/ZLQtDialog.cpp
+index 24eb897..c17e86c 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtDialog.cpp
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtDialog.cpp
+@@ -17,8 +17,8 @@
+  * 02110-1301, USA.
+  */
+ 
+-#include <QtGui/QApplication>
+-#include <QtGui/QPushButton>
++#include <QtWidgets/QApplication>
++#include <QtWidgets/QPushButton>
+ 
+ #include <ZLDialogManager.h>
+ 
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtDialog.h b/zlibrary/ui/src/qt4/dialogs/ZLQtDialog.h
+index 068039d..811cec8 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtDialog.h
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtDialog.h
+@@ -20,8 +20,8 @@
+ #ifndef __ZLQTDIALOG_H__
+ #define __ZLQTDIALOG_H__
+ 
+-#include <QtGui/QDialog>
+-#include <QtGui/QLayout>
++#include <QtWidgets/QDialog>
++#include <QtWidgets/QLayout>
+ 
+ #include <ZLDialog.h>
+ 
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtDialogContent.cpp b/zlibrary/ui/src/qt4/dialogs/ZLQtDialogContent.cpp
+index e8ff422..352c350 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtDialogContent.cpp
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtDialogContent.cpp
+@@ -17,10 +17,10 @@
+  * 02110-1301, USA.
+  */
+ 
+-#include <QtGui/QApplication>
+-#include <QtGui/QDesktopWidget>
+-#include <QtGui/QWidget>
+-#include <QtGui/QLayout>
++#include <QtWidgets/QApplication>
++#include <QtWidgets/QDesktopWidget>
++#include <QtWidgets/QWidget>
++#include <QtWidgets/QLayout>
+ 
+ #include "ZLQtDialogContent.h"
+ #include "ZLQtOptionView.h"
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtDialogManager.cpp b/zlibrary/ui/src/qt4/dialogs/ZLQtDialogManager.cpp
+index d5eb4d4..2fc769b 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtDialogManager.cpp
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtDialogManager.cpp
+@@ -17,11 +17,11 @@
+  * 02110-1301, USA.
+  */
+ 
+-#include <QtGui/QApplication>
+-#include <QtGui/QMessageBox>
+-#include <QtGui/QFileDialog>
++#include <QtWidgets/QApplication>
++#include <QtWidgets/QMessageBox>
++#include <QtWidgets/QFileDialog>
+ #include <QtGui/QClipboard>
+-#include <QtGui/QDesktopWidget>
++#include <QtWidgets/QDesktopWidget>
+ 
+ #include "ZLQtDialogManager.h"
+ #include "ZLQtDialog.h"
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtOpenFileDialog.cpp b/zlibrary/ui/src/qt4/dialogs/ZLQtOpenFileDialog.cpp
+index ec9e73c..a50a40d 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtOpenFileDialog.cpp
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtOpenFileDialog.cpp
+@@ -17,7 +17,7 @@
+  * 02110-1301, USA.
+  */
+ 
+-#include <QtGui/QFileDialog>
++#include <QtWidgets/QFileDialog>
+ 
+ #include "ZLQtOpenFileDialog.h"
+ 
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtOptionView.cpp b/zlibrary/ui/src/qt4/dialogs/ZLQtOptionView.cpp
+index 48a1b8f..90d50fb 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtOptionView.cpp
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtOptionView.cpp
+@@ -19,16 +19,16 @@
+ 
+ #include <cctype>
+ 
+-#include <QtGui/QCheckBox>
+-#include <QtGui/QComboBox>
+-#include <QtGui/QLabel>
+-#include <QtGui/QGroupBox>
+-#include <QtGui/QRadioButton>
+-#include <QtGui/QPushButton>
+-#include <QtGui/QSpinBox>
+-#include <QtGui/QLineEdit>
+-#include <QtGui/QSlider>
+-#include <QtGui/QLayout>
++#include <QtWidgets/QCheckBox>
++#include <QtWidgets/QComboBox>
++#include <QtWidgets/QLabel>
++#include <QtWidgets/QGroupBox>
++#include <QtWidgets/QRadioButton>
++#include <QtWidgets/QPushButton>
++#include <QtWidgets/QSpinBox>
++#include <QtWidgets/QLineEdit>
++#include <QtWidgets/QSlider>
++#include <QtWidgets/QLayout>
+ 
+ #include <ZLStringUtil.h>
+ #include <ZLDialogManager.h>
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtOptionsDialog.cpp b/zlibrary/ui/src/qt4/dialogs/ZLQtOptionsDialog.cpp
+index f6c36fb..7fe855a 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtOptionsDialog.cpp
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtOptionsDialog.cpp
+@@ -17,11 +17,11 @@
+  * 02110-1301, USA.
+  */
+ 
+-#include <QtGui/QApplication>
+-#include <QtGui/QDesktopWidget>
+-#include <QtGui/QLayout>
+-#include <QtGui/QPushButton>
+-#include <QtGui/QButtonGroup>
++#include <QtWidgets/QApplication>
++#include <QtWidgets/QDesktopWidget>
++#include <QtWidgets/QLayout>
++#include <QtWidgets/QPushButton>
++#include <QtWidgets/QButtonGroup>
+ #include <QtGui/QResizeEvent>
+ 
+ #include <ZLDialogManager.h>
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtOptionsDialog.h b/zlibrary/ui/src/qt4/dialogs/ZLQtOptionsDialog.h
+index e38b62a..ad26fba 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtOptionsDialog.h
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtOptionsDialog.h
+@@ -20,9 +20,9 @@
+ #ifndef __ZLQTOPTIONSDIALOG_H__
+ #define __ZLQTOPTIONSDIALOG_H__
+ 
+-#include <QtGui/QWidget>
+-#include <QtGui/QTabWidget>
+-#include <QtGui/QDialog>
++#include <QtWidgets/QWidget>
++#include <QtWidgets/QTabWidget>
++#include <QtWidgets/QDialog>
+ 
+ #include "../../../../core/src/desktop/dialogs/ZLDesktopOptionsDialog.h"
+ 
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtProgressDialog.cpp b/zlibrary/ui/src/qt4/dialogs/ZLQtProgressDialog.cpp
+index 98e469e..5a1d574 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtProgressDialog.cpp
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtProgressDialog.cpp
+@@ -19,11 +19,11 @@
+ 
+ #include <unistd.h>
+ 
+-#include <QtGui/QApplication>
+-#include <QtGui/QDesktopWidget>
+-#include <QtGui/QWidget>
+-#include <QtGui/QLabel>
+-#include <QtGui/QLayout>
++#include <QtWidgets/QApplication>
++#include <QtWidgets/QDesktopWidget>
++#include <QtWidgets/QWidget>
++#include <QtWidgets/QLabel>
++#include <QtWidgets/QLayout>
+ #include <QtCore/QThreadPool>
+ 
+ #include "../dialogs/ZLQtDialogManager.h"
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtProgressDialog.h b/zlibrary/ui/src/qt4/dialogs/ZLQtProgressDialog.h
+index df6c73b..837bce5 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtProgressDialog.h
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtProgressDialog.h
+@@ -22,11 +22,11 @@
+ 
+ #include <string>
+ 
+-#include <QtGui/QWidget>
++#include <QtWidgets/QWidget>
+ #include <QtGui/QCursor>
+-#include <QtGui/QDialog>
+-#include <QtGui/QProgressBar>
+-#include <QtGui/QLabel>
++#include <QtWidgets/QDialog>
++#include <QtWidgets/QProgressBar>
++#include <QtWidgets/QLabel>
+ #include <QtCore/QRunnable>
+ 
+ #include <ZLProgressDialog.h>
+diff --git a/zlibrary/ui/src/qt4/dialogs/ZLQtTreeDialog.h b/zlibrary/ui/src/qt4/dialogs/ZLQtTreeDialog.h
+index 9cf7c47..03f1223 100644
+--- a/zlibrary/ui/src/qt4/dialogs/ZLQtTreeDialog.h
++++ b/zlibrary/ui/src/qt4/dialogs/ZLQtTreeDialog.h
+@@ -24,12 +24,12 @@
+ #include <QtCore/QSet>
+ #include <QtCore/QMap>
+ 
+-#include <QtGui/QDialog>
+-#include <QtGui/QScrollArea>
+-#include <QtGui/QPushButton>
+-#include <QtGui/QLabel>
+-#include <QtGui/QLineEdit>
+-#include <QtGui/QWidget>
++#include <QtWidgets/QDialog>
++#include <QtWidgets/QScrollArea>
++#include <QtWidgets/QPushButton>
++#include <QtWidgets/QLabel>
++#include <QtWidgets/QLineEdit>
++#include <QtWidgets/QWidget>
+ 
+ #include <ZLTreeDialog.h>
+ 
+diff --git a/zlibrary/ui/src/qt4/library/ZLQApplication.h b/zlibrary/ui/src/qt4/library/ZLQApplication.h
+index c08c536..a714fa9 100644
+--- a/zlibrary/ui/src/qt4/library/ZLQApplication.h
++++ b/zlibrary/ui/src/qt4/library/ZLQApplication.h
+@@ -20,7 +20,7 @@
+ #ifndef __ZLQAPPLICATION_H__
+ #define __ZLQAPPLICATION_H__
+ 
+-#include <QtGui/QApplication>
++#include <QtWidgets/QApplication>
+ 
+ class ZLQApplication : public QApplication {
+ 
+diff --git a/zlibrary/ui/src/qt4/library/ZLibrary.cpp b/zlibrary/ui/src/qt4/library/ZLibrary.cpp
+index 9648e95..a544031 100644
+--- a/zlibrary/ui/src/qt4/library/ZLibrary.cpp
++++ b/zlibrary/ui/src/qt4/library/ZLibrary.cpp
+@@ -19,7 +19,7 @@
+ 
+ #include <QtCore/QTextCodec>
+ #include <QtCore/QFile>
+-#include <QtGui/QApplication>
++#include <QtWidgets/QApplication>
+ #include <QtGui/QFileOpenEvent>
+ 
+ #include <ZLApplication.h>
+@@ -72,7 +72,7 @@ bool ZLQApplication::event(QEvent *e) {
+ void ZLQtLibraryImplementation::init(int &argc, char **&argv) {
+ 	new ZLQApplication(argc, argv);
+ 
+-	QTextCodec::setCodecForCStrings(QTextCodec::codecForName("utf-8"));
++	QTextCodec::setCodecForLocale(QTextCodec::codecForName("utf-8"));
+ 
+ 	ZLibrary::parseArguments(argc, argv);
+ 
+diff --git a/zlibrary/ui/src/qt4/tree/QtWaitingSpinner.h b/zlibrary/ui/src/qt4/tree/QtWaitingSpinner.h
+index cdaef01..a259c65 100644
+--- a/zlibrary/ui/src/qt4/tree/QtWaitingSpinner.h
++++ b/zlibrary/ui/src/qt4/tree/QtWaitingSpinner.h
+@@ -3,7 +3,7 @@
+ 
+ #include <QtCore/QTimer>
+ 
+-#include <QtGui/QWidget>
++#include <QtWidgets/QWidget>
+ #include <QtGui/QColor>
+ 
+ class QtWaitingSpinner : public QWidget {
+diff --git a/zlibrary/ui/src/qt4/tree/ZLQtPreviewWidget.h b/zlibrary/ui/src/qt4/tree/ZLQtPreviewWidget.h
+index 1b8ebcc..6f3b4e3 100644
+--- a/zlibrary/ui/src/qt4/tree/ZLQtPreviewWidget.h
++++ b/zlibrary/ui/src/qt4/tree/ZLQtPreviewWidget.h
+@@ -20,11 +20,11 @@
+ #ifndef __ZLQTPREVIEWWIDGET_H__
+ #define __ZLQTPREVIEWWIDGET_H__
+ 
+-#include <QtGui/QWidget>
+-#include <QtGui/QPushButton>
+-#include <QtGui/QLabel>
+-#include <QtGui/QScrollArea>
+-#include <QtGui/QVBoxLayout>
++#include <QtWidgets/QWidget>
++#include <QtWidgets/QPushButton>
++#include <QtWidgets/QLabel>
++#include <QtWidgets/QScrollArea>
++#include <QtWidgets/QVBoxLayout>
+ #include <QtCore/QSet>
+ 
+ #include <ZLTreePageNode.h>
+diff --git a/zlibrary/ui/src/qt4/tree/ZLQtSearchField.h b/zlibrary/ui/src/qt4/tree/ZLQtSearchField.h
+index f6e174c..c360965 100644
+--- a/zlibrary/ui/src/qt4/tree/ZLQtSearchField.h
++++ b/zlibrary/ui/src/qt4/tree/ZLQtSearchField.h
+@@ -21,8 +21,8 @@
+ #define __ZLQTSEARCHFIELD_H__
+ 
+ #include <QtCore/QSet>
+-#include <QtGui/QLabel>
+-#include <QtGui/QLineEdit>
++#include <QtWidgets/QLabel>
++#include <QtWidgets/QLineEdit>
+ 
+ #include "QtWaitingSpinner.h"
+ #include "ZLQtItemsListWidget.h"
+diff --git a/zlibrary/ui/src/qt4/view/ZLQtViewWidget.cpp b/zlibrary/ui/src/qt4/view/ZLQtViewWidget.cpp
+index 4f5d196..615050c 100644
+--- a/zlibrary/ui/src/qt4/view/ZLQtViewWidget.cpp
++++ b/zlibrary/ui/src/qt4/view/ZLQtViewWidget.cpp
+@@ -19,8 +19,8 @@
+ 
+ #include <algorithm>
+ 
+-#include <QtGui/QLayout>
+-#include <QtGui/QScrollBar>
++#include <QtWidgets/QLayout>
++#include <QtWidgets/QScrollBar>
+ #include <QtGui/QPainter>
+ #include <QtGui/QPixmap>
+ #include <QtGui/QMouseEvent>
+@@ -185,11 +185,11 @@ void ZLQtViewWidget::repaint()	{
+ 
+ void ZLQtViewWidget::setScrollbarEnabled(ZLView::Direction direction, bool enabled) {
+ 	if (direction == ZLView::VERTICAL) {
+-		myRightScrollBar->setShown(enabled && myShowScrollBarAtRight);
+-		myLeftScrollBar->setShown(enabled && !myShowScrollBarAtRight);
++		myRightScrollBar->setVisible(enabled && myShowScrollBarAtRight);
++		myLeftScrollBar->setVisible(enabled && !myShowScrollBarAtRight);
+ 	} else {
+-		myBottomScrollBar->setShown(enabled && myShowScrollBarAtBottom);
+-		myTopScrollBar->setShown(enabled && !myShowScrollBarAtBottom);
++		myBottomScrollBar->setVisible(enabled && myShowScrollBarAtBottom);
++		myTopScrollBar->setVisible(enabled && !myShowScrollBarAtBottom);
+ 	}
+ }
+ 
+diff --git a/zlibrary/ui/src/qt4/view/ZLQtViewWidget.h b/zlibrary/ui/src/qt4/view/ZLQtViewWidget.h
+index 6fabf00..ccec1e3 100644
+--- a/zlibrary/ui/src/qt4/view/ZLQtViewWidget.h
++++ b/zlibrary/ui/src/qt4/view/ZLQtViewWidget.h
+@@ -20,7 +20,7 @@
+ #ifndef __ZLQTVIEWWIDGET_H__
+ #define __ZLQTVIEWWIDGET_H__
+ 
+-#include <QtGui/QWidget>
++#include <QtWidgets/QWidget>
+ 
+ #include "../../../../core/src/view/ZLViewWidget.h"
+ #include <ZLApplication.h>


### PR DESCRIPTION
Patch is based on patch found at https://github.com/geometer/FBReader/issues/285

Also bump EAPI to 6.

diff:
```
--- app-text/fbreader/fbreader-0.99.4-r2.ebuild 2017-09-15 22:55:25.647892838 +0300
+++ app-text/fbreader/fbreader-0.99.4-r3.ebuild 2017-10-18 08:35:34.327996496 +0300
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
-inherit eutils multilib
+inherit eutils multilib flag-o-matic
 
 DESCRIPTION="E-Book Reader. Supports many e-book formats"
 HOMEPAGE="http://www.fbreader.org/"
@@ -11,7 +11,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ppc x86"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
 IUSE="debug"
 
 RDEPEND="
@@ -22,8 +22,10 @@
        dev-db/sqlite
        net-misc/curl
        sys-libs/zlib
-       dev-qt/qtcore:4[ssl]
-       dev-qt/qtgui:4
+       dev-qt/qtcore:5
+       dev-qt/qtgui:5
+       dev-qt/qtwidgets:5
+       dev-qt/qtnetwork:5[ssl]
 "
 DEPEND="${RDEPEND}
        virtual/pkgconfig
@@ -66,15 +68,20 @@
        fi
 
        # bug #452636
-       epatch "${FILESDIR}"/${P}.patch
+       eapply "${FILESDIR}"/${P}.patch
        # bug #515698
-       epatch "${FILESDIR}"/${P}-qreal-cast.patch
+       eapply "${FILESDIR}"/${P}-qreal-cast.patch
        # bug #516794
-       epatch "${FILESDIR}"/${P}-mimetypes.patch
+       eapply "${FILESDIR}"/${P}-mimetypes.patch
        # bug #437262
-       epatch "${FILESDIR}"/${P}-ld-bfd.patch
+       eapply "${FILESDIR}"/${P}-ld-bfd.patch
        # bug #592588
-       epatch "${FILESDIR}"/${P}-gcc6.patch
+       eapply -p0 "${FILESDIR}"/${P}-gcc6.patch
+
+       eapply "${FILESDIR}"/${P}-qt5.patch
+       append-cflags -std=c++11
+
+       eapply_user
 }
 
 src_compile() {
```