### PR TITLE
 mozconfig-v6.52.eclass: unbreak compile for arm

### DIFF
--- a/eclass/mozconfig-v6.52.eclass
+++ b/eclass/mozconfig-v6.52.eclass
@@ -26,7 +26,7 @@ case ${EAPI} in
 		;;
 esac
 
-inherit flag-o-matic toolchain-funcs mozcoreconf-v5
+inherit flag-o-matic toolchain-funcs mozcoreconf-v6
 
 # @ECLASS-VARIABLE: MOZCONFIG_OPTIONAL_WIFI
 # @DEFAULT_UNSET


### PR DESCRIPTION
>=firefox-50.0 compiled with >=gcc-6 has to pass -O2 -fno-insns-schedule , otherwise there will be a linking error. This has been fixed in tree for mozcoreconf-v6 and firefox-60.0, but somehow never got backported for the older esr branch. 

Bug: https://bugs.gentoo.org/649540