### PR TITLE
net-dns/getdns: add systemd unit files

### DIFF
--- a/net-dns/getdns/files/stubby.systemd
+++ b/net-dns/getdns/files/stubby.systemd
@@ -1,0 +1,12 @@
+[Unit]
+Description=stubby DNS resolver
+
+[Service]
+WorkingDirectory=/run/stubby
+ExecStart=/usr/bin/stubby
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+User=stubby
+
+[Install]
+WantedBy=multi-user.target

--- a/net-dns/getdns/files/stubby.tmpfilesd
+++ b/net-dns/getdns/files/stubby.tmpfilesd
@@ -1,0 +1,2 @@
+# tmpfiles.d (5) for use with stubby.service
+d /run/stubby 0750 root stubby - -

--- a/net-dns/getdns/getdns-1.4.1-r1.ebuild
+++ b/net-dns/getdns/getdns-1.4.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit user fcaps
+inherit user fcaps systemd
 
 DESCRIPTION="Modern asynchronous DNS API"
 HOMEPAGE="https://getdnsapi.net/"
@@ -52,6 +52,8 @@ src_install() {
 	if use stubby; then
 		newinitd "${FILESDIR}"/stubby.initd stubby
 		newconfd "${FILESDIR}"/stubby.confd stubby
+		systemd_newunit "${FILESDIR}"/stubby.systemd stubby.service
+		systemd_newtmpfilesd "${FILESDIR}"/stubby.tmpfilesd stubby.conf
 	fi
 }
 


### PR DESCRIPTION
After discussing about it here https://bugs.gentoo.org/638166#c10, I added systemd unit files to the ebuild for people on systemd profiles.

CC @blueness 