### PR TITLE
app-emulation/vagrant: add ruby25 support

### DIFF
--- a/app-emulation/vagrant/files/vagrant-r1.in
+++ b/app-emulation/vagrant/files/vagrant-r1.in
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# This is a wrapper to properly execute Vagrant within the embedded
+# Vagrant installation directory. This sets up proper environmental variables
+# so that everything loads and compiles to proper directories.
+
+for r in ruby25 ruby24 ruby23; do
+  # not all ruby versions are guaranteed to be installed
+  if ! command -v "${r}" >/dev/null 2>&1; then
+    continue
+  fi
+
+  VAGRANT_DIR="$( "${r}" -e 'print Gem::default_path[-1] + "/gems/vagrant-@VAGRANT_VERSION@"' )"
+
+  # Export the VAGRANT_EXECUTABLE so that pre-rubygems can optimize a bit
+  export VAGRANT_EXECUTABLE="${VAGRANT_DIR}/bin/vagrant"
+
+  if [ -f ${VAGRANT_EXECUTABLE} ] ;then
+    ruby="${r}"
+    break
+  fi
+done
+
+if [ -z ${ruby} ]; then
+  echo "Error: failed to find any usable ruby"
+  exit 1
+fi
+
+# Export GEM_HOME based on VAGRANT_HOME
+#
+# This needs to be set because Bundler includes gem paths
+# from RubyGems' Gem.paths.
+if [ -z ${VAGRANT_HOME} ]; then
+  VAGRANT_HOME="~/.vagrant.d"
+fi
+export GEM_HOME="${VAGRANT_HOME}/gems"
+
+# SSL certs
+export SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
+
+# Export an environmental variable to say we're in a Vagrant
+# installer created environment.
+export VAGRANT_INSTALLER_ENV=1
+
+# This is currently used only in Vagrant::Plugin::Manager.system_plugins_file
+# to locate plugins configuration file.
+export VAGRANT_INSTALLER_EMBEDDED_DIR="/var/lib/vagrant"
+export VAGRANT_INSTALLER_VERSION=2
+
+# Export the OS as an environmental variable that Vagrant can access
+# so that it can behave better.
+export VAGRANT_DETECTED_OS="$(uname -s 2>/dev/null)"
+
+# Allow to install plugins even with deps in different slots (Bug #628648)
+export VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1
+
+# Make it work with rvm (Bugs #474476 #628648)
+unset GEM_HOME GEM_PATH
+
+# Call the actual Vagrant bin with our arguments
+exec "${ruby}" "${VAGRANT_EXECUTABLE}" "$@"

--- a/app-emulation/vagrant/vagrant-2.1.2-r1.ebuild
+++ b/app-emulation/vagrant/vagrant-2.1.2-r1.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+USE_RUBY="ruby23 ruby24 ruby25"
+
+RUBY_FAKEGEM_EXTRADOC="CHANGELOG.md README.md"
+RUBY_FAKEGEM_GEMSPEC="vagrant.gemspec"
+RUBY_FAKEGEM_EXTRAINSTALL="keys plugins templates version.txt"
+RUBY_FAKEGEM_TASK_DOC=""
+
+inherit bash-completion-r1 ruby-fakegem
+
+DESCRIPTION="A tool for building and distributing development environments"
+HOMEPAGE="https://vagrantup.com/"
+SRC_URI="https://github.com/hashicorp/vagrant/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="+virtualbox"
+RESTRICT="test"
+
+RDEPEND="${RDEPEND}
+	app-arch/libarchive
+	net-misc/curl
+	virtualbox? ( || ( app-emulation/virtualbox app-emulation/virtualbox-bin ) )"
+
+ruby_add_rdepend "
+	>=dev-ruby/childprocess-0.6.0
+	>=dev-ruby/erubis-2.7.0
+	<dev-ruby/i18n-0.8.0:*
+	>=dev-ruby/listen-3.1.5
+	>=dev-ruby/hashicorp-checkpoint-0.1.5
+	>=dev-ruby/log4r-1.1.9 <dev-ruby/log4r-1.1.11
+	>=dev-ruby/net-ssh-4.2.0:*
+	>=dev-ruby/net-sftp-2.1
+	>=dev-ruby/net-scp-1.2.0
+	|| ( dev-ruby/rest-client:2 >=dev-ruby/rest-client-1.6.0:0 )
+	>=dev-ruby/nokogiri-1.7.1
+	<dev-ruby/mime-types-3:*
+"
+
+ruby_add_bdepend "
+	>=dev-ruby/rake-12.0.0
+"
+
+all_ruby_prepare() {
+	# remove bundler support
+	sed -i '/[Bb]undler/d' Rakefile || die
+	rm Gemfile || die
+
+	# loosen dependencies
+	sed -e '/hashicorp-checkpoint\|listen\|net-ssh\|net-scp\|rake\|childprocess/s/~>/>=/' \
+		-e '/ruby_dep/s/<=/>=/' \
+		-i ${PN}.gemspec || die
+
+	# remove windows-specific gems
+	sed -e '/wdm\|win32-\|winrm/d' \
+		-i ${PN}.gemspec || die
+
+	# remove bsd-specific gems
+	sed -e '/rb-kqueue/d' \
+		-i ${PN}.gemspec || die
+
+	sed -e "s/@VAGRANT_VERSION@/${PV}/g" "${FILESDIR}/${PN}-r1.in" > "${PN}" || die
+}
+
+all_ruby_install() {
+	newbashcomp contrib/bash/completion.sh ${PN}
+	all_fakegem_install
+
+	# provide executable similar to upstream:
+	# https://github.com/hashicorp/vagrant-installers/blob/master/substrate/modules/vagrant_installer/templates/vagrant.erb
+	dobin "${PN}"
+
+	# directory for plugins.json
+	keepdir /var/lib/vagrant
+}


### PR DESCRIPTION
@hydrapolic hey, I convinced graaf adding ruby25 to `dev-ruby/i18n:0.7` so here we go.
I know you wanted to do it at the next bump, but I'd like to push it, cause I want to get rid of ruby-2.4 ;-D

lmk if it looks/works fine and I'll merge.