### PR TITLE
Revert "net-misc/bopm: Remove proxied maintainer"

### DIFF
--- a/net-misc/bopm/metadata.xml
+++ b/net-misc/bopm/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!--maintainer-needed-->
+	<maintainer type="person">
+		<email>shentino@gmail.com</email>
+		<name>Shentino</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">blitzed-org/bopm</remote-id>
 	</upstream>


### PR DESCRIPTION
I would like to be readded as the proxied maintainer for BOPM.

I recently realized that me being removed isn't just a cosmestic/paperwork change and will actually hamper my ability to remain active.

Removing me as a listed maintainer will blind my attention to future bug reports against this package which I will be willing to address if/when they are filed.  But without me being listed the bug wranglers won't know to assign such bugs to me, and polling bugzilla for bugs against bopm is not an optimal way to spend my time.

The only reason I was inactive in bopm is because it's an old package that quite simply doesn't get much activity.  I was not inactive, I was just idle.  Mind you I want to be ready to receive any future bugs against this package and I feel that my removal as proxied maintainer was not in the best interests of this package.

This reverts commit 185bff2c0d9947cb053cd6d2a851f28dff0052a3.