### PR TITLE
net-im/telegram-desktop-bin: fix Icon in .desktop file

### DIFF
--- a/net-im/telegram-desktop-bin/telegram-desktop-bin-1.4.3-r1.ebuild
+++ b/net-im/telegram-desktop-bin/telegram-desktop-bin-1.4.3-r1.ebuild
@@ -39,7 +39,7 @@ src_install() {
 	for icon_size in 16 32 48 64 128 256 512; do
 		newicon -s "${icon_size}" \
 			"${WORKDIR}/tdesktop-${PV}/Telegram/Resources/art/icon${icon_size}.png" \
-			telegram-desktop.png
+			telegram.png
 	done
 
 	dodir /etc/${PN}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/667784
Signed-off-by: Henning Schild <henning@hennsch.de>