### PR TITLE
lxde-base/lxrandr: Better HOMEPAGE, use https

### DIFF
--- a/lxde-base/lxrandr/lxrandr-0.3.1-r1.ebuild
+++ b/lxde-base/lxrandr/lxrandr-0.3.1-r1.ebuild
@@ -12,7 +12,7 @@ PLOCALE_BACKUP="en_GB"
 inherit l10n
 
 DESCRIPTION="LXDE GUI interface to RandR extention"
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://wiki.lxde.org/en/LXRandR"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/lxde-base/lxrandr/lxrandr-0.3.1.ebuild
+++ b/lxde-base/lxrandr/lxrandr-0.3.1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="LXDE GUI interface to RandR extention"
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://wiki.lxde.org/en/LXRandR"
 SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
-HOMEPAGE="http://lxde.org/"
+HOMEPAGE="https://wiki.lxde.org/en/LXRandR"

Package-Manager: Portage-2.3.24, Repoman-2.3.6