### PR TITLE
app-emulation/fuse: make default backend USE flags non-contradictory

### DIFF
--- a/app-emulation/fuse/fuse-1.5.1.ebuild
+++ b/app-emulation/fuse/fuse-1.5.1.ebuild
@@ -10,26 +10,25 @@ SRC_URI="mirror://sourceforge/fuse-emulator/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE="alsa ao fbcon gpm gtk joystick memlimit png sdl svga X xml"
+IUSE="alsa ao backend-fbcon +backend-gtk backend-sdl backend-svga backend-X gpm joystick memlimit png xml"
 
 # Only one UI back-end can be enabled at a time
-REQUIRED_USE="^^ ( X fbcon gtk sdl svga )"
+REQUIRED_USE="^^ ( backend-fbcon backend-gtk backend-sdl backend-svga backend-X )"
 
 RDEPEND=">=app-emulation/libspectrum-1.4.1
 	dev-libs/glib:2
 	alsa? ( media-libs/alsa-lib )
 	ao? ( media-libs/libao )
 	gpm? ( sys-libs/gpm )
-	gtk? ( x11-libs/gtk+:3 )
 	joystick? ( media-libs/libjsw )
 	png? ( media-libs/libpng:0= sys-libs/zlib )
-	sdl? ( media-libs/libsdl )
-	svga? ( media-libs/svgalib )
-	X? ( x11-libs/libX11
-		x11-libs/libXext )
+	backend-gtk? ( x11-libs/gtk+:3 )
+	backend-sdl? ( media-libs/libsdl )
+	backend-svga? ( media-libs/svgalib )
+	backend-X? ( x11-libs/libX11 x11-libs/libXext )
 	xml? ( dev-libs/libxml2:2 )"
 DEPEND="${RDEPEND}
-	fbcon? ( virtual/linux-sources )
+	backend-fbcon? ( virtual/linux-sources )
 	dev-lang/perl
 	virtual/pkgconfig"
 
@@ -48,15 +47,15 @@ src_configure() {
 		$(use_with xml libxml2)
 	)
 
-	if use gtk; then
+	if use backend-gtk; then
 		:
-	elif use sdl; then
+	elif use backend-sdl; then
 		myconf+=("--with-sdl")
-	elif use X; then
+	elif use backend-X; then
 		myconf+=("--without-gtk")
-	elif use svga; then
+	elif use backend-svga; then
 		myconf+=("--with-svgalib")
-	elif use fbcon; then
+	elif use backend-fbcon; then
 		myconf+=("--with-fb")
 	fi
 

--- a/app-emulation/fuse/metadata.xml
+++ b/app-emulation/fuse/metadata.xml
@@ -12,4 +12,11 @@
 	<upstream>
 		<remote-id type="sourceforge">fuse-emulator</remote-id>
 	</upstream>
+	<use>
+		<flag name="backend-fbcon">Use framebuffer rendering backend</flag>
+		<flag name="backend-gtk">Use GTK+ rendering backend</flag>
+		<flag name="backend-sdl">Use SDL rendering backend</flag>
+		<flag name="backend-svga">Use svgalib rendering backend</flag>
+		<flag name="backend-X">Use X11 rendering backend</flag>
+	</use>
 </pkgmetadata>

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -3,6 +3,10 @@
 
 # This file requires >=portage-2.1.1
 
+# Jan Ziak <0xe2.0x9a.0x9b@gmail.com> (14 Mar 2018)
+# Expose SVGA backend for x86 users
+app-emulation/fuse -backend-svga
+
 # Thomas Deutschmann <whissi@gentoo.org> (10 Feb 2018)
 # Requires dev-db/mongodb which has dropped x86 support
 >=dev-libs/mongo-c-driver-1.8.2 test

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -7,6 +7,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Jan Ziak <0xe2.0x9a.0x9b@gmail.com> (14 Mar 2018)
+# Mask local USE flag to satisfy repoman
+app-emulation/fuse backend-svga
+
 # Pacho Ramos <pacho@gentoo.org> (13 Mar 2018)
 # libewf is going to be removed, bug #547418
 app-admin/testdisk ewf


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/649180

Please merge if possible. Thanks.