### PR TITLE
dev-python/python-stdnum: use HTTPS

### DIFF
--- a/dev-python/python-stdnum/python-stdnum-1.7.ebuild
+++ b/dev-python/python-stdnum/python-stdnum-1.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit distutils-r1
 
 DESCRIPTION="A module to handle standardized numbers and codes"
-HOMEPAGE="http://arthurdejong.org/python-stdnum/"
+HOMEPAGE="https://arthurdejong.org/python-stdnum/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"

--- a/dev-python/python-stdnum/python-stdnum-1.8.1.ebuild
+++ b/dev-python/python-stdnum/python-stdnum-1.8.1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit distutils-r1
 
 DESCRIPTION="A module to handle standardized numbers and codes"
-HOMEPAGE="http://arthurdejong.org/python-stdnum/"
+HOMEPAGE="https://arthurdejong.org/python-stdnum/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"


### PR DESCRIPTION
Hi,

This PR fixes the package to use https instead of http.

Please review.