### PR TITLE
sci-electronics/puff: EAPI7, improve ebuild

### DIFF
--- a/sci-electronics/puff/puff-20100127-r1.ebuild
+++ b/sci-electronics/puff/puff-20100127-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic
+
+DESCRIPTION="microwave CAD software"
+HOMEPAGE="http://wwwhome.cs.utwente.nl/~ptdeboer/ham/puff/"
+SRC_URI="http://wwwhome.cs.utwente.nl/~ptdeboer/ham/${PN}/${P}.tgz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="x11-libs/libX11"
+DEPEND="${RDEPEND}
+	dev-lang/fpc"
+
+src_prepare() {
+	default
+	# fix lib path for X11 and dont ignore LDFLAGS
+	sed -i -e "s#lib\\\/#$(get_libdir)\\\/#" \
+		-e 's/CFLAGS/#CFLAGS/' \
+		-e 's/link.res pu/link.res $(LDFLAGS) pu/' Makefile || die
+}
+
+src_compile() {
+	LDFLAGS="$(raw-ldflags)"
+	emake -j1
+}
+
+src_install() {
+	dobin puff
+
+	dodoc changelog.txt README.txt
+	newdoc "Puff Manual.pdf" Puff_Manual.pdf
+
+	insinto /usr/share/${PN}
+	doins setup.puf
+	doins -r orig_dev_and_puf_files
+}
+
+pkg_postinst() {
+	elog "You must copy /usr/share/${PN}/setup.puf into your working directory"
+	elog "before using the program."
+}


### PR DESCRIPTION
Hi,

This PR is another small update for sci-electronics/puff.
Please review.

diff -u
```
--- puff-20100127.ebuild        2017-03-19 10:57:14.431786216 +0100
+++ puff-20100127-r1.ebuild     2018-07-16 19:08:37.121716859 +0200
@@ -1,9 +1,9 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI=7
 
-inherit flag-o-matic multilib
+inherit flag-o-matic
 
 DESCRIPTION="microwave CAD software"
 HOMEPAGE="http://wwwhome.cs.utwente.nl/~ptdeboer/ham/puff/"
@@ -12,14 +12,13 @@
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 RDEPEND="x11-libs/libX11"
 DEPEND="${RDEPEND}
-       dev-lang/fpc
-       amd64? ( >=dev-lang/fpc-2.4.0 )"
+       dev-lang/fpc"
 
 src_prepare() {
+       default
        # fix lib path for X11 and dont ignore LDFLAGS
        sed -i -e "s#lib\\\/#$(get_libdir)\\\/#" \
                -e 's/CFLAGS/#CFLAGS/' \
@@ -28,18 +27,18 @@
 
 src_compile() {
        LDFLAGS="$(raw-ldflags)"
-       emake -j1 || die
+       emake -j1
 }
 
 src_install() {
-       dobin puff || die
+       dobin puff
 
-       dodoc changelog.txt README.txt || die
-       newdoc "Puff Manual.pdf" Puff_Manual.pdf || die
+       dodoc changelog.txt README.txt
+       newdoc "Puff Manual.pdf" Puff_Manual.pdf
 
        insinto /usr/share/${PN}
-       doins setup.puf || die
-       doins -r orig_dev_and_puf_files || die
+       doins setup.puf
+       doins -r orig_dev_and_puf_files
 }
 
 pkg_postinst() {
```