### PR TITLE
media-libs/freeimage: Fix building against =media-libs/jpeg-9*

### DIFF
--- a/media-libs/freeimage/files/freeimage-3.15.4-libjpeg9.patch
+++ b/media-libs/freeimage/files/freeimage-3.15.4-libjpeg9.patch
@@ -1,0 +1,45 @@
+Bug: https://bugs.gentoo.org/647422
+Upstream Patch: https://sourceforge.net/p/freeimage/patches/130/
+
+diff -Naur a/Source/FreeImage/PluginJPEG.cpp b/Source/FreeImage/PluginJPEG.cpp
+--- a/Source/FreeImage/PluginJPEG.cpp	2018-03-24 23:24:11.062695375 -0400
++++ b/Source/FreeImage/PluginJPEG.cpp	2018-03-24 23:25:39.451124161 -0400
+@@ -1586,14 +1586,14 @@
+ 
+ 			// thumbnail support (JFIF 1.02 extension markers)
+ 			if(FreeImage_GetThumbnail(dib) != NULL) {
+-				cinfo.write_JFIF_header = 1; //<### force it, though when color is CMYK it will be incorrect
++				cinfo.write_JFIF_header = static_cast<boolean>(1); //<### force it, though when color is CMYK it will be incorrect
+ 				cinfo.JFIF_minor_version = 2;
+ 			}
+ 
+ 			// baseline JPEG support
+ 			if ((flags & JPEG_BASELINE) ==  JPEG_BASELINE) {
+-				cinfo.write_JFIF_header = 0;	// No marker for non-JFIF colorspaces
+-				cinfo.write_Adobe_marker = 0;	// write no Adobe marker by default				
++				cinfo.write_JFIF_header = static_cast<boolean>(0);	// No marker for non-JFIF colorspaces
++				cinfo.write_Adobe_marker = static_cast<boolean>(0);	// write no Adobe marker by default
+ 			}
+ 
+ 			// set subsampling options if required
+diff -Naur a/Source/FreeImage.h b/Source/FreeImage.h
+--- a/Source/FreeImage.h	2018-03-24 23:24:11.066695395 -0400
++++ b/Source/FreeImage.h	2018-03-24 23:26:35.945391182 -0400
+@@ -117,12 +117,17 @@
+ #ifndef _WINDOWS_
+ #define _WINDOWS_
+ 
++#if JPEG_LIB_VERSION < 90
++
+ #ifndef FALSE
+ #define FALSE 0
+ #endif
+ #ifndef TRUE
+ #define TRUE 1
+ #endif
++
++#endif
++
+ #ifndef NULL
+ #define NULL 0
+ #endif

--- a/media-libs/freeimage/freeimage-3.15.4-r1.ebuild
+++ b/media-libs/freeimage/freeimage-3.15.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -45,6 +45,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.15.4-CVE-2016-5684-1.patch
 	"${FILESDIR}"/${PN}-3.15.4-CVE-2016-5684-2.patch
 	"${FILESDIR}"/${PN}-3.15.4-CVE-2015-0852.patch
+	"${FILESDIR}"/${PN}-3.15.4-libjpeg9.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/647422
Package-Manager: Portage-2.3.16, Repoman-2.3.6

Building against media-libs/jpeg-9c fails though it succeeds against media-libs/libjpeg-turbo.  There is a change in the libjpeg-9's implementation of `boolean`.  This is similar to the problems reported in https://github.com/openscenegraph/OpenSceneGraph/issues/58 and [Bug 339864 - kis_jpeg_converter.cc fails to build with libjpeg-9a](https://bugs.kde.org/show_bug.cgi?id=339864).  The solutions are similar to https://github.com/openscenegraph/OpenSceneGraph/commit/34b4e7001522c1b47b4211dac34d2d6a6b994a6f and [calligra/krita@8af9690](https://cgit.kde.org/calligra.git/commit/?id=8af9690779ff573b4da8943cbb8f502bc1f95638).

Reported upstream at https://sourceforge.net/p/freeimage/patches/130/