### PR TITLE
app-crypt/dehydrated:  add "cron" USE flag

### DIFF
--- a/app-crypt/dehydrated/dehydrated-0.6.2-r1.ebuild
+++ b/app-crypt/dehydrated/dehydrated-0.6.2-r1.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit user
+
+DESCRIPTION="a client for signing certificates with an ACME-server"
+HOMEPAGE="https://github.com/lukas2511/dehydrated"
+SRC_URI="https://github.com/lukas2511/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+cron"
+
+DEPEND="cron? ( virtual/cron )"
+RDEPEND="
+	${DEPEND}
+	app-shells/bash
+	net-misc/curl
+"
+
+src_configure() {
+	default
+	sed -i  's,^#CONFIG_D=.*,CONFIG_D="/etc/dehydrated/config.d",' docs/examples/config || die "could not set config (CONFIG_D)"
+}
+
+src_install() {
+	dobin "${PN}"
+	insinto "/etc/${PN}"
+	doins docs/examples/{config,domains.txt,hook.sh}
+	dodoc docs/*.md
+
+	insinto /etc/"${PN}"/config.d
+	doins "${FILESDIR}"/00_gentoo.sh
+
+	if use cron ; then
+		insinto "/etc/cron.d"
+		newins "${FILESDIR}"/cron "${PN}"
+	fi
+
+	dodir /etc/"${PN}"/config.d
+	keepdir /etc/"${PN}"/config.d
+
+	default
+}
+
+pkg_preinst() {
+	enewgroup "${PN}"
+	enewuser "${PN}" -1 -1 /var/lib/"${PN}" "${PN}"
+}
+
+pkg_postinst() {
+	if [[ "${REPLACING_VERSIONS}" =~ (0\.3\.1|0\.4\.0) ]]; then
+		ewarn ""
+		ewarn "The new default BASEDIR is now '/var/lib/dehydrated'"
+		ewarn "Please consider migrating your data with a command like"
+		ewarn ""
+		ewarn "  'mv -v /etc/dehydrated/{accounts,archive,certs,lock} /var/lib/dehydrated'"
+		ewarn ""
+		ewarn "and make sure BASEDIR is set to '/var/lib/dehydrated'"
+		ewarn ""
+	fi
+	einfo "See /etc/dehydrated/config for configuration."
+	use cron && einfo "After finishing setup you should enable the cronjob in /etc/cron.d/dehydrated."
+}

--- a/app-crypt/dehydrated/metadata.xml
+++ b/app-crypt/dehydrated/metadata.xml
@@ -8,6 +8,9 @@
 		<email>whissi@gentoo.org</email>
 		<name>Thomas Deutschmann</name>
 	</maintainer>
+	<use>
+		<flag name="cron">Install cron job to sign/renew non-existent/changed/expiring certificates</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">lukas2511/dehydrated</remote-id>
 	</upstream>


### PR DESCRIPTION
This makes installation of the included cron script optional, and by extension the dependency on virtual/cron.