### PR TITLE
app-eselect/eselect-fontconfig: raise EAPI

### DIFF
--- a/app-eselect/eselect-fontconfig/eselect-fontconfig-1.1-r1.ebuild
+++ b/app-eselect/eselect-fontconfig/eselect-fontconfig-1.1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 DESCRIPTION="An eselect module to manage /etc/fonts/conf.d symlinks"
 HOMEPAGE="https://www.gentoo.org"
@@ -12,7 +12,6 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
-DEPEND=""
 RDEPEND=">=app-admin/eselect-1.2.3
 		 >=media-libs/fontconfig-2.4"
 


### PR DESCRIPTION
Hi,

This simply raises EAPI for the 1.1-r1 ebuild in order to have a stable candidate.

Please review.
