### PR TITLE
media-gfx/qrencode: stable 4.0.0 for ppc, bug #651588

### DIFF
--- a/media-gfx/qrencode/qrencode-4.0.0.ebuild
+++ b/media-gfx/qrencode/qrencode-4.0.0.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://fukuchi.org/works/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2"
 SLOT="0/4"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ~ppc ppc64 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="media-libs/libpng:0="


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/651588
Package-Manager: Portage-2.3.24, Repoman-2.3.6