### PR TITLE
net-im/corebird: use HTTPS

### DIFF
--- a/net-im/corebird/corebird-0.8.ebuild
+++ b/net-im/corebird/corebird-0.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ AUTOTOOLS_IN_SOURCE_BUILD=1
 inherit eutils autotools-utils gnome2 vala
 
 DESCRIPTION="Native GTK+3 Twitter client"
-HOMEPAGE="http://corebird.baedert.org/"
+HOMEPAGE="https://corebird.baedert.org/"
 SRC_URI="https://github.com/baedert/corebird/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/net-im/corebird/corebird-1.0.ebuild
+++ b/net-im/corebird/corebird-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ AUTOTOOLS_IN_SOURCE_BUILD=1
 inherit eutils autotools-utils gnome2 vala
 
 DESCRIPTION="Native GTK+3 Twitter client"
-HOMEPAGE="http://corebird.baedert.org/"
+HOMEPAGE="https://corebird.baedert.org/"
 SRC_URI="https://github.com/baedert/corebird/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/net-im/corebird/corebird-1.1.ebuild
+++ b/net-im/corebird/corebird-1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ AUTOTOOLS_IN_SOURCE_BUILD=1
 inherit eutils autotools-utils gnome2 vala
 
 DESCRIPTION="Native GTK+3 Twitter client"
-HOMEPAGE="http://corebird.baedert.org/"
+HOMEPAGE="https://corebird.baedert.org/"
 SRC_URI="https://github.com/baedert/corebird/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/net-im/corebird/corebird-1.5-r2.ebuild
+++ b/net-im/corebird/corebird-1.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ VALA_MIN_API_VERSION=0.34
 inherit autotools gnome2 vala virtualx
 
 DESCRIPTION="Native GTK+3 Twitter client"
-HOMEPAGE="http://corebird.baedert.org/"
+HOMEPAGE="https://corebird.baedert.org/"
 SRC_URI="https://github.com/baedert/corebird/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/net-im/corebird/corebird-1.5.1.ebuild
+++ b/net-im/corebird/corebird-1.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ VALA_MIN_API_VERSION=0.34
 inherit autotools gnome2 vala virtualx
 
 DESCRIPTION="Native GTK+3 Twitter client"
-HOMEPAGE="http://corebird.baedert.org/"
+HOMEPAGE="https://corebird.baedert.org/"
 SRC_URI="https://github.com/baedert/corebird/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/net-im/corebird/corebird-1.6.ebuild
+++ b/net-im/corebird/corebird-1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ VALA_MIN_API_VERSION=0.34
 inherit autotools gnome2 vala virtualx
 
 DESCRIPTION="Native GTK+3 Twitter client"
-HOMEPAGE="http://corebird.baedert.org/"
+HOMEPAGE="https://corebird.baedert.org/"
 SRC_URI="https://github.com/baedert/corebird/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/net-im/corebird/corebird-1.7.2.ebuild
+++ b/net-im/corebird/corebird-1.7.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ VALA_MIN_API_VERSION=0.34
 inherit autotools gnome2 vala virtualx
 
 DESCRIPTION="Native GTK+3 Twitter client"
-HOMEPAGE="http://corebird.baedert.org/"
+HOMEPAGE="https://corebird.baedert.org/"
 SRC_URI="https://github.com/baedert/corebird/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"


### PR DESCRIPTION
Hi,

This PR fixes net-im/corebird to use https instead of http.

Please review.