### PR TITLE
dev-util/glslang: fix LICENSE

### DIFF
--- a/dev-util/glslang/glslang-7.10.2984.ebuild
+++ b/dev-util/glslang/glslang-7.10.2984.ebuild
@@ -12,5 +12,5 @@ KEYWORDS="amd64 ~x86"
 DESCRIPTION="Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator"
 HOMEPAGE="https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/"
 
-LICENSE="BSD"
+LICENSE="BSD Apache-2.0"
 SLOT="0"

--- a/dev-util/glslang/glslang-7.9.2888.ebuild
+++ b/dev-util/glslang/glslang-7.9.2888.ebuild
@@ -12,5 +12,5 @@ KEYWORDS="~amd64 ~x86"
 DESCRIPTION="Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator"
 HOMEPAGE="https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/"
 
-LICENSE="BSD"
+LICENSE="BSD Apache-2.0"
 SLOT="0"

--- a/dev-util/glslang/glslang-9999.ebuild
+++ b/dev-util/glslang/glslang-9999.ebuild
@@ -11,5 +11,5 @@ SRC_URI=""
 DESCRIPTION="Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator"
 HOMEPAGE="https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/"
 
-LICENSE="BSD"
+LICENSE="BSD Apache-2.0"
 SLOT="0"


### PR DESCRIPTION
Fix License from BSD to Apache-2.0.

Signed-off-by: Po-Hsien Wang <ddmail2009@gmail.com>