### PR TITLE
www-client/midori: use HTTPS

### DIFF
--- a/www-client/midori/midori-0.5.11-r2.ebuild
+++ b/www-client/midori/midori-0.5.11-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ VALA_MAX_API_VERSION=0.34
 inherit cmake-utils gnome2-utils pax-utils python-any-r1 vala virtualx xdg-utils
 
 DESCRIPTION="A lightweight web browser based on WebKitGTK+"
-HOMEPAGE="http://www.midori-browser.org/"
+HOMEPAGE="https://www.midori-browser.org/"
 SRC_URI="http://www.${PN}-browser.org/downloads/${PN}_${PV}_all_.tar.bz2"
 
 KEYWORDS="~amd64 ~arm ~mips x86 ~x86-fbsd"

--- a/www-client/midori/midori-0.5.11-r3.ebuild
+++ b/www-client/midori/midori-0.5.11-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ VALA_MIN_API_VERSION=0.36
 inherit cmake-utils gnome2-utils pax-utils python-any-r1 vala virtualx xdg-utils
 
 DESCRIPTION="A lightweight web browser based on WebKitGTK+"
-HOMEPAGE="http://www.midori-browser.org/"
+HOMEPAGE="https://www.midori-browser.org/"
 SRC_URI="http://www.${PN}-browser.org/downloads/${PN}_${PV}_all_.tar.bz2"
 
 KEYWORDS="~amd64 ~arm ~mips ~x86 ~x86-fbsd"

--- a/www-client/midori/midori-6.0.ebuild
+++ b/www-client/midori/midori-6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit cmake-utils eapi7-ver eutils gnome2-utils vala xdg-utils
 
 MY_P=${PN}-v${PV}
 DESCRIPTION="A lightweight web browser based on WebKitGTK+"
-HOMEPAGE="http://www.midori-browser.org/"
+HOMEPAGE="https://www.midori-browser.org/"
 SRC_URI="https://github.com/midori-browser/core/releases/download/v$(ver_cut 1)/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1+"

--- a/www-client/midori/midori-7.0.ebuild
+++ b/www-client/midori/midori-7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit cmake-utils eapi7-ver gnome2-utils vala xdg-utils
 
 MY_P=${PN}-v${PV}
 DESCRIPTION="A lightweight web browser based on WebKitGTK+"
-HOMEPAGE="http://www.midori-browser.org/"
+HOMEPAGE="https://www.midori-browser.org/"
 SRC_URI="https://github.com/midori-browser/core/releases/download/v$(ver_cut 1)/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1+"


### PR DESCRIPTION
Hi,

Simple PR to use https instead of http for www-client/midori.

Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>