### PR TITLE
=www-client/chromium-67.*: Re-enable widevine support.

### DIFF
--- a/www-client/chromium/chromium-67.0.3396.18.ebuild
+++ b/www-client/chromium/chromium-67.0.3396.18.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${P}
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="component-build cups gnome-keyring +hangouts jumbo-build kerberos neon pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc"
+IUSE="component-build cups gnome-keyring +hangouts jumbo-build kerberos neon pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc widevine"
 RESTRICT="!system-ffmpeg? ( proprietary-codecs? ( bindist ) )"
 
 COMMON_DEPEND="
@@ -85,6 +85,7 @@ RDEPEND="${COMMON_DEPEND}
 	virtual/ttf-fonts
 	selinux? ( sec-policy/selinux-chromium )
 	tcmalloc? ( !<x11-drivers/nvidia-drivers-331.20 )
+	widevine? ( www-plugins/chrome-binary-plugins[widevine(-)] )
 "
 # dev-vcs/git - https://bugs.gentoo.org/593476
 # sys-apps/sandbox - https://crbug.com/586444
@@ -144,6 +145,7 @@ GTK+ icon theme.
 "
 
 PATCHES=(
+	"${FILESDIR}/chromium-widevine-r2.patch"
 	"${FILESDIR}/chromium-compiler-r0.patch"
 	"${FILESDIR}/chromium-webrtc-r0.patch"
 	"${FILESDIR}/chromium-memcpy-r0.patch"
@@ -467,6 +469,7 @@ src_configure() {
 
 	# Optional dependencies.
 	myconf_gn+=" enable_hangout_services_extension=$(usex hangouts true false)"
+	myconf_gn+=" enable_widevine=$(usex widevine true false)"
 	myconf_gn+=" use_cups=$(usex cups true false)"
 	myconf_gn+=" use_gnome_keyring=$(usex gnome-keyring true false)"
 	myconf_gn+=" use_kerberos=$(usex kerberos true false)"

--- a/www-client/chromium/chromium-67.0.3396.30.ebuild
+++ b/www-client/chromium/chromium-67.0.3396.30.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${P}
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="component-build cups gnome-keyring +hangouts jumbo-build kerberos neon pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc"
+IUSE="component-build cups gnome-keyring +hangouts jumbo-build kerberos neon pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc widevine"
 RESTRICT="!system-ffmpeg? ( proprietary-codecs? ( bindist ) )"
 
 COMMON_DEPEND="
@@ -85,6 +85,7 @@ RDEPEND="${COMMON_DEPEND}
 	virtual/ttf-fonts
 	selinux? ( sec-policy/selinux-chromium )
 	tcmalloc? ( !<x11-drivers/nvidia-drivers-331.20 )
+	widevine? ( www-plugins/chrome-binary-plugins[widevine(-)] )
 "
 # dev-vcs/git - https://bugs.gentoo.org/593476
 # sys-apps/sandbox - https://crbug.com/586444
@@ -144,6 +145,7 @@ GTK+ icon theme.
 "
 
 PATCHES=(
+	"${FILESDIR}/chromium-widevine-r2.patch"
 	"${FILESDIR}/chromium-compiler-r0.patch"
 	"${FILESDIR}/chromium-webrtc-r0.patch"
 	"${FILESDIR}/chromium-memcpy-r0.patch"
@@ -467,6 +469,7 @@ src_configure() {
 
 	# Optional dependencies.
 	myconf_gn+=" enable_hangout_services_extension=$(usex hangouts true false)"
+	myconf_gn+=" enable_widevine=$(usex widevine true false)"
 	myconf_gn+=" use_cups=$(usex cups true false)"
 	myconf_gn+=" use_gnome_keyring=$(usex gnome-keyring true false)"
 	myconf_gn+=" use_kerberos=$(usex kerberos true false)"

--- a/www-client/chromium/chromium-68.0.3409.2.ebuild
+++ b/www-client/chromium/chromium-68.0.3409.2.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${P}
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="component-build cups gnome-keyring +hangouts jumbo-build kerberos neon pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc"
+IUSE="component-build cups gnome-keyring +hangouts jumbo-build kerberos neon pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc widevine"
 RESTRICT="!system-ffmpeg? ( proprietary-codecs? ( bindist ) )"
 
 COMMON_DEPEND="
@@ -85,6 +85,7 @@ RDEPEND="${COMMON_DEPEND}
 	virtual/ttf-fonts
 	selinux? ( sec-policy/selinux-chromium )
 	tcmalloc? ( !<x11-drivers/nvidia-drivers-331.20 )
+	widevine? ( www-plugins/chrome-binary-plugins[widevine(-)] )
 "
 # dev-vcs/git - https://bugs.gentoo.org/593476
 # sys-apps/sandbox - https://crbug.com/586444
@@ -144,6 +145,7 @@ GTK+ icon theme.
 "
 
 PATCHES=(
+	"${FILESDIR}/chromium-widevine-r2.patch"
 	"${FILESDIR}/chromium-compiler-r1.patch"
 	"${FILESDIR}/chromium-ffmpeg-build-r0.patch"
 	"${FILESDIR}/chromium-webrtc-r0.patch"
@@ -472,6 +474,7 @@ src_configure() {
 
 	# Optional dependencies.
 	myconf_gn+=" enable_hangout_services_extension=$(usex hangouts true false)"
+	myconf_gn+=" enable_widevine=$(usex widevine true false)"
 	myconf_gn+=" use_cups=$(usex cups true false)"
 	myconf_gn+=" use_gnome_keyring=$(usex gnome-keyring true false)"
 	myconf_gn+=" use_kerberos=$(usex kerberos true false)"

--- a/www-client/chromium/files/chromium-widevine-r2.patch
+++ b/www-client/chromium/files/chromium-widevine-r2.patch
@@ -1,0 +1,39 @@
+Minimal patch to get chromium to compile with widevine support.
+
+Exactly the same as -r1, but we now need to patch
+ninja to pretty please not terminate our build.
+
+caveat emptor: it's in no way clear that building chromium this
+way is safer, from a security perspective, than whatever Google
+Chrome does.
+
+Upstream appears to be cooking up a code-signing trust-chain
+which may protect users against malicious cdm blobs; I doubt
+we benefit from these using this kludge.  Ideally, someone
+would look into this more carefully than I have ... tbh as
+soon as I got my "stories" back, I pretty much lost interest :)
+
+-gmt
+
+--
+--- a/third_party/widevine/cdm/stub/widevine_cdm_version.h
++++ b/third_party/widevine/cdm/stub/widevine_cdm_version.h
+@@ -10,6 +10,7 @@
+
+ #include "third_party/widevine/cdm/widevine_cdm_common.h"
+
++#define WIDEVINE_CDM_VERSION_STRING "unknown"
+ #define WIDEVINE_CDM_AVAILABLE
+
+ #endif  // WIDEVINE_CDM_VERSION_H_
+--- a/third_party/widevine/cdm/BUILD.gn
++++ b/third_party/widevine/cdm/BUILD.gn
+@@ -11,7 +11,7 @@ import("//third_party/widevine/cdm/widev
+ # Internal Cast builds set enable_widevine=true to bring in Widevine support.
+ # TODO(xhwang): Support component updated CDM on other platforms and remove this
+ # assert.
+-assert(!enable_widevine || is_win || is_mac || is_chromecast,
++assert(!enable_widevine || is_win || is_mac || is_chromecast || is_linux,
+        "Component updated CDM only supported on Windows and Mac for now.")
+
+ widevine_arch = current_cpu


### PR DESCRIPTION
chromium 67 broke the widevine enablement hack, but we can apparently
unbreak it, by simply asking gn to please not break.  Also: ninja
conventiently no longer copies the .so to out/.

Signed-off-by: Gregory M. Turner <gmt@be-evil.net>