### PR TITLE
net-nntp/nzbget: require openssl to be compiled with USE=-bindist

### DIFF
--- a/net-nntp/nzbget/nzbget-20.0_pre2108-r1.ebuild
+++ b/net-nntp/nzbget/nzbget-20.0_pre2108-r1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="dev-libs/libxml2
 			net-libs/gnutls:=
 			dev-libs/nettle:=
 		)
-		!gnutls? ( dev-libs/openssl:0= )
+		!gnutls? ( dev-libs/openssl:0=[-bindist] )
 	)
 	zlib? ( sys-libs/zlib )"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/635196
Package-Manager: Portage-2.3.12, Repoman-2.3.3