### PR TITLE
dev-db/percona-xtrabackup: adjust blocker on dev-db/percona-xtrabacku…

### DIFF
--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.12.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -29,7 +29,7 @@ DEPEND="
 
 RDEPEND="
 	${DEPEND}
-	!dev-db/xtrabackup-bin
+	!dev-db/percona-xtrabackup-bin
 	dev-perl/DBD-mysql"
 
 PATCHES=(

--- a/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.13.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-2.4.13.ebuild
@@ -29,7 +29,7 @@ DEPEND="
 
 RDEPEND="
 	${DEPEND}
-	!dev-db/xtrabackup-bin
+	!dev-db/percona-xtrabackup-bin
 	dev-perl/DBD-mysql"
 
 PATCHES=(


### PR DESCRIPTION
…p-bin

Commit 7008658c4a69aa73b53d30ea3a20b5e719a04f2e changed the name of the
binary version of xtrabackup.

Closes: https://bugs.gentoo.org/677924
Package-Manager: Portage-2.3.59, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>