### PR TITLE
games-roguelike/angband: fix build with sys-libs/ncurses[tinfo]

### DIFF
--- a/games-roguelike/angband/angband-4.1.3.ebuild
+++ b/games-roguelike/angband/angband-4.1.3.ebuild
@@ -37,6 +37,8 @@ DEPEND="${RDEPEND}"
 BDEPEND="dev-python/docutils
 	virtual/pkgconfig"
 
+PATCHES=( "${FILESDIR}"/${P}-tinfo.patch )
+
 src_prepare() {
 	default
 

--- a/games-roguelike/angband/files/angband-4.1.3-tinfo.patch
+++ b/games-roguelike/angband/files/angband-4.1.3-tinfo.patch
@@ -1,0 +1,29 @@
+From de53f9644323af0ff084bc82ef17b26aa6db250e Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <stefan.strogin@gmail.com>
+Date: Thu, 4 Apr 2019 04:24:49 +0300
+Subject: [PATCH] Link against tinfow or tinfo if needed
+
+It is needed on systems where libtinfo is separate from libncurses.
+See: https://bugs.gentoo.org/679942
+
+Upstream-Status: Submitted [https://github.com/angband/angband/pull/522]
+Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>
+---
+ configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure.ac b/configure.ac
+index 4a671f33..04fa8cae 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -244,6 +244,7 @@ if test "$enable_curses" = "yes"; then
+ 			LIBS="${LIBS} -lncursesw"
+ 			MAINFILES="${MAINFILES} \$(GCUMAINFILES)"
+ 		])
++		AC_SEARCH_LIBS([keypad], [tinfow tinfo])
+ 	fi
+ fi
+ 
+-- 
+2.21.0
+

--- a/games-roguelike/angband/metadata.xml
+++ b/games-roguelike/angband/metadata.xml
@@ -5,6 +5,14 @@
 		<email>games@gentoo.org</email>
 		<name>Gentoo Games Project</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>stefan.strogin@gmail.com</email>
+		<name>Stefan Strogin</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<use>
 		<flag name="sound">Enable and install sounds</flag>
 	</use>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/679942
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>