### PR TITLE
media-fonts/arabeyes-fonts: EAPI6, fix HOMEPAGE

### DIFF
--- a/media-fonts/arabeyes-fonts/arabeyes-fonts-2.0-r1.ebuild
+++ b/media-fonts/arabeyes-fonts/arabeyes-fonts-2.0-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit font
+
+MY_PN="ae_fonts"
+S="${WORKDIR}"/${MY_PN}_${PV}
+
+DESCRIPTION="Arabeyes Arabic TrueType fonts"
+HOMEPAGE="https://www.arabeyes.org/Khotot#2.0"
+SRC_URI="mirror://sourceforge/arabeyes/${MY_PN}_${PV}.tar.bz2"
+LICENSE="GPL-2"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~s390 ~sh ~sparc ~x86 ~x86-fbsd"
+
+FONT_SUFFIX="ttf"
+
+DOCS="README ChangeLog"
+
+src_install() {
+	local d
+	for d in AAHS AGA FS Kasr MCS Shmookh; do
+		FONT_S="${S}"/$d
+		font_src_install
+	done
+}


### PR DESCRIPTION
Hi,
This Bug/PR updates media-fonts/arabeyes-fonts for EAPI6 and fixes the HOMEPAGE"

Please review.

Closes: https://bugs.gentoo.org/678592
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>