### PR TITLE
sys-kernel/dracut-crypt-ssh: bump to fix RDEPEND

### DIFF
--- a/sys-kernel/dracut-crypt-ssh/dracut-crypt-ssh-1.0.6-r1.ebuild
+++ b/sys-kernel/dracut-crypt-ssh/dracut-crypt-ssh-1.0.6-r1.ebuild
@@ -14,11 +14,7 @@ IUSE=""
 
 DEPEND="sys-kernel/dracut"
 RDEPEND="${DEPEND}
+	net-misc/dhcp
 	net-misc/dropbear"
 
 DOCS=("README.md")
-
-pkg_postinst() {
-	elog "If you want to use DHCP in the initramfs during boot,"
-	elog "dracut will require dhclient provided by net-misc/dhcp."
-}


### PR DESCRIPTION
This package requires the network module of dracut, which in turn
requires dhclient, even if used with a static network configuration.
Thus the dependency on net-misc/dhclient is unconditional.

Suggested-by: Marcin Mirosław
Closes: https://bugs.gentoo.org/650620
Package-Manager: Portage-2.3.24, Repoman-2.3.6