### PR TITLE
net-vpn/openvpn: add patch to fix build with LibreSSL

### DIFF
--- a/net-vpn/openvpn/files/openvpn-2.4.7-libressl.patch
+++ b/net-vpn/openvpn/files/openvpn-2.4.7-libressl.patch
@@ -1,0 +1,49 @@
+From 4faf695e3c42a81131c2aae96c4a60228aa237a5 Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <stefan.strogin@gmail.com>
+Date: Sat, 23 Feb 2019 20:13:41 +0200
+Subject: [PATCH] Fix compilation with LibreSSL
+
+TLS 1.3 is not ready yet in LibreSSL.
+Also SSL_get1_supported_ciphers() has been just added into master (not yet
+released).
+
+Upstream-Status: Submitted [https://github.com/OpenVPN/openvpn/pull/123]
+Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>
+---
+ src/openvpn/ssl_openssl.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/openvpn/ssl_openssl.c b/src/openvpn/ssl_openssl.c
+index a78dae99..6a8fcef3 100644
+--- a/src/openvpn/ssl_openssl.c
++++ b/src/openvpn/ssl_openssl.c
+@@ -459,7 +459,7 @@ tls_ctx_restrict_ciphers_tls13(struct tls_root_ctx *ctx, const char *ciphers)
+         return;
+     }
+ 
+-#if (OPENSSL_VERSION_NUMBER < 0x1010100fL)
++#if (OPENSSL_VERSION_NUMBER < 0x1010100fL) || defined(LIBRESSL_VERSION_NUMBER)
+         crypto_msg(M_WARN, "Not compiled with OpenSSL 1.1.1 or higher. "
+                        "Ignoring TLS 1.3 only tls-ciphersuites '%s' setting.",
+                         ciphers);
+@@ -1846,7 +1846,7 @@ show_available_tls_ciphers_list(const char *cipher_list,
+         crypto_msg(M_FATAL, "Cannot create SSL_CTX object");
+     }
+ 
+-#if (OPENSSL_VERSION_NUMBER >= 0x1010100fL)
++#if (OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(LIBRESSL_VERSION_NUMBER))
+     if (tls13)
+     {
+         SSL_CTX_set_min_proto_version(tls_ctx.ctx, TLS1_3_VERSION);
+@@ -1867,7 +1867,7 @@ show_available_tls_ciphers_list(const char *cipher_list,
+         crypto_msg(M_FATAL, "Cannot create SSL object");
+     }
+ 
+-#if (OPENSSL_VERSION_NUMBER < 0x1010000fL)
++#if (OPENSSL_VERSION_NUMBER < 0x1010000fL) || defined(LIBRESSL_VERSION_NUMBER)
+     STACK_OF(SSL_CIPHER) *sk = SSL_get_ciphers(ssl);
+ #else
+     STACK_OF(SSL_CIPHER) *sk = SSL_get1_supported_ciphers(ssl);
+-- 
+2.20.1
+

--- a/net-vpn/openvpn/openvpn-2.4.7-r1.ebuild
+++ b/net-vpn/openvpn/openvpn-2.4.7-r1.ebuild
@@ -50,6 +50,7 @@ CONFIG_CHECK="~TUN"
 PATCHES=(
 	"${FILESDIR}/${PN}-external-cmocka.patch"
 	"${FILESDIR}/${PN}-2.4.5-libressl-macro-fix.patch"
+	"${FILESDIR}/${P}-libressl.patch"
 )
 
 pkg_setup()  {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/678604
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>