### PR TITLE
app-admin/passwordsafe: fix help file location

### DIFF
--- a/app-admin/passwordsafe/passwordsafe-1.06_beta-r1.ebuild
+++ b/app-admin/passwordsafe/passwordsafe-1.06_beta-r1.ebuild
@@ -77,11 +77,7 @@ src_install() {
 	insinto /usr/share/locale
 	doins -r src/ui/wxWidgets/I18N/mos/*
 
-	# The upstream Makefile builds this .zip file from html source material for
-	# use by the package's internal help system. Must prevent
-	# Portage from applying additional compression.
-	docompress -x /usr/share/doc/${PN}/help
-	insinto /usr/share/doc/${PN}/help
+	insinto /usr/share/${PN}/help
 	doins help/*.zip
 
 	popd || die
@@ -90,8 +86,8 @@ src_install() {
 
 	dodoc README.md README.LINUX.* docs/{ReleaseNotes.txt,ChangeLog.txt}
 
-	insinto /usr/share/pwsafe/xml
-	doins xml/*
+	insinto /usr/share/${PN}
+	doins -r xml
 
 	newicon install/graphics/pwsafe.png ${PN}.png
 	newmenu install/desktop/pwsafe.desktop ${PN}.desktop


### PR DESCRIPTION
they are expected at the "official" package name of pwsafe. Without this an error message is shown on startup that the help subsystem could not be initilised. It can be dismissed and disabled, but it is annoying. Moving the help files to the expected location fixes this.

Package-Manager: Portage-2.3.48, Repoman-2.3.10