### PR TITLE
net-misc/dropbear: add utmp useflag + version bump to eapi7

### DIFF
--- a/net-misc/dropbear/dropbear-2018.76-r1.ebuild
+++ b/net-misc/dropbear/dropbear-2018.76-r1.ebuild
@@ -1,0 +1,111 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit pam savedconfig user
+
+DESCRIPTION="small SSH 2 client/server designed for small memory environments"
+HOMEPAGE="https://matt.ucc.asn.au/dropbear/dropbear.html"
+SRC_URI="https://matt.ucc.asn.au/dropbear/releases/${P}.tar.bz2
+	https://matt.ucc.asn.au/dropbear/testing/${P}.tar.bz2"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="bsdpty minimal multicall pam +shadow static +syslog +utmp zlib"
+
+LIB_DEPEND="zlib? ( sys-libs/zlib[static-libs(+)] )
+	dev-libs/libtommath[static-libs(+)]"
+RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )
+	pam? ( virtual/pam )"
+DEPEND="${RDEPEND}
+	static? ( ${LIB_DEPEND} )"
+RDEPEND+=" pam? ( >=sys-auth/pambase-20080219.1 )"
+
+REQUIRED_USE="pam? ( !static )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2018-dbscp.patch"
+)
+
+set_options() {
+	secondary_progs=(
+		dbclient dropbearkey
+		$(usex minimal "" "dropbearconvert scp")
+	)
+	progs=(dropbear "${secondary_progs[@]}")
+	makeopts=(
+		MULTI=$(usex multicall 1 0)
+		STATIC=$(usex static 1 0)
+	)
+}
+
+src_prepare() {
+	default
+	sed \
+		-e '/SFTPSERVER_PATH/s:".*":"/usr/lib/misc/sftp-server":' \
+		default_options.h > localoptions.h || die
+	sed -i \
+		-e '/pam_start/s:sshd:dropbear:' \
+		svr-authpam.c || die
+	restore_config localoptions.h
+}
+
+src_configure() {
+	# XXX: Need to add libtomcrypt to the tree and re-enable this.
+	#	--disable-bundled-libtom
+	# We disable the hardening flags as our compiler already enables them
+	# by default as is appropriate for the target.
+
+	confopts=(
+		--disable-harden
+		$(use_enable zlib)
+		$(use_enable pam)
+		$(use_enable !bsdpty openpty)
+		$(use_enable shadow)
+		$(use_enable syslog)
+	)
+
+	if ! use utmp ; then
+		confopts+=(--disable-{lastlog,utmp{,x},wtmp{,x},loginfunc,putut{,x}line})
+	fi
+
+	econf "${confopts[@]}"
+}
+
+src_compile() {
+	set_options
+	emake "${makeopts[@]}" PROGRAMS="${progs[*]}"
+}
+
+src_install() {
+	set_options
+	doman *.8
+	newinitd "${FILESDIR}"/dropbear.init.d dropbear
+	newconfd "${FILESDIR}"/dropbear.conf.d dropbear
+
+	# The multi install target does not install the links right.
+	if use multicall ; then
+		dobin dropbearmulti || die "dobin failed"
+		dosym ../bin/dropbearmulti "${EPREFIX}"/usr/sbin/dropbear
+		for p in "${secondary_progs[@]}" ; do
+			dosym dropbearmulti "${EPREFIX}/usr/bin/$p"
+		done
+	else
+		emake "${makeopts[@]}" PROGRAMS="${progs[*]}" DESTDIR="${ED%/}" install
+	fi
+	save_config localoptions.h
+
+	if ! use minimal ; then
+		mv "${ED%/}"/usr/bin/{,db}scp || die
+		dodoc CHANGES README SMALL MULTI
+	fi
+
+	pamd_mimic system-remote-login dropbear auth account password session
+}
+
+pkg_preinst() {
+	enewgroup sshd 22
+	enewuser sshd 22 -1 /var/empty sshd
+}

--- a/net-misc/dropbear/files/dropbear-2018-dbscp.patch
+++ b/net-misc/dropbear/files/dropbear-2018-dbscp.patch
@@ -1,0 +1,22 @@
+diff --git a/dbmulti.c b/dbmulti.c
+index 204e9a3..4bdae09 100644
+--- a/dbmulti.c
++++ b/dbmulti.c
+@@ -56,7 +56,7 @@ static int runprog(const char *progname, int argc, char ** argv, int *match) {
+ 		}
+ #endif
+ #ifdef DBMULTI_scp
+-		if (strcmp(progname, "scp") == 0) {
++		if ((strcmp(progname, "scp") == 0) || (strcmp(progname, "dbscp") == 0)) {
+ 			return scp_main(argc, argv);
+ 		}
+ #endif
+@@ -95,7 +95,7 @@ int main(int argc, char ** argv) {
+ 			"'dropbearconvert' - the key converter\n"
+ #endif
+ #ifdef DBMULTI_scp
+-			"'scp' - secure copy\n"
++			"'dbscp' - secure copy\n"
+ #endif
+ 			,
+ 			DROPBEAR_VERSION);

--- a/net-misc/dropbear/metadata.xml
+++ b/net-misc/dropbear/metadata.xml
@@ -6,10 +6,10 @@
     <name>Embedded Gentoo</name>
   </maintainer>
   <longdescription>
-I was looking for a small and secure SSH server to fit on a laptop with 4 megs ram and no hard 
-disk, and couldn't find one which was satisfactory. I decided to write my own, and Dropbear is 
-the result. It implements most required features of the SSH 2 protocol, and other features such 
-as X11, TCP and Authentication Agent forwarding. Dropbear is Open Source software, distributed 
+I was looking for a small and secure SSH server to fit on a laptop with 4 megs ram and no hard
+disk, and couldn't find one which was satisfactory. I decided to write my own, and Dropbear is
+the result. It implements most required features of the SSH 2 protocol, and other features such
+as X11, TCP and Authentication Agent forwarding. Dropbear is Open Source software, distributed
 under a MIT-style license.
 </longdescription>
   <longdescription lang="ja">
@@ -24,6 +24,7 @@ under a MIT-style license.
     <flag name="bsdpty">Add support for legacy BSD pty's rather than dynamic UNIX pty's -- do not use this flag unless you are absolutely sure you actually want it</flag>
     <flag name="multicall">Build all the programs as one little binary (to save space)</flag>
     <flag name="shadow">Enable shadow password support</flag>
+    <flag name="utmp">Enable support for lastlog/{u,w}tmp{,x}</flag>
   </use>
 <upstream>
   <remote-id type="cpe">cpe:/a:matt_johnston:dropbear_ssh_server</remote-id>


### PR DESCRIPTION
  -add utmp useflag: lastlog/utmp it not useful for a initramfs encrypting the root partition,
   musl does support it only as dummy...

Package-Manager: Portage-2.3.51, Repoman-2.3.11