### PR TITLE
add missing versionator inherit

### DIFF
--- a/app-emulation/qemu/qemu-2.11.1-r2.ebuild
+++ b/app-emulation/qemu/qemu-2.11.1-r2.ebuild
@@ -11,7 +11,7 @@ PLOCALES="bg de_DE fr_FR hu it tr zh_CN"
 FIRMWARE_ABI_VERSION="2.9.0-r52"
 
 inherit eutils flag-o-matic linux-info toolchain-funcs multilib python-r1 \
-	user udev fcaps readme.gentoo-r1 pax-utils l10n
+	user udev fcaps readme.gentoo-r1 pax-utils l10n versionator
 
 if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="git://git.qemu.org/qemu.git"

--- a/app-emulation/qemu/qemu-2.12.0-r3.ebuild
+++ b/app-emulation/qemu/qemu-2.12.0-r3.ebuild
@@ -11,7 +11,7 @@ PLOCALES="bg de_DE fr_FR hu it tr zh_CN"
 FIRMWARE_ABI_VERSION="2.11.1-r50"
 
 inherit eutils flag-o-matic linux-info toolchain-funcs multilib python-r1 \
-	user udev fcaps readme.gentoo-r1 pax-utils l10n
+	user udev fcaps readme.gentoo-r1 pax-utils l10n versionator
 
 if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="git://git.qemu.org/qemu.git"

--- a/app-emulation/qemu/qemu-2.12.0-r4.ebuild
+++ b/app-emulation/qemu/qemu-2.12.0-r4.ebuild
@@ -11,7 +11,7 @@ PLOCALES="bg de_DE fr_FR hu it tr zh_CN"
 FIRMWARE_ABI_VERSION="2.11.1-r50"
 
 inherit eutils flag-o-matic linux-info toolchain-funcs multilib python-r1 \
-	user udev fcaps readme.gentoo-r1 pax-utils l10n
+	user udev fcaps readme.gentoo-r1 pax-utils l10n versionator
 
 if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="git://git.qemu.org/qemu.git"

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -11,7 +11,7 @@ PLOCALES="bg de_DE fr_FR hu it tr zh_CN"
 FIRMWARE_ABI_VERSION="2.11.1-r50"
 
 inherit eutils flag-o-matic linux-info toolchain-funcs multilib python-r1 \
-	user udev fcaps readme.gentoo-r1 pax-utils l10n
+	user udev fcaps readme.gentoo-r1 pax-utils l10n versionator
 
 if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="git://git.qemu.org/qemu.git"

--- a/net-misc/openvswitch/openvswitch-2.7.2-r1.ebuild
+++ b/net-misc/openvswitch/openvswitch-2.7.2-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 
-inherit autotools eutils linux-info linux-mod python-r1 systemd
+inherit autotools eutils linux-info linux-mod python-r1 systemd versionator
 
 DESCRIPTION="Production quality, multilayer virtual switch"
 HOMEPAGE="https://www.openvswitch.org"

--- a/net-misc/openvswitch/openvswitch-2.7.2.ebuild
+++ b/net-misc/openvswitch/openvswitch-2.7.2.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python{2_7,3_4,3_5} )
 
-inherit autotools eutils linux-info linux-mod python-r1 systemd
+inherit autotools eutils linux-info linux-mod python-r1 systemd versionator
 
 DESCRIPTION="Production quality, multilayer virtual switch"
 HOMEPAGE="https://www.openvswitch.org"

--- a/net-misc/openvswitch/openvswitch-2.8.1.ebuild
+++ b/net-misc/openvswitch/openvswitch-2.8.1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
-inherit autotools eutils linux-info linux-mod python-r1 systemd
+inherit autotools eutils linux-info linux-mod python-r1 systemd versionator
 
 DESCRIPTION="Production quality, multilayer virtual switch"
 HOMEPAGE="https://www.openvswitch.org"


### PR DESCRIPTION
c6b150836dfef848e51ec2cce801b12daf2c77b1 dropped versionator from
linux-info, which these ebuilds were using via the implicit inherit.