### PR TITLE
dev-qt/qtdeclarative: Backport fix for textures memleak

### DIFF
--- a/dev-qt/qtdeclarative/files/qtdeclarative-5.9.5-texture-memleak.patch
+++ b/dev-qt/qtdeclarative/files/qtdeclarative-5.9.5-texture-memleak.patch
@@ -1,0 +1,59 @@
+From 839f09c65523fb5c419b62e078f72bb39285449a Mon Sep 17 00:00:00 2001
+From: David Edmundson <davidedmundson@kde.org>
+Date: Wed, 28 Mar 2018 00:24:56 +0100
+Subject: [PATCH] Avoid marking hidden windows as updatePending in Gui render
+ loop
+
+Since eeb320bbd8763f3e72f79369cc3908e999a0da3c the GL context only
+deletes textures when all windows with pending updates have finished
+rendering.
+
+renderWindow will not process any window that is not visible. This
+leaves a logic bug that we can have the updatePending flag set but
+never cleared.
+
+If we have two windows, this leaves the other window still updating
+normally, but lastDirtyWindow will always be false and we never call
+endSync.
+
+This results in an effective memory leak of all textures.
+
+This patch resets the flag on hide() a move that can be considered safe
+given the show() method will reset this flag anyway.
+
+Change-Id: Iab0171716e27e31077a66b5e36a00bf28a2e7a8c
+Reviewed-by: Kai Uwe Broulik <kde@privat.broulik.de>
+Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+Reviewed-by: Dominik Holland <dominik.holland@pelagicore.com>
+Reviewed-by: Aleix Pol
+Reviewed-by: Andy Nichols <andy.nichols@qt.io>
+---
+ src/quick/scenegraph/qsgrenderloop.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/quick/scenegraph/qsgrenderloop.cpp b/src/quick/scenegraph/qsgrenderloop.cpp
+index 60f3538662..2eaed497ef 100644
+--- a/src/quick/scenegraph/qsgrenderloop.cpp
++++ b/src/quick/scenegraph/qsgrenderloop.cpp
+@@ -305,6 +305,8 @@ void QSGGuiThreadRenderLoop::hide(QQuickWindow *window)
+ {
+     QQuickWindowPrivate *cd = QQuickWindowPrivate::get(window);
+     cd->fireAboutToStop();
++    if (m_windows.contains(window))
++        m_windows[window].updatePending = false;
+ }
+ 
+ void QSGGuiThreadRenderLoop::windowDestroyed(QQuickWindow *window)
+@@ -494,7 +496,8 @@ QImage QSGGuiThreadRenderLoop::grab(QQuickWindow *window)
+ 
+ void QSGGuiThreadRenderLoop::maybeUpdate(QQuickWindow *window)
+ {
+-    if (!m_windows.contains(window))
++    QQuickWindowPrivate *cd = QQuickWindowPrivate::get(window);
++    if (!cd->isRenderable() || !m_windows.contains(window))
+         return;
+ 
+     m_windows[window].updatePending = true;
+-- 
+2.16.3
+

--- a/dev-qt/qtdeclarative/qtdeclarative-5.9.5-r1.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.9.5-r1.ebuild
@@ -1,0 +1,58 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+inherit python-any-r1 qt5-build
+
+DESCRIPTION="The QML and Quick modules for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-fbsd"
+fi
+
+IUSE="gles2 +jit localstorage +widgets xml"
+
+# qtgui[gles2=] is needed because of bug 504322
+COMMON_DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qttest-${PV}
+	localstorage? ( ~dev-qt/qtsql-${PV} )
+	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2=] )
+	xml? (
+		~dev-qt/qtnetwork-${PV}
+		~dev-qt/qtxmlpatterns-${PV}
+	)
+"
+DEPEND="${COMMON_DEPEND}
+	${PYTHON_DEPS}
+"
+RDEPEND="${COMMON_DEPEND}
+	!<dev-qt/qtquickcontrols-5.7:5
+"
+
+PATCHES=( "${FILESDIR}/${P}-texture-memleak.patch" )
+
+src_prepare() {
+	use jit || PATCHES+=("${FILESDIR}/${PN}-5.4.2-disable-jit.patch")
+
+	qt_use_disable_mod localstorage sql \
+		src/imports/imports.pro
+
+	qt_use_disable_mod widgets widgets \
+		src/src.pro \
+		src/qmltest/qmltest.pro \
+		tests/auto/auto.pro \
+		tools/tools.pro \
+		tools/qmlscene/qmlscene.pro \
+		tools/qml/qml.pro
+
+	qt_use_disable_mod xml xmlpatterns \
+		src/imports/imports.pro \
+		tests/auto/quick/quick.pro \
+		tests/auto/quick/examples/examples.pro
+
+	qt5-build_src_prepare
+}


### PR DESCRIPTION
KDE-Bug: https://bugs.kde.org/show_bug.cgi?id=368838
See also: https://codereview.qt-project.org/#/c/224684/
https://pointieststick.wordpress.com/2018/04/14/this-week-in-usability-productivity-part-14/

Package-Manager: Portage-2.3.28, Repoman-2.3.9