### PR TITLE
dev-util/btyacc: EAPI7 revbump, improve ebuild

### DIFF
--- a/dev-util/btyacc/btyacc-3.0-r3.ebuild
+++ b/dev-util/btyacc/btyacc-3.0-r3.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+MY_P="${PN}-3-0"
+DESCRIPTION="Backtracking YACC - modified from Berkeley YACC"
+HOMEPAGE="http://www.siber.com/btyacc"
+SRC_URI="http://www.siber.com/btyacc/${MY_P}.tar.gz"
+
+LICENSE="freedist"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-fbsd ~x86-linux ~ppc-macos ~x86-macos"
+
+S="${WORKDIR}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-includes.patch"
+	"${FILESDIR}/${P}-makefile.patch"
+)
+
+src_prepare() {
+	cp -av Makefile{,.orig} || die
+	default
+	# fix memory issue/glibc corruption
+	sed -i -e "s|len + 13|len + 14|" main.c || die "Could not fix main.c"
+	# Darwin doesn't do static binaries
+	if [[ ${CHOST} == *-darwin* ]]; then
+		sed -i -e 's/-static//' Makefile || die
+	fi
+}
+
+src_compile() {
+	emake CC=$(tc-getCC)
+}
+
+src_install() {
+	dobin btyacc
+	dodoc README README.BYACC
+	newman manpage btyacc.1
+}

--- a/dev-util/btyacc/files/btyacc-3.0-includes.patch
+++ b/dev-util/btyacc/files/btyacc-3.0-includes.patch
@@ -1,5 +1,5 @@
---- mstring.c
-+++ mstring.c
+--- a/mstring.c
++++ b/mstring.c
 @@ -1,6 +1,7 @@
  #include <stdlib.h>
  #include <stdio.h>

--- a/dev-util/btyacc/files/btyacc-3.0-makefile.patch
+++ b/dev-util/btyacc/files/btyacc-3.0-makefile.patch
@@ -1,7 +1,7 @@
 Respect CC, append to CFLAGS (but not -g), append to LDFLAGS, use system LD -jer
 
---- Makefile.orig	1999-07-15 19:40:12.000000000 +0200
-+++ Makefile	2009-09-04 15:27:15.000000000 +0200
+--- a/Makefile	1999-07-15 19:40:12.000000000 +0200
++++ b/Makefile	2009-09-04 15:27:15.000000000 +0200
 @@ -8,14 +8,13 @@
  
  HDRS	      = defs.h mstring.h


### PR DESCRIPTION
Hi,

This PR/Bug updates dev-util/btyacc for EAPI7.
Please review

```diff
--- btyacc-3.0-r2.ebuild        2017-03-19 10:57:12.737786293 +0100
+++ btyacc-3.0-r3.ebuild        2018-08-25 10:24:40.824881711 +0200
@@ -1,12 +1,11 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 MY_P=${P/./-}
-IUSE=""
 DESCRIPTION="Backtracking YACC - modified from Berkeley YACC"
 HOMEPAGE="http://www.siber.com/btyacc"
 SRC_URI="http://www.siber.com/btyacc/${MY_P}.tar.gz"
@@ -17,23 +16,30 @@
 
 S="${WORKDIR}"
 
+PATCHES=(
+       "${FILESDIR}/${P}-includes.patch"
+       "${FILESDIR}/${P}-makefile.patch"
+)
+DOCS=( README README.BYACC )
+
 src_prepare() {
-       cp -av Makefile{,.orig}
-       epatch "${FILESDIR}/${P}-includes.patch"
-       epatch "${FILESDIR}/${P}-makefile.patch"
+       cp -av Makefile{,.orig} || die
+       default
        # fix memory issue/glibc corruption
        sed -i -e "s|len + 13|len + 14|" main.c || die "Could not fix main.c"
        # Darwin doesn't do static binaries
-       [[ ${CHOST} == *-darwin* ]] && sed -i -e 's/-static//' Makefile
+       if [[ ${CHOST} == *-darwin* ]]; then
+               sed -i -e 's/-static//' Makefile || die
+       fi
 }
 
 src_compile() {
        tc-export CC
-       emake || die
+       emake CC=$(tc-getCC)
 }
 
 src_install() {
        dobin btyacc
-       dodoc README README.BYACC
+       einstalldocs
        newman manpage btyacc.1
 }
```

Closes: https://bugs.gentoo.org/664546