### PR TITLE
profiles.desc: Mark amd64-fbsd 11.1 profile stable

### DIFF
--- a/profiles/profiles.desc
+++ b/profiles/profiles.desc
@@ -250,7 +250,7 @@ x86		default/linux/x86/17.0/systemd			stable
 # Gentoo/FreeBSD Profiles
 # @MAINTAINER: bsd@gentoo.org
 amd64-fbsd	default/bsd/fbsd/amd64/9.1			exp
-amd64-fbsd	default/bsd/fbsd/amd64/11.1			dev
+amd64-fbsd	default/bsd/fbsd/amd64/11.1			stable
 amd64-fbsd	default/bsd/fbsd/amd64/9.1/clang		exp
 amd64-fbsd	default/bsd/fbsd/amd64/11.1/clang		exp
 x86-fbsd	default/bsd/fbsd/x86/9.1			exp


### PR DESCRIPTION
Mark the main amd64-fbsd profile stable now that all depgraph breakages
are fixed and the arch is actively maintained. This should prevent
regressions from occurring due to developers forgetting to use 'repoman
full -d' or forgetting to file keywordreqs to us.

For users, this does not change much since there is no other stable
amd64-fbsd profile. In other words, it remains being the only non-exp
profile.