### PR TITLE
dev-libs/device-atlas-api-c: remove stable keywords

### DIFF
--- a/dev-libs/device-atlas-api-c/device-atlas-api-c-2.1.2_p1.ebuild
+++ b/dev-libs/device-atlas-api-c/device-atlas-api-c-2.1.2_p1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="${MY_P}.tgz"
 
 LICENSE="all-rights-reserved"
 SLOT="0"
-KEYWORDS="amd64 ~arm ppc x86"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
 IUSE="doc examples"
 
 RDEPEND="dev-libs/libpcre[${MULTILIB_USEDEP}]"

--- a/dev-libs/device-atlas-api-c/device-atlas-api-c-2.1.ebuild
+++ b/dev-libs/device-atlas-api-c/device-atlas-api-c-2.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="${MY_P}.zip"
 
 LICENSE="all-rights-reserved"
 SLOT="0"
-KEYWORDS="amd64 arm ppc x86"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
 IUSE="doc examples"
 
 RDEPEND="dev-libs/libpcre[${MULTILIB_USEDEP}]"

--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -4,6 +4,11 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in package.use.mask
 
+# Michał Górny <mgorny@gentoo.org> (20 Jan 2018)
+# Requires proprietary fetch-restricted package that is not suitable
+# for stabilization. Bug #645092.
+net-proxy/haproxy device-atlas
+
 # Andreas Sturmlechner <asturm@gentoo.org> (16 Jan 2018)
 # USE=wxwidgets Requires x11-libs/wxGTK:3.0-gtk3 stabilisation
 # USE=tcl does not build reliably, bug #624576


### PR DESCRIPTION
The stable versions can no longer be fetched, and this is going to be a perpetual problem.