### PR TITLE
app-accessibility/epos: EAPI bump and patch updates

### DIFF
--- a/app-accessibility/epos/epos-2.5.37-r2.ebuild
+++ b/app-accessibility/epos/epos-2.5.37-r2.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
-inherit eutils autotools
+inherit autotools
 
 DESCRIPTION="language independent text-to-speech system"
-HOMEPAGE="http://epos.ure.cas.cz/"
+HOMEPAGE="http://epos.ufe.cz/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
@@ -18,12 +18,15 @@ DEPEND=">=app-text/sgmltools-lite-3.0.3-r9
 	dev-util/byacc"
 RDEPEND=""
 
-src_prepare() {
-	epatch "${FILESDIR}"/${P}-gcc43.patch \
-		"${FILESDIR}"/${P}-gcc45.patch \
-		"${FILESDIR}"/${P}-gcc47.patch \
-		"${FILESDIR}"/${P}-disable-tests.patch
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.5.37-gcc43.patch
+	"${FILESDIR}"/${PN}-2.5.37-gcc45.patch
+	"${FILESDIR}"/${PN}-2.5.37-gcc47.patch
+	"${FILESDIR}"/${PN}-2.5.37-disable-tests.patch
+)
 
+src_prepare() {
+	default
 	sed -i -e "s/CCC/#CCC/" configure.ac || die
 
 	eautoreconf

--- a/app-accessibility/epos/files/epos-2.5.37-disable-tests.patch
+++ b/app-accessibility/epos/files/epos-2.5.37-disable-tests.patch
@@ -1,6 +1,5 @@
-diff -uNr epos-2.5.37.org/src/tests/Makefile.am epos-2.5.37/src/tests/Makefile.am
---- epos-2.5.37.org/src/tests/Makefile.am	2012-04-14 00:38:56.000000000 -0400
-+++ epos-2.5.37/src/tests/Makefile.am	2012-04-14 00:39:10.000000000 -0400
+--- a/src/tests/Makefile.am
++++ b/src/tests/Makefile.am
 @@ -1,11 +1,9 @@
  ##	Process this file with automake run in the top directory to yield Makefile.in
  

--- a/app-accessibility/epos/files/epos-2.5.37-gcc43.patch
+++ b/app-accessibility/epos/files/epos-2.5.37-gcc43.patch
@@ -1,5 +1,5 @@
---- epos-2.5.37.orig/src/nnet/neural.cc
-+++ epos-2.5.37/src/nnet/neural.cc
+--- a/src/nnet/neural.cc
++++ b/src/nnet/neural.cc
 @@ -38,7 +38,7 @@
  #include <string.h>
  #include <ctype.h>
@@ -9,8 +9,8 @@
  #include <time.h>
  
  /*
---- epos-2.5.37.orig/arch/win/service/install.cpp
-+++ epos-2.5.37/arch/win/service/install.cpp
+--- a/arch/win/service/install.cpp
++++ b/arch/win/service/install.cpp
 @@ -23,7 +23,7 @@
  #include <winsvc.h>
  #include "service.h"

--- a/app-accessibility/epos/files/epos-2.5.37-gcc45.patch
+++ b/app-accessibility/epos/files/epos-2.5.37-gcc45.patch
@@ -2,8 +2,8 @@ Fixing build with gcc 4.5
 
 http://bugs.gentoo.org/show_bug.cgi?id=318585
 
---- src/nnet/neural_parse.yy
-+++ src/nnet/neural_parse.yy
+--- a/src/nnet/neural_parse.yy
++++ b/src/nnet/neural_parse.yy
 @@ -255,7 +255,7 @@
  
  int yyerror (char *s)


### PR DESCRIPTION
Bump EAPI to 6, and cleanup the patches a bit

Package-Manager: Portage-2.3.24, Repoman-2.3.6