### PR TITLE
kde-misc/latte-dock: stabilize 0.7.4 for x86 and amd64

### DIFF
--- a/kde-misc/latte-dock/latte-dock-0.7.4.ebuild
+++ b/kde-misc/latte-dock/latte-dock-0.7.4.ebuild
@@ -7,7 +7,7 @@ inherit kde5
 
 if [[ ${KDE_BUILD_TYPE} = release ]]; then
 	SRC_URI="mirror://kde/stable/${PN}/${P}.tar.xz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="amd64 x86"
 fi
 
 DESCRIPTION="Elegant dock, based on KDE Frameworks"


### PR DESCRIPTION
Bug : https://bugs.gentoo.org/653048

Package-Manager: Portage-2.3.28, Repoman-2.3.9