### PR TITLE
app-crypt/efitools: fix dependency and use toolchain-funcs

### DIFF
--- a/app-crypt/efitools/efitools-1.8.1.ebuild
+++ b/app-crypt/efitools/efitools-1.8.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit flag-o-matic
+inherit flag-o-matic toolchain-funcs
 
 DESCRIPTION="Tools for manipulating UEFI secure boot platforms"
 HOMEPAGE="https://git.kernel.org/cgit/linux/kernel/git/jejb/efitools.git"
@@ -23,10 +23,7 @@ RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )
 DEPEND="${RDEPEND}
 	app-crypt/sbsigntool
 	dev-perl/File-Slurp
-	static? (
-		${LIB_DEPEND}
-		dev-util/pkgconfig
-	)
+	static? ( ${LIB_DEPEND} )
 	sys-apps/help2man
 	sys-boot/gnu-efi
 	virtual/pkgconfig"
@@ -39,7 +36,8 @@ PATCHES=(
 src_prepare() {
 	if use static; then
 		append-ldflags -static
-		sed -i 's/-lcrypto/`pkg-config --static --libs libcrypto`/g' Makefile || die
+		sed -i "s/-lcrypto\b/$($(tc-getPKG_CONFIG) --static --libs libcrypto)/g" \
+			Makefile || die
 	fi
 
 	# Respect users CFLAGS


### PR DESCRIPTION
This change fixes the issues addressed during the code review at
https://github.com/gentoo/gentoo/pull/8648 .
    
Fixes: ed1d845779b0 ("app-crypt/efitools: support "static" USE flag")