### PR TITLE
gnome related packages: use HTTPS

### DIFF
--- a/dev-cpp/cairomm/cairomm-1.12.0-r1.ebuild
+++ b/dev-cpp/cairomm/cairomm-1.12.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ GCONF_DEBUG="no"
 inherit gnome2 multilib-minimal
 
 DESCRIPTION="C++ bindings for the Cairo vector graphics library"
-HOMEPAGE="http://cairographics.org/cairomm"
+HOMEPAGE="https://cairographics.org/cairomm/"
 
 LICENSE="LGPL-2+"
 SLOT="0"

--- a/dev-libs/qqwing/qqwing-1.3.3.ebuild
+++ b/dev-libs/qqwing/qqwing-1.3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit autotools eutils
 
 DESCRIPTION="Sudoku puzzle generator and solver"
-HOMEPAGE="http://qqwing.com/"
+HOMEPAGE="https://qqwing.com"
 SRC_URI="https://github.com/stephenostermiller/${PN}/archive/v${PV}.tar.gz -> ${PN}-${PV}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/dev-libs/qqwing/qqwing-1.3.4.ebuild
+++ b/dev-libs/qqwing/qqwing-1.3.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils
 
 DESCRIPTION="Sudoku puzzle generator and solver"
-HOMEPAGE="http://qqwing.com/"
-SRC_URI="http://qqwing.com/${P}.tar.gz"
+HOMEPAGE="https://qqwing.com"
+SRC_URI="https://qqwing.com/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0/2"

--- a/net-libs/libdmapsharing/libdmapsharing-2.9.39.ebuild
+++ b/net-libs/libdmapsharing/libdmapsharing-2.9.39.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit gnome2
 
 DESCRIPTION="A library that implements the DMAP family of protocols"
-HOMEPAGE="http://www.flyn.org/projects/libdmapsharing"
-SRC_URI="http://www.flyn.org/projects/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.flyn.org/projects/libdmapsharing/"
+SRC_URI="https://www.flyn.org/projects/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="3.0/2"

--- a/net-libs/webkit-gtk/webkit-gtk-2.18.6.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.18.6.ebuild
@@ -10,8 +10,8 @@ inherit check-reqs cmake-utils eutils flag-o-matic gnome2 pax-utils python-any-r
 
 MY_P="webkitgtk-${PV}"
 DESCRIPTION="Open source web browser engine"
-HOMEPAGE="http://www.webkitgtk.org/"
-SRC_URI="http://www.webkitgtk.org/releases/${MY_P}.tar.xz"
+HOMEPAGE="https://www.webkitgtk.org"
+SRC_URI="https://www.webkitgtk.org/releases/${MY_P}.tar.xz"
 
 LICENSE="LGPL-2+ BSD"
 SLOT="4/37" # soname version of libwebkit2gtk-4.0

--- a/net-voip/telepathy-haze/telepathy-haze-0.8.0-r1.ebuild
+++ b/net-voip/telepathy-haze/telepathy-haze-0.8.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils python-single-r1
 
 DESCRIPTION="Telepathy connection manager providing libpurple supported protocols"
-HOMEPAGE="http://developer.pidgin.im/wiki/TelepathyHaze"
+HOMEPAGE="https://telepathy.freedesktop.org https://developer.pidgin.im/wiki/TelepathyHaze"
 SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-voip/telepathy-haze/telepathy-haze-0.8.0-r2.ebuild
+++ b/net-voip/telepathy-haze/telepathy-haze-0.8.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit python-any-r1
 
 DESCRIPTION="Telepathy connection manager providing libpurple supported protocols"
-HOMEPAGE="https://telepathy.freedesktop.org/"
+HOMEPAGE="https://telepathy.freedesktop.org https://developer.pidgin.im/wiki/TelepathyHaze"
 SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-libs/gtkglarea/gtkglarea-2.0.1-r1.ebuild
+++ b/x11-libs/gtkglarea/gtkglarea-2.0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -9,7 +9,7 @@ GNOME_TARBALL_SUFFIX="bz2"
 inherit gnome2
 
 DESCRIPTION="OpenGL canvas and context provider for GTK+"
-HOMEPAGE="http://www.mono-project.com/GtkGLArea"
+HOMEPAGE="https://www.mono-project.com/archived/gtkglarea/"
 
 LICENSE="LGPL-2+ GPL-2+" # examples are GPL-2+, library is LGPL-2+
 SLOT="2"

--- a/x11-libs/gtkglarea/gtkglarea-2.1.0.ebuild
+++ b/x11-libs/gtkglarea/gtkglarea-2.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -7,7 +7,7 @@ GCONF_DEBUG="no"
 inherit gnome2
 
 DESCRIPTION="OpenGL canvas and context provider for GTK+"
-HOMEPAGE="http://www.mono-project.com/GtkGLArea"
+HOMEPAGE="https://www.mono-project.com/archived/gtkglarea/"
 
 LICENSE="LGPL-2+ GPL-2+" # examples are GPL-2+, library is LGPL-2+
 SLOT="2"

--- a/x11-themes/zukitwo-shell/zukitwo-shell-2016.08.08.ebuild
+++ b/x11-themes/zukitwo-shell/zukitwo-shell-2016.08.08.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Transition package to zuki-themes"
-HOMEPAGE="http://gnome-look.org/content/show.php/Zukitwo?content=140562"
+HOMEPAGE="https://www.gnome-look.org/content/show.php/Zukitwo?content=140562"
 
 LICENSE="metapackage"
 SLOT="0"

--- a/x11-themes/zukitwo/zukitwo-2016.08.08.ebuild
+++ b/x11-themes/zukitwo/zukitwo-2016.08.08.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Transition package to zuki-themes"
-HOMEPAGE="http://gnome-look.org/content/show.php/Zukitwo?content=140562"
+HOMEPAGE="https://www.gnome-look.org/content/show.php/Zukitwo?content=140562"
 
 LICENSE="metapackage"
 SLOT="0"


### PR DESCRIPTION
Hi, 

This PR fixes a few gnome related packages to use https instead of http.

Please review.