### PR TITLE
dev-libs/libgpg-error: fix build when BUILD_CC contains spaces

### DIFF
--- a/dev-libs/libgpg-error/libgpg-error-1.27-r1.ebuild
+++ b/dev-libs/libgpg-error/libgpg-error-1.27-r1.ebuild
@@ -37,7 +37,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	ECONF_SOURCE="${S}" econf \
-		CC_FOR_BUILD=$(tc-getBUILD_CC) \
+		CC_FOR_BUILD="$(tc-getBUILD_CC)" \
 		--enable-threads \
 		$(use_enable nls) \
 		$(use_enable static-libs static) \


### PR DESCRIPTION
Filled compiler can be more than just compiler executable name. If 32bit
abi is enable the -m32 is passed with it. Before this the -m32 was
passed to configure script and it failed with error (because it clearly
doesn't support -m32 switch).

Bug: https://bugs.gentoo.org/643274
  