### PR TITLE
dev-cpp/gtest: Enable the 'source', USE flag

### DIFF
--- a/dev-cpp/gtest/gtest-1.8.0-r1.ebuild
+++ b/dev-cpp/gtest/gtest-1.8.0-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/google/googletest/archive/release-${PV}.tar.gz -> ${
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE="doc examples test"
+IUSE="doc examples source test"
 
 DEPEND="test? ( ${PYTHON_DEPS} )"
 RDEPEND="!dev-cpp/gmock"
@@ -64,5 +64,13 @@ multilib_src_install_all() {
 	if use examples; then
 		docinto examples
 		dodoc googletest/samples/*.{cc,h}
+	fi
+
+	if use source; then
+		insinto /usr/src/gtest/src
+		doins "${S}"/googletest/src/*
+
+		insinto /usr/src/gmock/src
+		doins "${S}"/googlemock/src/*
 	fi
 }

--- a/dev-cpp/gtest/gtest-9999.ebuild
+++ b/dev-cpp/gtest/gtest-9999.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://github.com/google/googletest"
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="doc examples test"
+IUSE="doc examples source test"
 
 DEPEND="test? ( ${PYTHON_DEPS} )"
 RDEPEND="!dev-cpp/gmock"
@@ -72,5 +72,13 @@ multilib_src_install_all() {
 	if use examples; then
 		docinto examples
 		dodoc googletest/samples/*.{cc,h}
+	fi
+
+	if use source; then
+		insinto /usr/src/gtest/src
+		doins "${S}"/googletest/src/*
+
+		insinto /usr/src/gmock/src
+		doins "${S}"/googlemock/src/*
 	fi
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/643566

Because googletest considers linking to systemwide gtest/gmock shared
libraries to be [ill-advised](https://github.com/google/googletest/blob/master/googletest/docs/FAQ.md#why-is-it-not-recommended-to-install-a-pre-compiled-copy-of-google-test-for-example-into-usrlocal), some packages such as app-office/gnucash
rely on building gtest/gmock from existing sources.  As long as the
resulting libraries exist for testing and aren't installed, there's
nothing wrong with supporting the 'source' USE flag.

Package-Manager: Portage-2.3.16, Repoman-2.3.6