### PR TITLE
app-admin/apachetop: Fixing source URI

### DIFF
--- a/app-admin/apachetop/apachetop-0.12.6-r2.ebuild
+++ b/app-admin/apachetop/apachetop-0.12.6-r2.ebuild
@@ -7,7 +7,7 @@ inherit autotools
 
 DESCRIPTION="A realtime Apache log analyzer"
 HOMEPAGE="https://github.com/tessus/apachetop"
-SRC_URI="http://www.webta.org/${PN}/${P}.tar.gz"
+SRC_URI="https://dev.gentoo.org/~jstein/dist/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Fixing the source URI since original one became obsolete.

Closes: https://bugs.gentoo.org/647068
Package-Manager: Portage-2.3.23, Repoman-2.3.6