### PR TITLE
app-emulation/wine-vanilla: re-fix a crash in install phase (#6407)

### DIFF
--- a/app-emulation/wine-vanilla/wine-vanilla-2.0.3.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-2.0.3.ebuild
@@ -478,7 +478,7 @@ multilib_src_install_all() {
 
 	# respect LINGUAS when installing man pages, #469418
 	local l
-	for l in de fr pl; do
+	for l in de fr; do
 		has ${l} ${LINGUAS-${l}} || rm -rf "${D%/}${MY_MANDIR}"/${l}*
 	done
 


### PR DESCRIPTION
Sorry for PR #6407, that has a defect.
Now I'm trying to re-fix it with simple patch -- manpage `pl` doesn't seem to exist.

(I have patched only to v2.0.3, because I'm not sure that other versions have `pl`.)
