### PR TITLE
media-libs/libdvdnav: stable 6.0.0 for ppc, bug #648060

### DIFF
--- a/media-libs/libdvdnav/libdvdnav-6.0.0.ebuild
+++ b/media-libs/libdvdnav/libdvdnav-6.0.0.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = 9999 ]]; then
 	EGIT_REPO_URI="https://code.videolan.org/videolan/libdvdnav.git"
 else
 	SRC_URI="https://downloads.videolan.org/pub/videolan/libdvdnav/${PV}/${P}.tar.bz2"
-	KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ~ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+	KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 fi
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/648060
Package-Manager: Portage-2.3.24, Repoman-2.3.6