### PR TITLE
boot-sys/os-prober: Bump to EAPI=7

### DIFF
--- a/sys-boot/os-prober/metadata.xml
+++ b/sys-boot/os-prober/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>pabloorduna98@gmail.com</email>
+		<name>Pablo Orduna</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Gentoo Proxy Maintainers Project</name>
+	</maintainer>
 </pkgmetadata>

--- a/sys-boot/os-prober/os-prober-1.76-r1.ebuild
+++ b/sys-boot/os-prober/os-prober-1.76-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit readme.gentoo-r1 toolchain-funcs
 
 DESCRIPTION="Utility to detect other OSs on a set of drives"


### PR DESCRIPTION
Bumped the ebuild to EAPI 7 and added myself as Proxy Maintainer

Signed-off-by: Pablo Orduna <pabloorduna98@gmail.com>