### PR TITLE
Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y

### DIFF
--- a/eclass/kernel-2.eclass
+++ b/eclass/kernel-2.eclass
@@ -606,6 +606,7 @@ if [[ ${ETYPE} == sources ]]; then
 		sys-devel/make
 		dev-lang/perl
 		sys-devel/bc
+		virtual/libelf
 	)"
 
 	SLOT="${PVR}"


### PR DESCRIPTION
New 4.14 kernel is using CONFIG_UNWINDER_ORC=y by default
but having USE="minimal" is removing virtual/libelf,
this is breaking the Kernel compilation.