### PR TITLE
dev-libs/libsodium: add multilib support

### DIFF
--- a/dev-libs/libsodium/libsodium-1.0.16-r1.ebuild
+++ b/dev-libs/libsodium/libsodium-1.0.16-r1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools multilib-minimal
+
+DESCRIPTION="A portable fork of NaCl, a higher-level cryptographic library"
+HOMEPAGE="https://github.com/jedisct1/libsodium"
+SRC_URI="http://download.libsodium.org/${PN}/releases/${P}.tar.gz"
+
+LICENSE="ISC"
+SLOT="0/23"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="+asm minimal static-libs +urandom cpu_flags_x86_sse4_1 cpu_flags_x86_aes"
+
+PATCHES=( "${FILESDIR}"/${PN}-1.0.10-cpuflags.patch )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local ECONF_SOURCE="${S}"
+	local myconf
+
+	# --disable-pie is needed on x86, see bug #512734
+	if [[ "${MULTILIB_ABI_FLAG}" == "abi_x86_32" ]]; then
+		myconf="${myconf} --disable-pie"
+	fi
+
+	econf \
+		$(use_enable asm) \
+		$(use_enable minimal) \
+		$(use_enable !urandom blocking-random) \
+		$(use_enable static-libs static) \
+		$(use_enable cpu_flags_x86_sse4_1 sse4_1) \
+		$(use_enable cpu_flags_x86_aes aesni) \
+		${myconf}
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${D}" -name "*.la" -delete || die
+}


### PR DESCRIPTION
dev-libs/libsodium: add multilib support

Closes: https://bugs.gentoo.org/622140