### PR TITLE
dev-libs/libatomic_ops: Fix building with GCC-7

### DIFF
--- a/dev-libs/libatomic_ops/files/libatomic_ops-7.6.4-gcc7.patch
+++ b/dev-libs/libatomic_ops/files/libatomic_ops-7.6.4-gcc7.patch
@@ -1,0 +1,40 @@
+Upstream commit: https://github.com/ivmai/libatomic_ops/commit/759fa976432e4f09b4a436774fff7119da050042
+
+From 759fa976432e4f09b4a436774fff7119da050042 Mon Sep 17 00:00:00 2001
+From: Ivan Maidanski <ivmai@mail.ru>
+Date: Thu, 29 Mar 2018 01:42:38 +0300
+Subject: [PATCH] Fix 'undefined reference to __atomic_load/store/cas_16' error
+ (gcc-7/x64)
+
+Issue #34 (libatomic_ops).
+
+* src/atomic_ops/sysdeps/gcc/x86.h [!AO_DISABLE_GCC_ATOMICS
+&& !__APPLE_CC__ && !__clang__ && AO_GNUC_PREREQ(7, 0)
+&& !AO_PREFER_BUILTIN_ATOMICS && !AO_THREAD_SANITIZER
+&& !__MINGW32__] (AO_SKIPATOMIC_double_compare_and_swap_ANY,
+AO_SKIPATOMIC_DOUBLE_LOAD_STORE_ANY): Define macro; add comment.
+---
+ src/atomic_ops/sysdeps/gcc/x86.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/atomic_ops/sysdeps/gcc/x86.h b/src/atomic_ops/sysdeps/gcc/x86.h
+index d7c06c5..b4ca39f 100644
+--- a/src/atomic_ops/sysdeps/gcc/x86.h
++++ b/src/atomic_ops/sysdeps/gcc/x86.h
+@@ -67,7 +67,15 @@
+ #       define AO_SKIPATOMIC_DOUBLE_LOAD_STORE_ANY
+ #     endif
+ #   endif /* __x86_64__ */
+-# endif /* __clang__ */
++
++# elif AO_GNUC_PREREQ(7, 0) && !defined(AO_PREFER_BUILTIN_ATOMICS) \
++       && !defined(AO_THREAD_SANITIZER) && !defined(__MINGW32__)
++    /* gcc-7.x/x64 (gcc-7.2, at least) requires -latomic flag in case   */
++    /* of double-word atomic operations use (but not in case of TSan).  */
++    /* TODO: Revise it for the future gcc-7 releases. */
++#   define AO_SKIPATOMIC_double_compare_and_swap_ANY
++#   define AO_SKIPATOMIC_DOUBLE_LOAD_STORE_ANY
++# endif /* __GNUC__ && !__clang__ */
+ 
+ # ifdef AO_SKIPATOMIC_DOUBLE_LOAD_STORE_ANY
+ #   define AO_SKIPATOMIC_double_load

--- a/dev-libs/libatomic_ops/libatomic_ops-7.6.4.ebuild
+++ b/dev-libs/libatomic_ops/libatomic_ops-7.6.4.ebuild
@@ -14,6 +14,8 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
+PATCHES=( "${FILESDIR}"/${P}-gcc7.patch )
+
 multilib_src_configure() {
 	ECONF_SOURCE=${S} econf
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/638222
Package-Manager: Portage-2.3.16, Repoman-2.3.6

Due to [changes in compiler intrinsics in GCC-7](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878), libatomic_ops-7.6.4 fails to compile.

The patch is taken from upstream commit https://github.com/ivmai/libatomic_ops/commit/759fa976432e4f09b4a436774fff7119da050042. 

Also note that though the bug references libatomic_ops-7.6.0, it would be quite problematic to backport the patch to 7.6.0 given that the affected header file `src/atomic_ops/sysdeps/gcc/x86.h` has been substantially refactored since then.  The bug should probably remain open until libatomic_ops-7.6.4 is stabilized and libatomic_ops-7.6.0 removed.