### PR TITLE
games-emulation/dolphin: Disable SDL by default

### DIFF
--- a/games-emulation/dolphin/dolphin-9999.ebuild
+++ b/games-emulation/dolphin/dolphin-9999.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://www.dolphin-emu.org/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="alsa bluetooth discord-presence doc egl +evdev ffmpeg libav log lto profile pulseaudio +qt5 sdl systemd upnp"
+IUSE="alsa bluetooth discord-presence doc egl +evdev ffmpeg libav log lto profile pulseaudio +qt5 -sdl systemd upnp"
 
 RDEPEND="
 	dev-libs/hidapi:0=


### PR DESCRIPTION
The desktop profile enables SDL by default, and it's likely that the
desktop profile is being used on a computer that uses dolphin. SDL is
legacy according to upstream and evdev should be used instead.

Package-Manager: Portage-2.3.49, Repoman-2.3.10
Closes: https://bugs.gentoo.org/666558