### PR TITLE
x11-plugins/wmpager: EAPI7, improve ebuild

### DIFF
--- a/x11-plugins/wmpager/wmpager-1.2-r2.ebuild
+++ b/x11-plugins/wmpager/wmpager-1.2-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="A simple pager docklet for the WindowMaker window manager"
+HOMEPAGE="http://wmpager.sourceforge.net/"
+SRC_URI="mirror://sourceforge/wmpager/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXpm
+	x11-libs/libXext"
+
+src_prepare() {
+	default
+	sed -i "s:\(WMPAGER_DEFAULT_INSTALL_DIR \).*:\1\"/usr/share/wmpager\":" \
+		src/wmpager.c || die
+
+	#Honour Gentoo CFLAGS and LDFLAGS, see bug #337604
+	sed -i -e "s/-g/${CFLAGS}/" \
+		-e "s/\${LIBS}/\${LIBS} \${LDFLAGS}/" \
+		src/Makefile || die
+}
+
+src_install() {
+	emake INSTALLDIR="${ED}/usr" install
+	rm -rf "${ED}"/usr/man || die
+	doman man/man1/*.1x
+	dodoc README
+}


### PR DESCRIPTION
Hi,

Another EAPI update for x11-plugins/wmpager.

Please review

diff -u:
```
--- wmpager-1.2-r1.ebuild       2017-03-19 10:57:15.524786167 +0100
+++ wmpager-1.2-r2.ebuild       2018-07-16 19:04:43.775595879 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
+EAPI=7
 
 DESCRIPTION="A simple pager docklet for the WindowMaker window manager"
 HOMEPAGE="http://wmpager.sourceforge.net/"
@@ -9,28 +9,26 @@
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~sparc ~x86"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXpm
        x11-libs/libXext"
-DEPEND="${RDEPEND}
-       >=sys-apps/sed-4"
 
 src_prepare() {
-       sed -i "s:\(WMPAGER_DEFAULT_INSTALL_DIR \).*:\1\"/usr/share/wmpager\":" src/wmpager.c
-
-       #Honour Gentoo CFLAGS
-       sed -i "s/-g/${CFLAGS}/" src/Makefile
-
-       #Honour Gentoo LDFLAGS, see bug #337604
-       sed -i "s/\${LIBS}/\${LIBS} \${LDFLAGS}/" src/Makefile
+       default
+       sed -i "s:\(WMPAGER_DEFAULT_INSTALL_DIR \).*:\1\"/usr/share/wmpager\":" \
+               src/wmpager.c || die
+
+       #Honour Gentoo CFLAGS and LDFLAGS, see bug #337604
+       sed -i -e "s/-g/${CFLAGS}/" \
+               -e "s/\${LIBS}/\${LIBS} \${LDFLAGS}/" \
+               src/Makefile || die
 }
 
 src_install() {
-       emake INSTALLDIR="${D}/usr" install || die
-       rm -rf "${D}"/usr/man
+       emake INSTALLDIR="${D}/usr" install
+       rm -rf "${D}"/usr/man || die
        doman man/man1/*.1x
        dodoc README
 }
```