### PR TITLE
media-libs/tiff: Patch to fix type (CVE-2017-9935)

### DIFF
--- a/media-libs/tiff/files/tiff-4.0.9-CVE-2017-9935-fix-incorrect-type.patch
+++ b/media-libs/tiff/files/tiff-4.0.9-CVE-2017-9935-fix-incorrect-type.patch
@@ -1,0 +1,58 @@
+From d4f213636b6f950498a1386083199bd7f65676b9 Mon Sep 17 00:00:00 2001
+From: Brian May <brian@linuxpenguins.xyz>
+Date: Thu, 7 Dec 2017 07:49:20 +1100
+Subject: [PATCH] tiff2pdf: Fix apparent incorrect type for transfer table
+
+The standard says the transfer table contains unsigned 16 bit values,
+I have no idea why we refer to them as floats.
+---
+ tools/tiff2pdf.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/tools/tiff2pdf.c b/tools/tiff2pdf.c
+index c3ec074..484776c 100644
+--- a/tools/tiff2pdf.c
++++ b/tools/tiff2pdf.c
+@@ -237,7 +237,7 @@ typedef struct {
+ 	float tiff_whitechromaticities[2];
+ 	float tiff_primarychromaticities[6];
+ 	float tiff_referenceblackwhite[2];
+-	float* tiff_transferfunction[3];
++	uint16* tiff_transferfunction[3];
+ 	int pdf_image_interpolate;	/* 0 (default) : do not interpolate,
+ 					   1 : interpolate */
+ 	uint16 tiff_transferfunctioncount;
+@@ -1048,7 +1048,7 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
+ 	uint16 paged=0;
+ 	uint16 xuint16=0;
+ 	uint16 tiff_transferfunctioncount=0;
+-	float* tiff_transferfunction[3];
++	uint16* tiff_transferfunction[3];
+ 
+ 	directorycount=TIFFNumberOfDirectories(input);
+ 	t2p->tiff_pages = (T2P_PAGE*) _TIFFmalloc(TIFFSafeMultiply(tmsize_t,directorycount,sizeof(T2P_PAGE)));
+@@ -1153,8 +1153,8 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
+                                  &(tiff_transferfunction[1]),
+                                  &(tiff_transferfunction[2]))) {
+ 
+-                        if((tiff_transferfunction[1] != (float*) NULL) &&
+-                           (tiff_transferfunction[2] != (float*) NULL)
++                        if((tiff_transferfunction[1] != (uint16*) NULL) &&
++                           (tiff_transferfunction[2] != (uint16*) NULL)
+                           ) {
+                             tiff_transferfunctioncount=3;
+                         } else {
+@@ -1851,8 +1851,8 @@ void t2p_read_tiff_data(T2P* t2p, TIFF* input){
+ 			 &(t2p->tiff_transferfunction[0]),
+ 			 &(t2p->tiff_transferfunction[1]),
+ 			 &(t2p->tiff_transferfunction[2]))) {
+-		if((t2p->tiff_transferfunction[1] != (float*) NULL) &&
+-                   (t2p->tiff_transferfunction[2] != (float*) NULL)
++		if((t2p->tiff_transferfunction[1] != (uint16*) NULL) &&
++                   (t2p->tiff_transferfunction[2] != (uint16*) NULL)
+                   ) {
+ 			t2p->tiff_transferfunctioncount=3;
+ 		} else {
+--
+libgit2 0.26.0
+

--- a/media-libs/tiff/tiff-4.0.9-r2.ebuild
+++ b/media-libs/tiff/tiff-4.0.9-r2.ebuild
@@ -1,0 +1,80 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+inherit autotools eutils libtool multilib-minimal
+
+DESCRIPTION="Tag Image File Format (TIFF) library"
+HOMEPAGE="http://libtiff.maptools.org"
+SRC_URI="http://download.osgeo.org/libtiff/${P}.tar.gz
+	ftp://ftp.remotesensing.org/pub/libtiff/${P}.tar.gz"
+
+LICENSE="libtiff"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="+cxx jbig jpeg lzma static-libs test zlib"
+
+RDEPEND="jpeg? ( >=virtual/jpeg-0-r2:0=[${MULTILIB_USEDEP}] )
+	jbig? ( >=media-libs/jbigkit-2.1:=[${MULTILIB_USEDEP}] )
+	lzma? ( >=app-arch/xz-utils-5.0.5-r1:=[${MULTILIB_USEDEP}] )
+	zlib? ( >=sys-libs/zlib-1.2.8-r1:=[${MULTILIB_USEDEP}] )
+	abi_x86_32? (
+		!<=app-emulation/emul-linux-x86-baselibs-20130224-r9
+		!app-emulation/emul-linux-x86-baselibs[-abi_x86_32(-)]
+	)"
+DEPEND="${RDEPEND}"
+
+REQUIRED_USE="test? ( jpeg )" #483132
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.0.7-pdfium-0006-HeapBufferOverflow-ChopUpSingleUncompressedStrip.patch
+	"${FILESDIR}"/${PN}-4.0.7-pdfium-0008-HeapBufferOverflow-ChopUpSingleUncompressedStrip.patch
+	"${FILESDIR}"/${P}-CVE-2017-9935.patch #624696
+	"${FILESDIR}"/${P}-CVE-2017-9935-fix-incorrect-type.patch #624696
+)
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/tiffconf.h
+)
+
+src_prepare() {
+	default
+
+	# tiffcp-thumbnail.sh fails as thumbnail binary doesn't get built anymore since tiff-4.0.7
+	sed '/tiffcp-thumbnail\.sh/d' -i test/Makefile.am || die
+
+	eautoreconf
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf \
+		$(use_enable static-libs static) \
+		$(use_enable zlib) \
+		$(use_enable jpeg) \
+		$(use_enable jbig) \
+		$(use_enable lzma) \
+		$(use_enable cxx) \
+		--without-x
+
+	# remove useless subdirs
+	if ! multilib_is_native_abi ; then
+		sed -i \
+			-e 's/ tools//' \
+			-e 's/ contrib//' \
+			-e 's/ man//' \
+			-e 's/ html//' \
+			Makefile || die
+	fi
+}
+
+multilib_src_test() {
+	if ! multilib_is_native_abi ; then
+		emake -C tools
+	fi
+	emake check
+}
+
+multilib_src_install_all() {
+	prune_libtool_files --all
+	rm -f "${ED}"/usr/share/doc/${PF}/{COPYRIGHT,README*,RELEASE-DATE,TODO,VERSION}
+}


### PR DESCRIPTION
CVE-2017-9935 has a second commit with ID
d4f213636b6f950498a1386083199bd7f65676b9 to fix the type of the table.

Bug: https://bugs.gentoo.org/624696

Package-Manager: Portage-2.3.19, Repoman-2.3.6