### PR TITLE
dev-libs/{cdk,locked_sstream,shhopt}, dev-util/bcpp, net-mail/libpst: use HTTPS

### DIFF
--- a/dev-libs/cdk/cdk-5.0.20160131.ebuild
+++ b/dev-libs/cdk/cdk-5.0.20160131.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit versionator
 
 MY_P="${PN}-$(replace_version_separator 2 -)"
 DESCRIPTION="A library of curses widgets"
-HOMEPAGE="http://dickey.his.com/cdk/cdk.html"
+HOMEPAGE="https://dickey.his.com/cdk/cdk.html"
 SRC_URI="ftp://invisible-island.net/cdk/${MY_P}.tgz"
 
 LICENSE="BSD"

--- a/dev-libs/locked_sstream/locked_sstream-0.0.5.ebuild
+++ b/dev-libs/locked_sstream/locked_sstream-0.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,8 +9,8 @@ PYTHON_REQ_USE="threads(+)"
 inherit python-any-r1 waf-utils
 
 DESCRIPTION="tiny C++ library which wraps std::stringstream in a mutex"
-HOMEPAGE="http://carlh.net/locked_sstream"
-SRC_URI="http://carlh.net/downloads/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://carlh.net/locked_sstream"
+SRC_URI="https://carlh.net/downloads/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-libs/shhopt/shhopt-1.1.7-r3.ebuild
+++ b/dev-libs/shhopt/shhopt-1.1.7-r3.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="library for parsing command line options"
-HOMEPAGE="http://shh.thathost.com/pub-unix/"
-SRC_URI="http://shh.thathost.com/pub-unix/files/${P}.tar.gz"
+HOMEPAGE="https://shh.thathost.com/pub-unix/"
+SRC_URI="https://shh.thathost.com/pub-unix/files/${P}.tar.gz"
 
 LICENSE="Artistic"
 SLOT="0"

--- a/dev-util/bcpp/bcpp-20150811-r1.ebuild
+++ b/dev-util/bcpp/bcpp-20150811-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="Indents C/C++ source code"
-HOMEPAGE="http://invisible-island.net/bcpp/"
+HOMEPAGE="https://invisible-island.net/bcpp/"
 SRC_URI="ftp://invisible-island.net/bcpp/${P}.tgz"
 
 LICENSE="MIT"

--- a/net-mail/cyrus-imapd/cyrus-imapd-3.0.4.ebuild
+++ b/net-mail/cyrus-imapd/cyrus-imapd-3.0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit autotools pam ssl-cert user
 MY_P=${P/_/}
 
 DESCRIPTION="The Cyrus IMAP Server"
-HOMEPAGE="http://www.cyrusimap.org/"
+HOMEPAGE="https://www.cyrusimap.org/"
 SRC_URI="ftp://ftp.cyrusimap.org/cyrus-imapd/${MY_P}.tar.gz"
 
 LICENSE="BSD-with-attribution"
@@ -214,7 +214,7 @@ pkg_postinst() {
 	fi
 
 	echo
-	ewarn "Please see http://www.cyrusimap.org/imap/download/upgrade.html"
+	ewarn "Please see https://www.cyrusimap.org/imap/download/upgrade.html"
 	ewarn "for upgrade instructions."
 	echo
 }

--- a/net-mail/cyrus-imapd/cyrus-imapd-3.0.5.ebuild
+++ b/net-mail/cyrus-imapd/cyrus-imapd-3.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit autotools flag-o-matic pam ssl-cert user
 MY_P=${P/_/}
 
 DESCRIPTION="The Cyrus IMAP Server"
-HOMEPAGE="http://www.cyrusimap.org/"
+HOMEPAGE="https://www.cyrusimap.org/"
 SRC_URI="ftp://ftp.cyrusimap.org/cyrus-imapd/${MY_P}.tar.gz"
 
 LICENSE="BSD-with-attribution"
