### PR TITLE
Revert "x11-wm/i3: add ~arm64, bug #640274"

### DIFF
--- a/x11-wm/i3/i3-4.14.1.ebuild
+++ b/x11-wm/i3/i3-4.14.1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://i3wm.org/downloads/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="doc debug test"
 
 CDEPEND="dev-libs/libev


### PR DESCRIPTION
This reverts commit 5bde02429fa44ae1d62e116b7ae008ec6b3babd0.

Dependencies are not keyworded, see bug for details.

Bug: 640274