### PR TITLE
media-libs/vulkan-loader: fix missing dep on libXrandr

### DIFF
--- a/media-libs/vulkan-loader/vulkan-loader-1.0.42.0.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.0.42.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,10 @@ IUSE="wayland X"
 RDEPEND=""
 DEPEND="${PYTHON_DEPS}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
-	X? ( x11-libs/libX11:=[${MULTILIB_USEDEP}] )"
+	X? (
+		x11-libs/libX11:=[${MULTILIB_USEDEP}]
+		x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
+		)"
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/media-libs/vulkan-loader/vulkan-loader-1.0.42.2.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.0.42.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,10 @@ IUSE="wayland X"
 RDEPEND=""
 DEPEND="${PYTHON_DEPS}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
-	X? ( x11-libs/libX11:=[${MULTILIB_USEDEP}] )"
+	X? (
+		x11-libs/libX11:=[${MULTILIB_USEDEP}]
+		x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
+		)"
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/media-libs/vulkan-loader/vulkan-loader-1.0.46.0.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.0.46.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,10 @@ IUSE="wayland X"
 RDEPEND=""
 DEPEND="${PYTHON_DEPS}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
-	X? ( x11-libs/libX11:=[${MULTILIB_USEDEP}] )"
+	X? (
+		x11-libs/libX11:=[${MULTILIB_USEDEP}]
+		x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
+		)"
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/media-libs/vulkan-loader/vulkan-loader-1.0.51.0.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.0.51.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,10 @@ IUSE="wayland X"
 RDEPEND=""
 DEPEND="${PYTHON_DEPS}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
-	X? ( x11-libs/libX11:=[${MULTILIB_USEDEP}] )"
+	X? (
+		x11-libs/libX11:=[${MULTILIB_USEDEP}]
+		x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
+		)"
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/media-libs/vulkan-loader/vulkan-loader-1.0.54.0.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.0.54.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,10 @@ IUSE="wayland X"
 RDEPEND=""
 DEPEND="${PYTHON_DEPS}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
-	X? ( x11-libs/libX11:=[${MULTILIB_USEDEP}] )"
+	X? (
+		x11-libs/libX11:=[${MULTILIB_USEDEP}]
+		x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
+		)"
 
 PATCHES=( "${FILESDIR}"/${P}-remove-executable-stack.patch )
 

--- a/media-libs/vulkan-loader/vulkan-loader-1.0.61.1.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.0.61.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,10 @@ IUSE="wayland X"
 RDEPEND=""
 DEPEND="${PYTHON_DEPS}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
-	X? ( x11-libs/libX11:=[${MULTILIB_USEDEP}] )"
+	X? (
+		x11-libs/libX11:=[${MULTILIB_USEDEP}]
+		x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
+		)"
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,10 @@ IUSE="wayland X"
 RDEPEND=""
 DEPEND="${PYTHON_DEPS}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
-	X? ( x11-libs/libX11:=[${MULTILIB_USEDEP}] )"
+	X? (
+		x11-libs/libX11:=[${MULTILIB_USEDEP}]
+		x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
+		)"
 
 multilib_src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
I just happened to catch this bug trying to install vulkan before having graphical stack installed.
Not sure if I need to do a revbump in this scenario, because most users will have libXrandr installed anyway, lmk if I should do a revbump to trigger rebuilds and deps registered by the PM.

Closes: https://bugs.gentoo.org/649334
Package-Manager: Portage-2.3.19, Repoman-2.3.6