### PR TITLE
app-doc/gimp-help-2.8.2: disable parallel build

### DIFF
--- a/app-doc/gimp-help/gimp-help-2.8.2.ebuild
+++ b/app-doc/gimp-help/gimp-help-2.8.2.ebuild
@@ -24,3 +24,8 @@ DEPEND="${PYTHON_DEPS}
 src_configure() {
 	econf --without-gimp
 }
+
+src_compile() {
+	# see https://bugs.gentoo.org/677198
+	emake -j 1
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/677198
