### PR TITLE
dev-python/APScheduler: fix HOMEPAGE

### DIFF
--- a/dev-python/APScheduler/APScheduler-3.1.0.ebuild
+++ b/dev-python/APScheduler/APScheduler-3.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="In-process task scheduler with Cron-like capabilities"
-HOMEPAGE="https://bitbucket.org/agronholm/apscheduler"
+HOMEPAGE="https://github.com/agronholm/apscheduler"
 SRC_URI="mirror://pypi/A/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/APScheduler/APScheduler-3.2.0.ebuild
+++ b/dev-python/APScheduler/APScheduler-3.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="In-process task scheduler with Cron-like capabilities"
-HOMEPAGE="https://bitbucket.org/agronholm/apscheduler"
+HOMEPAGE="https://github.com/agronholm/apscheduler"
 SRC_URI="mirror://pypi/A/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/APScheduler/APScheduler-3.3.1.ebuild
+++ b/dev-python/APScheduler/APScheduler-3.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit distutils-r1
 
 DESCRIPTION="In-process task scheduler with Cron-like capabilities"
-HOMEPAGE="https://bitbucket.org/agronholm/apscheduler"
+HOMEPAGE="https://github.com/agronholm/apscheduler"
 SRC_URI="mirror://pypi/A/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"


### PR DESCRIPTION
Hi,

The bitbucket site doesn't exist anymore and only points to the github page. I've updated the ebuilds accordingly.

Please review.