### PR TITLE
x11-wm/enlightenment: disable module_check from 0.20.5 & 0.20.6

### DIFF
--- a/x11-wm/enlightenment/enlightenment-0.20.5.ebuild
+++ b/x11-wm/enlightenment/enlightenment-0.20.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -13,7 +13,7 @@ else
 	EKEY_STATE="snap"
 fi
 
-inherit enlightenment
+inherit enlightenment xdg-utils
 
 DESCRIPTION="Enlightenment DR17 window manager"
 
@@ -57,7 +57,10 @@ RDEPEND="
 	>=dev-libs/efl-1.17[X]
 	>=media-libs/elementary-1.17
 	x11-libs/xcb-util-keysyms"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	sys-devel/automake:1.15
+"
 
 S=${WORKDIR}/${MY_P}
 
@@ -91,7 +94,9 @@ check_modules() {
 }
 
 src_configure() {
-	check_modules
+	# sanity check fails after commit e25cf18ca19463a7d05519aa843cc76a189ab75c
+	# see #648896. Can be restored with future release
+	# check_modules
 
 	E_ECONF=(
 		--disable-install-sysactions
@@ -124,4 +129,14 @@ src_install() {
 	enlightenment_src_install
 	insinto /etc/enlightenment
 	newins "${FILESDIR}"/gentoo-sysactions.conf sysactions.conf
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }

--- a/x11-wm/enlightenment/enlightenment-0.20.6.ebuild
+++ b/x11-wm/enlightenment/enlightenment-0.20.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -13,7 +13,7 @@ else
 	EKEY_STATE="snap"
 fi
 
-inherit enlightenment
+inherit enlightenment xdg-utils
 
 DESCRIPTION="Enlightenment DR17 window manager"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x64-solaris ~x86-solaris"
@@ -57,7 +57,10 @@ RDEPEND="
 	>=dev-libs/efl-1.17[X]
 	>=media-libs/elementary-1.17
 	x11-libs/xcb-util-keysyms"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	sys-devel/automake:1.15
+"
 
 S=${WORKDIR}/${MY_P}
 
@@ -91,7 +94,9 @@ check_modules() {
 }
 
 src_configure() {
-	check_modules
+	# sanity check fails after commit e25cf18ca19463a7d05519aa843cc76a189ab75c
+	# see #648896. Can be restored with future release
+	# check_modules
 
 	E_ECONF=(
 		--disable-install-sysactions
@@ -124,4 +129,14 @@ src_install() {
 	enlightenment_src_install
 	insinto /etc/enlightenment
 	newins "${FILESDIR}"/gentoo-sysactions.conf sysactions.conf
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
 }


### PR DESCRIPTION
Commit e25cf18ca19463a7d05519aa843cc76a189ab75c caused all E17 releases in tree to be unbuildable, 
https://bugs.gentoo.org/648896

0.21.7 was fixed with #7566 but there was an update in that bug, 
https://bugs.gentoo.org/648896#c6
asking for older releases to be fixed as well.

so this PR makes the previous releases build as well. Tested both, and both build and work with these changes.

Bug: https://bugs.gentoo.org/648896
Package-Manager: Portage[mgorny]-2.3.26.1