### PR TITLE
media-libs/mesa: Only r600 and radeonsi provide opencl implementation

### DIFF
--- a/media-libs/mesa/mesa-17.3.9.ebuild
+++ b/media-libs/mesa/mesa-17.3.9.ebuild
@@ -46,7 +46,7 @@ IUSE="${IUSE_VIDEO_CARDS}
 REQUIRED_USE="
 	d3d9?   ( dri3 gallium )
 	llvm?   ( gallium )
-	opencl? ( gallium llvm )
+	opencl? ( gallium llvm || ( video_cards_r600 video_cards_radeonsi ) )
 	openmax? ( gallium )
 	gles1?  ( egl )
 	gles2?  ( egl )

--- a/media-libs/mesa/mesa-18.0.5.ebuild
+++ b/media-libs/mesa/mesa-18.0.5.ebuild
@@ -46,7 +46,7 @@ IUSE="${IUSE_VIDEO_CARDS}
 REQUIRED_USE="
 	d3d9?   ( dri3 gallium )
 	llvm?   ( gallium )
-	opencl? ( gallium llvm )
+	opencl? ( gallium llvm || ( video_cards_r600 video_cards_radeonsi ) )
 	openmax? ( gallium )
 	gles1?  ( egl )
 	gles2?  ( egl )

--- a/media-libs/mesa/mesa-18.1.1-r1.ebuild
+++ b/media-libs/mesa/mesa-18.1.1-r1.ebuild
@@ -46,7 +46,7 @@ IUSE="${IUSE_VIDEO_CARDS}
 REQUIRED_USE="
 	d3d9?   ( dri3 gallium )
 	llvm?   ( gallium )
-	opencl? ( gallium llvm )
+	opencl? ( gallium llvm || ( video_cards_r600 video_cards_radeonsi ) )
 	openmax? ( gallium )
 	gles1?  ( egl )
 	gles2?  ( egl )

--- a/media-libs/mesa/mesa-18.1.1.ebuild
+++ b/media-libs/mesa/mesa-18.1.1.ebuild
@@ -46,7 +46,7 @@ IUSE="${IUSE_VIDEO_CARDS}
 REQUIRED_USE="
 	d3d9?   ( dri3 gallium )
 	llvm?   ( gallium )
-	opencl? ( gallium llvm )
+	opencl? ( gallium llvm || ( video_cards_r600 video_cards_radeonsi ) )
 	openmax? ( gallium )
 	gles1?  ( egl )
 	gles2?  ( egl )

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -44,7 +44,7 @@ IUSE="${IUSE_VIDEO_CARDS}
 REQUIRED_USE="
 	d3d9?   ( dri3 gallium )
 	llvm?   ( gallium )
-	opencl? ( gallium llvm )
+	opencl? ( gallium llvm || ( video_cards_r600 video_cards_radeonsi ) )
 	openmax? ( gallium )
 	gles1?  ( egl )
 	gles2?  ( egl )

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Jan Vesely <jano.vesely@gmail.com> (15 June 2018)
+# Mesa clover only works on r600 or radeonsi GPUs. The corresponding
+# video_cards useflags are not available on arm
+media-libs/mesa opencl
+
 # Alex Bennee <alex@bennee.com> (31 May 2018)
 # bunch of dev-perl packages not yet keyworded
 # and the i3 ebuild currently has RESTRICT="test" due to upstream bug


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/658120