### PR TITLE
dev-libs/granite: Don't explicitly set libdir

### DIFF
--- a/dev-libs/granite/granite-0.5.0.ebuild
+++ b/dev-libs/granite/granite-0.5.0.ebuild
@@ -41,7 +41,6 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DLIB_INSTALL_DIR=$(get_libdir)
 		-DVALA_EXECUTABLE=${VALAC}
 	)
 


### PR DESCRIPTION
Tested on amd64 and x86 and both place libs in correct path without variable.

Bug: https://bugs.gentoo.org/659654
