### PR TITLE
net-dns/avahi: QA dohtml is deprecated with EAPI6

### DIFF
--- a/net-dns/avahi/avahi-0.7-r1.ebuild
+++ b/net-dns/avahi/avahi-0.7-r1.ebuild
@@ -186,7 +186,8 @@ multilib_src_install() {
 	use mdnsresponder-compat && dosym avahi-compat-libdns_sd/dns_sd.h /usr/include/dns_sd.h
 
 	if multilib_is_native_abi && use doc; then
-		dohtml -r doxygen/html/. || die
+		docinto html
+		dodoc -r doxygen/html/.
 		insinto /usr/share/devhelp/books/avahi
 		doins avahi.devhelp || die
 	fi

--- a/net-dns/avahi/avahi-0.7.ebuild
+++ b/net-dns/avahi/avahi-0.7.ebuild
@@ -184,7 +184,8 @@ multilib_src_install() {
 	use mdnsresponder-compat && dosym avahi-compat-libdns_sd/dns_sd.h /usr/include/dns_sd.h
 
 	if multilib_is_native_abi && use doc; then
-		dohtml -r doxygen/html/. || die
+		docinto html
+		dodoc -r doxygen/html/.
 		insinto /usr/share/devhelp/books/avahi
 		doins avahi.devhelp || die
 	fi


### PR DESCRIPTION
Get rid of it.
@blueness this one is last from you,
won't bug you again on this ;)

Package-Manager: Portage-2.3.36, Repoman-2.3.9