### PR TITLE
sys-firmware/seabios: Actually use iasl to rebuild hex files

### DIFF
--- a/sys-firmware/seabios/seabios-1.11.0-r1.ebuild
+++ b/sys-firmware/seabios/seabios-1.11.0-r1.ebuild
@@ -1,0 +1,145 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+PYTHON_COMPAT=( python{2_7,3_{4,5,6}} )
+
+inherit eutils toolchain-funcs python-any-r1
+
+# SeaBIOS maintainers sometimes don't release stable tarballs or stable
+# binaries to generate the stable tarball the following is necessary:
+# git clone git://git.seabios.org/seabios.git && cd seabios
+# git archive --output seabios-${PV}.tar.gz --prefix seabios-${PV}/ rel-${PV}
+
+if [[ ${PV} == *9999* || -n "${EGIT_COMMIT}" ]] ; then
+	EGIT_REPO_URI="git://git.seabios.org/seabios.git"
+	inherit git-r3
+else
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+
+	# Binary versions taken from fedora:
+	# http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/s/
+	#   seabios-bin-1.10.2-1.fc27.noarch.rpm
+	#   seavgabios-bin-1.10.2-1.fc27.noarch.rpm
+	SRC_URI="
+		!binary? ( https://code.coreboot.org/p/seabios/downloads/get/${P}.tar.gz )
+		binary? ( https://dev.gentoo.org/~tamiko/distfiles/${P}-bin.tar.xz )"
+fi
+
+DESCRIPTION="Open Source implementation of a 16-bit x86 BIOS"
+HOMEPAGE="https://www.seabios.org/"
+
+LICENSE="LGPL-3 GPL-3"
+SLOT="0"
+IUSE="+binary debug +seavgabios"
+
+REQUIRED_USE="debug? ( !binary )
+	!amd64? ( !x86? ( binary ) )"
+
+# The amd64/x86 check is needed to workaround #570892.
+SOURCE_DEPEND="
+	>=sys-power/iasl-20060912
+	${PYTHON_DEPS}"
+DEPEND="
+	!binary? (
+		amd64? ( ${SOURCE_DEPEND} )
+		x86? ( ${SOURCE_DEPEND} )
+	)"
+RDEPEND=""
+
+pkg_pretend() {
+	if ! use binary; then
+		ewarn "You have decided to compile your own SeaBIOS. This is not"
+		ewarn "supported by upstream unless you use their recommended"
+		ewarn "toolchain (which you are not)."
+		elog
+		ewarn "If you are intending to use this build with QEMU, realize"
+		ewarn "you will not receive any support if you have compiled your"
+		ewarn "own SeaBIOS. Virtual machines subtly fail based on changes"
+		ewarn "in SeaBIOS."
+	fi
+}
+
+pkg_setup() {
+	use binary || python-any-r1_pkg_setup
+}
+
+src_unpack() {
+	default
+
+	# This simplifies the logic between binary & source builds.
+	mkdir -p "${S}"
+}
+
+src_prepare() {
+	default
+
+	# Ensure precompiled iasl files are never used
+	find "${WORKDIR}" -name '*.hex' -delete || die
+}
+
+src_configure() {
+	use binary && return
+
+	tc-ld-disable-gold #438058
+
+	if use debug ; then
+		echo "CONFIG_DEBUG_LEVEL=8" >.config
+	fi
+	_emake config
+}
+
+_emake() {
+	LANG=C \
+	emake V=1 \
+		CC="$(tc-getCC)" \
+		LD="$(tc-getLD)" \
+		AR="$(tc-getAR)" \
+		AS="$(tc-getAS)" \
+		OBJCOPY="$(tc-getOBJCOPY)" \
+		RANLIB="$(tc-getRANLIB)" \
+		OBJDUMP="$(tc-getOBJDUMP)" \
+		HOST_CC="$(tc-getBUILD_CC)" \
+		VERSION="Gentoo/${EGIT_COMMIT:-${PVR}}" \
+		"$@"
+}
+
+src_compile() {
+	use binary && return
+
+	cp "${FILESDIR}/seabios/config.seabios-256k" .config || die
+	_emake oldnoconfig
+	_emake iasl
+	_emake out/bios.bin
+	mv out/bios.bin ../bios-256k.bin || die
+
+	if use seavgabios ; then
+		local config t targets=(
+			cirrus
+			isavga
+			qxl
+			stdvga
+			virtio
+			vmware
+		)
+		for t in "${targets[@]}" ; do
+			emake clean distclean
+			cp "${FILESDIR}/seavgabios/config.vga-${t}" .config || die
+			_emake oldnoconfig
+			_emake out/vgabios.bin
+			cp out/vgabios.bin ../vgabios-${t}.bin || die
+		done
+	fi
+}
+
+src_install() {
+	insinto /usr/share/seabios
+	use binary && doins ../bios.bin
+	doins ../bios-256k.bin
+
+	if use seavgabios ; then
+		insinto /usr/share/seavgabios
+		doins ../vgabios*.bin
+	fi
+}


### PR DESCRIPTION
Fixed build to actually use sys-power/iasl (rather than using bundled
pre-compiled hex files). Generated hex files do not match, so to be sure,
I revbumped the ebuild version.

Note: Untested by itself - only with non-x86 cross-compile improvements (to follow in another PR)