### PR TITLE
net-analyzer/openvas: minor improvements

### DIFF
--- a/net-analyzer/openvas/openvas-9.0.0.ebuild
+++ b/net-analyzer/openvas/openvas-9.0.0.ebuild
@@ -14,22 +14,13 @@ KEYWORDS="~amd64 ~x86"
 IUSE="+cli +extras +gsa ldap +ospd radius"
 
 RDEPEND="
-	>=net-analyzer/openvas-libraries-9.0.3
-	>=net-analyzer/openvas-manager-7.0.3
-	>=net-analyzer/openvas-scanner-5.1.3
+	>=net-analyzer/openvas-libraries-9.0.3[extras?]
+	>=net-analyzer/openvas-manager-7.0.3[extras?]
+	>=net-analyzer/openvas-scanner-5.1.3[extras?]
 	cli? ( >=net-analyzer/gvm-tools-1.4.1 )
-	extras? (
-		>=net-analyzer/openvas-libraries-9.0.3[extras]
-		>=net-analyzer/openvas-manager-7.0.3[extras]
-		>=net-analyzer/openvas-scanner-5.1.3[extras]
-	)
-	gsa? (  >=net-analyzer/greenbone-security-assistant-7.0.3
-		extras? ( >=net-analyzer/greenbone-security-assistant-7.0.3[extras] )
-	)
+	gsa? ( >=net-analyzer/greenbone-security-assistant-7.0.3[extras?] )
 	ldap? ( >=net-analyzer/openvas-libraries-9.0.3[ldap] )
-	ospd? ( >=net-analyzer/ospd-1.3.2
-		extras? ( >=net-analyzer/ospd-1.3.2[extras] )
-	)
+	ospd? ( >=net-analyzer/ospd-1.3.2[extras?] )
 	radius? ( >=net-analyzer/openvas-libraries-9.0.3[radius] )"
 
 pkg_postinst() {


### PR DESCRIPTION
Compact form for conditional use dependencies.

5 insertions(+), 14 deletions(-)

```
RDEPEND="
	>=net-analyzer/openvas-libraries-9.0.3
	>=net-analyzer/openvas-manager-7.0.3
	>=net-analyzer/openvas-scanner-5.1.3
	cli? ( >=net-analyzer/gvm-tools-1.4.1 )
	extras? (
		>=net-analyzer/openvas-libraries-9.0.3[extras]
		>=net-analyzer/openvas-manager-7.0.3[extras]
		>=net-analyzer/openvas-scanner-5.1.3[extras]
	)
	gsa? (  >=net-analyzer/greenbone-security-assistant-7.0.3
		extras? ( >=net-analyzer/greenbone-security-assistant-7.0.3[extras] )
	)
	ldap? ( >=net-analyzer/openvas-libraries-9.0.3[ldap] )
	ospd? ( >=net-analyzer/ospd-1.3.2
		extras? ( >=net-analyzer/ospd-1.3.2[extras] )
	)
	radius? ( >=net-analyzer/openvas-libraries-9.0.3[radius] )"
```

=

```

RDEPEND="
	>=net-analyzer/openvas-libraries-9.0.3[extras?]
	>=net-analyzer/openvas-manager-7.0.3[extras?]
	>=net-analyzer/openvas-scanner-5.1.3[extras?]
	cli? ( >=net-analyzer/gvm-tools-1.4.1 )
	gsa? ( >=net-analyzer/greenbone-security-assistant-7.0.3[extras?] )
	ldap? ( >=net-analyzer/openvas-libraries-9.0.3[ldap] )
	ospd? ( >=net-analyzer/ospd-1.3.2[extras?] )
	radius? ( >=net-analyzer/openvas-libraries-9.0.3[radius] )"
```

Signed-off-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>
Package-Manager: Portage-2.3.62, Repoman-2.3.11