### PR TITLE
x11-drivers: xorg-server:= dep and --disable-selective-werror

### DIFF
--- a/x11-drivers/xf86-input-evdev/xf86-input-evdev-2.10.5-r1.ebuild
+++ b/x11-drivers/xf86-input-evdev/xf86-input-evdev-2.10.5-r1.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	dev-libs/libevdev
 	sys-libs/mtdev
 	virtual/libudev:=
-	>=x11-base/xorg-server-1.18[udev]
+	>=x11-base/xorg-server-1.18:=[udev]
 "
 DEPEND="
 	${LIVE_DEPEND}

--- a/x11-drivers/xf86-input-evdev/xf86-input-evdev-2.10.5-r1.ebuild
+++ b/x11-drivers/xf86-input-evdev/xf86-input-evdev-2.10.5-r1.ebuild
@@ -49,3 +49,10 @@ src_prepare() {
 	default
 	[[ ${PV} == 9999 ]] && eautoreconf
 }
+
+src_configure() {
+	local econfargs=(
+		--disable-selective-werror
+	)
+	econf "${econfargs[@]}"
+}

--- a/x11-drivers/xf86-input-evdev/xf86-input-evdev-2.10.6-r1.ebuild
+++ b/x11-drivers/xf86-input-evdev/xf86-input-evdev-2.10.6-r1.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	dev-libs/libevdev
 	sys-libs/mtdev
 	virtual/libudev:=
-	>=x11-base/xorg-server-1.18[udev]
+	>=x11-base/xorg-server-1.18:=[udev]
 "
 DEPEND="
 	${LIVE_DEPEND}

--- a/x11-drivers/xf86-input-evdev/xf86-input-evdev-2.10.6-r1.ebuild
+++ b/x11-drivers/xf86-input-evdev/xf86-input-evdev-2.10.6-r1.ebuild
@@ -49,3 +49,10 @@ src_prepare() {
 	default
 	[[ ${PV} == 9999 ]] && eautoreconf
 }
+
+src_configure() {
+	local econfargs=(
+		--disable-selective-werror
+	)
+	econf "${econfargs[@]}"
+}

--- a/x11-drivers/xf86-input-evdev/xf86-input-evdev-9999.ebuild
+++ b/x11-drivers/xf86-input-evdev/xf86-input-evdev-9999.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == 9999 ]]; then
 	LIVE_DEPEND=">=x11-misc/util-macros-1.18"
 else
 	SRC_URI="mirror://xorg/driver/${P}.tar.bz2"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86"
 fi
 
 LICENSE="MIT"
@@ -28,7 +28,7 @@ RDEPEND="
 	dev-libs/libevdev
 	sys-libs/mtdev
 	virtual/libudev:=
-	>=x11-base/xorg-server-1.18[udev]
+	>=x11-base/xorg-server-1.18:=[udev]
 "
 DEPEND="
 	${LIVE_DEPEND}

--- a/x11-drivers/xf86-input-evdev/xf86-input-evdev-9999.ebuild
+++ b/x11-drivers/xf86-input-evdev/xf86-input-evdev-9999.ebuild
@@ -49,3 +49,10 @@ src_prepare() {
 	default
 	[[ ${PV} == 9999 ]] && eautoreconf
 }
+
+src_configure() {
+	local econfargs=(
+		--disable-selective-werror
+	)
+	econf "${econfargs[@]}"
+}

--- a/x11-drivers/xf86-input-libinput/xf86-input-libinput-0.28.0.ebuild
+++ b/x11-drivers/xf86-input-libinput/xf86-input-libinput-0.28.0.ebuild
@@ -44,6 +44,13 @@ src_prepare() {
 	[[ ${PV} == 9999 ]] && eautoreconf
 }
 
