### PR TITLE
net-misc/cfengine: find ifconfig(8) in /bin/

### DIFF
--- a/net-misc/cfengine/files/cfengine-3.6.2-ifconfig.patch
+++ b/net-misc/cfengine/files/cfengine-3.6.2-ifconfig.patch
@@ -5,7 +5,7 @@
      }
  #else
 -    if ((pp = cf_popen("/sbin/ifconfig -a", "r", true)) == NULL)
-+    if ((pp = cf_popen("/sbin/ifconfig -a", "r", true)) == NULL || (pp = cf_popen("/bin/ifconfig -a", "r", true)) == NULL)
++    if ((pp = cf_popen("/sbin/ifconfig -a", "r", true)) == NULL && (pp = cf_popen("/bin/ifconfig -a", "r", true)) == NULL)
      {
          Log(LOG_LEVEL_VERBOSE, "Could not find interface info");
          return;


### PR DESCRIPTION
The ebuild is applying a patch intending to look for ifconfig(8) in
/bin/ after not finding it in /sbin/.  The patch is obviosly wrong,
though, and is instead requiring ifconfig to be found in *both*
locations.

Bug: http://bugs.gentoo.org/645106