### PR TITLE
net-proxy/3proxy: use HTTPS

### DIFF
--- a/net-proxy/3proxy/3proxy-0.7.1.2.ebuild
+++ b/net-proxy/3proxy/3proxy-0.7.1.2.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit eutils
 
 DESCRIPTION="A really tiny cross-platform proxy servers set"
-HOMEPAGE="http://www.3proxy.ru/"
-SRC_URI="http://3proxy.ru/${PV}/${P}.tgz"
+HOMEPAGE="https://www.3proxy.ru/"
+SRC_URI="https://3proxy.ru/${PV}/${P}.tgz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~x86 ~amd64 ~ppc"

--- a/net-proxy/3proxy/3proxy-0.7.1.4.ebuild
+++ b/net-proxy/3proxy/3proxy-0.7.1.4.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit eutils
 
 DESCRIPTION="A really tiny cross-platform proxy servers set"
-HOMEPAGE="http://www.3proxy.ru/"
-SRC_URI="http://3proxy.ru/${PV}/${P}.tgz"
+HOMEPAGE="https://www.3proxy.ru/"
+SRC_URI="https://3proxy.ru/${PV}/${P}.tgz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~x86 ~amd64 ~ppc"

--- a/net-proxy/3proxy/3proxy-0.8.6.ebuild
+++ b/net-proxy/3proxy/3proxy-0.8.6.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit eutils
 
 DESCRIPTION="A really tiny cross-platform proxy servers set"
-HOMEPAGE="http://www.3proxy.ru/"
-SRC_URI="http://3proxy.ru/${PV}/${P}.tgz"
+HOMEPAGE="https://www.3proxy.ru/"
+SRC_URI="https://3proxy.ru/${PV}/${P}.tgz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~x86 ~amd64 ~ppc"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/651666
Package-Manager: Portage-2.3.24, Repoman-2.3.6