### PR TITLE
dev-util/strace-4.22: Fix static build

### DIFF
--- a/dev-util/strace/strace-4.22.ebuild
+++ b/dev-util/strace/strace-4.22.ebuild
@@ -45,7 +45,7 @@ src_prepare() {
 	fi
 
 	filter-lfs-flags # configure handles this sanely
-	use static && append-ldflags -static
+	use static && append-ldflags -static -pthread
 
 	export ac_cv_header_libaio_h=$(usex aio)
 	use elibc_musl && export ac_cv_header_stdc=no


### PR DESCRIPTION
dev-util/strace-4.22: Fix static build

Closes: https://bugs.gentoo.org/653292
Package-Manager: Portage-2.3.24, Repoman-2.3.6