### PR TITLE
sci-mathematics/minisat: don't sed header files

### DIFF
--- a/sci-mathematics/minisat/minisat-2.2.0_p20130925-r1.ebuild
+++ b/sci-mathematics/minisat/minisat-2.2.0_p20130925-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -32,12 +32,6 @@ src_prepare() {
 
 	sed -i -e "s:\$(exec_prefix)/lib:\$(exec_prefix)/$(get_libdir):" \
 		Makefile || die
-
-	# Fix headers ( #include "minisat/..." -> #include <...> )
-	while IFS="" read -d $'\0' -r file; do
-		einfo Correcting header "$file"
-		sed -i -e 's:#include "minisat/\([^"]*\)":#include <\1>:g' "${file}" || die
-	done < <(find minisat -name "*.h" -print0)
 }
 
 src_configure() {


### PR DESCRIPTION
The `minisat/` part of `#include <minisat/...>` should not be removed as minisat installs header files to `/usr/include/minisat/...`.

cc. @g-braeunlich, author of the original ebuild in https://github.com/gentoo/gentoo/pull/2282.