### PR TITLE
net-misc/curl: add ~amd64-fbsd, ~x86-fbsd KEYWORDS

### DIFF
--- a/net-misc/curl/curl-7.56.1.ebuild
+++ b/net-misc/curl/curl-7.56.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://curl.haxx.se/download/${P}.tar.bz2"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="adns http2 idn ipv6 kerberos ldap metalink rtmp samba ssh ssl static-libs test threads"
 IUSE+=" curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
 IUSE+=" elibc_Winnt"


### PR DESCRIPTION
This package is required by dev-util/cmake but it doesn't have fbsd keywords.
Please add them.

```
# required by dev-util/cmake-3.10.0::gentoo
# required by sys-devel/llvm-3.9.1-r1::gentoo
# required by sys-devel/clang-3.9.1-r100::gentoo
# required by @system
# required by @world (argument)
=net-misc/curl-7.56.1 **
```