### PR TITLE
WIP: Remove wxGTK:2.8

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -616,6 +616,12 @@ sys-devel/automake:1.6
 sys-devel/automake:1.7
 sys-devel/automake:1.8
 
+# Mart Raudsepp <leio@gentoo.org> (12 Oct 2017)
+# Ancient SLOT, use newer wxGTK versions instead
+# https://bugs.gentoo.org/562480
+x11-libs/wxGTK:2.8
+dev-python/wxpython:2.8
+
 # Kent Fredric <kentnl@gentoo.org> (11 Oct 2017)
 # This package should now be provided entirely by dev-lang/perl,
 # stable perl 5.24 provides Unicode-Collate-1.140.0


### PR DESCRIPTION
CI check for wxGTK:2.8 SLOT removal. https://bugs.gentoo.org/562480
Continuation from #5927 