### PR TITLE
app-emulation/cadvisor: depend use docker

### DIFF
--- a/app-emulation/cadvisor/cadvisor-0.33.0-r1.ebuild
+++ b/app-emulation/cadvisor/cadvisor-0.33.0-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+EGO_PN="github.com/google/cadvisor"
+
+inherit user golang-build golang-vcs-snapshot
+SRC_URI="https://${EGO_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+COMMIT="511ec9e"
+KEYWORDS="~amd64"
+
+DESCRIPTION="Analyzes resource usage and performance characteristics of running containers"
+HOMEPAGE="https://github.com/google/cadvisor"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+
+pkg_setup() {
+	enewgroup ${PN}
+	enewuser ${PN} -1 -1 /dev/null ${PN}
+}
+
+src_prepare() {
+	sed -i -e "/go get/d" src/${EGO_PN}/build/assets.sh || die
+	sed -i -e "s/git describe.*/echo ${PV} )/"\
+		-e "s/git rev-parse --short HEAD.*/echo ${COMMIT} )/"\
+		src/${EGO_PN}/build/build.sh || die
+	default
+}
+
+src_compile() {
+	pushd "src/${EGO_PN}"
+	GO_FLAGS="-v -work -x" VERBOSE="true" GOPATH="${S}:$(get_golibdir_gopath)" emake build
+	popd || die
+}
+
+src_install() {
+	newinitd "${FILESDIR}"/${PN}.initd-r1 ${PN}
+	dobin src/${EGO_PN}/${PN}
+	keepdir /var/log/${PN}
+	fowners ${PN}:${PN} /var/log/${PN}
+}

--- a/app-emulation/cadvisor/files/cadvisor.initd-r1
+++ b/app-emulation/cadvisor/files/cadvisor.initd-r1
@@ -1,0 +1,19 @@
+#!/sbin/openrc-run
+# Copyright 2016-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+description="cAdvisor - Analyzes resource usage and performance characteristics of running containers"
+pidfile=${pidfile:-"/run/${SVCNAME}.pid"}
+user=${user:-${SVCNAME}}
+group=${group:-${SVCNAME}}
+
+command="/usr/bin/cadvisor"
+command_background="true"
+start_stop_daemon_args="--user ${user} --group ${group} \
+	--stdout /var/log/${SVCNAME}/${SVCNAME}.log \
+	--stderr /var/log/${SVCNAME}/${SVCNAME}.log"
+
+depend() {
+	after net
+	use docker
+}


### PR DESCRIPTION
added "use docker" in init scripts
without it have to restart /etc/init.d/cadvisor after reboot server


Signed-off-by: Denis Pershin bazukajo@gmail.com