### PR TITLE
app-emulation/q4wine: use HTTPS

### DIFF
--- a/app-emulation/q4wine/q4wine-1.3.5.ebuild
+++ b/app-emulation/q4wine/q4wine-1.3.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit cmake-utils gnome2-utils xdg-utils
 MY_P=${PN}-${PV/_p/-r}
 
 DESCRIPTION="Qt GUI configuration tool for Wine"
-HOMEPAGE="http://q4wine.brezblock.org.ua/"
+HOMEPAGE="https://q4wine.brezblock.org.ua/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.bz2"
 
 LICENSE="GPL-3"

--- a/app-emulation/q4wine/q4wine-1.3.6-r1.ebuild
+++ b/app-emulation/q4wine/q4wine-1.3.6-r1.ebuild
@@ -10,7 +10,7 @@ inherit cmake-utils gnome2-utils xdg-utils
 MY_P=${PN}-${PV/_p/-r}
 
 DESCRIPTION="Qt GUI configuration tool for Wine"
-HOMEPAGE="http://q4wine.brezblock.org.ua/"
+HOMEPAGE="https://q4wine.brezblock.org.ua/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.bz2"
 
 LICENSE="GPL-3"


### PR DESCRIPTION
Hi,

This PR fixes q4wine to use https instead of http.

Please review.