### PR TITLE
app-text/xapian-omega, sys-devel/ct-ng, sys-kernel/hardened-sources, www-servers/varnish: use HTTPS

### DIFF
--- a/app-text/xapian-omega/xapian-omega-1.2.24.ebuild
+++ b/app-text/xapian-omega/xapian-omega-1.2.24.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
 DESCRIPTION="An application built on Xapian, consisting of indexers and a CGI search frontend"
 SRC_URI="http://www.oligarchy.co.uk/xapian/${PV}/xapian-omega-${PV}.tar.xz"
-HOMEPAGE="http://www.xapian.org/"
+HOMEPAGE="https://xapian.org/"
 S="${WORKDIR}/xapian-omega-${PV}"
 
 LICENSE="GPL-2"

--- a/app-text/xapian-omega/xapian-omega-1.2.25.ebuild
+++ b/app-text/xapian-omega/xapian-omega-1.2.25.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
 DESCRIPTION="An application built on Xapian, consisting of indexers and a CGI search frontend"
 SRC_URI="http://www.oligarchy.co.uk/xapian/${PV}/xapian-omega-${PV}.tar.xz"
-HOMEPAGE="http://www.xapian.org/"
+HOMEPAGE="https://xapian.org/"
 S="${WORKDIR}/xapian-omega-${PV}"
 
 LICENSE="GPL-2"

--- a/app-text/xapian-omega/xapian-omega-1.4.4.ebuild
+++ b/app-text/xapian-omega/xapian-omega-1.4.4.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="An application built on Xapian, consisting of indexers and a CGI search frontend"
 SRC_URI="http://www.oligarchy.co.uk/xapian/${PV}/xapian-omega-${PV}.tar.xz"
-HOMEPAGE="http://www.xapian.org/"
+HOMEPAGE="https://xapian.org/"
 S="${WORKDIR}/xapian-omega-${PV}"
 
 LICENSE="GPL-2"

--- a/app-text/xapian-omega/xapian-omega-1.4.5.ebuild
+++ b/app-text/xapian-omega/xapian-omega-1.4.5.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="An application built on Xapian, consisting of indexers and a CGI search frontend"
 SRC_URI="http://www.oligarchy.co.uk/xapian/${PV}/xapian-omega-${PV}.tar.xz"
-HOMEPAGE="http://www.xapian.org/"
+HOMEPAGE="https://xapian.org/"
 S="${WORKDIR}/xapian-omega-${PV}"
 
 LICENSE="GPL-2"

--- a/sys-devel/ct-ng/ct-ng-1.22.0.ebuild
+++ b/sys-devel/ct-ng/ct-ng-1.22.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,7 +6,7 @@ EAPI="5"
 inherit bash-completion-r1
 
 DESCRIPTION="crosstool-ng is a tool to build cross-compiling toolchains"
-HOMEPAGE="http://crosstool-ng.org"
+HOMEPAGE="https://crosstool-ng.org"
 MY_P=${P/ct/crosstool}
 SRC_URI="http://ymorin.is-a-geek.org/download/crosstool-ng/${MY_P}.tar.bz2"
 

--- a/sys-devel/ct-ng/ct-ng-1.23.0.ebuild
+++ b/sys-devel/ct-ng/ct-ng-1.23.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,7 +6,7 @@ EAPI="5"
 inherit bash-completion-r1
 
 DESCRIPTION="crosstool-ng is a tool to build cross-compiling toolchains"
-HOMEPAGE="http://crosstool-ng.org"
+HOMEPAGE="https://crosstool-ng.org"
 MY_P=${P/ct/crosstool}
 SRC_URI="http://ymorin.is-a-geek.org/download/crosstool-ng/${MY_P}.tar.bz2"
 

--- a/sys-kernel/hardened-sources/hardened-sources-4.4.8-r1.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.4.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -21,7 +21,7 @@ UNIPATCH_EXCLUDE="
 	2900_dev-root-proc-mount-fix.patch"
 
 DESCRIPTION="Hardened kernel sources (kernel series ${KV_MAJOR}.${KV_MINOR})"
-HOMEPAGE="http://www.gentoo.org/proj/en/hardened/"
+HOMEPAGE="https://www.gentoo.org/proj/en/hardened/"
 IUSE="deblob"
 
 KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86"

--- a/sys-kernel/hardened-sources/hardened-sources-4.7.10.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.7.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -21,7 +21,7 @@ UNIPATCH_EXCLUDE="
 	2900_dev-root-proc-mount-fix.patch"
 
 DESCRIPTION="Hardened kernel sources (kernel series ${KV_MAJOR}.${KV_MINOR})"
-HOMEPAGE="http://www.gentoo.org/proj/en/hardened/"
+HOMEPAGE="https://www.gentoo.org/proj/en/hardened/"
 IUSE="deblob"
 
 KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86"

--- a/sys-kernel/hardened-sources/hardened-sources-4.7.6.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.7.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -21,7 +21,7 @@ UNIPATCH_EXCLUDE="
 	2900_dev-root-proc-mount-fix.patch"
 
 DESCRIPTION="Hardened kernel sources (kernel series ${KV_MAJOR}.${KV_MINOR})"
