### PR TITLE
app-admin/keepassxc: add missing qtsvg dep

### DIFF
--- a/app-admin/keepassxc/keepassxc-2.4.0.ebuild
+++ b/app-admin/keepassxc/keepassxc-2.4.0.ebuild
@@ -33,6 +33,7 @@ RDEPEND="
 	dev-qt/qtdbus:5
 	dev-qt/qtgui:5
 	dev-qt/qtnetwork:5
+	dev-qt/qtsvg:5
 	dev-qt/qtwidgets:5
 	media-gfx/qrencode:=
 	sys-libs/zlib

--- a/app-admin/keepassxc/keepassxc-9999.ebuild
+++ b/app-admin/keepassxc/keepassxc-9999.ebuild
@@ -33,6 +33,7 @@ RDEPEND="
 	dev-qt/qtdbus:5
 	dev-qt/qtgui:5
 	dev-qt/qtnetwork:5
+	dev-qt/qtsql:5
 	dev-qt/qtwidgets:5
 	media-gfx/qrencode:=
 	sys-libs/zlib


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/681562

Signed-off-by: David Heidelberg <david@ixit.cz>