### PR TITLE
app-i18n/scim: Fix building with GCC-7

### DIFF
--- a/app-i18n/scim/files/scim-1.4.17-gcc7.patch
+++ b/app-i18n/scim/files/scim-1.4.17-gcc7.patch
@@ -1,0 +1,26 @@
+Bug: https://bugs.gentoo.org/638368
+Upstream commit: https://github.com/scim-im/scim/commit/b32c2f93292a8145a23c35034bcc96d92fe79046
+
+From b32c2f93292a8145a23c35034bcc96d92fe79046 Mon Sep 17 00:00:00 2001
+From: Marguerite Su <i@marguerite.su>
+Date: Mon, 31 Jul 2017 02:38:23 +0000
+Subject: [PATCH] FTBFS with GCC-7: invalid conversion from 'char' to 'const
+ void*'. fixed debian#854654 opensuse#1041268
+
+---
+ extras/immodules/agent/scim-bridge-agent-signal-listener.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/extras/immodules/agent/scim-bridge-agent-signal-listener.cpp b/extras/immodules/agent/scim-bridge-agent-signal-listener.cpp
+index 88c5d34..c0ba7fd 100644
+--- a/extras/immodules/agent/scim-bridge-agent-signal-listener.cpp
++++ b/extras/immodules/agent/scim-bridge-agent-signal-listener.cpp
+@@ -64,7 +64,7 @@ static void sig_quit (int sig)
+ {
+     if (!signal_occurred) {
+         signal_occurred = true;
+-        send (pipe_in, '\0', sizeof (char), MSG_NOSIGNAL);
++        send (pipe_in, "", sizeof (char), MSG_NOSIGNAL);
+     }
+ }
+ 

--- a/app-i18n/scim/scim-1.4.17.ebuild
+++ b/app-i18n/scim/scim-1.4.17.ebuild
@@ -38,6 +38,8 @@ DOCS=(
 	docs/scim.cfg
 )
 
+PATCHES=( "${FILESDIR}"/${P}-gcc7.patch )
+
 src_prepare() {
 	default
 	eautoreconf


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/638368
Closes: https://bugs.gentoo.org/638368
Package-Manager: Portage-2.3.16, Repoman-2.3.6

Already fixed upstream for scim-1.4.18, this backports https://github.com/scim-im/scim/commit/b32c2f93292a8145a23c35034bcc96d92fe79046 for scim-1.4.17.