### PR TITLE
Add Python 3.7 support to x11-base/xcb-proto and x11-libs/libxcb

### DIFF
--- a/x11-base/xcb-proto/xcb-proto-1.13.ebuild
+++ b/x11-base/xcb-proto/xcb-proto-1.13.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} )
 XORG_MULTILIB=yes
 XORG_STATIC=no
 

--- a/x11-libs/libxcb/libxcb-1.13.1.ebuild
+++ b/x11-libs/libxcb/libxcb-1.13.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} )
 PYTHON_REQ_USE=xml
 
 XORG_DOC=doc

--- a/x11-libs/libxcb/libxcb-1.13.ebuild
+++ b/x11-libs/libxcb/libxcb-1.13.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} )
 PYTHON_REQ_USE=xml
 
 XORG_DOC=doc


### PR DESCRIPTION
Simply adding python3_7 to PYTHON_COMPAT makes those packages compatible with this version.