### PR TITLE
app-text/html2text: EAPI7 revbump, improve ebuild

### DIFF
--- a/app-text/html2text/html2text-1.3.2a-r2.ebuild
+++ b/app-text/html2text/html2text-1.3.2a-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="HTML to text converter"
+HOMEPAGE="http://www.mbayer.de/html2text/"
+SRC_URI="http://www.mbayer.de/html2text/downloads/${P}.tar.gz
+	http://www.mbayer.de/html2text/downloads/patch-utf8-${P}.diff
+	http://www.mbayer.de/html2text/downloads/patch-amd64-${P}.diff
+"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+
+PATCHES=(
+	"${FILESDIR}/${P}-compiler.patch"
+	"${FILESDIR}/${P}-urlistream-get.patch"
+	"${DISTDIR}/patch-utf8-${P}.diff"
+	"${DISTDIR}/patch-amd64-${P}.diff"
+)
+
+src_prepare() {
+	default
+	gunzip html2text.1.gz html2textrc.5.gz || die
+	tc-export CXX
+}
+
+src_compile() {
+	emake LDFLAGS="${LDFLAGS}" DEBUG="${CXXFLAGS}"
+}
+
+src_install() {
+	dobin html2text
+	doman html2text.1 html2textrc.5
+	dodoc CHANGES CREDITS KNOWN_BUGS README TODO
+}


### PR DESCRIPTION
Hi

This PR/Bug update app-text/html2text for EAPI7. It also fixes the installation of compressed (gz) man pages.
Please review.

```diff
--- html2text-1.3.2a-r1.ebuild  2017-03-19 10:57:10.777786381 +0100
+++ html2text-1.3.2a-r2.ebuild  2018-09-30 17:14:03.254418075 +0200
@@ -1,11 +1,11 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
-DESCRIPTION="A HTML to text converter"
+DESCRIPTION="HTML to text converter"
 HOMEPAGE="http://www.mbayer.de/html2text/"
 SRC_URI="http://www.mbayer.de/html2text/downloads/${P}.tar.gz
        http://www.mbayer.de/html2text/downloads/patch-utf8-${P}.diff
@@ -16,18 +16,21 @@
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 
+PATCHES=(
+       "${FILESDIR}/${P}-compiler.patch"
+       "${FILESDIR}/${P}-urlistream-get.patch"
+       "${DISTDIR}/patch-utf8-${P}.diff"
+       "${DISTDIR}/patch-amd64-${P}.diff"
+)
+
 src_unpack() {
        unpack ${P}.tar.gz
 }
 
 src_prepare() {
+       default
+       gunzip ${PN}.1.gz ${PN}rc.5.gz || die
        tc-export CXX
-       epatch \
-               "${FILESDIR}/${P}-compiler.patch" \
-               "${FILESDIR}/${P}-urlistream-get.patch" \
-               "${DISTDIR}/patch-utf8-${P}.diff" \
-               "${DISTDIR}/patch-amd64-${P}.diff"
-       epatch_user
 }
 
 src_compile() {
@@ -36,6 +39,6 @@
 
 src_install() {
        dobin html2text
-       doman html2text.1.gz html2textrc.5.gz
+       doman html2text.1 html2textrc.5
        dodoc CHANGES CREDITS KNOWN_BUGS README TODO
 }
```

Closes: https://bugs.gentoo.org/667382
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>