### PR TITLE
vagrant: only use installed ruby versions

### DIFF
--- a/app-emulation/vagrant/files/vagrant.in-r1
+++ b/app-emulation/vagrant/files/vagrant.in-r1
@@ -5,6 +5,10 @@
 # so that everything loads and compiles to proper directories.
 
 for r in ruby24 ruby23 ruby22; do
+  # not all ruby versions are guaranteed to be installed
+  if ! command -v "${r}" >/dev/null 2>&1; then
+    continue
+  fi
   VAGRANT_DIR="$( "${r}" -e 'print Gem::default_path[-1] + "/gems/vagrant-@VAGRANT_VERSION@"' )"
   # Export the VAGRANT_EXECUTABLE so that pre-rubygems can optimize a bit
   export VAGRANT_EXECUTABLE="${VAGRANT_DIR}/bin/vagrant"


### PR DESCRIPTION
Not all ruby versions are guaranteed to be installed.
So only try each ruby version if it is on the PATH. 

I do not have ruby24 on my system. Without this, I get:

  $ vagrant version
  /usr/bin/vagrant: line 8: ruby24: command not found
  Installed Version: 2.0.1
  Latest Version: 2.0.1
 
  You're running an up-to-date version of Vagrant!