### PR TITLE
x11-misc/sddm: use elog instead of einfo for messages to users

### DIFF
--- a/x11-misc/sddm/sddm-0.18.0.ebuild
+++ b/x11-misc/sddm/sddm-0.18.0.ebuild
@@ -85,9 +85,9 @@ src_install() {
 }
 
 pkg_postinst() {
-	einfo "Starting with 0.18.0, SDDM no longer installs /etc/sddm.conf"
-	einfo "Use it to override specific options. SDDM defaults are now"
-	einfo "found in: /usr/share/sddm/sddm.conf.d/00default.conf"
+	elog "Starting with 0.18.0, SDDM no longer installs /etc/sddm.conf"
+	elog "Use it to override specific options. SDDM defaults are now"
+	elog "found in: /usr/share/sddm/sddm.conf.d/00default.conf"
 
 	enewgroup ${PN}
 	enewuser ${PN} -1 -1 /var/lib/${PN} ${PN},video


### PR DESCRIPTION
See https://dev.gentoo.org/~zmedico/portage/doc/ch06s02.html for details.