### PR TITLE
app-office/gnucash: Remove -Werror for 3.3+

### DIFF
--- a/app-office/gnucash/gnucash-3.3-r1.ebuild
+++ b/app-office/gnucash/gnucash-3.3-r1.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 GV="1.8.0"
 PYTHON_COMPAT=( python3_{5,6} )
 
-inherit cmake-utils gnome2-utils python-single-r1 xdg-utils
+inherit cmake-utils flag-o-matic gnome2-utils python-single-r1 xdg-utils
 
 DESCRIPTION="A personal finance manager"
 HOMEPAGE="http://www.gnucash.org/"
@@ -109,6 +109,8 @@ src_configure() {
 		-DWITH_GNUCASH=$(usex gui)
 	)
 
+	append-cflags -Wno-error
+	append-cxxflags -Wno-error
 	cmake-utils_src_configure
 }
 

--- a/app-office/gnucash/gnucash-3.3.ebuild
+++ b/app-office/gnucash/gnucash-3.3.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 GV="1.8.0"
 PYTHON_COMPAT=( python3_{5,6} )
 
-inherit cmake-utils gnome2-utils python-single-r1 xdg-utils
+inherit cmake-utils flag-o-matic gnome2-utils python-single-r1 xdg-utils
 
 DESCRIPTION="A personal finance manager"
 HOMEPAGE="http://www.gnucash.org/"
@@ -107,6 +107,8 @@ src_configure() {
 		-DWITH_GNUCASH=$(usex gui)
 	)
 
+	append-cflags -Wno-error
+	append-cxxflags -Wno-error
 	cmake-utils_src_configure
 }
 

--- a/app-office/gnucash/gnucash-3.4.ebuild
+++ b/app-office/gnucash/gnucash-3.4.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 GV="1.8.0"
 PYTHON_COMPAT=( python3_{5,6} )
 
-inherit cmake-utils gnome2-utils python-single-r1 xdg-utils
+inherit cmake-utils flag-o-matic gnome2-utils python-single-r1 xdg-utils
 
 DESCRIPTION="A personal finance manager"
 HOMEPAGE="http://www.gnucash.org/"
@@ -120,6 +120,8 @@ src_configure() {
 		-DWITH_GNUCASH=$(usex gui)
 	)
 
+	append-cflags -Wno-error
+	append-cxxflags -Wno-error
 	cmake-utils_src_configure
 }
 

--- a/app-office/gnucash/gnucash-3.5.ebuild
+++ b/app-office/gnucash/gnucash-3.5.ebuild
@@ -7,7 +7,7 @@ EAPI=6
 GV="1.8.0"
 PYTHON_COMPAT=( python3_{5,6} )
 
-inherit cmake-utils gnome2-utils python-single-r1 xdg-utils
+inherit cmake-utils flag-o-matic gnome2-utils python-single-r1 xdg-utils
 
 DESCRIPTION="A personal finance manager"
 HOMEPAGE="http://www.gnucash.org/"


### PR DESCRIPTION
-Werror was hardcoded in CMakeLists.txt by the GnuCash developers. This
flag should be removed for installation in Gentoo.

See https://bugs.gentoo.org/684286 - this caused a compile failure for me on GCC 8.2.0.