### PR TITLE
media-sound/clementine-9999: Remove unnecessary patch

### DIFF
--- a/media-sound/clementine/clementine-9999.ebuild
+++ b/media-sound/clementine/clementine-9999.ebuild
@@ -100,8 +100,6 @@ DEPEND="${COMMON_DEPEND}
 
 DOCS=( Changelog README.md )
 
-PATCHES=( "${FILESDIR}"/${PN}-fts3-tokenizer.patch )
-
 src_prepare() {
 	l10n_find_plocales_changes "src/translations" "" ".po"
 


### PR DESCRIPTION
No longer necessary since https://github.com/clementine-player/Clementine/pull/5669 was merged (2018-09-29).