### PR TITLE
xfce-extra/xfce4-weather-plugin: fix bug 593358

### DIFF
--- a/xfce-extra/xfce4-weather-plugin/xfce4-weather-plugin-0.8.10.ebuild
+++ b/xfce-extra/xfce4-weather-plugin/xfce4-weather-plugin-0.8.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,7 +16,7 @@ IUSE="upower"
 
 RDEPEND=">=dev-libs/glib-2.20:=
 	dev-libs/libxml2:=
-	>=net-libs/libsoup-2.32:=
+	>=net-libs/libsoup-2.32:=[ssl]
 	>=x11-libs/gtk+-2.14:2=
 	>=xfce-base/libxfce4ui-4.10:=
 	>=xfce-base/libxfce4util-4.10:=

--- a/xfce-extra/xfce4-weather-plugin/xfce4-weather-plugin-0.8.9.ebuild
+++ b/xfce-extra/xfce4-weather-plugin/xfce4-weather-plugin-0.8.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ IUSE="upower"
 
 RDEPEND=">=dev-libs/glib-2.20:=
 	dev-libs/libxml2:=
-	>=net-libs/libsoup-2.32:=
+	>=net-libs/libsoup-2.32:=[ssl]
 	>=x11-libs/gtk+-2.14:2=
 	>=xfce-base/libxfce4ui-4.10:=
 	>=xfce-base/libxfce4util-4.10:=


### PR DESCRIPTION
Norwegian data provider serves data over HTTPS. Upstream source code has
hard-coded HTTPS URLs passed into libsoup functions. This could emerge
without SSL support enabled in libsoup, but would not function without
it. Explicitly requiring SSL USE on libsoup dependency.

Closes: https://bugs.gentoo.org/593358
Package-Manager: Portage-2.3.13, Repoman-2.3.3