### PR TITLE
sci-physics/root: build with C++14 support

### DIFF
--- a/sci-physics/root/root-9999.ebuild
+++ b/sci-physics/root/root-9999.ebuild
@@ -201,7 +201,7 @@ src_configure() {
 		-Dcling=ON # cling=OFF is broken
 		-Dcocoa=$(usex aqua)
 		-Dcuda=$(usex cuda)
-		-Dcxx14=$(usex root7)
+		-Dcxx14=ON
 		-Dcxxmodules=OFF # requires clang, unstable
 		-Ddavix=$(usex davix)
 		-Ddcache=OFF


### PR DESCRIPTION
Given that since the release of the 17.0 profiles C++14 is default language and that compilers not supporting it are masked, it seems logical to me to also enable C++14 support in ROOT.

Maybe even worthwhile to add a root-6.14.04-r3.ebuild