### PR TITLE
media-video/super_demux: EAPI7, improve ebuild

### DIFF
--- a/media-video/super_demux/super_demux-0.3-r1.ebuild
+++ b/media-video/super_demux/super_demux-0.3-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs flag-o-matic
+
+DESCRIPTION="DVB transport stream TS to ES demultiplexer"
+HOMEPAGE="http://panteltje.com/panteltje/dvd/"
+SRC_URI="http://panteltje.com/panteltje/dvd/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=( "${FILESDIR}/${P}.diff" )
+
+src_compile() {
+	append-flags -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE	-D_LARGEFILE64_SOURCE
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
+}
+
+src_install() {
+	dobin super_demux
+	dodoc CHANGES README
+}


### PR DESCRIPTION
Hi,

This PR updates media-video/super_demux for EAPI7.
Please review.

diff -u:
```
--- super_demux-0.3.ebuild      2017-03-19 10:57:13.763786246 +0100
+++ super_demux-0.3-r1.ebuild   2018-07-16 20:08:53.006106597 +0200
@@ -1,11 +1,9 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI=7
 
-inherit eutils toolchain-funcs flag-o-matic
-
-IUSE=""
+inherit toolchain-funcs flag-o-matic
 
 DESCRIPTION="DVB transport stream TS to ES demultiplexer"
 HOMEPAGE="http://panteltje.com/panteltje/dvd/"
@@ -15,13 +13,11 @@
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-src_prepare() {
-       epatch "${FILESDIR}/${P}.diff"
-}
+PATCHES=( "${FILESDIR}/${P}.diff" )
 
 src_compile() {
        append-flags -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE
-       emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}" || die "emake failed"
+       emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
 }
 
 src_install() {
```