### PR TITLE
media-libs/aribb24-1.0.3-r1: enable multilib, bump to EAPI 7

### DIFF
--- a/media-libs/aribb24/aribb24-1.0.3-r1.ebuild
+++ b/media-libs/aribb24/aribb24-1.0.3-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools multilib-minimal
+
+DESCRIPTION="Library for decoding ARIB STD-B24 subtitles"
+HOMEPAGE="https://github.com/nkoriyama/aribb24"
+SRC_URI="https://github.com/nkoriyama/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
+
+RDEPEND="media-libs/libpng:0=[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf --disable-static
+}
+
+multilib_src_install_all() {
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
media-video/ffmpeg supports this in master now, multilib will be required when that is released.

Signed-off-by: Hector Martin <marcan@marcan.st>
Package-Manager: Portage-2.3.59, Repoman-2.3.12