### PR TITLE
net-libs/libsoup-2.58.2: fix unaligned accesses

### DIFF
--- a/net-libs/libsoup/files/libsoup-2.58.2-sparc-unaligned.patch
+++ b/net-libs/libsoup/files/libsoup-2.58.2-sparc-unaligned.patch
@@ -1,0 +1,28 @@
+From c2aaac0083f58d285b8feb24f13fe347d7f726fe Mon Sep 17 00:00:00 2001
+From: Rolf Eike Beer <eike@sf-mail.de>
+Date: Sat, 17 Mar 2018 10:28:00 +0000
+Subject: [PATCH] WebSockets: Avoid unaligned memory access
+
+This is causing test failures in SPARC architectures.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=794421
+---
+ libsoup/soup-websocket-connection.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libsoup/soup-websocket-connection.c b/libsoup/soup-websocket-connection.c
+index 0258a22c..35eee6a6 100644
+--- a/libsoup/soup-websocket-connection.c
++++ b/libsoup/soup-websocket-connection.c
+@@ -401,9 +401,10 @@ send_message (SoupWebsocketConnection *self,
+ 	 * probably a client somewhere that's not expecting it.
+ 	 */
+ 	if (self->pv->connection_type == SOUP_WEBSOCKET_CONNECTION_CLIENT) {
++		guint32 rnd = g_random_int ();
+ 		outer[1] |= 0x80;
+ 		mask = outer + bytes->len;
+-		* ((guint32 *)mask) = g_random_int ();
++		memcpy (mask, &rnd, sizeof (rnd));
+ 		bytes->len += 4;
+ 	}
+ 

--- a/net-libs/libsoup/libsoup-2.58.2.ebuild
+++ b/net-libs/libsoup/libsoup-2.58.2.ebuild
@@ -44,6 +44,11 @@ DEPEND="${RDEPEND}
 #		net-misc/curl
 #		net-libs/glib-networking[ssl])"
 
+PATCHES=(
+	# https://bugs.gentoo.org/630516
+	"${FILESDIR}/${PN}-2.58.2-sparc-unaligned.patch"
+)
+
 src_prepare() {
 	if ! use test; then
 		# don't waste time building tests (bug #226271)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/630516