### PR TITLE
games-util/xboxdrv: fix wireless pad udev match

### DIFF
--- a/games-util/xboxdrv/files/xboxdrv.udev-rules
+++ b/games-util/xboxdrv/files/xboxdrv.udev-rules
@@ -1,5 +1,5 @@
 SUBSYSTEM=="usb", ACTION=="add",\
-	ENV{ID_MODEL_FROM_DATABASE}=="Xbox*Controller|Xbox*Controller S",\
+	ENV{ID_MODEL_FROM_DATABASE}=="Xbox*Controller|Xbox*Controller S|Xbox 360 Wireless Adapter",\
 	TAG+="systemd",\
 	ENV{SYSTEMD_ALIAS}="/sys/subsystem/usb/xbox/controller$number",\
 	ENV{SYSTEMD_WANTS}+="xboxdrv.service"


### PR DESCRIPTION
Add "Xbox 360 Wireless Adapter" to the ID_MODEL_FROM_DATABASE match
patterns so that the wireless Xbox 360 controller adapter is detected.