### PR TITLE
dev-util/ftnchek: EAPI7, use HTTPs

### DIFF
--- a/dev-util/ftnchek/ftnchek-3.3.1-r1.ebuild
+++ b/dev-util/ftnchek/ftnchek-3.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="2"
@@ -6,8 +6,8 @@ EAPI="2"
 inherit autotools
 
 DESCRIPTION="Static analyzer a la 'lint' for Fortran 77"
-HOMEPAGE="http://www.dsm.fordham.edu/~ftnchek/"
-SRC_URI="http://www.dsm.fordham.edu/~${PN}/download/${P}.tar.gz"
+HOMEPAGE="https://www.dsm.fordham.edu/~ftnchek/"
+SRC_URI="https://www.dsm.fordham.edu/~${PN}/download/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-util/ftnchek/ftnchek-3.3.1-r2.ebuild
+++ b/dev-util/ftnchek/ftnchek-3.3.1-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Static analyzer a la 'lint' for Fortran 77"
+HOMEPAGE="https://www.dsm.fordham.edu/~ftnchek/"
+SRC_URI="https://www.dsm.fordham.edu/~${PN}/download/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+src_prepare() {
+	default
+	mv configure.{in,ac} || die
+	mv dcl2inc.{man,1} || die
+
+	#1 Do not strip
+	#2 CFLAGS is used internally, so append to it
+	sed -i Makefile.in \
+		-e '/-$(STRIP)/d' \
+		-e 's|CFLAGS\([[:space:]]*\)=|CFLAGS\1+=|' \
+		|| die "sed Makefile.in"
+
+	#1 Respect CFLAGS
+	#2 Respect LDFLAGS
+	sed -i configure.ac \
+		-e 's|OPT=".*"|OPT=""|g' \
+		-e '/^LDFLAGS=/d' \
+		|| die "sed configure.ac"
+
+	eautoreconf
+}
+
+src_install() {
+	dobin ${PN} dcl2inc
+	doman ${PN}.1 dcl2inc.1
+	insinto /usr/share/${PN}
+	doins dcl2inc.awk
+	doins -r test
+	dodoc FAQ PATCHES README ToDo
+	docinto html
+	dodoc -r html/*
+}


### PR DESCRIPTION
Hi,

This Bug/PR updates dev-util/ftnchek for EAPI7 with some minor improvements.
Also uses https instead of http.

Please review.

Closes: https://bugs.gentoo.org/678598
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>