### PR TITLE
net-misc/icaclient, mail-client/claws-mail: use HTTPS

### DIFF
--- a/mail-client/claws-mail/claws-mail-3.15.0-r2.ebuild
+++ b/mail-client/claws-mail/claws-mail-3.15.0-r2.ebuild
@@ -7,9 +7,9 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools gnome2-utils python-single-r1 xdg-utils
 
 DESCRIPTION="An email client (and news reader) based on GTK+"
-HOMEPAGE="http://www.claws-mail.org/"
+HOMEPAGE="https://www.claws-mail.org/"
 
-SRC_URI="http://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
+SRC_URI="https://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
 
 SLOT="0"
 LICENSE="GPL-3"

--- a/mail-client/claws-mail/claws-mail-3.15.1.ebuild
+++ b/mail-client/claws-mail/claws-mail-3.15.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,9 +7,9 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools gnome2-utils python-single-r1 xdg-utils
 
 DESCRIPTION="An email client (and news reader) based on GTK+"
-HOMEPAGE="http://www.claws-mail.org/"
+HOMEPAGE="https://www.claws-mail.org/"
 
-SRC_URI="http://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
+SRC_URI="https://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
 
 SLOT="0"
 LICENSE="GPL-3"

--- a/mail-client/claws-mail/claws-mail-3.16.0.ebuild
+++ b/mail-client/claws-mail/claws-mail-3.16.0.ebuild
@@ -7,9 +7,9 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools gnome2-utils python-single-r1 xdg-utils
 
 DESCRIPTION="An email client (and news reader) based on GTK+"
-HOMEPAGE="http://www.claws-mail.org/"
+HOMEPAGE="https://www.claws-mail.org/"
 
-SRC_URI="http://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
+SRC_URI="https://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
 
 SLOT="0"
 LICENSE="GPL-3"

--- a/mail-client/claws-mail/claws-mail-9999.ebuild
+++ b/mail-client/claws-mail/claws-mail-9999.ebuild
@@ -7,13 +7,13 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools gnome2-utils python-single-r1 xdg-utils
 
 DESCRIPTION="An email client (and news reader) based on GTK+"
-HOMEPAGE="http://www.claws-mail.org/"
+HOMEPAGE="https://www.claws-mail.org/"
 
 if [[ "${PV}" == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.claws-mail.org/claws.git"
 else
-	SRC_URI="http://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
+	SRC_URI="https://www.claws-mail.org/download.php?file=releases/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 

--- a/net-misc/icaclient/icaclient-13.8.0.10299729-r1.ebuild
+++ b/net-misc/icaclient/icaclient-13.8.0.10299729-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit multilib eutils versionator
 
 DESCRIPTION="ICA Client for Citrix Presentation servers"
-HOMEPAGE="http://www.citrix.com/"
+HOMEPAGE="https://www.citrix.com/"
 SRC_URI="amd64? ( linuxx64-${PV}.tar.gz )
 	x86? ( linuxx86-${PV}.tar.gz )"
 

--- a/net-misc/icaclient/icaclient-13.9.1.6.ebuild
+++ b/net-misc/icaclient/icaclient-13.9.1.6.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 inherit desktop eutils multilib versionator xdg-utils
 
 DESCRIPTION="ICA Client for Citrix Presentation servers"
-HOMEPAGE="http://www.citrix.com/"
+HOMEPAGE="https://www.citrix.com/"
 SRC_URI="amd64? ( linuxx64-${PV}.tar.gz )
 	x86? ( linuxx86-${PV}.tar.gz )"
 


### PR DESCRIPTION
Hi,

This PR fixes the packages to use https instead of http.

Please review.