### PR TITLE
radio@g.o: git-2->git-r3 migration

### DIFF
--- a/net-libs/liba53/liba53-9999.ebuild
+++ b/net-libs/liba53/liba53-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit git-2
+inherit git-r3
 
 DESCRIPTION="A5/3 Call encryption library"
 HOMEPAGE="https://github.com/RangeNetworks/liba53"

--- a/net-libs/libhackrf/libhackrf-2014.04.1.ebuild
+++ b/net-libs/libhackrf/libhackrf-2014.04.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,9 +10,9 @@ HOMEPAGE="http://greatscottgadgets.com/hackrf/"
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/mossmann/hackrf.git"
-	inherit git-2
+	inherit git-r3
 	KEYWORDS=""
-	EGIT_SOURCEDIR="${WORKDIR}/hackrf"
+	EGIT_CHECKOUT_DIR="${WORKDIR}/hackrf"
 	S="${WORKDIR}/hackrf/host/libhackrf"
 else
 	S="${WORKDIR}/hackrf-${PV}/host/libhackrf"

--- a/net-libs/libhackrf/libhackrf-2014.08.1.ebuild
+++ b/net-libs/libhackrf/libhackrf-2014.08.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,9 +10,9 @@ HOMEPAGE="http://greatscottgadgets.com/hackrf/"
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/mossmann/hackrf.git"
-	inherit git-2
+	inherit git-r3
 	KEYWORDS=""
-	EGIT_SOURCEDIR="${WORKDIR}/hackrf"
+	EGIT_CHECKOUT_DIR="${WORKDIR}/hackrf"
 	S="${WORKDIR}/hackrf/host/libhackrf"
 else
 	S="${WORKDIR}/hackrf-${PV}/host/libhackrf"

--- a/net-libs/libhackrf/libhackrf-2015.07.2.ebuild
+++ b/net-libs/libhackrf/libhackrf-2015.07.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,9 +10,9 @@ HOMEPAGE="http://greatscottgadgets.com/hackrf/"
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/mossmann/hackrf.git"
-	inherit git-2
+	inherit git-r3
 	KEYWORDS=""
-	EGIT_SOURCEDIR="${WORKDIR}/hackrf"
+	EGIT_CHECKOUT_DIR="${WORKDIR}/hackrf"
 	S="${WORKDIR}/hackrf/host/libhackrf"
 else
 	S="${WORKDIR}/hackrf-${PV}/host/libhackrf"

--- a/net-libs/libmirisdr/libmirisdr-9999.ebuild
+++ b/net-libs/libmirisdr/libmirisdr-9999.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit cmake-utils git-2 multilib
+inherit cmake-utils git-r3 multilib
 
 DESCRIPTION="Software for the Mirics MSi2500 + MSi001 SDR platform"
 HOMEPAGE="http://cgit.osmocom.org/libmirisdr/"

--- a/net-libs/libosmo-abis/libosmo-abis-9999.ebuild
+++ b/net-libs/libosmo-abis/libosmo-abis-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit autotools git-2
+inherit autotools git-r3
 
 DESCRIPTION="Osmocom library for A-bis interface"
 HOMEPAGE="http://openbsc.osmocom.org/trac/wiki/libosmo-abis"

--- a/net-libs/libosmo-dsp/libosmo-dsp-0.3.ebuild
+++ b/net-libs/libosmo-dsp/libosmo-dsp-0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ DESCRIPTION="A library with SDR DSP primitives"
 HOMEPAGE="http://git.osmocom.org/libosmo-dsp/"
 
 if [[ ${PV} == 9999* ]]; then
-	inherit git-2
+	inherit git-r3
 	EGIT_REPO_URI="git://git.osmocom.org/${PN}"
 	KEYWORDS=""
 else

--- a/net-libs/libosmo-dsp/libosmo-dsp-9999.ebuild
+++ b/net-libs/libosmo-dsp/libosmo-dsp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ DESCRIPTION="A library with SDR DSP primitives"
 HOMEPAGE="http://git.osmocom.org/libosmo-dsp/"
 
 if [[ ${PV} == 9999* ]]; then
-	inherit git-2
+	inherit git-r3
 	EGIT_REPO_URI="git://git.osmocom.org/${PN}"
 	KEYWORDS=""
 else

--- a/net-libs/libosmo-netif/libosmo-netif-9999.ebuild
+++ b/net-libs/libosmo-netif/libosmo-netif-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit autotools eutils git-2
+inherit autotools eutils git-r3
 
 DESCRIPTION="Utility functions for OsmocomBB, OpenBSC and related projects"
 HOMEPAGE="http://bb.osmocom.org/trac/wiki/"

--- a/net-libs/libosmocore/libosmocore-0.8.0.ebuild
+++ b/net-libs/libosmocore/libosmocore-0.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ DESCRIPTION="Utility functions for OsmocomBB, OpenBSC and related projects"
 HOMEPAGE="http://bb.osmocom.org/trac/wiki/libosmocore"
 
 if [[ ${PV} == 9999* ]]; then
