### PR TITLE
WIP media-plugins/kodi-vfs-nfs: NFS VFS addon for Kodi

### DIFF
--- a/media-plugins/kodi-vfs-nfs/kodi-vfs-nfs-9999.ebuild
+++ b/media-plugins/kodi-vfs-nfs/kodi-vfs-nfs-9999.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils kodi-addon
+
+DESCRIPTION="NFS VFS addon for Kodi"
+HOMEPAGE="https://github.com/notspiff/vfs.nfs"
+SRC_URI=""
+
+case ${PV} in
+9999)
+	SRC_URI=""
+	EGIT_REPO_URI="https://github.com/notspiff/vfs.nfs.git"
+	inherit git-r3
+	;;
+*)
+	KEYWORDS="~amd64 ~x86"
+	SRC_URI="https://github.com/notspiff/vfs.nfs/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/vfs.nfs-${PV}"
+	;;
+esac
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+DEPEND="
+	=dev-libs/libplatform-2*
+	=media-libs/kodi-platform-9999
+	=media-tv/kodi-9999
+	net-fs/libnfs:=
+	"

--- a/media-plugins/kodi-vfs-nfs/metadata.xml
+++ b/media-plugins/kodi-vfs-nfs/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+    <maintainer type="person">
+        <email>candrews@gentoo.org</email>
+        <name>Craig Andrews</name>
+    </maintainer>
+    <longdescription>NFS VFS addon for Kodi</longdescription>
+    <upstream>
+        <remote-id type="github">notspiff/vfs.nfs</remote-id>
+    </upstream>
+</pkgmetadata>

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -28,7 +28,7 @@ SLOT="0"
 # use flag is called libusb so that it doesn't fool people in thinking that
 # it is _required_ for USB support. Otherwise they'll disable udev and
 # that's going to be worse.
-IUSE="airplay alsa bluetooth bluray caps cec +css dbus debug dvd gbm gles lcms libressl libusb lirc mysql nfs +opengl pulseaudio samba sftp systemd +system-ffmpeg test +udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
+IUSE="airplay alsa bluetooth bluray caps cec +css dbus debug dvd gbm gles lcms libressl libusb lirc mysql +opengl pulseaudio samba sftp systemd +system-ffmpeg test +udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	gbm? ( gles )
@@ -75,7 +75,6 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	system-ffmpeg? ( >=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,openssl,postproc] )
 	mysql? ( virtual/mysql )
 	>=net-misc/curl-7.56.1
-	nfs? ( net-fs/libnfs:= )
 	opengl? ( media-libs/glu )
 	!libressl? ( >=dev-libs/openssl-1.0.2l:0= )
 	libressl? ( dev-libs/libressl:0= )
@@ -235,7 +234,6 @@ src_configure() {
 		-DENABLE_LIRC=$(usex lirc)
 		-DENABLE_MICROHTTPD=$(usex webserver)
 		-DENABLE_MYSQLCLIENT=$(usex mysql)
-		-DENABLE_NFS=$(usex nfs)
 		-DENABLE_OPENGLES=$(usex gles)
 		-DENABLE_OPENGL=$(usex opengl)
 		-DENABLE_OPENSSL=ON


### PR DESCRIPTION
Adds support for SFTP to Kodi.
This functionality was originally part of Kodi itself, but was removed in Kodi 18.

Do not merge until https://github.com/xbmc/xbmc/pull/12837 is merged.