### PR TITLE
app-admin/sudo: add USE system-digest,libressl

### DIFF
--- a/app-admin/sudo/metadata.xml
+++ b/app-admin/sudo/metadata.xml
@@ -12,12 +12,17 @@
 		arguments.
 	</longdescription>
 	<use>
-		<flag name="gcrypt">Use SHA2 from <pkg>dev-libs/libgcrypt</pkg> instead of sudo's internal SHA2</flag>
+		<flag name="gcrypt">Use message digest functions from <pkg>dev-libs/libgcrypt</pkg> instead of sudo's</flag>
+		<flag name="libressl">Use message digest functions from <pkg>dev-libs/libressl</pkg> instead of sudo's</flag>
 		<flag name="offensive">Let sudo print insults when the user types the wrong password</flag>
-		<flag name="openssl">Use SHA2 from <pkg>dev-libs/openssl</pkg> instead of sudo's internal SHA2</flag>
+		<flag name="openssl">Use message digest functions from <pkg>dev-libs/openssl</pkg> instead of sudo's</flag>
 		<flag name="sendmail">Allow sudo to send emails with sendmail</flag>
 		<flag name="sssd">Add System Security Services Daemon support</flag>
 		<flag name="secure-path">Replace PATH variable with compile time secure paths</flag>
+		<flag name="system-digest">
+			Use message digest functions from <pkg>dev-libs/libgcrypt</pkg>, <pkg>dev-libs/libressl</pkg>
+			or <pkg>dev-libs/openssl</pkg> instead of sudo's internal SHA2 implementation
+		</flag>
 	</use>
 	<upstream>
 		<remote-id type="cpe">cpe:/a:todd_miller:sudo</remote-id>


### PR DESCRIPTION
Add system-digest USE flag for building with support of using message
digest functions from libgcrypt, LibreSSL or OpenSSL, depending on
USE gcrypt or libressl, instead of sudo's own implementation.

Minor amend of USE flag descriptions as per descriptions from sudo's
configure.ac and ChangeLog.

Closes: https://bugs.gentoo.org/678888
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>