### PR TITLE
dev-util/electron: add missing build-time dependencies causing emerge failure

### DIFF
--- a/dev-util/electron/electron-1.6.11-r1.ebuild
+++ b/dev-util/electron/electron-1.6.11-r1.ebuild
@@ -110,7 +110,6 @@ COMMON_DEPEND="
 	media-libs/libpng:=
 	media-libs/libvpx:=[svc]
 	media-libs/speex:=
-	net-libs/nodejs:=
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? ( >=media-video/ffmpeg-3:= )
 	sys-apps/dbus:=
@@ -163,6 +162,7 @@ DEPEND="${COMMON_DEPEND}
 	dev-perl/JSON
 	>=dev-util/gperf-3.0.3
 	dev-util/ninja
+	net-libs/nodejs
 	sys-apps/hwids[usb(+)]
 	>=sys-devel/bison-2.4.3
 	sys-devel/flex

--- a/dev-util/electron/electron-1.6.11-r1.ebuild
+++ b/dev-util/electron/electron-1.6.11-r1.ebuild
@@ -110,6 +110,7 @@ COMMON_DEPEND="
 	media-libs/libpng:=
 	media-libs/libvpx:=[svc]
 	media-libs/speex:=
+	net-libs/nodejs:=
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? ( >=media-video/ffmpeg-3:= )
 	sys-apps/dbus:=

--- a/dev-util/electron/electron-1.6.11-r1.ebuild
+++ b/dev-util/electron/electron-1.6.11-r1.ebuild
@@ -120,6 +120,7 @@ COMMON_DEPEND="
 	x11-libs/cairo:=
 	x11-libs/gdk-pixbuf:2
 	x11-libs/libdrm
+	x11-libs/libnotify:=
 	x11-libs/libX11:=
 	x11-libs/libXcomposite:=
 	x11-libs/libXcursor:=


### PR DESCRIPTION
Electron fails to emerge without net-libs/nodejs and x11-libs/libnotify at version 1.6.11-r1. Other versions have not been tested. libnotify was probably simply overlooked while writing the ebuild, as it is listed in older versions, as well as in the official documentation as a dependency.

Not sure if it is the same issue for nodejs, as it is not listed as a dependency in older ebuilds. It is also bundled, so it is probably due to the build system change, which I am not familiar with. A response from someone with more knowledge would be appreciated.

I've attached build logs; builds fail near the end, so they're **huge** (35mb unpacked each). If you're interested in checking them out, I'd suggest extracting last ~50 lines, as before there's just normal build stuff.

[build.no-nodejs.no-libnotify.log.gz](https://github.com/gentoo/gentoo/files/1392144/build.no-nodejs.no-libnotify.log.gz)
[build.nodejs.no-libnotify.log.gz](https://github.com/gentoo/gentoo/files/1392143/build.nodejs.no-libnotify.log.gz)