### PR TITLE
eclass/mysql-multilib-r1: use HTTPs

### DIFF
--- a/eclass/mysql-multilib-r1.eclass
+++ b/eclass/mysql-multilib-r1.eclass
@@ -149,7 +149,7 @@ if [[ ${MY_EXTRAS_VER} != "live" && ${MY_EXTRAS_VER} != "none" ]]; then
 fi
 
 DESCRIPTION="A fast, multi-threaded, multi-user SQL database server"
-HOMEPAGE="http://www.mysql.com/"
+HOMEPAGE="https://www.mysql.com/"
 LICENSE="GPL-2"
 SLOT="0/${SUBSLOT:-0}"
 


### PR DESCRIPTION
Hi,

This is a simply fix for the mysql-multilib-r1 eclass to use https instead of http for the HOMEPAGE.

Please review.