### PR TITLE
dev-lang/python: compatibility patch for libressl

### DIFF
--- a/dev-lang/python/files/python-3.5.5-libressl-compatibility.patch
+++ b/dev-lang/python/files/python-3.5.5-libressl-compatibility.patch
@@ -1,0 +1,69 @@
+# From 8d89a385b71a2e4cce0fba0cfc8d91b63485edc5 Mon Sep 17 00:00:00 2001
+# From: Christian Heimes <christian@python.org>
+# Date: Sat, 24 Mar 2018 18:38:14 +0100
+# Subject: [PATCH] [3.6] bpo-33127: Compatibility patch for LibreSSL 2.7.0
+# (GH-6210) (GH-6214)
+#
+# LibreSSL 2.7 introduced OpenSSL 1.1.0 API. The ssl module now detects
+# LibreSSL 2.7 and only provides API shims for OpenSSL < 1.1.0 and
+# LibreSSL < 2.7.
+
+# Documentation updates and fixes for failing tests will be provided in
+# another patch set.
+
+# Signed-off-by: Christian Heimes <christian@python.org>.
+# (cherry picked from commit 4ca0739c9d97ac7cd45499e0d31be68dc659d0e1)
+
+# Co-authored-by: Christian Heimes <christian@python.org>
+# Patch modified by Aaron Bauman <bman@gentoo.org> for 3.5.5
+
+--- a/Modules/_ssl.c	2018-04-13 18:33:17.397649561 -0400
++++ b/Modules/_ssl.c	2018-04-13 18:40:22.319852014 -0400
+@@ -101,6 +101,12 @@
+ 
+ #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+ #  define OPENSSL_VERSION_1_1 1
++#  define PY_OPENSSL_1_1_API 1
++#endif
++
++/* LibreSSL 2.7.0 provides necessary OpenSSL 1.1.0 APIs */
++#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL
++#  define PY_OPENSSL_1_1_API 1
+ #endif
+ 
+ /* Openssl comes with TLSv1.1 and TLSv1.2 between 1.0.0h and 1.0.1
+@@ -129,16 +135,18 @@
+ #define INVALID_SOCKET (-1)
+ #endif
+ 
+-#ifdef OPENSSL_VERSION_1_1
+-/* OpenSSL 1.1.0+ */
+-#ifndef OPENSSL_NO_SSL2
+-#define OPENSSL_NO_SSL2
+-#endif
+-#else /* OpenSSL < 1.1.0 */
+-#if defined(WITH_THREAD)
++/* OpenSSL 1.0.2 and LibreSSL needs extra code for locking */
++#if !defined(OPENSSL_VERSION_1_1) && defined(WITH_THREAD)
+ #define HAVE_OPENSSL_CRYPTO_LOCK
+ #endif
+ 
++#if defined(OPENSSL_VERSION_1_1) && !defined(OPENSSL_NO_SSL2)
++#define OPENSSL_NO_SSL2
++#endif
++
++#ifndef PY_OPENSSL_1_1_API
++/* OpenSSL 1.1 API shims for OpenSSL < 1.1.0 and LibreSSL < 2.7.0 */
++
+ #define TLS_method SSLv23_method
+ 
+ static int X509_NAME_ENTRY_set(const X509_NAME_ENTRY *ne)
+@@ -187,7 +195,7 @@
+ {
+     return store->param;
+ }
+-#endif /* OpenSSL < 1.1.0 or LibreSSL */
++#endif /* OpenSSL < 1.1.0 or LibreSSL < 2.7.0 */
+ 
+ 
+ enum py_ssl_error {

--- a/dev-lang/python/python-3.5.5.ebuild
+++ b/dev-lang/python/python-3.5.5.ebuild
@@ -38,7 +38,7 @@ RDEPEND="app-arch/bzip2:0=
 	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
 	ssl? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:= )
+		libressl? ( dev-libs/libressl:0= )
 	)
 	tk? (
 		>=dev-lang/tcl-8.0:0=
@@ -74,6 +74,7 @@ src_prepare() {
 	epatch "${FILESDIR}/${PN}-3.4.3-ncurses-pkg-config.patch"
 	epatch "${FILESDIR}/${PN}-3.5-distutils-OO-build.patch"
 	epatch "${FILESDIR}/3.6-disable-nis.patch"
+	epatch "${FILESDIR}/python-3.5.5-libressl-compatibility.patch"
 
 	epatch_user
 


### PR DESCRIPTION
This patch fixes building with >=dev-libs/libressl-2.7. Additionally,
the slot and subslot modifier have been updated to ensure rebuilds are
properly triggered.

Bug: https://bugs.gentoo.org/651162
Package-Manager: Portage-2.3.28, Repoman-2.3.9