### PR TITLE
x11-misc/i3status: remove unneeded dependency

### DIFF
--- a/x11-misc/i3status/i3status-2.11.ebuild
+++ b/x11-misc/i3status/i3status-2.11.ebuild
@@ -20,7 +20,6 @@ RDEPEND="dev-libs/confuse:=
 	media-libs/alsa-lib
 	pulseaudio? ( media-sound/pulseaudio )"
 DEPEND="${RDEPEND}
-	app-text/asciidoc
 	virtual/pkgconfig"
 
 src_prepare() {

--- a/x11-misc/i3status/i3status-2.12.ebuild
+++ b/x11-misc/i3status/i3status-2.12.ebuild
@@ -22,7 +22,6 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
-	app-text/asciidoc
 	virtual/pkgconfig
 "
 PATCHES=(


### PR DESCRIPTION
DEPEND does not need app-text/asciidoc

Package-Manager: Portage-2.3.24, Repoman-2.3.6