### PR TITLE
app-crypt/kbfs: build the Git remote helper, #633554

### DIFF
--- a/app-crypt/kbfs/kbfs-9999.ebuild
+++ b/app-crypt/kbfs/kbfs-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ EGIT_REPO_URI="https://github.com/keybase/kbfs.git"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="git"
 
 DEPEND="
 	>=dev-lang/go-1.6:0
@@ -37,8 +37,16 @@ src_compile() {
 		-tags production \
 		-o "${T}/kbfsfuse" \
 		github.com/keybase/kbfs/kbfsfuse
+	use git && \
+		GOPATH="${WORKDIR}" \
+			  go build -v -x \
+			  -tags production \
+			  -o "${T}/git-remote-keybase" \
+			  github.com/keybase/kbfs/kbfsgit/git-remote-keybase
 }
 
 src_install() {
 	dobin "${T}/kbfsfuse"
+	use git && \
+		dobin "${T}/git-remote-keybase"
 }

--- a/app-crypt/kbfs/metadata.xml
+++ b/app-crypt/kbfs/metadata.xml
@@ -8,4 +8,7 @@
 		The official Keybase implementation of the client-side code for the
 		Keybase filesystem (KBFS).
 	</longdescription>
+	<use>
+		<flag name="git">Build the Git remote helper for storing repositories in Keybase</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
Keybase has introduced a remote helper for Git which makes it easy to store repositories in KBFS. See the blog post at [https://keybase.io/blog/encrypted-git-for-everyone](https://keybase.io/blog/encrypted-git-for-everyone).

Attached is an updated `app-crypt/kbfs-9999.ebuild` that builds and installs the `git-remote-keybase` binary required to add this functionality to Git.

Like the rest of Keybase, it's written in Go, which I have no idea how to properly build, but cargo-culting the lines for the kbfsfuse binary seems to work.

@nicolasbock 