### PR TITLE
mail-filter/opendkim: Added pre-start configuration checks

### DIFF
--- a/mail-filter/opendkim/files/opendkim.confd.r2
+++ b/mail-filter/opendkim/files/opendkim.confd.r2
@@ -1,0 +1,19 @@
+# This overrides the "Socket" line in your opendkim.conf configuration
+# file, and is required (so that we don't have to try to parse the
+# configuration file in an init script). The setting below listens
+# on the network.
+#OPENDKIM_SOCKET="inet:8891@localhost"
+#
+# A local (UNIX) socket in combination with an additional group that
+# is shared by OpenDKIM and your MTA is safer. Please see
+# https://wiki.gentoo.org/wiki/OpenDKIM for more information.
+#
+# WARNING: The directory containing this socket will have its owner
+#          changed to "opendkim".
+#
+OPENDKIM_SOCKET="local:/run/opendkim/socket"
+#
+# More examples of valid socket syntax can be found in the opendkim(8)
+# man page, under the "-p socketspec" option. However -- contrary to
+# what that man page says -- if you want to use a local socket, the
+# "local:" prefix is not optional here.

--- a/mail-filter/opendkim/files/opendkim.init.r6
+++ b/mail-filter/opendkim/files/opendkim.init.r6
@@ -1,0 +1,77 @@
+#!/sbin/openrc-run
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+CONFFILE="/etc/opendkim/${RC_SVCNAME}.conf"
+required_files="${CONFFILE}"
+
+command="/usr/sbin/opendkim"
+pidfile="/run/${RC_SVCNAME}.pid"
+command_args="-P ${pidfile} -x ${CONFFILE} -p ${OPENDKIM_SOCKET}"
+
+depend() {
+	use dns logger net
+	before mta
+}
+
+check_cfg() {
+	#
+	# The opendkim.conf man page says,
+	#
+	#   For parameters that are Boolean in nature, only the first byte
+	#   of the value is processed... For negative values, the following
+	#   are accepted: "F", "f", "N", "n", "0".'
+	#
+	if grep --quiet '^[[:space:]]*Background[[:space:]]\+[FfNn0]' \
+			"${CONFFILE}"; then
+		eerror "${RC_SVCNAME} cannot run in the foreground!"
+		return 1
+	fi
+	if ! ${command} -n ${command_args}; then
+		eerror "Configuration check failed"
+		return 1
+	fi
+}
+
+start_pre() {
+	# If this isn't a restart, make sure that the user's config isn't
+	# busted before we try to start the daemon (this will produce
+	# better error messages than if we just try to start it blindly).
+	#
+	# If, on the other hand, this *is* a restart, then the stop_pre
+	# action will have ensured that the config is usable and we don't
+	# need to do that again.
+	if [ "${RC_CMD}" != "restart" ]; then
+		check_cfg || return $?
+	fi
+
+	if [ -S "${OPENDKIM_SOCKET}" ] && ! fuser -s "${OPENDKIM_SOCKET}"; then
+		# Remove stalled Unix socket if no other process is
+		# using it
+		if ! rm "${UNIX_SOCKET}"; then
+			eerror "failed to remove stale unix socket ${OPENDKIM_SOCKET}"
+			return 2
+		fi
+	fi
+
+	# This relies on the "local:" prefix being there, but the conf.d
+	# file explicitly states that it's not optional (contrary to what
+	# the opendkim(8) man page says).
+	if [ "${OPENDKIM_SOCKET#local:}" != "${OPENDKIM_SOCKET}" ]; then
+		# The socket begins with "local:"
+		OPENDKIM_SOCKET_PATH="${OPENDKIM_SOCKET#local:}"
+		OPENDKIM_SOCKET_DIR="${OPENDKIM_SOCKET_PATH%/*}"
+
+		# This is dangerous, but there's a big warning about it
+		# in the conf.d file.
+		checkpath --directory --owner opendkim "${OPENDKIM_SOCKET_DIR}"
+	fi
+}
+
+stop_pre() {
+	# If this is a restart, check to make sure the user's config
+	# isn't busted before we stop the running daemon.
+	if [ "${RC_CMD}" = "restart" ]; then
+		check_cfg || return $?
+	fi
+}

