### PR TITLE
app-text/zathura: fix 9999

### DIFF
--- a/app-text/zathura-cb/zathura-cb-9999.ebuild
+++ b/app-text/zathura-cb/zathura-cb-9999.ebuild
@@ -3,15 +3,15 @@
 
 EAPI=6
 
-inherit eutils toolchain-funcs readme.gentoo-r1 xdg
+inherit meson xdg
 
 if [[ ${PV} == *9999 ]]; then
-	inherit git-r3
-	EGIT_REPO_URI="https://git.pwmt.org/pwmt/zathura-cb.git"
+	EGIT_REPO_URI="https://git.pwmt.org/pwmt/${PN}.git"
 	EGIT_BRANCH="develop"
+	inherit git-r3
 else
-	KEYWORDS="~amd64 ~arm ~x86"
-	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/${PN}/download/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
 fi
 
 DESCRIPTION="Comic book plug-in for zathura with 7zip, rar, tar and zip support"
@@ -21,38 +21,18 @@ LICENSE="ZLIB"
 SLOT="0"
 IUSE=""
 
-RDEPEND=">=app-text/zathura-0.3.8
-	dev-libs/glib:2=
-	app-arch/libarchive:=
-	x11-libs/cairo:=
-	x11-libs/gdk-pixbuf:="
+RDEPEND="
+	>=app-text/zathura-0.2.0
+	app-arch/libarchive
+	dev-libs/girara
+	x11-libs/cairo
+"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
-src_configure() {
-	myzathuraconf=(
-		CC="$(tc-getCC)"
-		LD="$(tc-getLD)"
-		VERBOSE=1
-		DESTDIR="${D}"
-	)
-}
-
-src_compile() {
-	emake "${myzathuraconf[@]}"
-}
-
-src_install() {
-	emake "${myzathuraconf[@]}" install
-	dodoc AUTHORS
-
-	FORCE_PRINT_ELOG=1
-	local DOC_CONTENTS="Consider installing app-arch/p7zip app-arch/tar app-arch/unrar
-		app-arch/unzip for additional file support."
-	readme.gentoo_create_doc
-}
-
 pkg_postinst() {
 	xdg_pkg_postinst
-	readme.gentoo_print_elog
+
+	einfo "Consider installing app-arch/p7zip app-arch/tar app-arch/unrar
+		app-arch/unzip for additional file support."
 }

--- a/app-text/zathura-djvu/zathura-djvu-9999.ebuild
+++ b/app-text/zathura-djvu/zathura-djvu-9999.ebuild
@@ -3,15 +3,15 @@
 
 EAPI=6
 
-inherit eutils toolchain-funcs xdg
+inherit meson xdg
 
 if [[ ${PV} == *9999 ]]; then
-	inherit git-r3
-	EGIT_REPO_URI="https://git.pwmt.org/pwmt/zathura-djvu.git"
+	EGIT_REPO_URI="https://git.pwmt.org/pwmt/${PN}.git"
 	EGIT_BRANCH="develop"
+	inherit git-r3
 else
-	KEYWORDS="~amd64 ~arm ~x86"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/${PN}/download/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
 fi
 
 DESCRIPTION="DjVu plug-in for zathura"
@@ -21,27 +21,11 @@ LICENSE="ZLIB"
 SLOT="0"
 IUSE=""
 
-RDEPEND=">=app-text/djvu-3.5.24-r1:=
+RDEPEND="
+	app-text/djvu
 	>=app-text/zathura-0.3.8
-	dev-libs/glib:2=
-	x11-libs/cairo:="
+	dev-libs/glib:2
+	x11-libs/cairo
+"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
-src_configure() {
-	myzathuraconf=(
-		CC="$(tc-getCC)"
-		LD="$(tc-getLD)"
-		VERBOSE=1
-		DESTDIR="${D}"
-	)
-}
-
-src_compile() {
-	emake "${myzathuraconf[@]}"
-}
-
-src_install() {
-	emake "${myzathuraconf[@]}" install
-	dodoc AUTHORS
-}

--- a/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-9999.ebuild
+++ b/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-9999.ebuild
@@ -3,15 +3,15 @@
 
 EAPI=6
 
-inherit eutils toolchain-funcs xdg
+inherit meson xdg
 
 if [[ ${PV} == *9999 ]]; then
-	inherit git-r3
-	EGIT_REPO_URI="https://git.pwmt.org/pwmt/zathura-pdf-mupdf.git"
+	EGIT_REPO_URI="https://git.pwmt.org/pwmt/${PN}.git"
 	EGIT_BRANCH="develop"
+	inherit git-r3
 else
-	KEYWORDS="~amd64 ~arm ~x86"
-	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/${PN}/download/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
 fi
 
 DESCRIPTION="PDF plug-in for zathura"
@@ -21,33 +21,18 @@ LICENSE="ZLIB"
 SLOT="0"
 IUSE=""
 
