### PR TITLE
sys-apps/systemd: fix kernel-install initramfs detection regression

### DIFF
--- a/sys-apps/systemd/files/241_rc1-kernel-install-initrd-detection.patch
+++ b/sys-apps/systemd/files/241_rc1-kernel-install-initrd-detection.patch
@@ -1,0 +1,64 @@
+--- a/src/kernel-install/90-loaderentry.install
++++ b/src/kernel-install/90-loaderentry.install
+@@ -83,7 +83,9 @@ cp "$KERNEL_IMAGE" "$BOOT_DIR_ABS/linux" &&
+     exit 1
+ }
+ 
+-for initrd in "${@:${INITRD_OPTIONS_START}}"; do
++INITRD_OPTIONS=( "${@:${INITRD_OPTIONS_START}}" )
++
++for initrd in "${INITRD_OPTIONS[@]}"; do
+     if [[ -f "${initrd}" ]]; then
+         initrd_basename="$(basename ${initrd})"
+         cp "${initrd}" "$BOOT_DIR_ABS/${initrd_basename}" &&
+@@ -95,6 +97,10 @@ for initrd in "${@:${INITRD_OPTIONS_START}}"; do
+     fi
+ done
+ 
++# If no initrd option is supplied, fallback to "initrd" which is
++# the name used by dracut when generating it in its kernel-install hook
++[[ ${#INITRD_OPTIONS[@]} == 0 ]] && INITRD_OPTIONS=( initrd )
++
+ mkdir -p "${LOADER_ENTRY%/*}" || {
+     echo "Could not create loader entry directory '${LOADER_ENTRY%/*}'." >&2
+     exit 1
+@@ -106,7 +112,7 @@ mkdir -p "${LOADER_ENTRY%/*}" || {
+     echo "machine-id $MACHINE_ID"
+     echo "options    ${BOOT_OPTIONS[*]}"
+     echo "linux      $BOOT_DIR/linux"
+-    for initrd in "${@:${INITRD_OPTIONS_START}}"; do
++    for initrd in "${INITRD_OPTIONS[@]}"; do
+         [[ -f $BOOT_DIR_ABS/$(basename ${initrd}) ]] && \
+             echo "initrd     $BOOT_DIR/$(basename ${initrd})"
+     done
+diff --git a/src/kernel-install/kernel-install b/src/kernel-install/kernel-install
+index 7973818bcad..b85c7c557e2 100644
+--- a/src/kernel-install/kernel-install
++++ b/src/kernel-install/kernel-install
+@@ -65,14 +65,16 @@ done
+ 
+ if [[ "${0##*/}" == 'installkernel' ]]; then
+     COMMAND='add'
++    # make install doesn't pass any parameter wrt initrd handling
++    INITRD_OPTIONS=()
+ else
+     COMMAND="$1"
+     shift
++    INITRD_OPTIONS=( "${@:3}" )
+ fi
+ 
+ KERNEL_VERSION="$1"
+ KERNEL_IMAGE="$2"
+-INITRD_OPTIONS_START="3"
+ 
+ if [[ -f /etc/machine-id ]]; then
+     read MACHINE_ID < /etc/machine-id
+@@ -124,7 +126,7 @@ case $COMMAND in
+ 
+         for f in "${PLUGINS[@]}"; do
+             if [[ -x $f ]]; then
+-                "$f" add "$KERNEL_VERSION" "$BOOT_DIR_ABS" "$KERNEL_IMAGE" "${@:${INITRD_OPTIONS_START}}"
++                "$f" add "$KERNEL_VERSION" "$BOOT_DIR_ABS" "$KERNEL_IMAGE" "${INITRD_OPTIONS[@]}"
+                 x=$?
+                 if [[ $x == $SKIP_REMAINING ]]; then
+                     ret=0

--- a/sys-apps/systemd/systemd-241_rc1-r1.ebuild
+++ b/sys-apps/systemd/systemd-241_rc1-r1.ebuild
@@ -160,6 +160,7 @@ src_prepare() {
 
 	# Add local patches here
 	PATCHES+=(
+		"${FILESDIR}/241_rc1-kernel-install-initrd-detection.patch"
 	)
 
 	if ! use vanilla; then


### PR DESCRIPTION
Merged upstream in commit https://github.com/systemd/systemd/commit/d279b185c004fdaf7913778f052ec2ab249cd473

Between systemd-240 and systemd-241_rc1, a regression was introduced into the kernel-install utility whereby the initramfs would silently not be written into the systemd-boot loader entry, meaning, in the worst case, an unbootable system.

As per the discussion on the upstream systemd bug https://github.com/systemd/systemd/issues/11572 and the related pull request https://github.com/systemd/systemd/pull/11570, this change is indeed a regression. A patch by Marc-Antoine Perennou has fixed this behaviour without having to also revert the newly-added functionality to the kernel-install utility.

For background, the kernel-install utility is used to facilitate kernel upgrades when using systemd-boot. It generates a new boot loader entry, it can use dracut hooks to automatically generate an initramfs for a given kernel image, and it will copy both the kernel image and the initramfs into the places on the ESP which respect the Boot Loader Specification, which systemd-boot interprets.

Bug: https://github.com/systemd/systemd/issues/11572
Package-Manager: Portage-2.3.58, Repoman-2.3.12
Signed-off-by: Jack Todaro <jackmtodaro@gmail.com>