### PR TITLE
net-im/telegram-desktop-bin: exclude from session management

### DIFF
--- a/net-im/telegram-desktop-bin/files/telegram-desktop-bin-r1
+++ b/net-im/telegram-desktop-bin/files/telegram-desktop-bin-r1
@@ -1,0 +1,9 @@
+#!/bin/sh
+# this wrapper disables the auto-updater of telegram-desktop
+# This program is licensed under the same license as telegram-desktop
+
+# telegram-desktop fails to set RestartCommand with the session manager
+# exclude it from session management to prevent restarts without the argument
+unset SESSION_MANAGER
+
+exec /usr/lib/telegram-desktop-bin/Telegram -externalupdater $@

--- a/net-im/telegram-desktop-bin/telegram-desktop-bin-1.3.10-r1.ebuild
+++ b/net-im/telegram-desktop-bin/telegram-desktop-bin-1.3.10-r1.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit desktop gnome2-utils xdg
+
+DESCRIPTION="Official desktop client for Telegram (binary package)"
+HOMEPAGE="https://desktop.telegram.org"
+SRC_URI="
+	https://github.com/telegramdesktop/tdesktop/archive/v${PV}.tar.gz -> tdesktop-${PV}.tar.gz
+	amd64? ( https://updates.tdesktop.com/tlinux/tsetup.${PV}.tar.xz )
+	x86? ( https://updates.tdesktop.com/tlinux32/tsetup32.${PV}.tar.xz )
+"
+
+LICENSE="telegram"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+QA_PREBUILT="usr/lib/${PN}/Telegram"
+
+RDEPEND="
+	dev-libs/glib:2
+	dev-libs/gobject-introspection
+	>=sys-apps/dbus-1.4.20
+	x11-libs/libX11
+	>=x11-libs/libxcb-1.10[xkb]
+"
+
+S="${WORKDIR}/Telegram"
+
+src_install() {
+	exeinto /usr/lib/${PN}
+	doexe "Telegram"
+	newbin "${FILESDIR}"/${PN}-r1 "telegram-desktop"
+
+	local icon_size
+	for icon_size in 16 32 48 64 128 256 512; do
+		newicon -s "${icon_size}" \
+			"${WORKDIR}/tdesktop-${PV}/Telegram/Resources/art/icon${icon_size}.png" \
+			telegram-desktop.png
+	done
+
+	domenu "${WORKDIR}/tdesktop-${PV}"/lib/xdg/telegramdesktop.desktop
+}
+
+pkg_preinst() {
+	xdg_pkg_preinst
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
The application seems to register with the X11 session manager but fails
to follow the protocol for remembering its state. The result is that a
session manager will restart it, and during that process the command
line argument for disabling the internal updater gets lost.
So on a restarted session the updater will be enabled again.

Do not let the application register at the session manager in the first
place, by unsetting the env variable used to find it.

Closes: https://bugs.gentoo.org/662330
Signed-off-by: Henning Schild <henning@hennsch.de>