### PR TITLE
media-libs/libaom: Correctly report version as 1.0.0 and fix armv7l

### DIFF
--- a/media-libs/libaom/files/libaom-1.0.0-armv7l.patch
+++ b/media-libs/libaom/files/libaom-1.0.0-armv7l.patch
@@ -1,0 +1,13 @@
+Only in libaom.orig/build/cmake: .aom_configure.cmake.swp
+diff -ru libaom.orig/build/cmake/aom_configure.cmake libaom/build/cmake/aom_configure.cmake
+--- libaom.orig/build/cmake/aom_configure.cmake	2018-06-13 21:22:56.295771914 +0200
++++ libaom/build/cmake/aom_configure.cmake	2018-06-13 21:23:10.489772591 +0200
+@@ -16,7 +16,7 @@
+ include(FindThreads)
+ 
+ set(AOM_SUPPORTED_CPU_TARGETS
+-    "arm64 armv7 armv7s generic mips32 mips64 ppc x86 x86_64")
++    "arm64 armv7 armv7l armv7s generic mips32 mips64 ppc x86 x86_64")
+ 
+ # Generate the user config settings. This must occur before include of
+ # aom_config_defaults.cmake (because it turns every config variable into a cache

--- a/media-libs/libaom/files/libaom-1.0.0-version.patch
+++ b/media-libs/libaom/files/libaom-1.0.0-version.patch
@@ -1,0 +1,10 @@
+--- a/build/cmake/version.cmake	2018-09-21 01:20:32.299238765 +0200
++++ b/build/cmake/version.cmake	2018-09-21 01:21:01.473106534 +0200
+@@ -46,6 +46,7 @@
+ endif()
+ 
+ if(NOT "${aom_version}" STREQUAL "${last_aom_version}")
++  set(aom_version "v1.0.0")
+ 
+   # TODO(tomfinegan): Perl dependency is unnecessary. CMake can do everything
+   # that is done by version.pl on its own (if a bit more verbose...).

--- a/media-libs/libaom/libaom-1.0.0-r1.ebuild
+++ b/media-libs/libaom/libaom-1.0.0-r1.ebuild
@@ -46,6 +46,7 @@ PATCHES=(
 	"${FILESDIR}/libdirpc2.patch"
 	"${FILESDIR}/pthread_lib2.patch"
 	"${FILESDIR}/${P}-version.patch"
+	"${FILESDIR}/${P}-armv7l.patch"
 )
 
 src_prepare() {

--- a/media-libs/libaom/libaom-1.0.0-r1.ebuild
+++ b/media-libs/libaom/libaom-1.0.0-r1.ebuild
@@ -1,0 +1,88 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit cmake-multilib
+
+if [[ ${PV} == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://aomedia.googlesource.com/aom"
+else
+	if [[ ${PV} == *pre* ]]; then
+		SRC_URI="mirror://gentoo/${P}.tar.xz"
+		S="${WORKDIR}/${PN}"
+	else
+		# SRC_URI="https://aomedia.googlesource.com/aom/+archive/v${PV}.tar.gz -> ${P}.tar.gz"
+		SRC_URI="mirror://gentoo/${P}.tar.gz"
+		S="${WORKDIR}"
+	fi
+	KEYWORDS="~amd64 ~arm ~hppa ~ia64 ~x86"
+fi
+
+DESCRIPTION="Alliance for Open Media AV1 Codec SDK"
+HOMEPAGE="https://aomedia.org"
+
+LICENSE="BSD-2"
+SLOT="0/0"
+IUSE="doc examples"
+IUSE="${IUSE} cpu_flags_x86_mmx cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse3 cpu_flags_x86_ssse3 cpu_flags_x86_sse4_1 cpu_flags_x86_avx cpu_flags_x86_avx2"
+IUSE="${IUSE} cpu_flags_arm_neon"
+
+RDEPEND=""
+DEPEND="abi_x86_32? ( dev-lang/yasm )
+	abi_x86_64? ( dev-lang/yasm )
+	abi_x86_x32? ( dev-lang/yasm )
+	x86-fbsd? ( dev-lang/yasm )
+	amd64-fbsd? ( dev-lang/yasm )
+	doc? ( app-doc/doxygen )
+"
+
+REQUIRED_USE="
+	cpu_flags_x86_sse2? ( cpu_flags_x86_mmx )
+	cpu_flags_x86_ssse3? ( cpu_flags_x86_sse2 )
+"
+
+PATCHES=(
+	"${FILESDIR}/libdirpc2.patch"
+	"${FILESDIR}/pthread_lib2.patch"
+	"${FILESDIR}/${P}-version.patch"
+)
+
+src_prepare() {
+	sed -e 's/lib"/lib${LIB_SUFFIX}"/' -i CMakeLists.txt || die
+	cmake-utils_src_prepare
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DENABLE_DOCS=$(multilib_native_usex doc ON OFF)
+		-DENABLE_EXAMPLES=$(multilib_native_usex examples ON OFF)
+		-DENABLE_NASM=OFF
+		-DENABLE_TOOLS=ON
+		-DENABLE_WERROR=OFF
+
+		-DENABLE_NEON=$(usex cpu_flags_arm_neon ON OFF)
+		-DENABLE_NEON_ASM=$(usex cpu_flags_arm_neon ON OFF)
+		# ENABLE_DSPR2 / ENABLE_MSA for mips
+		-DENABLE_MMX=$(usex cpu_flags_x86_mmx ON OFF)
+		-DENABLE_SSE=$(usex cpu_flags_x86_sse ON OFF)
+		-DENABLE_SSE2=$(usex cpu_flags_x86_sse2 ON OFF)
+		-DENABLE_SSE3=$(usex cpu_flags_x86_sse3 ON OFF)
+		-DENABLE_SSSE3=$(usex cpu_flags_x86_ssse3 ON OFF)
+		-DENABLE_SSE4_1=$(usex cpu_flags_x86_sse4_1 ON OFF)
+		-DENABLE_AVX=$(usex cpu_flags_x86_avx ON OFF)
+		-DENABLE_AVX2=$(usex cpu_flags_x86_avx2 ON OFF)
+
+		-DBUILD_SHARED_LIBS=ON
+	)
+	cmake-utils_src_configure
+	rm aom.pc # ensure it is rebuilt with proper libdir
+}
+
+multilib_src_install() {
+	cmake-utils_src_install
+	if multilib_is_native_abi && use doc ; then
+		docinto html
+		dodoc docs/html/*
+	fi
+}


### PR DESCRIPTION
Confirmed that with `media-libs/libaom-1.0.0-r1` from this PR, `media-video/ffmpeg-4.1[libaom]` now builds and merges without error.

Closes: https://bugs.gentoo.org/670550
Closes: https://bugs.gentoo.org/661888
Package-Manager: Portage-2.3.51, Repoman-2.3.12
Signed-off-by: Craig Andrews <candrews@gentoo.org>