### PR TITLE
dev-util/meson: fix typo in ebuild

### DIFF
--- a/dev-util/meson/meson-0.48.2.ebuild
+++ b/dev-util/meson/meson-0.48.2.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="http://mesonbuild.com/"
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="test"
-RESTIRCT="!test? ( test )"
+RESTRICT="!test? ( test )"
 
 RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}

--- a/dev-util/meson/meson-0.49.0.ebuild
+++ b/dev-util/meson/meson-0.49.0.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="http://mesonbuild.com/"
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="test"
-RESTIRCT="!test? ( test )"
+RESTRICT="!test? ( test )"
 
 RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}

--- a/dev-util/meson/meson-9999.ebuild
+++ b/dev-util/meson/meson-9999.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="http://mesonbuild.com/"
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="test"
-RESTIRCT="!test? ( test )"
+RESTRICT="!test? ( test )"
 
 RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
RESTIRCT!=RESTRICT

Closes: https://bugs.gentoo.org/673130

Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>