### PR TITLE
dev-python/typing: Remove meaningless py3.5+ support

### DIFF
--- a/dev-db/mongodb/mongodb-3.6.2-r1.ebuild
+++ b/dev-db/mongodb/mongodb-3.6.2-r1.ebuild
@@ -39,7 +39,7 @@ DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	dev-python/cheetah[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	<dev-util/scons-3
 	sys-libs/ncurses
 	sys-libs/readline

--- a/dev-db/mongodb/mongodb-3.6.3-r1.ebuild
+++ b/dev-db/mongodb/mongodb-3.6.3-r1.ebuild
@@ -39,7 +39,7 @@ DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	dev-python/cheetah[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	<dev-util/scons-3
 	sys-libs/ncurses
 	sys-libs/readline

--- a/dev-db/mongodb/mongodb-3.6.4-r1.ebuild
+++ b/dev-db/mongodb/mongodb-3.6.4-r1.ebuild
@@ -39,7 +39,7 @@ DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	dev-python/cheetah[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	<dev-util/scons-3
 	sys-libs/ncurses
 	sys-libs/readline

--- a/dev-db/mongodb/mongodb-3.6.5-r1.ebuild
+++ b/dev-db/mongodb/mongodb-3.6.5-r1.ebuild
@@ -39,7 +39,7 @@ DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	dev-python/cheetah[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	<dev-util/scons-3
 	sys-libs/ncurses
 	sys-libs/readline

--- a/dev-db/mongodb/mongodb-4.0.0-r1.ebuild
+++ b/dev-db/mongodb/mongodb-4.0.0-r1.ebuild
@@ -39,7 +39,7 @@ DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	dev-python/cheetah[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	<dev-util/scons-3
 	sys-libs/ncurses
 	sys-libs/readline

--- a/dev-python/ipython/ipython-5.4.1-r1.ebuild
+++ b/dev-python/ipython/ipython-5.4.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{4,5,6} )
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 PYTHON_REQ_USE='readline,sqlite,threads(+)'
 
 inherit distutils-r1 eutils
@@ -14,8 +14,8 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="doc examples matplotlib notebook nbconvert qt5 smp test"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc ppc64 x86 ~amd64-linux ~x86-linux"
+IUSE="doc examples matplotlib notebook nbconvert qt5 +smp test wxwidgets"
 
 CDEPEND="
 	dev-python/decorator[${PYTHON_USEDEP}]
@@ -23,24 +23,26 @@ CDEPEND="
 	dev-python/pexpect[${PYTHON_USEDEP}]
 	dev-python/pickleshare[${PYTHON_USEDEP}]
 	>=dev-python/prompt_toolkit-1.0.4[${PYTHON_USEDEP}]
-	dev-python/pygments[${PYTHON_USEDEP}]
 	dev-python/pyparsing[${PYTHON_USEDEP}]
 	dev-python/simplegeneric[${PYTHON_USEDEP}]
 	>=dev-python/traitlets-4.2.1[${PYTHON_USEDEP}]
 	matplotlib? ( dev-python/matplotlib[${PYTHON_USEDEP}] )
+	wxwidgets? ( $(python_gen_cond_dep 'dev-python/wxpython:*[${PYTHON_USEDEP}]' 'python2*') )
 "
 
 RDEPEND="${CDEPEND}
-	nbconvert? ( dev-python/nbconvert[${PYTHON_USEDEP}] )
-"
-
+	virtual/python-pathlib[${PYTHON_USEDEP}]
+	nbconvert? ( dev-python/nbconvert[${PYTHON_USEDEP}] )"
 DEPEND="${CDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep \
+		'dev-python/backports-shutil_get_terminal_size[${PYTHON_USEDEP}]' 'python2*')
+	virtual/python-typing[${PYTHON_USEDEP}]
 	test? (
 		dev-python/ipykernel[${PYTHON_USEDEP}]
 		dev-python/nbformat[${PYTHON_USEDEP}]
 		dev-python/nose[${PYTHON_USEDEP}]
+		dev-python/pygments[${PYTHON_USEDEP}]
 		dev-python/requests[${PYTHON_USEDEP}]
 		dev-python/testpath[${PYTHON_USEDEP}]
 	)
@@ -48,8 +50,7 @@ DEPEND="${CDEPEND}
 		dev-python/ipykernel[${PYTHON_USEDEP}]
 		dev-python/sphinx[${PYTHON_USEDEP}]
 		dev-python/sphinxcontrib-websupport[${PYTHON_USEDEP}]
-	)
-"
+	)"
 
 PDEPEND="
 	notebook? (
@@ -57,12 +58,11 @@ PDEPEND="
 		dev-python/ipywidgets[${PYTHON_USEDEP}]
 	)
 	qt5? ( dev-python/qtconsole[${PYTHON_USEDEP}] )
-	smp? ( dev-python/ipyparallel[${PYTHON_USEDEP}] )
-"
+	smp? ( dev-python/ipyparallel[${PYTHON_USEDEP}] )"
 
 PATCHES=( "${FILESDIR}"/2.1.0-substitute-files.patch )
 
-#DISTUTILS_IN_SOURCE_BUILD=1
+DISTUTILS_IN_SOURCE_BUILD=1
 
 python_prepare_all() {
 	# Remove out of date insource files
@@ -73,6 +73,7 @@ python_prepare_all() {
 	if use doc; then
 		sed -e "/^    'sphinx.ext.intersphinx',/d" -i docs/source/conf.py || die
 	fi
+
 	distutils-r1_python_prepare_all
 }
 
@@ -104,6 +105,7 @@ python_install() {
 
 python_install_all() {
 	distutils-r1_python_install_all
+
 	if use examples; then
 		dodoc -r examples
 		docompress -x /usr/share/doc/${PF}/examples

--- a/dev-python/ipython/ipython-6.1.0-r1.ebuild
+++ b/dev-python/ipython/ipython-6.1.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 PYTHON_REQ_USE='readline,sqlite,threads(+)'
 
 inherit distutils-r1 eutils
@@ -14,8 +14,8 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 ~ppc ppc64 x86 ~amd64-linux ~x86-linux"
-IUSE="doc examples matplotlib notebook nbconvert qt5 +smp test wxwidgets"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc examples matplotlib notebook nbconvert qt5 smp test"
 
 CDEPEND="
 	dev-python/decorator[${PYTHON_USEDEP}]
@@ -23,26 +23,24 @@ CDEPEND="
 	dev-python/pexpect[${PYTHON_USEDEP}]
 	dev-python/pickleshare[${PYTHON_USEDEP}]
 	>=dev-python/prompt_toolkit-1.0.4[${PYTHON_USEDEP}]
+	dev-python/pygments[${PYTHON_USEDEP}]
 	dev-python/pyparsing[${PYTHON_USEDEP}]
 	dev-python/simplegeneric[${PYTHON_USEDEP}]
 	>=dev-python/traitlets-4.2.1[${PYTHON_USEDEP}]
 	matplotlib? ( dev-python/matplotlib[${PYTHON_USEDEP}] )
-	wxwidgets? ( $(python_gen_cond_dep 'dev-python/wxpython:*[${PYTHON_USEDEP}]' 'python2*') )
 "
 
 RDEPEND="${CDEPEND}
-	virtual/python-pathlib[${PYTHON_USEDEP}]
-	nbconvert? ( dev-python/nbconvert[${PYTHON_USEDEP}] )"
+	nbconvert? ( dev-python/nbconvert[${PYTHON_USEDEP}] )
+"
+
 DEPEND="${CDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]
-	$(python_gen_cond_dep \
-		'dev-python/backports-shutil_get_terminal_size[${PYTHON_USEDEP}]' 'python2*')
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	test? (
 		dev-python/ipykernel[${PYTHON_USEDEP}]
 		dev-python/nbformat[${PYTHON_USEDEP}]
 		dev-python/nose[${PYTHON_USEDEP}]
-		dev-python/pygments[${PYTHON_USEDEP}]
 		dev-python/requests[${PYTHON_USEDEP}]
 		dev-python/testpath[${PYTHON_USEDEP}]
 	)
@@ -50,7 +48,8 @@ DEPEND="${CDEPEND}
 		dev-python/ipykernel[${PYTHON_USEDEP}]
 		dev-python/sphinx[${PYTHON_USEDEP}]
 		dev-python/sphinxcontrib-websupport[${PYTHON_USEDEP}]
-	)"
+	)
+"
 
 PDEPEND="
 	notebook? (
@@ -58,11 +57,12 @@ PDEPEND="
 		dev-python/ipywidgets[${PYTHON_USEDEP}]
 	)
 	qt5? ( dev-python/qtconsole[${PYTHON_USEDEP}] )
-	smp? ( dev-python/ipyparallel[${PYTHON_USEDEP}] )"
+	smp? ( dev-python/ipyparallel[${PYTHON_USEDEP}] )
+"
 
 PATCHES=( "${FILESDIR}"/2.1.0-substitute-files.patch )
 
-DISTUTILS_IN_SOURCE_BUILD=1
+#DISTUTILS_IN_SOURCE_BUILD=1
 
 python_prepare_all() {
 	# Remove out of date insource files
@@ -73,7 +73,6 @@ python_prepare_all() {
 	if use doc; then
 		sed -e "/^    'sphinx.ext.intersphinx',/d" -i docs/source/conf.py || die
 	fi
-
 	distutils-r1_python_prepare_all
 }
 
@@ -105,7 +104,6 @@ python_install() {
 
 python_install_all() {
 	distutils-r1_python_install_all
-
 	if use examples; then
 		dodoc -r examples
 		docompress -x /usr/share/doc/${PF}/examples

--- a/dev-python/m2crypto/m2crypto-0.27.0-r2.ebuild
+++ b/dev-python/m2crypto/m2crypto-0.27.0-r2.ebuild
@@ -23,7 +23,7 @@ IUSE="libressl"
 RDEPEND="
 	!libressl? ( >=dev-libs/openssl-0.9.8:0=[-bindist(-)] )
 	libressl? ( dev-libs/libressl:0= )
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}
 	>=dev-lang/swig-1.3.28:0

--- a/dev-python/m2crypto/m2crypto-0.27.0.ebuild
+++ b/dev-python/m2crypto/m2crypto-0.27.0.ebuild
@@ -23,7 +23,7 @@ IUSE="libressl"
 RDEPEND="
 	!libressl? ( >=dev-libs/openssl-0.9.8:0=[-bindist(-)] )
 	libressl? ( dev-libs/libressl:0= )
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}
 	>=dev-lang/swig-1.3.28:0

--- a/dev-python/promises/promises-2.0.1-r1.ebuild
+++ b/dev-python/promises/promises-2.0.1-r1.ebuild
@@ -7,12 +7,11 @@ PYTHON_COMPAT=( python2_7 python3_{5,6} )
 
 inherit distutils-r1
 
-MY_PN=${PN%s}
-MY_P=${MY_PN}-${PV}
+MY_P=${PN%s}-${PV}
 
 DESCRIPTION="An implementation of Promises in Python"
 HOMEPAGE="https://github.com/syrusakbary/promise"
-SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
+SRC_URI="https://github.com/syrusakbary/${PN%s}/archive/v${PV}.tar.gz -> ${MY_P}.tar.gz"
 
 S=${WORKDIR}/${MY_P}
 
@@ -22,7 +21,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	dev-python/six[${PYTHON_USEDEP}]
 "
 

--- a/dev-python/promises/promises-2.1-r1.ebuild
+++ b/dev-python/promises/promises-2.1-r1.ebuild
@@ -7,11 +7,12 @@ PYTHON_COMPAT=( python2_7 python3_{5,6} )
 
 inherit distutils-r1
 
-MY_P=${PN%s}-${PV}
+MY_PN=${PN%s}
+MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="An implementation of Promises in Python"
 HOMEPAGE="https://github.com/syrusakbary/promise"
-SRC_URI="https://github.com/syrusakbary/${PN%s}/archive/v${PV}.tar.gz -> ${MY_P}.tar.gz"
+SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 S=${WORKDIR}/${MY_P}
 
@@ -21,7 +22,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	dev-python/six[${PYTHON_USEDEP}]
 "
 

--- a/dev-python/sphinx/sphinx-1.6.3-r4.ebuild
+++ b/dev-python/sphinx/sphinx-1.6.3-r4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/S/${PN^}/${P^}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~m68k ppc ppc64 s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x64-solaris"
 IUSE="doc latex net test"
 
 RDEPEND="
@@ -31,7 +31,7 @@ RDEPEND="
 	>=dev-python/sphinx_rtd_theme-0.1[${PYTHON_USEDEP}]
 	<dev-python/sphinx_rtd_theme-2.0[${PYTHON_USEDEP}]
 	dev-python/sphinxcontrib-websupport[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	latex? (
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-luatex

--- a/dev-python/sphinx/sphinx-1.6.5-r1.ebuild
+++ b/dev-python/sphinx/sphinx-1.6.5-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/S/${PN^}/${P^}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x64-solaris"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~m68k ppc ppc64 s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
 IUSE="doc latex net test"
 
 RDEPEND="
@@ -31,7 +31,7 @@ RDEPEND="
 	>=dev-python/sphinx_rtd_theme-0.1[${PYTHON_USEDEP}]
 	<dev-python/sphinx_rtd_theme-2.0[${PYTHON_USEDEP}]
 	dev-python/sphinxcontrib-websupport[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	latex? (
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-luatex

--- a/dev-python/sphinx/sphinx-1.7.5-r1.ebuild
+++ b/dev-python/sphinx/sphinx-1.7.5-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy{,3} )
 PYTHON_REQ_USE="threads(+)"
 
-inherit distutils-r1 eutils versionator
+inherit distutils-r1
 
 DESCRIPTION="Python documentation generator"
 HOMEPAGE="http://www.sphinx-doc.org/"
@@ -25,13 +25,14 @@ RDEPEND="
 	dev-python/imagesize[${PYTHON_USEDEP}]
 	>=dev-python/jinja-2.3[${PYTHON_USEDEP}]
 	>=dev-python/pygments-2.0.1-r1[${PYTHON_USEDEP}]
-	dev-python/requests[${PYTHON_USEDEP}]
+	>=dev-python/requests-2.0.0[${PYTHON_USEDEP}]
 	>=dev-python/six-1.5[${PYTHON_USEDEP}]
 	>=dev-python/snowballstemmer-1.1[${PYTHON_USEDEP}]
 	>=dev-python/sphinx_rtd_theme-0.1[${PYTHON_USEDEP}]
 	<dev-python/sphinx_rtd_theme-2.0[${PYTHON_USEDEP}]
+	dev-python/packaging[${PYTHON_USEDEP}]
 	dev-python/sphinxcontrib-websupport[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	latex? (
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-luatex
@@ -59,10 +60,6 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/${P^}"
 
-PATCHES=(
-	"${FILESDIR}"/${PN}-1.5.1-fix-pycode-grammar.patch
-)
-
 python_prepare_all() {
 	# remove tests that fail due to network-sandbox
 	rm tests/test_websupport.py || die "Failed to remove web tests"
@@ -85,8 +82,8 @@ python_compile() {
 
 python_compile_all() {
 	if use doc; then
-		emake -C doc SPHINXBUILD='"${EPYTHON}" "${S}/sphinx-build.py"' html
-		HTML_DOCS=( doc/_build/html/. )
+		esetup.py build_sphinx
+		HTML_DOCS=( "${BUILD_DIR}"/sphinx/html/. )
 	fi
 }
 
@@ -96,22 +93,4 @@ python_test() {
 	cp -r -l tests "${BUILD_DIR}"/ || die "Failed to copy tests"
 	cp Makefile "${BUILD_DIR}"/ || die "Failed to copy Makefile"
 	emake test
-}
-
-pkg_postinst() {
-	replacing_python_eclass() {
-		local pv
-		for pv in ${REPLACING_VERSIONS}; do
-			if ! version_is_at_least 1.1.3-r4 ${pv}; then
-				return 0
-			fi
-		done
-
-		return 1
-	}
-
-	if replacing_python_eclass; then
-		ewarn "Replaced a very old sphinx version. If you are"
-		ewarn "experiencing problems, please re-emerge sphinx."
-	fi
 }

--- a/dev-python/typing/typing-3.6.2-r1.ebuild
+++ b/dev-python/typing/typing-3.6.2-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
+PYTHON_COMPAT=( python{2_7,3_4} pypy )
 
 inherit distutils-r1
 
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="PSF-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-fbsd ~x64-solaris"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sparc x86 ~amd64-fbsd ~x64-solaris"
 IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-python/typing/typing-3.6.4-r1.ebuild
+++ b/dev-python/typing/typing-3.6.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy{,3} )
+PYTHON_COMPAT=( python{2_7,3_4} pypy )
 
 inherit distutils-r1
 
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="PSF-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sparc x86 ~amd64-fbsd ~x64-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-fbsd ~x64-solaris"
 IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-util/Orange/Orange-3.4.5-r3.ebuild
+++ b/dev-util/Orange/Orange-3.4.5-r3.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	>=dev-python/pyqtgraph-0.10.0[${PYTHON_USEDEP}]
 	dev-python/PyQt5[webkit,svg,${PYTHON_USEDEP}]
 	dev-python/radon[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]
+	virtual/python-typing[${PYTHON_USEDEP}]
 	>=dev-python/xlrd-0.9.2[${PYTHON_USEDEP}]
 	>=sci-libs/scipy-0.11.0[${PYTHON_USEDEP}]
 	>=sci-libs/scikits_learn-0.18.1[${PYTHON_USEDEP}]"

--- a/net-analyzer/nagstamon/nagstamon-3.0.2-r1.ebuild
+++ b/net-analyzer/nagstamon/nagstamon-3.0.2-r1.ebuild
@@ -33,7 +33,7 @@ RDEPEND="${PYTHON_DEPS}
 	dev-python/secretstorage[${PYTHON_USEDEP}]
 	>=dev-python/python-xlib-0.19[${PYTHON_USEDEP}]
 	dev-python/requests-kerberos[${PYTHON_USEDEP}]
-	dev-python/typing[${PYTHON_USEDEP}]"
+	virtual/python-typing[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]"
 

--- a/net-misc/gns3-gui/gns3-gui-1.5.3.1.ebuild
+++ b/net-misc/gns3-gui/gns3-gui-1.5.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,7 @@ RDEPEND="
 	>=dev-python/paramiko-1.15.1[${PYTHON_USEDEP}]
 	>=dev-python/psutil-3.0.0[${PYTHON_USEDEP}]
 	>=net-misc/gns3-converter-1.3.0[${PYTHON_USEDEP}]
-	=net-misc/gns3-server-$PVR[${PYTHON_USEDEP}]
+	~net-misc/gns3-server-${PV}[${PYTHON_USEDEP}]
 	dev-qt/qtgui:5
 	dev-qt/qtsvg:5
 	dev-python/PyQt5[gui,network,svg,widgets,${PYTHON_USEDEP}]

--- a/net-misc/gns3-gui/gns3-gui-2.0.3-r1.ebuild
+++ b/net-misc/gns3-gui/gns3-gui-2.0.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -24,7 +24,7 @@ RDEPEND="
 	>=dev-python/ws4py-0.3.4[${PYTHON_USEDEP}]
 	>=dev-python/requests-2.6.0[${PYTHON_USEDEP}]
 	>=dev-python/paramiko-1.15.1[${PYTHON_USEDEP}]
-	=net-misc/gns3-server-$PVR[${PYTHON_USEDEP}]
+	~net-misc/gns3-server-${PV}[${PYTHON_USEDEP}]
 	dev-python/PyQt5[gui,network,svg,widgets,${PYTHON_USEDEP}]
 "
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/net-misc/gns3-gui/gns3-gui-2.1.3-r1.ebuild
+++ b/net-misc/gns3-gui/gns3-gui-2.1.3-r1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	>=dev-python/ws4py-0.3.4[${PYTHON_USEDEP}]
 	>=dev-python/requests-2.6.0[${PYTHON_USEDEP}]
 	>=dev-python/paramiko-1.15.1[${PYTHON_USEDEP}]
-	~net-misc/gns3-server-$PV[${PYTHON_USEDEP}]
+	~net-misc/gns3-server-${PV}[${PYTHON_USEDEP}]
 	dev-python/PyQt5[gui,network,svg,websockets,widgets,${PYTHON_USEDEP}]
 "
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/net-misc/gns3-server/gns3-server-1.5.3.1-r1.ebuild
+++ b/net-misc/gns3-server/gns3-server-1.5.3.1-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{4,5,6} )
+PYTHON_COMPAT=( python3_4 )
 
 inherit distutils-r1 eutils
 
@@ -13,34 +13,25 @@ SRC_URI="https://github.com/GNS3/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64"
 RESTRICT="test"
 
 RDEPEND=">=app-emulation/dynamips-0.2.12
-		>=dev-python/aiohttp-2.2.0[${PYTHON_USEDEP}]
-		<dev-python/aiohttp-cors-0.6[${PYTHON_USEDEP}]
-		>=dev-python/aiohttp-cors-0.5.3[${PYTHON_USEDEP}]
+		>=dev-python/aiohttp-1.2.0[${PYTHON_USEDEP}]
+		>=dev-python/aiohttp-cors-0.5.0[${PYTHON_USEDEP}]
 		>=dev-python/docker-py-1.4.0[${PYTHON_USEDEP}]
 		>=dev-python/netifaces-0.8-r2[${PYTHON_USEDEP}]
 		>=dev-python/jinja-2.7.3[${PYTHON_USEDEP}]
 		>=dev-python/jsonschema-2.4.0[${PYTHON_USEDEP}]
 		>=dev-python/libcloud-0.14.1[${PYTHON_USEDEP}]
-		>=dev-python/raven-5.23.0[${PYTHON_USEDEP}]
-		dev-python/prompt_toolkit[${PYTHON_USEDEP}]
+		>=dev-python/raven-5.2.0[${PYTHON_USEDEP}]
 		>=dev-python/psutil-3.0.0[${PYTHON_USEDEP}]
 		>=dev-python/pyzmq-14.3.1[${PYTHON_USEDEP}]
 		>=dev-python/python-zipstream-1.1.4[${PYTHON_USEDEP}]
 		>=www-servers/tornado-3.1.1[${PYTHON_USEDEP}]
-		>=dev-python/typing-3.5.3.0[${PYTHON_USEDEP}]
-		>=dev-python/yarl-0.11[${PYTHON_USEDEP}]"
+		virtual/python-typing[${PYTHON_USEDEP}]
+		>=dev-python/yarl-0.7.0[${PYTHON_USEDEP}]"
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
-
-src_prepare() {
-	default
-
-	# Package installs 'tests' package which is forbidden
-	rm -rf tests || die
-}
 
 pkg_postinst() {
 	ewarn "net-misc/gns3-server has several optional packages that must be merged manually for additional functionality."

--- a/net-misc/gns3-server/gns3-server-2.0.3-r2.ebuild
+++ b/net-misc/gns3-server/gns3-server-2.0.3-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_4 )
+PYTHON_COMPAT=( python3_{4,5} )
 
 inherit distutils-r1 eutils
 
@@ -13,25 +13,30 @@ SRC_URI="https://github.com/GNS3/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86"
 RESTRICT="test"
 
 RDEPEND=">=app-emulation/dynamips-0.2.12
-		>=dev-python/aiohttp-1.2.0[${PYTHON_USEDEP}]
-		>=dev-python/aiohttp-cors-0.5.0[${PYTHON_USEDEP}]
+		=dev-python/aiohttp-1.3.5*[${PYTHON_USEDEP}]
+		=dev-python/aiohttp-cors-0.5.1[${PYTHON_USEDEP}]
 		>=dev-python/docker-py-1.4.0[${PYTHON_USEDEP}]
 		>=dev-python/netifaces-0.8-r2[${PYTHON_USEDEP}]
 		>=dev-python/jinja-2.7.3[${PYTHON_USEDEP}]
 		>=dev-python/jsonschema-2.4.0[${PYTHON_USEDEP}]
 		>=dev-python/libcloud-0.14.1[${PYTHON_USEDEP}]
-		>=dev-python/raven-5.2.0[${PYTHON_USEDEP}]
+		>=dev-python/raven-5.23.0[${PYTHON_USEDEP}]
 		>=dev-python/psutil-3.0.0[${PYTHON_USEDEP}]
 		>=dev-python/pyzmq-14.3.1[${PYTHON_USEDEP}]
 		>=dev-python/python-zipstream-1.1.4[${PYTHON_USEDEP}]
 		>=www-servers/tornado-3.1.1[${PYTHON_USEDEP}]
-		>=dev-python/typing-3.5.3.0[${PYTHON_USEDEP}]
-		>=dev-python/yarl-0.7.0[${PYTHON_USEDEP}]"
+		virtual/python-typing[${PYTHON_USEDEP}]
+		~dev-python/yarl-0.9.8[${PYTHON_USEDEP}]"
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+
+src_prepare() {
+	rm -rf tests || die
+	eapply_user
+}
 
 pkg_postinst() {
 	ewarn "net-misc/gns3-server has several optional packages that must be merged manually for additional functionality."

--- a/net-misc/gns3-server/gns3-server-2.1.3-r2.ebuild
+++ b/net-misc/gns3-server/gns3-server-2.1.3-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{4,5} )
+PYTHON_COMPAT=( python3_{4,5,6} )
 
 inherit distutils-r1 eutils
 
@@ -17,25 +17,29 @@ KEYWORDS="~amd64 ~x86"
 RESTRICT="test"
 
 RDEPEND=">=app-emulation/dynamips-0.2.12
-		=dev-python/aiohttp-1.3.5*[${PYTHON_USEDEP}]
-		=dev-python/aiohttp-cors-0.5.1[${PYTHON_USEDEP}]
+		>=dev-python/aiohttp-2.2.0[${PYTHON_USEDEP}]
+		<dev-python/aiohttp-cors-0.6[${PYTHON_USEDEP}]
+		>=dev-python/aiohttp-cors-0.5.3[${PYTHON_USEDEP}]
 		>=dev-python/docker-py-1.4.0[${PYTHON_USEDEP}]
 		>=dev-python/netifaces-0.8-r2[${PYTHON_USEDEP}]
 		>=dev-python/jinja-2.7.3[${PYTHON_USEDEP}]
 		>=dev-python/jsonschema-2.4.0[${PYTHON_USEDEP}]
 		>=dev-python/libcloud-0.14.1[${PYTHON_USEDEP}]
 		>=dev-python/raven-5.23.0[${PYTHON_USEDEP}]
+		dev-python/prompt_toolkit[${PYTHON_USEDEP}]
 		>=dev-python/psutil-3.0.0[${PYTHON_USEDEP}]
 		>=dev-python/pyzmq-14.3.1[${PYTHON_USEDEP}]
 		>=dev-python/python-zipstream-1.1.4[${PYTHON_USEDEP}]
 		>=www-servers/tornado-3.1.1[${PYTHON_USEDEP}]
-		>=dev-python/typing-3.5.3.0[${PYTHON_USEDEP}]
-		~dev-python/yarl-0.9.8[${PYTHON_USEDEP}]"
+		virtual/python-typing[${PYTHON_USEDEP}]
+		>=dev-python/yarl-0.11[${PYTHON_USEDEP}]"
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 
 src_prepare() {
+	default
+
+	# Package installs 'tests' package which is forbidden
 	rm -rf tests || die
-	eapply_user
 }
 
 pkg_postinst() {

--- a/virtual/python-typing/python-typing-0-r1.ebuild
+++ b/virtual/python-typing/python-typing-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,4 +14,4 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
 	$(python_gen_cond_dep 'dev-python/typing[${PYTHON_USEDEP}]' \
-	'python2*' python3_4 'pypy*')"
+	'python2*' python3_4 pypy)"


### PR DESCRIPTION
Remove the PYTHON_COMPAT for py3.5+.  This module is built-in in those
Python versions, so it should not be ever used.