### PR TITLE
dev-python/pytest-forked: Fix tests

### DIFF
--- a/dev-python/pytest-forked/pytest-forked-0.2.ebuild
+++ b/dev-python/pytest-forked/pytest-forked-0.2.ebuild
@@ -33,5 +33,5 @@ python_prepare_all() {
 
 python_test() {
 	distutils_install_for_testing
-	py.test -v || die "Tests failed under ${EPYTHON}"
+	py.test -v -p no:flaky || die "Tests failed under ${EPYTHON}"
 }


### PR DESCRIPTION
The plugin flaky is not compatible with the pytest-forked plugin.
Thanks to maram@fake-box.com for the workaround

Closes: https://bugs.gentoo.org/653722

Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>