### PR TITLE
net-wireless/crda: fix build with LibreSSL

### DIFF
--- a/net-wireless/crda/crda-3.18-r3.ebuild
+++ b/net-wireless/crda/crda-3.18-r3.ebuild
@@ -18,9 +18,9 @@ IUSE="gcrypt libressl"
 
 RDEPEND="!gcrypt? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:= )
+		libressl? ( dev-libs/libressl:0= )
 	)
-	gcrypt? ( dev-libs/libgcrypt:0 )
+	gcrypt? ( dev-libs/libgcrypt:0= )
 	dev-libs/libnl:3
 	net-wireless/wireless-regdb"
 DEPEND="${RDEPEND}

--- a/net-wireless/crda/crda-3.18-r3.ebuild
+++ b/net-wireless/crda/crda-3.18-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -38,6 +38,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.18-cflags.patch
 	"${FILESDIR}"/${PN}-3.18-libreg-link.patch #542436
 	"${FILESDIR}"/${PN}-3.18-openssl-1.1.0-compatibility.patch #652428
+	"${FILESDIR}"/${PN}-3.18-libressl.patch
 )
 
 src_prepare() {

--- a/net-wireless/crda/files/crda-3.18-libressl.patch
+++ b/net-wireless/crda/files/crda-3.18-libressl.patch
@@ -1,0 +1,11 @@
+--- crda-3.18/reglib.c	2018-10-26 12:39:19.128083735 +1100
++++ crda-3.18.a/reglib.c	2018-10-26 12:42:39.737916626 +1100
+@@ -111,7 +111,7 @@ int reglib_verify_db_signature(uint8_t *
+ 			goto out;
+ 		}
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ 		rsa->e = rsa_e;
+ 		rsa->n = rsa_n;
+ #else


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/669596
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>