### PR TITLE
games-emulation/atari800: update HOMEPAGE, SRC_URI, metadata

### DIFF
--- a/games-emulation/atari800/atari800-3.1.0-r1.ebuild
+++ b/games-emulation/atari800/atari800-3.1.0-r1.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit desktop autotools
 
 DESCRIPTION="Atari 800 emulator"
-HOMEPAGE="http://atari800.sourceforge.net/"
-SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz
-	mirror://sourceforge/${PN}/xf25.zip"
+HOMEPAGE="https://atari800.github.io/"
+SRC_URI="https://sourceforge.net/projects/${PN}/files/${PN}/${PV}/${P}.tar.gz
+	https://sourceforge.net/projects/${PN}/files/ROM/Original%20XL%20ROM/xf25.zip"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/games-emulation/atari800/metadata.xml
+++ b/games-emulation/atari800/metadata.xml
@@ -25,5 +25,6 @@ ways :
 </longdescription>
   <upstream>
     <remote-id type="sourceforge">atari800</remote-id>
+    <remote-id type="github">atari800/atari800</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/683648
Signed-off-by: Wim Muskee <wimmuskee@gmail.com>