### PR TITLE
dev-python/python-magic: add Python 3.7, PyPy{,3}, fix tests

### DIFF
--- a/dev-python/python-magic/files/python-magic-0.4.15-fix-buffer-test.patch
+++ b/dev-python/python-magic/files/python-magic-0.4.15-fix-buffer-test.patch
@@ -1,0 +1,65 @@
+commit acfda9c26df888741805249f3ec0f60f369fc664
+Author: Louis Sautier <sautier.louis@gmail.com>
+Date:   Tue Aug 14 11:14:19 2018 +0200
+
+    Tests: allow differences when reading a buffer or a file, fixes #173
+    
+    Also remove the loop in order to avoid analyzing files or buffers for each
+    expected value, replace it with a call to assertIn().
+
+diff --git a/test/test.py b/test/test.py
+index addccc6..67957ee 100755
+--- a/test/test.py
++++ b/test/test.py
+@@ -10,7 +10,7 @@ import magic
+ class MagicTest(unittest.TestCase):
+     TESTDATA_DIR = os.path.join(os.path.dirname(__file__), 'testdata')
+ 
+-    def assert_values(self, m, expected_values):
++    def assert_values(self, m, expected_values, buf_equals_file=True):
+         for filename, expected_value in expected_values.items():
+             try:
+                 filename = os.path.join(self.TESTDATA_DIR, filename)
+@@ -21,15 +21,16 @@ class MagicTest(unittest.TestCase):
+             if type(expected_value) is not tuple:
+                 expected_value = (expected_value,)
+ 
+-            for i in expected_value:
+-                with open(filename, 'rb') as f:
+-                    buf_value = m.from_buffer(f.read())
++            with open(filename, 'rb') as f:
++                buf_value = m.from_buffer(f.read())
+ 
+-                file_value = m.from_file(filename)
+-                if buf_value == i and file_value == i:
+-                    break
+-            else:
+-                self.assertTrue(False, "no match for " + repr(expected_value))
++            file_value = m.from_file(filename)
++
++            if buf_equals_file:
++                self.assertEqual(buf_value, file_value)
++
++            for value in (buf_value, file_value):
++                self.assertIn(value, expected_value)
+ 
+     def test_from_buffer_str_and_bytes(self):
+         m = magic.Magic(mime=True)
+@@ -62,10 +63,14 @@ class MagicTest(unittest.TestCase):
+                 'magic._pyc_': 'python 2.4 byte-compiled',
+                 'test.pdf': 'PDF document, version 1.2',
+                 'test.gz':
+-                ('gzip compressed data, was "test", from Unix, last modified: Sun Jun 29 01:32:52 2008',
+-                 'gzip compressed data, was "test", last modified: Sun Jun 29 01:32:52 2008, from Unix'),
++                ('gzip compressed data, was "test", from Unix, last '
++                 'modified: Sun Jun 29 01:32:52 2008',
++                 'gzip compressed data, was "test", last modified'
++                 ': Sun Jun 29 01:32:52 2008, from Unix',
++                 'gzip compressed data, was "test", last modified'
++                 ': Sun Jun 29 01:32:52 2008, from Unix, original size 15'),
+                 'text.txt': 'ASCII text',
+-            })
++            }, buf_equals_file=False)
+         finally:
+             del os.environ['TZ']
+ 

