### PR TITLE
app-i18n/zhcon: Update to EAPI-6

### DIFF
--- a/app-i18n/zhcon/files/zhcon-0.2.6.sysconfdir.patch
+++ b/app-i18n/zhcon/files/zhcon-0.2.6.sysconfdir.patch
@@ -1,6 +1,6 @@
-diff -ruN zhcon-0.2.5/src/Makefile.am /tmp/zhcon-0.2.5/src/Makefile.am
---- a/zhcon-0.2.5/src/Makefile.am	2006-06-22 12:35:01.531885552 +0800
-+++ b/zhcon-0.2.5/src/Makefile.am	2006-06-22 12:31:44.000000000 +0800
+diff -ruN /src/Makefile.am /tmp/src/Makefile.am
+--- a/src/Makefile.am	2006-06-22 12:35:01.531885552 +0800
++++ b/src/Makefile.am	2006-06-22 12:31:44.000000000 +0800
 @@ -5,6 +5,8 @@
  
  zhcon_LDADD = display/libdisplay.a
@@ -10,9 +10,9 @@ diff -ruN zhcon-0.2.5/src/Makefile.am /tmp/zhcon-0.2.5/src/Makefile.am
  SUBDIRS = display
  
  install-exec-local:
-diff -ruN zhcon-0.2.5/src/zhcon.cpp /tmp/zhcon-0.2.5/src/zhcon.cpp
---- a/zhcon-0.2.5/src/zhcon.cpp	2006-06-22 12:35:01.398905768 +0800
-+++ b/zhcon-0.2.5/src/zhcon.cpp	2006-06-22 12:32:41.000000000 +0800
+diff -ruN src/zhcon.cpp /tmp/src/zhcon.cpp
+--- a/src/zhcon.cpp	2006-06-22 12:35:01.398905768 +0800
++++ b/src/zhcon.cpp	2006-06-22 12:32:41.000000000 +0800
 @@ -123,7 +123,7 @@
      string cfgfile = getenv("HOME");
      cfgfile += "/.zhconrc";

--- a/app-i18n/zhcon/zhcon-0.2.6-r3.ebuild
+++ b/app-i18n/zhcon/zhcon-0.2.6-r3.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2012 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+WANT_AUTOMAKE="1.9"
+
+inherit autotools eutils
+
+MY_P="${P/6/5}"
+
+DESCRIPTION="A Fast CJK (Chinese/Japanese/Korean) Console Environment"
+HOMEPAGE="http://zhcon.sourceforge.net/"
+SRC_URI="mirror://sourceforge/zhcon/${MY_P}.tar.gz
+		mirror://sourceforge/zhcon/zhcon-0.2.5-to-0.2.6.diff.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="ggi gpm"
+
+DEPEND="ggi? ( media-libs/libggi[X] )
+	gpm? ( sys-libs/gpm )"
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}.sysconfdir.patch
+	"${FILESDIR}"/${P}.configure.in.patch
+	"${FILESDIR}"/${P}+gcc-4.3.patch
+	"${FILESDIR}"/${P}+linux-headers-2.6.26.patch
+	"${FILESDIR}"/${P}-curses.patch
+	"${FILESDIR}"/${P}-amd64.patch
+	"${FILESDIR}"/${P}-automagic-fix.patch
+	"${FILESDIR}"/${P}.make-fix.patch
+)
+
+src_prepare() {
+	epatch "${DISTDIR}"/zhcon-0.2.5-to-0.2.6.diff.gz
+	default
+	for f in $(grep -lir HAVE_GGI_LIB *); do
+		sed -i -e "s/HAVE_GGI_LIB/HAVE_LIBGGI/" "${f}" || die "sed failed"
+	done
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_with ggi) \
+		$(use_with gpm)
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	dodoc AUTHORS ChangeLog README NEWS TODO THANKS
+	dodoc README.BSD README.gpm README.utf8
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/621956
Package-Manager: Portage-2.3.13