### PR TITLE
net-im/telegram-desktop-bin: remove obsolete file

### DIFF
--- a/net-im/telegram-desktop-bin/files/telegram-desktop-bin-r1
+++ b/net-im/telegram-desktop-bin/files/telegram-desktop-bin-r1
@@ -1,9 +1,0 @@
-#!/bin/sh
-# this wrapper disables the auto-updater of telegram-desktop
-# This program is licensed under the same license as telegram-desktop
-
-# telegram-desktop fails to set RestartCommand with the session manager
-# exclude it from session management to prevent restarts without the argument
-unset SESSION_MANAGER
-
-exec /usr/lib/telegram-desktop-bin/Telegram -externalupdater $@


### PR DESCRIPTION
file made obsolete by 3a5ad41ffebc

Signed-off-by: Henning Schild <henning@hennsch.de>