### PR TITLE
Fixed issue with games-puzzle/sgt-puzzles having duplicate menu entries.

### DIFF
--- a/games-puzzle/sgt-puzzles/sgt-puzzles-20170314.ebuild
+++ b/games-puzzle/sgt-puzzles/sgt-puzzles-20170314.ebuild
@@ -84,7 +84,7 @@ src_install() {
 		name=$(awk -F: '/exe:/ { print $3 }' "${file}")
 		file=${file%.R}
 		newicon -s 48 icons/${file}-48d24.png ${PN}_${file}.png
-		make_desktop_entry "${PN}_${file}" "${name}" "${PN}_${file}" "Game;LogicGame;X-${PN};"
+		make_desktop_entry "${PN}_${file}" "${name}" "${PN}_${file}" "LogicGame;X-${PN};"
 	done
 
 	if use doc ; then

--- a/games-puzzle/sgt-puzzles/sgt-puzzles-20170514.ebuild
+++ b/games-puzzle/sgt-puzzles/sgt-puzzles-20170514.ebuild
@@ -84,7 +84,7 @@ src_install() {
 		name=$(awk -F: '/exe:/ { print $3 }' "${file}")
 		file=${file%.R}
 		newicon -s 48 icons/${file}-48d24.png ${PN}_${file}.png
-		make_desktop_entry "${PN}_${file}" "${name}" "${PN}_${file}" "Game;LogicGame;X-${PN};"
+		make_desktop_entry "${PN}_${file}" "${name}" "${PN}_${file}" "LogicGame;X-${PN};"
 	done
 
 	if use doc ; then

--- a/games-puzzle/sgt-puzzles/sgt-puzzles-20171029.ebuild
+++ b/games-puzzle/sgt-puzzles/sgt-puzzles-20171029.ebuild
@@ -84,7 +84,7 @@ src_install() {
 		name=$(awk -F: '/exe:/ { print $3 }' "${file}")
 		file=${file%.R}
 		newicon -s 48 icons/${file}-48d24.png ${PN}_${file}.png
-		make_desktop_entry "${PN}_${file}" "${name}" "${PN}_${file}" "Game;LogicGame;X-${PN};"
+		make_desktop_entry "${PN}_${file}" "${name}" "${PN}_${file}" "LogicGame;X-${PN};"
 	done
 
 	if use doc ; then

--- a/games-puzzle/sgt-puzzles/sgt-puzzles-99999999.ebuild
+++ b/games-puzzle/sgt-puzzles/sgt-puzzles-99999999.ebuild
@@ -84,7 +84,7 @@ src_install() {
 		name=$(awk -F: '/exe:/ { print $3 }' "${file}")
 		file=${file%.R}
 		newicon -s 48 icons/${file}-48d24.png ${PN}_${file}.png
-		make_desktop_entry "${PN}_${file}" "${name}" "${PN}_${file}" "Game;LogicGame;X-${PN};"
+		make_desktop_entry "${PN}_${file}" "${name}" "${PN}_${file}" "LogicGame;X-${PN};"
 	done
 
 	if use doc ; then


### PR DESCRIPTION
ebuild creates a menu folder in Games/Puzzles/ therefore category Game; needs to be removed otherwise the puzzles will appear in Games/Puzzles/ AND in Games/ which is quite some overkill.