### PR TITLE
media-gfx/blender: use HTTPS

### DIFF
--- a/media-gfx/blender/blender-2.72b-r4.ebuild
+++ b/media-gfx/blender/blender-2.72b-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 ## BUNDLED-DEPS:
@@ -32,13 +32,13 @@ PYTHON_COMPAT=( python3_4 )
 inherit multilib fdo-mime gnome2-utils cmake-utils eutils python-single-r1 versionator flag-o-matic toolchain-funcs pax-utils check-reqs
 
 DESCRIPTION="3D Creation/Animation/Publishing System"
-HOMEPAGE="http://www.blender.org"
+HOMEPAGE="https://www.blender.org"
 
 case ${PV} in
 	*_p*)
 		SRC_URI="https://dev.gentoo.org/~lu_zero/${P}.tar.gz" ;;
 	*)
-		SRC_URI="http://download.blender.org/source/${P}.tar.gz" ;;
+		SRC_URI="https://download.blender.org/source/${P}.tar.gz" ;;
 esac
 
 if [[ -n ${PATCHSET} ]]; then

--- a/media-gfx/blender/blender-2.79-r1.ebuild
+++ b/media-gfx/blender/blender-2.79-r1.ebuild
@@ -8,9 +8,9 @@ inherit check-reqs cmake-utils xdg-utils flag-o-matic gnome2-utils \
 	pax-utils python-single-r1 toolchain-funcs versionator
 
 DESCRIPTION="3D Creation/Animation/Publishing System"
-HOMEPAGE="http://www.blender.org"
+HOMEPAGE="https://www.blender.org"
 
-SRC_URI="http://download.blender.org/source/${P}.tar.gz"
+SRC_URI="https://download.blender.org/source/${P}.tar.gz"
 
 # Blender can have letters in the version string,
 # so strip of the letter if it exists.

--- a/media-gfx/blender/blender-2.79.ebuild
+++ b/media-gfx/blender/blender-2.79.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,9 +8,9 @@ inherit check-reqs cmake-utils xdg-utils flag-o-matic gnome2-utils \
 	pax-utils python-single-r1 toolchain-funcs versionator
 
 DESCRIPTION="3D Creation/Animation/Publishing System"
-HOMEPAGE="http://www.blender.org"
+HOMEPAGE="https://www.blender.org"
 
-SRC_URI="http://download.blender.org/source/${P}.tar.gz"
+SRC_URI="https://download.blender.org/source/${P}.tar.gz"
 
 # Blender can have letters in the version string,
 # so strip of the letter if it exists.


### PR DESCRIPTION
Hi,

This PR fixes the package to use HTTPS in HOMEPAGE and SRC_URI.

Please review.