### PR TITLE
app-emulation/xe-guest-utilities: use HTTPS

### DIFF
--- a/app-emulation/xe-guest-utilities/xe-guest-utilities-5.6.0_p595.ebuild
+++ b/app-emulation/xe-guest-utilities/xe-guest-utilities-5.6.0_p595.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils rpm linux-info
 DESCRIPTION="XenServer Virtual Machine Tools"
-HOMEPAGE="http://www.citrix.com/"
+HOMEPAGE="https://www.citrix.com/"
 PV_BASE=${PV/_*}
 PV_FULL=${PV/_p/-}
 SRC_URI="http://updates.vmd.citrix.com/XenServer/${PV_BASE}/rhel4x/SRPMS/xe-guest-utilities-${PV_FULL}.src.rpm"

--- a/app-emulation/xe-guest-utilities/xe-guest-utilities-6.1.0_p1033.ebuild
+++ b/app-emulation/xe-guest-utilities/xe-guest-utilities-6.1.0_p1033.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils rpm linux-info
 DESCRIPTION="XenServer Virtual Machine Tools"
-HOMEPAGE="http://www.citrix.com/"
+HOMEPAGE="https://www.citrix.com/"
 PV_BASE=${PV/_*}
 PV_FULL=${PV/_p/-}
 SRC_URI="http://updates.vmd.citrix.com/XenServer/${PV_BASE}/rhel4x/SRPMS/xe-guest-utilities-${PV_FULL}.src.rpm"

--- a/app-emulation/xe-guest-utilities/xe-guest-utilities-6.2.0_p1120.ebuild
+++ b/app-emulation/xe-guest-utilities/xe-guest-utilities-6.2.0_p1120.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils rpm linux-info
 DESCRIPTION="XenServer Virtual Machine Tools"
-HOMEPAGE="http://www.citrix.com/"
+HOMEPAGE="https://www.citrix.com/"
 PV_BASE=${PV/_*}
 PV_FULL=${PV/_p/-}
 SRC_URI="http://updates.vmd.citrix.com/XenServer/${PV_BASE}/rhel4x/SRPMS/xe-guest-utilities-${PV_FULL}.src.rpm"


### PR DESCRIPTION
Hi,

This PR fixes xe-guest-utilities to use https instead of http.

Please review.