### PR TITLE
net-analyzer/nload: EAPI=7, fix bug 663402 "speed graph rendering issue"

### DIFF
--- a/net-analyzer/nload/files/nload-0.7.4-Eliminate-flicker-on-some-terminals.patch
+++ b/net-analyzer/nload/files/nload-0.7.4-Eliminate-flicker-on-some-terminals.patch
@@ -1,0 +1,26 @@
+From 8a93886e0fb33a81b8fe32e88ee106a581fedd34 Mon Sep 17 00:00:00 2001
+From: Roland Riegel <roland@roland-riegel.de>
+Date: Sun, 28 Jan 2018 16:59:39 +0100
+Subject: [PATCH 1/1] Eliminate flicker on some terminals like rxvt (thanks to
+ Alex Wilson)
+
+---
+ src/window.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/window.cpp b/src/window.cpp
+index bfa7701..2083fd0 100644
+--- a/src/window.cpp
++++ b/src/window.cpp
+@@ -108,7 +108,7 @@ void Window::refresh()
+ void Window::clear()
+ {
+     if(m_window)
+-        wclear(m_window);
++        werase(m_window);
+ }
+ 
+ // move and resize window
+-- 
+2.16.4
+

--- a/net-analyzer/nload/files/nload-0.7.4-Makefile-spec-don-t-compress-man-page.patch
+++ b/net-analyzer/nload/files/nload-0.7.4-Makefile-spec-don-t-compress-man-page.patch
@@ -1,0 +1,65 @@
+From 04d5af489f998568553dc54f39c56ef740a27f1b Mon Sep 17 00:00:00 2001
+From: Andrey Mazo <ahippo@yandex.com>
+Date: Sun, 26 Aug 2018 00:00:35 +0300
+Subject: [PATCH 1/1] Makefile,spec: don't compress the man-page
+
+Package managers like to compress man-pages on their own,
+because the type of compression for man-pages is user-configurable.
+In particular, Gentoo [1] doesn't want packages to compress their man-pages.
+Gentoo Portage has workarounds for this,
+but this is not specified in Package Manager Specification and
+results in extra compression-decompression pass.
+
+RPM also compresses man-pages itself (in `brp-compress`)
+(and similarly recompresses them as needed)
+rather than relying on packages to install compressed man-pages.
+
+Automake can handle installation of man-pages without the explicit "install" target,
+so use the standard automake-provided way of installing man-pages.
+It's also smart enough to package `nload.1.in` automatically.
+
+Don't specify an explicit man-page extension in .spec file as recommended by Fedora.
+
+[1] https://github.com/gentoo/gentoo/pull/9543#issuecomment-415662844
+
+(cherry picked from commit 096df0d1282a8c8c535e730d28fe281ea290b58d)
+
+Upstream: https://github.com/rolandriegel/nload/pull/4
+---
+ docs/Makefile.am | 10 +---------
+ nload.spec.in    |  2 +-
+ 2 files changed, 2 insertions(+), 10 deletions(-)
+
+diff --git a/docs/Makefile.am b/docs/Makefile.am
+index 646d438..9032a02 100644
+--- a/docs/Makefile.am
++++ b/docs/Makefile.am
+@@ -1,11 +1,3 @@
+ ## Helder Correia <helder.correia@netcabo.pt>
+ 
+-man1_MAN = nload.1
+-
+-install:
+-	$(mkinstalldirs) $(DESTDIR)$(mandir)/man1
+-	$(INSTALL_DATA) $(top_srcdir)/docs/$(PACKAGE).1 $(DESTDIR)$(mandir)/man1
+-	gzip -f $(DESTDIR)$(mandir)/man1/$(PACKAGE).1
+-
+-uninstall:
+-	rm $(DESTDIR)$(mandir)/man1/$(PACKAGE).1.gz
++man1_MANS = nload.1
+diff --git a/nload.spec.in b/nload.spec.in
+index 36496fd..53f6f19 100644
+--- a/nload.spec.in
++++ b/nload.spec.in
+@@ -41,7 +41,7 @@ rm -rf %{buildroot}
+ %defattr(-,root,root)
+ %doc AUTHORS COPYING ChangeLog NEWS README
+ %attr(0755,root,root) %{_bindir}/%{name}
+-%{_mandir}/man1/%{name}.1.gz
++%{_mandir}/man1/%{name}.1*
+ 
+ 
+ %changelog
+-- 
+2.16.4
+

--- a/net-analyzer/nload/metadata.xml
+++ b/net-analyzer/nload/metadata.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+  <maintainer type="person">
+    <email>ahippo@yandex.ru</email>
+    <name>Andrey Mazo</name>
+  </maintainer>
   <maintainer type="project">
     <email>netmon@gentoo.org</email>
     <name>Gentoo network monitoring and analysis project</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
   </maintainer>
 </pkgmetadata>

--- a/net-analyzer/nload/nload-0.7.4-r1.ebuild
+++ b/net-analyzer/nload/nload-0.7.4-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Real time network traffic monitor for the command line interface"
+HOMEPAGE="http://www.roland-riegel.de/nload/index.html"
+SRC_URI="http://www.roland-riegel.de/nload/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~x86"
+
+RDEPEND=">=sys-libs/ncurses-5.2:0="
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-tinfo.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# --enable-debug means do not strip debugging symbols (default no)
+	econf --enable-debug
+}

--- a/net-analyzer/nload/nload-0.7.4-r1.ebuild
+++ b/net-analyzer/nload/nload-0.7.4-r1.ebuild
@@ -19,6 +19,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-tinfo.patch
+	"${FILESDIR}"/${P}-Eliminate-flicker-on-some-terminals.patch
 )
 
 src_prepare() {

--- a/net-analyzer/nload/nload-0.7.4-r1.ebuild
+++ b/net-analyzer/nload/nload-0.7.4-r1.ebuild
@@ -20,6 +20,7 @@ BDEPEND="virtual/pkgconfig"
 PATCHES=(
 	"${FILESDIR}"/${P}-tinfo.patch
 	"${FILESDIR}"/${P}-Eliminate-flicker-on-some-terminals.patch
+	"${FILESDIR}"/${P}-Makefile-spec-don-t-compress-man-page.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
The first patch is a preparation, which adds -r1 ebuild, and fixes repoman warnings for it.
(switches to EAPI=7 and shortens the package description).
The second patch adds an upstream patch to fix the issue described in Gentoo bug 663402.