### PR TITLE
media-video/obs-studio: Support NVENC encoding for nVidia video cards

### DIFF
--- a/media-video/obs-studio/metadata.xml
+++ b/media-video/obs-studio/metadata.xml
@@ -14,6 +14,7 @@
   <use>
     <flag name="fdk">Enable libfdk support for AAC encoding.</flag>
     <flag name="imagemagick">Use ImageMagick for image loading instead of FFmpeg.</flag>
+    <flag name="nvenc">Enable NVENC encoding for nVidia video cards</flag>
   </use>
   <upstream>
     <remote-id type="github">jp9000/obs-studio</remote-id>

--- a/media-video/obs-studio/obs-studio-21.0.2.ebuild
+++ b/media-video/obs-studio/obs-studio-21.0.2.ebuild
@@ -21,7 +21,7 @@ HOMEPAGE="https://obsproject.com"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+alsa fdk imagemagick jack pulseaudio truetype v4l"
+IUSE="+alsa fdk imagemagick jack nvenc pulseaudio truetype v4l"
 
 COMMON_DEPEND="
 	>=dev-libs/jansson-2.5
@@ -36,6 +36,7 @@ COMMON_DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	media-video/ffmpeg:=[x264]
+	nvenc? ( media-video/ffmpeg:=[nvenc] )
 	net-misc/curl
 	x11-libs/libXcomposite
 	x11-libs/libXinerama


### PR DESCRIPTION
I added the ```nvenc``` use flag to support the NVENC encoding for nVidia cards.