### PR TITLE
x11-misc/libinput-gestures: Fix doc directory path

### DIFF
--- a/x11-misc/libinput-gestures/libinput-gestures-2.34.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-2.34.ebuild
@@ -34,7 +34,7 @@ src_prepare() {
 	default
 
 	# Fix docdir installation path
-	sed '/^DOCDIR/s@$NAME@${PF}@' -i libinput-gestures-setup || die
+	sed '/^DOCDIR/s@$NAME@'"${PF}"'@' -i libinput-gestures-setup || die
 }
 
 pkg_postinst() {

--- a/x11-misc/libinput-gestures/libinput-gestures-2.36.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-2.36.ebuild
@@ -34,7 +34,7 @@ src_prepare() {
 	default
 
 	# Fix docdir installation path
-	sed '/^DOCDIR/s@$NAME@${PF}@' -i libinput-gestures-setup || die
+	sed '/^DOCDIR/s@$NAME@'"${PF}"'@' -i libinput-gestures-setup || die
 }
 
 pkg_postinst() {

--- a/x11-misc/libinput-gestures/libinput-gestures-9999.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-9999.ebuild
@@ -34,7 +34,7 @@ src_prepare() {
 	default
 
 	# Fix docdir installation path
-	sed '/^DOCDIR/s@$NAME@${PF}@' -i libinput-gestures-setup || die
+	sed '/^DOCDIR/s@$NAME@'"${PF}"'@' -i libinput-gestures-setup || die
 }
 
 pkg_postinst() {


### PR DESCRIPTION
libinput-gestures-setup uninstall would rm -rfv /usr/share/doc
due to a misconfiguration

Package-Manager: Portage-2.3.40, Repoman-2.3.9