### PR TITLE
profiles: add default llvm_targets for rust

### DIFF
--- a/profiles/arch/amd64/package.use.force
+++ b/profiles/arch/amd64/package.use.force
@@ -1,6 +1,10 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Georgy Yakovlev <ya@sysdump.net> (14 May 2018)
+# Force the host target to avoid dependency hell
+dev-lang/rust llvm_targets_X86
+
 # NP-Hardass <NP-Hardass@gentoo.org> (23 May 2017)
 # Packages with optional 64-bit variant
 app-emulation/wine-vanilla -abi_x86_64

--- a/profiles/arch/arm64/package.use.force
+++ b/profiles/arch/arm64/package.use.force
@@ -1,6 +1,10 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Georgy Yakovlev <ya@sysdump.net> (14 May 2018)
+# Force the host target to avoid dependency hell
+dev-lang/rust llvm_targets_AArch64
+
 # Michał Górny <mgorny@gentoo.org> (24 Sep 2016)
 # Force the host target to avoid dependency hell
 sys-devel/clang llvm_targets_AArch64

--- a/profiles/arch/x86/package.use.force
+++ b/profiles/arch/x86/package.use.force
@@ -1,6 +1,10 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Georgy Yakovlev <ya@sysdump.net> (14 May 2018)
+# Force the host target to avoid dependency hell 
+dev-lang/rust llvm_targets_X86
+
 # Michał Górny <mgorny@gentoo.org> (24 Sep 2016)
 # Force the host target to avoid dependency hell
 sys-devel/clang llvm_targets_X86


### PR DESCRIPTION
It's not installable without user invervention
with latest changes.
```sh
!!! The ebuild selected to satisfy "dev-lang/rust" has unmet
requirements.
- dev-lang/rust-1.26.0::gentoo USE="-debug -doc (-extended) -jemalloc"
ABI_X86="(64)" LLVM_TARGETS="-AArch64 -AMDGPU -ARM -BPF -Hexagon -Lanai
-MSP430 -Mips -NVPTX -PowerPC -Sparc -SystemZ -X86 -XCore"
```

Treat is the same way as llvm/clang does.
Not touching musl/uclibc profiles, since they
maintain their own rust ebuild.