### PR TITLE
cargo.eclass updates

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -121,7 +121,7 @@ cargo_src_compile() {
 
 	export CARGO_HOME="${ECARGO_HOME}"
 
-	cargo build -v -j $(makeopts_jobs) $(usex debug "" --release) \
+	cargo build -j $(makeopts_jobs) $(usex debug "" --release) \
 		|| die "cargo build failed"
 }
 

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -12,7 +12,7 @@ if [[ -z ${_CARGO_ECLASS} ]]; then
 _CARGO_ECLASS=1
 
 CARGO_DEPEND=""
-[[ ${CATEGORY}/${PN} != dev-util/cargo ]] && CARGO_DEPEND=">=dev-util/cargo-0.13.0"
+[[ ${CATEGORY}/${PN} != dev-util/cargo ]] && CARGO_DEPEND="virtual/cargo"
 
 case ${EAPI} in
 	6) : DEPEND="${DEPEND} ${CARGO_DEPEND}";;

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -11,8 +11,12 @@
 if [[ -z ${_CARGO_ECLASS} ]]; then
 _CARGO_ECLASS=1
 
+CARGO_DEPEND=""
+[[ ${CATEGORY}/${PN} != dev-util/cargo ]] && CARGO_DEPEND=">=dev-util/cargo-0.13.0"
+
 case ${EAPI} in
-	6) : ;;
+	6) : DEPEND="${DEPEND} ${CARGO_DEPEND}";;
+	7) : BDEPEND="${BDEPEND} ${CARGO_DEPEND}";;
 	*) die "EAPI=${EAPI:-0} is not supported" ;;
 esac
 
@@ -21,8 +25,6 @@ inherit multiprocessing
 EXPORT_FUNCTIONS src_unpack src_compile src_install
 
 IUSE="${IUSE} debug"
-
-[[ ${CATEGORY}/${PN} != dev-util/cargo ]] && DEPEND=">=dev-util/cargo-0.13.0"
 
 ECARGO_HOME="${WORKDIR}/cargo_home"
 ECARGO_VENDOR="${ECARGO_HOME}/gentoo"


### PR DESCRIPTION
* Updated for `EAPI=7`: no longer `die` and add `cargo` as `BDEPEND` instead of `DEPEND`
* Replace auto-dependency on `>=dev-util/cargo-0.13.0` with `virtual/cargo`
* Turn off verbose builds by default

@gentoo/rust please take a look.