### PR TITLE
media-video/griffith: fixes cannot import name InstrumentationManager

### DIFF
--- a/media-video/griffith/files/griffith-0.13-validators.patch
+++ b/media-video/griffith/files/griffith-0.13-validators.patch
@@ -1,0 +1,17 @@
+--- a/griffith-0.13/lib/db/validators.py	2018-09-02 00:37:03.052248916 +0300
++++ b/griffith-0.13/lib/db/validators.py	2018-09-02 00:37:22.462248580 +0300
+@@ -23,7 +23,13 @@
+ 
+ import logging
+ 
+-from sqlalchemy.orm.interfaces import AttributeExtension, InstrumentationManager
++from sqlalchemy.orm.interfaces import AttributeExtension
++try:
++    # sql alchemy 0.8 (and above)
++    from sqlalchemy.ext.instrumentation import InstrumentationManager
++except:
++    # sql alchemy 0.7
++    from sqlalchemy.orm.interfaces import InstrumentationManager
+ from sqlalchemy.orm import ColumnProperty
+ from sqlalchemy.types import String
+ 

--- a/media-video/griffith/griffith-0.13-r2.ebuild
+++ b/media-video/griffith/griffith-0.13-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -46,6 +46,7 @@ src_prepare() {
 		"${S}"/lib/gconsole.py || die "sed failed"
 
 	epatch "${FILESDIR}/0.10-fix_lib_path.patch"
+	epatch "${FILESDIR}/griffith-0.13-validators.patch"
 }
 
 src_compile() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/665068
Package-Manager: Portage-2.3.48, Repoman-2.3.10
