### PR TITLE
dev-lang/rust: add python-3.6 support

### DIFF
--- a/dev-lang/rust/rust-1.26.0.ebuild
+++ b/dev-lang/rust/rust-1.26.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_5 )
+PYTHON_COMPAT=( python{2_7,3_5,3_6} )
 
 inherit multiprocessing python-any-r1 versionator toolchain-funcs
 


### PR DESCRIPTION
Builds fine for me.

```
_python_EPYTHON_supported: entering function, parameters: python3.6
python_export: entering function, parameters: python3_6 PYTHON_PKG_DEP
python_export: implementation: python3.6
python_export: PYTHON_PKG_DEP = dev-lang/python:3.6
python_export: entering function, parameters: python3.6 EPYTHON PYTHON
python_export: implementation: python3.6
python_export: EPYTHON = python3.6
python_export: PYTHON = /usr/bin/python3.6
```

I saved build logs, can upload if needed.