### PR TITLE
Dropping python@ from more packages + last rites

### DIFF
--- a/dev-python/pyjade/metadata.xml
+++ b/dev-python/pyjade/metadata.xml
@@ -5,10 +5,6 @@
 		<email>dolsen@gentoo.org</email>
 		<name>Brian Dolbec</name>
 	</maintainer>
-	<maintainer type="project">
-		<email>python@gentoo.org</email>
-		<name>Python</name>
-	</maintainer>
 	<upstream>
 		<maintainer>
 			<email>me@syrusakbary.com</email>

--- a/dev-python/pyramid/metadata.xml
+++ b/dev-python/pyramid/metadata.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>python@gentoo.org</email>
-		<name>Python</name>
+	<maintainer type="person">
+		<email>dolsen@gentoo.org</email>
+		<name>Brian Dolbec</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="pypi">pyramid</remote-id>

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -30,6 +30,11 @@
 #--- END OF EXAMPLES ---
 
 # Michał Górny <mgorny@gentoo.org> (26 Apr 2018)
+# Produces a lot of Pango warnings, then segfaults.  Unmaintained.
+# No reverse dependencies.  Removal in 30 days.  Bug #526668.
+dev-python/kiwi
+
+# Michał Górny <mgorny@gentoo.org> (26 Apr 2018)
 # Obsolete package used during some past GSoC development
 # and unmaintained since.  All of its users have retired already.
 # No reverse dependencies.  The ebuild runs test suite of CPython

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -30,6 +30,12 @@
 #--- END OF EXAMPLES ---
 
 # Michał Górny <mgorny@gentoo.org> (26 Apr 2018)
+# Apparently redundant to built-in Python features.  Homepage gone
+# without trace.  Last release in 2003.  No reverse dependencies.
+# Removal in 30 days.  Bug #537720.
+dev-python/iconvcodec
+
+# Michał Górny <mgorny@gentoo.org> (26 Apr 2018)
 # Does not work with any of the unmasked django versions.  Unmaintained.
 # No reverse dependencies.  Removal in 30 days.  Bug #527176.
 dev-python/django-evolution

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -30,6 +30,11 @@
 #--- END OF EXAMPLES ---
 
 # Michał Górny <mgorny@gentoo.org> (26 Apr 2018)
+# Does not work with any of the unmasked django versions.  Unmaintained.
+# No reverse dependencies.  Removal in 30 days.  Bug #527176.
+dev-python/django-evolution
+
+# Michał Górny <mgorny@gentoo.org> (26 Apr 2018)
 # Produces a lot of Pango warnings, then segfaults.  Unmaintained.
 # No reverse dependencies.  Removal in 30 days.  Bug #526668.
 dev-python/kiwi

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -29,6 +29,13 @@
 
 #--- END OF EXAMPLES ---
 
+# Michał Górny <mgorny@gentoo.org> (26 Apr 2018)
+# Obsolete package used during some past GSoC development
+# and unmaintained since.  All of its users have retired already.
+# No reverse dependencies.  The ebuild runs test suite of CPython
+# instead of its own.  Removal in 30 days.  Bug #526552.
+dev-python/tdaemon
+
 # Andreas Sturmlechner <asturm@gentoo.org> (26 Apr 2018)
 # Depends on dead Qt4, no more revdeps. Masked for removal in 30 days.
 dev-libs/qjson


### PR DESCRIPTION
Some more packages which don't seem very useful to the general audience, and that aren't really maintained by python@.