### PR TITLE
app-i18n/fbterm: fix file collision with sys-libs/ncurses-6.1

### DIFF
--- a/app-i18n/fbterm/fbterm-1.7-r4.ebuild
+++ b/app-i18n/fbterm/fbterm-1.7-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -14,11 +14,13 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 IUSE="gpm video_cards_vesa"
 
-RDEPEND="media-libs/fontconfig
+COMMON_DEPEND="media-libs/fontconfig
 	media-libs/freetype:2
 	gpm? ( sys-libs/gpm )
 	video_cards_vesa? ( dev-libs/libx86 )"
-DEPEND="${RDEPEND}
+RDEPEND="${COMMON_DEPEND}
+	!>=sys-libs/ncurses-6.1"
+DEPEND="${COMMON_DEPEND}
 	sys-libs/ncurses
 	virtual/pkgconfig"
 

--- a/app-i18n/fbterm/fbterm-1.7-r5.ebuild
+++ b/app-i18n/fbterm/fbterm-1.7-r5.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+inherit autotools fcaps
+
+DESCRIPTION="Fast terminal emulator for the Linux framebuffer"
+HOMEPAGE="https://code.google.com/p/fbterm"
+SRC_URI="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/${PN}/${P}.0.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+IUSE="gpm video_cards_vesa"
+
+RDEPEND="media-libs/fontconfig
+	media-libs/freetype:2
+	gpm? ( sys-libs/gpm )
+	video_cards_vesa? ( dev-libs/libx86 )
+	>=sys-libs/ncurses-6.1"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-gcc6.patch
+	"${FILESDIR}"/${PN}-noterminfo.patch
+)
+
+FILECAPS=(
+	cap_sys_tty_config+ep usr/bin/${PN}
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable gpm) \
+		$(use_enable video_cards_vesa vesa)
+}
+
+src_install() {
+	default
+
+	use filecaps || fperms u+s /usr/bin/${PN}
+}
+
+pkg_postinst() {
+	fcaps_pkg_postinst
+
+	elog "${PN} won't work with vga16fb. You have to use other native"
+	elog "framebuffer drivers or vesa driver."
+	elog "See ${EPREFIX}/usr/share/doc/${P}/README for details."
+	elog
+	elog "To use ${PN}, ensure you are in video group."
+}

--- a/app-i18n/fbterm/files/fbterm-noterminfo.patch
+++ b/app-i18n/fbterm/files/fbterm-noterminfo.patch
@@ -1,0 +1,15 @@
+commit 77c90022233634a3c891dc778585c526d9d846a1
+Author: Alexey Sokolov <sokolov@google.com>
+Date:   Sun Apr 1 11:33:20 2018 +0100
+
+    Don't install terminfo: ncurses-6.1 supports fbterm itself
+
+    https://bugs.gentoo.org/648472
+
+diff --git a/Makefile.am b/Makefile.am
+index 10814b6..8adcd57 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1 +1 @@
+-SUBDIRS = src im terminfo doc
++SUBDIRS = src im doc


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/648472