### PR TITLE
dev-libs/nss: Don't use weak entropy fallback

### DIFF
--- a/dev-libs/nss/nss-3.38.ebuild
+++ b/dev-libs/nss/nss-3.38.ebuild
@@ -180,6 +180,7 @@ multilib_src_compile() {
 	export NSDISTMODE=copy
 	export NSS_ENABLE_ECC=1
 	export FREEBL_NO_DEPEND=1
+	export NSS_SEED_ONLY_DEV_URANDOM=1
 	export ASFLAGS=""
 
 	local d


### PR DESCRIPTION
NSS 3.37 introduces NSS_SEED_ONLY_DEV_URANDOM, which enables getentropy() or /dev/urandom, without the fallback path for other platforms, such as sysinfo. If /dev/urandom and getentropy() fail, it is treated as a hard failure.