### PR TITLE
kernel-2.eclass: Implicit dependency cleanups (and others)

### DIFF
--- a/dev-lang/teyjus/teyjus-2.0.2.ebuild
+++ b/dev-lang/teyjus/teyjus-2.0.2.ebuild
@@ -17,9 +17,7 @@ KEYWORDS="~amd64 ~x86"
 LICENSE="GPL-3"
 IUSE="emacs examples +ocamlopt"
 
-RDEPEND=">=sys-devel/binutils-2.17:*
-	>=sys-devel/gcc-2.95.3:*
-	>=dev-lang/ocaml-3.10[ocamlopt?]
+RDEPEND=" >=dev-lang/ocaml-3.10[ocamlopt?]
 	emacs? ( virtual/emacs )"
 DEPEND="${RDEPEND}
 	dev-util/omake"

--- a/dev-lang/teyjus/teyjus-2.1.ebuild
+++ b/dev-lang/teyjus/teyjus-2.1.ebuild
@@ -14,9 +14,7 @@ KEYWORDS="~amd64 ~x86"
 LICENSE="GPL-3"
 IUSE="emacs examples +ocamlopt"
 
-RDEPEND=">=sys-devel/binutils-2.17:*
-	>=sys-devel/gcc-2.95.3:*
-	>=dev-lang/ocaml-3.10[ocamlopt?]
+RDEPEND="=dev-lang/ocaml-3.10[ocamlopt?]
 	emacs? ( virtual/emacs )"
 DEPEND="${RDEPEND}
 	dev-util/omake"

--- a/eclass/kernel-2.eclass
+++ b/eclass/kernel-2.eclass
@@ -599,7 +599,6 @@ kernel_is_2_6() {
 if [[ ${ETYPE} == sources ]]; then
 	DEPEND="!build? (
 		sys-apps/sed
-		>=sys-devel/binutils-2.11.90.0.31
 	)"
 	RDEPEND="!build? (
 		>=sys-libs/ncurses-5.2

--- a/eclass/mozconfig-v6.45.eclass
+++ b/eclass/mozconfig-v6.45.eclass
@@ -183,7 +183,6 @@ fi
 
 DEPEND="app-arch/zip
 	app-arch/unzip
-	>=sys-devel/binutils-2.16.1
 	${RDEPEND}"
 
 RDEPEND+="

--- a/eclass/mozconfig-v6.49.eclass
+++ b/eclass/mozconfig-v6.49.eclass
@@ -190,7 +190,6 @@ fi
 
 DEPEND="app-arch/zip
 	app-arch/unzip
-	>=sys-devel/binutils-2.16.1
 	sys-apps/findutils
 	${RDEPEND}"
 

--- a/eclass/mozconfig-v6.51.eclass
+++ b/eclass/mozconfig-v6.51.eclass
@@ -194,7 +194,6 @@ fi
 
 DEPEND="app-arch/zip
 	app-arch/unzip
-	>=sys-devel/binutils-2.16.1
 	sys-apps/findutils
 	${RDEPEND}"
 

--- a/eclass/mozconfig-v6.52.eclass
+++ b/eclass/mozconfig-v6.52.eclass
@@ -166,7 +166,6 @@ fi
 
 DEPEND="app-arch/zip
 	app-arch/unzip
-	>=sys-devel/binutils-2.16.1
 	sys-apps/findutils
 	pulseaudio? ( media-sound/pulseaudio )
 	${RDEPEND}"

--- a/eclass/mozconfig-v6.53.eclass
+++ b/eclass/mozconfig-v6.53.eclass
@@ -169,7 +169,6 @@ fi
 
 DEPEND="app-arch/zip
 	app-arch/unzip
-	>=sys-devel/binutils-2.16.1
 	sys-apps/findutils
 	pulseaudio? ( media-sound/pulseaudio )
 	${RDEPEND}"

--- a/eclass/mozconfig-v6.55.eclass
+++ b/eclass/mozconfig-v6.55.eclass
@@ -169,7 +169,6 @@ fi
 
 DEPEND="app-arch/zip
 	app-arch/unzip
-	>=sys-devel/binutils-2.16.1
 	sys-apps/findutils
 	pulseaudio? ( media-sound/pulseaudio )
 	${RDEPEND}"

--- a/eclass/mozconfig-v6.56.eclass
+++ b/eclass/mozconfig-v6.56.eclass
@@ -169,7 +169,6 @@ fi
 
 DEPEND="app-arch/zip
 	app-arch/unzip
-	>=sys-devel/binutils-2.16.1
 	sys-apps/findutils
 	pulseaudio? ( media-sound/pulseaudio )
 	${RDEPEND}"

--- a/eclass/mozconfig-v6.57.eclass
+++ b/eclass/mozconfig-v6.57.eclass
@@ -169,7 +169,6 @@ fi
 
 DEPEND="app-arch/zip
 	app-arch/unzip
