### PR TITLE
dev-libs/jansson: Remove libtool archives

### DIFF
--- a/dev-libs/jansson/jansson-2.11.ebuild
+++ b/dev-libs/jansson/jansson-2.11.ebuild
@@ -29,3 +29,9 @@ multilib_src_compile() {
 		HTML_DOCS=( "${BUILD_DIR}"/doc/_build/html/. )
 	fi
 }
+
+multilib_src_install() {
+	default
+
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
This commit adds a multilib_src_install() hook that removes any
generated libtool archives.

This fixes https://bugs.gentoo.org/642174

@trofi I finally had some spare time to get around to this