### PR TITLE
dev-db/pgtap: add missing app-arch/unzip dependency

### DIFF
--- a/dev-db/pgtap/pgtap-0.98.0.ebuild
+++ b/dev-db/pgtap/pgtap-0.98.0.ebuild
@@ -17,6 +17,7 @@ KEYWORDS="amd64"
 IUSE=""
 
 DEPEND="${POSTGRES_DEP}
+		app-arch/unzip
 		dev-perl/TAP-Parser-SourceHandler-pgTAP
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Hi,

The ebuild downloads a zip file for what we need app-arch/unzip to be able to extract it. This PR simple adds the missing dependency to the ebuild.

Please review.