### PR TITLE
net-misc/csync, x11-libs/libdockapp, x11-plugins/*: use HTTPS

### DIFF
--- a/net-misc/csync/csync-0.50.0.ebuild
+++ b/net-misc/csync/csync-0.50.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="lightweight file synchronizer utility"
-HOMEPAGE="http://csync.org/"
+HOMEPAGE="https://www.csync.org/"
 SRC_URI="https://open.cryptomilk.org/attachments/download/27/${P}.tar.xz"
 
 LICENSE="GPL-2"

--- a/x11-libs/libdockapp/libdockapp-0.7.2.ebuild
+++ b/x11-libs/libdockapp/libdockapp-0.7.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools font
 
 DESCRIPTION="Window Maker Dock Applet Library"
-HOMEPAGE="http://www.dockapps.net/libdockapp"
+HOMEPAGE="https://www.dockapps.net/libdockapp"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="MIT public-domain"

--- a/x11-plugins/cputnik/cputnik-0.2.0.ebuild
+++ b/x11-plugins/cputnik/cputnik-0.2.0.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit eutils toolchain-funcs
 
 DESCRIPTION="cputnik is a simple cpu monitor dockapp"
-HOMEPAGE="http://www.dockapps.net/cputnik"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/cputnik"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmSun/wmSun-1.05.ebuild
+++ b/x11-plugins/wmSun/wmSun-1.05.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ inherit eutils multilib toolchain-funcs
 
 MY_P=${P/S/s}
 DESCRIPTION="dockapp which displays the rise/set time of the sun"
-HOMEPAGE="http://www.dockapps.net/wmsun"
+HOMEPAGE="https://www.dockapps.net/wmsun"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmacpi/wmacpi-2.3.ebuild
+++ b/x11-plugins/wmacpi/wmacpi-2.3.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="DockApp ACPI status monitor for laptops"
-HOMEPAGE="http://www.dockapps.net/wmacpi"
+HOMEPAGE="https://www.dockapps.net/wmacpi"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmail/wmail-2.0-r4.ebuild
+++ b/x11-plugins/wmail/wmail-2.0-r4.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils
 
 DESCRIPTION="Window Maker dock application showing incoming mail"
-HOMEPAGE="http://www.dockapps.net/wmail"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmail"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmbattery/wmbattery-2.50.ebuild
+++ b/x11-plugins/wmbattery/wmbattery-2.50.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools
 
 DESCRIPTION="A dockable app to report APM, ACPI, or SPIC battery status"
-HOMEPAGE="http://www.dockapps.net/wmbattery"
+HOMEPAGE="https://www.dockapps.net/wmbattery"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmbattery/wmbattery-2.51.ebuild
+++ b/x11-plugins/wmbattery/wmbattery-2.51.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools
 
 DESCRIPTION="A dockable app to report APM, ACPI, or SPIC battery status"
-HOMEPAGE="http://www.dockapps.net/wmbattery"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmbattery"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmbiff/wmbiff-0.4.28.ebuild
+++ b/x11-plugins/wmbiff/wmbiff-0.4.28.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools eutils
 
 DESCRIPTION="WMBiff is a dock applet for WindowMaker which can monitor up to 5 mailboxes"
-HOMEPAGE="http://www.dockapps.net/wmbiff"
+HOMEPAGE="https://www.dockapps.net/wmbiff"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmbiff/wmbiff-0.4.30.ebuild
+++ b/x11-plugins/wmbiff/wmbiff-0.4.30.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools eutils
 
 DESCRIPTION="WMBiff is a dock applet for WindowMaker which can monitor up to 5 mailboxes"
-HOMEPAGE="http://www.dockapps.net/wmbiff"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmbiff"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmbiff/wmbiff-0.4.31.ebuild
+++ b/x11-plugins/wmbiff/wmbiff-0.4.31.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools eutils
 
 DESCRIPTION="WMBiff is a dock applet for WindowMaker which can monitor up to 5 mailboxes"
-HOMEPAGE="http://www.dockapps.net/wmbiff"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmbiff"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmbutton/wmbutton-0.7.0.ebuild
+++ b/x11-plugins/wmbutton/wmbutton-0.7.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="a dockapp application that displays nine configurable buttons"
-HOMEPAGE="http://www.dockapps.net/wmbutton"
+HOMEPAGE="https://www.dockapps.net/wmbutton"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz
 	branding? ( mirror://gentoo/${PN}-buttons.xpm )"
 

--- a/x11-plugins/wmbutton/wmbutton-0.7.1.ebuild
+++ b/x11-plugins/wmbutton/wmbutton-0.7.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="a dockapp application that displays nine configurable buttons"
-HOMEPAGE="http://www.dockapps.net/wmbutton"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmbutton"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmcalc/wmcalc-0.6.ebuild
+++ b/x11-plugins/wmcalc/wmcalc-0.6.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="A WindowMaker DockApp calculator"
-HOMEPAGE="http://www.dockapps.net/wmcalc"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmcalc"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmcdplay/wmcdplay-1.0_beta1.ebuild
+++ b/x11-plugins/wmcdplay/wmcdplay-1.0_beta1.ebuild
@@ -11,8 +11,8 @@ MY_P=${P/_beta/-beta}
 S=${WORKDIR}/${PN}
 
 DESCRIPTION="CD player applet for WindowMaker"
-SRC_URI="http://www.dockapps.net/download/${MY_P}.tgz"
-HOMEPAGE="http://www.dockapps.net/wmcdplay"
+SRC_URI="https://www.dockapps.net/download/${MY_P}.tgz"
+HOMEPAGE="https://www.dockapps.net/wmcdplay"
 
 RDEPEND="x11-libs/libX11
 	x11-libs/libXext

--- a/x11-plugins/wmcdplay/wmcdplay-1.1.ebuild
+++ b/x11-plugins/wmcdplay/wmcdplay-1.1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools
 
 DESCRIPTION="CD player applet for WindowMaker"
-HOMEPAGE="http://www.dockapps.net/wmcdplay"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmcdplay"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmcliphist/wmcliphist-2.1-r1.ebuild
+++ b/x11-plugins/wmcliphist/wmcliphist-2.1-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="Dockable clipboard history application for Window Maker"
-HOMEPAGE="http://www.dockapps.net/wmcliphist"
+HOMEPAGE="https://www.dockapps.net/wmcliphist"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmcliphist/wmcliphist-2.1-r2.ebuild
+++ b/x11-plugins/wmcliphist/wmcliphist-2.1-r2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="Dockable clipboard history application for Window Maker"
-HOMEPAGE="http://www.dockapps.net/wmcliphist"
+HOMEPAGE="https://www.dockapps.net/wmcliphist"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmcliphist/wmcliphist-2.1.ebuild
+++ b/x11-plugins/wmcliphist/wmcliphist-2.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="Dockable clipboard history application for Window Maker"
-HOMEPAGE="http://www.dockapps.net/wmcliphist"
+HOMEPAGE="https://www.dockapps.net/wmcliphist"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmclock/wmclock-1.0.16.ebuild
+++ b/x11-plugins/wmclock/wmclock-1.0.16.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools
 
 DESCRIPTION="a dockapp that displays time and date (same style as NEXTSTEP(tm) OS)"
-HOMEPAGE="http://www.dockapps.net/wmclock"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmclock"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmcp/wmcp-1.2.8.ebuild
+++ b/x11-plugins/wmcp/wmcp-1.2.8.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit eutils multilib toolchain-funcs
 
 DESCRIPTION="A pager dockapp"
-HOMEPAGE="http://www.dockapps.net/wmcp"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmcp"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmcpuload/wmcpuload-1.1.0_pre5.ebuild
+++ b/x11-plugins/wmcpuload/wmcpuload-1.1.0_pre5.ebuild
@@ -4,7 +4,7 @@
 EAPI=0
 
 DESCRIPTION="a dockapp for monitoring CPU usage with a LCD display"
-HOMEPAGE="http://dockapps.windowmaker.org/file.php/id/36"
+HOMEPAGE="https://www.dockapps.net/wmcpuload"
 SRC_URI="mirror://gentoo/${P/_/}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmcpuload/wmcpuload-1.1.1.ebuild
+++ b/x11-plugins/wmcpuload/wmcpuload-1.1.1.ebuild
@@ -4,8 +4,8 @@
 EAPI=6
 
 DESCRIPTION="a dockapp for monitoring CPU usage with a LCD display"
-HOMEPAGE="http://www.dockapps.net/wmcpuload"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmcpuload"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmdots/wmdots-0.2_beta.ebuild
+++ b/x11-plugins/wmdots/wmdots-0.2_beta.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit eutils multilib toolchain-funcs
 
 DESCRIPTION="multishape 3d rotating dots"
-HOMEPAGE="http://www.dockapps.net/wmdots"
-SRC_URI="http://www.dockapps.net/download/${P/_}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmdots"
+SRC_URI="https://www.dockapps.net/download/${P/_}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmfsm/wmfsm-0.36.ebuild
+++ b/x11-plugins/wmfsm/wmfsm-0.36.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ inherit autotools
 
 IUSE=""
 DESCRIPTION="dockapp for monitoring filesystem usage"
-HOMEPAGE="http://www.dockapps.net/wmfsm"
+HOMEPAGE="https://www.dockapps.net/wmfsm"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmget/wmget-0.6.1.ebuild
+++ b/x11-plugins/wmget/wmget-0.6.1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools
 
 DESCRIPTION="a libcurl based dockapp for automated downloads"
-HOMEPAGE="http://www.dockapps.net/wmget"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmget"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/x11-plugins/wmgtemp/wmgtemp-1.2.ebuild
+++ b/x11-plugins/wmgtemp/wmgtemp-1.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="CPU and SYS temperature dockapp"
-HOMEPAGE="http://www.dockapps.net/wmgtemp"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmgtemp"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="Artistic"
 SLOT="0"

--- a/x11-plugins/wmhdplop/wmhdplop-0.9.10.ebuild
+++ b/x11-plugins/wmhdplop/wmhdplop-0.9.10.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools
 
 DESCRIPTION="a dockapp for monitoring disk activities with fancy visuals"
-HOMEPAGE="http://www.dockapps.net/wmhdplop"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmhdplop"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmifinfo/wmifinfo-0.10.ebuild
+++ b/x11-plugins/wmifinfo/wmifinfo-0.10.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="a dockapp for monitoring network interfaces"
-HOMEPAGE="http://www.dockapps.net/wmifinfo"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmifinfo"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmifs/wmifs-1.8.ebuild
+++ b/x11-plugins/wmifs/wmifs-1.8.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Network monitoring dockapp"
-HOMEPAGE="http://www.dockapps.net/wmifs"
+HOMEPAGE="https://www.dockapps.net/wmifs"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmitime/wmitime-0.5.ebuild
+++ b/x11-plugins/wmitime/wmitime-0.5.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="Overglorified clock dockapp w/time, date, and internet time"
-HOMEPAGE="http://www.dockapps.net/wmitime"
+HOMEPAGE="https://www.dockapps.net/wmitime"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmix/wmix-3.2.ebuild
+++ b/x11-plugins/wmix/wmix-3.2.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="Dockapp mixer for OSS or ALSA"
-HOMEPAGE="http://www.dockapps.net/wmix"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmix"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmix/wmix-3.3.ebuild
+++ b/x11-plugins/wmix/wmix-3.3.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="Dockapp mixer for OSS or ALSA"
-HOMEPAGE="http://www.dockapps.net/wmix"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmix"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmload/wmload-0.9.7.ebuild
+++ b/x11-plugins/wmload/wmload-0.9.7.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="yet another dock application showing a system load gauge"
-HOMEPAGE="http://www.dockapps.net/wmload"
+HOMEPAGE="https://www.dockapps.net/wmload"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmlongrun/wmlongrun-0.3.1.ebuild
+++ b/x11-plugins/wmlongrun/wmlongrun-0.3.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="A dockapp to monitor LongRun on a Transmeta Crusoe processor"
-HOMEPAGE="http://www.dockapps.net/wmlongrun"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmlongrun"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmmemload/wmmemload-0.1.8.ebuild
+++ b/x11-plugins/wmmemload/wmmemload-0.1.8.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools eutils
 
 DESCRIPTION="dockapp that displays memory and swap space usage"
-HOMEPAGE="http://www.dockapps.net/wmmemload"
+HOMEPAGE="https://www.dockapps.net/wmmemload"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmmenu/wmmenu-1.3-r1.ebuild
+++ b/x11-plugins/wmmenu/wmmenu-1.3-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="a popup menu of icons like in AfterStep, as a dockapp"
-HOMEPAGE="http://www.dockapps.net/wmmenu"
+HOMEPAGE="https://www.dockapps.net/wmmenu"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmmixer/wmmixer-1.8.ebuild
+++ b/x11-plugins/wmmixer/wmmixer-1.8.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="A mixer designed for WindowMaker"
-HOMEPAGE="http://www.dockapps.net/wmmon"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmmon"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmmoonclock/wmmoonclock-1.27-r1.ebuild
+++ b/x11-plugins/wmmoonclock/wmmoonclock-1.27-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit eutils multilib toolchain-funcs
 
 DESCRIPTION="dockapp that shows lunar ephemeris to a high accuracy"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
-HOMEPAGE="http://www.dockapps.net/wmmoonclock"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmmoonclock"
 
 RDEPEND="x11-libs/libX11
 	x11-libs/libXext

--- a/x11-plugins/wmmoonclock/wmmoonclock-1.29.ebuild
+++ b/x11-plugins/wmmoonclock/wmmoonclock-1.29.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="dockapp that shows lunar ephemeris to a high accuracy"
-HOMEPAGE="http://www.dockapps.net/wmmoonclock"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmmoonclock"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmpop3/wmpop3-0.5.6a-r1.ebuild
+++ b/x11-plugins/wmpop3/wmpop3-0.5.6a-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit eutils toolchain-funcs
 
 DESCRIPTION="dockapp for checking pop3 accounts"
-HOMEPAGE="http://www.dockapps.net/wmpop3"
-SRC_URI="http://www.dockapps.net/download/${P/wmpop3/WMPop3}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmpop3"
+SRC_URI="https://www.dockapps.net/download/${P/wmpop3/WMPop3}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmswallow/wmswallow-0.6.1-r1.ebuild
+++ b/x11-plugins/wmswallow/wmswallow-0.6.1-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="A dock applet to make any application dockable"
-HOMEPAGE="http://www.dockapps.net/wmswallow"
-SRC_URI="http://www.dockapps.net/download/${PN}.tar.Z"
+HOMEPAGE="https://www.dockapps.net/wmswallow"
+SRC_URI="https://www.dockapps.net/download/${PN}.tar.Z"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmtime/wmtime-1.4.ebuild
+++ b/x11-plugins/wmtime/wmtime-1.4.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="applet which displays the date and time in a dockable tile"
-HOMEPAGE="http://www.dockapps.net/wmtime"
+HOMEPAGE="https://www.dockapps.net/wmtime"
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmtop/wmtop-0.85.ebuild
+++ b/x11-plugins/wmtop/wmtop-0.85.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools
 
 DESCRIPTION="dockapp for monitoring the top three processes using cpu or memory"
-HOMEPAGE="http://www.dockapps.net/wmtop"
-SRC_URI="http://www.dockapps.net/download/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmtop"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmtz/wmtz-0.7_p20150816.ebuild
+++ b/x11-plugins/wmtz/wmtz-0.7_p20150816.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit multilib toolchain-funcs
 
 DESCRIPTION="dockapp that shows the time in multiple timezones"
-HOMEPAGE="http://www.dockapps.net/wmtz"
-# http://www.dockapps.net/download/${P}.tar.gz
+HOMEPAGE="https://www.dockapps.net/wmtz"
+# https://www.dockapps.net/download/${P}.tar.gz
 SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/x11-plugins/wmweather+/wmweather+-2.13.ebuild
+++ b/x11-plugins/wmweather+/wmweather+-2.13.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
 inherit flag-o-matic
 
 DESCRIPTION="A dockapp for displaying data collected from METAR, AVN, ETA, and MRF forecasts"
-HOMEPAGE="http://www.sourceforge.net/projects/wmweatherplus/"
+HOMEPAGE="https://www.sourceforge.net/projects/wmweatherplus/"
 SRC_URI="mirror://sourceforge/wmweatherplus/${P}.tar.gz"
 
 SLOT="0"

--- a/x11-plugins/wmweather+/wmweather+-2.15.ebuild
+++ b/x11-plugins/wmweather+/wmweather+-2.15.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit flag-o-matic
 
 DESCRIPTION="A dockapp for displaying data collected from METAR, AVN, ETA, and MRF forecasts"
-HOMEPAGE="http://www.sourceforge.net/projects/wmweatherplus/"
+HOMEPAGE="https://www.sourceforge.net/projects/wmweatherplus/"
 SRC_URI="mirror://sourceforge/wmweatherplus/${P}.tar.gz"
 
 SLOT="0"

--- a/x11-plugins/wmweather+/wmweather+-2.16.ebuild
+++ b/x11-plugins/wmweather+/wmweather+-2.16.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="A dockapp for displaying data collected from METAR, AVN, ETA, and MRF forecasts"
-HOMEPAGE="http://www.sourceforge.net/projects/wmweatherplus/"
+HOMEPAGE="https://www.sourceforge.net/projects/wmweatherplus/"
 SRC_URI="mirror://sourceforge/wmweatherplus/${P}.tar.gz"
 
 SLOT="0"

--- a/x11-plugins/wmweather+/wmweather+-2.17.ebuild
+++ b/x11-plugins/wmweather+/wmweather+-2.17.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="A dockapp for displaying data collected from METAR, AVN, ETA, and MRF forecasts"
-HOMEPAGE="http://www.sourceforge.net/projects/wmweatherplus/"
+HOMEPAGE="https://www.sourceforge.net/projects/wmweatherplus/"
 SRC_URI="mirror://sourceforge/wmweatherplus/${P}.tar.gz"
 
 SLOT="0"


### PR DESCRIPTION
Hi,

Another few packages to fix http -> https. ;)
SRC_URI changes were all testet.

Please review.

