### PR TITLE
media-libs/liblscp: EAPI7 revbump, improve ebuild

### DIFF
--- a/media-libs/liblscp/liblscp-0.5.8-r1.ebuild
+++ b/media-libs/liblscp/liblscp-0.5.8-r1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="C++ library for the Linux Sampler control protocol"
+HOMEPAGE="https://www.linuxsampler.org"
+SRC_URI="https://download.linuxsampler.org/packages/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="doc"
+
+DEPEND="doc? ( app-doc/doxygen )"
+
+DOCS=( AUTHORS ChangeLog TODO NEWS README )
+
+src_install() {
+	use doc && local HTML_DOCS=( doc/html/. )
+	default
+}


### PR DESCRIPTION
Hi,

This PR updates media-libs/liblscp for EAPI7.
Please review.

Closes: https://bugs.gentoo.org/667302
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>