### PR TITLE
net-libs/serf: fix scons3/python3 support

### DIFF
--- a/net-libs/serf/files/serf-1.3.9-fix-scons3-py3-build.patch
+++ b/net-libs/serf/files/serf-1.3.9-fix-scons3-py3-build.patch
@@ -1,0 +1,63 @@
+
+calling "print" as statement causes SyntaxError when SCons 3
+is installed, due to the use of python3's print function by
+said version of SCons.
+
+This change reformats print to be compatible both with py3
+and py2.
+
+Signed-off-by: Leonardo Sandoval <leonardo.sandoval.gonzalez@linux.intel.com>
+Signed-off-by: Jose Lamego <jose.a.lamego@linux.intel.com>
+---
+ SConstruct     | 2 +-
+ build/check.py | 8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/build/check.py b/build/check.py
+index 2dacb4c..11ba839 100755
+--- a/build/check.py
++++ b/build/check.py
+@@ -52,16 +52,16 @@ if __name__ == '__main__':
+ 
+   # Find test responses and run them one by one
+   for case in glob.glob(testdir + "/testcases/*.response"):
+-    print "== Testing %s ==" % (case)
++    print("== Testing %s ==" % (case))
+     try:
+       subprocess.check_call([SERF_RESPONSE_EXE, case])
+     except subprocess.CalledProcessError:
+-      print "ERROR: test case %s failed" % (case)
++      print("ERROR: test case %s failed" % (case))
+       sys.exit(1)
+ 
+-  print "== Running the unit tests =="
++  print("== Running the unit tests ==")
+   try:
+     subprocess.check_call(TEST_ALL_EXE)
+   except subprocess.CalledProcessError:
+-    print "ERROR: test(s) failed in test_all"
++    print("ERROR: test(s) failed in test_all")
+     sys.exit(1)
+-- 
+2.7.4
+
+--- serf/SConstruct	2017/09/21 08:55:11	1809132
++++ serf/SConstruct	2017/11/08 17:05:28	1814604
+@@ -182,7 +182,7 @@
+ match = re.search('SERF_MAJOR_VERSION ([0-9]+).*'
+                   'SERF_MINOR_VERSION ([0-9]+).*'
+                   'SERF_PATCH_VERSION ([0-9]+)',
+-                  env.File('serf.h').get_contents(),
++                  env.File('serf.h').get_contents().decode('utf-8'),
+                   re.DOTALL)
+ MAJOR, MINOR, PATCH = [int(x) for x in match.groups()]
+ env.Append(MAJOR=str(MAJOR))
+@@ -199,7 +199,7 @@
+ 
+ unknown = opts.UnknownVariables()
+ if unknown:
+-  print 'Warning: Used unknown variables:', ', '.join(unknown.keys())
++  print('Warning: Used unknown variables:', ', '.join(unknown.keys()))
+ 
+ apr = str(env['APR'])
+ apu = str(env['APU'])

--- a/net-libs/serf/serf-1.3.9-r1.ebuild
+++ b/net-libs/serf/serf-1.3.9-r1.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+PYTHON_COMPAT=(python2_7 python3_{4,5,6})
+
+inherit eutils flag-o-matic python-any-r1 scons-utils toolchain-funcs
+
+DESCRIPTION="HTTP client library"
+HOMEPAGE="https://serf.apache.org/"
+SRC_URI="mirror://apache/${PN}/${P}.tar.bz2"
+
+LICENSE="Apache-2.0"
+SLOT="1"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
+IUSE="kerberos static-libs libressl"
+
+RDEPEND="dev-libs/apr:1=
+	dev-libs/apr-util:1=
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
+	sys-libs/zlib:0=
+	kerberos? ( virtual/krb5 )"
+DEPEND="${RDEPEND}
+	>=dev-util/scons-2.3.0[${PYTHON_USEDEP}]"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.3.8-static-lib.patch"
+	"${FILESDIR}/${PN}-1.3.8-openssl.patch"
+	"${FILESDIR}/${PN}-1.3.9-fix-scons3-py3-build.patch"
+)
+
+src_prepare() {
+	sed -e "/env.Append(CCFLAGS=\['-O2'\])/d" -i SConstruct
+
+	default
+}
+
+src_configure() {
+	# need limits.h for PATH_MAX (only when EXTENSIONS is enabled)
+	[[ ${CHOST} == *-solaris* ]] && append-cppflags -D__EXTENSIONS__
+}
+
+src_compile() {
+	myesconsargs=(
+		PREFIX="${EPREFIX}/usr"
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+		# These config scripts are sent through a shell with an empty env
+		# which breaks the SYSROOT usage in them.  Set the vars inline to
+		# avoid that.
+		APR="SYSROOT='${SYSROOT}' ${SYSROOT}${EPREFIX}/usr/bin/apr-1-config"
+		APU="SYSROOT='${SYSROOT}' ${SYSROOT}${EPREFIX}/usr/bin/apu-1-config"
+		BUILD_STATIC=$(usex static-libs)
+		AR="$(tc-getAR)"
+		RANLIB="$(tc-getRANLIB)"
+		CC="$(tc-getCC)"
+		CPPFLAGS="${CPPFLAGS}"
+		CFLAGS="${CFLAGS}"
+		LINKFLAGS="${LDFLAGS}"
+	)
+
+	if use kerberos; then
+		myesconsargs+=( GSSAPI="${SYSROOT}${EPREFIX}/usr/bin/krb5-config" )
+	fi
+
+	escons
+}
+
+src_test() {
+	escons check
+}
+
+src_install() {
+	escons install --install-sandbox="${D}"
+}


### PR DESCRIPTION
bump EAPI to 6

add support for SCons3 + Python3 builds

Closes: https://bugs.gentoo.org/635874