### PR TITLE
media-fonts/cantarell: requires appstream

### DIFF
--- a/media-fonts/cantarell/cantarell-0.101.ebuild
+++ b/media-fonts/cantarell/cantarell-0.101.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/CantarellFonts"
 
 LICENSE="OFL-1.1"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~sh ~sparc ~x86 ~x86-fbsd"
 IUSE=""
 
 RDEPEND="media-libs/fontconfig"

--- a/media-fonts/cantarell/cantarell-0.101.ebuild
+++ b/media-fonts/cantarell/cantarell-0.101.ebuild
@@ -16,6 +16,7 @@ IUSE=""
 
 RDEPEND="media-libs/fontconfig"
 DEPEND="
+	dev-libs/appstream
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/656710