### PR TITLE
sys-devel/clang-runtime: bump SLOT to 6.0.1

### DIFF
--- a/sys-devel/clang-runtime/clang-runtime-6.0.9999.ebuild
+++ b/sys-devel/clang-runtime/clang-runtime-6.0.9999.ebuild
@@ -11,7 +11,7 @@ SRC_URI=""
 
 LICENSE="metapackage"
 # Note: keep it matching clang-9999 version
-SLOT="6.0.0"
+SLOT="6.0.1"
 KEYWORDS=""
 IUSE="+compiler-rt crt libcxx openmp +sanitize"
 


### PR DESCRIPTION
Sorry, I totally forgot about this when I was pushing #7979