### PR TITLE
sys-cluster/ceph: Fix build error resulting from db6059b

### DIFF
--- a/sys-cluster/ceph/files/ceph.initd-r8
+++ b/sys-cluster/ceph/files/ceph.initd-r8
@@ -77,7 +77,7 @@ start_pre() {
 			log_postfix=".${daemon_id}-${arg_name}.log"
 			log_file="${arg_val}"
 
-			if [ "${log_file}" != /dev/null ]
+			if [ "${log_file}" != /dev/null ]; then
 				log_file="${log_file}${log_postfix}"
 			fi
 


### PR DESCRIPTION
Syntax error in files/ceph.initd-r8 caused failure to build

Closes: https://bugs.gentoo.org/650168

Package-Manager: Portage-2.3.24, Repoman-2.3.6