### PR TITLE
media-libs/liboggz: use HTTPS

### DIFF
--- a/media-libs/liboggz/liboggz-1.1.1.ebuild
+++ b/media-libs/liboggz/liboggz-1.1.1.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="Oggz provides a simple programming interface for reading and writing Ogg files and streams"
-HOMEPAGE="http://www.xiph.org/oggz/"
-SRC_URI="http://downloads.xiph.org/releases/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.xiph.org/oggz/"
+SRC_URI="https://downloads.xiph.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Hi,

simple https fix for media-libs/liboggz.

Please review.