### PR TITLE
dev-python/pallets-sphinx-themes: add rdepend on jinja/packaging

### DIFF
--- a/dev-python/pallets-sphinx-themes/pallets-sphinx-themes-1.1.2.ebuild
+++ b/dev-python/pallets-sphinx-themes/pallets-sphinx-themes-1.1.2.ebuild
@@ -15,4 +15,6 @@ SLOT="0"
 KEYWORDS="~amd64 ~ia64 ~x86"
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
-RDEPEND="dev-python/sphinx[${PYTHON_USEDEP}]"
+RDEPEND="dev-python/jinja[${PYTHON_USEDEP}]
+	dev-python/packaging[${PYTHON_USEDEP}]
+	dev-python/sphinx[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/669814
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11