### PR TITLE
app-admin/metalog: DEPEND on sys-devel/autoconf-archive

### DIFF
--- a/app-admin/metalog/metalog-20181125.ebuild
+++ b/app-admin/metalog/metalog-20181125.ebuild
@@ -15,6 +15,7 @@ IUSE="unicode"
 
 RDEPEND=">=dev-libs/libpcre-3.4"
 DEPEND="${RDEPEND}
+	sys-devel/autoconf-archive
 	virtual/pkgconfig"
 
 S="${WORKDIR}/${PN}-${P}"


### PR DESCRIPTION
Its autoconf requires AX_CHECK_COMPILE_FLAG macro from
sys-devel/autoconf-archive, or otherwise configure will
fail with syntax error from unexpanded macro invocation.

Closes: https://bugs.gentoo.org/671464
Bug: https://bugs.gentoo.org/670757
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: YiFei Zhu <zhuyifei1999@gmail.com>