### PR TITLE
media-video/mpv: fix float comparisons in tests

### DIFF
--- a/media-video/mpv/files/mpv-0.25.0-fix-float-comparisons-in-tests.patch
+++ b/media-video/mpv/files/mpv-0.25.0-fix-float-comparisons-in-tests.patch
@@ -1,0 +1,61 @@
+commit f4f24c105f9c132e84cba9a9707acc261033a816
+Author: Ilya Tumaykin <itumaykin@gmail.com>
+Date:   Thu Feb 1 14:05:06 2018 +0300
+
+tests: stop comparing floats against DBL_EPSILON, use FLT_EPSILON
+
+Fixes #5253.
+
+diff --git a/test/gl_video.c b/test/gl_video.c
+index a2d2577e25..6b5f3a7060 100644
+--- a/test/gl_video.c
++++ b/test/gl_video.c
+@@ -4,22 +4,22 @@
+ static void test_scale_ambient_lux_limits(void **state) {
+     float x;
+     x = gl_video_scale_ambient_lux(16.0, 64.0, 2.40, 1.961, 16.0);
+-    assert_double_equal(x, 2.40f);
++    assert_float_equal(x, 2.40f);
+
+     x = gl_video_scale_ambient_lux(16.0, 64.0, 2.40, 1.961, 64.0);
+-    assert_double_equal(x, 1.961f);
++    assert_float_equal(x, 1.961f);
+ }
+
+ static void test_scale_ambient_lux_sign(void **state) {
+     float x;
+     x = gl_video_scale_ambient_lux(16.0, 64.0, 1.961, 2.40, 64.0);
+-    assert_double_equal(x, 2.40f);
++    assert_float_equal(x, 2.40f);
+ }
+
+ static void test_scale_ambient_lux_clamping(void **state) {
+     float x;
+     x = gl_video_scale_ambient_lux(16.0, 64.0, 2.40, 1.961, 0.0);
+-    assert_double_equal(x, 2.40f);
++    assert_float_equal(x, 2.40f);
+ }
+
+ static void test_scale_ambient_lux_log10_midpoint(void **state) {
+@@ -27,7 +27,7 @@ static void test_scale_ambient_lux_log10_midpoint(void **state) {
+     // 32 corresponds to the the midpoint after converting lux to the log10 scale
+     x = gl_video_scale_ambient_lux(16.0, 64.0, 2.40, 1.961, 32.0);
+     float mid_gamma = (2.40 - 1.961) / 2 + 1.961;
+-    assert_double_equal(x, mid_gamma);
++    assert_float_equal(x, mid_gamma);
+ }
+
+ int main(void) {
+diff --git a/test/test_helpers.h b/test/test_helpers.h
+index 7a61da82ea..49328f623f 100644
+--- a/test/test_helpers.h
++++ b/test/test_helpers.h
+@@ -10,6 +10,7 @@
+ #include <math.h>
+ #include <float.h>
+
+-#define assert_double_equal(a, b) assert_true(fabs(a - b) <= DBL_EPSILON)
++#define assert_double_equal(a, b) assert_true(fabs((a) - (b)) <= DBL_EPSILON * fmax(fabs(a), fabs(b)))
++#define assert_float_equal(a, b) assert_true(fabsf((a) - (b)) <= FLT_EPSILON * fmaxf(fabsf(a), fabsf(b)))
+
+ #endif

--- a/media-video/mpv/mpv-0.25.0-r2.ebuild
+++ b/media-video/mpv/mpv-0.25.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -136,6 +136,7 @@ RDEPEND="${COMMON_DEPEND}
 PATCHES=(
 	"${FILESDIR}/${PN}-0.19.0-make-ffmpeg-version-check-non-fatal.patch"
 	"${FILESDIR}/${PN}-0.23.0-make-libavdevice-check-accept-libav.patch"
+	"${FILESDIR}/${PN}-0.25.0-fix-float-comparisons-in-tests.patch"
 )
 
 mpv_check_compiler() {

--- a/media-video/mpv/mpv-0.26.0.ebuild
+++ b/media-video/mpv/mpv-0.26.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -141,6 +141,7 @@ RDEPEND="${COMMON_DEPEND}
 PATCHES=(
 	"${FILESDIR}/${PN}-0.19.0-make-ffmpeg-version-check-non-fatal.patch"
 	"${FILESDIR}/${PN}-0.23.0-make-libavdevice-check-accept-libav.patch"
+	"${FILESDIR}/${PN}-0.25.0-fix-float-comparisons-in-tests.patch"
 )
 
 pkg_setup() {

--- a/media-video/mpv/mpv-0.27.0-r1.ebuild
+++ b/media-video/mpv/mpv-0.27.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -141,6 +141,7 @@ RDEPEND="${COMMON_DEPEND}
 PATCHES=(
 	"${FILESDIR}/${PN}-0.19.0-make-ffmpeg-version-check-non-fatal.patch"
 	"${FILESDIR}/${PN}-0.23.0-make-libavdevice-check-accept-libav.patch"
+	"${FILESDIR}/${PN}-0.25.0-fix-float-comparisons-in-tests.patch"
 )
 
 pkg_setup() {

--- a/media-video/mpv/mpv-0.28.0.ebuild
+++ b/media-video/mpv/mpv-0.28.0.ebuild
@@ -132,6 +132,7 @@ RDEPEND="${COMMON_DEPEND}
 
 PATCHES=(
 	"${FILESDIR}/${PN}-0.19.0-make-ffmpeg-version-check-non-fatal.patch"
+	"${FILESDIR}/${PN}-0.25.0-fix-float-comparisons-in-tests.patch"
 )
 
 pkg_setup() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/628252
Closes: https://bugs.gentoo.org/628252
Package-Manager: Portage-2.3.24, Repoman-2.3.6