### PR TITLE
sys-cluster/kube-apiserver: Checkpath for --cert-dir and suggest --etcd-servers

### DIFF
--- a/sys-cluster/kube-apiserver/files/kube-apiserver.confd
+++ b/sys-cluster/kube-apiserver/files/kube-apiserver.confd
@@ -4,4 +4,4 @@
 # The following values are used to configure the kube-apiserver
 #
 
-command_args=""
+command_args="--etcd-servers=http://127.0.0.1:4001"

--- a/sys-cluster/kube-apiserver/files/kube-apiserver.initd
+++ b/sys-cluster/kube-apiserver/files/kube-apiserver.initd
@@ -4,11 +4,12 @@
 
 description="Kubernetes API Server"
 pidfile=${pidfile:-"/run/${RC_SVCNAME}.pid"}
+certdir=${certdir:-"/run/${RC_SVCNAME}"}
 user=${user:-${RC_SVCNAME}}
 group=${group:-${RC_SVCNAME}}
 
 command="/usr/bin/kube-apiserver"
-command_args="${command_args}"
+command_args="--cert-dir=${certdir} ${command_args}"
 command_background="true"
 start_stop_daemon_args="--user ${user} --group ${group} \
 	--stdout /var/log/${RC_SVCNAME}/${RC_SVCNAME}.log \
@@ -16,4 +17,8 @@ start_stop_daemon_args="--user ${user} --group ${group} \
 
 depend() {
 	after net
+}
+
+start_pre() {
+	checkpath -d -o "${user}:${group}" -m 0770 "${certdir}"
 }


### PR DESCRIPTION
This gets kube-apiserver running out of the box, avoiding:

    error creating self-signed certificates: mkdir /var/run/kubernetes: permission denied

and:

    --etcd-servers must be specified

Folks may need to override the defaults, but the `conf.d` file is where they'd go to do that anyway.  I can add a stub `certdir` entry there too if the `init.d` entry isn't discoverable enough.

Ping @mrueg.