### PR TITLE
lxqt-base: remove missing 'qt5' use flag from dependencies

### DIFF
--- a/lxqt-base/lxqt-policykit/lxqt-policykit-0.11.0-r1.ebuild
+++ b/lxqt-base/lxqt-policykit/lxqt-policykit-0.11.0-r1.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	dev-qt/qtxml:5
 	~lxqt-base/liblxqt-${PV}
 	>=dev-libs/libqtxdg-1.0.0
-	sys-auth/polkit-qt[qt5(+)]"
+	>=sys-auth/polkit-qt-0.112.0_p20160416-r1"
 DEPEND="${RDEPEND}
 	dev-qt/linguist-tools:5
 	virtual/pkgconfig"

--- a/lxqt-base/lxqt-qtplugin/lxqt-qtplugin-0.11.0-r1.ebuild
+++ b/lxqt-base/lxqt-qtplugin/lxqt-qtplugin-0.11.0-r1.ebuild
@@ -19,7 +19,7 @@ LICENSE="LGPL-2.1+"
 SLOT="0"
 
 RDEPEND="
-	dev-libs/libdbusmenu-qt[qt5(+)]
+	>=dev-libs/libdbusmenu-qt-0.9.3_pre20160218-r1
 	>=dev-libs/libqtxdg-2.0.0
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5


### PR DESCRIPTION
```text
Some time ago the following ebuilds removed 'qt5' use flag in favor of
making Qt5 build the default behavior:

 - dev-libs/libdbusmenu-qt (since 0.9.3_pre20160218-r1)
 - sys-auth/polkit-qt      (since 0.112.0_p20160416-r1)

However, this flag was still referenced in lxqt-policykit-0.11.0.ebuild
and lxqt-qtplugin-0.11.0.ebuild, which resulted in an unsolvable dependency
graph when updating lxqt.
```
### P. S.

I hope I did the right thing to resolve the situation, but I'm still a newbie. Someone, please check.