### PR TITLE
[CI] profiles: Switch default PYTHON_TARGET to Python 3.5

### DIFF
--- a/profiles/arch/alpha/use.stable.mask
+++ b/profiles/arch/alpha/use.stable.mask
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 # This file requires eapi 5 or later. New entries go on top.
@@ -8,8 +8,6 @@
 # Mask python targets until dev-lang/python is stable.
 python_single_target_python3_6
 python_targets_python3_6
-python_single_target_python3_5
-python_targets_python3_5
 
 # Tobias Klausmann <klausman@gentoo.org> (17 Mar 2016)
 # Webkit itself is enormous (~13h compile+test on our fastest dev machine), so

--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -113,12 +113,13 @@ PYTHONDONTWRITEBYTECODE="1"
 # Add default USE value for bootstrap and rename it from STAGE1_USE to BOOTSTRAP_USE
 # Add in expanded PYTHON_TARGETS or stage1 builds break because of USE="-* ${BOOTSTRAP_USE}"
 # This MUST be kept in sync with the PYTHON_TARGETS below
-BOOTSTRAP_USE="cxx unicode internal-glib python_targets_python3_4 python_targets_python2_7"
+BOOTSTRAP_USE="cxx unicode internal-glib python_targets_python3_5 python_targets_python2_7"
 
 # Mike Gilbert <floppym@gentoo.org> (15 May 2012)
 # Default target(s) for python-r1.eclass
-PYTHON_TARGETS="python2_7 python3_4"
-PYTHON_SINGLE_TARGET="python3_4"
+# Updated to python3_5 on 28 Nov 2017
+PYTHON_TARGETS="python2_7 python3_5"
+PYTHON_SINGLE_TARGET="python3_5"
 
 # Michał Górny <mgorny@gentoo.org> (10 Aug 2013)
 # Moved from portage's make.globals.

--- a/profiles/base/package.use
+++ b/profiles/base/package.use
@@ -2,13 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 # David Seifert <soap@gentoo.org> (17 Apr 2017)
-# Only python 3.5 supported
-kde-apps/kajongg:5 python_single_target_python3_5 python_targets_python3_5
-dev-python/pygcrypt python_targets_python3_5
-dev-python/uvloop python_targets_python3_5
-media-gfx/blender python_targets_python3_5
-
-# David Seifert <soap@gentoo.org> (17 Apr 2017)
 # These py2-only packages also support pypy, enable
 # Python 2.7 as the default implementation, preparing
 # for the eventual switch to py3 in PYTHON_SINGLE_TARGET

--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -138,7 +138,6 @@ app-emulation/ganeti monitoring
 
 # Mike Gilbert <floppym@gentoo.org> (03 Oct 2015)
 # Unmask stable-masked implementations for python-exec
-dev-lang/python-exec -python_targets_python3_5
 dev-lang/python-exec -python_targets_python3_6
 
 # Pacho Ramos <pacho@gentoo.org> (15 May 2015)

--- a/profiles/features/prefix/standalone/legacy/make.defaults
+++ b/profiles/features/prefix/standalone/legacy/make.defaults
@@ -14,4 +14,4 @@ ac_cv_func_utimensat=no
 ac_cv_func_pipe2=no
 
 # >=python-3 is masked.
-PYTHON_TARGETS="-python3_4"
+PYTHON_TARGETS="-python3_5"

--- a/profiles/prefix/use.stable.mask
+++ b/profiles/prefix/use.stable.mask
@@ -1,7 +1,0 @@
-# Copyright 1999-2016 Gentoo Foundation
-# Distributed under the terms of the GNU General Public License v2
-
-# Re-enable python-3.5, we are fully ~arch, so avoid problems with
-# Portage like bug #572502
--python_targets_python3_5
--python_single_target_python3_5


### PR DESCRIPTION
@gentoo/python 