### PR TITLE
net-misc/snarf: use HTTPs, EAPI7, improve ebuild

### DIFF
--- a/net-misc/snarf/snarf-7.0-r3.ebuild
+++ b/net-misc/snarf/snarf-7.0-r3.ebuild
@@ -7,8 +7,8 @@ inherit eutils
 
 IUSE=""
 DESCRIPTION="Small and fast CLI resource grabber for http, gopher, finger, ftp"
-SRC_URI="http://www.xach.com/snarf/${P}.tar.gz"
-HOMEPAGE="http://www.xach.com/snarf/"
+SRC_URI="https://www.xach.com/snarf/${P}.tar.gz"
+HOMEPAGE="https://www.xach.com/snarf/"
 KEYWORDS="alpha amd64 ppc sparc x86"
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/snarf/snarf-7.0-r4.ebuild
+++ b/net-misc/snarf/snarf-7.0-r4.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Small and fast CLI resource grabber for http, gopher, finger, ftp"
+HOMEPAGE="https://www.xach.com/snarf/"
+SRC_URI="https://www.xach.com/snarf/${P}.tar.gz"
+
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+PATCHES=(
+	"${FILESDIR}"/snarf-basename-patch.diff
+	"${FILESDIR}"/snarf-unlink-empty.diff
+	"${FILESDIR}"/snarf-fix-off-by-ones.diff
+)
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin snarf
+	doman snarf.1
+	dodoc ChangeLog README TODO
+}
+
+pkg_postinst() {
+	elog 'To use snarf with portage, try these settings in your make.conf'
+	elog
+	elog '	FETCHCOMMAND="/usr/bin/snarf -b \${URI} \${DISTDIR}/\${FILE}"'
+	elog '	RESUMECOMMAND="/usr/bin/snarf -rb \${URI} \${DISTDIR}/\${FILE}"'
+}


### PR DESCRIPTION
Hi,

This PR updates snarf. I've also fixed calling ```gcc``` directly which the old ebuilds doing right now.

Please review.

diff -u
```
--- snarf-7.0-r3.ebuild 2018-06-24 17:26:55.421984276 +0200
+++ snarf-7.0-r4.ebuild 2018-06-24 17:26:55.421984276 +0200
@@ -1,25 +1,27 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-inherit eutils
+inherit toolchain-funcs
 
-IUSE=""
 DESCRIPTION="Small and fast CLI resource grabber for http, gopher, finger, ftp"
-SRC_URI="https://www.xach.com/snarf/${P}.tar.gz"
 HOMEPAGE="https://www.xach.com/snarf/"
-KEYWORDS="alpha amd64 ppc sparc x86"
+SRC_URI="https://www.xach.com/snarf/${P}.tar.gz"
+
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
 LICENSE="GPL-2"
 SLOT="0"
+IUSE=""
 
-DEPEND=""
+PATCHES=(
+       "${FILESDIR}"/snarf-basename-patch.diff
+       "${FILESDIR}"/snarf-unlink-empty.diff
+       "${FILESDIR}"/snarf-fix-off-by-ones.diff
+)
 
-src_unpack() {
-       unpack ${A}
-       epatch "${FILESDIR}"/snarf-basename-patch.diff
-       epatch "${FILESDIR}"/snarf-unlink-empty.diff
-       epatch "${FILESDIR}"/snarf-fix-off-by-ones.diff
+src_compile() {
+       emake CC="$(tc-getCC)"
 }
 
 src_install() {
```