### PR TITLE
dev-libs/spsdeclib: fix dodoc failed

### DIFF
--- a/dev-libs/spsdeclib/spsdeclib-5.1-r1.ebuild
+++ b/dev-libs/spsdeclib/spsdeclib-5.1-r1.ebuild
@@ -17,7 +17,7 @@ DEPEND="app-arch/unzip"
 
 S="${WORKDIR}/capsimg_source_linux_macosx/CAPSImg"
 
-DOCS=( "${WORKDIR}/{DONATIONS,HISTORY,RELEASE}.txt" )
+DOCS=( "${WORKDIR}"/{DONATIONS,HISTORY,RELEASE}.txt )
 
 PATCHES=( "${FILESDIR}"/add_symlink.patch )
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/669988
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11