### PR TITLE
 media-libs/libdvdnav: stable 6.0.0 for ppc, bug #648060 

### DIFF
--- a/media-libs/libdvdnav/libdvdnav-5.0.3.ebuild
+++ b/media-libs/libdvdnav/libdvdnav-5.0.3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 AUTOTOOLS_AUTORECONF=1
 AUTOTOOLS_PRUNE_LIBTOOL_FILES=all
-inherit autotools-multilib
+inherit multilib-minimal
 
 DESCRIPTION="Library for DVD navigation tools"
 HOMEPAGE="https://www.videolan.org/developers/libdvdnav.html"

--- a/media-libs/libdvdnav/libdvdnav-6.0.0.ebuild
+++ b/media-libs/libdvdnav/libdvdnav-6.0.0.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = 9999 ]]; then
 	EGIT_REPO_URI="https://code.videolan.org/videolan/libdvdnav.git"
 else
 	SRC_URI="https://downloads.videolan.org/pub/videolan/libdvdnav/${PV}/${P}.tar.bz2"
-	KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ~ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+	KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 fi
 
 LICENSE="GPL-2"

--- a/media-libs/libdvdread/libdvdread-5.0.3.ebuild
+++ b/media-libs/libdvdread/libdvdread-5.0.3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 AUTOTOOLS_AUTORECONF=1
 AUTOTOOLS_PRUNE_LIBTOOL_FILES=all
-inherit autotools-multilib
+inherit multilib-minimal
 
 DESCRIPTION="Library for DVD navigation tools"
 HOMEPAGE="https://www.videolan.org/developers/libdvdnav.html"

--- a/media-libs/libdvdread/libdvdread-6.0.0.ebuild
+++ b/media-libs/libdvdread/libdvdread-6.0.0.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = 9999 ]]; then
 	EGIT_REPO_URI="https://code.videolan.org/videolan/libdvdread.git"
 else
 	SRC_URI="https://downloads.videolan.org/pub/videolan/libdvdread/${PV}/${P}.tar.bz2"
-	KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ~ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+	KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 fi
 
 LICENSE="GPL-2"


### PR DESCRIPTION
stable 6.0.0 for ppc, bug #648060
upgrade 5.0.3 from EAPI 5 to 6 (migrate from 'autotools-multilib' to 'multilib-minimal')

Bug: https://bugs.gentoo.org/648060