### PR TITLE
dev-python/pyotp: Introducing support for Python 3.7

### DIFF
--- a/dev-python/pyotp/pyotp-2.2.6-r1.ebuild
+++ b/dev-python/pyotp/pyotp-2.2.6-r1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
+
+inherit distutils-r1
+
+DESCRIPTION="PyOTP is a Python library for generating and verifying one-time passwords."
+HOMEPAGE="https://github.com/pyotp/pyotp https://pypi.org/project/pyotp/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+
+python_test() {
+	"${EPYTHON}" -m unittest discover -v || die "Testing failed with ${EPYTHON}"
+}


### PR DESCRIPTION
Introducing support for Python 3.7.

I confirm the package builds and passes tests on python 3.7

Closes: https://bugs.gentoo.org/663160
Package-Manager: Portage-2.3.48, Repoman-2.3.10