### PR TITLE
media-gfx/alembic: use HTTPS

### DIFF
--- a/media-gfx/alembic/alembic-1.7.4.ebuild
+++ b/media-gfx/alembic/alembic-1.7.4.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils python-single-r1 cmake-utils
 
 DESCRIPTION="Alembic is an open framework for storing and sharing scene data"
-HOMEPAGE="http://alembic.io/"
+HOMEPAGE="https://www.alembic.io"
 SRC_URI="https://github.com/${PN}/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Hi,

This PR fixes media-gfx/alembic to use https instead of http.

Please review.