### PR TITLE
app-text/zathura-pdf-mupdf: Updates deps to prevent compilation failure

### DIFF
--- a/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.4.ebuild
+++ b/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.4.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://git.pwmt.org/pwmt/zathura-pdf-mupdf.git"
 	EGIT_BRANCH="develop"
 else
-	KEYWORDS="amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~x86"
 	SRC_URI="https://pwmt.org/projects/zathura-pdf-mupdf/download/${P}.tar.xz"
 fi
 
@@ -20,7 +20,7 @@ HOMEPAGE="https://pwmt.org/projects/zathura-pdf-mupdf/"
 LICENSE="ZLIB"
 SLOT="0"
 
-DEPEND="app-text/mupdf
+DEPEND=">=app-text/mupdf-1.14.0-r2
 	>=app-text/zathura-0.3.9
 	dev-libs/girara
 	dev-libs/glib:2


### PR DESCRIPTION
As per [bug 671374](https://bugs.gentoo.org/671374), `app-text/zathura-pdf-mupdf-0.3.4` currently doesn't build. It seems that a mupdf API changed in version 1.14.0, which is not currently a stable package. Therefore, when building `zathura-pdf-mupdf-0.3.4` with the latest stable version of mupdf, the compilation fails. There is currently [another bug](https://bugs.gentoo.org/671376) requesting for `app-text/mupdf-1.14.0-r2` to be made stable (and this bug is listed as a blocker for 671374), however I believe that even if it was stable, there is a bug with the current dependencies in the `app-text/zathura-pdf-mupdf-0.3.4` ebuild. I simply modified it to require `>=app-text/mupdf-1.14.0-r2`, because otherwise the package doesn't build. 

Bug: https://bugs.gentoo.org/671374
Package-Manager: Portage-2.3.51, Repoman-2.3.11