### PR TITLE
media-video/mpv: update ffmpeg patch for 9999

### DIFF
--- a/media-video/mpv/files/mpv-9999-make-ffmpeg-version-check-non-fatal.patch
+++ b/media-video/mpv/files/mpv-9999-make-ffmpeg-version-check-non-fatal.patch
@@ -1,0 +1,28 @@
+player: make ffmpeg/libav version check non-fatal
+
+We already enforce mpv rebuilds when ffmpeg/libav SONAME changes.
+
+diff --git a/player/main.c b/player/main.c
+index 5a3fe4c1b7..8cfbb09c56 100644
+--- a/player/main.c
++++ b/player/main.c
+@@ -429,13 +429,12 @@ int mp_initialize(struct MPContext *mpctx, char **options)
+         // Distro maintainers who patch this out should be aware that mpv
+         // intentionally ignores ABI in some places where it's not possible to
+         // get by without violating it.
+-        print_libav_versions(mpctx->log, MSGL_FATAL);
+-        MP_FATAL(mpctx, "\nmpv was compiled against a different version of "
+-                 "FFmpeg/Libav than the shared\nlibrary it is linked against. "
+-                 "This is most likely a broken build and could\nresult in "
+-                 "misbehavior and crashes.\n\nmpv does not support this "
+-                 "configuration and will not run - rebuild mpv instead.\n");
+-        return -1;
++        print_libav_versions(mpctx->log, MSGL_WARN);
++        MP_WARN(mpctx, "\nmpv was compiled against a different version of "
++                "FFmpeg/Libav than the shared\nlibrary it is linked against. "
++                "This could result in misbehavior and crashes.\n\n"
++                "Upstream does not support this configuration.\n"
++                "Please rebuild mpv in case of any problems.\n");
+     }
+
+     if (!mpctx->playlist->first && !opts->player_idle_mode)

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -132,7 +132,7 @@ RDEPEND="${COMMON_DEPEND}
 "
 
 PATCHES=(
-	"${FILESDIR}/${PN}-0.19.0-make-ffmpeg-version-check-non-fatal.patch"
+	"${FILESDIR}/${P}-make-ffmpeg-version-check-non-fatal.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/649908
Package-Manager: Portage-2.3.24, Repoman-2.3.6