### PR TITLE
dev-libs/libevent: fix slot operator for libressl dependency

### DIFF
--- a/dev-libs/libevent/libevent-2.1.8-r1.ebuild
+++ b/dev-libs/libevent/libevent-2.1.8-r1.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit autotools eutils multilib-minimal
+
+DESCRIPTION="Library to execute a function when a specific event occurs on a file descriptor"
+HOMEPAGE="http://libevent.org/ https://github.com/libevent/libevent/"
+SRC_URI="https://github.com/${PN}/${PN}/releases/download/release-${PV}-stable/${P}-stable.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+# libevent-2.1.so.6
+SLOT="0/2.1-6"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="debug libressl +ssl static-libs test +threads"
+
+DEPEND="
+	ssl? (
+		!libressl? ( >=dev-libs/openssl-1.0.1h-r2:0=[${MULTILIB_USEDEP}] )
+		libressl? ( dev-libs/libressl:0=[${MULTILIB_USEDEP}] )
+	)
+"
+RDEPEND="
+	${DEPEND}
+	!<=dev-libs/9libs-1.0
+"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/event2/event-config.h
+)
+
+S=${WORKDIR}/${P}-stable
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	# fix out-of-source builds
+	mkdir -p test || die
+
+	ECONF_SOURCE="${S}" \
+	econf \
+		--disable-samples \
+		$(use_enable debug debug-mode) \
+		$(use_enable debug malloc-replacement) \
+		$(use_enable ssl openssl) \
+		$(use_enable static-libs static) \
+		$(use_enable test libevent-regress) \
+		$(use_enable threads thread-support)
+}
+
+src_test() {
+	# The test suite doesn't quite work (see bug #406801 for the latest
+	# installment in a riveting series of reports).
+	:
+	# emake -C test check | tee "${T}"/tests
+}
+
+DOCS=( ChangeLog{,-1.4,-2.0} )
+
+multilib_src_install_all() {
+	einstalldocs
+	prune_libtool_files
+}


### PR DESCRIPTION
No changes except the slot operator. Bump the revision since the ebuild is stable:

```
--- libevent-2.1.8.ebuild	2018-09-14 20:45:57.346940241 +0300
+++ libevent-2.1.8-r1.ebuild	2019-02-16 19:50:27.195153047 +0200
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,13 +11,13 @@
 LICENSE="BSD"
 # libevent-2.1.so.6
 SLOT="0/2.1-6"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="debug libressl +ssl static-libs test +threads"
 
 DEPEND="
 	ssl? (
 		!libressl? ( >=dev-libs/openssl-1.0.1h-r2:0=[${MULTILIB_USEDEP}] )
-		libressl? ( dev-libs/libressl:=[${MULTILIB_USEDEP}] )
+		libressl? ( dev-libs/libressl:0=[${MULTILIB_USEDEP}] )
 	)
 "
 RDEPEND="
```

Package-Manager: Portage-2.3.60, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>