### PR TITLE
x11-themes/gtk-theme-switch: EAPI7, improved ebuild

### DIFF
--- a/x11-themes/gtk-theme-switch/gtk-theme-switch-2.1.0-r1.ebuild
+++ b/x11-themes/gtk-theme-switch/gtk-theme-switch-2.1.0-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Utility to switch and preview GTK+ theme"
+HOMEPAGE="https://packages.qa.debian.org/g/gtk-theme-switch.html"
+SRC_URI="mirror://debian/pool/main/g/${PN}/${PN}_${PV}.orig.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos"
+
+RDEPEND="x11-libs/gtk+:2"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( ChangeLog readme todo )
+
+src_prepare() {
+	default
+	sed -i \
+		-e 's:${GCC}:$(CC) $(LDFLAGS):' \
+		Makefile || die
+}
+
+src_compile() {
+	tc-export CC
+	emake CFLAGS="${CFLAGS} -Wall"
+}
+
+src_install() {
+	newbin ${PN}2 ${PN}
+	newman ${PN}2.1 ${PN}.1
+	einstalldocs
+}


### PR DESCRIPTION
Hi,

This PR/Bug updates x11-themes/gtk-theme-switch for EAPI7. I only made minor changes to the ebuild.
Please review.

Closes: https://bugs.gentoo.org/663810