### PR TITLE
app-shells/mpv-bash-completion: add ~x86 keyword

### DIFF
--- a/app-shells/mpv-bash-completion/mpv-bash-completion-3.3.16.ebuild
+++ b/app-shells/mpv-bash-completion/mpv-bash-completion-3.3.16.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/2ion/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="amd64"
+KEYWORDS="amd64 ~x86"
 IUSE="luajit"
 
 COMMON_DEPEND=">=media-video/mpv-0.25.0[cli]"


### PR DESCRIPTION
Builds and works. Tested by me in a stable x86 chroot.

Package-Manager: Portage-2.3.31, Repoman-2.3.9