### PR TITLE
dev-lang/nasm: use HTTPs

### DIFF
--- a/dev-lang/nasm/nasm-2.11.08.ebuild
+++ b/dev-lang/nasm/nasm-2.11.08.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit flag-o-matic
 
 DESCRIPTION="groovy little assembler"
-HOMEPAGE="http://nasm.sourceforge.net/"
-SRC_URI="http://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
+HOMEPAGE="https://www.nasm.us/"
+SRC_URI="https://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/dev-lang/nasm/nasm-2.12.01.ebuild
+++ b/dev-lang/nasm/nasm-2.12.01.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit flag-o-matic
 
 DESCRIPTION="groovy little assembler"
-HOMEPAGE="http://www.nasm.us/"
-SRC_URI="http://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
+HOMEPAGE="https://www.nasm.us/"
+SRC_URI="https://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/dev-lang/nasm/nasm-2.13.01.ebuild
+++ b/dev-lang/nasm/nasm-2.13.01.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit flag-o-matic
 
 DESCRIPTION="groovy little assembler"
-HOMEPAGE="http://www.nasm.us/"
-SRC_URI="http://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
+HOMEPAGE="https://www.nasm.us/"
+SRC_URI="https://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/dev-lang/nasm/nasm-2.13.03-r1.ebuild
+++ b/dev-lang/nasm/nasm-2.13.03-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit flag-o-matic
 
 DESCRIPTION="groovy little assembler"
-HOMEPAGE="http://www.nasm.us/"
-SRC_URI="http://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
+HOMEPAGE="https://www.nasm.us/"
+SRC_URI="https://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/dev-lang/nasm/nasm-2.13.03.ebuild
+++ b/dev-lang/nasm/nasm-2.13.03.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit flag-o-matic
 
 DESCRIPTION="groovy little assembler"
-HOMEPAGE="http://www.nasm.us/"
-SRC_URI="http://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
+HOMEPAGE="https://www.nasm.us/"
+SRC_URI="https://www.nasm.us/pub/nasm/releasebuilds/${PV/_}/${P/_}.tar.xz"
 
 LICENSE="BSD-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes dev-lang/nasm to use https instead of http.

Please review.