### PR TITLE
dev-ruby/net-scp: add ruby version 2.4

### DIFF
--- a/dev-ruby/net-scp/files/net-scp-1.2.1-fix-common.path
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-fix-common.path
@@ -1,0 +1,28 @@
+--- test/common.rb	2018-01-21 16:23:07.384173147 +0100
++++ test/common.rb	2018-01-21 16:20:34.084172782 +0100
+@@ -1,11 +1,11 @@
+ require 'test/unit'
+ require 'mocha/setup'
+ 
+-begin
+-  gem 'net-ssh', ">= 2.0.0"
+-  require 'net/ssh'
+-rescue LoadError
+-  $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../../net-ssh/lib"
++#begin
++#  #gem 'net-ssh', ">= 2.0.0"
++#  require 'net/ssh'
++#rescue LoadError
++#  $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../../net-ssh/lib"
+ 
+   begin
+     require 'net/ssh'
+@@ -14,7 +14,7 @@
+   rescue LoadError => e
+     abort "could not load net/ssh v2 (#{e.inspect})"
+   end
+-end
++#end
+ 
+ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib"
+ 

--- a/dev-ruby/net-scp/files/net-scp-1.2.1-fix-download_test.patch
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-fix-download_test.patch
@@ -1,0 +1,21 @@
+--- test/test_download.rb	2018-01-22 02:08:00.000013728 +0100
++++ test/test_download.rb.1	2018-01-22 02:11:49.820014276 +0100
+@@ -70,12 +70,12 @@
+     end
+ 
+     error = nil
+-    assert_scripted do
+-      begin
+-        scp.download!("/path/to/remote.txt")
+-      rescue
+-        error = $!
+-      end
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++    begin
++      scp.download!("/path/to/remote.txt")
++    rescue
++      error = $!
++    end
+     end
+     assert_equal Net::SCP::Error, error.class
+     assert_equal "SCP did not finish successfully (1): File not found: /path/to/remote.txt\n", error.message

--- a/dev-ruby/net-scp/files/net-scp-1.2.1-fix-download_test_2.patch
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-fix-download_test_2.patch
@@ -1,0 +1,25 @@
+--- test/test_download.rb	2018-01-22 02:26:56.440016436 +0100
++++ test/test_download.rb	2018-01-22 02:32:46.076017270 +0100
+@@ -116,7 +116,9 @@
+ 
+   def test_download_io_with_recursive_should_raise_error
+     expect_scp_session "-f -r /path/to/remote.txt"
+-    assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", StringIO.new, :recursive => true) }
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", StringIO.new, :recursive => true) }
++    end
+   end
+ 
+   def test_download_io_with_preserve_should_ignore_preserve
+@@ -154,8 +156,9 @@
+       channel.sends_ok
+       channel.gets_data "D0755 0 remote\n"
+     end
+-
+-    assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote") }
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote") }
++    end
+   end
+ 
+   def test_download_should_raise_error_if_gets_not_ok

--- a/dev-ruby/net-scp/files/net-scp-1.2.1-fix-download_test_3.patch
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-fix-download_test_3.patch
@@ -1,0 +1,15 @@
+--- test/test_download.rb	2018-01-22 02:35:45.200017696 +0100
++++ test/test_download.rb.1	2018-01-22 02:38:40.000018113 +0100
+@@ -217,8 +217,10 @@
+       channel.gets_data "E\n"
+       channel.sends_ok
+     end
+-
+-    scp.download!("/path/to/remote", "/path/to/local", :recursive => true, :ssh => { :verbose => :debug })
++    
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      scp.download!("/path/to/remote", "/path/to/local", :recursive => true, :ssh => { :verbose => :debug })
++    end
+     assert_equal "a" * 1234, file.io.string
+   end
+ 

--- a/dev-ruby/net-scp/files/net-scp-1.2.1-fix-upload_tests.patch
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-fix-upload_tests.patch
@@ -1,0 +1,14 @@
+--- test/test_upload.rb	2018-01-22 08:15:30.996002204 +0100
++++ test/test_upload.rb.1	2018-01-22 08:18:09.328002581 +0100
+@@ -155,8 +155,9 @@
+     expect_scp_session("-t /path/to/remote") do |channel|
+       channel.gets_ok
+     end
+-
+-    assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local", "/path/to/remote") }
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local", "/path/to/remote") }
++    end
+   end
+ 
+   def test_upload_empty_directory_should_create_directory_and_finish

--- a/dev-ruby/net-scp/files/net-scp-1.2.1-raise-correct-errors-net-ssh-4.0-compat.patch
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-raise-correct-errors-net-ssh-4.0-compat.patch
@@ -1,0 +1,30 @@
+--- test/test_download.rb	2018-01-22 01:47:38.932010818 +0100
++++ test/test_download.rb.1	2018-01-22 01:49:14.552011046 +0100
+@@ -205,9 +205,11 @@
+       channel.sends_ok
+       channel.gets_data "\1"
+     end
+-
+-    e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", "/path/to/local.txt") }
+-    assert_equal("\1", e.message)
++    
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", "/path/to/local.txt") }
++      assert_equal("\1", e.message)
++    end
+   end
+ 
+   def test_download_directory_should_raise_error_if_local_exists_and_is_not_directory
+@@ -223,8 +225,10 @@
+       channel.sends_ok
+     end
+     
+-    e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote", "/path/to/local", :recursive => true) }
+-    assert_match(/exists and is not a directory/, e.message)
++    Net::SSH::Test::Extensions::IO.with_test_extension do
++      e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote", "/path/to/local", :recursive => true) }
++      assert_match(/exists and is not a directory/, e.message)
++    end
+   end
+ 
+   def test_download_directory_should_create_directory_and_files_locally

