### PR TITLE
media-libs/vulkan-loader: Require X if building demos

### DIFF
--- a/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,6 +23,7 @@ HOMEPAGE="https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers"
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="demos wayland X"
+REQUIRED_USE="demos? ( X )"
 
 RDEPEND=""
 DEPEND="${PYTHON_DEPS}


### PR DESCRIPTION
Reported-by: Simon <simon.vanderveldt@gmail.com>

Package-Manager: Portage-2.3.28, Repoman-2.3.9

@mattst88 