### PR TITLE
www-client/dillo: EAPI7, improve ebuild

### DIFF
--- a/www-client/dillo/dillo-9999.ebuild
+++ b/www-client/dillo/dillo-9999.ebuild
@@ -1,8 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit autotools eutils mercurial multilib toolchain-funcs
+EAPI=7
+
+inherit autotools desktop mercurial toolchain-funcs
 
 DESCRIPTION="Lean FLTK based web browser"
 HOMEPAGE="https://www.dillo.org/"
@@ -29,6 +30,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}2-inbuf.patch
 )
 
+DOCS="AUTHORS ChangeLog README NEWS doc/*.txt doc/README"
+
 src_prepare() {
 	default
 	eautoreconf
@@ -52,12 +55,12 @@ src_compile() {
 }
 
 src_install() {
-	dodir /etc
 	default
 
-	use doc && dohtml html/*
-	dodoc AUTHORS ChangeLog README NEWS
-	dodoc doc/*.txt doc/README
+	if use doc; then
+		docinto html
+		dodoc -r html/
+	fi
 
 	doicon "${DISTDIR}"/${PN}.png
 	make_desktop_entry ${PN} Dillo


### PR DESCRIPTION
Hi,

This simple PR/Bug updates the live ebuild of dillo for EAPI7.
Please review.

Closes: https://bugs.gentoo.org/665720

diff:
```diff
diff --git a/www-client/dillo/dillo-9999.ebuild b/www-client/dillo/dillo-9999.ebuild
index 0d478f4ab15..529e790b676 100644
--- a/www-client/dillo/dillo-9999.ebuild
+++ b/www-client/dillo/dillo-9999.ebuild
@@ -1,8 +1,9 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit autotools eutils mercurial multilib toolchain-funcs
+EAPI=7
+
+inherit autotools desktop mercurial toolchain-funcs
 
 DESCRIPTION="Lean FLTK based web browser"
 HOMEPAGE="https://www.dillo.org/"
@@ -29,6 +30,8 @@ PATCHES=(
        "${FILESDIR}"/${PN}2-inbuf.patch
 )
 
+DOCS="AUTHORS ChangeLog README NEWS doc/*.txt doc/README"
+
 src_prepare() {
        default
        eautoreconf
@@ -55,9 +58,10 @@ src_install() {
        dodir /etc
        default
 
-       use doc && dohtml html/*
-       dodoc AUTHORS ChangeLog README NEWS
-       dodoc doc/*.txt doc/README
+       if use doc; then
+               docinto html
+               dodoc -r html/*
+       fi
 
        doicon "${DISTDIR}"/${PN}.png
        make_desktop_entry ${PN} Dillo
```