### PR TITLE
dev-lang/{rust,rust-bin}: use HTTPS

### DIFF
--- a/dev-lang/rust-bin/rust-bin-1.25.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.25.0.ebuild
@@ -8,14 +8,14 @@ inherit eutils bash-completion-r1 toolchain-funcs
 MY_P="rust-${PV}"
 
 DESCRIPTION="Systems programming language from Mozilla"
-HOMEPAGE="http://www.rust-lang.org/"
-SRC_URI="amd64? ( http://static.rust-lang.org/dist/${MY_P}-x86_64-unknown-linux-gnu.tar.gz )
+HOMEPAGE="https://www.rust-lang.org/"
+SRC_URI="amd64? ( https://static.rust-lang.org/dist/${MY_P}-x86_64-unknown-linux-gnu.tar.gz )
 	arm? (
-		http://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabi.tar.gz
-		http://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabihf.tar.gz
-		http://static.rust-lang.org/dist/${MY_P}-armv7-unknown-linux-gnueabihf.tar.gz
+		https://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabi.tar.gz
+		https://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabihf.tar.gz
+		https://static.rust-lang.org/dist/${MY_P}-armv7-unknown-linux-gnueabihf.tar.gz
 		)
-	x86? ( http://static.rust-lang.org/dist/${MY_P}-i686-unknown-linux-gnu.tar.gz )"
+	x86? ( https://static.rust-lang.org/dist/${MY_P}-i686-unknown-linux-gnu.tar.gz )"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="stable"

--- a/dev-lang/rust-bin/rust-bin-1.26.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.26.0.ebuild
@@ -8,14 +8,14 @@ inherit eutils bash-completion-r1 versionator toolchain-funcs
 MY_P="rust-${PV}"
 
 DESCRIPTION="Systems programming language from Mozilla"
-HOMEPAGE="http://www.rust-lang.org/"
-SRC_URI="amd64? ( http://static.rust-lang.org/dist/${MY_P}-x86_64-unknown-linux-gnu.tar.xz )
+HOMEPAGE="https://www.rust-lang.org/"
+SRC_URI="amd64? ( https://static.rust-lang.org/dist/${MY_P}-x86_64-unknown-linux-gnu.tar.xz )
 	arm? (
-		http://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabi.tar.xz
-		http://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabihf.tar.xz
-		http://static.rust-lang.org/dist/${MY_P}-armv7-unknown-linux-gnueabihf.tar.xz
+		https://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabi.tar.xz
+		https://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabihf.tar.xz
+		https://static.rust-lang.org/dist/${MY_P}-armv7-unknown-linux-gnueabihf.tar.xz
 		)
-	x86? ( http://static.rust-lang.org/dist/${MY_P}-i686-unknown-linux-gnu.tar.xz )"
+	x86? ( https://static.rust-lang.org/dist/${MY_P}-i686-unknown-linux-gnu.tar.xz )"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="stable"

--- a/dev-lang/rust-bin/rust-bin-1.26.2.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.26.2.ebuild
@@ -8,14 +8,14 @@ inherit eutils bash-completion-r1 versionator toolchain-funcs
 MY_P="rust-${PV}"
 
 DESCRIPTION="Systems programming language from Mozilla"
-HOMEPAGE="http://www.rust-lang.org/"
-SRC_URI="amd64? ( http://static.rust-lang.org/dist/${MY_P}-x86_64-unknown-linux-gnu.tar.xz )
+HOMEPAGE="https://www.rust-lang.org/"
+SRC_URI="amd64? ( https://static.rust-lang.org/dist/${MY_P}-x86_64-unknown-linux-gnu.tar.xz )
 	arm? (
-		http://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabi.tar.xz
-		http://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabihf.tar.xz
-		http://static.rust-lang.org/dist/${MY_P}-armv7-unknown-linux-gnueabihf.tar.xz
+		https://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabi.tar.xz
+		https://static.rust-lang.org/dist/${MY_P}-arm-unknown-linux-gnueabihf.tar.xz
+		https://static.rust-lang.org/dist/${MY_P}-armv7-unknown-linux-gnueabihf.tar.xz
 		)
-	x86? ( http://static.rust-lang.org/dist/${MY_P}-i686-unknown-linux-gnu.tar.xz )"
+	x86? ( https://static.rust-lang.org/dist/${MY_P}-i686-unknown-linux-gnu.tar.xz )"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="stable"

--- a/dev-lang/rust/rust-1.25.0.ebuild
+++ b/dev-lang/rust/rust-1.25.0.ebuild
@@ -34,7 +34,7 @@ RUST_STAGE0_arm64="rust-${RUST_STAGE0_VERSION}-${CHOST_arm64}"
 CARGO_DEPEND_VERSION="0.$(($(get_version_component_range 2) + 1)).0"
 
 DESCRIPTION="Systems programming language from Mozilla"
-HOMEPAGE="http://www.rust-lang.org/"
+HOMEPAGE="https://www.rust-lang.org/"
 
 SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.gz
 	amd64? ( https://static.rust-lang.org/dist/${RUST_STAGE0_amd64}.tar.gz )

--- a/dev-lang/rust/rust-1.26.0-r3.ebuild
+++ b/dev-lang/rust/rust-1.26.0-r3.ebuild
@@ -34,7 +34,7 @@ RUST_STAGE0_arm64="rust-${RUST_STAGE0_VERSION}-${CHOST_arm64}"
 CARGO_DEPEND_VERSION="0.$(($(get_version_component_range 2) + 1)).0"
 
 DESCRIPTION="Systems programming language from Mozilla"
-HOMEPAGE="http://www.rust-lang.org/"
+HOMEPAGE="https://www.rust-lang.org/"
 
 SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.xz
 	amd64? ( https://static.rust-lang.org/dist/${RUST_STAGE0_amd64}.tar.xz )

--- a/dev-lang/rust/rust-1.26.0.ebuild
+++ b/dev-lang/rust/rust-1.26.0.ebuild
@@ -34,7 +34,7 @@ RUST_STAGE0_arm64="rust-${RUST_STAGE0_VERSION}-${CHOST_arm64}"
 CARGO_DEPEND_VERSION="0.$(($(get_version_component_range 2) + 1)).0"
 
 DESCRIPTION="Systems programming language from Mozilla"
-HOMEPAGE="http://www.rust-lang.org/"
+HOMEPAGE="https://www.rust-lang.org/"
 
 SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.xz
 	amd64? ( https://static.rust-lang.org/dist/${RUST_STAGE0_amd64}.tar.xz )

--- a/dev-lang/rust/rust-1.26.1.ebuild
+++ b/dev-lang/rust/rust-1.26.1.ebuild
@@ -34,7 +34,7 @@ RUST_STAGE0_arm64="rust-${RUST_STAGE0_VERSION}-${CHOST_arm64}"
 CARGO_DEPEND_VERSION="0.$(($(get_version_component_range 2) + 1)).0"
 
 DESCRIPTION="Systems programming language from Mozilla"
-HOMEPAGE="http://www.rust-lang.org/"
+HOMEPAGE="https://www.rust-lang.org/"
 
 SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.xz
 	amd64? ( https://static.rust-lang.org/dist/${RUST_STAGE0_amd64}.tar.xz )

--- a/dev-lang/rust/rust-1.26.2.ebuild
+++ b/dev-lang/rust/rust-1.26.2.ebuild
@@ -34,7 +34,7 @@ RUST_STAGE0_arm64="rust-${RUST_STAGE0_VERSION}-${CHOST_arm64}"
 CARGO_DEPEND_VERSION="0.$(($(get_version_component_range 2) + 1)).0"
 
 DESCRIPTION="Systems programming language from Mozilla"
-HOMEPAGE="http://www.rust-lang.org/"
+HOMEPAGE="https://www.rust-lang.org/"
 
 SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.xz
 	amd64? ( https://static.rust-lang.org/dist/${RUST_STAGE0_amd64}.tar.xz )


### PR DESCRIPTION
Hi,

This PR fixes the packages to use https instead of http.

Please review.