### PR TITLE
dev-libs/appstream-0.10.6-r1: add xmlto to depends

### DIFF
--- a/dev-libs/appstream/appstream-0.10.6-r1.ebuild
+++ b/dev-libs/appstream/appstream-0.10.6-r1.ebuild
@@ -35,6 +35,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	app-text/docbook-xml-dtd:4.5
+	app-text/xmlto
 	dev-util/itstool
 	sys-devel/gettext
 	test? (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/660692