### PR TITLE
net-p2p/bitcoin-qt-0.16.0*: Add missing <memory> include

### DIFF
--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.16.0-r1.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.16.0-r1.ebuild
@@ -95,6 +95,8 @@ src_prepare() {
 		eapply "${FILESDIR}/${P}-fix_mempoolstats.patch"
 	fi
 
+	eapply "${FILESDIR}/${P}-fix_memory_include.patch"
+
 	eapply_user
 
 	if ! use bitcoin_policy_rbf; then

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.16.0.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.16.0.ebuild
@@ -92,6 +92,8 @@ src_prepare() {
 		eapply "${FILESDIR}/${P}-fix_mempoolstats.patch"
 	fi
 
+	eapply "${FILESDIR}/${P}-fix_memory_include.patch"
+
 	eapply_user
 
 	if ! use bitcoin_policy_rbf; then

--- a/net-p2p/bitcoin-qt/files/bitcoin-qt-0.16.0-fix_memory_include.patch
+++ b/net-p2p/bitcoin-qt/files/bitcoin-qt-0.16.0-fix_memory_include.patch
@@ -1,0 +1,13 @@
+diff --git a/src/qt/walletmodeltransaction.h b/src/qt/walletmodeltransaction.h
+index cd531dba4b..816b0c35af 100644
+--- a/src/qt/walletmodeltransaction.h
++++ b/src/qt/walletmodeltransaction.h
+@@ -7,6 +7,8 @@
+ 
+ #include <qt/walletmodel.h>
+ 
++#include <memory>
++
+ #include <QObject>
+ 
+ class SendCoinsRecipient;


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/652142