### PR TITLE
net-ftp/atftp: fix collision with net-ftp/uftpd

### DIFF
--- a/net-ftp/atftp/atftp-0.7-r3.ebuild
+++ b/net-ftp/atftp/atftp-0.7-r3.ebuild
@@ -23,6 +23,7 @@ DEPEND="tcpd? ( sys-apps/tcp-wrappers )
 RDEPEND="${DEPEND}
 	!net-ftp/netkit-tftp
 	!net-ftp/tftp-hpa
+	!net-ftp/uftpd
 	selinux? ( sec-policy/selinux-tftp )"
 
 src_prepare() {

--- a/net-ftp/atftp/atftp-0.7-r5.ebuild
+++ b/net-ftp/atftp/atftp-0.7-r5.ebuild
@@ -23,6 +23,7 @@ DEPEND="tcpd? ( sys-apps/tcp-wrappers )
 RDEPEND="${DEPEND}
 	!net-ftp/netkit-tftp
 	!net-ftp/tftp-hpa
+	!net-ftp/uftpd
 	selinux? ( sec-policy/selinux-tftp )"
 
 PATCHES=(


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/648984
Closes: https://bugs.gentoo.org/648984
Package-Manager: Portage-2.3.24, Repoman-2.3.6


```
$ diff -u atftp-0.7-r5.ebuild atftp-0.7-r6.ebuild 
--- atftp-0.7-r5.ebuild	2017-12-06 16:19:38.544007078 +0100
+++ atftp-0.7-r6.ebuild	2018-05-15 03:47:37.092350115 +0200
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~s390 ~sparc ~x86"
 IUSE="selinux tcpd readline pcre"
 
 DEPEND="tcpd? ( sys-apps/tcp-wrappers )
@@ -23,6 +23,7 @@
 RDEPEND="${DEPEND}
 	!net-ftp/netkit-tftp
 	!net-ftp/tftp-hpa
+	!net-ftp/uftpd
 	selinux? ( sec-policy/selinux-tftp )"
 
 PATCHES=(
```