### PR TITLE
neta-analyzer/zabbix-4.0.2:  Change DEPENDs for building server

### DIFF
--- a/net-analyzer/zabbix/zabbix-4.0.2.ebuild
+++ b/net-analyzer/zabbix/zabbix-4.0.2.ebuild
@@ -16,7 +16,7 @@ LICENSE="GPL-2"
 SLOT="0"
 WEBAPP_MANUAL_SLOT="yes"
 KEYWORDS=""
-IUSE="+agent java curl frontend ipv6 xmpp ldap libxml2 mysql openipmi oracle +postgres proxy server ssh ssl snmp sqlite odbc static"
+IUSE="+agent java curl frontend ipv6 xmpp ldap libxml2 mysql openipmi oracle postgres proxy server ssh ssl snmp sqlite odbc static"
 REQUIRED_USE="|| ( agent frontend proxy server )
 	proxy? ( ^^ ( mysql oracle postgres sqlite odbc ) )
 	server? ( ^^ ( mysql oracle postgres odbc ) )
@@ -28,7 +28,6 @@ COMMON_DEPEND="snmp? ( net-analyzer/net-snmp )
 		=dev-libs/cyrus-sasl-2*
 		net-libs/gnutls
 	)
-	mysql? ( >=virtual/mysql-5.0.3 )
 	sqlite? ( >=dev-db/sqlite-3.3.5 )
 	postgres? ( >=dev-db/postgresql-8.1:* )
 	oracle? ( >=dev-db/oracle-instantclient-basic-10.0.0.0 )
@@ -46,7 +45,6 @@ COMMON_DEPEND="snmp? ( net-analyzer/net-snmp )
 RDEPEND="${COMMON_DEPEND}
 	proxy? ( net-analyzer/fping[suid] )
 	server? ( net-analyzer/fping[suid]
-		app-admin/webapp-config
 		dev-libs/libpcre
 		dev-libs/libevent )
 	java?	(
@@ -70,7 +68,7 @@ DEPEND="${COMMON_DEPEND}
 			=dev-libs/cyrus-sasl-2*[static-libs]
 			net-libs/gnutls[static-libs]
 		)
-	mysql? ( >=virtual/mysql-5.0.3[static-libs] )
+	mysql? ( dev-db/mysql-connector-c )	
 	sqlite? ( >=dev-db/sqlite-3.3.5[static-libs] )
 	postgres? ( >=dev-db/postgresql-8.1:*[static-libs] )
 	libxml2? ( dev-libs/libxml2[static-libs] )


### PR DESCRIPTION
I'm going to install Zabbix4.0.2 in an enterprise environment using containers. Therefore, I want to split the Zabbix installation into tree parts: First one with the Zabbix server, second with the (MySQL) database engine as a master-slave pair, and third with an Apache/PHP-Server for the frontend.

The ebuild already support the split into server and frontend. But with the database part, the "server mysql" USEflag want to pull a whole MySQL (or MariaDB) installation. But to build the server, there's no need for this; the package   dev-db/mysql-connector-c  with the mysql C binding will be sufficient.

But I don't know if it's the Gentoo way to "kick out" the runtime dependency for MySQL if one has applied the "mysql" USEflag on the Zabbix build. Within this build, the meaning is to select to build with the MySQL bindings. For me that's OK because I guess that it's quite usual to have the database engine running elsewhere.

Sign-off-by: G.Jaekel@DNB.DE