### PR TITLE
x11-base/xcb-proto: PYTHON_TARGETS+="python3_7"

### DIFF
--- a/x11-base/xcb-proto/xcb-proto-1.13.ebuild
+++ b/x11-base/xcb-proto/xcb-proto-1.13.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} )
 XORG_MULTILIB=yes
 XORG_STATIC=no
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.50, Repoman-2.3.11

Signed-off-by: Philipp Ammann <philipp.ammann@posteo.de>