### PR TITLE
media-libs/libsfml: use HTTPS

### DIFF
--- a/media-libs/libsfml/libsfml-2.5.1.ebuild
+++ b/media-libs/libsfml/libsfml-2.5.1.ebuild
@@ -7,7 +7,7 @@ inherit cmake-utils eapi7-ver
 MY_P="SFML-${PV}"
 
 DESCRIPTION="Simple and Fast Multimedia Library (SFML)"
-HOMEPAGE="http://www.sfml-dev.org/ https://github.com/SFML/SFML"
+HOMEPAGE="https://www.sfml-dev.org/ https://github.com/SFML/SFML"
 SRC_URI="https://github.com/SFML/SFML/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="ZLIB"


### PR DESCRIPTION
Hi,
A simple PR to use https instead of http.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>