### PR TITLE
dev-cpp/*,dev-libs/*,dev-util/build: use HTTPS

### DIFF
--- a/dev-cpp/libcutl/libcutl-1.10.0.ebuild
+++ b/dev-cpp/libcutl/libcutl-1.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit autotools flag-o-matic versionator
 
 DESCRIPTION="A collection of C++ libraries (successor of libcult)"
-HOMEPAGE="http://www.codesynthesis.com/projects/libcutl/"
-SRC_URI="http://www.codesynthesis.com/download/${PN}/$(get_version_component_range 1-2)/${P}.tar.bz2"
+HOMEPAGE="https://www.codesynthesis.com/projects/libcutl/"
+SRC_URI="https://www.codesynthesis.com/download/${PN}/$(get_version_component_range 1-2)/${P}.tar.bz2"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-cpp/libxsd-frontend/libxsd-frontend-2.0.0.ebuild
+++ b/dev-cpp/libxsd-frontend/libxsd-frontend-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs versionator
 
 DESCRIPTION="A compiler frontend for the W3C XML Schema definition language"
-HOMEPAGE="http://www.codesynthesis.com/projects/libxsd-frontend/"
-SRC_URI="http://www.codesynthesis.com/download/${PN}/$(get_version_component_range 1-2)/${P}.tar.bz2"
+HOMEPAGE="https://www.codesynthesis.com/projects/libxsd-frontend/"
+SRC_URI="https://www.codesynthesis.com/download/${PN}/$(get_version_component_range 1-2)/${P}.tar.bz2"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"

--- a/dev-cpp/xsd/xsd-4.0.0.ebuild
+++ b/dev-cpp/xsd/xsd-4.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs versionator
 
 DESCRIPTION="An open-source, cross-platform W3C XML Schema to C++ data binding compiler"
-HOMEPAGE="http://www.codesynthesis.com/products/xsd/"
-SRC_URI="http://www.codesynthesis.com/download/${PN}/$(get_version_component_range 1-2)/${P}.tar.bz2"
+HOMEPAGE="https://www.codesynthesis.com/products/xsd/"
+SRC_URI="https://www.codesynthesis.com/download/${PN}/$(get_version_component_range 1-2)/${P}.tar.bz2"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"

--- a/dev-libs/boost/boost-1.63.0.ebuild
+++ b/dev-libs/boost/boost-1.63.0.ebuild
@@ -10,7 +10,7 @@ MY_P="${PN}_$(replace_all_version_separators _)"
 MAJOR_V="$(get_version_component_range 1-2)"
 
 DESCRIPTION="Boost Libraries for C++"
-HOMEPAGE="http://www.boost.org/"
+HOMEPAGE="https://www.boost.org/"
 SRC_URI="https://downloads.sourceforge.net/project/boost/${PN}/${PV}/${MY_P}.tar.bz2"
 
 LICENSE="Boost-1.0"

--- a/dev-libs/boost/boost-1.65.0.ebuild
+++ b/dev-libs/boost/boost-1.65.0.ebuild
@@ -10,7 +10,7 @@ MY_P="${PN}_$(replace_all_version_separators _)"
 MAJOR_V="$(get_version_component_range 1-2)"
 
 DESCRIPTION="Boost Libraries for C++"
-HOMEPAGE="http://www.boost.org/"
+HOMEPAGE="https://www.boost.org/"
 SRC_URI="https://downloads.sourceforge.net/project/boost/${PN}/${PV}/${MY_P}.tar.bz2"
 
 LICENSE="Boost-1.0"

--- a/dev-libs/boost/boost-1.66.0.ebuild
+++ b/dev-libs/boost/boost-1.66.0.ebuild
@@ -10,7 +10,7 @@ MY_P="${PN}_$(replace_all_version_separators _)"
 MAJOR_V="$(get_version_component_range 1-2)"
 
 DESCRIPTION="Boost Libraries for C++"
-HOMEPAGE="http://www.boost.org/"
+HOMEPAGE="https://www.boost.org/"
 SRC_URI="https://downloads.sourceforge.net/project/boost/${PN}/${PV}/${MY_P}.tar.bz2"
 
 LICENSE="Boost-1.0"

--- a/dev-libs/poco/poco-1.4.6_p4-r1.ebuild
+++ b/dev-libs/poco/poco-1.4.6_p4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -9,8 +9,8 @@ MY_P="${P/_}"
 MY_DOCP="${PN}-$(get_version_component_range 1-3)-all-doc"
 
 DESCRIPTION="C++ libraries for building network-based applications"
-HOMEPAGE="http://pocoproject.org/"
-SRC_URI="http://pocoproject.org/releases/poco-$(get_version_component_range 1-3)/${MY_P}-all.tar.bz2
+HOMEPAGE="https://pocoproject.org/"
+SRC_URI="https://pocoproject.org/releases/poco-$(get_version_component_range 1-3)/${MY_P}-all.tar.bz2
 	doc? ( mirror://sourceforge/poco/${MY_DOCP}.zip )"
 LICENSE="Boost-1.0"
 SLOT="0"

--- a/dev-libs/poco/poco-1.4.6_p4.ebuild
+++ b/dev-libs/poco/poco-1.4.6_p4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -9,8 +9,8 @@ MY_P="${P/_}"
 MY_DOCP="${PN}-$(get_version_component_range 1-3)-all-doc"
 
 DESCRIPTION="C++ libraries for building network-based applications"
-HOMEPAGE="http://pocoproject.org/"
-SRC_URI="http://pocoproject.org/releases/poco-$(get_version_component_range 1-3)/${MY_P}-all.tar.bz2
+HOMEPAGE="https://pocoproject.org/"
+SRC_URI="https://pocoproject.org/releases/poco-$(get_version_component_range 1-3)/${MY_P}-all.tar.bz2
 	doc? ( mirror://sourceforge/poco/${MY_DOCP}.zip )"
 LICENSE="Boost-1.0"
 SLOT="0"

--- a/dev-libs/poco/poco-1.7.6.ebuild
+++ b/dev-libs/poco/poco-1.7.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="C++ libraries for building network-based applications"
-HOMEPAGE="http://pocoproject.org/"
+HOMEPAGE="https://pocoproject.org/"
 SRC_URI="https://github.com/pocoproject/${PN}/archive/${P}-release.tar.gz -> ${P}.tar.gz"
 LICENSE="Boost-1.0"
 SLOT="0"

--- a/dev-libs/quantlib/quantlib-1.6.ebuild
+++ b/dev-libs/quantlib/quantlib-1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit elisp-common eutils toolchain-funcs
 MY_P="QuantLib-${PV}"
 
 DESCRIPTION="A comprehensive software framework for quantitative finance"
-HOMEPAGE="http://quantlib.org/"
+HOMEPAGE="https://quantlib.org/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-libs/quantlib/quantlib-1.7.1.ebuild
+++ b/dev-libs/quantlib/quantlib-1.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ inherit elisp-common eutils toolchain-funcs
 MY_P="QuantLib-${PV}"
 
 DESCRIPTION="A comprehensive software framework for quantitative finance"
-HOMEPAGE="http://quantlib.org/"
+HOMEPAGE="https://quantlib.org/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-util/build/build-0.3.10.ebuild
+++ b/dev-util/build/build-0.3.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,9 +6,9 @@ EAPI=6
 inherit versionator
 
 DESCRIPTION="A massively-parallel software build system implemented on top of GNU make"
-HOMEPAGE="http://www.codesynthesis.com/projects/build/"
+HOMEPAGE="https://www.codesynthesis.com/projects/build/"
 SLOT="0"
-SRC_URI="http://www.codesynthesis.com/download/${PN}/$(get_version_component_range 1-2)/${P}.tar.bz2"
+SRC_URI="https://www.codesynthesis.com/download/${PN}/$(get_version_component_range 1-2)/${P}.tar.bz2"
 LICENSE="GPL-2"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
 IUSE="examples"


### PR DESCRIPTION
Hi,

Just a few cpp related packages which should use https instead of http.

Please review.