### PR TITLE
sci-physics/root: Fix clean-up code and compile options

### DIFF
--- a/sci-physics/root/root-9999.ebuild
+++ b/sci-physics/root/root-9999.ebuild
@@ -198,6 +198,7 @@ src_configure() {
 		-Dccache=OFF # use ccache via portage
 		-Dcastor=OFF
 		-Dchirp=OFF
+		-Dclad=OFF
 		-Dcling=ON # cling=OFF is broken
 		-Dcocoa=$(usex aqua)
 		-Dcuda=$(usex cuda)
@@ -308,15 +309,11 @@ src_install() {
 		elisp-install ${PN}-$(ver_cut 1-2) "${BUILD_DIR}"/root-help.el
 	fi
 
-	if ! use gdml; then
-		rm -r geom || die
-	fi
-
 	if ! use examples; then
 		rm -r test tutorials || die
 	fi
 
-	if use tmva; then
+	if ! use tmva; then
 		rm -r tmva || die
 	fi
 


### PR DESCRIPTION
- compilation with clad enabled fails
not sure if this is even supposed to work
- there's no geom directory with gdml disabled, 
so the install phase fails because of the failing `rm -r geom`
- deletion logic for tmva seems inverted

Or am I overlooking something here?