### PR TITLE
app-vim/scala-syntax: use HTTPs, raise EAPI

### DIFF
--- a/app-vim/scala-syntax/scala-syntax-1.0-r1.ebuild
+++ b/app-vim/scala-syntax/scala-syntax-1.0-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: Scala syntax highlighting, filetype and indent settings"
-HOMEPAGE="http://www.scala-lang.org/"
+HOMEPAGE="https://www.scala-lang.org/"
 SRC_URI="https://dev.gentoo.org/~monsieurp/packages/${P}.tar.gz"
 
 SLOT="0"


### PR DESCRIPTION
Hi,

Simple update for app-vim/scala-syntax. Fixes http -> https and raises EAPI=6
I've only renamed the ebuild and raised the revision as the update doesn't change anything for the package. 

Please review.