### PR TITLE
sys-block/arcconf: add proxy maintainer

### DIFF
--- a/sys-block/arcconf/metadata.xml
+++ b/sys-block/arcconf/metadata.xml
@@ -5,4 +5,12 @@
 		<email>dev-zero@gentoo.org</email>
 		<name>Tiziano Müller</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>ck+gentoo@bl4ckb0x.de</email>
+		<name>Conrad Kostecki</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
As in https://bugs.gentoo.org/588432 discussed, I would be willing to proxy maintain sys-block/arcconf.