### PR TITLE
games-action/minetest: Disable building with Postgresql

### DIFF
--- a/games-action/minetest/minetest-0.4.16.ebuild
+++ b/games-action/minetest/minetest-0.4.16.ebuild
@@ -76,6 +76,7 @@ src_configure() {
 		-DENABLE_GLES=0
 		-DENABLE_LEVELDB=$(usex leveldb)
 		-DENABLE_REDIS=$(usex redis)
+		-DENABLE_POSTGRESQL=0
 		-DENABLE_SPATIAL=$(usex spatial)
 		-DENABLE_SOUND=$(usex sound)
 		-DENABLE_LUAJIT=$(usex luajit)


### PR DESCRIPTION
If this isn't set and you have postegresql installed in your chroot it will actually build and link with it, causing a so called "automagic dependency"