### PR TITLE
dev-lang/perl: turn off optimization in case of cross-compiler

### DIFF
--- a/dev-lang/perl/perl-5.26.2.ebuild
+++ b/dev-lang/perl/perl-5.26.2.ebuild
@@ -359,6 +359,11 @@ src_configure() {
 	# Perl has problems compiling with -Os in your flags with glibc
 	use elibc_uclibc || replace-flags "-Os" "-O2"
 
+	# perl-cross should be built without -O flags, so it does not segfault.
+	if tc-is-cross-compiler; then
+		replace-flags -O? -O0
+	fi
+
 	# xlocale.h is going away in glibc-2.26, so it's counterproductive
 	# if we use it and include it in CORE/perl.h ... Perl builds just
 	# fine with glibc and locale.h only.

--- a/dev-lang/perl/perl-5.28.0.ebuild
+++ b/dev-lang/perl/perl-5.28.0.ebuild
@@ -356,6 +356,11 @@ src_configure() {
 	# Perl has problems compiling with -Os in your flags with glibc
 	use elibc_uclibc || replace-flags "-Os" "-O2"
 
+	# perl-cross should be built without -O flags, so it does not segfault.
+	if tc-is-cross-compiler; then
+		replace-flags -O? -O0
+	fi
+
 	# xlocale.h is going away in glibc-2.26, so it's counterproductive
 	# if we use it and include it in CORE/perl.h ... Perl builds just
 	# fine with glibc and locale.h only.

--- a/dev-lang/perl/perl-5.28.9999.ebuild
+++ b/dev-lang/perl/perl-5.28.9999.ebuild
@@ -356,6 +356,11 @@ src_configure() {
 	# Perl has problems compiling with -Os in your flags with glibc
 	use elibc_uclibc || replace-flags "-Os" "-O2"
 
+	# perl-cross should be built without -O flags, so it does not segfault.
+	if tc-is-cross-compiler; then
+		replace-flags -O? -O0
+	fi
+
 	# xlocale.h is going away in glibc-2.26, so it's counterproductive
 	# if we use it and include it in CORE/perl.h ... Perl builds just
 	# fine with glibc and locale.h only.


### PR DESCRIPTION
There has been a bug that cross-compiled perl crashes with segmentation fault. It has two different reasons: first, perl-cross didn't append CFLAGS `-fwrapv` in case of gcc 7.x or newer, and the other is that the CFLAGS still contained `-O2`.

The first issue was recently fixed by setting `CROSS_VER` to `1.2.2`. On the other hand, the second issue is not fixed yet, so perl still segfaults in case of a cross-compiled version. So let's fix it by replacing `-O?` with `-O2`.

For example, how to test inside a cross-compilation SDK environment:

```
LD_PRELOAD=/build/amd64-usr/usr/lib/libperl.so.5.24.1 /build/amd64-usr/usr/bin/perl -V
```

See also https://github.com/coreos/bugs/issues/2369
https://github.com/coreos/bugs/issues/2545
https://github.com/arsv/perl-cross/issues/60

Signed-off-by: Dongsu Park <dongsu@kinvolk.io>