### PR TITLE
dev-vcs/mercurial: Install contrib/chg

### DIFF
--- a/dev-vcs/mercurial/mercurial-4.9-r1.ebuild
+++ b/dev-vcs/mercurial/mercurial-4.9-r1.ebuild
@@ -58,6 +58,7 @@ python_configure_all() {
 
 python_compile_all() {
 	rm -r contrib/win32 || die
+	emake -C contrib/chg
 	if use emacs; then
 		cd contrib || die
 		elisp-compile mercurial.el || die "elisp-compile failed!"
@@ -85,7 +86,10 @@ python_install_all() {
 		elisp-site-file-install "${FILESDIR}"/${SITEFILE}
 	fi
 
-	local RM_CONTRIB=( hgk hg-ssh bash_completion zsh_completion wix plan9 *.el )
+	dobin contrib/chg/chg
+	doman contrib/chg/chg.1
+
+	local RM_CONTRIB=( chg hgk hg-ssh bash_completion zsh_completion wix plan9 *.el )
 	for f in ${RM_CONTRIB[@]}; do
 		rm -r contrib/${f} || die
 	done


### PR DESCRIPTION
`chg` has no dependencies other than `@system` (and `hg` itself, surprisingly), so install it unconditionally.

This change is only for the 4.9 ebuild.  I can change the older ones as well if you’d like me to.