### PR TITLE
dev-vcs/git: update openrc init.d script

### DIFF
--- a/dev-vcs/git/files/git-daemon-r1.initd
+++ b/dev-vcs/git/files/git-daemon-r1.initd
@@ -5,7 +5,8 @@
 pidfile="/var/run/git-daemon.pid"
 command="/usr/bin/git"
 command_args="daemon ${GITDAEMON_OPTS}"
-start_stop_daemon_args="-e HOME= -e XDG_CONFIG_HOME= -b -m -p ${pidfile} -u ${GIT_USER:-nobody}:${GIT_GROUP:-nobody}"
+command_user="${GIT_USER:-nobody}:${GIT_GROUP:-nobody}"
+start_stop_daemon_args="-e HOME= -e XDG_CONFIG_HOME= -b -m"
 
 depend() {
 	use logger


### PR DESCRIPTION
There's no need to duplicate pid in commandline, and moving user/group declaration into specific separate variable is needed as part of fix for https://github.com/OpenRC/openrc/issues/180