### PR TITLE
x11-wm/xmonad: Remove NoDisplay

### DIFF
--- a/x11-wm/xmonad/files/xmonad.desktop
+++ b/x11-wm/xmonad/files/xmonad.desktop
@@ -5,7 +5,6 @@ Name=xmonad
 Comment=A lightweight window manager
 Exec=/etc/X11/Sessions/xmonad
 TryExec=xmonad
-NoDisplay=true
 Icon=
 X-GNOME-WMName=Xmonad
 X-GNOME-Autostart-Phase=WindowManager


### PR DESCRIPTION
Newer versions of sddm display manager do not add entries from /usr/share/xsessions/ files with "NoDisplay=true".
https://github.com/sddm/sddm/commit/cf4c3caf058ea81d0e61c2087493623faac56a3f
After updating to new sddm the entry for xmonad session is missing.