### PR TITLE
games-strategy/wesnoth: drop lua dependency

### DIFF
--- a/games-strategy/wesnoth/wesnoth-1.12.6.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.12.6.ebuild
@@ -23,7 +23,6 @@ RDEPEND=">=media-libs/libsdl-1.2.7:0[joystick,video,X]
 		dbus? ( sys-apps/dbus )
 		sys-libs/zlib
 		x11-libs/pango
-		dev-lang/lua:0
 		media-libs/fontconfig
 	)
 	>=dev-libs/boost-1.48:=[nls,threads]


### PR DESCRIPTION
Wesnoth uses its own bundled-in lua
Bug 299068 no longer applies