### PR TITLE
sci-mathematics/nusmv: add missing app-arch/unzip dependency

### DIFF
--- a/sci-mathematics/nusmv/nusmv-2.6.0.ebuild
+++ b/sci-mathematics/nusmv/nusmv-2.6.0.ebuild
@@ -31,6 +31,7 @@ DEPEND="${SHARED_DEPEND}
 		dev-texlive/texlive-latexextra
 		app-doc/doxygen
 	)
+	app-arch/unzip
 	dev-libs/libxml2
 	${PYTHON_DEPS}"
 


### PR DESCRIPTION
Hi,

The ebuild downloads a zip file for what we need app-arch/unzip to be able to extract it. This PR simple adds the missing dependency to the ebuild.

Please review.