### PR TITLE
games-server/steamcmd: don't set default values for conf.d

### DIFF
--- a/games-server/steamcmd/files/steamcmd.confd-r1
+++ b/games-server/steamcmd/files/steamcmd.confd-r1
@@ -1,0 +1,15 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# Specifies, which server binary is used.
+# This could be 'hlds_run' or 'srcds_run', depending on your game.
+# STEAMCMD_BINARY="hlds_run"
+
+# Path to the files of your started server.
+# It's recommended to use:
+# '/opt/steamcmd/hlds' for older HL1 based mods.
+# '/opt/steamcmd/srcds' for newer HL2 based mods.
+# STEAMCMD_PATH="/opt/steamcmd/hlds"
+
+# Options for your server binary.
+# STEAMCMD_OPTS="-game valve +ip 127.0.0.1 +maxplayers 32 +map crossfire -pingboost 3"

--- a/games-server/steamcmd/files/steamcmd.initd-r1
+++ b/games-server/steamcmd/files/steamcmd.initd-r1
@@ -1,0 +1,32 @@
+#!/sbin/openrc-run
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+if [ "${SVCNAME}" = "steamcmd" ]; then
+	instance="main"
+else
+	instance="${SVCNAME#steamcmd.}"
+fi
+
+name="SteamCMD (Mod: ${instance})"
+pidfile="/run/steamcmd.${instance}.pid"
+screen_name="steamcmd.${instance}"
+start_stop_daemon_args="--chdir ${STEAMCMD_PATH}"
+
+command="screen"
+command_args="-DmUS ${screen_name} ${STEAMCMD_PATH}/${STEAMCMD_BINARY} ${STEAMCMD_OPTS}"
+command_background="true"
+command_group="steamcmd"
+command_user="steamcmd"
+
+depend() {
+	use net
+}
+
+start_pre() {
+	if [ -z "${STEAMCMD_BINARY}" ] || [ -z "${STEAMCMD_PATH}" ]; then
+		eerror "One or more STEAMCMD_* variables in /etc/conf.d/steamcmd.${SVCNAME} are not set!"
+		return 1
+	fi
+	return 0
+}

--- a/games-server/steamcmd/steamcmd-1.0-r1.ebuild
+++ b/games-server/steamcmd/steamcmd-1.0-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit readme.gentoo-r1 user
+
+DESCRIPTION="This is the command-line version of the Steam client for dedicated servers"
+HOMEPAGE="https://developer.valvesoftware.com/wiki/SteamCMD"
+SRC_URI="https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1+ Steam"
+SLOT="0"
+KEYWORDS="-* ~amd64 ~x86"
+
+RDEPEND="app-misc/screen"
+
+RESTRICT="bindist mirror"
+
+S="${WORKDIR}"
+
+QA_PREBUILT="opt/steamcmd/linux32/libstdc++.so.6
+	opt/steamcmd/linux32/steamcmd"
+
+pkg_setup() {
+	enewgroup steamcmd
+	enewuser steamcmd -1 -1 /opt/steamcmd steamcmd
+}
+
+src_install() {
+	diropts -o steamcmd -g steamcmd
+	dodir /opt/steamcmd
+	keepdir /opt/steamcmd/{.steam,.steam/sdk32,linux32}
+
+	exeopts -o steamcmd -g steamcmd
+	exeinto /opt/steamcmd
+	doexe steamcmd.sh
+
+	exeopts -o steamcmd -g steamcmd
+	exeinto /opt/steamcmd/linux32
+	doexe linux32/steamcmd linux32/libstdc++.so.6
+
+	newinitd "${FILESDIR}"/steamcmd.initd-r1 steamcmd
+	newconfd "${FILESDIR}"/steamcmd.confd-r1 steamcmd
+
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/665158
Package-Manager: Portage-2.3.48, Repoman-2.3.10