### PR TITLE
media-fonts/iosevka: use HTTPS

### DIFF
--- a/media-fonts/iosevka/iosevka-1.14.1.ebuild
+++ b/media-fonts/iosevka/iosevka-1.14.1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit font
 
 DESCRIPTION="Slender typeface for code, from code"
-HOMEPAGE="http://be5invis.github.io/Iosevka"
+HOMEPAGE="https://be5invis.github.io/Iosevka/"
 SRC_URI="https://github.com/be5invis/${PN}/releases/download/v${PV}/01-${P}.zip
 https://github.com/be5invis/${PN}/releases/download/v${PV}/02-${PN}-term-${PV}.zip"
 


### PR DESCRIPTION
Hi, 

This PR fixes the package to use https instead of http.

Please review.