### PR TITLE
media-libs/libart_lgpl: use HTTPS, add missing die

### DIFF
--- a/media-libs/libart_lgpl/libart_lgpl-2.3.21-r3.ebuild
+++ b/media-libs/libart_lgpl/libart_lgpl-2.3.21-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,14 +8,12 @@ GNOME2_LA_PUNT="yes"
 inherit autotools gnome2 multilib-minimal
 
 DESCRIPTION="A LGPL version of libart"
-HOMEPAGE="http://www.levien.com/libart"
+HOMEPAGE="https://www.levien.com/libart"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
-IUSE=""
 
-RDEPEND=""
 DEPEND=">=virtual/pkgconfig-0-r1[${MULTILIB_USEDEP}]"
 
 # The provided tests are interactive only
@@ -29,7 +27,7 @@ src_prepare() {
 	gnome2_src_prepare
 
 	# Fix crosscompiling, bug #185684
-	rm "${S}"/art_config.h
+	rm "${S}"/art_config.h || die
 	eapply "${FILESDIR}"/${PN}-2.3.21-crosscompile.patch
 
 	# Do not build tests if not required


### PR DESCRIPTION
Hi,

Just a simple PR to update the Homepage to use https instead of http, add a missing die and remove empty Vars.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>