### PR TITLE
app-misc/neofetch: change maintainer email

### DIFF
--- a/app-misc/neofetch/metadata.xml
+++ b/app-misc/neofetch/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>herdiansyah@openmailbox.org</email>
+		<email>herdiansyah@netc.eu</email>
 		<name>Muhammad Herdiansyah</name>
 	</maintainer>
 	<maintainer type="project">


### PR DESCRIPTION
Self-explanatory since openmailbox went rogue.