### PR TITLE
net-dialup/freeradius: add patch for LibreSSL support

### DIFF
--- a/net-dialup/freeradius/files/freeradius-3.0.18-libressl.patch
+++ b/net-dialup/freeradius/files/freeradius-3.0.18-libressl.patch
@@ -1,0 +1,63 @@
+From 39e4ac0cf8d415b41dc2ff1fc329de0522b135ca Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <stefan.strogin@gmail.com>
+Date: Wed, 24 Apr 2019 09:16:12 +0300
+Subject: [PATCH] Fix build to LibreSSL
+
+Upstream-Status: Inappropriate
+[https://github.com/FreeRADIUS/freeradius-server/commit/9652affe38f41ba2484e013cf9d2c0bcb8c80d67]
+Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>
+---
+ src/main/tls.c                                    | 9 ++++++---
+ src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c | 3 ++-
+ 2 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/src/main/tls.c b/src/main/tls.c
+index 9726953234..840724bf61 100644
+--- a/src/main/tls.c
++++ b/src/main/tls.c
+@@ -1579,7 +1579,8 @@ done:
+ 	return 0;
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
++  (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2090100fL)
+ static SSL_SESSION *cbtls_get_session(SSL *ssl, unsigned char *data, int len, int *copy)
+ #else
+ static SSL_SESSION *cbtls_get_session(SSL *ssl, const unsigned char *data, int len, int *copy)
+@@ -3379,14 +3380,16 @@ post_ca:
+ 		 */
+ 		SSL_CTX_sess_set_cache_size(ctx, conf->session_cache_size);
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
++/* Not implemented in LibreSSL 2.9.1 */
++#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 		SSL_CTX_set_num_tickets(ctx, 1);
+ #endif
+ 
+ 	} else {
+ 		SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
++/* Not implemented in LibreSSL 2.9.1 */
++#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 		/*
+ 		 *	This controls the number of stateful or stateless tickets
+ 		 *	generated with TLS 1.3.  In OpenSSL 1.1.1 it's also
+diff --git a/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c b/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
+index fa9c58f3c3..a53341fc20 100644
+--- a/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
++++ b/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
+@@ -44,7 +44,8 @@ static int openssl_get_keyblock_size(REQUEST *request, SSL *ssl)
+ {
+ 	const EVP_CIPHER *c;
+ 	const EVP_MD *h;
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
++  (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2090100fL)
+ 	int md_size;
+ 
+ 	if (ssl->enc_read_ctx == NULL || ssl->enc_read_ctx->cipher == NULL ||
+-- 
+2.21.0
+

--- a/net-dialup/freeradius/freeradius-3.0.18.ebuild
+++ b/net-dialup/freeradius/freeradius-3.0.18.ebuild
@@ -60,6 +60,8 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 S="${WORKDIR}/${MY_P}"
 
+PATCHES=( "${FILESDIR}"/${P}-libressl.patch )
+
 pkg_setup() {
 	enewgroup radius
 	enewuser radius -1 -1 /var/log/radius radius


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/680066
Package-Manager: Portage-2.3.64, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>