### PR TITLE
app-text/calibre: remove unRAR license

### DIFF
--- a/app-text/calibre/calibre-3.15.0.ebuild
+++ b/app-text/calibre/calibre-3.15.0.ebuild
@@ -30,7 +30,6 @@ LICENSE="
 	CC-BY-3.0
 	OFL-1.1
 	PSF-2
-	unRAR
 "
 KEYWORDS="amd64 ~arm x86"
 SLOT="0"

--- a/app-text/calibre/calibre-3.26.1.ebuild
+++ b/app-text/calibre/calibre-3.26.1.ebuild
@@ -30,7 +30,6 @@ LICENSE="
 	CC-BY-3.0
 	OFL-1.1
 	PSF-2
-	unRAR
 "
 KEYWORDS="~amd64 ~arm ~x86"
 SLOT="0"


### PR DESCRIPTION
Calibre developers removed unrar code with the following commit:
https://github.com/kovidgoyal/calibre/commit/d305656bb4923c3737b3f143416c0e3ab682b9a5