### PR TITLE
dev-util/cmake-3.11.0_rc2: simplify FindBLAS patch

### DIFF
--- a/dev-util/cmake/cmake-3.11.0_rc2.ebuild
+++ b/dev-util/cmake/cmake-3.11.0_rc2.ebuild
@@ -51,7 +51,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.0-darwin-isysroot.patch
 
 	# handle gentoo packaging in find modules
-	"${FILESDIR}"/${PN}-3.0.0-FindBLAS.patch
+	"${FILESDIR}"/${PN}-3.11.0_rc2-FindBLAS.patch
 	"${FILESDIR}"/${PN}-3.8.0_rc2-FindBoost-python.patch
 	"${FILESDIR}"/${PN}-3.0.2-FindLAPACK.patch
 	"${FILESDIR}"/${PN}-3.5.2-FindQt4.patch

--- a/dev-util/cmake/files/cmake-3.11.0_rc2-FindBLAS.cmake
+++ b/dev-util/cmake/files/cmake-3.11.0_rc2-FindBLAS.cmake
@@ -1,0 +1,23 @@
+--- a/Modules/FindBLAS.cmake
++++ b/Modules/FindBLAS.cmake
+@@ -4,6 +4,10 @@
+ #
+ # Find BLAS library
+ #
++# Version modified for Gentoo Linux.
++# If a valid PkgConfig configuration is found, this overrides and cancels
++# all further checks.
++#
+ # This module finds an installed fortran library that implements the
+ # BLAS linear-algebra interface (see http://www.netlib.org/blas/).  The
+ # list of libraries searched for is taken from the autoconf macro file,
+@@ -50,6 +54,9 @@
+ # (To distribute this file outside of CMake, substitute the full
+ #  License text for the above reference.)
+ 
++# first, try PkgConfig
++set(BLA_PREFER_PKGCONFIG On)
++
+ include(${CMAKE_CURRENT_LIST_DIR}/CheckFunctionExists.cmake)
+ include(${CMAKE_CURRENT_LIST_DIR}/CheckFortranFunctionExists.cmake)
+ 


### PR DESCRIPTION
Most of the previous Gentoo patch has been upstreamed.