### PR TITLE
app-emulation/lxc: fix compilation error with static libcap

### DIFF
--- a/app-emulation/lxc/files/lxc-3.0.0-static-libcap.patch
+++ b/app-emulation/lxc/files/lxc-3.0.0-static-libcap.patch
@@ -1,0 +1,72 @@
+From 49bc916b1daa79cffe38fae32059bcdd985c8c8e Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Sat, 7 Apr 2018 15:48:46 +0200
+Subject: [PATCH] Fix compilation with static libcap and shared gnutls
+
+Commit c06ed219c47098f34485d408410b6ecc94a40877 has broken
+compilation with a static libcap and a shared gnutls.
+This results in a build failure on init_lxc_static if gnutls is
+a shared library as init_lxc_static is built with -all-static option
+(see src/lxc/Makefile.am) and AC_CHECK_LIB adds gnutls to LIBS.
+
+This commit fix the issue by removing default behavior of AC_CHECK_LIB
+and handling manually GNUTLS_LIBS and HAVE_LIBGNUTLS
+
+Fixes:
+ - http://autobuild.buildroot.net/results/b655d6853c25a195df28d91512b3ffb6c654fc90
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+---
+ configure.ac        | 2 +-
+ src/lxc/Makefile.am | 8 ++++++--
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 50c99836..2467bb54 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -263,7 +263,7 @@ AM_CONDITIONAL([ENABLE_GNUTLS], [test "x$enable_gnutls" = "xyes"])
+ 
+ AM_COND_IF([ENABLE_GNUTLS],
+ 	[AC_CHECK_HEADER([gnutls/gnutls.h],[],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
+-	AC_CHECK_LIB([gnutls], [gnutls_hash_fast],[],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
++	AC_CHECK_LIB([gnutls], [gnutls_hash_fast],[true],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
+ 	AC_SUBST([GNUTLS_LIBS], [-lgnutls])])
+ 
+ # SELinux
+diff --git a/src/lxc/Makefile.am b/src/lxc/Makefile.am
+index c8d76836..0662d83d 100644
+--- a/src/lxc/Makefile.am
++++ b/src/lxc/Makefile.am
+@@ -175,6 +175,10 @@ if ENABLE_APPARMOR
+ AM_CFLAGS += -DHAVE_APPARMOR
+ endif
+ 
++if ENABLE_GNUTLS
++AM_CFLAGS += -DHAVE_LIBGNUTLS
++endif
++
+ if ENABLE_SELINUX
+ AM_CFLAGS += -DHAVE_SELINUX
+ endif
+@@ -196,7 +200,7 @@ liblxc_la_LDFLAGS = \
+ 	-Wl,-soname,liblxc.so.$(firstword $(subst ., ,@LXC_ABI@)) \
+ 	-version-info @LXC_ABI_MAJOR@
+ 
+-liblxc_la_LIBADD = $(CAP_LIBS) $(SELINUX_LIBS) $(SECCOMP_LIBS)
++liblxc_la_LIBADD = $(CAP_LIBS) $(GNUTLS_LIBS) $(SELINUX_LIBS) $(SECCOMP_LIBS)
+ 
+ bin_SCRIPTS=
+ 
+@@ -243,7 +247,7 @@ AM_LDFLAGS = -Wl,-E
+ if ENABLE_RPATH
+ AM_LDFLAGS += -Wl,-rpath -Wl,$(libdir)
+ endif
+-LDADD=liblxc.la @CAP_LIBS@ @SELINUX_LIBS@ @SECCOMP_LIBS@
++LDADD=liblxc.la @CAP_LIBS@ @GNUTLS_LIBS@ @SELINUX_LIBS@ @SECCOMP_LIBS@
+ 
+ if ENABLE_TOOLS
+ lxc_attach_SOURCES = tools/lxc_attach.c tools/arguments.c tools/tool_utils.c
+-- 
+2.16.1
+

--- a/app-emulation/lxc/lxc-3.0.0.ebuild
+++ b/app-emulation/lxc/lxc-3.0.0.ebuild
@@ -96,6 +96,7 @@ pkg_setup() {
 
 src_prepare() {
 	eapply "${FILESDIR}"/${PN}-3.0.0-bash-completion.patch
+	eapply "${FILESDIR}"/${PN}-3.0.0-static-libcap.patch
 	#558854
 	eapply "${FILESDIR}"/${PN}-2.0.5-omit-sysconfig.patch
 	eapply_user


### PR DESCRIPTION
The fix was already upstream, applying it as patch.

Closes: https://bugs.gentoo.org/654210
Package-Manager: Portage-2.3.24, Repoman-2.3.6