### PR TITLE
dev-lang/crystal: Fix build with doc use flag

### DIFF
--- a/dev-lang/crystal/crystal-0.24.1.ebuild
+++ b/dev-lang/crystal/crystal-0.24.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -62,7 +62,7 @@ src_compile() {
 		CRYSTAL_PATH=src \
 		CRYSTAL_CONFIG_VERSION=${PV} \
 		CRYSTAL_CONFIG_PATH="lib:${EPREFIX}/usr/$(get_libdir)/crystal"
-	use doc && emake doc
+	use doc && emake docs
 }
 
 src_test() {
@@ -93,7 +93,7 @@ src_install() {
 
 	if use doc ; then
 		docinto api
-		dodoc -r doc/.
+		dodoc -r docs/.
 	fi
 
 	newbashcomp etc/completion.bash ${PN}


### PR DESCRIPTION
In PR https://github.com/crystal-lang/crystal/pull/5217 directory doc renamed to docs

Package-Manager: Portage-2.3.19, Repoman-2.3.6