### PR TITLE
app-crypt/certbot: add ~arm64 keywords to certbot and dependencies.

### DIFF
--- a/app-admin/augeas/augeas-1.11.0-r1.ebuild
+++ b/app-admin/augeas/augeas-1.11.0-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://download.augeas.net/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="LGPL-2.1"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ~ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm ~arm64 hppa ia64 ppc ~ppc64 sparc x86"
 IUSE="static-libs test"
 
 RDEPEND="

--- a/app-crypt/acme/acme-0.28.0.ebuild
+++ b/app-crypt/acme/acme-0.28.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/certbot/certbot/archive/v${PV}.tar.gz -> certbot-${PV}.tar.gz"
-	KEYWORDS="amd64 ~arm ~ppc64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 	S=${WORKDIR}/certbot-${PV}/acme
 fi
 

--- a/app-crypt/acme/acme-0.29.1.ebuild
+++ b/app-crypt/acme/acme-0.29.1.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/certbot/certbot/archive/v${PV}.tar.gz -> certbot-${PV}.tar.gz"
-	KEYWORDS="amd64 ~arm ~ppc64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 	S=${WORKDIR}/certbot-${PV}/acme
 fi
 

--- a/app-crypt/acme/acme-0.30.0.ebuild
+++ b/app-crypt/acme/acme-0.30.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/certbot/certbot/archive/v${PV}.tar.gz -> certbot-${PV}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 	S=${WORKDIR}/certbot-${PV}/acme
 fi
 

--- a/app-crypt/acme/acme-9999.ebuild
+++ b/app-crypt/acme/acme-9999.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/certbot/certbot/archive/v${PV}.tar.gz -> certbot-${PV}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 	S=${WORKDIR}/certbot-${PV}/acme
 fi
 

--- a/app-crypt/certbot-apache/certbot-apache-0.28.0.ebuild
+++ b/app-crypt/certbot-apache/certbot-apache-0.28.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/${PN%-apache}/${PN%-apache}/archive/v${PV}.tar.gz -> ${PN%-apache}-${PV}.tar.gz"
-	KEYWORDS="amd64 x86"
+	KEYWORDS="amd64 ~arm64 x86"
 	S=${WORKDIR}/${PN%-apache}-${PV}/${PN}
 fi
 

--- a/app-crypt/certbot-apache/certbot-apache-0.29.1.ebuild
+++ b/app-crypt/certbot-apache/certbot-apache-0.29.1.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/${PN%-apache}/${PN%-apache}/archive/v${PV}.tar.gz -> ${PN%-apache}-${PV}.tar.gz"
-	KEYWORDS="amd64 x86"
+	KEYWORDS="amd64 ~arm64 x86"
 	S=${WORKDIR}/${PN%-apache}-${PV}/${PN}
 fi
 

--- a/app-crypt/certbot-apache/certbot-apache-0.30.0.ebuild
+++ b/app-crypt/certbot-apache/certbot-apache-0.30.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/${PN%-apache}/${PN%-apache}/archive/v${PV}.tar.gz -> ${PN%-apache}-${PV}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 	S=${WORKDIR}/${PN%-apache}-${PV}/${PN}
 fi
 

--- a/app-crypt/certbot-apache/certbot-apache-9999.ebuild
+++ b/app-crypt/certbot-apache/certbot-apache-9999.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/${PN%-apache}/${PN%-apache}/archive/v${PV}.tar.gz -> ${PN%-apache}-${PV}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 	S=${WORKDIR}/${PN%-apache}-${PV}/${PN}
 fi
 

--- a/app-crypt/certbot-nginx/certbot-nginx-0.28.0.ebuild
+++ b/app-crypt/certbot-nginx/certbot-nginx-0.28.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/${PN%-nginx}/${PN%-nginx}/archive/v${PV}.tar.gz -> ${PN%-nginx}-${PV}.tar.gz"
-	KEYWORDS="amd64 ~arm x86"
+	KEYWORDS="amd64 ~arm ~arm64 x86"
 	S=${WORKDIR}/${PN%-nginx}-${PV}/${PN}
 fi
 

--- a/app-crypt/certbot-nginx/certbot-nginx-0.29.1.ebuild
+++ b/app-crypt/certbot-nginx/certbot-nginx-0.29.1.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/${PN%-nginx}/${PN%-nginx}/archive/v${PV}.tar.gz -> ${PN%-nginx}-${PV}.tar.gz"
-	KEYWORDS="amd64 ~arm x86"
+	KEYWORDS="amd64 ~arm ~arm64 x86"
 	S=${WORKDIR}/${PN%-nginx}-${PV}/${PN}
 fi
 

--- a/app-crypt/certbot-nginx/certbot-nginx-0.30.0.ebuild
+++ b/app-crypt/certbot-nginx/certbot-nginx-0.30.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/${PN%-nginx}/${PN%-nginx}/archive/v${PV}.tar.gz -> ${PN%-nginx}-${PV}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 	S=${WORKDIR}/${PN%-nginx}-${PV}/${PN}
 fi
 

--- a/app-crypt/certbot-nginx/certbot-nginx-9999.ebuild
+++ b/app-crypt/certbot-nginx/certbot-nginx-9999.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999* ]]; then
 	S=${WORKDIR}/${P}/${PN}
 else
 	SRC_URI="https://github.com/${PN%-nginx}/${PN%-nginx}/archive/v${PV}.tar.gz -> ${PN%-nginx}-${PV}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 	S=${WORKDIR}/${PN%-nginx}-${PV}/${PN}
 fi
 

--- a/app-crypt/certbot/certbot-0.28.0.ebuild
+++ b/app-crypt/certbot/certbot-0.28.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~arm ~ppc64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 inherit distutils-r1

--- a/app-crypt/certbot/certbot-0.29.1.ebuild
+++ b/app-crypt/certbot/certbot-0.29.1.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~arm ~ppc64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 inherit distutils-r1

--- a/app-crypt/certbot/certbot-0.30.0.ebuild
+++ b/app-crypt/certbot/certbot-0.30.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 fi
 
 inherit distutils-r1

--- a/app-crypt/certbot/certbot-9999.ebuild
+++ b/app-crypt/certbot/certbot-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 fi
 
 inherit distutils-r1

--- a/app-doc/NaturalDocs/NaturalDocs-1.52-r1.ebuild
+++ b/app-doc/NaturalDocs/NaturalDocs-1.52-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/naturaldocs/${P}.zip"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm hppa ia64 ppc ~ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm ~arm64 hppa ia64 ppc ~ppc64 sparc x86"
 
 IUSE=""
 

--- a/dev-python/betamax/betamax-0.8.0.ebuild
+++ b/dev-python/betamax/betamax-0.8.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ppc64 x86"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 IUSE="test"
 
 RDEPEND="dev-python/requests[${PYTHON_USEDEP}]"

--- a/dev-python/josepy/josepy-1.1.0.ebuild
+++ b/dev-python/josepy/josepy-1.1.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ppc64 x86"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 IUSE=""
 
 DEPEND="

--- a/dev-python/python-augeas/python-augeas-0.5.0.ebuild
+++ b/dev-python/python-augeas/python-augeas-0.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE=""
 
 DEPEND="app-admin/augeas"

--- a/dev-python/requests-toolbelt/requests-toolbelt-0.8.0.ebuild
+++ b/dev-python/requests-toolbelt/requests-toolbelt-0.8.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ppc64 x86"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 IUSE="test"
 
 RDEPEND="<dev-python/requests-3.0.0[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Signed-off-by: Andrius Štikonas <andrius@stikonas.eu>