### PR TITLE
app-forensics/volatility: use HTTPs, EAPI7, add missing die

### DIFF
--- a/app-forensics/volatility/volatility-2.4.1.ebuild
+++ b/app-forensics/volatility/volatility-2.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,9 +7,9 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="Framework for analyzing volatile memory"
-HOMEPAGE="http://www.volatilityfoundation.org/"
+HOMEPAGE="https://www.volatilityfoundation.org/"
 #2.4.1 not on mirrors yet
-#SRC_URI="http://downloads.volatilityfoundation.org/releases/${PV}/${P}.tar.gz"
+#SRC_URI="https://downloads.volatilityfoundation.org/releases/${PV}/${P}.tar.gz"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-2+"

--- a/app-forensics/volatility/volatility-2.6-r1.ebuild
+++ b/app-forensics/volatility/volatility-2.6-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 )
+inherit distutils-r1
+
+DESCRIPTION="Framework for analyzing volatile memory"
+HOMEPAGE="https://www.volatilityfoundation.org/"
+SRC_URI="https://downloads.volatilityfoundation.org/releases/${PV}/${P}.zip"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+S=${WORKDIR}/${PN}-master
+
+DEPEND="app-arch/unzip"
+RDEPEND=">=dev-libs/distorm64-3[${PYTHON_USEDEP}]
+	dev-libs/libpcre
+	|| (
+		dev-python/pycryptodome[${PYTHON_USEDEP}]
+		dev-python/pycrypto[${PYTHON_USEDEP}]
+	)"
+
+src_install() {
+	distutils-r1_src_install
+	mkdir "${D}/usr/share/${PN}" || die
+	mv "${D}/usr/contrib/plugins" "${D}/usr/share/${PN}/" || die
+	rmdir --ignore-fail-on-non-empty "${D}/usr/contrib" || die
+	mv "${D}/usr/tools" "${D}/usr/share/${PN}/" || die
+	dosym vol.py /usr/bin/volatility
+}

--- a/app-forensics/volatility/volatility-2.6.ebuild
+++ b/app-forensics/volatility/volatility-2.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,8 +7,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="Framework for analyzing volatile memory"
-HOMEPAGE="http://www.volatilityfoundation.org/"
-SRC_URI="http://downloads.volatilityfoundation.org/releases/${PV}/${P}.zip"
+HOMEPAGE="https://www.volatilityfoundation.org/"
+SRC_URI="https://downloads.volatilityfoundation.org/releases/${PV}/${P}.zip"
 
 LICENSE="GPL-2+"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR updates the ebuilds to use https and adds a r1 with EAPI7. I've also added a few missing ```|| die```
However, since ```rmdir``` would fail now (because of the added ```die```) i've also added ```--ignore-fail-on-non-empty``` to the ```rmdir``` command.

Please review.