### PR TITLE
media-fonts/polarsys-b612-fonts: use HTTPS

### DIFF
--- a/media-fonts/polarsys-b612-fonts/polarsys-b612-fonts-1.003.ebuild
+++ b/media-fonts/polarsys-b612-fonts/polarsys-b612-fonts-1.003.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit font vcs-snapshot
 
 DESCRIPTION="Font designed for aircraft cockpit displays"
-HOMEPAGE="http://b612-font.com/"
+HOMEPAGE="https://b612-font.com/"
 SRC_URI="https://git.polarsys.org/c/b612/b612.git/snapshot/b612-bd14fde2544566e620eab106eb8d6f2b7fb1347e.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="EPL-1.0"


### PR DESCRIPTION
Hi,

Another simple PR to use https instead of http.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>