### PR TITLE
dev-python/pypax: PYTHON_TARGETS+="python3_7"

### DIFF
--- a/dev-python/pypax/pypax-0.9.2.ebuild
+++ b/dev-python/pypax/pypax-0.9.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} pypy )
 
 inherit distutils-r1
 

--- a/dev-python/pypax/pypax-0.9.3.ebuild
+++ b/dev-python/pypax/pypax-0.9.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} pypy )
 
 inherit distutils-r1
 

--- a/dev-python/pypax/pypax-0.9.4.ebuild
+++ b/dev-python/pypax/pypax-0.9.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} pypy )
 
 inherit distutils-r1
 

--- a/dev-python/pypax/pypax-9999.ebuild
+++ b/dev-python/pypax/pypax-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} pypy )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} pypy )
 
 inherit distutils-r1
 


### PR DESCRIPTION
I've been running pypax without on Python 3.7 without issues since at least 0.9.2.

This is a follow-up to #10117. I don't know why the updated commit doesn't show up in this bug.