### PR TITLE
net-analyzer/authforce: take maintainership, EAPI7, fix manpage installation

### DIFF
--- a/net-analyzer/authforce/authforce-0.9.9-r2.ebuild
+++ b/net-analyzer/authforce/authforce-0.9.9-r2.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="An HTTP authentication brute forcer"
+HOMEPAGE="http://www.divineinvasion.net/authforce/"
+SRC_URI="http://www.divineinvasion.net/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="curl nls"
+
+RDEPEND="sys-libs/readline:0=
+	curl? ( net-misc/curl )"
+DEPEND="${RDEPEND}"
+BDEPEND="nls? ( sys-devel/gettext )"
+
+DOCS=( AUTHORS BUGS NEWS README THANKS TODO )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-curl.patch
+	"${FILESDIR}"/${P}-locale.patch
+)
+
+src_prepare() {
+	default
+	gunzip doc/${PN}.1.gz
+	sed -i -e "s/${PN}.1.gz/${PN}.1/g" \
+		-e "s/\/mang/\/man1/g" doc/Makefile* || die
+}
+
+src_configure() {
+	econf \
+		$(use_with curl) \
+		$(use_enable nls) \
+		--with-path=/usr/share/${PN}/data:.
+}
+
+src_install() {
+	default
+	doman doc/${PN}.1
+}

--- a/net-analyzer/authforce/metadata.xml
+++ b/net-analyzer/authforce/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>bu9zilla@gmail.com</email>
+		<name>Michael Mair-Keimberger</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
Hi, 

I would like to take over net-analyzer/authforce.
For the start i've updated the ebuild for EAPI7 and fixed the manpage installation (and also decompressed the precompressed manpage file). For some reason the Makefile want's to install the manpage under ```/usr/share/man/mang``` which doesn't make sense at all and wouldn't be accessible for the user. 

Please review.