### PR TITLE
app-crypt/mit-krb5: add missing slot operator for libressl dependency

### DIFF
--- a/app-crypt/mit-krb5/mit-krb5-1.16.3.ebuild
+++ b/app-crypt/mit-krb5/mit-krb5-1.16.3.ebuild
@@ -33,7 +33,7 @@ CDEPEND="
 	openldap? ( >=net-nds/openldap-2.4.38-r1[${MULTILIB_USEDEP}] )
 	pkinit? (
 		!libressl? ( >=dev-libs/openssl-1.0.1h-r2:0=[${MULTILIB_USEDEP}] )
-		libressl? ( dev-libs/libressl[${MULTILIB_USEDEP}] )
+		libressl? ( dev-libs/libressl:0=[${MULTILIB_USEDEP}] )
 	)
 	xinetd? ( sys-apps/xinetd )
 	"


### PR DESCRIPTION
Package-Manager: Portage-2.3.60, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>