### PR TITLE
net-libs/nodejs: Adding inspector USE flag and enabling icu by default. bug #638456

### DIFF
--- a/net-libs/nodejs/metadata.xml
+++ b/net-libs/nodejs/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Patrick Lauer</name>
 	</maintainer>
 	<use>
+	<flag name="inspector">Enable v8 inspector support</flag>
 	<flag name="npm">Enable NPM package manager</flag>
 	<flag name="snapshot">Enable snapshot creation for faster startup</flag>
 	<flag name="systemtap">Enable SystemTAP/DTrace tracing</flag>

--- a/net-libs/nodejs/nodejs-8.9.1-r1.ebuild
+++ b/net-libs/nodejs/nodejs-8.9.1-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz"
 LICENSE="Apache-1.1 Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x64-macos"
-IUSE="cpu_flags_x86_sse2 debug doc icu +npm +snapshot +ssl systemtap test"
+IUSE="cpu_flags_x86_sse2 debug doc +icu +inspector +npm +snapshot +ssl systemtap test"
 
 RDEPEND="
 	>=dev-libs/libuv-1.15.0:=
@@ -33,7 +33,8 @@ DEPEND="${RDEPEND}
 	test? ( net-misc/curl )"
 
 S="${WORKDIR}/node-v${PV}"
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}
+inspector? ( icu ssl )"
 
 PATCHES=(
 	"${FILESDIR}"/gentoo-global-npm-config.patch
@@ -94,6 +95,7 @@ src_configure() {
 	local myconf=( --shared-http-parser --shared-libuv --shared-nghttp2 --shared-zlib )
 	use debug && myconf+=( --debug )
 	use icu && myconf+=( --with-intl=system-icu ) || myconf+=( --with-intl=none )
+	use inspector || myconf+=( --without-inspector )
 	use npm || myconf+=( --without-npm )
 	use snapshot && myconf+=( --with-snapshot )
 	use ssl && myconf+=( --shared-openssl ) || myconf+=( --without-ssl )

--- a/net-libs/nodejs/nodejs-9.2.0-r1.ebuild
+++ b/net-libs/nodejs/nodejs-9.2.0-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz"
 LICENSE="Apache-1.1 Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x64-macos"
-IUSE="cpu_flags_x86_sse2 debug doc icu +npm +snapshot +ssl systemtap test"
+IUSE="cpu_flags_x86_sse2 debug doc +icu +inspector +npm +snapshot +ssl systemtap test"
 
 RDEPEND="
 	>=dev-libs/libuv-1.16.1:=
@@ -33,7 +33,8 @@ DEPEND="${RDEPEND}
 	test? ( net-misc/curl )"
 
 S="${WORKDIR}/node-v${PV}"
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}
+inspector? ( icu ssl )"
 
 PATCHES=(
 	"${FILESDIR}"/gentoo-global-npm-config.patch
@@ -94,6 +95,7 @@ src_configure() {
 	local myconf=( --shared-http-parser --shared-libuv --shared-nghttp2 --shared-zlib )
 	use debug && myconf+=( --debug )
 	use icu && myconf+=( --with-intl=system-icu ) || myconf+=( --with-intl=none )
+	use inspector || myconf+=( --without-inspector )
 	use npm || myconf+=( --without-npm )
 	use snapshot && myconf+=( --with-snapshot )
 	use ssl && myconf+=( --shared-openssl ) || myconf+=( --without-ssl )


### PR DESCRIPTION
Since Node 8, `icu` and `ssl` are required to use the v8 inspector. Since this isn't mentioned anywhere, it might be confusing for some users to try to use the debugger and get this message:

`Inspector support is not available with this Node.js build`

Because `icu` isn't enabled. This PR adds a `inspector` USE flag with the correct `REQUIRED_USE`, and sets `+icu` and `+inspector` by default. I believe it's the common use case to have the inspector enabled by default.