### PR TITLE
mail-filter/rspamd: Init file updates (added "use" & "before")

### DIFF
--- a/mail-filter/rspamd/files/rspamd.init-r5
+++ b/mail-filter/rspamd/files/rspamd.init-r5
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 2015-2017 Gentoo Foundation
+# Copyright 2015-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 extra_commands="checkconfig"
@@ -9,7 +9,8 @@ RUNDIR=/var/run/rspamd
 PIDFILE=$RUNDIR/rspamd.pid
 
 depend() {
-	need net
+	use dns redis
+	before mta
 }
 
 checkconfig() {


### PR DESCRIPTION
Changed init file to indicate that Rspamd uses Redis and that this filter should be started before any MTA.

Signed-off-by: Ralph Seichter <gentoo@seichter.de>
Package-Manager: Portage-2.3.51, Repoman-2.3.11