### PR TITLE
app-emulation/virtualbox: add missing dep on media-libs/opus

### DIFF
--- a/app-emulation/virtualbox/virtualbox-5.2.16.ebuild
+++ b/app-emulation/virtualbox/virtualbox-5.2.16.ebuild
@@ -28,6 +28,7 @@ RDEPEND="!app-emulation/virtualbox-bin
 	dev-libs/libxml2
 	media-libs/libpng:0=
 	media-libs/libvpx:0=
+	media-libs/opus:0=
 	sys-libs/zlib
 	!headless? (
 		media-libs/libsdl:0[X,video]


### PR DESCRIPTION
Even with USE="headless -alsa -qt5" its required to build, and assumed
run (VBoxSVC contains references to it but not in ldd).

Package-Manager: Portage-2.3.43, Repoman-2.3.10