### PR TITLE
media-libs/imlib2: enable 'shm' and 'X' by default in 1.5.1-r1

### DIFF
--- a/media-libs/imlib2/imlib2-1.5.1-r1.ebuild
+++ b/media-libs/imlib2/imlib2-1.5.1-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://downloads.sourceforge.net/enlightenment/${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x64-solaris ~x86-solaris"
-IUSE="bzip2 cpu_flags_x86_mmx cpu_flags_x86_sse2 doc gif jpeg mp3 nls png shm static-libs tiff X zlib"
+IUSE="bzip2 cpu_flags_x86_mmx cpu_flags_x86_sse2 doc gif jpeg mp3 nls png +shm static-libs tiff +X zlib"
 
 REQUIRED_USE="shm? ( X )"
 


### PR DESCRIPTION
With xorg bump to 1.20.1 the issue with shm in imlib2 is fixed, and it should be enabled by default as is done upstream.

To my knowledge this doesn't require revbump. Will request stabilization for this package when >=xorg-1.20.1 hits stable.