### PR TITLE
www-client/qutebrowser: update dependencies for PyQt5-5.12

### DIFF
--- a/www-client/qutebrowser/qutebrowser-1.6.1-r1.ebuild
+++ b/www-client/qutebrowser/qutebrowser-1.6.1-r1.ebuild
@@ -30,7 +30,8 @@ RDEPEND="${COMMON_DEPEND}
 	>=dev-python/jinja-2.8[${PYTHON_USEDEP}]
 	>=dev-python/pygments-2.1.3[${PYTHON_USEDEP}]
 	>=dev-python/pypeg2-2.15.2[${PYTHON_USEDEP}]
-	>=dev-python/PyQt5-5.7.1[${PYTHON_USEDEP},declarative,multimedia,gui,network,opengl,printsupport,sql,webengine,widgets]
+	>=dev-python/PyQt5-5.12[${PYTHON_USEDEP},declarative,multimedia,gui,network,opengl,printsupport,sql,widgets]
+	dev-python/PyQtWebEngine[${PYTHON_USEDEP}]
 	>=dev-python/pyyaml-3.12[${PYTHON_USEDEP},libyaml]
 "
 

--- a/www-client/qutebrowser/qutebrowser-9999.ebuild
+++ b/www-client/qutebrowser/qutebrowser-9999.ebuild
@@ -30,7 +30,8 @@ RDEPEND="${COMMON_DEPEND}
 	>=dev-python/jinja-2.8[${PYTHON_USEDEP}]
 	>=dev-python/pygments-2.1.3[${PYTHON_USEDEP}]
 	>=dev-python/pypeg2-2.15.2[${PYTHON_USEDEP}]
-	>=dev-python/PyQt5-5.7.1[${PYTHON_USEDEP},declarative,multimedia,gui,network,opengl,printsupport,sql,webengine,widgets]
+	>=dev-python/PyQt5-5.12[${PYTHON_USEDEP},declarative,multimedia,gui,network,opengl,printsupport,sql,widgets]
+	dev-python/PyQtWebEngine[${PYTHON_USEDEP}]
 	>=dev-python/pyyaml-3.12[${PYTHON_USEDEP},libyaml]
 "
 


### PR DESCRIPTION
Before PyQt5-5.12 PyQtWebEngine was a part of PyQt5, now it is a
separate package, dev-python/PyQtWebEngine. Now qutebrowser must depend
on dev-python/PyQtWebEngine instead of dev-python/PyQt5[webengine].

Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>