### PR TITLE
media-gfx/wings: dependency default for the "smp" USE flag 

### DIFF
--- a/media-gfx/wings/wings-2.1.7-r1.ebuild
+++ b/media-gfx/wings/wings-2.1.7-r1.ebuild
@@ -13,7 +13,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
-	>=dev-lang/erlang-18.1[smp,wxwidgets]
+	>=dev-lang/erlang-18.1[smp(+),wxwidgets]
 	dev-libs/cl
 	media-libs/glu
 	media-libs/libsdl[opengl]


### PR DESCRIPTION
the "smp" USE flag is no longer available in dev-lang/erlang-21.0.x
related PR: https://github.com/gentoo/gentoo/pull/9357