### PR TITLE
dev-util/edb-debugger: add dev-qt/qtsvg:5 as a runtime dependency

### DIFF
--- a/dev-util/edb-debugger/edb-debugger-1.0.0-r1.ebuild
+++ b/dev-util/edb-debugger/edb-debugger-1.0.0-r1.ebuild
@@ -18,14 +18,15 @@ S="${WORKDIR}/${P}"
 
 RDEPEND="
 	dev-libs/capstone
-	graphviz? ( media-gfx/graphviz )
+	dev-qt/qtconcurrent:5
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtsvg:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
 	dev-qt/qtxmlpatterns:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtcore:5
+	graphviz? ( media-gfx/graphviz )
 "
 
 DEPEND="

--- a/dev-util/edb-debugger/edb-debugger-9999.ebuild
+++ b/dev-util/edb-debugger/edb-debugger-9999.ebuild
@@ -16,14 +16,15 @@ IUSE="graphviz"
 
 RDEPEND="
 	dev-libs/capstone
-	graphviz? ( media-gfx/graphviz )
+	dev-qt/qtconcurrent:5
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtsvg:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
 	dev-qt/qtxmlpatterns:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtgui:5
-	dev-qt/qtcore:5
+	graphviz? ( media-gfx/graphviz )
 "
 
 DEPEND="


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/664188

Package-Manager: Portage-2.3.47, Repoman-2.3.10