### PR TITLE
dev-python/paho-mqtt: fix use of undef var

### DIFF
--- a/dev-python/paho-mqtt/paho-mqtt-1.2.3.ebuild
+++ b/dev-python/paho-mqtt/paho-mqtt-1.2.3.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 RDEPEND=""
-DEPEND="dev-python/setuptools[${MULTILIB_USEDEP}]"
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 
 S="${WORKDIR}/paho.mqtt.python-${PV}"
 


### PR DESCRIPTION
Paludis gave me this warning about `dev-python/paho-mqtt-1.2.3`.
```
[WARNING e.cache.save.failure] Not writing cache file to '/var/cache/paludis/metadata/gentoo/dev-python/paho-mqtt-1.2.3' due to exception 'Invalid [] contents' (paludis::PackageDepSpecError)
```

Look like `MULTILIB_USEDEP` (not `inherit`'ed) was written instead of `PYTHON_USEDEP` (`inherit`'ed).