### PR TITLE
dev-lang/erlang: use HTTPS, update SRC_URI

### DIFF
--- a/dev-lang/erlang/erlang-19.1.ebuild
+++ b/dev-lang/erlang/erlang-19.1.ebuild
@@ -10,8 +10,8 @@ inherit autotools elisp-common eutils java-pkg-opt-2 multilib systemd versionato
 # open up a bug to let it be created.
 
 DESCRIPTION="Erlang programming language, runtime environment and libraries (OTP)"
-HOMEPAGE="http://www.erlang.org/"
-SRC_URI="http://www.erlang.org/download/otp_src_${PV}.tar.gz
+HOMEPAGE="https://www.erlang.org/"
+SRC_URI="http://erlang.org/download/otp_src_${PV}.tar.gz
 	http://erlang.org/download/otp_doc_man_${PV}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${PV}.tar.gz )"
 

--- a/dev-lang/erlang/erlang-19.3.ebuild
+++ b/dev-lang/erlang/erlang-19.3.ebuild
@@ -10,8 +10,8 @@ inherit autotools elisp-common eutils java-pkg-opt-2 multilib systemd versionato
 # open up a bug to let it be created.
 
 DESCRIPTION="Erlang programming language, runtime environment and libraries (OTP)"
-HOMEPAGE="http://www.erlang.org/"
-SRC_URI="http://www.erlang.org/download/otp_src_${PV}.tar.gz
+HOMEPAGE="https://www.erlang.org/"
+SRC_URI="http://erlang.org/download/otp_src_${PV}.tar.gz
 	http://erlang.org/download/otp_doc_man_${PV}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${PV}.tar.gz )"
 

--- a/dev-lang/erlang/erlang-20.2.ebuild
+++ b/dev-lang/erlang/erlang-20.2.ebuild
@@ -10,8 +10,8 @@ inherit autotools elisp-common eutils java-pkg-opt-2 multilib systemd versionato
 # open up a bug to let it be created.
 
 DESCRIPTION="Erlang programming language, runtime environment and libraries (OTP)"
-HOMEPAGE="http://www.erlang.org/"
-SRC_URI="http://www.erlang.org/download/otp_src_${PV}.tar.gz
+HOMEPAGE="https://www.erlang.org/"
+SRC_URI="http://erlang.org/download/otp_src_${PV}.tar.gz
 	http://erlang.org/download/otp_doc_man_${PV}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${PV}.tar.gz )"
 

--- a/dev-lang/erlang/erlang-20.3.2.ebuild
+++ b/dev-lang/erlang/erlang-20.3.2.ebuild
@@ -12,7 +12,7 @@ inherit autotools elisp-common java-pkg-opt-2 systemd versionator wxwidgets
 UPSTREAM_V="$(get_version_component_range 1-2)"
 
 DESCRIPTION="Erlang programming language, runtime environment and libraries (OTP)"
-HOMEPAGE="http://www.erlang.org/"
+HOMEPAGE="https://www.erlang.org/"
 SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	http://erlang.org/download/otp_doc_man_${UPSTREAM_V}.tar.gz -> ${PN}_doc_man_${UPSTREAM_V}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"

--- a/dev-lang/erlang/erlang-20.3.8.ebuild
+++ b/dev-lang/erlang/erlang-20.3.8.ebuild
@@ -12,7 +12,7 @@ inherit autotools elisp-common java-pkg-opt-2 systemd versionator wxwidgets
 UPSTREAM_V="$(get_version_component_range 1-2)"
 
 DESCRIPTION="Erlang programming language, runtime environment and libraries (OTP)"
-HOMEPAGE="http://www.erlang.org/"
+HOMEPAGE="https://www.erlang.org/"
 SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	http://erlang.org/download/otp_doc_man_${UPSTREAM_V}.tar.gz -> ${PN}_doc_man_${UPSTREAM_V}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"

--- a/dev-lang/erlang/erlang-20.3.ebuild
+++ b/dev-lang/erlang/erlang-20.3.ebuild
@@ -10,8 +10,8 @@ inherit autotools elisp-common java-pkg-opt-2 systemd versionator wxwidgets
 # open up a bug to let it be created.
 
 DESCRIPTION="Erlang programming language, runtime environment and libraries (OTP)"
-HOMEPAGE="http://www.erlang.org/"
-SRC_URI="http://www.erlang.org/download/otp_src_${PV}.tar.gz
+HOMEPAGE="https://www.erlang.org/"
+SRC_URI="http://erlang.org/download/otp_src_${PV}.tar.gz
 	http://erlang.org/download/otp_doc_man_${PV}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${PV}.tar.gz )"
 

--- a/dev-lang/erlang/erlang-21.0.2.ebuild
+++ b/dev-lang/erlang/erlang-21.0.2.ebuild
@@ -12,7 +12,7 @@ inherit autotools elisp-common java-pkg-opt-2 systemd versionator wxwidgets
 UPSTREAM_V="$(get_version_component_range 1-2)"
 
 DESCRIPTION="Erlang programming language, runtime environment and libraries (OTP)"
-HOMEPAGE="http://www.erlang.org/"
+HOMEPAGE="https://www.erlang.org/"
 SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	http://erlang.org/download/otp_doc_man_${UPSTREAM_V}.tar.gz -> ${PN}_doc_man_${UPSTREAM_V}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"


### PR DESCRIPTION
Hi,

This PR updates the HOMEPAGE of the erlang packages to use https instead of http.
I've also updated the SRC_URI links. In this case it always redirects to ```http://erlang``` for the download (even when using https) so I've updated the links accordingly.
