### PR TITLE
x11-wm/treewm: EAPI7, improve ebuild

### DIFF
--- a/x11-wm/treewm/files/treewm-0.4.5-gcc43.patch
+++ b/x11-wm/treewm/files/treewm-0.4.5-gcc43.patch
@@ -1,5 +1,5 @@
---- treewm-0.4.5b/src/action.cc	2009-01-17 18:17:32.000000000 -0400
-+++ treewm-0.4.5/src/action.cc	2009-01-17 18:20:41.000000000 -0400
+--- a/src/action.cc	2009-01-17 18:17:32.000000000 -0400
++++ b/src/action.cc	2009-01-17 18:20:41.000000000 -0400
 @@ -9,6 +9,7 @@
  #include "clienttree.h"
  #include "clientinfo.h"
@@ -8,8 +8,8 @@
  
  Action::Action(Section *section) {
    s = section;
---- treewm-0.4.5b/src/resmanager.h	2009-01-17 18:17:32.000000000 -0400
-+++ treewm-0.4.5/src/resmanager.h	2009-01-17 18:21:10.000000000 -0400
+--- a/src/resmanager.h	2009-01-17 18:17:32.000000000 -0400
++++ b/src/resmanager.h	2009-01-17 18:21:10.000000000 -0400
 @@ -12,6 +12,7 @@
  #include "global.h"
  #include "client.h"

--- a/x11-wm/treewm/treewm-0.4.5-r2.ebuild
+++ b/x11-wm/treewm/treewm-0.4.5-r2.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="WindowManager that arranges the windows in a tree (not in a list)"
+HOMEPAGE="http://treewm.sourceforge.net/"
+SRC_URI="mirror://sourceforge/treewm/${P}.tar.bz2"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~ppc ~sparc ~x86"
+
+RDEPEND="
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXxf86vm
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto
+	x11-misc/imake"
+
+src_prepare() {
+	default
+	# bug 251845
+	eapply "${FILESDIR}/${P}-gcc43.patch"
+	# bug 86453
+	sed -i xprop/dsimple.c \
+		-e 's:malloc:Malloc:g' \
+		|| die "sed xprop/dsimple.c"
+}
+
+src_compile() {
+	# only compile treewm, not (x11-apps/){xprop,xkill}
+	emake treewm \
+		CXX=$(tc-getCXX) \
+		CCOPTIONS="${CFLAGS}" \
+		EXTRA_LDOPTIONS="${LDFLAGS}" \
+		PREFIX="/usr" ROOT="${D}"
+}
+
+src_install() {
+	# only install treewm, not (x11-apps/){xprop,xkill}
+	dobin src/treewm
+	dodoc AUTHORS ChangeLog PROBLEMS README README.tiling TODO default.cfg \
+		sample.cfg
+	insinto /usr/share/pixmaps/treewm
+	doins src/pixmaps/*.xpm
+}
+
+pkg_postinst() {
+	elog "x11-wm/treewm used to install its own versions of x11-apps/xprop and"
+	elog "x11-apps/xkill as treewm-xprop and treewm-xkill respectively, since"
+	elog "they are assumed to be broken in combination with treewm. Since"
+	elog "X(org) has become modular since treewm's last release and are not"
+	elog "installed by default, we can leave those out and simply point out"
+	elog "that it is NOT adviseable to use these programs when using treewm."
+}


### PR DESCRIPTION
Hi,

This PR updates x11-wm/treewm for EAPI7.

Please review.

diff -u:
```
--- treewm-0.4.5-r1.ebuild      2018-05-23 19:05:41.685212215 +0200
+++ treewm-0.4.5-r2.ebuild      2018-07-16 19:06:59.473173859 +0200
@@ -1,17 +1,17 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI=7
 
-inherit eutils
+inherit toolchain-funcs
 
 DESCRIPTION="WindowManager that arranges the windows in a tree (not in a list)"
-SRC_URI="mirror://sourceforge/treewm/${P}.tar.bz2"
 HOMEPAGE="http://treewm.sourceforge.net/"
+SRC_URI="mirror://sourceforge/treewm/${P}.tar.bz2"
+
 SLOT="0"
 LICENSE="GPL-2"
 KEYWORDS="~ppc ~sparc ~x86"
-IUSE=""
 
 RDEPEND="
        x11-libs/libX11
@@ -23,8 +23,9 @@
        x11-misc/imake"
 
 src_prepare() {
+       default
        # bug 251845
-       epatch "${FILESDIR}/${P}-gcc43.patch"
+       eapply "${FILESDIR}/${P}-gcc43.patch"
        # bug 86453
        sed -i xprop/dsimple.c \
                -e 's:malloc:Malloc:g' \
@@ -37,8 +38,7 @@
                CXX=$(tc-getCXX) \
                CCOPTIONS="${CFLAGS}" \
                EXTRA_LDOPTIONS="${LDFLAGS}" \
-               PREFIX="/usr" ROOT="${D}" \
-               || die "emake"
+               PREFIX="/usr" ROOT="${D}"
 }
 
 src_install() {
```