### PR TITLE
www-misc/multisort: use HTTPs, add EAPI7 ebuild

### DIFF
--- a/www-misc/multisort/multisort-1.1-r1.ebuild
+++ b/www-misc/multisort/multisort-1.1-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=4
 inherit toolchain-funcs
 
 DESCRIPTION="Merges httpd logfiles in the Common Log Format"
-HOMEPAGE="http://www.xach.com/multisort/"
-SRC_URI="http://www.xach.com/${PN}/${PN}-${PV}.tar.gz"
+HOMEPAGE="https://www.xach.com/multisort/"
+SRC_URI="https://www.xach.com/${PN}/${PN}-${PV}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/www-misc/multisort/multisort-1.1-r2.ebuild
+++ b/www-misc/multisort/multisort-1.1-r2.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Merges httpd logfiles in the Common Log Format"
+HOMEPAGE="https://www.xach.com/multisort/"
+SRC_URI="https://www.xach.com/${PN}/${PN}-${PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+src_prepare() {
+	default
+	# respect LDFLAGS wrt bug #337359
+	sed -i -e 's/$(CFLAGS)/& \$(LDFLAGS)/' Makefile || die 'sed on Makefile failed'
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
+}
+
+src_install() {
+	dosbin multisort
+}


### PR DESCRIPTION
Hi,

Another very simple EAPI update for www-misc/multisort.
Please review.

diff -u 
```
--- multisort-1.1-r1.ebuild     2018-06-28 20:48:27.844673495 +0200
+++ multisort-1.1-r2.ebuild     2018-06-28 20:48:27.844673495 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
 
 inherit toolchain-funcs
 
@@ -14,11 +14,10 @@
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-DEPEND=""
-
 src_prepare() {
        # respect LDFLAGS wrt bug #337359
        sed -i -e 's/$(CFLAGS)/& \$(LDFLAGS)/' Makefile || die 'sed on Makefile failed'
+       default
 }
 
 src_compile() {
```