### PR TITLE
app-admin/clog: avoid redirection, fix HOMEPAGE

### DIFF
--- a/app-admin/clog/clog-1.1.0.ebuild
+++ b/app-admin/clog/clog-1.1.0.ebuild
@@ -10,7 +10,7 @@ EGIT_REPO_URI="https://git.tasktools.org/scm/ut/${PN}.git"
 inherit cmake-utils bash-completion-r1
 
 DESCRIPTION="A colorized log tail utility"
-HOMEPAGE="http://tasktools.org/projects/clog.html"
+HOMEPAGE="https://taskwarrior.org/docs/clog/"
 [[ ${PV} == *9999* ]] || \
 	SRC_URI="http://taskwarrior.org/download/${P}.tar.gz"
 

--- a/app-admin/clog/clog-1.3.0.ebuild
+++ b/app-admin/clog/clog-1.3.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="clog is a colorized log tail utility"
-HOMEPAGE="https://taskwarrior.org/docs/clog"
+HOMEPAGE="https://taskwarrior.org/docs/clog/"
 SRC_URI="https://tasktools.org/download/${P}.tar.gz"
 
 KEYWORDS="~amd64 ~x86 ~x64-macos ~amd64-fbsd"


### PR DESCRIPTION
Hi,

This fixes the HOMEPAGE of the older ebuild and adds a "/" to the newer one in order to avoid redirection.

Please review.