### PR TITLE
Drop EAPI2 src_install()

### DIFF
--- a/app-text/aiksaurus/aiksaurus-1.2.1.ebuild
+++ b/app-text/aiksaurus/aiksaurus-1.2.1.ebuild
@@ -30,8 +30,3 @@ src_configure() {
 	filter-flags -fno-exceptions
 	econf $(use_with gtk)
 }
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/media-libs/fnlib/fnlib-0.5-r2.ebuild
+++ b/media-libs/fnlib/fnlib-0.5-r2.ebuild
@@ -27,8 +27,3 @@ src_prepare() {
 src_configure() {
 	econf --sysconfdir=/etc/fnlib
 }
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/media-libs/fnlib/fnlib-0.5-r2.ebuild
+++ b/media-libs/fnlib/fnlib-0.5-r2.ebuild
@@ -25,5 +25,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --sysconfdir=/etc/fnlib
+	econf --sysconfdir="${EPREFIX}"/etc/fnlib
 }

--- a/media-libs/libptp2/libptp2-1.1.10.ebuild
+++ b/media-libs/libptp2/libptp2-1.1.10.ebuild
@@ -29,8 +29,3 @@ src_prepare() {
 src_test() {
 	env LD_LIBRARY_PATH=./src/.libs/ ./src/ptpcam -l || die
 }
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/media-sound/aseqview/aseqview-0.2.8.ebuild
+++ b/media-sound/aseqview/aseqview-0.2.8.ebuild
@@ -21,8 +21,3 @@ DEPEND="${RDEPEND}
 src_configure() {
 	econf --disable-alsatest --disable-gtktest --enable-gtk2
 }
-
-src_install() {
-	emake DESTDIR="${D}" install || die "emake install failed."
-	default
-}

--- a/media-sound/bladeenc/bladeenc-0.94.2-r1.ebuild
+++ b/media-sound/bladeenc/bladeenc-0.94.2-r1.ebuild
@@ -13,8 +13,3 @@ KEYWORDS="amd64 ppc ppc64 sparc x86"
 IUSE=""
 
 PATCHES=( "${FILESDIR}/${P}-secfix.diff" )
-
-src_install () {
-	emake DESTDIR="${D}" install || die "emake install failed"
-	default
-}

--- a/media-sound/modplugtools/modplugtools-0.5.1.ebuild
+++ b/media-sound/modplugtools/modplugtools-0.5.1.ebuild
@@ -17,8 +17,3 @@ RDEPEND=">=media-libs/libao-0.8.0
 	!media-sound/modplugplay"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/media-sound/modplugtools/modplugtools-0.5.3.ebuild
+++ b/media-sound/modplugtools/modplugtools-0.5.3.ebuild
@@ -17,8 +17,3 @@ RDEPEND=">=media-libs/libao-0.8.0
 	!media-sound/modplugplay"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/media-sound/sidplay/sidplay-2.0.9.ebuild
+++ b/media-sound/sidplay/sidplay-2.0.9.ebuild
@@ -20,8 +20,3 @@ PATCHES=(
 	"${FILESDIR}/${P}-gcc43.patch"
 	"${FILESDIR}/${P}-gcc44.patch"
 )
-
-src_install () {
-	emake DESTDIR="${D}" install || die "emake install failed"
-	default
-}

--- a/media-sound/synaesthesia/synaesthesia-2.4.ebuild
+++ b/media-sound/synaesthesia/synaesthesia-2.4.ebuild
@@ -20,12 +20,8 @@ DEPEND="${RDEPEND}
 	x11-base/xorg-proto"
 
 src_prepare() {
+	default
 	sed -e '/CFLAGS=/s:-O4:${CFLAGS}:' \
 		-e '/CXXFLAGS=/s:-O4:${CXXFLAGS}:' -i configure || die "sed failed"
 	sed -e 's:void inline:inline void:' -i syna.h || die "sed failed"
-}
-
-src_install() {
-	emake DESTDIR="${D}" install || die "emake install failed"
-	default
 }

--- a/media-sound/xineadump/xineadump-0.1-r1.ebuild
+++ b/media-sound/xineadump/xineadump-0.1-r1.ebuild
@@ -22,8 +22,3 @@ PATCHES=(
 	"${FILESDIR}/${P}-gcc-4.3.patch"
 	"${FILESDIR}/${P}-gcc-4.4.patch"
 )
-
-src_install() {
-	emake DESTDIR="${D}" install || die "emake install failed"
-	default
-}

--- a/media-video/subsync/subsync-0.0.1.ebuild
+++ b/media-video/subsync/subsync-0.0.1.ebuild
@@ -14,8 +14,3 @@ IUSE=""
 
 DEPEND=""
 RDEPEND="${DEPEND}"
-
-src_install() {
-	emake DESTDIR="${D}" install || die "emake install failed"
-	default
-}

--- a/sys-apps/dnotify/dnotify-0.18.0.ebuild
+++ b/sys-apps/dnotify/dnotify-0.18.0.ebuild
@@ -24,8 +24,3 @@ src_configure() {
 	econf \
 		$(use_enable nls)
 }
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/sys-fs/autorun/autorun-3.17.ebuild
+++ b/sys-fs/autorun/autorun-3.17.ebuild
@@ -25,8 +25,3 @@ src_configure() {
 	econf \
 		--disable-dependency-tracking
 }
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/sys-fs/autorun/autorun-3.17.ebuild
+++ b/sys-fs/autorun/autorun-3.17.ebuild
@@ -18,10 +18,6 @@ DEPEND="sys-devel/gettext
 	app-text/xmlto
 	app-text/docbook-xml-dtd:4.1.2"
 
-PATCHES=( "${FILESDIR}/${P}-headers.patch" )
+export KDEDIR=/usr
 
-src_configure() {
-	export KDEDIR=/usr
-	econf \
-		--disable-dependency-tracking
-}
+PATCHES=( "${FILESDIR}/${P}-headers.patch" )

--- a/x11-misc/bblaunch/bblaunch-0.0.3.ebuild
+++ b/x11-misc/bblaunch/bblaunch-0.0.3.ebuild
@@ -13,8 +13,3 @@ KEYWORDS="ppc x86 ~x86-fbsd"
 IUSE=""
 
 PATCHES=( "${FILESDIR}/${P}.patch" )
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/x11-misc/fluxter/fluxter-0.1.0.ebuild
+++ b/x11-misc/fluxter/fluxter-0.1.0.ebuild
@@ -28,8 +28,3 @@ src_configure() {
 	econf \
 		--datadir=/usr/share/commonbox
 }
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/x11-misc/fluxter/fluxter-0.1.0.ebuild
+++ b/x11-misc/fluxter/fluxter-0.1.0.ebuild
@@ -26,5 +26,5 @@ src_prepare() {
 
 src_configure() {
 	econf \
-		--datadir=/usr/share/commonbox
+		--datadir="${EPREFIX}"/usr/share/commonbox
 }

--- a/x11-misc/imwheel/imwheel-1.0.0_pre13_p20100827.ebuild
+++ b/x11-misc/imwheel/imwheel-1.0.0_pre13_p20100827.ebuild
@@ -31,8 +31,6 @@ src_prepare() {
 }
 
 src_configure() {
-	local myconf
 	# don't build gpm stuff
-	myconf="--disable-gpm --disable-gpm-doc"
-	econf ${myconf} || die "configure failed"
+	econf --disable-gpm --disable-gpm-doc
 }

--- a/x11-misc/imwheel/imwheel-1.0.0_pre13_p20100827.ebuild
+++ b/x11-misc/imwheel/imwheel-1.0.0_pre13_p20100827.ebuild
@@ -36,8 +36,3 @@ src_configure() {
 	myconf="--disable-gpm --disable-gpm-doc"
 	econf ${myconf} || die "configure failed"
 }
-
-src_install() {
-	emake DESTDIR="${D}" install || die "make install failed"
-	default
-}

--- a/x11-plugins/guifications/guifications-2.16.ebuild
+++ b/x11-plugins/guifications/guifications-2.16.ebuild
@@ -28,8 +28,3 @@ src_configure() {
 		$(use_enable debug ) \
 		$(use_enable nls) || die "econf failure"
 }
-
-src_install() {
-	emake install DESTDIR="${D}" || die "make install failure"
-	default
-}

--- a/x11-plugins/guifications/guifications-2.16.ebuild
+++ b/x11-plugins/guifications/guifications-2.16.ebuild
@@ -26,5 +26,5 @@ DEPEND="${DEPEND}
 src_configure() {
 	econf \
 		$(use_enable debug ) \
-		$(use_enable nls) || die "econf failure"
+		$(use_enable nls)
 }

--- a/x11-plugins/pidgin-hotkeys/pidgin-hotkeys-0.2.4.ebuild
+++ b/x11-plugins/pidgin-hotkeys/pidgin-hotkeys-0.2.4.ebuild
@@ -17,8 +17,3 @@ RDEPEND="net-im/pidgin[gtk]
 
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
-src_install() {
-	emake DESTDIR="${D}" install || die
-	default
-}

--- a/x11-plugins/pidgin-musictracker/pidgin-musictracker-0.4.22.ebuild
+++ b/x11-plugins/pidgin-musictracker/pidgin-musictracker-0.4.22.ebuild
@@ -33,7 +33,6 @@ src_configure() {
 }
 
 src_install() {
-	emake install DESTDIR="${D}" || die "make install failure"
-	find "${D}" -name "*.la" -delete || die "error cleaning la file."
 	default
+	find "${D}" -name "*.la" -delete || die "error cleaning la file."
 }

--- a/x11-plugins/pidgin-privacy-please/pidgin-privacy-please-0.7.1.ebuild
+++ b/x11-plugins/pidgin-privacy-please/pidgin-privacy-please-0.7.1.ebuild
@@ -23,8 +23,3 @@ src_prepare() {
 	sed -e 's: -Wall -g3::' -i configure.ac || die
 	eautoreconf
 }
-
-src_install() {
-	emake DESTDIR="${D}" ALL_LINGUAS="${LANGS}" install || die
-	default
-}


### PR DESCRIPTION
Thanks to @SoapGentoo for the reminder that src_install is not needed in >=EAPI4