-HOMEPAGE="http://www.gentoo.org/proj/en/hardened/"
+HOMEPAGE="https://www.gentoo.org/proj/en/hardened/"
 IUSE="deblob"
 
 KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86"

--- a/sys-kernel/hardened-sources/hardened-sources-4.8.17-r2.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.8.17-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -21,7 +21,7 @@ UNIPATCH_EXCLUDE="
 	2900_dev-root-proc-mount-fix.patch"
 
 DESCRIPTION="Hardened kernel sources (kernel series ${KV_MAJOR}.${KV_MINOR})"
-HOMEPAGE="http://www.gentoo.org/proj/en/hardened/"
+HOMEPAGE="https://www.gentoo.org/proj/en/hardened/"
 IUSE="deblob"
 
 KEYWORDS="~alpha amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86"

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.21.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.21.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -22,7 +22,7 @@ UNIPATCH_EXCLUDE="
 	2900_dev-root-proc-mount-fix.patch"
 
 DESCRIPTION="Hardened kernel sources (kernel series ${KV_MAJOR}.${KV_MINOR})"
-HOMEPAGE="http://www.gentoo.org/proj/en/hardened/"
+HOMEPAGE="https://www.gentoo.org/proj/en/hardened/"
 IUSE="deblob"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.22.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -22,7 +22,7 @@ UNIPATCH_EXCLUDE="
 	2900_dev-root-proc-mount-fix.patch"
 
 DESCRIPTION="Hardened kernel sources (kernel series ${KV_MAJOR}.${KV_MINOR})"
-HOMEPAGE="http://www.gentoo.org/proj/en/hardened/"
+HOMEPAGE="https://www.gentoo.org/proj/en/hardened/"
 IUSE="deblob"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.23.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.23.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -22,7 +22,7 @@ UNIPATCH_EXCLUDE="
 	2900_dev-root-proc-mount-fix.patch"
 
 DESCRIPTION="Hardened kernel sources (kernel series ${KV_MAJOR}.${KV_MINOR})"
-HOMEPAGE="http://www.gentoo.org/proj/en/hardened/"
+HOMEPAGE="https://www.gentoo.org/proj/en/hardened/"
 IUSE="deblob"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"

--- a/sys-kernel/hardened-sources/hardened-sources-4.9.24.ebuild
+++ b/sys-kernel/hardened-sources/hardened-sources-4.9.24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -22,7 +22,7 @@ UNIPATCH_EXCLUDE="
 	2900_dev-root-proc-mount-fix.patch"
 
 DESCRIPTION="Hardened kernel sources (kernel series ${KV_MAJOR}.${KV_MINOR})"
-HOMEPAGE="http://www.gentoo.org/proj/en/hardened/"
+HOMEPAGE="https://www.gentoo.org/proj/en/hardened/"
 IUSE="deblob"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"

--- a/www-servers/varnish/varnish-4.0.5.ebuild
+++ b/www-servers/varnish/varnish-4.0.5.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4} pypy )
 inherit user autotools systemd python-r1
 
 DESCRIPTION="Varnish is a state-of-the-art, high-performance HTTP accelerator"
-HOMEPAGE="http://www.varnish-cache.org/"
+HOMEPAGE="https://varnish-cache.org/"
 SRC_URI="http://varnish-cache.org/_downloads/${P}.tgz"
 
 LICENSE="BSD-2 GPL-2"

--- a/www-servers/varnish/varnish-4.1.8.ebuild
+++ b/www-servers/varnish/varnish-4.1.8.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4} pypy )
 inherit user autotools systemd python-r1
 
 DESCRIPTION="Varnish is a state-of-the-art, high-performance HTTP accelerator"
-HOMEPAGE="http://www.varnish-cache.org/"
+HOMEPAGE="https://varnish-cache.org/"
 SRC_URI="http://varnish-cache.org/_downloads/${P}.tgz"
 
 LICENSE="BSD-2 GPL-2"

--- a/www-servers/varnish/varnish-5.1.3.ebuild
+++ b/www-servers/varnish/varnish-5.1.3.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
 inherit user autotools systemd python-r1
 
 DESCRIPTION="Varnish is a state-of-the-art, high-performance HTTP accelerator"
-HOMEPAGE="http://www.varnish-cache.org/"
+HOMEPAGE="https://varnish-cache.org/"
 SRC_URI="http://varnish-cache.org/_downloads/${P}.tgz"
 
 LICENSE="BSD-2 GPL-2"

--- a/www-servers/varnish/varnish-5.2.1.ebuild
+++ b/www-servers/varnish/varnish-5.2.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
 inherit user autotools systemd python-r1
 
 DESCRIPTION="Varnish is a state-of-the-art, high-performance HTTP accelerator"
-HOMEPAGE="http://www.varnish-cache.org/"
+HOMEPAGE="https://varnish-cache.org/"
 SRC_URI="http://varnish-cache.org/_downloads/${P}.tgz"
 
 LICENSE="BSD-2 GPL-2"


### PR DESCRIPTION
Hi,

This PR fixes a few packages to use https instead of http for the HOMEPAGE

Please review.