### PR TITLE
media-libs/mesa: Add support for LLVM 9 slot

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -136,6 +136,7 @@ RDEPEND="${RDEPEND}
 # 3. Specify LLVM_MAX_SLOT, e.g. 6.
 LLVM_DEPSTR="
 	|| (
+		sys-devel/llvm:9[${MULTILIB_USEDEP}]
 		sys-devel/llvm:8[${MULTILIB_USEDEP}]
 		sys-devel/llvm:7[${MULTILIB_USEDEP}]
 		sys-devel/llvm:6[${MULTILIB_USEDEP}]


### PR DESCRIPTION
The usual LLVM bump breakage

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>