### PR TITLE
dev-python/pygresql-5.0.4: add REQUIRED_USE for PostgreSQL

### DIFF
--- a/dev-python/pygresql/pygresql-5.0.4.ebuild
+++ b/dev-python/pygresql/pygresql-5.0.4.ebuild
@@ -19,6 +19,8 @@ SLOT="0"
 KEYWORDS="~alpha amd64 ~hppa ~ia64 ~ppc sparc x86"
 IUSE=""
 
+REQUIRED_USE="${POSTGRES_REQ_USE}"
+
 DEPEND="${POSTGRES_DEP}"
 
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/595752