### PR TITLE
www-client/midori: Fix net-libs/webkit-gtk[jit] dependence to net-libs/webkit-gtk[jit,opengl]

### DIFF
--- a/www-client/midori/midori-0.5.11-r2.ebuild
+++ b/www-client/midori/midori-0.5.11-r2.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	>=net-libs/libsoup-2.38:2.4
 	>=x11-libs/libnotify-0.7
 	>=x11-libs/gtk+-3.10.0:3
-	>=net-libs/webkit-gtk-2.3.91:4[jit=]
+	>=net-libs/webkit-gtk-2.3.91:4[jit=,opengl]
 	granite? ( >=dev-libs/granite-0.2 )
 	xscreensaver? (
 		x11-libs/libX11

--- a/www-client/midori/midori-0.5.11-r3.ebuild
+++ b/www-client/midori/midori-0.5.11-r3.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	>=net-libs/libsoup-2.38:2.4
 	>=x11-libs/libnotify-0.7
 	>=x11-libs/gtk+-3.10.0:3
-	>=net-libs/webkit-gtk-2.3.91:4[jit=]
+	>=net-libs/webkit-gtk-2.3.91:4[jit=,opengl]
 	granite? ( >=dev-libs/granite-0.2 )
 	xscreensaver? (
 		x11-libs/libX11


### PR DESCRIPTION
Hello,
I was trying to build www-client/midori with all net-libs/webkit-gtk USE flags disabled and it failed until I enabled opengl use flag. So as a result, midori doesnot depend on net-libs/webkit-gtk[jit] but depends on net-libs/webkit-gtk[jit,opengl].