### PR TITLE
media-libs/vulkan-layers: Install headers into /usr/include/vulkan

### DIFF
--- a/media-libs/vulkan-layers/vulkan-layers-1.1.82.0-r1.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-1.1.82.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,8 +9,8 @@ if [[ "${PV}" == "9999" ]]; then
 	EGIT_SUBMODULES=()
 	inherit git-r3
 else
-	EGIT_COMMIT="6e6da6ccab8931f7c30815966ef839b1155e5bec"
-	KEYWORDS="amd64"
+	EGIT_COMMIT="89bbac497742d48c3d483f78b1bba99101784746"
+	KEYWORDS="~amd64"
 	SRC_URI="https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/Vulkan-ValidationLayers-${EGIT_COMMIT}"
 fi
@@ -25,24 +25,29 @@ SLOT="0"
 IUSE="X wayland"
 
 DEPEND="${PYTHON_DEPS}
-		>=dev-util/glslang-7.10.2984:=[${MULTILIB_USEDEP}]
+		>=dev-util/glslang-7.9.2888:=[${MULTILIB_USEDEP}]
 		>=dev-util/spirv-tools-2018.2-r1:=[${MULTILIB_USEDEP}]
-		>=dev-util/vulkan-headers-1.1.92.0
+		>=dev-util/vulkan-headers-1.1.82.0
 		wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
 		X? (
 		   x11-libs/libX11:=[${MULTILIB_USEDEP}]
 		   x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
 		   )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-Use-a-file-to-get-the-spirv-tools-commit-ID.patch"
+	 )
+
 multilib_src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=True
+		-DBUILD_WSI_MIR_SUPPORT=False
 		-DBUILD_WSI_WAYLAND_SUPPORT=$(usex wayland)
 		-DBUILD_WSI_XCB_SUPPORT=$(usex X)
 		-DBUILD_WSI_XLIB_SUPPORT=$(usex X)
 		-DBUILD_TESTS=False
 		-DGLSLANG_INSTALL_DIR="/usr"
-		-DVULKAN_HEADERS_INSTALL_DIR="/usr"
+		-DCMAKE_INSTALL_INCLUDEDIR="/usr/include/vulkan/"
 	)
 	cmake-utils_src_configure
 }

--- a/media-libs/vulkan-layers/vulkan-layers-1.1.92.0-r1.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-1.1.92.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,8 +9,8 @@ if [[ "${PV}" == "9999" ]]; then
 	EGIT_SUBMODULES=()
 	inherit git-r3
 else
-	EGIT_COMMIT="89bbac497742d48c3d483f78b1bba99101784746"
-	KEYWORDS="~amd64"
+	EGIT_COMMIT="6e6da6ccab8931f7c30815966ef839b1155e5bec"
+	KEYWORDS="amd64"
 	SRC_URI="https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/Vulkan-ValidationLayers-${EGIT_COMMIT}"
 fi
@@ -25,29 +25,24 @@ SLOT="0"
 IUSE="X wayland"
 
 DEPEND="${PYTHON_DEPS}
-		>=dev-util/glslang-7.9.2888:=[${MULTILIB_USEDEP}]
+		>=dev-util/glslang-7.10.2984:=[${MULTILIB_USEDEP}]
 		>=dev-util/spirv-tools-2018.2-r1:=[${MULTILIB_USEDEP}]
-		>=dev-util/vulkan-headers-1.1.82.0
+		>=dev-util/vulkan-headers-1.1.92.0
 		wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
 		X? (
 		   x11-libs/libX11:=[${MULTILIB_USEDEP}]
 		   x11-libs/libXrandr:=[${MULTILIB_USEDEP}]
 		   )"
 
-PATCHES=(
-	"${FILESDIR}/${PN}-Use-a-file-to-get-the-spirv-tools-commit-ID.patch"
-	 )
-
 multilib_src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=True
-		-DBUILD_WSI_MIR_SUPPORT=False
 		-DBUILD_WSI_WAYLAND_SUPPORT=$(usex wayland)
 		-DBUILD_WSI_XCB_SUPPORT=$(usex X)
 		-DBUILD_WSI_XLIB_SUPPORT=$(usex X)
 		-DBUILD_TESTS=False
 		-DGLSLANG_INSTALL_DIR="/usr"
-		-DVULKAN_HEADERS_INSTALL_DIR="/usr"
+		-DCMAKE_INSTALL_INCLUDEDIR="/usr/include/vulkan/"
 	)
 	cmake-utils_src_configure
 }

--- a/media-libs/vulkan-layers/vulkan-layers-9999.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-9999.ebuild
@@ -42,7 +42,7 @@ multilib_src_configure() {
 		-DBUILD_WSI_XLIB_SUPPORT=$(usex X)
 		-DBUILD_TESTS=False
 		-DGLSLANG_INSTALL_DIR="/usr"
-		-DVULKAN_HEADERS_INSTALL_DIR="/usr"
+		-DCMAKE_INSTALL_INCLUDEDIR="/usr/include/vulkan/"
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
This is required to allow the new mesa vulkan-overlay-layer to build
correctly

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>