### PR TITLE
games-engines/gargoyle: fix build on recent GCC, ebuild improvements, cancel last-rites

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -292,10 +292,6 @@ games-strategy/gorky17-demo
 net-vpn/miredo
 
 # Pacho Ramos <pacho@gentoo.org> (17 Jun 2018)
-# Fails to build (#642996). Removal in a month.
-games-engines/gargoyle
-
-# Pacho Ramos <pacho@gentoo.org> (17 Jun 2018)
 # Fails to compile (#648430), crashes from time to time (#222065). Removal
 # in a month.
 app-misc/wyrd


### PR DESCRIPTION
Bumped EAPI, removed the use of games.eclass, fixed a runtime error due
to a no longer needed sed, create relative instead of absolute symlinks.
Revbump due to a file location change.

Cancel games-engines/gargoyle last-rites as build issue is fixed.

Closes: https://bugs.gentoo.org/642996
Package-Manager: Portage-2.3.42, Repoman-2.3.9