### PR TITLE
sys-block/rts_pstor: fix compile issue, #680478

### DIFF
--- a/sys-block/rts_pstor/files/fix-compile-kernel-5.0.0.patch
+++ b/sys-block/rts_pstor/files/fix-compile-kernel-5.0.0.patch
@@ -1,0 +1,36 @@
+--- a/rtsx.h
++++ b/rtsx.h
+@@ -81,6 +81,17 @@
+ 	pci_get_domain_bus_and_slot(0, (bus), (devfn))
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
++static void do_gettimeofday(struct timeval *tv)
++{
++	struct timespec64 now;
++
++	ktime_get_real_ts64(&now);
++	tv->tv_sec = now.tv_sec;
++	tv->tv_usec = now.tv_nsec / 1000;
++}
++#endif
++
+ /*
+  * macros for easy use
+  */
+--- a/rtsx.c
++++ b/rtsx.c
+@@ -300,11 +300,13 @@
+ 	
+ 	.max_sectors =                  240,
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+ 	/* merge commands... this seems to help performance, but
+ 	 * periodically someone should test to see which setting is more
+ 	 * optimal.
+ 	 */
+ 	.use_clustering =		1,
++#endif
+ 
+ 	
+ 	.emulated =			1,

--- a/sys-block/rts_pstor/rts_pstor-1.10_p20160103.ebuild
+++ b/sys-block/rts_pstor/rts_pstor-1.10_p20160103.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2018 Gentoo Authors
+# Copyright 2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,6 +18,7 @@ KEYWORDS="~amd64 ~x86"
 DEPEND="virtual/linux-sources"
 PATCHES=(
 	"${FILESDIR}/rts_pstor-makefile.patch"
+	"${FILESDIR}/fix-compile-kernel-5.0.0.patch"
 )
 S="${WORKDIR}/RTS5209-linux-driver-${GIT_COMMIT}"
 


### PR DESCRIPTION
fix compile issue with kernel >=5.0

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>
Closes: https://bugs.gentoo.org/680478
Package-Manager: Portage-2.3.62, Repoman-2.3.12