### PR TITLE
 net-libs/loudmouth: Fix building with GCC-7 and revbump for EAPI-6

### DIFF
--- a/net-libs/loudmouth/files/loudmouth-1.5.3-gcc7.patch
+++ b/net-libs/loudmouth/files/loudmouth-1.5.3-gcc7.patch
@@ -1,0 +1,25 @@
+Bug: https://bugs.gentoo.org/618330
+Upstream commit: https://github.com/mcabber/loudmouth/commit/01fdfa0f5d1b8502b92d2e78d757e9b19661d054
+
+From 01fdfa0f5d1b8502b92d2e78d757e9b19661d054 Mon Sep 17 00:00:00 2001
+From: tmp170422 <tmp131110@ya.ru>
+Date: Sun, 14 May 2017 12:18:32 +0300
+Subject: [PATCH] An apparent typo
+
+---
+ loudmouth/lm-sasl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/loudmouth/lm-sasl.c b/loudmouth/lm-sasl.c
+index 00cf9b7..38cd88c 100644
+--- a/loudmouth/lm-sasl.c
++++ b/loudmouth/lm-sasl.c
+@@ -529,7 +529,7 @@ sasl_md5_prepare_response (LmSASL *sasl, GHashTable *challenge)
+     }
+ 
+     nonce = g_hash_table_lookup (challenge, "nonce");
+-    if (nonce == NULL || nonce == '\0') {
++    if (nonce == NULL || nonce[0] == '\0') {
+         g_log (LM_LOG_DOMAIN, LM_LOG_LEVEL_SASL,
+                "%s: server didn't provide a nonce in the challenge",
+                G_STRFUNC);

--- a/net-libs/loudmouth/loudmouth-1.5.3-r1.ebuild
+++ b/net-libs/loudmouth/loudmouth-1.5.3-r1.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools
+
+DESCRIPTION="Lightweight C Jabber library"
+HOMEPAGE="https://github.com/mcabber/loudmouth"
+SRC_URI="https://github.com/mcabber/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~ppc-macos"
+
+IUSE="asyncns ssl openssl static-libs test"
+
+# Automagic libidn dependency
+RDEPEND="
+	>=dev-libs/glib-2.16:2
+	net-dns/libidn
+	ssl? (
+		!openssl? ( >=net-libs/gnutls-1.4.0 )
+		openssl? ( dev-libs/openssl:0= )
+	)
+	asyncns? ( >=net-libs/libasyncns-0.3 )
+"
+DEPEND="${RDEPEND}
+	test? ( dev-libs/check )
+	virtual/pkgconfig
+	>=dev-util/gtk-doc-1
+	>=dev-util/gtk-doc-am-1
+"
+
+PATCHES=( "${FILESDIR}"/${P}-gcc7.patch )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myconf
+
+	if use ssl; then
+		if ! use openssl; then
+			myconf="${myconf} --with-ssl=gnutls"
+		else
+			myconf="${myconf} --with-ssl=openssl"
+		fi
+	else
+		myconf="${myconf} --with-ssl=no"
+	fi
+
+	econf \
+		$(use_enable static-libs static) \
+		$(use_with asyncns) \
+		${myconf}
+}

--- a/net-libs/loudmouth/loudmouth-1.5.3.ebuild
+++ b/net-libs/loudmouth/loudmouth-1.5.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -34,6 +34,7 @@ DEPEND="${RDEPEND}
 "
 
 src_prepare() {
+	epatch "${FILESDIR}"/${P}-gcc7.patch
 	eautoreconf
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/618330
Package-Manager: Portage-2.3.16, Repoman-2.3.6
Closes: https://bugs.gentoo.org/618330

GCC-7's stricter rules on `char` to pointer conversion/comparison and template parsing leads to another typo/bug being caught.

Fixed upstream: https://github.com/mcabber/loudmouth/commit/01fdfa0f5d1b8502b92d2e78d757e9b19661d054