### PR TITLE
app-arch/xz-utils: remove non-exist blocker

### DIFF
--- a/app-arch/xz-utils/xz-utils-5.2.3.ebuild
+++ b/app-arch/xz-utils/xz-utils-5.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Remember: we cannot leverage autotools in this ebuild in order
@@ -30,7 +30,6 @@ SLOT="0"
 IUSE="elibc_FreeBSD +extra-filters nls static-libs +threads"
 
 RDEPEND="!<app-arch/lzma-4.63
-	!app-arch/lzma-utils
 	!<app-arch/p7zip-4.57"
 DEPEND="${RDEPEND}
 	${EXTRA_DEPEND}"

--- a/app-arch/xz-utils/xz-utils-5.2.4-r2.ebuild
+++ b/app-arch/xz-utils/xz-utils-5.2.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Remember: we cannot leverage autotools in this ebuild in order
@@ -31,7 +31,6 @@ SLOT="0"
 IUSE="elibc_FreeBSD +extra-filters nls static-libs +threads"
 
 RDEPEND="!<app-arch/lzma-4.63
-	!app-arch/lzma-utils
 	!<app-arch/p7zip-4.57"
 DEPEND="${RDEPEND}
 	${EXTRA_DEPEND}"

--- a/app-arch/xz-utils/xz-utils-9999.ebuild
+++ b/app-arch/xz-utils/xz-utils-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Remember: we cannot leverage autotools in this ebuild in order
@@ -31,7 +31,6 @@ SLOT="0"
 IUSE="elibc_FreeBSD +extra-filters nls static-libs +threads"
 
 RDEPEND="!<app-arch/lzma-4.63
-	!app-arch/lzma-utils
 	!<app-arch/p7zip-4.57"
 DEPEND="${RDEPEND}
 	${EXTRA_DEPEND}"


### PR DESCRIPTION
Hi,

app-arch/xz-utils has a blocker on ```app-arch/lzma-utils```. However this package doesn't exist and i couldn't find it in the git history, which means might existed prior the git migration. I think we can finally remove this blocker.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>