### PR TITLE
games-simulation/openrct2: update-website

### DIFF
--- a/games-simulation/openrct2/openrct2-0.2.0.ebuild
+++ b/games-simulation/openrct2/openrct2-0.2.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils gnome2-utils xdg-utils
 
 DESCRIPTION="An open source re-implementation of RollerCoaster Tycoon 2"
-HOMEPAGE="https://openrct2.website/"
+HOMEPAGE="https://openrct2.org/"
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/OpenRCT2/OpenRCT2.git"
 	EGIT_BRANCH="develop"

--- a/games-simulation/openrct2/openrct2-9999.ebuild
+++ b/games-simulation/openrct2/openrct2-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit cmake-utils gnome2-utils xdg-utils
 
 DESCRIPTION="An open source re-implementation of RollerCoaster Tycoon 2"
-HOMEPAGE="https://openrct2.website/"
+HOMEPAGE="https://openrct2.org/"
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/OpenRCT2/OpenRCT2.git"
 	EGIT_BRANCH="develop"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/667134
Reported-by: Daniel M. Weeks <dan@danweeks.net>
Signed-off-by: Hendrik v. Raven <hendrik@consetetur.de>
Package-Manager: Portage-2.3.38, Repoman-2.3.9