### PR TITLE
Keyworded mate and mate-extras for ~arm64

### DIFF
--- a/app-arch/engrampa/engrampa-1.18.1.ebuild
+++ b/app-arch/engrampa/engrampa-1.18.1.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Engrampa archive manager for MATE"

--- a/app-cdr/brasero/brasero-3.12.2.ebuild
+++ b/app-cdr/brasero/brasero-3.12.2.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/Brasero"
 LICENSE="GPL-2+ CC-BY-SA-3.0"
 SLOT="0/3.1" # subslot is 3.suffix of libbrasero-burn3
 IUSE="+css +introspection +libburn mp3 nautilus packagekit playlist test tracker"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 
 COMMON_DEPEND="
 	>=dev-libs/glib-2.29.14:2

--- a/app-cdr/cdrdao/cdrdao-1.2.3-r4.ebuild
+++ b/app-cdr/cdrdao/cdrdao-1.2.3-r4.ebuild
@@ -16,7 +16,7 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sh ~sparc x86 ~x86-fbsd"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sh ~sparc x86 ~x86-fbsd"
 IUSE="encode mad vorbis"
 
 RDEPEND="virtual/cdrtools

--- a/app-cdr/dvd+rw-tools/dvd+rw-tools-7.1-r3.ebuild
+++ b/app-cdr/dvd+rw-tools/dvd+rw-tools-7.1-r3.ebuild
@@ -10,7 +10,7 @@ SRC_URI="http://fy.chalmers.se/~appro/linux/DVD+RW/tools/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~sh sparc x86 ~amd64-linux ~arm-linux ~x86-linux"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 ~sh sparc x86 ~amd64-linux ~arm-linux ~x86-linux"
 IUSE=""
 
 RDEPEND="virtual/cdrtools"

--- a/app-editors/pluma/pluma-1.18.2.ebuild
+++ b/app-editors/pluma/pluma-1.18.2.ebuild
@@ -10,7 +10,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit mate multilib python-single-r1 virtualx
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Pluma text editor for the MATE desktop"

--- a/app-text/atril/atril-1.18.0.ebuild
+++ b/app-text/atril/atril-1.18.0.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Atril document viewer for MATE"

--- a/dev-cpp/gtkmm/gtkmm-3.22.2.ebuild
+++ b/dev-cpp/gtkmm/gtkmm-3.22.2.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="https://www.gtkmm.org"
 
 LICENSE="LGPL-2.1+"
 SLOT="3.0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
 
 IUSE="aqua doc test wayland X"
 REQUIRED_USE="|| ( aqua wayland X )"

--- a/dev-libs/libappindicator/libappindicator-12.10.0-r301.ebuild
+++ b/dev-libs/libappindicator/libappindicator-12.10.0-r301.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ SRC_URI="https://launchpad.net/${PN}/${PV%.*}/${PV}/+download/${P}.tar.gz"
 
 LICENSE="LGPL-2.1 LGPL-3"
 SLOT="3"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE="+introspection"
 
 RDEPEND="

--- a/dev-libs/libbytesize/libbytesize-1.2.ebuild
+++ b/dev-libs/libbytesize/libbytesize-1.2.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://github.com/rhinstaller/libbytesize"
 SRC_URI="https://github.com/rhinstaller/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="doc test"
 
 RDEPEND="

--- a/dev-libs/libindicator/libindicator-12.10.1-r301.ebuild
+++ b/dev-libs/libindicator/libindicator-12.10.1-r301.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ SRC_URI="https://launchpad.net/${PN}/${PV%.*}/${PV}/+download/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="3"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE="test"
 
 RDEPEND=">=dev-libs/glib-2.22[${MULTILIB_USEDEP}]

--- a/dev-libs/libmateweather/libmateweather-1.18.0.ebuild
+++ b/dev-libs/libmateweather/libmateweather-1.18.0.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE library to access weather information from online services"

