### PR TITLE
media-tv/tvheadend: add ddci USE flag (support for DDCI hardware)

### DIFF
--- a/media-tv/tvheadend/metadata.xml
+++ b/media-tv/tvheadend/metadata.xml
@@ -9,6 +9,7 @@
 		<flag name="capmt">Enable support for capmt (dvbapi) protocol</flag>
 		<flag name="constcw">Enable support for the constcw protocol</flag>
 		<flag name="cwc">Enable support for the cwc (newcamd) protocol</flag>
+		<flag name="ddci">Enable support for DDCI hardware</flag>
 		<flag name="dvbcsa">Enable decryption of the DVB Common Scrambling Algorithm</flag>
 		<flag name="dvben50221">Enable support for hardware CAM</flag>
 		<flag name="hdhomerun">Enable support for the HDHomeRun device</flag>

--- a/media-tv/tvheadend/tvheadend-9999.ebuild
+++ b/media-tv/tvheadend/tvheadend-9999.ebuild
@@ -13,7 +13,7 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS=""
 
-IUSE="+capmt +constcw +cwc dbus debug dvbcsa dvben50221 +dvb +ffmpeg hdhomerun +imagecache +inotify iptv libressl opus satip systemd +timeshift uriparser vpx x264 x265 xmltv zeroconf zlib"
+IUSE="+capmt +constcw +cwc dbus debug ddci dvbcsa dvben50221 +dvb +ffmpeg hdhomerun +imagecache +inotify iptv libressl opus satip systemd +timeshift uriparser vpx x264 x265 xmltv zeroconf zlib"
 
 RDEPEND="
 	virtual/libiconv
@@ -47,7 +47,10 @@ RDEPEND+="
 	dvb? ( media-tv/dtv-scan-tables )
 	xmltv? ( media-tv/xmltv )"
 
-REQUIRED_USE="dvbcsa? ( || ( capmt constcw cwc dvben50221 ) )"
+REQUIRED_USE="
+	dvbcsa? ( || ( capmt constcw cwc dvben50221 ) )
+	ddci? ( dvb dvben50221 )
+"
 
 # Some patches from:
 # https://github.com/rpmfusion/tvheadend
@@ -92,6 +95,7 @@ src_configure() {
 		$(use_enable cwc) \
 		$(use_enable dbus dbus_1) \
 		$(use_enable debug trace) \
+		$(use_enable ddci) \
 		$(use_enable dvb linuxdvb) \
 		$(use_enable dvbcsa) \
 		$(use_enable dvben50221) \


### PR DESCRIPTION
--enable-ddci enables the recently added support for the Digital Devices
CI hardware (Octopus CI, DuoFlex CI), for which the driver exposes their
functionality via a /dev/dvb/adapterX/secY (recent kernels) or ciY (dddvb
vendor driver package, both supported equally) dev node. This support
will be part of the tvheadend 4.4 release.

Repoman 2.3.3 (portage-2.3.13)