### PR TITLE
x11-misc/xflux-gui: updated metadata.xml

### DIFF
--- a/x11-misc/xflux-gui/metadata.xml
+++ b/x11-misc/xflux-gui/metadata.xml
@@ -9,4 +9,14 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<longdescription>
+		The f.lux indicator applet fluxgui is an indicator applet to control xflux,
+		an application that makes the color of your computer's display adapt to
+		the time of day: warm at night, and like sunlight during the day.
+		Reducing blue light exposure in the evening can help you fall asleep at night.
+	</longdescription>
+	<upstream>
+		<bugs-to>https://github.com/xflux-gui/fluxgui/issues</bugs-to>
+		<remote-id type="github">xflux-gui/fluxgui</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Added a longdescription and upstream section.

Closes: https://bugs.gentoo.org/669762
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11