### PR TITLE
app-admin/installer: remove proxy-maint from metadata.xml

### DIFF
--- a/app-admin/installer/metadata.xml
+++ b/app-admin/installer/metadata.xml
@@ -6,9 +6,6 @@
 		<name>Christopher Díaz Riveros</name>
 		<description>Primary maintainer</description>
 	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-	</maintainer>
 	<longdescription>
 		installer is designed to aid users during the installation
 		process of Gentoo Linux. It is capable of walk a beginner 


### PR DESCRIPTION
Hi

The package app-admin/installer has no proxy-maintainer (a non gentoo mail Adresse) listed. This PR removes the proxy-maint maintainer from the package.

Please review.