### PR TITLE
net-libs/webkit-gtk: add python3_7 compat

### DIFF
--- a/net-libs/webkit-gtk/webkit-gtk-2.24.0.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.24.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 CMAKE_MAKEFILE_GENERATOR="ninja"
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python2_7 python3_{6,7} )
 USE_RUBY="ruby23 ruby24 ruby25 ruby26"
 
 inherit check-reqs cmake-utils flag-o-matic gnome2 pax-utils python-any-r1 ruby-single toolchain-funcs virtualx


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/682528

Signed-off-by: David Heidelberg <david@ixit.cz>