### PR TITLE
app-crypt/tpm-tools: fix build with openssl-1.1

### DIFF
--- a/app-crypt/tpm-tools/files/tpm-tools-1.3.9.1-openssl-1.1.patch
+++ b/app-crypt/tpm-tools/files/tpm-tools-1.3.9.1-openssl-1.1.patch
@@ -1,0 +1,106 @@
+Author: Philipp Kern <pkern@debian.org>
+Subject: Fix openssl1.1 support in data_mgmt
+Date: Tue, 31 Jan 2017 22:40:10 +0100
+
+
+---
+ src/data_mgmt/data_import.c |   60 ++++++++++++++++++++++++++++----------------
+ 1 file changed, 39 insertions(+), 21 deletions(-)
+
+--- a/src/data_mgmt/data_import.c
++++ b/src/data_mgmt/data_import.c
+@@ -372,7 +372,7 @@ readX509Cert( const char  *a_pszFile,
+ 		goto out;
+ 	}
+ 
+-	if ( EVP_PKEY_type( pKey->type ) != EVP_PKEY_RSA ) {
++	if ( EVP_PKEY_base_id( pKey ) != EVP_PKEY_RSA ) {
+ 		logError( TOKEN_RSA_KEY_ERROR );
+ 
+ 		X509_free( pX509 );
+@@ -691,8 +691,13 @@ createRsaPubKeyObject( RSA
+ 
+ 	int  rc = -1;
+ 
+-	int  nLen = BN_num_bytes( a_pRsa->n );
+-	int  eLen = BN_num_bytes( a_pRsa->e );
++	const BIGNUM *bn;
++	const BIGNUM *be;
++
++	RSA_get0_key( a_pRsa, &bn, &be, NULL );
++
++	int  nLen = BN_num_bytes( bn );
++	int  eLen = BN_num_bytes( be );
+ 
+ 	CK_RV  rv;
+ 
+@@ -732,8 +737,8 @@ createRsaPubKeyObject( RSA
+ 	}
+ 
+ 	// Get binary representations of the RSA key information
+-	BN_bn2bin( a_pRsa->n, n );
+-	BN_bn2bin( a_pRsa->e, e );
++	BN_bn2bin( bn, n );
++	BN_bn2bin( be, e );
+ 
+ 	// Create the RSA public key object
+ 	rv = createObject( a_hSession, tAttr, ulAttrCount, a_hObject );
+@@ -760,14 +765,27 @@ createRsaPrivKeyObject( RSA
+ 
+ 	int  rc = -1;
+ 
+-	int  nLen = BN_num_bytes( a_pRsa->n );
+-	int  eLen = BN_num_bytes( a_pRsa->e );
+-	int  dLen = BN_num_bytes( a_pRsa->d );
+-	int  pLen = BN_num_bytes( a_pRsa->p );
+-	int  qLen = BN_num_bytes( a_pRsa->q );
+-	int  dmp1Len = BN_num_bytes( a_pRsa->dmp1 );
+-	int  dmq1Len = BN_num_bytes( a_pRsa->dmq1 );
+-	int  iqmpLen = BN_num_bytes( a_pRsa->iqmp );
++	const BIGNUM *bn;
++	const BIGNUM *be;
++	const BIGNUM *bd;
++	const BIGNUM *bp;
++	const BIGNUM *bq;
++	const BIGNUM *bdmp1;
++	const BIGNUM *bdmq1;
++	const BIGNUM *biqmp;
++
++	RSA_get0_key( a_pRsa, &bn, &be, &bd);
++	RSA_get0_factors( a_pRsa, &bp, &bq);
++	RSA_get0_crt_params( a_pRsa, &bdmp1, &bdmq1, &biqmp );
++
++	int  nLen = BN_num_bytes( bn );
++	int  eLen = BN_num_bytes( be );
++	int  dLen = BN_num_bytes( bd );
++	int  pLen = BN_num_bytes( bp );
++	int  qLen = BN_num_bytes( bq );
++	int  dmp1Len = BN_num_bytes( bdmp1 );
++	int  dmq1Len = BN_num_bytes( bdmq1 );
++	int  iqmpLen = BN_num_bytes( biqmp );
+ 
+ 	CK_RV  rv;
+ 
+@@ -821,14 +839,14 @@ createRsaPrivKeyObject( RSA
+ 	}
+ 
+ 	// Get binary representations of the RSA key information
+-	BN_bn2bin( a_pRsa->n, n );
+-	BN_bn2bin( a_pRsa->e, e );
+-	BN_bn2bin( a_pRsa->d, d );
+-	BN_bn2bin( a_pRsa->p, p );
+-	BN_bn2bin( a_pRsa->q, q );
+-	BN_bn2bin( a_pRsa->dmp1, dmp1 );
+-	BN_bn2bin( a_pRsa->dmq1, dmq1 );
+-	BN_bn2bin( a_pRsa->iqmp, iqmp );
++	BN_bn2bin( bn, n );
++	BN_bn2bin( be, e );
++	BN_bn2bin( bd, d );
++	BN_bn2bin( bp, p );
++	BN_bn2bin( bq, q );
++	BN_bn2bin( bdmp1, dmp1 );
++	BN_bn2bin( bdmq1, dmq1 );
++	BN_bn2bin( biqmp, iqmp );
+ 
+ 	// Create the RSA private key object
+ 	rv = createObject( a_hSession, tAttr, ulAttrCount, a_hObject );

--- a/app-crypt/tpm-tools/tpm-tools-1.3.9.1-r1.ebuild
+++ b/app-crypt/tpm-tools/tpm-tools-1.3.9.1-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="TrouSerS' support tools for the Trusted Platform Modules"
+HOMEPAGE="http://trousers.sourceforge.net"
+SRC_URI="mirror://sourceforge/trousers/${PN}/${P}.tar.gz"
+
+LICENSE="CPL-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~m68k ~s390 ~sh ~x86"
+IUSE="libressl nls pkcs11 debug"
+
+DEPEND=">=app-crypt/trousers-0.3.0
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
+	pkcs11? ( dev-libs/opencryptoki )"
+RDEPEND="${DEPEND}"
+BDEPEND="nls? ( sys-devel/gettext )"
+
+S="${WORKDIR}"
+
+PATCHES=( "${FILESDIR}/${P}-openssl-1.1.patch" )
+
+src_prepare() {
+	default
+
+	sed -i -r \
+		-e '/CFLAGS/s/ -m64//' \
+		configure.ac || die
+
+	eautoreconf
+}
+
+src_configure() {
+	append-cppflags $(usex debug -DDEBUG -DNDEBUG)
+
+	econf \
+		$(use_enable nls) \
+		$(use pkcs11 || echo --disable-pkcs11-support)
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/672756
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>