### PR TITLE
x11-drivers/xf86-video-amdgpu: add "udev" USE flag

### DIFF
--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-18.1.0-r1.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-18.1.0-r1.ebuild
@@ -13,11 +13,17 @@ fi
 
 DESCRIPTION="Accelerated Open Source driver for AMDGPU cards"
 
+IUSE="udev"
+
 RDEPEND=">=x11-libs/libdrm-2.4.78[video_cards_amdgpu]
-	x11-base/xorg-server[glamor(-)]"
+	x11-base/xorg-server[glamor(-)]
+	udev? ( virtual/libudev:= )"
 DEPEND="${RDEPEND}"
 
 src_configure() {
-	XORG_CONFIGURE_OPTIONS="--enable-glamor"
+	XORG_CONFIGURE_OPTIONS=(
+		--enable-glamor
+		$(use_enable udev)
+	)
 	xorg-2_src_configure
 }


### PR DESCRIPTION
This fixes automagic dependency on udev.

Closes: https://bugs.gentoo.org/667058
Signed-off-by: Alexander Tsoy <alexander@tsoy.me>