### PR TITLE
dev-qt/qt-creator: Fix error in prepare() due to a changed filename.

### DIFF
--- a/dev-qt/qt-creator/qt-creator-9999.ebuild
+++ b/dev-qt/qt-creator/qt-creator-9999.ebuild
@@ -123,7 +123,7 @@ src_prepare() {
 	sed -i -e '/sdktool/ d' tests/auto/auto.pro || die
 	sed -i -e '/\(dumpers\|offsets\)\.pro/ d' tests/auto/debugger/debugger.pro || die
 	sed -i -e '/CONFIG -=/ s/$/ testcase/' tests/auto/extensionsystem/pluginmanager/correctplugins1/plugin?/plugin?.pro || die
-	sed -i -e '/timeline\(items\|notes\|selection\)renderpass/ d' tests/auto/timeline/timeline.pro || die
+	sed -i -e '/timeline\(items\|notes\|selection\)renderpass/ d' tests/auto/tracing/tracing.pro || die
 	sed -i -e 's/\<memcheck\>//' tests/auto/valgrind/valgrind.pro || die
 
 	# fix path to some clang headers


### PR DESCRIPTION
We disable unreliable tests by using sed magic, and one of the files
(and directories) related to this was renamed from 'timeline' to
'tracing'.

http://code.qt.io/cgit/qt-creator/qt-creator.git/commit/?id=734611131dc20283b118353130bdd5e16ce0aeaf

Package-Manager: Portage-2.3.37, Repoman-2.3.9