### PR TITLE
www-client/firefox: bump nspr and nss requirements (again).

### DIFF
--- a/www-client/firefox/firefox-60.0.1.ebuild
+++ b/www-client/firefox/firefox-60.0.1.ebuild
@@ -56,8 +56,8 @@ ASM_DEPEND=">=dev-lang/yasm-1.1"
 RDEPEND="
 	system-icu? ( >=dev-libs/icu-60.2 )
 	jack? ( virtual/jack )
-	>=dev-libs/nss-3.35
-	>=dev-libs/nspr-4.18
+	>=dev-libs/nss-3.36.1
+	>=dev-libs/nspr-4.19
 	selinux? ( sec-policy/selinux-mozilla )"
 
 DEPEND="${RDEPEND}


### PR DESCRIPTION
This was already fixed in https://github.com/gentoo/gentoo/pull/8349 and https://github.com/gentoo/gentoo/pull/8350 but for some reason was reverted in aa6acbf175583b662e55b2b6f6dc5bc924b7db03

Bug: https://bugs.gentoo.org/655524
Bug: https://bugs.gentoo.org/655528