### PR TITLE
media-sound/pavucontrol-qt: block 'lxqt-base/lxqt-l10n'

### DIFF
--- a/media-sound/pavucontrol-qt/pavucontrol-qt-0.14.1.ebuild
+++ b/media-sound/pavucontrol-qt/pavucontrol-qt-0.14.1.ebuild
@@ -31,4 +31,6 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	media-sound/pulseaudio[glib]
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	!lxqt-base/lxqt-l10n
+"


### PR DESCRIPTION
Somehow missed adding the blocker for this one.