### PR TITLE
sci-libs/vtk-7.1.0: patch to use dev-python/twisted

### DIFF
--- a/sci-libs/vtk/vtk-7.1.0.ebuild
+++ b/sci-libs/vtk/vtk-7.1.0.ebuild
@@ -98,8 +98,9 @@ RDEPEND="
 	video_cards_nvidia? ( || ( x11-drivers/nvidia-drivers[tools,static-libs] media-video/nvidia-settings ) )
 	web? (
 		${WEBAPP_DEPEND}
+		dev-python/six[${PYTHON_USEDEP}]
 		dev-python/autobahn[${PYTHON_USEDEP}]
-		dev-python/twisted-core[${PYTHON_USEDEP}]
+		dev-python/twisted[${PYTHON_USEDEP}]
 		dev-python/zope-interface[${PYTHON_USEDEP}]
 	)
 	xdmf2? ( sci-libs/xdmf2 )
@@ -247,6 +248,7 @@ src_configure() {
 			-DVTK_PYTHON_INCLUDE_DIR="$(python_get_includedir)"
 			-DVTK_PYTHON_LIBRARY="$(python_get_library_path)"
 			-DVTK_PYTHON_SETUP_ARGS:STRING="--prefix=${EPREFIX} --root=${D}"
+			-DVTK_USE_SYSTEM_SIX=ON
 		)
 	fi
 


### PR DESCRIPTION
Depending on dev-python/twisted-core and dev-python/autobahn produces
a block, because autobahn depends on dev-python/twisted.

Bug: https://bugs.gentoo.org/637646
Bug: https://bugs.gentoo.org/612702
Package-Manager: Portage-2.3.14, Repoman-2.3.5

Includes patch proposed in bug https://bugs.gentoo.org/612702 to successfully merge to package. Compiles, but has yet not been runtime tested extensively.