### PR TITLE
keyword pillow-4.3.0 and deps ~arm64

### DIFF
--- a/dev-python/olefile/olefile-0.44.ebuild
+++ b/dev-python/olefile/olefile-0.44.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/decalage2/${PN}/releases/download/v${PV}/${P}.tar.gz
 
 LICENSE="BSD-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc"
 
 RDEPEND=""

--- a/dev-python/pillow/pillow-4.3.0.ebuild
+++ b/dev-python/pillow/pillow-4.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,7 +17,7 @@ SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="HPND"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc examples imagequant jpeg2k lcms test tiff tk truetype webp zlib"
 
 REQUIRED_USE="test? ( tiff )"

--- a/media-gfx/libimagequant/libimagequant-2.11.7.ebuild
+++ b/media-gfx/libimagequant/libimagequant-2.11.7.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/ImageOptim/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="GPL-3"
 SLOT="0/0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="cpu_flags_x86_sse2 debug openmp static-libs"
 
 DEPEND=""


### PR DESCRIPTION
Bring dev-python/pillow-4.3.0 to ~arm64.
Keeping up with ~amd64