### PR TITLE
dev-db/redis: re-add -lm for luajit

### DIFF
--- a/dev-db/redis/files/redis-5.0-sharedlua.patch
+++ b/dev-db/redis/files/redis-5.0-sharedlua.patch
@@ -12,7 +12,7 @@ index c26c0d7..fa50c41 100644
  #ifndef CJSON_MODNAME
  #define CJSON_MODNAME   "cjson"
 diff --git a/src/Makefile b/src/Makefile
-index 6f12a20..205cd59 100644
+index f5525bd..cecd8d0 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -16,7 +16,7 @@ release_hdr := $(shell sh -c './mkreleasehdr.sh')
@@ -24,16 +24,15 @@ index 6f12a20..205cd59 100644
  NODEPS:=clean distclean
  
  # Default settings
-@@ -58,7 +58,7 @@ endif
- 
+@@ -66,6 +66,7 @@ endif
  FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
  FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
--FINAL_LIBS=-lm
-+FINAL_LIBS=@LUA_LIBS@
+ FINAL_LIBS=-lm
++FINAL_LIBS+=@LUA_LIBS@
  DEBUG=-g -ggdb
  
  ifeq ($(uname_S),SunOS)
-@@ -100,7 +100,7 @@ endif
+@@ -107,7 +108,7 @@ endif
  endif
  endif
  # Include paths to dependencies
@@ -42,7 +41,7 @@ index 6f12a20..205cd59 100644
  
  ifeq ($(MALLOC),tcmalloc)
  	FINAL_CFLAGS+= -DUSE_TCMALLOC
-@@ -137,6 +137,7 @@ endif
+@@ -145,6 +146,7 @@ endif
  REDIS_SERVER_NAME=redis-server
  REDIS_SENTINEL_NAME=redis-sentinel
  REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o
@@ -50,7 +49,7 @@ index 6f12a20..205cd59 100644
  REDIS_CLI_NAME=redis-cli
  REDIS_CLI_OBJ=anet.o adlist.o dict.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o siphash.o crc16.o
  REDIS_BENCHMARK_NAME=redis-benchmark
-@@ -188,7 +189,7 @@ endif
+@@ -196,7 +198,7 @@ endif
  
  # redis-server
  $(REDIS_SERVER_NAME): $(REDIS_SERVER_OBJ)


### PR DESCRIPTION
Linking the math library (-lm) was accidentally removed by me.

Closes: https://bugs.gentoo.org/664648
Package-Manager: Portage-2.3.45, Repoman-2.3.10