### PR TITLE
sys-kernel/ck-sources: heal regression @ metadata.xml

### DIFF
--- a/sys-kernel/ck-sources/metadata.xml
+++ b/sys-kernel/ck-sources/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>kuzetsa@poindexter.ovh</email>
-    <name>Sarah White</name>
+    <name>kuza IRL (kuzetsa)</name>
   </maintainer>
   <maintainer type="person">
     <email>gokturk@gentoo.org</email>


### PR DESCRIPTION
re-introduce maintainer's affirmed name (kuzetsa)

regression was introduced in commit:
c625a728ae57e5901ab40baebce6a818a674690c

Bug: https://bugs.gentoo.org/606562
Package-Manager: Portage-2.3.51, Repoman-2.3.11
Signed-off-by: kuza IRL <kuzetsa@poindexter.ovh>