### PR TITLE
net-ftp/uftpd: fix file collision

### DIFF
--- a/net-ftp/uftpd/uftpd-2.4-r1.ebuild
+++ b/net-ftp/uftpd/uftpd-2.4-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="The no nonsense TFTP/FTP server."
+HOMEPAGE="https://github.com/troglobit/uftpd"
+SRC_URI="https://github.com/troglobit/${PN}/releases/download/v${PV}/${P}.tar.xz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="
+		!net-misc/uftp
+		!net-ftp/atftp
+		"
+
+DEPEND="
+	dev-libs/libite
+	dev-libs/libuev
+	"
+
+RDEPEND="${DEPEND}"


### PR DESCRIPTION
See bug linked

```
diff -up uftpd-2.4.ebuild uftpd-2.4-r1.ebuild 
--- uftpd-2.4.ebuild	2018-01-08 16:19:49.980109231 +0100
+++ uftpd-2.4-r1.ebuild	2018-02-28 08:51:21.968982310 +0100
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,9 +12,14 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
+RDEPEND="
+		!net-misc/uftp
+		!net-ftp/atftp
+		"
+
 DEPEND="
 	dev-libs/libite
 	dev-libs/libuev
-	!!net-misc/uftp"
+	"
 
 RDEPEND="${DEPEND}"
```

Bug: https://bugs.gentoo.org/show_bug.cgi?id=648984
Package-Manager: Portage-2.3.19, Repoman-2.3.6