### PR TITLE
dev-util/rebar: Drop to maint-needed

### DIFF
--- a/dev-util/rebar/metadata.xml
+++ b/dev-util/rebar/metadata.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>aranea@aixah.de</email>
-    <name>Luis Ressel</name>
-    <description>Proxy-maintainer, assign bugs</description>
-  </maintainer>
-  <maintainer type="person">
-    <email>djc@gentoo.org</email>
-    <name>Dirkjan Ochtman</name>
-  </maintainer>
-  <maintainer type="project">
-    <email>proxy-maint@gentoo.org</email>
-    <name>Proxy Maintainers</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <upstream>
     <remote-id type="github">rebar/rebar</remote-id>
   </upstream>


### PR DESCRIPTION
When djc dropped maintainership of erlang, I asked on g-dev if someone could take over rebar, but noone stepped up for either erlang or rebar. Since I haven't used it for quite a while and don't really have time for it, I'd like to relinquish maintainership.

rebar is EOL anyway, with a replacement being developed at https://github.com/rebar/rebar3. Unfortunately, it can't be dropped from the tree yet due to a number of revdeps.