### PR TITLE
dev-haskell/*: use HTTPS

### DIFF
--- a/dev-haskell/blaze-html/blaze-html-0.6.1.2.ebuild
+++ b/dev-haskell/blaze-html/blaze-html-0.6.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="A blazingly fast HTML combinator library for Haskell"
-HOMEPAGE="http://jaspervdj.be/blaze"
+HOMEPAGE="https://jaspervdj.be/blaze/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/blaze-html/blaze-html-0.6.1.3.ebuild
+++ b/dev-haskell/blaze-html/blaze-html-0.6.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="A blazingly fast HTML combinator library for Haskell"
-HOMEPAGE="http://jaspervdj.be/blaze"
+HOMEPAGE="https://jaspervdj.be/blaze/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/blaze-html/blaze-html-0.7.1.0.ebuild
+++ b/dev-haskell/blaze-html/blaze-html-0.7.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="A blazingly fast HTML combinator library for Haskell"
-HOMEPAGE="http://jaspervdj.be/blaze"
+HOMEPAGE="https://jaspervdj.be/blaze/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/blaze-html/blaze-html-0.8.1.1.ebuild
+++ b/dev-haskell/blaze-html/blaze-html-0.8.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="A blazingly fast HTML combinator library for Haskell"
-HOMEPAGE="http://jaspervdj.be/blaze"
+HOMEPAGE="https://jaspervdj.be/blaze/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/blaze-html/blaze-html-0.8.1.2.ebuild
+++ b/dev-haskell/blaze-html/blaze-html-0.8.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="A blazingly fast HTML combinator library for Haskell"
-HOMEPAGE="http://jaspervdj.be/blaze"
+HOMEPAGE="https://jaspervdj.be/blaze/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/bytestring-handle/bytestring-handle-0.1.0.4.ebuild
+++ b/dev-haskell/bytestring-handle/bytestring-handle-0.1.0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="ByteString-backed Handles"
-HOMEPAGE="http://hub.darcs.net/ganesh/bytestring-handle"
+HOMEPAGE="https://hub.darcs.net/ganesh/bytestring-handle"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/css-text/css-text-0.1.2.1.ebuild
+++ b/dev-haskell/css-text/css-text-0.1.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="CSS parser and renderer"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/fgl/fgl-5.5.2.3.ebuild
+++ b/dev-haskell/fgl/fgl-5.5.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Martin Erwig's Functional Graph Library"
-HOMEPAGE="http://hackage.haskell.org/package/fgl"
+HOMEPAGE="https://hackage.haskell.org/package/fgl"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/fgl/fgl-5.5.3.0.ebuild
+++ b/dev-haskell/fgl/fgl-5.5.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Martin Erwig's Functional Graph Library"
-HOMEPAGE="http://hackage.haskell.org/package/fgl"
+HOMEPAGE="https://hackage.haskell.org/package/fgl"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/hamlet/hamlet-1.1.9.2.ebuild
+++ b/dev-haskell/hamlet/hamlet-1.1.9.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Haml-like template files that are compile-time checked"
-HOMEPAGE="http://www.yesodweb.com/book/shakespearean-templates"
+HOMEPAGE="https://www.yesodweb.com/book/shakespearean-templates"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/hamlet/hamlet-1.2.0.ebuild
+++ b/dev-haskell/hamlet/hamlet-1.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile"
 inherit haskell-cabal
 
 DESCRIPTION="Haml-like template files that are compile-time checked (deprecated)"
-HOMEPAGE="http://www.yesodweb.com/book/shakespearean-templates"
+HOMEPAGE="https://www.yesodweb.com/book/shakespearean-templates"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/haxml/haxml-1.24.1.ebuild
+++ b/dev-haskell/haxml/haxml-1.24.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ MY_PN="HaXml"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Utilities for manipulating XML documents"
-HOMEPAGE="http://www.cs.york.ac.uk/fp/HaXml/"
+HOMEPAGE="https://archives.haskell.org/projects.haskell.org/HaXml/"
 SRC_URI="mirror://hackage/packages/archive/${MY_PN}/${PV}/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-haskell/haxml/haxml-1.24.ebuild
+++ b/dev-haskell/haxml/haxml-1.24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ MY_PN="HaXml"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Utilities for manipulating XML documents"
-HOMEPAGE="http://www.cs.york.ac.uk/fp/HaXml/"
+HOMEPAGE="https://archives.haskell.org/projects.haskell.org/HaXml/"
 SRC_URI="mirror://hackage/packages/archive/${MY_PN}/${PV}/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-haskell/haxml/haxml-1.25.3.ebuild
+++ b/dev-haskell/haxml/haxml-1.25.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ MY_PN="HaXml"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Utilities for manipulating XML documents"
-HOMEPAGE="http://projects.haskell.org/HaXml/"
+HOMEPAGE="https://archives.haskell.org/projects.haskell.org/HaXml/"
 SRC_URI="mirror://hackage/packages/archive/${MY_PN}/${PV}/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-haskell/hs3/hs3-0.5.9.ebuild
+++ b/dev-haskell/hs3/hs3-0.5.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ MY_PN="hS3"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Interface to Amazon's Simple Storage Service (S3)"
-HOMEPAGE="http://gregheartsfield.com/hS3/"
+HOMEPAGE="https://gregheartsfield.com/hS3/"
 SRC_URI="mirror://hackage/packages/archive/${MY_PN}/${PV}/${MY_P}.tar.gz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Hi,

This PR fixes some haskell packages to use https instead of http.

Please review.