### PR TITLE
dev-scheme/guile: Added sub-slot dep for boehm-gc.

### DIFF
--- a/dev-scheme/guile/guile-2.0.13-r2.ebuild
+++ b/dev-scheme/guile/guile-2.0.13-r2.ebuild
@@ -16,7 +16,7 @@ IUSE="debug debug-malloc +deprecated +networking +nls +regex +threads" # upstrea
 REQUIRED_USE="regex"
 
 RDEPEND="
-	>=dev-libs/boehm-gc-7.0[threads?]
+	>=dev-libs/boehm-gc-7.0:=[threads?]
 	dev-libs/gmp:=
 	virtual/libffi
 	dev-libs/libltdl:=

--- a/dev-scheme/guile/guile-2.0.14-r3.ebuild
+++ b/dev-scheme/guile/guile-2.0.14-r3.ebuild
@@ -16,7 +16,7 @@ IUSE="debug debug-malloc +deprecated +networking +nls +regex +threads" # upstrea
 REQUIRED_USE="regex"
 
 RDEPEND="
-	>=dev-libs/boehm-gc-7.0[threads?]
+	>=dev-libs/boehm-gc-7.0:=[threads?]
 	dev-libs/gmp:=
 	virtual/libffi
 	dev-libs/libltdl:=

--- a/dev-scheme/guile/guile-2.2.3.ebuild
+++ b/dev-scheme/guile/guile-2.2.3.ebuild
@@ -16,7 +16,7 @@ IUSE="debug debug-malloc +deprecated +networking +nls +regex +threads" # upstrea
 REQUIRED_USE="regex"
 
 RDEPEND="
-	>=dev-libs/boehm-gc-7.0[threads?]
+	>=dev-libs/boehm-gc-7.0:=[threads?]
 	dev-libs/gmp:=
 	virtual/libffi
 	dev-libs/libltdl:=


### PR DESCRIPTION
Latest boehm-gc bump (commit bcd5d8dafb7c0369084f6a578c569ee704d6a3fd) changed .so version and got a new sub-slot. We should reflect that in guile ebuilds in order to trigger automatic rebuild instead of relying on preserve-libs feature.