### PR TITLE
dev-tex/biber: pin Unicode-Collate for testing

### DIFF
--- a/dev-tex/biber/biber-2.10.ebuild
+++ b/dev-tex/biber/biber-2.10.ebuild
@@ -59,7 +59,8 @@ DEPEND="${RDEPEND}
 	dev-perl/Module-Build
 	dev-perl/ExtUtils-LibBuilder
 	test? ( dev-perl/File-Which
-			dev-perl/Test-Differences )"
+			dev-perl/Test-Differences
+			~virtual/perl-Unicode-Collate-1.210.0 )"
 
 PATCHES=( "${FILESDIR}/${PN}-2.7-drop-mozilla-ca.patch" )
 

--- a/dev-tex/biber/biber-2.7.ebuild
+++ b/dev-tex/biber/biber-2.7.ebuild
@@ -58,7 +58,8 @@ DEPEND="${RDEPEND}
 	dev-perl/Module-Build
 	dev-perl/ExtUtils-LibBuilder
 	test? ( dev-perl/File-Which
-			dev-perl/Test-Differences )"
+			dev-perl/Test-Differences
+			~virtual/perl-Unicode-Collate-1.190.0 )"
 
 PATCHES=( "${FILESDIR}/${PN}-2.7-drop-mozilla-ca.patch" )
 


### PR DESCRIPTION
The test suite is unstable against different versions of
Unicode-Collate. It uses some hashes for comparision which change with
different Unicode-Collate versions. See upstream
https://github.com/plk/biber/issues/207 .
"Fix" this by pinning the version of Unicode-Collate when testing.

Closes: https://bugs.gentoo.org/643966
Package-Manager: Portage-2.3.44, Repoman-2.3.10