### PR TITLE
dev-util/codeblocks: Fix building with GCC-7

### DIFF
--- a/dev-util/codeblocks/codeblocks-16.01.ebuild
+++ b/dev-util/codeblocks/codeblocks-16.01.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -27,6 +27,8 @@ RDEPEND="app-arch/zip
 	)"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}"/${P}-gcc7.patch )
 
 src_configure() {
 	touch "${S}"/revision.m4 -r "${S}"/acinclude.m4

--- a/dev-util/codeblocks/files/codeblocks-16.01-gcc7.patch
+++ b/dev-util/codeblocks/files/codeblocks-16.01-gcc7.patch
@@ -1,0 +1,30 @@
+Bug: https://bugs.gentoo.org/649248
+SVN Revision: https://sourceforge.net/p/codeblocks/code/11006
+GIT Commit: https://github.com/jenslody/codeblocks/commit/1fd6799ded8475fafaca17de9c23db767177d31b
+
+From 1fd6799ded8475fafaca17de9c23db767177d31b Mon Sep 17 00:00:00 2001
+From: jenslody <jenslody@2a5c6006-c6dd-42ca-98ab-0921f2732cef>
+Date: Fri, 10 Feb 2017 20:56:25 +0000
+Subject: [PATCH] gcc7 build-fix: avoid template-related error
+
+---
+ src/include/scripting/sqplus/sqplus.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/include/scripting/sqplus/sqplus.h b/src/include/scripting/sqplus/sqplus.h
+index 73f37b24f..ae7d3c75f 100644
+--- a/src/include/scripting/sqplus/sqplus.h
++++ b/src/include/scripting/sqplus/sqplus.h
+@@ -154,10 +154,10 @@ struct ScriptStringVar : ScriptStringVarBase {
+     return safeStringCopy(s,_s.s,MaxLength);
+   }
+   bool operator == (const ScriptStringVar & _s) {
+-    return _strcmp(s,_s.s) == 0;
++    return strcmp(s,_s.s) == 0;
+   }
+   bool compareCaseInsensitive(const ScriptStringVar & _s) {
+-    return _stricmp(s,_s.s) == 0;
++    return strcasecmp(s,_s.s) == 0;
+   }
+ };
+ 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/637126
Package-Manager: Portage-2.3.16, Repoman-2.3.6
Closes: https://bugs.gentoo.org/649248
Closes: https://bugs.gentoo.org/637126
Closes: [#7600](https://github.com/gentoo/gentoo/pull/7600)

Taken from [r11006](https://sourceforge.net/p/codeblocks/code/11006).