### PR TITLE
Kdepim meta

### DIFF
--- a/app-arch/pax/pax-20161104.ebuild
+++ b/app-arch/pax/pax-20161104.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ SRC_URI="https://www.mirbsd.org/MirOS/dist/mir/cpio/paxmirabilis-${PV}.cpio.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86"
 
 RDEPEND="
 	dev-libs/libbsd

--- a/app-crypt/paperkey/paperkey-1.6.ebuild
+++ b/app-crypt/paperkey/paperkey-1.6.ebuild
@@ -9,5 +9,5 @@ SRC_URI="http://www.jabberwocky.com/software/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86 ~x64-macos"
+KEYWORDS="amd64 ~arm64 x86 ~x64-macos"
 IUSE=""

--- a/dev-libs/kdiagram/kdiagram-2.6.1.ebuild
+++ b/dev-libs/kdiagram/kdiagram-2.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,7 +16,7 @@ IUSE=""
 REQUIRED_USE="test? ( examples )"
 
 if [[ ${KDE_BUILD_TYPE} = release ]]; then
-	KEYWORDS="amd64 x86"
+	KEYWORDS="amd64 ~arm64 x86"
 	SRC_URI="mirror://kde/stable/${PN}/${PV}/${P}.tar.xz"
 fi
 

--- a/dev-qt/qtnetworkauth/qtnetworkauth-5.12.1.ebuild
+++ b/dev-qt/qtnetworkauth/qtnetworkauth-5.12.1.ebuild
@@ -8,7 +8,7 @@ DESCRIPTION="Network authorization library for the Qt5 framework"
 LICENSE="GPL-3"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
 IUSE=""

--- a/kde-apps/akonadi-calendar/akonadi-calendar-18.12.3.ebuild
+++ b/kde-apps/akonadi-calendar/akonadi-calendar-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Library for akonadi calendar integration"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/akonadi-import-wizard/akonadi-import-wizard-18.12.3.ebuild
+++ b/kde-apps/akonadi-import-wizard/akonadi-import-wizard-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 DESCRIPTION="Assistant to import PIM data from other applications into Akonadi"
 HOMEPAGE+=" https://userbase.kde.org/Kmail/Import_Options"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/akonadi-mime/akonadi-mime-18.12.3.ebuild
+++ b/kde-apps/akonadi-mime/akonadi-mime-18.12.3.ebuild
@@ -7,7 +7,7 @@ KDE_TEST="true"
 inherit kde5
 
 DESCRIPTION="Library for akonadi mime types"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 LICENSE="GPL-2+ LGPL-2.1+"
 IUSE=""
 

--- a/kde-apps/akonadi-notes/akonadi-notes-18.12.3.ebuild
+++ b/kde-apps/akonadi-notes/akonadi-notes-18.12.3.ebuild
@@ -7,7 +7,7 @@ KDE_TEST="true"
 inherit kde5
 
 DESCRIPTION="Library for akonadi notes integration"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 LICENSE="GPL-2+"
 IUSE=""
 

--- a/kde-apps/akonadi-search/akonadi-search-18.12.3.ebuild
+++ b/kde-apps/akonadi-search/akonadi-search-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 DESCRIPTION="Libraries and daemons to implement searching in Akonadi"
 HOMEPAGE="https://cgit.kde.org/akonadi-search.git"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 BDEPEND="

--- a/kde-apps/akonadiconsole/akonadiconsole-18.12.3.ebuild
+++ b/kde-apps/akonadiconsole/akonadiconsole-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 DESCRIPTION="Application for debugging Akonadi Resources"
 LICENSE="GPL-2+ LGPL-2.1+ handbook? ( FDL-1.2+ )"
 HOMEPAGE="https://www.kde.org/"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 IUSE=""
 

--- a/kde-apps/akregator/akregator-18.12.3.ebuild
+++ b/kde-apps/akregator/akregator-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 DESCRIPTION="News feed aggregator"
 HOMEPAGE="https://www.kde.org/applications/internet/akregator"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 IUSE=""
 

