### PR TITLE
media-libs/libogg: do not delete *.dll.a libraries

### DIFF
--- a/media-libs/libogg/libogg-1.3.3.ebuild
+++ b/media-libs/libogg/libogg-1.3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -30,7 +30,4 @@ multilib_src_configure() {
 multilib_src_install_all() {
 	einstalldocs
 	find "${ED}" -name "*.la" -delete || die
-	if ! use static-libs ; then
-		find "${ED}" -name "*.a" -delete || die
-	fi
 }


### PR DESCRIPTION
libogg.dll.a is what is used when you pass -logg to the linker and
without it you cannot compile programs linked against libogg.

Package-Manager: Portage-2.3.19, Repoman-2.3.6