### PR TITLE
sys-fs/lvm2: Fix correct order for applying patches

### DIFF
--- a/sys-fs/lvm2/lvm2-2.02.171.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.171.ebuild
@@ -66,9 +66,9 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.02.99-locale-muck.patch #330373
 	"${FILESDIR}"/${PN}-2.02.70-asneeded.patch # -Wl,--as-needed
 	"${FILESDIR}"/${PN}-2.02.139-dynamic-static-ldflags.patch #332905
-	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	"${FILESDIR}"/${PN}-2.02.129-static-pkgconfig-libs.patch #370217, #439414 + blkid
 	"${FILESDIR}"/${PN}-2.02.130-pthread-pkgconfig.patch #492450
+	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	#"${FILESDIR}"/${PN}-2.02.145-mkdev.patch #580062 # Merged upstream
 )
 

--- a/sys-fs/lvm2/lvm2-2.02.172.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.172.ebuild
@@ -66,9 +66,9 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.02.99-locale-muck.patch #330373
 	"${FILESDIR}"/${PN}-2.02.70-asneeded.patch # -Wl,--as-needed
 	"${FILESDIR}"/${PN}-2.02.139-dynamic-static-ldflags.patch #332905
-	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	"${FILESDIR}"/${PN}-2.02.172-static-pkgconfig-libs.patch #370217, #439414 + blkid
 	"${FILESDIR}"/${PN}-2.02.130-pthread-pkgconfig.patch #492450
+	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	#"${FILESDIR}"/${PN}-2.02.145-mkdev.patch #580062 # Merged upstream
 )
 

--- a/sys-fs/lvm2/lvm2-2.02.173.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.173.ebuild
@@ -66,9 +66,9 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.02.99-locale-muck.patch #330373
 	"${FILESDIR}"/${PN}-2.02.70-asneeded.patch # -Wl,--as-needed
 	"${FILESDIR}"/${PN}-2.02.139-dynamic-static-ldflags.patch #332905
-	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	"${FILESDIR}"/${PN}-2.02.172-static-pkgconfig-libs.patch #370217, #439414 + blkid
 	"${FILESDIR}"/${PN}-2.02.130-pthread-pkgconfig.patch #492450
+	"${FILESDIR}"/${PN}-2.02.171-static-libm.patch #617756
 	#"${FILESDIR}"/${PN}-2.02.145-mkdev.patch #580062 # Merged upstream
 )
 


### PR DESCRIPTION
Don't have a clue, why I haven't noticed that.. Sorry! :/

Closes: https://bugs.gentoo.org/617756
Package-Manager: Portage-2.3.36, Repoman-2.3.9