### PR TITLE
net-analyzer/bing: EAPI7, improve ebuild

### DIFF
--- a/net-analyzer/bing/bing-1.1.3-r2.ebuild
+++ b/net-analyzer/bing/bing-1.1.3-r2.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="A point-to-point bandwidth measurement tool"
+HOMEPAGE="http://fgouget.free.fr/bing/index-en.shtml"
+SRC_URI="mirror://debian/pool/main/b/bing/${PN}_${PV}.orig.tar.gz"
+
+LICENSE="BSD-4"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~sparc ~x86"
+
+src_prepare() {
+	default
+	sed -i -e "s:#COPTIM = -g: COPTIM = ${CFLAGS}:" Makefile || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin bing
+	doman unix/bing.8
+	dodoc ChangeLog Readme.{1st,txt}
+}


### PR DESCRIPTION
Hi,

This PR/Bug updates net-analyzer/bing for EAPI7. I've only made minor changes to the ebuild and also removed the sed dependency since sed is a system package anyway.
Please review.

Closes: https://bugs.gentoo.org/664074