### PR TITLE
media-plugins/vdr-epgsearch-1.0.1_p20141227: no "doman" with *.gz files, EAPI=6

### DIFF
--- a/media-plugins/vdr-epgsearch/files/fix-manpage-generation.diff
+++ b/media-plugins/vdr-epgsearch/files/fix-manpage-generation.diff
@@ -1,0 +1,45 @@
+--- a/docsrc2man.sh	2018-04-25 23:19:05.623375324 +0200
++++ b/docsrc2man.sh	2018-04-25 23:19:35.519934631 +0200
+@@ -37,23 +37,6 @@
+ 	done
+ 
+ 	rm "$DOCSRC"/$LANGUAGE/*~ 2>/dev/null
+-	gzip -f man/$LANGUAGE/*.[0-9]
+-
+-done
+-
+-echo
+-
+-for LANGUAGE in $(ls "$DOCSRC"/); do
+-
+-	[ ! -d "$DOCSRC/$LANGUAGE" ] && continue
+-	mkdir -p doc/$LANGUAGE
+-	rm doc/$LANGUAGE/* 2>/dev/null
+-
+-	for i in man/$LANGUAGE/*.gz; do
+-		echo -ne "create doc file from man page: ($LANGUAGE) $(basename "$i")..."
+-		zcat "$i" | nroff -man - | col -xbp > "doc/$LANGUAGE/$(basename "$i" ".gz").txt"
+-		echo " done"
+-	done
+ 
+ done
+ 
+--- a/Makefile	2018-04-25 23:32:59.042967016 +0200
++++ b/Makefile	2018-04-25 23:33:35.535649724 +0200
+@@ -276,16 +276,6 @@
+ 	cp -n conf/* $(DESTDIR)$(CONFDIR)/plugins/$(PLUGIN)
+ 
+ install-doc:
+-	mkdir -p $(DESTDIR)$(MANDIR)/man1
+-	mkdir -p $(DESTDIR)$(MANDIR)/man4
+-	mkdir -p $(DESTDIR)$(MANDIR)/man5
+-	mkdir -p $(DESTDIR)$(MANDIR)/de/man1
+-	mkdir -p $(DESTDIR)$(MANDIR)/de/man5
+-	cp man/en/*1.gz $(DESTDIR)$(MANDIR)/man1/
+-	cp man/en/*4.gz $(DESTDIR)$(MANDIR)/man4/
+-	cp man/en/*5.gz $(DESTDIR)$(MANDIR)/man5/
+-	cp man/de/*1.gz $(DESTDIR)$(MANDIR)/de/man1/
+-	cp man/de/*5.gz $(DESTDIR)$(MANDIR)/de/man5/
+ 
+ install-bin: createcats
+ 	mkdir -p $(DESTDIR)$(BINDIR)

--- a/media-plugins/vdr-epgsearch/metadata.xml
+++ b/media-plugins/vdr-epgsearch/metadata.xml
@@ -1,14 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+<maintainer type="person">
+	<email>martin.dummer@gmx.net</email>
+	<name>Martin Dummer</name>
+</maintainer>
 <maintainer type="project">
-<email>vdr@gentoo.org</email>
-<name>Gentoo VDR Project</name>
+	<email>proxy-maint@gentoo.org</email>
+	<name>Proxy Maintainers</name>
+</maintainer>
+<maintainer type="project">
+	<email>vdr@gentoo.org</email>
+	<name>Gentoo VDR Project</name>
 </maintainer>
 <use>
-	<flag name="conflictcheckonly">ToDo</flag>
-	<flag name="epgsearchonly">ToDo</flag>
-	<flag name="quicksearch">ToDo</flag>
+	<flag name="conflictcheckonly">install the "conflictcheckonly" vdr-plugin</flag>
+	<flag name="epgsearchonly">install the "epgsearchonly" vdr-plugin</flag>
+	<flag name="quicksearch">install the "quicksearch" vdr-plugin</flag>
 	<flag name="tre">Add support for unlimited fuzzy searching with help of <pkg>dev-libs/tre</pkg> library</flag>
 </use>
 </pkgmetadata>


### PR DESCRIPTION
Remove usage of "doman" with pre-compressed files
Update to EAPI=6
Bug: https://bugs.gentoo.org/619954
Package-Manager: Portage-2.3.31, Repoman-2.3.9