### PR TITLE
media-gfx/mypaint: fix multilib support for no SYMLINK_LIB support

### DIFF
--- a/media-gfx/mypaint/mypaint-1.2.1.ebuild
+++ b/media-gfx/mypaint/mypaint-1.2.1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit fdo-mime gnome2-utils multilib scons-utils toolchain-funcs python-single-r1
+inherit fdo-mime gnome2-utils scons-utils toolchain-funcs python-single-r1
 
 DESCRIPTION="fast and easy graphics application for digital painters"
 HOMEPAGE="http://mypaint.org/"
@@ -38,14 +38,6 @@ REQUIRED_USE=${PYTHON_REQUIRED_USE}
 
 pkg_setup() {
 	python-single-r1_pkg_setup
-}
-
-src_prepare() {
-	default
-
-	# multilib support
-	sed -i -e "s:lib\/${PN}:$(get_libdir)\/${PN}:" \
-		SConstruct SConscript || die
 }
 
 src_compile() {


### PR DESCRIPTION
Package-Manager: Portage-2.3.43, Repoman-2.3.10

This is a proposal to fix bug #648960: multilib support is not complete, the lib path is changed from "lib" to $(get_libdir), but the binary still hardcode the "lib" path.
This patch address this issue and patch the binary too, to use $(get_libdir).

Closes: https://bugs.gentoo.org/648960