### PR TITLE
app-emulation/vkd3d: Update 9999 version

### DIFF
--- a/app-emulation/vkd3d/vkd3d-9999.ebuild
+++ b/app-emulation/vkd3d/vkd3d-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -22,13 +22,19 @@ RDEPEND="spirv-tools? ( dev-util/spirv-tools:=[${MULTILIB_USEDEP}] )
 
 DEPEND="${RDEPEND}
 		dev-util/spirv-headers
-		dev-util/vulkan-headers"
+		dev-util/vulkan-headers
+		|| ( app-emulation/wine-any app-emulation/wine-d3d9 app-emulation/wine-staging app-emulation/wine-vanilla )"
 
 DESCRIPTION="D3D12 to Vulkan translation library"
 HOMEPAGE="https://source.winehq.org/git/vkd3d.git/"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 multilib_src_configure() {
 	local myconf=(


### PR DESCRIPTION
vkd3d from Git has two changes from tarball source : 
1- "configure" file is replaced by "autogen.sh" so we need to generate "configure" with autotools.
2- The headers are built with "widl" which is available only when Wine is installed. That's why i added wine-* as DEPEND (see https://bugs.winehq.org/show_bug.cgi?id=46606).

Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Maxime Lombard <berillions@gmail.com>