### PR TITLE
app-emulation/wine-any-9999 requires changes in PROCALES.

### DIFF
--- a/app-emulation/wine-any/wine-any-9999.ebuild
+++ b/app-emulation/wine-any/wine-any-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PLOCALES="ar bg ca cs da de el en en_US eo es fa fi fr he hi hr hu it ja ko lt ml nb_NO nl or pa pl pt_BR pt_PT rm ro ru sk sl sr_RS@cyrillic sr_RS@latin sv te th tr uk wa zh_CN zh_TW"
+PLOCALES="ar bg ca cs da de el en en_US eo es fa fi fr he hi hr hu it ja ko lt ml nb_NO nl or pa pl pt_BR pt_PT rm ro ru si sk sl sr_RS@cyrillic sr_RS@latin sv te th tr uk wa zh_CN zh_TW"
 PLOCALE_BACKUP="en"
 
 inherit autotools eapi7-ver estack eutils flag-o-matic gnome2-utils l10n multilib multilib-minimal pax-utils toolchain-funcs virtualx xdg-utils


### PR DESCRIPTION
ebuild requested these changes:

```
 * Messages for package app-emulation/wine-any-9999:

 * There are changes in locales! This ebuild should be updated to:
 * PLOCALES="ar bg ca cs da de el en en_US eo es fa fi fr he hi hr hu it ja ko lt ml nb_NO nl or pa pl pt_BR pt_PT rm ro ru si sk sl sr_RS@cyrillic sr_RS@latin sv te th tr uk wa zh_CN zh_TW"
```

https://paste.pound-python.org/show/2mjNy8CIgXw3eMCZ8eZH/

The error message is not present with changed PROCALES. Possible affects other wine versions. 

Linked bug: https://bugs.gentoo.org/673906

Signed-off-by: Jacob Hrbek <werifgx@gmail.com>

`The contribution was provided directly to me by some other person who certified 1., 2., 3., or 4., and I have not modified it.` - This contribution is made by myself and based on terminal output.

EDIT: added requested changes from larry