### PR TITLE
media-sound/id3ed: fix LICENSE, SRC_URI and HOMEPAGE + EAPI7 revbump

### DIFF
--- a/media-sound/id3ed/id3ed-1.10.4-r1.ebuild
+++ b/media-sound/id3ed/id3ed-1.10.4-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="ID3 tag editor for mp3 files"
+HOMEPAGE="http://code.fluffytapeworm.com/projects/id3ed"
+SRC_URI="http://code.fluffytapeworm.com/projects/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+DEPEND="sys-libs/ncurses:0=
+	sys-libs/readline:0="
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+	sed -i \
+		-e '/install/s:-s::' \
+		-e 's:$(CXX) $(CXXFLAGS):$(CXX) $(LDFLAGS) $(CXXFLAGS):' \
+		Makefile.in || die
+}
+
+src_compile() {
+	emake CXX="$(tc-getCXX)" CFLAGS="${CFLAGS} -I./" || die
+}
+
+src_install() {
+	dodir /usr/bin /usr/share/man/man1
+	default
+}

--- a/media-sound/id3ed/id3ed-1.10.4.ebuild
+++ b/media-sound/id3ed/id3ed-1.10.4.ebuild
@@ -1,17 +1,17 @@
-# Copyright 1999-2010 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=2
+
 inherit toolchain-funcs
 
 DESCRIPTION="ID3 tag editor for mp3 files"
-HOMEPAGE="http://www.dakotacom.net/~donut/programs/id3ed.html"
-SRC_URI="http://www.dakotacom.net/~donut/programs/${PN}/${P}.tar.gz"
+HOMEPAGE="http://code.fluffytapeworm.com/projects/id3ed"
+SRC_URI="http://code.fluffytapeworm.com/projects/${PN}/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ppc ppc64 sparc x86"
-IUSE=""
 
 DEPEND="sys-libs/ncurses
 	sys-libs/readline"


### PR DESCRIPTION
Hi,

This PR updates media-sound/id3ed for EAPI7 alongside with a few other fixes.
Please review.