### PR TITLE
profiles: force 'unwind' on with dev-libs/efl on ppc & ppc64

### DIFF
--- a/profiles/arch/powerpc/package.use.force
+++ b/profiles/arch/powerpc/package.use.force
@@ -1,5 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Joonas Niilola <juippis@gmail.com> (12 Jan 2019)
+# Force 'unwind' on for ppc and ppc64 with dev-libs/efl
+# #668486, #657750
+dev-libs/efl unwind
 
 # Sergei Trofimovich <slyfox@gentoo.org> (25 Dec 2018)
 # Enable powerpc target by default.


### PR DESCRIPTION
I believe this file handles both ppc and ppc64?

Bug: https://bugs.gentoo.org/668486
Bug: https://bugs.gentoo.org/657750