### PR TITLE
dev-cpp/gtkmm: remove emul-linux-x86 references

### DIFF
--- a/dev-cpp/gtkmm/gtkmm-2.24.5.ebuild
+++ b/dev-cpp/gtkmm/gtkmm-2.24.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SLOT="2.4"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~x86-solaris"
 IUSE="doc examples test"
 
-COMMON_DEPEND="
+RDEPEND="
 	>=dev-cpp/glibmm-2.34.1:2[${MULTILIB_USEDEP}]
 	>=x11-libs/gtk+-2.24.15:2[${MULTILIB_USEDEP}]
 	>=x11-libs/gdk-pixbuf-2.28:2[${MULTILIB_USEDEP}]
@@ -22,12 +22,8 @@ COMMON_DEPEND="
 	>=dev-cpp/pangomm-2.34.0:1.4[${MULTILIB_USEDEP}]
 	>=dev-libs/libsigc++-2.3.2:2[${MULTILIB_USEDEP}]
 "
-RDEPEND="${COMMON_DEPEND}
-	abi_x86_32? (
-		!<=app-emulation/emul-linux-x86-gtkmmlibs-20140508
-		!app-emulation/emul-linux-x86-gtkmmlibs[-abi_x86_32(-)] )
-"
-DEPEND="${COMMON_DEPEND}
+
+DEPEND="${RDEPEND}
 	virtual/pkgconfig[${MULTILIB_USEDEP}]
 	doc? (
 		media-gfx/graphviz


### PR DESCRIPTION
Package-Manager: Portage-2.3.24, Repoman-2.3.6