### PR TITLE
virtual/python-funcsigs: require correct USE flags of python/funcsigs

### DIFF
--- a/virtual/python-funcsigs/python-funcsigs-2.ebuild
+++ b/virtual/python-funcsigs/python-funcsigs-2.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} pypy pypy3 )
+
+inherit python-r1
+
+DESCRIPTION="A Virtual for Python function signatures from PEP362 (py3.6 variant)"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~amd64-linux ~x86-linux ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	$(python_gen_cond_dep '>=dev-python/funcsigs-1[${PYTHON_USEDEP}]' python2_7 python3_{3,4,5} pypy{,3} )"


### PR DESCRIPTION
Disclaimer: I don't know whether it's the right fix.

Here's what happened: I tried to get rid of python 2, but eventually gave up, and tried to bring python 2 back. I have FEATURES=test, and various builds were failing with python2_7 because they couldn't open module funcsigs in the test phase.
It turns out they depend on virtual/python-funcsigs[python2_7], but virtual/python-funcsigs depends on python/funcsigs without requiring any specific python. `emerge -DNu @world` does attempt to update it:
`[ebuild   R    ] dev-python/funcsigs-1.0.2-r1::gentoo  USE="test" PYTHON_TARGETS="python2_7* python3_6 (-pypy) -pypy3 -python3_4 -python3_5 (-python3_7)" 0 KiB`, but does that after trying to build other packages which depend on it.
Adding `[${PYTHON_USEDEP}]` fixes it for me.