### PR TITLE
sys-fs/davl: Remove ~amd64

### DIFF
--- a/sys-fs/davl/davl-1.2.4-r2.ebuild
+++ b/sys-fs/davl/davl-1.2.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~x86"
 IUSE=""
 
 RDEPEND=">=x11-libs/gtk+-2.6:2"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/662150
Package-Manager: Portage-2.3.40, Repoman-2.3.9