### PR TITLE
games-fps/redeclipse: revision bump, fix installation

### DIFF
--- a/games-fps/redeclipse/files/redeclipse
+++ b/games-fps/redeclipse/files/redeclipse
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# It is necessary to run the binary from the root of the data directory
+# for the binary to properly locate its assets and load properly.
+# Upstream's original install procedure is doing the same thing.
+
+SERVER=/usr/bin/redeclipse_server_linux
+CLIENT=/usr/bin/redeclipse_linux
+cd /usr/share/redeclipse || exit 1
+[ "$0" = "redeclipse_server" ] && exec $SERVER || exec $CLIENT

--- a/games-fps/redeclipse/redeclipse-1.6.0-r1.ebuild
+++ b/games-fps/redeclipse/redeclipse-1.6.0-r1.ebuild
@@ -70,9 +70,13 @@ src_install() {
 	if ! use dedicated; then
 		dobin src/redeclipse_linux
 		newicon "src/install/nix/${PN}_x128.png" "${PN}.png"
-		make_desktop_entry "src/install/nix/${PN}.desktop"
+		domenu "src/install/nix/${PN}.desktop"
 		doman doc/man/redeclipse.6
 	fi
+
+	dobin "${FILESDIR}/redeclipse"
+	cd /usr/bin || die
+	dosym redeclipse redeclipse_server
 
 	doman doc/man/redeclipse-server.6
 	dodoc readme.txt doc/examples/servinit.cfg


### PR DESCRIPTION
This revision fixes the incorrect installation of the desktop file
entry, and provides a wrapper script to address the runtime problem
introduced by no longer using EAPI 5's games installation paths.

Package-Manager: Portage-2.3.19, Repoman-2.3.6