### PR TITLE
net-misc/asterisk: disable native building

### DIFF
--- a/net-misc/asterisk/asterisk-11.25.1.ebuild
+++ b/net-misc/asterisk/asterisk-11.25.1.ebuild
@@ -130,6 +130,9 @@ src_configure() {
 	# Compile menuselect binary for optional components
 	emake menuselect.makeopts
 
+	# We'll decide our target CPU in make.conf
+	menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
+
 	# Broken functionality is forcibly disabled (bug #360143)
 	menuselect/menuselect --disable chan_misdn menuselect.makeopts
 	menuselect/menuselect --disable chan_ooh323 menuselect.makeopts

--- a/net-misc/asterisk/asterisk-11.25.3.ebuild
+++ b/net-misc/asterisk/asterisk-11.25.3.ebuild
@@ -130,6 +130,9 @@ src_configure() {
 	# Compile menuselect binary for optional components
 	emake menuselect.makeopts
 
+	# We'll decide our target CPU in make.conf
+	menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
+
 	# Broken functionality is forcibly disabled (bug #360143)
 	menuselect/menuselect --disable chan_misdn menuselect.makeopts
 	menuselect/menuselect --disable chan_ooh323 menuselect.makeopts

--- a/net-misc/asterisk/asterisk-13.19.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-13.19.0-r1.ebuild
@@ -133,6 +133,9 @@ src_configure() {
 	# Compile menuselect binary for optional components
 	emake menuselect.makeopts
 
+	# We'll decide our target CPU in make.conf
+	menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
+
 	# Broken functionality is forcibly disabled (bug #360143)
 	menuselect/menuselect --disable chan_misdn menuselect.makeopts
 	menuselect/menuselect --disable chan_ooh323 menuselect.makeopts

--- a/net-misc/asterisk/asterisk-13.19.2.ebuild
+++ b/net-misc/asterisk/asterisk-13.19.2.ebuild
@@ -133,6 +133,9 @@ src_configure() {
 	# Compile menuselect binary for optional components
 	emake menuselect.makeopts
 
+	# We'll decide our target CPU in make.conf
+	menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
+
 	# Broken functionality is forcibly disabled (bug #360143)
 	menuselect/menuselect --disable chan_misdn menuselect.makeopts
 	menuselect/menuselect --disable chan_ooh323 menuselect.makeopts

--- a/net-misc/asterisk/asterisk-13.20.0.ebuild
+++ b/net-misc/asterisk/asterisk-13.20.0.ebuild
@@ -133,6 +133,9 @@ src_configure() {
 	# Compile menuselect binary for optional components
 	emake menuselect.makeopts
 
+	# We'll decide our target CPU in make.conf
+	menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
+
 	# Broken functionality is forcibly disabled (bug #360143)
 	menuselect/menuselect --disable chan_misdn menuselect.makeopts
 	menuselect/menuselect --disable chan_ooh323 menuselect.makeopts

--- a/net-misc/asterisk/asterisk-13.21.0.ebuild
+++ b/net-misc/asterisk/asterisk-13.21.0.ebuild
@@ -133,6 +133,9 @@ src_configure() {
 	# Compile menuselect binary for optional components
 	emake menuselect.makeopts
 
+	# We'll decide our target CPU in make.conf
+	menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
+
 	# Broken functionality is forcibly disabled (bug #360143)
 	menuselect/menuselect --disable chan_misdn menuselect.makeopts
 	menuselect/menuselect --disable chan_ooh323 menuselect.makeopts

--- a/net-misc/asterisk/asterisk-13.22.0.ebuild
+++ b/net-misc/asterisk/asterisk-13.22.0.ebuild
@@ -133,6 +133,9 @@ src_configure() {
 	# Compile menuselect binary for optional components
 	emake menuselect.makeopts
 
+	# We'll decide our target CPU in make.conf
+	menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
+
 	# Broken functionality is forcibly disabled (bug #360143)
 	menuselect/menuselect --disable chan_misdn menuselect.makeopts
 	menuselect/menuselect --disable chan_ooh323 menuselect.makeopts


### PR DESCRIPTION
By default Asterisk is compiled for the CPU detected at build time. This overrides any -march or -mtune settings in make.conf and results in bad executables when building binary packages for different architectures. This disables the aforementioned behaviour.

https://bugs.gentoo.org/667498

https://wiki.asterisk.org/wiki/display/AST/Building%2Band%2BInstalling%2BAsterisk#BuildingandInstallingAsterisk-Buildingfornon-nativearchitectures