### PR TITLE
media-video/mpv: fix CUDA HW decoding in 9999

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -119,6 +119,7 @@ DEPEND="${COMMON_DEPEND}
 	${PYTHON_DEPS}
 	dev-python/docutils
 	virtual/pkgconfig
+	cuda? ( >=media-libs/nv-codec-headers-8.1.24.1 )
 	doc? ( dev-python/rst2pdf )
 	dvb? ( virtual/linuxtv-dvb-headers )
 	test? ( >=dev-util/cmocka-1.0.0 )


### PR DESCRIPTION
@kkkrackpot, if you could test this, it would be great. It builds at least.