### PR TITLE
dev-db/mariadb{-galera,-connector-c}: use HTTPs

### DIFF
--- a/dev-db/mariadb-connector-c/mariadb-connector-c-3.0.3.ebuild
+++ b/dev-db/mariadb-connector-c/mariadb-connector-c-3.0.3.ebuild
@@ -25,7 +25,7 @@ MULTILIB_WRAPPED_HEADERS+=(
 )
 
 DESCRIPTION="C client library for MariaDB/MySQL"
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 LICENSE="LGPL-2.1"
 
 SLOT="0/3"

--- a/dev-db/mariadb-connector-c/mariadb-connector-c-3.0.4.ebuild
+++ b/dev-db/mariadb-connector-c/mariadb-connector-c-3.0.4.ebuild
@@ -25,7 +25,7 @@ MULTILIB_WRAPPED_HEADERS+=(
 )
 
 DESCRIPTION="C client library for MariaDB/MySQL"
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 LICENSE="LGPL-2.1"
 
 SLOT="0/3"

--- a/dev-db/mariadb-connector-c/mariadb-connector-c-9999.ebuild
+++ b/dev-db/mariadb-connector-c/mariadb-connector-c-9999.ebuild
@@ -25,7 +25,7 @@ MULTILIB_WRAPPED_HEADERS+=(
 )
 
 DESCRIPTION="C client library for MariaDB/MySQL"
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 LICENSE="LGPL-2.1"
 
 SLOT="0/3"

--- a/dev-db/mariadb-galera/mariadb-galera-10.0.35-r1.ebuild
+++ b/dev-db/mariadb-galera/mariadb-galera-10.0.35-r1.ebuild
@@ -23,7 +23,7 @@ if [[ "${MY_EXTRAS_VER}" != "live" && "${MY_EXTRAS_VER}" != "none" ]]; then
 		https://dev.gentoo.org/~jmbsvicetto/distfiles/mysql-extras-${MY_EXTRAS_VER}.tar.bz2"
 fi
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 LICENSE="GPL-2 LGPL-2.1+"
 SLOT="0/${SUBSLOT:-0}"
