### PR TITLE
app-antivirus/clamav: fix clamd@.service path

### DIFF
--- a/app-antivirus/clamav/files/clamd.service
+++ b/app-antivirus/clamav/files/clamd.service
@@ -1,4 +1,4 @@
-.include /usr/lib/systemd/system/clamd@.service
+.include /lib/systemd/system/clamd@.service
 
 [Unit]
 Description=Generic ClamAV scanner daemon


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/627700