### PR TITLE
app-portage/gentoolkit: use elog instead of einfo for messages to users

### DIFF
--- a/app-portage/gentoolkit/gentoolkit-0.4.0.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -40,11 +40,11 @@ pkg_postinst() {
 	mkdir -p -m 0755 "${EROOT%/}"/var/cache
 	mkdir -p -m 0700 "${EROOT%/}"/var/cache/revdep-rebuild
 
-	einfo "Starting with this version, ebump, ekeyword and imlate are now"
-	einfo "part of the gentoolkit package."
-	einfo "The gentoolkit-dev package is now deprecated in favor of a single"
-	einfo "gentoolkit package.   The remaining tools from gentoolkit-dev"
-	einfo "are now obsolete/unused with the git based tree."
+	elog "Starting with this version, ebump, ekeyword and imlate are now"
+	elog "part of the gentoolkit package."
+	elog "The gentoolkit-dev package is now deprecated in favor of a single"
+	elog "gentoolkit package.   The remaining tools from gentoolkit-dev"
+	elog "are now obsolete/unused with the git based tree."
 
 	# Only show the elog information on a new install
 	if [[ ! ${REPLACING_VERSIONS} ]]; then

--- a/app-portage/gentoolkit/gentoolkit-0.4.1.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-0.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -40,11 +40,11 @@ pkg_postinst() {
 	mkdir -p -m 0755 "${EROOT%/}"/var/cache
 	mkdir -p -m 0700 "${EROOT%/}"/var/cache/revdep-rebuild
 
-	einfo "Starting with version 0.4.0, ebump, ekeyword and imlate are now"
-	einfo "part of the gentoolkit package."
-	einfo "The gentoolkit-dev package is now deprecated in favor of a single"
-	einfo "gentoolkit package.   The remaining tools from gentoolkit-dev"
-	einfo "are now obsolete/unused with the git based tree."
+	elog "Starting with version 0.4.0, ebump, ekeyword and imlate are now"
+	elog "part of the gentoolkit package."
+	elog "The gentoolkit-dev package is now deprecated in favor of a single"
+	elog "gentoolkit package.   The remaining tools from gentoolkit-dev"
+	elog "are now obsolete/unused with the git based tree."
 
 	# Only show the elog information on a new install
 	if [[ ! ${REPLACING_VERSIONS} ]]; then

--- a/app-portage/gentoolkit/gentoolkit-0.4.2-r1.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-0.4.2-r1.ebuild
@@ -44,11 +44,11 @@ pkg_postinst() {
 	mkdir -p -m 0755 "${EROOT%/}"/var/cache
 	mkdir -p -m 0700 "${EROOT%/}"/var/cache/revdep-rebuild
 
-	einfo "Starting with version 0.4.0, ebump, ekeyword and imlate are now"
-	einfo "part of the gentoolkit package."
-	einfo "The gentoolkit-dev package is now deprecated in favor of a single"
-	einfo "gentoolkit package.   The remaining tools from gentoolkit-dev"
-	einfo "are now obsolete/unused with the git based tree."
+	elog "Starting with version 0.4.0, ebump, ekeyword and imlate are now"
+	elog "part of the gentoolkit package."
+	elog "The gentoolkit-dev package is now deprecated in favor of a single"
+	elog "gentoolkit package.   The remaining tools from gentoolkit-dev"
+	elog "are now obsolete/unused with the git based tree."
 
 	# Only show the elog information on a new install
 	if [[ ! ${REPLACING_VERSIONS} ]]; then


### PR DESCRIPTION
Please see https://dev.gentoo.org/~zmedico/portage/doc/ch06s02.html for details.