### PR TITLE
app-eselect/eselect-php: do not use get_libdir in php-fpm-launcher

### DIFF
--- a/app-eselect/eselect-php/eselect-php-0.9.4-r3.ebuild
+++ b/app-eselect/eselect-php/eselect-php-0.9.4-r3.ebuild
@@ -3,26 +3,21 @@
 
 EAPI=6
 
-inherit systemd git-r3 autotools
+inherit systemd
 
 DESCRIPTION="PHP eselect module"
 HOMEPAGE="https://gitweb.gentoo.org/proj/eselect-php.git/"
-EGIT_REPO_URI="https://anongit.gentoo.org/git/proj/eselect-php.git"
+SRC_URI="https://dev.gentoo.org/~mjo/distfiles/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="fpm apache2"
 
 # The "DirectoryIndex" line in 70_mod_php.conf requires mod_dir.
 RDEPEND="app-admin/eselect
 	apache2? ( www-servers/apache[apache2_modules_dir] )
 	fpm? ( sys-apps/gentoo-functions )"
-
-src_prepare() {
-	eapply_user
-	eautoreconf
-}
 
 src_configure(){
 	# We expect localstatedir to be "var"ish, not "var/lib"ish, because

--- a/app-eselect/eselect-php/files/php-fpm-launcher-r3
+++ b/app-eselect/eselect-php/files/php-fpm-launcher-r3
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# If there are no arguments, then "shift" will fail (bug 626496).
+if [ $# -eq 0 ]; then
+    PHP_SLOT=$(eselect php show fpm)
+else
+    PHP_SLOT=$1
+    shift
+fi
+
+exec "/usr/@libdir@/${PHP_SLOT}/bin/php-fpm" "${@}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/640460
Package-Manager: Portage-2.3.17, Repoman-2.3.6