### PR TITLE
x11-plugins/{wminet,wmitime,wmlife,wmload}: EAPI7, updates

### DIFF
--- a/x11-plugins/wminet/wminet-3.0.0-r2.ebuild
+++ b/x11-plugins/wminet/wminet-3.0.0-r2.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="dockapp for monitoring internet connections to and from your computer"
+HOMEPAGE="http://www.improbability.net/#wminet"
+SRC_URI="http://www.improbability.net/wmdock//${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=( "${FILESDIR}"/${P}-list.patch )
+
+DOCS=( AUTHORS ChangeLog NEWS README wminetrc )
+
+src_compile() {
+	tc-export CC
+	emake LDFLAGS="${LDFLAGS}"
+}

--- a/x11-plugins/wmitime/wmitime-0.5-r1.ebuild
+++ b/x11-plugins/wmitime/wmitime-0.5-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="Overglorified clock dockapp w/time, date, and internet time"
+HOMEPAGE="https://www.dockapps.net/wmitime"
+SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND=">=x11-libs/libdockapp-0.7:=
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}"
+
+src_compile() {
+	emake CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" PREFIX=/usr install
+	einstalldocs
+}

--- a/x11-plugins/wmlife/wmlife-1.0.1-r1.ebuild
+++ b/x11-plugins/wmlife/wmlife-1.0.1-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="dockapp running Conway's Game of Life (and program launcher)"
+HOMEPAGE="http://www.improbability.net/#wmlife"
+SRC_URI="http://www.improbability.net/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="x11-libs/gtk+:2
+	x11-libs/libICE
+	x11-libs/libSM
+	x11-libs/libX11
+	x11-libs/libXext"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( AUTHORS ChangeLog NEWS README )
+
+PATCHES=( "${FILESDIR}"/${PN}-1.0.0-stringh.patch
+	"${FILESDIR}"/${P}-configure.patch )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf --enable-session
+}

--- a/x11-plugins/wmlife/wmlife-1.0.1.ebuild
+++ b/x11-plugins/wmlife/wmlife-1.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -18,13 +18,10 @@ RDEPEND="x11-libs/gtk+:2
 	x11-libs/libSM
 	x11-libs/libX11
 	x11-libs/libXext"
-EPEND="${RDEPEND}
+DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
 DOCS="AUTHORS ChangeLog NEWS README"
-
-PATCHES=( "${FILESDIR}"/${PN}-1.0.0-stringh.patch
-	"${FILESDIR}"/${P}-configure.patch )
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.0.0-stringh.patch

--- a/x11-plugins/wmload/files/wmload-0.9.6-solaris.patch
+++ b/x11-plugins/wmload/files/wmload-0.9.6-solaris.patch
@@ -1,7 +1,7 @@
 * original: http://www.rampant.org/~dp/software/wmload.solaris.patch
 
---- wmload.c
-+++ wmload.c
+--- a/wmload.c
++++ b/wmload.c
 @@ -6,6 +6,11 @@
  #include <math.h>
  #include <fcntl.h>

--- a/x11-plugins/wmload/wmload-0.9.7-r1.ebuild
+++ b/x11-plugins/wmload/wmload-0.9.7-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop toolchain-funcs
+
+DESCRIPTION="yet another dock application showing a system load gauge"
+HOMEPAGE="https://www.dockapps.net/wmload"
+SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~amd64-linux ~ppc ~sparc ~sparc-solaris ~x86 ~x86-linux ~x64-solaris ~x86-solaris"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=( "${FILESDIR}"/${PN}-0.9.6-solaris.patch )
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	emake DESTDIR="${D}" PREFIX="${EPREFIX}"/usr install
+
+	dodoc README
+	domenu "${FILESDIR}"/${PN}.desktop
+}


### PR DESCRIPTION
Hi,

Anouther round of x11-plugins/wm* updates.
I've also updated the wmlife ebuild as it had a typo and redundant PATCHES set.
Please review.

Edit: Removed wmlaptop as it was treecleaned.

