### PR TITLE
dev-lang/tcc: use HTTPS

### DIFF
--- a/dev-lang/tcc/tcc-0.9.26-r1.ebuild
+++ b/dev-lang/tcc/tcc-0.9.26-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs
 
 DESCRIPTION="A very small C compiler for ix86/amd64"
-HOMEPAGE="http://bellard.org/tcc/"
-SRC_URI="http://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
+HOMEPAGE="https://bellard.org/tcc/"
+SRC_URI="https://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-lang/tcc/tcc-0.9.26-r2.ebuild
+++ b/dev-lang/tcc/tcc-0.9.26-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils toolchain-funcs
 
 DESCRIPTION="A very small C compiler for ix86/amd64"
-HOMEPAGE="http://bellard.org/tcc/"
-SRC_URI="http://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
+HOMEPAGE="https://bellard.org/tcc/"
+SRC_URI="https://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-lang/tcc/tcc-0.9.26-r3.ebuild
+++ b/dev-lang/tcc/tcc-0.9.26-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -6,8 +6,8 @@ EAPI="6"
 inherit toolchain-funcs
 
 DESCRIPTION="A very small C compiler for ix86/amd64"
-HOMEPAGE="http://bellard.org/tcc/"
-SRC_URI="http://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
+HOMEPAGE="https://bellard.org/tcc/"
+SRC_URI="https://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-lang/tcc/tcc-0.9.27.ebuild
+++ b/dev-lang/tcc/tcc-0.9.27.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -6,8 +6,8 @@ EAPI="6"
 inherit toolchain-funcs
 
 DESCRIPTION="A very small C compiler for ix86/amd64"
-HOMEPAGE="http://bellard.org/tcc/"
-SRC_URI="http://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
+HOMEPAGE="https://bellard.org/tcc/"
+SRC_URI="https://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-lang/tcc/tcc-9999.ebuild
+++ b/dev-lang/tcc/tcc-9999.ebuild
@@ -1,19 +1,19 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="A very small C compiler for ix86/amd64"
-HOMEPAGE="http://bellard.org/tcc/"
+HOMEPAGE="https://bellard.org/tcc/"
 
 if [[ $PV == *9999* ]]; then
-	EGIT_REPO_URI="http://repo.or.cz/r/tinycc.git"
+	EGIT_REPO_URI="https://repo.or.cz/r/tinycc.git"
 	KEYWORDS=""
 	SRC_URI=""
 	scm_eclass=git-r3
 else
 	KEYWORDS="~amd64 ~x86 ~amd64-linux"
-	SRC_URI="http://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
+	SRC_URI="https://download.savannah.gnu.org/releases/tinycc/${P}.tar.bz2"
 fi
 
 inherit toolchain-funcs ${scm_eclass}


### PR DESCRIPTION
Hi,

This PR fixes dev-lang/tcc to use https instead of http.

Please review.