### PR TITLE
Spamassassin for kde-apps/kdepim-meta

### DIFF
--- a/dev-perl/BSD-Resource/BSD-Resource-1.291.100.ebuild
+++ b/dev-perl/BSD-Resource/BSD-Resource-1.291.100.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl module for BSD process resource limit and priority functions"
 
 SLOT="0"
-KEYWORDS="alpha amd64 ~arm ia64 ~ppc ~ppc64 s390 sparc x86"
+KEYWORDS="alpha amd64 ~arm ~arm64 ia64 ~ppc ~ppc64 s390 sparc x86"
 IUSE=""
 
 DEPEND="virtual/perl-ExtUtils-MakeMaker"

--- a/dev-perl/Convert-ASN1/Convert-ASN1-0.270.0.ebuild
+++ b/dev-perl/Convert-ASN1/Convert-ASN1-0.270.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Standard en/decode of ASN.1 structures"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Crypt-OpenSSL-Bignum/Crypt-OpenSSL-Bignum-0.90.0.ebuild
+++ b/dev-perl/Crypt-OpenSSL-Bignum/Crypt-OpenSSL-Bignum-0.90.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="OpenSSL's multiprecision integer arithmetic"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="libressl"
 
 RDEPEND="

--- a/dev-perl/Crypt-OpenSSL-RSA/Crypt-OpenSSL-RSA-0.280.0-r3.ebuild
+++ b/dev-perl/Crypt-OpenSSL-RSA/Crypt-OpenSSL-RSA-0.280.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Crypt::OpenSSL::RSA module for perl"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="libressl"
 
 RDEPEND="dev-perl/Crypt-OpenSSL-Bignum

--- a/dev-perl/Crypt-OpenSSL-Random/Crypt-OpenSSL-Random-0.110.0.ebuild
+++ b/dev-perl/Crypt-OpenSSL-Random/Crypt-OpenSSL-Random-0.110.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="OpenSSL/LibreSSL pseudo-random number generator access"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="libressl"
 
 RDEPEND="

--- a/dev-perl/DBD-Pg/DBD-Pg-3.7.0.ebuild
+++ b/dev-perl/DBD-Pg/DBD-Pg-3.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ inherit perl-module
 DESCRIPTION="PostgreSQL database driver for the DBI module"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="

--- a/dev-perl/Digest-BubbleBabble/Digest-BubbleBabble-0.20.0-r1.ebuild
+++ b/dev-perl/Digest-BubbleBabble/Digest-BubbleBabble-0.20.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Create bubble-babble fingerprints"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 PATCHES=( "${FILESDIR}/0.02-dot-in-inc.patch" ) # https://github.com/btrott/Digest-BubbleBabble/pull/1
 SRC_TEST="do parallel"

--- a/dev-perl/Encode-Detect/Encode-Detect-1.10.0-r1.ebuild
+++ b/dev-perl/Encode-Detect/Encode-Detect-1.10.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ DESCRIPTION="Encode::Detect - An Encode::Encoding subclass that detects the enco
 
 LICENSE="MPL-1.1"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/Geo-IP/Geo-IP-1.510.0.ebuild
+++ b/dev-perl/Geo-IP/Geo-IP-1.510.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,7 +10,7 @@ inherit perl-module multilib
 DESCRIPTION="Look up country by IP Address"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd"
 IUSE=""
 
 DEPEND="dev-libs/geoip"

--- a/dev-perl/Mail-DKIM/Mail-DKIM-0.440.0.ebuild
+++ b/dev-perl/Mail-DKIM/Mail-DKIM-0.440.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Signs/verifies Internet mail using DKIM message signatures"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND=">=dev-perl/Crypt-OpenSSL-RSA-0.24

--- a/dev-perl/Mail-SPF/Mail-SPF-2.9.0-r2.ebuild
+++ b/dev-perl/Mail-SPF/Mail-SPF-2.9.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ DESCRIPTION="An object-oriented implementation of Sender Policy Framework"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Net-CIDR-Lite/Net-CIDR-Lite-0.210.0-r1.ebuild
+++ b/dev-perl/Net-CIDR-Lite/Net-CIDR-Lite-0.210.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl extension for merging IPv4 or IPv6 CIDR addresses"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND=""

