### PR TITLE
app-eselect/eselect-lcdfilter: raise EAPI, use readme.gentoo-r1

### DIFF
--- a/app-eselect/eselect-lcdfilter/eselect-lcdfilter-2.ebuild
+++ b/app-eselect/eselect-lcdfilter/eselect-lcdfilter-2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit vcs-snapshot readme.gentoo
+EAPI=6
+inherit vcs-snapshot readme.gentoo-r1
 
 DESCRIPTION="Eselect module to choose Freetype infinality-enhanced LCD filtering settings"
 HOMEPAGE="https://github.com/yngwin/eselect-lcdfilter"
@@ -13,17 +13,16 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-DEPEND=""
 RDEPEND="app-admin/eselect"
 PDEPEND="media-libs/freetype[infinality]"
 
-src_install() {
-	DOC_CONTENTS="Use eselect lcdfilter to select an lcdfiltering font style.
-	You can customize ${EPREFIX}/usr/share/${PN}/env.d/custom with your own settings.
-	See ${EPREFIX}/usr/share/doc/${PF}/infinality-settings.sh for an explanation and
+DOC_CONTENTS="Use eselect lcdfilter to select an lcdfiltering font style.
+	You can customize ${EPREFIX}/usr/share/"${PN}"/env.d/custom with your own settings.
+	See ${EPREFIX}/usr/share/doc/"${PF}"/infinality-settings.sh for an explanation and
 	examples of the variables. This module is supposed to be used in pair with
 	eselect infinality."
 
+src_install() {
 	dodoc README.rst infinality-settings.sh
 	readme.gentoo_create_doc
 


### PR DESCRIPTION
Hi,

This PR raises the EAPI of the ebuild and uses readme.gentoo-r1.
Also quoting the Vars in order to make repoman happy.

Please review.