### PR TITLE
x11-themes/silver-xcursors: use readme.gentoo-r1.eclass and EAPI=6 (bug #637686)

### DIFF
--- a/x11-themes/silver-xcursors/silver-xcursors-0.4.ebuild
+++ b/x11-themes/silver-xcursors/silver-xcursors-0.4.ebuild
@@ -1,5 +1,9 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit readme.gentoo-r1
 
 MY_P="5533-Silver-XCursors-3D-${PV}"
 DESCRIPTION="A high quality set of Xfree 4.3.0 animated mouse cursors"
@@ -14,31 +18,39 @@ IUSE=""
 RDEPEND=""
 DEPEND="${RDEPEND}"
 
+S="${WORKDIR}/${MY_P:5}"
+
+DOC_CONTENTS="To use this set of cursors, edit or create the file ~/.Xdefaults
+and add the following line:
+Xcursor.theme: Silver
+
+You can change the size by adding a line like:
+Xcursor.size: 48
+
+Also, to globally use this set of mouse cursors edit the file:
+	  /usr/share/cursors/xorg-x11/default/index.theme
+and change the line:
+	Inherits=[current setting]
+to
+	Inherits=Silver
+
+Note this will be overruled by a user's ~/.Xdefaults file."
+
 src_install() {
-	dodir /usr/share/cursors/xorg-x11/Silver/cursors/
-	cp -R  "${WORKDIR}"/${MY_P:5}/Silver/cursors "${D}"/usr/share/cursors/xorg-x11/Silver/ || die
-	dodoc "${WORKDIR}"/${MY_P:5}/README
+	insinto /usr/share/cursors/xorg-x11/Silver
+	doins -r Silver/cursors
+	einstalldocs
+
+	DISABLE_AUTOFORMATTING="yes"
+	readme.gentoo_create_doc
 }
 
 pkg_postinst() {
-	einfo "To use this set of cursors, edit or create the file ~/.Xdefaults"
-	einfo "and add the following line:"
-	einfo "Xcursor.theme: Silver"
-	einfo ""
-	einfo "You can change the size by adding a line like:"
-	einfo "Xcursor.size: 48"
-	einfo ""
-	einfo "Also, to globally use this set of mouse cursors edit the file:"
-	einfo "   /usr/share/cursors/xorg-x11/default/index.theme"
-	einfo "and change the line:"
-	einfo "    Inherits=[current setting]"
-	einfo "to"
-	einfo "    Inherits=Silver"
-	einfo ""
-	einfo "Note this will be overruled by a user's ~/.Xdefaults file."
-	einfo ""
+	DISABLE_AUTOFORMATTING="yes"
+	readme.gentoo_print_elog
+
 	ewarn "If you experience flickering, try setting the following line in"
-	ewarn ""
 	ewarn "the Device section of your xorg.conf file:"
-	ewarn "    Option  \"HWCursor\"  \"false\""
+	ewarn "    Option \"HWCursor\" \"false\""
+
 }


### PR DESCRIPTION
elog should be used instead of einfo for important messages that should
be read by users; moreover elog is logged by default while einfo isn't

https://dev.gentoo.org/~zmedico/portage/doc/portage.html#package-ebuild-helper-functions-output

Closes: https://bugs.gentoo.org/637686