### PR TITLE
media-gfx/darktable : add hints to find opencl header file

### DIFF
--- a/media-gfx/darktable/darktable-2.4.0.ebuild
+++ b/media-gfx/darktable/darktable-2.4.0.ebuild
@@ -69,6 +69,8 @@ DEPEND="${CDEPEND}
 		>=sys-devel/llvm-4
 	)"
 
+PATCHES=( "${FILESDIR}"/"${PN}"-find-opencl-header.patch )
+
 S="${WORKDIR}/${P/_/~}"
 
 pkg_pretend() {

--- a/media-gfx/darktable/files/darktable-find-opencl-header.patch
+++ b/media-gfx/darktable/files/darktable-find-opencl-header.patch
@@ -1,0 +1,12 @@
+diff -Nur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2017-12-24 09:09:10.000000000 +0000
++++ b/CMakeLists.txt	2017-12-25 20:42:40.998693994 +0000
+@@ -355,7 +355,7 @@
+       message(STATUS "Found clang compiler - ${CLANG_OPENCL_COMPILER}")
+ 
+       find_path(CLANG_OPENCL_INCLUDE_DIR opencl-c.h
+-        HINTS ${LLVM_INSTALL_PREFIX}/lib/clang ${LLVM_INSTALL_PREFIX}/lib64/clang
++        HINTS ${LLVM_INSTALL_PREFIX}/lib/clang ${LLVM_INSTALL_PREFIX}/lib64/clang /usr/lib/clang /usr/lib64/clang
+         PATH_SUFFIXES include ${LLVM_PACKAGE_VERSION}/include
+         NO_DEFAULT_PATH
+       )


### PR DESCRIPTION
On Gentoo , LLVM_INSTALL_PREFIX is /usr/${get_libdir}/llvm/version , but opencl-c.h header file resides in /usr/${get_libdir}/clang/include, so when cmake looks for it in LLVM_INSTALL_PREFIX/lib64/clang it wont find it.

This patch adds some additional hints to search the opencl-c.h header file in /usr/${get_libdir}/clang as well. This will also allow darktable to build against LLVM 5, so the users of ~arch won't have to downgrade in order to get opencl working.

Some logs from my machine : 

-- Found LLVM 5.0.1
-- Found clang compiler - /usr/lib/llvm/5/bin/clang-5.0
-- Found clang opencl-c.h header in /usr/lib/clang/5.0.1/include
-- Will be able to test-compile OpenCL programs. Nice.