### PR TITLE
sys-apps/miller: use HTTPS

### DIFF
--- a/sys-apps/miller/miller-4.2.0.ebuild
+++ b/sys-apps/miller/miller-4.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="A tool like sed, awk, cut, join, and sort for name-indexed data (CSV, JSON, ..)"
-HOMEPAGE="http://johnkerl.org/miller"
+HOMEPAGE="https://johnkerl.org/miller/doc/index.html"
 LICENSE="BSD-2"
 
 SLOT="0"

--- a/sys-apps/miller/miller-5.2.2.ebuild
+++ b/sys-apps/miller/miller-5.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="A tool like sed, awk, cut, join, and sort for name-indexed data (CSV, JSON, ..)"
-HOMEPAGE="http://johnkerl.org/miller"
+HOMEPAGE="https://johnkerl.org/miller/doc/index.html"
 SRC_URI="https://github.com/johnkerl/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD-2"

--- a/sys-apps/miller/miller-5.3.0.ebuild
+++ b/sys-apps/miller/miller-5.3.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="A tool like sed, awk, cut, join, and sort for name-indexed data (CSV, JSON, ..)"
-HOMEPAGE="http://johnkerl.org/miller"
+HOMEPAGE="https://johnkerl.org/miller/doc/index.html"
 SRC_URI="https://github.com/johnkerl/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD-2"


### PR DESCRIPTION
Hi,

This PR fixes sys-apps/miller to use https instead of http.

Please review.