### PR TITLE
virtual: add dev-util/mingw64-runtime to providers

### DIFF
--- a/virtual/glu/glu-9.0-r2.ebuild
+++ b/virtual/glu/glu-9.0-r2.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for OpenGL utility library"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+	|| (
+		>=media-libs/glu-9.0.0-r1[${MULTILIB_USEDEP}]
+		media-libs/opengl-apple
+		dev-util/mingw64-runtime
+	)"

--- a/virtual/opengl/opengl-7.0-r2.ebuild
+++ b/virtual/opengl/opengl-7.0-r2.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for OpenGL implementation"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+	|| (
+		>=media-libs/mesa-9.1.6[${MULTILIB_USEDEP}]
+		media-libs/opengl-apple
+		dev-util/mingw64-runtime
+	)"

--- a/virtual/os-headers/os-headers-0-r1.ebuild
+++ b/virtual/os-headers/os-headers-0-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Virtual for operating system headers"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+# depend on SLOT 0 of linux-headers, because kernel-2.eclass
+# sets a different SLOT for cross-building
+RDEPEND="
+	|| (
+		kernel_linux? ( sys-kernel/linux-headers:0 )
+		kernel_Winnt? (
+			elibc_mingw? ( dev-util/mingw64-runtime )
+		)
+		!prefix? ( sys-freebsd/freebsd-lib )
+	)"


### PR DESCRIPTION
With recent changes to dev-util/mingw64-runtime, one can directly install it via crossdev
in the cross-sysroot and be used as a provider. This will ease cross-compilation of windows
binaries (particularly those with a graphical component) using crossdev.

Closes: https://bugs.gentoo.org/621574
Closes: https://bugs.gentoo.org/621768
Package-Manager: Portage-2.3.28, Repoman-2.3.9