### PR TITLE
media-tv/tvheadend: add epatch_user to src_prepare

### DIFF
--- a/media-tv/tvheadend/tvheadend-9999.ebuild
+++ b/media-tv/tvheadend/tvheadend-9999.ebuild
@@ -47,6 +47,8 @@ pkg_setup() {
 src_prepare() {
 	# remove '-Werror' wrt bug #438424
 	sed -e 's:-Werror::' -i Makefile || die 'sed failed!'
+
+	epatch_user
 }
 
 src_configure() {


### PR DESCRIPTION
Allow for automatic apply of patched dropped in /etc/portage/patches/.

Repoman 2.3.3 (portage-2.3.13)