### PR TITLE
games-sports/torcs: Fix building with GCC-7

### DIFF
--- a/games-sports/torcs/files/torcs-1.3.6-gcc7.patch
+++ b/games-sports/torcs/files/torcs-1.3.6-gcc7.patch
@@ -1,0 +1,11 @@
+--- a/src/libs/musicplayer/OpenALMusicPlayer.cpp
++++ b/src/libs/musicplayer/OpenALMusicPlayer.cpp
+@@ -161,7 +161,7 @@
+ {
+ 	char pcm[BUFFERSIZE];
+ 	int size = 0;
+-	const char* error = '\0';
++	const char* error = "";
+ 	
+ 	if (!stream->read(pcm, BUFFERSIZE, &size, &error)) {
+ 		GfError("OpenALMusicPlayer: Stream read error: %s\n", error);

--- a/games-sports/torcs/torcs-1.3.6-r1.ebuild
+++ b/games-sports/torcs/torcs-1.3.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -34,6 +34,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-format.patch
 	"${FILESDIR}"/${P}-noXmuXt.patch
 	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${P}-gcc7.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/631542
Closes: https://bugs.gentoo.org/631542
Package-Manager: Portage-2.3.16, Repoman-2.3.6

GCC-7 doesn't allow implicit conversion from `char` to pointer.  The offending line is:
`const char* error = '\0';`

Debian already patches this [here](https://sources.debian.org/src/torcs/1.3.7+dfsg-4/debian/patches/gcc7.patch/) using `nullptr`, an inappropriate construct if building in c++98 mode.

Furthermore, examining the context of use:
`GfError("OpenALMusicPlayer: Stream read error: %s\n", error);`

`GfError` is a macro name for `printf`.  Since passing a `NULL` char pointer as a `printf` `%s` placeholder is undefined behavior, `error` should ideally be implemented as a real pointer pointing to an empty cstring.

Reported upstream: https://sourceforge.net/p/torcs/support-requests/13/

