### PR TITLE
x11-libs/motif: use HTTPS, add missing die

### DIFF
--- a/x11-libs/motif/motif-2.3.8-r1.ebuild
+++ b/x11-libs/motif/motif-2.3.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit autotools flag-o-matic multilib toolchain-funcs multilib-minimal
 
 DESCRIPTION="The Motif user interface component toolkit"
 HOMEPAGE="https://sourceforge.net/projects/motif/
-	http://motif.ics.com/"
+	https://motif.ics.com/"
 SRC_URI="mirror://sourceforge/project/motif/Motif%20${PV}%20Source%20Code/${P}.tar.gz
 	https://dev.gentoo.org/~ulm/distfiles/${PN}-2.3.6-patches-2.tar.xz"
 
@@ -39,10 +39,10 @@ src_prepare() {
 	eapply_user
 
 	# disable compilation of demo binaries
-	sed -i -e '/^SUBDIRS/{:x;/\\$/{N;bx;};s/[ \t\n\\]*demos//;}' Makefile.am
+	sed -i -e '/^SUBDIRS/{:x;/\\$/{N;bx;};s/[ \t\n\\]*demos//;}' Makefile.am || die
 
 	# add X.Org vendor string to aliases for virtual bindings
-	echo -e '"The X.Org Foundation"\t\t\t\t\tpc' >>bindings/xmbind.alias
+	echo -e '"The X.Org Foundation"\t\t\t\t\tpc' >>bindings/xmbind.alias || die
 
 	AT_M4DIR=. eautoreconf
 


### PR DESCRIPTION
Hi,

Simple update to the ebuild to use https and add some missing die's.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>