### PR TITLE
dev-python/pew: Add shutilwhich dependency

### DIFF
--- a/dev-python/pew/pew-1.1.1.ebuild
+++ b/dev-python/pew/pew-1.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -20,7 +20,8 @@ IUSE=""
 
 RDEPEND=""
 DEPEND="${RDEPEND}
+	>=dev-python/pythonz-bd-1.11.2[${PYTHON_USEDEP}]
 	>=dev-python/setuptools-17.1[${PYTHON_USEDEP}]
+	>=dev-python/shutilwhich-1.1.0[${PYTHON_USEDEP}]
 	>=dev-python/virtualenv-1.11.6[${PYTHON_USEDEP}]
-	>=dev-python/virtualenv-clone-0.2.5[${PYTHON_USEDEP}]
-	>=dev-python/pythonz-bd-1.11.2[${PYTHON_USEDEP}]"
+	>=dev-python/virtualenv-clone-0.2.5[${PYTHON_USEDEP}]"

--- a/dev-python/shutilwhich/shutilwhich-1.1.0.ebuild
+++ b/dev-python/shutilwhich/shutilwhich-1.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="PSF-2"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"


### PR DESCRIPTION
dev-python/shutilwhich is a pure Python package, so adding ~x86 keyword
should pose no issues.

Closes: https://bugs.gentoo.org/660998

Please merge. Thanks.