### PR TITLE
net-dns/ddclient: add need net for init script

### DIFF
--- a/net-dns/ddclient/ddclient-3.9.0-r2.ebuild
+++ b/net-dns/ddclient/ddclient-3.9.0-r2.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit systemd user
+
+DESCRIPTION="Perl client used to update dynamic DNS entries"
+HOMEPAGE="https://sourceforge.net/projects/ddclient/"
+SRC_URI="mirror://sourceforge/ddclient/${P}.tar.gz"
+
+KEYWORDS="~alpha ~amd64 ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+LICENSE="GPL-2+"
+SLOT="0"
+IUSE="examples iproute2"
+
+RDEPEND="
+	dev-lang/perl
+	dev-perl/Data-Validate-IP
+	dev-perl/Digest-SHA1
+	dev-perl/IO-Socket-INET6
+	dev-perl/IO-Socket-SSL
+	virtual/perl-Digest-SHA
+	virtual/perl-JSON-PP
+	iproute2? ( sys-apps/iproute2 )
+"
+
+pkg_setup() {
+	enewgroup ddclient
+	enewuser ddclient -1 -1 -1 ddclient
+}
+
+src_prepare() {
+	# Remove PID setting, to reliably setup the environment for the init script
+	sed -e '/^pid/d' -i sample-etc_ddclient.conf || die
+
+	# Remove windows executable
+	if use examples; then
+		rm sample-etc_dhcpc_dhcpcd-eth0.exe || die
+	fi
+
+	# Use sys-apps/iproute2 instead of sys-apps/net-tools
+	use iproute2 && eapply "${FILESDIR}"/${P}-use_iproute2.patch
+
+	default
+}
+
+src_install() {
+	dobin ddclient
+
+	insinto /etc/ddclient
+	insopts -m 0600 -o ddclient -g ddclient
+	newins sample-etc_ddclient.conf ddclient.conf
+
+	newinitd "${FILESDIR}"/ddclient.initd-r6 ddclient
+	systemd_newunit "${FILESDIR}"/ddclient.service-r1 ddclient.service
+	systemd_newtmpfilesd "${FILESDIR}"/ddclient.tmpfiles ddclient.conf
+
+	dodoc Change* README* RELEASENOTE TODO UPGRADE
+
+	if use examples; then
+		docinto examples
+		dodoc sample-*
+	fi
+}

--- a/net-dns/ddclient/files/ddclient.initd-r6
+++ b/net-dns/ddclient/files/ddclient.initd-r6
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+name="DDclient"
+pidfile="/run/ddclient/${RC_SVCNAME}.pid"
+
+command="/usr/bin/ddclient"
+command_args="-pid ${pidfile}"
+command_group="ddclient"
+command_user="ddclient"
+
+depend() {
+	need net
+	use dns logger
+}
+
+start_pre() {
+	checkpath -f -m 0600 -o ${command_user}:${command_group} /etc/ddclient/ddclient.conf
+	checkpath -d -m 0700 -o ${command_user}:${command_group} /run/ddclient
+	checkpath -d -m 0700 -o ${command_user}:${command_group} /var/cache/ddclient
+}


### PR DESCRIPTION
Also bumped to EAPI=7.

Closes: https://bugs.gentoo.org/672338
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>