### PR TITLE
media-libs/libfishsound: EAPI7, improve ebuild

### DIFF
--- a/media-libs/libfishsound/files/libfishsound-1.0.0-pc.patch
+++ b/media-libs/libfishsound/files/libfishsound-1.0.0-pc.patch
@@ -1,8 +1,8 @@
 This will avoid including -I/usr/include/FLAC in `pkg-config --cflags fishsound` since
 FLAC/assert.h will collide with system assert.h.
 
---- fishsound.pc.in
-+++ fishsound.pc.in
+--- a/fishsound.pc.in
++++ b/fishsound.pc.in
 @@ -5,7 +5,6 @@
  
  Name: fishsound

--- a/media-libs/libfishsound/libfishsound-1.0.0-r1.ebuild
+++ b/media-libs/libfishsound/libfishsound-1.0.0-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Simple programming interface for decoding and encoding audio data using vorbis or speex"
+HOMEPAGE="https://www.xiph.org/fishsound/"
+SRC_URI="https://downloads.xiph.org/releases/libfishsound/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="flac speex"
+
+RDEPEND="media-libs/libvorbis
+	media-libs/libogg
+	flac? ( media-libs/flac )
+	speex? ( media-libs/speex )"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+# bug #395153
+RESTRICT="test"
+
+PATCHES=( "${FILESDIR}"/${P}-pc.patch )
+
+src_prepare() {
+	default
+	sed -i \
+		-e 's:doxygen:doxygen-dummy:' \
+		configure || die
+}
+
+src_configure() {
+	local myconf=""
+	use flac || myconf="${myconf} --disable-flac"
+	use speex || myconf="${myconf} --disable-speex"
+
+	econf \
+		--disable-dependency-tracking \
+		${myconf}
+}
+
+src_install() {
+	emake DESTDIR="${D}" \
+		docdir="${D}/usr/share/doc/${PF}" install
+	dodoc AUTHORS ChangeLog README
+}


### PR DESCRIPTION
Hi,

this adds a new revision of media-libs/libfishsound with EAPI7 and minor improvements.

diff -u:
```
--- libfishsound-1.0.0.ebuild   2017-09-11 19:58:55.249193523 +0200
+++ libfishsound-1.0.0-r1.ebuild        2018-07-16 18:47:01.187004228 +0200
@@ -1,16 +1,15 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
-inherit eutils
+EAPI=7
 
 DESCRIPTION="Simple programming interface for decoding and encoding audio data using vorbis or speex"
-HOMEPAGE="http://www.xiph.org/fishsound/"
-SRC_URI="http://downloads.xiph.org/releases/libfishsound/${P}.tar.gz"
+HOMEPAGE="https://www.xiph.org/fishsound/"
+SRC_URI="https://downloads.xiph.org/releases/libfishsound/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="flac speex"
 
 RDEPEND="media-libs/libvorbis
@@ -23,8 +22,10 @@
 # bug #395153
 RESTRICT="test"
 
+PATCHES=( "${FILESDIR}"/${P}-pc.patch )
+
 src_prepare() {
-       epatch "${FILESDIR}"/${P}-pc.patch
+       default
        sed -i \
                -e 's:doxygen:doxygen-dummy:' \
                configure || die
@@ -42,6 +43,6 @@
 
 src_install() {
        emake DESTDIR="${D}" \
-               docdir="${D}/usr/share/doc/${PF}" install || die
+               docdir="${D}/usr/share/doc/${PF}" install
        dodoc AUTHORS ChangeLog README
 }
```