### PR TITLE
app-backup/duplicity: replace einfo with elog for messages to users

### DIFF
--- a/app-backup/duplicity/duplicity-0.7.10.ebuild
+++ b/app-backup/duplicity/duplicity-0.7.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -46,6 +46,6 @@ python_test() {
 }
 
 pkg_postinst() {
-	einfo "Duplicity has many optional dependencies to support various backends."
-	einfo "Currently it's up to you to install them as necessary."
+	elog "Duplicity has many optional dependencies to support various backends."
+	elog "Currently it's up to you to install them as necessary."
 }

--- a/app-backup/duplicity/duplicity-0.7.11.ebuild
+++ b/app-backup/duplicity/duplicity-0.7.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -46,6 +46,6 @@ python_test() {
 }
 
 pkg_postinst() {
-	einfo "Duplicity has many optional dependencies to support various backends."
-	einfo "Currently it's up to you to install them as necessary."
+	elog "Duplicity has many optional dependencies to support various backends."
+	elog "Currently it's up to you to install them as necessary."
 }

--- a/app-backup/duplicity/duplicity-0.7.12.ebuild
+++ b/app-backup/duplicity/duplicity-0.7.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -46,6 +46,6 @@ python_test() {
 }
 
 pkg_postinst() {
-	einfo "Duplicity has many optional dependencies to support various backends."
-	einfo "Currently it's up to you to install them as necessary."
+	elog "Duplicity has many optional dependencies to support various backends."
+	elog "Currently it's up to you to install them as necessary."
 }

--- a/app-backup/duplicity/duplicity-0.7.13.1.ebuild
+++ b/app-backup/duplicity/duplicity-0.7.13.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -46,6 +46,6 @@ python_test() {
 }
 
 pkg_postinst() {
-	einfo "Duplicity has many optional dependencies to support various backends."
-	einfo "Currently it's up to you to install them as necessary."
+	elog "Duplicity has many optional dependencies to support various backends."
+	elog "Currently it's up to you to install them as necessary."
 }

--- a/app-backup/duplicity/duplicity-0.7.14.ebuild
+++ b/app-backup/duplicity/duplicity-0.7.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -46,6 +46,6 @@ python_test() {
 }
 
 pkg_postinst() {
-	einfo "Duplicity has many optional dependencies to support various backends."
-	einfo "Currently it's up to you to install them as necessary."
+	elog "Duplicity has many optional dependencies to support various backends."
+	elog "Currently it's up to you to install them as necessary."
 }

--- a/app-backup/duplicity/duplicity-0.7.15.ebuild
+++ b/app-backup/duplicity/duplicity-0.7.15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -47,6 +47,6 @@ python_test() {
 }
 
 pkg_postinst() {
-	einfo "Duplicity has many optional dependencies to support various backends."
-	einfo "Currently it's up to you to install them as necessary."
+	elog "Duplicity has many optional dependencies to support various backends."
+	elog "Currently it's up to you to install them as necessary."
 }

--- a/app-backup/duplicity/duplicity-0.7.16.ebuild
+++ b/app-backup/duplicity/duplicity-0.7.16.ebuild
@@ -47,6 +47,6 @@ python_test() {
 }
 
 pkg_postinst() {
-	einfo "Duplicity has many optional dependencies to support various backends."
-	einfo "Currently it's up to you to install them as necessary."
+	elog "Duplicity has many optional dependencies to support various backends."
+	elog "Currently it's up to you to install them as necessary."
 }

--- a/app-backup/duplicity/duplicity-0.7.17.ebuild
+++ b/app-backup/duplicity/duplicity-0.7.17.ebuild
@@ -47,6 +47,6 @@ python_test() {
 }
 
 pkg_postinst() {
-	einfo "Duplicity has many optional dependencies to support various backends."
-	einfo "Currently it's up to you to install them as necessary."
+	elog "Duplicity has many optional dependencies to support various backends."
+	elog "Currently it's up to you to install them as necessary."
 }


### PR DESCRIPTION
See https://dev.gentoo.org/~zmedico/portage/doc/ch06s02.html for details.