### PR TITLE
app-misc/icdiff: use HTTPS

### DIFF
--- a/app-misc/icdiff/icdiff-1.7.3.ebuild
+++ b/app-misc/icdiff/icdiff-1.7.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=(python2_7 python3_4 python3_5)
 inherit distutils-r1
 
 DESCRIPTION="Colourized diff that supports side-by-side diffing"
-HOMEPAGE="http://www.jefftk.com/icdiff"
+HOMEPAGE="https://www.jefftk.com/icdiff"
 SRC_URI="https://github.com/jeffkaufman/${PN}/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="PSF-2"

--- a/app-misc/icdiff/icdiff-1.9.1.ebuild
+++ b/app-misc/icdiff/icdiff-1.9.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=(python2_7 python3_4 python3_5)
 inherit distutils-r1
 
 DESCRIPTION="Colourized diff that supports side-by-side diffing"
-HOMEPAGE="http://www.jefftk.com/icdiff"
+HOMEPAGE="https://www.jefftk.com/icdiff"
 SRC_URI="https://github.com/jeffkaufman/${PN}/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="PSF-2"


### PR DESCRIPTION
Hi,

This fixes the package to use https instead of http.

Please review.