### PR TITLE
x11-terms/terminology: fix up live ebuild

### DIFF
--- a/x11-terms/terminology/terminology-9999.ebuild
+++ b/x11-terms/terminology/terminology-9999.ebuild
@@ -9,10 +9,11 @@ if [[ "${PV}" != "9999" ]] ; then
 	SRC_URI="https://download.enlightenment.org/rel/apps/${PN}/${MY_P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 else
+	inherit git-r3
 	EGIT_REPO_URI="https://git.enlightenment.org/apps/${PN}.git"
 fi
 
-inherit git-r3 meson
+inherit meson
 
 DESCRIPTION="Feature rich terminal emulator using the Enlightenment Foundation Libraries"
 HOMEPAGE="https://www.enlightenment.org/p.php?p=about/terminology"

--- a/x11-terms/terminology/terminology-9999.ebuild
+++ b/x11-terms/terminology/terminology-9999.ebuild
@@ -1,23 +1,26 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI="6"
 
 MY_P=${P/_/-}
 
-if [[ "${PV}" == "9999" ]] ; then
-	EGIT_SUB_PROJECT="apps"
-	EGIT_URI_APPEND="${PN}"
-else
+if [[ "${PV}" != "9999" ]] ; then
 	SRC_URI="https://download.enlightenment.org/rel/apps/${PN}/${MY_P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
+else
+	EGIT_REPO_URI="https://git.enlightenment.org/apps/${PN}.git"
 fi
 
-inherit enlightenment
+inherit git-r3 meson
 
 DESCRIPTION="Feature rich terminal emulator using the Enlightenment Foundation Libraries"
 HOMEPAGE="https://www.enlightenment.org/p.php?p=about/terminology"
 
-RDEPEND=">=dev-libs/efl-1.18"
+LICENSE="BSD-2"
+SLOT="0"
+IUSE=""
+
+RDEPEND=">=dev-libs/efl-1.18[X]"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"


### PR DESCRIPTION
Upstream migrated to meson as build system, autotools support has been
removed.
The meson eclass requires EAPI 6, which the enlightenment eclass does
not support.
I feel the enlightenment.eclass has outlived its usefulness, so this
patch drops it completely and replaces it by including an additional 3
lines of boilerplate, which is all that using the eclass saved.

Closes: https://bugs.gentoo.org/637544
Package-Manager: Portage-2.3.13, Repoman-2.3.4