### PR TITLE
dev-util/patchbin: Use correct ${S} with git-r3.eclass

### DIFF
--- a/dev-util/patchbin/patchbin-20160208.ebuild
+++ b/dev-util/patchbin/patchbin-20160208.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,6 @@ if [[ ${PV} == 99999999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/wine-compholio/wine-staging"
 	KEYWORDS=""
-	S="${WORKDIR}/wine-staging"
 else
 	SHA="4ffcf184bb71c6c3512b3a8c144dcf4a3a76d23c"
 	SRC_URI="https://github.com/wine-compholio/wine-staging/archive/${SHA}.tar.gz -> ${P}.tar.gz"

--- a/dev-util/patchbin/patchbin-99999999.ebuild
+++ b/dev-util/patchbin/patchbin-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,6 @@ if [[ ${PV} == 99999999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/wine-compholio/wine-staging"
 	KEYWORDS=""
-	S="${WORKDIR}/wine-staging"
 else
 	SHA="4ffcf184bb71c6c3512b3a8c144dcf4a3a76d23c"
 	SRC_URI="https://github.com/wine-compholio/wine-staging/archive/${SHA}.tar.gz -> ${P}.tar.gz"


### PR DESCRIPTION
Package-Manager: Portage-2.3.19, Repoman-2.3.6