### PR TITLE
sys-apps/busybox: EAPI=6 and drop eutils, multilib

### DIFF
--- a/sys-apps/busybox/busybox-1.28.3.ebuild
+++ b/sys-apps/busybox/busybox-1.28.3.ebuild
@@ -3,8 +3,9 @@
 
 # See `man savedconfig.eclass` for info on how to use USE=savedconfig.
 
-EAPI="5"
-inherit eutils flag-o-matic savedconfig toolchain-funcs multilib
+EAPI=6
+
+inherit flag-o-matic savedconfig toolchain-funcs
 
 DESCRIPTION="Utilities for rescue and embedded systems"
 HOMEPAGE="https://www.busybox.net/"
@@ -62,14 +63,18 @@ busybox_config_enabled() {
 	esac
 }
 
+# patches go here!
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.26.2-bb.patch
+	# "${FILESDIR}"/${P}-*.patch
+)
+
 src_prepare() {
+	default
 	unset KBUILD_OUTPUT #88088
 	append-flags -fno-strict-aliasing #310413
 	use ppc64 && append-flags -mminimal-toc #130943
 
-	# patches go here!
-	epatch "${FILESDIR}"/${PN}-1.26.2-bb.patch
-#	epatch "${FILESDIR}"/${P}-*.patch
 	cp "${FILESDIR}"/ginit.c init/ || die
 
 	# flag cleanup

--- a/sys-apps/busybox/busybox-9999.ebuild
+++ b/sys-apps/busybox/busybox-9999.ebuild
@@ -3,8 +3,9 @@
 
 # See `man savedconfig.eclass` for info on how to use USE=savedconfig.
 
-EAPI="5"
-inherit eutils flag-o-matic savedconfig toolchain-funcs multilib
+EAPI=6
+
+inherit flag-o-matic savedconfig toolchain-funcs
 
 DESCRIPTION="Utilities for rescue and embedded systems"
 HOMEPAGE="https://www.busybox.net/"
@@ -62,14 +63,18 @@ busybox_config_enabled() {
 	esac
 }
 
+# patches go here!
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.26.2-bb.patch
+	# "${FILESDIR}"/${P}-*.patch
+)
+
 src_prepare() {
+	default
 	unset KBUILD_OUTPUT #88088
 	append-flags -fno-strict-aliasing #310413
 	use ppc64 && append-flags -mminimal-toc #130943
 
-	# patches go here!
-	epatch "${FILESDIR}"/${PN}-1.26.2-bb.patch
-#	epatch "${FILESDIR}"/${P}-*.patch
 	cp "${FILESDIR}"/ginit.c init/ || die
 
 	# flag cleanup


### PR DESCRIPTION
Both build tested, with and without USE=mdev (which is the only thing that causes
`get_libdir` from `multilib.eclass` to be used, which is now native to EAPI=6 ebuilds).

```
Portage 2.3.31 (python 3.5.5-final-0, default/linux/amd64/17.1/desktop, gcc-7.3.0,
glibc-2.26-r6, 4.16.1-gentoo x86_64)
```