### PR TITLE
net-p2p/rtorrent: Update init.d script to use correct PID

### DIFF
--- a/net-p2p/rtorrent/files/rtorrentd.init
+++ b/net-p2p/rtorrent/files/rtorrentd.init
@@ -22,7 +22,8 @@ start() {
 			--name rtorrent \
 			--exec /usr/bin/screen -- -D -m -S rtorrentd /usr/bin/rtorrent
 	# Because we've daemonized with screen, we need to replace the PID file with the real PID of rtorrent
-	pgrep -P $(cat /var/run/rtorrentd.pid) > /var/run/rtorrentd.pid
+	# Sleep before we begin, to give s-s-d the chance to create the PID file
+	sleep .1 && pgrep -P $(cat /var/run/rtorrentd.pid) > /var/run/rtorrentd.pid
 	eend $?
 }
 


### PR DESCRIPTION
Overwrites the start-stop-daemon created PID file with the child PID
obtained by searching for children of screen.

Closes: https://bugs.gentoo.org/634852
Package-Manager: Portage-2.3.13, Repoman-2.3.3