--- a/dev-libs/volume_key/volume_key-0.3.9.ebuild
+++ b/dev-libs/volume_key/volume_key-0.3.9.ebuild
@@ -13,7 +13,7 @@ SRC_URI="http://releases.pagure.org/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="test"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/dev-python/pocketlint/pocketlint-0.15.ebuild
+++ b/dev-python/pocketlint/pocketlint-0.15.ebuild
@@ -13,5 +13,5 @@ SRC_URI="https://github.com/rhinstaller/${PN}/archive/${PV}.tar.gz -> ${P}.tar.g
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""

--- a/dev-python/polib/polib-1.0.7.ebuild
+++ b/dev-python/polib/polib-1.0.7.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE="doc"
 
 DEPEND="doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )"

--- a/gnome-extra/gucharmap/gucharmap-10.0.0.ebuild
+++ b/gnome-extra/gucharmap/gucharmap-10.0.0.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/Gucharmap"
 
 LICENSE="GPL-3"
 SLOT="2.90"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd"
 
 IUSE="debug +introspection test vala"
 REQUIRED_USE="vala? ( introspection )"

--- a/gnome-extra/zenity/zenity-3.24.0.ebuild
+++ b/gnome-extra/zenity/zenity-3.24.0.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/Zenity"
 
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="debug libnotify webkit"
 
 # TODO: X11 dependency is automagically enabled

--- a/mate-base/caja/caja-1.18.3.ebuild
+++ b/mate-base/caja/caja-1.18.3.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate virtualx
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Caja file manager for the MATE desktop"

--- a/mate-base/libmatekbd/libmatekbd-1.18.2.ebuild
+++ b/mate-base/libmatekbd/libmatekbd-1.18.2.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE keyboard configuration library"

--- a/mate-base/mate-applets-meta/mate-applets-meta-1.18.ebuild
+++ b/mate-base/mate-applets-meta/mate-applets-meta-1.18.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	inherit versionator
 	MATE_BRANCH="$(get_version_component_range 1-2)"
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Meta package for MATE panel applets"

--- a/mate-base/mate-applets/mate-applets-1.18.1-r1.ebuild
+++ b/mate-base/mate-applets/mate-applets-1.18.1-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit mate python-single-r1
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Applets for the MATE Desktop and Panel"

--- a/mate-base/mate-applets/mate-applets-1.18.1.ebuild
+++ b/mate-base/mate-applets/mate-applets-1.18.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit mate python-single-r1
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Applets for the MATE Desktop and Panel"

--- a/mate-base/mate-common/mate-common-1.18.0.ebuild
+++ b/mate-base/mate-common/mate-common-1.18.0.ebuild
@@ -8,7 +8,7 @@ inherit mate-desktop.org
 if [[ ${PV} == 9999 ]]; then
 	inherit autotools
 else
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Common files for development of MATE packages"

--- a/mate-base/mate-control-center/mate-control-center-1.18.1.ebuild
+++ b/mate-base/mate-control-center/mate-control-center-1.18.1.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="The MATE Desktop configuration tool"

--- a/mate-base/mate-desktop/mate-desktop-1.18.0.ebuild
+++ b/mate-base/mate-desktop/mate-desktop-1.18.0.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Libraries for the MATE desktop that are not part of the UI"

--- a/mate-base/mate-menus/mate-menus-1.18.0.ebuild
+++ b/mate-base/mate-menus/mate-menus-1.18.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit python-r1 mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE menu system, implementing the F.D.O cross-desktop spec"

--- a/mate-base/mate-panel/mate-panel-1.18.2.ebuild
+++ b/mate-base/mate-panel/mate-panel-1.18.2.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="The MATE panel"

--- a/mate-base/mate-session-manager/mate-session-manager-1.18.0-r1.ebuild
+++ b/mate-base/mate-session-manager/mate-session-manager-1.18.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE session manager"

--- a/mate-base/mate-settings-daemon/mate-settings-daemon-1.18.1.ebuild
+++ b/mate-base/mate-settings-daemon/mate-settings-daemon-1.18.1.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE Settings Daemon"

