### PR TITLE
app-admin/mongo-tools: require <dev-lang/go-1.12

### DIFF
--- a/app-admin/mongo-tools/mongo-tools-4.0.6.ebuild
+++ b/app-admin/mongo-tools/mongo-tools-4.0.6.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 IUSE="sasl ssl"
 
-DEPEND="dev-lang/go:=
+DEPEND="<dev-lang/go-1.12:=
 	net-libs/libpcap
 	sasl? ( dev-libs/cyrus-sasl )
 	ssl? ( dev-libs/openssl:0= )"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/678924
Bug: https://jira.mongodb.org/browse/TOOLS-2233
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>

Just a workaround until fixed upstream. Only applying to latest testing version.