### PR TITLE
base-system@g.o: git-2->git-r3

### DIFF
--- a/net-fs/libnfs/libnfs-1.10.0.ebuild
+++ b/net-fs/libnfs/libnfs-1.10.0.ebuild
@@ -1,18 +1,17 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
 AUTOTOOLS_AUTORECONF="1"
 
-inherit eutils
+inherit autotools-utils eutils
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/sahlberg/${PN}.git"
-	inherit git-2 autotools-utils
+	inherit git-r3
 else
 	SRC_URI="https://github.com/sahlberg/${PN}/archive/${P}.tar.gz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~x86"
-	inherit autotools-utils
 fi
 
 DESCRIPTION="Client library for accessing NFS shares over a network"

--- a/net-fs/libnfs/libnfs-1.11.0.ebuild
+++ b/net-fs/libnfs/libnfs-1.11.0.ebuild
@@ -1,18 +1,17 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
 AUTOTOOLS_AUTORECONF="1"
 
-inherit eutils
+inherit autotools-utils eutils
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/sahlberg/${PN}.git"
-	inherit git-2 autotools-utils
+	inherit git-r3
 else
 	SRC_URI="https://github.com/sahlberg/${PN}/archive/${P}.tar.gz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~x86"
-	inherit autotools-utils
 fi
 
 DESCRIPTION="Client library for accessing NFS shares over a network"

--- a/net-fs/libnfs/libnfs-1.9.5.ebuild
+++ b/net-fs/libnfs/libnfs-1.9.5.ebuild
@@ -1,18 +1,17 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
 AUTOTOOLS_AUTORECONF="1"
 
-inherit eutils
+inherit autotools-utils eutils
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/sahlberg/${PN}.git"
-	inherit git-2 autotools-utils
+	inherit git-r3
 else
 	SRC_URI="https://github.com/sahlberg/${PN}/archive/${P}.tar.gz"
 	KEYWORDS="alpha amd64 arm hppa ppc ppc64 x86"
-	inherit autotools-utils
 fi
 
 DESCRIPTION="Client library for accessing NFS shares over a network"

--- a/net-fs/libnfs/libnfs-1.9.7.ebuild
+++ b/net-fs/libnfs/libnfs-1.9.7.ebuild
@@ -1,18 +1,17 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
 AUTOTOOLS_AUTORECONF="1"
 
-inherit eutils
+inherit autotools-utils eutils
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/sahlberg/${PN}.git"
-	inherit git-2 autotools-utils
+	inherit git-r3
 else
 	SRC_URI="https://github.com/sahlberg/${PN}/archive/${P}.tar.gz"
 	KEYWORDS="~alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh x86"
-	inherit autotools-utils
 fi
 
 DESCRIPTION="Client library for accessing NFS shares over a network"

--- a/net-fs/libnfs/libnfs-1.9.8.ebuild
+++ b/net-fs/libnfs/libnfs-1.9.8.ebuild
@@ -1,18 +1,17 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
 AUTOTOOLS_AUTORECONF="1"
 
-inherit eutils
+inherit autotools-utils eutils
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/sahlberg/${PN}.git"
-	inherit git-2 autotools-utils
+	inherit git-r3
 else
 	SRC_URI="https://github.com/sahlberg/${PN}/archive/${P}.tar.gz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~x86"
-	inherit autotools-utils
 fi
 
 DESCRIPTION="Client library for accessing NFS shares over a network"

--- a/net-fs/libnfs/libnfs-2.0.0.ebuild
+++ b/net-fs/libnfs/libnfs-2.0.0.ebuild
@@ -5,10 +5,10 @@ EAPI="5"
 
 AUTOTOOLS_AUTORECONF="1"
 
-inherit eutils autotools autotools-utils
+inherit autotools autotools-utils eutils
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/sahlberg/${PN}.git"
-	inherit git-2
+	inherit git-r3
 else
 	SRC_URI="https://github.com/sahlberg/${PN}/archive/${P}.tar.gz"
 	KEYWORDS="alpha amd64 arm arm64 ~hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh x86"

