### PR TITLE
dev-libs/libusb: use HTTPs

### DIFF
--- a/dev-libs/libusb/libusb-1.0.19-r1.ebuild
+++ b/dev-libs/libusb/libusb-1.0.19-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit multilib-minimal toolchain-funcs
 
 DESCRIPTION="Userspace access to USB devices"
-HOMEPAGE="http://libusb.info/"
+HOMEPAGE="https://libusb.info/ https://github.com/libusb/libusb"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"

--- a/dev-libs/libusb/libusb-1.0.20.ebuild
+++ b/dev-libs/libusb/libusb-1.0.20.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit multilib-minimal toolchain-funcs
 
 DESCRIPTION="Userspace access to USB devices"
-HOMEPAGE="http://libusb.info/ https://github.com/libusb/libusb"
+HOMEPAGE="https://libusb.info/ https://github.com/libusb/libusb"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"

--- a/dev-libs/libusb/libusb-1.0.21.ebuild
+++ b/dev-libs/libusb/libusb-1.0.21.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit multilib-minimal toolchain-funcs
 
 DESCRIPTION="Userspace access to USB devices"
-HOMEPAGE="http://libusb.info/ https://github.com/libusb/libusb"
+HOMEPAGE="https://libusb.info/ https://github.com/libusb/libusb"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"

--- a/dev-libs/libusb/libusb-1.0.22.ebuild
+++ b/dev-libs/libusb/libusb-1.0.22.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 inherit ltprune toolchain-funcs multilib-minimal
 
 DESCRIPTION="Userspace access to USB devices"
-HOMEPAGE="http://libusb.info/ https://github.com/libusb/libusb"
+HOMEPAGE="https://libusb.info/ https://github.com/libusb/libusb"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"


### PR DESCRIPTION
Hi,

This PR fixes dev-libs/libusb to use https instead of http.

Please review.