### PR TITLE
app-misc/bottlerocket: EAPI7, improve ebuild

### DIFF
--- a/app-misc/bottlerocket/bottlerocket-0.04c-r2.ebuild
+++ b/app-misc/bottlerocket/bottlerocket-0.04c-r2.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="CLI interface to the X-10 Firecracker Kit"
+HOMEPAGE="http://www.linuxha.com/bottlerocket/"
+SRC_URI="http://www.linuxha.com/${PN}/${P}.tar.gz"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+src_prepare() {
+	default
+	# inset LDFLAGS
+	sed -i Makefile.in \
+		-e 's| -O2 ||g' \
+		-e '/ -o br /s|${CFLAGS}|& $(LDFLAGS)|g' \
+		|| die "sed Makefile.in"
+}
+
+src_configure() {
+	econf --with-x10port=/dev/firecracker
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dodoc README
+	dobin br
+}
+
+pkg_postinst() {
+	elog
+	elog "Be sure to create a /dev/firecracker symlink to the"
+	elog "serial port that has the Firecracker serial interface"
+	elog "installed on it."
+	elog
+}


### PR DESCRIPTION
Hi, 
This PR updates app-misc/bottlerocket for EAPI7.

Please review.

diff -u:
```
--- bottlerocket-0.04c-r1.ebuild        2017-11-20 12:10:25.040697114 +0100
+++ bottlerocket-0.04c-r2.ebuild        2018-08-01 13:00:38.880204731 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2

-EAPI="2"
+EAPI=7

 inherit toolchain-funcs

@@ -11,10 +11,10 @@

 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc ~sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"

 src_prepare() {
+       default
        # inset LDFLAGS
        sed -i Makefile.in \
                -e 's| -O2 ||g' \
@@ -27,12 +27,12 @@
 }

 src_compile() {
-       emake CC="$(tc-getCC)" || die "emake failed"
+       emake CC="$(tc-getCC)"
 }

 src_install() {
-       einstall || die "einstall"
        dodoc README
+       dobin br
 }

 pkg_postinst() {
```