### PR TITLE
dev-ruby/hashicorp-checkpoint: use HTTPS

### DIFF
--- a/dev-ruby/hashicorp-checkpoint/hashicorp-checkpoint-0.1.5.ebuild
+++ b/dev-ruby/hashicorp-checkpoint/hashicorp-checkpoint-0.1.5.ebuild
@@ -12,7 +12,7 @@ RUBY_FAKEGEM_EXTRADOC="README.md"
 inherit ruby-fakegem
 
 DESCRIPTION="Internal HashiCorp service to check version information"
-HOMEPAGE="http://www.hashicorp.com"
+HOMEPAGE="https://www.hashicorp.com"
 
 LICENSE="MPL-2.0"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes dev-ruby/hashicorp-checkpoint to use https instead of http.

Please review.