### PR TITLE
dev-libs/{OpenNI2,capnproto}, net-libs/ignition-{msgs,transport}, sci-libs/ignition-math: use HTTPS

### DIFF
--- a/dev-libs/OpenNI2/OpenNI2-2.2_beta2.ebuild
+++ b/dev-libs/OpenNI2/OpenNI2-2.2_beta2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -21,7 +21,7 @@ else
 fi
 
 DESCRIPTION="OpenNI2 SDK"
-HOMEPAGE="http://structure.io/openni"
+HOMEPAGE="https://structure.io/openni"
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="doc java neon opengl static-libs"

--- a/dev-libs/OpenNI2/OpenNI2-9999.ebuild
+++ b/dev-libs/OpenNI2/OpenNI2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -21,7 +21,7 @@ else
 fi
 
 DESCRIPTION="OpenNI2 SDK"
-HOMEPAGE="http://structure.io/openni"
+HOMEPAGE="https://structure.io/openni"
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="doc java neon opengl static-libs"

--- a/dev-libs/capnproto/capnproto-0.6.0.ebuild
+++ b/dev-libs/capnproto/capnproto-0.6.0.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit autotools
 
 DESCRIPTION="RPC/Serialization system with capabilities support"
-HOMEPAGE="http://capnproto.org"
+HOMEPAGE="https://capnproto.org"
 SRC_URI="https://github.com/sandstorm-io/capnproto/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-libs/capnproto/capnproto-0.6.1.ebuild
+++ b/dev-libs/capnproto/capnproto-0.6.1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit autotools
 
 DESCRIPTION="RPC/Serialization system with capabilities support"
-HOMEPAGE="http://capnproto.org"
+HOMEPAGE="https://capnproto.org"
 SRC_URI="https://github.com/sandstorm-io/capnproto/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"

--- a/net-libs/ignition-msgs/ignition-msgs-0.7.0.ebuild
+++ b/net-libs/ignition-msgs/ignition-msgs-0.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="Protobuf messages and functions for robot applications"
-HOMEPAGE="http://ignitionrobotics.org/libraries/messages https://bitbucket.org/ignitionrobotics/ign-msgs"
+HOMEPAGE="https://ignitionrobotics.org/libraries/messages https://bitbucket.org/ignitionrobotics/ign-msgs"
 SRC_URI="https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/${P}.tar.bz2"
 
 LICENSE="Apache-2.0"

--- a/net-libs/ignition-msgs/ignition-msgs-1.0.0.ebuild
+++ b/net-libs/ignition-msgs/ignition-msgs-1.0.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-multilib
 
 DESCRIPTION="Protobuf messages and functions for robot applications"
-HOMEPAGE="http://ignitionrobotics.org/libraries/messages https://bitbucket.org/ignitionrobotics/ign-msgs"
+HOMEPAGE="https://ignitionrobotics.org/libraries/messages https://bitbucket.org/ignitionrobotics/ign-msgs"
 SRC_URI="https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/${P}.tar.bz2"
 
 LICENSE="Apache-2.0"

--- a/net-libs/ignition-transport/ignition-transport-3.1.0-r1.ebuild
+++ b/net-libs/ignition-transport/ignition-transport-3.1.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit cmake-utils vcs-snapshot flag-o-matic
 
 DESCRIPTION="Combines ZeroMQ with Protobufs to create a fast and efficient message passing system"
-HOMEPAGE="http://ignitionrobotics.org/libraries/transport"
+HOMEPAGE="https://ignitionrobotics.org/libraries/transport"
 SRC_URI="http://gazebosim.org/distributions/ign-transport/releases/${PN}3-${PV}.tar.bz2"
 
 LICENSE="Apache-2.0"

--- a/net-libs/ignition-transport/ignition-transport-4.0.0.ebuild
+++ b/net-libs/ignition-transport/ignition-transport-4.0.0.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit cmake-utils vcs-snapshot flag-o-matic
 
 DESCRIPTION="Combines ZeroMQ with Protobufs to create a fast and efficient message passing system"
-HOMEPAGE="http://ignitionrobotics.org/libraries/transport"
+HOMEPAGE="https://ignitionrobotics.org/libraries/transport"
 SRC_URI="http://gazebosim.org/distributions/ign-transport/releases/${PN}4-${PV}.tar.bz2"
 
 LICENSE="Apache-2.0"

--- a/sci-libs/ignition-math/ignition-math-3.2.0.ebuild
+++ b/sci-libs/ignition-math/ignition-math-3.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit cmake-multilib vcs-snapshot flag-o-matic
 
 DESCRIPTION="A small, fast, and high performance math library for robot applications"
-HOMEPAGE="http://ignitionrobotics.org/libraries/math"
+HOMEPAGE="https://ignitionrobotics.org/libraries/math"
 SRC_URI="https://bitbucket.org/ignitionrobotics/ign-math/get/${PN}3_${PV}.tar.bz2"
 
 LICENSE="Apache-2.0"

--- a/sci-libs/ignition-math/ignition-math-4.0.0.ebuild
+++ b/sci-libs/ignition-math/ignition-math-4.0.0.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit cmake-multilib vcs-snapshot flag-o-matic
 
 DESCRIPTION="A small, fast, and high performance math library for robot applications"
-HOMEPAGE="http://ignitionrobotics.org/libraries/math"
+HOMEPAGE="https://ignitionrobotics.org/libraries/math"
 SRC_URI="https://bitbucket.org/ignitionrobotics/ign-math/get/${PN}4_${PV}.tar.bz2"
 
 LICENSE="Apache-2.0"


### PR DESCRIPTION
Hi,

This PR fixes a few ebuilds to use https instead of http.

Please review.