--- a/dev-ruby/net-scp/files/net-scp-1.2.1-raise-correct-errors.patch
+++ b/dev-ruby/net-scp/files/net-scp-1.2.1-raise-correct-errors.patch
@@ -1,0 +1,80 @@
+--- README.rdoc
++++ README.rdoc
+@@ -42,7 +42,7 @@ In a nutshell:
+   data = Net::SCP::download!("remote.host.com", "username", "/remote/path")
+ 
+   # use a persistent connection to transfer files
+-  Net::SCP.start("remote.host.com", "username", :ssh => { :password => "password" }) do |scp|
++  Net::SCP.start("remote.host.com", "username", :password => "password") do |scp|
+     # upload a file to a remote server
+     scp.upload! "/local/path", "/remote/path"
+ 
+--- lib/net/scp.rb
++++ lib/net/scp.rb
+@@ -395,7 +395,7 @@ module Net
+       def await_response_state(channel)
+         return if channel[:buffer].available == 0
+         c = channel[:buffer].read_byte
+-        raise "#{c.chr}#{channel[:buffer].read}" if c != 0
++        raise Net::SCP::Error, "#{c.chr}#{channel[:buffer].read}" if c != 0
+         channel[:next], channel[:state] = nil, channel[:next]
+         send("#{channel[:state]}_state", channel)
+       end
+--- lib/net/scp/download.rb
++++ lib/net/scp/download.rb
+@@ -129,7 +129,7 @@ module Net; class SCP
+       channel[:local] = File.join(channel[:local], directive[:name])
+ 
+       if File.exists?(channel[:local]) && !File.directory?(channel[:local])
+-        raise "#{channel[:local]} already exists and is not a directory"
++        raise Net::SCP::Error, "#{channel[:local]} already exists and is not a directory"
+       elsif !File.exists?(channel[:local])
+         Dir.mkdir(channel[:local], directive[:mode] | 0700)
+       end
+@@ -162,4 +162,4 @@ module Net; class SCP
+     end
+   end
+ 
+-end; end
+\ No newline at end of file
++end; end
+--- test/test_download.rb
++++ test/test_download.rb
+@@ -158,6 +158,37 @@ class TestDownload < Net::SCP::TestCase
+     assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote") }
+   end
+ 
++  def test_download_should_raise_error_if_gets_not_ok
++    prepare_file("/path/to/local.txt", "")
++
++    expect_scp_session "-f /path/to/remote.txt" do |channel|
++      channel.sends_ok
++      channel.gets_data "C0666 0 remote.txt\n"
++      channel.sends_ok
++      channel.gets_data "\1"
++    end
++
++    e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", "/path/to/local.txt") }
++    assert_equal("\1", e.message)
++  end
++
++  def test_download_directory_should_raise_error_if_local_exists_and_is_not_directory
++    File.stubs(:exists?).with("/path/to/local").returns(true)
++    File.stubs(:exists?).with("/path/to/local/remote").returns(true)
++    File.stubs(:directory?).with("/path/to/local/remote").returns(false)
++
++    expect_scp_session "-f -r /path/to/remote" do |channel|
++      channel.sends_ok
++      channel.gets_data "D0755 0 remote\n"
++      channel.sends_ok
++      channel.gets_data "E\n"
++      channel.sends_ok
++    end
++    
++    e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote", "/path/to/local", :recursive => true) }
++    assert_match(/exists and is not a directory/, e.message)
++  end
++
+   def test_download_directory_should_create_directory_and_files_locally
+     file = nil
+     prepare_directory "/path/to/local" do |dir|

--- a/dev-ruby/net-scp/net-scp-1.2.1-r1.ebuild
+++ b/dev-ruby/net-scp/net-scp-1.2.1-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+USE_RUBY="ruby23 ruby24"
+
+RUBY_FAKEGEM_EXTRADOC="CHANGES.txt README.rdoc"
+
+RUBY_FAKEGEM_TASK_TEST=""
+
+inherit ruby-fakegem
+
+DESCRIPTION="A pure Ruby implementation of the SCP client protocol"
+HOMEPAGE="https://github.com/net-ssh/net-scp"
+
+LICENSE="GPL-2"
+SLOT="4"
+KEYWORDS="~amd64"
+IUSE=""
+
+RUBY_PATCHES=(
+	${P}-raise-correct-errors.patch
+	${P}-fix-common.path
+	${P}-fix-download_test.patch
+	${P}-fix-download_test_2.patch
+	${P}-fix-download_test_3.patch
+	${P}-fix-upload_tests.patch
+	${P}-raise-correct-errors-net-ssh-4.0-compat.patch
+	)
+
+ruby_add_bdepend "
+	doc? ( >=dev-ruby/net-ssh-4.0:4 )
+	test? (
+		>=dev-ruby/net-ssh-4.0:4
+		dev-ruby/mocha
+	)"
+
+ruby_add_rdepend ">=dev-ruby/net-ssh-4.0:4"
+
+all_ruby_prepare() {
+	sed -i -e 's/>= 2.0.0/~> 2.0/' test/common.rb || die
+}
+
+each_ruby_test() {
+	${RUBY} -Ilib:test test/test_all.rb || die
+}


### PR DESCRIPTION
 This ebuild also corrects the tests to pass
 with net-ssh-4.0 or later.

 The patches are taken from

 https://anonscm.debian.org/cgit/pkg-ruby-extras/ruby-net-sftp.git/

 And from git commits following version 1.2.1 in upstream.

Bug: https://bugs.gentoo.org/643990
Package-Manager: Portage-2.3.19, Repoman-2.3.6
