### PR TITLE
net-libs/libtorrent: clarify openssl <1.1 requirement

### DIFF
--- a/net-libs/libtorrent/libtorrent-0.13.6-r1.ebuild
+++ b/net-libs/libtorrent/libtorrent-0.13.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -24,7 +24,7 @@ RDEPEND="
 	sys-libs/zlib
 	>=dev-libs/libsigc++-2.2.2:2
 	ssl? (
-	    !libressl? ( dev-libs/openssl:0= )
+	    !libressl? ( <dev-libs/openssl-1.1:0= )
 	    libressl? ( dev-libs/libressl:= )
 	)"
 DEPEND="${RDEPEND}

--- a/net-libs/libtorrent/libtorrent-0.13.6.ebuild
+++ b/net-libs/libtorrent/libtorrent-0.13.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -24,7 +24,7 @@ RDEPEND="
 	sys-libs/zlib
 	>=dev-libs/libsigc++-2.2.2:2
 	ssl? (
-	    !libressl? ( dev-libs/openssl:0= )
+	    !libressl? ( <dev-libs/openssl-1.1:0= )
 	    libressl? ( dev-libs/libressl:= )
 	)"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/655696
Package-Manager: Portage-2.3.24, Repoman-2.3.6