### PR TITLE
dev-cpp/ms-gsl: Disable Werror when compiling tests

### DIFF
--- a/dev-cpp/ms-gsl/files/ms-gsl-0_pre20180304-disable_Werror-644042.patch
+++ b/dev-cpp/ms-gsl/files/ms-gsl-0_pre20180304-disable_Werror-644042.patch
@@ -1,0 +1,27 @@
+From 402dd069acc1944428fd9f4ed3620a157028f6cc Mon Sep 17 00:00:00 2001
+From: Jan Henke <Jan.Henke@taujhe.de>
+Date: Sat, 17 Mar 2018 19:47:52 +0100
+Subject: [PATCH] Disable -Werror when compiling tests
+
+GCC 7 generates new warnings on some of the test files, which lead to
+build failures. -Werror generally is helpful while developing to enforce
+a zero error policy, but not so much when packaging. Gentoo bug 644042
+---
+ tests/CMakeLists.txt | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 0e08d77..86e9af7 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -41,7 +41,6 @@ target_compile_options(gsl_tests_config INTERFACE
+         -Wcast-align
+         -Wconversion
+         -Wctor-dtor-privacy
+-        -Werror
+         -Wextra
+         -Wno-missing-braces
+         -Wnon-virtual-dtor
+-- 
+2.16.1
+

--- a/dev-cpp/ms-gsl/ms-gsl-0_pre20180304-r1.ebuild
+++ b/dev-cpp/ms-gsl/ms-gsl-0_pre20180304-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils vcs-snapshot
+
+DESCRIPTION="Guideline Support Library implementation by Microsoft"
+HOMEPAGE="https://github.com/Microsoft/GSL"
+SRC_URI="https://github.com/Microsoft/gsl/tarball/6a33b97a84f9c0a60ede78b5db98647e9a48d6c9 -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+
+# header only library
+RDEPEND=""
+DEPEND="test? ( >=dev-cpp/catch-1.11.0 )"
+
+PATCHES=(
+	"${FILESDIR}/ms-gsl-0_pre20180108-use_system_catch-636828.patch"
+	"${FILESDIR}/ms-gsl-0_pre20180304-disable_Werror-644042.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DGSL_TEST=$(usex test)
+		-DFORCE_SYSTEM_CATCH=ON
+	)
+	cmake-utils_src_configure
+}


### PR DESCRIPTION
This lead to build failures due to new warnings being emmited by GCC 7

Closes: https://bugs.gentoo.org/644042
Package-Manager: Portage-2.3.24, Repoman-2.3.6