### PR TITLE
app-arch/hardlink: restore DEPEND

### DIFF
--- a/app-arch/hardlink/hardlink-0.3.0-r1.ebuild
+++ b/app-arch/hardlink/hardlink-0.3.0-r1.ebuild
@@ -13,6 +13,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
 
 RDEPEND="dev-libs/libpcre"
+DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 DOCS=( README ${T}/README.rsync )


### PR DESCRIPTION
@johu 
I've made a mistake in https://github.com/gentoo/gentoo/pull/9029 and wrongly removed DEPEND in the ebuild. I've rechecked the package, dev-libs/libpcre is clearly needed at runtime too.

This PR should fix it.
Sorry for the mistake