### PR TITLE
dev-util/strace: Add use flag for elfutils.

### DIFF
--- a/dev-util/strace/metadata.xml
+++ b/dev-util/strace/metadata.xml
@@ -12,6 +12,9 @@
     <flag name="unwind">
       Enable stack backtraces (-k flag) via <pkg>sys-libs/libunwind</pkg>
     </flag>
+    <flag name="elfutils">
+      Enable stack backtraces (-k flag) via <pkg>dev-libs/elfutils</pkg>
+    </flag>
   </use>
   <upstream>
     <remote-id type="sourceforge">strace</remote-id>

--- a/dev-util/strace/strace-4.23-r1.ebuild
+++ b/dev-util/strace/strace-4.23-r1.ebuild
@@ -18,9 +18,14 @@ HOMEPAGE="https://strace.io/"
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="aio perl static unwind"
+IUSE="aio perl static unwind elfutils"
 
-LIB_DEPEND="unwind? ( sys-libs/libunwind[static-libs(+)] )"
+REQUIRED_USE="?? ( unwind elfutils )"
+
+LIB_DEPEND="
+	unwind? ( sys-libs/libunwind[static-libs(+)] )
+	elfutils? ( dev-libs/elfutils[static-libs(+)] )
+"
 # strace only uses the header from libaio to decode structs
 DEPEND="
 	static? ( ${LIB_DEPEND} )
@@ -66,7 +71,8 @@ src_configure() {
 	# Don't require mpers support on non-multilib systems. #649560
 	econf \
 		--enable-mpers=check \
-		$(use_with unwind libunwind)
+		$(use_with unwind libunwind) \
+		$(use_with elfutils libdw)
 }
 
 src_test() {


### PR DESCRIPTION
strace can use libdw to implement stack tracing support and will use it
automatically if it is installed on the system. The commit makes this
configurable.