@@ -215,7 +215,7 @@ pkg_postinst() {
 	fi
 
 	echo
-	ewarn "Please see http://www.cyrusimap.org/imap/download/upgrade.html"
+	ewarn "Please see https://www.cyrusimap.org/imap/download/upgrade.html"
 	ewarn "for upgrade instructions."
 	echo
 }

--- a/net-mail/cyrus-imapd/cyrus-imapd-3.0.6.ebuild
+++ b/net-mail/cyrus-imapd/cyrus-imapd-3.0.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit autotools flag-o-matic pam ssl-cert user
 MY_P=${P/_/}
 
 DESCRIPTION="The Cyrus IMAP Server"
-HOMEPAGE="http://www.cyrusimap.org/"
+HOMEPAGE="https://www.cyrusimap.org/"
 SRC_URI="ftp://ftp.cyrusimap.org/cyrus-imapd/${MY_P}.tar.gz"
 
 LICENSE="BSD-with-attribution"
@@ -215,7 +215,7 @@ pkg_postinst() {
 	fi
 
 	echo
-	einfo "Please see http://www.cyrusimap.org/imap/download/upgrade.html"
+	einfo "Please see https://www.cyrusimap.org/imap/download/upgrade.html"
 	einfo "for upgrade instructions."
 	echo
 }

--- a/net-mail/cyrus-imapd/cyrus-imapd-3.0.8-r1.ebuild
+++ b/net-mail/cyrus-imapd/cyrus-imapd-3.0.8-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 inherit autotools flag-o-matic pam ssl-cert user
 
 DESCRIPTION="The Cyrus IMAP Server"
-HOMEPAGE="http://www.cyrusimap.org/"
+HOMEPAGE="https://www.cyrusimap.org/"
 SRC_URI="https://github.com/cyrusimap/${PN}/releases/download/${P}/${P}.tar.gz"
 
 LICENSE="BSD-with-attribution"
@@ -208,7 +208,7 @@ pkg_postinst() {
 	fi
 
 	echo
-	einfo "Please see http://www.cyrusimap.org/imap/download/upgrade.html"
+	einfo "Please see https://www.cyrusimap.org/imap/download/upgrade.html"
 	einfo "for upgrade instructions."
 	echo
 }

--- a/net-mail/cyrus-imapd/cyrus-imapd-3.0.9.ebuild
+++ b/net-mail/cyrus-imapd/cyrus-imapd-3.0.9.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 inherit autotools flag-o-matic pam ssl-cert user
 
 DESCRIPTION="The Cyrus IMAP Server"
-HOMEPAGE="http://www.cyrusimap.org/"
+HOMEPAGE="https://www.cyrusimap.org/"
 SRC_URI="https://github.com/cyrusimap/${PN}/releases/download/${P}/${P}.tar.gz"
 
 LICENSE="BSD-with-attribution"
@@ -212,7 +212,7 @@ pkg_postinst() {
 	fi
 
 	echo
-	einfo "Please see http://www.cyrusimap.org/imap/download/upgrade.html"
+	einfo "Please see https://www.cyrusimap.org/imap/download/upgrade.html"
 	einfo "for upgrade instructions."
 	echo
 }

--- a/net-mail/libpst/libpst-0.6.66-r1.ebuild
+++ b/net-mail/libpst/libpst-0.6.66-r1.ebuild
@@ -7,8 +7,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit autotools python-single-r1
 
 DESCRIPTION="Tools and library for reading Outlook files (.pst format)"
-HOMEPAGE="http://www.five-ten-sg.com/libpst/"
-SRC_URI="http://www.five-ten-sg.com/${PN}/packages/${P}.tar.gz"
+HOMEPAGE="https://www.five-ten-sg.com/libpst/"
+SRC_URI="https://www.five-ten-sg.com/${PN}/packages/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

Another few https fixes for maintainer-needed packages.
Please review.