### PR TITLE
www-servers/h2o: fix build with LibreSSL 2.7

### DIFF
--- a/www-servers/h2o/files/h2o-2.2.4-libressl.patch
+++ b/www-servers/h2o/files/h2o-2.2.4-libressl.patch
@@ -1,0 +1,54 @@
+--- a/include/h2o/openssl_backport.h
++++ b/include/h2o/openssl_backport.h
+@@ -25,7 +25,7 @@
+ #include <stdlib.h>
+
+ /* backports for OpenSSL 1.0.2 */
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+
+ #define BIO_get_data(bio) ((bio)->ptr)
+ #define BIO_set_data(bio, p) ((bio)->ptr = (p))
+@@ -57,7 +58,7 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
+ #endif
+
+ /* backports for OpenSSL 1.0.1 and LibreSSL */
+-#if OPENSSL_VERSION_NUMBER < 0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10002000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+
+ #define SSL_is_server(ssl) ((ssl)->server)
+
+--- a/deps/neverbleed/neverbleed.c
++++ b/deps/neverbleed/neverbleed.c
+@@ -547,7 +547,7 @@ static int sign_stub(struct expbuf_t *buf)
+     return 0;
+ }
+
+-#if !OPENSSL_1_1_API
++#if !OPENSSL_1_1_API && (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+
+ static void RSA_get0_key(const RSA *rsa, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+ {
+
+--- a/deps/picotls/lib/openssl.c
++++ b/deps/picotls/lib/openssl.c
+@@ -41,13 +41,15 @@
+ #include "picotls.h"
+ #include "picotls/openssl.h"
+
+-#if (OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER))
+-#define OPENSSL_1_0_API 1
++#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
++#define OPENSSL_1_1_API 1
++#elif defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL
++#define OPENSSL_1_1_API 1
+ #else
+-#define OPENSSL_1_0_API 0
++#define OPENSSL_1_1_API 0
+ #endif
+
+-#if OPENSSL_1_0_API
++#if !OPENSSL_1_1_API
+
+ #define EVP_PKEY_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_EVP_PKEY)
+ #define X509_STORE_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_X509_STORE)

--- a/www-servers/h2o/h2o-2.2.4.ebuild
+++ b/www-servers/h2o/h2o-2.2.4.ebuild
@@ -25,6 +25,8 @@ DEPEND="${RDEPEND}
 		${RUBY_DEPS}
 	)"
 
+PATCHES=( "${FILESDIR}"/${P}-libressl.patch )
+
 pkg_setup() {
 	enewgroup h2o
 	enewuser h2o -1 -1 -1 h2o


### PR DESCRIPTION
- LibreSSL 2.7 implements OpenSSL 1.1 API
- Use patch from upstream: h2o/h2o#1706

Package-Manager: Portage-2.3.36, Repoman-2.3.9