### PR TITLE
x11-misc/parcellite: keyworded 1.2.1 for ppc, bug #657070

### DIFF
--- a/x11-misc/parcellite/parcellite-1.2.1.ebuild
+++ b/x11-misc/parcellite/parcellite-1.2.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 inherit autotools eutils xdg-utils
 
@@ -13,7 +13,7 @@ SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 x86 ~ppc"
 IUSE="nls"
 
 RDEPEND=">=dev-libs/glib-2.14

--- a/x11-terms/terminator/terminator-1.91.ebuild
+++ b/x11-terms/terminator/terminator-1.91.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 PYTHON_COMPAT=( python2_7 )
 inherit gnome2 distutils-r1 virtualx
 
@@ -11,7 +11,7 @@ SRC_URI="https://launchpad.net/${PN}/gtk3/${PV}/+download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 x86 ~ppc"
 IUSE="dbus +libnotify"
 
 RDEPEND="


### PR DESCRIPTION
bumped EAPI from 5 to 6 without additional changes to the .ebuild

Package-Manager: Portage-2.3.24, Repoman-2.3.6
Bug: https://bugs.gentoo.org/657070