### PR TITLE
media-libs/libcdaudio: EAPI7, improve ebuild

### DIFF
--- a/media-libs/libcdaudio/files/libcdaudio-0.99.12-bug245649.patch
+++ b/media-libs/libcdaudio/files/libcdaudio-0.99.12-bug245649.patch
@@ -1,5 +1,5 @@
---- src/cddb.c
-+++ src/cddb.c
+--- a/src/cddb.c
++++ b/src/cddb.c
 @@ -1679,7 +1679,7 @@ cddb_read_disc_data(int cd_desc, struct disc_data *outdata)
        free(file);
  	 

--- a/media-libs/libcdaudio/libcdaudio-0.99.12-r2.ebuild
+++ b/media-libs/libcdaudio/libcdaudio-0.99.12-r2.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Library of cd audio related routines"
+HOMEPAGE="http://libcdaudio.sourceforge.net/"
+SRC_URI="mirror://sourceforge/libcdaudio/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+
+PATCHES=( "${FILESDIR}"/${PN}-0.99-CAN-2005-0706.patch
+	"${FILESDIR}"/${P}-bug245649.patch )
+
+src_configure() {
+	econf --enable-threads
+}


### PR DESCRIPTION
Hi,

This PR updates media-libs/libcdaudio for EAPI7.
Please review

diff -u
```
--- libcdaudio-0.99.12-r1.ebuild        2018-05-06 12:15:30.662164306 +0200
+++ libcdaudio-0.99.12-r2.ebuild        2018-07-28 19:42:11.369818530 +0200
@@ -1,9 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
-
-inherit eutils
+EAPI=7
 
 DESCRIPTION="Library of cd audio related routines"
 HOMEPAGE="http://libcdaudio.sourceforge.net/"
@@ -11,22 +9,11 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
-IUSE=""
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
 
-src_unpack() {
-       unpack ${A}
-       cd "${S}"
-       epatch "${FILESDIR}"/${PN}-0.99-CAN-2005-0706.patch #84936
-       epatch "${FILESDIR}"/${P}-bug245649.patch
-}
+PATCHES=( "${FILESDIR}"/${PN}-0.99-CAN-2005-0706.patch
+       "${FILESDIR}"/${P}-bug245649.patch )
 
-src_compile() {
+src_configure() {
        econf --enable-threads
-       emake || die "compile problem."
-}
-
-src_install() {
-       emake DESTDIR="${D}" install || die "make install failed"
-       dodoc AUTHORS ChangeLog NEWS README TODO
 }
```