### PR TITLE
dev-db/unixODBC: Fix CVE-2018-7485

### DIFF
--- a/dev-db/unixODBC/files/unixODBC-2.3.5-CVE-2018-7485.patch
+++ b/dev-db/unixODBC/files/unixODBC-2.3.5-CVE-2018-7485.patch
@@ -1,0 +1,135 @@
+From 45ef78e037f578b15fc58938a3a3251655e71d6f Mon Sep 17 00:00:00 2001
+From: Nick Gorham <nick@lurcher.ink.org>
+Date: Mon, 8 Jan 2018 11:12:39 +0000
+Subject: [PATCH] New Pre Source
+
+diff --git a/DriverManager/SQLGetDiagRecW.c b/DriverManager/SQLGetDiagRecW.c
+index a6368d7..be89120 100644
+--- a/DriverManager/SQLGetDiagRecW.c
++++ b/DriverManager/SQLGetDiagRecW.c
+@@ -98,6 +98,8 @@
+ 
+ static char const rcsid[]= "$RCSfile: SQLGetDiagRecW.c,v $";
+ 
++extern int __is_env( EHEAD * head );        /* in SQLGetDiagRec.c */
++
+ static SQLRETURN extract_sql_error_rec_w( EHEAD *head,
+         SQLWCHAR *sqlstate,
+         SQLINTEGER rec_number,
+diff --git a/DriverManager/SQLSetDescField.c b/DriverManager/SQLSetDescField.c
+index 333d786..0e2f67c 100644
+--- a/DriverManager/SQLSetDescField.c
++++ b/DriverManager/SQLSetDescField.c
+@@ -306,7 +306,7 @@ SQLRETURN SQLSetDescField( SQLHDESC descriptor_handle,
+         return function_return_nodrv( SQL_HANDLE_DESC, descriptor, SQL_ERROR );
+     }
+ 
+-    if ( field_identifier == SQL_DESC_COUNT && (SQLINTEGER)value < 0 )
++    if ( field_identifier == SQL_DESC_COUNT && (intptr_t)value < 0 )
+     {
+         __post_internal_error( &descriptor -> error,
+                 ERROR_07009, NULL,
+@@ -315,9 +315,9 @@ SQLRETURN SQLSetDescField( SQLHDESC descriptor_handle,
+         return function_return_nodrv( SQL_HANDLE_DESC, descriptor, SQL_ERROR );
+     }
+     
+-    if ( field_identifier == SQL_DESC_PARAMETER_TYPE && value != SQL_PARAM_INPUT
+-        && value != SQL_PARAM_OUTPUT && value != SQL_PARAM_INPUT_OUTPUT &&
+-        value != SQL_PARAM_INPUT_OUTPUT_STREAM && value != SQL_PARAM_OUTPUT_STREAM )
++    if ( field_identifier == SQL_DESC_PARAMETER_TYPE && (intptr_t)value != SQL_PARAM_INPUT
++        && (intptr_t)value != SQL_PARAM_OUTPUT && (intptr_t)value != SQL_PARAM_INPUT_OUTPUT &&
++        (intptr_t)value != SQL_PARAM_INPUT_OUTPUT_STREAM && (intptr_t)value != SQL_PARAM_OUTPUT_STREAM )
+     {
+         __post_internal_error( &descriptor -> error,
+                 ERROR_HY105, NULL,
+diff --git a/DriverManager/SQLSetDescFieldW.c b/DriverManager/SQLSetDescFieldW.c
+index 5e066ac..45125ff 100644
+--- a/DriverManager/SQLSetDescFieldW.c
++++ b/DriverManager/SQLSetDescFieldW.c
+@@ -288,7 +288,7 @@ SQLRETURN SQLSetDescFieldW( SQLHDESC descriptor_handle,
+         return function_return_nodrv( SQL_HANDLE_DESC, descriptor, SQL_ERROR );
+     }
+ 
+-    if ( field_identifier == SQL_DESC_COUNT && (SQLINTEGER)value < 0 )
++    if ( field_identifier == SQL_DESC_COUNT && (intptr_t)value < 0 )
+     {
+         __post_internal_error( &descriptor -> error,
+                 ERROR_07009, NULL,
+@@ -297,9 +297,9 @@ SQLRETURN SQLSetDescFieldW( SQLHDESC descriptor_handle,
+         return function_return_nodrv( SQL_HANDLE_DESC, descriptor, SQL_ERROR );
+     }
+ 
+-    if ( field_identifier == SQL_DESC_PARAMETER_TYPE && value != SQL_PARAM_INPUT
+-        && value != SQL_PARAM_OUTPUT && value != SQL_PARAM_INPUT_OUTPUT &&
+-        value != SQL_PARAM_INPUT_OUTPUT_STREAM && value != SQL_PARAM_OUTPUT_STREAM )
++    if ( field_identifier == SQL_DESC_PARAMETER_TYPE && (intptr_t)value != SQL_PARAM_INPUT
++        && (intptr_t)value != SQL_PARAM_OUTPUT && (intptr_t)value != SQL_PARAM_INPUT_OUTPUT &&
++        (intptr_t)value != SQL_PARAM_INPUT_OUTPUT_STREAM && (intptr_t)value != SQL_PARAM_OUTPUT_STREAM )
+     {
+         __post_internal_error( &descriptor -> error,
+                 ERROR_HY105, NULL,
+diff --git a/exe/iusql.c b/exe/iusql.c
+index aac5329..484a889 100644
+--- a/exe/iusql.c
++++ b/exe/iusql.c
+@@ -413,7 +413,6 @@ static int ExecuteSQL( SQLHDBC hDbc, char *szSQL, char cDelimiter, int bColumnNa
+             if ( bVerbose ) DumpODBCLog( hEnv, hDbc, hStmt );
+             fprintf( stderr, "[ISQL]ERROR: Could not SQLExecDirect\n" );
+             SQLFreeStmt( hStmt, SQL_DROP );
+-            free(szSepLine);
+             return 0;
+         }
+     }
+diff --git a/odbcinst/SQLCreateDataSource.c b/odbcinst/SQLCreateDataSource.c
+index a9fa735..83a1e9e 100644
+--- a/odbcinst/SQLCreateDataSource.c
++++ b/odbcinst/SQLCreateDataSource.c
+@@ -26,7 +26,7 @@ char* _multi_string_alloc_and_copy( LPCWSTR in )
+ 
+     if ( !in )
+     {
+-        return in;
++        return NULL;
+     }
+ 
+     while ( in[ len ] != 0 || in[ len + 1 ] != 0 )
+@@ -55,7 +55,7 @@ char* _single_string_alloc_and_copy( LPCWSTR in )
+ 
+     if ( !in )
+     {
+-        return in;
++        return NULL;
+     }
+ 
+     while ( in[ len ] != 0 )
+@@ -83,7 +83,7 @@ SQLWCHAR* _multi_string_alloc_and_expand( LPCSTR in )
+ 
+     if ( !in )
+     {
+-        return in;
++        return NULL;
+     }
+     
+     while ( in[ len ] != 0 || in[ len + 1 ] != 0 )
+@@ -112,7 +112,7 @@ SQLWCHAR* _single_string_alloc_and_expand( LPCSTR in )
+ 
+     if ( !in )
+     {
+-        return in;
++        return NULL;
+     }
+ 
+     while ( in[ len ] != 0 )
+diff --git a/odbcinst/SQLWriteFileDSN.c b/odbcinst/SQLWriteFileDSN.c
+index c2f987b..e225796 100644
+--- a/odbcinst/SQLWriteFileDSN.c
++++ b/odbcinst/SQLWriteFileDSN.c
+@@ -21,7 +21,7 @@ BOOL SQLWriteFileDSN(			LPCSTR	pszFileName,
+ 
+ 	if ( pszFileName[0] == '/' )
+ 	{
+-		strncpy( szFileName, sizeof(szFileName) - 5, pszFileName );
++		strncpy( szFileName, pszFileName, sizeof(szFileName) - 5 );
+ 	}
+ 	else
+ 	{	

--- a/dev-db/unixODBC/unixODBC-2.3.5-r1.ebuild
+++ b/dev-db/unixODBC/unixODBC-2.3.5-r1.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit libtool ltprune multilib-minimal
+
+DESCRIPTION="A complete ODBC driver manager"
+HOMEPAGE="http://www.unixodbc.org/"
+SRC_URI="ftp://ftp.unixodbc.org/pub/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+minimal odbcmanual static-libs unicode"
+
+RDEPEND="
+	|| (
+		dev-libs/libltdl:0[${MULTILIB_USEDEP}]
+		>=sys-devel/libtool-2.4.2-r1[${MULTILIB_USEDEP}]
+	)
+	>=sys-libs/readline-6.2_p5-r1:0=[${MULTILIB_USEDEP}]
+	>=sys-libs/ncurses-5.9-r3:0=[${MULTILIB_USEDEP}]
+	>=virtual/libiconv-0-r1[${MULTILIB_USEDEP}]
+"
+DEPEND="${RDEPEND}
+	sys-devel/flex
+"
+
+MULTILIB_CHOST_TOOLS=( /usr/bin/odbc_config )
+MULTILIB_WRAPPED_HEADERS=( /usr/include/unixodbc_conf.h )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.3.5-CVE-2018-7485.patch"
+)
+
+multilib_src_configure() {
+	# --enable-driver-conf is --enable-driverc as per configure.in
+	myeconfargs=(
+		--sysconfdir="${EPREFIX}"/etc/${PN}
+		--disable-static
+		--enable-iconv
+		--enable-shared
+		$(use_enable static-libs static)
+		$(use_enable !minimal drivers)
+		$(use_enable !minimal driverc)
+		$(use_with unicode iconv-char-enc UTF8)
+		$(use_with unicode iconv-ucode-enc UTF16LE)
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	if use odbcmanual ; then
+		# We could simply run "make install-html" if we'd not had 
+		# out-of-source builds here.
+		docinto html
+		dodoc -r doc/.
+		find "${ED%/}/usr/share/doc/${PF}/html" -name "Makefile*" -delete || die
+	fi
+
+	use prefix && dodoc README*
+	prune_libtool_files
+}


### PR DESCRIPTION
Adding a patch based on
https://github.com/lurcher/unixODBC/commit/45ef78e037f578b15fc58938a3a3251655e71d6f

Without the changes for 2.3.6 in ChangeLog and configure.ac.

Package-Manager: Portage-2.3.19, Repoman-2.3.6