### PR TITLE
sys-apps/dstat: keyword ~arm64

### DIFF
--- a/net-wireless/python-wifi/python-wifi-0.5.0-r3.ebuild
+++ b/net-wireless/python-wifi/python-wifi-0.5.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ HOMEPAGE="https://pypi.python.org/pypi/python-wifi"
 SRC_URI="mirror://sourceforge/${PN}.berlios/${P}.tar.bz2"
 
 SLOT="0"
-KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86"
 LICENSE="LGPL-2.1 examples? ( GPL-2 )"
 IUSE="examples"
 

--- a/sys-apps/dstat/dstat-0.7.3.ebuild
+++ b/sys-apps/dstat/dstat-0.7.3.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/dagwieers/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm64 hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
 IUSE="wifi doc examples"
 REQUIRED_USE="wifi? ( ${PYTHON_REQUIRED_USE} )"
 


### PR DESCRIPTION
dstat works well on arm64. Keywording ~arm64 required keywording also net-wireless/python-wifi.

Repoman complains
```
net-wireless/python-wifi/python-wifi-0.5.0-r3.ebuild: DESCRIPTION is 97 characters (max 80)
```