### PR TITLE
media-gfx/jhead: add libjhead

### DIFF
--- a/media-gfx/jhead/files/Makefile
+++ b/media-gfx/jhead/files/Makefile
@@ -1,0 +1,44 @@
+#--------------------------------
+# jhead makefile for Unix
+# this make file also creates libjhead for meshlab
+#--------------------------------
+OBJ=.
+SRC=.
+AR = ar cqs
+LFLAGS = -shared -Wl,-soname,libjhead.so.1
+
+objs = $(OBJ)/jhead.o $(OBJ)/jpgfile.o $(OBJ)/jpgqguess.o $(OBJ)/paths.o \
+	$(OBJ)/exif.o $(OBJ)/iptc.o $(OBJ)/gpsinfo.o $(OBJ)/makernote.o 
+
+TARGET        = libjhead.so.1.0.0
+TARGET0       = libjhead.so
+TARGET1       = libjhead.so.1
+TARGET2       = libjhead.so.1.0
+
+all: jhead $(TARGET) 
+
+$(OBJ)/%.o:$(SRC)/%.c
+	${CC} -fPIC $(CFLAGS) -c $< -o $@
+
+jhead: $(objs) jhead.h
+	${CC} ${LDFLAGS} -o jhead $(objs) -lm
+
+clean:
+	rm -f $(objs) jhead ${TARGET} ${TARGETA} ${TARGET0} ${TARGETD} \
+	 ${TARGET1} ${TARGET2}
+ 
+install:
+	cp jhead ${DESTDIR}/usr/bin/
+	cp ${TARGET} ${DESTDIR}/usr/lib/
+	cp jhead ${DESTDIR}/usr/bin/
+	cp ${TARGET0} ${DESTDIR}/usr/lib/
+	cp ${TARGET1} ${DESTDIR}/usr/lib/
+	cp ${TARGET2} ${DESTDIR}/usr/lib/
+
+$(TARGET):  $(objs) jhead
+	${CC} $(LDFLAGS) $(LFLAGS) -o $(TARGET) $(objs) 
+	ln -s ${TARGET} ${TARGET0}
+	ln -s ${TARGET} ${TARGET1}
+	ln -s ${TARGET} ${TARGET2}
+
+	

--- a/media-gfx/jhead/jhead-3.00-r1.ebuild
+++ b/media-gfx/jhead/jhead-3.00-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit toolchain-funcs
+
+DESCRIPTION="Exif Jpeg camera setting parser and thumbnail remover"
+HOMEPAGE="http://www.sentex.net/~mwandel/jhead"
+SRC_URI="http://www.sentex.net/~mwandel/${PN}/${P}.tar.gz"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+src_prepare(){
+	# bug 275200 - respect flags and use mktemp instead of mkstemp
+	eapply "${FILESDIR}/${PN}-2.90-mkstemp_respect_flags.patch"
+	cp "${FILESDIR}/Makefile" makefile || die
+	eapply_user
+}
+
+src_install() {
+	dobin ${PN}
+	dodoc *.txt
+	docinto html
+	dodoc *.html
+	doman ${PN}.1
+	dolib.so libjhead.so*
+}


### PR DESCRIPTION
compile jhead as a library and a binary
for media-gfx/meshlab-2016.12 also remove
unnecessary src_compile function