### PR TITLE
net-misc/netpipe: use HTTPs, EAPI7, improve ebuild

### DIFF
--- a/net-misc/netpipe/netpipe-1.0.0_beta2-r1.ebuild
+++ b/net-misc/netpipe/netpipe-1.0.0_beta2-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit toolchain-funcs
 
 DESCRIPTION="tool to reliably distribute binary data using UDP broadcasting techniques"
-HOMEPAGE="http://www.wudika.de/~jan/netpipe/"
-SRC_URI="http://www.wudika.de/~jan/${PN}/${PN}.tar.gz"
+HOMEPAGE="https://www.wudika.de/~jan/netpipe/"
+SRC_URI="https://www.wudika.de/~jan/${PN}/${PN}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/netpipe/netpipe-1.0.0_beta2-r2.ebuild
+++ b/net-misc/netpipe/netpipe-1.0.0_beta2-r2.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="tool to reliably distribute binary data using UDP broadcasting techniques"
+HOMEPAGE="https://www.wudika.de/~jan/netpipe/"
+SRC_URI="https://www.wudika.de/~jan/${PN}/${PN}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE=""
+
+S="${WORKDIR}/${PN}"
+
+src_prepare() {
+	sed -i \
+		-e "s:^OPT=.*:OPT = ${CFLAGS} ${LDFLAGS}:" \
+		-e "s:^CC=.*:CC = $(tc-getCC):" \
+		Makefile || die "sed failed"
+	default
+}
+
+src_install() {
+	dobin netpipe
+	dodoc DOCUMENTATION INSTALL TECH-NOTES
+}

--- a/net-misc/netpipe/netpipe-1.0.0_beta2.ebuild
+++ b/net-misc/netpipe/netpipe-1.0.0_beta2.ebuild
@@ -6,8 +6,8 @@ EAPI=0
 inherit toolchain-funcs
 
 DESCRIPTION="tool to reliably distribute binary data using UDP broadcasting techniques"
-HOMEPAGE="http://www.wudika.de/~jan/netpipe/"
-SRC_URI="http://www.wudika.de/~jan/netpipe/${PN}.tar.gz"
+HOMEPAGE="https://www.wudika.de/~jan/netpipe/"
+SRC_URI="https://www.wudika.de/~jan/netpipe/${PN}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR updates netpipe.
Please review.

diff -u
```
--- netpipe-1.0.0_beta2-r1.ebuild       2018-06-24 17:19:18.495548617 +0200
+++ netpipe-1.0.0_beta2-r2.ebuild       2018-06-24 17:20:34.106669561 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
 inherit toolchain-funcs
 
@@ -16,16 +16,15 @@
 
 S="${WORKDIR}/${PN}"
 
-src_unpack() {
-       unpack ${A}
-       cd "${S}"
+src_prepare() {
        sed -i \
                -e "s:^OPT=.*:OPT = ${CFLAGS} ${LDFLAGS}:" \
                -e "s:^CC=.*:CC = $(tc-getCC):" \
                Makefile || die "sed failed"
+       default
 }
 
 src_install() {
-       dobin netpipe || die "dobin failed"
-       dodoc DOCUMENTATION INSTALL TECH-NOTES || die
+       dobin netpipe
+       dodoc DOCUMENTATION INSTALL TECH-NOTES
 }
```