### PR TITLE
 media-libs/audiofile: Fix audiofile-0.3.6-CVE-2015-7747.patch and audiofile-0.3.6-system-gtest.patch

### DIFF
--- a/media-libs/audiofile/files/audiofile-0.3.6-CVE-2015-7747.patch
+++ b/media-libs/audiofile/files/audiofile-0.3.6-CVE-2015-7747.patch
@@ -35,7 +35,7 @@ Bug-Debian: https://bugs.debian.org/801102
  
 --- /dev/null
 +++ b/test/sixteen-stereo-to-eight-mono.c
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,117 @@
 +/*
 +	Audio File Library
 +
@@ -95,8 +95,8 @@ Bug-Debian: https://bugs.debian.org/801102
 +	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 16);
 +	afInitChannels(setup, AF_DEFAULT_TRACK, 2);
 +
-+	char *testFileName;
-+	if (!createTemporaryFile("sixteen-to-eight", &testFileName))
++	char testFileName[PATH_MAX];
++	if (!createTemporaryFile("sixteen-to-eight", testFileName))
 +	{
 +		fprintf(stderr, "Could not create temporary file.\n");
 +		exit(EXIT_FAILURE);
@@ -150,7 +150,6 @@ Bug-Debian: https://bugs.debian.org/801102
 +
 +	afCloseFile(file);
 +	unlink(testFileName);
-+	free(testFileName);
 +
 +	exit(EXIT_SUCCESS);
 +}

--- a/media-libs/audiofile/files/audiofile-0.3.6-system-gtest.patch
+++ b/media-libs/audiofile/files/audiofile-0.3.6-system-gtest.patch
@@ -1,3 +1,38 @@
+--- audiofile-0.3.6/configure.ac
++++ audiofile-0.3.6/configure.ac
+@@ -160,7 +160,6 @@
+ 	audiofile-uninstalled.pc
+ 	sfcommands/Makefile
+ 	test/Makefile
+-	gtest/Makefile
+ 	examples/Makefile
+ 	libaudiofile/Makefile
+ 	libaudiofile/alac/Makefile
+--- audiofile-0.3.6/libaudiofile/Makefile.am
++++ audiofile-0.3.6/libaudiofile/Makefile.am
+@@ -108,10 +108,9 @@
+ TESTS_ENVIRONMENT = $(top_builddir)/libtool --mode=execute $(VALGRIND) $(VALGRIND_FLAGS)
+ endif
+ 
+-LIBGTEST = ../gtest/libgtest.la
+ 
+-UnitTests_SOURCES = modules/UT_RebufferModule.cpp
+-UnitTests_LDADD = libaudiofile.la $(LIBGTEST)
++UnitTests_SOURCES = modules/UT_RebufferModule.cpp $(libaudiofile_la_SOURCES)
++UnitTests_LDADD = $(libaudiofile_la_LIBADD) -lgtest
+ UnitTests_CPPFLAGS = -I$(top_srcdir)
+ UnitTests_CXXFLAGS = -fno-rtti -fno-exceptions -DGTEST_HAS_RTTI=0 -DGTEST_HAS_EXCEPTIONS=0
+ UnitTests_LDFLAGS = -static
+--- audiofile-0.3.6/Makefile.am
++++ audiofile-0.3.6/Makefile.am
+@@ -1,6 +1,6 @@
+ ## Process this file with automake to produce Makefile.in
+ 
+-SUBDIRS = gtest libaudiofile sfcommands test examples docs
++SUBDIRS =  libaudiofile sfcommands test examples docs
+ 
+ EXTRA_DIST = \
+ 	ACKNOWLEDGEMENTS \
 --- audiofile-0.3.6/test/Makefile.am
 +++ audiofile-0.3.6/test/Makefile.am
 @@ -59,79 +59,77 @@


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/511882
Closes: https://github.com/gentoo/gentoo/pull/9953
Package-Manager: Portage-2.3.49, Repoman-2.3.10

`audiofile-0.3.6-CVE-2015-7747.patch` comes from a Debian patch which, itself, depends on Debian's [02_hurd.patch](https://sources.debian.org/src/audiofile/0.3.6-4/debian/patches/02_hurd.patch/).  Without it, the unittest that the patch creates fails with a segfault. Specifically, it passes a `char*` to a function that expects an allocated char array.  Upstream fixed CVE-2015-7747 with https://github.com/mpruett/audiofile/commit/49103e386808042f830c18365976ad40875923ea, without including Debian's unittest.  But since the unittest requires a small fix and seems to be useful it's best to amend `audiofile-0.3.6-CVE-2015-7747.patch`.

There still exists references to the bundled gtest which leads to unresolved symbols while building.  Also, building tests without static-libs is unsupported upstream (see https://github.com/mpruett/audiofile/issues/15) but building and testing succeeds without issue if the unittests are linked to the same object files used to build libaudiofile.