### PR TITLE
sys-devel/llvm: add symlinks use flag

### DIFF
--- a/sys-devel/llvm/llvm-6.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-6.0.9999.ebuild
@@ -35,7 +35,7 @@ LICENSE="UoI-NCSA rc BSD public-domain
 	llvm_targets_ARM? ( LLVM-Grant )"
 SLOT="$(ver_cut 1)"
 KEYWORDS=""
-IUSE="debug doc gold libedit +libffi ncurses test xar xml
+IUSE="debug doc gold libedit +libffi ncurses symlinks test xar xml
 	kernel_Darwin ${ALL_LLVM_TARGETS[*]}"
 RESTRICT="!test? ( test )"
 
@@ -45,6 +45,10 @@ RDEPEND="
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
 	libffi? ( >=virtual/libffi-3.0.13-r1:0=[${MULTILIB_USEDEP}] )
 	ncurses? ( >=sys-libs/ncurses-5.9-r3:0=[${MULTILIB_USEDEP}] )
+	symlinks? (
+		!sys-devel/binutils
+		!sys-devel/binutils-config
+	)
 	xar? ( app-arch/xar )
 	xml? ( dev-libs/libxml2:2=[${MULTILIB_USEDEP}] )"
 # configparser-3.2 breaks the build (3.3 or none at all are fine)
@@ -125,6 +129,11 @@ multilib_src_configure() {
 
 		# disable OCaml bindings (now in dev-ml/llvm-ocaml)
 		-DOCAMLFIND=NO
+	)
+
+	# create symlinks to locacations for binutils if wanted
+	use symlinks && mycmakeargs+=(
+		-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON
 	)
 
 #	Note: go bindings have no CMake rules at the moment

--- a/sys-devel/llvm/llvm-9999.ebuild
+++ b/sys-devel/llvm/llvm-9999.ebuild
@@ -37,7 +37,7 @@ LICENSE="UoI-NCSA rc BSD public-domain
 	llvm_targets_ARM? ( LLVM-Grant )"
 SLOT="7"
 KEYWORDS=""
-IUSE="debug doc gold libedit +libffi ncurses test xar xml
+IUSE="debug doc gold libedit +libffi ncurses symlinks test xar xml
 	kernel_Darwin ${ALL_LLVM_TARGETS[*]}"
 RESTRICT="!test? ( test )"
 
@@ -47,6 +47,10 @@ RDEPEND="
 	libedit? ( dev-libs/libedit:0=[${MULTILIB_USEDEP}] )
 	libffi? ( >=virtual/libffi-3.0.13-r1:0=[${MULTILIB_USEDEP}] )
 	ncurses? ( >=sys-libs/ncurses-5.9-r3:0=[${MULTILIB_USEDEP}] )
+	symlinks? (
+		!sys-devel/binutils
+		!sys-devel/binutils-config
+	)
 	xar? ( app-arch/xar )
 	xml? ( dev-libs/libxml2:2=[${MULTILIB_USEDEP}] )"
 # configparser-3.2 breaks the build (3.3 or none at all are fine)
@@ -130,6 +134,11 @@ multilib_src_configure() {
 
 		# disable OCaml bindings (now in dev-ml/llvm-ocaml)
 		-DOCAMLFIND=NO
+	)
+
+	# create symlinks to locacations for binutils if wanted
+	use symlinks && mycmakeargs+=(
+		-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON
 	)
 
 #	Note: go bindings have no CMake rules at the moment

--- a/sys-devel/llvm/metadata.xml
+++ b/sys-devel/llvm/metadata.xml
@@ -18,6 +18,7 @@
 		<flag name="lldb">Build the lldb debugger</flag>
 		<flag name="multitarget">Build all host targets (default: host only)</flag>
 		<flag name="ncurses">Support querying terminal properties using ncurses' terminfo</flag>
+		<flag name="symlinks">Create symlinks from llvm-binutils programs to their respective gnu-binutils programs</flag>
 		<flag name="sanitize">Build compiler-rt's sanitizers</flag>
 		<flag name="static-analyzer">Install the Clang static analyzer (requires USE=clang)</flag>
 		<flag name="xar">Support dumping LLVM bitcode sections in Mach-O files


### PR DESCRIPTION
the symlinks use flag will allow a user who does not have
sys-devel/binutils installed to still have access to programs such as
nm,ar,ranlib. LLVM provides programs such as llvm-nm,llvm-nm,and
llvm-ranlib, but these are nonstandard locations. this use flag symlinks
these respective programs to their standard locations.