### PR TITLE
net-irc/unrealircd: Add IUSE=libressl

### DIFF
--- a/net-irc/unrealircd/unrealircd-4.2.0.ebuild
+++ b/net-irc/unrealircd/unrealircd-4.2.0.ebuild
@@ -13,11 +13,12 @@ SRC_URI="https://www.unrealircd.org/${PN}$(ver_cut 1)/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86 ~x86-fbsd ~amd64-linux"
-IUSE="class-nofakelag curl +extban-stacking +operoverride operoverride-verify +prefixaq
-	showlistmodes shunnotices topicisnuhost +usermod"
+IUSE="class-nofakelag curl +extban-stacking libressl +operoverride operoverride-verify
+	+prefixaq showlistmodes shunnotices topicisnuhost +usermod"
 
 RDEPEND="
-	dev-libs/openssl:0=
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:= )
 	dev-libs/libpcre2
 	dev-libs/tre
 	>=net-dns/c-ares-1.7:=

--- a/net-irc/unrealircd/unrealircd-4.2.2.ebuild
+++ b/net-irc/unrealircd/unrealircd-4.2.2.ebuild
@@ -13,12 +13,13 @@ SRC_URI="https://www.unrealircd.org/${PN}$(ver_cut 1)/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86 ~x86-fbsd ~amd64-linux"
-IUSE="class-nofakelag curl +extban-stacking +operoverride operoverride-verify +prefixaq
-	showlistmodes shunnotices topicisnuhost +usermod"
+IUSE="class-nofakelag curl +extban-stacking libressl +operoverride operoverride-verify
+	+prefixaq showlistmodes shunnotices topicisnuhost +usermod"
 
 RDEPEND="
 	>=app-crypt/argon2-20171227-r1:=
-	dev-libs/openssl:0=
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:= )
 	dev-libs/libpcre2
 	dev-libs/tre
 	>=net-dns/c-ares-1.7:=


### PR DESCRIPTION
I’ve confirmed that unrealircd 4.2.0+ works with libressl, 4.0.18-r1 might work as well but I didn’t test it in real life.