### PR TITLE
dev-vcs/git-annex: remove unused patch

### DIFF
--- a/dev-vcs/git-annex/files/git-annex-5.20150731-no-strange-installs.patch
+++ b/dev-vcs/git-annex/files/git-annex-5.20150731-no-strange-installs.patch
@@ -1,9 +1,0 @@
-diff --git a/Setup.hs b/Setup.hs
-index f90a9b2..97afb7f 100644
---- a/Setup.hs
-+++ b/Setup.hs
-@@ -25,3 +25,3 @@ main = defaultMainWithHooks simpleUserHooks
- 		return (Nothing, [])	
--	, postCopy = myPostCopy
-+	-- , postCopy = myPostCopy
- 	}


### PR DESCRIPTION
Hi,

This PR removes a unused patch from dev-vcs/git-annex.

Please review.