### PR TITLE
sys-devel/slibtool: use HTTPS

### DIFF
--- a/sys-devel/slibtool/slibtool-0.5.17.ebuild
+++ b/sys-devel/slibtool/slibtool-0.5.17.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="A skinny libtool implementation, written in C"
-HOMEPAGE="http://git.midipix.org/cgit.cgi/slibtool"
-SRC_URI="http://git.midipix.org/cgit.cgi/${PN}/snapshot/${P}.tar.xz"
+HOMEPAGE="https://git.midipix.org/cgit.cgi/slibtool"
+SRC_URI="https://git.midipix.org/cgit.cgi/${PN}/snapshot/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes sys-devel/slibtool to use https instead of http.

Please review.