### PR TITLE
dev-python/twisted-conch: support dev-python/pycryptodome

### DIFF
--- a/dev-python/twisted-conch/twisted-conch-15.2.1.ebuild
+++ b/dev-python/twisted-conch/twisted-conch-15.2.1.ebuild
@@ -14,7 +14,7 @@ IUSE=""
 DEPEND="
 	=dev-python/twisted-core-${TWISTED_RELEASE}*[${PYTHON_USEDEP}]
 	dev-python/pyasn1[${PYTHON_USEDEP}]
-	dev-python/pycrypto[${PYTHON_USEDEP}]"
+	dev-python/pycryptodome[${PYTHON_USEDEP}]"
 RDEPEND="${DEPEND}
 	!dev-python/twisted
 "


### PR DESCRIPTION
Fixes #611618 by using pycryptodome as drop in replacement for
vulnerable pycrypto.

Signed-off-by: Bob Brooks <gitbugged@cool.fr.nf>