### PR TITLE
net-misc/openssh: no hardening with Cygwin yet, #659210

### DIFF
--- a/net-misc/openssh/openssh-7.7_p1-r5.ebuild
+++ b/net-misc/openssh/openssh-7.7_p1-r5.ebuild
@@ -291,6 +291,7 @@ src_configure() {
 		$(use_with ssl openssl)
 		$(use_with ssl md5-passwords)
 		$(use_with ssl ssl-engine)
+		$(use_with !elibc_Cygwin hardening) #659210
 	)
 
 	# The seccomp sandbox is broken on x32, so use the older method for now. #553748


### PR DESCRIPTION
Default is --with-hardening, and openssh detects -mfunction-return=thunk
as supported by gcc-7.3 on Cygwin, but that actually breaks at linking
right now, see https://cygwin.com/ml/cygwin/2018-06/msg00273.html

Closes: https://bugs.gentoo.org/659210
Package-Manager: Portage-2.3.24, Repoman-2.3.6