### PR TITLE
dev-java/*: use HTTPS

### DIFF
--- a/dev-java/android-util/android-util-4.1.1.4.ebuild
+++ b/dev-java/android-util/android-util-4.1.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -9,7 +9,7 @@ MY_PN="${PN/-util}"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Library providing APIs for applications written for Google Android"
-HOMEPAGE="http://source.android.com/"
+HOMEPAGE="https://source.android.com/"
 SRC_URI="http://central.maven.org/maven2/com/google/${MY_PN}/${MY_PN}/${PV}/${MY_P}-sources.jar"
 LICENSE="Apache-2.0"
 SLOT="0"

--- a/dev-java/ant-ivy/ant-ivy-1.3.1-r1.ebuild
+++ b/dev-java/ant-ivy/ant-ivy-1.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 JAVA_PKG_IUSE="doc source"
@@ -9,7 +9,7 @@ MY_PN=${PN##*-}
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Ivy is a free java based dependency manager"
-HOMEPAGE="http://jayasoft.org/ivy"
+HOMEPAGE="https://ant.apache.org/ivy/"
 SRC_URI="http://jayasoft.org/downloads/ivy/1.3.1/${MY_P}-src.zip"
 
 LICENSE="BSD"

--- a/dev-java/ant-ivy/ant-ivy-1.4.1-r1.ebuild
+++ b/dev-java/ant-ivy/ant-ivy-1.4.1-r1.ebuild
@@ -17,7 +17,7 @@ MY_PN="${PN##*-}"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Ivy is a free java based dependency manager"
-HOMEPAGE="http://ant.apache.org/ivy"
+HOMEPAGE="https://ant.apache.org/ivy/"
 SRC_URI="http://www.jaya.free.fr/downloads/ivy/${PV}/${MY_P}-src.zip"
 
 LICENSE="Apache-2.0"

--- a/dev-java/ant-ivy/ant-ivy-2.0.0.ebuild
+++ b/dev-java/ant-ivy/ant-ivy-2.0.0.ebuild
@@ -15,7 +15,7 @@ MY_PN="apache-ivy"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Ivy is a free java based dependency manager"
-HOMEPAGE="http://ant.apache.org/ivy"
+HOMEPAGE="https://ant.apache.org/ivy/"
 SRC_URI="mirror://apache/ant/ivy/${PV}/${MY_P}-src.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-java/ant-ivy/ant-ivy-2.3.0-r2.ebuild
+++ b/dev-java/ant-ivy/ant-ivy-2.3.0-r2.ebuild
@@ -17,7 +17,7 @@ MY_PN="apache-ivy"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Ivy is a free java based dependency manager"
-HOMEPAGE="http://ant.apache.org/ivy"
+HOMEPAGE="https://ant.apache.org/ivy/"
 SRC_URI="mirror://apache/ant/ivy/${PV}/${MY_P}-src.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-java/cortado/cortado-0.6.0-r1.ebuild
+++ b/dev-java/cortado/cortado-0.6.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="Multimedia framework for Java written by Fluendo"
-HOMEPAGE="http://www.theora.org/cortado/"
-SRC_URI="http://downloads.xiph.org/releases/cortado/${P}.tar.gz"
+HOMEPAGE="https://www.theora.org/cortado/"
+SRC_URI="https://downloads.xiph.org/releases/cortado/${P}.tar.gz"
 
 LICENSE="GPL-2 LGPL-2"
 SLOT="0"

--- a/dev-java/ecs/ecs-1.4.2-r2.ebuild
+++ b/dev-java/ecs/ecs-1.4.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Java library to generate markup language text such as HTML and XML"
-HOMEPAGE="http://jakarta.apache.org/ecs"
+HOMEPAGE="https://jakarta.apache.org/ecs"
 SRC_URI="mirror://apache/jakarta/${PN}/source/${P}-src.tar.gz"
 
 LICENSE="Apache-1.1"

--- a/dev-java/edtftpj/edtftpj-2.4.0.ebuild
+++ b/dev-java/edtftpj/edtftpj-2.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,8 +8,8 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="FTP client library written in Java"
-SRC_URI="http://www.enterprisedt.com/products/edtftpj/download/${P}.zip"
-HOMEPAGE="http://enterprisedt.com/products/edtftpnet"
+SRC_URI="https://www.enterprisedt.com/products/edtftpj/download/${P}.zip"
+HOMEPAGE="https://enterprisedt.com/products/edtftpnet"
 LICENSE="LGPL-2.1+"
 SLOT="0"
 KEYWORDS="amd64 x86"

--- a/dev-java/fontbox/fontbox-1.7.1.ebuild
+++ b/dev-java/fontbox/fontbox-1.7.1.ebuild
@@ -10,7 +10,7 @@ inherit java-pkg-2 java-ant-2
 MY_PN=pdfbox
 
 DESCRIPTION="An open source Java library for parsing font files"
-HOMEPAGE="http://pdfbox.apache.org/"
+HOMEPAGE="https://pdfbox.apache.org/"
 SRC_URI="mirror://apache/${MY_PN}/${PV}/${MY_PN}-${PV}-src.zip"
 
 LICENSE="BSD"

--- a/dev-java/fontbox/fontbox-1.8.11.ebuild
+++ b/dev-java/fontbox/fontbox-1.8.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="An open source Java library for parsing font files"
-HOMEPAGE="http://pdfbox.apache.org/"
+HOMEPAGE="https://pdfbox.apache.org/"
 SRC_URI="mirror://apache/${MY_PN}/${PV}/${MY_P}-src.zip"
 LICENSE="Apache-2.0"
 SLOT="1.8"

--- a/dev-java/htmlparser/htmlparser-1.4-r1.ebuild
+++ b/dev-java/htmlparser/htmlparser-1.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,8 +8,8 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="Implementation of the HTML5 parsing algorithm in Java"
-HOMEPAGE="http://about.validator.nu/htmlparser/"
-SRC_URI="http://about.validator.nu/${PN}/${P}.zip"
+HOMEPAGE="https://about.validator.nu/htmlparser/"
+SRC_URI="https://about.validator.nu/${PN}/${P}.zip"
 
 LICENSE="W3C"
 SLOT="0"

--- a/dev-java/itext/itext-2.1.5-r2.ebuild
+++ b/dev-java/itext/itext-2.1.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -12,7 +12,7 @@ ASIANJAR="iTextAsian.jar"
 ASIANCMAPSJAR="iTextAsianCmaps.jar"
 
 DESCRIPTION="Generate documents in the Portable Document Format (PDF) and/or HTML"
-HOMEPAGE="http://www.lowagie.com/iText/"
+HOMEPAGE="https://itextpdf.com"
 SRC_URI="mirror://sourceforge/itext/${DISTFILE}
 	cjk? ( mirror://sourceforge/itext/${ASIANJAR}
 		mirror://sourceforge/itext/${ASIANCMAPSJAR} )"

--- a/dev-java/itext/itext-5.5.4-r2.ebuild
+++ b/dev-java/itext/itext-5.5.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Generate documents in the Portable Document Format (PDF) and/or HTML"
-HOMEPAGE="http://itextpdf.com"
+HOMEPAGE="https://itextpdf.com"
 SRC_URI="mirror://sourceforge/${PN}/${P}.zip"
 
 LICENSE="AGPL-3"

--- a/dev-java/jacoco/jacoco-0.7.5.ebuild
+++ b/dev-java/jacoco/jacoco-0.7.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit java-pkg-2 java-pkg-simple
 DATE="201505241946"
 
 DESCRIPTION="Java Code Coverage library."
-HOMEPAGE="http://eclemma.org/jacoco/"
+HOMEPAGE="https://eclemma.org/jacoco/"
 SRC_URI="
 	https://repo1.maven.org/maven2/org/${PN}/org.${PN}.report/${PV}.${DATE}/org.${PN}.report-${PV}.${DATE}-sources.jar -> ${P}-report.jar
 	https://repo1.maven.org/maven2/org/${PN}/org.${PN}.agent/${PV}.${DATE}/org.${PN}.agent-${PV}.${DATE}-sources.jar -> ${P}-agent.jar

--- a/dev-java/jacoco/jacoco-0.7.9.ebuild
+++ b/dev-java/jacoco/jacoco-0.7.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Java Code Coverage library"
-HOMEPAGE="http://eclemma.org/jacoco/"
+HOMEPAGE="https://eclemma.org/jacoco/"
 
 SRC_URI="
 	https://repo1.maven.org/maven2/org/${PN}/org.${PN}.report/${PV}/org.${PN}.report-${PV}-sources.jar -> ${P}-report.jar

--- a/dev-java/jama/jama-1.0.3-r1.ebuild
+++ b/dev-java/jama/jama-1.0.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -11,8 +11,8 @@ MY_PN="Jama"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="A Java Matrix Package"
-HOMEPAGE="http://math.nist.gov/javanumerics/jama/"
-SRC_URI="http://math.nist.gov/javanumerics/${PN}/${MY_P}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://math.nist.gov/javanumerics/jama/"
+SRC_URI="https://math.nist.gov/javanumerics/${PN}/${MY_P}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0"

--- a/dev-java/javacsv/javacsv-2.1.ebuild
+++ b/dev-java/javacsv/javacsv-2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit java-pkg-2 java-ant-2
 RESTRICT="test"
 
 DESCRIPTION="Java library for reading and writing CSV and plain delimited text files"
-HOMEPAGE="http://www.csvreader.com/java_csv.php"
+HOMEPAGE="https://www.csvreader.com/java_csv.php"
 SRC_URI="mirror://sourceforge/${PN}/${P/-/}.zip"
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-java/jdbc-postgresql/jdbc-postgresql-9.2_p1003.ebuild
+++ b/dev-java/jdbc-postgresql/jdbc-postgresql-9.2_p1003.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -12,8 +12,8 @@ MY_PV="${PV/_p/-}"
 MY_P="${MY_PN}-${MY_PV}.src"
 
 DESCRIPTION="JDBC Driver for PostgreSQL"
-SRC_URI="http://jdbc.postgresql.org/download/${MY_P}.tar.gz"
-HOMEPAGE="http://jdbc.postgresql.org/"
+SRC_URI="https://jdbc.postgresql.org/download/${MY_P}.tar.gz"
+HOMEPAGE="https://jdbc.postgresql.org/"
 
 LICENSE="POSTGRESQL"
 SLOT="0"

--- a/dev-java/jdbc-postgresql/jdbc-postgresql-9.2_p1004.ebuild
+++ b/dev-java/jdbc-postgresql/jdbc-postgresql-9.2_p1004.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -12,8 +12,8 @@ MY_PV="${PV/_p/-}"
 MY_P="${MY_PN}-${MY_PV}.src"
 
 DESCRIPTION="JDBC Driver for PostgreSQL"
-SRC_URI="http://jdbc.postgresql.org/download/${MY_P}.tar.gz"
-HOMEPAGE="http://jdbc.postgresql.org/"
+SRC_URI="https://jdbc.postgresql.org/download/${MY_P}.tar.gz"
+HOMEPAGE="https://jdbc.postgresql.org/"
 
 LICENSE="POSTGRESQL"
 SLOT="0"

--- a/dev-java/jdbc-postgresql/jdbc-postgresql-9.3_p1100.ebuild
+++ b/dev-java/jdbc-postgresql/jdbc-postgresql-9.3_p1100.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -12,8 +12,8 @@ MY_PV="${PV/_p/-}"
 MY_P="${MY_PN}-${MY_PV}.src"
 
 DESCRIPTION="JDBC Driver for PostgreSQL"
-SRC_URI="http://jdbc.postgresql.org/download/${MY_P}.tar.gz"
-HOMEPAGE="http://jdbc.postgresql.org/"
+SRC_URI="https://jdbc.postgresql.org/download/${MY_P}.tar.gz"
+HOMEPAGE="https://jdbc.postgresql.org/"
 
 LICENSE="POSTGRESQL"
 SLOT="0"

--- a/dev-java/jdbc-postgresql/jdbc-postgresql-9.4_p1205.ebuild
+++ b/dev-java/jdbc-postgresql/jdbc-postgresql-9.4_p1205.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -12,8 +12,8 @@ MY_PV="${PV/_p/-}"
 MY_P="${MY_PN}-${MY_PV}.src"
 
 DESCRIPTION="JDBC Driver for PostgreSQL"
-SRC_URI="http://jdbc.postgresql.org/download/${MY_P}.tar.gz"
-HOMEPAGE="http://jdbc.postgresql.org/"
+SRC_URI="https://jdbc.postgresql.org/download/${MY_P}.tar.gz"
+HOMEPAGE="https://jdbc.postgresql.org/"
 
 LICENSE="POSTGRESQL"
 SLOT="0"

--- a/dev-java/jdbc-postgresql/jdbc-postgresql-9.4_p1206.ebuild
+++ b/dev-java/jdbc-postgresql/jdbc-postgresql-9.4_p1206.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -12,8 +12,8 @@ MY_PV="${PV/_p/-}"
 MY_P="${MY_PN}-${MY_PV}.src"
 
 DESCRIPTION="JDBC Driver for PostgreSQL"
-SRC_URI="http://jdbc.postgresql.org/download/${MY_P}.tar.gz"
-HOMEPAGE="http://jdbc.postgresql.org/"
+SRC_URI="https://jdbc.postgresql.org/download/${MY_P}.tar.gz"
+HOMEPAGE="https://jdbc.postgresql.org/"
 
 LICENSE="POSTGRESQL"
 SLOT="0"

--- a/dev-java/jgraph/jgraph-5.12.0.4.ebuild
+++ b/dev-java/jgraph/jgraph-5.12.0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 JAVA_PKG_IUSE="doc source"
@@ -7,7 +7,7 @@ inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="Open-source graph component for Java"
 SRC_URI="mirror://sourceforge/${PN}/${P}-lgpl-src.jar"
-HOMEPAGE="http://www.jgraph.com"
+HOMEPAGE="https://www.jgraph.com"
 IUSE="doc examples source"
 DEPEND=">=virtual/jdk-1.4
 	app-arch/unzip"

--- a/dev-java/jsoup/jsoup-1.8.3.ebuild
+++ b/dev-java/jsoup/jsoup-1.8.3.ebuild
@@ -11,7 +11,7 @@ MY_PV="${PV}a"
 MY_P="${PN}-${PN}-${MY_PV}"
 
 DESCRIPTION="Java HTML parser that makes sense of real-world HTML soup"
-HOMEPAGE="http://jsoup.org/"
+HOMEPAGE="https://jsoup.org/"
 SRC_URI="https://github.com/jhy/${PN}/archive/${PN}-${MY_PV}.zip"
 
 LICENSE="MIT"

--- a/dev-java/jstun/jstun-0.7.3.ebuild
+++ b/dev-java/jstun/jstun-0.7.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,8 +8,8 @@ JAVA_PKG_IUSE="doc source test"
 inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="Java-based STUN implementation"
-HOMEPAGE="http://jstun.javawi.de/"
-SRC_URI="http://${PN}.javawi.de/${P}.src.tar.gz"
+HOMEPAGE="https://jstun.javawi.de/"
+SRC_URI="https://${PN}.javawi.de/${P}.src.tar.gz"
 
 LICENSE="Apache-2.0 GPL-2"
 SLOT="0"

--- a/dev-java/jts-core/jts-core-1.14.ebuild
+++ b/dev-java/jts-core/jts-core-1.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="JTS Topology Suite for Java"
-HOMEPAGE="http://tsusiatsoftware.net/jts/main.html"
+HOMEPAGE="https://tsusiatsoftware.net/jts/main.html"
 SRC_URI="https://github.com/dr-jts/jts/archive/${GIT_REF}.tar.gz -> ${MY_PN}-${PV}.tar.gz"
 LICENSE="LGPL-2.1+"
 SLOT="0"

--- a/dev-java/lzma/lzma-9.18.ebuild
+++ b/dev-java/lzma/lzma-9.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Java code for LZMA compression and decompression"
-HOMEPAGE="http://www.7-zip.org/"
+HOMEPAGE="https://www.7-zip.org/"
 SRC_URI="mirror://sourceforge/sevenzip/${PN}${PV/./}.tar.bz2"
 
 LICENSE="public-domain"

--- a/dev-java/lzmajio/lzmajio-0.95-r1.ebuild
+++ b/dev-java/lzmajio/lzmajio-0.95-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,8 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="LzmaInputStream/LzmaOutputStream interacting with underlying LZMA en-/decoders"
-HOMEPAGE="http://contrapunctus.net/league/haques/lzmajio/"
+HOMEPAGE="https://contrapunctus.net/league/haques/lzmajio/
+	https://github.com/league/lzmajio"
 SRC_URI="http://comsci.liu.edu/~league/dist/${PN}/${P}.tar.gz"
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-java/lzmajio/lzmajio-0.95-r2.ebuild
+++ b/dev-java/lzmajio/lzmajio-0.95-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,8 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="LzmaInputStream/LzmaOutputStream interacting with underlying LZMA en-/decoders"
-HOMEPAGE="https://github.com/league/lzmajio"
+HOMEPAGE="https://contrapunctus.net/league/haques/lzmajio/
+	https://github.com/league/lzmajio"
 SRC_URI="https://github.com/league/${P}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-java/sbt-bin/sbt-bin-0.12.4.ebuild
+++ b/dev-java/sbt-bin/sbt-bin-0.12.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit java-pkg-2
 
 DESCRIPTION="sbt, a build tool for Scala."
-HOMEPAGE="http://scala-sbt.org"
+HOMEPAGE="https://scala-sbt.org"
 SRC_URI="https://dl.bintray.com/sbt/native-packages/sbt/${PV}/${PN/-bin}-${PV}.tgz"
 
 LICENSE="BSD"

--- a/dev-java/sbt-bin/sbt-bin-0.13.15.ebuild
+++ b/dev-java/sbt-bin/sbt-bin-0.13.15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit java-pkg-2
 
 DESCRIPTION="sbt, a build tool for Scala"
-HOMEPAGE="http://scala-sbt.org"
+HOMEPAGE="https://scala-sbt.org"
 SRC_URI="https://dl.bintray.com/sbt/native-packages/sbt/${PV}/${PN/-bin}-${PV}.tgz"
 
 LICENSE="BSD"

--- a/dev-java/sbt-bin/sbt-bin-0.13.6.ebuild
+++ b/dev-java/sbt-bin/sbt-bin-0.13.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit java-pkg-2
 
 DESCRIPTION="sbt, a build tool for Scala."
-HOMEPAGE="http://scala-sbt.org"
+HOMEPAGE="https://scala-sbt.org"
 SRC_URI="https://dl.bintray.com/sbt/native-packages/sbt/${PV}/${PN/-bin}-${PV}.tgz"
 
 LICENSE="BSD"

--- a/dev-java/sbt-bin/sbt-bin-0.13.7.ebuild
+++ b/dev-java/sbt-bin/sbt-bin-0.13.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit java-pkg-2
 
 DESCRIPTION="sbt, a build tool for Scala."
-HOMEPAGE="http://scala-sbt.org"
+HOMEPAGE="https://scala-sbt.org"
 SRC_URI="https://dl.bintray.com/sbt/native-packages/sbt/${PV}/${PN/-bin}-${PV}.tgz"
 
 LICENSE="BSD"

--- a/dev-java/sbt-bin/sbt-bin-0.13.8.ebuild
+++ b/dev-java/sbt-bin/sbt-bin-0.13.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit java-pkg-2
 
 DESCRIPTION="sbt, a build tool for Scala."
-HOMEPAGE="http://scala-sbt.org"
+HOMEPAGE="https://scala-sbt.org"
 SRC_URI="https://dl.bintray.com/sbt/native-packages/sbt/${PV}/${PN/-bin}-${PV}.tgz"
 
 LICENSE="BSD"

--- a/dev-java/sbt-bin/sbt-bin-0.13.9.ebuild
+++ b/dev-java/sbt-bin/sbt-bin-0.13.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit java-pkg-2
 
 DESCRIPTION="sbt, a build tool for Scala."
-HOMEPAGE="http://scala-sbt.org"
+HOMEPAGE="https://scala-sbt.org"
 SRC_URI="https://dl.bintray.com/sbt/native-packages/sbt/${PV}/${PN/-bin}-${PV}.tgz"
 
 LICENSE="BSD"

--- a/dev-java/xmlgraphics-commons/xmlgraphics-commons-2.0.1.ebuild
+++ b/dev-java/xmlgraphics-commons/xmlgraphics-commons-2.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ JAVA_PKG_IUSE="doc examples source test"
 inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="A library of several reusable components used by Apache Batik and Apache FOP"
-HOMEPAGE="http://xmlgraphics.apache.org/commons/index.html"
+HOMEPAGE="https://xmlgraphics.apache.org/commons/index.html"
 SRC_URI="mirror://apache/xmlgraphics/commons/source/${P}-src.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-java/xmpcore/xmpcore-5.1.2.ebuild
+++ b/dev-java/xmpcore/xmpcore-5.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ JAVA_PKG_IUSE="doc source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Java library based on the Adobe C++ XMPCore library with a similar API"
-HOMEPAGE="http://www.adobe.com/devnet/xmp.html"
+HOMEPAGE="https://www.adobe.com/devnet/xmp.html"
 SRC_URI="http://central.maven.org/maven2/com/adobe/xmp/${PN}/${PV}/${P}-sources.jar"
 LICENSE="BSD"
 SLOT="0"

--- a/dev-java/xz-java/xz-java-1.5.ebuild
+++ b/dev-java/xz-java/xz-java-1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,8 +7,8 @@ JAVA_PKG_IUSE="doc examples source"
 inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="Implementation of xz data compression in pure java"
-HOMEPAGE="http://tukaani.org/xz/java.html"
-SRC_URI="http://tukaani.org/xz/${P}.zip"
+HOMEPAGE="https://tukaani.org/xz/java.html"
+SRC_URI="https://tukaani.org/xz/${P}.zip"
 
 LICENSE="public-domain"
 SLOT="0"

--- a/dev-java/xz-java/xz-java-1.6-r1.ebuild
+++ b/dev-java/xz-java/xz-java-1.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ JAVA_PKG_IUSE="doc examples source"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Implementation of xz data compression in pure java"
-HOMEPAGE="http://tukaani.org/xz/java.html"
-SRC_URI="http://tukaani.org/xz/${P}.zip"
+HOMEPAGE="https://tukaani.org/xz/java.html"
+SRC_URI="https://tukaani.org/xz/${P}.zip"
 
 LICENSE="public-domain"
 SLOT="0"

--- a/dev-java/xz-java/xz-java-1.6.ebuild
+++ b/dev-java/xz-java/xz-java-1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,8 +7,8 @@ JAVA_PKG_IUSE="doc examples source"
 inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="Implementation of xz data compression in pure java"
-HOMEPAGE="http://tukaani.org/xz/java.html"
-SRC_URI="http://tukaani.org/xz/${P}.zip"
+HOMEPAGE="https://tukaani.org/xz/java.html"
+SRC_URI="https://tukaani.org/xz/${P}.zip"
 
 LICENSE="public-domain"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes a few java packages to use https instead of http.
All homepages were tested, all SRC_URI were fetch-tested.

Please review.