### PR TITLE
media-gfx/inkscape: Fix building with GCC-7

### DIFF
--- a/media-gfx/inkscape/files/inkscape-0.91-gcc7.patch
+++ b/media-gfx/inkscape/files/inkscape-0.91-gcc7.patch
@@ -1,0 +1,114 @@
+Bug: https://bugs.gentoo.org/618350
+Upstream Commit: https://gitlab.com/inkscape/inkscape/commit/3876176ec28cac3b70f0b330b760aaa561236ee7
+
+From 3876176ec28cac3b70f0b330b760aaa561236ee7 Mon Sep 17 00:00:00 2001
+From: Alex Valavanis <valavanisalex@gmail.com>
+Date: Sun, 5 Feb 2017 16:04:35 +0000
+Subject: [PATCH] Fix build with gcc 7
+
+(partial backport of 349536d49558ec5841e799eb33a4cbbb3fa9722d)
+
+Fixed bug:
+  - https://bugs.launchpad.net/inkscape/+bug/1660992
+---
+ src/ui/tools/flood-tool.cpp | 59 +++++++++++++++++++++++++++++++++++++++++------------------
+ 1 file changed, 41 insertions(+), 18 deletions(-)
+
+diff --git a/src/ui/tools/flood-tool.cpp b/src/ui/tools/flood-tool.cpp
+index 8ceaea2..9ebe390 100644
+--- a/src/ui/tools/flood-tool.cpp
++++ b/src/ui/tools/flood-tool.cpp
+@@ -21,6 +21,7 @@
+ #include "config.h"
+ #endif
+ 
++#include <cmath>
+ #include "trace/potrace/inkscape-potrace.h"
+ #include <2geom/pathvector.h>
+ #include <gdk/gdkkeysyms.h>
+@@ -196,6 +197,21 @@ inline unsigned char * get_trace_pixel(guchar *trace_px, int x, int y, int width
+ }
+ 
+ /**
++ * \brief Check whether two unsigned integers are close to each other
++ *
++ * \param[in] a The 1st unsigned int
++ * \param[in] b The 2nd unsigned int
++ * \param[in] d The threshold for comparison
++ *
++ * \return true if |a-b| <= d; false otherwise
++ */
++static bool compare_guint32(guint32 const a, guint32 const b, guint32 const d)
++{
++    const int difference = std::abs(static_cast<int>(a) - static_cast<int>(b));
++    return difference <= d;
++}
++
++/**
+  * Compare a pixel in a pixel buffer with another pixel to determine if a point should be included in the fill operation.
+  * @param check The pixel in the pixel buffer to check.
+  * @param orig The original selected pixel to use as the fill target color.
+@@ -206,7 +222,6 @@ inline unsigned char * get_trace_pixel(guchar *trace_px, int x, int y, int width
+  */
+ static bool compare_pixels(guint32 check, guint32 orig, guint32 merged_orig_pixel, guint32 dtc, int threshold, PaintBucketChannels method)
+ {
+-    int diff = 0;
+     float hsl_check[3] = {0,0,0}, hsl_orig[3] = {0,0,0};
+ 
+     guint32 ac = 0, rc = 0, gc = 0, bc = 0;
+@@ -232,27 +247,35 @@ static bool compare_pixels(guint32 check, guint32 orig, guint32 merged_orig_pixe
+     
+     switch (method) {
+         case FLOOD_CHANNELS_ALPHA:
+-            return abs(static_cast<int>(ac) - ao) <= threshold;
++            return compare_guint32(ac, ao, threshold);
+         case FLOOD_CHANNELS_R:
+-            return abs(static_cast<int>(ac ? unpremul_alpha(rc, ac) : 0) - (ao ? unpremul_alpha(ro, ao) : 0)) <= threshold;
++            return compare_guint32(ac ? unpremul_alpha(rc, ac) : 0,
++                                   ao ? unpremul_alpha(ro, ao) : 0,
++                                   threshold);
+         case FLOOD_CHANNELS_G:
+-            return abs(static_cast<int>(ac ? unpremul_alpha(gc, ac) : 0) - (ao ? unpremul_alpha(go, ao) : 0)) <= threshold;
++            return compare_guint32(ac ? unpremul_alpha(gc, ac) : 0,
++                                   ao ? unpremul_alpha(go, ao) : 0,
++                                   threshold);
+         case FLOOD_CHANNELS_B:
+-            return abs(static_cast<int>(ac ? unpremul_alpha(bc, ac) : 0) - (ao ? unpremul_alpha(bo, ao) : 0)) <= threshold;
++            return compare_guint32(ac ? unpremul_alpha(bc, ac) : 0,
++                                   ao ? unpremul_alpha(bo, ao) : 0,
++                                   threshold);
+         case FLOOD_CHANNELS_RGB:
+-            guint32 amc, rmc, bmc, gmc;
+-            //amc = 255*255 - (255-ac)*(255-ad); amc = (amc + 127) / 255;
+-            //amc = (255-ac)*ad + 255*ac; amc = (amc + 127) / 255;
+-            amc = 255; // Why are we looking at desktop? Cairo version ignores destop alpha
+-            rmc = (255-ac)*rd + 255*rc; rmc = (rmc + 127) / 255;
+-            gmc = (255-ac)*gd + 255*gc; gmc = (gmc + 127) / 255;
+-            bmc = (255-ac)*bd + 255*bc; bmc = (bmc + 127) / 255;
+-
+-            diff += abs(static_cast<int>(amc ? unpremul_alpha(rmc, amc) : 0) - (amop ? unpremul_alpha(rmop, amop) : 0));
+-            diff += abs(static_cast<int>(amc ? unpremul_alpha(gmc, amc) : 0) - (amop ? unpremul_alpha(gmop, amop) : 0));
+-            diff += abs(static_cast<int>(amc ? unpremul_alpha(bmc, amc) : 0) - (amop ? unpremul_alpha(bmop, amop) : 0));
+-            return ((diff / 3) <= ((threshold * 3) / 4));
+-        
++            {
++                guint32 amc, rmc, bmc, gmc;
++                //amc = 255*255 - (255-ac)*(255-ad); amc = (amc + 127) / 255;
++                //amc = (255-ac)*ad + 255*ac; amc = (amc + 127) / 255;
++                amc = 255; // Why are we looking at desktop? Cairo version ignores destop alpha
++                rmc = (255-ac)*rd + 255*rc; rmc = (rmc + 127) / 255;
++                gmc = (255-ac)*gd + 255*gc; gmc = (gmc + 127) / 255;
++                bmc = (255-ac)*bd + 255*bc; bmc = (bmc + 127) / 255;
++
++                int diff = 0; // The total difference between each of the 3 color components
++                diff += std::abs(static_cast<int>(amc ? unpremul_alpha(rmc, amc) : 0) - static_cast<int>(amop ? unpremul_alpha(rmop, amop) : 0));
++                diff += std::abs(static_cast<int>(amc ? unpremul_alpha(gmc, amc) : 0) - static_cast<int>(amop ? unpremul_alpha(gmop, amop) : 0));
++                diff += std::abs(static_cast<int>(amc ? unpremul_alpha(bmc, amc) : 0) - static_cast<int>(amop ? unpremul_alpha(bmop, amop) : 0));
++                return ((diff / 3) <= ((threshold * 3) / 4));
++            }
+         case FLOOD_CHANNELS_H:
+             return ((int)(fabs(hsl_check[0] - hsl_orig[0]) * 100.0) <= threshold);
+         case FLOOD_CHANNELS_S:
+--
+libgit2 0.26.0
+

--- a/media-gfx/inkscape/inkscape-0.91-r4.ebuild
+++ b/media-gfx/inkscape/inkscape-0.91-r4.ebuild
@@ -100,6 +100,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-0.91_pre3-sk-man.patch"
 	"${FILESDIR}/${PN}-0.48.4-epython.patch"
 	"${FILESDIR}/${PN}-0.91-fix-gtkmm-2.48.patch"
+	"${FILESDIR}/${PN}-0.91-gcc7.patch"
 )
 
 S=${WORKDIR}/${MY_P}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/618350
Closes: https://bugs.gentoo.org/618350
Closes: [#7632](https://github.com/gentoo/gentoo/pull/7632)
Package-Manager: Portage-2.3.16, Repoman-2.3.6

Patch taken from upstream commit: https://gitlab.com/inkscape/inkscape/commit/3876176ec28cac3b70f0b330b760aaa561236ee7