### PR TITLE
net-misc/yazproxy-1.3.10

### DIFF
--- a/net-misc/yazproxy/yazproxy-1.3.10.ebuild
+++ b/net-misc/yazproxy/yazproxy-1.3.10.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Z3950 proxy"
+HOMEPAGE="https://www.indexdata.com/resources/software/yazproxy"
+SRC_URI="http://ftp.indexdata.dk/pub/yazproxy/yazproxy-1.3.10.tar.gz"
+
+LICENSE=""
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+DEPEND="dev-libs/yazpp"
+RDEPEND="${DEPEND}"


### PR DESCRIPTION
The YAZ Proxy is highly configurable and can be used in a number of different applications, ranging from debugging Z39.50-based applications and protecting overworked servers, to improving the performance of stateless WWW/Z39.50 gateways. (taken from https://www.indexdata.com/resources/software/yazproxy/)

YAZProxy depends on the YAZ++-API (dev-libs/yazpp), which depend on the YAZ Toolik (dev-libs/yaz)

--
Bug: https://bugs.gentoo.org/664098
Signed-off-by: Guido Jäkel G.Jaekel@DNB.DE