### PR TITLE
dev-lang/scala: fix compile's encoding

### DIFF
--- a/dev-lang/scala/scala-2.12.4.ebuild
+++ b/dev-lang/scala/scala-2.12.4.ebuild
@@ -145,7 +145,7 @@ src_prepare() {
 			#!/bin/bash
 			gjl_package=sbt
 			gjl_jar="sbt-launch.jar"
-			gjl_java_args="-Dsbt.version=0.13.13 -Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -Duser.home="${WORKDIR}""
+			gjl_java_args="-Dsbt.version=0.13.13 -Dfile.encoding=UTF8 -Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -Duser.home="${WORKDIR}""
 			source /usr/share/java-config-2/launcher/launcher.bash
 		EOF
 		chmod u+x "${S}/sbt" || die
@@ -161,7 +161,6 @@ src_prepare() {
 src_compile() {
 	if ! use binary; then
 		export PATH="${EROOT}usr/share/scala-${SV}/bin:${WORKDIR}/${L_P}:${PATH}"
-		export LANG="en_US.UTF-8"
 		einfo "=== scala compile ..."
 		"${S}"/sbt -Dsbt.log.noformat=true compile || die "sbt compile failed"
 		einfo "=== sbt publishLocal with jdk $(java-pkg_get-vm-version) ..."


### PR DESCRIPTION
The current fix for encoding is not working, this patch fixes it.

It seems that if `LC_CTYPE` is not set in the environment, the JVM sets the encoding to "ISO8859-1", as definied in `icedtea-3.6-jdk-a05e38417041.tar.xz:jdk-a05e38417041/src/solaris/native/java/lang/java_props_md.c:GetJavaProperties`.