### PR TITLE
app-arch/bzip2: EAPI update and patch cleanup.

### DIFF
--- a/app-arch/bzip2/bzip2-1.0.6-r9.ebuild
+++ b/app-arch/bzip2/bzip2-1.0.6-r9.ebuild
@@ -1,0 +1,116 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# XXX: atm, libbz2.a is always PIC :(, so it is always built quickly
+#      (since we're building shared libs) ...
+
+EAPI=6
+
+inherit toolchain-funcs multilib-minimal
+
+DESCRIPTION="A high-quality data compressor used extensively by Gentoo Linux"
+HOMEPAGE="http://www.bzip.org/"
+SRC_URI="http://www.bzip.org/${PV}/${P}.tar.gz"
+
+LICENSE="BZIP2"
+SLOT="0/1" # subslot = SONAME
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE="static static-libs"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0.4-makefile-CFLAGS.patch
+	"${FILESDIR}"/${PN}-1.0.6-saneso.patch
+	"${FILESDIR}"/${PN}-1.0.4-man-links.patch #172986
+	"${FILESDIR}"/${PN}-1.0.6-progress.patch
+	"${FILESDIR}"/${PN}-1.0.3-no-test.patch
+	"${FILESDIR}"/${PN}-1.0.4-POSIX-shell.patch #193365
+	"${FILESDIR}"/${PN}-1.0.6-mingw.patch #393573
+	"${FILESDIR}"/${PN}-1.0.6-out-of-tree-build.patch
+	"${FILESDIR}"/${PN}-1.0.6-CVE-2016-3189.patch #620466
+)
+
+DOCS=( CHANGES README{,.COMPILATION.PROBLEMS,.XML.STUFF} manual.pdf )
+HTML_DOCS=( manual.html )
+
+src_prepare() {
+	default
+
+	# - Use right man path
+	# - Generate symlinks instead of hardlinks
+	# - pass custom variables to control libdir
+	sed -i \
+		-e 's:\$(PREFIX)/man:\$(PREFIX)/share/man:g' \
+		-e 's:ln -s -f $(PREFIX)/bin/:ln -s -f :' \
+		-e 's:$(PREFIX)/lib:$(PREFIX)/$(LIBDIR):g' \
+		Makefile || die
+}
+
+bemake() {
+	emake \
+		VPATH="${S}" \
+		CC="$(tc-getCC)" \
+		AR="$(tc-getAR)" \
+		RANLIB="$(tc-getRANLIB)" \
+		"$@"
+}
+
+multilib_src_compile() {
+	bemake -f "${S}"/Makefile-libbz2_so all
+	# Make sure we link against the shared lib #504648
+	ln -sf libbz2.so.${PV} libbz2.so || die
+	bemake -f "${S}"/Makefile all LDFLAGS="${LDFLAGS} $(usex static -static '')"
+}
+
+multilib_src_install() {
+	into /usr
+
+	# Install the shared lib manually.  We install:
+	#  .x.x.x - standard shared lib behavior
+	#  .x.x   - SONAME some distros use #338321
+	#  .x     - SONAME Gentoo uses
+	dolib.so libbz2.so.${PV}
+	local v
+	for v in libbz2.so{,.{${PV%%.*},${PV%.*}}} ; do
+		dosym libbz2.so.${PV} /usr/$(get_libdir)/${v}
+	done
+	use static-libs && dolib.a libbz2.a
+
+	if multilib_is_native_abi ; then
+		gen_usr_ldscript -a bz2
+
+		dobin bzip2recover
+		into /
+		dobin bzip2
+	fi
+}
+
+multilib_src_install_all() {
+	# `make install` doesn't cope with out-of-tree builds, nor with
+	# installing just non-binaries, so handle things ourselves.
+	insinto /usr/include
+	doins bzlib.h
+	into /usr
+	dobin bz{diff,grep,more}
+	doman *.1
+
+	dosym bzdiff /usr/bin/bzcmp
+	dosym bzdiff.1 /usr/share/man/man1/bzcmp.1
+
+	dosym bzmore /usr/bin/bzless
+	dosym bzmore.1 /usr/share/man/man1/bzless.1
+
+	local x
+	for x in bunzip2 bzcat bzip2recover ; do
+		dosym bzip2.1 /usr/share/man/man1/${x}.1
+	done
+	for x in bz{e,f}grep ; do
+		dosym bzgrep /usr/bin/${x}
+		dosym bzgrep.1 /usr/share/man/man1/${x}.1
+	done
+
+	einstalldocs
+
+	# move "important" bzip2 binaries to /bin and use the shared libbz2.so
+	dosym bzip2 /bin/bzcat
+	dosym bzip2 /bin/bunzip2
+}

