### PR TITLE
Kdeaccessibility meta

### DIFF
--- a/kde-apps/kdeaccessibility-meta/kdeaccessibility-meta-18.12.3.ebuild
+++ b/kde-apps/kdeaccessibility-meta/kdeaccessibility-meta-18.12.3.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="https://www.kde.org/"
 
 LICENSE="metapackage"
 SLOT="5"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 RDEPEND="

--- a/kde-apps/kmag/kmag-18.12.3.ebuild
+++ b/kde-apps/kmag/kmag-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="KDE screen magnifier"
 HOMEPAGE="https://www.kde.org/applications/utilities/kmag/"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="keyboardfocus"
 
 DEPEND="

--- a/kde-apps/kmousetool/kmousetool-18.12.3.ebuild
+++ b/kde-apps/kmousetool/kmousetool-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="KDE program that clicks the mouse for you"
 HOMEPAGE="https://www.kde.org/applications/utilities/kmousetool/"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="

--- a/kde-apps/kmouth/kmouth-18.12.3.ebuild
+++ b/kde-apps/kmouth/kmouth-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Text-to-speech synthesizer front end"
 HOMEPAGE="https://www.kde.org/applications/utilities/kmouth/"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/media-libs/libqaccessibilityclient/libqaccessibilityclient-0.4.0.ebuild
+++ b/media-libs/libqaccessibilityclient/libqaccessibilityclient-0.4.0.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://accessibility.kde.org/ https://cgit.kde.org/libqaccessibilityc
 SRC_URI="mirror://kde/stable/${PN}/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="


### PR DESCRIPTION
kdeaccessibility-meta for ~arm64.
Just  FEATURES=test USE=test emerge <stuff that worked> and keyword.