### PR TITLE
net-wireless/wpa_supplicant: restore USE=suiteb

### DIFF
--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.7-r3.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.7-r3.ebuild
@@ -18,7 +18,7 @@ else
 fi
 
 SLOT="0"
-IUSE="ap bindist dbus eap-sim eapol_test fasteap +hs2-0 libressl macsec p2p privsep ps3 qt5 readline selinux smartcard tdls uncommon-eap-types wimax wps kernel_linux kernel_FreeBSD"
+IUSE="ap bindist dbus eap-sim eapol_test fasteap +hs2-0 libressl macsec p2p privsep ps3 qt5 readline selinux smartcard suiteb tdls uncommon-eap-types wimax wps kernel_linux kernel_FreeBSD"
 
 CDEPEND="dbus? ( sys-apps/dbus )
 	kernel_linux? (
@@ -227,7 +227,9 @@ src_configure() {
 		Kconfig_style_config OWE
 		Kconfig_style_config SAE
 		Kconfig_style_config DPP
-		Kconfig_style_config SUITEB
+		if use suiteb; then
+			Kconfig_style_config SUITEB
+		fi
 		Kconfig_style_config SUITEB192
 	fi
 

--- a/net-wireless/wpa_supplicant/wpa_supplicant-9999.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-9999.ebuild
@@ -18,7 +18,7 @@ else
 fi
 
 SLOT="0"
-IUSE="ap bindist dbus eap-sim eapol_test fasteap +hs2-0 libressl macsec p2p privsep ps3 qt5 readline selinux smartcard tdls uncommon-eap-types wimax wps kernel_linux kernel_FreeBSD"
+IUSE="ap bindist dbus eap-sim eapol_test fasteap +hs2-0 libressl macsec p2p privsep ps3 qt5 readline selinux smartcard suiteb tdls uncommon-eap-types wimax wps kernel_linux kernel_FreeBSD"
 
 CDEPEND="dbus? ( sys-apps/dbus )
 	kernel_linux? (
@@ -221,7 +221,9 @@ src_configure() {
 		Kconfig_style_config OWE
 		Kconfig_style_config SAE
 		Kconfig_style_config DPP
-		Kconfig_style_config SUITEB
+		if use suiteb; then
+			Kconfig_style_config SUITEB
+		fi
 		Kconfig_style_config SUITEB192
 	fi
 


### PR DESCRIPTION
The current implementation of Suite B in wpa_supplicant/hostapd is not
yet supported by LibreSSL. Also users may want to disable it for some
other reason.

Closes: https://bugs.gentoo.org/678784
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>