### PR TITLE
media-gfx/pinta, net-libs/librsync: use HTTPS

### DIFF
--- a/media-gfx/pinta/pinta-1.6-r2.ebuild
+++ b/media-gfx/pinta/pinta-1.6-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit fdo-mime mono-env gnome2-utils
 
 DESCRIPTION="Simple Painting for Gtk"
-HOMEPAGE="http://pinta-project.com"
+HOMEPAGE="https://pinta-project.com"
 SRC_URI="https://github.com/PintaProject/Pinta/releases/download/${PV}/${P}.tar.gz"
 
 LICENSE="MIT CC-BY-3.0"

--- a/media-gfx/pinta/pinta-9999.ebuild
+++ b/media-gfx/pinta/pinta-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit fdo-mime mono-env gnome2-utils autotools git-2
 
 DESCRIPTION="Simple Painting for Gtk"
-HOMEPAGE="http://pinta-project.com"
+HOMEPAGE="https://pinta-project.com"
 SRC_URI=""
 EGIT_REPO_URI="https://github.com/PintaProject/Pinta.git"
 

--- a/net-libs/librsync/librsync-0.9.7-r3.ebuild
+++ b/net-libs/librsync/librsync-0.9.7-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ AUTOTOOLS_AUTORECONF=true
 inherit autotools-utils
 
 DESCRIPTION="Flexible remote checksum-based differencing"
-HOMEPAGE="http://librsync.sourceforge.net/"
+HOMEPAGE="https://librsync.github.io/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/net-libs/librsync/librsync-2.0.0-r1.ebuild
+++ b/net-libs/librsync/librsync-2.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="Remote delta-compression library"
-HOMEPAGE="http://librsync.sourcefrog.net/"
+HOMEPAGE="https://librsync.github.io/"
 SRC_URI="https://github.com/librsync/librsync/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/net-libs/librsync/librsync-2.0.0.ebuild
+++ b/net-libs/librsync/librsync-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="Remote delta-compression library"
-HOMEPAGE="http://librsync.sourcefrog.net/"
+HOMEPAGE="https://librsync.github.io/"
 SRC_URI="https://github.com/librsync/librsync/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/net-libs/librsync/librsync-2.0.1-r1.ebuild
+++ b/net-libs/librsync/librsync-2.0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="Remote delta-compression library"
-HOMEPAGE="http://librsync.sourcefrog.net/"
+HOMEPAGE="https://librsync.github.io/"
 SRC_URI="https://github.com/librsync/librsync/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"


### PR DESCRIPTION
Hi,

This PR fixes two packages to use https and avoids redirection.
Please review.