### PR TITLE
Kde prep

### DIFF
--- a/dev-lang/sassc/sassc-3.5.0.ebuild
+++ b/dev-lang/sassc/sassc-3.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ if [[ ${PV} = *9999 ]]; then
 	KEYWORDS=
 else
 	SRC_URI="https://github.com/sass/sassc/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux"
 fi
 
 DESCRIPTION="A libsass command line driver"

--- a/dev-libs/libsass/libsass-3.5.2.ebuild
+++ b/dev-libs/libsass/libsass-3.5.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ if [[ ${PV} = *9999 ]]; then
 	KEYWORDS=
 else
 	SRC_URI="https://github.com/sass/libsass/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux"
 fi
 
 DESCRIPTION="A C/C++ implementation of a Sass CSS compiler"

--- a/dev-python/twisted-words/twisted-words-15.2.1.ebuild
+++ b/dev-python/twisted-words/twisted-words-15.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ inherit twisted-r1
 
 DESCRIPTION="Twisted Words contains Instant Messaging implementations"
 
-KEYWORDS="~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 IUSE=""
 
 DEPEND="

--- a/dev-qt/qtimageformats/qtimageformats-5.11.3.ebuild
+++ b/dev-qt/qtimageformats/qtimageformats-5.11.3.ebuild
@@ -7,7 +7,7 @@ inherit qt5-build
 DESCRIPTION="Additional format plugins for the Qt image I/O system"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 ~arm ~hppa ppc64 ~sparc x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~hppa ppc64 ~sparc x86"
 fi
 
 IUSE="jpeg2k mng"

--- a/dev-qt/qtspeech/qtspeech-5.11.3.ebuild
+++ b/dev-qt/qtspeech/qtspeech-5.11.3.ebuild
@@ -7,7 +7,7 @@ inherit qt5-build
 DESCRIPTION="Text-to-speech library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 x86"
+	KEYWORDS="amd64 ~arm64 x86"
 fi
 
 # TODO: flite plugin - needs 2.0.0 (not yet in tree)

--- a/games-board/gnugo/gnugo-3.9.1-r2.ebuild
+++ b/games-board/gnugo/gnugo-3.9.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~arm ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="amd64 ~arm ~arm64 ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="readline"
 
 RDEPEND="

--- a/media-fonts/kanjistrokeorders/kanjistrokeorders-4.002.ebuild
+++ b/media-fonts/kanjistrokeorders/kanjistrokeorders-4.002.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2009-2018 Gentoo Authors
+# Copyright 2009-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -13,7 +13,7 @@ SRC_URI="https://sites.google.com/site/nihilistorguk/${MY_P}.zip"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE=""
 RESTRICT="binchecks"
 

--- a/media-libs/id3lib/id3lib-3.8.3-r8.ebuild
+++ b/media-libs/id3lib/id3lib-3.8.3-r8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P/_}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos ~x86-solaris"
 IUSE="doc static-libs"
 
 RDEPEND="sys-libs/zlib:="

--- a/media-libs/libebur128/libebur128-1.2.3.ebuild
+++ b/media-libs/libebur128/libebur128-1.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/jiixyj/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="MIT"
 SLOT="0/1"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 sparc x86"
 IUSE="static-libs test"
 
 DEPEND="test? ( app-arch/unzip

--- a/media-libs/mlt/mlt-6.12.0-r1.ebuild
+++ b/media-libs/mlt/mlt-6.12.0-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://github.com/mltframework/${PN}/releases/download/v${PV}/${P}.tar
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="compressed-lumas cpu_flags_x86_mmx cpu_flags_x86_sse cpu_flags_x86_sse2 debug ffmpeg fftw frei0r
 gtk jack kdenlive libav libsamplerate lua melt opencv opengl python qt5 rtaudio ruby sdl vdpau xine xml"
 # java perl php tcl vidstab

