### PR TITLE
Kdesdk meta

### DIFF
--- a/app-arch/advancecomp/advancecomp-2.2_pre20190301.ebuild
+++ b/app-arch/advancecomp/advancecomp-2.2_pre20190301.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/amadvance/advancecomp/archive/${EGIT_COMMIT}.tar.gz
 
 LICENSE="GPL-2+ Apache-2.0 LGPL-2.1+ MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86 ~x86-fbsd"
 IUSE=""
 
 RDEPEND="app-arch/bzip2:=

--- a/app-text/gtkspell/gtkspell-3.0.9.ebuild
+++ b/app-text/gtkspell/gtkspell-3.0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/project/${PN}/${PV}/${MY_P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="3/0"
-KEYWORDS="~alpha amd64 ~arm hppa ~ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ~ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos ~x86-solaris"
 IUSE="+introspection vala"
 REQUIRED_USE="vala? ( introspection )"
 

--- a/dev-python/diff-match-patch/diff-match-patch-20121119.ebuild
+++ b/dev-python/diff-match-patch/diff-match-patch-20121119.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE=""
 
 RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-python/iniparse/iniparse-0.4-r2.ebuild
+++ b/dev-python/iniparse/iniparse-0.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT PSF-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE=""
 
 DEPEND=">=dev-python/six-1.10.0[${PYTHON_USEDEP}]"

--- a/dev-python/pyenchant/pyenchant-2.0.0.ebuild
+++ b/dev-python/pyenchant/pyenchant-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="test"
 
 RDEPEND="app-text/enchant"

--- a/dev-python/python-levenshtein/python-levenshtein-0.12.0.ebuild
+++ b/dev-python/python-levenshtein/python-levenshtein-0.12.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,7 +18,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ia64 x86"
+KEYWORDS="amd64 ~arm64 ~ia64 x86"
 IUSE="doc"
 
 REQUIRED_USE="doc? ( || ( $(python_gen_useflags 'python2*' pypy) ) )"

--- a/dev-python/translate-toolkit/translate-toolkit-2.0.0.ebuild
+++ b/dev-python/translate-toolkit/translate-toolkit-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,7 +16,7 @@ SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/${MY_PV}.tar.gz -> ${P}.ta
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm64 x86 ~amd64-linux ~x86-linux"
 IUSE="doc +html +ical +ini +subtitles +yaml"
 
 COMMON_DEPEND="

--- a/dev-python/utidylib/utidylib-0.3-r2.ebuild
+++ b/dev-python/utidylib/utidylib-0.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -15,7 +15,7 @@ SRC_URI="http://dl.cihar.com/${PN}/${MY_P}.tar.bz2"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 x86"
+KEYWORDS="amd64 ~arm64 ppc ppc64 x86"
 IUSE="doc test"
 
 RDEPEND="

--- a/kde-apps/cervisia/cervisia-18.12.3.ebuild
+++ b/kde-apps/cervisia/cervisia-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="CVS frontend by KDE"
 HOMEPAGE="https://www.kde.org/applications/development/cervisia"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/dolphin-plugins-git/dolphin-plugins-git-18.12.3.ebuild
+++ b/kde-apps/dolphin-plugins-git/dolphin-plugins-git-18.12.3.ebuild
@@ -9,7 +9,7 @@ MY_PLUGIN_NAME="git"
 inherit kde5
 
 DESCRIPTION="Dolphin plugin for Git integration"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/dolphin-plugins-subversion/dolphin-plugins-subversion-18.12.3.ebuild
+++ b/kde-apps/dolphin-plugins-subversion/dolphin-plugins-subversion-18.12.3.ebuild
@@ -9,7 +9,7 @@ MY_PLUGIN_NAME="svn"
 inherit kde5
 
 DESCRIPTION="Dolphin plugin for Subversion integration"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kapptemplate/kapptemplate-18.12.3.ebuild
+++ b/kde-apps/kapptemplate/kapptemplate-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Shell script to create the necessary framework to develop KDE applications"
 HOMEPAGE="https://www.kde.org/applications/development/kapptemplate"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kcachegrind/kcachegrind-18.12.3.ebuild
+++ b/kde-apps/kcachegrind/kcachegrind-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 DESCRIPTION="Frontend for Cachegrind by KDE"
 HOMEPAGE="https://www.kde.org/applications/development/kcachegrind
 https://kcachegrind.github.io/html/Home.html"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="nls"
 
 BDEPEND="

--- a/kde-apps/kde-dev-scripts/kde-dev-scripts-18.12.3.ebuild
+++ b/kde-apps/kde-dev-scripts/kde-dev-scripts-18.12.3.ebuild
@@ -7,7 +7,7 @@ KDE_HANDBOOK="true"
 inherit kde5
 
 DESCRIPTION="KDE Development Scripts"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 # kdelibs4support - required for kdex.dtd

--- a/kde-apps/kde-dev-utils/kde-dev-utils-18.12.3.ebuild
+++ b/kde-apps/kde-dev-utils/kde-dev-utils-18.12.3.ebuild
@@ -7,7 +7,7 @@ inherit kde5
 
 DESCRIPTION="KDE Development Utilities"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kdesdk-kioslaves/kdesdk-kioslaves-18.12.3.ebuild
+++ b/kde-apps/kdesdk-kioslaves/kdesdk-kioslaves-18.12.3.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit kde5
 
 DESCRIPTION="kioslaves from kdesdk package"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kdesdk-meta/kdesdk-meta-18.12.3.ebuild
+++ b/kde-apps/kdesdk-meta/kdesdk-meta-18.12.3.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="https://www.kde.org/applications/development"
 
 LICENSE="metapackage"
 SLOT="5"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="bazaar cvs git mercurial subversion +webkit"
 
 RDEPEND="

--- a/kde-apps/kdesdk-thumbnailers/kdesdk-thumbnailers-18.12.3.ebuild
+++ b/kde-apps/kdesdk-thumbnailers/kdesdk-thumbnailers-18.12.3.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit kde5
 
 DESCRIPTION="Thumbnail generator for PO files"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kompare/kompare-18.12.3.ebuild
+++ b/kde-apps/kompare/kompare-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="A program to view the differences between files"
 HOMEPAGE="https://www.kde.org/applications/development/kompare"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kross-interpreters/kross-interpreters-18.12.3.ebuild
+++ b/kde-apps/kross-interpreters/kross-interpreters-18.12.3.ebuild
@@ -8,7 +8,7 @@ USE_RUBY="ruby25"
 inherit kde5 python-single-r1 ruby-single
 
 DESCRIPTION="Kross interpreter plugins for programming languages"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+python ruby"
 
 REQUIRED_USE="|| ( python ruby ) python? ( ${PYTHON_REQUIRED_USE} )"

--- a/kde-apps/libkomparediff2/libkomparediff2-18.12.3.ebuild
+++ b/kde-apps/libkomparediff2/libkomparediff2-18.12.3.ebuild
@@ -7,7 +7,7 @@ KDE_TEST="true"
 inherit kde5
 
 DESCRIPTION="KDE library to compare files and strings"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/lokalize/lokalize-18.12.3.ebuild
+++ b/kde-apps/lokalize/lokalize-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit python-single-r1 kde5
 DESCRIPTION="KDE Applications 5 translation tool"
 HOMEPAGE="https://www.kde.org/applications/development/lokalize
 https://l10n.kde.org/tools/"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/kde-apps/umbrello/umbrello-18.12.3.ebuild
+++ b/kde-apps/umbrello/umbrello-18.12.3.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://www.kde.org/applications/development/umbrello
 	https://umbrello.kde.org
 "
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="

--- a/media-gfx/optipng/optipng-0.7.7.ebuild
+++ b/media-gfx/optipng/optipng-0.7.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 RDEPEND="sys-libs/zlib

--- a/media-video/gaupol/gaupol-1.5.ebuild
+++ b/media-video/gaupol/gaupol-1.5.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/otsaloma/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="spell test"
 
 RDEPEND="


### PR DESCRIPTION
Does what it says on the tin. Adds the ~arm64 keyword to kdesdk-meta and its dependencies.
There is no 'footering' with masking any USE flags either. 