### PR TITLE
media-libs/osl: Make clang depend compatible with llvm 4

### DIFF
--- a/media-libs/osl/osl-1.8.12.ebuild
+++ b/media-libs/osl/osl-1.8.12.ebuild
@@ -28,7 +28,7 @@ RDEPEND=">=media-libs/openexr-2.2.0
 
 DEPEND="${RDEPEND}
 	>=dev-libs/boost-1.62
-	sys-devel/llvm[clang]
+	sys-devel/clang
 	sys-devel/bison
 	sys-devel/flex
 	virtual/pkgconfig"


### PR DESCRIPTION
LLVM 4 dropped a use flag to enable clang support. The depend is
now directly to sys-devel/clang.

Closes: https://bugs.gentoo.org/642728