### PR TITLE
media-libs/openal: fix mingw-w64 build

### DIFF
--- a/media-libs/openal/files/openal-1.18.2-dont-specify-macros-as-arguments.patch
+++ b/media-libs/openal/files/openal-1.18.2-dont-specify-macros-as-arguments.patch
@@ -1,0 +1,50 @@
+From cae4b1a062b53dd25eba7caa41622be730106749 Mon Sep 17 00:00:00 2001
+From: Chris Robinson <chris.kcat@gmail.com>
+Date: Wed, 28 Mar 2018 14:34:58 -0700
+Subject: [PATCH] Don't specify macros as arguments to CHECK_INCLUDE_FILE(S)
+
+---
+ CMakeLists.txt | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index df1dfe63..07454f15 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -577,7 +577,12 @@ ENDIF()
+ 
+ 
+ # Check if we have Windows headers
+-CHECK_INCLUDE_FILE(windows.h HAVE_WINDOWS_H -D_WIN32_WINNT=0x0502)
++SET(OLD_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS})
++SET(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} -D_WIN32_WINNT=0x0502)
++CHECK_INCLUDE_FILE(windows.h HAVE_WINDOWS_H)
++SET(CMAKE_REQUIRED_DEFINITIONS ${OLD_REQUIRED_DEFINITIONS})
++UNSET(OLD_REQUIRED_DEFINITIONS)
++
+ IF(NOT HAVE_WINDOWS_H)
+     CHECK_SYMBOL_EXISTS(gettimeofday sys/time.h HAVE_GETTIMEOFDAY)
+     IF(NOT HAVE_GETTIMEOFDAY)
+@@ -975,8 +980,11 @@ OPTION(ALSOFT_REQUIRE_WINMM "Require Windows Multimedia backend" OFF)
+ OPTION(ALSOFT_REQUIRE_DSOUND "Require DirectSound backend" OFF)
+ OPTION(ALSOFT_REQUIRE_WASAPI "Require WASAPI backend" OFF)
+ IF(HAVE_WINDOWS_H)
++    SET(OLD_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS})
++    SET(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} -D_WIN32_WINNT=0x0502)
++
+     # Check MMSystem backend
+-    CHECK_INCLUDE_FILES("windows.h;mmsystem.h" HAVE_MMSYSTEM_H -D_WIN32_WINNT=0x0502)
++    CHECK_INCLUDE_FILES("windows.h;mmsystem.h" HAVE_MMSYSTEM_H)
+     IF(HAVE_MMSYSTEM_H)
+         CHECK_SHARED_FUNCTION_EXISTS(waveOutOpen "windows.h;mmsystem.h" winmm "" HAVE_LIBWINMM)
+         IF(HAVE_LIBWINMM)
+@@ -1013,6 +1021,9 @@ IF(HAVE_WINDOWS_H)
+             SET(ALC_OBJS  ${ALC_OBJS} Alc/backends/wasapi.c)
+         ENDIF()
+     ENDIF()
++
++    SET(CMAKE_REQUIRED_DEFINITIONS ${OLD_REQUIRED_DEFINITIONS})
++    UNSET(OLD_REQUIRED_DEFINITIONS)
+ ENDIF()
+ IF(ALSOFT_REQUIRE_WINMM AND NOT HAVE_WINMM)
+     MESSAGE(FATAL_ERROR "Failed to enabled required WinMM backend")

--- a/media-libs/openal/openal-1.18.2-r1.ebuild
+++ b/media-libs/openal/openal-1.18.2-r1.ebuild
@@ -38,6 +38,10 @@ S="${WORKDIR}/${MY_P}"
 
 DOCS=( alsoftrc.sample docs/env-vars.txt docs/hrtf.txt ChangeLog README )
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.18.2-dont-specify-macros-as-arguments.patch
+)
+
 src_configure() {
 	# -DEXAMPLES=OFF to avoid FFmpeg dependency wrt #481670
 	my_configure() {


### PR DESCRIPTION
Added an upstream patch which fixes an issue when using crossdev to
build for mingw-w64:
```
CMake Error at /usr/share/cmake/Modules/CheckIncludeFiles.cmake:63 (message):
  Unknown arguments:

    -D_WIN32_WINNT=0x0502

Call Stack (most recent call first):
  CMakeLists.txt:968 (CHECK_INCLUDE_FILES)
```

Package-Manager: Portage-2.3.28, Repoman-2.3.9