### PR TITLE
sys-apps/shadow: Fix CVE-2018-7169

### DIFF
--- a/sys-apps/shadow/files/shadow-4.5-CVE-2018-7169.patch
+++ b/sys-apps/shadow/files/shadow-4.5-CVE-2018-7169.patch
@@ -1,0 +1,180 @@
+From fb28c99b8a66ff2605c5cb96abc0a4d975f92de0 Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <asarai@suse.de>
+Date: Thu, 15 Feb 2018 23:49:40 +1100
+Subject: [PATCH] newgidmap: enforce setgroups=deny if self-mapping a group
+
+This is necessary to match the kernel-side policy of "self-mapping in a
+user namespace is fine, but you cannot drop groups" -- a policy that was
+created in order to stop user namespaces from allowing trivial privilege
+escalation by dropping supplementary groups that were "blacklisted" from
+certain paths.
+
+This is the simplest fix for the underlying issue, and effectively makes
+it so that unless a user has a valid mapping set in /etc/subgid (which
+only administrators can modify) -- and they are currently trying to use
+that mapping -- then /proc/$pid/setgroups will be set to deny. This
+workaround is only partial, because ideally it should be possible to set
+an "allow_setgroups" or "deny_setgroups" flag in /etc/subgid to allow
+administrators to further restrict newgidmap(1).
+
+We also don't write anything in the "allow" case because "allow" is the
+default, and users may have already written "deny" even if they
+technically are allowed to use setgroups. And we don't write anything if
+the setgroups policy is already "deny".
+
+Ref: https://bugs.launchpad.net/ubuntu/+source/shadow/+bug/1729357
+Fixes: CVE-2018-7169
+Reported-by: Craig Furman <craig.furman89@gmail.com>
+Signed-off-by: Aleksa Sarai <asarai@suse.de>
+---
+ src/newgidmap.c | 89 +++++++++++++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 80 insertions(+), 9 deletions(-)
+
+diff --git a/src/newgidmap.c b/src/newgidmap.c
+index b1e33513..59a2e75c 100644
+--- a/src/newgidmap.c
++++ b/src/newgidmap.c
+@@ -46,32 +46,37 @@
+  */
+ const char *Prog;
+ 
+-static bool verify_range(struct passwd *pw, struct map_range *range)
++
++static bool verify_range(struct passwd *pw, struct map_range *range, bool *allow_setgroups)
+ {
+ 	/* An empty range is invalid */
+ 	if (range->count == 0)
+ 		return false;
+ 
+-	/* Test /etc/subgid */
+-	if (have_sub_gids(pw->pw_name, range->lower, range->count))
++	/* Test /etc/subgid. If the mapping is valid then we allow setgroups. */
++	if (have_sub_gids(pw->pw_name, range->lower, range->count)) {
++		*allow_setgroups = true;
+ 		return true;
++	}
+ 
+-	/* Allow a process to map its own gid */
+-	if ((range->count == 1) && (pw->pw_gid == range->lower))
++	/* Allow a process to map its own gid. */
++	if ((range->count == 1) && (pw->pw_gid == range->lower)) {
++		/* noop -- if setgroups is enabled already we won't disable it. */
+ 		return true;
++	}
+ 
+ 	return false;
+ }
+ 
+ static void verify_ranges(struct passwd *pw, int ranges,
+-	struct map_range *mappings)
++	struct map_range *mappings, bool *allow_setgroups)
+ {
+ 	struct map_range *mapping;
+ 	int idx;
+ 
+ 	mapping = mappings;
+ 	for (idx = 0; idx < ranges; idx++, mapping++) {
+-		if (!verify_range(pw, mapping)) {
++		if (!verify_range(pw, mapping, allow_setgroups)) {
+ 			fprintf(stderr, _( "%s: gid range [%lu-%lu) -> [%lu-%lu) not allowed\n"),
+ 				Prog,
+ 				mapping->upper,
+@@ -89,6 +94,70 @@ static void usage(void)
+ 	exit(EXIT_FAILURE);
+ }
+ 
++void write_setgroups(int proc_dir_fd, bool allow_setgroups)
++{
++	int setgroups_fd;
++	char *policy, policy_buffer[4096];
++
++	/*
++	 * Default is "deny", and any "allow" will out-rank a "deny". We don't
++	 * forcefully write an "allow" here because the process we are writing
++	 * mappings for may have already set themselves to "deny" (and "allow"
++	 * is the default anyway). So allow_setgroups == true is a noop.
++	 */
++	policy = "deny\n";
++	if (allow_setgroups)
++		return;
++
++	setgroups_fd = openat(proc_dir_fd, "setgroups", O_RDWR|O_CLOEXEC);
++	if (setgroups_fd < 0) {
++		/*
++		 * If it's an ENOENT then we are on too old a kernel for the setgroups
++		 * code to exist. Emit a warning and bail on this.
++		 */
++		if (ENOENT == errno) {
++			fprintf(stderr, _("%s: kernel doesn't support setgroups restrictions\n"), Prog);
++			goto out;
++		}
++		fprintf(stderr, _("%s: couldn't open process setgroups: %s\n"),
++			Prog,
++			strerror(errno));
++		exit(EXIT_FAILURE);
++	}
++
++	/*
++	 * Check whether the policy is already what we want. /proc/self/setgroups
++	 * is write-once, so attempting to write after it's already written to will
++	 * fail.
++	 */
++	if (read(setgroups_fd, policy_buffer, sizeof(policy_buffer)) < 0) {
++		fprintf(stderr, _("%s: failed to read setgroups: %s\n"),
++			Prog,
++			strerror(errno));
++		exit(EXIT_FAILURE);
++	}
++	if (!strncmp(policy_buffer, policy, strlen(policy)))
++		goto out;
++
++	/* Write the policy. */
++	if (lseek(setgroups_fd, 0, SEEK_SET) < 0) {
++		fprintf(stderr, _("%s: failed to seek setgroups: %s\n"),
++			Prog,
++			strerror(errno));
++		exit(EXIT_FAILURE);
++	}
++	if (dprintf(setgroups_fd, "%s", policy) < 0) {
++		fprintf(stderr, _("%s: failed to setgroups %s policy: %s\n"),
++			Prog,
++			policy,
++			strerror(errno));
++		exit(EXIT_FAILURE);
++	}
++
++out:
++	close(setgroups_fd);
++}
++
+ /*
+  * newgidmap - Set the gid_map for the specified process
+  */
+@@ -103,6 +172,7 @@ int main(int argc, char **argv)
+ 	struct stat st;
+ 	struct passwd *pw;
+ 	int written;
++	bool allow_setgroups = false;
+ 
+ 	Prog = Basename (argv[0]);
+ 
+@@ -145,7 +215,7 @@ int main(int argc, char **argv)
+ 				(unsigned long) getuid ()));
+ 		return EXIT_FAILURE;
+ 	}
+-	
++
+ 	/* Get the effective uid and effective gid of the target process */
+ 	if (fstat(proc_dir_fd, &st) < 0) {
+ 		fprintf(stderr, _("%s: Could not stat directory for target %u\n"),
+@@ -177,8 +247,9 @@ int main(int argc, char **argv)
+ 	if (!mappings)
+ 		usage();
+ 
+-	verify_ranges(pw, ranges, mappings);
++	verify_ranges(pw, ranges, mappings, &allow_setgroups);
+ 
++	write_setgroups(proc_dir_fd, allow_setgroups);
+ 	write_mapping(proc_dir_fd, ranges, mappings, "gid_map");
+ 	sub_gid_close();
+ 

--- a/sys-apps/shadow/shadow-4.5-r1.ebuild
+++ b/sys-apps/shadow/shadow-4.5-r1.ebuild
@@ -1,0 +1,210 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="5"
+
+inherit eutils libtool pam multilib
+
+DESCRIPTION="Utilities to deal with user accounts"
+HOMEPAGE="https://github.com/shadow-maint/shadow http://pkg-shadow.alioth.debian.org/"
+SRC_URI="https://github.com/shadow-maint/shadow/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+IUSE="acl audit +cracklib nls pam selinux skey xattr"
+# Taken from the man/Makefile.am file.
+LANGS=( cs da de es fi fr hu id it ja ko pl pt_BR ru sv tr zh_CN zh_TW )
+
+RDEPEND="acl? ( sys-apps/acl:0= )
+	audit? ( >=sys-process/audit-2.6:0= )
+	cracklib? ( >=sys-libs/cracklib-2.7-r3:0= )
+	pam? ( virtual/pam:0= )
+	skey? ( sys-auth/skey:0= )
+	selinux? (
+		>=sys-libs/libselinux-1.28:0=
+		sys-libs/libsemanage:0=
+	)
+	nls? ( virtual/libintl )
+	xattr? ( sys-apps/attr:0= )"
+DEPEND="${RDEPEND}
+	app-arch/xz-utils
+	nls? ( sys-devel/gettext )"
+RDEPEND="${RDEPEND}
+	pam? ( >=sys-auth/pambase-20150213 )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-4.1.3-dots-in-usernames.patch"
+	"${FILESDIR}/${P}-CVE-2018-7169.patch"
+)
+
+src_prepare() {
+	epatch "${PATCHES[@]}"
+	epatch_user
+	#eautoreconf
+	elibtoolize
+}
+
+src_configure() {
+	econf \
+		--without-group-name-max-length \
+		--without-tcb \
+		--enable-shared=no \
+		--enable-static=yes \
+		$(use_with acl) \
+		$(use_with audit) \
+		$(use_with cracklib libcrack) \
+		$(use_with pam libpam) \
+		$(use_with skey) \
+		$(use_with selinux) \
+		$(use_enable nls) \
+		$(use_with elibc_glibc nscd) \
+		$(use_with xattr attr)
+	has_version 'sys-libs/uclibc[-rpc]' && sed -i '/RLOGIN/d' config.h #425052
+
+	if use nls ; then
+		local l langs="po" # These are the pot files.
+		for l in ${LANGS[*]} ; do
+			has ${l} ${LINGUAS-${l}} && langs+=" ${l}"
+		done
+		sed -i "/^SUBDIRS = /s:=.*:= ${langs}:" man/Makefile || die
+	fi
+}
+
+set_login_opt() {
+	local comment="" opt=$1 val=$2
+	if [[ -z ${val} ]]; then
+		comment="#"
+		sed -i \
+			-e "/^${opt}\>/s:^:#:" \
+			"${ED}"/etc/login.defs || die
+	else
+		sed -i -r \
+			-e "/^#?${opt}\>/s:.*:${opt} ${val}:" \
+			"${ED}"/etc/login.defs
+	fi
+	local res=$(grep "^${comment}${opt}\>" "${ED}"/etc/login.defs)
+	einfo "${res:-Unable to find ${opt} in /etc/login.defs}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" suidperms=4711 install
+
+	# Remove libshadow and libmisc; see bug 37725 and the following
+	# comment from shadow's README.linux:
+	#   Currently, libshadow.a is for internal use only, so if you see
+	#   -lshadow in a Makefile of some other package, it is safe to
+	#   remove it.
+	rm -f "${ED}"/{,usr/}$(get_libdir)/lib{misc,shadow}.{a,la}
+
+	insinto /etc
+	if ! use pam ; then
+		insopts -m0600
+		doins etc/login.access etc/limits
+	fi
+
+	# needed for 'useradd -D'
+	insinto /etc/default
+	insopts -m0600
+	doins "${FILESDIR}"/default/useradd
+
+	# move passwd to / to help recover broke systems #64441
+	mv "${ED}"/usr/bin/passwd "${ED}"/bin/ || die
+	dosym /bin/passwd /usr/bin/passwd
+
+	cd "${S}"
+	insinto /etc
+	insopts -m0644
+	newins etc/login.defs login.defs
+
+	set_login_opt CREATE_HOME yes
+	if ! use pam ; then
+		set_login_opt MAIL_CHECK_ENAB no
+		set_login_opt SU_WHEEL_ONLY yes
+		set_login_opt CRACKLIB_DICTPATH /usr/$(get_libdir)/cracklib_dict
+		set_login_opt LOGIN_RETRIES 3
+		set_login_opt ENCRYPT_METHOD SHA512
+		set_login_opt CONSOLE
+	else
+		dopamd "${FILESDIR}"/pam.d-include/shadow
+
+		for x in chpasswd chgpasswd newusers; do
+			newpamd "${FILESDIR}"/pam.d-include/passwd ${x}
+		done
+
+		for x in chage chsh chfn \
+				 user{add,del,mod} group{add,del,mod} ; do
+			newpamd "${FILESDIR}"/pam.d-include/shadow ${x}
+		done
+
+		# comment out login.defs options that pam hates
+		local opt sed_args=()
+		for opt in \
+			CHFN_AUTH \
+			CONSOLE \
+			CRACKLIB_DICTPATH \
+			ENV_HZ \
+			ENVIRON_FILE \
+			FAILLOG_ENAB \
+			FTMP_FILE \
+			LASTLOG_ENAB \
+			MAIL_CHECK_ENAB \
+			MOTD_FILE \
+			NOLOGINS_FILE \
+			OBSCURE_CHECKS_ENAB \
+			PASS_ALWAYS_WARN \
+			PASS_CHANGE_TRIES \
+			PASS_MIN_LEN \
+			PORTTIME_CHECKS_ENAB \
+			QUOTAS_ENAB \
+			SU_WHEEL_ONLY
+		do
+			set_login_opt ${opt}
+			sed_args+=( -e "/^#${opt}\>/b pamnote" )
+		done
+		sed -i "${sed_args[@]}" \
+			-e 'b exit' \
+			-e ': pamnote; i# NOTE: This setting should be configured via /etc/pam.d/ and not in this file.' \
+			-e ': exit' \
+			"${ED}"/etc/login.defs || die
+
+		# remove manpages that pam will install for us
+		# and/or don't apply when using pam
+		find "${ED}"/usr/share/man \
+			'(' -name 'limits.5*' -o -name 'suauth.5*' ')' \
+			-delete
+
+		# Remove pam.d files provided by pambase.
+		rm "${ED}"/etc/pam.d/{login,passwd,su} || die
+	fi
+
+	# Remove manpages that are handled by other packages
+	find "${ED}"/usr/share/man \
+		'(' -name id.1 -o -name passwd.5 -o -name getspnam.3 ')' \
+		-delete
+
+	cd "${S}"
+	dodoc ChangeLog NEWS TODO
+	newdoc README README.download
+	cd doc
+	dodoc HOWTO README* WISHLIST *.txt
+}
+
+pkg_preinst() {
+	rm -f "${EROOT}"/etc/pam.d/system-auth.new \
+		"${EROOT}/etc/login.defs.new"
+}
+
+pkg_postinst() {
+	# Enable shadow groups.
+	if [ ! -f "${EROOT}"/etc/gshadow ] ; then
+		if grpck -r -R "${EROOT}" 2>/dev/null ; then
+			grpconv -R "${EROOT}"
+		else
+			ewarn "Running 'grpck' returned errors.  Please run it by hand, and then"
+			ewarn "run 'grpconv' afterwards!"
+		fi
+	fi
+
+	einfo "The 'adduser' symlink to 'useradd' has been dropped."
+}


### PR DESCRIPTION
Fix CVE-2018-7169 by applying upstream patch:
https://github.com/shadow-maint/shadow/commit/fb28c99b8a66ff2605c5cb96abc0a4d975f92de0

Closes: https://bugs.gentoo.org/647790

Package-Manager: Portage-2.3.19, Repoman-2.3.6