### PR TITLE
www-servers/h2o: drop support for Ruby 2.2 (masked for removal)

### DIFF
--- a/www-servers/h2o/h2o-2.2.4.ebuild
+++ b/www-servers/h2o/h2o-2.2.4.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-USE_RUBY="ruby22 ruby23 ruby24"
+USE_RUBY="ruby23 ruby24"
 
 inherit cmake-utils ruby-single systemd user
 

--- a/www-servers/h2o/h2o-9999.ebuild
+++ b/www-servers/h2o/h2o-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-USE_RUBY="ruby22 ruby23 ruby24"
+USE_RUBY="ruby23 ruby24"
 
 inherit cmake-utils git-r3 ruby-single systemd user
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.24, Repoman-2.3.6