### PR TITLE
x11-plugins/pidgin-telegram: add LibreSSL support

### DIFF
--- a/x11-plugins/pidgin-telegram/files/pidgin-telegram-1.3.1-libressl.patch
+++ b/x11-plugins/pidgin-telegram/files/pidgin-telegram-1.3.1-libressl.patch
@@ -1,0 +1,25 @@
+From 6ab594162a228bb5d79ba274859d4d2ab0eb7041 Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <stefan.strogin@gmail.com>
+Date: Sat, 10 Nov 2018 10:15:19 +0200
+Subject: [PATCH] Fix LibreSSL <2.7.0 support
+
+---
+ tgl/crypto/rsa_pem_openssl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tgl/crypto/rsa_pem_openssl.c b/tgl/crypto/rsa_pem_openssl.c
+index fe5cd9c..be657b3 100644
+--- a/tgl/crypto/rsa_pem_openssl.c
++++ b/tgl/crypto/rsa_pem_openssl.c
+@@ -31,7 +31,7 @@
+ #include "meta.h"
+ #include "rsa_pem.h"
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER < 0x2070000fL))
+ 
+ int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
+ {
+-- 
+2.19.1
+

--- a/x11-plugins/pidgin-telegram/pidgin-telegram-1.3.1-r2.ebuild
+++ b/x11-plugins/pidgin-telegram/pidgin-telegram-1.3.1-r2.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+DESCRIPTION="A libpurple protocol plugin that adds support for the Telegram messenger"
+HOMEPAGE="https://github.com/majn/telegram-purple"
+SRC_URI="https://github.com/majn/telegram-purple/releases/download/v${PV}/telegram-purple_${PV}.orig.tar.gz"
+
+LICENSE="GPL-2+"
+KEYWORDS="~amd64 ~x86"
+SLOT="0"
+IUSE="gcrypt libressl +nls +webp"
+
+RDEPEND="net-im/pidgin
+	sys-libs/zlib:=
+	gcrypt? ( dev-libs/libgcrypt:0= )
+	!gcrypt? (
+		libressl? ( dev-libs/libressl:0= )
+		!libressl? ( dev-libs/openssl:0= )
+	)
+	nls? ( sys-devel/gettext )
+	webp? ( media-libs/libwebp:= )"
+
+BDEPEND="virtual/pkgconfig"
+DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-libressl.patch" )
+
+S="${WORKDIR}/telegram-purple"
+
+DOCS=( "AUTHORS" "CHANGELOG.md" "HACKING.md" "HACKING.BUILD.md" "README.md" )
+
+src_prepare() {
+	default
+
+	# Remove '-Werror' to make it compile
+	find -name 'Makefile*' -exec sed -i -e 's/-Werror //'  {} + || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable gcrypt)
+		$(use_enable nls translation)
+		$(use_enable webp libwebp)
+	)
+
+	econf "${myeconfargs[@]}"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/666562
Package-Manager: Portage-2.3.51, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>