### PR TITLE
app-text/enchant: disable zemberek provider in 1.6.1

### DIFF
--- a/app-text/enchant/enchant-1.6.1-r1.ebuild
+++ b/app-text/enchant/enchant-1.6.1-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit versionator
+inherit autotools versionator
 
 MY_PV="$(replace_all_version_separators '-')"
 DESCRIPTION="Spellchecker wrapping library"
@@ -32,11 +32,13 @@ DOCS="AUTHORS BUGS ChangeLog HACKING MAINTAINERS NEWS README TODO"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.6.0-hunspell150_fix.patch
+	"${FILESDIR}"/${PN}-1.6.1-autoconf-zemberek.patch
 )
 
 src_prepare() {
 	default
 	sed -e "/SUBDIRS/ s/unittests//" -i "${S}"/Makefile.{am,in} || die
+	eautoreconf
 }
 
 src_configure() {
@@ -48,6 +50,7 @@ src_configure() {
 		--disable-ispell \
 		--disable-uspell \
 		--disable-voikko \
+		--disable-zemberek \
 		--with-myspell-dir="${EPREFIX}"/usr/share/myspell/
 }
 

--- a/app-text/enchant/files/enchant-1.6.1-autoconf-zemberek.patch
+++ b/app-text/enchant/files/enchant-1.6.1-autoconf-zemberek.patch
@@ -1,0 +1,21 @@
+Allow disabling zemberek provider
+https://bugs.gentoo.org/662484
+
+--- a/configure.ac	2017-04-05 00:13:57.000000000 +0300
++++ b/configure.ac	2018-07-30 20:00:43.597328307 +0300
+@@ -489,10 +489,12 @@
+ AM_CONDITIONAL(WITH_HSPELL, test "$build_hspell" = yes)
+ 
+ build_zemberek=no
++check_zemberek=yes
++AC_ARG_ENABLE(zemberek, AS_HELP_STRING([--disable-zemberek],[enable the experimental zemberek (turkish) backend @<:@default=auto@:>@]), check_zemberek="$enableval", check_zemberek=yes)
+ 
+-AC_ARG_ENABLE(zemberek, AS_HELP_STRING([--disable-zemberek],[enable the experimental zemberek (turkish) backend @<:@default=auto@:>@]), build_zemberek="$enableval", build_zemberek=no)
+-
+-PKG_CHECK_MODULES(ZEMBEREK, [dbus-glib-1 >= 0.62], build_zemberek=yes, build_zemberek=no)
++if test "x$check_zemberek" != "xno"; then
++   PKG_CHECK_MODULES(ZEMBEREK, [dbus-glib-1 >= 0.62], build_zemberek=yes, build_zemberek=no)
++fi
+ 
+ AC_SUBST(ZEMBEREK_CFLAGS)
+ AC_SUBST(ZEMBEREK_LIBS)


### PR DESCRIPTION
zemberek provider causes segmentation faults, it is disabled by default in newer enchant versions and marked as experimental/deprecated.

Also app-text/zemberek-server has been removed from the tree.

Bug: https://bugs.gentoo.org/651616
Closes: https://bugs.gentoo.org/662484