### PR TITLE
dev-python/async: remove dead HOMEPAGE

### DIFF
--- a/dev-python/async/async-0.6.2.ebuild
+++ b/dev-python/async/async-0.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,9 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_4 python3_5 python3_6 )
 inherit distutils-r1
 
 DESCRIPTION="Async Framework"
-HOMEPAGE="
-	http://gitorious.org/git-python/async
-	https://pypi.python.org/pypi/async"
+HOMEPAGE="https://pypi.python.org/pypi/async"
 SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Hi,

This PR removes the dead gitorious HOMEPAGE from dev-python/async.

Please review.