### PR TITLE
media-video/syncplay: use HTTPS

### DIFF
--- a/media-video/syncplay/syncplay-1.5.0.ebuild
+++ b/media-video/syncplay/syncplay-1.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit python-r1
 MY_PV=${PV/_rc/-RC}
 
 DESCRIPTION="Client/server to synchronize media playback"
-HOMEPAGE="http://syncplay.pl"
+HOMEPAGE="https://syncplay.pl"
 SRC_URI="https://github.com/Syncplay/syncplay/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/media-video/syncplay/syncplay-1.5.1.ebuild
+++ b/media-video/syncplay/syncplay-1.5.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit python-r1
 
 DESCRIPTION="Client/server to synchronize media playback"
-HOMEPAGE="http://syncplay.pl"
+HOMEPAGE="https://syncplay.pl"
 SRC_URI="https://github.com/Syncplay/syncplay/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/media-video/syncplay/syncplay-9999.ebuild
+++ b/media-video/syncplay/syncplay-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit git-r3 python-r1
 MY_PV=${PV/_rc/-RC}
 
 DESCRIPTION="Client/server to synchronize media playback"
-HOMEPAGE="http://syncplay.pl"
+HOMEPAGE="https://syncplay.pl"
 EGIT_REPO_URI="https://github.com/Syncplay/${PN}.git"
 
 LICENSE="Apache-2.0"


### PR DESCRIPTION
Hi,

This PR fixes media-video/syncplay to use https instead of http.

Please review.