### PR TITLE
net-analyzer/zabbix: use HTTPS

### DIFF
--- a/net-analyzer/zabbix/zabbix-2.2.16.ebuild
+++ b/net-analyzer/zabbix/zabbix-2.2.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"

--- a/net-analyzer/zabbix/zabbix-2.2.21.ebuild
+++ b/net-analyzer/zabbix/zabbix-2.2.21.ebuild
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"

--- a/net-analyzer/zabbix/zabbix-3.0.14.ebuild
+++ b/net-analyzer/zabbix/zabbix-3.0.14.ebuild
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"

--- a/net-analyzer/zabbix/zabbix-3.2.10.ebuild
+++ b/net-analyzer/zabbix/zabbix-3.2.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"

--- a/net-analyzer/zabbix/zabbix-3.2.11.ebuild
+++ b/net-analyzer/zabbix/zabbix-3.2.11.ebuild
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"

--- a/net-analyzer/zabbix/zabbix-3.2.9.ebuild
+++ b/net-analyzer/zabbix/zabbix-3.2.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"

--- a/net-analyzer/zabbix/zabbix-3.4.5.ebuild
+++ b/net-analyzer/zabbix/zabbix-3.4.5.ebuild
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"

--- a/net-analyzer/zabbix/zabbix-3.4.6.ebuild
+++ b/net-analyzer/zabbix/zabbix-3.4.6.ebuild
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"

--- a/net-analyzer/zabbix/zabbix-3.4.7.ebuild
+++ b/net-analyzer/zabbix/zabbix-3.4.7.ebuild
@@ -8,10 +8,10 @@ WEBAPP_OPTIONAL="yes"
 inherit flag-o-matic webapp java-pkg-opt-2 user systemd toolchain-funcs
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
-HOMEPAGE="http://www.zabbix.com/"
+HOMEPAGE="https://www.zabbix.com/"
 MY_P=${P/_/}
 MY_PV=${PV/_/}
-SRC_URI="http://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
+SRC_URI="https://prdownloads.sourceforge.net/zabbix/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"


### PR DESCRIPTION
Hi,

This PR fixes the Zabbix package to use https instead of http.

Please review.