### PR TITLE
media-plugins/calf: work around buggy configure check

### DIFF
--- a/media-plugins/calf/calf-0.90.0-r1.ebuild
+++ b/media-plugins/calf/calf-0.90.0-r1.ebuild
@@ -46,6 +46,7 @@ src_configure() {
 	#$(use_with jack)
 	econf \
 		--prefix="${EPREFIX}"/usr \
+		--without-obsolete-check \
 		$(use_with lash) \
 		$(use_with lv2 lv2) \
 		$(usex lv2 "--with-lv2-dir=${EPREFIX}/usr/$(get_libdir)/lv2" "") \

--- a/media-plugins/calf/calf-0.90.0.ebuild
+++ b/media-plugins/calf/calf-0.90.0.ebuild
@@ -45,6 +45,7 @@ src_configure() {
 	#$(use_with gtk gui)
 	#$(use_with jack)
 	econf \
+		--without-obsolete-check \
 		$(use_with lash) \
 		$(use_with lv2 lv2) \
 		$(usex lv2 "--with-lv2-dir=/usr/$(get_libdir)/lv2" "") \

--- a/media-plugins/calf/calf-9999.ebuild
+++ b/media-plugins/calf/calf-9999.ebuild
@@ -46,6 +46,7 @@ src_configure() {
 	#$(use_with jack)
 	econf \
 		--prefix="${EPREFIX}"/usr \
+		--without-obsolete-check \
 		$(use_with lash) \
 		$(use_with lv2 lv2) \
 		$(usex lv2 "--with-lv2-dir=${EPREFIX}/usr/$(get_libdir)/lv2" "") \


### PR DESCRIPTION
The upstream project's configure.ac hard-codes a check to see if calf is
already installed to /usr/lib or /usr/local/lib, and if so, refuses to
configure (causing econf to fail) if `calf` is already installed on the
system.

Simply adding --without-obsolete-check to the configure invocation
disables this (pointless) check.