### PR TITLE
dev-python/python-evdev: specify header locations

### DIFF
--- a/dev-python/python-evdev/python-evdev-0.7.0-r1.ebuild
+++ b/dev-python/python-evdev/python-evdev-0.7.0-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 inherit distutils-r1
@@ -16,3 +16,9 @@ KEYWORDS="~amd64 ~arm ~x86"
 IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+
+python_compile() {
+	distutils-r1_python_compile build_ecodes \
+		--evdev-headers \
+		"${SYSROOT}"/usr/include/linux/input.h:"${SYSROOT}"/usr/include/linux/input-event-codes.h
+}


### PR DESCRIPTION
setup.py hardcodes /usr/include/linux/... paths. This doesn't work if
cross-compiling or otherwise using a different $ROOT with a different
set of headers, as the setup stage might pick up one set of headers,
while the compilation might pick up another.

Fortunately, setup.py supports an --evdev-headers arg so we can fix
this. Let's use it.

Signed-off-by: Brian Norris <briannorris@chromium.org>