### PR TITLE
app-arch/lbzip2: fix gnulib fseterr.c for glibc-2.28

### DIFF
--- a/app-arch/lbzip2/files/lbzip2-2.5-glibc-2.28.patch
+++ b/app-arch/lbzip2/files/lbzip2-2.5-glibc-2.28.patch
@@ -1,0 +1,50 @@
+diff --git a/lib/fseterr.c b/lib/fseterr.c
+index 1e212e4..81f51ed 100644
+--- a/lib/fseterr.c
++++ b/lib/fseterr.c
+@@ -1,5 +1,5 @@
+ /* Set the error indicator of a stream.
+-   Copyright (C) 2007-2014 Free Software Foundation, Inc.
++   Copyright (C) 2007-2018 Free Software Foundation, Inc.
+ 
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+@@ -12,7 +12,7 @@
+    GNU General Public License for more details.
+ 
+    You should have received a copy of the GNU General Public License
+-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+ 
+ #include <config.h>
+ 
+@@ -23,21 +23,26 @@
+ 
+ #include "stdio-impl.h"
+ 
++/* This file is not used on systems that have the __fseterr function,
++   namely musl libc.  */
++
+ void
+ fseterr (FILE *fp)
+ {
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
++  /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+-#elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
++#elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
++  /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+   fp_->_flags |= __SERR;
+ #elif defined __EMX__               /* emx+gcc */
+   fp->_flags |= _IOERR;
+ #elif defined __minix               /* Minix */
+   fp->_flags |= _IOERR;
+-#elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, NonStop Kernel */
++#elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel, OpenVMS */
+   fp_->_flag |= _IOERR;
+ #elif defined __UCLIBC__            /* uClibc */
+   fp->__modeflags |= __FLAG_ERROR;

--- a/app-arch/lbzip2/lbzip2-2.5-r1.ebuild
+++ b/app-arch/lbzip2/lbzip2-2.5-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Parallel bzip2 utility"
+HOMEPAGE="https://github.com/kjn/lbzip2/"
+SRC_URI="http://archive.lbzip2.org/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
+IUSE="debug symlink"
+
+RDEPEND="symlink? ( !app-arch/pbzip2[symlink] )"
+DEPEND=""
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.3-s_isreg.patch
+	# bug 669594
+	"${FILESDIR}"/${PN}-2.5-glibc-2.28.patch
+)
+
+src_configure() {
+	local myeconfargs=(
+		--disable-silent-rules
+		$(use_enable debug tracing)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	if use symlink; then
+		dosym ${PN} /usr/bin/bzip2
+		dosym lbunzip2 /usr/bin/bunzip2
+	fi
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/669594
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>