### PR TITLE
dev-lang/mono-basic: restrict tests

### DIFF
--- a/dev-lang/mono-basic/mono-basic-4.6-r2.ebuild
+++ b/dev-lang/mono-basic/mono-basic-4.6-r2.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit mono-env
+
+DESCRIPTION="Visual Basic Compiler and Runtime"
+HOMEPAGE="https://www.mono-project.com/docs/about-mono/languages/visualbasic/"
+
+KEYWORDS="~amd64 ~x86"
+LICENSE="LGPL-2 MIT"
+SLOT="0"
+
+RDEPEND="dev-lang/mono"
+DEPEND="${RDEPEND}"
+
+RESTRICT="test"

--- a/dev-lang/mono-basic/mono-basic-4.7-r1.ebuild
+++ b/dev-lang/mono-basic/mono-basic-4.7-r1.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit mono-env
+
+DESCRIPTION="Visual Basic Compiler and Runtime"
+HOMEPAGE="https://www.mono-project.com/docs/about-mono/languages/visualbasic/"
+
+KEYWORDS="~amd64 ~x86"
+LICENSE="LGPL-2 MIT"
+SLOT="0"
+
+RDEPEND="dev-lang/mono"
+DEPEND="${RDEPEND}"
+
+RESTRICT="test"


### PR DESCRIPTION
Tests do need internet access, so network-sandbox must be disabled.
But tests also seems to fail. No response from upstream.

Also bumped to EAPI="7".

Closes: https://bugs.gentoo.org/656682
Closes: https://bugs.gentoo.org/655900
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>
Package-Manager: Portage-2.3.50, Repoman-2.3.11