### PR TITLE
sci-geosciences/josm: josm now uses a svg icon

### DIFF
--- a/sci-geosciences/josm/josm-99999.ebuild
+++ b/sci-geosciences/josm/josm-99999.ebuild
@@ -45,6 +45,6 @@ src_install() {
 	java-pkg_newjar "dist/${PN}-custom-optimized.jar" "${PN}.jar" || die "java-pkg_newjar failed"
 	java-pkg_dolauncher "${PN}" --jar "${PN}.jar" || die "java-pkg_dolauncher failed"
 
-	newicon images/logo.png josm.png || die "newicon failed"
+	newicon images/logo.svg josm.svg || die "newicon failed"
 	make_desktop_entry "${PN}" "Java OpenStreetMap Editor" josm "Utility;Science;Geoscience"
 }


### PR DESCRIPTION
PR from the INODE64 Sistemas patch on gentoo bug #648838

closes: https://bugs.gentoo.org/648838
Package-Manager: Portage-2.3.48, Repoman-2.3.10