### PR TITLE
profiles/arch/amd64-fbsd/clang/package.use.force: add dev-libs/libgcrypt

### DIFF
--- a/profiles/arch/amd64-fbsd/clang/package.use.force
+++ b/profiles/arch/amd64-fbsd/clang/package.use.force
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 # Force building libc++ over libcxxrt.
@@ -14,3 +14,7 @@ net-misc/curl ssl curl_ssl_openssl
 
 # We obviously need clang
 sys-devel/llvm clang static-analyzer default-compiler-rt default-libcxx
+
+# o-flag-munging is required to compile dev-libs/libgcrypt with clang.
+# https://bugs.gentoo.org/629410
+dev-libs/libgcrypt o-flag-munging


### PR DESCRIPTION
If you are using CC=clang, it requires the local flag, "o-flag-munging" to pass a compile phase.
Please add it to package.use.force because the clang is the default compiler in the clang profile.

Thanks.