### PR TITLE
media-gfx/fbgrab: use HTTPS

### DIFF
--- a/media-gfx/fbgrab/fbgrab-1.0-r2.ebuild
+++ b/media-gfx/fbgrab/fbgrab-1.0-r2.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="Framebuffer screenshot utility"
-HOMEPAGE="http://hem.bredband.net/gmogmo/fbgrab/"
-SRC_URI="http://hem.bredband.net/gmogmo/${PN}/${P}.tar.gz"
+HOMEPAGE="https://fbgrab.monells.se"
+SRC_URI="https://fbgrab.monells.se/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-gfx/fbgrab/fbgrab-1.3.ebuild
+++ b/media-gfx/fbgrab/fbgrab-1.3.ebuild
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="Framebuffer screenshot utility"
-HOMEPAGE="http://fbgrab.monells.se/"
-SRC_URI="http://fbgrab.monells.se/${P}.tar.gz"
+HOMEPAGE="https://fbgrab.monells.se"
+SRC_URI="https://fbgrab.monells.se/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes media-gfx/fbgrab to use https instead of http.

Please review.