### PR TITLE
dev-libs/mongo-c-driver: drop tests on x86

### DIFF
--- a/dev-libs/mongo-c-driver/mongo-c-driver-0.98.2.ebuild
+++ b/dev-libs/mongo-c-driver/mongo-c-driver-0.98.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -24,6 +24,10 @@ DEPEND="${RDEPEND}
 	test? ( dev-db/mongodb )"
 
 DOCS=( NEWS README.rst TUTORIAL.md )
+
+# No tests on x86 because tests require dev-db/mongodb which don't support
+# x86 anymore (bug #645994)
+RESTRICT="x86? ( test )"
 
 src_prepare() {
 	# https://github.com/mongodb/mongo-c-driver/issues/54

--- a/dev-libs/mongo-c-driver/mongo-c-driver-1.1.10.ebuild
+++ b/dev-libs/mongo-c-driver/mongo-c-driver-1.1.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -24,6 +24,10 @@ DEPEND="${RDEPEND}
 	test? ( dev-db/mongodb )"
 
 DOCS=( NEWS README.rst TUTORIAL.md )
+
+# No tests on x86 because tests require dev-db/mongodb which don't support
+# x86 anymore (bug #645994)
+RESTRICT="x86? ( test )"
 
 src_prepare() {
 	rm -r src/libbson || die

--- a/dev-libs/mongo-c-driver/mongo-c-driver-1.1.2-r1.ebuild
+++ b/dev-libs/mongo-c-driver/mongo-c-driver-1.1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -24,6 +24,10 @@ DEPEND="${RDEPEND}
 	test? ( dev-db/mongodb )"
 
 DOCS=( NEWS README.rst TUTORIAL.md )
+
+# No tests on x86 because tests require dev-db/mongodb which don't support
+# x86 anymore (bug #645994)
+RESTRICT="x86? ( test )"
 
 src_prepare() {
 	rm -r src/libbson || die

--- a/dev-libs/mongo-c-driver/mongo-c-driver-1.3.5.ebuild
+++ b/dev-libs/mongo-c-driver/mongo-c-driver-1.3.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -24,6 +24,10 @@ DEPEND="${RDEPEND}
 	test? ( dev-db/mongodb )"
 
 DOCS=( NEWS README.rst )
+
+# No tests on x86 because tests require dev-db/mongodb which don't support
+# x86 anymore (bug #645994)
+RESTRICT="x86? ( test )"
 
 src_prepare() {
 	rm -r src/libbson || die

--- a/dev-libs/mongo-c-driver/mongo-c-driver-1.6.2.ebuild
+++ b/dev-libs/mongo-c-driver/mongo-c-driver-1.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -24,6 +24,10 @@ DEPEND="${RDEPEND}
 	test? ( dev-db/mongodb )"
 
 DOCS=( NEWS README.rst )
+
+# No tests on x86 because tests require dev-db/mongodb which don't support
+# x86 anymore (bug #645994)
+RESTRICT="x86? ( test )"
 
 src_prepare() {
 	rm -r src/libbson || die


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/668288
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11