### PR TITLE
net-p2p/bitcoind: Add missing bitcoin.conf.5 & bitcoind.service-r1

### DIFF
--- a/net-p2p/bitcoind/files/bitcoin.conf.5
+++ b/net-p2p/bitcoind/files/bitcoin.conf.5
@@ -1,0 +1,19 @@
+.TH BITCOIN.CONF "5" "February 2016" "bitcoin.conf 0.12"
+.SH NAME
+bitcoin.conf \- bitcoin configuration file
+.SH SYNOPSIS
+All command-line options (except for '\-conf') may be specified in a configuration file, and all configuration file options may also be specified on the command line. Command-line options override values set in the configuration file.
+.TP
+The configuration file is a list of 'setting=value' pairs, one per line, with optional comments starting with the '#' character. Please refer to bitcoind(1) for a up to date list of valid options.
+.TP
+The configuration file is not automatically created; you can create it using your favorite plain-text editor. By default, bitcoind(1) will look for a file named bitcoin.conf(5) in the bitcoin data directory, but both the data directory and the configuration file path may be changed using the '\-datadir' and '\-conf' command-line arguments.
+.SH LOCATION
+bitcoin.conf should be located in $HOME/.bitcoin
+
+.SH "SEE ALSO"
+bitcoind(1)
+.SH AUTHOR
+This manual page was written by Micah Anderson <micah@debian.org> for the Debian system (but may be used by others). Permission is granted to copy, distribute and/or modify this document under the terms of the GNU General Public License, Version 3 or any later version published by the Free Software Foundation.
+
+On Debian systems, the complete text of the GNU General Public License can be found in /usr/share/common-licenses/GPL.
+

--- a/net-p2p/bitcoind/files/bitcoind.service-r1
+++ b/net-p2p/bitcoind/files/bitcoind.service-r1
@@ -1,0 +1,25 @@
+# It is not recommended to modify this file in-place, because it will
+# be overwritten during package upgrades. If you want to add further
+# options or overwrite existing ones then use
+# $ systemctl edit bitcoind.service
+# See "man systemd.service" for details.
+
+# Note that almost all daemon options could be specified in
+# /etc/bitcoin/bitcoin.conf
+
+[Unit]
+Description=Bitcoin daemon
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/bitcoind -daemon -conf=/etc/bitcoin/bitcoin.conf -pid=/run/bitcoind/bitcoind.pid
+# Creates /run/bitcoind owned by bitcoin
+RuntimeDirectory=bitcoind
+User=bitcoin
+Type=forking
+PIDFile=/run/bitcoind/bitcoind.pid
+Restart=on-failure
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/642920