### PR TITLE
x11-themes/notify-osd-icons: revbump for EAPI7

### DIFF
--- a/x11-themes/notify-osd-icons/notify-osd-icons-0.7-r1.ebuild
+++ b/x11-themes/notify-osd-icons/notify-osd-icons-0.7-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Icons for on-screen-display notification agent"
+HOMEPAGE="https://launchpad.net/notify-osd"
+SRC_URI="mirror://ubuntu/pool/main/n/${PN}/${PN}_${PV}.tar.gz"
+
+LICENSE="CC-BY-SA-3.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="x11-misc/notify-osd"
+
+S=${WORKDIR}/${PN}
+
+DOCS=( AUTHORS debian/changelog )
+
+src_install() {
+	default
+
+	# Source: debian/notify-osd-icons.links
+	local path=/usr/share/notify-osd/icons/gnome/scalable/status
+	dosym notification-battery-000.svg ${path}/notification-battery-empty.svg
+	dosym notification-battery-020.svg ${path}/notification-battery-low.svg
+}


### PR DESCRIPTION
Hi,

This is another small update for x11-thems/notify-osd-icons to bump it to EAPI7.
Please review.

Closes: https://bugs.gentoo.org/665646