### PR TITLE
app-forensics/cmospwd: use HTTPS, EAPI7

### DIFF
--- a/app-forensics/cmospwd/cmospwd-5.1-r1.ebuild
+++ b/app-forensics/cmospwd/cmospwd-5.1-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="CmosPwd decrypts password stored in cmos used to access BIOS SETUP"
+HOMEPAGE="https://www.cgsecurity.org/wiki/CmosPwd"
+SRC_URI="https://www.cgsecurity.org/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+src_compile() {
+	cd src || die
+	$(tc-getCC) ${CFLAGS} ${LDFLAGS} cmospwd.c -o cmospwd || die
+}
+
+src_install() {
+	dosbin src/cmospwd
+	dodoc cmospwd.txt
+}

--- a/app-forensics/cmospwd/cmospwd-5.1.ebuild
+++ b/app-forensics/cmospwd/cmospwd-5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -6,8 +6,8 @@ EAPI=4
 inherit toolchain-funcs
 
 DESCRIPTION="CmosPwd decrypts password stored in cmos used to access BIOS SETUP"
-HOMEPAGE="http://www.cgsecurity.org/wiki/CmosPwd"
-SRC_URI="http://www.cgsecurity.org/${P}.tar.bz2"
+HOMEPAGE="https://www.cgsecurity.org/wiki/CmosPwd"
+SRC_URI="https://www.cgsecurity.org/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This is a simple update for app-forensics/cmospwd with minor changes. Only added a ```|| die``` to the ```cd``` command, even though i'm not really sure this is needed..

diff -u:
```
-EAPI=4
+EAPI=7
 
 inherit toolchain-funcs
 
@@ -11,11 +11,11 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 src_compile() {
-       cd src
+       cd src || die
        $(tc-getCC) ${CFLAGS} ${LDFLAGS} cmospwd.c -o cmospwd || die
 }
 ```