### PR TITLE
sys-devel/clang: fix path for clang-tblgen to allow cross-compile with cross-emerge, part of #667094 [do not merge]

### DIFF
--- a/sys-devel/clang/clang-4.0.1.ebuild
+++ b/sys-devel/clang/clang-4.0.1.ebuild
@@ -171,11 +171,12 @@ multilib_src_configure() {
 	fi
 
 	if tc-is-cross-compiler; then
-		[[ -x "/usr/bin/clang-tblgen" ]] \
-			|| die "/usr/bin/clang-tblgen not found or usable"
+		local tblgen="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/clang-tblgen"
+		[[ -x "${tblgen}" ]] \
+			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=ON
-			-DCLANG_TABLEGEN=/usr/bin/clang-tblgen
+			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi
 

--- a/sys-devel/clang/clang-4.0.1.ebuild
+++ b/sys-devel/clang/clang-4.0.1.ebuild
@@ -181,6 +181,7 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
+			-DLLVM_CONFIG="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/llvm-config"
 		)
 	fi
 

--- a/sys-devel/clang/clang-4.0.1.ebuild
+++ b/sys-devel/clang/clang-4.0.1.ebuild
@@ -179,7 +179,7 @@ multilib_src_configure() {
 		[[ -x "${tblgen}" ]] \
 			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
-			-DCMAKE_CROSSCOMPILING=ON
+			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi

--- a/sys-devel/clang/clang-4.0.1.ebuild
+++ b/sys-devel/clang/clang-4.0.1.ebuild
@@ -98,6 +98,10 @@ src_prepare() {
 	# (backport, temporary reverted upstream because of FreeBSD issues)
 	eapply "${FILESDIR}"/4.0.1/0001-Frontend-Correct-values-of-ATOMIC_-_LOCK_FREE-to-mat.patch
 
+	# add tblgen for cross compile
+	# https://bugs.gentoo.org/667094
+	"${FILESDIR}"/fix-tblgen.patch
+
 	cd tools/extra || die
 	# fix stand-alone test build for extra tools
 	eapply "${FILESDIR}"/4.0.1/extra/0001-test-Fix-test-dependencies-when-using-installed-tool.patch

--- a/sys-devel/clang/clang-5.0.2.ebuild
+++ b/sys-devel/clang/clang-5.0.2.ebuild
@@ -198,7 +198,7 @@ multilib_src_configure() {
 		[[ -x "${tblgen}" ]] \
 			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
-			-DCMAKE_CROSSCOMPILING=ON
+			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi

--- a/sys-devel/clang/clang-5.0.2.ebuild
+++ b/sys-devel/clang/clang-5.0.2.ebuild
@@ -113,6 +113,10 @@ src_prepare() {
 	# add Prefix include paths for Darwin
 	eapply "${FILESDIR}"/6.0.1/darwin_prefix-include-paths.patch
 
+	# add tblgen for cross compile
+	# https://bugs.gentoo.org/667094
+	"${FILESDIR}"/fix-tblgen.patch
+
 	cd tools/extra || die
 	# fix setting LD_LIBRARY_PATH for tests on *BSD (extra part)
 	eapply "${FILESDIR}"/5.0.2/extra/0001-Assume-the-shared-library-path-variable-is-LD_LIBRAR.patch

--- a/sys-devel/clang/clang-5.0.2.ebuild
+++ b/sys-devel/clang/clang-5.0.2.ebuild
@@ -190,11 +190,12 @@ multilib_src_configure() {
 	fi
 
 	if tc-is-cross-compiler; then
-		[[ -x "/usr/bin/clang-tblgen" ]] \
-			|| die "/usr/bin/clang-tblgen not found or usable"
+		local tblgen="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/clang-tblgen"
+		[[ -x "${tblgen}" ]] \
+			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=ON
-			-DCLANG_TABLEGEN=/usr/bin/clang-tblgen
+			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi
 

--- a/sys-devel/clang/clang-5.0.2.ebuild
+++ b/sys-devel/clang/clang-5.0.2.ebuild
@@ -200,6 +200,7 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
+			-DLLVM_CONFIG="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/llvm-config"
 		)
 	fi
 

--- a/sys-devel/clang/clang-6.0.1.ebuild
+++ b/sys-devel/clang/clang-6.0.1.ebuild
@@ -201,6 +201,7 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
+			-DLLVM_CONFIG="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/llvm-config"
 		)
 	fi
 

--- a/sys-devel/clang/clang-6.0.1.ebuild
+++ b/sys-devel/clang/clang-6.0.1.ebuild
@@ -75,6 +75,10 @@ PATCHES=(
 	# fix test failure with default-compiler-rt
 	# https://bugs.gentoo.org/650316
 	"${FILESDIR}"/6.0.1/0002-test-Fix-Cross-DSO-CFI-Android-sanitizer-test-for-rt.patch
+
+	# add tblgen for cross compile
+	# https://bugs.gentoo.org/667094
+	"${FILESDIR}"/fix-tblgen.patch
 )
 
 # Multilib notes:

--- a/sys-devel/clang/clang-6.0.1.ebuild
+++ b/sys-devel/clang/clang-6.0.1.ebuild
@@ -191,11 +191,12 @@ multilib_src_configure() {
 	fi
 
 	if tc-is-cross-compiler; then
-		[[ -x "/usr/bin/clang-tblgen" ]] \
-			|| die "/usr/bin/clang-tblgen not found or usable"
+		local tblgen="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/clang-tblgen"
+		[[ -x "${tblgen}" ]] \
+			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=ON
-			-DCLANG_TABLEGEN=/usr/bin/clang-tblgen
+			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi
 

--- a/sys-devel/clang/clang-6.0.1.ebuild
+++ b/sys-devel/clang/clang-6.0.1.ebuild
@@ -199,7 +199,7 @@ multilib_src_configure() {
 		[[ -x "${tblgen}" ]] \
 			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
-			-DCMAKE_CROSSCOMPILING=ON
+			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi

--- a/sys-devel/clang/clang-7.0.0.ebuild
+++ b/sys-devel/clang/clang-7.0.0.ebuild
@@ -198,6 +198,7 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
+			-DLLVM_CONFIG="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/llvm-config"
 		)
 	fi
 

--- a/sys-devel/clang/clang-7.0.0.ebuild
+++ b/sys-devel/clang/clang-7.0.0.ebuild
@@ -188,11 +188,12 @@ multilib_src_configure() {
 	fi
 
 	if tc-is-cross-compiler; then
-		[[ -x "/usr/bin/clang-tblgen" ]] \
-			|| die "/usr/bin/clang-tblgen not found or usable"
+		local tblgen="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/clang-tblgen"
+		[[ -x "${tblgen}" ]] \
+			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=ON
-			-DCLANG_TABLEGEN=/usr/bin/clang-tblgen
+			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi
 

--- a/sys-devel/clang/clang-7.0.0.ebuild
+++ b/sys-devel/clang/clang-7.0.0.ebuild
@@ -71,6 +71,10 @@ CMAKE_BUILD_TYPE=RelWithDebInfo
 PATCHES=(
 	# add Prefix include paths for Darwin
 	"${FILESDIR}"/6.0.1/darwin_prefix-include-paths.patch
+
+	# add tblgen for cross compile
+	# https://bugs.gentoo.org/667094
+	"${FILESDIR}"/fix-tblgen.patch
 )
 
 # Multilib notes:

--- a/sys-devel/clang/clang-7.0.0.ebuild
+++ b/sys-devel/clang/clang-7.0.0.ebuild
@@ -196,7 +196,7 @@ multilib_src_configure() {
 		[[ -x "${tblgen}" ]] \
 			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
-			-DCMAKE_CROSSCOMPILING=ON
+			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi

--- a/sys-devel/clang/clang-7.0.9999.ebuild
+++ b/sys-devel/clang/clang-7.0.9999.ebuild
@@ -173,11 +173,12 @@ multilib_src_configure() {
 	fi
 
 	if tc-is-cross-compiler; then
-		[[ -x "/usr/bin/clang-tblgen" ]] \
-			|| die "/usr/bin/clang-tblgen not found or usable"
+		local tblgen="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/clang-tblgen"
+		[[ -x "${tblgen}" ]] \
+			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=ON
-			-DCLANG_TABLEGEN=/usr/bin/clang-tblgen
+			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi
 

--- a/sys-devel/clang/clang-7.0.9999.ebuild
+++ b/sys-devel/clang/clang-7.0.9999.ebuild
@@ -64,6 +64,12 @@ S=${WORKDIR}/x/y/${P}
 # least intrusive of all
 CMAKE_BUILD_TYPE=RelWithDebInfo
 
+PATCHES=(
+	# add tblgen for cross compile
+	# https://bugs.gentoo.org/667094
+	"${FILESDIR}"/fix-tblgen.patch
+)
+
 # Multilib notes:
 # 1. ABI_* flags control ABIs libclang* is built for only.
 # 2. clang is always capable of compiling code for all ABIs for enabled

--- a/sys-devel/clang/clang-7.0.9999.ebuild
+++ b/sys-devel/clang/clang-7.0.9999.ebuild
@@ -185,6 +185,7 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
+			-DLLVM_CONFIG="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/llvm-config"
 		)
 	fi
 

--- a/sys-devel/clang/clang-7.0.9999.ebuild
+++ b/sys-devel/clang/clang-7.0.9999.ebuild
@@ -183,7 +183,7 @@ multilib_src_configure() {
 		[[ -x "${tblgen}" ]] \
 			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
-			-DCMAKE_CROSSCOMPILING=ON
+			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi

--- a/sys-devel/clang/clang-9999.ebuild
+++ b/sys-devel/clang/clang-9999.ebuild
@@ -174,11 +174,12 @@ multilib_src_configure() {
 	fi
 
 	if tc-is-cross-compiler; then
-		[[ -x "/usr/bin/clang-tblgen" ]] \
-			|| die "/usr/bin/clang-tblgen not found or usable"
+		local tblgen="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/clang-tblgen"
+		[[ -x "${tblgen}" ]] \
+			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=ON
-			-DCLANG_TABLEGEN=/usr/bin/clang-tblgen
+			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi
 

--- a/sys-devel/clang/clang-9999.ebuild
+++ b/sys-devel/clang/clang-9999.ebuild
@@ -186,6 +186,7 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
+			-DLLVM_CONFIG="${EPREFIX}/usr/lib/llvm/${SLOT}/bin/llvm-config"
 		)
 	fi
 

--- a/sys-devel/clang/clang-9999.ebuild
+++ b/sys-devel/clang/clang-9999.ebuild
@@ -65,6 +65,12 @@ S=${WORKDIR}/x/y/${P}
 # least intrusive of all
 CMAKE_BUILD_TYPE=RelWithDebInfo
 
+PATCHES=(
+	# add tblgen for cross compile
+	# https://bugs.gentoo.org/667094
+	"${FILESDIR}"/fix-tblgen.patch
+)
+
 # Multilib notes:
 # 1. ABI_* flags control ABIs libclang* is built for only.
 # 2. clang is always capable of compiling code for all ABIs for enabled

--- a/sys-devel/clang/clang-9999.ebuild
+++ b/sys-devel/clang/clang-9999.ebuild
@@ -184,7 +184,7 @@ multilib_src_configure() {
 		[[ -x "${tblgen}" ]] \
 			|| die "${tblgen} not found or usable"
 		mycmakeargs+=(
-			-DCMAKE_CROSSCOMPILING=ON
+			-DCMAKE_CROSSCOMPILING=True
 			-DLLVM_TABLEGEN="${tblgen}"
 		)
 	fi

--- a/sys-devel/clang/files/fix-tblgen.patch
+++ b/sys-devel/clang/files/fix-tblgen.patch
@@ -1,0 +1,17 @@
+diff --git a/utils/TableGen/CMakeLists.txt b/utils/TableGen/CMakeLists.txt
+index dba0c94..5428683 100644
+--- a/utils/TableGen/CMakeLists.txt
++++ b/utils/TableGen/CMakeLists.txt
+@@ -13,4 +13,12 @@ add_tablegen(clang-tblgen CLANG
+   NeonEmitter.cpp
+   TableGen.cpp
+   )
++
++if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
++    install(TARGETS clang-tblgen
++	    EXPORT ClangTargets
++            RUNTIME DESTINATION bin)
++endif()
++set_property(GLOBAL APPEND PROPERTY CLANG_EXPORTS clang-tblgen)
++
+ set_target_properties(clang-tblgen PROPERTIES FOLDER "Clang tablegenning")


### PR DESCRIPTION
@mgorny 

emerge-armv6j-unknown-linux-gnueabihf -av clang:6 must fail, because clang-tblgen would be installed into `/usr/lib/llvm/6/bin/` and not into `/usr/bin` as it propably was with < sys-devel/clang-4 

- [ ] clang-tblgen is compiled on the hosts side, but not installed during src_install. fix that with fix-tblgen.patch for all >=clang-4 

- [ ] clang-tblgen cannot be found when tc-is-cross-compiler, as it assumes it to be in `/usr/bin` and not /`usr/lib/llvm/6/bin/`

asking for feedback mostly, cc-ing @chewi as mgorny told me you're doing a lot of cross compiling. 