### PR TITLE
lxqt-base/*: use HTTPS

### DIFF
--- a/lxqt-base/lxqt-l10n/lxqt-l10n-0.11.0.ebuild
+++ b/lxqt-base/lxqt-l10n/lxqt-l10n-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="LXQt localisation package"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/lxqt-base/lxqt-meta/lxqt-meta-0.11.0.ebuild
+++ b/lxqt-base/lxqt-meta/lxqt-meta-0.11.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=5
 
 DESCRIPTION="Meta ebuild for LXQt, the Lightweight Desktop Environment"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 LICENSE="metapackage"
 SLOT="0"

--- a/lxqt-base/lxqt-notificationd/lxqt-notificationd-0.11.0.ebuild
+++ b/lxqt-base/lxqt-notificationd/lxqt-notificationd-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQt notification daemon and library"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/lxqt-base/lxqt-openssh-askpass/lxqt-openssh-askpass-0.11.0.ebuild
+++ b/lxqt-base/lxqt-openssh-askpass/lxqt-openssh-askpass-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQt OpenSSH user password prompt tool"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/lxqt-base/lxqt-panel/lxqt-panel-0.11.0.ebuild
+++ b/lxqt-base/lxqt-panel/lxqt-panel-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQt desktop panel and plugins"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"


### PR DESCRIPTION
Hi,

This PR fixes a few lxqt packages to use https instead of http.
Also fixes the git usage to use https:// instead of git://

Please review.