### PR TITLE
media-sound/ncmpcpp: cleanup dependencies

### DIFF
--- a/media-sound/ncmpcpp/ncmpcpp-0.8.2-r1.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-0.8.2-r1.ebuild
@@ -23,10 +23,8 @@ RDEPEND="
 	taglib? ( media-libs/taglib )
 	visualizer? ( sci-libs/fftw:3.0= )
 "
-DEPEND="
-	${RDEPEND}
-	virtual/pkgconfig
-"
+DEPEND="${RDEPEND}"
+BDEPDND="virtual/pkgconfig"
 
 src_prepare() {
 	default

--- a/media-sound/ncmpcpp/ncmpcpp-9999.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-9999.ebuild
@@ -24,10 +24,8 @@ RDEPEND="
 	taglib? ( media-libs/taglib )
 	visualizer? ( sci-libs/fftw:3.0= )
 "
-DEPEND="
-	${RDEPEND}
-	virtual/pkgconfig
-"
+DEPEND="${RDEPEND}"
+BDEPDND="virtual/pkgconfig"
 
 src_prepare() {
 	default


### PR DESCRIPTION
move `virtual/pkgconfig` from `DEPEND` to `BDEPDND`

Package-Manager: Portage-2.3.62, Repoman-2.3.12