### PR TITLE
Fixed luajit USE for Prefix and 17.1 profiles.

### DIFF
--- a/x11-wm/awesome/awesome-4.2.ebuild
+++ b/x11-wm/awesome/awesome-4.2.ebuild
@@ -61,8 +61,8 @@ src_configure() {
 		-DWITH_GENERATE_DOC=$(usex doc $(usex doc) n)
 	)
 	if use luajit; then
-		mycmakeargs+=('-DLUA_INCLUDE_DIR=/usr/include/luajit-2.0')
-		mycmakeargs+=('-DLUA_LIBRARY=/usr/lib/libluajit-5.1.so')
+		mycmakeargs+=('-DLUA_INCLUDE_DIR=${EPREFIX}/usr/include/luajit-2.0')
+		mycmakeargs+=("-DLUA_LIBRARY=${EPREFIX}/usr/$(get_libdir)/libluajit-5.1.so")
 	fi
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
The new 17.1 profiles have lib contain the 32 bit libraries and lib64 contain the 64 bit ones. As such on 17.1 systems libluajit-5.1.so is in /usr/lib64.

Additionally, on prefix systems the luajit includes and library will be in $EPREFIX.