### PR TITLE
x11-plugins/{wmrecord,wmsallow,wmsystemtray,wmsystray,wmtime}: EAPI7, improve ebuild

### DIFF
--- a/x11-plugins/wmrecord/wmrecord-1.0.5.3-r2.ebuild
+++ b/x11-plugins/wmrecord/wmrecord-1.0.5.3-r2.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop toolchain-funcs
+
+DESCRIPTION="A Dockable General Purpose Recording Utility"
+HOMEPAGE="http://ret009t0.eresmas.net/other_software/wmrecord/"
+SRC_URI="http://ret009t0.eresmas.net/other_software/wmrecord/${PN}-1.0.5_20040218_0029.tgz"
+
+RDEPEND="
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~ppc ~x86"
+
+S="${WORKDIR}/${PN}-1.0.5"
+
+src_prepare() {
+	default
+	#prevent auto-stripping of binaries. Closes bug #252112
+	sed -i 's/install -s -o/install -o/' "${S}/Makefile" || die
+
+	#Honour Gentoo LDFLAGS. Closes bug #336753.
+	sed -i 's/-o $@ wmrecord.o/$(LDFLAGS) -o $@ wmrecord.o/' "${S}/Makefile" || die
+
+	#Fix buffer overflow. Closes bug #336754.
+	sed -i 's/sprintf(cse, "000");/snprintf(cse, "000", 3);/' "${S}/wmrecord.c" || die
+}
+
+src_compile() {
+	emake CC=$(tc-getCC) CFLAGS="${CFLAGS} -Wall"
+}
+
+src_install() {
+	dobin ${PN}
+	doman man/${PN}.1
+	domenu "${FILESDIR}"/${PN}.desktop
+	einstalldocs
+}

