### PR TITLE
net-misc/icaclient: drop PATH from env.d we have a wrapper

### DIFF
--- a/net-misc/icaclient/files/10ICAClient
+++ b/net-misc/icaclient/files/10ICAClient
@@ -1,3 +1,2 @@
-PATH=/opt/Citrix/ICAClient
 ROOTPATH=/opt/Citrix/ICAClient
 ICAROOT=/opt/Citrix/ICAClient

--- a/net-misc/icaclient/icaclient-13.10.0.20-r1.ebuild
+++ b/net-misc/icaclient/icaclient-13.10.0.20-r1.ebuild
@@ -1,9 +1,10 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit multilib eutils versionator
+# eutils inherit required for make_wrapper call
+inherit desktop eutils multilib versionator xdg-utils
 
 DESCRIPTION="ICA Client for Citrix Presentation servers"
 HOMEPAGE="https://www.citrix.com/"
@@ -12,7 +13,7 @@ SRC_URI="amd64? ( linuxx64-${PV}.tar.gz )
 
 LICENSE="icaclient"
 SLOT="0"
-KEYWORDS="-* amd64 x86"
+KEYWORDS="-* ~amd64 ~x86"
 IUSE="nsplugin l10n_de l10n_es l10n_fr l10n_ja l10n_zh_CN"
 RESTRICT="mirror strip userpriv fetch"
 
@@ -40,11 +41,13 @@ RDEPEND="
 	media-libs/speex
 	net-dns/libidn:1.33
 	net-libs/libsoup:2.4
+	net-misc/curl
 	sys-libs/e2fsprogs-libs
 	sys-libs/zlib
 	virtual/krb5
+	virtual/jpeg:0
 	x11-libs/cairo
-	x11-libs/gdk-pixbuf
+	x11-libs/gdk-pixbuf:2
 	x11-libs/gtk+:2
 	x11-libs/libX11
 	x11-libs/libXaw
@@ -174,6 +177,11 @@ src_install() {
 	doexe util/{configmgr,conncenter,gst_play1.0,gst_read1.0,hdxcheck.sh,icalicense.sh,libgstflatstm1.0.so}
 	doexe util/{lurdump,new_store,nslaunch,pnabrowse,storebrowse,sunraymac.sh,what,xcapture}
 
+	# https://bugs.gentoo.org/655922
+	dosym gst_play1.0 "${ICAROOT}"/util/gst_play
+	dosym gst_read1.0 "${ICAROOT}"/util/gst_read
+	dosym libgstflatstm1.0.so "${ICAROOT}"/util/libgstflatstm.so
+
 	doenvd "${FILESDIR}"/10ICAClient
 
 	make_wrapper wfica "${ICAROOT}"/wfica . "${ICAROOT}"
@@ -181,6 +189,9 @@ src_install() {
 	dodir /etc/revdep-rebuild/
 	echo "SEARCH_DIRS_MASK=\"${ICAROOT}\"" \
 		> "${ED%/}"/etc/revdep-rebuild/70icaclient
+
+	# 651926
+	domenu "${FILESDIR}"/wfica.desktop
 }
 
 pkg_preinst() {
@@ -192,4 +203,12 @@ pkg_preinst() {
 			${wrapper} -r ${old_plugin}
 		fi
 	fi
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
 }

--- a/net-misc/icaclient/icaclient-13.8.0.10299729-r2.ebuild
+++ b/net-misc/icaclient/icaclient-13.8.0.10299729-r2.ebuild
@@ -1,10 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-# eutils inherit required for make_wrapper call
-inherit desktop eutils multilib versionator xdg-utils
+inherit multilib eutils versionator
 
 DESCRIPTION="ICA Client for Citrix Presentation servers"
 HOMEPAGE="https://www.citrix.com/"
@@ -13,7 +12,7 @@ SRC_URI="amd64? ( linuxx64-${PV}.tar.gz )
 
 LICENSE="icaclient"
 SLOT="0"
-KEYWORDS="-* ~amd64 ~x86"
+KEYWORDS="-* amd64 x86"
 IUSE="nsplugin l10n_de l10n_es l10n_fr l10n_ja l10n_zh_CN"
 RESTRICT="mirror strip userpriv fetch"
 
@@ -182,9 +181,6 @@ src_install() {
 	dodir /etc/revdep-rebuild/
 	echo "SEARCH_DIRS_MASK=\"${ICAROOT}\"" \
 		> "${ED%/}"/etc/revdep-rebuild/70icaclient
-
-	# 651926
-	domenu "${FILESDIR}"/wfica.desktop
 }
 
 pkg_preinst() {
@@ -196,12 +192,4 @@ pkg_preinst() {
 			${wrapper} -r ${old_plugin}
 		fi
 	fi
-}
-
-pkg_postinst() {
-	xdg_desktop_database_update
-}
-
-pkg_postrm() {
-	xdg_desktop_database_update
 }

--- a/net-misc/icaclient/icaclient-13.9.1.6-r1.ebuild
+++ b/net-misc/icaclient/icaclient-13.9.1.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -41,13 +41,11 @@ RDEPEND="
 	media-libs/speex
 	net-dns/libidn:1.33
 	net-libs/libsoup:2.4
-	net-misc/curl
 	sys-libs/e2fsprogs-libs
 	sys-libs/zlib
 	virtual/krb5
-	virtual/jpeg:0
 	x11-libs/cairo
-	x11-libs/gdk-pixbuf:2
+	x11-libs/gdk-pixbuf
 	x11-libs/gtk+:2
 	x11-libs/libX11
 	x11-libs/libXaw
@@ -176,11 +174,6 @@ src_install() {
 	exeinto "${ICAROOT}"/util
 	doexe util/{configmgr,conncenter,gst_play1.0,gst_read1.0,hdxcheck.sh,icalicense.sh,libgstflatstm1.0.so}
 	doexe util/{lurdump,new_store,nslaunch,pnabrowse,storebrowse,sunraymac.sh,what,xcapture}
-
-	# https://bugs.gentoo.org/655922
-	dosym gst_play1.0 "${ICAROOT}"/util/gst_play
-	dosym gst_read1.0 "${ICAROOT}"/util/gst_read
-	dosym libgstflatstm1.0.so "${ICAROOT}"/util/libgstflatstm.so
 
 	doenvd "${FILESDIR}"/10ICAClient
 


### PR DESCRIPTION
The wrapper makes sure that the application gets launched from the right
place, no need to mess up the PATH.

Signed-off-by: Henning Schild <henning@hennsch.de>