### PR TITLE
sys-kernel/raspberrypi-sources-4.14.9999: fix to work with git-r3.eclass

### DIFF
--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.14.9999.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.14.9999.ebuild
@@ -12,9 +12,9 @@ detect_version
 detect_arch
 
 inherit git-r3 versionator
-EGIT_REPO_URI=https://github.com/raspberrypi/linux.git
-EGIT_PROJECT="raspberrypi-linux.git"
+EGIT_REPO_URI="https://github.com/raspberrypi/linux.git -> raspberrypi-linux.git"
 EGIT_BRANCH="rpi-$(get_version_component_range 1-2).y"
+EGIT_CHECKOUT_DIR="${WORKDIR}/linux-${PV}-raspberrypi"
 
 DESCRIPTION="Raspberry PI kernel sources"
 HOMEPAGE="https://github.com/raspberrypi/linux"


### PR DESCRIPTION
* Replaces use of obsolete eclass variable EGIT_PROJECT (see https://bugs.gentoo.org/633542)

ping @alexxy 