### PR TITLE
dev-python/autobahn: remove binary junk

### DIFF
--- a/dev-python/autobahn/files/autobahn-18.3.1-Fix-cs-test-955.patch
+++ b/dev-python/autobahn/files/autobahn-18.3.1-Fix-cs-test-955.patch
@@ -1,18 +1,35 @@
 From 604bc53a3beec173020c944ce9cb38afca2a9126 Mon Sep 17 00:00:00 2001
-From:   <°?¡>
+From: Tobias Oberstein <tobias.oberstein@crossbario.com>
 Date: Fri, 9 Mar 2018 10:37:31 +0100
 Subject: [PATCH] Fix cs test (#955)
 
+* encode test string
+
+* already an instance
+
+* add extra deps (encryption)
+
+* add extra deps
+
+* deactivate py 3.3, tx < 15.4
+
+* systematic version coverage
+
+* fix coverage (hopefully)
+
+* another try
+
+* actually need to yield, as a future is returned
 ---
- .travis.yml                           | 58 +++++++++++++++++++++++++++++++++++++++++++++++++++++-----
- Makefile                              |  3 +++
+ .travis.yml                           | 58 ++++++++++++++++++++++++++++++++---
+ Makefile                              |  3 ++
  autobahn/asyncio/rawsocket.py         |  2 +-
- autobahn/wamp/test/test_cryptosign.py | 18 +++++++++++++++---
- tox.ini                               | 32 +++++++++++++++++---------------
+ autobahn/wamp/test/test_cryptosign.py | 18 +++++++++--
+ tox.ini                               | 32 ++++++++++---------
  5 files changed, 89 insertions(+), 24 deletions(-)
 
 diff --git a/autobahn/asyncio/rawsocket.py b/autobahn/asyncio/rawsocket.py
-index 130a8e4..bbb8333 100644
+index 130a8e41..bbb83337 100644
 --- a/autobahn/asyncio/rawsocket.py
 +++ b/autobahn/asyncio/rawsocket.py
 @@ -408,7 +408,7 @@ class WampRawSocketClientProtocol(WampRawSocketMixinGeneral, WampRawSocketMixinA
@@ -25,7 +42,7 @@ index 130a8e4..bbb8333 100644
  
      def get_channel_id(self, channel_id_type=u'tls-unique'):
 diff --git a/autobahn/wamp/test/test_cryptosign.py b/autobahn/wamp/test/test_cryptosign.py
-index 700ca3c..78f8d55 100644
+index 700ca3cc..78f8d556 100644
 --- a/autobahn/wamp/test/test_cryptosign.py
 +++ b/autobahn/wamp/test/test_cryptosign.py
 @@ -25,9 +25,21 @@
@@ -50,7 +67,7 @@ index 700ca3c..78f8d55 100644
  from autobahn.wamp.cryptosign import _makepad, HAS_CRYPTOSIGN
  from autobahn.wamp import types
  from autobahn.wamp.auth import create_authenticator
-@@ -59,14 +71,14 @@ class TestAuth(unittest.TestCase):
+@@ -59,14 +71,14 @@ def setUp(self):
          self.key = SigningKey.from_ssh_data(keybody)
          self.privkey_hex = self.key._key.encode(encoder=HexEncoder)
          m = hashlib.sha256()
@@ -67,7 +84,7 @@ index 700ca3c..78f8d55 100644
          self.assertEqual(
              u'9b6f41540c9b95b4b7b281c3042fa9c54cef43c842d62ea3fd6030fcb66e70b3e80d49d44c29d1635da9348d02ec93f3ed1ef227dfb59a07b580095c2b82f80f9d16ca518aa0c2b707f2b2a609edeca73bca8dd59817a633f35574ac6fd80d00',
              signed.result,
-@@ -81,7 +93,7 @@ class TestAuth(unittest.TestCase):
+@@ -81,7 +93,7 @@ def test_authenticator(self):
          session = Mock()
          session._transport.get_channel_id = Mock(return_value=self.channel_id)
          challenge = types.Challenge(u"cryptosign", dict(challenge="ff" * 32))
@@ -76,6 +93,3 @@ index 700ca3c..78f8d55 100644
          self.assertEqual(
              reply.result,
              u'9b6f41540c9b95b4b7b281c3042fa9c54cef43c842d62ea3fd6030fcb66e70b3e80d49d44c29d1635da9348d02ec93f3ed1ef227dfb59a07b580095c2b82f80f9d16ca518aa0c2b707f2b2a609edeca73bca8dd59817a633f35574ac6fd80d00',
---
-libgit2 0.24.6
-


### PR DESCRIPTION
The git-email header had some junk in it which caused qa-reports to
think it was binary data. Remove it as being unneeded.

Package-Manager: Portage-2.3.28, Repoman-2.3.9