### PR TITLE
media-gfx/gpicview: update GTK+ icon cache and xdg desktop database

### DIFF
--- a/media-gfx/gpicview/gpicview-0.2.5-r1.ebuild
+++ b/media-gfx/gpicview/gpicview-0.2.5-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit gnome2-utils xdg-utils
+
+DESCRIPTION="A Simple and Fast Image Viewer for X"
+HOMEPAGE="http://lxde.sourceforge.net/gpicview"
+SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ppc ~x86 ~arm-linux ~x86-linux"
+
+RDEPEND="virtual/jpeg:0
+	>=x11-libs/gtk+-2.6:2"
+DEPEND="${RDEPEND}
+	>=dev-util/intltool-0.40
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+}


### PR DESCRIPTION
* fix QA warnings