### PR TITLE
dev-db/mydumper: replace virtual/mysql dependency

### DIFF
--- a/dev-db/mydumper/mydumper-0.9.5-r1.ebuild
+++ b/dev-db/mydumper/mydumper-0.9.5-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit cmake-utils
+
+DESCRIPTION="A high-performance multi-threaded backup (and restore) toolset for MySQL"
+HOMEPAGE="https://github.com/maxbube/mydumper"
+SRC_URI="https://github.com/maxbube/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc"
+
+COMMON_DEPEND="dev-db/mysql-connector-c:=
+	dev-libs/glib:=
+	dev-libs/libpcre:=
+	dev-libs/openssl:=
+	sys-libs/zlib:="
+DEPEND="${COMMON_DEPEND}
+	virtual/pkgconfig
+	doc? ( dev-python/sphinx )"
+RDEPEND="${COMMON_DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-atomic.patch" #654314
+)
+
+src_prepare() {
+	# respect user cflags; do not expand ${CMAKE_C_FLAGS} (!)
+	sed -i -e 's:-Werror -O3 -g:${CMAKE_C_FLAGS}:' CMakeLists.txt || die
+
+	# fix doc install path
+	sed -i -e "s:share/doc/mydumper:share/doc/${PF}:" docs/CMakeLists.txt || die
+
+	cmake-utils_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=("-DBUILD_DOCS=$(usex doc)")
+
+	cmake-utils_src_configure
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/665844
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>
Package-Manager: Portage-2.3.50, Repoman-2.3.11

````
--- mydumper-0.9.5.ebuild       2018-05-24 12:40:35.079204613 +0200
+++ mydumper-0.9.5-r1.ebuild    2018-09-28 12:30:23.665947775 +0200
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,11 +13,11 @@
 KEYWORDS="~amd64 ~x86"
 IUSE="doc"
 
-CDEPEND="dev-libs/glib:=
+CDEPEND="dev-db/mysql-connector-c:=
+       dev-libs/glib:=
        dev-libs/libpcre:=
        dev-libs/openssl:=
-       sys-libs/zlib:=
-       virtual/mysql"
+       sys-libs/zlib:="
 DEPEND="${CDEPEND}
        virtual/pkgconfig
        doc? ( dev-python/sphinx )"
````