### PR TITLE
net-im/ejabberd, net-mail/notmuch: use HTTPS

### DIFF
--- a/net-im/ejabberd/ejabberd-16.09.ebuild
+++ b/net-im/ejabberd/ejabberd-16.09.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ SSL_CERT_MANDATORY=1
 inherit eutils pam rebar ssl-cert systemd
 
 DESCRIPTION="Robust, scalable and extensible XMPP server"
-HOMEPAGE="http://www.ejabberd.im/ https://github.com/processone/ejabberd/"
-SRC_URI="http://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
+HOMEPAGE="https://www.ejabberd.im/ https://github.com/processone/ejabberd/"
+SRC_URI="https://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
 	-> ${P}.tar.gz"
 
 LICENSE="GPL-2"
@@ -264,7 +264,7 @@ pkg_postinst() {
 	if [[ ! ${REPLACING_VERSIONS} ]]; then
 		echo
 		elog "For configuration instructions, please see"
-		elog "  http://www.process-one.net/en/ejabberd/docs/"
+		elog "  https://docs.ejabberd.im/"
 		echo
 		if [[ " ${REPLACING_VERSIONS} " =~ \ 2\. ]]; then
 			ewarn "If you have used pubsub in ejabberd-2.* you may encounter issues after"

--- a/net-im/ejabberd/ejabberd-17.01-r2.ebuild
+++ b/net-im/ejabberd/ejabberd-17.01-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ SSL_CERT_MANDATORY=1
 inherit eutils pam rebar ssl-cert systemd
 
 DESCRIPTION="Robust, scalable and extensible XMPP server"
-HOMEPAGE="http://www.ejabberd.im/ https://github.com/processone/ejabberd/"
-SRC_URI="http://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
+HOMEPAGE="https://www.ejabberd.im/ https://github.com/processone/ejabberd/"
+SRC_URI="https://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
 	-> ${P}.tar.gz"
 
 LICENSE="GPL-2"
@@ -278,7 +278,7 @@ pkg_postinst() {
 	if [[ ! ${REPLACING_VERSIONS} ]]; then
 		echo
 		elog "For configuration instructions, please see"
-		elog "  http://www.process-one.net/en/ejabberd/docs/"
+		elog "  https://docs.ejabberd.im/"
 		echo
 		if [[ " ${REPLACING_VERSIONS} " =~ \ 2\. ]]; then
 			ewarn "If you have used pubsub in ejabberd-2.* you may encounter issues after"

--- a/net-im/ejabberd/ejabberd-17.04-r1.ebuild
+++ b/net-im/ejabberd/ejabberd-17.04-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ SSL_CERT_MANDATORY=1
 inherit eutils pam rebar ssl-cert systemd
 
 DESCRIPTION="Robust, scalable and extensible XMPP server"
-HOMEPAGE="http://www.ejabberd.im/ https://github.com/processone/ejabberd/"
-SRC_URI="http://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
+HOMEPAGE="https://www.ejabberd.im/ https://github.com/processone/ejabberd/"
+SRC_URI="https://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
 	-> ${P}.tar.gz"
 
 LICENSE="GPL-2"
@@ -279,7 +279,7 @@ pkg_postinst() {
 	if [[ ! ${REPLACING_VERSIONS} ]]; then
 		echo
 		elog "For configuration instructions, please see"
-		elog "  http://www.process-one.net/en/ejabberd/docs/"
+		elog "  https://docs.ejabberd.im/"
 		echo
 		if [[ " ${REPLACING_VERSIONS} " =~ \ 2\. ]]; then
 			ewarn "If you have used pubsub in ejabberd-2.* you may encounter issues after"

--- a/net-mail/notmuch/notmuch-0.23.7.ebuild
+++ b/net-mail/notmuch/notmuch-0.23.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit bash-completion-r1 elisp-common eutils flag-o-matic pax-utils \
 	distutils-r1 toolchain-funcs
 
 DESCRIPTION="Thread-based e-mail indexer, supporting quick search and tagging"
-HOMEPAGE="http://notmuchmail.org/"
+HOMEPAGE="https://notmuchmail.org/"
 SRC_URI="${HOMEPAGE%/}/releases/${P}.tar.gz
 	test? ( ${HOMEPAGE%/}/releases/test-databases/database-v1.tar.xz )"
 

--- a/net-mail/notmuch/notmuch-0.24.2.ebuild
+++ b/net-mail/notmuch/notmuch-0.24.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit bash-completion-r1 elisp-common eutils flag-o-matic pax-utils \
 	distutils-r1 toolchain-funcs
 
 DESCRIPTION="Thread-based e-mail indexer, supporting quick search and tagging"
-HOMEPAGE="http://notmuchmail.org/"
+HOMEPAGE="https://notmuchmail.org/"
 SRC_URI="${HOMEPAGE%/}/releases/${P}.tar.gz
 	test? ( ${HOMEPAGE%/}/releases/test-databases/database-v1.tar.xz )"
 

--- a/net-mail/notmuch/notmuch-0.25.1.ebuild
+++ b/net-mail/notmuch/notmuch-0.25.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit bash-completion-r1 elisp-common eutils flag-o-matic pax-utils \
 	distutils-r1 toolchain-funcs
 
 DESCRIPTION="Thread-based e-mail indexer, supporting quick search and tagging"
-HOMEPAGE="http://notmuchmail.org/"
+HOMEPAGE="https://notmuchmail.org/"
 SRC_URI="${HOMEPAGE%/}/releases/${P}.tar.gz
 	test? ( ${HOMEPAGE%/}/releases/test-databases/database-v1.tar.xz )"
 

--- a/net-mail/notmuch/notmuch-0.25.2.ebuild
+++ b/net-mail/notmuch/notmuch-0.25.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit bash-completion-r1 elisp-common eutils flag-o-matic pax-utils \
 	distutils-r1 toolchain-funcs
 
 DESCRIPTION="Thread-based e-mail indexer, supporting quick search and tagging"
-HOMEPAGE="http://notmuchmail.org/"
+HOMEPAGE="https://notmuchmail.org/"
 SRC_URI="${HOMEPAGE%/}/releases/${P}.tar.gz
 	test? ( ${HOMEPAGE%/}/releases/test-databases/database-v1.tar.xz )"
 

--- a/net-mail/notmuch/notmuch-0.25.3.ebuild
+++ b/net-mail/notmuch/notmuch-0.25.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit bash-completion-r1 elisp-common eutils flag-o-matic pax-utils \
 	distutils-r1 toolchain-funcs
 
 DESCRIPTION="Thread-based e-mail indexer, supporting quick search and tagging"
-HOMEPAGE="http://notmuchmail.org/"
+HOMEPAGE="https://notmuchmail.org/"
 SRC_URI="${HOMEPAGE%/}/releases/${P}.tar.gz
 	test? ( ${HOMEPAGE%/}/releases/test-databases/database-v1.tar.xz )"
 

--- a/net-mail/notmuch/notmuch-0.25.ebuild
+++ b/net-mail/notmuch/notmuch-0.25.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit bash-completion-r1 elisp-common eutils flag-o-matic pax-utils \
 	distutils-r1 toolchain-funcs
 
 DESCRIPTION="Thread-based e-mail indexer, supporting quick search and tagging"
-HOMEPAGE="http://notmuchmail.org/"
+HOMEPAGE="https://notmuchmail.org/"
 SRC_URI="${HOMEPAGE%/}/releases/${P}.tar.gz
 	test? ( ${HOMEPAGE%/}/releases/test-databases/database-v1.tar.xz )"
 


### PR DESCRIPTION
Hi,

This fixes 
net-im/ejabberd
net-mail/notmuch
to use https instead of http.

Please review.