### PR TITLE
media-sound/flacon: Add dev-qt/qtconcurrent:5 to RDEPEND list

### DIFF
--- a/media-sound/flacon/flacon-4.0.0.ebuild
+++ b/media-sound/flacon/flacon-4.0.0.ebuild
@@ -24,11 +24,11 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtnetwork:5
 	dev-qt/qtwidgets:5
-	dev-qt/qtconcurrent:5
 "
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	dev-qt/linguist-tools:5
+	dev-qt/qtconcurrent:5
 	test? (
 		dev-qt/qttest:5
 		media-libs/flac

--- a/media-sound/flacon/flacon-4.0.0.ebuild
+++ b/media-sound/flacon/flacon-4.0.0.ebuild
@@ -24,6 +24,7 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtnetwork:5
 	dev-qt/qtwidgets:5
+	dev-qt/qtconcurrent:5
 "
 DEPEND="${RDEPEND}
 	virtual/pkgconfig


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/643212
Closes: https://bugs.gentoo.org/643212