### PR TITLE
app-editors/scite: use HTTPS

### DIFF
--- a/app-editors/scite/scite-4.1.3.ebuild
+++ b/app-editors/scite/scite-4.1.3.ebuild
@@ -7,7 +7,7 @@ inherit gnome2-utils toolchain-funcs xdg-utils
 
 MY_PV=${PV//./}
 DESCRIPTION="A very powerful, highly configurable, small editor with syntax coloring"
-HOMEPAGE="http://www.scintilla.org/SciTE.html"
+HOMEPAGE="https://www.scintilla.org/SciTE.html"
 SRC_URI="https://www.scintilla.org/${PN}${MY_PV}.tgz -> ${P}.tgz"
 
 LICENSE="HPND lua? ( MIT )"


### PR DESCRIPTION
Hi,

Looks like the last version lost the https in it's homepage. ;)

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>