### PR TITLE
dev-lang/rust: fix 1.26.2 multilib src_install

### DIFF
--- a/dev-lang/rust/rust-1.26.2.ebuild
+++ b/dev-lang/rust/rust-1.26.2.ebuild
@@ -184,7 +184,7 @@ src_install() {
 		abi_libdir=$(get_abi_LIBDIR ${v##*.})
 		rust_target=$(get_abi_CHOST ${v##*.})
 		mkdir -p "${D}/usr/${abi_libdir}"
-		cp "${D}/usr/$(get_libdir)/rustlib/${rust_target}/lib/*.so" \
+		cp "${D}/usr/$(get_libdir)/rustlib/${rust_target}"/lib/*.so \
 		   "${D}/usr/${abi_libdir}" || die
 	done
 


### PR DESCRIPTION
simple globbing issue, quoted too much =)

Closes: https://bugs.gentoo.org/657496
Package-Manager: Portage-2.3.40, Repoman-2.3.9