### PR TITLE
x11-misc/polybar: Respect CMAKE_INSTALL_DOCDIR

### DIFF
--- a/x11-misc/polybar/files/polybar-3.2.1-versioned-docdir.patch
+++ b/x11-misc/polybar/files/polybar-3.2.1-versioned-docdir.patch
@@ -1,0 +1,13 @@
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index 3ed6c45..775c0af 100644
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -88,7 +88,7 @@ configure_file(
+   ESCAPE_QUOTES @ONLY)
+ 
+ install(FILES config
+-  DESTINATION share/doc/polybar
++  DESTINATION ${CMAKE_INSTALL_DOCDIR}
+   COMPONENT config)
+ 
+ # }}}

--- a/x11-misc/polybar/polybar-3.2.1-r1.ebuild
+++ b/x11-misc/polybar/polybar-3.2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -22,6 +22,9 @@ KEYWORDS="amd64 x86"
 
 IUSE="alsa curl i3wm ipc mpd network pulseaudio"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+PATCHES=(
+    "${FILESDIR}/${PN}-3.2.1-versioned-docdir.patch"
+)
 
 DEPEND="
 	${PYTHON_DEPS}
@@ -62,6 +65,7 @@ src_configure() {
 		-DENABLE_MPD="$(usex mpd)"
 		-DENABLE_NETWORK="$(usex network)"
 		-DENABLE_PULSEAUDIO="$(usex pulseaudio)"
+		-DCMAKE_INSTALL_DOCDIR="share/doc/${PF}"
 	)
 	cmake-utils_src_configure
 }

--- a/x11-misc/polybar/polybar-9999.ebuild
+++ b/x11-misc/polybar/polybar-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,6 +17,9 @@ KEYWORDS=""
 
 IUSE="alsa curl i3wm ipc mpd network pulseaudio"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+PATCHES=(
+    "${FILESDIR}/${PN}-3.2.1-versioned-docdir.patch"
+)
 
 DEPEND="
 	${PYTHON_DEPS}
@@ -45,6 +48,7 @@ src_configure() {
 		-DENABLE_MPD="$(usex mpd)"
 		-DENABLE_NETWORK="$(usex network)"
 		-DENABLE_PULSEAUDIO="$(usex pulseaudio)"
+		-DCMAKE_INSTALL_DOCDIR="share/doc/${PF}"
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
* ~~Add `{bash,zsh}-completion` use flags~~
* Example config is properly installed into `${P}` instead pf `${PN}`