### PR TITLE
dev-libs/sway: add xkeyboard-config dep; improve elog message

### DIFF
--- a/dev-libs/sway/sway-1.0_beta1.ebuild
+++ b/dev-libs/sway/sway-1.0_beta1.ebuild
@@ -92,5 +92,9 @@ pkg_postinst() {
 		elog ""
 		elog "If you use ConsoleKit2, remember to launch sway using:"
 		elog "exec ck-launch-session ${dbus_cmd}sway"
+		elog ""
+		elog "If your system does not set the XDG_RUNTIME_DIR environment"
+		elog "variable, you must set it manually to run Sway. See wiki"
+		elog "for details: https://wiki.gentoo.org/wiki/Sway"
 	fi
 }

--- a/dev-libs/sway/sway-1.0_beta1.ebuild
+++ b/dev-libs/sway/sway-1.0_beta1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -34,6 +34,7 @@ RDEPEND="~dev-libs/wlroots-0.1[systemd=,elogind=,X=]
 	x11-libs/libxkbcommon
 	x11-libs/pango
 	x11-libs/pixman
+	x11-misc/xkeyboard-config
 	elogind? ( >=sys-auth/elogind-237 )
 	swaybar? ( x11-libs/gdk-pixbuf:2[jpeg] )
 	swaybg? ( x11-libs/gdk-pixbuf:2[jpeg] )

--- a/dev-libs/sway/sway-1.0_beta2.ebuild
+++ b/dev-libs/sway/sway-1.0_beta2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -34,6 +34,7 @@ RDEPEND="~dev-libs/wlroots-0.2[systemd=,elogind=,X=]
 	x11-libs/libxkbcommon
 	x11-libs/pango
 	x11-libs/pixman
+	x11-misc/xkeyboard-config
 	elogind? ( >=sys-auth/elogind-237 )
 	swaybar? ( x11-libs/gdk-pixbuf:2[jpeg] )
 	swaybg? ( x11-libs/gdk-pixbuf:2[jpeg] )

--- a/dev-libs/sway/sway-1.0_beta2.ebuild
+++ b/dev-libs/sway/sway-1.0_beta2.ebuild
@@ -93,6 +93,10 @@ pkg_postinst() {
 		elog ""
 		elog "If you use ConsoleKit2, remember to launch sway using:"
 		elog "exec ck-launch-session ${dbus_cmd}sway"
+		elog ""
+		elog "If your system does not set the XDG_RUNTIME_DIR environment"
+		elog "variable, you must set it manually to run Sway. See wiki"
+		elog "for details: https://wiki.gentoo.org/wiki/Sway"
 	fi
 	if use swaylock && ! use pam; then
 		fcaps cap_sys_admin usr/bin/swaylock

--- a/dev-libs/sway/sway-9999.ebuild
+++ b/dev-libs/sway/sway-9999.ebuild
@@ -92,6 +92,10 @@ pkg_postinst() {
 		elog ""
 		elog "If you use ConsoleKit2, remember to launch sway using:"
 		elog "exec ck-launch-session ${dbus_cmd}sway"
+		elog ""
+		elog "If your system does not set the XDG_RUNTIME_DIR environment"
+		elog "variable, you must set it manually to run Sway. See wiki"
+		elog "for details: https://wiki.gentoo.org/wiki/Sway"
 	fi
 	if use swaylock && ! use pam; then
 		fcaps cap_sys_admin usr/bin/swaylock

--- a/dev-libs/sway/sway-9999.ebuild
+++ b/dev-libs/sway/sway-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -34,6 +34,7 @@ RDEPEND="~dev-libs/wlroots-9999[systemd=,elogind=,X=]
 	x11-libs/libxkbcommon
 	x11-libs/pango
 	x11-libs/pixman
+	x11-misc/xkeyboard-config
 	elogind? ( >=sys-auth/elogind-237 )
 	swaybar? ( x11-libs/gdk-pixbuf:2[jpeg] )
 	swaybg? ( x11-libs/gdk-pixbuf:2[jpeg] )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/674640
Signed-off-by: Niccolò Scatena <speedjack95@gmail.com>
Package-Manager: Portage-2.3.55, Repoman-2.3.12