### PR TITLE
media-sound/whipper: changed homepage to match new project home

### DIFF
--- a/media-sound/whipper/whipper-0.7.0.ebuild
+++ b/media-sound/whipper/whipper-0.7.0.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
 DESCRIPTION="A Python CD-DA ripper preferring accuracy over speed (forked from morituri)"
-HOMEPAGE="https://github.com/JoeLametta/whipper"
-SRC_URI="https://github.com/JoeLametta/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/whipper-team/whipper"
+SRC_URI="https://github.com/whipper-team/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3+"
 SLOT="0"


### PR DESCRIPTION
Whipper project moved its home to what seems to be a "GitHub's organization".
GitHub is automatically redirecting old links to that new home but I thought it was better to update links in ebuild too.