### PR TITLE
sys-apps/sandbox: drop ~x86-fbsd keyword.

### DIFF
--- a/sys-apps/sandbox/sandbox-2.12.ebuild
+++ b/sys-apps/sandbox/sandbox-2.12.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://dev.gentoo.org/~mgorny/dist/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86"
 IUSE=""
 
 DEPEND="app-arch/xz-utils

--- a/sys-apps/sandbox/sandbox-2.13.ebuild
+++ b/sys-apps/sandbox/sandbox-2.13.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://dev.gentoo.org/~mgorny/dist/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 IUSE=""
 
 DEPEND="app-arch/xz-utils


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/374425

sys-apps/sandbox can't work fine and fails to compile on Gentoo/FreeBSD. So, please remove ~x86-fbsd keyword.

Thanks.