### PR TITLE
x11-drivers/xf86-video-ati: Update libDRM dependency

### DIFF
--- a/x11-drivers/xf86-video-ati/xf86-video-ati-7.10.0.ebuild
+++ b/x11-drivers/xf86-video-ati/xf86-video-ati-7.10.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.x.org/wiki/ati/"
 KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd"
 IUSE="+glamor udev"
 
-RDEPEND=">=x11-libs/libdrm-2.4.58[video_cards_radeon]
+RDEPEND=">=x11-libs/libdrm-2.4.78[video_cards_radeon]
 	>=x11-libs/libpciaccess-0.8.0
 	glamor? ( x11-base/xorg-server[glamor] )
 	udev? ( virtual/udev )"

--- a/x11-drivers/xf86-video-ati/xf86-video-ati-7.9.0.ebuild
+++ b/x11-drivers/xf86-video-ati/xf86-video-ati-7.9.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="http://www.x.org/wiki/ati/"
 KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~amd64-fbsd"
 IUSE="+glamor udev"
 
-RDEPEND=">=x11-libs/libdrm-2.4.58[video_cards_radeon]
+RDEPEND=">=x11-libs/libdrm-2.4.60[video_cards_radeon]
 	>=x11-libs/libpciaccess-0.8.0
 	glamor? ( x11-base/xorg-server[glamor] )
 	udev? ( virtual/udev )"


### PR DESCRIPTION
Based on the configure.ac from both versions. 

Fixes: https://bugs.gentoo.org/635190
@mattst88 

Signed-off-by: Nick Sarnie <commendsarnex@gmail.com>