### PR TITLE
net-p2p/rtorrent: Fix init script to ensure PID file is created

### DIFF
--- a/net-p2p/rtorrent/files/rtorrentd.init
+++ b/net-p2p/rtorrent/files/rtorrentd.init
@@ -21,13 +21,14 @@ start() {
 			--env HOME="${PWHOME:-/home/$USER}" \
 			--name rtorrent \
 			--exec /usr/bin/screen -- -D -m -S rtorrentd /usr/bin/rtorrent
-	# Because we've daemonized with screen, we need to replace the PID file with the real PID of rtorrent
-	pgrep -P $(cat /var/run/rtorrentd.pid) > /var/run/rtorrentd.pid
 	eend $?
 }
 
 stop() {
 	ebegin "Stopping rtorrent"
+	# Because we've daemonized with screen, we need to replace the PID file with the real PID of rtorrent
+	pgrep -P $(cat /var/run/rtorrentd.pid) > /var/run/rtorrentd.pid
+
 	start-stop-daemon --stop --signal 15 \
 			--pidfile /var/run/rtorrentd.pid
 	eend $?


### PR DESCRIPTION
This helps ensure start-stop-daemon has had time to create the PID file
before we attempt to read it back again.

Closes: https://bugs.gentoo.org/634852

Package-Manager: Portage-2.3.19, Repoman-2.3.6