### PR TITLE
sys-apps/haveged: keyword ~arm64

### DIFF
--- a/sys-apps/haveged/haveged-1.9.2.ebuild
+++ b/sys-apps/haveged/haveged-1.9.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ SRC_URI="http://www.issihosts.com/haveged/${P}.tar.gz"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~ppc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~x86"
 IUSE="selinux"
 
 DEPEND=""


### PR DESCRIPTION
haveged works well on arm64. Repoman complains
```
sys-apps/haveged/haveged-1.9.2.ebuild: please migrate from 'autotools-utils'
```
but I leave this to the maintainers.