### PR TITLE
app-misc/clockywock, dev-libs/libx86, net-misc/quagga, ...: use HTTPS

### DIFF
--- a/app-misc/clockywock/clockywock-0.3.1a.ebuild
+++ b/app-misc/clockywock/clockywock-0.3.1a.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit base toolchain-funcs
 
 DESCRIPTION="ncurses based analog clock"
-HOMEPAGE="http://soomka.com/clockywock"
-SRC_URI="http://soomka.com/${P}.tar.gz"
+HOMEPAGE="https://soomka.com/clockywock"
+SRC_URI="https://soomka.com/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-libs/libx86/libx86-1.1-r2.ebuild
+++ b/dev-libs/libx86/libx86-1.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib toolchain-funcs
 
 DESCRIPTION="A hardware-independent library for executing real-mode x86 code"
-HOMEPAGE="http://www.codon.org.uk/~mjg59/libx86"
-SRC_URI="http://www.codon.org.uk/~mjg59/${PN}/downloads/${P}.tar.gz"
+HOMEPAGE="https://www.codon.org.uk/~mjg59/libx86/"
+SRC_URI="https://www.codon.org.uk/~mjg59/${PN}/downloads/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-libs/libx86/libx86-1.1-r3.ebuild
+++ b/dev-libs/libx86/libx86-1.1-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit eutils multilib toolchain-funcs flag-o-matic
 
 DESCRIPTION="A hardware-independent library for executing real-mode x86 code"
-HOMEPAGE="http://www.codon.org.uk/~mjg59/libx86"
-SRC_URI="http://www.codon.org.uk/~mjg59/${PN}/downloads/${P}.tar.gz"
+HOMEPAGE="https://www.codon.org.uk/~mjg59/libx86/"
+SRC_URI="https://www.codon.org.uk/~mjg59/${PN}/downloads/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-libs/libx86/libx86-1.1-r4.ebuild
+++ b/dev-libs/libx86/libx86-1.1-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit eutils toolchain-funcs flag-o-matic
 
 DESCRIPTION="A hardware-independent library for executing real-mode x86 code"
-HOMEPAGE="http://www.codon.org.uk/~mjg59/libx86"
-SRC_URI="http://www.codon.org.uk/~mjg59/${PN}/downloads/${P}.tar.gz"
+HOMEPAGE="https://www.codon.org.uk/~mjg59/libx86/"
+SRC_URI="https://www.codon.org.uk/~mjg59/${PN}/downloads/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/net-misc/quagga/quagga-1.2.4.ebuild
+++ b/net-misc/quagga/quagga-1.2.4.ebuild
@@ -8,7 +8,7 @@ CLASSLESS_BGP_PATCH=ht-20040304-classless-bgp.patch
 inherit autotools eutils flag-o-matic multilib pam readme.gentoo-r1 systemd tmpfiles user
 
 DESCRIPTION="A free routing daemon replacing Zebra supporting RIP, OSPF and BGP"
-HOMEPAGE="http://quagga.net/"
+HOMEPAGE="https://www.quagga.net"
 SRC_URI="mirror://nongnu/${PN}/${P}.tar.gz
 	bgpclassless? ( http://hasso.linux.ee/stuff/patches/quagga/${CLASSLESS_BGP_PATCH} )"
 

--- a/net-news/canto-curses/canto-curses-0.9.3.ebuild
+++ b/net-news/canto-curses/canto-curses-0.9.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,8 +8,8 @@ PYTHON_REQ_USE="ncurses(+),threads(+)"
 inherit distutils-r1 multilib
 
 DESCRIPTION="The ncurses client for canto-daemon"
-HOMEPAGE="http://codezen.org/canto-ng/"
-SRC_URI="http://codezen.org/static/${P}.tar.gz"
+HOMEPAGE="https://codezen.org/canto-ng/"
+SRC_URI="https://codezen.org/static/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-news/canto-daemon/canto-daemon-0.9.1.ebuild
+++ b/net-news/canto-daemon/canto-daemon-0.9.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,8 +8,8 @@ PYTHON_REQ_USE="xml(+),threads(+)"
 inherit distutils-r1 multilib
 
 DESCRIPTION="Daemon part of Canto-NG RSS reader"
-HOMEPAGE="http://codezen.org/canto-ng/"
-SRC_URI="http://codezen.org/static/${P}.tar.gz"
+HOMEPAGE="https://codezen.org/canto-ng/"
+SRC_URI="https://codezen.org/static/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/xgestures/xgestures-0.4.ebuild
+++ b/x11-misc/xgestures/xgestures-0.4.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="A mouse gesture recognition program for X11 desktops"
-HOMEPAGE="http://www.cs.bgu.ac.il/~tzachar/xgestures.html"
+HOMEPAGE="https://www.cs.bgu.ac.il/~tzachar/xgestures.html"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

Another PR to fix a few packages to use https instead of http.

Please review.