### PR TITLE
lxde-base/lxdm: Better HOMEPAGE

### DIFF
--- a/lxde-base/lxdm/lxdm-0.4.1-r9.ebuild
+++ b/lxde-base/lxdm/lxdm-0.4.1-r9.ebuild
@@ -7,7 +7,7 @@ WANT_AUTOMAKE="1.12" #493996
 inherit eutils autotools systemd
 
 DESCRIPTION="LXDE Display Manager"
-HOMEPAGE="https://lxde.org"
+HOMEPAGE="https://wiki.lxde.org/en/LXDM"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/lxde-base/lxdm/lxdm-0.5.3-r1.ebuild
+++ b/lxde-base/lxdm/lxdm-0.5.3-r1.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 inherit eutils autotools systemd
 
 DESCRIPTION="LXDE Display Manager"
-HOMEPAGE="https://lxde.org"
+HOMEPAGE="https://wiki.lxde.org/en/LXDM"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-3"

--- a/lxde-base/lxdm/lxdm-0.5.3.ebuild
+++ b/lxde-base/lxdm/lxdm-0.5.3.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit eutils autotools systemd
 
 DESCRIPTION="LXDE Display Manager"
-HOMEPAGE="https://lxde.org"
+HOMEPAGE="https://wiki.lxde.org/en/LXDM"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-3"


### PR DESCRIPTION
Use https://wiki.lxde.org/en/LXDM instead of https://lxde.org

Package-Manager: Portage-2.3.24, Repoman-2.3.6