### PR TITLE
games-emulation/vbam: add missing call to setup-wxwidgets()

### DIFF
--- a/games-emulation/vbam/vbam-2.0.0_beta2_p20161211-r1.ebuild
+++ b/games-emulation/vbam/vbam-2.0.0_beta2_p20161211-r1.ebuild
@@ -54,6 +54,7 @@ PATCHES=(
 )
 
 src_configure() {
+	use wxwidgets && setup-wxwidgets
 	local mycmakeargs=(
 		-DENABLE_CAIRO=$(usex cairo)
 		-DENABLE_FFMPEG=$(usex ffmpeg)

--- a/games-emulation/vbam/vbam-9999.ebuild
+++ b/games-emulation/vbam/vbam-9999.ebuild
@@ -52,6 +52,7 @@ src_prepare() {
 }
 
 src_configure() {
+	use wxwidgets && setup-wxwidgets
 	local mycmakeargs=(
 		-DENABLE_CAIRO=$(usex cairo)
 		-DENABLE_FFMPEG=$(usex ffmpeg)


### PR DESCRIPTION
setup-wxwidgets() is required in EAPI 6 ebuilds. Probably it was
forgotten with EAPI bump.

Closes: https://bugs.gentoo.org/604244