### PR TITLE
bzip2: Fix an error reported by ubsan.

### DIFF
--- a/app-arch/bzip2/bzip2-1.0.6-r10.ebuild
+++ b/app-arch/bzip2/bzip2-1.0.6-r10.ebuild
@@ -27,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.0.6-mingw.patch #393573
 	"${FILESDIR}"/${PN}-1.0.6-out-of-tree-build.patch
 	"${FILESDIR}"/${PN}-1.0.6-CVE-2016-3189.patch #620466
+	"${FILESDIR}"/${PN}-1.0.6-ubsan-error.patch
 )
 
 DOCS=( CHANGES README{,.COMPILATION.PROBLEMS,.XML.STUFF} manual.pdf )

--- a/app-arch/bzip2/files/bzip2-1.0.6-ubsan-error.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.6-ubsan-error.patch
@@ -1,0 +1,24 @@
+Use unsigned 1 for shifting instead of signed 1.
+
+This fixed an issue with shift caught by undefined behavior
+sanitizer in clang.
+bzip2-1.0.6/blocksort.c:255:7
+runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
+
+diff --git a/bzip2/blocksort.c b/bzip2/blocksort.c
+index d0d662c..e72b83a 100644
+--- a/bzip2/blocksort.c
++++ b/bzip2/blocksort.c
+@@ -202,9 +202,9 @@ void fallbackQSort3 ( UInt32* fmap,
+       bhtab [ 0 .. 2+(nblock/32) ] destroyed
+ */
+ 
+-#define       SET_BH(zz)  bhtab[(zz) >> 5] |= (1 << ((zz) & 31))
+-#define     CLEAR_BH(zz)  bhtab[(zz) >> 5] &= ~(1 << ((zz) & 31))
+-#define     ISSET_BH(zz)  (bhtab[(zz) >> 5] & (1 << ((zz) & 31)))
++#define       SET_BH(zz)  bhtab[(zz) >> 5] |= (1u << ((zz) & 31))
++#define     CLEAR_BH(zz)  bhtab[(zz) >> 5] &= ~(1u << ((zz) & 31))
++#define     ISSET_BH(zz)  (bhtab[(zz) >> 5] & (1u << ((zz) & 31)))
+ #define      WORD_BH(zz)  bhtab[(zz) >> 5]
+ #define UNALIGNED_BH(zz)  ((zz) & 0x01f)
+ 


### PR DESCRIPTION
Use unsigned 1 for shifting instead of signed 1.

Fix an issue with shift caught by undefined behavior
sanitizer in clang.
bzip2-1.0.6/blocksort.c:255:7
runtime error: left shift of 1 by 31 places cannot be represented
in type 'int'.