### PR TITLE
media-plugins/vdr-*: use HTTPS

### DIFF
--- a/media-plugins/vdr-cdplayer/vdr-cdplayer-1.2.0.ebuild
+++ b/media-plugins/vdr-cdplayer/vdr-cdplayer-1.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: CD-PLAYER"
-HOMEPAGE="http://www.uli-eckhardt.de/vdr/cdplayer.en.shtml"
-SRC_URI="http://www.uli-eckhardt.de/vdr/download/${P}.tgz"
+HOMEPAGE="https://www.uli-eckhardt.de/vdr/cdplayer.en.shtml"
+SRC_URI="https://www.uli-eckhardt.de/vdr/download/${P}.tgz"
 
 KEYWORDS="~amd64 ~x86"
 SLOT="0"

--- a/media-plugins/vdr-cdplayer/vdr-cdplayer-1.2.1.ebuild
+++ b/media-plugins/vdr-cdplayer/vdr-cdplayer-1.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: CD-PLAYER"
-HOMEPAGE="http://www.uli-eckhardt.de/vdr/cdplayer.en.shtml"
-SRC_URI="http://www.uli-eckhardt.de/vdr/download/${P}.tgz"
+HOMEPAGE="https://www.uli-eckhardt.de/vdr/cdplayer.en.shtml"
+SRC_URI="https://www.uli-eckhardt.de/vdr/download/${P}.tgz"
 
 KEYWORDS="~amd64 ~x86"
 SLOT="0"

--- a/media-plugins/vdr-cdplayer/vdr-cdplayer-1.2.2.ebuild
+++ b/media-plugins/vdr-cdplayer/vdr-cdplayer-1.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: CD-PLAYER"
-HOMEPAGE="http://www.uli-eckhardt.de/vdr/cdplayer.en.shtml"
-SRC_URI="http://www.uli-eckhardt.de/vdr/download/${P}.tgz"
+HOMEPAGE="https://www.uli-eckhardt.de/vdr/cdplayer.en.shtml"
+SRC_URI="https://www.uli-eckhardt.de/vdr/download/${P}.tgz"
 
 KEYWORDS="~amd64 ~x86"
 SLOT="0"

--- a/media-plugins/vdr-dvdswitch/vdr-dvdswitch-0.2.0.ebuild
+++ b/media-plugins/vdr-dvdswitch/vdr-dvdswitch-0.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="534" # every bump, new version
 
 DESCRIPTION="VDR Plugin: to play dvds and dvd file structures"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-dvdswitch"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-dvdswitch"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 LICENSE="GPL-2"

--- a/media-plugins/vdr-dvdswitch/vdr-dvdswitch-0.2.1.ebuild
+++ b/media-plugins/vdr-dvdswitch/vdr-dvdswitch-0.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1059" # every bump, new version
 
 DESCRIPTION="VDR Plugin: to play dvds and dvd file structures"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-dvdswitch"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-dvdswitch"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 LICENSE="GPL-2"

--- a/media-plugins/vdr-dvdswitch/vdr-dvdswitch-0.2.2.ebuild
+++ b/media-plugins/vdr-dvdswitch/vdr-dvdswitch-0.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1323" # every bump, new version
 
 DESCRIPTION="VDR Plugin: to play dvds and dvd file structures"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-dvdswitch"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-dvdswitch"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 LICENSE="GPL-2"

--- a/media-plugins/vdr-graphlcd/vdr-graphlcd-0.1.9.ebuild
+++ b/media-plugins/vdr-graphlcd/vdr-graphlcd-0.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="502" # every bump, new version
 
 DESCRIPTION="VDR Plugin: support output on Graphical LCD "
-HOMEPAGE="http://projects.vdr-developer.org/projects/graphlcd"
+HOMEPAGE="https://projects.vdr-developer.org/projects/graphlcd"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="~x86 ~amd64"

--- a/media-plugins/vdr-image/vdr-image-0.3.1.ebuild
+++ b/media-plugins/vdr-image/vdr-image-0.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit vdr-plugin-2 flag-o-matic
 VERSION="679" #every bump, new version
 
 DESCRIPTION="VDR plugin: display of digital images, like jpeg, tiff, png, bmp"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-image"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-image"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tar.gz"
 
 KEYWORDS="amd64 x86"

--- a/media-plugins/vdr-image/vdr-image-0.4.0.ebuild
+++ b/media-plugins/vdr-image/vdr-image-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1325" #every bump, new version
 
 DESCRIPTION="VDR plugin: display of digital images, like jpeg, tiff, png, bmp"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-image"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-image"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="amd64 x86"

--- a/media-plugins/vdr-markad/vdr-markad-0.1.4-r1.ebuild
+++ b/media-plugins/vdr-markad/vdr-markad-0.1.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1041" # every bump, new version
 
 DESCRIPTION="VDR Plugin: marks advertisements in VDR recordings"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-markad/"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-markad/"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="amd64 x86"

--- a/media-plugins/vdr-markad/vdr-markad-0.1.4-r2.ebuild
+++ b/media-plugins/vdr-markad/vdr-markad-0.1.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1041" # every bump, new version
 
 DESCRIPTION="VDR Plugin: marks advertisements in VDR recordings"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-markad/"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-markad/"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="~amd64 ~arm ~x86"

--- a/media-plugins/vdr-markad/vdr-markad-0.1.4.ebuild
+++ b/media-plugins/vdr-markad/vdr-markad-0.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1041" # every bump, new version
 
 DESCRIPTION="VDR Plugin: marks advertisements in VDR recordings"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-markad/"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-markad/"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="amd64 x86"

