### PR TITLE
net-libs/libsoup-2.64.2: add dev-lang/python-3.7

### DIFF
--- a/net-libs/libsoup/libsoup-2.64.2.ebuild
+++ b/net-libs/libsoup/libsoup-2.64.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 GNOME2_LA_PUNT="yes"
-PYTHON_COMPAT=( python{3_5,3_6} )
+PYTHON_COMPAT=( python3_{5,6,7} )
 VALA_USE_DEPEND="vapigen"
 
 inherit gnome2 multilib-minimal python-any-r1 vala


### PR DESCRIPTION
It also supports dev-lang/python:3.7 version