### PR TITLE
dev-tex/biber-2.5: add patch to fix perl-5.26 warnings

### DIFF
--- a/dev-tex/biber/biber-2.5-r1.ebuild
+++ b/dev-tex/biber/biber-2.5-r1.ebuild
@@ -9,12 +9,12 @@ DESCRIPTION="A BibTeX replacement for users of biblatex"
 HOMEPAGE="http://biblatex-biber.sourceforge.net/ https://github.com/plk/biber/"
 SRC_URI="https://github.com/plk/biber/archive/v${PV}.tar.gz  -> ${P}.tar.gz"
 
-LICENSE="Artistic-2"
+LICENSE="|| ( Artistic-2 GPL-1 GPL-2 GPL-3 )"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
-IUSE="test"
+KEYWORDS="~amd64"
+IUSE="doc test"
 
-RDEPEND=">=dev-lang/perl-5.24
+RDEPEND=">=dev-lang/perl-5.16
 	dev-perl/autovivification
 	dev-perl/Business-ISBN
 	dev-perl/Business-ISMN
@@ -23,46 +23,55 @@ RDEPEND=">=dev-lang/perl-5.24
 	dev-perl/Data-Compare
 	dev-perl/Data-Dump
 	dev-perl/Data-Uniqid
-	dev-perl/DateTime-Calendar-Julian
-	dev-perl/DateTime-Format-Builder
+	dev-perl/Date-Simple
 	dev-perl/Encode-EUCJPASCII
 	dev-perl/Encode-HanExtra
 	dev-perl/Encode-JIS2K
-	dev-perl/File-Slurp
+	dev-perl/File-Slurp-Unicode
 	dev-perl/IPC-Run3
 	dev-perl/libwww-perl[ssl]
-	>=dev-perl/Lingua-Translit-0.250
+	>=dev-perl/Lingua-Translit-0.25
 	dev-perl/List-AllUtils
-	dev-perl/List-MoreUtils
-	dev-perl/List-MoreUtils-XS
+	>=dev-perl/List-MoreUtils-0.408.0
 	dev-perl/Log-Log4perl
 	dev-perl/LWP-Protocol-https
 	dev-perl/Regexp-Common
-	dev-perl/Sort-Key
-	>=dev-perl/Text-BibTeX-0.760.0
-	dev-perl/Text-CSV
-	dev-perl/Text-CSV_XS
+	dev-perl/Readonly
+	dev-perl/Readonly-XS
 	dev-perl/Text-Roman
+	>=dev-perl/Text-BibTeX-0.720.0
 	dev-perl/URI
-	>=dev-perl/Unicode-LineBreak-2016.3.0
-	>=virtual/perl-Unicode-Normalize-1.250.0
-	>=dev-perl/XML-LibXML-1.70
+	dev-perl/Unicode-LineBreak
+	>=virtual/perl-Unicode-Normalize-1.230.0
+	dev-perl/XML-LibXML
 	dev-perl/XML-LibXML-Simple
 	dev-perl/XML-LibXSLT
+	dev-perl/XML-SAX-Base
 	dev-perl/XML-Writer
-	~dev-tex/biblatex-3.7
+	~dev-tex/biblatex-3.4
 	virtual/perl-IPC-Cmd
-	>=virtual/perl-Unicode-Collate-1.190.0"
+	>=virtual/perl-Unicode-Collate-1.140.0"
 DEPEND="${RDEPEND}
 	dev-perl/Config-AutoConf
 	dev-perl/Module-Build
-	dev-perl/ExtUtils-LibBuilder
 	test? ( dev-perl/File-Which
-			dev-perl/Test-Differences )"
+			dev-perl/Test-Differences
+			dev-perl/Test-Pod
+			dev-perl/Test-Pod-Coverage
+			~virtual/perl-Unicode-Collate-1.140.0 )"
+
+SRC_TEST="parallel"
 
 PATCHES=(
-	"${FILESDIR}/${PN}-2.7-drop-mozilla-ca.patch"
-	"${FILESDIR}/${PN}-2.5-unescaped-left-brace-in-regex.patch"
+	"${FILESDIR}"/${PN}-2.4-drop-mozilla-ca.patch
+	"${FILESDIR}"/${PN}-2.5-unescaped-left-brace-in-regex.patch
 	)
 
-mydoc="doc/biber.tex"
+src_install(){
+	perl-module_src_install
+	use doc && dodoc -r doc
+}
+
+src_test() {
+	BIBER_SKIP_DEV_TESTS=1 perl-module_src_test
+}

--- a/dev-tex/biber/files/biber-2.5-unescaped-left-brace-in-regex.patch
+++ b/dev-tex/biber/files/biber-2.5-unescaped-left-brace-in-regex.patch
@@ -1,0 +1,12 @@
+diff -Naur ./lib/Biber/LaTeX/Recode.pm ./lib/Biber/LaTeX/Recode.pm
+--- ./lib/Biber/LaTeX/Recode.pm	2018-07-25 21:20:25.961547631 +0200
++++ ./lib/Biber/LaTeX/Recode.pm	2018-07-25 21:20:06.653779312 +0200
+@@ -292,7 +292,7 @@
+     # Workaround perl's lack of variable-width negative look-behind -
+     # Reverse string (and therefore some of the Re) and use variable width negative look-ahead
+     $text = reverse $text;
+-    $text =~ s/}(\pM+\pL){(?!\pL+\\)/$1/g;
++    $text =~ s/}(\pM+\pL)\{(?!\pL+\\)/$1/g;
+     $text = reverse $text;
+     $logger->trace("String in latex_decode() now -> '$text'");
+ 


### PR DESCRIPTION
Trivial patch to fix the warning just doing what the warnings says.

Bug: https://bugs.gentoo.org/623410
Package-Manager: Portage-2.3.42, Repoman-2.3.9