### PR TITLE
sys-auth/{pam-afs-session,pam_krb5}: use HTTPS, fix SRC_URI

### DIFF
--- a/sys-auth/pam-afs-session/pam-afs-session-1.3.ebuild
+++ b/sys-auth/pam-afs-session/pam-afs-session-1.3.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit pam
 
 DESCRIPTION="OpenAFS PAM Module"
-HOMEPAGE="http://www.eyrie.org/~eagle/software/pam-afs-session/"
-SRC_URI="http://archives.eyrie.org/software/afs/${P}.tar.gz"
+HOMEPAGE="https://www.eyrie.org/~eagle/software/pam-afs-session/"
+SRC_URI="https://archives.eyrie.org/software/ARCHIVE/${PN}/${P}.tar.gz"
 
 LICENSE="HPND openafs-krb5-a"
 SLOT="0"

--- a/sys-auth/pam-afs-session/pam-afs-session-1.5.ebuild
+++ b/sys-auth/pam-afs-session/pam-afs-session-1.5.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit pam
 
 DESCRIPTION="OpenAFS PAM Module"
-HOMEPAGE="http://www.eyrie.org/~eagle/software/pam-afs-session/"
-SRC_URI="http://archives.eyrie.org/software/afs/${P}.tar.gz"
+HOMEPAGE="https://www.eyrie.org/~eagle/software/pam-afs-session/"
+SRC_URI="https://archives.eyrie.org/software/ARCHIVE/${PN}/${P}.tar.gz"
 
 LICENSE="HPND openafs-krb5-a"
 SLOT="0"

--- a/sys-auth/pam-afs-session/pam-afs-session-1.6.ebuild
+++ b/sys-auth/pam-afs-session/pam-afs-session-1.6.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit pam
 
 DESCRIPTION="OpenAFS PAM Module"
-HOMEPAGE="http://www.eyrie.org/~eagle/software/pam-afs-session/"
-SRC_URI="http://archives.eyrie.org/software/afs/${P}.tar.gz"
+HOMEPAGE="https://www.eyrie.org/~eagle/software/pam-afs-session/"
+SRC_URI="https://archives.eyrie.org/software/ARCHIVE/${PN}/${P}.tar.gz"
 
 LICENSE="HPND openafs-krb5-a"
 SLOT="0"

--- a/sys-auth/pam_krb5/pam_krb5-4.6.ebuild
+++ b/sys-auth/pam_krb5/pam_krb5-4.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -6,8 +6,8 @@ EAPI=4
 inherit multilib
 
 DESCRIPTION="Kerberos V PAM Authentication Module"
-HOMEPAGE="http://www.eyrie.org/~eagle/software/pam-krb5"
-SRC_URI="http://archives.eyrie.org/software/kerberos/pam-krb5-${PV}.tar.gz"
+HOMEPAGE="https://www.eyrie.org/~eagle/software/pam-krb5/"
+SRC_URI="https://archives.eyrie.org/software/ARCHIVE/pam-krb5/pam-krb5-${PV}.tar.gz"
 
 LICENSE="|| ( BSD-2 GPL-2 )"
 SLOT="0"

--- a/sys-auth/pam_krb5/pam_krb5-4.7.ebuild
+++ b/sys-auth/pam_krb5/pam_krb5-4.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit multilib
 
 DESCRIPTION="Kerberos V PAM Authentication Module"
-HOMEPAGE="http://www.eyrie.org/~eagle/software/pam-krb5"
-SRC_URI="http://archives.eyrie.org/software/kerberos/pam-krb5-${PV}.tar.gz"
+HOMEPAGE="https://www.eyrie.org/~eagle/software/pam-krb5/"
+SRC_URI="https://archives.eyrie.org/software/ARCHIVE/pam-krb5/pam-krb5-${PV}.tar.gz"
 
 LICENSE="|| ( BSD-2 GPL-2 )"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes the two packages to use https and fixes SRC_URI.

Please review.