### PR TITLE
media-video/ffmpeg: Fix building tools with vaapi

### DIFF
--- a/media-video/ffmpeg/ffmpeg-4.1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-4.1.ebuild
@@ -304,6 +304,7 @@ S=${WORKDIR}/${P/_/-}
 
 PATCHES=(
 	"${FILESDIR}"/chromium-r1.patch
+	"${FILESDIR}/${P}-vaapi-tools.patch"
 )
 
 MULTILIB_WRAPPED_HEADERS=(

--- a/media-video/ffmpeg/files/ffmpeg-4.1-vaapi-tools.patch
+++ b/media-video/ffmpeg/files/ffmpeg-4.1-vaapi-tools.patch
@@ -1,0 +1,27 @@
+From 4f1e07090a9f6064078cac694f1d7148f86176c3 Mon Sep 17 00:00:00 2001
+From: Mark Thompson <sw@jkqxz.net>
+Date: Wed, 14 Nov 2018 22:56:18 +0000
+Subject: [PATCH] configure: Add missing xlib dependency for VAAPI X11 code
+
+Fixes #7538.
+
+(cherry picked from commit 2ce3a48f30fe3cec7153aa3f18a1012a366aca3a)
+---
+ configure | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure b/configure
+index e79dae896c..a70c5f9e9e 100755
+--- a/configure
++++ b/configure
+@@ -2812,6 +2812,7 @@ d3d11va_deps="dxva_h ID3D11VideoDecoder ID3D11VideoContext"
+ dxva2_deps="dxva2api_h DXVA2_ConfigPictureDecode ole32 user32"
+ ffnvcodec_deps_any="libdl LoadLibrary"
+ nvdec_deps="ffnvcodec"
++vaapi_x11_deps="xlib"
+ videotoolbox_hwaccel_deps="videotoolbox pthreads"
+ videotoolbox_hwaccel_extralibs="-framework QuartzCore"
+ xvmc_deps="X11_extensions_XvMClib_h"
+-- 
+2.11.0
+


### PR DESCRIPTION
Patch from ffmpeg git master

Closes: https://bugs.gentoo.org/670712
Package-Manager: Portage-2.3.51, Repoman-2.3.12
Signed-off-by: Craig Andrews <candrews@gentoo.org>