### PR TITLE
mail-filter/sieve-connect: EAPI7 revbump, use HTTPs

### DIFF
--- a/mail-filter/sieve-connect/sieve-connect-0.87-r1.ebuild
+++ b/mail-filter/sieve-connect/sieve-connect-0.87-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Sieve Command Line Interface"
+HOMEPAGE="https://people.spodhuis.org/phil.pennock/software/"
+SRC_URI="https://github.com/syscomet/sieve-connect/releases/download/v${PV}/${P}.tar.bz2"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=">=dev-lang/perl-5"
+RDEPEND="${DEPEND}
+	>=dev-perl/Authen-SASL-2.11
+	dev-perl/IO-Socket-INET6
+	>=dev-perl/IO-Socket-SSL-0.97
+	dev-perl/Net-DNS
+	dev-perl/Net-SSLeay
+	dev-perl/TermReadKey
+	dev-perl/Term-ReadLine-Gnu"
+
+src_compile() {
+	emake all sieve-connect.1
+}
+
+src_install() {
+	dobin sieve-connect
+	doman sieve-connect.1
+	dodoc README*
+}

--- a/mail-filter/sieve-connect/sieve-connect-0.87.ebuild
+++ b/mail-filter/sieve-connect/sieve-connect-0.87.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 DESCRIPTION="Sieve Command Line Interface"
-HOMEPAGE="http://people.spodhuis.org/phil.pennock/software/"
+HOMEPAGE="https://people.spodhuis.org/phil.pennock/software/"
 SRC_URI="https://github.com/syscomet/sieve-connect/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="BSD"


### PR DESCRIPTION
Hi,

Another simple PR/bug to update this package to EAPI7 and uses https

Please review.