### PR TITLE
app-admin/syslog-ng: require rabbitmq-c[ssl] for USE=amqp

### DIFF
--- a/app-admin/syslog-ng/syslog-ng-3.17.2.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-3.17.2.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	>=dev-libs/ivykis-0.42.3
 	>=dev-libs/libpcre-6.1:=
 	!dev-libs/eventlog
-	amqp? ( >=net-libs/rabbitmq-c-0.8.0:= )
+	amqp? ( >=net-libs/rabbitmq-c-0.8.0:=[ssl] )
 	caps? ( sys-libs/libcap )
 	dbi? ( >=dev-db/libdbi-0.9.0 )
 	geoip? ( >=dev-libs/geoip-1.5.0 )

--- a/app-admin/syslog-ng/syslog-ng-3.18.1.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-3.18.1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	>=dev-libs/ivykis-0.42.3
 	>=dev-libs/libpcre-6.1:=
 	!dev-libs/eventlog
-	amqp? ( >=net-libs/rabbitmq-c-0.8.0:= )
+	amqp? ( >=net-libs/rabbitmq-c-0.8.0:=[ssl] )
 	caps? ( sys-libs/libcap )
 	dbi? ( >=dev-db/libdbi-0.9.0 )
 	geoip? ( >=dev-libs/geoip-1.5.0 )

--- a/app-admin/syslog-ng/syslog-ng-3.19.1.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-3.19.1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	>=dev-libs/ivykis-0.42.3
 	>=dev-libs/libpcre-6.1:=
 	!dev-libs/eventlog
-	amqp? ( >=net-libs/rabbitmq-c-0.8.0:= )
+	amqp? ( >=net-libs/rabbitmq-c-0.8.0:=[ssl] )
 	caps? ( sys-libs/libcap )
 	dbi? ( >=dev-db/libdbi-0.9.0 )
 	geoip? ( >=dev-libs/geoip-1.5.0 )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/678610
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>