### PR TITLE
app-arch/file-roller: keyword ~arm64

### DIFF
--- a/app-arch/file-roller/file-roller-3.24.1.ebuild
+++ b/app-arch/file-roller/file-roller-3.24.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/FileRoller"
 LICENSE="GPL-2+ CC-BY-SA-3.0"
 SLOT="0"
 IUSE="libnotify nautilus packagekit"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 
 # gdk-pixbuf used extensively in the source
 # cairo used in eggtreemultidnd.c


### PR DESCRIPTION
File-roller works fine on ~arm64. Please keyword.