### PR TITLE
app-arch/deb2targz: EAPI7 bump

### DIFF
--- a/app-arch/deb2targz/deb2targz-1-r3.ebuild
+++ b/app-arch/deb2targz/deb2targz-1-r3.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Convert a .deb file to a .tar.gz archive"
+HOMEPAGE="http://www.miketaylor.org.uk/tech/deb/"
+SRC_URI="http://www.miketaylor.org.uk/tech/deb/${PN}"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~amd64-linux ~arm ~hppa ~ia64 ~ppc ~ppc-aix ~ppc-macos ~ppc64 ~sparc ~sparc-solaris ~x86 ~x86-linux ~x86-macos ~x86-solaris"
+
+RDEPEND="dev-lang/perl"
+
+S=${WORKDIR}
+PATCHES=( "${FILESDIR}/${PN}-any-data.patch" )
+
+src_unpack() {
+	cp "${DISTDIR}/${PN}" "${S}" || die
+}
+
+src_install() {
+	dobin ${PN}
+}

--- a/app-arch/deb2targz/files/deb2targz-any-data.patch
+++ b/app-arch/deb2targz/files/deb2targz-any-data.patch
@@ -1,6 +1,6 @@
 Support any/all compression formats for data.tar
---- deb2targz
-+++ deb2targz
+--- a/deb2targz
++++ b/deb2targz
 @@ -47,10 +47,11 @@
  	($header, $data) = ($data =~ /(.*?)\n(.*)/s);
  	my($name, $num1, $num2, $num3, $num4, $len) = split /\s+/, $header;


### PR DESCRIPTION
Hi,

This PR is a simple EAPI bump for app-arch/deb2targz.
Please review.

Closes: https://bugs.gentoo.org/683304
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>