### PR TITLE
x11-base/xorg-server: Remove suid USE as everything is handled by the suid wrapper script

### DIFF
--- a/x11-base/xorg-server/xorg-server-1.19.5-r1.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.19.5-r1.ebuild
@@ -12,7 +12,7 @@ SLOT="0/${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux"
 
 IUSE_SERVERS="dmx kdrive wayland xephyr xnest xorg xvfb"
-IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux +suid suid-wrapper systemd tslib +udev unwind xcsecurity"
+IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux systemd tslib +udev unwind xcsecurity"
 
 CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	!libressl? ( dev-libs/openssl:0= )
@@ -133,7 +133,6 @@ PDEPEND="
 REQUIRED_USE="!minimal? (
 		|| ( ${IUSE_SERVERS} )
 	)
-	^^ ( suid suid-wrapper )
 	xephyr? ( kdrive )"
 
 #UPSTREAMED_PATCHES=(
@@ -176,8 +175,6 @@ src_configure() {
 		$(use_enable kdrive kdrive-kbd)
 		$(use_enable kdrive kdrive-mouse)
 		$(use_enable kdrive kdrive-evdev)
-		$(use_enable suid install-setuid)
-		$(use_enable suid-wrapper)
 		$(use_enable tslib)
 		$(use_enable unwind libunwind)
 		$(use_enable wayland xwayland)
@@ -197,6 +194,7 @@ src_configure() {
 		$(use_with systemd systemd-daemon)
 		$(use_enable systemd systemd-logind)
 		--enable-libdrm
+		--enable-suid-wrapper
 		--sysconfdir="${EPREFIX}"/etc/X11
 		--localstatedir="${EPREFIX}"/var
 		--with-fontrootdir="${EPREFIX}"/usr/share/fonts

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -12,7 +12,7 @@ SLOT="0/${PV}"
 KEYWORDS=""
 
 IUSE_SERVERS="dmx kdrive wayland xephyr xnest xorg xvfb"
-IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux +suid suid-wrapper systemd +udev unwind xcsecurity"
+IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux systemd +udev unwind xcsecurity"
 
 CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	!libressl? ( dev-libs/openssl:0= )
@@ -132,7 +132,6 @@ PDEPEND="
 REQUIRED_USE="!minimal? (
 		|| ( ${IUSE_SERVERS} )
 	)
-	^^ ( suid suid-wrapper )
 	xephyr? ( kdrive )"
 
 #UPSTREAMED_PATCHES=(
@@ -171,8 +170,6 @@ src_configure() {
 		$(use_enable dmx)
 		$(use_enable glamor)
 		$(use_enable kdrive)
-		$(use_enable suid install-setuid)
-		$(use_enable suid-wrapper)
 		$(use_enable unwind libunwind)
 		$(use_enable wayland xwayland)
 		$(use_enable !minimal record)
@@ -191,6 +188,7 @@ src_configure() {
 		$(use_with systemd systemd-daemon)
 		$(use_enable systemd systemd-logind)
 		--enable-libdrm
+		--enable-suid-wrapper
 		--sysconfdir="${EPREFIX}"/etc/X11
 		--localstatedir="${EPREFIX}"/var
 		--with-fontrootdir="${EPREFIX}"/usr/share/fonts


### PR DESCRIPTION
The suid wrapper will keep root if it will be needed (non-KMS drivers), but drop to user in other cases. No need to deal with it manually


Signed-off-by: Nick Sarnie <commendsarnex@gmail.com>