### PR TITLE
dev-lang/go: fix cross-compile under crossdev

### DIFF
--- a/dev-lang/go/go-1.11.5.ebuild
+++ b/dev-lang/go/go-1.11.5.ebuild
@@ -12,21 +12,31 @@ inherit toolchain-funcs
 
 BOOTSTRAP_DIST="https://dev.gentoo.org/~williamh/dist"
 BOOTSTRAP_VERSION="bootstrap-1.8"
-BOOTSTRAP_URI="
-amd64? ( ${BOOTSTRAP_DIST}/go-linux-amd64-${BOOTSTRAP_VERSION}.tbz )
-arm? ( ${BOOTSTRAP_DIST}/go-linux-arm-${BOOTSTRAP_VERSION}.tbz )
-arm64? ( ${BOOTSTRAP_DIST}/go-linux-arm64-${BOOTSTRAP_VERSION}.tbz )
-ppc64? (
-	${BOOTSTRAP_DIST}/go-linux-ppc64-${BOOTSTRAP_VERSION}.tbz
-	${BOOTSTRAP_DIST}/go-linux-ppc64le-${BOOTSTRAP_VERSION}.tbz
-)
-s390? ( ${BOOTSTRAP_DIST}/go-linux-s390x-${BOOTSTRAP_VERSION}.tbz )
-x86? ( ${BOOTSTRAP_DIST}/go-linux-386-${BOOTSTRAP_VERSION}.tbz )
-amd64-fbsd? ( ${BOOTSTRAP_DIST}/go-freebsd-amd64-${BOOTSTRAP_VERSION}.tbz )
-x86-fbsd? ( ${BOOTSTRAP_DIST}/go-freebsd-386-${BOOTSTRAP_VERSION}.tbz )
-x64-macos? ( ${BOOTSTRAP_DIST}/go-darwin-amd64-${BOOTSTRAP_VERSION}.tbz )
-x64-solaris? ( ${BOOTSTRAP_DIST}/go-solaris-amd64-${BOOTSTRAP_VERSION}.tbz )
-"
+case ${CHOST} in
+*-darwin*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-darwin-amd64-${BOOTSTRAP_VERSION}.tbz" ;;
+*-solaris*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-solaris-amd64-${BOOTSTRAP_VERSION}.tbz" ;;
+x86_64*freebsd*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-freebsd-amd64-${BOOTSTRAP_VERSION}.tbz" ;;
+x86_64*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-linux-amd64-${BOOTSTRAP_VERSION}.tbz" ;;
+i?86*freebsd*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-freebsd-386-${BOOTSTRAP_VERSION}.tbz" ;;
+i?86*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-linux-386-${BOOTSTRAP_VERSION}.tbz" ;;
+arm*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-linux-arm-${BOOTSTRAP_VERSION}.tbz" ;;
+aarch64*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-linux-arm64-${BOOTSTRAP_VERSION}.tbz" ;;
+powerpc64*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-linux-ppc64-${BOOTSTRAP_VERSION}.tbz
+		${BOOTSTRAP_DIST}/go-linux-ppc64le-${BOOTSTRAP_VERSION}.tbz" ;;
+s390*)
+	BOOTSTRAP_URI="${BOOTSTRAP_DIST}/go-linux-s390x-${BOOTSTRAP_VERSION}.tbz" ;;
+*)
+	die "unsupported arch: ${BOOTSTRAP_ARCH}" ;;
+esac
 
 case ${PV}  in
 *9999*)
@@ -160,7 +170,7 @@ src_unpack()
 
 src_compile()
 {
-	export GOROOT_BOOTSTRAP="${WORKDIR}"/go-$(go_os)-$(go_arch)-bootstrap
+	export GOROOT_BOOTSTRAP="${WORKDIR}"/go-$(go_os ${CBUILD})-$(go_arch ${CBUILD})-bootstrap
 	if use gccgo; then
 		mkdir -p "${GOROOT_BOOTSTRAP}/bin" || die
 		local go_binary=$(gcc-config --get-bin-path)/go-$(gcc-major-version)


### PR DESCRIPTION
As stated in the bug, dev-lang/go fails to under an env generated by
sys-devel/crossdev for two reasons:  one, the bootstrap download package
matches the target rather than host arch, and two, the GOROOT_BOOTSTRAP
environment variable matches the opposite - host instead of target.
This fixes both issues for a successful cross-compile.

Closes: https://bugs.gentoo.org/671394
Signed-off-by: matoro <matoro@airmail.cc>