### PR TITLE
media-gfx/viewnior: Bump to version 1.7

### DIFF
--- a/media-gfx/viewnior/files/0.17-Replace-calls-to-getenv-with-g_getenv.patch
+++ b/media-gfx/viewnior/files/0.17-Replace-calls-to-getenv-with-g_getenv.patch
@@ -1,0 +1,28 @@
+Using getenv() triggers compile errors in Open Build Service.
+Thanks to Axel Köllhofer for the patch.
+---
+ src/uni-utils.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/uni-utils.c b/src/uni-utils.c
+index 8152848..1b4992a 100755
+--- a/src/uni-utils.c
++++ b/src/uni-utils.c
+@@ -106,10 +106,10 @@ uni_detect_desktop_environment ()
+ {
+     VnrPrefsDesktop environment = VNR_PREFS_DESKTOP_GNOME3;
+ 
+-    gchar *xdg_current_desktop = g_ascii_strup(getenv("XDG_CURRENT_DESKTOP"), -1);
+-    gchar *xdg_session_desktop = g_ascii_strup(getenv("XDG_SESSION_DESKTOP"), -1);
+-    gchar *desktop_session = g_ascii_strdown(getenv("DESKTOP_SESSION"), -1);
+-    gchar *gdmsession = g_ascii_strdown(getenv("GDMSESSION"), -1);
++    gchar *xdg_current_desktop = g_ascii_strup(g_getenv("XDG_CURRENT_DESKTOP"), -1);
++    gchar *xdg_session_desktop = g_ascii_strup(g_getenv("XDG_SESSION_DESKTOP"), -1);
++    gchar *desktop_session = g_ascii_strdown(g_getenv("DESKTOP_SESSION"), -1);
++    gchar *gdmsession = g_ascii_strdown(g_getenv("GDMSESSION"), -1);
+ 
+     if (!g_strcmp0(xdg_current_desktop, "GNOME") || !g_strcmp0(xdg_session_desktop, "GNOME"))
+     {
+-- 
+2.18.1
+

--- a/media-gfx/viewnior/metadata.xml
+++ b/media-gfx/viewnior/metadata.xml
@@ -11,5 +11,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="github">hellosiyan/Viewnior</remote-id>
+		<changelog>https://siyanpanayotov.com/project/viewnior/news</changelog>
 	</upstream>
 </pkgmetadata>

--- a/media-gfx/viewnior/metadata.xml
+++ b/media-gfx/viewnior/metadata.xml
@@ -1,6 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>gentoo@tastytea.de</email>
+		<name>Ronny Gutbrod</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">hellosiyan/Viewnior</remote-id>
 	</upstream>

--- a/media-gfx/viewnior/viewnior-1.7-r1.ebuild
+++ b/media-gfx/viewnior/viewnior-1.7-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit gnome2-utils meson xdg-utils
+
+MY_PN=Viewnior
+DESCRIPTION="Fast and simple image viewer"
+HOMEPAGE="https://siyanpanayotov.com/project/viewnior/ https://github.com/hellosiyan/Viewnior"
+SRC_URI="https://github.com/hellosiyan/${MY_PN}/archive/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="media-gfx/exiv2:0=
+	dev-libs/glib:2
+	x11-libs/gtk+:2"
+
+DEPEND="${RDEPEND}
+	dev-util/glib-utils
+	virtual/pkgconfig
+	x11-misc/shared-mime-info
+"
+
+S="${WORKDIR}/${MY_PN}-${P}"
+
+PATCHES=(
+	"${FILESDIR}/0.17-Replace-calls-to-getenv-with-g_getenv.patch"
+)
+
+src_prepare() {
+	default
+	# That script would update icon cache and desktop database
+	sed -i "s/meson.add_install_script('meson_post_install.py')//" meson.build || die 'Failed to remove post-install-script invocation from meson.build'
+	# Don't let meson compress the manpage
+	sed -i "s/subdir('man')//" meson.build || die 'Failed to remove manpage compression from meson.build'
+}
+
+src_install() {
+	meson_src_install
+	doman man/viewnior.1
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
Hello friends,
I'd like to maintain media-gfx/viewnior. It is orphaned. I believe by rewriting the ebuild to use meson and incorporating a bugfix I have proven that I can write ebuilds. The bugfix is a [commit from upstream](https://github.com/hellosiyan/Viewnior/commit/aac0a0c4ad232723e8aecbab4dff99691b90a08e) after the last release.