### PR TITLE
net-misc/spice-gtk: fix build for >=libressl-2.7.0

### DIFF
--- a/net-misc/spice-gtk/files/spice-gtk-0.35-libressl.patch
+++ b/net-misc/spice-gtk/files/spice-gtk-0.35-libressl.patch
@@ -1,16 +1,21 @@
 https://bugs.gentoo.org/631250
 https://631250.bugs.gentoo.org/attachment.cgi?id=513720
 
+https://bugs.gentoo.org/664512
+https://cgit.freedesktop.org/spice/spice-common/commit/?id=8e8476d932d9866d950fe616fe1c10361b75a3a2
+https://cgit.freedesktop.org/spice/spice-gtk/commit/?id=a45e8a56e389e41c891eaa204b16dd89e74e2e69
+
 diff --git a/spice-common/common/ssl_verify.c b/spice-common/common/ssl_verify.c
 index a9ed650..821faa9 100644
 --- a/spice-common/common/ssl_verify.c
 +++ b/spice-common/common/ssl_verify.c
-@@ -33,7 +33,7 @@
+@@ -33,7 +33,8 @@
  #include <string.h>
  #include <gio/gio.h>
  
--#if OPENSSL_VERSION_NUMBER < 0x10100000
-+#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
+-#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined (LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000 || \
++    (defined (LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000)
  static const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *asn1)
  {
      return M_ASN1_STRING_data(asn1);
@@ -18,12 +23,13 @@ diff --git a/src/bio-gio.c b/src/bio-gio.c
 index 9358fae..30aa73b 100644
 --- a/src/bio-gio.c
 +++ b/src/bio-gio.c
-@@ -23,7 +23,7 @@
+@@ -23,7 +23,8 @@
  #include "spice-util.h"
  #include "bio-gio.h"
  
--#if OPENSSL_VERSION_NUMBER < 0x10100000
-+#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
+-#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000 || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000)
  static BIO_METHOD one_static_bio;
  
  static int BIO_meth_set_read(BIO_METHOD *biom,
@@ -31,12 +37,13 @@ diff --git a/src/spice-channel.c b/src/spice-channel.c
 index 4c3db9d..9df0203 100644
 --- a/src/spice-channel.c
 +++ b/src/spice-channel.c
-@@ -55,7 +55,7 @@ static void spice_channel_reset_capabilities(SpiceChannel *channel);
+@@ -55,7 +55,8 @@ static void spice_channel_reset_capabilities(SpiceChannel *channel);
  static void spice_channel_send_migration_handshake(SpiceChannel *channel);
  static gboolean channel_connect(SpiceChannel *channel, gboolean tls);
  
--#if OPENSSL_VERSION_NUMBER < 0x10100000
-+#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
+-#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000 || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000)
  static RSA *EVP_PKEY_get0_RSA(EVP_PKEY *pkey)
  {
      if (pkey->type != EVP_PKEY_RSA) {

--- a/net-misc/spice-gtk/spice-gtk-0.35-r1.ebuild
+++ b/net-misc/spice-gtk/spice-gtk-0.35-r1.ebuild
@@ -1,0 +1,154 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+GCONF_DEBUG="no"
+VALA_MIN_API_VERSION="0.14"
+VALA_USE_DEPEND="vapigen"
+
+inherit autotools eutils xdg-utils vala readme.gentoo-r1
+
+DESCRIPTION="Set of GObject and Gtk objects for connecting to Spice servers and a client GUI"
+HOMEPAGE="https://www.spice-space.org https://cgit.freedesktop.org/spice/spice-gtk/"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+SRC_URI="https://www.spice-space.org/download/gtk/${P}.tar.bz2"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="dbus gstaudio gstvideo +gtk3 +introspection lz4 mjpeg policykit pulseaudio sasl smartcard static-libs usbredir vala webdav libressl"
+
+REQUIRED_USE="?? ( pulseaudio gstaudio )"
+
+# TODO:
+# * check if sys-freebsd/freebsd-lib (from virtual/acl) provides acl/libacl.h
+# * use external pnp.ids as soon as that means not pulling in gnome-desktop
+RDEPEND="
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
+	pulseaudio? ( media-sound/pulseaudio[glib] )
+	gstvideo? (
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+		media-libs/gst-plugins-good:1.0
+		)
+	gstaudio? (
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+		media-libs/gst-plugins-good:1.0
+		)
+	>=x11-libs/pixman-0.17.7
+	media-libs/opus
+	gtk3? ( x11-libs/gtk+:3[introspection?] )
+	>=dev-libs/glib-2.36:2
+	>=x11-libs/cairo-1.2
+	virtual/jpeg:0=
+	sys-libs/zlib
+	introspection? ( dev-libs/gobject-introspection )
+	lz4? ( app-arch/lz4 )
+	sasl? ( dev-libs/cyrus-sasl )
+	smartcard? ( app-emulation/qemu[smartcard] )
+	usbredir? (
+		sys-apps/hwids
+		>=sys-apps/usbredir-0.4.2
+		virtual/libusb:1
+		virtual/libgudev:=
+		policykit? (
+			sys-apps/acl
+			>=sys-auth/polkit-0.110-r1
+			!~sys-auth/polkit-0.111 )
+		)
+	webdav? (
+		net-libs/phodav:2.0
+		>=dev-libs/glib-2.43.90:2
+		>=net-libs/libsoup-2.49.91 )
+"
+DEPEND="${RDEPEND}
+	>=app-emulation/spice-protocol-0.12.14
+	dev-perl/Text-CSV
+	>=dev-util/gtk-doc-am-1.14
+	>=dev-util/intltool-0.40.0
+	>=sys-devel/gettext-0.17
+	virtual/pkgconfig
+	vala? ( $(vala_depend) )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.34-openssl11.patch
+	"${FILESDIR}"/${P}-libressl.patch
+)
+
+src_prepare() {
+	# bug 558558
+	export GIT_CEILING_DIRECTORIES="${WORKDIR}"
+	echo GIT_CEILING_DIRECTORIES=${GIT_CEILING_DIRECTORIES}
+
+	default
+
+	eautoreconf
+
+	use vala && vala_src_prepare
+}
+
+src_configure() {
+	# Prevent sandbox violations, bug #581836
+	# https://bugzilla.gnome.org/show_bug.cgi?id=744134
+	# https://bugzilla.gnome.org/show_bug.cgi?id=744135
+	addpredict /dev
+
+	# Clean up environment, bug #586642
+	xdg_environment_reset
+
+	local myconf
+
+	if use vala ; then
+		# force vala regen for MinGW, etc
+		rm -fv gtk/controller/controller.{c,vala.stamp} gtk/controller/menu.c
+	fi
+
+	myconf="
+		$(use_enable static-libs static)
+		$(use_enable introspection)
+		$(use_with sasl)
+		$(use_enable smartcard)
+		$(use_enable usbredir)
+		$(use_with usbredir usb-ids-path /usr/share/misc/usb.ids)
+		$(use_with usbredir usb-acl-helper-dir /usr/libexec)
+		$(use_with gtk3 gtk 3.0)
+		$(use_enable policykit polkit)
+		$(use_enable pulseaudio pulse)
+		$(use_enable gstaudio)
+		$(use_enable gstvideo)
+		$(use_enable mjpeg builtin-mjpeg)
+		$(use_enable vala)
+		$(use_enable webdav)
+		$(use_enable dbus)
+		--disable-celt051
+		--disable-gtk-doc
+		--disable-maintainer-mode
+		--disable-werror
+		--enable-pie"
+
+	econf ${myconf}
+}
+
+src_compile() {
+	# Prevent sandbox violations, bug #581836
+	# https://bugzilla.gnome.org/show_bug.cgi?id=744134
+	# https://bugzilla.gnome.org/show_bug.cgi?id=744135
+	addpredict /dev
+
+	default
+}
+
+src_install() {
+	default
+
+	dodoc AUTHORS ChangeLog NEWS README THANKS TODO
+
+	# Remove .la files if they're not needed
+	use static-libs || prune_libtool_files
+
+	make_desktop_entry spicy Spicy "utilities-terminal" "Network;RemoteAccess;"
+	readme.gentoo_create_doc
+}


### PR DESCRIPTION
NB: spice-gtk-0.34-libressl.patch was not used anywhere.

Closes: https://bugs.gentoo.org/664512
Package-Manager: Portage-2.3.60, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>