### PR TITLE
media-plugins/live: stable 2017.10.28 for ppc, bug #648068

### DIFF
--- a/media-plugins/live/live-2017.10.28.ebuild
+++ b/media-plugins/live/live-2017.10.28.ebuild
@@ -10,7 +10,7 @@ SRC_URI="http://www.live555.com/liveMedia/public/${P/-/.}.tar.gz
 	mirror://gentoo/${P/-/.}.tar.gz"
 
 LICENSE="LGPL-2.1"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ~ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="examples static-libs"
 DOCS=( "live-shared/README" )
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/648068
Package-Manager: Portage-2.3.24, Repoman-2.3.6