### PR TITLE
dev-ruby/*, net-irc/rbot: use HTTPS

### DIFF
--- a/dev-ruby/cmdparse/cmdparse-2.0.6-r1.ebuild
+++ b/dev-ruby/cmdparse/cmdparse-2.0.6-r1.ebuild
@@ -15,7 +15,7 @@ inherit ruby-fakegem
 IUSE=""
 
 DESCRIPTION="Advanced command line parser supporting commands"
-HOMEPAGE="http://cmdparse.gettalong.org/"
+HOMEPAGE="https://cmdparse.gettalong.org/"
 
 KEYWORDS="amd64 ppc64 x86"
 LICENSE="LGPL-3"

--- a/dev-ruby/cri/cri-2.7.1.ebuild
+++ b/dev-ruby/cri/cri-2.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ RUBY_FAKEGEM_TASK_DOC="doc"
 inherit ruby-fakegem
 
 DESCRIPTION="Cri is a library for building easy-to-use commandline tools"
-HOMEPAGE="http://rubygems.org/gems/cri"
+HOMEPAGE="https://rubygems.org/gems/cri"
 LICENSE="MIT"
 
 KEYWORDS="~amd64 ~x86 ~x86-fbsd"

--- a/dev-ruby/expression_parser/expression_parser-0.9.0_p20130518.ebuild
+++ b/dev-ruby/expression_parser/expression_parser-0.9.0_p20130518.ebuild
@@ -12,7 +12,7 @@ RUBY_FAKEGEM_VERSION="0.9.0.20130518"
 inherit ruby-fakegem
 
 DESCRIPTION="A math parser"
-HOMEPAGE="http://lukaszwrobel.pl/blog/math-parser-part-3-implementation"
+HOMEPAGE="https://lukaszwrobel.pl/blog/math-parser-part-3-implementation"
 COMMIT_ID="6e3c7973423ff0f2cd33db2304fcd4eac3af01ad"
 SRC_URI="https://github.com/nricciar/${PN}/archive/${COMMIT_ID}.tar.gz -> ${P}.tar.gz"
 

--- a/dev-ruby/kramdown/kramdown-1.13.2-r1.ebuild
+++ b/dev-ruby/kramdown/kramdown-1.13.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ RUBY_FAKEGEM_EXTRAINSTALL="data"
 inherit ruby-fakegem
 
 DESCRIPTION="Yet-another-markdown-parser but fast, pure Ruby, using strict syntax definition"
-HOMEPAGE="http://kramdown.gettalong.org/"
+HOMEPAGE="https://kramdown.gettalong.org/"
 
 LICENSE="MIT"
 

--- a/dev-ruby/kramdown/kramdown-1.14.0.ebuild
+++ b/dev-ruby/kramdown/kramdown-1.14.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ RUBY_FAKEGEM_EXTRAINSTALL="data"
 inherit ruby-fakegem
 
 DESCRIPTION="Yet-another-markdown-parser but fast, pure Ruby, using strict syntax definition"
-HOMEPAGE="http://kramdown.gettalong.org/"
+HOMEPAGE="https://kramdown.gettalong.org/"
 
 LICENSE="MIT"
 

--- a/dev-ruby/nokogiri/nokogiri-1.6.8.1.ebuild
+++ b/dev-ruby/nokogiri/nokogiri-1.6.8.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -13,7 +13,7 @@ RUBY_FAKEGEM_EXTRAINSTALL="ext"
 inherit ruby-fakegem eutils multilib
 
 DESCRIPTION="Nokogiri is an HTML, XML, SAX, and Reader parser"
-HOMEPAGE="http://nokogiri.org/"
+HOMEPAGE="https://www.nokogiri.org/"
 LICENSE="MIT"
 SRC_URI="https://github.com/sparklemotion/nokogiri/archive/v${PV}.tar.gz -> ${P}-git.tgz"
 

--- a/dev-ruby/nokogiri/nokogiri-1.7.1.ebuild
+++ b/dev-ruby/nokogiri/nokogiri-1.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -13,7 +13,7 @@ RUBY_FAKEGEM_EXTRAINSTALL="ext"
 inherit ruby-fakegem eutils multilib
 
 DESCRIPTION="Nokogiri is an HTML, XML, SAX, and Reader parser"
-HOMEPAGE="http://nokogiri.org/"
+HOMEPAGE="https://www.nokogiri.org/"
 LICENSE="MIT"
 SRC_URI="https://github.com/sparklemotion/nokogiri/archive/v${PV}.tar.gz -> ${P}-git.tgz"
 

--- a/dev-ruby/nokogiri/nokogiri-1.8.1.ebuild
+++ b/dev-ruby/nokogiri/nokogiri-1.8.1.ebuild
@@ -13,7 +13,7 @@ RUBY_FAKEGEM_EXTRAINSTALL="ext"
 inherit ruby-fakegem eutils multilib
 
 DESCRIPTION="Nokogiri is an HTML, XML, SAX, and Reader parser"
-HOMEPAGE="http://nokogiri.org/"
+HOMEPAGE="https://www.nokogiri.org/"
 LICENSE="MIT"
 SRC_URI="https://github.com/sparklemotion/nokogiri/archive/v${PV}.tar.gz -> ${P}-git.tgz"
 

--- a/dev-ruby/nokogiri/nokogiri-1.8.2.ebuild
+++ b/dev-ruby/nokogiri/nokogiri-1.8.2.ebuild
@@ -13,7 +13,7 @@ RUBY_FAKEGEM_EXTRAINSTALL="ext"
 inherit ruby-fakegem eutils multilib
 
 DESCRIPTION="Nokogiri is an HTML, XML, SAX, and Reader parser"
-HOMEPAGE="http://nokogiri.org/"
+HOMEPAGE="https://www.nokogiri.org/"
 LICENSE="MIT"
 SRC_URI="https://github.com/sparklemotion/nokogiri/archive/v${PV}.tar.gz -> ${P}-git.tgz"
 

--- a/dev-ruby/rb-readline/rb-readline-0.5.5.ebuild
+++ b/dev-ruby/rb-readline/rb-readline-0.5.5.ebuild
@@ -8,7 +8,7 @@ RUBY_FAKEGEM_RECIPE_DOC="rdoc"
 inherit ruby-fakegem
 
 DESCRIPTION="Ruby implementation of the GNU readline C library"
-HOMEPAGE="http://rubygems.org/gems/rb-readline"
+HOMEPAGE="https://rubygems.org/gems/rb-readline"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-ruby/ruby-sdl/ruby-sdl-2.1.2-r2.ebuild
+++ b/dev-ruby/ruby-sdl/ruby-sdl-2.1.2-r2.ebuild
@@ -10,7 +10,7 @@ RELEASE="rel-${PV//./-}"
 RUBY_S="rubysdl-${RELEASE}"
 
 DESCRIPTION="Ruby/SDL: Ruby bindings for SDL"
-HOMEPAGE="http://www.kmc.gr.jp/~ohai/rubysdl.en.html"
+HOMEPAGE="https://www.kmc.gr.jp/~ohai/rubysdl.en.html"
 SRC_URI="https://github.com/ohai/rubysdl/archive/${RELEASE}.tar.gz -> ${P}.tar.gz"
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-ruby/typhoeus/typhoeus-0.6.9.ebuild
+++ b/dev-ruby/typhoeus/typhoeus-0.6.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -13,7 +13,8 @@ RUBY_FAKEGEM_RECIPE_TEST="rspec"
 inherit ruby-fakegem
 
 DESCRIPTION="Runs HTTP requests in parallel while cleanly encapsulating handling logic"
-HOMEPAGE="http://rubygems.org/gems/typhoeus/"
+HOMEPAGE="https://rubygems.org/gems/typhoeus/
+	https://github.com/typhoeus/typhoeus"
 
 LICENSE="Ruby"
 SLOT="0"

--- a/dev-ruby/typhoeus/typhoeus-1.1.2.ebuild
+++ b/dev-ruby/typhoeus/typhoeus-1.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -13,7 +13,8 @@ RUBY_FAKEGEM_RECIPE_TEST="rspec3"
 inherit ruby-fakegem
 
 DESCRIPTION="Runs HTTP requests in parallel while cleanly encapsulating handling logic"
-HOMEPAGE="https://github.com/typhoeus/typhoeus"
+HOMEPAGE="https://rubygems.org/gems/typhoeus/
+	https://github.com/typhoeus/typhoeus"
 
 LICENSE="Ruby"
 SLOT="1"

--- a/dev-ruby/typhoeus/typhoeus-1.3.0.ebuild
+++ b/dev-ruby/typhoeus/typhoeus-1.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,8 @@ RUBY_FAKEGEM_RECIPE_TEST="rspec3"
 inherit ruby-fakegem
 
 DESCRIPTION="Runs HTTP requests in parallel while cleanly encapsulating handling logic"
-HOMEPAGE="https://github.com/typhoeus/typhoeus"
+HOMEPAGE="https://rubygems.org/gems/typhoeus/
+	https://github.com/typhoeus/typhoeus"
 
 LICENSE="Ruby"
 SLOT="1"

--- a/dev-ruby/tzinfo/tzinfo-0.3.53.ebuild
+++ b/dev-ruby/tzinfo/tzinfo-0.3.53.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ RUBY_FAKEGEM_EXTRADOC="CHANGES README"
 inherit ruby-fakegem
 
 DESCRIPTION="Daylight-savings aware timezone library"
-HOMEPAGE="http://tzinfo.github.io/"
+HOMEPAGE="https://tzinfo.github.io/"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-ruby/yard/yard-0.9.11.ebuild
+++ b/dev-ruby/yard/yard-0.9.11.ebuild
@@ -16,7 +16,7 @@ RUBY_FAKEGEM_EXTRAINSTALL="templates"
 inherit ruby-fakegem
 
 DESCRIPTION="Documentation generation tool for the Ruby programming language"
-HOMEPAGE="http://yardoc.org/"
+HOMEPAGE="https://yardoc.org/"
 
 # The gem lakes the gemspec file needed to pass tests.
 SRC_URI="https://github.com/lsegal/yard/archive/v${PV}.tar.gz -> ${P}-git.tgz"

--- a/dev-ruby/yard/yard-0.9.12.ebuild
+++ b/dev-ruby/yard/yard-0.9.12.ebuild
@@ -16,7 +16,7 @@ RUBY_FAKEGEM_EXTRAINSTALL="templates"
 inherit ruby-fakegem
 
 DESCRIPTION="Documentation generation tool for the Ruby programming language"
-HOMEPAGE="http://yardoc.org/"
+HOMEPAGE="https://yardoc.org/"
 
 # The gem lakes the gemspec file needed to pass tests.
 SRC_URI="https://github.com/lsegal/yard/archive/v${PV}.tar.gz -> ${P}-git.tgz"


### PR DESCRIPTION
Hi,

This PR fixes a few ruby packages to use HTTPS.
All sites were tested, all SRC_URI changes were testet aswell.

Please review.