### PR TITLE
x11-misc/zim: add missing mimeinfo cache update

### DIFF
--- a/x11-misc/zim/zim-0.67-r1.ebuild
+++ b/x11-misc/zim/zim-0.67-r1.ebuild
@@ -59,6 +59,7 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
+	xdg_mimeinfo_database_update
 	xdg_desktop_database_update
 	gnome2_icon_cache_update
 	if ! has_version ${CATEGORY}/${PN}; then
@@ -76,6 +77,7 @@ pkg_postinst() {
 }
 
 pkg_postrm() {
+	xdg_mimeinfo_database_update
 	xdg_desktop_database_update
 	gnome2_icon_cache_update
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/635108
Package-Manager: Portage-2.3.49, Repoman-2.3.10
@veremitz's request in #gentoo-dev-help