### PR TITLE
media-gfx/ephoto: update SRC_URI to download from Gentoo mirrors

### DIFF
--- a/media-gfx/ephoto/ephoto-1.5.ebuild
+++ b/media-gfx/ephoto/ephoto-1.5.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Enlightenment image viewer written with EFL"
 HOMEPAGE="https://www.enlightenment.org/about-ephoto"
-SRC_URI="http://www.smhouston.us/stuff/${P}.tar.xz"
+SRC_URI="mirror://gentoo/${P}.tar.xz"
 
 LICENSE="BSD-2"
 SLOT="0"


### PR DESCRIPTION
Previous host URI was pretty inconsistently available and now it seems like it's gone for good. The file found from Gentoo mirrros matches with current Manifest hashes. 