### PR TITLE
lxde-base/{lxde-meta,lxinput,lxmenu-data,lxdm}: use HTTPS

### DIFF
--- a/lxde-base/lxde-meta/lxde-meta-0.5.5-r5.ebuild
+++ b/lxde-base/lxde-meta/lxde-meta-0.5.5-r5.ebuild
@@ -4,7 +4,7 @@
 EAPI="6"
 
 DESCRIPTION="Meta ebuild for LXDE, the Lightweight X11 Desktop Environment"
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://lxde.org/"
 
 LICENSE="metapackage"
 SLOT="0"

--- a/lxde-base/lxdm/lxdm-0.4.1-r9.ebuild
+++ b/lxde-base/lxdm/lxdm-0.4.1-r9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="2"
@@ -7,7 +7,7 @@ WANT_AUTOMAKE="1.12" #493996
 inherit eutils autotools systemd
 
 DESCRIPTION="LXDE Display Manager"
-HOMEPAGE="http://lxde.org"
+HOMEPAGE="https://lxde.org"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/lxde-base/lxdm/lxdm-0.5.3-r1.ebuild
+++ b/lxde-base/lxdm/lxdm-0.5.3-r1.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 inherit eutils autotools systemd
 
 DESCRIPTION="LXDE Display Manager"
-HOMEPAGE="http://lxde.org"
+HOMEPAGE="https://lxde.org"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-3"

--- a/lxde-base/lxdm/lxdm-0.5.3.ebuild
+++ b/lxde-base/lxdm/lxdm-0.5.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit eutils autotools systemd
 
 DESCRIPTION="LXDE Display Manager"
-HOMEPAGE="http://lxde.org"
+HOMEPAGE="https://lxde.org"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-3"

--- a/lxde-base/lxinput/lxinput-0.3.5-r1.ebuild
+++ b/lxde-base/lxinput/lxinput-0.3.5-r1.ebuild
@@ -12,7 +12,7 @@ PLOCALE_BACKUP="en_GB"
 inherit l10n
 
 DESCRIPTION="LXDE keyboard and mouse configuration tool"
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://lxde.org/"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/lxde-base/lxinput/lxinput-0.3.5.ebuild
+++ b/lxde-base/lxinput/lxinput-0.3.5.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="LXDE keyboard and mouse configuration tool"
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://lxde.org/"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/lxde-base/lxmenu-data/lxmenu-data-0.1.5.ebuild
+++ b/lxde-base/lxmenu-data/lxmenu-data-0.1.5.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="Provides files needed for LXDE application menus"
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://lxde.org/"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This PR fixes a few lxde packages to use https instead of http.

Please review.