### PR TITLE
dev-libs/mxml: fix slot version

### DIFF
--- a/dev-libs/mxml/mxml-3.0.ebuild
+++ b/dev-libs/mxml/mxml-3.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 SRC_URI="https://github.com/michaelrsweet/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Mini-XML"
-SLOT="1/6"
+SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="static-libs threads"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/680158
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>