### PR TITLE
www-client/firefox-62.0.3: webrtc is broken on arm, disable it for now

### DIFF
--- a/www-client/firefox/firefox-62.0.3.ebuild
+++ b/www-client/firefox/firefox-62.0.3.ebuild
@@ -339,6 +339,8 @@ src_configure() {
 		fi
 	fi
 
+	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
+
 	mozconfig_use_enable !bindist official-branding
 	# Enable position independent executables
 	mozconfig_annotate 'enabled by Gentoo' --enable-pie

--- a/www-client/firefox/firefox-62.0.3.ebuild
+++ b/www-client/firefox/firefox-62.0.3.ebuild
@@ -339,6 +339,7 @@ src_configure() {
 		fi
 	fi
 
+	# disable webrtc for now, moz stated in #1496027 they're not going to put any ressources into a possible fix
 	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
 
 	mozconfig_use_enable !bindist official-branding


### PR DESCRIPTION
@Whissi - sorry about the double post, didn't expect the ebuild to be revbumped over night 

gentoo: #667642 
todo: open bug upstream 