### PR TITLE
app-arch/zstd: fix automagic dep on app-arch/lz4

### DIFF
--- a/app-arch/zstd/metadata.xml
+++ b/app-arch/zstd/metadata.xml
@@ -13,4 +13,9 @@
   <upstream>
     <remote-id type="github">facebook/zstd</remote-id>
   </upstream>
+  <use>
+    <flag name="lz4">
+      Enable support for LZ4 compression using <pkg>app-arch/lz4</pkg>
+    </flag>
+  </use>
 </pkgmetadata>

--- a/app-arch/zstd/zstd-1.3.4.ebuild
+++ b/app-arch/zstd/zstd-1.3.4.ebuild
@@ -12,15 +12,17 @@ SRC_URI="https://github.com/facebook/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="|| ( BSD GPL-2 )"
 SLOT="0/1"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
-IUSE="static-libs"
+IUSE="lz4 static-libs"
 
-RDEPEND="app-arch/xz-utils"
+RDEPEND="app-arch/xz-utils
+	lz4? ( app-arch/lz4 )"
 DEPEND="${RDEPEND}"
 
 src_compile() {
 	emake \
 		CC="$(tc-getCC)" \
 		AR="$(tc-getAR)" \
+		HAVE_LZ4=$(usex lz4 1 0) \
 		PREFIX="${EPREFIX}/usr" \
 		LIBDIR="${EPREFIX}/usr/$(get_libdir)" zstd
 


### PR DESCRIPTION
 Add USE "lz4" for build with or without app-arch/lz4.
 Add conditional DEPENDS/RDEPENDS.
 Add USE "lz4" in metadata.

Bug: https://bugs.gentoo.org/show_bug.cgi?id=656316
Closes: https://github.com/gentoo/gentoo/pull/9076
Package-Manager: Portage-2.3.24, Repoman-2.3.6