### PR TITLE
app-admin/apg: restore RDEPEND

### DIFF
--- a/app-admin/apg/apg-2.3.0b-r7.ebuild
+++ b/app-admin/apg/apg-2.3.0b-r7.ebuild
@@ -15,6 +15,7 @@ KEYWORDS="~alpha amd64 hppa ppc ~ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="cracklib"
 
 DEPEND="cracklib? ( sys-libs/cracklib )"
+RDEPEND="${DEPEND}"
 
 src_prepare() {
 	default


### PR DESCRIPTION
@mgorny 
I've made a small mistake in https://github.com/gentoo/gentoo/pull/9146 and wrongly removed RDEPEND in the ebuild. I've rechecked the package, cracklib is clearly needed at runtime too.

This PR should fix it.
Sorry for the mistake

PS: I also couldn't find a alternative for the HOMEPAGE and SRC_URI. For the Homepage we might could use something like: https://linux.die.net/man/1/apg but there seems to be no alternative for SRC_URI..