### PR TITLE
x11-*: Remove glamor USE from amdgpu, make glamor USE default on xorg-server

### DIFF
--- a/x11-base/xorg-server/xorg-server-1.19.5-r1.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.19.5-r1.ebuild
@@ -12,7 +12,7 @@ SLOT="0/${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux"
 
 IUSE_SERVERS="dmx kdrive wayland xephyr xnest xorg xvfb"
-IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux systemd tslib +udev unwind xcsecurity"
+IUSE="${IUSE_SERVERS} debug +glamor ipv6 libressl minimal selinux systemd tslib +udev unwind xcsecurity"
 
 CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	!libressl? ( dev-libs/openssl:0= )

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -12,7 +12,7 @@ SLOT="0/${PV}"
 KEYWORDS=""
 
 IUSE_SERVERS="dmx kdrive wayland xephyr xnest xorg xvfb"
-IUSE="${IUSE_SERVERS} debug glamor ipv6 libressl minimal selinux systemd +udev unwind xcsecurity"
+IUSE="${IUSE_SERVERS} debug +glamor ipv6 libressl minimal selinux systemd +udev unwind xcsecurity"
 
 CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	!libressl? ( dev-libs/openssl:0= )

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-1.4.0.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-1.4.0.ebuild
@@ -13,13 +13,10 @@ fi
 
 DESCRIPTION="Accelerated Open Source driver for AMDGPU cards"
 
-IUSE="glamor"
-
 RDEPEND=">=x11-libs/libdrm-2.4.72[video_cards_amdgpu]
-	x11-base/xorg-server[glamor(-)?]"
+	x11-base/xorg-server[glamor]"
 DEPEND="${RDEPEND}"
 
 src_configure() {
-	XORG_CONFIGURE_OPTIONS="$(use_enable glamor)"
 	xorg-2_src_configure
 }

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
@@ -13,13 +13,10 @@ fi
 
 DESCRIPTION="Accelerated Open Source driver for AMDGPU cards"
 
-IUSE="glamor"
-
 RDEPEND=">=x11-libs/libdrm-2.4.72[video_cards_amdgpu]
-	x11-base/xorg-server[glamor(-)?]"
+	x11-base/xorg-server[glamor]"
 DEPEND="${RDEPEND}"
 
 src_configure() {
-	XORG_CONFIGURE_OPTIONS="$(use_enable glamor)"
 	xorg-2_src_configure
 }


### PR DESCRIPTION
The first patch removes the glamor USE from the amdgpu ddx, and requires +glamor from xorg-server

The second patch sets glamor as a default USE for xorg-server because it is widely used or required

I'm keeping the glamor metadata for amdgpu because stable is still using it.

@mattst88 

Thanks!

Closes: https://bugs.gentoo.org/623142