### PR TITLE
sci-electronics/kicad: Fix configuration issue with >=CMake-3.11

### DIFF
--- a/sci-electronics/kicad/files/kicad-cmake-checkcxxsymbolexists.patch
+++ b/sci-electronics/kicad/files/kicad-cmake-checkcxxsymbolexists.patch
@@ -1,0 +1,46 @@
+diff -Naur kicad-4.0.7.orig/CMakeModules/CheckCXXSymbolExists.cmake kicad-4.0.7/CMakeModules/CheckCXXSymbolExists.cmake
+--- kicad-4.0.7.orig/CMakeModules/CheckCXXSymbolExists.cmake	2017-08-28 07:31:31.000000000 -0700
++++ kicad-4.0.7/CMakeModules/CheckCXXSymbolExists.cmake	1969-12-31 16:00:00.000000000 -0800
+@@ -1,42 +0,0 @@
+-# - Check if a symbol exists as a function, variable, or macro in C++
+-# CHECK_CXX_SYMBOL_EXISTS(<symbol> <files> <variable>)
+-#
+-# Check that the <symbol> is available after including given header
+-# <files> and store the result in a <variable>.  Specify the list
+-# of files in one argument as a semicolon-separated list.
+-# CHECK_CXX_SYMBOL_EXISTS() can be used to check in C++ files, as opposed
+-# to CHECK_SYMBOL_EXISTS(), which works only for C.
+-#
+-# If the header files define the symbol as a macro it is considered
+-# available and assumed to work.  If the header files declare the
+-# symbol as a function or variable then the symbol must also be
+-# available for linking.  If the symbol is a type or enum value
+-# it will not be recognized (consider using CheckTypeSize or
+-# CheckCSourceCompiles).
+-#
+-# The following variables may be set before calling this macro to
+-# modify the way the check is run:
+-#
+-#  CMAKE_REQUIRED_FLAGS = string of compile command line flags
+-#  CMAKE_REQUIRED_DEFINITIONS = list of macros to define (-DFOO=bar)
+-#  CMAKE_REQUIRED_INCLUDES = list of include directories
+-#  CMAKE_REQUIRED_LIBRARIES = list of libraries to link
+-
+-#=============================================================================
+-# Copyright 2003-2011 Kitware, Inc.
+-#
+-# Distributed under the OSI-approved BSD License (the "License");
+-# see accompanying file Copyright.txt for details.
+-#
+-# This software is distributed WITHOUT ANY WARRANTY; without even the
+-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+-# See the License for more information.
+-#=============================================================================
+-# (To distribute this file outside of CMake, substitute the full
+-#  License text for the above reference.)
+-
+-include(CheckSymbolExists)
+-
+-macro(CHECK_CXX_SYMBOL_EXISTS SYMBOL FILES VARIABLE)
+-  _CHECK_SYMBOL_EXISTS("${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckSymbolExists.cxx" "${SYMBOL}" "${FILES}" "${VARIABLE}" )
+-endmacro()

--- a/sci-electronics/kicad/kicad-4.0.4-r1.ebuild
+++ b/sci-electronics/kicad/kicad-4.0.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,6 +10,7 @@ inherit cmake-utils eutils flag-o-matic gnome2-utils python-single-r1 wxwidgets 
 
 DESCRIPTION="Electronic Schematic and PCB design tools."
 HOMEPAGE="http://www.kicad-pcb.org"
+LIBCONTEXT_COMMIT="3d92a1a50f4749b5a92131a957c9615473be85b4"
 
 SERIES=$(get_version_component_range 1-2)
 
@@ -18,11 +19,12 @@ SRC_URI="https://launchpad.net/${PN}/${SERIES}/${PV}/+download/${P}.tar.xz
 		http://downloads.kicad-pcb.org/libraries/${PN}-footprints-${PV}.tar.gz
 		http://downloads.kicad-pcb.org/libraries/kicad-library-${PV}.tar.gz
 	)
