### PR TITLE
app-editors/mg, app-emacs/*: fix HTTPS, remove dead HOMEPAGES

### DIFF
--- a/app-editors/mg/mg-20170828.ebuild
+++ b/app-editors/mg/mg-20170828.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="MicroGnuEmacs, a port from the BSDs"
-HOMEPAGE="http://homepage.boetes.org/software/mg/"
-SRC_URI="http://homepage.boetes.org/software/mg/${P}.tar.gz"
+HOMEPAGE="https://homepage.boetes.org/software/mg/"
+SRC_URI="https://homepage.boetes.org/software/mg/${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0"

--- a/app-editors/mg/mg-20171014.ebuild
+++ b/app-editors/mg/mg-20171014.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="MicroGnuEmacs, a port from the BSDs"
-HOMEPAGE="http://homepage.boetes.org/software/mg/"
-SRC_URI="http://homepage.boetes.org/software/mg/${P}.tar.gz"
+HOMEPAGE="https://homepage.boetes.org/software/mg/"
+SRC_URI="https://homepage.boetes.org/software/mg/${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0"

--- a/app-emacs/bm/bm-1.32_p20140214.ebuild
+++ b/app-emacs/bm/bm-1.32_p20140214.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Visible bookmarks in buffer"
-HOMEPAGE="http://www.nongnu.org/bm/
-	http://www.emacswiki.org/emacs/VisibleBookmarks"
+HOMEPAGE="https://www.nongnu.org/bm/
+	https://www.emacswiki.org/emacs/VisibleBookmarks"
 # snapshot of https://github.com/joodland/bm.git
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.tar.xz"
 

--- a/app-emacs/buffer-extension/buffer-extension-0.1.ebuild
+++ b/app-emacs/buffer-extension/buffer-extension-0.1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit elisp
 
 DESCRIPTION="Some enhanced functions for buffer manipulate"
-HOMEPAGE="http://www.emacswiki.org/emacs/buffer-extension.el"
+HOMEPAGE="https://www.emacswiki.org/emacs/buffer-extension.el"
 # taken from https://www.emacswiki.org/emacs/download/buffer-extension.el
 SRC_URI="https://github.com/gavv/distfiles/raw/master/${P}.el.xz"
 

--- a/app-emacs/color-browser/color-browser-0.3-r1.ebuild
+++ b/app-emacs/color-browser/color-browser-0.3-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="A utility for designing Emacs color themes"
-HOMEPAGE="http://www.emacswiki.org/emacs/KahlilHodgson"
+HOMEPAGE="https://www.emacswiki.org/emacs/KahlilHodgson"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/color-moccur/color-moccur-2.73.ebuild
+++ b/app-emacs/color-moccur/color-moccur-2.73.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Major mode for color moccur"
 HOMEPAGE="http://www.bookshelf.jp/
-	http://www.emacswiki.org/emacs/SearchBuffers"
+	https://www.emacswiki.org/emacs/SearchBuffers"
 # taken from http://www.bookshelf.jp/elc/color-moccur.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/crypt++/crypt++-2.92.ebuild
+++ b/app-emacs/crypt++/crypt++-2.92.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Handle all sorts of compressed and encrypted files"
-HOMEPAGE="http://www.emacswiki.org/emacs/CryptPlusPlus"
+HOMEPAGE="https://www.emacswiki.org/emacs/CryptPlusPlus"
 SRC_URI="mirror://debian/pool/main/c/crypt++el/crypt++el_${PV}.orig.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-emacs/crypt++/crypt++-2.94_pre20080430.ebuild
+++ b/app-emacs/crypt++/crypt++-2.94_pre20080430.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Handle all sorts of compressed and encrypted files"
-HOMEPAGE="http://www.emacswiki.org/emacs/CryptPlusPlus"
+HOMEPAGE="https://www.emacswiki.org/emacs/CryptPlusPlus"
 # snapshot from http://cvs.xemacs.org/viewcvs.cgi/XEmacs/packages/xemacs-packages/os-utils/crypt.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.bz2"
 

--- a/app-emacs/cycle-buffer/cycle-buffer-2.16.ebuild
+++ b/app-emacs/cycle-buffer/cycle-buffer-2.16.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit elisp
 
 DESCRIPTION="Select buffer by cycling through"
-HOMEPAGE="http://www.emacswiki.org/emacs/cycle-buffer.el"
+HOMEPAGE="https://www.emacswiki.org/emacs/cycle-buffer.el"
 # taken from https://www.emacswiki.org/emacs/download/cycle-buffer.el
 SRC_URI="https://github.com/gavv/distfiles/raw/master/${P}.el.xz"
 

--- a/app-emacs/d-mode/d-mode-2.0.6.ebuild
+++ b/app-emacs/d-mode/d-mode-2.0.6.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Emacs major mode for editing D code"
 HOMEPAGE="https://github.com/Emacs-D-Mode-Maintainers/Emacs-D-Mode
-	http://www.emacswiki.org/emacs/DMode"
+	https://www.emacswiki.org/emacs/DMode"
 SRC_URI="https://github.com/Emacs-D-Mode-Maintainers/Emacs-D-Mode/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/develock/develock-0.45.ebuild
+++ b/app-emacs/develock/develock-0.45.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="An Emacs minor mode for highlighting broken formatting rules"
-HOMEPAGE="http://www.jpl.org/ftp/pub/elisp/
-	http://www.emacswiki.org/emacs/DevelockMode"
+HOMEPAGE="https://www.jpl.org/ftp/pub/elisp/
+	https://www.emacswiki.org/emacs/DevelockMode"
 # taken from http://www.jpl.org/ftp/pub/elisp/${PN}.el.gz
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.gz"
 

--- a/app-emacs/df-mode/df-mode-20050509.ebuild
+++ b/app-emacs/df-mode/df-mode-20050509.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Minor mode to show space left on devices in the mode line"
 HOMEPAGE="https://web.archive.org/web/20061001221337/http://www.coli.uni-saarland.de/~fouvry/software.html
-	http://www.emacswiki.org/emacs/DfMode"
+	https://www.emacswiki.org/emacs/DfMode"
 # taken from http://www.coli.uni-saarland.de/~fouvry/files/df-mode.el.gz
 SRC_URI="mirror://gentoo/${P}.el.bz2"
 

--- a/app-emacs/dropdown-list/dropdown-list-20120329.ebuild
+++ b/app-emacs/dropdown-list/dropdown-list-20120329.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Drop-down menu interface"
-HOMEPAGE="http://www.emacswiki.org/emacs/dropdown-list.el"
+HOMEPAGE="https://www.emacswiki.org/emacs/dropdown-list.el"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 
 LICENSE="GPL-3+"

--- a/app-emacs/edb/edb-1.31.ebuild
+++ b/app-emacs/edb/edb-1.31.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="EDB, The Emacs Database"
 HOMEPAGE="http://www.gnuvola.org/software/edb/
-	http://www.emacswiki.org/emacs/EmacsDataBase"
+	https://www.emacswiki.org/emacs/EmacsDataBase"
 SRC_URI="http://www.gnuvola.org/software/edb/${P}.tar.gz"
 
 LICENSE="GPL-3+ Texinfo-manual"

--- a/app-emacs/edb/edb-1.32.ebuild
+++ b/app-emacs/edb/edb-1.32.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="EDB, The Emacs Database"
 HOMEPAGE="http://www.gnuvola.org/software/edb/
-	http://www.emacswiki.org/emacs/EmacsDataBase"
+	https://www.emacswiki.org/emacs/EmacsDataBase"
 SRC_URI="http://www.gnuvola.org/software/edb/${P}.tar.gz"
 
 LICENSE="GPL-3+ Texinfo-manual"

--- a/app-emacs/emacs-jabber/emacs-jabber-0.8.92.ebuild
+++ b/app-emacs/emacs-jabber/emacs-jabber-0.8.92.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="A Jabber client for Emacs"
 HOMEPAGE="http://emacs-jabber.sourceforge.net/
-	http://emacswiki.org/emacs/JabberEl"
+	https://www.emacswiki.org/emacs/JabberEl"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/emms/emms-3.0-r1.ebuild
+++ b/app-emacs/emms/emms-3.0-r1.ebuild
@@ -7,7 +7,7 @@ inherit elisp toolchain-funcs
 
 DESCRIPTION="The Emacs Multimedia System"
 HOMEPAGE="https://www.gnu.org/software/emms/
-	http://www.emacswiki.org/emacs/EMMS"
+	https://www.emacswiki.org/emacs/EMMS"
 SRC_URI="https://www.gnu.org/software/emms/download/${P}.tar.gz"
 
 LICENSE="GPL-3+ FDL-1.1+"

--- a/app-emacs/folding/folding-2012.0226.1623.ebuild
+++ b/app-emacs/folding/folding-2012.0226.1623.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="A folding-editor-like Emacs minor mode"
-HOMEPAGE="http://www.emacswiki.org/emacs/FoldingMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/FoldingMode"
 # taken from http://git.savannah.gnu.org/cgit/emacs-tiny-tools.git
 SRC_URI="mirror://gentoo/${P}.el.bz2"
 

--- a/app-emacs/folding/folding-2013.0613.1821.ebuild
+++ b/app-emacs/folding/folding-2013.0613.1821.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="A folding-editor-like Emacs minor mode"
-HOMEPAGE="http://www.emacswiki.org/emacs/FoldingMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/FoldingMode"
 # taken from http://git.savannah.gnu.org/cgit/emacs-tiny-tools.git
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/h4x0r/h4x0r-0.13-r1.ebuild
+++ b/app-emacs/h4x0r/h4x0r-0.13-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Aid in writing like a script kiddie does"
-HOMEPAGE="http://www.emacswiki.org/emacs/EliteSpeech"
+HOMEPAGE="https://www.emacswiki.org/emacs/EliteSpeech"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/hexrgb/hexrgb-0_p957.ebuild
+++ b/app-emacs/hexrgb/hexrgb-0_p957.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Functions to manipulate colors, including RGB hex strings"
-HOMEPAGE="http://www.emacswiki.org/emacs/hexrgb.el"
+HOMEPAGE="https://www.emacswiki.org/emacs/hexrgb.el"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/highline/highline-7.2.2.ebuild
+++ b/app-emacs/highline/highline-7.2.2.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Minor mode to highlight current line in buffer"
-HOMEPAGE="http://www.emacswiki.org/emacs/HighlineMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/HighlineMode"
 # taken from: http://www.emacswiki.org/emacs/download/${PN}.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/htmlize/htmlize-1.43.ebuild
+++ b/app-emacs/htmlize/htmlize-1.43.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 inherit elisp
 
 DESCRIPTION="HTML-ize font-lock buffers in Emacs"
-HOMEPAGE="http://emacswiki.org/emacs/Htmlize
+HOMEPAGE="https://www.emacswiki.org/emacs/Htmlize
 	http://fly.srk.fer.hr/~hniksic/emacs/"
 SRC_URI="mirror://gentoo/${P}.el.bz2"
 

--- a/app-emacs/htmlize/htmlize-1.47.ebuild
+++ b/app-emacs/htmlize/htmlize-1.47.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="HTML-ize font-lock buffers in Emacs"
-HOMEPAGE="http://emacswiki.org/emacs/Htmlize
+HOMEPAGE="https://www.emacswiki.org/emacs/Htmlize
 	http://fly.srk.fer.hr/~hniksic/emacs/"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/icicles/icicles-2013.04.23.23400.ebuild
+++ b/app-emacs/icicles/icicles-2013.04.23.23400.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Minibuffer input completion and cycling"
-HOMEPAGE="http://www.emacswiki.org/emacs/Icicles"
+HOMEPAGE="https://www.emacswiki.org/emacs/Icicles"
 SRC_URI="https://github.com/emacsmirror/icicles/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3+"

--- a/app-emacs/igrep/igrep-2.113.ebuild
+++ b/app-emacs/igrep/igrep-2.113.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION='An improved interface to "grep" and "find"'
-HOMEPAGE="http://www.emacswiki.org/emacs/GrepMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/GrepMode"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="GPL-2+"

--- a/app-emacs/inform-mode/inform-mode-1.5.8.ebuild
+++ b/app-emacs/inform-mode/inform-mode-1.5.8.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="A major mode for editing Inform programs"
-HOMEPAGE="http://rupert-lane.org/inform-mode/
+HOMEPAGE="https://www.rupert-lane.org/inform-mode/
 	http://www.emacswiki.org/emacs/InformMode"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 

--- a/app-emacs/inform-mode/inform-mode-1.5.8.ebuild
+++ b/app-emacs/inform-mode/inform-mode-1.5.8.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="A major mode for editing Inform programs"
 HOMEPAGE="https://www.rupert-lane.org/inform-mode/
-	http://www.emacswiki.org/emacs/InformMode"
+	https://www.emacswiki.org/emacs/InformMode"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="GPL-2+"

--- a/app-emacs/inform-mode/inform-mode-1.6.2.ebuild
+++ b/app-emacs/inform-mode/inform-mode-1.6.2.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="A major mode for editing Inform programs"
 HOMEPAGE="https://www.rupert-lane.org/inform-mode/
-	http://www.emacswiki.org/emacs/InformMode"
+	https://www.emacswiki.org/emacs/InformMode"
 SRC_URI="http://rupert-lane.org/${PN}/releases/${P}.tar.gz"
 
 LICENSE="GPL-3+"

--- a/app-emacs/inform-mode/inform-mode-1.6.2.ebuild
+++ b/app-emacs/inform-mode/inform-mode-1.6.2.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="A major mode for editing Inform programs"
-HOMEPAGE="http://rupert-lane.org/inform-mode/
+HOMEPAGE="https://www.rupert-lane.org/inform-mode/
 	http://www.emacswiki.org/emacs/InformMode"
 SRC_URI="http://rupert-lane.org/${PN}/releases/${P}.tar.gz"
 

--- a/app-emacs/initsplit/initsplit-1.7_pre20140203.ebuild
+++ b/app-emacs/initsplit/initsplit-1.7_pre20140203.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit readme.gentoo elisp
 
 DESCRIPTION="Split customizations into different files"
-HOMEPAGE="http://www.emacswiki.org/emacs/InitSplit"
+HOMEPAGE="https://www.emacswiki.org/emacs/InitSplit"
 # taken from https://github.com/dabrahams/${PN}
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/magit/magit-2.9.0.ebuild
+++ b/app-emacs/magit/magit-2.9.0.ebuild
@@ -7,7 +7,7 @@ NEED_EMACS=24
 inherit elisp
 
 DESCRIPTION="A Git porcelain inside Emacs"
-HOMEPAGE="http://magit.vc/"
+HOMEPAGE="https://magit.vc/"
 SRC_URI="https://github.com/magit/magit/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3+"

--- a/app-emacs/markdown-mode/markdown-mode-1.8.1-r1.ebuild
+++ b/app-emacs/markdown-mode/markdown-mode-1.8.1-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 inherit elisp
 
 DESCRIPTION="Major mode for editing Markdown-formatted text files"
-HOMEPAGE="http://jblevins.org/projects/markdown-mode/"
+HOMEPAGE="https://jblevins.org/projects/markdown-mode/"
 # Cannot use this url because its hash differ about every five minutes
 # SRC_URI="http://jblevins.org/git/markdown-mode.git/snapshot/${P}.tar.gz"
 SRC_URI="mirror://gentoo/${P}.el.xz"

--- a/app-emacs/markdown-mode/markdown-mode-2.0.ebuild
+++ b/app-emacs/markdown-mode/markdown-mode-2.0.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Major mode for editing Markdown-formatted text files"
-HOMEPAGE="http://jblevins.org/projects/markdown-mode/"
+HOMEPAGE="https://jblevins.org/projects/markdown-mode/"
 # Cannot use this url because its hash differ about every five minutes
 # SRC_URI="http://jblevins.org/git/${PN}.git/snapshot/${P}.tar.gz"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"

--- a/app-emacs/markdown-mode/markdown-mode-2.1.ebuild
+++ b/app-emacs/markdown-mode/markdown-mode-2.1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Major mode for editing Markdown-formatted text files"
-HOMEPAGE="http://jblevins.org/projects/markdown-mode/"
+HOMEPAGE="https://jblevins.org/projects/markdown-mode/"
 # Cannot use this url because its hash differ about every five minutes
 # SRC_URI="http://jblevins.org/git/${PN}.git/snapshot/${P}.tar.gz"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"

--- a/app-emacs/mic-paren/mic-paren-3.11.ebuild
+++ b/app-emacs/mic-paren/mic-paren-3.11.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Advanced highlighting of matching parentheses"
 HOMEPAGE="http://www.gnuvola.org/software/j/mic-paren/
-	http://www.emacswiki.org/emacs/MicParen"
+	https://www.emacswiki.org/emacs/MicParen"
 # taken from http://www.gnuvola.org/software/j/mic-paren/mic-paren.el
 SRC_URI="mirror://gentoo/${P}.el.xz"
 

--- a/app-emacs/mldonkey/mldonkey-0.0.4b-r1.ebuild
+++ b/app-emacs/mldonkey/mldonkey-0.0.4b-r1.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 MY_P="${PN}-el-${PV}"
 DESCRIPTION="An Emacs Lisp interface to the MLDonkey core"
-HOMEPAGE="http://www.emacswiki.org/emacs/MlDonkey
+HOMEPAGE="https://www.emacswiki.org/emacs/MlDonkey
 	http://web.archive.org/web/20070107165326/www.physik.fu-berlin.de/~dhansen/mldonkey/"
 SRC_URI="http://www.physik.fu-berlin.de/%7Edhansen/mldonkey/files/${MY_P}.tar.gz"
 

--- a/app-emacs/mode-compile/mode-compile-2.29.1.ebuild
+++ b/app-emacs/mode-compile/mode-compile-2.29.1.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Smart command for compiling files according to major-mode"
 HOMEPAGE="https://github.com/emacsmirror/mode-compile
-	http://www.emacswiki.org/emacs/ModeCompile"
+	https://www.emacswiki.org/emacs/ModeCompile"
 SRC_URI="https://github.com/emacsmirror/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3+"

--- a/app-emacs/multi-term/multi-term-1.3.ebuild
+++ b/app-emacs/multi-term/multi-term-1.3.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit elisp
 
 DESCRIPTION="Manage multiple terminal buffers in Emacs"
-HOMEPAGE="http://www.emacswiki.org/emacs/MultiTerm"
+HOMEPAGE="https://www.emacswiki.org/emacs/MultiTerm"
 # Taken from http://www.emacswiki.org/emacs/download/${PN}.el
 SRC_URI="https://dev.gentoo.org/~mjo/distfiles/${P}.el.xz"
 

--- a/app-emacs/org-mode/org-mode-8.2.6.ebuild
+++ b/app-emacs/org-mode/org-mode-8.2.6.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="An Emacs mode for notes and project planning"
-HOMEPAGE="http://www.orgmode.org/"
+HOMEPAGE="https://www.orgmode.org/"
 SRC_URI="http://orgmode.org/org-${PV}.tar.gz"
 
 LICENSE="GPL-3+ FDL-1.3+ contrib? ( GPL-2+ MIT ) odt-schema? ( OASIS-Open )"

--- a/app-emacs/org-mode/org-mode-8.3.2-r1.ebuild
+++ b/app-emacs/org-mode/org-mode-8.3.2-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp readme.gentoo-r1
 
 DESCRIPTION="An Emacs mode for notes and project planning"
-HOMEPAGE="http://www.orgmode.org/"
+HOMEPAGE="https://www.orgmode.org/"
 SRC_URI="http://orgmode.org/org-${PV}.tar.gz"
 
 LICENSE="GPL-3+ FDL-1.3+ contrib? ( GPL-2+ MIT ) odt-schema? ( OASIS-Open )"

--- a/app-emacs/org-mode/org-mode-9.0.1.ebuild
+++ b/app-emacs/org-mode/org-mode-9.0.1.ebuild
@@ -7,7 +7,7 @@ NEED_EMACS=24
 inherit elisp readme.gentoo-r1
 
 DESCRIPTION="An Emacs mode for notes and project planning"
-HOMEPAGE="http://www.orgmode.org/"
+HOMEPAGE="https://www.orgmode.org/"
 SRC_URI="http://orgmode.org/org-${PV}.tar.gz"
 
 LICENSE="GPL-3+ FDL-1.3+ contrib? ( GPL-2+ MIT ) odt-schema? ( OASIS-Open )"

--- a/app-emacs/org-mode/org-mode-9.0.4.ebuild
+++ b/app-emacs/org-mode/org-mode-9.0.4.ebuild
@@ -7,7 +7,7 @@ NEED_EMACS=24
 inherit elisp readme.gentoo-r1
 
 DESCRIPTION="An Emacs mode for notes and project planning"
-HOMEPAGE="http://www.orgmode.org/"
+HOMEPAGE="https://www.orgmode.org/"
 SRC_URI="http://orgmode.org/org-${PV}.tar.gz"
 
 LICENSE="GPL-3+ FDL-1.3+ contrib? ( GPL-2+ MIT ) odt-schema? ( OASIS-Open )"

--- a/app-emacs/outline-magic/outline-magic-0.9.ebuild
+++ b/app-emacs/outline-magic/outline-magic-0.9.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Outline mode extensions for Emacs"
 HOMEPAGE="https://github.com/tj64/outline-magic
-	http://www.emacswiki.org/emacs/OutlineMagic"
+	https://www.emacswiki.org/emacs/OutlineMagic"
 SRC_URI="mirror://gentoo/${P}.el.bz2"
 
 LICENSE="GPL-2+"

--- a/app-emacs/paredit/paredit-23-r1.ebuild
+++ b/app-emacs/paredit/paredit-23-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Minor mode for performing structured editing of S-expressions"
-HOMEPAGE="http://mumble.net/~campbell/emacs/
-	http://www.emacswiki.org/emacs/ParEdit"
+HOMEPAGE="https://mumble.net/~campbell/emacs/
+	https://www.emacswiki.org/emacs/ParEdit"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.tar.xz"
 
 LICENSE="GPL-3+"

--- a/app-emacs/planner/planner-3.42.ebuild
+++ b/app-emacs/planner/planner-3.42.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Maintain a local Wiki using Emacs-friendly markup"
-HOMEPAGE="http://www.emacswiki.org/emacs/PlannerMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/PlannerMode"
 SRC_URI="http://download.gna.org/planner-el/${P}.tar.gz"
 
 LICENSE="GPL-3+"

--- a/app-emacs/protbuf/protbuf-1.7-r1.ebuild
+++ b/app-emacs/protbuf/protbuf-1.7-r1.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Protect Emacs buffers from accidental killing"
 HOMEPAGE="http://www.splode.com/~friedman/software/emacs-lisp/
-	http://www.emacswiki.org/emacs/ProtectingBuffers"
+	https://www.emacswiki.org/emacs/ProtectingBuffers"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="GPL-2+"

--- a/app-emacs/psgml/psgml-1.4.0.ebuild
+++ b/app-emacs/psgml/psgml-1.4.0.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="A GNU Emacs Major Mode for editing SGML and XML coded documents"
 HOMEPAGE="https://sourceforge.net/projects/psgml/
-	http://www.emacswiki.org/emacs/PsgmlMode"
+	https://www.emacswiki.org/emacs/PsgmlMode"
 SRC_URI="http://www.fsavigny.de/gpled-software/${P}.tar.gz"
 
 LICENSE="GPL-2+ Texinfo-manual"

--- a/app-emacs/pymacs/pymacs-0.25-r2.ebuild
+++ b/app-emacs/pymacs/pymacs-0.25-r2.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit elisp distutils-r1 vcs-snapshot
 
 DESCRIPTION="A tool that allows both-side communication beetween Python and Emacs Lisp"
-HOMEPAGE="http://www.emacswiki.org/emacs/PyMacs"
+HOMEPAGE="https://www.emacswiki.org/emacs/PyMacs"
 SRC_URI="https://github.com/pinard/Pymacs/tarball/v${PV} -> ${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/redo+/redo+-1.19.ebuild
+++ b/app-emacs/redo+/redo+-1.19.ebuild
@@ -7,7 +7,7 @@ inherit readme.gentoo elisp
 
 DESCRIPTION="Redo/undo system for Emacs"
 HOMEPAGE="https://www.emacswiki.org/emacs/RedoPlus
-	http://www11.atwiki.jp/s-irie/pages/18.html"
+	https://www11.atwiki.jp/s-irie/pages/18.html"
 # taken from http://www.emacswiki.org/emacs/${PN}.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/redo+/redo+-1.19.ebuild
+++ b/app-emacs/redo+/redo+-1.19.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit readme.gentoo elisp
 
 DESCRIPTION="Redo/undo system for Emacs"
-HOMEPAGE="http://www.emacswiki.org/emacs/RedoPlus
+HOMEPAGE="https://www.emacswiki.org/emacs/RedoPlus
 	http://www11.atwiki.jp/s-irie/pages/18.html"
 # taken from http://www.emacswiki.org/emacs/${PN}.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"

--- a/app-emacs/regress/regress-1.5.1.ebuild
+++ b/app-emacs/regress/regress-1.5.1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Regression test harness for Emacs Lisp code"
-HOMEPAGE="http://www.emacswiki.org/emacs/WikifiedEmacsLispList"
+HOMEPAGE="https://www.emacswiki.org/emacs/WikifiedEmacsLispList"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-1+"

--- a/app-emacs/remember/remember-2.0.ebuild
+++ b/app-emacs/remember/remember-2.0.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Simplify writing short notes in emacs"
-HOMEPAGE="http://www.emacswiki.org/emacs/RememberMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/RememberMode"
 SRC_URI="http://download.gna.org/${PN}-el/${P}.tar.gz"
 
 LICENSE="GPL-3+ FDL-1.2+"

--- a/app-emacs/rfcview/rfcview-0.13.ebuild
+++ b/app-emacs/rfcview/rfcview-0.13.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="An Emacs mode that reformats IETF RFCs for display"
 HOMEPAGE="http://www.loveshack.ukfsn.org/emacs/
-	http://www.emacswiki.org/emacs/RfcView"
+	https://www.emacswiki.org/emacs/RfcView"
 # taken from http://www.loveshack.ukfsn.org/emacs/${PN}.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/rpm-spec-mode/rpm-spec-mode-0.15.ebuild
+++ b/app-emacs/rpm-spec-mode/rpm-spec-mode-0.15.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Emacs mode to ease editing of RPM spec files"
-HOMEPAGE="http://www.emacswiki.org/emacs/RpmSpecMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/RpmSpecMode"
 # taken from http://www.tihlde.org/~stigb/${PN}.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/rudel/rudel-0.3_pre20110721-r1.ebuild
+++ b/app-emacs/rudel/rudel-0.3_pre20110721-r1.ebuild
@@ -8,7 +8,7 @@ inherit readme.gentoo-r1 elisp
 
 DESCRIPTION="Collaborative editing environment for GNU Emacs"
 HOMEPAGE="http://rudel.sourceforge.net/
-	http://www.emacswiki.org/emacs/Rudel"
+	https://www.emacswiki.org/emacs/Rudel"
 # snapshot of bzr://rudel.bzr.sourceforge.net/bzrroot/rudel/trunk
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.tar.xz"
 

--- a/app-emacs/rust-mode/rust-mode-1_beta20150411.ebuild
+++ b/app-emacs/rust-mode/rust-mode-1_beta20150411.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="A major emacs mode for editing Rust source code"
-HOMEPAGE="http://www.rust-lang.org/"
+HOMEPAGE="https://www.rust-lang.org/"
 SRC_URI="https://dev.gentoo.org/~jauhien/distfiles/${P}.tar.gz"
 
 LICENSE="|| ( MIT Apache-2.0 )"

--- a/app-emacs/setnu/setnu-1.06.ebuild
+++ b/app-emacs/setnu/setnu-1.06.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Display line numbers in Emacs buffers"
 HOMEPAGE="http://www.wonderworks.com/
-	http://www.emacswiki.org/emacs/LineNumbers"
+	https://www.emacswiki.org/emacs/LineNumbers"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/stripes/stripes-0.2-r1.ebuild
+++ b/app-emacs/stripes/stripes-0.2-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="An Emacs mode that alternates the background color of lines"
-HOMEPAGE="http://www.emacswiki.org/emacs/StripesMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/StripesMode"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/teco/teco-7-r1.ebuild
+++ b/app-emacs/teco/teco-7-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit readme.gentoo elisp
 
 DESCRIPTION="TECO interpreter for GNU Emacs"
-HOMEPAGE="http://www.emacswiki.org/emacs/TECO"
+HOMEPAGE="https://www.emacswiki.org/emacs/TECO"
 # taken from: http://www.emacswiki.org/emacs/teco.el
 SRC_URI="mirror://gentoo/${P}.el.bz2"
 

--- a/app-emacs/tempo-snippets/tempo-snippets-0.1.5.ebuild
+++ b/app-emacs/tempo-snippets/tempo-snippets-0.1.5.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Visual insertion of tempo templates"
-HOMEPAGE="http://nschum.de/src/emacs/tempo-snippets/
-	http://www.emacswiki.org/emacs/TempoSnippets"
+HOMEPAGE="https://nschum.de/src/emacs/tempo-snippets/
+	https://www.emacswiki.org/emacs/TempoSnippets"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.bz2"
 
 LICENSE="GPL-2+"

--- a/app-emacs/thumbs/thumbs-2.0-r1.ebuild
+++ b/app-emacs/thumbs/thumbs-2.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 inherit elisp
 
 DESCRIPTION="Emacs thumbnail previewer for image files"
-HOMEPAGE="http://www.emacswiki.org/emacs/ThumbsMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/ThumbsMode"
 SRC_URI="mirror://gentoo/${P}.el.bz2"
 
 LICENSE="GPL-2"

--- a/app-emacs/typing/typing-1.1.4.ebuild
+++ b/app-emacs/typing/typing-1.1.4.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="The Typing of Emacs -- an Elisp parody of The Typing of the Dead for Dreamcast"
-HOMEPAGE="http://www.emacswiki.org/emacs/TypingOfEmacs"
+HOMEPAGE="https://www.emacswiki.org/emacs/TypingOfEmacs"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/visual-basic-mode/visual-basic-mode-1.4.12.ebuild
+++ b/app-emacs/visual-basic-mode/visual-basic-mode-1.4.12.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="A mode for editing Visual Basic programs"
-HOMEPAGE="http://www.emacswiki.org/emacs/VisualBasicMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/VisualBasicMode"
 # taken from http://www.emacswiki.org/emacs/${PN}.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 

--- a/app-emacs/wanderlust/wanderlust-2.15.9_p20130619.ebuild
+++ b/app-emacs/wanderlust/wanderlust-2.15.9_p20130619.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Yet Another Message Interface on Emacsen"
 HOMEPAGE="https://github.com/wanderlust/wanderlust
-	http://emacswiki.org/emacs/WanderLust"
+	https://www.emacswiki.org/emacs/WanderLust"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.tar.xz"
 
 LICENSE="GPL-2+"

--- a/app-emacs/whine/whine-20091222.ebuild
+++ b/app-emacs/whine/whine-20091222.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Complaint generator for GNU Emacs"
-HOMEPAGE="http://www.emacswiki.org/emacs/Whine"
+HOMEPAGE="https://www.emacswiki.org/emacs/Whine"
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.tar.bz2"
 
 LICENSE="public-domain"

--- a/app-emacs/wikipedia-mode/wikipedia-mode-0.5-r1.ebuild
+++ b/app-emacs/wikipedia-mode/wikipedia-mode-0.5-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp eutils
 
 DESCRIPTION="Mode for editing Wikipedia articles off-line"
-HOMEPAGE="http://www.emacswiki.org/emacs/WikipediaMode"
+HOMEPAGE="https://www.emacswiki.org/emacs/WikipediaMode"
 SRC_URI="mirror://gentoo/${P}.el.bz2"
 
 LICENSE="GPL-2+"

--- a/app-emacs/with-editor/with-editor-2.5.8.ebuild
+++ b/app-emacs/with-editor/with-editor-2.5.8.ebuild
@@ -7,7 +7,7 @@ NEED_EMACS=24
 inherit elisp
 
 DESCRIPTION="Use the Emacsclient as the \$EDITOR of child processes"
-HOMEPAGE="http://magit.vc/manual/with-editor"
+HOMEPAGE="https://magit.vc/manual/with-editor/"
 SRC_URI="https://github.com/magit/with-editor/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3+"

--- a/app-emacs/xrdb-mode/xrdb-mode-3.0.ebuild
+++ b/app-emacs/xrdb-mode/xrdb-mode-3.0.ebuild
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="An Emacs major mode for editing X resource database files"
 HOMEPAGE="https://launchpad.net/xrdb-mode
-	http://www.emacswiki.org/emacs/ResourceFiles"
+	https://www.emacswiki.org/emacs/ResourceFiles"
 # taken from https://launchpad.net/${PN}/trunk/3.0/+download/${PN}.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.xz"
 


### PR DESCRIPTION
Hi,

This PR fixes a lot of emacs related packages to use https instead of http and also removes some dead HOMEPAGES.
I saw 2 Homepages who provide https but aren't trusted by the browser. I didn't change those.

Please review.