### PR TITLE
x11-plugins/{wmmenu,wmmemload,wmmisc,wmmon+smp,wmnd}: EAPI7, improve ebuild

### DIFF
--- a/x11-plugins/wmmemload/wmmemload-0.1.8-r1.ebuild
+++ b/x11-plugins/wmmemload/wmmemload-0.1.8-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit autotools
+
+DESCRIPTION="dockapp that displays memory and swap space usage"
+HOMEPAGE="https://www.dockapps.net/wmmemload"
+SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto
+	x11-libs/libICE
+	x11-libs/libXt"
+
+S="${WORKDIR}/dockapps"
+
+src_prepare() {
+	default
+	eautoreconf
+}

--- a/x11-plugins/wmmenu/files/wmmenu-1.3-Makefile.patch
+++ b/x11-plugins/wmmenu/files/wmmenu-1.3-Makefile.patch
@@ -1,5 +1,5 @@
---- Makefile.orig	2015-04-17 13:43:08.122972280 +0200
-+++ Makefile	2015-04-17 13:43:11.569975854 +0200
+--- a/Makefile	2015-04-17 13:43:08.122972280 +0200
++++ b/Makefile	2015-04-17 13:43:11.569975854 +0200
 @@ -14,12 +14,12 @@
  PIXBUF_LIB := -rdynamic -L$(shell $(PIXBUF_CFG) --variable=prefix)/lib -lgdk_pixbuf_xlib-2.0 -lgdk_pixbuf-2.0 -lgobject-2.0
  endif

--- a/x11-plugins/wmmenu/wmmenu-1.3-r2.ebuild
+++ b/x11-plugins/wmmenu/wmmenu-1.3-r2.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="a popup menu of icons like in AfterStep, as a dockapp"
+HOMEPAGE="https://www.dockapps.net/wmmenu"
+SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="x11-libs/gdk-pixbuf[X]
+	>=x11-libs/libdockapp-0.7:="
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/dockapps"
+
+PATCHES=( "${FILESDIR}"/${P}-Makefile.patch )
+
+DOCS=( README TODO example/{apps,defaults,extract_icon_back} )
+
+src_prepare() {
+	default
+	sed -e 's#<dockapp.h>#<libdockapp/dockapp.h>#' -i *.c || die
+}
+
+src_compile() {
+	emake  CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin wmmenu
+	doman wmmenu.1
+	einstalldocs
+}

--- a/x11-plugins/wmmisc/files/wmmisc-1.1-build.patch
+++ b/x11-plugins/wmmisc/files/wmmisc-1.1-build.patch
@@ -1,6 +1,6 @@
 diff -ur wmmisc-1.1.orig/src/general.mk wmmisc-1.1/src/general.mk
---- wmmisc-1.1.orig/src/general.mk	2006-01-07 19:50:31.000000000 +0200
-+++ wmmisc-1.1/src/general.mk	2008-01-16 20:44:59.000000000 +0200
+--- a/general.mk	2006-01-07 19:50:31.000000000 +0200
++++ b/general.mk	2008-01-16 20:44:59.000000000 +0200
 @@ -16,7 +16,7 @@
  MANDIR      = $(PREFIX)/share/man
  # Set some destination locations.
@@ -35,8 +35,8 @@ diff -ur wmmisc-1.1.orig/src/general.mk wmmisc-1.1/src/general.mk
  INCLUDES   += -I.
  # Set the include locations.
 diff -ur wmmisc-1.1.orig/src/Makefile wmmisc-1.1/src/Makefile
---- wmmisc-1.1.orig/src/Makefile	2006-01-07 20:45:59.000000000 +0200
-+++ wmmisc-1.1/src/Makefile	2008-01-16 20:43:31.000000000 +0200
+--- a/Makefile	2006-01-07 20:45:59.000000000 +0200
++++ b/Makefile	2008-01-16 20:43:31.000000000 +0200
 @@ -23,7 +23,7 @@
  
  $(package): $(objects)

--- a/x11-plugins/wmmisc/wmmisc-1.1-r1.ebuild
+++ b/x11-plugins/wmmisc/wmmisc-1.1-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="a monitoring dockapp for system load, user amount, fork amount and processes"
+HOMEPAGE="https://packages.qa.debian.org/w/wmmisc.html"
+SRC_URI="mirror://debian/pool/main/w/${PN}/${PN}_${PV}.orig.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+S="${WORKDIR}/${P}/src"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=( "${FILESDIR}"/${P}-build.patch )
+
+src_compile() {
+	tc-export CC
+	emake
+}
+
+src_install() {
+	dobin ${PN}
+	dodoc ../{ChangeLog,README}
+}

--- a/x11-plugins/wmmon+smp/files/wmmon+smp-1.0-list.patch
+++ b/x11-plugins/wmmon+smp/files/wmmon+smp-1.0-list.patch
@@ -1,6 +1,6 @@
 diff -Naur wmgeneral.orig/list.c wmgeneral/list.c
