### PR TITLE
x11-plugins/purple-slack: new package

### DIFF
--- a/x11-plugins/purple-slack/metadata.xml
+++ b/x11-plugins/purple-slack/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">dylex/slack-libpurple</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/x11-plugins/purple-slack/purple-slack-9999.ebuild
+++ b/x11-plugins/purple-slack/purple-slack-9999.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit git-r3
+
+DESCRIPTION="A libpurple plugin for the web-based slack api."
+HOMEPAGE="https://github.com/dylex/slack-libpurple"
+EGIT_REPO_URI="https://github.com/dylex/slack-libpurple"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+RDEPEND="net-im/pidgin"
+DEPEND="${RDEPEND}
+	dev-vcs/git"


### PR DESCRIPTION
Added the package purple-slack from [here](https://github.com/dylex/slack-libpurple).
Now that slack shut down their bridges to proper chat protocols, we will have to use their api.

I ran `repoman ci`, which always deleted my Manifest file. I'm not quite sure why, or if this is intended but I wasn't confident enough to simply use `git commit` with my Manifest instead.