### PR TITLE
media-video/obs-studio: fix building without Python targets

### DIFF
--- a/media-video/obs-studio/obs-studio-21.1.2.ebuild
+++ b/media-video/obs-studio/obs-studio-21.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -68,6 +68,10 @@ PATCHES=(
 )
 
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
 
 src_configure() {
 	local libdir=$(get_libdir)

--- a/media-video/obs-studio/obs-studio-22.0.3.ebuild
+++ b/media-video/obs-studio/obs-studio-22.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -65,6 +65,10 @@ RDEPEND="${COMMON_DEPEND}"
 PATCHES=( "${FILESDIR}/${PN}-21.1.2-use-less-automagic.patch" )
 
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
 
 src_configure() {
 	local libdir=$(get_libdir)

--- a/media-video/obs-studio/obs-studio-9999.ebuild
+++ b/media-video/obs-studio/obs-studio-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -63,6 +63,10 @@ DEPEND="${COMMON_DEPEND}
 RDEPEND="${COMMON_DEPEND}"
 
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
 
 src_configure() {
 	local libdir=$(get_libdir)


### PR DESCRIPTION
Only call 'python-single-r1_pkg_setup' if USE="python" is set, since
without supported Python targets, things will go bad even if
USE="-python" is being used.
