### PR TITLE
app-crypt/bcwipe: use HTTPS

### DIFF
--- a/app-crypt/bcwipe/bcwipe-1.9.13.ebuild
+++ b/app-crypt/bcwipe/bcwipe-1.9.13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 MY_PV="$(ver_rs 2- -)"
 
 DESCRIPTION="Secure file removal utility"
-HOMEPAGE="http://www.jetico.com/"
+HOMEPAGE="https://www.jetico.com/"
 SRC_URI="https://www.jetico.com/linux/BCWipe-${MY_PV}.tar.gz
 	doc? ( http://www.jetico.com/linux/BCWipe.doc.tgz )"
 


### PR DESCRIPTION
Hi,

This is a simple PR to update the ebuild to use https instead of http.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>