### PR TITLE
app-crypt/md4sum: use HTTPS, EAPI7, improve ebuild

### DIFF
--- a/app-crypt/md4sum/md4sum-0.02.03-r2.ebuild
+++ b/app-crypt/md4sum/md4sum-0.02.03-r2.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="md4 and edonkey hash algorithm tool"
+HOMEPAGE="https://linux.xulin.de/c/"
+SRC_URI="https://linux.xulin.de/c/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=( "${FILESDIR}"/md4sum-fix-out-of-bounds-write.diff )
+
+src_prepare() {
+	default
+	sed -i -e "s:CFLAGS=:CFLAGS=${CFLAGS} :g" \
+		-e "s:install -s:install:g" Makefile.Linux || die
+}
+
+src_compile() {
+	emake LDFLAGS="${LDFLAGS}" CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin ${PN}
+	doman ${PN}.1
+}


### PR DESCRIPTION
Hi,

This is my take on this ebuild to update it for EAPI7.
Please review.

diff -u
```
--- md4sum-0.02.03-r1.ebuild    2018-07-16 18:43:43.961316248 +0200
+++ md4sum-0.02.03-r2.ebuild    2018-07-16 18:43:44.063313478 +0200
@@ -1,30 +1,31 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit eutils
+inherit toolchain-funcs
 
 DESCRIPTION="md4 and edonkey hash algorithm tool"
 HOMEPAGE="https://linux.xulin.de/c/"
 SRC_URI="https://linux.xulin.de/c/${P}.tar.gz"
+
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~ppc"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=( ${FILESDIR}/md4sum-fix-out-of-bounds-write.diff )
 
-src_prepare() {
-       epatch "${FILESDIR}/md4sum-fix-out-of-bounds-write.diff"
+src_configure() {
+       default
+       sed -i -e "s:CFLAGS=:CFLAGS=${CFLAGS} :g" \
+               -e "s:install -s:install:g" Makefile || die
 }
 
 src_compile() {
-       sed -i -e "s:CFLAGS=:CFLAGS=${CFLAGS} :g" \
-               -e "s:install -s:install:g" Makefile
-       emake LDFLAGS="${LDFLAGS}" CC="$(tc-getCC)" || die "emake failed"
+       emake LDFLAGS="${LDFLAGS}" CC="$(tc-getCC)"
 }
 
 src_install() {
-       mkdir -p "${D}/usr/bin"
-       mkdir -p "${D}/usr/share/man/man1"
-       einstall || die "einstall failed"
+       dobin ${PN}
+       doman ${PN}.1
 }

```