### PR TITLE
app-text/docbook-dsssl-stylesheets: update homepage

### DIFF
--- a/app-text/docbook-dsssl-stylesheets/docbook-dsssl-stylesheets-1.79-r2.ebuild
+++ b/app-text/docbook-dsssl-stylesheets/docbook-dsssl-stylesheets-1.79-r2.ebuild
@@ -8,7 +8,7 @@ inherit sgml-catalog
 MY_P=${P/-stylesheets/}
 S=${WORKDIR}/${MY_P}
 DESCRIPTION="DSSSL Stylesheets for DocBook"
-HOMEPAGE="http://wiki.docbook.org/topic/DocBookDssslStylesheets"
+HOMEPAGE="https://github.com/docbook/wiki/wiki"
 SRC_URI="mirror://sourceforge/docbook/${MY_P}.tar.bz2"
 
 LICENSE="MIT"

--- a/app-text/docbook-dsssl-stylesheets/docbook-dsssl-stylesheets-1.79.ebuild
+++ b/app-text/docbook-dsssl-stylesheets/docbook-dsssl-stylesheets-1.79.ebuild
@@ -8,7 +8,7 @@ inherit sgml-catalog
 MY_P=${P/-stylesheets/}
 S=${WORKDIR}/${MY_P}
 DESCRIPTION="DSSSL Stylesheets for DocBook"
-HOMEPAGE="http://wiki.docbook.org/topic/DocBookDssslStylesheets"
+HOMEPAGE="https://github.com/docbook/wiki/wiki"
 SRC_URI="mirror://sourceforge/docbook/${MY_P}.tar.bz2"
 
 LICENSE="MIT"


### PR DESCRIPTION
Docbook homepage has been moved to https://github.com/docbook/wiki/wiki

There's no section for the DSSSL stylesheets, only a paragraph where they are told, but only with a link to the XSL stylesheets.

Last update of the source code on sourceforge was in 2004, last bug report in 2006, 28 open issues. Looks to me like it is not maintained any more.

