### PR TITLE
net-mail/fetchmail: libressl and OpenSSL 1.1 support, EAPI=7

### DIFF
--- a/net-mail/fetchmail/fetchmail-6.3.26-r4.ebuild
+++ b/net-mail/fetchmail/fetchmail-6.3.26-r4.ebuild
@@ -1,0 +1,109 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="tk"
+
+inherit python-single-r1 user systemd toolchain-funcs autotools
+
+DESCRIPTION="the legendary remote-mail retrieval and forwarding utility"
+HOMEPAGE="http://www.fetchmail.info/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz"
+
+LICENSE="GPL-2 public-domain"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="ssl nls kerberos tk socks libressl"
+REQUIRED_USE="tk? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="ssl? (
+		!libressl? ( >=dev-libs/openssl-0.9.6:= )
+		libressl?  ( dev-libs/libressl:= )
+	)
+	kerberos? (
+		virtual/krb5
+		!libressl? ( >=dev-libs/openssl-0.9.6:= )
+		libressl?  ( dev-libs/libressl:= )
+	)
+	nls? ( virtual/libintl )
+	!elibc_glibc? ( sys-libs/e2fsprogs-libs )
+	socks? ( net-proxy/dante )
+	tk? ( ${PYTHON_DEPS} )"
+DEPEND="${RDEPEND}
+	app-arch/xz-utils
+	sys-devel/flex
+	nls? ( sys-devel/gettext )"
+
+DOCS="FAQ FEATURES NEWS NOTES README README.NTLM README.SSL* TODO"
+HTML_DOCS="*.html"
+PATCHES=(
+	"${FILESDIR}"/${P}-python-optional.patch
+	"${FILESDIR}"/${P}-tests.patch
+	"${FILESDIR}"/${P}-libressl.patch
+)
+
+pkg_setup() {
+	enewgroup ${PN}
+	enewuser ${PN} -1 -1 /var/lib/${PN} ${PN}
+
+	use tk && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+	# don't compile during src_install
+	use tk && : > "${S}"/py-compile
+	eautoreconf
+}
+
+src_configure() {
+	use tk || export PYTHON=:
+
+	econf \
+		--enable-RPA \
+		--enable-NTLM \
+		--enable-SDPS \
+		$(use_enable nls) \
+		$(use_with ssl ssl "${EPREFIX}/usr") \
+		$(use kerberos && echo "--with-ssl=${EPREFIX}/usr") \
+		$(use_with kerberos gssapi) \
+		$(use_with kerberos kerberos5) \
+		--without-hesiod \
+		$(use_with socks)
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
+src_install() {
+	# fetchmail's homedir (holds fetchmail's .fetchids)
+	keepdir /var/lib/${PN}
+	fowners ${PN}:${PN} /var/lib/${PN}
+	fperms 700 /var/lib/${PN}
+
+	default
+
+	newinitd "${FILESDIR}"/fetchmail.initd fetchmail
+	newconfd "${FILESDIR}"/fetchmail.confd fetchmail
+
+	systemd_dounit  "${FILESDIR}"/${PN}.service
+	systemd_newunit "${FILESDIR}"/${PN}_at.service "${PN}@.service"
+	systemd_dotmpfilesd "${FILESDIR}"/${PN}.conf
+
+	docinto contrib
+	local f
+	for f in contrib/* ; do
+		[ -f "${f}" ] && dodoc "${f}"
+	done
+
+	use tk && python_optimize
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		elog "Please see /etc/conf.d/fetchmail if you want to adjust"
+		elog "the polling delay used by the fetchmail init script."
+	fi
+}

--- a/net-mail/fetchmail/files/fetchmail-6.3.26-libressl.patch
+++ b/net-mail/fetchmail/files/fetchmail-6.3.26-libressl.patch
@@ -1,0 +1,117 @@
+--- a/configure.ac	2013-04-23 16:51:10.000000000 -0400
++++ b/configure.ac	2016-01-30 00:14:01.114090572 -0500
+@@ -803,6 +803,7 @@
+ 
+ case "$LIBS" in *-lssl*)
+ 	AC_CHECK_DECLS([SSLv2_client_method],,,[#include <openssl/ssl.h>])
++	AC_CHECK_DECLS([SSLv3_client_method],,,[#include <openssl/ssl.h>])
+ 	;;
+ esac
+ 
+--- a/po/de.po	2013-04-23 17:33:52.000000000 -0400
++++ b/po/de.po	2016-01-30 00:25:00.255287974 -0500
+@@ -8,8 +8,8 @@
+ msgstr ""
+ "Project-Id-Version: fetchmail 6.3.26\n"
+ "Report-Msgid-Bugs-To: fetchmail-devel@lists.berlios.de\n"
+-"POT-Creation-Date: 2013-04-23 23:24+0200\n"
+-"PO-Revision-Date: 2013-04-23 23:33+0200\n"
++"POT-Creation-Date: 2015-01-16 20:42+0100\n"
++"PO-Revision-Date: 2016-01-30 00:23-0500\n"
+ "Last-Translator: Matthias Andree <matthias.andree@gmx.de>\n"
+ "Language-Team: Deutsch <de@li.org>\n"
+ "Language: \n"
+@@ -3198,20 +3198,24 @@
+ msgstr "Datei-Deskriptor außerhalb des Bereichs für SSL"
+ 
+ #: socket.c:913
+-msgid "Your operating system does not support SSLv2.\n"
+-msgstr "Ihr Betriebssystem unterstützt SSLv2 nicht.\n"
++msgid "Your OpenSSL version does not support SSLv2.\n"
++msgstr "Ihre OpenSSL-Version unterstützt SSLv2 nicht.\n"
+ 
+-#: socket.c:923
++#: socket.c:920
++msgid "Your OpenSSL version does not support SSLv3.\n"
++msgstr "Ihre OpenSSL-Version unterstützt SSLv3 nicht.\n"
++
++#: socket.c:928
+ #, c-format
+ msgid "Invalid SSL protocol '%s' specified, using default (SSLv23).\n"
+ msgstr ""
+ "Ungültiges SSL-Protokoll „%s“ angegeben, benutze Voreinstellung (SSLv23).\n"
+ 
+-#: socket.c:1022
++#: socket.c:1027
+ msgid "Certificate/fingerprint verification was somehow skipped!\n"
+ msgstr "Zertifikat-/Fingerabdruck-Überprüfung wurde irgendwie übersprungen!\n"
+ 
+-#: socket.c:1039
++#: socket.c:1044
+ msgid ""
+ "Warning: the connection is insecure, continuing anyways. (Better use --"
+ "sslcertck!)\n"
+@@ -3219,11 +3223,11 @@
+ "Warnung: Die Verbindung ist unsicher, mache trotzdem weiter. (Nehmen Sie "
+ "lieber --sslcertck!)\n"
+ 
+-#: socket.c:1081
++#: socket.c:1086
+ msgid "Cygwin socket read retry\n"
+ msgstr "Cygwin-Socket-Lese-Wiederholung\n"
+ 
+-#: socket.c:1084
++#: socket.c:1089
+ msgid "Cygwin socket read retry failed!\n"
+ msgstr "Cygwin-Socket-Lese-Wiederholung fehlgeschlagen!\n"
+ 
+--- a/fetchmail.c	2013-04-23 16:00:45.000000000 -0400
++++ b/fetchmail.c	2016-01-30 00:16:26.104294447 -0500
+@@ -54,6 +54,10 @@
+ #define ENETUNREACH   128       /* Interactive doesn't know this */
+ #endif /* ENETUNREACH */
+ 
++#ifdef SSL_ENABLE
++#include <openssl/ssl.h>	/* for OPENSSL_NO_SSL2 and ..._SSL3 checks */
++#endif
++
+ /* prototypes for internal functions */
+ static int load_params(int, char **, int);
+ static void dump_params (struct runctl *runp, struct query *, flag implicit);
+@@ -263,6 +267,12 @@
+ #ifdef SSL_ENABLE
+ 	"+SSL"
+ #endif
++#if HAVE_DECL_SSLV2_CLIENT_METHOD + 0 == 0
++	"-SSLv2"
++#endif
++#if HAVE_DECL_SSLV3_CLIENT_METHOD + 0 == 0
++	"-SSLv3"
++#endif
+ #ifdef OPIE_ENABLE
+ 	"+OPIE"
+ #endif /* OPIE_ENABLE */
+--- a/socket.c	2013-04-23 16:00:45.000000000 -0400
++++ b/socket.c	2016-01-30 00:28:26.718678785 -0500
+@@ -907,14 +907,19 @@
+ 	_ssl_context[sock] = NULL;
+ 	if(myproto) {
+ 		if(!strcasecmp("ssl2",myproto)) {
+-#if HAVE_DECL_SSLV2_CLIENT_METHOD + 0 > 0
++#if (HAVE_DECL_SSLV2_CLIENT_METHOD + 0 > 0) && (0 == OPENSSL_NO_SSL2 + 0)
+ 			_ctx[sock] = SSL_CTX_new(SSLv2_client_method());
+ #else
+-			report(stderr, GT_("Your operating system does not support SSLv2.\n"));
++			report(stderr, GT_("Your OpenSSL version does not support SSLv2.\n"));
+ 			return -1;
+ #endif
+ 		} else if(!strcasecmp("ssl3",myproto)) {
++#if (HAVE_DECL_SSLV3_CLIENT_METHOD + 0 > 0) && (0 == OPENSSL_NO_SSL3 + 0)
+ 			_ctx[sock] = SSL_CTX_new(SSLv3_client_method());
++#else
++			report(stderr, GT_("Your OpenSSL version does not support SSLv3.\n"));
++			return -1;
++#endif
+ 		} else if(!strcasecmp("tls1",myproto)) {
+ 			_ctx[sock] = SSL_CTX_new(TLSv1_client_method());
+ 		} else if (!strcasecmp("ssl23",myproto)) {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/573352
Signed-off-by: Craig Andrews <candrews@gentoo.org>
Package-Manager: Portage-2.3.51, Repoman-2.3.11