### PR TITLE
sys-devel/llvm: removed implicit dependency on binutils

### DIFF
--- a/sys-devel/llvm/llvm-5.0.1.ebuild
+++ b/sys-devel/llvm/llvm-5.0.1.ebuild
@@ -49,7 +49,6 @@ DEPEND="${RDEPEND}
 	|| ( >=sys-devel/gcc-3.0 >=sys-devel/llvm-3.5
 		( >=sys-freebsd/freebsd-lib-9.1-r10 sys-libs/libcxx )
 	)
-	|| ( >=sys-devel/binutils-2.18 >=sys-devel/binutils-apple-5.1 )
 	kernel_Darwin? ( <sys-libs/libcxx-$(ver_cut 1-3).9999 )
 	doc? ( dev-python/sphinx )
 	gold? ( sys-libs/binutils-libs )

--- a/sys-devel/llvm/llvm-5.0.1.ebuild
+++ b/sys-devel/llvm/llvm-5.0.1.ebuild
@@ -49,7 +49,10 @@ DEPEND="${RDEPEND}
 	|| ( >=sys-devel/gcc-3.0 >=sys-devel/llvm-3.5
 		( >=sys-freebsd/freebsd-lib-9.1-r10 sys-libs/libcxx )
 	)
-	kernel_Darwin? ( <sys-libs/libcxx-$(ver_cut 1-3).9999 )
+	kernel_Darwin? (
+		<sys-libs/libcxx-$(ver_cut 1-3).9999
+		>=sys-devel/binutils-apple-5.1
+	)
 	doc? ( dev-python/sphinx )
 	gold? ( sys-libs/binutils-libs )
 	libffi? ( virtual/pkgconfig )

--- a/sys-devel/llvm/llvm-6.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-6.0.9999.ebuild
@@ -54,8 +54,10 @@ DEPEND="${RDEPEND}
 	|| ( >=sys-devel/gcc-3.0 >=sys-devel/llvm-3.5
 		( >=sys-freebsd/freebsd-lib-9.1-r10 sys-libs/libcxx )
 	)
-	|| ( >=sys-devel/binutils-2.18 >=sys-devel/binutils-apple-5.1 )
-	kernel_Darwin? ( <sys-libs/libcxx-$(ver_cut 1-3).9999 )
+	kernel_Darwin? (
+		<sys-libs/libcxx-$(ver_cut 1-3).9999
+		>=sys-devel/binutils-apple-5.1
+	)
 	doc? ( dev-python/sphinx )
 	gold? ( sys-libs/binutils-libs )
 	libffi? ( virtual/pkgconfig )

--- a/sys-devel/llvm/llvm-9999.ebuild
+++ b/sys-devel/llvm/llvm-9999.ebuild
@@ -53,7 +53,10 @@ DEPEND="${RDEPEND}
 	|| ( >=sys-devel/gcc-3.0 >=sys-devel/llvm-3.5
 		( >=sys-freebsd/freebsd-lib-9.1-r10 sys-libs/libcxx )
 	)
-	kernel_Darwin? ( <sys-libs/libcxx-$(ver_cut 1-3).9999 )
+	kernel_Darwin? (
+		<sys-libs/libcxx-$(ver_cut 1-3).9999
+		>=sys-devel/binutils-apple-5.1
+	)
 	doc? ( dev-python/sphinx )
 	gold? ( sys-libs/binutils-libs )
 	libffi? ( virtual/pkgconfig )

--- a/sys-devel/llvm/llvm-9999.ebuild
+++ b/sys-devel/llvm/llvm-9999.ebuild
@@ -53,7 +53,6 @@ DEPEND="${RDEPEND}
 	|| ( >=sys-devel/gcc-3.0 >=sys-devel/llvm-3.5
 		( >=sys-freebsd/freebsd-lib-9.1-r10 sys-libs/libcxx )
 	)
-	|| ( >=sys-devel/binutils-2.18 >=sys-devel/binutils-apple-5.1 )
 	kernel_Darwin? ( <sys-libs/libcxx-$(ver_cut 1-3).9999 )
 	doc? ( dev-python/sphinx )
 	gold? ( sys-libs/binutils-libs )


### PR DESCRIPTION
Binutils should be an implicit system dependency. No need to force llvm to pull it in. 