### PR TITLE
dev-util/netbeans: use HTTPS, fix DEPEND

### DIFF
--- a/dev-util/netbeans/netbeans-8.2.ebuild
+++ b/dev-util/netbeans/netbeans-8.2.ebuild
@@ -5,9 +5,9 @@ EAPI="6"
 inherit eutils java-pkg-2 java-ant-2
 
 DESCRIPTION="Netbeans IDE"
-HOMEPAGE="http://netbeans.org/"
+HOMEPAGE="https://netbeans.org/"
 SLOT="8.2"
-SOURCE_URL="http://download.netbeans.org/netbeans/8.2/final/zip/netbeans-8.2-201609300101-src.zip"
+SOURCE_URL="https://download.netbeans.org/netbeans/8.2/final/zip/netbeans-8.2-201609300101-src.zip"
 PATCHES_URL="https://dev.gentoo.org/~fordfrog/distfiles/netbeans-8.2-build.xml.patch.bz2"
 L10N_URL="https://dev.gentoo.org/~fordfrog/distfiles/netbeans-l10n-8.2-20160920.tar.bz2"
 ALL_URLS="${SOURCE_URL} ${PATCHES_URL} ${L10N_URL}"
@@ -100,6 +100,7 @@ S="${WORKDIR}"
 
 CDEPEND="virtual/jdk:1.8"
 DEPEND="${CDEPEND}
+	app-arch/unzip
 	dev-java/javahelp:0"
 RDEPEND="${CDEPEND}
 	~dev-java/netbeans-harness-${PV}


### PR DESCRIPTION
Hi,

This PR fixes the package to use https instead of http.
I also added app-arch/unzip as dependency since the ebuild downloads a zip file..

Please review.