### PR TITLE
dev-libs/yazpp-1.6.5.ebuild

### DIFF
--- a/dev-libs/yazpp/yazpp-1.6.5.ebuild
+++ b/dev-libs/yazpp/yazpp-1.6.5.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="C++ toolkit for Z39.50v3 clients and servers"
+HOMEPAGE="http://www.indexdata.dk/yaz"
+SRC_URI="http://ftp.indexdata.dk/pub/${PN}/${P}.tar.gz"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="amd64 x86"
+IUSE=""
+
+DEPEND="dev-libs/yaz"
+RDEPEND="${DEPEND}"


### PR DESCRIPTION
YAZ++ is an application programming interface (API) to YAZ which supports the development of Z39.50/SRU/Solr client and server applications using C++. Like YAZ, it supports Z39.50-2003 (version 3) as well as SRU version 1.1 thru 2.0 in both the client and server roles. YAZ++ includes an implementation of the ZOOM C++ binding and a generic client/server API based on the Observer/Observable design pattern. (taken from https://www.indexdata.com/resources/software/yazpp/)

YAZ++-APU depends on the YAZ Toolkit (dev-libs/yaz)

--
Bug: https://bugs.gentoo.org/664090
Signed-off-by: Guido Jäkel G.Jaekel@DNB.DE
