### PR TITLE
www-client/firefox-62.0.2: disable webrtc for arm

### DIFF
--- a/www-client/firefox/firefox-62.0.2.ebuild
+++ b/www-client/firefox/firefox-62.0.2.ebuild
@@ -339,6 +339,8 @@ src_configure() {
 		fi
 	fi
 
+	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
+
 	mozconfig_use_enable !bindist official-branding
 	# Enable position independent executables
 	mozconfig_annotate 'enabled by Gentoo' --enable-pie


### PR DESCRIPTION
@Whissi - webrtc build scripts seems to have been rewritten to use `gn`, so lets disable it for now on arm. Gentoo bug is #667642 , for tracking. Will open an upstream bug later on. 

esr is not affected. 