### PR TITLE
x11-wm/i3: Add ~arm64 keyword

### DIFF
--- a/x11-wm/i3/i3-4.14.1.ebuild
+++ b/x11-wm/i3/i3-4.14.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://i3wm.org/"
 SRC_URI="https://i3wm.org/downloads/${P}.tar.bz2"
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="doc debug test"
 
 CDEPEND="dev-libs/libev


### PR DESCRIPTION
Bug: 640274
Package-Manager: Portage-2.3.19, Repoman-2.3.6

Ping mentor: @Polynomial-C 