### PR TITLE
app-misc/khal: update dependency of 0.9.10 release

### DIFF
--- a/app-misc/khal/khal-0.9.10.ebuild
+++ b/app-misc/khal/khal-0.9.10.ebuild
@@ -19,7 +19,7 @@ IUSE="zsh-completion"
 
 RDEPEND=">=dev-python/click-3.2[${PYTHON_USEDEP}]
 	>=dev-python/click-log-0.2.0[${PYTHON_USEDEP}]
-	dev-python/icalendar[${PYTHON_USEDEP}]
+	>=dev-python/icalendar-3.11.7[${PYTHON_USEDEP}]
 	dev-python/urwid[${PYTHON_USEDEP}]
 	dev-python/pyxdg[${PYTHON_USEDEP}]
 	dev-python/pytz[${PYTHON_USEDEP}]


### PR DESCRIPTION
Latest release of khal requires icalendar at least in version 3.11.7.
Let's force that in dependencies.

Bug: https://bugs.gentoo.org/672532
Signed-off-by: Karel Kočí <cynerd@email.cz>