### PR TITLE
sys-apps/yarn: Set installationMethod = portage

### DIFF
--- a/sys-apps/yarn/yarn-1.10.1.ebuild
+++ b/sys-apps/yarn/yarn-1.10.1.ebuild
@@ -20,6 +20,11 @@ DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${MY_P}"
 
+src_prepare() {
+	default
+	sed -i 's/"installationMethod": "tar"/"installationMethod": "portage"/g' "${S}/package.json" || die
+}
+
 src_install() {
 	local install_dir="/usr/$(get_libdir)/node_modules/yarn" path shebang
 	insinto "${install_dir}"

--- a/sys-apps/yarn/yarn-1.12.3.ebuild
+++ b/sys-apps/yarn/yarn-1.12.3.ebuild
@@ -20,6 +20,11 @@ DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${MY_P}"
 
+src_prepare() {
+	default
+	sed -i 's/"installationMethod": "tar"/"installationMethod": "portage"/g' "${S}/package.json" || die
+}
+
 src_install() {
 	local install_dir="/usr/$(get_libdir)/node_modules/yarn" path shebang
 	insinto "${install_dir}"

--- a/sys-apps/yarn/yarn-1.13.0.ebuild
+++ b/sys-apps/yarn/yarn-1.13.0.ebuild
@@ -20,6 +20,11 @@ DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${MY_P}"
 
+src_prepare() {
+	default
+	sed -i 's/"installationMethod": "tar"/"installationMethod": "portage"/g' "${S}/package.json" || die
+}
+
 src_install() {
 	local install_dir="/usr/$(get_libdir)/node_modules/yarn" path shebang
 	insinto "${install_dir}"

--- a/sys-apps/yarn/yarn-1.15.2.ebuild
+++ b/sys-apps/yarn/yarn-1.15.2.ebuild
@@ -20,6 +20,11 @@ DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${MY_P}"
 
+src_prepare() {
+	default
+	sed -i 's/"installationMethod": "tar"/"installationMethod": "portage"/g' "${S}/package.json" || die
+}
+
 src_install() {
 	local install_dir="/usr/$(get_libdir)/node_modules/yarn" path shebang
 	insinto "${install_dir}"

--- a/sys-apps/yarn/yarn-1.9.4.ebuild
+++ b/sys-apps/yarn/yarn-1.9.4.ebuild
@@ -20,6 +20,11 @@ DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${MY_P}"
 
+src_prepare() {
+	default
+	sed -i 's/"installationMethod": "tar"/"installationMethod": "portage"/g' "${S}/package.json" || die
+}
+
 src_install() {
 	local install_dir="/usr/$(get_libdir)/node_modules/yarn" path shebang
 	insinto "${install_dir}"


### PR DESCRIPTION
By setting the installation method, yarn will do one of two things:

1) For older versions with no message for installationMethod = portage*,
no message will be shown. (without this, a message would be shown
recommending the user download and install a new version using a shell
script)

2) For versions that understand installationMethod = portage*,
a message telling the user to update yarn via portage will be shown.

*: https://github.com/yarnpkg/yarn/pull/7123

Signed-off-by: Jonathan Janzen jjjonjanzen@gmail.com
Package-Manager: Portage-2.3.62, Repoman-2.3.11