### PR TITLE
x11-misc/xflux: bump to EAPI=7

### DIFF
--- a/x11-misc/xflux/metadata.xml
+++ b/x11-misc/xflux/metadata.xml
@@ -9,4 +9,9 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<longdescription>
+		F.lux makes your computer screen look like the room you're in, all the time.
+		When the sun sets, it makes your computer look like your indoor lights.
+		In the morning, it makes things look like sunlight again.
+	</longdescription>
 </pkgmetadata>

--- a/x11-misc/xflux/xflux-20130927-r1.ebuild
+++ b/x11-misc/xflux/xflux-20130927-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Makes the color of your computer's display adapt to the time of the day"
+HOMEPAGE="https://justgetflux.com/"
+SRC_URI="
+	amd64? ( https://justgetflux.com/linux/${PN}64.tgz -> ${PN}64-${PV}.tar.gz )
+	x86? ( https://justgetflux.com/linux/${PN}-pre.tgz -> ${P}.tar.gz )
+"
+
+KEYWORDS="-* ~amd64 ~x86"
+LICENSE="f.lux"
+SLOT="0"
+
+RESTRICT="bindist mirror"
+
+RDEPEND="
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXrandr
+	x11-libs/libXxf86vm
+"
+
+S="${WORKDIR}"
+
+QA_PREBUILT="usr/bin/xflux"
+
+src_install() {
+	dobin xflux
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/669760
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11