--- a/mail-filter/opendkim/files/opendkim.init.r6
+++ b/mail-filter/opendkim/files/opendkim.init.r6
@@ -59,8 +59,8 @@ start_pre() {
 	# the opendkim(8) man page says).
 	if [ "${OPENDKIM_SOCKET#local:}" != "${OPENDKIM_SOCKET}" ]; then
 		# The socket begins with "local:"
-		OPENDKIM_SOCKET_PATH="${OPENDKIM_SOCKET#local:}"
-		OPENDKIM_SOCKET_DIR="${OPENDKIM_SOCKET_PATH%/*}"
+		local OPENDKIM_SOCKET_PATH="${OPENDKIM_SOCKET#local:}"
+		local OPENDKIM_SOCKET_DIR="${OPENDKIM_SOCKET_PATH%/*}"
 
 		# This is dangerous, but there's a big warning about it
 		# in the conf.d file.

--- a/mail-filter/opendkim/files/opendkim.service.r4
+++ b/mail-filter/opendkim/files/opendkim.service.r4
@@ -1,0 +1,16 @@
+[Unit]
+Description=DomainKeys Identified Mail (DKIM) Milter
+Documentation=man:opendkim(8) man:opendkim.conf(5) man:opendkim-genkey(8) man:opendkim-genzone(8) man:opendkim-testadsp(8) man:opendkim-testkey http://www.opendkim.org/docs.html
+After=network.target nss-lookup.target syslog.target
+
+[Service]
+ExecStartPre=/usr/sbin/opendkim -n -f -x /etc/opendkim/opendkim.conf -p $OPENDKIM_SOCKET
+ExecStart=/usr/sbin/opendkim -f -x /etc/opendkim/opendkim.conf -p $OPENDKIM_SOCKET
+ExecReload=/bin/kill -USR1 $MAINPID
+RuntimeDirectory=opendkim
+RuntimeDirectoryMode=0750
+User=opendkim
+Group=opendkim
+
+[Install]
+WantedBy=multi-user.target

--- a/mail-filter/opendkim/opendkim-2.10.3-r9.ebuild
+++ b/mail-filter/opendkim/opendkim-2.10.3-r9.ebuild
@@ -1,0 +1,223 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools db-use eutils systemd user
+
+DESCRIPTION="A milter providing DKIM signing and verification"
+HOMEPAGE="http://opendkim.org/"
+SRC_URI="mirror://sourceforge/opendkim/${P}.tar.gz"
+
+# The GPL-2 is for the init script, bug 425960.
+LICENSE="BSD GPL-2 Sendmail-Open-Source"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="+berkdb gnutls ldap libressl lmdb lua memcached opendbx poll sasl selinux +ssl static-libs unbound"
+
+DEPEND="|| ( mail-filter/libmilter mail-mta/sendmail )
+	dev-libs/libbsd
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	berkdb? ( >=sys-libs/db-3.2:* )
+	opendbx? ( >=dev-db/opendbx-1.4.0 )
+	lua? ( dev-lang/lua:* )
+	ldap? ( net-nds/openldap )
+	lmdb? ( dev-db/lmdb )
+	memcached? ( dev-libs/libmemcached )
+	sasl? ( dev-libs/cyrus-sasl )
+	unbound? ( >=net-dns/unbound-1.4.1:= net-dns/dnssec-root )
+	!unbound? ( net-libs/ldns )
+	gnutls? ( >=net-libs/gnutls-3.3 )"
+
+RDEPEND="${DEPEND}
+	sys-process/psmisc
+	selinux? ( sec-policy/selinux-dkim )
+"
+
+REQUIRED_USE="sasl? ( ldap )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-gnutls-3.4.patch"
+	"${FILESDIR}/${P}-openssl-1.1.1.patch"
+)
+
+pkg_setup() {
+	# This user can read your private keys, and must therefore not be
+	# shared with any other package.
+	enewuser opendkim
+}
+
+src_prepare() {
+	default
+
+	# We delete the "Socket" setting because it's overridden by our
+	# conf.d file.
+	sed -e 's:/var/db/dkim:/var/lib/opendkim:g' \
+		-e '/^[[:space:]]*Socket/d' \
+		-i opendkim/opendkim.conf.sample opendkim/opendkim.conf.simple.in \
+		stats/opendkim-reportstats{,.in} || die
+
+	sed -i -e 's:dist_doc_DATA:dist_html_DATA:' libopendkim/docs/Makefile.am \
+		|| die
+
+	# TODO: what purpose does this serve, do the tests even get run?
+	sed -e "/sock.*mt.getcwd/s:mt.getcwd():${T}:" \
+		-i opendkim/tests/*.lua || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=()
+	if use berkdb ; then
+		myconf+=(
+			$(db_includedir)
+			--with-db-incdir=${myconf#-I}
+			--enable-popauth
+			--enable-query_cache
+			--enable-stats
+		)
+	fi
+	if use unbound; then
+		myconf+=( --with-unbound )
+	else
+		myconf+=( --with-ldns )
+	fi
+	if use ldap; then
+		myconf+=( $(use_with sasl) )
+	fi
+	econf \
+		$(use_with berkdb db) \
+		$(use_with opendbx odbx) \
+		$(use_with lua) \
+		$(use_enable lua rbl) \
+		$(use_with ldap openldap) \
+		$(use_with lmdb) \
+		$(use_enable poll) \
+		$(use_enable static-libs static) \
+		$(use_with gnutls) \
+		$(use_with memcached libmemcached) \
+		"${myconf[@]}" \
+		--enable-filter \
+		--enable-atps \
+		--enable-identity_header \
+		--enable-rate_limit \
+		--enable-resign \
+		--enable-replace_rules \
+		--enable-default_sender \
+		--enable-sender_macro \
+		--enable-vbr \
+		--disable-live-testing
+}
+
+src_install() {
+	default
+	prune_libtool_files
+
+	dosbin stats/opendkim-reportstats
+
+	newinitd "${FILESDIR}/opendkim.init.r6" opendkim
+	newconfd "${FILESDIR}/opendkim.confd" opendkim
+	systemd_newunit "${FILESDIR}/opendkim.service.r4" opendkim.service
+	systemd_install_serviced "${FILESDIR}/${PN}.service.conf" "${PN}.service"
+
+	dodir /etc/opendkim
+	keepdir /var/lib/opendkim
+
+	# The OpenDKIM data (particularly, your keys) should be read-only to
+	# the UserID that the daemon runs as.
+	fowners root:opendkim /var/lib/opendkim
+	fperms 750 /var/lib/opendkim
+
+	# Strip the comments out of the "simple" example configuration...
+	grep ^[^#] "${S}"/opendkim/opendkim.conf.simple \
+		 > "${T}/opendkim.conf" || die
+
+	# and tweak it a bit before installing it unconditionally.
+	echo "# For use with unbound" >> "${T}/opendkim.conf" || die
+	echo "#TrustAnchorFile /etc/dnssec/root-anchors.txt" \
+		 >> "${T}/opendkim.conf" || die
+	echo UserID opendkim >> "${T}/opendkim.conf" || die
+	insinto /etc/opendkim
+	doins "${T}/opendkim.conf"
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSION} ]]; then
+		elog "If you want to sign your mail messages and need some help"
+		elog "please run:"
+		elog "  emerge --config ${CATEGORY}/${PN}"
+		elog "It will help you create your key and give you hints on how"
+		elog "to configure your DNS and MTA."
+
+		# TODO: This is tricky, we really need a good wiki page showing
+		# how to share a local socket with an MTA!
+		elog "If you are using a local (UNIX) socket, then you will"
+		elog "need to make sure that your MTA has read/write access"
+		elog "to the socket file. This is best accomplished by creating"
+		elog "a completely-new group with only your MTA user and the "
+		elog "\"opendkim\" user in it. You would then set \"UMask 0112\""
+		elog "in your opendkim.conf, and switch the primary group of your"
+		elog "\"opendkim\" user to the group that you just created. The"
+		elog "last step is necessary for the socket to be created as the"
+		elog "new group (and not as group \"opendkim\")".
+	else
+		ewarn "The user account for the OpenDKIM daemon has changed"
+		ewarn "from \"milter\" to \"opendkim\" to prevent unrelated services"
+		ewarn "from being able to read your private keys. You should"
+		ewarn "adjust your existing configuration to use the \"opendkim\""
+		ewarn "user and group, and change the permissions on"
+		ewarn "${ROOT}var/lib/opendkim to root:opendkim with mode 0750."
+		ewarn "The owner and group of the files within that directory"
+		ewarn "will likely need to be adjusted as well."
+	fi
+}
+
+pkg_config() {
+	local selector keysize pubkey
+
+	read -p "Enter the selector name (default ${HOSTNAME}): " selector
+	[[ -n "${selector}" ]] || selector="${HOSTNAME}"
+	if [[ -z "${selector}" ]]; then
+		eerror "Oddly enough, you don't have a HOSTNAME."
+		return 1
+	fi
+	if [[ -f "${ROOT}var/lib/opendkim/${selector}.private" ]]; then
+		ewarn "The private key for this selector already exists."
+	else
+		keysize=1024
+		# Generate the private and public keys. Note that opendkim-genkeys
+		# sets umask=077 on its own to keep these safe. However, we want
+		# them to be readable (only!) to the opendkim user, and we manage
+		# that by changing their groups and making everything group-readable.
+		opendkim-genkey -b ${keysize} -D "${ROOT}"var/lib/opendkim/ \
+			-s "${selector}" -d '(your domain)' && \
+			chgrp --no-dereference opendkim \
+				  "${ROOT}var/lib/opendkim/${selector}".{private,txt} || \
+				{ eerror "Failed to create private and public keys." ;
+				  return 1; }
+		chmod g+r "${ROOT}var/lib/opendkim/${selector}".{private,txt}
+	fi
+
+	# opendkim selector configuration
+	echo
+	einfo "Make sure you have the following settings in your /etc/opendkim/opendkim.conf:"
+	einfo "  Keyfile /var/lib/opendkim/${selector}.private"
+	einfo "  Selector ${selector}"
+
+	# MTA configuration
+	echo
+	einfo "If you are using Postfix, add following lines to your main.cf:"
+	einfo "  smtpd_milters     = unix:/run/opendkim/opendkim.sock"
+	einfo "  non_smtpd_milters = unix:/run/opendkim/opendkim.sock"
+	einfo "  and read http://www.postfix.org/MILTER_README.html"
+
+	# DNS configuration
+	einfo "After you configured your MTA, publish your key by adding this TXT record to your domain:"
+	cat "${ROOT}var/lib/opendkim/${selector}.txt"
+	einfo "t=y signifies you only test the DKIM on your domain. See following page for the complete list of tags:"
+	einfo "  http://www.dkim.org/specs/rfc4871-dkimbase.html#key-text"
+}


### PR DESCRIPTION
Added pre-start configuration checks for OpenRC and systemd. Closes [bug 622604 ](https://bugs.gentoo.org/622604).

@orlitzky Three of the 156 tests fail here. Is this something you ever worried about, given that the last upstream release was almost four years ago?

```
t-test04: t-test04.c:152: main: Assertion `status == DKIM_STAT_OK' failed.
FAIL t-test04 (exit status: 134)
t-test05: t-test05.c:152: main: Assertion `status == DKIM_STAT_OK' failed.
FAIL t-test05 (exit status: 134)
t-test06: t-test06.c:152: main: Assertion `status == DKIM_STAT_OK' failed.
FAIL t-test06 (exit status: 134)
```
