### PR TITLE
app-editors/gummi: add runtime dependencies

### DIFF
--- a/app-editors/gummi/gummi-0.6.6-r1.ebuild
+++ b/app-editors/gummi/gummi-0.6.6-r1.ebuild
@@ -15,16 +15,16 @@ KEYWORDS="amd64 ~arm64 x86"
 IUSE=""
 
 RDEPEND="
+	app-text/gtkspell:2
+	app-text/poppler[cairo]
 	dev-libs/glib:2
 	dev-texlive/texlive-latex
 	dev-texlive/texlive-latexextra
-	x11-libs/gtk+:2"
-
-DEPEND="${RDEPEND}
-	app-text/gtkspell:2
-	app-text/poppler[cairo]
+	x11-libs/gtk+:2
 	x11-libs/gtksourceview:2.0
 	x11-libs/pango"
+
+DEPEND="${RDEPEND}"
 
 src_prepare() {
 	default


### PR DESCRIPTION
Gummi is using gtkspell, poppler, gtksourceview and pango at runtime, not only at compilation. These need to be in RDEPEND.

Closes: https://bugs.gentoo.org/666794