### PR TITLE
net-misc/stargazer: ebuild cleanup, fix bugs 594242 and 587104

### DIFF
--- a/net-misc/stargazer/files/patches/stg-2.408-build-upstream.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-build-upstream.patch
@@ -1,5 +1,5 @@
---- projects/rlm_stg/build.org	2013-01-15 15:25:59.000000000 +0200
-+++ projects/rlm_stg/build	2013-01-15 19:48:13.000000000 +0200
+--- a/projects/rlm_stg/build
++++ b/projects/rlm_stg/build
 @@ -16,21 +16,15 @@
  DIR_MODE=0755
  OWNER=root
@@ -30,8 +30,8 @@
  fi
  
  CXXFLAGS="$CXXFLAGS -I/usr/local/include"
---- projects/rscriptd/build.org	2013-01-15 18:28:32.000000000 +0200
-+++ projects/rscriptd/build	2013-01-15 18:38:13.000000000 +0200
+--- a/projects/rscriptd/build
++++ b/projects/rscriptd/build
 @@ -16,21 +16,15 @@
  DIR_MODE=0755
  OWNER=root
@@ -61,8 +61,8 @@
  fi
  
  CXXFLAGS="$CXXFLAGS -I/usr/local/include"
---- projects/sgauth/build.org	2013-01-15 18:29:20.000000000 +0200
-+++ projects/sgauth/build	2013-01-15 18:36:33.000000000 +0200
+--- a/projects/sgauth/build
++++ b/projects/sgauth/build
 @@ -16,21 +16,15 @@
  DIR_MODE=0755
  OWNER=root
@@ -92,8 +92,8 @@
  fi
  
  CXXFLAGS="$CXXFLAGS -I/usr/local/include"
---- projects/sgconf/build.org	2013-01-15 18:29:59.000000000 +0200
-+++ projects/sgconf/build	2013-01-15 18:35:41.000000000 +0200
+--- a/projects/sgconf/build
++++ b/projects/sgconf/build
 @@ -16,21 +16,15 @@
  DIR_MODE=0755
  OWNER=root
@@ -123,8 +123,8 @@
  fi
  
  CXXFLAGS="$CXXFLAGS -I/usr/local/include"
---- projects/sgconf_xml/build.org	2013-01-15 18:30:26.000000000 +0200
-+++ projects/sgconf_xml/build	2013-01-15 18:34:53.000000000 +0200
+--- a/projects/sgconf_xml/build
++++ b/projects/sgconf_xml/build
 @@ -16,21 +16,15 @@
  DIR_MODE=0755
  OWNER=root
@@ -154,8 +154,8 @@
  fi
  
  CXXFLAGS="$CXXFLAGS -I/usr/local/include"
---- projects/sgconv/build.org	2013-01-15 18:31:01.000000000 +0200
-+++ projects/sgconv/build	2013-01-15 18:32:46.000000000 +0200
+--- a/projects/sgconv/build
++++ b/projects/sgconv/build
 @@ -16,11 +16,20 @@
  DIR_MODE=0755
  OWNER=root
@@ -180,8 +180,8 @@
  
  if [ "$sys" = "Linux" ]
  then
---- projects/stargazer/build.org	2013-01-15 19:48:54.000000000 +0200
-+++ projects/stargazer/build	2013-01-15 19:51:13.000000000 +0200
+--- a/projects/stargazer/build
++++ b/projects/stargazer/build
 @@ -35,23 +35,15 @@
  XMLRPC_FEATURES="c++2 abyss-server"
  

--- a/net-misc/stargazer/files/patches/stg-2.408-build.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-build.patch
@@ -1,5 +1,5 @@
---- projects/rlm_stg/configure.org	2013-01-18 18:06:17.000000000 +0200
-+++ projects/rlm_stg/configure	2013-01-18 18:07:18.000000000 +0200
+--- a/projects/rlm_stg/configure.org	2013-01-18 18:06:17.000000000 +0200
++++ b/projects/rlm_stg/configure	2013-01-18 18:07:18.000000000 +0200
 @@ -34,6 +34,7 @@
  then
      OS=linux
@@ -24,8 +24,8 @@
 -
 +echo "ETC_DIR=$ETC_DIR" >> $CONFFILE
 \ No newline at end of file
---- projects/rscriptd/configure.org	2013-01-18 18:07:28.000000000 +0200
-+++ projects/rscriptd/configure	2013-01-18 18:08:02.000000000 +0200
+--- a/projects/rscriptd/configure.org	2013-01-18 18:07:28.000000000 +0200
++++ b/projects/rscriptd/configure	2013-01-18 18:08:02.000000000 +0200
 @@ -34,6 +34,7 @@
  then
      OS=linux
@@ -51,8 +51,8 @@
 -
 +echo "ETC_DIR=$ETC_DIR" >> $CONFFILE
 \ No newline at end of file
---- projects/sgauth/configure.org	2013-01-18 18:08:10.000000000 +0200
-+++ projects/sgauth/configure	2013-01-18 18:08:38.000000000 +0200
+--- a/projects/sgauth/configure.org	2013-01-18 18:08:10.000000000 +0200
++++ b/projects/sgauth/configure	2013-01-18 18:08:38.000000000 +0200
 @@ -34,6 +34,7 @@
  then
      OS=linux
@@ -77,8 +77,8 @@
 -
 +echo "ETC_DIR=$ETC_DIR" >> $CONFFILE
 \ No newline at end of file
---- projects/sgconf/configure.org	2013-01-18 18:08:46.000000000 +0200
-+++ projects/sgconf/configure	2013-01-18 18:09:44.000000000 +0200
+--- a/projects/sgconf/configure.org	2013-01-18 18:08:46.000000000 +0200
++++ b/projects/sgconf/configure	2013-01-18 18:09:44.000000000 +0200
 @@ -34,6 +34,7 @@
  then
      OS=linux
@@ -104,8 +104,8 @@
 -
 +echo "ETC_DIR=$ETC_DIR" >> $CONFFILE
 \ No newline at end of file
---- projects/sgconf_xml/configure.org	2013-01-18 18:09:54.000000000 +0200
-+++ projects/sgconf_xml/configure	2013-01-18 18:10:23.000000000 +0200
+--- a/projects/sgconf_xml/configure.org	2013-01-18 18:09:54.000000000 +0200
++++ b/projects/sgconf_xml/configure	2013-01-18 18:10:23.000000000 +0200
 @@ -34,6 +34,7 @@
  then
      OS=linux
@@ -131,8 +131,8 @@
 -
 +echo "ETC_DIR=$ETC_DIR" >> $CONFFILE
 \ No newline at end of file
---- projects/sgconv/configure.org	2013-01-18 18:10:30.000000000 +0200
-+++ projects/sgconv/configure	2013-01-18 18:11:09.000000000 +0200
+--- a/projects/sgconv/configure.org	2013-01-18 18:10:30.000000000 +0200
++++ b/projects/sgconv/configure	2013-01-18 18:11:09.000000000 +0200
 @@ -35,6 +35,7 @@
  then
      OS=linux
@@ -161,8 +161,8 @@
 -
 +mkdir -p ../stargazer/modules
 \ No newline at end of file
---- projects/stargazer/configure.org	2013-01-18 18:11:15.000000000 +0200
-+++ projects/stargazer/configure	2013-01-18 18:11:40.000000000 +0200
+--- a/projects/stargazer/configure.org	2013-01-18 18:11:15.000000000 +0200
++++ b/projects/stargazer/configure	2013-01-18 18:11:40.000000000 +0200
 @@ -404,11 +404,4 @@
  echo "VAR_DIR=$VAR_DIR" >> $CONFFILE
  echo "ETC_DIR=$ETC_DIR" >> $CONFFILE

--- a/net-misc/stargazer/files/patches/stg-2.408-correct-paths.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-correct-paths.patch
@@ -1,5 +1,5 @@
---- projects/rscriptd/rscriptd.conf.org	2013-01-08 18:19:34.000000000 +0200
-+++ projects/rscriptd/rscriptd.conf	2013-01-08 18:20:52.000000000 +0200
+--- a/projects/rscriptd/rscriptd.conf
++++ b/projects/rscriptd/rscriptd.conf
 @@ -6,7 +6,7 @@
  # Parameter: optional
  # Value: file path
