### PR TITLE
app-i18n/ibus: limit max vala version, add python3.7

### DIFF
--- a/app-i18n/ibus/ibus-1.5.19.ebuild
+++ b/app-i18n/ibus/ibus-1.5.19.ebuild
@@ -2,8 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
-PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} )
 VALA_MIN_API_VERSION="0.34"
+VALA_MAX_API_VERSION="0.36"
 VALA_USE_DEPEND="vapigen"
 
 inherit autotools bash-completion-r1 gnome2-utils python-r1 vala virtualx xdg-utils


### PR DESCRIPTION
build fails with newer vala: https://bpaste.net/show/2fe42f8d633a

bug: https://bugs.gentoo.org/677972