### PR TITLE
media-gfx/cura: fdo-mime migration

### DIFF
--- a/media-gfx/cura/cura-0.15.04.4.ebuild
+++ b/media-gfx/cura/cura-0.15.04.4.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils fdo-mime gnome2-utils python-single-r1
+inherit desktop gnome2-utils python-single-r1 xdg-utils
 
 MY_PV=${PV#0.}
 MY_PN=Cura
@@ -30,8 +30,11 @@ RDEPEND="${PYTHON_DEPS}
 DEPEND="${RDEPEND}
 	>=dev-python/setuptools-0.6.34[${PYTHON_USEDEP}]"
 
-PATCHES=( "${FILESDIR}/${P}-nopower.patch" )
 S="${WORKDIR}/${MY_PN}-${MY_PV}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.15.04.4-nopower.patch"
+)
 
 src_prepare() {
 	cat > "${T}"/cura <<- CURAEOF || die
@@ -62,13 +65,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/media-gfx/cura/cura-0.15.04.5_rc5.ebuild
+++ b/media-gfx/cura/cura-0.15.04.5_rc5.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
-inherit eutils fdo-mime gnome2-utils python-single-r1
+
+inherit desktop gnome2-utils python-single-r1 xdg-utils
 
 MY_PV=${PV#0.}
 MY_PV=${MY_PV/_rc/-RC}
@@ -30,8 +31,11 @@ RDEPEND="${PYTHON_DEPS}
 DEPEND="${RDEPEND}
 	>=dev-python/setuptools-0.6.34[${PYTHON_USEDEP}]"
 
-PATCHES=( "${FILESDIR}/${PN}-0.15.04.4-nopower.patch" )
 S="${WORKDIR}/${MY_PN}-${MY_PV}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.15.04.4-nopower.patch"
+)
 
 src_prepare() {
 	cat > "${T}"/cura <<- CURAEOF || die
@@ -62,13 +66,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/media-gfx/cura/cura-2.1.0_beta.ebuild
+++ b/media-gfx/cura/cura-2.1.0_beta.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
 PYTHON_COMPAT=( python3_4 python3_5 )
-inherit cmake-utils fdo-mime gnome2-utils python-single-r1
+
+inherit cmake-utils gnome2-utils python-single-r1 xdg-utils
 
 MY_PN=Cura
 MY_PV=${PV/_beta}
@@ -28,7 +29,11 @@ DEPEND="${RDEPEND}
 	sys-devel/gettext"
 
 S="${WORKDIR}/${MY_PN}-${MY_PV}"
-PATCHES=( "${FILESDIR}/${P}-fix-install-paths.patch" )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.1.0_beta-fix-install-paths.patch"
+)
+
 DOCS=( README.md )
 
 src_configure() {
@@ -52,13 +57,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/media-gfx/cura/cura-2.3.1.ebuild
+++ b/media-gfx/cura/cura-2.3.1.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
-PYTHON_COMPAT=( python3_4 python3_5 )
-inherit cmake-utils fdo-mime gnome2-utils python-single-r1
+PYTHON_COMPAT=( python3_{4,5} )
+
+inherit cmake-utils gnome2-utils python-single-r1 xdg-utils
 
 MY_PN=Cura
 MY_PV=${PV/_beta}
@@ -29,7 +30,11 @@ DEPEND="${RDEPEND}
 	sys-devel/gettext"
 
 S="${WORKDIR}/${MY_PN}-${MY_PV}"
-PATCHES=( "${FILESDIR}/${P}-fix-install-paths.patch" )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.3.1-fix-install-paths.patch"
+)
+
 DOCS=( README.md )
 
 src_configure() {
@@ -53,13 +58,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/media-gfx/cura/cura-2.6.0.ebuild
+++ b/media-gfx/cura/cura-2.6.0.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
 PYTHON_COMPAT=( python3_{4,5,6} )
-inherit cmake-utils fdo-mime gnome2-utils python-single-r1
+
+inherit cmake-utils gnome2-utils python-single-r1 xdg-utils
 
 MY_PN=Cura
 MY_PV=${PV/_beta}
@@ -29,7 +30,11 @@ DEPEND="${RDEPEND}
 	sys-devel/gettext"
 
 S="${WORKDIR}/${MY_PN}-${MY_PV}"
-PATCHES=( "${FILESDIR}/${PN}-2.3.1-fix-install-paths.patch" )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.3.1-fix-install-paths.patch"
+)
+
 DOCS=( README.md )
 
 src_configure() {
@@ -53,13 +58,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }


### PR DESCRIPTION
Plus some minor formatting changes to be more in accord with the rest of
the ::gentoo tree, and removal of eutils in favor of desktop.

Package-Manager: Portage-2.3.27, Repoman-2.3.9