### PR TITLE
app-admin/installer: fix SRC_URI bug #655038

### DIFF
--- a/app-admin/installer/installer-0.1.1_beta.ebuild
+++ b/app-admin/installer/installer-0.1.1_beta.ebuild
@@ -11,7 +11,7 @@ MY_PV=${PV/_/-}
 
 DESCRIPTION="A software for Gentoo installation"
 HOMEPAGE="https://github.com/ChrisADR/installer"
-SRC_URI="mirror://github.com/ChrisADR/${PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/ChrisADR/${PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
 
 SLOT="0"
 LICENSE="GPL-2"


### PR DESCRIPTION
Fixes alert:
Couldn't download 'installer-0.1.1_beta.tar.gz'. Aborting.

Change SRC_URI to https: protocol instead of mirror: