### PR TITLE
kde-frameworks/sonnet: VIRTUALX is required for tests

### DIFF
--- a/kde-frameworks/sonnet/sonnet-5.42.0.ebuild
+++ b/kde-frameworks/sonnet/sonnet-5.42.0.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=6
 
+VIRTUALX_REQUIRED="test"
 inherit kde5
 
 DESCRIPTION="Framework for providing spell-checking through abstraction of popular backends"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/644646