### PR TITLE
app-text/zathura-pdf-poppler: Build for EPREFIX

### DIFF
--- a/app-text/zathura-pdf-poppler/zathura-pdf-poppler-0.2.7.ebuild
+++ b/app-text/zathura-pdf-poppler/zathura-pdf-poppler-0.2.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -32,7 +32,6 @@ src_configure() {
 		CC="$(tc-getCC)"
 		LD="$(tc-getLD)"
 		VERBOSE=1
-		DESTDIR="${D}"
 	)
 }
 
@@ -41,6 +40,6 @@ src_compile() {
 }
 
 src_install() {
-	emake "${myzathuraconf[@]}" install
+	emake "${myzathuraconf[@]}" DESTDIR="${ED%/}" install
 	dodoc AUTHORS
 }

--- a/app-text/zathura-pdf-poppler/zathura-pdf-poppler-0.2.8.ebuild
+++ b/app-text/zathura-pdf-poppler/zathura-pdf-poppler-0.2.8.ebuild
@@ -32,7 +32,6 @@ src_configure() {
 		CC="$(tc-getCC)"
 		LD="$(tc-getLD)"
 		VERBOSE=1
-		DESTDIR="${D}"
 	)
 }
 
@@ -41,6 +40,6 @@ src_compile() {
 }
 
 src_install() {
-	emake "${myzathuraconf[@]}" install
+	emake "${myzathuraconf[@]}" DESTDIR="${ED%/}" install
 	dodoc AUTHORS
 }

--- a/app-text/zathura-pdf-poppler/zathura-pdf-poppler-9999.ebuild
+++ b/app-text/zathura-pdf-poppler/zathura-pdf-poppler-9999.ebuild
@@ -32,7 +32,6 @@ src_configure() {
 		CC="$(tc-getCC)"
 		LD="$(tc-getLD)"
 		VERBOSE=1
-		DESTDIR="${D}"
 	)
 }
 
@@ -41,6 +40,6 @@ src_compile() {
 }
 
 src_install() {
-	emake "${myzathuraconf[@]}" install
+	emake "${myzathuraconf[@]}" DESTDIR="${ED%/}" install
 	dodoc AUTHORS
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/645352
Package-Manager: Portage-2.3.13, Repoman-2.3.3