### PR TITLE
net-dns/openresolv: use HTTPS

### DIFF
--- a/net-dns/openresolv/openresolv-3.8.1.ebuild
+++ b/net-dns/openresolv/openresolv-3.8.1.ebuild
@@ -4,8 +4,8 @@
 EAPI=6
 
 DESCRIPTION="A framework for managing DNS information"
-HOMEPAGE="http://roy.marples.name/projects/openresolv"
-SRC_URI="http://roy.marples.name/downloads/${PN}/${P}.tar.xz"
+HOMEPAGE="https://roy.marples.name/projects/openresolv"
+SRC_URI="https://roy.marples.name/downloads/${PN}/${P}.tar.xz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/net-dns/openresolv/openresolv-3.9.0.ebuild
+++ b/net-dns/openresolv/openresolv-3.9.0.ebuild
@@ -4,8 +4,8 @@
 EAPI=6
 
 DESCRIPTION="A framework for managing DNS information"
-HOMEPAGE="http://roy.marples.name/projects/openresolv"
-SRC_URI="http://roy.marples.name/downloads/${PN}/${P}.tar.xz"
+HOMEPAGE="https://roy.marples.name/projects/openresolv"
+SRC_URI="https://roy.marples.name/downloads/${PN}/${P}.tar.xz"
 
 LICENSE="BSD-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes net-dns/openresolv to use https instead of http.

Please review.