### PR TITLE
net-im/telegram-desktop-bin: work around fontconfig issues

### DIFF
--- a/net-im/telegram-desktop-bin/files/fonts.conf
+++ b/net-im/telegram-desktop-bin/files/fonts.conf
@@ -1,0 +1,60 @@
+<?xml version='1.0'?>
+<!--
+     This file is only here to work around
+     https://github.com/telegramdesktop/tdesktop/issues/4240
+     It has been taken from (with slight modification)
+     https://github.com/telegramdesktop/tdesktop/issues/4493
+-->
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+    <dir>/usr/share/fonts</dir>
+    <dir>/usr/local/share/fonts</dir>
+    <dir prefix="xdg">fonts</dir>
+    <match target="pattern">
+	<test qual="any" name="family">
+	    <string>mono</string>
+	</test>
+	<edit name="family" mode="assign" binding="same">
+	    <string>monospace</string>
+	</edit>
+    </match>
+    <match target="pattern">
+	<test qual="any" name="family">
+	    <string>sans serif</string>
+	</test>
+	<edit name="family" mode="assign" binding="same">
+	    <string>sans-serif</string>
+	</edit>
+    </match>
+    <match target="pattern">
+	<test qual="any" name="family">
+	    <string>sans</string>
+	</test>
+	<edit name="family" mode="assign" binding="same">
+	    <string>sans-serif</string>
+	</edit>
+    </match>
+    <cachedir>/var/cache/fontconfig</cachedir>
+    <cachedir prefix="xdg">fontconfig</cachedir>
+    <cachedir>~/.fontconfig</cachedir>
+    <match target="font">
+	<edit mode="assign" name="antialias">
+	    <bool>true</bool>
+	</edit>
+	<edit mode="assign" name="embeddedbitmap">
+	    <bool>false</bool>
+	</edit>
+	<edit mode="assign" name="hinting">
+	    <bool>true</bool>
+	</edit>
+	<edit mode="assign" name="hintstyle">
+	    <const>hintslight</const>
+	</edit>
+	<edit mode="assign" name="lcdfilter">
+	    <const>lcddefault</const>
+	</edit>
+	<edit mode="assign" name="rgba">
+	    <const>rgb</const>
+	</edit>
+    </match>
+</fontconfig>

--- a/net-im/telegram-desktop-bin/files/telegram-desktop-bin-r2
+++ b/net-im/telegram-desktop-bin/files/telegram-desktop-bin-r2
@@ -1,0 +1,15 @@
+#!/bin/sh
+# this wrapper disables the auto-updater of telegram-desktop
+# This program is licensed under the same license as telegram-desktop
+
+# telegram-desktop fails to set RestartCommand with the session manager
+# exclude it from session management to prevent restarts without the argument
+unset SESSION_MANAGER
+
+# telegram-desktop expects old fontconfig configuration files
+# this is a workaround to try and deal with that
+[ -e /etc/telegram-desktop-bin/fonts.conf ] && \
+  [ -z $( printenv FONTCONFIG_FILE ) ] && \
+  export FONTCONFIG_FILE=/etc/telegram-desktop-bin/fonts.conf
+
+exec /usr/lib/telegram-desktop-bin/Telegram -externalupdater $@

--- a/net-im/telegram-desktop-bin/telegram-desktop-bin-1.4.0-r1.ebuild
+++ b/net-im/telegram-desktop-bin/telegram-desktop-bin-1.4.0-r1.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit desktop gnome2-utils xdg
+
+DESCRIPTION="Official desktop client for Telegram (binary package)"
+HOMEPAGE="https://desktop.telegram.org"
+SRC_URI="
+	https://github.com/telegramdesktop/tdesktop/archive/v${PV}.tar.gz -> tdesktop-${PV}.tar.gz
+	amd64? ( https://updates.tdesktop.com/tlinux/tsetup.${PV}.tar.xz )
+	x86? ( https://updates.tdesktop.com/tlinux32/tsetup32.${PV}.tar.xz )
+"
+
+LICENSE="telegram"
+SLOT="0"
+KEYWORDS="-* ~amd64 ~x86"
+
+QA_PREBUILT="usr/lib/${PN}/Telegram"
+
+RDEPEND="
+	dev-libs/glib:2
+	dev-libs/gobject-introspection
+	>=sys-apps/dbus-1.4.20
+	x11-libs/libX11
+	>=x11-libs/libxcb-1.10[xkb]
+	>=media-libs/fontconfig-2.13
+"
+
+S="${WORKDIR}/Telegram"
+
+src_install() {
+	exeinto /usr/lib/${PN}
+	doexe "Telegram"
+	newbin "${FILESDIR}"/${PN}-r2 "telegram-desktop"
+
+	local icon_size
+	for icon_size in 16 32 48 64 128 256 512; do
+		newicon -s "${icon_size}" \
+			"${WORKDIR}/tdesktop-${PV}/Telegram/Resources/art/icon${icon_size}.png" \
+			telegram-desktop.png
+	done
+
+	dodir /etc/${PN}
+	insinto /etc/${PN}/
+	doins ${FILESDIR}/fonts.conf
+
+	domenu "${WORKDIR}/tdesktop-${PV}"/lib/xdg/telegramdesktop.desktop
+}
+
+pkg_preinst() {
+	xdg_pkg_preinst
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_icon_cache_update
+	einfo
+	einfo "Previous versions of ${PN} have created "
+	einfo "\"~/.local/share/applications/telegram.desktop\". These files"
+	einfo "conflict with the one shipped by portage and should be removed"
+	einfo "from all homedirs. (https://bugs.gentoo.org/618662)"
+	einfo
+	einfo "This versions fixes fontconfig issues that have been reported"
+	einfo "by several users. However, the fix might have side-effects on"
+	einfo "non-latin fonts. If you have font issues with this version just"
+	einfo "delete \"/etc/${PN}/fonts.conf\" and leave a comment here"
+	einfo "https://bugs.gentoo.org/664872"
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
This commit makes telegram-desktop-bin bring its own fontconfig
file for the old version of fontconfig it has built in. It also allows
to fall back to the "old way" by removing the file from /etc/.

Signed-off-by: Henning Schild <henning@hennsch.de>
Closes: https://bugs.gentoo.org/664872