--- a/mate-base/mate/mate-1.18.ebuild
+++ b/mate-base/mate/mate-1.18.ebuild
@@ -10,7 +10,7 @@ else
 	inherit versionator
 	MATE_BRANCH="$(get_version_component_range 1-2)"
 	MATE_THEMES_V=3
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 SRC_URI=""

--- a/mate-extra/caja-extensions/caja-extensions-1.18.1.ebuild
+++ b/mate-extra/caja-extensions/caja-extensions-1.18.1.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Several Caja extensions"

--- a/mate-extra/mate-calc/mate-calc-1.18.0.ebuild
+++ b/mate-extra/mate-calc/mate-calc-1.18.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Calculator for MATE"

--- a/mate-extra/mate-media/mate-media-1.18.0.ebuild
+++ b/mate-extra/mate-media/mate-media-1.18.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Multimedia related programs for the MATE desktop"

--- a/mate-extra/mate-netbook/mate-netbook-1.18.0.ebuild
+++ b/mate-extra/mate-netbook/mate-netbook-1.18.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE utilities for netbooks"

--- a/mate-extra/mate-polkit/mate-polkit-1.18.1.ebuild
+++ b/mate-extra/mate-polkit/mate-polkit-1.18.1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="A MATE specific DBUS service that is used to bring up authentication dialogs"

--- a/mate-extra/mate-power-manager/mate-power-manager-1.18.0.ebuild
+++ b/mate-extra/mate-power-manager/mate-power-manager-1.18.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="A session daemon for MATE that makes it easy to manage your laptop or desktop"

--- a/mate-extra/mate-screensaver/mate-screensaver-1.18.1.ebuild
+++ b/mate-extra/mate-screensaver/mate-screensaver-1.18.1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate multilib readme.gentoo-r1
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Replaces xscreensaver, integrating with the MATE desktop"

--- a/mate-extra/mate-system-monitor/mate-system-monitor-1.18.0.ebuild
+++ b/mate-extra/mate-system-monitor/mate-system-monitor-1.18.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="The MATE System Monitor"

--- a/mate-extra/mate-utils/mate-utils-1.18.2.ebuild
+++ b/mate-extra/mate-utils/mate-utils-1.18.2.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Utilities for the MATE desktop"

--- a/media-gfx/eom/eom-1.18.2.ebuild
+++ b/media-gfx/eom/eom-1.18.2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="The MATE image viewer"

--- a/media-libs/libmatemixer/libmatemixer-1.18.0.ebuild
+++ b/media-libs/libmatemixer/libmatemixer-1.18.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Mixer library for MATE Desktop"

--- a/media-plugins/gst-plugins-libnice/gst-plugins-libnice-0.1.13-r100.ebuild
+++ b/media-plugins/gst-plugins-libnice/gst-plugins-libnice-0.1.13-r100.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ SRC_URI="https://nice.freedesktop.org/releases/${MY_P}.tar.gz"
 
 LICENSE="|| ( MPL-1.1 LGPL-2.1 )"
 SLOT="1.0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 RDEPEND="

--- a/net-im/gajim/gajim-0.16.8.ebuild
+++ b/net-im/gajim/gajim-0.16.8.ebuild
@@ -21,7 +21,7 @@ SRC_URI="
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~x86-fbsd"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~x86-fbsd"
 IUSE="crypt dbus gnome gnome-keyring kde idle jingle libnotify networkmanager nls spell +srv test X xhtml zeroconf"
 
 REQUIRED_USE="

--- a/net-im/pidgin/pidgin-2.12.0.ebuild
+++ b/net-im/pidgin/pidgin-2.12.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="
 
 LICENSE="GPL-2"
 SLOT="0/2" # libpurple version
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x86-macos"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x86-macos"
 IUSE="dbus debug doc eds gadu gnutls +gstreamer +gtk idn meanwhile pie"
 IUSE+=" networkmanager nls perl silc tcl tk spell sasl ncurses"
 IUSE+=" groupwise prediction python +xscreensaver zephyr zeroconf" # mono"

