### PR TITLE
app-shells/bash: fix building with USE=bashlogger

### DIFF
--- a/app-shells/bash/bash-5.0_p2.ebuild
+++ b/app-shells/bash/bash-5.0_p2.ebuild
@@ -124,7 +124,7 @@ src_configure() {
 		-DSYS_BASH_LOGOUT=\'\"${EPREFIX}/etc/bash/bash_logout\"\' \
 		-DNON_INTERACTIVE_LOGIN_SHELLS \
 		-DSSH_SOURCE_BASHRC \
-		$(use bashlogger && echo -DSYSLOG_HISTORY)
+		$(use bashlogger && echo -DSYSLOG_HISTORY -DSYSLOG_SHOPT)
 
 	# Don't even think about building this statically without
 	# reading Bug 7714 first.  If you still build it statically,


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/676114
Package-Manager: Portage-2.3.59, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>