### PR TITLE
net-libs/nDPI: use HTTPS

### DIFF
--- a/net-libs/nDPI/nDPI-2.0.ebuild
+++ b/net-libs/nDPI/nDPI-2.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools eutils multilib
 
 DESCRIPTION="Open Source Deep Packet Inspection Software Toolkit"
-HOMEPAGE="http://www.ntop.org/"
+HOMEPAGE="https://www.ntop.org/"
 SRC_URI="https://github.com/ntop/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/net-libs/nDPI/nDPI-2.2.ebuild
+++ b/net-libs/nDPI/nDPI-2.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools eutils multilib versionator
 
 DESCRIPTION="Open Source Deep Packet Inspection Software Toolkit"
-HOMEPAGE="http://www.ntop.org/"
+HOMEPAGE="https://www.ntop.org/"
 SRC_URI="https://github.com/ntop/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"


### PR DESCRIPTION
Hi,

This PR updates net-libs/nDPI to use https instead of http.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>