### PR TITLE
Update dev-libs/ocl-icd

### DIFF
--- a/dev-libs/ocl-icd/metadata.xml
+++ b/dev-libs/ocl-icd/metadata.xml
@@ -5,4 +5,9 @@
     <email>patrick@gentoo.org</email>
     <name>Patrick Lauer</name>
   </maintainer>
+  <use>
+    <flag name="khronos-headers" restrict="&gt;dev-libs/ocl-icd-2.2.11-r1">
+      Install Khronos OpenCL headers.
+    </flag>
+  </use>
 </pkgmetadata>

--- a/media-libs/mesa/mesa-18.2.2-r1.ebuild
+++ b/media-libs/mesa/mesa-18.2.2-r1.ebuild
@@ -95,7 +95,7 @@ RDEPEND="
 		)
 		lm_sensors? ( sys-apps/lm_sensors:=[${MULTILIB_USEDEP}] )
 		opencl? (
-					dev-libs/ocl-icd
+					dev-libs/ocl-icd[khronos-headers]
 					dev-libs/libclc
 					virtual/libelf:0=[${MULTILIB_USEDEP}]
 				)

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -95,7 +95,7 @@ RDEPEND="
 		)
 		lm_sensors? ( sys-apps/lm_sensors:=[${MULTILIB_USEDEP}] )
 		opencl? (
-					dev-libs/ocl-icd
+					dev-libs/ocl-icd[khronos-headers]
 					dev-libs/libclc
 					virtual/libelf:0=[${MULTILIB_USEDEP}]
 				)


### PR DESCRIPTION
Since mesa no longer provides libOpenCL.so or the headers, ocl-icd needs to step in.
Closes: https://bugs.gentoo.org/668140