### PR TITLE
dev-python/mkdocs*: EAPI7, use HTTPs

### DIFF
--- a/dev-python/mkdocs-bootstrap/mkdocs-bootstrap-0.1.1-r1.ebuild
+++ b/dev-python/mkdocs-bootstrap/mkdocs-bootstrap-0.1.1-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+
+inherit distutils-r1
+
+DESCRIPTION="Bootstrap theme for MkDocs"
+HOMEPAGE="https://www.mkdocs.org"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-python/mkdocs-bootstrap/mkdocs-bootstrap-0.1.1.ebuild
+++ b/dev-python/mkdocs-bootstrap/mkdocs-bootstrap-0.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 inherit distutils-r1
 
 DESCRIPTION="Bootstrap theme for MkDocs"
-HOMEPAGE="http://www.mkdocs.org"
+HOMEPAGE="https://www.mkdocs.org"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/mkdocs-bootswatch/mkdocs-bootswatch-0.4.0-r1.ebuild
+++ b/dev-python/mkdocs-bootswatch/mkdocs-bootswatch-0.4.0-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+
+inherit distutils-r1
+
+DESCRIPTION="Bootswatch themes for MkDocs"
+HOMEPAGE="https://www.mkdocs.org"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-python/mkdocs-bootswatch/mkdocs-bootswatch-0.4.0.ebuild
+++ b/dev-python/mkdocs-bootswatch/mkdocs-bootswatch-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 inherit distutils-r1
 
 DESCRIPTION="Bootswatch themes for MkDocs"
-HOMEPAGE="http://www.mkdocs.org"
+HOMEPAGE="https://www.mkdocs.org"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/mkdocs/mkdocs-0.15.3.ebuild
+++ b/dev-python/mkdocs/mkdocs-0.15.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 inherit distutils-r1 vcs-snapshot
 
 DESCRIPTION="Project documentation with Markdown."
-HOMEPAGE="http://www.mkdocs.org"
+HOMEPAGE="https://www.mkdocs.org"
 SRC_URI="https://github.com/tomchristie/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/mkdocs/mkdocs-0.17.4.ebuild
+++ b/dev-python/mkdocs/mkdocs-0.17.4.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 inherit distutils-r1 vcs-snapshot
 
 DESCRIPTION="Project documentation with Markdown."
-HOMEPAGE="http://www.mkdocs.org"
+HOMEPAGE="https://www.mkdocs.org"
 SRC_URI="https://github.com/tomchristie/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-python/mkdocs/mkdocs-1.0.1.ebuild
+++ b/dev-python/mkdocs/mkdocs-1.0.1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 inherit distutils-r1 vcs-snapshot
 
 DESCRIPTION="Project documentation with Markdown."
-HOMEPAGE="http://www.mkdocs.org"
+HOMEPAGE="https://www.mkdocs.org"
 SRC_URI="https://github.com/tomchristie/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Hi,

This PR updates the dev-python/mkdocs* packages to use https over http. I've also added two EAPI7 updated packages with only minor changes (removed empty Variables).

Please review.