### PR TITLE
profiles: media-video/vlc cleanup and then some

### DIFF
--- a/profiles/arch/arm/package.use.stable.mask
+++ b/profiles/arch/arm/package.use.stable.mask
@@ -51,14 +51,9 @@ media-sound/mpd fluidsynth
 <media-video/libav-12 frei0r
 <=media-video/ffmpeg-3.3.6 frei0r sofalizer
 
-# Alexis Ballier <aballier@gentoo.org> (26 May 2017)
-# No musepack-tools stable yet
-media-plugins/gst-plugins-meta:0.10 musepack
-media-sound/mpd musepack
-
 # Alexis Ballier <aballier@gentoo.org> (18 Apr 2017)
-# No gst-plugins-vp8:0.10 stable
-media-plugins/gst-plugins-meta:0.10 vpx
+# No gst-plugins-vp8:0.10, gst-plugins-musepack:0.10 stable
+media-plugins/gst-plugins-meta:0.10 musepack vpx
 
 # Michael Weber <xmw@gentoo.org> (1 Apr 2017)
 # no stable jdk

--- a/profiles/arch/arm/package.use.stable.mask
+++ b/profiles/arch/arm/package.use.stable.mask
@@ -42,14 +42,9 @@ net-mail/dovecot textcat
 dev-db/mariadb galera
 
 # Alexis Ballier <aballier@gentoo.org> (30 May 2017)
-# No stable libtar yet
-<media-video/vlc-2.3 libtar
-
-# Alexis Ballier <aballier@gentoo.org> (30 May 2017)
 # No stable fluidsynth yet
 media-libs/sdl-mixer fluidsynth
 media-sound/mpd fluidsynth
-<media-video/vlc-2.3 fluidsynth
 
 # Alexis Ballier <aballier@gentoo.org> (29 May 2017)
 # frei0r-plugins is not stable yet, mask it on stable versions
@@ -58,7 +53,6 @@ media-sound/mpd fluidsynth
 
 # Alexis Ballier <aballier@gentoo.org> (26 May 2017)
 # No musepack-tools stable yet
-media-video/vlc musepack
 media-plugins/gst-plugins-meta:0.10 musepack
 media-sound/mpd musepack
 

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -667,7 +667,7 @@ media-sound/pulseaudio system-wide
 net-proxy/squid ipf-transparent pf-transparent
 
 # Alexis Ballier <aballier@gentoo.org> <16 Feb 2011>
-# Win32 specific useflags for vlc. Can be used for cross-compiling.
-media-video/vlc directx dxva2
+# Win32 specific useflag for vlc. Can be used for cross-compiling.
+media-video/vlc directx
 # Mac OSX / iPhone OS specific useflags
-media-video/vlc audioqueue macosx-dialog-provider macosx-eyetv macosx-quartztext macosx-qtkit
+media-video/vlc macosx-qtkit

--- a/profiles/default/linux/powerpc/ppc64/13.0/package.use.stable.mask
+++ b/profiles/default/linux/powerpc/ppc64/13.0/package.use.stable.mask
@@ -1,6 +1,2 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-
-# Tom Wijsman <TomWij@gentoo.org (16 Mar 2014)
-# Mask unstable USE flags on media-video/vlc, see security bug #499806.
-media-video/vlc chromaprint gnutls opus

--- a/profiles/default/linux/powerpc/ppc64/17.0/package.use.stable.mask
+++ b/profiles/default/linux/powerpc/ppc64/17.0/package.use.stable.mask
@@ -1,6 +1,2 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-
-# Tom Wijsman <TomWij@gentoo.org (16 Mar 2014)
-# Mask unstable USE flags on media-video/vlc, see security bug #499806.
-media-video/vlc chromaprint gnutls opus

--- a/profiles/prefix/darwin/package.use.mask
+++ b/profiles/prefix/darwin/package.use.mask
@@ -25,10 +25,6 @@ media-gfx/tachyon mpi
 # gdb server is not supported on this platform
 sys-devel/gdb server
 
-# Fabian Groffen <grobian@gentoo.org> (16 Feb 2011)
-# De-mask of OSX-specific USE-flags that are useful for VLC
-media-video/vlc -audioqueue -macosx-dialog-provider -macosx-eyetv -macosx-quartztext
-
 # Fabian Groffen <grobian@gentoo.org> (08 Jan 2011)
 # Darwin has libuuid from util-linux
 x11-libs/libSM -uuid


### PR DESCRIPTION
@aballier also dropping some fluidsynth, musepack and frei0r *.use.mask entries that are obsolete.