### PR TITLE
dev-python/seaborn: bumped Python support

### DIFF
--- a/dev-python/seaborn/seaborn-0.7.1.ebuild
+++ b/dev-python/seaborn/seaborn-0.7.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_{4,5}} )
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} )
 
 inherit distutils-r1 virtualx
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.28, Repoman-2.3.9