### PR TITLE
profiles/default/bsd/fbsd/amd64/9.1/clang/deprecated: fix typo

### DIFF
--- a/profiles/default/bsd/fbsd/amd64/9.1/clang/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.1/clang/deprecated
@@ -1,4 +1,4 @@
-default/bsd/fbsd/amd64/clang/11.1
+default/bsd/fbsd/amd64/11.1/clang
 Please read carefully the wiki.
 Follow the correct steps, or your system will be broken.
 https://wiki.gentoo.org/wiki/Gentoo_FreeBSD/Upgrade_Guide


### PR DESCRIPTION
I found a typo in profiles/default/bsd/fbsd/amd64/9.1/clang/deprecated.
I'm sorry to trouble you, but could you please merge this PR?

Thanks.