### PR TITLE
sys-libs/db: port to EAPI 7

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -15,7 +15,7 @@
 # you should inherit java-pkg-2 for Java packages or java-pkg-opt-2 for packages
 # that have optional Java support. In addition you can inherit java-ant-2 for
 # Ant-based packages.
-inherit eutils versionator multilib
+has "${EAPI:-0}" 0 1 2 3 4 5 6 && inherit eutils versionator multilib
 
 IUSE="elibc_FreeBSD"
 
@@ -1526,8 +1526,16 @@ java-pkg_is-vm-version-eq() {
 
 	local vm_version="$(java-pkg_get-vm-version)"
 
-	vm_version="$(get_version_component_range 1-2 "${vm_version}")"
-	needed_version="$(get_version_component_range 1-2 "${needed_version}")"
+	case ${EAPI} in
+	0|1|2|3|4|5|6)
+		vm_version="$(get_version_component_range 1-2 "${vm_version}")"
+		needed_version="$(get_version_component_range 1-2 "${needed_version}")"
+		;;
+	7)
+		vm_version="$(ver_cut 1-2 "${vm_version}")"
+		needed_version="$(ver_cut 1-2 "${needed_version}")"
+		;;
+	esac
 
 	if [[ -z "${vm_version}" ]]; then
 		debug-print "Could not get JDK version from DEPEND"

