### PR TITLE
media-video/vcsi: enable python3.7 (and to its deps)

### DIFF
--- a/dev-python/cjkwrap/cjkwrap-2.2.ebuild
+++ b/dev-python/cjkwrap/cjkwrap-2.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_COMPAT=( python2_7 python3_{5..7} )
 inherit distutils-r1
 
 DESCRIPTION="A library for wrapping and filling UTF-8 CJK text"

--- a/dev-python/parsedatetime/parsedatetime-2.4-r1.ebuild
+++ b/dev-python/parsedatetime/parsedatetime-2.4-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=(python{2_7,3_4,3_5,3_6})
+PYTHON_COMPAT=( python{2_7,3_{4..7}} )
 
 inherit distutils-r1
 

--- a/dev-python/texttable/texttable-1.4.0.ebuild
+++ b/dev-python/texttable/texttable-1.4.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python{2_7,3_{5,6}} )
+PYTHON_COMPAT=( python{2_7,3_{5..7}} )
 
 inherit distutils-r1
 

--- a/media-video/vcsi/vcsi-7.ebuild
+++ b/media-video/vcsi/vcsi-7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{5,6} )
+PYTHON_COMPAT=( python3_{5..7} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
All ebuilds tested and built. No EAPI bumps, no ebuild enhancements - just python3.7 COMPAT bumps. 