### PR TITLE
net-p2p/deluge: restrict libtorrent-rasterbar dependency

### DIFF
--- a/net-p2p/deluge/deluge-1.3.15-r3.ebuild
+++ b/net-p2p/deluge/deluge-1.3.15-r3.ebuild
@@ -10,11 +10,10 @@ inherit distutils-r1 systemd user
 DESCRIPTION="BitTorrent client with a client/server model"
 HOMEPAGE="https://deluge-torrent.org/"
 
-if [[ ${PV} == 1.3.9999 ]]; then
+if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://deluge-torrent.org/${PN}.git
 		http://git.deluge-torrent.org/${PN}"
-	EGIT_BRANCH="1.3-stable"
 	SRC_URI=""
 else
 	SRC_URI="http://download.deluge-torrent.org/source/${P}.tar.bz2"
@@ -31,6 +30,7 @@ REQUIRED_USE="
 "
 PATCHES=(
 	"${FILESDIR}/${PN}-1.3.5-disable_libtorrent_internal_copy.patch"
+	"${FILESDIR}/${PN}-1.3.15-r1-fix-preferences-ui.patch"
 )
 
 DEPEND="<net-libs/libtorrent-rasterbar-1.2[python,${PYTHON_USEDEP}]


### PR DESCRIPTION
net-libs/libtorrent-rasterbar-1.2 removed several deprecated
functions needed by net-p2p/deluge. We thus restrict the
dependency to be <net-libs/libtorrent-rasterbar-1.2

Also a few cleanups already discussed for deluge-9999

Closes: https://bugs.gentoo.org/676056
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>
Package-Manager: Portage-2.3.51, Repoman-2.3.11