### PR TITLE
sys-apps/openrc: Add USE=init to replace sysvinit

### DIFF
--- a/sys-apps/openrc/metadata.xml
+++ b/sys-apps/openrc/metadata.xml
@@ -11,6 +11,7 @@
 		</flag>
 		<flag name="netifrc">enable Gentoo's network stack (net.* scripts)</flag>
 		<flag name="newnet">enable the new network stack (experimental)</flag>
+		<flag name="init">install as a replacement of <pkg>sys-apps/sysvinit</pkg></flag>
 	</use>
 	<upstream>
 		<remote-id type="github">openrc/openrc</remote-id>

--- a/sys-apps/openrc/openrc-9999.ebuild
+++ b/sys-apps/openrc/openrc-9999.ebuild
@@ -18,8 +18,8 @@ fi
 
 LICENSE="BSD-2"
 SLOT="0"
-IUSE="audit bash debug ncurses pam newnet prefix +netifrc selinux static-libs
-	unicode kernel_linux kernel_FreeBSD"
+IUSE="audit bash debug init ncurses pam newnet prefix +netifrc selinux
+	static-libs unicode kernel_linux kernel_FreeBSD"
 
 COMMON_DEPEND="kernel_FreeBSD? ( || ( >=sys-freebsd/freebsd-ubin-9.0_rc sys-process/fuser-bsd ) )
 	ncurses? ( sys-libs/ncurses:0= )
@@ -45,7 +45,8 @@ DEPEND="${COMMON_DEPEND}
 RDEPEND="${COMMON_DEPEND}
 	!prefix? (
 		kernel_linux? (
-			>=sys-apps/sysvinit-2.86-r6[selinux?]
+			!init? ( >=sys-apps/sysvinit-2.86-r6[selinux?] )
+			init? ( !sys-apps/sysvinit )
 			virtual/tmpfiles
 		)
 		kernel_FreeBSD? ( sys-freebsd/freebsd-sbin )
@@ -77,6 +78,7 @@ src_compile() {
 		MKBASHCOMP=yes
 		MKNET=$(usex newnet)
 		MKSELINUX=$(usex selinux)
+		MKSYSVINIT=$(usex init)
 		MKAUDIT=$(usex audit)
 		MKPAM=$(usev pam)
 		MKSTATICLIBS=$(usex static-libs)


### PR DESCRIPTION
I didn’t change the other versions but `MKSYSVINIT` option has been there for quite a while (I have it on my systems with the current `amd64`)

Closes: https://bugs.gentoo.org/show_bug.cgi?id=599468

Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>