### PR TITLE
app-editors/ghostwriter: add missing dependency

### DIFF
--- a/app-editors/ghostwriter/ghostwriter-1.7.4-r1.ebuild
+++ b/app-editors/ghostwriter/ghostwriter-1.7.4-r1.ebuild
@@ -19,6 +19,7 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtprintsupport:5
+	dev-qt/qtsvg:5
 	dev-qt/qtwebkit:5
 	dev-qt/qtwidgets:5
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/673318
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: David Roman <davidroman96@gmail.com>