### PR TITLE
dev-libs/double-conversion: stable 3.0.0 for ppc, bug #649508

### DIFF
--- a/dev-libs/double-conversion/double-conversion-3.0.0.ebuild
+++ b/dev-libs/double-conversion/double-conversion-3.0.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/google/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/1"
-KEYWORDS="amd64 arm ~arm64 ~hppa ~mips ~ppc ppc64 sparc x86 ~amd64-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm ~arm64 ~hppa ~mips ppc ppc64 sparc x86 ~amd64-fbsd ~amd64-linux ~x86-linux"
 IUSE="test"
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/649508
Package-Manager: Portage-2.3.24, Repoman-2.3.6