### PR TITLE
dev-libs/libmowgli: Bump to EAPI=6

### DIFF
--- a/dev-libs/libmowgli/libmowgli-1.0.0-r1.ebuild
+++ b/dev-libs/libmowgli/libmowgli-1.0.0-r1.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Useful set of performance and usability-oriented extensions to C"
+HOMEPAGE="http://atheme.org/projects/libmowgli.html"
+SRC_URI="http://distfiles.atheme.org/${P}.tar.bz2"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+IUSE=""
+
+DOCS=( AUTHORS README doc/BOOST )

--- a/dev-libs/libmowgli/libmowgli-1.0.0.ebuild
+++ b/dev-libs/libmowgli/libmowgli-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=3

--- a/dev-libs/libmowgli/libmowgli-9999.ebuild
+++ b/dev-libs/libmowgli/libmowgli-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,13 +6,13 @@ EAPI=6
 inherit git-r3
 
 DESCRIPTION="Useful set of performance and usability-oriented extensions to C"
-HOMEPAGE="http://atheme.org/projects/libmowgli.html"
+HOMEPAGE="https://github.com/atheme/libmowgli-2"
 EGIT_REPO_URI="https://github.com/atheme/libmowgli-2.git"
-IUSE="libressl ssl"
 
 LICENSE="BSD-2"
 SLOT="2"
 KEYWORDS=""
+IUSE="libressl ssl"
 RDEPEND="ssl? (
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/644264
Package-Manager: Portage-2.3.13, Repoman-2.3.3