### PR TITLE
x11-themes: EAPI bump

### DIFF
--- a/x11-themes/claws-mail-themes/claws-mail-themes-20140629.ebuild
+++ b/x11-themes/claws-mail-themes/claws-mail-themes-20140629.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Iconsets for Claws Mail"
 HOMEPAGE="http://www.claws-mail.org/"

--- a/x11-themes/clearlooks-phenix/clearlooks-phenix-3.0.15.ebuild
+++ b/x11-themes/clearlooks-phenix/clearlooks-phenix-3.0.15.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Clearlooks-Phenix is a GTK+ 3 port of Clearlooks, the default theme for GNOME 2"
 HOMEPAGE="https://github.com/jpfleury/clearlooks-phenix"

--- a/x11-themes/clearlooks-phenix/clearlooks-phenix-3.0.16.ebuild
+++ b/x11-themes/clearlooks-phenix/clearlooks-phenix-3.0.16.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Clearlooks-Phenix is a GTK+ 3 port of Clearlooks, the default theme for GNOME 2"
 HOMEPAGE="https://github.com/jpfleury/clearlooks-phenix"

--- a/x11-themes/clearlooks-phenix/clearlooks-phenix-5.0.7.ebuild
+++ b/x11-themes/clearlooks-phenix/clearlooks-phenix-5.0.7.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Clearlooks-Phenix is a GTK+ 3 port of Clearlooks, the default theme for GNOME 2"
 HOMEPAGE="https://github.com/jpfleury/clearlooks-phenix"

--- a/x11-themes/clearlooks-phenix/clearlooks-phenix-6.0.3.ebuild
+++ b/x11-themes/clearlooks-phenix/clearlooks-phenix-6.0.3.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Clearlooks-Phenix is a GTK+ 3 port of Clearlooks, the default theme for GNOME 2"
 HOMEPAGE="https://github.com/jpfleury/clearlooks-phenix"

--- a/x11-themes/clearlooks-phenix/clearlooks-phenix-7.0.1.ebuild
+++ b/x11-themes/clearlooks-phenix/clearlooks-phenix-7.0.1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Clearlooks-Phenix is a GTK+ 3 port of Clearlooks, the default theme for GNOME 2"
 HOMEPAGE="https://github.com/jpfleury/clearlooks-phenix"

--- a/x11-themes/clearlooks-phenix/clearlooks-phenix-9999.ebuild
+++ b/x11-themes/clearlooks-phenix/clearlooks-phenix-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 inherit git-r3
 

--- a/x11-themes/comix-xcursors/comix-xcursors-0.8.2.ebuild
+++ b/x11-themes/comix-xcursors/comix-xcursors-0.8.2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 MY_PN="ComixCursors"
 

--- a/x11-themes/faenza-icon-theme/faenza-icon-theme-1.3.1.ebuild
+++ b/x11-themes/faenza-icon-theme/faenza-icon-theme-1.3.1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 inherit gnome2-utils
 
 MY_P=${PN}_${PV}

--- a/x11-themes/fluxbox-styles-fluxmod/fluxbox-styles-fluxmod-20050128-r1.ebuild
+++ b/x11-themes/fluxbox-styles-fluxmod/fluxbox-styles-fluxmod-20050128-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
+EAPI=6
 
 DESCRIPTION="A collection of FluxBox themes from FluxMod"
 HOMEPAGE="http://tenr.de/styles/"