--- a/sys-libs/db/db-5.3.28-r4.ebuild
+++ b/sys-libs/db/db-5.3.28-r4.ebuild
@@ -1,0 +1,243 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit db flag-o-matic java-pkg-opt-2 autotools multilib-minimal toolchain-funcs
+
+#Number of official patches
+#PATCHNO=`echo ${PV}|sed -e "s,\(.*_p\)\([0-9]*\),\2,"`
+PATCHNO=${PV/*.*.*_p}
+if [[ ${PATCHNO} == "${PV}" ]] ; then
+	MY_PV=${PV}
+	MY_P=${P}
+	PATCHNO=0
+else
+	MY_PV=${PV/_p${PATCHNO}}
+	MY_P=${PN}-${MY_PV}
+fi
+
+S="${WORKDIR}/${MY_P}"
+BUILD_DIR="${S}/build${MULTIBUILD_VARIANT}"
+DESCRIPTION="Oracle Berkeley DB"
+HOMEPAGE="http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html"
+SRC_URI="http://download.oracle.com/berkeley-db/${MY_P}.tar.gz"
+for (( i=1 ; i<=${PATCHNO} ; i++ )) ; do
+	export SRC_URI="${SRC_URI} http://www.oracle.com/technology/products/berkeley-db/db/update/${MY_PV}/patch.${MY_PV}.${i}"
+done
+
+LICENSE="Sleepycat"
+SLOT="$(ver_cut 1-2)"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd"
+IUSE="doc java cxx tcl test"
+
+REQUIRED_USE="test? ( tcl )"
+
+# the entire testsuite needs the TCL functionality
+DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
+	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
+	java? ( >=virtual/jdk-1.5 )
+	>=sys-devel/binutils-2.16.1"
+RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
+	java? ( >=virtual/jre-1.5 )"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/db$(ver_cut 1-2)/db.h
+)
+
+PATCHES=()
+for (( i=1 ; i<=${PATCHNO} ; i++ ))
+do
+	PATCHES+=( "${DISTDIR}"/patch."${MY_PV}"."${i}" )
+done
+PATCHES+=(
+	# bug #510506
+	"${FILESDIR}"/${PN}-4.8.24-java-manifest-location.patch
+
+	# use the includes from the prefix
+	"${FILESDIR}"/${PN}-4.6-jni-check-prefix-first.patch
+	"${FILESDIR}"/${PN}-4.3-listen-to-java-options.patch
+
+	# sqlite configure call has an extra leading ..
+	# upstreamed:5.2.36, missing in 5.3.x
+	"${FILESDIR}"/${PN}-5.2.28-sqlite-configure-path.patch
+
+	# The upstream testsuite copies .lib and the binaries for each parallel test
+	# core, ~300MB each. This patch uses links instead, saves a lot of space.
+	"${FILESDIR}"/${PN}-6.0.20-test-link.patch
+
+	# Needed when compiling with clang
+	"${FILESDIR}"/${PN}-5.1.29-rename-atomic-compare-exchange.patch
+)
+
+src_prepare() {
+	default
+
+	# Upstream release script grabs the dates when the script was run, so lets
+	# end-run them to keep the date the same.
+	export REAL_DB_RELEASE_DATE="$(awk \
+		'/^DB_VERSION_STRING=/{ gsub(".*\\(|\\).*","",$0); print $0; }' \
+		dist/configure)"
+	sed -r -i \
+		-e "/^DB_RELEASE_DATE=/s~=.*~='${REAL_DB_RELEASE_DATE}'~g" \
+		dist/RELEASE || die
+
+	# Include the SLOT for Java JAR files
+	# This supersedes the unused jarlocation patches.
+	sed -r -i \
+		-e '/jarfile=.*\.jar$/s,(.jar$),-$(LIBVERSION)\1,g' \
+		"${S}"/dist/Makefile.in || die
+
+	cd dist || die
+	rm -f aclocal/libtool.m4
+	sed -i \
+		-e '/AC_PROG_LIBTOOL$/aLT_OUTPUT' \
+		configure.ac || die
+	sed -i \
+		-e '/^AC_PATH_TOOL/s/ sh, none/ bash, none/' \
+		aclocal/programs.m4 || die
+	AT_M4DIR="aclocal aclocal_java" eautoreconf
+	# Upstream sucks - they do autoconf and THEN replace the version variables.
+	. ./RELEASE
+	for v in \
+		DB_VERSION_{FAMILY,LETTER,RELEASE,MAJOR,MINOR} \
+		DB_VERSION_{PATCH,FULL,UNIQUE_NAME,STRING,FULL_STRING} \
+		DB_VERSION \
+		DB_RELEASE_DATE ; do
+		local ev="__EDIT_${v}__"
+		sed -i -e "s/${ev}/${!v}/g" configure || die
+	done
+
+	# This is a false positive skip in the tests as the test-reviewer code
+	# looks for 'Skipping\s'
+	sed -i \
+		-e '/db_repsite/s,Skipping:,Skipping,g' \
+		"${S}"/test/tcl/reputils.tcl || die
+}
+
+multilib_src_configure() {
+	local myconf=()
+
+	tc-ld-disable-gold #470634
+
+	# compilation with -O0 fails on amd64, see bug #171231
+	if [[ ${ABI} == amd64 ]]; then
+		local CFLAGS=${CFLAGS} CXXFLAGS=${CXXFLAGS}
+		replace-flags -O0 -O2
+		is-flagq -O[s123] || append-flags -O2
+	fi
+
+	# Add linker versions to the symbols. Easier to do, and safer than header file
+	# mumbo jumbo.
+	if use userland_GNU ; then
+		append-ldflags -Wl,--default-symver
+	fi
+
+	# use `set` here since the java opts will contain whitespace
+	if multilib_is_native_abi && use java ; then
+		myconf+=(
+			--with-java-prefix="${JAVA_HOME}"
+			--with-javac-flags="$(java-pkg_javac-args)"
+		)
+	fi
+
+	# Bug #270851: test needs TCL support
+	if use tcl || use test ; then
+		myconf+=(
+			--enable-tcl
+			--with-tcl="${EPREFIX}/usr/$(get_libdir)"
+		)
+	else
+		myconf+=(--disable-tcl )
+	fi
+
+	# sql_compat will cause a collision with sqlite3
+	# --enable-sql_compat
+	# Don't --enable-sql* because we don't want to use bundled sqlite.
+	# See Gentoo bug #605688
+	ECONF_SOURCE="${S}"/dist \
+	STRIP="true" \
+	econf \
+		--enable-compat185 \
+		--enable-dbm \
+		--enable-o_direct \
+		--without-uniquename \
+		--disable-sql \
+		--disable-sql_codegen \
+		--disable-sql_compat \
+		$([[ ${ABI} == arm ]] && echo --with-mutex=ARM/gcc-assembly) \
+		$([[ ${ABI} == amd64 ]] && echo --with-mutex=x86/gcc-assembly) \
+		$(use_enable cxx) \
+		$(use_enable cxx stl) \
+		$(multilib_native_use_enable java) \
+		"${myconf[@]}" \
+		$(use_enable test)
+}
+
+multilib_src_install() {
+	emake install DESTDIR="${D}"
+
+	db_src_install_headerslot
+
+	db_src_install_usrlibcleanup
+
+	if multilib_is_native_abi && use java; then
+		java-pkg_regso "${ED}"/usr/"$(get_libdir)"/libdb_java*.so
+		java-pkg_dojar "${ED}"/usr/"$(get_libdir)"/*.jar
+		rm -f "${ED}"/usr/"$(get_libdir)"/*.jar
+	fi
+}
+
+multilib_src_install_all() {
+	db_src_install_usrbinslot
+
+	db_src_install_doc
+
+	dodir /usr/sbin
+	# This file is not always built, and no longer exists as of db-4.8
+	if [[ -f "${ED}"/usr/bin/berkeley_db_svc ]] ; then
+		mv "${ED}"/usr/bin/berkeley_db_svc \
+			"${ED}"/usr/sbin/berkeley_db"${SLOT/./}"_svc || die
+	fi
+}
+
+pkg_postinst() {
+	multilib_foreach_abi db_fix_so
+}
+
+pkg_postrm() {
+	multilib_foreach_abi db_fix_so
+}
+
+src_test() {
+	# db_repsite is impossible to build, as upstream strips those sources.
+	# db_repsite is used directly in the setup_site_prog,
+	# setup_site_prog is called from open_site_prog
+	# which is called only from tests in the multi_repmgr group.
+	#sed -ri \
+	#	-e '/set subs/s,multi_repmgr,,g' \
+	#	"${S_BASE}/test/testparams.tcl"
+	sed -ri \
+		-e '/multi_repmgr/d' \
+		"${S}/test/tcl/test.tcl" || die
+
+	# This is the only failure in 5.2.28 so far, and looks like a false positive.
+	# Repmgr018 (btree): Test of repmgr stats.
+	#     Repmgr018.a: Start a master.
+	#     Repmgr018.b: Start a client.
+	#     Repmgr018.c: Run some transactions at master.
+	#         Rep_test: btree 20 key/data pairs starting at 0
+	#         Rep_test.a: put/get loop
+	# FAIL:07:05:59 (00:00:00) perm_no_failed_stat: expected 0, got 1
+	sed -ri \
+		-e '/set parms.*repmgr018/d' \
+		-e 's/repmgr018//g' \
+		"${S}/test/tcl/test.tcl" || die
+
+	multilib-minimal_src_test
+}
+
+multilib_src_test() {
+	multilib_is_native_abi || return
+
+	S=${BUILD_DIR} db_src_test
+}

--- a/sys-libs/db/db-6.0.35-r2.ebuild
+++ b/sys-libs/db/db-6.0.35-r2.ebuild
@@ -1,0 +1,241 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit db flag-o-matic java-pkg-opt-2 autotools multilib multilib-minimal toolchain-funcs
+
+#Number of official patches
+#PATCHNO=`echo ${PV}|sed -e "s,\(.*_p\)\([0-9]*\),\2,"`
+PATCHNO=${PV/*.*.*_p}
+if [[ ${PATCHNO} == "${PV}" ]] ; then
+	MY_PV=${PV}
+	MY_P=${P}
+	PATCHNO=0
+else
+	MY_PV=${PV/_p${PATCHNO}}
+	MY_P=${PN}-${MY_PV}
+fi
+
+S="${WORKDIR}/${MY_P}"
+BUILD_DIR="${S}/build${MULTIBUILD_VARIANT}"
+DESCRIPTION="Oracle Berkeley DB"
+HOMEPAGE="http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html"
+SRC_URI="http://download.oracle.com/berkeley-db/${MY_P}.tar.gz"
+for (( i=1 ; i<=${PATCHNO} ; i++ )) ; do
+	export SRC_URI="${SRC_URI} http://www.oracle.com/technology/products/berkeley-db/db/update/${MY_PV}/patch.${MY_PV}.${i}"
+done
+
+LICENSE="AGPL-3"
+SLOT="$(ver_cut 1-2)"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd"
+IUSE="doc java cxx tcl test"
+
+REQUIRED_USE="test? ( tcl )"
+
+# the entire testsuite needs the TCL functionality
+DEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
+	test? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
+	java? ( >=virtual/jdk-1.5 )
+	>=sys-devel/binutils-2.16.1"
+RDEPEND="tcl? ( >=dev-lang/tcl-8.5.15-r1:0=[${MULTILIB_USEDEP}] )
+	java? ( >=virtual/jre-1.5 )"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/db$(ver_cut 1-2)/db.h
+)
+
+PATCHES=()
+for (( i=1 ; i<=${PATCHNO} ; i++ ))
+do
+	PATCHES+=( "${DISTDIR}"/patch."${MY_PV}"."${i}" )
+done
+PATCHES+=(
+	# bug #510506
+	"${FILESDIR}"/${PN}-4.8.24-java-manifest-location.patch
+
+	# use the includes from the prefix
+	"${FILESDIR}"/${PN}-4.6-jni-check-prefix-first.patch
+	"${FILESDIR}"/${PN}-4.3-listen-to-java-options.patch
+
+	# sqlite configure call has an extra leading ..
+	# upstreamed:5.2.36, missing in 5.3.x/6.x
+	# still needs to be patched in 6.0.20
+	"${FILESDIR}"/${PN}-6.0.35-sqlite-configure-path.patch
+
+	# The upstream testsuite copies .lib and the binaries for each parallel test
+	# core, ~300MB each. This patch uses links instead, saves a lot of space.
+	"${FILESDIR}"/${PN}-6.0.20-test-link.patch
+)
+
+src_prepare() {
+	default
+
+	# Upstream release script grabs the dates when the script was run, so lets
+	# end-run them to keep the date the same.
+	export REAL_DB_RELEASE_DATE="$(awk \
+		'/^DB_VERSION_STRING=/{ gsub(".*\\(|\\).*","",$0); print $0; }' \
+		dist/configure)"
+	sed -r -i \
+		-e "/^DB_RELEASE_DATE=/s~=.*~='${REAL_DB_RELEASE_DATE}'~g" \
+		dist/RELEASE || die
+
+	# Include the SLOT for Java JAR files
+	# This supersedes the unused jarlocation patches.
+	sed -r -i \
+		-e '/jarfile=.*\.jar$/s,(.jar$),-$(LIBVERSION)\1,g' \
+		"${S}"/dist/Makefile.in || die
+
+	cd dist || die
+	rm -f aclocal/libtool.m4
+	sed -i \
+		-e '/AC_PROG_LIBTOOL$/aLT_OUTPUT' \
+		configure.ac || die
+	sed -i \
+		-e '/^AC_PATH_TOOL/s/ sh, none/ bash, none/' \
+		aclocal/programs.m4 || die
+	AT_M4DIR="aclocal aclocal_java" eautoreconf
+	# Upstream sucks - they do autoconf and THEN replace the version variables.
+	. ./RELEASE
+	for v in \
+		DB_VERSION_{FAMILY,LETTER,RELEASE,MAJOR,MINOR} \
+		DB_VERSION_{PATCH,FULL,UNIQUE_NAME,STRING,FULL_STRING} \
+		DB_VERSION \
+		DB_RELEASE_DATE ; do
+		local ev="__EDIT_${v}__"
+		sed -i -e "s/${ev}/${!v}/g" configure || die
+	done
+
+	# This is a false positive skip in the tests as the test-reviewer code
+	# looks for 'Skipping\s'
+	sed -i \
+		-e '/db_repsite/s,Skipping:,Skipping,g' \
+		"${S}"/test/tcl/reputils.tcl || die
+}
+
+multilib_src_configure() {
+	local myconf=()
+
+	tc-ld-disable-gold #470634
+
+	# compilation with -O0 fails on amd64, see bug #171231
+	if [[ ${ABI} == amd64 ]]; then
+		local CFLAGS=${CFLAGS} CXXFLAGS=${CXXFLAGS}
+		replace-flags -O0 -O2
+		is-flagq -O[s123] || append-flags -O2
+	fi
+
+	# Add linker versions to the symbols. Easier to do, and safer than header file
+	# mumbo jumbo.
+	if use userland_GNU ; then
+		append-ldflags -Wl,--default-symver
+	fi
+
+	# use `set` here since the java opts will contain whitespace
+	if multilib_is_native_abi && use java ; then
+		myconf+=(
+			--with-java-prefix="${JAVA_HOME}"
+			--with-javac-flags="$(java-pkg_javac-args)"
+		)
+	fi
+
+	# Bug #270851: test needs TCL support
+	if use tcl || use test ; then
+		myconf+=(
+			--enable-tcl
+			--with-tcl="${EPREFIX}/usr/$(get_libdir)"
+		)
+	else
+		myconf+=(--disable-tcl )
+	fi
+
+	# sql_compat will cause a collision with sqlite3
+	# --enable-sql_compat
+	# Don't --enable-sql* because we don't want to use bundled sqlite.
+	# See Gentoo bug #605688
+	ECONF_SOURCE="${S}"/dist \
+	STRIP="true" \
+	econf \
+		--enable-compat185 \
+		--enable-dbm \
+		--enable-o_direct \
+		--without-uniquename \
+		--disable-sql \
+		--disable-sql_codegen \
+		--disable-sql_compat \
+		$([[ ${ABI} == arm ]] && echo --with-mutex=ARM/gcc-assembly) \
+		$([[ ${ABI} == amd64 ]] && echo --with-mutex=x86/gcc-assembly) \
+		$(use_enable cxx) \
+		$(use_enable cxx stl) \
+		$(multilib_native_use_enable java) \
+		"${myconf[@]}" \
+		$(use_enable test)
+}
+
+multilib_src_install() {
+	emake install DESTDIR="${D}"
+
+	db_src_install_headerslot
+
+	db_src_install_usrlibcleanup
+
+	if multilib_is_native_abi && use java; then
+		java-pkg_regso "${ED}"/usr/"$(get_libdir)"/libdb_java*.so
+		java-pkg_dojar "${ED}"/usr/"$(get_libdir)"/*.jar
+		rm -f "${ED}"/usr/"$(get_libdir)"/*.jar
+	fi
+}
+
+multilib_src_install_all() {
+	db_src_install_usrbinslot
+
+	db_src_install_doc
+
+	dodir /usr/sbin
+	# This file is not always built, and no longer exists as of db-4.8
+	if [[ -f "${ED}"/usr/bin/berkeley_db_svc ]] ; then
+		mv "${ED}"/usr/bin/berkeley_db_svc \
+			"${ED}"/usr/sbin/berkeley_db"${SLOT/./}"_svc || die
+	fi
+}
+
+pkg_postinst() {
+	multilib_foreach_abi db_fix_so
+}
+
+pkg_postrm() {
+	multilib_foreach_abi db_fix_so
+}
+
+src_test() {
+	# db_repsite is impossible to build, as upstream strips those sources.
+	# db_repsite is used directly in the setup_site_prog,
+	# setup_site_prog is called from open_site_prog
+	# which is called only from tests in the multi_repmgr group.
+	#sed -ri \
+	#	-e '/set subs/s,multi_repmgr,,g' \
+	#	"${S_BASE}/test/testparams.tcl"
+	sed -ri \
+		-e '/multi_repmgr/d' \
+		"${S}/test/tcl/test.tcl" || die
+
+	# This is the only failure in 5.2.28 so far, and looks like a false positive.
+	# Repmgr018 (btree): Test of repmgr stats.
+	#     Repmgr018.a: Start a master.
+	#     Repmgr018.b: Start a client.
+	#     Repmgr018.c: Run some transactions at master.
+	#         Rep_test: btree 20 key/data pairs starting at 0
+	#         Rep_test.a: put/get loop
+	# FAIL:07:05:59 (00:00:00) perm_no_failed_stat: expected 0, got 1
+	sed -ri \
+		-e '/set parms.*repmgr018/d' \
+		-e 's/repmgr018//g' \
+		"${S}/test/tcl/test.tcl" || die
+
+	multilib-minimal_src_test
+}
+
+multilib_src_test() {
+	multilib_is_native_abi || return
+
+	S=${BUILD_DIR} db_src_test
+}

--- a/sys-libs/db/files/db-4.3-listen-to-java-options.patch
+++ b/sys-libs/db/files/db-4.3-listen-to-java-options.patch
@@ -1,5 +1,5 @@
---- dist/configure.ac	2005-09-23 21:01:26.000000000 +0200
-+++ dist/configure.ac	2005-09-23 20:59:20.000000000 +0200
+--- a/dist/configure.ac
++++ b/dist/configure.ac
 @@ -385,6 +385,7 @@
          # A classpath that includes . is needed to check for Java
  	CLASSPATH=".:$CLASSPATH"

--- a/sys-libs/db/files/db-4.6-jni-check-prefix-first.patch
+++ b/sys-libs/db/files/db-4.6-jni-check-prefix-first.patch
@@ -1,5 +1,5 @@
---- dist/aclocal_java/ac_jni_include_dirs.m4	2003-10-06 20:41:38.000000000 +0200
-+++ dist/aclocal_java/ac_jni_include_dirs.m4	2005-09-23 21:31:26.000000000 +0200
+--- a/dist/aclocal_java/ac_jni_include_dirs.m4
++++ b/dist/aclocal_java/ac_jni_include_dirs.m4
 @@ -43,14 +43,19 @@
  *)	AC_MSG_ERROR([$_ACJNI_JAVAC is not an absolute path name]);;
  esac

--- a/sys-libs/db/files/db-4.8.24-java-manifest-location.patch
+++ b/sys-libs/db/files/db-4.8.24-java-manifest-location.patch
@@ -1,6 +1,5 @@
-diff -Nuar db-4.8.24.orig/dist/Makefile.in db-4.8.24/dist/Makefile.in
---- db-4.8.24.orig/dist/Makefile.in	2009-09-19 23:39:45.286001896 +0000
-+++ db-4.8.24/dist/Makefile.in	2009-09-19 23:41:13.079326882 +0000
+--- a/dist/Makefile.in
++++ b/dist/Makefile.in
 @@ -830,7 +830,7 @@
  	$(JAVA) -classpath $(JAVA_CLASSTOP) \
  	    com.sleepycat.persist.model.ClassEnhancer $(JAVA_CLASSTOP)


### PR DESCRIPTION
There are some problems with this one I can't quite solve myself. The upstream
patches seem to be formatted to be -p0, which means they can't be just slapped
into the PATCHES array. One suggestion would be to mirror them in a devspace,
modified to be -p1 applicable (and preferably converted to a unified diff format,
as the context diff used by upstream is 1. very large relatively speaking to a unified
diff and 2. difficult to easily assess visually, as compared to unified diffs).

Porting to EAPI 7 because with an otherwise stock crossdev toolchain this cannot
be emerged because it cannot find autotools, with the following error:

```
* Running eautoreconf in '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-libs/db-6.0.35-r1/work/db-6.0.35/dist' ...
 * ERROR: sys-libs/db-6.0.35-r1::gentoo failed (prepare phase):
 *   Cannot find the latest automake! Tried 1.16:1.16 1.15.1:1.15
 * 
 * Call stack:
 *     ebuild.sh, line  124:  Called src_prepare
 *   environment, line 4944:  Called eautoreconf
 *   environment, line 1112:  Called _elibtoolize '--auto-ltdl' '--install' '--copy' '--force'
 *   environment, line  324:  Called autotools_run_tool 'libtoolize' '--install' '--copy' '--force'
 *   environment, line  672:  Called autotools_env_setup
 *   environment, line  625:  Called die
 * The specific snippet of code:
 *           [[ ${WANT_AUTOMAKE} == "latest" ]] && die "Cannot find the latest automake! Tried ${_LATEST_AUTOMAKE[*]}";
 * 
 * If you need support, post the output of `emerge --info '=sys-libs/db-6.0.35-r1::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=sys-libs/db-6.0.35-r1::gentoo'`.
!!! When you file a bug report, please include the following information:
GENTOO_VM=  CLASSPATH="" JAVA_HOME="/etc/java-config-2/current-system-vm"
JAVACFLAGS="" COMPILER=""
and of course, the output of emerge --info =db-6.0.35
 * The complete build log is located at '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-libs/db-6.0.35-r1/temp/build.log'.
 * The ebuild environment file is located at '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-libs/db-6.0.35-r1/temp/environment'.
 * Working directory: '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-libs/db-6.0.35-r1/work/db-6.0.35/dist'
 * S: '/usr/armv7a-hardfloat-linux-gnueabi/tmp/portage/sys-libs/db-6.0.35-r1/work/db-6.0.35/build_unix'
```