### PR TITLE
dev-util/shellcheck: require quickcheck[template_haskell]

### DIFF
--- a/dev-util/shellcheck/shellcheck-0.5.0-r1.ebuild
+++ b/dev-util/shellcheck/shellcheck-0.5.0-r1.ebuild
@@ -23,7 +23,7 @@ IUSE=""
 RDEPEND="dev-haskell/aeson:=[profile?]
 	>=dev-haskell/mtl-2.2.1:=[profile?]
 	>=dev-haskell/parsec-3.0:=[profile?]
-	>=dev-haskell/quickcheck-2.7.4:2=[profile?]
+	>=dev-haskell/quickcheck-2.7.4:2=[template_haskell,profile?]
 	dev-haskell/regex-tdfa:=[profile?]
 	dev-haskell/semigroups:=[profile?]
 	>=dev-lang/ghc-7.8.2:=


### PR DESCRIPTION
Shellcheck fails to build when QuickCheck is built without the `template_haskell` USE flag:

```
src/ShellCheck/Parser.hs:51:1: error:
    Failed to load interface for `Test.QuickCheck.All'
    Perhaps you meant
      Test.QuickCheck.Gen (from QuickCheck-2.9.2)
      Test.QuickCheck.Poly (from QuickCheck-2.9.2)
      Test.QuickCheck (from QuickCheck-2.9.2)
    Use -v to see a list of the files searched for.
```

[The `Test.QuickCheck.All` module is only exposed if `flag(templateHaskell)` is set.](https://github.com/nick8325/quickcheck/blob/master/QuickCheck.cabal#L89-L92)