### PR TITLE
sys-apps/dstat: avoid running network... etc tests

### DIFF
--- a/sys-apps/dstat/dstat-0.7.3.ebuild
+++ b/sys-apps/dstat/dstat-0.7.3.ebuild
@@ -24,6 +24,8 @@ RDEPEND="
 	)"
 DEPEND=""
 
+PATCHES=( "${FILESDIR}/dstat-${PV}-skip-non-sandbox-tests.patch" )
+
 src_install() {
 	emake DESTDIR="${ED}" install
 	einstalldocs

--- a/sys-apps/dstat/files/dstat-0.7.3-skip-non-sandbox-tests.patch
+++ b/sys-apps/dstat/files/dstat-0.7.3-skip-non-sandbox-tests.patch
@@ -1,0 +1,15 @@
+--- a/Makefile	2016-03-18 13:03:22.000000000 +0000
++++ b/Makefile	2018-10-02 11:11:00.344942941 +0100
+@@ -32,9 +32,11 @@
+ 	rm -f examples/*.pyc plugins/*.pyc
+ 	$(MAKE) -C docs clean
+ 
++TEST_PLUGINS=--cpufreq --disk-avgqu --disk-avgrq --disk-svctm --disk-tps --disk-util --disk-wait --dstat-cpu --dstat-ctxt --dstat-mem --dstat --helloworld --md-status --net-packets --proc-count --snooze --test --top-bio-adv --top-bio --top-childwait --top-cpu-adv --top-cpu --top-cputime-avg --top-cputime --top-int --top-io-adv --top-io --top-latency-avg --top-latency --top-mem --top-oom
++
+ test:
+ 	./dstat -taf 1 5
+-	./dstat -t --all-plugins 1 5
++	./dstat -t $(TEST_PLUGINS) 1 5
+ 
+ dist: clean
+ 	$(MAKE) -C docs dist

--- a/sys-apps/dstat/metadata.xml
+++ b/sys-apps/dstat/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>lmiphay@gmail.com</email>
+		<name>Paul Healy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription>
 Dstat is a versatile replacement for vmstat, iostat and ifstat. Dstat overcomes
 some of the limitations and adds some extra features.


### PR DESCRIPTION
This fixes the test target to only load a restricted number of the shipped plugins - network, db,
virtualisation... etc will fail in different ways unless the environment or explicit dependencies are met.

I would like to maintain this package, and have added myself to metadata.xml

Closes: https://bugs.gentoo.org/638728
Closes: https://bugs.gentoo.org/656514