### PR TITLE
app-misc/grabcartoons: use HTTPs

### DIFF
--- a/app-misc/grabcartoons/grabcartoons-2.8.4_p20141112.ebuild
+++ b/app-misc/grabcartoons/grabcartoons-2.8.4_p20141112.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ else
 fi
 
 DESCRIPTION="Comic-summarizing utility"
-HOMEPAGE="http://zzamboni.org/grabcartoons"
+HOMEPAGE="https://zzamboni.org/code/grabcartoons/"
 
 LICENSE="BSD"
 SLOT="0"

--- a/app-misc/grabcartoons/grabcartoons-9999.ebuild
+++ b/app-misc/grabcartoons/grabcartoons-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ else
 fi
 
 DESCRIPTION="Comic-summarizing utility"
-HOMEPAGE="http://zzamboni.org/grabcartoons"
+HOMEPAGE="https://zzamboni.org/code/grabcartoons/"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Hi,

This fixes the HOMEPAGE for app-misc/grabcartoons to use https instead of http.

Please review.