### PR TITLE
eclass/mozcoreconf: fix linker flags

### DIFF
--- a/eclass/mozcoreconf-v6.eclass
+++ b/eclass/mozcoreconf-v6.eclass
@@ -210,9 +210,7 @@ mozconfig_init() {
 	case "${ARCH}" in
 	arm)
 		# Reduce the memory requirements for linking
-		if tc-ld-is-bfd
-		append-ldflags -Wl,--no-keep-memory -Wl,--reduce-memory-overheads
-		else tc-ld-is-gold
+		if tc-ld-is-gold
 		append-ldflags -Wl,--no-keep-memory
 		fi
 		;;
@@ -229,11 +227,7 @@ mozconfig_init() {
 	ppc64)
 		append-flags -fPIC -mminimal-toc
 		# Reduce the memory requirements for linking
-		if tc-ld-is-bfd
 		append-ldflags -Wl,--no-keep-memory -Wl,--reduce-memory-overheads
-		else tc-ld-is-gold
-		append-ldflags -Wl,--no-keep-memory
-		fi
 		;;
 	esac
 

--- a/eclass/mozcoreconf-v6.eclass
+++ b/eclass/mozcoreconf-v6.eclass
@@ -210,7 +210,11 @@ mozconfig_init() {
 	case "${ARCH}" in
 	arm)
 		# Reduce the memory requirements for linking
+		if tc-ld-is-bfd
 		append-ldflags -Wl,--no-keep-memory -Wl,--reduce-memory-overheads
+		else tc-ld-is-gold
+		append-ldflags -Wl,--no-keep-memory
+		fi
 		;;
 	alpha)
 		# Historically we have needed to add -fPIC manually for 64-bit.

--- a/eclass/mozcoreconf-v6.eclass
+++ b/eclass/mozcoreconf-v6.eclass
@@ -229,7 +229,11 @@ mozconfig_init() {
 	ppc64)
 		append-flags -fPIC -mminimal-toc
 		# Reduce the memory requirements for linking
+		if tc-ld-is-bfd
 		append-ldflags -Wl,--no-keep-memory -Wl,--reduce-memory-overheads
+		else tc-ld-is-gold
+		append-ldflags -Wl,--no-keep-memory
+		fi
 		;;
 	esac
 


### PR DESCRIPTION
This gives arm and ppc64 users the ability to use gold linker. 

todo: fix lld, if needed