### PR TITLE
kde-apps/lokalize: use HTTPS

### DIFF
--- a/kde-apps/lokalize/lokalize-17.08.3.ebuild
+++ b/kde-apps/lokalize/lokalize-17.08.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit python-single-r1 kde5
 
 DESCRIPTION="KDE Applications 5 translation tool"
 HOMEPAGE="https://www.kde.org/applications/development/lokalize
-http://l10n.kde.org/tools"
+https://l10n.kde.org/tools"
 KEYWORDS="amd64 x86"
 IUSE=""
 

--- a/kde-apps/lokalize/lokalize-17.12.3.ebuild
+++ b/kde-apps/lokalize/lokalize-17.12.3.ebuild
@@ -9,7 +9,7 @@ inherit python-single-r1 kde5
 
 DESCRIPTION="KDE Applications 5 translation tool"
 HOMEPAGE="https://www.kde.org/applications/development/lokalize
-http://l10n.kde.org/tools"
+https://l10n.kde.org/tools"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 


### PR DESCRIPTION
Hi,

This PR uses HTTPS for the package instead of http.

Please review.