### PR TITLE
Make the shadow ebuild ensure /bin is present before using it

### DIFF
--- a/sys-apps/shadow/shadow-4.6.ebuild
+++ b/sys-apps/shadow/shadow-4.6.ebuild
@@ -110,6 +110,7 @@ src_install() {
 	doins "${FILESDIR}"/default/useradd
 
 	# move passwd to / to help recover broke systems #64441
+	mkdir -p "${ED%/}"/bin/
 	mv "${ED%/}"/usr/bin/passwd "${ED%/}"/bin/ || die
 	dosym ../../bin/passwd /usr/bin/passwd
 


### PR DESCRIPTION
When building with a new prefix, sometimes the /bin directory
does not exist at install time. Therefore, we need to create it
before using it.