### PR TITLE
app-text/htmlrecode: use HTTPs, EAPI7, improve ebuild

### DIFF
--- a/app-text/htmlrecode/htmlrecode-1.3.1-r1.ebuild
+++ b/app-text/htmlrecode/htmlrecode-1.3.1-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Recodes HTML file using a new character set"
+HOMEPAGE="https://bisqwit.iki.fi/source/htmlrecode.html"
+SRC_URI="https://bisqwit.iki.fi/src/arch/${P}.tar.bz2"
+
+KEYWORDS="~amd64 ~ppc ~x86"
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+PATCHES=( "${FILESDIR}/${P}-ar.patch" )
+
+src_prepare() {
+	touch .depend argh/.depend || die
+	default
+}
+
+src_configure() { :; }
+
+src_compile() {
+	local makeopts=(
+		AR="$(tc-getAR)"
+		CPPDEBUG=
+		CXX="$(tc-getCXX)"
+		CXXFLAGS="${CXXFLAGS}"
+		LDFLAGS="${LDFLAGS}"
+	)
+	emake "${makeopts[@]}" -C argh libargh.a
+	emake "${makeopts[@]}" htmlrecode
+}
+
+src_install() {
+	dobin htmlrecode
+	dodoc README.html
+}

--- a/app-text/htmlrecode/htmlrecode-1.3.1.ebuild
+++ b/app-text/htmlrecode/htmlrecode-1.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -6,8 +6,8 @@ EAPI=4
 inherit eutils toolchain-funcs
 
 DESCRIPTION="Recodes HTML file using a new character set"
-HOMEPAGE="http://bisqwit.iki.fi/source/htmlrecode.html"
-SRC_URI="http://bisqwit.iki.fi/src/arch/${P}.tar.bz2"
+HOMEPAGE="https://bisqwit.iki.fi/source/htmlrecode.html"
+SRC_URI="https://bisqwit.iki.fi/src/arch/${P}.tar.bz2"
 
 KEYWORDS="~amd64 ~ppc ~x86"
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

Another update for a older ebuild.
Please review.

diff -u
```
--- htmlrecode-1.3.1.ebuild     2018-06-24 17:30:57.468942487 +0200
+++ htmlrecode-1.3.1-r1.ebuild  2018-06-24 17:30:57.468942487 +0200
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="Recodes HTML file using a new character set"
 HOMEPAGE="https://bisqwit.iki.fi/source/htmlrecode.html"
@@ -14,17 +14,15 @@
 SLOT="0"
 IUSE=""
 
-DEPEND=">=sys-apps/sed-4"
-RDEPEND=""
+PATCHES=( "${FILESDIR}/${P}-ar.patch" )
+HTML_DOCS=( README.html )
 
 src_prepare() {
-       epatch "${FILESDIR}/${P}-ar.patch"
        touch .depend argh/.depend
+       default
 }
 
-src_configure() {
-       :
-}
+src_configure() { :; }
 
 src_compile() {
        local makeopts=(
@@ -40,5 +38,5 @@
 
 src_install() {
        dobin htmlrecode
-       dohtml README.html
+       einstalldocs
 }
```

@Zlogene 
In case your're gonna review it again: Regarding the ```src_configure() { :; }``` below my comment from the original PR:

> I guess, you're asking why i'm skipping src_configure at all? Because this already exists in the original ebuild too, i've just put it into one line...
> 
> Actually, I've tried to remove that part from the ebuild, but it's really not needed since the configure script is just a bash script which test's the compiler. It doesn't fail, but it's not needed at all.