### PR TITLE
app-benchmarks/stress-ng: use HTTPS

### DIFF
--- a/app-benchmarks/stress-ng/stress-ng-0.09.49.ebuild
+++ b/app-benchmarks/stress-ng/stress-ng-0.09.49.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
 
 DESCRIPTION="Stress test for a computer system with various selectable ways"
-HOMEPAGE="http://kernel.ubuntu.com/~cking/stress-ng/"
-SRC_URI="http://kernel.ubuntu.com/~cking/tarballs/${PN}/${P}.tar.xz"
+HOMEPAGE="https://kernel.ubuntu.com/~cking/stress-ng/"
+SRC_URI="https://kernel.ubuntu.com/~cking/tarballs/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-benchmarks/stress-ng/stress-ng-0.09.50.ebuild
+++ b/app-benchmarks/stress-ng/stress-ng-0.09.50.ebuild
@@ -4,8 +4,8 @@
 EAPI=7
 
 DESCRIPTION="Stress test for a computer system with various selectable ways"
-HOMEPAGE="http://kernel.ubuntu.com/~cking/stress-ng/"
-SRC_URI="http://kernel.ubuntu.com/~cking/tarballs/${PN}/${P}.tar.xz"
+HOMEPAGE="https://kernel.ubuntu.com/~cking/stress-ng/"
+SRC_URI="https://kernel.ubuntu.com/~cking/tarballs/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

Simple PR to use https for app-benchmarks/stress-ng.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>