### PR TITLE
dev-libs/libfastjson: use HTTPs

### DIFF
--- a/dev-libs/libfastjson/libfastjson-0.99.8.ebuild
+++ b/dev-libs/libfastjson/libfastjson-0.99.8.ebuild
@@ -6,7 +6,7 @@ EAPI="6"
 inherit autotools
 
 DESCRIPTION="Fork of the json-c library, which is optimized for liblognorm processing"
-HOMEPAGE="http://www.rsyslog.com/tag/libfastjson/"
+HOMEPAGE="https://www.rsyslog.com/tag/libfastjson/"
 SRC_URI="http://download.rsyslog.com/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0/4.2.0"


### PR DESCRIPTION
Hi,

This PR fixes dev-libs/libfastjson to use https instead of http.

Please review.