### PR TITLE
media-libs/opencv: disable implied CPU flags

### DIFF
--- a/media-libs/opencv/opencv-3.4.1-r4.ebuild
+++ b/media-libs/opencv/opencv-3.4.1-r4.ebuild
@@ -41,16 +41,7 @@ REQUIRED_USE="
 	java? ( python )
 	opengl? ( || ( gtk qt5 ) )
 	python? ( ${PYTHON_REQUIRED_USE} )
-	tesseract? ( contrib )
-	cpu_flags_x86_avx2? ( cpu_flags_x86_avx cpu_flags_x86_fma3 )
-	cpu_flags_x86_fma3? ( cpu_flags_x86_avx2 )
-	cpu_flags_x86_avx? ( cpu_flags_x86_sse4_2 )
-	cpu_flags_x86_sse4_2? ( cpu_flags_x86_sse4_1 cpu_flags_x86_popcnt )
-	cpu_flags_x86_popcnt? ( cpu_flags_x86_sse4_1 )
-	cpu_flags_x86_sse4_1? ( cpu_flags_x86_sse3 cpu_flags_x86_ssse3 )
-	cpu_flags_x86_ssse3? ( cpu_flags_x86_sse3 )
-	cpu_flags_x86_sse3? ( cpu_flags_x86_sse2 )
-	cpu_flags_x86_sse2? ( cpu_flags_x86_sse )"
+	tesseract? ( contrib )"
 
 # The following logic is intrinsic in the build system, but we do not enforce
 # it on the useflags since this just blocks emerging pointlessly:
@@ -413,6 +404,7 @@ multilib_src_configure() {
 	# ==================================================
 	# cpu flags, should solve 633900
 	#===================================================
+		-DOPENCV_CPU_OPT_IMPLIES_IGNORE=ON
 		-DCPU_DISPATCH=
 		-DENABLE_SSE=$(usex cpu_flags_x86_sse)
 		-DENABLE_SSE2=$(usex cpu_flags_x86_sse2)


### PR DESCRIPTION
The OpenCV build system tries to be helpful by enabling unrequested CPU
flags based on requested ones. Unfortunately, this breaks the build on
AMD Piledriver because FMA3 implies AVX2 which is not available on this
architecture.

Further more, these CPU flags should only be handled by the
corresponding Portage flags, instead of CMake's hard-coded automagic.
This commit fixes that by disabling the whole "implication" mechanism
for CPU flags, while also undoing the previous attempt at solving the
problem by translating those broken "implications" into REQUIRED_USE.

Authored-by: Ștefan Talpalaru <stefantalpalaru@yahoo.com>
Bug: https://bugs.gentoo.org/656638