### PR TITLE
sys-cluster/mpich: Enable fortran for multilib

### DIFF
--- a/sys-cluster/mpich/mpich-3.2-r1.ebuild
+++ b/sys-cluster/mpich/mpich-3.2-r1.ebuild
@@ -90,7 +90,7 @@ multilib_src_configure() {
 		--enable-versioning \
 		$(use_enable romio) \
 		$(use_enable cxx) \
-		$(multilib_native_use_enable fortran fortran all)
+		$(use_enable fortran fortran all)
 }
 
 multilib_src_test() {


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/680236
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Jian Cao <sworden.cao@gmail.com>

The `multilib-native-use-enable fortran` conflicts with the removal part of the patch (bug 540508), so re-enable the `fortran` flag and therefore the patch works.