--- a/media-plugins/vdr-menuorg/vdr-menuorg-0.5.1.ebuild
+++ b/media-plugins/vdr-menuorg/vdr-menuorg-0.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit flag-o-matic vdr-plugin-2
 VERSION="1312" # every bump, new version
 
 DESCRIPTION="VDR plugin: make osd menu configurable via config-file"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-menuorg"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-menuorg"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/media-plugins/vdr-osdpip/vdr-osdpip-0.1.2-r1.ebuild
+++ b/media-plugins/vdr-osdpip/vdr-osdpip-0.1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ VERSION="961" # every bump, new version
 inherit vdr-plugin-2 flag-o-matic
 
 DESCRIPTION="VDR plugin: Show another channel in the OSD"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-osdpip"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-osdpip"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="amd64 x86"

--- a/media-plugins/vdr-pin/vdr-pin-0.1.14.ebuild
+++ b/media-plugins/vdr-pin/vdr-pin-0.1.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1379" # every bump, new version
 
 DESCRIPTION="VDR plugin: enable/disable parentalrating in records"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-${VDRPLUGIN}"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-pin"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 KEYWORDS="~amd64 ~x86"
 

--- a/media-plugins/vdr-rpihddevice/vdr-rpihddevice-0.0.10.ebuild
+++ b/media-plugins/vdr-rpihddevice/vdr-rpihddevice-0.0.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1817" #every bump, new version
 
 DESCRIPTION="VDR Plugin: Output Device for Raspberry Pi"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-rpihddevice"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-rpihddevice"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="~arm"

--- a/media-plugins/vdr-rpihddevice/vdr-rpihddevice-0.0.11.ebuild
+++ b/media-plugins/vdr-rpihddevice/vdr-rpihddevice-0.0.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1861" #every bump, new version
 
 DESCRIPTION="VDR Plugin: Output Device for Raspberry Pi"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-rpihddevice"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-rpihddevice"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="~arm"

--- a/media-plugins/vdr-rpihddevice/vdr-rpihddevice-1.0.0.ebuild
+++ b/media-plugins/vdr-rpihddevice/vdr-rpihddevice-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1966" #every bump, new version
 
 DESCRIPTION="VDR Plugin: Output Device for Raspberry Pi"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-rpihddevice"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-rpihddevice"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="~arm"

--- a/media-plugins/vdr-rpihddevice/vdr-rpihddevice-1.0.3.ebuild
+++ b/media-plugins/vdr-rpihddevice/vdr-rpihddevice-1.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="2045" #every bump, new version
 
 DESCRIPTION="VDR Plugin: Output Device for Raspberry Pi"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-rpihddevice"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-rpihddevice"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 KEYWORDS="~arm"

--- a/media-plugins/vdr-streamdev/vdr-streamdev-0.6.1.ebuild
+++ b/media-plugins/vdr-streamdev/vdr-streamdev-0.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1580" # every bump, new version !
 
 DESCRIPTION="VDR Plugin: Client/Server and http streaming plugin"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-streamdev"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-streamdev"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 LICENSE="GPL-2"

--- a/media-plugins/vdr-streamdev/vdr-streamdev-0.6.1_p20160320.ebuild
+++ b/media-plugins/vdr-streamdev/vdr-streamdev-0.6.1_p20160320.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ inherit vdr-plugin-2
 GIT_VERSION="674bb5b331240de3ba2a8beb63a1276003e64e3e"
 
 DESCRIPTION="VDR Plugin: Client/Server and http streaming plugin"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-streamdev"
-SRC_URI="http://projects.vdr-developer.org/git/vdr-plugin-streamdev.git/snapshot/vdr-plugin-streamdev-${GIT_VERSION}.tar.bz2"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-streamdev"
+SRC_URI="https://projects.vdr-developer.org/git/vdr-plugin-streamdev.git/snapshot/vdr-plugin-streamdev-${GIT_VERSION}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/vdr-undelete/vdr-undelete-0.0.7-r1.ebuild
+++ b/media-plugins/vdr-undelete/vdr-undelete-0.0.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1060" # every bump, new version!
 
 DESCRIPTION="VDR Plugin: Recover deleted recordings of VDR"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-undelete"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-undelete"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 SLOT="0"

--- a/media-plugins/vdr-undelete/vdr-undelete-0.0.7.ebuild
+++ b/media-plugins/vdr-undelete/vdr-undelete-0.0.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1060" # every bump, new version!
 
 DESCRIPTION="VDR Plugin: Recover deleted recordings of VDR"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-undelete"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-undelete"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz"
 
 SLOT="0"

--- a/media-plugins/vdr-vodcatcher/vdr-vodcatcher-0.2.2.ebuild
+++ b/media-plugins/vdr-vodcatcher/vdr-vodcatcher-0.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,7 +6,7 @@ EAPI="5"
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR plugin: Downloads rss-feeds and passes video enclosures to the mplayer plugin"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-vodcatcher"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-vodcatcher"
 SRC_URI="mirror://vdr-developerorg/154/${P}.tar.gz"
 
 SLOT="0"

--- a/media-plugins/vdr-zaphistory/vdr-zaphistory-0.9.6.ebuild
+++ b/media-plugins/vdr-zaphistory/vdr-zaphistory-0.9.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit vdr-plugin-2
 VERSION="1437" # every bump, new Version
 
 DESCRIPTION="VDR Plugin: Shows the least recently used channels"
-HOMEPAGE="http://projects.vdr-developer.org/projects/plg-zaphistory"
+HOMEPAGE="https://projects.vdr-developer.org/projects/plg-zaphistory"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/zaphistory-${PV}.tar.gz"
 
 KEYWORDS="amd64 x86"


### PR DESCRIPTION
Hi,

This PR fixes a bunch of vdr related packages to use https instead of http.

Please review.