### PR TITLE
dev-libs/yaz-5.26.1 version bump

### DIFF
--- a/dev-libs/yaz/files/yaz-5.26.1-icu-automagic.patch
+++ b/dev-libs/yaz/files/yaz-5.26.1-icu-automagic.patch
@@ -1,0 +1,25 @@
+--- yaz-5.26.1/configure.ac.orig        2009-07-08 04:58:43.000000000 -0700
++++ yaz-5.26.1/configure.ac     2009-07-31 01:46:21.764545198 -0700
+@@ -373,14 +373,14 @@
+
+ dnl
+ dnl
+-AC_CHECK_ICU([3.4],[
+-	if test "$xml_enabled" = "true"; then
+-	    ICU_CPPFLAGS="$ICU_CPPFLAGS -D YAZ_HAVE_ICU=1"
+-	else
+-	    ICU_CPPFLAGS=""
+-	    AC_MSG_WARN([ICU support disabled because XML support is unavailable])
+-	fi
+-])
++dnl ------ ICU
++AC_ARG_ENABLE(icu, [  --enable-icu            enable ICU support],[enable_icu=$enableval],[enable_icu=no])
++if test "$enable_icu" = "yes"; then
++    AC_CHECK_ICU([3.4],[
++       ICU_CPPFLAGS="$ICU_CPPFLAGS -D YAZ_HAVE_ICU=1"],[
++       AC_MSG_ERROR([For ICU support please install libicu34-dev or similar])
++    ])
++fi
+ dnl ------ versioning
+ dnl
+ WIN_FILEVERSION=`echo $PACKAGE_VERSION | $AWK 'BEGIN { FS = "."; } { m = $4; printf("%d,%d,%d,%d", $1, $2, $3 == "" ? "0" : $3, $4 == "" ? "1" : $4);}'`

--- a/dev-libs/yaz/yaz-5.26.1.ebuild
+++ b/dev-libs/yaz/yaz-5.26.1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+inherit eutils autotools
+
+DESCRIPTION="C toolkit for Z39.50v3 clients and servers"
+HOMEPAGE="http://www.indexdata.dk/yaz"
+SRC_URI="http://ftp.indexdata.dk/pub/${PN}/${P}.tar.gz"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm hppa ~ia64 ~mips ~ppc ppc64 ~s390 ~sh ~sparc x86"
+IUSE="debug icu libressl tcpd ziffy"
+
+RDEPEND="dev-libs/libxml2
+        dev-libs/libxslt
+        !libressl? ( dev-libs/openssl:0= )
+        libressl? ( dev-libs/libressl:0= )
+        icu? ( dev-libs/icu:= )
+        tcpd? ( sys-apps/tcp-wrappers )
+        ziffy? ( net-libs/libpcap )"
+DEPEND="${RDEPEND}
+        virtual/pkgconfig
+        dev-lang/tcl:0
+        >=sys-devel/libtool-2"
+
+src_prepare() {
+        epatch "${FILESDIR}"/${PN}-5.26.1-icu-automagic.patch
+        AT_M4DIR="m4" eautoreconf
+}
+
+src_configure() {
+        econf \
+                --enable-static \
+                --enable-shared \
+                $(use_enable debug memdebug) \
+                $(use_enable icu) \
+                $(use_enable tcpd tcpd /usr)
+}
+
+src_compile() {
+        emake || die "emake failed"
+}
+
+src_install() {
+        local docdir="/usr/share/doc/${PF}"
+        emake DESTDIR="${D}" docdir="${docdir}" install || die "install failed"
+
+        dodir ${docdir}/html
+        mv -f "${D}"/${docdir}/*.{html,png} "${D}"/${docdir}/html/ || die "Failed to move HTML docs"
+        mv -f "${D}"/usr/share/doc/${PN}/common "${D}"/${docdir}/html/ || die "Failed to move HTML docs"
+        rm -rf "${D}"/usr/share/doc/${PN}
+
+        dodoc ChangeLog NEWS 
+}


### PR DESCRIPTION
based on yaz-3.0.53.ebuild

I'll also try to contribute an ebuild for the  YAZ++-API as   dev-libs/yazpp  and the YAZProxy as  net-misc/yazproxy

Bug: https://bugs.gentoo.org/637404
Signed-off-by: Guido Jäkel G.Jaekel@DNB.DE


