### PR TITLE
dev-lang/python: add valgrind support

### DIFF
--- a/dev-lang/python/metadata.xml
+++ b/dev-lang/python/metadata.xml
@@ -24,6 +24,9 @@
 		<flag name="lto">
 			Optimize the build using Link Time Optimization (LTO)
 		</flag>
+		<flag name="valgrind">
+			Detect if run within <pkg>dev-util/valgrind</pkg> and don't use pymalloc then
+		</flag>
 		<flag name="wininst">
 			Install Windows executables required to create an executable
 			installer for MS Windows

--- a/dev-lang/python/python-2.7.18_p16.ebuild
+++ b/dev-lang/python/python-2.7.18_p16.ebuild
@@ -30,7 +30,7 @@ SLOT="${PYVER}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="
 	berkdb bluetooth build examples gdbm hardened +ncurses +readline
-	+sqlite +ssl tk wininst +xml
+	+sqlite +ssl tk valgrind wininst +xml
 "
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -59,6 +59,7 @@ RDEPEND="
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
+	valgrind? ( dev-util/valgrind )
 	xml? ( >=dev-libs/expat-2.1:= )
 "
 # bluetooth requires headers from bluez
@@ -196,6 +197,8 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+
+		$(use_with valgrind)
 	)
 
 	# disable implicit optimization/debugging flags

--- a/dev-lang/python/python-3.10.8_p3.ebuild
+++ b/dev-lang/python/python-3.10.8_p3.ebuild
@@ -31,7 +31,7 @@ SLOT="${PYVER}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="
 	bluetooth build +ensurepip examples gdbm hardened libedit lto
-	+ncurses pgo +readline +sqlite +ssl test tk +xml
+	+ncurses pgo +readline +sqlite +ssl test tk valgrind +xml
 "
 RESTRICT="!test? ( test )"
 
@@ -64,6 +64,7 @@ RDEPEND="
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
+	valgrind? ( dev-util/valgrind )
 	xml? ( >=dev-libs/expat-2.1:= )
 	!!<sys-apps/sandbox-2.21
 "
@@ -222,6 +223,7 @@ src_configure() {
 		$(use_with lto)
 		$(use_enable pgo optimizations)
 		$(use_with readline readline "$(usex libedit editline readline)")
+		$(use_with valgrind)
 	)
 
 	# disable implicit optimization/debugging flags

--- a/dev-lang/python/python-3.11.0_p2.ebuild
+++ b/dev-lang/python/python-3.11.0_p2.ebuild
@@ -31,7 +31,7 @@ SLOT="${PYVER}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="
 	bluetooth build +ensurepip examples gdbm hardened libedit lto
-	+ncurses pgo +readline +sqlite +ssl test tk
+	+ncurses pgo +readline +sqlite +ssl test tk valgrind
 "
 RESTRICT="!test? ( test )"
 
@@ -65,6 +65,7 @@ RDEPEND="
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
+	valgrind? ( dev-util/valgrind )
 	!!<sys-apps/sandbox-2.21
 "
 # bluetooth requires headers from bluez
@@ -211,6 +212,7 @@ src_configure() {
 		$(use_with lto)
 		$(use_enable pgo optimizations)
 		$(use_with readline readline "$(usex libedit editline readline)")
+		$(use_with valgrind)
 	)
 
 	# disable implicit optimization/debugging flags

--- a/dev-lang/python/python-3.12.0_alpha1_p2.ebuild
+++ b/dev-lang/python/python-3.12.0_alpha1_p2.ebuild
@@ -31,7 +31,7 @@ SLOT="${PYVER}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="
 	bluetooth build +ensurepip examples gdbm hardened libedit lto
-	+ncurses pgo +readline +sqlite +ssl test tk
+	+ncurses pgo +readline +sqlite +ssl test tk valgrind
 "
 RESTRICT="!test? ( test )"
 
@@ -65,6 +65,7 @@ RDEPEND="
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
+	valgrind? ( dev-util/valgrind )
 	!!<sys-apps/sandbox-2.21
 "
 # bluetooth requires headers from bluez
@@ -207,6 +208,7 @@ src_configure() {
 		$(use_with lto)
 		$(use_enable pgo optimizations)
 		$(use_with readline readline "$(usex libedit editline readline)")
+		$(use_with valgrind)
 	)
 
 	# disable implicit optimization/debugging flags

--- a/dev-lang/python/python-3.12.0_alpha2.ebuild
+++ b/dev-lang/python/python-3.12.0_alpha2.ebuild
@@ -31,7 +31,7 @@ SLOT="${PYVER}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="
 	bluetooth build +ensurepip examples gdbm hardened libedit lto
-	+ncurses pgo +readline +sqlite +ssl test tk
+	+ncurses pgo +readline +sqlite +ssl test tk valgrind
 "
 RESTRICT="!test? ( test )"
 
@@ -65,6 +65,7 @@ RDEPEND="
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
+	valgrind? ( dev-util/valgrind )
 	!!<sys-apps/sandbox-2.21
 "
 # bluetooth requires headers from bluez
@@ -207,6 +208,7 @@ src_configure() {
 		$(use_with lto)
 		$(use_enable pgo optimizations)
 		$(use_with readline readline "$(usex libedit editline readline)")
+		$(use_with valgrind)
 	)
 
 	# disable implicit optimization/debugging flags

--- a/dev-lang/python/python-3.8.15_p3.ebuild
+++ b/dev-lang/python/python-3.8.15_p3.ebuild
@@ -31,7 +31,7 @@ SLOT="${PYVER}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="
 	bluetooth build +ensurepip examples gdbm hardened lto +ncurses pgo
-	+readline +sqlite +ssl test tk wininst +xml
+	+readline +sqlite +ssl test tk valgrind wininst +xml
 "
 RESTRICT="!test? ( test )"
 
@@ -61,6 +61,7 @@ RDEPEND="
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
+	valgrind? ( dev-util/valgrind )
 	xml? ( >=dev-libs/expat-2.1:= )
 "
 # bluetooth requires headers from bluez
@@ -175,6 +176,8 @@ src_configure() {
 		--with-system-expat
 		--with-system-ffi
 		--with-wheel-pkg-dir="${EPREFIX}"/usr/lib/python/ensurepip
+
+		$(use_with valgrind)
 	)
 
 	# disable implicit optimization/debugging flags

--- a/dev-lang/python/python-3.9.15_p3.ebuild
+++ b/dev-lang/python/python-3.9.15_p3.ebuild
@@ -31,7 +31,7 @@ SLOT="${PYVER}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="
 	bluetooth build +ensurepip examples gdbm hardened lto +ncurses pgo
-	+readline +sqlite +ssl test tk +xml
+	+readline +sqlite +ssl test tk valgrind +xml
 "
 RESTRICT="!test? ( test )"
 
@@ -61,6 +61,7 @@ RDEPEND="
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
+	valgrind? ( dev-util/valgrind )
 	xml? ( >=dev-libs/expat-2.1:= )
 "
 # bluetooth requires headers from bluez
@@ -216,6 +217,7 @@ src_configure() {
 
 		$(use_with lto)
 		$(use_enable pgo optimizations)
+		$(use_with valgrind)
 	)
 
 	# disable implicit optimization/debugging flags


### PR DESCRIPTION
When the valgrind useflag is enabled, Python performs a runtime check if
it is run in the Valgrind VM, and adjusts its memory allocator to not
use pymalloc. Valgrind then does a much better job in tracking the
memory reachability.

Closes: https://bugs.gentoo.org/610816