### PR TITLE
eclass/xfconf: fdo-mime->xdg-utils

### DIFF
--- a/eclass/xfconf.eclass
+++ b/eclass/xfconf.eclass
@@ -25,7 +25,7 @@ fi
 unset _xfconf_live
 [[ $PV == *9999* ]] && _xfconf_live=git-2
 
-inherit ${_xfconf_live} autotools eutils fdo-mime gnome2-utils libtool
+inherit ${_xfconf_live} autotools eutils gnome2-utils libtool xdg-utils
 
 EGIT_BOOTSTRAP=autogen.sh
 EGIT_REPO_URI="git://git.xfce.org/xfce/${MY_PN:-${PN}}"
@@ -134,11 +134,11 @@ xfconf_pkg_preinst() {
 
 # @FUNCTION: xfconf_pkg_postinst
 # @DESCRIPTION:
-# Run fdo-mime_{desktop,mime}_database_update and gnome2_icon_cache_update
+# Run xdg_{desktop,mimeinfo}_database_update and gnome2_icon_cache_update
 xfconf_pkg_postinst() {
 	debug-print-function ${FUNCNAME} "$@"
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	if [[ -n ${GNOME2_ECLASS_ICONS} ]]; then
 		gnome2_icon_cache_update
 	fi
@@ -146,11 +146,11 @@ xfconf_pkg_postinst() {
 
 # @FUNCTION: xfconf_pkg_postrm
 # @DESCRIPTION:
-# Run fdo-mime_{desktop,mime}_database_update and gnome2_icon_cache_update
+# Run xdg_{desktop,mimeinfo}_database_update and gnome2_icon_cache_update
 xfconf_pkg_postrm() {
 	debug-print-function ${FUNCNAME} "$@"
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	if [[ -n ${GNOME2_ECLASS_ICONS} ]]; then
 		gnome2_icon_cache_update
 	fi


### PR DESCRIPTION
A very simple change, just replace the eclass and functions.
Mostly to just get the ebuilds using this eclass out of the qa-report:
https://qa-reports.gentoo.org/output/eclass-usage/fdo-mime.txt

Package-Manager: Portage-2.3.28, Repoman-2.3.9