### PR TITLE
dev-util/electron: add USE=+system-ssl

### DIFF
--- a/dev-util/electron/electron-2.0.17-r1.ebuild
+++ b/dev-util/electron/electron-2.0.17-r1.ebuild
@@ -79,7 +79,7 @@ LICENSE="BSD"
 SLOT="$(ver_cut 1-2)"
 KEYWORDS="~amd64"
 IUSE="cups custom-cflags gconf gnome-keyring kerberos lto neon pic
-	  +proprietary-codecs pulseaudio selinux +system-ffmpeg +tcmalloc"
+	+proprietary-codecs pulseaudio selinux +system-ffmpeg +system-ssl +tcmalloc"
 RESTRICT="!system-ffmpeg? ( proprietary-codecs? ( bindist ) )"
 
 # Native Client binaries are compiled with different set of flags, bug #452066.
@@ -100,7 +100,7 @@ COMMON_DEPEND="
 	dev-libs/libxslt:=
 	dev-libs/nspr:=
 	>=dev-libs/nss-3.14.3:=
-	<dev-libs/openssl-1.1:0=
+	system-ssl? ( <dev-libs/openssl-1.1:0= )
 	>=dev-libs/re2-0.2016.05.01:=
 	gconf? ( >=gnome-base/gconf-2.24.0:= )
 	gnome-keyring? ( >=gnome-base/libgnome-keyring-3.12:= )
@@ -533,7 +533,6 @@ src_configure() {
 	# TODO: use_system_libsrtp (bug #459932).
 	# TODO: xml (bug #616818).
 	# TODO: use_system_protobuf (bug #525560).
-	# TODO: use_system_ssl (http://crbug.com/58087).
 	# TODO: use_system_sqlite (http://crbug.com/22208).
 
 	# libevent: https://bugs.gentoo.org/593458
@@ -688,7 +687,8 @@ src_configure() {
 	# --shared-libuv cannot be used as electron's node fork
 	# patches uv_loop structure.
 	./configure --shared --without-bundled-v8 \
-		--shared-openssl --shared-http-parser --shared-zlib \
+		$(usex system-ssl '--shared-openssl' '' ) \
+		--shared-http-parser --shared-zlib \
 		--shared-nghttp2 --shared-cares \
 		--without-npm --with-intl=system-icu --without-dtrace \
 		--dest-cpu=${target_arch} --prefix="" || die

--- a/dev-util/electron/metadata.xml
+++ b/dev-util/electron/metadata.xml
@@ -17,6 +17,7 @@
 		<flag name="pic">Disable optimized assembly code that is not PIC friendly</flag>
 		<flag name="proprietary-codecs">Enable proprietary codecs like H.264, MP3</flag>
 		<flag name="system-ffmpeg">Use system ffmpeg instead of the bundled one</flag>
+		<flag name="system-ssl">Use system OpenSSL instead of the bundled one</flag>
 		<flag name="tcmalloc">Use bundled tcmalloc instead of system malloc</flag>
 	</use>
 	<upstream>


### PR DESCRIPTION
For now disabling this is needed to build on systems with LibreSSL or
OpenSSL 1.1.x.

Bug: https://bugs.gentoo.org/681734
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>