### PR TITLE
app-text/txt2tags: use HTTPS

### DIFF
--- a/app-text/txt2tags/txt2tags-2.6-r1.ebuild
+++ b/app-text/txt2tags/txt2tags-2.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ PYTHON_REQ_USE="tk?"
 inherit eutils elisp-common python-single-r1
 
 DESCRIPTION="Generate marked up documents (HTML, etc.)from a plain text file with markup"
-HOMEPAGE="http://txt2tags.org/"
+HOMEPAGE="https://txt2tags.org"
 SRC_URI="https://${PN}.googlecode.com/files/${P}.tgz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This PR fixes app-text/txt2tags to use https instead of http.

Please review.