### PR TITLE
app-admin/rasdaemon: fix multiple issues with initscripts

### DIFF
--- a/app-admin/rasdaemon/files/ras-mc-ctl.openrc-r1
+++ b/app-admin/rasdaemon/files/ras-mc-ctl.openrc-r1
@@ -1,0 +1,23 @@
+#!/sbin/openrc-run
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Loads Motherboard DIMM labels into EDAC driver"
+
+depend() {
+	keyword -stop
+	need sysfs
+}
+
+command="/usr/sbin/ras-mc-ctl"
+command_args="--register-labels"
+
+start() {
+	ebegin "Loading Motherboard DIMM labels into EDAC driver"
+	"${command}" "${command_args}"
+	eend $?
+}
+
+stop() {
+	:
+}

--- a/app-admin/rasdaemon/files/rasdaemon.openrc-r1
+++ b/app-admin/rasdaemon/files/rasdaemon.openrc-r1
@@ -1,0 +1,24 @@
+#!/sbin/openrc-run
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Starts Reliablity, Availability and Serviceability (RAS) service"
+
+depend() {
+	need localmount
+	use logger
+}
+
+command="/usr/sbin/rasdaemon"
+command_args="--foreground --record"
+command_background=true
+pidfile=/run/${RC_SVCNAME}.pid
+
+
+start_post() {
+	"${command}" --enable >/dev/null 2>&1
+}
+
+stop_post() {
+	"${command}" --disable >/dev/null 2>&1
+}

--- a/app-admin/rasdaemon/rasdaemon-0.6.2-r3.ebuild
+++ b/app-admin/rasdaemon/rasdaemon-0.6.2-r3.ebuild
@@ -52,6 +52,6 @@ src_install() {
 
 	systemd_dounit misc/*.service
 
-	newinitd "${FILESDIR}/rasdaemon.openrc" rasdaemon
-	newinitd "${FILESDIR}/ras-mc-ctl.openrc" ras-mc-ctl
+	newinitd "${FILESDIR}/rasdaemon.openrc-r1" rasdaemon
+	newinitd "${FILESDIR}/ras-mc-ctl.openrc-r1" ras-mc-ctl
 }


### PR DESCRIPTION
Hey, it's me again.

Fixed initscripts, ras-mc-ctl was failing to stop and
failing to report status, because it's not a daemon. It's equivalent of systemd's oneshot. just runs command and exits. openrc remembers exit code now and reports it properly as started.
also added noop stop function and keyword, because if can't be stopped.

also fixed deps, and output from rasdaemon goes to syslog and no longer printed
on console on start.

ebuild almost unchanged, just updated path to files.


```diff
--- files/rasdaemon.openrc      2018-12-12 19:49:09.162474522 -0800
+++ files/rasdaemon.openrc-r1   2018-12-14 00:50:28.539671943 -0800
@@ -2,17 +2,23 @@
 # Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-description="Starts ${SVCNAME} service"
+description="Starts Reliablity, Availability and Serviceability (RAS) service"
 
-command="/usr/sbin/${SVCNAME}"
+depend() {
+       need localmount
+       use logger
+}
+
+command="/usr/sbin/rasdaemon"
 command_args="--foreground --record"
-pidfile=/run/${SVCNAME}.pid
 command_background=true
+pidfile=/run/${RC_SVCNAME}.pid
+
 
 start_post() {
-  "${command}" --enable
+       "${command}" --enable >/dev/null 2>&1
 }
 
 stop_post() {
-  "${command}" --disable
+       "${command}" --disable >/dev/null 2>&1
 }

```


```diff
 --- files/ras-mc-ctl.openrc     2018-12-12 19:49:09.162474522 -0800
+++ files/ras-mc-ctl.openrc-r1  2018-12-14 00:35:07.227300847 -0800
@@ -2,9 +2,22 @@
 # Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-description="Starts ${SVCNAME} service for rasdaemon"
+description="Loads Motherboard DIMM labels into EDAC driver"
 
-command="/usr/sbin/${SVCNAME}"
+depend() {
+       keyword -stop
+       need sysfs
+}
+
+command="/usr/sbin/ras-mc-ctl"
 command_args="--register-labels"
-pidfile=/run/${SVCNAME}.pid
-command_background=true
+
+start() {
+       ebegin "Loading Motherboard DIMM labels into EDAC driver"
+       "${command}" "${command_args}"
+       eend $?
+}
+
+stop() {
+       :
+}
```