### PR TITLE
net-misc/megatools: remove non-available configure switches and deps

### DIFF
--- a/net-misc/megatools/megatools-1.9.98.ebuild
+++ b/net-misc/megatools/megatools-1.9.98.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -14,12 +14,11 @@ SRC_URI="https://github.com/megous/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="fuse introspection static-libs"
+IUSE=""
 
 COMMON_DEPEND="dev-libs/glib:2
 	dev-libs/openssl:0
 	net-misc/curl
-	fuse? ( sys-fs/fuse )
 "
 RDEPEND="${COMMON_DEPEND}
 	net-libs/glib-networking[ssl]
@@ -30,14 +29,9 @@ DEPEND="${COMMON_DEPEND}
 
 src_configure() {
 	local myeconfargs=(
-		--enable-shared
-		--enable-docs-build
 		--disable-maintainer-mode
 		--disable-warnings
 		--disable-glibtest
-		$(use_enable static-libs static)
-		$(use_enable introspection)
-		$(use_with fuse)
 	)
 	autotools-utils_src_configure
 }

--- a/net-misc/megatools/metadata.xml
+++ b/net-misc/megatools/metadata.xml
@@ -12,6 +12,9 @@ a command line of your desktop or server.
 Mega website can be found at http://mega.co.nz.
 </longdescription>
 	<use>
+		<!--
+			this should be dropped when megatools-1.9.97.ebuild gets removed
+		-->
 		<flag name="fuse">
 		Enables support for the filesystem in userspace plugin through <pkg>sys-fs/fuse</pkg>.
 		</flag>


### PR DESCRIPTION
Version 1.9.98 dropped fuse support and some configure switches, correct
the ebuild for that version.

Bug: https://bugs.gentoo.org/649460

Signed-off-by: Henning Schild <henning@hennsch.de>