### PR TITLE
dev-db/mysql-init-scripts: Respect my.cnf user setting

### DIFF
--- a/dev-db/mysql-init-scripts/files/init.d-2.2-r1
+++ b/dev-db/mysql-init-scripts/files/init.d-2.2-r1
@@ -1,0 +1,196 @@
+#!/sbin/openrc-run
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+extra_commands="checkconfig"
+extra_stopped_commands="bootstrap_galera"
+
+description_checkconfig="Verify the server's configuration"
+description_boostrap_galera="Start a new Galera cluster with this server as the initial node"
+
+depend() {
+	use net.lo
+	# localmount needed for $basedir
+	need localmount
+	# This service has its own timeout and may need to wait for repairs
+	# or remote synchronization
+	keyword -timeout
+}
+
+get_config() {
+	my_print_defaults --defaults-file="$1" mysqld server mariadb |
+	sed -n -e "s/^--$2=//p"
+}
+
+mysql_svcname() {
+	local ebextra=
+	case "${SVCNAME}" in
+		mysql*) ;;
+		*) ebextra=" (mysql)" ;;
+	esac
+	echo "${SVCNAME}${ebextra}"
+}
+
+stringContain() { [ -z "${2##*$1*}" ] && [ -z "$1" -o -n "$2" ]; }
+
+bootstrap_galera() {
+	MY_ARGS="--wsrep-new-cluster ${MY_ARGS}"
+	mark_service_starting
+	if start ; then
+		mark_service_started
+		return 0
+	else
+		mark_service_stopped
+		return 1
+	fi
+}
+
+start() {
+	# Check for old conf.d variables that mean migration was not yet done.
+	set | egrep -sq '^(mysql_slot_|MYSQL_BLOG_PID_FILE|STOPTIMEOUT)'
+	rc=$?
+	# Yes, MYSQL_INIT_I_KNOW_WHAT_I_AM_DOING is a hidden variable.
+	# It does have a use in testing, as it is possible to build a config file
+	# that works with both the old and new init scripts simulateously.
+	if [ "${rc}" = 0 -a -z "${MYSQL_INIT_I_KNOW_WHAT_I_AM_DOING}" ]; then
+		eerror "You have not updated your conf.d for the new mysql-init-scripts-2 revamp."
+		eerror "Not proceeding because it may be dangerous."
+		return 1
+	fi
+
+	# Check the config or die
+	if [ ${RC_CMD} != "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	# Now we can startup
+	ebegin "Starting $(mysql_svcname)"
+
+	MY_CNF="${MY_CNF:-/etc/${SVCNAME}/my.cnf}"
+
+	if [ ! -r "${MY_CNF}" ] ; then
+		eerror "Cannot read the configuration file \`${MY_CNF}'"
+		return 1
+	fi
+
+	# tail -n1 is critical as these we only want the last instance of the option
+	local user=$(get_config "${MY_CNF}" user | tail -n1)
+	local basedir=$(get_config "${MY_CNF}" basedir | tail -n1)
+	local pidfile=$(get_config "${MY_CNF}" pid-file | tail -n1)
+	local socket=$(get_config "${MY_CNF}" socket | tail -n1)
+	local chroot=$(get_config "${MY_CNF}" chroot | tail -n1)
+	local wsrep="$(get_config "${MY_CNF}" 'wsrep[_-]on' | tail -n1 | awk '{print tolower($0)}')"
+	local wsrep_new=$(get_config "${MY_CNF}" 'wsrep-new-cluster' | tail -n1)
+
+	if [ -n "${chroot}" ] ; then
+		socket="${chroot}/${socket}"
+		pidfile="${chroot}/${pidfile}"
+	fi
+
+	# Galera: Only check datadir if not starting a new cluster and galera is enabled
+	# wsrep_on is not on or wsrep-new-cluster exists in the config or MY_ARGS
+	[ "${wsrep}" = "1" ] && wsrep="on"
+	if [ "${wsrep}" != "on" ] || [ -n "${wsrep_new}" ] || stringContain 'wsrep-new-cluster' "${MY_ARGS}" ; then
+
+		local datadir=$(get_config "${MY_CNF}" datadir | tail -n1)
+		if [ ! -d "${datadir}" ] ; then
+			eerror "MySQL datadir \`${datadir}' is empty or invalid"
+			eerror "Please check your config file \`${MY_CNF}'"
+			return 1
+		fi
+
+		if [ ! -d "${datadir}"/mysql ] ; then
+			# find which package is installed to report an error
+			local EROOT=$(portageq envvar EROOT)
+			local DBPKG_P=$(portageq match ${EROOT} $(portageq expand_virtual ${EROOT} virtual/mysql | head -n1))
+			if [ -z ${DBPKG_P} ] ; then
+				eerror "You don't appear to have a server package installed yet."
+			else
+				eerror "You don't appear to have the mysql database installed yet."
+				eerror "Please run \`emerge --config =${DBPKG_P}\` to have this done..."
+			fi
+			return 1
+		fi
+	fi
+
+	local piddir="${pidfile%/*}"
+	checkpath -d --owner "${user}" --mode 0755 "$piddir"
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		eerror "Directory $piddir for pidfile does not exist and cannot be created"
+		return 1
+	fi
+
+	local startup_timeout=${STARTUP_TIMEOUT:-900}
+	local startup_early_timeout=${STARTUP_EARLY_TIMEOUT:-1000}
+	local tmpnice="${NICE:+"--nicelevel "}${NICE}"
+	local tmpionice="${IONICE:+"--ionice "}${IONICE}"
+	start-stop-daemon \
+		${DEBUG:+"--verbose"} \
+		--start \
+		--user "${user}" \
+		--exec "${basedir}"/sbin/mysqld \
+		--pidfile "${pidfile}" \
+		--background \
+		--wait ${startup_early_timeout} \
+		${tmpnice} \
+		${tmpionice} \
+		-- --defaults-file="${MY_CNF}" ${MY_ARGS}
+	local ret=$?
+	if [ ${ret} -ne 0 ] ; then
+		eend ${ret}
+		return ${ret}
+	fi
+
+	ewaitfile ${startup_timeout} "${socket}"
+	eend $? || return 1
+
+	save_options pidfile "${pidfile}"
+	save_options basedir "${basedir}"
+}
+
+stop() {
+	if [ ${RC_CMD} = "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	ebegin "Stopping $(mysql_svcname)"
+
+	local pidfile="$(get_options pidfile)"
+	local basedir="$(get_options basedir)"
+	local stop_timeout=${STOP_TIMEOUT:-120}
+
+	start-stop-daemon \
+		${DEBUG:+"--verbose"} \
+		--stop \
+		--exec "${basedir}"/sbin/mysqld \
+		--pidfile "${pidfile}" \
+		--retry ${stop_timeout}
+	eend $?
+}
+
+checkconfig() {
+	local my_cnf="${MY_CNF:-/etc/${SVCNAME}/my.cnf}"
+	local basedir=$(get_config "${my_cnf}" basedir | tail -n1)
+	local svc_name=$(mysql_svcname)
+	ebegin "Checking mysqld configuration for ${svc_name}"
+
+	if [ ${RC_CMD} = "checkconfig" ] ; then
+		# We are calling checkconfig specifically.  Print warnings regardless.
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+	else
+		# Suppress output to check the return value
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null 2>&1
+
+		# If the above command does not return 0,
+		# then there is an error to echo to the user
+		if [ $? -ne 0 ] ; then
+			"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+		fi
+	fi
+
+	eend $? "${svc_name} config check failed"
+}
+
+# vim: filetype=gentoo-init-d sw=2 ts=2 sts=2 noet:
+

--- a/dev-db/mysql-init-scripts/files/init.d-supervise-r1
+++ b/dev-db/mysql-init-scripts/files/init.d-supervise-r1
@@ -1,0 +1,182 @@
+#!/sbin/openrc-run
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+extra_commands="checkconfig"
+extra_stopped_commands="boostrap_galera"
+
+description_checkconfig="Verify the server's configuration"
+description_boostrap_galera="Start a new Galera cluster with this server as the initial node"
+
+depend() {
+	use net.lo
+	# localmount needed for $basedir
+	need localmount
+}
+
+get_config() {
+	my_print_defaults --defaults-file="$1" mysqld server mariadb |
+	sed -n -e "s/^--$2=//p"
+}
+
+mysql_svcname() {
+	local ebextra=
+	case "${SVCNAME}" in
+		mysql*) ;;
+		*) ebextra=" (mysql)" ;;
+	esac
+	echo "${SVCNAME}${ebextra}"
+}
+
+stringContain() { [ -z "${2##*$1*}" ] && [ -z "$1" -o -n "$2" ]; }
+
+bootstrap_galera() {
+	MY_ARGS="--wsrep-new-cluster ${MY_ARGS}"
+	mark_service_starting
+	if start ; then
+		mark_service_started
+		return 0
+	else
+		mark_service_stopped
+		return 1
+	fi
+}
+
+start() {
+	# Check for old conf.d variables that mean migration was not yet done.
+	set | egrep -sq '^(mysql_slot_|MYSQL_BLOG_PID_FILE|STOPTIMEOUT)'
+	rc=$?
+	# Yes, MYSQL_INIT_I_KNOW_WHAT_I_AM_DOING is a hidden variable.
+	# It does have a use in testing, as it is possible to build a config file
+	# that works with both the old and new init scripts simulateously.
+	if [ "${rc}" = 0 -a -z "${MYSQL_INIT_I_KNOW_WHAT_I_AM_DOING}" ]; then
+		eerror "You have not updated your conf.d for the new mysql-init-scripts-2 revamp."
+		eerror "Not proceeding because it may be dangerous."
+		return 1
+	fi
+
+	# Check the config or die
+	if [ ${RC_CMD} != "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	# Now we can startup
+	ebegin "Starting $(mysql_svcname)"
+
+	MY_CNF="${MY_CNF:-/etc/${SVCNAME}/my.cnf}"
+
+	if [ ! -r "${MY_CNF}" ] ; then
+		eerror "Cannot read the configuration file \`${MY_CNF}'"
+		return 1
+	fi
+
+	# tail -n1 is critical as these we only want the last instance of the option
+	local user=$(get_config "${MY_CNF}" user | tail -n1)
+	local basedir=$(get_config "${MY_CNF}" basedir | tail -n1)
+	local pidfile=$(get_config "${MY_CNF}" pid-file | tail -n1)
+	local socket=$(get_config "${MY_CNF}" socket | tail -n1)
+	local chroot=$(get_config "${MY_CNF}" chroot | tail -n1)
+	local wsrep="$(get_config "${MY_CNF}" 'wsrep[_-]on' | tail -n1 | awk '{print tolower($0)}')"
+	local wsrep_new=$(get_config "${MY_CNF}" 'wsrep-new-cluster' | tail -n1)
+
+	if [ -n "${chroot}" ] ; then
+		socket="${chroot}/${socket}"
+		pidfile="${chroot}/${pidfile}"
+	fi
+
+	# Galera: Only check datadir if not starting a new cluster and galera is enabled
+	# wsrep_on is not on or wsrep-new-cluster exists in the config or MY_ARGS
+	[ "${wsrep}" = "1" ] && wsrep="on"
+	if [ "${wsrep}" != "on" ] || [ -n "${wsrep_new}" ] || stringContain 'wsrep-new-cluster' "${MY_ARGS}" ; then
+
+		local datadir=$(get_config "${MY_CNF}" datadir | tail -n1)
+		if [ ! -d "${datadir}" ] ; then
+			eerror "MySQL datadir \`${datadir}' is empty or invalid"
+			eerror "Please check your config file \`${MY_CNF}'"
+			return 1
+		fi
+
+		if [ ! -d "${datadir}"/mysql ] ; then
+			# find which package is installed to report an error
+			local EROOT=$(portageq envvar EROOT)
+			local DBPKG_P=$(portageq match ${EROOT} $(portageq expand_virtual ${EROOT} virtual/mysql | head -n1))
+			if [ -z ${DBPKG_P} ] ; then
+				eerror "You don't appear to have a server package installed yet."
+			else
+				eerror "You don't appear to have the mysql database installed yet."
+				eerror "Please run \`emerge --config =${DBPKG_P}\` to have this done..."
+			fi
+			return 1
+		fi
+	fi
+
+	local piddir="${pidfile%/*}"
+	checkpath -d --owner "${user}" --mode 0755 "$piddir"
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		eerror "Directory $piddir for pidfile does not exist and cannot be created"
+		return 1
+	fi
+
+	local startup_timeout=${STARTUP_TIMEOUT:-900}
+#	local startup_early_timeout=${STARTUP_EARLY_TIMEOUT:-1000}
+	local tmpnice="${NICE:+"--nicelevel "}${NICE}"
+	local tmpionice="${IONICE:+"--ionice "}${IONICE}"
+	supervise-daemon \
+		${DEBUG:+"--verbose"} \
+		--pidfile "/run/${SVCNAME}.pid" \
+		${tmpnice} \
+		${tmpionice} \
+		--start \
+		--user "${user}" \
+		"${basedir}"/sbin/mysqld \
+		-- --defaults-file="${MY_CNF}" ${MY_ARGS}
+	local ret=$?
+	if [ ${ret} -ne 0 ] ; then
+		eend ${ret}
+		return ${ret}
+	fi
+
+	ewaitfile ${startup_timeout} "${socket}"
+	eend $? || return 1
+}
+
+stop() {
+	if [ ${RC_CMD} = "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	ebegin "Stopping $(mysql_svcname)"
+
+	supervise-daemon \
+		${DEBUG:+"--verbose"} \
+		--stop \
+		--pidfile "/run/${SVCNAME}.pid"
+	eend $?
+}
+
+checkconfig() {
+	local my_cnf="${MY_CNF:-/etc/${SVCNAME}/my.cnf}"
+	local basedir=$(get_config "${my_cnf}" basedir | tail -n1)
+	local svc_name=$(mysql_svcname)
+	ebegin "Checking mysqld configuration for ${svc_name}"
+
+	if [ ${RC_CMD} = "checkconfig" ] ; then
+		# We are calling checkconfig specifically.  Print warnings regardless.
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+	else
+		# Suppress output to check the return value
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null 2>&1
+
+		# If the above command does not return 0,
+		# then there is an error to echo to the user
+		if [ $? -ne 0 ] ; then
+			"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+		fi
+	fi
+
+	eend $? "${svc_name} config check failed"
+}
+
+# vim: filetype=gentoo-init-d sw=2 ts=2 sts=2 noet:
+

--- a/dev-db/mysql-init-scripts/mysql-init-scripts-2.2-r4.ebuild
+++ b/dev-db/mysql-init-scripts/mysql-init-scripts-2.2-r4.ebuild
@@ -1,0 +1,64 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit systemd s6
+
+DESCRIPTION="Gentoo MySQL init scripts."
+HOMEPAGE="https://www.gentoo.org/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd"
+IUSE=""
+
+DEPEND=""
+# This _will_ break with MySQL 5.0, 4.x, 3.x
+# It also NEEDS openrc for the save_options/get_options builtins.
+# The s6 support was added after openrc 0.16.2
+RDEPEND="
+	!<dev-db/mysql-5.1
+	!<sys-apps/openrc-0.16.2
+	"
+# Need to set S due to PMS saying we need it existing, but no SRC_URI
+S=${WORKDIR}
+
+src_install() {
+	newconfd "${FILESDIR}/conf.d-2.0" "mysql"
+
+	# s6 init scripts
+	if use amd64 || use x86 ; then
+		newconfd "${FILESDIR}/conf.d-2.0" "mysql-s6"
+		newinitd "${FILESDIR}/init.d-s6-2.2" "mysql-s6"
+		s6_install_service mysql "${FILESDIR}/run-s6"
+		s6_install_service mysql/log "${FILESDIR}/log-s6"
+	fi
+
+	newinitd "${FILESDIR}/init.d-2.2-r1" "mysql"
+	newinitd "${FILESDIR}/init.d-supervise-r1" "mysql-supervise"
+
+	# systemd unit installation
+	exeinto /usr/libexec
+	doexe "${FILESDIR}"/mysqld-wait-ready
+	systemd_newunit "${FILESDIR}/mysqld-v2.service" "mysqld.service"
+	systemd_newunit "${FILESDIR}/mysqld_at-v2.service" "mysqld@.service"
+	systemd_dotmpfilesd "${FILESDIR}/mysql.conf"
+
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}/logrotate.mysql" "mysql"
+}
+
+pkg_postinst() {
+	if use amd64 || use x86 ; then
+		elog ""
+		elog "To use the mysql-s6 script, you need to install the optional sys-apps/s6 package."
+		elog "If you wish to use s6 logging support, comment out the log-error setting in your my.cnf"
+	fi
+
+	elog ""
+	elog "Starting with version 10.1.8, MariaDB includes an improved systemd unit named mariadb.service"
+	elog "You should prefer that unit over this package's mysqld.service."
+	einfo ""
+}


### PR DESCRIPTION
CC @gentoo/mysql

**Blocker to merging:** How do we set the user in the s6 init?

* Fix running mysql as a different user
* Fix multiple Galera SST failures when /proc is mounted with hidepid=2.

On startup wsrep_sst_rsync was failing to run because it checks to
see if the mysqld process is running. When the service is started
without --user, the mysqld process calls setuid() to perform the
user change itself. The setuid call will flip the dumpable bit for
the process, disabling the ability for the mysql user to ptrace it.

The hidepid=2 /proc mount option checks not only if the process is
owned by the user, but also if the user can ptrace the process. If a
process can not be ptraced, it does not appear in the output of ps.

As a result of this, wsrep_sst_rsync would start the rsync daemon
and immediately kill it because it thought mysqld wasn't running,
since it didn't appear in ps.

Starting mysqld as the correct user allows the process to appear.

Closes: https://bugs.gentoo.org/593046
Package-Manager: Portage-2.3.24, Repoman-2.3.6