### PR TITLE
app-misc/anki: depends on dev-python/PyQt5[webengine,widgets]

### DIFF
--- a/app-misc/anki/anki-2.1.0_beta27.ebuild
+++ b/app-misc/anki/anki-2.1.0_beta27.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -22,7 +22,7 @@ IUSE="latex +recording +sound test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
-	dev-python/PyQt5[gui,svg,webkit,${PYTHON_USEDEP}]
+	dev-python/PyQt5[gui,svg,widgets,webengine,${PYTHON_USEDEP}]
 	>=dev-python/httplib2-0.7.4[${PYTHON_USEDEP}]
 	dev-python/beautifulsoup:4[${PYTHON_USEDEP}]
 	dev-python/decorator[${PYTHON_USEDEP}]


### PR DESCRIPTION
Package-Manager: Portage-2.3.24, Repoman-2.3.6

With -webengine +webkit:
  File "/usr/lib64/python3.6/site-packages/aqt/qt.py", line 17, in <module>
    from PyQt5.QtWebEngineWidgets import QWebEnginePage
ModuleNotFoundError: No module named 'PyQt5.QtWebEngineWidgets'
