### PR TITLE
profiles: Mask dnscrypt-proxy-1.x for removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -29,6 +29,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Georgy Yakovlev <ya@sysdump.net> (13 Mar 2018)
+# 1.x version is no longer maintained by upstream
+# 2.x is in the tree and is better in almost every way
+# Removal in 90 days. Bug #650464
+=net-dns/dnscrypt-proxy-1.9.5-r1
+
 # Pacho Ramos <pacho@gentoo.org> (13 Mar 2018)
 # Tests need network, nothing requires this old lib anymore and upstream is
 # dead for a long time (#335233). Removal in a month.


### PR DESCRIPTION
I feel proper mask and last-rite is needed because 2.x is a complete rewrite in another language, full re-implementation of the client.
Give users a bit more time to migrate to 2.x.

A fork of 1.x exists[1] on life support mode with no intentions of adding new functionality and will be retired in a year anyway.

Also one of 1.x plugins is vulnerable [2].

I see no reason keeping old version in the tree anymore.

[1]https://github.com/dyne/dnscrypt-proxy/commit/45912417738ce38ce6dd04cc4173d276a17ef2d8
[2]https://github.com/dyne/dnscrypt-proxy/issues/5