### PR TITLE
dev-embedded/arduino: version bump to 1.8.8 (WIP)

### DIFF
--- a/dev-embedded/arduino/arduino-1.8.8.ebuild
+++ b/dev-embedded/arduino/arduino-1.8.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -20,7 +20,7 @@ done
 
 SRC_URI="https://github.com/arduino/Arduino/archive/${PV}.tar.gz -> ${P}.tar.gz
 	https://downloads.arduino.cc/cores/avr-1.6.23.tar.bz2 -> ${PN}-avr-1.6.23.tar.bz2
-	https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.9.2/WiFi101-Updater-ArduinoIDE-Plugin-0.9.2.zip -> ${PN}-WiFi101-Updater-ArduinoIDE-Plugin-0.9.2.zip
+	https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.10.5/WiFi101-Updater-ArduinoIDE-Plugin-0.10.5.zip -> ${PN}-WiFi101-Updater-ArduinoIDE-Plugin-0.10.5.zip
 	doc? (
 		${ARDUINO_DOCS_URI}
 	)"
@@ -62,7 +62,7 @@ src_unpack() {
 	unpack `echo ${A} | cut -d ' ' -f1`
 
 	cp "${DISTDIR}/${PN}-avr-1.6.23.tar.bz2" "${S}/build/avr-1.6.23.tar.bz2" || die
-	cp "${DISTDIR}/${PN}-WiFi101-Updater-ArduinoIDE-Plugin-0.9.2.zip" "${S}/build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.9.2.zip"|| die
+	cp "${DISTDIR}/${PN}-WiFi101-Updater-ArduinoIDE-Plugin-0.10.5.zip" "${S}/build/shared/WiFi101-Updater-ArduinoIDE-Plugin-0.10.5.zip"|| die
 
 	if use doc; then
 		local docname


### PR DESCRIPTION
This PR bumps arduino to 1.8.8 and also updates WiFi101-Updater-ArduinoIDE-Plugin to 0.10.5

Signed-off-by: Gianluca Varisco <gianluca.varisco@gmail.com>