### PR TITLE
dev-libs/libyaml: fix dll build on mingw-w64

### DIFF
--- a/dev-libs/libyaml/files/libyaml-0.1.7-mingw-no-undefined.patch
+++ b/dev-libs/libyaml/files/libyaml-0.1.7-mingw-no-undefined.patch
@@ -1,0 +1,32 @@
+--- a/include/yaml.h
++++ b/include/yaml.h
+@@ -26,7 +26,9 @@ extern "C" {
+ 
+ /** The public API declaration. */
+ 
+-#ifdef _WIN32
++#if defined(__MINGW32__)
++#   define  YAML_DECLARE(type)  type
++#elif defined(WIN32)
+ #   if defined(YAML_DECLARE_STATIC)
+ #       define  YAML_DECLARE(type)  type
+ #   elif defined(YAML_DECLARE_EXPORT)
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,4 +1,4 @@
+ AM_CPPFLAGS = -I$(top_srcdir)/include
+ lib_LTLIBRARIES = libyaml.la
+ libyaml_la_SOURCES = yaml_private.h api.c reader.c scanner.c parser.c loader.c writer.c emitter.c dumper.c
+-libyaml_la_LDFLAGS = -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)
++libyaml_la_LDFLAGS = -no-undefined -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -312,7 +312,7 @@ top_srcdir = @top_srcdir@
+ AM_CPPFLAGS = -I$(top_srcdir)/include
+ lib_LTLIBRARIES = libyaml.la
+ libyaml_la_SOURCES = yaml_private.h api.c reader.c scanner.c parser.c loader.c writer.c emitter.c dumper.c
+-libyaml_la_LDFLAGS = -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)
++libyaml_la_LDFLAGS = -no-undefined -release $(YAML_LT_RELEASE) -version-info $(YAML_LT_CURRENT):$(YAML_LT_REVISION):$(YAML_LT_AGE)
+ all: all-am
+ 
+ .SUFFIXES:

--- a/dev-libs/libyaml/libyaml-0.1.7-r1.ebuild
+++ b/dev-libs/libyaml/libyaml-0.1.7-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit libtool
+
+MY_P="${P/lib}"
+
+DESCRIPTION="YAML 1.1 parser and emitter written in C"
+HOMEPAGE="http://pyyaml.org/wiki/LibYAML"
+SRC_URI="http://pyyaml.org/download/${PN}/${MY_P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc static-libs test"
+
+S="${WORKDIR}/${MY_P}"
+PATCHES=(
+	"${FILESDIR}/${PN}-0.1.7-mingw-no-undefined.patch"
+)
+
+src_prepare() {
+	default
+
+	# conditionally remove tests
+	if ! use test; then
+		sed -i -e 's: tests::g' Makefile* || die
+	fi
+
+	elibtoolize  # for FreeMiNT
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_install() {
+	use doc && HTML_DOCS=( doc/html/. )
+	default
+
+	find "${D}" -name '*.la' -delete || die
+
+	docinto examples
+	dodoc tests/example-*.c
+	docompress -x /usr/share/doc/${PF}/examples
+}


### PR DESCRIPTION
includes the following patches:

https://github.com/yaml/libyaml/commit/119b7b6adfa72552d6dc7eb03f402ff5cf8f9fa6
https://github.com/yaml/libyaml/pull/85

Former is upstreamed, the latter is a pending pr. Without these changes
a shared library/dll cannot be created on mingw-w64. Latter patch is
applied also to the generated Makefile.in in order to prevent the need
for eautoreconf.

Package-Manager: Portage-2.3.19, Repoman-2.3.6