### PR TITLE
dev-libs/klibc: Add dependency to sys-devel/bc

### DIFF
--- a/dev-libs/klibc/klibc-2.0.4-r2.ebuild
+++ b/dev-libs/klibc/klibc-2.0.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 # Robin H. Johnson <robbat2@gentoo.org>, 12 Nov 2007:
@@ -54,8 +54,9 @@ KEYWORDS="~alpha amd64 ~arm ia64 -mips ~ppc ~ppc64 ~sparc x86"
 SLOT="0"
 IUSE="debug test custom-cflags"
 
-DEPEND="dev-lang/perl"
-RDEPEND="${DEPEND}"
+RDEPEND="dev-lang/perl"
+DEPEND="${RDEPEND}
+	sys-devel/bc"
 
 KS="${WORKDIR}/linux-${OKV}"
 


### PR DESCRIPTION
bc is needed for compilation:

/bin/sh: bc: command not found
make[1]: *** [Kbuild:66: include/generated/timeconst.h] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:986: prepare0] Error 2

Package-Manager: Portage-2.3.13, Repoman-2.3.4