### PR TITLE
sci-mathematics/wxmaxima: make use of wxwidgets eclass

### DIFF
--- a/sci-mathematics/wxmaxima/wxmaxima-17.10.1.ebuild
+++ b/sci-mathematics/wxmaxima/wxmaxima-17.10.1.ebuild
@@ -2,9 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
+WX_GTK_VER="3.0"
 
 PLOCALES="ca cs da de el es fi fr gl hu it ja kab nb pl pt_BR ru tr uk zh_CN zh_TW"
-inherit cmake-utils l10n xdg-utils gnome2-utils
+inherit cmake-utils l10n xdg-utils gnome2-utils wxwidgets
 
 DESCRIPTION="Graphical frontend to Maxima, using the wxWidgets toolkit"
 HOMEPAGE="http://andrejv.github.io/wxmaxima/"
@@ -18,7 +19,7 @@ S="${WORKDIR}"/${PN}-Version-${PV}
 
 DEPEND="
 	dev-libs/libxml2:2
-	x11-libs/wxGTK:3.0"
+	x11-libs/wxGTK:${WX_GTK_VER}"
 RDEPEND="${DEPEND}
 	media-fonts/jsmath
 	sci-visualization/gnuplot[wxwidgets]
@@ -27,6 +28,10 @@ RDEPEND="${DEPEND}
 PATCHES=(
 	"${FILESDIR}"/${PN}-require-wxGTK-3.0.patch
 )
+
+pkg_setup() {
+	setup-wxwidgets
+}
 
 src_prepare() {
 	cmake-utils_src_prepare


### PR DESCRIPTION
Otherwise ebuild fails at configure phase on systems with SYMLINK_LIB=no

Closes: https://bugs.gentoo.org/642734