### PR TITLE
dev-util/diffball: update SRC_URI, HOMEPAGE, metadata.xml

### DIFF
--- a/dev-util/diffball/diffball-1.0.1.ebuild
+++ b/dev-util/diffball/diffball-1.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit flag-o-matic
 
 DESCRIPTION="Delta compression suite for using/generating binary patches"
-HOMEPAGE="https://diffball.googlecode.com/"
-SRC_URI="https://diffball.googlecode.com/files/${P}.tar.bz2"
+HOMEPAGE="https://github.com/rafaelmartins/diffball"
+SRC_URI="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/${PN}/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-util/diffball/metadata.xml
+++ b/dev-util/diffball/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Rafael G. Martins</name>
 	</maintainer>
 	<upstream>
+		<remote-id type="github">rafaelmartins/diffball</remote-id>
 		<remote-id type="google-code">diffball</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/680560
Signed-off-by: Wim Muskee <wimmuskee@gmail.com>

Checksum for new SRC_URI download is same as in Manifest.