### PR TITLE
virtual/notification-daemon: depend on x11-wm/awesome[dbus]

### DIFF
--- a/virtual/notification-daemon/notification-daemon-0.ebuild
+++ b/virtual/notification-daemon/notification-daemon-0.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 		xfce-extra/xfce4-notifyd
 		x11-misc/notify-osd
 		x11-misc/dunst
-		>=x11-wm/awesome-3.4.4
+		>=x11-wm/awesome-3.4.4[dbus]
 		x11-wm/enlightenment[enlightenment_modules_notification]
 		x11-wm/enlightenment[e_modules_notification]
 		x11-misc/mate-notification-daemon


### PR DESCRIPTION
Awesome WM only provides a notification service if it is compiled
with dbus enabled.