### PR TITLE
x11-misc/libinput-gestures: Fix doc directory path

### DIFF
--- a/x11-misc/libinput-gestures/libinput-gestures-2.41.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-2.41.ebuild
@@ -33,7 +33,7 @@ src_prepare() {
 	default
 
 	# Fix docdir installation path
-	sed '/^DOCDIR/s@$NAME@${PF}@' -i libinput-gestures-setup || die
+	sed '/^DOCDIR/s@$NAME@'"${PF}"'@' -i libinput-gestures-setup || die
 }
 
 src_test() { :; }

--- a/x11-misc/libinput-gestures/libinput-gestures-2.45.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-2.45.ebuild
@@ -33,7 +33,7 @@ src_prepare() {
 	default
 
 	# Fix docdir installation path
-	sed '/^DOCDIR/s@$NAME@${PF}@' -i libinput-gestures-setup || die
+	sed '/^DOCDIR/s@$NAME@'"${PF}"'@' -i libinput-gestures-setup || die
 }
 
 src_test() { :; }

--- a/x11-misc/libinput-gestures/libinput-gestures-2.48.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-2.48.ebuild
@@ -33,7 +33,7 @@ src_prepare() {
 	default
 
 	# Fix docdir installation path
-	sed '/^DOCDIR/s@$NAME@${PF}@' -i libinput-gestures-setup || die
+	sed '/^DOCDIR/s@$NAME@'"${PF}"'@' -i libinput-gestures-setup || die
 }
 
 src_test() { :; }

--- a/x11-misc/libinput-gestures/libinput-gestures-9999.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-9999.ebuild
@@ -33,7 +33,7 @@ src_prepare() {
 	default
 
 	# Fix docdir installation path
-	sed '/^DOCDIR/s@$NAME@${PF}@' -i libinput-gestures-setup || die
+	sed '/^DOCDIR/s@$NAME@'"${PF}"'@' -i libinput-gestures-setup || die
 }
 
 src_test() { :; }


### PR DESCRIPTION
libinput-gestures-setup uninstall would rm -rfv /usr/share/doc
due to a misconfiguration

Package-Manager: Portage-2.3.40, Repoman-2.3.9