### PR TITLE
app-backup/burp, media-libs/elles_icc_profiles: use HTTPS

### DIFF
--- a/app-backup/burp/burp-2.1.32.ebuild
+++ b/app-backup/burp/burp-2.1.32.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools systemd user versionator
 
 DESCRIPTION="Network backup and restore client and server for Unix and Windows"
-HOMEPAGE="http://burp.grke.org/"
+HOMEPAGE="https://burp.grke.org/"
 SRC_URI="https://github.com/grke/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="AGPL-3"

--- a/media-libs/elles_icc_profiles/elles_icc_profiles-20160501.0932-r1.ebuild
+++ b/media-libs/elles_icc_profiles/elles_icc_profiles-20160501.0932-r1.ebuild
@@ -7,7 +7,7 @@ MY_PV="$(ver_rs 1 '-')EST"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Elle Stone's well-behaved RGB and grey ICC profiles"
-HOMEPAGE="http://ninedegreesbelow.com/photography/lcms-make-icc-profiles.html"
+HOMEPAGE="https://ninedegreesbelow.com/photography/lcms-make-icc-profiles.html"
 SRC_URI="https://github.com/ellelstone/${PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="CC-BY-SA-3.0"

--- a/media-libs/elles_icc_profiles/elles_icc_profiles-20160501.0932.ebuild
+++ b/media-libs/elles_icc_profiles/elles_icc_profiles-20160501.0932.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ MY_PV="$(replace_version_separator 1 '-')EST"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Elle Stone's well-behaved RGB and grey ICC profiles"
-HOMEPAGE="http://ninedegreesbelow.com/photography/lcms-make-icc-profiles.html"
+HOMEPAGE="https://ninedegreesbelow.com/photography/lcms-make-icc-profiles.html"
 SRC_URI="https://github.com/ellelstone/${PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="CC-BY-SA-3.0"


### PR DESCRIPTION
Hi,

This PR fixes the packages to use https instead of http.

Please review