### PR TITLE
app-editors/gummi: keyword ~arm64

### DIFF
--- a/app-editors/gummi/gummi-0.6.6-r1.ebuild
+++ b/app-editors/gummi/gummi-0.6.6-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/alexandervdm/${PN}/archive/${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE=""
 
 RDEPEND="


### PR DESCRIPTION
Gummi works fine on ~arm64. Please keyword.