### PR TITLE
sys-cluster/kubeadm: add openrc support via patch

### DIFF
--- a/sys-cluster/kubeadm/files/kubeadm-1.14-openrc.patch
+++ b/sys-cluster/kubeadm/files/kubeadm-1.14-openrc.patch
@@ -1,0 +1,110 @@
+Needed for OpenRC support until https://github.com/kubernetes/kubernetes/pull/73101 is merged.
+
+Brought to attention by https://bugs.alpinelinux.org/issues/10179
+
+---------------------------------
+--- a/pkg/util/initsystem/initsystem.go
++++ b/pkg/util/initsystem/initsystem.go
+@@ -1,5 +1,5 @@
+ /*
+-Copyright 2016 The Kubernetes Authors.
++Copyright 2019 The Kubernetes Authors.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+@@ -23,6 +23,9 @@
+ )
+ 
+ type InitSystem interface {
++	// return a string describing how to enable a service
++	EnableCommand(service string) string
++
+ 	// ServiceStart tries to start a specific service
+ 	ServiceStart(service string) error
+ 
+@@ -42,8 +45,63 @@
+ 	ServiceIsActive(service string) bool
+ }
+ 
++type OpenRCInitSystem struct{}
++
++func (openrc OpenRCInitSystem) ServiceStart(service string) error {
++	args := []string{service, "start"}
++	return exec.Command("rc-service", args...).Run()
++}
++
++func (openrc OpenRCInitSystem) ServiceStop(service string) error {
++	args := []string{service, "stop"}
++	return exec.Command("rc-service", args...).Run()
++}
++
++func (openrc OpenRCInitSystem) ServiceRestart(service string) error {
++	args := []string{service, "restart"}
++	return exec.Command("rc-service", args...).Run()
++}
++
++// openrc writes to stderr if a service is not found or not enabled
++// this is in contrast to systemd which only writes to stdout.
++// Hence, we use the Combinedoutput, and ignore the error.
++func (openrc OpenRCInitSystem) ServiceExists(service string) bool {
++	args := []string{service, "status"}
++	outBytes, _ := exec.Command("rc-service", args...).CombinedOutput()
++	if strings.Contains(string(outBytes), "does not exist") {
++		return false
++	}
++	return true
++}
++
++func (openrc OpenRCInitSystem) ServiceIsEnabled(service string) bool {
++	args := []string{"show", "default"}
++	outBytes, _ := exec.Command("rc-update", args...).Output()
++	if strings.Contains(string(outBytes), service) {
++		return true
++	}
++	return false
++}
++
++func (openrc OpenRCInitSystem) ServiceIsActive(service string) bool {
++	args := []string{service, "status"}
++	outBytes, _ := exec.Command("rc-service", args...).Output()
++	if strings.Contains(string(outBytes), "stopped") {
++		return false
++	}
++	return true
++}
++
++func (openrc OpenRCInitSystem) EnableCommand(service string) string {
++	return fmt.Sprintf("rc-update add %s default", service)
++}
++
+ type SystemdInitSystem struct{}
+ 
++func (sysd SystemdInitSystem) EnableCommand(service string) string {
++	return fmt.Sprintf("systemctl enable %s.service", service)
++}
++
+ func (sysd SystemdInitSystem) reloadSystemd() error {
+ 	if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
+ 		return fmt.Errorf("failed to reload systemd: %v", err)
+@@ -110,6 +168,10 @@
+ // WindowsInitSystem is the windows implementation of InitSystem
+ type WindowsInitSystem struct{}
+ 
++func (sysd WindowsInitSystem) EnableCommand(service string) string {
++	return fmt.Sprintf("Set-Service '%s' -StartupType Automatic", service)
++}
++
+ func (sysd WindowsInitSystem) ServiceStart(service string) error {
+ 	args := []string{"Start-Service", service}
+ 	err := exec.Command("powershell", args...).Run()
+@@ -170,6 +232,10 @@
+ 	_, err := exec.LookPath("systemctl")
+ 	if err == nil {
+ 		return &SystemdInitSystem{}, nil
++	}
++	_, err = exec.LookPath("openrc")
++	if err == nil {
++		return &OpenRCInitSystem{}, nil
+ 	}
+ 	_, err = exec.LookPath("wininit.exe")
+ 	if err == nil {

--- a/sys-cluster/kubeadm/kubeadm-1.14.0-r1.ebuild
+++ b/sys-cluster/kubeadm/kubeadm-1.14.0-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit golang-build golang-vcs-snapshot bash-completion-r1
+
+EGO_PN="k8s.io/kubernetes"
+ARCHIVE_URI="https://github.com/kubernetes/kubernetes/archive/v${PV}.tar.gz -> kubernetes-${PV}.tar.gz"
+KEYWORDS="~amd64"
+
+DESCRIPTION="CLI to Easily bootstrap a secure Kubernetes cluster"
+HOMEPAGE="https://github.com/kubernetes/kubernetes https://kubernetes.io"
+SRC_URI="${ARCHIVE_URI}"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+
+DEPEND=">=dev-lang/go-1.12
+	dev-go/go-bindata"
+
+RESTRICT="test"
+
+src_prepare() {
+	default
+	sed -i -e "/vendor\/github.com\/jteeuwen\/go-bindata\/go-bindata/d" -e "s/-s -w/-w/" src/${EGO_PN}/hack/lib/golang.sh || die
+	sed -i -e "/export PATH/d" src/${EGO_PN}/hack/generate-bindata.sh || die
+	pushd src/${EGO_PN} || die
+	eapply "${FILESDIR}/${PN}-1.14-openrc.patch"
+	popd || die
+}
+
+src_compile() {
+	LDFLAGS="" GOPATH="${WORKDIR}/${P}" emake -j1 -C src/${EGO_PN} WHAT=cmd/${PN} GOFLAGS=-v
+	pushd src/${EGO_PN} || die
+	_output/bin/${PN} completion bash > ${PN}.bash || die
+	_output/bin/${PN} completion zsh > ${PN}.zsh || die
+	popd || die
+}
+
+src_install() {
+	pushd src/${EGO_PN} || die
+	dobin _output/bin/${PN}
+
+	newbashcomp ${PN}.bash ${PN}
+	insinto /usr/share/zsh/site-functions
+	newins ${PN}.zsh _${PN}
+
+	popd || die
+}


### PR DESCRIPTION
Also kubeadm requires go-1.12 to compile

Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Dan Molik <dan@danmolik.com>
Tested-by: Dan Molik <dan@danmolik.com>