### PR TITLE
dev-python/{flask-security,flask-uploads,lxml,pyyaml,pytz}: use HTTPs

### DIFF
--- a/dev-python/flask-security/flask-security-3.0.0.ebuild
+++ b/dev-python/flask-security/flask-security-3.0.0.ebuild
@@ -10,7 +10,7 @@ MY_PN="Flask-Security"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Simple security for Flask apps"
-HOMEPAGE="http://pythonhosted.org/Flask-Security/ https://pypi.org/project/Flask-Security/"
+HOMEPAGE="https://pythonhosted.org/Flask-Security/ https://pypi.org/project/Flask-Security/"
 SRC_URI="mirror://pypi/${MY_P:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/flask-uploads/flask-uploads-0.2.0-r1.ebuild
+++ b/dev-python/flask-uploads/flask-uploads-0.2.0-r1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
 inherit distutils-r1
 
 DESCRIPTION="Flexible and efficient upload handling for Flask"
-HOMEPAGE="http://pythonhosted.org/Flask-Testing/
+HOMEPAGE="https://pythonhosted.org/Flask-Testing/
 	https://pypi.org/project/Flask-Testing/"
 SRC_URI="https://github.com/maxcountryman/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 # use the GitHub tarball since the pypi-tarball does not contain the tests

--- a/dev-python/lxml/lxml-3.8.0.ebuild
+++ b/dev-python/lxml/lxml-3.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 inherit distutils-r1 eutils flag-o-matic toolchain-funcs
 
 DESCRIPTION="A Pythonic binding for the libxml2 and libxslt libraries"
-HOMEPAGE="http://lxml.de/ https://pypi.org/project/lxml/ https://github.com/lxml/lxml"
+HOMEPAGE="https://lxml.de/ https://pypi.org/project/lxml/ https://github.com/lxml/lxml"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD ElementTree GPL-2 PSF-2"

--- a/dev-python/lxml/lxml-4.1.1.ebuild
+++ b/dev-python/lxml/lxml-4.1.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy )
 inherit distutils-r1 eutils flag-o-matic toolchain-funcs
 
 DESCRIPTION="A Pythonic binding for the libxml2 and libxslt libraries"
-HOMEPAGE="http://lxml.de/ https://pypi.org/project/lxml/ https://github.com/lxml/lxml"
+HOMEPAGE="https://lxml.de/ https://pypi.org/project/lxml/ https://github.com/lxml/lxml"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD ElementTree GPL-2 PSF-2"

--- a/dev-python/lxml/lxml-4.2.0.ebuild
+++ b/dev-python/lxml/lxml-4.2.0.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy )
 inherit distutils-r1 eutils toolchain-funcs
 
 DESCRIPTION="A Pythonic binding for the libxml2 and libxslt libraries"
-HOMEPAGE="http://lxml.de/ https://pypi.org/project/lxml/ https://github.com/lxml/lxml"
+HOMEPAGE="https://lxml.de/ https://pypi.org/project/lxml/ https://github.com/lxml/lxml"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD ElementTree GPL-2 PSF-2"

--- a/dev-python/lxml/lxml-4.2.2.ebuild
+++ b/dev-python/lxml/lxml-4.2.2.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy )
 inherit distutils-r1 eutils toolchain-funcs
 
 DESCRIPTION="A Pythonic binding for the libxml2 and libxslt libraries"
-HOMEPAGE="http://lxml.de/ https://pypi.org/project/lxml/ https://github.com/lxml/lxml"
+HOMEPAGE="https://lxml.de/ https://pypi.org/project/lxml/ https://github.com/lxml/lxml"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD ElementTree GPL-2 PSF-2"

--- a/dev-python/pytz/pytz-2018.4.ebuild
+++ b/dev-python/pytz/pytz-2018.4.ebuild
@@ -9,7 +9,7 @@ PYTHON_REQ_USE="threads(+)"
 inherit distutils-r1
 
 DESCRIPTION="World timezone definitions for Python"
-HOMEPAGE="http://pythonhosted.org/pytz/ https://pypi.org/project/pytz/"
+HOMEPAGE="https://pythonhosted.org/pytz/ https://pypi.org/project/pytz/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/pyyaml/pyyaml-3.12.ebuild
+++ b/dev-python/pyyaml/pyyaml-3.12.ebuild
@@ -10,8 +10,8 @@ inherit distutils-r1
 MY_P="PyYAML-${PV}"
 
 DESCRIPTION="YAML parser and emitter for Python"
-HOMEPAGE="http://pyyaml.org/wiki/PyYAML https://pypi.org/project/PyYAML/"
-SRC_URI="http://pyyaml.org/download/${PN}/${MY_P}.tar.gz"
+HOMEPAGE="https://pyyaml.org/wiki/PyYAML https://pypi.org/project/PyYAML/"
+SRC_URI="https://pyyaml.org/download/${PN}/${MY_P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
Hi,

Another simple PR for a few python packages to use https over http.

Please review.