### PR TITLE
dev-util/astyle: Fix broken build with "java" enabled

### DIFF
--- a/dev-util/astyle/astyle-3.1.ebuild
+++ b/dev-util/astyle/astyle-3.1.ebuild
@@ -57,8 +57,8 @@ src_install() {
 	# ex: libastyle.so.3
 	dosym lib${PN}.so.${PV}.0 /usr/$(get_libdir)/lib${PN}.so.$(get_major_version)
 	if use java ; then
-		dolib.so lib${PN}j.so.${PV}
-		dosym lib${PN}j.so.${PV} /usr/$(get_libdir)/lib${PN}j.so.$(get_major_version)
+		dolib.so lib${PN}j.so.${PV}.0
+		dosym lib${PN}j.so.${PV}.0 /usr/$(get_libdir)/lib${PN}j.so.$(get_major_version)
 	fi
 	if use static-libs ; then
 		dolib lib${PN}.a


### PR DESCRIPTION
The `.0` that was added to the library name in the 3.1 ebuild wasn't
copied to its java counterpart. When `java` use flag is enabled, the
ebuild fails its `install` phase. Applying the same `.0` change to the
`j` lib fixes the problem.

Closes: https://bugs.gentoo.org/647232
Package-Manager: Portage-2.3.19, Repoman-2.3.6