### PR TITLE
dev-python/argh: use HTTPS, avoid redirection

### DIFF
--- a/dev-python/argh/argh-0.26.2-r1.ebuild
+++ b/dev-python/argh/argh-0.26.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
 inherit distutils-r1
 
 DESCRIPTION="A simple argparse wrapper"
-HOMEPAGE="http://packages.python.org/argh/"
+HOMEPAGE="https://pythonhosted.org/argh/"
 SRC_URI="mirror://pypi/a/${PN}/${P}.tar.gz"
 
 SLOT="0"

--- a/dev-python/argh/argh-0.26.2.ebuild
+++ b/dev-python/argh/argh-0.26.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
 inherit distutils-r1
 
 DESCRIPTION="A simple argparse wrapper"
-HOMEPAGE="http://packages.python.org/argh/"
+HOMEPAGE="https://pythonhosted.org/argh/"
 SRC_URI="mirror://pypi/a/${PN}/${P}.tar.gz"
 
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR updates the ebuilds to use HTTPS instead of http and also avoids redirection.

Please review.