### PR TITLE
fix media-libs/opusfile-0.11 install inside prefix

### DIFF
--- a/media-libs/opusfile/opusfile-0.11.ebuild
+++ b/media-libs/opusfile/opusfile-0.11.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="^^ ( fixed-point float )"
 
 src_configure() {
 	local myeconfargs=(
-		--docdir=/usr/share/doc/${PF}
+		--docdir="${EPREFIX}/usr/share/doc/${PF}"
 		$(use_enable doc)
 		$(use_enable fixed-point)\
 		$(use_enable float)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/667332

Package-Manager: portage-2.3.50-r3, repoman-2.3.11