### PR TITLE
mask doc useflag for rust{-bin} for all arches but amd64 and x86

### DIFF
--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Dirkjan Ochtman <rust@gentoo.org> (04 Aug 2018) 
+# rust-docs is available for amd64
+>=dev-lang/rust-1.26.0 -doc
+>=dev-lang/rust-bin-1.26.0 -doc
+
 # Göktürk Yüksek <gokturk@gentoo.org> (6 Jul 2018)
 # Dependency app-crypt/jitterentropy is keyworded for amd64
 sys-apps/rng-tools -jitterentropy

--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -19,8 +19,8 @@
 
 # Dirkjan Ochtman <rust@gentoo.org> (04 Aug 2018) 
 # rust-docs is available for amd64
->=dev-lang/rust-1.26.0 -doc
->=dev-lang/rust-bin-1.26.0 -doc
+>=dev-lang/rust-1.27.1 -doc
+>=dev-lang/rust-bin-1.27.1 -doc
 
 # Göktürk Yüksek <gokturk@gentoo.org> (6 Jul 2018)
 # Dependency app-crypt/jitterentropy is keyworded for amd64

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Dirkjan Ochtman <rust@gentoo.org> (04 Aug 2018)
+# from rust-1.26.0 on, there is no rust-docs anymore but for amd64
+>=dev-lang/rust-1.26.0 doc
+>=dev-lang/rust-bin-1.26.0 doc
+
 # Rick Farina <zerochaos@gentoo.org> (27 Jun 2018)
 # Catalyst only has support for assembling bootloader on some arches
 dev-util/catalyst system-bootloader

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -5,8 +5,8 @@
 
 # Dirkjan Ochtman <rust@gentoo.org> (04 Aug 2018)
 # rust-docs is available for x86
->=dev-lang/rust-1.26.0 -doc
->=dev-lang/rust-bin-1.26.0 -doc
+>=dev-lang/rust-1.27.1 -doc
+>=dev-lang/rust-bin-1.27.1 -doc
 
 # Rick Farina <zerochaos@gentoo.org> (27 Jun 2018)
 # Catalyst has support for assembling bootloader on this arch

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -3,6 +3,11 @@
 
 # This file requires >=portage-2.1.1
 
+# Dirkjan Ochtman <rust@gentoo.org> (04 Aug 2018)
+# rust-docs is available for x86
+>=dev-lang/rust-1.26.0 -doc
+>=dev-lang/rust-bin-1.26.0 -doc
+
 # Rick Farina <zerochaos@gentoo.org> (27 Jun 2018)
 # Catalyst has support for assembling bootloader on this arch
 dev-util/catalyst -system-bootloader


### PR DESCRIPTION
@djc here is the mask for anything but amd64. 