### PR TITLE
media-libs/libgroove: fix build with ffmpeg-4

### DIFF
--- a/media-libs/libgroove/files/libgroove-4.3.0_ffmpeg4.patch
+++ b/media-libs/libgroove/files/libgroove-4.3.0_ffmpeg4.patch
@@ -1,0 +1,47 @@
+Description: Fix FTBFS with FFmpeg 4.0
+Author: James Cowgill <jcowgill@debian.org>
+Bug-Debian: https://bugs.debian.org/888376
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/groove/encoder.c
++++ b/groove/encoder.c
+@@ -616,7 +616,7 @@ int groove_encoder_attach(struct GrooveE
+ 
+     e->sink->audio_format = encoder->actual_audio_format;
+     e->sink->buffer_size = encoder->sink_buffer_size;
+-    e->sink->buffer_sample_count = (codec->capabilities & CODEC_CAP_VARIABLE_FRAME_SIZE) ?
++    e->sink->buffer_sample_count = (codec->capabilities & AV_CODEC_CAP_VARIABLE_FRAME_SIZE) ?
+         0 : e->stream->codec->frame_size;
+     e->sink->gain = encoder->gain;
+ 
+--- a/groove/playlist.c
++++ b/groove/playlist.c
+@@ -186,7 +186,7 @@ static int audio_decode_frame(struct Gro
+ 
+         if (!got_frame) {
+             // stop sending empty packets if the decoder is finished
+-            if (!pkt_temp->data && dec->codec->capabilities & CODEC_CAP_DELAY)
++            if (!pkt_temp->data && dec->codec->capabilities & AV_CODEC_CAP_DELAY)
+                 return 0;
+             continue;
+         }
+@@ -571,7 +571,7 @@ static int decode_one_frame(struct Groov
+     pthread_mutex_unlock(&f->seek_mutex);
+ 
+     if (f->eof) {
+-        if (f->audio_st->codec->codec->capabilities & CODEC_CAP_DELAY) {
++        if (f->audio_st->codec->codec->capabilities & AV_CODEC_CAP_DELAY) {
+             av_init_packet(pkt);
+             pkt->data = NULL;
+             pkt->size = 0;
+--- a/groove/file.c
++++ b/groove/file.c
+@@ -281,7 +281,7 @@ int groove_file_save(struct GrooveFile *
+         ocodec->rc_buffer_size = icodec->rc_buffer_size;
+         ocodec->field_order    = icodec->field_order;
+ 
+-        uint64_t extra_size = (uint64_t)icodec->extradata_size + FF_INPUT_BUFFER_PADDING_SIZE;
++        uint64_t extra_size = (uint64_t)icodec->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE;
+         if (extra_size > INT_MAX) {
+             cleanup_save(file);
+             av_log(NULL, AV_LOG_ERROR, "codec extra size too big\n");

--- a/media-libs/libgroove/libgroove-4.3.0-r1.ebuild
+++ b/media-libs/libgroove/libgroove-4.3.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -23,6 +23,7 @@ RDEPEND="${DEPEND}"
 
 PATCHES=( "${FILESDIR}/${P}_cflags.patch"
 	"${FILESDIR}/${P}_sdl2_include_dir.patch"
+	"${FILESDIR}/${P}_ffmpeg4.patch"
 	"${FILESDIR}/${P}_GNUInstallDirs.patch" )
 
 src_configure() {

--- a/media-libs/libgroove/metadata.xml
+++ b/media-libs/libgroove/metadata.xml
@@ -18,10 +18,11 @@
 	<flag name="sound">Enable audio playing.</flag>
 </use>
 <upstream>
-	<maintainer status="active">
+	<maintainer status="inactive">
 		<email>superjoe30@gmail.com</email>
 		<name>Andrew Kelley</name>
 	</maintainer>
 	<remote-id type="github">andrewrk/libgroove</remote-id>
+	<bugs-to>https://github.com/andrewrk/libgroove/issues</bugs-to>
 </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/654330