### PR TITLE
app-emulation/wine-vanilla: fix a crash in install phase

### DIFF
--- a/app-emulation/wine-vanilla/wine-vanilla-2.0-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.0-r1.ebuild
@@ -483,7 +483,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-2.0.1-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.0.1-r1.ebuild
@@ -483,7 +483,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-2.0.1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.0.1.ebuild
@@ -474,7 +474,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-2.0.2-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.0.2-r1.ebuild
@@ -483,7 +483,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-2.0.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.0.2.ebuild
@@ -474,7 +474,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-2.0.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.0.3.ebuild
@@ -479,7 +479,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-2.18-r2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.18-r2.ebuild
@@ -481,7 +481,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-2.19-r1.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.19-r1.ebuild
@@ -481,7 +481,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-2.20.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.20.ebuild
@@ -483,7 +483,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"

--- a/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
@@ -483,7 +483,7 @@ multilib_src_install_all() {
 	# respect LINGUAS when installing man pages, #469418
 	local l
 	for l in de fr pl; do
-		use linguas_${l} || rm -r "${D%/}${MY_MANDIR}"/${l}*
+		use linguas_${l} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 
 	eval "${glob_state}"


### PR DESCRIPTION
Hello!

`app-emulation/wine-vanilla` crashes in install phase with following message:
```
/var/tmp/portage/app-emulation/wine-vanilla-2.0.2/temp/environment: line 3644: no match: /var/tmp/portage/app-emulation/wine-vanilla-2.0.2/image/usr/share/wine-vanilla-2.0.2/man/pl*
```

this pull-request will fix it.