### PR TITLE
app-text/ghostscript-gpl, net-print/{cups-pdf,gtklp}: use HTTPS

### DIFF
--- a/app-text/ghostscript-gpl/ghostscript-gpl-9.21.ebuild
+++ b/app-text/ghostscript-gpl/ghostscript-gpl-9.21.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools multilib versionator flag-o-matic toolchain-funcs
 
 DESCRIPTION="Ghostscript is an interpreter for the PostScript language and for PDF"
-HOMEPAGE="http://ghostscript.com/"
+HOMEPAGE="https://ghostscript.com/"
 
 MY_P=${P/-gpl}
 PVM=$(get_version_component_range 1-2)

--- a/net-print/cups-pdf/cups-pdf-2.6.1.ebuild
+++ b/net-print/cups-pdf/cups-pdf-2.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -6,8 +6,8 @@ EAPI=4
 inherit toolchain-funcs
 
 DESCRIPTION="Provides a virtual printer for CUPS to produce PDF files"
-HOMEPAGE="http://www.cups-pdf.de/"
-SRC_URI="http://www.cups-pdf.de/src/${PN}_${PV}.tar.gz"
+HOMEPAGE="https://www.cups-pdf.de/"
+SRC_URI="https://www.cups-pdf.de/src/${PN}_${PV}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-print/cups-pdf/cups-pdf-3.0.0.ebuild
+++ b/net-print/cups-pdf/cups-pdf-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="Provides a virtual printer for CUPS to produce PDF files"
-HOMEPAGE="http://www.cups-pdf.de/"
-SRC_URI="http://www.cups-pdf.de/src/${PN}_${PV/_}.tar.gz"
+HOMEPAGE="https://www.cups-pdf.de/"
+SRC_URI="https://www.cups-pdf.de/src/${PN}_${PV/_}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/net-print/cups-pdf/cups-pdf-3.0.1.ebuild
+++ b/net-print/cups-pdf/cups-pdf-3.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="Provides a virtual printer for CUPS to produce PDF files"
-HOMEPAGE="http://www.cups-pdf.de/"
-SRC_URI="http://www.cups-pdf.de/src/${PN}_${PV/_}.tar.gz"
+HOMEPAGE="https://www.cups-pdf.de/"
+SRC_URI="https://www.cups-pdf.de/src/${PN}_${PV/_}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/net-print/gtklp/gtklp-1.3.1.ebuild
+++ b/net-print/gtklp/gtklp-1.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools eutils
 
 DESCRIPTION="A GUI for cupsd"
-HOMEPAGE="http://gtklp.sirtobi.com/"
+HOMEPAGE="https://gtklp.sirtobi.com/"
 SRC_URI="mirror://sourceforge/gtklp/${P}.src.tar.gz
 	mirror://sourceforge/gtklp/logo.xpm.gz -> gtklp-logo.xpm.gz"
 


### PR DESCRIPTION
Hi,

This PR fixes a few http -> https.

Please review.