### PR TITLE
games-board/spider: use xmkmf instead of calling imake directly

### DIFF
--- a/games-board/spider/spider-1.2_p4-r1.ebuild
+++ b/games-board/spider/spider-1.2_p4-r1.ebuild
@@ -38,12 +38,10 @@ src_prepare() {
 }
 
 src_configure() {
-	imake \
-		-DUseInstalled \
+	xmkmf \
 		-DSmallCards=NO \
 		-DRoundCards \
 		$(use athena && echo "-DCompileXAW=YES" || echo "-DCompileXlibOnly=YES") \
-		-I/usr/lib/X11/config \
 		|| die "imake failed"
 	sed -i \
 		-e '/CC = /d' \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/640686