### PR TITLE
media-sound/mpd: remove opts variable from init script

### DIFF
--- a/media-sound/mpd/files/mpd-0.20.4.init
+++ b/media-sound/mpd/files/mpd-0.20.4.init
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 : CFGFILE=${CFGFILE:=/etc/mpd.conf}
@@ -20,7 +20,7 @@ get_config() {
 
 extra_started_commands='reload'
 command=/usr/bin/mpd
-command_args=${opts:=${CFGFILE}}
+command_args=${CFGFILE}
 required_files=${CFGFILE}
 pidfile=$(get_config pid_file)
 description="Music Player Daemon"

--- a/media-sound/mpd/mpd-0.20.12-r1.ebuild
+++ b/media-sound/mpd/mpd-0.20.12-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6


### PR DESCRIPTION
This variable should never have been used in the first place because it
is reserved to OpenRC. It is unlikely that this variable was ever used
because mpd exposes no interesting command-line options and Gentoo never
provided an associated conf.d file either.

Closes: https://bugs.gentoo.org/645664
Package-Manager: Portage-2.3.38, Repoman-2.3.9