### PR TITLE
x11-misc/xembedsniproxy: drop extraneous depend

### DIFF
--- a/x11-misc/xembedsniproxy/xembedsniproxy-5.10.3.ebuild
+++ b/x11-misc/xembedsniproxy/xembedsniproxy-5.10.3.ebuild
@@ -18,7 +18,6 @@ CDEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtdbus:5
 	dev-qt/qtx11extras:5
-	kde-frameworks/kwindowsystem:5
 	x11-libs/libxcb
 	x11-libs/libXtst
 	x11-libs/xcb-util-image


### PR DESCRIPTION
drop depend on kde-frameworks/kwindowsystem