### PR TITLE
app-admin/rasdaemon: fix multiple issues

### DIFF
--- a/app-admin/rasdaemon/rasdaemon-0.6.2-r2.ebuild
+++ b/app-admin/rasdaemon/rasdaemon-0.6.2-r2.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit linux-info systemd
+
+DESCRIPTION="Reliability, Availability and Serviceability logging tool"
+HOMEPAGE="http://www.infradead.org/~mchehab/rasdaemon/"
+SRC_URI="http://www.infradead.org/~mchehab/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+DEPEND=""
+RDEPEND="
+	${DEPEND}
+	sys-devel/gettext
+	dev-db/sqlite
+	sys-apps/dmidecode
+	dev-perl/DBD-SQLite
+"
+
+pkg_setup() {
+	linux-info_pkg_setup
+	local CONFIG_CHECK="~ACPI_EXTLOG ~DYNAMIC_FTRACE ~FUNCTION_GRAPH_TRACER  ~FUNCTION_TRACER ~STACK_TRACER"
+	check_extra_config
+}
+
+src_configure() {
+	local myconf=(
+		--enable-abrt-report
+		--enable-aer
+		--enable-arm
+		--enable-extlog
+		--enable-hisi-ns-decode
+		--enable-mce
+		--enable-non-standard
+		--enable-sqlite3
+		--includedir="/usr/include/${PN}"
+		--localstatedir=/var
+	)
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+
+	keepdir "/var/lib/${PN}"
+
+	systemd_dounit misc/*.service
+
+	newinitd "${FILESDIR}/rasdaemon.openrc" rasdaemon
+	newinitd "${FILESDIR}/ras-mc-ctl.openrc" ras-mc-ctl
+}


### PR DESCRIPTION
Hey, found multiple issues with it. here are the fixes.

- 1

```sh
Calling ras_mc_event_opendb()
rasdaemon: cpu 0: Failed to connect to /var/lib/rasdaemon/ras-mc_event.db: error = 14
```

```
 * QA Notice:
 * One or more empty directories installed to /var:
 * 
 *   /var/lib
 *   /var/lib/rasdaemon

```

keepdir it. otherwise it does not store events.
looks like empty dir was deleted by portage.


- 2
```sh
qlist rasdaemon
...
/usr/include/event-parse.h
/usr/include/event-utils.h
/usr/include/kbuffer.h
/usr/include/config.h
/usr/include/ras-events.h
/usr/include/ras-logger.h
/usr/include/ras-mc-handler.h
/usr/include/ras-aer-handler.h
/usr/include/ras-mce-handler.h
/usr/include/ras-record.h
/usr/include/bitfield.h
/usr/include/ras-report.h
/usr/include/ras-extlog-handler.h
/usr/include/ras-arm-handler.h
/usr/include/ras-non-standard-handler.h
...
```

this looks very wrong. move it to subdir by passing explicit `--includedir=/usr/include/${PN}`

- 3
--enable-extlog wants kernel with `CONFIG_ACPI_EXTLOG`, added this to checks.
also probably it's not worth enabling ARM events on non-arm arch, but it looks it does no harm.



here's list of installed files after fixes
```Hack
/tmp/portage/app-admin/rasdaemon-0.6.2-r2/image
├── etc
│   └── init.d
│       ├── rasdaemon
│       └── ras-mc-ctl
├── lib
│   └── systemd
│       └── system
│           ├── rasdaemon.service
│           └── ras-mc-ctl.service
├── usr
│   ├── include
│   │   └── rasdaemon
│   │       ├── bitfield.h
│   │       ├── config.h
│   │       ├── event-parse.h
│   │       ├── event-utils.h
│   │       ├── kbuffer.h
│   │       ├── ras-aer-handler.h
│   │       ├── ras-arm-handler.h
│   │       ├── ras-events.h
│   │       ├── ras-extlog-handler.h
│   │       ├── ras-logger.h
│   │       ├── ras-mce-handler.h
│   │       ├── ras-mc-handler.h
│   │       ├── ras-non-standard-handler.h
│   │       ├── ras-record.h
│   │       └── ras-report.h
│   ├── lib
│   │   └── debug
│   │       └── usr
│   │           └── sbin
│   │               └── rasdaemon.debug
│   ├── sbin
│   │   ├── rasdaemon
│   │   └── ras-mc-ctl
│   └── share
│       ├── doc
│       │   └── rasdaemon-0.6.2-r2
│       │       ├── AUTHORS
│       │       ├── ChangeLog.bz2
│       │       ├── NEWS.bz2
│       │       ├── README.bz2
│       │       └── TODO.bz2
│       └── man
│           ├── man1
│           │   └── rasdaemon.1.bz2
│           └── man8
│               └── ras-mc-ctl.8.bz2
└── var
    └── lib
        └── rasdaemon
            └── .keep_app-admin_rasdaemon-0

22 directories, 30 files
```

and here's the diff.
```diff
diff -u rasdaemon-0.6.2-r1.ebuild rasdaemon-0.6.2-r2.ebuild 
--- rasdaemon-0.6.2-r1.ebuild   2018-12-11 22:20:29.875285533 -0800
+++ rasdaemon-0.6.2-r2.ebuild   2018-12-11 22:24:06.969850181 -0800
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit linux-info systemd
+inherit linux-info systemd
 
 DESCRIPTION="Reliability, Availability and Serviceability logging tool"
 HOMEPAGE="http://www.infradead.org/~mchehab/rasdaemon/"
@@ -25,24 +25,31 @@
 
 pkg_setup() {
        linux-info_pkg_setup
-       local CONFIG_CHECK="~FUNCTION_TRACER ~FUNCTION_GRAPH_TRACER ~STACK_TRACER ~DYNAMIC_FTRACE"
+       local CONFIG_CHECK="~ACPI_EXTLOG ~DYNAMIC_FTRACE ~FUNCTION_GRAPH_TRACER  ~FUNCTION_TRACER ~STACK_TRACER"
        check_extra_config
 }
 
 src_configure() {
-       econf --enable-abrt-report \
-               --enable-aer \
-               --enable-arm \
-               --enable-extlog \
-               --enable-hisi-ns-decode \
-               --enable-mce \
-               --enable-non-standard \
-               --enable-sqlite3 \
+       local myconf=(
+               --enable-abrt-report
+               --enable-aer
+               --enable-arm
+               --enable-extlog
+               --enable-hisi-ns-decode
+               --enable-mce
+               --enable-non-standard
+               --enable-sqlite3
+               --includedir="/usr/include/${PN}"
                --localstatedir=/var
+       )
+       econf "${myconf[@]}"
 }
 
 src_install() {
        default
+
+       keepdir "/var/lib/${PN}"
+
        systemd_dounit misc/*.service
 
        newinitd "${FILESDIR}/rasdaemon.openrc" rasdaemon
        ```