### PR TITLE
dev-libs/tvision: Fix dot-in-INC issue

### DIFF
--- a/dev-libs/tvision/files/tvision-2.1.0_pre2-perl-INC.patch
+++ b/dev-libs/tvision/files/tvision-2.1.0_pre2-perl-INC.patch
@@ -1,0 +1,30 @@
+diff --git a/config.pl b/config.pl
+index 53a7b50..784676b 100644
+--- a/config.pl
++++ b/config.pl
+@@ -5,8 +5,8 @@
+ # To specify the compilation flags define the CFLAGS environment variable.
+ #
+ 
+-require "miscperl.pl";
+-require "conflib.pl";
++require "./miscperl.pl";
++require "./conflib.pl";
+ 
+ # If the script is newer discard the cache.
+ #GetCache() unless (-M 'config.pl' < -M 'configure.cache');
+diff --git a/confignt.pl b/confignt.pl
+index e185f49..9ff7ae6 100644
+--- a/confignt.pl
++++ b/confignt.pl
+@@ -3,8 +3,8 @@
+ # see copyrigh file for details
+ #
+ 
+-require "miscperl.pl";
+-require "conflib.pl";
++require "./miscperl.pl";
++require "./conflib.pl";
+ 
+ SeeCommandLine();
+ 

--- a/dev-libs/tvision/tvision-2.1.0_pre2-r4.ebuild
+++ b/dev-libs/tvision/tvision-2.1.0_pre2-r4.ebuild
@@ -28,6 +28,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-flags.patch"
 	"${FILESDIR}/${P}-gcc6.patch" # bug #594176
 	"${FILESDIR}/${P}-build-system.patch" # for EAPI=6
+	"${FILESDIR}/${P}-perl-INC.patch" # dot-in-INC
 )
 
 src_prepare() {


### PR DESCRIPTION
Patching config.pl and confignt.pl so it uses `require` with explicit path to include local files.