### PR TITLE
dev-util/clinfo: A tool to display info about the system's OpenCL capabilities.

### DIFF
--- a/dev-util/clinfo/clinfo-9999.ebuild
+++ b/dev-util/clinfo/clinfo-9999.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://github.com/Oblomov/clinfo.git"
+	inherit git-r3
+	SRC_URI=""
+else
+	SRC_URI="https://github.com/Oblomov/clinfo/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+fi
+
+DESCRIPTION="A tool to display info about the system's OpenCL capabilities"
+HOMEPAGE="https://github.com/Oblomov/clinfo"
+LICENSE="CC0-1.0"
+SLOT="0"
+
+DEPEND="virtual/opencl"
+RDEPEND="${DEPEND}"
+
+src_install() {
+	emake MANDIR="${ED}"/usr/share/man PREFIX="${ED}"/usr install
+}

--- a/dev-util/clinfo/metadata.xml
+++ b/dev-util/clinfo/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>candrews@gentoo.org</email>
+		<name>Craig Andrews</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">Oblomov/clinfo</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
Package-Manager: Portage-2.3.12, Repoman-2.3.3