### PR TITLE
sys-fs/zfs: add python-3.6 support

### DIFF
--- a/sys-fs/zfs/zfs-0.7.8.ebuild
+++ b/sys-fs/zfs/zfs-0.7.8.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 if [ ${PV} == "9999" ] ; then
 	inherit git-r3 linux-mod

--- a/sys-fs/zfs/zfs-0.7.9.ebuild
+++ b/sys-fs/zfs/zfs-0.7.9.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 if [ ${PV} == "9999" ] ; then
 	inherit git-r3 linux-mod

--- a/sys-fs/zfs/zfs-0.7.9999.ebuild
+++ b/sys-fs/zfs/zfs-0.7.9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 if [[ ${PV} == *"9999" ]] ; then
 	AUTOTOOLS_AUTORECONF="1"

--- a/sys-fs/zfs/zfs-9999.ebuild
+++ b/sys-fs/zfs/zfs-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 if [ ${PV} == "9999" ] ; then
 	inherit git-r3 linux-mod


### PR DESCRIPTION
python scripts work fine with 3.6
not touching old 6.x stuff