### PR TITLE
sys-boot/systemrescuecd-x86-grub: Update for 6

### DIFF
--- a/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.default-2
+++ b/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.default-2
@@ -1,0 +1,33 @@
+# Here you can set custom bootoptions for the SystemRescueCD
+#
+# For SystemRescueCD version 6.x:
+#
+# You can add in a space separated list:
+#  setkmap=xx: set keyboard layout for terminal
+#  copytoram: load the ISO fully in memory
+#             requires 2GB of memory to cache the system
+#
+# For SystemRescueCD version 5.x:
+#
+# You can add for example in a space separated list:
+#  setkmap=xx: which defines the keymap to load (example: setkmap=de)
+#  dostartx: load the X.Org graphical environment and launch Xfce
+#  docache: causes the iso file to be fully loaded into memory
+#           this requires 400MB of memory to cache everything
+#  doload=xxx: loads needed kernel modules (example: doload=3c59x,e1000)
+#  noload=xxx: prevents loading kernel modules
+#  nomodeset: do not load the Kernel-Mode-Setting video driver
+#
+# Example:
+#  SRCD_BOOTOPTIONS="setkmap=de docache dostartx"
+#
+# For all available bootoptions see:
+#  http://www.sysresccd.org/Sysresccd-manual-en_Booting_the_CD-ROM
+#
+# Note:
+#  After changing this, you must update your grub configuration file, to take effect
+
+SRCD_BOOTOPTIONS=""
+
+# Copy ISO to /boot if there is enough space
+#COPY_SRCD_TO_BOOT="yes"

--- a/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.grub-2
+++ b/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.grub-2
@@ -129,7 +129,7 @@ if [ "${COPY_SRCD_TO_BOOT}" = yes ]; then
 fi
 
 # Build menu entries
-for isopref in ${bootdir} ${installdir}; do
+for isopref in "${bootdir}" "${installdir}"; do
 	# Make sure there are any ISOs
 	ls "${isopref}" | grep -E -q -e "${isorex}" || continue
 

