### PR TITLE
dev-qt/qtchooser: stable 0_p20170803 for ppc, bug #651672

### DIFF
--- a/dev-qt/qtchooser/qtchooser-0_p20170803.ebuild
+++ b/dev-qt/qtchooser/qtchooser-0_p20170803.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://dev.gentoo.org/~pesa/distfiles/${P}.tar.xz"
 
 LICENSE="|| ( LGPL-2.1 GPL-3 )"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ~ppc ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 ~sparc x86 ~amd64-fbsd ~x86-fbsd"
 IUSE="test"
 
 DEPEND="test? (


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/651672
Package-Manager: Portage-2.3.24, Repoman-2.3.6