### PR TITLE
net-vpn/strongswan: padlock use flag is x86 only

### DIFF
--- a/net-vpn/strongswan/strongswan-5.7.1.ebuild
+++ b/net-vpn/strongswan/strongswan-5.7.1.ebuild
@@ -23,6 +23,8 @@ for mod in $STRONGSWAN_PLUGINS_OPT; do
 	IUSE="${IUSE} strongswan_plugins_${mod}"
 done
 
+REQUIRED_USE="!x86? ( !strongswan_plugins_padlock )"
+
 COMMON_DEPEND="!net-misc/openswan
 	gmp? ( >=dev-libs/gmp-4.1.5:= )
 	gcrypt? ( dev-libs/libgcrypt:0 )


### PR DESCRIPTION
The `strongswan_plugin_padlock` use flag should only be enabled on x86.
`padlock_aes_crypter.c` contains x86 specific inline assembly. Enforce
this constraint in `REQUIRED_USE`.