### PR TITLE
media-video/subtitlecomposer-0.6.4: fix for Gentoo bug #613514

### DIFF
--- a/media-video/subtitlecomposer/subtitlecomposer-0.6.4.ebuild
+++ b/media-video/subtitlecomposer/subtitlecomposer-0.6.4.ebuild
@@ -13,6 +13,7 @@ SRC_URI="https://github.com/maxrd2/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-2"
 KEYWORDS="amd64 x86"
 IUSE="mpv unicode xine"
+VIRTUALX_REQUIRED=test
 
 CDEPEND="
 	$(add_frameworks_dep kcodecs)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/613514