### PR TITLE
dev-lang/rust: fix MAKEOPTS -l/--load-average build

### DIFF
--- a/dev-lang/rust/rust-1.23.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.23.0-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator toolchain-funcs
+inherit multiprocessing python-any-r1 versionator toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -119,7 +119,7 @@ src_configure() {
 }
 
 src_compile() {
-	./x.py build --verbose --config="${S}"/config.toml "${MAKEOPTS}" || die
+	./x.py build --verbose --config="${S}"/config.toml -j$(makeopts_jobs) || die
 }
 
 src_install() {


### PR DESCRIPTION
Upstream build system does not like -l/--load-average,
So we cannot use MAKEOPTS as-is. The only relevant option is -j<num>.
This commit changes to using multiprocessing.eclass makeopts_jobs()

Closes: https://bugs.gentoo.org/646092
Package-Manager: Portage-2.3.19, Repoman-2.3.6