### PR TITLE
dev-lang/ruby: 2.3.x require <dev-libs/openssl-1.1

### DIFF
--- a/dev-lang/ruby/ruby-2.3.7.ebuild
+++ b/dev-lang/ruby/ruby-2.3.7.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 	gdbm? ( sys-libs/gdbm:= )
 	jemalloc? ( dev-libs/jemalloc )
 	ssl? (
-		!libressl? ( dev-libs/openssl:0= )
+		!libressl? ( <dev-libs/openssl-1.1:0= )
 		libressl? ( dev-libs/libressl )
 	)
 	socks5? ( >=net-proxy/dante-1.1.13 )

--- a/dev-lang/ruby/ruby-2.3.8.ebuild
+++ b/dev-lang/ruby/ruby-2.3.8.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 	gdbm? ( sys-libs/gdbm:= )
 	jemalloc? ( dev-libs/jemalloc )
 	ssl? (
-		!libressl? ( dev-libs/openssl:0= )
+		!libressl? ( <dev-libs/openssl-1.1:0= )
 		libressl? ( dev-libs/libressl )
 	)
 	socks5? ( >=net-proxy/dante-1.1.13 )


### PR DESCRIPTION
Ruby 2.3.x is not compatible with OpenSSL 1.1

Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Craig Andrews <candrews@gentoo.org>