### PR TITLE
app-admin/syslog-summary: add sys-apps file suggestion

### DIFF
--- a/app-admin/syslog-summary/metadata.xml
+++ b/app-admin/syslog-summary/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <!-- maintainer-needed -->
+  <maintainer type="person">
+    <email>lmiphay@gmail.com</email>
+    <name>Paul Healy</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
   <upstream>
     <remote-id type="github">dpaleino/syslog-summary</remote-id>
   </upstream>

--- a/app-admin/syslog-summary/syslog-summary-1.14-r2.ebuild
+++ b/app-admin/syslog-summary/syslog-summary-1.14-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils python-single-r1
+inherit python-single-r1
 
 DESCRIPTION="Summarizes the contents of a syslog log file"
 HOMEPAGE="https://github.com/dpaleino/syslog-summary"
@@ -24,7 +24,7 @@ RDEPEND="${PYTHON_DEPS}"
 src_prepare() {
 	python_fix_shebang -f syslog-summary
 
-	sed -i -e 's:python-magic:sys-apps/file[python]:' "syslog-summary"
+	sed -i -e 's:python-magic:sys-apps/file[python]:' "syslog-summary" || die
 
 	# Sadly, the makefile is useless for us.
 	rm Makefile || die
@@ -34,7 +34,7 @@ src_prepare() {
 
 src_install() {
 	dobin syslog-summary
-	dodoc AUTHORS ChangeLog NEWS README
+	einstalldocs
 	doman syslog-summary.1
 
 	insinto /etc/syslog-summary

--- a/app-admin/syslog-summary/syslog-summary-1.14-r2.ebuild
+++ b/app-admin/syslog-summary/syslog-summary-1.14-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit eutils python-single-r1
+
+DESCRIPTION="Summarizes the contents of a syslog log file"
+HOMEPAGE="https://github.com/dpaleino/syslog-summary"
+SRC_URI="mirror://github/dpaleino/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~sparc ~x86"
+IUSE=""
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+DEPEND=""
+RDEPEND="${PYTHON_DEPS}"
+
+src_prepare() {
+	python_fix_shebang -f syslog-summary
+
+	sed -i -e 's:python-magic:sys-apps/file[python]:' "syslog-summary"
+
+	# Sadly, the makefile is useless for us.
+	rm Makefile || die
+
+	eapply_user
+}
+
+src_install() {
+	dobin syslog-summary
+	dodoc AUTHORS ChangeLog NEWS README
+	doman syslog-summary.1
+
+	insinto /etc/syslog-summary
+	doins ignore.rules
+}
+
+pkg_postinst() {
+	elog "install sys-apps/file[python] to enable processing"
+	elog "of gzip compressed logfiles"
+}

--- a/app-admin/syslog-summary/syslog-summary-1.14-r2.ebuild
+++ b/app-admin/syslog-summary/syslog-summary-1.14-r2.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Summarizes the contents of a syslog log file"
 HOMEPAGE="https://github.com/dpaleino/syslog-summary"
 SRC_URI="mirror://github/dpaleino/${PN}/${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~sparc ~x86"
 IUSE=""


### PR DESCRIPTION
This adds a suggestion to install sys-apps/file[python] to support processing gzip compressed logfiles.

Also:
EAPI 6
Dropped stable keywords

I would like to maintain this package, and have added myself to metadata.xml

Closes: https://bugs.gentoo.org/472884