### PR TITLE
net-analyzer/sarg: stable 2.3.11-r1 for ppc, bug #653220

### DIFF
--- a/net-analyzer/sarg/sarg-2.3.11-r1.ebuild
+++ b/net-analyzer/sarg/sarg-2.3.11-r1.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="http://sarg.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="amd64 ppc x86"
 SLOT="0"
 IUSE="+gd ldap pcre"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/653220
Package-Manager: Portage-2.3.24, Repoman-2.3.6