### PR TITLE
x11-wm/enlightenment: call xdg_environment_reset in 0.22.3

### DIFF
--- a/x11-wm/enlightenment/enlightenment-0.22.3.ebuild
+++ b/x11-wm/enlightenment/enlightenment-0.22.3.ebuild
@@ -68,6 +68,8 @@ DEPEND="
 src_prepare() {
 	default
 
+	xdg_environment_reset
+
 	# fix QA issues with .desktop files
 	find data/desktop/ -type f -exec sed -i 's|OnlyShowIn=Enlightenment|OnlyShowIn=X-Enlightenment|g' {} \; || die
 	sed -i 's/Categories=Audio/Categories=AudioVideo/g' src/modules/mixer/emixer.desktop || die


### PR DESCRIPTION
Reported by Toralf Förster.
Closes: https://bugs.gentoo.org/656146
Package-Manager: Portage[mgorny]-2.3.36.1