### PR TITLE
dev-python/libnacl: add python3.7 support, EAPI 7

### DIFF
--- a/dev-python/libnacl/libnacl-1.6.1.ebuild
+++ b/dev-python/libnacl/libnacl-1.6.1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-PYTHON_COMPAT=(python{2_7,3_4,3_5,3_6})
+EAPI=7
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6,3_7} )
 inherit distutils-r1
 
 DESCRIPTION="Python ctypes wrapper for libsodium"


### PR DESCRIPTION
*I just added python3.7 support (tested) and bumped EAPI to 7.
*Upstream EOL-ed Python 3.4 but i am not sure about dropping python3.4 support now.
*I think current maintainer take care of this.

```
python3.7 runtests.py
test_gcm_aead (test_aead.TestAEAD) ... skipped 'AES256-GCM AEAD not available'
test_ietf_aead (test_aead.TestAEAD) ... ok
test_auth_verify (test_auth_verify.TestAuthVerify) ... ok
test_onetimeauth_verify (test_auth_verify.TestAuthVerify) ... ok
test_key_blake (test_blake.TestBlake) ... ok
test_keyless_blake (test_blake.TestBlake) ... ok
test_publickey (test_dual.TestDual) ... ok
test_secretkey (test_dual.TestDual) ... ok
test_sign (test_dual.TestDual) ... ok
test_publickey (test_public.TestPublic) ... ok
test_secretkey (test_public.TestPublic) ... ok
test_secret_box (test_raw_auth_sym.TestSecretBox) ... ok
test_key_generichash (test_raw_generichash.TestGenericHash) ... ok
test_keyless_generichash (test_raw_generichash.TestGenericHash) ... ok
test_hash (test_raw_hash.TestHash) ... ok
test_box (test_raw_public.TestPublic) ... ok
test_box_seal (test_raw_public.TestPublic) ... ok
test_boxnm (test_raw_public.TestPublic) ... ok
test_gen (test_raw_public.TestPublic) ... ok
test_randombytes (test_raw_random.TestRandomBytes)
copied from libsodium default/randombytes.c ... ok
test_randombytes_random (test_raw_random.TestRandomBytes) ... ok
test_randombytes_uniform (test_raw_random.TestRandomBytes) ... ok
test_secretbox (test_raw_secret.TestSecret) ... ok
test_box (test_raw_sign.TestSign) ... ok
test_gen (test_raw_sign.TestSign) ... ok
test_save_load (test_save.TestSave) ... ok
test_save_load_secret (test_save.TestSave) ... ok
test_save_load_sign (test_save.TestSave) ... ok
test_save_perms (test_save.TestSave) ... ok
test_publickey_only (test_seal.TestSealed) ... ok
test_secretkey (test_seal.TestSealed) ... ok
test_secret (test_secret.TestSecret) ... ok
test_sign (test_sign.TestSigning) ... ok
test_verify16 (test_verify.TestVerify) ... ok
test_verify32 (test_verify.TestVerify) ... ok
test_verify64 (test_verify.TestVerify) ... ok
test_different (test_verify.TestVerifyBytesEq) ... ok
test_different_length (test_verify.TestVerifyBytesEq) ... ok
test_equal (test_verify.TestVerifyBytesEq) ... ok
test_invalid_type (test_verify.TestVerifyBytesEq) ... ok
test_library_version_major (test_version.TestSodiumVersion) ... ok
test_library_version_minor (test_version.TestSodiumVersion) ... ok
test_version_string (test_version.TestSodiumVersion) ... ok

----------------------------------------------------------------------
Ran 43 tests in 0.115s
OK (skipped=1)
```

Signed-off-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>
Package-Manager: Portage-2.3.62, Repoman-2.3.11