---- wmgeneral.orig/list.c	2016-01-04 13:28:36.583339716 +0100
-+++ wmgeneral/list.c	2016-01-04 13:28:48.694343645 +0100
+--- a/wmgeneral/list.c	2016-01-04 13:28:36.583339716 +0100
++++ b/wmgeneral/list.c	2016-01-04 13:28:48.694343645 +0100
 @@ -38,7 +38,7 @@
  
  /* Return a cons cell produced from (head . tail)
@@ -83,8 +83,8 @@ diff -Naur wmgeneral.orig/list.c wmgeneral/list.c
  {
    while(list)
 diff -Naur wmgeneral.orig/list.h wmgeneral/list.h
---- wmgeneral.orig/list.h	2016-01-04 13:28:36.583339716 +0100
-+++ wmgeneral/list.h	2016-01-04 13:28:39.471340654 +0100
+--- a/wmgeneral/list.h	2016-01-04 13:28:36.583339716 +0100
++++ b/wmgeneral/list.h	2016-01-04 13:28:39.471340654 +0100
 @@ -29,31 +29,25 @@
  #ifndef __LIST_H_
  #define __LIST_H_

--- a/x11-plugins/wmmon+smp/wmmon+smp-1.0-r3.ebuild
+++ b/x11-plugins/wmmon+smp/wmmon+smp-1.0-r3.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Dockapp CPU monitor resembling Xosview, support for smp"
+HOMEPAGE="http://www.ne.jp/asahi/linux/timecop/"
+SRC_URI="http://www.ne.jp/asahi/linux/timecop/software/wmmon+smp.tar.gz"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc64 ~x86"
+
+RDEPEND="
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+S="${WORKDIR}/wmmon.app/wmmon"
+
+PATCHES=( "${FILESDIR}"/${P}-list.patch )
+
+src_prepare() {
+	tc-export CC
+	# Respect LDFLAGS, see bug #335047
+	sed \
+		-e 's/cc -o/${CC} ${LDFLAGS} -o/' \
+		-e 's/cc -c/${CC} ${CFLAGS} -c/' \
+		-i Makefile || die
+
+	cd "${WORKDIR}"/wmmon.app || die
+	default
+}
+
+src_install () {
+	newbin wmmon wmmon+smp
+	dodoc ../README
+}

--- a/x11-plugins/wmnd/wmnd-0.4.16.ebuild
+++ b/x11-plugins/wmnd/wmnd-0.4.16.ebuild
@@ -4,8 +4,8 @@
 EAPI=4
 
 DESCRIPTION="WindowMaker Network Devices (dockapp)"
-HOMEPAGE="http://www.thregr.org/~wavexx/software/wmnd/"
-SRC_URI="http://www.thregr.org/~wavexx/software/wmnd/releases/${P}.tar.gz"
+HOMEPAGE="https://www.thregr.org/~wavexx/software/wmnd/"
+SRC_URI="https://www.thregr.org/~wavexx/software/wmnd/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmnd/wmnd-0.4.17-r1.ebuild
+++ b/x11-plugins/wmnd/wmnd-0.4.17-r1.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="WindowMaker Network Devices (dockapp)"
+HOMEPAGE="https://www.thregr.org/~wavexx/software/wmnd/"
+SRC_URI="https://www.thregr.org/~wavexx/software/wmnd/releases/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux ~x64-solaris"
+IUSE="snmp"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXt
+	x11-libs/libXpm
+	snmp? ( >=net-analyzer/net-snmp-5.2.1 )"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"

--- a/x11-plugins/wmnd/wmnd-0.4.17.ebuild
+++ b/x11-plugins/wmnd/wmnd-0.4.17.ebuild
@@ -4,8 +4,8 @@
 EAPI=4
 
 DESCRIPTION="WindowMaker Network Devices (dockapp)"
-HOMEPAGE="http://www.thregr.org/~wavexx/software/wmnd/"
-SRC_URI="http://www.thregr.org/~wavexx/software/wmnd/releases/${P}.tar.gz"
+HOMEPAGE="https://www.thregr.org/~wavexx/software/wmnd/"
+SRC_URI="https://www.thregr.org/~wavexx/software/wmnd/releases/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

Another round of fixes. Mostly simple changes.
Please review.

diff -u wmmenu:
```
--- wmmenu-1.3-r1.ebuild        2018-05-06 12:15:30.746161257 +0200
+++ wmmenu-1.3-r2.ebuild        2018-07-22 19:26:53.232963668 +0200
@@ -1,8 +1,8 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils toolchain-funcs
+EAPI=7
+inherit toolchain-funcs
 
 DESCRIPTION="a popup menu of icons like in AfterStep, as a dockapp"
 HOMEPAGE="https://www.dockapps.net/wmmenu"
@@ -10,18 +10,20 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND="x11-libs/gdk-pixbuf[X]
        >=x11-libs/libdockapp-0.7:="
 DEPEND="${RDEPEND}"
 
-S=${WORKDIR}/dockapps
+S="${WORKDIR}/dockapps"
 
-src_prepare() {
-       epatch "${FILESDIR}"/${P}-Makefile.patch
+PATCHES=( "${FILESDIR}"/${P}-Makefile.patch )
+
+DOCS=( README TODO example/{apps,defaults,extract_icon_back} )
 
+src_prepare() {
+       default
        sed -e 's#<dockapp.h>#<libdockapp/dockapp.h>#' -i *.c || die
 }
 
@@ -32,5 +34,5 @@
 src_install() {
        dobin wmmenu
        doman wmmenu.1
-       dodoc README TODO example/apps example/defaults example/extract_icon_back
+       einstalldocs
 }
```

diff -u wmmemload:
```--- wmmemload-0.1.8.ebuild      2018-05-23 19:05:41.675212458 +0200
+++ wmmemload-0.1.8-r1.ebuild   2018-07-22 19:29:18.700831338 +0200
@@ -1,8 +1,8 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit autotools eutils
+EAPI=7
+inherit autotools
 
 DESCRIPTION="dockapp that displays memory and swap space usage"
 HOMEPAGE="https://www.dockapps.net/wmmemload"
@@ -10,8 +10,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 ~ppc ppc64 sparc x86"
-IUSE=""
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext
@@ -21,13 +20,9 @@
        x11-libs/libICE
        x11-libs/libXt"
 
-S=${WORKDIR}/dockapps
+S="${WORKDIR}/dockapps"
 
 src_prepare() {
+       default
        eautoreconf
 }
-
-src_install() {
-       emake DESTDIR="${D}" install
-       dodoc AUTHORS ChangeLog THANKS
-}

```

diff -u wmmisc:
```
--- wmmisc-1.1.ebuild   2018-05-23 19:05:41.675212458 +0200
+++ wmmisc-1.1-r1.ebuild        2018-07-22 19:34:34.633284226 +0200
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="a monitoring dockapp for system load, user amount, fork amount and processes"
 HOMEPAGE="https://packages.qa.debian.org/w/wmmisc.html"
@@ -11,10 +11,9 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
 
-S=${WORKDIR}/${P}/src
+S="${WORKDIR}/${P}/src"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext
@@ -22,15 +21,11 @@
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
-src_unpack() {
-       unpack ${A}
-       cd "${S}"
-       epatch "${FILESDIR}"/${P}-build.patch
-}
+PATCHES=( "${FILESDIR}"/${P}-build.patch )
 
 src_compile() {
        tc-export CC
-       emake || die "emake failed."
+       emake
 }
 
 src_install() {
```

diff -u wmmon+smp:
```
--- wmmon+smp-1.0-r2.ebuild     2018-05-23 19:05:41.675212458 +0200
+++ wmmon+smp-1.0-r3.ebuild     2018-07-22 19:42:23.913255661 +0200
@@ -1,18 +1,17 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="Dockapp CPU monitor resembling Xosview, support for smp"
-SRC_URI="http://www.ne.jp/asahi/linux/timecop/software/wmmon+smp.tar.gz"
 HOMEPAGE="http://www.ne.jp/asahi/linux/timecop/"
+SRC_URI="http://www.ne.jp/asahi/linux/timecop/software/wmmon+smp.tar.gz"
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="amd64 ppc64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc64 ~x86"
 
 RDEPEND="
        x11-libs/libX11
@@ -21,9 +20,10 @@
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
-S=${WORKDIR}/wmmon.app/wmmon
+S="${WORKDIR}/wmmon.app/wmmon"
 
 src_prepare() {
+       default
        # Respect LDFLAGS, see bug #335047
        sed \
                -e 's/cc -o/${CC} ${LDFLAGS} -o/' \
@@ -32,8 +32,7 @@
        tc-export CC
 
        cd "${WORKDIR}"/wmmon.app || die
-       ls
-       epatch "${FILESDIR}"/${P}-list.patch
+       eapply "${FILESDIR}"/${P}-list.patch
 }
 
 src_install () {
```

diff -u wmnd:
```
--- wmnd-0.4.17.ebuild  2018-07-22 19:43:12.973992678 +0200
+++ wmnd-0.4.17-r1.ebuild       2018-07-22 19:44:35.398868567 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
 
 DESCRIPTION="WindowMaker Network Devices (dockapp)"
 HOMEPAGE="https://www.thregr.org/~wavexx/software/wmnd/"
@@ -19,9 +19,3 @@
        snmp? ( >=net-analyzer/net-snmp-5.2.1 )"
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
-
-src_install() {
-       emake DESTDIR="${D}" install
-
-       dodoc README AUTHORS ChangeLog NEWS TODO
-}
```