### PR TITLE
sys-process/rtirq: use HTTPS, fix SRC_URI

### DIFF
--- a/sys-process/rtirq/rtirq-20150216.ebuild
+++ b/sys-process/rtirq/rtirq-20150216.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="Modify realtime scheduling policy and priority of IRQ handlers"
-HOMEPAGE="http://www.rncbc.org/archive/#rtirq"
+HOMEPAGE="https://www.rncbc.org/archive/#rtirq"
 
-SRC_URI="http://www.rncbc.org/archive/${P}.tar.gz"
+SRC_URI="https://www.rncbc.org/archive/old/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"

--- a/sys-process/rtirq/rtirq-20180209.ebuild
+++ b/sys-process/rtirq/rtirq-20180209.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -6,8 +6,8 @@ EAPI="7"
 inherit linux-info systemd
 
 DESCRIPTION="Modify realtime scheduling policy and priority of IRQ handlers"
-HOMEPAGE="http://www.rncbc.org/archive/#rtirq"
-SRC_URI="http://www.rncbc.org/archive/${P}.tar.gz"
+HOMEPAGE="https://www.rncbc.org/archive/#rtirq"
+SRC_URI="https://www.rncbc.org/archive/old/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR updates rtirq to use https instead of http and fixes the SRC_URI.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>