### PR TITLE
media-video/obs-studio: add missing qtsvg:5 to DEPEND

### DIFF
--- a/media-video/obs-studio/obs-studio-23.1.0.ebuild
+++ b/media-video/obs-studio/obs-studio-23.1.0.ebuild
@@ -37,6 +37,7 @@ DEPEND="
 	dev-qt/qtnetwork:5
 	dev-qt/qtquickcontrols:5
 	dev-qt/qtsql:5
+	dev-qt/qtsvg:5
 	dev-qt/qttest:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5

--- a/media-video/obs-studio/obs-studio-9999.ebuild
+++ b/media-video/obs-studio/obs-studio-9999.ebuild
@@ -37,6 +37,7 @@ DEPEND="
 	dev-qt/qtnetwork:5
 	dev-qt/qtquickcontrols:5
 	dev-qt/qtsql:5
+	dev-qt/qtsvg:5
 	dev-qt/qttest:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5


### PR DESCRIPTION
media-video/obs-studio-23.1.0 build fails when qtsvg is not installed:

```
CMake Error at UI/CMakeLists.txt:59 (find_package):
  By not providing "FindQt5Svg.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Qt5Svg", but
  CMake did not find one.

  Could not find a package configuration file provided by "Qt5Svg" with any
  of the following names:

    Qt5SvgConfig.cmake
    qt5svg-config.cmake

  Add the installation prefix of "Qt5Svg" to CMAKE_PREFIX_PATH or set
  "Qt5Svg_DIR" to a directory containing one of the above files.  If "Qt5Svg"
  provides a separate development package or SDK, be sure it has been
  installed.
```

This PR adds `dev-qt/qtsvg:5` to `DEPEND` for 23.1.0 and 9999 ebuilds.

Signed-off-by: Jiri Helebrant <helb@helb.cz>