### PR TITLE
dev-libs/dotconf: Bump to EAPI=6

### DIFF
--- a/dev-libs/dotconf/dotconf-1.3-r1.ebuild
+++ b/dev-libs/dotconf/dotconf-1.3-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit toolchain-funcs
+
+DESCRIPTION="dot.conf configuration file parser"
+HOMEPAGE="https://github.com/williamh/dotconf"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE=""
+
+DEPEND=">=sys-devel/autoconf-2.58"
+RDEPEND=""
+
+src_compile() {
+	emake CC=$(tc-getCC)
+}
+
+pkg_postinst() {
+	ewarn 'This version requires that you run revdep-rebuild after'
+	ewarn 'the upgrade.'
+}


### PR DESCRIPTION
  repo.eapi.deprecated          1
   dev-libs/dotconf/dotconf-1.3.ebuild: 3

Bug: https://bugs.gentoo.org/642274
Package-Manager: Portage-2.3.19, Repoman-2.3.6