### PR TITLE
sys-boot/systemrescuecd-x86-grub: update to 0.1-r2

### DIFF
--- a/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.grub
+++ b/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.grub
@@ -44,20 +44,6 @@ ${grub_string}
 		linux (loop)/isolinux/rescue64 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
 		initrd (loop)/isolinux/initram.igz
 	}
-	menuentry "${longname} (32bit alternative${bootops}" --class rescue {
-${grub_string}
-		set isofile=${path}
-		loopback loop \${isofile}
-		linux (loop)/isolinux/altker32 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
-		initrd (loop)/isolinux/initram.igz
-	}
-	menuentry "${longname} (64bit alternative${bootops}" --class rescue {
-${grub_string}
-		set isofile=${path}
-		loopback loop \${isofile}
-		linux (loop)/isolinux/altker64 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
-		initrd (loop)/isolinux/initram.igz
-	}
 }
 EOF
 

--- a/sys-boot/systemrescuecd-x86-grub/systemrescuecd-x86-grub-0.1-r2.ebuild
+++ b/sys-boot/systemrescuecd-x86-grub/systemrescuecd-x86-grub-0.1-r2.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Grub menu entries for the .iso image of systemrescuecd-x86"
+HOMEPAGE="http://www.sysresccd.org/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT=0
+KEYWORDS="~amd64 ~x86"
+
+S=${WORKDIR}
+
+RDEPEND="app-admin/systemrescuecd-x86
+	sys-boot/grub"
+
+src_install() {
+	exeinto /etc/grub.d
+	newexe "${FILESDIR}"/systemrescuecd.grub 39_systemrescuecd
+
+	insinto /etc/default
+	newins "${FILESDIR}"/systemrescuecd.default systemrescuecd
+}
+
+pkg_postinst() {
+	elog "To add the menu entries for systemrescuecd to grub, you should now run"
+	elog "	grub-mkconfig -o /boot/grub/grub.cfg"
+	elog "You can set custom bootoptions in /etc/default/systemrescuecd"
+}


### PR DESCRIPTION
Alternative kernels has been dropped in systemrescuecd-5.0.0, so drop them also from grub menu.
All stable versions of app-admin/systemrescuecd-x86 ar greater than 5.0.0.

Bug: https://bugs.gentoo.org/659040