### PR TITLE
texlive-core freetype deps version bump

### DIFF
--- a/app-text/texlive-core/texlive-core-2017-r3.ebuild
+++ b/app-text/texlive-core/texlive-core-2017-r3.ebuild
@@ -118,7 +118,7 @@ COMMON_DEPEND="${MODULAR_X_DEPEND}
 	cjk? ( >=dev-libs/ptexenc-1.3.5 )"
 
 DEPEND="${COMMON_DEPEND}
-	<media-libs/freetype-2.9.1-r2
+	<media-libs/freetype-2.9.1-r3
 	virtual/pkgconfig
 	sys-apps/ed
 	sys-devel/flex


### PR DESCRIPTION
`app-text/texlive-core-2017-r3` needs a version bump for freetypes deps.

```text
media-libs/freetype:2

  (media-libs/freetype-2.9.1-r3:2/2::gentoo, ebuild scheduled for merge) conflicts with
    <media-libs/freetype-2.9.1-r2 required by (app-text/texlive-core-2017-r3:0/0::gentoo, installed)
    ^
```

Give this a test first. 😄 