### PR TITLE
dev-libs/opencryptoki: fix libressl support

### DIFF
--- a/dev-libs/opencryptoki/opencryptoki-3.6.1-r1.ebuild
+++ b/dev-libs/opencryptoki/opencryptoki-3.6.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,7 +17,8 @@ KEYWORDS="~amd64 ~arm ~s390 ~x86"
 IUSE="debug libressl +tpm"
 
 RDEPEND="tpm? ( app-crypt/trousers )
-	>=dev-libs/openssl-1.1.0:0="
+	!libressl? ( >=dev-libs/openssl-1.1.0:0= )
+	libressl? ( dev-libs/libressl:0= )"
 DEPEND="${RDEPEND}"
 
 DOCS=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/587970
Package-Manager: Portage-2.3.60, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>