### PR TITLE
sys-apps/flashrom: use https, avoid redirection

### DIFF
--- a/sys-apps/flashrom/flashrom-0.9.6.1.ebuild
+++ b/sys-apps/flashrom/flashrom-0.9.6.1.ebuild
@@ -8,12 +8,12 @@ if [[ ${PV} == "9999" ]] ; then
 	ESVN_REPO_URI="https://code.coreboot.org/svn/flashrom/trunk"
 	inherit subversion
 else
-	SRC_URI="http://download.flashrom.org/releases/${P}.tar.bz2"
+	SRC_URI="https://download.flashrom.org/releases/${P}.tar.bz2"
 	KEYWORDS="amd64 arm x86"
 fi
 
 DESCRIPTION="Utility for reading, writing, erasing and verifying flash ROM chips"
-HOMEPAGE="http://flashrom.org/"
+HOMEPAGE="https://flashrom.org/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/flashrom/flashrom-0.9.7.ebuild
+++ b/sys-apps/flashrom/flashrom-0.9.7.ebuild
@@ -8,12 +8,12 @@ if [[ ${PV} == "9999" ]] ; then
 	ESVN_REPO_URI="https://code.coreboot.org/svn/flashrom/trunk"
 	inherit subversion
 else
-	SRC_URI="http://download.flashrom.org/releases/${P}.tar.bz2"
+	SRC_URI="https://download.flashrom.org/releases/${P}.tar.bz2"
 	KEYWORDS="amd64 arm ~mips x86"
 fi
 
 DESCRIPTION="Utility for reading, writing, erasing and verifying flash ROM chips"
-HOMEPAGE="http://flashrom.org/"
+HOMEPAGE="https://flashrom.org/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/flashrom/flashrom-0.9.8.ebuild
+++ b/sys-apps/flashrom/flashrom-0.9.8.ebuild
@@ -8,12 +8,12 @@ if [[ ${PV} == "9999" ]] ; then
 	ESVN_REPO_URI="https://code.coreboot.org/svn/flashrom/trunk"
 	inherit subversion
 else
-	SRC_URI="http://download.flashrom.org/releases/${P}.tar.bz2"
+	SRC_URI="https://download.flashrom.org/releases/${P}.tar.bz2"
 	KEYWORDS="amd64 arm ~arm64 ~mips ~ppc ~ppc64 ~sparc x86"
 fi
 
 DESCRIPTION="Utility for reading, writing, erasing and verifying flash ROM chips"
-HOMEPAGE="http://flashrom.org/"
+HOMEPAGE="https://flashrom.org/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/flashrom/flashrom-0.9.9.ebuild
+++ b/sys-apps/flashrom/flashrom-0.9.9.ebuild
@@ -8,12 +8,12 @@ if [[ ${PV} == "9999" ]] ; then
 	ESVN_REPO_URI="https://code.coreboot.org/svn/flashrom/trunk"
 	inherit subversion
 else
-	SRC_URI="http://download.flashrom.org/releases/${P}.tar.bz2"
+	SRC_URI="https://download.flashrom.org/releases/${P}.tar.bz2"
 	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~sparc ~x86"
 fi
 
 DESCRIPTION="Utility for reading, writing, erasing and verifying flash ROM chips"
-HOMEPAGE="http://flashrom.org/"
+HOMEPAGE="https://flashrom.org/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/flashrom/flashrom-9999.ebuild
+++ b/sys-apps/flashrom/flashrom-9999.ebuild
@@ -8,12 +8,12 @@ if [[ ${PV} == "9999" ]] ; then
 	ESVN_REPO_URI="https://code.coreboot.org/svn/flashrom/trunk"
 	inherit subversion
 else
-	SRC_URI="http://download.flashrom.org/releases/${P}.tar.bz2"
+	SRC_URI="https://download.flashrom.org/releases/${P}.tar.bz2"
 	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~sparc ~x86"
 fi
 
 DESCRIPTION="Utility for reading, writing, erasing and verifying flash ROM chips"
-HOMEPAGE="http://flashrom.org/"
+HOMEPAGE="https://flashrom.org/"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR uses HTTPS for all ebuilds and avoids redirection.

Please review.