### PR TITLE
app-cdr/cue2toc: EAPI bump

### DIFF
--- a/app-cdr/cue2toc/cue2toc-0.4.ebuild
+++ b/app-cdr/cue2toc/cue2toc-0.4.ebuild
@@ -1,18 +1,15 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 DESCRIPTION="Convert CUE files to cdrdao's TOC format"
 HOMEPAGE="http://cue2toc.sourceforge.net/"
 SRC_URI="mirror://sourceforge/cue2toc/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ppc64 ~sh ~sparc ~x86 ~x86-fbsd"
 IUSE=""
 
 DEPEND="!app-cdr/cdrdao"
-
-src_install() {
-	emake DESTDIR="${D}" install || die "emake install failed."
-	dodoc AUTHORS ChangeLog NEWS README
-}


### PR DESCRIPTION
Compiles fine.

Package-Manager: Portage-2.3.24, Repoman-2.3.6