### PR TITLE
x11-misc/redshift add ayatana USE flag

### DIFF
--- a/x11-misc/redshift/metadata.xml
+++ b/x11-misc/redshift/metadata.xml
@@ -9,7 +9,6 @@
     <name>Gentoo Desktop Miscellaneous Project</name>
   </maintainer>
   <use>
-    <flag name="appindicator">Enable usage of <pkg>dev-libs/libappindicator</pkg> to export menu options in to unity and KDE 5</flag>
     <flag name="geoclue">Control dependency on <pkg>app-misc/geoclue</pkg></flag>
   </use>
   <upstream>

--- a/x11-misc/redshift/redshift-1.11-r1.ebuild
+++ b/x11-misc/redshift/redshift-1.11-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/jonls/redshift/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 x86"
-IUSE="appindicator geoclue gtk nls"
+IUSE="ayatana geoclue gtk nls"
 
 COMMON_DEPEND=">=x11-libs/libX11-1.4
 	x11-libs/libXxf86vm
@@ -28,7 +28,7 @@ RDEPEND="${COMMON_DEPEND}
 DEPEND="${COMMON_DEPEND}
 	>=dev-util/intltool-0.50
 	nls? ( sys-devel/gettext )
-	appindicator? ( dev-libs/libappindicator )
+	ayatana? ( dev-libs/libappindicator:3 )
 "
 REQUIRED_USE="gtk? ( ${PYTHON_REQUIRED_USE} )"
 


### PR DESCRIPTION
And make sure the dependency on dev-libs/libappindicator is on the correct version/slot

The name of the USE flag for appindicator support is ayatana, not appindicator :)
See https://github.com/gentoo/gentoo/blob/master/profiles/use.desc#L28

I don't think this requires a revbump, but if it should be a revbump please let me know and I'll update the PR.