### PR TITLE
dev-libs/cyrus-sasl-2.1.27-r2: fix LDAP dependencies

### DIFF
--- a/dev-libs/cyrus-sasl/cyrus-sasl-2.1.27-r2.ebuild
+++ b/dev-libs/cyrus-sasl/cyrus-sasl-2.1.27-r2.ebuild
@@ -34,6 +34,8 @@ CDEPEND="
 	)
 	java? ( >=virtual/jdk-1.6:= )"
 
+REQUIRED_USE="ldapdb? ( openldap )"
+
 RDEPEND="
 	${CDEPEND}
 	selinux? ( sec-policy/selinux-sasl )"


### PR DESCRIPTION
Otherwise it fails to configure:

  checking LDAPDB... enabled
  configure: error: Cannot enable LDAPDB plugin: You need to specify --with-ldap
