### PR TITLE
app-misc/digitemp: use HTTPs

### DIFF
--- a/app-misc/digitemp/digitemp-3.5.0-r2.ebuild
+++ b/app-misc/digitemp/digitemp-3.5.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="Temperature logging and reporting using Maxim's iButtons and 1-Wire protocol"
-HOMEPAGE="http://www.digitemp.com/ http://www.ibutton.com/"
-SRC_URI="http://www.digitemp.com/software/linux/${P}.tar.gz"
+HOMEPAGE="https://www.digitemp.com/ https://www.ibutton.com/"
+SRC_URI="https://www.digitemp.com/software/linux/${P}.tar.gz"
 
 IUSE="ds9097 ds9097u ds2490"
 SLOT="0"

--- a/app-misc/digitemp/digitemp-3.7.1.ebuild
+++ b/app-misc/digitemp/digitemp-3.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit toolchain-funcs
 
 DESCRIPTION="Temperature logging and reporting using Maxim's iButtons and 1-Wire protocol"
-HOMEPAGE="http://www.digitemp.com/ http://www.ibutton.com/"
+HOMEPAGE="https://www.digitemp.com/ https://www.ibutton.com/"
 SRC_URI="https://github.com/bcl/digitemp/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 IUSE="ds9097 ds9097u ds2490"


### PR DESCRIPTION
Hi,

This PR fixes app-misc/digitemp to use https over http.

Please review.