### PR TITLE
dev-python/ansicolor: add live ebuild

### DIFF
--- a/dev-python/ansicolor/ansicolor-9999.ebuild
+++ b/dev-python/ansicolor/ansicolor-9999.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
+
+inherit distutils-r1 git-r3
+
+DESCRIPTION="Produce ansi color output and colored highlighting and diffing"
+HOMEPAGE="https://github.com/numerodix/ansicolor"
+EGIT_REPO_URI="https://github.com/numerodix/ansicolor.git"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS=""
+IUSE="test"
+
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? ( dev-python/pytest[${PYTHON_USEDEP}] )
+"
+
+python_test() {
+	py.test -v || die "Test suite failed with ${EPYTHON}"
+}


### PR DESCRIPTION
It has tests!

Package-Manager: Portage-2.3.24, Repoman-2.3.6