### PR TITLE
Media radio/ax25 tools

### DIFF
--- a/media-radio/ax25-tools/ax25-tools-0.0.10_rc4.ebuild
+++ b/media-radio/ax25-tools/ax25-tools-0.0.10_rc4.ebuild
@@ -22,6 +22,13 @@ DEPEND="dev-libs/libax25
 		media-libs/mesa )"
 RDEPEND=${DEPEND}
 
+src_prepare() {
+        for filename in 6pack/m6pack.c kiss/kissattach.c kiss/kissnetd.c kiss/mkiss.c kiss/net2kiss.c;
+        do
+            sed -i -e "s/__USE_XOPEN/__USE_XOPEN_EXTENDED/g" $filename
+        done
+}
+
 src_configure() {
 	econf $(use_with X x)
 }


### PR DESCRIPTION
KISS applications aren't working anymore, because there is a segfault during execution.
See 'https://bugzilla.redhat.com/show_bug.cgi?id=1520042' for more detail.
After modifying source files, everything is running fine again. (Tested by me on x86-64 machine)
