### PR TITLE
app-misc/irtrans-{irclient,irserver}: EAPI7, improve ebuild

### DIFF
--- a/app-misc/irtrans-irclient/irtrans-irclient-6.01.05-r1.ebuild
+++ b/app-misc/irtrans-irclient/irtrans-irclient-6.01.05-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic toolchain-funcs
+
+RESTRICT="strip"
+
+DESCRIPTION="ASCII Client for the IRTrans Server"
+HOMEPAGE="http://www.irtrans.de"
+SRC_URI="http://www.irtrans.de/download/Client/irclient-src.tar.gz -> irclient-src-${PV}.tar.gz
+	http://ftp.disconnected-by-peer.at/irtrans/${PN}-5.11.04-ip_assign-1.patch.bz2"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~x86 ~amd64 ~arm"
+
+S="${WORKDIR}"
+
+PATCHES=( "${WORKDIR}/${PN}"-5.11.04-ip_assign-1.patch )
+
+src_compile() {
+	append-flags -DLINUX
+
+	# Set sane defaults (arm target has no -D flags added)
+	local irbuild
+	local ipbuild
+	irclient=irclient
+	ip_assign=ip_assign
+
+	# change variable by need
+	if use amd64; then
+		irbuild=irclient64
+		irclient=irclient64
+		ipbuild=ip_assign64
+		ip_assign=ip_assign64
+	elif use arm; then
+		irbuild=irclient_arm
+		ipbuild=ip_assign_arm
+	elif use x86; then
+		irbuild=irclient
+		ipbuild=ip_assign
+	fi
+
+	emake CXX="$(tc-getCXX)" CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" CXXFLAGS="${CXXFLAGS}" \
+		"${irbuild}"
+	emake CXX="$(tc-getCXX)" CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" CXXFLAGS="${CXXFLAGS}" \
+		"${ipbuild}"
+}
+
+src_install() {
+	newbin "${irclient}" irclient
+	newbin "${ip_assign}" ip_assign
+}

