### PR TITLE
x11-wm/enlightenment: force later efl to be used with e21

### DIFF
--- a/x11-wm/enlightenment/enlightenment-0.21.11.ebuild
+++ b/x11-wm/enlightenment/enlightenment-0.21.11.ebuild
@@ -42,7 +42,7 @@ IUSE_E_MODULES=(
 IUSE="acpi connman doc egl nls pam static-libs systemd udisks wayland ${IUSE_E_MODULES[@]/#/+}"
 
 RDEPEND="
-	>=dev-libs/efl-1.17.0[eet,X]
+	>=dev-libs/efl-1.18.0[eet,X]
 	virtual/udev
 	x11-libs/libXext
 	x11-libs/libxcb


### PR DESCRIPTION
In theory 1.17 still works without wayland, but it causes troubles
when using stable version of EFL and ~testing version of E.

Id try to avoid adding complicated checks in the ebuild because Im trying to stabilize efl-1.18, that allows to remove old scattered E libraries (elementary, evas_generic_loaders, emotion_generic_layers). Efl-1.18 is required with e-0.21.7 too, even though without wayland in theory 1.17 should be enough. This was the fastest, easiest and best option for longevity.

Closes: https://bugs.gentoo.org/658178
Package-Manager: Portage[mgorny]-2.3.36.1