### PR TITLE
net-misc/stunnel: update LibreSSL patch for 5.51

### DIFF
--- a/net-misc/stunnel/files/stunnel-5.51-libressl.patch
+++ b/net-misc/stunnel/files/stunnel-5.51-libressl.patch
@@ -1,0 +1,268 @@
+diff --git a/src/client.c b/src/client.c
+index b67544a..6676529 100644
+--- a/src/client.c
++++ b/src/client.c
+@@ -680,7 +680,7 @@ NOEXPORT void transfer(CLI *c) {
+         }
+ 
+         /****************************** wait for an event */
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+         pending=SSL_pending(c->ssl) || SSL_has_pending(c->ssl);
+ #else
+         pending=SSL_pending(c->ssl);
+diff --git a/src/ctx.c b/src/ctx.c
+index b3dc684..0186968 100644
+--- a/src/ctx.c
++++ b/src/ctx.c
+@@ -91,7 +91,7 @@ NOEXPORT void set_prompt(const char *);
+ NOEXPORT int ui_retry();
+ 
+ /* session tickets */
+-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
++#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
+ NOEXPORT int generate_session_ticket_cb(SSL *, void *);
+ NOEXPORT int decrypt_session_ticket_cb(SSL *, SSL_SESSION *,
+     const unsigned char *, size_t, SSL_TICKET_STATUS, void *);
+@@ -125,7 +125,7 @@ NOEXPORT void sslerror_log(unsigned long, const char *, int, char *);
+ 
+ /**************************************** initialize section->ctx */
+ 
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ typedef long unsigned SSL_OPTIONS_TYPE;
+ #else
+ typedef long SSL_OPTIONS_TYPE;
+@@ -133,7 +133,7 @@ typedef long SSL_OPTIONS_TYPE;
+ 
+ int context_init(SERVICE_OPTIONS *section) { /* init TLS context */
+     /* create TLS context */
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+     if(section->option.client)
+         section->ctx=SSL_CTX_new(TLS_client_method());
+     else /* server mode */
+@@ -229,7 +229,7 @@ int context_init(SERVICE_OPTIONS *section) { /* init TLS context */
+ #endif
+ 
+     /* setup session tickets */
+-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
++#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
+     SSL_CTX_set_session_ticket_cb(section->ctx, generate_session_ticket_cb,
+         decrypt_session_ticket_cb, NULL);
+ #endif /* OpenSSL 1.1.1 or later */
+@@ -483,7 +483,7 @@ NOEXPORT int ecdh_init(SERVICE_OPTIONS *section) {
+ /**************************************** initialize OpenSSL CONF */
+ 
+ NOEXPORT int conf_init(SERVICE_OPTIONS *section) {
+-#if OPENSSL_VERSION_NUMBER>=0x10002000L
++#if OPENSSL_VERSION_NUMBER>=0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+     SSL_CONF_CTX *cctx;
+     NAME_LIST *curr;
+     char *cmd, *param;
+@@ -969,7 +969,7 @@ NOEXPORT int ui_retry() {
+ 
+ /**************************************** session tickets */
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
++#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 
+ typedef struct {
+     void *session_authenticated;
+@@ -1412,7 +1412,7 @@ NOEXPORT void info_callback(const SSL *ssl, int where, int ret) {
+ 
+     c=SSL_get_ex_data((SSL *)ssl, index_ssl_cli);
+     if(c) {
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+         OSSL_HANDSHAKE_STATE state=SSL_get_state(ssl);
+ #else
+         int state=SSL_get_state((SSL *)ssl);
+diff --git a/src/options.c b/src/options.c
+index c7bd5c5..5441b80 100644
+--- a/src/options.c
++++ b/src/options.c
+@@ -81,7 +81,7 @@ NOEXPORT char *sni_init(SERVICE_OPTIONS *);
+ NOEXPORT void sni_free(SERVICE_OPTIONS *);
+ #endif /* !defined(OPENSSL_NO_TLSEXT) */
+ 
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ NOEXPORT int str_to_proto_version(const char *);
+ #else /* OPENSSL_VERSION_NUMBER<0x10100000L */
+ NOEXPORT char *tls_methods_set(SERVICE_OPTIONS *, const char *);
+@@ -3098,7 +3098,7 @@ NOEXPORT char *parse_service_option(CMD cmd, SERVICE_OPTIONS **section_ptr,
+         break;
+     }
+ 
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 
+     /* sslVersion */
+     switch(cmd) {
+@@ -3671,7 +3671,7 @@ NOEXPORT void sni_free(SERVICE_OPTIONS *section) {
+ 
+ /**************************************** modern TLS version handling */
+ 
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 
+ NOEXPORT int str_to_proto_version(const char *name) {
+     if(!strcasecmp(name, "all"))
+diff --git a/src/prototypes.h b/src/prototypes.h
+index 4a5d9af..057d3b9 100644
+--- a/src/prototypes.h
++++ b/src/prototypes.h
+@@ -226,7 +226,7 @@ typedef struct service_options_struct {
+ #if OPENSSL_VERSION_NUMBER>=0x009080dfL
+     long unsigned ssl_options_clear;
+ #endif /* OpenSSL 0.9.8m or later */
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+     int min_proto_version, max_proto_version;
+ #else /* OPENSSL_VERSION_NUMBER<0x10100000L */
+     SSL_METHOD *client_method, *server_method;
+@@ -666,7 +666,7 @@ int getnameinfo(const struct sockaddr *, socklen_t,
+ #define USE_OS_THREADS
+ #endif
+ 
+-#if OPENSSL_VERSION_NUMBER<0x10100004L
++#if OPENSSL_VERSION_NUMBER<0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #ifdef USE_OS_THREADS
+ 
+@@ -714,7 +714,7 @@ typedef enum {
+ 
+ extern CRYPTO_RWLOCK *stunnel_locks[STUNNEL_LOCKS];
+ 
+-#if OPENSSL_VERSION_NUMBER<0x10100004L
++#if OPENSSL_VERSION_NUMBER<0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
+ /* Emulate the OpenSSL 1.1 locking API for older OpenSSL versions */
+ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void);
+ int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *);
+diff --git a/src/ssl.c b/src/ssl.c
+index 60e31c1..10b0658 100644
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -39,7 +39,7 @@
+ #include "prototypes.h"
+ 
+     /* global OpenSSL initialization: compression, engine, entropy */
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ NOEXPORT int cb_dup_addr(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
+     void *from_d, int idx, long argl, void *argp);
+ #else
+@@ -114,7 +114,7 @@ int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g) {
+ #endif
+ #endif
+ 
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ NOEXPORT int cb_dup_addr(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
+         void *from_d, int idx, long argl, void *argp) {
+ #else
+@@ -177,7 +177,7 @@ int ssl_configure(GLOBAL_OPTIONS *global) { /* configure global TLS settings */
+ 
+ #ifndef OPENSSL_NO_COMP
+ 
+-#if OPENSSL_VERSION_NUMBER<0x10100000L
++#if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ NOEXPORT int COMP_get_type(const COMP_METHOD *meth) {
+     return meth->type;
+diff --git a/src/sthreads.c b/src/sthreads.c
+index 37a1398..750e312 100644
+--- a/src/sthreads.c
++++ b/src/sthreads.c
+@@ -97,14 +97,16 @@ unsigned long stunnel_thread_id(void) {
+ 
+ #endif /* USE_WIN32 */
+ 
+-#if OPENSSL_VERSION_NUMBER>=0x10000000L && OPENSSL_VERSION_NUMBER<0x10100004L
++#if (OPENSSL_VERSION_NUMBER>=0x10000000L && OPENSSL_VERSION_NUMBER<0x10100004L) || \
++    defined(LIBRESSL_VERSION_NUMBER)
+ NOEXPORT void threadid_func(CRYPTO_THREADID *tid) {
+     CRYPTO_THREADID_set_numeric(tid, stunnel_thread_id());
+ }
+ #endif
+ 
+ void thread_id_init(void) {
+-#if OPENSSL_VERSION_NUMBER>=0x10000000L && OPENSSL_VERSION_NUMBER<0x10100000L
++#if (OPENSSL_VERSION_NUMBER>=0x10000000L && OPENSSL_VERSION_NUMBER<0x10100000L) || \
++    defined(LIBRESSL_VERSION_NUMBER)
+     CRYPTO_THREADID_set_callback(threadid_func);
+ #endif
+ #if OPENSSL_VERSION_NUMBER<0x10000000L || !defined(OPENSSL_NO_DEPRECATED)
+@@ -115,7 +117,7 @@ void thread_id_init(void) {
+ /**************************************** locking */
+ 
+ /* we only need to initialize locking with OpenSSL older than 1.1.0 */
+-#if OPENSSL_VERSION_NUMBER<0x10100004L
++#if OPENSSL_VERSION_NUMBER<0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #ifdef USE_PTHREAD
+ 
+@@ -224,7 +226,7 @@ NOEXPORT int s_atomic_add(int *val, int amount, CRYPTO_RWLOCK *lock) {
+ 
+ CRYPTO_RWLOCK *stunnel_locks[STUNNEL_LOCKS];
+ 
+-#if OPENSSL_VERSION_NUMBER<0x10100004L
++#if OPENSSL_VERSION_NUMBER<0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #ifdef USE_OS_THREADS
+ 
+@@ -334,7 +336,8 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock) {
+ 
+ void locking_init(void) {
+     size_t i;
+-#if defined(USE_OS_THREADS) && OPENSSL_VERSION_NUMBER<0x10100004L
++#if defined(USE_OS_THREADS) && \
++    (OPENSSL_VERSION_NUMBER<0x10100004L || defined(LIBRESSL_VERSION_NUMBER))
+     size_t num;
+ 
+     /* initialize the OpenSSL static locking */
+diff --git a/src/tls.c b/src/tls.c
+index 6c92b96..5e60a95 100644
+--- a/src/tls.c
++++ b/src/tls.c
+@@ -41,7 +41,7 @@
+ volatile int tls_initialized=0;
+ 
+ NOEXPORT void tls_platform_init();
+-#if OPENSSL_VERSION_NUMBER<0x10100000L
++#if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ NOEXPORT void free_function(void *);
+ #endif
+ 
+@@ -52,7 +52,7 @@ void tls_init() {
+     tls_platform_init();
+     tls_initialized=1;
+     ui_tls=tls_alloc(NULL, NULL, "ui");
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+     CRYPTO_set_mem_functions(str_alloc_detached_debug,
+         str_realloc_detached_debug, str_free_debug);
+ #else
+@@ -184,7 +184,7 @@ TLS_DATA *tls_get() {
+ 
+ /**************************************** OpenSSL allocator hook */
+ 
+-#if OPENSSL_VERSION_NUMBER<0x10100000L
++#if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ NOEXPORT void free_function(void *ptr) {
+     /* CRYPTO_set_mem_ex_functions() needs a function rather than a macro */
+     /* unfortunately, OpenSSL provides no file:line information here */
+diff --git a/src/verify.c b/src/verify.c
+index acdfb5b..d7b7655 100644
+--- a/src/verify.c
++++ b/src/verify.c
+@@ -346,7 +346,7 @@ NOEXPORT int cert_check_local(X509_STORE_CTX *callback_ctx) {
+     cert=X509_STORE_CTX_get_current_cert(callback_ctx);
+     subject=X509_get_subject_name(cert);
+ 
+-#if OPENSSL_VERSION_NUMBER<0x10100006L
++#if OPENSSL_VERSION_NUMBER<0x10100006L || defined(LIBRESSL_VERSION_NUMBER)
+ #define X509_STORE_CTX_get1_certs X509_STORE_get1_certs
+ #endif
+     /* modern API allows retrieving multiple matching certificates */

--- a/net-misc/stunnel/stunnel-5.51-r1.ebuild
+++ b/net-misc/stunnel/stunnel-5.51-r1.ebuild
@@ -39,8 +39,8 @@ src_prepare() {
 	sed -i -e "s/^install-data-local:/do-not-run-this:/" \
 		tools/Makefile.in || die "sed failed"
 
-	# bug 656420
-	eapply "${FILESDIR}"/${PN}-5.50-libressl.patch
+	# bugs 656420, 682894
+	eapply "${FILESDIR}"/${P}-libressl.patch
 
 	echo "CONFIG_PROTECT=\"/etc/stunnel/stunnel.conf\"" > "${T}"/20stunnel
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/682894
Package-Manager: Portage-2.3.64, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>