### PR TITLE
sci-libs/opencascade: fix flag description

### DIFF
--- a/sci-libs/opencascade/metadata.xml
+++ b/sci-libs/opencascade/metadata.xml
@@ -14,6 +14,6 @@
 	<flag name="gl2ps">Use gl2ps PostScript printing library</flag>
 	<flag name="gles2">Use OpenGL ES 2.0</flag>
 	<flag name="tbb">Enable multithreading with the Intel Threads Building Block dev-cpp/tbb</flag>
-	<flag name="vtk">Enable Virtualisation Toolkit</flag>
+	<flag name="vtk">Enable Visualization Toolkit</flag>
 </use>
 </pkgmetadata>


### PR DESCRIPTION
USE flag description for vtk has been wrong in metadata.xml.
Thanks to Dirk Gouders for pointing it out.

Reported-by: Dirk Gouders <dirk@gouders.net>
Closes: https://bugs.gentoo.org/683138
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Bernd Waibel <waebbl@gmail.com>