### PR TITLE
Fix too long descriptions for packages maintained by proaudio project

### DIFF
--- a/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.6-r1.ebuild
+++ b/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.6-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 
 inherit toolchain-funcs eutils multilib multilib-minimal
 
-DESCRIPTION="Audio processing plugin system for plugins that extract descriptive information from audio data"
+DESCRIPTION="Audio processing system for plugins to extract information from audio data"
 HOMEPAGE="http://www.vamp-plugins.org"
 SRC_URI="https://code.soundsoftware.ac.uk/attachments/download/1514/${P}.tar.gz"
 

--- a/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.7.1.ebuild
+++ b/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.7.1.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 
 inherit toolchain-funcs eutils multilib multilib-minimal
 
-DESCRIPTION="Audio processing plugin system for plugins that extract descriptive information from audio data"
+DESCRIPTION="Audio processing system for plugins to extract information from audio data"
 HOMEPAGE="http://www.vamp-plugins.org"
 SRC_URI="https://code.soundsoftware.ac.uk/attachments/download/2206/${P}.tar.gz"
 

--- a/media-plugins/tap-plugins/tap-plugins-0.7.2.ebuild
+++ b/media-plugins/tap-plugins/tap-plugins-0.7.2.ebuild
@@ -7,7 +7,7 @@ inherit multilib toolchain-funcs eutils
 
 IUSE=""
 
-DESCRIPTION="TAP LADSPA plugins package. Contains DeEsser, Dynamics, Equalizer, Reverb, Stereo Echo, Tremolo"
+DESCRIPTION="A bunch of LADSPA plugins for audio processing"
 HOMEPAGE="http://tap-plugins.sourceforge.net"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 

--- a/media-plugins/tap-plugins/tap-plugins-0.7.3.ebuild
+++ b/media-plugins/tap-plugins/tap-plugins-0.7.3.ebuild
@@ -7,7 +7,7 @@ inherit multilib toolchain-funcs eutils
 
 IUSE=""
 
-DESCRIPTION="TAP LADSPA plugins package. Contains DeEsser, Dynamics, Equalizer, Reverb, Stereo Echo, Tremolo"
+DESCRIPTION="A bunch of LADSPA plugins for audio processing"
 HOMEPAGE="http://tap-plugins.sourceforge.net"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 

--- a/media-plugins/vamp-libxtract-plugins/vamp-libxtract-plugins-0.6.6.20121204.ebuild
+++ b/media-plugins/vamp-libxtract-plugins/vamp-libxtract-plugins-0.6.6.20121204.ebuild
@@ -4,7 +4,7 @@
 EAPI=2
 inherit eutils multilib toolchain-funcs
 
-DESCRIPTION="Low-level feature extraction plugins using Jamie Bullock's libxtract library to provide around 50 spectral and other features"
+DESCRIPTION="Vamp plugin encapsulating many of the functions of the LibXtract library"
 HOMEPAGE="http://www.vamp-plugins.org/"
 SRC_URI="http://code.soundsoftware.ac.uk/attachments/download/618/${P}.tar.gz"
 


### PR DESCRIPTION
Some small changes to fix one of the QA issues reported here https://gentoo.levelnine.at/full-sort-by-maintainer/proaudio_at_g.o.txt
I used the upstream description in as unedited a fashion as possible.

Discussed this on `#gentoo-dev-help` on IRC. I'll try to fix the other issues as well in the coming week(s).