### PR TITLE
dev-python/pipenv: fix outdated dependency version

### DIFF
--- a/dev-python/pipenv/pipenv-9.0.0-r1.ebuild
+++ b/dev-python/pipenv/pipenv-9.0.0-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} )
+
+inherit distutils-r1
+
+DESCRIPTION="Python Development Workflow for Humans"
+HOMEPAGE="https://github.com/pypa/pipenv https://pypi.python.org/pypi/pipenv"
+SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="test"
+
+DEPEND="
+	>=dev-python/flake8-3.0.0[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	>=dev-python/pew-0.1.26[${PYTHON_USEDEP}]
+	>=dev-python/pip-9.0.1[${PYTHON_USEDEP}]
+	>dev-python/requests-2.18.0[${PYTHON_USEDEP}]
+	>=dev-python/urllib3-1.21.1[${PYTHON_USEDEP}]
+	test? (
+		dev-python/flake8[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+	)"
+
+# not completely packed
+# requires networking
+RESTRICT="test"
+
+python_test() {
+	py.test -v -v || die
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/645530
Package-Manager: Portage-2.3.19, Repoman-2.3.6