### PR TITLE
sci-electronics/kicad: Add USE=occ,openmp, fix curl dependency

### DIFF
--- a/sci-electronics/kicad/files/kicad-5.0.0-curl.patch
+++ b/sci-electronics/kicad/files/kicad-5.0.0-curl.patch
@@ -1,0 +1,23 @@
+--- a/common/CMakeLists.txt.old    2018-09-13 16:21:29.642915273 +0200
++++ a/common/CMakeLists.txt    2018-09-13 16:23:25.146914833 +0200
+@@ -337,14 +337,17 @@
+     list( APPEND COMMON_SRCS strtok_r.c )
+ endif()
+ 
++if( BUILD_GITHUB_PLUGIN )
++    list( APPEND COMMON_SRCS
++        kicad_curl/kicad_curl.cpp
++        kicad_curl/kicad_curl_easy.cpp
++    )
++endif()
+ 
+ set( COMMON_SRCS
+     ${COMMON_SRCS}
+     system/libcontext.cpp
+ 
+-    kicad_curl/kicad_curl.cpp
+-    kicad_curl/kicad_curl_easy.cpp
+-
+     view/view.cpp
+     view/view_item.cpp
+     view/view_group.cpp

--- a/sci-electronics/kicad/kicad-5.0.0-r1.ebuild
+++ b/sci-electronics/kicad/kicad-5.0.0-r1.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python2_7 )
 
 WX_GTK_VER="3.0"
 
-inherit check-reqs cmake-utils eapi7-ver eutils gnome2-utils python-single-r1 wxwidgets xdg
+inherit check-reqs cmake-utils eapi7-ver eutils gnome2-utils python-single-r1 toolchain-funcs wxwidgets xdg
 
 DESCRIPTION="Electronic Schematic and PCB design tools"
 HOMEPAGE="http://www.kicad-pcb.org"
@@ -15,10 +15,11 @@ SRC_URI="https://launchpad.net/${PN}/$(ver_cut 1-2)/${PV}/+download/${P}.tar.xz"
 LICENSE="GPL-2+ GPL-3+ Boost-1.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="doc examples github +ngspice +oce +python"
+IUSE="doc examples github +ngspice occ +oce openmp +python"
 
 REQUIRED_USE="
 	python? ( ${PYTHON_REQUIRED_USE} )
+	?? ( occ oce )
 "
 
 COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
@@ -27,9 +28,6 @@ COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 		${PYTHON_DEPS}
 	)
 	>=dev-libs/boost-1.61[context,nls,threads,python?,${PYTHON_USEDEP}]
-	github? (
-		net-misc/curl[ssl]
-	)
 	media-libs/glew:0=
 	media-libs/glm
 	media-libs/freeglut
@@ -37,13 +35,14 @@ COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 	ngspice? (
 		sci-electronics/ngspice[shared]
 	)
-	oce? (
-		sci-libs/oce
-	)
-	x11-libs/cairo"
+	occ? ( >=sci-libs/opencascade-6.8.0 )
+	oce? ( sci-libs/oce )
+	>=x11-libs/cairo-1.8.8
+	>=x11-libs/pixman-0.30"
 DEPEND="${COMMON_DEPEND}
 	doc? ( app-doc/doxygen )
-	python? ( dev-lang/swig:0 )"
+	github? ( net-misc/curl[ssl] )
+	python? ( >=dev-lang/swig-3.0:0 )"
 RDEPEND="${COMMON_DEPEND}
 	sci-electronics/electronics-menu
 "
@@ -51,6 +50,7 @@ CHECKREQS_DISK_BUILD="800M"
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup
+	use openmp && tc-check-openmp
 	setup-wxwidgets
 	check-reqs_pkg_setup
 }
@@ -58,6 +58,14 @@ pkg_setup() {
 src_prepare() {
 	xdg_src_prepare
 	cmake-utils_src_prepare
+
+	epatch "${FILESDIR}"/${P}-curl.patch
+
+	# fix application categories in desktop files
+	while IFS="" read -d $'\0' -r f; do
+		sed -i.bkp '/Categories/s/Development;//' "${f}"
+	done < <(find "${S}" -type f -name "*.desktop" -print0)
+
 }
 
 src_configure() {
@@ -67,8 +75,9 @@ src_configure() {
 		-DKICAD_SCRIPTING="$(usex python)"
 		-DKICAD_SCRIPTING_MODULES="$(usex python)"
 		-DKICAD_SCRIPTING_WXPYTHON="$(usex python)"
+		-DKICAD_SCRIPTING_ACTION_MENU="$(usex python)"
 		-DKICAD_SPICE="$(usex ngspice)"
-		-DKICAD_USE_OCC=OFF
+		-DKICAD_USE_OCC="$(usex occ)"
 		-DKICAD_USE_OCE="$(usex oce)"
 		-DKICAD_INSTALL_DEMOS="$(usex examples)"
 	)
@@ -78,13 +87,16 @@ src_configure() {
 		-DPYTHON_INCLUDE_DIR="$(python_get_includedir)"
 		-DPYTHON_LIBRARY="$(python_get_library_path)"
 	)
+	use occ && mycmakeargs+=( -DOCC_LIBRARY_DIR="${CASROOT}"/lib )
+
 	cmake-utils_src_configure
 }
 
 src_compile() {
 	cmake-utils_src_compile
 	if use doc; then
-		doxygen Doxyfile || die
+		cmake-utils_src_compile doxygen-docs
+		cmake-utils_src_compile dev-docs
 	fi
 }
 
@@ -94,7 +106,7 @@ src_install() {
 	if use doc ; then
 		dodoc uncrustify.cfg
 		cd Documentation || die
-		dodoc -r doxygen/.
+		dodoc -r *.txt kicad_doxygen_logo.png notes_about_pcbnew_new_file_format.odt doxygen/. development/doxygen/.
 	fi
 }
 

--- a/sci-electronics/kicad/metadata.xml
+++ b/sci-electronics/kicad/metadata.xml
@@ -14,6 +14,7 @@
 		<flag name="i18n">Allow GUI internationalization through l10n_* use flags</flag>
 		<flag name="minimal">Build only binaries without parts library and examples</flag>
 		<flag name="ngspice">Enable circuit simulation</flag>
+		<flag name="occ">Enable viewing 3D rendering of designs via opencascade</flag>
 		<flag name="oce">Enable viewing 3D rendering of designs via OCE</flag>
 		<flag name="python">Enable python scripting support</flag>
 	</use>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/665500
Package-Manager: Portage-2.3.48, Repoman-2.3.10
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>