### PR TITLE
app-emulation/libvirt: fixes dependency on incompatible gnu-netcat & netcat

### DIFF
--- a/app-emulation/libvirt/libvirt-4.9.0.ebuild
+++ b/app-emulation/libvirt/libvirt-4.9.0.ebuild
@@ -57,11 +57,7 @@ RDEPEND="
 	dev-libs/libgcrypt:0
 	dev-libs/libnl:3
 	>=dev-libs/libxml2-2.7.6
-	|| (
-		>=net-analyzer/gnu-netcat-0.7.1-r3
-		>=net-analyzer/netcat-110-r9
-		>=net-analyzer/openbsd-netcat-1.105-r1
-	)
+	>=net-analyzer/openbsd-netcat-1.105-r1
 	>=net-libs/gnutls-1.0.25:0=
 	net-libs/libssh2
 	net-libs/libtirpc

--- a/app-emulation/libvirt/libvirt-5.0.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-5.0.0-r1.ebuild
@@ -56,11 +56,7 @@ RDEPEND="
 	dev-libs/libgcrypt:0
 	dev-libs/libnl:3
 	>=dev-libs/libxml2-2.7.6
-	|| (
-		>=net-analyzer/gnu-netcat-0.7.1-r3
-		>=net-analyzer/netcat-110-r9
-		>=net-analyzer/openbsd-netcat-1.105-r1
-	)
+	>=net-analyzer/openbsd-netcat-1.105-r1
 	>=net-libs/gnutls-1.0.25:0=
 	net-libs/libssh2
 	net-libs/libtirpc

--- a/app-emulation/libvirt/libvirt-5.1.0.ebuild
+++ b/app-emulation/libvirt/libvirt-5.1.0.ebuild
@@ -56,11 +56,7 @@ RDEPEND="
 	dev-libs/libgcrypt:0
 	dev-libs/libnl:3
 	>=dev-libs/libxml2-2.7.6
-	|| (
-		>=net-analyzer/gnu-netcat-0.7.1-r3
-		>=net-analyzer/netcat-110-r9
-		>=net-analyzer/openbsd-netcat-1.105-r1
-	)
+	>=net-analyzer/openbsd-netcat-1.105-r1
 	>=net-libs/gnutls-1.0.25:0=
 	net-libs/libssh2
 	net-libs/libtirpc

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -56,11 +56,7 @@ RDEPEND="
 	dev-libs/libgcrypt:0
 	dev-libs/libnl:3
 	>=dev-libs/libxml2-2.7.6
-	|| (
-		>=net-analyzer/gnu-netcat-0.7.1-r3
-		>=net-analyzer/netcat-110-r9
-		>=net-analyzer/openbsd-netcat-1.105-r1
-	)
+	>=net-analyzer/openbsd-netcat-1.105-r1
 	>=net-libs/gnutls-1.0.25:0=
 	net-libs/libssh2
 	net-libs/libtirpc


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/682494