--- a/app-arch/bzip2/files/bzip2-1.0.3-no-test.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.3-no-test.patch
@@ -1,5 +1,5 @@
---- Makefile
-+++ Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -23,5 +23,5 @@
        bzlib.o
  

--- a/app-arch/bzip2/files/bzip2-1.0.4-POSIX-shell.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.4-POSIX-shell.patch
@@ -3,8 +3,8 @@ with calls to sed so POSIX shells work
 
 http://bugs.gentoo.org/193365
 
---- bzgrep
-+++ bzgrep
+--- a/bzgrep
++++ b/bzgrep
 @@ -63,10 +63,9 @@
      bzip2 -cdfq "$i" | $grep $opt "$pat"
      r=$?

--- a/app-arch/bzip2/files/bzip2-1.0.4-makefile-CFLAGS.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.4-makefile-CFLAGS.patch
@@ -1,5 +1,5 @@
---- Makefile
-+++ Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -18,10 +18,9 @@
  CC=gcc
  AR=ar
@@ -12,8 +12,8 @@
  
  # Where you want it installed when you do 'make install'
  PREFIX=/usr/local
---- Makefile-libbz2_so
-+++ Makefile-libbz2_so
+--- a/Makefile-libbz2_so
++++ b/Makefile-libbz2_so
 @@ -24,7 +24,7 @@
  SHELL=/bin/sh
  CC=gcc

--- a/app-arch/bzip2/files/bzip2-1.0.4-man-links.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.4-man-links.patch
@@ -1,7 +1,7 @@
 http://bugs.gentoo.org/172986
 
---- bzip2-1.0.4/Makefile
-+++ bzip2-1.0.4/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -85,4 +85,7 @@
  	cp -f bzip2.1 $(PREFIX)/share/man/man1
  	chmod a+r $(PREFIX)/share/man/man1/bzip2.1

--- a/app-arch/bzip2/files/bzip2-1.0.6-CVE-2016-3189.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.6-CVE-2016-3189.patch
@@ -6,8 +6,8 @@ Signed-off-by: Armin Kuster <akuster@mvista.com>
 
 Index: bzip2-1.0.6/bzip2recover.c
 ===================================================================
---- bzip2-1.0.6.orig/bzip2recover.c
-+++ bzip2-1.0.6/bzip2recover.c
+--- a/bzip2recover.c
++++ b/bzip2recover.c
 @@ -457,6 +457,7 @@ Int32 main ( Int32 argc, Char** argv )
              bsPutUChar ( bsWr, 0x50 ); bsPutUChar ( bsWr, 0x90 );
              bsPutUInt32 ( bsWr, blockCRC );

--- a/app-arch/bzip2/files/bzip2-1.0.6-progress.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.6-progress.patch
@@ -2,8 +2,8 @@ Ripped from Mandrake
 
 http://bugs.gentoo.org/82192
 
---- bzip2-1.0.6/bzip2.1
-+++ bzip2-1.0.6/bzip2.1
+--- a/bzip2.1
++++ b/bzip2.1
 @@ -235,6 +235,10 @@
  Suppress non-essential warning messages.  Messages pertaining to
  I/O errors and other critical events will not be suppressed.
@@ -15,8 +15,8 @@ http://bugs.gentoo.org/82192
  .B \-v --verbose
  Verbose mode -- show the compression ratio for each file processed.
  Further \-v's increase the verbosity level, spewing out lots of
---- bzip2-1.0.6/bzip2.c
-+++ bzip2-1.0.6/bzip2.c
+--- a/bzip2.c
++++ b/bzip2.c
 @@ -145,6 +145,7 @@
  #include <signal.h>
  #include <math.h>

--- a/app-arch/bzip2/files/bzip2-1.0.6-saneso.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.6-saneso.patch
@@ -1,5 +1,5 @@
---- Makefile-libbz2_so
-+++ Makefile-libbz2_so
+--- a/Makefile-libbz2_so
++++ b/Makefile-libbz2_so
 @@ -35,8 +35,8 @@
        bzlib.o
  


### PR DESCRIPTION
Think of this as a precursor to switching bzip2 to an autotools build.
EAPI has been bumped from 5 to 6, and the patches have been reformatted
to apply with `eapply` in in addition to `epatch` (which apparently tries
every -pN option with patch until it hits one that works), so the new
revbump can be tested and stabilized while the old version is still
available without change.

Also changed `dodoc/dohtml` to `DOCS=()/HTML_DOCS=() einstalldocs`.

Package-Manager: Portage-2.3.28, Repoman-2.3.9