### PR TITLE
app-admin/apachetop: Fixing homepage and copyright message.

### DIFF
--- a/app-admin/apachetop/apachetop-0.12.6-r2.ebuild
+++ b/app-admin/apachetop/apachetop-0.12.6-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="A realtime Apache log analyzer"
-HOMEPAGE="http://www.webta.org/projects/apachetop"
+HOMEPAGE="https://github.com/tessus/apachetop"
 SRC_URI="http://www.webta.org/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Updating the homepage. Copyright message got included because repomain
suggested it too.

Bug: https://bugs.gentoo.org/646954
Package-Manager: Portage-2.3.23, Repoman-2.3.6