### PR TITLE
app-text/ttf2pk2: use pkg-config instead of freetype-config

### DIFF
--- a/app-text/ttf2pk2/files/ttf2pk2-2.0_p20170524-freetype2-config.patch
+++ b/app-text/ttf2pk2/files/ttf2pk2-2.0_p20170524-freetype2-config.patch
@@ -1,0 +1,23 @@
+--- m4/kpse-freetype2-flags.m4	2018-09-19 10:19:06.437789178 +0100
++++ m4/kpse-freetype2-flags.m4	2018-09-19 10:23:48.556050046 +0100
+@@ -21,17 +21,10 @@
+ 
+ # KPSE_FREETYPE2_OPTIONS([WITH-SYSTEM])
+ # -------------------------------------
+-AC_DEFUN([KPSE_FREETYPE2_OPTIONS], [_KPSE_LIB_OPTIONS([freetype2], [$1], [freetype-config])])
++AC_DEFUN([KPSE_FREETYPE2_OPTIONS], [_KPSE_LIB_OPTIONS([freetype2], [$1], [pkg-config])])
+ 
+ # KPSE_FREETYPE2_SYSTEM_FLAGS
+ # ---------------------------
+ AC_DEFUN([KPSE_FREETYPE2_SYSTEM_FLAGS], [dnl
+-AC_REQUIRE([AC_CANONICAL_HOST])[]dnl
+-AC_CHECK_TOOL([FT2_CONFIG], [freetype-config], [false])[]dnl
+-if $FT2_CONFIG --ftversion >/dev/null 2>&1; then
+-  FREETYPE2_INCLUDES=`$FT2_CONFIG --cflags`
+-  FREETYPE2_LIBS=`$FT2_CONFIG --libs`
+-elif test "x$need_freetype2:$with_system_freetype2" = xyes:yes; then
+-  AC_MSG_ERROR([did not find freetype-config required for system freetype2 library])
+-fi
+-]) # KPSE_FREETYPE2_SYSTEM_FLAGS
++_KPSE_PKG_CONFIG_FLAGS([freetype2], [freetype2])])
++

--- a/app-text/ttf2pk2/ttf2pk2-2.0_p20170524-r1.ebuild
+++ b/app-text/ttf2pk2/ttf2pk2-2.0_p20170524-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+inherit epatch autotools
+
+DESCRIPTION="Freetype 2 based TrueType font to TeX's PK format converter"
+HOMEPAGE="http://tug.org/texlive/"
+SRC_URI="mirror://gentoo/texlive-${PV#*_p}-source.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE=""
+
+# Note about blockers: it is a freetype2 based replacement for ttf2pk and
+# ttf2tfm from freetype1, so block freetype1.
+# It installs some data that collides with
+# dev-texlive/texlive-langcjk-2011[source]. Hope it'd be fixed with 2012,
+# meanwhile we can start dropping freetype1.
+RDEPEND=">=dev-libs/kpathsea-6.2.1
+		media-libs/freetype:2
+		sys-libs/zlib
+		!media-libs/freetype:1
+		!=dev-texlive/texlive-langcjk-2011*[source]"
+DEPEND="${RDEPEND}
+	app-arch/xz-utils
+	virtual/pkgconfig"
+
+S=${WORKDIR}/texlive-${PV#*_p}-source/texk/${PN}
+
+src_prepare () {
+	# Bug 654770
+	cd "${WORKDIR}/texlive-${PV#*_p}-source"
+	epatch "${FILESDIR}"/ttf2pk2-2.0_p20170524-freetype2-config.patch
+	cd "${S}"
+	eautoreconf
+}
+
+src_configure() {
+	econf --with-system-kpathsea \
+		--with-system-freetype2 \
+		--with-system-zlib
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	dodoc BUGS README TODO ChangeLog
+}


### PR DESCRIPTION
Patch by Aidan Thornton, taken from a975bbac7
"app-text/xdvik: use pkg-config instead of freetype-config"

Closes: https://bugs.gentoo.org/654770
Package-Manager: Portage-2.3.56, Repoman-2.3.12