### PR TITLE
mail-filter/opendkim: fix compilation with dev-libs/libressl

### DIFF
--- a/mail-filter/opendkim/files/opendkim-2.10.3-openssl-1.1.1-2.patch
+++ b/mail-filter/opendkim/files/opendkim-2.10.3-openssl-1.1.1-2.patch
@@ -1,0 +1,170 @@
+From FreeBSD: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=223568
+--- a/configure.ac	2015-05-12 18:43:09 UTC
++++ b/configure.ac
+@@ -860,26 +860,28 @@ then
+ 	AC_SEARCH_LIBS([ERR_peek_error], [crypto], ,
+ 	               AC_MSG_ERROR([libcrypto not found]))
+ 
+-	AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+-		[
+-			if test x"$enable_shared" = x"yes"
+-			then
+-				AC_MSG_ERROR([Cannot build shared opendkim
+-				              against static openssl libraries.
+-				              Configure with --disable-shared
+-				              to get this working or obtain a
+-				              shared libssl library for
+-				              opendkim to use.])
+-			fi
+ 
+-			# avoid caching issue - last result of SSL_library_init
+-			# shouldn't be cached for this next check
+-			unset ac_cv_search_SSL_library_init
+-			LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS -ldl"
+-			AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+-			               AC_MSG_ERROR([libssl not found]), [-ldl])
+-		]
+-	)
++	AC_LINK_IFELSE(
++		       [AC_LANG_PROGRAM([[#include <openssl/ssl.h>]],
++					[[SSL_library_init();]])],
++					[od_have_ossl="yes";],
++					[od_have_ossl="no";])
++	if test x"$od_have_ossl" = x"no"
++	then
++		if test x"$enable_shared" = x"yes"
++		then
++			AC_MSG_ERROR([Cannot build shared opendkim
++			              against static openssl libraries.
++			              Configure with --disable-shared
++			              to get this working or obtain a
++			              shared libssl library for
++			              opendkim to use.])
++		fi
++
++		LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS -ldl"
++		AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
++		               AC_MSG_ERROR([libssl not found]), [-ldl])
++	fi
+ 
+ 	AC_CHECK_DECL([SHA256_DIGEST_LENGTH],
+                       AC_DEFINE([HAVE_SHA256], 1,
+--- a/libopendkim/tests/Makefile.in	2015-05-12 18:43:48 UTC
++++ b/libopendkim/tests/Makefile.in
+@@ -1108,8 +1108,10 @@ am__nobase_list = $(am__nobase_strip_setup); \
+       { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
+     END { for (dir in files) print dir, files[dir] }'
+ am__base_list = \
+-  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
+-  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
++  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\
++/ /g' | \
++  sed '$$!N;$$!N;$$!N;$$!N;s/\
++/ /g'
+ am__uninstall_files_from_dir = { \
+   test -z "$$files" \
+     || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
+@@ -4131,16 +4133,19 @@ uninstall-am: uninstall-dist_docDATA
+ @LCOV_TRUE@description.txt: $(check_PROGRAMS) $(check_SCRIPTS)
+ @LCOV_TRUE@	rm -f $@
+ @LCOV_TRUE@	for i in $(check_PROGRAMS); do \
+-@LCOV_TRUE@		testname=$${i/t-}; \
+-@LCOV_TRUE@		testname=$${testname//-/_}; \
++@LCOV_TRUE@		testname=$${i#t-}; \
++@LCOV_TRUE@		testname=$$(echo $${testname} | sed -e 's/-/_/g'); \
+ @LCOV_TRUE@		fgrep '***' $$i.c | tail -n 1 | \
+-@LCOV_TRUE@		(echo $${testname} ; sed -e 's/[^*]*\*\*\*\(.*\)\\n.*/\t\1\n/g' ) >> $@; \
++@LCOV_TRUE@		(echo $${testname} ; sed -e 's/[^*]*\*\*\*\(.*\)\\
++@LCOV_TRUE@.*/	\1\
++@LCOV_TRUE@/g' ) >> $@; \
+ @LCOV_TRUE@	done
+ @LCOV_TRUE@	for i in $(check_SCRIPTS); do \
+-@LCOV_TRUE@		testname=$${i/t-}; \
+-@LCOV_TRUE@		testname=$${testname//-/_}; \
++@LCOV_TRUE@		testname=$${i#t-}; \
++@LCOV_TRUE@		testname=$$(echo $${testname} | sed -e 's/-/_/g'); \
+ @LCOV_TRUE@		grep '^#' $$i | tail -n 1 | \
+-@LCOV_TRUE@		(echo $${testname} ; sed -e 's/^# \(.*\)/\t\1\n/g' ) >> $@; \
++@LCOV_TRUE@		(echo $${testname} ; sed -e 's/^# \(.*\)/	\1\
++@LCOV_TRUE@/g' ) >> $@; \
+ @LCOV_TRUE@	done
+ 
+ @LCOV_TRUE@description.html: description.txt
+--- a/libopendkim/dkim-canon.c	2015-05-11 03:56:13 UTC
++++ b/libopendkim/dkim-canon.c
+@@ -388,7 +388,7 @@ dkim_canon_header_string(struct dkim_dstring *dstr, dk
+ 		}
+ 
+ 		/* skip all spaces before first word */
+-		while (*p != '\0' && DKIM_ISWSP(*p))
++		while (*p != '\0' && DKIM_ISLWSP(*p))
+ 			p++;
+ 
+ 		space = FALSE;				/* just saw a space */
+--- a/opendkim/tests/Makefile.in	2015-05-12 18:43:49 UTC
++++ b/opendkim/tests/Makefile.in
+@@ -139,8 +139,10 @@ am__nobase_list = $(am__nobase_strip_setup); \
+       { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
+     END { for (dir in files) print dir, files[dir] }'
+ am__base_list = \
+-  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
+-  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
++  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\
++/ /g' | \
++  sed '$$!N;$$!N;$$!N;$$!N;s/\
++/ /g'
+ am__uninstall_files_from_dir = { \
+   test -z "$$files" \
+     || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
+@@ -1298,14 +1300,16 @@ uninstall-am: uninstall-dist_docDATA
+ @LCOV_TRUE@description.txt: $(check_SCRIPTS)
+ @LCOV_TRUE@	rm -f $@
+ @LCOV_TRUE@	for test in $? ; do \
+-@LCOV_TRUE@		testname=$${test/t-}; \
+-@LCOV_TRUE@		testname=$${testname//-/_}; \
++@LCOV_TRUE@		testname=$${test#t-}; \
++@LCOV_TRUE@		testname=$$(echo $${testname} | sed -e 's/-/_/g'); \
+ @LCOV_TRUE@		grep ^# $$test | tail -n 1 | \
+-@LCOV_TRUE@			sed -e "s/^#\(.*\)/$${testname}\n\t\1\n/g" >> $@; \
++@LCOV_TRUE@			sed -e "s/^#\(.*\)/$${testname}\
++@LCOV_TRUE@	\1\
++@LCOV_TRUE@/g" >> $@; \
+ @LCOV_TRUE@	done
+ 
+ @LCOV_TRUE@description.html: description.txt
+-@LCOV_TRUE@	gendesc --output $@ $<
++@LCOV_TRUE@	gendesc --output $@ $?
+ 
+ @LCOV_TRUE@maintainer-clean-local:
+ @LCOV_TRUE@	-rm -rf lcov/[^C]*
+--- a/opendkim/opendkim-crypto.c	2013-02-25 21:02:41 UTC
++++ b/opendkim/opendkim-crypto.c
+@@ -222,7 +222,11 @@ dkimf_crypto_free_id(void *ptr)
+ 	{
+ 		assert(pthread_setspecific(id_key, ptr) == 0);
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined (LIBRESSL_VERSION_NUMBER)
++		OPENSSL_thread_stop();
++#else
+ 		ERR_remove_state(0);
++#endif
+ 
+ 		free(ptr);
+ 
+@@ -392,11 +396,15 @@ dkimf_crypto_free(void)
+ {
+ 	if (crypto_init_done)
+ 	{
++#if OPENSSL_VERSION_NUMBER >= 0x10100000  && !defined (LIBRESSL_VERSION_NUMBER)
++		OPENSSL_thread_stop();
++#else
+ 		CRYPTO_cleanup_all_ex_data();
+ 		CONF_modules_free();
+ 		EVP_cleanup();
+ 		ERR_free_strings();
+ 		ERR_remove_state(0);
++#endif
+ 
+ 		if (nmutexes > 0)
+ 		{
+

--- a/mail-filter/opendkim/opendkim-2.10.3-r11.ebuild
+++ b/mail-filter/opendkim/opendkim-2.10.3-r11.ebuild
@@ -1,0 +1,227 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools db-use eutils systemd user
+
+DESCRIPTION="A milter providing DKIM signing and verification"
+HOMEPAGE="http://opendkim.org/"
+SRC_URI="mirror://sourceforge/opendkim/${P}.tar.gz"
+
+# The GPL-2 is for the init script, bug 425960.
+LICENSE="BSD GPL-2 Sendmail-Open-Source"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="+berkdb ldap libressl lmdb lua memcached opendbx poll sasl selinux +ssl static-libs unbound"
+
+DEPEND="|| ( mail-filter/libmilter mail-mta/sendmail )
+	dev-libs/libbsd
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	berkdb? ( >=sys-libs/db-3.2:* )
+	opendbx? ( >=dev-db/opendbx-1.4.0 )
+	lua? ( dev-lang/lua:* )
+	ldap? ( net-nds/openldap )
+	lmdb? ( dev-db/lmdb )
+	memcached? ( dev-libs/libmemcached )
+	sasl? ( dev-libs/cyrus-sasl )
+	unbound? ( >=net-dns/unbound-1.4.1:= net-dns/dnssec-root )
+	!unbound? ( net-libs/ldns )"
+
+RDEPEND="${DEPEND}
+	sys-process/psmisc
+	selinux? ( sec-policy/selinux-dkim )
+"
+
+REQUIRED_USE="sasl? ( ldap )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-openssl-1.1.1-2.patch"
+)
+
+pkg_setup() {
+	# This user can read your private keys, and must therefore not be
+	# shared with any other package.
+	enewgroup opendkim
+	enewuser opendkim -1 -1 -1 opendkim
+}
+
+src_prepare() {
+	default
+
+	# We delete the "Socket" setting because it's overridden by our
+	# conf.d file.
+	sed -e 's:/var/db/dkim:/var/lib/opendkim:g' \
+		-e '/^[[:space:]]*Socket/d' \
+		-i opendkim/opendkim.conf.sample opendkim/opendkim.conf.simple.in \
+		stats/opendkim-reportstats{,.in} || die
+
+	sed -i -e 's:dist_doc_DATA:dist_html_DATA:' libopendkim/docs/Makefile.am \
+		|| die
+
+	# TODO: what purpose does this serve, do the tests even get run?
+	sed -e "/sock.*mt.getcwd/s:mt.getcwd():${T}:" \
+		-i opendkim/tests/*.lua || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=()
+	if use berkdb ; then
+		myconf+=(
+			$(db_includedir)
+			--with-db-incdir=${myconf#-I}
+			--enable-popauth
+			--enable-query_cache
+			--enable-stats
+		)
+	fi
+	if use unbound; then
+		myconf+=( --with-unbound )
+	else
+		myconf+=( --with-ldns )
+	fi
+	if use ldap; then
+		myconf+=( $(use_with sasl) )
+	fi
+	econf \
+		$(use_with berkdb db) \
+		$(use_with opendbx odbx) \
+		$(use_with lua) \
+		$(use_enable lua rbl) \
+		$(use_with ldap openldap) \
+		$(use_with lmdb) \
+		$(use_enable poll) \
+		$(use_enable static-libs static) \
+		$(use_with memcached libmemcached) \
+		"${myconf[@]}" \
+		--enable-filter \
+		--enable-atps \
+		--enable-identity_header \
+		--enable-rate_limit \
+		--enable-resign \
+		--enable-replace_rules \
+		--enable-default_sender \
+		--enable-sender_macro \
+		--enable-vbr \
+		--disable-live-testing
+}
+
+src_install() {
+	default
+	prune_libtool_files
+
+	dosbin stats/opendkim-reportstats
+
+	newinitd "${FILESDIR}/opendkim.init.r6" opendkim
+	newconfd "${FILESDIR}/opendkim.confd" opendkim
+	systemd_newunit "${FILESDIR}/opendkim.service.r4" opendkim.service
+	systemd_install_serviced "${FILESDIR}/${PN}.service.conf" "${PN}.service"
+
+	dodir /etc/opendkim
+	keepdir /var/lib/opendkim
+
+	# The OpenDKIM data (particularly, your keys) should be read-only to
+	# the UserID that the daemon runs as.
+	fowners root:opendkim /var/lib/opendkim
+	fperms 750 /var/lib/opendkim
+
+	# Strip the comments out of the "simple" example configuration...
+	grep ^[^#] "${S}"/opendkim/opendkim.conf.simple \
+		 > "${T}/opendkim.conf" || die
+
+	# and tweak it a bit before installing it unconditionally.
+	echo "# For use with unbound" >> "${T}/opendkim.conf" || die
+	echo "#TrustAnchorFile /etc/dnssec/root-anchors.txt" \
+		 >> "${T}/opendkim.conf" || die
+	echo "UserID opendkim" >> "${T}/opendkim.conf" || die
+
+	# The UMask is really only used for the PID file (root:root) and the
+	# local UNIX socket, if you're using one. It should be 0117 for the
+	# socket, so we might as well set that unconditionally here.
+	echo "UMask 0117" >> "${T}/opendkim.conf" || die
+
+	insinto /etc/opendkim
+	doins "${T}/opendkim.conf"
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSION} ]]; then
+		elog "If you want to sign your mail messages and need some help"
+		elog "please run:"
+		elog "  emerge --config ${CATEGORY}/${PN}"
+		elog "It will help you create your key and give you hints on how"
+		elog "to configure your DNS and MTA."
+
+		# TODO: This is tricky, we really need a good wiki page showing
+		# how to share a local socket with an MTA!
+		elog "If you are using a local (UNIX) socket, then you will"
+		elog "need to make sure that your MTA has read/write access"
+		elog "to the socket file. This is best accomplished by creating"
+		elog "a completely-new group with only your MTA user and the "
+		elog "\"opendkim\" user in it. You would then set \"UMask 0112\""
+		elog "in your opendkim.conf, and switch the primary group of your"
+		elog "\"opendkim\" user to the group that you just created. The"
+		elog "last step is necessary for the socket to be created as the"
+		elog "new group (and not as group \"opendkim\")".
+	else
+		ewarn "The user account for the OpenDKIM daemon has changed"
+		ewarn "from \"milter\" to \"opendkim\" to prevent unrelated services"
+		ewarn "from being able to read your private keys. You should"
+		ewarn "adjust your existing configuration to use the \"opendkim\""
+		ewarn "user and group, and change the permissions on"
+		ewarn "${ROOT}var/lib/opendkim to root:opendkim with mode 0750."
+		ewarn "The owner and group of the files within that directory"
+		ewarn "will likely need to be adjusted as well."
+	fi
+}
+
+pkg_config() {
+	local selector keysize pubkey
+
+	read -p "Enter the selector name (default ${HOSTNAME}): " selector
+	[[ -n "${selector}" ]] || selector="${HOSTNAME}"
+	if [[ -z "${selector}" ]]; then
+		eerror "Oddly enough, you don't have a HOSTNAME."
+		return 1
+	fi
+	if [[ -f "${ROOT}var/lib/opendkim/${selector}.private" ]]; then
+		ewarn "The private key for this selector already exists."
+	else
+		keysize=1024
+		# Generate the private and public keys. Note that opendkim-genkeys
+		# sets umask=077 on its own to keep these safe. However, we want
+		# them to be readable (only!) to the opendkim user, and we manage
+		# that by changing their groups and making everything group-readable.
+		opendkim-genkey -b ${keysize} -D "${ROOT}"var/lib/opendkim/ \
+			-s "${selector}" -d '(your domain)' && \
+			chgrp --no-dereference opendkim \
+				  "${ROOT}var/lib/opendkim/${selector}".{private,txt} || \
+				{ eerror "Failed to create private and public keys." ;
+				  return 1; }
+		chmod g+r "${ROOT}var/lib/opendkim/${selector}".{private,txt}
+	fi
+
+	# opendkim selector configuration
+	echo
+	einfo "Make sure you have the following settings in your /etc/opendkim/opendkim.conf:"
+	einfo "  Keyfile /var/lib/opendkim/${selector}.private"
+	einfo "  Selector ${selector}"
+
+	# MTA configuration
+	echo
+	einfo "If you are using Postfix, add following lines to your main.cf:"
+	einfo "  smtpd_milters     = unix:/run/opendkim/opendkim.sock"
+	einfo "  non_smtpd_milters = unix:/run/opendkim/opendkim.sock"
+	einfo "  and read http://www.postfix.org/MILTER_README.html"
+
+	# DNS configuration
+	einfo "After you configured your MTA, publish your key by adding this TXT record to your domain:"
+	cat "${ROOT}var/lib/opendkim/${selector}.txt"
+	einfo "t=y signifies you only test the DKIM on your domain. See following page for the complete list of tags:"
+	einfo "  http://www.dkim.org/specs/rfc4871-dkimbase.html#key-text"
+}


### PR DESCRIPTION
dev-libs/libressl lacks support for OPENSSL_thread_stop which was used
by the patch adding support for dev-libs/openssl-1.1.1

In order to address this problem we modify the patch to default to the
old deinitialization code when dev-libs/libressl is used.

Closes: https://bugs.gentoo.org/669612
Bug: https://bugs.gentoo.org/669612
Signed-off-by: Francisco Blas Izquierdo Riera (klondike) <klondike@gentoo.org>
Package-Manager: Portage-2.3.51, Repoman-2.3.11