### PR TITLE
dev-libs/libedit, sys-auth/openpam, sys-process/pidof-bsd: use HTTPS

### DIFF
--- a/dev-libs/libedit/libedit-20130712.3.1.ebuild
+++ b/dev-libs/libedit/libedit-20130712.3.1.ebuild
@@ -9,8 +9,8 @@ MY_PV=$(get_major_version)-$(get_after_major_version)
 MY_P=${PN}-${MY_PV}
 
 DESCRIPTION="BSD replacement for libreadline"
-HOMEPAGE="http://www.thrysoee.dk/editline/"
-SRC_URI="http://www.thrysoee.dk/editline/${MY_P}.tar.gz"
+HOMEPAGE="https://thrysoee.dk/editline/"
+SRC_URI="https://thrysoee.dk/editline/${MY_P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/dev-libs/libedit/libedit-20170329.3.1.ebuild
+++ b/dev-libs/libedit/libedit-20170329.3.1.ebuild
@@ -8,8 +8,8 @@ MY_PV=${PV/./-}
 MY_P=${PN}-${MY_PV}
 
 DESCRIPTION="BSD replacement for libreadline"
-HOMEPAGE="http://thrysoee.dk/editline/"
-SRC_URI="http://thrysoee.dk/editline/${MY_P}.tar.gz"
+HOMEPAGE="https://thrysoee.dk/editline/"
+SRC_URI="https://thrysoee.dk/editline/${MY_P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/sys-auth/openpam/openpam-20140912-r1.ebuild
+++ b/sys-auth/openpam/openpam-20140912-r1.ebuild
@@ -9,7 +9,7 @@ AUTOTOOLS_PRUNE_LIBTOOL_FILES=all
 inherit multilib autotools-multilib
 
 DESCRIPTION="Open source PAM library"
-HOMEPAGE="http://www.openpam.org/"
+HOMEPAGE="https://www.openpam.org/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/sys-auth/openpam/openpam-20140912-r2.ebuild
+++ b/sys-auth/openpam/openpam-20140912-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools multilib-minimal
 
 DESCRIPTION="Open source PAM library"
-HOMEPAGE="http://www.openpam.org/"
+HOMEPAGE="https://www.openpam.org/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/sys-process/pidof-bsd/pidof-bsd-20050501-r4.ebuild
+++ b/sys-process/pidof-bsd/pidof-bsd-20050501-r4.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 inherit bsdmk
 
 DESCRIPTION="pidof(1) utility for *BSD"
-HOMEPAGE="http://people.freebsd.org/~novel/pidof.html"
+HOMEPAGE="https://people.freebsd.org/~novel/pidof.html"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Hi,

This PR fixes a few bsd related packages to use https instead of http.

Please review.