--- a/kde-apps/calendarjanitor/calendarjanitor-18.12.3.ebuild
+++ b/kde-apps/calendarjanitor/calendarjanitor-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="Tool to scan calendar data for buggy instances"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 IUSE=""
 

--- a/kde-apps/calendarsupport/calendarsupport-18.12.3.ebuild
+++ b/kde-apps/calendarsupport/calendarsupport-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Calendar support library"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/eventviews/eventviews-18.12.3.ebuild
+++ b/kde-apps/eventviews/eventviews-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Calendar viewer for KDE PIM"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/grantlee-editor/grantlee-editor-18.12.3.ebuild
+++ b/kde-apps/grantlee-editor/grantlee-editor-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Utilities and tools to manage themes in KDE PIM applications"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/grantleetheme/grantleetheme-18.12.3.ebuild
+++ b/kde-apps/grantleetheme/grantleetheme-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Library for Grantlee plugins"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="

--- a/kde-apps/incidenceeditor/incidenceeditor-18.12.3.ebuild
+++ b/kde-apps/incidenceeditor/incidenceeditor-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Incidence editor for korganizer"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kaddressbook/kaddressbook-18.12.3.ebuild
+++ b/kde-apps/kaddressbook/kaddressbook-18.12.3.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Address book application based on KDE Frameworks"
 HOMEPAGE="https://www.kde.org/applications/office/kaddressbook/"
 
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kalarm/kalarm-18.12.3.ebuild
+++ b/kde-apps/kalarm/kalarm-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 DESCRIPTION="Application to manage alarms and other timer based alerts for the desktop"
 HOMEPAGE+=" https://userbase.kde.org/KAlarm"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="X"
 
 BDEPEND="

--- a/kde-apps/kalarmcal/kalarmcal-18.12.3.ebuild
+++ b/kde-apps/kalarmcal/kalarmcal-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Client library to access and handling of KAlarm calendar data"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="

--- a/kde-apps/kcalcore/kcalcore-18.12.3.ebuild
+++ b/kde-apps/kcalcore/kcalcore-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Library for handling calendar data"
 LICENSE="GPL-2+ test? ( LGPL-3+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 BDEPEND="

--- a/kde-apps/kcalutils/kcalutils-18.12.3.ebuild
+++ b/kde-apps/kcalutils/kcalutils-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Library providing utility functions for the handling of calendar data"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kdav/kdav-18.12.3.ebuild
+++ b/kde-apps/kdav/kdav-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="DAV protocol implemention with KJobs"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kdepim-addons/kdepim-addons-18.12.3.ebuild
+++ b/kde-apps/kdepim-addons/kdepim-addons-18.12.3.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Plugins for KDE Personal Information Management Suite"
 HOMEPAGE="https://www.kde.org/applications/office/kontact/"
 
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="importwizard markdown"
 
 COMMON_DEPEND="

--- a/kde-apps/kdepim-apps-libs/kdepim-apps-libs-18.12.3.ebuild
+++ b/kde-apps/kdepim-apps-libs/kdepim-apps-libs-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Libraries for KDE PIM applications"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kdepim-runtime/kdepim-runtime-18.12.3.ebuild
+++ b/kde-apps/kdepim-runtime/kdepim-runtime-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="Runtime plugin collection to extend the functionality of KDE PIM"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+oauth"
 
 # TODO kolab

--- a/kde-apps/kimap/kimap-18.12.3.ebuild
+++ b/kde-apps/kimap/kimap-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Library for interacting with IMAP servers"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="

--- a/kde-apps/kitinerary/kitinerary-18.12.3.ebuild
+++ b/kde-apps/kitinerary/kitinerary-18.12.3.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Data Model and Extraction System for Travel Reservation information
 HOMEPAGE="https://www.kde.org/applications/office/kontact/"
 
 LICENSE="LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="pdf"
 
 DEPEND="

