### PR TITLE
dev-libs/libite: fix failing tests

### DIFF
--- a/dev-libs/libite/files/libite-2.0.0-fix-path.patch
+++ b/dev-libs/libite/files/libite-2.0.0-fix-path.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/which.c b/tests/which.c
+index cda57c6..3e74867 100644
+--- a/tests/which.c
++++ b/tests/which.c
+@@ -21,6 +21,7 @@ int main(void)
+ 		{ NULL, 0 }
+ 	};
+ 
++	setenv("PATH", "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin", 1);
+ 	for (i = 0; test[i].cmd; i++) {
+ 		char *path;
+ 

--- a/dev-libs/libite/files/libite-2.0.0-fix-which-path.patch
+++ b/dev-libs/libite/files/libite-2.0.0-fix-which-path.patch
@@ -1,0 +1,25 @@
+diff --git a/tests/which.c b/tests/which.c
+index 46dcccf..cda57c6 100644
+--- a/tests/which.c
++++ b/tests/which.c
+@@ -11,13 +11,13 @@ int main(void)
+ 	int result = 0;
+ 	size_t i;
+ 	struct tc test[] = {
+-		{ "ls",          1 },
+-		{ "free",        1 },
+-		{ "modinfo",     1 },
+-		{ "useradd",     1 },
+-		{ "/bin/which",  1 },
+-		{ "/bin/ps aux", 1 },
+-		{ "/etc/passwd", 0 },
++		{ "ls",             1 },
++		{ "free",           1 },
++		{ "modinfo",        1 },
++		{ "useradd",        1 },
++		{ "/usr/bin/which", 1 },
++		{ "/bin/ps aux",    1 },
++		{ "/etc/passwd",    0 },
+ 		{ NULL, 0 }
+ 	};
+ 

--- a/dev-libs/libite/libite-2.0.0-r1.ebuild
+++ b/dev-libs/libite/libite-2.0.0-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Libite is a collection of useful BSD APIs"
+HOMEPAGE="https://github.com/troglobit/libite"
+SRC_URI="https://github.com/troglobit/libite/releases/download/v${PV}/${P}.tar.xz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="static-libs"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-which-path.patch
+	"${FILESDIR}"/${P}-fix-path.patch
+)
+
+src_configure(){
+	econf --enable-static=$(usex static-libs)
+}
+
+src_install(){
+	default
+	find "${D}" -name '*.la' -delete || die
+	rm "${D}/usr/share/doc/${PF}/LICENSE" || die
+}


### PR DESCRIPTION
 * This commit adds two patches from upstream
   They should be removed as soon as upstream
   releases new version.

Bug: https://bugs.gentoo.org/show_bug.cgi?id=640202

Package-Manager: Portage-2.3.13, Repoman-2.3.1