### PR TITLE
x11-misc/rofi: librsvg is a dependency of rofi

### DIFF
--- a/x11-misc/rofi/rofi-1.5.0.ebuild
+++ b/x11-misc/rofi/rofi-1.5.0.ebuild
@@ -32,6 +32,7 @@ DEPEND="
 	virtual/pkgconfig
 	x11-proto/xineramaproto
 	x11-proto/xproto
+	gnome-base/librsvg
 	test? ( >=dev-libs/check-0.11 )
 "
 PATCHES=(


### PR DESCRIPTION
x11-misc/rofi will fail to build if gnome-base/librsvg is not in the
DEPEND list or was not installed previously.