### PR TITLE
lxqt-base/*, media-gfx/lximage, x11-{libs,misc}/*: use HTTPs

### DIFF
--- a/lxqt-base/lxqt-policykit/lxqt-policykit-0.11.0.ebuild
+++ b/lxqt-base/lxqt-policykit/lxqt-policykit-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQt PolKit authentication agent"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/lxqt-base/lxqt-powermanagement/lxqt-powermanagement-0.11.0.ebuild
+++ b/lxqt-base/lxqt-powermanagement/lxqt-powermanagement-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQt daemon for power management and auto-suspend"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/lxqt-base/lxqt-qtplugin/lxqt-qtplugin-0.11.0.ebuild
+++ b/lxqt-base/lxqt-qtplugin/lxqt-qtplugin-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQt system integration plugin for Qt"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/lxqt-base/lxqt-runner/lxqt-runner-0.11.0.ebuild
+++ b/lxqt-base/lxqt-runner/lxqt-runner-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQt quick launcher"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/lxqt-base/lxqt-session/lxqt-session-0.11.0.ebuild
+++ b/lxqt-base/lxqt-session/lxqt-session-0.11.0.ebuild
@@ -6,11 +6,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQT session manager"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/lxqt-base/lxqt-sudo/lxqt-sudo-0.11.0.ebuild
+++ b/lxqt-base/lxqt-sudo/lxqt-sudo-0.11.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXQt GUI frontend for sudo"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/media-gfx/lximage-qt/lximage-qt-0.4.0.ebuild
+++ b/media-gfx/lximage-qt/lximage-qt-0.4.0.ebuild
@@ -5,11 +5,11 @@ EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="LXImage Image Viewer - GPicView replacement"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/media-gfx/lximage-qt/lximage-qt-0.5.0.ebuild
+++ b/media-gfx/lximage-qt/lximage-qt-0.5.0.ebuild
@@ -5,11 +5,11 @@ EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="LXImage Image Viewer - GPicView replacement"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm64 x86"

--- a/x11-libs/libfm-qt/libfm-qt-0.11.1.ebuild
+++ b/x11-libs/libfm-qt/libfm-qt-0.11.1.ebuild
@@ -7,14 +7,14 @@ inherit cmake-utils
 
 if [[ "${PV}" == "9999" ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}"
 else
 	SRC_URI="https://github.com/lxde/${PN}/releases/download/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"
 fi
 
 DESCRIPTION="Qt port of libfm, a library providing components to build desktop file managers"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 LICENSE="LGPL-2.1+"
 SLOT="0/3"

--- a/x11-misc/obconf-qt/obconf-qt-0.9.0_p20150729.ebuild
+++ b/x11-misc/obconf-qt/obconf-qt-0.9.0_p20150729.ebuild
@@ -1,15 +1,15 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit cmake-utils
 
 DESCRIPTION="Openbox window manager configuration tool"
-HOMEPAGE="http://lxqt.org/"
+HOMEPAGE="https://lxqt.org"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
+	EGIT_REPO_URI="https://git.lxde.org/git/lxde/${PN}.git"
 else
 	SRC_URI="https://dev.gentoo.org/~jauhien/distfiles/${P}.tar.gz"
 	KEYWORDS="amd64 ~arm ~arm64 x86"


### PR DESCRIPTION
Hi, 

Concerning https://github.com/gentoo/gentoo/pull/8305#issuecomment-388403911 i've added another PR to fix all other lxqt related packages to use https instead of http.

Please review. @johu 