### PR TITLE
sys-libs/readline: EAPI bump and mingw-w64 patch

### DIFF
--- a/sys-libs/readline/files/readline-5.0-no_rpath.patch
+++ b/sys-libs/readline/files/readline-5.0-no_rpath.patch
@@ -1,7 +1,7 @@
 ripped from Fedora
 
---- support/shobj-conf
-+++ support/shobj-conf
+--- a/support/shobj-conf
++++ b/support/shobj-conf
 @@ -102,7 +102,7 @@
  	SHOBJ_LD='${CC}'
  	SHOBJ_LDFLAGS='-shared -Wl,-soname,$@'

--- a/sys-libs/readline/files/readline-7.0-headers.patch
+++ b/sys-libs/readline/files/readline-7.0-headers.patch
@@ -9,8 +9,8 @@ Subject: [PATCH] include ctype.h for isdigit usage
 
 diff --git a/lib/readline/histexpand.c b/lib/readline/histexpand.c
 index 46a99aa62e30..13248db83048 100644
---- a/lib/readline/histexpand.c
-+++ b/lib/readline/histexpand.c
+--- a/histexpand.c
++++ b/histexpand.c
 @@ -26,6 +26,7 @@
  #endif
  

--- a/sys-libs/readline/files/readline-7.0-mingw.patch
+++ b/sys-libs/readline/files/readline-7.0-mingw.patch
@@ -1,0 +1,152 @@
+--- a/colors.c
++++ b/colors.c
+@@ -37,6 +37,10 @@
+ #include "posixstat.h" // stat related macros (S_ISREG, ...)
+ #include <fcntl.h> // S_ISUID
+ 
++#ifndef S_ISDIR
++#define	S_ISDIR(m)	(((m) & S_IFMT) == S_IFDIR)
++#endif
++
+ // strlen()
+ #if defined (HAVE_STRING_H)
+ #  include <string.h>
+@@ -182,12 +186,17 @@ _rl_print_color_indicator (const char *f
+       if (S_ISREG (mode))
+         {
+           colored_filetype = C_FILE;
+-
++#ifdef S_ISUID
+           if ((mode & S_ISUID) != 0 && is_colored (C_SETUID))
+             colored_filetype = C_SETUID;
+-          else if ((mode & S_ISGID) != 0 && is_colored (C_SETGID))
++		else
++#endif
++#ifdef S_ISGID
++          if ((mode & S_ISGID) != 0 && is_colored (C_SETGID))
+             colored_filetype = C_SETGID;
+-          else if (is_colored (C_CAP) && 0) //f->has_capability)
++          else
++#endif
++		  if (is_colored (C_CAP) && 0) //f->has_capability)
+             colored_filetype = C_CAP;
+           else if ((mode & S_IXUGO) != 0 && is_colored (C_EXEC))
+             colored_filetype = C_EXEC;
+@@ -211,12 +220,16 @@ _rl_print_color_indicator (const char *f
+             colored_filetype = C_STICKY;
+ #endif
+         }
++#if defined (S_ISLNK)
+       else if (S_ISLNK (mode))
+         colored_filetype = C_LINK;
++#endif
+       else if (S_ISFIFO (mode))
+         colored_filetype = C_FIFO;
++#if defined (S_ISSOCK)
+       else if (S_ISSOCK (mode))
+         colored_filetype = C_SOCK;
++#endif
+       else if (S_ISBLK (mode))
+         colored_filetype = C_BLK;
+       else if (S_ISCHR (mode))
+--- a/histfile.c
++++ b/histfile.c
+@@ -606,12 +606,14 @@ history_truncate_file (fname, lines)
+       history_lines_written_to_file = 0;
+     }
+ 
++#if defined (HAVE_CHOWN)
+   /* Make sure the new filename is owned by the same user as the old.  If one
+      user is running this, it's a no-op.  If the shell is running after sudo
+      with a shared history file, we don't want to leave the history file
+      owned by root. */
+   if (rv == 0 && exists)
+     r = chown (filename, finfo.st_uid, finfo.st_gid);
++#endif
+ 
+   xfree (filename);
+   FREE (tempname);
+@@ -753,12 +755,14 @@ mmap_error:
+       history_lines_written_to_file = 0;
+     }
+ 
++#if defined (HAVE_CHOWN)
+   /* Make sure the new filename is owned by the same user as the old.  If one
+      user is running this, it's a no-op.  If the shell is running after sudo
+      with a shared history file, we don't want to leave the history file
+      owned by root. */
+   if (rv == 0 && exists)
+     mode = chown (histname, finfo.st_uid, finfo.st_gid);
++#endif
+ 
+   FREE (histname);
+   FREE (tempname);
+--- a/input.c
++++ b/input.c
+@@ -71,6 +71,10 @@ extern int errno;
+ #include "rlshell.h"
+ #include "xmalloc.h"
+ 
++#if defined (__MINGW32__)
++#include <conio.h>
++#endif
++
+ /* What kind of non-blocking I/O do we have? */
+ #if !defined (O_NDELAY) && defined (O_NONBLOCK)
+ #  define O_NDELAY O_NONBLOCK	/* Posix style */
+--- a/posixstat.h
++++ b/posixstat.h
+@@ -78,30 +78,44 @@
+ 
+ #if defined (S_IFBLK) && !defined (S_ISBLK)
+ #define	S_ISBLK(m)	(((m)&S_IFMT) == S_IFBLK)	/* block device */
++#elif !defined (S_IFBLK)
++#define S_ISBLK(m) 0
+ #endif
+ 
+ #if defined (S_IFCHR) && !defined (S_ISCHR)
+ #define	S_ISCHR(m)	(((m)&S_IFMT) == S_IFCHR)	/* character device */
++#elif !defined (S_IFCHR)
++#define S_ISCHR(m) 0
+ #endif
+ 
+ #if defined (S_IFDIR) && !defined (S_ISDIR)
+ #define	S_ISDIR(m)	(((m)&S_IFMT) == S_IFDIR)	/* directory */
++#elif !defined (S_IFDIR)
++#define S_ISDIR(m) 0
+ #endif
+ 
+ #if defined (S_IFREG) && !defined (S_ISREG)
+ #define	S_ISREG(m)	(((m)&S_IFMT) == S_IFREG)	/* file */
++#elif !defined (S_IFREG)
++#define S_ISREG(m) 0
+ #endif
+ 
+ #if defined (S_IFIFO) && !defined (S_ISFIFO)
+ #define	S_ISFIFO(m)	(((m)&S_IFMT) == S_IFIFO)	/* fifo - named pipe */
++#elif !defined (S_IFIFO)
++#define S_ISFIFO(m) 0
+ #endif
+ 
+ #if defined (S_IFLNK) && !defined (S_ISLNK)
+ #define	S_ISLNK(m)	(((m)&S_IFMT) == S_IFLNK)	/* symbolic link */
++#elif !defined (S_IFLNK)
++#define S_ISLNK(m) 0
+ #endif
+ 
+ #if defined (S_IFSOCK) && !defined (S_ISSOCK)
+ #define	S_ISSOCK(m)	(((m)&S_IFMT) == S_IFSOCK)	/* socket */
++#elif !defined (S_IFSOCK)
++#define S_ISSOCK(m) 0
+ #endif
+ 
+ /*
+@@ -137,6 +151,8 @@
+ /* These are non-standard, but are used in builtins.c$symbolic_umask() */
+ #define S_IRUGO		(S_IRUSR | S_IRGRP | S_IROTH)
+ #define S_IWUGO		(S_IWUSR | S_IWGRP | S_IWOTH)
++#if defined(S_IXUSR) && defined(S_IXOTH)
+ #define S_IXUGO		(S_IXUSR | S_IXGRP | S_IXOTH)
++#endif
+ 
+ #endif /* _POSIXSTAT_H_ */

