### PR TITLE
app-cdr/*: fdo-mime->xdg-utils

### DIFF
--- a/app-cdr/isomaster/isomaster-1.3.13.ebuild
+++ b/app-cdr/isomaster/isomaster-1.3.13.ebuild
@@ -37,10 +37,9 @@ pkg_setup() {
 
 src_prepare() {
 	default
+	rm -f configure || die #274361
 	rm -R iniparser-2.17 || die
 }
-
-src_configure() { :; } #274361
 
 src_compile() {
 	tc-export CC

--- a/app-cdr/isomaster/isomaster-1.3.13.ebuild
+++ b/app-cdr/isomaster/isomaster-1.3.13.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 
-inherit eutils toolchain-funcs xdg-utils
+inherit toolchain-funcs xdg-utils
 
 DESCRIPTION="Graphical CD image editor for reading, modifying and writing ISO images"
 HOMEPAGE="http://littlesvr.ca/isomaster"
@@ -20,6 +20,10 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	nls? ( >=sys-devel/gettext-0.19.1 )"  # bug 512448
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.3.9-iniparser-3.0.0.patch #399629
+)
+
 pkg_setup() {
 	myisoconf=(
 		DEFAULT_EDITOR=leafpad
@@ -32,7 +36,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	epatch "${FILESDIR}"/${PN}-1.3.9-iniparser-3.0.0.patch #399629
+	default
 	rm -R iniparser-2.17 || die
 }
 

--- a/app-cdr/isomaster/isomaster-1.3.13.ebuild
+++ b/app-cdr/isomaster/isomaster-1.3.13.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
-inherit eutils fdo-mime toolchain-funcs
+
+inherit eutils toolchain-funcs xdg-utils
 
 DESCRIPTION="Graphical CD image editor for reading, modifying and writing ISO images"
 HOMEPAGE="http://littlesvr.ca/isomaster"
@@ -60,9 +61,9 @@ src_install() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 }

--- a/app-cdr/isomaster/isomaster-1.3.14.ebuild
+++ b/app-cdr/isomaster/isomaster-1.3.14.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils xdg-utils toolchain-funcs
+
+inherit eutils toolchain-funcs xdg-utils
 
 DESCRIPTION="Graphical CD image editor for reading, modifying and writing ISO images"
 HOMEPAGE="http://littlesvr.ca/isomaster"

--- a/app-cdr/isomaster/isomaster-1.3.14.ebuild
+++ b/app-cdr/isomaster/isomaster-1.3.14.ebuild
@@ -34,10 +34,9 @@ pkg_setup() {
 
 src_prepare() {
 	default
+	rm -f configure || die #274361
 	rm -R iniparser-4.1 || die
 }
-
-src_configure() { :; } #274361
 
 src_compile() {
 	tc-export CC

--- a/app-cdr/isomaster/isomaster-1.3.14.ebuild
+++ b/app-cdr/isomaster/isomaster-1.3.14.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit eutils toolchain-funcs xdg-utils
+inherit toolchain-funcs xdg-utils
 
 DESCRIPTION="Graphical CD image editor for reading, modifying and writing ISO images"
 HOMEPAGE="http://littlesvr.ca/isomaster"
@@ -33,8 +33,8 @@ pkg_setup() {
 }
 
 src_prepare() {
+	default
 	rm -R iniparser-4.1 || die
-	eapply_user
 }
 
 src_configure() { :; } #274361

--- a/app-cdr/nero/nero-4.0.0.0b-r2.ebuild
+++ b/app-cdr/nero/nero-4.0.0.0b-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils fdo-mime gnome2-utils linux-info rpm
+inherit eutils gnome2-utils linux-info rpm xdg-utils
 
 DESCRIPTION="Nero Burning ROM for Linux"
 HOMEPAGE="http://nerolinux.nero.com"
@@ -92,15 +92,15 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 
 	nero --perform-post-installation || die
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
-	fdo-mime_mime_database_update
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 	gnome2_icon_cache_update
 }


### PR DESCRIPTION
Also fixed up some oddities with isomaster; commits are atomic so you can chose to just go with
the fdo-mime migration or the whole bit.