### PR TITLE
media-gfx/gimp, media-libs/{babl,gegl}: replace git.gnome.org with gitlab.gnome.org

### DIFF
--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -9,7 +9,7 @@ inherit virtualx autotools gnome2 multilib python-single-r1 ltprune git-r3
 
 DESCRIPTION="GNU Image Manipulation Program"
 HOMEPAGE="https://www.gimp.org/"
-EGIT_REPO_URI="https://git.gnome.org/browse/gimp"
+EGIT_REPO_URI="https://gitlab.gnome.org/GNOME/gimp"
 SRC_URI=""
 LICENSE="GPL-3 LGPL-3"
 SLOT="2"

--- a/media-libs/babl/babl-0.1.12.ebuild
+++ b/media-libs/babl/babl-0.1.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.18.ebuild
+++ b/media-libs/babl/babl-0.1.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.20.ebuild
+++ b/media-libs/babl/babl-0.1.20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.22.ebuild
+++ b/media-libs/babl/babl-0.1.22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.24.ebuild
+++ b/media-libs/babl/babl-0.1.24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.26.ebuild
+++ b/media-libs/babl/babl-0.1.26.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.30.ebuild
+++ b/media-libs/babl/babl-0.1.30.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.38.ebuild
+++ b/media-libs/babl/babl-0.1.38.ebuild
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.40.ebuild
+++ b/media-libs/babl/babl-0.1.40.ebuild
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.42.ebuild
+++ b/media-libs/babl/babl-0.1.42.ebuild
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.44.ebuild
+++ b/media-libs/babl/babl-0.1.44.ebuild
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.46.ebuild
+++ b/media-libs/babl/babl-0.1.46.ebuild
@@ -7,7 +7,7 @@ inherit eutils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/babl/babl-0.1.48.ebuild
+++ b/media-libs/babl/babl-0.1.48.ebuild
@@ -7,7 +7,7 @@ inherit ltprune
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	inherit autotools

--- a/media-libs/babl/babl-0.1.50.ebuild
+++ b/media-libs/babl/babl-0.1.50.ebuild
@@ -7,7 +7,7 @@ inherit ltprune
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	inherit autotools

--- a/media-libs/babl/babl-0.1.52.ebuild
+++ b/media-libs/babl/babl-0.1.52.ebuild
@@ -7,7 +7,7 @@ inherit ltprune
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	inherit autotools

--- a/media-libs/babl/babl-0.1.54.ebuild
+++ b/media-libs/babl/babl-0.1.54.ebuild
@@ -7,7 +7,7 @@ inherit ltprune
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	inherit autotools

--- a/media-libs/babl/babl-9999.ebuild
+++ b/media-libs/babl/babl-9999.ebuild
@@ -7,7 +7,7 @@ inherit ltprune
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/babl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/babl"
 	SRC_URI=""
 else
 	SRC_URI="http://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.3.0-r1.ebuild
+++ b/media-libs/gegl/gegl-0.3.0-r1.ebuild
@@ -13,7 +13,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.3.0.ebuild
+++ b/media-libs/gegl/gegl-0.3.0.ebuild
@@ -13,7 +13,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.3.26.ebuild
+++ b/media-libs/gegl/gegl-0.3.26.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.3.34.ebuild
+++ b/media-libs/gegl/gegl-0.3.34.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.3.8-r1.ebuild
+++ b/media-libs/gegl/gegl-0.3.8-r1.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.3.8.ebuild
+++ b/media-libs/gegl/gegl-0.3.8.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.4.0-r1.ebuild
+++ b/media-libs/gegl/gegl-0.4.0-r1.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.4.0.ebuild
+++ b/media-libs/gegl/gegl-0.4.0.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.4.2.ebuild
+++ b/media-libs/gegl/gegl-0.4.2.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.4.4.ebuild
+++ b/media-libs/gegl/gegl-0.4.4.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-0.4.6.ebuild
+++ b/media-libs/gegl/gegl-0.4.6.ebuild
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"

--- a/media-libs/gegl/gegl-9999.ebuild
+++ b/media-libs/gegl/gegl-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ inherit versionator gnome2-utils eutils autotools python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit autotools git-r3
-	EGIT_REPO_URI="git://git.gnome.org/gegl"
+	EGIT_REPO_URI="git://gitlab.gnome.org/GNOME/gegl"
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.bz2"


### PR DESCRIPTION
git.gnome.org now redirects to gitlab.gnome.org