### PR TITLE
app-text/docbook-sgml: EAPI7 revbump, use HTTPS

### DIFF
--- a/app-text/docbook-sgml/docbook-sgml-1.0-r1.ebuild
+++ b/app-text/docbook-sgml/docbook-sgml-1.0-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="A helper package for sgml docbook"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+HOMEPAGE="https://www.docbook.org/sgml/"
+
+RDEPEND="app-text/sgml-common app-text/openjade
+	>=app-text/docbook-dsssl-stylesheets-1.64
+	>=app-text/docbook-sgml-utils-0.6.6
+	~app-text/docbook-sgml-dtd-3.0
+	~app-text/docbook-sgml-dtd-3.1
+	~app-text/docbook-sgml-dtd-4.0
+	~app-text/docbook-sgml-dtd-4.1"


### PR DESCRIPTION
Hi,

This PR/Bug updates app-text/docbook-sgml for EAPI7. The ebuild is pretty simple so i've only removed the empty IUSE variable and fixed the homepage to use https instead of http.

Please review.

Closes: https://bugs.gentoo.org/664160