### PR TITLE
lxde-base/lxde-common: Update HOMEPAGE

### DIFF
--- a/lxde-base/lxde-common/lxde-common-0.99.1.ebuild
+++ b/lxde-base/lxde-common/lxde-common-0.99.1.ebuild
@@ -6,7 +6,7 @@ EAPI="6"
 inherit eutils
 
 DESCRIPTION="LXDE Session default configuration files and nuoveXT2 iconset"
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://wiki.lxde.org/en/LXDE_Common"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Package should use a more package specific homepage:
https://wiki.lxde.org/en/LXDE_Common

Closes: https://bugs.gentoo.org/640830
Package-Manager: Portage-2.3.13, Repoman-2.3.3