### PR TITLE
blueness@g.o: epatch->eapply for EAPI 6

### DIFF
--- a/app-admin/paxtest/files/paxtest-0.9.13-Makefile.patch
+++ b/app-admin/paxtest/files/paxtest-0.9.13-Makefile.patch
@@ -1,6 +1,5 @@
-diff -Naur paxtest-0.9.13.orig/Makefile paxtest-0.9.13/Makefile
---- paxtest-0.9.13.orig/Makefile	2014-12-09 19:53:48.000000000 -0500
-+++ paxtest-0.9.13/Makefile	2014-12-12 13:07:55.715099100 -0500
+--- a/Makefile
++++ b/Makefile
 @@ -52,12 +52,14 @@
  endif
  

--- a/app-admin/paxtest/paxtest-0.9.15-r1.ebuild
+++ b/app-admin/paxtest/paxtest-0.9.15-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
-inherit eutils multilib toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="PaX regression test suite"
 HOMEPAGE="https://pax.grsecurity.net"
@@ -21,12 +21,15 @@ DEPEND="${RDEPEND}
 # EI_PAX flags are not strip safe.
 RESTRICT="strip"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-0.9.13-Makefile.patch"
+)
+
 src_prepare() {
 	mv Makefile.psm Makefile
-	epatch "${FILESDIR}/${PN}-0.9.13-Makefile.patch"
+	default
 	sed -i "s/^CC := gcc/CC := $(tc-getCC)/" Makefile
 	sed -i "s/^LD := ld/LD := $(tc-getLD)/" Makefile
-	eapply_user
 }
 
 src_compile() {

--- a/dev-libs/libcgroup/libcgroup-0.41-r4.ebuild
+++ b/dev-libs/libcgroup/libcgroup-0.41-r4.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
-inherit autotools eutils flag-o-matic linux-info pam
+inherit autotools flag-o-matic linux-info pam
 
 DESCRIPTION="Tools and libraries to configure and manage kernel control groups"
 HOMEPAGE="http://libcg.sourceforge.net/"
@@ -33,11 +33,14 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
-src_prepare() {
-	epatch "${FILESDIR}"/${P}-replace_DECLS.patch
-	epatch "${FILESDIR}"/${P}-replace_INLCUDES.patch
-	epatch "${FILESDIR}"/${P}-reorder-headers.patch
+PATCHES=(
+	"${FILESDIR}"/${P}-replace_DECLS.patch
+	"${FILESDIR}"/${P}-replace_INLCUDES.patch
+	"${FILESDIR}"/${P}-reorder-headers.patch
+)
 
+src_prepare() {
+	default
 	# Change rules file location
 	sed -e 's:/etc/cgrules.conf:/etc/cgroup/cgrules.conf:' \
 		-i src/libcgroup-internal.h || die "sed failed"
@@ -47,7 +50,6 @@ src_prepare() {
 		-i src/pam/Makefile.am || die "sed failed"
 	sed -e 's#/var/run#/run#g' -i configure.in || die "sed failed"
 
-	eapply_user
 	eautoreconf
 }
 

--- a/dev-util/elfkickers/elfkickers-3.1.ebuild
+++ b/dev-util/elfkickers/elfkickers-3.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 MY_PN=${PN/elf/ELF}-${PV}
 S=${WORKDIR}/${MY_PN}
@@ -20,13 +20,16 @@ IUSE="doc"
 DEPEND="app-misc/pax-utils"
 RDEPEND=""
 
+PATCHES=(
+	"${FILESDIR}"/${P}-respect-CFLAGS-LDFLAGS.patch
+	"${FILESDIR}"/${P}-create-destdir-path.patch
+	"${FILESDIR}"/add-freebsd-elf-defs.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/${P}-respect-CFLAGS-LDFLAGS.patch
-	epatch "${FILESDIR}"/${P}-create-destdir-path.patch
-	epatch "${FILESDIR}"/add-freebsd-elf-defs.patch
+	default
 	sed -i -e "s:^prefix = /usr/local:prefix = ${D}:" Makefile \
 		|| die "sed failed"
-	eapply_user
 }
 
 src_compile() {

--- a/net-vpn/tinc/tinc-1.1_pre15.ebuild
+++ b/net-vpn/tinc/tinc-1.1_pre15.ebuild
@@ -1,14 +1,14 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
 MY_PV=${PV/_/}
 MY_P=${PN}-${MY_PV}
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit autotools multilib python-single-r1 systemd
+inherit autotools python-single-r1 systemd
 
 DESCRIPTION="tinc is an easy to configure VPN implementation"
 HOMEPAGE="http://www.tinc-vpn.org/"
@@ -43,20 +43,18 @@ RDEPEND="${DEPEND}
 	vde? ( net-misc/vde )"
 S="${WORKDIR}/${MY_P}"
 
+# Upstream's patchset
+if [[ -n ${UPSTREAM_VER} ]]; then
+	PATCHES=( "${WORKDIR}"/patches-upstream )
+fi
+
+PATCHES+=(
+	"${FILESDIR}"/${PN}-1.1-fix-paths.patch #560528
+	"${FILESDIR}"/${PN}-1.1-tinfo.patch #621868
+)
+
 src_prepare() {
-	# Upstream's patchset
-	if [[ -n ${UPSTREAM_VER} ]]; then
-		einfo "Try to apply Tinc Upstream patch set"
-		EPATCH_SUFFIX="patch" \
-		EPATCH_FORCE="yes" \
-		EPATCH_OPTS="-p1" \
-			epatch "${WORKDIR}"/patches-upstream
-	fi
-
-	eapply "${FILESDIR}"/tinc-1.1-fix-paths.patch #560528
-	eapply "${FILESDIR}"/${PN}-1.1-tinfo.patch #621868
-	eapply_user
-
+	default
 	eautoreconf
 }
 

--- a/sys-apps/agedu/agedu-20170831.ebuild
+++ b/sys-apps/agedu/agedu-20170831.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
-inherit autotools eutils
+inherit autotools
 
 # agedu-20151213.59b0ed3.ebuild is not a legitimate name
 # so we'll drop versionator and just set MY_P manually.
@@ -21,9 +21,12 @@ IUSE="doc ipv6"
 
 DEPEND="doc? ( app-doc/halibut )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-r9671-fix-automagic.patch"
+)
+
 src_prepare() {
-	epatch "${FILESDIR}/${PN}-r9671-fix-automagic.patch"
-	eapply_user
+	default
 	eautoreconf
 }
 

--- a/sys-apps/agedu/agedu-20171202.ebuild
+++ b/sys-apps/agedu/agedu-20171202.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
-inherit autotools eutils
+inherit autotools
 
 # agedu-20151213.59b0ed3.ebuild is not a legitimate name
 # so we'll drop versionator and just set MY_P manually.
@@ -21,9 +21,12 @@ IUSE="doc ipv6"
 
 DEPEND="doc? ( app-doc/halibut )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-r9671-fix-automagic.patch"
+)
+
 src_prepare() {
-	epatch "${FILESDIR}/${PN}-r9671-fix-automagic.patch"
-	eapply_user
+	default
 	eautoreconf
 }
 

--- a/sys-apps/agedu/agedu-20180302.ebuild
+++ b/sys-apps/agedu/agedu-20180302.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
-inherit autotools eutils
+inherit autotools
 
 # agedu-20151213.59b0ed3.ebuild is not a legitimate name
 # so we'll drop versionator and just set MY_P manually.
@@ -21,9 +21,12 @@ IUSE="doc ipv6"
 
 DEPEND="doc? ( app-doc/halibut )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-r9671-fix-automagic.patch"
+)
+
 src_prepare() {
-	epatch "${FILESDIR}/${PN}-r9671-fix-automagic.patch"
-	eapply_user
+	default
 	eautoreconf
 }
 

--- a/sys-apps/agedu/agedu-20180329.ebuild
+++ b/sys-apps/agedu/agedu-20180329.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=6
 
 inherit autotools eutils
 
@@ -21,9 +21,12 @@ IUSE="doc ipv6"
 
 DEPEND="doc? ( app-doc/halibut )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-r9671-fix-automagic.patch"
+)
+
 src_prepare() {
-	epatch "${FILESDIR}/${PN}-r9671-fix-automagic.patch"
-	eapply_user
+	default
 	eautoreconf
 }
 

