### PR TITLE
sys-power/apcupsd: Remove dead nls keyword

### DIFF
--- a/sys-power/apcupsd/apcupsd-3.14.14-r2.ebuild
+++ b/sys-power/apcupsd/apcupsd-3.14.14-r2.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/apcupsd/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ~arm ppc x86 ~x86-fbsd"
-IUSE="snmp +usb +modbus cgi nls gnome kernel_linux"
+IUSE="snmp +usb +modbus cgi gnome kernel_linux"
 
 DEPEND="
 	||	( >=sys-apps/util-linux-2.23[tty-helpers(-)]
@@ -20,7 +20,6 @@ DEPEND="
 		)
 	modbus? ( usb? ( virtual/libusb:0 ) )
 	cgi? ( >=media-libs/gd-1.8.4 )
-	nls? ( sys-devel/gettext )
 	snmp? ( >=net-analyzer/net-snmp-5.7.2 )
 	gnome? ( >=x11-libs/gtk+-2.4.0:2
 		dev-libs/glib:2


### PR DESCRIPTION
NLS support was removed from apcupsd in the 3.14.4 release, as stated in
the ReleaseNotes. The ebuild still have an IUSE for nls and a DEPEND on
sys-devel/gettext, for no reason. So this cleans up the ebuild.

Closes: https://bugs.gentoo.org/499770
Signed-off-by: John Einar Reitan <john.einar@gmail.com>