### PR TITLE
media-gfx/graphviz: clarify description of gts USE flag

### DIFF
--- a/media-gfx/graphviz/metadata.xml
+++ b/media-gfx/graphviz/metadata.xml
@@ -34,7 +34,7 @@
 		<flag name="devil">Enables DevIL output plugin -Tdevil</flag>
 		<flag name="gdk-pixbuf">Enables gdk-pixbuf2 plugin</flag>
 		<flag name="gtk">Enables gtk+ output plugin -Tgtk (needs cairo)</flag>
-		<flag name="gts">Enables support for gts</flag>
+		<flag name="gts">Enables support for GNU Triangulated Surface Library (required for sfdp to work)</flag>
 		<flag name="lasi">Enables PostScript output via <pkg>media-libs/lasi</pkg>, for plugin -Tlasi (needs cairo)</flag>
 		<flag name="X">Builds lefty front-end, builds plugin -Txlib, and enables support for x11 in various other modules (needs cairo)</flag>
 	</use>


### PR DESCRIPTION
GTS stands for GNU Triangulated Surface Library, and is required for sfdp to work.

Building graphiz without this flag and trying to run sfdp leads to the following error:

    Error: remove_overlap: Graphviz not built with triangulation library

I had to waste 10 minutes of my time figuring out what the missing USE flag was, and hopefully, with this PR accepted, nobody will have to do the same :)