### PR TITLE
app-misc/cdircmp: fix SRC_URI, EAPI7, improve ebuild

### DIFF
--- a/app-misc/cdircmp/cdircmp-0.3-r1.ebuild
+++ b/app-misc/cdircmp/cdircmp-0.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="2"
@@ -7,7 +7,7 @@ inherit toolchain-funcs
 
 DESCRIPTION="Compare directories and select files to copy"
 HOMEPAGE="http://home.hccnet.nl/paul.schuurmans/"
-SRC_URI="http://home.hccnet.nl/paul.schuurmans/download/${P}.tar.gz"
+SRC_URI="http://home.hccnet.nl/paul.schuurmans/linux/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-misc/cdircmp/cdircmp-0.3-r2.ebuild
+++ b/app-misc/cdircmp/cdircmp-0.3-r2.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Compare directories and select files to copy"
+HOMEPAGE="http://home.hccnet.nl/paul.schuurmans/"
+SRC_URI="http://home.hccnet.nl/paul.schuurmans/linux/download/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE=""
+
+RDEPEND=">=sys-libs/ncurses-5.4:0="
+
+src_prepare() {
+	sed -i Makefile \
+		-e 's| -o | $(LDFLAGS)&|g' \
+		|| die "sed Makefile"
+	default
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS}" \
+		LDFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	einstalldocs
+	dobin ${PN}
+}


### PR DESCRIPTION
Hi,

Another small update for a old ebuild.

Please review.

diff -u:
```
--- cdircmp-0.3-r1.ebuild       2018-06-20 21:48:33.039907539 +0200
+++ cdircmp-0.3-r2.ebuild       2018-06-20 21:54:50.085242361 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI=7
 
 inherit toolchain-funcs
 
@@ -11,28 +11,25 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE=""
 
 RDEPEND=">=sys-libs/ncurses-5.4"
-DEPEND="${RDEPEND}
-       >=sys-apps/sed-4"
 
 src_prepare() {
        sed -i Makefile \
                -e 's| -o | $(LDFLAGS)&|g' \
                || die "sed Makefile"
+       default
 }
 
 src_compile() {
        emake CC="$(tc-getCC)" \
                CFLAGS="${CFLAGS}" \
-               LDFLAGS="${LDFLAGS}" \
-               || die "emake failed"
+               LDFLAGS="${LDFLAGS}"
 }
 
 src_install() {
-       dodoc AUTHORS ChangeLog README
-
-       dobin ${PN} || die "dobin failed"
+       einstalldocs
+       dobin ${PN}
 }
```