### PR TITLE
app-accessibility/yasr: EAPI bump and patches cleanup

### DIFF
--- a/app-accessibility/yasr/files/yasr-0.6.9-automake113.patch
+++ b/app-accessibility/yasr/files/yasr-0.6.9-automake113.patch
@@ -1,5 +1,3 @@
-diff --git a/configure.in b/configure.in
-index d78e8b2..15e8666 100644
 --- a/configure.in
 +++ b/configure.in
 @@ -2,11 +2,10 @@ dnl Process this file with autoconf to produce a configure script.

--- a/app-accessibility/yasr/files/yasr-0.6.9-gcc43.patch
+++ b/app-accessibility/yasr/files/yasr-0.6.9-gcc43.patch
@@ -1,6 +1,5 @@
-diff -NrU5 yasr-0.6.9.orig/yasr/yasr.h yasr-0.6.9/yasr/yasr.h
---- yasr-0.6.9.orig/yasr/yasr.h	2008-06-29 01:23:44.000000000 +0200
-+++ yasr-0.6.9/yasr/yasr.h	2008-06-29 01:37:00.000000000 +0200
+--- a/yasr/yasr.h
++++ b/yasr/yasr.h
 @@ -306,22 +306,10 @@
  extern void opt_say(int num, int flag);
  extern void opt_set(int num, void *val);

--- a/app-accessibility/yasr/files/yasr-0.6.9-gettext019.patch
+++ b/app-accessibility/yasr/files/yasr-0.6.9-gettext019.patch
@@ -1,5 +1,3 @@
-diff --git a/configure.in b/configure.in
-index c26f577..d78e8b2 100644
 --- a/configure.in
 +++ b/configure.in
 @@ -57,7 +57,7 @@ fi
@@ -7,7 +5,7 @@ index c26f577..d78e8b2 100644
  
  AM_GNU_GETTEXT(external)
 -AM_GNU_GETTEXT_VERSION([0.17])
-+AM_GNU_GETTEXT_VERSION([0.18.1])
++AM_GNU_GETTEXT_VERSION([0.19])
  
  AC_OUTPUT([ m4/Makefile 
  Makefile

--- a/app-accessibility/yasr/files/yasr-0.6.9-remove-m4.patch
+++ b/app-accessibility/yasr/files/yasr-0.6.9-remove-m4.patch
@@ -1,6 +1,5 @@
-diff -Naur yasr-0.6.9.orig/Makefile.am yasr-0.6.9/Makefile.am
---- yasr-0.6.9.orig/Makefile.am	2008-02-02 06:44:05.000000000 -0600
-+++ yasr-0.6.9/Makefile.am	2009-02-06 08:37:07.000000000 -0600
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -7,7 +7,6 @@
  
  SUBDIRS = \
@@ -14,9 +13,8 @@ diff -Naur yasr-0.6.9.orig/Makefile.am yasr-0.6.9/Makefile.am
  	README-ru
  
 -ACLOCAL_AMFLAGS = -I m4
-diff -Naur yasr-0.6.9.orig/configure.in yasr-0.6.9/configure.in
---- yasr-0.6.9.orig/configure.in	2008-02-02 07:09:04.000000000 -0600
-+++ yasr-0.6.9/configure.in	2009-02-06 08:36:43.000000000 -0600
+--- a/configure.in
++++ b/configure.in
 @@ -59,8 +59,7 @@
  AM_GNU_GETTEXT(external)
  AM_GNU_GETTEXT_VERSION([0.17])

--- a/app-accessibility/yasr/yasr-0.6.9-r1.ebuild
+++ b/app-accessibility/yasr/yasr-0.6.9-r1.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
-inherit autotools eutils
+EAPI=6
 
-DESCRIPTION="general-purpose console screen reader"
+inherit autotools
+
+DESCRIPTION="General-purpose console screen reader"
 HOMEPAGE="http://yasr.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
@@ -16,16 +17,27 @@ IUSE="nls"
 RDEPEND=""
 DEPEND="nls? ( sys-devel/gettext )"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.6.9-automake113.patch
+	"${FILESDIR}"/${PN}-0.6.9-gettext019.patch
+	"${FILESDIR}"/${PN}-0.6.9-gcc43.patch
+	"${FILESDIR}"/${PN}-0.6.9-remove-m4.patch
+)
+
 src_prepare() {
+	default
 	local x=/usr/share/gettext/po/Makefile.in.in
-	[[ -e $x ]] && cp -f $x po/ #330879
+	[[ -e $x ]] && cp -f $x po/ || die #330879
 
-	epatch "${FILESDIR}"/${P}-automake113.patch \
-		"${FILESDIR}"/${P}-gettext018.patch \
-		"${FILESDIR}"/${P}-gcc43.patch \
-		"${FILESDIR}"/${P}-remove-m4.patch
+	rm -r "${S}"/m4 || die
 
-	rm -r "${S}"/m4
+	sed -i \
+	's:^\(synthesizer=emacspeak server\):#\1:
+	s:^\(synthesizer port=|/usr/local/bin/eflite\):#\1:
+	s:^#\(synthesizer=speech dispatcher\):\1:
+	s:^#\(synthesizer port=127.0.0.1.6560\):\1:' yasr.conf || die
+
+	mv configure.{in,ac} || die
 	eautoreconf
 }
 
@@ -34,16 +46,6 @@ src_configure() {
 		--datadir=/etc \
 		--disable-dependency-tracking \
 		$(use_enable nls)
-}
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	dodoc README ChangeLog AUTHORS BUGS CREDITS
-	dosed \
-	's:^\(synthesizer=emacspeak server\):#\1:
-	s:^\(synthesizer port=|/usr/local/bin/eflite\):#\1:
-	s:^#\(synthesizer=speech dispatcher\):\1:
-	s:^#\(synthesizer port=127.0.0.1.6560\):\1:' /etc/yasr/yasr.conf
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Bump EAPI to 6, cleanup patches, remove eutils, move dosed from
src_install to src_prepare (and change it to normal sed -i), allow
building with sys-devel/gettext-0.19.8.1

Package-Manager: Portage-2.3.24, Repoman-2.3.6