### PR TITLE
dev-db/sqlitestudio: add patch to fix build with LibreSSL

### DIFF
--- a/dev-db/sqlitestudio/files/sqlitestudio-3.2.1-libressl.patch
+++ b/dev-db/sqlitestudio/files/sqlitestudio-3.2.1-libressl.patch
@@ -1,0 +1,32 @@
+From 64542c8c5cb3ad9249fa353ff4472c405057d743 Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <stefan.strogin@gmail.com>
+Date: Mon, 25 Mar 2019 18:07:13 +0200
+Subject: [PATCH] #3505 Fix compilation with LibreSSL >=2.7.0
+
+HMAC_CTX_{new,free} were provided by LibreSSL 2.7.0.
+Do not redefine them, otherwise it breaks compilation.
+
+Upstream-Status: Accepted
+[https://github.com/pawelsalawa/sqlitestudio/pull/3507]
+Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>
+---
+ Plugins/DbSqliteCipher/sqlcipher.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Plugins/DbSqliteCipher/sqlcipher.c b/Plugins/DbSqliteCipher/sqlcipher.c
+index 4918cb6f..10c4e5a3 100644
+--- a/Plugins/DbSqliteCipher/sqlcipher.c
++++ b/Plugins/DbSqliteCipher/sqlcipher.c
+@@ -21638,7 +21638,8 @@ static unsigned int openssl_external_init = 0;
+ static unsigned int openssl_init_count = 0;
+ static sqlcipher_sqlite3_mutex* openssl_rand_mutex = NULL;
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ static HMAC_CTX *HMAC_CTX_new(void)
+ {
+   HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
+-- 
+2.21.0
+

--- a/dev-db/sqlitestudio/sqlitestudio-3.2.1-r1.ebuild
+++ b/dev-db/sqlitestudio/sqlitestudio-3.2.1-r1.ebuild
@@ -36,6 +36,7 @@ DEPEND="${RDEPEND}
 	dev-qt/qtconcurrent:5
 	test? ( dev-qt/qttest:5 )
 "
+PATCHES=( "${FILESDIR}"/${P}-libressl.patch )
 
 S="${WORKDIR}"
 core_build_dir="${S}/output/build"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/681638
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>