### PR TITLE
app-admin/xstow: EAPI7 revbump, minor updates

### DIFF
--- a/app-admin/xstow/xstow-1.0.1-r1.ebuild
+++ b/app-admin/xstow/xstow-1.0.1-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="replacement for GNU stow with extensions"
+HOMEPAGE="http://xstow.sourceforge.net/"
+SRC_URI="mirror://sourceforge/xstow/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="ncurses"
+
+DEPEND="ncurses? ( sys-libs/ncurses:0= )"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${P}-ncurses.patch )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_with ncurses curses)
+}
+
+src_install() {
+	emake DESTDIR="${D}" docdir="/usr/share/doc/${PF}/html" install
+	dodoc AUTHORS ChangeLog NEWS README TODO
+
+	# create new STOWDIR
+	dodir /var/lib/xstow
+	keepdir /var/lib/xstow
+
+	# install env.d file to add STOWDIR to PATH and LDPATH
+	doenvd "${FILESDIR}/99xstow"
+}
+
+pkg_postinst() {
+	elog "We now recommend that you use /var/lib/xstow as your STOWDIR"
+	elog "instead of /usr/local in order to avoid conflicts with the"
+	elog "symlink from /usr/lib64 -> /usr/lib.  See Bug 246264"
+	elog "(regarding app-admin/stow, equally applicable to XStow) for"
+	elog "more details on this change."
+	elog "For your convenience, PATH has been updated to include"
+	elog "/var/lib/bin."
+}


### PR DESCRIPTION
Hi,

This is a simply EAPI7 revbump which also fixes a simple QA warning about a empty dir.
Please review.

```diff
--- xstow-1.0.1.ebuild  2018-09-30 21:33:00.191620937 +0200
+++ xstow-1.0.1-r1.ebuild       2018-10-02 20:20:50.647973831 +0200
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit autotools eutils
+inherit autotools
 
 DESCRIPTION="replacement for GNU stow with extensions"
 HOMEPAGE="http://xstow.sourceforge.net/"
@@ -11,14 +11,16 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="ncurses"
 
 DEPEND="ncurses? ( sys-libs/ncurses:0= )"
 RDEPEND="${DEPEND}"
 
+PATCHES=( "${FILESDIR}"/${P}-ncurses.patch )
+
 src_prepare() {
-       epatch "${FILESDIR}"/${P}-ncurses.patch
+       default
        eautoreconf
 }
 
@@ -32,9 +34,10 @@
 
        # create new STOWDIR
        dodir /var/lib/xstow
+       keepdir /var/lib/xstow
 
        # install env.d file to add STOWDIR to PATH and LDPATH
-       doenvd "${FILESDIR}/99xstow" || die "doenvd failed"
+       doenvd "${FILESDIR}/99xstow"
 }
 
 pkg_postinst() {
```

Closes: https://bugs.gentoo.org/667596
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>