### PR TITLE
sys-process/iotop: Fix parse_proc_pid_status()

### DIFF
--- a/sys-process/iotop/files/iotop-0.6-Actually-skip-invalid-lines-in-proc-status.patch
+++ b/sys-process/iotop/files/iotop-0.6-Actually-skip-invalid-lines-in-proc-status.patch
@@ -1,0 +1,26 @@
+From 7c51ce0e29bd135c216f18e18f0c4ab769af0d6f Mon Sep 17 00:00:00 2001
+From: Paul Wise <pabs3@bonedaddy.net>
+Date: Fri, 25 May 2018 15:20:44 +0800
+Subject: [PATCH 2/2] Actually skip invalid lines in /proc/*/status
+
+Fixes: commit 0392b205b5c3973a326721c2e9f97f0fa2eefa82
+---
+ iotop/data.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iotop/data.py b/iotop/data.py
+index e0387f0..3874974 100644
+--- a/iotop/data.py
++++ b/iotop/data.py
+@@ -214,7 +214,7 @@ def parse_proc_pid_status(pid):
+                 # Ignore lines that are not formatted correctly as
+                 # some downstream kernels may have weird lines and
+                 # the needed fields are probably formatted correctly.
+-                pass
++                continue
+             result_dict[key] = value.strip()
+     except IOError:
+         pass  # No such process
+-- 
+2.20.1.97.g81188d93c3-goog
+

--- a/sys-process/iotop/files/iotop-0.6-Ignore-invalid-lines-in-proc-status-files.patch
+++ b/sys-process/iotop/files/iotop-0.6-Ignore-invalid-lines-in-proc-status-files.patch
@@ -1,0 +1,64 @@
+From 0392b205b5c3973a326721c2e9f97f0fa2eefa82 Mon Sep 17 00:00:00 2001
+From: Paul Wise <pabs3@bonedaddy.net>
+Date: Fri, 25 May 2018 15:13:26 +0800
+Subject: [PATCH 1/2] Ignore invalid lines in /proc/*/status files
+
+One Ubuntu Linux kernel security fix introduced a blank line.
+Some other Linux kernels may have invalid lines in the future.
+
+See-also: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1772671
+Fixes: https://bugs.launchpad.net/ubuntu/+source/iotop/+bug/1772856
+Reported-by: Paul Jaros <jaros.paul@gmail.com>
+Reported-in: <CAEh_nc0_DXTmfu16PxmVyrCi6QQeSrpnGGhtfNu60wJYfa_6Zw@mail.gmail.com>
+Traceback (most recent call last):
+  File "/usr/sbin/iotop", line 17, in <module>
+    main()
+  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 620, in main
+    main_loop()
+  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 610, in <lambda>
+    main_loop = lambda: run_iotop(options)
+  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 508, in run_iotop
+    return curses.wrapper(run_iotop_window, options)
+  File "/usr/lib/python2.7/curses/wrapper.py", line 43, in wrapper
+    return func(stdscr, *args, **kwds)
+  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 501, in run_iotop_window
+    ui.run()
+  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 155, in run
+    self.process_list.duration)
+  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 434, in refresh_display
+    lines = self.get_data()
+  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 415, in get_data
+    return list(map(format, processes))
+  File "/usr/lib/python2.7/dist-packages/iotop/ui.py", line 388, in format
+    cmdline = p.get_cmdline()
+  File "/usr/lib/python2.7/dist-packages/iotop/data.py", line 292, in get_cmdline
+    proc_status = parse_proc_pid_status(self.pid)
+  File "/usr/lib/python2.7/dist-packages/iotop/data.py", line 196, in parse_proc_pid_status
+    key, value = line.split(':\t', 1)
+ValueError: need more than 1 value to unpack
+---
+ iotop/data.py | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/iotop/data.py b/iotop/data.py
+index 115bb8f..e0387f0 100644
+--- a/iotop/data.py
++++ b/iotop/data.py
+@@ -208,7 +208,13 @@ def parse_proc_pid_status(pid):
+     result_dict = {}
+     try:
+         for line in open('/proc/%d/status' % pid):
+-            key, value = line.split(':', 1)
++            try:
++                key, value = line.split(':', 1)
++            except ValueError:
++                # Ignore lines that are not formatted correctly as
++                # some downstream kernels may have weird lines and
++                # the needed fields are probably formatted correctly.
++                pass
+             result_dict[key] = value.strip()
+     except IOError:
+         pass  # No such process
+-- 
+2.20.1.97.g81188d93c3-goog
+

--- a/sys-process/iotop/files/iotop-0.6-Only-split-proc-status-lines-on-the-character.patch
+++ b/sys-process/iotop/files/iotop-0.6-Only-split-proc-status-lines-on-the-character.patch
@@ -1,0 +1,31 @@
+From 7814f30a5ed65acd07f284bba991ca557788ee80 Mon Sep 17 00:00:00 2001
+From: Paul Wise <pabs3@bonedaddy.net>
+Date: Thu, 28 Jul 2016 13:25:54 +0800
+Subject: [PATCH] Only split /proc/*/status lines on the : character.
+
+Apparently vserver kernels have some lines that don't
+appear to have the tab character so iotop crashes.
+
+The tab character will be stripped by the next code line.
+
+Closes: https://bugs.gentoo.org/show_bug.cgi?id=458556
+---
+ iotop/data.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iotop/data.py b/iotop/data.py
+index c4e961e..d18ca9d 100644
+--- a/iotop/data.py
++++ b/iotop/data.py
+@@ -197,7 +197,7 @@ def parse_proc_pid_status(pid):
+     result_dict = {}
+     try:
+         for line in open('/proc/%d/status' % pid):
+-            key, value = line.split(':\t', 1)
++            key, value = line.split(':', 1)
+             result_dict[key] = value.strip()
+     except IOError:
+         pass  # No such process
+-- 
+2.20.1.97.g81188d93c3-goog
+

--- a/sys-process/iotop/iotop-0.6.ebuild
+++ b/sys-process/iotop/iotop-0.6.ebuild
@@ -21,7 +21,12 @@ CONFIG_CHECK="~TASK_IO_ACCOUNTING ~TASK_DELAY_ACCT ~TASKSTATS ~VM_EVENT_COUNTERS
 
 DOCS=( NEWS README THANKS ChangeLog )
 
-PATCHES=( "${FILESDIR}"/${P}-setup.py3.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-setup.py3.patch
+	"${FILESDIR}"/${P}-Only-split-proc-status-lines-on-the-character.patch
+	"${FILESDIR}"/${P}-Ignore-invalid-lines-in-proc-status-files.patch
+	"${FILESDIR}"/${P}-Actually-skip-invalid-lines-in-proc-status.patch
+)
 
 pkg_setup() {
 	linux-info_pkg_setup


### PR DESCRIPTION
iotop does not work on kernels that populate /proc/*/status either with
empty lines or lines containing spaces after the : character. These
patches from the upstream iotop project fixes the parsing of status.

Signed-off-by: Emil Lundmark <lndmrk@chromium.org>