### PR TITLE
app-misc/datovka: Adjusted (sub-)slot dependency on dev-libs/openssl

### DIFF
--- a/app-misc/datovka/datovka-4.10.3.ebuild
+++ b/app-misc/datovka/datovka-4.10.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,7 +18,7 @@ IUSE=""
 QT_PV="5.3.2:5"
 
 RDEPEND="
-	>=dev-libs/openssl-1.0.2
+	>=dev-libs/openssl-1.0.2:0=
 	>=dev-qt/qtcore-${QT_PV}
 	>=dev-qt/qtgui-${QT_PV}
 	>=dev-qt/qtnetwork-${QT_PV}

--- a/app-misc/datovka/datovka-4.11.0.ebuild
+++ b/app-misc/datovka/datovka-4.11.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,7 +18,7 @@ IUSE=""
 QT_PV="5.3.2:5"
 
 RDEPEND="
-	>=dev-libs/openssl-1.0.2
+	>=dev-libs/openssl-1.0.2:0=
 	>=dev-qt/qtcore-${QT_PV}
 	>=dev-qt/qtgui-${QT_PV}
 	>=dev-qt/qtnetwork-${QT_PV}

--- a/app-misc/datovka/datovka-4.11.1.ebuild
+++ b/app-misc/datovka/datovka-4.11.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,7 +18,7 @@ IUSE=""
 QT_PV="5.3.2:5"
 
 RDEPEND="
-	>=dev-libs/openssl-1.0.2
+	>=dev-libs/openssl-1.0.2:0=
 	>=dev-qt/qtcore-${QT_PV}
 	>=dev-qt/qtgui-${QT_PV}
 	>=dev-qt/qtnetwork-${QT_PV}


### PR DESCRIPTION
This fixes the dependency on dev-libs/openssl to only take slot 0 into account (which all source-based packages should use) and also trigger rebuilds of the package when openssl sub-slot changes.