### PR TITLE
=net-p2p/pybitmessage-0.6.2-r3, masked

### DIFF
--- a/net-p2p/pybitmessage/pybitmessage-0.6.2-r3.ebuild
+++ b/net-p2p/pybitmessage/pybitmessage-0.6.2-r3.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://github.com/Bitmessage/${MY_PN}/archive/v${PV}.tar.gz
 	-> ${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS=""
 IUSE="libressl ncurses opencl sound"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 


### PR DESCRIPTION
pybitmessage-0.6.2 should be masked, see [0.6.3 release note](../../../Bitmessage/PyBitmessage/releases/tag/v0.6.3)