### PR TITLE
dev-python/flask-dashed: EAPI7 revbump, fix HOMEPAGE

### DIFF
--- a/dev-python/flask-dashed/flask-dashed-0.1b_p2-r1.ebuild
+++ b/dev-python/flask-dashed/flask-dashed-0.1b_p2-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python2_7 )
+
+inherit distutils-r1
+
+MY_PN="Flask-Dashed"
+MY_PV="${PV/_p/}"
+MY_P="${MY_PN}-${MY_PV}"
+
+DESCRIPTION="Admin app framework for flask"
+HOMEPAGE="https://github.com/jeanphix/Flask-Dashed https://pypi.org/project/Flask-Dashed/"
+SRC_URI="mirror://pypi/${MY_P:0:1}/${MY_PN}/${MY_P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="dev-python/flask[${PYTHON_USEDEP}]
+	dev-python/flask-wtf[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]"
+
+S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	distutils-r1_src_prepare
+	rm -rf "${S}/tests" || die
+}


### PR DESCRIPTION
Hi,

This PR/Bug fixes dev-python/flask-dashed for EAPI7. Also changed the HOMEPAGE as the original doesn't show much at all.
Please review.

Closes: https://bugs.gentoo.org/665790

```diff 
--- flask-dashed-0.1b_p2.ebuild 2018-04-21 10:08:07.254543838 +0200
+++ flask-dashed-0.1b_p2-r1.ebuild      2018-09-12 14:36:59.574729531 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 PYTHON_COMPAT=( python2_7 )
 
 inherit distutils-r1
@@ -11,13 +11,12 @@
 MY_P="${MY_PN}-${MY_PV}"
 
 DESCRIPTION="Admin app framework for flask"
-HOMEPAGE="http://jeanphix.me/${MY_PN}/ https://pypi.org/project/${MY_PN}"
+HOMEPAGE="https://github.com/jeanphix/Flask-Dashed https://pypi.org/project/Flask-Dashed/"
 SRC_URI="mirror://pypi/${MY_P:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND="dev-python/flask[${PYTHON_USEDEP}]
        dev-python/flask-wtf[${PYTHON_USEDEP}]"
@@ -28,5 +27,5 @@
 
 src_prepare() {
        distutils-r1_src_prepare
-       rm -rf "${S}/tests"
+       rm -rf "${S}/tests" || die
 }
```