### PR TITLE
games-emulation/desmume: Fix building with GCC-7

### DIFF
--- a/games-emulation/desmume/desmume-0.9.11-r1.ebuild
+++ b/games-emulation/desmume/desmume-0.9.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -31,4 +31,5 @@ DOCS=( AUTHORS ChangeLog README README.LIN )
 PATCHES=(
 	"${FILESDIR}/${P}-fix-pointer-conversion-warning.diff"
 	"${FILESDIR}/${P}-gcc6.patch"
+	"${FILESDIR}/${P}-gcc7.patch"
 )

--- a/games-emulation/desmume/files/desmume-0.9.11-gcc7.patch
+++ b/games-emulation/desmume/files/desmume-0.9.11-gcc7.patch
@@ -1,0 +1,21 @@
+Bug: https://bugs.gentoo.org/646352
+Patch: https://sources.debian.org/data/main/d/desmume/0.9.11-3/debian/patches/gcc7_fixes.patch
+
+From e1f7039f1b06add4fb75b2f8774000b8f05574af Mon Sep 17 00:00:00 2001
+From: rogerman <rogerman@users.sf.net>
+Date: Mon, 17 Aug 2015 21:15:04 +0000
+Subject: Fix bug with libfat string handling.
+
+diff --git a/src/utils/libfat/directory.cpp b/src/utils/libfat/directory.cpp
+index 765d7ae5..b6d7f01f 100644
+--- a/src/utils/libfat/directory.cpp
++++ b/src/utils/libfat/directory.cpp
+@@ -139,7 +139,7 @@ static size_t _FAT_directory_mbstoucs2 (ucs2_t* dst, const char* src, size_t len
+ 	int bytes;
+ 	size_t count = 0;
+ 
+-	while (count < len-1 && src != '\0') {
++	while (count < len-1 && *src != '\0') {
+ 		bytes = mbrtowc (&tempChar, src, MB_CUR_MAX, &ps);
+ 		if (bytes > 0) {
+ 			*dst = (ucs2_t)tempChar;


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/646352
Package-Manager: Portage-2.3.16, Repoman-2.3.6
Closes: https://bugs.gentoo.org/646352
Closes: [#7606](https://github.com/gentoo/gentoo/pull/7606)

The intent appears to have been to check for a terminating nul character at the end of the C string `src`, not to check if `src` is `NULL`.  Thanks to GCC-7's strict rules against char literal to pointer conversion, this was caught.

Patch was taken from https://sources.debian.org/data/main/d/desmume/0.9.11-3/debian/patches/gcc7_fixes.patch.

Fixed upstream with https://github.com/TASVideos/desmume/commit/e1f7039f1b06add4fb75b2f8774000b8f05574af.