### PR TITLE
x11-misc/gmrun: Add 0.9.2-r2 w/ gcc-6 pie patch

### DIFF
--- a/x11-misc/gmrun/files/gmrun-0.9.2-gcc6-pie.patch
+++ b/x11-misc/gmrun/files/gmrun-0.9.2-gcc6-pie.patch
@@ -1,0 +1,84 @@
+From 351d355835532dbea8430902977873e887dd1c12 Mon Sep 17 00:00:00 2001
+From: Lucian Poston <lucian.poston@gmail.com>
+Date: Wed, 6 Dec 2017 04:22:28 -0800
+Subject: [PATCH] fix segfault in gcc-6
+
+---
+ src/gtkcompletionline.cc | 27 +++++++++++++++------------
+ src/gtkcompletionline.h  |  2 +-
+ 2 files changed, 16 insertions(+), 13 deletions(-)
+
+diff --git a/src/gtkcompletionline.cc b/src/gtkcompletionline.cc
+index eb324b5..537fafb 100644
+--- a/src/gtkcompletionline.cc
++++ b/src/gtkcompletionline.cc
+@@ -77,22 +77,25 @@ static gboolean
+ on_key_press(GtkCompletionLine *cl, GdkEventKey *event, gpointer data);
+ 
+ /* get_type */
+-guint gtk_completion_line_get_type(void)
++GType gtk_completion_line_get_type(void)
+ {
+-  static guint type = 0;
++  static GType type = 0;
+   if (type == 0)
+   {
+-    GtkTypeInfo type_info =
++    static const GTypeInfo type_info =
+     {
+-      "GtkCompletionLine",
+-      sizeof(GtkCompletionLine),
+       sizeof(GtkCompletionLineClass),
+-      (GtkClassInitFunc)gtk_completion_line_class_init,
+-      (GtkObjectInitFunc)gtk_completion_line_init,
+-      /*(GtkArgSetFunc)*/NULL /* reserved */,
+-      /*(GtkArgGetFunc)*/NULL /* reserved */
++      NULL,
++      NULL,
++      (GClassInitFunc)gtk_completion_line_class_init,
++      NULL,
++      NULL,
++      sizeof(GtkCompletionLine),
++      0,
++      (GInstanceInitFunc)gtk_completion_line_init,
++      NULL
+     };
+-    type = gtk_type_unique(gtk_entry_get_type(), &type_info);
++    type = g_type_register_static(GTK_TYPE_ENTRY, "GtkCompletionLine", &type_info, (GTypeFlags)0);
+   }
+   return type;
+ }
+@@ -114,7 +117,7 @@ gtk_completion_line_class_init(GtkCompletionLineClass *klass)
+ 
+   gtk_completion_line_signals[NOTUNIQUE] =
+     gtk_signal_new("notunique",
+-                   GTK_RUN_FIRST, G_TYPE_FROM_CLASS(object_class),
++                  GTK_RUN_FIRST, G_TYPE_FROM_CLASS(object_class),
+                    GTK_SIGNAL_OFFSET(GtkCompletionLineClass,
+                                      notunique),
+                    gtk_signal_default_marshaller, GTK_TYPE_NONE, 0);
+@@ -778,7 +781,7 @@ complete_line(GtkCompletionLine *object)
+ GtkWidget *
+ gtk_completion_line_new()
+ {
+-  return GTK_WIDGET(gtk_type_new(gtk_completion_line_get_type()));
++  return GTK_WIDGET(g_object_new(gtk_completion_line_get_type(), NULL));
+ }
+ 
+ static void
+diff --git a/src/gtkcompletionline.h b/src/gtkcompletionline.h
+index 5e14cd7..0d7f2dc 100644
+--- a/src/gtkcompletionline.h
++++ b/src/gtkcompletionline.h
+@@ -76,7 +76,7 @@ extern "C++" {
+     void (* cancel)(GtkCompletionLine *cl);
+   };
+ 
+-  guint gtk_completion_line_get_type(void);
++  GType gtk_completion_line_get_type(void);
+   GtkWidget *gtk_completion_line_new();
+ 
+   void gtk_completion_line_last_history_item(GtkCompletionLine*);
+-- 
+2.13.6
+

--- a/x11-misc/gmrun/gmrun-0.9.2-r2.ebuild
+++ b/x11-misc/gmrun/gmrun-0.9.2-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit autotools
+
+DESCRIPTION="A GTK-2 based launcher box with bash style auto completion!"
+HOMEPAGE="https://sourceforge.net/projects/gmrun/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-1"
+SLOT="0"
+KEYWORDS="~amd64 ~mips ~ppc ~x86"
+
+RDEPEND="
+	dev-libs/glib:2
+	dev-libs/popt
+	x11-libs/gtk+:2
+"
+DEPEND="
+	${RDEPEND}
+	elibc_glibc? ( >=sys-libs/glibc-2.10 )
+	sys-apps/sed
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	eapply \
+		"${FILESDIR}"/${P}-gcc43.patch \
+		"${FILESDIR}"/${P}-gcc6-pie.patch \
+		"${FILESDIR}"/${P}-sysconfdir.patch \
+		"${FILESDIR}"/${P}-glibc210.patch \
+		"${FILESDIR}"/${P}-stlport.patch
+
+	eapply_user
+	eautoreconf
+}


### PR DESCRIPTION
r2 is updated to eapi 6 and includes the patch to fix https://bugs.gentoo.org/640018