### PR TITLE
dev-ruby/net-scp: update ruby versions

### DIFF
--- a/dev-ruby/net-scp/files/net-scp-1.2.1-fix-download_tests.patch
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-fix-download_tests.patch
@@ -1,0 +1,107 @@
+--- test/test_download.rb	2018-01-20 18:35:08.964014750 +0100
++++ test/test_download.rb.1	2018-01-20 18:36:51.312014994 +0100
+@@ -11,7 +11,7 @@
+     assert_scripted { scp.download!("/path/to/remote.txt", "/path/to/local.txt") }
+     assert_equal "a" * 1234, file.io.string
+   end
+-  
++
+   def test_download_file_with_spaces_in_name_should_escape_remote_file_name
+     file = prepare_file("/path/to/local file.txt", "")
+ 
+@@ -25,7 +25,7 @@
+ 
+     assert_scripted { scp.download!("/path/to/remote file.txt", "/path/to/local file.txt") }
+   end
+-  
++
+   def test_download_file_with_metacharacters_in_name_should_escape_remote_file_name
+     file = prepare_file("/path/to/local/#{awful_file_name}", "")
+ 
+@@ -70,12 +70,12 @@
+     end
+ 
+     error = nil
+-    assert_scripted do
+-      begin
+-        scp.download!("/path/to/remote.txt")
+-      rescue
+-        error = $!
+-      end
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++    begin
++      scp.download!("/path/to/remote.txt")
++    rescue
++      error = $!
++    end
+     end
+     assert_equal Net::SCP::Error, error.class
+     assert_equal "SCP did not finish successfully (1): File not found: /path/to/remote.txt\n", error.message
+@@ -116,7 +116,9 @@
+ 
+   def test_download_io_with_recursive_should_raise_error
+     expect_scp_session "-f -r /path/to/remote.txt"
+-    assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", StringIO.new, :recursive => true) }
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", StringIO.new, :recursive => true) }
++    end
+   end
+ 
+   def test_download_io_with_preserve_should_ignore_preserve
+@@ -154,8 +156,44 @@
+       channel.sends_ok
+       channel.gets_data "D0755 0 remote\n"
+     end
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote") }
++    end
++  end
++
++  def test_download_should_raise_error_if_gets_not_ok
++    prepare_file("/path/to/local.txt", "")
++
++    expect_scp_session "-f /path/to/remote.txt" do |channel|
++      channel.sends_ok
++      channel.gets_data "C0666 0 remote.txt\n"
++      channel.sends_ok
++      channel.gets_data "\1"
++    end
++
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", "/path/to/local.txt") }
++      assert_equal("\1", e.message)
++    end
++  end
++
++  def test_download_directory_should_raise_error_if_local_exists_and_is_not_directory
++    File.stubs(:exists?).with("/path/to/local").returns(true)
++    File.stubs(:exists?).with("/path/to/local/remote").returns(true)
++    File.stubs(:directory?).with("/path/to/local/remote").returns(false)
++
++    expect_scp_session "-f -r /path/to/remote" do |channel|
++      channel.sends_ok
++      channel.gets_data "D0755 0 remote\n"
++      channel.sends_ok
++      channel.gets_data "E\n"
++      channel.sends_ok
++    end
+ 
+-    assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote") }
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote", "/path/to/local", :recursive => true) }
++      assert_match(/exists and is not a directory/, e.message)
++    end
+   end
+ 
+   def test_download_directory_should_create_directory_and_files_locally
+@@ -180,7 +218,9 @@
+       channel.sends_ok
+     end
+ 
+-    scp.download!("/path/to/remote", "/path/to/local", :recursive => true, :ssh => { :verbose => :debug })
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      scp.download!("/path/to/remote", "/path/to/local", :recursive => true, :ssh => { :verbose => :debug })
++    end
+     assert_equal "a" * 1234, file.io.string
+   end
+ 

