### PR TITLE
nvidia-drivers: 340.106 definitely supports Linux 4.14

### DIFF
--- a/x11-drivers/nvidia-drivers/nvidia-drivers-340.106.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-340.106.ebuild
@@ -78,11 +78,11 @@ nvidia_drivers_versions_check() {
 		die "Unexpected \${DEFAULT_ABI} = ${DEFAULT_ABI}"
 	fi
 
-	if use kernel_linux && kernel_is ge 4 11; then
+	if use kernel_linux && kernel_is ge 4 15; then
 		ewarn "Gentoo supports kernels which are supported by NVIDIA"
 		ewarn "which are limited to the following kernels:"
-		ewarn "<sys-kernel/gentoo-sources-4.11"
-		ewarn "<sys-kernel/vanilla-sources-4.11"
+		ewarn "<sys-kernel/gentoo-sources-4.15"
+		ewarn "<sys-kernel/vanilla-sources-4.15"
 		ewarn ""
 		ewarn "You are free to utilize eapply_user to provide whatever"
 		ewarn "support you feel is appropriate, but will not receive"


### PR DESCRIPTION
I'm tired of seeing this warning:

```
 * Gentoo supports kernels which are supported by NVIDIA
 * which are limited to the following kernels:
 * <sys-kernel/gentoo-sources-4.11
 * <sys-kernel/vanilla-sources-4.11
 *
 * You are free to utilize eapply_user to provide whatever
 * support you feel is appropriate, but will not receive
 * support as a result of those changes.
 *
 * Do not file a bug report about this.
```

The warning used to be true (I had to use custom patches to get the drivers to compile with my kernel), but that's no longer the case. `340.106` compiles just fine with `4.14` without any patches on my computer.

You don't have to take my word -- look at https://devtalk.nvidia.com/default/topic/1028805 . KPTI was merged in 4.15 and was backported to 4.14.

It's possible 4.15 is also supported, but I haven't checked if that's the case.