### PR TITLE
toolchain-funcs.eclass: do not set --with-float for arm multilib

### DIFF
--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -235,6 +235,14 @@ tc-detect-is-softfloat() {
 		# hardfloat but we now treat it as softfloat like most everyone
 		# else. Check existing toolchains to respect existing systems.
 		arm*)
+			# All tests are meaningless when `multilib` flag is enabled.
+			# Furthermore `--with-float=` compilation option is incompatible
+			# with `--with-multilib-list=`.
+			if use multilib; then
+				echo "no"
+				return 0
+			fi
+
 			if tc-cpp-is-true "defined(__ARM_PCS_VFP)"; then
 				echo "no"
 			else


### PR DESCRIPTION
Setting --with-multilib-list profiles is incompatible
with --with-arch/cpu/fpu/float/mode options.

We should avoid passing --with-float option at least for arm-* multilib.

Closes: https://bugs.gentoo.org/666896