### PR TITLE
net-misc/aria2: fix libuv version depend

### DIFF
--- a/net-misc/aria2/aria2-1.33.1.ebuild
+++ b/net-misc/aria2/aria2-1.33.1.ebuild
@@ -29,7 +29,7 @@ CDEPEND="sys-libs/zlib:0=
 			nettle? ( >=dev-libs/nettle-2.4:0=[gmp] >=dev-libs/gmp-6:0= )
 			!nettle? ( >=dev-libs/libgcrypt-1.2.2:0= ) ) )
 	jemalloc? ( dev-libs/jemalloc )
-	libuv? ( dev-libs/libuv:0= )
+	libuv? ( >=dev-libs/libuv-1.13:0= )
 	metalink? (
 		libxml2? ( >=dev-libs/libxml2-2.6.26:2= )
 		!libxml2? ( dev-libs/expat:0= ) )


### PR DESCRIPTION
aria2-1.33 requires >=libuv-1.13 which is not stable.
Thus dropping keyword for now.

Package-Manager: Portage-2.3.24, Repoman-2.3.6