@@ -34,8 +34,8 @@
  
  ################################################################################
 \ No newline at end of file
---- projects/sgconv/sgconv.conf.org	2012-12-18 21:56:33.578221904 +0200
-+++ projects/sgconv/sgconv.conf	2012-12-18 21:58:22.355217059 +0200
+--- a/projects/sgconv/sgconv.conf
++++ b/projects/sgconv/sgconv.conf
 @@ -18,27 +18,27 @@
      # Working server directory, provides data on tariffs, users, administrators.
      # Parameter: required
@@ -80,8 +80,8 @@
  
      # Database username
      # Parameter: required
---- projects/stargazer/inst/linux/etc/stargazer/stargazer.conf.org	2012-12-30 14:35:22.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/stargazer.conf	2012-12-30 14:36:37.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/stargazer.conf
++++ b/projects/stargazer/inst/linux/etc/stargazer/stargazer.conf
 @@ -6,7 +6,7 @@
  # Parameter: required
  # Value: file path
@@ -100,8 +100,8 @@
  
  # Defines message maximum lifetime
  # Note: 0 - unlimited
---- projects/stargazer/inst/linux/etc/stargazer/conf-available.d/mod_remote_script.conf.org	2012-12-25 14:03:49.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/conf-available.d/mod_remote_script.conf	2012-12-25 14:04:00.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/mod_remote_script.conf
++++ b/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/mod_remote_script.conf
 @@ -16,7 +16,7 @@
      # Parametr: required
      # Values: filename
@@ -111,8 +111,8 @@
  
      # The password to encrypt packets between the stg-server and remote server
      # Parameter: required
---- projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_files.conf.org	2012-12-25 13:31:01.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_files.conf	2012-12-25 13:31:43.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_files.conf
++++ b/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_files.conf
 @@ -5,27 +5,27 @@
      # Working server directory, provides data on tariffs, users, administrators.
      # Parameter: required
@@ -148,8 +148,8 @@
      UserLogMode = 640
  
  </StoreModule>
---- projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_firebird.conf.org	2012-12-25 13:39:00.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_firebird.conf	2012-12-25 13:39:28.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_firebird.conf
++++ b/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_firebird.conf
 @@ -9,7 +9,7 @@
      # Parameter: required
      # Value: file path
@@ -159,8 +159,8 @@
  
      # Database username
      # Parameter: required
---- projects/stargazer/plugins/configuration/rpcconfig/rpcconfig.cpp.org	2012-12-31 11:08:26.000000000 +0200
-+++ projects/stargazer/plugins/configuration/rpcconfig/rpcconfig.cpp	2012-12-31 11:08:41.000000000 +0200
+--- a/projects/stargazer/plugins/configuration/rpcconfig/rpcconfig.cpp
++++ b/projects/stargazer/plugins/configuration/rpcconfig/rpcconfig.cpp
 @@ -169,7 +169,7 @@
  rpcServer = new xmlrpc_c::serverAbyss(
          xmlrpc_c::serverAbyss::constrOpt()
@@ -170,8 +170,8 @@
          .socketFd(fd)
          );
  
