### PR TITLE
x11-wm/i3: Use current musl patch for live ebuild

### DIFF
--- a/x11-wm/i3/i3-9999.ebuild
+++ b/x11-wm/i3/i3-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -39,7 +39,7 @@ RDEPEND="${CDEPEND}
 	dev-perl/JSON-XS"
 
 PATCHES=(
-	"${FILESDIR}/${PN}-musl-GLOB_TILDE.patch"
+	"${FILESDIR}/${PN}-4.16-musl-GLOB_TILDE.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Package-Manager: Portage-2.3.51, Repoman-2.3.12