--- a/media-libs/qt-gstreamer/qt-gstreamer-1.2.0-r4.ebuild
+++ b/media-libs/qt-gstreamer/qt-gstreamer-1.2.0-r4.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 if [[ ${PV} != *9999* ]]; then
 	SRC_URI="https://gstreamer.freedesktop.org/src/qt-gstreamer/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~ppc ~ppc64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc ~ppc64 x86"
 else
 	EGIT_REPO_URI="https://anongit.freedesktop.org/git/gstreamer/qt-gstreamer.git"
 	inherit git-r3

--- a/media-libs/rtaudio/rtaudio-5.0.0.ebuild
+++ b/media-libs/rtaudio/rtaudio-5.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="https://www.music.mcgill.ca/~gary/${PN}/release/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/6"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+alsa doc jack pulseaudio static-libs"
 REQUIRED_USE="|| ( alsa jack pulseaudio )"
 

--- a/media-libs/sdl2-image/sdl2-image-2.0.4.ebuild
+++ b/media-libs/sdl2-image/sdl2-image-2.0.4.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://www.libsdl.org/projects/SDL_image/release/${MY_P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE="gif jpeg png static-libs tiff webp"
 
 RDEPEND="

--- a/media-video/movit/movit-1.6.2.ebuild
+++ b/media-video/movit/movit-1.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -16,7 +16,7 @@ SRC_URI="http://movit.sesse.net/${P}.tar.gz
 LICENSE="GPL-2+"
 SLOT="0"
 
-KEYWORDS="~amd64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 IUSE=""
 
 RDEPEND="media-libs/mesa

--- a/media-video/transcode/transcode-1.1.7-r3.ebuild
+++ b/media-video/transcode/transcode-1.1.7-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="https://www.bitbucket.org/france/${PN}-tcforge/downloads/${P}.tar.bz2
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 ppc ppc64 sparc x86"
+KEYWORDS="alpha amd64 ~arm64 ppc ppc64 sparc x86"
 IUSE="cpu_flags_x86_3dnow a52 aac alsa altivec dv dvd +iconv imagemagick jpeg lzo mjpeg cpu_flags_x86_mmx mp3 mpeg nuv ogg oss pic postproc quicktime sdl cpu_flags_x86_sse cpu_flags_x86_sse2 theora truetype v4l vorbis X x264 xml xvid"
 
 RDEPEND="

--- a/net-im/telepathy-connection-managers/telepathy-connection-managers-2-r2.ebuild
+++ b/net-im/telepathy-connection-managers/telepathy-connection-managers-2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -9,7 +9,7 @@ SRC_URI=""
 LICENSE="metapackage"
 SLOT="0"
 
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
 
 IUSE="gadu icq +irc meanwhile msn sip sipe +xmpp yahoo steam zeroconf"
 

--- a/net-im/telepathy-logger/telepathy-logger-0.8.2.ebuild
+++ b/net-im/telepathy-logger/telepathy-logger-0.8.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -13,7 +13,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1+"
 SLOT="0/3"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
 IUSE="+introspection"
 
 RDEPEND="

--- a/net-irc/telepathy-idle/telepathy-idle-0.2.0.ebuild
+++ b/net-irc/telepathy-idle/telepathy-idle-0.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
 IUSE="test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 

--- a/net-libs/accounts-qt/accounts-qt-1.15.ebuild
+++ b/net-libs/accounts-qt/accounts-qt-1.15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="https://gitlab.com/accounts-sso/libaccounts-qt/repository/VERSION_1.15/
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE="doc test"
 
 # dbus problems

--- a/net-libs/libaccounts-glib/libaccounts-glib-1.23.ebuild
+++ b/net-libs/libaccounts-glib/libaccounts-glib-1.23.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="https://gitlab.com/accounts-sso/libaccounts-glib/repository/archive.tar
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE="debug"
 
 RDEPEND="

