### PR TITLE
dev-libs/libexplain: patch with missing defines

### DIFF
--- a/dev-libs/libexplain/files/libexplain-missing-defines.patch
+++ b/dev-libs/libexplain/files/libexplain-missing-defines.patch
@@ -1,0 +1,18 @@
+--- libexplain-1.4.D001.orig/libexplain/buffer/file_inode_flags.c
++++ libexplain-1.4.D001/libexplain/buffer/file_inode_flags.c
+@@ -28,6 +28,14 @@
+
+ #if defined(FS_IOC_GETFLAGS) || defined(FS_IOC32_GETFLAGS)
+
++#ifndef FS_ECOMPR_FL
++#define FS_ECOMPR_FL                    0x00000800 /* Compression error */
++#endif
++
++#ifndef FS_DIRECTIO_FL
++#define FS_DIRECTIO_FL                  0x00100000 /* Use direct i/o */
++#endif
++
+ void
+ explain_buffer_file_inode_flags(explain_string_buffer_t *sb, int value)
+ {
+

--- a/dev-libs/libexplain/libexplain-1.4-r2.ebuild
+++ b/dev-libs/libexplain/libexplain-1.4-r2.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools
+
+DESCRIPTION="Library which may be used to explain Unix and Linux system call errors"
+HOMEPAGE="http://libexplain.sourceforge.net/"
+SRC_URI="http://libexplain.sourceforge.net/${P}.tar.gz"
+
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
+LICENSE="GPL-3 LGPL-3"
+IUSE="static-libs"
+
+DEPEND="
+	sys-apps/acl
+	sys-apps/groff
+	app-text/ghostscript-gpl
+	>=sys-kernel/linux-headers-2.6.35"
+
+RDEPEND="
+	${DEPEND}
+	sys-libs/libcap
+	sys-process/lsof
+	sys-libs/glibc"
+
+# Test fails with:
+# This is not a bug, but it does indicate where libexplain's ioctl support
+# could be improved.
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.45-configure.patch
+	"${FILESDIR}"/libexplain-missing-defines.patch
+)
+
+src_prepare() {
+	# Portage incompatible test
+	sed \
+		-e '/t0524a/d' \
+		-e '/t0363a/d' \
+		-i Makefile.in || die
+
+	cp -v "${S}"/etc/configure.ac "${S}" || die
+	default
+	eautoreconf
+}
+
+src_install() {
+	default
+}


### PR DESCRIPTION
This defines where removed from the Linux headers and have
to be added with a patch to make the library compile again.

The patch comes from the Debian bug:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=828853

Closes: https://bugs.gentoo.org/628628
Package-Manager: Portage-2.3.24, Repoman-2.3.6