--- a/app-misc/irtrans-irserver/irtrans-irserver-6.09.04-r1.ebuild
+++ b/app-misc/irtrans-irserver/irtrans-irserver-6.09.04-r1.ebuild
@@ -1,0 +1,77 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic toolchain-funcs mono-env
+
+DESCRIPTION="Server software for IRTrans"
+HOMEPAGE="http://www.irtrans.de"
+SRC_URI="http://ftp.disconnected-by-peer.at/irtrans/irserver-src-${PV}.tar.gz
+	 http://ftp.disconnected-by-peer.at/irtrans/irserver-${PV}.tar.gz
+	http://www.irtrans.de/download/Server/Linux/irserver-src.tar.gz -> irserver-src-${PV}.tar.gz
+	http://www.irtrans.de/download/Server/Linux/irserver.tar.gz -> irserver-${PV}.tar.gz"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="mono"
+RESTRICT="strip"
+
+RDEPEND="mono? ( >=dev-lang/mono-2.10.5 )"
+
+S="${WORKDIR}"
+
+src_prepare() {
+	default
+	sed -e 's!^ODIRARM = .*!ODIRARM = n800!' -i makefile || die
+}
+
+src_compile() {
+	append-flags -DLINUX -DMEDIACENTER
+	append-ldflags --static
+
+	# Set sane defaults (arm target has no -D flags added)
+	local irbuild=irserver_arm_noccf
+	irserver=irserver
+
+	# change variable by need
+	if use x86 ; then
+		irbuild=irserver
+	elif use amd64 ; then
+		irbuild=irserver64
+		irserver=irserver64
+	elif use arm ; then
+		irbuild=irserver_arm
+	fi
+
+	emake CXX="$(tc-getCXX)" CC="$(tc-getCC)" CFLAGS="${CFLAGS}" \
+		CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" "${irbuild}"
+}
+
+src_install() {
+	newbin "${WORKDIR}/${irserver}" irserver
+
+	keepdir /etc/irserver/remotes
+
+	docinto remotes
+	dodoc -r remotes
+
+	newinitd "${FILESDIR}"/irtrans-server.initd irtrans-server
+	newconfd "${FILESDIR}"/irtrans-server.confd irtrans-server
+
+	if use mono ; then
+		# Wrapper script to launch mono
+		make_wrapper irguiclient "mono /usr/$(get_libdir)/${PN}/GUIClient.exe"
+
+		insinto /usr/$(get_libdir)/${PN}/
+		exeinto /usr/$(get_libdir)/${PN}/
+
+		# The Libs and Translations
+		doins GUIClient/*.tra
+		doexe GUIClient/*.dll
+
+		# The actual executable
+		doexe GUIClient/*.exe
+	fi
+}


### PR DESCRIPTION
Hi,

This updates the irtrans-* packages to EAPI7.
I've removed some einfo output from the ebuilds, which was there for bugreports!?

Edit:
I've added the bug reports regarding irtrans* to the PR. Not sure if I can close them, but at least 425912 should be already fixed in tree.

Please review.

diff -u irclient:
```
--- irtrans-irclient-6.01.05.ebuild     2018-06-22 15:29:55.118643051 +0200
+++ irtrans-irclient-6.01.05-r1.ebuild  2018-07-16 18:38:00.083805848 +0200
@@ -1,13 +1,13 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI=7
 
-inherit eutils flag-o-matic toolchain-funcs
+inherit flag-o-matic toolchain-funcs
 
 RESTRICT="strip"
 
-DESCRIPTION="IRTrans Server"
+DESCRIPTION="ASCII Client for the IRTrans Server"
 HOMEPAGE="http://www.irtrans.de"
 SRC_URI="http://www.irtrans.de/download/Client/irclient-src.tar.gz -> irclient-src-${PV}.tar.gz
        http://ftp.disconnected-by-peer.at/irtrans/${PN}-5.11.04-ip_assign-1.patch.bz2"
@@ -15,52 +15,43 @@
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~x86 ~amd64 ~arm"
-IUSE=""
-
-DEPEND=""
-RDEPEND="${RDEPND}"
 
 S="${WORKDIR}"
 
-src_prepare() {
-       epatch "${WORKDIR}/${PN}"-5.11.04-ip_assign-1.patch
-}
+PATCHES=( "${WORKDIR}/${PN}"-5.11.04-ip_assign-1.patch )
 
 src_compile() {
-
        append-flags -DLINUX
 
        # Set sane defaults (arm target has no -D flags added)
-       irbuild=irclient_arm
+       local irbuild
+       local ipbuild
        irclient=irclient
-       ipbuild=ip_assign_arm
        ip_assign=ip_assign
 
        # change variable by need
-       if use x86 ; then
-               irbuild=irclient
-               ipbuild=ip_assign
-       elif use amd64 ; then
+       if use amd64; then
                irbuild=irclient64
                irclient=irclient64
                ipbuild=ip_assign64
                ip_assign=ip_assign64
+       elif use arm; then
+               irbuild=irclient_arm
+               ipbuild=ip_assign_arm
+       elif use x86; then
+               irbuild=irclient
+               ipbuild=ip_assign
        fi
 
-       # Some output for bugreport
-       einfo "CFLAGS=\"${CFLAGS}\""
-       einfo "Build client Target=\"${irbuild}\""
-       einfo "Build client Binary=\"${irclient}\""
-       einfo "Build ip_assign Target=\"${ipbuild}\""
-       einfo "Build ip_assign Binary=\"${ip_assign}\""
-
-       # Build
-       emake CXX="$(tc-getCXX)" CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" CXXFLAGS="${CXXFLAGS}" "${irbuild}" || die "emake irclient failed"
-       emake CXX="$(tc-getCXX)" CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" CXXFLAGS="${CXXFLAGS}" "${ipbuild}" || die "emake ip_assign failed"
+       emake CXX="$(tc-getCXX)" CC="$(tc-getCC)" \
+               CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" CXXFLAGS="${CXXFLAGS}" \
+               "${irbuild}"
+       emake CXX="$(tc-getCXX)" CC="$(tc-getCC)" \
+               CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" CXXFLAGS="${CXXFLAGS}" \
+               "${ipbuild}"
 }
 
 src_install() {
-
-       newbin "${WORKDIR}/${irclient}" irclient
-       newbin "${WORKDIR}/${ip_assign}" ip_assign
+       newbin "${irclient}" irclient
+       newbin "${ip_assign}" ip_assign
 }
```

diff -u irserver:
```
--- irtrans-irserver-6.09.04.ebuild     2017-03-19 10:57:10.701786384 +0100
+++ irtrans-irserver-6.09.04-r1.ebuild  2018-07-16 18:38:00.184803015 +0200
@@ -1,13 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI=7
 
-inherit eutils flag-o-matic toolchain-funcs mono-env multilib
+inherit flag-o-matic toolchain-funcs mono-env
 
-RESTRICT="strip"
-
-DESCRIPTION="IRTrans Server"
+DESCRIPTION="Server software for IRTrans"
 HOMEPAGE="http://www.irtrans.de"
 SRC_URI="http://ftp.disconnected-by-peer.at/irtrans/irserver-src-${PV}.tar.gz
         http://ftp.disconnected-by-peer.at/irtrans/irserver-${PV}.tar.gz
@@ -16,15 +14,17 @@
 
 LICENSE="BSD GPL-2"
 SLOT="0"
-KEYWORDS="~x86 ~amd64 ~arm"
+KEYWORDS="~amd64 ~arm ~x86"
 IUSE="mono"
+RESTRICT="strip"
 
 RDEPEND="mono? ( >=dev-lang/mono-2.10.5 )"
 
 S="${WORKDIR}"
 
 src_prepare() {
-       sed -e 's!^ODIRARM = .*!ODIRARM = n800!' -i makefile
+       default
+       sed -e 's!^ODIRARM = .*!ODIRARM = n800!' -i makefile || die
 }
 
 src_compile() {
@@ -32,7 +32,7 @@
        append-ldflags --static
 
        # Set sane defaults (arm target has no -D flags added)
-       irbuild=irserver_arm_noccf
+       local irbuild=irserver_arm_noccf
        irserver=irserver
 
        # change variable by need
@@ -45,12 +45,6 @@
                irbuild=irserver_arm
        fi
 
-       # Some output for bugreport
-       einfo "CFLAGS=\"${CFLAGS}\""
-       einfo "Build Target=\"${irbuild}\""
-       einfo "Build Binary=\"${irserver}\""
-
-       # Build
        emake CXX="$(tc-getCXX)" CC="$(tc-getCC)" CFLAGS="${CFLAGS}" \
                CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" "${irbuild}"
 }
@@ -61,7 +55,7 @@
        keepdir /etc/irserver/remotes
 
        docinto remotes
-       dodoc remotes/*
+       dodoc -r remotes
 
        newinitd "${FILESDIR}"/irtrans-server.initd irtrans-server
        newconfd "${FILESDIR}"/irtrans-server.confd irtrans-server
```