### PR TITLE
net-irc/kvirc: Install reasonable defaults during dodoc.

### DIFF
--- a/net-irc/kvirc/kvirc-9999.ebuild
+++ b/net-irc/kvirc/kvirc-9999.ebuild
@@ -76,8 +76,6 @@ DEPEND="${RDEPEND}
 RDEPEND="${RDEPEND}
 	gsm? ( media-sound/gsm )"
 
-DOCS=(ChangeLog doc/FAQ)
-
 pkg_setup() {
 	if use python; then
 		python-single-r1_pkg_setup


### PR DESCRIPTION
Fixes build after https://github.com/kvirc/KVIrc/pull/2366