### PR TITLE
media-plugins/kodi-vfs-rar vs media-plugins/kodi-vfs-libarchive: postinst message that they compete

### DIFF
--- a/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-1.0.2.ebuild
+++ b/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-1.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -41,3 +41,9 @@ DEPEND="
 	)
 	=media-tv/kodi-18*
 	"
+
+pkg_postinst() {
+	elog "${PN} competes with media-plugins/kodi-vfs-rar."
+	elog "Both plugins register the RAR extension resulting in Kodi not"
+	elog "recognizing RAR at all. So be aware to activate only one of them."
+}

--- a/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-1.0.5.ebuild
+++ b/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-1.0.5.ebuild
@@ -41,3 +41,9 @@ DEPEND="
 	)
 	=media-tv/kodi-18*
 	"
+
+pkg_postinst() {
+	elog "${PN} competes with media-plugins/kodi-vfs-rar."
+	elog "Both plugins register the RAR extension resulting in Kodi not"
+	elog "recognizing RAR at all. So be aware to activate only one of them."
+}

--- a/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-9999.ebuild
+++ b/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -41,3 +41,9 @@ DEPEND="
 	)
 	~media-tv/kodi-9999
 	"
+
+pkg_postinst() {
+	elog "${PN} competes with media-plugins/kodi-vfs-rar."
+	elog "Both plugins register the RAR extension resulting in Kodi not"
+	elog "recognizing RAR at all. So be aware to activate only one of them."
+}

--- a/media-plugins/kodi-vfs-rar/kodi-vfs-rar-2.0.5.ebuild
+++ b/media-plugins/kodi-vfs-rar/kodi-vfs-rar-2.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -32,3 +32,9 @@ DEPEND="
 	=media-libs/kodi-platform-18*
 	=media-tv/kodi-18*
 	"
+
+pkg_postinst() {
+	elog "${PN} competes with media-plugins/kodi-vfs-libarchive."
+	elog "Both plugins register the RAR extension resulting in Kodi not"
+	elog "recognizing RAR at all. So be aware to activate only one of them."
+}

--- a/media-plugins/kodi-vfs-rar/kodi-vfs-rar-2.0.6.ebuild
+++ b/media-plugins/kodi-vfs-rar/kodi-vfs-rar-2.0.6.ebuild
@@ -32,3 +32,9 @@ DEPEND="
 	=media-libs/kodi-platform-18*
 	=media-tv/kodi-18*
 	"
+
+pkg_postinst() {
+	elog "${PN} competes with media-plugins/kodi-vfs-libarchive."
+	elog "Both plugins register the RAR extension resulting in Kodi not"
+	elog "recognizing RAR at all. So be aware to activate only one of them."
+}

--- a/media-plugins/kodi-vfs-rar/kodi-vfs-rar-9999.ebuild
+++ b/media-plugins/kodi-vfs-rar/kodi-vfs-rar-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -32,3 +32,9 @@ DEPEND="
 	~media-libs/kodi-platform-9999
 	~media-tv/kodi-9999
 	"
+
+pkg_postinst() {
+	elog "${PN} competes with media-plugins/kodi-vfs-libarchive."
+	elog "Both plugins register the RAR extension resulting in Kodi not"
+	elog "recognizing RAR at all. So be aware to activate only one of them."
+}


### PR DESCRIPTION
The two plugins result in a [conflict](https://github.com/xbmc/vfs.rar/issues/29) when activating both of them. However, both of them are installable in parallel, so a merge conflict might be too much.

This pull requests adds a message so users are less confused.

