### PR TITLE
media-libs/mesa: The vulkan-overlay-layer no longer requires media-libs/vulkan-layers

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -218,7 +218,6 @@ DEPEND="${RDEPEND}
 	sys-devel/gettext
 	virtual/pkgconfig
 	valgrind? ( dev-util/valgrind )
-	vulkan-overlay? ( media-libs/vulkan-layers[${MULTILIB_USEDEP}] )
 	x11-base/xorg-proto
 	x11-libs/libXrandr[${MULTILIB_USEDEP}]
 	$(python_gen_any_dep ">=dev-python/mako-0.8.0[\${PYTHON_USEDEP}]")

--- a/media-libs/mesa/metadata.xml
+++ b/media-libs/mesa/metadata.xml
@@ -24,7 +24,7 @@
 		<flag name="valgrind">Compile in valgrind memory hints</flag>
 		<flag name="vdpau">Enable the VDPAU acceleration interface for the Gallium3D Video Layer.</flag>
 		<flag name="vulkan">Enable Vulkan drivers</flag>
-		<flag name="vulkan-overlay">Enable vulkan-overlay-layer for vulkan stats"</flag>
+		<flag name="vulkan-overlay">Build vulkan-overlay-layer which displays Frames Per Second and other statistics</flag>
 		<flag name="wayland">Enable support for dev-libs/wayland</flag>
 		<flag name="xa">Enable the XA (X Acceleration) API for Gallium3D.</flag>
 		<flag name="xvmc">Enable the XvMC acceleration interface for the Gallium3D Video Layer.</flag>


### PR DESCRIPTION
Remove the requirement on media-libs/vulkan-layers when vulkan-overlay USE-flag is enabled

Update the description of vulkan-overlay use in the metadata.xml