### PR TITLE
media-{libs,plugins,sound}/*: use HTTPS

### DIFF
--- a/media-libs/rubberband/rubberband-1.8.1-r1.ebuild
+++ b/media-libs/rubberband/rubberband-1.8.1-r1.ebuild
@@ -5,8 +5,8 @@ EAPI=5
 inherit multilib multilib-minimal
 
 DESCRIPTION="An audio time-stretching and pitch-shifting library and utility program"
-HOMEPAGE="http://www.breakfastquay.com/rubberband/"
-SRC_URI="http://code.breakfastquay.com/attachments/download/34/${P}.tar.bz2"
+HOMEPAGE="https://www.breakfastquay.com/rubberband/"
+SRC_URI="https://code.breakfastquay.com/attachments/download/34/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.6-r1.ebuild
+++ b/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit toolchain-funcs eutils multilib multilib-minimal
 
 DESCRIPTION="Audio processing system for plugins to extract information from audio data"
-HOMEPAGE="http://www.vamp-plugins.org"
+HOMEPAGE="https://www.vamp-plugins.org"
 SRC_URI="https://code.soundsoftware.ac.uk/attachments/download/1514/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.7.1.ebuild
+++ b/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.7.1.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit toolchain-funcs eutils multilib multilib-minimal
 
 DESCRIPTION="Audio processing system for plugins to extract information from audio data"
-HOMEPAGE="http://www.vamp-plugins.org"
+HOMEPAGE="https://www.vamp-plugins.org"
 SRC_URI="https://code.soundsoftware.ac.uk/attachments/download/2206/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/media-plugins/vamp-aubio-plugins/vamp-aubio-plugins-0.5.0.ebuild
+++ b/media-plugins/vamp-aubio-plugins/vamp-aubio-plugins-0.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit flag-o-matic toolchain-funcs multilib
 
 DESCRIPTION="Onset detection, pitch tracking, note tracking and tempo tracking plugins"
-HOMEPAGE="http://www.vamp-plugins.org/"
-SRC_URI="http://aubio.org/pub/vamp-aubio-plugins/${P}.tar.bz2"
+HOMEPAGE="https://www.vamp-plugins.org/"
+SRC_URI="https://aubio.org/pub/vamp-aubio-plugins/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/vamp-aubio-plugins/vamp-aubio-plugins-0.5.1.ebuild
+++ b/media-plugins/vamp-aubio-plugins/vamp-aubio-plugins-0.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,8 +8,8 @@ PYTHON_REQ_USE='threads(+)'
 inherit flag-o-matic toolchain-funcs multilib python-any-r1 waf-utils
 
 DESCRIPTION="Onset detection, pitch tracking, note tracking and tempo tracking plugins"
-HOMEPAGE="http://www.vamp-plugins.org/"
-SRC_URI="http://aubio.org/pub/vamp-aubio-plugins/${P}.tar.bz2"
+HOMEPAGE="https://www.vamp-plugins.org/"
+SRC_URI="https://aubio.org/pub/vamp-aubio-plugins/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-sound/ecasound/ecasound-2.6.0-r1.ebuild
+++ b/media-sound/ecasound/ecasound-2.6.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,8 +7,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils python-single-r1
 
 DESCRIPTION="a package for multitrack audio processing"
-HOMEPAGE="http://ecasound.seul.org/ecasound"
-SRC_URI="http://${PN}.seul.org/download/${P}.tar.gz"
+HOMEPAGE="https://ecasound.seul.org/ecasound/"
+SRC_URI="https://${PN}.seul.org/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="1"

--- a/media-sound/ecasound/ecasound-2.9.1-r1.ebuild
+++ b/media-sound/ecasound/ecasound-2.9.1-r1.ebuild
@@ -7,8 +7,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools eutils python-single-r1
 
 DESCRIPTION="a package for multitrack audio processing"
-HOMEPAGE="http://ecasound.seul.org/ecasound"
-SRC_URI="http://ecasound.seul.org/download/${P}.tar.gz"
+HOMEPAGE="https://ecasound.seul.org/ecasound/"
+SRC_URI="https://ecasound.seul.org/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="1"

--- a/media-sound/rosegarden/rosegarden-17.04.ebuild
+++ b/media-sound/rosegarden/rosegarden-17.04.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils gnome2-utils xdg-utils
 
 DESCRIPTION="MIDI and audio sequencer and notation editor"
-HOMEPAGE="http://www.rosegardenmusic.com/"
+HOMEPAGE="https://www.rosegardenmusic.com/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/media-sound/rosegarden/rosegarden-17.12.1.ebuild
+++ b/media-sound/rosegarden/rosegarden-17.12.1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils gnome2-utils xdg-utils
 
 DESCRIPTION="MIDI and audio sequencer and notation editor"
-HOMEPAGE="http://www.rosegardenmusic.com/"
+HOMEPAGE="https://www.rosegardenmusic.com/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/media-sound/sonic-visualiser/sonic-visualiser-2.5.ebuild
+++ b/media-sound/sonic-visualiser/sonic-visualiser-2.5.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
 inherit eutils qmake-utils autotools xdg-utils
 
 DESCRIPTION="Music audio files viewer and analiser"
-HOMEPAGE="http://www.sonicvisualiser.org/"
+HOMEPAGE="https://www.sonicvisualiser.org/"
 SRC_URI="https://code.soundsoftware.ac.uk/attachments/download/1675/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/media-sound/sonic-visualiser/sonic-visualiser-3.0.2.ebuild
+++ b/media-sound/sonic-visualiser/sonic-visualiser-3.0.2.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 inherit eutils qmake-utils autotools xdg-utils
 
 DESCRIPTION="Music audio files viewer and analiser"
-HOMEPAGE="http://www.sonicvisualiser.org/"
+HOMEPAGE="https://www.sonicvisualiser.org/"
 SRC_URI="https://code.soundsoftware.ac.uk/attachments/download/2222/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This PR fixes a few proaudio packages to use https instead of http.

Please review.