### PR TITLE
media-sound/calf add USE flag to enable experimental plugins

### DIFF
--- a/media-plugins/calf/calf-0.0.60-r1.ebuild
+++ b/media-plugins/calf/calf-0.0.60-r1.ebuild
@@ -18,7 +18,7 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE="lash lv2 static-libs"
+IUSE="lash lv2 static-libs experimental"
 
 RDEPEND="dev-libs/atk
 	dev-libs/expat
@@ -44,6 +44,7 @@ src_configure() {
 		--with-lv2-dir=/usr/$(get_libdir)/lv2
 		$(use_with lash)
 		$(use_with lv2)
+		$(use_enable experimental)
 	)
 	autotools-utils_src_configure
 }

--- a/media-plugins/calf/calf-9999.ebuild
+++ b/media-plugins/calf/calf-9999.ebuild
@@ -18,7 +18,7 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE="lash lv2 static-libs"
+IUSE="lash lv2 static-libs experimental"
 
 RDEPEND="dev-libs/atk
 	dev-libs/expat
@@ -40,6 +40,7 @@ src_configure() {
 		--with-lv2-dir=/usr/$(get_libdir)/lv2
 		$(use_with lash)
 		$(use_with lv2)
+		$(use_enable experimental)
 	)
 	autotools-utils_src_configure
 }

--- a/media-plugins/calf/metadata.xml
+++ b/media-plugins/calf/metadata.xml
@@ -6,6 +6,7 @@
     <name>Gentoo ProAudio Project</name>
   </maintainer>
   <use>
+    <flag name="experimental">Enable experimental features/plugins</flag>
     <flag name="lv2">Add support for Ladspa V2</flag>
   </use>
   <upstream>


### PR DESCRIPTION
Fixes bug #599120