### PR TITLE
media-libs/libifp: EAPI7, improve ebuild

### DIFF
--- a/media-libs/libifp/libifp-1.0.0.2-r1.ebuild
+++ b/media-libs/libifp/libifp-1.0.0.2-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="A general-purpose library for iRiver's iFP portable audio players"
+HOMEPAGE="http://ifp-driver.sourceforge.net/libifp/"
+SRC_URI="mirror://sourceforge/ifp-driver/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~x86"
+IUSE="doc examples static-libs"
+
+RDEPEND="virtual/libusb:0"
+DEPEND="${RDEPEND}
+	doc? ( >=app-doc/doxygen-1.3.7 )"
+
+src_prepare() {
+	default
+	sed -i \
+		-e '/CFLAGS=/s:-g -O2:${CFLAGS}:' \
+		-e '/CXXFLAGS=/s:-g -O2:${CXXFLAGS}:' \
+		configure || die
+}
+
+src_configure() {
+	use doc || export have_doxygen=no
+
+	econf \
+		--disable-dependency-tracking \
+		$(use_enable static-libs static) \
+		$(use_enable examples) \
+		--with-libusb \
+		--without-kmodule
+}
+
+src_test() { :; } # hardware dependant wrt #318597
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	find "${D}" -name '*.la' -exec rm -f {} + || die
+
+	# clean /usr/bin after installation
+	# by moving examples to examples dir
+	if use examples; then
+	    insinto /usr/share/${PN}/examples
+	    doins "${S}"/examples/simple.c "${S}"/examples/ifpline.c
+	    mv "${D}"/usr/bin/{simple,ifpline} "${D}"/usr/share/${PN}/examples || die
+	else
+	    rm -f "${D}"/usr/bin/{simple,ifpline} || die
+	fi
+
+	use doc && dodoc README ChangeLog TODO
+}


### PR DESCRIPTION
Hi,

This PR updates media-libs/libifp for EAPI7.
Please review.

diff -u
```
--- libifp-1.0.0.2.ebuild       2017-03-19 10:57:13.433786261 +0100
+++ libifp-1.0.0.2-r1.ebuild    2018-07-28 19:47:20.137070422 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=2
+EAPI=7
 
 DESCRIPTION="A general-purpose library for iRiver's iFP portable audio players"
 HOMEPAGE="http://ifp-driver.sourceforge.net/libifp/"
@@ -9,15 +9,15 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ia64 ppc ppc64 x86"
+KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~x86"
 IUSE="doc examples static-libs"
 
 RDEPEND="virtual/libusb:0"
 DEPEND="${RDEPEND}
-       doc? ( >=app-doc/doxygen-1.3.7 )
-       sys-apps/sed"
+       doc? ( >=app-doc/doxygen-1.3.7 )"
 
 src_prepare() {
+       default
        sed -i \
                -e '/CFLAGS=/s:-g -O2:${CFLAGS}:' \
                -e '/CXXFLAGS=/s:-g -O2:${CXXFLAGS}:' \
@@ -38,18 +38,18 @@
 src_test() { :; } # hardware dependant wrt #318597
 
 src_install() {
-       emake DESTDIR="${D}" install || die
+       emake DESTDIR="${D}" install
 
-       find "${D}" -name '*.la' -exec rm -f {} +
+       find "${D}" -name '*.la' -exec rm -f {} + || die
 
        # clean /usr/bin after installation
        # by moving examples to examples dir
        if use examples; then
            insinto /usr/share/${PN}/examples
            doins "${S}"/examples/simple.c "${S}"/examples/ifpline.c
-           mv "${D}"/usr/bin/{simple,ifpline} "${D}"/usr/share/${PN}/examples
+           mv "${D}"/usr/bin/{simple,ifpline} "${D}"/usr/share/${PN}/examples || die
        else
-           rm -f "${D}"/usr/bin/{simple,ifpline}
+           rm -f "${D}"/usr/bin/{simple,ifpline} || die
        fi
 
        use doc && dodoc README ChangeLog TODO
```