### PR TITLE
games-misc/katawa-shoujo, media-gfx/pngquant: use HTTPS

### DIFF
--- a/games-misc/katawa-shoujo/katawa-shoujo-1.3.1-r1.ebuild
+++ b/games-misc/katawa-shoujo/katawa-shoujo-1.3.1-r1.ebuild
@@ -5,8 +5,8 @@ EAPI=6
 inherit eutils gnome2-utils
 
 DESCRIPTION="Bishoujo-style visual novel by Four Leaf Studios"
-HOMEPAGE="http://katawa-shoujo.com/"
-SRC_URI="http://dl.katawa-shoujo.com/gold_1.3.1/%5B4ls%5D_katawa_shoujo_1.3.1-%5Blinux-x86%5D%5B18161880%5D.tar.bz2 -> ${P}.tar.bz2
+HOMEPAGE="https://www.katawa-shoujo.com"
+SRC_URI="https://dl.katawa-shoujo.com/gold_1.3.1/%5B4ls%5D_katawa_shoujo_1.3.1-%5Blinux-x86%5D%5B18161880%5D.tar.bz2 -> ${P}.tar.bz2
 	https://dev.gentoo.org/~hasufell/distfiles/katawa-shoujo-48.png
 	https://dev.gentoo.org/~hasufell/distfiles/katawa-shoujo-256.png"
 

--- a/media-gfx/pngquant/pngquant-2.11.4.ebuild
+++ b/media-gfx/pngquant/pngquant-2.11.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="command-line utility and library for lossy compression of PNG images"
-HOMEPAGE="http://pngquant.org/"
-SRC_URI="http://pngquant.org/${P}-src.tar.gz"
+HOMEPAGE="https://pngquant.org/"
+SRC_URI="https://pngquant.org/${P}-src.tar.gz"
 
 LICENSE="GPL-3 HPND rwpng"
 SLOT="0"

--- a/media-gfx/pngquant/pngquant-2.11.7.ebuild
+++ b/media-gfx/pngquant/pngquant-2.11.7.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="command-line utility and library for lossy compression of PNG images"
-HOMEPAGE="http://pngquant.org/"
-SRC_URI="http://pngquant.org/${P}-src.tar.gz"
+HOMEPAGE="https://pngquant.org/"
+SRC_URI="https://pngquant.org/${P}-src.tar.gz"
 
 LICENSE="GPL-3 HPND rwpng"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes two packages to use HTTPS instead of http.

Please review.