--- a/dev-python/python-magic/files/python-magic-0.4.15-fix-gzip-test.patch
+++ b/dev-python/python-magic/files/python-magic-0.4.15-fix-gzip-test.patch
@@ -1,0 +1,19 @@
+commit e83487a20bacd4f9b33d0478861671bf79468f59
+Author: Louis Sautier <sautier.louis@gmail.com>
+Date:   Mon Aug 13 12:15:13 2018 +0200
+
+    Allow x-gzip as MIME type for gzip files, fixes #96
+
+diff --git a/test/test.py b/test/test.py
+index e29335f..e3ee703 100755
+--- a/test/test.py
++++ b/test/test.py
+@@ -54,7 +54,7 @@ class MagicTest(unittest.TestCase):
+             self.assert_values(m, {
+                 'magic._pyc_': 'application/octet-stream',
+                 'test.pdf': 'application/pdf',
+-                'test.gz': 'application/gzip',
++                'test.gz': ('application/gzip', 'application/x-gzip'),
+                 'text.txt': 'text/plain',
+                 b'\xce\xbb'.decode('utf-8'): 'text/plain',
+                 b'\xce\xbb': 'text/plain',

--- a/dev-python/python-magic/files/python-magic-0.4.15-fix-jpeg-test.patch
+++ b/dev-python/python-magic/files/python-magic-0.4.15-fix-jpeg-test.patch
@@ -1,0 +1,49 @@
+commit 4bda684f8b461cc1f69593799efcf6afe8397756
+Author: Adam Hupp <adam@hupp.org>
+Date:   Sat Dec 9 09:09:00 2017 -0800
+
+    fix test for xenial since travis started enabling it
+
+diff --git a/test/test.py b/test/test.py
+index addccc6..c6e2d9c 100755
+--- a/test/test.py
++++ b/test/test.py
+@@ -17,7 +17,7 @@ class MagicTest(unittest.TestCase):
+             except TypeError:
+                 filename = os.path.join(self.TESTDATA_DIR.encode('utf-8'), filename)
+ 
+-            
++
+             if type(expected_value) is not tuple:
+                 expected_value = (expected_value,)
+ 
+@@ -37,7 +37,7 @@ class MagicTest(unittest.TestCase):
+         self.assertEqual("text/x-python", m.from_buffer(s))
+         b = b'#!/usr/bin/env python\nprint("foo")'
+         self.assertEqual("text/x-python", m.from_buffer(b))
+-                
++
+     def test_mime_types(self):
+         dest = os.path.join(MagicTest.TESTDATA_DIR, b'\xce\xbb'.decode('utf-8'))
+         shutil.copyfile(os.path.join(MagicTest.TESTDATA_DIR, 'lambda'), dest)
+@@ -92,9 +92,9 @@ class MagicTest(unittest.TestCase):
+ 
+         m = magic.Magic(mime=True)
+         self.assertEqual(m.from_file(filename), 'image/jpeg')
+-        
++
+         m = magic.Magic(mime=True, keep_going=True)
+-        self.assertEqual(m.from_file(filename), 'image/jpeg')
++        self.assertEqual(m.from_file(filename), 'image/jpeg\\012- application/octet-stream')
+ 
+ 
+     def test_rethrow(self):
+@@ -103,7 +103,7 @@ class MagicTest(unittest.TestCase):
+             def t(x,y):
+                 raise magic.MagicException("passthrough")
+             magic.magic_buffer = t
+-            
++
+             self.assertRaises(magic.MagicException, magic.from_buffer, "hello", True)
+         finally:
+             magic.magic_buffer = old

--- a/dev-python/python-magic/python-magic-0.4.15-r1.ebuild
+++ b/dev-python/python-magic/python-magic-0.4.15-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( pypy{,3} python{2_7,3_{4,5,6,7}} )
+
+inherit distutils-r1
+
+DESCRIPTION="Access the libmagic file type identification library"
+HOMEPAGE="https://github.com/ahupp/python-magic"
+# https://github.com/ahupp/python-magic/pull/178
+SRC_URI="https://github.com/ahupp/python-magic/archive/${PV}.tar.gz -> ${P}.gh.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~ia64 ~x86"
+IUSE="test"
+
+RDEPEND="sys-apps/file[-python]"
+BDEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? ( ${RDEPEND} )
+"
+
+PATCHES=(
+	# https://github.com/ahupp/python-magic/pull/177
+	"${FILESDIR}/${P}-fix-buffer-test.patch"
+	# https://github.com/ahupp/python-magic/pull/176
+	"${FILESDIR}/${P}-fix-gzip-test.patch"
+	# https://github.com/ahupp/python-magic/commit/4bda684f8b461cc1f69593799efcf6afe8397756
+	"${FILESDIR}/${P}-fix-jpeg-test.patch"
+)
+
+python_test() {
+	"${EPYTHON}" test/test.py -v || die "Tests fail with ${EPYTHON}"
+}


### PR DESCRIPTION
* Tests didn't work with recent versions of file. Provide patches that
  have been merged upstream.
* Fix dependencies, DEPEND=${DEPEND} was a typo.
* EAPI=7.

Package-Manager: Portage-2.3.45, Repoman-2.3.10

```diff
--- python-magic-0.4.15.ebuild  2018-07-19 11:59:11.864854272 +0200
+++ python-magic-0.4.15-r1.ebuild       2018-08-18 03:02:47.071147365 +0200
@@ -1,24 +1,36 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2

-EAPI=6
+EAPI=7

-PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+PYTHON_COMPAT=( pypy{,3} python{2_7,3_{4,5,6,7}} )

 inherit distutils-r1

 DESCRIPTION="Access the libmagic file type identification library"
 HOMEPAGE="https://github.com/ahupp/python-magic"
+# https://github.com/ahupp/python-magic/pull/178
 SRC_URI="https://github.com/ahupp/python-magic/archive/${PV}.tar.gz -> ${P}.gh.tar.gz"

 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~hppa ia64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~hppa ~ia64 ~x86"
+IUSE="test"

 RDEPEND="sys-apps/file[-python]"
-DEPEND="${DEPEND}
-       dev-python/setuptools[${PYTHON_USEDEP}]"
+BDEPEND="
+       dev-python/setuptools[${PYTHON_USEDEP}]
+       test? ( ${RDEPEND} )
+"
+
+PATCHES=(
+       # https://github.com/ahupp/python-magic/pull/177
+       "${FILESDIR}/${P}-fix-buffer-test.patch"
+       # https://github.com/ahupp/python-magic/pull/176
+       "${FILESDIR}/${P}-fix-gzip-test.patch"
+       # https://github.com/ahupp/python-magic/commit/4bda684f8b461cc1f69593799efcf6afe8397756
+       "${FILESDIR}/${P}-fix-jpeg-test.patch"
+)

 python_test() {
        "${EPYTHON}" test/test.py -v || die "Tests fail with ${EPYTHON}"
```