--- a/net-im/silc-toolkit/silc-toolkit-1.1.10.ebuild
+++ b/net-im/silc-toolkit/silc-toolkit-1.1.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -11,7 +11,7 @@ SRC_URI="http://silcnet.org/download/toolkit/sources/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
 IUSE="debug ipv6"
 
 RDEPEND=""

--- a/net-libs/farstream/farstream-0.2.8-r1.ebuild
+++ b/net-libs/farstream/farstream-0.2.8-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.freedesktop.org/wiki/Software/Farstream"
 SRC_URI="https://freedesktop.org/software/farstream/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="+introspection test upnp"
 SLOT="0.2/5" # .so version
 

--- a/net-libs/libnice/libnice-0.1.13.ebuild
+++ b/net-libs/libnice/libnice-0.1.13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ SRC_URI="https://nice.freedesktop.org/releases/${P}.tar.gz"
 
 LICENSE="|| ( MPL-1.1 LGPL-2.1 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="+introspection +upnp"
 
 RDEPEND="

--- a/net-libs/meanwhile/meanwhile-1.0.2-r1.ebuild
+++ b/net-libs/meanwhile/meanwhile-1.0.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 LICENSE="LGPL-2"
 IUSE="doc debug"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86"
 
 RDEPEND=">=dev-libs/glib-2:2"
 

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -136,7 +136,6 @@ scanner
 zvbi
 ldap
 mysql
-dvd
 fluidsynth
 sid
 mms

--- a/sys-apps/gnome-disk-utility/gnome-disk-utility-3.24.1.ebuild
+++ b/sys-apps/gnome-disk-utility/gnome-disk-utility-3.24.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://git.gnome.org/browse/gnome-disk-utility"
 LICENSE="GPL-2+"
 SLOT="0"
 IUSE="fat gnome systemd"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sh ~sparc ~x86"
 
 COMMON_DEPEND="
 	>=app-arch/xz-utils-5.0.5

--- a/sys-fs/udisks/udisks-2.7.3.ebuild
+++ b/sys-fs/udisks/udisks-2.7.3.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://github.com/storaged-project/${PN}/archive/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="2"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="acl cryptsetup debug elogind +gptfdisk +introspection lvm nls selinux systemd"
 
 REQUIRED_USE="?? ( elogind systemd )"

--- a/sys-libs/libblockdev/libblockdev-2.13.ebuild
+++ b/sys-libs/libblockdev/libblockdev-2.13.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/rhinstaller/libblockdev"
 SRC_URI="https://github.com/rhinstaller/${PN}/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="bcache +crypt dmraid doc lvm kbd test"
 
 CDEPEND="

--- a/sys-power/cpupower/cpupower-4.13.0.ebuild
+++ b/sys-power/cpupower/cpupower-4.13.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://dev.gentoo.org/~floppym/dist/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0/0"
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 IUSE="cpufreq_bench nls"
 
 # File collision w/ headers of the deprecated cpufrequtils

--- a/x11-libs/gksu/gksu-2.0.2-r2.ebuild
+++ b/x11-libs/gksu/gksu-2.0.2-r2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://people.debian.org/~kov/gksu/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd"
 IUSE="gnome"
 
 RDEPEND="

--- a/x11-libs/libfakekey/libfakekey-0.1-r2.ebuild
+++ b/x11-libs/libfakekey/libfakekey-0.1-r2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://matchbox-project.org/sources/${PN}/${PV}/${P}.tar.bz2"
 LICENSE="GPL-2"
 SLOT="0"
 
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 IUSE="debug doc"
 
 RDEPEND="x11-libs/libXtst"

--- a/x11-misc/mate-notification-daemon/mate-notification-daemon-1.18.0.ebuild
+++ b/x11-misc/mate-notification-daemon/mate-notification-daemon-1.18.0.ebuild
@@ -8,7 +8,7 @@ MATE_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE Notification daemon"

