### PR TITLE
app-misc/neofetch: Fix DESTDIR

### DIFF
--- a/app-misc/neofetch/neofetch-5.0.0.ebuild
+++ b/app-misc/neofetch/neofetch-5.0.0.ebuild
@@ -28,5 +28,5 @@ RDEPEND="sys-apps/pciutils
 	)"
 
 src_install() {
-	emake DESTDIR="${ED}/usr" install
+	emake DESTDIR="${ED}" install
 }


### PR DESCRIPTION
Since in the Makefile neofetch already installs to "/usr" by default,
additional "/usr" in DESTDIR will be redundant.

Closes: https://bugs.gentoo.org/666682
Package-Manager: Portage-2.3.49, Repoman-2.3.10