### PR TITLE
app-misc/colordiff, dev-libs/tre: use HTTPS

### DIFF
--- a/app-misc/colordiff/colordiff-1.0.18.ebuild
+++ b/app-misc/colordiff/colordiff-1.0.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit prefix
 
 DESCRIPTION="Colorizes output of diff"
-HOMEPAGE="http://www.colordiff.org/"
-SRC_URI="http://www.colordiff.org/${P}.tar.gz"
+HOMEPAGE="https://www.colordiff.org/"
+SRC_URI="https://www.colordiff.org/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-libs/tre/tre-0.8.0-r1.ebuild
+++ b/dev-libs/tre/tre-0.8.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit multilib
 
 DESCRIPTION="Lightweight, robust, and efficient POSIX compliant regexp matching library"
-HOMEPAGE="http://laurikari.net/tre/ https://github.com/laurikari/tre/"
-SRC_URI="http://laurikari.net/tre/${P}.tar.bz2"
+HOMEPAGE="https://laurikari.net/tre/ https://github.com/laurikari/tre/"
+SRC_URI="https://laurikari.net/tre/${P}.tar.bz2"
 
 LICENSE="BSD-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

Two simple commits to fix the packages to use HTTPS instead of http.

Please review.