### PR TITLE
profiles/targets/desktop/gnome: package.use remove xorg-server[kdrive]

### DIFF
--- a/profiles/targets/desktop/gnome/package.use
+++ b/profiles/targets/desktop/gnome/package.use
@@ -58,9 +58,6 @@ net-misc/spice-gtk gtk3
 # for gnome-extra/gnome-user-share
 www-servers/apache apache2_modules_dav apache2_modules_dav_fs apache2_modules_authn_file apache2_modules_auth_digest apache2_modules_authz_groupfile
 
-# Required by app-admin/sabayon
-x11-base/xorg-server kdrive
-
 # Alexandre Rostovtsev <tetromino@gentoo.org> (19 Feb 2015)
 # Set reasonable default toolkit for gnome users to prevent emerge error
 # when USE=tools


### PR DESCRIPTION
It references app-admin/sabayon which is dead upstream and not in tree any more.
Nuke it.