### PR TITLE
app-crypt/efitools: Use dev-perl/File-Slurp

### DIFF
--- a/app-crypt/efitools/efitools-1.8.1.ebuild
+++ b/app-crypt/efitools/efitools-1.8.1.ebuild
@@ -20,7 +20,7 @@ RDEPEND="!libressl? ( dev-libs/openssl:0= )
 
 DEPEND="${RDEPEND}
 	app-crypt/sbsigntool
-	dev-perl/File-Slurp-Unicode
+	dev-perl/File-Slurp
 	sys-apps/help2man
 	sys-boot/gnu-efi
 	virtual/pkgconfig"

--- a/app-crypt/efitools/metadata.xml
+++ b/app-crypt/efitools/metadata.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<!-- maintainer-needed -->
 </pkgmetadata>


### PR DESCRIPTION
app-crypt/efitools: Use dev-perl/File-Slurp instead of dev-perl/File-Slurp-Unicode, as it will be removed from portage, but dev-perl/File-Slurp works fine with app-crypt/efitools.

@mgorny: This will fix the test warning about ~arm64. Could you merge it? Thanks.

Package-Manager: Portage-2.3.30, Repoman-2.3.9