### PR TITLE
dev-python/asciitree: fix description

### DIFF
--- a/dev-python/asciitree/asciitree-0.3.3.ebuild
+++ b/dev-python/asciitree/asciitree-0.3.3.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python2_7 )
 inherit distutils-r1
 
-DESCRIPTION="Fast erasure codec for the command-line, C, Python, or Haskell"
+DESCRIPTION="Draws ASCII trees"
 HOMEPAGE="https://pypi.org/project/asciitree/"
 SRC_URI="mirror://pypi/a/asciitree/${P}.tar.gz"
 


### PR DESCRIPTION
The DESCRIPTION appears to have been copied from dev-python/zfec and is
definitely not accurate for asciitree. Use the description from PyPI.

Signed-off-by: Christopher Head <chead@chead.ca>
Package-Manager: Portage-2.3.51, Repoman-2.3.11