### PR TITLE
sys-apps/groff: fix cross-compile sed

### DIFF
--- a/sys-apps/groff/files/groff-1.22.4-cross-compile.patch
+++ b/sys-apps/groff/files/groff-1.22.4-cross-compile.patch
@@ -1,0 +1,13 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -4228,8 +4228,8 @@ prefixexecbin_SCRIPTS = chem neqn nroff
+ 
+ # Path to binaries and flags used by contribs and doc to generated doc.
+ # These may be overridden if cross-compiling.
+-GROFFBIN = $(abs_top_builddir)/groff
+-GROFF_BIN_PATH = $(abs_top_builddir)
++GROFFBIN = ${EPREFIX}/usr/bin/groff
++GROFF_BIN_PATH =
+ PDFMOMBIN = $(abs_top_builddir)/pdfmom
+ # The second directories are needed for the case "cd build; ../configure".
+ FFLAG = -F$(abs_top_builddir)/font -F$(abs_top_srcdir)/font

--- a/sys-apps/groff/groff-1.22.4-r1.ebuild
+++ b/sys-apps/groff/groff-1.22.4-r1.ebuild
@@ -1,0 +1,95 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit toolchain-funcs
+
+MY_P="${P/_/.}"
+
+DESCRIPTION="Text formatter used for man pages"
+HOMEPAGE="https://www.gnu.org/software/groff/groff.html"
+SRC_URI="mirror://gnu/groff/${MY_P}.tar.gz
+	mirror://gnu-alpha/groff/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+[[ "${PV}" == *_rc* ]] || \
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="examples X"
+
+RDEPEND="
+	X? (
+		x11-libs/libX11
+		x11-libs/libXt
+		x11-libs/libXmu
+		x11-libs/libXaw
+		x11-libs/libSM
+		x11-libs/libICE
+	)"
+DEPEND="${RDEPEND}
+	dev-lang/perl"
+
+DOCS=( BUG-REPORT ChangeLog MORE.STUFF NEWS PROBLEMS PROJECTS README TODO )
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.19.2-man-unicode-dashes.patch #16108 #17580 #121502
+)
+
+src_prepare() {
+	default
+
+	# honor Gentoo's docdir
+	sed -i -e '/^docdir=/s/^/#/' \
+		Makefile.am \
+		|| die "failed to modify Makefile.am"
+
+	# Make sure we can cross-compile this puppy
+	if tc-is-cross-compiler ; then
+		eapply "${FILESDIR}"/${PN}-1.22.4-cross-compile.patch
+	fi
+
+	local pfx=$(usex prefix ' Prefix' '')
+	cat <<-EOF >> tmac/mdoc.local
+	.ds volume-operating-system Gentoo${pfx}
+	.ds operating-system Gentoo${pfx}/${KERNEL}
+	.ds default-operating-system Gentoo${pfx}/${KERNEL}
+	EOF
+
+	# make sure we don't get a crappy `g' nameprefix on UNIX systems with real
+	# troff (GROFF_G macro runs some test to see, its own troff doesn't satisfy)
+	sed -i -e 's/^[ \t]\+g=g$/g=/' configure || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		--with-appresdir="${EPREFIX%/}"/usr/share/X11/app-defaults
+		--docdir="${EPREFIX%/}"/usr/share/doc/${PF}
+		$(use_with X x)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
+src_install() {
+	default
+
+	# The following links are required for man #123674
+	dosym eqn /usr/bin/geqn
+	dosym tbl /usr/bin/gtbl
+
+	if ! use examples ; then
+		# The pdf files might not be generated if ghostscript is unavailable. #602020
+		local pdf="${ED%/}/usr/share/doc/${PF}/examples/mom/mom-pdf.pdf"
+		if [[ -e ${pdf} ]] ; then
+			# Keep mom-pdf.pdf since it's more of a manual than an example. #454196 #516732
+			mv "${pdf}" "${ED%/}"/usr/share/doc/${PF}/pdf/ || die
+		fi
+		rm -rf "${ED%/}"/usr/share/doc/${PF}/examples
+	fi
+}


### PR DESCRIPTION
Files impacted by the cross-compile sed no longer exist so
cross-emerging this package failes. Removing the sed calls allow the
executables to build, but as later portions of the build execute the
built groff executables, so I cooked up a small patch which is eapply'd
conditionally on cross-compiles

Package-Manager: Portage-2.3.54, Repoman-2.3.12
Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>