### PR TITLE
dev-libs/libical: fix libical.pc to prevent overlinking

### DIFF
--- a/dev-libs/libical/files/libical-2.0.0-libical.pc-fix-libdir-location.patch
+++ b/dev-libs/libical/files/libical-2.0.0-libical.pc-fix-libdir-location.patch
@@ -1,0 +1,28 @@
+This is a patch for Gentoo bug 560572, provided by Georgi Georgiev.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 773cf0c..e282ce4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -336,7 +336,7 @@ endif()
+ set(VERSION "${PROJECT_VERSION}")
+ set(prefix "${CMAKE_INSTALL_PREFIX}")
+ set(exec_prefix "\${prefix}")
+-set(libdir "\${exec_prefix}/lib")
++set(libdir "${LIB_INSTALL_DIR}")
+ set(includedir "\${prefix}/include")
+ set(PTHREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}")
+ 
+diff --git a/libical.pc.in b/libical.pc.in
+index 7774dce..bf88476 100644
+--- a/libical.pc.in
++++ b/libical.pc.in
+@@ -8,8 +8,8 @@ iculib=@ICU_LIBRARIES@ @ICU_I18N_LIBRARIES@
+ Name: libical
+ Description: An implementation of basic iCAL protocols
+ Version: @LIBICAL_LIB_VERSION_STRING@
+-Libs: -L${libdir} -lical -licalss -licalvcal
++Libs: -lical -licalss -licalvcal
+ Libs.private: @PTHREAD_LIBS@
+ @REQUIRES_PRIVATE_ICU@
+ Cflags: -I${includedir}

--- a/dev-libs/libical/files/libical-2.0.0-libical.pc-icu-move-to-requires.patch
+++ b/dev-libs/libical/files/libical-2.0.0-libical.pc-icu-move-to-requires.patch
@@ -1,0 +1,47 @@
+commit f70a26aaf836da0f9e242945151b49190d682d95
+Author: Allen Winter <allen.winter@kdab.com>
+Date:   Sat Dec 3 11:11:48 2016 -0500
+
+    CMakeLists.txt, libical.pc.in - ICU must appear as Requires in pkgconfig
+    issue#244
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b3d49d0d..0f6dfc34 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -145,7 +145,7 @@ endif()
+ #  RSCALE info at http://tools.ietf.org/html/rfc7529
+ find_package(ICU)
+ if(ICU_FOUND)
+-  set(ICUUC_LIBS "-licuuc") #for libical.pc
++  set(REQUIRES_PRIVATE_ICU "Requires.private: icu-i18n") #for libical.pc
+   set(HAVE_LIBICU 1)
+   if(ICU_MAJOR_VERSION VERSION_GREATER 50)
+     set(HAVE_ICU_DANGI TRUE)
+@@ -155,7 +155,6 @@ if(ICU_FOUND)
+ endif()
+ if(ICU_I18N_FOUND)
+   set(HAVE_LIBICU_I18N 1)
+-  set(ICUI18N_LIBS "-licui18n") #for libical.pc
+ endif()
+ 
+ # MSVC specific definitions
+diff --git a/libical.pc.in b/libical.pc.in
+index 8899f430..c07eb52a 100644
+--- a/libical.pc.in
++++ b/libical.pc.in
+@@ -2,11 +2,11 @@ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@
+-threadslib=@PTHREAD_LIBS@
+-iculibs=@ICUUC_LIBS@ @ICUI18N_LIBS@
+ 
+ Name: libical
+ Description: An implementation of basic iCAL protocols
+ Version: @LIBICAL_LIB_VERSION_STRING@
+-Libs: -L${libdir} -lical -licalss -licalvcal ${threadslib} ${iculibs}
++Libs: -L${libdir} -lical -licalss -licalvcal
++Libs.private: @PTHREAD_LIBS@
++@REQUIRES_PRIVATE_ICU@
+ Cflags: -I${includedir}

