### PR TITLE
sci-libs/Scipy: parallel compilation fix

### DIFF
--- a/sci-libs/scipy/scipy-0.16.1.ebuild
+++ b/sci-libs/scipy/scipy-0.16.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5

--- a/sci-libs/scipy/scipy-0.18.1.ebuild
+++ b/sci-libs/scipy/scipy-0.18.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -108,7 +108,7 @@ python_prepare_all() {
 python_compile() {
 	${EPYTHON} tools/cythonize.py || die
 	distutils-r1_python_compile \
-		$(usex python_targets_python3_5 "" "-j $(makeopts_jobs)") \
+		$(usex python_targets_python3_5 "" "-j1") \
 		${SCIPY_FCONFIG}
 }
 

--- a/sci-libs/scipy/scipy-0.19.1.ebuild
+++ b/sci-libs/scipy/scipy-0.19.1.ebuild
@@ -104,7 +104,7 @@ python_prepare_all() {
 python_compile() {
 	${EPYTHON} tools/cythonize.py || die
 	distutils-r1_python_compile \
-		$(usex python_targets_python3_5 "" "-j $(makeopts_jobs)") \
+		$(usex python_targets_python3_5 "" "-j1") \
 		${SCIPY_FCONFIG}
 }
 

--- a/sci-libs/scipy/scipy-0.19.1.ebuild
+++ b/sci-libs/scipy/scipy-0.19.1.ebuild
@@ -104,7 +104,8 @@ python_prepare_all() {
 python_compile() {
 	${EPYTHON} tools/cythonize.py || die
 	distutils-r1_python_compile \
-		$(usex python_targets_python3_5 "" "-j1") \
+		$(usex python_targets_python3_5 "-j$(makeopts_jobs)" "-j1") \
+		$(usex python_targets_python3_6 "-j$(makeopts_jobs)" "-j1") \
 		${SCIPY_FCONFIG}
 }
 

--- a/sci-libs/scipy/scipy-1.0.0.ebuild
+++ b/sci-libs/scipy/scipy-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -107,7 +107,7 @@ python_prepare_all() {
 python_compile() {
 	${EPYTHON} tools/cythonize.py || die
 	distutils-r1_python_compile \
-		$(usex python_targets_python3_5 "" "-j $(makeopts_jobs)") \
+		$(usex python_targets_python3_5 "" "-j1") \
 		${SCIPY_FCONFIG}
 }
 

--- a/sci-libs/scipy/scipy-1.0.0.ebuild
+++ b/sci-libs/scipy/scipy-1.0.0.ebuild
@@ -107,7 +107,8 @@ python_prepare_all() {
 python_compile() {
 	${EPYTHON} tools/cythonize.py || die
 	distutils-r1_python_compile \
-		$(usex python_targets_python3_5 "" "-j1") \
+		$(usex python_targets_python3_5 "-j$(makeopts_jobs)" "-j1") \
+		$(usex python_targets_python3_6 "-j$(makeopts_jobs)" "-j1") \
 		${SCIPY_FCONFIG}
 }
 


### PR DESCRIPTION
Fixed the issue that always enabled parallel build even without python 3.5.

Closes: https://bugs.gentoo.org/646328