### PR TITLE
games-util/nml: block >=dev-python/pillow-6.0.0

### DIFF
--- a/games-util/nml/nml-0.4.5.ebuild
+++ b/games-util/nml/nml-0.4.5.ebuild
@@ -13,7 +13,7 @@ LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 
-RDEPEND="dev-python/pillow[zlib,${PYTHON_USEDEP}]
+RDEPEND="<dev-python/pillow-6.0.0[zlib,${PYTHON_USEDEP}]
 	dev-python/ply[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]"


### PR DESCRIPTION
The tool nmlc doesn't work with dev-python/pillow in version 6.0.0 and
newer. So adding a blocker, to make games-misc/opengfx compiling again.

Closes: https://bugs.gentoo.org/682436
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>