### PR TITLE
dev-embedded/arduino: add missing app-arch/unzip dependency

### DIFF
--- a/dev-embedded/arduino/arduino-1.8.5-r2.ebuild
+++ b/dev-embedded/arduino/arduino-1.8.5-r2.ebuild
@@ -68,6 +68,7 @@ RDEPEND="${CDEPEND}
 	>=virtual/jre-1.8"
 
 DEPEND="${CDEPEND}
+	app-arch/unzip
 	>=virtual/jdk-1.8"
 
 EANT_BUILD_TARGET="build"


### PR DESCRIPTION
Hi,

dev-embedded/arduino downloads and installs zip files but doesn't have a dependency on app-arch/unzip.
This PR adds app-arch/unzip as dependency.

Please review.