### PR TITLE
app-emulation/virtualbox-modules: respect CC, don't check TRIM_UNUSED_KSYMS

### DIFF
--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.1.32.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.1.32.ebuild
@@ -34,7 +34,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.1.32.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.1.32.ebuild
@@ -28,12 +28,7 @@ MODULE_NAMES="vboxdrv(misc:${S}) vboxnetflt(misc:${S}) vboxnetadp(misc:${S}) vbo
 
 pkg_setup() {
 	enewgroup vboxusers
-
-	CONFIG_CHECK="!TRIM_UNUSED_KSYMS"
-	ERROR_TRIM_UNUSED_KSYMS="The kernel option CONFIG_TRIM_UNUSED_KSYMS removed kernel symbols that are needed by ${PN} to load correctly."
-
 	linux-mod_pkg_setup
-
 	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.1.34.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.1.34.ebuild
@@ -34,7 +34,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.1.34.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.1.34.ebuild
@@ -28,12 +28,7 @@ MODULE_NAMES="vboxdrv(misc:${S}) vboxnetflt(misc:${S}) vboxnetadp(misc:${S}) vbo
 
 pkg_setup() {
 	enewgroup vboxusers
-
-	CONFIG_CHECK="!TRIM_UNUSED_KSYMS"
-	ERROR_TRIM_UNUSED_KSYMS="The kernel option CONFIG_TRIM_UNUSED_KSYMS removed kernel symbols that are needed by ${PN} to load correctly."
-
 	linux-mod_pkg_setup
-
 	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.1.36.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.1.36.ebuild
@@ -34,7 +34,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.1.36.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.1.36.ebuild
@@ -28,12 +28,7 @@ MODULE_NAMES="vboxdrv(misc:${S}) vboxnetflt(misc:${S}) vboxnetadp(misc:${S}) vbo
 
 pkg_setup() {
 	enewgroup vboxusers
-
-	CONFIG_CHECK="!TRIM_UNUSED_KSYMS"
-	ERROR_TRIM_UNUSED_KSYMS="The kernel option CONFIG_TRIM_UNUSED_KSYMS removed kernel symbols that are needed by ${PN} to load correctly."
-
 	linux-mod_pkg_setup
-
 	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.2.10.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.2.10.ebuild
@@ -34,7 +34,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.2.10.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.2.10.ebuild
@@ -28,12 +28,7 @@ MODULE_NAMES="vboxdrv(misc:${S}) vboxnetflt(misc:${S}) vboxnetadp(misc:${S}) vbo
 
 pkg_setup() {
 	enewgroup vboxusers
-
-	CONFIG_CHECK="!TRIM_UNUSED_KSYMS"
-	ERROR_TRIM_UNUSED_KSYMS="The kernel option CONFIG_TRIM_UNUSED_KSYMS removed kernel symbols that are needed by ${PN} to load correctly."
-
 	linux-mod_pkg_setup
-
 	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.2.8.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.2.8.ebuild
@@ -34,7 +34,7 @@ pkg_setup() {
 
 	linux-mod_pkg_setup
 
-	BUILD_PARAMS="KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-5.2.8.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-5.2.8.ebuild
@@ -28,12 +28,7 @@ MODULE_NAMES="vboxdrv(misc:${S}) vboxnetflt(misc:${S}) vboxnetadp(misc:${S}) vbo
 
 pkg_setup() {
 	enewgroup vboxusers
-
-	CONFIG_CHECK="!TRIM_UNUSED_KSYMS"
-	ERROR_TRIM_UNUSED_KSYMS="The kernel option CONFIG_TRIM_UNUSED_KSYMS removed kernel symbols that are needed by ${PN} to load correctly."
-
 	linux-mod_pkg_setup
-
 	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 


### PR DESCRIPTION
remove superfluous TRIM_UNUSED_KSYMS check
It's enforced by eclass, see #591832 or df7f1d7932de1cc6b8f9027a26d6e4c8dc65ca07
Also try to fix CC variable handling.
Closes: https://bugs.gentoo.org/655306
