### PR TITLE
media-sound/alsamixer-app: EAPI7, improve ebuild, use HTTPs

### DIFF
--- a/media-sound/alsamixer-app/alsamixer-app-0.1-r1.ebuild
+++ b/media-sound/alsamixer-app/alsamixer-app-0.1-r1.ebuild
@@ -1,16 +1,16 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 MY_PN=AlsaMixer.app
 MY_P=${MY_PN}-${PV}
 
-DESCRIPTION="AlsaMixer.app is a simple mixer dockapp"
-HOMEPAGE="http://www.dockapps.net/alsamixerapp"
-SRC_URI="http://www.dockapps.net/download/${MY_P}.tar.gz"
+DESCRIPTION="simple alsa mixer dockapp"
+HOMEPAGE="https://www.dockapps.net/alsamixerapp"
+SRC_URI="https://www.dockapps.net/download/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -26,18 +26,9 @@ DEPEND="${RDEPEND}
 
 S=${WORKDIR}/${MY_P}
 
-src_unpack() {
-	unpack ${A}
-	cd "${S}"
-	epatch "${FILESDIR}"/${P}-Makefile.patch
-}
+PATCHES=( "${FILESDIR}"/${P}-Makefile.patch )
 
 src_compile() {
 	tc-export CXX
-	emake || die "emake failed."
-}
-
-src_install() {
-	dobin ${MY_PN} || die "dobin failed."
-	dodoc README
+	default
 }

--- a/media-sound/alsamixer-app/files/alsamixer-app-0.1-Makefile.patch
+++ b/media-sound/alsamixer-app/files/alsamixer-app-0.1-Makefile.patch
@@ -1,6 +1,6 @@
-diff -ur AlsaMixer.app-0.1.orig/Makefile AlsaMixer.app-0.1/Makefile
---- AlsaMixer.app-0.1.orig/Makefile	2004-09-30 23:44:06.000000000 +0300
-+++ AlsaMixer.app-0.1/Makefile	2008-06-28 08:40:28.000000000 +0300
+diff -ur a/Makefile b/Makefile
+--- a/Makefile	2004-09-30 23:44:06.000000000 +0300
++++ b/Makefile	2008-06-28 08:40:28.000000000 +0300
 @@ -4,22 +4,22 @@
  
  DESTDIR =


### PR DESCRIPTION
Hi,

This is my approach to update meida-sound/alsamixer-app.
Updates the ebuild to EAPI7, uses https and improves the ebuild in general.

Please review.