### PR TITLE
media-gfx/dawn: EAPI-6 revbump and fix building with GCC-7

### DIFF
--- a/media-gfx/dawn/dawn-3.90b-r1.ebuild
+++ b/media-gfx/dawn/dawn-3.90b-r1.ebuild
@@ -25,7 +25,10 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/${MYP}"
 
-PATCHES=( "${FILESDIR}"/${P}-no-interactive.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-no-interactive.patch
+	"${FILESDIR}"/${P}-gcc7.patch
+)
 
 src_prepare() {
 	default

--- a/media-gfx/dawn/dawn-3.90b-r1.ebuild
+++ b/media-gfx/dawn/dawn-3.90b-r1.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit toolchain-funcs versionator
+
+MYP=${PN}_$(replace_version_separator 1 _)
+
+DESCRIPTION="3D geometrical postscript renderer"
+HOMEPAGE="http://geant4.kek.jp/~tanaka/DAWN/About_DAWN.html"
+SRC_URI="http://geant4.kek.jp/~tanaka/src/${MYP}.tgz"
+
+LICENSE="public-domain"
+SLOT="0"
+
+KEYWORDS="~amd64 ~hppa ~ppc ~x86"
+IUSE="doc opengl X"
+
+RDEPEND="dev-lang/tk:*
+	X? ( x11-libs/libX11 )
+	opengl? ( virtual/opengl )"
+DEPEND="${RDEPEND}
+	app-shells/tcsh
+	doc? ( virtual/latex-base )"
+
+S="${WORKDIR}/${MYP}"
+
+PATCHES=( "${FILESDIR}"/${P}-no-interactive.patch )
+
+src_prepare() {
+	default
+
+	sed -i -e "s/\$(LIB_DIR)/\$(LDFLAGS) &/" \
+		-e '/strip/d' Makefile*in || die
+
+	if use X; then
+		mv -f "${S}"/configure_xwin "${S}"/configure || die
+	fi
+
+	tc-export CXX
+}
+
+src_install() {
+	dodir /usr/bin
+
+	if use doc; then
+		pdflatex DOC/G4PRIM_FORMAT_24.tex || die "pdf generation failed"
+		DOCS=( README.txt DOC/*.pdf )
+		HTML_DOCS=( DOC/*.html )
+	fi
+
+	default
+}

--- a/media-gfx/dawn/dawn-3.90b.ebuild
+++ b/media-gfx/dawn/dawn-3.90b.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=2
@@ -27,6 +27,7 @@ S="${WORKDIR}/${MYP}"
 
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-no-interactive.patch
+	epatch "${FILESDIR}"/${P}-gcc7.patch
 	sed -i -e "s/\$(LIB_DIR)/\$(LDFLAGS) &/" \
 		-e '/strip/d' Makefile*in || die
 }

--- a/media-gfx/dawn/files/dawn-3.90b-gcc7.patch
+++ b/media-gfx/dawn/files/dawn-3.90b-gcc7.patch
@@ -1,0 +1,21 @@
+Bug: https://bugs.gentoo.org/638616
+
+--- a/FRString.h
++++ b/FRString.h
+@@ -137,13 +137,13 @@
+ 	char*  p = m_string ;
+ 	
+ 	// skip first blank if any
+-	while(  isspace(*p) && p != '\0' ) {p++;} 
++	while(  isspace(*p) && *p != '\0' ) {p++;}
+ 
+ 	// skip one word
+-	while( !isspace(*p) && p != '\0' ) {p++;} 
++	while( !isspace(*p) && *p != '\0' ) {p++;}
+ 
+ 	// skip second blank if any
+-	while(  isspace(*p) && p != '\0' ) {p++;} 
++	while(  isspace(*p) && *p != '\0' ) {p++;}
+ 
+ 	// reset string
+ 	strcpy( tmp, p  );

--- a/media-gfx/dawn/files/dawn-3.90b-no-interactive.patch
+++ b/media-gfx/dawn/files/dawn-3.90b-no-interactive.patch
@@ -1,5 +1,5 @@
---- configure_xwin.orig	2008-04-02 22:58:44.973465484 +0100
-+++ configure_xwin	2008-04-03 00:02:15.950190359 +0100
+--- a/configure_xwin
++++ b/configure_xwin
 @@ -16,17 +16,17 @@
  #----- C++ compiler name
  echo "Input C++ compiler name (e.g. g++, no default)."
@@ -87,8 +87,8 @@
  echo ""                                                >> Makefile
  
  echo "### Socket libraries to be linked "              >> Makefile
---- FRSocketMacro.h.orig	2008-04-02 23:58:51.126518123 +0100
-+++ FRSocketMacro.h	2008-04-02 23:59:03.443220012 +0100
+--- a/FRSocketMacro.h
++++ b/FRSocketMacro.h
 @@ -14,8 +14,8 @@
  #elif defined SOCKET_REDHAT61
  	#define         CLIENT_ADDR_LENGTH    socklen_t
@@ -100,8 +100,8 @@
  #endif
  
  	//----- gethostname
---- configure.orig	2010-08-21 14:22:18.000000000 +0100
-+++ configure	2010-09-23 05:57:02.000000000 +0100
+--- a/configure
++++ b/configure
 @@ -13,22 +13,22 @@
  #----- C++ compiler name
  echo "Input C++ compiler name (e.g. g++, no default)."


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/638616
Closes: https://bugs.gentoo.org/638616
Package-Manager: Portage-2.3.16, Repoman-2.3.6

GCC-7 doesn't allow implicit conversion or comparison between integral and pointer types.   The context demonstrates the intent is to check for a terminating nul character but the char pointer wasn't properly dereferenced.

Upstream doesn't have a means of bug submission and last activity was in 2011.