### PR TITLE
x11-libs/libgksu: fix gksu-run-helper installation path

### DIFF
--- a/x11-libs/libgksu/files/libgksu-2.0.12-automake-1.11.2-v2.patch
+++ b/x11-libs/libgksu/files/libgksu-2.0.12-automake-1.11.2-v2.patch
@@ -1,0 +1,26 @@
+Due to the following change, pkglib_PROGRAMS is invalid:
+    http://git.savannah.gnu.org/cgit/automake.git/commit/?id=9ca632642b006ac6b0fc4ce0ae5b34023faa8cbf
+
+https://savannah.nongnu.org/bugs/index.php?35241
+https://bugs.gentoo.org/397411
+https://bugs.gentoo.org/640772
+
+---
+ libgksu/Makefile.am |    4 ++--
+ 1 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libgksu/Makefile.am b/libgksu/Makefile.am
+index 49362f9..3cb1090 100644
+--- a/libgksu/Makefile.am
++++ b/libgksu/Makefile.am
+@@ -22,8 +22,8 @@ includedir = ${prefix}/include/${PACKAGE}
+ pkgconfigdir = ${libdir}/pkgconfig
+ pkgconfig_DATA = libgksu2.pc
+ 
+-pkglibdir = ${libdir}/${PACKAGE}
+-pkglib_PROGRAMS = gksu-run-helper
++pkglibexecdir = ${libexecdir}/${PACKAGE}
++pkglibexec_PROGRAMS = gksu-run-helper
+ gksu_run_helper_LDADD = ${GLIB_LIBS} 
+ gksu_run_helper_SOURCES = gksu-run-helper.c
+ 

--- a/x11-libs/libgksu/files/libgksu-2.0.12-gksu-run-helper_path.patch
+++ b/x11-libs/libgksu/files/libgksu-2.0.12-gksu-run-helper_path.patch
@@ -1,0 +1,23 @@
+diff -urN libgksu-2.0.12.orig/libgksu/libgksu.c libgksu-2.0.12/libgksu/libgksu.c
+--- libgksu-2.0.12.orig/libgksu/libgksu.c	2018-03-06 15:39:34.594733354 +0300
++++ libgksu-2.0.12/libgksu/libgksu.c	2018-03-06 16:03:11.812213290 +0300
+@@ -1937,7 +1937,7 @@
+   GQuark gksu_quark;
+   int i = 0;
+ 
+-  gchar auxcommand[] = PREFIX "/lib/" PACKAGE "/gksu-run-helper";
++  gchar auxcommand[] = LIBEXECDIR "/" PACKAGE "/gksu-run-helper";
+ 
+   int fdpty;
+   pid_t pid;
+diff -urN libgksu-2.0.12.orig/libgksu/Makefile.am libgksu-2.0.12/libgksu/Makefile.am
+--- libgksu-2.0.12.orig/libgksu/Makefile.am	2018-03-06 15:39:34.545736138 +0300
++++ libgksu-2.0.12/libgksu/Makefile.am	2018-03-06 16:01:23.700033494 +0300
+@@ -1,6 +1,6 @@
+ AM_CFLAGS = -g -O2 -Wall
+ INCLUDES = ${LIBGKSU_CFLAGS}
+-AM_CPPFLAGS = -DLOCALEDIR=\"$(datadir)/locale\" -DDATA_DIR=\"$(datadir)\" -DPREFIX=\"$(prefix)\"
++AM_CPPFLAGS = -DLOCALEDIR=\"$(datadir)/locale\" -DDATA_DIR=\"$(datadir)\" -DPREFIX=\"$(prefix)\" -DLIBEXECDIR=\"$(libexecdir)\"
+ 
+ lib_LTLIBRARIES = libgksu2.la
+ libgksu2_la_SOURCES = libgksu.c libgksu.h

--- a/x11-libs/libgksu/libgksu-2.0.12-r4.ebuild
+++ b/x11-libs/libgksu/libgksu-2.0.12-r4.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+GNOME2_EAUTORECONF="yes"
+
+inherit gnome2
+
+DESCRIPTION="A library for integration of su into applications"
+HOMEPAGE="http://www.nongnu.org/gksu/"
+SRC_URI="https://people.debian.org/~kov/gksu/${P}.tar.gz"
+
+LICENSE="LGPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~x86-fbsd"
+IUSE="nls static-libs"
+
+COMMON_DEPEND="
+	>=x11-libs/gtk+-2.12:2
+	x11-libs/libX11
+	>=gnome-base/gconf-2
+	gnome-base/libgnome-keyring
+	x11-libs/startup-notification
+	>=gnome-base/libgtop-2:2=
+	nls? ( >=sys-devel/gettext-0.14.1 )
+"
+DEPEND="${COMMON_DEPEND}
+	dev-util/gtk-doc-am
+	>=dev-util/intltool-0.35.5
+	virtual/pkgconfig
+"
+RDEPEND="${COMMON_DEPEND}
+	app-admin/sudo
+"
+
+PATCHES=(
+	# Fix compilation on bsd
+	"${FILESDIR}"/${PN}-2.0.0-fbsd.patch
+
+	# Fix wrong usage of LDFLAGS, bug #226837
+	"${FILESDIR}"/${PN}-2.0.7-libs.patch
+
+	# Use po/LINGUAS
+	"${FILESDIR}"/${PN}-2.0.7-polinguas.patch
+
+	# Don't forkpty; bug #298289
+	"${FILESDIR}"/${P}-revert-forkpty.patch
+
+	# Make this gmake-3.82 compliant, bug #333961
+	"${FILESDIR}"/${P}-fix-make-3.82.patch
+
+	# Do not build test programs that are never executed; also fixes bug
+	# #367397 (underlinking issues).
+	"${FILESDIR}"/${P}-notests.patch
+
+	# Fix automake-1.11.2 compatibility, bug #397411
+	"${FILESDIR}"/${P}-automake-1.11.2-v2.patch
+	"${FILESDIR}"/${P}-missing-libs.patch
+
+	# Fix build with format-security, bug #517614
+	"${FILESDIR}"/${P}-format_security.patch
+
+	# Fix .desktop file validation, bug #512364
+	"${FILESDIR}"/${P}-desktop-validation.patch
+
+	# Collection of patches from Debian
+	"${FILESDIR}"/${P}-g_markup_escape_text_for_command.patch
+	"${FILESDIR}"/${P}-sudo_keep_env.patch
+	"${FILESDIR}"/${P}-correct_colormap_get.patch
+
+	# Fix gksu-run-helper path
+	"${FILESDIR}"/${P}-gksu-run-helper_path.patch
+)
+
+src_prepare() {
+	sed -i -e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' configure.ac || die #467026
+	gnome2_src_prepare
+}
+
+src_configure() {
+	gnome2_src_configure \
+		$(use_enable nls) \
+		$(use_enable static-libs static)
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/640772