### PR TITLE
media-sound/teamspeak-server-bin: Group should be also created

### DIFF
--- a/media-sound/teamspeak-server-bin/teamspeak-server-bin-3.1.1.ebuild
+++ b/media-sound/teamspeak-server-bin/teamspeak-server-bin-3.1.1.ebuild
@@ -24,8 +24,12 @@ RESTRICT="mirror strip"
 
 S="${WORKDIR}/teamspeak3-server_linux"
 
+QA_PREBUILT="opt/teamspeak3-server/libts3db_sqlite3.so
+		opt/teamspeak3-server/ts3server"
+
 pkg_setup() {
-	enewuser teamspeak
+	enewgroup teamspeak
+	enewuser teamspeak -1 -1 /opt/teamspeak3-server teamspeak
 }
 
 src_unpack() {


### PR DESCRIPTION
@mgorny: Sorry, but I was a little bit to slow, as you have already merged my other PR. I think, it should make sense, to specify the group and add a home directory (It isn't needed strictly) for the user. I didn't make -r1, as it was new merged. I also added the QA_PREBUILT.

Closes: https://bugs.gentoo.org/653600
Package-Manager: Portage-2.3.30, Repoman-2.3.9