### PR TITLE
dev-util/edb-debugger: add sub-slot operator for capstone and revbump

### DIFF
--- a/dev-util/edb-debugger/edb-debugger-1.0.0-r2.ebuild
+++ b/dev-util/edb-debugger/edb-debugger-1.0.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -15,7 +15,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="graphviz"
 
 RDEPEND="
-	dev-libs/capstone
+	dev-libs/capstone:=
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5

--- a/dev-util/edb-debugger/edb-debugger-9999.ebuild
+++ b/dev-util/edb-debugger/edb-debugger-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -15,7 +15,7 @@ KEYWORDS=""
 IUSE="graphviz"
 
 RDEPEND="
-	dev-libs/capstone
+	dev-libs/capstone:=
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/673466
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Petros Siligkounas <petross404@gmail.com>