### PR TITLE
media-gfx/iscan: fixed x86 compilation failure

### DIFF
--- a/media-gfx/iscan/files/iscan-2.30.3.1-fix-x86-unknown-types.patch
+++ b/media-gfx/iscan/files/iscan-2.30.3.1-fix-x86-unknown-types.patch
@@ -1,0 +1,11 @@
+diff -ru iscan-2.30.3-old/sanei/sanei_pio.c iscan-2.30.3/sanei/sanei_pio.c
+--- iscan-2.30.3-old/sanei/sanei_pio.c	2019-03-01 10:44:36.723260142 -0600
++++ iscan-2.30.3/sanei/sanei_pio.c	2019-03-01 10:48:47.660693036 -0600
+@@ -73,6 +73,7 @@
+ #elif HAVE_SYS_HW_H
+ # include <sys/hw.h>
+ #elif defined(__i386__)  && defined (__GNUC__)
++#include <sys/types.h>
+ 
+ static __inline__ void
+ outb (u_char value, u_long port)

--- a/media-gfx/iscan/iscan-2.30.3.1.ebuild
+++ b/media-gfx/iscan/iscan-2.30.3.1.ebuild
@@ -69,6 +69,7 @@ PATCHES=(
 	"${FILESDIR}"/iscan-2.29.1-png-libs.patch
 	"${FILESDIR}"/iscan-2.30.1-fix-g++-test.patch
 	"${FILESDIR}"/iscan-2.30.1.1-gcc6.patch
+	"${FILESDIR}"/iscan-2.30.3.1-fix-x86-unknown-types.patch
 )
 
 QA_PRESTRIPPED="usr/lib.*/libesmod.so.*"
@@ -115,7 +116,7 @@ src_install() {
 	if use gimp; then
 		local plugindir="$(gimptool-2.0 --gimpplugindir)/plug-ins"
 		dodir "${plugindir}"
-		dosym /usr/bin/iscan "${plugindir}"/iscan
+		dosym "${ED%/}"/usr/bin/iscan "${plugindir}"/iscan
 	fi
 
 	use X && make_desktop_entry iscan "Image Scan! for Linux ${PV}" scanner


### PR DESCRIPTION
Fixed x86 compilation failure as documented in bug 678046.

Reported-by: Thomas Deutschmann <whissi@gentoo.org>
Signed-off-by: Matthew Schultz <mattsch@gmail.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11