### PR TITLE
dev-libs/ucommon: Fix building with GCC-7 and GCC8

### DIFF
--- a/dev-libs/ucommon/files/ucommon-6.5.7-gcc7.patch
+++ b/dev-libs/ucommon/files/ucommon-6.5.7-gcc7.patch
@@ -1,0 +1,53 @@
+Bug: https://bugs.gentoo.org/638252
+
+--- a/inc/ucommon/linked.h
++++ b/inc/ucommon/linked.h
+@@ -1992,7 +1992,7 @@
+      * @return pointer to index root.
+      */
+     inline NamedObject **root(void) {
+-        return static_cast<NamedObject**>(&head);
++        return reinterpret_cast<NamedObject**>(&head);
+     }
+
+     /**
+--- a/inc/ucommon/memory.h
++++ b/inc/ucommon/memory.h
+@@ -1228,7 +1228,7 @@
+      * inherit keyassoc privately.
+      * @return pager utilization, 0-100.
+      */
+-    inline unsigned utilization(void) const
++    inline unsigned utilization(void)
+         {return mempager::utilization();}
+ 
+     /**
+@@ -1322,7 +1322,7 @@
+      * inherit keyassoc privately.
+      * @return pager utilization, 0-100.
+      */
+-    inline unsigned utilization(void) const
++    inline unsigned utilization(void)
+         {return mempager::utilization();}
+ 
+     /**
+@@ -1396,7 +1396,7 @@
+      * @param name to search for.
+      * @return typed object if found through map or NULL.
+      */
+-    inline T *get(const char *name) const {
++    inline T *get(const char *name) {
+         T *node = (static_cast<T*>(NamedObject::map(idx, name, M)));
+         if(!node) {
+             node = init<T>(static_cast<T*>(mempager::_alloc(sizeof(T))));
+--- a/inc/ucommon/object.h
++++ b/inc/ucommon/object.h
+@@ -301,7 +301,7 @@
+         return reference_cast<T>(get(offset));
+     }
+ 
+-    inline const T* at(unsigned offset) const {
++    inline const T* at(unsigned offset) {
+         return immutable_cast<T*>(SparseObjects::get(offset));
+     }
+ 

--- a/dev-libs/ucommon/ucommon-6.5.7.ebuild
+++ b/dev-libs/ucommon/ucommon-6.5.7.ebuild
@@ -36,6 +36,7 @@ DOCS=(README NEWS SUPPORT ChangeLog AUTHORS)
 PATCHES=(
 	"${FILESDIR}/${PN}-6.0.3-install_gcrypt.m4_file.patch"
 	"${FILESDIR}/${PN}-6.3.1-gcrypt_autotools.patch"
+	"${FILESDIR}/${PN}-6.5.7-gcc7.patch"
 )
 
 # Needed for doxygen, bug #526726


### PR DESCRIPTION
Signed-off-by: Peter Levine <plevine457@gmail.com>
Closes: https://bugs.gentoo.org/638252
Package-Manager: Portage-2.3.49, Repoman-2.3.10

Most of the errors are a result of overload resolution failure caused by a const qualified method trying to call a non-const qualified, inherited method.  One way to resolve it is to remove const qualification from the calling method.  The other is to add const qualification to the called method.  Attempting to add const qualification, in the latter case, resulted in many more failures as many other parts of the code were dependent on the non-const method.  Removing the const qualification, in the former case, resulted in build success.

Also, for GCC-8, `static_cast` cannot be used to cast a pointer of a pointer of an object to a pointer of a pointer of a different object.  `reinterpret_cast` works fine though.

Note: I initially attempted to make an EAPI 7 build, changing dependence on `autotools-utils.eclass` to `autotools.eclass`, but any EAPI above 5 causes the `aclocal -I m4` command in `eaclocal` to fail for some unknown reason.