### PR TITLE
dev-python/ssl-fetch: use elog instead of einfo for messages to users

### DIFF
--- a/dev-python/ssl-fetch/ssl-fetch-0.2.1.ebuild
+++ b/dev-python/ssl-fetch/ssl-fetch-0.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -29,13 +29,13 @@ RDEPEND="${DEPEND}
 	"
 
 pkg_postinst() {
-	einfo
-	einfo "This is beta software."
-	einfo "The APIs it installs should be considered unstable"
-	einfo "and are subject to change in these early versions."
-	einfo
-	einfo "Please file any enhancement requests, or bugs"
-	einfo "at https://github.com/dol-sen/ssl-fetch/issues"
-	einfo "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the freenode network"
-	einfo
+	elog
+	elog "This is beta software."
+	elog "The APIs it installs should be considered unstable"
+	elog "and are subject to change in these early versions."
+	elog
+	elog "Please file any enhancement requests, or bugs"
+	elog "at https://github.com/dol-sen/ssl-fetch/issues"
+	elog "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the freenode network"
+	elog
 }

--- a/dev-python/ssl-fetch/ssl-fetch-0.2.ebuild
+++ b/dev-python/ssl-fetch/ssl-fetch-0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -29,13 +29,13 @@ RDEPEND="${DEPEND}
 	"
 
 pkg_postinst() {
-	einfo
-	einfo "This is beta software."
-	einfo "The APIs it installs should be considered unstable"
-	einfo "and are subject to change in these early versions."
-	einfo
-	einfo "Please file any enhancement requests, or bugs"
-	einfo "at https://github.com/dol-sen/ssl-fetch/issues"
-	einfo "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the freenode network"
-	einfo
+	elog
+	elog "This is beta software."
+	elog "The APIs it installs should be considered unstable"
+	elog "and are subject to change in these early versions."
+	elog
+	elog "Please file any enhancement requests, or bugs"
+	elog "at https://github.com/dol-sen/ssl-fetch/issues"
+	elog "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the freenode network"
+	elog
 }

--- a/dev-python/ssl-fetch/ssl-fetch-0.3.ebuild
+++ b/dev-python/ssl-fetch/ssl-fetch-0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -30,12 +30,12 @@ RDEPEND="${DEPEND}
 
 pkg_postinst() {
 	echo
-	einfo "This is beta software."
-	einfo "The APIs it installs should be considered unstable"
-	einfo "and are subject to change in these early versions."
-	einfo
-	einfo "Please file any enhancement requests, or bugs"
-	einfo "at https://github.com/dol-sen/ssl-fetch/issues"
-	einfo "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the Freenode network"
+	elog "This is beta software."
+	elog "The APIs it installs should be considered unstable"
+	elog "and are subject to change in these early versions."
+	elog
+	elog "Please file any enhancement requests, or bugs"
+	elog "at https://github.com/dol-sen/ssl-fetch/issues"
+	elog "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the Freenode network"
 	echo
 }

--- a/dev-python/ssl-fetch/ssl-fetch-0.4.ebuild
+++ b/dev-python/ssl-fetch/ssl-fetch-0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -30,12 +30,12 @@ RDEPEND="${DEPEND}
 
 pkg_postinst() {
 	echo
-	einfo "This is beta software."
-	einfo "The APIs it installs should be considered unstable"
-	einfo "and are subject to change in these early versions."
-	einfo
-	einfo "Please file any enhancement requests, or bugs"
-	einfo "at https://github.com/dol-sen/ssl-fetch/issues"
-	einfo "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the Freenode network"
+	elog "This is beta software."
+	elog "The APIs it installs should be considered unstable"
+	elog "and are subject to change in these early versions."
+	elog
+	elog "Please file any enhancement requests, or bugs"
+	elog "at https://github.com/dol-sen/ssl-fetch/issues"
+	elog "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the Freenode network"
 	echo
 }

--- a/dev-python/ssl-fetch/ssl-fetch-9999.ebuild
+++ b/dev-python/ssl-fetch/ssl-fetch-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -33,12 +33,12 @@ RDEPEND="${DEPEND}
 
 pkg_postinst() {
 	echo
-	einfo "This is experimental software."
-	einfo "The APIs it installs should be considered unstable"
-	einfo "and are subject to change."
+	elog "This is experimental software."
+	elog "The APIs it installs should be considered unstable"
+	elog "and are subject to change."
 	echo
-	einfo "Please file any enhancement requests, or bugs"
-	einfo "at https://github.com/dol-sen/ssl-fetch/issues"
-	einfo "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the freenode network"
+	elog "Please file any enhancement requests, or bugs"
+	elog "at https://github.com/dol-sen/ssl-fetch/issues"
+	elog "I am also on IRC @ #gentoo-portage, #gentoo-keys,... of the freenode network"
 	echo
 }


### PR DESCRIPTION
See [this](https://dev.gentoo.org/~zmedico/portage/doc/ch06s02.html) for details.