### PR TITLE
net-im/psi: use HTTPS

### DIFF
--- a/net-im/psi/psi-1.3-r1.ebuild
+++ b/net-im/psi/psi-1.3-r1.ebuild
@@ -9,7 +9,7 @@ PLOCALE_BACKUP="en"
 inherit l10n qmake-utils xdg-utils
 
 DESCRIPTION="Qt XMPP client"
-HOMEPAGE="http://psi-im.org/"
+HOMEPAGE="https://psi-im.org"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz
 	https://github.com/psi-im/psi-l10n/archive/${PV}.tar.gz -> psi-l10n-${PV}.tar.gz"
 

--- a/net-im/psi/psi-9999.ebuild
+++ b/net-im/psi/psi-9999.ebuild
@@ -9,7 +9,7 @@ PLOCALE_BACKUP="en"
 inherit l10n git-r3 qmake-utils gnome2-utils xdg-utils
 
 DESCRIPTION="Qt XMPP client"
-HOMEPAGE="http://psi-im.org/"
+HOMEPAGE="https://psi-im.org"
 
 PSI_URI="https://github.com/psi-im"
 PSI_PLUS_URI="https://github.com/psi-plus"


### PR DESCRIPTION
Hi,

This PR fixes net-im/psi to use https instead of http.

Please review.