### PR TITLE
dev-ml/ocaml-autoconf: revbump for EAPI7

### DIFF
--- a/dev-ml/ocaml-autoconf/ocaml-autoconf-1.1-r1.ebuild
+++ b/dev-ml/ocaml-autoconf/ocaml-autoconf-1.1-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="autoconf macros to support configuration of OCaml programs and libraries"
+HOMEPAGE="http://ocaml-autoconf.forge.ocamlcore.org/"
+SRC_URI="http://forge.ocamlcore.org/frs/download.php/282/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~x86"
+
+src_install() {
+	emake DESTDIR="${D}" prefix="/usr" install
+	dodoc README
+}


### PR DESCRIPTION
Hi,

This is another very simple EAPI7 bump.
Please review.

Closes: https://bugs.gentoo.org/663882