### PR TITLE
media-video/subcheck: EAPI7, improve ebuild

### DIFF
--- a/media-video/subcheck/subcheck-0.78.2-r1.ebuild
+++ b/media-video/subcheck/subcheck-0.78.2-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Subcheck checks srt subtitle files for errors"
+HOMEPAGE="http://subcheck.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="!sci-biology/ncbi-tools++"  # bug 377093
+
+S="${WORKDIR}/${PN}"
+
+src_prepare() {
+	default
+	sed -i -e "s:${PN}.pl:${PN}:g" all-checksub || die
+}
+
+src_compile() { :; }
+
+src_install() {
+	doman man/subcheck.8.gz
+	newbin subcheck.pl subcheck
+	dobin all-checksub
+	dodoc Changes
+}


### PR DESCRIPTION
Hi,

This is a simple PR to update media-video/subcheck for EAPI7.
Please review.

diff -u:
```
--- subcheck-0.78.2.ebuild      2017-03-19 10:57:13.762786247 +0100
+++ subcheck-0.78.2-r1.ebuild   2018-07-18 19:46:52.573642475 +0200
@@ -1,9 +1,7 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
-
-inherit eutils
+EAPI=7
 
 DESCRIPTION="Subcheck checks srt subtitle files for errors"
 HOMEPAGE="http://subcheck.sourceforge.net/"
@@ -12,20 +10,17 @@
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="!sci-biology/ncbi-tools++"  # bug 377093
-RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}"
 
 src_prepare() {
-       sed -i -e "s:${PN}.pl:${PN}:g" all-checksub
+       default
+       sed -i -e "s:${PN}.pl:${PN}:g" all-checksub || die
 }
 
-src_compile() {
-       :  # nothing to do
-}
+src_compile() { :; }
 
 src_install() {
        doman man/subcheck.8.gz
```