### PR TITLE
net-libs/libesmtp: Fix OpenSSL 1.1, EAPI=7 bump

### DIFF
--- a/net-libs/libesmtp/files/libesmtp-1.0.6-openssl-1.1-api-compatibility.patch
+++ b/net-libs/libesmtp/files/libesmtp-1.0.6-openssl-1.1-api-compatibility.patch
@@ -1,0 +1,72 @@
+diff --git a/configure.ac b/configure.ac
+index 556f220..2c0693d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -303,7 +303,7 @@ if test x$with_openssl != xno ; then
+ 	)
+ fi
+ if test x$with_openssl != xno ; then
+-	AC_CHECK_LIB(ssl, SSL_library_init, [
++	AC_CHECK_LIB(ssl, SSL_new, [
+ 				with_openssl=yes
+ 				LIBS="-lssl -lcrypto $LIBS"
+ 		     ], [
+diff --git a/smtp-tls.c b/smtp-tls.c
+index 9a66806..cfc6589 100644
+--- a/smtp-tls.c
++++ b/smtp-tls.c
+@@ -57,6 +57,7 @@ static void *ctx_password_cb_arg;
+ #ifdef USE_PTHREADS
+ #include <pthread.h>
+ static pthread_mutex_t starttls_mutex = PTHREAD_MUTEX_INITIALIZER;
++#if OPENSSL_VERSION_NUMBER < 0x10100000
+ static pthread_mutex_t *openssl_mutex;
+ 
+ static void
+@@ -70,6 +71,7 @@ openssl_mutexcb (int mode, int n,
+     pthread_mutex_unlock (&openssl_mutex[n]);
+ }
+ #endif
++#endif
+ 
+ static int
+ starttls_init (void)
+@@ -77,6 +79,10 @@ starttls_init (void)
+   if (tls_init)
+     return 1;
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000
++  /* starting from OpenSSL 1.1.0, OpenSSL uses a new threading API and does its own locking */
++  /* also initialization has been reworked and is done automatically */
++  /* so there's not much to do here any more */
+ #ifdef USE_PTHREADS
+   /* Set up mutexes for the OpenSSL library */
+   if (openssl_mutex == NULL)
+@@ -94,9 +100,10 @@ starttls_init (void)
+       CRYPTO_set_locking_callback (openssl_mutexcb);
+     }
+ #endif
+-  tls_init = 1;
+   SSL_load_error_strings ();
+   SSL_library_init ();
++#endif
++  tls_init = 1;
+   return 1;
+ }
+ 
+@@ -201,7 +208,15 @@ starttls_create_ctx (smtp_session_t session)
+      3207.  Servers typically support SSL as well as TLS because some
+      versions of Netscape do not support TLS.  I am assuming that all
+      currently deployed servers correctly support TLS.  */
++#if OPENSSL_VERSION_NUMBER < 0x10100000
+   ctx = SSL_CTX_new (TLSv1_client_method ());
++#else
++  ctx = SSL_CTX_new (TLS_client_method ());
++  if (!SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION)) {
++        /* FIXME: set an error code AND free the allocated ctx */
++        return NULL;
++  }
++#endif
+ 
+   /* Load our keys and certificates.  To avoid messing with configuration
+      variables etc, use fixed paths for the certificate store.  These are

--- a/net-libs/libesmtp/libesmtp-1.0.6-r3.ebuild
+++ b/net-libs/libesmtp/libesmtp-1.0.6-r3.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit autotools
+
+DESCRIPTION="lib that implements the client side of the SMTP protocol"
+HOMEPAGE="http://brianstafford.info/libesmtp/"
+SRC_URI="http://brianstafford.info/${PN}/${P}.tar.bz2"
+
+LICENSE="LGPL-2.1 GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~x86-macos"
+IUSE="debug libressl ntlm ssl static-libs threads"
+
+RDEPEND="
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:= )
+	)"
+DEPEND="${RDEPEND}"
+DOCS=( AUTHORS ChangeLog NEWS Notes README TODO )
+PATCHES=(
+	"${FILESDIR}/${P}-openssl-1.1-api-compatibility.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-dependency-tracking \
+		$(use_enable static-libs static) \
+		--enable-all \
+		$(use_enable ntlm) \
+		$(use_enable threads pthreads) \
+		$(use_enable debug) \
+		$(use_with ssl openssl)
+}
+
+src_install() {
+	default
+	insinto /usr/share/doc/${PF}/xml
+	doins doc/api.xml
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/624412
Signed-off-by: Craig Andrews <candrews@gentoo.org>
Package-Manager: Portage-2.3.51, Repoman-2.3.11