### PR TITLE
www-misc/monitorix: use HTTPS, fix download link

### DIFF
--- a/www-misc/monitorix/monitorix-3.10.0-r1.ebuild
+++ b/www-misc/monitorix/monitorix-3.10.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI="6"
 inherit systemd user
 
 DESCRIPTION="A lightweight system monitoring tool"
-HOMEPAGE="http://www.monitorix.org/"
+HOMEPAGE="https://www.monitorix.org/"
 SRC_URI="https://github.com/mikaku/Monitorix/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/www-misc/monitorix/monitorix-3.10.1.ebuild
+++ b/www-misc/monitorix/monitorix-3.10.1.ebuild
@@ -6,8 +6,8 @@ EAPI="6"
 inherit systemd user
 
 DESCRIPTION="A lightweight system monitoring tool"
-HOMEPAGE="http://www.monitorix.org/"
-SRC_URI="http://www.monitorix.org/${P}.tar.gz"
+HOMEPAGE="https://www.monitorix.org/"
+SRC_URI="https://www.monitorix.org/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/www-misc/monitorix/monitorix-3.5.1.ebuild
+++ b/www-misc/monitorix/monitorix-3.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit eutils systemd user
 
 DESCRIPTION="A lightweight system monitoring tool"
-HOMEPAGE="http://www.monitorix.org/"
-SRC_URI="http://www.${PN}.org/${P}.tar.gz"
+HOMEPAGE="https://www.monitorix.org/"
+SRC_URI="https://www.${PN}.org/old-versions/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/www-misc/monitorix/monitorix-3.8.1-r1.ebuild
+++ b/www-misc/monitorix/monitorix-3.8.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,7 +6,7 @@ EAPI="5"
 inherit systemd user
 
 DESCRIPTION="A lightweight system monitoring tool"
-HOMEPAGE="http://www.monitorix.org/"
+HOMEPAGE="https://www.monitorix.org/"
 SRC_URI="https://github.com/mikaku/Monitorix/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/www-misc/monitorix/monitorix-3.9.0.ebuild
+++ b/www-misc/monitorix/monitorix-3.9.0.ebuild
@@ -6,7 +6,7 @@ EAPI="6"
 inherit systemd user
 
 DESCRIPTION="A lightweight system monitoring tool"
-HOMEPAGE="http://www.monitorix.org/"
+HOMEPAGE="https://www.monitorix.org/"
 SRC_URI="https://github.com/mikaku/Monitorix/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2+"


### PR DESCRIPTION
Hi,

This PR fixes www-misc/monitorix to use https instead of http.

Please review.