### PR TITLE
games-util/gamemode: GameMode requires polkit for pkexec

### DIFF
--- a/games-util/gamemode/gamemode-1.2.ebuild
+++ b/games-util/gamemode/gamemode-1.2.ebuild
@@ -26,6 +26,7 @@ IUSE=""
 
 RDEPEND="
 	>=sys-apps/systemd-236[${MULTILIB_USEDEP}]
+	sys-auth/polkit
 "
 DEPEND="${RDEPEND}"
 
@@ -79,10 +80,12 @@ multilib_src_compile() {
 
 multilib_src_install() {
 	DESTDIR="${D}" eninja install
-	insinto /etc/security/limits.d
-	newins - 45-gamemode.conf <<-EOF
-		@gamemode - nice -10
-	EOF
+	if multilib_is_native_abi; then
+		insinto /etc/security/limits.d
+		newins - 45-gamemode.conf <<-EOF
+			@gamemode - nice -10
+		EOF
+	fi
 }
 
 pkg_postinst() {

--- a/games-util/gamemode/gamemode-9999.ebuild
+++ b/games-util/gamemode/gamemode-9999.ebuild
@@ -26,6 +26,7 @@ IUSE=""
 
 RDEPEND="
 	>=sys-apps/systemd-236[${MULTILIB_USEDEP}]
+	sys-auth/polkit
 "
 DEPEND="${RDEPEND}"
 
@@ -79,10 +80,12 @@ multilib_src_compile() {
 
 multilib_src_install() {
 	DESTDIR="${D}" eninja install
-	insinto /etc/security/limits.d
-	newins - 45-gamemode.conf <<-EOF
-		@gamemode - nice -10
-	EOF
+	if multilib_is_native_abi; then
+		insinto /etc/security/limits.d
+		newins - 45-gamemode.conf <<-EOF
+			@gamemode - nice -10
+		EOF
+	fi
 }
 
 pkg_postinst() {


### PR DESCRIPTION
~~GameMode requires a suid helper to work correctly. This wasn't installed with proper permissions previously. This PR adjust the 9999 ebuild, then bumps the version of the old ebuild and removes the old.~~

GameMode requires pkexec to exist to start elevated processes. Let's depend on polkit for that reason. I did not bump the version as nothing of the installation itself changed, only a required runtime dep will be pulled it.

There's only an additional minor tweak to not write a config template twice. Result of the installation is the same.