### PR TITLE
dev-ruby/rubygems: add GPL-2 to the LICENSE to cover init script ... and switch to --user

### DIFF
--- a/dev-ruby/rubygems/files/init.d-gem_server2
+++ b/dev-ruby/rubygems/files/init.d-gem_server2
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2008 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 PID=/var/run/gem_server.pid
@@ -10,8 +10,9 @@ depend() {
 
 start() {
 	ebegin "Starting gem_server"
-	start-stop-daemon --start --chuid nobody --quiet --background --make-pidfile \
-		 --pidfile ${PID} --exec /usr/bin/ruby -- /usr/bin/gem server ${GEM_SERVER_OPTS}
+	start-stop-daemon --start --user nobody --quiet --background \
+		--make-pidfile --pidfile ${PID} --exec /usr/bin/ruby -- \
+		/usr/bin/gem server ${GEM_SERVER_OPTS}
 	eend ${?}
 }
 

--- a/dev-ruby/rubygems/rubygems-2.7.6-r1.ebuild
+++ b/dev-ruby/rubygems/rubygems-2.7.6-r1.ebuild
@@ -9,7 +9,7 @@ inherit ruby-ng prefix
 
 DESCRIPTION="Centralized Ruby extension management system"
 HOMEPAGE="https://rubygems.org/"
-LICENSE="|| ( Ruby MIT )"
+LICENSE="GPL-2 || ( Ruby MIT )"
 
 SRC_URI="https://rubygems.org/rubygems/${P}.tgz"
 

--- a/dev-ruby/rubygems/rubygems-2.7.7-r1.ebuild
+++ b/dev-ruby/rubygems/rubygems-2.7.7-r1.ebuild
@@ -9,7 +9,7 @@ inherit ruby-ng prefix
 
 DESCRIPTION="Centralized Ruby extension management system"
 HOMEPAGE="https://rubygems.org/"
-LICENSE="|| ( Ruby MIT )"
+LICENSE="GPL-2 || ( Ruby MIT )"
 
 SRC_URI="https://rubygems.org/rubygems/${P}.tgz"
 


### PR DESCRIPTION
Using GPL-2 for the init script would add that licence to this ebuild,
while the original software is not GPL-2. Simply remove licence
information to get rid of that problem.
Also change --chuid to --user to get rid of warning when starting, and
bump ebuild to -r1 to force remerge.

Bug: https://bugs.gentoo.org/425936
Signed-off-by: Henning Schild <henning@hennsch.de>