### PR TITLE
app-editors/vim: vim-pager needs -minimal

### DIFF
--- a/app-editors/vim/vim-8.1.0648-r1.ebuild
+++ b/app-editors/vim/vim-8.1.0648-r1.ebuild
@@ -27,6 +27,7 @@ IUSE="X acl cscope debug gpm lua luajit minimal nls perl python racket ruby seli
 REQUIRED_USE="
 	luajit? ( lua )
 	python? ( ${PYTHON_REQUIRED_USE} )
+	vim-pager? ( !minimal )
 "
 
 RDEPEND="
@@ -57,6 +58,7 @@ DEPEND="
 	${RDEPEND}
 	sys-devel/autoconf
 	nls? ( sys-devel/gettext )
+	vim-pager? ( app-editors/vim-core[-minimal] )
 "
 
 pkg_setup() {

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -51,12 +51,14 @@ RDEPEND="
 	selinux? ( sys-libs/libselinux )
 	tcl? ( dev-lang/tcl:0= )
 	X? ( x11-libs/libXt )
+	vim-pager? ( !minimal )
 "
 
 DEPEND="
 	${RDEPEND}
 	sys-devel/autoconf
 	nls? ( sys-devel/gettext )
+	vim-pager? ( app-editors/vim-core[-minimal] )
 "
 
 pkg_setup() {


### PR DESCRIPTION
The vimpager command will not work with app-editors/vim-core[minimal] or
app-editors/vim[minimal]. Do not allow the vim-pager USE flag to be
enabled if either is enabled.

Signed-off-by: Dan Robertson <daniel.robertson@starlab.io>