### PR TITLE
net-p2p/deluge: use HTTPS

### DIFF
--- a/net-p2p/deluge/deluge-1.3.15-r2.ebuild
+++ b/net-p2p/deluge/deluge-1.3.15-r2.ebuild
@@ -9,7 +9,7 @@ PLOCALES="af ar ast be bg bn bs ca cs cy da de el en_AU en_CA en_GB eo es et eu 
 inherit distutils-r1 eutils systemd user l10n
 
 DESCRIPTION="BitTorrent client with a client/server model"
-HOMEPAGE="http://deluge-torrent.org/"
+HOMEPAGE="https://deluge-torrent.org/"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
@@ -138,6 +138,6 @@ pkg_postinst() {
 	elog "happens in /etc/systemd/system/deluged.service.d/00gentoo.conf"
 	elog "and /etc/systemd/system/deluge-web.service.d/00gentoo.conf"
 	elog
-	elog "For more information look at http://dev.deluge-torrent.org/wiki/Faq"
+	elog "For more information look at https://dev.deluge-torrent.org/wiki/Faq"
 	elog
 }

--- a/net-p2p/deluge/deluge-1.3.9999.ebuild
+++ b/net-p2p/deluge/deluge-1.3.9999.ebuild
@@ -9,7 +9,7 @@ PLOCALES="af ar ast be bg bn bs ca cs cy da de el en_AU en_CA en_GB eo es et eu 
 inherit distutils-r1 eutils systemd user l10n
 
 DESCRIPTION="BitTorrent client with a client/server model"
-HOMEPAGE="http://deluge-torrent.org/"
+HOMEPAGE="https://deluge-torrent.org/"
 
 if [[ ${PV} == 1.3.9999 ]]; then
 	inherit git-r3
@@ -138,6 +138,6 @@ pkg_postinst() {
 	elog "happens in /etc/systemd/system/deluged.service.d/00gentoo.conf"
 	elog "and /etc/systemd/system/deluge-web.service.d/00gentoo.conf"
 	elog
-	elog "For more information look at http://dev.deluge-torrent.org/wiki/Faq"
+	elog "For more information look at https://dev.deluge-torrent.org/wiki/Faq"
 	elog
 }

--- a/net-p2p/deluge/deluge-9999.ebuild
+++ b/net-p2p/deluge/deluge-9999.ebuild
@@ -9,7 +9,7 @@ PLOCALES="af ar ast be bg bn bs ca cs cy da de el en_AU en_CA en_GB eo es et eu 
 inherit distutils-r1 eutils systemd user l10n
 
 DESCRIPTION="BitTorrent client with a client/server model"
-HOMEPAGE="http://deluge-torrent.org/"
+HOMEPAGE="https://deluge-torrent.org/"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
@@ -134,6 +134,6 @@ pkg_postinst() {
 	elog "happens in /etc/systemd/system/deluged.service.d/00gentoo.conf"
 	elog "and /etc/systemd/system/deluge-web.service.d/00gentoo.conf"
 	elog
-	elog "For more information look at http://dev.deluge-torrent.org/wiki/Faq"
+	elog "For more information look at https://dev.deluge-torrent.org/wiki/Faq"
 	elog
 }


### PR DESCRIPTION
Hi,

This PR fixes net-p2p/deluge to use https instead of http.

Please review.