### PR TITLE
app-emulation/xen-tools: disable capstone

### DIFF
--- a/app-emulation/xen-tools/xen-tools-4.11.1.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.11.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -333,6 +333,10 @@ src_prepare() {
 		-e 's:^#lockfile=:lockfile=:' \
 		-e 's:^#vif.default.script=:vif.default.script=:' \
 		-i tools/examples/xl.conf  || die
+
+	# disable capstone (Bug #673474)
+	sed -e "s:\$\$source/configure:\0 --disable-capstone:" \
+		-i tools/Makefile || die
 
 	default
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/673474
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>