--- a/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.grub-2
+++ b/sys-boot/systemrescuecd-x86-grub/files/systemrescuecd.grub-2
@@ -1,0 +1,146 @@
+#!/bin/sh
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+. /usr/share/grub/grub-mkconfig_lib
+
+if [ -r /etc/default/systemrescuecd ] ; then
+	. /etc/default/systemrescuecd
+fi
+
+COPY_SRCD_TO_BOOT=${COPY_SRCD_TO_BOOT:-no}
+
+bootdir="/boot"
+installdir="/usr/share/systemrescuecd"
+
+isorex='^(/.*/)?systemrescuecd-.*[.]iso$'
+
+# Path of the link to the newest ISO, created by ebuild
+srcd="${installdir}/systemrescuecd-x86-newest.iso"
+
+# Extract ISO version
+isovsed() {
+	sed -E 's|^.*systemrescuecd(-x86)?-||;s|.iso$||'
+}
+
+# Find ISOs in a given directory
+isofind() {
+	find "${1}" -maxdepth 1 -type f -regextype egrep -regex ${isorex}
+}
+
+# Copy ISO to boot partition
+copy_srcd_iso() {
+	if [ ! -f "${bootdir}/"$(basename "${1}") ]; then
+		if [ $(df -k --output=avail "${bootdir}" | tail -1) -gt $(du -k "${1}" | cut -f 1) ]; then
+			cp "${1}" "${bootdir}/"
+		else
+			# Before complaining, check if the installed ISO is actually newer
+			if $(printf '%s\n' $(isofind "${bootdir}" | isovsed | sort -V) $(echo "${1}" | isovsed) | sort -VC); then
+				gettext_printf "Error: Not enough free disk space on ${bootdir}!\n" >&2
+				gettext_printf "Error: Failed to copy the new iso!\n" >&2
+			fi
+		fi
+	fi
+}
+
+write_srcd() {
+	cat <<EOF
+	menuentry "${longname} [${1}] (Copy to RAM${bootops}" --class rescue {
+${grub_string}
+		set gfxpayload=keep
+		set isofile=${path}
+		loopback loop \${isofile}
+		linux (loop)/sysresccd/boot/x86_64/vmlinuz archisobasedir=sysresccd img_loop=\${isofile} img_dev=${diskuuid} copytoram ${SRCD_BOOTOPTIONS}
+		initrd (loop)/sysresccd/boot/intel_ucode.img (loop)/sysresccd/boot/amd_ucode.img (loop)/sysresccd/boot/x86_64/sysresccd.img
+	}
+	menuentry "${longname} [${1}] (Copy to RAM with persistence${bootops}" --class rescue {
+${grub_string}
+		set gfxpayload=keep
+		set isofile=${path}
+		loopback loop \${isofile}
+		linux (loop)/sysresccd/boot/x86_64/vmlinuz archisobasedir=sysresccd img_loop=\${isofile} img_dev=${diskuuid} cow_device=${diskuuid} cow_directory=/persistent_sysresccd-${1}/x86_64 copytoram ${SRCD_BOOTOPTIONS}
+		initrd (loop)/sysresccd/boot/intel_ucode.img (loop)/sysresccd/boot/amd_ucode.img (loop)/sysresccd/boot/x86_64/sysresccd.img
+	}
+	menuentry "${longname} [${1}] (Minimal${bootops}" --class rescue {
+${grub_string}
+		set gfxpayload=keep
+		set isofile=${path}
+		loopback loop \${isofile}
+		linux (loop)/sysresccd/boot/x86_64/vmlinuz archisobasedir=sysresccd img_loop=\${isofile} img_dev=${diskuuid} ${SRCD_BOOTOPTIONS}
+		initrd (loop)/sysresccd/boot/intel_ucode.img (loop)/sysresccd/boot/amd_ucode.img (loop)/sysresccd/boot/x86_64/sysresccd.img
+	}
+EOF
+}
+
+write_srcd_5() {
+	cat <<EOF
+	menuentry "${longname} [${1}] (64bit${bootops}" --class rescue {
+${grub_string}
+		set isofile=${path}
+		loopback loop \${isofile}
+		linux (loop)/isolinux/rescue64 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
+		initrd (loop)/isolinux/initram.igz
+	}
+	menuentry "${longname} [${1}] (32bit${bootops}" --class rescue {
+${grub_string}
+		set isofile=${path}
+		loopback loop \${isofile}
+		linux (loop)/isolinux/rescue32 ${SRCD_BOOTOPTIONS} isoloop=\${isofile}
+		initrd (loop)/isolinux/initram.igz
+	}
+EOF
+}
+
+# Get v5 ISOs
+# Use: isogrep5 [-v]
+#   -v invert match
+isogrep5() {
+	ls -rv "${isopref}"/systemrescuecd-*.iso | grep ${1} -e '-x86-5'
+}
+
+write_srcd_submenu() {
+	# Start submenu
+	echo "submenu \"${longname}\" --class submenu {"
+
+	# Make sure to reverse-sort by version
+	for iso in $(isogrep5 -v; isogrep5); do
+		path=$(make_system_path_relative_to_its_root "${iso}")
+		gettext_printf "  image: ${iso}\n" >&2
+		if $(printf '%s\n' "6.0.0" $(echo ${iso} | isovsed) | sort -VC); then
+			write_srcd $(echo ${iso} | isovsed)
+		else
+			write_srcd_5 $(echo ${iso} | isovsed)
+		fi
+	done
+
+	# End submenu
+	echo "}"
+}
+
+bootops=")"
+
+if [ ! -z "${SRCD_BOOTOPTIONS}" ]; then
+	bootops=" with bootoptions)"
+fi
+
+if [ "${COPY_SRCD_TO_BOOT}" = yes ]; then
+	srcd=$(realpath "${srcd}")
+	copy_srcd_iso "${srcd}"
+fi
+
+# Build menu entries
+for isopref in ${bootdir} ${installdir}; do
+	# Make sure there are any ISOs
+	ls "${isopref}" | grep -E -q -e "${isorex}" || continue
+
+	diskuuid=/dev/disk/by-uuid/$(${grub_probe} --target=fs_uuid "${isopref}")
+	device=$(${grub_probe} --target=device "${isopref}")
+	label=$(${grub_probe} --target=fs_label "${isopref}")
+	[ "${label}" = "(null)" ] && label=${device}
+	grub_string=$(prepare_grub_to_access_device "${device}" | grub_add_tab | grub_add_tab)
+	longname="SystemRescueCD on ${label}"
+
+	gettext_printf "Found %s on %s\n" "${longname}" "${device}" >&2
+
+	write_srcd_submenu
+done

--- a/sys-boot/systemrescuecd-x86-grub/systemrescuecd-x86-grub-0.2.ebuild
+++ b/sys-boot/systemrescuecd-x86-grub/systemrescuecd-x86-grub-0.2.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Grub menu entries for the .iso image of systemrescuecd-x86"
+HOMEPAGE="http://www.sysresccd.org/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT=0
+KEYWORDS="~amd64 ~x86"
+
+S="${WORKDIR}"
+
+RDEPEND="app-admin/systemrescuecd-x86
+	sys-boot/grub"
+
+src_install() {
+	exeinto /etc/grub.d
+	newexe "${FILESDIR}"/systemrescuecd.grub-2 39_systemrescuecd
+
+	insinto /etc/default
+	newins "${FILESDIR}"/systemrescuecd.default-2 systemrescuecd
+}
+
+pkg_postinst() {
+	elog "To add the menu entries for systemrescuecd to grub, you should now run"
+	elog "	grub-mkconfig -o /boot/grub/grub.cfg"
+	elog "You can set custom bootoptions in /etc/default/systemrescuecd"
+}


### PR DESCRIPTION
SystemRescueCD starting from version 6 is based on Arch and the way it
is booted changed.

Rewrite to:
- Support SystemRescueCD versions 5 and 6.

- Create menu entries for all versions found.

- Add option to copy the newest ISO to /boot if there is enough free
space. Helpful if / becomes unaccessible while /boot is on a separate
partition.

- Add a menu entry for persistent boot (version 6 only). Will put data
on the same disk, where the current ISO resides, in
"/persistent_sysresccd-${version}/x86_64".