### PR TITLE
media-gfx/sane-frontends: Make GUI optional.

### DIFF
--- a/media-gfx/sane-frontends/metadata.xml
+++ b/media-gfx/sane-frontends/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>herb@hlmjr.com</email>
+		<name>Herb Miller Jr. (herbmillerjr)</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/media-gfx/sane-frontends/sane-frontends-1.0.14-r2.ebuild
+++ b/media-gfx/sane-frontends/sane-frontends-1.0.14-r2.ebuild
@@ -11,11 +11,13 @@ SRC_URI="ftp://ftp.sane-project.org/pub/sane/${P}/${P}.tar.gz
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~ppc ~ppc64 sparc x86"
-IUSE="gimp"
+IUSE="gimp gtk"
 
 RDEPEND="
-	dev-libs/glib:2
-	x11-libs/gtk+:2
+	gtk? (
+		dev-libs/glib:2
+		x11-libs/gtk+:2
+	)
 "
 DEPEND="${RDEPEND}
 	media-gfx/sane-backends
@@ -29,7 +31,9 @@ PATCHES=( "${FILESDIR}/MissingCapsFlag.patch" )
 src_configure() {
 	econf \
 		--datadir=/usr/share/misc \
-		$(use_enable gimp)
+		$(use_enable gimp) \
+		$(use_enable gtk gtk2) \
+		$(use_enable gtk guis)
 }
 
 src_install() {


### PR DESCRIPTION
Utilizes gtk USE flag and --enable-gtk2 / --enable-guis configuration options.

Bug: https://bugs.gentoo.org/649570