### PR TITLE
dev-util/android-sdk-update-manager: use HTTPS

### DIFF
--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-21.1.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-21.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -91,7 +91,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-21.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-21.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -91,7 +91,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.1-r1.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -91,7 +91,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.1.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -91,7 +91,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.4.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -91,7 +91,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.5-r1.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -92,7 +92,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.5.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -91,7 +91,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.2.1.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -92,7 +92,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.3.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user udev
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -94,7 +94,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.6.1.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user udev
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -94,7 +94,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.6.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user udev
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -94,7 +94,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit eutils user
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -91,7 +91,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-23-r1.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-23-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user udev
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -94,7 +94,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-23.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-23.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user udev
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -94,7 +94,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"

--- a/dev-util/android-sdk-update-manager/android-sdk-update-manager-24.4.1.ebuild
+++ b/dev-util/android-sdk-update-manager/android-sdk-update-manager-24.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit eutils user udev
 MY_P="android-sdk_r${PV}-linux"
 
 DESCRIPTION="Open Handset Alliance's Android SDK"
-HOMEPAGE="http://developer.android.com"
+HOMEPAGE="https://developer.android.com"
 SRC_URI="https://dl.google.com/android/${MY_P}.tgz"
 IUSE=""
 RESTRICT="mirror"
@@ -94,7 +94,7 @@ pkg_postinst() {
 	elog "Run 'android' to download the full SDK, including some of the platform tools."
 	elog "You must be in the android group to manage the development environment."
 	elog "Just run 'gpasswd -a <USER> android', then have <USER> re-login."
-	elog "See http://developer.android.com/sdk/adding-components.html for more"
+	elog "See https://developer.android.com/sdk/adding-components.html for more"
 	elog "information."
 	elog "If you have problems downloading the SDK, see https://code.google.com/p/android/issues/detail?id=4406"
 	elog "You need to run env-update and source /etc/profile in any open shells"


### PR DESCRIPTION
Hi,

This fixes dev-util/android-sdk-update-manager to use https instead of http.

Please review.