### PR TITLE
net-analyzer/wireshark: Fix install to avoid calling doins per-file

### DIFF
--- a/net-analyzer/wireshark/wireshark-2.6.1.ebuild
+++ b/net-analyzer/wireshark/wireshark-2.6.1.ebuild
@@ -176,31 +176,24 @@ src_install() {
 	dodoc AUTHORS ChangeLog NEWS README* doc/randpkt.txt doc/README*
 
 	# install headers
-	local wsheader
-	for wsheader in \
-		epan/*.h \
-		epan/crypt/*.h \
-		epan/dfilter/*.h \
-		epan/dissectors/*.h \
-		epan/ftypes/*.h \
-		epan/wmem/*.h \
-		wiretap/*.h \
-		ws_diag_control.h \
-		ws_symbol_export.h \
-		wsutil/*.h
-	do
-		echo "Installing ${wsheader}"
-		insinto /usr/include/wireshark/$( dirname ${wsheader} )
-		doins ${wsheader}
-	done
+	insinto /usr/include/wireshark
+	doins ws_diag_control.h ws_symbol_export.h \
+		"${BUILD_DIR}"/config.h "${BUILD_DIR}"/version.h
 
-	for wsheader in \
-		../${P}_build/config.h \
-		../${P}_build/version.h
+	local dir dirs=(
+		epan
+		epan/crypt
+		epan/dfilter
+		epan/dissectors
+		epan/ftypes
+		epan/wmem
+		wiretap
+		wsutil
+	)
+	for dir in "${dirs[@]}"
 	do
-		echo "Installing ${wsheader}"
-		insinto /usr/include/wireshark
-		doins ${wsheader}
+		insinto /usr/include/wireshark/${dir}
+		doins ${dir}/*.h
 	done
 
 	#with the above this really shouldn't be needed, but things may be looking


### PR DESCRIPTION
Call doins per-directory rather than per-file.  doins accept multiple
arguments, so it's entirely silly to iterate and call it separately
for each file; not to mention that thanks to new Python implementation
in Portage it is veeeeery slow.  This patch reduces install time by
around 10 minutes.

Closes: https://bugs.gentoo.org/656834