### PR TITLE
net-libs/liboauth: fix slot operator for libressl dependency

### DIFF
--- a/net-libs/liboauth/liboauth-1.0.3-r1.ebuild
+++ b/net-libs/liboauth/liboauth-1.0.3-r1.ebuild
@@ -30,7 +30,7 @@ CDEPEND="
 	)
 	!nss? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:= )
+		libressl? ( dev-libs/libressl:0= )
 		curl? ( || (
 			net-misc/curl[ssl,curl_ssl_openssl]
 			net-misc/curl[-ssl]


### PR DESCRIPTION
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>