### PR TITLE
dev-db/mongodb: reintroduce scons fixes

### DIFF
--- a/dev-db/mongodb/files/mongodb-3.6.1-fix-scons.patch
+++ b/dev-db/mongodb/files/mongodb-3.6.1-fix-scons.patch
@@ -1,0 +1,32 @@
+diff --git a/SConstruct b/SConstruct
+index fe7975b..92659a7 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -1619,7 +1619,6 @@ if env.TargetOSIs('posix'):
+     # -Winvalid-pch Warn if a precompiled header (see Precompiled Headers) is found in the search path but can't be used.
+     env.Append( CCFLAGS=["-fno-omit-frame-pointer",
+                          "-fno-strict-aliasing",
+-                         "-ggdb",
+                          "-pthread",
+                          "-Wall",
+                          "-Wsign-compare",
+@@ -1631,6 +1630,8 @@ if env.TargetOSIs('posix'):
+             env.Append( CCFLAGS=["-Werror"] )
+ 
+     env.Append( CXXFLAGS=["-Woverloaded-virtual"] )
++    env.Append( CXXFLAGS=os.environ['CXXFLAGS'] )
++    env.Append( LINKFLAGS=os.environ['LDFLAGS'] )
+     if env.ToolchainIs('clang'):
+         env.Append( CXXFLAGS=['-Werror=unused-result'] )
+ 
+@@ -1650,8 +1651,8 @@ if env.TargetOSIs('posix'):
+ 
+     env.Append( LIBS=[] )
+ 
+-    #make scons colorgcc friendly
+-    for key in ('HOME', 'TERM'):
++    #make scons colorgcc, distcc, ccache friendly
++    for key in ('HOME', 'PATH', 'TERM'):
+         try:
+             env['ENV'][key] = os.environ[key]
+         except KeyError:

--- a/dev-db/mongodb/mongodb-3.6.1-r1.ebuild
+++ b/dev-db/mongodb/mongodb-3.6.1-r1.ebuild
@@ -52,6 +52,7 @@ PDEPEND="tools? ( >=app-admin/mongo-tools-${PV} )"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-3.4.7-no-boost-check.patch"
+	"${FILESDIR}/${PN}-3.6.1-fix-scons.patch"
 	"${FILESDIR}/${PN}-3.6.1-no-compass.patch"
 )
 


### PR DESCRIPTION
Reintroduce scons fixes from 3.4.

Closes: https://bugs.gentoo.org/643984
Package-Manager: Portage-2.3.19, Repoman-2.3.6