### PR TITLE
app-misc/anki: Add webengine and webchannel dependencies

### DIFF
--- a/app-misc/anki/anki-2.1.0_beta27.ebuild
+++ b/app-misc/anki/anki-2.1.0_beta27.ebuild
@@ -22,7 +22,7 @@ IUSE="latex +recording +sound test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
-	dev-python/PyQt5[gui,svg,webkit,${PYTHON_USEDEP}]
+	dev-python/PyQt5[gui,svg,webengine,webchannel,${PYTHON_USEDEP}]
 	>=dev-python/httplib2-0.7.4[${PYTHON_USEDEP}]
 	dev-python/beautifulsoup:4[${PYTHON_USEDEP}]
 	dev-python/decorator[${PYTHON_USEDEP}]


### PR DESCRIPTION
Anki requires webengine and webchannel to work.
Webkit is no longer used (and is deprecated in Qt) so it is removed here.