### PR TITLE
app-arch/cksfv: fix LICENSE, EAPI=7

### DIFF
--- a/app-arch/cksfv/cksfv-1.3.14-r1.ebuild
+++ b/app-arch/cksfv/cksfv-1.3.14-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="SFV checksum utility (simple file verification)"
+HOMEPAGE="http://zakalwe.fi/~shd/foss/cksfv/"
+SRC_URI="http://zakalwe.fi/~shd/foss/cksfv/files/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~amd64-linux ~hppa ~ia64 ~ppc ~sparc ~x86 ~x86-fbsd ~x86-linux"
+
+src_configure() {
+	# note: not an autoconf configure script
+	./configure \
+		--compiler="$(tc-getCC)" \
+		--prefix="${EPREFIX}"/usr \
+		--package-prefix="${D}" \
+		--bindir="${EPREFIX}"/usr/bin \
+		--mandir="${EPREFIX}"/usr/share/man || die
+}

--- a/app-arch/cksfv/cksfv-1.3.14.ebuild
+++ b/app-arch/cksfv/cksfv-1.3.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -9,7 +9,7 @@ DESCRIPTION="SFV checksum utility (simple file verification)"
 HOMEPAGE="http://zakalwe.fi/~shd/foss/cksfv/"
 SRC_URI="http://zakalwe.fi/~shd/foss/cksfv/files/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="alpha amd64 hppa ia64 ppc sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE=""


### PR DESCRIPTION
Hi,

This PR updates app-arch/cksfv for EAPI=7 and fixes the LICENSE
Please review.