### PR TITLE
www-servers/gunicorn: use HTTPS

### DIFF
--- a/www-servers/gunicorn/gunicorn-19.8.1.ebuild
+++ b/www-servers/gunicorn/gunicorn-19.8.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 python3_{4,5,6} pypy )
 inherit distutils-r1
 
 DESCRIPTION="A WSGI HTTP Server for UNIX"
-HOMEPAGE="http://gunicorn.org https://pypi.org/project/gunicorn https://github.com/benoitc/gunicorn"
+HOMEPAGE="https://gunicorn.org https://pypi.org/project/gunicorn https://github.com/benoitc/gunicorn"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT PSF-2 doc? ( BSD )"


### PR DESCRIPTION
Hi,

Another very simple http -> https fix.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>