### PR TITLE
dev-libs/girara: newer meson required

### DIFF
--- a/dev-libs/girara/girara-9999.ebuild
+++ b/dev-libs/girara/girara-9999.ebuild
@@ -28,6 +28,7 @@ RDEPEND="dev-libs/glib:2
 	 libnotify? ( x11-libs/libnotify )"
 
 DEPEND="${RDEPEND}
+	 >=dev-util/meson-0.48
 	 doc? ( app-doc/doxygen )
 	 test? ( dev-libs/check )"
 


### PR DESCRIPTION
With current 9999, `src_compile` fails with
```
meson.build:1:0: ERROR:  Meson version is 0.47.1 but project requires >=0.48.
```
This PR add this dependency.