### PR TITLE
media-libs/skstream, sci-mathematics/alt-ergo: use HTTPS

### DIFF
--- a/media-libs/skstream/skstream-0.3.9.ebuild
+++ b/media-libs/skstream/skstream-0.3.9.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit flag-o-matic
 
 DESCRIPTION="FreeSockets - Portable C++ classes for IP (sockets) applications"
-HOMEPAGE="http://www.worldforge.org/"
+HOMEPAGE="https://www.worldforge.org/"
 SRC_URI="mirror://sourceforge/worldforge/${P}.tar.bz2"
 
 LICENSE="GPL-2"

--- a/sci-mathematics/alt-ergo/alt-ergo-1.30.ebuild
+++ b/sci-mathematics/alt-ergo/alt-ergo-1.30.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Automatic theorem prover"
-HOMEPAGE="http://alt-ergo.ocamlpro.com"
+HOMEPAGE="https://alt-ergo.ocamlpro.com"
 SRC_URI="https://alt-ergo.ocamlpro.com/http/${P}/${P}.tar.gz"
 
 LICENSE="CeCILL-C"


### PR DESCRIPTION
Hi,

Another two packages to use https over http.

Please review.