--- a/sys-libs/readline/files/readline-7.0-missing-echo-proto.patch
+++ b/sys-libs/readline/files/readline-7.0-missing-echo-proto.patch
@@ -2,8 +2,8 @@ https://lists.gnu.org/archive/html/bug-readline/2016-11/msg00000.html
 
 fix from upstream
 
---- a/lib/readline/readline.h
-+++ b/lib/readline/readline.h
+--- a/readline.h
++++ b/readline.h
 @@ -413,6 +413,7 @@
  extern void rl_tty_set_default_bindings PARAMS((Keymap));
  extern void rl_tty_unset_default_bindings PARAMS((Keymap));

--- a/sys-libs/readline/readline-7.0_p3-r1.ebuild
+++ b/sys-libs/readline/readline-7.0_p3-r1.ebuild
@@ -1,0 +1,163 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit flag-o-matic multilib-minimal toolchain-funcs
+
+# Official patches
+# See ftp://ftp.cwru.edu/pub/bash/readline-7.0-patches/
+PLEVEL=${PV##*_p}
+MY_PV=${PV/_p*}
+MY_PV=${MY_PV/_/-}
+MY_P=${PN}-${MY_PV}
+[[ ${PV} != *_p* ]] && PLEVEL=0
+patches() {
+	[[ ${PLEVEL} -eq 0 ]] && return 1
+	local opt=$1
+	eval set -- {1..${PLEVEL}}
+	set -- $(printf "${PN}${MY_PV/\.}-%03d " "$@")
+	if [[ ${opt} == -s ]] ; then
+		echo "${@/#/${DISTDIR}/}"
+	else
+		local u
+		for u in ftp://ftp.cwru.edu/pub/bash mirror://gnu/${PN} ; do
+			printf "${u}/${PN}-${MY_PV}-patches/%s " "$@"
+		done
+	fi
+}
+
+DESCRIPTION="Another cute console display library"
+HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
+case ${PV} in
+*_alpha*|*_beta*|*_rc*) SRC_URI+=" ftp://ftp.cwru.edu/pub/bash/${MY_P}.tar.gz" ;;
+*) SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz $(patches)" ;;
+esac
+
+LICENSE="GPL-3"
+SLOT="0/7"  # subslot matches SONAME major
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux"
+IUSE="static-libs utils"
+
+RDEPEND=">=sys-libs/ncurses-5.9-r3:0=[static-libs?,${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+S=${WORKDIR}/${MY_P}
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.0-no_rpath.patch
+	"${FILESDIR}"/${PN}-6.2-rlfe-tgoto.patch #385091
+	"${FILESDIR}"/${PN}-7.0-headers.patch
+	"${FILESDIR}"/${PN}-7.0-missing-echo-proto.patch
+	"${FILESDIR}"/${PN}-7.0-mingw.patch
+)
+
+src_prepare() {
+	[[ ${PLEVEL} -gt 0 ]] && eapply -p0 $(patches -s)
+	default
+
+	# Force ncurses linking. #71420
+	# Use pkg-config to get the right values. #457558
+	local ncurses_libs=$($(tc-getPKG_CONFIG) ncurses --libs)
+	sed -i \
+		-e "/^SHLIB_LIBS=/s:=.*:='${ncurses_libs}':" \
+		support/shobj-conf || die
+	sed -i \
+		-e "/^[[:space:]]*LIBS=.-lncurses/s:-lncurses:${ncurses_libs}:" \
+		examples/rlfe/configure || die
+
+	# fix building under Gentoo/FreeBSD; upstream FreeBSD deprecated
+	# objformat for years, so we don't want to rely on that.
+	sed -i -e '/objformat/s:if .*; then:if true; then:' support/shobj-conf || die
+
+	ln -s ../.. examples/rlfe/readline || die # for local readline headers
+}
+
+src_configure() {
+	# fix implicit decls with widechar funcs
+	append-cppflags -D_GNU_SOURCE
+	# https://lists.gnu.org/archive/html/bug-readline/2010-07/msg00013.html
+	append-cppflags -Dxrealloc=_rl_realloc -Dxmalloc=_rl_malloc -Dxfree=_rl_free
+
+	# Make sure configure picks a better ar than `ar`. #484866
+	export ac_cv_prog_AR=$(tc-getAR)
+
+	# Force the test since we used sed above to force it.
+	export bash_cv_termcap_lib=ncurses
+
+	# Control cross-compiling cases when we know the right answer.
+	# In cases where the C library doesn't support wide characters, readline
+	# itself won't work correctly, so forcing the answer below should be OK.
+	if tc-is-cross-compiler ; then
+		use kernel_Winnt || export bash_cv_func_sigsetjmp='present'
+		export bash_cv_func_ctype_nonascii='yes'
+		export bash_cv_wcwidth_broken='no' #503312
+	fi
+
+	# This is for rlfe, but we need to make sure LDFLAGS doesn't change
+	# so we can re-use the config cache file between the two.
+	append-ldflags -L.
+
+	multilib-minimal_src_configure
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE=${S} \
+	econf \
+		--cache-file="${BUILD_DIR}"/config.cache \
+		--docdir='$(datarootdir)'/doc/${PF} \
+		--with-curses \
+		$(use_enable static-libs static)
+
+	if use utils && multilib_is_native_abi && ! tc-is-cross-compiler ; then
+		# code is full of AC_TRY_RUN()
+		mkdir -p examples/rlfe || die
+		cd examples/rlfe || die
+		ECONF_SOURCE=${S}/examples/rlfe \
+		econf --cache-file="${BUILD_DIR}"/config.cache
+	fi
+}
+
+multilib_src_compile() {
+	emake
+
+	if use utils && multilib_is_native_abi && ! tc-is-cross-compiler ; then
+		# code is full of AC_TRY_RUN()
+		cd examples/rlfe || die
+		local l
+		for l in readline history ; do
+			ln -s ../../shlib/lib${l}$(get_libname)* lib${l}$(get_libname) || die
+			ln -sf ../../lib${l}.a lib${l}.a || die
+		done
+		emake
+	fi
+}
+
+multilib_src_install() {
+	default
+
+	if multilib_is_native_abi ; then
+		gen_usr_ldscript -a readline history #4411
+
+		if use utils && ! tc-is-cross-compiler; then
+			dobin examples/rlfe/rlfe
+		fi
+	fi
+}
+
+multilib_src_install_all() {
+	HTML_DOCS="doc/history.html doc/readline.html doc/rluserman.html" einstalldocs
+	dodoc USAGE
+	docinto ps
+	dodoc doc/*.ps
+}
+pkg_preinst() {
+	# bug #29865
+	# Reappeared in #595324 with paludis so keeping this for now...
+	preserve_old_lib /$(get_libdir)/lib{history,readline}.so.{4,5,6}
+}
+
+pkg_postinst() {
+	preserve_old_lib_notify /$(get_libdir)/lib{history,readline}.so.{4,5,6}
+}


### PR DESCRIPTION
EAPI 6, patches reformatted to be -p1 (still usable for the older
ebuilds), upstreamish [patch](http://lists.gnu.org/archive/html/bug-readline/2018-01/msg00001.html) added to support mingw-w64.
`dohtml` changed to `HTML_DOCS einstalldocs`. Removed src_unpack as
unneeded (probably a holdover from a much older version).

Package-Manager: Portage-2.3.24, Repoman-2.3.6