### PR TITLE
media-libs/imlib2: fix build issue with 'doc' USE in 1.5.1-r1

### DIFF
--- a/media-libs/imlib2/imlib2-1.5.1-r1.ebuild
+++ b/media-libs/imlib2/imlib2-1.5.1-r1.ebuild
@@ -64,12 +64,13 @@ multilib_src_configure() {
 
 multilib_src_install() {
 	V=1 emake install DESTDIR="${D}"
+	find "${D}" -name '*.la' -delete || die
+}
 
+multilib_src_install_all() {
 	if use doc; then
 		local HTML_DOCS=( "${S}"/doc/. )
 		rm "${S}"/doc/Makefile.{am,in} || die
 	fi
 	einstalldocs
-
-	find "${D}" -name '*.la' -delete || die
 }


### PR DESCRIPTION
With ABI_X86="32 (64) (-x32)" & multilib systems the build fails to `rm "${S}"/doc/Makefile.{am,in} || die` because it runs the phase twice (I guess?) Adding `rm -f` doesn't solve it. This was the cleanest solution I figured to install docs without extra makefiles. 