### PR TITLE
net-libs/nativebiginteger: fix build with -test

### DIFF
--- a/net-libs/nativebiginteger/metadata.xml
+++ b/net-libs/nativebiginteger/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>tharvik@gmail.com</email>
-		<name>Tharvik</name>
+		<name>Valérian Rousset</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>

--- a/net-libs/nativebiginteger/nativebiginteger-0.9.36-r1.ebuild
+++ b/net-libs/nativebiginteger/nativebiginteger-0.9.36-r1.ebuild
@@ -1,0 +1,70 @@
+# Copyright 2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit java-pkg-2 toolchain-funcs
+
+DESCRIPTION='jbigi library used by net-vpn/i2p'
+HOMEPAGE='https://geti2p.net'
+SRC_URI="https://download.i2p2.de/releases/${PV}/i2psource_${PV}.tar.bz2"
+
+LICENSE='public-domain'
+SLOT='0'
+KEYWORDS='~amd64 ~x86'
+IUSE='test'
+
+DEPEND='
+	dev-libs/gmp:0=
+	virtual/jdk:1.8
+'
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/i2p-${PV}/core"
+
+PATCHES=(
+	"${FILESDIR}/${P}-asmfix.patch"
+)
+
+src_compile() {
+	local compile_lib
+	compile_lib() {
+		local name="${1}"
+		local file="${2}"
+		shift 2
+
+		"$(tc-getCC)" "${@}" ${CFLAGS} $(java-pkg_get-jni-cflags) \
+			${LDFLAGS} -shared -fPIC "-Wl,-soname,lib${name}.so" \
+			"${file}" -o "lib${name}.so"
+	}
+
+	cd "${S}/c/jbigi/jbigi" &&
+		compile_lib jbigi src/jbigi.c -Iinclude -lgmp ||
+		die 'unable to build jbigi'
+
+	if use amd64 || use x86; then
+		cd "${S}/c/jcpuid" &&
+			compile_lib jcpuid src/jcpuid.c -Iinclude ||
+			die 'unable to build jcpuid'
+	fi
+
+	if use test; then
+		cd "${S}/java/src" &&
+			ejavac -encoding UTF-8 net/i2p/util/NativeBigInteger.java ||
+			die 'unable to build tests'
+	fi
+}
+
+src_test() {
+	cd "${S}/java/src" &&
+		"$(java-config -J)" -Djava.library.path="${S}/c/jbigi/jbigi" net/i2p/util/NativeBigInteger ||
+		die 'unable to pass tests'
+}
+
+src_install() {
+	dolib.so c/jbigi/jbigi/libjbigi.so
+
+	if use amd64 || use x86; then
+		dolib.so c/jcpuid/libjcpuid.so
+	fi
+}


### PR DESCRIPTION
* rewrite of the ebuild to ensure new copyright following GLEP 76
* fix 667292
  * instead of using broken build script, the ebuild directly build the wanted libraries
* remove the `-java` USE, as it need the JNI headers anyway
* also add my real name to `metadata.xml`