### PR TITLE
*/*/metadata.xml: fix various whitespace issues

### DIFF
--- a/sci-chemistry/vmd/metadata.xml
+++ b/sci-chemistry/vmd/metadata.xml
@@ -13,7 +13,7 @@
     <flag name="cuda">Use nvidia cuda toolkit for speeding up computations</flag>
     <flag name="gromacs">Add support for TNG file format</flag>
     <flag name="msms">Add support for MSMS SES calcualtion tool</flag>
-    <flag name="povray">Add support for povray raytracer for HQ	images</flag>
+    <flag name="povray">Add support for povray raytracer for HQ images</flag>
     <flag name="tachyon">Add support for tachyon raytracer for HQ images</flag>
   </use>
 </pkgmetadata>

--- a/sci-libs/dmlc-core/metadata.xml
+++ b/sci-libs/dmlc-core/metadata.xml
@@ -15,5 +15,5 @@
   </upstream>
   <use>
     <flag name="s3">Support for the Amazon Simple Storage Service</flag>
-  </use>		
+  </use>
 </pkgmetadata>

--- a/sci-mathematics/pspp/metadata.xml
+++ b/sci-mathematics/pspp/metadata.xml
@@ -10,7 +10,7 @@
   interprets commands in the SPSS language and produces tabular and
   graphical output in ASCII, HTML, or PostScript format.
   PSPP supports a large subset of SPSS's transformation language. Its
-  statistical procedure support is limited but growing.	
+  statistical procedure support is limited but growing.
   PSPP has both text-based and a GTK+ based graphical user interfaces.
 </longdescription>
 </pkgmetadata>


### PR DESCRIPTION
Some were trailing whitespace, others were mixed truthfully. Mixed cases were fixed
by `:%s:\t:    :g` within vim, and checking the indentation actually looks alright. Github's
formatting turned that into a single space but its four.