### PR TITLE
net-wireless/wpa_supplicant: HOMEPAGE, avoid redirect

### DIFF
--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.6-r3.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.6-r3.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit eutils qmake-utils systemd toolchain-funcs
 
 DESCRIPTION="IEEE 802.1X/WPA supplicant for secure wireless transfers"
-HOMEPAGE="http://hostap.epitest.fi/wpa_supplicant/"
+HOMEPAGE="https://w1.fi/wpa_supplicant/"
 SRC_URI="http://hostap.epitest.fi/releases/${P}.tar.gz"
 LICENSE="|| ( GPL-2 BSD )"
 

--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.6.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.6.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils toolchain-funcs qt4-r2 qmake-utils systemd multilib
 
 DESCRIPTION="IEEE 802.1X/WPA supplicant for secure wireless transfers"
-HOMEPAGE="http://hostap.epitest.fi/wpa_supplicant/"
+HOMEPAGE="https://w1.fi/wpa_supplicant/"
 SRC_URI="http://hostap.epitest.fi/releases/${P}.tar.gz"
 LICENSE="|| ( GPL-2 BSD )"
 


### PR DESCRIPTION
curl --head http://hostap.epitest.fi/wpa_supplicant/
HTTP/1.1 301 Moved Permanently
Date: Fri, 20 Oct 2017 04:56:32 GMT
Server: Apache/2.2.22 (Ubuntu)
Location: http://w1.fi/wpa_supplicant/
Vary: Accept-Encoding
Content-Type: text/html; charset=iso-8859-1
Package-Manager: Portage-2.3.10, Repoman-2.3.3