### PR TITLE
dev-perl/Crypt-OpenSSL-RSA: compatibility patch for LibreSSL

### DIFF
--- a/dev-perl/Crypt-OpenSSL-RSA/files/Crypt-OpenSSL-RSA-0.280.0-openssl-1.1.0.patch
+++ b/dev-perl/Crypt-OpenSSL-RSA/files/Crypt-OpenSSL-RSA-0.280.0-openssl-1.1.0.patch
@@ -20,8 +20,8 @@ index de512e7822d0..b384cb0e23a2 100644
  
  #define THROW(p_result) if (!(p_result)) { error = 1; goto err; }
  
-+#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
-+
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 +static void RSA_get0_key(const RSA *r,
 +                         const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
 +{


### PR DESCRIPTION
This patch was pulled from upstream to adjust version checks to fix
compatibiity with the OpenSSL and LibreSSL 1.1 API implementations.

Closes: https://bugs.gentoo.org/651170
Package-Manager: Portage-2.3.31, Repoman-2.3.9