### PR TITLE
profiles/*/musl: package.use.mask app-shells/bash[mem-scramble]

### DIFF
--- a/profiles/default/linux/musl/package.use.mask
+++ b/profiles/default/linux/musl/package.use.mask
@@ -17,3 +17,8 @@ sys-fs/e2fsprogs nls
 
 # See bug #576928
 media-libs/mesa nptl
+
+# bash-malloc relies on sbrk which is implemented
+# as a fail-only stub in musl. breaks horribly if enabled.
+# bash: xmalloc: locale.c:81: cannot allocate 18 bytes (0 bytes allocated)
+app-shells/bash mem-scramble

--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -17,3 +17,8 @@ sys-fs/e2fsprogs nls
 
 # See bug #576928
 media-libs/mesa nptl
+
+# bash-malloc relies on sbrk which is implemented
+# as a fail-only stub in musl. breaks horribly if enabled.
+# bash: xmalloc: locale.c:81: cannot allocate 18 bytes (0 bytes allocated)
+app-shells/bash mem-scramble


### PR DESCRIPTION
mem-scramble enables bash-malloc which relies on sbrk
which is implemented as a fail-only stub in musl.
Enabling it will break bash (and portage) horribly.
bash: xmalloc: locale.c:81: cannot allocate 18 bytes (0 bytes allocated)

http://git.musl-libc.org/cgit/musl/commit/?id=7a995fe706e519a4f55399776ef0df9596101f93
https://marc.info/?l=musl&m=140094280805343

ping @blueness 