### PR TITLE
sci-electronics/drahnr-oregano: add glib-utils as dependency

### DIFF
--- a/sci-electronics/drahnr-oregano/drahnr-oregano-0.84.40.ebuild
+++ b/sci-electronics/drahnr-oregano/drahnr-oregano-0.84.40.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,6 +25,7 @@ COMMON_DEP="dev-libs/glib:2
 
 DEPEND="${COMMON_DEP}
 	${PYTHON_DEPS}
+	dev-util/glib-utils
 	virtual/pkgconfig"
 
 RDEPEND="${COMMON_DEP}


### PR DESCRIPTION
 Fix #671846, add depenency on dev-util/glib-utils

Closes: https://bugs.gentoo.org/671846
Signed-off-by:  Victor Kustov <ktrace@yandex.ru>
Package-Manager: Portage-2.3.51, Repoman-2.3.11