### PR TITLE
dev-vcs/cvs2cl: use HTTPS, EAPI7 revbump

### DIFF
--- a/dev-vcs/cvs2cl/cvs2cl-2.71-r1.ebuild
+++ b/dev-vcs/cvs2cl/cvs2cl-2.71-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="produces a GNU-style ChangeLog for CVS-controlled sources"
+HOMEPAGE="https://www.red-bean.com/cvs2cl/"
+SRC_URI="mirror://gentoo/${P}.pl.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+
+DEPEND="dev-lang/perl"
+
+S=${WORKDIR}
+
+src_install() {
+	newbin ${P}.pl ${PN}
+}

--- a/dev-vcs/cvs2cl/cvs2cl-2.71.ebuild
+++ b/dev-vcs/cvs2cl/cvs2cl-2.71.ebuild
@@ -4,7 +4,7 @@
 EAPI=0
 
 DESCRIPTION="produces a GNU-style ChangeLog for CVS-controlled sources"
-HOMEPAGE="http://www.red-bean.com/cvs2cl/"
+HOMEPAGE="https://www.red-bean.com/cvs2cl/"
 SRC_URI="mirror://gentoo/${P}.pl.bz2"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This PR/Bug updates dev-vcs/cvs2cl for EAPI7 and also fixes the HOMEPAGE to use https instead of http.

Please review.