### PR TITLE
dev-ruby/facter: ebuild cleanup

### DIFF
--- a/dev-ruby/facter/facter-3.11.3-r1.ebuild
+++ b/dev-ruby/facter/facter-3.11.3-r1.ebuild
@@ -17,18 +17,16 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/puppetlabs/facter.git"
 	EGIT_BRANCH="master"
-	S="${S}/${P}"
 else
 	[[ "${PV}" = *_rc* ]] || \
 	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 	SRC_URI="https://github.com/puppetlabs/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	S="${S}/all/${P}"
 fi
 
 BDEPEND="
 	>=sys-devel/gcc-4.8:*
 	dev-cpp/cpp-hocon"
-CDEPEND="
+COMMON_DEPEND="
 	>=dev-libs/leatherman-1.0.0:=
 	dev-libs/openssl:*
 	sys-apps/util-linux
@@ -40,23 +38,29 @@ CDEPEND="
 
 ruby_add_bdepend "test? ( dev-ruby/rake dev-ruby/rspec:2 dev-ruby/mocha:0.14 )"
 
-RDEPEND="${CDEPEND}"
+RDEPEND="${COMMON_DEPEND}"
 DEPEND="${BDEPEND}
-	${CDEPEND}"
+	${COMMON_DEPEND}"
+
+# restore ${S} and override all phases exported by ruby-ng.eclass
+S="${WORKDIR}/${P}"
+
+pkg_setup() {
+	ruby-ng_pkg_setup
+}
+
+src_unpack() {
+	default
+
+	if [[ ${PV} == 9999 ]] ; then
+		git-r3_src_unpack
+	fi
+}
 
 src_prepare() {
-	# Remove the code that installs facter.rb to the wrong directory.
-	sed -i '/install(.*facter\.rb/d' lib/CMakeLists.txt || die
-	sed -i '/install(.*facter\.jar/d' lib/CMakeLists.txt || die
-	# make it support multilib
-	sed -i "s/\ lib)/\ $(get_libdir))/g" lib/CMakeLists.txt || die
-	sed -i "s/lib\")/$(get_libdir)\")/g" CMakeLists.txt || die
-	# make the require work
-	sed -i 's/\${LIBFACTER_INSTALL_DESTINATION}\///g' lib/facter.rb.in || die
-	# be explicit about the version of rspec we test with and use the
-	# correct lib directory for tests
+	# be explicit about the version of rspec we test with
 	sed -i -e '/libfacter.*specs/ s/rspec/rspec-2/' \
-		-e '/libfacter.*specs/ s/lib64/lib/' CMakeLists.txt || die
+		CMakeLists.txt || die
 	# be more lenient for software versions for tests
 	sed -i -e '/rake/ s/~> 10.1.0/>= 10/' \
 		-e '/rspec/ s/2.11.0/2.11/' \
@@ -66,12 +70,18 @@ src_prepare() {
 	cmake-utils_src_prepare
 }
 
+each_ruby_configure() {
+	# hack for correct calculation of relative path from facter.rb to
+	# libfacter.so
+	my_ruby_sitelibdir=$(ruby_rbconfig_value 'sitelibdir')
+}
+
 src_configure() {
+	ruby-ng_src_configure
+
 	local mycmakeargs=(
 		-DCMAKE_VERBOSE_MAKEFILE=ON
-		-DCMAKE_BUILD_TYPE=None
-		-DCMAKE_INSTALL_PREFIX=/usr
-		-DBLKID_LIBRARY=/$(get_libdir)/libblkid.so.1
+		-DRUBY_LIB_INSTALL=${my_ruby_sitelibdir}
 	)
 	if use debug; then
 		mycmakeargs+=(
@@ -85,21 +95,15 @@ src_compile() {
 	cmake-utils_src_compile
 }
 
-each_ruby_install() {
-	doruby "${BUILD_DIR}"/lib/facter.rb
-}
-
 src_test() {
 	cmake-utils_src_test
+}
+
+each_ruby_install() {
+	doruby "${BUILD_DIR}"/lib/facter.rb
 }
 
 src_install() {
 	cmake-utils_src_install
 	ruby-ng_src_install
-
-	# need a variable file in env.d :(
-	diropts -m0755
-	dodir /etc/env.d
-	echo -n "FACTERDIR=/usr/$(get_libdir)" > "${D}/etc/env.d/00facterdir"
-	fperms 0644 /etc/env.d/00facterdir
 }

--- a/dev-ruby/facter/facter-9999.ebuild
+++ b/dev-ruby/facter/facter-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-USE_RUBY="ruby21 ruby22 ruby23 ruby24"
+USE_RUBY="ruby23 ruby24 ruby25"
 
 # git-r3 goes after ruby-ng so that it overrides src_unpack properly
 inherit cmake-utils eutils multilib ruby-ng
@@ -17,18 +17,16 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/puppetlabs/facter.git"
 	EGIT_BRANCH="master"
-	S="${S}/${P}"
 else
 	[[ "${PV}" = *_rc* ]] || \
 	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 	SRC_URI="https://github.com/puppetlabs/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	S="${S}/all/${P}"
 fi
 
 BDEPEND="
 	>=sys-devel/gcc-4.8:*
 	dev-cpp/cpp-hocon"
-CDEPEND="
+COMMON_DEPEND="
 	>=dev-libs/leatherman-1.0.0:=
 	dev-libs/openssl:*
 	sys-apps/util-linux
@@ -40,23 +38,29 @@ CDEPEND="
 
 ruby_add_bdepend "test? ( dev-ruby/rake dev-ruby/rspec:2 dev-ruby/mocha:0.14 )"
 
-RDEPEND="${CDEPEND}"
+RDEPEND="${COMMON_DEPEND}"
 DEPEND="${BDEPEND}
-	${CDEPEND}"
+	${COMMON_DEPEND}"
+
+# restore ${S} and override all phases exported by ruby-ng.eclass
+S="${WORKDIR}/${P}"
+
+pkg_setup() {
+	ruby-ng_pkg_setup
+}
+
+src_unpack() {
+	default
+
+	if [[ ${PV} == 9999 ]] ; then
+		git-r3_src_unpack
+	fi
+}
 
 src_prepare() {
-	# Remove the code that installs facter.rb to the wrong directory.
-	sed -i '/install(.*facter\.rb/d' lib/CMakeLists.txt || die
-	sed -i '/install(.*facter\.jar/d' lib/CMakeLists.txt || die
-	# make it support multilib
-	sed -i "s/\ lib)/\ $(get_libdir))/g" lib/CMakeLists.txt || die
-	sed -i "s/lib\")/$(get_libdir)\")/g" CMakeLists.txt || die
-	# make the require work
-	sed -i 's/\${LIBFACTER_INSTALL_DESTINATION}\///g' lib/facter.rb.in || die
-	# be explicit about the version of rspec we test with and use the
-	# correct lib directory for tests
+	# be explicit about the version of rspec we test with
 	sed -i -e '/libfacter.*specs/ s/rspec/rspec-2/' \
-		-e '/libfacter.*specs/ s/lib64/lib/' CMakeLists.txt || die
+		CMakeLists.txt || die
 	# be more lenient for software versions for tests
 	sed -i -e '/rake/ s/~> 10.1.0/>= 10/' \
 		-e '/rspec/ s/2.11.0/2.11/' \
@@ -66,12 +70,18 @@ src_prepare() {
 	cmake-utils_src_prepare
 }
 
+each_ruby_configure() {
+	# hack for correct calculation of relative path from facter.rb to
+	# libfacter.so
+	my_ruby_sitelibdir=$(ruby_rbconfig_value 'sitelibdir')
+}
+
 src_configure() {
+	ruby-ng_src_configure
+
 	local mycmakeargs=(
 		-DCMAKE_VERBOSE_MAKEFILE=ON
-		-DCMAKE_BUILD_TYPE=None
-		-DCMAKE_INSTALL_PREFIX=/usr
-		-DBLKID_LIBRARY=/$(get_libdir)/libblkid.so.1
+		-DRUBY_LIB_INSTALL=${my_ruby_sitelibdir}
 	)
 	if use debug; then
 		mycmakeargs+=(
@@ -85,21 +95,15 @@ src_compile() {
 	cmake-utils_src_compile
 }
 
-each_ruby_install() {
-	doruby "${BUILD_DIR}"/lib/facter.rb
-}
-
 src_test() {
 	cmake-utils_src_test
+}
+
+each_ruby_install() {
+	doruby "${BUILD_DIR}"/lib/facter.rb
 }
 
 src_install() {
 	cmake-utils_src_install
 	ruby-ng_src_install
-
-	# need a variable file in env.d :(
-	diropts -m0755
-	dodir /etc/env.d
-	echo -n "FACTERDIR=/usr/$(get_libdir)" > "${D}/etc/env.d/00facterdir"
-	fperms 0644 /etc/env.d/00facterdir
 }


### PR DESCRIPTION
Cleanup:
- do not use ${S} set by ruby-ng.eclass
- correctly generate facter.rb, FACTERDIR environment variable is no
  longer required
- remove no longer needed environment file
- remove no longer needed multilib magic

Bug: https://bugs.gentoo.org/601746