### PR TITLE
dev-python/m2crypto: Fix crossdev

### DIFF
--- a/dev-python/m2crypto/files/m2crypto-crossdev-0.31.0.patch
+++ b/dev-python/m2crypto/files/m2crypto-crossdev-0.31.0.patch
@@ -1,0 +1,12 @@
+--- a/setup.py
++++ b/setup.py
+@@ -50,7 +50,8 @@
+                                 '*Visual*', 'VC', 'include')
+         err = glob.glob(globmask)
+     else:
+-        pid = subprocess.Popen(['cpp', '-Wp,-v', '-'],
++        pid = subprocess.Popen(os.environ.get('CPP', 'cpp').split() +
++                               ['-Wp,-v', '-'],
+                                stdin=open(os.devnull, 'r'),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)

--- a/dev-python/m2crypto/m2crypto-0.31.0-r2.ebuild
+++ b/dev-python/m2crypto/m2crypto-0.31.0-r2.ebuild
@@ -25,7 +25,8 @@ RDEPEND="
 	libressl? ( dev-libs/libressl:0= )
 	virtual/python-typing[${PYTHON_USEDEP}]
 "
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	>=dev-lang/swig-2.0.9
 	dev-python/setuptools[${PYTHON_USEDEP}]
 "
@@ -37,18 +38,18 @@ RESTRICT=test
 
 PATCHES=(
 	"${FILESDIR}/${PN}-libressl-${PV}.patch"
+	"${FILESDIR}/${PN}-crossdev-${PV}.patch"
 )
 
 python_compile() {
 	# setup.py looks at platform.machine() to determine swig options.
 	# For exotic ABIs, we need to give swig a hint.
 	# https://bugs.gentoo.org/617946
-	# TODO: Fix cross-compiles
 	local -x SWIG_FEATURES=
 	case ${ABI} in
 		x32) SWIG_FEATURES="-D__ILP32__" ;;
 	esac
-	distutils-r1_python_compile --openssl="${EPREFIX}"/usr
+	distutils-r1_python_compile --openssl="${ESYSROOT}"/usr
 }
 
 python_test() {


### PR DESCRIPTION
Fix crossdev in this new revision.

Bug: https://bugs.gentoo.org/665544
Package-Manager: Portage-2.3.62, Repoman-2.3.11