### PR TITLE
app-i18n/uchardet: backport patch to enforce IEEE float precision

### DIFF
--- a/app-i18n/uchardet/files/uchardet-0.0.6-enforce-IEEE-float-precision.patch
+++ b/app-i18n/uchardet/files/uchardet-0.0.6-enforce-IEEE-float-precision.patch
@@ -1,0 +1,53 @@
+Add configuration option to enable SSE2.
+Add -ffloat-store flag on x86 without SSE2.
+
+Gentoo bug: https://bugs.gentoo.org/631852
+Upstream bug: https://bugs.freedesktop.org/show_bug.cgi?id=101033
+
+This patch is an aggregation of the following upstream commits:
+5996bbd995aed5045cc22e4d1fab08c989377983
+77bf71ea365a19ac55c59cf10399b566a02d82c1
+939482ab2b5a6585bdd2e5251f3f2f113d64686f
+cd617d181de03a7a13c2020e6c73cd14585e24b6
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 84270e3..e212b4a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,6 @@
+ ######## Project settings
+ cmake_minimum_required(VERSION 2.8.5)
++include(CheckCCompilerFlag)
+ set (PACKAGE_NAME uchardet)
+ project (${PACKAGE_NAME} CXX C)
+ enable_testing()
+@@ -35,13 +36,27 @@ include(GNUInstallDirs)
+
+ ######## Configuration
+
+-option(BUILD_BINARY "Build executable" ON)
+-option(BUILD_SHARED_LIBS "Build shared library and link executable to it" ON)
++option(BUILD_BINARY "Build the CLI tool." ON)
++option(BUILD_SHARED_LIBS "Build shared library and link executable to it." ON)
++option(CHECK_SSE2 "Check and enable SSE2 extensions if supported. Disabling SSE on platforms which support it may decrease performances." ON)
+
+ if (BUILD_SHARED_LIBS)
+ 	option(BUILD_STATIC "Build static library" ON)
+ endif (BUILD_SHARED_LIBS)
+
++string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} TARGET_ARCHITECTURE)
++if (TARGET_ARCHITECTURE MATCHES ".*(x86)|(amd).*")
++    CHECK_C_COMPILER_FLAG(-msse2 SUPPORTS_CFLAG_SSE2)
++    CHECK_C_COMPILER_FLAG(-mfpmath=sse SUPPORTS_CFLAG_SSE_MATH)
++    if (CHECK_SSE2 AND SUPPORTS_CFLAG_SSE2 AND SUPPORTS_CFLAG_SSE_MATH)
++        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -mfpmath=sse")
++        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse")
++    else (CHECK_SSE2 AND SUPPORTS_CFLAG_SSE2 AND SUPPORTS_CFLAG_SSE_MATH)
++        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffloat-store")
++        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffloat-store")
++    endif (CHECK_SSE2 AND SUPPORTS_CFLAG_SSE2 AND SUPPORTS_CFLAG_SSE_MATH)
++endif (TARGET_ARCHITECTURE MATCHES ".*(x86)|(amd).*")
++
+ configure_file(
+ 	uchardet.pc.in
+ 	uchardet.pc

--- a/app-i18n/uchardet/uchardet-0.0.6-r1.ebuild
+++ b/app-i18n/uchardet/uchardet-0.0.6-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils
+
+DESCRIPTION="An encoding detector library"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/uchardet/"
+SRC_URI="https://www.freedesktop.org/software/uchardet/releases/${P}.tar.xz"
+
+LICENSE="|| ( MPL-1.1 GPL-2+ LGPL-2.1+ )"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+IUSE="cpu_flags_x86_sse2 static-libs test"
+
+PATCHES=( "${FILESDIR}/${P}-enforce-IEEE-float-precision.patch" )
+
+src_prepare() {
+	cmake-utils_src_prepare
+	use test || cmake_comment_add_subdirectory test
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_STATIC=$(usex static-libs)
+		-DCHECK_SSE2=$(usex cpu_flags_x86_sse2)
+	)
+	cmake-utils_src_configure
+}

--- a/app-i18n/uchardet/uchardet-9999.ebuild
+++ b/app-i18n/uchardet/uchardet-9999.ebuild
@@ -12,7 +12,7 @@ EGIT_REPO_URI="https://anongit.freedesktop.org/git/uchardet/uchardet.git"
 LICENSE="|| ( MPL-1.1 GPL-2+ LGPL-2.1+ )"
 SLOT="0"
 KEYWORDS=""
-IUSE="static-libs test"
+IUSE="cpu_flags_x86_sse2 static-libs test"
 
 src_prepare() {
 	cmake-utils_src_prepare
@@ -22,6 +22,7 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DBUILD_STATIC=$(usex static-libs)
+		-DCHECK_SSE2=$(usex cpu_flags_x86_sse2)
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
Tested and works on a regular SSE2 amd64 machine and in a x86 chroot with SSE2 disabled on the same machine.