### PR TITLE
net-libs/pjproject libressl support

### DIFF
--- a/net-libs/pjproject/files/pjproject-2.7.2-libressl.patch
+++ b/net-libs/pjproject/files/pjproject-2.7.2-libressl.patch
@@ -1,0 +1,98 @@
+Index: /third_party/srtp/crypto/hash/hmac_ossl.c
+===================================================================
+--- /third_party/srtp/crypto/hash/hmac_ossl.c	(revision 5725)
++++ /third_party/srtp/crypto/hash/hmac_ossl.c	(revision 5726)
+@@ -52,6 +52,8 @@
+ #include <openssl/evp.h>
+ #include <openssl/hmac.h>
++#include <openssl/opensslv.h>
+ 
+ #define SHA1_DIGEST_SIZE		20
++#define USING_LIBRESSL (defined(LIBRESSL_VERSION_NUMBER))
+ 
+ /* the debug module for authentiation */
+@@ -77,5 +79,5 @@
+ /* OpenSSL 1.1.0 made HMAC_CTX an opaque structure, which must be allocated
+    using HMAC_CTX_new.  But this function doesn't exist in OpenSSL 1.0.x. */
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if USING_LIBRESSL || OPENSSL_VERSION_NUMBER < 0x10100000L
+     {
+         /* allocate memory for auth and HMAC_CTX structures */
+@@ -122,5 +124,5 @@
+     hmac_ctx = (HMAC_CTX*)a->state;
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if USING_LIBRESSL || OPENSSL_VERSION_NUMBER < 0x10100000L
+     HMAC_CTX_cleanup(hmac_ctx);
+ 
+Index: /pjlib/src/pj/ssl_sock_ossl.c
+===================================================================
+--- /pjlib/src/pj/ssl_sock_ossl.c	(revision 5725)
++++ /pjlib/src/pj/ssl_sock_ossl.c	(revision 5726)
+@@ -56,6 +56,10 @@
+ #include <openssl/rand.h>
+ #include <openssl/opensslconf.h>
+-
+-#if !defined(OPENSSL_NO_EC) && OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#include <openssl/opensslv.h>
++
++#define USING_LIBRESSL (defined(LIBRESSL_VERSION_NUMBER))
++
++#if !USING_LIBRESSL && !defined(OPENSSL_NO_EC) \
++	&& OPENSSL_VERSION_NUMBER >= 0x1000200fL
+ 
+ #   include <openssl/obj_mac.h>
+@@ -115,5 +119,5 @@
+ 
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if !USING_LIBRESSL && OPENSSL_VERSION_NUMBER >= 0x10100000L
+ #  define OPENSSL_NO_SSL2	    /* seems to be removed in 1.1.0 */
+ #  define M_ASN1_STRING_data(x)	    ASN1_STRING_get0_data(x)
+@@ -539,5 +543,5 @@
+ 
+     /* Init OpenSSL lib */
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if USING_LIBRESSL || OPENSSL_VERSION_NUMBER < 0x10100000L
+     SSL_library_init();
+     SSL_load_error_strings();
+@@ -560,5 +564,7 @@
+ 	const char *cname;
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (USING_LIBRESSL && LIBRESSL_VERSION_NUMBER < 0x2020100fL)\
++    || OPENSSL_VERSION_NUMBER < 0x10100000L
++
+ 	meth = (SSL_METHOD*)SSLv23_server_method();
+ 	if (!meth)
+@@ -603,5 +609,6 @@
+ 	SSL_set_session(ssl, SSL_SESSION_new());
+ 
+-#if !defined(OPENSSL_NO_EC) && OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if !USING_LIBRESSL && !defined(OPENSSL_NO_EC) \
++    && OPENSSL_VERSION_NUMBER >= 0x1000200fL
+ 	openssl_curves_num = SSL_get_shared_curve(ssl,-1);
+ 	if (openssl_curves_num > PJ_ARRAY_SIZE(openssl_curves))
+@@ -795,5 +802,6 @@
+ 
+     /* Determine SSL method to use */
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (USING_LIBRESSL && LIBRESSL_VERSION_NUMBER < 0x2020100fL)\
++    || OPENSSL_VERSION_NUMBER < 0x10100000L
+     switch (ssock->param.proto) {
+     case PJ_SSL_SOCK_PROTO_TLS1:
+@@ -1232,5 +1240,6 @@
+ static pj_status_t set_curves_list(pj_ssl_sock_t *ssock)
+ {
+-#if !defined(OPENSSL_NO_EC) && OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if !USING_LIBRESSL && !defined(OPENSSL_NO_EC) \
++    && OPENSSL_VERSION_NUMBER >= 0x1000200fL
+     int ret;
+     int curves[PJ_SSL_SOCK_MAX_CURVES];
+@@ -1263,5 +1272,5 @@
+ static pj_status_t set_sigalgs(pj_ssl_sock_t *ssock)
+ {
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if !USING_LIBRESSL && OPENSSL_VERSION_NUMBER >= 0x1000200fL
+     int ret;
+ 

--- a/net-libs/pjproject/pjproject-2.7.2.ebuild
+++ b/net-libs/pjproject/pjproject-2.7.2.ebuild
@@ -15,9 +15,12 @@ SLOT="0"
 CODEC_FLAGS="g711 g722 g7221 gsm ilbc speex l16"
 VIDEO_FLAGS="sdl ffmpeg v4l2 openh264 libyuv"
 SOUND_FLAGS="alsa oss portaudio"
-IUSE="amr debug doc epoll examples ipv6 opus resample silk ssl static-libs webrtc ${CODEC_FLAGS} ${VIDEO_FLAGS} ${SOUND_FLAGS}"
+IUSE="amr debug doc epoll examples ipv6 libressl opus resample silk ssl static-libs webrtc ${CODEC_FLAGS} ${VIDEO_FLAGS} ${SOUND_FLAGS}"
 
-PATCHES=( "${FILESDIR}"/${P}-ssl-flipflop.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-ssl-flipflop.patch
+	"${FILESDIR}"/${P}-libressl.patch
+)
 
 RDEPEND="alsa? ( media-libs/alsa-lib )
 	oss? ( media-libs/portaudio[oss] )
@@ -34,7 +37,10 @@ RDEPEND="alsa? ( media-libs/alsa-lib )
 	openh264? ( media-libs/openh264 )
 	resample? ( media-libs/libsamplerate )
 
-	ssl? ( dev-libs/openssl:= )
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
 
 	net-libs/libsrtp:0"
 DEPEND="${RDEPEND}

--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-gentoo
+github


### PR DESCRIPTION
Patch for libressl support from the upstream:
https://trac.pjsip.org/repos/changeset/5726

Closes: https://bugs.gentoo.org/656414