### PR TITLE
www-client/dillo, x11-misc/xautomation, x11-themes/{gargantuan-icon-theme,gartoon-redux}: use HTTPS

### DIFF
--- a/www-client/dillo/dillo-3.0.5-r1.ebuild
+++ b/www-client/dillo/dillo-3.0.5-r1.ebuild
@@ -5,8 +5,8 @@ EAPI=5
 inherit eutils multilib toolchain-funcs
 
 DESCRIPTION="Lean FLTK based web browser"
-HOMEPAGE="http://www.dillo.org/"
-SRC_URI="http://www.dillo.org/download/${P}.tar.bz2
+HOMEPAGE="https://www.dillo.org/"
+SRC_URI="https://www.dillo.org/download/${P}.tar.bz2
 	mirror://gentoo/${PN}.png"
 
 LICENSE="GPL-3"

--- a/www-client/dillo/dillo-3.0.5.ebuild
+++ b/www-client/dillo/dillo-3.0.5.ebuild
@@ -5,8 +5,8 @@ EAPI=5
 inherit eutils multilib toolchain-funcs
 
 DESCRIPTION="Lean FLTK based web browser"
-HOMEPAGE="http://www.dillo.org/"
-SRC_URI="http://www.dillo.org/download/${P}.tar.bz2
+HOMEPAGE="https://www.dillo.org/"
+SRC_URI="https://www.dillo.org/download/${P}.tar.bz2
 	mirror://gentoo/${PN}.png"
 
 LICENSE="GPL-3"

--- a/x11-misc/xautomation/xautomation-1.09-r1.ebuild
+++ b/x11-misc/xautomation/xautomation-1.09-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Control X from command line and find things on screen"
-HOMEPAGE="http://hoopajoo.net/projects/xautomation.html"
-SRC_URI="http://hoopajoo.net/static/projects/${P}.tar.gz"
+HOMEPAGE="https://hoopajoo.net/projects/xautomation.html"
+SRC_URI="https://hoopajoo.net/static/projects/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-themes/gargantuan-icon-theme/gargantuan-icon-theme-1.7.ebuild
+++ b/x11-themes/gargantuan-icon-theme/gargantuan-icon-theme-1.7.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit gnome2-utils
 
 DESCRIPTION="Gargantuan Icon Theme"
-HOMEPAGE="http://www.gnome-look.org/content/show.php?content=24364"
+HOMEPAGE="https://www.gnome-look.org/content/show.php?content=24364"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="public-domain"

--- a/x11-themes/gartoon-redux/gartoon-redux-1.10-r1.ebuild
+++ b/x11-themes/gartoon-redux/gartoon-redux-1.10-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils gnome2-utils
 
 DESCRIPTION="A massively improved variant of the well-known Gartoon theme"
-HOMEPAGE="http://gnome-look.org/content/show.php/?content=74841"
+HOMEPAGE="https://gnome-look.org/content/show.php/?content=74841"
 SRC_URI="http://tweenk.artfx.pl/gartoon/source/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This PR fixes a few desktop-misc related packages to use https instead of http.

Please review.