### PR TITLE
sys-fs/mtools: add texinfo dependency

### DIFF
--- a/sys-fs/mtools/mtools-4.0.18-r2.ebuild
+++ b/sys-fs/mtools/mtools-4.0.18-r2.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="alpha amd64 arm ~hppa ~ppc ~ppc64 sparc x86 ~x64-macos ~x64-solaris"
 IUSE="X elibc_glibc"
 
-DEPEND="
+COMMON_DEPEND="
 	!elibc_glibc? ( virtual/libiconv )
 	X? (
 		x11-libs/libICE
@@ -23,7 +23,9 @@ DEPEND="
 		x11-libs/libX11
 		x11-libs/libXt
 	)"
-RDEPEND="${DEPEND}"
+RDEPEND="${COMMON_DEPEND}"
+DEPEND="${COMMON_DEPEND}
+	sys-apps/texinfo"
 
 src_prepare() {
 	# Don't throw errors on existing directories


### PR DESCRIPTION
This is needed because one of the patches modifies the documentation