### PR TITLE
dev-python/pbkdf2: use HTTPS

### DIFF
--- a/dev-python/pbkdf2/pbkdf2-1.3.ebuild
+++ b/dev-python/pbkdf2/pbkdf2-1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Implementation of the password-based key derivation function, PBKDF2, specified in RSA PKCS#5 v2.0"
-HOMEPAGE="http://www.dlitz.net/software/python-pbkdf2/"
+HOMEPAGE="https://www.dlitz.net/software/python-pbkdf2/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"


### PR DESCRIPTION
Hi,

This PR fixes the package to use https instead of http.

Please review.