### PR TITLE
mail-client/kube: depend on dev-qt/qtwebengine[widgets]

### DIFF
--- a/mail-client/kube/kube-0.5.0-r1.ebuild
+++ b/mail-client/kube/kube-0.5.0-r1.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	$(add_qt_dep qtquickcontrols)
 	$(add_qt_dep qtquickcontrols2)
 	$(add_qt_dep qttest)
-	$(add_qt_dep qtwebengine)
+	$(add_qt_dep qtwebengine 'widgets')
 	$(add_qt_dep qtwidgets)
 	>=app-crypt/gpgme-1.7.1:=[cxx,qt5]
 	dev-libs/kasync


### PR DESCRIPTION
Hi,

As mentioned in the Bug, kube needs ```dev-qt/qtwebengine[widgets]``` to be able to build. This fixes the ebuild.

Please review.