### PR TITLE
x11-plugins/{wmappl,wmcdplay,wmclock,wmclockmon}: EAPI7, update ebuilds

### DIFF
--- a/x11-plugins/wmappl/wmappl-0.71-r1.ebuild
+++ b/x11-plugins/wmappl/wmappl-0.71-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Simple application launcher for the Window Maker dock"
+HOMEPAGE="https://www.dockapps.net/wmappl"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXt
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~x86 ~sparc ~amd64 ~ppc"

--- a/x11-plugins/wmappl/wmappl-0.71.ebuild
+++ b/x11-plugins/wmappl/wmappl-0.71.ebuild
@@ -6,7 +6,7 @@ EAPI=0
 IUSE=""
 DESCRIPTION="Simple application launcher for the Window Maker dock"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
-HOMEPAGE="http://wmappl.sourceforge.net/"
+HOMEPAGE="https://www.dockapps.net/wmappl"
 
 RDEPEND="x11-libs/libX11
 	x11-libs/libXext

--- a/x11-plugins/wmcdplay/wmcdplay-1.1-r1.ebuild
+++ b/x11-plugins/wmcdplay/wmcdplay-1.1-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit autotools desktop
+
+DESCRIPTION="CD player applet for WindowMaker"
+HOMEPAGE="https://www.dockapps.net/wmcdplay"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+S="${WORKDIR}/dockapps"
+
+DOCS=( ARTWORK README )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_install() {
+	default
+	domenu "${FILESDIR}"/${PN}.desktop
+}

--- a/x11-plugins/wmcdplay/wmcdplay-1.1.ebuild
+++ b/x11-plugins/wmcdplay/wmcdplay-1.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-inherit autotools
+inherit autotools desktop
 
 DESCRIPTION="CD player applet for WindowMaker"
 HOMEPAGE="https://www.dockapps.net/wmcdplay"
@@ -21,13 +21,13 @@ DEPEND="${RDEPEND}
 
 S=${WORKDIR}/dockapps
 
+DOCS=( ARTWORK README )
+
 src_prepare() {
 	eautoreconf
 }
 
 src_install() {
-	emake DESTDIR="${D}" install
-
-	dodoc ARTWORK README
+	default
 	domenu "${FILESDIR}"/${PN}.desktop
 }

--- a/x11-plugins/wmclock/wmclock-1.0.16-r1.ebuild
+++ b/x11-plugins/wmclock/wmclock-1.0.16-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit autotools
+
+DESCRIPTION="a dockapp that displays time and date (same style as NEXTSTEP(tm) OS)"
+HOMEPAGE="https://www.dockapps.net/wmclock"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+# Specific path for this version
+S="${WORKDIR}/dockapps-daaf3aa"
+
+src_prepare() {
+	default
+	eautoreconf
+}

--- a/x11-plugins/wmclockmon/wmclockmon-0.8.1-r1.ebuild
+++ b/x11-plugins/wmclockmon/wmclockmon-0.8.1-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="a nice digital clock with 7 different styles either in LCD or LED style"
+HOMEPAGE="http://tnemeth.free.fr/projets/dockapps.html"
+SRC_URI="mirror://debian/pool/main/w/${PN}/${PN}_${PV}-1.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="x11-libs/gtk+:2
+	x11-libs/libXext
+	x11-libs/libX11
+	x11-libs/libXpm
+	x11-libs/libICE"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	x11-base/xorg-proto
+	x11-libs/libXt"
+
+PATCHES=( "${FILESDIR}"/${P}-gtk.patch )
+
+DOCS=( AUTHORS BUGS ChangeLog NEWS README THANKS TODO \
+	doc/sample2.wmclockmonrc doc/sample1.wmclockmonrc )
+
+src_install() {
+	default
+	newdoc debian/changelog ChangeLog.debian
+}


### PR DESCRIPTION
Hi,

Another few x11-plugins/wm* updates. Some notes:

wmappl: Changed the Homepage to the dockapps Homepage as the sourceforge page seems to be offline.

