### PR TITLE
sci-astronomy/stellarium: Fix tests

### DIFF
--- a/sci-astronomy/stellarium/files/stellarium-0.18.2-fix-test.patch
+++ b/sci-astronomy/stellarium/files/stellarium-0.18.2-fix-test.patch
@@ -1,0 +1,113 @@
+From d20954d0a9a7890865a2d4b09a01d62f2ed0d8e9 Mon Sep 17 00:00:00 2001
+From: Alexey Sokolov <sokolov@google.com>
+Date: Sun, 6 Jan 2019 13:20:59 +0000
+Subject: [PATCH 1/2] Fix test, when building out of source.
+
+https://bugs.gentoo.org/674472 has details.
+---
+ src/CMakeLists.txt          | 2 ++
+ src/core/StelFileMgr.cpp    | 9 +++++----
+ src/tests/testEphemeris.cpp | 5 -----
+ 3 files changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 6a46d006b2..10db29593b 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -646,5 +646,7 @@ IF(ENABLE_TESTING)
+     ADD_DEPENDENCIES(buildTests testEphemeris)
+     ADD_TEST(testEphemeris testEphemeris)
+     SET_TARGET_PROPERTIES(testEphemeris PROPERTIES FOLDER "src/tests")
++    SET_TESTS_PROPERTIES(testEphemeris PROPERTIES
++        ENVIRONMENT "STELLARIUM_DATA_ROOT=${PROJECT_SOURCE_DIR}")
+ 
+ ENDIF (ENABLE_TESTING)
+diff --git a/src/core/StelFileMgr.cpp b/src/core/StelFileMgr.cpp
+index c88fd72b86..95126152f2 100644
+--- a/src/core/StelFileMgr.cpp
++++ b/src/core/StelFileMgr.cpp
+@@ -26,6 +26,7 @@
+ #include <QString>
+ #include <QDebug>
+ #include <QStandardPaths>
++#include <QProcessEnvironment>
+ 
+ #include <stdio.h>
+ 
+@@ -78,11 +79,11 @@ void StelFileMgr::init()
+ 
+ 	
+ 	// Determine install data directory location
+-
+-	// If we are running from the build tree, we use the files from the current directory
+-	if (QFileInfo(CHECK_FILE).exists())
++	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
++	QString envRoot = env.value("STELLARIUM_DATA_ROOT", ".");
++	if (QFileInfo(envRoot + QDir::separator() + QString(CHECK_FILE)).exists())
+ 	{
+-		installDir = ".";
++		installDir = envRoot;
+ 	}
+ 	else
+ 	{
+diff --git a/src/tests/testEphemeris.cpp b/src/tests/testEphemeris.cpp
+index 26b4d83b98..ba5ac2a315 100644
+--- a/src/tests/testEphemeris.cpp
++++ b/src/tests/testEphemeris.cpp
+@@ -42,12 +42,7 @@ QTEST_GUILESS_MAIN(TestEphemeris)
+ 
+ void TestEphemeris::initTestCase()
+ {
+-	#ifndef Q_OS_WIN
+-	// FIXME: StelFileMgr::init(); is disabled on Windows due it will caused problem "could not find install location"
+-	//        on Windows machines without installed Stellarium (e.g. AppVeyor). So, it will be give "false positive
+-	//        test pass" at the moment for DE42x ephemeris.
+ 	StelFileMgr::init();
+-	#endif
+ 
+ 	de430FilePath = StelFileMgr::findFile("ephem/" + QString(DE430_FILENAME), StelFileMgr::File);
+ 	de431FilePath = StelFileMgr::findFile("ephem/" + QString(DE431_FILENAME), StelFileMgr::File);	
+
+From 2620a64db14e5feb5db8cb085dacef592556ded1 Mon Sep 17 00:00:00 2001
+From: Alexey Sokolov <sokolov@google.com>
+Date: Sun, 6 Jan 2019 15:56:52 +0000
+Subject: [PATCH 2/2] Fix testExtinction on i686
+
+https://bugs.gentoo.org/674472
+---
+ src/tests/testExtinction.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tests/testExtinction.cpp b/src/tests/testExtinction.cpp
+index bfb6ff8479..6a4c22212c 100644
+--- a/src/tests/testExtinction.cpp
++++ b/src/tests/testExtinction.cpp
+@@ -41,5 +41,5 @@ void TestExtinction::testBase()
+ 	mag=2.0f;
+ 	extCls.setExtinctionCoefficient(0.25);
+ 	extCls.forward(vert, &mag);
+-	QVERIFY(mag==2.25);
++	QVERIFY(fabs(mag-2.25)<0.0001);
+ }
+From 3ffebb1ce599e2f0062472ee05060a5de5838101 Mon Sep 17 00:00:00 2001
+From: Alexey Sokolov <sokolov@google.com>
+Date: Sun, 6 Jan 2019 18:00:41 +0000
+Subject: [PATCH 2/2] Try fix #587 differently
+
+---
+ src/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 10db29593b..18cae6be4d 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -546,6 +546,8 @@ IF(ENABLE_TESTING)
+     ADD_DEPENDENCIES(buildTests testStelFileMgr)
+     ADD_TEST(testStelFileMgr testStelFileMgr)
+     SET_TARGET_PROPERTIES(testStelFileMgr PROPERTIES FOLDER "src/tests")
++    SET_TESTS_PROPERTIES(testStelFileMgr PROPERTIES
++        ENVIRONMENT "STELLARIUM_DATA_ROOT=.")
+ 
+     SET(tests_testStelSphereGeometry_SRCS
+         tests/testStelSphereGeometry.hpp

--- a/sci-astronomy/stellarium/stellarium-0.18.2.ebuild
+++ b/sci-astronomy/stellarium/stellarium-0.18.2.ebuild
@@ -43,7 +43,10 @@ DEPEND="${RDEPEND}
 	test? ( dev-qt/qttest:5 )
 "
 
-PATCHES=( "${FILESDIR}"/${P}-as-needed.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-as-needed.patch
+	"${FILESDIR}"/${P}-fix-test.patch
+)
 
 src_prepare() {
 	cmake-utils_src_prepare


### PR DESCRIPTION
The patch is merged upstream at
https://github.com/Stellarium/stellarium/pull/586

Closes: https://bugs.gentoo.org/674472
Signed-off-by: Alexey Sokolov <sokolov@google.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11