### PR TITLE
net-im/signal-desktop-bin: requires libXss.so

### DIFF
--- a/net-im/signal-desktop-bin/signal-desktop-bin-1.8.0.ebuild
+++ b/net-im/signal-desktop-bin/signal-desktop-bin-1.8.0.ebuild
@@ -20,6 +20,7 @@ RESTRICT="bindist mirror"
 RDEPEND="
 	gnome-base/gconf:2
 	dev-libs/nss
+	x11-libs/libXScrnSaver
 	x11-libs/libXtst
 	net-print/cups
 	ayatana? ( dev-libs/libappindicator:3 )


### PR DESCRIPTION
"net-im/signal-desktop-bin" requires "libXss.so.1" and can't find this library.
We need to add "x11-libs/libXScrnSaver" into required dependencies to solve this issue.

Package-Manager: Portage 2.3.24