### PR TITLE
dev-util/yuicompressor: drop maintainership

### DIFF
--- a/dev-util/yuicompressor/metadata.xml
+++ b/dev-util/yuicompressor/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>hydrapolic@gmail.com</email>
-		<name>Tomas Mozes</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">yui/yuicompressor</remote-id>
 	</upstream>


### PR DESCRIPTION
I don't use this package any more, so dropping to maintainer-needed.

Package-Manager: Portage-2.3.24, Repoman-2.3.6