### PR TITLE
app-mobilephone/gammu: remove virtual/mysql from deps

### DIFF
--- a/app-mobilephone/gammu/gammu-1.39.0-r1.ebuild
+++ b/app-mobilephone/gammu/gammu-1.39.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -20,7 +20,7 @@ COMMON_DEPEND="
 	bluetooth? ( net-wireless/bluez:= )
 	curl? ( net-misc/curl:= )
 	dbi? ( >=dev-db/libdbi-0.8.3:= )
-	mysql? ( virtual/mysql:= )
+	mysql? ( dev-db/mysql-connector-c:= )
 	postgres? ( dev-db/postgresql:= )
 	usb? ( virtual/libusb:1= )
 "


### PR DESCRIPTION
Replace virtual/mysql by mariadb- or mysql- connectors in dependencies.

Closes: https://bugs.gentoo.org/665826
Closes: https://github.com/gentoo/gentoo/pull/9962
Signed-off-by: Victor Kustov <ktrace@yandex.ru>
Package-Manager: Portage-2.3.40, Repoman-2.3.9