### PR TITLE
sys-devel/clang: add support for Gentoo Prefix

### DIFF
--- a/sys-devel/clang/clang-5.0.1.ebuild
+++ b/sys-devel/clang/clang-5.0.1.ebuild
@@ -149,6 +149,7 @@ multilib_src_configure() {
 		-DCLANG_ENABLE_STATIC_ANALYZER=$(usex static-analyzer)
 		# z3 is not multilib-friendly
 		-DCLANG_ANALYZER_BUILD_Z3=$(multilib_native_usex z3)
+		-DGCC_INSTALL_PREFIX="${EPREFIX}/usr"
 	)
 	use test && mycmakeargs+=(
 		-DLLVM_MAIN_SRC_DIR="${WORKDIR}/llvm"


### PR DESCRIPTION
When running clang in Gentoo Prefix, clang will fail to find gcc's location. This PR fix it by adding a CMake flag which specify the location of gcc in Gentoo Prefix.