### PR TITLE
media-sound/spotify: use gunzip instead of uncompress for docs

### DIFF
--- a/media-sound/spotify/spotify-1.0.72-r1.ebuild
+++ b/media-sound/spotify/spotify-1.0.72-r1.ebuild
@@ -56,7 +56,7 @@ src_prepare() {
 }
 
 src_install() {
-	uncompress usr/share/doc/spotify-client/changelog.gz
+	gunzip usr/share/doc/spotify-client/changelog.gz || die
 	dodoc usr/share/doc/spotify-client/changelog
 
 	SPOTIFY_PKG_HOME=usr/share/spotify

--- a/media-sound/spotify/spotify-1.0.80-r1.ebuild
+++ b/media-sound/spotify/spotify-1.0.80-r1.ebuild
@@ -60,7 +60,7 @@ src_prepare() {
 }
 
 src_install() {
-	uncompress usr/share/doc/spotify-client/changelog.gz
+	gunzip usr/share/doc/spotify-client/changelog.gz || die
 	dodoc usr/share/doc/spotify-client/changelog
 
 	SPOTIFY_PKG_HOME=usr/share/spotify

--- a/media-sound/spotify/spotify-1.0.92.ebuild
+++ b/media-sound/spotify/spotify-1.0.92.ebuild
@@ -60,7 +60,7 @@ src_prepare() {
 }
 
 src_install() {
-	uncompress usr/share/doc/spotify-client/changelog.gz
+	gunzip usr/share/doc/spotify-client/changelog.gz || die
 	dodoc usr/share/doc/spotify-client/changelog
 
 	SPOTIFY_PKG_HOME=usr/share/spotify


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/670016
Signed-off-by: Nikos Chantziaras <realnc@gmail.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11