### PR TITLE
app-crypt/rhash: pass --target=${CHOST} to configure

### DIFF
--- a/app-crypt/rhash/rhash-1.3.6-r1.ebuild
+++ b/app-crypt/rhash/rhash-1.3.6-r1.ebuild
@@ -34,6 +34,7 @@ src_prepare() {
 multilib_src_configure() {
 	set -- \
 		./configure \
+		--target="${CHOST}" \
 		--cc="$(tc-getCC)" \
 		--ar="$(tc-getAR)" \
 		--extra-cflags="${CFLAGS}" \
@@ -59,8 +60,9 @@ multilib_src_configure() {
 multilib_src_install() {
 	# -j1 needed due to race condition.
 	emake DESTDIR="${D}" -j1 \
-		  install{,-lib-so-link,-pkg-config} \
-		  $(use nls && echo install-gmo)
+		  install{,-pkg-config} \
+		  $(use nls && echo install-gmo) \
+		  $(use kernel_Winnt || echo install-lib-so-link)
 
 	emake DESTDIR="${D}" -j1 \
 		  -C lib${PN} install-headers


### PR DESCRIPTION
Without this change, app-crypt/rhash when built with a mingw-w64
crossdev toolchain ends up with the various rhash binaries being PE32
binaries without an '*.exe' extension and librhash having a '*.so'
extension, also a PE32 library, and no import library ('*.dll.a').

Package-Manager: Portage-2.3.24, Repoman-2.3.6