### PR TITLE
media-video/mpv: drop 'encode' USE in 9999 as did upstream

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -29,9 +29,9 @@ DOCS+=( README.md DOCS/{client-api,interface}-changes.rst )
 LICENSE="LGPL-2.1+ GPL-2+ BSD ISC samba? ( GPL-3+ )"
 SLOT="0"
 IUSE="+alsa aqua archive bluray cdda +cli coreaudio cplugins cuda doc drm dvb
-	dvd +egl encode gbm +iconv jack javascript jpeg lcms +libass libav libcaca
-	libmpv +lua luajit openal +opengl oss pulseaudio raspberry-pi rubberband
-	samba sdl selinux test tools +uchardet v4l vaapi vdpau wayland +X +xv zlib
+	dvd +egl gbm +iconv jack javascript jpeg lcms +libass libav libcaca libmpv
+	+lua luajit openal +opengl oss pulseaudio raspberry-pi rubberband samba sdl
+	selinux test tools +uchardet v4l vaapi vdpau wayland +X +xv zlib
 	zsh-completion"
 
 REQUIRED_USE="
@@ -58,8 +58,8 @@ REQUIRED_USE="
 "
 
 COMMON_DEPEND="
-	!libav? ( >=media-video/ffmpeg-4.0:0=[encode?,threads,vaapi?,vdpau?] )
-	libav? ( ~media-video/libav-9999:0=[encode?,threads,vaapi?,vdpau?] )
+	!libav? ( >=media-video/ffmpeg-4.0:0=[encode,threads,vaapi?,vdpau?] )
+	libav? ( ~media-video/libav-9999:0=[encode,threads,vaapi?,vdpau?] )
 	alsa? ( >=media-libs/alsa-lib-1.0.18 )
 	archive? ( >=app-arch/libarchive-3.0.0:= )
 	bluray? ( >=media-libs/libbluray-0.3.0:= )
@@ -180,7 +180,6 @@ src_configure() {
 		$(use_enable libass)
 		$(use_enable libass libass-osd)
 		$(use_enable zlib)
-		$(use_enable encode encoding)
 		$(use_enable bluray libbluray)
 		$(use_enable dvd dvdread)
 		$(use_enable dvd dvdnav)


### PR DESCRIPTION
Encoding bit are always enabled now.

Upstream-commit: https://github.com/mpv-player/mpv/commit/e02c9b9902f5bd356088cfbff3b9c333e50f1e47
Closes: https://bugs.gentoo.org/655982
Package-Manager: Portage-2.3.37, Repoman-2.3.9