### PR TITLE
dev-libs: removal of unneeded xorg-2 usage

### DIFF
--- a/dev-libs/libevdev/libevdev-1.5.9-r1.ebuild
+++ b/dev-libs/libevdev/libevdev-1.5.9-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
+
+inherit multilib-minimal python-any-r1
+
+DESCRIPTION="Handler library for evdev events"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libevdev/"
+
+if [[ ${PV} == 9999* ]] ; then
+	EGIT_REPO_URI="https://anongit.freedesktop.org/git/libevdev.git"
+	inherit autotools git-r3
+else
+	SRC_URI="https://www.freedesktop.org/software/libevdev/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="doc static-libs"
+
+BDEPEND="
+	${PYTHON_DEPS}
+	doc? ( app-doc/doxygen )
+	virtual/pkgconfig
+"
+RESTRICT="test" # Tests need to run as root.
+
+src_prepare() {
+	default
+	[[ ${PV} == 9999* ]] && eautoreconf
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf $(use_enable static-libs static)
+}
+
+multilib_src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+	if use doc ;then
+		local HTML_DOCS=( doc/html/. )
+		einstalldocs
+	fi
+}

--- a/dev-libs/libevdev/libevdev-9999.ebuild
+++ b/dev-libs/libevdev/libevdev-9999.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
+
+inherit multilib-minimal python-any-r1
+
+DESCRIPTION="Handler library for evdev events"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/libevdev/"
+
+if [[ ${PV} == 9999* ]] ; then
+	EGIT_REPO_URI="https://anongit.freedesktop.org/git/libevdev.git"
+	inherit autotools git-r3
+else
+	SRC_URI="https://www.freedesktop.org/software/libevdev/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="doc static-libs"
+
+BDEPEND="
+	${PYTHON_DEPS}
+	doc? ( app-doc/doxygen )
+	virtual/pkgconfig
+"
+RESTRICT="test" # Tests need to run as root.
+
+src_prepare() {
+	default
+	[[ ${PV} == 9999* ]] && eautoreconf
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf $(use_enable static-libs static)
+}
+
+multilib_src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+	if use doc ;then
+		local HTML_DOCS=( doc/html/. )
+		einstalldocs
+	fi
+}

--- a/dev-libs/libpthread-stubs/libpthread-stubs-0.4-r1.ebuild
+++ b/dev-libs/libpthread-stubs/libpthread-stubs-0.4-r1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal
+
+DESCRIPTION="Pthread functions stubs for platforms missing them"
+HOMEPAGE="https://www.x.org/wiki/"
+SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-fbsd ~x86-fbsd ~amd64-linux ~arm-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE=""
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf
+}
+
+# there is nothing to compile for this package, all its contents are produced by
+# configure. the only make job that matters is make install
+multilib_src_compile() { true; }


### PR DESCRIPTION
dev-libs/libevdev: bog standard autotools build system. Only needs
multilib-minimal to be able to build with `USE="abi_x86_32"`. Added doc to
IUSE.

dev-libs/libpthread-stubs: almost pure autotools; pkg-config files are generated
by configure, and make is only used for make install. Only needs mutilib-minimal
to build with `USE="abi_x86_32"`.