### PR TITLE
app-editors/vis: Add Lua support

### DIFF
--- a/app-editors/vis/metadata.xml
+++ b/app-editors/vis/metadata.xml
@@ -13,5 +13,7 @@ Vis aims to be a modern, legacy free, simple yet efficient editor combining the 
 </longdescription>
 <use>
 	<flag name="tre">more memory efficient regex search using <pkg>dev-libs/tre</pkg></flag>
+	<flag name="lua">enable <pkg>dev-lang/lua</pkg> support</flag>
+	<flag name="lpeg">enable syntax highlighting using <pkg>dev-lua/lpeg</pkg></flag>
 </use>
 </pkgmetadata>

--- a/app-editors/vis/vis-0.4.ebuild
+++ b/app-editors/vis/vis-0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,14 +12,16 @@ SRC_URI="https://github.com/martanne/vis/archive/v${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="ISC"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="+ncurses selinux test tre"
+IUSE="+ncurses lua lpeg selinux test tre"
 
 #Note: vis is reported to also work with NetBSD curses
 #TODO: >=dev-lang/lua-5.2 (needed for syntax highlighting and settings)
 DEPEND="dev-libs/libtermkey
+	lua? ( dev-lang/lua:= )
 	ncurses? ( sys-libs/ncurses:0= )
 	tre? ( dev-libs/tre:= )"
 RDEPEND="${DEPEND}
+	lua? ( lpeg? ( dev-lua/lpeg ) )
 	app-eselect/eselect-vi"
 
 src_prepare() {
@@ -42,6 +44,7 @@ src_configure() {
 	./configure \
 		--prefix="${EROOT}usr" \
 		--docdir="${EROOT}usr/share/doc/${PF}" \
+		$(use_enable lua) \
 		$(use_enable ncurses curses) \
 		$(use_enable selinux) \
 		$(use_enable tre) || die


### PR DESCRIPTION
I added Lua support for vis allowing configuration and syntax highlighting as well as extensions.