### PR TITLE
media-libs/sdl-sound: fix build with dev-games/physfs-3.0.1

### DIFF
--- a/media-libs/sdl-sound/files/sdl-sound-1.0.3-physfs-3.0.1.patch
+++ b/media-libs/sdl-sound/files/sdl-sound-1.0.3-physfs-3.0.1.patch
@@ -1,0 +1,38 @@
+--- a/playsound/physfsrwops.h.ini	2008-04-17 13:56:21.000000000 -0400
++++ b/playsound/physfsrwops.h	2017-12-23 05:05:31.657371092 -0500
+@@ -39,7 +39,7 @@
+  *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+  *           of the error can be gleaned from PHYSFS_getLastError().
+  */
+-__EXPORT__ SDL_RWops *PHYSFSRWOPS_openRead(const char *fname);
++SDL_RWops *PHYSFSRWOPS_openRead(const char *fname);
+ 
+ /**
+  * Open a platform-independent filename for writing, and make it accessible
+@@ -51,7 +51,7 @@
+  *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+  *           of the error can be gleaned from PHYSFS_getLastError().
+  */
+-__EXPORT__ SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname);
++SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname);
+ 
+ /**
+  * Open a platform-independent filename for appending, and make it accessible
+@@ -63,7 +63,7 @@
+  *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+  *           of the error can be gleaned from PHYSFS_getLastError().
+  */
+-__EXPORT__ SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname);
++SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname);
+ 
+ /**
+  * Make a SDL_RWops from an existing PhysicsFS file handle. You should
+@@ -75,7 +75,7 @@
+  *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+  *           of the error can be gleaned from PHYSFS_getLastError().
+  */
+-__EXPORT__ SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_file *handle);
++SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_file *handle);
+ 
+ #ifdef __cplusplus
+ }

--- a/media-libs/sdl-sound/metadata.xml
+++ b/media-libs/sdl-sound/metadata.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>games@gentoo.org</email>
-    <name>Gentoo Games Project</name>
-  </maintainer>
-  <use>
-    <flag name="physfs">Enable physfs support</flag>
-  </use>
+	<maintainer type="project">
+		<email>games@gentoo.org</email>
+		<name>Gentoo Games Project</name>
+	</maintainer>
+	<use>
+		<flag name="physfs">Enable support for various formats through <pkg>dev-games/physfs</pkg>.</flag>
+	</use>
+	<upstream>
+		<bugs-to>mailto:sdlsound@icculus.org</bugs-to>
+	</upstream>
 </pkgmetadata>

--- a/media-libs/sdl-sound/sdl-sound-1.0.3-r2.ebuild
+++ b/media-libs/sdl-sound/sdl-sound-1.0.3-r2.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools multilib-minimal
+
+MY_P="${P/sdl-/SDL_}"
+
+DESCRIPTION="A library for handling the decoding of various sound file formats"
+HOMEPAGE="https://icculus.org/SDL_sound/"
+SRC_URI="https://icculus.org/${MY_PN}/downloads/${MY_P}.tar.gz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x64-macos"
+IUSE="flac mikmod modplug mp3 mpeg physfs speex static-libs vorbis"
+
+RDEPEND="
+	>=media-libs/libsdl-1.2.15-r4[${MULTILIB_USEDEP}]
+	flac? ( >=media-libs/flac-1.2.1-r5[${MULTILIB_USEDEP}] )
+	mikmod? ( >=media-libs/libmikmod-3.2.0[${MULTILIB_USEDEP}] )
+	modplug? ( >=media-libs/libmodplug-0.8.8.4-r1[${MULTILIB_USEDEP}] )
+	mpeg? ( >=media-libs/smpeg-0.4.4-r10[${MULTILIB_USEDEP}] )
+	physfs? ( >=dev-games/physfs-3.0.1[${MULTILIB_USEDEP}] )
+	speex? (
+		>=media-libs/speex-1.2_rc1-r1[${MULTILIB_USEDEP}]
+		>=media-libs/libogg-1.3.0[${MULTILIB_USEDEP}]
+	)
+	vorbis? ( >=media-libs/libvorbis-1.3.3-r1[${MULTILIB_USEDEP}] )
+"
+
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/"${P}"-automake-1.13.patch
+	"${FILESDIR}"/"${P}"-physfs-3.0.1.patch
+	"${FILESDIR}"/"${P}"-underlinking.patch
+)
+
+S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	default
+
+	mv configure.in configure.ac || die
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--enable-aiff
+		--enable-au
+		--enable-midi
+		--enable-raw
+		--enable-shn
+		--enable-voc
+		--enable-wav
+		$(use_enable flac)
+		$(use_enable mikmod)
+		$(use_enable modplug)
+		$(use_enable mp3 mpglib)
+		$(use_enable mpeg smpeg)
+		$(use_enable physfs)
+		$(use_enable speex)
+		$(use_enable static-libs static)
+		$(use_enable vorbis ogg)
+	)
+
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install() {
+	emake DESTDIR="${D}" install
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	if ! use static-libs ; then
+		find "${D}" -name '*.la' -delete || die
+	fi
+}


### PR DESCRIPTION
Also reworked whole eBuild and bumped to EAPI=7.
Added also new build options, to support more formats.

Closes: https://bugs.gentoo.org/636266
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>