+src_configure() {
+	local econfargs=(
+		--disable-selective-werror
+	)
+	econf "${econfargs[@]}"
+}
+
 src_install() {
 	default
 	find "${D}" -name '*.la' -delete || die

--- a/x11-drivers/xf86-input-libinput/xf86-input-libinput-9999.ebuild
+++ b/x11-drivers/xf86-input-libinput/xf86-input-libinput-9999.ebuild
@@ -44,6 +44,13 @@ src_prepare() {
 	[[ ${PV} == 9999 ]] && eautoreconf
 }
 
+src_configure() {
+	local econfargs=(
+		--disable-selective-werror
+	)
+	econf "${econfargs[@]}"
+}
+
 src_install() {
 	default
 	find "${D}" -name '*.la' -delete || die

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-18.0.1-r1.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-18.0.1-r1.ebuild
@@ -39,6 +39,7 @@ src_prepare() {
 
 src_configure() {
 	local econfargs=(
+		--disable-selective-werror
 		--enable-glamor
 	)
 

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-18.0.1-r1.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-18.0.1-r1.ebuild
@@ -25,7 +25,7 @@ BDEPEND="
 RDEPEND="
 	>=x11-libs/libdrm-2.4.78[video_cards_amdgpu]
 	x11-libs/libpciaccess
-	x11-base/xorg-server[glamor(-),-minimal]
+	x11-base/xorg-server:=[glamor(-),-minimal]
 "
 DEPEND="
 	${LIVE_DEPEND}

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
@@ -39,6 +39,7 @@ src_prepare() {
 
 src_configure() {
 	local econfargs=(
+		--disable-selective-werror
 		--enable-glamor
 	)
 

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
@@ -25,7 +25,7 @@ BDEPEND="
 RDEPEND="
 	>=x11-libs/libdrm-2.4.78[video_cards_amdgpu]
 	x11-libs/libpciaccess
-	x11-base/xorg-server[glamor(-),-minimal]
+	x11-base/xorg-server:=[glamor(-),-minimal]
 "
 DEPEND="
 	${LIVE_DEPEND}

--- a/x11-drivers/xf86-video-ati/xf86-video-ati-18.0.1-r2.ebuild
+++ b/x11-drivers/xf86-video-ati/xf86-video-ati-18.0.1-r2.ebuild
@@ -55,6 +55,7 @@ src_prepare() {
 
 src_configure() {
 	local econfargs=(
+		--disable-selective-werror
 		$(use_enable glamor)
 		$(use_enable udev)
 	)

--- a/x11-drivers/xf86-video-ati/xf86-video-ati-18.0.1-r2.ebuild
+++ b/x11-drivers/xf86-video-ati/xf86-video-ati-18.0.1-r2.ebuild
@@ -27,6 +27,7 @@ BDEPEND="
 RDEPEND="
 	>=x11-libs/libdrm-2.4.78[video_cards_radeon]
 	>=x11-libs/libpciaccess-0.8.0
+	x11-base/xorg-server:=
 	glamor? ( x11-base/xorg-server[glamor] )
 	udev? ( virtual/libudev:= )
 "

--- a/x11-drivers/xf86-video-ati/xf86-video-ati-9999.ebuild
+++ b/x11-drivers/xf86-video-ati/xf86-video-ati-9999.ebuild
@@ -55,6 +55,7 @@ src_prepare() {
 
 src_configure() {
 	local econfargs=(
+		--disable-selective-werror
 		$(use_enable glamor)
 		$(use_enable udev)
 	)

--- a/x11-drivers/xf86-video-ati/xf86-video-ati-9999.ebuild
+++ b/x11-drivers/xf86-video-ati/xf86-video-ati-9999.ebuild
@@ -27,6 +27,7 @@ BDEPEND="
 RDEPEND="
 	>=x11-libs/libdrm-2.4.78[video_cards_radeon]
 	>=x11-libs/libpciaccess-0.8.0
+	x11-base/xorg-server:=
 	glamor? ( x11-base/xorg-server[glamor] )
 	udev? ( virtual/libudev:= )
 "


### PR DESCRIPTION
Adding a dep on `x11-base/xorg-server:=` in order to properly trigger rebuilds,
and adding `--disable-selective-werror`.

Follow up to #9222 due to a premature merge.