### PR TITLE
dev-python/m2crypto: add LibreSSL support

### DIFF
--- a/dev-python/m2crypto/files/m2crypto-libressl-0.31.0.patch
+++ b/dev-python/m2crypto/files/m2crypto-libressl-0.31.0.patch
@@ -1,0 +1,222 @@
+From fa56170c7adf5f124a48cf1074390adfc697272c Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <stefan.strogin@gmail.com>
+Date: Wed, 9 Jan 2019 10:15:08 +0200
+Subject: [PATCH] Fix compilation with LibreSSL
+
+---
+ SWIG/_bio.i           |  8 +++++---
+ SWIG/_evp.i           |  2 +-
+ SWIG/_lib.i           |  2 +-
+ SWIG/_lib11_compat.i  |  5 ++++-
+ SWIG/_m2crypto_wrap.c | 11 ++++++++---
+ SWIG/_ssl.i           |  4 ++--
+ SWIG/_threads.i       | 10 +++++-----
+ 7 files changed, 26 insertions(+), 16 deletions(-)
+
+diff --git a/SWIG/_bio.i b/SWIG/_bio.i
+index e85a275..8eada82 100644
+--- a/SWIG/_bio.i
++++ b/SWIG/_bio.i
+@@ -293,7 +293,7 @@ int bio_should_write(BIO* a) {
+ }
+ 
+ /* Macros for things not defined before 1.1.0 */
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ static BIO_METHOD *
+ BIO_meth_new( int type, const char *name )
+ {
+@@ -325,11 +325,13 @@ BIO_meth_free( BIO_METHOD *meth )
+ #define BIO_set_shutdown(b, x) (b)->shutdown = x
+ #define BIO_get_shutdown(b) (b)->shutdown
+ #define BIO_set_init(b, x)    b->init = x
+-#define BIO_get_init(b) (b)->init
+ #define BIO_set_data(b, x)    b->ptr = x
+ #define BIO_clear_flags(b, x)    b->flags &= ~(x)
+ #define BIO_get_data(b)    b->ptr
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#define BIO_get_init(b) (b)->init
++#endif
+ 
+ /* implment custom BIO_s_pyfd */
+ 
+@@ -515,7 +517,7 @@ static long pyfd_ctrl(BIO *b, int cmd, long num, void *ptr) {
+ }
+ 
+ void pyfd_init(void) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
+     methods_fdp = BIO_meth_new(
+         BIO_get_new_index()|BIO_TYPE_DESCRIPTOR|BIO_TYPE_SOURCE_SINK,
+         "python file descriptor");
+diff --git a/SWIG/_evp.i b/SWIG/_evp.i
+index d04e806..6fa9b38 100644
+--- a/SWIG/_evp.i
++++ b/SWIG/_evp.i
+@@ -19,7 +19,7 @@ Copyright (c) 2009-2010 Heikki Toivonen. All rights reserved.
+ #include <openssl/rsa.h>
+ #include <openssl/opensslv.h>
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ 
+ HMAC_CTX *HMAC_CTX_new(void) {
+     HMAC_CTX *ret = PyMem_Malloc(sizeof(HMAC_CTX));
+diff --git a/SWIG/_lib.i b/SWIG/_lib.i
+index c84b800..807d5f6 100644
+--- a/SWIG/_lib.i
++++ b/SWIG/_lib.i
+@@ -512,7 +512,7 @@ int passphrase_callback(char *buf, int num, int v, void *arg) {
+ %inline %{
+ 
+ void lib_init() {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+     SSLeay_add_all_algorithms();
+     ERR_load_ERR_strings();
+ #endif
+diff --git a/SWIG/_lib11_compat.i b/SWIG/_lib11_compat.i
+index 1ec42dd..4234004 100644
+--- a/SWIG/_lib11_compat.i
++++ b/SWIG/_lib11_compat.i
+@@ -8,7 +8,7 @@
+  */
+ 
+ %{
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #include <string.h>
+ #include <openssl/engine.h>
+@@ -24,6 +24,9 @@ static void *CRYPTO_zalloc(size_t num, const char *file, int line)
+       return ret;
+ }
+ 
++#endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
++
+ #include <openssl/bn.h>
+ 
+ #ifndef BN_F_BN_GENCB_NEW
+diff --git a/SWIG/_m2crypto_wrap.c b/SWIG/_m2crypto_wrap.c
+index 0f07702..f168822 100644
+--- a/SWIG/_m2crypto_wrap.c
++++ b/SWIG/_m2crypto_wrap.c
+@@ -3838,7 +3838,7 @@ void threading_cleanup(void) {
+ #include <ceval.h>
+ 
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #include <string.h>
+ #include <openssl/engine.h>
+@@ -3854,6 +3854,9 @@ static void *CRYPTO_zalloc(size_t num, const char *file, int line)
+       return ret;
+ }
+ 
++#endif
++#ifdef OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
++
+ #include <openssl/bn.h>
+ 
+ #ifndef BN_F_BN_GENCB_NEW
+@@ -5315,7 +5318,7 @@ int bio_should_write(BIO* a) {
+ }
+ 
+ /* Macros for things not defined before 1.1.0 */
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ static BIO_METHOD *
+ BIO_meth_new( int type, const char *name )
+ {
+@@ -5347,11 +5350,13 @@ BIO_meth_free( BIO_METHOD *meth )
+ #define BIO_set_shutdown(b, x) (b)->shutdown = x
+ #define BIO_get_shutdown(b) (b)->shutdown
+ #define BIO_set_init(b, x)    b->init = x
+-#define BIO_get_init(b) (b)->init
+ #define BIO_set_data(b, x)    b->ptr = x
+ #define BIO_clear_flags(b, x)    b->flags &= ~(x)
+ #define BIO_get_data(b)    b->ptr
+ #endif
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#define BIO_get_init(b) (b)->init
++#endif
+ 
+ /* implment custom BIO_s_pyfd */
+ 
+diff --git a/SWIG/_ssl.i b/SWIG/_ssl.i
+index 7257656..40b0582 100644
+--- a/SWIG/_ssl.i
++++ b/SWIG/_ssl.i
+@@ -27,7 +27,7 @@ typedef unsigned __int64 uint64_t;
+ #endif
+ %}
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10100005L
++#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100005L) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
+ %include <openssl/safestack.h>
+ #endif
+ 
+@@ -261,7 +261,7 @@ void ssl_init(PyObject *ssl_err, PyObject *ssl_timeout_err) {
+ }
+ 
+ const SSL_METHOD *tlsv1_method(void) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
+     PyErr_WarnEx(PyExc_DeprecationWarning,
+                  "Function TLSv1_method has been deprecated.", 1);
+ #endif
+diff --git a/SWIG/_threads.i b/SWIG/_threads.i
+index 69adb9f..fd2285a 100644
+--- a/SWIG/_threads.i
++++ b/SWIG/_threads.i
+@@ -5,7 +5,7 @@
+ #include <pythread.h>
+ #include <openssl/crypto.h>
+ 
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && (OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL))
+ #define CRYPTO_num_locks()      (CRYPTO_NUM_LOCKS)
+ static PyThread_type_lock lock_cs[CRYPTO_num_locks()];
+ static long lock_count[CRYPTO_num_locks()];
+@@ -13,7 +13,7 @@ static int thread_mode = 0;
+ #endif
+ 
+ void threading_locking_callback(int mode, int type, const char *file, int line) {
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && (OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL))
+         if (mode & CRYPTO_LOCK) {
+                 PyThread_acquire_lock(lock_cs[type], WAIT_LOCK);
+                 lock_count[type]++;
+@@ -25,7 +25,7 @@ void threading_locking_callback(int mode, int type, const char *file, int line)
+ }
+ 
+ unsigned long threading_id_callback(void) {
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && (OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL))
+     return (unsigned long)PyThread_get_thread_ident();
+ #else
+     return (unsigned long)0;
+@@ -35,7 +35,7 @@ unsigned long threading_id_callback(void) {
+ 
+ %inline %{
+ void threading_init(void) {
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && (OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL))
+     int i;
+     if (!thread_mode) {
+         for (i=0; i<CRYPTO_num_locks(); i++) {
+@@ -50,7 +50,7 @@ void threading_init(void) {
+ }
+ 
+ void threading_cleanup(void) {
+-#if defined(THREADING) && OPENSSL_VERSION_NUMBER < 0x10100000L
++#if defined(THREADING) && (OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL))
+     int i;
+     if (thread_mode) {
+         CRYPTO_set_locking_callback(NULL);
+-- 
+2.20.1
+

--- a/dev-python/m2crypto/m2crypto-0.31.0-r1.ebuild
+++ b/dev-python/m2crypto/m2crypto-0.31.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2018 Gentoo Authors
+# Copyright 2018-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,11 +18,11 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
 
-# NOTE: Apparently nobody cares about libressl support, dropping support
-# IUSE="libressl"
+IUSE="libressl"
 
 RDEPEND="
-	dev-libs/openssl:0=[-bindist(-)]
+	!libressl? ( dev-libs/openssl:0=[-bindist(-)] )
+	libressl? ( dev-libs/libressl:0= )
 	virtual/python-typing[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}
@@ -34,6 +34,10 @@ S="${WORKDIR}/${MY_PN}-${PV}"
 
 # Tests access network, and fail randomly. Bug #431458.
 RESTRICT=test
+
+PATCHES=(
+	"${FILESDIR}/${PN}-libressl-${PV}.patch"
+)
 
 python_compile() {
 	# setup.py looks at platform.machine() to determine swig options.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/674942
Package-Manager: Portage-2.3.54, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>