### PR TITLE
dev-embedded/*,dev-libs/*,sci-electronics/*,... : use HTTPS

### DIFF
--- a/dev-embedded/arduino/arduino-1.0.5-r1.ebuild
+++ b/dev-embedded/arduino/arduino-1.0.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -7,7 +7,7 @@ JAVA_PKG_IUSE="doc examples"
 inherit eutils java-pkg-2 java-ant-2
 
 DESCRIPTION="An open-source AVR electronics prototyping platform"
-HOMEPAGE="http://arduino.cc/ https://arduino.googlecode.com/"
+HOMEPAGE="https://arduino.cc/ https://github.com/arduino/"
 SRC_URI="https://${PN}.googlecode.com/files/${P}-src.tar.gz
 mirror://gentoo/arduino-icons.tar.bz2"
 LICENSE="GPL-2 GPL-2+ LGPL-2 CC-BY-SA-3.0"

--- a/dev-embedded/arduino/arduino-1.0.5-r2.ebuild
+++ b/dev-embedded/arduino/arduino-1.0.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ JAVA_PKG_IUSE="doc examples"
 inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="An open-source AVR electronics prototyping platform"
-HOMEPAGE="http://arduino.cc/ https://github.com/arduino/"
+HOMEPAGE="https://arduino.cc/ https://github.com/arduino/"
 SRC_URI="
 	https://github.com/arduino/Arduino/archive/${PV}.tar.gz -> arduino-src-${PV}.tar.gz
 	mirror://gentoo/arduino-icons.tar.bz2

--- a/dev-embedded/arduino/arduino-1.8.5.ebuild
+++ b/dev-embedded/arduino/arduino-1.8.5.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit java-pkg-2 java-ant-2 gnome2-utils
 
 DESCRIPTION="An open-source AVR electronics prototyping platform"
-HOMEPAGE="http://arduino.cc/"
+HOMEPAGE="https://arduino.cc/ https://github.com/arduino/"
 
 ARDUINO_LIBRARIES=(
 	"Firmata 2.5.6"

--- a/dev-embedded/gnome-avrdude/gnome-avrdude-0.1.ebuild
+++ b/dev-embedded/gnome-avrdude/gnome-avrdude-0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit gnome2 autotools
 
 DESCRIPTION="GNOME GUI for avrdude"
-HOMEPAGE="http://www.sourceforge.net/projects/gnome-avrdude/"
+HOMEPAGE="https://www.sourceforge.net/projects/gnome-avrdude/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-embedded/mspdebug/mspdebug-0.23.ebuild
+++ b/dev-embedded/mspdebug/mspdebug-0.23.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit toolchain-funcs eutils
 
 DESCRIPTION="A free debugger for use with MSP430 MCUs"
-HOMEPAGE="http://dlbeer.co.nz/mspdebug/ https://github.com/dlbeer/mspdebug"
+HOMEPAGE="https://dlbeer.co.nz/mspdebug/ https://github.com/dlbeer/mspdebug"
 SRC_URI="https://github.com/dlbeer/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-embedded/mspdebug/mspdebug-0.24.ebuild
+++ b/dev-embedded/mspdebug/mspdebug-0.24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="A free debugger for use with MSP430 MCUs"
-HOMEPAGE="http://dlbeer.co.nz/mspdebug/ https://github.com/dlbeer/mspdebug"
+HOMEPAGE="https://dlbeer.co.nz/mspdebug/ https://github.com/dlbeer/mspdebug"
 SRC_URI="https://github.com/dlbeer/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-libs/libserialport/libserialport-0.1.0.ebuild
+++ b/dev-libs/libserialport/libserialport-0.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -9,12 +9,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="Cross platform serial port access library"
-HOMEPAGE="http://sigrok.org/wiki/Libserialport"
+HOMEPAGE="https://sigrok.org/wiki/Libserialport"
 
 LICENSE="LGPL-3"
 SLOT="0"

--- a/dev-libs/libserialport/libserialport-0.1.1.ebuild
+++ b/dev-libs/libserialport/libserialport-0.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,12 +9,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="amd64 x86"
 fi
 
 DESCRIPTION="Cross platform serial port access library"
-HOMEPAGE="http://sigrok.org/wiki/Libserialport"
+HOMEPAGE="https://sigrok.org/wiki/Libserialport"
 
 LICENSE="LGPL-3"
 SLOT="0"

--- a/dev-libs/libserialport/libserialport-9999.ebuild
+++ b/dev-libs/libserialport/libserialport-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,12 +9,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="Cross platform serial port access library"
-HOMEPAGE="http://sigrok.org/wiki/Libserialport"
+HOMEPAGE="https://sigrok.org/wiki/Libserialport"
 
 LICENSE="LGPL-3"
 SLOT="0"

--- a/sci-electronics/pulseview/pulseview-0.4.0.ebuild
+++ b/sci-electronics/pulseview/pulseview-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="Qt based logic analyzer GUI for sigrok"
-HOMEPAGE="http://sigrok.org/wiki/PulseView"
+HOMEPAGE="https://sigrok.org/wiki/PulseView"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/sci-electronics/pulseview/pulseview-9999.ebuild
+++ b/sci-electronics/pulseview/pulseview-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="Qt based logic analyzer GUI for sigrok"
-HOMEPAGE="http://sigrok.org/wiki/PulseView"
+HOMEPAGE="https://sigrok.org/wiki/PulseView"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/sci-electronics/sigrok-cli/sigrok-cli-0.7.0.ebuild
+++ b/sci-electronics/sigrok-cli/sigrok-cli-0.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="Command-line client for the sigrok logic analyzer software"
-HOMEPAGE="http://sigrok.org/wiki/Sigrok-cli"
+HOMEPAGE="https://sigrok.org/wiki/Sigrok-cli"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/sci-electronics/sigrok-cli/sigrok-cli-9999.ebuild
+++ b/sci-electronics/sigrok-cli/sigrok-cli-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="Command-line client for the sigrok logic analyzer software"
-HOMEPAGE="http://sigrok.org/wiki/Sigrok-cli"
+HOMEPAGE="https://sigrok.org/wiki/Sigrok-cli"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/sci-libs/libsigrok/libsigrok-0.3.0.ebuild
+++ b/sci-libs/libsigrok/libsigrok-0.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -9,12 +9,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="amd64 x86"
 fi
 
 DESCRIPTION="basic hardware drivers for logic analyzers and input/output file format support"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrok"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrok"
 
 LICENSE="GPL-3"
 SLOT="0/2"

--- a/sci-libs/libsigrok/libsigrok-0.4.0.ebuild
+++ b/sci-libs/libsigrok/libsigrok-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="basic hardware drivers for logic analyzers and input/output file format support"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrok"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrok"
 
 LICENSE="GPL-3"
 SLOT="0/3"

--- a/sci-libs/libsigrok/libsigrok-0.5.0.ebuild
+++ b/sci-libs/libsigrok/libsigrok-0.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="basic hardware drivers for logic analyzers and input/output file format support"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrok"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrok"
 
 LICENSE="GPL-3"
 SLOT="0/4"

--- a/sci-libs/libsigrok/libsigrok-9999.ebuild
+++ b/sci-libs/libsigrok/libsigrok-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="basic hardware drivers for logic analyzers and input/output file format support"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrok"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrok"
 
 LICENSE="GPL-3"
 SLOT="0/9999"

--- a/sci-libs/libsigrokdecode/libsigrokdecode-0.3.0.ebuild
+++ b/sci-libs/libsigrokdecode/libsigrokdecode-0.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -10,12 +10,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="provide (streaming) protocol decoding functionality"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrokdecode"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrokdecode"
 
 LICENSE="GPL-3"
 SLOT="0/2"

--- a/sci-libs/libsigrokdecode/libsigrokdecode-0.4.0.ebuild
+++ b/sci-libs/libsigrokdecode/libsigrokdecode-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="provide (streaming) protocol decoding functionality"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrokdecode"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrokdecode"
 
 LICENSE="GPL-3"
 SLOT="0/3"

--- a/sci-libs/libsigrokdecode/libsigrokdecode-0.4.1.ebuild
+++ b/sci-libs/libsigrokdecode/libsigrokdecode-0.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="provide (streaming) protocol decoding functionality"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrokdecode"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrokdecode"
 
 LICENSE="GPL-3"
 SLOT="0/3"

--- a/sci-libs/libsigrokdecode/libsigrokdecode-0.5.0.ebuild
+++ b/sci-libs/libsigrokdecode/libsigrokdecode-0.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="provide (streaming) protocol decoding functionality"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrokdecode"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrokdecode"
 
 LICENSE="GPL-3"
 SLOT="0/4"

--- a/sci-libs/libsigrokdecode/libsigrokdecode-9999.ebuild
+++ b/sci-libs/libsigrokdecode/libsigrokdecode-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,12 +11,12 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="http://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="provide (streaming) protocol decoding functionality"
-HOMEPAGE="http://sigrok.org/wiki/Libsigrokdecode"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrokdecode"
 
 LICENSE="GPL-3"
 SLOT="0/9999"

--- a/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.2.ebuild
+++ b/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -9,13 +9,13 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="git://sigrok.org/${PN}"
 	inherit git-r3 autotools
 else
-	SRC_URI="binary? ( http://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
-		!binary? ( http://sigrok.org/download/source/${PN}/${P}.tar.gz )"
+	SRC_URI="binary? ( https://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
+		!binary? ( https://sigrok.org/download/source/${PN}/${P}.tar.gz )"
 	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="Firmware for Cypress FX2 chips for use as simple logic analyzer hardware"
-HOMEPAGE="http://sigrok.org/wiki/Fx2lafw"
+HOMEPAGE="https://sigrok.org/wiki/Fx2lafw"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.3.ebuild
+++ b/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -10,15 +10,15 @@ if [[ ${PV} == "9999" ]]; then
 	IUSE=""
 	inherit git-r3 autotools
 else
-	SRC_URI="binary? ( http://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
-		!binary? ( http://sigrok.org/download/source/${PN}/${P}.tar.gz )"
+	SRC_URI="binary? ( https://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
+		!binary? ( https://sigrok.org/download/source/${PN}/${P}.tar.gz )"
 	KEYWORDS="~amd64 ~x86"
 	IUSE="binary"
 	SDCC_DEPEND="!binary? ( ${SDCC_DEPEND} )"
 fi
 
 DESCRIPTION="Firmware for Cypress FX2 chips for use as simple logic analyzer hardware"
-HOMEPAGE="http://sigrok.org/wiki/Fx2lafw"
+HOMEPAGE="https://sigrok.org/wiki/Fx2lafw"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.4.ebuild
+++ b/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -10,15 +10,15 @@ if [[ ${PV} == "9999" ]]; then
 	IUSE=""
 	inherit git-r3 autotools
 else
-	SRC_URI="binary? ( http://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
-		!binary? ( http://sigrok.org/download/source/${PN}/${P}.tar.gz )"
+	SRC_URI="binary? ( https://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
+		!binary? ( https://sigrok.org/download/source/${PN}/${P}.tar.gz )"
 	KEYWORDS="~amd64 ~x86"
 	IUSE="binary"
 	SDCC_DEPEND="!binary? ( ${SDCC_DEPEND} )"
 fi
 
 DESCRIPTION="Firmware for Cypress FX2 chips for use as simple logic analyzer hardware"
-HOMEPAGE="http://sigrok.org/wiki/Fx2lafw"
+HOMEPAGE="https://sigrok.org/wiki/Fx2lafw"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.5.ebuild
+++ b/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -10,15 +10,15 @@ if [[ ${PV} == "9999" ]]; then
 	IUSE=""
 	inherit git-r3 autotools
 else
-	SRC_URI="binary? ( http://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
-		!binary? ( http://sigrok.org/download/source/${PN}/${P}.tar.gz )"
+	SRC_URI="binary? ( https://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
+		!binary? ( https://sigrok.org/download/source/${PN}/${P}.tar.gz )"
 	KEYWORDS="~amd64 ~x86"
 	IUSE="binary"
 	SDCC_DEPEND="!binary? ( ${SDCC_DEPEND} )"
 fi
 
 DESCRIPTION="Firmware for Cypress FX2 chips for use as simple logic analyzer hardware"
-HOMEPAGE="http://sigrok.org/wiki/Fx2lafw"
+HOMEPAGE="https://sigrok.org/wiki/Fx2lafw"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.6.ebuild
+++ b/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.6.ebuild
@@ -10,15 +10,15 @@ if [[ ${PV} == "9999" ]]; then
 	IUSE=""
 	inherit git-r3 autotools
 else
-	SRC_URI="binary? ( http://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
-		!binary? ( http://sigrok.org/download/source/${PN}/${P}.tar.gz )"
+	SRC_URI="binary? ( https://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
+		!binary? ( https://sigrok.org/download/source/${PN}/${P}.tar.gz )"
 	KEYWORDS="~amd64 ~x86"
 	IUSE="binary"
 	SDCC_DEPEND="!binary? ( ${SDCC_DEPEND} )"
 fi
 
 DESCRIPTION="Firmware for Cypress FX2 chips for use as simple logic analyzer hardware"
-HOMEPAGE="http://sigrok.org/wiki/Fx2lafw"
+HOMEPAGE="https://sigrok.org/wiki/Fx2lafw"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-9999.ebuild
+++ b/sys-firmware/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -10,15 +10,15 @@ if [[ ${PV} == "9999" ]]; then
 	IUSE=""
 	inherit git-r3 autotools
 else
-	SRC_URI="binary? ( http://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
-		!binary? ( http://sigrok.org/download/source/${PN}/${P}.tar.gz )"
+	SRC_URI="binary? ( https://sigrok.org/download/binary/${PN}/${PN}-bin-${PV}.tar.gz )
+		!binary? ( https://sigrok.org/download/source/${PN}/${P}.tar.gz )"
 	KEYWORDS="~amd64 ~x86"
 	IUSE="binary"
 	SDCC_DEPEND="!binary? ( ${SDCC_DEPEND} )"
 fi
 
 DESCRIPTION="Firmware for Cypress FX2 chips for use as simple logic analyzer hardware"
-HOMEPAGE="http://sigrok.org/wiki/Fx2lafw"
+HOMEPAGE="https://sigrok.org/wiki/Fx2lafw"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/sys-libs/uclibc-ng/uclibc-ng-1.0.26.ebuild
+++ b/sys-libs/uclibc-ng/uclibc-ng-1.0.26.ebuild
@@ -14,10 +14,10 @@ else
 fi
 
 DESCRIPTION="C library for developing embedded Linux systems"
-HOMEPAGE="http://www.uclibc-ng.org/"
+HOMEPAGE="https://uclibc-ng.org/"
 if [[ ${PV} != "9999" ]] ; then
 	PATCH_VER=""
-	SRC_URI="http://downloads.uclibc-ng.org/releases/${PV}/${MY_P}.tar.bz2"
+	SRC_URI="https://downloads.uclibc-ng.org/releases/${PV}/${MY_P}.tar.bz2"
 	KEYWORDS="-* amd64 arm ~mips ~ppc x86"
 fi
 

--- a/sys-libs/uclibc-ng/uclibc-ng-1.0.28.ebuild
+++ b/sys-libs/uclibc-ng/uclibc-ng-1.0.28.ebuild
@@ -17,7 +17,7 @@ DESCRIPTION="C library for developing embedded Linux systems"
 HOMEPAGE="https://uclibc-ng.org/"
 if [[ ${PV} != "9999" ]] ; then
 	PATCH_VER=""
-	SRC_URI="http://downloads.uclibc-ng.org/releases/${PV}/${MY_P}.tar.bz2"
+	SRC_URI="https://downloads.uclibc-ng.org/releases/${PV}/${MY_P}.tar.bz2"
 	KEYWORDS="-* ~amd64 ~arm ~mips ~ppc ~x86"
 fi
 

--- a/sys-libs/uclibc-ng/uclibc-ng-1.0.29.ebuild
+++ b/sys-libs/uclibc-ng/uclibc-ng-1.0.29.ebuild
@@ -17,7 +17,7 @@ DESCRIPTION="C library for developing embedded Linux systems"
 HOMEPAGE="https://uclibc-ng.org/"
 if [[ ${PV} != "9999" ]] ; then
 	PATCH_VER=""
-	SRC_URI="http://downloads.uclibc-ng.org/releases/${PV}/${MY_P}.tar.bz2"
+	SRC_URI="https://downloads.uclibc-ng.org/releases/${PV}/${MY_P}.tar.bz2"
 	KEYWORDS="-* ~amd64 ~arm ~mips ~ppc ~x86"
 fi
 

--- a/sys-libs/uclibc-ng/uclibc-ng-9999.ebuild
+++ b/sys-libs/uclibc-ng/uclibc-ng-9999.ebuild
@@ -17,7 +17,7 @@ DESCRIPTION="C library for developing embedded Linux systems"
 HOMEPAGE="https://uclibc-ng.org/"
 if [[ ${PV} != "9999" ]] ; then
 	PATCH_VER=""
-	SRC_URI="http://downloads.uclibc-ng.org/releases/${PV}/${MY_P}.tar.bz2"
+	SRC_URI="https://downloads.uclibc-ng.org/releases/${PV}/${MY_P}.tar.bz2"
 	KEYWORDS="-* ~amd64 ~arm ~mips ~ppc ~x86"
 fi
 


### PR DESCRIPTION
Hi,

This PR fixes a few embedded related packages to use https instead of http.

Please review.