--- a/dev-ruby/net-scp/files/net-scp-1.2.1-fix-upload_tests.patch
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-fix-upload_tests.patch
@@ -1,0 +1,30 @@
+--- test/test_upload.rb	2018-01-20 18:35:08.964014750 +0100
++++ test/test_upload.rb.1	2018-01-20 18:36:37.256014961 +0100
+@@ -156,7 +156,9 @@
+       channel.gets_ok
+     end
+ 
+-    assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local", "/path/to/remote") }
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local", "/path/to/remote") }
++    end
+   end
+ 
+   def test_upload_empty_directory_should_create_directory_and_finish
+@@ -266,4 +268,16 @@
+     story { |s| s.opens_channel(false) }
+     assert_scripted { scp.upload("/path/to/local.txt", "/path/to/remote.txt") }
+   end
++
++  def test_upload_should_raise_error_if_gets_not_ok
++    prepare_file("/path/to/local.txt", "")
++
++    expect_scp_session "-t /path/to/remote.txt" do |channel|
++      channel.gets_data "\1"
++    end
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      e = assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local.txt", "/path/to/remote.txt") }
++      assert_equal("\1", e.message)
++    end
++  end
+ end

--- a/dev-ruby/net-scp/net-scp-1.2.1-r1.ebuild
+++ b/dev-ruby/net-scp/net-scp-1.2.1-r1.ebuild
@@ -19,14 +19,17 @@ SLOT="4"
 KEYWORDS="~amd64"
 IUSE=""
 
+RUBY_PATCHES=( ${P}-fix-download_tests.patch  ${P}-fix-upload_tests.patch )
+
+
 ruby_add_bdepend "
-	doc? ( >=dev-ruby/net-ssh-2.6.5:4 )
+	doc? ( >=dev-ruby/net-ssh-4.0:4 )
 	test? (
-		>=dev-ruby/net-ssh-2.9.0:4
+		>=dev-ruby/net-ssh-4.0:4
 		dev-ruby/mocha
 	)"
 
-ruby_add_rdepend ">=dev-ruby/net-ssh-2.6.5:4"
+ruby_add_rdepend ">=dev-ruby/net-ssh-4.0:4"
 
 all_ruby_prepare() {
 	sed -i -e 's/>= 2.0.0/~> 2.0/' test/common.rb || die

--- a/dev-ruby/net-scp/net-scp-1.2.1-r1.ebuild
+++ b/dev-ruby/net-scp/net-scp-1.2.1-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+USE_RUBY="ruby23 ruby24"
+
+RUBY_FAKEGEM_EXTRADOC="CHANGES.txt README.rdoc"
+
+RUBY_FAKEGEM_TASK_TEST=""
+
+inherit ruby-fakegem
+
+DESCRIPTION="A pure Ruby implementation of the SCP client protocol"
+HOMEPAGE="https://github.com/net-ssh/net-scp"
+
+LICENSE="GPL-2"
+SLOT="4"
+KEYWORDS="~amd64"
+IUSE=""
+
+ruby_add_bdepend "
+	doc? ( >=dev-ruby/net-ssh-2.6.5:4 )
+	test? (
+		>=dev-ruby/net-ssh-2.9.0:4
+		dev-ruby/mocha
+	)"
+
+ruby_add_rdepend ">=dev-ruby/net-ssh-2.6.5:4"
+
+all_ruby_prepare() {
+	sed -i -e 's/>= 2.0.0/~> 2.0/' test/common.rb || die
+}
+
+each_ruby_test() {
+	${RUBY} -Ilib:test test/test_all.rb || die
+}


### PR DESCRIPTION
remove old versions: ruby21 ruby22
add new ruby version: ruby24

This is part of the effort to update ruby versions
of app-emulation/vagrant

see https://bugs.gentoo.org/show_bug.cgi?id=643876

Bug: https://bugs.gentoo.org/show_bug.cgi?id=643990
