### PR TITLE
Kde stuff

### DIFF
--- a/dev-ml/facile/facile-1.1.3.ebuild
+++ b/dev-ml/facile/facile-1.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ SRC_URI="http://opti.recherche.enac.fr/facile/distrib/${P}.tar.gz"
 LICENSE="LGPL-2.1"
 SLOT="0/${PV}"
 
-KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 ~sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 ~arm64 hppa ia64 ppc ppc64 ~sparc x86 ~x86-fbsd"
 IUSE="+ocamlopt"
 
 RDEPEND=">=dev-lang/ocaml-4:=[ocamlopt?]"

--- a/kde-apps/kalzium/kalzium-18.12.3.ebuild
+++ b/kde-apps/kalzium/kalzium-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5 flag-o-matic
 
 DESCRIPTION="Periodic table of the elements"
 HOMEPAGE="https://www.kde.org/applications/education/kalzium https://edu.kde.org/kalzium/"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="editor solver"
 
 DEPEND="

--- a/kde-apps/kdeedu-meta/kdeedu-meta-18.12.3.ebuild
+++ b/kde-apps/kdeedu-meta/kdeedu-meta-18.12.3.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="https://edu.kde.org"
 
 LICENSE="metapackage"
 SLOT="5"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+webengine +webkit"
 
 RDEPEND="

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Roy Bamford <neddyseagoon@gentoo.org> (10 Mar 2019)
+# kde-apps/kalzium editor as sci-chemistry/openbabel 
+# fails to build on arm64
+kde-apps/kalzium editor
+
 # Mart Raudsepp <leio@gentoo.org> (23 Feb 2019)
 # x11-libs/libXTrap not keyworded yet
 x11-misc/x11vnc xtrap


### PR DESCRIPTION
This PR is broken. Do not merge it!
repoman says 
 roy@NeddySeagoon_Static ~/portage2/kde-apps/kdeedu-meta $ repoman -d

RepoMan scours the neighborhood...
  dependency.badindev           3
   kde-apps/kdeedu-meta/kdeedu-meta-18.12.3.ebuild: RDEPEND: ~arm64(default/linux/arm64/17.0)
['>=kde-apps/kalzium-18.12.3:5']
   kde-apps/kdeedu-meta/kdeedu-meta-18.12.3.ebuild: RDEPEND: ~arm64(default/linux/arm64/17.0/desktop/systemd)
['>=kde-apps/kalzium-18.12.3:5']
   kde-apps/kdeedu-meta/kdeedu-meta-18.12.3.ebuild: RDEPEND: ~arm64(default/linux/arm64/17.0/systemd)
['>=kde-apps/kalzium-18.12.3:5']

and at the same time

roy@NeddySeagoon_Static ~/portage2/kde-apps/kdeedu-meta $ cd ../../kde-apps/kalzium
roy@NeddySeagoon_Static ~/portage2/kde-apps/kalzium $ repoman -d

RepoMan scours the neighborhood...

Note: use --without-mask to check KEYWORDS on dependencies of masked packages

RepoMan sez: "If everyone were like you, I'd be out of business!"

So kdeedu-meta claims that kde-apps/kalzium is broken but kde-apps/kalzium says that its not.
Let CIBot poke at it. 
