### PR TITLE
app-accessibility/epos: Fix building with GCC-7

### DIFF
--- a/app-accessibility/epos/epos-2.5.37-r2.ebuild
+++ b/app-accessibility/epos/epos-2.5.37-r2.ebuild
@@ -23,6 +23,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.5.37-gcc45.patch
 	"${FILESDIR}"/${PN}-2.5.37-gcc47.patch
 	"${FILESDIR}"/${PN}-2.5.37-disable-tests.patch
+	"${FILESDIR}"/${PN}-2.5.37-gcc7.patch
 )
 
 src_prepare() {

--- a/app-accessibility/epos/files/epos-2.5.37-gcc7.patch
+++ b/app-accessibility/epos/files/epos-2.5.37-gcc7.patch
@@ -1,0 +1,22 @@
+Bug: https://bugs.gentoo.org/638596
+
+--- a/src/nnet/matrix.cc
++++ b/src/nnet/matrix.cc
+@@ -63,7 +63,7 @@
+ template<class T> void CMatrix<T>::multiplyByTransponed (const CMatrix &y, CMatrix &retval)
+ {
+ 	int i,j,k;
+-	assert (cols == y.cols);
++	this->assert (cols == y.cols);
+ 	if (cols != y.cols) { retval.Realloc (0,0); return; }
+ 
+ 	T sum;
+@@ -80,7 +80,7 @@
+ template<class T> void CMatrix<T>::transponedMultiply (const CMatrix &y, CMatrix &retval)
+ {
+ 	int i,j,k;
+-	assert (rows == y.rows);
++	this->assert (rows == y.rows);
+ 	if (rows != y.rows) { retval.Realloc (0,0); return; }
+ 
+ 	T sum;


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/638596
Closes: https://bugs.gentoo.org/638596
Package-Manager: Portage-2.3.16, Repoman-2.3.6

GCC-7 is stricter about template parsing rules and requires that declarations independent of template parameters be available before instantiation.  Other non-affected methods of `CMatrix<T>` call `this->assert` instead of `assert` so it's trivial simple to modify affected calls to `assert` with `this->` to overtly state its dependence on the template-expanded type.

Upstream has no issue tracker for submission.