### PR TITLE
games-action: missing or unneeded inherits.

### DIFF
--- a/games-action/abuse/abuse-0.8-r1.ebuild
+++ b/games-action/abuse/abuse-0.8-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit autotools eutils
+inherit autotools desktop
 
 DESCRIPTION="Port of Abuse by Crack Dot Com"
 HOMEPAGE="http://abuse.zoy.org/"

--- a/games-action/accelerator3d/accelerator3d-0.1.1-r3.ebuild
+++ b/games-action/accelerator3d/accelerator3d-0.1.1-r3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
-inherit eutils python-r1
+inherit desktop python-r1
 
 DESCRIPTION="Fast-paced, 3D, first-person shoot/dodge-'em-up, in the vain of Tempest or n2o"
 HOMEPAGE="http://accelerator3d.sourceforge.net/"

--- a/games-action/armagetronad/armagetronad-0.2.8.3.3-r1.ebuild
+++ b/games-action/armagetronad/armagetronad-0.2.8.3.3-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils gnome2-utils
+inherit desktop gnome2-utils
 
 DESCRIPTION="Fast-paced 3D lightcycle game based on Tron"
 HOMEPAGE="http://armagetronad.org/"

--- a/games-action/atanks/atanks-6.4-r1.ebuild
+++ b/games-action/atanks/atanks-6.4-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils gnome2-utils toolchain-funcs
+inherit desktop gnome2-utils toolchain-funcs
 
 DESCRIPTION="Worms and Scorched Earth-like game"
 HOMEPAGE="http://atanks.sourceforge.net/"

--- a/games-action/barrage/barrage-1.0.4-r1.ebuild
+++ b/games-action/barrage/barrage-1.0.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit desktop
+inherit desktop gnome2-utils
 
 DESCRIPTION="A violent point-and-click shooting game"
 HOMEPAGE="http://lgames.sourceforge.net/Barrage/"
@@ -25,4 +25,12 @@ src_install() {
 	newicon barrage48.png ${PN}.png
 	make_desktop_entry ${PN} Barrage
 	rm "${ED%/}"/usr/share/applications/${PN}.desktop || die
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
 }

--- a/games-action/barrage/barrage-1.0.4-r1.ebuild
+++ b/games-action/barrage/barrage-1.0.4-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils
+inherit desktop
 
 DESCRIPTION="A violent point-and-click shooting game"
 HOMEPAGE="http://lgames.sourceforge.net/Barrage/"

--- a/games-action/bomberclone/bomberclone-0.11.8-r1.ebuild
+++ b/games-action/bomberclone/bomberclone-0.11.8-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils autotools
+inherit autotools desktop vcs-clean
 
 DESCRIPTION="BomberMan clone with network game support"
 HOMEPAGE="https://www.bomberclone.de/"
@@ -39,7 +39,7 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_with X x) \
-		--datadir=/usr/share
+		--datadir="${EPREFIX}"/usr/share
 	sed -i \
 		-e "/PACKAGE_DATA_DIR/ s:/usr/games/share/games/:/usr/share:" \
 		config.h || die
