### PR TITLE
sys-apps/busybox: QA don't use dohtml

### DIFF
--- a/sys-apps/busybox/busybox-1.28.3.ebuild
+++ b/sys-apps/busybox/busybox-1.28.3.ebuild
@@ -285,7 +285,8 @@ src_install() {
 	dodoc *.txt
 	docinto pod
 	dodoc *.pod
-	dohtml *.html
+	docinto html
+	dodoc *.html
 
 	cd ../examples
 	docinto examples

--- a/sys-apps/busybox/busybox-9999.ebuild
+++ b/sys-apps/busybox/busybox-9999.ebuild
@@ -285,7 +285,8 @@ src_install() {
 	dodoc *.txt
 	docinto pod
 	dodoc *.pod
-	dohtml *.html
+	docinto html
+	dodoc *.html
 
 	cd ../examples
 	docinto examples


### PR DESCRIPTION
Fixes:
QA: install

'dohtml' is deprecated in EAPI '6'

Also install html docs into html subdir.
Before that html docs ended up in pod,
because of 'docinto pod' above

Package-Manager: Portage-2.3.36, Repoman-2.3.9