### PR TITLE
app-benchmarks/i7z: Support PKG_CONFIG variable

### DIFF
--- a/app-benchmarks/i7z/files/i7z-0.27.2-ncurses.patch
+++ b/app-benchmarks/i7z/files/i7z-0.27.2-ncurses.patch
@@ -7,7 +7,7 @@ Index: Makefile
  CC       ?= gcc
  
 -LIBS  += -lncurses -lpthread -lrt -lm
-+LIBS  += `pkg-config --libs ncurses` -lpthread -lrt -lm
++LIBS  += `$(PKG_CONFIG) --libs ncurses` -lpthread -lrt -lm
  INCLUDEFLAGS = 
  
  BIN	= i7z
@@ -16,7 +16,7 @@ Index: Makefile
  #http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=644728 for -ltinfo on debian
  static-bin: message $(OBJ)
 -	$(CC) $(CFLAGS) $(LDFLAGS) -o $(BIN) $(OBJ) -static-libgcc -DNCURSES_STATIC -static -lpthread -lncurses -lrt -lm -ltinfo
-+	$(CC) $(CFLAGS) $(LDFLAGS) -o $(BIN) $(OBJ) -static-libgcc -DNCURSES_STATIC -static -lpthread `pkg-config --static --libs ncurses` -lrt -lm
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $(BIN) $(OBJ) -static-libgcc -DNCURSES_STATIC -static -lpthread `$(PKG_CONFIG) --static --libs ncurses` -lrt -lm
  
  # perfmon-bin: message $(OBJ)
  # 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(PERFMON-BIN) perfmon-i7z.c helper_functions.c $(LIBS)

--- a/app-benchmarks/i7z/i7z-93_p20131012-r1.ebuild
+++ b/app-benchmarks/i7z/i7z-93_p20131012-r1.ebuild
@@ -45,7 +45,7 @@ src_configure() {
 	# Looks to work fine for me with -O2 (pacho - 20170530)
 #	filter-flags "-O*"
 
-	tc-export CC
+	tc-export CC PKG_CONFIG
 	cd GUI || die
 
 	use qt5 && eqmake5 ${PN}_GUI.pro

--- a/app-benchmarks/i7z/i7z-93_p20131012-r2.ebuild
+++ b/app-benchmarks/i7z/i7z-93_p20131012-r2.ebuild
@@ -40,7 +40,7 @@ PATCHES=(
 S="${WORKDIR}/${PN}-${COMMIT}"
 
 src_configure() {
-	tc-export CC
+	tc-export CC PKG_CONFIG
 	cd GUI || die
 	use qt5 && eqmake5 ${PN}_GUI.pro
 }


### PR DESCRIPTION
- Replace hardcoded use of pkg-config in ncurses patch