### PR TITLE
dev-python/capturer: EAPI7, update HOMEPAGE

### DIFF
--- a/dev-python/capturer/capturer-2.3.ebuild
+++ b/dev-python/capturer/capturer-2.3.ebuild
@@ -1,14 +1,16 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
 
 inherit distutils-r1
 
 DESCRIPTION="Easily capture stdout/stderr of the current process and subprocesses"
-HOMEPAGE="https://capturer.readthedocs.org/ https://pypi.org/project/capturer/ https://github.com/xolox/python-capturer"
+HOMEPAGE="https://capturer.readthedocs.io/en/latest/
+	https://pypi.org/project/capturer/
+	https://github.com/xolox/python-capturer"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 SLOT="0"


### PR DESCRIPTION
Hi,

Another simple update, this time for dev-python/capturer. Only raised EAPI7 and updated one of the HOMEPAGES.
Please review.