### PR TITLE
eclass/webapp.eclass: fix install with EAPI=7

### DIFF
--- a/eclass/webapp.eclass
+++ b/eclass/webapp.eclass
@@ -42,9 +42,9 @@ IS_REPLACE=0
 INSTALL_CHECK_FILE="installed_by_webapp_eclass"
 SETUP_CHECK_FILE="setup_by_webapp_eclass"
 
-ETC_CONFIG="${ROOT}etc/vhosts/webapp-config"
-WEBAPP_CONFIG="${ROOT}usr/sbin/webapp-config"
-WEBAPP_CLEANER="${ROOT}usr/sbin/webapp-cleaner"
+ETC_CONFIG="${ROOT%/}/etc/vhosts/webapp-config"
+WEBAPP_CONFIG="${ROOT%/}/usr/sbin/webapp-config"
+WEBAPP_CLEANER="${ROOT%/}/usr/sbin/webapp-cleaner"
 
 # ==============================================================================
 # INTERNAL FUNCTIONS
@@ -365,7 +365,7 @@ webapp_src_preinst() {
 # @DESCRIPTION:
 # The default pkg_setup() for this eclass. This will gather required variables
 # from webapp-config and check if there is an application installed to
-# `${ROOT}/var/www/localhost/htdocs/${PN}/' if USE=vhosts is not set.
+# `${ROOT%/}/var/www/localhost/htdocs/${PN}/' if USE=vhosts is not set.
 #
 # You need to call this function BEFORE anything else has run in your custom
 # pkg_setup().
@@ -389,7 +389,7 @@ webapp_pkg_setup() {
 	G_HOSTNAME="localhost"
 	webapp_read_config
 
-	local my_dir="${ROOT}${VHOST_ROOT}/${MY_HTDOCSBASE}/${PN}"
+	local my_dir="${ROOT%/}/${VHOST_ROOT}/${MY_HTDOCSBASE}/${PN}"
 
 	# if USE=vhosts is enabled OR no application is installed we're done here
 	if ! has vhosts ${IUSE} || use vhosts || [[ ! -d "${my_dir}" ]]; then
@@ -453,7 +453,7 @@ webapp_src_install() {
 # @FUNCTION: webapp_pkg_postinst
 # @DESCRIPTION:
 # The default pkg_postinst() for this eclass. This installs the web application to
-# `${ROOT}/var/www/localhost/htdocs/${PN}/' if USE=vhosts is not set. Otherwise
+# `${ROOT%/}/var/www/localhost/htdocs/${PN}/' if USE=vhosts is not set. Otherwise
 # display a short notice how to install this application with webapp-config.
 #
 # You need to call this function AFTER everything else has run in your custom
@@ -464,7 +464,7 @@ webapp_pkg_postinst() {
 	webapp_read_config
 
 	# sanity checks, to catch bugs in the ebuild
-	if [[ ! -f "${ROOT}${MY_APPDIR}/${INSTALL_CHECK_FILE}" ]]; then
+	if [[ ! -f "${ROOT%/}/${MY_APPDIR}/${INSTALL_CHECK_FILE}" ]]; then
 		eerror
 		eerror "This ebuild did not call webapp_src_install() at the end"
 		eerror "of the src_install() function"


### PR DESCRIPTION
Starting with EAPI=7 the ROOT variable does not contain any trailing
slash anymore, so it need's to be adjusted to work with EAPI=7, while
maintaining compatibility with older EAPI.

Closes: https://bugs.gentoo.org/671258

@a17r As spoken, here is the PR.