### PR TITLE
sci-mathematics/pymc3: Fix installation error, bug #632334

### DIFF
--- a/sci-mathematics/pymc3/pymc3-3.1.ebuild
+++ b/sci-mathematics/pymc3/pymc3-3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -46,7 +46,7 @@ DEPEND="
 	)
 "
 
-DOCS=(CHANGELOG.md  CONTRIBUTING.md RELEASE-NOTES.md
+DOCS=(CONTRIBUTING.md RELEASE-NOTES.md
 	  CONDUCT.md GOVERNANCE.md README.rst)
 
 python_prepare_all() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/632334
Package-Manager: Portage-2.3.24, Repoman-2.3.6