### PR TITLE
media-libs/glm: Fix tests with GCC-7

### DIFF
--- a/media-libs/glm/files/glm-0.9.8.5-gcc7_tests.patch
+++ b/media-libs/glm/files/glm-0.9.8.5-gcc7_tests.patch
@@ -1,0 +1,70 @@
+Bug: https://bugs.gentoo.org/638312
+Upstream commit: https://github.com/g-truc/glm/commit/e37cf6e47fa4305c82845103b17af58f6cfe23db
+
+From e37cf6e47fa4305c82845103b17af58f6cfe23db Mon Sep 17 00:00:00 2001
+From: Christophe Riccio <christophe.riccio@unity3d.com>
+Date: Thu, 17 Aug 2017 00:08:37 +0200
+Subject: [PATCH] Fixed GCC 7.1.0 failing tests #666
+
+---
+ test/core/core_type_mat2x4.cpp | 4 +++-
+ test/core/core_type_mat3x4.cpp | 4 +++-
+ test/core/core_type_mat4x4.cpp | 3 ++-
+ 3 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/test/core/core_type_mat2x4.cpp b/test/core/core_type_mat2x4.cpp
+index 17afebf91..eea3e46f4 100644
+--- a/test/core/core_type_mat2x4.cpp
++++ b/test/core/core_type_mat2x4.cpp
+@@ -1,3 +1,5 @@
++#include <glm/gtc/epsilon.hpp>
++#include <glm/gtc/constants.hpp>
+ #include <glm/vector_relational.hpp>
+ #include <glm/mat2x2.hpp>
+ #include <glm/mat2x3.hpp>
+@@ -83,7 +85,7 @@ namespace cast
+ 		glm::mat2x4 Identity(1.0f);
+ 
+ 		for(glm::length_t i = 0, length = B.length(); i < length; ++i)
+-			Error += glm::all(glm::equal(B[i], Identity[i])) ? 0 : 1;
++			Error += glm::all(glm::epsilonEqual(B[i], Identity[i], glm::epsilon<float>())) ? 0 : 1;
+ 
+ 		return Error;
+ 	}
+diff --git a/test/core/core_type_mat3x4.cpp b/test/core/core_type_mat3x4.cpp
+index e3b78d31b..74a45d87a 100644
+--- a/test/core/core_type_mat3x4.cpp
++++ b/test/core/core_type_mat3x4.cpp
+@@ -1,3 +1,5 @@
++#include <glm/gtc/epsilon.hpp>
++#include <glm/gtc/constants.hpp>
+ #include <glm/vector_relational.hpp>
+ #include <glm/mat2x2.hpp>
+ #include <glm/mat2x3.hpp>
+@@ -87,7 +89,7 @@ namespace cast
+ 		glm::mat3x4 Identity(1.0f);
+ 
+ 		for(glm::length_t i = 0, length = B.length(); i < length; ++i)
+-			Error += glm::all(glm::equal(B[i], Identity[i])) ? 0 : 1;
++			Error += glm::all(glm::epsilonEqual(B[i], Identity[i], glm::epsilon<float>())) ? 0 : 1;
+ 
+ 		return Error;
+ 	}
+diff --git a/test/core/core_type_mat4x4.cpp b/test/core/core_type_mat4x4.cpp
+index 3966c2b7f..fd2aca8b4 100644
+--- a/test/core/core_type_mat4x4.cpp
++++ b/test/core/core_type_mat4x4.cpp
+@@ -1,3 +1,4 @@
++#include <glm/gtc/constants.hpp>
+ #include <glm/gtc/epsilon.hpp>
+ #include <glm/matrix.hpp>
+ #include <glm/mat2x2.hpp>
+@@ -263,7 +264,7 @@ namespace cast
+ 		glm::mat4x4 Identity(1.0f);
+ 
+ 		for(glm::length_t i = 0, length = B.length(); i < length; ++i)
+-			Error += glm::all(glm::equal(B[i], Identity[i])) ? 0 : 1;
++			Error += glm::all(glm::epsilonEqual(B[i], Identity[i], glm::epsilon<float>())) ? 0 : 1;
+ 
+ 		return Error;
+ 	}

--- a/media-libs/glm/glm-0.9.8.5-r1.ebuild
+++ b/media-libs/glm/glm-0.9.8.5-r1.ebuild
@@ -18,6 +18,7 @@ RDEPEND="virtual/opengl"
 
 PATCHES=(
 	"${FILESDIR}/glm-gcc73.patch"
+	"${FILESDIR}/${P}-gcc7_tests.patch"
 )
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/638312
Closes: https://bugs.gentoo.org/638312
Package-Manager: Portage-2.3.16, Repoman-2.3.6

Patch taken from upstream commit https://github.com/g-truc/glm/commit/e37cf6e47fa4305c82845103b17af58f6cfe23db.