### PR TITLE
sys-libs/timezone-data: Removed old URL from homepage metadata

### DIFF
--- a/sys-libs/timezone-data/timezone-data-2018i.ebuild
+++ b/sys-libs/timezone-data/timezone-data-2018i.ebuild
@@ -8,7 +8,7 @@ inherit toolchain-funcs flag-o-matic
 code_ver=${PV}
 data_ver=${PV}
 DESCRIPTION="Timezone data (/usr/share/zoneinfo) and utilities (tzselect/zic/zdump)"
-HOMEPAGE="https://www.iana.org/time-zones http://www.twinsun.com/tz/tz-link.htm"
+HOMEPAGE="https://www.iana.org/time-zones"
 SRC_URI="https://www.iana.org/time-zones/repository/releases/tzdata${data_ver}.tar.gz
 	https://www.iana.org/time-zones/repository/releases/tzcode${code_ver}.tar.gz"
 


### PR DESCRIPTION
The ebuild contains a reference to http://www.twinsun.com/tz/tz-link.htm,
which now leads to a 404.
This just removes the URL from the HOMEPAGE variable in the ebuild,
as it is the only place in the ebuild where this URL or domain exist.
Closes: https://bugs.gentoo.org/674738
Signed-off-by: Timothy Mason masonts@gmail.com
Package-Manager: Portage-2.3.51, Repoman-2.3.11