### PR TITLE
app-eselect/eselect-metasploit: fix for SYMLINK_LIB=no profiles (i.e 17.1)

### DIFF
--- a/app-eselect/eselect-metasploit/eselect-metasploit-0.16_p1.ebuild
+++ b/app-eselect/eselect-metasploit/eselect-metasploit-0.16_p1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -18,11 +18,19 @@ DEPEND="app-admin/eselect
 	!<net-analyzer/metasploit-4.6"
 RDEPEND="${DEPEND}"
 
-S=${WORKDIR}
+S="${WORKDIR}"
+
+src_prepare() {
+	cp "${FILESDIR}"/91metasploit 91metasploit || die
+	cp "${FILESDIR}"/msfloader-${PV} msfloader-${PV} || die
+
+	sed -i -e "s/@LIBDIR@/$(get_libdir)/g" 91metasploit || die
+	sed -i -e "s/@LIBDIR@/$(get_libdir)/g" msfloader-${PV} || die
+}
 
 src_install() {
 	#force to use the outdated bundled version of metasm
-	doenvd "${FILESDIR}"/91metasploit
+	doenvd 91metasploit
 
 	newinitd "${FILESDIR}"/msfrpcd.initd msfrpcd
 	newconfd "${FILESDIR}"/msfrpcd.confd msfrpcd
@@ -30,7 +38,7 @@ src_install() {
 	insinto /usr/share/eselect/modules
 	newins "${FILESDIR}/metasploit.eselect-0.13" metasploit.eselect
 
-	newbin "${FILESDIR}"/msfloader-${PV} msfloader
+	newbin msfloader-${PV} msfloader
 }
 
 pkg_postinst() {

--- a/app-eselect/eselect-metasploit/files/91metasploit
+++ b/app-eselect/eselect-metasploit/files/91metasploit
@@ -1,8 +1,8 @@
-MSF_DATABASE_CONFIG=/usr/lib/metasploit/config/database.yml
+MSF_DATABASE_CONFIG=/usr/@LIBDIR@/metasploit/config/database.yml
 
 # needed because MSF ships an old version of metasm 
 # which isn't compatible with the new one
-MSF_LOCAL_LIB="/usr/lib/metasploit/lib/metasm"
+MSF_LOCAL_LIB="/usr/@LIBDIR@/metasploit/lib/metasm"
 
 # needed because MSF doesn't know where it is since the alzheimer's
-MSF_ROOT=/usr/lib/metasploit
+MSF_ROOT=/usr/@LIBDIR@/metasploit

--- a/app-eselect/eselect-metasploit/files/msfloader-0.16_p1
+++ b/app-eselect/eselect-metasploit/files/msfloader-0.16_p1
@@ -4,7 +4,7 @@
 #add in optional auto starting/stopping of postgres
 
 #read the desired version of ruby from the eselected version of msf
-header="$(head -n1 /usr/lib/metasploit/msfconsole)"
+header="$(head -n1 /usr/@LIBDIR@/metasploit/msfconsole)"
 ruby="${header:2}"
 
 #normally msf makes this dir, however, this script runs first
@@ -21,9 +21,9 @@ if ls -A ~/.msf4/*.gemspec > /dev/zero 2>&1; then
 fi
 
 #fetch the latest Gemfile and gemspecsfrom the selected version of msf
-cp /usr/lib/metasploit/Gemfile ~/.msf4/
-if ls -A /usr/lib/metasploit/*.gemspec > /dev/zero 2>&1; then
-	cp /usr/lib/metasploit/*.gemspec ~/.msf4/
+cp /usr/@LIBDIR@/metasploit/Gemfile ~/.msf4/
+if ls -A /usr/@LIBDIR@/metasploit/*.gemspec > /dev/zero 2>&1; then
+	cp /usr/@LIBDIR@/metasploit/*.gemspec ~/.msf4/
 fi
 
 #ensure Gemfile.lock is up to date
@@ -37,5 +37,5 @@ if [ "$?" != "0" ]; then
 fi
 
 #ready to go
-BUNDLE_GEMFILE=~/.msf4/Gemfile ${ruby} -S bundle exec /usr/lib/metasploit/$(basename $0) "$@"
+BUNDLE_GEMFILE=~/.msf4/Gemfile ${ruby} -S bundle exec /usr/@LIBDIR@/metasploit/$(basename $0) "$@"
 #profit


### PR DESCRIPTION
Since the `env.d` file `91metasploit` and `msfloader` scripts depended on Metasploit being installed to `/usr/lib`, I updated the two files to get a sed replacement to put the correct lib directory used by the `net-analyzer/metasploit` ebuild. The current eselect module breaks with SYMLINK_LIB=no profiles such as the new 17.1 profile.

Package-Manager: Portage-2.3.19, Repoman-2.3.6