### PR TITLE
dev-cpp/glibmm: Fix build with GCC 8

### DIFF
--- a/dev-cpp/glibmm/files/glibmm-fix-threads-gobject.patch
+++ b/dev-cpp/glibmm/files/glibmm-fix-threads-gobject.patch
@@ -1,0 +1,34 @@
+From 37d57ae9572b7d74aa385a30313eceae7f2d3fce Mon Sep 17 00:00:00 2001
+From: Kjell Ahlstedt <kjellahlstedt@gmail.com>
+Date: Wed, 20 Dec 2017 20:00:32 +0100
+Subject: [PATCH] Glib::Threads::Private: Fix gobj()
+
+Bug 791711
+---
+ glib/src/threads.hg | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/glib/src/threads.hg b/glib/src/threads.hg
+index 86d7a17b..c82a6130 100644
+--- a/glib/src/threads.hg
++++ b/glib/src/threads.hg
+@@ -628,7 +628,7 @@ public:
+    */
+   inline void replace(T* data);
+ 
+-  GPrivate* gobj() { return gobject_; }
++  GPrivate* gobj() { return &gobject_; }
+ 
+ private:
+   GPrivate gobject_;
+--- a/glib/glibmm/threads.h	2017-09-04 15:27:31.000000000 +0200
++++ b/glib/glibmm/threads.h	2018-05-05 10:53:44.339288554 +0200
+@@ -657,7 +657,7 @@
+    */
+   inline void replace(T* data);
+ 
+-  GPrivate* gobj() { return gobject_; }
++  GPrivate* gobj() { return &gobject_; }
+ 
+ private:
+   GPrivate gobject_;

--- a/dev-cpp/glibmm/glibmm-2.52.1.ebuild
+++ b/dev-cpp/glibmm/glibmm-2.52.1.ebuild
@@ -33,6 +33,8 @@ src_prepare() {
 	sed 's/^\(SUBDIRS =.*\)examples\(.*\)$/\1\2/' \
 		-i Makefile.am Makefile.in || die "sed 2 failed"
 
+	epatch "${FILESDIR}/${PN}-fix-threads-gobject.patch"
+
 	gnome2_src_prepare
 }
 


### PR DESCRIPTION
Patch taken from upstream and adapted to actually touch the pregenerated
file shipped with the release tarbal as well. That code appears to have
been always wrong, with no chance to build. This probably means that GCC
8 is suddenly being detected in some other way, making the code use that
include file which was previously apparently kept unused. But anyway,
upstream killed that include in a later release, so let's just let this
build and watch the eventual breakage.

Upstream says:

> Fixed in the glibmm-2-54 branch. No fix is necessary in the master
> branch. The threads.hg and threads.h files don't exist there.

Closes: https://bugs.gentoo.org/654776
Bug: https://bugzilla.gnome.org/show_bug.cgi?id=791711