### PR TITLE
Add Python 3.7 support to dev-java/java-config

### DIFF
--- a/dev-java/java-config/java-config-2.2.0-r4.ebuild
+++ b/dev-java/java-config/java-config-2.2.0-r4.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 # jython depends on java-config, so don't add it or things will break
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Adding python3_7 to PYTHON_COMPAT makes dev-java/java-config compatible with this version.