### PR TITLE
dev-lang/coffee-script, net-analyzer/{nagios,nagios-core}: use HTTPS

### DIFF
--- a/dev-lang/coffee-script/coffee-script-1.12.5.ebuild
+++ b/dev-lang/coffee-script/coffee-script-1.12.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 MY_PN="coffeescript"
 
 DESCRIPTION="A little language that compiles into javascript"
-HOMEPAGE="http://coffeescript.org/"
+HOMEPAGE="https://coffeescript.org/"
 SRC_URI="https://github.com/jashkenas/${MY_PN}/archive/${PV}.tar.gz
 	-> ${P}.tar.gz"
 S="${WORKDIR}/${MY_PN}-${PV}"

--- a/dev-lang/coffee-script/coffee-script-1.9.3-r1.ebuild
+++ b/dev-lang/coffee-script/coffee-script-1.9.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ inherit multilib
 MY_PN="coffeescript"
 
 DESCRIPTION="A little language that compiles into javascript"
-HOMEPAGE="http://coffeescript.org/"
+HOMEPAGE="https://coffeescript.org/"
 
 # The tests are missing from the npm registry package, so use Github
 # instead.

--- a/net-analyzer/nagios-core/nagios-core-3.5.1.ebuild
+++ b/net-analyzer/nagios-core/nagios-core-3.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ inherit depend.apache eutils multilib toolchain-funcs user
 
 MY_P=${PN/-core}-${PV}
 DESCRIPTION="Nagios Core - Check daemon, CGIs, docs"
-HOMEPAGE="http://www.nagios.org/"
+HOMEPAGE="https://www.nagios.org/"
 SRC_URI="mirror://sourceforge/nagios/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-analyzer/nagios-core/nagios-core-4.3.1-r1.ebuild
+++ b/net-analyzer/nagios-core/nagios-core-4.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit toolchain-funcs user
 
 MY_P=${PN/-core}-${PV}
 DESCRIPTION="Nagios core - monitoring daemon, web GUI, and documentation"
-HOMEPAGE="http://www.nagios.org/"
+HOMEPAGE="https://www.nagios.org/"
 
 # The name of the directory into which our Gentoo icons will be
 # extracted, and also the basename of the archive containing it.

--- a/net-analyzer/nagios-core/nagios-core-4.3.3.ebuild
+++ b/net-analyzer/nagios-core/nagios-core-4.3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit toolchain-funcs user
 
 MY_P=${PN/-core}-${PV}
 DESCRIPTION="Nagios core - monitoring daemon, web GUI, and documentation"
-HOMEPAGE="http://www.nagios.org/"
+HOMEPAGE="https://www.nagios.org/"
 
 # The name of the directory into which our Gentoo icons will be
 # extracted, and also the basename of the archive containing it.

--- a/net-analyzer/nagios-core/nagios-core-4.3.4.ebuild
+++ b/net-analyzer/nagios-core/nagios-core-4.3.4.ebuild
@@ -7,7 +7,7 @@ inherit toolchain-funcs user
 
 MY_P=${PN/-core}-${PV}
 DESCRIPTION="Nagios core - monitoring daemon, web GUI, and documentation"
-HOMEPAGE="http://www.nagios.org/"
+HOMEPAGE="https://www.nagios.org/"
 
 # The name of the directory into which our Gentoo icons will be
 # extracted, and also the basename of the archive containing it.

--- a/net-analyzer/nagios/nagios-4.3.1.ebuild
+++ b/net-analyzer/nagios/nagios-4.3.1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="The Nagios metapackage"
-HOMEPAGE="http://www.nagios.org/"
+HOMEPAGE="https://www.nagios.org/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-analyzer/nagios/nagios-4.3.3.ebuild
+++ b/net-analyzer/nagios/nagios-4.3.3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="The Nagios metapackage"
-HOMEPAGE="http://www.nagios.org/"
+HOMEPAGE="https://www.nagios.org/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-analyzer/nagios/nagios-4.3.4.ebuild
+++ b/net-analyzer/nagios/nagios-4.3.4.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="The Nagios metapackage"
-HOMEPAGE="http://www.nagios.org/"
+HOMEPAGE="https://www.nagios.org/"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR fixes the packages to use https instead of http.

Please review.