### PR TITLE
dev-libs/ivykis: fix building with glibc-2.28

### DIFF
--- a/dev-libs/ivykis/files/ivykis-fix-segfault-glibc-2.28.patch
+++ b/dev-libs/ivykis/files/ivykis-fix-segfault-glibc-2.28.patch
@@ -1,0 +1,29 @@
+# https://github.com/buytenh/ivykis/issues/15
+# https://github.com/buytenh/ivykis/pull/16
+
+diff --git a/configure.ac b/configure.ac
+index e9b10c0..56440d1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -88,6 +88,8 @@ esac
+ # link in libpthread_nonshared.a if it is available.
+ #
+ AC_CHECK_LIB([pthread_nonshared], [pthread_atfork])
++# the lib is gone in glibc 2.28, things are now in c_nonshared
++AC_CHECK_LIB([c_nonshared], [pthread_atfork])
+ 
+ # Checks for header files.
+ AC_CHECK_HEADERS([process.h])
+diff --git a/src/pthr.h b/src/pthr.h
+index a41eaf3..32c1af2 100644
+--- a/src/pthr.h
++++ b/src/pthr.h
+@@ -42,7 +42,7 @@ static inline int pthreads_available(void)
+  * symbol because that causes it to be undefined even if you link
+  * libpthread_nonshared.a in explicitly.
+  */
+-#ifndef HAVE_LIBPTHREAD_NONSHARED
++#if !defined(HAVE_LIBPTHREAD_NONSHARED) && !defined(HAVE_LIBC_NONSHARED)
+ #pragma weak pthread_atfork
+ #endif
+ 

--- a/dev-libs/ivykis/ivykis-0.42.3-r1.ebuild
+++ b/dev-libs/ivykis/ivykis-0.42.3-r1.ebuild
@@ -12,6 +12,10 @@ SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 ppc ppc64 sparc x86"
 IUSE="static-libs"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-fix-segfault-glibc-2.28.patch" # Bug 675338
+)
+
 src_configure() {
 	econf $(use_enable static-libs static)
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/675338
Package-Manager: Portage-2.3.55, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>