### PR TITLE
sys-cluster/keepalived: fix segfault when no sorry server is configured

### DIFF
--- a/sys-cluster/keepalived/files/keepalived-1.4.0-fix-no-sorry-segfault.patch
+++ b/sys-cluster/keepalived/files/keepalived-1.4.0-fix-no-sorry-segfault.patch
@@ -1,0 +1,28 @@
+From 49559856e19a1a9fad590cc640da7df57c6b9a66 Mon Sep 17 00:00:00 2001
+From: Quentin Armitage <quentin@armitage.org.uk>
+Date: Wed, 17 Jan 2018 12:08:07 +0000
+Subject: [PATCH] Fix segfault if no sorry server configured for a virtual
+ server
+
+Issue #751 identified a segfault in vs_end_handler(), and it
+transpires that the forwarding method of the sorry server was being
+checked without first testing that a sorry server had been configured.
+
+Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>
+---
+ keepalived/check/check_parser.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/keepalived/check/check_parser.c b/keepalived/check/check_parser.c
+index b2518da7..170e47d4 100644
+--- a/keepalived/check/check_parser.c
++++ b/keepalived/check/check_parser.c
+@@ -120,7 +120,7 @@ vs_end_handler(void)
+ 
+ 	/* If the real (sorry) server uses tunnel forwarding, the address family
+ 	 * does not have to match the address family of the virtaul server */
+-	if (vs->s_svr->forwarding_method != IP_VS_CONN_F_TUNNEL) {
++	if (vs->s_svr && vs->s_svr->forwarding_method != IP_VS_CONN_F_TUNNEL) {
+ 		if (vs->af == AF_UNSPEC)
+ 			vs->af = vs->s_svr->addr.ss_family;
+ 		else if (vs->af != vs->s_svr->addr.ss_family) {

--- a/sys-cluster/keepalived/keepalived-1.4.0-r1.ebuild
+++ b/sys-cluster/keepalived/keepalived-1.4.0-r1.ebuild
@@ -25,12 +25,19 @@ RDEPEND="dev-libs/libnl:=
 DEPEND="${RDEPEND}
 	>=sys-kernel/linux-headers-4.4"
 
-DOCS=( README CONTRIBUTORS INSTALL ChangeLog AUTHOR TODO
-	doc/keepalived.conf.SYNOPSIS doc/NOTE_vrrp_vmac.txt )
+DOCS=(
+	README CONTRIBUTORS INSTALL ChangeLog AUTHOR TODO
+	doc/keepalived.conf.SYNOPSIS doc/NOTE_vrrp_vmac.txt
+)
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-no-sorry-segfault.patch"
+)
 
 src_prepare() {
-	eautoreconf
 	default
+
+	eautoreconf
 }
 
 src_configure() {
@@ -60,7 +67,7 @@ src_install() {
 	newdoc INSTALL INSTALL+HOWTO
 
 	# Security risk to bundle SSL certs
-	rm -f "${ED}"/etc/keepalived/samples/*.pem
+	rm -v "${ED}"/etc/keepalived/samples/*.pem || die
 	# Clean up sysvinit files
-	rm -rf "${ED}"/etc/sysconfig "${ED}"/etc/rc.d/
+	rm -rv "${ED}"/etc/sysconfig || die
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/643992
Package-Manager: Portage-2.3.19, Repoman-2.3.6