### PR TITLE
net-irc/hexchat: Needs dev-util/glib-utils

### DIFF
--- a/net-irc/hexchat/hexchat-2.14.2.ebuild
+++ b/net-irc/hexchat/hexchat-2.14.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -54,6 +54,7 @@ COMMON_DEPEND="
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="
 	${COMMON_DEPEND}
+	dev-util/glib-utils
 	app-arch/xz-utils
 	app-text/iso-codes
 	sys-devel/gettext

--- a/net-irc/hexchat/hexchat-9999.ebuild
+++ b/net-irc/hexchat/hexchat-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -54,6 +54,7 @@ COMMON_DEPEND="
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="
 	${COMMON_DEPEND}
+	dev-util/glib-utils
 	app-arch/xz-utils
 	app-text/iso-codes
 	sys-devel/gettext


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/669932
Signed-off-by: Anthony Ryan <anthonyryan1@gmail.com>
Package-Manager: Portage-2.3.49, Repoman-2.3.11