### PR TITLE
games-strategy/0ad: add missing setup-wxwidgets()

### DIFF
--- a/games-strategy/0ad/0ad-0.0.22_alpha.ebuild
+++ b/games-strategy/0ad/0ad-0.0.22_alpha.ebuild
@@ -51,6 +51,7 @@ S="${WORKDIR}/${MY_P}"
 
 pkg_setup() {
 	python-any-r1_pkg_setup
+	use editor && setup-wxwidgets
 }
 
 PATCHES=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/642748