### PR TITLE
www-misc/wsmake: fix HOMEPAGE, SRC_URI, LICENSE, EAPI=7, add amd64 and fix calling g++ directly

### DIFF
--- a/www-misc/wsmake/wsmake-0.6.4-r1.ebuild
+++ b/www-misc/wsmake/wsmake-0.6.4-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Website pre-processor features tag substitution and page ordering"
+HOMEPAGE="https://sourceforge.net/projects/wsmake/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2+ Artistic"
+SLOT="0"
+KEYWORDS="~x86 ~amd64"
+IUSE="examples"
+
+PATCHES=( "${FILESDIR}"/${P}-bv.diff
+	"${FILESDIR}"/${P}-gcc43.patch	# 251745
+	"${FILESDIR}"/${P}-fix-const-va_list.patch
+	)
+
+src_prepare() {
+	tc-export CXX
+	default
+}
+
+src_unpack() {
+	default
+
+	cd "${S}"/doc || die
+	tar -cf examples.tar examples || die
+}
+
+src_install() {
+	default
+	dodoc doc/manual.txt
+
+	if use examples; then
+		rm -r doc/examples/CVS || die
+		dodoc -r doc/examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+}

--- a/www-misc/wsmake/wsmake-0.6.4.ebuild
+++ b/www-misc/wsmake/wsmake-0.6.4.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-DESCRIPTION="Website Pre-processor"
-HOMEPAGE="http://www.wsmake.org/"
-SRC_URI="http://ftp.wsmake.org/pub/wsmake6/stable/${P}.tar.bz2"
+DESCRIPTION="Website pre-processor features tag substitution and page ordering"
+HOMEPAGE="https://sourceforge.net/projects/wsmake/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
-LICENSE="GPL-2 Artistic"
+LICENSE="GPL-2+ Artistic"
 SLOT="0"
 KEYWORDS="x86"
 IUSE="examples"


### PR DESCRIPTION
Hi,

This PR fixes a few problem with the www-misc/wsmake ebuild and also add amd64 arch as it builds and runs fine there too.
Please review.