### PR TITLE
sys-apps/portage: Add USE=rsync-verify

### DIFF
--- a/app-portage/gemato/gemato-10.2-r1.ebuild
+++ b/app-portage/gemato/gemato-10.2-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
 LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="+blake2 bzip2 +gpg lzma +portage-postsync sha3 test"
+IUSE="+blake2 bzip2 +gpg lzma sha3 test"
 
 MODULE_RDEPEND="
 	blake2? ( $(python_gen_cond_dep 'dev-python/pyblake2[${PYTHON_USEDEP}]' python{2_7,3_4,3_5} pypy{,3}) )
@@ -24,20 +24,10 @@ MODULE_RDEPEND="
 	sha3? ( $(python_gen_cond_dep 'dev-python/pysha3[${PYTHON_USEDEP}]' python{2_7,3_4,3_5} pypy{,3}) )"
 
 RDEPEND="${MODULE_RDEPEND}
-	dev-python/setuptools[${PYTHON_USEDEP}]
-	portage-postsync? ( app-crypt/gentoo-keys )"
+	dev-python/setuptools[${PYTHON_USEDEP}]"
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( ${MODULE_RDEPEND} )"
 
 python_test() {
 	esetup.py test
-}
-
-python_install_all() {
-	distutils-r1_python_install_all
-
-	if use portage-postsync; then
-		exeinto /etc/portage/repo.postsync.d
-		doexe utils/repo.postsync.d/00gemato
-	fi
 }

--- a/app-portage/gemato/gemato-9999.ebuild
+++ b/app-portage/gemato/gemato-9999.ebuild
@@ -16,7 +16,7 @@ EGIT_REPO_URI="https://github.com/mgorny/gemato.git"
 LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS=""
-IUSE="+blake2 bzip2 +gpg lzma +portage-postsync sha3 test"
+IUSE="+blake2 bzip2 +gpg lzma sha3 test"
 
 MODULE_RDEPEND="
 	blake2? ( $(python_gen_cond_dep 'dev-python/pyblake2[${PYTHON_USEDEP}]' python{2_7,3_4,3_5} pypy{,3}) )
@@ -26,20 +26,10 @@ MODULE_RDEPEND="
 	sha3? ( $(python_gen_cond_dep 'dev-python/pysha3[${PYTHON_USEDEP}]' python{2_7,3_4,3_5} pypy{,3}) )"
 
 RDEPEND="${MODULE_RDEPEND}
-	dev-python/setuptools[${PYTHON_USEDEP}]
-	portage-postsync? ( app-crypt/gentoo-keys )"
+	dev-python/setuptools[${PYTHON_USEDEP}]"
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( ${MODULE_RDEPEND} )"
 
 python_test() {
 	esetup.py test
-}
-
-python_install_all() {
-	distutils-r1_python_install_all
-
-	if use portage-postsync; then
-		exeinto /etc/portage/repo.postsync.d
-		doexe utils/repo.postsync.d/00gemato
-	fi
 }

--- a/sys-apps/portage/metadata.xml
+++ b/sys-apps/portage/metadata.xml
@@ -20,6 +20,10 @@
         This should only be temporarily disabled for some bootstrapping
         operations.  Cross-compilation is not supported.
     </flag>
+    <flag name="rsync-verify">
+        Enable full-tree cryptographic verification of Gentoo repository
+        rsync checkouts using <pkg>app-portage/gemato</pkg>.
+    </flag>
     <flag name="xattr">Preserve extended attributes (filesystem-stored metadata)
         when installing files. Usually only required for hardened systems.
     </flag>


### PR DESCRIPTION
So here's the new version, using built-in Portage support that's just been pushed.