### PR TITLE
media-gfx/{exiv2,openclipart}: use HTTPS

### DIFF
--- a/media-gfx/exiv2/exiv2-0.27.0-r2.ebuild
+++ b/media-gfx/exiv2/exiv2-0.27.0-r2.ebuild
@@ -15,7 +15,7 @@ PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 inherit cmake-multilib python-any-r1
 
 DESCRIPTION="EXIF, IPTC and XMP metadata C++ library and command line utility"
-HOMEPAGE="http://www.exiv2.org/"
+HOMEPAGE="https://www.exiv2.org/"
 
 LICENSE="GPL-2"
 SLOT="0/27"

--- a/media-gfx/openclipart/openclipart-0.20.ebuild
+++ b/media-gfx/openclipart/openclipart-0.20.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="Open Clip Art Library (openclipart.org)"
-HOMEPAGE="http://www.openclipart.org/"
+HOMEPAGE="https://www.openclipart.org/"
 SRC_URI="http://download.openclipart.org/downloads/${PV}/${P}.tar.bz2"
 
 LICENSE="public-domain"


### PR DESCRIPTION
Hi,

A simple http -> https fix for these two packages.
Please review.