### PR TITLE
eclass/mozconfig-v6.60: remove obsolete sandbox detection to fix #663040

### DIFF
--- a/eclass/mozconfig-v6.60.eclass
+++ b/eclass/mozconfig-v6.60.eclass
@@ -325,9 +325,6 @@ mozconfig_config() {
 		mozconfig_annotate '-pulseaudio' --enable-alsa
 	fi
 
-	# For testing purpose only
-	mozconfig_annotate 'Sandbox' --enable-content-sandbox
-
 	mozconfig_use_enable system-sqlite
 	mozconfig_use_with system-jpeg
 	mozconfig_use_with system-icu


### PR DESCRIPTION
@Whissi 

If you have the sandbox compile switch turned on by default, it breaks the compile on all arches but those where it is enabled now automatically. The detection of sandbox is now managed via configure: https://searchfox.org/mozilla-central/rev/f5fb323246bf22a3a3b4185882a1c5d8a2c02996/old-configure.in#3251

The whole detection now done automatically via configure scripts by upstream means, that this fix is not invasive and very benign. 

This is true since firefox-60.0_beta8 or so

``` 
119:52.09 libsecurity_sandbox_common.a.desc
121:17.62 libjs_src.a.desc
121:22.77 /var/tmp/portage/www-client/firefox-60.1.0/work/firefox-60.1.0/security/sandbox/linux/reporter/SandboxReporter.cpp:30:2: error: #error "unrecognized architecture"
121:22.77  #error "unrecognized architecture"
121:22.77   ^~~~~
121:27.70 libsecurity_sandbox_linux_broker.a.desc
121:30.20 /var/tmp/portage/www-client/firefox-60.1.0/work/firefox-60.1.0/security/sandbox/linux/reporter/SandboxReporter.cpp: In function 'void mozilla::SubmitToTelemetry(const mozilla::SandboxReport&)':
121:30.20 /var/tmp/portage/www-client/firefox-60.1.0/work/firefox-60.1.0/security/sandbox/linux/reporter/SandboxReporter.cpp:220:16: error: 'SANDBOX_ARCH_NAME' was not declared in this scope
121:30.21      key.Append(SANDBOX_ARCH_NAME "/");
121:30.21                 ^~~~~~~~~~~~~~~~~
121:30.28 /var/tmp/portage/www-client/firefox-60.1.0/work/firefox-60.1.0/security/sandbox/linux/reporter/SandboxReporter.cpp:220:16: note: suggested alternative: 'SANDBOX_LOG_LEN'
121:30.28      key.Append(SANDBOX_ARCH_NAME "/");
121:30.29                 ^~~~~~~~~~~~~~~~~
121:30.29                 SANDBOX_LOG_LEN
121:31.42 gmake[4]: *** [/var/tmp/portage/www-client/firefox-60.1.0/work/firefox-60.1.0/config/rules.mk:1049: SandboxReporter.o] Error 1
```

looking into SandboxReporter.cpp makes me think this is not an accident:

```
// Distinguish architectures for the telemetry key.
#if defined(__i386__)
#define SANDBOX_ARCH_NAME "x86"
#elif defined(__x86_64__)
#define SANDBOX_ARCH_NAME "amd64"
#else
#error "unrecognized architecture"
#endif
``` 

I know that there are plans to move away from mozconfig, but this is not true for esr as fare as I'm concerned.

Closes: https://bugs.gentoo.org/663040