### PR TITLE
sys-apps/openrc: Stop adding tmpfiles.* to boot runlevel

### DIFF
--- a/sys-apps/openrc/openrc-0.34.11.ebuild
+++ b/sys-apps/openrc/openrc-0.34.11.ebuild
@@ -213,13 +213,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.35.5.ebuild
+++ b/sys-apps/openrc/openrc-0.35.5.ebuild
@@ -221,13 +221,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.36.ebuild
+++ b/sys-apps/openrc/openrc-0.36.ebuild
@@ -214,13 +214,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-0.37.ebuild
+++ b/sys-apps/openrc/openrc-0.37.ebuild
@@ -214,13 +214,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier

--- a/sys-apps/openrc/openrc-9999.ebuild
+++ b/sys-apps/openrc/openrc-9999.ebuild
@@ -214,13 +214,11 @@ pkg_preinst() {
 
 	if ! has_version ">=sys-apps/openrc-0.11.3" ; then
 		migrate_udev_mount_script
-		add_boot_init tmpfiles.setup boot
 	fi
 
 	# these were added in 0.12.
 	if ! has_version ">=sys-apps/openrc-0.12"; then
 		add_boot_init loopback
-		add_boot_init tmpfiles.dev sysinit
 
 		# ensure existing /etc/conf.d/net is not removed
 		# undoes the hack to get around CONFIG_PROTECT in openrc-0.11.8 and earlier


### PR DESCRIPTION
tmpfiles.setup and tmpfiles.dev are not part of OpenRC since version
0.23, resulting in symlinks pointing to non existing files.

See: https://gitweb.gentoo.org/proj/openrc.git/commit/?id=e0ac661419042cb39c1ccf93df2981504d1e6339

Previous PR #5711 was closed with no reason

Package-Manager: Portage-2.3.6, Repoman-2.3.1