### PR TITLE
dev-util/boost-build: add patch to unbreak compiler options on sparc

### DIFF
--- a/dev-util/boost-build/boost-build-1.62.0-r1.ebuild
+++ b/dev-util/boost-build/boost-build-1.62.0-r1.ebuild
@@ -38,6 +38,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.52.0-darwin-no-python-framework.patch"
 	"${FILESDIR}/${PN}-1.54.0-support_dots_in_python-buildid.patch"
 	"${FILESDIR}/${PN}-1.55.0-ppc-aix.patch"
+	"${FILESDIR}/${PN}-1.62.0-sparc-no-default-flags.patch"
 )
 
 pkg_setup() {

--- a/dev-util/boost-build/boost-build-1.63.0.ebuild
+++ b/dev-util/boost-build/boost-build-1.63.0.ebuild
@@ -38,6 +38,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.52.0-darwin-no-python-framework.patch"
 	"${FILESDIR}/${PN}-1.54.0-support_dots_in_python-buildid.patch"
 	"${FILESDIR}/${PN}-1.55.0-ppc-aix.patch"
+	"${FILESDIR}/${PN}-1.62.0-sparc-no-default-flags.patch"
 )
 
 pkg_setup() {

--- a/dev-util/boost-build/boost-build-1.65.0.ebuild
+++ b/dev-util/boost-build/boost-build-1.65.0.ebuild
@@ -38,6 +38,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.52.0-darwin-no-python-framework.patch"
 	"${FILESDIR}/${PN}-1.54.0-support_dots_in_python-buildid.patch"
 	"${FILESDIR}/${PN}-1.55.0-ppc-aix.patch"
+	"${FILESDIR}/${PN}-1.62.0-sparc-no-default-flags.patch"
 )
 
 pkg_setup() {

--- a/dev-util/boost-build/boost-build-1.66.0.ebuild
+++ b/dev-util/boost-build/boost-build-1.66.0.ebuild
@@ -38,6 +38,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.52.0-darwin-no-python-framework.patch"
 	"${FILESDIR}/${PN}-1.54.0-support_dots_in_python-buildid.patch"
 	"${FILESDIR}/${PN}-1.55.0-ppc-aix.patch"
+	"${FILESDIR}/${PN}-1.62.0-sparc-no-default-flags.patch"
 	"${FILESDIR}/${PN}-1.66.0-add-none-feature-options.patch"
 )
 

--- a/dev-util/boost-build/boost-build-1.67.0.ebuild
+++ b/dev-util/boost-build/boost-build-1.67.0.ebuild
@@ -38,6 +38,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.52.0-darwin-no-python-framework.patch"
 	"${FILESDIR}/${PN}-1.54.0-support_dots_in_python-buildid.patch"
 	"${FILESDIR}/${PN}-1.55.0-ppc-aix.patch"
+	"${FILESDIR}/${PN}-1.62.0-sparc-no-default-flags.patch"
 	"${FILESDIR}/${PN}-1.66.0-add-none-feature-options.patch"
 )
 

--- a/dev-util/boost-build/files/boost-build-1.62.0-sparc-no-default-flags.patch
+++ b/dev-util/boost-build/files/boost-build-1.62.0-sparc-no-default-flags.patch
@@ -1,0 +1,47 @@
+--- a/tools/gcc.py	2018-09-07 17:44:59.668796217 +0200
++++ b/tools/gcc.py	2018-09-07 17:45:56.378794314 +0200
+@@ -811,20 +811,6 @@
+ # Sparc
+ flags('gcc', 'OPTIONS', ['<architecture>sparc/<address-model>32'], ['-m32'])
+ flags('gcc', 'OPTIONS', ['<architecture>sparc/<address-model>64'], ['-m64'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'v7', ['-mcpu=v7'], default=True)
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'cypress', ['-mcpu=cypress'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'v8', ['-mcpu=v8'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'supersparc', ['-mcpu=supersparc'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'sparclite', ['-mcpu=sparclite'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'hypersparc', ['-mcpu=hypersparc'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'sparclite86x', ['-mcpu=sparclite86x'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'f930', ['-mcpu=f930'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'f934', ['-mcpu=f934'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'sparclet', ['-mcpu=sparclet'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'tsc701', ['-mcpu=tsc701'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'v9', ['-mcpu=v9'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'ultrasparc', ['-mcpu=ultrasparc'])
+-cpu_flags('gcc', 'OPTIONS', 'sparc', 'ultrasparc3', ['-mcpu=ultrasparc3'])
+ # RS/6000 & PowerPC
+ flags('gcc', 'OPTIONS', ['<architecture>power/<address-model>32'], ['-m32'])
+ flags('gcc', 'OPTIONS', ['<architecture>power/<address-model>64'], ['-m64'])
+--- a/tools/gcc.jam	2018-09-07 17:45:12.168795797 +0200
++++ b/tools/gcc.jam	2018-09-07 17:46:25.498793337 +0200
+@@ -1134,21 +1134,6 @@
+ cpu-flags gcc OPTIONS : x86 : c3-2 : -march=c3-2 ;
+ ##
+ cpu-flags gcc OPTIONS : x86 : atom : -march=atom ;
+-# Sparc
+-cpu-flags gcc OPTIONS : sparc : v7 : -mcpu=v7 : default ;
+-cpu-flags gcc OPTIONS : sparc : cypress : -mcpu=cypress ;
+-cpu-flags gcc OPTIONS : sparc : v8 : -mcpu=v8 ;
+-cpu-flags gcc OPTIONS : sparc : supersparc : -mcpu=supersparc ;
+-cpu-flags gcc OPTIONS : sparc : sparclite : -mcpu=sparclite ;
+-cpu-flags gcc OPTIONS : sparc : hypersparc : -mcpu=hypersparc ;
+-cpu-flags gcc OPTIONS : sparc : sparclite86x : -mcpu=sparclite86x ;
+-cpu-flags gcc OPTIONS : sparc : f930 : -mcpu=f930 ;
+-cpu-flags gcc OPTIONS : sparc : f934 : -mcpu=f934 ;
+-cpu-flags gcc OPTIONS : sparc : sparclet : -mcpu=sparclet ;
+-cpu-flags gcc OPTIONS : sparc : tsc701 : -mcpu=tsc701 ;
+-cpu-flags gcc OPTIONS : sparc : v9 : -mcpu=v9 ;
+-cpu-flags gcc OPTIONS : sparc : ultrasparc : -mcpu=ultrasparc ;
+-cpu-flags gcc OPTIONS : sparc : ultrasparc3 : -mcpu=ultrasparc3 ;
+ # RS/6000 & PowerPC
+ cpu-flags gcc OPTIONS : power : 403 : -mcpu=403 ;
+ cpu-flags gcc OPTIONS : power : 505 : -mcpu=505 ;


### PR DESCRIPTION
Boost tries to autodetect the processor architecture and overrides any flags set with CXXFLAGS with the -mcpu value it thinks it is appropiate. Sadly the most recent architecture it knows of is ultrasparc3. For every newer cpu type it falls back to it's default, which is v7 (which would be the compiler default anyway). This avoids any advanced cpu instructions, e.g. those that support atomic operations on thing larger than a byte. Remove the whole outdated cruft and just use whatever the user passed in.

Closes: https://bugs.gentoo.org/646234
Package-Manager: Portage-2.3.40, Repoman-2.3.9