### PR TITLE
dev-lua/lualdap, mail-mta/opensmtpd, sys-fs/ctmg, www-apps/cgit: use HTTPS

### DIFF
--- a/dev-lua/lualdap/lualdap-1.2.0.ebuild
+++ b/dev-lua/lualdap/lualdap-1.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,8 +8,8 @@ inherit eutils toolchain-funcs
 MY_PN="LuaLDAP"
 
 DESCRIPTION="Simple interface from Lua to OpenLDAP"
-HOMEPAGE="http://git.zx2c4.com/lualdap/about/"
-SRC_URI="http://git.zx2c4.com/${PN}/snapshot/${P}.tar.xz"
+HOMEPAGE="https://git.zx2c4.com/lualdap/about/"
+SRC_URI="https://git.zx2c4.com/${PN}/snapshot/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/mail-mta/opensmtpd/opensmtpd-6.0.2_p1-r1.ebuild
+++ b/mail-mta/opensmtpd/opensmtpd-6.0.2_p1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit multilib user flag-o-matic eutils pam toolchain-funcs autotools systemd versionator
 
 DESCRIPTION="Lightweight but featured SMTP daemon from OpenBSD"
-HOMEPAGE="http://www.opensmtpd.org/"
+HOMEPAGE="https://www.opensmtpd.org"
 MY_P="${P}"
 if [ $(get_last_version_component_index) -eq 4 ]; then
 	MY_P="${PN}-$(get_version_component_range 4-)"

--- a/mail-mta/opensmtpd/opensmtpd-6.0.2_p1-r2.ebuild
+++ b/mail-mta/opensmtpd/opensmtpd-6.0.2_p1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit multilib user flag-o-matic eutils pam toolchain-funcs autotools systemd versionator
 
 DESCRIPTION="Lightweight but featured SMTP daemon from OpenBSD"
-HOMEPAGE="http://www.opensmtpd.org/"
+HOMEPAGE="https://www.opensmtpd.org"
 MY_P="${P}"
 if [ $(get_last_version_component_index) -eq 4 ]; then
 	MY_P="${PN}-$(get_version_component_range 4-)"

--- a/mail-mta/opensmtpd/opensmtpd-6.0.2_p1.ebuild
+++ b/mail-mta/opensmtpd/opensmtpd-6.0.2_p1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit multilib user flag-o-matic eutils pam toolchain-funcs autotools systemd versionator
 
 DESCRIPTION="Lightweight but featured SMTP daemon from OpenBSD"
-HOMEPAGE="http://www.opensmtpd.org/"
+HOMEPAGE="https://www.opensmtpd.org"
 MY_P="${P}"
 if [ $(get_last_version_component_index) -eq 4 ]; then
 	MY_P="${PN}-$(get_version_component_range 4-)"

--- a/sys-fs/ctmg/ctmg-1.2.ebuild
+++ b/sys-fs/ctmg/ctmg-1.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 DESCRIPTION="Simple wrapper around cryptsetup for encrypted containers"
-HOMEPAGE="http://git.zx2c4.com/ctmg/about/"
-SRC_URI="http://git.zx2c4.com/${PN}/snapshot/${P}.tar.xz"
+HOMEPAGE="https://git.zx2c4.com/ctmg/about/"
+SRC_URI="https://git.zx2c4.com/${PN}/snapshot/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/www-apps/cgit/cgit-0.12.ebuild
+++ b/www-apps/cgit/cgit-0.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,9 +12,9 @@ inherit webapp eutils multilib user toolchain-funcs
 GIT_V="2.7.0"
 
 DESCRIPTION="a fast web-interface for git repositories"
-HOMEPAGE="http://git.zx2c4.com/cgit/about"
+HOMEPAGE="https://git.zx2c4.com/cgit/about"
 SRC_URI="mirror://kernel/software/scm/git/git-${GIT_V}.tar.xz
-	http://git.zx2c4.com/cgit/snapshot/${P}.tar.xz"
+	https://git.zx2c4.com/cgit/snapshot/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/www-apps/cgit/cgit-1.1.ebuild
+++ b/www-apps/cgit/cgit-1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,9 +12,9 @@ inherit webapp eutils multilib user toolchain-funcs
 GIT_V="2.10.2"
 
 DESCRIPTION="a fast web-interface for git repositories"
-HOMEPAGE="http://git.zx2c4.com/cgit/about"
+HOMEPAGE="https://git.zx2c4.com/cgit/about"
 SRC_URI="mirror://kernel/software/scm/git/git-${GIT_V}.tar.xz
-	http://git.zx2c4.com/cgit/snapshot/${P}.tar.xz"
+	https://git.zx2c4.com/cgit/snapshot/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/www-apps/cgit/cgit-9999.ebuild
+++ b/www-apps/cgit/cgit-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -10,7 +10,7 @@ inherit webapp eutils multilib user toolchain-funcs git-2
 [[ -z "${CGIT_CACHEDIR}" ]] && CGIT_CACHEDIR="/var/cache/${PN}/"
 
 DESCRIPTION="a fast web-interface for git repositories"
-HOMEPAGE="http://git.zx2c4.com/cgit/about"
+HOMEPAGE="https://git.zx2c4.com/cgit/about"
 SRC_URI=""
 EGIT_REPO_URI="https://git.zx2c4.com/cgit"
 


### PR DESCRIPTION
Hi,

This PR fixes another 4 packages to use https instead of http.

Please review.