### PR TITLE
mail-mta/postfix: drop dependency on net-mail/dovecot

### DIFF
--- a/mail-mta/postfix/postfix-3.2.4.ebuild
+++ b/mail-mta/postfix/postfix-3.2.4.ebuild
@@ -37,7 +37,6 @@ DEPEND=">=dev-libs/libpcre-3.4
 	)"
 
 RDEPEND="${DEPEND}
-	dovecot-sasl? ( net-mail/dovecot )
 	memcached? ( net-misc/memcached )
 	net-mail/mailbase
 	!mail-mta/courier

--- a/mail-mta/postfix/postfix-3.4_pre20180203.ebuild
+++ b/mail-mta/postfix/postfix-3.4_pre20180203.ebuild
@@ -37,7 +37,6 @@ DEPEND=">=dev-libs/libpcre-3.4
 	)"
 
 RDEPEND="${DEPEND}
-	dovecot-sasl? ( net-mail/dovecot )
 	memcached? ( net-misc/memcached )
 	net-mail/mailbase
 	!mail-mta/courier


### PR DESCRIPTION
USE=dovecot-sasl doesn't actually depend on the dovecot package, neither at build nor at runtime (it is possible to communicate with a remote dovecot running on another host). All the code is internal to postfix.

Tested by emerging on a machine without dovecot, then testing that postfix works in general, then installing that binary package on a machine with dovecot, then testing that postfix correctly works with dovecot for SASL.

Note: not sure if this requires a revbump; I'm guessing no, but will be happy to correct it if it does.