### PR TITLE
media-sound/pnmixer: keyworded 0.7.1 for ppc, bug #657232

### DIFF
--- a/media-sound/pnmixer/pnmixer-0.6_pre20111213.ebuild
+++ b/media-sound/pnmixer/pnmixer-0.6_pre20111213.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=5
 
 inherit autotools eutils gnome2-utils
 

--- a/media-sound/pnmixer/pnmixer-0.6_pre20111213.ebuild
+++ b/media-sound/pnmixer/pnmixer-0.6_pre20111213.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 inherit autotools eutils gnome2-utils
 

--- a/media-sound/pnmixer/pnmixer-0.7.1.ebuild
+++ b/media-sound/pnmixer/pnmixer-0.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/nicklan/pnmixer/archive/v${PV/_rc/-rc}.tar.gz -> ${P
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="libnotify"
 
 RDEPEND="dev-libs/glib:2


### PR DESCRIPTION
keyworded 0.7.1 for ppc
bumped EAPI from 5 to 6 in 0.6_pre20111213 without addidtional changes

Closes: https://bugs.gentoo.org/657232
Package-Manager: Portage-2.3.24, Repoman-2.3.6