### PR TITLE
sys-block/scsiadd: use HTTPS, EAPI7 bump, minor improvements

### DIFF
--- a/sys-block/scsiadd/scsiadd-1.97-r1.ebuild
+++ b/sys-block/scsiadd/scsiadd-1.97-r1.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit user toolchain-funcs flag-o-matic
+
+DESCRIPTION="Add and remove SCSI devices from your Linux system during runtime"
+HOMEPAGE="https://llg.cubic.org/tools/"
+SRC_URI="https://llg.cubic.org/tools/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="suid"
+
+pkg_setup() {
+	use suid && enewgroup scsi
+}
+
+src_prepare() {
+	default
+	# remove 'strip' command
+	sed -i -e "s:^\(.*strip.*\):#\1:g" Makefile.in || die
+
+	# convert docs to utf-8
+	if [ -x "$(type -p iconv)" ]; then
+		for X in NEWS README; do
+			iconv -f LATIN1 -t UTF8 -o "${X}~" "${X}" && mv -f "${X}~" "${X}" \
+				|| rm -f "${X}~" || die
+		done
+	fi
+}
+
+src_compile() {
+	# extra safety for suid
+	append-ldflags -Wl,-z,now
+
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dosbin scsiadd
+	if use suid; then
+		fowners root:scsi /usr/sbin/scsiadd
+		fperms  4710      /usr/sbin/scsiadd
+	fi
+	dodoc NEWS README TODO
+	doman scsiadd.8
+}
+
+pkg_postinst() {
+	if use suid; then
+		ewarn
+		ewarn "You have chosen to install ${PN} with the binary setuid root. This"
+		ewarn "means that if there any undetected vulnerabilities in the binary,"
+		ewarn "then local users may be able to gain root access on your machine."
+		ewarn
+	fi
+}

--- a/sys-block/scsiadd/scsiadd-1.97.ebuild
+++ b/sys-block/scsiadd/scsiadd-1.97.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="2"
@@ -6,8 +6,8 @@ EAPI="2"
 inherit user toolchain-funcs flag-o-matic
 
 DESCRIPTION="Add and remove SCSI devices from your Linux system during runtime"
-HOMEPAGE="http://llg.cubic.org/tools/"
-SRC_URI="http://llg.cubic.org/tools/${P}.tar.gz"
+HOMEPAGE="https://llg.cubic.org/tools/"
+SRC_URI="https://llg.cubic.org/tools/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR updates sys-block/scsiadd for EAPI7 and uses https for SRC_URI and HOMEPAGE
Please review.