### PR TITLE
dev-python/bytecodeassembler: EAPI7, fix HOMEPAGE, minor improvements

### DIFF
--- a/dev-python/bytecodeassembler/bytecodeassembler-0.6.ebuild
+++ b/dev-python/bytecodeassembler/bytecodeassembler-0.6.ebuild
@@ -1,23 +1,21 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 PYTHON_COMPAT=( python2_7 pypy )
 
 inherit distutils-r1
 
 MY_PN="BytecodeAssembler"
 
-DESCRIPTION="Generate Python code objects by "assembling" bytecode"
-HOMEPAGE="https://pypi.org/project//BytecodeAssembler"
+DESCRIPTION="Generate Python code objects by assembling bytecode"
+HOMEPAGE="https://pypi.org/project/BytecodeAssembler/"
 SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_PN}-${PV}.zip -> ${P}.zip"
 
 KEYWORDS="amd64 x86"
-IUSE=""
 LICENSE="Apache-2.0"
 SLOT="0"
 
-RDEPEND=""
 DEPEND="app-arch/unzip
 	>=dev-python/symboltype-1.0[${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Hi,

This PR updates dev-python/bytecodeassembler for EAPI7. I've only raised the EAPI, fixed the HOMEPAGE and removed some unused Vars thus i didn't made a revbump.

Please review.