### PR TITLE
gnome2-utils.ecalss: add support for EAPI 7

### DIFF
--- a/eclass/gnome2-utils.eclass
+++ b/eclass/gnome2-utils.eclass
@@ -19,7 +19,7 @@
 inherit eutils xdg-utils
 
 case "${EAPI:-0}" in
-	0|1|2|3|4|5|6) ;;
+	0|1|2|3|4|5|6|7) ;;
 	*) die "EAPI=${EAPI} is not supported" ;;
 esac
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/676888
Signed-off-by: Oz N Tiram <oz.tiram@gmail.com>