### PR TITLE
sys-boot/raspberrypi-firmware: Use shallow clone for raspberrypi-firmware git repo

### DIFF
--- a/sys-boot/raspberrypi-firmware/raspberrypi-firmware-9999.ebuild
+++ b/sys-boot/raspberrypi-firmware/raspberrypi-firmware-9999.ebuild
@@ -18,6 +18,7 @@ DEPEND=""
 RDEPEND="!sys-boot/raspberrypi-loader"
 
 EGIT_REPO_URI="https://github.com/raspberrypi/firmware"
+EGIT_CLONE_TYPE=shallow
 
 RESTRICT="binchecks strip"
 


### PR DESCRIPTION
Live ebuild for raspberrypi-firmware uses a shallow clone of the upstream git repository to avoid having to download 6+GB of git history (see https://bugs.gentoo.org/636688)

ping @ralimi 