--- a/kde-apps/kldap/kldap-18.12.3.ebuild
+++ b/kde-apps/kldap/kldap-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Library for interacting with LDAP servers"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kleopatra/kleopatra-18.12.3.ebuild
+++ b/kde-apps/kleopatra/kleopatra-18.12.3.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Certificate manager and GUI for OpenPGP and CMS cryptography"
 HOMEPAGE="https://www.kde.org/applications/utilities/kleopatra"
 
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kmail-account-wizard/kmail-account-wizard-18.12.3.ebuild
+++ b/kde-apps/kmail-account-wizard/kmail-account-wizard-18.12.3.ebuild
@@ -11,7 +11,7 @@ inherit kde5
 DESCRIPTION="Assistant for KMail accounts configuration"
 HOMEPAGE+=" https://userbase.kde.org/Kmail/Account_Wizard"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kmail/kmail-18.12.3.ebuild
+++ b/kde-apps/kmail/kmail-18.12.3.ebuild
@@ -11,7 +11,7 @@ inherit kde5
 DESCRIPTION="Email client, supporting POP3 and IMAP mailboxes."
 HOMEPAGE="https://www.kde.org/applications/internet/kmail/"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 BDEPEND="

--- a/kde-apps/kmailtransport/kmailtransport-18.12.3.ebuild
+++ b/kde-apps/kmailtransport/kmailtransport-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Mail transport service"
 LICENSE="LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="

--- a/kde-apps/kmbox/kmbox-18.12.3.ebuild
+++ b/kde-apps/kmbox/kmbox-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Library for accessing MBox format mail storages"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="$(add_kdeapps_dep kmime)"

--- a/kde-apps/knotes/knotes-18.12.3.ebuild
+++ b/kde-apps/knotes/knotes-18.12.3.ebuild
@@ -11,7 +11,7 @@ inherit kde5
 DESCRIPTION="Note taking application"
 HOMEPAGE="https://www.kde.org/"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 IUSE=""
 

--- a/kde-apps/konsolekalendar/konsolekalendar-18.12.3.ebuild
+++ b/kde-apps/konsolekalendar/konsolekalendar-18.12.3.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Command line interface to KDE calendars"
 HOMEPAGE+=" https://userbase.kde.org/KonsoleKalendar"
 
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kontact/kontact-18.12.3.ebuild
+++ b/kde-apps/kontact/kontact-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Container application to unify several major PIM applications within one"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kontactinterface/kontactinterface-18.12.3.ebuild
+++ b/kde-apps/kontactinterface/kontactinterface-18.12.3.ebuild
@@ -7,7 +7,7 @@ inherit kde5
 
 DESCRIPTION="Library for embedding KParts in a Kontact component"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/korganizer/korganizer-18.12.3.ebuild
+++ b/kde-apps/korganizer/korganizer-18.12.3.ebuild
@@ -11,7 +11,7 @@ inherit kde5
 DESCRIPTION="Organizational assistant, providing calendars and other similar functionality"
 HOMEPAGE="https://www.kde.org/applications/office/korganizer/"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="X"
 
 BDEPEND="

--- a/kde-apps/kpkpass/kpkpass-18.12.3.ebuild
+++ b/kde-apps/kpkpass/kpkpass-18.12.3.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Library to deal with Apple Wallet pass files"
 HOMEPAGE="https://www.kde.org/applications/office/kontact/"
 
 LICENSE="LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/ksmtp/ksmtp-18.12.3.ebuild
+++ b/kde-apps/ksmtp/ksmtp-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Job-based library to send email through an SMTP server"
 LICENSE="LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/libgravatar/libgravatar-18.12.3.ebuild
+++ b/kde-apps/libgravatar/libgravatar-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Library for gravatar integration"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/libkdepim/libkdepim-18.12.3.ebuild
+++ b/kde-apps/libkdepim/libkdepim-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="Common PIM libraries"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/libkgapi/libkgapi-18.12.3.ebuild
+++ b/kde-apps/libkgapi/libkgapi-18.12.3.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Library for accessing Google calendar and contact resources"
 HOMEPAGE="https://cgit.kde.org/libkgapi.git"
 
 LICENSE="LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="nls"
 
 BDEPEND="

