### PR TITLE
dev-libs/faxpp: EAPI7 revbump, improve ebuild

### DIFF
--- a/dev-libs/faxpp/faxpp-0.4-r1.ebuild
+++ b/dev-libs/faxpp/faxpp-0.4-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Small, fast and conformant XML pull parser written in C"
+HOMEPAGE="http://faxpp.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc examples"
+
+src_install() {
+	default
+
+	if use doc; then
+		docinto html
+		dodoc -r docs/api/
+	fi
+	if use examples; then
+		insinto /usr/share/doc/${PF}
+		doins -r examples
+	fi
+}


### PR DESCRIPTION
Hi,

This PR/Bug adds a EAPI7 ebuild for dev-libs/faxpp.
Please review.

Closes: https://bugs.gentoo.org/666772
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>