### PR TITLE
app-cdr/cdw: EAPI=7 bump

### DIFF
--- a/app-cdr/cdw/cdw-0.8.1-r1.ebuild
+++ b/app-cdr/cdw/cdw-0.8.1-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="An ncurses based console frontend for cdrtools and dvd+rw-tools"
+HOMEPAGE="http://cdw.sourceforge.net"
+SRC_URI="mirror://sourceforge/cdw/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="
+	app-cdr/dvd+rw-tools
+	dev-libs/libburn
+	dev-libs/libcdio:=[-minimal]
+	sys-libs/ncurses:0=[unicode]
+	virtual/cdrtools
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( AUTHORS ChangeLog NEWS README THANKS cdw.conf )
+
+src_configure() {
+	econf LIBS="$( $(tc-getPKG_CONFIG) --libs ncurses )"
+}

--- a/app-cdr/cdw/cdw-0.8.1.ebuild
+++ b/app-cdr/cdw/cdw-0.8.1.ebuild
@@ -8,7 +8,7 @@ DESCRIPTION="An ncurses based console frontend for cdrtools and dvd+rw-tools"
 HOMEPAGE="http://cdw.sourceforge.net"
 SRC_URI="mirror://sourceforge/cdw/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ~ppc x86"
 

--- a/app-cdr/cdw/cdw-9999.ebuild
+++ b/app-cdr/cdw/cdw-9999.ebuild
@@ -1,32 +1,30 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 ECVS_SERVER="cdw.cvs.sourceforge.net:/cvsroot/cdw"
 ECVS_MODULE="cdw"
 ECVS_TOPDIR="${DISTDIR}/cvs-src/${ECVS_MODULE}"
 
 inherit autotools cvs toolchain-funcs
 
-MY_P=${PN}_${PV}
 DESCRIPTION="An ncurses based console frontend for cdrtools and dvd+rw-tools"
 HOMEPAGE="http://cdw.sourceforge.net"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS=""
+DOCS=( AUTHORS ChangeLog NEWS README THANKS cdw.conf )
 
 RDEPEND="
-	virtual/cdrtools
 	app-cdr/dvd+rw-tools
 	dev-libs/libburn
-	dev-libs/libcdio[-minimal]
-	sys-libs/ncurses:*[unicode]
+	dev-libs/libcdio:=[-minimal]
+	sys-libs/ncurses:0=[unicode]
+	virtual/cdrtools
 "
-DEPEND="
-	${RDEPEND}
-	virtual/pkgconfig
-"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
 S=${WORKDIR}/${ECVS_MODULE}
 
 src_prepare() {
@@ -36,9 +34,4 @@ src_prepare() {
 
 src_configure() {
 	econf LIBS="$( $(tc-getPKG_CONFIG) --libs ncurses )"
-}
-
-src_install() {
-	DOCS="AUTHORS ChangeLog NEWS README THANKS cdw.conf" \
-		default
 }

--- a/app-cdr/cdw/metadata.xml
+++ b/app-cdr/cdw/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>arthurzam+gentoo@gmail.com</email>
+		<name>Arthur Zamarin</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="sourceforge">cdw</remote-id>
 	</upstream>


### PR DESCRIPTION
- `EAPI=7` bump
- fix dependency on `dev-libs/libcdio` - need to rebuild on sub-SLOT change.
- updated both live version and regular version (bumped `r0 -> r1`)