### PR TITLE
dev-tcltk/tkimg: Fix build with jpeg-9

### DIFF
--- a/dev-tcltk/tkimg/files/tkimg-1.4-jpeg-9.patch
+++ b/dev-tcltk/tkimg/files/tkimg-1.4-jpeg-9.patch
@@ -1,0 +1,18 @@
+Fix build with jpeg-9, bug #520886
+
+--- a/jpeg/jpeg.c	2010-06-17 15:40:24.000000000 +0200
++++ b/jpeg/jpeg.c	2018-02-07 23:26:38.050073397 +0100
+@@ -53,6 +53,13 @@
+  */
+ 
+ #include "tkimg.h"
++#ifndef FALSE
++#define FALSE 0
++#endif
++#ifndef TRUE
++#define TRUE 1
++#endif
++#define HAVE_BOOLEAN
+ #include "jpegtcl.h"
+ 
+ static int SetupJPegLibrary(Tcl_Interp *interp);

--- a/dev-tcltk/tkimg/tkimg-1.4-r9.ebuild
+++ b/dev-tcltk/tkimg/tkimg-1.4-r9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -40,6 +40,7 @@ S="${WORKDIR}/${MYP}"
 src_prepare() {
 	epatch \
 		"${WORKDIR}"/${P}-jpeg.patch \
+		"${FILESDIR}"/${P}-jpeg-9.patch \
 		"${WORKDIR}"/${P}-tiff.patch \
 		"${WORKDIR}"/${P}-png.patch \
 		"${FILESDIR}"/${P}-png2.patch \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/520886

Only tested with jpeg-9c so far.