### PR TITLE
media-sound/mp3info: Patch for printf format issue

### DIFF
--- a/media-sound/mp3info/files/mp3info-0.8.5a-format-security.patch
+++ b/media-sound/mp3info/files/mp3info-0.8.5a-format-security.patch
@@ -1,0 +1,21 @@
+diff -Nuar mp3info-0.8.5a.orig/textfunc.c mp3info-0.8.5a/textfunc.c
+--- mp3info-0.8.5a.orig/textfunc.c	2018-06-09 21:56:18.450985762 +0300
++++ mp3info-0.8.5a/textfunc.c	2018-06-09 22:09:07.164948467 +0300
+@@ -227,7 +227,7 @@
+ 
+ 	while((percent=strchr(format,'%'))) {
+ 		*percent=0;
+-		printf(format);
++		printf("%s", format);
+ 		*percent='%';
+ 		code=percent+1;
+ 		while(*code && (code[0] != '%' && !isalpha(*code))) code++;
+@@ -354,7 +354,7 @@
+ 		}
+ 		
+ 	}
+-	printf(format);
++	printf("%s", format);
+ }
+ 
+ 

--- a/media-sound/mp3info/mp3info-0.8.5a-r1.ebuild
+++ b/media-sound/mp3info/mp3info-0.8.5a-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit toolchain-funcs
+
+DESCRIPTION="An MP3 technical info viewer and ID3 1.x tag editor"
+HOMEPAGE="http://ibiblio.org/mp3info/"
+SRC_URI="http://ibiblio.org/pub/linux/apps/sound/mp3-utils/${PN}/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris"
+IUSE="gtk"
+
+RDEPEND="
+	gtk? ( >=x11-libs/gtk+-2.6.10:2 )
+	sys-libs/ncurses:0=
+"
+DEPEND="
+	${RDEPEND}
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-ldflags.patch"
+	"${FILESDIR}/${P}-tinfo.patch"
+	"${FILESDIR}/${P}-format-security.patch"
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake mp3info $(usex gtk gmp3info '') CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
+}
+
+src_install() {
+	dobin mp3info $(usex gtk gmp3info '')
+
+	dodoc ChangeLog README
+	doman mp3info.1
+}


### PR DESCRIPTION
Fix for #657668, EAPI 6, ebuild cleanup.

Closes: https://bugs.gentoo.org/657668
Package-Manager: Portage-2.3.40, Repoman-2.3.9