### PR TITLE
sys-apps/portage: Enable additional QA features for USE=gentoo-dev

### DIFF
--- a/sys-apps/portage/portage-2.3.24.ebuild
+++ b/sys-apps/portage/portage-2.3.24.ebuild
@@ -99,6 +99,10 @@ python_prepare_all() {
 		sed -e 's:\("--dynamic-deps", \)\("y"\):\1"n":' \
 			-i pym/_emerge/create_depgraph_params.py || \
 			die "failed to patch create_depgraph_params.py"
+
+		einfo "Enabling additional FEATURES for gentoo-dev..."
+		echo 'FEATURES="${FEATURES} ipc-sandbox network-sandbox strict-keepdir"' \
+			>> cnf/make.globals || die
 	fi
 
 	if use native-extensions; then

--- a/sys-apps/portage/portage-9999.ebuild
+++ b/sys-apps/portage/portage-9999.ebuild
@@ -98,6 +98,10 @@ python_prepare_all() {
 		sed -e 's:\("--dynamic-deps", \)\("y"\):\1"n":' \
 			-i pym/_emerge/create_depgraph_params.py || \
 			die "failed to patch create_depgraph_params.py"
+
+		einfo "Enabling additional FEATURES for gentoo-dev..."
+		echo 'FEATURES="${FEATURES} ipc-sandbox network-sandbox strict-keepdir"' \
+			>> cnf/make.globals || die
 	fi
 
 	if use native-extensions; then


### PR DESCRIPTION
Enable additional FEATURES for developers that are not ready for
deployment on our users but are useful for preventing developers from
committing common mistakes.