--- a/sys-apps/agedu/files/agedu-r9671-fix-automagic.patch
+++ b/sys-apps/agedu/files/agedu-r9671-fix-automagic.patch
@@ -1,6 +1,5 @@
-diff -Naur agedu-r9671.orig/configure.ac agedu-r9671/configure.ac
---- agedu-r9671.orig/configure.ac	2012-10-20 21:20:47.000000000 -0400
-+++ agedu-r9671/configure.ac	2012-10-21 15:13:08.000000000 -0400
+--- a/configure.ac
++++ b/configure.ac
 @@ -10,8 +10,6 @@
  AC_PROG_CC
  AC_PROG_CC_C99

--- a/sys-apps/gradm/files/respect-gentoo-env-r3.patch
+++ b/sys-apps/gradm/files/respect-gentoo-env-r3.patch
@@ -1,6 +1,5 @@
-diff -Naur gradm2.orig/Makefile gradm2/Makefile
---- gradm2.orig/Makefile	2013-08-09 16:28:37.000000000 -0400
-+++ gradm2/Makefile	2013-08-10 07:57:12.000000000 -0400
+--- a/Makefile
++++ b/Makefile
 @@ -18,18 +18,18 @@
  BISON=/usr/bin/bison
  #YACC := $(shell if [ -x $(BYACC) ]; then echo $(BYACC); else echo $(BISON); fi)

