### PR TITLE
dev-lang/go: Unpack bootstrap archive for current platform only

### DIFF
--- a/dev-lang/go/go-1.12.4.ebuild
+++ b/dev-lang/go/go-1.12.4.ebuild
@@ -158,7 +158,8 @@ src_unpack()
 	if [[ ${PV} = 9999 ]]; then
 		git-r3_src_unpack
 	fi
-	default
+	unpack "go${MY_PV}.src.tar.gz"
+	unpack "go-$(go_os ${CBUILD})-$(go_arch ${CBUILD})-${BOOTSTRAP_VERSION}.tbz"
 }
 
 src_compile()

--- a/dev-lang/go/go-9999.ebuild
+++ b/dev-lang/go/go-9999.ebuild
@@ -158,7 +158,7 @@ src_unpack()
 	if [[ ${PV} = 9999 ]]; then
 		git-r3_src_unpack
 	fi
-	default
+	unpack "go-$(go_os ${CBUILD})-$(go_arch ${CBUILD})-${BOOTSTRAP_VERSION}.tbz"
 }
 
 src_compile()


### PR DESCRIPTION
Unpack the specific bootstrap archive for current platform rather than
all bootstrap tarballs in SRC_URI.  This provides significant space
savings during build.

Closes: https://bugs.gentoo.org/680860
Signed-off-by: Michał Górny <mgorny@gentoo.org>