### PR TITLE
app-text/texlive-core: Fix build with poppler-0.71, poppler-0.72 and poppler-0.73

### DIFF
--- a/app-text/texlive-core/files/texlive-core-2017-poppler069.patch
+++ b/app-text/texlive-core/files/texlive-core-2017-poppler069.patch
@@ -1,0 +1,216 @@
+From 29f2412e10523158f5e601f32482d3d233a934fc Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date: Sat, 12 Jan 2019 21:42:09 +0100
+Subject: [PATCH 1/2] Fix build with poppler-0.69.0
+
+---
+ texk/web2c/luatexdir/image/epdf.h          |  1 +
+ texk/web2c/luatexdir/image/pdftoepdf.w     | 14 +++++++-------
+ texk/web2c/luatexdir/lua/lepdflib.cc       | 18 +++++++++---------
+ texk/web2c/luatexdir/lua/lpdfscannerlib.cc |  1 +
+ texk/web2c/pdftexdir/pdftoepdf.cc          |  7 ++++---
+ texk/web2c/pdftexdir/pdftosrc.cc           |  5 +++--
+ 6 files changed, 25 insertions(+), 21 deletions(-)
+
+diff --git a/texk/web2c/luatexdir/image/epdf.h b/texk/web2c/luatexdir/image/epdf.h
+index 57bb2e39..ebc83bdb 100644
+--- a/texk/web2c/luatexdir/image/epdf.h
++++ b/texk/web2c/luatexdir/image/epdf.h
+@@ -39,6 +39,7 @@ extern "C" {
+ #  include <goo/GooString.h>
+ #  include <goo/gmem.h>
+ #  include <goo/gfile.h>
++#  include <goo/gdir.h>
+ #  include <Object.h>
+ #  include <Stream.h>
+ #  include <Gfx.h>
+diff --git a/texk/web2c/luatexdir/image/pdftoepdf.w b/texk/web2c/luatexdir/image/pdftoepdf.w
+index 3aebf009..0a23b201 100644
+--- a/texk/web2c/luatexdir/image/pdftoepdf.w
++++ b/texk/web2c/luatexdir/image/pdftoepdf.w
+@@ -31,7 +31,7 @@
+ 
+ extern void md5(Guchar *msg, int msgLen, Guchar *digest);
+ 
+-static GBool isInit = gFalse;
++static bool isInit = false;
+ 
+ /* Maintain AVL tree of all PDF files for embedding */
+ 
+@@ -468,7 +468,7 @@ static void copyObject(PDF pdf, PdfDocument * pdf_doc, Object * obj)
+         break;
+     /*
+     case objNum:
+-        GBool isNum() { return type == objInt || type == objReal; }
++        bool isNum() { return type == objInt || type == objReal; }
+         break;
+     */
+     case objString:
+@@ -587,11 +587,11 @@ void read_pdf_info(image_dict * idict)
+     PDFRectangle *pagebox;
+     int pdf_major_version_found, pdf_minor_version_found;
+     float xsize, ysize, xorig, yorig;
+-    if (isInit == gFalse) {
++    if (isInit == false) {
+         if (!(globalParams))
+             globalParams = new GlobalParams();
+-        globalParams->setErrQuiet(gFalse);
+-        isInit = gTrue;
++        globalParams->setErrQuiet(false);
++        isInit = true;
+     }
+     if (img_type(idict) == IMG_TYPE_PDF)
+         pdf_doc = refPdfDocument(img_filepath(idict), FE_FAIL);
+@@ -960,7 +960,7 @@ void epdf_free()
+     if (PdfDocumentTree != NULL)
+         avl_destroy(PdfDocumentTree, destroyPdfDocument);
+     PdfDocumentTree = NULL;
+-    if (isInit == gTrue)
++    if (isInit == true)
+         delete globalParams;
+-    isInit = gFalse;
++    isInit = false;
+ }
+diff --git a/texk/web2c/luatexdir/lua/lepdflib.cc b/texk/web2c/luatexdir/lua/lepdflib.cc
+index 14558510..d47ec941 100644
+--- a/texk/web2c/luatexdir/lua/lepdflib.cc
++++ b/texk/web2c/luatexdir/lua/lepdflib.cc
+@@ -1374,9 +1374,9 @@ static int m_Object_initBool(lua_State * L)
+         pdfdoc_changed_error(L);
+     luaL_checktype(L, 2, LUA_TBOOLEAN);
+     if (lua_toboolean(L, 2) != 0)
+-        *((Object *) uin->d) = Object(gTrue);
++        *((Object *) uin->d) = Object(true);
+     else
+-        *((Object *) uin->d) = Object(gFalse);
++        *((Object *) uin->d) = Object(false);
+     return 0;
+ }
+ 
+@@ -2881,12 +2881,12 @@ m_poppler_get_BOOL(Attribute, isHidden);
+ 
+ static int m_Attribute_setHidden(lua_State * L)
+ {
+-    GBool i;
++    bool i;
+     udstruct *uin;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_Attribute);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+         pdfdoc_changed_error(L);
+-    i = (GBool) lua_toboolean(L, 2);
++    i = (bool) lua_toboolean(L, 2);
+     ((Attribute *) uin->d)->setHidden(i);
+     return 0;
+ }
+@@ -3023,7 +3023,7 @@ static int m_StructElement_getParentRef(lua_State * L)
+ // Ref is false if the C++ functione return false
+ static int m_StructElement_getPageRef(lua_State * L)
+ {
+-    GBool b;
++    bool b;
+     Ref *r;
+     udstruct *uin, *uout;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_StructElement);
+@@ -3069,13 +3069,13 @@ static int m_StructElement_setRevision(lua_State * L)
+ 
+ static int m_StructElement_getText(lua_State * L)
+ {
+-    GBool i;
++    bool i;
+     GooString *gs;
+     udstruct *uin;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_StructElement);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+         pdfdoc_changed_error(L);
+-    i = (GBool) lua_toboolean(L, 2);
++    i = (bool) lua_toboolean(L, 2);
+     gs =  ((StructElement *) uin->d)->getText(i);
+     if (gs != NULL)
+         lua_pushlstring(L, gs->getCString(), gs->getLength());
+@@ -3164,7 +3164,7 @@ static int m_StructElement_findAttribute(lua_State * L)
+ {
+     Attribute::Type t;
+     Attribute::Owner o;
+-    GBool g;
++    bool g;
+     udstruct *uin, *uout;
+     const Attribute *a;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_StructElement);
+@@ -3172,7 +3172,7 @@ static int m_StructElement_findAttribute(lua_State * L)
+         pdfdoc_changed_error(L);
+     t = (Attribute::Type) luaL_checkint(L,1);
+     o = (Attribute::Owner) luaL_checkint(L,2);
+-    g = (GBool) lua_toboolean(L, 3);
++    g = (bool) lua_toboolean(L, 3);
+     a = ((StructElement *) uin->d)->findAttribute(t,g,o);
+ 
+     if (a!=NULL){
+diff --git a/texk/web2c/luatexdir/lua/lpdfscannerlib.cc b/texk/web2c/luatexdir/lua/lpdfscannerlib.cc
+index eb881b63..a2d39b83 100644
+--- a/texk/web2c/luatexdir/lua/lpdfscannerlib.cc
++++ b/texk/web2c/luatexdir/lua/lpdfscannerlib.cc
+@@ -34,6 +34,7 @@ extern "C" {
+ #  include <goo/GooString.h>
+ #  include <goo/gmem.h>
+ #  include <goo/gfile.h>
++#  include <goo/gdir.h>
+ #  include <Object.h>
+ #  include <Stream.h>
+ #  include <Gfx.h>
+diff --git a/texk/web2c/pdftexdir/pdftoepdf.cc b/texk/web2c/pdftexdir/pdftoepdf.cc
+index 0ffc3e19..af12c74e 100644
+--- a/texk/web2c/pdftexdir/pdftoepdf.cc
++++ b/texk/web2c/pdftexdir/pdftoepdf.cc
+@@ -37,6 +37,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include <goo/GooString.h>
+ #include <goo/gmem.h>
+ #include <goo/gfile.h>
++#include <goo/gdir.h>
+ #define GString GooString
+ #else
+ #include <aconf.h>
+@@ -114,7 +115,7 @@ struct UsedEncoding {
+ 
+ static InObj *inObjList;
+ static UsedEncoding *encodingList;
+-static GBool isInit = gFalse;
++static bool isInit = false;
+ 
+ // --------------------------------------------------------------------
+ // Maintain list of open embedded PDF files
+@@ -718,8 +719,8 @@ read_pdf_info(char *image_name, char *page_name, int page_num,
+     // initialize
+     if (!isInit) {
+         globalParams = new GlobalParams();
+-        globalParams->setErrQuiet(gFalse);
+-        isInit = gTrue;
++        globalParams->setErrQuiet(false);
++        isInit = true;
+     }
+     // open PDF file
+     pdf_doc = find_add_document(image_name);
+diff --git a/texk/web2c/pdftexdir/pdftosrc.cc b/texk/web2c/pdftexdir/pdftosrc.cc
+index ead9f209..22ab6bdc 100644
+--- a/texk/web2c/pdftexdir/pdftosrc.cc
++++ b/texk/web2c/pdftexdir/pdftosrc.cc
+@@ -31,6 +31,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include <goo/GooString.h>
+ #include <goo/gmem.h>
+ #include <goo/gfile.h>
++#include <goo/gdir.h>
+ #else
+ #include <aconf.h>
+ #include <GString.h>
+@@ -167,8 +168,8 @@ int main(int argc, char *argv[])
+ 
+                 // parse the header: object numbers and offsets
+                 objStr.streamReset();
+-                str = new EmbedStream(objStr.getStream(), Object(objNull), gTrue, first);
+-                parser = new Parser(xref, new Lexer(xref, str), gFalse);
++                str = new EmbedStream(objStr.getStream(), Object(objNull), true, first);
++                parser = new Parser(xref, new Lexer(xref, str), false);
+                 for (n = 0; n < nObjects; ++n) {
+                     obj1 = parser->getObj();
+                     obj2 = parser->getObj();
+-- 
+2.20.1

--- a/app-text/texlive-core/files/texlive-core-2017-poppler071.patch
+++ b/app-text/texlive-core/files/texlive-core-2017-poppler071.patch
@@ -1,0 +1,281 @@
+From 2f77decfd2340c9a241dc508ae984a93dfef2643 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date: Sat, 12 Jan 2019 21:43:29 +0100
+Subject: [PATCH 2/2] Fix build with poppler-0.71.0
+
+Thanks-to: maurerpe <junk4me46806@yahoo.com>
+---
+ texk/web2c/luatexdir/image/pdftoepdf.w | 10 +++++-----
+ texk/web2c/luatexdir/lua/lepdflib.cc   | 18 +++++++++---------
+ texk/web2c/pdftexdir/pdftex-common.h   |  2 +-
+ texk/web2c/pdftexdir/pdftoepdf.cc      | 20 ++++++++++----------
+ texk/web2c/pdftexdir/writeenc.c        |  2 +-
+ texk/web2c/xetexdir/pdfimage.cpp       |  2 +-
+ 6 files changed, 27 insertions(+), 27 deletions(-)
+
+diff --git a/texk/web2c/luatexdir/image/pdftoepdf.w b/texk/web2c/luatexdir/image/pdftoepdf.w
+index 0a23b201..aa1d7f25 100644
+--- a/texk/web2c/luatexdir/image/pdftoepdf.w
++++ b/texk/web2c/luatexdir/image/pdftoepdf.w
+@@ -363,7 +363,7 @@ void copyReal(PDF pdf, double d)
+ 
+ static void copyString(PDF pdf, GooString * string)
+ {
+-    char *p;
++    const char *p;
+     unsigned char c;
+     size_t i, l;
+     p = string->getCString();
+@@ -393,7 +393,7 @@ static void copyString(PDF pdf, GooString * string)
+     pdf->cave = true;
+ }
+ 
+-static void copyName(PDF pdf, char *s)
++static void copyName(PDF pdf, const char *s)
+ {
+     pdf_out(pdf, '/');
+     for (; *s != 0; s++) {
+@@ -527,7 +527,7 @@ static void writeRefs(PDF pdf, PdfDocument * pdf_doc)
+ 
+ /* get the pagebox coordinates according to the pagebox_spec */
+ 
+-static PDFRectangle *get_pagebox(Page * page, int pagebox_spec)
++static const PDFRectangle *get_pagebox(Page * page, int pagebox_spec)
+ {
+     switch (pagebox_spec) {
+         case PDF_BOX_SPEC_MEDIA:
+@@ -584,7 +584,7 @@ void read_pdf_info(image_dict * idict)
+     Catalog *catalog;
+     Page *page;
+     int rotate;
+-    PDFRectangle *pagebox;
++    const PDFRectangle *pagebox;
+     int pdf_major_version_found, pdf_minor_version_found;
+     float xsize, ysize, xorig, yorig;
+     if (isInit == false) {
+@@ -721,7 +721,7 @@ void write_epdf(PDF pdf, image_dict * idict, int suppress_optional_info)
+     Ref *pageref;
+     Dict *pageDict;
+     Object obj1, contents, pageobj, pagesobj1, pagesobj2, *op1, *op2, *optmp;
+-    PDFRectangle *pagebox;
++    const PDFRectangle *pagebox;
+     int i, l;
+     double bbox[4];
+     /* char s[256]; */
+diff --git a/texk/web2c/luatexdir/lua/lepdflib.cc b/texk/web2c/luatexdir/lua/lepdflib.cc
+index d47ec941..01f9415c 100644
+--- a/texk/web2c/luatexdir/lua/lepdflib.cc
++++ b/texk/web2c/luatexdir/lua/lepdflib.cc
+@@ -238,7 +238,7 @@ static int l_new_Attribute(lua_State * L)
+        if (uobj->pd != NULL && uobj->pd->pc != uobj->pc)
+           pdfdoc_changed_error(L);
+        uout = new_Attribute_userdata(L);
+-       uout->d = new Attribute(n, nlen, (Object *)uobj->d);
++       uout->d = new Attribute(GooString(n, nlen), (Object *)uobj->d);
+        uout->atype = ALLOC_LEPDF;
+        uout->pc = uobj->pc;
+        uout->pd = uobj->pd;
+@@ -443,7 +443,7 @@ static int m_##in##_##function(lua_State * L)                  \
+     uin = (udstruct *) luaL_checkudata(L, 1, M_##in);          \
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)             \
+         pdfdoc_changed_error(L);                               \
+-    o = ((in *) uin->d)->function();                           \
++    o = (out *) ((in *) uin->d)->function();		       \
+     if (o != NULL) {                                           \
+         uout = new_##out##_userdata(L);                        \
+         uout->d = o;                                           \
+@@ -972,12 +972,12 @@ m_poppler_get_INT(Dict, getLength);
+ 
+ static int m_Dict_add(lua_State * L)
+ {
+-    char *s;
++    const char *s;
+     udstruct *uin, *uobj;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_Dict);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+         pdfdoc_changed_error(L);
+-    s = copyString(luaL_checkstring(L, 2));
++    s = luaL_checkstring(L, 2);
+     uobj = (udstruct *) luaL_checkudata(L, 3, M_Object);
+     ((Dict *) uin->d)->add(s, std::move(*((Object *) uobj->d)));
+     return 0;
+@@ -1894,7 +1894,7 @@ static int m_Object_dictAdd(lua_State * L)
+         pdfdoc_changed_error(L);
+     if (!((Object *) uin->d)->isDict())
+         luaL_error(L, "Object is not a Dict");
+-    ((Object *) uin->d)->dictAdd(copyString(s), std::move(*((Object *) uobj->d)));
++    ((Object *) uin->d)->dictAdd(s, std::move(*((Object *) uobj->d)));
+     return 0;
+ }
+ 
+@@ -2308,7 +2308,7 @@ m_PDFDoc_INT(getErrorCode);
+ 
+ static int m_PDFDoc_getFileName(lua_State * L)
+ {
+-    GooString *gs;
++    const GooString *gs;
+     udstruct *uin;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_PDFDoc);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+@@ -2396,7 +2396,7 @@ m_PDFDoc_INT(getNumPages);
+ 
+ static int m_PDFDoc_readMetadata(lua_State * L)
+ {
+-    GooString *gs;
++    const GooString *gs;
+     udstruct *uin;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_PDFDoc);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+@@ -2414,7 +2414,7 @@ static int m_PDFDoc_readMetadata(lua_State * L)
+ 
+ static int m_PDFDoc_getStructTreeRoot(lua_State * L)
+ {
+-    StructTreeRoot *obj;
++    const StructTreeRoot *obj;
+     udstruct *uin, *uout;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_PDFDoc);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+@@ -2422,7 +2422,7 @@ static int m_PDFDoc_getStructTreeRoot(lua_State * L)
+     if (((PdfDocument *) uin->d)->doc->getCatalog()->isOk()) {
+         obj = ((PdfDocument *) uin->d)->doc->getStructTreeRoot();
+         uout = new_StructTreeRoot_userdata(L);
+-        uout->d = obj;
++        uout->d = (StructTreeRoot *) obj;
+         uout->pc = uin->pc;
+         uout->pd = uin->pd;
+     } else
+diff --git a/texk/web2c/pdftexdir/pdftex-common.h b/texk/web2c/pdftexdir/pdftex-common.h
+index 307ba64a..09741707 100644
+--- a/texk/web2c/pdftexdir/pdftex-common.h
++++ b/texk/web2c/pdftexdir/pdftex-common.h
+@@ -101,7 +101,7 @@ extern void tex_printf(const char *, ...);
+ extern void write_epdf(void);
+ 
+ /* writeenc.c */
+-extern void epdf_write_enc(char **, int);
++extern void epdf_write_enc(const char **, int);
+ 
+ /* writeimg.c */
+ extern float epdf_width;
+diff --git a/texk/web2c/pdftexdir/pdftoepdf.cc b/texk/web2c/pdftexdir/pdftoepdf.cc
+index af12c74e..e353b652 100644
+--- a/texk/web2c/pdftexdir/pdftoepdf.cc
++++ b/texk/web2c/pdftexdir/pdftoepdf.cc
+@@ -270,7 +270,7 @@ static int getNewObjectNumber(Ref ref)
+ 
+ static void copyObject(Object *);
+ 
+-static void copyName(char *s)
++static void copyName(const char *s)
+ {
+     pdf_puts("/");
+     for (; *s != 0; s++) {
+@@ -305,7 +305,7 @@ static void copyDict(Object * obj)
+ static void copyFontDict(Object * obj, InObj * r)
+ {
+     int i, l;
+-    char *key;
++    const char *key;
+     if (!obj->isDict())
+         pdftex_fail("PDF inclusion: invalid dict type <%s>",
+                     obj->getTypeName());
+@@ -377,7 +377,7 @@ static bool embeddableFont(Object * fontdesc)
+     return false;
+ }
+ 
+-static void copyFont(char *tag, Object * fontRef)
++static void copyFont(const char *tag, Object * fontRef)
+ {
+     Object fontdict, subtype, basefont, fontdescRef, fontdesc, charset,
+         stemV;
+@@ -462,7 +462,7 @@ static void copyFontResources(Object * obj)
+     pdf_puts(">>\n");
+ }
+ 
+-static void copyOtherResources(Object * obj, char *key)
++static void copyOtherResources(Object * obj, const char *key)
+ {
+     // copies all other resources (write_epdf handles Fonts and ProcSets),
+ 
+@@ -549,7 +549,7 @@ static void copyObject(Object * obj)
+     Object obj1;
+     int i, l, c;
+     Ref ref;
+-    char *p;
++    const char *p;
+     GString *s;
+     if (obj->isBool()) {
+         pdf_printf("%s", obj->getBool()? "true" : "false");
+@@ -650,7 +650,7 @@ static void writeRefs()
+ static void writeEncodings()
+ {
+     UsedEncoding *r, *n;
+-    char *glyphNames[256], *s;
++    const char *glyphNames[256], *s;
+     int i;
+     for (r = encodingList; r != 0; r = r->next) {
+         for (i = 0; i < 256; i++) {
+@@ -678,7 +678,7 @@ static void writeEncodings()
+ }
+ 
+ // get the pagebox according to the pagebox_spec
+-static PDFRectangle *get_pagebox(Page * page, int pagebox_spec)
++static const PDFRectangle *get_pagebox(Page * page, int pagebox_spec)
+ {
+     if (pagebox_spec == pdfboxspecmedia)
+         return page->getMediaBox();
+@@ -710,7 +710,7 @@ read_pdf_info(char *image_name, char *page_name, int page_num,
+ {
+     PdfDocument *pdf_doc;
+     Page *page;
+-    PDFRectangle *pagebox;
++    const PDFRectangle *pagebox;
+ #ifdef POPPLER_VERSION
+     int pdf_major_version_found, pdf_minor_version_found;
+ #else
+@@ -829,7 +829,7 @@ void write_epdf(void)
+     Object groupDict;
+     bool writeSepGroup = false;
+     Object info;
+-    char *key;
++    const char *key;
+     char s[256];
+     int i, l;
+     int rotate;
+@@ -856,7 +856,7 @@ void write_epdf(void)
+     pageObj = xref->fetch(pageRef->num, pageRef->gen);
+     pageDict = pageObj.getDict();
+     rotate = page->getRotate();
+-    PDFRectangle *pagebox;
++    const PDFRectangle *pagebox;
+     // write the Page header
+     pdf_puts("/Type /XObject\n");
+     pdf_puts("/Subtype /Form\n");
+diff --git a/texk/web2c/pdftexdir/writeenc.c b/texk/web2c/pdftexdir/writeenc.c
+index bd55103f..08f44633 100644
+--- a/texk/web2c/pdftexdir/writeenc.c
++++ b/texk/web2c/pdftexdir/writeenc.c
+@@ -83,7 +83,7 @@ fe_entry *get_fe_entry(char *s)
+ 
+ /**********************************************************************/
+ 
+-void epdf_write_enc(char **glyph_names, int fe_objnum)
++void epdf_write_enc(const char **glyph_names, int fe_objnum)
+ {
+     int i, i_old;
+     assert(glyph_names != NULL);
+diff --git a/texk/web2c/xetexdir/pdfimage.cpp b/texk/web2c/xetexdir/pdfimage.cpp
+index 85389136..ce46cae1 100644
+--- a/texk/web2c/xetexdir/pdfimage.cpp
++++ b/texk/web2c/xetexdir/pdfimage.cpp
+@@ -78,7 +78,7 @@ pdf_get_rect(char* filename, int page_num, int pdf_box, realrect* box)
+ 
+ 	Page*		page = doc->getCatalog()->getPage(page_num);
+ 
+-	PDFRectangle*	r;
++	const PDFRectangle*	r;
+ 	switch (pdf_box) {
+ 		default:
+ 		case pdfbox_crop:
+-- 
+2.20.1

--- a/app-text/texlive-core/files/texlive-core-2017-poppler072.patch
+++ b/app-text/texlive-core/files/texlive-core-2017-poppler072.patch
@@ -1,0 +1,157 @@
+From 19462cf1b5628d7251cde91031a0635e636d890a Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
+Date: Sat, 12 Jan 2019 21:59:07 +0100
+Subject: [PATCH] Fix build with poppler-0.72
+
+---
+ texk/web2c/luatexdir/image/pdftoepdf.w |  2 +-
+ texk/web2c/luatexdir/lua/lepdflib.cc   | 16 ++++++++--------
+ texk/web2c/pdftexdir/pdftoepdf.cc      |  4 ++--
+ texk/web2c/pdftexdir/pdftosrc.cc       |  6 +++---
+ 4 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/texk/web2c/luatexdir/image/pdftoepdf.w b/texk/web2c/luatexdir/image/pdftoepdf.w
+index aa1d7f25..2f143068 100644
+--- a/texk/web2c/luatexdir/image/pdftoepdf.w
++++ b/texk/web2c/luatexdir/image/pdftoepdf.w
+@@ -366,7 +366,7 @@ static void copyString(PDF pdf, GooString * string)
+     const char *p;
+     unsigned char c;
+     size_t i, l;
+-    p = string->getCString();
++    p = string->c_str();
+     l = (size_t) string->getLength();
+     if (pdf->cave)
+         pdf_out(pdf, ' ');
+diff --git a/texk/web2c/luatexdir/lua/lepdflib.cc b/texk/web2c/luatexdir/lua/lepdflib.cc
+index 01f9415c..6b24a39b 100644
+--- a/texk/web2c/luatexdir/lua/lepdflib.cc
++++ b/texk/web2c/luatexdir/lua/lepdflib.cc
+@@ -523,7 +523,7 @@ static int m_##in##_##function(lua_State * L)                  \
+         pdfdoc_changed_error(L);                               \
+     gs = (GooString *)((in *) uin->d)->function();             \
+     if (gs != NULL)                                            \
+-        lua_pushlstring(L, gs->getCString(), gs->getLength()); \
++        lua_pushlstring(L, gs->c_str(), gs->getLength()); \
+     else                                                       \
+         lua_pushnil(L);                                        \
+     return 1;                                                  \
+@@ -758,7 +758,7 @@ static int m_Array_getString(lua_State * L)
+     if (i > 0 && i <= len) {
+         gs = new GooString();
+         if (((Array *) uin->d)->getString(i - 1, gs))
+-            lua_pushlstring(L, gs->getCString(), gs->getLength());
++            lua_pushlstring(L, gs->c_str(), gs->getLength());
+         else
+             lua_pushnil(L);
+         delete gs;
+@@ -910,7 +910,7 @@ static int m_Catalog_getJS(lua_State * L)
+     if (i > 0 && i <= len) {
+         gs = ((Catalog *) uin->d)->getJS(i - 1);
+         if (gs != NULL)
+-            lua_pushlstring(L, gs->getCString(), gs->getLength());
++            lua_pushlstring(L, gs->c_str(), gs->getLength());
+         else
+             lua_pushnil(L);
+         delete gs;
+@@ -1225,7 +1225,7 @@ static int m_GooString__tostring(lua_State * L)
+     uin = (udstruct *) luaL_checkudata(L, 1, M_GooString);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+         pdfdoc_changed_error(L);
+-    lua_pushlstring(L, ((GooString *) uin->d)->getCString(),
++    lua_pushlstring(L, ((GooString *) uin->d)->c_str(),
+                     ((GooString *) uin->d)->getLength());
+     return 1;
+ }
+@@ -1657,7 +1657,7 @@ static int m_Object_getString(lua_State * L)
+         pdfdoc_changed_error(L);
+     if (((Object *) uin->d)->isString()) {
+         gs = (GooString *)((Object *) uin->d)->getString();
+-        lua_pushlstring(L, gs->getCString(), gs->getLength());
++        lua_pushlstring(L, gs->c_str(), gs->getLength());
+     } else
+         lua_pushnil(L);
+     return 1;
+@@ -2315,7 +2315,7 @@ static int m_PDFDoc_getFileName(lua_State * L)
+         pdfdoc_changed_error(L);
+     gs = ((PdfDocument *) uin->d)->doc->getFileName();
+     if (gs != NULL)
+-        lua_pushlstring(L, gs->getCString(), gs->getLength());
++        lua_pushlstring(L, gs->c_str(), gs->getLength());
+     else
+         lua_pushnil(L);
+     return 1;
+@@ -2404,7 +2404,7 @@ static int m_PDFDoc_readMetadata(lua_State * L)
+     if (((PdfDocument *) uin->d)->doc->getCatalog()->isOk()) {
+         gs = ((PdfDocument *) uin->d)->doc->readMetadata();
+         if (gs != NULL)
+-            lua_pushlstring(L, gs->getCString(), gs->getLength());
++            lua_pushlstring(L, gs->c_str(), gs->getLength());
+         else
+             lua_pushnil(L);
+     } else
+@@ -3078,7 +3078,7 @@ static int m_StructElement_getText(lua_State * L)
+     i = (bool) lua_toboolean(L, 2);
+     gs =  ((StructElement *) uin->d)->getText(i);
+     if (gs != NULL)
+-        lua_pushlstring(L, gs->getCString(), gs->getLength());
++        lua_pushlstring(L, gs->c_str(), gs->getLength());
+     else
+         lua_pushnil(L);
+     return 1;
+diff --git a/texk/web2c/pdftexdir/pdftoepdf.cc b/texk/web2c/pdftexdir/pdftoepdf.cc
+index e353b652..84e9f7ce 100644
+--- a/texk/web2c/pdftexdir/pdftoepdf.cc
++++ b/texk/web2c/pdftexdir/pdftoepdf.cc
+@@ -422,7 +422,7 @@ static void copyFont(const char *tag, Object * fontRef)
+         charset = fontdesc.dictLookup("CharSet");
+         if (!charset.isNull() &&
+             charset.isString() && is_subsetable(fontmap))
+-            epdf_mark_glyphs(fd, (char *)charset.getString()->getCString());
++            epdf_mark_glyphs(fd, (char *)charset.getString()->c_str());
+         else
+             embed_whole_font(fd);
+         addFontDesc(fontdescRef.getRef(), fd);
+@@ -561,7 +561,7 @@ static void copyObject(Object * obj)
+         pdf_printf("%s", convertNumToPDF(obj->getNum()));
+     } else if (obj->isString()) {
+         s = (GooString *)obj->getString();
+-        p = s->getCString();
++        p = s->c_str();
+         l = s->getLength();
+         if (strlen(p) == (unsigned int) l) {
+             pdf_puts("(");
+diff --git a/texk/web2c/pdftexdir/pdftosrc.cc b/texk/web2c/pdftexdir/pdftosrc.cc
+index 22ab6bdc..bad1b78f 100644
+--- a/texk/web2c/pdftexdir/pdftosrc.cc
++++ b/texk/web2c/pdftexdir/pdftosrc.cc
+@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
+             fprintf(stderr, "No SourceName found\n");
+             exit(1);
+         }
+-        outname = (char *)srcName.getString()->getCString();
++        outname = (char *)srcName.getString()->c_str();
+         // We cannot free srcName, as objname shares its string.
+         // srcName.free();
+     } else if (objnum > 0) {
+@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
+             fprintf(stderr, "Not a Stream object\n");
+             exit(1);
+         }
+-        sprintf(buf, "%s", fileName->getCString());
++        sprintf(buf, "%s", fileName->c_str());
+         if ((p = strrchr(buf, '.')) == 0)
+             p = strchr(buf, 0);
+         if (objgen == 0)
+@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
+         outname = buf;
+     } else {                    // objnum < 0 means we are extracting the XRef table
+         extract_xref_table = true;
+-        sprintf(buf, "%s", fileName->getCString());
++        sprintf(buf, "%s", fileName->c_str());
+         if ((p = strrchr(buf, '.')) == 0)
+             p = strchr(buf, 0);
+         sprintf(p, ".xref");
+-- 
+2.20.1
+

--- a/app-text/texlive-core/files/texlive-core-2017-poppler073.patch
+++ b/app-text/texlive-core/files/texlive-core-2017-poppler073.patch
@@ -1,0 +1,74 @@
+From b3df00dcf7332ae9b64f019278af8708c1ced284 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Wed, 16 Jan 2019 21:10:09 +0100
+Subject: [PATCH] Fix build with poppler-0.73
+
+---
+ texk/web2c/luatexdir/image/pdftoepdf.w | 2 +-
+ texk/web2c/luatexdir/lua/lepdflib.cc   | 8 ++++----
+ texk/web2c/pdftexdir/pdftosrc.cc       | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/texk/web2c/luatexdir/image/pdftoepdf.w b/texk/web2c/luatexdir/image/pdftoepdf.w
+index 2f143068..10ed9879 100644
+--- a/texk/web2c/luatexdir/image/pdftoepdf.w
++++ b/texk/web2c/luatexdir/image/pdftoepdf.w
+@@ -29,7 +29,7 @@
+     the functions of poppler, which happens to be written in C++.
+ */
+ 
+-extern void md5(Guchar *msg, int msgLen, Guchar *digest);
++extern void md5(unsigned char *msg, int msgLen, unsigned char *digest);
+ 
+ static bool isInit = false;
+ 
+diff --git a/texk/web2c/luatexdir/lua/lepdflib.cc b/texk/web2c/luatexdir/lua/lepdflib.cc
+index 6b24a39b..87078fc5 100644
+--- a/texk/web2c/luatexdir/lua/lepdflib.cc
++++ b/texk/web2c/luatexdir/lua/lepdflib.cc
+@@ -2867,12 +2867,12 @@ m_poppler_get_GUINT(Attribute,getRevision);
+ 
+ static int m_Attribute_setRevision(lua_State * L)
+ {
+-    Guint i;
++    unsigned int i;
+     udstruct *uin;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_Attribute);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+         pdfdoc_changed_error(L);
+-    i = (Guint) luaL_checkint(L, 2);
++    i = (unsigned int) luaL_checkint(L, 2);
+     ((Attribute *) uin->d)->setRevision(i);
+     return 0;
+ }
+@@ -3057,12 +3057,12 @@ static int m_StructElement_getTypeName(lua_State * L)
+ 
+ static int m_StructElement_setRevision(lua_State * L)
+ {
+-    Guint i;
++    unsigned int i;
+     udstruct *uin;
+     uin = (udstruct *) luaL_checkudata(L, 1, M_StructElement);
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+         pdfdoc_changed_error(L);
+-    i = (Guint) luaL_checkint(L, 2);
++    i = (unsigned int) luaL_checkint(L, 2);
+     ((StructElement *) uin->d)->setRevision(i);
+     return 0;
+ }
+diff --git a/texk/web2c/pdftexdir/pdftosrc.cc b/texk/web2c/pdftexdir/pdftosrc.cc
+index bad1b78f..295c4e66 100644
+--- a/texk/web2c/pdftexdir/pdftosrc.cc
++++ b/texk/web2c/pdftexdir/pdftosrc.cc
+@@ -156,7 +156,7 @@ int main(int argc, char *argv[])
+                 Object objStr, obj1, obj2;
+                 int nObjects, first, n;
+                 int localOffset = 0;
+-                Guint firstOffset;
++                unsigned int firstOffset;
+ 
+                 objStr = xref->fetch(e->offset, 0);
+                 assert(objStr.isStream());
+-- 
+2.20.1
+

--- a/app-text/texlive-core/texlive-core-2017-r4.ebuild
+++ b/app-text/texlive-core/texlive-core-2017-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -165,6 +165,10 @@ src_prepare() {
 
 	# bug ?
 	epatch "${FILESDIR}/${P}-poppler064.patch"
+
+	if has_version ">=app-text/poppler-0.69.0"; then
+		epatch "${FILESDIR}"/${P}-poppler0{69,71,72}.patch # bug #672854
+	fi
 
 	sed -i \
 		-e "s,/usr/include /usr/local/include.*echo \$KPATHSEA_INCLUDES.*,${EPREFIX}/usr/include\"," \

--- a/app-text/texlive-core/texlive-core-2017-r4.ebuild
+++ b/app-text/texlive-core/texlive-core-2017-r4.ebuild
@@ -167,7 +167,7 @@ src_prepare() {
 	epatch "${FILESDIR}/${P}-poppler064.patch"
 
 	if has_version ">=app-text/poppler-0.69.0"; then
-		epatch "${FILESDIR}"/${P}-poppler0{69,71,72}.patch # bug #672854
+		epatch "${FILESDIR}"/${P}-poppler0{69,71,72,73}.patch # bugs #672854, 675448
 	fi
 
 	sed -i \

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -197,7 +197,8 @@ dev-go/sarama
 # Andreas Sturmlechner <asturm@gentoo.org> (03 Nov 2018)
 # Breaks revdeps (GDir and GDirEntry split from gfile.h into new gdir.h)
 # See tracker: https://bugs.gentoo.org/670222
->=app-text/poppler-0.71.0
+=app-text/poppler-0.71.0
+=app-text/poppler-0.72.0
 
 # Pacho Ramos <pacho@gentoo.org> (01 Nov 2018)
 # All this packages are broken and need major version bumps to fix them. See


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/672854

Not pretty, but at least we're getting there while maybe 2018 is being prepared - and hopefully we can drop most patches then.