### PR TITLE
app-text/grip: use doubleqoutes instead of single qoutes

### DIFF
--- a/app-text/grip/grip-4.2.0.ebuild
+++ b/app-text/grip/grip-4.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,14 +7,14 @@ PYTHON_COMPAT=( python2_7 pypy{,3} python3_{4,5} )
 
 inherit distutils-r1
 
-DESCRIPTION='Preview GitHub Markdown files like Readme locally before committing them'
-HOMEPAGE='https://github.com/joeyespo/grip'
-LICENSE='MIT'
+DESCRIPTION="Preview GitHub Markdown files like Readme locally before committing them"
+HOMEPAGE="https://github.com/joeyespo/grip"
+LICENSE="MIT"
 
-SLOT='0'
+SLOT="0"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.zip"
 
-KEYWORDS='~amd64'
+KEYWORDS="~amd64"
 
 RDEPEND="
 	>=dev-python/docopt-0.6.2


### PR DESCRIPTION
Hi, 

This PR removes the qoutes from the packages and uses doubleqoutes instead.

Please review.