### PR TITLE
x11-plugins/wm*: restore RDEPEND and DEPEND

### DIFF
--- a/x11-plugins/wmail/wmail-2.0-r5.ebuild
+++ b/x11-plugins/wmail/wmail-2.0-r5.ebuild
@@ -14,6 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 
 RDEPEND=">=x11-libs/libdockapp-0.7:="
+DEPEND="${RDEPEND}"
 
 src_prepare() {
 	default

--- a/x11-plugins/wmcalendar/wmcalendar-0.5.2-r2.ebuild
+++ b/x11-plugins/wmcalendar/wmcalendar-0.5.2-r2.ebuild
@@ -17,8 +17,8 @@ RDEPEND="
 	x11-libs/gtk+:2
 	x11-libs/libX11
 	x11-libs/libXext
-	x11-libs/libXpm
-"
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 DOCS=( ../{BUGS,CHANGES,HINTS,README,TODO} )

--- a/x11-plugins/wmforkplop/wmforkplop-0.9.3-r3.ebuild
+++ b/x11-plugins/wmforkplop/wmforkplop-0.9.3-r3.ebuild
@@ -13,6 +13,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux ~x64-solaris"
 
 DEPEND="gnome-base/libgtop
 	media-libs/imlib2[X]"
+RDEPEND="${DEPEND}"
 
 # Easier to patch configure directly here
 PATCHES=( "${FILESDIR}"/${P}-cflags.patch )

--- a/x11-plugins/wmnetload/wmnetload-1.3-r6.ebuild
+++ b/x11-plugins/wmnetload/wmnetload-1.3-r6.ebuild
@@ -14,6 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 
 DEPEND=">=x11-libs/libdockapp-0.7:="
+RDEPEND="${DEPEND}"
 
 PATCHES=( "${FILESDIR}/${P}-r4-configure.patch" )
 

--- a/x11-plugins/wmpager/wmpager-1.2-r2.ebuild
+++ b/x11-plugins/wmpager/wmpager-1.2-r2.ebuild
@@ -14,6 +14,7 @@ KEYWORDS="~amd64 ~sparc ~x86"
 RDEPEND="x11-libs/libX11
 	x11-libs/libXpm
 	x11-libs/libXext"
+DEPEND="${RDEPEND}"
 
 src_prepare() {
 	default

--- a/x11-plugins/wmsystemtray/wmsystemtray-1.4-r2.ebuild
+++ b/x11-plugins/wmsystemtray/wmsystemtray-1.4-r2.ebuild
@@ -15,3 +15,4 @@ DEPEND="x11-libs/libXext
 	x11-libs/libXfixes
 	x11-libs/libXmu
 	x11-libs/libXpm"
+RDEPEND="${DEPEND}"


### PR DESCRIPTION
@voyageur 
I've made some mistakes in my PRs regarding your wm* packages and wrongly removed some (R)DEPEND variables in the ebuild.

This PR should fix it.
Sorry for the mistake