### PR TITLE
app-benchmarks/cpuburn: Add arm support and fix QA warnings

### DIFF
--- a/app-benchmarks/cpuburn/cpuburn-1.4a-r2.ebuild
+++ b/app-benchmarks/cpuburn/cpuburn-1.4a-r2.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+MY_PV="${PV/./_}"
+
+DESCRIPTION="CPU testing utilities in optimized assembler for maximum loading"
+HOMEPAGE="https://downloads.bl4ckb0x.de/pages.sbcglobal.net/redelm/"
+SRC_URI="https://downloads.bl4ckb0x.de/pages.sbcglobal.net/redelm/${PN}_${MY_PV}_tar.gz -> ${P}.tar.gz"
+
+KEYWORDS="-* ~amd64 ~arm ~x86"
+LICENSE="GPL-2"
+SLOT="0"
+
+PATCHES=( "${FILESDIR}/01-variables.patch" )
+
+QA_FLAGS_IGNORED="usr/bin/burnBX
+	usr/bin/burnK6
+	usr/bin/burnK7
+	usr/bin/burnMMX
+	usr/bin/burnP5
+	usr/bin/burnP6"
+
+QA_TEXTRELS="${QA_FLAGS_IGNORED}"
+
+src_prepare() {
+	default
+
+	# Respect users compiler and users CFLAGS and LDFLAGS on x86/amd64
+	# Must be always compiled in 32-bit on amd64 arch
+	# See https://bugs.gentoo.org/65719
+	sed -i -e 's/gcc -s/$(CC) $(CFLAGS) -m32 $(LDFLAGS)/' Makefile || die
+
+	# Respect users compiler and users CFLAGS and LDFLAGS on arm
+	sed -i -e '/CC :=/d' -e 's/^.*-mfloat-abi=softfp/	$(CC) $(CFLAGS) -nostdlib $(LDFLAGS)/' ARM/Makefile || die
+}
+
+src_compile() {
+	if use arm; then
+		cd "${S}"/ARM || die
+	fi
+
+	default
+}
+
+src_install() {
+	if use arm; then
+		dobin ARM/burnCortexA8 ARM/burnCortexA9
+		local DOCS=( "ARM/Design" "README" )
+	else
+		dobin burnBX burnK6 burnK7 burnMMX burnP5 burnP6
+		local DOCS=( "Design" "README" )
+	fi
+
+	einstalldocs
+}

--- a/app-benchmarks/cpuburn/metadata.xml
+++ b/app-benchmarks/cpuburn/metadata.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>ck+gentoo@bl4ckb0x.de</email>
+		<name>Conrad Kostecki</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription>
-		CPUBurn is the ultimate stability testing tool for overclockers. The
-		program heats up any x86 CPU to the maximum possible operating
-		temperature that is achievable by using ordinary software.
+		CPU testing utilities in optimized assembler for maximum loading
+		P6 (Intel Pentium Pro/II/III and Celeron TM),
+		AMD K7 (Athlon/Duron/Thunderbird TM),
+		AMD K6, and Intel P5 Pentium chips. 
 	</longdescription>
 </pkgmetadata>


### PR DESCRIPTION
Changes:
1) Bump to EAPI=6
2) Add support for ARM
3) Fix QA warnings
- I just set the QA_* variables, as I think, it can't be better done. Compiling with GCC, it does not seem to use CFLAGS, when only compiling assembler. Also, for Textrels, it says `ELF has TEXTREL markings but doesnt appear to have any real TEXTREL's !?` So could be a false positive?

Closes: https://bugs.gentoo.org/show_bug.cgi?id=650058
Closes: https://bugs.gentoo.org/show_bug.cgi?id=654966
Package-Manager: Portage-2.3.35, Repoman-2.3.9