### PR TITLE
dev-libs/nmeap: add ~ppc keyword

### DIFF
--- a/dev-libs/nmeap/nmeap-0.3.ebuild
+++ b/dev-libs/nmeap/nmeap-0.3.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="doc"
 
 DEPEND="doc? ( app-doc/doxygen )"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/658734
Package-Manager: Portage-2.3.41, Repoman-2.3.9