--- a/kde-apps/libksieve/libksieve-18.12.3.ebuild
+++ b/kde-apps/libksieve/libksieve-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="Common PIM libraries"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="

--- a/kde-apps/libktnef/libktnef-18.12.3.ebuild
+++ b/kde-apps/libktnef/libktnef-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Library for handling TNEF data"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/mailcommon/mailcommon-18.12.3.ebuild
+++ b/kde-apps/mailcommon/mailcommon-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="Common mail library"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 BDEPEND="

--- a/kde-apps/mailimporter/mailimporter-18.12.3.ebuild
+++ b/kde-apps/mailimporter/mailimporter-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Library to import mail from various sources"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/mbox-importer/mbox-importer-18.12.3.ebuild
+++ b/kde-apps/mbox-importer/mbox-importer-18.12.3.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Import mbox email archives from various sources into Akonadi"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/messagelib/messagelib-18.12.3.ebuild
+++ b/kde-apps/messagelib/messagelib-18.12.3.ebuild
@@ -9,7 +9,7 @@ inherit kde5
 
 DESCRIPTION="Libraries for messaging functions"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/pim-data-exporter/pim-data-exporter-18.12.3.ebuild
+++ b/kde-apps/pim-data-exporter/pim-data-exporter-18.12.3.ebuild
@@ -11,7 +11,7 @@ inherit kde5
 DESCRIPTION="Assistant to backup and archive PIM data and configuration"
 HOMEPAGE+=" https://userbase.kde.org/Kmail/Backup_Options"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/pim-sieve-editor/pim-sieve-editor-18.12.3.ebuild
+++ b/kde-apps/pim-sieve-editor/pim-sieve-editor-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="Assistant for editing IMAP Sieve filters"
 LICENSE="GPL-2+ handbook? ( FDL-1.2+ )"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/pimcommon/pimcommon-18.12.3.ebuild
+++ b/kde-apps/pimcommon/pimcommon-18.12.3.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="Common PIM libraries"
 LICENSE="GPL-2+ LGPL-2.1+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="share"
 
 BDEPEND="

--- a/kde-frameworks/syndication/syndication-5.56.0.ebuild
+++ b/kde-frameworks/syndication/syndication-5.56.0.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Library for parsing RSS and Atom feeds"
 LICENSE="LGPL-2+"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 COMMON_DEPEND="

--- a/mail-filter/bogofilter/bogofilter-1.2.4-r2.ebuild
+++ b/mail-filter/bogofilter/bogofilter-1.2.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~hppa ia64 ppc ppc64 ~sh ~sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ppc ppc64 ~sh ~sparc x86 ~x86-fbsd"
 IUSE="berkdb sqlite tokyocabinet"
 
 # pax needed for bf_tar

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,12 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Roy Bamford <neddyseagoon@gentoo.org> (14 Mar 2019)
+# mask mail-filter/spamassassin meanwhile. It builds with 
+# FEATURES=yes USE=test but ths allows kde-apps/kdepim-meta to 
+# get ~arm64 now. 
+kde-apps/kdepim-meta spamassassin
+
 # Roy Bamford <neddyseagoon@gentoo.org> (12 Mar 2019)
 # Let kde-apps/akonadi use mysql.
 kde-apps/akonadi -mysql

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Roy Bamford <neddyseagoon@gentoo.org> (12 Mar 2019)
+# Let kde-apps/akonadi use mysql.
+kde-apps/akonadi -mysql
+
 # Mart Raudsepp <leio@gentoo.org> (11 Mar 2019)
 # media-libs/bcg729 not keyworded yet
 net-analyzer/wireshark bcg729


### PR DESCRIPTION
kdepim-meta for ~arm64 users. kdepim-meta mail-filter/spamassassin is in package.use.mask meanwhile.
Its known to build and install with FEATURES=test USE=test but it real life is picking up, so I'll keyword it later.