### PR TITLE
sys-process/dcron: fix qa warning

### DIFF
--- a/sys-process/dcron/dcron-4.5-r2.ebuild
+++ b/sys-process/dcron/dcron-4.5-r2.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+inherit cron toolchain-funcs systemd
+
+DESCRIPTION="A cute little cron from Matt Dillon"
+HOMEPAGE="http://www.jimpryor.net/linux/dcron.html http://apollo.backplane.com/FreeSrc/"
+SRC_URI="http://www.jimpryor.net/linux/releases/${P}.tar.gz"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+LICENSE="GPL-2"
+SLOT="0"
+
+DOCS=( CHANGELOG README extra/run-cron extra/root.crontab "${FILESDIR}"/crontab )
+
+PATCHES=( "${FILESDIR}"/${PN}-4.5-ldflags.patch "${FILESDIR}"/${PN}-4.5-pidfile.patch )
+
+src_prepare() {
+	default
+
+	tc-export CC
+
+	cat <<-EOF > config
+		PREFIX = /usr
+		CRONTAB_GROUP = cron
+	EOF
+}
+
+src_install() {
+	default
+
+	docrondir
+	docron crond -m0700 -o root -g wheel
+	docrontab
+
+	insinto /etc
+	doins "${FILESDIR}"/crontab
+
+	insinto /etc/cron.d
+	doins extra/prune-cronstamps
+
+	insinto /etc/logrotate.d
+	newins extra/crond.logrotate dcron
+
+	keepdir /var/spool/cron/cronstamps
+
+	newinitd "${FILESDIR}"/dcron.init dcron
+	newconfd "${FILESDIR}"/dcron.confd dcron
+	systemd_dounit "${FILESDIR}"/dcron.service
+}

--- a/sys-process/dcron/metadata.xml
+++ b/sys-process/dcron/metadata.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>cron-bugs@gentoo.org</email>
-</maintainer>
-<upstream>
-	<remote-id type="github">dubiousjim/dcron</remote-id>
-</upstream>
+	<maintainer type="project">
+		<email>cron-bugs@gentoo.org</email>
+	</maintainer>
+	<longdescription>
+		This lightweight cron daemon aims to be simple and secure, with just enough
+		features to stay useful.
+		Unlike other fatter cron daemons, though, this cron doesn't even try to manage
+		environment variables or act as a shell.
+		All jobs are run with `/bin/sh` for conformity and portability.
+	</longdescription>
+	<upstream>
+		<bugs-to>https://github.com/dubiousjim/dcron/issues</bugs-to>
+		<remote-id type="github">dubiousjim/dcron</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Also bump to EAPI="6".

Closes: https://bugs.gentoo.org/651202
Package-Manager: Portage-2.3.44, Repoman-2.3.10