### PR TITLE
www-servers/h2o: remove myself as proxied maintainer

### DIFF
--- a/www-servers/h2o/metadata.xml
+++ b/www-servers/h2o/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>gentoo@chaoslab.org</email>
-		<name>Ian Moone</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<longdescription lang="en">
 		H2O is a new generation HTTP server. Not only is it very fast,
 		it also provides much quicker response to end-users


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/633284
Package-Manager: Portage-2.3.40, Repoman-2.3.9