### PR TITLE
dev-util/spirv-tools: Remove unnecessary "die" call

### DIFF
--- a/dev-util/spirv-tools/spirv-tools-2018.2-r1.ebuild
+++ b/dev-util/spirv-tools/spirv-tools-2018.2-r1.ebuild
@@ -32,5 +32,5 @@ multilib_src_install() {
 	default
 	echo "${UPSTREAM_COMMIT}" > "${PN}-commit.h" || die
 	insinto /usr/include/"${PN}"
-	doins  "${PN}-commit.h" || die
+	doins  "${PN}-commit.h"
 }


### PR DESCRIPTION
Package-Manager: Portage-2.3.28, Repoman-2.3.9