### PR TITLE
app-arch/xz-utils: support disabling useless filters

### DIFF
--- a/app-arch/xz-utils/metadata.xml
+++ b/app-arch/xz-utils/metadata.xml
@@ -5,4 +5,9 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<use>
+	<flag name='extra-filters'>Build additional filters that are not
+		used in any of the default xz presets. This includes delta
+		and BCJ coders, additional match finders and SHA256 checks.</flag>
+</use>
 </pkgmetadata>

--- a/app-arch/xz-utils/xz-utils-5.2.3.ebuild
+++ b/app-arch/xz-utils/xz-utils-5.2.3.ebuild
@@ -27,13 +27,16 @@ HOMEPAGE="http://tukaani.org/xz/"
 # See top-level COPYING file as it outlines the various pieces and their licenses.
 LICENSE="public-domain LGPL-2.1+ GPL-2+"
 SLOT="0"
-IUSE="elibc_FreeBSD nls static-libs +threads"
+IUSE="elibc_FreeBSD +extra-filters nls static-libs +threads"
 
 RDEPEND="!<app-arch/lzma-4.63
 	!app-arch/lzma-utils
 	!<app-arch/p7zip-4.57"
 DEPEND="${RDEPEND}
 	${EXTRA_DEPEND}"
+
+# Tests currently do not account for smaller feature set
+RESTRICT="!extra-filters? ( test )"
 
 src_prepare() {
 	if [[ ${PV} == "9999" ]] ; then
@@ -52,6 +55,17 @@ multilib_src_configure() {
 	)
 	multilib_is_native_abi ||
 		myconf+=( --disable-{xz,xzdec,lzmadec,lzmainfo,lzma-links,scripts} )
+	if ! use extra-filters; then
+		myconf+=(
+			# LZMA1 + LZMA2 for standard .lzma & .xz files
+			--enable-encoders=lzma1,lzma2
+			--enable-decoders=lzma1,lzma2
+			# those are used by default, depending on preset
+			--enable-match-finders=hc3,hc4,bt4
+			# CRC64 is used by default, though some (old?) files use CRC32
+			--enable-checks=crc32,crc64
+		)
+	fi
 
 	use elibc_FreeBSD && export ac_cv_header_sha256_h=no #545714
 	ECONF_SOURCE="${S}" econf "${myconf[@]}"

--- a/app-arch/xz-utils/xz-utils-5.2.3.ebuild
+++ b/app-arch/xz-utils/xz-utils-5.2.3.ebuild
@@ -45,12 +45,16 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	local myconf=(
+		$(use_enable nls)
+		$(use_enable threads)
+		$(use_enable static-libs static)
+	)
+	multilib_is_native_abi ||
+		myconf+=( --disable-{xz,xzdec,lzmadec,lzmainfo,lzma-links,scripts} )
+
 	use elibc_FreeBSD && export ac_cv_header_sha256_h=no #545714
-	ECONF_SOURCE="${S}" econf \
-		$(use_enable nls) \
-		$(use_enable threads) \
-		$(use_enable static-libs static) \
-		$(multilib_is_native_abi || echo --disable-{xz,xzdec,lzmadec,lzmainfo,lzma-links,scripts})
+	ECONF_SOURCE="${S}" econf "${myconf[@]}"
 }
 
 multilib_src_install() {

--- a/app-arch/xz-utils/xz-utils-9999.ebuild
+++ b/app-arch/xz-utils/xz-utils-9999.ebuild
@@ -27,13 +27,16 @@ HOMEPAGE="http://tukaani.org/xz/"
 # See top-level COPYING file as it outlines the various pieces and their licenses.
 LICENSE="public-domain LGPL-2.1+ GPL-2+"
 SLOT="0"
-IUSE="elibc_FreeBSD nls static-libs +threads"
+IUSE="elibc_FreeBSD +extra-filters nls static-libs +threads"
 
 RDEPEND="!<app-arch/lzma-4.63
 	!app-arch/lzma-utils
 	!<app-arch/p7zip-4.57"
 DEPEND="${RDEPEND}
 	${EXTRA_DEPEND}"
+
+# Tests currently do not account for smaller feature set
+RESTRICT="!extra-filters? ( test )"
 
 src_prepare() {
 	if [[ ${PV} == "9999" ]] ; then
@@ -52,6 +55,17 @@ multilib_src_configure() {
 	)
 	multilib_is_native_abi ||
 		myconf+=( --disable-{xz,xzdec,lzmadec,lzmainfo,lzma-links,scripts} )
+	if ! use extra-filters; then
+		myconf+=(
+			# LZMA1 + LZMA2 for standard .lzma & .xz files
+			--enable-encoders=lzma1,lzma2
+			--enable-decoders=lzma1,lzma2
+			# those are used by default, depending on preset
+			--enable-match-finders=hc3,hc4,bt4
+			# CRC64 is used by default, though some (old?) files use CRC32
+			--enable-checks=crc32,crc64
+		)
+	fi
 
 	use elibc_FreeBSD && export ac_cv_header_sha256_h=no #545714
 	ECONF_SOURCE="${S}" econf "${myconf[@]}"

--- a/app-arch/xz-utils/xz-utils-9999.ebuild
+++ b/app-arch/xz-utils/xz-utils-9999.ebuild
@@ -45,12 +45,16 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	local myconf=(
+		$(use_enable nls)
+		$(use_enable threads)
+		$(use_enable static-libs static)
+	)
+	multilib_is_native_abi ||
+		myconf+=( --disable-{xz,xzdec,lzmadec,lzmainfo,lzma-links,scripts} )
+
 	use elibc_FreeBSD && export ac_cv_header_sha256_h=no #545714
-	ECONF_SOURCE="${S}" econf \
-		$(use_enable nls) \
-		$(use_enable threads) \
-		$(use_enable static-libs static) \
-		$(multilib_is_native_abi || echo --disable-{xz,xzdec,lzmadec,lzmainfo,lzma-links,scripts})
+	ECONF_SOURCE="${S}" econf "${myconf[@]}"
 }
 
 multilib_src_install() {


### PR DESCRIPTION
Adds a new USE=extra-filters flag (on by default) that can be used to disable filters and other cruft that's not used by xz-utils by default and is totally irrelevant to the common use of xz-utils to compress and decompress .xz files using default (-0..-9+-e) profiles.