### PR TITLE
www-client/firefox: bump dependency on dev-libs/nss to 3.36.1

### DIFF
--- a/www-client/firefox/firefox-60.0.ebuild
+++ b/www-client/firefox/firefox-60.0.ebuild
@@ -56,7 +56,7 @@ ASM_DEPEND=">=dev-lang/yasm-1.1"
 RDEPEND="
 	system-icu? ( >=dev-libs/icu-60.2 )
 	jack? ( virtual/jack )
-	>=dev-libs/nss-3.35
+	>=dev-libs/nss-3.36.1
 	>=dev-libs/nspr-4.18
 	selinux? ( sec-policy/selinux-mozilla )"
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/655528
Package-Manager: Portage-2.3.24, Repoman-2.3.6