diff -u wminet:
```
--- wminet-3.0.0-r1.ebuild      2018-05-23 19:05:41.674212482 +0200
+++ wminet-3.0.0-r2.ebuild      2018-07-22 16:50:01.204884623 +0200
@@ -1,8 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils toolchain-funcs
+EAPI=7
+
+inherit toolchain-funcs
 
 DESCRIPTION="dockapp for monitoring internet connections to and from your computer"
 HOMEPAGE="http://www.improbability.net/#wminet"
@@ -10,8 +11,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext
@@ -19,17 +19,11 @@
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
-src_prepare() {
-       epatch "${FILESDIR}"/${P}-list.patch
+PATCHES=( "${FILESDIR}"/${P}-list.patch )
 
-       tc-export CC
-}
+DOCS=( AUTHORS ChangeLog NEWS README wminetrc )
 
 src_compile() {
+       tc-export CC
        emake LDFLAGS="${LDFLAGS}"
 }
-
-src_install() {
-       emake DESTDIR="${D}" install
-       dodoc AUTHORS ChangeLog NEWS README wminetrc
-}
```
diff -u wmitime:
```
--- wmitime-0.5.ebuild  2018-05-06 12:15:30.746161257 +0200
+++ wmitime-0.5-r1.ebuild       2018-07-22 16:53:02.443732495 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Overglorified clock dockapp w/time, date, and internet time"
@@ -10,8 +10,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc ppc64 sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 
 RDEPEND=">=x11-libs/libdockapp-0.7:=
        x11-libs/libX11
@@ -26,6 +25,5 @@
 
 src_install() {
        emake DESTDIR="${D}" PREFIX=/usr install
-
        dodoc BUGS CHANGES README
 }
```
diff -u wmlife:
```
--- wmlife-1.0.1.ebuild 2018-07-22 17:46:10.343613835 +0200
+++ wmlife-1.0.1-r1.ebuild      2018-07-22 17:46:10.946600374 +0200
@@ -1,8 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit autotools eutils
+EAPI=7
+
+inherit autotools
 
 DESCRIPTION="dockapp running Conway's Game of Life (and program launcher)"
 HOMEPAGE="http://www.improbability.net/#wmlife"
@@ -11,22 +12,22 @@
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 RDEPEND="x11-libs/gtk+:2
        x11-libs/libICE
        x11-libs/libSM
        x11-libs/libX11
        x11-libs/libXext"
-DEPEND="${RDEPEND}
-       virtual/pkgconfig"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
 
-DOCS="AUTHORS ChangeLog NEWS README"
+DOCS=( AUTHORS ChangeLog NEWS README )
 
-src_prepare() {
-       epatch "${FILESDIR}"/${PN}-1.0.0-stringh.patch
-       epatch "${FILESDIR}"/${P}-configure.patch
+PATCHES=( "${FILESDIR}"/${PN}-1.0.0-stringh.patch
+       "${FILESDIR}"/${P}-configure.patch )
 
+src_prepare() {
+       default
        eautoreconf
 }

```
diff -u wmload:
```
--- wmload-0.9.7.ebuild 2018-05-23 19:05:41.675212458 +0200
+++ wmload-0.9.7-r1.ebuild      2018-07-22 17:46:11.529587359 +0200
@@ -1,8 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils toolchain-funcs
+EAPI=7
+
+inherit desktop toolchain-funcs
 
 DESCRIPTION="yet another dock application showing a system load gauge"
 HOMEPAGE="https://www.dockapps.net/wmload"
@@ -10,8 +11,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc sparc x86 ~amd64-linux ~x86-linux ~sparc-solaris ~x64-solaris ~x86-solaris"
-IUSE=""
+KEYWORDS="~amd64 ~amd64-linux ~ppc ~sparc ~sparc-solaris ~x86 ~x86-linux ~x64-solaris ~x86-solaris"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext
@@ -19,9 +19,7 @@
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
-src_prepare() {
-       epatch "${FILESDIR}"/${PN}-0.9.6-solaris.patch
-}
+PATCHES=( "${FILESDIR}"/${PN}-0.9.6-solaris.patch )
 
 src_compile() {
        emake CC="$(tc-getCC)"
```