### PR TITLE
package.mask: Extend sys-devel/gcc to <5.4

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -780,7 +780,7 @@ dev-ruby/poltergeist
 # If you still use one of these old toolchain packages, please upgrade (and
 # switch the compiler / the binutils) ASAP. If you need them for a specific
 # (isolated) use case, feel free to unmask them on your system.
-<sys-devel/gcc-4.9
+<sys-devel/gcc-5.4
 <sys-libs/glibc-2.25-r9
 <sys-devel/binutils-2.28.1
 

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -788,8 +788,8 @@ dev-ruby/poltergeist
 # Old versions of CUDA and their reverse dependencies. They do not
 # support GCC 4.9+, and are really old.
 <dev-python/pycuda-2016
-<dev-util/nvidia-cuda-sdk-7
-<dev-util/nvidia-cuda-toolkit-7
+<dev-util/nvidia-cuda-sdk-8
+<dev-util/nvidia-cuda-toolkit-8
 net-wireless/cpyrit-cuda
 
 # Maciej Mrozowski <reavertm@gentoo.org> (18 May 2017)


### PR DESCRIPTION
Extend the sys-devel/gcc mask to include all versions <5.4,
in particular gcc-4.9 that is still present in Gentoo. This version is
causing numeruous build failures for various packages, and there is
really no point in pursuing restrictions package-by-package.

@gentoo/toolchain 