### PR TITLE
media-video/motion: Fix build errors with FFmpeg 4.0

### DIFF
--- a/media-video/motion/files/4.1.1/Fix-build-errors-with-FFmpeg-4.0.patch
+++ b/media-video/motion/files/4.1.1/Fix-build-errors-with-FFmpeg-4.0.patch
@@ -1,0 +1,54 @@
+From 9a9e918ec819277c6c5c2f21b52dd63570e426a7 Mon Sep 17 00:00:00 2001
+From: James Cowgill <jcowgill@users.noreply.github.com>
+Date: Sun, 25 Feb 2018 20:13:57 +0000
+Subject: [PATCH] Fix build errors with FFmpeg 4.0
+
+---
+ ffmpeg.c | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/ffmpeg.c b/ffmpeg.c
+index b2780bb..23644db 100644
+--- a/ffmpeg.c
++++ b/ffmpeg.c
+@@ -67,6 +67,19 @@
+ 
+ #endif
+ 
++/*********************************************/
++#if (LIBAVCODEC_VERSION_MAJOR >= 57)
++
++#define MY_CODEC_FLAG_GLOBAL_HEADER AV_CODEC_FLAG_GLOBAL_HEADER
++#define MY_CODEC_FLAG_QSCALE        AV_CODEC_FLAG_QSCALE
++
++#else
++
++#define MY_CODEC_FLAG_GLOBAL_HEADER CODEC_FLAG_GLOBAL_HEADER
++#define MY_CODEC_FLAG_QSCALE        CODEC_FLAG_QSCALE
++
++#endif
++
+ /*********************************************/
+ AVFrame *my_frame_alloc(void){
+     AVFrame *pic;
+@@ -538,7 +551,7 @@ static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
+         /* The selection of 8000 in the else is a subjective number based upon viewing output files */
+         if (ffmpeg->vbr > 0){
+             ffmpeg->vbr =(int)(((100-ffmpeg->vbr)*(100-ffmpeg->vbr)*(100-ffmpeg->vbr) * 8000) / 1000000) + 1;
+-            ffmpeg->ctx_codec->flags |= CODEC_FLAG_QSCALE;
++            ffmpeg->ctx_codec->flags |= MY_CODEC_FLAG_QSCALE;
+             ffmpeg->ctx_codec->global_quality=ffmpeg->vbr;
+         }
+     }
+@@ -663,7 +676,7 @@ static int ffmpeg_set_codec(struct ffmpeg *ffmpeg){
+       ffmpeg->ctx_codec->strict_std_compliance = -2;
+       ffmpeg->ctx_codec->level = 3;
+     }
+-    ffmpeg->ctx_codec->flags |= CODEC_FLAG_GLOBAL_HEADER;
++    ffmpeg->ctx_codec->flags |= MY_CODEC_FLAG_GLOBAL_HEADER;
+ 
+     retcd = ffmpeg_set_quality(ffmpeg);
+     if (retcd < 0){
+-- 
+2.16.2
+

--- a/media-video/motion/motion-4.1.1-r1.ebuild
+++ b/media-video/motion/motion-4.1.1-r1.ebuild
@@ -1,0 +1,94 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit autotools readme.gentoo-r1 systemd user
+
+DESCRIPTION="A software motion detector"
+HOMEPAGE="https://motion-project.github.io"
+SRC_URI="https://github.com/Motion-Project/${PN}/archive/release-${PV}.tar.gz -> ${PN}-release-${PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="ffmpeg libav mmal mysql postgres sqlite v4l webp"
+
+RDEPEND="
+	virtual/jpeg:=
+	ffmpeg? (
+		libav? ( media-video/libav:= )
+		!libav? ( media-video/ffmpeg:0= )
+	)
+	mmal? ( media-libs/raspberrypi-userland )
+	mysql? ( virtual/mysql )
+	postgres? ( dev-db/postgresql:= )
+	sqlite? ( dev-db/sqlite:3 )
+	webp? ( media-libs/libwebp:= )
+"
+DEPEND="${RDEPEND}
+	v4l? (
+		media-libs/libv4l
+		virtual/os-headers
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PV}/Fix-build-errors-with-FFmpeg-4.0.patch
+)
+
+DISABLE_AUTOFORMATTING="yes"
+DOC_CONTENTS="
+You need to setup /etc/motion/motion.conf before running motion for the
+first time. You can use /etc/motion/motion-dist.conf as a template.
+Please note that the 'daemon' and 'process_id_file' settings are
+overridden by the bundled OpenRC init script and systemd unit where
+appropriate.
+
+To install motion as a service, use:
+rc-update add motion default # with OpenRC
+systemctl enable motion.service # with systemd
+"
+
+S="${WORKDIR}"/${PN}-release-${PV}
+
+pkg_setup() {
+	enewuser ${PN} -1 -1 -1 video
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_with ffmpeg) \
+		$(use_with mmal) \
+		$(use_with mysql) \
+		$(use_with postgres pgsql) \
+		$(use_with sqlite sqlite3) \
+		$(use_with v4l v4l2) \
+		$(use_with webp) \
+		--without-optimizecpu
+}
+
+src_install() {
+	emake \
+		DESTDIR="${D}" \
+		docdir=/usr/share/doc/${PF} \
+		examplesdir=/usr/share/doc/${PF}/examples \
+		install
+
+	newinitd "${FILESDIR}"/${PN}.initd-r3 ${PN}
+	newconfd "${FILESDIR}"/${PN}.confd-r1 ${PN}
+
+	systemd_dounit "${FILESDIR}"/${PN}.service
+	systemd_dotmpfilesd "${FILESDIR}"/${PN}.conf
+
+	keepdir /var/lib/motion
+	fowners motion:video /var/lib/motion
+	fperms 0750 /var/lib/motion
+
+	readme.gentoo_create_doc
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/654416