### PR TITLE
mail-filter/opendkim: Improved OpenRC and systemd support

### DIFF
--- a/mail-filter/opendkim/files/opendkim-2.10.3-openrc.patch
+++ b/mail-filter/opendkim/files/opendkim-2.10.3-openrc.patch
@@ -1,0 +1,303 @@
+diff --git a/Makefile.am b/Makefile.am
+index ee2d21ab..b085b988 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -39,6 +39,52 @@ DISTCLEANFILES = opendkim-@VERSION@.tar.gz
+ # though.
+ DISTCHECK_CONFIGURE_FLAGS=--enable-vbr --with-lua --enable-stats --with-odbx --with-db --with-openssl=/usr/local --enable-atps --enable-replace_rules
+ 
++
++#
++# Handle some scripts and configuration files that need @VARIABLE@
++# replacements here, so that we can share the rules (which are
++# identical) between all of the targets.
++#
++
++# We want to *build and install* these on the target machine.
++nodist_doc_DATA = contrib/OpenRC/opendkim.openrc \
++                  contrib/systemd/opendkim.service \
++                  contrib/systemd/opendkim.tmpfiles \
++                  opendkim/opendkim.conf.simple \
++                  opendkim/opendkim.conf.simple-verify
++
++# Custom variable to keep the rule below as sane as possible.
++doc_DATA_intermediate = contrib/OpenRC/opendkim.openrc.in
++
++# We want to *ship* these.
++EXTRA_DIST = contrib/OpenRC/opendkim.openrc.in.in \
++             contrib/systemd/opendkim.service.in \
++             contrib/systemd/opendkim.tmpfiles.in \
++             opendkim/opendkim.conf.simple.in \
++             opendkim/opendkim.conf.simple-verify.in
++
++# The next rule allow us to replace bindir, libdir, etc.  within
++# files. The example is taken from the autoconf documentation and can
++# be found in the "Installation Directory Variables" section.
++edit = sed -e 's|@DOMAIN[@]|$(DOMAIN)|g' \
++           -e 's|@RUNSTATEDIR[@]|$(runstatedir)|g' \
++           -e 's|@SBINDIR[@]|$(sbindir)|g' \
++           -e 's|@SYSCONFDIR[@]|$(sysconfdir)|g'
++
++# This rule includes EVERY source/intermediate file as a dependency of
++# EVERY output file, which is clearly wrong, but it may be the best we
++# can do without duplication. At least it's the right kind of wrong,
++# and rebuilds too often rather than not often enough.
++$(nodist_doc_DATA): $(doc_DATA_intermediate) $(EXTRA_DIST) Makefile
++	rm -f $@ $@.tmp
++	srcdir=''; \
++	  test -f ./$@.in || srcdir=$(srcdir)/; \
++	  $(edit) $${srcdir}$@.in > $@.tmp
++	mv $@.tmp $@
++
++
++
++
+ $(DIST_ARCHIVES): distcheck
+ 
+ $(DIST_ARCHIVES).md5: $(DIST_ARCHIVES)
+diff --git a/configure.ac b/configure.ac
+index 76914fd9..a478bb83 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -65,6 +65,9 @@ AC_PROG_CC_C99
+ AM_PROG_CC_C_O
+ AC_PROG_LIBTOOL
+ 
++# Used by the OpenRC service script, at least.
++AC_PROG_GREP
++
+ PKG_PROG_PKG_CONFIG
+ 
+ #
+@@ -2628,6 +2631,11 @@ AC_SUBST(SPECCONFIGURE)
+ AC_SUBST(SPECREQUIRES)
+ AC_SUBST(SPECBUILDREQUIRES)
+ 
++# Autoconf 2.70 will support this, and many distros patch it in,
++# but Autoconf 2.70 hasn't actually been released yet.
++AS_IF([test -z "${runstatedir}"], [runstatedir='${localstatedir}/run'])
++AC_SUBST([runstatedir])
++
+ #
+ # Finish up
+ #
+@@ -2639,6 +2647,7 @@ AC_OUTPUT([	Makefile
+ 			contrib/docs/Makefile
+ 			contrib/init/Makefile
+ 			contrib/init/generic/Makefile
++			contrib/OpenRC/opendkim.openrc.in
+ 			contrib/init/redhat/Makefile
+ 			contrib/init/redhat/opendkim
+ 			contrib/init/redhat/opendkim-default-keygen
+@@ -2650,8 +2659,6 @@ AC_OUTPUT([	Makefile
+ 			contrib/spec/Makefile
+ 			contrib/spec/opendkim.spec
+ 			contrib/stats/Makefile
+-			contrib/systemd/Makefile
+-			contrib/systemd/opendkim.service
+ 		libopendkim/opendkim.pc libopendkim/Makefile
+ 		libopendkim/docs/Makefile
+ 		libopendkim/tests/Makefile
+@@ -2664,8 +2671,6 @@ AC_OUTPUT([	Makefile
+ 			opendkim/opendkim-lua.3 
+ 			opendkim/opendkim-testkey.8 opendkim/opendkim-stats.8
+ 			opendkim/opendkim-testmsg.8 opendkim/opendkim.conf.5
+-			opendkim/opendkim.conf.simple
+-			opendkim/opendkim.conf.simple-verify
+ 			opendkim/opendkim-atpszone.8 opendkim/opendkim-spam.1
+ 		opendkim/tests/Makefile
+ 		stats/Makefile stats/opendkim-importstats.8
+diff --git a/contrib/Makefile.am b/contrib/Makefile.am
+index 76df01cd..401130bb 100644
+--- a/contrib/Makefile.am
++++ b/contrib/Makefile.am
+@@ -3,6 +3,6 @@
+ 
+ #AUTOMAKE_OPTIONS = foreign
+ 
+-SUBDIRS = convert docs init ldap lua patches repute spec stats systemd
++SUBDIRS = convert docs init ldap lua patches repute spec stats
+ 
+ dist_doc_DATA = README
+diff --git a/contrib/OpenRC/.gitignore b/contrib/OpenRC/.gitignore
+new file mode 100644
+index 00000000..af0aa700
+--- /dev/null
++++ b/contrib/OpenRC/.gitignore
+@@ -0,0 +1,2 @@
++opendkim.openrc
++opendkim.openrc.in
+diff --git a/contrib/OpenRC/opendkim.openrc.in.in b/contrib/OpenRC/opendkim.openrc.in.in
+new file mode 100644
+index 00000000..d9631cdf
+--- /dev/null
++++ b/contrib/OpenRC/opendkim.openrc.in.in
+@@ -0,0 +1,54 @@
++#!/sbin/openrc-run
++# Copyright 1999-2019 Gentoo Authors
++# Distributed under the terms of the GNU General Public License v2
++
++CONFFILE="@SYSCONFDIR@/opendkim/${RC_SVCNAME}.conf"
++required_files="${CONFFILE}"
++
++command="@SBINDIR@/opendkim"
++pidfile="@RUNSTATEDIR@/${RC_SVCNAME}.pid"
++command_args="-P ${pidfile} -x ${CONFFILE}"
++extra_commands="checkconfig"
++
++depend() {
++	use dns logger net
++	before mta
++}
++
++checkconfig() {
++	#
++	# The opendkim.conf man page says,
++	#
++	#   For parameters that are Boolean in nature, only the first byte
++	#   of the value is processed... For negative values, the following
++	#   are accepted: "F", "f", "N", "n", "0".'
++	#
++	if @GREP@ '^[[:space:]]*Background[[:space:]]\+[FfNn0]' "${CONFFILE}" \
++		>/dev/null 2>&1; then
++		eend 1 "${RC_SVCNAME} cannot run in the foreground!"
++	fi
++	if ! "${command}" -n "${command_args}"; then
++		eend 1 "${RC_SVCNAME} configuration check failed"
++	fi
++}
++
++start_pre() {
++	# If this isn't a restart, make sure that the user's config isn't
++	# busted before we try to start the daemon (this will produce
++	# better error messages than if we just try to start it blindly).
++	#
++	# If, on the other hand, this *is* a restart, then the stop_pre
++	# action will have ensured that the config is usable and we don't
++	# need to do that again.
++	if [ "${RC_CMD}" != "restart" ]; then
++		checkconfig || return $?
++	fi
++}
++
++stop_pre() {
++	# If this is a restart, check to make sure the user's config
++	# isn't busted before we stop the running daemon.
++	if [ "${RC_CMD}" = "restart" ]; then
++		checkconfig || return $?
++	fi
++}
+diff --git a/contrib/systemd/Makefile.am b/contrib/systemd/Makefile.am
+deleted file mode 100644
+index 2ffc88cc..00000000
+--- a/contrib/systemd/Makefile.am
++++ /dev/null
+@@ -1,3 +0,0 @@
+-# Copyright (c) 2013, The Trusted Domain Project.  All rights reserved.
+-
+-dist_doc_DATA = opendkim.service
+diff --git a/contrib/systemd/opendkim.service.in b/contrib/systemd/opendkim.service.in
+index f7665f43..236f8a06 100644
+--- a/contrib/systemd/opendkim.service.in
++++ b/contrib/systemd/opendkim.service.in
+@@ -1,20 +1,28 @@
+-# If you are using OpenDKIM with SQL datasets it might be necessary to start OpenDKIM after the database servers.
+-# For example, if using both MariaDB and PostgreSQL, change "After=" in the "[Unit]" section to:
+-# After=network.target nss-lookup.target syslog.target mariadb.service postgresql.service
++# If you are using OpenDKIM with SQL datasets, you should start
++# OpenDKIM after your database server. For example, when using
++# PostgreSQL, you should create a supplementary ".conf" file in the
++# appropriate directory containing,
++#
++# [Unit]
++# After=postgresql.service
++#
+ 
+ [Unit]
+ Description=DomainKeys Identified Mail (DKIM) Milter
+-Documentation=man:opendkim(8) man:opendkim.conf(5) man:opendkim-genkey(8) man:opendkim-genzone(8) man:opendkim-testadsp(8) man:opendkim-testkey http://www.opendkim.org/docs.html
++Documentation=man:opendkim(8) \
++              man:opendkim.conf(5) \
++              man:opendkim-genkey(8) \
++              man:opendkim-genzone(8) \
++              man:opendkim-testkey(8) \
++              http://www.opendkim.org/docs.html
+ After=network.target nss-lookup.target syslog.target
+ 
+ [Service]
+ Type=forking
+-PIDFile=@localstatedir@/run/opendkim/opendkim.pid
+-EnvironmentFile=-@sysconfdir@/sysconfig/opendkim
+-ExecStart=@sbindir@/opendkim $OPTIONS
++ExecStart=@SBINDIR@/opendkim -P @RUNSTATEDIR@/opendkim.pid
++ExecStartPre=@SBINDIR@/opendkim -P @RUNSTATEDIR@/opendkim.pid -n -f
+ ExecReload=/bin/kill -USR1 $MAINPID
+-User=opendkim
+-Group=opendkim
++PIDFile=@RUNSTATEDIR@/opendkim.pid
+ 
+ [Install]
+ WantedBy=multi-user.target
+diff --git a/contrib/systemd/opendkim.tmpfiles.in b/contrib/systemd/opendkim.tmpfiles.in
+new file mode 100644
+index 00000000..a9118974
+--- /dev/null
++++ b/contrib/systemd/opendkim.tmpfiles.in
+@@ -0,0 +1,5 @@
++# We allow everyone to read/traverse this directory because if it
++# contains a local socket, then (for example) your MTA will want to
++# look in there. Permissions on the socket itself are controlled
++# by the "UserID" and "UMask" directives in the daemon's configuration.
++d @RUNSTATEDIR@/opendkim 0755 opendkim opendkim
+diff --git a/opendkim/Makefile.am b/opendkim/Makefile.am
+index 4aa615c1..7d514771 100644
+--- a/opendkim/Makefile.am
++++ b/opendkim/Makefile.am
+@@ -16,9 +16,11 @@ endif
+ sbin_PROGRAMS += opendkim-stats
+ endif
+ 
++
+ dist_sbin_SCRIPTS = opendkim-genkey
+-dist_doc_DATA = opendkim.conf.sample opendkim.conf.simple \
+-	opendkim.conf.simple-verify README.SQL
++
++dist_doc_DATA = opendkim.conf.sample README.SQL
++
+ 
+ if BUILD_FILTER
+ sbin_PROGRAMS += opendkim
+diff --git a/opendkim/opendkim.conf.simple-verify.in b/opendkim/opendkim.conf.simple-verify.in
+index 2224b64f..463048ab 100644
+--- a/opendkim/opendkim.conf.simple-verify.in
++++ b/opendkim/opendkim.conf.simple-verify.in
+@@ -17,5 +17,5 @@ Mode			v
+ 
+ # ADSPDiscard	no
+ 
+-# PidFile		/var/run/opendkim/opendkim.pid
++# PidFile		@RUNSTATEDIR@/opendkim.pid
+ 
+diff --git a/opendkim/opendkim.conf.simple.in b/opendkim/opendkim.conf.simple.in
+index 735b924b..b70bfb46 100644
+--- a/opendkim/opendkim.conf.simple.in
++++ b/opendkim/opendkim.conf.simple.in
+@@ -12,6 +12,12 @@ KeyFile			/var/db/dkim/@DOMAIN@.private
+ 
+ Socket                  inet:8891@localhost
+ 
++# To use a local socket instead, specify a path here. The "standard"
++# location is under @runstatedir@/opendkim, and it's best to agree
++# on that directory so that various init systems can configure its
++# permissions and ownership automatically.
++#Socket                 local:@RUNSTATEDIR@/opendkim/opendkim.sock
++
+ ReportAddress           postmaster@@DOMAIN@
+ SendReports             yes
+ 
+@@ -25,4 +31,4 @@ SendReports             yes
+ #
+ # PeerList		X.X.X.X
+ 
+-# PidFile		/var/run/opendkim/opendkim.pid
++# PidFile		@RUNSTATEDIR@/opendkim.pid

--- a/mail-filter/opendkim/files/opendkim-2.10.3-openssl-1.1.1.patch.r2
+++ b/mail-filter/opendkim/files/opendkim-2.10.3-openssl-1.1.1.patch.r2
@@ -1,0 +1,170 @@
+From FreeBSD: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=223568
+--- a/configure.ac	2015-05-12 18:43:09 UTC
++++ b/configure.ac
+@@ -860,26 +860,28 @@ then
+ 	AC_SEARCH_LIBS([ERR_peek_error], [crypto], ,
+ 	               AC_MSG_ERROR([libcrypto not found]))
+ 
+-	AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+-		[
+-			if test x"$enable_shared" = x"yes"
+-			then
+-				AC_MSG_ERROR([Cannot build shared opendkim
+-				              against static openssl libraries.
+-				              Configure with --disable-shared
+-				              to get this working or obtain a
+-				              shared libssl library for
+-				              opendkim to use.])
+-			fi
+ 
+-			# avoid caching issue - last result of SSL_library_init
+-			# shouldn't be cached for this next check
+-			unset ac_cv_search_SSL_library_init
+-			LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS -ldl"
+-			AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+-			               AC_MSG_ERROR([libssl not found]), [-ldl])
+-		]
+-	)
++	AC_LINK_IFELSE(
++		       [AC_LANG_PROGRAM([[#include <openssl/ssl.h>]],
++					[[SSL_library_init();]])],
++					[od_have_ossl="yes";],
++					[od_have_ossl="no";])
++	if test x"$od_have_ossl" = x"no"
++	then
++		if test x"$enable_shared" = x"yes"
++		then
++			AC_MSG_ERROR([Cannot build shared opendkim
++			              against static openssl libraries.
++			              Configure with --disable-shared
++			              to get this working or obtain a
++			              shared libssl library for
++			              opendkim to use.])
++		fi
++
++		LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS -ldl"
++		AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
++		               AC_MSG_ERROR([libssl not found]), [-ldl])
++	fi
+ 
+ 	AC_CHECK_DECL([SHA256_DIGEST_LENGTH],
+                       AC_DEFINE([HAVE_SHA256], 1,
+--- a/libopendkim/tests/Makefile.in	2015-05-12 18:43:48 UTC
++++ b/libopendkim/tests/Makefile.in
+@@ -1108,8 +1108,10 @@ am__nobase_list = $(am__nobase_strip_setup); \
+       { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
+     END { for (dir in files) print dir, files[dir] }'
+ am__base_list = \
+-  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
+-  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
++  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\
++/ /g' | \
++  sed '$$!N;$$!N;$$!N;$$!N;s/\
++/ /g'
+ am__uninstall_files_from_dir = { \
+   test -z "$$files" \
+     || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
+@@ -4131,16 +4133,19 @@ uninstall-am: uninstall-dist_docDATA
+ @LCOV_TRUE@description.txt: $(check_PROGRAMS) $(check_SCRIPTS)
+ @LCOV_TRUE@	rm -f $@
+ @LCOV_TRUE@	for i in $(check_PROGRAMS); do \
+-@LCOV_TRUE@		testname=$${i/t-}; \
+-@LCOV_TRUE@		testname=$${testname//-/_}; \
++@LCOV_TRUE@		testname=$${i#t-}; \
++@LCOV_TRUE@		testname=$$(echo $${testname} | sed -e 's/-/_/g'); \
+ @LCOV_TRUE@		fgrep '***' $$i.c | tail -n 1 | \
+-@LCOV_TRUE@		(echo $${testname} ; sed -e 's/[^*]*\*\*\*\(.*\)\\n.*/\t\1\n/g' ) >> $@; \
++@LCOV_TRUE@		(echo $${testname} ; sed -e 's/[^*]*\*\*\*\(.*\)\\
++@LCOV_TRUE@.*/	\1\
++@LCOV_TRUE@/g' ) >> $@; \
+ @LCOV_TRUE@	done
+ @LCOV_TRUE@	for i in $(check_SCRIPTS); do \
+-@LCOV_TRUE@		testname=$${i/t-}; \
+-@LCOV_TRUE@		testname=$${testname//-/_}; \
++@LCOV_TRUE@		testname=$${i#t-}; \
++@LCOV_TRUE@		testname=$$(echo $${testname} | sed -e 's/-/_/g'); \
+ @LCOV_TRUE@		grep '^#' $$i | tail -n 1 | \
+-@LCOV_TRUE@		(echo $${testname} ; sed -e 's/^# \(.*\)/\t\1\n/g' ) >> $@; \
++@LCOV_TRUE@		(echo $${testname} ; sed -e 's/^# \(.*\)/	\1\
++@LCOV_TRUE@/g' ) >> $@; \
+ @LCOV_TRUE@	done
+ 
+ @LCOV_TRUE@description.html: description.txt
+--- a/libopendkim/dkim-canon.c	2015-05-11 03:56:13 UTC
++++ b/libopendkim/dkim-canon.c
+@@ -388,7 +388,7 @@ dkim_canon_header_string(struct dkim_dstring *dstr, dk
+ 		}
+ 
+ 		/* skip all spaces before first word */
+-		while (*p != '\0' && DKIM_ISWSP(*p))
++		while (*p != '\0' && DKIM_ISLWSP(*p))
+ 			p++;
+ 
+ 		space = FALSE;				/* just saw a space */
+--- a/opendkim/tests/Makefile.in	2015-05-12 18:43:49 UTC
++++ b/opendkim/tests/Makefile.in
+@@ -139,8 +139,10 @@ am__nobase_list = $(am__nobase_strip_setup); \
+       { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
+     END { for (dir in files) print dir, files[dir] }'
+ am__base_list = \
+-  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
+-  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
++  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\
++/ /g' | \
++  sed '$$!N;$$!N;$$!N;$$!N;s/\
++/ /g'
+ am__uninstall_files_from_dir = { \
+   test -z "$$files" \
+     || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
+@@ -1298,14 +1300,16 @@ uninstall-am: uninstall-dist_docDATA
+ @LCOV_TRUE@description.txt: $(check_SCRIPTS)
+ @LCOV_TRUE@	rm -f $@
+ @LCOV_TRUE@	for test in $? ; do \
+-@LCOV_TRUE@		testname=$${test/t-}; \
+-@LCOV_TRUE@		testname=$${testname//-/_}; \
++@LCOV_TRUE@		testname=$${test#t-}; \
++@LCOV_TRUE@		testname=$$(echo $${testname} | sed -e 's/-/_/g'); \
+ @LCOV_TRUE@		grep ^# $$test | tail -n 1 | \
+-@LCOV_TRUE@			sed -e "s/^#\(.*\)/$${testname}\n\t\1\n/g" >> $@; \
++@LCOV_TRUE@			sed -e "s/^#\(.*\)/$${testname}\
++@LCOV_TRUE@	\1\
++@LCOV_TRUE@/g" >> $@; \
+ @LCOV_TRUE@	done
+ 
+ @LCOV_TRUE@description.html: description.txt
+-@LCOV_TRUE@	gendesc --output $@ $<
++@LCOV_TRUE@	gendesc --output $@ $?
+ 
+ @LCOV_TRUE@maintainer-clean-local:
+ @LCOV_TRUE@	-rm -rf lcov/[^C]*
+--- a/opendkim/opendkim-crypto.c	2013-02-25 21:02:41 UTC
++++ b/opendkim/opendkim-crypto.c
+@@ -222,7 +222,11 @@ dkimf_crypto_free_id(void *ptr)
+ 	{
+ 		assert(pthread_setspecific(id_key, ptr) == 0);
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined (LIBRESSL_VERSION_NUMBER)
++		OPENSSL_thread_stop();
++#else
+ 		ERR_remove_state(0);
++#endif
+ 
+ 		free(ptr);
+ 
+@@ -392,11 +396,15 @@ dkimf_crypto_free(void)
+ {
+ 	if (crypto_init_done)
+ 	{
++#if OPENSSL_VERSION_NUMBER >= 0x10100000  && !defined (LIBRESSL_VERSION_NUMBER)
++		OPENSSL_thread_stop();
++#else
+ 		CRYPTO_cleanup_all_ex_data();
+ 		CONF_modules_free();
+ 		EVP_cleanup();
+ 		ERR_free_strings();
+ 		ERR_remove_state(0);
++#endif
+ 
+ 		if (nmutexes > 0)
+ 		{
+

--- a/mail-filter/opendkim/opendkim-2.10.3-r11.ebuild
+++ b/mail-filter/opendkim/opendkim-2.10.3-r11.ebuild
@@ -40,7 +40,7 @@ REQUIRED_USE="sasl? ( ldap )"
 
 PATCHES=(
 	"${FILESDIR}/${P}-openrc.patch"
-	"${FILESDIR}/${P}-openssl-1.1.1.patch"
+	"${FILESDIR}/${P}-openssl-1.1.1.patch.r2"
 )
 
 pkg_setup() {

--- a/mail-filter/opendkim/opendkim-2.10.3-r11.ebuild
+++ b/mail-filter/opendkim/opendkim-2.10.3-r11.ebuild
@@ -1,0 +1,222 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools db-use eutils systemd tmpfiles user
+
+DESCRIPTION="A milter providing DKIM signing and verification"
+HOMEPAGE="http://opendkim.org/"
+SRC_URI="mirror://sourceforge/opendkim/${P}.tar.gz"
+
+# The GPL-2 is for the init script, bug 425960.
+LICENSE="BSD GPL-2 Sendmail-Open-Source"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="+berkdb ldap libressl lmdb lua memcached opendbx poll sasl selinux +ssl static-libs unbound"
+
+DEPEND="|| ( mail-filter/libmilter mail-mta/sendmail )
+	dev-libs/libbsd
+	sys-apps/grep
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	berkdb? ( >=sys-libs/db-3.2:* )
+	opendbx? ( >=dev-db/opendbx-1.4.0 )
+	lua? ( dev-lang/lua:* )
+	ldap? ( net-nds/openldap )
+	lmdb? ( dev-db/lmdb )
+	memcached? ( dev-libs/libmemcached )
+	sasl? ( dev-libs/cyrus-sasl )
+	unbound? ( >=net-dns/unbound-1.4.1:= net-dns/dnssec-root )
+	!unbound? ( net-libs/ldns )"
+
+RDEPEND="${DEPEND}
+	sys-process/psmisc
+	selinux? ( sec-policy/selinux-dkim )"
+
+REQUIRED_USE="sasl? ( ldap )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-openrc.patch"
+	"${FILESDIR}/${P}-openssl-1.1.1.patch"
+)
+
+pkg_setup() {
+	# This user can read your private keys, and must therefore not be
+	# shared with any other package.
+	enewgroup opendkim
+	enewuser opendkim -1 -1 -1 opendkim
+}
+
+src_prepare() {
+	default
+	sed -i -e 's:/var/db/dkim:/var/lib/opendkim:g' \
+		opendkim/opendkim.conf.sample opendkim/opendkim.conf.simple.in || die
+	sed -i -e 's:dist_doc_DATA:dist_html_DATA:' libopendkim/docs/Makefile.am || die
+	# TODO: what purpose does this serve?
+	sed -i -e "/sock.*mt.getcwd/s:mt.getcwd():${T}:" \
+		opendkim/tests/*.lua || die
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=()
+	if use berkdb ; then
+		myconf+=(
+			$(db_includedir)
+			--with-db-incdir=${myconf#-I}
+			--enable-popauth
+			--enable-query_cache
+			--enable-stats
+		)
+	fi
+	if use unbound; then
+		myconf+=( --with-unbound )
+	else
+		myconf+=( --with-ldns )
+	fi
+	if use ldap; then
+		myconf+=( $(use_with sasl) )
+	fi
+	econf \
+		$(use_with berkdb db) \
+		$(use_with opendbx odbx) \
+		$(use_with lua) \
+		$(use_enable lua rbl) \
+		$(use_with ldap openldap) \
+		$(use_with lmdb) \
+		$(use_enable poll) \
+		$(use_enable static-libs static) \
+		$(use_with memcached libmemcached) \
+		"${myconf[@]}" \
+		--enable-filter \
+		--enable-atps \
+		--enable-identity_header \
+		--enable-rate_limit \
+		--enable-resign \
+		--enable-replace_rules \
+		--enable-default_sender \
+		--enable-sender_macro \
+		--enable-vbr \
+		--disable-live-testing
+}
+
+src_compile() {
+	emake runstatedir=/run
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -type f -delete || die
+
+	dosbin stats/opendkim-reportstats
+
+	newinitd "${S}/contrib/OpenRC/opendkim.openrc" "${PN}"
+	systemd_newtmpfilesd "${S}/contrib/systemd/opendkim.tmpfiles" "${PN}.conf"
+	systemd_newunit "contrib/systemd/opendkim.service" "${PN}.service"
+
+	dodir /etc/opendkim
+	keepdir /var/lib/opendkim
+
+	# The OpenDKIM data (particularly, your keys) should be read-only to
+	# the UserID that the daemon runs as.
+	fowners root:opendkim /var/lib/opendkim
+	fperms 750 /var/lib/opendkim
+
+	# Tweak the "simple" example configuration a bit before installing
+	# it unconditionally.
+	local cf="${T}/opendkim.conf"
+	# Some MTAs are known to break DKIM signatures with "simple"
+	# canonicalization [1], so we choose the "relaxed" policy
+	# over OpenDKIM's current default settings.
+	# [1] https://wordtothewise.com/2016/12/dkim-canonicalization-or-why-microsoft-breaks-your-mail/
+	sed -E -e 's:^(Canonicalization)[[:space:]]+.*:\1\trelaxed/relaxed:' \
+		"${S}/opendkim/opendkim.conf.simple" >"${cf}" || die
+	cat >>"${cf}" <<EOT || die
+
+# The UMask is really only used for the PID file (root:root) and the
+# local UNIX socket, if you're using one. It should be 0117 for the
+# socket.
+UMask			0117
+UserID			opendkim
+
+# For use with unbound
+#TrustAnchorFile	/etc/dnssec/root-anchors.txt
+EOT
+	insinto /etc/opendkim
+	doins "${cf}"
+}
+
+pkg_postinst() {
+	tmpfiles_process "${PN}.conf"
+	if [[ -z ${REPLACING_VERSION} ]]; then
+		elog "If you want to sign your mail messages and need some help"
+		elog "please run:"
+		elog "	emerge --config ${CATEGORY}/${PN}"
+		elog "It will help you create your key and give you hints on how"
+		elog "to configure your DNS and MTA."
+
+		elog "If you are using a local (UNIX) socket, then you will"
+		elog "need to make sure that your MTA has read/write access"
+		elog "to the socket file. This is best accomplished by creating"
+		elog "a completely-new group with only your MTA user and the"
+		elog "\"opendkim\" user in it. Step-by-step instructions can be"
+		elog "found on our Wiki, at https://wiki.gentoo.org/wiki/OpenDKIM ."
+	else
+		ewarn "The user account for the OpenDKIM daemon has changed"
+		ewarn "from \"milter\" to \"opendkim\" to prevent unrelated services"
+		ewarn "from being able to read your private keys. You should"
+		ewarn "adjust your existing configuration to use the \"opendkim\""
+		ewarn "user and group, and change the permissions on"
+		ewarn "${ROOT}var/lib/opendkim to root:opendkim with mode 0750."
+		ewarn "The owner and group of the files within that directory"
+		ewarn "will likely need to be adjusted as well."
+	fi
+}
+
+pkg_config() {
+	local selector keysize pubkey
+
+	read -p "Enter the selector name (default ${HOSTNAME}): " selector
+	[[ -n "${selector}" ]] || selector="${HOSTNAME}"
+	if [[ -z "${selector}" ]]; then
+		eerror "Oddly enough, you don't have a HOSTNAME."
+		return 1
+	fi
+	if [[ -f "${ROOT}var/lib/opendkim/${selector}.private" ]]; then
+		ewarn "The private key for this selector already exists."
+	else
+		keysize=1024
+		# Generate the private and public keys. Note that opendkim-genkeys
+		# sets umask=077 on its own to keep these safe. However, we want
+		# them to be readable (only!) to the opendkim user, and we manage
+		# that by changing their groups and making everything group-readable.
+		opendkim-genkey -b ${keysize} -D "${ROOT}"var/lib/opendkim/ \
+			-s "${selector}" -d '(your domain)' && \
+			chgrp --no-dereference opendkim \
+				"${ROOT}var/lib/opendkim/${selector}".{private,txt} || \
+				{ eerror "Failed to create private and public keys."; return 1; }
+		chmod g+r "${ROOT}var/lib/opendkim/${selector}".{private,txt}
+	fi
+
+	# opendkim selector configuration
+	echo
+	einfo "Make sure you have the following settings in your /etc/opendkim/opendkim.conf:"
+	einfo "  Keyfile /var/lib/opendkim/${selector}.private"
+	einfo "  Selector ${selector}"
+
+	# MTA configuration
+	echo
+	einfo "If you are using Postfix, add following lines to your main.cf:"
+	einfo "  smtpd_milters	   = unix:/run/opendkim/opendkim.sock"
+	einfo "  non_smtpd_milters = unix:/run/opendkim/opendkim.sock"
+	einfo "  and read http://www.postfix.org/MILTER_README.html"
+
+	# DNS configuration
+	einfo "After you configured your MTA, publish your key by adding this TXT record to your domain:"
+	cat "${ROOT}var/lib/opendkim/${selector}.txt"
+	einfo "t=y signifies you only test the DKIM on your domain. See following page for the complete list of tags:"
+	einfo "  http://www.dkim.org/specs/rfc4871-dkimbase.html#key-text"
+}


### PR DESCRIPTION
Michael Orlitzky and I have been working on improved OpenRC support for OpenDKIM. Our pull request has not yet been accepted upstream (not even acknowledged, in fact). The multi-file patch adds our changes to the existing Gentoo ebuild. Changes to the upstream build files include:

* `configure.ac` Added workaround to support @runstatedir@. On modern systems /run replaces /var/run, so using @runstatedir@ instead of @localstatedir@/run is preferable. Autoconf 2.70 will support @runstatedir@ , but it has not been released yet, so a workaround is required for version 2.61.

* `contrib/systemd` Use @runstatedir@ in opendkim.service.in, enable full @VARIABLE@ substitution, fix inconsistencies in the systemd service file, add tmpfiles.d configuration file.

* `opendkim/opendkim.conf.*.in` Use @runstatedir@ in PidFile paths, enable full @VARIABLE@ substitution.
