### PR TITLE
dev-vcs/cvsutils: EAPI7 revbump, use HTTPs

### DIFF
--- a/dev-vcs/cvsutils/cvsutils-0.2.5-r1.ebuild
+++ b/dev-vcs/cvsutils/cvsutils-0.2.5-r1.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="A small bundle of utilities to work with CVS repositories"
+HOMEPAGE="https://www.red-bean.com/cvsutils/"
+SRC_URI="https://www.red-bean.com/cvsutils/releases/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
+
+RDEPEND="dev-lang/perl"

--- a/dev-vcs/cvsutils/cvsutils-0.2.5.ebuild
+++ b/dev-vcs/cvsutils/cvsutils-0.2.5.ebuild
@@ -4,8 +4,8 @@
 EAPI=0
 
 DESCRIPTION="A small bundle of utilities to work with CVS repositories"
-HOMEPAGE="http://www.red-bean.com/cvsutils/"
-SRC_URI="http://www.red-bean.com/cvsutils/releases/${P}.tar.gz"
+HOMEPAGE="https://www.red-bean.com/cvsutils/"
+SRC_URI="https://www.red-bean.com/cvsutils/releases/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR/Bug updates dev-vcs/cvsutils for EAPI7 and uses https instead of http.

Please review