### PR TITLE
dev-util/rr-5.2.0: Fix error type ::ucontext_t not correctly defined

### DIFF
--- a/dev-util/rr/files/rr-5.2.0-ucontext_t.patch
+++ b/dev-util/rr/files/rr-5.2.0-ucontext_t.patch
@@ -1,0 +1,65 @@
+From 53c5bd72bae089616a3ca626b8af240481d70e6f Mon Sep 17 00:00:00 2001
+From: Robert O'Callahan <robert@ocallahan.org>
+Date: Fri, 10 Aug 2018 15:17:55 +1200
+Subject: [PATCH] Remove ucontext_t/rt_sigframe from kernel-abi
+
+These were added in 18bb097736a1b728f1e5bfec972ca10f6e763d82 to help us determine
+the sigmask effect of rt_sigreturn syscalls, but they're no longer needed
+because we query the new mask via /proc instead.
+
+Resolves #2237
+---
+ src/kernel_abi.h | 33 ---------------------------------
+ 1 file changed, 33 deletions(-)
+
+diff --git a/src/kernel_abi.h b/src/kernel_abi.h
+index e73e49933..29d3c9242 100644
+--- a/src/kernel_abi.h
++++ b/src/kernel_abi.h
+@@ -1609,23 +1609,6 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
+   };
+   RR_VERIFY_TYPE_ARCH(SupportedArch::x86, ::sigcontext, sigcontext);
+ 
+-  struct ucontext_t {
+-    uint32_t uc_flags;
+-    uint32_t uc_link;
+-    stack_t uc_stack;
+-    sigcontext uc_mcontext;
+-    kernel_sigset_t uc_sigmask;
+-  };
+-
+-  struct rt_sigframe {
+-    uint32_t pretcode;
+-    int sig;
+-    uint32_t pinfo;
+-    uint32_t puc;
+-    siginfo_t info;
+-    struct ucontext_t uc;
+-  };
+-
+   struct _fpstate_32 {
+     uint32_t cw, sw, tag, ipoff, cssel, dataoff, datasel;
+     uint16_t _st[40];
+@@ -1806,22 +1789,6 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
+   RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, ::user_fpregs_struct,
+                       user_fpregs_struct);
+ 
+-  struct ucontext_t {
+-    uint64_t ucflags;
+-    ptr<struct ucontext_t> uc_link;
+-    stack_t uc_stack;
+-    struct sigcontext uc_mcontext;
+-    sigset_t uc_sigmask;
+-    user_fpregs_struct uc_fpregs;
+-  };
+-  RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, ::ucontext_t, ucontext_t);
+-
+-  struct rt_sigframe {
+-    ptr<char> pretcode;
+-    struct ucontext_t uc;
+-    siginfo_t info;
+-  };
+-
+   struct user {
+     struct user_regs_struct regs;
+     int u_fpvalid;

--- a/dev-util/rr/rr-5.2.0.ebuild
+++ b/dev-util/rr/rr-5.2.0.ebuild
@@ -31,9 +31,9 @@ DEPEND+="
 		sys-devel/gdb[xml]
 	)"
 
-#PATCHES=(
-#	"${FILESDIR}"/${P}-sysmacros.patch
-#)
+PATCHES=(
+	"${FILESDIR}"/${P}-ucontext_t.patch
+)
 
 pkg_setup() {
 	if use kernel_linux; then


### PR DESCRIPTION
Introduce rr commit:
https://github.com/mozilla/rr/commit/53c5bd72bae089616a3ca626b8af240481d70e6f

Closes: https://bugs.gentoo.org/669788

Signed-off-by: Han Han <hanhanzhiyeqianke@gmail.com>