### PR TITLE
app-eselect/eselect-opencascade: fix issues from b.g.o

### DIFF
--- a/app-eselect/eselect-opencascade/eselect-opencascade-1.ebuild
+++ b/app-eselect/eselect-opencascade/eselect-opencascade-1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
 
 DESCRIPTION="Manages opencascade env file"
 HOMEPAGE="https://www.gentoo.org/proj/en/eselect/"

--- a/app-eselect/eselect-opencascade/files/eselect-opencascade-1.eselect
+++ b/app-eselect/eselect-opencascade/files/eselect-opencascade-1.eselect
@@ -1,5 +1,5 @@
 # -*-eselect-*-  vim: ft=eselect
-# Copyright (c) 2006-2013 Gentoo Foundation
+# Copyright (c) 2006-2018 Gentoo Authors
 #
 # This file is part of the 'eselect' tools framework.
 #
@@ -14,6 +14,10 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # eselect.  If not, see <http://www.gnu.org/licenses/>.
+
+DESCRIPTION="Manage OpenCASCADE implementation used by your system"
+MAINTAINER="waebbl@gmail.com"
+VERSION="1"
 
 MODULE=opencascade
 TARGET=${EROOT}/etc/env.d/51${MODULE}
@@ -51,6 +55,10 @@ switch_implem() {
 	echo "an already running shell, please remember to do:"
 	echo
 	echo ". /etc/profile"
+}
+
+describe_list() {
+	echo "List available OpenCASCADE implementations"
 }
 
 do_list() {

--- a/app-eselect/eselect-opencascade/metadata.xml
+++ b/app-eselect/eselect-opencascade/metadata.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+<maintainer type="person">
+	<email>waebbl@gmail.com</email>
+	<name>Bernd Waibel</name>
+</maintainer>
+<maintainer type="project">
+	<email>proxy-maint@gentoo.org</email>
+	<name>Proxy Maintainers project</name>
+</maintainer>
+<longdescription>
+Utility to switch between the different OpenCASCADE implementations
+on your system.
+</longdescription>
 </pkgmetadata>


### PR DESCRIPTION
Add DESCRIPTION, MAINTAINER and VERSION variables, and implement
a describe_list() function.
Update metadata.xml

Closes: https://bugs.gentoo.org/504632
Package-Manager: Portage-2.3.51, Repoman-2.3.12
Signed-off-by: Bernd Waibel <waebbl@gmail.com>