### PR TITLE
net-mail/dovecot: init file fix and "checkconfig" extra command

### DIFF
--- a/net-mail/dovecot/files/dovecot.init-r5
+++ b/net-mail/dovecot/files/dovecot.init-r5
@@ -2,6 +2,7 @@
 # Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License, v2 or later
 
+extra_commands="checkconfig"
 extra_started_commands="reload"
 
 depend() {
@@ -22,10 +23,9 @@ checkconfig() {
 		eerror "You will need an ${DOVECOT_CONF} first"
 		return 1
 	fi
-	if [ -x /usr/sbin/dovecot ]; then
-		DOVECOT_BASEDIR=$(/usr/sbin/dovecot -c ${DOVECOT_CONF} config -h base_dir)
-	else
-		eerror "dovecot not executable"
+	DOVECOT_BASEDIR=$(/usr/bin/doveconf -c ${DOVECOT_CONF} -h base_dir)
+	if [ $? -ne 0 ]; then
+		eerror "Error parsing ${DOVECOT_CONF}"
 		return 1
 	fi
 	DOVECOT_BASEDIR=${DOVECOT_BASEDIR:-/run/dovecot}


### PR DESCRIPTION
`/etc/init.d/dovecot` does not currently exit cleanly if Dovecot's configuration file cannot be parsed. This pull request fixes the issue and also makes the "checkconfig" extra command available for manual invocation.

See [this message](https://www.dovecot.org/pipermail/dovecot/2018-November/113586.html) from Dovecot author Aki Tuomi for an explanation why I chose to use `doveconf` as a means of detecting configuration problems.

Signed-off-by: Ralph Seichter <gentoo@seichter.de>
Package-Manager: Portage-2.3.51, Repoman-2.3.11