### PR TITLE
dev-python/aiosmtpd: use HTTPS, add missing die

### DIFF
--- a/dev-python/aiosmtpd/aiosmtpd-1.0.ebuild
+++ b/dev-python/aiosmtpd/aiosmtpd-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,18 +7,17 @@ PYTHON_COMPAT=( python3_4 python3_5 python3_6 )
 inherit distutils-r1
 
 DESCRIPTION="asyncio based SMTP server"
-HOMEPAGE="http://aiosmtpd.readthedocs.io/"
+HOMEPAGE="https://aiosmtpd.readthedocs.io/en/latest/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 RDEPEND="dev-python/atpublic[${PYTHON_USEDEP}]"
 
 src_prepare() {
-	rm -r examples
+	rm -r examples || die
 	distutils-r1_python_prepare_all
 }

--- a/dev-python/aiosmtpd/aiosmtpd-1.1.ebuild
+++ b/dev-python/aiosmtpd/aiosmtpd-1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,18 +7,17 @@ PYTHON_COMPAT=( python3_4 python3_5 python3_6 )
 inherit distutils-r1
 
 DESCRIPTION="asyncio based SMTP server"
-HOMEPAGE="http://aiosmtpd.readthedocs.io/"
+HOMEPAGE="https://aiosmtpd.readthedocs.io/en/latest/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 RDEPEND="dev-python/atpublic[${PYTHON_USEDEP}]"
 
 src_prepare() {
-	rm -r examples
+	rm -r examples || die
 	distutils-r1_python_prepare_all
 }


### PR DESCRIPTION
Hi,

Simple PR to add https and a missing ```die``` to dev-python/aiosmtpd.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>