### PR TITLE
sys-block/targetcli-fb: fix python3 compatibility

### DIFF
--- a/sys-block/targetcli-fb/files/targetcli-fb-2.1.48-python3.patch
+++ b/sys-block/targetcli-fb/files/targetcli-fb-2.1.48-python3.patch
@@ -1,0 +1,23 @@
+From ed5ff9b9505e50b545e86dfbdd32077f0ddda0cb Mon Sep 17 00:00:00 2001
+From: Taylor Jakobson <tjakobs@us.ibm.com>
+Date: Thu, 1 Feb 2018 14:44:32 -0600
+Subject: [PATCH] Use signed char instead of char
+
+Python3 does not have the "character" type, use signed char instead.
+---
+ targetcli/ui_backstore.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/targetcli/ui_backstore.py b/targetcli/ui_backstore.py
+index 3a2db10..5af448f 100644
+--- a/targetcli/ui_backstore.py
++++ b/targetcli/ui_backstore.py
+@@ -536,7 +536,7 @@ def _ui_block_ro_check(self, dev):
+         except (OSError, IOError):
+             raise ExecutionError("Could not open %s" % dev)
+         # ioctl returns an int. Provision a buffer for it
+-        buf = array.array('c', [chr(0)] * 4)
++        buf = array.array('b', [0] * 4)
+         try:
+             fcntl.ioctl(f, BLKROGET, buf)
+         except (OSError, IOError):

--- a/sys-block/targetcli-fb/targetcli-fb-2.1.48-r2.ebuild
+++ b/sys-block/targetcli-fb/targetcli-fb-2.1.48-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+
+inherit distutils-r1 versionator
+
+MY_PV=$(replace_version_separator 2 '.fb' ${PV})
+
+DESCRIPTION="Command shell for managing Linux LIO kernel target"
+HOMEPAGE="https://github.com/open-iscsi/targetcli-fb"
+SRC_URI="https://github.com/open-iscsi/${PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+RDEPEND="dev-python/configshell-fb[${PYTHON_USEDEP}]
+	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	>=dev-python/rtslib-fb-2.1.62[${PYTHON_USEDEP}]
+	dev-python/six[${PYTHON_USEDEP}]
+	!sys-block/targetcli"
+
+S="${WORKDIR}/${PN}-${MY_PV}"
+
+PATCHES=( "${FILESDIR}/${P}-python3.patch" )
+
+src_install() {
+	distutils-r1_src_install
+
+	keepdir /etc/target /etc/target/backup
+	doman targetcli.8
+}


### PR DESCRIPTION
Fix a crash under python3 when creating a block-based backstore.

Closes: https://bugs.gentoo.org/654756