### PR TITLE
dev-tex/abntex: update HOMEPAGE, metadata

### DIFF
--- a/dev-tex/abntex/abntex-0.9_beta2-r1.ebuild
+++ b/dev-tex/abntex/abntex-0.9_beta2-r1.ebuild
@@ -9,7 +9,7 @@ MY_PV="${PV/_/-}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="LaTeX macros for writing documents following the ABNT norms"
-HOMEPAGE="http://abntex.codigolivre.org.br/ http://abntex.sourceforge.net/"
+HOMEPAGE="https://www.abntex.net.br/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz
 	doc? ( mirror://sourceforge/${PN}/${PN}-doc-${MY_PV}.tar.gz )"
 

--- a/dev-tex/abntex/metadata.xml
+++ b/dev-tex/abntex/metadata.xml
@@ -8,7 +8,4 @@
 	<use>
 		<flag name="lyx">Install with <pkg>app-office/lyx</pkg> layout</flag>
 	</use>
-	<upstream>
-		<remote-id type="sourceforge">abntex</remote-id>
-	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/680402
Signed-off-by: Wim Muskee <wimmuskee@gmail.com>

Not replacing metadata.xml upstream with abntex2 github or ctan because these refer to the replacement of abntex.