### PR TITLE
x11-plugins/wmstickynotes: use HTTPS, EAPI7 revbump

### DIFF
--- a/x11-plugins/wmstickynotes/wmstickynotes-0.2-r1.ebuild
+++ b/x11-plugins/wmstickynotes/wmstickynotes-0.2-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="A dockapp for keeping small notes around on the desktop"
+HOMEPAGE="https://sourceforge.net/projects/wmstickynotes/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="x11-libs/gtk+:2"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${P}-gold.patch )

--- a/x11-plugins/wmstickynotes/wmstickynotes-0.2.ebuild
+++ b/x11-plugins/wmstickynotes/wmstickynotes-0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -6,7 +6,7 @@ EAPI=4
 inherit eutils
 
 DESCRIPTION="A dockapp for keeping small notes around on the desktop"
-HOMEPAGE="http://wmstickynotes.sourceforge.net/"
+HOMEPAGE="https://sourceforge.net/projects/wmstickynotes/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"


### PR DESCRIPTION
Hi,

This PR simple updates x11-plugins/wmstickynotes for EAPI7 and fixes to use https instead of http.
Please review.