### PR TITLE
app-cdr/dvdisaster: stabilize 0.79.5

### DIFF
--- a/app-cdr/dvdisaster/dvdisaster-0.72.4.ebuild
+++ b/app-cdr/dvdisaster/dvdisaster-0.72.4.ebuild
@@ -8,7 +8,7 @@ DESCRIPTION="Data-protection and recovery tool for DVDs"
 HOMEPAGE="http://dvdisaster.sourceforge.net/"
 SRC_URI="mirror://debian/pool/main/${PN:0:1}/${PN}/${PN}_${PV}.orig.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ppc x86"
 IUSE="debug nls"

--- a/app-cdr/dvdisaster/dvdisaster-0.79.5.ebuild
+++ b/app-cdr/dvdisaster/dvdisaster-0.79.5.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils gnome2-utils toolchain-funcs
+EAPI=6
+inherit gnome2-utils toolchain-funcs
 
 DESCRIPTION="Tool for creating error correction data (ecc) for optical media (DVD, CD, BD)"
 HOMEPAGE="http://dvdisaster.net/"
@@ -10,7 +10,7 @@ SRC_URI="http://dvdisaster.net/downloads/${PN}-${PV}.tar.bz2"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~x86"
+KEYWORDS="amd64 ppc x86"
 IUSE="debug nls"
 
 dvdi_langs="cs de it pt-BR ru sv"
@@ -64,12 +64,11 @@ src_install() {
 		use l10n_${dvdi_lang} || rm -rf \
 			${dest}/doc/${PF}/${dvdi_lang/-/_} \
 			${dest}/doc/${PF}/CREDITS.${dvdi_lang/-/_} \
-			${dest}/man/${dvdi_lang/-/_}
+			${dest}/man/${dvdi_lang/-/_} || die
 	done
 
-	rm -f "${D}"usr/bin/*-uninstall.sh
+	rm -f "${D}"usr/bin/*-uninstall.sh || die
 }
 
-pkg_preinst() { gnome2_icon_savelist; }
 pkg_postinst() { gnome2_icon_cache_update; }
 pkg_postrm() { gnome2_icon_cache_update; }


### PR DESCRIPTION
stabilization of version 0.79.5
fix license for 0.72.4

Closes: https://bugs.gentoo.org/653788
Closes: https://bugs.gentoo.org/653772