### PR TITLE
app-cdr/cddetect: EAPI=7 bump

### DIFF
--- a/app-cdr/cddetect/cddetect-2.1.ebuild
+++ b/app-cdr/cddetect/cddetect-2.1.ebuild
@@ -1,23 +1,21 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
+
 inherit toolchain-funcs
 
-DESCRIPTION="A tool for detecting the type of a CD/DVD without mounting it"
+DESCRIPTION="Tool for detecting the type of a CD/DVD without mounting it"
 HOMEPAGE="http://www.bellut.net/projects.html"
 SRC_URI="http://www.bellut.net/files/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 S=${WORKDIR}
 
-src_prepare() {
-	sed -i -e '1i#include <limits.h>' ${PN}.c || die #337628
-}
+PATCHES=( "${FILESDIR}"/"${P}"-fix-include.patch ) #337628
 
 src_compile() {
 	emake CC="$(tc-getCC)" CFLAGS="-Wall ${CFLAGS}"

--- a/app-cdr/cddetect/files/cddetect-2.1-fix-include.patch
+++ b/app-cdr/cddetect/files/cddetect-2.1-fix-include.patch
@@ -1,0 +1,9 @@
+diff --git a/cddetect-2.1-org/cddetect.c b/cddetect-2.1-ng/cddetect.c
+index 8b5619f..66ae8a7 100644
+--- a/cddetect.c
++++ b/cddetect.c
+@@ -1,3 +1,4 @@
++#include <limits.h>
+ /* big parts taken from cdfs (C) 1999, 2000, 2001 by Michiel Ronsse
+  * relesed under the GPL v.2
+  * more parts taken from isoinfo/isodump (W) 1993 Eric Youngdale,


### PR DESCRIPTION
Hi, 

This is a very simple EAPI=7 bump for app-cdr/cddectect.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>