### PR TITLE
profiles/base/package.use.stable.mask: mask USE flags for testing (was: media-gfx/alembic: fix boost not found error)

### DIFF
--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -4,6 +4,14 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in package.use.mask
 
+# Bernd Waibel <waebbl@gmail.com> (13 May 2019)
+# needs build and runtime testing
+# Due to non-available licenses for arnold and maya I can
+# not test these addons.
+# Any build and functional tests and reports on issues are
+# appreciated!
+media-gfx/alembic arnold maya
+
 # Georgy Yakovlev <gyakovlev@gentoo.org> (10 May 2019)
 # needs llvm slots which are not stable #678908
 # also prone to weird compilation failures


### PR DESCRIPTION
Fixes an error with >=cmake-3.11* where boost is not found due to changes in cmake syntax.

Closes: https://bugs.gentoo.org/667728

The `package.use.mask` change masks two USE flags for testing. I can't test them myself, because I don't have access to the needed software. But to let people know about the plugins, I decided to p.u.mask them, rather than removing them.
