### PR TITLE
media-libs/libjpeg-turbo: Fix "java/turbojpeg.jar does not exist"

### DIFF
--- a/media-libs/libjpeg-turbo/libjpeg-turbo-2.0.0.ebuild
+++ b/media-libs/libjpeg-turbo/libjpeg-turbo-2.0.0.ebuild
@@ -76,8 +76,9 @@ multilib_src_install() {
 			INSTALL="install -m755" INSTALLDIR="install -d -m755" \
 			install
 
+		popd || die
 		if use java ; then
-			rm -rf "${ED%/}"/usr/classes
+			rm -rf "${ED%/}"/usr/classes || die
 			java-pkg_dojar java/turbojpeg.jar
 		fi
 	fi


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/662578
Package-Manager: Portage-2.3.44, Repoman-2.3.10