### PR TITLE
app-admin/syslog-ng: fix bison version constraint

### DIFF
--- a/app-admin/syslog-ng/syslog-ng-3.19.1.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-3.19.1.ebuild
@@ -41,7 +41,6 @@ RDEPEND="
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )"
 DEPEND="${RDEPEND}
-	<sys-devel/bison-3.3.1
 	sys-devel/flex
 	virtual/pkgconfig"
 


### PR DESCRIPTION
This reverts commit 644c4d2379e2c9a8930a2e50450ef54c74b77e47.
Closes: https://bugs.gentoo.org/677040

It's not needed since sys-devel/bison-3.3.2 fixed the issue.