### PR TITLE
dev-lang/mono: Don't block dev-lang/mono-basic

### DIFF
--- a/dev-lang/mono/mono-4.4.1.0.ebuild
+++ b/dev-lang/mono/mono-4.4.1.0.ebuild
@@ -28,7 +28,6 @@ DEPEND="${COMMONDEPEND}
 	sys-devel/bc
 	virtual/yacc
 	pax_kernel? ( sys-apps/elfix )
-	!dev-lang/mono-basic
 "
 
 S="${WORKDIR}/${PN}-$(get_version_component_range 1-3)"

--- a/dev-lang/mono/mono-4.6.1.5-r1.ebuild
+++ b/dev-lang/mono/mono-4.6.1.5-r1.ebuild
@@ -28,7 +28,6 @@ DEPEND="${COMMONDEPEND}
 	sys-devel/bc
 	virtual/yacc
 	pax_kernel? ( sys-apps/elfix )
-	!dev-lang/mono-basic
 "
 
 S="${WORKDIR}/${PN}-$(get_version_component_range 1-3)"

--- a/dev-lang/mono/mono-4.6.1.5.ebuild
+++ b/dev-lang/mono/mono-4.6.1.5.ebuild
@@ -28,7 +28,6 @@ DEPEND="${COMMONDEPEND}
 	sys-devel/bc
 	virtual/yacc
 	pax_kernel? ( sys-apps/elfix )
-	!dev-lang/mono-basic
 "
 
 S="${WORKDIR}/${PN}-$(get_version_component_range 1-3)"

--- a/dev-lang/mono/mono-4.8.0.425.ebuild
+++ b/dev-lang/mono/mono-4.8.0.425.ebuild
@@ -29,7 +29,6 @@ DEPEND="${COMMONDEPEND}
 	virtual/yacc
 	pax_kernel? ( sys-apps/elfix )
 	dev-util/cmake
-	!dev-lang/mono-basic
 "
 
 PATCHES=(

--- a/dev-lang/mono/mono-4.8.0.495.ebuild
+++ b/dev-lang/mono/mono-4.8.0.495.ebuild
@@ -29,7 +29,6 @@ DEPEND="${COMMONDEPEND}
 	virtual/yacc
 	pax_kernel? ( sys-apps/elfix )
 	dev-util/cmake
-	!dev-lang/mono-basic
 "
 
 PATCHES=(

--- a/dev-lang/mono/mono-4.8.0.524.ebuild
+++ b/dev-lang/mono/mono-4.8.0.524.ebuild
@@ -29,7 +29,6 @@ DEPEND="${COMMONDEPEND}
 	virtual/yacc
 	pax_kernel? ( sys-apps/elfix )
 	dev-util/cmake
-	!dev-lang/mono-basic
 "
 
 PATCHES=(

--- a/dev-lang/mono/mono-5.4.1.6.ebuild
+++ b/dev-lang/mono/mono-5.4.1.6.ebuild
@@ -29,7 +29,6 @@ DEPEND="${COMMONDEPEND}
 	virtual/yacc
 	pax_kernel? ( sys-apps/elfix )
 	dev-util/cmake
-	!dev-lang/mono-basic
 "
 
 PATCHES=(


### PR DESCRIPTION
This blocker was against an old version of dev-lang/mono-basic, which has been removed from portage.
The current version works fine and is compatible.

Bug: https://bugs.gentoo.org/655018
Package-Manager: Portage-2.3.36, Repoman-2.3.9