### PR TITLE
sys-cluster/util-vserver Fix: dietlibc headers patch

### DIFF
--- a/sys-cluster/util-vserver/files/util-vserver-0.30.216-pre3120-dietlibc.patch
+++ b/sys-cluster/util-vserver/files/util-vserver-0.30.216-pre3120-dietlibc.patch
@@ -1,0 +1,23 @@
+diff -puriN util-vserver-0.30.216-pre3120.orig/lib_internal/util-cleanupmount.c util-vserver-0.30.216-pre3120/lib_internal/util-cleanupmount.c
+--- util-vserver-0.30.216-pre3120.orig/lib_internal/util-cleanupmount.c	2015-05-30 10:18:50.000000000 -0500
++++ util-vserver-0.30.216-pre3120/lib_internal/util-cleanupmount.c	2019-02-19 02:36:55.000000000 -0600
+@@ -22,7 +22,6 @@
+ 
+ #include <stdio.h>
+ #include <sys/mount.h>
+-#include <linux/fs.h>
+ 
+ #ifndef MS_REC
+ #define MS_REC		0x4000
+diff -puriN util-vserver-0.30.216-pre3120.orig/src/secure-mount.c util-vserver-0.30.216-pre3120/src/secure-mount.c
+--- util-vserver-0.30.216-pre3120.orig/src/secure-mount.c	2015-05-30 10:18:50.000000000 -0500
++++ util-vserver-0.30.216-pre3120/src/secure-mount.c	2019-02-19 02:37:17.000000000 -0600
+@@ -46,7 +46,7 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <sys/file.h>
+-#include <linux/fs.h>
++#include <limits.h>
+ #include <assert.h>
+ #include <ctype.h>
+ #include <sys/wait.h>

--- a/sys-cluster/util-vserver/util-vserver-0.30.216_pre3120-r1.ebuild
+++ b/sys-cluster/util-vserver/util-vserver-0.30.216_pre3120-r1.ebuild
@@ -30,6 +30,8 @@ RDEPEND="
 
 S="${WORKDIR}/${MY_P}"
 
+PATCHES="${FILESDIR}/util-vserver-0.30.216-pre3120-dietlibc.patch "
+
 DOCS=( README ChangeLog NEWS AUTHORS THANKS util-vserver.spec )
 
 pkg_setup() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/650578 
This patch replaces the conflicting glibc headers with dietlibc's. 