### PR TITLE
net-im/skypeforlinux - Add runtime dependencies for logind

### DIFF
--- a/net-im/skypeforlinux/skypeforlinux-8.32.0.44-r1.ebuild
+++ b/net-im/skypeforlinux/skypeforlinux-8.32.0.44-r1.ebuild
@@ -21,6 +21,10 @@ QA_PREBUILT="*"
 RESTRICT="mirror bindist strip" #299368
 
 RDEPEND="
+	|| (
+		sys-auth/elogind
+		sys-apps/systemd
+	)
 	dev-libs/atk[${MULTILIB_USEDEP}]
 	dev-libs/expat[${MULTILIB_USEDEP}]
 	dev-libs/glib:2[${MULTILIB_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/666396

Signed-off-by: Gino B <onigino@protonmail.com>
Reported-by:  Guillaume Castagnino <casta@xwing.info>