### PR TITLE
 sci-geosciencies/qgis: Fixing USE=-python building (bug #653712)

### DIFF
--- a/sci-geosciences/qgis/qgis-3.0.1-r1.ebuild
+++ b/sci-geosciences/qgis/qgis-3.0.1-r1.ebuild
@@ -99,7 +99,10 @@ RESTRICT="test"
 PATCHES=(
 	# git master
 	"${FILESDIR}/${PN}-2.18.12-cmake-lib-suffix.patch"
+	# release-3_0 branch
+	"${FILESDIR}/${P}-check-constraints.patch"
 	# TODO upstream
+	"${FILESDIR}/${P}-qt-5.11.patch"
 	"${FILESDIR}/${PN}-3.0.0-featuresummary.patch"
 )
 

--- a/sci-geosciences/qgis/qgis-3.0.1-r1.ebuild
+++ b/sci-geosciences/qgis/qgis-3.0.1-r1.ebuild
@@ -27,6 +27,7 @@ IUSE="3d examples georeferencer grass mapserver oracle polar postgres python web
 
 REQUIRED_USE="
 	mapserver? ( python )
+	grass? ( python )
 	python? ( ${PYTHON_REQUIRED_USE} )"
 
 COMMON_DEPEND="

--- a/sci-geosciences/qgis/qgis-9999.ebuild
+++ b/sci-geosciences/qgis/qgis-9999.ebuild
@@ -27,6 +27,7 @@ IUSE="3d examples georeferencer grass mapserver oracle polar postgres python web
 
 REQUIRED_USE="
 	mapserver? ( python )
+	grass? ( python )
 	python? ( ${PYTHON_REQUIRED_USE} )"
 
 COMMON_DEPEND="


### PR DESCRIPTION
I might have screwed the git flow, but in the end this 2 files are the only ones that need to be touched by this PL.
This closes https://bugs.gentoo.org/show_bug.cgi?id=653712 as far as I am concerned (and I am the reporter).

For something like this, is the right way to bump the revision of the ebuild, or just patch directly? (advice for my future contributions)