### PR TITLE
app-leechcraft/leechcraft-meta: use HTTPS

### DIFF
--- a/app-leechcraft/leechcraft-meta/leechcraft-meta-9999.ebuild
+++ b/app-leechcraft/leechcraft-meta/leechcraft-meta-9999.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Metapackage containing all ready-to-use LeechCraft plugins"
-HOMEPAGE="http://leechcraft.org/"
+HOMEPAGE="https://leechcraft.org/"
 
 SLOT="0"
 KEYWORDS=""


### PR DESCRIPTION
Hi,

This PR fixes the leechcraft meta ebuild to use https instead of http.

Please review.