### PR TITLE
sys-boot/netboot: bump to EAPI=7

### DIFF
--- a/sys-boot/netboot/metadata.xml
+++ b/sys-boot/netboot/metadata.xml
@@ -1,8 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>ck+gentoo@bl4ckb0x.de</email>
+		<name>Conrad Kostecki</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<longdescription>
+		Netboot enables a computer with a compatible CPU to boot without access to a hdd or floppy.
+		The computer has to be equipped so it can load the operating system over an IP network from a server.
+		All tools required for this are included in the netboot package. 
+	</longdescription>
 	<upstream>
+		<bugs-to>https://sourceforge.net/p/netboot/bugs/</bugs-to>
 		<remote-id type="sourceforge">netboot</remote-id>
 	</upstream>
+	<use>
+		<flag name="bootrom">Install the bootrom binary for creation of rom files, which can be used for booting via floppy or rom.</flag>
+	</use>
 </pkgmetadata>

--- a/sys-boot/netboot/netboot-0.10.2-r1.ebuild
+++ b/sys-boot/netboot/netboot-0.10.2-r1.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Allows to remote boot a computer over an IP network"
+HOMEPAGE="http://netboot.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="berkdb +bootrom +lzo odbc static-libs"
+
+DEPEND="
+	berkdb? ( sys-libs/db:= )
+	lzo? ( dev-libs/lzo:2= )
+	odbc? ( dev-db/unixODBC:= )
+"
+
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+
+	# Respect users LDFLAGS
+	eapply "${FILESDIR}"/"${P}"-ldflags.patch
+
+	# Don't	install	support	binaries into libdir
+	sed -e "152s:nblibdir:bindir:" -e "153s:nblibdir:bindir:" -i misc/Makefile || die
+
+	# Don't install perl script into libdir
+	sed -e 's/nblibdir/nbmiscdir/g' -i mknbi-dos/utils/Makefile || die
+
+	# Don't install vim syntax file, as it will be installed manually
+	sed -e '/mgl.vim/d' -i mknbi-mgl/Makefile || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		--datadir="/usr/share/netboot"
+		$(use_with berkdb berkeley-db)
+		$(use_enable bootrom)
+		$(use_with lzo)
+		$(use_with odbc)
+		$(use_enable static-libs static)
+		--with-gnu-as86="$(tc-getAS)"
+		--with-gnu-cc86="$(tc-getCC)"
+		--with-gnu-ld86="$(tc-getLD)"
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	# mknbi fails with parallel build
+	emake -j1
+}
+
+src_install() {
+	emake DESTDIR="${ED}" install
+
+	insinto /usr/share/vim/vimfiles/syntax
+	doins "${S}"/mknbi-mgl/misc/mgl.vim
+
+	dodoc README doc/{HISTORY,PROBLEMS,README.*,Spec.doc}
+
+	docinto flashcard
+	dodoc FlashCard/README FlashCard/*.ps
+
+	find "${D}" -name '*.la' -type f -delete || die
+}


### PR DESCRIPTION
Changes to ebuild:
* bumped from EAPI=2 to EAPI=7
* license changed to GPL-2+, since GPL-2 is wrong here
* added amd64 arch, as it compiles and works fine on this arch
* Patched several makefiles, to install into the correct pathes
* Overhauled whole build to make it more clean
* Install more docs, to make it complete
* Dropped unnecessary move/delete of directories/files
* Added better description to ebuild and metadata.xml
* Taking ownership by myself

Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>