### PR TITLE
app-benchmarks/stress: bump to EAPI=7

### DIFF
--- a/app-benchmarks/stress/metadata.xml
+++ b/app-benchmarks/stress/metadata.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>ck+gentoo@bl4ckb0x.de</email>
+		<name>Conrad Kostecki</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<longdescription>
+		Stress is a deliberately simple workload generator for POSIX systems.
+		It imposes a configurable amount of CPU, memory, I/O, and disk stress on the system.
+	</longdescription>
 </pkgmetadata>

--- a/app-benchmarks/stress/stress-1.0.4-r2.ebuild
+++ b/app-benchmarks/stress/stress-1.0.4-r2.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+DESCRIPTION="A deliberately simple workload generator for POSIX systems"
+HOMEPAGE="https://people.seas.harvard.edu/~apw/stress"
+SRC_URI="https://people.seas.harvard.edu/~apw/${PN}/${P}.tar.gz -> ${P}-r1.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="static"
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable static)
+	)
+
+	econf "${myeconfargs[@]}"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/667192
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>
Package-Manager: Portage-2.3.49, Repoman-2.3.10