### PR TITLE
net-p2p/qbittorrent: install desktop file

### DIFF
--- a/net-p2p/qbittorrent/qbittorrent-4.1.2.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-4.1.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit gnome2-utils xdg-utils
+inherit desktop gnome2-utils xdg-utils
 
 DESCRIPTION="BitTorrent client in C++ and Qt"
 HOMEPAGE="https://www.qbittorrent.org
@@ -54,6 +54,7 @@ src_configure() {
 
 src_install() {
 	emake STRIP="/bin/false" INSTALL_ROOT="${D}" install
+	domenu dist/unix/qbittorrent.desktop
 	einstalldocs
 }
 


### PR DESCRIPTION
The net-p2p/qbittorrent-4.1.2 ebuild switched from CMake to autotools, and as a result no desktop file is being installed. Install it manually.

Closes: https://bugs.gentoo.org/663554
Package-Manager: Portage-2.3.46, Repoman-2.3.10