### PR TITLE
games-puzzle/nudoku: use HTTPS

### DIFF
--- a/games-puzzle/nudoku/nudoku-1.0.0.ebuild
+++ b/games-puzzle/nudoku/nudoku-1.0.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="ncurses based sudoku game"
-HOMEPAGE="http://jubalh.github.io/nudoku"
+HOMEPAGE="https://jubalh.github.io/nudoku"
 SRC_URI="https://github.com/jubalh/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"


### PR DESCRIPTION
Hi,

This PR fixes games-puzzle/nudoku to use https instead of http.

Please review.