### PR TITLE
dev-db/mysql-connector-c++: use HTTPs

### DIFF
--- a/dev-db/mysql-connector-c++/mysql-connector-c++-1.1.3.ebuild
+++ b/dev-db/mysql-connector-c++/mysql-connector-c++-1.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils cmake-utils flag-o-matic multilib
 
 DESCRIPTION="MySQL database connector for C++ (mimics JDBC 4.0 API)"
-HOMEPAGE="http://dev.mysql.com/downloads/connector/cpp/"
+HOMEPAGE="https://dev.mysql.com/downloads/connector/cpp/"
 URI_DIR="Connector-C++"
 SRC_URI="https://dev.mysql.com/get/Downloads/${URI_DIR}/${P}.tar.gz"
 

--- a/dev-db/mysql-connector-c++/mysql-connector-c++-1.1.6.ebuild
+++ b/dev-db/mysql-connector-c++/mysql-connector-c++-1.1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils cmake-utils flag-o-matic multilib
 
 DESCRIPTION="MySQL database connector for C++ (mimics JDBC 4.0 API)"
-HOMEPAGE="http://dev.mysql.com/downloads/connector/cpp/"
+HOMEPAGE="https://dev.mysql.com/downloads/connector/cpp/"
 URI_DIR="Connector-C++"
 SRC_URI="https://dev.mysql.com/get/Downloads/${URI_DIR}/${P}.tar.gz"
 

--- a/dev-db/mysql-connector-c++/mysql-connector-c++-1.1.8.ebuild
+++ b/dev-db/mysql-connector-c++/mysql-connector-c++-1.1.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils flag-o-matic
 
 DESCRIPTION="MySQL database connector for C++ (mimics JDBC 4.0 API)"
-HOMEPAGE="http://dev.mysql.com/downloads/connector/cpp/"
+HOMEPAGE="https://dev.mysql.com/downloads/connector/cpp/"
 URI_DIR="Connector-C++"
 SRC_URI="https://dev.mysql.com/get/Downloads/${URI_DIR}/${P}.tar.gz"
 

--- a/dev-db/mysql-connector-c++/mysql-connector-c++-1.1.9.ebuild
+++ b/dev-db/mysql-connector-c++/mysql-connector-c++-1.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils flag-o-matic
 
 DESCRIPTION="MySQL database connector for C++ (mimics JDBC 4.0 API)"
-HOMEPAGE="http://dev.mysql.com/downloads/connector/cpp/"
+HOMEPAGE="https://dev.mysql.com/downloads/connector/cpp/"
 URI_DIR="Connector-C++"
 SRC_URI="https://dev.mysql.com/get/Downloads/${URI_DIR}/${P}.tar.gz"
 

--- a/dev-db/mysql-connector-c++/mysql-connector-c++-8.0.11.ebuild
+++ b/dev-db/mysql-connector-c++/mysql-connector-c++-8.0.11.ebuild
@@ -7,7 +7,7 @@ CMAKE_MAKEFILE_GENERATOR=emake
 inherit cmake-utils
 
 DESCRIPTION="MySQL database connector for C++ (mimics JDBC 4.0 API)"
-HOMEPAGE="http://dev.mysql.com/downloads/connector/cpp/"
+HOMEPAGE="https://dev.mysql.com/downloads/connector/cpp/"
 URI_DIR="Connector-C++"
 SRC_URI="https://dev.mysql.com/get/Downloads/${URI_DIR}/${P}-src.tar.gz"
 


### PR DESCRIPTION
Hi,

Fixes dev-db/mysql-connector-c++ for http -> https.

Please review.