### PR TITLE
sys-kernel/raspberrypi-sources: Fix the rest of files for git-r3, like in #6102

### DIFF
--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.10.9999.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.10.9999.ebuild
@@ -12,8 +12,9 @@ detect_version
 detect_arch
 
 inherit git-r3 versionator
-EGIT_REPO_URI=https://github.com/raspberrypi/linux.git
+EGIT_REPO_URI="https://github.com/raspberrypi/linux.git -> raspberrypi-linux.git"
 EGIT_BRANCH="rpi-$(get_version_component_range 1-2).y"
+EGIT_CHECKOUT_DIR="${WORKDIR}/linux-${PV}-raspberrypi"
 
 DESCRIPTION="Raspberry PI kernel sources"
 HOMEPAGE="https://github.com/raspberrypi/linux"

--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.11.9999.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.11.9999.ebuild
@@ -12,8 +12,9 @@ detect_version
 detect_arch
 
 inherit git-r3 versionator
-EGIT_REPO_URI=https://github.com/raspberrypi/linux.git
+EGIT_REPO_URI="https://github.com/raspberrypi/linux.git -> raspberrypi-linux.git"
 EGIT_BRANCH="rpi-$(get_version_component_range 1-2).y"
+EGIT_CHECKOUT_DIR="${WORKDIR}/linux-${PV}-raspberrypi"
 
 DESCRIPTION="Raspberry PI kernel sources"
 HOMEPAGE="https://github.com/raspberrypi/linux"

--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.12.9999.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.12.9999.ebuild
@@ -12,8 +12,9 @@ detect_version
 detect_arch
 
 inherit git-r3 versionator
-EGIT_REPO_URI=https://github.com/raspberrypi/linux.git
+EGIT_REPO_URI="https://github.com/raspberrypi/linux.git -> raspberrypi-linux.git"
 EGIT_BRANCH="rpi-$(get_version_component_range 1-2).y"
+EGIT_CHECKOUT_DIR="${WORKDIR}/linux-${PV}-raspberrypi"
 
 DESCRIPTION="Raspberry PI kernel sources"
 HOMEPAGE="https://github.com/raspberrypi/linux"

--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.13.9999.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.13.9999.ebuild
@@ -12,8 +12,9 @@ detect_version
 detect_arch
 
 inherit git-r3 versionator
-EGIT_REPO_URI=https://github.com/raspberrypi/linux.git
+EGIT_REPO_URI="https://github.com/raspberrypi/linux.git -> raspberrypi-linux.git"
 EGIT_BRANCH="rpi-$(get_version_component_range 1-2).y"
+EGIT_CHECKOUT_DIR="${WORKDIR}/linux-${PV}-raspberrypi"
 
 DESCRIPTION="Raspberry PI kernel sources"
 HOMEPAGE="https://github.com/raspberrypi/linux"

--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.14.9999.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.14.9999.ebuild
@@ -14,6 +14,7 @@ detect_arch
 inherit git-r3 versionator
 EGIT_REPO_URI="https://github.com/raspberrypi/linux.git -> raspberrypi-linux.git"
 EGIT_BRANCH="rpi-$(get_version_component_range 1-2).y"
+EGIT_CHECKOUT_DIR="${WORKDIR}/linux-${PV}-raspberrypi"
 
 DESCRIPTION="Raspberry PI kernel sources"
 HOMEPAGE="https://github.com/raspberrypi/linux"

--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.4.9999.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.4.9999.ebuild
@@ -12,8 +12,9 @@ detect_version
 detect_arch
 
 inherit git-r3 versionator
-EGIT_REPO_URI=https://github.com/raspberrypi/linux.git
+EGIT_REPO_URI="https://github.com/raspberrypi/linux.git -> raspberrypi-linux.git"
 EGIT_BRANCH="rpi-$(get_version_component_range 1-2).y"
+EGIT_CHECKOUT_DIR="${WORKDIR}/linux-${PV}-raspberrypi"
 
 DESCRIPTION="Raspberry PI kernel sources"
 HOMEPAGE="https://github.com/raspberrypi/linux"

--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.9.9999.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-4.9.9999.ebuild
@@ -12,8 +12,9 @@ detect_version
 detect_arch
 
 inherit git-r3 versionator
-EGIT_REPO_URI=https://github.com/raspberrypi/linux.git
+EGIT_REPO_URI="https://github.com/raspberrypi/linux.git -> raspberrypi-linux.git"
 EGIT_BRANCH="rpi-$(get_version_component_range 1-2).y"
+EGIT_CHECKOUT_DIR="${WORKDIR}/linux-${PV}-raspberrypi"
 
 DESCRIPTION="Raspberry PI kernel sources"
 HOMEPAGE="https://github.com/raspberrypi/linux"


### PR DESCRIPTION
Also partially revert 524925d4b833502b81a5c653b57cfe5437820d81

Closes:  https://bugs.gentoo.org/633542

#6102 