### PR TITLE
net-analyzer/linkchecker: add missing runtime dependency

### DIFF
--- a/net-analyzer/linkchecker/linkchecker-9999.ebuild
+++ b/net-analyzer/linkchecker/linkchecker-9999.ebuild
@@ -19,6 +19,7 @@ KEYWORDS=""
 IUSE="gnome sqlite"
 
 RDEPEND="
+	dev-python/pyxdg[${PYTHON_USEDEP}]
 	virtual/python-dnspython[${PYTHON_USEDEP}]
 	gnome? ( dev-python/pygtk:2[${PYTHON_USEDEP}] )
 "


### PR DESCRIPTION
Without adding `dev-python/pyxdg` as a dependency I get the following error message when running `linkchecker`:

    ImportError: No module named xdg.BaseDirectory