### PR TITLE
app-arch/libarchive: compatibility patch update for LibreSSL

### DIFF
--- a/app-arch/libarchive/files/libarchive-3.3.1-libressl.patch
+++ b/app-arch/libarchive/files/libarchive-3.3.1-libressl.patch
@@ -1,22 +1,25 @@
---- a/libarchive/archive_openssl_evp_private.h
-+++ b/libarchive/archive_openssl_evp_private.h
-@@ -28,7 +28,7 @@
+--- a/libarchive/archive_openssl_evp_private.h       2017-01-29 05:06:27.000000000 +0000
++++ b/libarchive/archive_openssl_evp_private.h   2018-04-19 04:00:14.061922747 +0000
+@@ -28,7 +28,8 @@
  #include <openssl/evp.h>
  #include <openssl/opensslv.h>
- 
+
 -#if OPENSSL_VERSION_NUMBER < 0x10100000L
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
++(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
  #include <stdlib.h> /* malloc, free */
  #include <string.h> /* memset */
  static inline EVP_MD_CTX *EVP_MD_CTX_new(void)
---- a/libarchive/archive_openssl_hmac_private.h
-+++ b/libarchive/archive_openssl_hmac_private.h
-@@ -28,7 +28,7 @@
+
+--- a/libarchive/archive_openssl_hmac_private.h	2017-01-29 05:06:27.000000000 +0000
++++ b/libarchive/archive_openssl_hmac_private.h	2018-04-19 04:02:18.309167446 +0000
+@@ -28,7 +28,8 @@
  #include <openssl/hmac.h>
  #include <openssl/opensslv.h>
  
 -#if OPENSSL_VERSION_NUMBER < 0x10100000L
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
++(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
  #include <stdlib.h> /* malloc, free */
  #include <string.h> /* memset */
  static inline HMAC_CTX *HMAC_CTX_new(void)


### PR DESCRIPTION
This updates the LibreSSL patch to fix building with
dev-libs/libressl-2.7.x. This is a build fix so do not rev bump.

Package-Manager: Portage-2.3.29, Repoman-2.3.9