### PR TITLE
games-util/nml: add patch for >=dev-python/pillow-6.0.0

### DIFF
--- a/games-util/nml/files/nml-0.4.5-pillow6.patch
+++ b/games-util/nml/files/nml-0.4.5-pillow6.patch
@@ -1,0 +1,31 @@
+From fc7517a66fa6c0424d176a8a1d44659273a04a1d Mon Sep 17 00:00:00 2001
+From: Conrad Kostecki <conrad@kostecki.com>
+Date: Thu, 18 Apr 2019 22:14:49 +0200
+Subject: [PATCH] Add compatibility with >=pillow-6.0.0
+
+Changed VERSION to PILLOW_VERSION,
+as it got removed with >=pillow-6.0.0.
+
+Signed-off-by: Conrad Kostecki <conrad@kostecki.com>
+---
+ nml/version_info.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/nml/version_info.py b/nml/version_info.py
+index d7faec0..32aa3b1 100644
+--- a/nml/version_info.py
++++ b/nml/version_info.py
+@@ -139,11 +139,11 @@ def get_lib_versions():
+     #PIL
+     try:
+         from PIL import Image
+-        versions["PIL"] = Image.VERSION
++        versions["PIL"] = Image.PILLOW_VERSION
+     except ImportError:
+         try:
+             import Image
+-            versions["PIL"] = Image.VERSION
++            versions["PIL"] = Image.PILLOW_VERSION
+         except ImportError:
+             versions["PIL"] = "Not found!"
+ 

--- a/games-util/nml/nml-0.4.5-r1.ebuild
+++ b/games-util/nml/nml-0.4.5-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{5,6,7} )
+inherit distutils-r1
+
+DESCRIPTION="Compiler of NML files into grf/nfo files"
+HOMEPAGE="https://dev.openttdcoop.org/projects/nml"
+SRC_URI="http://bundles.openttdcoop.org/nml/releases/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+
+RDEPEND="dev-python/pillow[zlib,${PYTHON_USEDEP}]
+	dev-python/ply[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]"
+
+DOCS=( docs/{changelog,readme}.txt )
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.4.4-pillow3.patch
+	"${FILESDIR}"/${PN}-0.4.5-pillow6.patch
+)
+
+src_install() {
+	distutils-r1_src_install
+	doman docs/nmlc.1
+}


### PR DESCRIPTION
Patch submitted upstream: https://github.com/OpenTTD/nml/pull/29

Package-Manager: Portage-2.3.63, Repoman-2.3.12
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>