### PR TITLE
app-misc/trash-cli: Claim ebuild as a proxy-maintainer

### DIFF
--- a/app-misc/trash-cli/metadata.xml
+++ b/app-misc/trash-cli/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>zoltan@sinustrom.info</email>
+		<name>Zoltan Puskas</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<maintainer status="active">
 			<email>sito@andreafrancia.it</email>


### PR DESCRIPTION
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
Package-Manager: Portage-2.3.62, Repoman-2.3.12