### PR TITLE
app-eselect/eselect-infinality: raise EAPI, use readme.gentoo-r1

### DIFF
--- a/app-eselect/eselect-infinality/eselect-infinality-1-r1.ebuild
+++ b/app-eselect/eselect-infinality/eselect-infinality-1-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
-inherit vcs-snapshot readme.gentoo
+EAPI=6
+inherit vcs-snapshot readme.gentoo-r1
 
 DESCRIPTION="Eselect module to choose an infinality font configuration style"
 HOMEPAGE="https://github.com/yngwin/eselect-infinality"


### PR DESCRIPTION
Hi,

This PR raises the EAPI and uses the readme.gentoo-r1 eclass.
I've only renamed the ebuild and raised the revision as the update doesn't change anything for the package. 

Please review.