wmcdplay: the 1.1 ebuild missed a eclass to inherit in order to use domenu

wmclockmon: for some reason i couldn't use ```DOCS=( AUTHORS BUGS ChangeLog NEWS README THANKS TODO doc/sample* )```. I always got the error: ```wmclockmon-0.8.1-r1.ebuild: line 26: no match: doc/*``` Since it's only two files i just wrote the full name.


diff -u wmappl:
```
--- wmappl-0.71.ebuild  2018-07-21 22:06:10.221911267 +0200
+++ wmappl-0.71-r1.ebuild       2018-07-21 22:09:32.132858886 +0200
@@ -1,12 +1,11 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-IUSE=""
 DESCRIPTION="Simple application launcher for the Window Maker dock"
-SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 HOMEPAGE="https://www.dockapps.net/wmappl"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext
@@ -17,13 +16,4 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="x86 sparc amd64 ppc"
-
-src_compile() {
-       econf || die "Configuration failed"
-       emake || die "Compilation failed"
-}
-
-src_install () {
-       emake DESTDIR="${D}" install || die "Installation failed"
-}
+KEYWORDS="~x86 ~sparc ~amd64 ~ppc"
```

diff -u wmcdplay:
```
--- wmcdplay-1.1.ebuild 2018-07-21 22:17:24.727267128 +0200
+++ wmcdplay-1.1-r1.ebuild      2018-07-21 22:22:21.587629970 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit autotools desktop
 
 DESCRIPTION="CD player applet for WindowMaker"
@@ -11,7 +11,6 @@
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE=""
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext
@@ -19,15 +18,16 @@
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
-S=${WORKDIR}/dockapps
+S="${WORKDIR}/dockapps"
+
+DOCS=( ARTWORK README )
 
 src_prepare() {
+       default
        eautoreconf
 }
 
 src_install() {
-       emake DESTDIR="${D}" install
-
-       dodoc ARTWORK README
+       default
        domenu "${FILESDIR}"/${PN}.desktop
 }
```

diff -u wmclock:
```
--- wmclock-1.0.16.ebuild       2018-05-23 19:05:41.673212506 +0200
+++ wmclock-1.0.16-r1.ebuild    2018-07-21 22:27:00.357375685 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit autotools
 
 DESCRIPTION="a dockapp that displays time and date (same style as NEXTSTEP(tm) OS)"
@@ -10,8 +10,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc ~sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext
@@ -20,8 +19,9 @@
        x11-base/xorg-proto"
 
 # Specific path for this version
-S=${WORKDIR}/dockapps-daaf3aa
+S="${WORKDIR}/dockapps-daaf3aa"
 
 src_prepare() {
+       default
        eautoreconf
 }
```

diff -u wmclockmon:
```
--- wmclockmon-0.8.1.ebuild     2018-05-23 19:05:41.673212506 +0200
+++ wmclockmon-0.8.1-r1.ebuild  2018-07-21 22:46:39.486720579 +0200
@@ -1,8 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils
+EAPI=7
 
 DESCRIPTION="a nice digital clock with 7 different styles either in LCD or LED style"
 HOMEPAGE="http://tnemeth.free.fr/projets/dockapps.html"
@@ -10,8 +9,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 
 RDEPEND="x11-libs/gtk+:2
        x11-libs/libXext
@@ -23,12 +21,12 @@
        x11-base/xorg-proto
        x11-libs/libXt"
 
-src_prepare() {
-       epatch "${FILESDIR}"/${P}-gtk.patch
-}
+PATCHES=( "${FILESDIR}"/${P}-gtk.patch )
+
+DOCS=( AUTHORS BUGS ChangeLog NEWS README THANKS TODO \
+       doc/sample2.wmclockmonrc doc/sample1.wmclockmonrc )
 
 src_install() {
-       emake DESTDIR="${D}" install
-       dodoc AUTHORS BUGS ChangeLog NEWS README THANKS TODO doc/sample*
+       default
        newdoc debian/changelog ChangeLog.debian
 }
```