### PR TITLE
lxde-base/lxpanel: RDEPEND x11-libs/gdk-pixbuf[X]

### DIFF
--- a/lxde-base/lxpanel/lxpanel-0.9.3-r1.ebuild
+++ b/lxde-base/lxpanel/lxpanel-0.9.3-r1.ebuild
@@ -1,17 +1,23 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
-inherit readme.gentoo-r1
+PLOCALES="af ar be bg bn_IN bn ca cs da de el en_GB es et eu fa fi fo fr frp
+gl he hr hu id is it ja kk km ko lg lt lv ml ms nb nl nn pa pl ps pt_BR pt ro
+ru sk sl sr@latin sr sv te th tr tt_RU ug uk ur_PK ur vi zh_CN zh_HK zh_TW"
+
+PLOCALE_BACKUP="en_GB"
+
+inherit l10n readme.gentoo-r1
 
 DESCRIPTION="Lightweight X11 desktop panel for LXDE"
 HOMEPAGE="https://wiki.lxde.org/en/LXPanel"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"
-KEYWORDS="~alpha amd64 arm ~arm64 ppc x86 ~amd64-linux ~arm-linux ~x86-linux"
 SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ppc ~x86 ~amd64-linux ~arm-linux ~x86-linux"
 IUSE="+alsa wifi"
 
 RDEPEND="dev-libs/keybinder:0=
@@ -21,7 +27,7 @@ RDEPEND="dev-libs/keybinder:0=
 	x11-libs/libXmu
 	x11-libs/libXpm
 	x11-libs/cairo
-	x11-libs/gdk-pixbuf
+	x11-libs/gdk-pixbuf[X]
 	x11-libs/libX11
 	lxde-base/lxmenu-data
 	lxde-base/menu-cache
@@ -34,6 +40,13 @@ DEPEND="${RDEPEND}
 DOC_CONTENTS="If you have problems with broken icons shown in the main panel,
 you will have to configure panel settings via its menu.
 This will not be an issue with first time installations."
+
+src_prepare() {
+	default
+
+	export LINGUAS="${LINGUAS:-${PLOCALE_BACKUP}}"
+	l10n_get_locales > po/LINGUAS || die
+}
 
 src_configure() {
 	local plugins="netstatus,volume,cpu,deskno,batt, \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/614086
Package-Manager: Portage-2.3.13, Repoman-2.3.3