### PR TITLE
app-misc/mx5000tools: fix DEPEND/RDEPEND

### DIFF
--- a/app-misc/mx5000tools/mx5000tools-0.1.2.ebuild
+++ b/app-misc/mx5000tools/mx5000tools-0.1.2.ebuild
@@ -13,7 +13,7 @@ LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 
-DEPEND="media-libs/netpbm:="
+RDEPEND="media-libs/netpbm:="
 DEPEND="${RDEPEND}"
 
 PATCHES=( "${FILESDIR}/${P}-find-netpbm-header.patch" )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/670888
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11