### PR TITLE
app-text/ebook-tools: fix HOMEPAGE (save a redirect)

### DIFF
--- a/app-text/ebook-tools/ebook-tools-0.2.2-r1.ebuild
+++ b/app-text/ebook-tools/ebook-tools-0.2.2-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="Tools for accessing and converting various ebook file formats"
-HOMEPAGE="https://sourceforge.net/projects/ebook-tools"
+HOMEPAGE="https://sourceforge.net/projects/ebook-tools/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"


### PR DESCRIPTION
Hi,

This is a minor change to some of the kde packages. 
The PR only adds a ```/``` to some of the HOMEPAGEs in order to save a redirect. It's not really a fix as the original HOMEPAGE would redirect the user anyway, but it's a nice to have.

Please review.