### PR TITLE
app-backup/snapper: remove ext4, force btrfs

### DIFF
--- a/app-backup/snapper/snapper-0.5.4.ebuild
+++ b/app-backup/snapper/snapper-0.5.4.ebuild
@@ -1,18 +1,18 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 inherit systemd
 
-DESCRIPTION="Command-line program for btrfs and ext4 snapshot management"
+DESCRIPTION="Command-line program for btrfs and lvm snapshot management"
 HOMEPAGE="http://snapper.io/"
 SRC_URI="ftp://ftp.suse.com/pub/projects/snapper/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="+btrfs ext4 lvm pam xattr"
+IUSE="lvm pam xattr"
 
 RDEPEND="dev-libs/boost:=[threads]
 	dev-libs/libxml2
@@ -20,10 +20,9 @@ RDEPEND="dev-libs/boost:=[threads]
 	sys-apps/acl
 	sys-apps/dbus
 	sys-apps/util-linux
+	>=sys-fs/btrfs-progs-3.17.1
 	sys-libs/zlib
 	virtual/libintl
-	btrfs? ( >=sys-fs/btrfs-progs-3.17.1 )
-	ext4? ( sys-fs/e2fsprogs )
 	lvm? ( sys-fs/lvm2 )
 	pam? ( sys-libs/pam )
 	xattr? ( sys-apps/attr )"
@@ -31,8 +30,6 @@ RDEPEND="dev-libs/boost:=[threads]
 DEPEND="${RDEPEND}
 	sys-devel/gettext
 	virtual/pkgconfig"
-
-REQUIRED_USE="|| ( btrfs ext4 lvm )"
 
 PATCHES=(
 	"${FILESDIR}"/cron-confd.patch
@@ -47,13 +44,15 @@ src_prepare() {
 }
 
 src_configure() {
+	# ext4 code does not work anymore
+	# snapper does not build without btrfs
 	local myeconfargs=(
 		--with-conf="/etc/conf.d"
 		--docdir="/usr/share/doc/${PF}"
 		--disable-zypp
 		--enable-rollback
-		$(use_enable btrfs)
-		$(use_enable ext4)
+		--disable-ext4
+		--enable-btrfs
 		$(use_enable lvm)
 		$(use_enable pam)
 		$(use_enable xattr xattrs)


### PR DESCRIPTION
Snapper's ext4 code does not work anymore.
So we need to compile with --disable-ext4 by default.

Also snapper does not seem to work without btrfs enabled, so we need to
enable it by default.

Package-Manager: Portage-2.3.19, Repoman-2.3.6