### PR TITLE
x11-misc/lightdm-gtk-greeter: add missing eutils

### DIFF
--- a/x11-misc/lightdm-gtk-greeter/lightdm-gtk-greeter-2.0.1-r1.ebuild
+++ b/x11-misc/lightdm-gtk-greeter/lightdm-gtk-greeter-2.0.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=4
 
-inherit versionator
+inherit versionator eutils
 
 DESCRIPTION="LightDM GTK+ Greeter"
 HOMEPAGE="https://launchpad.net/lightdm-gtk-greeter"


### PR DESCRIPTION
lightdm-gtk-greeter-2.0.1-r1 (latest stable) fails to compile with gcc-6 because the patch is not applied:
`/var/tmp/portage/x11-misc/lightdm-gtk-greeter-2.0.1-r1/temp/environment: line 457: epatch: command not found`
This patch adds the missing inherit of eutils eclass.