### PR TITLE
app-accessibility/brltty: bump to EAPI 6

### DIFF
--- a/app-accessibility/brltty/brltty-5.2-r1.ebuild
+++ b/app-accessibility/brltty/brltty-5.2-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 FINDLIB_USE="ocaml"
@@ -42,11 +42,17 @@ DEPEND="virtual/pkgconfig
 RDEPEND="java? ( >=virtual/jre-1.4 )
 	${COMMON_DEP}"
 
+HTML_DOCS=( "${S}"/Documents/Manual-BrlAPI/. )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.2-fix-ldflags.patch
+	"${FILESDIR}"/${PN}-5.2-udev.patch
+	"${FILESDIR}"/${PN}-5.2-respect-AR.patch
+	"${FILESDIR}"/${PN}-5.2-sysmacros.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/${P}-fix-ldflags.patch \
-		"${FILESDIR}"/${P}-udev.patch \
-		"${FILESDIR}"/${P}-respect-AR.patch \
-		"${FILESDIR}"/${P}-sysmacros.patch
+	default
 
 	java-pkg-opt-2_src_prepare
 
@@ -163,30 +169,29 @@ src_install() {
 
 	libdir="$(get_libdir)"
 	mkdir -p "${D}"/usr/${libdir}/
-	mv "${D}"/${libdir}/*.a "${D}"/usr/${libdir}/
+	mv "${D}"/${libdir}/*.a "${D}"/usr/${libdir}/ || die
 	gen_usr_ldscript libbrlapi.so
 
-	cd Documents
-	mv Manual-BRLTTY/English/BRLTTY.txt BRLTTY-en.txt
-	mv Manual-BRLTTY/French/BRLTTY.txt BRLTTY-fr.txt
-	mv Manual-BrlAPI/English/BrlAPI.txt BrlAPI-en.txt
+	cd Documents || die
+	mv Manual-BRLTTY/English/BRLTTY.txt BRLTTY-en.txt || die
+	mv Manual-BRLTTY/French/BRLTTY.txt BRLTTY-fr.txt || die
+	mv Manual-BrlAPI/English/BrlAPI.txt BrlAPI-en.txt || die
 	dodoc CONTRIBUTORS ChangeLog HISTORY README* TODO BRLTTY-*.txt
-	dohtml -r Manual-BRLTTY
 	if use doc; then
-		dohtml -r Manual-BrlAPI
 		dodoc BrlAPI-*.txt
+		HTML_DOCS="Manual-BRLTTY" einstalldocs
 	fi
 
-	keepdir /var/lib/brlapi
-	rmdir "${D}/run/brltty"
-	rmdir "${D}/run"
+	keepdir /var/lib/BrlAPI
+	rmdir "${D}/run/brltty" || die
+	rmdir "${D}/run" || die
 }
 
 pkg_postinst() {
 	elog
-	elog please be sure "${ROOT}"etc/brltty.conf is correct for your system.
+	elog "please be sure ${ROOT}etc/brltty.conf is correct for your system."
 	elog
-	elog To make brltty start on boot, type this command as root:
+	elog "To make brltty start on boot, type this command as root:"
 	elog
-	elog rc-update add brltty boot
+	elog "rc-update add brltty boot"
 }

--- a/app-accessibility/brltty/files/brltty-5.2-respect-AR.patch
+++ b/app-accessibility/brltty/files/brltty-5.2-respect-AR.patch
@@ -1,6 +1,5 @@
-diff -Naur brltty-5.2/Programs/Makefile.in brltty-5.2-new/Programs/Makefile.in
---- brltty-5.2/Programs/Makefile.in	2014-11-06 07:28:41.000000000 -0800
-+++ brltty-5.2-new/Programs/Makefile.in	2014-11-20 05:41:57.144219093 -0800
+--- a/Programs/Makefile.in
++++ b/Programs/Makefile.in
 @@ -434,7 +434,7 @@
  	[ ! -f lib.def ] || mv lib.def $(API_DEF)
  

--- a/app-accessibility/brltty/files/brltty-5.2-udev.patch
+++ b/app-accessibility/brltty/files/brltty-5.2-udev.patch
@@ -1,6 +1,5 @@
-diff -Naur brltty-5.2/Autostart/Udev/udev.rules brltty-5.2-new/Autostart/Udev/udev.rules
---- brltty-5.2/Autostart/Udev/udev.rules	2014-11-06 07:28:41.000000000 -0800
-+++ brltty-5.2-new/Autostart/Udev/udev.rules	2014-11-20 05:28:44.404885312 -0800
+--- a/Autostart/Udev/udev.rules
++++ b/Autostart/Udev/udev.rules
 @@ -182,20 +182,22 @@
  # FreedomScientific [Focus Blue]
  ENV{PRODUCT}=="f4e/114/*", ENV{BRLTTY_BRAILLE_DRIVER}="fs", GOTO="brltty_usb_run"


### PR DESCRIPTION
Also readjusted the epatch call to an eapply call, added
HTML_DOCS/einstalldocs as dohtml is deprecated on EAPI=6,
and adjusted the keepdir call to point at the correct directory.

Package-Manager: Portage-2.3.24, Repoman-2.3.6