### PR TITLE
dev-libs/mongo-c-driver: disable automagic on dev-libs/icu

### DIFF
--- a/dev-libs/mongo-c-driver/mongo-c-driver-1.13.0-r1.ebuild
+++ b/dev-libs/mongo-c-driver/mongo-c-driver-1.13.0-r1.ebuild
@@ -1,0 +1,91 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils
+
+DESCRIPTION="Client library written in C for MongoDB"
+HOMEPAGE="https://github.com/mongodb/mongo-c-driver"
+SRC_URI="https://github.com/mongodb/mongo-c-driver/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~x86"
+IUSE="debug examples icu libressl sasl ssl static-libs test"
+REQUIRED_USE="test? ( static-libs )"
+
+RDEPEND="app-arch/snappy:=
+	>=dev-libs/libbson-${PV}
+	dev-python/sphinx
+	sys-libs/zlib:=
+	icu? ( dev-libs/icu:= )
+	sasl? ( dev-libs/cyrus-sasl:= )
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)"
+DEPEND="${RDEPEND}
+	test? (
+		dev-db/mongodb
+		dev-libs/libbson[static-libs]
+	)"
+
+# No tests on x86 because tests require dev-db/mongodb which don't support
+# x86 anymore (bug #645994)
+RESTRICT="x86? ( test )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-no-uninstall.patch"
+	"${FILESDIR}/${P}-enable-tests.patch" # enable tests with system libbson
+)
+
+src_prepare() {
+	cmake-utils_src_prepare
+
+	# copy private headers for tests since we don't build libbson
+	if use test; then
+		mkdir -p src/libbson/tests/bson || die
+		for f in bson-fnv-private.h bson-iso8601-private.h bson-private.h bson-thread-private.h; do
+			cp -v src/libbson/src/bson/${f} src/libbson/tests/bson/ || die
+		done
+	fi
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_SKIP_RPATH=ON # mongoc-stat insecure runpath
+		-DENABLE_BSON=SYSTEM
+		-DENABLE_EXAMPLES=OFF
+		-DENABLE_ICU="$(usex icu ON OFF)"
+		-DENABLE_MAN_PAGES=ON
+		-DENABLE_MONGOC=ON
+		-DENABLE_SNAPPY=SYSTEM
+		-DENABLE_ZLIB=SYSTEM
+		-DENABLE_SASL="$(usex sasl CYRUS OFF)"
+		-DENABLE_SSL="$(usex ssl $(usex libressl LIBRESSL OPENSSL) OFF)"
+		-DENABLE_STATIC="$(usex static-libs ON OFF)"
+		-DENABLE_TESTS="$(usex test ON OFF)"
+		-DENABLE_TRACING="$(usex debug ON OFF)"
+	)
+
+	cmake-utils_src_configure
+}
+
+# FEATURES="test" USE="static-libs" emerge dev-libs/mongo-c-driver
+src_test() {
+	local PORT=27099
+	mongod --port ${PORT} --bind_ip 127.0.0.1 --nounixsocket --fork \
+		--dbpath="${T}" --logpath="${T}/mongod.log" || die
+	MONGOC_TEST_URI="mongodb://[127.0.0.1]:${PORT}" ../mongo-c-driver-${PV}_build/src/libmongoc/test-libmongoc || die
+	kill $(<"${T}/mongod.lock")
+}
+
+src_install() {
+	if use examples; then
+		docinto examples
+		dodoc src/libmongoc/examples/*.c
+	fi
+
+	cmake-utils_src_install
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/666592
Package-Manager: Portage-2.3.52, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>

```
--- mongo-c-driver-1.13.0.ebuild        2019-01-07 12:27:59.264995144 +0100
+++ mongo-c-driver-1.13.0-r1.ebuild     2019-01-09 16:27:23.208916000 +0100
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,14 +11,15 @@
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~hppa x86"
-IUSE="debug examples libressl sasl ssl static-libs test"
+KEYWORDS="~amd64 ~hppa ~x86"
+IUSE="debug examples icu libressl sasl ssl static-libs test"
 REQUIRED_USE="test? ( static-libs )"
 
 RDEPEND="app-arch/snappy:=
        >=dev-libs/libbson-${PV}
        dev-python/sphinx
        sys-libs/zlib:=
+       icu? ( dev-libs/icu:= )
        sasl? ( dev-libs/cyrus-sasl:= )
        ssl? (
                !libressl? ( dev-libs/openssl:0= )
@@ -56,6 +57,7 @@
                -DCMAKE_SKIP_RPATH=ON # mongoc-stat insecure runpath
                -DENABLE_BSON=SYSTEM
                -DENABLE_EXAMPLES=OFF
+               -DENABLE_ICU="$(usex icu ON OFF)"
                -DENABLE_MAN_PAGES=ON
                -DENABLE_MONGOC=ON
                -DENABLE_SNAPPY=SYSTEM
```