### PR TITLE
app-editors/leafpad: fdo-mime migration

### DIFF
--- a/app-editors/leafpad/files/leafpad-0.8.18.1-fdo.patch
+++ b/app-editors/leafpad/files/leafpad-0.8.18.1-fdo.patch
@@ -5,8 +5,8 @@ does not have a semicolon (';') as trailing character
 
 leafpad.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
 
---- data/leafpad.desktop.in
-+++ data/leafpad.desktop.in
+--- a/data/leafpad.desktop.in
++++ b/data/leafpad.desktop.in
 @@ -1,10 +1,9 @@
  [Desktop Entry]
 -Encoding=UTF-8

--- a/app-editors/leafpad/files/leafpad-0.8.18.1-format-security.patch
+++ b/app-editors/leafpad/files/leafpad-0.8.18.1-format-security.patch
@@ -1,7 +1,7 @@
 - dialog.c:39:3: error: format not a string literal and no format arguments [-Werror=format-security]
 
---- src/dialog.c
-+++ src/dialog.c
+--- a/src/dialog.c
++++ b/src/dialog.c
 @@ -36,6 +36,7 @@
  		GTK_DIALOG_DESTROY_WITH_PARENT,
  		type,
@@ -18,8 +18,8 @@
  		str);
  	gtk_window_set_resizable(GTK_WINDOW(dialog), FALSE);
  	gtk_dialog_add_buttons(GTK_DIALOG(dialog),
---- src/gtkprint.c
-+++ src/gtkprint.c
+--- a/src/gtkprint.c
++++ b/src/gtkprint.c
 @@ -165,6 +165,7 @@
  		GTK_DIALOG_DESTROY_WITH_PARENT,
  		GTK_MESSAGE_ERROR,

--- a/app-editors/leafpad/leafpad-0.8.18.1.ebuild
+++ b/app-editors/leafpad/leafpad-0.8.18.1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils fdo-mime gnome2-utils
+EAPI=6
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="A simple GTK2 text editor"
 HOMEPAGE="http://tarot.freeshell.org/leafpad/"
@@ -22,11 +23,10 @@ DEPEND="${RDEPEND}
 
 DOCS="AUTHORS ChangeLog NEWS README"
 
-src_prepare() {
-	epatch \
-		"${FILESDIR}"/${P}-fdo.patch \
-		"${FILESDIR}"/${P}-format-security.patch
-}
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.8.18.1-fdo.patch
+	"${FILESDIR}"/${PN}-0.8.18.1-format-security.patch
+)
 
 src_configure() {
 	econf \
@@ -40,11 +40,11 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 	gnome2_icon_cache_update
 }


### PR DESCRIPTION
Also bumped EAPI to 6 and replaced eutils/epatch with a PATCHES=()
array, reformatted patches to apply.

Package-Manager: Portage-2.3.27, Repoman-2.3.9