### PR TITLE
app-vim/selinux-syntax: EAPI7 bump

### DIFF
--- a/app-vim/selinux-syntax/selinux-syntax-20041225-r1.ebuild
+++ b/app-vim/selinux-syntax/selinux-syntax-20041225-r1.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit vim-plugin
+
+DESCRIPTION="vim plugin: SELinux type enforcement policy syntax"
+HOMEPAGE="http://www.cip.ifi.lmu.de/~bleher/selinux/"
+LICENSE="vim"
+KEYWORDS="~alpha ~amd64 ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+
+VIM_PLUGIN_HELPTEXT=\
+"This plugin provides syntax highlighting for SELinux type enforcement
+policy (*.te) files."


### PR DESCRIPTION
Hi,

This PR only bump app-vim/selinux-syntax to EAPI7.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>