### PR TITLE
dev-python/python-ly: use HTTPS

### DIFF
--- a/dev-python/python-ly/python-ly-0.9.4.ebuild
+++ b/dev-python/python-ly/python-ly-0.9.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 inherit distutils-r1
 
 DESCRIPTION="Tool and library for manipulating LilyPond files"
-HOMEPAGE="https://github.com/wbsoft/python-ly http://pypi.org/project/python-ly/"
+HOMEPAGE="https://github.com/wbsoft/python-ly https://pypi.org/project/python-ly/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/dev-python/python-ly/python-ly-0.9.5.ebuild
+++ b/dev-python/python-ly/python-ly-0.9.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 inherit distutils-r1
 
 DESCRIPTION="Tool and library for manipulating LilyPond files"
-HOMEPAGE="https://github.com/wbsoft/python-ly http://pypi.org/project/python-ly/"
+HOMEPAGE="https://github.com/wbsoft/python-ly https://pypi.org/project/python-ly/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2+"


### PR DESCRIPTION
Hi,

This PR fixes dev-python/python-ly to use https instead of http.

Please review.