### PR TITLE
app-editors/bluefish: migrate from fdo-mime eclass.

### DIFF
--- a/app-editors/bluefish/bluefish-2.2.10.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.10.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit autotools eutils gnome2-utils python-single-r1 xdg-utils
+inherit autotools gnome2-utils python-single-r1 xdg-utils
 
 MY_P=${P/_/-}
 
@@ -77,7 +77,7 @@ src_configure() {
 
 src_install() {
 	default
-	prune_libtool_files
+	find "${ED}" -name '*.la' -delete || die
 }
 
 pkg_preinst() {

--- a/app-editors/bluefish/bluefish-2.2.10.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.10.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit autotools eutils fdo-mime python-single-r1
+inherit autotools eutils gnome2-utils python-single-r1 xdg-utils
 
 MY_P=${P/_/-}
 
@@ -80,9 +80,14 @@ src_install() {
 	prune_libtool_files
 }
 
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 
 	einfo "Adding XML catalog entries..."
 	/usr/bin/xmlcatalog  --noout \
@@ -94,8 +99,9 @@ pkg_postinst() {
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	einfo "Removing XML catalog entries..."
 	/usr/bin/xmlcatalog  --noout \
 		--del 'Bluefish/DTD/Bflang' \

--- a/app-editors/bluefish/bluefish-2.2.6.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.6.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils gnome2-utils python-single-r1 xdg-utils
+inherit gnome2-utils python-single-r1 xdg-utils
 
 MY_P=${P/_/-}
 
@@ -35,7 +35,7 @@ DEPEND="${RDEPEND}
 		dev-util/intltool
 	)"
 
-S=${WORKDIR}/${MY_P}
+S="${WORKDIR}/${MY_P}"
 
 # there actually is just some broken manpage checkup -> not bother
 RESTRICT="test"
@@ -60,7 +60,7 @@ src_configure() {
 
 src_install() {
 	default
-	find "${ED}" -name '*.la' -exec rm -f {} +
+	find "${ED}" -name '*.la' -delete || die
 }
 
 pkg_preinst() {

--- a/app-editors/bluefish/bluefish-2.2.6.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.6.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils fdo-mime python-single-r1
+inherit eutils gnome2-utils python-single-r1 xdg-utils
 
 MY_P=${P/_/-}
 
@@ -63,9 +63,14 @@ src_install() {
 	find "${ED}" -name '*.la' -exec rm -f {} +
 }
 
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 
 	einfo "Adding XML catalog entries..."
 	/usr/bin/xmlcatalog  --noout \
@@ -77,8 +82,9 @@ pkg_postinst() {
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	einfo "Removing XML catalog entries..."
 	/usr/bin/xmlcatalog  --noout \
 		--del 'Bluefish/DTD/Bflang' \

--- a/app-editors/bluefish/bluefish-2.2.8.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.8.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils fdo-mime python-single-r1
+inherit eutils gnome2-utils python-single-r1 xdg-utils
 
 MY_P=${P/_/-}
 
@@ -74,9 +74,14 @@ src_install() {
 	prune_libtool_files
 }
 
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 
 	einfo "Adding XML catalog entries..."
 	/usr/bin/xmlcatalog  --noout \
@@ -88,8 +93,9 @@ pkg_postinst() {
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	einfo "Removing XML catalog entries..."
 	/usr/bin/xmlcatalog  --noout \
 		--del 'Bluefish/DTD/Bflang' \

--- a/app-editors/bluefish/bluefish-2.2.8.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.8.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils gnome2-utils python-single-r1 xdg-utils
+inherit gnome2-utils python-single-r1 xdg-utils
 
 MY_P=${P/_/-}
 
@@ -71,7 +71,7 @@ src_configure() {
 
 src_install() {
 	default
-	prune_libtool_files
+	find "${ED}" -name '*.la' -delete || die
 }
 
 pkg_preinst() {

--- a/app-editors/bluefish/bluefish-2.2.9.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.9.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit autotools eutils gnome2-utils python-single-r1 xdg-utils
+inherit autotools gnome2-utils python-single-r1 xdg-utils
 
 MY_P=${P/_/-}
 
@@ -77,7 +77,7 @@ src_configure() {
 
 src_install() {
 	default
-	prune_libtool_files
+	find "${ED}" -name '*.la' -delete || die
 }
 
 pkg_preinst() {

--- a/app-editors/bluefish/bluefish-2.2.9.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.9.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit autotools eutils fdo-mime python-single-r1
+inherit autotools eutils gnome2-utils python-single-r1 xdg-utils
 
 MY_P=${P/_/-}
 
@@ -80,9 +80,14 @@ src_install() {
 	prune_libtool_files
 }
 
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 
 	einfo "Adding XML catalog entries..."
 	/usr/bin/xmlcatalog  --noout \
@@ -94,8 +99,9 @@ pkg_postinst() {
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	einfo "Removing XML catalog entries..."
 	/usr/bin/xmlcatalog  --noout \
 		--del 'Bluefish/DTD/Bflang' \


### PR DESCRIPTION
Also removed eutils/prune_libtool_files and added gnome2-utils,
bumped EAPI on 2.2.6

Package-Manager: Portage-2.3.27, Repoman-2.3.9