### PR TITLE
freedict: EAPI 6

### DIFF
--- a/app-dicts/freedict-deu-eng/freedict-deu-eng-1.0.ebuild
+++ b/app-dicts/freedict-deu-eng/freedict-deu-eng-1.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 FORLANG="German"
 TOLANG="English"

--- a/app-dicts/freedict-eng-fra/freedict-eng-fra-1.0.ebuild
+++ b/app-dicts/freedict-eng-fra/freedict-eng-fra-1.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 FORLANG="English"
 TOLANG="French"

--- a/app-dicts/freedict-eng-ita/freedict-eng-ita-1.0.ebuild
+++ b/app-dicts/freedict-eng-ita/freedict-eng-ita-1.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 KEYWORDS="alpha ~amd64 ~hppa ~mips ppc sparc x86"
 

--- a/app-dicts/freedict-eng-swe/freedict-eng-swe-1.0.ebuild
+++ b/app-dicts/freedict-eng-swe/freedict-eng-swe-1.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 KEYWORDS="alpha ~amd64 ~hppa ~mips ppc sparc x86"
 

--- a/app-dicts/freedict-fra-eng/freedict-fra-eng-1.0.ebuild
+++ b/app-dicts/freedict-fra-eng/freedict-fra-eng-1.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 KEYWORDS="alpha ~amd64 ~hppa ~mips ppc sparc x86"
 

--- a/app-dicts/freedict-ita-eng/freedict-ita-eng-1.0.ebuild
+++ b/app-dicts/freedict-ita-eng/freedict-ita-eng-1.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 KEYWORDS="alpha ~amd64 ~hppa ~mips ppc sparc x86"
 


### PR DESCRIPTION
All ebuilds are flat data, had no `EAPI` to begin with, and only inherited `freedict.eclass` which
did all the heavy lifting, which itself only needed the `$(get_libdir)` function which is available
without need of external eclasses in `EAPI=6`.