### PR TITLE
media-libs/libuninameslist: EAPI6, add missing die

### DIFF
--- a/media-libs/libuninameslist/libuninameslist-20091231-r1.ebuild
+++ b/media-libs/libuninameslist/libuninameslist-20091231-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=6
 
 DESCRIPTION="Library of unicode annotation data"
 HOMEPAGE="http://libuninameslist.sourceforge.net/"
@@ -12,7 +12,7 @@ SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE=""
 
-S=${WORKDIR}/${PN}
+S="${WORKDIR}/${PN}"
 
 src_configure() {
 	econf \
@@ -21,5 +21,5 @@ src_configure() {
 
 src_install() {
 	default
-	find "${ED}" -name '*.la' -exec rm -f {} +
+	find "${ED%/}"/usr -name '*.la' -delete || die
 }


### PR DESCRIPTION
Hi,

Simple update for media-libs/libuninameslist. Added a missing die and raised EAPI.
I've only renamed the ebuild and raised the revision as the update doesn't change anything for the package. 

Please review.