### PR TITLE
app-admin/chroot_safe: EAPI7 revbump, improve ebuild

### DIFF
--- a/app-admin/chroot_safe/chroot_safe-1.4-r1.ebuild
+++ b/app-admin/chroot_safe/chroot_safe-1.4-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Chroot any dynamically linked application in a safe and sane manner"
+HOMEPAGE="http://chrootsafe.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN//_}/${P}.tgz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=( "${FILESDIR}"/${P}-ldflags.patch )
+
+src_configure() {
+	econf --libexecdir="${EPREFIX}/usr/$(get_libdir)"
+}
+
+src_compile() {
+	emake CPPFLAGS="${CXXFLAGS}" CXX="$(tc-getCXX)"
+}
+
+src_install() {
+	dolib.so chroot_safe.so
+	dosbin chroot_safe
+	sed -i -e "s:/chroot_safe::" "${ED}"/usr/sbin/chroot_safe \
+		|| die "sed chroot_safe failed"
+	doman chroot_safe.1
+	dodoc CHANGES.txt
+}


### PR DESCRIPTION
Hi,

This PR/bug updates app-admin/chroot_safe for EAPI7.
Please review.

```diff
--- chroot_safe-1.4.ebuild      2017-03-19 10:57:10.406786397 +0100
+++ chroot_safe-1.4-r1.ebuild   2018-09-30 13:33:10.074436494 +0200
@@ -1,21 +1,19 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
-inherit eutils multilib
+EAPI=7
 
-DESCRIPTION="a tool to chroot any dynamically linked application in a safe and sane manner"
+inherit toolchain-funcs
+
+DESCRIPTION="Chroot any dynamically linked application in a safe and sane manner"
 HOMEPAGE="http://chrootsafe.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN//_}/${P}.tgz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ppc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
 
-src_prepare() {
-       epatch "${FILESDIR}"/${P}-ldflags.patch
-}
+PATCHES=( "${FILESDIR}"/${P}-ldflags.patch )
 
 src_configure() {
        econf --libexecdir="${EPREFIX}/usr/$(get_libdir)"
```

Closes: https://bugs.gentoo.org/667358
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>