### PR TITLE
dev-lang/python: properly detect LibreSSL version

### DIFF
--- a/dev-lang/python/files/python-2.7.14-libressl-version-check.patch
+++ b/dev-lang/python/files/python-2.7.14-libressl-version-check.patch
@@ -1,0 +1,27 @@
+$OpenBSD: patch-Modules__ssl_c,v 1.6 2018/03/17 22:30:04 sthen Exp $
+
+XXX maybe the second hunk can go away now we have auto-init, I'm not sure
+exactly what python's lock protects
+
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -95,7 +95,8 @@ struct py_ssl_library_code {
+ /* Include generated data (error codes) */
+ #include "_ssl_data.h"
+ 
+-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
++    (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
+ #  define OPENSSL_VERSION_1_1 1
+ #endif
+ 
+@@ -130,6 +131,9 @@ struct py_ssl_library_code {
+ /* OpenSSL 1.1.0+ */
+ #ifndef OPENSSL_NO_SSL2
+ #define OPENSSL_NO_SSL2
++#endif
++#if defined(LIBRESSL_VERSION_NUMBER) && defined(WITH_THREAD)
++#define HAVE_OPENSSL_CRYPTO_LOCK
+ #endif
+ #else /* OpenSSL < 1.1.0 */
+ #if defined(WITH_THREAD)

--- a/dev-lang/python/files/python-3.6.3-libressl-version-check.patch
+++ b/dev-lang/python/files/python-3.6.3-libressl-version-check.patch
@@ -1,0 +1,27 @@
+$OpenBSD: patch-Modules__ssl_c,v 1.2 2018/03/17 22:30:04 sthen Exp $
+
+XXX maybe the second hunk can go away now we have auto-init, I'm not sure
+exactly what python's lock protects
+
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -99,7 +99,8 @@ struct py_ssl_library_code {
+ /* Include generated data (error codes) */
+ #include "_ssl_data.h"
+ 
+-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
++    (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
+ #  define OPENSSL_VERSION_1_1 1
+ #endif
+ 
+@@ -133,6 +134,9 @@ struct py_ssl_library_code {
+ /* OpenSSL 1.1.0+ */
+ #ifndef OPENSSL_NO_SSL2
+ #define OPENSSL_NO_SSL2
++#endif
++#if defined(LIBRESSL_VERSION_NUMBER) && defined(WITH_THREAD)
++#define HAVE_OPENSSL_CRYPTO_LOCK
+ #endif
+ #else /* OpenSSL < 1.1.0 */
+ #if defined(WITH_THREAD)

--- a/dev-lang/python/python-2.7.14-r2.ebuild
+++ b/dev-lang/python/python-2.7.14-r2.ebuild
@@ -1,0 +1,367 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="5"
+WANT_LIBTOOL="none"
+
+inherit autotools eutils flag-o-matic multilib pax-utils python-utils-r1 toolchain-funcs multiprocessing
+
+MY_P="Python-${PV}"
+PATCHSET_VERSION="2.7.14-0"
+
+DESCRIPTION="An interpreted, interactive, object-oriented programming language"
+HOMEPAGE="https://www.python.org/"
+SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~floppym/python/python-gentoo-patches-${PATCHSET_VERSION}.tar.xz"
+
+LICENSE="PSF-2"
+SLOT="2.7"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE="-berkdb build doc elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk +wide-unicode wininst +xml"
+
+# Do not add a dependency on dev-lang/python to this ebuild.
+# If you need to apply a patch which requires python for bootstrapping, please
+# run the bootstrap code on your dev box and include the results in the
+# patchset. See bug 447752.
+
+RDEPEND="app-arch/bzip2:0=
+	>=sys-libs/zlib-1.1.3:0=
+	virtual/libffi
+	virtual/libintl
+	berkdb? ( || (
+		sys-libs/db:5.3
+		sys-libs/db:5.2
+		sys-libs/db:5.1
+		sys-libs/db:5.0
+		sys-libs/db:4.8
+		sys-libs/db:4.7
+		sys-libs/db:4.6
+		sys-libs/db:4.5
+		sys-libs/db:4.4
+		sys-libs/db:4.3
+		sys-libs/db:4.2
+	) )
+	gdbm? ( sys-libs/gdbm:0=[berkdb] )
+	ncurses? (
+		>=sys-libs/ncurses-5.2:0=
+		readline? ( >=sys-libs/readline-4.1:0= )
+	)
+	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	tk? (
+		>=dev-lang/tcl-8.0:0=
+		>=dev-lang/tk-8.0:0=
+		dev-tcltk/blt:0=
+		dev-tcltk/tix
+	)
+	xml? ( >=dev-libs/expat-2.1 )
+	!!<sys-apps/portage-2.1.9"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	>=sys-devel/autoconf-2.65
+	!sys-devel/gcc[libffi(-)]"
+RDEPEND+=" !build? ( app-misc/mime-types )
+	doc? ( dev-python/python-docs:${SLOT} )"
+PDEPEND=">=app-eselect/eselect-python-20140125-r1"
+
+S="${WORKDIR}/${MY_P}"
+
+pkg_setup() {
+	if use berkdb; then
+		ewarn "'bsddb' module is out-of-date and no longer maintained inside"
+		ewarn "dev-lang/python. 'bsddb' and 'dbhash' modules have been additionally"
+		ewarn "removed in Python 3. A maintained alternative of 'bsddb3' module"
+		ewarn "is provided by dev-python/bsddb3."
+	else
+		if has_version "=${CATEGORY}/${PN}-${PV%%.*}*[berkdb]"; then
+			ewarn "You are migrating from =${CATEGORY}/${PN}-${PV%%.*}*[berkdb]"
+			ewarn "to =${CATEGORY}/${PN}-${PV%%.*}*[-berkdb]."
+			ewarn "You might need to migrate your databases."
+		fi
+	fi
+}
+
+src_prepare() {
+	# Ensure that internal copies of expat, libffi and zlib are not used.
+	rm -r Modules/expat || die
+	rm -r Modules/_ctypes/libffi* || die
+	rm -r Modules/zlib || die
+
+	if tc-is-cross-compiler; then
+		local EPATCH_EXCLUDE="*_regenerate_platform-specific_modules.patch"
+	fi
+
+	EPATCH_SUFFIX="patch" epatch "${WORKDIR}/patches"
+
+	# Fix for cross-compiling.
+	epatch "${FILESDIR}/python-2.7.5-nonfatal-compileall.patch"
+	epatch "${FILESDIR}/python-2.7.9-ncurses-pkg-config.patch"
+	epatch "${FILESDIR}/python-2.7.10-cross-compile-warn-test.patch"
+	epatch "${FILESDIR}/python-2.7.10-system-libffi.patch"
+	epatch "${FILESDIR}/2.7-disable-nis.patch"
+	epatch "${FILESDIR}/python-2.7.14-libressl-version-check.patch"
+
+	epatch_user
+
+	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		Lib/distutils/command/install.py \
+		Lib/distutils/sysconfig.py \
+		Lib/site.py \
+		Lib/sysconfig.py \
+		Lib/test/test_site.py \
+		Makefile.pre.in \
+		Modules/Setup.dist \
+		Modules/getpath.c \
+		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
+
+	eautoreconf
+}
+
+src_configure() {
+		# dbm module can be linked against berkdb or gdbm.
+		# Defaults to gdbm when both are enabled, #204343.
+		local disable
+		use berkdb   || use gdbm || disable+=" dbm"
+		use berkdb   || disable+=" _bsddb"
+		use gdbm     || disable+=" gdbm"
+		use ncurses  || disable+=" _curses _curses_panel"
+		use readline || disable+=" readline"
+		use sqlite   || disable+=" _sqlite3"
+		use ssl      || export PYTHON_DISABLE_SSL="1"
+		use tk       || disable+=" _tkinter"
+		use xml      || disable+=" _elementtree pyexpat" # _elementtree uses pyexpat.
+		export PYTHON_DISABLE_MODULES="${disable}"
+
+		if ! use xml; then
+			ewarn "You have configured Python without XML support."
+			ewarn "This is NOT a recommended configuration as you"
+			ewarn "may face problems parsing any XML documents."
+		fi
+
+	if [[ -n "${PYTHON_DISABLE_MODULES}" ]]; then
+		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
+	fi
+
+	if [[ "$(gcc-major-version)" -ge 4 ]]; then
+		append-flags -fwrapv
+	fi
+
+	filter-flags -malign-double
+
+	# https://bugs.gentoo.org/show_bug.cgi?id=50309
+	if is-flagq -O3; then
+		is-flagq -fstack-protector-all && replace-flags -O3 -O2
+		use hardened && replace-flags -O3 -O2
+	fi
+
+	if tc-is-cross-compiler; then
+		# Force some tests that try to poke fs paths.
+		export ac_cv_file__dev_ptc=no
+		export ac_cv_file__dev_ptmx=yes
+	fi
+
+	# Export CXX so it ends up in /usr/lib/python2.X/config/Makefile.
+	tc-export CXX
+	# The configure script fails to use pkg-config correctly.
+	# http://bugs.python.org/issue15506
+	export ac_cv_path_PKG_CONFIG=$(tc-getPKG_CONFIG)
+
+	# Set LDFLAGS so we link modules with -lpython2.7 correctly.
+	# Needed on FreeBSD unless Python 2.7 is already installed.
+	# Please query BSD team before removing this!
+	append-ldflags "-L."
+
+	local dbmliborder
+	if use gdbm; then
+		dbmliborder+="${dbmliborder:+:}gdbm"
+	fi
+	if use berkdb; then
+		dbmliborder+="${dbmliborder:+:}bdb"
+	fi
+
+	BUILD_DIR="${WORKDIR}/${CHOST}"
+	mkdir -p "${BUILD_DIR}" || die
+	cd "${BUILD_DIR}" || die
+
+	ECONF_SOURCE="${S}" OPT="" \
+	econf \
+		--with-fpectl \
+		--enable-shared \
+		$(use_enable ipv6) \
+		$(use_with threads) \
+		$(use wide-unicode && echo "--enable-unicode=ucs4" || echo "--enable-unicode=ucs2") \
+		--infodir='${prefix}/share/info' \
+		--mandir='${prefix}/share/man' \
+		--with-computed-gotos \
+		--with-dbmliborder="${dbmliborder}" \
+		--with-libc="" \
+		--enable-loadable-sqlite-extensions \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip
+
+	if use threads && grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
+		eerror "configure has detected that the sem_open function is broken."
+		eerror "Please ensure that /dev/shm is mounted as a tmpfs with mode 1777."
+		die "Broken sem_open function (bug 496328)"
+	fi
+}
+
+src_compile() {
+	# Avoid invoking pgen for cross-compiles.
+	touch Include/graminit.h Python/graminit.c
+
+	cd "${BUILD_DIR}" || die
+	emake
+
+	# Work around bug 329499. See also bug 413751 and 457194.
+	if has_version dev-libs/libffi[pax_kernel]; then
+		pax-mark E python
+	else
+		pax-mark m python
+	fi
+}
+
+src_test() {
+	# Tests will not work when cross compiling.
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	cd "${BUILD_DIR}" || die
+
+	# Skip failing tests.
+	local skipped_tests="distutils gdb"
+
+	for test in ${skipped_tests}; do
+		mv "${S}"/Lib/test/test_${test}.py "${T}"
+	done
+
+	# Daylight saving time problem
+	# https://bugs.python.org/issue22067
+	# https://bugs.gentoo.org/610628
+	local -x TZ=UTC
+
+	# Rerun failed tests in verbose mode (regrtest -w).
+	emake test EXTRATESTOPTS="-w" < /dev/tty
+	local result="$?"
+
+	for test in ${skipped_tests}; do
+		mv "${T}/test_${test}.py" "${S}"/Lib/test
+	done
+
+	elog "The following tests have been skipped:"
+	for test in ${skipped_tests}; do
+		elog "test_${test}.py"
+	done
+
+	elog "If you would like to run them, you may:"
+	elog "cd '${EPREFIX}/usr/$(get_libdir)/python${SLOT}/test'"
+	elog "and run the tests separately."
+
+	if [[ "${result}" -ne 0 ]]; then
+		die "emake test failed"
+	fi
+}
+
+src_install() {
+	local libdir=${ED}/usr/$(get_libdir)/python${SLOT}
+
+	cd "${BUILD_DIR}" || die
+	emake DESTDIR="${D}" altinstall
+
+	sed -e "s/\(LDFLAGS=\).*/\1/" -i "${libdir}/config/Makefile" || die "sed failed"
+
+	# Fix collisions between different slots of Python.
+	mv "${ED}usr/bin/2to3" "${ED}usr/bin/2to3-${SLOT}"
+	mv "${ED}usr/bin/pydoc" "${ED}usr/bin/pydoc${SLOT}"
+	mv "${ED}usr/bin/idle" "${ED}usr/bin/idle${SLOT}"
+	rm -f "${ED}usr/bin/smtpd.py"
+
+	use berkdb || rm -r "${libdir}/"{bsddb,dbhash.py*,test/test_bsddb*} || die
+	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
+	use tk || rm -r "${ED}usr/bin/idle${SLOT}" "${libdir}/"{idlelib,lib-tk} || die
+	use elibc_uclibc && rm -fr "${libdir}/"{bsddb/test,test}
+
+	use threads || rm -r "${libdir}/multiprocessing" || die
+	use wininst || rm -r "${libdir}/distutils/command/"wininst-*.exe || die
+
+	dodoc "${S}"/Misc/{ACKS,HISTORY,NEWS}
+
+	if use examples; then
+		insinto /usr/share/doc/${PF}/examples
+		doins -r "${S}"/Tools
+	fi
+	insinto /usr/share/gdb/auto-load/usr/$(get_libdir) #443510
+	local libname=$(printf 'e:\n\t@echo $(INSTSONAME)\ninclude Makefile\n' | \
+		emake --no-print-directory -s -f - 2>/dev/null)
+	newins "${S}"/Tools/gdb/libpython.py "${libname}"-gdb.py
+
+	newconfd "${FILESDIR}/pydoc.conf" pydoc-${SLOT}
+	newinitd "${FILESDIR}/pydoc.init" pydoc-${SLOT}
+	sed \
+		-e "s:@PYDOC_PORT_VARIABLE@:PYDOC${SLOT/./_}_PORT:" \
+		-e "s:@PYDOC@:pydoc${SLOT}:" \
+		-i "${ED}etc/conf.d/pydoc-${SLOT}" "${ED}etc/init.d/pydoc-${SLOT}" || die "sed failed"
+
+	# for python-exec
+	local vars=( EPYTHON PYTHON_SITEDIR PYTHON_SCRIPTDIR )
+
+	# if not using a cross-compiler, use the fresh binary
+	if ! tc-is-cross-compiler; then
+		local -x PYTHON=./python
+		local -x LD_LIBRARY_PATH=${LD_LIBRARY_PATH+${LD_LIBRARY_PATH}:}${PWD}
+	else
+		vars=( PYTHON "${vars[@]}" )
+	fi
+
+	python_export "python${SLOT}" "${vars[@]}"
+	echo "EPYTHON='${EPYTHON}'" > epython.py || die
+	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${SLOT%.*}
+	mkdir -p "${D}${PYTHON_SCRIPTDIR}" || die
+	# python and pythonX
+	ln -s "../../../bin/python${SLOT}" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}" || die
+	ln -s "python${pymajor}" \
+		"${D}${PYTHON_SCRIPTDIR}/python" || die
+	# python-config and pythonX-config
+	ln -s "../../../bin/python${SLOT}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${SLOT}" \
+		"${D}${PYTHON_SCRIPTDIR}/2to3" || die
+	ln -s "../../../bin/pydoc${SLOT}" \
+		"${D}${PYTHON_SCRIPTDIR}/pydoc" || die
+	# idle
+	if use tk; then
+		ln -s "../../../bin/idle${SLOT}" \
+			"${D}${PYTHON_SCRIPTDIR}/idle" || die
+	fi
+}
+
+eselect_python_update() {
+	if [[ -z "$(eselect python show)" || ! -f "${EROOT}usr/bin/$(eselect python show)" ]]; then
+		eselect python update
+	fi
+
+	if [[ -z "$(eselect python show --python${PV%%.*})" || ! -f "${EROOT}usr/bin/$(eselect python show --python${PV%%.*})" ]]; then
+		eselect python update --python${PV%%.*}
+	fi
+}
+
+pkg_postinst() {
+	eselect_python_update
+}
+
+pkg_postrm() {
+	eselect_python_update
+}

--- a/dev-lang/python/python-3.5.4-r2.ebuild
+++ b/dev-lang/python/python-3.5.4-r2.ebuild
@@ -38,7 +38,7 @@ RDEPEND="app-arch/bzip2:0=
 	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
 	ssl? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:= )
+		libressl? ( dev-libs/libressl:0= )
 	)
 	tk? (
 		>=dev-lang/tcl-8.0:0=
@@ -74,6 +74,7 @@ src_prepare() {
 	epatch "${FILESDIR}/${PN}-3.4.3-ncurses-pkg-config.patch"
 	epatch "${FILESDIR}/${PN}-3.5-distutils-OO-build.patch"
 	epatch "${FILESDIR}/3.6-disable-nis.patch"
+	epatch "${FILESDIR}/python-3.6.3-libressl-version-check.patch"
 
 	epatch_user
 

--- a/dev-lang/python/python-3.5.5-r1.ebuild
+++ b/dev-lang/python/python-3.5.5-r1.ebuild
@@ -1,23 +1,23 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="5"
 WANT_LIBTOOL="none"
 
-inherit autotools flag-o-matic pax-utils python-utils-r1 toolchain-funcs
+inherit autotools eutils flag-o-matic multilib pax-utils python-utils-r1 toolchain-funcs
 
-MY_P="Python-${PV}"
-PATCHSET_VERSION="3.6.4"
+MY_P="Python-${PV/_/}"
+PATCHSET_VERSION="3.5.4-0"
 
 DESCRIPTION="An interpreted, interactive, object-oriented programming language"
 HOMEPAGE="https://www.python.org/"
-SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
+SRC_URI="https://www.python.org/ftp/python/${PV%_rc*}/${MY_P}.tar.xz
 	https://dev.gentoo.org/~floppym/python/python-gentoo-patches-${PATCHSET_VERSION}.tar.xz"
 
 LICENSE="PSF-2"
-SLOT="3.6/3.6m"
+SLOT="3.5/3.5m"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
-IUSE="build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test +threads tk wininst +xml"
+IUSE="build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test +threads tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -38,7 +38,7 @@ RDEPEND="app-arch/bzip2:0=
 	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
 	ssl? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:= )
+		libressl? ( dev-libs/libressl:0= )
 	)
 	tk? (
 		>=dev-lang/tcl-8.0:0=
@@ -56,6 +56,7 @@ RDEPEND+=" !build? ( app-misc/mime-types )"
 PDEPEND=">=app-eselect/eselect-python-20140125-r1"
 
 S="${WORKDIR}/${MY_P}"
+
 PYVER=${SLOT%/*}
 
 src_prepare() {
@@ -64,24 +65,29 @@ src_prepare() {
 	rm -fr Modules/_ctypes/libffi*
 	rm -fr Modules/zlib
 
-	local PATCHES=(
-		"${WORKDIR}/patches"
-		"${FILESDIR}/${PN}-3.5-distutils-OO-build.patch"
-		"${FILESDIR}/3.6-disable-nis.patch"
-	)
+	if tc-is-cross-compiler; then
+		# Invokes BUILDPYTHON, which is built for the host arch
+		local EPATCH_EXCLUDE="*_regenerate_platform-specific_modules.patch"
+	fi
 
-	default
+	EPATCH_SUFFIX="patch" epatch "${WORKDIR}/patches"
+	epatch "${FILESDIR}/${PN}-3.4.3-ncurses-pkg-config.patch"
+	epatch "${FILESDIR}/${PN}-3.5-distutils-OO-build.patch"
+	epatch "${FILESDIR}/3.6-disable-nis.patch"
+	epatch "${FILESDIR}/python-3.6.3-libressl-version-check.patch"
+
+	epatch_user
 
 	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		configure.ac \
 		Lib/distutils/command/install.py \
 		Lib/distutils/sysconfig.py \
 		Lib/site.py \
 		Lib/sysconfig.py \
 		Lib/test/test_site.py \
 		Makefile.pre.in \
-		Modules/Setup.dist \
 		Modules/getpath.c \
-		configure.ac \
+		Modules/Setup.dist \
 		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
 
 	eautoreconf
@@ -123,6 +129,10 @@ src_configure() {
 	# Export CXX so it ends up in /usr/lib/python3.X/config/Makefile.
 	tc-export CXX
 
+	# The configure script fails to use pkg-config correctly.
+	# http://bugs.python.org/issue15506
+	export ac_cv_path_PKG_CONFIG=$(tc-getPKG_CONFIG)
+
 	# Set LDFLAGS so we link modules with -lpython3.2 correctly.
 	# Needed on FreeBSD unless Python 3.2 is already installed.
 	# Please query BSD team before removing this!
@@ -132,6 +142,10 @@ src_configure() {
 	if use gdbm; then
 		dbmliborder+="${dbmliborder:+:}gdbm"
 	fi
+
+	BUILD_DIR="${WORKDIR}/${CHOST}"
+	mkdir -p "${BUILD_DIR}" || die
+	cd "${BUILD_DIR}" || die
 
 	local myeconfargs=(
 		--with-fpectl
@@ -149,7 +163,7 @@ src_configure() {
 		--with-system-ffi
 	)
 
-	OPT="" econf "${myeconfargs[@]}"
+	ECONF_SOURCE="${S}" OPT="" econf "${myeconfargs[@]}"
 
 	if use threads && grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
 		eerror "configure has detected that the sem_open function is broken."
@@ -162,6 +176,8 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
+
+	cd "${BUILD_DIR}" || die
 
 	emake CPPFLAGS= CFLAGS= LDFLAGS=
 
@@ -180,6 +196,8 @@ src_test() {
 		return
 	fi
 
+	cd "${BUILD_DIR}" || die
+
 	# Skip failing tests.
 	local skipped_tests="gdb"
 
@@ -188,7 +206,6 @@ src_test() {
 	done
 
 	local -x PYTHONDONTWRITEBYTECODE=
-
 	emake test EXTRATESTOPTS="-u-network" CPPFLAGS= CFLAGS= LDFLAGS= < /dev/tty
 	local result=$?
 
@@ -212,6 +229,8 @@ src_test() {
 
 src_install() {
 	local libdir=${ED}/usr/$(get_libdir)/python${PYVER}
+
+	cd "${BUILD_DIR}" || die
 
 	emake DESTDIR="${D}" altinstall
 
@@ -243,11 +262,12 @@ src_install() {
 		pax-mark m "${ED}usr/bin/${abiver}"
 	fi
 
-	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
-	use tk || rm -r "${ED}usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+	use elibc_uclibc && rm -fr "${libdir}/test"
+	use sqlite || rm -fr "${libdir}/"{sqlite3,test/test_sqlite*}
+	use tk || rm -fr "${ED}usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*}
 
-	use threads || rm -r "${libdir}/multiprocessing" || die
-	use wininst || rm "${libdir}/distutils/command/"wininst-*.exe || die
+	use threads || rm -fr "${libdir}/multiprocessing"
+	use wininst || rm -f "${libdir}/distutils/command/"wininst-*.exe
 
 	dodoc "${S}"/Misc/{ACKS,HISTORY,NEWS}
 

--- a/dev-lang/python/python-3.6.3-r2.ebuild
+++ b/dev-lang/python/python-3.6.3-r2.ebuild
@@ -1,0 +1,346 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="5"
+WANT_LIBTOOL="none"
+
+inherit autotools eutils flag-o-matic multilib pax-utils python-utils-r1 toolchain-funcs
+
+MY_P="Python-${PV}"
+PATCHSET_VERSION="3.6.2-0"
+
+DESCRIPTION="An interpreted, interactive, object-oriented programming language"
+HOMEPAGE="https://www.python.org/"
+SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~floppym/python/python-gentoo-patches-${PATCHSET_VERSION}.tar.xz"
+
+LICENSE="PSF-2"
+SLOT="3.6/3.6m"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE="build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test +threads tk wininst +xml"
+RESTRICT="!test? ( test )"
+
+# Do not add a dependency on dev-lang/python to this ebuild.
+# If you need to apply a patch which requires python for bootstrapping, please
+# run the bootstrap code on your dev box and include the results in the
+# patchset. See bug 447752.
+
+RDEPEND="app-arch/bzip2:0=
+	app-arch/xz-utils:0=
+	>=sys-libs/zlib-1.1.3:0=
+	virtual/libffi
+	virtual/libintl
+	gdbm? ( sys-libs/gdbm:0=[berkdb] )
+	ncurses? (
+		>=sys-libs/ncurses-5.2:0=
+		readline? ( >=sys-libs/readline-4.1:0= )
+	)
+	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	tk? (
+		>=dev-lang/tcl-8.0:0=
+		>=dev-lang/tk-8.0:0=
+		dev-tcltk/blt:0=
+		dev-tcltk/tix
+	)
+	xml? ( >=dev-libs/expat-2.1:0= )
+	!!<sys-apps/sandbox-2.6-r1"
+DEPEND="${RDEPEND}
+	test? ( app-arch/xz-utils[extra-filters(+)] )
+	virtual/pkgconfig
+	!sys-devel/gcc[libffi(-)]"
+RDEPEND+=" !build? ( app-misc/mime-types )"
+PDEPEND=">=app-eselect/eselect-python-20140125-r1"
+
+S="${WORKDIR}/${MY_P}"
+PYVER=${SLOT%/*}
+
+src_prepare() {
+	# Ensure that internal copies of expat, libffi and zlib are not used.
+	rm -fr Modules/expat
+	rm -fr Modules/_ctypes/libffi*
+	rm -fr Modules/zlib
+
+	EPATCH_SUFFIX="patch" epatch "${WORKDIR}/patches"
+	epatch "${FILESDIR}/${PN}-3.5-distutils-OO-build.patch"
+	epatch "${FILESDIR}/3.6-blake2.patch"
+	epatch "${FILESDIR}/3.6-disable-nis.patch"
+	epatch "${FILESDIR}/python-3.6.3-libressl-version-check.patch"
+
+	epatch_user
+
+	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		Lib/distutils/command/install.py \
+		Lib/distutils/sysconfig.py \
+		Lib/site.py \
+		Lib/sysconfig.py \
+		Lib/test/test_site.py \
+		Makefile.pre.in \
+		Modules/Setup.dist \
+		Modules/getpath.c \
+		configure.ac \
+		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
+
+	eautoreconf
+}
+
+src_configure() {
+	local disable
+	use gdbm     || disable+=" gdbm"
+	use ncurses  || disable+=" _curses _curses_panel"
+	use readline || disable+=" readline"
+	use sqlite   || disable+=" _sqlite3"
+	use ssl      || export PYTHON_DISABLE_SSL="1"
+	use tk       || disable+=" _tkinter"
+	use xml      || disable+=" _elementtree pyexpat" # _elementtree uses pyexpat.
+	export PYTHON_DISABLE_MODULES="${disable}"
+
+	if ! use xml; then
+		ewarn "You have configured Python without XML support."
+		ewarn "This is NOT a recommended configuration as you"
+		ewarn "may face problems parsing any XML documents."
+	fi
+
+	if [[ -n "${PYTHON_DISABLE_MODULES}" ]]; then
+		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
+	fi
+
+	if [[ "$(gcc-major-version)" -ge 4 ]]; then
+		append-flags -fwrapv
+	fi
+
+	filter-flags -malign-double
+
+	# https://bugs.gentoo.org/show_bug.cgi?id=50309
+	if is-flagq -O3; then
+		is-flagq -fstack-protector-all && replace-flags -O3 -O2
+		use hardened && replace-flags -O3 -O2
+	fi
+
+	# Export CXX so it ends up in /usr/lib/python3.X/config/Makefile.
+	tc-export CXX
+
+	# Set LDFLAGS so we link modules with -lpython3.2 correctly.
+	# Needed on FreeBSD unless Python 3.2 is already installed.
+	# Please query BSD team before removing this!
+	append-ldflags "-L."
+
+	local dbmliborder
+	if use gdbm; then
+		dbmliborder+="${dbmliborder:+:}gdbm"
+	fi
+
+	local myeconfargs=(
+		--with-fpectl
+		--enable-shared
+		$(use_enable ipv6)
+		$(use_with threads)
+		--infodir='${prefix}/share/info'
+		--mandir='${prefix}/share/man'
+		--with-computed-gotos
+		--with-dbmliborder="${dbmliborder}"
+		--with-libc=
+		--enable-loadable-sqlite-extensions
+		--without-ensurepip
+		--with-system-expat
+		--with-system-ffi
+	)
+
+	OPT="" econf "${myeconfargs[@]}"
+
+	if use threads && grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
+		eerror "configure has detected that the sem_open function is broken."
+		eerror "Please ensure that /dev/shm is mounted as a tmpfs with mode 1777."
+		die "Broken sem_open function (bug 496328)"
+	fi
+}
+
+src_compile() {
+	# Ensure sed works as expected
+	# https://bugs.gentoo.org/594768
+	local -x LC_ALL=C
+
+	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Work around bug 329499. See also bug 413751 and 457194.
+	if has_version dev-libs/libffi[pax_kernel]; then
+		pax-mark E python
+	else
+		pax-mark m python
+	fi
+}
+
+src_test() {
+	# Tests will not work when cross compiling.
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	# Skip failing tests.
+	local skipped_tests="gdb"
+
+	for test in ${skipped_tests}; do
+		mv "${S}"/Lib/test/test_${test}.py "${T}"
+	done
+
+	local -x PYTHONDONTWRITEBYTECODE=
+
+	emake test EXTRATESTOPTS="-u-network" CPPFLAGS= CFLAGS= LDFLAGS= < /dev/tty
+	local result=$?
+
+	for test in ${skipped_tests}; do
+		mv "${T}/test_${test}.py" "${S}"/Lib/test
+	done
+
+	elog "The following tests have been skipped:"
+	for test in ${skipped_tests}; do
+		elog "test_${test}.py"
+	done
+
+	elog "If you would like to run them, you may:"
+	elog "cd '${EPREFIX}/usr/$(get_libdir)/python${PYVER}/test'"
+	elog "and run the tests separately."
+
+	if [[ ${result} -ne 0 ]]; then
+		die "emake test failed"
+	fi
+}
+
+src_install() {
+	local libdir=${ED}/usr/$(get_libdir)/python${PYVER}
+
+	emake DESTDIR="${D}" altinstall
+
+	sed \
+		-e "s/\(CONFIGURE_LDFLAGS=\).*/\1/" \
+		-e "s/\(PY_LDFLAGS=\).*/\1/" \
+		-i "${libdir}/config-${PYVER}"*/Makefile || die "sed failed"
+
+	# Fix collisions between different slots of Python.
+	rm -f "${ED}usr/$(get_libdir)/libpython3.so"
+
+	# Cheap hack to get version with ABIFLAGS
+	local abiver=$(cd "${ED}usr/include"; echo python*)
+	if [[ ${abiver} != python${PYVER} ]]; then
+		# Replace python3.X with a symlink to python3.Xm
+		rm "${ED}usr/bin/python${PYVER}" || die
+		dosym "${abiver}" "/usr/bin/python${PYVER}"
+		# Create python3.X-config symlink
+		dosym "${abiver}-config" "/usr/bin/python${PYVER}-config"
+		# Create python-3.5m.pc symlink
+		dosym "python-${PYVER}.pc" "/usr/$(get_libdir)/pkgconfig/${abiver/${PYVER}/-${PYVER}}.pc"
+	fi
+
+	# python seems to get rebuilt in src_install (bug 569908)
+	# Work around it for now.
+	if has_version dev-libs/libffi[pax_kernel]; then
+		pax-mark E "${ED}usr/bin/${abiver}"
+	else
+		pax-mark m "${ED}usr/bin/${abiver}"
+	fi
+
+	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
+	use tk || rm -r "${ED}usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+
+	use threads || rm -r "${libdir}/multiprocessing" || die
+	use wininst || rm "${libdir}/distutils/command/"wininst-*.exe || die
+
+	dodoc "${S}"/Misc/{ACKS,HISTORY,NEWS}
+
+	if use examples; then
+		insinto /usr/share/doc/${PF}/examples
+		find "${S}"/Tools -name __pycache__ -print0 | xargs -0 rm -fr
+		doins -r "${S}"/Tools
+	fi
+	insinto /usr/share/gdb/auto-load/usr/$(get_libdir) #443510
+	local libname=$(printf 'e:\n\t@echo $(INSTSONAME)\ninclude Makefile\n' | \
+		emake --no-print-directory -s -f - 2>/dev/null)
+	newins "${S}"/Tools/gdb/libpython.py "${libname}"-gdb.py
+
+	newconfd "${FILESDIR}/pydoc.conf" pydoc-${PYVER}
+	newinitd "${FILESDIR}/pydoc.init" pydoc-${PYVER}
+	sed \
+		-e "s:@PYDOC_PORT_VARIABLE@:PYDOC${PYVER/./_}_PORT:" \
+		-e "s:@PYDOC@:pydoc${PYVER}:" \
+		-i "${ED}etc/conf.d/pydoc-${PYVER}" "${ED}etc/init.d/pydoc-${PYVER}" || die "sed failed"
+
+	# for python-exec
+	local vars=( EPYTHON PYTHON_SITEDIR PYTHON_SCRIPTDIR )
+
+	# if not using a cross-compiler, use the fresh binary
+	if ! tc-is-cross-compiler; then
+		local -x PYTHON=./python
+		local -x LD_LIBRARY_PATH=${LD_LIBRARY_PATH+${LD_LIBRARY_PATH}:}${PWD}
+	else
+		vars=( PYTHON "${vars[@]}" )
+	fi
+
+	python_export "python${PYVER}" "${vars[@]}"
+	echo "EPYTHON='${EPYTHON}'" > epython.py || die
+	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	mkdir -p "${D}${PYTHON_SCRIPTDIR}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}" || die
+	ln -s "python${pymajor}" \
+		"${D}${PYTHON_SCRIPTDIR}/python" || die
+	# python-config and pythonX-config
+	# note: we need to create a wrapper rather than symlinking it due
+	# to some random dirname(argv[0]) magic performed by python-config
+	cat > "${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" <<-EOF || die
+		#!/bin/sh
+		exec "${abiver}-config" "\${@}"
+	EOF
+	chmod +x "${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pydoc" || die
+	ln -s "../../../bin/pyvenv-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pyvenv" || die
+	# idle
+	if use tk; then
+		ln -s "../../../bin/idle${PYVER}" \
+			"${D}${PYTHON_SCRIPTDIR}/idle" || die
+	fi
+}
+
+pkg_preinst() {
+	if has_version "<${CATEGORY}/${PN}-${PYVER}" && ! has_version ">=${CATEGORY}/${PN}-${PYVER}_alpha"; then
+		python_updater_warning="1"
+	fi
+}
+
+eselect_python_update() {
+	if [[ -z "$(eselect python show)" || ! -f "${EROOT}usr/bin/$(eselect python show)" ]]; then
+		eselect python update
+	fi
+
+	if [[ -z "$(eselect python show --python${PV%%.*})" || ! -f "${EROOT}usr/bin/$(eselect python show --python${PV%%.*})" ]]; then
+		eselect python update --python${PV%%.*}
+	fi
+}
+
+pkg_postinst() {
+	eselect_python_update
+
+	if [[ "${python_updater_warning}" == "1" ]]; then
+		ewarn "You have just upgraded from an older version of Python."
+		ewarn
+		ewarn "Please adjust PYTHON_TARGETS (if so desired), and run emerge with the --newuse or --changed-use option to rebuild packages installing python modules."
+	fi
+}
+
+pkg_postrm() {
+	eselect_python_update
+}

--- a/dev-lang/python/python-3.6.4-r1.ebuild
+++ b/dev-lang/python/python-3.6.4-r1.ebuild
@@ -38,7 +38,7 @@ RDEPEND="app-arch/bzip2:0=
 	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
 	ssl? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:= )
+		libressl? ( dev-libs/libressl:0= )
 	)
 	tk? (
 		>=dev-lang/tcl-8.0:0=
@@ -67,7 +67,8 @@ src_prepare() {
 	local PATCHES=(
 		"${WORKDIR}/patches"
 		"${FILESDIR}/${PN}-3.5-distutils-OO-build.patch"
-		"${FILESDIR}/3.6.5-disable-nis.patch"
+		"${FILESDIR}/3.6-disable-nis.patch"
+		"${FILESDIR}/python-3.6.3-libressl-version-check.patch"
 	)
 
 	default

--- a/dev-lang/python/python-3.6.5-r1.ebuild
+++ b/dev-lang/python/python-3.6.5-r1.ebuild
@@ -1,0 +1,347 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+WANT_LIBTOOL="none"
+
+inherit autotools flag-o-matic pax-utils python-utils-r1 toolchain-funcs
+
+MY_P="Python-${PV}"
+PATCHSET_VERSION="3.6.4"
+
+DESCRIPTION="An interpreted, interactive, object-oriented programming language"
+HOMEPAGE="https://www.python.org/"
+SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~floppym/python/python-gentoo-patches-${PATCHSET_VERSION}.tar.xz"
+
+LICENSE="PSF-2"
+SLOT="3.6/3.6m"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE="build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test +threads tk wininst +xml"
+RESTRICT="!test? ( test )"
+
+# Do not add a dependency on dev-lang/python to this ebuild.
+# If you need to apply a patch which requires python for bootstrapping, please
+# run the bootstrap code on your dev box and include the results in the
+# patchset. See bug 447752.
+
+RDEPEND="app-arch/bzip2:0=
+	app-arch/xz-utils:0=
+	>=sys-libs/zlib-1.1.3:0=
+	virtual/libffi
+	virtual/libintl
+	gdbm? ( sys-libs/gdbm:0=[berkdb] )
+	ncurses? (
+		>=sys-libs/ncurses-5.2:0=
+		readline? ( >=sys-libs/readline-4.1:0= )
+	)
+	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	tk? (
+		>=dev-lang/tcl-8.0:0=
+		>=dev-lang/tk-8.0:0=
+		dev-tcltk/blt:0=
+		dev-tcltk/tix
+	)
+	xml? ( >=dev-libs/expat-2.1:0= )
+	!!<sys-apps/sandbox-2.6-r1"
+DEPEND="${RDEPEND}
+	test? ( app-arch/xz-utils[extra-filters(+)] )
+	virtual/pkgconfig
+	!sys-devel/gcc[libffi(-)]"
+RDEPEND+=" !build? ( app-misc/mime-types )"
+PDEPEND=">=app-eselect/eselect-python-20140125-r1"
+
+S="${WORKDIR}/${MY_P}"
+PYVER=${SLOT%/*}
+
+src_prepare() {
+	# Ensure that internal copies of expat, libffi and zlib are not used.
+	rm -fr Modules/expat
+	rm -fr Modules/_ctypes/libffi*
+	rm -fr Modules/zlib
+
+	local PATCHES=(
+		"${WORKDIR}/patches"
+		"${FILESDIR}/${PN}-3.5-distutils-OO-build.patch"
+		"${FILESDIR}/3.6.5-disable-nis.patch"
+		"${FILESDIR}/python-3.6.3-libressl-version-check.patch"
+	)
+
+	default
+
+	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		Lib/distutils/command/install.py \
+		Lib/distutils/sysconfig.py \
+		Lib/site.py \
+		Lib/sysconfig.py \
+		Lib/test/test_site.py \
+		Makefile.pre.in \
+		Modules/Setup.dist \
+		Modules/getpath.c \
+		configure.ac \
+		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
+
+	eautoreconf
+}
+
+src_configure() {
+	local disable
+	use gdbm     || disable+=" gdbm"
+	use ncurses  || disable+=" _curses _curses_panel"
+	use readline || disable+=" readline"
+	use sqlite   || disable+=" _sqlite3"
+	use ssl      || export PYTHON_DISABLE_SSL="1"
+	use tk       || disable+=" _tkinter"
+	use xml      || disable+=" _elementtree pyexpat" # _elementtree uses pyexpat.
+	export PYTHON_DISABLE_MODULES="${disable}"
+
+	if ! use xml; then
+		ewarn "You have configured Python without XML support."
+		ewarn "This is NOT a recommended configuration as you"
+		ewarn "may face problems parsing any XML documents."
+	fi
+
+	if [[ -n "${PYTHON_DISABLE_MODULES}" ]]; then
+		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
+	fi
+
+	if [[ "$(gcc-major-version)" -ge 4 ]]; then
+		append-flags -fwrapv
+	fi
+
+	filter-flags -malign-double
+
+	# https://bugs.gentoo.org/show_bug.cgi?id=50309
+	if is-flagq -O3; then
+		is-flagq -fstack-protector-all && replace-flags -O3 -O2
+		use hardened && replace-flags -O3 -O2
+	fi
+
+	# Export CXX so it ends up in /usr/lib/python3.X/config/Makefile.
+	tc-export CXX
+
+	# Set LDFLAGS so we link modules with -lpython3.2 correctly.
+	# Needed on FreeBSD unless Python 3.2 is already installed.
+	# Please query BSD team before removing this!
+	append-ldflags "-L."
+
+	local dbmliborder
+	if use gdbm; then
+		dbmliborder+="${dbmliborder:+:}gdbm"
+	fi
+
+	local myeconfargs=(
+		--with-fpectl
+		--enable-shared
+		$(use_enable ipv6)
+		$(use_with threads)
+		--infodir='${prefix}/share/info'
+		--mandir='${prefix}/share/man'
+		--with-computed-gotos
+		--with-dbmliborder="${dbmliborder}"
+		--with-libc=
+		--enable-loadable-sqlite-extensions
+		--without-ensurepip
+		--with-system-expat
+		--with-system-ffi
+	)
+
+	OPT="" econf "${myeconfargs[@]}"
+
+	if use threads && grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
+		eerror "configure has detected that the sem_open function is broken."
+		eerror "Please ensure that /dev/shm is mounted as a tmpfs with mode 1777."
+		die "Broken sem_open function (bug 496328)"
+	fi
+}
+
+src_compile() {
+	# Ensure sed works as expected
+	# https://bugs.gentoo.org/594768
+	local -x LC_ALL=C
+
+	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Work around bug 329499. See also bug 413751 and 457194.
+	if has_version dev-libs/libffi[pax_kernel]; then
+		pax-mark E python
+	else
+		pax-mark m python
+	fi
+}
+
+src_test() {
+	# Tests will not work when cross compiling.
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	# Skip failing tests.
+	local skipped_tests="gdb"
+
+	for test in ${skipped_tests}; do
+		mv "${S}"/Lib/test/test_${test}.py "${T}"
+	done
+
+	local -x PYTHONDONTWRITEBYTECODE=
+
+	emake test EXTRATESTOPTS="-u-network" CPPFLAGS= CFLAGS= LDFLAGS= < /dev/tty
+	local result=$?
+
+	for test in ${skipped_tests}; do
+		mv "${T}/test_${test}.py" "${S}"/Lib/test
+	done
+
+	elog "The following tests have been skipped:"
+	for test in ${skipped_tests}; do
+		elog "test_${test}.py"
+	done
+
+	elog "If you would like to run them, you may:"
+	elog "cd '${EPREFIX}/usr/$(get_libdir)/python${PYVER}/test'"
+	elog "and run the tests separately."
+
+	if [[ ${result} -ne 0 ]]; then
+		die "emake test failed"
+	fi
+}
+
+src_install() {
+	local libdir=${ED}/usr/$(get_libdir)/python${PYVER}
+
+	emake DESTDIR="${D}" altinstall
+
+	sed \
+		-e "s/\(CONFIGURE_LDFLAGS=\).*/\1/" \
+		-e "s/\(PY_LDFLAGS=\).*/\1/" \
+		-i "${libdir}/config-${PYVER}"*/Makefile || die "sed failed"
+
+	# Fix collisions between different slots of Python.
+	rm -f "${ED}usr/$(get_libdir)/libpython3.so"
+
+	# Cheap hack to get version with ABIFLAGS
+	local abiver=$(cd "${ED}usr/include"; echo python*)
+	if [[ ${abiver} != python${PYVER} ]]; then
+		# Replace python3.X with a symlink to python3.Xm
+		rm "${ED}usr/bin/python${PYVER}" || die
+		dosym "${abiver}" "/usr/bin/python${PYVER}"
+		# Create python3.X-config symlink
+		dosym "${abiver}-config" "/usr/bin/python${PYVER}-config"
+		# Create python-3.5m.pc symlink
+		dosym "python-${PYVER}.pc" "/usr/$(get_libdir)/pkgconfig/${abiver/${PYVER}/-${PYVER}}.pc"
+	fi
+
+	# python seems to get rebuilt in src_install (bug 569908)
+	# Work around it for now.
+	if has_version dev-libs/libffi[pax_kernel]; then
+		pax-mark E "${ED}usr/bin/${abiver}"
+	else
+		pax-mark m "${ED}usr/bin/${abiver}"
+	fi
+
+	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
+	use tk || rm -r "${ED}usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+
+	use threads || rm -r "${libdir}/multiprocessing" || die
+	use wininst || rm "${libdir}/distutils/command/"wininst-*.exe || die
+
+	dodoc "${S}"/Misc/{ACKS,HISTORY,NEWS}
+
+	if use examples; then
+		insinto /usr/share/doc/${PF}/examples
+		find "${S}"/Tools -name __pycache__ -print0 | xargs -0 rm -fr
+		doins -r "${S}"/Tools
+	fi
+	insinto /usr/share/gdb/auto-load/usr/$(get_libdir) #443510
+	local libname=$(printf 'e:\n\t@echo $(INSTSONAME)\ninclude Makefile\n' | \
+		emake --no-print-directory -s -f - 2>/dev/null)
+	newins "${S}"/Tools/gdb/libpython.py "${libname}"-gdb.py
+
+	newconfd "${FILESDIR}/pydoc.conf" pydoc-${PYVER}
+	newinitd "${FILESDIR}/pydoc.init" pydoc-${PYVER}
+	sed \
+		-e "s:@PYDOC_PORT_VARIABLE@:PYDOC${PYVER/./_}_PORT:" \
+		-e "s:@PYDOC@:pydoc${PYVER}:" \
+		-i "${ED}etc/conf.d/pydoc-${PYVER}" "${ED}etc/init.d/pydoc-${PYVER}" || die "sed failed"
+
+	# for python-exec
+	local vars=( EPYTHON PYTHON_SITEDIR PYTHON_SCRIPTDIR )
+
+	# if not using a cross-compiler, use the fresh binary
+	if ! tc-is-cross-compiler; then
+		local -x PYTHON=./python
+		local -x LD_LIBRARY_PATH=${LD_LIBRARY_PATH+${LD_LIBRARY_PATH}:}${PWD}
+	else
+		vars=( PYTHON "${vars[@]}" )
+	fi
+
+	python_export "python${PYVER}" "${vars[@]}"
+	echo "EPYTHON='${EPYTHON}'" > epython.py || die
+	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	mkdir -p "${D}${PYTHON_SCRIPTDIR}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${D}${PYTHON_SCRIPTDIR}/python${pymajor}" || die
+	ln -s "python${pymajor}" \
+		"${D}${PYTHON_SCRIPTDIR}/python" || die
+	# python-config and pythonX-config
+	# note: we need to create a wrapper rather than symlinking it due
+	# to some random dirname(argv[0]) magic performed by python-config
+	cat > "${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" <<-EOF || die
+		#!/bin/sh
+		exec "${abiver}-config" "\${@}"
+	EOF
+	chmod +x "${D}${PYTHON_SCRIPTDIR}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${D}${PYTHON_SCRIPTDIR}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pydoc" || die
+	ln -s "../../../bin/pyvenv-${PYVER}" \
+		"${D}${PYTHON_SCRIPTDIR}/pyvenv" || die
+	# idle
+	if use tk; then
+		ln -s "../../../bin/idle${PYVER}" \
+			"${D}${PYTHON_SCRIPTDIR}/idle" || die
+	fi
+}
+
+pkg_preinst() {
+	if has_version "<${CATEGORY}/${PN}-${PYVER}" && ! has_version ">=${CATEGORY}/${PN}-${PYVER}_alpha"; then
+		python_updater_warning="1"
+	fi
+}
+
+eselect_python_update() {
+	if [[ -z "$(eselect python show)" || ! -f "${EROOT}usr/bin/$(eselect python show)" ]]; then
+		eselect python update
+	fi
+
+	if [[ -z "$(eselect python show --python${PV%%.*})" || ! -f "${EROOT}usr/bin/$(eselect python show --python${PV%%.*})" ]]; then
+		eselect python update --python${PV%%.*}
+	fi
+}
+
+pkg_postinst() {
+	eselect_python_update
+
+	if [[ "${python_updater_warning}" == "1" ]]; then
+		ewarn "You have just upgraded from an older version of Python."
+		ewarn
+		ewarn "Please adjust PYTHON_TARGETS (if so desired), and run emerge with the --newuse or --changed-use option to rebuild packages installing python modules."
+	fi
+}
+
+pkg_postrm() {
+	eselect_python_update
+}


### PR DESCRIPTION
Revision bumps for each slot to applies patches allowing Python to
properly detech the LibreSSL versions. The patches support the latest
LibreSSL API changes. This patchset does not include any patches for
the dev-lang/python 3.4 slot as they are not needed.

Closes: https://bugs.gentoo.org/651162
Package-Manager: Portage-2.3.28, Repoman-2.3.9