### PR TITLE
net-libs/libtorrent: support openssl-1.1

### DIFF
--- a/net-libs/libtorrent/files/libtorrent-0001-Fix-the-DH-parameters-generation-with-OpenSSL-1.1.patch
+++ b/net-libs/libtorrent/files/libtorrent-0001-Fix-the-DH-parameters-generation-with-OpenSSL-1.1.patch
@@ -1,0 +1,105 @@
+From 4607bbf78040789dee29266878ce109136b984ef Mon Sep 17 00:00:00 2001
+From: rakshasa <sundell.software@gmail.com>
+Date: Tue, 20 Dec 2016 19:51:02 +0900
+Subject: [PATCH] Added support for openssl 1.1.
+
+---
+ configure.ac                |  4 ++++
+ src/utils/diffie_hellman.cc | 36 ++++++++++++++++++++++++++++++++++--
+ 2 files changed, 38 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 65e34872..27e33570 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -69,12 +69,15 @@ AC_ARG_ENABLE(openssl,
+   [  --disable-openssl       Don't use OpenSSL's SHA1 implementation.],
+   [
+     if test "$enableval" = "yes"; then
++dnl move to scripts.
+       PKG_CHECK_MODULES(OPENSSL, libcrypto,
+         CXXFLAGS="$CXXFLAGS $OPENSSL_CFLAGS";
+         LIBS="$LIBS $OPENSSL_LIBS")
+ 
+       AC_DEFINE(USE_OPENSSL, 1, Using OpenSSL.)
+       AC_DEFINE(USE_OPENSSL_SHA, 1, Using OpenSSL's SHA1 implementation.)
++      AC_CHECK_LIB([crypto], [DH_set0_pqg], [AC_DEFINE(USE_OPENSSL_1_1, 1, Using OpenSSL 1.1.)])
++
+     else
+       AC_DEFINE(USE_NSS_SHA, 1, Using Mozilla's SHA1 implementation.)
+     fi
+@@ -85,6 +88,7 @@ AC_ARG_ENABLE(openssl,
+ 
+     AC_DEFINE(USE_OPENSSL, 1, Using OpenSSL.)
+     AC_DEFINE(USE_OPENSSL_SHA, 1, Using OpenSSL's SHA1 implementation.)
++    AC_CHECK_LIB([crypto], [DH_set0_pqg], [AC_DEFINE(USE_OPENSSL_1_1, 1, Using OpenSSL 1.1.)])
+   ]
+ )
+ 
+diff --git a/src/utils/diffie_hellman.cc b/src/utils/diffie_hellman.cc
+index aa653d45..7ec13165 100644
+--- a/src/utils/diffie_hellman.cc
++++ b/src/utils/diffie_hellman.cc
+@@ -54,11 +54,23 @@ DiffieHellman::DiffieHellman(const unsigned char *prime, int primeLength,
+   m_secret(NULL), m_size(0) {
+ 
+ #ifdef USE_OPENSSL
++
+   m_dh = DH_new();
++
++#ifdef USE_OPENSSL_1_1
++  BIGNUM * const dh_p = BN_bin2bn(prime, primeLength, NULL);
++  BIGNUM * const dh_g = BN_bin2bn(generator, generatorLength, NULL);
++
++  if (dh_p == NULL || dh_g == NULL ||
++      !DH_set0_pqg(m_dh, dh_p, NULL, dh_g))
++	  throw internal_error("Could not generate Diffie-Hellman parameters");
++#else
+   m_dh->p = BN_bin2bn(prime, primeLength, NULL);
+   m_dh->g = BN_bin2bn(generator, generatorLength, NULL);
++#endif
+ 
+   DH_generate_key(m_dh);
++
+ #else
+   throw internal_error("Compiled without encryption support.");
+ #endif
+@@ -74,7 +86,19 @@ DiffieHellman::~DiffieHellman() {
+ bool
+ DiffieHellman::is_valid() const {
+ #ifdef USE_OPENSSL
++  if (m_dh == NULL)
++    return false;
++
++#ifdef USE_OPENSSL_1_1
++  const BIGNUM *pub_key;
++
++  DH_get0_key(m_dh, &pub_key, NULL);
++
++  return pub_key != NULL;
++#else
+   return m_dh != NULL && m_dh->pub_key != NULL;
++#endif
++
+ #else
+   return false;
+ #endif
+@@ -103,8 +127,16 @@ DiffieHellman::store_pub_key(unsigned char* dest, unsigned int length) {
+ #ifdef USE_OPENSSL
+   std::memset(dest, 0, length);
+ 
+-  if ((int)length >= BN_num_bytes(m_dh->pub_key))
+-    BN_bn2bin(m_dh->pub_key, dest + length - BN_num_bytes(m_dh->pub_key));
++  const BIGNUM *pub_key;
++
++#ifdef USE_OPENSSL_1_1
++  DH_get0_key(m_dh, &pub_key, NULL);
++#else
++  pub_key = m_dh->pub_key;
++#endif
++
++  if ((int)length >= BN_num_bytes(pub_key))
++    BN_bn2bin(pub_key, dest + length - BN_num_bytes(pub_key));
+ #endif
+ }
+ 

--- a/net-libs/libtorrent/files/libtorrent-cppunit.patch
+++ b/net-libs/libtorrent/files/libtorrent-cppunit.patch
@@ -1,0 +1,36 @@
+From b8b24b58a9bed6db1c886ea71a9bb407fb41fc2f Mon Sep 17 00:00:00 2001
+From: rakshasa <sundell.software@gmail.com>
+Date: Sun, 23 Oct 2016 08:54:11 +0900
+Subject: [PATCH] Use pkg-config for cppunit.
+
+---
+ configure.ac | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 2b3eb7ab..65e34872 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -19,7 +19,6 @@ AC_SUBST(LIBTORRENT_INTERFACE_VERSION_NO)
+ 
+ AM_INIT_AUTOMAKE
+ AC_CONFIG_HEADERS(config.h)
+-AM_PATH_CPPUNIT(1.9.6)
+ 
+ AC_PROG_CXX
+ 
+@@ -60,9 +59,11 @@ CC_ATTRIBUTE_VISIBILITY
+ AX_PTHREAD
+ AX_CHECK_ZLIB
+ 
+-CFLAGS="$PTHREAD_CFLAGS $CFLAGS"
+-CXXFLAGS="$PTHREAD_CFLAGS $CXXFLAGS"
+-LIBS="$PTHREAD_LIBS $LIBS"
++PKG_CHECK_MODULES([CPPUNIT], [cppunit],, [no_cppunit="yes"])
++
++CFLAGS="$PTHREAD_CFLAGS $CPPUNIT_CFLAGS $CFLAGS"
++CXXFLAGS="$PTHREAD_CFLAGS $CPPUNIT_CFLAGS $CXXFLAGS"
++LIBS="$PTHREAD_LIBS $CPPUNIT_LIBS $LIBS"
+ 
+ AC_ARG_ENABLE(openssl,
+   [  --disable-openssl       Don't use OpenSSL's SHA1 implementation.],

--- a/net-libs/libtorrent/files/libtorrent-openssl-1.1-part2.patch
+++ b/net-libs/libtorrent/files/libtorrent-openssl-1.1-part2.patch
@@ -1,0 +1,57 @@
+From 43213fecfad863e2c9e47accde9b76496ff6d1e5 Mon Sep 17 00:00:00 2001
+From: rakshasa <sundell.software@gmail.com>
+Date: Sun, 25 Dec 2016 11:58:04 +0900
+Subject: [PATCH] Cleaned up openssl automake script.
+
+---
+ configure.ac | 37 ++-----------------------------------
+ 1 file changed, 2 insertions(+), 35 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 27e33570..33f755c9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -65,41 +65,8 @@ CFLAGS="$PTHREAD_CFLAGS $CPPUNIT_CFLAGS $CFLAGS"
+ CXXFLAGS="$PTHREAD_CFLAGS $CPPUNIT_CFLAGS $CXXFLAGS"
+ LIBS="$PTHREAD_LIBS $CPPUNIT_LIBS $LIBS"
+ 
+-AC_ARG_ENABLE(openssl,
+-  [  --disable-openssl       Don't use OpenSSL's SHA1 implementation.],
+-  [
+-    if test "$enableval" = "yes"; then
+-dnl move to scripts.
+-      PKG_CHECK_MODULES(OPENSSL, libcrypto,
+-        CXXFLAGS="$CXXFLAGS $OPENSSL_CFLAGS";
+-        LIBS="$LIBS $OPENSSL_LIBS")
+-
+-      AC_DEFINE(USE_OPENSSL, 1, Using OpenSSL.)
+-      AC_DEFINE(USE_OPENSSL_SHA, 1, Using OpenSSL's SHA1 implementation.)
+-      AC_CHECK_LIB([crypto], [DH_set0_pqg], [AC_DEFINE(USE_OPENSSL_1_1, 1, Using OpenSSL 1.1.)])
+-
+-    else
+-      AC_DEFINE(USE_NSS_SHA, 1, Using Mozilla's SHA1 implementation.)
+-    fi
+-  ],[
+-    PKG_CHECK_MODULES(OPENSSL, libcrypto,
+-      CXXFLAGS="$CXXFLAGS $OPENSSL_CFLAGS";
+-      LIBS="$LIBS $OPENSSL_LIBS")
+-
+-    AC_DEFINE(USE_OPENSSL, 1, Using OpenSSL.)
+-    AC_DEFINE(USE_OPENSSL_SHA, 1, Using OpenSSL's SHA1 implementation.)
+-    AC_CHECK_LIB([crypto], [DH_set0_pqg], [AC_DEFINE(USE_OPENSSL_1_1, 1, Using OpenSSL 1.1.)])
+-  ]
+-)
+-
+-AC_ARG_ENABLE(cyrus-rc4,
+-  [  --enable-cyrus-rc4=PFX  Use Cyrus RC4 implementation.],
+-  [
+-    CXXFLAGS="$CXXFLAGS -I${enableval}/include";
+-    LIBS="$LIBS -lrc4 -L${enableval}/lib"
+-    AC_DEFINE(USE_CYRUS_RC4, 1, Using Cyrus RC4 implementation.)
+-  ]
+-)
++TORRENT_ARG_OPENSSL
++TORRENT_ARG_CYRUS_RC4
+ 
+ AC_CHECK_FUNCS(posix_memalign)
+ 

--- a/net-libs/libtorrent/files/libtorrent-openssl-1.1-part3.patch
+++ b/net-libs/libtorrent/files/libtorrent-openssl-1.1-part3.patch
@@ -1,0 +1,68 @@
+From d36561c8cc91698f3075c264af6d7d99e13cbff0 Mon Sep 17 00:00:00 2001
+From: rakshasa <sundell.software@gmail.com>
+Date: Sun, 25 Dec 2016 12:09:35 +0900
+Subject: [PATCH] More stuff.
+
+---
+ Makefile.am    |  1 +
+ scripts/ssl.m4 | 39 +++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 40 insertions(+)
+ create mode 100644 scripts/ssl.m4
+
+diff --git a/Makefile.am b/Makefile.am
+index f175e634..9507b9ea 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -8,6 +8,7 @@ EXTRA_DIST= \
+ 	scripts/checks.m4 \
+ 	scripts/common.m4 \
+ 	scripts/attributes.m4 \
++	scripts/ssl.m4 \
+ 	doc/main.xml \
+ 	doc/http.xml \
+ 	doc/torrent.xml \
+diff --git a/scripts/ssl.m4 b/scripts/ssl.m4
+new file mode 100644
+index 00000000..e9cf6303
+--- /dev/null
++++ b/scripts/ssl.m4
+@@ -0,0 +1,39 @@
++AC_DEFUN([TORRENT_CHECK_OPENSSL],
++  [
++    PKG_CHECK_MODULES(OPENSSL, libcrypto,
++      CXXFLAGS="$CXXFLAGS $OPENSSL_CFLAGS";
++      LIBS="$LIBS $OPENSSL_LIBS")
++
++    AC_DEFINE(USE_OPENSSL, 1, Using OpenSSL.)
++    AC_DEFINE(USE_OPENSSL_SHA, 1, Using OpenSSL's SHA1 implementation.)
++    AC_CHECK_LIB([crypto], [DH_set0_pqg], [AC_DEFINE(USE_OPENSSL_1_1, 1, Using OpenSSL 1.1.)])
++  ]
++)
++
++AC_DEFUN([TORRENT_ARG_OPENSSL],
++  [
++    AC_ARG_ENABLE(openssl,
++      [  --disable-openssl       Don't use OpenSSL's SHA1 implementation.],
++      [
++        if test "$enableval" = "yes"; then
++          TORRENT_CHECK_OPENSSL
++        else
++          AC_DEFINE(USE_NSS_SHA, 1, Using Mozilla's SHA1 implementation.)
++        fi
++      ],[
++        TORRENT_CHECK_OPENSSL
++      ])
++  ]
++)
++
++AC_DEFUN([TORRENT_ARG_CYRUS_RC4],
++  [
++    AC_ARG_ENABLE(cyrus-rc4,
++      [  --enable-cyrus-rc4=PFX  Use Cyrus RC4 implementation.],
++      [
++        CXXFLAGS="$CXXFLAGS -I${enableval}/include";
++        LIBS="$LIBS -lrc4 -L${enableval}/lib"
++        AC_DEFINE(USE_CYRUS_RC4, 1, Using Cyrus RC4 implementation.)
++      ])
++  ]
++)

--- a/net-libs/libtorrent/libtorrent-0.13.6-r2.ebuild
+++ b/net-libs/libtorrent/libtorrent-0.13.6-r2.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="BitTorrent library written in C++ for *nix"
+HOMEPAGE="https://rakshasa.github.io/rtorrent/"
+SRC_URI="http://rtorrent.net/downloads/${P}.tar.gz"
+
+LICENSE="GPL-2"
+
+# The README says that the library ABI is not yet stable and dependencies on
+# the library should be an explicit, syncronized version until the library
+# has had more time to mature. Until it matures we should not include a soname
+# subslot.
+SLOT="0"
+
+KEYWORDS="~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris"
+IUSE="debug ipv6 libressl ssl test"
+
+RDEPEND="
+	sys-libs/zlib
+	>=dev-libs/libsigc++-2.2.2:2
+	ssl? (
+	    !libressl? ( dev-libs/openssl:0= )
+	    libressl? ( dev-libs/libressl:= )
+	)"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	dev-util/cppunit"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-cppunit.patch"
+	"${FILESDIR}/${PN}-0001-Fix-the-DH-parameters-generation-with-OpenSSL-1.1.patch"
+	"${FILESDIR}/${PN}-openssl-1.1-part2.patch"
+	"${FILESDIR}/${PN}-openssl-1.1-part3.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# bug 518582
+	local disable_instrumentation
+	echo -e "#include <inttypes.h>\nint main(){ int64_t var = 7; __sync_add_and_fetch(&var, 1); return 0;}" > "${T}/sync_add_and_fetch.c" || die
+	$(tc-getCC) ${CFLAGS} -o /dev/null -x c "${T}/sync_add_and_fetch.c" >/dev/null 2>&1
+	if [[ $? -ne 0 ]]; then
+		disable_instrumentation="--disable-instrumentation"
+	fi
+
+	# configure needs bash or script bombs out on some null shift, bug #291229
+	CONFIG_SHELL=${BASH} econf \
+		--enable-aligned \
+		$(use_enable debug) \
+		$(use_enable ipv6) \
+		$(use_enable ssl openssl) \
+		${disable_instrumentation} \
+		--with-posix-fallocate
+}
+
+src_install() {
+	default
+
+	find "${D}" -name '*.la' -delete
+}


### PR DESCRIPTION
Fixes #655696.

Package-Manager: Portage-2.3.24, Repoman-2.3.6