--- a/dev-perl/Net-DNS-Resolver-Mock/Net-DNS-Resolver-Mock-1.201.710.310.ebuild
+++ b/dev-perl/Net-DNS-Resolver-Mock/Net-DNS-Resolver-Mock-1.201.710.310.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Mock a DNS Resolver object for testing"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="dev-perl/Net-DNS"

--- a/dev-perl/Net-DNS-Resolver-Programmable/Net-DNS-Resolver-Programmable-0.9.0.ebuild
+++ b/dev-perl/Net-DNS-Resolver-Programmable/Net-DNS-Resolver-Programmable-0.9.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="programmable DNS resolver class for offline emulation of DNS"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Net-DNS-SEC/Net-DNS-SEC-1.30.0.ebuild
+++ b/dev-perl/Net-DNS-SEC/Net-DNS-SEC-1.30.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="DNSSEC extensions to Net::DNS"
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ~ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="

--- a/dev-perl/Net-DNS/Net-DNS-1.130.0.ebuild
+++ b/dev-perl/Net-DNS/Net-DNS-1.130.0.ebuild
@@ -11,7 +11,7 @@ inherit toolchain-funcs perl-module
 DESCRIPTION="Perl Interface to the Domain Name System"
 
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="+ipv6 test minimal"
 
 PDEPEND="!minimal? ( >=dev-perl/Net-DNS-SEC-1.10.0 )"

--- a/dev-perl/Net-LibIDN2/Net-LibIDN2-1.0.0-r1.ebuild
+++ b/dev-perl/Net-LibIDN2/Net-LibIDN2-1.0.0-r1.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Perl bindings for GNU Libidn2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 
 RDEPEND="net-dns/libidn2:="

--- a/dev-perl/Net-Patricia/Net-Patricia-1.220.0-r1.ebuild
+++ b/dev-perl/Net-Patricia/Net-Patricia-1.220.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="Patricia Trie perl module for fast IP address lookups"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd"
 IUSE="ipv6"
 
 RDEPEND="dev-perl/Net-CIDR-Lite

--- a/dev-perl/NetAddr-IP/NetAddr-IP-4.79.0.ebuild
+++ b/dev-perl/NetAddr-IP/NetAddr-IP-4.79.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="Manipulation and operations on IP addresses"
 
 SLOT="0"
 LICENSE="|| ( Artistic GPL-2 )"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~x86-fbsd"
 IUSE="ipv6 test"
 
 RDEPEND="ipv6? ( dev-perl/Socket6 )"

--- a/dev-perl/YAML-LibYAML/YAML-LibYAML-0.690.0.ebuild
+++ b/dev-perl/YAML-LibYAML/YAML-LibYAML-0.690.0.ebuild
@@ -9,7 +9,7 @@ inherit perl-module
 
 DESCRIPTION="Perl YAML Serialization using XS and libyaml"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND=""

--- a/dev-perl/perl-ldap/perl-ldap-0.650.0.ebuild
+++ b/dev-perl/perl-ldap/perl-ldap-0.650.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl modules which provide an object-oriented interface to LDAP servers"
 
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris"
 IUSE="sasl xml ssl"
 
 RDEPEND="

--- a/mail-filter/spamassassin/spamassassin-3.4.2-r6.ebuild
+++ b/mail-filter/spamassassin/spamassassin-3.4.2-r6.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://apache/spamassassin/source/${MY_P}.tar.bz2"
 
 LICENSE="Apache-2.0 GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos"
 IUSE="berkdb cron ipv6 ldap libressl mysql postgres qmail sqlite ssl test"
 
 # The Makefile.PL script checks for dependencies, but only fails if a

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -6,10 +6,6 @@
 dev-qt/qtsql -mysql
 kde-apps/akonadi -mysql
 
-# Andreas Sturmlechner <asturm@gentoo.org> (19 Mar 2019)
-# mail-filter/spamassassin is not yet keyworded
-kde-apps/kdepim-meta spamassassin
-
 # Mart Raudsepp <leio@gentoo.org> (11 Mar 2019)
 # media-libs/bcg729 not keyworded yet
 net-analyzer/wireshark bcg729


### PR DESCRIPTION
Add ~arm64 to mail-filter/spamassassin and its dependencies then remove kde-apps/kdepim-meta spamassassin package.use mask. 