### PR TITLE
dev-util/valgrind: fix for --xml-socket option

### DIFF
--- a/dev-util/valgrind/files/valgrind-3.13.0-xml-socket.patch
+++ b/dev-util/valgrind/files/valgrind-3.13.0-xml-socket.patch
@@ -1,0 +1,27 @@
+From: Ivo Raisr <ivosh@ivosh.net>
+Date: Thu, 3 Aug 2017 05:22:01 +0000 (+0000)
+Subject: Fix handling command line option --xml-socket.
+X-Git-Url: https://sourceware.org/git/?p=valgrind.git;a=commitdiff_plain;h=34dd8493de39314033509bb7ad62673f33dcf3db
+
+Fix handling command line option --xml-socket.
+Fixes BZ#382998
+Patch by: Orgad Shaneh <orgads@gmail.com>
+
+
+
+git-svn-id: svn://svn.valgrind.org/valgrind/trunk@16467
+---
+
+diff --git a/coregrind/m_libcprint.c b/coregrind/m_libcprint.c
+index d66c67d..f6ba202 100644
+--- a/coregrind/m_libcprint.c
++++ b/coregrind/m_libcprint.c
+@@ -526,7 +526,7 @@ void VG_(init_log_xml_sinks)(VgLogTo log_to, VgLogTo xml_to,
+          break;
+ 
+       case VgLogTo_Socket:
+-         log_fd = prepare_sink_socket(VG_(clo_xml_fname_unexpanded),
++         xml_fd = prepare_sink_socket(VG_(clo_xml_fname_unexpanded),
+                                       &VG_(xml_output_sink), True);
+          break;
+    }

--- a/dev-util/valgrind/valgrind-3.13.0-r2.ebuild
+++ b/dev-util/valgrind/valgrind-3.13.0-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 inherit autotools flag-o-matic toolchain-funcs multilib pax-utils
 
 DESCRIPTION="An open-source memory debugger for GNU/Linux"
@@ -45,7 +45,7 @@ src_prepare() {
 }
 
 src_configure() {
-	local myconf
+	local myconf=()
 
 	# Respect ar, bug #468114
 	tc-export AR
@@ -67,23 +67,23 @@ src_configure() {
 	replace-flags -ggdb3 -ggdb2
 
 	if use amd64 || use ppc64; then
-		! has_multilib_profile && myconf="${myconf} --enable-only64bit"
+		! has_multilib_profile && myconf+=("--enable-only64bit")
 	fi
 
 	# Force bitness on darwin, bug #306467
-	use x86-macos && myconf="${myconf} --enable-only32bit"
-	use x64-macos && myconf="${myconf} --enable-only64bit"
+	use x86-macos && myconf+=("--enable-only32bit")
+	use x64-macos && myconf+=("--enable-only64bit")
 
 	# Don't use mpicc unless the user asked for it (bug #258832)
 	if ! use mpi; then
-		myconf="${myconf} --without-mpicc"
+		myconf+=("--without-mpicc")
 	fi
 
-	econf ${myconf}
+	econf "${myconf[@]}"
 }
 
 src_install() {
-	emake DESTDIR="${D}" install
+	default
 
 	if [[ ${PV} == "9999" ]]; then
 		# Otherwise FAQ.txt won't exist:
@@ -91,7 +91,7 @@ src_install() {
 		mv docs/FAQ.txt . || die "Couldn't move FAQ.txt"
 	fi
 
-	dodoc AUTHORS FAQ.txt NEWS README*
+	dodoc FAQ.txt
 
 	pax-mark m "${ED}"/usr/$(get_libdir)/valgrind/*-*-linux
 

--- a/dev-util/valgrind/valgrind-3.13.0-r2.ebuild
+++ b/dev-util/valgrind/valgrind-3.13.0-r2.ebuild
@@ -1,0 +1,115 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+inherit autotools flag-o-matic toolchain-funcs multilib pax-utils
+
+DESCRIPTION="An open-source memory debugger for GNU/Linux"
+HOMEPAGE="http://www.valgrind.org"
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="mpi"
+
+if [[ ${PV} == "9999" ]]; then
+	EGIT_REPO_URI="git://sourceware.org/git/${PN}.git/"
+	inherit git-r3
+else
+	SRC_URI="ftp://sourceware.org/pub/valgrind/${P}.tar.bz2"
+	KEYWORDS="-* ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
+fi
+
+DEPEND="mpi? ( virtual/mpi )"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	# Correct hard coded doc location
+	sed -i -e "s:doc/valgrind:doc/${PF}:" docs/Makefile.am || die
+
+	# Don't force multiarch stuff on OSX, bug #306467
+	sed -i -e 's:-arch \(i386\|x86_64\)::g' Makefile.all.am || die
+
+	# Respect CFLAGS, LDFLAGS
+	eapply "${FILESDIR}"/${PN}-3.7.0-respect-flags.patch
+
+	# Fix test failures on glibc-2.26
+	eapply "${FILESDIR}"/${P}-test-fixes.patch
+
+	# Fix --xml-socket command line option (qt-creator), bug #641790
+	eapply "${FILESDIR}"/${P}-xml-socket.patch
+
+	# Allow users to test their own patches
+	eapply_user
+
+	# Regenerate autotools files
+	eautoreconf
+}
+
+src_configure() {
+	local myconf
+
+	# Respect ar, bug #468114
+	tc-export AR
+
+	# -fomit-frame-pointer	"Assembler messages: Error: junk `8' after expression"
+	#                       while compiling insn_sse.c in none/tests/x86
+	# -fstack-protector     more undefined references to __guard and __stack_smash_handler
+	#                       because valgrind doesn't link to glibc (bug #114347)
+	# -fstack-protector-all    Fails same way as -fstack-protector/-fstack-protector-strong.
+	#                          Note: -fstack-protector-explicit is a no-op for Valgrind, no need to strip it
+	# -fstack-protector-strong See -fstack-protector (bug #620402)
+	# -m64 -mx32			for multilib-portage, bug #398825
+	# -ggdb3                segmentation fault on startup
+	filter-flags -fomit-frame-pointer
+	filter-flags -fstack-protector
+	filter-flags -fstack-protector-all
+	filter-flags -fstack-protector-strong
+	filter-flags -m64 -mx32
+	replace-flags -ggdb3 -ggdb2
+
+	if use amd64 || use ppc64; then
+		! has_multilib_profile && myconf="${myconf} --enable-only64bit"
+	fi
+
+	# Force bitness on darwin, bug #306467
+	use x86-macos && myconf="${myconf} --enable-only32bit"
+	use x64-macos && myconf="${myconf} --enable-only64bit"
+
+	# Don't use mpicc unless the user asked for it (bug #258832)
+	if ! use mpi; then
+		myconf="${myconf} --without-mpicc"
+	fi
+
+	econf ${myconf}
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	if [[ ${PV} == "9999" ]]; then
+		# Otherwise FAQ.txt won't exist:
+		emake -C docs FAQ.txt
+		mv docs/FAQ.txt . || die "Couldn't move FAQ.txt"
+	fi
+
+	dodoc AUTHORS FAQ.txt NEWS README*
+
+	pax-mark m "${ED}"/usr/$(get_libdir)/valgrind/*-*-linux
+
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		# fix install_names on shared libraries, can't turn them into bundles,
+		# as dyld won't load them any more then, bug #306467
+		local l
+		for l in "${ED}"/usr/lib/valgrind/*.so ; do
+			install_name_tool -id "${EPREFIX}"/usr/lib/valgrind/${l##*/} "${l}"
+		done
+	fi
+}
+
+pkg_postinst() {
+	elog "Valgrind will not work if glibc does not have debug symbols."
+	elog "To fix this you can add splitdebug to FEATURES in make.conf"
+	elog "and remerge glibc.  See:"
+	elog "https://bugs.gentoo.org/show_bug.cgi?id=214065"
+	elog "https://bugs.gentoo.org/show_bug.cgi?id=274771"
+	elog "https://bugs.gentoo.org/show_bug.cgi?id=388703"
+}

--- a/dev-util/valgrind/valgrind-9999.ebuild
+++ b/dev-util/valgrind/valgrind-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 inherit autotools flag-o-matic toolchain-funcs multilib pax-utils
 
 DESCRIPTION="An open-source memory debugger for GNU/Linux"
@@ -39,7 +39,7 @@ src_prepare() {
 }
 
 src_configure() {
-	local myconf
+	local myconf=()
 
 	# Respect ar, bug #468114
 	tc-export AR
@@ -61,23 +61,23 @@ src_configure() {
 	replace-flags -ggdb3 -ggdb2
 
 	if use amd64 || use ppc64; then
-		! has_multilib_profile && myconf="${myconf} --enable-only64bit"
+		! has_multilib_profile && myconf+=("--enable-only64bit")
 	fi
 
 	# Force bitness on darwin, bug #306467
-	use x86-macos && myconf="${myconf} --enable-only32bit"
-	use x64-macos && myconf="${myconf} --enable-only64bit"
+	use x86-macos && myconf+=("--enable-only32bit")
+	use x64-macos && myconf+=("--enable-only64bit")
 
 	# Don't use mpicc unless the user asked for it (bug #258832)
 	if ! use mpi; then
-		myconf="${myconf} --without-mpicc"
+		myconf+=("--without-mpicc")
 	fi
 
-	econf ${myconf}
+	econf "${myconf[@]}"
 }
 
 src_install() {
-	emake DESTDIR="${D}" install
+	default
 
 	if [[ ${PV} == "9999" ]]; then
 		# Otherwise FAQ.txt won't exist:
@@ -85,7 +85,7 @@ src_install() {
 		mv docs/FAQ.txt . || die "Couldn't move FAQ.txt"
 	fi
 
-	dodoc AUTHORS FAQ.txt NEWS README*
+	dodoc FAQ.txt
 
 	pax-mark m "${ED}"/usr/$(get_libdir)/valgrind/*-*-linux
 


### PR DESCRIPTION
Fix for Qt Creator working.

Closes: https://bugs.gentoo.org/641790
Package-Manager: Portage-2.3.13, Repoman-2.3.3