-	>=sys-devel/binutils-2.16.1
 	sys-apps/findutils
 	pulseaudio? ( media-sound/pulseaudio )
 	>=virtual/rust-1.19.0

--- a/sys-apps/paxctl/paxctl-0.7-r2.ebuild
+++ b/sys-apps/paxctl/paxctl-0.7-r2.ebuild
@@ -14,7 +14,7 @@ IUSE=""
 LICENSE="GPL-2"
 SLOT="0"
 
-DEPEND=">=sys-devel/binutils-2.14.90.0.8-r1"
+DEPEND=""
 RDEPEND=""
 
 src_prepare() {

--- a/sys-apps/paxctl/paxctl-0.8.ebuild
+++ b/sys-apps/paxctl/paxctl-0.8.ebuild
@@ -14,7 +14,7 @@ IUSE=""
 LICENSE="GPL-2"
 SLOT="0"
 
-DEPEND=">=sys-devel/binutils-2.14.90.0.8-r1"
+DEPEND=""
 RDEPEND=""
 
 src_prepare() {

--- a/sys-apps/paxctl/paxctl-0.9.ebuild
+++ b/sys-apps/paxctl/paxctl-0.9.ebuild
@@ -14,7 +14,7 @@ IUSE=""
 LICENSE="GPL-2"
 SLOT="0"
 
-DEPEND=">=sys-devel/binutils-2.14.90.0.8-r1"
+DEPEND=""
 RDEPEND=""
 
 src_prepare() {

--- a/sys-devel/prelink/prelink-20130503-r1.ebuild
+++ b/sys-devel/prelink/prelink-20130503-r1.ebuild
@@ -25,8 +25,7 @@ DEPEND=">=dev-libs/elfutils-0.100[static-libs(+)]
 	selinux? ( sys-libs/libselinux[static-libs(+)] )
 	!dev-libs/libelf
 	>=sys-libs/glibc-2.8"
-RDEPEND="${DEPEND}
-	>=sys-devel/binutils-2.18"
+RDEPEND="${DEPEND}"
 
 S=${WORKDIR}/${PN}
 

--- a/sys-devel/prelink/prelink-20130503.ebuild
+++ b/sys-devel/prelink/prelink-20130503.ebuild
@@ -25,8 +25,7 @@ DEPEND=">=dev-libs/elfutils-0.100[static-libs(+)]
 	selinux? ( sys-libs/libselinux[static-libs(+)] )
 	!dev-libs/libelf
 	>=sys-libs/glibc-2.8"
-RDEPEND="${DEPEND}
-	>=sys-devel/binutils-2.18"
+RDEPEND="${DEPEND}"
 
 S=${WORKDIR}/${PN}
 

--- a/sys-devel/prelink/prelink-20151030.ebuild
+++ b/sys-devel/prelink/prelink-20151030.ebuild
@@ -23,8 +23,7 @@ DEPEND=">=dev-libs/elfutils-0.100[static-libs(+)]
 	!dev-libs/libelf
 	sys-libs/binutils-libs
 	>=sys-libs/glibc-2.8"
-RDEPEND="${DEPEND}
-	>=sys-devel/binutils-2.18"
+RDEPEND="${DEPEND}"
 
 S=${WORKDIR}/${MY_P}
 

--- a/sys-fs/lvm2/lvm2-2.02.116-r1.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.116-r1.ebuild
@@ -35,7 +35,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.116-r2.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.116-r2.ebuild
@@ -36,7 +36,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.116-r4.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.116-r4.ebuild
@@ -39,7 +39,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.116-r5.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.116-r5.ebuild
@@ -46,7 +46,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.116-r6.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.116-r6.ebuild
@@ -46,7 +46,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.116.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.116.ebuild
@@ -35,7 +35,6 @@ RDEPEND="${DEPEND_COMMON}
 # note: thin- 0.3.0 is required to avoid --disable-thin_check_needs_check
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=virtual/libudev-208:=[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.136-r1.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.136-r1.ebuild
@@ -43,7 +43,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.136-r2.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.136-r2.ebuild
@@ -44,7 +44,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.136.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.136.ebuild
@@ -36,7 +36,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.139-r1.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.139-r1.ebuild
@@ -44,7 +44,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.139.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.139.ebuild
@@ -43,7 +43,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		udev? ( >=sys-fs/eudev-3.1.2[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.145-r1.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.145-r1.ebuild
@@ -43,7 +43,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	sys-devel/autoconf-archive
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.145-r2.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.145-r2.ebuild
@@ -44,7 +44,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	sys-devel/autoconf-archive
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.145.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.145.ebuild
@@ -43,7 +43,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	sys-devel/autoconf-archive
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.166-r2.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.166-r2.ebuild
@@ -45,7 +45,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	sys-devel/autoconf-archive
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.166.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.166.ebuild
@@ -44,7 +44,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	sys-devel/autoconf-archive
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.171.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.171.ebuild
@@ -45,7 +45,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	sys-devel/autoconf-archive
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.172.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.172.ebuild
@@ -45,7 +45,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	sys-devel/autoconf-archive
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )

--- a/sys-fs/lvm2/lvm2-2.02.173.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.173.ebuild
@@ -45,7 +45,6 @@ RDEPEND="${DEPEND_COMMON}
 # USE 'static' currently only works with eudev, bug 520450
 DEPEND="${DEPEND_COMMON}
 	virtual/pkgconfig
-	>=sys-devel/binutils-2.20.1-r1
 	sys-devel/autoconf-archive
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )

--- a/sys-libs/db/db-6.0.35-r1.ebuild
+++ b/sys-libs/db/db-6.0.35-r1.ebuild
@@ -35,8 +35,7 @@ REQUIRED_USE="test? ( tcl )"
 # the entire testsuite needs the TCL functionality
 DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
-	java? ( >=virtual/jdk-1.5 )
-	>=sys-devel/binutils-2.16.1"
+	java? ( >=virtual/jdk-1.5 )"
 RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	java? ( >=virtual/jre-1.5 )"
 

--- a/sys-libs/db/db-6.0.35.ebuild
+++ b/sys-libs/db/db-6.0.35.ebuild
@@ -35,8 +35,7 @@ REQUIRED_USE="test? ( tcl )"
 # the entire testsuite needs the TCL functionality
 DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
-	java? ( >=virtual/jdk-1.5 )
-	>=sys-devel/binutils-2.16.1"
+	java? ( >=virtual/jdk-1.5 )"
 RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	java? ( >=virtual/jre-1.5 )"
 

--- a/sys-libs/db/db-6.1.29-r1.ebuild
+++ b/sys-libs/db/db-6.1.29-r1.ebuild
@@ -35,8 +35,7 @@ REQUIRED_USE="test? ( tcl )"
 # the entire testsuite needs the TCL functionality
 DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
-	java? ( >=virtual/jdk-1.5 )
-	>=sys-devel/binutils-2.16.1"
+	java? ( >=virtual/jdk-1.5 )"
 RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	java? ( >=virtual/jre-1.5 )"
 

--- a/sys-libs/db/db-6.1.29.ebuild
+++ b/sys-libs/db/db-6.1.29.ebuild
@@ -35,8 +35,7 @@ REQUIRED_USE="test? ( tcl )"
 # the entire testsuite needs the TCL functionality
 DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
-	java? ( >=virtual/jdk-1.5 )
-	>=sys-devel/binutils-2.16.1"
+	java? ( >=virtual/jdk-1.5 )"
 RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	java? ( >=virtual/jre-1.5 )"
 

--- a/sys-libs/db/db-6.2.23-r1.ebuild
+++ b/sys-libs/db/db-6.2.23-r1.ebuild
@@ -35,8 +35,7 @@ REQUIRED_USE="test? ( tcl )"
 # the entire testsuite needs the TCL functionality
 DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
-	java? ( >=virtual/jdk-1.5 )
-	>=sys-devel/binutils-2.16.1"
+	java? ( >=virtual/jdk-1.5 )"
 RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	java? ( >=virtual/jre-1.5 )"
 

--- a/sys-libs/db/db-6.2.23.ebuild
+++ b/sys-libs/db/db-6.2.23.ebuild
@@ -35,8 +35,7 @@ REQUIRED_USE="test? ( tcl )"
 # the entire testsuite needs the TCL functionality
 DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
-	java? ( >=virtual/jdk-1.5 )
-	>=sys-devel/binutils-2.16.1"
+	java? ( >=virtual/jdk-1.5 )"
 RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	java? ( >=virtual/jre-1.5 )"
 

--- a/sys-libs/db/db-6.2.32-r1.ebuild
+++ b/sys-libs/db/db-6.2.32-r1.ebuild
@@ -35,8 +35,7 @@ REQUIRED_USE="test? ( tcl )"
 # the entire testsuite needs the TCL functionality
 DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
-	java? ( >=virtual/jdk-1.5 )
-	>=sys-devel/binutils-2.16.1"
+	java? ( >=virtual/jdk-1.5 )"
 RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	java? ( >=virtual/jre-1.5 )"
 

--- a/sys-libs/db/db-6.2.32.ebuild
+++ b/sys-libs/db/db-6.2.32.ebuild
@@ -35,8 +35,7 @@ REQUIRED_USE="test? ( tcl )"
 # the entire testsuite needs the TCL functionality
 DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
-	java? ( >=virtual/jdk-1.5 )
-	>=sys-devel/binutils-2.16.1"
+	java? ( >=virtual/jdk-1.5 )"
 RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
 	java? ( >=virtual/jre-1.5 )"
 


### PR DESCRIPTION
Binutils is listed as a dependency of many packages, which is undesired. It is provided implicitly with the system.