### PR TITLE
app-backup/restic: add bash-completion support

### DIFF
--- a/app-backup/restic/restic-0.7.3-r1.ebuild
+++ b/app-backup/restic/restic-0.7.3-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit golang-vcs-snapshot bash-completion-r1
+
+DESCRIPTION="A backup program that is fast, efficient and secure"
+HOMEPAGE="https://restic.github.io/"
+SRC_URI="https://github.com/restic/restic/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+EGO_PN="github.com/restic/restic"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="test bash-completion"
+
+DOCS=(
+	README.rst CONTRIBUTING.md doc/design.rst
+	doc/faq.rst doc/index.rst doc/manual.rst
+	doc/rest_backend.rst doc/development.rst
+	doc/talks.rst doc/tutorial_aws_s3.rst doc/installation.rst
+)
+
+DEPEND="
+	dev-lang/go
+	test? ( sys-fs/fuse:0 )"
+
+RDEPEND="sys-fs/fuse:0"
+
+S="${WORKDIR}/${P}/src/${EGO_PN}"
+
+src_compile() {
+	local mygoargs=(
+		-v
+		-work
+		-x
+		-tags release
+		-ldflags "-s -w -X main.version=${PV}"
+		-asmflags "-trimpath=${S}"
+		-gcflags "-trimpath=${S}"
+		-o restic ${EGO_PN}/cmd/restic
+	)
+
+	GOPATH="${WORKDIR}/${P}:$(get_golibdir_gopath)" \
+		go build "${mygoargs[@]}" || die
+}
+
+src_test() {
+	GOPATH="${WORKDIR}/${P}:$(get_golibdir_gopath)" \
+		go test -timeout 30m -v -work -x ${EGO_PN}/cmd/... ${EGO_PN}/internal/... || die
+}
+
+src_install() {
+	dobin restic
+	einstalldocs
+
+	local i
+	for i in doc/man/*; do
+		doman "$i"
+	done
+
+	if use bash-completion ; then
+		# restic generates it's own bash-comp file
+		GOPATH="${WORKDIR}/${P}:$(get_golibdir_gopath)" \
+			"${S}/restic" autocomplete --completionfile "${T}/${PN}.bash-completion" || die
+		newbashcomp "${T}/${PN}.bash-completion" ${PN}
+	fi
+}


### PR DESCRIPTION
Have ebuild generate the bash completion script with the restic executable and install it (conditionally on bash-completion flag, naturally).

Package-Manager: Portage-2.3.13, Repoman-2.3.3