### PR TITLE
app-crypt/xca: use HTTPS

### DIFF
--- a/app-crypt/xca/xca-1.4.1.ebuild
+++ b/app-crypt/xca/xca-1.4.1.ebuild
@@ -6,7 +6,7 @@ EAPI="6"
 inherit xdg-utils
 
 DESCRIPTION="A GUI to OpenSSL, RSA public keys, certificates, signing requests etc"
-HOMEPAGE="http://hohnstaedt.de/xca/"
+HOMEPAGE="https://hohnstaedt.de/xca/"
 SRC_URI="https://github.com/chris2511/${PN}/releases/download/RELEASE.${PV}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/app-crypt/xca/xca-2.1.0.ebuild
+++ b/app-crypt/xca/xca-2.1.0.ebuild
@@ -6,7 +6,7 @@ EAPI="6"
 inherit xdg-utils
 
 DESCRIPTION="A GUI to OpenSSL, RSA public keys, certificates, signing requests etc"
-HOMEPAGE="http://hohnstaedt.de/xca/"
+HOMEPAGE="https://hohnstaedt.de/xca/"
 SRC_URI="https://github.com/chris2511/${PN}/releases/download/RELEASE.${PV}/${P}.tar.gz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Hi,

Simple PR to update the build to use https instead of http.
Please review.