### PR TITLE
skel.ebuild: Update EAPI in skeleton ebuild to version 7

### DIFF
--- a/skel.ebuild
+++ b/skel.ebuild
@@ -10,7 +10,7 @@
 # It is suggested that you use the latest EAPI approved by the Council.
 # The PMS contains specifications for all EAPIs. Eclasses will test for this
 # variable if they need to use features that are not universal in all EAPIs.
-EAPI=6
+EAPI=7
 
 # inherit lists eclasses to inherit functions from. For example, an ebuild
 # that needs the eautoreconf function from autotools.eclass won't work


### PR DESCRIPTION
I recently created a new package and used [skel.ebuild](https://github.com/gentoo/gentoo/blob/master/skel.ebuild) as a template. The skeleton ebuild file comes with `EAPI=6`, but I was asked to use version 7 instead. According to comments on recent pull requests, I was not the only one, and I created this PR to help avoid future ebuild authors falling into the same trap.