### PR TITLE
sys-fs/bees: Best-Effort Extent-Same, a btrfs dedup agent.

### DIFF
--- a/sys-fs/bees/bees-9999.ebuild
+++ b/sys-fs/bees/bees-9999.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit linux-info
+
+DESCRIPTION="Best-Effort Extent-Same, a btrfs dedup agent"
+HOMEPAGE="https://github.com/Zygo/bees"
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://github.com/Zygo/bees.git"
+	inherit git-r3
+else
+	SRC_URI="https://github.com/Zygo/bees/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+fi
+
+LICENSE="GPL-3"
+SLOT="0"
+IUSE="tools"
+
+DEPEND="
+	>=sys-apps/util-linux-2.30.2
+	>=sys-fs/btrfs-progs-4.1
+"
+RDEPEND="${DEPEND}"
+
+CONFIG_CHECK="~BTRFS_FS"
+ERROR_BTRFS_FS="CONFIG_BTRFS_FS: bees does currently only work with btrfs"
+
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != buildonly ]]; then
+		if kernel_is -lt 4 4 3; then
+			ewarn "Kernel versions below 4.4.3 lack critical features needed for bees to"
+			ewarn "properly operate, so it won't work. It's recommended to run at least"
+			ewarn "kernel version 4.11 for best performance and reliability."
+			ewarn
+		elif kernel_is -lt 4 11; then
+			ewarn "With kernel versions below 4.11, bees may severely degrade system performance"
+			ewarn "and responsiveness. Especially, the kernel may deadlock while bees is"
+			ewarn "running, it's recommended to run at least kernel 4.11."
+			ewarn
+		elif kernel_is -lt 4 14 29; then
+			ewarn "With kernel versions below 4.14.29, bees may generate a lot of bogus WARN_ON()"
+			ewarn "messages in the kernel log. These messages can be ignored and this is fixed"
+			ewarn "with more recent kernels:"
+			ewarn "# WARNING: CPU: 3 PID: 18172 at fs/btrfs/backref.c:1391 find_parent_nodes+0xc41/0x14e0"
+			ewarn
+		fi
+		elog "Bees recommends to run the latest current kernel for performance and"
+		elog "reliability reasons, see README.md."
+	fi
+}
+
+src_configure() {
+	cat >localconf <<-EOF || die
+		LIBEXEC_PREFIX=/usr/libexec
+		PREFIX=/usr
+		LIBDIR=$(get_libdir)
+		DEFAULT_MAKE_TARGET=all
+	EOF
+	if use tools; then
+		echo OPTIONAL_INSTALL_TARGETS=install_tools >>localconf || die
+	fi
+}

--- a/sys-fs/bees/metadata.xml
+++ b/sys-fs/bees/metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>hurikhan77+bgo@gmail.com</email>
+		<name>Kai Krakow</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+<use>
+	<flag name="tools">Build extra tools useful for debugging (fiemap, fiewalk)</flag>
+</use>
+<upstream>
+	<bugs-to>https://github.com/Zygo/bees/issues</bugs-to>
+	<remote-id type="github">Zygo/bees</remote-id>
+</upstream>
+</pkgmetadata>


### PR DESCRIPTION
This is the second attempt to make a pull-request. Previous attempts timed out because of delayed upstream activity. All Gentoo QA issues should have been fixed now and merged upstream, tagging a stable version is soon to come. The build is prepared to handle v0.6 and upwards.

The current ebuild version also incorporates all previous QA suggestions squashed into a single commit and rebased to current portage.

Bees is a block-oriented userspace dedup agent designed to avoid
scalability problems on large filesystems.

Bees is designed to degrade gracefully when underprovisioned with RAM.
Bees does not use more RAM or storage as filesystem data size
increases. The dedup hash table size is fixed at creation time and does
not change. The effective dedup block size is dynamic and adjusts
automatically to fit the hash table into the configured RAM limit. Hash
table overflow is not implemented to eliminate the IO overhead of hash
table overflow. Hash table entries are only 16 bytes per dedup block to
keep the average dedup block size small.

Package-Manager: Portage-2.3.49, Repoman-2.3.10
Signed-off-by: Kai Krakow <kai@kaishome.de>