### PR TITLE
dev-lang/python: compatibility patch for libressl

### DIFF
--- a/dev-lang/python/files/python-3.6.5-libressl-compatibility.patch
+++ b/dev-lang/python/files/python-3.6.5-libressl-compatibility.patch
@@ -1,0 +1,114 @@
+From 8d89a385b71a2e4cce0fba0cfc8d91b63485edc5 Mon Sep 17 00:00:00 2001
+From: Christian Heimes <christian@python.org>
+Date: Sat, 24 Mar 2018 18:38:14 +0100
+Subject: [PATCH] [3.6] bpo-33127: Compatibility patch for LibreSSL 2.7.0
+ (GH-6210) (GH-6214)
+
+LibreSSL 2.7 introduced OpenSSL 1.1.0 API. The ssl module now detects
+LibreSSL 2.7 and only provides API shims for OpenSSL < 1.1.0 and
+LibreSSL < 2.7.
+
+Documentation updates and fixes for failing tests will be provided in
+another patch set.
+
+Signed-off-by: Christian Heimes <christian@python.org>.
+(cherry picked from commit 4ca0739c9d97ac7cd45499e0d31be68dc659d0e1)
+
+Co-authored-by: Christian Heimes <christian@python.org>
+---
+ Lib/test/test_ssl.py                          |  1 +
+ .../2018-03-24-15-08-24.bpo-33127.olJmHv.rst  |  1 +
+ Modules/_ssl.c                                | 24 ++++++++++++-------
+ Tools/ssl/multissltests.py                    |  3 ++-
+ 4 files changed, 20 insertions(+), 9 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Library/2018-03-24-15-08-24.bpo-33127.olJmHv.rst
+
+diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
+index 8dd3b41450..9785a59a7e 100644
+--- a/Lib/test/test_ssl.py
++++ b/Lib/test/test_ssl.py
+@@ -1687,6 +1687,7 @@ class SimpleBackgroundTests(unittest.TestCase):
+         self.assertEqual(len(ctx.get_ca_certs()), 1)
+ 
+     @needs_sni
++    @unittest.skipUnless(hasattr(ssl, "PROTOCOL_TLSv1_2"), "needs TLS 1.2")
+     def test_context_setget(self):
+         # Check that the context of a connected socket can be replaced.
+         ctx1 = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+diff --git a/Misc/NEWS.d/next/Library/2018-03-24-15-08-24.bpo-33127.olJmHv.rst b/Misc/NEWS.d/next/Library/2018-03-24-15-08-24.bpo-33127.olJmHv.rst
+new file mode 100644
+index 0000000000..635aabbde0
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2018-03-24-15-08-24.bpo-33127.olJmHv.rst
+@@ -0,0 +1 @@
++The ssl module now compiles with LibreSSL 2.7.1.
+diff --git a/Modules/_ssl.c b/Modules/_ssl.c
+index c54e43c2b4..5e007da858 100644
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -106,6 +106,12 @@ struct py_ssl_library_code {
+ 
+ #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+ #  define OPENSSL_VERSION_1_1 1
++#  define PY_OPENSSL_1_1_API 1
++#endif
++
++/* LibreSSL 2.7.0 provides necessary OpenSSL 1.1.0 APIs */
++#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL
++#  define PY_OPENSSL_1_1_API 1
+ #endif
+ 
+ /* Openssl comes with TLSv1.1 and TLSv1.2 between 1.0.0h and 1.0.1
+@@ -152,16 +158,18 @@ struct py_ssl_library_code {
+ #define INVALID_SOCKET (-1)
+ #endif
+ 
+-#ifdef OPENSSL_VERSION_1_1
+-/* OpenSSL 1.1.0+ */
+-#ifndef OPENSSL_NO_SSL2
+-#define OPENSSL_NO_SSL2
+-#endif
+-#else /* OpenSSL < 1.1.0 */
+-#if defined(WITH_THREAD)
++/* OpenSSL 1.0.2 and LibreSSL needs extra code for locking */
++#if !defined(OPENSSL_VERSION_1_1) && defined(WITH_THREAD)
+ #define HAVE_OPENSSL_CRYPTO_LOCK
+ #endif
+ 
++#if defined(OPENSSL_VERSION_1_1) && !defined(OPENSSL_NO_SSL2)
++#define OPENSSL_NO_SSL2
++#endif
++
++#ifndef PY_OPENSSL_1_1_API
++/* OpenSSL 1.1 API shims for OpenSSL < 1.1.0 and LibreSSL < 2.7.0 */
++
+ #define TLS_method SSLv23_method
+ #define TLS_client_method SSLv23_client_method
+ #define TLS_server_method SSLv23_server_method
+@@ -227,7 +235,7 @@ SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *s)
+     return s->tlsext_tick_lifetime_hint;
+ }
+ 
+-#endif /* OpenSSL < 1.1.0 or LibreSSL */
++#endif /* OpenSSL < 1.1.0 or LibreSSL < 2.7.0 */
+ 
+ 
+ enum py_ssl_error {
+diff --git a/Tools/ssl/multissltests.py b/Tools/ssl/multissltests.py
+index ce5bbd8530..ba4529ae06 100755
+--- a/Tools/ssl/multissltests.py
++++ b/Tools/ssl/multissltests.py
+@@ -57,8 +57,9 @@ LIBRESSL_OLD_VERSIONS = [
+ ]
+ 
+ LIBRESSL_RECENT_VERSIONS = [
+-    "2.5.3",
+     "2.5.5",
++    "2.6.4",
++    "2.7.1",
+ ]
+ 
+ # store files in ../multissl
+-- 
+2.17.0
+

--- a/dev-lang/python/python-3.6.5.ebuild
+++ b/dev-lang/python/python-3.6.5.ebuild
@@ -38,7 +38,7 @@ RDEPEND="app-arch/bzip2:0=
 	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
 	ssl? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:= )
+		libressl? ( dev-libs/libressl:0= )
 	)
 	tk? (
 		>=dev-lang/tcl-8.0:0=
@@ -68,6 +68,7 @@ src_prepare() {
 		"${WORKDIR}/patches"
 		"${FILESDIR}/${PN}-3.5-distutils-OO-build.patch"
 		"${FILESDIR}/3.6.5-disable-nis.patch"
+		"${FILESDIR}/python-3.6.5-libressl-compatibility.patch"
 	)
 
 	default


### PR DESCRIPTION
This patch fixes building with >=dev-libs/libressl-2.7. Additionally,
the slot and subslot modifier have been updated to ensure rebuilds are
properly triggered.

Package-Manager: Portage-2.3.28, Repoman-2.3.9