### PR TITLE
net-im/bitlbee-facebook: add missing dep on dev-util/glib-utils #668448

### DIFF
--- a/net-im/bitlbee-facebook/bitlbee-facebook-1.1.2.ebuild
+++ b/net-im/bitlbee-facebook/bitlbee-facebook-1.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2017 Gentoo Foundation
+# Copyright 2017-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,6 +25,7 @@ RDEPEND="
 	dev-libs/json-glib
 	>=net-im/bitlbee-3[plugins]"
 DEPEND="${RDEPEND}
+	dev-util/glib-utils
 	virtual/pkgconfig"
 
 src_prepare() {

--- a/net-im/bitlbee-facebook/bitlbee-facebook-9999.ebuild
+++ b/net-im/bitlbee-facebook/bitlbee-facebook-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 2017-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit autotools
 
@@ -24,7 +24,8 @@ RDEPEND="
 	dev-libs/glib:2
 	dev-libs/json-glib
 	>=net-im/bitlbee-3[plugins]"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	dev-util/glib-utils
 	virtual/pkgconfig"
 

--- a/net-im/bitlbee-facebook/bitlbee-facebook-9999.ebuild
+++ b/net-im/bitlbee-facebook/bitlbee-facebook-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2017 Gentoo Foundation
+# Copyright 2017-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,6 +25,7 @@ RDEPEND="
 	dev-libs/json-glib
 	>=net-im/bitlbee-3[plugins]"
 DEPEND="${RDEPEND}
+	dev-util/glib-utils
 	virtual/pkgconfig"
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/668448
Package-Manager: Portage-2.3.51, Repoman-2.3.11
Signed-off-by: Petr Vaněk <arkamar@atlas.cz>