### PR TITLE
app-admin/passwordsafe: force system gtest

### DIFF
--- a/app-admin/passwordsafe/files/passwordsafe-1.06_beta-system-gtest.patch
+++ b/app-admin/passwordsafe/files/passwordsafe-1.06_beta-system-gtest.patch
@@ -1,0 +1,69 @@
+--- a/CMakeLists.txt	2018-08-11 09:54:05.000000000 +0200
++++ b/CMakeLists.txt	2018-08-22 10:48:06.422755215 +0200
+@@ -91,6 +91,7 @@
+ # Configurable options:
+ option (NO_YUBI "Set ON to disable YubiKey support" OFF)
+ option (NO_GTEST "Set ON to disable gtest unit testing" OFF)
++option (SYSTEM_GTEST "Set ON to use gtest provided by the system" OFF)
+ 
+ if (WIN32)
+   option (WX_WINDOWS "Build wxWidget under Windows" OFF)
+@@ -256,31 +257,36 @@
+ endif (MSVC)
+ 
+ if (NOT NO_GTEST)
+-   # Download and unpack googletest at configure time
+-   # See https://crascit.com/2015/07/25/cmake-gtest/
+-   configure_file(Misc/CMakeLists.gtest.txt.in googletest-download/CMakeLists.txt)
+-   execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
++  if (NOT SYSTEM_GTEST)
++    # Download and unpack googletest at configure time
++    # See https://crascit.com/2015/07/25/cmake-gtest/
++    configure_file(Misc/CMakeLists.gtest.txt.in googletest-download/CMakeLists.txt)
++    execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
+-   execute_process(COMMAND "${CMAKE_COMMAND}" --build .
++     execute_process(COMMAND "${CMAKE_COMMAND}" --build .
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
++    # Prevent GoogleTest from overriding our compiler/linker options
++    # when building with Visual Studio
++    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
++    # Set some other gtest configurations:
++    set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
++    set(BUILD_GTEST ON CACHE BOOL "" FORCE)
++    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
++
++    # Add googletest directly to our build. This adds
++    # the following targets: gtest, gtest_main, gmock
++    # and gmock_main
++    add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src"
++                     "${CMAKE_BINARY_DIR}/googletest-build")
++
++    include_directories("${gtest_SOURCE_DIR}/include"
++#                        "${gmock_SOURCE_DIR}/include"
++                        )
++  else (NOT SYSTEM_GTEST)
++    find_package(GTest REQUIRED)
++    set(GTEST_LIBRARIES ${GTEST_BOTH_LIBRARIES})
++  endif(NOT SYSTEM_GTEST)
+ 
+-   # Prevent GoogleTest from overriding our compiler/linker options
+-   # when building with Visual Studio
+-   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+-   # Set some other gtest configurations:
+-   set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+-   set(BUILD_GTEST ON CACHE BOOL "" FORCE)
+-   set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+-
+-   # Add googletest directly to our build. This adds
+-   # the following targets: gtest, gtest_main, gmock
+-   # and gmock_main
+-   add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src"
+-                    "${CMAKE_BINARY_DIR}/googletest-build")
+-
+-   include_directories("${gtest_SOURCE_DIR}/include"
+-#                       "${gmock_SOURCE_DIR}/include"
+-                       )
+ endif(NOT NO_GTEST)
+ 
+ if (WIN32 AND NOT WX_WINDOWS)

--- a/app-admin/passwordsafe/passwordsafe-1.06_beta.ebuild
+++ b/app-admin/passwordsafe/passwordsafe-1.06_beta.ebuild
@@ -32,6 +32,10 @@ DEPEND="${RDEPEND}
 
 S=${WORKDIR}/pwsafe-${MY_PV}
 
+PATCHES=(
+	"${FILESDIR}/${PN}-1.06_beta-system-gtest.patch"
+)
+
 pkg_pretend() {
 	einfo "Checking for -std=c++11 support in compiler"
 	test-flags-CXX -std=c++11 > /dev/null || die
@@ -54,6 +58,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DNO_QR=$(usex !qr)
 		-DNO_GTEST=$(usex !test)
+		-DSYSTEM_GTEST=ON
 		-DXML_XERCESC=$(usex xml)
 		-DNO_YUBI=$(usex !yubikey)
 	)


### PR DESCRIPTION
this has been changed in the latest release to download gtest. I missed this change when bumping to the latest release. I will also post the patch upstream to fix it for future versions.

Closes: https://bugs.gentoo.org/664200
Package-Manager: Portage-2.3.38, Repoman-2.3.9