### PR TITLE
media-video/blinken*: fix HOMEPAGE, SRC_URI, EAPI7 revbump, improve ebuilds

### DIFF
--- a/media-video/blinkensim/blinkensim-2.7-r1.ebuild
+++ b/media-video/blinkensim/blinkensim-2.7-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 DESCRIPTION="Graphical Blinkenlights simulator with networking support"
 
-HOMEPAGE="http://www.blinkenlights.net/project/developer-tools"
-SRC_URI="http://www.blinkenlights.de/dist/${P}.tar.gz"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-video/blinkenthemes/blinkenthemes-0.10-r1.ebuild
+++ b/media-video/blinkenthemes/blinkenthemes-0.10-r1.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Themes for blinkensim"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="media-libs/blib"
+BDEPEND="virtual/pkgconfig"

--- a/media-video/blinkenthemes/blinkenthemes-0.10.ebuild
+++ b/media-video/blinkenthemes/blinkenthemes-0.10.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
 
 DESCRIPTION="Themes for blinkensim"
-HOMEPAGE="http://www.blinkenlights.net/project/developer-tools"
-SRC_URI="http://www.blinkenlights.de/dist/blinkenthemes-0.10.tar.gz"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/blinkenthemes-0.10.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-video/blinkentools/blinkentools-2.9-r1.ebuild
+++ b/media-video/blinkentools/blinkentools-2.9-r1.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Provides a set of commandline utilities related to Blinkenlights"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="media-libs/blib
+	media-libs/libmng"
+BDEPEND="virtual/pkgconfig"

--- a/media-video/blinkentools/blinkentools-2.9-r1.ebuild
+++ b/media-video/blinkentools/blinkentools-2.9-r1.ebuild
@@ -13,4 +13,5 @@ KEYWORDS="~amd64 ~x86"
 
 DEPEND="media-libs/blib
 	media-libs/libmng"
+RDEPEND="${DEPEND}"
 BDEPEND="virtual/pkgconfig"

--- a/media-video/blinkentools/blinkentools-2.9.ebuild
+++ b/media-video/blinkentools/blinkentools-2.9.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
 
 DESCRIPTION="blinkentools is a set of commandline utilities related to Blinkenlights"
-HOMEPAGE="http://www.blinkenlights.net/project/developer-tools"
-SRC_URI="http://www.blinkenlights.de/dist/${P}.tar.gz"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi, 

This PR/Bug fixes the Homepage and SRC_URI of the blinken* packages. The Homepage actually redirected to some explicit Homepage.
I've also updated the blinkenthemes and blinkentools ebuilds for EAPI7.

Please review.

```diff
diff --git a/media-video/blinkensim/blinkensim-2.7-r1.ebuild b/media-video/blinkensim/blinkensim-2.7-r1.ebuild
index ab3ed37579a..a5d76d7a4b6 100644
--- a/media-video/blinkensim/blinkensim-2.7-r1.ebuild
+++ b/media-video/blinkensim/blinkensim-2.7-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 DESCRIPTION="Graphical Blinkenlights simulator with networking support"
 
-HOMEPAGE="http://www.blinkenlights.net/project/developer-tools"
-SRC_URI="http://www.blinkenlights.de/dist/${P}.tar.gz"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
diff --git a/media-video/blinkenthemes/blinkenthemes-0.10-r1.ebuild b/media-video/blinkenthemes/blinkenthemes-0.10-r1.ebuild
new file mode 100644
index 00000000000..9fbddc48b41
--- /dev/null
+++ b/media-video/blinkenthemes/blinkenthemes-0.10-r1.ebuild
@@ -0,0 +1,15 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Themes for blinkensim"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="media-libs/blib"
+BDEPEND="virtual/pkgconfig"
diff --git a/media-video/blinkenthemes/blinkenthemes-0.10.ebuild b/media-video/blinkenthemes/blinkenthemes-0.10.ebuild
index d518284a6c4..2521e9e94a2 100644
--- a/media-video/blinkenthemes/blinkenthemes-0.10.ebuild
+++ b/media-video/blinkenthemes/blinkenthemes-0.10.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
 
 DESCRIPTION="Themes for blinkensim"
-HOMEPAGE="http://www.blinkenlights.net/project/developer-tools"
-SRC_URI="http://www.blinkenlights.de/dist/blinkenthemes-0.10.tar.gz"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/blinkenthemes-0.10.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
diff --git a/media-video/blinkentools/blinkentools-2.9-r1.ebuild b/media-video/blinkentools/blinkentools-2.9-r1.ebuild
new file mode 100644
index 00000000000..aac82f88023
--- /dev/null
+++ b/media-video/blinkentools/blinkentools-2.9-r1.ebuild
@@ -0,0 +1,16 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Provides a set of commandline utilities related to Blinkenlights"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="media-libs/blib
+       media-libs/libmng"
+BDEPEND="virtual/pkgconfig"
diff --git a/media-video/blinkentools/blinkentools-2.9.ebuild b/media-video/blinkentools/blinkentools-2.9.ebuild
index 28ec8114d50..81f422d42d6 100644
--- a/media-video/blinkentools/blinkentools-2.9.ebuild
+++ b/media-video/blinkentools/blinkentools-2.9.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
 
 DESCRIPTION="blinkentools is a set of commandline utilities related to Blinkenlights"
-HOMEPAGE="http://www.blinkenlights.net/project/developer-tools"
-SRC_URI="http://www.blinkenlights.de/dist/${P}.tar.gz"
+HOMEPAGE="http://blinkenlights.net/project/developer-tools"
+SRC_URI="http://blinkenlights.de/dist/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
```
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>
Closes: https://bugs.gentoo.org/667838