### PR TITLE
app-arch/zip: mask/drop natspec patch

### DIFF
--- a/app-arch/zip/files/zip-3.0-format-security.patch
+++ b/app-arch/zip/files/zip-3.0-format-security.patch
@@ -1,5 +1,5 @@
---- zip.c
-+++ zip.c
+--- zip/zip.c
++++ zip/zip.c
 @@ -1028,7 +1028,7 @@
  
    for (i = 0; i < sizeof(text)/sizeof(char *); i++)

--- a/app-arch/zip/files/zip-3.0-no-crypt.patch
+++ b/app-arch/zip/files/zip-3.0-no-crypt.patch
@@ -4,8 +4,8 @@ forward ported from zip-2.32
 
 http://bugs.gentoo.org/238398
 
---- zip.c
-+++ zip.c
+--- zip/zip.c
++++ zip/zip.c
 @@ -3452,6 +3452,9 @@ char **argv;            /* command line tokens */
  
    /* Key not yet specified.  If needed, get/verify it now. */
@@ -24,8 +24,8 @@ http://bugs.gentoo.org/238398
    }
    if (key) {
      /* if -P "" could get here */
---- zipcloak.c
-+++ zipcloak.c
+--- zip/zipcloak.c
++++ zip/zipcloak.c
 @@ -744,6 +744,28 @@ struct option_struct far options[] = {
  
  int main OF((void));

--- a/app-arch/zip/files/zip-3.0-pic.patch
+++ b/app-arch/zip/files/zip-3.0-pic.patch
@@ -1,8 +1,8 @@
 if our toolchain generates PIC by default, then do not use the hand written
 assembly files as none of it is PIC friendly.
 
---- unix/configure
-+++ unix/configure
+--- zip/unix/configure
++++ zip/unix/configure
 @@ -29,6 +29,9 @@
  echo Check if we can use asm code
  OBJA=""

--- a/app-arch/zip/zip-3.0-r4.ebuild
+++ b/app-arch/zip/zip-3.0-r4.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+inherit toolchain-funcs eutils flag-o-matic
+
+MY_P="${PN}${PV//.}"
+DESCRIPTION="Info ZIP (encryption support)"
+HOMEPAGE="http://www.info-zip.org/"
+SRC_URI="mirror://sourceforge/infozip/${MY_P}.zip"
+
+LICENSE="Info-ZIP"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~arm-linux"
+IUSE="bzip2 crypt unicode"
+
+RDEPEND="bzip2? ( app-arch/bzip2 )"
+DEPEND="${RDEPEND}
+	app-arch/unzip"
+
+S=${WORKDIR}/${MY_P}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-no-crypt.patch #238398
+	"${FILESDIR}"/${P}-pic.patch
+	"${FILESDIR}"/${P}-exec-stack.patch #122849
+	"${FILESDIR}"/${P}-build.patch #200995
+	"${FILESDIR}"/${P}-zipnote-freeze.patch #322047
+	"${FILESDIR}"/${P}-format-security.patch #512414
+)
+
+src_configure() {
+	append-cppflags \
+		-DLARGE_FILE_SUPPORT \
+		-DUIDGID_NOT_16BIT \
+		-D$(usex bzip2 '' NO)BZIP2_SUPPORT \
+		-D$(usex crypt '' NO)CRYPT \
+		-D$(usex unicode '' NO)UNICODE_SUPPORT
+	# Third arg disables bzip2 logic as we handle it ourselves above.
+	sh ./unix/configure "$(tc-getCC)" "-I. -DUNIX ${CFLAGS} ${CPPFLAGS}" "${T}" || die
+	if use bzip2 ; then
+		sed -i -e "s:LFLAGS2=:&'-lbz2 ':" flags || die
+	fi
+}
+
+src_compile() {
+	emake \
+		CPP="$(tc-getCPP)" \
+		-f unix/Makefile generic
+}
+
+src_install() {
+	dobin zip zipnote zipsplit
+	doman man/zip{,note,split}.1
+	if use crypt ; then
+		dobin zipcloak
+		doman man/zipcloak.1
+	fi
+	dodoc BUGS CHANGES README* TODO WHATSNEW WHERE proginfo/*.txt
+}

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -7,6 +7,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Yuri Konotopov <ykonotopov@gnome.org> (24 Jun 2018)
+# natspec patch is broken and will be removed
+app-arch/zip natspec
+
 # Pacho Ramos <pacho@gentoo.org> (17 Jun 2018)
 # dev-libs/DirectFB is being removed (#606194)
 media-libs/libsdl2 fusionsound


### PR DESCRIPTION
Natspec patch is broken because it changes default behavior of zip so latest can not create archives with symbolic links anymore.

Bug: https://bugs.gentoo.org/620162