### PR TITLE
net-libs/libnice: add patch for LibreSSL support

### DIFF
--- a/net-libs/libnice/files/libnice-0.1.15-libressl.patch
+++ b/net-libs/libnice/files/libnice-0.1.15-libressl.patch
@@ -1,0 +1,57 @@
+From 926afef019ca9f297cebbe13479159ac5c087f00 Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <stefan.strogin@gmail.com>
+Date: Fri, 15 Feb 2019 20:45:34 +0200
+Subject: [PATCH] stun: Fix LibreSSL support
+
+Closes #71
+---
+ stun/stunhmac.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/stun/stunhmac.c b/stun/stunhmac.c
+index c7d1432..c9d183f 100644
+--- a/stun/stunhmac.c
++++ b/stun/stunhmac.c
+@@ -75,7 +75,8 @@ void stun_sha1 (const uint8_t *msg, size_t len, size_t msg_len, uint8_t *sha,
+   assert (ret == 1);
+ #endif
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+   HMAC_CTX stackctx;
+   HMAC_CTX *ctx = &stackctx;
+   HMAC_CTX_init (ctx);
+@@ -101,7 +102,8 @@ void stun_sha1 (const uint8_t *msg, size_t len, size_t msg_len, uint8_t *sha,
+ 
+   TRY (HMAC_Final (ctx, sha, NULL));
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+   HMAC_CTX_cleanup (ctx);
+ #else
+   HMAC_CTX_free (ctx);
+@@ -172,7 +174,8 @@ void stun_hash_creds (const uint8_t *realm, size_t realm_len,
+ #ifdef HAVE_OPENSSL
+   EVP_MD_CTX *ctx;
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+   ctx = EVP_MD_CTX_create ();
+ #else
+   ctx = EVP_MD_CTX_new ();
+@@ -186,7 +189,8 @@ void stun_hash_creds (const uint8_t *realm, size_t realm_len,
+   EVP_DigestUpdate (ctx, password_trimmed, password_len);
+   EVP_DigestFinal_ex (ctx, md5, NULL);
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+   EVP_MD_CTX_destroy (ctx);
+ #else
+   EVP_MD_CTX_free (ctx);
+-- 
+2.20.1
+

--- a/net-libs/libnice/libnice-0.1.15.ebuild
+++ b/net-libs/libnice/libnice-0.1.15.ebuild
@@ -28,6 +28,8 @@ DEPEND="${RDEPEND}
 	>=virtual/pkgconfig-0-r1[${MULTILIB_USEDEP}]
 "
 
+PATCHES=( "${FILESDIR}/${P}-libressl.patch" )
+
 multilib_src_configure() {
 	# gstreamer plugin split off into media-plugins/gst-plugins-libnice
 	ECONF_SOURCE=${S} \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/678000
Package-Manager: Portage-2.3.60, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>