--- a/net-libs/libgadu/libgadu-1.12.2.ebuild
+++ b/net-libs/libgadu/libgadu-1.12.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -12,7 +12,7 @@ HOMEPAGE="http://toxygen.net/libgadu/"
 SRC_URI="https://github.com/wojtekka/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
-KEYWORDS="amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
 SLOT="0"
 IUSE="doc gnutls ssl static-libs test threads"
 

--- a/net-libs/libotr/libotr-4.1.1.ebuild
+++ b/net-libs/libotr/libotr-4.1.1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://otr.cypherpunks.ca/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm hppa ~ia64 ppc ppc64 ~s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ~ia64 ppc ppc64 ~s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""
 
 RDEPEND=">=dev-libs/libgcrypt-1.2:0

--- a/net-libs/libsignon-glib/libsignon-glib-1.14.ebuild
+++ b/net-libs/libsignon-glib/libsignon-glib-1.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ SRC_URI="https://gitlab.com/accounts-sso/libsignon-glib/repository/archive.tar.g
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE="debug doc +introspection python test"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} introspection )"

--- a/net-libs/signon-oauth2/signon-oauth2-0.24.ebuild
+++ b/net-libs/signon-oauth2/signon-oauth2-0.24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ SRC_URI="https://gitlab.com/accounts-sso/${MY_PN}/-/archive/${MY_PV}/${MY_PN}-${
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE="test"
 
 RDEPEND="

--- a/net-libs/signon-ui/signon-ui-0.15_p20171022.ebuild
+++ b/net-libs/signon-ui/signon-ui-0.15_p20171022.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://gitlab.com/accounts-sso/${PN}/-/archive/${COMMIT}/${PN}-${COMMI
 
 LICENSE="GPL-2 GPL-3"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE="test"
 
 BDEPEND="test? ( dev-qt/qttest:5 )"

--- a/net-libs/signond/signond-8.59-r1.ebuild
+++ b/net-libs/signond/signond-8.59-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="https://gitlab.com/accounts-sso/signond/repository/archive.tar.gz?ref=V
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE="doc test"
 
 RESTRICT="test"

--- a/net-libs/sofia-sip/sofia-sip-1.12.11.ebuild
+++ b/net-libs/sofia-sip/sofia-sip-1.12.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -9,7 +9,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+ BSD public-domain" # See COPYRIGHT
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ia64 ppc ~ppc64 sparc x86 ~x86-linux"
+KEYWORDS="alpha amd64 ~arm ~arm64 ia64 ppc ~ppc64 sparc x86 ~x86-linux"
 IUSE="libressl ssl static-libs"
 
 RDEPEND="dev-libs/glib:2

--- a/net-libs/telepathy-accounts-signon/telepathy-accounts-signon-1.0.ebuild
+++ b/net-libs/telepathy-accounts-signon/telepathy-accounts-signon-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ SRC_URI="https://dev.gentoo.org/~johu/distfiles/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE=""
 
 DEPEND="

--- a/net-libs/telepathy-farstream/telepathy-farstream-0.6.2.ebuild
+++ b/net-libs/telepathy-farstream/telepathy-farstream-0.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -12,7 +12,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/3"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86"
 IUSE="examples +introspection"
 
 RDEPEND="

--- a/net-libs/telepathy-logger-qt/telepathy-logger-qt-17.08.0.ebuild
+++ b/net-libs/telepathy-logger-qt/telepathy-logger-qt-17.08.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ HOMEPAGE="https://cgit.kde.org/telepathy-logger-qt.git"
 
 if [[ ${KDE_BUILD_TYPE} = release ]]; then
 	SRC_URI="mirror://kde/stable/telepathy-logger-qt/${PV%.*}/src/${P}.tar.xz"
-	KEYWORDS="amd64 x86"
+	KEYWORDS="amd64 ~arm64 x86"
 fi
 
 LICENSE="LGPL-2.1"

