### PR TITLE
app-admin/packagekit-{base,gtk,qt}: fix HOMEPAGE, use HTTPS

### DIFF
--- a/app-admin/packagekit-base/packagekit-base-1.0.11.ebuild
+++ b/app-admin/packagekit-base/packagekit-base-1.0.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -14,7 +14,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Manage packages in a secure way using a cross-distro and cross-architecture API"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-base/packagekit-base-1.1.1.ebuild
+++ b/app-admin/packagekit-base/packagekit-base-1.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -14,7 +14,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Manage packages in a secure way using a cross-distro and cross-architecture API"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-base/packagekit-base-1.1.4.ebuild
+++ b/app-admin/packagekit-base/packagekit-base-1.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -14,7 +14,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Manage packages in a secure way using a cross-distro and cross-architecture API"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-base/packagekit-base-1.1.5-r2.ebuild
+++ b/app-admin/packagekit-base/packagekit-base-1.1.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -14,7 +14,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Manage packages in a secure way using a cross-distro and cross-architecture API"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-base/packagekit-base-1.1.7-r1.ebuild
+++ b/app-admin/packagekit-base/packagekit-base-1.1.7-r1.ebuild
@@ -14,7 +14,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Manage packages in a secure way using a cross-distro and cross-architecture API"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-gtk/packagekit-gtk-1.0.11.ebuild
+++ b/app-admin/packagekit-gtk/packagekit-gtk-1.0.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -9,7 +9,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Gtk3 PackageKit backend library"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-gtk/packagekit-gtk-1.1.1.ebuild
+++ b/app-admin/packagekit-gtk/packagekit-gtk-1.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,7 +9,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Gtk3 PackageKit backend library"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-gtk/packagekit-gtk-1.1.4.ebuild
+++ b/app-admin/packagekit-gtk/packagekit-gtk-1.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,7 +9,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Gtk3 PackageKit backend library"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-gtk/packagekit-gtk-1.1.5.ebuild
+++ b/app-admin/packagekit-gtk/packagekit-gtk-1.1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,7 +9,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Gtk3 PackageKit backend library"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-gtk/packagekit-gtk-1.1.7.ebuild
+++ b/app-admin/packagekit-gtk/packagekit-gtk-1.1.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,7 +9,7 @@ MY_PN="PackageKit"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Gtk3 PackageKit backend library"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://www.freedesktop.org/software/${MY_PN}/releases/${MY_P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/app-admin/packagekit-qt/packagekit-qt-1.0.0.ebuild
+++ b/app-admin/packagekit-qt/packagekit-qt-1.0.0.ebuild
@@ -8,7 +8,7 @@ MY_P=${MY_PN}-${PV}
 inherit cmake-utils
 
 DESCRIPTION="Qt PackageKit backend library"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://github.com/hughsie/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/app-admin/packagekit-qt/packagekit-qt-1.0.1.ebuild
+++ b/app-admin/packagekit-qt/packagekit-qt-1.0.1.ebuild
@@ -8,7 +8,7 @@ MY_P=${MY_PN}-${PV}
 inherit cmake-utils
 
 DESCRIPTION="Qt PackageKit backend library"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI="https://github.com/hughsie/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/app-admin/packagekit/packagekit-1.0.11-r1.ebuild
+++ b/app-admin/packagekit/packagekit-1.0.11-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="PackageKit Package Manager interface (meta package)"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI=""
 
 LICENSE="metapackage"

--- a/app-admin/packagekit/packagekit-1.1.1.ebuild
+++ b/app-admin/packagekit/packagekit-1.1.1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="PackageKit Package Manager interface (meta package)"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI=""
 
 LICENSE="metapackage"

--- a/app-admin/packagekit/packagekit-1.1.4.ebuild
+++ b/app-admin/packagekit/packagekit-1.1.4.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="PackageKit Package Manager interface (meta package)"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI=""
 
 LICENSE="metapackage"

--- a/app-admin/packagekit/packagekit-1.1.5.ebuild
+++ b/app-admin/packagekit/packagekit-1.1.5.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="PackageKit Package Manager interface (meta package)"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI=""
 
 LICENSE="metapackage"

--- a/app-admin/packagekit/packagekit-1.1.7.ebuild
+++ b/app-admin/packagekit/packagekit-1.1.7.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="PackageKit Package Manager interface (meta package)"
-HOMEPAGE="http://www.packagekit.org/"
+HOMEPAGE="https://www.freedesktop.org/software/PackageKit/"
 SRC_URI=""
 
 LICENSE="metapackage"


### PR DESCRIPTION
Hi,

This PR fixes the HOMEPAGE for packagekit-* packages and uses https instead of http.

Please review.