---- projects/stargazer/inst/var/00-base-00.sql.org	2013-01-02 16:22:28.000000000 +0200
-+++ projects/stargazer/inst/var/00-base-00.sql	2013-01-02 16:22:52.000000000 +0200
+--- a/projects/stargazer/inst/var/00-base-00.sql
++++ b/projects/stargazer/inst/var/00-base-00.sql
 @@ -50,9 +50,9 @@
  /*
   * CONNECT 'localhost:/var/stg/stargazer.fdb' USER 'stg' PASSWORD '123456';

--- a/net-misc/stargazer/files/patches/stg-2.408-makefile-firebird-upstream.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-makefile-firebird-upstream.patch
@@ -1,5 +1,5 @@
---- projects/stargazer/plugins/store/firebird/Makefile.org	2013-01-04 22:50:13.000000000 +0200
-+++ projects/stargazer/plugins/store/firebird/Makefile	2013-01-04 22:50:56.000000000 +0200
+--- a/projects/stargazer/plugins/store/firebird/Makefile.org	2013-01-04 22:50:13.000000000 +0200
++++ b/projects/stargazer/plugins/store/firebird/Makefile	2013-01-04 22:50:56.000000000 +0200
 @@ -22,5 +22,11 @@
  	  locker \
  	  crypto

--- a/net-misc/stargazer/files/patches/stg-2.408-makefile.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-makefile.patch
@@ -1,5 +1,5 @@
---- projects/sgauth/Makefile.org	2013-01-05 23:47:38.000000000 +0200
-+++ projects/sgauth/Makefile	2013-01-05 23:48:34.000000000 +0200
+--- a/projects/sgauth/Makefile
++++ b/projects/sgauth/Makefile
 @@ -67,8 +67,8 @@
  
  install-data:
@@ -11,8 +11,8 @@
  
  uninstall: uninstall-bin uninstall-data
  
---- projects/stargazer/Makefile.org	2013-01-05 22:53:26.000000000 +0200
-+++ projects/stargazer/Makefile	2013-01-05 22:54:52.000000000 +0200
+--- a/projects/stargazer/Makefile
++++ b/projects/stargazer/Makefile
 @@ -92,30 +92,8 @@
  	mkdir -m $(DIR_MODE) -p $(PREFIX)/etc/stargazer/conf-available.d
  	mkdir -m $(DIR_MODE) -p $(PREFIX)/etc/stargazer/conf-enabled.d
@@ -44,8 +44,8 @@
  
  uninstall: uninstall-bin uninstall-data
  
---- projects/rscriptd/Makefile.org	2013-01-19 17:03:42.000000000 +0200
-+++ projects/rscriptd/Makefile	2013-01-19 17:04:25.000000000 +0200
+--- a/projects/rscriptd/Makefile
++++ b/projects/rscriptd/Makefile
 @@ -65,15 +65,13 @@
  	$(MAKE) -C $(DIR_LIBSRC) install
  
@@ -67,8 +67,8 @@
  endif
  
  uninstall: uninstall-bin uninstall-data
---- projects/rlm_stg/Makefile.org	2013-02-03 14:02:58.000000000 +0200
-+++ projects/rlm_stg/Makefile	2013-02-03 14:05:43.000000000 +0200
+--- a/projects/rlm_stg/Makefile
++++ b/projects/rlm_stg/Makefile
 @@ -56,19 +56,11 @@
  install: install-bin
  
@@ -89,8 +89,8 @@
  	$(MAKE) -C $(DIR_LIBSRC) install
  
  uninstall: uninstall-bin
---- projects/rscriptd/Makefile.org	2013-02-03 14:17:01.000000000 +0200
-+++ projects/rscriptd/Makefile	2013-02-03 14:17:32.000000000 +0200
+--- a/projects/rscriptd/Makefile
++++ b/projects/rscriptd/Makefile
 @@ -57,11 +57,7 @@
  install: install-bin install-data
  
@@ -103,8 +103,8 @@
  	$(MAKE) -C $(DIR_LIBSRC) install
  
  install-data:
---- projects/sgauth/Makefile.org	2013-02-03 14:18:37.000000000 +0200
-+++ projects/sgauth/Makefile	2013-02-03 14:18:48.000000000 +0200
+--- a/projects/sgauth/Makefile
++++ b/projects/sgauth/Makefile
 @@ -58,11 +58,7 @@
  install: install-bin install-data
  
@@ -117,8 +117,8 @@
  	$(MAKE) -C $(DIR_LIBSRC) install
  
  install-data:
---- projects/sgconf/Makefile.org	2013-02-03 14:19:18.000000000 +0200
-+++ projects/sgconf/Makefile	2013-02-03 14:19:28.000000000 +0200
+--- a/projects/sgconf/Makefile
++++ b/projects/sgconf/Makefile
 @@ -66,11 +66,7 @@
  install: install-bin
  
@@ -131,8 +131,8 @@
  	$(MAKE) -C $(DIR_LIBSRC) install
  
  uninstall: uninstall-bin
---- projects/sgconf_xml/Makefile.org	2013-02-03 14:19:53.000000000 +0200
-+++ projects/sgconf_xml/Makefile	2013-02-03 14:19:59.000000000 +0200
+--- a/projects/sgconf_xml/Makefile
++++ b/projects/sgconf_xml/Makefile
 @@ -66,11 +66,7 @@
  install: install-bin install-data
  
@@ -145,8 +145,8 @@
  	$(MAKE) -C $(DIR_LIBSRC) install
  
  uninstall: uninstall-bin uninstall-data
---- projects/sgconv/Makefile.org	2013-02-03 14:20:24.000000000 +0200
-+++ projects/sgconv/Makefile	2013-02-03 14:20:33.000000000 +0200
+--- a/projects/sgconv/Makefile
++++ b/projects/sgconv/Makefile
 @@ -61,11 +61,7 @@
  install: install-bin
  
@@ -159,8 +159,8 @@
  	$(MAKE) -C $(DIR_PLUGINS) install
  
  uninstall: uninstall-bin
---- projects/stargazer/Makefile.org	2013-02-03 14:20:56.000000000 +0200
-+++ projects/stargazer/Makefile	2013-02-03 14:21:30.000000000 +0200
+--- a/projects/stargazer/Makefile
++++ b/projects/stargazer/Makefile
 @@ -77,11 +77,7 @@
  install: install-bin install-data
  
@@ -173,8 +173,8 @@
  	$(MAKE) -C $(DIR_INCLUDE) install
  	$(MAKE) -C $(DIR_LIBSRC) install
  	$(MAKE) -C $(DIR_PLUGINS) install
---- stglibs/Makefile.in.org	2013-02-03 14:53:02.000000000 +0200
-+++ stglibs/Makefile.in	2013-02-03 14:53:11.000000000 +0200
+--- a/stglibs/Makefile.in
++++ b/stglibs/Makefile.in
 @@ -35,11 +35,7 @@
  	rm -f deps $(PROG) *.o *.a *.so tags *.*~ 
  
@@ -187,8 +187,8 @@
  	mkdir -m $(DIR_MODE) -p $(PREFIX)/usr/include/stg
  	install -m $(DATA_MODE) -o $(OWNER) $(addprefix include/stg/,$(INCS)) $(PREFIX)/usr/include/stg/
  
---- projects/stargazer/plugins/Makefile.in.org	2013-02-03 15:38:41.000000000 +0200
-+++ projects/stargazer/plugins/Makefile.in	2013-02-03 15:38:51.000000000 +0200
+--- a/projects/stargazer/plugins/Makefile.in
++++ b/projects/stargazer/plugins/Makefile.in
 @@ -28,11 +28,7 @@
  
  install: $(PROG)

--- a/net-misc/stargazer/files/patches/stg-2.408-on-upstream.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-on-upstream.patch
@@ -1,5 +1,5 @@
---- projects/stargazer/inst/linux/etc/stargazer/OnChange.org	2013-01-09 14:30:32.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/OnChange	2013-01-09 15:50:01.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/OnChange
++++ b/projects/stargazer/inst/linux/etc/stargazer/OnChange
 @@ -1,8 +1,20 @@
  #! /bin/sh
  
@@ -28,8 +28,8 @@
 +# Usage examples:
 +#echo "User: '$LOGIN'. Parameter $PARAMETER changed from '$OLDVALUE' to '$NEWVALUE'" >> /var/stargazer/user.change.log
 \ No newline at end of file
---- projects/stargazer/inst/linux/etc/stargazer/OnConnect.org	2013-01-09 14:39:51.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/OnConnect	2013-01-09 15:11:49.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/OnConnect
++++ b/projects/stargazer/inst/linux/etc/stargazer/OnConnect
 @@ -1,24 +1,23 @@
  #! /bin/sh
  
@@ -66,8 +66,8 @@
 +# Usage examples:
 +#echo "Connected `date +%Y.%m.%d-%H.%M.%S` $IP $CASH" >> /var/stargazer/users/$LOGIN/connect.log
 \ No newline at end of file
---- projects/stargazer/inst/linux/etc/stargazer/OnDisconnect.org	2013-01-09 14:54:36.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/OnDisconnect	2013-01-09 15:11:33.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/OnDisconnect
++++ b/projects/stargazer/inst/linux/etc/stargazer/OnDisconnect
 @@ -1,24 +1,23 @@
  #! /bin/sh
  
@@ -104,8 +104,8 @@
 +# Usage examples:
 +#echo "Disconnected `date +%Y.%m.%d-%H.%M.%S` $IP $CASH" >> /var/stargazer/users/$LOGIN/connect.log
 \ No newline at end of file
---- projects/stargazer/inst/linux/etc/stargazer/OnUserAdd.org	2013-01-09 15:01:57.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/OnUserAdd	2013-01-09 15:10:55.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/OnUserAdd
++++ b/projects/stargazer/inst/linux/etc/stargazer/OnUserAdd
 @@ -1,14 +1,12 @@
  #! /bin/sh
  
@@ -130,8 +130,8 @@
 +# Usage examples:
 +#echo "Added user $login" >> /var/stargazer/add_del.log
 \ No newline at end of file
---- projects/stargazer/inst/linux/etc/stargazer/OnUserDel.org	2013-01-09 15:12:32.000000000 +0200
-+++ projects/stargazer/inst/linux/etc/stargazer/OnUserDel	2013-01-09 15:14:10.000000000 +0200
+--- a/projects/stargazer/inst/linux/etc/stargazer/OnUserDel
++++ b/projects/stargazer/inst/linux/etc/stargazer/OnUserDel
 @@ -1,7 +1,13 @@
  #! /bin/sh
  

--- a/net-misc/stargazer/files/patches/stg-2.408-radius-upstream.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-radius-upstream.patch
@@ -1,5 +1,5 @@
---- projects/rlm_stg/Makefile.org	2013-01-18 16:17:18.000000000 +0200
-+++ projects/rlm_stg/Makefile	2013-01-18 16:19:13.000000000 +0200
+--- a/projects/rlm_stg/Makefile
++++ b/projects/rlm_stg/Makefile
 @@ -57,16 +57,28 @@
  
  install-bin:

--- a/net-misc/stargazer/files/patches/stg-2.408-rscriptd-upstream.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-rscriptd-upstream.patch
@@ -1,5 +1,5 @@
---- projects/rscriptd/Makefile.org	2013-01-18 16:22:46.000000000 +0200
-+++ projects/rscriptd/Makefile	2013-01-18 16:25:08.000000000 +0200
+--- a/projects/rscriptd/Makefile
++++ b/projects/rscriptd/Makefile
 @@ -68,6 +68,13 @@
  	# Install etc
  	mkdir -m $(DIR_MODE) -p $(PREFIX)/etc/rscriptd

--- a/net-misc/stargazer/files/patches/stg-2.408-rscriptd.conf-upstream.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-rscriptd.conf-upstream.patch
@@ -1,5 +1,5 @@
---- projects/rscriptd/rscriptd.conf.org	2013-01-12 15:44:46.000000000 +0200
-+++ projects/rscriptd/rscriptd.conf	2013-01-12 15:45:44.000000000 +0200
+--- a/projects/rscriptd/rscriptd.conf
++++ b/projects/rscriptd/rscriptd.conf
 @@ -1,8 +1,68 @@
 -LogFileName=/var/log/rscriptd.log
 -ExecutersNum=1

--- a/net-misc/stargazer/files/patches/stg-2.408-sgauth.conf-upstream.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-sgauth.conf-upstream.patch
@@ -1,5 +1,5 @@
---- projects/sgauth/sgauth.conf.org	2013-01-08 15:43:09.000000000 +0200
-+++ projects/sgauth/sgauth.conf	2013-01-09 13:41:53.000000000 +0200
+--- a/projects/sgauth/sgauth.conf
++++ b/projects/sgauth/sgauth.conf
 @@ -1,37 +1,72 @@
 -#Stargazer server ip
 -ServerName=192.168.1.2

--- a/net-misc/stargazer/files/patches/stg-2.408-sgconv-upstream.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-sgconv-upstream.patch
@@ -1,5 +1,5 @@
---- projects/sgconv/Makefile.org	2013-01-08 12:07:06.000000000 +0200
-+++ projects/sgconv/Makefile	2013-01-08 12:07:11.000000000 +0200
+--- a/projects/sgconv/Makefile
++++ b/projects/sgconv/Makefile
 @@ -4,7 +4,7 @@
  
  include ../../Makefile.conf
@@ -9,8 +9,8 @@
  
  SRCS = ./main.cpp \
         ./settings_impl.cpp
---- projects/sgconv/build.org	2012-02-09 12:26:57.000000000 +0200
-+++ projects/sgconv/build	2013-01-08 12:10:02.000000000 +0200
+--- a/projects/sgconv/build
++++ b/projects/sgconv/build
 @@ -45,13 +45,13 @@
  if [ "$OS" = "unknown" ]
  then 
@@ -27,8 +27,8 @@
  echo "#############################################################################"
  
  STG_LIBS="logger.lib 
---- projects/sgconv/settings_impl.h.org	2013-01-08 12:11:53.000000000 +0200
-+++ projects/sgconv/settings_impl.h	2013-01-08 12:11:58.000000000 +0200
+--- a/projects/sgconv/settings_impl.h
++++ b/projects/sgconv/settings_impl.h
 @@ -38,7 +38,7 @@
  
  class SETTINGS_IMPL {

--- a/net-misc/stargazer/files/patches/stg-2.408-static-libs.patch
+++ b/net-misc/stargazer/files/patches/stg-2.408-static-libs.patch
@@ -1,5 +1,5 @@
---- stglibs/Makefile.org	2013-01-19 18:21:57.000000000 +0200
-+++ stglibs/Makefile	2013-01-19 18:24:25.000000000 +0200
+--- a/stglibs/Makefile
++++ b/stglibs/Makefile
 @@ -15,6 +15,6 @@
  
  clean: all

--- a/net-misc/stargazer/metadata.xml
+++ b/net-misc/stargazer/metadata.xml
@@ -1,54 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>spiderx@spiderx.dp.ua</email>
-    <name>Vladimir Pavljuchenkov</name>
-    <description>Primary maintainer.</description>
-  </maintainer>
-  <maintainer type="project">
-    <email>proxy-maint@gentoo.org</email>
-    <name>Proxy Maintainers</name>
-  </maintainer>
-  <longdescription>
-    Stargazer is a powerful (inter)net billing system, capable of gathering
-    traffic statistics from many sources (such as NetFlow protocol,
-    ethernet packets capture, or IPQ subsystem), managing and billing user
-    accounts according to specified fees and rules (including time-based rules,
-    traffic source/destination rules and a payoff system).
-    This ebuild allows you to compile it yourself depending of your needs.
-  </longdescription>
-  <use>
-    <flag name="sgconv">Enable build of utility to convert Stargazer data between storage backends.</flag>
-    <flag name="radius">Enable build of FreeRADIUS module for data access via Stargazer.</flag>
-    <flag name="rscriptd">Enable build of remote script execute daemon for Stargazer, which run scripts when receive special signal from Stargazer.</flag>
-    <flag name="sgauth">Enable build of command-line utility for authorization in Stargazer.</flag>
-    <flag name="sgconf">Enable build of command-line utility for configuring Stargazer.</flag>
-    <flag name="sgconf_xml">Enable build of command-line xml-based utility for configuring Stargazer.</flag>
-    <flag name="stargazer">Enable build of Stargazer billing system.</flag>
-    <flag name="debug">Enable extra debug codepaths, like asserts and extra output.</flag>
-    <flag name="doc">Adds extra documentation (API, doc, etc).</flag>
-    <flag name="examples">Install examples, usually source code.</flag>
-    <flag name="static-libs">Install static libraries.</flag>
-    <flag name="module_auth_always_online">Enable build of "Always Online" authentication module for Stargazer.</flag>
-    <flag name="module_auth_internet_access">Enable build of "InetAccess" authentication module for Stargazer. InetAccess is a Stargazer specific authentication protocol.</flag>
-    <flag name="module_auth_freeradius">Enable build of "Radius" authentication module for Stargazer. This module capable of using RADIUS procotol for user authentication.</flag>
-    <flag name="module_capture_ether">Enable build of "Ethernet" traffic capture module for Stargazer. This module uses RAW sockets to capture traffic.</flag>
-    <flag name="module_capture_ipq">Enable build of "IPQ" traffic capture module for Stargazer. This module uses IPQ subsystem to capture traffic.</flag>
-    <flag name="module_capture_netflow">Enable build of "NetFlow" traffic capture module for Stargazer. This module capable of receiving traffic data by NetFlow protocol.</flag>
-    <flag name="module_config_rpcconfig">Enable build of "XMLRPC" configuration module for Stargazer. This module uses XML-RPC protocol for configuring Stargazer.</flag>
-    <flag name="module_config_sgconfig">Enable build of "SGConf" configuration module for Stargazer. This module uses Stargazer specific protocol for configuring Stargazer.</flag>
-    <flag name="module_other_ping">Enable build of "Ping" module for Stargazer. This module pings connected users from time to time to ensure they are alive.</flag>
-    <flag name="module_other_remote_script">Enable build of "Remote Script" module for Stargazer. This module control rscriptd daemon over the net and makes it execute scripts in reaction to different Stargazer events.</flag>
-    <flag name="module_other_smux">Enable build of SMUX module for Stargazer. This module uses SMUX protocol to provide various information about Stargazer.</flag>
-    <flag name="module_store_files">Enable build of storage plugin for Stargazer based on plain files.</flag>
-    <flag name="module_store_firebird">Enable build of storage plugin for Stargazer, which uses Firebird database for storage.</flag>
-    <flag name="module_store_mysql">Enable build of storage plugin for Stargazer, which uses MySQL for storage.</flag>
-    <flag name="module_store_postgres">Enable build of storage plugin for Stargazer, which uses PostgreSQL for storage.</flag>
-  </use>
-  <upstream>
-    <changelog>http://stg.dp.ua/server_dl.php</changelog>
-    <doc>http://stg.dp.ua/doc.php</doc>
-    <bugs-to>mailto:faust@stg.dp.ua</bugs-to>
-  </upstream>
+	<maintainer type="person">
+		<email>spiderx@spiderx.dp.ua</email>
+		<name>Vladimir Pavljuchenkov</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<longdescription lang="en">
+	Stargazer is a powerful (inter)net billing system, capable of gathering
+	traffic statistics from many sources (such as NetFlow protocol,
+	ethernet packets capture, or IPQ subsystem), managing and billing user
+	accounts according to specified fees and rules (including time-based rules,
+	traffic source/destination rules and a payoff system).
+	This ebuild allows you to compile it yourself depending of your needs.
+	</longdescription>
+	<use>
+		<flag name="sgconv">Enable build of utility to convert Stargazer data between storage backends.</flag>
+		<flag name="radius">Enable build of FreeRADIUS module for data access via Stargazer.</flag>
+		<flag name="rscriptd">Enable build of remote script execute daemon for Stargazer, which run scripts when receive special signal from Stargazer.</flag>
+		<flag name="sgauth">Enable build of command-line utility for authorization in Stargazer.</flag>
+		<flag name="sgconf">Enable build of command-line utility for configuring Stargazer.</flag>
+		<flag name="sgconf_xml">Enable build of command-line xml-based utility for configuring Stargazer.</flag>
+		<flag name="stargazer">Enable build of Stargazer billing system.</flag>
+		<flag name="debug">Enable extra debug codepaths, like asserts and extra output.</flag>
+		<flag name="module_auth_always_online">Enable build of "Always Online" authentication module for Stargazer.</flag>
+		<flag name="module_auth_internet_access">Enable build of "InetAccess" authentication module for Stargazer. InetAccess is a Stargazer specific authentication protocol.</flag>
+		<flag name="module_auth_freeradius">Enable build of "Radius" authentication module for Stargazer. This module capable of using RADIUS procotol for user authentication.</flag>
+		<flag name="module_capture_ether">Enable build of "Ethernet" traffic capture module for Stargazer. This module uses RAW sockets to capture traffic.</flag>
+		<flag name="module_capture_ipq">Enable build of "IPQ" traffic capture module for Stargazer. This module uses IPQ subsystem to capture traffic.</flag>
+		<flag name="module_capture_netflow">Enable build of "NetFlow" traffic capture module for Stargazer. This module capable of receiving traffic data by NetFlow protocol.</flag>
+		<flag name="module_config_rpcconfig">Enable build of "XMLRPC" configuration module for Stargazer. This module uses XML-RPC protocol for configuring Stargazer.</flag>
+		<flag name="module_config_sgconfig">Enable build of "SGConf" configuration module for Stargazer. This module uses Stargazer specific protocol for configuring Stargazer.</flag>
+		<flag name="module_other_ping">Enable build of "Ping" module for Stargazer. This module pings connected users from time to time to ensure they are alive.</flag>
+		<flag name="module_other_remote_script">Enable build of "Remote Script" module for Stargazer. This module control rscriptd daemon over the net and makes it execute scripts in reaction to different Stargazer events.</flag>
+		<flag name="module_other_smux">Enable build of SMUX module for Stargazer. This module uses SMUX protocol to provide various information about Stargazer.</flag>
+		<flag name="module_store_files">Enable build of storage plugin for Stargazer based on plain files.</flag>
+		<flag name="module_store_firebird">Enable build of storage plugin for Stargazer, which uses Firebird database for storage.</flag>
+		<flag name="module_store_mysql">Enable build of storage plugin for Stargazer, which uses MySQL for storage.</flag>
+		<flag name="module_store_postgres">Enable build of storage plugin for Stargazer, which uses PostgreSQL for storage.</flag>
+	</use>
+	<upstream>
+		<doc>http://stg.net.ua/doc/index.html</doc>
+		<bugs-to>mailto:faust@stg.dp.ua</bugs-to>
+		<remote-id type="github">madf/stg</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/net-misc/stargazer/stargazer-2.408.ebuild
+++ b/net-misc/stargazer/stargazer-2.408.ebuild
@@ -1,33 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
-
-inherit eutils linux-info multilib user
-
-DESCRIPTION="Billing system for small home and office networks"
-HOMEPAGE="http://stg.dp.ua/"
-LICENSE="GPL-2"
-
-MY_P="stg-${PV}"
-SRC_URI="http://stg.dp.ua/download/server/${PV}/${MY_P}.tar.gz"
-SLOT="0"
-KEYWORDS="~amd64 ~x86"
-
-S="${WORKDIR}/${MY_P}"
-
-REQUIRED_USE="stargazer? ( ^^ ( module_store_files module_store_firebird module_store_mysql module_store_postgres ) )"
-
-RDEPEND="module_config_rpcconfig? ( dev-libs/xmlrpc-c[abyss] sys-libs/zlib )
-	module_config_sgconfig? ( dev-libs/expat )
-	module_store_firebird? ( >=dev-db/firebird-2.0.3.12981.0-r6 )
-	module_store_mysql? ( virtual/mysql )
-	module_store_postgres? ( dev-db/postgresql dev-libs/openssl sys-libs/zlib )
-	sgconf? ( dev-libs/expat )
-	sgconf_xml? ( dev-libs/expat )"
-
-DEPEND="${RDEPEND}
-	doc? ( dev-libs/libxslt )"
+EAPI=6
 
 PROJECTS="sgconv rlm_stg rscriptd sgauth sgconf sgconf_xml stargazer"
 
@@ -55,7 +29,69 @@ MODULES=( [module_auth_always_online]="authorization\/ao:mod_ao"
 	[module_store_postgres]="store\/postgresql:store_postgresql"
 )
 
-IUSE="sgconv radius rscriptd sgauth sgconf sgconf_xml stargazer debug doc examples static-libs"
+declare -A INIT
+INIT=(	[module_store_files]="11d"
+	[module_store_firebird]="11d;s/need net/need net firebird/"
+	[module_store_mysql]="11d;s/need net/need net mysql/"
+	[module_store_postgres]="11d;s/need net/need net postgresql/"
+)
+
+MY_P="stg-${PV}"
+
+inherit eutils flag-o-matic linux-info user
+
+DESCRIPTION="Billing system for small home and office networks"
+HOMEPAGE="http://stg.dp.ua/"
+SRC_URI="http://stg.dp.ua/download/server/${PV}/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	module_config_rpcconfig? (
+		dev-libs/expat
+		dev-libs/xmlrpc-c[abyss,cxx]
+	)
+	module_config_sgconfig? ( dev-libs/expat )
+	module_store_firebird? ( dev-db/firebird )
+	module_store_mysql? ( virtual/mysql:0= )
+	module_store_postgres? ( dev-db/postgresql:= )
+	sgconf? ( dev-libs/expat )
+	sgconf_xml? ( dev-libs/expat )"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/${MY_P}"
+
+REQUIRED_USE="stargazer? ( ^^ ( module_store_files module_store_firebird module_store_mysql module_store_postgres ) )"
+
+DOCS=( BUGS ../../ChangeLog CHANGES README TODO )
+
+# Patches already in upstream's trunk
+PATCHES=(
+	# Fix dependency on fbclient for module_store_firebird
+	"${FILESDIR}"/patches/stg-2.408-makefile-firebird-upstream.patch
+	# Rewrite config for rscriptd
+	"${FILESDIR}"/patches/stg-2.408-rscriptd.conf-upstream.patch
+	# Rewrite config for sgauth
+	"${FILESDIR}"/patches/stg-2.408-sgauth.conf-upstream.patch
+	# Standardization of 'On-scripts'
+	"${FILESDIR}"/patches/stg-2.408-on-upstream.patch
+	# Install demo scripts for rscriptd
+	"${FILESDIR}"/patches/stg-2.408-rscriptd-upstream.patch
+	# Fix crush on stop
+	"${FILESDIR}"/patches/stg-2.408-fix-crash-on-stop.patch
+	# Rename convertor to sgconv to avoid possible file name collisions
+	"${FILESDIR}"/patches/stg-2.408-sgconv-upstream.patch
+	# Debug support. Install radius lib to /usr/lib/freeradius
+	"${FILESDIR}"/patches/stg-2.408-makefile-build-upstream.patch
+	# Don't compile sgconv always with debug. Remove MAKEOPTS=-j1
+	"${FILESDIR}"/patches/stg-2.408-build-upstream.patch
+	# FreeBSD install directory
+	"${FILESDIR}"/patches/stg-2.408-radius-upstream.patch
+)
+
+IUSE="sgconv radius rscriptd sgauth sgconf sgconf_xml stargazer debug"
 
 for module in ${STG_MODULES_AUTH} ; do IUSE="${IUSE} module_auth_${module}" ; done
 for module in ${STG_MODULES_CAPTURE} ; do IUSE="${IUSE} module_capture_${module}" ; done
@@ -67,103 +103,82 @@ IUSE=${IUSE/stargazer/+stargazer}
 IUSE=${IUSE/module_store_files/+module_store_files}
 
 src_prepare() {
-	# Patches already in upstream's trunk
 	# Rename convertor to sgconv to avoid possible file name collisions
-	mv "${S}"/projects/convertor/ "${S}"/projects/sgconv/ || die "Couldn't move convertor folder"
-	mv "${S}"/projects/sgconv/convertor.conf "${S}"/projects/sgconv/sgconv.conf || die "Couldn't move convertor config"
-	epatch "${FILESDIR}"/patches/stg-2.408-sgconv-upstream.patch
+	mv projects/convertor/ projects/sgconv/ \
+		|| die "Couldn't move convertor folder"
+	mv projects/sgconv/convertor.conf \
+		projects/sgconv/sgconv.conf || die "Couldn't move convertor config"
 
-	# Fix dependency on fbclient for module_store_firebird
-	epatch "${FILESDIR}"/patches/stg-2.408-makefile-firebird-upstream.patch
+	default
 
-	# Debug support. Install radius lib to /usr/lib/freeradius
-	epatch "${FILESDIR}"/patches/stg-2.408-makefile-build-upstream.patch
-
-	# Don't compile sgconv always with debug. Remove MAKEOPTS=-j1
-	epatch "${FILESDIR}"/patches/stg-2.408-build-upstream.patch
-
-	# Rewrite config for rscriptd
-	epatch "${FILESDIR}"/patches/stg-2.408-rscriptd.conf-upstream.patch
-
-	# Rewrite config for sgauth
-	epatch "${FILESDIR}"/patches/stg-2.408-sgauth.conf-upstream.patch
-
-	# Standardization of 'On-scripts'
-	epatch "${FILESDIR}"/patches/stg-2.408-on-upstream.patch
-
-	# FreeBSD install directory
-	epatch "${FILESDIR}"/patches/stg-2.408-radius-upstream.patch
-
-	# Install demo scripts for rscriptd
-	epatch "${FILESDIR}"/patches/stg-2.408-rscriptd-upstream.patch
-
-	# Fix crush on stop
-	epatch "${FILESDIR}"/patches/stg-2.408-fix-crash-on-stop.patch
-
+	local project
 	for project in ${PROJECTS} ; do
-		# Rename build script to configure for further econf launch in every projects
-		mv "${S}"/projects/${project}/build "${S}"/projects/${project}/configure || die "Couldn't move build folder for ${project}"
-
+		# Rename build script to configure for further econf launch in every project
+		mv projects/$project/build projects/$project/configure \
+			|| die "Couldn't move build folder for $project"
 		# Change check for debug build
-		sed -i 's/if \[ "$1" = "debug" \]/if \[ "${10}" = "--enable-debug" \]/' "${S}"/projects/${project}/configure || die "sed for debug check failed"
+		sed -i 's/if \[ "$1" = "debug" \]/if \[ "${10}" = "--enable-debug" \]/' \
+			projects/$project/configure \
+			|| die "sed for debug check failed"
 	done
 
 	# Correct working directory, user and group for sgconv.conf, store_files.conf
 	# Correct paths for rscriptd.conf, store_firebird.conf, mod_remote_scriptd.conf, stargazer.conf, rpcconfig.cpp, 00-base-00.sql
-	epatch "${FILESDIR}"/patches/stg-2.408-correct-paths.patch
+	eapply "${FILESDIR}"/patches/stg-2.408-correct-paths.patch
 
 	# Correct target install-data for stargazer, rscriptd, sgauth, remove debug symbols stripping
-	epatch "${FILESDIR}"/patches/stg-2.408-makefile.patch
+	eapply "${FILESDIR}"/patches/stg-2.408-makefile.patch
 
 	# Remove make from script (for keeping symbols), always add variable to Makefile.conf for all projects
-	epatch "${FILESDIR}"/patches/stg-2.408-build.patch
+	eapply "${FILESDIR}"/patches/stg-2.408-build.patch
 
-	# Remove static-libs if not needed
-	use static-libs || epatch "${FILESDIR}"/patches/stg-2.408-static-libs.patch
+	# Remove static-libs
+	eapply "${FILESDIR}"/patches/stg-2.408-static-libs.patch
 
 	# Define which module to compile
+	local module
 	for module in ${!MODULES[@]} ; do
 		if ! use $module ; then
-			sed -i "s/${MODULES[$module]%:*}//" "${S}"/projects/stargazer/configure || die "sed for module configure failed"
+			sed -i "s/${MODULES[$module]%:*}//" \
+				projects/stargazer/configure \
+				|| die "sed for module configure failed"
 		fi
 	done
 
-	# Correct Gentoo init script provided by upstream (TODO: Remove in further releases, already fixed in upstream's trunk)
-	if use stargazer ; then
-		sed -i 's/opts/extra_commands/' "${S}"/projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo || die "sed for stargazer failed"
-	fi
-
-	# Correct Gentoo init script dependencies
-	if use module_store_files ; then
-		sed -i '11d' "${S}"/projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo || die "sed for module_store_files failed"
-	fi
-
-	if use module_store_firebird ; then
-		sed -i '11d;s/need net/need net firebird/' "${S}"/projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo || die "sed for module_store_firebird failed"
-	fi
-
-	if use module_store_mysql ; then
-		sed -i '11d;s/need net/need net mysql/' "${S}"/projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo || die "sed for module_store_mysql failed"
-	fi
-
-	if use module_store_postgres ; then
-		sed -i '11d;s/need net/need net postgresql/' "${S}"/projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo || die "sed for module_store_postgres failed"
-	fi
+	# Correct Gentoo init script
+	sed -i 's/opts/extra_commands/' \
+		projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo \
+		|| die "sed for stargazer failed"
+	sed -i "s/runscript/openrc-run/" \
+		projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo \
+		|| die "sed for init-script failed"
+	local init
+	for init in ${!INIT[@]} ; do
+		if use $init ; then
+			sed -i "${INIT[$init]}" \
+				projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo \
+				|| die "sed for $init failed"
+		fi
+	done
 
 	# Check for IPQ subsystem availability
-	( use module_capture_ipq && kernel_is ge 3 5 ) && die "IPQ subsystem is gone since Linux kernel 3.5. You can't compile module_capture_ipq with your current kernel."
-
-	epatch_user
+	if use module_capture_ipq && kernel_is ge 3 5 ; then
+		die "You can't use IPQ subsystem with your kernel."
+	fi
 }
 
 src_configure() {
+	use debug && filter-flags '-O?'
+
 	# Define local variables, strip '+' symbol for used by default USE flags
 	local USEFLAGS=(${IUSE//+})
 	local PROJECTS=($PROJECTS)
+	local i
 
 	for (( i = 0 ; i < ${#PROJECTS[@]} ; i++ )) ; do
 		if use ${USEFLAGS[$i]} ; then
-			cd "${S}"/projects/${PROJECTS[$i]} || die "cd to ${PROJECTS[$i]} failed"
+			cd "${S}"/projects/${PROJECTS[$i]} \
+				|| die "cd to ${PROJECTS[$i]} failed"
 			econf $(use_enable debug)
 		fi
 	done
@@ -173,31 +188,26 @@ src_compile() {
 	# Define local variables, strip '+' symbol for used by default USE flags
 	local USEFLAGS=(${IUSE//+})
 	local PROJECTS=($PROJECTS)
+	local i
 
 	# Set jobs to 1 for debug build
 	use debug && MAKEOPTS="-j1"
 
 	# Build necessary libraries first
-	touch "${S}"/Makefile.conf
-	cd "${S}"/stglibs || die "cd to stglibs failed"
+	touch Makefile.conf
+	cd stglibs || die "cd to stglibs failed"
 	emake STG_LIBS="ia.lib srvconf.lib"
 
 	for (( i = 0 ; i < ${#PROJECTS[@]} ; i++ )) ; do
 		if use ${USEFLAGS[$i]} ; then
-			cd "${S}"/projects/${PROJECTS[$i]} || die "cd to ${PROJECTS[$i]} failed"
+			cd "${S}"/projects/${PROJECTS[$i]} \
+				|| die "cd to ${PROJECTS[$i]} failed"
 			emake
 		fi
 	done
-
-	if use doc ; then
-		cd "${S}"/doc/xmlrpc || die "cd to doc/xmlrpc failed"
-		emake
-	fi
 }
 
 src_install() {
-	dodoc ChangeLog
-
 	if use rscriptd || use stargazer ; then
 		# Install config file for logrotate
 		insinto /etc/logrotate.d
@@ -212,26 +222,8 @@ src_install() {
 		fi
 	fi
 
-	if use doc ; then
-		# Install files into docs directory
-		dodoc "${S}"/projects/stargazer/inst/var/base.dia
-		dodoc "${S}"/doc/proto_client.gif
-		dodoc "${S}"/doc/proto_server.gif
-
-		# Install html documentation
-		docinto html/xmlrpc
-		dohtml -r "${S}"/doc/xmlrpc/book/
-	fi
-
-	if use examples ; then
-		# Install files into specified directory
-		insinto /usr/share/stargazer
-		doins -r "${S}"/projects/stargazer/scripts
-		doins "${S}"/doc/xmlrpc.php
-	fi
-
 	if use sgconv ; then
-		cd "${S}"/projects/sgconv || die "cd to sgconv project failed"
+		cd projects/sgconv || die "cd to sgconv failed"
 
 		emake DESTDIR="${D}" PREFIX="${D}" install
 
@@ -244,13 +236,13 @@ src_install() {
 	fi
 
 	if use radius ; then
-		cd "${S}"/projects/rlm_stg || die "cd to rlm_stg project failed"
+		cd "${S}"/projects/rlm_stg || die "cd to rlm_stg failed"
 
 		emake DESTDIR="${D}" PREFIX="${D}" install
 	fi
 
 	if use rscriptd ; then
-		cd "${S}"/projects/rscriptd || die "cd to rscriptd project failed"
+		cd "${S}"/projects/rscriptd || die "cd to rscriptd failed"
 
 		emake DESTDIR="${D}" PREFIX="${D}" install
 
@@ -265,7 +257,7 @@ src_install() {
 	fi
 
 	if use sgauth ; then
-		cd "${S}"/projects/sgauth || die "cd to sgauth project failed"
+		cd "${S}"/projects/sgauth || die "cd to sgauth failed"
 
 		emake DESTDIR="${D}" PREFIX="${D}" install
 
@@ -277,7 +269,7 @@ src_install() {
 	fi
 
 	if use sgconf ; then
-		cd "${S}"/projects/sgconf || die "cd to sgconf project failed"
+		cd "${S}"/projects/sgconf || die "cd to sgconf failed"
 
 		emake DESTDIR="${D}" PREFIX="${D}" install
 
@@ -286,7 +278,7 @@ src_install() {
 	fi
 
 	if use sgconf_xml ; then
-		cd "${S}"/projects/sgconf_xml || die "cd to sgconf_xml project failed"
+		cd "${S}"/projects/sgconf_xml || die "cd to sgconf_xml failed"
 
 		emake DESTDIR="${D}" PREFIX="${D}" install
 
@@ -295,12 +287,12 @@ src_install() {
 	fi
 
 	if use stargazer ; then
-		cd "${S}"/projects/stargazer || die "cd to stargazer project failed"
+		cd "${S}"/projects/stargazer || die "cd to stargazer failed"
 
 		emake DESTDIR="${D}" PREFIX="${D}" install
 
 		# Install docs
-		dodoc BUGS CHANGES README TODO
+		einstalldocs
 
 		# Install and rename Gentoo init script
 		newinitd "${S}"/projects/stargazer/inst/linux/etc/init.d/stargazer.gentoo stargazer
@@ -348,7 +340,8 @@ src_install() {
 
 		if use module_other_remote_script ; then
 			# Create subnets file based on example from mod_remote_script.conf
-			grep 192 "${S}"/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/mod_remote_script.conf | sed 's/# //' > "${D}"/etc/stargazer/subnets
+			grep 192 "${S}"/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/mod_remote_script.conf \
+				| sed 's/# //' > "${ED%/}"/etc/stargazer/subnets
 
 			# Correct permissions for file
 			fperms 0640 /etc/stargazer/subnets
@@ -363,22 +356,29 @@ src_install() {
 		insinto /etc/stargazer/conf-available.d
 		insopts -m 0640
 
+		local module
 		for module in ${!MODULES[@]} ; do
 			use $module && doins "${S}"/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/${MODULES[$module]#*:}.conf
 		done
 
 		# Create symlinks of configs for selected modules
 		for module in ${!MODULES[@]} ; do
-			use $module && dosym /etc/stargazer/conf-available.d/${MODULES[$module]#*:}.conf /etc/stargazer/conf-enabled.d/${MODULES[$module]#*:}.conf
+			use $module \
+				&& dosym \
+				/etc/stargazer/conf-available.d/${MODULES[$module]#*:}.conf \
+				/etc/stargazer/conf-enabled.d/${MODULES[$module]#*:}.conf
 		done
 	fi
 
 	# Correct user and group for files and directories
-	( use sgconv || use rscriptd || use sgauth || use stargazer ) && fowners -R stg:stg /etc/stargazer
+	if use sgconv || use rscriptd || use sgauth || use stargazer ; then
+		fowners -R stg:stg /etc/stargazer
+	fi
 
 	# Put the files in the right folder to support multilib
 	if [ ! -e "${ED}"/usr/$(get_libdir) ] ; then
-		mv "${ED}"/usr/lib/ "${ED}"/usr/$(get_libdir) || die "Failed to move library directory for multilib support"
+		mv "${ED}"/usr/lib/ "${ED}"/usr/$(get_libdir) \
+			|| die "Failed to move library directory for multilib support"
 	fi
 }
 
@@ -386,8 +386,6 @@ pkg_setup() {
 	# Add user and group to system only when necessary
 	if use sgconv || use rscriptd || use sgauth || use stargazer ; then
 		enewgroup stg
-
-		# Add stg user to system (no home directory specified, because otherwise it will be result in stg:root ownership on it)
 		enewuser stg -1 -1 -1 stg
 	fi
 }
@@ -396,163 +394,147 @@ pkg_postinst() {
 	if use sgconv ; then
 		einfo "\nSgconv:"
 		einfo "----------"
-		einfo "    For further use of sgconv please edit /etc/stargazer/sgconv.conf depending on your needs."
+		einfo "For further use edit /etc/stargazer/sgconv.conf."
 	fi
 
 	if use radius ; then
 		einfo "\nRadius:"
 		einfo "-------"
-		einfo "    For further use of radius, emerge net-dialup/freeradius.\n"
+		einfo "For further use emerge net-dialup/freeradius.\n"
 
-		einfo "    Example config:\n"
+		einfo "Example config:\n"
 
-		einfo "        stg {"
-		einfo "               local_port = 6667"
-		einfo "               server = localhost"
-		einfo "               port = 6666"
-		einfo "               password = 123456"
-		einfo "        }\n"
+		einfo "stg {"
+		einfo "      local_port = 6667"
+		einfo "      server = localhost"
+		einfo "      port = 6666"
+		einfo "      password = 123456"
+		einfo "    }\n"
 
-		einfo "    You should place 'stg' into section Instantiate, Authorize."
-		einfo "    In section Authentificate 'stg' should go in sub-section Auth-Type before other authentifications modules:\n"
+		einfo "You should place 'stg' into section Instantiate, Authorize."
+		einfo "In section Authentificate 'stg' should go in sub-section"
+		einfo "Auth-Type before other authentifications modules:\n"
 
-		einfo "        Auth-Type PAP {"
-		einfo "                         stg"
-		einfo "                         pap"
-		einfo "        }\n"
+		einfo "Auth-Type PAP {"
+		einfo "                stg"
+		einfo "                pap"
+		einfo "}\n"
 
-		einfo "    It also may be used in section Accounting and Post-Auth."
+		einfo "It also may be used in section Accounting and Post-Auth."
 
-		use module_auth_freeradius || einfo "\n    For use RADIUS data processing you should also enable USE-flag module_auth_freeradius."
+		use module_auth_freeradius || einfo "\nFor use RADIUS enable USE-flag module_auth_freeradius."
 	fi
 
 	if use rscriptd ; then
 		einfo "\nRemote Script Executer:"
 		einfo "-----------------------"
-		einfo "    For further use of rscriptd please edit /etc/stargazer/rscriptd.conf depending on your needs."
-		einfo "    You have to change 'Password' field at least."
+		einfo "For further use edit /etc/stargazer/rscriptd.conf."
+		einfo "You have to change 'Password' field at least."
 	fi
 
 	if use sgauth ; then
 		einfo "\nSgauth:"
 		einfo "-------"
-		einfo "    For further use of sgauth please edit /etc/stargazer/sgauth.conf depending on your needs."
-		einfo "    You have to change 'ServerName', 'Login', 'Password' fields at least."
+		einfo "For further use edit /etc/stargazer/sgauth.conf."
+		einfo "You have to change 'ServerName', 'Login', 'Password' fields at least."
 	fi
 
 	if use sgconf ; then
 		einfo "\nSgconf:"
 		einfo "-------"
-		use module_config_sgconfig || einfo "    For further use of sgconf utility you should also enable USE-flag module_config_sgconfig."
+		use module_config_sgconfig \
+			|| einfo "For further use enable USE-flag module_config_sgconfig."
 	fi
 
 	if use sgconf_xml ; then
 		einfo "\nSgconf_xml:"
 		einfo "-----------"
-		use module_config_rpcconfig || einfo "    For further use of sgconf_xml utility you should also enable USE-flag module_config_rpcconfig."
+		use module_config_rpcconfig \
+			|| einfo "For further use enable USE-flag module_config_rpcconfig."
 	fi
 
 	if use stargazer ; then
 		einfo "\nStargazer:"
 		einfo "----------"
-		einfo "    Modules availability:\n"
-
+		einfo "Modules availability:\n"
 		if use module_auth_always_online ; then
-			einfo "      * module_auth_always_online available."
+			einfo "* module_auth_always_online available."
 		fi
-
 		if use module_auth_internet_access ; then
-			einfo "      * module_auth_internet_access available."
+			einfo "* module_auth_internet_access available."
 		fi
-
 		if use module_auth_freeradius ; then
-			einfo "      * module_auth_freeradius available.\n"
-			einfo "           For further use of module, emerge net-dialup/freeradius.\n"
-			use radius || einfo "\n           For use RADIUS data processing you should also enable use USE-flag radius."
+			einfo "* module_auth_freeradius available.\n"
+			einfo "For further use emerge net-dialup/freeradius.\n"
+			use radius || einfo "\n           For use RADIUS enable use USE-flag radius."
 		fi
-
 		if use module_capture_ipq ; then
-			einfo "      * module_capture_ipq available."
+			einfo "* module_capture_ipq available."
 		fi
-
 		if use module_capture_ether ; then
-			einfo "      * module_capture_ether available."
+			einfo "* module_capture_ether available."
 		fi
-
 		if use module_capture_netflow ; then
-			einfo "      * module_capture_netflow available.\n"
-			einfo "           For further use of module, emerge net-firewall/ipt_netflow or net-analyzer/softflowd.\n"
+			einfo "* module_capture_netflow available.\n"
+			einfo "For further use emerge any netflow sensor:\n"
+			einfo "net-firewall/ipt_netflow or net-analyzer/softflowd.\n"
 		fi
-
 		if use module_config_sgconfig ; then
-			einfo "      * module_config_sgconfig available."
+			einfo "* module_config_sgconfig available."
 		fi
-
 		if use module_config_rpcconfig ; then
-			einfo "      * module_config_rpcconfig available.\n"
-			einfo "           KNOWN BUG: Sometimes you can't configure Stargazer through xml-based configurator,"
-			einfo "                      because module is not responding."
-			einfo "                      This bug is introduced by xmlrpc-c library. This bug proceeds very rare, but it still exists.\n"
+			einfo "* module_config_rpcconfig available.\n"
+			einfo "KNOWN BUG: Sometimes you can't configure Stargazer"
+			einfo "through xml-based configurator, because module is not responding."
+			einfo "This bug is introduced by xmlrpc-c library."
+			einfo "This bug proceeds very rare, but it still exists.\n"
 		fi
-
 		if use module_other_ping ; then
-			einfo "      * module_other_ping available."
+			einfo "* module_other_ping available."
 		fi
-
 		if use module_other_smux ; then
-			einfo "      * module_other_smux available.\n"
-			einfo "           For further use of module emerge net-analyzer/net-snmp.\n"
+			einfo "* module_other_smux available.\n"
+			einfo "For further use emerge net-analyzer/net-snmp.\n"
 		fi
-
 		if use module_other_remote_script ; then
-			einfo "      * module_other_remote_script available.\n"
-			einfo "           Don't forget to edit /etc/stargazer/subnets file depending on your needs."
+			einfo "* module_other_remote_script available.\n"
+			einfo "For further use edit /etc/stargazer/subnets.\n"
 		fi
-
 		if use module_store_files ; then
-			einfo "      * module_store_files available.\n"
-			einfo "           Necessary and sufficient rights to the directory /var/lib/stargazer for this backend is 0755."
-			einfo "           You may fix it if needed.\n"
+			einfo "* module_store_files available."
 		fi
-
 		if use module_store_firebird ; then
-			einfo "      * module_store_firebird available.\n"
-			einfo "           Necessary and sufficient rights to the directory /var/lib/stargazer for this backend is 0775."
-			einfo "           Check that it was so, and fix it if needed."
-			einfo "           You should add 'firebird' user to stg group:\n"
-			einfo "             # usermod -a -G stg firebird\n"
-			einfo "           and restart firebird:\n"
-			einfo "             # /etc/init.d/firebird restart\n"
-			einfo "           Stargazer DB schema for Firebird is here: /usr/share/stargazer/db/firebird"
-			einfo "           For new setup you should execute 00-base-00.sql:\n"
-			einfo "             # fbsql -q -i /usr/share/stargazer/db/firebird/00-base-00.sql\n"
-			einfo "           For upgrade from version 2.406 you should execute 00-alter-01.sql:\n"
-			einfo "             # fbsql -q -u <username> -p <password> -d <database> -i /usr/share/stargazer/db/firebird/00-alter-01.sql\n"
+			einfo "* module_store_firebird available.\n"
+			einfo "You should add 'firebird' user to stg group:\n"
+			einfo "# usermod -a -G stg firebird\n"
+			einfo "and restart firebird:\n"
+			einfo "# /etc/init.d/firebird restart\n"
+			einfo "Stargazer DB schema for Firebird is here: /usr/share/stargazer/db/firebird"
+			einfo "For new setup you should execute 00-base-00.sql:\n"
+			einfo "# fbsql -q -i /usr/share/stargazer/db/firebird/00-base-00.sql\n"
+			einfo "For upgrade from version 2.406 you should execute 00-alter-01.sql:\n"
+			einfo "# fbsql -i /usr/share/stargazer/db/firebird/00-alter-01.sql\n"
 		fi
-
 		if use module_store_mysql ; then
-			einfo "      * module_store_mysql available.\n"
-			einfo "           For upgrade from version 2.406 you should execute 00-mysql-01.sql:\n"
-			einfo "             # mysql -h <hostname> -P <port> -u <username> -p <password> <database> < /usr/share/stargazer/db/mysql/00-mysql-01.sql\n"
+			einfo "* module_store_mysql available.\n"
+			einfo "For upgrade from version 2.406 you should execute 00-mysql-01.sql:\n"
+			einfo "# mysql < /usr/share/stargazer/db/mysql/00-mysql-01.sql\n"
 		fi
-
 		if use module_store_postgres ; then
-			einfo "      * module_store_postgres available.\n"
-			einfo "           Stargazer DB schema for PostgresSQL is here: /usr/share/stargazer/db/postgresql"
-			einfo "           For new setup you should execute 00-base-00.postgresql.sql:\n"
-			einfo "             # psql -h <hostname> -p <port> -U <username> -d <database> -W -f /usr/share/stargazer/db/postgresql/00-base-00.postgresql.sql\n"
-			einfo "           For upgrade from version 2.406 you should execute 00-alter-01.sql:\n"
-			einfo "             # psql -h <hostname> -p <port> -U <username> -d <database> -W -f /usr/share/stargazer/db/postgresql/00-alter-01.sql\n"
+			einfo "* module_store_postgres available.\n"
+			einfo "DB schema for PostgresSQL is here: /usr/share/stargazer/db/postgresql"
+			einfo "For new setup you should execute 00-base-00.postgresql.sql:\n"
+			einfo "# psql -f /usr/share/stargazer/db/postgresql/00-base-00.postgresql.sql\n"
+			einfo "For upgrade from version 2.406 you should execute 00-alter-01.sql:\n"
+			einfo "# psql -f /usr/share/stargazer/db/postgresql/00-alter-01.sql\n"
 		fi
-
 		einfo "\n    For all storage backends:\n"
-		einfo "      * Default admin login - admin, default admin password - 123456."
-		einfo "      * Default subscriber login - test, default subscriber password - 123456.\n"
+		einfo "* Default admin login - admin, default admin password - 123456."
+		einfo "* Default subscriber login - test, default subscriber password - 123456.\n"
 		einfo "Don't run newer versions without reading their ChangeLog first,"
 		einfo "it can be found in /usr/share/doc/${PF}"
 	fi
-
 	if use debug ; then
-		ewarn "\nThis is a debug build. You should avoid to use it in production.\n"
+		ewarn "\nThis is a debug build, avoid to use it in production."
 	fi
 }


### PR DESCRIPTION
1. Updated header, moved to EAPI 6, removed multilib eclass.
2. Patches were recreated to work with EAPI 6.
3. Fixed bug 587104.
4. Removed USE flags doc, examples, static-libs.
5. metadata.xml cleanup and fix bug #594242
6. Ebuild cleanup.

Closes: https://bugs.gentoo.org/587104
Closes: https://bugs.gentoo.org/594242
Package-Manager: Portage-2.3.13, Repoman-2.3.3