### PR TITLE
scsh.eclass: last-rite

### DIFF
--- a/eclass/scsh.eclass
+++ b/eclass/scsh.eclass
@@ -2,6 +2,11 @@
 # Distributed under the terms of the GNU General Public License v2
 #
 
+# @DEAD
+# Joonas Niilola <juippis@gmail.com> (08 Aug 2018)
+# Unused, judging from history unmaintained and lacks documentation. 
+# #658284, #637876. Removal in ~30 days.
+
 inherit eutils multilib
 
 SLOT="0"


### PR DESCRIPTION
Was browsing https://qa-reports.gentoo.org/output/eclass-usage/ and saw this eclass isn't being used by any packages in the tree. Removal approved in https://bugs.gentoo.org/658284 but I guess it needs a proper last-rite first?