### PR TITLE
media-sound/audacious, media-plugins/audacious-plugins: use HTTPS instead of HTTP

### DIFF
--- a/media-plugins/audacious-plugins/audacious-plugins-3.9-r1.ebuild
+++ b/media-plugins/audacious-plugins/audacious-plugins-3.9-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,15 +6,15 @@ EAPI=6
 MY_P="${P/_/-}"
 
 DESCRIPTION="Audacious Player - Your music, your way, no exceptions"
-HOMEPAGE="http://audacious-media-player.org/"
+HOMEPAGE="https://audacious-media-player.org/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit autotools git-r3
 	EGIT_REPO_URI="https://github.com/audacious-media-player/audacious-plugins.git"
 else
 	SRC_URI="
-		!gtk3? ( http://distfiles.audacious-media-player.org/${MY_P}.tar.bz2 )
-		gtk3? ( http://distfiles.audacious-media-player.org/${MY_P}-gtk3.tar.bz2 )"
+		!gtk3? ( https://distfiles.audacious-media-player.org/${MY_P}.tar.bz2 )
+		gtk3? ( https://distfiles.audacious-media-player.org/${MY_P}-gtk3.tar.bz2 )"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/media-plugins/audacious-plugins/audacious-plugins-9999.ebuild
+++ b/media-plugins/audacious-plugins/audacious-plugins-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,15 +6,15 @@ EAPI=6
 MY_P="${P/_/-}"
 
 DESCRIPTION="Audacious Player - Your music, your way, no exceptions"
-HOMEPAGE="http://audacious-media-player.org/"
+HOMEPAGE="https://audacious-media-player.org/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit autotools git-r3
 	EGIT_REPO_URI="https://github.com/audacious-media-player/audacious-plugins.git"
 else
 	SRC_URI="
-		!gtk3? ( http://distfiles.audacious-media-player.org/${MY_P}.tar.bz2 )
-		gtk3? ( http://distfiles.audacious-media-player.org/${MY_P}-gtk3.tar.bz2 )"
+		!gtk3? ( https://distfiles.audacious-media-player.org/${MY_P}.tar.bz2 )
+		gtk3? ( https://distfiles.audacious-media-player.org/${MY_P}-gtk3.tar.bz2 )"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/media-sound/audacious/audacious-3.9.ebuild
+++ b/media-sound/audacious/audacious-3.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,15 +9,15 @@ MY_P="${P/_/-}"
 S="${WORKDIR}/${MY_P}"
 
 DESCRIPTION="Audacious Player - Your music, your way, no exceptions"
-HOMEPAGE="http://audacious-media-player.org/"
+HOMEPAGE="https://audacious-media-player.org/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit autotools git-r3
 	EGIT_REPO_URI="https://github.com/audacious-media-player/audacious.git"
 else
 	SRC_URI="
-		!gtk3? ( http://distfiles.audacious-media-player.org/${MY_P}.tar.bz2 )
-		gtk3? ( http://distfiles.audacious-media-player.org/${MY_P}-gtk3.tar.bz2 )"
+		!gtk3? ( https://distfiles.audacious-media-player.org/${MY_P}.tar.bz2 )
+		gtk3? ( https://distfiles.audacious-media-player.org/${MY_P}-gtk3.tar.bz2 )"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/media-sound/audacious/audacious-9999.ebuild
+++ b/media-sound/audacious/audacious-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,15 +9,15 @@ MY_P="${P/_/-}"
 S="${WORKDIR}/${MY_P}"
 
 DESCRIPTION="Audacious Player - Your music, your way, no exceptions"
-HOMEPAGE="http://audacious-media-player.org/"
+HOMEPAGE="https://audacious-media-player.org/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit autotools git-r3
 	EGIT_REPO_URI="https://github.com/audacious-media-player/audacious.git"
 else
 	SRC_URI="
-		!gtk3? ( http://distfiles.audacious-media-player.org/${MY_P}.tar.bz2 )
-		gtk3? ( http://distfiles.audacious-media-player.org/${MY_P}-gtk3.tar.bz2 )"
+		!gtk3? ( https://distfiles.audacious-media-player.org/${MY_P}.tar.bz2 )
+		gtk3? ( https://distfiles.audacious-media-player.org/${MY_P}-gtk3.tar.bz2 )"
 	KEYWORDS="~amd64 ~x86"
 fi
 


### PR DESCRIPTION
Homepage link "http://audacious-media-player.org/" is a permanent redirect to "https://audacious-media-player.org/" and should be updated.