### PR TITLE
x11-libs/qtermwidget and x11-terms/qterminal: block 'lxqt-base/lxqt-l10n'

### DIFF
--- a/x11-libs/qtermwidget/qtermwidget-0.14.1.ebuild
+++ b/x11-libs/qtermwidget/qtermwidget-0.14.1.ebuild
@@ -28,4 +28,6 @@ DEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	!lxqt-base/lxqt-l10n
+"

--- a/x11-terms/qterminal/qterminal-0.14.1.ebuild
+++ b/x11-terms/qterminal/qterminal-0.14.1.ebuild
@@ -28,7 +28,9 @@ DEPEND="
 	x11-libs/libX11
 	~x11-libs/qtermwidget-${PV}
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	!lxqt-base/lxqt-l10n
+"
 
 pkg_postinst() {
 	xdg_icon_cache_update


### PR DESCRIPTION
These also got away without them blockers.