### PR TITLE
dev-haskell/*: use HTTPS

### DIFF
--- a/dev-haskell/sendfile/sendfile-0.7.9.ebuild
+++ b/dev-haskell/sendfile/sendfile-0.7.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="A portable sendfile library"
-HOMEPAGE="http://hub.darcs.net/stepcut/sendfile"
+HOMEPAGE="https://hub.darcs.net/stepcut/sendfile"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/time-compat/time-compat-0.1.0.3.ebuild
+++ b/dev-haskell/time-compat/time-compat-0.1.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Compatibility with old-time for the time package"
-HOMEPAGE="http://hub.darcs.net/dag/time-compat"
+HOMEPAGE="https://hub.darcs.net/dag/time-compat"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/wai-app-static/wai-app-static-1.3.2.1.ebuild
+++ b/dev-haskell/wai-app-static/wai-app-static-1.3.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="WAI application for static serving"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wai-app-static/wai-app-static-2.0.0.3.ebuild
+++ b/dev-haskell/wai-app-static/wai-app-static-2.0.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="WAI application for static serving"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wai-app-static/wai-app-static-3.0.1.ebuild
+++ b/dev-haskell/wai-app-static/wai-app-static-3.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="bin lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="WAI application for static serving"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wai-app-static/wai-app-static-3.1.4.1.ebuild
+++ b/dev-haskell/wai-app-static/wai-app-static-3.1.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="bin lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="WAI application for static serving"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wai-app-static/wai-app-static-3.1.6.1.ebuild
+++ b/dev-haskell/wai-app-static/wai-app-static-3.1.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="bin lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="WAI application for static serving"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wai-test/wai-test-1.3.1.1.ebuild
+++ b/dev-haskell/wai-test/wai-test-1.3.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Unit test framework (built on HUnit) for WAI applications"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wai-test/wai-test-2.0.0.2.ebuild
+++ b/dev-haskell/wai-test/wai-test-2.0.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Unit test framework (built on HUnit) for WAI applications"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wai-test/wai-test-3.0.0.ebuild
+++ b/dev-haskell/wai-test/wai-test-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile"
 inherit haskell-cabal
 
 DESCRIPTION="Unit test framework (built on HUnit) for WAI applications. (deprecated)"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wavy/wavy-0.1.0.0.ebuild
+++ b/dev-haskell/wavy/wavy-0.1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="bin lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Process WAVE files in Haskell"
-HOMEPAGE="http://bitbucket.org/robertmassaioli/wavy"
+HOMEPAGE="https://bitbucket.org/robertmassaioli/wavy"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/xml-hamlet/xml-hamlet-0.4.0.11.ebuild
+++ b/dev-haskell/xml-hamlet/xml-hamlet-0.4.0.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Hamlet-style quasiquoter for XML content"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/xml-hamlet/xml-hamlet-0.4.0.12.ebuild
+++ b/dev-haskell/xml-hamlet/xml-hamlet-0.4.0.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Hamlet-style quasiquoter for XML content"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/yesod-core/yesod-core-1.2.7.ebuild
+++ b/dev-haskell/yesod-core/yesod-core-1.2.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Creation of type-safe, RESTful web applications"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-core/yesod-core-1.4.18.1.ebuild
+++ b/dev-haskell/yesod-core/yesod-core-1.4.18.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Creation of type-safe, RESTful web applications"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-core/yesod-core-1.4.20.2.ebuild
+++ b/dev-haskell/yesod-core/yesod-core-1.4.20.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Creation of type-safe, RESTful web applications"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-core/yesod-core-1.4.25.ebuild
+++ b/dev-haskell/yesod-core/yesod-core-1.4.25.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Creation of type-safe, RESTful web applications"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-core/yesod-core-1.4.31.ebuild
+++ b/dev-haskell/yesod-core/yesod-core-1.4.31.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Creation of type-safe, RESTful web applications"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-default/yesod-default-1.2.0.ebuild
+++ b/dev-haskell/yesod-default/yesod-default-1.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Default config and main functions for your yesod application (deprecated)"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-test/yesod-test-1.2.3.1.ebuild
+++ b/dev-haskell/yesod-test/yesod-test-1.2.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="integration testing for WAI/Yesod Applications"
-HOMEPAGE="http://www.yesodweb.com"
+HOMEPAGE="https://www.yesodweb.com"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-test/yesod-test-1.4.3.1.ebuild
+++ b/dev-haskell/yesod-test/yesod-test-1.4.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="integration testing for WAI/Yesod Applications"
-HOMEPAGE="http://www.yesodweb.com"
+HOMEPAGE="https://www.yesodweb.com"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-test/yesod-test-1.5.0.1.ebuild
+++ b/dev-haskell/yesod-test/yesod-test-1.5.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="integration testing for WAI/Yesod Applications"
-HOMEPAGE="http://www.yesodweb.com"
+HOMEPAGE="https://www.yesodweb.com"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-test/yesod-test-1.5.1.1.ebuild
+++ b/dev-haskell/yesod-test/yesod-test-1.5.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="integration testing for WAI/Yesod Applications"
-HOMEPAGE="http://www.yesodweb.com"
+HOMEPAGE="https://www.yesodweb.com"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-test/yesod-test-1.5.3.ebuild
+++ b/dev-haskell/yesod-test/yesod-test-1.5.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="integration testing for WAI/Yesod Applications"
-HOMEPAGE="http://www.yesodweb.com"
+HOMEPAGE="https://www.yesodweb.com"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-test/yesod-test-1.5.4.1.ebuild
+++ b/dev-haskell/yesod-test/yesod-test-1.5.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="integration testing for WAI/Yesod Applications"
-HOMEPAGE="http://www.yesodweb.com"
+HOMEPAGE="https://www.yesodweb.com"
 SRC_URI="mirror://hackage/packages/archive/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"


### PR DESCRIPTION
Hi,

This PR updates a few haskell packages to use https instead of http.

Please review.