### PR TITLE
E17 profile cleaning

### DIFF
--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -155,10 +155,6 @@ media-video/ffmpeg nvenc openh264
 # Missing test deps keyword #575366
 dev-cpp/eigen test
 
-# Mike Frysinger <vapier@gentoo.org> (21 Feb 2016)
-# Needs arch love for elementary. #575322
-media-libs/elementary javascript
-
 # Tobias Klausmann <klausman@gentoo.org> 04 Feb 2016
 # sys-cluster/ceph is not broken per se, but a maintenance burden.
 net-analyzer/rrdtool rados

--- a/profiles/arch/alpha/package.use.stable.mask
+++ b/profiles/arch/alpha/package.use.stable.mask
@@ -39,7 +39,3 @@ gnome-base/gvfs google
 media-plugins/gst-plugins-meta modplug
 >=x11-libs/gtk+-3.12.2 cloudprint
 x11-libs/gksu gnome
-
-# sufficiently recent wayland is not stable yet, bug #559062
-~dev-libs/efl-1.17.0 wayland
-~media-libs/elementary-1.17.0 wayland

--- a/profiles/arch/amd64-fbsd/package.use.mask
+++ b/profiles/arch/amd64-fbsd/package.use.mask
@@ -74,7 +74,6 @@ media-libs/gstreamer unwind
 
 # Michał Górny <mgorny@gentoo.org> (17 Feb 2018)
 # Unkeyworded deps.
-media-libs/elementary javascript
 media-libs/phonon vlc
 virtual/notification-daemon kde
 

--- a/profiles/arch/amd64/x32/package.use.mask
+++ b/profiles/arch/amd64/x32/package.use.mask
@@ -9,7 +9,6 @@ dev-ruby/jsobfu test
 dev-ruby/rails asset-pipeline
 dev-ruby/sprockets test
 dev-ruby/tilt test
-media-libs/elementary javascript
 net-analyzer/netdata nodejs
 dev-lang/nim test
 www-apps/jekyll test

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -91,10 +91,6 @@ kde-frameworks/extra-cmake-modules doc
 # pulls in many dev-ruby/asciidoctor dependencies (bug #583390)
 net-misc/chrony html
 
-# Mike Frysinger <vapier@gentoo.org> (21 Feb 2016)
-# Needs arch love for elementary. #575322
-media-libs/elementary javascript
-
 # Jeroen Roovers <jer@gentoo.org> (16 Aug 2015)
 # Bundles luajit which has not been ported to HPPA (bug #554376)
 app-text/texlive-core luajittex

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -144,10 +144,6 @@ media-sound/rhythmbox upnp-av
 # Missing test deps keyword #575366
 dev-cpp/eigen test
 
-# Mike Frysinger <vapier@gentoo.org> (21 Feb 2016)
-# Needs arch love for elementary. #575322
-media-libs/elementary javascript
-
 # Pacho Ramos <pacho@gentoo.org> (31 Jan 2016)
 # Missing keywords, bug #560382
 media-video/ffmpeg snappy

--- a/profiles/arch/ia64/package.use.stable.mask
+++ b/profiles/arch/ia64/package.use.stable.mask
@@ -38,7 +38,3 @@ dev-util/geany-plugins gtkspell
 gnome-base/gvfs google
 >=x11-libs/gtk+-3.12.2 cloudprint
 x11-libs/gksu gnome
-
-# sufficiently recent wayland is not stable yet, bug #559062
-~dev-libs/efl-1.17.0 wayland
-~media-libs/elementary-1.17.0 wayland

--- a/profiles/arch/mips/package.use.mask
+++ b/profiles/arch/mips/package.use.mask
@@ -71,10 +71,6 @@ net-dns/dnsmasq conntrack
 # net-libs/openpgm is not keyworded on mips
 net-libs/zeromq pgm
 
-# Mike Frysinger <vapier@gentoo.org> 21 Feb 2016
-# Needs arch love for elementary. #575322
-media-libs/elementary javascript
-
 # Mike Frysinger <vapier@gentoo.org> (17 Dec 2015)
 # The tlsdate seccomp logic is open-coded and doesn't support this arch yet.
 net-misc/tlsdate seccomp

--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -141,10 +141,6 @@ net-irc/quassel snorenotify
 # Missing test deps keyword #575366
 dev-cpp/eigen test
 
-# Mike Frysinger <vapier@gentoo.org> (21 Feb 2016)
-# Needs arch love for elementary. #575322
-media-libs/elementary javascript
-
 # Pacho Ramos <pacho@gentoo.org> (15 Nov 2015)
 # Missing keywords
 media-sound/rhythmbox upnp-av

--- a/profiles/arch/sh/package.use.mask
+++ b/profiles/arch/sh/package.use.mask
@@ -18,10 +18,6 @@ media-sound/pulseaudio native-headset ofono-headset
 x11-base/xorg-server glamor wayland
 x11-drivers/xf86-video-ati glamor
 
-# Mike Frysinger <vapier@gentoo.org> 21 Feb 2016
-# Needs arch love for elementary. #575322
-media-libs/elementary javascript
-
 # Sergey Popov <pinkbyte@gentoo.org> (24 Oct 2015)
 # Not tested
 net-mail/dovecot lz4

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -122,10 +122,6 @@ gnome-extra/nm-applet teamd
 # Missing test deps keyword #575366
 dev-cpp/eigen test
 
-# Mike Frysinger <vapier@gentoo.org> (21 Feb 2016)
-# Needs arch love for elementary. #575322
-media-libs/elementary javascript
-
 # Pacho Ramos <pacho@gentoo.org> (20 Feb 2016)
 # Missing keywords, bug #551580
 app-office/planner eds

--- a/profiles/arch/sparc/package.use.stable.mask
+++ b/profiles/arch/sparc/package.use.stable.mask
@@ -31,7 +31,6 @@ sci-mathematics/octave gnuplot
 # Mart Raudsepp <leio@gentoo.org> (02 Sep 2017)
 # Drop stable gstreamer on sparc, can move to use.stable.mask
 # after gstreamer:0.10 is gone; #601354
-media-plugins/evas_generic_loaders gstreamer
 dev-libs/efl gstreamer
 media-sound/mp3splt-gtk gstreamer
 net-im/pidgin gstreamer
@@ -60,7 +59,3 @@ gnome-base/gvfs google
 >=x11-libs/gtk+-3.12.2 cloudprint
 x11-libs/gksu gnome
 x11-wm/icewm gnome
-
-# sufficiently recent wayland is not stable yet, bug #559062
-~dev-libs/efl-1.17.0 wayland
-~media-libs/elementary-1.17.0 wayland


### PR DESCRIPTION
That should be all of e17-related packages cleaned from profile files. This PR is related to #9737 and that should be resolved first.

I split all commits so it's easier to rebase if needed.