### PR TITLE
media-video/flvstreamer: add EAPI7 ebuild

### DIFF
--- a/media-video/flvstreamer/flvstreamer-2.1c-r1.ebuild
+++ b/media-video/flvstreamer/flvstreamer-2.1c-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Open source command-line RTMP client intended to stream audio or video flash content"
+HOMEPAGE="https://savannah.nongnu.org/projects/flvstreamer/"
+SRC_URI="mirror://nongnu/${PN}/source/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+S="${WORKDIR}/${PN}"
+
+src_prepare() {
+	default
+	#fix Makefile ( bug #298535 and bug #318353)
+	sed -i 's/\$(MAKEFLAGS)//g' Makefile \
+		|| die "failed to fix Makefile"
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" \
+		CXX="$(tc-getCXX)" \
+		CFLAGS="${CFLAGS} `sed -n 's/DEF=\(.*\)/\1/p' Makefile`" \
+		CXXFLAGS="${CXXFLAGS}" \
+		LDFLAGS="${LDFLAGS}" linux
+}
+
+src_install() {
+	dobin {${PN},streams}
+	dodoc README ChangeLog
+}


### PR DESCRIPTION
Hi,

Another simple update for flvstreamer to bring it to EAPI7:
Please review.

diff -u:
```
--- flvstreamer-2.1c.ebuild     2018-02-15 12:46:56.148532208 +0100
+++ flvstreamer-2.1c-r1.ebuild  2018-07-16 19:20:56.097373486 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI=7
 
 inherit toolchain-funcs
 
@@ -11,14 +11,15 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
+
 S="${WORKDIR}/${PN}"
 
 src_prepare() {
+       default
        #fix Makefile ( bug #298535 and bug #318353)
        sed -i 's/\$(MAKEFLAGS)//g' Makefile \
-               || die "failed to fixe Makefile"
+               || die "failed to fix Makefile"
 }
 
 src_compile() {
@@ -30,6 +31,6 @@
 }
 
 src_install() {
-       dobin {${PN},streams} || die "dobin failed"
-       dodoc README ChangeLog || die "dodoc failed"
+       dobin {${PN},streams}
+       dodoc README ChangeLog
 }
```