@@ -21,6 +21,7 @@ src_prepare() {
 		sed -i "{}" -e 's-^\(rootcommand\)-!!! \1-i' \;
 	# weird tarball...
 	find . -exec chmod a+r '{}' \;
+	eapply_user
 }
 
 src_install() {

--- a/x11-themes/gargantuan-icon-theme/gargantuan-icon-theme-1.7.ebuild
+++ b/x11-themes/gargantuan-icon-theme/gargantuan-icon-theme-1.7.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 inherit gnome2-utils
 
 DESCRIPTION="Gargantuan Icon Theme"

--- a/x11-themes/gartoon-redux/gartoon-redux-1.10-r1.ebuild
+++ b/x11-themes/gartoon-redux/gartoon-redux-1.10-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils gnome2-utils
+EAPI=6
+inherit gnome2-utils
 
 DESCRIPTION="A massively improved variant of the well-known Gartoon theme"
 HOMEPAGE="http://gnome-look.org/content/show.php/?content=74841"
@@ -20,9 +20,9 @@ DEPEND="
 
 RESTRICT="binchecks strip"
 
-src_prepare() {
-	epatch "${FILESDIR}"/${PN}-1.10-rsvg-convert.patch
-}
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.10-rsvg-convert.patch
+)
 
 src_configure() {
 	# perl script, not autotools based

--- a/x11-themes/gartoon/gartoon-0.5-r2.ebuild
+++ b/x11-themes/gartoon/gartoon-0.5-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Gartoon SVG icon theme"
 HOMEPAGE="https://www.gentoo.org"
@@ -23,6 +23,7 @@ src_prepare() {
 	sed -i \
 		-e "s:\(^pixmap_path\) \(\".*\"$\):\1 \"${mydest}/scalable/stock\":" \
 		scalable/stock/iconrc || die
+	eapply_user
 }
 
 src_install() {

--- a/x11-themes/gentoo10-backgrounds/gentoo10-backgrounds-20110309.ebuild
+++ b/x11-themes/gentoo10-backgrounds/gentoo10-backgrounds-20110309.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Gentoo - 10 Years Compiling Background Artwork"
 HOMEPAGE="https://www.gentoo.org/inside-gentoo/artwork/"
@@ -21,6 +21,7 @@ SLOT="0"
 
 src_prepare() {
 	sed -i -e "s:/usr/:${EPREFIX}/usr/:" *.xml || die
+	eapply_user
 }
 
 src_compile() { :; }

--- a/x11-themes/gkrellm-themes/gkrellm-themes-0.1.ebuild
+++ b/x11-themes/gkrellm-themes/gkrellm-themes-0.1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 DESCRIPTION="A pack of ~200 themes for GKrellM"
 HOMEPAGE="http://www.muhri.net/gkrellm"
 THEME_URI="http://www.muhri.net/gkrellm"
@@ -224,10 +224,8 @@ src_compile() { :; }
 src_install() {
 	dodir /usr/share/gkrellm2/themes/
 	keepdir /usr/share/gkrellm2/themes/
-	cd "${S}"
-	ewarn "Please ignore any errors that may appear!"
-	chmod -R g-sw+rx *
-	chmod -R o-sw+rx *
-	chmod -R u-s+rwx *
-	cp -pR * "${D}"/usr/share/gkrellm2/themes/
+	cd "${S}" || die
+	find . -type d -exec chmod 755 {} ';'
+	find . -type f -exec chmod 644 {} ';'
+	cp -pR * "${D}"/usr/share/gkrellm2/themes/ || die
 }

--- a/x11-themes/gnustep-neos-theme/gnustep-neos-theme-0.1.ebuild
+++ b/x11-themes/gnustep-neos-theme/gnustep-neos-theme-0.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
-inherit eutils gnustep-2
+inherit gnustep-2 vcs-clean
 
 DESCRIPTION="GNUstep theme closely following the original NeXT look and feel"
 HOMEPAGE="http://gap.nongnu.org/themes/index.html"
@@ -20,6 +20,7 @@ RESTRICT="binchecks strip"
 
 src_prepare() {
 	ecvs_clean
+	eapply_user
 }
 
 src_compile() { :; }

--- a/x11-themes/gnustep-silver-theme/gnustep-silver-theme-2.5.ebuild
+++ b/x11-themes/gnustep-silver-theme/gnustep-silver-theme-2.5.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 inherit gnustep-2
 
 DESCRIPTION="a GNUstep silver theme"
@@ -11,10 +11,6 @@ SRC_URI="http://download.gna.org/gnustep-nonfsf/silver.theme-${PV}.tar.gz"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE=""
-
-DEPEND=""
-RDEPEND="${DEPEND}"
 
 S=${WORKDIR}/Silver.theme
 

--- a/x11-themes/gnustep-silver-theme/gnustep-silver-theme-3.1.ebuild
+++ b/x11-themes/gnustep-silver-theme/gnustep-silver-theme-3.1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 inherit gnustep-2
 
 MY_P=Silver.theme-${PV}
@@ -12,10 +12,6 @@ SRC_URI="http://download.gna.org/gnustep-nonfsf/${MY_P}.tar.gz"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE=""
-
-DEPEND=""
-RDEPEND="${DEPEND}"
 
 S=${WORKDIR}/${MY_P}
 

--- a/x11-themes/greybird/greybird-1.2.2.ebuild
+++ b/x11-themes/greybird/greybird-1.2.2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 MY_PN=${PN/g/G}
 
@@ -18,11 +18,7 @@ RDEPEND=">=x11-themes/gtk-engines-murrine-0.90"
 DEPEND=""
 
 RESTRICT="binchecks strip"
-
-src_unpack() {
-	unpack ${A}
-	mv ${MY_PN}-* "${S}" || die
-}
+S="${WORKDIR}/${MY_PN}-${PV}"
 
 src_install() {
 	dodoc README

--- a/x11-themes/greybird/greybird-1.3.4.ebuild
+++ b/x11-themes/greybird/greybird-1.3.4.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 MY_PN=${PN/g/G}
 
@@ -19,11 +19,7 @@ RDEPEND=">=x11-themes/gtk-engines-murrine-0.90"
 DEPEND=""
 
 RESTRICT="binchecks strip"
-
-src_unpack() {
-	unpack ${A}
-	mv ${MY_PN}-* "${S}" || die
-}
+S="${WORKDIR}/${MY_PN}-${PV}"
 
 src_install() {
 	dodoc README

--- a/x11-themes/greybird/greybird-1.5.3.ebuild
+++ b/x11-themes/greybird/greybird-1.5.3.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 MY_PN=${PN/g/G}
 
@@ -19,11 +19,7 @@ RDEPEND=">=x11-themes/gtk-engines-murrine-0.90"
 DEPEND=""
 
 RESTRICT="binchecks strip"
-
-src_unpack() {
-	unpack ${A}
-	mv ${MY_PN}-* "${S}" || die
-}
+S="${WORKDIR}/${MY_PN}-${PV}"
 
 src_install() {
 	dodoc README

--- a/x11-themes/greybird/greybird-3.18.0.ebuild
+++ b/x11-themes/greybird/greybird-3.18.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -21,8 +21,7 @@ RDEPEND="
 "
 
 RESTRICT="binchecks strip"
-
-S=${WORKDIR}/${MY_PN}-${PV}
+S="${WORKDIR}/${MY_PN}-${PV}"
 
 src_install() {
 	dodoc README

--- a/x11-themes/greybird/greybird-3.20.1-r2.ebuild
+++ b/x11-themes/greybird/greybird-3.20.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-themes/greybird/greybird-3.22.3.ebuild
+++ b/x11-themes/greybird/greybird-3.22.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-themes/greybird/greybird-9999.ebuild
+++ b/x11-themes/greybird/greybird-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-themes/human-icon-theme/human-icon-theme-0.36.ebuild
+++ b/x11-themes/human-icon-theme/human-icon-theme-0.36.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 inherit gnome2-utils
 
 DESCRIPTION="A nice and well polished icon theme"
@@ -37,6 +37,7 @@ src_prepare() {
 		rsvg-convert -w ${res} -h ${res} scalable/places/start-here.svg \
 			> ${res}x${res}/places/start-here.png || die
 	done
+	eapply_user
 }
 
 src_compile() {

--- a/x11-themes/light-themes/light-themes-17.04_p20170406.ebuild
+++ b/x11-themes/light-themes/light-themes-17.04_p20170406.ebuild
@@ -1,8 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils
+EAPI=6
 
 MY_PN=ubuntu-themes
 MY_PV=16.10+${PV/_p/.}
@@ -41,12 +40,19 @@ src_prepare() {
 		Ambiance-Gentoo/gtk-3.*/gtk-main.css \
 		Radiance-Gentoo/gtk-3.*/gtk-main.css || die
 
-	cp -f "${WORKDIR}"/Gentoo-Buttons/*.png "${S}"/Ambiance-Gentoo/metacity-1/. || die
-	cp -f "${WORKDIR}"/Gentoo-Buttons/*.png "${S}"/Radiance-Gentoo/metacity-1/. || die
-	cp -f "${WORKDIR}"/Gentoo-Buttons/assets/*.png "${S}"/Ambiance-Gentoo/gtk-3.0/assets/. || die
-	cp -f "${WORKDIR}"/Gentoo-Buttons/assets/*.png "${S}"/Ambiance-Gentoo/gtk-3.20/assets/. || die
-	cp -f "${WORKDIR}"/Gentoo-Buttons/assets/*.png "${S}"/Radiance-Gentoo/gtk-3.0/assets/. || die
-	cp -f "${WORKDIR}"/Gentoo-Buttons/assets/*.png "${S}"/Radiance-Gentoo/gtk-3.20/assets/. || die
+	cp -f "${WORKDIR}"/Gentoo-Buttons/*.png \
+		"${S}"/Ambiance-Gentoo/metacity-1/. || die
+	cp -f "${WORKDIR}"/Gentoo-Buttons/*.png \
+		"${S}"/Radiance-Gentoo/metacity-1/. || die
+	cp -f "${WORKDIR}"/Gentoo-Buttons/assets/*.png \
+		"${S}"/Ambiance-Gentoo/gtk-3.0/assets/. || die
+	cp -f "${WORKDIR}"/Gentoo-Buttons/assets/*.png \
+		"${S}"/Ambiance-Gentoo/gtk-3.20/assets/. || die
+	cp -f "${WORKDIR}"/Gentoo-Buttons/assets/*.png \
+		"${S}"/Radiance-Gentoo/gtk-3.0/assets/. || die
+	cp -f "${WORKDIR}"/Gentoo-Buttons/assets/*.png \
+		"${S}"/Radiance-Gentoo/gtk-3.20/assets/. || die
+	eapply_user
 }
 
 src_compile() {

--- a/x11-themes/nimbus/nimbus-0.1.7-r1.ebuild
+++ b/x11-themes/nimbus/nimbus-0.1.7-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 AUTOTOOLS_AUTO_DEPEND=no
 inherit autotools gnome2-utils
 
@@ -42,6 +42,7 @@ src_prepare() {
 	if [[ ${CHOST} == *-interix* ]] || ! use gtk; then
 		eautoreconf
 	fi
+	eapply_user
 }
 
 src_configure() {

--- a/x11-themes/notify-osd-icons/notify-osd-icons-0.7.ebuild
+++ b/x11-themes/notify-osd-icons/notify-osd-icons-0.7.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
+EAPI=6
 
 DESCRIPTION="Icons for on-screen-display notification agent"
 HOMEPAGE="https://launchpad.net/notify-osd"

--- a/x11-themes/nou-icon-theme/nou-icon-theme-09.02.08.ebuild
+++ b/x11-themes/nou-icon-theme/nou-icon-theme-09.02.08.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 inherit gnome2-utils versionator
 
 MY_PV="$(delete_all_version_separators ${PV})"

--- a/x11-themes/nuovo-icon-theme/nuovo-icon-theme-0.5.ebuild
+++ b/x11-themes/nuovo-icon-theme/nuovo-icon-theme-0.5.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 inherit gnome2-utils
 
 DESCRIPTION="A scalable icon theme called Nuovo"

--- a/x11-themes/nuvox/nuvox-07.1-r1.ebuild
+++ b/x11-themes/nuvox/nuvox-07.1-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 
 MY_P=nuvoX_${PV}
 
@@ -23,6 +23,7 @@ S=${WORKDIR}/${MY_P}
 
 src_prepare() {
 	sed -i -e '/rm -fr/d' -e '/tar cf/d' buildset || die
+	eapply_user
 }
 
 src_compile() {

--- a/x11-themes/pidgin-penguins-smileys/pidgin-penguins-smileys-1.0.ebuild
+++ b/x11-themes/pidgin-penguins-smileys/pidgin-penguins-smileys-1.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Penguins pidgin smiley theme"
 HOMEPAGE="http://gnome-look.org/content/show.php?content=62566"

--- a/x11-themes/redhat-artwork/redhat-artwork-5.0.8-r4.ebuild
+++ b/x11-themes/redhat-artwork/redhat-artwork-5.0.8-r4.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit autotools eutils rpm
+EAPI=6
+inherit autotools rpm
 
 MY_R=${PR/r/}
 DESCRIPTION="RedHat's Bluecurve theme for GTK2, KDE, GDM, Metacity and Nautilus"
@@ -24,13 +24,17 @@ DEPEND="
 
 RESTRICT="test"
 
+PATCHES=(
+	"${WORKDIR}"/redhat-artwork-5.0.5-add-dirs-to-bluecurve-theme-index.patch
+	"${WORKDIR}"/redhat-artwork-5.0.8-echo.patch
+)
+
 src_unpack() {
 	rpm_src_unpack
 }
 
 src_prepare() {
-	epatch "${WORKDIR}"/redhat-artwork-5.0.5-add-dirs-to-bluecurve-theme-index.patch
-	epatch "${WORKDIR}"/redhat-artwork-5.0.8-echo.patch
+	eapply "${PATCHES[@]}"
 
 	# dies if LANG has UTF-8
 	export LANG=C
@@ -66,11 +70,13 @@ src_prepare() {
 		art/icon/Makefile.am \
 		art/icon/Bluecurve/sheets/Makefile.am || die
 
+	mv configure.{in,ac}
 	eautoreconf
 
 	intltoolize --force || die
 
 	sed -i -e 's|GtkStyle|4|' art/qt/Bluecurve/bluecurve.cpp || die
+	eapply_user
 }
 
 src_compile() {

--- a/x11-themes/shiki-colors/shiki-colors-4.6.ebuild
+++ b/x11-themes/shiki-colors/shiki-colors-4.6.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Mixes the elegance of a dark theme with the usability of a light theme"
 HOMEPAGE="https://code.google.com/p/gnome-colors/"

--- a/x11-themes/slim-themes/files/slim-themes-1.2.3a-r7-flat.patch
+++ b/x11-themes/slim-themes/files/slim-themes-1.2.3a-r7-flat.patch
@@ -1,5 +1,5 @@
---- flat/slim.theme.orig	2010-01-15 14:10:18.000000000 -0200
-+++ flat/slim.theme	2010-01-15 14:25:10.000000000 -0200
+--- a/flat/slim.theme
++++ b/flat/slim.theme
 @@ -20,9 +20,9 @@
  input_pass_y            163
  

--- a/x11-themes/slim-themes/slim-themes-1.2.3a-r7.ebuild
+++ b/x11-themes/slim-themes/slim-themes-1.2.3a-r7.ebuild
@@ -1,8 +1,7 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils
+EAPI=6
 
 DESCRIPTION="SLiM (Simple Login Manager) themes pack"
 HOMEPAGE="https://sourceforge.net/projects/slim.berlios/"
@@ -40,9 +39,9 @@ RESTRICT="strip binchecks"
 
 S="${WORKDIR}"
 
-src_prepare() {
-	epatch "${FILESDIR}/slim-theme-flat.diff"
-}
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.2.3a-r7-flat.patch
+)
 
 src_compile() {
 	:

--- a/x11-themes/smplayer-skins/smplayer-skins-15.2.0-r1.ebuild
+++ b/x11-themes/smplayer-skins/smplayer-skins-15.2.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/x11-themes/smplayer-skins/smplayer-skins-15.2.0.ebuild
+++ b/x11-themes/smplayer-skins/smplayer-skins-15.2.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 DESCRIPTION="Skins for SMPlayer"
 HOMEPAGE="http://www.smplayer.info/"
@@ -14,6 +14,10 @@ IUSE=""
 
 DEPEND=""
 RDEPEND="media-video/smplayer"
+
+src_compile() {
+	:
+}
 
 src_install() {
 	rm themes/Makefile

--- a/x11-themes/tactile/tactile-0_pre20060612.ebuild
+++ b/x11-themes/tactile/tactile-0_pre20060612.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 
 MY_PN="Tactile"
 

--- a/x11-themes/tactile3/tactile3-3.1.ebuild
+++ b/x11-themes/tactile3/tactile3-3.1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 
 MY_PN="Tactile3"
 MY_P="${MY_PN}-${PV}"

--- a/x11-themes/tangerine-icon-theme/tangerine-icon-theme-0.27.ebuild
+++ b/x11-themes/tangerine-icon-theme/tangerine-icon-theme-0.27.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 inherit gnome2-utils
 
 DESCRIPTION="a derivative of the standard Tango theme, using a more orange approach"
@@ -24,10 +24,6 @@ DEPEND="dev-util/intltool
 
 DOCS="AUTHORS README"
 
-src_unpack() {
-	unpack ${PN}_${PV}.tar.gz
-}
-
 src_prepare() {
 	sed -i \
 		-e 's:lib/icon-naming-utils/icon:libexec/icon:' \
@@ -40,6 +36,7 @@ src_prepare() {
 		rsvg-convert -w ${res} -h ${res} scalable/places/start-here.svg \
 			> ${res}x${res}/places/start-here.png || die
 	done
+	eapply_user
 }
 
 src_compile() {

--- a/x11-themes/tango-icon-theme-extras/files/tango-icon-theme-extras-0.1.0-graphicsmagick.patch
+++ b/x11-themes/tango-icon-theme-extras/files/tango-icon-theme-extras-0.1.0-graphicsmagick.patch
@@ -1,7 +1,7 @@
 http://bugs.gentoo.org/314423
 
---- configure.ac
-+++ configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -39,9 +39,6 @@
  AM_CONDITIONAL(ENABLE_ICON_FRAMING, test x$enable_framing = xyes)
  

--- a/x11-themes/tango-icon-theme-extras/tango-icon-theme-extras-0.1.0-r2.ebuild
+++ b/x11-themes/tango-icon-theme-extras/tango-icon-theme-extras-0.1.0-r2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
-inherit autotools eutils gnome2-utils
+EAPI=6
+inherit autotools gnome2-utils
 
 DESCRIPTION="Tango icons for iPod Digital Audio Player devices and the Dell Pocket DJ DAP"
 HOMEPAGE="http://tango.freedesktop.org"
@@ -24,10 +24,15 @@ RESTRICT="binchecks strip"
 
 DOCS="AUTHORS ChangeLog NEWS README"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.1.0-graphicsmagick.patch
+	"${FILESDIR}"/${PN}-0.1.0-MKDIR_P.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/${P}-graphicsmagick.patch
-	epatch "${FILESDIR}"/${P}-MKDIR_P.patch
+	eapply "${PATCHES[@]}"
 	sed -i -e '/svgconvert_prog/s:rsvg:&-convert:' configure{,.ac} || die #413183
+	eapply_user
 	eautoreconf
 }
 

--- a/x11-themes/tango-icon-theme/tango-icon-theme-0.8.90-r1.ebuild
+++ b/x11-themes/tango-icon-theme/tango-icon-theme-0.8.90-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 inherit gnome2-utils
 
 DESCRIPTION="SVG and PNG icon theme from the Tango project"
@@ -37,6 +37,7 @@ src_prepare() {
 		addpredict "${cards}"
 	fi
 	shopt -u nullglob
+	eapply_user
 }
 
 src_configure() {

--- a/x11-themes/vdr-channel-logos/vdr-channel-logos-0.2-r1.ebuild
+++ b/x11-themes/vdr-channel-logos/vdr-channel-logos-0.2-r1.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-
-inherit eutils
+EAPI=6
 
 MY_P=${PN#vdr-channel-}-${PV}
 
@@ -21,8 +19,8 @@ S=${WORKDIR}/logos
 RDEPEND="app-text/convmv"
 
 src_prepare() {
-
 	convmv --notest --replace -f iso-8859-1 -t utf-8 -r "${S}"/
+	eapply_user
 }
 
 src_install() {

--- a/x11-themes/vdr-channel-logos/vdr-channel-logos-0.2.ebuild
+++ b/x11-themes/vdr-channel-logos/vdr-channel-logos-0.2.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-
-inherit eutils
+EAPI=6
 
 MY_P=${PN#vdr-channel-}-${PV}
 

--- a/x11-themes/xxv-skins/xxv-skins-1.6.1-r1.ebuild
+++ b/x11-themes/xxv-skins/xxv-skins-1.6.1-r1.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-
-inherit eutils
+EAPI=6
 
 DESCRIPTION="Additional skins for XXV"
 HOMEPAGE="http://projects.vdr-developer.org/projects/xxv"
@@ -20,7 +18,7 @@ RDEPEND="~www-misc/xxv-${PV}"
 SKINROOT=/usr/share/xxv/skins
 
 src_compile() {
-:
+	:
 }
 
 src_install() {

--- a/x11-themes/yasis-icon-theme/yasis-icon-theme-0.4.2.ebuild
+++ b/x11-themes/yasis-icon-theme/yasis-icon-theme-0.4.2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 inherit gnome2-utils
 
 DESCRIPTION="A scalable icon theme called Yasis"

--- a/x11-themes/zukini/zukini-20120806.ebuild
+++ b/x11-themes/zukini/zukini-20120806.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 
 DESCRIPTION="Unified look for GTK+ 2.x, GTK+ 3.x, gnome-shell, metacity and more"
 HOMEPAGE="http://lassekongo83.deviantart.com/#/d4ic1u2"


### PR DESCRIPTION
Most are pretty simple changes, and I avoided packages which were already showing
signs of being migrated to EAPI 6 and packages masked for removal.