### PR TITLE
dev-util/nvidia-cuda-toolkit: Fix gcc, dep. Got lost during merge.

### DIFF
--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-9.0.176.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-9.0.176.ebuild
@@ -19,7 +19,7 @@ IUSE="debugger doc eclipse profiler"
 DEPEND=""
 RDEPEND="${DEPEND}
 	>=sys-devel/gcc-4.7[cxx]
-	<sys-devel/gcc-6[cxx]
+	<sys-devel/gcc-7[cxx]
 	>=x11-drivers/nvidia-drivers-384.81[X,uvm]
 	debugger? (
 		sys-libs/libtermcap-compat


### PR DESCRIPTION
@amadio It seems you merged not the latest commit. This was already in https://github.com/gentoo/gentoo/pull/5980/files#diff-c1de6c75954bd5670590cc23531017aaR22, but isn't in the now merged ebuild.