### PR TITLE
app-emacs/{markdown-mode,scala-mode,distel,moccur-edit}: use HTTPS

### DIFF
--- a/app-emacs/distel/distel-4.0.6.ebuild
+++ b/app-emacs/distel/distel-4.0.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="Distributed Emacs Lisp for Erlang"
 HOMEPAGE="https://code.google.com/p/distel/
-	http://www.emacswiki.org/emacs/DistributedEmacsLisp"
+	https://www.emacswiki.org/emacs/DistributedEmacsLisp"
 SRC_URI="https://github.com/massemanet/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 # "New BSD License" according to https://code.google.com/p/distel/

--- a/app-emacs/markdown-mode/markdown-mode-2.3.ebuild
+++ b/app-emacs/markdown-mode/markdown-mode-2.3.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit elisp
 
 DESCRIPTION="Major mode for editing Markdown-formatted text files"
-HOMEPAGE="http://jblevins.org/projects/markdown-mode/"
+HOMEPAGE="https://jblevins.org/projects/markdown-mode/"
 SRC_URI="https://stable.melpa.org/packages/${P}.el"
 
 LICENSE="GPL-2+"

--- a/app-emacs/moccur-edit/moccur-edit-2.16.ebuild
+++ b/app-emacs/moccur-edit/moccur-edit-2.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ inherit elisp
 
 DESCRIPTION="An improved interface to color-moccur for editing"
 HOMEPAGE="http://www.bookshelf.jp/
-	http://www.emacswiki.org/emacs/SearchBuffers"
+	https://www.emacswiki.org/emacs/SearchBuffers"
 # taken from http://www.bookshelf.jp/elc/moccur-edit.el
 SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.el.bz2"
 

--- a/app-emacs/scala-mode/scala-mode-2.10.3.ebuild
+++ b/app-emacs/scala-mode/scala-mode-2.10.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,8 +7,8 @@ inherit elisp
 
 MY_P="scala-tool-support-${PV}"
 DESCRIPTION="Scala mode for Emacs"
-HOMEPAGE="http://www.scala-lang.org/"
-SRC_URI="http://www.scala-lang.org/files/archive/${MY_P}.tgz"
+HOMEPAGE="https://www.scala-lang.org/"
+SRC_URI="https://www.scala-lang.org/files/archive/${MY_P}.tgz"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes a few app-emacs packages to use https instead of http.

Please review.