### PR TITLE
dev-python/h11: Introducing support for Python3.7

### DIFF
--- a/dev-python/h11/h11-0.7.0.ebuild
+++ b/dev-python/h11/h11-0.7.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
 
 inherit distutils-r1
 

--- a/dev-python/h11/h11-0.8.1.ebuild
+++ b/dev-python/h11/h11-0.8.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{4,5} pypy )
+PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Dropping support for pypy because tests fail on it.
All Python target USE flags confirmed to pass tests

This is inspired by comment https://github.com/gentoo/gentoo/pull/9250#issuecomment-405638033

When I was originally introducing the package I blindly trusted documentation of the upstream, but this time I invested extra time into testing everything and turns out `pypy` tests fail. So I remove it from 0.8.0. All other python versions in both ebuilds pass tests.

Closes: https://bugs.gentoo.org/661638
Package-Manager: Portage-2.3.43, Repoman-2.3.10