### PR TITLE
net-misc/youtube-dl: keyword ~arm64

### DIFF
--- a/net-misc/youtube-dl/youtube-dl-2018.03.20.ebuild
+++ b/net-misc/youtube-dl/youtube-dl-2018.03.20.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://youtube-dl.org/downloads/${PV}/${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="+offensive test"
 
 RDEPEND="


### PR DESCRIPTION
youtube-dl works fine on ~arm64. Please keyword.