### PR TITLE
www-servers/tomcat: fix link to tomcat guide

### DIFF
--- a/www-servers/tomcat/tomcat-7.0.82.ebuild
+++ b/www-servers/tomcat/tomcat-7.0.82.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -144,5 +144,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-7.0.84.ebuild
+++ b/www-servers/tomcat/tomcat-7.0.84.ebuild
@@ -142,5 +142,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-7.0.85.ebuild
+++ b/www-servers/tomcat/tomcat-7.0.85.ebuild
@@ -142,5 +142,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-8.0.48.ebuild
+++ b/www-servers/tomcat/tomcat-8.0.48.ebuild
@@ -153,5 +153,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-8.0.49.ebuild
+++ b/www-servers/tomcat/tomcat-8.0.49.ebuild
@@ -153,5 +153,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-8.0.50.ebuild
+++ b/www-servers/tomcat/tomcat-8.0.50.ebuild
@@ -153,5 +153,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-8.5.24.ebuild
+++ b/www-servers/tomcat/tomcat-8.5.24.ebuild
@@ -153,5 +153,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-8.5.27.ebuild
+++ b/www-servers/tomcat/tomcat-8.5.27.ebuild
@@ -153,5 +153,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-8.5.28.ebuild
+++ b/www-servers/tomcat/tomcat-8.5.28.ebuild
@@ -153,5 +153,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-9.0.4.ebuild
+++ b/www-servers/tomcat/tomcat-9.0.4.ebuild
@@ -153,5 +153,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }

--- a/www-servers/tomcat/tomcat-9.0.5.ebuild
+++ b/www-servers/tomcat/tomcat-9.0.5.ebuild
@@ -153,5 +153,5 @@ pkg_postinst() {
 	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
 	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
 
-#	einfo "Please read https://www.gentoo.org/proj/en/java/tomcat6-guide.xml for more information."
+#	einfo "Please read https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
 }


### PR DESCRIPTION
Hi,

This fixes the Link to the Tomcat guide in all tomcat ebuilds.

Please review.