### PR TITLE
net-dns/dnssec-{check,lookup,nodes,validator}: use HTTPS

### DIFF
--- a/net-dns/dnssec-check/dnssec-check-2.2.ebuild
+++ b/net-dns/dnssec-check/dnssec-check-2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils qmake-utils
 
 DESCRIPTION="tests local resolver for support of DNSSEC validation"
-HOMEPAGE="http://www.dnssec-tools.org"
-SRC_URI="http://www.dnssec-tools.org/download/${P}.tar.gz"
+HOMEPAGE="https://www.dnssec-tools.org"
+SRC_URI="https://www.dnssec-tools.org/download/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/net-dns/dnssec-lookup/dnssec-lookup-2.2.ebuild
+++ b/net-dns/dnssec-lookup/dnssec-lookup-2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,8 +8,8 @@ inherit qt4-r2
 MY_PN=${PN/dnssec-/}
 MY_P=${MY_PN}-${PV}
 DESCRIPTION="DNS lookup utility that supports DNSSEC validation"
-HOMEPAGE="http://www.dnssec-tools.org"
-SRC_URI="http://www.dnssec-tools.org/download/${MY_P}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://www.dnssec-tools.org"
+SRC_URI="https://www.dnssec-tools.org/download/${MY_P}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/net-dns/dnssec-nodes/dnssec-nodes-2.2.ebuild
+++ b/net-dns/dnssec-nodes/dnssec-nodes-2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils qt4-r2
 
 DESCRIPTION="graphically depicts the DNSSEC results from a lookup via logfiles"
-HOMEPAGE="http://www.dnssec-tools.org"
-SRC_URI="http://www.dnssec-tools.org/download/${P}.tar.gz"
+HOMEPAGE="https://www.dnssec-tools.org"
+SRC_URI="https://www.dnssec-tools.org/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-dns/dnssec-validator/dnssec-validator-2.2-r1.ebuild
+++ b/net-dns/dnssec-validator/dnssec-validator-2.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit eutils
 
 DESCRIPTION="DNSSEC validator (dnsval)"
-HOMEPAGE="http://www.dnssec-tools.org/"
-SRC_URI="http://www.dnssec-tools.org/download/dnsval-${PV}.tar.gz"
+HOMEPAGE="https://www.dnssec-tools.org/"
+SRC_URI="https://www.dnssec-tools.org/download/dnsval-${PV}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes a few dnssec packages to use HTTPS.

Please review.