### PR TITLE
dev-lang/duktape: use HTTPS

### DIFF
--- a/dev-lang/duktape/duktape-2.1.1.ebuild
+++ b/dev-lang/duktape/duktape-2.1.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Embeddable Javascript engine"
-HOMEPAGE="http://duktape.org"
-SRC_URI="http://duktape.org/${P}.tar.xz"
+HOMEPAGE="https://duktape.org"
+SRC_URI="https://duktape.org/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-lang/duktape/duktape-2.2.0.ebuild
+++ b/dev-lang/duktape/duktape-2.2.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Embeddable Javascript engine"
-HOMEPAGE="http://duktape.org"
-SRC_URI="http://duktape.org/${P}.tar.xz"
+HOMEPAGE="https://duktape.org"
+SRC_URI="https://duktape.org/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-lang/duktape/duktape-2.2.1.ebuild
+++ b/dev-lang/duktape/duktape-2.2.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Embeddable Javascript engine"
-HOMEPAGE="http://duktape.org"
-SRC_URI="http://duktape.org/${P}.tar.xz"
+HOMEPAGE="https://duktape.org"
+SRC_URI="https://duktape.org/${P}.tar.xz"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
Hi,

Another simple http -> https fix, this time for dev-lang/duktape.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>