### PR TITLE
kde-misc/plasma-applet-network-monitor: use HTTPS, avoid redirection

### DIFF
--- a/kde-misc/plasma-applet-network-monitor/plasma-applet-network-monitor-1.7.3.ebuild
+++ b/kde-misc/plasma-applet-network-monitor/plasma-applet-network-monitor-1.7.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit kde5
 
 DESCRIPTION="Plasma 5 applet for monitoring active network connections"
-HOMEPAGE="http://kde-look.org/content/show.php/Network+Monitor?content=169377
+HOMEPAGE="https://store.kde.org/content/show.php/Network+Monitor?content=169377
 https://github.com/kotelnik/plasma-applet-network-monitor"
 
 if [[ ${KDE_BUILD_TYPE} = live ]] ; then


### PR DESCRIPTION
Hi,

This PR fix the kde-misc/plasma-applet-network-monitor to use https instead of http.

Please review.