### PR TITLE
app-portage/elogviewer: >=2.7-r2 ppc re-keywording (bug #656040)

### DIFF
--- a/app-portage/elogviewer/elogviewer-2.7-r2.ebuild
+++ b/app-portage/elogviewer/elogviewer-2.7-r2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/Synss/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~sparc x86 ~x86-fbsd"
+KEYWORDS="amd64 ~ppc ~sparc x86 ~x86-fbsd"
 IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 

--- a/app-portage/elogviewer/elogviewer-2.9.ebuild
+++ b/app-portage/elogviewer/elogviewer-2.9.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/Synss/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~x86-fbsd"
 IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/656040
Package-Manager: Portage-2.3.24-r1, Repoman-2.3.6