### PR TITLE
app-text/pelican: use HTTPS

### DIFF
--- a/app-text/pelican/pelican-3.6.0.ebuild
+++ b/app-text/pelican/pelican-3.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4} )
 inherit distutils-r1
 
 DESCRIPTION="A tool to generate a static blog, with restructured text or markdown input files"
-HOMEPAGE="http://blog.getpelican.com/ https://pypi.org/project/pelican/"
+HOMEPAGE="https://blog.getpelican.com/ https://pypi.org/project/pelican/"
 SRC_URI="https://github.com/getpelican/pelican/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="AGPL-3"

--- a/app-text/pelican/pelican-3.6.3.ebuild
+++ b/app-text/pelican/pelican-3.6.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="A tool to generate a static blog, with restructured text or markdown input files"
-HOMEPAGE="http://blog.getpelican.com/ https://pypi.org/project/pelican/"
+HOMEPAGE="https://blog.getpelican.com/ https://pypi.org/project/pelican/"
 SRC_URI="https://github.com/getpelican/pelican/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="AGPL-3"

--- a/app-text/pelican/pelican-3.7.0.ebuild
+++ b/app-text/pelican/pelican-3.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="A tool to generate a static blog, with restructured text or markdown input files"
-HOMEPAGE="http://blog.getpelican.com/ https://pypi.org/project/pelican/"
+HOMEPAGE="https://blog.getpelican.com/ https://pypi.org/project/pelican/"
 SRC_URI="https://github.com/getpelican/pelican/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="AGPL-3"

--- a/app-text/pelican/pelican-3.7.1.ebuild
+++ b/app-text/pelican/pelican-3.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="A tool to generate a static blog, with restructured text or markdown input files"
-HOMEPAGE="http://blog.getpelican.com/ https://pypi.org/project/pelican/"
+HOMEPAGE="https://blog.getpelican.com/ https://pypi.org/project/pelican/"
 SRC_URI="https://github.com/getpelican/pelican/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="AGPL-3"

--- a/app-text/pelican/pelican-9999.ebuild
+++ b/app-text/pelican/pelican-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1 git-r3
 
 DESCRIPTION="A tool to generate a static blog, with restructured text or markdown input files"
-HOMEPAGE="http://blog.getpelican.com/ https://pypi.org/project/pelican/"
+HOMEPAGE="https://blog.getpelican.com/ https://pypi.org/project/pelican/"
 EGIT_REPO_URI="https://github.com/getpelican/pelican.git"
 EGIT_CHECKOUT_DIR="${WORKDIR}/${P}"
 


### PR DESCRIPTION
Hi, 

This PR fixes the package to use https instead of http.

Please review.