### PR TITLE
media-gfx/curaengine: Fix StringTest for 32-bit arches

### DIFF
--- a/media-gfx/curaengine/curaengine-2.3.1-r2.ebuild
+++ b/media-gfx/curaengine/curaengine-2.3.1-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+inherit cmake-utils
+
+MY_PN=CuraEngine
+MY_PV=${PV/_beta}
+
+DESCRIPTION="A 3D model slicing engine for 3D printing"
+HOMEPAGE="https://github.com/Ultimaker/CuraEngine"
+SRC_URI="https://github.com/Ultimaker/${MY_PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
+KEYWORDS="~amd64 ~x86"
+
+LICENSE="AGPL-3"
+SLOT="0"
+IUSE="doc test"
+
+RDEPEND="${PYTHON_DEPS}
+	dev-libs/libarcus:=
+	>=dev-libs/protobuf-3"
+DEPEND="${RDEPEND}
+	doc? ( app-doc/doxygen
+	       media-gfx/graphviz )
+	test? ( dev-util/cppunit )"
+
+S="${WORKDIR}/${MY_PN}-${MY_PV}"
+DOCS=( "README.md" )
+PATCHES=( "${FILESDIR}/${P}-remove-gcodeplannertest.patch"
+	  "${FILESDIR}/${P}-make-stringtest-64bit-safe.patch"
+	  "${FILESDIR}/${P}-fix-stringtest-int-types.patch" )
+
+src_configure() {
+	local mycmakeargs=( "-DBUILD_TESTS=$(usex test ON OFF)" )
+	cmake-utils_src_configure
+}
+
+src_compile() {
+	cmake-utils_src_make
+	if use doc; then
+		doxygen || die
+		mv docs/html . || die
+		find html -name '*.md5' -or -name '*.map' -delete || die
+		HTML_DOCS=( html/. )
+	fi
+}

--- a/media-gfx/curaengine/files/curaengine-2.3.1-fix-stringtest-int-types.patch
+++ b/media-gfx/curaengine/files/curaengine-2.3.1-fix-stringtest-int-types.patch
@@ -1,0 +1,43 @@
+From fe45e504ace024d920fe18b4f55d6aa07b2f929b Mon Sep 17 00:00:00 2001
+From: Ghostkeeper <rubend@tutanota.com>
+Date: Mon, 20 Nov 2017 10:46:09 +0100
+Subject: [PATCH] Use ints instead of int64_t to test writing ints
+
+Because sprintf doesn't accept anything more.
+---
+ tests/utils/StringTest.cpp | 4 ++--
+ tests/utils/StringTest.h   | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/utils/StringTest.cpp b/tests/utils/StringTest.cpp
+index 5bd16c5d3..980d2145f 100644
+--- a/tests/utils/StringTest.cpp
++++ b/tests/utils/StringTest.cpp
+@@ -71,12 +71,12 @@ void StringTest::writeInt2mmTestMax()
+ }
+ 
+ 
+-void StringTest::writeInt2mmAssert(int64_t in)
++void StringTest::writeInt2mmAssert(int in)
+ {
+     std::ostringstream ss;
+     writeInt2mm(in, ss);
+     std::string str = ss.str();
+-    int64_t out = MM2INT(strtod(str.c_str(), nullptr));
++    int out = MM2INT(strtod(str.c_str(), nullptr));
+ 
+     char buffer[200];
+     sprintf(buffer, "The integer %d was printed as '%s' which was interpreted as %d rather than %d!", in, str.c_str(), out, in);
+diff --git a/tests/utils/StringTest.h b/tests/utils/StringTest.h
+index 58be00642..da1da793a 100644
+--- a/tests/utils/StringTest.h
++++ b/tests/utils/StringTest.h
+@@ -68,7 +68,7 @@ class StringTest : public CppUnit::TestFixture
+      * 
+      * \param in the integer to check
+      */
+-    void writeInt2mmAssert(int64_t in);
++    void writeInt2mmAssert(int in);
+ };
+ 
+ }

--- a/media-gfx/curaengine/files/curaengine-2.3.1-make-stringtest-64bit-safe.patch
+++ b/media-gfx/curaengine/files/curaengine-2.3.1-make-stringtest-64bit-safe.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/utils/StringTest.cpp b/tests/utils/StringTest.cpp
+index aa369f3da..b1a084587 100644
+--- a/tests/utils/StringTest.cpp
++++ b/tests/utils/StringTest.cpp
+@@ -79,7 +79,7 @@ void StringTest::writeInt2mmAssert(int64_t in)
+     int64_t out = MM2INT(strtod(str.c_str(), nullptr));
+ 
+     char buffer[200];
+-    sprintf(buffer, "The integer %ld was printed as '%s' which was interpreted as %ld rather than %ld!", in, str.c_str(), out, in);
++    sprintf(buffer, "The integer %d was printed as '%s' which was interpreted as %d rather than %d!", in, str.c_str(), out, in);
+     CPPUNIT_ASSERT_MESSAGE(std::string(buffer), in == out);
+ }
+ 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/655116
Package-Manager: Portage-2.3.13, Repoman-2.3.3