### PR TITLE
games-arcade/oshu: Dependencies fixes

### DIFF
--- a/games-arcade/oshu/oshu-1.6.0.ebuild
+++ b/games-arcade/oshu/oshu-1.6.0.ebuild
@@ -15,6 +15,7 @@ RDEPEND="
 	>=media-libs/libsdl2-2.0.5:=
 	media-libs/sdl2-image:=
 	x11-libs/cairo:=
+	x11-libs/pango:=
 	!libav? ( media-video/ffmpeg:= )
 	libav? ( media-video/libav:= )
 "

--- a/games-arcade/oshu/oshu-1.6.0.ebuild
+++ b/games-arcade/oshu/oshu-1.6.0.ebuild
@@ -12,7 +12,7 @@ SLOT="0"
 IUSE="libav"
 
 RDEPEND="
-	media-libs/libsdl2:=
+	>=media-libs/libsdl2-2.0.5:=
 	media-libs/sdl2-image:=
 	x11-libs/cairo:=
 	!libav? ( media-video/ffmpeg:= )


### PR DESCRIPTION
* oshu needs SDL2 2.0.5+
* I forgot pango in the dependencies

Also, it might be usefull to force [jpeg,png] on sdl2-image as otherwise images in the background will not show (the game still works).
