### PR TITLE
media-gfx/videorbits: Fix for glibc-2.27

### DIFF
--- a/media-gfx/videorbits/files/videorbits-2.205-remove-bits-nan.patch
+++ b/media-gfx/videorbits/files/videorbits-2.205-remove-bits-nan.patch
@@ -1,0 +1,35 @@
+From 27db38e20d2f1c685c9a4aa01cfbde96b0555d80 Mon Sep 17 00:00:00 2001
+From: Harri Nieminen <moikkis@gmail.com>
+Date: Tue, 27 Mar 2018 19:45:19 +0300
+Subject: [PATCH] Don't include bits/nan.h
+
+---
+ src/cement.c     | 1 -
+ src/cementinit.c | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/src/cement.c b/src/cement.c
+index 3dfb6f9..23c424c 100644
+--- a/src/cement.c
++++ b/src/cement.c
+@@ -1,7 +1,6 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <math.h>
+-#include <bits/nan.h>
+ #include <limits.h>
+ #include <string.h>
+ #include <errno.h>
+diff --git a/src/cementinit.c b/src/cementinit.c
+index 95850d9..afa160e 100644
+--- a/src/cementinit.c
++++ b/src/cementinit.c
+@@ -1,5 +1,4 @@
+ #include <math.h>
+-#include <bits/nan.h>
+ /* NB:  supposedly nan.h is included from math.h when -std=c99 is on the
+  *      gcc compile line but that doesn't work so its included it directly.
+  *      Not having this line makes nan become unreliable, sometime it is
+-- 
+2.16.3
+

--- a/media-gfx/videorbits/videorbits-2.205-r1.ebuild
+++ b/media-gfx/videorbits/videorbits-2.205-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -26,6 +26,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-2.201-libpng15.patch"
 	"${FILESDIR}/${P}-qa-implicit-declarations.patch"
 	"${FILESDIR}/${P}-fix-buildsystem.patch"
+	"${FILESDIR}/${P}-remove-bits-nan.patch"
 )
 DOCS=( AUTHORS README README.MORE )
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/648770
Package-Manager: Portage-2.3.24, Repoman-2.3.6