### PR TITLE
net-irc/inspircd: Fix OpenRC rehash to reload SSL certificates

### DIFF
--- a/net-irc/inspircd/files/inspircd.initd
+++ b/net-irc/inspircd/files/inspircd.initd
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 : ${INSPIRCD_USER:="inspircd"}
@@ -38,6 +38,11 @@ start_pre() {
 rehash() {
 	ebegin "Rehashing InspIRCd"
 	start-stop-daemon --signal HUP --pidfile "${pidfile}"
+
+	# SIGHUP does not reload SSL certificates
+	# They need to be rehashed separately with USR1
+	# https://github.com/inspircd/inspircd/issues/1143
+	start-stop-daemon --signal USR1 --pidfile "${pidfile}"
 	eend $?
 }
 


### PR DESCRIPTION
At present, the OpenRC script for InspIRCd does not have a method to rehash SSL certificates. As short lifespan certificates become more common and rotations more automated, we really need a method to do this.

Other possible solutions could include a separate rehash_ssl action in the runscript, but it's generally assumed that rehash will reload certificates in many applications.

Package-Manager: Portage-2.3.49, Repoman-2.3.11