### PR TITLE
base-system@g.o: drop versionator in favor of eapi7-ver

### DIFF
--- a/app-arch/dump/dump-0.4.46.ebuild
+++ b/app-arch/dump/dump-0.4.46.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
-inherit versionator
+inherit eapi7-ver
 
-MY_P="${PN}-$(replace_version_separator 2 b)"
+MY_P="${PN}-$(ver_rs 2 b)"
 S=${WORKDIR}/${MY_P}
 DESCRIPTION="Dump/restore ext2fs backup utilities"
 HOMEPAGE="http://dump.sourceforge.net/"

--- a/app-misc/ca-certificates/ca-certificates-20170717.3.36.1.ebuild
+++ b/app-misc/ca-certificates/ca-certificates-20170717.3.36.1.ebuild
@@ -33,10 +33,10 @@ inherit eutils python-any-r1
 if [[ ${PV} == *.* ]] ; then
 	# Compile from source ourselves.
 	PRECOMPILED=false
-	inherit versionator
+	inherit eapi7-ver
 
-	DEB_VER=$(get_version_component_range 1)
-	NSS_VER=$(get_version_component_range 2-)
+	DEB_VER=$(ver_cut 1)
+	NSS_VER=$(ver_cut 2-)
 	RTM_NAME="NSS_${NSS_VER//./_}_RTM"
 else
 	# Debian precompiled version.

--- a/app-misc/ca-certificates/ca-certificates-20180409.3.36.1-r1.ebuild
+++ b/app-misc/ca-certificates/ca-certificates-20180409.3.36.1-r1.ebuild
@@ -33,10 +33,10 @@ inherit eutils python-any-r1
 if [[ ${PV} == *.* ]] ; then
 	# Compile from source ourselves.
 	PRECOMPILED=false
-	inherit versionator
+	inherit eapi7-ver
 
-	DEB_VER=$(get_version_component_range 1)
-	NSS_VER=$(get_version_component_range 2-)
+	DEB_VER=$(ver_cut 1)
+	NSS_VER=$(ver_cut 2-)
 	RTM_NAME="NSS_${NSS_VER//./_}_RTM"
 else
 	# Debian precompiled version.

--- a/app-misc/ca-certificates/ca-certificates-20180409.3.37.ebuild
+++ b/app-misc/ca-certificates/ca-certificates-20180409.3.37.ebuild
@@ -33,10 +33,10 @@ inherit eutils python-any-r1
 if [[ ${PV} == *.* ]] ; then
 	# Compile from source ourselves.
 	PRECOMPILED=false
-	inherit versionator
+	inherit eapi7-ver
 
-	DEB_VER=$(get_version_component_range 1)
-	NSS_VER=$(get_version_component_range 2-)
+	DEB_VER=$(ver_cut 1)
+	NSS_VER=$(ver_cut 2-)
 	RTM_NAME="NSS_${NSS_VER//./_}_RTM"
 else
 	# Debian precompiled version.

--- a/app-shells/dash/dash-0.5.10.1-r2.ebuild
+++ b/app-shells/dash/dash-0.5.10.1-r2.ebuild
@@ -3,10 +3,10 @@
 
 EAPI=6
 
-inherit flag-o-matic toolchain-funcs versionator
+inherit eapi7-ver flag-o-matic toolchain-funcs
 
-#MY_PV="$(get_version_component_range 1-3)"
-DEB_PATCH="" #$(get_version_component_range 4)
+#MY_PV="$(ver_cut 1-3)"
+DEB_PATCH="" #$(ver_cut 4)
 #MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Debian Almquist Shell"

--- a/app-shells/dash/dash-0.5.10.2.ebuild
+++ b/app-shells/dash/dash-0.5.10.2.ebuild
@@ -3,10 +3,10 @@
 
 EAPI=6
 
-inherit flag-o-matic toolchain-funcs versionator
+inherit eapi7-ver flag-o-matic toolchain-funcs
 
-#MY_PV="$(get_version_component_range 1-3)"
-DEB_PATCH="" #$(get_version_component_range 4)
+#MY_PV="$(ver_cut 1-3)"
+DEB_PATCH="" #$(ver_cut 4)
 #MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Debian Almquist Shell"

--- a/app-shells/dash/dash-0.5.9.1-r3.ebuild
+++ b/app-shells/dash/dash-0.5.9.1-r3.ebuild
@@ -3,10 +3,10 @@
 
 EAPI=6
 