--- a/dev-libs/libical/files/libical-2.0.0-libical.pc-icu-remove-full-paths.patch
+++ b/dev-libs/libical/files/libical-2.0.0-libical.pc-icu-remove-full-paths.patch
@@ -1,0 +1,44 @@
+commit 1a41069c0dc054e59cd76fc3d8cf7cc2a78b5e8d
+Author: Allen Winter <allen.winter@kdab.com>
+Date:   Sat Sep 3 16:56:29 2016 -0400
+
+    CMakeLists.txt, libical.pc.in - fix iculibs (remove full path)
+    ISSUE: 227
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0173e1a8..0c903ee5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -145,6 +145,7 @@ endif()
+ #  RSCALE info at http://tools.ietf.org/html/rfc7529
+ find_package(ICU)
+ if(ICU_FOUND)
++  set(ICUUC_LIBS "-licuuc") #for libical.pc
+   set(HAVE_LIBICU 1)
+   if(ICU_MAJOR_VERSION VERSION_GREATER 50)
+     set(HAVE_ICU_DANGI TRUE)
+@@ -154,6 +155,7 @@ if(ICU_FOUND)
+ endif()
+ if(ICU_I18N_FOUND)
+   set(HAVE_LIBICU_I18N 1)
++  set(ICUI18N_LIBS "-licui18n") #for libical.pc
+ endif()
+ 
+ # MSVC specific definitions
+diff --git a/libical.pc.in b/libical.pc.in
+index 5c2debd8..8899f430 100644
+--- a/libical.pc.in
++++ b/libical.pc.in
+@@ -3,10 +3,10 @@ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@
+ threadslib=@PTHREAD_LIBS@
+-iculib=@ICU_LIBRARIES@ @ICU_I18N_LIBRARIES@
++iculibs=@ICUUC_LIBS@ @ICUI18N_LIBS@
+ 
+ Name: libical
+ Description: An implementation of basic iCAL protocols
+ Version: @LIBICAL_LIB_VERSION_STRING@
+-Libs: -L${libdir} -lical -licalss -licalvcal ${threadslib} ${iculib}
++Libs: -L${libdir} -lical -licalss -licalvcal ${threadslib} ${iculibs}
+ Cflags: -I${includedir}

--- a/dev-libs/libical/files/libical-2.0.0-libical.pc-set-full-version.patch
+++ b/dev-libs/libical/files/libical-2.0.0-libical.pc-set-full-version.patch
@@ -1,0 +1,19 @@
+commit cdc85e9e7a14932808471f823bc974031a0c4842
+Author: Allen Winter <allen.winter@kdab.com>
+Date:   Mon Jan 25 14:57:20 2016 -0500
+
+    libical.pc.in - set the version to the full major.minor.patch
+    as requested by Milan.
+
+diff --git a/libical.pc.in b/libical.pc.in
+index 7774dce2..5c2debd8 100644
+--- a/libical.pc.in
++++ b/libical.pc.in
+@@ -7,6 +7,6 @@ iculib=@ICU_LIBRARIES@ @ICU_I18N_LIBRARIES@
+ 
+ Name: libical
+ Description: An implementation of basic iCAL protocols
+-Version: @VERSION@
++Version: @LIBICAL_LIB_VERSION_STRING@
+ Libs: -L${libdir} -lical -licalss -licalvcal ${threadslib} ${iculib}
+ Cflags: -I${includedir}

--- a/dev-libs/libical/libical-2.0.0-r3.ebuild
+++ b/dev-libs/libical/libical-2.0.0-r3.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit cmake-utils
+
+DESCRIPTION="An implementation of basic iCAL protocols"
+HOMEPAGE="https://github.com/libical/libical"
+SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="|| ( MPL-1.0 LGPL-2.1 )"
+SLOT="0/2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+IUSE="doc examples static-libs"
+
+# The GOBJECT_INTROSPECTION build is broken, and upstream has given up
+# on it at the moment (it's disabled in Travis). It will probably come
+# back in v2.0.1 or later.
+# This snippet belongs to RDEPEND:
+# introspection? ( dev-libs/gobject-introspection )"
+RDEPEND="dev-libs/icu:="
+DEPEND="${RDEPEND}
+	dev-lang/perl"
+
+DOCS=(
+	AUTHORS ReadMe.txt ReleaseNotes.txt TEST THANKS TODO
+	doc/{AddingOrModifyingComponents,UsingLibical}.txt
+)
+
+PATCHES=(
+	"${FILESDIR}/libical-2.0.0-libical.pc-set-full-version.patch"
+	"${FILESDIR}/libical-2.0.0-libical.pc-icu-remove-full-paths.patch"
+	"${FILESDIR}/libical-2.0.0-libical.pc-icu-move-to-requires.patch"
+	"${FILESDIR}/libical-2.0.0-libical.pc-fix-libdir-location.patch"
+)
+
+src_configure() {
+	# See above, introspection is disabled for v2.0.0 at least.
+	#local mycmakeargs=(
+	#	-DGOBJECT_INTROSPECTION=$(usex introspection true false)
+	#)
+	use static-libs || mycmakeargs+=( -DSHARED_ONLY=ON )
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+
+	if use examples; then
+		rm examples/CMakeLists.txt || die
+		dodoc -r examples
+	fi
+}


### PR DESCRIPTION
Move pthread and ICU libs to *.private sections in libical.pc. Also
fixes absolute paths to ICU libraries.

Bug: https://bugs.gentoo.org/599244