### PR TITLE
sys-apps/kmod: add patch and USE flag for LibreSSL support

### DIFF
--- a/sys-apps/kmod/files/kmod-26-libressl.patch
+++ b/sys-apps/kmod/files/kmod-26-libressl.patch
@@ -1,0 +1,143 @@
+From 628677e066198d8658d7edd5511a5bb27cd229f5 Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <steils@gentoo.org>
+Date: Sun, 19 May 2019 03:42:01 +0300
+Subject: [PATCH] libkmod-signature: use PKCS#7 instead of CMS
+
+Linux uses either PKCS #7 or CMS for signing modules (see
+scripts/sign-file.c). CMS is not supported by LibreSSL or older OpenSSL,
+so PKCS #7 is used on systems with these libcrypto providers.
+
+CMS and PKCS #7 formats are very similar. CMS is newer but is as much as
+possible backward compatible with PKCS #7 [1]. PKCS #7 is supported in
+the latest OpenSSL as well as CMS. The fields used for signing kernel
+modules are supported both in PKCS #7 and CMS.
+
+For now modinfo uses CMS with no alternative requiring OpenSSL 1.1.0 or
+newer.
+
+Use PKCS #7 for parsing module signature information, so that modinfo
+could be used both with OpenSSL and LibreSSL.
+
+[1] https://tools.ietf.org/html/rfc5652#section-1.1
+
+Changes v1->v2:
+- Don't use ifdefs for keeping redundant CMS code, just use PKCS #7 both
+with OpenSSL and LibreSSL.
+
+Upstream-Status: Accepted
+[https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/commit/?id=628677e066198d8658d7edd5511a5bb27cd229f5]
+Signed-off-by: Stefan Strogin <steils@gentoo.org>
+---
+ libkmod/libkmod-signature.c | 37 +++++++++++++++++++------------------
+ 1 file changed, 19 insertions(+), 18 deletions(-)
+
+diff --git a/libkmod/libkmod-signature.c b/libkmod/libkmod-signature.c
+index 48d0145..4e8748c 100644
+--- a/libkmod/libkmod-signature.c
++++ b/libkmod/libkmod-signature.c
+@@ -20,7 +20,7 @@
+ #include <endian.h>
+ #include <inttypes.h>
+ #ifdef ENABLE_OPENSSL
+-#include <openssl/cms.h>
++#include <openssl/pkcs7.h>
+ #include <openssl/ssl.h>
+ #endif
+ #include <stdio.h>
+@@ -122,7 +122,7 @@ static bool fill_default(const char *mem, off_t size,
+ #ifdef ENABLE_OPENSSL
+ 
+ struct pkcs7_private {
+-	CMS_ContentInfo *cms;
++	PKCS7 *pkcs7;
+ 	unsigned char *key_id;
+ 	BIGNUM *sno;
+ };
+@@ -132,7 +132,7 @@ static void pkcs7_free(void *s)
+ 	struct kmod_signature_info *si = s;
+ 	struct pkcs7_private *pvt = si->private;
+ 
+-	CMS_ContentInfo_free(pvt->cms);
++	PKCS7_free(pvt->pkcs7);
+ 	BN_free(pvt->sno);
+ 	free(pvt->key_id);
+ 	free(pvt);
+@@ -197,11 +197,10 @@ static bool fill_pkcs7(const char *mem, off_t size,
+ 		       struct kmod_signature_info *sig_info)
+ {
+ 	const char *pkcs7_raw;
+-	CMS_ContentInfo *cms;
+-	STACK_OF(CMS_SignerInfo) *sis;
+-	CMS_SignerInfo *si;
+-	int rc;
+-	ASN1_OCTET_STRING *key_id;
++	PKCS7 *pkcs7;
++	STACK_OF(PKCS7_SIGNER_INFO) *sis;
++	PKCS7_SIGNER_INFO *si;
++	PKCS7_ISSUER_AND_SERIAL *is;
+ 	X509_NAME *issuer;
+ 	ASN1_INTEGER *sno;
+ 	ASN1_OCTET_STRING *sig;
+@@ -220,31 +219,33 @@ static bool fill_pkcs7(const char *mem, off_t size,
+ 
+ 	in = BIO_new_mem_buf(pkcs7_raw, sig_len);
+ 
+-	cms = d2i_CMS_bio(in, NULL);
+-	if (cms == NULL) {
++	pkcs7 = d2i_PKCS7_bio(in, NULL);
++	if (pkcs7 == NULL) {
+ 		BIO_free(in);
+ 		return false;
+ 	}
+ 
+ 	BIO_free(in);
+ 
+-	sis = CMS_get0_SignerInfos(cms);
++	sis = PKCS7_get_signer_info(pkcs7);
+ 	if (sis == NULL)
+ 		goto err;
+ 
+-	si = sk_CMS_SignerInfo_value(sis, 0);
++	si = sk_PKCS7_SIGNER_INFO_value(sis, 0);
+ 	if (si == NULL)
+ 		goto err;
+ 
+-	rc = CMS_SignerInfo_get0_signer_id(si, &key_id, &issuer, &sno);
+-	if (rc == 0)
++	is = si->issuer_and_serial;
++	if (is == NULL)
+ 		goto err;
++	issuer = is->issuer;
++	sno = is->serial;
+ 
+-	sig = CMS_SignerInfo_get0_signature(si);
++	sig = si->enc_digest;
+ 	if (sig == NULL)
+ 		goto err;
+ 
+-	CMS_SignerInfo_get0_algs(si, NULL, NULL, &dig_alg, &sig_alg);
++	PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, &sig_alg);
+ 
+ 	sig_info->sig = (const char *)ASN1_STRING_get0_data(sig);
+ 	sig_info->sig_len = ASN1_STRING_length(sig);
+@@ -277,7 +278,7 @@ static bool fill_pkcs7(const char *mem, off_t size,
+ 	if (pvt == NULL)
+ 		goto err3;
+ 
+-	pvt->cms = cms;
++	pvt->pkcs7 = pkcs7;
+ 	pvt->key_id = key_id_str;
+ 	pvt->sno = sno_bn;
+ 	sig_info->private = pvt;
+@@ -290,7 +291,7 @@ err3:
+ err2:
+ 	BN_free(sno_bn);
+ err:
+-	CMS_ContentInfo_free(cms);
++	PKCS7_free(pkcs7);
+ 	return false;
+ }
+ 
+-- 
+2.21.0
+

--- a/sys-apps/kmod/kmod-26-r1.ebuild
+++ b/sys-apps/kmod/kmod-26-r1.ebuild
@@ -1,0 +1,200 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_{5,6,7}} )
+
+inherit bash-completion-r1 multilib python-r1
+
+if [[ ${PV} == 9999* ]]; then
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
+	inherit autotools git-r3
+else
+	SRC_URI="mirror://kernel/linux/utils/kernel/kmod/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86"
+	inherit libtool
+fi
+
+DESCRIPTION="library and tools for managing linux kernel modules"
+HOMEPAGE="https://git.kernel.org/?p=utils/kernel/kmod/kmod.git"
+
+LICENSE="LGPL-2"
+SLOT="0"
+IUSE="debug doc libressl lzma python ssl static-libs +tools zlib"
+
+# Upstream does not support running the test suite with custom configure flags.
+# I was also told that the test suite is intended for kmod developers.
+# So we have to restrict it.
+# See bug #408915.
+RESTRICT="test"
+
+# Block systemd below 217 for -static-nodes-indicate-that-creation-of-static-nodes-.patch
+RDEPEND="!sys-apps/module-init-tools
+	!sys-apps/modutils
+	!<sys-apps/openrc-0.13.8
+	!<sys-apps/systemd-216-r3
+	lzma? ( >=app-arch/xz-utils-5.0.4-r1 )
+	python? ( ${PYTHON_DEPS} )
+	ssl? (
+		!libressl? ( >=dev-libs/openssl-1.1.0:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	zlib? ( >=sys-libs/zlib-1.2.6 )" #427130
+DEPEND="${RDEPEND}
+	doc? ( dev-util/gtk-doc )
+	lzma? ( virtual/pkgconfig )
+	python? (
+		dev-python/cython[${PYTHON_USEDEP}]
+		virtual/pkgconfig
+		)
+	zlib? ( virtual/pkgconfig )"
+if [[ ${PV} == 9999* ]]; then
+	DEPEND="${DEPEND}
+		dev-libs/libxslt"
+fi
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+DOCS="NEWS README TODO"
+
+PATCHES=(
+	"${FILESDIR}/${P}-libressl.patch" # bug 677960
+)
+
+src_prepare() {
+	default
+
+	if [[ ! -e configure ]] ; then
+		if use doc; then
+			gtkdocize --copy --docdir libkmod/docs || die
+		else
+			touch libkmod/docs/gtk-doc.make
+		fi
+		eautoreconf
+	else
+		elibtoolize
+	fi
+
+	# Restore possibility of running --enable-static wrt #472608
+	sed -i \
+		-e '/--enable-static is not supported by kmod/s:as_fn_error:echo:' \
+		configure || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		--bindir="${EPREFIX}/bin"
+		--enable-shared
+		--with-bashcompletiondir="$(get_bashcompdir)"
+		--with-rootlibdir="${EPREFIX}/$(get_libdir)"
+		$(use_enable debug)
+		$(use_enable doc gtk-doc)
+		$(use_enable static-libs static)
+		$(use_enable tools)
+		$(use_with lzma xz)
+		$(use_with ssl openssl)
+		$(use_with zlib)
+	)
+
+	local ECONF_SOURCE="${S}"
+
+	kmod_configure() {
+		mkdir -p "${BUILD_DIR}" || die
+		run_in_build_dir econf "${myeconfargs[@]}" "$@"
+	}
+
+	BUILD_DIR="${WORKDIR}/build"
+	kmod_configure --disable-python
+
+	if use python; then
+		python_foreach_impl kmod_configure --enable-python
+	fi
+}
+
+src_compile() {
+	emake -C "${BUILD_DIR}"
+
+	if use python; then
+		local native_builddir=${BUILD_DIR}
+
+		python_compile() {
+			emake -C "${BUILD_DIR}" -f Makefile -f - python \
+				VPATH="${native_builddir}:${S}" \
+				native_builddir="${native_builddir}" \
+				libkmod_python_kmod_{kmod,list,module,_util}_la_LIBADD='$(PYTHON_LIBS) $(native_builddir)/libkmod/libkmod.la' \
+				<<< 'python: $(pkgpyexec_LTLIBRARIES)'
+		}
+
+		python_foreach_impl python_compile
+	fi
+}
+
+src_install() {
+	emake -C "${BUILD_DIR}" DESTDIR="${D}" install
+	einstalldocs
+
+	if use python; then
+		local native_builddir=${BUILD_DIR}
+
+		python_install() {
+			emake -C "${BUILD_DIR}" DESTDIR="${D}" \
+				VPATH="${native_builddir}:${S}" \
+				install-pkgpyexecLTLIBRARIES \
+				install-dist_pkgpyexecPYTHON
+		}
+
+		python_foreach_impl python_install
+	fi
+
+	find "${ED}" -name "*.la" -delete || die
+
+	if use tools; then
+		local bincmd sbincmd
+		for sbincmd in depmod insmod lsmod modinfo modprobe rmmod; do
+			dosym ../bin/kmod /sbin/${sbincmd}
+		done
+
+		# These are also usable as normal user
+		for bincmd in lsmod modinfo; do
+			dosym kmod /bin/${bincmd}
+		done
+	fi
+
+	cat <<-EOF > "${T}"/usb-load-ehci-first.conf
+	softdep uhci_hcd pre: ehci_hcd
+	softdep ohci_hcd pre: ehci_hcd
+	EOF
+
+	insinto /lib/modprobe.d
+	doins "${T}"/usb-load-ehci-first.conf #260139
+
+	newinitd "${FILESDIR}"/kmod-static-nodes-r1 kmod-static-nodes
+}
+
+pkg_postinst() {
+	if [[ -L ${EROOT%/}/etc/runlevels/boot/static-nodes ]]; then
+		ewarn "Removing old conflicting static-nodes init script from the boot runlevel"
+		rm -f "${EROOT%/}"/etc/runlevels/boot/static-nodes
+	fi
+
+	# Add kmod to the runlevel automatically if this is the first install of this package.
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		if [[ ! -d ${EROOT%/}/etc/runlevels/sysinit ]]; then
+			mkdir -p "${EROOT%/}"/etc/runlevels/sysinit
+		fi
+		if [[ -x ${EROOT%/}/etc/init.d/kmod-static-nodes ]]; then
+			ln -s /etc/init.d/kmod-static-nodes "${EROOT%/}"/etc/runlevels/sysinit/kmod-static-nodes
+		fi
+	fi
+
+	if [[ -e ${EROOT%/}/etc/runlevels/sysinit ]]; then
+		if [[ ! -e ${EROOT%/}/etc/runlevels/sysinit/kmod-static-nodes ]]; then
+			ewarn
+			ewarn "You need to add kmod-static-nodes to the sysinit runlevel for"
+			ewarn "kernel modules to have required static nodes!"
+			ewarn "Run this command:"
+			ewarn "\trc-update add kmod-static-nodes sysinit"
+		fi
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/677960
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>