### PR TITLE
x11-wm/enlightenment-0.21.7: Disable module_check to fix #648896

### DIFF
--- a/x11-wm/enlightenment/enlightenment-0.21.7.ebuild
+++ b/x11-wm/enlightenment/enlightenment-0.21.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -13,7 +13,7 @@ else
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x64-solaris ~x86-solaris"
 fi
 
-inherit enlightenment
+inherit enlightenment xdg-utils
 
 DESCRIPTION="Enlightenment DR17 window manager"
 
@@ -55,7 +55,10 @@ RDEPEND="
 	)
 	>=dev-libs/efl-1.18[X]
 	x11-libs/xcb-util-keysyms"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	sys-devel/automake:1.15
+"
 
 S=${WORKDIR}/${MY_P}
 
@@ -89,7 +92,9 @@ check_modules() {
 }
 
 src_configure() {
-	check_modules
+	# sanity check fails after commit e25cf18ca19463a7d05519aa843cc76a189ab75c 
+	# see #648896. Can be restored with future release
+	# check_modules
 
 	E_ECONF=(
 		--disable-install-sysactions
@@ -122,4 +127,14 @@ src_install() {
 	enlightenment_src_install
 	insinto /etc/enlightenment
 	newins "${FILESDIR}"/gentoo-sysactions.conf sysactions.conf
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }


### PR DESCRIPTION
As mgorny suggested, module_check can be disabled from this version instead of sedding Makefiles. I noticed it requires automake-1.15 since I had it uninstalled and the configuration failed. 
Oh, I did add xdg_desktop_database_update & xdg_mimeinfo_database_update due to portages QA messages. Just a quick fix to make it build, no EAPI bumpings etc...

```diff
--- /usr/portage/x11-wm/enlightenment/enlightenment-0.21.7.ebuild	2018-03-10 09:08:29.881702182 +0200
+++ ./enlightenment-0.21.7.ebuild	2018-03-23 16:45:31.632122946 +0200
@@ -13,7 +13,7 @@
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x64-solaris ~x86-solaris"
 fi
 
-inherit enlightenment
+inherit enlightenment xdg-utils
 
 DESCRIPTION="Enlightenment DR17 window manager"
 
@@ -55,7 +55,10 @@
 	)
 	>=dev-libs/efl-1.18[X]
 	x11-libs/xcb-util-keysyms"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	sys-devel/automake:1.15
+"
 
 S=${WORKDIR}/${MY_P}
 
@@ -89,7 +92,9 @@
 }
 
 src_configure() {
-	check_modules
+	# sanity check fails after commit e25cf18ca19463a7d05519aa843cc76a189ab75c 
+	# see #648896. Can be restored with future release
+	# check_modules
 
 	E_ECONF=(
 		--disable-install-sysactions
@@ -123,3 +128,13 @@
 	insinto /etc/enlightenment
 	newins "${FILESDIR}"/gentoo-sysactions.conf sysactions.conf
 }
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
```

Closes: https://bugs.gentoo.org/648896