### PR TITLE
sys-power/powertop: Support ncurses with tinfo

### DIFF
--- a/sys-power/powertop/files/powertop-2.8-ncurses_tinfo.patch
+++ b/sys-power/powertop/files/powertop-2.8-ncurses_tinfo.patch
@@ -1,0 +1,41 @@
+From e1295099f8b42670718ba875cb6749a90042293f Mon Sep 17 00:00:00 2001
+From: Zentaro Kavanagh <zentaro@chromium.org>
+Date: Thu, 14 Jun 2018 13:13:37 -0700
+Subject: [PATCH] Fix configure to support ncurses w/ tinfo
+
+- The existing code checked for both ncursesw and ncurses and if
+  both were not found, NCURSES_LIBS was not set correctly.
+- Removed redundant concatenation to $LIBS since the makefile.am
+  already maps NCURSES_LIBS into LIBS.
+- Patch sent upstream to powertop mailing list [1]
+
+[1] - https://lists.01.org/pipermail/powertop/2018-June/002021.html
+---
+ configure.ac | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index d6a15e1..c6ee50a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -110,10 +110,13 @@ AC_CHECK_FUNCS([ \
+ 
+ AC_SEARCH_LIBS([clock_gettime], [rt])
+ 
+-PKG_CHECK_MODULES([NCURSES], [ncursesw ncurses], [LIBS="$LIBS $ncurses_LIBS"], [
+-	AC_SEARCH_LIBS([delwin], [ncursesw ncurses], [], [
+-		AC_MSG_ERROR([ncurses is required but was not found])
+-	], [])
++PKG_CHECK_MODULES([ncursesw], [ncursesw],
++	[NCURSES_CFLAGS="$ncursesw_CFLAGS"; NCURSES_LIBS="$ncursesw_LIBS"], [
++	PKG_CHECK_MODULES([NCURSES], [ncurses], [], [
++		AC_SEARCH_LIBS([delwin], [ncursesw ncurses], [], [
++			AC_MSG_ERROR([ncurses is required but was not found])
++		])
++	])
+ ])
+ 
+ has_libpci=0
+-- 
+2.18.0.rc1.242.g61856ae69a-goog
+

--- a/sys-power/powertop/powertop-2.8.ebuild
+++ b/sys-power/powertop/powertop-2.8.ebuild
@@ -91,11 +91,10 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} == "9999" ]] ; then
-		eautoreconf
-	else
-		default
-	fi
+	epatch "${FILESDIR}"/${P}-ncurses_tinfo.patch
+
+	# Call eautoreconf since ncurses patch touches configure.ac
+	eautoreconf
 }
 
 src_configure() {

--- a/sys-power/powertop/powertop-2.9.ebuild
+++ b/sys-power/powertop/powertop-2.9.ebuild
@@ -40,6 +40,7 @@ RDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-libc++.patch
+	"${FILESDIR}"/${P}-ncurses_tinfo.patch
 )
 
 pkg_setup() {
@@ -105,8 +106,10 @@ src_prepare() {
 	if [[ ${PV} == "9999" ]] ; then
 		chmod +x scripts/version || die "Failed to make 'scripts/version' executable"
 		scripts/version || die "Failed to extract version information"
-		eautoreconf
 	fi
+
+	# Call eautoreconf since ncurses patch touches configure.ac
+	eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
- Patches the configure.ac to fix bug getting libs from pkg-config
- Previous code matched only when both ncursesw and ncurses existed
- Used wrong variable when concatenating to LIBS
- Concatenating to LIBS was redundant anyway since it is done in
  makefile.am