### PR TITLE
waf-utils.eclass: WAF_VERBOSE always effectively on

### DIFF
--- a/eclass/waf-utils.eclass
+++ b/eclass/waf-utils.eclass
@@ -98,7 +98,7 @@ waf-utils_src_configure() {
 waf-utils_src_compile() {
 	debug-print-function ${FUNCNAME} "$@"
 	local _mywafconfig
-	[[ "${WAF_VERBOSE}" ]] && _mywafconfig="--verbose"
+	[[ "${WAF_VERBOSE}" = "ON" ]] && _mywafconfig="--verbose"
 
 	local jobs="--jobs=$(makeopts_jobs)"
 	echo "\"${WAF_BINARY}\" build ${_mywafconfig} ${jobs}"


### PR DESCRIPTION
Fix broken behavior not allowing to change the default verbosity.
This should be of importance to everybody building on SMP systems, since
giving the --verbose option to waf breaks a multi-job build (by making
it one-job), at least for me. This is probably a waf issue, but the
inability to change WAF_VERBOSE is clearly a bug in the eclass.
The test affected by change is always true because WAF_VERBOSE is always
set to "ON" or other non-null value. The change fixes that.