### PR TITLE
KiCAD-5 occ issues

### DIFF
--- a/sci-electronics/kicad-packages3d/kicad-packages3d-5.0.0-r1.ebuild
+++ b/sci-electronics/kicad-packages3d/kicad-packages3d-5.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,10 +12,12 @@ SRC_URI="https://github.com/KiCad/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="CC-BY-SA-4.0"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE=""
+IUSE="occ +oce"
+
+REQUIRED_USE="|| ( occ oce )"
 
 DEPEND=""
-RDEPEND=">=sci-electronics/kicad-5.0.0[oce]"
+RDEPEND=">=sci-electronics/kicad-5.0.0[occ=,oce=]"
 
 CHECKREQS_DISK_BUILD="9G"
 S="${WORKDIR}/${P/3d/3D}"

--- a/sci-electronics/kicad/kicad-5.0.0-r2.ebuild
+++ b/sci-electronics/kicad/kicad-5.0.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -87,7 +87,10 @@ src_configure() {
 		-DPYTHON_INCLUDE_DIR="$(python_get_includedir)"
 		-DPYTHON_LIBRARY="$(python_get_library_path)"
 	)
-	use occ && mycmakeargs+=( -DOCC_LIBRARY_DIR="${CASROOT}"/lib )
+	use occ && mycmakeargs+=(
+		-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade
+		-DOCC_LIBRARY_DIR="${CASROOT}"/lib
+	)
 
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
* Fix opencascade include dir not found in sci-electronics/kicad-5.0.0-r1
* Remove USE dependency on sci-libs/oce for sci-electronics/kicad-packages3d-5.0.0
