### PR TITLE
dev-util/quilt: fix broken patch

### DIFF
--- a/dev-util/quilt/files/quilt-0.66-no-graphviz.patch
+++ b/dev-util/quilt/files/quilt-0.66-no-graphviz.patch
@@ -1,5 +1,5 @@
---- Makefile.in.orig	2017-04-12 09:27:40.853018901 -0400
-+++ Makefile.in	2017-04-12 09:36:16.584315529 -0400
+--- a/Makefile.in	2017-04-12 09:27:40.853018901 -0400
++++ b/Makefile.in	2017-04-12 09:36:16.584315529 -0400
 @@ -78,8 +78,7 @@ QUILT :=	$(QUILT_IN)
  SRC +=		$(QUILT_SRC:%=quilt/%)
  DIRT +=		$(QUILT_IN:%=quilt/%)
@@ -10,8 +10,8 @@
 
  SCRIPTS_SRC :=	$(SCRIPTS_IN:%=%.in)
  SCRIPTS :=	$(SCRIPTS_IN)
---- bash_completion.orig	2017-04-12 09:27:57.643126246 -0400
-+++ bash_completion	2017-04-12 09:30:27.673938451 -0400
+--- a/bash_completion	2017-04-12 09:27:57.643126246 -0400
++++ b/bash_completion	2017-04-12 09:30:27.673938451 -0400
 @@ -28,7 +28,7 @@ _quilt_completion()
      prev=${COMP_WORDS[COMP_CWORD-1]}
 

--- a/dev-util/quilt/quilt-0.66.ebuild
+++ b/dev-util/quilt/quilt-0.66.ebuild
@@ -33,7 +33,7 @@ pkg_setup() {
 
 src_prepare() {
 	# Add support for USE=graphviz
-	use graphviz || eapply -p0 "${FILESDIR}/${P}-no-graphviz.patch"
+	use graphviz || PATCHES+=( "${FILESDIR}"/${PN}-0.66-no-graphviz.patch )
 	default
 }
 


### PR DESCRIPTION
As it currently stands with USE="-graphviz" quilt-0.66-no-graphviz.patch
does not apply to the source tree. Fixed that and adjusted the patch to
be -p1 applicable.

Package-Manager: Portage-2.3.65, Repoman-2.3.12
Signed-off-by: Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>