### PR TITLE
dev-libs/efl[vlc] use masks for alpha and ia64 profiles

### DIFF
--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Joonas Niilola <juippis@gmail.com> (17 Jun 2018)
+# Optional dependency not available for this arch
+dev-libs/efl vlc
+
 # Thomas Deutschmann <whissi@gentoo.org> (06 Jun 2018)
 # Needs sys-apps/fakechroot which isn't keyworded
 app-arch/rpm test

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Joonas Niilola <juippis@gmail.com> (17 Jun 2018)
+# Optional dependency not available for this arch
+dev-libs/efl vlc
+
 # Thomas Deutschmann <whissi@gentoo.org> (06 Jun 2018)
 # Needs sys-apps/fakechroot which isn't keyworded
 app-arch/rpm test


### PR DESCRIPTION
Needed to re-keyword x11-wm/enlightenment

Bug: https://bugs.gentoo.org/657334

Bug: https://bugs.gentoo.org/657090