### PR TITLE
sys-fs/mtpfs: EAPI7, improve ebuild

### DIFF
--- a/sys-fs/mtpfs/files/mtpfs-1.1-unitialized-variable.patch
+++ b/sys-fs/mtpfs/files/mtpfs-1.1-unitialized-variable.patch
@@ -1,6 +1,6 @@
 https://bugs.gentoo.org/556690
---- mtpfs.c.old	2015-08-04 21:56:13.080712801 +0200
-+++ mtpfs.c	2015-08-04 21:20:54.822965092 +0200
+--- a/mtpfs.c	2015-08-04 21:56:13.080712801 +0200
++++ b/mtpfs.c	2015-08-04 21:20:54.822965092 +0200
 @@ -1324,7 +1324,7 @@ main (int argc, char *argv[])
      LIBMTP_raw_device_t * rawdevices;
      int numrawdevices;

--- a/sys-fs/mtpfs/mtpfs-1.1-r4.ebuild
+++ b/sys-fs/mtpfs/mtpfs-1.1-r4.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="A FUSE filesystem providing access to MTP devices"
+HOMEPAGE="https://www.adebenham.com/mtpfs/"
+SRC_URI="https://www.adebenham.com/files/mtp/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug mad"
+
+RDEPEND="dev-libs/glib:2
+	>=media-libs/libmtp-1.1.2
+	sys-fs/fuse
+	mad? (
+		media-libs/libid3tag
+		media-libs/libmad
+	)"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=(AUTHORS NEWS README)
+
+PATCHES=( "${FILESDIR}"/${P}-fix-mutex-crash.patch
+	"${FILESDIR}"/${P}-unitialized-variable.patch
+	"${FILESDIR}"/${P}-wking-patches/
+	"${FILESDIR}"/${P}-g_printf.patch )
+
+src_prepare() {
+	default
+	sed -e "/#include <string.h>/ a\
+		#include <stdlib.h>" -i mtpfs.h id3read.c || die #implicit
+}
+
+src_configure() {
+	econf $(use_enable debug) \
+		$(use_enable mad)
+}
+
+pkg_postinst() {
+	einfo "To mount your MTP device, issue:"
+	einfo "    /usr/bin/mtpfs <mountpoint>"
+	echo
+	einfo "To unmount your MTP device, issue:"
+	einfo "    /usr/bin/fusermount -u <mountpoint>"
+
+	if use debug; then
+		echo
+		einfo "You have enabled debugging output."
+		einfo "Please make sure you run mtpfs with the -d flag."
+	fi
+}


### PR DESCRIPTION
Hi,

Another small EAPI7 bump.
Please review.

diff -u:
```
--- mtpfs-1.1-r3.ebuild 2017-11-20 12:10:33.442696892 +0100
+++ mtpfs-1.1-r4.ebuild 2018-07-20 12:39:35.843888362 +0200
@@ -1,9 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2

-EAPI=5
-
-inherit eutils
+EAPI=7

 DESCRIPTION="A FUSE filesystem providing access to MTP devices"
 HOMEPAGE="https://www.adebenham.com/mtpfs/"
@@ -21,19 +19,20 @@
                media-libs/libid3tag
                media-libs/libmad
        )"
-DEPEND="${RDEPEND}
-       virtual/pkgconfig"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"

 DOCS=(AUTHORS NEWS README)

 src_prepare() {
+       default
        sed -e "/#include <string.h>/ a\
                #include <stdlib.h>" -i mtpfs.h id3read.c || die #implicit

-       epatch "${FILESDIR}"/${P}-fix-mutex-crash.patch
-       epatch "${FILESDIR}"/${P}-unitialized-variable.patch
-       epatch "${FILESDIR}"/${P}-wking-patches/*.patch
-       epatch "${FILESDIR}"/${P}-g_printf.patch
+       eapply "${FILESDIR}"/${P}-fix-mutex-crash.patch
+       eapply "${FILESDIR}"/${P}-unitialized-variable.patch
+       eapply "${FILESDIR}"/${P}-wking-patches/*.patch
+       eapply "${FILESDIR}"/${P}-g_printf.patch
 }

 src_configure() {
```