### PR TITLE
media-libs/glpng: update HOMEPAGE, use HTTPS

### DIFF
--- a/media-libs/glpng/glpng-1.46-r1.ebuild
+++ b/media-libs/glpng/glpng-1.46-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit cmake-multilib
 
 DESCRIPTION="An OpenGL PNG image library"
-HOMEPAGE="http://repo.or.cz/w/glpng.git"
-SRC_URI="http://repo.or.cz/w/glpng.git/snapshot/v${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://repo.or.cz/w/glpng.git"
+SRC_URI="https://repo.or.cz/w/glpng.git/snapshot/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/682504
Signed-off-by: Wim Muskee <wimmuskee@gmail.com>