### PR TITLE
net-p2p/bitcoind: Fix dodoc in case USE=examples

### DIFF
--- a/net-p2p/bitcoind/bitcoind-0.17.1.ebuild
+++ b/net-p2p/bitcoind/bitcoind-0.17.1.ebuild
@@ -147,7 +147,7 @@ src_install() {
 
 	if use examples; then
 		docinto examples
-		dodoc -r contrib/{linearize,qos,tidy_datadir.sh}
+		dodoc -r contrib/{linearize,qos}
 		use zeromq && dodoc -r contrib/zmq
 	fi
 


### PR DESCRIPTION
The referenced file 'contrib/tidy_datadir.sh' is no longer shipped by
upstream.

Closes: https://bugs.gentoo.org/675474
Package-Manager: Portage-2.3.51, Repoman-2.3.11

Signed-off-by: Florian Schmaus <flo@geekplace.eu>