-inherit flag-o-matic toolchain-funcs versionator
+inherit eapi7-ver flag-o-matic toolchain-funcs
 
-#MY_PV="$(get_version_component_range 1-3)"
-DEB_PATCH="" #$(get_version_component_range 4)
+#MY_PV="$(ver_cut 1-3)"
+DEB_PATCH="" #$(ver_cut 4)
 #MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Debian Almquist Shell"
@@ -27,7 +27,9 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	libedit? ( static? ( dev-libs/libedit[static-libs] ) )"
 
-PATCHES=( "${FILESDIR}"/${PN}-0.5.9.1-format-security.patch )
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.5.9.1-format-security.patch
+)
 
 src_prepare() {
 	if [[ -n "${DEB_PATCH}" ]] ; then

--- a/net-firewall/ebtables/ebtables-2.0.10.4-r1.ebuild
+++ b/net-firewall/ebtables/ebtables-2.0.10.4-r1.ebuild
@@ -3,9 +3,9 @@
 
 EAPI="4"
 
-inherit versionator eutils toolchain-funcs multilib flag-o-matic
+inherit eapi7-ver eutils flag-o-matic multilib toolchain-funcs
 
-MY_PV=$(replace_version_separator 3 '-' )
+MY_PV=$(ver_rs 3 '-' )
 MY_P=${PN}-v${MY_PV}
 
 DESCRIPTION="Controls Ethernet frame filtering on a Linux bridge, MAC NAT and brouting"

--- a/net-firewall/ebtables/ebtables-2.0.10.4-r2.ebuild
+++ b/net-firewall/ebtables/ebtables-2.0.10.4-r2.ebuild
@@ -3,9 +3,9 @@
 
 EAPI="6"
 
-inherit versionator toolchain-funcs flag-o-matic
+inherit eapi7-ver flag-o-matic toolchain-funcs
 
-MY_PV=$(replace_version_separator 3 '-' )
+MY_PV=$(ver_rs 3 '-' )
 MY_P=${PN}-v${MY_PV}
 
 DESCRIPTION="Controls Ethernet frame filtering on a Linux bridge, MAC NAT and brouting"

--- a/net-firewall/ebtables/ebtables-2.0.10.4.ebuild
+++ b/net-firewall/ebtables/ebtables-2.0.10.4.ebuild
@@ -3,19 +3,19 @@
 
 EAPI="4"
 
-inherit versionator eutils toolchain-funcs multilib flag-o-matic
+inherit eapi7-ver eutils flag-o-matic multilib toolchain-funcs
 
-MY_PV=$(replace_version_separator 3 '-' )
+MY_PV=$(ver_rs 3 '-' )
 MY_P=${PN}-v${MY_PV}
 
 DESCRIPTION="Controls Ethernet frame filtering on a Linux bridge, MAC NAT and brouting"
 HOMEPAGE="http://ebtables.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
 
-KEYWORDS="amd64 ppc x86"
-IUSE="static"
 LICENSE="GPL-2"
 SLOT="0"
+KEYWORDS="amd64 ppc x86"
+IUSE="static"
 
 RDEPEND="
 	!<net-firewall/iptables-1.6.2-r2[nftables(-)]

--- a/net-fs/nfs-utils/nfs-utils-2.3.1-r3.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-2.3.1-r3.ebuild
@@ -9,8 +9,8 @@ DESCRIPTION="NFS client and server daemons"
 HOMEPAGE="http://linux-nfs.org/"
 
 if [[ "${PV}" = *_rc* ]] ; then
-	inherit versionator
-	MY_PV="$(replace_all_version_separators -)"
+	inherit eapi7-ver
+	MY_PV="$(ver_rs 1- -)"
 	SRC_URI="http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=snapshot;h=refs/tags/${PN}-${MY_PV};sf=tgz -> ${P}.tar.gz"
 	S="${WORKDIR}/${PN}-${PN}-${MY_PV}"
 else

--- a/net-fs/nfs-utils/nfs-utils-2.3.2.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-2.3.2.ebuild
@@ -9,8 +9,8 @@ DESCRIPTION="NFS client and server daemons"
 HOMEPAGE="http://linux-nfs.org/"
 
 if [[ "${PV}" = *_rc* ]] ; then
-	inherit versionator
-	MY_PV="$(replace_all_version_separators -)"
+	inherit eapi7-ver
+	MY_PV="$(ver_rs 1- -)"
 	SRC_URI="http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=snapshot;h=refs/tags/${PN}-${MY_PV};sf=tgz -> ${P}.tar.gz"
 	S="${WORKDIR}/${PN}-${PN}-${MY_PV}"
 else

--- a/net-ftp/ftp/ftp-0.17.23.0.2.1.ebuild
+++ b/net-ftp/ftp/ftp-0.17.23.0.2.1.ebuild
@@ -3,14 +3,14 @@
 
 EAPI="5"
 
-inherit eutils toolchain-funcs flag-o-matic versionator
+inherit eutils eapi7-ver flag-o-matic toolchain-funcs
 
 PATCH_VER="2"
 MY_PN="netkit-ftp"
-MY_PV="$(get_version_component_range 1-2)"
+MY_PV="$(ver_cut 1-2)"
 MY_P="netkit-${PN}-${MY_PV}"
 DEB_PN="${MY_PN}-ssl"
-DEB_PV="$(get_version_component_range 1-3)+$(get_version_component_range 4-5)-$(get_version_component_range 6)"
+DEB_PV="$(ver_cut 1-3)+$(ver_cut 4-5)-$(ver_cut 6)"
 DESCRIPTION="Standard Linux FTP client"
 HOMEPAGE="http://www.hcs.harvard.edu/~dholland/computers/netkit.html"
 SRC_URI="ftp://sunsite.unc.edu/pub/Linux/system/network/netkit/${MY_P}.tar.gz

--- a/net-misc/openssh/openssh-7.5_p1-r4.ebuild
+++ b/net-misc/openssh/openssh-7.5_p1-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="5"
 
-inherit eutils user flag-o-matic multilib autotools pam systemd versionator
+inherit autotools eutils flag-o-matic multilib pam systemd user
 
 # Make it more portable between straight releases
 # and _p? releases.

--- a/net-misc/openssh/openssh-7.6_p1-r4.ebuild
+++ b/net-misc/openssh/openssh-7.6_p1-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit user flag-o-matic multilib autotools pam systemd versionator
+inherit autotools flag-o-matic multilib pam systemd user
 
 # Make it more portable between straight releases
 # and _p? releases.

--- a/net-misc/openssh/openssh-7.6_p1-r5.ebuild
+++ b/net-misc/openssh/openssh-7.6_p1-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit user flag-o-matic multilib autotools pam systemd versionator
+inherit autotools flag-o-matic multilib pam systemd user
 
 # Make it more portable between straight releases
 # and _p? releases.

--- a/net-misc/openssh/openssh-7.7_p1-r1.ebuild
+++ b/net-misc/openssh/openssh-7.7_p1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit user flag-o-matic multilib autotools pam systemd versionator
+inherit autotools flag-o-matic multilib pam systemd user
 
 # Make it more portable between straight releases
 # and _p? releases.
@@ -178,7 +178,7 @@ src_prepare() {
 			einfo "Disabling known non-working MT AES cipher per default ..."
 
 			cat > "${T}"/disable_mtaes.conf <<- EOF
-			
+
 			# HPN's Multi-Threaded AES CTR cipher is currently known to be broken
 			# and therefore disabled per default.
 			DisableMTAES yes

--- a/net-misc/openssh/openssh-7.7_p1-r2.ebuild
+++ b/net-misc/openssh/openssh-7.7_p1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit user flag-o-matic multilib autotools pam systemd versionator
+inherit autotools flag-o-matic multilib pam systemd user
 
 # Make it more portable between straight releases
 # and _p? releases.
@@ -185,7 +185,7 @@ src_prepare() {
 			einfo "Disabling known non-working MT AES cipher per default ..."
 
 			cat > "${T}"/disable_mtaes.conf <<- EOF
-			
+
 			# HPN's Multi-Threaded AES CTR cipher is currently known to be broken
 			# and therefore disabled per default.
 			DisableMTAES yes
@@ -227,6 +227,7 @@ src_prepare() {
 	sed -i \
 		-e "/#UseLogin no/d" \
 		"${S}"/sshd_config || die "Failed to remove removed UseLogin option (sshd_config)"
+
 	eapply "${WORKDIR}"/patch/*.patch
 
 	eapply_user #473004

--- a/net-misc/openssh/openssh-7.7_p1-r3.ebuild
+++ b/net-misc/openssh/openssh-7.7_p1-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit user flag-o-matic multilib autotools pam systemd versionator
+inherit autotools flag-o-matic multilib pam systemd user
 
 # Make it more portable between straight releases
 # and _p? releases.
@@ -185,7 +185,7 @@ src_prepare() {
 			einfo "Disabling known non-working MT AES cipher per default ..."
 
 			cat > "${T}"/disable_mtaes.conf <<- EOF
-			
+
 			# HPN's Multi-Threaded AES CTR cipher is currently known to be broken
 			# and therefore disabled per default.
 			DisableMTAES yes

--- a/sys-apps/baselayout/baselayout-2.4.1-r2.ebuild
+++ b/sys-apps/baselayout/baselayout-2.4.1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit eutils multilib versionator prefix
+inherit eapi7-ver eutils multilib prefix
 
 DESCRIPTION="Filesystem baselayout and init scripts"
 HOMEPAGE="https://www.gentoo.org/"
@@ -233,9 +233,9 @@ pkg_postinst() {
 	fi
 
 	for x in ${REPLACING_VERSIONS}; do
-		if ! version_is_at_least 2.4 ${v}; then
+		if ver_compare ${x} -lt 2.4; then
 			ewarn "After updating ${EROOT}etc/profile, please run"
-			ewarn "env-update and . /etc/profile"
+			ewarn "env-update && . /etc/profile"
 			break
 		fi
 	done

--- a/sys-apps/baselayout/baselayout-2.6.ebuild
+++ b/sys-apps/baselayout/baselayout-2.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit multilib versionator prefix
+inherit eapi7-ver multilib prefix
 
 DESCRIPTION="Filesystem baselayout and init scripts"
 HOMEPAGE="https://www.gentoo.org/"
@@ -249,12 +249,12 @@ pkg_postinst() {
 	fi
 
 	for x in ${REPLACING_VERSIONS}; do
-		if ! version_is_at_least 2.4 ${x}; then
+		if ver_compare ${x} -lt 2.4; then
 			ewarn "After updating ${EROOT}etc/profile, please run"
 			ewarn "env-update && . /etc/profile"
 		fi
 
-		if ! version_is_at_least 2.6 ${x}; then
+		if ver_compare ${x} -lt 2.6; then
 			ewarn "Please run env-update then log out and back in to"
 			ewarn "update your path."
 		fi

--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit multilib versionator prefix
+inherit eapi7-ver multilib prefix
 
 DESCRIPTION="Filesystem baselayout and init scripts"
 HOMEPAGE="https://www.gentoo.org/"
@@ -249,12 +249,12 @@ pkg_postinst() {
 	fi
 
 	for x in ${REPLACING_VERSIONS}; do
-		if ! version_is_at_least 2.4 ${x}; then
+		if ver_compare ${x} -lt 2.4; then
 			ewarn "After updating ${EROOT}etc/profile, please run"
 			ewarn "env-update && . /etc/profile"
 		fi
 
-		if ! version_is_at_least 2.6 ${x}; then
+		if ver_compare ${x} -lt 2.6; then
 			ewarn "Please run env-update then log out and back in to"
 			ewarn "update your path."
 		fi

--- a/sys-apps/tcp-wrappers/tcp-wrappers-7.6.22-r1.ebuild
+++ b/sys-apps/tcp-wrappers/tcp-wrappers-7.6.22-r1.ebuild
@@ -3,10 +3,10 @@
 
 EAPI="4"
 
-inherit eutils toolchain-funcs versionator flag-o-matic multilib-minimal
+inherit eapi7-ver eutils flag-o-matic multilib-minimal toolchain-funcs
 
-MY_PV=$(get_version_component_range 1-2)
-DEB_PV=$(get_version_component_range 3)
+MY_PV=$(ver_cut 1-2)
+DEB_PV=$(ver_cut 3)
 MY_P="${PN//-/_}_${MY_PV}"
 DESCRIPTION="TCP Wrappers"
 HOMEPAGE="ftp://ftp.porcupine.org/pub/security/index.html"

--- a/sys-block/open-iscsi/open-iscsi-2.0.872-r2.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.872-r2.ebuild
@@ -1,22 +1,26 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=2
-inherit versionator linux-info eutils flag-o-matic toolchain-funcs
+
+inherit eapi7-ver eutils flag-o-matic linux-info toolchain-funcs
+
+MY_P="${PN}-$(ver_rs 2 "-")"
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"
-MY_PV="${PN}-$(replace_version_separator 2 "-" $MY_PV)"
-SRC_URI="http://www.open-iscsi.org/bits/${MY_PV}.tar.gz"
+SRC_URI="http://www.open-iscsi.org/bits/${MY_P}.tar.gz"
+
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="alpha amd64 arm ia64 ~mips ppc ppc64 sparc x86"
 IUSE="debug slp"
+
 DEPEND="slp? ( net-libs/openslp )"
 RDEPEND="${DEPEND}
 	sys-apps/util-linux"
 
-S="${WORKDIR}/${MY_PV}"
+S="${WORKDIR}/${MY_P}"
 
 pkg_setup() {
 	linux-info_pkg_setup

--- a/sys-block/open-iscsi/open-iscsi-2.0.872-r3.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.872-r3.ebuild
@@ -1,24 +1,28 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=2
-inherit versionator linux-info eutils flag-o-matic toolchain-funcs
+
+inherit eapi7-ver eutils flag-o-matic linux-info toolchain-funcs
+
+MY_P="${PN}-$(ver_rs 2 "-")"
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"
-MY_PV="${PN}-$(replace_version_separator 2 "-" $MY_PV)"
-SRC_URI="http://www.open-iscsi.org/bits/${MY_PV}.tar.gz"
+SRC_URI="http://www.open-iscsi.org/bits/${MY_P}.tar.gz"
+
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
 IUSE="debug slp"
+
 DEPEND="slp? ( net-libs/openslp )"
 RDEPEND="${DEPEND}
 	virtual/udev
 	sys-fs/lsscsi
 	sys-apps/util-linux"
 
-S="${WORKDIR}/${MY_PV}"
+S="${WORKDIR}/${MY_P}"
 
 pkg_setup() {
 	linux-info_pkg_setup

--- a/sys-block/open-iscsi/open-iscsi-2.0.873-r1.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.873-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit versionator linux-info eutils flag-o-matic toolchain-funcs udev
+inherit eapi7-ver eutils flag-o-matic linux-info toolchain-funcs udev
 
-MY_P="${PN}-$(replace_version_separator 2 "-")"
+MY_P="${PN}-$(ver_rs 2 "-")"
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"

--- a/sys-block/open-iscsi/open-iscsi-2.0.873-r2.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.873-r2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit versionator linux-info eutils flag-o-matic toolchain-funcs udev
+inherit eapi7-ver eutils flag-o-matic linux-info toolchain-funcs udev
 
-MY_P="${PN}-$(replace_version_separator 2 "-")"
+MY_P="${PN}-$(ver_rs 2 "-")"
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"
@@ -21,6 +21,7 @@ RDEPEND="${DEPEND}
 	sys-fs/lsscsi
 	sys-apps/util-linux"
 REQUIRED_USE="infiniband? ( rdma ) || ( rdma tcp )"
+
 S="${WORKDIR}/${MY_P}"
 
 pkg_setup() {

--- a/sys-block/open-iscsi/open-iscsi-2.0.873-r3.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.873-r3.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit versionator linux-info eutils flag-o-matic toolchain-funcs udev
+inherit eapi7-ver eutils flag-o-matic linux-info toolchain-funcs udev
 
-MY_P="${PN}-$(replace_version_separator 2 "-")"
+MY_P="${PN}-$(ver_rs 2 "-")"
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"
@@ -21,6 +21,7 @@ RDEPEND="${DEPEND}
 	sys-fs/lsscsi
 	sys-apps/util-linux"
 REQUIRED_USE="infiniband? ( rdma ) || ( rdma tcp )"
+
 S="${WORKDIR}/${MY_P}"
 
 pkg_setup() {

--- a/sys-block/open-iscsi/open-iscsi-2.0.873.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.873.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit versionator linux-info eutils flag-o-matic toolchain-funcs
+inherit eapi7-ver eutils flag-o-matic linux-info toolchain-funcs
 
-MY_P="${PN}-$(replace_version_separator 2 "-")"
+MY_P="${PN}-$(ver_rs 2 "-")"
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"

--- a/sys-block/open-iscsi/open-iscsi-2.0.874-r1.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.874-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit versionator linux-info flag-o-matic toolchain-funcs udev
+inherit flag-o-matic linux-info toolchain-funcs udev
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"

--- a/sys-block/open-iscsi/open-iscsi-2.0.874-r2.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.874-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit autotools versionator linux-info flag-o-matic toolchain-funcs udev systemd
+inherit autotools flag-o-matic linux-info systemd toolchain-funcs udev
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"

--- a/sys-block/open-iscsi/open-iscsi-2.0.874.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.874.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit versionator linux-info flag-o-matic toolchain-funcs udev
+inherit flag-o-matic linux-info toolchain-funcs udev
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"

--- a/sys-block/open-iscsi/open-iscsi-2.0.875.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.875.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit autotools versionator linux-info flag-o-matic toolchain-funcs udev systemd
+inherit autotools flag-o-matic linux-info systemd toolchain-funcs udev
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"

--- a/sys-block/open-iscsi/open-iscsi-2.0.876.ebuild
+++ b/sys-block/open-iscsi/open-iscsi-2.0.876.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit autotools versionator linux-info flag-o-matic toolchain-funcs udev systemd
+inherit autotools flag-o-matic linux-info systemd toolchain-funcs udev
 
 DESCRIPTION="A performant, transport independent, multi-platform implementation of RFC3720"
 HOMEPAGE="http://www.open-iscsi.com/"

--- a/sys-boot/grub/grub-2.02-r1.ebuild
+++ b/sys-boot/grub/grub-2.02-r1.ebuild
@@ -16,7 +16,7 @@ if [[ -n ${GRUB_AUTORECONF} ]]; then
 	inherit autotools
 fi
 
-inherit bash-completion-r1 flag-o-matic multibuild pax-utils toolchain-funcs versionator
+inherit bash-completion-r1 flag-o-matic multibuild pax-utils toolchain-funcs
 
 if [[ ${PV} != 9999 ]]; then
 	if [[ ${PV} == *_alpha* || ${PV} == *_beta* || ${PV} == *_rc* ]]; then

--- a/sys-boot/grub/grub-2.02.ebuild
+++ b/sys-boot/grub/grub-2.02.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ if [[ -n ${GRUB_AUTOGEN} ]]; then
 	inherit autotools python-any-r1
 fi
 
-inherit autotools bash-completion-r1 flag-o-matic multibuild pax-utils toolchain-funcs versionator
+inherit autotools bash-completion-r1 flag-o-matic multibuild pax-utils toolchain-funcs
 
 if [[ ${PV} != 9999 ]]; then
 	if [[ ${PV} == *_alpha* || ${PV} == *_beta* || ${PV} == *_rc* ]]; then

--- a/sys-boot/grub/grub-9999.ebuild
+++ b/sys-boot/grub/grub-9999.ebuild
@@ -18,7 +18,7 @@ if [[ -n ${GRUB_AUTORECONF} ]]; then
 	inherit autotools
 fi
 
-inherit bash-completion-r1 flag-o-matic multibuild pax-utils toolchain-funcs versionator
+inherit bash-completion-r1 flag-o-matic multibuild pax-utils toolchain-funcs
 
 if [[ ${PV} != 9999 ]]; then
 	if [[ ${PV} == *_alpha* || ${PV} == *_beta* || ${PV} == *_rc* ]]; then

--- a/sys-devel/automake/automake-1.14.1-r2.ebuild
+++ b/sys-devel/automake/automake-1.14.1-r2.ebuild
@@ -4,14 +4,14 @@
 EAPI="6"
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator
+inherit eapi7-ver python-any-r1
 
 if [[ ${PV/_beta} == ${PV} ]]; then
 	MY_P=${P}
 	SRC_URI="mirror://gnu/${PN}/${P}.tar.xz
 		https://alpha.gnu.org/pub/gnu/${PN}/${MY_P}.tar.xz"
 else
-	MY_PV="$(get_major_version).$(($(get_version_component_range 2)-1))b"
+	MY_PV="$(ver_cut 1).$(($(ver_cut 2)-1))b"
 	MY_P="${PN}-${MY_PV}"
 
 	# Alpha/beta releases are not distributed on the usual mirrors.

--- a/sys-devel/automake/automake-1.15.1-r2.ebuild
+++ b/sys-devel/automake/automake-1.15.1-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI="6"
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator
+inherit python-any-r1
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://git.savannah.gnu.org/r/${PN}.git"

--- a/sys-devel/automake/automake-1.16-r2.ebuild
+++ b/sys-devel/automake/automake-1.16-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI="6"
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator
+inherit python-any-r1
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://git.savannah.gnu.org/r/${PN}.git"

--- a/sys-devel/automake/automake-1.16.1-r1.ebuild
+++ b/sys-devel/automake/automake-1.16.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI="6"
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator
+inherit python-any-r1
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://git.savannah.gnu.org/r/${PN}.git"

--- a/sys-devel/automake/automake-9999.ebuild
+++ b/sys-devel/automake/automake-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI="6"
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-any-r1 versionator
+inherit python-any-r1
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://git.savannah.gnu.org/r/${PN}.git"

--- a/sys-fs/cryptsetup/cryptsetup-1.7.5.ebuild
+++ b/sys-fs/cryptsetup/cryptsetup-1.7.5.ebuild
@@ -6,11 +6,11 @@ EAPI=5
 DISTUTILS_OPTIONAL=1
 PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
-inherit autotools distutils-r1 linux-info libtool eutils versionator
+inherit autotools distutils-r1 eapi7-ver eutils libtool linux-info
 
 DESCRIPTION="Tool to setup encrypted devices with dm-crypt"
 HOMEPAGE="https://gitlab.com/cryptsetup/cryptsetup/blob/master/README.md"
-SRC_URI="mirror://kernel/linux/utils/${PN}/v$(get_version_component_range 1-2)/${P}.tar.xz"
+SRC_URI="mirror://kernel/linux/utils/${PN}/v$(ver_cut 1-2)/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0"
@@ -23,7 +23,8 @@ REQUIRED_USE="^^ ( ${CRYPTO_BACKENDS//+/} )
 	python? ( ${PYTHON_REQUIRED_USE} )
 	static? ( !gcrypt )" #496612
 
-LIB_DEPEND="dev-libs/libgpg-error[static-libs(+)]
+LIB_DEPEND="
+	dev-libs/libgpg-error[static-libs(+)]
 	dev-libs/popt[static-libs(+)]
 	sys-apps/util-linux[static-libs(+)]
 	gcrypt? ( dev-libs/libgcrypt:0=[static-libs(+)] )

--- a/sys-fs/cryptsetup/cryptsetup-2.0.2.ebuild
+++ b/sys-fs/cryptsetup/cryptsetup-2.0.2.ebuild
@@ -5,11 +5,11 @@ EAPI=6
 
 PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
-inherit autotools python-single-r1 linux-info libtool ltprune versionator
+inherit autotools eapi7-ver libtool linux-info ltprune python-single-r1
 
 DESCRIPTION="Tool to setup encrypted devices with dm-crypt"
 HOMEPAGE="https://gitlab.com/cryptsetup/cryptsetup/blob/master/README.md"
-SRC_URI="mirror://kernel/linux/utils/${PN}/v$(get_version_component_range 1-2)/${P/_/-}.tar.xz"
+SRC_URI="mirror://kernel/linux/utils/${PN}/v$(ver_cut 1-2)/${P/_/-}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0/12" # libcryptsetup.so version

--- a/sys-fs/cryptsetup/cryptsetup-2.0.3.ebuild
+++ b/sys-fs/cryptsetup/cryptsetup-2.0.3.ebuild
@@ -5,11 +5,11 @@ EAPI=6
 
 PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
-inherit autotools python-single-r1 linux-info libtool ltprune versionator
+inherit autotools eapi7-ver libtool linux-info ltprune python-single-r1
 
 DESCRIPTION="Tool to setup encrypted devices with dm-crypt"
 HOMEPAGE="https://gitlab.com/cryptsetup/cryptsetup/blob/master/README.md"
-SRC_URI="mirror://kernel/linux/utils/${PN}/v$(get_version_component_range 1-2)/${P/_/-}.tar.xz"
+SRC_URI="mirror://kernel/linux/utils/${PN}/v$(ver_cut 1-2)/${P/_/-}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="0/12" # libcryptsetup.so version

--- a/sys-process/runit/runit-2.1.2.ebuild
+++ b/sys-process/runit/runit-2.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -115,7 +115,7 @@ migrate_from_211() {
 pkg_postinst() {
 	if [ -z "$REPLACING_VERSIONS" ]; then
 		default_config
-	elif [ ! version_is_at_least 2.1.2 $REPLACING_VERSIONS ]; then
+	elif [ ver_compare $REPLACING_VERSIONS -lt 2.1.2 ]; then
 		migrate_from_211
 	fi
 


### PR DESCRIPTION
Some of these entirely drop versionator, as it is not used at all in the ebuild that
I could see. Some of the pkg_postinst logic I need a double check on to make
sure my logic is right, but I think I got it.