### PR TITLE
x11-wm/i3-gaps: Build docs and man pages

### DIFF
--- a/x11-wm/i3-gaps/metadata.xml
+++ b/x11-wm/i3-gaps/metadata.xml
@@ -5,6 +5,9 @@
 		<email>johu@gentoo.org</email>
 		<name>Johannes Huber</name>
 	</maintainer>
+	<use>
+		<flag name="man">Build and install man pages</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">Airblader/i3</remote-id>
 	</upstream>


### PR DESCRIPTION
Added the ability for i3-gaps-4.16.ebuild to build docs and man pages,
and brought it closer to the functionality of the regular i3 ebuild.

Signed-off-by: mid-kid <esteve.varela@gmail.com>