### PR TITLE
gnome-extra/gnome-commander: use HTTPS

### DIFF
--- a/gnome-extra/gnome-commander/gnome-commander-1.6.1.ebuild
+++ b/gnome-extra/gnome-commander/gnome-commander-1.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ GNOME2_LA_PUNT="yes"
 inherit eutils gnome2 python-single-r1
 
 DESCRIPTION="A graphical, full featured, twin-panel file manager"
-HOMEPAGE="http://gcmd.github.io/"
+HOMEPAGE="https://gcmd.github.io/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/gnome-extra/gnome-commander/gnome-commander-1.6.3.ebuild
+++ b/gnome-extra/gnome-commander/gnome-commander-1.6.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ GNOME2_LA_PUNT="yes"
 inherit eutils gnome2 python-single-r1
 
 DESCRIPTION="A graphical, full featured, twin-panel file manager"
-HOMEPAGE="http://gcmd.github.io/"
+HOMEPAGE="https://gcmd.github.io/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/gnome-extra/gnome-commander/gnome-commander-1.6.4.ebuild
+++ b/gnome-extra/gnome-commander/gnome-commander-1.6.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ GNOME2_LA_PUNT="yes"
 inherit eutils gnome2 python-single-r1
 
 DESCRIPTION="A graphical, full featured, twin-panel file manager"
-HOMEPAGE="http://gcmd.github.io/"
+HOMEPAGE="https://gcmd.github.io/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/gnome-extra/gnome-commander/gnome-commander-1.8.0.ebuild
+++ b/gnome-extra/gnome-commander/gnome-commander-1.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ GNOME2_LA_PUNT="yes"
 inherit eutils gnome2 python-single-r1
 
 DESCRIPTION="A graphical, full featured, twin-panel file manager"
-HOMEPAGE="http://gcmd.github.io/"
+HOMEPAGE="https://gcmd.github.io/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/gnome-extra/gnome-commander/gnome-commander-1.8.1.ebuild
+++ b/gnome-extra/gnome-commander/gnome-commander-1.8.1.ebuild
@@ -8,7 +8,7 @@ GNOME2_LA_PUNT="yes"
 inherit gnome2
 
 DESCRIPTION="A graphical, full featured, twin-panel file manager"
-HOMEPAGE="http://gcmd.github.io/"
+HOMEPAGE="https://gcmd.github.io/"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes gnome-extra/gnome-commander to use https instead of http.

Please review.