### PR TITLE
www-client/qutebrowser: fix desktop menu file name

### DIFF
--- a/www-client/qutebrowser/qutebrowser-9999.ebuild
+++ b/www-client/qutebrowser/qutebrowser-9999.ebuild
@@ -52,7 +52,7 @@ python_test() {
 
 python_install_all() {
 	doman doc/${PN}.1
-	domenu misc/org.${PN}.${PN}.desktop
+	newmenu misc/org.${PN}.${PN}.desktop ${PN}.desktop
 	doicon -s scalable icons/${PN}.svg
 
 	distutils-r1_python_install_all


### PR DESCRIPTION
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>