### PR TITLE
net-p2p/retroshare update development ebuild

### DIFF
--- a/net-p2p/retroshare/metadata.xml
+++ b/net-p2p/retroshare/metadata.xml
@@ -14,24 +14,26 @@
 		<name>Sergey Popov</name>
 	</maintainer>
 	<longdescription lang="en">
-		RetroShare is a Open Source cross-platform, Friend-2-Friend and
+		RetroShare is a Free and Open Source cross-platform, Friend-2-Friend
 		secure decentralised communication platform.
-		It lets you to securely chat and share files with your friends
-		and family, using a web-of-trust to authenticate peers and OpenSSL
+		It lets you to securely chat and share files with your friends, family
+		and even unknown people using PGP to authenticate peers and OpenSSL
 		to encrypt all communication.
-		RetroShare provides filesharing, chat, messages, forums and
-		channels
+		RetroShare provides filesharing, chat, mails, forums and channels.
 	</longdescription>
 	<use>
 		<flag name="cli">Enables the CLI version of RetroShare</flag>
+		<flag name="control-socket">Enables API via Unix socket support</flag>
 		<flag name="feedreader">Enables the Feedreader plugin</flag>
 		<flag name="gnome-keyring">Enables potentially insecure autologin capability via Gnome Keyring</flag>
 		<flag name="gui">Enables the GUI version of RetroShare</flag>
+		<flag name="settings-api">Enables settings control via API</flag>
+		<flag name="sqlcipher">Enables GXS database encryption via SQLCipher</flag>
 		<flag name="voip">Enables VOIP plugin</flag>
+		<flag name="webui">Enables Web interface and API support</flag>
 	</use>
 	<upstream>
-		<bugs-to>https://sourceforge.net/p/retroshare/bugs</bugs-to>
-		<remote-id type="sourceforge">retroshare</remote-id>
+		<bugs-to>https://github.com/RetroShare/RetroShare/issues</bugs-to>
 		<remote-id type="github">RetroShare/RetroShare</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Development version of retroshare expose qmake flags that permit easier
build customization without crufty patching, improve development ebuild
to take advantage of that and have a cleaner ebuild.
For future stable versions this ebuild should be used as reference and
not the older ones.