### PR TITLE
games-arcade: missing or unneeded inherits.

### DIFF
--- a/games-arcade/funnyboat/funnyboat-1.5-r2.ebuild
+++ b/games-arcade/funnyboat/funnyboat-1.5-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils gnome2-utils python-single-r1
+inherit desktop eutils gnome2-utils python-single-r1
 
 DESCRIPTION="A side scrolling shooter game starring a steamboat on the sea"
 HOMEPAGE="http://funnyboat.sourceforge.net/"

--- a/games-arcade/jvgs/jvgs-0.5-r1.ebuild
+++ b/games-arcade/jvgs/jvgs-0.5-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit cmake-utils eutils
+inherit cmake-utils desktop
 
 DESCRIPTION="An open-source platform game with a sketched and minimalistic look"
 HOMEPAGE="http://jvgs.sourceforge.net/"

--- a/games-arcade/mrrescue/mrrescue-1.02b-r1.ebuild
+++ b/games-arcade/mrrescue/mrrescue-1.02b-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils gnome2-utils
+
+inherit desktop eutils gnome2-utils
 
 DESCRIPTION="Arcade 2d action game based around evacuating civilians from burning buildings"
 HOMEPAGE="http://tangramgames.dk/games/mrrescue/"

--- a/games-arcade/mrrescue/mrrescue-1.02b-r2.ebuild
+++ b/games-arcade/mrrescue/mrrescue-1.02b-r2.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils gnome2-utils
+
+inherit desktop eutils gnome2-utils
 
 DESCRIPTION="Arcade 2d action game based around evacuating civilians from burning buildings"
 HOMEPAGE="http://tangramgames.dk/games/mrrescue/"

--- a/games-arcade/notpacman/notpacman-1.0.4-r1.ebuild
+++ b/games-arcade/notpacman/notpacman-1.0.4-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils gnome2-utils
+
+inherit desktop eutils gnome2-utils
 
 DESCRIPTION="A mashup of \"Not\" and \"Pacman\""
 HOMEPAGE="http://stabyourself.net/notpacman/"

--- a/games-arcade/nottetris2/nottetris2-1-r1.ebuild
+++ b/games-arcade/nottetris2/nottetris2-1-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils
+
+inherit desktop eutils
 
 DESCRIPTION="The spiritual successor of the classic Tetris mixed with physics"
 HOMEPAGE="http://stabyourself.net/nottetris2/"

--- a/games-arcade/opentyrian/opentyrian-2.1.20130907-r1.ebuild
+++ b/games-arcade/opentyrian/opentyrian-2.1.20130907-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit desktop
+inherit desktop gnome2-utils
 
 DESCRIPTION="Open-source port of the DOS game Tyrian, vertical scrolling shooter"
 HOMEPAGE="https://bitbucket.org/opentyrian/opentyrian/wiki/Home"
@@ -46,4 +46,12 @@ src_install() {
 	cd "${WORKDIR}/tyrian21"
 	rm *.exe dpmi16bi.ovl loudness.awe || die "Failed to remove win32 binaries"
 	doins * || die "Failed to install game data"
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
 }

--- a/games-arcade/opentyrian/opentyrian-2.1.20130907-r1.ebuild
+++ b/games-arcade/opentyrian/opentyrian-2.1.20130907-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils
+inherit desktop
 
 DESCRIPTION="Open-source port of the DOS game Tyrian, vertical scrolling shooter"
 HOMEPAGE="https://bitbucket.org/opentyrian/opentyrian/wiki/Home"

--- a/games-arcade/retrobattle/retrobattle-1.0.0-r1.ebuild
+++ b/games-arcade/retrobattle/retrobattle-1.0.0-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils
+
+inherit desktop eutils
 
 MY_P="${PN}-src-${PV}"
 DESCRIPTION="A NES-like platform arcade game"

--- a/games-arcade/solarwolf/solarwolf-1.5-r1.ebuild
+++ b/games-arcade/solarwolf/solarwolf-1.5-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils
+
+inherit desktop eutils
 
 DESCRIPTION="Action/arcade recreation of SolarFox"
 HOMEPAGE="http://www.pygame.org/shredwheat/solarwolf/"

--- a/games-arcade/triplexinvaders/triplexinvaders-1.08-r1.ebuild
+++ b/games-arcade/triplexinvaders/triplexinvaders-1.08-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils python-single-r1
+inherit desktop eutils python-single-r1
 
 DESCRIPTION="An Alien Invaders style game with 3d graphics"
 HOMEPAGE="http://triplexinvaders.infogami.com"

--- a/games-arcade/wop/wop-0.4.3-r2.ebuild
+++ b/games-arcade/wop/wop-0.4.3-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit eutils toolchain-funcs
+inherit desktop toolchain-funcs
 
 MY_DATA_V="2005-12-21"
 MY_DATA_P="${PN}data-${MY_DATA_V}"


### PR DESCRIPTION
Quite a lot of games-arcade packages inherit eutils to get functions in desktop. I assume
this to be from before eutils was split into a number of eclasses. A few actually use eutils
but do not explicitly inherit eclasses they use functions from.