### PR TITLE
mail-mta/postfix: Linux 5 support

### DIFF
--- a/mail-mta/postfix/files/postfix-linux-5.patch
+++ b/mail-mta/postfix/files/postfix-linux-5.patch
@@ -1,0 +1,23 @@
+See http://postfix.1071664.n5.nabble.com/Support-for-quot-Linux-5-quot-td99786.html
+--- a/makedefs	2018-02-03 12:20:46.000000000 -0500
++++ b/makedefs	2019-02-18 15:39:17.711376206 -0500
+@@ -546,7 +546,7 @@
+ 		: ${SHLIB_ENV="LD_LIBRARY_PATH=`pwd`/lib"}
+ 		: ${PLUGIN_LD="${CC-gcc} -shared"}
+ 		;;
+-  Linux.[34].*)	SYSTYPE=LINUX$RELEASE_MAJOR
++  Linux.[345].*)	SYSTYPE=LINUX$RELEASE_MAJOR
+ 		case "$CCARGS" in
+ 		 *-DNO_DB*) ;;
+ 		 *-DHAS_DB*) ;;
+--- a/src/util/sys_defs.h	2019-02-18 15:40:19.008167828 -0500
++++ b/src/util/sys_defs.h	2019-02-18 15:42:17.241742169 -0500
+@@ -748,7 +748,7 @@
+  /*
+   * LINUX.
+   */
+-#if defined(LINUX2) || defined(LINUX3) || defined(LINUX4)
++#if defined(LINUX2) || defined(LINUX3) || defined(LINUX4) || defined(LINUX5)
+ #define SUPPORTED
+ #define UINT32_TYPE	unsigned int
+ #define UINT16_TYPE	unsigned short

--- a/mail-mta/postfix/postfix-3.3.2-r1.ebuild
+++ b/mail-mta/postfix/postfix-3.3.2-r1.ebuild
@@ -59,6 +59,10 @@ REQUIRED_USE="ldap-bind? ( ldap sasl )"
 
 S="${WORKDIR}/${MY_SRC}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-linux-5.patch"
+)
+
 pkg_setup() {
 	# Add postfix, postdrop user/group (bug #77565)
 	enewgroup postfix 207

--- a/mail-mta/postfix/postfix-3.4_pre20190129.ebuild
+++ b/mail-mta/postfix/postfix-3.4_pre20190129.ebuild
@@ -59,6 +59,10 @@ REQUIRED_USE="ldap-bind? ( ldap sasl )"
 
 S="${WORKDIR}/${MY_SRC}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-linux-5.patch"
+)
+
 pkg_setup() {
 	# Add postfix, postdrop user/group (bug #77565)
 	enewgroup postfix 207


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/678326
Package-Manager: Portage-2.3.61, Repoman-2.3.12
Signed-off-by: Craig Andrews <candrews@gentoo.org>