### PR TITLE
sys-fs/f2fs-tools: keyword ~arm64

### DIFF
--- a/sys-fs/f2fs-tools/f2fs-tools-1.10.0.ebuild
+++ b/sys-fs/f2fs-tools/f2fs-tools-1.10.0.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://dev.gentoo.org/~blueness/f2fs-tools/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0/4"
-KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 IUSE="selinux"
 
 RDEPEND="


### PR DESCRIPTION
sys-fs/f2fs-tools works on arm64 and is important for various flash storagedevices

@leio 