### PR TITLE
media-libs/glew: add mesa compatibility

### DIFF
--- a/media-libs/glew/files/glew-2.1.0-mesa-compat.patch
+++ b/media-libs/glew/files/glew-2.1.0-mesa-compat.patch
@@ -1,0 +1,21 @@
+diff --git a/include/GL/glew.h b/include/GL/glew.h
+index b5b6987..a9f9e4b 100644
+--- a/include/GL/glew.h
++++ b/include/GL/glew.h
+@@ -93,7 +93,7 @@
+ #if defined(__REGAL_H__)
+ #error Regal.h included before glew.h
+ #endif
+-#if defined(__glext_h_) || defined(__GLEXT_H_)
++#if defined(__glext_h_) || defined(__GLEXT_H_) || defined(__gl_glext_h_)
+ #error glext.h included before glew.h
+ #endif
+ #if defined(__gl_ATI_h_)
+@@ -109,6 +109,7 @@
+ #define __X_GL_H
+ #define __glext_h_
+ #define __GLEXT_H_
++#define __gl_glext_h_
+ #define __gl_ATI_h_
+ 
+ #if defined(_WIN32)

--- a/media-libs/glew/glew-2.1.0-r1.ebuild
+++ b/media-libs/glew/glew-2.1.0-r1.ebuild
@@ -1,0 +1,104 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal toolchain-funcs
+
+DESCRIPTION="The OpenGL Extension Wrangler Library"
+HOMEPAGE="http://glew.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tgz"
+
+LICENSE="BSD MIT"
+SLOT="0/$(ver_cut 1-2)"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc static-libs"
+
+DEPEND="
+	>=virtual/glu-9.0-r1[${MULTILIB_USEDEP}]
+	>=virtual/opengl-7.0-r1[${MULTILIB_USEDEP}]
+	>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+	>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]
+	>=x11-libs/libXi-1.7.2[${MULTILIB_USEDEP}]
+	>=x11-libs/libXmu-1.1.1-r1[${MULTILIB_USEDEP}]
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	local PATCHES=(
+		"${FILESDIR}"/${PN}-2.0.0-install-headers.patch
+		"${FILESDIR}"/${P}-mesa-compat.patch
+	)
+
+	sed -i \
+		-e '/INSTALL/s:-s::' \
+		-e '/$(CC) $(CFLAGS) -o/s:$(CFLAGS):$(CFLAGS) $(LDFLAGS):' \
+		-e '/^.PHONY: .*\.pc$/d' \
+		Makefile || die
+
+	if ! use static-libs ; then
+		sed -i \
+			-e '/glew.lib:/s|lib/$(LIB.STATIC) ||' \
+			-e '/glew.lib.mx:/s|lib/$(LIB.STATIC.MX) ||' \
+			-e '/INSTALL.*LIB.STATIC/d' \
+			Makefile || die
+	fi
+
+	# don't do stupid Solaris specific stuff that won't work in Prefix
+	cp config/Makefile.linux config/Makefile.solaris || die
+	# and let freebsd be built as on linux too
+	cp config/Makefile.linux config/Makefile.freebsd || die
+
+	default
+	multilib_copy_sources
+}
+
+glew_system() {
+	# Set the SYSTEM variable instead of probing. #523444 #595280
+	case ${CHOST} in
+	*linux*)          echo "linux" ;;
+	*-freebsd*)       echo "freebsd" ;;
+	*-darwin*)        echo "darwin" ;;
+	*-solaris*)       echo "solaris" ;;
+	mingw*|*-mingw*)  echo "mingw" ;;
+	*) die "Unknown system ${CHOST}" ;;
+	esac
+}
+
+set_opts() {
+	myglewopts=(
+		AR="$(tc-getAR)"
+		STRIP=true
+		CC="$(tc-getCC)"
+		LD="$(tc-getCC) ${LDFLAGS}"
+		SYSTEM="$(glew_system)"
+		M_ARCH=""
+		LDFLAGS.EXTRA=""
+		POPT="${CFLAGS}"
+	)
+}
+
+multilib_src_compile() {
+	set_opts
+	emake \
+		GLEW_PREFIX="${EPREFIX}/usr" \
+		GLEW_DEST="${EPREFIX}/usr" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
+		"${myglewopts[@]}"
+}
+
+multilib_src_install() {
+	set_opts
+	emake \
+		GLEW_DEST="${ED}/usr" \
+		LIBDIR="${ED}/usr/$(get_libdir)" \
+		PKGDIR="${ED}/usr/$(get_libdir)/pkgconfig" \
+		"${myglewopts[@]}" \
+		install.all
+
+	dodoc README.md
+	if use doc; then
+		docinto html
+		dodoc doc/*
+	fi
+}


### PR DESCRIPTION
* update to EAPI 7
* add compatibility for >=mesa-18 in glext.h

Closes: https://bugs.gentoo.org/671486
Closes: https://bugs.gentoo.org/673172
Package-Manager: Portage-2.3.54, Repoman-2.3.12
Signed-off-by: Bernd Waibel <waebbl@gmail.com>

The bugfix has already been merged upstream, see comment #1 at https://bugs.gentoo.org/671486 and https://github.com/nigels-com/glew/pull/198/commits/d6c2c3b9ca52af697088f280c30fe5b27f7a694f
