### PR TITLE
dev-util/statifier: Don't compile 32-bit on amd64 no-multilib profile

### DIFF
--- a/dev-util/statifier/statifier-1.7.4.ebuild
+++ b/dev-util/statifier/statifier-1.7.4.ebuild
@@ -3,6 +3,10 @@
 
 EAPI="6"
 
+MULTILIB_COMPAT=( abi_x86_{32,64} )
+
+inherit multilib-build
+
 DESCRIPTION="Statifier is a tool for creating portable, self-containing Linux executables"
 HOMEPAGE="http://statifier.sourceforge.net"
 SRC_URI="https://sourceforge.net/projects/${PN}/files/${PN}/${PV}/${P}.tar.gz"
@@ -19,6 +23,11 @@ RDEPEND="app-shells/bash
 src_prepare() {
 	# Respect users CFLAGS and LDFLAGS
 	sed -i -e 's/-Wall -O2/$(CFLAGS) $(LDFLAGS)/g' src/Makefile || die
+
+	# Don't compile 32-bit on amd64 no-multilib profile
+	if ! use abi_x86_32; then
+		sed -i -e 's/ELF32 .*/ELF32 := no/g' configs/config.x86_64 || die
+	fi
 
 	# Apply user patches
 	eapply_user


### PR DESCRIPTION
dev-util/statifier: Don't compile 32-bit on amd64 no-multilib profile

Closes: https://bugs.gentoo.org/651260