### PR TITLE
hardened/linux/powerpc/ppc64/64bit-userland/use.mask: mask luajit USE

### DIFF
--- a/profiles/hardened/linux/powerpc/ppc64/64bit-userland/use.mask
+++ b/profiles/hardened/linux/powerpc/ppc64/64bit-userland/use.mask
@@ -1,3 +1,8 @@
+# Ilya Tumaykin <itumaykin+gentoo@gmail.com> (26 Feb 2018)
+# There is no luajit support on ppc64 userland. Bug #608326.
+# This mirrors USE mask from non-hardened 64ul.
+luajit
+
 # We mask this since we don't have a stable sys-process/audit yet
 audit
 


### PR DESCRIPTION
dev-lang/luajit upstream doesn't support ppc64.

This indirectly fixes dependency.badindev repoman warning re luajit USE in mpv.
Maybe hardened people would like to mask luajit USE on every arch instead, since it's jit.
CC @mgorny.