### PR TITLE
app-crypt/easy-rsa: fix slot operators for dependencies

### DIFF
--- a/app-crypt/easy-rsa/easy-rsa-3.0.6.ebuild
+++ b/app-crypt/easy-rsa/easy-rsa-3.0.6.ebuild
@@ -12,8 +12,8 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 IUSE="libressl"
 
-DEPEND="!libressl? ( >=dev-libs/openssl-0.9.6:0 )
-	libressl? ( dev-libs/libressl )"
+DEPEND="!libressl? ( >=dev-libs/openssl-0.9.6:0= )
+	libressl? ( dev-libs/libressl:0= )"
 RDEPEND="${DEPEND}
 	!<net-vpn/openvpn-2.3"
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.60, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>