### PR TITLE
media-tv/v4l-dvb-saa716x: fix kernel 4.15+4.16 compile

### DIFF
--- a/media-tv/v4l-dvb-saa716x/files/v4l-dvb-saa716x-4.15-fix-autorepeat.patch
+++ b/media-tv/v4l-dvb-saa716x/files/v4l-dvb-saa716x-4.15-fix-autorepeat.patch
@@ -1,0 +1,107 @@
+# Source: https://github.com/s-moch/linux-saa716x/commit/0b2276ee2e6383ad577fce5c694f8c4062d5334b.patch
+
+From 0b2276ee2e6383ad577fce5c694f8c4062d5334b Mon Sep 17 00:00:00 2001
+From: Soeren Moch <smoch@web.de>
+Date: Sat, 2 Dec 2017 20:51:10 +0100
+Subject: [PATCH] saa716x_ff: Remove autorepeat handling
+
+Let the input layer handle autorepeat for the IR remote.
+So no repeat_key timer is required anymore.
+
+Signed-off-by: Soeren Moch <smoch@web.de>
+---
+ drivers/media/common/saa716x/saa716x_ff_ir.c | 45 ++++++++--------------------
+ 1 file changed, 12 insertions(+), 33 deletions(-)
+
+diff --git a/drivers/media/common/saa716x/saa716x_ff_ir.c b/drivers/media/common/saa716x/saa716x_ff_ir.c
+index 35624789aa862..ad6f38611026c 100644
+--- a/linux/drivers/media/common/saa716x/saa716x_ff_ir.c
++++ b/linux/drivers/media/common/saa716x/saa716x_ff_ir.c
+@@ -40,7 +40,7 @@ struct infrared {
+ 	u8			protocol;
+ 	u16			last_key;
+ 	u16			last_toggle;
+-	bool			delay_timer_finished;
++	bool			key_pressed;
+ };
+ 
+ #define IR_RC5		0
+@@ -52,11 +52,12 @@ static void ir_emit_keyup(unsigned long parm)
+ {
+ 	struct infrared *ir = (struct infrared *) parm;
+ 
+-	if (!ir || !test_bit(ir->last_key, ir->input_dev->key))
++	if (!ir || !ir->key_pressed)
+ 		return;
+ 
+ 	input_report_key(ir->input_dev, ir->last_key, 0);
+ 	input_sync(ir->input_dev);
++	ir->key_pressed = false;
+ }
+ 
+ 
+@@ -114,28 +115,18 @@ static void ir_emit_key(unsigned long parm)
+ 		return;
+ 	}
+ 
+-	if (timer_pending(&ir->keyup_timer)) {
+-		del_timer(&ir->keyup_timer);
+-		if (ir->last_key != keycode || toggle != ir->last_toggle) {
+-			ir->delay_timer_finished = false;
+-			input_event(ir->input_dev, EV_KEY, ir->last_key, 0);
+-			input_event(ir->input_dev, EV_KEY, keycode, 1);
+-			input_sync(ir->input_dev);
+-		} else if (ir->delay_timer_finished) {
+-			input_event(ir->input_dev, EV_KEY, keycode, 2);
+-			input_sync(ir->input_dev);
+-		}
+-	} else {
+-		ir->delay_timer_finished = false;
+-		input_event(ir->input_dev, EV_KEY, keycode, 1);
+-		input_sync(ir->input_dev);
+-	}
++	if (ir->key_pressed &&
++	    (ir->last_key != keycode || toggle != ir->last_toggle))
++		input_event(ir->input_dev, EV_KEY, ir->last_key, 0);
+ 
++	input_event(ir->input_dev, EV_KEY, keycode, 1);
++	input_sync(ir->input_dev);
++
++	ir->key_pressed = true;
+ 	ir->last_key = keycode;
+ 	ir->last_toggle = toggle;
+ 
+-	ir->keyup_timer.expires = jiffies + UP_TIMEOUT;
+-	add_timer(&ir->keyup_timer);
++	mod_timer(&ir->keyup_timer, jiffies + UP_TIMEOUT);
+ 
+ }
+ 
+@@ -166,16 +157,6 @@ static void ir_register_keys(struct infrared *ir)
+ 	ir->input_dev->keycodemax = ARRAY_SIZE(ir->key_map);
+ }
+ 
+-
+-/* called by the input driver after rep[REP_DELAY] ms */
+-static void ir_repeat_key(unsigned long parm)
+-{
+-	struct infrared *ir = (struct infrared *) parm;
+-
+-	ir->delay_timer_finished = true;
+-}
+-
+-
+ /* interrupt handler */
+ void saa716x_ir_handler(struct saa716x_dev *saa716x, u32 ir_cmd)
+ {
+@@ -236,9 +217,7 @@ int saa716x_ir_init(struct saa716x_dev *saa716x)
+ 		ir->key_map[i] = i+1;
+ 	ir_register_keys(ir);
+ 
+-	/* override repeat timer */
+-	input_dev->timer.function = ir_repeat_key;
+-	input_dev->timer.data = (unsigned long) ir;
++	input_enable_softrepeat(input_dev, 800, 200);
+ 
+ 	tasklet_init(&ir->tasklet, ir_emit_key, (unsigned long) saa716x);
+ 	saa716x->ir_priv = ir;

--- a/media-tv/v4l-dvb-saa716x/files/v4l-dvb-saa716x-4.15-fix-timers.patch
+++ b/media-tv/v4l-dvb-saa716x/files/v4l-dvb-saa716x-4.15-fix-timers.patch
@@ -1,0 +1,41 @@
+# Source: https://github.com/s-moch/linux-saa716x/commit/1002d79c4ba60de0dbeacba0f289119556d7450d.patch
+
+From 1002d79c4ba60de0dbeacba0f289119556d7450d Mon Sep 17 00:00:00 2001
+From: Soeren Moch <smoch@web.de>
+Date: Sat, 2 Dec 2017 21:23:34 +0100
+Subject: [PATCH] saa716x_ff: Convert to new timer API
+
+Convert to new timer API in linux-4.15.
+
+Signed-off-by: Soeren Moch <smoch@web.de>
+---
+ drivers/media/common/saa716x/saa716x_ff_ir.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/media/common/saa716x/saa716x_ff_ir.c b/drivers/media/common/saa716x/saa716x_ff_ir.c
+index ad6f38611026c..7894adff4d4f6 100644
+--- a/linux/drivers/media/common/saa716x/saa716x_ff_ir.c
++++ b/linux/drivers/media/common/saa716x/saa716x_ff_ir.c
+@@ -48,9 +48,9 @@ struct infrared {
+ 
+ 
+ /* key-up timer */
+-static void ir_emit_keyup(unsigned long parm)
++static void ir_emit_keyup(struct timer_list *t)
+ {
+-	struct infrared *ir = (struct infrared *) parm;
++	struct infrared *ir = from_timer(ir, t, keyup_timer);
+ 
+ 	if (!ir || !ir->key_pressed)
+ 		return;
+@@ -184,9 +184,7 @@ int saa716x_ir_init(struct saa716x_dev *saa716x)
+ 	if (!ir)
+ 		return -ENOMEM;
+ 
+-	init_timer(&ir->keyup_timer);
+-	ir->keyup_timer.function = ir_emit_keyup;
+-	ir->keyup_timer.data = (unsigned long) ir;
++	timer_setup(&ir->keyup_timer, ir_emit_keyup, 0);
+ 
+ 	input_dev = input_allocate_device();
+ 	if (!input_dev)

--- a/media-tv/v4l-dvb-saa716x/files/v4l-dvb-saa716x-4.16-fix-compile.patch
+++ b/media-tv/v4l-dvb-saa716x/files/v4l-dvb-saa716x-4.16-fix-compile.patch
@@ -1,0 +1,49 @@
+diff -Naur powARman-v4l-dvb-saa716x-3b9fce66666a.orig/linux/drivers/media/common/saa716x/saa716x_adap.c powARman-v4l-dvb-saa716x-3b9fce66666a/linux/drivers/media/common/saa716x/saa716x_adap.c
+--- powARman-v4l-dvb-saa716x-3b9fce66666a.orig/linux/drivers/media/common/saa716x/saa716x_adap.c	2018-04-04 08:24:59.454708009 +0200
++++ powARman-v4l-dvb-saa716x-3b9fce66666a/linux/drivers/media/common/saa716x/saa716x_adap.c	2018-04-04 08:25:36.263560559 +0200
+@@ -1,9 +1,9 @@
+ #include <linux/bitops.h>
+ 
+-#include "dmxdev.h"
+-#include "dvbdev.h"
+-#include "dvb_demux.h"
+-#include "dvb_frontend.h"
++#include <media/dmxdev.h>
++#include <media/dvbdev.h>
++#include <media/dvb_demux.h>
++#include <media/dvb_frontend.h>
+ 
+ #include "saa716x_mod.h"
+ #include "saa716x_spi.h"
+diff -Naur powARman-v4l-dvb-saa716x-3b9fce66666a.orig/linux/drivers/media/common/saa716x/saa716x_ff.h powARman-v4l-dvb-saa716x-3b9fce66666a/linux/drivers/media/common/saa716x/saa716x_ff.h
+--- powARman-v4l-dvb-saa716x-3b9fce66666a.orig/linux/drivers/media/common/saa716x/saa716x_ff.h	2018-04-04 08:24:59.458708101 +0200
++++ powARman-v4l-dvb-saa716x-3b9fce66666a/linux/drivers/media/common/saa716x/saa716x_ff.h	2018-04-04 08:25:36.263560559 +0200
+@@ -1,7 +1,7 @@
+ #ifndef __SAA716x_FF_H
+ #define __SAA716x_FF_H
+ 
+-#include "dvb_ringbuffer.h"
++#include <media/dvb_ringbuffer.h>
+ #include <linux/version.h>
+ #include <linux/workqueue.h>
+ 
+diff -Naur powARman-v4l-dvb-saa716x-3b9fce66666a.orig/linux/drivers/media/common/saa716x/saa716x_priv.h powARman-v4l-dvb-saa716x-3b9fce66666a/linux/drivers/media/common/saa716x/saa716x_priv.h
+--- powARman-v4l-dvb-saa716x-3b9fce66666a.orig/linux/drivers/media/common/saa716x/saa716x_priv.h	2018-04-04 08:24:59.458708101 +0200
++++ powARman-v4l-dvb-saa716x-3b9fce66666a/linux/drivers/media/common/saa716x/saa716x_priv.h	2018-04-04 08:25:36.263560559 +0200
+@@ -18,11 +18,11 @@
+ #include "saa716x_spi.h"
+ #include "saa716x_vip.h"
+ 
+-#include "dvbdev.h"
+-#include "dvb_demux.h"
+-#include "dmxdev.h"
+-#include "dvb_frontend.h"
+-#include "dvb_net.h"
++#include <media/dvbdev.h>
++#include <media/dvb_demux.h>
++#include <media/dmxdev.h>
++#include <media/dvb_frontend.h>
++#include <media/dvb_net.h>
+ 
+ #define SAA716x_ERROR		0
+ #define SAA716x_NOTICE		1

--- a/media-tv/v4l-dvb-saa716x/v4l-dvb-saa716x-0.0.1_p20170225-r1.ebuild
+++ b/media-tv/v4l-dvb-saa716x/v4l-dvb-saa716x-0.0.1_p20170225-r1.ebuild
@@ -45,6 +45,8 @@ src_prepare() {
 	kernel_is ge 4 9 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.9-fix-warnings.patch"
 	kernel_is ge 4 10 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.10-fix-compile.patch"
 	kernel_is ge 4 14 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.14.0-fix-compile.patch"
+	kernel_is ge 4 15 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.15-fix-autorepeat.patch"
+	kernel_is ge 4 15 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.15-fix-timers.patch"
 }
 
 src_compile() {

--- a/media-tv/v4l-dvb-saa716x/v4l-dvb-saa716x-0.0.1_p20170225-r1.ebuild
+++ b/media-tv/v4l-dvb-saa716x/v4l-dvb-saa716x-0.0.1_p20170225-r1.ebuild
@@ -47,6 +47,7 @@ src_prepare() {
 	kernel_is ge 4 14 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.14.0-fix-compile.patch"
 	kernel_is ge 4 15 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.15-fix-autorepeat.patch"
 	kernel_is ge 4 15 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.15-fix-timers.patch"
+	kernel_is ge 4 16 0 && eapply "${FILESDIR}/v4l-dvb-saa716x-4.16-fix-compile.patch"
 }
 
 src_compile() {


### PR DESCRIPTION
driver for TT S2-6400 card needs fixes to compile with kernel 4.15 and 4.16
This PR add fixes to existing ebuild w/o revbump