### PR TITLE
sys-apps/portage, app-portage/repoman: use elog instead of einfo for messages to users

### DIFF
--- a/app-portage/repoman/repoman-2.3.0-r1.ebuild
+++ b/app-portage/repoman/repoman-2.3.0-r1.ebuild
@@ -82,13 +82,13 @@ python_install_all() {
 }
 
 pkg_postinst() {
-	einfo ""
-	einfo "This release of repoman is from the new portage/repoman split"
-	einfo "release code base."
-	einfo "This new repoman code base is still being developed.  So its API's"
-	einfo "are not to be considered stable and are subject to change."
-	einfo "The code released has been tested and considered ready for use."
-	einfo "This however does not guarantee it to be completely bug free."
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of repoman is from the new portage/repoman split"
+	elog "release code base."
+	elog "This new repoman code base is still being developed.  So its API's"
+	elog "are not to be considered stable and are subject to change."
+	elog "The code released has been tested and considered ready for use."
+	elog "This however does not guarantee it to be completely bug free."
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/app-portage/repoman/repoman-2.3.10.ebuild
+++ b/app-portage/repoman/repoman-2.3.10.ebuild
@@ -49,13 +49,13 @@ python_install() {
 }
 
 pkg_postinst() {
-	einfo ""
-	einfo "This release of repoman is from the new portage/repoman split"
-	einfo "release code base."
-	einfo "This new repoman code base is still being developed.  So its API's"
-	einfo "are not to be considered stable and are subject to change."
-	einfo "The code released has been tested and considered ready for use."
-	einfo "This however does not guarantee it to be completely bug free."
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of repoman is from the new portage/repoman split"
+	elog "release code base."
+	elog "This new repoman code base is still being developed.  So its API's"
+	elog "are not to be considered stable and are subject to change."
+	elog "The code released has been tested and considered ready for use."
+	elog "This however does not guarantee it to be completely bug free."
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/app-portage/repoman/repoman-2.3.6.ebuild
+++ b/app-portage/repoman/repoman-2.3.6.ebuild
@@ -48,13 +48,13 @@ python_install() {
 }
 
 pkg_postinst() {
-	einfo ""
-	einfo "This release of repoman is from the new portage/repoman split"
-	einfo "release code base."
-	einfo "This new repoman code base is still being developed.  So its API's"
-	einfo "are not to be considered stable and are subject to change."
-	einfo "The code released has been tested and considered ready for use."
-	einfo "This however does not guarantee it to be completely bug free."
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of repoman is from the new portage/repoman split"
+	elog "release code base."
+	elog "This new repoman code base is still being developed.  So its API's"
+	elog "are not to be considered stable and are subject to change."
+	elog "The code released has been tested and considered ready for use."
+	elog "This however does not guarantee it to be completely bug free."
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/app-portage/repoman/repoman-2.3.9.ebuild
+++ b/app-portage/repoman/repoman-2.3.9.ebuild
@@ -55,13 +55,13 @@ python_install() {
 }
 
 pkg_postinst() {
-	einfo ""
-	einfo "This release of repoman is from the new portage/repoman split"
-	einfo "release code base."
-	einfo "This new repoman code base is still being developed.  So its API's"
-	einfo "are not to be considered stable and are subject to change."
-	einfo "The code released has been tested and considered ready for use."
-	einfo "This however does not guarantee it to be completely bug free."
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of repoman is from the new portage/repoman split"
+	elog "release code base."
+	elog "This new repoman code base is still being developed.  So its API's"
+	elog "are not to be considered stable and are subject to change."
+	elog "The code released has been tested and considered ready for use."
+	elog "This however does not guarantee it to be completely bug free."
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/app-portage/repoman/repoman-9999.ebuild
+++ b/app-portage/repoman/repoman-9999.ebuild
@@ -49,13 +49,13 @@ python_install() {
 }
 
 pkg_postinst() {
-	einfo ""
-	einfo "This release of repoman is from the new portage/repoman split"
-	einfo "release code base."
-	einfo "This new repoman code base is still being developed.  So its API's"
-	einfo "are not to be considered stable and are subject to change."
-	einfo "The code released has been tested and considered ready for use."
-	einfo "This however does not guarantee it to be completely bug free."
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of repoman is from the new portage/repoman split"
+	elog "release code base."
+	elog "This new repoman code base is still being developed.  So its API's"
+	elog "are not to be considered stable and are subject to change."
+	elog "The code released has been tested and considered ready for use."
+	elog "This however does not guarantee it to be completely bug free."
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/sys-apps/portage/portage-2.3.13-r1.ebuild
+++ b/sys-apps/portage/portage-2.3.13-r1.ebuild
@@ -253,10 +253,10 @@ pkg_postinst() {
 		ewarn "git repositories.  There have been too many problems and"
 		ewarn "performance issues.  See bugs 552814, 559008"
 	fi
-	einfo ""
-	einfo "This release of portage NO LONGER contains the repoman code base."
-	einfo "Repoman has its own ebuild and release package."
-	einfo "For repoman functionality please emerge app-portage/repoman"
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of portage NO LONGER contains the repoman code base."
+	elog "Repoman has its own ebuild and release package."
+	elog "For repoman functionality please emerge app-portage/repoman"
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/sys-apps/portage/portage-2.3.19-r1.ebuild
+++ b/sys-apps/portage/portage-2.3.19-r1.ebuild
@@ -251,10 +251,10 @@ pkg_postinst() {
 		ewarn "git repositories.  There have been too many problems and"
 		ewarn "performance issues.  See bugs 552814, 559008"
 	fi
-	einfo ""
-	einfo "This release of portage NO LONGER contains the repoman code base."
-	einfo "Repoman has its own ebuild and release package."
-	einfo "For repoman functionality please emerge app-portage/repoman"
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of portage NO LONGER contains the repoman code base."
+	elog "Repoman has its own ebuild and release package."
+	elog "For repoman functionality please emerge app-portage/repoman"
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/sys-apps/portage/portage-2.3.24-r1.ebuild
+++ b/sys-apps/portage/portage-2.3.24-r1.ebuild
@@ -275,10 +275,10 @@ pkg_postinst() {
 		ewarn "git repositories.  There have been too many problems and"
 		ewarn "performance issues.  See bugs 552814, 559008"
 	fi
-	einfo ""
-	einfo "This release of portage NO LONGER contains the repoman code base."
-	einfo "Repoman has its own ebuild and release package."
-	einfo "For repoman functionality please emerge app-portage/repoman"
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of portage NO LONGER contains the repoman code base."
+	elog "Repoman has its own ebuild and release package."
+	elog "For repoman functionality please emerge app-portage/repoman"
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/sys-apps/portage/portage-2.3.40-r1.ebuild
+++ b/sys-apps/portage/portage-2.3.40-r1.ebuild
@@ -284,10 +284,10 @@ pkg_postinst() {
 		ewarn "git repositories.  There have been too many problems and"
 		ewarn "performance issues.  See bugs 552814, 559008"
 	fi
-	einfo ""
-	einfo "This release of portage NO LONGER contains the repoman code base."
-	einfo "Repoman has its own ebuild and release package."
-	einfo "For repoman functionality please emerge app-portage/repoman"
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of portage NO LONGER contains the repoman code base."
+	elog "Repoman has its own ebuild and release package."
+	elog "For repoman functionality please emerge app-portage/repoman"
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/sys-apps/portage/portage-2.3.43-r1.ebuild
+++ b/sys-apps/portage/portage-2.3.43-r1.ebuild
@@ -276,10 +276,10 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	einfo ""
-	einfo "This release of portage NO LONGER contains the repoman code base."
-	einfo "Repoman has its own ebuild and release package."
-	einfo "For repoman functionality please emerge app-portage/repoman"
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of portage NO LONGER contains the repoman code base."
+	elog "Repoman has its own ebuild and release package."
+	elog "For repoman functionality please emerge app-portage/repoman"
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/sys-apps/portage/portage-2.3.44.ebuild
+++ b/sys-apps/portage/portage-2.3.44.ebuild
@@ -264,10 +264,10 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	einfo ""
-	einfo "This release of portage NO LONGER contains the repoman code base."
-	einfo "Repoman has its own ebuild and release package."
-	einfo "For repoman functionality please emerge app-portage/repoman"
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of portage NO LONGER contains the repoman code base."
+	elog "Repoman has its own ebuild and release package."
+	elog "For repoman functionality please emerge app-portage/repoman"
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/sys-apps/portage/portage-2.3.8.ebuild
+++ b/sys-apps/portage/portage-2.3.8.ebuild
@@ -241,10 +241,10 @@ pkg_postinst() {
 		ewarn "git repositories.  There have been too many problems and"
 		ewarn "performance issues.  See bugs 552814, 559008"
 	fi
-	einfo ""
-	einfo "This release of portage NO LONGER contains the repoman code base."
-	einfo "Repoman has its own ebuild and release package."
-	einfo "For repoman functionality please emerge app-portage/repoman"
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of portage NO LONGER contains the repoman code base."
+	elog "Repoman has its own ebuild and release package."
+	elog "For repoman functionality please emerge app-portage/repoman"
+	elog "Please report any bugs you may encounter."
+	elog ""
 }

--- a/sys-apps/portage/portage-9999.ebuild
+++ b/sys-apps/portage/portage-9999.ebuild
@@ -262,10 +262,10 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	einfo ""
-	einfo "This release of portage NO LONGER contains the repoman code base."
-	einfo "Repoman now has it's own ebuild and release package."
-	einfo "For repoman functionality please emerge app-portage/repoman"
-	einfo "Please report any bugs you may encounter."
-	einfo ""
+	elog ""
+	elog "This release of portage NO LONGER contains the repoman code base."
+	elog "Repoman now has it's own ebuild and release package."
+	elog "For repoman functionality please emerge app-portage/repoman"
+	elog "Please report any bugs you may encounter."
+	elog ""
 }


### PR DESCRIPTION
Please see https://dev.gentoo.org/~zmedico/portage/doc/ch06s02.html for details.