### PR TITLE
net-p2p/amule: fixed link against crypto++

### DIFF
--- a/net-p2p/amule/amule-2.3.2-r1.ebuild
+++ b/net-p2p/amule/amule-2.3.2-r1.ebuild
@@ -19,7 +19,7 @@ KEYWORDS="alpha amd64 ~arm ppc ppc64 ~sparc x86"
 IUSE="daemon debug geoip nls remote stats unicode upnp +X"
 
 COMMON_DEPEND="
-	dev-libs/crypto++
+	dev-libs/crypto++[asm]
 	sys-libs/binutils-libs:0=
 	sys-libs/zlib
 	x11-libs/wxGTK:${WX_GTK_VER}[X?]

--- a/net-p2p/amule/amule-2.3.2-r2.ebuild
+++ b/net-p2p/amule/amule-2.3.2-r2.ebuild
@@ -20,7 +20,7 @@ IUSE="daemon debug geoip nls remote stats upnp +X"
 
 COMMON_DEPEND="
 	dev-libs/boost:=
-	dev-libs/crypto++:=
+	dev-libs/crypto++:=[asm]
 	sys-libs/binutils-libs:0=
 	sys-libs/zlib
 	x11-libs/wxGTK:${WX_GTK_VER}[X?]


### PR DESCRIPTION
This is build fix, so If I remember correctly, we may not revbump package.
If crypto++ is built without asm use flag amule fails to build:

