### PR TITLE
dev-util/treecc: fix LICENSE, EAPI7, improve ebuild

### DIFF
--- a/dev-util/treecc/treecc-0.3.10-r1.ebuild
+++ b/dev-util/treecc/treecc-0.3.10-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Compiler-compiler tool for aspect-oriented programming"
+HOMEPAGE="https://www.gnu.org/software/dotgnu"
+SRC_URI="https://download.savannah.gnu.org/releases/dotgnu-pnet/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~amd64-linux ~arm ~hppa ~ia64 ~mips ~ppc ~ppc-macos ~ppc64 ~s390 ~sparc ~sparc-solaris ~x86 ~x86-linux"
+IUSE="doc examples"
+
+DEPEND="doc? ( app-text/texi2html )"
+
+src_compile() {
+	default
+
+	if use doc ; then
+		if [ ! -f "${S}"/doc/treecc.texi ] ; then
+			die "treecc.texi was not generated"
+		fi
+
+		cd "${S}"/doc || die
+		texi2html -split_chapter "${S}"/doc/treecc.texi \
+			|| die "texi2html failed"
+		cd "${S}" || die
+	fi
+}
+
+src_install() {
+	default
+
+	if use examples ; then
+		docinto examples
+		dodoc examples/README
+		dodoc examples/{expr_c.tc,gram_c.y,scan_c.l}
+	fi
+
+	if use doc ; then
+		dodoc doc/*.{txt,html}
+
+		docinto html
+		dodoc -r doc/treecc/*.html
+	fi
+}

--- a/dev-util/treecc/treecc-0.3.10.ebuild
+++ b/dev-util/treecc/treecc-0.3.10.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
 
 DESCRIPTION="compiler-compiler tool for aspect-oriented programming"
 HOMEPAGE="https://www.gnu.org/software/dotgnu"
-SRC_URI="http://download.savannah.gnu.org/releases/dotgnu-pnet/${P}.tar.gz"
+SRC_URI="https://download.savannah.gnu.org/releases/dotgnu-pnet/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
 IUSE="doc examples"


### PR DESCRIPTION
Hi,

This Bug updates dev-util/treecc for EAPI7 and improves the ebuild a bit.
Please review.
