### PR TITLE
dev-libs/tinyxml: add pkgconfig 'tinyxml.pc' file

### DIFF
--- a/dev-libs/tinyxml/files/tinyxml.pc.patch
+++ b/dev-libs/tinyxml/files/tinyxml.pc.patch
@@ -1,0 +1,14 @@
+diff -Naur old/tinyxml.pc new/tinyxml.pc
+--- /dev/null	1970-01-01 03:00:00.000000000 +0300
++++ tinyxml.pc	2018-05-07 01:46:25.000000000 +0300
+@@ -0,0 +1,10 @@
++prefix=/usr
++exec_prefix=${prefix}
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
++
++Name: TinyXml
++Description: simple, small, C++ XML parser
++Version: 2.6.2
++Libs: -L${libdir} -ltinyxml
++Cflags: -I${includedir}

--- a/dev-libs/tinyxml/tinyxml-2.6.2-r3.ebuild
+++ b/dev-libs/tinyxml/tinyxml-2.6.2-r3.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit flag-o-matic toolchain-funcs eutils multilib versionator
+
+DESCRIPTION="Simple and small C++ XML parser"
+HOMEPAGE="http://www.grinninglizard.com/tinyxml/index.html"
+SRC_URI="mirror://sourceforge/${PN}/${PN}_${PV//./_}.tar.gz"
+
+LICENSE="ZLIB"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x64-macos ~x86-macos"
+IUSE="debug doc static-libs +stl"
+
+RDEPEND=""
+DEPEND="doc? ( app-doc/doxygen )"
+
+S="${WORKDIR}/${PN}"
+
+src_prepare() {
+	local major_v=$(get_major_version)
+	local minor_v=$(get_version_component_range 2-3)
+
+	sed -e "s:@MAJOR_V@:$major_v:" \
+	    -e "s:@MINOR_V@:$minor_v:" \
+		"${FILESDIR}"/Makefile-3 > Makefile || die
+
+	epatch "${FILESDIR}"/${PN}-2.6.1-entity.patch
+	epatch "${FILESDIR}"/${PN}.pc.patch
+
+	use debug && append-cppflags -DDEBUG
+	use stl && epatch "${FILESDIR}"/${P}-defineSTL.patch
+
+	if use stl; then
+		sed -e "s/Cflags: -I\${includedir}/Cflags: -I\${includedir} -DTIXML_USE_STL=YES/g" -i tinyxml.pc || die
+	fi
+
+	if ! use static-libs; then
+		sed -e "/^all:/s/\$(name).a //" -i Makefile || die
+	fi
+
+	tc-export AR CXX RANLIB
+
+	[[ ${CHOST} == *-darwin* ]] && export LIBDIR="${EPREFIX}"/usr/$(get_libdir)
+	eapply_user
+}
+
+src_install() {
+	dolib.so *$(get_libname)*
+
+	insinto /usr/include
+	doins *.h
+
+	insinto /usr/share/pkgconfig
+	doins tinyxml.pc
+
+	dodoc {changes,readme}.txt
+
+	use doc && dohtml -r docs/*
+}


### PR DESCRIPTION
Add 'tinyxml.pc' file to /usr/share/pkgconfig during installation.
This file could be required by some applications during configure stage,
e.g. dev-util/codeblocks-17.12 (currently uses bundled tinyxml).

If dev-libs/tinyxml build with USE="stl" then additional flag "-DTIXML_USE_STL=YES" 
is added to "Cflags:" option of 'tinyxml.pc' file.