### PR TITLE
dev-python/pyblake2: add ~amd64-fbsd, ~x86-fbsd KEYWORDS.

### DIFF
--- a/dev-python/pyblake2/pyblake2-1.1.0.ebuild
+++ b/dev-python/pyblake2/pyblake2-1.1.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
 # pyblake2 itself allows more licenses but blake2 allows the following three
 LICENSE="|| ( CC0-1.0 openssl Apache-2.0 )"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc ~x86 ~x64-cygwin ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc ~x86 ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 python_test() {
 	"${EPYTHON}" test/test.py || die "Tests fail with ${EPYTHON}"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/634936

This package is required by the latest version of the portage.
Please add ~amd64-fbsd, ~x86-fbsd keywords to use it.

Thanks.

```
>>> Test phase: dev-python/pyblake2-1.1.0
 * python2_7: running distutils-r1_run_phase python_test
test_block_size (__main__.BLAKE2bTest) ... ok
test_constants (__main__.BLAKE2bTest) ... ok
test_constructor (__main__.BLAKE2bTest) ... ok
test_digest (__main__.BLAKE2bTest) ... ok
test_digest_size (__main__.BLAKE2bTest) ... ok
test_empty_bytes (__main__.BLAKE2bTest) ... ok
test_hexdigest (__main__.BLAKE2bTest) ... ok
test_digest (__main__.BLAKE2bKeyedTest) ... ok
test_empty_bytes (__main__.BLAKE2bKeyedTest) ... ok
test_hexdigest (__main__.BLAKE2bKeyedTest) ... ok
test_block_size (__main__.BLAKE2sTest) ... ok
test_constants (__main__.BLAKE2sTest) ... ok
test_constructor (__main__.BLAKE2sTest) ... ok
test_digest (__main__.BLAKE2sTest) ... ok
test_digest_size (__main__.BLAKE2sTest) ... ok
test_empty_bytes (__main__.BLAKE2sTest) ... ok
test_hexdigest (__main__.BLAKE2sTest) ... ok
test_digest (__main__.BLAKE2sKeyedTest) ... ok
test_empty_bytes (__main__.BLAKE2sKeyedTest) ... ok
test_hexdigest (__main__.BLAKE2sKeyedTest) ... ok

----------------------------------------------------------------------
Ran 20 tests in 0.014s

OK
 * python3_5: running distutils-r1_run_phase python_test
test_block_size (__main__.BLAKE2bTest) ... ok
test_constants (__main__.BLAKE2bTest) ... ok
test_constructor (__main__.BLAKE2bTest) ... ok
test_digest (__main__.BLAKE2bTest) ... ok
test_digest_size (__main__.BLAKE2bTest) ... ok
test_empty_bytes (__main__.BLAKE2bTest) ... ok
test_hexdigest (__main__.BLAKE2bTest) ... ok
test_digest (__main__.BLAKE2bKeyedTest) ... ok
test_empty_bytes (__main__.BLAKE2bKeyedTest) ... ok
test_hexdigest (__main__.BLAKE2bKeyedTest) ... ok
test_block_size (__main__.BLAKE2sTest) ... ok
test_constants (__main__.BLAKE2sTest) ... ok
test_constructor (__main__.BLAKE2sTest) ... ok
test_digest (__main__.BLAKE2sTest) ... ok
test_digest_size (__main__.BLAKE2sTest) ... ok
test_empty_bytes (__main__.BLAKE2sTest) ... ok
test_hexdigest (__main__.BLAKE2sTest) ... ok
test_digest (__main__.BLAKE2sKeyedTest) ... ok
test_empty_bytes (__main__.BLAKE2sKeyedTest) ... ok
test_hexdigest (__main__.BLAKE2sKeyedTest) ... ok

----------------------------------------------------------------------
Ran 20 tests in 0.014s

OK
 * python2_7: running distutils-r1_run_phase _distutils-r1_clean_egg_info
 * python3_5: running distutils-r1_run_phase _distutils-r1_clean_egg_info
>>> Completed testing dev-python/pyblake2-1.1.0
```