-	i18n? ( https://github.com/KiCad/${PN}-i18n/archive/${PV}.tar.gz -> ${P}-i18n.tar.gz )"
+	i18n? ( https://github.com/KiCad/${PN}-i18n/archive/${PV}.tar.gz -> ${P}-i18n.tar.gz )
+	https://github.com/twlostow/libcontext/archive/${LIBCONTEXT_COMMIT}.tar.gz -> ${PN}-libcontext.tar.gz"
 
 LICENSE="GPL-2+ GPL-3+ Boost-1.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="debug doc examples github i18n libressl minimal +python"
 LANGS="bg ca cs de el es fi fr hu it ja ko nl pl pt ru sk sl sv zh-CN"
 for lang in ${LANGS} ; do
@@ -33,15 +35,15 @@ unset lang
 REQUIRED_USE="
 	python? ( ${PYTHON_REQUIRED_USE} )"
 
-COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
+COMMON_DEPEND="x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
 	python? (
 		dev-python/wxpython:${WX_GTK_VER}[opengl,${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
-	>=dev-libs/boost-1.61[context,nls,threads,python?,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.56[nls,threads,python?]
 	github? (
-		libressl? ( dev-libs/libressl:0= )
-		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0 )
+		!libressl? ( dev-libs/openssl:0 )
 	)
 	media-libs/glew:0=
 	media-libs/freeglut
@@ -56,24 +58,29 @@ RDEPEND="${COMMON_DEPEND}
 	sci-electronics/electronics-menu"
 
 pkg_setup() {
-	use python && python-single-r1_pkg_setup
-	setup-wxwidgets
+	python-single-r1_pkg_setup
 }
 
 src_prepare() {
 	xdg_src_prepare
+	cmake-utils_src_prepare
 
-	# Patch to work with >=boost 1.61
-	eapply "${FILESDIR}/${PN}-boost-1.61.patch"
+	# Add separated out libcontext files and patch source to use them
+	mkdir -p "${S}/common/system/" || die
+	mkdir -p "${S}/include/system/" || die
+	cp "${WORKDIR}/${PN}-libcontext/libcontext.cpp" "${S}/common/system/libcontext.cpp" || die
+	cp "${WORKDIR}/${PN}-libcontext/libcontext.h" "${S}/include/system/libcontext.h" || die
+	# Path source to use new "built in" libcontext. Also patch libcontext.cpp to have correct include file.
+	# Path must be applied after new libcontext files have been copied to the kicad source directory.
+	eapply "${FILESDIR}/${P}-boost-context.patch"
+	# Patch to work with >=cmake 3.11
+	eapply "${FILESDIR}/${PN}-cmake-checkcxxsymbolexists.patch"
 
-	# Remove cvpcb desktop file as it does nothing
-	rm "resources/linux/mime/applications/cvpcb.desktop" || die
+	# remove all the non unix file endings
+	edos2unix $(find "${S}" -type f -name "*.desktop")
 
-	# remove all the non unix file endings and fix application categories in desktop files
-	while IFS="" read -d $'\0' -r f; do
-		edos2unix "${f}"
-		sed -i '/Categories/s/Development;//' "${f}"
-	done < <(find "${S}" -type f -name "*.desktop" -print0)
+	# Remove cvpcb desktop file while it does nothing
+	rm "${WORKDIR}/${P}/resources/linux/mime/applications/cvpcb.desktop" || die
 
 	# Handle optional minimal install.
 	if use minimal; then
@@ -103,7 +110,7 @@ src_prepare() {
 		local lang
 		for lang in ${LANGS}; do
 			if ! use l10n_${lang}; then
-				lang="${lang//-/_}"  # Needed to turn zh-CN to zh_CN as KiCad does not follow l10n standard here
+				lang="${lang//-/_}"
 				sed "/${lang}/d" -i ${PN}-i18n/LINGUAS || die
 			fi
 		done
@@ -117,8 +124,14 @@ src_prepare() {
 		sed '/make uninstall/,$d' -i ${PN}-i18n/CMakeLists.txt || die
 	fi
 
-	# Install examples if requested
-	use examples || sed -e '/add_subdirectory( demos )/d' -i CMakeLists.txt || die
+	# Install examples in the right place if requested
+	if use examples; then
+		# install demos into the examples folder too
+		sed -e 's:${KICAD_DATA}/demos:${KICAD_DOCS}/examples:' -i CMakeLists.txt || die
+	else
+		# remove additional demos/examples as its not strictly required to run the binaries
+		sed -e '/add_subdirectory( demos )/d' -i CMakeLists.txt || die
+	fi
 
 	# Add important missing doc files
 	sed -e 's/INSTALL.txt/AUTHORS.txt CHANGELOG.txt README.txt TODO.txt/' -i CMakeLists.txt || die
@@ -126,22 +139,22 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DKICAD_DOCS="/usr/share/doc/${PF}"
-		-DKICAD_HELP="/usr/share/doc/${PF}/help"
-		-DwxUSE_UNICODE=ON
-		-DKICAD_SKIP_BOOST=ON
-		-DBUILD_GITHUB_PLUGIN="$(usex github)"
-		-DKICAD_SCRIPTING="$(usex python)"
-		-DKICAD_SCRIPTING_MODULES="$(usex python)"
-		-DKICAD_SCRIPTING_WXPYTHON="$(usex python)"
-		-DKICAD_I18N_UNIX_STRICT_PATH="$(usex i18n)"
-		-DCMAKE_CXX_FLAGS="-std=c++11"
-	)
-	use python && mycmakeargs+=(
 		-DPYTHON_DEST="$(python_get_sitedir)"
 		-DPYTHON_EXECUTABLE="${PYTHON}"
 		-DPYTHON_INCLUDE_DIR="$(python_get_includedir)"
 		-DPYTHON_LIBRARY="$(python_get_library_path)"
+		-DKICAD_DOCS="/usr/share/doc/${PF}"
+		-DKICAD_REPO_NAME="stable"
+		-DKICAD_BUILD_VERSION="${PV}"
+		-DKICAD_SKIP_BOOST=ON
+		-DBUILD_GITHUB_PLUGIN=$(usex github)
+		-DKICAD_SCRIPTING=$(usex python)
+		-DKICAD_SCRIPTING_MODULES=$(usex python)
+		-DKICAD_SCRIPTING_WXPYTHON=$(usex python)
+		$(usex i18n "-DKICAD_I18N_UNIX_STRICT_PATH=1" "")
+	)
+	use python && mycmakeargs+=(
+		-DwxUSE_UNICODE=ON
 	)
 	if use debug; then
 		append-cxxflags "-DDEBUG"
@@ -169,6 +182,7 @@ src_install() {
 
 pkg_preinst() {
 	xdg_pkg_preinst
+	gnome2_icon_savelist
 }
 
 pkg_postinst() {

--- a/sci-electronics/kicad/kicad-4.0.5-r2.ebuild
+++ b/sci-electronics/kicad/kicad-4.0.5-r2.ebuild
@@ -6,12 +6,13 @@ PYTHON_COMPAT=( python2_7 )
 
 WX_GTK_VER="3.0"
 
-inherit check-reqs cmake-utils flag-o-matic gnome2-utils python-single-r1 wxwidgets vcs-snapshot versionator xdg
-
-SERIES=$(get_version_component_range 1-2)
+inherit cmake-utils eutils flag-o-matic gnome2-utils python-single-r1 wxwidgets vcs-snapshot versionator xdg
 
 DESCRIPTION="Electronic Schematic and PCB design tools."
 HOMEPAGE="http://www.kicad-pcb.org"
+
+SERIES=$(get_version_component_range 1-2)
+
 SRC_URI="https://launchpad.net/${PN}/${SERIES}/${PV}/+download/${P}.tar.xz
 	!minimal? (
 		http://downloads.kicad-pcb.org/libraries/${PN}-footprints-${PV}.tar.gz
@@ -21,7 +22,7 @@ SRC_URI="https://launchpad.net/${PN}/${SERIES}/${PV}/+download/${P}.tar.xz
 
 LICENSE="GPL-2+ GPL-3+ Boost-1.0"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="debug doc examples github i18n libressl minimal +python"
 LANGS="bg ca cs de el es fi fr hu it ja ko nl pl pt ru sk sl sv zh-CN"
 for lang in ${LANGS} ; do
@@ -54,16 +55,9 @@ DEPEND="${COMMON_DEPEND}
 RDEPEND="${COMMON_DEPEND}
 	sci-electronics/electronics-menu"
 
-pkg_pretend() {
-	CHECKREQS_DISK_BUILD="8G"
-	check-reqs_pkg_pretend
-}
-
 pkg_setup() {
 	use python && python-single-r1_pkg_setup
 	setup-wxwidgets
-	CHECKREQS_DISK_BUILD="8G"
-	check-reqs_pkg_setup
 }
 
 src_prepare() {
@@ -72,9 +66,17 @@ src_prepare() {
 
 	# Patch to work with >=boost 1.61
 	eapply "${FILESDIR}/${PN}-boost-1.61.patch"
+	# Patch to work with >=cmake 3.11
+	eapply "${FILESDIR}/${PN}-cmake-checkcxxsymbolexists.patch"
 
 	# Remove cvpcb desktop file as it does nothing
 	rm "resources/linux/mime/applications/cvpcb.desktop" || die
+
+	# remove all the non unix file endings and fix application categories in desktop files
+	while IFS="" read -d $'\0' -r f; do
+		edos2unix "${f}"
+		sed -i '/Categories/s/Development;//' "${f}"
+	done < <(find "${S}" -type f -name "*.desktop" -print0)
 
 	# Handle optional minimal install.
 	if use minimal; then
@@ -128,8 +130,6 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DKICAD_DOCS="/usr/share/doc/${PF}"
-		-DKICAD_HELP="/usr/share/doc/${PF}/help"
-		-DwxUSE_UNICODE=ON
 		-DKICAD_SKIP_BOOST=ON
 		-DBUILD_GITHUB_PLUGIN="$(usex github)"
 		-DKICAD_SCRIPTING="$(usex python)"
@@ -139,6 +139,7 @@ src_configure() {
 		-DCMAKE_CXX_FLAGS="-std=c++11"
 	)
 	use python && mycmakeargs+=(
+		-DwxUSE_UNICODE=ON
 		-DPYTHON_DEST="$(python_get_sitedir)"
 		-DPYTHON_EXECUTABLE="${PYTHON}"
 		-DPYTHON_INCLUDE_DIR="$(python_get_includedir)"

--- a/sci-electronics/kicad/kicad-4.0.6-r1.ebuild
+++ b/sci-electronics/kicad/kicad-4.0.6-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 PYTHON_COMPAT=( python2_7 )
 
 WX_GTK_VER="3.0"
@@ -10,7 +10,6 @@ inherit cmake-utils eutils flag-o-matic gnome2-utils python-single-r1 wxwidgets 
 
 DESCRIPTION="Electronic Schematic and PCB design tools."
 HOMEPAGE="http://www.kicad-pcb.org"
-LIBCONTEXT_COMMIT="3d92a1a50f4749b5a92131a957c9615473be85b4"
 
 SERIES=$(get_version_component_range 1-2)
 
@@ -19,12 +18,11 @@ SRC_URI="https://launchpad.net/${PN}/${SERIES}/${PV}/+download/${P}.tar.xz
 		http://downloads.kicad-pcb.org/libraries/${PN}-footprints-${PV}.tar.gz
 		http://downloads.kicad-pcb.org/libraries/kicad-library-${PV}.tar.gz
 	)
-	i18n? ( https://github.com/KiCad/${PN}-i18n/archive/${PV}.tar.gz -> ${P}-i18n.tar.gz )
-	https://github.com/twlostow/libcontext/archive/${LIBCONTEXT_COMMIT}.tar.gz -> ${PN}-libcontext.tar.gz"
+	i18n? ( https://github.com/KiCad/${PN}-i18n/archive/${PV}.tar.gz -> ${P}-i18n.tar.gz )"
 
 LICENSE="GPL-2+ GPL-3+ Boost-1.0"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="debug doc examples github i18n libressl minimal +python"
 LANGS="bg ca cs de el es fi fr hu it ja ko nl pl pt ru sk sl sv zh-CN"
 for lang in ${LANGS} ; do
@@ -35,15 +33,15 @@ unset lang
 REQUIRED_USE="
 	python? ( ${PYTHON_REQUIRED_USE} )"
 
-COMMON_DEPEND="x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
+COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 	python? (
 		dev-python/wxpython:${WX_GTK_VER}[opengl,${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
-	>=dev-libs/boost-1.56[nls,threads,python?]
+	>=dev-libs/boost-1.61[context,nls,threads,python?,${PYTHON_USEDEP}]
 	github? (
-		libressl? ( dev-libs/libressl:0 )
-		!libressl? ( dev-libs/openssl:0 )
+		libressl? ( dev-libs/libressl:0= )
+		!libressl? ( dev-libs/openssl:0= )
 	)
 	media-libs/glew:0=
 	media-libs/freeglut
@@ -58,26 +56,27 @@ RDEPEND="${COMMON_DEPEND}
 	sci-electronics/electronics-menu"
 
 pkg_setup() {
-	python-single-r1_pkg_setup
+	use python && python-single-r1_pkg_setup
+	setup-wxwidgets
 }
 
 src_prepare() {
 	xdg_src_prepare
+	cmake-utils_src_prepare
 
-	# Add separated out libcontext files and patch source to use them
-	mkdir -p "${S}/common/system/" || die
-	mkdir -p "${S}/include/system/" || die
-	cp "${WORKDIR}/${PN}-libcontext/libcontext.cpp" "${S}/common/system/libcontext.cpp" || die
-	cp "${WORKDIR}/${PN}-libcontext/libcontext.h" "${S}/include/system/libcontext.h" || die
-	# Path source to use new "built in" libcontext. Also patch libcontext.cpp to have correct include file.
-	# Path must be applied after new libcontext files have been copied to the kicad source directory.
-	epatch "${FILESDIR}/${P}-boost-context.patch"
+	# Patch to work with >=boost 1.61
+	eapply "${FILESDIR}/${PN}-boost-1.61.patch"
+	# Patch to work with >=cmake 3.11
+	eapply "${FILESDIR}/${PN}-cmake-checkcxxsymbolexists.patch"
 
-	# remove all the non unix file endings
-	edos2unix $(find "${S}" -type f -name "*.desktop")
+	# Remove cvpcb desktop file as it does nothing
+	rm "resources/linux/mime/applications/cvpcb.desktop" || die
 
-	# Remove cvpcb desktop file while it does nothing
-	rm "${WORKDIR}/${P}/resources/linux/mime/applications/cvpcb.desktop" || die
+	# remove all the non unix file endings and fix application categories in desktop files
+	while IFS="" read -d $'\0' -r f; do
+		edos2unix "${f}"
+		sed -i '/Categories/s/Development;//' "${f}"
+	done < <(find "${S}" -type f -name "*.desktop" -print0)
 
 	# Handle optional minimal install.
 	if use minimal; then
@@ -107,7 +106,7 @@ src_prepare() {
 		local lang
 		for lang in ${LANGS}; do
 			if ! use l10n_${lang}; then
-				lang="${lang//-/_}"
+				lang="${lang//-/_}"  # Needed to turn zh-CN to zh_CN as KiCad does not follow l10n standard here
 				sed "/${lang}/d" -i ${PN}-i18n/LINGUAS || die
 			fi
 		done
@@ -121,14 +120,8 @@ src_prepare() {
 		sed '/make uninstall/,$d' -i ${PN}-i18n/CMakeLists.txt || die
 	fi
 
-	# Install examples in the right place if requested
-	if use examples; then
-		# install demos into the examples folder too
-		sed -e 's:${KICAD_DATA}/demos:${KICAD_DOCS}/examples:' -i CMakeLists.txt || die
-	else
-		# remove additional demos/examples as its not strictly required to run the binaries
-		sed -e '/add_subdirectory( demos )/d' -i CMakeLists.txt || die
-	fi
+	# Install examples if requested
+	use examples || sed -e '/add_subdirectory( demos )/d' -i CMakeLists.txt || die
 
 	# Add important missing doc files
 	sed -e 's/INSTALL.txt/AUTHORS.txt CHANGELOG.txt README.txt TODO.txt/' -i CMakeLists.txt || die
@@ -136,21 +129,21 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
+		-DKICAD_DOCS="/usr/share/doc/${PF}"
+		-DKICAD_SKIP_BOOST=ON
+		-DBUILD_GITHUB_PLUGIN="$(usex github)"
+		-DKICAD_SCRIPTING="$(usex python)"
+		-DKICAD_SCRIPTING_MODULES="$(usex python)"
+		-DKICAD_SCRIPTING_WXPYTHON="$(usex python)"
+		-DKICAD_I18N_UNIX_STRICT_PATH="$(usex i18n)"
+		-DCMAKE_CXX_FLAGS="-std=c++11"
+	)
+	use python && mycmakeargs+=(
+		-DwxUSE_UNICODE=ON
 		-DPYTHON_DEST="$(python_get_sitedir)"
 		-DPYTHON_EXECUTABLE="${PYTHON}"
 		-DPYTHON_INCLUDE_DIR="$(python_get_includedir)"
 		-DPYTHON_LIBRARY="$(python_get_library_path)"
-		-DKICAD_DOCS="/usr/share/doc/${PF}"
-		-DKICAD_HELP="/usr/share/doc/${PF}/help"
-		-DKICAD_REPO_NAME="stable"
-		-DKICAD_BUILD_VERSION="${PV}"
-		-DwxUSE_UNICODE=ON
-		-DKICAD_SKIP_BOOST=ON
-		$(cmake-utils_use github BUILD_GITHUB_PLUGIN)
-		$(cmake-utils_use python KICAD_SCRIPTING)
-		$(cmake-utils_use python KICAD_SCRIPTING_MODULES)
-		$(cmake-utils_use python KICAD_SCRIPTING_WXPYTHON)
-		$(usex i18n "-DKICAD_I18N_UNIX_STRICT_PATH=1" "")
 	)
 	if use debug; then
 		append-cxxflags "-DDEBUG"
@@ -178,7 +171,6 @@ src_install() {
 
 pkg_preinst() {
 	xdg_pkg_preinst
-	gnome2_icon_savelist
 }
 
 pkg_postinst() {


### PR DESCRIPTION
KiCad had a legacy redefinition of the CHECK_CXX_SYMBOL_EXISTS macro,
that is not needed since CMake-2.8.6. Upstream fix:
https://github.com/KiCad/kicad-source-mirror/commit/2e0b75c058d676f427328506bbf3bc10079da117
Also fixed src_configure() as well as moved kicad-4.0.4 to EAPI=6.

Closes: https://bugs.gentoo.org/652204
Closes: https://bugs.gentoo.org/652736

Package-Manager: Portage-2.3.28, Repoman-2.3.9