### PR TITLE
net-dns/getdns: typo fix and systemd unit patch

### DIFF
--- a/net-dns/getdns/files/getdns-1.4.2-stubby.service.patch
+++ b/net-dns/getdns/files/getdns-1.4.2-stubby.service.patch
@@ -1,0 +1,16 @@
+diff -ur a/stubby/systemd/stubby.service b/stubby/systemd/stubby.service
+--- a/stubby/systemd/stubby.service	2018-05-11 13:25:22.000000000 +0200
++++ b/stubby/systemd/stubby.service	2018-06-20 15:40:23.650164668 +0200
+@@ -3,9 +3,11 @@
+ 
+ [Service]
+ User=stubby
+-DynamicUser=yes
++DynamicUser=no
+ CacheDirectory=stubby
+ WorkingDirectory=/var/cache/stubby
++ExecStartPre=/bin/mkdir -p /var/cache/stubby
++ExecStartPre=/bin/chown stubby:stubby /var/cache/stubby
+ ExecStart=/usr/bin/stubby
+ AmbientCapabilities=CAP_NET_BIND_SERVICE
+ CapabilityBoundingSet=CAP_NET_BIND_SERVICE

--- a/net-dns/getdns/getdns-1.4.2-r1.ebuild
+++ b/net-dns/getdns/getdns-1.4.2-r1.ebuild
@@ -30,6 +30,8 @@ RDEPEND="
 	stubby? ( sys-libs/libcap:= )
 "
 
+PATCHES=( "${FILESDIR}/${PN}-1.4.2-stubby.service.patch" )
+
 src_configure() {
 	econf \
 		--runstatedir=/var/run \

--- a/net-dns/getdns/getdns-1.4.2.ebuild
+++ b/net-dns/getdns/getdns-1.4.2.ebuild
@@ -43,7 +43,7 @@ src_configure() {
 		$(use_with libevent) \
 		$(use_with libev) \
 		$(use_with libuv) \
-		$(use_with threads libpthread)
+		$(use_with threads libpthread) \
 		$(use_enable static-libs static)
 }
 


### PR DESCRIPTION
Hello,
I fixed a typo I just spotted in src_configure and I made a patch for upstream systemd unit to match system configuration as explained [in this bug report](https://bugs.gentoo.org/656988).

cc @blueness 