### PR TITLE
media-sound/meterbridge QA fix epatch in eapi6 ebuild

### DIFF
--- a/media-sound/meterbridge/meterbridge-0.9.3.ebuild
+++ b/media-sound/meterbridge/meterbridge-0.9.3.ebuild
@@ -21,12 +21,15 @@ RDEPEND="media-sound/jack-audio-connection-kit
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
+PATCHES=(
+	"${FILESDIR}/${P}-gcc41.patch"
+	"${FILESDIR}/${P}-asneeded.patch"
+	"${FILESDIR}/${P}-cflags.patch"
+	"${FILESDIR}/${P}-setrgba.patch"
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/${P}-gcc41.patch
-	epatch "${FILESDIR}"/${P}-asneeded.patch
-	epatch "${FILESDIR}"/${P}-cflags.patch
-	epatch "${FILESDIR}"/${P}-setrgba.patch
-	eapply_user
+	default
 	eautoreconf
 }
 


### PR DESCRIPTION
Another small QA fix for a proaudio package based on https://gentoo.levelnine.at/full-sort-by-maintainer/proaudio_at_g.o.txt