### PR TITLE
sys-fs/fuseiso: fix dependency problem and bump to EAPI=6

### DIFF
--- a/sys-fs/fuseiso/fuseiso-20070708-r1.ebuild
+++ b/sys-fs/fuseiso/fuseiso-20070708-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 inherit eutils
 
@@ -13,16 +13,11 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
-RDEPEND="sys-fs/fuse
+RDEPEND="sys-fs/fuse:=
 	sys-libs/zlib
 	dev-libs/glib:2"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
 DOCS=( AUTHORS ChangeLog NEWS README )
-
-src_prepare() {
-	epatch "${FILESDIR}/${P}-largeiso.patch"
-	epatch "${FILESDIR}/${P}-fix-typo.patch" # bug #482078
-	epatch_user
-}
+PATCHES=( ${FILESDIR}/${P}-largeiso.patch ${FILESDIR}/${P}-fix-typo.patch )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/634234
Closes: https://bugs.gentoo.org/634234
Package-Manager: Portage-2.3.8, Repoman-2.3.3 

