### PR TITLE
net-im/spectrum2: fix build depenencies

### DIFF
--- a/net-im/spectrum2/spectrum2-2.0.9.ebuild
+++ b/net-im/spectrum2/spectrum2-2.0.9.ebuild
@@ -20,12 +20,14 @@ REQUIRED_USE="|| ( mysql postgres sqlite )"
 RDEPEND="
 	dev-libs/boost:=
 	dev-libs/expat
+	dev-libs/libev:=
 	dev-libs/log4cxx
 	dev-libs/jsoncpp:=
 	dev-libs/openssl:0=
 	dev-libs/popt
 	dev-libs/protobuf:=
 	net-dns/libidn:0=
+	net-im/swift:=
 	net-misc/curl
 	sys-libs/zlib:=
 	frotz? ( !games-engines/frotz )
@@ -39,14 +41,12 @@ RDEPEND="
 	postgres? ( dev-libs/libpqxx:= )
 	purple? (
 		dev-libs/glib
-		dev-libs/libev:=
 		net-im/pidgin:=
 	)
 	sms? ( app-mobilephone/smstools )
 	sqlite? ( dev-db/sqlite:3 )
 	twitter? ( net-misc/curl )
-	whatsapp? ( net-im/transwhat )
-	xmpp? ( net-im/swift:= )"
+	whatsapp? ( net-im/transwhat )"
 
 DEPEND="
 	${PYTHON_DEPS}


### PR DESCRIPTION
The current build of net-im/spectrum2 needs always
net-im/swift and dev-libs/ev to be installed, otherwise it fails.

Closes: https://bugs.gentoo.org/671798
Package-Manager: Portage-2.3.51, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>