### PR TITLE
app-arch/atool: EAPI=7, use HTTPS, fix LICENSE

### DIFF
--- a/app-arch/atool/atool-0.39.0-r1.ebuild
+++ b/app-arch/atool/atool-0.39.0-r1.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Script for managing file archives of various types"
+HOMEPAGE="https://www.nongnu.org/atool/"
+SRC_URI="https://savannah.nongnu.org/download/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="dev-lang/perl"
+RDEPEND="${DEPEND}
+	!app-text/adiff"

--- a/app-arch/atool/atool-0.39.0.ebuild
+++ b/app-arch/atool/atool-0.39.0.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
 
 DESCRIPTION="a script for managing file archives of various types"
-HOMEPAGE="http://www.nongnu.org/atool/"
+HOMEPAGE="https://www.nongnu.org/atool/"
 SRC_URI="https://savannah.nongnu.org/download/${PN}/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ppc x86"
 IUSE=""


### PR DESCRIPTION
Hi,

This Bug updates app-arch/atool for EAPI=7, uses https for the HOMEPAGE and fixes the LICENSE.
Please review.