### PR TITLE
dev-python/pyopenssl: run tests with TZ=UTC

### DIFF
--- a/dev-python/pyopenssl/pyopenssl-17.2.0.ebuild
+++ b/dev-python/pyopenssl/pyopenssl-17.2.0.ebuild
@@ -52,7 +52,7 @@ python_compile_all() {
 
 python_test() {
 	# FIXME: for some reason, no-ops on PyPy
-	py.test -v || die "Testing failed with ${EPYTHON}"
+	TZ=UTC py.test -v || die "Testing failed with ${EPYTHON}" # Fixes bug #627530
 }
 
 python_install_all() {

--- a/dev-python/pyopenssl/pyopenssl-17.3.0.ebuild
+++ b/dev-python/pyopenssl/pyopenssl-17.3.0.ebuild
@@ -52,7 +52,7 @@ python_compile_all() {
 
 python_test() {
 	# FIXME: for some reason, no-ops on PyPy
-	py.test -v || die "Testing failed with ${EPYTHON}"
+	TZ=UTC py.test -v || die "Testing failed with ${EPYTHON}"
 }
 
 python_install_all() {

--- a/dev-python/pyopenssl/pyopenssl-17.4.0.ebuild
+++ b/dev-python/pyopenssl/pyopenssl-17.4.0.ebuild
@@ -52,7 +52,7 @@ python_compile_all() {
 
 python_test() {
 	# FIXME: for some reason, no-ops on PyPy
-	py.test -v || die "Testing failed with ${EPYTHON}"
+	TZ=UTC py.test -v || die "Testing failed with ${EPYTHON}"
 }
 
 python_install_all() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/627530