### PR TITLE
app-shells: {gentoo-,}zsh-completions add ~arm64 keyword

### DIFF
--- a/app-shells/gentoo-zsh-completions/gentoo-zsh-completions-20150103.ebuild
+++ b/app-shells/gentoo-zsh-completions/gentoo-zsh-completions-20150103.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/gentoo/gentoo-zsh-completions.git"
 else
 	SRC_URI="https://github.com/gentoo/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc64-solaris"
+	KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc64-solaris"
 fi
 
 DESCRIPTION="Gentoo specific zsh completion support (includes emerge and ebuild commands)"

--- a/app-shells/gentoo-zsh-completions/gentoo-zsh-completions-20180228.ebuild
+++ b/app-shells/gentoo-zsh-completions/gentoo-zsh-completions-20180228.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/gentoo/gentoo-zsh-completions.git"
 else
 	SRC_URI="https://github.com/gentoo/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc64-solaris"
+	KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc64-solaris"
 fi
 
 DESCRIPTION="Gentoo specific zsh completion support (includes emerge and ebuild commands)"

--- a/app-shells/gentoo-zsh-completions/gentoo-zsh-completions-99999999.ebuild
+++ b/app-shells/gentoo-zsh-completions/gentoo-zsh-completions-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/gentoo/gentoo-zsh-completions.git"
 else
 	SRC_URI="https://github.com/gentoo/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc64-solaris"
+	KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc64-solaris"
 fi
 
 DESCRIPTION="Gentoo specific zsh completion support (includes emerge and ebuild commands)"

--- a/app-shells/zsh-completions/zsh-completions-0.27.0.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-0.27.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/zsh-users/zsh-completions.git"
 else
 	SRC_URI="https://github.com/zsh-users/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~arm ~sparc ~x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~sparc ~x86"
 fi
 
 DESCRIPTION="Additional completion definitions for Zsh"

--- a/app-shells/zsh-completions/zsh-completions-0.28.0.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-0.28.0.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/zsh-users/zsh-completions.git"
 else
 	SRC_URI="https://github.com/zsh-users/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~arm ~sparc ~x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~sparc ~x86"
 fi
 
 DESCRIPTION="Additional completion definitions for Zsh"

--- a/app-shells/zsh-completions/zsh-completions-0.29.0.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-0.29.0.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/zsh-users/zsh-completions.git"
 else
 	SRC_URI="https://github.com/zsh-users/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~sparc ~x86"
 fi
 
 DESCRIPTION="Additional completion definitions for Zsh"

--- a/app-shells/zsh-completions/zsh-completions-9999.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/zsh-users/zsh-completions.git"
 else
 	SRC_URI="https://github.com/zsh-users/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
 DESCRIPTION="Additional completion definitions for Zsh"


### PR DESCRIPTION
Works well on my arm64 machine and is keyworded for every other arch as
well.

Signed-off-by: Jan Henke <Jan.Henke@taujhe.de>
Package-Manager: Portage-2.3.49, Repoman-2.3.11