### PR TITLE
dev-util/vmtouch, sys-fs/dfc: use HTTPS

### DIFF
--- a/dev-util/vmtouch/vmtouch-1.3.0.ebuild
+++ b/dev-util/vmtouch/vmtouch-1.3.0.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="Virtual Memory Toucher, portable file system cache diagnostics and control"
-HOMEPAGE="http://hoytech.com/vmtouch/"
+HOMEPAGE="https://hoytech.com/vmtouch/"
 SRC_URI="https://github.com/hoytech/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-util/vmtouch/vmtouch-1.3.1.ebuild
+++ b/dev-util/vmtouch/vmtouch-1.3.1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Virtual Memory Toucher, portable file system cache diagnostics and control"
-HOMEPAGE="http://hoytech.com/vmtouch/"
+HOMEPAGE="https://hoytech.com/vmtouch/"
 SRC_URI="https://github.com/hoytech/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"

--- a/sys-fs/dfc/dfc-3.1.1.ebuild
+++ b/sys-fs/dfc/dfc-3.1.1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="A simple CLI tool that display file system usage, with colors"
-HOMEPAGE="http://projects.gw-computing.net/projects/dfc"
-SRC_URI="http://projects.gw-computing.net/attachments/download/615/${P}.tar.gz"
+HOMEPAGE="https://projects.gw-computing.net/projects/dfc"
+SRC_URI="https://projects.gw-computing.net/attachments/download/615/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Hi,

Simple fix to use http instead of https for dev-util/vmtouch and sys-fs/dfc.
Please review.