### PR TITLE
 dev-libs/syncdir: use HTTPs, add EAPI7 ebuild

### DIFF
--- a/dev-libs/syncdir/syncdir-1.0-r1.ebuild
+++ b/dev-libs/syncdir/syncdir-1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -6,8 +6,8 @@ EAPI=4
 inherit multilib toolchain-funcs
 
 DESCRIPTION="Provides an alternate implementation for open, link, rename, and unlink"
-HOMEPAGE="http://untroubled.org/syncdir"
-SRC_URI="http://untroubled.org/syncdir/${P}.tar.gz"
+HOMEPAGE="https://untroubled.org/syncdir"
+SRC_URI="https://untroubled.org/syncdir/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/dev-libs/syncdir/syncdir-1.0-r2.ebuild
+++ b/dev-libs/syncdir/syncdir-1.0-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Provides an alternate implementation for open, link, rename, and unlink"
+HOMEPAGE="https://untroubled.org/syncdir"
+SRC_URI="https://untroubled.org/syncdir/${P}.tar.gz"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"
+IUSE="static-libs"
+
+src_prepare() {
+	default
+	if ! use static-libs; then
+		sed -i Makefile \
+			-e '/^all:/s|libsyncdir.a||' \
+			-e '/install -m 644 libsyncdir.a/d' \
+			|| die "sed Makefile"
+	fi
+}
+
+src_compile() {
+	emake \
+		CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS}" \
+		LDFLAGS="${LDFLAGS}" \
+		libsyncdir.so \
+		$(use static-libs && echo libsyncdir.a)
+}
+
+src_install() {
+	dodir /usr/$(get_libdir)
+	emake libdir="${D}/usr/$(get_libdir)" install
+	dodoc testsync.c
+}


### PR DESCRIPTION
Hi,

Simple updates for dev-libs/syncdir.
Please review.

diff -u
```
--- syncdir-1.0-r1.ebuild       2018-06-24 17:28:10.282990659 +0200
+++ syncdir-1.0-r2.ebuild       2018-06-24 17:28:32.448989193 +0200
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
 
-inherit multilib toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="Provides an alternate implementation for open, link, rename, and unlink"
 HOMEPAGE="https://untroubled.org/syncdir"
@@ -11,7 +11,7 @@
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="~amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="static-libs"
 
 src_prepare() {
@@ -21,6 +21,7 @@
                        -e '/install -m 644 libsyncdir.a/d' \
                        || die "sed Makefile"
        fi
+       default
 }
 
 src_compile() {
```