### PR TITLE
games-fps/redeclipse: fix missing manual error, fix bug 646708

### DIFF
--- a/games-fps/redeclipse/redeclipse-1.6.0-r1.ebuild
+++ b/games-fps/redeclipse/redeclipse-1.6.0-r1.ebuild
@@ -74,10 +74,10 @@ src_install() {
 		doman doc/man/redeclipse.6
 	fi
 
+	doman doc/man/redeclipse-server.6
+	dodoc readme.txt doc/examples/servinit.cfg
+
 	dobin "${FILESDIR}/redeclipse"
 	cd /usr/bin || die
 	dosym redeclipse redeclipse_server
-
-	doman doc/man/redeclipse-server.6
-	dodoc readme.txt doc/examples/servinit.cfg
 }


### PR DESCRIPTION
The symlink creation step uses a change directory command which breaks
the call to dodoc. Simply reversing the order solves the problem.

Closes: https://bugs.gentoo.org/646708
Package-Manager: Portage-2.3.19, Repoman-2.3.6