### PR TITLE
app-vim/ri-browser: EAPI7 bump, use HTTPS

### DIFF
--- a/app-vim/ri-browser/ri-browser-1.2-r1.ebuild
+++ b/app-vim/ri-browser/ri-browser-1.2-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit vim-plugin
+
+DESCRIPTION="vim plugin: interface for browsing ri/ruby documentation"
+HOMEPAGE="https://www.vim.org/scripts/script.php?script_id=494"
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~sparc"
+
+RDEPEND="dev-lang/ruby"
+
+VIM_PLUGIN_HELPFILES="ri.txt"
+VIM_PLUGIN_MESSAGES="filetype"

--- a/app-vim/ri-browser/ri-browser-1.2.ebuild
+++ b/app-vim/ri-browser/ri-browser-1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
@@ -6,7 +6,7 @@ EAPI=0
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: interface for browsing ri/ruby documentation"
-HOMEPAGE="http://www.vim.org/scripts/script.php?script_id=494"
+HOMEPAGE="https://www.vim.org/scripts/script.php?script_id=494"
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86 ~sparc"


### PR DESCRIPTION
Hi,

This is a very simple EAPI7 bump. Since the package is not stable anyway i've just updated the original ebuild.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>