### PR TITLE
Fix app-vim/youcompleteme installation problem

### DIFF
--- a/app-vim/youcompleteme/youcompleteme-99999999.ebuild
+++ b/app-vim/youcompleteme/youcompleteme-99999999.ebuild
@@ -102,7 +102,7 @@ src_install() {
 	rm -r third_party/ycmd/{*.md,*.sh} || die
 	find python -name *test* -exec rm -rf {} + || die
 	egit_clean
-	rm third_party/ycmd/libclang.so || die
+	rm third_party/ycmd/libclang.so* || die
 
 	vim-plugin_src_install
 


### PR DESCRIPTION
Error:
```
rm: cannot remove 'third_party/ycmd/libclang.so': No such file or directory
 * ERROR: app-vim/youcompleteme-99999999::gentoo failed (install phase):
 *   (no error message)
 * 
 * Call stack:
 *     ebuild.sh, line 124:  Called src_install
 *   environment, line 4440:  Called die
 * The specific snippet of code:
 *       rm third_party/ycmd/libclang.so || die;
```

Actually:
```
$ ls third_party/ycmd
...
libclang.so.5
libclang.so.5.0
```