### PR TITLE
dev-cpp/commoncpp2: add patch for openssl-1.1 and libressl support

### DIFF
--- a/dev-cpp/commoncpp2/commoncpp2-1.8.1-r4.ebuild
+++ b/dev-cpp/commoncpp2/commoncpp2-1.8.1-r4.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.gnu.org/software/commoncpp/"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
-IUSE="debug doc examples ipv6 gnutls ssl static-libs"
+IUSE="debug doc examples gnutls ipv6 libressl ssl static-libs"
 
 RDEPEND="
 	sys-libs/zlib
@@ -20,7 +20,10 @@ RDEPEND="
 			dev-libs/libgcrypt:0=
 			net-libs/gnutls:=
 		)
-		!gnutls? ( dev-libs/openssl:0= )
+		!gnutls? (
+			!libressl? ( dev-libs/openssl:0= )
+			libressl? ( dev-libs/libressl:0= )
+		)
 	)"
 DEPEND="${RDEPEND}
 	doc? ( >=app-doc/doxygen-1.3.6 )"

--- a/dev-cpp/commoncpp2/commoncpp2-1.8.1-r4.ebuild
+++ b/dev-cpp/commoncpp2/commoncpp2-1.8.1-r4.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools eutils
+
+DESCRIPTION="C++ library offering portable support for system-related services"
+SRC_URI="mirror://gnu/commoncpp/${P}.tar.gz"
+HOMEPAGE="https://www.gnu.org/software/commoncpp/"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE="debug doc examples ipv6 gnutls ssl static-libs"
+
+RDEPEND="
+	sys-libs/zlib
+	ssl? (
+		gnutls? (
+			dev-libs/libgcrypt:0=
+			net-libs/gnutls:=
+		)
+		!gnutls? ( dev-libs/openssl:0= )
+	)"
+DEPEND="${RDEPEND}
+	doc? ( >=app-doc/doxygen-1.3.6 )"
+
+HTML_DOCS=()
+
+PATCHES=(
+	"${FILESDIR}/1.8.1-configure_detect_netfilter.patch"
+	"${FILESDIR}/1.8.0-glibc212.patch"
+	"${FILESDIR}/1.8.1-autoconf-update.patch"
+	"${FILESDIR}/1.8.1-fix-buffer-overflow.patch"
+	"${FILESDIR}/1.8.1-parallel-build.patch"
+	"${FILESDIR}/1.8.1-libgcrypt.patch"
+	"${FILESDIR}/1.8.1-fix-c++14.patch"
+	"${FILESDIR}/1.8.1-gnutls-3.4.patch"
+	"${FILESDIR}/1.8.1-libressl.patch" # bug 674416
+)
+
+pkg_setup() {
+	use doc && HTML_DOCS+=( doc/html/. )
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	use ssl && local myconf=( $(usex gnutls '--with-gnutls' '--with-openssl') )
+
+	econf \
+		$(use_enable debug) \
+		$(use_with ipv6) \
+		$(use_enable static-libs static) \
+		$(use_with doc doxygen) \
+		"${myconf[@]}"
+}
+
+src_install () {
+	default
+	prune_libtool_files
+
+	dodoc COPYING.addendum
+
+	if use examples; then
+		docinto examples
+		dodoc demo/{*.cpp,*.h,*.xml,README}
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+}

--- a/dev-cpp/commoncpp2/files/1.8.1-libressl.patch
+++ b/dev-cpp/commoncpp2/files/1.8.1-libressl.patch
@@ -1,0 +1,15 @@
+Upstream-Status: Submitted [bug-commoncpp@gnu.org]
+
+diff --git a/src/ssl.cpp b/src/ssl.cpp
+index 5bf526d..3cd7040 100644
+--- a/src/ssl.cpp
++++ b/src/ssl.cpp
+@@ -386,7 +386,7 @@ bool SSLStream::getSession(void)
+     if(so == INVALID_SOCKET)
+         return false;
+ 
+-    ctx = SSL_CTX_new(SSLv3_client_method());
++    ctx = SSL_CTX_new(SSLv23_client_method());
+     if(!ctx) {
+         SSL_CTX_free(ctx);
+         return false;


### PR DESCRIPTION
SSLv3_client_method() is deprecated in openssl-1.1 and libressl.
They suggest to use SSLv23_client_method.

dev-cpp/commoncpp2: add USE=libressl

Closes: https://bugs.gentoo.org/674416
Closes: https://bugs.gentoo.org/678440

@flappyports 