### PR TITLE
media-video/ffmpeg: add USE=vidstab

### DIFF
--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -81,7 +81,7 @@ FFMPEG_FLAG_MAP=(
 		# libavfilter options
 		appkit
 		bs2b:libbs2b chromaprint flite:libflite frei0r
-		fribidi:libfribidi fontconfig ladspa libass lv2 truetype:libfreetype
+		fribidi:libfribidi fontconfig ladspa libass lv2 truetype:libfreetype vidstab:libvidstab
 		rubberband:librubberband zeromq:libzmq zimg:libzimg
 		# libswresample options
 		libsoxr
@@ -236,6 +236,7 @@ RDEPEND="
 	vaapi? ( >=x11-libs/libva-1.2.1-r1[${MULTILIB_USEDEP}] )
 	video_cards_nvidia? ( >=media-libs/nv-codec-headers-8.1.24.2[${MULTILIB_USEDEP}] )
 	vdpau? ( >=x11-libs/libvdpau-0.7[${MULTILIB_USEDEP}] )
+	vidstab? ( >=media-libs/vidstab-1.1.0[${MULTILIB_USEDEP}] )
 	vorbis? (
 		>=media-libs/libvorbis-1.3.3-r1[${MULTILIB_USEDEP}]
 		>=media-libs/libogg-1.3.0[${MULTILIB_USEDEP}]

--- a/media-video/ffmpeg/metadata.xml
+++ b/media-video/ffmpeg/metadata.xml
@@ -54,6 +54,7 @@
 	<flag name="srt">Enable support for Secure Reliable Transport (SRT) via <pkg>net-libs/srt</pkg></flag>
 	<flag name="ssh">Enable SSH/sftp support via <pkg>net-libs/libssh</pkg>.</flag>
 	<flag name="twolame">Enables MP2 encoding via <pkg>media-sound/twolame</pkg> as an alternative to the internal encoder.</flag>
+	<flag name="vidstab">Enables video stabilization filter using vid.stab library (<pkg>media-libs/vidstab</pkg>).</flag>
 	<flag name="vpx">Enables vp8 codec support using libvpx: Decoding vp8 does not require this to be enabled but libvpx can also be used for decoding; encoding vp8 requires this useflag to be enabled though.</flag>
 	<flag name="x265">Enables HEVC encoding with <pkg>media-libs/x265</pkg>.</flag>
 	<flag name="zeromq">Enables <pkg>net-libs/zeromq</pkg> support with the zmq/azmq filters.</flag>


### PR DESCRIPTION
Changed the PR to be against ffmpeg-9999 as requested by @aballier
Added useflag in metadata.xml
Changed the USEflag to vidstab to match others (e.g. truetype).
Ignored the sorting order of USEflags (to minimize diff).

The automated build should now pass, since PR #10797 was merged
(original PR #8250). Second attempt after PR #8251 went stale.

Hopefully @candrews can move this quick as well :-D

Closes: https://bugs.gentoo.org/517890
Closes: https://bugs.gentoo.org/675176

Signed-off-by: Kalin KOZHUHAROV <kalin@thinrope.net>
Signed-off-by: Kalin KOZHUHAROV <me.kalin@gmail.com>