### PR TITLE
dev-util/lldb: Fix building with GCC-7

### DIFF
--- a/dev-util/lldb/files/4.0.1/0003-gcc7.patch
+++ b/dev-util/lldb/files/4.0.1/0003-gcc7.patch
@@ -1,0 +1,12 @@
+Bug: https://bugs.gentoo.org/620410
+
+--- a/include/lldb/Utility/TaskPool.h
++++ b/include/lldb/Utility/TaskPool.h
+@@ -28,6 +28,7 @@
+ 
+ #include <cassert>
+ #include <cstdint>
++#include <functional>
+ #include <future>
+ #include <list>
+ #include <queue>

--- a/dev-util/lldb/lldb-4.0.1.ebuild
+++ b/dev-util/lldb/lldb-4.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -60,6 +60,8 @@ src_prepare() {
 	eapply "${FILESDIR}"/4.0.1/0001-test-Fix-finding-LLDB-tools-when-building-stand-alon.patch
 	# fix compatibility with new libedit
 	eapply "${FILESDIR}"/4.0.1/0002-Fix-bug-28898.patch
+	# fix building with GCC-7
+	eapply "${FILESDIR}"/4.0.1/0003-gcc7.patch
 
 	eapply_user
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/620410
Closes: https://bugs.gentoo.org/620410
Closes: [#7639](https://github.com/gentoo/gentoo/pull/7639)
Package-Manager: Portage-2.3.16, Repoman-2.3.6

In GCC-7, transitive dependencies have changed with regard to the `<functional>` header and it is no longer included via `<memory>`, `<future>`, `<mutex>`, and `<regex>`.

Fixed in upstream for branch `release_50` and later.