### PR TITLE
dev-lang/mujs: respect EPREFIX

### DIFF
--- a/dev-lang/mujs/mujs-1.0.5-r1.ebuild
+++ b/dev-lang/mujs/mujs-1.0.5-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic multilib toolchain-funcs
+
+DESCRIPTION="An embeddable Javascript interpreter in C."
+HOMEPAGE="
+	http://mujs.com/
+	https://github.com/ccxvii/mujs/
+"
+SRC_URI="https://github.com/ccxvii/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="AGPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos"
+IUSE="static-libs"
+
+RDEPEND="sys-libs/readline:0="
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-flags.patch"
+)
+
+src_prepare() {
+	default
+
+	tc-export AR CC
+
+	append-cflags -fPIC -Wl,-soname=lib${PN}.so.${PV}
+}
+
+src_compile() {
+	emake VERSION=${PV} prefix=/usr shared
+}
+
+src_install() {
+	local myeconfargs=(
+		DESTDIR="${ED}"
+		install-shared
+		libdir="/usr/$(get_libdir)"
+		prefix="/usr"
+		VERSION="${PV}"
+		$(usex static-libs install-static '')
+	)
+
+	emake DESTDIR="${ED}" "${myeconfargs[@]}"
+
+	mv -v "${D}"/usr/$(get_libdir)/lib${PN}.so{,.${PV}} || die
+
+	dosym lib${PN}.so.${PV} /usr/$(get_libdir)/lib${PN}.so
+	dosym lib${PN}.so.${PV} /usr/$(get_libdir)/lib${PN}.so.${PV:0:1}
+}


### PR DESCRIPTION
In older versions, the EPREFIX was introduced,
but got missing starting with 1.0.4 an newer.

See for more: https://github.com/gentoo/gentoo/pull/10283

Package-Manager: Portage-2.3.56, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>