### PR TITLE
dev-tcltk/tkcon: fix "-under" error and up/down keys

### DIFF
--- a/dev-tcltk/tkcon/files/tkcon-2.5-fix-under.patch
+++ b/dev-tcltk/tkcon/files/tkcon-2.5-fix-under.patch
@@ -1,0 +1,64 @@
+--- a/tkcon.tcl	2018-04-13 16:54:13.072236584 +0300
++++ b/tkcon.tcl	2018-04-13 17:03:22.019457401 +0300
+@@ -1013,9 +1013,9 @@
+ 		    set tag [UniqueTag $w]
+ 		    $w insert output $res [list stderr $tag] \n$trailer stderr
+ 		    $w tag bind $tag <Enter> \
+-			    [list $w tag configure $tag -under 1]
++			    [list $w tag configure $tag -underline 1]
+ 		    $w tag bind $tag <Leave> \
+-			    [list $w tag configure $tag -under 0]
++			    [list $w tag configure $tag -underline 0]
+ 		    $w tag bind $tag <ButtonRelease-1> \
+ 			    "if {!\[info exists tkPriv(mouseMoved)\] || !\$tkPriv(mouseMoved)} \
+ 			    {[list $OPT(edit) -attach [Attach] -type error -- $PRIV(errorInfo)]}"
+@@ -2978,8 +2978,8 @@
+ 	    set tag [UniqueTag $w]
+ 	    $w tag add $tag $start+${c0}c $start+1c+${c1}c
+ 	    $w tag configure $tag -foreground $COLOR(stdout)
+-	    $w tag bind $tag <Enter> [list $w tag configure $tag -under 1]
+-	    $w tag bind $tag <Leave> [list $w tag configure $tag -under 0]
++	    $w tag bind $tag <Enter> [list $w tag configure $tag -underline 1]
++	    $w tag bind $tag <Leave> [list $w tag configure $tag -underline 0]
+ 	    $w tag bind $tag <ButtonRelease-1> "if {!\$tkPriv(mouseMoved)} \
+ 		    {[list $OPT(edit) -attach $app -type proc -find $what -- $cmd]}"
+ 	}
+@@ -3007,8 +3007,8 @@
+ 	    set tag [UniqueTag $w]
+ 	    $w tag add $tag $ix+1c $start
+ 	    $w tag configure $tag -foreground $COLOR(proc)
+-	    $w tag bind $tag <Enter> [list $w tag configure $tag -under 1]
+-	    $w tag bind $tag <Leave> [list $w tag configure $tag -under 0]
++	    $w tag bind $tag <Enter> [list $w tag configure $tag -underline 1]
++	    $w tag bind $tag <Leave> [list $w tag configure $tag -underline 0]
+ 	    $w tag bind $tag <ButtonRelease-1> "if {!\$tkPriv(mouseMoved)} \
+ 		    {[list $OPT(edit) -attach $app -type proc -- $cmd]}"
+ 	}
+@@ -3835,14 +3835,14 @@
+     ##
+     set text $w.text
+     set m [menu [::tkcon::MenuButton $menu Edit edit]]
+-    $m add command -label "Cut"   -under 2 \
++    $m add command -label "Cut"   -underline 2 \
+ 	-command [list tk_textCut $text]
+-    $m add command -label "Copy"  -under 0 \
++    $m add command -label "Copy"  -underline 0 \
+ 	-command [list tk_textCopy $text]
+-    $m add command -label "Paste" -under 0 \
++    $m add command -label "Paste" -underline 0 \
+ 	-command [list tk_textPaste $text]
+     $m add separator
+-    $m add command -label "Find" -under 0 \
++    $m add command -label "Find" -underline 0 \
+ 	-command [list ::tkcon::FindBox $text]
+ 
+     ## Send To Menu
+@@ -5060,6 +5060,8 @@
+ 	## Make sure the specific key won't be defined
+ 	bind TkConsole $key {}
+     }
++    bind TkConsole <<NextLine>> {}
++    bind TkConsole <<PrevLine>> {}
+ 
+     ## Make the ROOT bindings
+     bind $PRIV(root) <<TkCon_Exit>>	exit

--- a/dev-tcltk/tkcon/tkcon-2.5-r1.ebuild
+++ b/dev-tcltk/tkcon/tkcon-2.5-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2012 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+inherit eutils multilib
+
+DESCRIPTION="Tk GUI console"
+HOMEPAGE="http://tkcon.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc ~x86"
+SLOT="0"
+IUSE="doc"
+
+DEPEND="dev-lang/tk"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	epatch "${FILESDIR}/${P}-fix-under.patch"
+}
+
+src_install() {
+	local tclver="$(echo 'puts $tcl_version' | tclsh)"
+	local instdir=/usr/$(get_libdir)/tcl${tclver}/${PN}2.5
+	dodir ${instdir}
+	cp -pP pkgIndex.tcl tkcon.tcl "${D}"${instdir} || die
+	dodir /usr/bin
+	dosym ${instdir}/tkcon.tcl /usr/bin/tkcon
+	dodoc README.txt
+	if use doc; then
+		dohtml doc/*
+	fi
+}


### PR DESCRIPTION
upstream is dead and tkcon spews lots of "-under" errors on events:

unknown option "-under"
unknown option "-under"
    while executing
".tkcon.tab1 tag configure _tag10 -under 1"
    (command bound to event)

the problems were discussed at https://wiki.tcl.tk/1878