### PR TITLE
net-dns/getdns: disable tests #661760

### DIFF
--- a/net-dns/getdns/getdns-1.4.2-r2.ebuild
+++ b/net-dns/getdns/getdns-1.4.2-r2.ebuild
@@ -14,6 +14,10 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="stubby +getdns_query +getdns_server_mon libressl +idn +unbound libevent libev libuv +threads static-libs"
 
+# https://bugs.gentoo.org/661760
+# https://github.com/getdnsapi/getdns/issues/407
+RESTRICT="test"
+
 DEPEND="
 	dev-libs/libbsd:=
 	dev-libs/libyaml:=


### PR DESCRIPTION
As reported in [this bug report](https://bugs.gentoo.org/661760) and this [getdns issue](https://github.com/getdnsapi/getdns/issues/407), tests fail because they need network access. Until that is fixed upstream, I think I should disable tests.

CC @blueness 