### PR TITLE
net-im/prosody: replace fixed lib64 by getlib_dir

### DIFF
--- a/net-im/prosody/files/prosody.initd-r2
+++ b/net-im/prosody/files/prosody.initd-r2
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 description="Prosody is a server for Jabber/XMPP written in Lua."

--- a/net-im/prosody/prosody-0.10.2-r1.ebuild
+++ b/net-im/prosody/prosody-0.10.2-r1.ebuild
@@ -1,0 +1,78 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic systemd
+
+DESCRIPTION="Prosody is a flexible communications server for Jabber/XMPP written in Lua"
+HOMEPAGE="https://prosody.im/"
+SRC_URI="https://prosody.im/downloads/source/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="ipv6 libevent mysql postgres sqlite ssl zlib jit libressl"
+
+DEPEND="net-im/jabber-base
+		dev-lua/LuaBitOp
+		!jit? ( >=dev-lang/lua-5.1:0 )
+		jit? ( dev-lang/luajit:2 )
+		>=net-dns/libidn-1.1:=
+		!libressl? ( dev-libs/openssl:0 ) libressl? ( dev-libs/libressl:= )"
+RDEPEND="${DEPEND}
+		>=dev-lua/luaexpat-1.3.0
+		dev-lua/luafilesystem
+		ipv6? ( >=dev-lua/luasocket-3 )
+		!ipv6? ( dev-lua/luasocket )
+		libevent? ( >=dev-lua/luaevent-0.4.3 )
+		mysql? ( dev-lua/luadbi[mysql] )
+		postgres? ( dev-lua/luadbi[postgres] )
+		sqlite? ( dev-lua/luadbi[sqlite] )
+		ssl? ( dev-lua/luasec )
+		zlib? ( dev-lua/lua-zlib )"
+
+JABBER_ETC="${EPREFIX}/etc/jabber"
+JABBER_SPOOL="${EPREFIX}/var/spool/jabber"
+
+src_prepare() {
+	eapply "${FILESDIR}/${PN}-0.10.0-cfg.lua.patch"
+	sed -i -e "s!MODULES = \$(DESTDIR)\$(PREFIX)/lib/!MODULES = \$(DESTDIR)\$(PREFIX)/$(get_libdir)/!"\
+		-e "s!SOURCE = \$(DESTDIR)\$(PREFIX)/lib/!SOURCE = \$(DESTDIR)\$(PREFIX)/$(get_libdir)/!"\
+		-e "s!INSTALLEDSOURCE = \$(PREFIX)/lib/!INSTALLEDSOURCE = \$(PREFIX)/$(get_libdir)/!"\
+		-e "s!INSTALLEDMODULES = \$(PREFIX)/lib/!INSTALLEDMODULES = \$(PREFIX)/$(get_libdir)/!"\
+		Makefile || die
+	default
+}
+
+src_configure() {
+	# the configure script is handcrafted (and yells at unknown options)
+	# hence do not use 'econf'
+	append-cflags -D_GNU_SOURCE
+	./configure \
+		--ostype=linux \
+		--prefix="${EPREFIX}/usr" \
+		--libdir="${EPREFIX}/usr/$(get_libdir)" \
+		--sysconfdir="${JABBER_ETC}" \
+		--datadir="${JABBER_SPOOL}" \
+		--with-lua-include="${EPREFIX}/usr/include" \
+		--with-lua-lib="${EPREFIX}/usr/$(get_libdir)/lua" \
+		--runwith=lua"$(usev jit)" \
+		--cflags="${CFLAGS} -Wall -fPIC" \
+		--ldflags="${LDFLAGS} -shared" \
+		--c-compiler="$(tc-getCC)" \
+		--linker="$(tc-getCC)" || die "configure failed"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	systemd_dounit "${FILESDIR}/${PN}".service
+	systemd_newtmpfilesd "${FILESDIR}/${PN}".tmpfilesd "${PN}".conf
+	newinitd "${FILESDIR}/${PN}".initd-r2 ${PN}
+	keepdir "${JABBER_SPOOL}"
+}
+
+src_test() {
+	cd tests || die
+	./run_tests.sh || die
+}

--- a/net-im/prosody/prosody-0.10.2-r1.ebuild
+++ b/net-im/prosody/prosody-0.10.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -49,6 +49,7 @@ src_configure() {
 	# the configure script is handcrafted (and yells at unknown options)
 	# hence do not use 'econf'
 	append-cflags -D_GNU_SOURCE
+	use elibc_musl && append-cflags -DWITHOUT_MALLINFO
 	./configure \
 		--ostype=linux \
 		--prefix="${EPREFIX}/usr" \

--- a/net-im/prosody/prosody-0.10.2.ebuild
+++ b/net-im/prosody/prosody-0.10.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5

--- a/net-im/prosody/prosody-0.9.14.ebuild
+++ b/net-im/prosody/prosody-0.9.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5


### PR DESCRIPTION
        - this fixes issue for installed module on 32bit platforms

Package-Manager: Portage-2.3.49, Repoman-2.3.10