### PR TITLE
mail-client/thunderbird: add dependency on clang

### DIFF
--- a/mail-client/thunderbird/thunderbird-60.0-r3.ebuild
+++ b/mail-client/thunderbird/thunderbird-60.0-r3.ebuild
@@ -60,7 +60,8 @@ DEPEND="rust? ( dev-lang/rust )
 	amd64? ( ${ASM_DEPEND}
 		virtual/opengl )
 	x86? ( ${ASM_DEPEND}
-		virtual/opengl )"
+		virtual/opengl )
+	sys-devel/clang"
 
 RDEPEND="${CDEPEND}
 	selinux? ( sec-policy/selinux-thunderbird )


### PR DESCRIPTION
I'm not quite sure if this is the correct way to go at this. The build log I attached in https://bugs.gentoo.org/664580 seems to suggest that stylo is optional, so that it can *maybe* be hidden behind a use flag, but it is default-enabled by upstream. Should a USE flag be added for this?