### PR TITLE
>=app-crypt/gnupg-2.1.12: depend on virtual/libusb:1

### DIFF
--- a/app-crypt/gnupg/gnupg-2.2.10.ebuild
+++ b/app-crypt/gnupg/gnupg-2.2.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -28,7 +28,7 @@ COMMON_DEPEND_LIBS="
 	ldap? ( net-nds/openldap )
 	bzip2? ( app-arch/bzip2 )
 	readline? ( sys-libs/readline:0= )
-	smartcard? ( usb? ( virtual/libusb:0 ) )
+	smartcard? ( usb? ( virtual/libusb:1 ) )
 	tofu? ( >=dev-db/sqlite-3.7 )
 	virtual/mta
 	"

--- a/app-crypt/gnupg/gnupg-2.2.12.ebuild
+++ b/app-crypt/gnupg/gnupg-2.2.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -27,7 +27,7 @@ DEPEND="!app-crypt/dirmngr
 	bzip2? ( app-arch/bzip2 )
 	ldap? ( net-nds/openldap )
 	readline? ( sys-libs/readline:0= )
-	smartcard? ( usb? ( virtual/libusb:0 ) )
+	smartcard? ( usb? ( virtual/libusb:1 ) )
 	ssl? ( >=net-libs/gnutls-3.0:0= )
 	sys-libs/zlib
 	tofu? ( >=dev-db/sqlite-3.7 )


### PR DESCRIPTION
Starting with GnuPG 2.1.12 it uses libusb-1. Excerpt from [NEWS](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=NEWS;hb=refs/heads/master):
```
Noteworthy changes in version 2.1.12 (2016-05-04)
-------------------------------------------------
[...]
 * scd: Changed to use the new libusb 1.0 API for the internal CCID
   driver.
```
My Nitrokey works fine with this even without `sys-apps/pcsc-lite` or `app-crypt/ccid` installed.