### PR TITLE
net-misc/ptpd: Fix conflicting types for EVP_MD_CTX

### DIFF
--- a/net-misc/ptpd/files/ptpd-2.3.1-fix-libressl-compatibility.patch
+++ b/net-misc/ptpd/files/ptpd-2.3.1-fix-libressl-compatibility.patch
@@ -1,0 +1,24 @@
+diff -urN old/src/dep/ntpengine/ntp_isc_md5.c new/src/dep/ntpengine/ntp_isc_md5.c
+--- old/src/dep/ntpengine/ntp_isc_md5.c	2015-06-29 17:13:29.000000000 +0200
++++ new/src/dep/ntpengine/ntp_isc_md5.c	2018-09-15 22:56:18.469044902 +0200
+@@ -262,7 +262,7 @@
+ {
+ 	u_char	digest[64];
+ 	u_int	len;
+-	EVP_MD_CTX ctx;
++	PTPD_EVP_MD_CTX ctx;
+         pkt[length / 4] = htonl(keyid); 
+ 	EVP_DigestInit(&ctx);
+ 	EVP_DigestUpdate(&ctx, (u_char *)key, (u_int)strlen(key));
+diff -urN old/src/dep/ntpengine/ntp_isc_md5.h new/src/dep/ntpengine/ntp_isc_md5.h
+--- old/src/dep/ntpengine/ntp_isc_md5.h	2015-06-29 17:13:29.000000000 +0200
++++ new/src/dep/ntpengine/ntp_isc_md5.h	2018-09-15 22:56:11.852020732 +0200
+@@ -80,7 +80,7 @@
+ # define MD5Init(c)             isc_md5_init(c)
+ # define MD5Update(c, p, s)     isc_md5_update(c, p, s)
+ # define MD5Final(d, c)         isc_md5_final((c), (d)) /* swapped */
+-  typedef MD5_CTX                       EVP_MD_CTX;
++  typedef MD5_CTX                       PTPD_EVP_MD_CTX;
+ # define EVP_DigestInit(c)              MD5Init(c)
+ # define EVP_DigestUpdate(c, p, s)      MD5Update(c, p, s)
+ # define EVP_DigestFinal(c, d, pdl)     \

--- a/net-misc/ptpd/files/ptpd-2.3.1-fix-snmp.patch
+++ b/net-misc/ptpd/files/ptpd-2.3.1-fix-snmp.patch
@@ -1,0 +1,12 @@
+diff -urN old/src/dep/snmp.c new/src/dep/snmp.c
+--- old/src/dep/snmp.c	2015-06-29 17:13:29.000000000 +0200
++++ new/src/dep/snmp.c	2018-09-15 22:54:11.818589001 +0200
+@@ -221,7 +221,7 @@
+ 
+ #define SNMP_LOCAL_VARIABLES			\
+ 	static unsigned long long_ret;		\
+-	static U64 counter64_ret;		\
++	static struct counter64 counter64_ret;		\
+ 	static uint32_t ipaddr;			\
+ 	Integer64 bigint;			\
+ 	struct snmpHeaderIndex idx;		\

--- a/net-misc/ptpd/ptpd-2.3.1-r2.ebuild
+++ b/net-misc/ptpd/ptpd-2.3.1-r2.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools flag-o-matic systemd
+
+DESCRIPTION="Precision Time Protocol daemon"
+HOMEPAGE="https://github.com/ptpd/ptpd"
+SRC_URI="https://github.com/ptpd/ptpd/archive/${P}.tar.gz"
+
+KEYWORDS="~amd64 ~arm ~x86"
+LICENSE="BSD"
+SLOT="0"
+IUSE="debug experimental ntp +pcap snmp slave-only +statistics"
+
+RDEPEND="
+	pcap? ( net-libs/libpcap )
+	snmp? ( net-analyzer/net-snmp )"
+DEPEND="${RDEPEND}"
+RDEPEND="${RDEPEND}
+	ntp? ( net-misc/ntp )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.3.1-fix-snmp.patch
+	"${FILESDIR}"/${PN}-2.3.1-fix-libressl-compatibility.patch
+)
+
+S=${WORKDIR}/ptpd-${P}
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	append-flags -fno-strict-aliasing
+	local myconf=(
+		--enable-daemon
+		$(use_enable snmp)
+		$(use_enable experimental experimental-options)
+		$(use_enable statistics)
+		$(use_enable debug runtime-debug)
+		$(use_enable pcap)
+		$(use_enable slave-only)
+	)
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	emake install DESTDIR="${D}"
+
+	insinto /etc
+	newins "src/ptpd2.conf.minimal" ptpd2.conf
+
+	newinitd "${FILESDIR}/ptpd2.rc" ptpd2
+	newconfd "${FILESDIR}/ptpd2.confd" ptpd2
+
+	systemd_dounit "${FILESDIR}/ptpd2.service"
+}
+
+pkg_postinst() {
+	elog "Do not forget to setup correct network interface."
+	elog "Change the config file ${EROOT}etc/ptpd2.conf to suit your needs."
+}


### PR DESCRIPTION
Fix compatibility with OpenSSL/LibreSSL by renaming conflicting identifier

Bug: https://bugs.gentoo.org/664500
Closes: https://bugs.gentoo.org/664500
Package-Manager: Portage-2.3.40, Repoman-2.3.9