### PR TITLE
net-misc/iperf: add USE=libressl

### DIFF
--- a/net-misc/iperf/iperf-3.5.ebuild
+++ b/net-misc/iperf/iperf-3.5.ebuild
@@ -11,9 +11,11 @@ SRC_URI="${HOMEPAGE}archive/${PV/_/}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="3"
 KEYWORDS="~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint"
-IUSE="sctp static-libs"
+IUSE="libressl sctp static-libs"
 
-DEPEND="dev-libs/openssl:0=
+DEPEND="
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
 	sctp? ( net-misc/lksctp-tools )"
 RDEPEND="${DEPEND}"
 

--- a/net-misc/iperf/iperf-3.6.ebuild
+++ b/net-misc/iperf/iperf-3.6.ebuild
@@ -11,9 +11,11 @@ SRC_URI="${HOMEPAGE}archive/${PV/_/}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="3"
 KEYWORDS="~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint"
-IUSE="sctp static-libs"
+IUSE="libressl sctp static-libs"
 
-DEPEND="dev-libs/openssl:0=
+DEPEND="
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
 	sctp? ( net-misc/lksctp-tools )"
 RDEPEND="${DEPEND}"
 

--- a/net-misc/iperf/iperf-3.99999.99999.ebuild
+++ b/net-misc/iperf/iperf-3.99999.99999.ebuild
@@ -11,9 +11,11 @@ EGIT_REPO_URI="${HOMEPAGE}"
 LICENSE="BSD"
 SLOT="3"
 KEYWORDS=""
-IUSE="profiling sctp static-libs"
+IUSE="libressl profiling sctp static-libs"
 
-DEPEND="dev-libs/openssl:0=
+DEPEND="
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
 	sctp? ( net-misc/lksctp-tools )"
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/658050
Package-Manager: Portage-2.3.51, Repoman-2.3.11
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>