### PR TITLE
dev-python/humanfriendly: drop unneeded test dependency

### DIFF
--- a/dev-python/humanfriendly/humanfriendly-4.17.ebuild
+++ b/dev-python/humanfriendly/humanfriendly-4.17.ebuild
@@ -29,7 +29,6 @@ DEPEND="${RDEPEND}
 		>=dev-python/capturer-2.1[${PYTHON_USEDEP}]
 		>=dev-python/coloredlogs-2.0[${PYTHON_USEDEP}]
 		>=dev-python/pytest-3.0.7[${PYTHON_USEDEP}]
-		>=dev-python/pytest-2.4.0[${PYTHON_USEDEP}]
 	)
 	"
 


### PR DESCRIPTION
Thanks to juippis for spotting the typo

Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>