### PR TITLE
net-p2p/qbittorrent: dep on libtorrent-rasterbar-1.1 and revbump-move

### DIFF
--- a/net-p2p/qbittorrent/qbittorrent-4.1.4-r1.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-4.1.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -29,7 +29,7 @@ RDEPEND="
 	dev-qt/qtnetwork:5[ssl]
 	>=dev-qt/qtsingleapplication-2.6.1_p20130904-r1[qt5(+),X?]
 	dev-qt/qtxml:5
-	>=net-libs/libtorrent-rasterbar-1.0.6:0=
+	=net-libs/libtorrent-rasterbar-1.1*:0=
 	sys-libs/zlib
 	dbus? ( dev-qt/qtdbus:5 )
 	X? (

--- a/net-p2p/qbittorrent/qbittorrent-4.1.5-r1.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-4.1.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -29,7 +29,7 @@ RDEPEND="
 	dev-qt/qtnetwork:5[ssl]
 	>=dev-qt/qtsingleapplication-2.6.1_p20130904-r1[qt5(+),X?]
 	dev-qt/qtxml:5
-	>=net-libs/libtorrent-rasterbar-1.0.6:0=
+	=net-libs/libtorrent-rasterbar-1.1*:0=
 	sys-libs/zlib
 	dbus? ( dev-qt/qtdbus:5 )
 	X? (

--- a/net-p2p/qbittorrent/qbittorrent-9999.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -29,7 +29,7 @@ RDEPEND="
 	dev-qt/qtnetwork:5[ssl]
 	>=dev-qt/qtsingleapplication-2.6.1_p20130904-r1[qt5(+),X?]
 	dev-qt/qtxml:5
-	>=net-libs/libtorrent-rasterbar-1.0.6:0=
+	=net-libs/libtorrent-rasterbar-1.1*:0=
 	sys-libs/zlib
 	dbus? ( dev-qt/qtdbus:5 )
 	X? (


### PR DESCRIPTION
QBittorrent doesn't build against  libtorrent-rasterbar-1.2, so dep needs to be restricted to 1.1.x versions. It's a straight-to-stable revbump, as per "Ebuild Revisions" recommendation.

The only other change is just the ebuild copyright header.