### PR TITLE
dev-python/hachoir-{core,parser,regex}: remove dead HOMEPAGE

### DIFF
--- a/dev-python/hachoir-core/hachoir-core-1.3.3-r1.ebuild
+++ b/dev-python/hachoir-core/hachoir-core-1.3.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 pypy )
 inherit distutils-r1
 
 DESCRIPTION="Core of Hachoir framework: parse and edit binary files"
-HOMEPAGE="https://bitbucket.org/haypo/hachoir/wiki/hachoir-core https://pypi.org/project/hachoir-core/"
+HOMEPAGE="https://pypi.org/project/hachoir-core/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-python/hachoir-parser/hachoir-parser-1.3.4-r1.ebuild
+++ b/dev-python/hachoir-parser/hachoir-parser-1.3.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 pypy )
 inherit distutils-r1
 
 DESCRIPTION="Package of Hachoir parsers used to open binary files"
-HOMEPAGE="https://bitbucket.org/haypo/hachoir/wiki/hachoir-parser https://pypi.org/project/hachoir-parser/"
+HOMEPAGE="https://pypi.org/project/hachoir-parser/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-python/hachoir-regex/hachoir-regex-1.0.5-r1.ebuild
+++ b/dev-python/hachoir-regex/hachoir-regex-1.0.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="Manipulation of regular expressions (regex)"
-HOMEPAGE="https://bitbucket.org/haypo/hachoir/wiki/hachoir-regex https://pypi.org/project/hachoir-regex/"
+HOMEPAGE="https://pypi.org/project/hachoir-regex/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This simple PR removes the dead bitbucket HOMEPAGE from the hachoir-* packages.
Please review.