### PR TITLE
net-dns/dnrd: EAPI7 revbump, improve ebuild

### DIFF
--- a/net-dns/dnrd/dnrd-2.20.3-r2.ebuild
+++ b/net-dns/dnrd/dnrd-2.20.3-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools user
+
+DESCRIPTION="A caching DNS proxy server"
+HOMEPAGE="http://dnrd.sourceforge.net/"
+SRC_URI="mirror://sourceforge/dnrd/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=( "${FILESDIR}"/${P}-docdir.patch )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_install() {
+	default
+
+	keepdir /etc/dnrd
+	doinitd "${FILESDIR}"/dnrd
+	newconfd "${FILESDIR}"/dnrd.conf dnrd
+}
+
+pkg_postinst() {
+	enewgroup dnrd
+	enewuser dnrd -1 -1 /dev/null dnrd
+}

--- a/net-dns/dnrd/files/dnrd
+++ b/net-dns/dnrd/files/dnrd
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2003 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License, v2 or later
 
 PIDFILE="/var/run/dnrd.pid"
@@ -11,13 +11,16 @@ depend() {
 
 start() {
 	ebegin "Starting dnrd"
-	/usr/sbin/dnrd $DNRD_OPTS &> /dev/null &
+	start-stop-daemon --start \
+		--pidfile ${PIDFILE} \
+		--exec /usr/sbin/dnrd \
+		-- ${DNRD_OPTS}
 	eend $?
 }
 
 stop() {
 	ebegin "Stopping dnrd"
-	/usr/sbin/dnrd -k	
+	start-stop-daemon --stop --quiet --pidfile ${PIDFILE}
 	eend $?
 }
 

--- a/net-dns/dnrd/files/dnrd-2.20.3-docdir.patch
+++ b/net-dns/dnrd/files/dnrd-2.20.3-docdir.patch
@@ -1,7 +1,7 @@
 Index: doc/Makefile.am
 ===================================================================
---- doc/Makefile.am	(revision 247)
-+++ doc/Makefile.am	(revision 248)
+--- a/doc/Makefile.am	(revision 247)
++++ b/doc/Makefile.am	(revision 248)
 @@ -1,5 +1,4 @@
  PACKAGE = @PACKAGE_TARNAME@
 -docdir = $(datadir)/doc/$(PACKAGE)
@@ -10,8 +10,8 @@ Index: doc/Makefile.am
  EXTRA_DIST = $(man_MANS) $(doc_DATA)
 Index: Makefile.am
 ===================================================================
---- Makefile.am	(revision 247)
-+++ Makefile.am	(revision 248)
+--- a/Makefile.am	(revision 247)
++++ b/Makefile.am	(revision 248)
 @@ -1,6 +1,5 @@
  PACKAGE = @PACKAGE_TARNAME@
  SUBDIRS = src doc


### PR DESCRIPTION
Hi,

This PR/Bug updates net-dns/dnrd for EAPI7 with some minor improvements to the ebuild and the init script.
Please review.

```diff
--- dnrd-2.20.3-r1.ebuild       2018-09-30 21:33:03.356550840 +0200
+++ dnrd-2.20.3-r2.ebuild       2018-10-03 19:39:00.214035275 +0200
@@ -1,38 +1,35 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-inherit autotools eutils user
+inherit autotools user
 
 DESCRIPTION="A caching DNS proxy server"
 HOMEPAGE="http://dnrd.sourceforge.net/"
 SRC_URI="mirror://sourceforge/dnrd/${P}.tar.gz"
+
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="debug"
-DEPEND=""
 
-src_unpack() {
-       unpack ${A}
-       cd "${S}"
-       epatch "${FILESDIR}"/${P}-docdir.patch
+PATCHES=( "${FILESDIR}"/${P}-docdir.patch )
+
+src_prepare() {
+       default
        eautoreconf
 }
 
-src_compile() {
+src_configure() {
        econf \
                $(use_enable debug) \
                --disable-dependency-tracking \
-               --docdir=/usr/share/doc/${PF} \
-               || die
-
-       emake || die
+               --docdir=/usr/share/doc/${PF}
 }
 
 src_install() {
-       emake DESTDIR="${D}" install || die
+       default
 
        keepdir /etc/dnrd
        doinitd ${FILESDIR}/dnrd
```

Closes: https://bugs.gentoo.org/667660
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>