### PR TITLE
net-wireless/wpa_supplicant: make dependency on CRDA optional

### DIFF
--- a/net-wireless/wpa_supplicant/metadata.xml
+++ b/net-wireless/wpa_supplicant/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="ap">Add support for access point mode</flag>
+		<flag name="crda">Add CRDA support</flag>
 		<flag name="eap-sim">Add support for EAP-SIM authentication algorithm</flag>
 		<flag name="eapol_test">Build and install eapol_test binary</flag>
 		<flag name="fasteap">Add support for FAST-EAP authentication algorithm</flag>

--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.6-r8.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.6-r8.ebuild
@@ -12,13 +12,13 @@ LICENSE="|| ( GPL-2 BSD )"
 
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
-IUSE="ap bindist dbus eap-sim eapol_test fasteap gnutls +hs2-0 libressl p2p privsep ps3 qt5 readline selinux smartcard ssl suiteb tdls uncommon-eap-types wimax wps kernel_linux kernel_FreeBSD"
+IUSE="ap bindist +crda dbus eap-sim eapol_test fasteap gnutls +hs2-0 libressl p2p privsep ps3 qt5 readline selinux smartcard ssl suiteb tdls uncommon-eap-types wimax wps kernel_linux kernel_FreeBSD"
 REQUIRED_USE="smartcard? ( ssl )"
 
 CDEPEND="dbus? ( sys-apps/dbus )
 	kernel_linux? (
 		dev-libs/libnl:3
-		net-wireless/crda
+		crda? ( net-wireless/crda )
 		eap-sim? ( sys-apps/pcsc-lite )
 	)
 	!kernel_linux? ( net-libs/libpcap )


### PR DESCRIPTION
The crda tool can be used to send information about a wireless
regulatory domain to the kernel to apply regulations depending on the
country the user is currently in. As it is possible to compile the
database directly into the kernel by providing "regulatory.db" from
net-wireless/wireless-regdb via CONFIG_EXTRA_FIRMWARE, a userspace crda
executable is not always required.

Add a "+crda" useflag that toggles the dependency on net-wireless/crda.
As crda currently requires Python 2 due to the dependency on m2crypto,
deactivating the flag can result in quite some savings.