### PR TITLE
x11-plugins/{wmwork,wmxkb,wmxres}: EAPI7, improve ebuild

### DIFF
--- a/x11-plugins/wmwork/wmwork-0.2.5-r1.ebuild
+++ b/x11-plugins/wmwork/wmwork-0.2.5-r1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="a dockapp that lets you easily track time spent on different projects"
+HOMEPAGE="https://www.dockapps.net/wmwork"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND=">=x11-libs/libXext-1.0.3
+	>=x11-libs/libX11-1.1.1-r1
+	>=x11-libs/libXpm-3.5.6"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+S="${WORKDIR}/${P}/src"
+
+DOCS=( ../{CHANGES,README} )

--- a/x11-plugins/wmwork/wmwork-0.2.5.ebuild
+++ b/x11-plugins/wmwork/wmwork-0.2.5.ebuild
@@ -4,8 +4,8 @@
 EAPI=0
 
 DESCRIPTION="a dockapp that lets you easily track time spent on different projects"
-HOMEPAGE="http://www.godisch.de/debian/wmwork"
-SRC_URI="http://www.godisch.de/debian/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.dockapps.net/wmwork"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-plugins/wmxkb/wmxkb-1.2.2-r1.ebuild
+++ b/x11-plugins/wmxkb/wmxkb-1.2.2-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Dockable keyboard layout switcher for Window Maker"
+HOMEPAGE="http://wmalms.tripod.com/#WMXKB"
+SRC_URI="http://wmalms.tripod.com/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXt
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+DOCS=( CHANGES README )
+HTML_DOCS=( doc/manual{,_body,_title}.html )
+
+src_prepare() {
+	default
+	sed -i -e 's:$(LD) -o:$(CC) $(LDFLAGS) -o:' Makefile.in || die #336528
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin wmxkb
+	insinto /usr/share/pixmaps/wmxkb
+	doins pixmaps/*.xpm
+	einstalldocs
+}

--- a/x11-plugins/wmxres/wmxres-1.2-r1.ebuild
+++ b/x11-plugins/wmxres/wmxres-1.2-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="Dock application to select your display mode among those possible"
+HOMEPAGE="http://yalla.free.fr/wn"
+SRC_URI="http://yalla.free.fr/wn/${PN}-1.1-0.tar.gz"
+
+LICENSE="GPL-1"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm
+	x11-libs/libXxf86vm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto
+	x11-libs/libXxf86dga"
+
+S="${WORKDIR}/${PN}.app"
+
+PATCHES=( "${FILESDIR}"/${PN}-debian-1.1-1.2.patch )
+
+src_prepare() {
+	default
+	sed -e "s:-g -c -O2:${CFLAGS} -c:" \
+		-e "s:\tcc :\t $(tc-getCC) \$(LDFLAGS) :g" \
+		-i Makefile || die "sed failed"
+}
+
+src_compile() {
+	emake INCDIR="-I/usr/include" LIBDIR="-L/usr/$(get_libdir)"
+}
+
+src_install() {
+	dobin ${PN}/${PN}
+	doman ${PN}.1
+}


### PR DESCRIPTION
Hi,

Another round of updates. Please review.

diff -u wmwork:
```
--- wmwork-0.2.5.ebuild 2018-07-24 20:48:51.867270590 +0200
+++ wmwork-0.2.5-r1.ebuild      2018-07-24 20:48:51.867270590 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
 DESCRIPTION="a dockapp that lets you easily track time spent on different projects"
 HOMEPAGE="https://www.dockapps.net/wmwork"
@@ -9,8 +9,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND=">=x11-libs/libXext-1.0.3
        >=x11-libs/libX11-1.1.1-r1
@@ -18,9 +17,6 @@
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
-S=${WORKDIR}/${P}/src
+S="${WORKDIR}/${P}/src"
 
-src_install() {
-       emake DESTDIR="${D}" install || die "emake install failed."
-       dodoc ../{CHANGES,README}
-}
+DOCS=( ../{CHANGES,README} )
```
diff -u wmxkb:
```
--- wmxkb-1.2.2.ebuild  2018-07-24 20:42:56.233333914 +0200
+++ wmxkb-1.2.2-r1.ebuild       2018-07-24 20:48:51.867270590 +0200
@@ -1,7 +1,8 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
+EAPI=7
+
 inherit toolchain-funcs
 
 DESCRIPTION="Dockable keyboard layout switcher for Window Maker"
@@ -10,8 +11,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXt
@@ -20,20 +20,21 @@
 DEPEND="${RDEPEND}
        x11-base/xorg-proto"
 
+DOCS=( CHANGES README )
+HTML_DOCS=( doc/manual{,_body,_title}.html )
+
 src_prepare() {
+       default
        sed -i -e 's:$(LD) -o:$(CC) $(LDFLAGS) -o:' Makefile.in || die #336528
 }
 
 src_compile() {
-       emake CC="$(tc-getCC)" || die
+       emake CC="$(tc-getCC)"
 }
 
 src_install() {
-       dobin wmxkb || die #242188
-
+       dobin wmxkb
        insinto /usr/share/pixmaps/wmxkb
-       doins pixmaps/*.xpm || die
-
-       dodoc CHANGES README || die #350496
-       dohtml doc/*.html || die
+       doins pixmaps/*.xpm
+       einstalldocs
 }
```
diff -u wmxres:
```
--- wmxres-1.2.ebuild   2018-05-23 19:05:41.677212409 +0200
+++ wmxres-1.2-r1.ebuild        2018-07-24 20:48:51.868270561 +0200
@@ -1,8 +1,8 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
-inherit eutils multilib toolchain-funcs
+EAPI=7
+inherit toolchain-funcs
 
 DESCRIPTION="Dock application to select your display mode among those possible"
 HOMEPAGE="http://yalla.free.fr/wn"
@@ -10,8 +10,7 @@
 
 LICENSE="GPL-1"
 SLOT="0"
-KEYWORDS="~amd64 x86 ~ppc"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
 
 RDEPEND="x11-libs/libX11
        x11-libs/libXext
@@ -21,10 +20,12 @@
        x11-base/xorg-proto
        x11-libs/libXxf86dga"
 
-S=${WORKDIR}/${PN}.app
+S="${WORKDIR}/${PN}.app"
+
+PATCHES=( "${FILESDIR}"/${PN}-debian-1.1-1.2.patch )
 
 src_prepare() {
-       epatch "${FILESDIR}"/${PN}-debian-1.1-1.2.patch
+       default
        sed -e "s:-g -c -O2:${CFLAGS} -c:" \
                -e "s:\tcc :\t $(tc-getCC) \$(LDFLAGS) :g" \
                -i Makefile || die "sed failed"
```