### PR TITLE
luajit: Fix cross-compilation build.

### DIFF
--- a/dev-lang/luajit/luajit-2.0.5-r2.ebuild
+++ b/dev-lang/luajit/luajit-2.0.5-r2.ebuild
@@ -38,10 +38,16 @@ _emake() {
 		PREFIX="${EPREFIX}/usr" \
 		MULTILIB="$(get_libdir)" \
 		DESTDIR="${D}" \
+		CFLAGS="" \
+		LDFLAGS="" \
 		HOST_CC="$(tc-getBUILD_CC)" \
+		HOST_CFLAGS="${BUILD_CPPFLAGS} ${BUILD_CFLAGS}" \
+		HOST_LDFLAGS="${BUILD_LDFLAGS}" \
 		STATIC_CC="$(tc-getCC)" \
 		DYNAMIC_CC="$(tc-getCC) -fPIC" \
 		TARGET_LD="$(tc-getCC)" \
+		TARGET_CFLAGS="${CPPFLAGS} ${CFLAGS}" \
+		TARGET_LDFLAGS="${LDFLAGS}" \
 		TARGET_AR="$(tc-getAR) rcus" \
 		BUILDMODE="$(usex static-libs mixed dynamic)" \
 		TARGET_STRIP="true" \
@@ -50,6 +56,7 @@ _emake() {
 }
 
 src_compile() {
+	tc-export_build_env
 	_emake XCFLAGS="$(usex lua52compat "-DLUAJIT_ENABLE_LUA52COMPAT" "")"
 }
 


### PR DESCRIPTION
luajit passes CFLAGS/LDFLAGS to both host and target builds.
This breaks when the host cpu does not support the target flags
e.g. using march=bdver4 in CFLAGS when cross-compiling for AMD
on an Intel host.

Instead pass the flags in {HOST|TARGET}-{CFLAGS|LDFLAGS} which is
supported by luajit
(https://github.com/LuaJIT/LuaJIT/blob/master/doc/install.html#L607).

Signed-off-by: Manoj Gupta <manojgupta@google.com>