### PR TITLE
net-dns/valtz: use HTTPs, add EAPI7 ebuild

### DIFF
--- a/net-dns/valtz/valtz-0.7-r1.ebuild
+++ b/net-dns/valtz/valtz-0.7-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Validation tool for tinydns-data zone files"
+SRC_URI="https://x42.com/software/valtz/${PN}.tgz"
+HOMEPAGE="https://x42.com/software/valtz/"
+IUSE=""
+
+SLOT="0"
+LICENSE="BSD"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="dev-lang/perl"
+
+src_install() {
+	dobin valtz
+	dodoc README CHANGES
+}

--- a/net-dns/valtz/valtz-0.7.ebuild
+++ b/net-dns/valtz/valtz-0.7.ebuild
@@ -4,8 +4,8 @@
 EAPI=0
 
 DESCRIPTION="Validation tool for tinydns-data zone files"
-SRC_URI="http://x42.com/software/valtz/${PN}.tgz"
-HOMEPAGE="http://x42.com/software/valtz/"
+SRC_URI="https://x42.com/software/valtz/${PN}.tgz"
+HOMEPAGE="https://x42.com/software/valtz/"
 IUSE=""
 
 SLOT="0"


### PR DESCRIPTION
Hi,

This is a simple EAPI update for net-dns/valtz. Almost nothing changed at the ebuild for EAPI7.

Please review:

diff -u:
```
--- valtz-0.7.ebuild    2018-06-28 20:46:50.278674289 +0200
+++ valtz-0.7-r1.ebuild 2018-06-28 20:46:50.277674309 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
 DESCRIPTION="Validation tool for tinydns-data zone files"
 SRC_URI="https://x42.com/software/valtz/${PN}.tgz"
@@ -15,6 +15,6 @@
 RDEPEND="dev-lang/perl"
 
 src_install() {
-       dobin valtz || die
+       dobin valtz
        dodoc README CHANGES
 }
```