### PR TITLE
dev-libs/amdgpu-pro-opencl: dolib (EAPI7) fix

### DIFF
--- a/dev-libs/amdgpu-pro-opencl/amdgpu-pro-opencl-17.50.511655.ebuild
+++ b/dev-libs/amdgpu-pro-opencl/amdgpu-pro-opencl-17.50.511655.ebuild
@@ -53,8 +53,8 @@ src_prepare() {
 
 src_install() {
 	into "/opt/amdgpu"
-	dolib opt/${SUPER_PN}/lib/x86_64-linux-gnu/*
-	dolib opt/amdgpu/lib/x86_64-linux-gnu/*
+	dolib.so opt/${SUPER_PN}/lib/x86_64-linux-gnu/*
+	dolib.so opt/amdgpu/lib/x86_64-linux-gnu/*
 	insinto "/opt/amdgpu"
 	doins -r opt/amdgpu/share
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/659676
Package-Manager: Portage-2.3.36, Repoman-2.3.9