@@ -52,7 +52,7 @@ src_install() {
 
 	insinto /usr/share/${PN}
 	doins -r data/{gfx,maps,player,tileset,music}
-	find "${D}" -name "Makefile*" -exec rm -f '{}' +
+	find "${D}" -name "Makefile*" -exec rm -f '{}' + || die
 
 	doicon data/pixmaps/bomberclone.png
 	make_desktop_entry bomberclone Bomberclone

--- a/games-action/bzflag/bzflag-2.4.12.ebuild
+++ b/games-action/bzflag/bzflag-2.4.12.ebuild
@@ -39,18 +39,18 @@ src_prepare() {
 }
 
 src_configure() {
-	local myconf
+	local myconf=(
+		$(use_enable upnp UPnP)
+	)
 
 	if use dedicated ; then
 		ewarn
 		ewarn "You are building a server-only copy of BZFlag"
 		ewarn
-		myconf="--disable-client --without-SDL"
+		myconf+=( --disable-client --without-SDL )
 	fi
 
-	econf \
-		$(use_enable upnp UPnP) \
-		${myconf}
+	econf "${myconf[@]}"
 }
 
 src_install() {

--- a/games-action/bzflag/bzflag-2.4.12.ebuild
+++ b/games-action/bzflag/bzflag-2.4.12.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils flag-o-matic autotools
+inherit autotools desktop flag-o-matic ltprune
 
 DESCRIPTION="3D tank combat simulator game"
 HOMEPAGE="https://www.bzflag.org/"

--- a/games-action/bzflag/bzflag-2.4.14.ebuild
+++ b/games-action/bzflag/bzflag-2.4.14.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils flag-o-matic autotools
+inherit autotools desktop flag-o-matic ltprune
 
 DESCRIPTION="3D tank combat simulator game"
 HOMEPAGE="https://www.bzflag.org/"

--- a/games-action/bzflag/bzflag-2.4.14.ebuild
+++ b/games-action/bzflag/bzflag-2.4.14.ebuild
@@ -40,21 +40,21 @@ src_prepare() {
 }
 
 src_configure() {
-	local myconf
+	local myconf=(
+		$(use_enable upnp UPnP)
+		--libdir="${EPREFIX}"/usr/$(get_libdir)/${PN}
+	)
 
 	if use dedicated ; then
 		ewarn
 		ewarn "You are building a server-only copy of BZFlag"
 		ewarn
-		myconf="--disable-client --without-SDL"
+		myconf+=( --disable-client --without-SDL )
 	else
-		myconf="--with-SDL=2"
+		myconf=( --with-SDL=2 )
 	fi
 
-	econf \
-		$(use_enable upnp UPnP) \
-		--libdir=/usr/$(get_libdir)/${PN} \
-		${myconf}
+	econf "${myconf[@]}"
 }
 
 src_install() {

--- a/games-action/chromium-bsu/chromium-bsu-0.9.15.1-r1.ebuild
+++ b/games-action/chromium-bsu/chromium-bsu-0.9.15.1-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils gnome2-utils
+inherit desktop gnome2-utils
 
 DESCRIPTION="Chromium B.S.U. - an arcade game"
 HOMEPAGE="http://chromium-bsu.sourceforge.net/"

--- a/games-action/cs2d/cs2d-1002-r1.ebuild
+++ b/games-action/cs2d/cs2d-1002-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils
+inherit desktop eutils
 
 DESCRIPTION="A freeware clone of Counter-Strike with some added features in gameplay"
 HOMEPAGE="http://www.cs2d.com/"

--- a/games-action/descent3-demo/descent3-demo-1.4.0a-r1.ebuild
+++ b/games-action/descent3-demo/descent3-demo-1.4.0a-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils unpacker xdg
+inherit desktop eutils unpacker xdg
 
 DESCRIPTION="Indoor/outdoor 3D combat with evil robotic mining spacecraft"
 HOMEPAGE="http://www.lokigames.com/products/descent3/"

--- a/games-action/extreme-tuxracer/extreme-tuxracer-0.7.4.ebuild
+++ b/games-action/extreme-tuxracer/extreme-tuxracer-0.7.4.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils autotools gnome2-utils
+
+inherit autotools desktop gnome2-utils
 
 DESCRIPTION="High speed arctic racing game based on Tux Racer"
 HOMEPAGE="http://extremetuxracer.sourceforge.net/"

--- a/games-action/formido/formido-1.0.1-r1.ebuild
+++ b/games-action/formido/formido-1.0.1-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils toolchain-funcs
+
+inherit desktop toolchain-funcs
 
 DESCRIPTION="A shooting game in the spirit of Phobia games"
 HOMEPAGE="http://www.mhgames.org/oldies/formido/"

--- a/games-action/geki2-KXL/geki2-KXL-2.0.3-r3.ebuild
+++ b/games-action/geki2-KXL/geki2-KXL-2.0.3-r3.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit autotools eutils user
+
+inherit autotools desktop user
 
 DESCRIPTION="2D length scroll shooting game"
 HOMEPAGE="http://triring.net/ps2linux/games/kxl/kxlgames.html"

--- a/games-action/geki3-KXL/geki3-KXL-1.0.3-r3.ebuild
+++ b/games-action/geki3-KXL/geki3-KXL-1.0.3-r3.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit autotools eutils user
+
+inherit autotools desktop user
 
 DESCRIPTION="2D length scroll shooting game"
 HOMEPAGE="http://triring.net/ps2linux/games/kxl/kxlgames.html"

--- a/games-action/gltron/gltron-0.70-r2.ebuild
+++ b/games-action/gltron/gltron-0.70-r2.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils
+
+inherit desktop
 
 DESCRIPTION="3d tron, just like the movie"
 HOMEPAGE="http://gltron.sourceforge.net/"

--- a/games-action/lugaru/lugaru-20151204-r1.ebuild
+++ b/games-action/lugaru/lugaru-20151204-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils cmake-utils
+
+inherit cmake-utils desktop
 
 DESCRIPTION="3D arcade with unique fighting system and anthropomorphic characters"
 HOMEPAGE="https://bitbucket.org/osslugaru/lugaru/wiki/Home"

--- a/games-action/luola/luola-1.3.2-r1.ebuild
+++ b/games-action/luola/luola-1.3.2-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils autotools gnome2-utils
+
+inherit autotools desktop gnome2-utils
 
 DESCRIPTION="A 2D multiplayer arcade game resembling V-Wing"
 HOMEPAGE="https://freecode.com/projects/luola"

--- a/games-action/openastromenace/openastromenace-1.3.2-r1.ebuild
+++ b/games-action/openastromenace/openastromenace-1.3.2-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit gnome2-utils cmake-utils eutils
+
+inherit cmake-utils desktop gnome2-utils
 
 DESCRIPTION="Modern 3D space shooter with spaceship upgrade possibilities"
 HOMEPAGE="https://sourceforge.net/projects/openastromenace/"

--- a/games-action/orbital-eunuchs-sniper/orbital-eunuchs-sniper-1.30-r1.ebuild
+++ b/games-action/orbital-eunuchs-sniper/orbital-eunuchs-sniper-1.30-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit autotools eutils
+
+inherit autotools desktop
 
 MY_P=${PN//-/_}-${PV}
 DESCRIPTION="Snipe terrorists from your orbital base"

--- a/games-action/powermanga/powermanga-0.93.1-r1.ebuild
+++ b/games-action/powermanga/powermanga-0.93.1-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils autotools user
+inherit autotools desktop eutils user
 
 DESCRIPTION="An arcade 2D shoot-em-up game"
 HOMEPAGE="http://linux.tlk.fr/"

--- a/games-action/shootingstar/shootingstar-1.2.0-r1.ebuild
+++ b/games-action/shootingstar/shootingstar-1.2.0-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit autotools eutils gnome2-utils
+inherit autotools desktop gnome2-utils
 
 # Note: currently segfaults on startup, but that's also in the previous ebuild
 # See https://bugs.gentoo.org/607428

--- a/games-action/snipes/snipes-1.0.4-r1.ebuild
+++ b/games-action/snipes/snipes-1.0.4-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit toolchain-funcs eutils
+
+inherit desktop toolchain-funcs
 
 DESCRIPTION="2D scrolling shooter, resembles the old DOS game of same name"
 HOMEPAGE="https://cyp.github.com/snipes/"

--- a/games-action/spacearyarya-kxl/spacearyarya-kxl-1.0.2-r2.ebuild
+++ b/games-action/spacearyarya-kxl/spacearyarya-kxl-1.0.2-r2.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit autotools eutils
+
+inherit autotools desktop
 
 MY_P=SpaceAryarya-KXL-${PV}
 DESCRIPTION="A 2D/3D shooting game"

--- a/games-action/spacetripper-demo/spacetripper-demo-1-r1.ebuild
+++ b/games-action/spacetripper-demo/spacetripper-demo-1-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils unpacker
+
+inherit desktop eutils unpacker
 
 MY_P="spacetripperdemo"
 DESCRIPTION="Hardcore arcade shoot-em-up"

--- a/games-action/supertuxkart/supertuxkart-0.9.3.ebuild
+++ b/games-action/supertuxkart/supertuxkart-0.9.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit cmake-utils eutils gnome2-utils
+inherit cmake-utils desktop gnome2-utils
 
 DESCRIPTION="A kart racing game starring Tux, the linux penguin (TuxKart fork)"
 HOMEPAGE="https://supertuxkart.net/"

--- a/games-action/transcend/transcend-0.3-r1.ebuild
+++ b/games-action/transcend/transcend-0.3-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils
+
+inherit desktop
 
 DESCRIPTION="Retro-style, abstract, 2D shooter"
 HOMEPAGE="http://transcend.sourceforge.net/"

--- a/games-action/trosh/trosh-20-r1.ebuild
+++ b/games-action/trosh/trosh-20-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils gnome2-utils
+
+inherit desktop eutils gnome2-utils
 
 DESCRIPTION="A game made in 20 hours for a friend. It has explosions"
 HOMEPAGE="http://stabyourself.net/trosh/"

--- a/games-action/trosh/trosh-20-r2.ebuild
+++ b/games-action/trosh/trosh-20-r2.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils gnome2-utils
+
+inherit desktop eutils gnome2-utils
 
 DESCRIPTION="A game made in 20 hours for a friend. It has explosions"
 HOMEPAGE="http://stabyourself.net/trosh/"

--- a/games-action/violetland/violetland-0.4.3-r1.ebuild
+++ b/games-action/violetland/violetland-0.4.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit eutils cmake-utils
+inherit cmake-utils desktop
 
 DESCRIPTION="Help a girl named Violet in the struggle with hordes of monsters"
 HOMEPAGE="https://violetland.github.io/"

--- a/games-action/wordwarvi/wordwarvi-1.00-r1.ebuild
+++ b/games-action/wordwarvi/wordwarvi-1.00-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils
+
+inherit desktop
 
 DESCRIPTION="A retro side-scrolling shoot'em up based on the editor war story"
 HOMEPAGE="http://wordwarvi.sourceforge.net"

--- a/games-action/xpilot/xpilot-4.5.5-r1.ebuild
+++ b/games-action/xpilot/xpilot-4.5.5-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils toolchain-funcs
+
+inherit desktop toolchain-funcs
 
 DESCRIPTION="A multi-player 2D client/server space game"
 HOMEPAGE="http://www.xpilot.org/"


### PR DESCRIPTION
Quite a lot of games-action packages inherit eutils to get functions in desktop. I assume
this to be from before eutils was split into a number of eclasses. A few actually use eutils
but do not explicitly inherit eclasses they use functions from.

Skipped games which either are p.masked or require the actual cd/media in order to install.