--- a/net-libs/telepathy-qt/telepathy-qt-0.9.7-r1.ebuild
+++ b/net-libs/telepathy-qt/telepathy-qt-0.9.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE="debug farstream"
 
 RDEPEND="

--- a/net-misc/freerdp/freerdp-2.0.0_rc4.ebuild
+++ b/net-misc/freerdp/freerdp-2.0.0_rc4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,7 +9,7 @@ if [[ ${PV} != 9999 ]]; then
 	MY_P=${P/_/-}
 	S="${WORKDIR}/${MY_P}"
 	SRC_URI="https://pub.freerdp.com/releases/${MY_P}.tar.gz"
-	KEYWORDS="alpha amd64 arm ~ppc ~ppc64 x86"
+	KEYWORDS="alpha amd64 arm ~arm64 ~ppc ~ppc64 x86"
 else
 	inherit git-r3
 	SRC_URI=""

--- a/net-voip/telepathy-gabble/telepathy-gabble-0.18.4.ebuild
+++ b/net-voip/telepathy-gabble/telepathy-gabble-0.18.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
 IUSE="gnutls +jingle libressl plugins test"
 
 # Prevent false positives due nested configure

--- a/net-voip/telepathy-haze/telepathy-haze-0.8.0-r2.ebuild
+++ b/net-voip/telepathy-haze/telepathy-haze-0.8.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="

--- a/net-voip/telepathy-rakia/telepathy-rakia-0.8.0.ebuild
+++ b/net-voip/telepathy-rakia/telepathy-rakia-0.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -13,7 +13,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
 IUSE="test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 

--- a/net-voip/telepathy-salut/telepathy-salut-0.8.1-r2.ebuild
+++ b/net-voip/telepathy-salut/telepathy-salut-0.8.1-r2.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ~ia64 ppc ~ppc64 sparc x86 ~x86-linux"
+KEYWORDS="alpha amd64 ~arm ~arm64 ~ia64 ppc ~ppc64 sparc x86 ~x86-linux"
 IUSE="gnutls test"
 
 RDEPEND="

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -136,7 +136,6 @@ mate-base/mate help
 mate-base/mate-applets-meta appindicator sensors
 mate-extra/caja-extensions gajim
 net-fs/samba dmapi
-net-im/pidgin gadu
 net-misc/ntpsec rclock_oncore rclock_pps
 sci-libs/gdal armadillo netcdf
 sys-fs/btrfs-progs reiserfs

--- a/sci-chemistry/chemical-mime-data/chemical-mime-data-0.1.94-r3.ebuild
+++ b/sci-chemistry/chemical-mime-data/chemical-mime-data-0.1.94-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN/-data/}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm ~arm64 x86"
 IUSE=""
 
 RDEPEND="

--- a/sys-fs/cryfs/cryfs-0.9.9.ebuild
+++ b/sys-fs/cryfs/cryfs-0.9.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,7 +23,7 @@ if [[ "${PV}" == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/cryfs/cryfs"
 else
 	SRC_URI="https://github.com/cryfs/cryfs/releases/download/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm x86"
+	KEYWORDS="amd64 ~arm ~arm64 x86"
 	S="${WORKDIR}"
 fi
 

--- a/www-client/falkon/falkon-3.0.1-r1.ebuild
+++ b/www-client/falkon/falkon-3.0.1-r1.ebuild
@@ -15,7 +15,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE="dbus gnome-keyring kwallet libressl +X"
 
 COMMON_DEPEND="


### PR DESCRIPTION
Team, particularly KDE team. These 39 of these 40 commits add ~arm64 to everything in my package.accept_keywords/kde that does not have kde in its name. Its required to bring kde to ~arm64.

All the existing features that repoman shouted at me for, EAPI 5, games, etc., are still there.  They are mostly beyond my ebuild skills to fix anyway.

The odd commit is a change to package use mask to allow repoman to accept net-im/telepathy-connection-managers.

This PR is required before I can start PRs on KDE. 
 