### PR TITLE
vgm fixes

### DIFF
--- a/sci-physics/vgm/vgm-4.4.ebuild
+++ b/sci-physics/vgm/vgm-4.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit cmake-utils versionator
+inherit cmake-utils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -27,6 +27,9 @@ RDEPEND="
 	geant4? ( >=sci-physics/geant-4.10.03 )"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen[dot] )"
+RESTRICT="
+	!geant4? ( test )
+	!root? ( test )"
 
 DOCS=(
 	doc/README

--- a/sci-physics/vgm/vgm-4.4.ebuild
+++ b/sci-physics/vgm/vgm-4.4.ebuild
@@ -21,9 +21,10 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="doc examples +geant4 +root test"
 
+# sci-physics/root[root7] flag activates std=c++14, only supported from VGM >4.4.
 RDEPEND="
 	sci-physics/clhep:=
-	root? ( sci-physics/root:= )
+	root? ( sci-physics/root:=[-root7] )
 	geant4? ( >=sci-physics/geant-4.10.03 )"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen[dot] )"

--- a/sci-physics/vgm/vgm-9999.ebuild
+++ b/sci-physics/vgm/vgm-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit cmake-utils versionator
+inherit cmake-utils
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -27,6 +27,9 @@ RDEPEND="
 	geant4? ( >=sci-physics/geant-4.10.03 )"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen[dot] )"
+RESTRICT="
+	!geant4? ( test )
+	!root? ( test )"
 
 DOCS=(
 	doc/README


### PR DESCRIPTION
- Remove unused versionator inheritance. 
- Restrict test-suite to USE flag combinations supported by upstream's test-suite. 
- Block `sci-physics/root[root7}` for release 4.4 of VGM since this activates `std=c++14` which will only be supported starting from next release. 