### PR TITLE
dev-cpp/libmcpp: Missing patches

### DIFF
--- a/dev-cpp/libmcpp/libmcpp-2.7.2-gniibe.patch
+++ b/dev-cpp/libmcpp/libmcpp-2.7.2-gniibe.patch
@@ -1,0 +1,33 @@
+Description: Simple fixes
+ * Fix freeing unmalloced memory
+   The memory of 'in_file' is not malloced, but points to argv[].
+   It is wrong to free it.
+ * When there is no input file specified by argv, it causes error
+   and fp_in == NULL.  Check is needed to call fclose for fp_in.
+Author: NIIBE Yutaka
+
+## Fixes the issue reported at:
+## http://www.forallsecure.com/bug-reports/6b11b6fccda17cc467e055ccf7fec3fa2d89ec00/
+
+Index: mcpp-2.7.2/src/main.c
+===================================================================
+--- mcpp-2.7.2.orig/src/main.c	2013-07-09 03:03:05.610947658 +0000
++++ mcpp-2.7.2/src/main.c	2013-07-09 03:03:05.534947624 +0000
+@@ -428,16 +428,11 @@
+ 
+ fatal_error_exit:
+ #if MCPP_LIB
+-    /* Free malloced memory */
+-    if (mcpp_debug & MACRO_CALL) {
+-        if (in_file != stdin_name)
+-            free( in_file);
+-    }
+     clear_filelist();
+     clear_symtable();
+ #endif
+ 
+-    if (fp_in != stdin)
++    if (fp_in && fp_in != stdin)
+         fclose( fp_in);
+     if (fp_out != stdout)
+         fclose( fp_out);

--- a/dev-cpp/libmcpp/libmcpp-2.7.2-r3.ebuild
+++ b/dev-cpp/libmcpp/libmcpp-2.7.2-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/dev-cpp/libmcpp/libmcpp-2.7.2-r3.ebuild
+++ b/dev-cpp/libmcpp/libmcpp-2.7.2-r3.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://sourceforge/mcpp/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ia64 x86 ~x86-linux ~x64-macos"
+KEYWORDS="~amd64 ~arm ~ia64 ~x86 ~x86-linux ~x64-macos"
 IUSE="static-libs"
 
 DEPEND=""

--- a/dev-cpp/libmcpp/libmcpp-2.7.2-r3.ebuild
+++ b/dev-cpp/libmcpp/libmcpp-2.7.2-r3.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools
+
+MY_P=${P/lib/}
+
+DESCRIPTION="A portable C++ preprocessor"
+HOMEPAGE="http://mcpp.sourceforge.net"
+SRC_URI="mirror://sourceforge/mcpp/${MY_P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="amd64 ~arm ~ia64 x86 ~x86-linux ~x64-macos"
+IUSE="static-libs"
+
+DEPEND=""
+RDEPEND=""
+
+S=${WORKDIR}/${MY_P}
+
+PATCHES=( "${FILESDIR}"/${PN}-2.7.2-fix-build-system.patch
+          "${FILESDIR}"/${PN}-2.7.2-zeroc.patch
+          "${FILESDIR}"/${PN}-2.7.2-gniibe.patch)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--enable-mcpplib \
+		$(use_enable static-libs static)
+}
+
+src_install() {
+	default
+
+	if ! use static-libs; then
+		find "${D}" -name '*.la' -delete || die
+	fi
+}

--- a/dev-cpp/libmcpp/libmcpp-2.7.2-zeroc.patch
+++ b/dev-cpp/libmcpp/libmcpp-2.7.2-zeroc.patch
@@ -1,0 +1,75 @@
+Description: Fixes by ZeroC, Inc.
+Author: ZeroC, Inc.
+Bug-Debian: http://bugs.debian.org/611749
+
+--- mcpp-2.7.2.orig/src/main.c
++++ mcpp-2.7.2/src/main.c
+@@ -326,6 +326,8 @@ static void     init_main( void)
+             = FALSE;
+     option_flags.trig = TRIGRAPHS_INIT;
+     option_flags.dig = DIGRAPHS_INIT;
++    sh_file = NULL;
++    sh_line = 0;
+ }
+ 
+ int     mcpp_lib_main
+--- mcpp-2.7.2.orig/src/support.c
++++ mcpp-2.7.2/src/support.c
+@@ -188,7 +188,7 @@ static char *   append_to_buffer(
+     size_t      length
+ )
+ {
+-    if (mem_buf_p->bytes_avail < length) {  /* Need to allocate more memory */
++    if (mem_buf_p->bytes_avail < length + 1) {  /* Need to allocate more memory */
+         size_t size = MAX( BUF_INCR_SIZE, length);
+ 
+         if (mem_buf_p->buffer == NULL) {            /* 1st append   */
+@@ -1722,6 +1722,8 @@ com_start:
+                     sp -= 2;
+                     while (*sp != '\n')     /* Until end of line    */
+                         mcpp_fputc( *sp++, OUT);
++                    mcpp_fputc( '\n', OUT);
++                    wrong_line = TRUE;
+                 }
+                 goto  end_line;
+             default:                        /* Not a comment        */
+--- mcpp-2.7.2.orig/src/internal.H
++++ mcpp-2.7.2/src/internal.H
+@@ -390,6 +390,8 @@ extern char * const     work_end;   /* E
+ extern char     identifier[];       /* Lastly scanned name          */
+ extern IFINFO   ifstack[];          /* Information of #if nesting   */
+ extern char     work_buf[];
++extern FILEINFO * sh_file;
++extern int      sh_line;
+         /* Temporary buffer for directive line and macro expansion  */
+ 
+ /* main.c   */
+@@ -557,6 +559,6 @@ extern void     init_system( void);
+ #endif
+ #endif
+ 
+-#if HOST_HAVE_STPCPY
++#if HOST_HAVE_STPCPY && !defined(stpcpy)
+ extern char *   stpcpy( char * dest, const char * src);
+ #endif
+--- mcpp-2.7.2.orig/src/system.c
++++ mcpp-2.7.2/src/system.c
+@@ -3858,6 +3858,9 @@ static int  chk_dirp(
+ }
+ #endif
+ 
++FILEINFO*       sh_file;
++int             sh_line;
++
+ void    sharp(
+     FILEINFO *  sharp_file,
+     int         flag        /* Flag to append to the line for GCC   */
+@@ -3868,8 +3871,6 @@ void    sharp(
+  * else (i.e. 'sharp_file' is NULL) 'infile'.
+  */
+ {
+-    static FILEINFO *   sh_file;
+-    static int  sh_line;
+     FILEINFO *  file;
+     int         line;
+ 


### PR DESCRIPTION
r3 include two new patches already in debian distributions, and
mcpp forums.

 - libmcpp-2.7.2-zeroc: patch is required for dev-libs/Ice to work propertly
 - libmcpp-2.7.2-gniibe: patch include two simple security fixes