### PR TITLE
www-apps/redmine: Explicitly depending on <rack-2.0

### DIFF
--- a/www-apps/redmine/redmine-3.4.4.ebuild
+++ b/www-apps/redmine/redmine-3.4.4.ebuild
@@ -38,6 +38,7 @@ ruby_add_rdepend "
 	>=dev-ruby/rbpdf-1.19.2
 	>=dev-ruby/ruby-openid-2.3.0
 	dev-ruby/rubygems
+	<dev-ruby/rack-2.0.0:*
 	fastcgi? ( dev-ruby/fcgi )
 	imagemagick? ( >=dev-ruby/rmagick-2.14.0 )
 	ldap? ( >=dev-ruby/ruby-net-ldap-0.12.0 )


### PR DESCRIPTION
The solution that worked for me.

Bug: https://bugs.gentoo.org/645178
Package-Manager: Portage-2.3.19, Repoman-2.3.6