### PR TITLE
www-apache/mod_security: fix building USE=doc

### DIFF
--- a/www-apache/mod_security/mod_security-2.9.3.ebuild
+++ b/www-apache/mod_security/mod_security-2.9.3.ebuild
@@ -60,19 +60,14 @@ src_configure() {
 		$(use_enable mlogc)
 		$(use_with lua)
 		$(use_enable lua lua-cache)
-		$(use_enable jit pcre-jit) )
+		$(use_enable jit pcre-jit)
+		$(use_enable doc docs) )
 
 	econf ${myconf[@]}
 }
 
 src_compile() {
 	default
-
-	# Building the docs is broken at the moment, see e.g.
-	# https://github.com/SpiderLabs/ModSecurity/issues/1322
-	if use doc; then
-		doxygen doc/doxygen-apache.conf || die 'failed to build documentation'
-	fi
 }
 
 src_install() {


### PR DESCRIPTION
Patch-by: Dennis Lichtenthäler
Closes: https://bugs.gentoo.org/679522
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>