### PR TITLE
dev-libs/liblognorm: use HTTPS

### DIFF
--- a/dev-libs/liblognorm/liblognorm-2.0.5.ebuild
+++ b/dev-libs/liblognorm/liblognorm-2.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -6,14 +6,14 @@ EAPI="6"
 inherit autotools
 
 DESCRIPTION="Fast samples-based log normalization library"
-HOMEPAGE="http://www.liblognorm.com"
+HOMEPAGE="https://www.liblognorm.com"
 
 if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="https://github.com/rsyslog/${PN}.git"
 
 	inherit git-r3
 else
-	SRC_URI="http://www.liblognorm.com/files/download/${P}.tar.gz"
+	SRC_URI="https://www.liblognorm.com/files/download/${P}.tar.gz"
 	KEYWORDS="amd64 arm ~arm64 hppa x86 ~amd64-linux"
 fi
 

--- a/dev-libs/liblognorm/liblognorm-2.0.6.ebuild
+++ b/dev-libs/liblognorm/liblognorm-2.0.6.ebuild
@@ -6,14 +6,14 @@ EAPI="6"
 inherit autotools
 
 DESCRIPTION="Fast samples-based log normalization library"
-HOMEPAGE="http://www.liblognorm.com"
+HOMEPAGE="https://www.liblognorm.com"
 
 if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="https://github.com/rsyslog/${PN}.git"
 
 	inherit git-r3
 else
-	SRC_URI="http://www.liblognorm.com/files/download/${P}.tar.gz"
+	SRC_URI="https://www.liblognorm.com/files/download/${P}.tar.gz"
 	KEYWORDS="amd64 arm ~arm64 hppa x86 ~amd64-linux"
 fi
 


### PR DESCRIPTION
Simple http -> https fix.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>