### PR TITLE
dev-util/qdevicemonitor: fix Qt 5.11 specific issues

### DIFF
--- a/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-crash-after-fresh-install.patch
+++ b/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-crash-after-fresh-install.patch
@@ -1,0 +1,26 @@
+From 079bc4cf3a59a98c429b1db21fcf3f88c19d2bb5 Mon Sep 17 00:00:00 2001
+From: Alexander Lopatin <alopatindev@gmail.com>
+Date: Fri, 13 Jul 2018 18:37:42 +0300
+Subject: [PATCH] fix crash that happens after fresh installation
+
+---
+ qdevicemonitor/devices/DeviceFacade.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qdevicemonitor/devices/DeviceFacade.cpp b/qdevicemonitor/devices/DeviceFacade.cpp
+index ced04b3..6df67eb 100644
+--- a/qdevicemonitor/devices/DeviceFacade.cpp
++++ b/qdevicemonitor/devices/DeviceFacade.cpp
+@@ -151,8 +151,8 @@ void DeviceFacade::loadSettings(const QSettings& s)
+     if (darkTheme.isValid())
+     {
+         m_darkTheme = darkTheme.toBool();
+-        m_colorTheme = ColorTheme::create(m_darkTheme);
+     }
++    m_colorTheme = ColorTheme::create(m_darkTheme);
+ 
+     const QVariant clearAndroidLog = s.value("clearAndroidLog");
+     if (clearAndroidLog.isValid())
+-- 
+2.16.4
+

--- a/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-qt-5.11.patch
+++ b/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-qt-5.11.patch
@@ -1,0 +1,24 @@
+From 5da5c11ff84cc293b5db3a0d7ba09c62b3db94a8 Mon Sep 17 00:00:00 2001
+From: Alexander Lopatin <alopatindev@gmail.com>
+Date: Fri, 13 Jul 2018 18:30:21 +0300
+Subject: [PATCH] fix Qt 5.11 specific issue https://bugs.gentoo.org/660932
+
+---
+ qdevicemonitor/ui/MainWindow.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/qdevicemonitor/ui/MainWindow.cpp b/qdevicemonitor/ui/MainWindow.cpp
+index c1bf263..fc22b4d 100644
+--- a/qdevicemonitor/ui/MainWindow.cpp
++++ b/qdevicemonitor/ui/MainWindow.cpp
+@@ -31,6 +31,7 @@
+ #include <QProcess>
+ #include <QSettings>
+ #include <QStringList>
++#include <QTabBar>
+ #include <QtCore/QStringBuilder>
+ 
+ #if defined(Q_OS_WIN32)
+-- 
+2.16.4
+

--- a/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r1.ebuild
+++ b/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -26,6 +26,8 @@ RDEPEND="
 	dev-util/android-tools
 	app-pda/usbmuxd"
 DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}"/${P}-qt-5.11.patch "${FILESDIR}"/${P}-crash-after-fresh-install.patch )
 
 src_configure() {
 	cd "${PN}" || die


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/660932
Package-Manager: Portage-2.3.40, Repoman-2.3.9