### PR TITLE
Partially revert "games-*/*: Remove stable keywords"

### DIFF
--- a/games-emulation/dolphin/dolphin-5.0.ebuild
+++ b/games-emulation/dolphin/dolphin-5.0.ebuild
@@ -10,7 +10,7 @@ WX_GTK_VER="3.0"
 inherit cmake-utils eutils l10n pax-utils toolchain-funcs versionator wxwidgets
 
 SRC_URI="https://github.com/${PN}-emu/${PN}/archive/${PV}.zip -> ${P}.zip"
-KEYWORDS="~amd64"
+KEYWORDS="amd64"
 
 DESCRIPTION="Gamecube and Wii game emulator"
 HOMEPAGE="https://www.dolphin-emu.org/"

--- a/games-emulation/mgba/mgba-0.5.2.ebuild
+++ b/games-emulation/mgba/mgba-0.5.2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/${PN}-emu/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MPL-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 ~x86"
 IUSE="ffmpeg imagemagick opengl qt5 +sdl"
 REQUIRED_USE="|| ( qt5 sdl )
 		qt5? ( opengl )"

--- a/games-emulation/pcsx2/pcsx2-1.4.0.ebuild
+++ b/games-emulation/pcsx2/pcsx2-1.4.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/PCSX2/${PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="-* ~amd64 ~x86"
+KEYWORDS="-* amd64 x86"
 IUSE=""
 
 RDEPEND="

--- a/games-engines/renpy/renpy-6.17.7.ebuild
+++ b/games-engines/renpy/renpy-6.17.7.ebuild
@@ -13,7 +13,7 @@ SRC_URI="http://www.renpy.org/dl/${PV}/${P}-source.tar.bz2"
 LICENSE="MIT"
 SLOT="$(get_version_component_range 1-2)"
 MYSLOT=$(delete_all_version_separators ${SLOT})
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="development doc examples"
 REQUIRED_USE="examples? ( development )"
 

--- a/games-engines/renpy/renpy-6.99.12.4-r3.ebuild
+++ b/games-engines/renpy/renpy-6.99.12.4-r3.ebuild
@@ -13,7 +13,7 @@ SRC_URI="http://www.renpy.org/dl/${PV}/${P}-source.tar.bz2"
 LICENSE="MIT"
 SLOT="$(get_version_component_range 1-2)"
 MYSLOT=$(delete_all_version_separators ${SLOT})
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="development doc examples"
 REQUIRED_USE="examples? ( development )"
 

--- a/games-misc/fortune-mod-gentoo-ru/fortune-mod-gentoo-ru-0.25.ebuild
+++ b/games-misc/fortune-mod-gentoo-ru/fortune-mod-gentoo-ru-0.25.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://slepnoga.googlecode.com/files/gentoo-ru-${PV}.gz
 
 LICENSE="fairuse"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND="games-misc/fortune-mod"

--- a/games-misc/fortune-mod-gentoo-ru/fortune-mod-gentoo-ru-0.26.ebuild
+++ b/games-misc/fortune-mod-gentoo-ru/fortune-mod-gentoo-ru-0.26.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://slepnoga.googlecode.com/files/gentoo-ru-${PV}.gz
 
 LICENSE="fairuse"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND="games-misc/fortune-mod"

--- a/games-misc/xcowsay/xcowsay-1.3.ebuild
+++ b/games-misc/xcowsay/xcowsay-1.3.ebuild
@@ -9,7 +9,7 @@ SRC_URI="http://www.nickg.me.uk/files/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="dbus fortune"
 
 RDEPEND="dbus? ( sys-apps/dbus )

--- a/games-strategy/seven-kingdoms/seven-kingdoms-2.14.4.ebuild
+++ b/games-strategy/seven-kingdoms/seven-kingdoms-2.14.4.ebuild
@@ -18,7 +18,7 @@ SRC_URI="mirror://sourceforge/skfans/${MY_PN}-source-${PV}.tar.bz2
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="network"
 
 DEPEND="media-libs/libsdl[X,video]

--- a/games-util/pogo-manager-bin/pogo-manager-bin-0.1.6.ebuild
+++ b/games-util/pogo-manager-bin/pogo-manager-bin-0.1.6.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/Wolfsblvt/BlossomsPokemonGoManager/releases/download
 
 LICENSE="CC-BY-NC-SA-4.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 ~x86"
 IUSE=""
 
 RDEPEND="|| ( dev-java/oracle-jdk-bin:1.8[javafx] dev-java/oracle-jre-bin:1.8[javafx] )"

--- a/games-util/wit/wit-2.40a.ebuild
+++ b/games-util/wit/wit-2.40a.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://dev.gentoo.org/~radhermit/distfiles/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="+fuse +zlib"
 
 RDEPEND="


### PR DESCRIPTION
Unstabled packages not maintained by Games team.
This partially reverts commit c9617875332b1b9c894c850a1f8d8dcc1897f33f.