### PR TITLE
app-text/*, dev-libs/girara, dev-python/pyClamd, ... : use HTTPS

### DIFF
--- a/app-text/xmldiff/xmldiff-0.6.10-r1.ebuild
+++ b/app-text/xmldiff/xmldiff-0.6.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="A tool that figures out the differences between two similar XML files"
-HOMEPAGE="http://www.logilab.org/project/xmldiff"
+HOMEPAGE="https://www.logilab.org/project/xmldiff"
 SRC_URI="ftp://ftp.logilab.fr/pub/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-text/zathura-cb/zathura-cb-0.1.6.ebuild
+++ b/app-text/zathura-cb/zathura-cb-0.1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="amd64 arm x86"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="Comic book plug-in for zathura with 7zip, rar, tar and zip support"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-text/zathura-cb/zathura-cb-0.1.7.ebuild
+++ b/app-text/zathura-cb/zathura-cb-0.1.7.ebuild
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="amd64 ~arm x86"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="Comic book plug-in for zathura with 7zip, rar, tar and zip support"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-text/zathura-cb/zathura-cb-9999.ebuild
+++ b/app-text/zathura-cb/zathura-cb-9999.ebuild
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="~amd64 ~arm ~x86"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="Comic book plug-in for zathura with 7zip, rar, tar and zip support"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-text/zathura-meta/zathura-meta-0.ebuild
+++ b/app-text/zathura-meta/zathura-meta-0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 DESCRIPTION="Meta package for app-text/zathura plugins"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 SRC_URI=""
 
 LICENSE="metapackage"

--- a/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.1.ebuild
+++ b/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.1.ebuild
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="amd64 arm x86"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="PDF plug-in for zathura"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.2.ebuild
+++ b/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.2.ebuild
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="amd64 ~arm x86"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="PDF plug-in for zathura"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-9999.ebuild
+++ b/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-9999.ebuild
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="~amd64 ~arm ~x86"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="PDF plug-in for zathura"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-text/zathura-ps/zathura-ps-0.2.4.ebuild
+++ b/app-text/zathura-ps/zathura-ps-0.2.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="amd64 arm x86 ~amd64-linux ~x86-linux"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="PostScript plug-in for zathura"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-text/zathura-ps/zathura-ps-0.2.5.ebuild
+++ b/app-text/zathura-ps/zathura-ps-0.2.5.ebuild
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="amd64 ~arm x86 ~amd64-linux ~x86-linux"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="PostScript plug-in for zathura"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/app-text/zathura-ps/zathura-ps-9999.ebuild
+++ b/app-text/zathura-ps/zathura-ps-9999.ebuild
@@ -11,11 +11,11 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="develop"
 else
 	KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="PostScript plug-in for zathura"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 LICENSE="ZLIB"
 SLOT="0"

--- a/dev-libs/girara/girara-0.2.7.ebuild
+++ b/dev-libs/girara/girara-0.2.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,9 +7,9 @@ inherit multilib toolchain-funcs virtualx
 [[ ${PV} == 9999* ]] && inherit git-2
 
 DESCRIPTION="UI library that focuses on simplicity and minimalism"
-HOMEPAGE="http://pwmt.org/projects/girara/"
+HOMEPAGE="https://pwmt.org/projects/girara/"
 if ! [[ ${PV} == 9999* ]]; then
-SRC_URI="http://pwmt.org/projects/${PN}/download/${P}.tar.gz"
+SRC_URI="https://pwmt.org/projects/${PN}/download/${P}.tar.gz"
 fi
 EGIT_REPO_URI="https://git.pwmt.org/pwmt/${PN}.git"
 EGIT_BRANCH="develop"

--- a/dev-libs/girara/girara-0.2.8.ebuild
+++ b/dev-libs/girara/girara-0.2.8.ebuild
@@ -7,9 +7,9 @@ inherit multilib toolchain-funcs virtualx
 [[ ${PV} == 9999* ]] && inherit git-2
 
 DESCRIPTION="UI library that focuses on simplicity and minimalism"
-HOMEPAGE="http://pwmt.org/projects/girara/"
+HOMEPAGE="https://pwmt.org/projects/girara/"
 if ! [[ ${PV} == 9999* ]]; then
-SRC_URI="http://pwmt.org/projects/${PN}/download/${P}.tar.gz"
+SRC_URI="https://pwmt.org/projects/${PN}/download/${P}.tar.gz"
 fi
 EGIT_REPO_URI="https://git.pwmt.org/pwmt/${PN}.git"
 EGIT_BRANCH="develop"

--- a/dev-libs/girara/girara-9999.ebuild
+++ b/dev-libs/girara/girara-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,9 +7,9 @@ inherit multilib toolchain-funcs virtualx
 [[ ${PV} == 9999* ]] && inherit git-2
 
 DESCRIPTION="UI library that focuses on simplicity and minimalism"
-HOMEPAGE="http://pwmt.org/projects/girara/"
+HOMEPAGE="https://pwmt.org/projects/girara/"
 if ! [[ ${PV} == 9999* ]]; then
-SRC_URI="http://pwmt.org/projects/${PN}/download/${P}.tar.gz"
+SRC_URI="https://pwmt.org/projects/${PN}/download/${P}.tar.gz"
 fi
 EGIT_REPO_URI="https://git.pwmt.org/pwmt/${PN}.git"
 EGIT_BRANCH="develop"

--- a/dev-python/pyClamd/pyClamd-0.3.17.ebuild
+++ b/dev-python/pyClamd/pyClamd-0.3.17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit distutils-r1
 
 DESCRIPTION="python interface to Clamd (Clamav daemon)"
-HOMEPAGE="http://xael.org/norman/python/pyclamd/"
+HOMEPAGE="https://xael.org/norman/python/pyclamd/"
 SRC_URI="mirror://pypi/p/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"

--- a/dev-python/pyClamd/pyClamd-0.4.0.ebuild
+++ b/dev-python/pyClamd/pyClamd-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit distutils-r1
 
 DESCRIPTION="python interface to Clamd (Clamav daemon)"
-HOMEPAGE="http://xael.org/pages/pyclamd-en.html"
+HOMEPAGE="https://xael.org/pages/pyclamd-en.html"
 SRC_URI="mirror://pypi/p/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"

--- a/media-video/dcpomatic/dcpomatic-2.10.2.ebuild
+++ b/media-video/dcpomatic/dcpomatic-2.10.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ PYTHON_REQ_USE="threads(+)"
 inherit python-any-r1 waf-utils wxwidgets
 
 DESCRIPTION="create Digital Cinema Packages (DCPs) from videos, images and sound files"
-HOMEPAGE="http://dcpomatic.com/"
+HOMEPAGE="https://dcpomatic.com/"
 SRC_URI="http://${PN}.com/downloads/${PV}/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/media-video/dcpomatic/dcpomatic-2.10.5.ebuild
+++ b/media-video/dcpomatic/dcpomatic-2.10.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ PYTHON_REQ_USE="threads(+)"
 inherit python-any-r1 waf-utils wxwidgets
 
 DESCRIPTION="create Digital Cinema Packages (DCPs) from videos, images and sound files"
-HOMEPAGE="http://dcpomatic.com/"
+HOMEPAGE="https://dcpomatic.com/"
 SRC_URI="http://${PN}.com/downloads/${PV}/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/media-video/dcpomatic/dcpomatic-2.11.7.ebuild
+++ b/media-video/dcpomatic/dcpomatic-2.11.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ PYTHON_REQ_USE="threads(+)"
 inherit python-any-r1 waf-utils wxwidgets
 
 DESCRIPTION="create Digital Cinema Packages (DCPs) from videos, images and sound files"
-HOMEPAGE="http://dcpomatic.com/"
+HOMEPAGE="https://dcpomatic.com/"
 SRC_URI="http://${PN}.com/downloads/${PV}/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/net-misc/mosh/mosh-1.2.6.ebuild
+++ b/net-misc/mosh/mosh-1.2.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit autotools bash-completion-r1 eutils vcs-snapshot
 
 DESCRIPTION="Mobile shell that supports roaming and intelligent local echo"
-HOMEPAGE="http://mosh.mit.edu"
-SRC_URI="http://mosh.mit.edu/${P}.tar.gz"
+HOMEPAGE="https://mosh.org"
+SRC_URI="https://mosh.org/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/net-misc/mosh/mosh-1.3.0.ebuild
+++ b/net-misc/mosh/mosh-1.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit autotools bash-completion-r1 eutils vcs-snapshot
 
 DESCRIPTION="Mobile shell that supports roaming and intelligent local echo"
-HOMEPAGE="http://mosh.org"
-SRC_URI="http://mosh.org/${P}.tar.gz"
+HOMEPAGE="https://mosh.org"
+SRC_URI="https://mosh.org/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/net-misc/mosh/mosh-1.3.2.ebuild
+++ b/net-misc/mosh/mosh-1.3.2.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit autotools bash-completion-r1 eutils vcs-snapshot
 
 DESCRIPTION="Mobile shell that supports roaming and intelligent local echo"
-HOMEPAGE="http://mosh.org"
-SRC_URI="http://mosh.org/${P}.tar.gz"
+HOMEPAGE="https://mosh.org"
+SRC_URI="https://mosh.org/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/net-misc/mosh/mosh-9999.ebuild
+++ b/net-misc/mosh/mosh-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools bash-completion-r1 eutils git-r3
 
 DESCRIPTION="Mobile shell that supports roaming and intelligent local echo"
-HOMEPAGE="http://mosh.mit.edu"
+HOMEPAGE="https://mosh.org"
 EGIT_REPO_URI="https://github.com/keithw/mosh.git"
 
 LICENSE="GPL-3"

--- a/net-misc/ndisc6/ndisc6-0.9.9-r2.ebuild
+++ b/net-misc/ndisc6/ndisc6-0.9.9-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 DESCRIPTION="Recursive DNS Servers discovery Daemon (rdnssd) for IPv6"
-HOMEPAGE="http://www.remlab.net/ndisc6/"
-SRC_URI="http://www.remlab.net/files/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://www.remlab.net/ndisc6/"
+SRC_URI="https://www.remlab.net/files/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/ndisc6/ndisc6-0.9.9.ebuild
+++ b/net-misc/ndisc6/ndisc6-0.9.9.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 DESCRIPTION="Recursive DNS Servers discovery Daemon (rdnssd) for IPv6"
-HOMEPAGE="http://www.remlab.net/ndisc6/"
-SRC_URI="http://www.remlab.net/files/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://www.remlab.net/ndisc6/"
+SRC_URI="https://www.remlab.net/files/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/ndisc6/ndisc6-1.0.2-r1.ebuild
+++ b/net-misc/ndisc6/ndisc6-1.0.2-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 DESCRIPTION="Recursive DNS Servers discovery Daemon (rdnssd) for IPv6"
-HOMEPAGE="http://www.remlab.net/ndisc6/"
-SRC_URI="http://www.remlab.net/files/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://www.remlab.net/ndisc6/"
+SRC_URI="https://www.remlab.net/files/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/ndisc6/ndisc6-1.0.2.ebuild
+++ b/net-misc/ndisc6/ndisc6-1.0.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 DESCRIPTION="Recursive DNS Servers discovery Daemon (rdnssd) for IPv6"
-HOMEPAGE="http://www.remlab.net/ndisc6/"
-SRC_URI="http://www.remlab.net/files/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://www.remlab.net/ndisc6/"
+SRC_URI="https://www.remlab.net/files/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/ndisc6/ndisc6-1.0.3.ebuild
+++ b/net-misc/ndisc6/ndisc6-1.0.3.ebuild
@@ -4,8 +4,8 @@
 EAPI=5
 
 DESCRIPTION="Recursive DNS Servers discovery Daemon (rdnssd) for IPv6"
-HOMEPAGE="http://www.remlab.net/ndisc6/"
-SRC_URI="http://www.remlab.net/files/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://www.remlab.net/ndisc6/"
+SRC_URI="https://www.remlab.net/files/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-p2p/ncdc/ncdc-1.19.1.ebuild
+++ b/net-p2p/ncdc/ncdc-1.19.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit autotools eutils toolchain-funcs
 
 DESCRIPTION="ncurses directconnect client"
-HOMEPAGE="http://dev.yorhel.nl/ncdc"
-SRC_URI="http://dev.yorhel.nl/download/${P}.tar.gz"
+HOMEPAGE="https://dev.yorhel.nl/ncdc"
+SRC_URI="https://dev.yorhel.nl/download/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/net-p2p/ncdc/ncdc-1.20.ebuild
+++ b/net-p2p/ncdc/ncdc-1.20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="ncurses directconnect client"
-HOMEPAGE="http://dev.yorhel.nl/ncdc"
-SRC_URI="http://dev.yorhel.nl/download/${P}.tar.gz"
+HOMEPAGE="https://dev.yorhel.nl/ncdc"
+SRC_URI="https://dev.yorhel.nl/download/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/net-p2p/ncdc/ncdc-9999.ebuild
+++ b/net-p2p/ncdc/ncdc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools git-r3 toolchain-funcs
 
 DESCRIPTION="ncurses directconnect client"
-HOMEPAGE="http://dev.yorhel.nl/ncdc"
+HOMEPAGE="https://dev.yorhel.nl/ncdc"
 EGIT_REPO_URI="git://g.blicky.net/ncdc.git"
 
 LICENSE="MIT"

--- a/sci-misc/mendeleydesktop/mendeleydesktop-1.17.13.ebuild
+++ b/sci-misc/mendeleydesktop/mendeleydesktop-1.17.13.ebuild
@@ -11,7 +11,7 @@ MY_P_AMD64="${P}-linux-x86_64"
 MY_P_X86="${P}-linux-i486"
 
 DESCRIPTION="Research management tool for desktop and web"
-HOMEPAGE="http://www.mendeley.com/"
+HOMEPAGE="https://www.mendeley.com/"
 SRC_URI="
 	amd64? ( ${MY_P_AMD64}.tar.bz2 )
 	x86? ( ${MY_P_X86}.tar.bz2 )


### PR DESCRIPTION
Hi,

This PR fixes another few packages to use HTTPS instead of http.

Please review.