### PR TITLE
sys-devel/clang: fix for prefix, bug 649732

### DIFF
--- a/sys-devel/clang/clang-4.0.1.ebuild
+++ b/sys-devel/clang/clang-4.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -161,6 +161,12 @@ multilib_src_configure() {
 	else
 		mycmakeargs+=(
 			-DLLVM_TOOL_CLANG_TOOLS_EXTRA_BUILD=OFF
+		)
+	fi
+
+	if [[ -n ${EPREFIX} ]]; then
+		mycmakeargs+=(
+			-DGCC_INSTALL_PREFIX="${EPREFIX}/usr"
 		)
 	fi
 

--- a/sys-devel/clang/clang-5.0.1.ebuild
+++ b/sys-devel/clang/clang-5.0.1.ebuild
@@ -178,6 +178,12 @@ multilib_src_configure() {
 		)
 	fi
 
+	if [[ -n ${EPREFIX} ]]; then
+		mycmakeargs+=(
+			-DGCC_INSTALL_PREFIX="${EPREFIX}/usr"
+		)
+	fi
+
 	if tc-is-cross-compiler; then
 		[[ -x "/usr/bin/clang-tblgen" ]] \
 			|| die "/usr/bin/clang-tblgen not found or usable"

--- a/sys-devel/clang/clang-6.0.0.ebuild
+++ b/sys-devel/clang/clang-6.0.0.ebuild
@@ -179,6 +179,12 @@ multilib_src_configure() {
 		)
 	fi
 
+	if [[ -n ${EPREFIX} ]]; then
+		mycmakeargs+=(
+			-DGCC_INSTALL_PREFIX="${EPREFIX}/usr"
+		)
+	fi
+
 	if tc-is-cross-compiler; then
 		[[ -x "/usr/bin/clang-tblgen" ]] \
 			|| die "/usr/bin/clang-tblgen not found or usable"

--- a/sys-devel/clang/clang-6.0.9999.ebuild
+++ b/sys-devel/clang/clang-6.0.9999.ebuild
@@ -164,6 +164,12 @@ multilib_src_configure() {
 		)
 	fi
 
+	if [[ -n ${EPREFIX} ]]; then
+		mycmakeargs+=(
+			-DGCC_INSTALL_PREFIX="${EPREFIX}/usr"
+		)
+	fi
+
 	if tc-is-cross-compiler; then
 		[[ -x "/usr/bin/clang-tblgen" ]] \
 			|| die "/usr/bin/clang-tblgen not found or usable"

--- a/sys-devel/clang/clang-9999.ebuild
+++ b/sys-devel/clang/clang-9999.ebuild
@@ -165,6 +165,12 @@ multilib_src_configure() {
 		)
 	fi
 
+	if [[ -n ${EPREFIX} ]]; then
+		mycmakeargs+=(
+			-DGCC_INSTALL_PREFIX="${EPREFIX}/usr"
+		)
+	fi
+
 	if tc-is-cross-compiler; then
 		[[ -x "/usr/bin/clang-tblgen" ]] \
 			|| die "/usr/bin/clang-tblgen not found or usable"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/649732
Package-Manager: Portage-2.3.24, Repoman-2.3.6