### PR TITLE
media-libs/libsdl2: enable cocoa on osx

### DIFF
--- a/media-libs/libsdl2/libsdl2-2.0.8-r1.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.0.8-r1.ebuild
@@ -13,7 +13,7 @@ LICENSE="ZLIB"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ia64 ~ppc ~ppc64 ~sparc x86"
 
-IUSE="cpu_flags_x86_3dnow alsa altivec custom-cflags dbus gles haptic libsamplerate +joystick cpu_flags_x86_mmx nas opengl oss pulseaudio +sound cpu_flags_x86_sse cpu_flags_x86_sse2 static-libs +threads tslib udev +video wayland X xinerama xscreensaver"
+IUSE="cpu_flags_x86_3dnow alsa altivec aqua custom-cflags dbus gles haptic libsamplerate +joystick cpu_flags_x86_mmx nas opengl oss pulseaudio +sound cpu_flags_x86_sse cpu_flags_x86_sse2 static-libs +threads tslib udev +video wayland X xinerama xscreensaver"
 REQUIRED_USE="
 	alsa? ( sound )
 	gles? ( video )
@@ -133,7 +133,7 @@ multilib_src_configure() {
 		$(use_enable xscreensaver video-x11-scrnsaver)
 		$(use_enable X video-x11-xshape)
 		$(use_enable X video-x11-vm)
-		--disable-video-cocoa
+		$(use_enable aqua video-cocoa)
 		--disable-video-directfb
 		--disable-fusionsound
 		--disable-fusionsound-shared


### PR DESCRIPTION
Required for building on osx prefix, otherwise you get the following
build failures:

```
Undefined symbols for architecture x86_64:
  "_Cocoa_IsWindowInFullscreenSpace", referenced from:
      _SDL_UpdateFullscreenMode in SDL_video.o
      _SDL_OnWindowFocusLost in SDL_video.o
  "_Cocoa_Mtl_AddMetalView", referenced from:
      _METAL_CreateRenderer in SDL_render_metal.o
  "_Cocoa_SetWindowFullscreenSpace", referenced from:
      _SDL_UpdateFullscreenMode in SDL_video.o
ld: symbol(s) not found for architecture x86_64
```
Package-Manager: Portage-2.3.31, Repoman-2.3.9