### PR TITLE
junghans@g.o: git-2->git-r3 migration

### DIFF
--- a/app-laptop/tpacpi-bat/tpacpi-bat-1.1-r1.ebuild
+++ b/app-laptop/tpacpi-bat/tpacpi-bat-1.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils systemd
 
 if [ "${PV}" = "9999" ]; then
-	inherit git-2
+	inherit git-r3
 	EGIT_REPO_URI="https://github.com/teleshoes/tpacpi-bat.git"
 	KEYWORDS=""
 else

--- a/app-laptop/tpacpi-bat/tpacpi-bat-2.1.ebuild
+++ b/app-laptop/tpacpi-bat/tpacpi-bat-2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils systemd
 
 if [ "${PV}" = "9999" ]; then
-	inherit git-2
+	inherit git-r3
 	EGIT_REPO_URI="https://github.com/teleshoes/tpacpi-bat.git"
 	KEYWORDS=""
 else

--- a/app-laptop/tpacpi-bat/tpacpi-bat-3.0-r1.ebuild
+++ b/app-laptop/tpacpi-bat/tpacpi-bat-3.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit systemd
 
 if [ "${PV}" = "9999" ]; then
-	inherit git-2
+	inherit git-r3
 	EGIT_REPO_URI="https://github.com/teleshoes/tpacpi-bat.git"
 	KEYWORDS=""
 else

--- a/app-laptop/tpacpi-bat/tpacpi-bat-3.0.ebuild
+++ b/app-laptop/tpacpi-bat/tpacpi-bat-3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils systemd
 
 if [ "${PV}" = "9999" ]; then
-	inherit git-2
+	inherit git-r3
 	EGIT_REPO_URI="https://github.com/teleshoes/tpacpi-bat.git"
 	KEYWORDS=""
 else

--- a/net-misc/grive/grive-0.4.0_pre20150905-r1.ebuild
+++ b/net-misc/grive/grive-0.4.0_pre20150905-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit cmake-utils
 
 if [[ ${PV} = *9999 ]]; then
-	inherit git-2
 	EGIT_REPO_URI="https://github.com/vitalif/${PN}2.git"
+	inherit git-r3
 else
 	inherit vcs-snapshot
 	COMMIT="5dc7028c8aebb26d35ed31c4b07ac180cc1887c9"

--- a/net-misc/grive/grive-0.4.0_pre20150905.ebuild
+++ b/net-misc/grive/grive-0.4.0_pre20150905.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit cmake-utils
 
 if [[ ${PV} = *9999 ]]; then
-	inherit git-2
 	EGIT_REPO_URI="https://github.com/vitalif/${PN}2.git"
+	inherit git-r3
 else
 	inherit vcs-snapshot
 	COMMIT="5dc7028c8aebb26d35ed31c4b07ac180cc1887c9"

--- a/net-misc/grive/grive-0.4.0_pre20151011.ebuild
+++ b/net-misc/grive/grive-0.4.0_pre20151011.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit cmake-utils
 
 if [[ ${PV} = *9999 ]]; then
-	inherit git-2
 	EGIT_REPO_URI="https://github.com/vitalif/${PN}2.git"
+	inherit git-r3
 else
 	inherit vcs-snapshot
 	COMMIT="44cb91f94e67bcdad77ca564b4d8083cedf72251"

--- a/net-misc/grive/grive-0.5.1_pre20160114.ebuild
+++ b/net-misc/grive/grive-0.5.1_pre20160114.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit cmake-utils
 
 if [[ ${PV} = *9999 ]]; then
-	inherit git-2
 	EGIT_REPO_URI="https://github.com/vitalif/${PN}2.git"
+	inherit git-r3
 else
 	inherit vcs-snapshot
 	COMMIT="cfb8ff08b300d1fa57e12cdc85f724e3e25c906d"

--- a/net-misc/grive/grive-0.5.1_pre20160706.ebuild
+++ b/net-misc/grive/grive-0.5.1_pre20160706.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit cmake-utils
 
 if [[ ${PV} = *9999 ]]; then
-	inherit git-2
 	EGIT_REPO_URI="https://github.com/vitalif/${PN}2.git"
+	inherit git-r3
 else
 	inherit vcs-snapshot
 	COMMIT="457d84974592ed3f123622b12f2a7a748cbc0668"

--- a/net-misc/grive/grive-0.5.1_pre20161004.ebuild
+++ b/net-misc/grive/grive-0.5.1_pre20161004.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit cmake-utils
 
 if [[ ${PV} = *9999 ]]; then
-	inherit git-2
 	EGIT_REPO_URI="https://github.com/vitalif/${PN}2.git"
+	inherit git-r3
 else
 	inherit vcs-snapshot
 	COMMIT="7bbb01c3014cc996ec24a7e5c0684f24b604b735"

--- a/sys-cluster/libcircle/libcircle-0.2.0_rc1.ebuild
+++ b/sys-cluster/libcircle/libcircle-0.2.0_rc1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,8 +7,7 @@ inherit autotools-utils
 
 if [ "${PV}" = "9999" ]; then
 	EGIT_REPO_URI="https://github.com/hpc/${PN}.git"
-	inherit git-2
-	KEYWORDS=""
+	inherit git-r3
 else
 	inherit vcs-snapshot
 	SRC_URI="https://github.com/hpc/${PN}/archive/${PV/_rc/-rc.}.tar.gz -> ${P}.tar.gz"

--- a/sys-cluster/libcircle/libcircle-0.2.1_rc1.ebuild
+++ b/sys-cluster/libcircle/libcircle-0.2.1_rc1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,8 +7,7 @@ inherit autotools-utils
 
 if [ "${PV}" = "9999" ]; then
 	EGIT_REPO_URI="https://github.com/hpc/${PN}.git"
-	inherit git-2
-	KEYWORDS=""
+	inherit git-r3
 else
 	inherit vcs-snapshot
 	SRC_URI="https://github.com/hpc/${PN}/archive/${PV/_rc/-rc.}.tar.gz -> ${P}.tar.gz"


### PR DESCRIPTION
Entirely cosmetic as far as I could see; primary purpose is to remove bad examples
from existing ebuilds and prevent false positives on the official qa and mm1ke's site.