### PR TITLE
net-libs/zeromq: Introduce drafts use flag

### DIFF
--- a/net-libs/zeromq/metadata.xml
+++ b/net-libs/zeromq/metadata.xml
@@ -28,6 +28,10 @@
 		<subslots>Reflect ABI of libzmq.so.</subslots>
 	</slots>
 	<use>
+		<flag name="drafts">
+			Build draft API, which may change at any time without any notice, and
+			is therefore not recommended for normal use.
+		</flag>
 		<flag name="pgm">
 			Build PGM (Pragmatic General Multicast)extention, a protocol for reliable 
 			multicast transport of data over IP networks.

--- a/net-libs/zeromq/zeromq-4.2.2-r2.ebuild
+++ b/net-libs/zeromq/zeromq-4.2.2-r2.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/zeromq/libzmq/releases/download/v${PV}/${P}.tar.gz"
 LICENSE="LGPL-3"
 SLOT="0/5"
 KEYWORDS="amd64 arm arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
-IUSE="doc pgm +sodium static-libs test unwind elibc_Darwin"
+IUSE="doc drafts pgm +sodium static-libs test unwind elibc_Darwin"
 
 RDEPEND="
 	!elibc_Darwin? ( unwind? ( sys-libs/libunwind ) )
@@ -40,6 +40,7 @@ src_prepare() {
 src_configure() {
 	local myeconfargs=(
 		--enable-shared
+		$(use_enable drafts)
 		$(use_enable static-libs static)
 		$(use_enable unwind libunwind)
 		$(use_with sodium libsodium)

--- a/net-libs/zeromq/zeromq-4.2.3.ebuild
+++ b/net-libs/zeromq/zeromq-4.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/zeromq/libzmq/releases/download/v${PV}/${P}.tar.gz"
 LICENSE="LGPL-3"
 SLOT="0/5"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
-IUSE="doc pgm +sodium static-libs test unwind elibc_Darwin"
+IUSE="doc drafts pgm +sodium static-libs test unwind elibc_Darwin"
 
 RDEPEND="
 	!elibc_Darwin? ( unwind? ( sys-libs/libunwind ) )
@@ -39,6 +39,7 @@ src_prepare() {
 src_configure() {
 	local myeconfargs=(
 		--enable-shared
+		$(use_enable drafts)
 		$(use_enable static-libs static)
 		$(use_enable unwind libunwind)
 		$(use_with sodium libsodium)

--- a/net-libs/zeromq/zeromq-4.2.5.ebuild
+++ b/net-libs/zeromq/zeromq-4.2.5.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/zeromq/libzmq/releases/download/v${PV}/${P}.tar.gz"
 LICENSE="LGPL-3"
 SLOT="0/5"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
-IUSE="doc pgm +sodium static-libs test unwind elibc_Darwin"
+IUSE="doc drafts pgm +sodium static-libs test unwind elibc_Darwin"
 
 RDEPEND="
 	!elibc_Darwin? ( unwind? ( sys-libs/libunwind ) )
@@ -39,6 +39,7 @@ src_prepare() {
 src_configure() {
 	local myeconfargs=(
 		--enable-shared
+		$(use_enable drafts)
 		$(use_enable static-libs static)
 		$(use_enable unwind libunwind)
 		$(use_with sodium libsodium)


### PR DESCRIPTION
dev-python/pzmq is build with `-DZMQ_BUILD_DRAFT_API=1`. However, the draft API is not build with zeromq, leading to failing test while trying to bump pyzmq to version 17.0. Introducing a new use flags allows successful running pyzmq tests. 