### PR TITLE
x11-*/*: maint-needed EAPI bumps

### DIFF
--- a/x11-libs/fox-wrapper/fox-wrapper-2.ebuild
+++ b/x11-libs/fox-wrapper/fox-wrapper-2.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 DESCRIPTION="wrapper for fox-config to manage multiple versions"
 HOMEPAGE="https://www.gentoo.org/"

--- a/x11-libs/fox-wrapper/fox-wrapper-3.ebuild
+++ b/x11-libs/fox-wrapper/fox-wrapper-3.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 DESCRIPTION="wrapper for fox-config to manage multiple versions"
 HOMEPAGE="https://www.gentoo.org/"

--- a/x11-misc/e16keyedit/e16keyedit-0.7.ebuild
+++ b/x11-misc/e16keyedit/e16keyedit-0.7.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 DESCRIPTION="Key binding editor for enlightenment 16"
 HOMEPAGE="https://www.enlightenment.org/"
@@ -14,12 +16,6 @@ RDEPEND="=x11-libs/gtk+-2*"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
-src_compile() {
-	econf --enable-gtk2 || die
-	emake || die
-}
-
-src_install() {
-	emake install DESTDIR="${D}" || die
-	dodoc README ChangeLog AUTHORS
+src_configure() {
+	econf --enable-gtk2
 }

--- a/x11-plugins/gkrellm-plugins/gkrellm-plugins-2.0.ebuild
+++ b/x11-plugins/gkrellm-plugins/gkrellm-plugins-2.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 DESCRIPTION="emerge this package to install all of the gkrellm plugins"
 HOMEPAGE="http://www.gkrellm.net/"
@@ -10,18 +12,19 @@ KEYWORDS="~ppc ~x86"
 IUSE="wifi"
 
 RDEPEND="!<app-admin/gkrellm-2
-		>=x11-plugins/gkrellaclock-0.3.2
-		x11-plugins/gkrellflynn
-		>=x11-plugins/gkrellkam-2.0.0
-		>=x11-plugins/gkrellm-leds-0.8.0
-		>=x11-plugins/gkrellm-volume-2.1.4
-		>=x11-plugins/gkrellmlaunch-0.5
-		>=x11-plugins/gkrellmoon-0.6
-		wifi? ( >=x11-plugins/gkrellmwireless-2.0.2 )
-		>=x11-plugins/gkrellshoot-0.4.1
-		>=x11-plugins/gkrellstock-0.5
-		>=x11-plugins/gkrellsun-0.12.2
-		x11-plugins/gkrelltop
-		>=x11-plugins/gkrellweather-2.0.6
-		x11-plugins/gkrellm-countdown
-		x11-plugins/gkrellm-trayicons"
+	>=x11-plugins/gkrellaclock-0.3.2
+	x11-plugins/gkrellflynn
+	>=x11-plugins/gkrellkam-2.0.0
+	>=x11-plugins/gkrellm-leds-0.8.0
+	>=x11-plugins/gkrellm-volume-2.1.4
+	>=x11-plugins/gkrellmlaunch-0.5
+	>=x11-plugins/gkrellmoon-0.6
+	wifi? ( >=x11-plugins/gkrellmwireless-2.0.2 )
+	>=x11-plugins/gkrellshoot-0.4.1
+	>=x11-plugins/gkrellstock-0.5
+	>=x11-plugins/gkrellsun-0.12.2
+	x11-plugins/gkrelltop
+	>=x11-plugins/gkrellweather-2.0.6
+	x11-plugins/gkrellm-countdown
+	x11-plugins/gkrellm-trayicons
+"

--- a/x11-themes/commonbox-styles-extra/commonbox-styles-extra-0.2-r2.ebuild
+++ b/x11-themes/commonbox-styles-extra/commonbox-styles-extra-0.2-r2.ebuild
@@ -1,27 +1,28 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-IUSE=""
-DESCRIPTION="Extra styles pack for flux|black|open(box)"
-SRC_URI="mirror://gentoo/${P}.tar.bz2
-		http://mkeadle.org/distfiles/${P}.tar.bz2"
-HOMEPAGE="http://mkeadle.org/"
+EAPI=6
 
-SLOT="0"
+DESCRIPTION="Extra styles pack for flux|black|open(box)"
+HOMEPAGE="http://mkeadle.org/"
+SRC_URI="mirror://gentoo/${P}.tar.bz2
+	http://mkeadle.org/distfiles/${P}.tar.bz2"
+
 LICENSE="GPL-2"
+SLOT="0"
 KEYWORDS="alpha amd64 ~hppa ia64 ppc ppc64 sparc x86 ~x86-fbsd"
+IUSE=""
 
 # xv is there so *box can convert backgrounds/textures to use
-DEPEND=""
 RDEPEND="media-gfx/xv
-		|| ( x11-wm/fluxbox x11-wm/blackbox x11-wm/openbox )"
+	|| ( x11-wm/fluxbox x11-wm/blackbox x11-wm/openbox )"
 
 src_install () {
 	insinto /usr/share/commonbox/styles
-	doins "${S}"/styles/*
+	doins -r styles/.
 
 	insinto /usr/share/commonbox/backgrounds
-	doins "${S}"/backgrounds/*
+	doins -r backgrounds/.
 
 	dodoc README.commonbox-styles-extra
 }

--- a/x11-themes/commonbox-styles/commonbox-styles-0.6.ebuild
+++ b/x11-themes/commonbox-styles/commonbox-styles-0.6.ebuild
@@ -1,15 +1,17 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-IUSE=""
+EAPI=6
+
 DESCRIPTION="Common styles for fluxbox, blackbox, and openbox"
+HOMEPAGE="http://mkeadle.org/distfiles/"
 SRC_URI="mirror://gentoo/${P}.tar.bz2
 		http://mkeadle.org/distfiles/${P}.tar.bz2"
-HOMEPAGE="http://mkeadle.org/distfiles/"
 
-SLOT="0"
 LICENSE="GPL-2"
+SLOT="0"
 KEYWORDS="alpha amd64 hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
+IUSE=""
 
 RDEPEND="|| ( x11-wm/fluxbox x11-wm/blackbox x11-wm/openbox )"
 

--- a/x11-themes/ethemes/ethemes-0.16.8.0.3.ebuild
+++ b/x11-themes/ethemes/ethemes-0.16.8.0.3.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 MY_P="e16-themes-${PV}"
 DESCRIPTION="all the official Enlightenment themes"
@@ -16,9 +18,4 @@ RDEPEND="!x11-themes/etheme-BlueSteel
 	!x11-themes/etheme-Ganymede
 	!x11-themes/etheme-ShinyMetal"
 
-S=${WORKDIR}/${MY_P}
-
-src_install() {
-	emake install DESTDIR="${D}" || die
-	dodoc AUTHORS ChangeLog
-}
+S="${WORKDIR}/${MY_P}"

--- a/x11-themes/ethemes/ethemes-1.0.0.ebuild
+++ b/x11-themes/ethemes/ethemes-1.0.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2009 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 MY_P="e16-themes-${PV}"
 DESCRIPTION="all the official Enlightenment themes"
@@ -16,9 +18,4 @@ RDEPEND="!x11-themes/etheme-BlueSteel
 	!x11-themes/etheme-Ganymede
 	!x11-themes/etheme-ShinyMetal"
 
-S=${WORKDIR}/${MY_P}
-
-src_install() {
-	emake install DESTDIR="${D}" || die
-	dodoc AUTHORS ChangeLog
-}
+S="${WORKDIR}/${MY_P}"

--- a/x11-themes/ethemes/ethemes-1.0.1.ebuild
+++ b/x11-themes/ethemes/ethemes-1.0.1.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 MY_P="e16-themes-${PV}"
 DESCRIPTION="all the official Enlightenment themes"
@@ -16,9 +18,4 @@ RDEPEND="!x11-themes/etheme-BlueSteel
 	!x11-themes/etheme-Ganymede
 	!x11-themes/etheme-ShinyMetal"
 
-S=${WORKDIR}/${MY_P}
-
-src_install() {
-	emake install DESTDIR="${D}" || die
-	dodoc AUTHORS ChangeLog
-}
+S="${WORKDIR}/${MY_P}"

--- a/x11-themes/fvwm_icons/fvwm_icons-1.0.ebuild
+++ b/x11-themes/fvwm_icons/fvwm_icons-1.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 DESCRIPTION="Icons for use with FVWM"
 HOMEPAGE="http://www.fvwm.org/"
@@ -11,12 +13,11 @@ KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-fbsd"
 IUSE=""
 
 RDEPEND=">=x11-wm/fvwm-2.6.2"
-DEPEND=""
 
 S=${WORKDIR}/${PN}
 
 src_install() {
 	dodir /usr/share/icons/fvwm
 	insinto /usr/share/icons/fvwm
-	doins "${S}"/*
+	doins -r .
 }

--- a/x11-themes/fvwm_sounds/fvwm_sounds-1.0.ebuild
+++ b/x11-themes/fvwm_sounds/fvwm_sounds-1.0.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 DESCRIPTION="Sounds for use with FVWM"
 HOMEPAGE="http://www.fvwm.org/"
@@ -11,12 +13,11 @@ KEYWORDS="~alpha amd64 ~ia64 ~ppc ~ppc64 ~sparc x86"
 IUSE=""
 
 RDEPEND=">=x11-wm/fvwm-2.6.2"
-DEPEND=""
 
 S=${WORKDIR}
 
 src_install() {
 	dodir /usr/share/sounds/fvwm
 	insinto /usr/share/sounds/fvwm
-	doins "${S}"/*
+	doins -r .
 }

--- a/x11-themes/pulse-glass/pulse-glass-20100616.ebuild
+++ b/x11-themes/pulse-glass/pulse-glass-20100616.ebuild
@@ -1,5 +1,7 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 MY_PN="Pulse-Glass"
 
@@ -16,5 +18,5 @@ S="${WORKDIR}/${MY_PN}"
 
 src_install() {
 	insinto /usr/share/cursors/xorg-x11/${MY_PN}
-	doins -r cursors || die
+	doins -r cursors
 }

--- a/x11-themes/wm-icons/files/wm-icons-0.4.0-build.patch
+++ b/x11-themes/wm-icons/files/wm-icons-0.4.0-build.patch
@@ -1,0 +1,24 @@
+--- a/configure.in
++++ b/configure.in
+@@ -129,7 +129,7 @@ AC_OUTPUT(
+ 	etc/debian-menu-system/Makefile
+ 	devel/Makefile
+ 	devel/bin/Makefile
+-	bin/Makefile
++	
+ 	bin/wm-icons-config
+ 	doc/Makefile
+ 	doc/wm-icons.lsm
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -13,8 +13,8 @@ SUBDIRS = bin doc icons etc devel rpm
+ # => icondir) is different for the build and install phases, as it
+ # is for a distribution package building.
+ install-data-local:
+-	# set the default icon set aliases (symlinks)
+-	$(bindir)/wm-icons-config --user-dir="$(icondir)" --defaults --quiet
++# set the default icon set aliases (symlinks)
++	true --user-dir="$(icondir)" --defaults --quiet
+ 
+ wm-configs _pack-symlinks _unpack-symlinks:
+ 	cd devel/bin && $(MAKE) $(AM_MAKEFLAGS) $@

--- a/x11-themes/wm-icons/wm-icons-0.4.0.ebuild
+++ b/x11-themes/wm-icons/wm-icons-0.4.0.ebuild
@@ -1,31 +1,33 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-DESCRIPTION="A Large Assortment of Beutiful Themed Icons, Created with FVWM in mind"
+EAPI=6
 
+DESCRIPTION="A Large Assortment of Beautiful Themed Icons, Created with FVWM in mind"
 HOMEPAGE="http://wm-icons.sourceforge.net/"
 SRC_URI="mirror://sourceforge/wm-icons/wm-icons-${PV}.tar.bz2"
-LICENSE="GPL-2"
 
+LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~x86"
-
 IUSE=""
+
 RDEPEND="virtual/awk dev-lang/perl"
 DEPEND="${RDEPEND} sys-devel/autoconf sys-devel/automake sys-apps/sed"
 
-src_compile() {
-	econf --enable-all-sets --enable-icondir=/usr/share/icons/wm-icons || die "econf failed"
-	emake || die
+src_configure() {
+	econf --enable-all-sets \
+		--enable-icondir="${EPREFIX}"/usr/share/icons/wm-icons
 }
 
 src_install() {
-	make icondir="${D}/usr/share/icons/wm-icons" DESTDIR="${D}" install
+	# strange makefile...
+	emake icondir="${ED%/}/usr/share/icons/wm-icons" DESTDIR="${D}" install
 
 	einfo "Setting default aliases..."
-	"${D}"/usr/bin/wm-icons-config --force --user-dir="${D}/usr/share/icons/wm-icons" --defaults
+	"${ED%/}/usr/bin/wm-icons-config" --force --user-dir="${ED%/}/usr/share/icons/wm-icons" --defaults
 
-	dodoc AUTHORS ChangeLog NEWS README
+	einstalldocs
 }
 
 pkg_postinst() {

--- a/x11-themes/wm-icons/wm-icons-0.4.0_pre1-r1.ebuild
+++ b/x11-themes/wm-icons/wm-icons-0.4.0_pre1-r1.ebuild
@@ -1,52 +1,46 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
 
 inherit autotools
 
-DESCRIPTION="A Large Assortment of Beutiful Themed Icons, Created with FVWM in mind"
-
+DESCRIPTION="A Large Assortment of Beautiful Themed Icons, Created with FVWM in mind"
 HOMEPAGE="http://wm-icons.sourceforge.net/"
 SRC_URI="mirror://gentoo/wm-icons-${PV}-cvs-01092003.tar.bz2"
-LICENSE="GPL-2"
 
+LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="alpha amd64 ia64 ppc ppc64 x86"
-
 IUSE=""
+
 RDEPEND="virtual/awk dev-lang/perl"
 
 S=${WORKDIR}/wm-icons
 
-src_unpack() {
-	unpack ${A}
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.4.0-build.patch
+)
 
-	sed -i 's#$(bindir)/wm-icons-config#true#g' "${S}"/Makefile.am
-	# duplication of bin/Makefile in configure.in #91764
-	sed -i '132s/bin\/Makefile//' "${S}"/configure.in
-	# non-portable comment bombs automake.
-	sed -i 's/\t#/#/' "${S}"/Makefile.am
-
-	cd "${S}"
+src_prepare() {
+	default
 	eautoreconf
 }
 
-src_compile() {
-	econf --enable-all-sets --enable-icondir=/usr/share/icons/wm-icons || die "econf failed"
-	emake || die "emake failed"
+src_configure() {
+	econf --enable-icondir="${EPREFIX}"/usr/share/icons/wm-icons
 }
 
 src_install() {
 	# strange makefile...
-	einstall icondir="${D}/usr/share/icons/wm-icons" DESTDIR="${D}" || die
+	emake icondir="${ED%/}/usr/share/icons/wm-icons" DESTDIR="${D}" install
 
-	dodir /usr/bin
-	mv "${D}"/"${D}"/usr/bin/wm-icons-config "${D}"/usr/bin/wm-icons-config
 	rm -rf "${D}"/var
 
 	einfo "Setting default aliases..."
-	"${D}"/usr/bin/wm-icons-config --user-dir="${D}/usr/share/icons/wm-icons" --defaults
+	"${ED%/}/usr/bin/wm-icons-config" --force --user-dir="${ED%/}/usr/share/icons/wm-icons" --defaults
 
-	dodoc AUTHORS ChangeLog NEWS README
+	einstalldocs
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Most of these are flat data (icon and sound themes, etc), with a few having actual executables.

All compile tested through `ebuild $ebuild clean install` on my current system, all maint-needed.