### PR TITLE
dev-util/bats: Keyword unstable arm

### DIFF
--- a/dev-util/bats/bats-0.4.0_p20170219.ebuild
+++ b/dev-util/bats/bats-0.4.0_p20170219.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/sstephenson/bats/archive/${COMMITHASH}.tar.gz -> ${P
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm ~x86"
 
 S="${WORKDIR}/bats-${COMMITHASH}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/638450

Package-Manager: Portage-2.3.16, Repoman-2.3.6

Also see #6319 