### PR TITLE
media-libs/mesa-9999: Add required use for xa

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -52,7 +52,9 @@ REQUIRED_USE="
 	vulkan? ( || ( video_cards_i965 video_cards_radeonsi )
 			  video_cards_radeonsi? ( llvm ) )
 	wayland? ( egl gbm )
-	xa?  ( gallium )
+	xa?  ( gallium
+		   || ( video_cards_freedreno video_cards_i915
+				video_cards_nouveau video_cards_vmware ) )
 	video_cards_freedreno?  ( gallium )
 	video_cards_intel?  ( classic )
 	video_cards_i915?   ( || ( classic gallium ) )


### PR DESCRIPTION
The xa use flag is only compatible with the nouveau, freedreno, i915 and
svga video drivers.

Closes: https://bugs.gentoo.org/658892