### PR TITLE
dev-python/editorconfig-core-py: use HTTPs

### DIFF
--- a/dev-python/editorconfig-core-py/editorconfig-core-py-0.12.0.ebuild
+++ b/dev-python/editorconfig-core-py/editorconfig-core-py-0.12.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_4 python3_5 python3_6 )
 inherit distutils-r1
 
 DESCRIPTION="Clone of EditorConfig core written in Python"
-HOMEPAGE="http://editorconfig.org/"
+HOMEPAGE="https://editorconfig.org/"
 SRC_URI="https://github.com/${PN%-core-py}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 	test? (
 		https://github.com/${PN%-core-py}/${PN%-core-py}-core-test/archive/${TESTVER}.tar.gz -> ${PN%-core-py}-core-test-${TESTVER}.tar.gz


### PR DESCRIPTION
Hi,

This is a simple PR to use https instead of http.

Please review.