### PR TITLE
sys-apps/dcfldd: EAPI7, improve ebuild

### DIFF
--- a/sys-apps/dcfldd/dcfldd-1.3.4.1-r1.ebuild
+++ b/sys-apps/dcfldd/dcfldd-1.3.4.1-r1.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+My_PV=$(ver_rs 3 '-')
+
+DESCRIPTION="enhanced dd with features for forensics and security"
+HOMEPAGE="http://dcfldd.sourceforge.net/"
+SRC_URI="mirror://sourceforge/dcfldd/${PN}-${My_PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+S="${WORKDIR}/${PN}-${My_PV}"


### PR DESCRIPTION
Hi,

This Bug/PR bumps sys-apps/dcfldd for EAPI7 and improves the ebuild a bit.
Please review.

Closes: https://bugs.gentoo.org/663250