### PR TITLE
media-sound/helm Fix dependencies

### DIFF
--- a/media-sound/helm/helm-0.4.1-r2.ebuild
+++ b/media-sound/helm/helm-0.4.1-r2.ebuild
@@ -14,11 +14,15 @@ KEYWORDS="~amd64"
 IUSE=""
 
 RDEPEND="media-libs/alsa-lib
+	media-libs/freetype
 	media-libs/lv2
 	virtual/jack
 	virtual/opengl
 	x11-libs/libX11
-	x11-libs/libXext"
+	x11-libs/libXcursor
+	x11-libs/libXext
+	x11-libs/libXinerama
+	x11-libs/libXrandr"
 DEPEND="${RDEPEND}"
 
 DOCS="README.md"


### PR DESCRIPTION
Small PR to fix the required dependencies for the current Helm version in the tree. This way the current version of Helm in the tree can at least be properly compiled. Validated in a clean amd64 stage3.

Should I revbump the ebuild because of this change?

I'll create a new bug to bump Helm to the current version, want to keep the changes small :)
[edit] Bug has been created, see https://bugs.gentoo.org/638150

Closes: https://bugs.gentoo.org/585202

