### PR TITLE
app-text/t1utils: apply memmem patch from upstream

### DIFF
--- a/app-text/t1utils/files/t1utils-1.41-memmem.patch
+++ b/app-text/t1utils/files/t1utils-1.41-memmem.patch
@@ -1,0 +1,27 @@
+commit 3f1ddda424353f0f926dd28efa47b0ac61556ce8
+Author: Eddie Kohler <ekohler@gmail.com>
+Date:   Wed Aug 16 12:37:34 2017 -0400
+
+    Check for memmem declaration; sometimes it is not declared by default.
+
+diff --git a/configure.ac b/configure.ac
+index 5b4e3ff..b4dc4fb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -19,6 +19,7 @@ dnl strerror()?
+ dnl
+ 
+ AC_REPLACE_FUNCS([strerror memmem])
++AC_CHECK_DECLS([memmem])
+ 
+ 
+ dnl
+@@ -88,7 +89,7 @@ char* strerror(int errno);
+ #endif
+ 
+ /* Prototype memmem if we don't have it. */
+-#if !HAVE_MEMMEM
++#if !HAVE_MEMMEM || !HAVE_DECL_MEMMEM
+ void* memmem(const void* haystack, size_t haystack_len,
+              const void* needle, size_t needle_len);
+ #endif

--- a/app-text/t1utils/t1utils-1.41-r2.ebuild
+++ b/app-text/t1utils/t1utils-1.41-r2.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools
+
+DESCRIPTION="Type 1 Font utilities"
+SRC_URI="http://www.lcdf.org/type/${P}.tar.gz"
+HOMEPAGE="http://www.lcdf.org/type/#t1utils"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+SLOT="0"
+LICENSE="BSD"
+IUSE=""
+
+DEPEND=""
+RDEPEND="${DEPEND}
+	!<media-libs/freetype-1.4_pre20080316"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-memmem.patch
+)
+DOCS=( NEWS.md README.md )
+
+src_prepare() {
+	default
+	eautoreconf
+}


### PR DESCRIPTION
This fixes:
* https://bugs.gentoo.org/630710
* https://bugs.gentoo.org/642586

I am still awaiting reply from Markus Oehme (reporter) in bug 630710, but since this also fixes 642586 I created this PR straight away to avoid double work.