### PR TITLE
games-fps/redeclipse: fix dosym and wrapper, fix bug 647170

### DIFF
--- a/games-fps/redeclipse/files/redeclipse
+++ b/games-fps/redeclipse/files/redeclipse
@@ -7,4 +7,4 @@
 SERVER=/usr/bin/redeclipse_server_linux
 CLIENT=/usr/bin/redeclipse_linux
 cd /usr/share/redeclipse || exit 1
-[ "$0" = "redeclipse_server" ] && exec $SERVER || exec $CLIENT
+[ "${0##*/}" = "redeclipse_server" ] && exec "${SERVER}" || exec "${CLIENT}"

--- a/games-fps/redeclipse/redeclipse-1.6.0-r2.ebuild
+++ b/games-fps/redeclipse/redeclipse-1.6.0-r2.ebuild
@@ -78,6 +78,5 @@ src_install() {
 	dodoc readme.txt doc/examples/servinit.cfg
 
 	dobin "${FILESDIR}/redeclipse"
-	cd /usr/bin || die
-	dosym redeclipse redeclipse_server
+	dosym redeclipse /usr/bin/redeclipse_server
 }


### PR DESCRIPTION
Fixed dosym syntax to install the symlink in the correct location.
Fixed wrapper script conditional to evaluate script call name
correctly.

Closes: https://bugs.gentoo.org/647170

Package-Manager: Portage-2.3.19, Repoman-2.3.6