### PR TITLE
dev-python/BitVector: use HTTPS, avoid redirection

### DIFF
--- a/dev-python/BitVector/BitVector-3.4.4.ebuild
+++ b/dev-python/BitVector/BitVector-3.4.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="A pure-Python memory-efficient packed representation for bit arrays"
-HOMEPAGE="http://cobweb.ecn.purdue.edu/~kak/dist/ https://pypi.python.org/pypi/BitVector"
-SRC_URI="http://cobweb.ecn.purdue.edu/~kak/dist/${P}.tar.gz"
+HOMEPAGE="https://engineering.purdue.edu/kak/dist/ https://pypi.python.org/pypi/BitVector"
+SRC_URI="https://engineering.purdue.edu/kak/dist/${P}.tar.gz"
 
 LICENSE="PSF-2"
 SLOT="0"

--- a/dev-python/BitVector/BitVector-3.4.6.ebuild
+++ b/dev-python/BitVector/BitVector-3.4.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="A pure-Python memory-efficient packed representation for bit arrays"
-HOMEPAGE="http://cobweb.ecn.purdue.edu/~kak/dist/ https://pypi.python.org/pypi/BitVector"
-SRC_URI="http://cobweb.ecn.purdue.edu/~kak/dist/${P}.tar.gz"
+HOMEPAGE="https://engineering.purdue.edu/kak/dist/ https://pypi.python.org/pypi/BitVector"
+SRC_URI="https://engineering.purdue.edu/kak/dist/${P}.tar.gz"
 
 LICENSE="PSF-2"
 SLOT="0"

--- a/dev-python/BitVector/BitVector-3.4.7.ebuild
+++ b/dev-python/BitVector/BitVector-3.4.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python{2_7,3_5,3_6} )
 inherit distutils-r1
 
 DESCRIPTION="A pure-Python memory-efficient packed representation for bit arrays"
-HOMEPAGE="http://cobweb.ecn.purdue.edu/~kak/dist/ https://pypi.python.org/pypi/BitVector"
-SRC_URI="http://cobweb.ecn.purdue.edu/~kak/dist/${P}.tar.gz"
+HOMEPAGE="https://engineering.purdue.edu/kak/dist/ https://pypi.python.org/pypi/BitVector"
+SRC_URI="https://engineering.purdue.edu/kak/dist/${P}.tar.gz"
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 RDEPEND=""
 LICENSE="PSF-2"


### PR DESCRIPTION
Hi,

This PR updates the HOMEPAGE and SRC_URI to use https and avoid redirection.

Please review.