-RDEPEND="!app-text/zathura-pdf-poppler
-	>=app-text/mupdf-1.12.0:=
-	>=app-text/zathura-0.3.8
-	media-libs/jbig2dec:=
-	media-libs/openjpeg:2=
-	virtual/jpeg:0
-	x11-libs/cairo:="
+RDEPEND="
+	>=app-text/zathura-2.0
+	dev-libs/girara
+	>=app-text/mupdf-1.14.0
+	!app-text/zathura-pdf-poppler
+"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
-src_configure() {
-	myzathuraconf=(
-		CC="$(tc-getCC)"
-		LD="$(tc-getLD)"
-		VERBOSE=1
-		DESTDIR="${D}"
-		MUPDF_LIB="$($(tc-getPKG_CONFIG) --libs mupdf)"
-		OPENSSL_INC="$($(tc-getPKG_CONFIG) --cflags mupdf)"
-		OPENSSL_LIB=''
-	)
-}
+src_prepare() {
+	default
 
-src_compile() {
-	emake "${myzathuraconf[@]}"
-}
-
-src_install() {
-	emake "${myzathuraconf[@]}" install
-	dodoc AUTHORS
+	sed -i '/mupdfthird/d' meson.build ||
+		die 'fail to remove uninstallable mupdfthird'
 }

--- a/app-text/zathura-pdf-poppler/zathura-pdf-poppler-9999.ebuild
+++ b/app-text/zathura-pdf-poppler/zathura-pdf-poppler-9999.ebuild
@@ -3,15 +3,15 @@
 
 EAPI=6
 
-inherit eutils toolchain-funcs xdg
+inherit meson xdg
 
 if [[ ${PV} == *9999 ]]; then
-	inherit git-r3
-	EGIT_REPO_URI="https://git.pwmt.org/pwmt/zathura-pdf-poppler.git"
+	EGIT_REPO_URI="https://git.pwmt.org/pwmt/${PN}.git"
 	EGIT_BRANCH="develop"
+	inherit git-r3
 else
-	KEYWORDS="~amd64 ~arm ~x86"
-	SRC_URI="http://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
+	SRC_URI="https://pwmt.org/projects/${PN}/download/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
 fi
 
 DESCRIPTION="PDF plug-in for zathura"
@@ -21,25 +21,11 @@ LICENSE="ZLIB"
 SLOT="0"
 IUSE=""
 
-RDEPEND="app-text/poppler[cairo]
-	>=app-text/zathura-0.3.8
-	x11-libs/cairo:="
+RDEPEND="
+	>=app-text/zathura-0.2.0
+	dev-libs/girara
+	>=app-text/poppler-0.18[cairo]
+	!app-text/zathura-pdf-mupdf
+"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
-src_configure() {
-	myzathuraconf=(
-		CC="$(tc-getCC)"
-		LD="$(tc-getLD)"
-		VERBOSE=1
-	)
-}
-
-src_compile() {
-	emake "${myzathuraconf[@]}"
-}
-
-src_install() {
-	emake "${myzathuraconf[@]}" DESTDIR="${ED%/}" install
-	dodoc AUTHORS
-}

--- a/app-text/zathura-ps/zathura-ps-9999.ebuild
+++ b/app-text/zathura-ps/zathura-ps-9999.ebuild
@@ -3,15 +3,15 @@
 
 EAPI=6
 
-inherit eutils toolchain-funcs xdg
+inherit meson xdg
 
 if [[ ${PV} == *9999 ]]; then
-	inherit git-r3
-	EGIT_REPO_URI="https://git.pwmt.org/pwmt/zathura-ps.git"
+	EGIT_REPO_URI="https://git.pwmt.org/pwmt/${PN}.git"
 	EGIT_BRANCH="develop"
+	inherit git-r3
 else
+	SRC_URI="https://pwmt.org/projects/${PN}/download/${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
-	SRC_URI="https://pwmt.org/projects/zathura/plugins/download/${P}.tar.gz"
 fi
 
 DESCRIPTION="PostScript plug-in for zathura"
@@ -21,28 +21,12 @@ LICENSE="ZLIB"
 SLOT="0"
 IUSE=""
 
-RDEPEND=">=app-text/libspectre-0.2.6:=
+RDEPEND="
 	>=app-text/zathura-0.3.8
-	dev-libs/glib:2=
-	x11-libs/cairo:="
+	dev-libs/girara
+	dev-libs/glib:2
+	x11-libs/cairo
+	app-text/libspectre
+"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
-src_configure() {
-	myzathuraconf=(
-		CC="$(tc-getCC)"
-		LD="$(tc-getLD)"
-		VERBOSE=1
-		DESTDIR="${D}"
-		PREFIX="${EPREFIX}/usr"
-	)
-}
-
-src_compile() {
-	emake "${myzathuraconf[@]}"
-}
-
-src_install() {
-	emake "${myzathuraconf[@]}" install
-	dodoc AUTHORS
-}

--- a/dev-libs/girara/metadata.xml
+++ b/dev-libs/girara/metadata.xml
@@ -18,4 +18,7 @@
     <doc lang="en">http://pwmt.org/projects/girara/</doc>
     <bugs-to>http://bugs.pwmt.org/</bugs-to>
   </upstream>
+  <use>
+    <flag name="json">Configuration dumping support via <pkg>dev-libs/json-c</pkg></flag>
+  </use>
 </pkgmetadata>


### PR DESCRIPTION
All related zathura 9999 ebuild are broken by the recent meson update. This PR fixes it with some more useflags.

Reopening of gentoo#8207, closed during the takeover of the organisation.