### PR TITLE
x11-misc/bbweather: use HTTPs, EAPI7, improve ebuild

### DIFF
--- a/x11-misc/bbweather/bbweather-0.6.3-r1.ebuild
+++ b/x11-misc/bbweather/bbweather-0.6.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=2
@@ -6,8 +6,8 @@ EAPI=2
 inherit autotools eutils
 
 DESCRIPTION="blackbox weather monitor"
-HOMEPAGE="http://www.netmeister.org/apps/bbweather/"
-SRC_URI="http://www.netmeister.org/apps/${P}.tar.bz2"
+HOMEPAGE="https://www.netmeister.org/apps/bbweather/"
+SRC_URI="https://www.netmeister.org/apps/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/bbweather/bbweather-0.6.3-r2.ebuild
+++ b/x11-misc/bbweather/bbweather-0.6.3-r2.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="blackbox weather monitor"
+HOMEPAGE="https://www.netmeister.org/apps/bbweather/"
+SRC_URI="https://www.netmeister.org/apps/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="amd64 hppa ppc x86"
+IUSE=""
+
+DEPEND="dev-lang/perl
+	x11-libs/libX11"
+RDEPEND="${DEPEND}
+	net-misc/wget
+	x11-apps/xmessage
+	!<=x11-plugins/gkrellweather-2.0.7-r1"
+
+PATCHES=( "${FILESDIR}"/${PN}-asneeded.patch )
+
+src_prepare() {
+	default
+	gunzip doc/*.gz || die
+	sed -i \
+		-e "s:man_DATA:man1_MANS:;s:.gz::g;/^mandir/d" \
+		doc/Makefile.am || die
+	sed -i \
+		-e 's|-helvetica-|-*-|g' \
+		resource.cpp data/${PN}.{nobb,style} || die
+	eautoreconf
+}
+
+src_install () {
+	emake DESTDIR="${D}" docdir="/usr/share/doc/${PF}" install
+	dodoc README AUTHORS ChangeLog NEWS TODO data/README.bbweather
+
+	# since multiple bbtools packages provide this file, install
+	# it in /usr/share/doc/${PF}
+	mv "${D}"/usr/share/bbtools/bbtoolsrc.in \
+		"${D}"/usr/share/doc/${PF}/bbtoolsrc.example || die
+}

--- a/x11-misc/bbweather/files/bbweather-asneeded.patch
+++ b/x11-misc/bbweather/files/bbweather-asneeded.patch
@@ -2,8 +2,8 @@ Fixing build with as-needed
 
 https://bugs.gentoo.org/248556
 
---- configure.in
-+++ configure.in
+--- a/configure.in
++++ b/configure.in
 @@ -56,15 +56,10 @@
  AC_PATH_X
  AC_PATH_XTRA
@@ -22,8 +22,8 @@ https://bugs.gentoo.org/248556
  
  dnl Checks for header files.
  AC_HEADER_STDC
---- Makefile.am
-+++ Makefile.am
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -1,5 +1,4 @@
 -CPPFLAGS =	@CPPFLAGS@ \
 -		-DDEFAULT_CONF=\"$(datadir)/bbtools/bbweather.conf\" \


### PR DESCRIPTION
Hi,

Another update for a old ebuild.
Please review.

diff -u: 
```
--- bbweather-0.6.3-r1.ebuild   2018-06-22 16:00:33.225758679 +0200
+++ bbweather-0.6.3-r2.ebuild   2018-06-22 16:06:27.556649066 +0200
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
+EAPI=7
 
-inherit autotools eutils
+inherit autotools
 
 DESCRIPTION="blackbox weather monitor"
 HOMEPAGE="https://www.netmeister.org/apps/bbweather/"
@@ -21,8 +21,9 @@
        x11-apps/xmessage
        !<=x11-plugins/gkrellweather-2.0.7-r1"
 
+PATCHES=( "${FILESDIR}"/${PN}-asneeded.patch )
+
 src_prepare() {
-       epatch "${FILESDIR}"/${PN}-asneeded.patch
        gunzip doc/*.gz || die
        sed -i \
                -e "s:man_DATA:man1_MANS:;s:.gz::g;/^mandir/d" \
@@ -31,11 +32,12 @@
                -e 's|-helvetica-|-*-|g' \
                resource.cpp data/${PN}.{nobb,style} || die
        eautoreconf
+       default
 }
 
 src_install () {
-       emake DESTDIR="${D}" docdir="/usr/share/doc/${PF}" install || die
-       dodoc README AUTHORS ChangeLog NEWS TODO data/README.bbweather || die
+       emake DESTDIR="${D}" docdir="/usr/share/doc/${PF}" install
+       dodoc README AUTHORS ChangeLog NEWS TODO data/README.bbweather
 
        # since multiple bbtools packages provide this file, install
        # it in /usr/share/doc/${PF}
```