### PR TITLE
x11-apps/xinit: rebase xinit-1.3.4-startx-current-vt.patch

### DIFF
--- a/x11-apps/xinit/files/xinit-1.4.0-startx-current-vt.patch
+++ b/x11-apps/xinit/files/xinit-1.4.0-startx-current-vt.patch
@@ -1,0 +1,20 @@
+--- a/startx.cpp
++++ b/startx.cpp
+@@ -200,17 +200,6 @@ XCOMM process server arguments
+ if [ x"$server" = x ]; then
+     server=$defaultserver
+ 
+-#ifdef __linux__
+-    XCOMM When starting the defaultserver start X on the current tty to avoid
+-    XCOMM the startx session being seen as inactive:
+-    XCOMM "https://bugzilla.redhat.com/show_bug.cgi?id=806491"
+-    tty=$(tty)
+-    if expr "$tty" : '/dev/tty[0-9][0-9]*$' > /dev/null; then
+-        tty_num=$(echo "$tty" | grep -oE '[0-9]+$')
+-        vtarg="vt$tty_num -keeptty"
+-    fi
+-#endif
+-
+     XCOMM For compatibility reasons, only use xserverrc if there were no server command line arguments
+     if [ x"$serverargs" = x -a x"$display" = x ]; then
+ 	if [ -f "$userserverrc" ]; then

--- a/x11-apps/xinit/xinit-1.4.0-r1.ebuild
+++ b/x11-apps/xinit/xinit-1.4.0-r1.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+inherit xorg-2
+
+DESCRIPTION="X Window System initializer"
+
+LICENSE="${LICENSE} GPL-2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~arm-linux ~x86-linux"
+IUSE="+minimal"
+
+RDEPEND="
+	!<x11-base/xorg-server-1.8.0
+	x11-apps/xauth
+	x11-libs/libX11
+"
+DEPEND="${RDEPEND}"
+PDEPEND="x11-apps/xrdb
+	!minimal? (
+		x11-apps/xclock
+		x11-apps/xsm
+		x11-terms/xterm
+		x11-wm/twm
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.3.3-gentoo-customizations.patch"
+	"${FILESDIR}/${PN}-1.4.0-startx-current-vt.patch"
+)
+
+src_configure() {
+	XORG_CONFIGURE_OPTIONS=(
+		--with-xinitdir="${EPREFIX}"/etc/X11/xinit
+	)
+	xorg-2_src_configure
+}
+
+src_install() {
+	xorg-2_src_install
+
+	exeinto /etc/X11
+	doexe "${FILESDIR}"/chooser.sh "${FILESDIR}"/startDM.sh
+	exeinto /etc/X11/Sessions
+	doexe "${FILESDIR}"/Xsession
+	exeinto /etc/X11/xinit
+	newexe "${FILESDIR}"/xserverrc.1 xserverrc
+	exeinto /etc/X11/xinit/xinitrc.d/
+	doexe "${FILESDIR}"/00-xhost
+
+	insinto /usr/share/xsessions
+	doins "${FILESDIR}"/Xsession.desktop
+}
+
+pkg_postinst() {
+	xorg-2_pkg_postinst
+	ewarn "If you use startx to start X instead of a login manager like gdm/kdm,"
+	ewarn "you can set the XSESSION variable to anything in /etc/X11/Sessions/ or"
+	ewarn "any executable. When you run startx, it will run this as the login session."
+	ewarn "You can set this in a file in /etc/env.d/ for the entire system,"
+	ewarn "or set it per-user in ~/.bash_profile (or similar for other shells)."
+	ewarn "Here's an example of setting it for the whole system:"
+	ewarn "    echo XSESSION=\"Gnome\" > /etc/env.d/90xsession"
+	ewarn "    env-update && source /etc/profile"
+}


### PR DESCRIPTION
Patch no longer cleanly applies, fixed it up to apply on new version
using quilt. Builds properly on my system.

Bug: https://bugs.gentoo.org/650066
Closes: https://bugs.gentoo.org/650066
Package-Manager: Portage-2.3.24, Repoman-2.3.6
Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>