### PR TITLE
dev-lang/python: compatibility patch for libressl

### DIFF
--- a/dev-lang/python/files/python-2.7-libressl-compatibility.patch
+++ b/dev-lang/python/files/python-2.7-libressl-compatibility.patch
@@ -1,0 +1,92 @@
+# From https://github.com/python/cpython/pull/6215
+
+# LibreSSL 2.7 introduced OpenSSL 1.1.0 API. The ssl module now detects
+# LibreSSL 2.7 and only provides API shims for OpenSSL < 1.1.0 and
+# LibreSSL < 2.7.
+
+# Documentation updates and fixes for failing tests will be provided in
+# another patch set.
+
+# Signed-off-by: Christian Heimes christian@python.org.
+# (cherry picked from commit 4ca0739)
+
+#Co-authored-by: Christian Heimes christian@python.org
+
+--- a/Modules/_ssl.c	2017-09-16 17:38:35.000000000 +0000
++++ b/Modules/_ssl.c	2018-04-13 15:55:10.919424126 +0000
+@@ -97,6 +102,12 @@
+ 
+ #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+ #  define OPENSSL_VERSION_1_1 1
++#  define PY_OPENSSL_1_1_API 1
++#endif
++
++/* LibreSSL 2.7.0 provides necessary OpenSSL 1.1.0 APIs */
++#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL
++#  define PY_OPENSSL_1_1_API 1
+ #endif
+ 
+ /* Openssl comes with TLSv1.1 and TLSv1.2 between 1.0.0h and 1.0.1
+@@ -118,24 +129,44 @@
+ #endif
+ 
+ /* ALPN added in OpenSSL 1.0.2 */
+-#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(OPENSSL_NO_TLSEXT)
+-# define HAVE_ALPN
++#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
++# define HAVE_ALPN 1
++#else
++# define HAVE_ALPN 0
++#endif
++
++/* We cannot rely on OPENSSL_NO_NEXTPROTONEG because LibreSSL 2.6.1 dropped
++ * NPN support but did not set OPENSSL_NO_NEXTPROTONEG for compatibility
++ * reasons. The check for TLSEXT_TYPE_next_proto_neg works with
++ * OpenSSL 1.0.1+ and LibreSSL.
++ * OpenSSL 1.1.1-pre1 dropped NPN but still has TLSEXT_TYPE_next_proto_neg.
++ */
++#ifdef OPENSSL_NO_NEXTPROTONEG
++# define HAVE_NPN 0
++#elif (OPENSSL_VERSION_NUMBER >= 0x10101000L) && !defined(LIBRESSL_VERSION_NUMBER)
++# define HAVE_NPN 0
++#elif defined(TLSEXT_TYPE_next_proto_neg)
++# define HAVE_NPN 1
++#else
++# define HAVE_NPN 0
+ #endif
+ 
+ #ifndef INVALID_SOCKET /* MS defines this */
+ #define INVALID_SOCKET (-1)
+ #endif
+ 
+-#ifdef OPENSSL_VERSION_1_1
+-/* OpenSSL 1.1.0+ */
+-#ifndef OPENSSL_NO_SSL2
+-#define OPENSSL_NO_SSL2
+-#endif
+-#else /* OpenSSL < 1.1.0 */
+-#if defined(WITH_THREAD)
++/* OpenSSL 1.0.2 and LibreSSL needs extra code for locking */
++#if !defined(OPENSSL_VERSION_1_1) && defined(WITH_THREAD)
+ #define HAVE_OPENSSL_CRYPTO_LOCK
+ #endif
+ 
++#if defined(OPENSSL_VERSION_1_1) && !defined(OPENSSL_NO_SSL2)
++#define OPENSSL_NO_SSL2
++#endif
++
++#ifndef PY_OPENSSL_1_1_API
++/* OpenSSL 1.1 API shims for OpenSSL < 1.1.0 and LibreSSL < 2.7.0 */
++
+ #define TLS_method SSLv23_method
+ 
+ static int X509_NAME_ENTRY_set(const X509_NAME_ENTRY *ne)
+@@ -178,7 +209,7 @@
+ {
+     return store->param;
+ }
+-#endif /* OpenSSL < 1.1.0 or LibreSSL */
++#endif /* OpenSSL < 1.1.0 or LibreSSL < 2.7.0 */
+ 
+ 
+ enum py_ssl_error {

--- a/dev-lang/python/python-2.7.14-r1.ebuild
+++ b/dev-lang/python/python-2.7.14-r1.ebuild
@@ -49,7 +49,7 @@ RDEPEND="app-arch/bzip2:0=
 	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
 	ssl? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:= )
+		libressl? ( dev-libs/libressl:0= )
 	)
 	tk? (
 		>=dev-lang/tcl-8.0:0=
@@ -102,6 +102,7 @@ src_prepare() {
 	epatch "${FILESDIR}/python-2.7.10-cross-compile-warn-test.patch"
 	epatch "${FILESDIR}/python-2.7.10-system-libffi.patch"
 	epatch "${FILESDIR}/2.7-disable-nis.patch"
+	epatch "${FILESDIR}/python-2.7-libressl-compatibility.patch"
 
 	epatch_user
 


### PR DESCRIPTION
This patch fixes building with >=dev-libs/libressl-2.7. Additionally,
the slot and subslot modifier have been updated to ensure rebuilds are
properly triggered. Patch is from upstream commit
4ca0739c9d97ac7cd45499e0d31be68dc659d0e1.

Package-Manager: Portage-2.3.28, Repoman-2.3.9