### PR TITLE
net-proxy/squid: Make perl optional

### DIFF
--- a/net-proxy/squid/squid-3.5.27-r1.ebuild
+++ b/net-proxy/squid/squid-3.5.27-r1.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~sparc x86 ~x86-fbsd"
 IUSE="caps ipv6 pam ldap libressl samba sasl kerberos nis radius ssl snmp selinux logrotate test \
 	ecap esi ssl-crtd \
 	mysql postgres sqlite \
-	qos tproxy \
+	perl qos tproxy \
 	+htcp +wccp +wccpv2 \
 	pf-transparent ipf-transparent kqueue \
 	elibc_uclibc kernel_linux"
@@ -33,13 +33,14 @@ COMMON_DEPEND="caps? ( >=sys-libs/libcap-2.16 )
 	esi? ( dev-libs/expat dev-libs/libxml2 )
 	!x86-fbsd? ( logrotate? ( app-admin/logrotate ) )
 	>=sys-libs/db-4:*
-	dev-lang/perl
 	dev-libs/libltdl:0"
 DEPEND="${COMMON_DEPEND}
+	dev-lang/perl
 	ecap? ( virtual/pkgconfig )
 	test? ( dev-util/cppunit )"
 RDEPEND="${COMMON_DEPEND}
 	samba? ( net-fs/samba )
+	perl? ( dev-lang/perl )
 	mysql? ( dev-perl/DBD-mysql )
 	postgres? ( dev-perl/DBD-Pg )
 	selinux? ( sec-policy/selinux-squid )
@@ -222,6 +223,15 @@ src_install() {
 	# pinger needs suid as well
 	fowners root:squid /usr/libexec/squid/pinger
 	fperms 4750 /usr/libexec/squid/pinger
+
+	# these scripts depend on perl
+	if ! use perl; then
+		rm -f "${D}"/usr/libexec/squid/basic_pop3_auth
+		rm -f "${D}"/usr/libexec/squid/log_db_daemon
+		rm -f "${D}"/usr/libexec/squid/basic_msnt_multi_domain_auth
+		rm -f "${D}"/usr/libexec/squid/storeid_file_rewrite
+		rm -f "${D}"/usr/libexec/squid/helper-mux.pl
+	fi
 
 	# cleanup
 	rm -f "${D}"/usr/bin/Run*


### PR DESCRIPTION
It is possible to use squid as a simple pull through cache without
pulling in perl.  To allow this simple use case, move the runtime
dependency on perl to be guarded by a use flag, and don't install
the scripts that use perl in that case.