### PR TITLE
x11-misc/dmenu: fix prefix install

### DIFF
--- a/x11-misc/dmenu/dmenu-4.8.ebuild
+++ b/x11-misc/dmenu/dmenu-4.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -54,7 +54,7 @@ src_compile() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" PREFIX="/usr" install
+	emake DESTDIR="${D}" PREFIX="${EPREFIX}/usr" install
 
 	save_config config.h
 }


### PR DESCRIPTION
Hi,

For gentoo-prefix, dmenu incorrectly installs files outside of prefix. This patch fixes installation paths.

Closes: https://bugs.gentoo.org/675750
Package-Manager: Portage-2.3.55, Repoman-2.3.12
Signed-off-by: Susan Wilson <susanw@airmail.cc>