### PR TITLE
app-emulation/bochs-2.6.9: Fix undeclared uintptr_t bug

### DIFF
--- a/app-emulation/bochs/bochs-2.6.9.ebuild
+++ b/app-emulation/bochs/bochs-2.6.9.ebuild
@@ -81,3 +81,7 @@ src_configure() {
 		$(use_with X x11) \
 		${myconf}
 }
+
+PATCHES=(
+	"${FILESDIR}"/${P}-slirpinc.patch
+)

--- a/app-emulation/bochs/files/bochs-2.6.9-slirpinc.patch
+++ b/app-emulation/bochs/files/bochs-2.6.9-slirpinc.patch
@@ -1,0 +1,11 @@
+--- bochs-2.6.9/iodev/network/slirp/slirp.h.orig	2014-12-25 18:58:26.557466000 +0100
++++ bochs-2.6.9/iodev/network/slirp/slirp.h	2018-07-03 09:54:56.164439625 +0200
+@@ -33,7 +33,7 @@
+ #endif
+ 
+ #include <sys/types.h>
+-#if defined(__OpenBSD__)
++#if defined(__OpenBSD__) || (__linux__)
+ #include <stdint.h>
+ #include <sys/wait.h>
+ #endif


### PR DESCRIPTION
In slirp.h, bochs forget to include stdint.h for linux. Add it.

From patch:
https://raw.githubusercontent.com/tsjk/portage-patches/master/app-emulation/bochs-2.6.9/slirp_h.patch

Refer to this solution:
https://sourceforge.net/p/bochs/bugs/1392/

Closes: https://bugs.gentoo.org/638476
Closes: https://bugs.gentoo.org/646318

Signed-off-by: Han Han <hanhanzhiyeqianke@gmail.com>