### PR TITLE
dev-python/pylint: Fix version requirement for astroid

### DIFF
--- a/dev-python/pylint/pylint-1.8.2.ebuild
+++ b/dev-python/pylint/pylint-1.8.2.ebuild
@@ -20,7 +20,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-lin
 IUSE="doc examples test"
 
 RDEPEND="
-	>=dev-python/astroid-1.5.1[${PYTHON_USEDEP}]
+	>=dev-python/astroid-1.6.0[${PYTHON_USEDEP}]
 	dev-python/six[${PYTHON_USEDEP}]
 	>=dev-python/isort-4.2.5[${PYTHON_USEDEP}]
 	dev-python/mccabe[${PYTHON_USEDEP}]


### PR DESCRIPTION
Pylint in version 1.8.2 really depends on >=dev-python/astroid-1.6:

$ pylint
> ...
> pkg_resources.DistributionNotFound: The 'astroid<2.0,>=1.6'
> distribution was not found and is required by pylint