### PR TITLE
sys-devel/gdb: fix gcore collision on freebsd

### DIFF
--- a/sys-devel/gdb/gdb-8.1.ebuild
+++ b/sys-devel/gdb/gdb-8.1.ebuild
@@ -234,6 +234,11 @@ src_install() {
 
 	# Remove shared info pages
 	rm -f "${ED}"/usr/share/info/{annotate,bfd,configure,standards}.info*
+
+	# gcore is part of ubin on freebsd
+	if [[ ${CHOST} == *-freebsd* ]]; then
+		rm "${ED}"/usr/bin/gcore || die
+	fi
 }
 
 pkg_postinst() {

--- a/sys-devel/gdb/gdb-9999.ebuild
+++ b/sys-devel/gdb/gdb-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -218,6 +218,11 @@ src_install() {
 
 	# Remove shared info pages
 	rm -f "${ED}"/usr/share/info/{annotate,bfd,configure,standards}.info*
+
+	# gcore is part of ubin on freebsd
+	if [[ ${CHOST} == *-freebsd* ]]; then
+		rm "${ED}"/usr/bin/gcore || die
+	fi
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/507456
Package-Manager: Portage-2.3.19, Repoman-2.3.6