### PR TITLE
x11-wm/enlightenment: add a wayland dependency for 0.22.3

### DIFF
--- a/x11-wm/enlightenment/enlightenment-0.22.3.ebuild
+++ b/x11-wm/enlightenment/enlightenment-0.22.3.ebuild
@@ -53,7 +53,7 @@ RDEPEND="
 	systemd? ( sys-apps/systemd )
 	udisks? ( sys-fs/udisks:2 )
 	wayland? (
-		dev-libs/efl[wayland]
+		dev-libs/efl[drm,wayland]
 		>=dev-libs/wayland-1.12.0
 		x11-libs/libxkbcommon
 		x11-libs/pixman


### PR DESCRIPTION
https://git.enlightenment.org/core/enlightenment.git/tree/meson.build#n284

Closes: https://bugs.gentoo.org/655984
Package-Manager: Portage[mgorny]-2.3.36.1