### PR TITLE
sci-electronics/librepcb: use HTTPS

### DIFF
--- a/sci-electronics/librepcb/librepcb-0.1.0_p201805.ebuild
+++ b/sci-electronics/librepcb/librepcb-0.1.0_p201805.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit qmake-utils
 
 DESCRIPTION="Free EDA software to develop printed circuit boards"
-HOMEPAGE="http://librepcb.org/"
+HOMEPAGE="https://librepcb.org/"
 MY_P="LibrePCB-first_pcb"
 SRC_URI="https://github.com/LibrePCB/LibrePCB/archive/first_pcb.tar.gz -> ${MY_P}.tar.gz"
 

--- a/sci-electronics/librepcb/librepcb-9999.ebuild
+++ b/sci-electronics/librepcb/librepcb-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit qmake-utils git-r3
 
 DESCRIPTION="Free EDA software to develop printed circuit boards"
-HOMEPAGE="http://librepcb.org/"
+HOMEPAGE="https://librepcb.org/"
 EGIT_REPO_URI="https://github.com/LibrePCB/LibrePCB.git"
 
 LICENSE="GPL-3+"


### PR DESCRIPTION
Hi,

This is a simple PR to use https instead of http for the Homepage.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>