### PR TITLE
app-arch/unzip: add -DUSE_ICONV_MAPPING on USE=unicode

### DIFF
--- a/app-arch/unzip/unzip-6.0_p21-r1.ebuild
+++ b/app-arch/unzip/unzip-6.0_p21-r1.ebuild
@@ -1,0 +1,85 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+inherit eutils toolchain-funcs flag-o-matic
+
+MY_PV="${PV//.}"
+MY_PV="${MY_PV%_p*}"
+MY_P="${PN}${MY_PV}"
+
+DESCRIPTION="unzipper for pkzip-compressed files"
+HOMEPAGE="http://www.info-zip.org/"
+SRC_URI="mirror://sourceforge/infozip/${MY_P}.tar.gz
+	mirror://debian/pool/main/u/${PN}/${PN}_${PV/_p/-}.debian.tar.xz"
+
+LICENSE="Info-ZIP"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~arm-linux ~x86-linux"
+IUSE="bzip2 natspec unicode"
+
+DEPEND="bzip2? ( app-arch/bzip2 )
+	natspec? ( dev-libs/libnatspec )"
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	local deb="${WORKDIR}"/debian/patches
+	rm "${deb}"/02-this-is-debian-unzip.patch || die
+	eapply "${deb}"/*.patch
+
+	eapply "${FILESDIR}"/${PN}-6.0-no-exec-stack.patch
+	use natspec && eapply "${FILESDIR}/${PN}-6.0-natspec.patch" #275244
+	sed -i -r \
+		-e '/^CFLAGS/d' \
+		-e '/CFLAGS/s:-O[0-9]?:$(CFLAGS) $(CPPFLAGS):' \
+		-e '/^STRIP/s:=.*:=true:' \
+		-e "s:\<CC *= *\"?g?cc2?\"?\>:CC=\"$(tc-getCC)\":" \
+		-e "s:\<LD *= *\"?(g?cc2?|ld)\"?\>:LD=\"$(tc-getCC)\":" \
+		-e "s:\<AS *= *\"?(g?cc2?|as)\"?\>:AS=\"$(tc-getCC)\":" \
+		-e 's:LF2 = -s:LF2 = :' \
+		-e 's:LF = :LF = $(LDFLAGS) :' \
+		-e 's:SL = :SL = $(LDFLAGS) :' \
+		-e 's:FL = :FL = $(LDFLAGS) :' \
+		-e "/^#L_BZ2/s:^$(use bzip2 && echo .)::" \
+		-e 's:$(AS) :$(AS) $(ASFLAGS) :g' \
+		unix/Makefile \
+		|| die "sed unix/Makefile failed"
+
+	# Delete bundled code to make sure we don't use it.
+	rm -r bzip2 || die
+
+	eapply_user
+}
+
+src_configure() {
+	case ${CHOST} in
+	i?86*-*linux*)       TARGET="linux_asm" ;;
+	*linux*)             TARGET="linux_noasm" ;;
+	i?86*-*bsd* | \
+	i?86*-dragonfly*)    TARGET="freebsd" ;; # mislabelled bsd with x86 asm
+	*bsd* | *dragonfly*) TARGET="bsd" ;;
+	*-darwin*)           TARGET="macosx" ;;
+	*-cygwin*)           TARGET="cygwin" ;;
+	*) die "Unknown target; please update the ebuild to handle ${CHOST}	" ;;
+	esac
+
+	[[ ${CHOST} == *linux* ]] && append-cppflags -DNO_LCHMOD
+	use bzip2 && append-cppflags -DUSE_BZIP2
+	use unicode && append-cppflags -DUNICODE_SUPPORT -DUNICODE_WCHAR -DUTF8_MAYBE_NATIVE -DUSE_ICONV_MAPPING
+	append-cppflags -DLARGE_FILE_SUPPORT #281473
+}
+
+src_compile() {
+	ASFLAGS="${ASFLAGS} $(get_abi_var CFLAGS)" \
+	emake -f unix/Makefile ${TARGET}
+}
+
+src_install() {
+	dobin unzip funzip unzipsfx unix/zipgrep
+	dosym unzip /usr/bin/zipinfo
+	doman man/*.1
+	dodoc BUGS History* README ToDo WHERE
+}


### PR DESCRIPTION
This build flag enables charset conversion for non-UTF8 zip files via
the -I and -O options. Without it, it is impossible to extract e.g.
Japanese SJIS encoded zip files without irreparably mangling all the
filenames.

Note that this uses libc's iconv, not libiconv, so no additional
dependencies are required.