--- a/net-fs/libnfs/libnfs-9999.ebuild
+++ b/net-fs/libnfs/libnfs-9999.ebuild
@@ -1,14 +1,14 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
 AUTOTOOLS_AUTORECONF="1"
 
-inherit eutils autotools autotools-utils
+inherit autotools autotools-utils eutils
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/sahlberg/${PN}.git"
-	inherit git-2
+	inherit git-r3
 else
 	SRC_URI="https://github.com/sahlberg/${PN}/archive/${P}.tar.gz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~x86"

--- a/sys-apps/install-xattr/install-xattr-0.5-r1.ebuild
+++ b/sys-apps/install-xattr/install-xattr-0.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ HOMEPAGE="https://dev.gentoo.org/~blueness/install-xattr/"
 inherit toolchain-funcs
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://anongit.gentoo.org/proj/elfix.git"
+	EGIT_REPO_URI="https://anongit.gentoo.org/git/proj/elfix.git"
 	inherit git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~blueness/install-xattr/${P}.tar.bz2"
@@ -21,8 +21,8 @@ LICENSE="GPL-3"
 SLOT="0"
 
 src_prepare() {
+	default
 	tc-export CC
-	eapply_user
 }
 
 src_compile() {

--- a/sys-apps/install-xattr/install-xattr-0.5.ebuild
+++ b/sys-apps/install-xattr/install-xattr-0.5.ebuild
@@ -1,15 +1,16 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
+
 DESCRIPTION="Wrapper to coreutil's install to preserve Filesystem Extended Attributes"
 HOMEPAGE="https://dev.gentoo.org/~blueness/install-xattr/"
 
 inherit toolchain-funcs
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://anongit.gentoo.org/proj/elfix.git"
-	inherit git-2
+	EGIT_REPO_URI="https://anongit.gentoo.org/git/proj/elfix.git"
+	inherit git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~blueness/install-xattr/${P}.tar.bz2"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86"

--- a/sys-apps/install-xattr/install-xattr-9999.ebuild
+++ b/sys-apps/install-xattr/install-xattr-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ HOMEPAGE="https://dev.gentoo.org/~blueness/install-xattr/"
 inherit toolchain-funcs
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://anongit.gentoo.org/proj/elfix.git"
+	EGIT_REPO_URI="https://anongit.gentoo.org/git/proj/elfix.git"
 	inherit git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~blueness/install-xattr/${P}.tar.bz2"
@@ -21,8 +21,8 @@ LICENSE="GPL-3"
 SLOT="0"
 
 src_prepare() {
+	default
 	tc-export CC
-	eapply_user
 }
 
 src_compile() {

--- a/sys-apps/iproute2/iproute2-4.10.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
@@ -21,20 +21,24 @@ SLOT="0"
 IUSE="atm berkdb +iptables ipv6 minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
-RDEPEND="!net-misc/arpd
+RDEPEND="
+	!net-misc/arpd
 	!minimal? ( net-libs/libmnl virtual/libelf )
 	iptables? ( >=net-firewall/iptables-1.4.20:= )
 	berkdb? ( sys-libs/db:= )
 	atm? ( net-dialup/linux-atm )
-	selinux? ( sys-libs/libselinux )"
+	selinux? ( sys-libs/libselinux )
+"
 # We require newer linux-headers for ipset support #549948 and some defines #553876
-DEPEND="${RDEPEND}
+DEPEND="
+	${RDEPEND}
 	app-arch/xz-utils
 	iptables? ( virtual/pkgconfig )
 	>=sys-devel/bison-2.4
 	sys-devel/flex
 	>=sys-kernel/linux-headers-3.16
-	elibc_glibc? ( >=sys-libs/glibc-2.7 )"
+	elibc_glibc? ( >=sys-libs/glibc-2.7 )
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.0-mtu.patch #291907

--- a/sys-apps/iproute2/iproute2-4.11.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.11.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
@@ -21,20 +21,24 @@ SLOT="0"
 IUSE="atm berkdb +iptables ipv6 minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
-RDEPEND="!net-misc/arpd
+RDEPEND="
+	!net-misc/arpd
 	!minimal? ( net-libs/libmnl virtual/libelf )
 	iptables? ( >=net-firewall/iptables-1.4.20:= )
 	berkdb? ( sys-libs/db:= )
 	atm? ( net-dialup/linux-atm )
-	selinux? ( sys-libs/libselinux )"
+	selinux? ( sys-libs/libselinux )
+"
 # We require newer linux-headers for ipset support #549948 and some defines #553876
-DEPEND="${RDEPEND}
+DEPEND="
+	${RDEPEND}
 	app-arch/xz-utils
 	iptables? ( virtual/pkgconfig )
 	>=sys-devel/bison-2.4
 	sys-devel/flex
 	>=sys-kernel/linux-headers-3.16
-	elibc_glibc? ( >=sys-libs/glibc-2.7 )"
+	elibc_glibc? ( >=sys-libs/glibc-2.7 )
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.0-mtu.patch #291907

--- a/sys-apps/iproute2/iproute2-4.12.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.12.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"

--- a/sys-apps/iproute2/iproute2-4.4.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86"
@@ -21,20 +21,24 @@ SLOT="0"
 IUSE="atm berkdb +iptables ipv6 minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
-RDEPEND="!net-misc/arpd
+RDEPEND="
+	!net-misc/arpd
 	!minimal? ( net-libs/libmnl virtual/libelf )
 	iptables? ( >=net-firewall/iptables-1.4.20:= )
 	berkdb? ( sys-libs/db:= )
 	atm? ( net-dialup/linux-atm )
-	selinux? ( sys-libs/libselinux )"
+	selinux? ( sys-libs/libselinux )
+"
 # We require newer linux-headers for ipset support #549948 and some defines #553876
-DEPEND="${RDEPEND}
+DEPEND="
+	${RDEPEND}
 	app-arch/xz-utils
 	iptables? ( virtual/pkgconfig )
 	>=sys-devel/bison-2.4
 	sys-devel/flex
 	>=sys-kernel/linux-headers-3.16
-	elibc_glibc? ( >=sys-libs/glibc-2.7 )"
+	elibc_glibc? ( >=sys-libs/glibc-2.7 )
+"
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-3.1.0-mtu.patch #291907

--- a/sys-apps/iproute2/iproute2-4.5.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
@@ -21,20 +21,24 @@ SLOT="0"
 IUSE="atm berkdb +iptables ipv6 minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
-RDEPEND="!net-misc/arpd
+RDEPEND="
+	!net-misc/arpd
 	!minimal? ( net-libs/libmnl virtual/libelf )
 	iptables? ( >=net-firewall/iptables-1.4.20:= )
 	berkdb? ( sys-libs/db:= )
 	atm? ( net-dialup/linux-atm )
-	selinux? ( sys-libs/libselinux )"
+	selinux? ( sys-libs/libselinux )
+"
 # We require newer linux-headers for ipset support #549948 and some defines #553876
-DEPEND="${RDEPEND}
+DEPEND="
+	${RDEPEND}
 	app-arch/xz-utils
 	iptables? ( virtual/pkgconfig )
 	>=sys-devel/bison-2.4
 	sys-devel/flex
 	>=sys-kernel/linux-headers-3.16
-	elibc_glibc? ( >=sys-libs/glibc-2.7 )"
+	elibc_glibc? ( >=sys-libs/glibc-2.7 )
+"
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-3.1.0-mtu.patch #291907

--- a/sys-apps/iproute2/iproute2-4.6.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
@@ -21,20 +21,24 @@ SLOT="0"
 IUSE="atm berkdb +iptables ipv6 minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
-RDEPEND="!net-misc/arpd
+RDEPEND="
+	!net-misc/arpd
 	!minimal? ( net-libs/libmnl virtual/libelf )
 	iptables? ( >=net-firewall/iptables-1.4.20:= )
 	berkdb? ( sys-libs/db:= )
 	atm? ( net-dialup/linux-atm )
-	selinux? ( sys-libs/libselinux )"
+	selinux? ( sys-libs/libselinux )
+"
 # We require newer linux-headers for ipset support #549948 and some defines #553876
-DEPEND="${RDEPEND}
+DEPEND="
+	${RDEPEND}
 	app-arch/xz-utils
 	iptables? ( virtual/pkgconfig )
 	>=sys-devel/bison-2.4
 	sys-devel/flex
 	>=sys-kernel/linux-headers-3.16
-	elibc_glibc? ( >=sys-libs/glibc-2.7 )"
+	elibc_glibc? ( >=sys-libs/glibc-2.7 )
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.0-mtu.patch #291907

--- a/sys-apps/iproute2/iproute2-4.7.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
@@ -21,20 +21,24 @@ SLOT="0"
 IUSE="atm berkdb +iptables ipv6 minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
-RDEPEND="!net-misc/arpd
+RDEPEND="
+	!net-misc/arpd
 	!minimal? ( net-libs/libmnl virtual/libelf )
 	iptables? ( >=net-firewall/iptables-1.4.20:= )
 	berkdb? ( sys-libs/db:= )
 	atm? ( net-dialup/linux-atm )
-	selinux? ( sys-libs/libselinux )"
+	selinux? ( sys-libs/libselinux )
+"
 # We require newer linux-headers for ipset support #549948 and some defines #553876
-DEPEND="${RDEPEND}
+DEPEND="
+	${RDEPEND}
 	app-arch/xz-utils
 	iptables? ( virtual/pkgconfig )
 	>=sys-devel/bison-2.4
 	sys-devel/flex
 	>=sys-kernel/linux-headers-3.16
-	elibc_glibc? ( >=sys-libs/glibc-2.7 )"
+	elibc_glibc? ( >=sys-libs/glibc-2.7 )
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.0-mtu.patch #291907

--- a/sys-apps/iproute2/iproute2-4.8.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
@@ -21,20 +21,24 @@ SLOT="0"
 IUSE="atm berkdb +iptables ipv6 minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
-RDEPEND="!net-misc/arpd
+RDEPEND="
+	!net-misc/arpd
 	!minimal? ( net-libs/libmnl virtual/libelf )
 	iptables? ( >=net-firewall/iptables-1.4.20:= )
 	berkdb? ( sys-libs/db:= )
 	atm? ( net-dialup/linux-atm )
-	selinux? ( sys-libs/libselinux )"
+	selinux? ( sys-libs/libselinux )
+"
 # We require newer linux-headers for ipset support #549948 and some defines #553876
-DEPEND="${RDEPEND}
+DEPEND="
+	${RDEPEND}
 	app-arch/xz-utils
 	iptables? ( virtual/pkgconfig )
 	>=sys-devel/bison-2.4
 	sys-devel/flex
 	>=sys-kernel/linux-headers-3.16
-	elibc_glibc? ( >=sys-libs/glibc-2.7 )"
+	elibc_glibc? ( >=sys-libs/glibc-2.7 )
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.0-mtu.patch #291907

--- a/sys-apps/iproute2/iproute2-4.9.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.9.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
-	inherit git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
@@ -21,20 +21,24 @@ SLOT="0"
 IUSE="atm berkdb +iptables ipv6 minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
-RDEPEND="!net-misc/arpd
+RDEPEND="
+	!net-misc/arpd
 	!minimal? ( net-libs/libmnl virtual/libelf )
 	iptables? ( >=net-firewall/iptables-1.4.20:= )
 	berkdb? ( sys-libs/db:= )
 	atm? ( net-dialup/linux-atm )
-	selinux? ( sys-libs/libselinux )"
+	selinux? ( sys-libs/libselinux )
+"
 # We require newer linux-headers for ipset support #549948 and some defines #553876
-DEPEND="${RDEPEND}
+DEPEND="
+	${RDEPEND}
 	app-arch/xz-utils
 	iptables? ( virtual/pkgconfig )
 	>=sys-devel/bison-2.4
 	sys-devel/flex
 	>=sys-kernel/linux-headers-3.16
-	elibc_glibc? ( >=sys-libs/glibc-2.7 )"
+	elibc_glibc? ( >=sys-libs/glibc-2.7 )
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.0-mtu.patch #291907

--- a/sys-apps/iproute2/iproute2-9999.ebuild
+++ b/sys-apps/iproute2/iproute2-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit toolchain-funcs flag-o-matic multilib
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"

--- a/sys-apps/kmod/kmod-24.ebuild
+++ b/sys-apps/kmod/kmod-24.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit bash-completion-r1 eutils multilib python-r1
 
 if [[ ${PV} == 9999* ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
-	inherit autotools git-2
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
+	inherit autotools git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/kernel/kmod/${P}.tar.xz"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86"

--- a/sys-apps/kmod/kmod-25.ebuild
+++ b/sys-apps/kmod/kmod-25.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit bash-completion-r1 ltprune multilib python-r1
 
 if [[ ${PV} == 9999* ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
 	inherit autotools git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/kernel/kmod/${P}.tar.xz"

--- a/sys-apps/kmod/kmod-9999.ebuild
+++ b/sys-apps/kmod/kmod-9999.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit bash-completion-r1 ltprune multilib python-r1
 
 if [[ ${PV} == 9999* ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
 	inherit autotools git-r3
 else
 	SRC_URI="mirror://kernel/linux/utils/kernel/kmod/${P}.tar.xz"

--- a/sys-apps/net-tools/net-tools-1.60_p20161110235919.ebuild
+++ b/sys-apps/net-tools/net-tools-1.60_p20161110235919.ebuild
@@ -6,9 +6,8 @@ EAPI="5"
 inherit flag-o-matic toolchain-funcs
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.code.sf.net/p/net-tools/code"
-	EGIT_PROJECT="${PN}"
-	inherit git-2
+	EGIT_REPO_URI="https://git.code.sf.net/p/net-tools/code"
+	inherit git-r3
 else
 	SRC_URI="mirror://gentoo/${P}.tar.xz"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux"

--- a/sys-apps/net-tools/net-tools-1.60_p20170221182432.ebuild
+++ b/sys-apps/net-tools/net-tools-1.60_p20170221182432.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit flag-o-matic toolchain-funcs
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.code.sf.net/p/net-tools/code"
+	EGIT_REPO_URI="https://git.code.sf.net/p/net-tools/code"
 	inherit git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~polynomial-c/dist/${P}.tar.xz"

--- a/sys-apps/net-tools/net-tools-9999.ebuild
+++ b/sys-apps/net-tools/net-tools-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit flag-o-matic toolchain-funcs
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.code.sf.net/p/net-tools/code"
+	EGIT_REPO_URI="https://git.code.sf.net/p/net-tools/code"
 	inherit git-r3
 else
 	SRC_URI="mirror://gentoo/${P}.tar.xz"

--- a/sys-devel/gnuconfig/gnuconfig-20161104.ebuild
+++ b/sys-devel/gnuconfig/gnuconfig-20161104.ebuild
@@ -8,10 +8,11 @@ if [[ ${PV} == "99999999" ]] ; then
 	EGIT_REPO_URI="git://git.savannah.gnu.org/config.git
 		http://git.savannah.gnu.org/r/config.git"
 
-	inherit git-2
+	inherit git-r3
 else
 	SRC_URI="mirror://gentoo/${P}.tar.bz2"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+	S="${WORKDIR}"
 fi
 
 DESCRIPTION="Updated config.sub and config.guess file from GNU"
@@ -20,8 +21,6 @@ HOMEPAGE="https://savannah.gnu.org/projects/config"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE=""
-
-S=${WORKDIR}
 
 maint_pkg_create() {
 	cd "${S}"
@@ -39,7 +38,7 @@ maint_pkg_create() {
 
 src_unpack() {
 	if [[ ${PV} == "99999999" ]] ; then
-		git-2_src_unpack
+		git-r3_src_unpack
 		maint_pkg_create
 	else
 		unpack ${A}
@@ -47,7 +46,7 @@ src_unpack() {
 }
 
 src_prepare() {
-	epatch "${WORKDIR}"/*.patch
+	epatch "${S}"/*.patch
 	use elibc_uclibc && sed -i 's:linux-gnu:linux-uclibc:' testsuite/config-guess.data #180637
 }
 

--- a/sys-devel/gnuconfig/gnuconfig-20170101.ebuild
+++ b/sys-devel/gnuconfig/gnuconfig-20170101.ebuild
@@ -8,10 +8,11 @@ if [[ ${PV} == "99999999" ]] ; then
 	EGIT_REPO_URI="git://git.savannah.gnu.org/config.git
 		http://git.savannah.gnu.org/r/config.git"
 
-	inherit git-2
+	inherit git-r3
 else
 	SRC_URI="mirror://gentoo/${P}.tar.bz2"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+	S="${WORKDIR}"
 fi
 
 DESCRIPTION="Updated config.sub and config.guess file from GNU"
@@ -20,8 +21,6 @@ HOMEPAGE="https://savannah.gnu.org/projects/config"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE=""
-
-S=${WORKDIR}
 
 maint_pkg_create() {
 	cd "${S}"
@@ -39,7 +38,7 @@ maint_pkg_create() {
 
 src_unpack() {
 	if [[ ${PV} == "99999999" ]] ; then
-		git-2_src_unpack
+		git-r3_src_unpack
 		maint_pkg_create
 	else
 		unpack ${A}
@@ -47,7 +46,7 @@ src_unpack() {
 }
 
 src_prepare() {
-	epatch "${WORKDIR}"/*.patch
+	epatch "${S}"/*.patch
 	use elibc_uclibc && sed -i 's:linux-gnu:linux-uclibc:' testsuite/config-guess.data #180637
 }
 

--- a/sys-devel/gnuconfig/gnuconfig-20180101.ebuild
+++ b/sys-devel/gnuconfig/gnuconfig-20180101.ebuild
@@ -8,10 +8,11 @@ if [[ ${PV} == "99999999" ]] ; then
 	EGIT_REPO_URI="git://git.savannah.gnu.org/config.git
 		http://git.savannah.gnu.org/r/config.git"
 
-	inherit git-2
+	inherit git-r3
 else
 	SRC_URI="mirror://gentoo/${P}.tar.bz2"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+	S="${WORKDIR}"
 fi
 
 DESCRIPTION="Updated config.sub and config.guess file from GNU"
@@ -20,8 +21,6 @@ HOMEPAGE="https://savannah.gnu.org/projects/config"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE=""
-
-S=${WORKDIR}
 
 maint_pkg_create() {
 	cd "${S}"
@@ -39,7 +38,7 @@ maint_pkg_create() {
 
 src_unpack() {
 	if [[ ${PV} == "99999999" ]] ; then
-		git-2_src_unpack
+		git-r3_src_unpack
 		maint_pkg_create
 	else
 		unpack ${A}
@@ -47,7 +46,7 @@ src_unpack() {
 }
 
 src_prepare() {
-	epatch "${WORKDIR}"/*.patch
+	epatch "${S}"/*.patch
 	use elibc_uclibc && sed -i 's:linux-gnu:linux-uclibc:' testsuite/config-guess.data #180637
 }
 

--- a/sys-devel/gnuconfig/gnuconfig-99999999.ebuild
+++ b/sys-devel/gnuconfig/gnuconfig-99999999.ebuild
@@ -8,10 +8,11 @@ if [[ ${PV} == "99999999" ]] ; then
 	EGIT_REPO_URI="git://git.savannah.gnu.org/config.git
 		http://git.savannah.gnu.org/r/config.git"
 
-	inherit git-2
+	inherit git-r3
 else
 	SRC_URI="mirror://gentoo/${P}.tar.bz2"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+	S="${WORKDIR}"
 fi
 
 DESCRIPTION="Updated config.sub and config.guess file from GNU"
@@ -20,8 +21,6 @@ HOMEPAGE="https://savannah.gnu.org/projects/config"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE=""
-
-S=${WORKDIR}
 
 maint_pkg_create() {
 	cd "${S}"
@@ -39,7 +38,7 @@ maint_pkg_create() {
 
 src_unpack() {
 	if [[ ${PV} == "99999999" ]] ; then
-		git-2_src_unpack
+		git-r3_src_unpack
 		maint_pkg_create
 	else
 		unpack ${A}
@@ -47,7 +46,7 @@ src_unpack() {
 }
 
 src_prepare() {
-	epatch "${WORKDIR}"/*.patch
+	epatch "${S}"/*.patch
 	use elibc_uclibc && sed -i 's:linux-gnu:linux-uclibc:' testsuite/config-guess.data #180637
 }
 

--- a/sys-devel/libtool/libtool-2.4.6-r3.ebuild
+++ b/sys-devel/libtool/libtool-2.4.6-r3.ebuild
@@ -10,7 +10,7 @@ inherit autotools epatch epunt-cxx multilib unpacker
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.savannah.gnu.org/${PN}.git
 		http://git.savannah.gnu.org/r/${PN}.git"
-	inherit git-2
+	inherit git-r3
 else
 	SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd"
@@ -35,7 +35,7 @@ DEPEND="${RDEPEND}
 
 src_unpack() {
 	if [[ ${PV} == "9999" ]] ; then
-		git-2_src_unpack
+		git-r3_src_unpack
 		cd "${S}"
 		./bootstrap || die
 	else

--- a/sys-devel/libtool/libtool-2.4.6-r4.ebuild
+++ b/sys-devel/libtool/libtool-2.4.6-r4.ebuild
@@ -10,7 +10,7 @@ inherit autotools epatch epunt-cxx multilib unpacker prefix
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.savannah.gnu.org/${PN}.git
 		http://git.savannah.gnu.org/r/${PN}.git"
-	inherit git-2
+	inherit git-r3
 else
 	SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
@@ -35,7 +35,7 @@ DEPEND="${RDEPEND}
 
 src_unpack() {
 	if [[ ${PV} == "9999" ]] ; then
-		git-2_src_unpack
+		git-r3_src_unpack
 		cd "${S}"
 		./bootstrap || die
 	else

--- a/sys-process/numad/numad-0.5-r1.ebuild
+++ b/sys-process/numad/numad-0.5-r1.ebuild
@@ -5,14 +5,14 @@ EAPI=5
 
 inherit linux-info toolchain-funcs eutils
 
-if [[ ${PV} = *9999* ]]; then
-	inherit git-2
-	EGIT_REPO_URI="git://git.fedorahosted.org/numad.git"
-	KEYWORDS="~amd64 -arm -s390 x86"
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="https://pagure.io/numad.git"
+	inherit git-r3
 else
-	SRC_URI="http://git.fedorahosted.org/git/?p=numad.git;a=snapshot;h=334278ff3d774d105939743436d7378a189e8693;sf=tbz2 -> numad-0.5-334278f.tar.bz2"
+	HASH="334278ff3d774d105939743436d7378a189e8693"
+	SRC_URI="mirror://gentoo/numad-0.5-${HASH:0:7}.tar.bz2"
 	KEYWORDS="amd64 -arm -s390 x86"
-	S="${WORKDIR}/${PN}-334278f"
+	S="${WORKDIR}/${PN}-${HASH:0:7}"
 fi
 
 DESCRIPTION="The NUMA daemon that manages application locality"
@@ -29,10 +29,6 @@ src_prepare() {
 		epatch
 
 	tc-export CC
-}
-
-src_configure() {
-	:
 }
 
 src_compile() {

--- a/sys-process/numad/numad-0.5-r2.ebuild
+++ b/sys-process/numad/numad-0.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,11 +6,11 @@ EAPI=5
 inherit linux-info toolchain-funcs eutils
 
 if [[ ${PV} == "9999" ]]; then
-	EGIT_REPO_URI="git://git.fedorahosted.org/numad.git"
-	inherit git-2
+	EGIT_REPO_URI="https://pagure.io/numad.git"
+	inherit git-r3
 else
 	HASH="334278ff3d774d105939743436d7378a189e8693"
-	SRC_URI="http://git.fedorahosted.org/git/?p=numad.git;a=snapshot;h=${HASH};sf=tbz2 -> numad-0.5-${HASH:0:7}.tar.bz2"
+	SRC_URI="mirror://gentoo/numad-0.5-${HASH:0:7}.tar.bz2"
 	KEYWORDS="~amd64 -arm ~arm64 -s390 ~x86"
 	S="${WORKDIR}/${PN}-${HASH:0:7}"
 fi
@@ -28,10 +28,6 @@ src_prepare() {
 	epatch "${FILESDIR}"/0001-Fix-man-page-directory-creation.patch
 	epatch "${FILESDIR}"/${PN}-0.5-ldlibs.patch #505760
 	tc-export CC
-}
-
-src_configure() {
-	:
 }
 
 src_compile() {

--- a/sys-process/numad/numad-0.5.ebuild
+++ b/sys-process/numad/numad-0.5.ebuild
@@ -1,18 +1,18 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
 
 inherit linux-info
 
-if [[ ${PV} = *9999* ]]; then
-	inherit git-2
-	EGIT_REPO_URI="git://git.fedorahosted.org/numad.git"
-	KEYWORDS="-arm -s390"
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="https://pagure.io/numad.git"
+	inherit git-r3
 else
-	SRC_URI="http://git.fedorahosted.org/git/?p=numad.git;a=snapshot;h=334278ff3d774d105939743436d7378a189e8693;sf=tbz2 -> numad-0.5-334278f.tar.bz2"
+	HASH="334278ff3d774d105939743436d7378a189e8693"
+	SRC_URI="mirror://gentoo/numad-0.5-${HASH:0:7}.tar.bz2"
 	KEYWORDS="amd64 -arm -s390 x86"
-	S="${WORKDIR}/${PN}-334278f"
+	S="${WORKDIR}/${PN}-${HASH:0:7}"
 fi
 
 DESCRIPTION="The NUMA daemon that manages application locality"
@@ -22,18 +22,11 @@ LICENSE="LGPL-2.1"
 SLOT="0"
 IUSE=""
 
-DEPEND=""
-RDEPEND="${DEPEND}"
-
 CONFIG_CHECK="~NUMA ~CPUSETS"
 
 src_prepare() {
 	EPATCH_FORCE=yes EPATCH_SUFFIX="patch" EPATCH_SOURCE="${FILESDIR}" \
 		epatch
-}
-
-src_configure() {
-	:
 }
 
 src_install() {

--- a/sys-process/numad/numad-9999.ebuild
+++ b/sys-process/numad/numad-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit linux-info toolchain-funcs eutils
 
 if [[ ${PV} == "9999" ]]; then
-	EGIT_REPO_URI="git://git.fedorahosted.org/numad.git"
-	inherit git-2
+	EGIT_REPO_URI="https://pagure.io/numad.git"
+	inherit git-r3
 else
 	SRC_URI=""
 	KEYWORDS="~amd64 ~x86 -arm -s390"
@@ -23,12 +23,7 @@ IUSE=""
 CONFIG_CHECK="~NUMA ~CPUSETS"
 
 src_prepare() {
-	epatch "${FILESDIR}"/0001-Fix-man-page-directory-creation.patch
 	tc-export CC
-}
-
-src_configure() {
-	:
 }
 
 src_compile() {

--- a/sys-process/numad/numad-9999.ebuild
+++ b/sys-process/numad/numad-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
-inherit linux-info toolchain-funcs eutils
+inherit linux-info toolchain-funcs
 
 if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="https://pagure.io/numad.git"
@@ -23,6 +23,7 @@ IUSE=""
 CONFIG_CHECK="~NUMA ~CPUSETS"
 
 src_prepare() {
+	default
 	tc-export CC
 }
 


### PR DESCRIPTION
A lot of these packages don't actually use `git-2`, but do include it in conditional code
based on `${PV}`. The intent here is to remove them so newbies looking for inspiration
from existing ebuilds do not try to use a deprecated eclass.