### PR TITLE
dev-python/click: add docutils/sphinx version constraints

### DIFF
--- a/dev-python/click/click-7.0.ebuild
+++ b/dev-python/click/click-7.0.ebuild
@@ -19,8 +19,9 @@ IUSE="doc examples test"
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( dev-python/pytest[${PYTHON_USEDEP}] )
-	doc? ( dev-python/sphinx[${PYTHON_USEDEP}]
-		dev-python/pallets-sphinx-themes[${PYTHON_USEDEP}] )"
+	doc? ( >=dev-python/docutils-0.14[${PYTHON_USEDEP}]
+		dev-python/pallets-sphinx-themes[${PYTHON_USEDEP}]
+		>=dev-python/sphinx-1.7.5-r1[${PYTHON_USEDEP}] )"
 
 python_prepare_all() {
 	# Prevent un-needed d'loading


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/677648
Package-Manager: Portage-2.3.59, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>