--- a/x11-misc/mozo/mozo-1.18.0.ebuild
+++ b/x11-misc/mozo/mozo-1.18.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_REQ_USE="xml"
 inherit python-r1 mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="Mozo menu editor for MATE"

--- a/x11-terms/mate-terminal/mate-terminal-1.18.1.ebuild
+++ b/x11-terms/mate-terminal/mate-terminal-1.18.1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="The MATE Terminal"

--- a/x11-themes/gtk-engines-murrine/gtk-engines-murrine-0.98.2-r1.ebuild
+++ b/x11-themes/gtk-engines-murrine/gtk-engines-murrine-0.98.2-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://www.cimitan.com/murrine/"
 
 LICENSE="LGPL-2.1 LGPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~arm ppc ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 ppc ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="+themes animation-rtl"
 
 RDEPEND=">=x11-libs/gtk+-2.24.23:2[${MULTILIB_USEDEP}]

--- a/x11-themes/gtk-engines/gtk-engines-2.20.2-r2.ebuild
+++ b/x11-themes/gtk-engines/gtk-engines-2.20.2-r2.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.gtk.org/"
 
 LICENSE="LGPL-2.1"
 SLOT="2"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x86-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~x86-macos ~x64-solaris ~x86-solaris"
 IUSE="accessibility lua"
 
 RDEPEND="

--- a/x11-themes/mate-backgrounds/mate-backgrounds-1.18.0.ebuild
+++ b/x11-themes/mate-backgrounds/mate-backgrounds-1.18.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="A set of backgrounds packaged with the MATE desktop"

--- a/x11-themes/mate-icon-theme/mate-icon-theme-1.18.2.ebuild
+++ b/x11-themes/mate-icon-theme/mate-icon-theme-1.18.2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE default icon themes"

--- a/x11-themes/mate-themes-meta/mate-themes-meta-3-r2.ebuild
+++ b/x11-themes/mate-themes-meta/mate-themes-meta-3-r2.ebuild
@@ -7,7 +7,7 @@ if [[ ${PV} == 9999 ]]; then
 	MATE_THEMES_V=".9999"
 else
 	MATE_THEMES_V="*"
-	KEYWORDS="amd64 ~arm x86"
+	KEYWORDS="amd64 ~arm ~arm64 x86"
 fi
 
 DESCRIPTION="Meta package to facilitate easy use of x11-themes/mate-themes"

--- a/x11-themes/mate-themes/mate-themes-3.22.11.ebuild
+++ b/x11-themes/mate-themes/mate-themes-3.22.11.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV#${MATE_GTK_V}.} == 9999 ]]; then
 	EGIT_BRANCH="gtk${MATE_GTK_V}"
 else
 	SRC_URI="http://pub.mate-desktop.org/releases/themes/${MATE_GTK_V}/${P}.tar.xz"
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 HOMEPAGE="http://mate-desktop.org"

--- a/x11-themes/murrine-themes/murrine-themes-0.98.0-r1.ebuild
+++ b/x11-themes/murrine-themes/murrine-themes-0.98.0-r1.ebuild
@@ -23,7 +23,7 @@ http://gnome-look.org/CONTENT/content-files/93558-Murreza.tar.gz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~x86-fbsd"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~x86-fbsd"
 IUSE=""
 
 RDEPEND=">=x11-themes/gtk-engines-murrine-0.98.0"

--- a/x11-wm/marco/marco-1.18.1.ebuild
+++ b/x11-wm/marco/marco-1.18.1.ebuild
@@ -8,7 +8,7 @@ MATE2_LA_PUNT="yes"
 inherit mate
 
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="MATE default window manager"


### PR DESCRIPTION
Keyworded mate and mate-extras for ~arm64
Removed the dvd use.mask.  A 64 bit Pi 3 plays the 1960s TV Robin Hood properly from a USB DVD.
It struggles with The Good the Bad and the Ugly.

Its not repoman clean but its no worse than when I started adding keywords.  