### PR TITLE
virtual/pager: remove dangling package

### DIFF
--- a/virtual/pager/pager-0-r1.ebuild
+++ b/virtual/pager/pager-0-r1.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="Virtual for command-line pagers"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="|| ( sys-apps/less
+	sys-apps/most
+	sys-apps/util-linux[ncurses]
+	app-text/lv
+	app-editors/vim[vim-pager] )"


### PR DESCRIPTION
Package-Manager: Portage-2.3.19, Repoman-2.3.6

Apparently, sys-apps/more is not available.