### PR TITLE
dev-python/nagiosplugin: support Python 3.6 and PyPy3, EAPI 7

### DIFF
--- a/dev-python/nagiosplugin/nagiosplugin-1.2.4.ebuild
+++ b/dev-python/nagiosplugin/nagiosplugin-1.2.4.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} pypy )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Not much to say about this, tests pass with the new implementations.