### PR TITLE
net-dialup/xl2tpd: add kernel mode support

### DIFF
--- a/net-dialup/xl2tpd/metadata.xml
+++ b/net-dialup/xl2tpd/metadata.xml
@@ -12,6 +12,7 @@
 	<longdescription>xl2tpd is a fork of l2tpd Layer 2 Tunneling Protocol (L2TP) daemon that can be used to transfer frames of OSI layer 2 protocols through an IP tunnel. While it provides authentication via CHAP or PAP it does not provide encryption itself and should therefore be externally secured (via IPSEC).</longdescription>
 	<use>
 		<flag name="dnsretry">Patch for host lookup retries, activated by redial feature</flag>
+		<flag name="kernel">Enable kernel interface for PPPoL2TP</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">xelerance/xl2tpd</remote-id>

--- a/net-dialup/xl2tpd/xl2tpd-1.3.12-r1.ebuild
+++ b/net-dialup/xl2tpd/xl2tpd-1.3.12-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit systemd toolchain-funcs
+
+DESCRIPTION="A modern version of the Layer 2 Tunneling Protocol (L2TP) daemon"
+HOMEPAGE="https://github.com/xelerance/xl2tpd"
+SRC_URI="https://github.com/xelerance/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
+IUSE="+kernel"
+
+DEPEND="
+	net-libs/libpcap
+	sys-kernel/linux-headers"
+
+RDEPEND="
+	${DEPEND}
+	net-dialup/ppp"
+
+DOCS=(CREDITS README.xl2tpd BUGS CHANGES TODO doc/README.patents)
+
+src_compile() {
+	tc-export CC
+	local osflags="-DLINUX"
+	use kernel && osflags+=" -DUSE_KERNEL"
+	emake OSFLAGS="$osflags"
+}
+
+src_install() {
+	emake PREFIX=/usr DESTDIR="${D}" install
+
+	newinitd "${FILESDIR}"/xl2tpd-init-r1 xl2tpd
+
+	systemd_dounit "${FILESDIR}"/xl2tpd.service
+	systemd_dotmpfilesd "${FILESDIR}"/xl2tpd.conf
+
+	einstalldocs
+
+	insinto /etc/xl2tpd
+	newins doc/l2tpd.conf.sample xl2tpd.conf
+	insopts -m 0600
+	newins doc/l2tp-secrets.sample l2tp-secrets
+}


### PR DESCRIPTION
Signed-off-by: Michael Perlov <perlovka@gmail.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11

Kernel mode support has been completely removed for some reason in versions >1.3.1-r4.
xl2tpd consumes around %10 CPU on i5-660 upon downloading files (e.g. kernel source) when not in kernel mode.

Tested with vanilla-sources-4.18.16 using kernel mode - 0% CPU consumed.
