### PR TITLE
app-emulation/libguestfs: Add eclass eutils

### DIFF
--- a/app-emulation/libguestfs/libguestfs-1.36.13.ebuild
+++ b/app-emulation/libguestfs/libguestfs-1.36.13.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python{2_7,3_{4,5}} )
 
-inherit autotools linux-info perl-functions python-single-r1 versionator
+inherit eutils autotools linux-info perl-functions python-single-r1 versionator
 
 MY_PV_1="$(get_version_component_range 1-2)"
 MY_PV_2="$(get_version_component_range 2)"


### PR DESCRIPTION
Without the eutils, in the installation phase, the error occurs: "strip-linguas: command not fount".