### PR TITLE
net-wireless/iw: put libnl back into DEPEND

### DIFF
--- a/net-wireless/iw/iw-5.0.1-r1.ebuild
+++ b/net-wireless/iw/iw-5.0.1-r1.ebuild
@@ -15,6 +15,7 @@ KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND="dev-libs/libnl:="
+DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 src_prepare() {


### PR DESCRIPTION
@Polynomial-C 

The 5.0 revbump dropped this. We definitely need libnl headers at build
time.

Closes: https://bugs.gentoo.org/677394
Signed-off-by: Brian Norris <briannorris@chromium.org>