### PR TITLE
dev-cpp/ETL: EAPI7, add missing die, use HTTPs

### DIFF
--- a/dev-cpp/ETL/ETL-0.04.15-r1.ebuild
+++ b/dev-cpp/ETL/ETL-0.04.15-r1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Multi-platform class and template library"
+HOMEPAGE="https://www.synfig.org"
+SRC_URI="mirror://sourceforge/synfig/${PN}/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+src_prepare() {
+	default
+	sed -i -e 's/CXXFLAGS="`echo $CXXFLAGS | sed s:-g::` $debug_flags"//' \
+		-e 's/CFLAGS="`echo $CFLAGS | sed s:-g::` $debug_flags"//'     \
+		m4/subs.m4 || die
+
+	eautoreconf
+}


### PR DESCRIPTION
Hi,

This PR raises EAPI, adds a missing ```die``` and uses https instead of http. Also dropped the *DEPEND vars.
I didn't introduced a new revision as nothing changed installation wise and the package isn't stable anyway.

Please review.