### PR TITLE
media-{gfx,libs,plugins,video}/*: use HTTPS

### DIFF
--- a/media-gfx/openexr_viewers/openexr_viewers-1.0.2.ebuild
+++ b/media-gfx/openexr_viewers/openexr_viewers-1.0.2.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=2
 inherit autotools eutils flag-o-matic
 
 DESCRIPTION="OpenEXR Viewers"
-SRC_URI="http://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
-HOMEPAGE="http://openexr.com/"
+SRC_URI="https://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
+HOMEPAGE="https://openexr.com"
 
 LICENSE="BSD"
 SLOT="0"

--- a/media-gfx/openexr_viewers/openexr_viewers-2.0.1.ebuild
+++ b/media-gfx/openexr_viewers/openexr_viewers-2.0.1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools eutils flag-o-matic
 
 DESCRIPTION="OpenEXR Viewers"
-HOMEPAGE="http://openexr.com/"
-SRC_URI="http://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
+HOMEPAGE="https://openexr.com"
+SRC_URI="https://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/media-gfx/openexr_viewers/openexr_viewers-2.1.0.ebuild
+++ b/media-gfx/openexr_viewers/openexr_viewers-2.1.0.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools eutils flag-o-matic
 
 DESCRIPTION="OpenEXR Viewers"
-HOMEPAGE="http://openexr.com/"
-SRC_URI="http://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
+HOMEPAGE="https://openexr.com"
+SRC_URI="https://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/media-gfx/openexr_viewers/openexr_viewers-2.2.0-r1.ebuild
+++ b/media-gfx/openexr_viewers/openexr_viewers-2.2.0-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools flag-o-matic
 
 DESCRIPTION="OpenEXR Viewers"
-HOMEPAGE="http://openexr.com/"
-SRC_URI="http://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
+HOMEPAGE="https://openexr.com"
+SRC_URI="https://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/media-gfx/openexr_viewers/openexr_viewers-2.2.0.ebuild
+++ b/media-gfx/openexr_viewers/openexr_viewers-2.2.0.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit autotools eutils flag-o-matic
 
 DESCRIPTION="OpenEXR Viewers"
-HOMEPAGE="http://openexr.com/"
-SRC_URI="http://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
+HOMEPAGE="https://openexr.com"
+SRC_URI="https://download.savannah.gnu.org/releases/openexr/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/media-libs/libaom/libaom-0_pre20180421.ebuild
+++ b/media-libs/libaom/libaom-0_pre20180421.ebuild
@@ -14,7 +14,7 @@ elif [[ ${PV} == *pre* ]]; then
 fi
 
 DESCRIPTION="Alliance for Open Media AV1 Codec SDK"
-HOMEPAGE="http://aomedia.org"
+HOMEPAGE="https://aomedia.org"
 
 LICENSE="BSD-2"
 SLOT="0/0"

--- a/media-libs/libaom/libaom-9999.ebuild
+++ b/media-libs/libaom/libaom-9999.ebuild
@@ -14,7 +14,7 @@ elif [[ ${PV} == *pre* ]]; then
 fi
 
 DESCRIPTION="Alliance for Open Media AV1 Codec SDK"
-HOMEPAGE="http://aomedia.org"
+HOMEPAGE="https://aomedia.org"
 
 LICENSE="BSD-2"
 SLOT="0/0"

--- a/media-plugins/frei0r-plugins/frei0r-plugins-1.5.0.ebuild
+++ b/media-plugins/frei0r-plugins/frei0r-plugins-1.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit cmake-utils multilib
 
 DESCRIPTION="A minimalistic plugin API for video effects"
-HOMEPAGE="http://www.dyne.org/software/frei0r/"
-SRC_URI="http://files.dyne.org/frei0r/releases/${P}.tar.gz"
+HOMEPAGE="https://www.dyne.org/software/frei0r/"
+SRC_URI="https://files.dyne.org/frei0r/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/frei0r-plugins/frei0r-plugins-1.6.0.ebuild
+++ b/media-plugins/frei0r-plugins/frei0r-plugins-1.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit cmake-utils multilib
 
 DESCRIPTION="A minimalistic plugin API for video effects"
-HOMEPAGE="http://www.dyne.org/software/frei0r/"
-SRC_URI="http://files.dyne.org/frei0r/releases/${P}.tar.gz"
+HOMEPAGE="https://www.dyne.org/software/frei0r/"
+SRC_URI="https://files.dyne.org/frei0r/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/frei0r-plugins/frei0r-plugins-1.6.1.ebuild
+++ b/media-plugins/frei0r-plugins/frei0r-plugins-1.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit cmake-utils multilib
 
 DESCRIPTION="A minimalistic plugin API for video effects"
-HOMEPAGE="http://www.dyne.org/software/frei0r/"
-SRC_URI="http://files.dyne.org/frei0r/releases/${P}.tar.gz"
+HOMEPAGE="https://www.dyne.org/software/frei0r/"
+SRC_URI="https://files.dyne.org/frei0r/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-video/dvdrip/dvdrip-0.98.11-r3.ebuild
+++ b/media-video/dvdrip/dvdrip-0.98.11-r3.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils flag-o-matic perl-module
 
 DESCRIPTION="dvd::rip is a graphical frontend for transcode"
-HOMEPAGE="http://www.exit1.org/dvdrip/"
-SRC_URI="http://www.exit1.org/dvdrip/dist/${P}.tar.gz"
+HOMEPAGE="https://www.exit1.org/dvdrip/"
+SRC_URI="https://www.exit1.org/dvdrip/dist/${P}.tar.gz"
 
 SLOT="0"
 KEYWORDS="amd64 ppc ppc64 x86"

--- a/media-video/dvdrip/dvdrip-0.98.11-r4.ebuild
+++ b/media-video/dvdrip/dvdrip-0.98.11-r4.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils flag-o-matic perl-module
 
 DESCRIPTION="dvd::rip is a graphical frontend for transcode"
-HOMEPAGE="http://www.exit1.org/dvdrip/"
-SRC_URI="http://www.exit1.org/dvdrip/dist/${P}.tar.gz"
+HOMEPAGE="https://www.exit1.org/dvdrip/"
+SRC_URI="https://www.exit1.org/dvdrip/dist/${P}.tar.gz"
 
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"

--- a/media-video/libav/libav-9.17.ebuild
+++ b/media-video/libav/libav-9.17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,13 +12,13 @@ fi
 inherit eutils flag-o-matic multilib multilib-minimal toolchain-funcs ${SCM}
 
 DESCRIPTION="Complete solution to record, convert and stream audio and video"
-HOMEPAGE="http://libav.org/"
+HOMEPAGE="https://libav.org/"
 if [[ ${PV} == *9999 ]] ; then
 	SRC_URI=""
 elif [[ ${PV%_p*} != ${PV} ]] ; then # Gentoo snapshot
 	SRC_URI="https://dev.gentoo.org/~lu_zero/libav/${P}.tar.xz"
 else # Official release
-	SRC_URI="http://${PN}.org/releases/${P}.tar.xz"
+	SRC_URI="https://${PN}.org/releases/${P}.tar.xz"
 fi
 
 SRC_URI+=" test? ( https://dev.gentoo.org/~lu_zero/libav/fate-9.tar.xz )"

--- a/media-video/minitube/minitube-2.5.2-r1.ebuild
+++ b/media-video/minitube/minitube-2.5.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ PLOCALE_BACKUP="en"
 inherit l10n qmake-utils
 
 DESCRIPTION="Qt5 YouTube Client"
-HOMEPAGE="http://flavio.tordini.org/minitube"
+HOMEPAGE="https://flavio.tordini.org/minitube"
 SRC_URI="https://github.com/flaviotordini/${PN}/archive/${PV}.tar.gz ->
 ${P}.tar.gz"
 

--- a/media-video/mkvalidator/mkvalidator-0.5.2.ebuild
+++ b/media-video/mkvalidator/mkvalidator-0.5.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="mkvalidator is a command line tool to verify Matroska files for spec conformance"
-HOMEPAGE="http://www.matroska.org/downloads/mkvalidator.html"
-SRC_URI="http://downloads.sourceforge.net/project/matroska/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://www.matroska.org/downloads/mkvalidator.html"
+SRC_URI="https://downloads.sourceforge.net/project/matroska/${PN}/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"

--- a/media-video/sswf/sswf-1.8.2-r1.ebuild
+++ b/media-video/sswf/sswf-1.8.2-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 DESCRIPTION="A C++ Library and a script language tool to create Flash (SWF) movies up to version 8"
-HOMEPAGE="http://www.m2osw.com/sswf.html"
+HOMEPAGE="https://www.m2osw.com/sswf.html"
 SRC_URI="mirror://sourceforge/${PN}/${P}-src.tar.bz2
 	mirror://sourceforge/${PN}/${P}-doc.tar.bz2"
 

--- a/media-video/sswf/sswf-1.8.4-r1.ebuild
+++ b/media-video/sswf/sswf-1.8.4-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 DESCRIPTION="A C++ Library and a script language tool to create Flash (SWF) movies up to version 8"
-HOMEPAGE="http://www.m2osw.com/sswf.html"
+HOMEPAGE="https://www.m2osw.com/sswf.html"
 SRC_URI="mirror://sourceforge/${PN}/${P}-src.tar.bz2
 	mirror://sourceforge/${PN}/${P}-doc.tar.bz2"
 

--- a/media-video/vdr2jpeg/vdr2jpeg-0.1.9-r1.ebuild
+++ b/media-video/vdr2jpeg/vdr2jpeg-0.1.9-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ VERSION="717" # every bump, new version
 RESTRICT="strip"
 
 DESCRIPTION="Addon needed for XXV - WWW Admin for the Video Disk Recorder"
-HOMEPAGE="http://projects.vdr-developer.org/projects/xxv"
+HOMEPAGE="https://projects.vdr-developer.org/projects/xxv"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz
 		mirror://gentoo/${P}.tgz"
 

--- a/media-video/vdr2jpeg/vdr2jpeg-0.2.0.ebuild
+++ b/media-video/vdr2jpeg/vdr2jpeg-0.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ VERSION="1911" # every bump, new version
 RESTRICT="strip"
 
 DESCRIPTION="Addon needed for XXV - WWW Admin for the Video Disk Recorder"
-HOMEPAGE="http://projects.vdr-developer.org/projects/xxv"
+HOMEPAGE="https://projects.vdr-developer.org/projects/xxv"
 SRC_URI="mirror://vdr-developerorg/${VERSION}/${P}.tgz
 		mirror://gentoo/${P}.tgz"
 


### PR DESCRIPTION
Hi,

This PR fixes a few media-video related packages to use https instead of http.

Please review.