### PR TITLE
dev-libs/libnl: add debug threads USE flags

### DIFF
--- a/dev-libs/libnl/libnl-3.2.28-r1.ebuild
+++ b/dev-libs/libnl/libnl-3.2.28-r1.ebuild
@@ -1,19 +1,24 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+PYTHON_COMPAT=( python2_7 python3_{4,5} )
 DISTUTILS_OPTIONAL=1
-inherit autotools distutils-r1 eutils git-r3 libtool multilib multilib-minimal
+inherit distutils-r1 eutils libtool multilib multilib-minimal
+
+LIBNL_P=${P/_/-}
+LIBNL_DIR=${PV/_/}
+LIBNL_DIR=${LIBNL_DIR//./_}
 
 DESCRIPTION="Libraries providing APIs to netlink protocol based Linux kernel interfaces"
 HOMEPAGE="http://www.infradead.org/~tgr/libnl/ https://github.com/thom311/libnl"
-EGIT_REPO_URI="
-	https://github.com/thom311/libnl.git
+SRC_URI="
+	https://github.com/thom311/${PN}/releases/download/${PN}${LIBNL_DIR}/${P/_rc/-rc}.tar.gz
+	https://dev.gentoo.org/~jer/libnl-3.2.28-in6.patch.xz
 "
 LICENSE="LGPL-2.1 utils? ( GPL-2 )"
 SLOT="3"
-KEYWORDS=""
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="debug python static-libs +threads utils"
 
 RDEPEND="
@@ -38,6 +43,8 @@ DOCS=(
 	ChangeLog
 )
 
+S=${WORKDIR}/${LIBNL_P}
+
 MULTILIB_WRAPPED_HEADERS=(
 	# we do not install CLI stuff for non-native
 	/usr/include/libnl3/netlink/cli/addr.h
@@ -54,10 +61,15 @@ MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/libnl3/netlink/cli/utils.h
 )
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.1-vlan-header.patch
+	"${WORKDIR}"/${PN}-3.2.28-in6.patch
+)
+
 src_prepare() {
 	default
 
-	eautoreconf
+	elibtoolize
 
 	if use python; then
 		cd "${S}"/python || die
@@ -72,9 +84,9 @@ src_prepare() {
 multilib_src_configure() {
 	econf \
 		--disable-silent-rules \
+		$(use_enable static-libs static) \
 		$(use_enable debug) \
 		$(use_enable threads pthreads) \
-		$(use_enable static-libs static) \
 		$(multilib_native_use_enable utils cli)
 }
 

--- a/dev-libs/libnl/libnl-3.4.0-r1.ebuild
+++ b/dev-libs/libnl/libnl-3.4.0-r1.ebuild
@@ -1,19 +1,23 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 DISTUTILS_OPTIONAL=1
-inherit autotools distutils-r1 eutils git-r3 libtool multilib multilib-minimal
+inherit distutils-r1 eutils libtool multilib multilib-minimal
+
+LIBNL_P=${P/_/-}
+LIBNL_DIR=${PV/_/}
+LIBNL_DIR=${LIBNL_DIR//./_}
 
 DESCRIPTION="Libraries providing APIs to netlink protocol based Linux kernel interfaces"
 HOMEPAGE="http://www.infradead.org/~tgr/libnl/ https://github.com/thom311/libnl"
-EGIT_REPO_URI="
-	https://github.com/thom311/libnl.git
+SRC_URI="
+	https://github.com/thom311/${PN}/releases/download/${PN}${LIBNL_DIR}/${P/_rc/-rc}.tar.gz
 "
 LICENSE="LGPL-2.1 utils? ( GPL-2 )"
 SLOT="3"
-KEYWORDS=""
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="debug python static-libs +threads utils"
 
 RDEPEND="
@@ -29,14 +33,14 @@ DEPEND="
 	sys-devel/bison
 	sys-devel/flex
 "
-
 REQUIRED_USE="
 	python? ( ${PYTHON_REQUIRED_USE} )
 "
-
 DOCS=(
 	ChangeLog
 )
+
+S=${WORKDIR}/${LIBNL_P}
 
 MULTILIB_WRAPPED_HEADERS=(
 	# we do not install CLI stuff for non-native
@@ -57,7 +61,7 @@ MULTILIB_WRAPPED_HEADERS=(
 src_prepare() {
 	default
 
-	eautoreconf
+	elibtoolize
 
 	if use python; then
 		cd "${S}"/python || die
@@ -72,9 +76,9 @@ src_prepare() {
 multilib_src_configure() {
 	econf \
 		--disable-silent-rules \
+		$(use_enable static-libs static) \
 		$(use_enable debug) \
 		$(use_enable threads pthreads) \
-		$(use_enable static-libs static) \
 		$(multilib_native_use_enable utils cli)
 }
 


### PR DESCRIPTION
* we can remove debugs messages as allowed by `configure`
* we can also remove threading support (enabled by default to avoid changing much the behavior of it)
* revbump because changing final binary
* change easily visible in libnl-99999999.ebuild (btw, why having "99999999" instead of the more widely used "9999"?) 