### PR TITLE
lxde-base/lxsession: Better HOMEPAGE, use https

### DIFF
--- a/lxde-base/lxsession/lxsession-0.5.2.ebuild
+++ b/lxde-base/lxsession/lxsession-0.5.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit vala autotools
 
 DESCRIPTION="LXDE session manager"
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://wiki.lxde.org/en/LXSession"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://wiki.lxde.org/en/LXSession"

Package-Manager: Portage-2.3.24, Repoman-2.3.6