### PR TITLE
media-video/openshot: add dev-python/requests to RDEPEND

### DIFF
--- a/media-video/openshot/openshot-2.4.0-r1.ebuild
+++ b/media-video/openshot/openshot-2.4.0-r1.ebuild
@@ -13,7 +13,7 @@ MY_PN="${PN}-qt"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Free, open-source, non-linear video editor to create and edit videos and movies"
-HOMEPAGE="http://www.openshot.org/ https://launchpad.net/openshot"
+HOMEPAGE="https://www.openshot.org/ https://launchpad.net/openshot"
 SRC_URI="https://launchpad.net/${PN}/$(get_version_component_range 1-2)/${PV}/+download/${MY_P}.tar.gz"
 
 LICENSE="GPL-3+"
@@ -21,10 +21,11 @@ SLOT="1"
 KEYWORDS="amd64 x86"
 
 RDEPEND="
-	dev-python/PyQt5[svg,webkit,${PYTHON_USEDEP}]
-	>=media-libs/libopenshot-0.1.8[python,${PYTHON_USEDEP}]
 	dev-python/httplib2[${PYTHON_USEDEP}]
+	dev-python/PyQt5[${PYTHON_USEDEP},svg,webkit]
 	dev-python/pyzmq[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	>=media-libs/libopenshot-0.1.8[python,${PYTHON_USEDEP}]
 "
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]


### PR DESCRIPTION
- added dev-python/requests to RDEPEND
- added https:// to HOMEPAGE
- added ~ keywords and made a revbump
- sorted deps alphabetically

Fast fix for a bug. Repomanned and emerged succesfully. 

```diff
--- openshot-2.4.0.ebuild	2018-04-05 09:45:31.044726504 +0300
+++ openshot-2.4.0-r1.ebuild	2018-04-18 10:23:55.522500517 +0300
@@ -13,20 +13,22 @@
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Free, open-source, non-linear video editor to create and edit videos and movies"
-HOMEPAGE="http://www.openshot.org/ https://launchpad.net/openshot"
+HOMEPAGE="https://www.openshot.org/ https://launchpad.net/openshot"
 SRC_URI="https://launchpad.net/${PN}/$(get_version_component_range 1-2)/${PV}/+download/${MY_P}.tar.gz"
 
 LICENSE="GPL-3+"
 SLOT="1"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
-	dev-python/PyQt5[svg,webkit,${PYTHON_USEDEP}]
-	>=media-libs/libopenshot-0.1.8[python,${PYTHON_USEDEP}]
 	dev-python/httplib2[${PYTHON_USEDEP}]
+	dev-python/PyQt5[${PYTHON_USEDEP},svg,webkit]
 	dev-python/pyzmq[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	>=media-libs/libopenshot-0.1.8[python,${PYTHON_USEDEP}]
 "
 DEPEND="
+	${PYTHON_DEPS}
 	dev-python/setuptools[${PYTHON_USEDEP}]
 "
```

Closes: https://bugs.gentoo.org/637448
Package-Manager: Portage[mgorny]-2.3.26.1