### PR TITLE
Drop python3.4 support for my packages

### DIFF
--- a/dev-python/python-axolotl-curve25519/python-axolotl-curve25519-0.4.1_p2-r1.ebuild
+++ b/dev-python/python-axolotl-curve25519/python-axolotl-curve25519-0.4.1_p2-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="7"
+EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit distutils-r1
 

--- a/dev-python/python-axolotl/python-axolotl-0.1.42-r1.ebuild
+++ b/dev-python/python-axolotl/python-axolotl-0.1.42-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="7"
+EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit distutils-r1
 

--- a/dev-python/python-sense-hat/python-sense-hat-2.2.0-r1.ebuild
+++ b/dev-python/python-sense-hat/python-sense-hat-2.2.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="7"
+EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit distutils-r1
 

--- a/dev-python/rtimulib/rtimulib-7.2.1-r1.ebuild
+++ b/dev-python/rtimulib/rtimulib-7.2.1-r1.ebuild
@@ -1,13 +1,14 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="7"
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+
+inherit distutils-r1
 
 MY_PN="RTIMULib"
 MY_P="${MY_PN}-${PV}"
-PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
-
-inherit distutils-r1
 
 DESCRIPTION="Python Binding for RTIMULib, a versatile IMU library"
 HOMEPAGE="https://github.com/RPi-Distro/RTIMULib"

--- a/net-im/yowsup/yowsup-2.5.7-r2.ebuild
+++ b/net-im/yowsup/yowsup-2.5.7-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 PYTHON_REQ_USE="readline"
 
 inherit distutils-r1

--- a/sys-apps/onerng/onerng-3.6-r1.ebuild
+++ b/sys-apps/onerng/onerng-3.6-r1.ebuild
@@ -1,12 +1,13 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-MY_P="${P/-/_}"
-PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit python-r1 udev
+
+MY_P="${P/-/_}"
 
 DESCRIPTION="Software for the Open Hardware Random Number Generator called OneRNG"
 HOMEPAGE="https://www.onerng.info/"

--- a/x11-misc/mugshot/mugshot-0.4.1.ebuild
+++ b/x11-misc/mugshot/mugshot-0.4.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{4,5,6} )
+PYTHON_COMPAT=( python3_{5,6} )
 
 inherit distutils-r1 eapi7-ver gnome2-utils
 


### PR DESCRIPTION
dev-python/python-axolotl: drop python3.4 support 
dev-python/python-axolotl-curve25519: drop python3.4 support 
dev-python/python-sense-hat: drop python3.4 support
dev-python/rtimulib: drop python3.4 support 
net-im/yowsup: drop python3.4 support 
sys-apps/onerng: drop python3.4 support 
x11-misc/mugshot: drop python3.4 support

Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>