### PR TITLE
sys-kernel/zen-sources: fix HOMEPAGE

### DIFF
--- a/sys-kernel/zen-sources/zen-sources-4.14.9999.ebuild
+++ b/sys-kernel/zen-sources/zen-sources-4.14.9999.ebuild
@@ -19,7 +19,7 @@ detect_version
 
 K_NOSETEXTRAVERSION="don't_set_it"
 DESCRIPTION="The Zen Kernel Live Sources"
-HOMEPAGE="https://zen-kernel.org"
+HOMEPAGE="https://github.com/zen-kernel"
 
 IUSE=""
 

--- a/sys-kernel/zen-sources/zen-sources-4.15.9999.ebuild
+++ b/sys-kernel/zen-sources/zen-sources-4.15.9999.ebuild
@@ -19,7 +19,7 @@ detect_version
 
 K_NOSETEXTRAVERSION="don't_set_it"
 DESCRIPTION="The Zen Kernel Live Sources"
-HOMEPAGE="https://zen-kernel.org"
+HOMEPAGE="https://github.com/zen-kernel"
 
 IUSE=""
 

--- a/sys-kernel/zen-sources/zen-sources-4.16.9999.ebuild
+++ b/sys-kernel/zen-sources/zen-sources-4.16.9999.ebuild
@@ -19,7 +19,7 @@ detect_version
 
 K_NOSETEXTRAVERSION="don't_set_it"
 DESCRIPTION="The Zen Kernel Live Sources"
-HOMEPAGE="https://zen-kernel.org"
+HOMEPAGE="https://github.com/zen-kernel"
 
 IUSE=""
 


### PR DESCRIPTION
Hi,

This PR fixes the HOMEPAGE of zen-sources.
https://zen-kernel.org/ -> doesn't work
http://zen-kernel.org/ -> points to the github page.
Means i changed it directly to the github page to avoid further redirections.

Please review.