### PR TITLE
dev-libs/libuv: remove ltprune

### DIFF
--- a/dev-libs/libuv/libuv-1.23.1.ebuild
+++ b/dev-libs/libuv/libuv-1.23.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit autotools ltprune multilib-minimal
+inherit autotools multilib-minimal
 
 DESCRIPTION="Cross-platform asychronous I/O"
 HOMEPAGE="https://github.com/libuv/libuv"
@@ -43,5 +43,5 @@ multilib_src_test() {
 
 multilib_src_install_all() {
 	einstalldocs
-	prune_libtool_files
+	find "${D}" -name '*.la' -delete || die
 }


### PR DESCRIPTION
Hi,

This PR/Bug bump libuv to version 1.23.1, raises EAPI and removes the deprecated eclass ```ltprune```.
Please review.

Closes: https://bugs.gentoo.org/666722
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>