### PR TITLE
media-libs/ftgl: skip unit tests (bug #619390)

### DIFF
--- a/media-libs/ftgl/files/ftgl-2.1.3_rc5-gentoo.patch
+++ b/media-libs/ftgl/files/ftgl-2.1.3_rc5-gentoo.patch
@@ -1,6 +1,16 @@
 --- configure.ac.old    2008-11-21 14:41:15.000000000 +0100
 +++ configure.ac        2008-11-21 14:44:19.000000000 +0100
-@@ -64,19 +64,11 @@
+@@ -50,8 +50,7 @@
+ FTGL_CHECK_GLUT
+ FTGL_CHECK_FONT
+
+-PKG_CHECK_MODULES(CPPUNIT, cppunit, [CPPUNIT="yes"], [CPPUNIT="no"])
+-AC_MSG_RESULT($CPPUNIT)
++CPPUNIT="no"
+ AM_CONDITIONAL(HAVE_CPPUNIT, test "x$CPPUNIT" != "xno")
+
+ dnl search the include directory (required for non-srcdir builds).
+@@ -64,19 +63,11 @@
  CFLAGS="${CFLAGS} -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs"
  
  # Build HTML documentatin?


### PR DESCRIPTION
```text
The build issue seem to be related to C++11 support in CppUnit and can be
worked around with one of the following approaches:

 - compiling with CXXFLAGS+='-std=c++11',
 - disabling unit tests completely.

In order not to introduce formal CppUnit dependency into the ebuild,
the latter approach is chosen.
```