### PR TITLE
dev-python/newt_syrup: EAPI7, fix Homepage and SRC_URI

### DIFF
--- a/dev-python/newt_syrup/newt_syrup-0.1.2-r2.ebuild
+++ b/dev-python/newt_syrup/newt_syrup-0.1.2-r2.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python2_7 )
+
+inherit distutils-r1
+
+DESCRIPTION="Python framework for creating text-based applications"
+HOMEPAGE="https://pagure.io/newt"
+SRC_URI="https://mcpierce.fedorapeople.org/sources/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+RDEPEND=">=dev-libs/newt-0.52.11"
+
+DOCS=( AUTHORS ChangeLog COLORS )


### PR DESCRIPTION
```diff
--- newt_syrup-0.1.2-r1.ebuild  2017-03-19 10:57:12.049786324 +0100
+++ newt_syrup-0.1.2-r2.ebuild  2019-01-29 14:15:50.716904026 +0100
@@ -1,21 +1,20 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 PYTHON_COMPAT=( python2_7 )
 
 inherit distutils-r1
 
-DESCRIPTION="A Python framework for creating text-based applications"
-HOMEPAGE="http://fedorahosted.org/newt-syrup/"
-SRC_URI="http://mcpierce.fedorapeople.org/rpms/${P}.tar.gz"
+DESCRIPTION="Python framework for creating text-based applications"
+HOMEPAGE="https://pagure.io/newt"
+SRC_URI="https://mcpierce.fedorapeople.org/sources/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 RDEPEND=">=dev-libs/newt-0.52.11"
 
-DOCS="COLORS"
+DOCS=( AUTHORS ChangeLog COLORS )
```

Hi,

This PR updates dev-python/newt_syrup for EAPI7, fixes the Homepage (was redirecting anyway there) and also fixes the SRC_URI.
Please review

Closes: https://bugs.gentoo.org/676770
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>