### PR TITLE
sci-electronics/kicad: keyword ~arm64

### DIFF
--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Alexey Korepanov <kaikaikai@yandex.ru> (31 Mar 2018)
+# Boost.Context can be built on arm64
+dev-libs/boost  -context
+
 # Michał Górny <mgorny@gentoo.org> (12 Mar 2018)
 # Requires masked net-misc/curl with libressl.
 dev-libs/libgit2 libressl

--- a/sci-electronics/electronics-menu/electronics-menu-1.0-r1.ebuild
+++ b/sci-electronics/electronics-menu/electronics-menu-1.0-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://geda.seul.org/dist/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 sparc x86 ~x86-macos"
+KEYWORDS="amd64 ~arm64 ppc ppc64 sparc x86 ~x86-macos"
 IUSE=""
 
 DEPEND=""

--- a/sci-electronics/kicad/kicad-4.0.7.ebuild
+++ b/sci-electronics/kicad/kicad-4.0.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -21,7 +21,7 @@ SRC_URI="https://launchpad.net/${PN}/${SERIES}/${PV}/+download/${P}.tar.xz
 
 LICENSE="GPL-2+ GPL-3+ Boost-1.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="debug doc examples github i18n libressl minimal +python"
 LANGS="bg ca cs de el es fi fr hu it ja ko nl pl pt ru sk sl sv zh-CN"
 for lang in ${LANGS} ; do


### PR DESCRIPTION
I am happily running gentoo on an arm64 laptop. I installed and used quite a lot of packages without ~arm64 or arm64 keywords. It would be good to have these packages keyworded. Following an advice on the forums https://forums.gentoo.org/viewtopic-t-1079200.html I plan to create a number of PRs. This is the first one, for kicad.

To keyword kicad it ~arm64, it is necessary to enable the `context` use flag for boost and to keyword electronics-menu.

