### PR TITLE
lxde-base/menu-cache: Drop libfm-extra for libfm-1.3-0.2

### DIFF
--- a/lxde-base/menu-cache/menu-cache-1.1.0.ebuild
+++ b/lxde-base/menu-cache/menu-cache-1.1.0.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~mips ~ppc ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND="dev-libs/glib:2
-	x11-libs/libfm-extra"
+	|| ( >=x11-libs/libfm-1.3.0.2  x11-libs/libfm-extra )"
 DEPEND="${RDEPEND}
 	sys-devel/gettext
 	virtual/pkgconfig"


### PR DESCRIPTION
Package-Manager: Portage-2.3.24, Repoman-2.3.6