### PR TITLE
net-vpn/openvpn: use HTTPs

### DIFF
--- a/net-vpn/openvpn/openvpn-2.4.4.ebuild
+++ b/net-vpn/openvpn/openvpn-2.4.4.ebuild
@@ -6,9 +6,9 @@ EAPI=6
 inherit autotools flag-o-matic user systemd linux-info
 
 DESCRIPTION="Robust and highly flexible tunneling application compatible with many OSes"
-SRC_URI="http://swupdate.openvpn.net/community/releases/${P}.tar.gz
+SRC_URI="https://swupdate.openvpn.net/community/releases/${P}.tar.gz
 	test? ( https://raw.githubusercontent.com/OpenVPN/${PN}/v${PV}/tests/unit_tests/${PN}/mock_msg.h )"
-HOMEPAGE="http://openvpn.net/"
+HOMEPAGE="https://openvpn.net/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-vpn/openvpn/openvpn-2.4.5.ebuild
+++ b/net-vpn/openvpn/openvpn-2.4.5.ebuild
@@ -6,9 +6,9 @@ EAPI=6
 inherit autotools flag-o-matic user systemd linux-info
 
 DESCRIPTION="Robust and highly flexible tunneling application compatible with many OSes"
-SRC_URI="http://swupdate.openvpn.net/community/releases/${P}.tar.gz
+SRC_URI="https://swupdate.openvpn.net/community/releases/${P}.tar.gz
 	test? ( https://raw.githubusercontent.com/OpenVPN/${PN}/v${PV}/tests/unit_tests/${PN}/mock_msg.h )"
-HOMEPAGE="http://openvpn.net/"
+HOMEPAGE="https://openvpn.net/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-vpn/openvpn/openvpn-2.4.6.ebuild
+++ b/net-vpn/openvpn/openvpn-2.4.6.ebuild
@@ -6,9 +6,9 @@ EAPI=6
 inherit autotools flag-o-matic user systemd linux-info
 
 DESCRIPTION="Robust and highly flexible tunneling application compatible with many OSes"
-SRC_URI="http://swupdate.openvpn.net/community/releases/${P}.tar.gz
+SRC_URI="https://swupdate.openvpn.net/community/releases/${P}.tar.gz
 	test? ( https://raw.githubusercontent.com/OpenVPN/${PN}/v${PV}/tests/unit_tests/${PN}/mock_msg.h )"
-HOMEPAGE="http://openvpn.net/"
+HOMEPAGE="https://openvpn.net/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-vpn/openvpn/openvpn-9999.ebuild
+++ b/net-vpn/openvpn/openvpn-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ inherit autotools flag-o-matic user systemd linux-info git-r3
 DESCRIPTION="Robust and highly flexible tunneling application compatible with many OSes"
 EGIT_REPO_URI="https://github.com/OpenVPN/${PN}.git"
 EGIT_SUBMODULES=(-cmocka)
-HOMEPAGE="http://openvpn.net/"
+HOMEPAGE="https://openvpn.net/"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes the ebuilds of openvpn to use https instead of http.

Please review.