### PR TITLE
net-analyzer/openvas-libraries: add missing dependency.

### DIFF
--- a/net-analyzer/openvas-libraries/openvas-libraries-9.0.3.ebuild
+++ b/net-analyzer/openvas-libraries/openvas-libraries-9.0.3.ebuild
@@ -17,6 +17,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="extras ldap radius"
 
 DEPEND="
+	app-crypt/gpgme:=
 	dev-libs/hiredis
 	dev-libs/libgcrypt:0=
 	dev-libs/libksba


### PR DESCRIPTION
Add missing dependency that fails to build. app-crypt/gpgme
app-crypt/gpgme is a library for making GnuPG easier to use.
This fixes important failing build bug 680836.
This also fixes version bump request bug 590324.
Bug 590324 has already been solved with old PR-10994
https://github.com/gentoo/gentoo/pull/10994
and all net-analyzer/openvas* components bumped to latest stables
but closing 590324 was forgotten with old PR-10994.Included to this PR.
NOTE:Because off new dependencies ~arm ~ppc keywords
had already been dropped with old PR-10994.
I will open re-keywording bug for this.

Reported-by: Agostino Sarubbo <ago@gentoo.org>
Reported-by: NP-Hardass <np-hardass@gentoo.org>
Acked-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>
Closes: https://bugs.gentoo.org/680836
Closes: https://bugs.gentoo.org/590324
Tested-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>
Signed-off-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>
Package-Manager: Portage-2.3.62, Repoman-2.3.11