### PR TITLE
net-libs/libupnpp: use HTTPS

### DIFF
--- a/net-libs/libupnpp/libupnpp-0.16.1.ebuild
+++ b/net-libs/libupnpp/libupnpp-0.16.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 DESCRIPTION="The libupnpp C++ library wraps libupnp for easier use by upmpdcli and upplay"
-HOMEPAGE="http://www.lesbonscomptes.com/upmpdcli"
+HOMEPAGE="https://www.lesbonscomptes.com/upmpdcli"
 SRC_URI="https://www.lesbonscomptes.com/upmpdcli/downloads/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-libs/libupnpp/libupnpp-0.17.0.ebuild
+++ b/net-libs/libupnpp/libupnpp-0.17.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 DESCRIPTION="The libupnpp C++ library wraps libupnp for easier use by upmpdcli and upplay"
-HOMEPAGE="http://www.lesbonscomptes.com/upmpdcli"
+HOMEPAGE="https://www.lesbonscomptes.com/upmpdcli"
 SRC_URI="https://www.lesbonscomptes.com/upmpdcli/downloads/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This PR updates net-libs/libupnpp to use https instead of http.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>