### PR TITLE
net-im/qtox: add missing libexif dep

### DIFF
--- a/net-im/qtox/qtox-1.16.3.ebuild
+++ b/net-im/qtox/qtox-1.16.3.ebuild
@@ -30,6 +30,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
 	media-gfx/qrencode:=
+	media-libs/libexif
 	media-libs/openal
 	>=media-video/ffmpeg-2.6.3:=[webp,v4l]
 	net-libs/tox:0/0.2[av]


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/663506