### PR TITLE
app-crypt/nitrokey-app: Fix resources build.

### DIFF
--- a/app-crypt/nitrokey-app/nitrokey-app-1.3.ebuild
+++ b/app-crypt/nitrokey-app/nitrokey-app-1.3.ebuild
@@ -36,6 +36,12 @@ DEPEND="
 	dev-qt/linguist-tools:5
 	virtual/pkgconfig"
 
+src_prepare(){
+	default
+	sed -i 's,^qt5_add_resources,# DISABLED qt5_add_resources,g' "${S}/CMakeLists.txt" || \
+		die "Unable to patch CMakeLists.txt"
+}
+
 pkg_postinst(){
 	gnome2_icon_cache_update
 }

--- a/app-crypt/nitrokey-app/nitrokey-app-9999.ebuild
+++ b/app-crypt/nitrokey-app/nitrokey-app-9999.ebuild
@@ -36,6 +36,12 @@ DEPEND="
 	dev-qt/linguist-tools:5
 	virtual/pkgconfig"
 
+src_prepare(){
+	default
+	sed -i 's,^qt5_add_resources,# DISABLED qt5_add_resources,g' "${S}/CMakeLists.txt" || \
+		die "Unable to patch CMakeLists.txt"
+}
+
 pkg_postinst(){
 	gnome2_icon_cache_update
 }


### PR DESCRIPTION
We need to remove qt5_add_resources() call from CMakeLists.txt becuase AUTORCC mode is enabled.
Keeping both flags doesn't permit (in some setup) to include the resources into the final executable producing the following log messages:

qt.svg: Cannot open file ':/images/new/icon_NK.svg', because: No such file or directory
qt.svg: Cannot open file ':/images/new/icon_NK.svg', because: No such file or directory
qt.svg: Cannot open file ':/images/new/icon_NK.svg', because: No such file or directory
qt.svg: Cannot open file ':/images/new/icon_NK.svg', because: No such file or directory
...

Also translations will not work because the translation files are included by means resources.

See also https://github.com/Nitrokey/nitrokey-app/pull/346

Bug: https://bugs.gentoo.org/653158
Closes: https://bugs.gentoo.org/653158