### PR TITLE
sci-libs/oce: Fix failing tests

### DIFF
--- a/sci-libs/oce/files/oce-0.18.3-test-fix.patch
+++ b/sci-libs/oce/files/oce-0.18.3-test-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/test/OCAFExport_test/CMakeLists.txt b/test/OCAFExport_test/CMakeLists.txt
+index f81798a3a4..8d9f6ad86c 100644
+--- a/test/OCAFExport_test/CMakeLists.txt
++++ b/test/OCAFExport_test/CMakeLists.txt
+@@ -5,6 +5,6 @@ if (OCE_OCAF AND NOT OCE_DISABLE_X11)
+ 	file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../src/StdResource" BuildPluginDir)
+ 	# Semi-colon is a delimiter in SET_TESTS_PROPERTIES and have to be escaped
+ 	string(REPLACE ";" "\\;" BuildPluginDir "${BuildPluginDir}")
+-	set_tests_properties(OCAFExportTestSuite.testExportAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir}")
+-	set_tests_properties(OCAFExportTestSuite.testExportNonAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir}")
++	set_tests_properties(OCAFExportTestSuite.testExportAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir};LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${LIBRARY_OUTPUT_PATH}")
++	set_tests_properties(OCAFExportTestSuite.testExportNonAscii PROPERTIES ENVIRONMENT "CSF_PluginDefaults=${BuildPluginDir};CSF_StandardDefaults=${BuildPluginDir};LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${LIBRARY_OUTPUT_PATH}")
+ endif ()

--- a/sci-libs/oce/oce-0.18.3-r1.ebuild
+++ b/sci-libs/oce/oce-0.18.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -36,6 +36,8 @@ RDEPEND="${DEPEND}"
 
 CHECKREQS_MEMORY="256M"
 CHECKREQS_DISK_BUILD="3584M"
+
+PATCHES=( "${FILESDIR}"/"${P}-test-fix.patch" )
 
 pkg_setup() {
 	check-reqs_pkg_setup


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/665596
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
Package-Manager: Portage-2.3.52, Repoman-2.3.12