### PR TITLE
app-portage/g-sorcery: EAPI7, minor improvements

### DIFF
--- a/app-portage/g-sorcery/g-sorcery-9999.ebuild
+++ b/app-portage/g-sorcery/g-sorcery-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 PYTHON_COMPAT=(python{2_7,3_4,3_5,3_6})
 
@@ -27,14 +27,16 @@ RDEPEND="${DEPEND}"
 PDEPEND=">=app-portage/layman-2.2.0[g-sorcery(-),${PYTHON_USEDEP}]"
 
 python_test() {
-	PYTHONPATH="." "${PYTHON}" scripts/run_tests.py
+	PYTHONPATH="." "${PYTHON}" scripts/run_tests.py || die
 }
 
 python_install_all() {
 	distutils-r1_python_install_all
 
 	doman docs/*.8
-	dohtml docs/developer_instructions.html
+	docinto html
+	dodoc docs/developer_instructions.html
 	diropts -m0777
-	dodir /var/lib/g-sorcery
+	dodir /var/lib/${PN}
+	keepdir /var/lib/${PN}
 }


### PR DESCRIPTION
Hi,

This PR/Bug updates the live ebuild of g-sorcery for EAPI7 with some minor improvements.
Please review.

diff -u:
```diff
diff --git a/app-portage/g-sorcery/g-sorcery-9999.ebuild b/app-portage/g-sorcery/g-sorcery-9999.ebuild
index 8425f5282fc..bb8f8a3556e 100644
--- a/app-portage/g-sorcery/g-sorcery-9999.ebuild
+++ b/app-portage/g-sorcery/g-sorcery-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 PYTHON_COMPAT=(python{2_7,3_4,3_5,3_6})
 
@@ -27,14 +27,16 @@ RDEPEND="${DEPEND}"
 PDEPEND=">=app-portage/layman-2.2.0[g-sorcery(-),${PYTHON_USEDEP}]"
 
 python_test() {
-       PYTHONPATH="." "${PYTHON}" scripts/run_tests.py
+       PYTHONPATH="." "${PYTHON}" scripts/run_tests.py || die
 }
 
 python_install_all() {
        distutils-r1_python_install_all
 
        doman docs/*.8
-       dohtml docs/developer_instructions.html
+       docinto html
+       dodoc docs/developer_instructions.html
        diropts -m0777
-       dodir /var/lib/g-sorcery
+       dodir /var/lib/${PN}
+       keepdir /var/lib/${PN}
 }
```