### PR TITLE
dev-util/ragel: Don't install header files straight to /usr/include

### DIFF
--- a/dev-util/ragel/files/ragel-7.0.0.10-pkginclude-headers.patch
+++ b/dev-util/ragel/files/ragel-7.0.0.10-pkginclude-headers.patch
@@ -1,0 +1,34 @@
+commit 927f380272442ae803fdccfc001b55877f25e7dc
+Author: Adrian Thurston <thurston@colm.net>
+Date:   Sat Dec 10 15:41:30 2016 -0500
+
+    use pkginclude for the headers
+
+diff --git a/aapl/Makefile.am b/aapl/Makefile.am
+index fd9f9cb0..80b972f1 100644
+--- a/aapl/Makefile.am
++++ b/aapl/Makefile.am
+@@ -1,4 +1,4 @@
+-include_HEADERS = \
++pkginclude_HEADERS = \
+ 	avlbasic.h avlimel.h avlmap.h bstcommon.h compare.h insertsort.h \
+ 	sbstset.h avlcommon.h avlimelkey.h avlmel.h bstmap.h dlcommon.h \
+ 	mergesort.h sbsttable.h avlibasic.h avliset.h avlmelkey.h bstset.h \
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 24a19a4b..60554a99 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -16,11 +16,11 @@ bin_PROGRAMS = ragel
+ 
+ endif
+ 
+-include_HEADERS = \
++pkginclude_HEADERS = \
+ 	action.h fsmgraph.h ragel.h common.h \
+ 	gendata.h redfsm.h dot.h
+ 
+-nodist_include_HEADERS = config.h
++nodist_pkginclude_HEADERS = config.h
+ 
+ ragel_CPPFLAGS = -I$(top_srcdir)/aapl -DBINDIR='"@bindir@"'
+ 

--- a/dev-util/ragel/ragel-7.0.0.10-r1.ebuild
+++ b/dev-util/ragel/ragel-7.0.0.10-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools
+
+DESCRIPTION="Compiles finite state machines from regular languages into executable code"
+HOMEPAGE="https://www.colm.net/open-source/ragel/"
+SRC_URI="https://www.colm.net/files/ragel/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86"
+IUSE="vim-syntax"
+
+DEPEND="~dev-util/colm-0.13.0.5"
+RDEPEND="${DEPEND}"
+
+PATCHES=("${FILESDIR}"/${P}-pkginclude-headers.patch )
+
+src_test() {
+	cd "${S}"/test || die
+	./runtests.in || die
+}
+
+src_configure() {
+	eautoreconf
+	default
+}
+
+src_install() {
+	if use vim-syntax; then
+		insinto /usr/share/vim/vimfiles/syntax
+		doins ragel.vim
+	fi
+	default
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/629674

The patch for version 7.0.0.10 is from upstream and already a year old, but there has been no new release.
