### PR TITLE
sys-fs/lvm2-2.02.17{1,2,3}: Fix static build

### DIFF
--- a/sys-fs/lvm2/files/lvm2-2.02.171-static-libm.patch
+++ b/sys-fs/lvm2/files/lvm2-2.02.171-static-libm.patch
@@ -1,0 +1,13 @@
+diff --git a/make.tmpl.in b/make.tmpl.in
+index a40eaaa15..7eea943aa 100644
+--- a/make.tmpl.in
++++ b/make.tmpl.in
+@@ -53,7 +53,7 @@ PYCOMPILE = $(top_srcdir)/autoconf/py-compile
+ 
+ LIBS = @LIBS@
+ # Extra libraries always linked with static binaries
+-STATIC_LIBS = $(SELINUX_STATIC_LIBS) $(UDEV_STATIC_LIBS) $(BLKID_STATIC_LIBS)
++STATIC_LIBS = $(SELINUX_STATIC_LIBS) $(UDEV_STATIC_LIBS) $(BLKID_STATIC_LIBS) $(M_LIBS)
+ DEFS += @DEFS@
+ # FIXME set this only where it's needed, not globally?
+ CFLAGS ?= @COPTIMISE_FLAG@ @CFLAGS@

--- a/sys-fs/lvm2/lvm2-2.02.171.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.171.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -66,6 +66,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.02.99-locale-muck.patch #330373
 	"${FILESDIR}"/${PN}-2.02.70-asneeded.patch # -Wl,--as-needed
 	"${FILESDIR}"/${PN}-2.02.139-dynamic-static-ldflags.patch #332905
+	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	"${FILESDIR}"/${PN}-2.02.129-static-pkgconfig-libs.patch #370217, #439414 + blkid
 	"${FILESDIR}"/${PN}-2.02.130-pthread-pkgconfig.patch #492450
 	#"${FILESDIR}"/${PN}-2.02.145-mkdev.patch #580062 # Merged upstream

--- a/sys-fs/lvm2/lvm2-2.02.172.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.172.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -66,6 +66,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.02.99-locale-muck.patch #330373
 	"${FILESDIR}"/${PN}-2.02.70-asneeded.patch # -Wl,--as-needed
 	"${FILESDIR}"/${PN}-2.02.139-dynamic-static-ldflags.patch #332905
+	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	"${FILESDIR}"/${PN}-2.02.172-static-pkgconfig-libs.patch #370217, #439414 + blkid
 	"${FILESDIR}"/${PN}-2.02.130-pthread-pkgconfig.patch #492450
 	#"${FILESDIR}"/${PN}-2.02.145-mkdev.patch #580062 # Merged upstream

--- a/sys-fs/lvm2/lvm2-2.02.173.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.173.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -66,6 +66,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.02.99-locale-muck.patch #330373
 	"${FILESDIR}"/${PN}-2.02.70-asneeded.patch # -Wl,--as-needed
 	"${FILESDIR}"/${PN}-2.02.139-dynamic-static-ldflags.patch #332905
+	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	"${FILESDIR}"/${PN}-2.02.172-static-pkgconfig-libs.patch #370217, #439414 + blkid
 	"${FILESDIR}"/${PN}-2.02.130-pthread-pkgconfig.patch #492450
 	#"${FILESDIR}"/${PN}-2.02.145-mkdev.patch #580062 # Merged upstream


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/617756
Package-Manager: Portage-2.3.35, Repoman-2.3.9