### PR TITLE
media-video/ffdiaporama: Fix patch location

### DIFF
--- a/media-video/ffdiaporama/ffdiaporama-2.1-r1.ebuild
+++ b/media-video/ffdiaporama/ffdiaporama-2.1-r1.ebuild
@@ -39,7 +39,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 DOCS=( authors.txt )
-PATCHES=( "${FILESDIR}"/${P}-{ffmpeg-2.4,libav10,ffmpeg-3.0}.patch )
+PATCHES=( "${DISTDIR}"/${P}-libav10.patch "${FILESDIR}"/${P}-{ffmpeg-2.4,ffmpeg-3.0}.patch )
 
 S="${WORKDIR}/ffDiaporama"
 


### PR DESCRIPTION
Fix the location of the patch recently moved to devspace.
Patch is now located in DISTDIR.
Closes: https://bugs.gentoo.org/640632