### PR TITLE
app-emulation/qemu: Make CONFIG_CHECK CPU-model dependent

### DIFF
--- a/app-emulation/qemu/qemu-2.10.1-r1.ebuild
+++ b/app-emulation/qemu/qemu-2.10.1-r1.ebuild
@@ -286,7 +286,11 @@ pkg_pretend() {
 			ERROR_VHOST_NET+=" support"
 
 			if use amd64 || use x86 || use amd64-linux || use x86-linux; then
-				CONFIG_CHECK+=" ~KVM_AMD ~KVM_INTEL"
+				if grep -q AuthenticAMD /proc/cpuinfo; then
+					CONFIG_CHECK+=" ~KVM_AMD"
+				elif grep -q GenuineIntel /proc/cpuinfo; then
+					CONFIG_CHECK+=" ~KVM_INTEL"
+				fi
 			fi
 
 			use python && CONFIG_CHECK+=" ~DEBUG_FS"

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -283,7 +283,11 @@ pkg_pretend() {
 			ERROR_VHOST_NET+=" support"
 
 			if use amd64 || use x86 || use amd64-linux || use x86-linux; then
-				CONFIG_CHECK+=" ~KVM_AMD ~KVM_INTEL"
+				if grep -q AuthenticAMD /proc/cpuinfo; then
+					CONFIG_CHECK+=" ~KVM_AMD"
+				elif grep -q GenuineIntel /proc/cpuinfo; then
+					CONFIG_CHECK+=" ~KVM_INTEL"
+				fi
 			fi
 
 			use python && CONFIG_CHECK+=" ~DEBUG_FS"


### PR DESCRIPTION
Every time I emerge qemu, I get

```
ERROR: pretend
  If you have an AMD CPU, you must enable KVM_AMD in your kernel configuration.
WARN: pretend
Please check to make sure these options are set correctly.
Failure to do so may cause unexpected problems.
```

As an Intel fanboy and shareholder, I find the assumption that I might own an AMD processor completely offensive.

This pull request makes such a warning appear only if there's actually an AMD processor present.