### PR TITLE
Fix deprecated fdo-mime inherits for proaudio packages

### DIFF
--- a/media-sound/rosegarden/rosegarden-13.04.ebuild
+++ b/media-sound/rosegarden/rosegarden-13.04.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit autotools eutils fdo-mime gnome2-utils multilib
+inherit autotools eutils xdg-utils gnome2-utils multilib
 
 DESCRIPTION="MIDI and audio sequencer and notation editor"
 HOMEPAGE="http://www.rosegardenmusic.com/"
@@ -56,12 +56,12 @@ pkg_preinst() {
 
 pkg_postinst() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }
 
 pkg_postrm() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }

--- a/media-sound/rosegarden/rosegarden-13.10-r1.ebuild
+++ b/media-sound/rosegarden/rosegarden-13.10-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit autotools eutils fdo-mime gnome2-utils multilib
+inherit autotools eutils xdg-utils gnome2-utils multilib
 
 DESCRIPTION="MIDI and audio sequencer and notation editor"
 HOMEPAGE="http://www.rosegardenmusic.com/"
@@ -54,12 +54,12 @@ pkg_preinst() {
 
 pkg_postinst() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }
 
 pkg_postrm() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }

--- a/media-sound/rosegarden/rosegarden-14.02.ebuild
+++ b/media-sound/rosegarden/rosegarden-14.02.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit autotools eutils fdo-mime gnome2-utils multilib
+inherit autotools eutils xdg-utils gnome2-utils multilib
 
 DESCRIPTION="MIDI and audio sequencer and notation editor"
 HOMEPAGE="http://www.rosegardenmusic.com/"
@@ -51,12 +51,12 @@ pkg_preinst() {
 
 pkg_postinst() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }
 
 pkg_postrm() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }

--- a/media-sound/rosegarden/rosegarden-14.12.ebuild
+++ b/media-sound/rosegarden/rosegarden-14.12.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit autotools eutils fdo-mime gnome2-utils multilib
+inherit autotools eutils xdg-utils gnome2-utils multilib
 
 DESCRIPTION="MIDI and audio sequencer and notation editor"
 HOMEPAGE="http://www.rosegardenmusic.com/"
@@ -51,12 +51,12 @@ pkg_preinst() {
 
 pkg_postinst() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }
 
 pkg_postrm() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }

--- a/media-sound/rosegarden/rosegarden-16.06.ebuild
+++ b/media-sound/rosegarden/rosegarden-16.06.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit cmake-utils eutils fdo-mime gnome2-utils
+inherit cmake-utils eutils xdg-utils gnome2-utils
 
 DESCRIPTION="MIDI and audio sequencer and notation editor"
 HOMEPAGE="http://www.rosegardenmusic.com/"
@@ -49,12 +49,12 @@ pkg_preinst() {
 
 pkg_postinst() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }
 
 pkg_postrm() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }

--- a/media-sound/rosegarden/rosegarden-17.04.ebuild
+++ b/media-sound/rosegarden/rosegarden-17.04.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit cmake-utils eutils fdo-mime gnome2-utils
+inherit cmake-utils eutils xdg-utils gnome2-utils
 
 DESCRIPTION="MIDI and audio sequencer and notation editor"
 HOMEPAGE="http://www.rosegardenmusic.com/"
@@ -49,12 +49,12 @@ pkg_preinst() {
 
 pkg_postinst() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }
 
 pkg_postrm() {
 	gnome2_icon_cache_update
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }

--- a/media-sound/sonic-visualiser/sonic-visualiser-2.5.ebuild
+++ b/media-sound/sonic-visualiser/sonic-visualiser-2.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
-inherit eutils qmake-utils autotools fdo-mime
+inherit eutils qmake-utils autotools xdg-utils
 
 DESCRIPTION="Music audio files viewer and analiser"
 HOMEPAGE="http://www.sonicvisualiser.org/"
@@ -97,9 +97,9 @@ src_install() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 }

--- a/media-sound/sonic-visualiser/sonic-visualiser-3.0.2.ebuild
+++ b/media-sound/sonic-visualiser/sonic-visualiser-3.0.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit eutils qmake-utils autotools fdo-mime
+inherit eutils qmake-utils autotools xdg-utils
 
 DESCRIPTION="Music audio files viewer and analiser"
 HOMEPAGE="http://www.sonicvisualiser.org/"
@@ -101,9 +101,9 @@ src_install() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 }


### PR DESCRIPTION
Another small QA fix from https://gentoo.levelnine.at/full-sort-by-maintainer/proaudio_at_g.o.txt
This time it replaces the deprecated `fdo-mime` inherits with `xdg-utils`.