### PR TITLE
app-emulation/qemu: Fix build with latest git:

### DIFF
--- a/app-emulation/qemu/files/qemu-2.11.9999-cflags.patch
+++ b/app-emulation/qemu/files/qemu-2.11.9999-cflags.patch
@@ -1,0 +1,24 @@
+--- a/configure	2018-02-01 22:51:53.068467555 +0000
++++ b/configure	2018-02-01 22:52:23.965041387 +0000
+@@ -5212,21 +5212,12 @@ fi
+ if test "$gcov" = "yes" ; then
+   CFLAGS="-fprofile-arcs -ftest-coverage -g $CFLAGS"
+   LDFLAGS="-fprofile-arcs -ftest-coverage $LDFLAGS"
+-elif test "$fortify_source" = "yes" ; then
+-  CFLAGS="-O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $CFLAGS"
+ elif test "$debug" = "yes"; then
+-  if compile_prog "-Og" ""; then
+-      CFLAGS="-Og $CFLAGS"
+-  elif compile_prog "-O1" ""; then
+-      CFLAGS="-O1 $CFLAGS"
+-  fi
+   # Workaround GCC false-positive Wuninitialized bugs with Og or O1:
+   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=24639
+   if cc_has_warning_flag "-Wno-maybe-uninitialized"; then
+       CFLAGS="-Wno-maybe-uninitialized $CFLAGS"
+   fi
+-else
+-    CFLAGS="-O2 $CFLAGS"
+ fi
+ 
+ ##########################################

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -34,13 +34,13 @@ IUSE="accessibility +aio alsa bluetooth bzip2 +caps +curl debug +fdt
 	spice ssh static static-user systemtap tci test usb usbredir vde
 	+vhost-net virgl virtfs +vnc vte xattr xen xfs"
 
-COMMON_TARGETS="aarch64 alpha arm cris i386 m68k microblaze microblazeel
+COMMON_TARGETS="aarch64 alpha arm cris hppa i386 m68k microblaze microblazeel
 	mips mips64 mips64el mipsel nios2 or1k ppc ppc64 s390x sh4 sh4eb sparc
 	sparc64 x86_64"
 IUSE_SOFTMMU_TARGETS="${COMMON_TARGETS}
 	lm32 moxie ppcemb tricore unicore32 xtensa xtensaeb"
 IUSE_USER_TARGETS="${COMMON_TARGETS}
-	armeb hppa mipsn32 mipsn32el ppc64abi32 ppc64le sparc32plus tilegx"
+	aarch64_be armeb mipsn32 mipsn32el ppc64abi32 ppc64le sparc32plus tilegx"
 
 use_softmmu_targets=$(printf ' qemu_softmmu_targets_%s' ${IUSE_SOFTMMU_TARGETS})
 use_user_targets=$(printf ' qemu_user_targets_%s' ${IUSE_USER_TARGETS})
@@ -201,7 +201,7 @@ RDEPEND="${CDEPEND}
 	selinux? ( sec-policy/selinux-qemu )"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-2.5.0-cflags.patch
+	"${FILESDIR}"/${PN}-2.11.9999-cflags.patch
 	"${FILESDIR}"/${PN}-2.5.0-sysmacros.patch
 )
 

--- a/profiles/desc/qemu_softmmu_targets.desc
+++ b/profiles/desc/qemu_softmmu_targets.desc
@@ -9,6 +9,7 @@ aarch64 - ARM64 system emulation target
 alpha - system emulation target
 arm - system emulation target
 cris - system emulation target
+hppa - system emulation target
 i386 - system emulation target
 lm32 - LatticeMico32 system emulation target
 m68k - system emulation target

--- a/profiles/desc/qemu_user_targets.desc
+++ b/profiles/desc/qemu_user_targets.desc
@@ -6,11 +6,12 @@
 # Keep it sorted.
 
 aarch64 - ARM64 userspace emulation target
+aarch64_be - ARM64 big endian userspace emulation target
 alpha - userspace emulation target
 arm - ARM (little endian) userspace emulation target
 armeb - ARM (big endian) userspace emulation target
 cris - userspace emulation target
-hppa - usersparce emulation target
+hppa - userspace emulation target
 i386 - userspace emulation target
 m68k - userspace emulation target
 microblazeel - userspace emulation target


### PR DESCRIPTION
* add hppa to softmmu targets
* add aarch64_be to user targets
* update the CFLAGS patch

Patch is named this way because 2.11 is not affected, and the affected version is not released yet.