### PR TITLE
app-doc/diveintopython: remove invalid KEYWORDS

### DIFF
--- a/app-doc/diveintopython/diveintopython-2.ebuild
+++ b/app-doc/diveintopython/diveintopython-2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,14 +16,10 @@ pdf? ( http://www.diveintopython.net/download/${PN}-pdf-${MY_PV}.zip -> ${P}-pdf
 LICENSE="FDL-1.1"
 SLOT="2"
 
-KEYWORDS="*"
+KEYWORDS="amd64 ppc ppc64 x86"
 IUSE="pdf"
 
 S="${WORKDIR}/${MY_P}"
-
-src_prepare() {
-	default
-}
 
 src_install() {
 	insinto "/usr/share/doc/${PN}-${SLOT}"

--- a/app-doc/diveintopython/diveintopython-3.ebuild
+++ b/app-doc/diveintopython/diveintopython-3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,12 +13,8 @@ SRC_URI="https://dev.gentoo.org/~monsieurp/packages/${P}.tar.gz
 
 LICENSE="CC-BY-SA-3.0"
 SLOT="3"
-KEYWORDS="*"
+KEYWORDS="amd64 ppc ppc64 x86"
 IUSE="pdf"
-
-src_prepare() {
-	default
-}
 
 src_install() {
 	insinto "/usr/share/doc/${PN}-${SLOT}"


### PR DESCRIPTION
f1eae109927 updated `KEYWORDS` to `*`, but it's an invalid value based on the [PMS](https://projects.gentoo.org/pms/6/pms.html#x1-710007.3.2). It's supported by portage but isn't by paludis.

I've also added some cleanup, copyright bump which shouldn't change anything.