### PR TITLE
dev-util/lxqt-build-tools: use HTTPS, fix SRC_URI

### DIFF
--- a/dev-util/lxqt-build-tools/lxqt-build-tools-0.2.0.ebuild
+++ b/dev-util/lxqt-build-tools/lxqt-build-tools-0.2.0.ebuild
@@ -1,17 +1,17 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="LXQt Build tools"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org/"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://downloads.lxqt.org/${PN}/${PV}/${P}.tar.xz"
+	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 


### PR DESCRIPTION
Hi,

This PR fixes the package to use https instead of http. Also fixes the SRC_URI download link.

Please review.