### PR TITLE
dev-python/cryptography: add patch for LibreSSL 2.9.1 support

### DIFF
--- a/dev-python/cryptography/cryptography-2.6.1.ebuild
+++ b/dev-python/cryptography/cryptography-2.6.1.ebuild
@@ -57,6 +57,7 @@ DEPEND="${RDEPEND}
 DOCS=( AUTHORS.rst CONTRIBUTING.rst README.rst )
 
 PATCHES=(
+	"${FILESDIR}"/${P}-libressl.patch
 )
 
 python_configure_all() {

--- a/dev-python/cryptography/files/cryptography-2.6.1-libressl.patch
+++ b/dev-python/cryptography/files/cryptography-2.6.1-libressl.patch
@@ -1,0 +1,69 @@
+From 340d55d28305e4449ccf019a5250df2c17dd70c6 Mon Sep 17 00:00:00 2001
+From: Charlie Li <vishwin@users.noreply.github.com>
+Date: Tue, 23 Apr 2019 11:07:00 -0400
+Subject: [PATCH] Use generic DTLS functions added in LibreSSL 2.9.1 (#4855)
+
+* Use generic DTLS functions added in LibreSSL 2.9.1
+
+While here, bump travis.
+
+* Remove LibreSSL 2.9.0 from travis now that 2.9.1 exists.
+
+Requested by: @reaperhulk
+
+Upstream-status: Backport
+[https://github.com/pyca/cryptography/commit/87550626ff995ae61abf441e5e89076cc5a7dd45]
+Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>
+---
+ src/_cffi_src/openssl/cryptography.py | 3 +++
+ src/_cffi_src/openssl/ssl.py          | 9 ++++++---
+ 3 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/src/_cffi_src/openssl/cryptography.py b/src/_cffi_src/openssl/cryptography.py
+index 4124dcb8..ac32fdff 100644
+--- a/src/_cffi_src/openssl/cryptography.py
++++ b/src/_cffi_src/openssl/cryptography.py
+@@ -38,9 +38,12 @@ INCLUDES = """
+     (LIBRESSL_VERSION_NUMBER >= 0x2070000f)
+ #define CRYPTOGRAPHY_LIBRESSL_28_OR_GREATER \
+     (LIBRESSL_VERSION_NUMBER >= 0x2080000f)
++#define CRYPTOGRAPHY_LIBRESSL_291_OR_GREATER \
++    (LIBRESSL_VERSION_NUMBER >= 0x2090100f)
+ #else
+ #define CRYPTOGRAPHY_LIBRESSL_27_OR_GREATER (0)
+ #define CRYPTOGRAPHY_LIBRESSL_28_OR_GREATER (0)
++#define CRYPTOGRAPHY_LIBRESSL_291_OR_GREATER (0)
+ #endif
+ 
+ #define CRYPTOGRAPHY_OPENSSL_102_OR_GREATER \
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index 92fd1e3e..da21f3ce 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -719,17 +719,20 @@ static const long TLS_ST_BEFORE = 0;
+ static const long TLS_ST_OK = 0;
+ #endif
+ 
+-#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
++/* LibreSSL 2.9.1 added only the DTLS_*_method functions */
++#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102 && !CRYPTOGRAPHY_LIBRESSL_291_OR_GREATER
+ static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 0;
+ const SSL_METHOD *(*DTLS_method)(void) = NULL;
+ const SSL_METHOD *(*DTLS_server_method)(void) = NULL;
+ const SSL_METHOD *(*DTLS_client_method)(void) = NULL;
++#else
++static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 1;
++#endif
++#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
+ static const long SSL_OP_NO_DTLSv1 = 0;
+ static const long SSL_OP_NO_DTLSv1_2 = 0;
+ long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
+ long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
+-#else
+-static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 1;
+ #endif
+ 
+ static const long Cryptography_HAS_DTLS = 1;
+-- 
+2.21.0
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/684234
Package-Manager: Portage-2.3.64, Repoman-2.3.12
Signed-off-by: Stefan Strogin <stefan.strogin@gmail.com>