### PR TITLE
mysql-multilib-r1.eclass: fix galera postinst wording

### DIFF
--- a/eclass/mysql-multilib-r1.eclass
+++ b/eclass/mysql-multilib-r1.eclass
@@ -720,9 +720,8 @@ mysql-multilib-r1_pkg_postinst() {
 			einfo
 			elog "Be sure to edit the my.cnf file to activate your cluster settings."
 			elog "This should be done after running \"emerge --config =${CATEGORY}/${PF}\""
-			elog "The first time the cluster is activated, you should add"
-			elog "--wsrep-new-cluster to the options in /etc/conf.d/mysql for one node."
-			elog "This option should then be removed for subsequent starts."
+			elog "The first time the galera cluster is activated, the database daemon"
+			elog "should be run as \"/etc/init.d/mysql bootstrap_galera\" on the primary node."
 			einfo
 		fi
 	fi


### PR DESCRIPTION
The current one confuses people a lot (and me either). We should do nothing manually, also clarify it a bit.

@gentoo/mysql 