### PR TITLE
x11-libs/pango: add patch to fix crash in pango_fc_font_key_get_variations()

### DIFF
--- a/x11-libs/pango/files/1.42.4-fix-crash-in-pango_fc_font_key_get_variations.patch
+++ b/x11-libs/pango/files/1.42.4-fix-crash-in-pango_fc_font_key_get_variations.patch
@@ -1,0 +1,35 @@
+From ad92e199f221499c19f22dce7a16e7d770ad3ae7 Mon Sep 17 00:00:00 2001
+From: Carsten Pfeiffer <carsten.pfeiffer@gebit.de>
+Date: Fri, 10 Aug 2018 16:06:20 +0200
+Subject: [PATCH] Fix crash in pango_fc_font_key_get_variations() when key is
+ null
+
+---
+ pango/pangofc-shape.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/pango/pangofc-shape.c b/pango/pangofc-shape.c
+index a59ca67c..53269d73 100644
+--- a/pango/pangofc-shape.c
++++ b/pango/pangofc-shape.c
+@@ -380,8 +380,10 @@ _pango_fc_shape (PangoFont           *font,
+ 		    fc_font->is_hinted ? ft_face->size->metrics.x_ppem : 0,
+ 		    fc_font->is_hinted ? ft_face->size->metrics.y_ppem : 0);
+ 
+-  variations = pango_fc_font_key_get_variations (key);
+-  if (variations)
++  if (key)
++  {
++    variations = pango_fc_font_key_get_variations (key);
++    if (variations)
+     {
+       guint n_variations;
+       hb_variation_t *hb_variations;
+@@ -391,6 +393,7 @@ _pango_fc_shape (PangoFont           *font,
+ 
+       g_free (hb_variations);
+     }
++  }
+ 
+   hb_buffer = acquire_buffer (&free_buffer);
+ 

--- a/x11-libs/pango/pango-1.42.4-r1.ebuild
+++ b/x11-libs/pango/pango-1.42.4-r1.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+GNOME2_LA_PUNT="yes"
+
+inherit gnome2 multilib-minimal toolchain-funcs
+
+DESCRIPTION="Internationalized text layout and rendering library"
+HOMEPAGE="https://www.pango.org/"
+
+LICENSE="LGPL-2+ FTL"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+
+IUSE="X +introspection test"
+
+RDEPEND="
+	>=media-libs/harfbuzz-1.4.2:=[glib(+),truetype(+),${MULTILIB_USEDEP}]
+	>=dev-libs/glib-2.50.2:2[${MULTILIB_USEDEP}]
+	>=media-libs/fontconfig-2.12.92:1.0=[${MULTILIB_USEDEP}]
+	>=media-libs/freetype-2.5.0.1:2=[${MULTILIB_USEDEP}]
+	>=x11-libs/cairo-1.12.14-r4:=[X?,${MULTILIB_USEDEP}]
+	>=dev-libs/fribidi-0.19.7[${MULTILIB_USEDEP}]
+	introspection? ( >=dev-libs/gobject-introspection-0.9.5:= )
+	X? (
+		>=x11-libs/libXrender-0.9.8[${MULTILIB_USEDEP}]
+		>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+		>=x11-libs/libXft-2.3.1-r1[${MULTILIB_USEDEP}]
+	)
+"
+DEPEND="${RDEPEND}
+	>=dev-util/gtk-doc-am-1.20
+	virtual/pkgconfig[${MULTILIB_USEDEP}]
+	test? ( media-fonts/cantarell )
+	X? ( x11-base/xorg-proto )
+	!<=sys-devel/autoconf-2.63:2.5
+"
+
+src_prepare() {
+	gnome2_src_prepare
+	# This should be updated if next release fails to pre-generate the manpage as well, or src_prepare removed if is properly generated
+	# https://gitlab.gnome.org/GNOME/pango/issues/270
+	cp -v "${FILESDIR}"/${PV}-pango-view.1.in "${S}/utils/pango-view.1.in" || die
+	eapply "${FILESDIR}"/${PV}-fix-crash-in-pango_fc_font_key_get_variations.patch
+}
+
+multilib_src_configure() {
+	tc-export CXX
+
+	ECONF_SOURCE=${S} \
+	gnome2_src_configure \
+		--with-cairo \
+		$(multilib_native_use_enable introspection) \
+		$(use_with X xft) \
+		"$(usex X --x-includes="${EPREFIX}/usr/include" "")" \
+		"$(usex X --x-libraries="${EPREFIX}/usr/$(get_libdir)" "")"
+
+	if multilib_is_native_abi; then
+		ln -s "${S}"/docs/html docs/html || die
+	fi
+}
+
+multilib_src_install() {
+	gnome2_src_install
+}


### PR DESCRIPTION
Since pango-1.42.x some Java applications crash with a segfault
in pango_fc_font_key_get_variations(). Adding an upstream patch
which followed the 1.42.4 release fixes the issue reproducibly.

More info: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898960

Bug: https://bugs.gentoo.org/671136
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>