### PR TITLE
lxqt-base/lxqt-panel: fix build issue related to disabled plugins

### DIFF
--- a/lxqt-base/lxqt-panel/lxqt-panel-0.13.0.ebuild
+++ b/lxqt-base/lxqt-panel/lxqt-panel-0.13.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,7 +23,10 @@ SLOT="0"
 IUSE="+alsa clock colorpicker cpuload +desktopswitch +directorymenu dom +kbindicator +mainmenu
 	+mount networkmonitor pulseaudio +quicklaunch sensors +showdesktop
 	+spacer statusnotifier sysstat +taskbar +tray +volume +worldclock"
-REQUIRED_USE="volume? ( || ( alsa pulseaudio ) )"
+REQUIRED_USE="
+	|| ( desktopswitch mainmenu showdesktop taskbar )
+	volume? ( || ( alsa pulseaudio ) )
+"
 
 RDEPEND="
 	>=dev-libs/libqtxdg-3.0.0


### PR DESCRIPTION
Work around build failure, that will occur if all of 'desktopswitch', 'mainmenu', 'showdesktop', and 'taskbar' are disabled.

Not getting rid of any of the flags yet, since this might be an easy upstream fix.
