### PR TITLE
virtual/libusb: add support for USE=static-libs

### DIFF
--- a/virtual/libusb/libusb-1-r3.ebuild
+++ b/virtual/libusb/libusb-1-r3.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit multilib-build
+
+DESCRIPTION="Virtual for libusb"
+SLOT="1"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+IUSE="static-libs udev"
+
+# We force a recent libusb so that downstream consumers of virtual/libusb
+# can depend on us directly (and not have to force >=libusb-1.0.19).
+RDEPEND="
+	|| (
+		>=dev-libs/libusb-1.0.19:1[static-libs(+)?,udev(+)?,${MULTILIB_USEDEP}]
+		>=sys-freebsd/freebsd-lib-9.1-r10[usb,${MULTILIB_USEDEP}]
+	)
+"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/672920
Reported-by: Kalin KOZHUHAROV <kalin@thinrope.net>

Thinks to consider:
* What does EAPI=6 change here (I think nothing)