### PR TITLE
sys-devel/ldd-5.0.0: Manually-specified variables were not used by the project: PTHREAD_LIB

### DIFF
--- a/sys-devel/lld/lld-5.0.0.ebuild
+++ b/sys-devel/lld/lld-5.0.0.ebuild
@@ -52,7 +52,7 @@ src_configure() {
 
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 		# TODO: fix detecting pthread upstream in stand-alone build
-		-DPTHREAD_LIB='-lpthread'
+		-DLLVM_PTHREAD_LIB='-lpthread'
 	)
 	use test && mycmakeargs+=(
 		-DLLVM_BUILD_TESTS=ON


### PR DESCRIPTION
```
CMake Warning:
  Manually-specified variables were not used by the project:

    PTHREAD_LIB
```
According to source there is LLVM_PTHREAD_LIB
``` 
LINK_LIBS
  ${LLVM_PTHREAD_LIB}
```