### PR TITLE
dev-util/rr: enable c++14 to fix compilation

### DIFF
--- a/dev-util/rr/files/rr-5.2.0-c++14.patch
+++ b/dev-util/rr/files/rr-5.2.0-c++14.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0d711f9..756a62e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,7 +42,7 @@ set(FLAGS_COMMON "-msse2 -D__MMX__ -D__SSE__ -D__SSE2__ -D__USE_LARGEFILE64 -pth
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_COMMON} -Wstrict-prototypes -std=gnu11")
+ # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
+ # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++11")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++14")
+ set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -g3")
+ 
+ set(RR_FLAGS_DEBUG "-Wall -Wextra  -O0 -DDEBUG -UNDEBUG")

--- a/dev-util/rr/rr-5.2.0.ebuild
+++ b/dev-util/rr/rr-5.2.0.ebuild
@@ -33,6 +33,7 @@ DEPEND+="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-ucontext_t.patch
+	"${FILESDIR}"/${P}-c++14.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
dev-util/rr-5.2.0 fails to compile if c++14 is not enabled. Add a patch
that ensures that c++14 is enabled

See also: https://github.com/mozilla/rr/issues/2269
Closes: https://bugs.gentoo.org/677860