### PR TITLE
sys-block/megactl: EAPI7, improve ebuild

### DIFF
--- a/sys-block/megactl/megactl-0.4.1-r3.ebuild
+++ b/sys-block/megactl/megactl-0.4.1-r3.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="LSI MegaRAID control utility"
+HOMEPAGE="https://sourceforge.net/projects/megactl/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=( "${FILESDIR}"/${P}.patch
+	"${FILESDIR}"/${P}-Makefile.patch
+	"${FILESDIR}"/${P}-gcc-fixes.patch
+	"${FILESDIR}"/${P}-tracefix.patch )
+
+src_compile() {
+	use x86 && MY_MAKEOPTS="ARCH=-m32"
+	use amd64 && MY_MAKEOPTS="ARCH=-m64"
+	emake -C src CC=$(tc-getCC) ${MY_MAKEOPTS}
+}
+
+src_install() {
+	cd src || die
+	dosbin megactl megasasctl megarpt megasasrpt
+	# it's not quite fixed yet
+	[ -x megatrace ] && dosbin megatrace
+	dodoc ../README
+}


### PR DESCRIPTION
Hi,

This PR update sys-block/megactl for EAPI7. Also fixes the direct calling of ```cc``` by using tc-getCC.
Please review.

diff -u:
```
--- megactl-0.4.1-r2.ebuild     2017-03-19 10:57:14.923786194 +0100
+++ megactl-0.4.1-r3.ebuild     2018-07-22 22:01:34.964827165 +0200
@@ -1,30 +1,28 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
+EAPI=7
 
-inherit eutils
+inherit toolchain-funcs
 
-IUSE=""
 DESCRIPTION="LSI MegaRAID control utility"
 HOMEPAGE="https://sourceforge.net/projects/megactl/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 
-src_prepare() {
-       epatch "${FILESDIR}"/${P}.patch
-       epatch "${FILESDIR}"/${P}-Makefile.patch
-       epatch "${FILESDIR}"/${P}-gcc-fixes.patch
-       epatch "${FILESDIR}"/${P}-tracefix.patch
-}
+PATCHES=( "${FILESDIR}"/${P}.patch
+       "${FILESDIR}"/${P}-Makefile.patch
+       "${FILESDIR}"/${P}-gcc-fixes.patch
+       "${FILESDIR}"/${P}-tracefix.patch )
 
 src_compile() {
        cd src
        use x86 && MY_MAKEOPTS="ARCH=-m32"
        use amd64 && MY_MAKEOPTS="ARCH=-m64"
-       emake ${MY_MAKEOPTS} || die "make failed"
+       emake CC=$(tc-getCC) ${MY_MAKEOPTS}
 }
 
 src_install() {
```