### PR TITLE
media-gfx/curaengine: Missing test DEP, remove broken test

### DIFF
--- a/media-gfx/curaengine/curaengine-2.3.1-r1.ebuild
+++ b/media-gfx/curaengine/curaengine-2.3.1-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+inherit cmake-utils
+
+MY_PN=CuraEngine
+MY_PV=${PV/_beta}
+
+DESCRIPTION="A 3D model slicing engine for 3D printing"
+HOMEPAGE="https://github.com/Ultimaker/CuraEngine"
+SRC_URI="https://github.com/Ultimaker/${MY_PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
+KEYWORDS="~amd64 ~x86"
+
+LICENSE="AGPL-3"
+SLOT="0"
+IUSE="doc test"
+
+RDEPEND="${PYTHON_DEPS}
+	dev-libs/libarcus:=
+	>=dev-libs/protobuf-3"
+DEPEND="${RDEPEND}
+	doc? ( app-doc/doxygen
+	       media-gfx/graphviz )
+	test? ( dev-util/cppunit )"
+
+S="${WORKDIR}/${MY_PN}-${MY_PV}"
+DOCS=( "README.md" )
+PATCHES=( "${FILESDIR}/${P}-remove-gcodeplannertest.patch" )
+
+src_configure() {
+	local mycmakeargs=( "-DBUILD_TESTS=$(usex test ON OFF)" )
+	cmake-utils_src_configure
+}
+
+src_compile() {
+	cmake-utils_src_make
+	if use doc; then
+		doxygen || die
+		mv docs/html . || die
+		find html -name '*.md5' -or -name '*.map' -delete || die
+		HTML_DOCS=( html/. )
+	fi
+}

--- a/media-gfx/curaengine/curaengine-2.6.0-r1.ebuild
+++ b/media-gfx/curaengine/curaengine-2.6.0-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+inherit cmake-utils
+
+MY_PN=CuraEngine
+MY_PV=${PV/_beta}
+
+DESCRIPTION="A 3D model slicing engine for 3D printing"
+HOMEPAGE="https://github.com/Ultimaker/CuraEngine"
+SRC_URI="https://github.com/Ultimaker/${MY_PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
+KEYWORDS="~amd64 ~x86"
+
+LICENSE="AGPL-3"
+SLOT="0"
+IUSE="doc test"
+
+RDEPEND="${PYTHON_DEPS}
+	dev-libs/libarcus:=
+	>=dev-libs/protobuf-3"
+DEPEND="${RDEPEND}
+	doc? ( app-doc/doxygen
+	       media-gfx/graphviz )
+	test? ( dev-util/cppunit )"
+
+S="${WORKDIR}/${MY_PN}-${MY_PV}"
+DOCS=( "README.md" )
+
+src_configure() {
+	local mycmakeargs=( "-DBUILD_TESTS=$(usex test ON OFF)" )
+	cmake-utils_src_configure
+}
+
+src_compile() {
+	cmake-utils_src_make
+	if use doc; then
+		doxygen || die
+		mv docs/html . || die
+		find html -name '*.md5' -or -name '*.map' -delete || die
+		HTML_DOCS=( html/. )
+	fi
+}

--- a/media-gfx/curaengine/files/curaengine-2.3.1-remove-gcodeplannertest.patch
+++ b/media-gfx/curaengine/files/curaengine-2.3.1-remove-gcodeplannertest.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 47dcd2d1..c2316d68 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -110,9 +125,6 @@ set(engine_SRCS # Except main.cpp.
+ )
+ 
+ # List of tests. For each test there must be a file tests/${NAME}.cpp and a file tests/${NAME}.h.
+-set(engine_TEST
+-    GCodePlannerTest
+-)
+ set(engine_TEST_INFILL
+ )
+ set(engine_TEST_UTILS


### PR DESCRIPTION
Tests require missing dev-util/cppinit.
GCodePlannerTest broken per issue #404 upstream.
Bug: https://bugs.gentoo.org/640838

Package-Manager: Portage-2.3.13, Repoman-2.3.3