### PR TITLE
dev-libs/efl: disable 'examples' USE for 1.21.0

### DIFF
--- a/dev-libs/efl/efl-1.21.0.ebuild
+++ b/dev-libs/efl/efl-1.21.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://download.enlightenment.org/rel/libs/${PN}/${P}.tar.xz"
 LICENSE="BSD-2 GPL-2 LGPL-2.1 ZLIB"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="avahi +bmp dds connman debug drm +eet egl examples fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz hyphen +ico ibus jpeg2k libressl libuv luajit neon nls opengl ssl pdf physics postscript +ppm +psd pulseaudio raw scim sdl sound static-libs svg +system-lz4 systemd tga tiff tslib unwind v4l valgrind vlc vnc wayland webp X xcf xim xine xpresent xpm"
+IUSE="avahi +bmp dds connman debug drm +eet egl fbcon +fontconfig fribidi gif gles glib gnutls gstreamer harfbuzz hyphen +ico ibus jpeg2k libressl libuv luajit neon nls opengl ssl pdf physics postscript +ppm +psd pulseaudio raw scim sdl sound static-libs svg +system-lz4 systemd tga tiff tslib unwind v4l valgrind vlc vnc wayland webp X xcf xim xine xpresent xpm"
 
 REQUIRED_USE="
 	?? ( opengl egl )
@@ -179,7 +179,6 @@ src_configure() {
 		$(use_enable drm elput)
 		$(use_enable eet image-loader-eet)
 		$(use_enable egl)
-		$(use_enable examples always-build-examples)
 		$(use_enable fbcon fb)
 		$(use_enable fontconfig)
 		$(use_enable fribidi)


### PR DESCRIPTION
'examples' USE flag should be disabled for now, because efl-1.21.0 doesn't build with it.

Upstream bug: https://phab.enlightenment.org/T7374