### PR TITLE
app-cdr/cdrtools: stable 3.02_alpha09 for ppc, bug #653608

### DIFF
--- a/app-cdr/cdrtools/cdrtools-3.02_alpha09.ebuild
+++ b/app-cdr/cdrtools/cdrtools-3.02_alpha09.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://sourceforge/${PN}/$([[ -z ${PV/*_alpha*} ]] && echo 'alpha')/$
 
 LICENSE="GPL-2 LGPL-2.1 CDDL-Schily"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 ~hppa ia64 ~mips ~ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm arm64 ~hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="acl caps nls unicode"
 
 RDEPEND="acl? ( virtual/acl )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/653608
Package-Manager: Portage-2.3.24, Repoman-2.3.6