### PR TITLE
net-analyzer/linkchecker: fix using newer dev-python/requests

### DIFF
--- a/net-analyzer/linkchecker/files/linkchecker-9.3.1-requests.patch
+++ b/net-analyzer/linkchecker/files/linkchecker-9.3.1-requests.patch
@@ -1,0 +1,46 @@
+From 9b12b5d66fa9b832f4d9e19a0b9dcb92607ee3e5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Antoine=20Beaupr=C3=A9?= <anarcat@debian.org>
+Date: Mon, 2 Oct 2017 20:18:54 -0400
+Subject: [PATCH] workaround new limitation in requests
+
+newer requests do not expose the internal SSL socket object so we
+cannot verify certificates. there was work to allow custom
+verification routines which we could use, but this never finished:
+
+https://github.com/shazow/urllib3/pull/257
+
+so right now, just treat missing socket information as if the cert was
+missing.
+
+Closes: #76
+---
+ linkcheck/checker/httpurl.py | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/linkcheck/checker/httpurl.py b/linkcheck/checker/httpurl.py
+index 161619c5..bde77c70 100644
+--- a/linkcheck/checker/httpurl.py
++++ b/linkcheck/checker/httpurl.py
+@@ -194,6 +194,10 @@ def _get_ssl_sock(self):
+         """Get raw SSL socket."""
+         assert self.scheme == u"https", self
+         raw_connection = self.url_connection.raw._connection
++        if not raw_connection:
++            # this happens with newer requests versions:
++            # https://github.com/linkcheck/linkchecker/issues/76
++            return None
+         if raw_connection.sock is None:
+             # sometimes the socket is not yet connected
+             # see https://github.com/kennethreitz/requests/issues/1966
+@@ -204,7 +208,10 @@ def _add_ssl_info(self):
+         """Add SSL cipher info."""
+         if self.scheme == u'https':
+             sock = self._get_ssl_sock()
+-            if hasattr(sock, 'cipher'):
++            if not sock:
++                log.debug(LOG_CHECK, "cannot extract SSL certificate from connection")
++                self.ssl_cert = None
++            elif hasattr(sock, 'cipher'):
+                 self.ssl_cert = sock.getpeercert()
+             else:
+                 # using pyopenssl

--- a/net-analyzer/linkchecker/linkchecker-9.3.1-r1.ebuild
+++ b/net-analyzer/linkchecker/linkchecker-9.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -19,7 +19,7 @@ IUSE="gnome sqlite X"
 
 RDEPEND="
 	virtual/python-dnspython[${PYTHON_USEDEP}]
-	<dev-python/requests-2.15.0[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
 	gnome? ( dev-python/pygtk:2[${PYTHON_USEDEP}] )
 	X? (
 		dev-python/PyQt4[X,help,${PYTHON_USEDEP}]
@@ -39,6 +39,7 @@ python_prepare_all() {
 		"${FILESDIR}/${PN}-9.3-bash-completion.patch"
 		"${FILESDIR}/${PN}-9.3-desktop.patch"
 		"${FILESDIR}/${PN}-9.3.1-build-fix.patch"
+		"${FILESDIR}/${PN}-9.3.1-requests.patch"
 	)
 
 	distutils-r1_python_prepare_all


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/643688
Package-Manager: Portage-2.3.18, Repoman-2.3.6