### PR TITLE
x11-misc/lightdm: use upstream lightdm-greeter pam config

### DIFF
--- a/x11-misc/lightdm/files/lightdm-1.28.0-pam-greeter.patch
+++ b/x11-misc/lightdm/files/lightdm-1.28.0-pam-greeter.patch
@@ -1,0 +1,10 @@
+--- a/data/pam/lightdm-greeter
++++ b/data/pam/lightdm-greeter
+@@ -14,4 +14,6 @@ password  required pam_deny.so
+ 
+ # Setup session
+ session   required pam_unix.so
+-session   optional pam_systemd.so
++-session  optional pam_systemd.so
++-session  optional pam_elogind.so
++-session  optional pam_ck_connector.so nox11

--- a/x11-misc/lightdm/lightdm-1.28.0-r1.ebuild
+++ b/x11-misc/lightdm/lightdm-1.28.0-r1.ebuild
@@ -1,0 +1,144 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools flag-o-matic pam qmake-utils readme.gentoo-r1 systemd vala xdg-utils
+
+DESCRIPTION="A lightweight display manager"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/LightDM"
+SRC_URI="https://github.com/CanonicalLtd/lightdm/releases/download/${PV}/${P}.tar.xz
+	mirror://gentoo/introspection-20110205.m4.tar.bz2"
+
+LICENSE="GPL-3 LGPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+IUSE="audit +gnome +gtk +introspection qt5 vala"
+
+COMMON_DEPEND="
+	>=dev-libs/glib-2.44.0:2
+	dev-libs/libxml2
+	virtual/pam
+	x11-libs/libX11
+	>=x11-libs/libxklavier-5
+	audit? ( sys-process/audit )
+	gnome? ( sys-apps/accountsservice )
+	introspection? ( >=dev-libs/gobject-introspection-1 )
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtdbus:5
+		dev-qt/qtgui:5
+	)
+"
+RDEPEND="${COMMON_DEPEND}
+	>=sys-auth/pambase-20101024-r2"
+DEPEND="${COMMON_DEPEND}
+	dev-util/gtk-doc-am
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig
+	gnome? ( gnome-base/gnome-common )
+	vala? ( $(vala_depend) )
+"
+PDEPEND="gtk? ( x11-misc/lightdm-gtk-greeter )"
+
+DOCS=( NEWS )
+RESTRICT="test"
+
+PATCHES=( "${FILESDIR}"/${PN}-1.28.0-pam-greeter.patch )
+
+src_prepare() {
+	xdg_environment_reset
+
+	sed -i -e 's:getgroups:lightdm_&:' tests/src/libsystem.c || die #412369
+	sed -i -e '/minimum-uid/s:500:1000:' data/users.conf || die
+
+	einfo "Fixing the session-wrapper variable in lightdm.conf"
+	sed -i -e \
+		"/^#session-wrapper/s@^.*@session-wrapper=/etc/${PN}/Xsession@" \
+		data/lightdm.conf || die "Failed to fix lightdm.conf"
+
+	# use correct version of qmake. bug #566950
+	sed \
+		-e "/AC_CHECK_TOOLS(MOC5/a AC_SUBST(MOC5,$(qt5_get_bindir)/moc)" \
+		-i configure.ac || die
+
+	default
+
+	# Remove bogus Makefile statement. This needs to go upstream
+	sed -i /"@YELP_HELP_RULES@"/d help/Makefile.am || die
+	if has_version dev-libs/gobject-introspection; then
+		eautoreconf
+	else
+		AT_M4DIR=${WORKDIR} eautoreconf
+	fi
+
+	use vala && vala_src_prepare
+}
+
+src_configure() {
+	# Set default values if global vars unset
+	local _greeter _session _user
+	_greeter=${LIGHTDM_GREETER:=lightdm-gtk-greeter}
+	_session=${LIGHTDM_SESSION:=gnome}
+	_user=${LIGHTDM_USER:=root}
+	# Let user know how lightdm is configured
+	einfo "Gentoo configuration"
+	einfo "Default greeter: ${_greeter}"
+	einfo "Default session: ${_session}"
+	einfo "Greeter user: ${_user}"
+
+	use qt5 && append-cxxflags -std=c++11
+
+	# also disable tests because libsystem.c does not build. Tests are
+	# restricted so it does not matter anyway.
+	local myeconfargs=(
+		--localstatedir=/var
+		--disable-static
+		--disable-tests
+		$(use_enable audit libaudit)
+		$(use_enable introspection)
+		--disable-liblightdm-qt
+		$(use_enable qt5 liblightdm-qt5)
+		$(use_enable vala)
+		--with-user-session=${_session}
+		--with-greeter-session=${_greeter}
+		--with-greeter-user=${_user}
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	# Delete apparmor profiles because they only work with Ubuntu's
+	# apparmor package. Bug #494426
+	if [[ -d ${ED%/}/etc/apparmor.d ]]; then
+		rm -r "${ED%/}/etc/apparmor.d" || die \
+			"Failed to remove apparmor profiles"
+	fi
+
+	insinto /etc/${PN}
+	doins data/{${PN},keys}.conf
+	doins "${FILESDIR}"/Xsession
+	fperms +x /etc/${PN}/Xsession
+	# /var/lib/lightdm-data could be useful. Bug #522228
+	dodir /var/lib/lightdm-data
+
+	find "${ED}" \( -name '*.a' -o -name "*.la" \) -delete || die
+	rm -rf "${ED%/}"/etc/init
+
+	# Remove existing pam file. We will build a new one. Bug #524792
+	rm -rf "${ED%/}"/etc/pam.d/${PN}
+	pamd_mimic system-local-login ${PN} auth account password session #372229
+	dopamd "${FILESDIR}"/${PN}-autologin #390863, #423163
+
+	readme.gentoo_create_doc
+
+	systemd_dounit "${FILESDIR}/${PN}.service"
+	keepdir /var/lib/${PN}-data
+}
+
+pkg_postinst() {
+	systemd_reenable "${PN}.service"
+}


### PR DESCRIPTION
This pam configuration file is only used by the greeter process.
Therefore is should't include system-local-login.

Closes: https://bugs.gentoo.org/600216
Package-Manager: Portage-2.3.49, Repoman-2.3.10


```
$ diff -u lightdm-1.28.0{,-r1}.ebuild 
--- lightdm-1.28.0.ebuild       2018-09-03 17:12:47.143097601 +0300
+++ lightdm-1.28.0-r1.ebuild    2018-09-26 15:32:30.149684983 +0300
@@ -45,6 +45,8 @@
 DOCS=( NEWS )
 RESTRICT="test"
 
+PATCHES=( "${FILESDIR}"/${PN}-1.28.0-pam-greeter.patch )
+
 src_prepare() {
        xdg_environment_reset
 
@@ -127,9 +129,8 @@
        rm -rf "${ED%/}"/etc/init
 
        # Remove existing pam file. We will build a new one. Bug #524792
-       rm -rf "${ED%/}"/etc/pam.d/${PN}{,-greeter}
+       rm -rf "${ED%/}"/etc/pam.d/${PN}
        pamd_mimic system-local-login ${PN} auth account password session #372229
-       pamd_mimic system-local-login ${PN}-greeter auth account password session #372229
        dopamd "${FILESDIR}"/${PN}-autologin #390863, #423163
 
        readme.gentoo_create_doc
```