### PR TITLE
app-emulation/virtualbox: optional depend on modules

### DIFF
--- a/app-emulation/virtualbox/virtualbox-5.2.8-r1.ebuild
+++ b/app-emulation/virtualbox/virtualbox-5.2.8-r1.ebuild
@@ -18,10 +18,10 @@ SRC_URI="https://download.virtualbox.org/virtualbox/${MY_PV}/${MY_P}.tar.bz2
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="alsa debug doc headless java libressl lvm pam pax_kernel pulseaudio +opengl python +qt5 +sdk +udev vboxwebsrv vnc"
+IUSE="alsa debug doc headless java libressl lvm +modules pam pax_kernel pulseaudio +opengl python +qt5 +sdk +udev vboxwebsrv vnc"
 
 RDEPEND="!app-emulation/virtualbox-bin
-	~app-emulation/virtualbox-modules-${PV}
+	modules? ( ~app-emulation/virtualbox-modules-${PV} )
 	dev-libs/libIDL
 	>=dev-libs/libxslt-1.1.19
 	net-misc/curl


### PR DESCRIPTION
Global use flag "modules" activate dependancy to other packages providing
kernel modules.
Usually kernel and user space versions are coupled and it make sense to
build both with portage.
However in some circumstances the user need to manage them differently.
This change add "modules" use flag enabled by default.