### PR TITLE
app-crypt/nitrokey-app: Add dev-qt/linguist-tools:5 as DEPEND instead…

### DIFF
--- a/app-crypt/nitrokey-app/nitrokey-app-1.3.ebuild
+++ b/app-crypt/nitrokey-app/nitrokey-app-1.3.ebuild
@@ -33,7 +33,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	dev-libs/cppcodec
-	dev-qt/qttranslations:5
+	dev-qt/linguist-tools:5
 	virtual/pkgconfig"
 
 pkg_postinst(){

--- a/app-crypt/nitrokey-app/nitrokey-app-9999.ebuild
+++ b/app-crypt/nitrokey-app/nitrokey-app-9999.ebuild
@@ -33,7 +33,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	dev-libs/cppcodec
-	dev-qt/qttranslations:5
+	dev-qt/linguist-tools:5
 	virtual/pkgconfig"
 
 pkg_postinst(){


### PR DESCRIPTION
… dev-qt/qttranslations.

My mistake sorry.

Bug: https://bugs.gentoo.org/653102
Closes: https://bugs.gentoo.org/653102