### PR TITLE
net-libs/iax, new-misc/openr2: use HTTPS

### DIFF
--- a/net-libs/iax/iax-0.2.2.ebuild
+++ b/net-libs/iax/iax-0.2.2.ebuild
@@ -6,12 +6,12 @@ EAPI=0
 IUSE=""
 
 DESCRIPTION="IAX (Inter Asterisk eXchange) Library"
-HOMEPAGE="http://www.digium.com/"
+HOMEPAGE="https://www.digium.com/"
 LICENSE="LGPL-2"
 DEPEND=""
 RDEPEND=""
 SLOT="0"
-SRC_URI="http://www.digium.com/pub/libiax/${P}.tar.gz"
+SRC_URI="https://www.digium.com/pub/libiax/${P}.tar.gz"
 
 D_PREFIX=/usr
 

--- a/net-misc/openr2/openr2-1.3.0.ebuild
+++ b/net-misc/openr2/openr2-1.3.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="An open implementation of the MFC/R2 telephony signaling protocol"
-HOMEPAGE="http://libopenr2.org/"
+HOMEPAGE="https://libopenr2.org/"
 SRC_URI="https://${PN}.googlecode.com/files/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

A few http -> https fixes.
Please review.