### PR TITLE
media-libs/libclalsadrv: EAPI7, improve ebuild

### DIFF
--- a/media-libs/libclalsadrv/libclalsadrv-2.0.0-r1.ebuild
+++ b/media-libs/libclalsadrv/libclalsadrv-2.0.0-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+MY_P=${P/lib}
+
+DESCRIPTION="ALSA driver C++ access library"
+HOMEPAGE="http://packages.debian.org/libclalsadrv"
+SRC_URI="mirror://gentoo/${MY_P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="media-libs/alsa-lib"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/${P/lib}/libs"
+
+PATCHES=( "${FILESDIR}"/${P}-makefile.patch )
+
+src_compile() {
+	tc-export CXX
+	emake
+}
+
+src_install() {
+	emake LIBDIR="$(get_libdir)" PREFIX="${D}/usr" install
+	dodoc ../AUTHORS
+}


### PR DESCRIPTION
Hi,

This PR updates media-libs/libclalsadrv for EAPI7.

diff -u:
```
--- libclalsadrv-2.0.0.ebuild   2017-03-19 10:57:13.416786262 +0100
+++ libclalsadrv-2.0.0-r1.ebuild        2018-07-28 19:39:14.345711901 +0200
@@ -1,8 +1,8 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
-inherit eutils multilib toolchain-funcs
+EAPI=7
+inherit toolchain-funcs
 
 MY_P=${P/lib}
 
@@ -12,17 +12,14 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc ~sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 
 RDEPEND="media-libs/alsa-lib"
 DEPEND="${RDEPEND}"
 
-S=${WORKDIR}/${P/lib}/libs
+S="${WORKDIR}/${P/lib}/libs"
 
-src_prepare() {
-       epatch "${FILESDIR}"/${P}-makefile.patch
-}
+PATCHES=( "${FILESDIR}"/${P}-makefile.patch )
 
 src_compile() {
        tc-export CXX
```