### PR TITLE
dev-libs/shhopt: EAPI7 revbump, improve ebuild

### DIFF
--- a/dev-libs/shhopt/files/shhopt-1.1.7-build.patch
+++ b/dev-libs/shhopt/files/shhopt-1.1.7-build.patch
@@ -1,5 +1,5 @@
---- Makefile
-+++ Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -5,20 +5,15 @@
  VERPAT		= 7
  VERSION		= $(VERMAJ).$(VERMIN).$(VERPAT)

--- a/dev-libs/shhopt/shhopt-1.1.7-r3.ebuild
+++ b/dev-libs/shhopt/shhopt-1.1.7-r3.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="library for parsing command line options"
+HOMEPAGE="http://shh.thathost.com/pub-unix/"
+SRC_URI="http://shh.thathost.com/pub-unix/files/${P}.tar.gz"
+
+LICENSE="Artistic"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=( "${FILESDIR}"/${P}-build.patch )
+
+src_compile() {
+	emake CC=$(tc-getCC)
+}
+
+src_install() {
+	dolib.a libshhopt.a
+	ln -s libshhopt.so.${PV} libshhopt.so || die
+	ln -s libshhopt.so.${PV} libshhopt.so.${PV:0:1} || die
+	dolib.so libshhopt.so*
+	doheader shhopt.h
+	dodoc ChangeLog CREDITS README TODO
+}


### PR DESCRIPTION
Hi,

This PR/Bug updates dev-libs/shhopt for EAPI7.
Please review.

Closes: https://bugs.gentoo.org/666574