### PR TITLE
media-video/m2vrequantizer: EAPI7, improve ebuild

### DIFF
--- a/media-video/m2vrequantizer/m2vrequantizer-0.0.2_pre20060306-r1.ebuild
+++ b/media-video/m2vrequantizer/m2vrequantizer-0.0.2_pre20060306-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+MY_P="${PN/m2vr/M2VR}-20060306"
+
+DESCRIPTION="Tool to requantize mpeg2 videos"
+HOMEPAGE="http://www.metakine.com/products/dvdremaster/modules.html"
+SRC_URI="mirror://vdrfiles/requant/${MY_P}.tgz"
+
+KEYWORDS="~amd64 ~x86"
+SLOT="0"
+LICENSE="GPL-2"
+
+S="${WORKDIR}/M2VRequantiser"
+
+src_prepare() {
+	default
+	sed -i "s:#elif defined(__i386__):#elif defined(__i386__) || defined(__amd64__):" main.c || die
+}
+
+src_compile() {
+	$(tc-getCC) -c ${CFLAGS} main.c -o requant.o || die
+	$(tc-getCC) ${CFLAGS} ${LDFLAGS} requant.o -o requant -lm || die
+}
+
+src_install() {
+	dobin requant
+}


### PR DESCRIPTION
Hi,

Another small EAPI update for a rather old package.
Please review.

diff -u:
```
--- m2vrequantizer-0.0.2_pre20060306.ebuild     2017-11-20 12:10:29.597696993 +0100
+++ m2vrequantizer-0.0.2_pre20060306-r1.ebuild  2018-07-19 09:15:16.273094227 +0200
@@ -1,7 +1,9 @@
-# Copyright 1999-2008 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2

-EAPI="2"
+EAPI=7
+
+inherit toolchain-funcs

 MY_P="${PN/m2vr/M2VR}-20060306"

@@ -9,28 +11,22 @@
 HOMEPAGE="http://www.metakine.com/products/dvdremaster/modules.html"
 SRC_URI="mirror://vdrfiles/requant/${MY_P}.tgz"

-KEYWORDS="~amd64 x86"
+KEYWORDS="~amd64 ~x86"
 SLOT="0"
 LICENSE="GPL-2"
-IUSE=""
-
-DEPEND=""
-RDEPEND="${DEPEND}"

-S=${WORKDIR}/M2VRequantiser
+S="${WORKDIR}/M2VRequantiser"

 src_prepare() {
-
-       sed -i "s:#elif defined(__i386__):#elif defined(__i386__) || defined(__amd64__):" main.c
+       default
+       sed -i "s:#elif defined(__i386__):#elif defined(__i386__) || defined(__amd64__):" main.c || die
 }

 src_compile() {
-
-       gcc -c ${CFLAGS} main.c -o requant.o
-       gcc ${CFLAGS} ${LDFLAGS} requant.o -o requant -lm
+       $(tc-getCC) -c ${CFLAGS} main.c -o requant.o || die
+       $(tc-getCC) ${CFLAGS} ${LDFLAGS} requant.o -o requant -lm || die
 }

 src_install() {
-
        dobin requant
 }
```