@@ -742,7 +742,7 @@ pkg_config() {
 	local sqltmp="$(emktemp)"
 
 	# Fix bug 446200. Don't reference host my.cnf, needs to come first,
-	# see http://bugs.mysql.com/bug.php?id=31312
+	# see https://bugs.mysql.com/bug.php?id=31312
 	use prefix && options="${options} '--defaults-file=${MY_SYSCONFDIR}/my.cnf'"
 
 	# Figure out which options we need to disable to do the setup
@@ -771,7 +771,7 @@ pkg_config() {
 	pushd "${TMPDIR}" &>/dev/null || die
 
 	# Filling timezones, see
-	# http://dev.mysql.com/doc/mysql/en/time-zone-support.html
+	# https://dev.mysql.com/doc/mysql/en/time-zone-support.html
 	"${EROOT}/usr/bin/mysql_tzinfo_to_sql" "${EROOT}/usr/share/zoneinfo" > "${sqltmp}" 2>/dev/null
 
 	local cmd=( "${EROOT}usr/share/mariadb/scripts/mysql_install_db" )

--- a/dev-db/mariadb/mariadb-10.0.33.ebuild
+++ b/dev-db/mariadb/mariadb-10.0.33.ebuild
@@ -10,7 +10,7 @@ JAVA_PKG_OPT_USE="jdbc"
 
 inherit toolchain-funcs java-pkg-opt-2 mysql-multilib-r1
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 
 IUSE="bindist jdbc odbc oqgraph pam sphinx tokudb xml"

--- a/dev-db/mariadb/mariadb-10.0.34.ebuild
+++ b/dev-db/mariadb/mariadb-10.0.34.ebuild
@@ -10,7 +10,7 @@ JAVA_PKG_OPT_USE="jdbc"
 
 inherit toolchain-funcs java-pkg-opt-2 mysql-multilib-r1
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 
 IUSE="bindist jdbc odbc oqgraph pam sphinx tokudb xml"

--- a/dev-db/mariadb/mariadb-10.0.35-r2.ebuild
+++ b/dev-db/mariadb/mariadb-10.0.35-r2.ebuild
@@ -23,7 +23,7 @@ if [[ "${MY_EXTRAS_VER}" != "live" && "${MY_EXTRAS_VER}" != "none" ]]; then
 		https://dev.gentoo.org/~jmbsvicetto/distfiles/mysql-extras-${MY_EXTRAS_VER}.tar.bz2"
 fi
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 LICENSE="GPL-2"
 SLOT="0/${SUBSLOT:-0}"
@@ -737,7 +737,7 @@ pkg_config() {
 	local sqltmp="$(emktemp)"
 
 	# Fix bug 446200. Don't reference host my.cnf, needs to come first,
-	# see http://bugs.mysql.com/bug.php?id=31312
+	# see https://bugs.mysql.com/bug.php?id=31312
 	use prefix && options="${options} '--defaults-file=${MY_SYSCONFDIR}/my.cnf'"
 
 	# Figure out which options we need to disable to do the setup
@@ -766,7 +766,7 @@ pkg_config() {
 	pushd "${TMPDIR}" &>/dev/null || die
 
 	# Filling timezones, see
-	# http://dev.mysql.com/doc/mysql/en/time-zone-support.html
+	# https://dev.mysql.com/doc/mysql/en/time-zone-support.html
 	"${EROOT}/usr/bin/mysql_tzinfo_to_sql" "${EROOT}/usr/share/zoneinfo" > "${sqltmp}" 2>/dev/null
 
 	local cmd=( "${EROOT}usr/share/mariadb/scripts/mysql_install_db" )

--- a/dev-db/mariadb/mariadb-10.0.35.ebuild
+++ b/dev-db/mariadb/mariadb-10.0.35.ebuild
@@ -10,7 +10,7 @@ JAVA_PKG_OPT_USE="jdbc"
 
 inherit toolchain-funcs java-pkg-opt-2 mysql-multilib-r1
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 
 IUSE="bindist jdbc odbc oqgraph pam sphinx tokudb xml"

--- a/dev-db/mariadb/mariadb-10.1.29.ebuild
+++ b/dev-db/mariadb/mariadb-10.1.29.ebuild
@@ -12,7 +12,7 @@ JAVA_PKG_OPT_USE="jdbc"
 
 inherit toolchain-funcs java-pkg-opt-2 mysql-multilib-r1
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 
 IUSE="+backup bindist cracklib galera kerberos innodb-lz4 innodb-lzo innodb-snappy jdbc mroonga odbc oqgraph pam sphinx sst-rsync sst-mariabackup sst-xtrabackup tokudb systemd xml"

--- a/dev-db/mariadb/mariadb-10.1.31-r1.ebuild
+++ b/dev-db/mariadb/mariadb-10.1.31-r1.ebuild
@@ -12,7 +12,7 @@ JAVA_PKG_OPT_USE="jdbc"
 
 inherit toolchain-funcs java-pkg-opt-2 mysql-multilib-r1
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 
 IUSE="+backup bindist cracklib galera kerberos innodb-lz4 innodb-lzo innodb-snappy jdbc mroonga numa odbc oqgraph pam sphinx sst-rsync sst-mariabackup sst-xtrabackup tokudb systemd xml"

--- a/dev-db/mariadb/mariadb-10.1.33.ebuild
+++ b/dev-db/mariadb/mariadb-10.1.33.ebuild
@@ -12,7 +12,7 @@ JAVA_PKG_OPT_USE="jdbc"
 
 inherit toolchain-funcs java-pkg-opt-2 mysql-multilib-r1
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 
 IUSE="+backup bindist cracklib galera kerberos innodb-lz4 innodb-lzo innodb-snappy jdbc mroonga numa odbc oqgraph pam sphinx sst-rsync sst-mariabackup sst-xtrabackup tokudb systemd xml"

--- a/dev-db/mariadb/mariadb-10.1.34.ebuild
+++ b/dev-db/mariadb/mariadb-10.1.34.ebuild
@@ -23,7 +23,7 @@ if [[ "${MY_EXTRAS_VER}" != "live" && "${MY_EXTRAS_VER}" != "none" ]]; then
 		https://dev.gentoo.org/~jmbsvicetto/distfiles/mysql-extras-${MY_EXTRAS_VER}.tar.bz2"
 fi
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 LICENSE="GPL-2"
 SLOT="0/${SUBSLOT:-0}"
@@ -774,7 +774,7 @@ pkg_config() {
 	local sqltmp="$(emktemp)"
 
 	# Fix bug 446200. Don't reference host my.cnf, needs to come first,
-	# see http://bugs.mysql.com/bug.php?id=31312
+	# see https://bugs.mysql.com/bug.php?id=31312
 	use prefix && options="${options} '--defaults-file=${MY_SYSCONFDIR}/my.cnf'"
 
 	# Figure out which options we need to disable to do the setup
@@ -803,7 +803,7 @@ pkg_config() {
 	pushd "${TMPDIR}" &>/dev/null || die
 
 	# Filling timezones, see
-	# http://dev.mysql.com/doc/mysql/en/time-zone-support.html
+	# https://dev.mysql.com/doc/mysql/en/time-zone-support.html
 	"${EROOT}/usr/bin/mysql_tzinfo_to_sql" "${EROOT}/usr/share/zoneinfo" > "${sqltmp}" 2>/dev/null
 
 	local cmd=( "${EROOT}usr/share/mariadb/scripts/mysql_install_db" )

--- a/dev-db/mariadb/mariadb-10.2.15.ebuild
+++ b/dev-db/mariadb/mariadb-10.2.15.ebuild
@@ -24,7 +24,7 @@ if [[ "${MY_EXTRAS_VER}" != "live" && "${MY_EXTRAS_VER}" != "none" ]]; then
 		https://dev.gentoo.org/~jmbsvicetto/distfiles/mysql-extras-${MY_EXTRAS_VER}.tar.bz2"
 fi
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 LICENSE="GPL-2 LGPL-2.1+"
 SLOT="0/${SUBSLOT:-0}"
@@ -904,7 +904,7 @@ pkg_config() {
 	local sqltmp="$(emktemp)"
 
 	# Fix bug 446200. Don't reference host my.cnf, needs to come first,
-	# see http://bugs.mysql.com/bug.php?id=31312
+	# see https://bugs.mysql.com/bug.php?id=31312
 	use prefix && options="${options} '--defaults-file=${MY_SYSCONFDIR}/my.cnf'"
 
 	# Figure out which options we need to disable to do the setup
@@ -933,7 +933,7 @@ pkg_config() {
 	pushd "${TMPDIR}" &>/dev/null || die
 
 	# Filling timezones, see
-	# http://dev.mysql.com/doc/mysql/en/time-zone-support.html
+	# https://dev.mysql.com/doc/mysql/en/time-zone-support.html
 	"${EROOT}/usr/bin/mysql_tzinfo_to_sql" "${EROOT}/usr/share/zoneinfo" > "${sqltmp}" 2>/dev/null
 
 	local cmd=( "${EROOT}usr/share/mariadb/scripts/mysql_install_db" )

--- a/dev-db/mariadb/mariadb-10.3.6_rc.ebuild
+++ b/dev-db/mariadb/mariadb-10.3.6_rc.ebuild
@@ -24,7 +24,7 @@ if [[ "${MY_EXTRAS_VER}" != "live" && "${MY_EXTRAS_VER}" != "none" ]]; then
 		https://dev.gentoo.org/~jmbsvicetto/distfiles/mysql-extras-${MY_EXTRAS_VER}.tar.bz2"
 fi
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 LICENSE="GPL-2 LGPL-2.1+"
 SLOT="0/${SUBSLOT:-0}"
@@ -915,7 +915,7 @@ pkg_config() {
 	local sqltmp="$(emktemp)"
 
 	# Fix bug 446200. Don't reference host my.cnf, needs to come first,
-	# see http://bugs.mysql.com/bug.php?id=31312
+	# see https://bugs.mysql.com/bug.php?id=31312
 	use prefix && options="${options} '--defaults-file=${MY_SYSCONFDIR}/my.cnf'"
 
 	# Figure out which options we need to disable to do the setup
@@ -944,7 +944,7 @@ pkg_config() {
 	pushd "${TMPDIR}" &>/dev/null || die
 
 	# Filling timezones, see
-	# http://dev.mysql.com/doc/mysql/en/time-zone-support.html
+	# https://dev.mysql.com/doc/mysql/en/time-zone-support.html
 	"${EROOT}/usr/bin/mysql_tzinfo_to_sql" "${EROOT}/usr/share/zoneinfo" > "${sqltmp}" 2>/dev/null
 
 	local cmd=( "${EROOT}usr/share/mariadb/scripts/mysql_install_db" )

--- a/dev-db/mariadb/mariadb-10.3.7.ebuild
+++ b/dev-db/mariadb/mariadb-10.3.7.ebuild
@@ -24,7 +24,7 @@ if [[ "${MY_EXTRAS_VER}" != "live" && "${MY_EXTRAS_VER}" != "none" ]]; then
 		https://dev.gentoo.org/~jmbsvicetto/distfiles/mysql-extras-${MY_EXTRAS_VER}.tar.bz2"
 fi
 
-HOMEPAGE="http://mariadb.org/"
+HOMEPAGE="https://mariadb.org/"
 DESCRIPTION="An enhanced, drop-in replacement for MySQL"
 LICENSE="GPL-2 LGPL-2.1+"
 SLOT="0/${SUBSLOT:-0}"
@@ -853,7 +853,7 @@ pkg_config() {
 	local sqltmp="$(emktemp)"
 
 	# Fix bug 446200. Don't reference host my.cnf, needs to come first,
-	# see http://bugs.mysql.com/bug.php?id=31312
+	# see https://bugs.mysql.com/bug.php?id=31312
 	use prefix && options="${options} '--defaults-file=${MY_SYSCONFDIR}/my.cnf'"
 
 	# Figure out which options we need to disable to do the setup
@@ -882,7 +882,7 @@ pkg_config() {
 	pushd "${TMPDIR}" &>/dev/null || die
 
 	# Filling timezones, see
-	# http://dev.mysql.com/doc/mysql/en/time-zone-support.html
+	# https://dev.mysql.com/doc/mysql/en/time-zone-support.html
 	"${EROOT}/usr/bin/mysql_tzinfo_to_sql" "${EROOT}/usr/share/zoneinfo" > "${sqltmp}" 2>/dev/null
 
 	local cmd=( "${EROOT}usr/share/mariadb/scripts/mysql_install_db" )


### PR DESCRIPTION
Hi,

This PR fixes a few mariadb packages to use https instead of http.

Please review.