### PR TITLE
dev-libs/libpcre2: fix cygwin build

### DIFF
--- a/dev-libs/libpcre2/files/libpcre2-10.31-cygwin.patch
+++ b/dev-libs/libpcre2/files/libpcre2-10.31-cygwin.patch
@@ -1,0 +1,16 @@
+https://bugs.exim.org/show_bug.cgi?id=2152#c14
+https://vcs.pcre.org/pcre2?view=revision&revision=939
+
+--- pcre2-10.31/src/pcre2grep.c
++++ pcre2-10.31/src/pcre2grep.c
+@@ -64,8 +64,8 @@
+ #endif
+ 
+ /* Some cmake's define it still */
+-#if defined(__CYGWIN__) && !defined(WIN32)
+-#define WIN32
++#if defined(__CYGWIN__) && defined(WIN32)
++#undef WIN32
+ #endif
+ 
+ #ifdef WIN32

--- a/dev-libs/libpcre2/libpcre2-10.31.ebuild
+++ b/dev-libs/libpcre2/libpcre2-10.31.ebuild
@@ -30,6 +30,10 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	userland_GNU? ( >=sys-apps/findutils-4.4.0 )"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-cygwin.patch #633612
+)
+
 S="${WORKDIR}/${MY_P}"
 
 MULTILIB_CHOST_TOOLS=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/633612
Package-Manager: Portage-2.3.13, Repoman-2.3.3