### PR TITLE
media-gfx/sane-frontends: remove unused eutils eclass, fix repoman warning

### DIFF
--- a/media-gfx/sane-frontends/sane-frontends-1.0.14-r1.ebuild
+++ b/media-gfx/sane-frontends/sane-frontends-1.0.14-r1.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=6
 
-inherit eutils
-
 DESCRIPTION="Scanner Access Now Easy"
 HOMEPAGE="http://www.sane-project.org"
 SRC_URI="ftp://ftp.sane-project.org/pub/sane/${P}/${P}.tar.gz
@@ -45,7 +43,7 @@ src_install () {
 		done
 		if [ "/plug-ins" != "${gimpplugindir}" ]; then
 			 dodir ${gimpplugindir}
-			dosym /usr/bin/xscanimage ${gimpplugindir}/xscanimage
+			dosym xscanimage ${gimpplugindir}/xscanimage
 		else
 			ewarn "No idea where to find the gimp plugin directory"
 		fi


### PR DESCRIPTION
Hi,

This fixes some minor issues with the sane-frontends ebuilds.
Please look at Bug: https://bugs.gentoo.org/647524

Please review.