### PR TITLE
media-libs/rubberband: add missing eapply_user

### DIFF
--- a/media-libs/rubberband/rubberband-1.8.1-r2.ebuild
+++ b/media-libs/rubberband/rubberband-1.8.1-r2.ebuild
@@ -28,6 +28,7 @@ src_prepare() {
 			-i Makefile.in || die
 	fi
 	multilib_copy_sources
+	eapply_user
 }
 
 multilib_src_install() {


### PR DESCRIPTION
See https://github.com/gentoo/gentoo/pull/9178#issuecomment-404616410

Since this ebuild was not working, should I still revbump it?

Sorry for the noise.

@prometheanfire 
Package-Manager: Portage-2.3.41, Repoman-2.3.9