### PR TITLE
net-misc/youtube-dl: add rtmp USE flag

### DIFF
--- a/net-misc/youtube-dl/metadata.xml
+++ b/net-misc/youtube-dl/metadata.xml
@@ -4,4 +4,7 @@
   <maintainer type="person">
     <email>jer@gentoo.org</email>
   </maintainer>
+  <use>
+    <flag name="rtmp">Enables Real Time Messaging Protocol support using media-video/rtmpdump.</flag>
+  </use>
 </pkgmetadata>

--- a/net-misc/youtube-dl/youtube-dl-2017.11.15.ebuild
+++ b/net-misc/youtube-dl/youtube-dl-2017.11.15.ebuild
@@ -12,13 +12,14 @@ SRC_URI="http://youtube-dl.org/downloads/${PV}/${P}.tar.gz"
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="amd64 ~arm hppa ~ppc ~ppc64 x86 ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
-IUSE="+offensive test"
+IUSE="+offensive rtmp test"
 
 RDEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 "
 DEPEND="
 	${RDEPEND}
+	rtmp? ( media-video/rtmpdump )
 	test? ( dev-python/nose[coverage(+)] )
 "
 


### PR DESCRIPTION
The youtube-dl script supports retrieving videos over the Real Time
Messaging Protocol (RTMP) should that be required. However, in order to
do so it makes use of the rtmpdump program.

  $ youtube-dl <url>
  > ERROR: RTMP download detected but "rtmpdump" could not be run.
  > Please install it.

This change adds a new USE flag 'rtmp' to youtube-dl which pulls in
media-video/rtmpdump as a dependency.