### PR TITLE
games-roguelike/FTL-gog: Rev bump, fix shell script perms

### DIFF
--- a/games-roguelike/FTL-gog/FTL-gog-1.6.7.18662-r1.ebuild
+++ b/games-roguelike/FTL-gog/FTL-gog-1.6.7.18662-r1.ebuild
@@ -42,12 +42,14 @@ src_prepare() {
 	if ! use amd64; then
 		rm game/data/FTL.amd64 || die
 	fi
+
+	sed -i start.sh -e '/chmod/d'
 }
 
 src_install() {
 	insinto /opt/gog/FTL
 	doins -r .
-	fperms +x /opt/gog/FTL/{start.sh,game/FTL}
+	fperms +x /opt/gog/FTL/{start.sh,game/FTL,game/data/FTL}
 
 	if use x86; then
 		fperms +x /opt/gog/FTL/game/data/FTL.x86


### PR DESCRIPTION
Fixed the permissions on one of the shell scripts called by the start
script and stripped useless chmod calls from that start script.

Package-Manager: Portage-2.3.40, Repoman-2.3.9

Note: this is a duplicate of #8961 which was improperly closed due to the recent breach.