### PR TITLE
net-dns/getdns: improved stubby initd/confd for logs and logrotate

### DIFF
--- a/net-dns/getdns/files/stubby.confd
+++ b/net-dns/getdns/files/stubby.confd
@@ -1,4 +1,0 @@
-# /etc/conf.d/stubby: config file for /etc/init.d/stubby
-
-# See stubby -h for possible options to put here.
-STUBBY_OPTS=""

--- a/net-dns/getdns/files/stubby.confd-r1
+++ b/net-dns/getdns/files/stubby.confd-r1
@@ -1,0 +1,16 @@
+# /etc/conf.d/stubby: config file for /etc/init.d/stubby
+
+# Enter here Stubby YAML configuration file to use.
+STUBBY_CONFIG_FILE="/etc/stubby/stubby.yml"
+
+# Set here Stubby log level to use.
+# Following log levels are available:
+#	0: EMERG  - System is unusable
+#	1: ALERT  - Action must be taken immediately
+#	2: CRIT   - Critical conditions
+#	3: ERROR  - Error conditions
+#	4: WARN   - Warning conditions
+#	5: NOTICE - Normal, but significant, condition
+#	6: INFO   - Informational message
+#	7: DEBUG  - Debug-level message
+STUBBY_LOGLEVEL="5"

--- a/net-dns/getdns/files/stubby.initd-r1
+++ b/net-dns/getdns/files/stubby.initd-r1
@@ -2,8 +2,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License, v2 or later
 
+stubby_opts="-C ${STUBBY_CONFIG_FILE:-/etc/stubby/stubby.yml} -v ${STUBBY_LOGLEVEL:-5}"
 command="capsh"
-command_args="--inh=cap_net_bind_service --user=stubby -- -c '/usr/bin/stubby -g ${STUBBY_OPTS}'"
+command_args="--inh=cap_net_bind_service --user=stubby -- -c '/usr/bin/stubby -g ${stubby_opts} >>/var/log/stubby.log 2>&1'"
 pidfile="/var/run/stubby/stubby.pid"
 name="DNS Privacy Daemon"
 
@@ -18,4 +19,5 @@ depend()
 start_pre()
 {
 	checkpath -d -m 1755 -o stubby:stubby /var/run/stubby
+	checkpath -f -m 0644 -o stubby:stubby /var/log/stubby.log
 }

--- a/net-dns/getdns/files/stubby.logrotate
+++ b/net-dns/getdns/files/stubby.logrotate
@@ -1,0 +1,7 @@
+/var/log/stubby.log {
+	rotate 4
+	compress
+	size 200k
+	noolddir
+	missingok
+}

--- a/net-dns/getdns/getdns-1.4.1-r2.ebuild
+++ b/net-dns/getdns/getdns-1.4.1-r2.ebuild
@@ -50,8 +50,10 @@ src_configure() {
 src_install() {
 	default
 	if use stubby; then
-		newinitd "${FILESDIR}"/stubby.initd stubby
-		newconfd "${FILESDIR}"/stubby.confd stubby
+		newinitd "${FILESDIR}"/stubby.initd-r1 stubby
+		newconfd "${FILESDIR}"/stubby.confd-r1 stubby
+		insinto /etc/logrotate.d
+		newins "${FILESDIR}"/stubby.logrotate stubby
 		systemd_newunit "${FILESDIR}"/stubby.systemd stubby.service
 		systemd_newtmpfilesd "${FILESDIR}"/stubby.tmpfilesd stubby.conf
 	fi


### PR DESCRIPTION
Stubby manage logs via command args only and print logs only on stdout and stderr.
I have improved stubby initd and confd to manage log level and redirecting them to file /var/log/stubby.log rotated with logrotate.

CC @blueness 