### PR TITLE
dev-db/mongodb: drop unused x86 arch conditional

### DIFF
--- a/dev-db/mongodb/mongodb-3.4.10.ebuild
+++ b/dev-db/mongodb/mongodb-3.4.10.ebuild
@@ -88,9 +88,6 @@ pkg_setup() {
 		--use-system-zlib
 	)
 
-	# wiredtiger not supported on 32bit platforms #572166
-	use x86 && scons_opts+=( --wiredtiger=off )
-
 	if use debug; then
 		scons_opts+=( --dbg=on )
 	fi

--- a/dev-db/mongodb/mongodb-3.4.13.ebuild
+++ b/dev-db/mongodb/mongodb-3.4.13.ebuild
@@ -87,9 +87,6 @@ pkg_setup() {
 		--use-system-zlib
 	)
 
-	# wiredtiger not supported on 32bit platforms #572166
-	use x86 && scons_opts+=( --wiredtiger=off )
-
 	if use debug; then
 		scons_opts+=( --dbg=on )
 	fi

--- a/dev-db/mongodb/mongodb-3.6.2.ebuild
+++ b/dev-db/mongodb/mongodb-3.6.2.ebuild
@@ -104,9 +104,6 @@ src_configure() {
 	use kerberos && scons_opts+=( --use-sasl-client )
 	use ssl && scons_opts+=( --ssl )
 
-	# wiredtiger not supported on 32bit platforms #572166
-	use x86 && scons_opts+=( --wiredtiger=off )
-
 	# respect mongoDB upstream's basic recommendations
 	# see bug #536688 and #526114
 	if ! use debug; then


### PR DESCRIPTION
Commit 95cda0448c11be5feb4c688138c9003af097f815 dropped the x86
keywords, but we forgot to drop this conditional.

Package-Manager: Portage-2.3.24, Repoman-2.3.6