### PR TITLE
app-antivirus/clamav: fix dependencies in libpcre & libpcre2

### DIFF
--- a/app-antivirus/clamav/clamav-0.99.2-r1.ebuild
+++ b/app-antivirus/clamav/clamav-0.99.2-r1.ebuild
@@ -24,7 +24,7 @@ CDEPEND="bzip2? ( app-arch/bzip2 )
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )
 	sys-devel/libtool
-	>dev-libs/libpcre-6
+	|| ( dev-libs/libpcre2 >dev-libs/libpcre-6 )
 	!!<app-antivirus/clamav-0.99"
 # hard block clamav < 0.99 due to linking problems Bug #567680
 # openssl is now *required* see this link as to why


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/628068
Closes: https://bugs.gentoo.org/603940