--- a/x11-plugins/wmswallow/files/wmswallow-0.6.1-format-security.patch
+++ b/x11-plugins/wmswallow/files/wmswallow-0.6.1-format-security.patch
@@ -1,5 +1,5 @@
---- wmswallow.c.orig	2015-04-01 17:12:29.420177608 +0200
-+++ wmswallow.c	2015-04-01 17:13:14.947182921 +0200
+--- a/wmswallow.c	2015-04-01 17:12:29.420177608 +0200
++++ b/wmswallow.c	2015-04-01 17:13:14.947182921 +0200
 @@ -445,11 +445,11 @@
  int printlist(FILE * stream, char * string, char **stringlist) {
    int i=0;

--- a/x11-plugins/wmsystemtray/wmsystemtray-1.4-r1.ebuild
+++ b/x11-plugins/wmsystemtray/wmsystemtray-1.4-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="a system tray dockapp with the ability to display more than just four tray icons"
+HOMEPAGE="https://sourceforge.net/projects/wmsystemtray/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="x11-libs/libXext
+	x11-libs/libXfixes
+	x11-libs/libXmu
+	x11-libs/libXpm"

--- a/x11-plugins/wmsystray/files/wmsystray-0.1.1-gcc-3.4.patch
+++ b/x11-plugins/wmsystray/files/wmsystray-0.1.1-gcc-3.4.patch
@@ -1,5 +1,5 @@
---- wmsystray/ui.c.orig	2004-08-25 11:14:51.265675224 +0000
-+++ wmsystray/ui.c	2004-08-25 11:09:56.676459592 +0000
+--- a/wmsystray/ui.c	2004-08-25 11:14:51.265675224 +0000
++++ b/wmsystray/ui.c	2004-08-25 11:09:56.676459592 +0000
 @@ -28,6 +28,7 @@
  int width, height, pos_x, pos_y;
  Pixmap bg_pixmap;

--- a/x11-plugins/wmsystray/wmsystray-0.1.1-r1.ebuild
+++ b/x11-plugins/wmsystray/wmsystray-0.1.1-r1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop
+
+DESCRIPTION="Window Maker dock app that provides a system tray for GNOME/KDE applications"
+HOMEPAGE="https://github.com/bbidulock/wmsystray"
+SRC_URI="https://github.com/bbidulock/wmsystray/releases/download/${PV}/${P}.tar.bz2"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+# Let's honour Gentoo CFLAGS and use correct install program
+# Fix for #61704, cannot compile with gcc 3.4.1:
+# it's a trivial change and does not affect other compilers...
+PATCHES=( "${FILESDIR}/${P}-Makefile.patch"
+	"${FILESDIR}/${P}-gcc-3.4.patch" )
+
+DOCS=( README HACKING AUTHORS )
+
+src_prepare() {
+	default
+	# Fix parallel compilation
+	sed -ie "s/make EXTRACFLAGS/make \${MAKEOPTS} EXTRACFLAGS/" Makefile || die
+
+	# Honour Gentoo LDFLAGS, see bug #336296
+	sed -ie "s/-o wmsystray/${LDFLAGS} -o wmsystray/" wmsystray/Makefile || die
+}
+
+src_compile() {
+	emake EXTRACFLAGS="${CFLAGS}"
+}
+
+src_install() {
+	dobin ${PN}/${PN}
+	doman doc/${PN}.1
+	domenu "${FILESDIR}/${PN}.desktop"
+	einstalldocs
+}

--- a/x11-plugins/wmtime/wmtime-1.4-r1.ebuild
+++ b/x11-plugins/wmtime/wmtime-1.4-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="applet which displays the date and time in a dockable tile"
+HOMEPAGE="https://www.dockapps.net/wmtime"
+SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND=">=x11-libs/libdockapp-0.7:=
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXau
+	x11-libs/libXdmcp
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+DOCS=( BUGS CHANGES HINTS README TODO )
+
+src_compile() {
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
+}
+
+src_install () {
+	emake DESTDIR="${D}" PREFIX=/usr install
+	einstalldocs
+}


### PR DESCRIPTION
Hi,

Another day, another PR, another few x11-plugins/wm* updates.
Please review.

diff -u wmrecord:
```
--- wmrecord-1.0.5.3-r1.ebuild  2018-05-23 19:05:41.676212433 +0200
+++ wmrecord-1.0.5.3-r2.ebuild  2018-07-24 19:51:26.822296017 +0200
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-inherit eutils
+inherit desktop toolchain-funcs
 
 DESCRIPTION="A Dockable General Purpose Recording Utility"
 HOMEPAGE="http://ret009t0.eresmas.net/other_software/wmrecord/"
@@ -18,34 +18,29 @@
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="x86 ~ppc"
-IUSE=""
+KEYWORDS="~ppc ~x86"
 
-S=${WORKDIR}/${PN}-1.0.5
-
-src_unpack() {
-       unpack ${A}
+S="${WORKDIR}/${PN}-1.0.5"
 
+src_prepare() {
+       default
        #prevent auto-stripping of binaries. Closes bug #252112
-       sed -i 's/install -s -o/install -o/' "${S}/Makefile"
+       sed -i 's/install -s -o/install -o/' "${S}/Makefile" || die
 
        #Honour Gentoo LDFLAGS. Closes bug #336753.
-       sed -i 's/-o $@ wmrecord.o/$(LDFLAGS) -o $@ wmrecord.o/' "${S}/Makefile"
+       sed -i 's/-o $@ wmrecord.o/$(LDFLAGS) -o $@ wmrecord.o/' "${S}/Makefile" || die
 
        #Fix buffer overflow. Closes bug #336754.
-       sed -i 's/sprintf(cse, "000");/snprintf(cse, "000", 3);/' "${S}/wmrecord.c"
+       sed -i 's/sprintf(cse, "000");/snprintf(cse, "000", 3);/' "${S}/wmrecord.c" || die
 }
 
 src_compile() {
-       emake CFLAGS="${CFLAGS} -Wall" || die "make failed"
+       emake CC=$(tc-getCC) CFLAGS="${CFLAGS} -Wall"
 }
 
 src_install() {
-       dodir /usr/bin
-       dodir /usr/share/man/man1
-       einstall BINDIR="${D}/usr/bin" MANDIR="${D}/usr/share/man/man1" || die "make install failed"
-
-       dodoc Changelog README TODO
-
+       dobin ${PN}
+       doman man/${PN}.1
        domenu "${FILESDIR}"/${PN}.desktop
+       einstalldocs
 }
```
diff -u wmsallow:
```
--- wmswallow-0.6.1-r1.ebuild   2018-05-23 19:05:41.676212433 +0200
+++ wmswallow-0.6.1-r2.ebuild   2018-07-24 19:54:34.602603078 +0200
@@ -1,8 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils toolchain-funcs
+EAPI=7
+
+inherit toolchain-funcs
 
 DESCRIPTION="A dock applet to make any application dockable"
 HOMEPAGE="https://www.dockapps.net/wmswallow"
@@ -10,18 +11,19 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext"
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
-S=${WORKDIR}/wmswallow
+S="${WORKDIR}/wmswallow"
+
+PATCHES=( "${FILESDIR}"/${P}-format-security.patch )
 
 src_prepare() {
-       epatch "${FILESDIR}"/${P}-format-security.patch
+       default
        sed -e "s:\${OBJS} -o:\${OBJS} \${LDFLAGS} -o:" \
                -e "/LIBS/s/-lXext/-lX11 \0/"\
                -i Makefile || die
```
diff -u wmsystemtray:
```
--- wmsystemtray-1.4.ebuild     2017-03-19 10:57:15.528786167 +0100
+++ wmsystemtray-1.4-r1.ebuild  2018-07-24 19:55:28.018993173 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 DESCRIPTION="a system tray dockapp with the ability to display more than just four tray icons"
 HOMEPAGE="https://sourceforge.net/projects/wmsystemtray/"
@@ -10,10 +10,8 @@
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="x11-libs/libXext
        x11-libs/libXfixes
        x11-libs/libXmu
        x11-libs/libXpm"
-RDEPEND="${DEPEND}"
```
diff -u wmsystray:
```
--- wmsystray-0.1.1.ebuild      2018-05-06 12:15:30.748161185 +0200
+++ wmsystray-0.1.1-r1.ebuild   2018-07-24 20:05:41.223490263 +0200
@@ -1,9 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-inherit eutils
+inherit desktop
 
 DESCRIPTION="Window Maker dock app that provides a system tray for GNOME/KDE applications"
 HOMEPAGE="https://github.com/bbidulock/wmsystray"
@@ -15,34 +15,32 @@
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="amd64 ppc ~sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 
-src_unpack() {
-       unpack ${A}
-       cd "${S}"
-
-       # Let's honour Gentoo CFLAGS and use correct install program
-       epatch "${FILESDIR}/${P}-Makefile.patch"
-
-       # Fix for #61704, cannot compile with gcc 3.4.1:
-       # it's a trivial change and does not affect other compilers...
-       epatch "${FILESDIR}/${P}-gcc-3.4.patch"
+# Let's honour Gentoo CFLAGS and use correct install program
+# Fix for #61704, cannot compile with gcc 3.4.1:
+# it's a trivial change and does not affect other compilers...
+PATCHES=( "${FILESDIR}/${P}-Makefile.patch"
+       "${FILESDIR}/${P}-gcc-3.4.patch" )
 
+DOCS=( README HACKING AUTHORS )
+
+src_prepare() {
+       default
        # Fix parallel compilation
-       sed -ie "s/make EXTRACFLAGS/make \${MAKEOPTS} EXTRACFLAGS/" Makefile
+       sed -ie "s/make EXTRACFLAGS/make \${MAKEOPTS} EXTRACFLAGS/" Makefile || die
 
        # Honour Gentoo LDFLAGS, see bug #336296
-       sed -ie "s/-o wmsystray/${LDFLAGS} -o wmsystray/" wmsystray/Makefile
+       sed -ie "s/-o wmsystray/${LDFLAGS} -o wmsystray/" wmsystray/Makefile || die
 }
 
 src_compile() {
-       emake EXTRACFLAGS="${CFLAGS}" || die "emake failed"
+       emake EXTRACFLAGS="${CFLAGS}"
 }
 
 src_install() {
-       einstall || die "einstall failed"
-       dodoc AUTHORS HACKING README || die
-
+       dobin ${PN}/${PN}
+       doman doc/${PN}.1
        domenu "${FILESDIR}/${PN}.desktop"
+       einstalldocs
 }

```
diff -u wmtime:
```
--- wmtime-1.4.ebuild   2018-05-23 19:05:41.676212433 +0200
+++ wmtime-1.4-r1.ebuild        2018-07-24 20:09:17.509893036 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="applet which displays the date and time in a dockable tile"
@@ -11,7 +11,6 @@
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 RDEPEND=">=x11-libs/libdockapp-0.7:=
        x11-libs/libX11
@@ -22,12 +21,13 @@
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
+DOCS=( BUGS CHANGES HINTS README TODO )
+
 src_compile() {
        emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
 }
 
 src_install () {
        emake DESTDIR="${D}" PREFIX=/usr install
-
-       dodoc BUGS CHANGES HINTS README TODO
+       einstalldocs
 }
```