### PR TITLE
sci-libs/opencascade: new patch for use with >=vtk-7.1

### DIFF
--- a/sci-libs/opencascade/files/opencascade-6.9.1-vtk-7.1.patch
+++ b/sci-libs/opencascade/files/opencascade-6.9.1-vtk-7.1.patch
@@ -1,0 +1,48 @@
+--- a/src/IVtkVTK/IVtkVTK_ShapeData.cxx
++++ b/src/IVtkVTK/IVtkVTK_ShapeData.cxx
+@@ -80,9 +80,9 @@ void IVtkVTK_ShapeData::InsertVertex (const IVtk_IdType theShapeID,
+   vtkIdType aPointIdVTK = thePointId;
+   myPolyData->InsertNextCell (VTK_VERTEX, 1, &aPointIdVTK);
+   const vtkIdType aShapeIDVTK = theShapeID;
+-  mySubShapeIDs->InsertNextTupleValue (&aShapeIDVTK);
++  mySubShapeIDs->InsertNextTypedTuple (&aShapeIDVTK);
+   const vtkIdType aType = theMeshType;
+-  myMeshTypes->InsertNextTupleValue (&aType);
++  myMeshTypes->InsertNextTypedTuple (&aType);
+ }
+ 
+ //================================================================
+@@ -97,9 +97,9 @@ void IVtkVTK_ShapeData::InsertLine (const IVtk_IdType   theShapeID,
+   vtkIdType aPoints[2] = { thePointId1, thePointId2 };
+   myPolyData->InsertNextCell (VTK_LINE, 2, aPoints);
+   const vtkIdType aShapeIDVTK = theShapeID;
+-  mySubShapeIDs->InsertNextTupleValue (&aShapeIDVTK);
++  mySubShapeIDs->InsertNextTypedTuple (&aShapeIDVTK);
+   const vtkIdType aType = theMeshType;
+-  myMeshTypes->InsertNextTupleValue (&aType);
++  myMeshTypes->InsertNextTypedTuple (&aType);
+ }
+ 
+ //================================================================
+@@ -124,9 +124,9 @@ void IVtkVTK_ShapeData::InsertLine (const IVtk_IdType       theShapeID,
+ 
+     myPolyData->InsertNextCell (VTK_POLY_LINE, anIdList);
+     const vtkIdType aShapeIDVTK = theShapeID;
+-    mySubShapeIDs->InsertNextTupleValue (&aShapeIDVTK);
++    mySubShapeIDs->InsertNextTypedTuple (&aShapeIDVTK);
+     const vtkIdType aType = theMeshType;
+-    myMeshTypes->InsertNextTupleValue (&aType);
++    myMeshTypes->InsertNextTypedTuple (&aType);
+     anIdList->Delete();
+   }
+ }
+@@ -144,7 +144,7 @@ void IVtkVTK_ShapeData::InsertTriangle (const IVtk_IdType   theShapeID,
+   vtkIdType aPoints[3] = { thePointId1, thePointId2, thePointId3 };
+   myPolyData->InsertNextCell (VTK_TRIANGLE, 3, aPoints);
+   const vtkIdType aShapeIDVTK = theShapeID;
+-  mySubShapeIDs->InsertNextTupleValue (&aShapeIDVTK);
++  mySubShapeIDs->InsertNextTypedTuple (&aShapeIDVTK);
+   const vtkIdType aType = theMeshType;
+-  myMeshTypes->InsertNextTupleValue (&aType);
++  myMeshTypes->InsertNextTypedTuple (&aType);
+ }

--- a/sci-libs/opencascade/opencascade-6.9.1-r2.ebuild
+++ b/sci-libs/opencascade/opencascade-6.9.1-r2.ebuild
@@ -31,13 +31,13 @@ DEPEND="
 	tbb? ( dev-cpp/tbb )
 	vtk? ( || ( sci-libs/vtk[imaging] sci-libs/vtk[rendering] sci-libs/vtk[views] sci-libs/vtk[all-modules] ) )"
 RDEPEND="${DEPEND}"
-
 CHECKREQS_MEMORY="256M"
 CHECKREQS_DISK_BUILD="3584M"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-6.8.0-fixed-DESTDIR.patch
 	"${FILESDIR}"/${PN}-6.9.1-vtk-configure.patch
+	"${FILESDIR}"/${PN}-6.9.1-vtk-7.1.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/650596

From VTK 7.1 the method name InsertNextTupleValue is repplaced by InsertNextTypedTuple.

Opencascade will not compile without this patch.