### PR TITLE
New LibreOffice versions require libexttextcat 3.4.1 or newer

### DIFF
--- a/app-office/libreoffice/libreoffice-6.1.4.2.ebuild
+++ b/app-office/libreoffice/libreoffice-6.1.4.2.ebuild
@@ -89,7 +89,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=app-text/libebook-0.1
 	app-text/libepubgen
 	>=app-text/libetonyek-0.1
-	app-text/libexttextcat
+	>=app-text/libexttextcat-3.4.1
 	app-text/liblangtag
 	>=app-text/libmspub-0.1.0
 	>=app-text/libmwaw-0.3.1

--- a/app-office/libreoffice/libreoffice-6.1.5.2.ebuild
+++ b/app-office/libreoffice/libreoffice-6.1.5.2.ebuild
@@ -89,7 +89,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=app-text/libebook-0.1
 	app-text/libepubgen
 	>=app-text/libetonyek-0.1
-	app-text/libexttextcat
+	>=app-text/libexttextcat-3.4.1
 	app-text/liblangtag
 	>=app-text/libmspub-0.1.0
 	>=app-text/libmwaw-0.3.1

--- a/app-office/libreoffice/libreoffice-6.2.1.1.ebuild
+++ b/app-office/libreoffice/libreoffice-6.2.1.1.ebuild
@@ -89,7 +89,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=app-text/libebook-0.1
 	app-text/libepubgen
 	>=app-text/libetonyek-0.1
-	app-text/libexttextcat
+	>=app-text/libexttextcat-3.4.1
 	app-text/liblangtag
 	>=app-text/libmspub-0.1.0
 	>=app-text/libmwaw-0.3.1

--- a/app-office/libreoffice/libreoffice-6.2.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-6.2.9999.ebuild
@@ -88,7 +88,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=app-text/libebook-0.1
 	app-text/libepubgen
 	>=app-text/libetonyek-0.1
-	app-text/libexttextcat
+	>=app-text/libexttextcat-3.4.1
 	app-text/liblangtag
 	>=app-text/libmspub-0.1.0
 	>=app-text/libmwaw-0.3.1

--- a/app-office/libreoffice/libreoffice-9999.ebuild
+++ b/app-office/libreoffice/libreoffice-9999.ebuild
@@ -88,7 +88,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=app-text/libebook-0.1
 	app-text/libepubgen
 	>=app-text/libetonyek-0.1
-	app-text/libexttextcat
+	>=app-text/libexttextcat-3.4.1
 	app-text/liblangtag
 	>=app-text/libmspub-0.1.0
 	>=app-text/libmwaw-0.3.1


### PR DESCRIPTION
```
checking which libexttextcat to use... external
checking for LIBEXTTEXTCAT... no
configure: error: Package requirements (libexttextcat >= 3.4.1) were not met:

Requested 'libexttextcat >= 3.4.1' but version of libexttextcat is 3.4.0

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables LIBEXTTEXTCAT_CFLAGS
and LIBEXTTEXTCAT_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```