### PR TITLE
net-misc/jlj: EAPI7 revbump

### DIFF
--- a/net-misc/jlj/jlj-2.12-r1.ebuild
+++ b/net-misc/jlj/jlj-2.12-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Simple console LiveJournal entry system"
+HOMEPAGE="http://umlautllama.com/projects/perl/#jlj"
+SRC_URI="http://umlautllama.com/projects/perl/${PN}_${PV}.tar.gz"
+
+LICENSE="freedist"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+SLOT="0"
+
+DEPEND="dev-lang/perl"
+
+S=${WORKDIR}/${PN}
+
+src_install() {
+	newbin ${PN}.pl ${PN}
+	newdoc .livejournal.rc livejournal.rc
+	dodoc README.JLJ
+}
+
+pkg_postinst() {
+	elog "README.JLJ and a sample livejournal.rc have been installed to"
+	elog "/usr/share/doc/${PF}/"
+}


### PR DESCRIPTION
Hi,

This is another very simple EAPI7 revbump with almost no changes (only removed a obsolete die and updated the description)
Please review.

```diff
--- jlj-2.12.ebuild     2018-09-30 21:33:03.561546300 +0200
+++ jlj-2.12-r1.ebuild  2018-10-03 19:49:31.706280024 +0200
@@ -1,22 +1,22 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-DESCRIPTION="A simple console LiveJournal entry system"
+DESCRIPTION="Simple console LiveJournal entry system"
 HOMEPAGE="http://umlautllama.com/projects/perl/#jlj"
 SRC_URI="http://umlautllama.com/projects/perl/${PN}_${PV}.tar.gz"
+
 LICENSE="freedist"
-KEYWORDS="~alpha ~amd64 ~ppc ~sparc x86"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
 SLOT="0"
-IUSE=""
 
 DEPEND="dev-lang/perl"
 
 S=${WORKDIR}/${PN}
 
 src_install() {
-       newbin ${PN}.pl ${PN} || die
+       newbin ${PN}.pl ${PN}
        newdoc .livejournal.rc livejournal.rc
        dodoc README.JLJ
 }
```

Closes: https://bugs.gentoo.org/667664
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>