### PR TITLE
app-crypt/rhash: add ~amd64-fbsd, ~x86-fbsd KEYWORDS

### DIFF
--- a/app-crypt/rhash/rhash-1.3.5.ebuild
+++ b/app-crypt/rhash/rhash-1.3.5.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 ~arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
 IUSE="debug nls openssl static-libs"
 
 RDEPEND="openssl? ( dev-libs/openssl:0=[${MULTILIB_USEDEP}] )"


### PR DESCRIPTION
This package is required by dev-util/cmake but it doesn't have fbsd keywords.
Please add them.

```
>>> Test phase: app-crypt/rhash-1.3.5
 * abi_x86_64.amd64_fbsd: running multilib-minimal_abi_src_test
Testing /var/tmp/portage/app-crypt/rhash-1.3.5/work/RHash-1.3.5-abi_x86_64.amd64_fbsd/rhash_shared
 1. test with text string:      Ok
 2. test with 1Kb data file:    Ok
 3. test handling empty files:  Ok
 4. test default format:        Ok
 5. test %x, %b, %B modifiers:  Ok
 6. test special characters:    Ok
 7. test eDonkey link:          Ok
 8. test all hash options:      Ok
 9. test checking all hashes:   Ok
10. test checking magnet link:  Ok
11. test bsd format checking:   Ok
12. test checking w/o filename: Ok
13. test checking embedded crc: Ok
14. test wrong sums detection:  Ok
15. test *accept options:       Ok
16. test ignoring of log files: Ok
17. test creating torrent file: Ok
18. test exit code:             Ok
>>> Completed testing app-crypt/rhash-1.3.5

>>> Test phase: app-crypt/rhash-1.3.5
 * abi_x86_32.x86_fbsd: running multilib-minimal_abi_src_test
Testing /var/tmp/portage/app-crypt/rhash-1.3.5/work/RHash-1.3.5-abi_x86_32.x86_fbsd/rhash_shared
 1. test with text string:      Ok
 2. test with 1Kb data file:    Ok
 3. test handling empty files:  Ok
 4. test default format:        Ok
 5. test %x, %b, %B modifiers:  Ok
 6. test special characters:    Ok
 7. test eDonkey link:          Ok
 8. test all hash options:      Ok
 9. test checking all hashes:   Ok
10. test checking magnet link:  Ok
11. test bsd format checking:   Ok
12. test checking w/o filename: Ok
13. test checking embedded crc: Ok
14. test wrong sums detection:  Ok
15. test *accept options:       Ok
16. test ignoring of log files: Ok
17. test creating torrent file: Ok
18. test exit code:             Ok
>>> Completed testing app-crypt/rhash-1.3.5
```
