### PR TITLE
dev-lang/ruby: 2.4.5-r1 for OpenSSL 1.1 "disable-deprecated"

### DIFF
--- a/dev-lang/ruby/files/2.4/012-openssl_1.1.patch
+++ b/dev-lang/ruby/files/2.4/012-openssl_1.1.patch
@@ -1,0 +1,339 @@
+From 7af808153dd34a980e027a04d4490ae38019b3ed Mon Sep 17 00:00:00 2001
+From: Mark Wright <gienah@gentoo.org>
+Date: Sun, 15 Oct 2017 01:24:12 +1100
+Subject: [PATCH] Fix build failure against OpenSSL 1.1 built with
+ no-deprecated Thanks rhenium for the code review and fixes.
+
+---
+ ext/openssl/openssl_missing.h |  4 +++
+ ext/openssl/ossl.c            | 23 ++++++---------
+ ext/openssl/ossl.h            |  5 ++++
+ ext/openssl/ossl_cipher.c     | 14 ++++-----
+ ext/openssl/ossl_engine.c     | 54 ++++++++++++++++++++++-------------
+ ext/openssl/ossl_ssl.c        |  2 +-
+ ext/openssl/ossl_x509cert.c   |  4 +--
+ ext/openssl/ossl_x509crl.c    |  4 +--
+ 8 files changed, 63 insertions(+), 47 deletions(-)
+
+diff --git a/ext/openssl/openssl_missing.h b/ext/openssl/openssl_missing.h
+index cc31f6ac..debd25ad 100644
+--- a/ext/openssl/openssl_missing.h
++++ b/ext/openssl/openssl_missing.h
+@@ -209,6 +209,10 @@ IMPL_PKEY_GETTER(EC_KEY, ec)
+ #  define X509_get0_notAfter(x) X509_get_notAfter(x)
+ #  define X509_CRL_get0_lastUpdate(x) X509_CRL_get_lastUpdate(x)
+ #  define X509_CRL_get0_nextUpdate(x) X509_CRL_get_nextUpdate(x)
++#  define X509_set1_notBefore(x, t) X509_set_notBefore(x, t)
++#  define X509_set1_notAfter(x, t) X509_set_notAfter(x, t)
++#  define X509_CRL_set1_lastUpdate(x, t) X509_CRL_set_lastUpdate(x, t)
++#  define X509_CRL_set1_nextUpdate(x, t) X509_CRL_set_nextUpdate(x, t)
+ #endif
+ 
+ #if !defined(HAVE_SSL_SESSION_GET_PROTOCOL_VERSION)
+diff --git a/ext/openssl/ossl.c b/ext/openssl/ossl.c
+index 93ecc7d4..245385e7 100644
+--- a/ext/openssl/ossl.c
++++ b/ext/openssl/ossl.c
+@@ -1109,25 +1109,14 @@ Init_openssl(void)
+     /*
+      * Init all digests, ciphers
+      */
+-    /* CRYPTO_malloc_init(); */
+-    /* ENGINE_load_builtin_engines(); */
++#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
++    if (!OPENSSL_init_ssl(0, NULL))
++        rb_raise(rb_eRuntimeError, "OPENSSL_init_ssl");
++#else
+     OpenSSL_add_ssl_algorithms();
+     OpenSSL_add_all_algorithms();
+     ERR_load_crypto_strings();
+     SSL_load_error_strings();
+-
+-    /*
+-     * FIXME:
+-     * On unload do:
+-     */
+-#if 0
+-    CONF_modules_unload(1);
+-    destroy_ui_method();
+-    EVP_cleanup();
+-    ENGINE_cleanup();
+-    CRYPTO_cleanup_all_ex_data();
+-    ERR_remove_state(0);
+-    ERR_free_strings();
+ #endif
+ 
+     /*
+@@ -1149,7 +1138,11 @@ Init_openssl(void)
+     /*
+      * Version of OpenSSL the ruby OpenSSL extension is running with
+      */
++#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
++    rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(OpenSSL_version(OPENSSL_VERSION)));
++#else
+     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
++#endif
+ 
+     /*
+      * Version number of OpenSSL the ruby OpenSSL extension was built with
+diff --git a/ext/openssl/ossl.h b/ext/openssl/ossl.h
+index f08889b2..5a15839c 100644
+--- a/ext/openssl/ossl.h
++++ b/ext/openssl/ossl.h
+@@ -35,6 +35,11 @@
+ #if !defined(OPENSSL_NO_OCSP)
+ #  include <openssl/ocsp.h>
+ #endif
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
++#include <openssl/dsa.h>
++#include <openssl/evp.h>
++#include <openssl/dh.h>
+ 
+ /*
+  * Common Module
+diff --git a/ext/openssl/ossl_cipher.c b/ext/openssl/ossl_cipher.c
+index bfa76c1a..e6179733 100644
+--- a/ext/openssl/ossl_cipher.c
++++ b/ext/openssl/ossl_cipher.c
+@@ -508,9 +508,9 @@ ossl_cipher_set_iv(VALUE self, VALUE iv)
+     StringValue(iv);
+     GetCipher(self, ctx);
+ 
+ #if defined(HAVE_AUTHENTICATED_ENCRYPTION)
+-    if (EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER)
++    if (EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER)
+ 	iv_len = (int)(VALUE)EVP_CIPHER_CTX_get_app_data(ctx);
+ #endif
+     if (!iv_len)
+ 	iv_len = EVP_CIPHER_CTX_iv_length(ctx);
+@@ -535,7 +535,7 @@ ossl_cipher_is_authenticated(VALUE self)
+ 
+     GetCipher(self, ctx);
+ 
+ #if defined(HAVE_AUTHENTICATED_ENCRYPTION)
+-    return (EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER) ? Qtrue : Qfalse;
++    return (EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER) ? Qtrue : Qfalse;
+ #else
+     return Qfalse;
+ #endif
+@@ -606,7 +606,7 @@ ossl_cipher_get_auth_tag(int argc, VALUE *argv, VALUE self)
+ 
+     GetCipher(self, ctx);
+ 
+-    if (!(EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER))
++    if (!(EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER))
+ 	ossl_raise(eCipherError, "authentication tag not supported by this cipher");
+ 
+     ret = rb_str_new(NULL, tag_len);
+@@ -641,7 +641,7 @@ ossl_cipher_set_auth_tag(VALUE self, VALUE vtag)
+     tag_len = RSTRING_LENINT(vtag);
+ 
+     GetCipher(self, ctx);
+-    if (!(EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER))
++    if (!(EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER))
+ 	ossl_raise(eCipherError, "authentication tag not supported by this cipher");
+ 
+     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, tag_len, tag))
+@@ -668,7 +668,7 @@ ossl_cipher_set_auth_tag_len(VALUE self, VALUE vlen)
+     EVP_CIPHER_CTX *ctx;
+ 
+     GetCipher(self, ctx);
+-    if (!(EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER))
++    if (!(EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER))
+ 	ossl_raise(eCipherError, "AEAD not supported by this cipher");
+ 
+     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, tag_len, NULL))
+@@ -695,7 +695,7 @@ ossl_cipher_set_iv_length(VALUE self, VALUE iv_length)
+     EVP_CIPHER_CTX *ctx;
+ 
+     GetCipher(self, ctx);
+-    if (!(EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER))
++    if (!(EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER))
+ 	ossl_raise(eCipherError, "cipher does not support AEAD");
+ 
+     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, len, NULL))
+@@ -786,9 +786,9 @@ ossl_cipher_iv_length(VALUE self)
+     int len = 0;
+ 
+     GetCipher(self, ctx);
+ #if defined(HAVE_AUTHENTICATED_ENCRYPTION)
+-    if (EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER)
++    if (EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER)
+ 	len = (int)(VALUE)EVP_CIPHER_CTX_get_app_data(ctx);
+ #endif
+     if (!len)
+ 	len = EVP_CIPHER_CTX_iv_length(ctx);
+diff --git a/ext/openssl/ossl_engine.c b/ext/openssl/ossl_engine.c
+index d69b5dca..5ca0d4ca 100644
+--- a/ext/openssl/ossl_engine.c
++++ b/ext/openssl/ossl_engine.c
+@@ -46,13 +46,25 @@ VALUE eEngineError;
+ /*
+  * Private
+  */
+-#define OSSL_ENGINE_LOAD_IF_MATCH(x) \
++#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
++#define OSSL_ENGINE_LOAD_IF_MATCH(engine_name, x) \
+ do{\
+-  if(!strcmp(#x, RSTRING_PTR(name))){\
+-    ENGINE_load_##x();\
++  if(!strcmp(#engine_name, RSTRING_PTR(name))){\
++    if (OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_##x, NULL))\
++      return Qtrue;\
++    else\
++      ossl_raise(eEngineError, "OPENSSL_init_crypto"); \
++  }\
++}while(0)
++#else
++#define OSSL_ENGINE_LOAD_IF_MATCH(engine_name, x)  \
++do{\
++  if(!strcmp(#engine_name, RSTRING_PTR(name))){\
++    ENGINE_load_##engine_name();\
+     return Qtrue;\
+   }\
+ }while(0)
++#endif
+ 
+ static void
+ ossl_engine_free(void *engine)
+@@ -94,55 +106,55 @@ ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
+     StringValueCStr(name);
+ #ifndef OPENSSL_NO_STATIC_ENGINE
+ #if HAVE_ENGINE_LOAD_DYNAMIC
+-    OSSL_ENGINE_LOAD_IF_MATCH(dynamic);
++    OSSL_ENGINE_LOAD_IF_MATCH(dynamic, DYNAMIC);
+ #endif
+ #if HAVE_ENGINE_LOAD_4758CCA
+-    OSSL_ENGINE_LOAD_IF_MATCH(4758cca);
++    OSSL_ENGINE_LOAD_IF_MATCH(4758cca, 4758CCA);
+ #endif
+ #if HAVE_ENGINE_LOAD_AEP
+-    OSSL_ENGINE_LOAD_IF_MATCH(aep);
++    OSSL_ENGINE_LOAD_IF_MATCH(aep, AEP);
+ #endif
+ #if HAVE_ENGINE_LOAD_ATALLA
+-    OSSL_ENGINE_LOAD_IF_MATCH(atalla);
++    OSSL_ENGINE_LOAD_IF_MATCH(atalla, ATALLA);
+ #endif
+ #if HAVE_ENGINE_LOAD_CHIL
+-    OSSL_ENGINE_LOAD_IF_MATCH(chil);
++    OSSL_ENGINE_LOAD_IF_MATCH(chil, CHIL);
+ #endif
+ #if HAVE_ENGINE_LOAD_CSWIFT
+-    OSSL_ENGINE_LOAD_IF_MATCH(cswift);
++    OSSL_ENGINE_LOAD_IF_MATCH(cswift, CSWIFT);
+ #endif
+ #if HAVE_ENGINE_LOAD_NURON
+-    OSSL_ENGINE_LOAD_IF_MATCH(nuron);
++    OSSL_ENGINE_LOAD_IF_MATCH(nuron, NURON);
+ #endif
+ #if HAVE_ENGINE_LOAD_SUREWARE
+-    OSSL_ENGINE_LOAD_IF_MATCH(sureware);
++    OSSL_ENGINE_LOAD_IF_MATCH(sureware, SUREWARE);
+ #endif
+ #if HAVE_ENGINE_LOAD_UBSEC
+-    OSSL_ENGINE_LOAD_IF_MATCH(ubsec);
++    OSSL_ENGINE_LOAD_IF_MATCH(ubsec, UBSEC);
+ #endif
+ #if HAVE_ENGINE_LOAD_PADLOCK
+-    OSSL_ENGINE_LOAD_IF_MATCH(padlock);
++    OSSL_ENGINE_LOAD_IF_MATCH(padlock, PADLOCK);
+ #endif
+ #if HAVE_ENGINE_LOAD_CAPI
+-    OSSL_ENGINE_LOAD_IF_MATCH(capi);
++    OSSL_ENGINE_LOAD_IF_MATCH(capi, CAPI);
+ #endif
+ #if HAVE_ENGINE_LOAD_GMP
+-    OSSL_ENGINE_LOAD_IF_MATCH(gmp);
++    OSSL_ENGINE_LOAD_IF_MATCH(gmp, GMP);
+ #endif
+ #if HAVE_ENGINE_LOAD_GOST
+-    OSSL_ENGINE_LOAD_IF_MATCH(gost);
++    OSSL_ENGINE_LOAD_IF_MATCH(gost, GOST);
+ #endif
+ #if HAVE_ENGINE_LOAD_CRYPTODEV
+-    OSSL_ENGINE_LOAD_IF_MATCH(cryptodev);
++    OSSL_ENGINE_LOAD_IF_MATCH(cryptodev, CRYPTODEV);
+ #endif
+ #if HAVE_ENGINE_LOAD_AESNI
+-    OSSL_ENGINE_LOAD_IF_MATCH(aesni);
++    OSSL_ENGINE_LOAD_IF_MATCH(aesni, AESNI);
+ #endif
+ #endif
+ #ifdef HAVE_ENGINE_LOAD_OPENBSD_DEV_CRYPTO
+-    OSSL_ENGINE_LOAD_IF_MATCH(openbsd_dev_crypto);
++    OSSL_ENGINE_LOAD_IF_MATCH(openbsd_dev_crypto, OPENBSD_DEV_CRYPTO);
+ #endif
+-    OSSL_ENGINE_LOAD_IF_MATCH(openssl);
++    OSSL_ENGINE_LOAD_IF_MATCH(openssl, OPENSSL);
+     rb_warning("no such builtin loader for `%"PRIsVALUE"'", name);
+     return Qnil;
+ #endif /* HAVE_ENGINE_LOAD_BUILTIN_ENGINES */
+@@ -160,7 +172,9 @@ ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
+ static VALUE
+ ossl_engine_s_cleanup(VALUE self)
+ {
++#if defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000
+     ENGINE_cleanup();
++#endif
+     return Qnil;
+ }
+ 
+diff --git a/ext/openssl/ossl_ssl.c b/ext/openssl/ossl_ssl.c
+index 8e3c0c42..d32a299c 100644
+--- a/ext/openssl/ossl_ssl.c
++++ b/ext/openssl/ossl_ssl.c
+@@ -379,7 +379,7 @@ ossl_call_session_get_cb(VALUE ary)
+ 
+ /* this method is currently only called for servers (in OpenSSL <= 0.9.8e) */
+ static SSL_SESSION *
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
+ ossl_sslctx_session_get_cb(SSL *ssl, const unsigned char *buf, int len, int *copy)
+ #else
+ ossl_sslctx_session_get_cb(SSL *ssl, unsigned char *buf, int len, int *copy)
+diff --git a/ext/openssl/ossl_x509cert.c b/ext/openssl/ossl_x509cert.c
+index cf82a53d..8d16b9b7 100644
+--- a/ext/openssl/ossl_x509cert.c
++++ b/ext/openssl/ossl_x509cert.c
+@@ -440,7 +440,7 @@ ossl_x509_set_not_before(VALUE self, VALUE time)
+ 
+     GetX509(self, x509);
+     asn1time = ossl_x509_time_adjust(NULL, time);
+-    if (!X509_set_notBefore(x509, asn1time)) {
++    if (!X509_set1_notBefore(x509, asn1time)) {
+ 	ASN1_TIME_free(asn1time);
+ 	ossl_raise(eX509CertError, "X509_set_notBefore");
+     }
+@@ -479,7 +479,7 @@ ossl_x509_set_not_after(VALUE self, VALUE time)
+ 
+     GetX509(self, x509);
+     asn1time = ossl_x509_time_adjust(NULL, time);
+-    if (!X509_set_notAfter(x509, asn1time)) {
++    if (!X509_set1_notAfter(x509, asn1time)) {
+ 	ASN1_TIME_free(asn1time);
+ 	ossl_raise(eX509CertError, "X509_set_notAfter");
+     }
+diff --git a/ext/openssl/ossl_x509crl.c b/ext/openssl/ossl_x509crl.c
+index 5ecd7ea0..45cf7fb4 100644
+--- a/ext/openssl/ossl_x509crl.c
++++ b/ext/openssl/ossl_x509crl.c
+@@ -226,7 +226,7 @@ ossl_x509crl_set_last_update(VALUE self, VALUE time)
+ 
+     GetX509CRL(self, crl);
+     asn1time = ossl_x509_time_adjust(NULL, time);
+-    if (!X509_CRL_set_lastUpdate(crl, asn1time)) {
++    if (!X509_CRL_set1_lastUpdate(crl, asn1time)) {
+ 	ASN1_TIME_free(asn1time);
+ 	ossl_raise(eX509CRLError, "X509_CRL_set_lastUpdate");
+     }
+@@ -257,7 +257,7 @@ ossl_x509crl_set_next_update(VALUE self, VALUE time)
+ 
+     GetX509CRL(self, crl);
+     asn1time = ossl_x509_time_adjust(NULL, time);
+-    if (!X509_CRL_set_nextUpdate(crl, asn1time)) {
++    if (!X509_CRL_set1_nextUpdate(crl, asn1time)) {
+ 	ASN1_TIME_free(asn1time);
+ 	ossl_raise(eX509CRLError, "X509_CRL_set_nextUpdate");
+     }

--- a/dev-lang/ruby/ruby-2.4.5-r1.ebuild
+++ b/dev-lang/ruby/ruby-2.4.5-r1.ebuild
@@ -1,0 +1,229 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools flag-o-matic multilib
+
+MY_P="${PN}-$(ver_cut 1-3)"
+S=${WORKDIR}/${MY_P}
+
+SLOT=$(ver_cut 1-2)
+MY_SUFFIX=$(ver_rs 1 '' ${SLOT})
+RUBYVERSION=${SLOT}.0
+
+DESCRIPTION="An object-oriented scripting language"
+HOMEPAGE="https://www.ruby-lang.org/"
+SRC_URI="mirror://ruby/${SLOT}/${MY_P}.tar.xz"
+
+LICENSE="|| ( Ruby-BSD BSD-2 )"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE="berkdb debug doc examples gdbm ipv6 jemalloc libressl +rdoc rubytests socks5 ssl static-libs tk xemacs"
+
+RDEPEND="
+	berkdb? ( sys-libs/db:= )
+	gdbm? ( sys-libs/gdbm:= )
+	jemalloc? ( dev-libs/jemalloc )
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl )
+	)
+	socks5? ( >=net-proxy/dante-1.1.13 )
+	tk? (
+		dev-lang/tcl:0=[threads]
+		dev-lang/tk:0=[threads]
+	)
+	dev-libs/libyaml
+	virtual/libffi:=
+	sys-libs/zlib
+	>=app-eselect/eselect-ruby-20161226
+	!<dev-ruby/rdoc-3.9.4
+	!<dev-ruby/rubygems-1.8.10-r1"
+
+DEPEND="${RDEPEND}"
+
+BUNDLED_GEMS="
+	>=dev-ruby/did_you_mean-1.1.0:2.4[ruby_targets_ruby24]
+	>=dev-ruby/minitest-5.10.1[ruby_targets_ruby24]
+	>=dev-ruby/net-telnet-0.1.1[ruby_targets_ruby24]
+	>=dev-ruby/power_assert-0.4.1[ruby_targets_ruby24]
+	>=dev-ruby/rake-12.0.0[ruby_targets_ruby24]
+	>=dev-ruby/test-unit-3.2.3[ruby_targets_ruby24]
+	>=dev-ruby/xmlrpc-0.2.1[ruby_targets_ruby24]
+"
+
+PDEPEND="
+	${BUNDLED_GEMS}
+	virtual/rubygems[ruby_targets_ruby24]
+	>=dev-ruby/json-2.0.2[ruby_targets_ruby24]
+	rdoc? ( >=dev-ruby/rdoc-5.1.0[ruby_targets_ruby24] )
+	xemacs? ( app-xemacs/ruby-modes )"
+
+src_prepare() {
+	eapply "${FILESDIR}"/${SLOT}/{002,005,009,012}*.patch
+
+	einfo "Unbundling gems..."
+	cd "$S"
+	# Remove bundled gems that we will install via PDEPEND, bug
+	# 539700. Use explicit version numbers to ensure rm fails when they
+	# change so we can update dependencies accordingly.
+	rm -f gems/{did_you_mean-1.1.0,minitest-5.10.1,net-telnet-0.1.1,power_assert-0.4.1,rake-12.0.0,test-unit-3.2.3,xmlrpc-0.2.1}.gem || die
+
+	einfo "Removing bundled libraries..."
+	rm -fr ext/fiddle/libffi-3.2.1 || die
+
+	# Fix a hardcoded lib path in configure script
+	sed -i -e "s:\(RUBY_LIB_PREFIX=\"\${prefix}/\)lib:\1$(get_libdir):" \
+		configure.in || die "sed failed"
+
+	eapply_user
+
+	eautoreconf
+}
+
+src_configure() {
+	local modules= myconf=
+
+	# -fomit-frame-pointer makes ruby segfault, see bug #150413.
+	filter-flags -fomit-frame-pointer
+	# In many places aliasing rules are broken; play it safe
+	# as it's risky with newer compilers to leave it as it is.
+	append-flags -fno-strict-aliasing
+	# SuperH needs this
+	use sh && append-flags -mieee
+
+	# Socks support via dante
+	if use socks5 ; then
+		# Socks support can't be disabled as long as SOCKS_SERVER is
+		# set and socks library is present, so need to unset
+		# SOCKS_SERVER in that case.
+		unset SOCKS_SERVER
+	fi
+
+	# Increase GC_MALLOC_LIMIT if set (default is 8000000)
+	if [ -n "${RUBY_GC_MALLOC_LIMIT}" ] ; then
+		append-flags "-DGC_MALLOC_LIMIT=${RUBY_GC_MALLOC_LIMIT}"
+	fi
+
+	# ipv6 hack, bug 168939. Needs --enable-ipv6.
+	use ipv6 || myconf="${myconf} --with-lookup-order-hack=INET"
+
+	# Determine which modules *not* to build depending in the USE flags.
+	if ! use berkdb ; then
+		modules="${modules},dbm"
+	fi
+	if ! use gdbm ; then
+		modules="${modules},gdbm"
+	fi
+	if ! use ssl ; then
+		modules="${modules},openssl"
+	fi
+	if ! use tk ; then
+		modules="${modules},tk"
+	fi
+
+	# Provide an empty LIBPATHENV because we disable rpath but we do not
+	# need LD_LIBRARY_PATH by default since that breaks USE=multitarget
+	# #564272
+	INSTALL="${EPREFIX}/usr/bin/install -c" LIBPATHENV="" econf \
+		--program-suffix=${MY_SUFFIX} \
+		--with-soname=ruby${MY_SUFFIX} \
+		--docdir=${EPREFIX}/usr/share/doc/${P} \
+		--enable-shared \
+		--enable-pthread \
+		--disable-rpath \
+		--with-out-ext="${modules}" \
+		$(use_with jemalloc jemalloc) \
+		$(use_enable socks5 socks) \
+		$(use_enable doc install-doc) \
+		--enable-ipv6 \
+		$(use_enable static-libs static) \
+		$(use_enable static-libs install-static-library) \
+		$(use_with static-libs static-linked-ext) \
+		$(use_enable debug) \
+		${myconf} \
+		--enable-option-checking=no \
+		|| die "econf failed"
+}
+
+src_compile() {
+	emake V=1 EXTLDFLAGS="${LDFLAGS}" || die "emake failed"
+}
+
+src_test() {
+	emake -j1 V=1 test || die "make test failed"
+
+	elog "Ruby's make test has been run. Ruby also ships with a make check"
+	elog "that cannot be run until after ruby has been installed."
+	elog
+	if use rubytests; then
+		elog "You have enabled rubytests, so they will be installed to"
+		elog "/usr/share/${PN}-${SLOT}/test. To run them you must be a user other"
+		elog "than root, and you must place them into a writeable directory."
+		elog "Then call: "
+		elog
+		elog "ruby${MY_SUFFIX} -C /location/of/tests runner.rb"
+	else
+		elog "Enable the rubytests USE flag to install the make check tests"
+	fi
+}
+
+src_install() {
+	# Remove the remaining bundled gems. We do this late in the process
+	# since they are used during the build to e.g. create the
+	# documentation.
+	rm -rf ext/json || die
+
+	# Ruby is involved in the install process, we don't want interference here.
+	unset RUBYOPT
+
+	local MINIRUBY=$(echo -e 'include Makefile\ngetminiruby:\n\t@echo $(MINIRUBY)'|make -f - getminiruby)
+
+	LD_LIBRARY_PATH="${S}:${ED}/usr/$(get_libdir)${LD_LIBRARY_PATH+:}${LD_LIBRARY_PATH}"
+	RUBYLIB="${S}:${ED}/usr/$(get_libdir)/ruby/${RUBYVERSION}"
+	for d in $(find "${S}/ext" -type d) ; do
+		RUBYLIB="${RUBYLIB}:$d"
+	done
+	export LD_LIBRARY_PATH RUBYLIB
+
+	emake V=1 DESTDIR="${D}" install || die "make install failed"
+
+	# Remove installed rubygems and rdoc copy
+	rm -rf "${ED}/usr/$(get_libdir)/ruby/${RUBYVERSION}/rubygems" || die "rm rubygems failed"
+	rm -rf "${ED}/usr/bin/"gem"${MY_SUFFIX}" || die "rm rdoc bins failed"
+	rm -rf "${ED}/usr/$(get_libdir)/ruby/${RUBYVERSION}"/rdoc* || die "rm rdoc failed"
+	rm -rf "${ED}/usr/bin/"{ri,rdoc}"${MY_SUFFIX}" || die "rm rdoc bins failed"
+
+	if use doc; then
+		make DESTDIR="${D}" install-doc || die "make install-doc failed"
+	fi
+
+	if use examples; then
+		insinto /usr/share/doc/${PF}
+		doins -r sample
+	fi
+
+	dodoc ChangeLog NEWS doc/NEWS* README* || die
+
+	if use rubytests; then
+		pushd test
+		insinto /usr/share/${PN}-${SLOT}/test
+		doins -r .
+		popd
+	fi
+}
+
+pkg_postinst() {
+	if [[ ! -n $(readlink "${EROOT}"usr/bin/ruby) ]] ; then
+		eselect ruby set ruby${MY_SUFFIX}
+	fi
+
+	elog
+	elog "To switch between available Ruby profiles, execute as root:"
+	elog "\teselect ruby set ruby(23|24|...)"
+	elog
+}
+
+pkg_postrm() {
+	eselect ruby cleanup
+}


### PR DESCRIPTION
Tested by running:
`USE="rubytests" FEATURES="test" ebuild ruby-2.4.5-r1.ebuild test`
Everything passes.

Closes: https://bugs.gentoo.org/614760
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Craig Andrews <candrews@gentoo.org>

@Polynomial-C should interest you