### PR TITLE
dev-python/m2crypto: properly detect LibreSSL versions

### DIFF
--- a/dev-python/m2crypto/files/m2crypto-libressl-version-check.patch
+++ b/dev-python/m2crypto/files/m2crypto-libressl-version-check.patch
@@ -1,0 +1,154 @@
+--- a/SWIG/_bio.i
++++ b/SWIG/_bio.i
+@@ -63,14 +63,14 @@ extern BIO *BIO_pop(BIO *);
+ static PyObject *_bio_err;
+ 
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ void pyfd_init(void);
+ #endif
+ 
+ void bio_init(PyObject *bio_err) {
+     Py_INCREF(bio_err);
+     _bio_err = bio_err;
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+     pyfd_init();
+ #endif
+ }
+@@ -299,7 +299,7 @@ int bio_should_write(BIO* a) {
+     return BIO_should_write(a);
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ /* implment custom BIO_s_pyfd */
+ 
+ #ifdef WIN32
+
+--- a/SWIG/_evp.i
++++ b/SWIG/_evp.i
+@@ -19,7 +19,7 @@ Copyright (c) 2009-2010 Heikki Toivonen. All rights reserved.
+ #include <openssl/rsa.h>
+ #include <openssl/opensslv.h>
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ HMAC_CTX *HMAC_CTX_new(void) {
+     HMAC_CTX *ret = PyMem_Malloc(sizeof(HMAC_CTX));
+
+--- a/SWIG/_lib.i
++++ b/SWIG/_lib.i
+@@ -18,7 +18,7 @@
+ 
+ %{
+ /* OpenSSL 1.0.2 copmatbility shim */
+-#if OPENSSL_VERSION_NUMBER < 0x10002000L
++#if OPENSSL_VERSION_NUMBER < 0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
+ typedef void (*OPENSSL_sk_freefunc)(void *);
+ typedef void *(*OPENSSL_sk_copyfunc)(const void *);
+ typedef struct stack_st OPENSSL_STACK;
+@@ -501,7 +501,7 @@ int passphrase_callback(char *buf, int num, int v, void *arg) {
+ %inline %{
+ 
+ void lib_init() {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+     SSLeay_add_all_algorithms();
+     ERR_load_ERR_strings();
+ #endif
+
+--- a/SWIG/_lib11_compat.i
++++ b/SWIG/_lib11_compat.i
+@@ -8,7 +8,7 @@
+  */
+ 
+ %{
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #include <string.h>
+ #include <openssl/engine.h>
+
+--- a/SWIG/_ssl.i
++++ b/SWIG/_ssl.i
+@@ -268,7 +268,7 @@ void ssl_init(PyObject *ssl_err, PyObject *ssl_timeout_err) {
+ 
+ #ifndef OPENSSL_NO_SSL3
+ const SSL_METHOD *sslv3_method(void) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+     PyErr_WarnEx(PyExc_DeprecationWarning,
+                  "Function SSLv3_method has been deprecated.", 1);
+ #endif
+@@ -277,7 +277,7 @@ const SSL_METHOD *sslv3_method(void) {
+ #endif
+ 
+ const SSL_METHOD *tlsv1_method(void) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+     PyErr_WarnEx(PyExc_DeprecationWarning,
+                  "Function TLSv1_method has been deprecated.", 1);
+ #endif
+
+--- a/SWIG/_threads.i
++++ b/SWIG/_threads.i
+@@ -5,7 +5,7 @@
+ #include <pythread.h>
+ #include <openssl/crypto.h>
+ 
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #define CRYPTO_num_locks()      (CRYPTO_NUM_LOCKS)
+ static PyThread_type_lock lock_cs[CRYPTO_num_locks()];
+ static long lock_count[CRYPTO_num_locks()];
+@@ -13,7 +13,7 @@ static int thread_mode = 0;
+ #endif
+ 
+ void threading_locking_callback(int mode, int type, const char *file, int line) {
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+         if (mode & CRYPTO_LOCK) {
+                 PyThread_acquire_lock(lock_cs[type], WAIT_LOCK);
+                 lock_count[type]++;
+@@ -25,7 +25,7 @@ void threading_locking_callback(int mode, int type, const char *file, int line)
+ }
+ 
+ unsigned long threading_id_callback(void) {
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+     return (unsigned long)PyThread_get_thread_ident();
+ #else
+     return (unsigned long)0;
+@@ -35,7 +35,7 @@ unsigned long threading_id_callback(void) {
+ 
+ %inline %{
+ void threading_init(void) {
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+     int i;
+     if (!thread_mode) {
+         for (i=0; i<CRYPTO_num_locks(); i++) {
+@@ -50,7 +50,7 @@ void threading_init(void) {
+ }
+ 
+ void threading_cleanup(void) {
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+     int i;
+     if (thread_mode) {
+         CRYPTO_set_locking_callback(NULL);
+
+--- a/SWIG/libcrypto-compat.h
++++ b/SWIG/libcrypto-compat.h
+@@ -1,7 +1,7 @@
+ #ifndef LIBCRYPTO_COMPAT_H
+ #define LIBCRYPTO_COMPAT_H
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #include <openssl/rsa.h>
+ #include <openssl/dsa.h>

--- a/dev-python/m2crypto/m2crypto-0.27.0-r1.ebuild
+++ b/dev-python/m2crypto/m2crypto-0.27.0-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1
+
+MY_PN="M2Crypto"
+
+DESCRIPTION="M2Crypto: A Python crypto and SSL toolkit"
+HOMEPAGE="https://gitlab.com/m2crypto/m2crypto https://pypi.python.org/pypi/M2Crypto"
+SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_PN}-${PV}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
+
+IUSE="libressl"
+
+RDEPEND="
+	!libressl? ( >=dev-libs/openssl-0.9.8:0=[-bindist(-)] )
+	libressl? ( dev-libs/libressl:0= )
+	dev-python/typing[${PYTHON_USEDEP}]
+"
+DEPEND="${RDEPEND}
+	>=dev-lang/swig-1.3.28:0
+	dev-python/setuptools[${PYTHON_USEDEP}]
+"
+
+S="${WORKDIR}/${MY_PN}-${PV}"
+
+# Tests access network, and fail randomly. Bug #431458.
+RESTRICT=test
+
+PATCHES=(
+	"${FILESDIR}/${PN}-libressl-version-check.patch"
+)
+
+python_compile() {
+	# setup.py looks at platform.machine() to determine swig options.
+	# For exotic ABIs, we need to give swig a hint.
+	# https://bugs.gentoo.org/617946
+	# TODO: Fix cross-compiles
+	local -x SWIG_FEATURES=
+	case ${ABI} in
+		x32) SWIG_FEATURES="-D__ILP32__" ;;
+	esac
+	distutils-r1_python_compile --openssl="${EPREFIX}"/usr
+}
+
+python_test() {
+	esetup.py test
+}


### PR DESCRIPTION
Ensure the build environment can determine the LibreSSL version. This
also fixes dependencies such as net-wireless/crda which fail to find the
m2crypto module due to the broken m2crypto build.

Bug: https://bugs.gentoo.org/633832
Package-Manager: Portage-2.3.28, Repoman-2.3.9