### PR TITLE
sci-mathematics/pari: make the fltk useflag work in 2.9.4

### DIFF
--- a/sci-mathematics/pari/files/pari-2.9.4-fltk-detection.patch
+++ b/sci-mathematics/pari/files/pari-2.9.4-fltk-detection.patch
@@ -1,0 +1,22 @@
+diff --git a/config/get_fltk b/config/get_fltk
+index 87d0c1d..22f5bd8 100644
+--- a/config/get_fltk
++++ b/config/get_fltk
+@@ -2,13 +2,16 @@ if test -z "$with_fltk"; then
+   with_fltk=yes
+ fi
+ 
++cmd="FLTK_CXXFLAGS=\`fltk-config --cxxflags\`"
++. log_cmd
++
+ cmd="FLTK_LIBS=\`fltk-config --ldflags\`"
+ . log_cmd
+ 
+ exe=$osname-$arch-fltk$$$exe_suff
+ cxx=$CXX
+ if test -z "$cxx"; then cxx=g++; fi;
+-cmd="$cxx $CFLAGS $FLTK_LIBS -o $exe has_fltk.c"
++cmd="$cxx $CFLAGS $FLTK_CXXFLAGS $FLTK_LIBS -o $exe has_fltk.c"
+ . log_cmd
+ if test -r "$exe"; then
+   echo "Using FLTK library"

--- a/sci-mathematics/pari/pari-2.9.4-r1.ebuild
+++ b/sci-mathematics/pari/pari-2.9.4-r1.ebuild
@@ -32,8 +32,9 @@ get_compile_dir() {
 }
 
 PATCHES=( "${FILESDIR}"/${P}-strip.patch
-		  "${FILESDIR}"/${P}-ppc.patch
-		  "${FILESDIR}"/${P}-no-automagic.patch
+		"${FILESDIR}"/${P}-ppc.patch
+		"${FILESDIR}"/${P}-no-automagic.patch
+		"${FILESDIR}"/${P}-fltk-detection.patch
 		)
 
 src_prepare() {


### PR DESCRIPTION
Package-Manager: Portage-2.3.19, Repoman-2.3.6
closes: https://bugs.gentoo.org/646942