### PR TITLE
games-arcade/{afternoonstalker,burgerspace,cosmosmash,epiar,cavezophear}: fix HOMEPAGE, SRC_URI

### DIFF
--- a/games-arcade/afternoonstalker/afternoonstalker-1.1.5-r1.ebuild
+++ b/games-arcade/afternoonstalker/afternoonstalker-1.1.5-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools
 
 DESCRIPTION="Clone of the 1981 Night Stalker video game by Mattel Electronics"
-HOMEPAGE="http://perso.b2b2c.ca/sarrazip/dev/afternoonstalker.html"
-SRC_URI="http://perso.b2b2c.ca/sarrazip/dev/${P}.tar.gz"
+HOMEPAGE="https://perso.b2b2c.ca/~sarrazip/dev/afternoonstalker.html"
+SRC_URI="https://perso.b2b2c.ca/~sarrazip/dev/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/680386
Closes: https://bugs.gentoo.org/680416
Closes: https://bugs.gentoo.org/680668
Closes: https://bugs.gentoo.org/680672
Closes: https://bugs.gentoo.org/680660

Signed-off-by: Daniel Schmidt gen2xmach1ne@tutanota.com
Package-Manager: Portage-2.3.51, Repoman-2.3.11