### PR TITLE
www-client/firefox: bump dependency on dev-libs/nspr to 4.19

### DIFF
--- a/www-client/firefox/firefox-60.0.ebuild
+++ b/www-client/firefox/firefox-60.0.ebuild
@@ -57,7 +57,7 @@ RDEPEND="
 	system-icu? ( >=dev-libs/icu-60.2 )
 	jack? ( virtual/jack )
 	>=dev-libs/nss-3.35
-	>=dev-libs/nspr-4.18
+	>=dev-libs/nspr-4.19
 	selinux? ( sec-policy/selinux-mozilla )"
 
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/655524
Package-Manager: Portage-2.3.24, Repoman-2.3.6