### PR TITLE
app-crypt/keybase: fixing non-working KBFS

### DIFF
--- a/app-crypt/keybase/keybase-1.0.44.ebuild
+++ b/app-crypt/keybase/keybase-1.0.44.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/keybase/client/archive/v${MY_PV}.tar.gz -> ${P}.tar.
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="+suid"
 
 DEPEND="
 	>=dev-lang/go-1.6:0
@@ -49,8 +49,12 @@ src_compile() {
 
 src_install() {
 	dobin "${T}/keybase"
+	dodir "/var/lib/keybase"
+	fowners keybasehelper:keybasehelper "/var/lib/keybase"
+	dosym "/tmp/keybase" "/var/lib/keybase/mount1"
 	dobin "${T}/keybase-mount-helper"
-	fowners keybasehelper:keybasehelper "${EROOT}/usr/bin/keybase-mount-helper"
+	fowners keybasehelper:keybasehelper "/usr/bin/keybase-mount-helper"
+	use suid && fperms 4755 "/usr/bin/keybase-mount-helper"
 	dobin "${S}/packaging/linux/run_keybase"
 	systemd_douserunit "${S}/packaging/linux/systemd/keybase.service"
 }

--- a/app-crypt/keybase/keybase-9999.ebuild
+++ b/app-crypt/keybase/keybase-9999.ebuild
@@ -14,7 +14,7 @@ EGIT_REPO_URI="https://github.com/keybase/client.git"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="+suid"
 
 DEPEND="
 	>=dev-lang/go-1.6:0
@@ -49,8 +49,12 @@ src_compile() {
 
 src_install() {
 	dobin "${T}/keybase"
+	dodir "/var/lib/keybase"
+	fowners keybasehelper:keybasehelper "/var/lib/keybase"
+	dosym "/tmp/keybase" "/var/lib/keybase/mount1"
 	dobin "${T}/keybase-mount-helper"
-	fowners keybasehelper:keybasehelper "${EROOT}/usr/bin/keybase-mount-helper"
+	fowners keybasehelper:keybasehelper "/usr/bin/keybase-mount-helper"
+	use suid && fperms 4755 "/usr/bin/keybase-mount-helper"
 	dobin "${S}/packaging/linux/run_keybase"
 	systemd_douserunit "${S}/packaging/linux/systemd/keybase.service"
 }


### PR DESCRIPTION
KBFS needs SUID and some other tweaks
Fixing BGO bug #649634 ...
Updating both 1.0.44 and 9999 with the same logic.

This is a rework for https://github.com/gentoo/gentoo/pull/7370/ due to (my) flowed git workflow... See the comments there.

Closes: https://bugs.gentoo.org/649634
Reported-by: Kalin KOZHUHAROV <kalin@thinrope.net>