-	inherit git-2
+	inherit git-r3
 	EGIT_REPO_URI="git://git.osmocom.org/${PN}.git"
 	KEYWORDS=""
 else

--- a/net-misc/lcr/lcr-9999.ebuild
+++ b/net-misc/lcr/lcr-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit git-2 autotools
+inherit autotools git-r3
 
 DESCRIPTION="Linux Call Router"
 HOMEPAGE="http://isdn.eversberg.eu/"

--- a/net-wireless/gnuradio/gnuradio-3.6.5.1-r2.ebuild
+++ b/net-wireless/gnuradio/gnuradio-3.6.5.1-r2.ebuild
@@ -13,7 +13,7 @@ SLOT="0/${PV}"
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="http://gnuradio.org/git/gnuradio.git"
-	inherit git-2
+	inherit git-r3
 	KEYWORDS=""
 else
 	SRC_URI="http://gnuradio.org/releases/${PN}/${P}.tar.gz"

--- a/net-wireless/gr-air-modes/gr-air-modes-9999.ebuild
+++ b/net-wireless/gr-air-modes/gr-air-modes-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 PYTHON_COMPAT=( python2_7 )
-inherit python-single-r1 cmake-utils git-2
+inherit python-single-r1 cmake-utils git-r3
 
 DESCRIPTION="This module implements a complete Mode S and ADS-B receiver for Gnuradio"
 HOMEPAGE="https://www.cgran.org/wiki/gr-air-modes"

--- a/net-wireless/hackrf-tools/hackrf-tools-2015.07.2-r1.ebuild
+++ b/net-wireless/hackrf-tools/hackrf-tools-2015.07.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,9 +10,9 @@ HOMEPAGE="http://greatscottgadgets.com/hackrf/"
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/mossmann/hackrf.git"
-	inherit git-2
+	inherit git-r3
 	KEYWORDS=""
-	EGIT_SOURCEDIR="${WORKDIR}/hackrf"
+	EGIT_CHECKOUT_DIR="${WORKDIR}/hackrf"
 	S="${WORKDIR}/hackrf/host/hackrf-tools"
 else
 	S="${WORKDIR}/hackrf-${PV}/host/hackrf-tools"

--- a/net-wireless/openbsc/openbsc-9999.ebuild
+++ b/net-wireless/openbsc/openbsc-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit autotools git-2 eutils
+inherit autotools eutils git-r3
 
 DESCRIPTION="OpenBSC, OsmoSGSN, OsmoBSC and other programs"
 HOMEPAGE="http://openbsc.osmocom.org/trac/wiki/OpenBSC"
@@ -25,7 +25,6 @@ RDEPEND="${DEPEND}
 	dev-db/sqlite:3"
 
 S="${WORKDIR}/${P}/${PN}"
-EGIT_SOURCEDIR="${WORKDIR}/${P}"
 
 src_prepare() {
 	epatch_user

--- a/net-wireless/openggsn/openggsn-9999.ebuild
+++ b/net-wireless/openggsn/openggsn-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit git-2 autotools
+inherit autotools git-r3
 
 DESCRIPTION="Gateway GPRS Support Node"
 HOMEPAGE="http://openbsc.osmocom.org/trac/wiki/OpenBSC_GPRS"

--- a/net-wireless/osmobts/osmobts-9999.ebuild
+++ b/net-wireless/osmobts/osmobts-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit autotools git-2
+inherit autotools git-r3
 
 DESCRIPTION="Osmocom BTS-Side code (Abis, scheduling)"
 HOMEPAGE="http://openbsc.osmocom.org/trac/wiki/OsmoBTS"
@@ -19,6 +19,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	eautoreconf
+	mkdir -p "${S}"/include/openbsc || die
 	wget -O "${S}"/include/openbsc/gsm_data_shared.h http://cgit.osmocom.org/openbsc/plain/openbsc/include/openbsc/gsm_data_shared.h || die
 	wget -O "${S}"/src/common/gsm_data_shared.c http://cgit.osmocom.org/openbsc/plain/openbsc/src/libcommon/gsm_data_shared.c || die
 

--- a/net-wireless/osmocom-bb/osmocom-bb-9999.ebuild
+++ b/net-wireless/osmocom-bb/osmocom-bb-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-inherit git-2 autotools flag-o-matic
+inherit autotools flag-o-matic git-r3
 
 DESCRIPTION="OsmocomBB MS-side GSM Protocol stack (L1, L2, L3) excluding firmware"
 HOMEPAGE="http://bb.osmocom.org"


### PR DESCRIPTION
A fair amount of these are cosmetic only (being the git-2 usage is gated by a
${PV} == 9999 check or the like), but it would be good to remove 'bad examples'
and false positives for eclass usage checks on both the offical qa reports site
and mm1ke's.