### PR TITLE
media-gfx/sane-frontends: Repoint SRC_URI.

### DIFF
--- a/media-gfx/sane-frontends/sane-frontends-1.0.14-r3.ebuild
+++ b/media-gfx/sane-frontends/sane-frontends-1.0.14-r3.ebuild
@@ -5,8 +5,7 @@ EAPI=6
 
 DESCRIPTION="Scanner Access Now Easy"
 HOMEPAGE="http://www.sane-project.org"
-SRC_URI="ftp://ftp.sane-project.org/pub/sane/${P}/${P}.tar.gz
-	ftp://ftp.sane-project.org/pub/sane/old-versions/${P}/${P}.tar.gz"
+SRC_URI="https://alioth.debian.org/frs/download.php/file/1140/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
The ftp location went down. Changed to the location in the documentation at http://www.sane-project.org/source.html. There is also a gitlab link but I'm not sure if we want to rely on that.