### PR TITLE
xfce-extra/*: fdo-mime->xdg-utils

### DIFF
--- a/xfce-extra/xfce4-battery-plugin/xfce4-battery-plugin-1.1.0.ebuild
+++ b/xfce-extra/xfce4-battery-plugin/xfce4-battery-plugin-1.1.0.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit linux-info fdo-mime gnome2-utils
+
+inherit gnome2-utils linux-info xdg-utils
 
 DESCRIPTION="A battery monitor panel plugin for the Xfce desktop environment"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-battery-plugin"
@@ -36,13 +37,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/xfce-extra/xfce4-datetime-plugin/xfce4-datetime-plugin-0.7.0.ebuild
+++ b/xfce-extra/xfce4-datetime-plugin/xfce4-datetime-plugin-0.7.0.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit fdo-mime gnome2-utils
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="A panel plug-in with date, time and embedded calender"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-datetime-plugin"
@@ -27,13 +28,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/xfce-extra/xfce4-diskperf-plugin/xfce4-diskperf-plugin-2.6.1.ebuild
+++ b/xfce-extra/xfce4-diskperf-plugin/xfce4-diskperf-plugin-2.6.1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit fdo-mime gnome2-utils
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="A panel plug-in for disk usage and performance statistics"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-diskperf-plugin"
@@ -27,13 +28,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/xfce-extra/xfce4-fsguard-plugin/xfce4-fsguard-plugin-1.1.0.ebuild
+++ b/xfce-extra/xfce4-fsguard-plugin/xfce4-fsguard-plugin-1.1.0.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit fdo-mime gnome2-utils
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="A filesystem guard plug-in for the Xfce panel"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-fsguard-plugin"
@@ -28,13 +29,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/xfce-extra/xfce4-mpc-plugin/xfce4-mpc-plugin-0.5.0.ebuild
+++ b/xfce-extra/xfce4-mpc-plugin/xfce4-mpc-plugin-0.5.0.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit fdo-mime gnome2-utils
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="Music Player Daemon (mpd) panel plugin"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-mpc-plugin"
@@ -31,13 +32,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/xfce-extra/xfce4-netload-plugin/xfce4-netload-plugin-1.3.1.ebuild
+++ b/xfce-extra/xfce4-netload-plugin/xfce4-netload-plugin-1.3.1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit fdo-mime gnome2-utils
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="A network load plug-in for the Xfce panel"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-netload-plugin"
@@ -26,13 +27,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/xfce-extra/xfce4-smartbookmark-plugin/xfce4-smartbookmark-plugin-0.5.0.ebuild
+++ b/xfce-extra/xfce4-smartbookmark-plugin/xfce4-smartbookmark-plugin-0.5.0.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit fdo-mime gnome2-utils
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="Smart bookmark plug-in for the Xfce desktop environment"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-smartbookmark-plugin"
@@ -33,13 +34,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/xfce-extra/xfce4-systemload-plugin/xfce4-systemload-plugin-1.2.1.ebuild
+++ b/xfce-extra/xfce4-systemload-plugin/xfce4-systemload-plugin-1.2.1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit fdo-mime gnome2-utils
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="System load plug-in for Xfce panel"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-systemload-plugin"
@@ -31,13 +32,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }

--- a/xfce-extra/xfce4-wavelan-plugin/xfce4-wavelan-plugin-0.6.0.ebuild
+++ b/xfce-extra/xfce4-wavelan-plugin/xfce4-wavelan-plugin-0.6.0.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit fdo-mime gnome2-utils
+
+inherit gnome2-utils xdg-utils
 
 DESCRIPTION="A panel plug-in to display wireless interface statistics"
 HOMEPAGE="https://goodies.xfce.org/projects/panel-plugins/xfce4-wavelan-plugin"
@@ -29,13 +30,13 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }


### PR DESCRIPTION
All build tested, with the exception of xfce-extra/xfce4-diskperf-plugin-2.6.1, which is a known
[bug](https://bugs.gentoo.org/611418) being worked on. Otherwise its all pretty simple changes.