### PR TITLE
www-client/firefox: add ~arm64 keyword to v63.0

### DIFF
--- a/www-client/firefox/firefox-63.0.ebuild
+++ b/www-client/firefox/firefox-63.0.ebuild
@@ -36,7 +36,7 @@ inherit check-reqs flag-o-matic toolchain-funcs eutils gnome2-utils llvm \
 DESCRIPTION="Firefox Web Browser"
 HOMEPAGE="https://www.mozilla.com/firefox"
 
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 SLOT="0"
 LICENSE="MPL-2.0 GPL-2 LGPL-2.1"


### PR DESCRIPTION
Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
Package-Manager: Portage-2.3.49, Repoman-2.3.11

This PR is just for gentoo-CI to do its thing.