### PR TITLE
 net-p2p/transmission: keyword ~arm64

### DIFF
--- a/net-libs/libnatpmp/libnatpmp-20150609.ebuild
+++ b/net-libs/libnatpmp/libnatpmp-20150609.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -10,7 +10,7 @@ SRC_URI="http://miniupnp.free.fr/files/download.php?file=${P}.tar.gz -> ${P}.tar
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
 IUSE="static-libs"
 
 src_prepare() {

--- a/net-p2p/transmission/transmission-2.93.ebuild
+++ b/net-p2p/transmission/transmission-2.93.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/transmission/transmission-releases/raw/master/${P}.t
 LICENSE="|| ( GPL-2 GPL-3 Transmission-OpenSSL-exception ) GPL-2 MIT"
 SLOT=0
 IUSE="ayatana gtk libressl lightweight systemd qt5 xfs"
-KEYWORDS="amd64 ~arm ~mips ppc ppc64 x86 ~x86-fbsd ~amd64-linux"
+KEYWORDS="amd64 ~arm ~arm64 ~mips ppc ppc64 x86 ~x86-fbsd ~amd64-linux"
 
 RDEPEND=">=dev-libs/libevent-2.0.10:=
 	!libressl? ( dev-libs/openssl:0= )


### PR DESCRIPTION
transmission works fine on ~arm64. Please keyword. Also the dependency libnatpmp.