### PR TITLE
www-apps/rutorrent: Remove broken .htaccess file on install of 3.8

### DIFF
--- a/www-apps/rutorrent/rutorrent-3.8-r1.ebuild
+++ b/www-apps/rutorrent/rutorrent-3.8-r1.ebuild
@@ -29,6 +29,8 @@ pkg_setup() {
 src_prepare() {
 	default
 	find -name '\.gitignore' -type f -exec rm -rf {} \;
+	# The 3.8 release of ruTorrent includes an .htaccess file that defines a .htpasswd that doesn't exist
+	rm '.htaccess'
 }
 
 src_install() {


### PR DESCRIPTION
This removes the broken .htaccess that is part of the release archive.
Removing this file matches the previous behaviour of the rutorrent ebuild (when the release contained no .htaccess file there).