### PR TITLE
www-client/qutebrowser: Force libyaml use flag on for pyyaml dependency

### DIFF
--- a/www-client/qutebrowser/qutebrowser-1.5.2-r1.ebuild
+++ b/www-client/qutebrowser/qutebrowser-1.5.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -31,7 +31,7 @@ RDEPEND="${COMMON_DEPEND}
 	>=dev-python/pygments-2.1.3[${PYTHON_USEDEP}]
 	>=dev-python/pypeg2-2.15.2[${PYTHON_USEDEP}]
 	>=dev-python/PyQt5-5.7.1[${PYTHON_USEDEP},declarative,multimedia,gui,network,opengl,printsupport,sql,webengine,widgets]
-	>=dev-python/pyyaml-3.12[${PYTHON_USEDEP}]
+	>=dev-python/pyyaml-3.12[${PYTHON_USEDEP},libyaml]
 "
 
 # Tests restricted as the deplist (misc/requirements/requirements-tests.txt)
@@ -56,10 +56,6 @@ python_install_all() {
 	doicon -s scalable icons/${PN}.svg
 
 	distutils-r1_python_install_all
-}
-
-pkg_preinst() {
-	gnome2_icon_savelist
 }
 
 pkg_postinst() {

--- a/www-client/qutebrowser/qutebrowser-9999.ebuild
+++ b/www-client/qutebrowser/qutebrowser-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -31,7 +31,7 @@ RDEPEND="${COMMON_DEPEND}
 	>=dev-python/pygments-2.1.3[${PYTHON_USEDEP}]
 	>=dev-python/pypeg2-2.15.2[${PYTHON_USEDEP}]
 	>=dev-python/PyQt5-5.7.1[${PYTHON_USEDEP},declarative,multimedia,gui,network,opengl,printsupport,sql,webengine,widgets]
-	>=dev-python/pyyaml-3.12[${PYTHON_USEDEP}]
+	>=dev-python/pyyaml-3.12[${PYTHON_USEDEP},libyaml]
 "
 
 # Tests restricted as the deplist (misc/requirements/requirements-tests.txt)
@@ -56,10 +56,6 @@ python_install_all() {
 	doicon -s scalable icons/${PN}.svg
 
 	distutils-r1_python_install_all
-}
-
-pkg_preinst() {
-	gnome2_icon_savelist
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Package-Manager: Portage-2.3.51, Repoman-2.3.11
Signed-off-by: Jay Kamat <jaygkamat@gmail.com>

I spent a while debugging why qutebrowser was hanging for several seconds on every page load on gentoo (but not other distros), and it was because C extensions are disabled by default for pyyaml. 

I'm not sure what policy gentoo has for required use flags, but I would consider using qutebrowser without this flag enabled almost unusable (due to the constant hangs).

See https://github.com/qutebrowser/qutebrowser/issues/2777 and https://github.com/qutebrowser/qutebrowser/issues/4535 for more information.

If you think this is against gentoo policy, feel free to close this. In that case though, is there a way to recommend a certain flag be enabled?
