### PR TITLE
net-dns/dnscrypt-proxy: QA minor openrc nits

### DIFF
--- a/net-dns/dnscrypt-proxy/files/dnscrypt-proxy-2.confd
+++ b/net-dns/dnscrypt-proxy/files/dnscrypt-proxy-2.confd
@@ -1,3 +1,3 @@
-#DNSCRYPT_PROXY_OPTS="--config /etc/dnscrypt-proxy/dnscrypt-proxy.toml"
+#DNSCRYPT_PROXY_OPTS="-config /etc/dnscrypt-proxy/dnscrypt-proxy.toml"
 #DNSCRYPT_PROXY_USER="dnscrypt-proxy"
 #DNSCRYPT_PROXY_GROUP="dnscrypt-proxy"

--- a/net-dns/dnscrypt-proxy/files/dnscrypt-proxy-2.initd
+++ b/net-dns/dnscrypt-proxy/files/dnscrypt-proxy-2.initd
@@ -14,6 +14,6 @@ depend() {
 }
 
 start_pre() {
-        checkpath -q -d -m 0775 -o "${command_user}" /var/cache/"${SVCNAME}"
-        checkpath -q -d -m 0775 -o "${command_user}" /var/log/"${SVCNAME}"
+        checkpath -q -d -m 0775 -o "${command_user}" /var/cache/"${RC_SVCNAME}"
+        checkpath -q -d -m 0775 -o "${command_user}" /var/log/"${RC_SVCNAME}"
 }


### PR DESCRIPTION
Just minor nits.
RC_SVCNAME is preferred for like 10 years.
Package-Manager: Portage-2.3.36, Repoman-2.3.9