### PR TITLE
sci-libs/hdf5: fix building 1.10.1 with USE="threads"

### DIFF
--- a/sci-libs/hdf5/hdf5-1.10.1.ebuild
+++ b/sci-libs/hdf5/hdf5-1.10.1.ebuild
@@ -84,6 +84,7 @@ src_configure() {
 		$(use_enable debug codestack)
 		$(use_enable cxx)
 		$(use_enable fortran)
+		$(use_enable hl)
 		$(use_enable mpi parallel)
 		$(use_enable threads threadsafe)
 		$(use_with szip szlib)


### PR DESCRIPTION
Configure high-level API depending on USE flag set (migrated from 1.8.x)
Closes: https://bugs.gentoo.org/640220