### PR TITLE
app-arch/hardlink: use HTTPS, EAPI7

### DIFF
--- a/app-arch/hardlink/hardlink-0.2.0.ebuild
+++ b/app-arch/hardlink/hardlink-0.2.0.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
 inherit toolchain-funcs
 
 DESCRIPTION="A tool which replaces copies of a file with hardlinks"
-HOMEPAGE="http://jak-linux.org/projects/hardlink/"
-SRC_URI="http://jak-linux.org/projects/${PN}/${PN}_${PV}.tar.gz"
+HOMEPAGE="https://jak-linux.org/projects/hardlink/"
+SRC_URI="https://jak-linux.org/projects/${PN}/${PN}_${PV}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/app-arch/hardlink/hardlink-0.3.0-r1.ebuild
+++ b/app-arch/hardlink/hardlink-0.3.0-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="A tool which replaces copies of a file with hardlinks"
+HOMEPAGE="https://jak-linux.org/projects/hardlink/"
+SRC_URI="https://jak-linux.org/projects/${PN}/${PN}_${PV}.tar.xz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
+
+RDEPEND="dev-libs/libpcre"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( README ${T}/README.rsync )
+
+src_prepare() {
+	default
+	sed -i -e '/^CF/s:?=:+=:' -e '/^CF/s:-O2 -g::' Makefile || die
+
+	cat <<-EOF > "${T}"/README.rsync
+	https://hardlinkpy.googlecode.com/svn/trunk/hardlink.py has regex '^\..*\.\?{6,6}$'
+	for excluding rsync temporary files by default.
+
+	To accomplish same with this version, you can use following syntax:
+	# hardlink -x '^\..*\.\?{6,6}$'
+
+	This was discussed at https://bugs.gentoo.org/416613
+	EOF
+}
+
+src_compile() {
+	emake CC=$(tc-getCC)
+}

--- a/app-arch/hardlink/hardlink-0.3.0.ebuild
+++ b/app-arch/hardlink/hardlink-0.3.0.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
 inherit toolchain-funcs
 
 DESCRIPTION="A tool which replaces copies of a file with hardlinks"
-HOMEPAGE="http://jak-linux.org/projects/hardlink/"
-SRC_URI="http://jak-linux.org/projects/${PN}/${PN}_${PV}.tar.xz"
+HOMEPAGE="https://jak-linux.org/projects/hardlink/"
+SRC_URI="https://jak-linux.org/projects/${PN}/${PN}_${PV}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
Hi,

Another small PR for app-arch/hardlink.
The EAPI7 version also doesn't change much.

diff -u
```
--- hardlink-0.3.0.ebuild       2018-07-16 18:41:56.121259481 +0200
+++ hardlink-0.3.0-r1.ebuild    2018-07-16 18:41:56.221256738 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="A tool which replaces copies of a file with hardlinks"
@@ -11,15 +11,15 @@
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
-IUSE=""
 
 RDEPEND="dev-libs/libpcre"
 DEPEND="${RDEPEND}
        virtual/pkgconfig"
 
-DOCS="README ${T}/README.rsync"
+DOCS=( README ${T}/README.rsync )
 
 src_prepare() {
+       default
        sed -i -e '/^CF/s:?=:+=:' -e '/^CF/s:-O2 -g::' Makefile || die
 
        cat <<-EOF > "${T}"/README.rsync
@@ -34,6 +34,5 @@
 }
 
 src_compile() {
-       tc-export CC
-       emake
+       emake CC=$(tc-getCC)
 }
```