```
x86_64-pc-linux-gnu-g++ -W -Wall -Wshadow -Wundef -pthread  -O3 -march=native -pipe -fomit-frame-pointer -lpthread -Wl,-O1 -Wl,--as-needed -o amule amule-CaptchaDialog.o amule-CaptchaGenerator.o amule-PartFileConvert.o amule-PartFileConvertDlg.o amule-amule.o amule-BaseClient.o amule-ClientList.o amule-ClientCreditsList.o amule-ClientTCPSocket.o amule-ClientUDPSocket.o amule-CorruptionBlackBox.o amule-DownloadClient.o amule-DownloadQueue.o amule-ECSpecialCoreTags.o amule-EMSocket.o amule-EncryptedStreamSocket.o amule-EncryptedDatagramSocket.o amule-ExternalConn.o amule-FriendList.o amule-IPFilter.o amule-KnownFileList.o amule-ListenSocket.o amule-MuleUDPSocket.o amule-SearchFile.o amule-SearchList.o amule-ServerConnect.o amule-ServerList.o amule-ServerSocket.o amule-ServerUDPSocket.o amule-SHAHashSet.o amule-SharedFileList.o amule-ThreadTasks.o amule-UploadBandwidthThrottler.o amule-UploadClient.o amule-UploadQueue.o amule-Kademlia.o amule-Prefs.o amule-Search.o amule-UDPFirewallTester.o amule-KademliaUDPListener.o amule-PacketTracking.o amule-Contact.o amule-RoutingZone.o amule-amule-gui.o amule-amuleDlg.o amule-AddFriend.o amule-CatDialog.o amule-ChatSelector.o amule-ChatWnd.o amule-CommentDialog.o amule-CommentDialogLst.o amule-GenericClientListCtrl.o amule-ClientDetailDialog.o amule-DirectoryTreeCtrl.o amule-FileDetailDialog.o amule-KadDlg.o amule-OScopeCtrl.o amule-PrefsUnifiedDlg.o amule-SearchDlg.o amule-ServerWnd.o amule-SharedFilesWnd.o amule-StatisticsDlg.o amule-SearchListCtrl.o amule-DownloadListCtrl.o amule-SourceListCtrl.o amule-SharedFilePeersListCtrl.o amule-FriendListCtrl.o amule-ServerListCtrl.o amule-SharedFilesCtrl.o amule-MuleTrayIcon.o amule-TransferWnd.o amule-amuleAppCommon.o amule-ClientRef.o amule-ECSpecialMuleTags.o amule-KnownFile.o amule-GetTickCount.o amule-GuiEvents.o amule-HTTPDownload.o amule-Logger.o amule-PartFile.o amule-Preferences.o amule-Proxy.o amule-Server.o amule-Statistics.o amule-StatTree.o amule-UserEvents.o -L. -lmuleappcommon -Llibs/common -Llibs/ec/cpp -lmulecommon -lec -lbfd  -lz  -lmulesocket  -lboost_system-mt  -lcryptopp -L. -lmuleappcore    -L. -lmuleappgui -L/usr/lib64 -pthread   -lwx_gtk2u_adv-3.0 -lwx_gtk2u_core-3.0 -lwx_baseu_net-3.0 -lwx_baseu-3.0   -lGeoIP  
x86_64-pc-linux-gnu-g++ -W -Wall -Wshadow -Wundef -pthread  -O3 -march=native -pipe -fomit-frame-pointer -lpthread -Wl,-O1 -Wl,--as-needed -o amulecmd amulecmd-TextClient.o amulecmd-DataToText.o amulecmd-ExternalConnector.o amulecmd-LoggerConsole.o amulecmd-OtherFunctions.o amulecmd-NetworkFunctions.o  -Llibs/common -Llibs/ec/cpp -L. -lmulecommon -lec -lmulesocket -L/usr/lib64 -pthread   -lwx_baseu_net-3.0 -lwx_baseu-3.0  -lreadline -lbfd  -lz   -lboost_system-mt 
amule-ClientCreditsList.o: In function `CryptoPP::PK_MessageAccumulatorImpl<CryptoPP::SHA1>::~PK_MessageAccumulatorImpl()':
ClientCreditsList.cpp:(.text._ZN8CryptoPP25PK_MessageAccumulatorImplINS_4SHA1EED2Ev[_ZN8CryptoPP25PK_MessageAccumulatorImplINS_4SHA1EED5Ev]+0x199): undefined reference to `CryptoPP::AlignedDeallocate(void*)'
ClientCreditsList.cpp:(.text._ZN8CryptoPP25PK_MessageAccumulatorImplINS_4SHA1EED2Ev[_ZN8CryptoPP25PK_MessageAccumulatorImplINS_4SHA1EED5Ev]+0x1a9): undefined reference to `CryptoPP::AlignedDeallocate(void*)'
amule-ClientCreditsList.o: In function `CryptoPP::SecBlock<unsigned long, CryptoPP::AllocatorWithCleanup<unsigned long, true> >::~SecBlock()':
ClientCreditsList.cpp:(.text._ZN8CryptoPP8SecBlockImNS_20AllocatorWithCleanupImLb1EEEED2Ev[_ZN8CryptoPP8SecBlockImNS_20AllocatorWithCleanupImLb1EEEED5Ev]+0x31): undefined reference to `CryptoPP::AlignedDeallocate(void*)'
amule-ClientCreditsList.o: In function `CryptoPP::PK_MessageAccumulatorBase::~PK_MessageAccumulatorBase()':
ClientCreditsList.cpp:(.text._ZN8CryptoPP25PK_MessageAccumulatorBaseD0Ev[_ZN8CryptoPP25PK_MessageAccumulatorBaseD5Ev]+0x139): undefined reference to `CryptoPP::AlignedDeallocate(void*)'
ClientCreditsList.cpp:(.text._ZN8CryptoPP25PK_MessageAccumulatorBaseD0Ev[_ZN8CryptoPP25PK_MessageAccumulatorBaseD5Ev]+0x149): undefined reference to `CryptoPP::AlignedDeallocate(void*)'
amule-EncryptedStreamSocket.o:EncryptedStreamSocket.cpp:(.text+0x401): more undefined references to `CryptoPP::AlignedDeallocate(void*)' follow
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:1127: amule] Error 1
make[3]: Leaving directory '/var/tmp/portage/net-p2p/amule-2.3.2-r2/work/aMule-2.3.2/src'
make[2]: *** [Makefile:5336: all-recursive] Error 1
make[2]: Leaving directory '/var/tmp/portage/net-p2p/amule-2.3.2-r2/work/aMule-2.3.2/src'
make[1]: *** [Makefile:532: all-recursive] Error 1
make[1]: Leaving directory '/var/tmp/portage/net-p2p/amule-2.3.2-r2/work/aMule-2.3.2'
make: *** [Makefile:426: all] Error 2
 * ERROR: net-p2p/amule-2.3.2-r2::gentoo failed (compile phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=net-p2p/amule-2.3.2-r2::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=net-p2p/amule-2.3.2-r2::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/net-p2p/amule-2.3.2-r2/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/net-p2p/amule-2.3.2-r2/temp/environment'.
 * Working directory: '/var/tmp/portage/net-p2p/amule-2.3.2-r2/work/aMule-2.3.2'
 * S: '/var/tmp/portage/net-p2p/amule-2.3.2-r2/work/aMule-2.3.2'
```
