### PR TITLE
app-admin/syslog-ng: fix building with automake 1.16

### DIFF
--- a/app-admin/syslog-ng/files/patches/syslog-ng-3.14.1-fix-automake-1.16-build.patch
+++ b/app-admin/syslog-ng/files/patches/syslog-ng-3.14.1-fix-automake-1.16-build.patch
@@ -1,0 +1,23 @@
+From 41dd64e7b11d527f8f3cc6ae13067d0225191538 Mon Sep 17 00:00:00 2001
+From: kokan <peter.kokai@balabit.com>
+Date: Sat, 31 Mar 2018 15:36:08 +0200
+Subject: [PATCH] libsyslog-ng: missing dependency libsecret-storage
+
+Signed-off-by: kokan <peter.kokai@balabit.com>
+---
+ lib/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+index af2f44ece2..4a0b11c92f 100644
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -47,7 +47,7 @@ lib_libsyslog_ng_la_LDFLAGS		= -no-undefined -release ${LSNG_RELEASE} \
+ 
+ lib_test_subdirs			= lib_filter lib_logproto lib_parser lib_rewrite lib_template lib_stats lib_control
+ 
+-lib_libsyslog_ng_la_DEPENDENCIES	= lib/eventlog/src/libevtlog.la
++lib_libsyslog_ng_la_DEPENDENCIES       = lib/eventlog/src/libevtlog.la lib/secret-storage/libsecret-storage.la
+ 
+ if IVYKIS_INTERNAL
+ lib_libsyslog_ng_la_DEPENDENCIES	+= lib/ivykis/src/libivykis.la

--- a/app-admin/syslog-ng/syslog-ng-3.14.1.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-3.14.1.ebuild
@@ -45,6 +45,7 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}/patches/${PN}-3.14.1-fix-tls-client.patch"
+	"${FILESDIR}/patches/${PN}-3.14.1-fix-automake-1.16-build.patch"
 )
 
 DOCS=( AUTHORS NEWS.md CONTRIBUTING.md contrib/syslog-ng.conf.{HP-UX,RedHat,SunOS,doc}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/650172
Package-Manager: Portage-2.3.26, Repoman-2.3.7