### PR TITLE
net-misc/bird-1.6.3-r1: added ~arm64 keyword.

### DIFF
--- a/net-misc/bird/bird-1.6.3-r1.ebuild
+++ b/net-misc/bird/bird-1.6.3-r1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="ftp://bird.network.cz/pub/${PN}/${P}.tar.gz"
 LICENSE="GPL-2"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+client debug ipv6"
 
 RDEPEND="client? ( sys-libs/ncurses )


### PR DESCRIPTION
 * Package:    net-misc/bird-1.6.3-r1
 * Repository: gentoo
 * USE:        arm64 client elibc_glibc ipv6 kernel_linux userland_GNU
 * FEATURES:   preserve-libs sandbox test userpriv usersandbox

Closes: https://bugs.gentoo.org/646788