--- a/sys-apps/gradm/gradm-3.1.201603152148.ebuild
+++ b/sys-apps/gradm/gradm-3.1.201603152148.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
-inherit flag-o-matic toolchain-funcs versionator eutils udev
+EAPI=6
+inherit flag-o-matic toolchain-funcs udev versionator
 
 MY_PV="$(replace_version_separator 2 -)"
 
@@ -23,10 +23,13 @@ DEPEND="
 
 S=${WORKDIR}/${PN}
 
+PATCHES=(
+	"${FILESDIR}"/respect-gentoo-env-r3.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/respect-gentoo-env-r3.patch
+	default
 	sed -i -e "s:/lib/udev:$(get_udevdir):" Makefile || die
-	eapply_user
 }
 
 src_compile() {

--- a/sys-apps/gradm/gradm-3.1.201607172312.ebuild
+++ b/sys-apps/gradm/gradm-3.1.201607172312.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
-inherit flag-o-matic toolchain-funcs versionator eutils udev
+EAPI=6
+inherit flag-o-matic toolchain-funcs udev versionator
 
 MY_PV="$(replace_version_separator 2 -)"
 
@@ -23,10 +23,13 @@ DEPEND="
 
 S=${WORKDIR}/${PN}
 
+PATCHES=(
+	"${FILESDIR}"/respect-gentoo-env-r3.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/respect-gentoo-env-r3.patch
+	default
 	sed -i -e "s:/lib/udev:$(get_udevdir):" Makefile || die
-	eapply_user
 }
 
 src_compile() {

--- a/sys-apps/gradm/gradm-3.1.201608131257.ebuild
+++ b/sys-apps/gradm/gradm-3.1.201608131257.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
-inherit flag-o-matic toolchain-funcs versionator eutils udev
+EAPI=6
+inherit flag-o-matic toolchain-funcs udev versionator
 
 MY_PV="$(replace_version_separator 2 -)"
 
@@ -23,10 +23,13 @@ DEPEND="
 
 S=${WORKDIR}/${PN}
 
+PATCHES=(
+	"${FILESDIR}"/respect-gentoo-env-r3.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/respect-gentoo-env-r3.patch
+	default
 	sed -i -e "s:/lib/udev:$(get_udevdir):" Makefile || die
-	eapply_user
 }
 
 src_compile() {

--- a/sys-apps/gradm/gradm-3.1.201708012022.ebuild
+++ b/sys-apps/gradm/gradm-3.1.201708012022.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
-inherit flag-o-matic toolchain-funcs versionator eutils udev
+EAPI=6
+inherit flag-o-matic toolchain-funcs udev versionator
 
 MY_PV="$(replace_version_separator 2 -)"
 
@@ -23,10 +23,13 @@ DEPEND="
 
 S=${WORKDIR}/${PN}
 
+PATCHES=(
+	"${FILESDIR}"/respect-gentoo-env-r3.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/respect-gentoo-env-r3.patch
+	default
 	sed -i -e "s:/lib/udev:$(get_udevdir):" Makefile || die
-	eapply_user
 }
 
 src_compile() {


### PR DESCRIPTION
Pretty straightforward. Dropped unneeded eutils and multilib eclasses where apropos,
and as a note tinc-1.1_pre15 could not work as-is due to epatch not being available in
an ebuild without the use of epatch.eclass, directly or indirectly, if you had set the
`UPSTREAM_VER` variable in a later iteration of the ebuild.