### PR TITLE
sci-physics/vgm: Add missing dependency for test.

### DIFF
--- a/sci-physics/vgm/vgm-4.4.ebuild
+++ b/sci-physics/vgm/vgm-4.4.ebuild
@@ -27,10 +27,12 @@ RDEPEND="
 	root? ( sci-physics/root:=[-root7] )
 	geant4? ( >=sci-physics/geant-4.10.03 )"
 DEPEND="${RDEPEND}
-	doc? ( app-doc/doxygen[dot] )"
+	doc? ( app-doc/doxygen[dot] )
+	test? ( sci-physics/geant-vmc[g4root] )"
 RESTRICT="
 	!geant4? ( test )
-	!root? ( test )"
+	!root? ( test )
+	!test? ( test )"
 
 DOCS=(
 	doc/README

--- a/sci-physics/vgm/vgm-9999.ebuild
+++ b/sci-physics/vgm/vgm-9999.ebuild
@@ -26,10 +26,12 @@ RDEPEND="
 	root? ( sci-physics/root:= )
 	geant4? ( >=sci-physics/geant-4.10.03 )"
 DEPEND="${RDEPEND}
-	doc? ( app-doc/doxygen[dot] )"
+	doc? ( app-doc/doxygen[dot] )
+	test? ( sci-physics/geant-vmc[g4root] )"
 RESTRICT="
 	!geant4? ( test )
-	!root? ( test )"
+	!root? ( test )
+	!test? ( test )"
 
 DOCS=(
 	doc/README


### PR DESCRIPTION
Package-Manager: Portage-2.3.48, Repoman-2.3.10

This adds the missing dependency on `sci-physics/geant-vmc[g4root]` for `test` as found by @amadio in #9668 . Thanks again! 