### PR TITLE
x11-wm/enlightenment: make wayland work with 0.22.4

### DIFF
--- a/x11-wm/enlightenment/enlightenment-0.22.4-r1.ebuild
+++ b/x11-wm/enlightenment/enlightenment-0.22.4-r1.ebuild
@@ -1,0 +1,102 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit meson xdg-utils
+
+DESCRIPTION="Enlightenment window manager"
+HOMEPAGE="https://www.enlightenment.org"
+SRC_URI="https://download.enlightenment.org/rel/apps/${PN}/${P}.tar.xz"
+
+LICENSE="BSD-2"
+SLOT="0.17/${PV%%_*}"
+KEYWORDS="~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86"
+IUSE="acpi bluetooth connman doc geolocation nls packagekit pam systemd udisks wayland wifi xwayland"
+
+REQUIRED_USE="xwayland? ( wayland )"
+
+RDEPEND="
+	>=dev-libs/efl-1.20.5[eet,X]
+	virtual/udev
+	x11-libs/libXext
+	x11-libs/libxcb
+	x11-libs/xcb-util-keysyms
+	x11-misc/xkeyboard-config
+	acpi? ( sys-power/acpid )
+	bluetooth? ( net-wireless/bluez )
+	connman? ( dev-libs/efl[connman] )
+	geolocation? ( app-misc/geoclue:2.0 )
+	packagekit? ( app-admin/packagekit-base )
+	pam? ( sys-libs/pam )
+	systemd? ( sys-apps/systemd )
+	udisks? ( sys-fs/udisks:2 )
+	wayland? (
+		>=dev-libs/efl-1.22.0[drm,wayland]
+		dev-libs/wayland
+		x11-libs/libxkbcommon
+		x11-libs/pixman
+	)
+	xwayland? (
+		dev-libs/efl[X,wayland]
+		x11-base/xorg-server[wayland]
+	)
+"
+BDEPEND="
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-efl-1.22-wayland.patch" )
+
+src_configure() {
+	local emesonargs=(
+		-D device-udev=true
+		-D install-sysactions=false
+
+		$(meson_use udisks mount-udisks)
+		$(meson_use bluetooth bluez4)
+		$(meson_use connman)
+		$(meson_use geolocation)
+		$(meson_use nls)
+		$(meson_use packagekit)
+		$(meson_use pam)
+		$(meson_use systemd)
+		$(meson_use wayland)
+		$(meson_use wifi wireless)
+		$(meson_use xwayland)
+	)
+
+	if ! use wayland; then
+		emesonargs+=(
+			-D wl-buffer=false
+			-D wl-desktop-shell=false
+			-D wl-drm=false
+			-D wl-text-input=false
+			-D wl-weekeyboard=false
+			-D wl-wl=false
+			-D wl-x11=false
+		)
+	fi
+
+	meson_src_configure
+}
+
+src_install() {
+	insinto /etc/enlightenment
+	newins "${FILESDIR}"/gentoo-sysactions.conf sysactions.conf
+
+	use doc && local HTML_DOCS=( doc/. )
+	meson_src_install
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}

--- a/x11-wm/enlightenment/files/enlightenment-0.22.4-efl-1.22-wayland.patch
+++ b/x11-wm/enlightenment/files/enlightenment-0.22.4-efl-1.22-wayland.patch
@@ -1,0 +1,65 @@
+From ea3f6ed68f948cea4b64432a6cdb72fca85e6987 Mon Sep 17 00:00:00 2001
+From: "Carsten Haitzler (Rasterman)" <raster@rasterman.com>
+Date: Fri, 22 Feb 2019 11:12:00 +0000
+Subject: e - unbreak build due to efl changes
+
+---
+ src/bin/e.h         | 1 +
+ src/bin/e_comp_wl.c | 8 ++++----
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/src/bin/e.h b/src/bin/e.h
+index 7d00d819e..abe5ed731 100644
+--- a/src/bin/e.h
++++ b/src/bin/e.h
+@@ -17,6 +17,7 @@
+ # endif
+ 
+ #ifdef HAVE_WAYLAND
++# define EFL_EO_API_SUPPORT
+ # define EFL_BETA_API_SUPPORT
+ #endif
+ 
+diff --git a/src/bin/e_comp_wl.c b/src/bin/e_comp_wl.c
+index a9adad104..e56e4e6f8 100644
+--- a/src/bin/e_comp_wl.c
++++ b/src/bin/e_comp_wl.c
+@@ -2188,7 +2188,7 @@ _cb_early_frame_cb(void *data, const Efl_Event *event EINA_UNUSED)
+    if (ec->comp_data->early_frame++ > 15)
+      {
+        ec->comp_data->early_frame = 0;
+-       efl_event_callback_del(e_comp->evas, EFL_EVENT_ANIMATOR_TICK,
++       efl_event_callback_del(e_comp->evas, EFL_CANVAS_OBJECT_EVENT_ANIMATOR_TICK,
+                               _cb_early_frame_cb, data);
+      }
+ }
+@@ -2198,14 +2198,14 @@ _e_comp_wl_surface_early_frame(E_Client *ec)
+ {
+    if (e_comp_object_damage_exists(ec->frame))
+      {
+-        efl_event_callback_del(e_comp->evas, EFL_EVENT_ANIMATOR_TICK,
++        efl_event_callback_del(e_comp->evas, EFL_CANVAS_OBJECT_EVENT_ANIMATOR_TICK,
+                                _cb_early_frame_cb, ec);
+         ec->comp_data->early_frame = 0;
+         return;
+      }
+    if (ec->on_post_updates) return;
+    if (!ec->comp_data->early_frame)
+-       efl_event_callback_add(e_comp->evas, EFL_EVENT_ANIMATOR_TICK,
++       efl_event_callback_add(e_comp->evas, EFL_CANVAS_OBJECT_EVENT_ANIMATOR_TICK,
+                               _cb_early_frame_cb, ec);
+    ec->comp_data->early_frame = 1;
+ }
+@@ -2582,7 +2582,7 @@ _e_comp_wl_client_cb_del(void *data EINA_UNUSED, E_Client *ec)
+    /* make sure this is a wayland client */
+    if (e_pixmap_type_get(ec->pixmap) != E_PIXMAP_TYPE_WL) return;
+ 
+-   efl_event_callback_del(e_comp->evas, EFL_EVENT_ANIMATOR_TICK,
++   efl_event_callback_del(e_comp->evas, EFL_CANVAS_OBJECT_EVENT_ANIMATOR_TICK,
+                           _cb_early_frame_cb, ec);
+    ec->comp_data->early_frame = 0;
+ 
+-- 
+cgit v1.2.1
+
+

--- a/x11-wm/enlightenment/metadata.xml
+++ b/x11-wm/enlightenment/metadata.xml
@@ -10,6 +10,7 @@
   </maintainer>
   <use>
     <flag name="packagekit">Enable module for package manager integration</flag>
+    <flag name="xwayland">Enable XWayland application support</flag>
   </use>
   <longdescription>
     Enlightenment is classed as a "desktop shell" as it provides everything you need to 


### PR DESCRIPTION
Committed to stable because there are no runtime changes, upstream expects enlightenment-0.22.4 to be run with efl-1.21 and wayland is broken with efl-1.22 so this restriction to ebuild is needed.

I'll update EAPI etc `$(meson_use)` stuff when next enlightenment is released and put into `~arch` keywords. This is just a minor change to stable ebuild :)

@gyakovlev 

```diff
--- enlightenment-0.22.4.ebuild	2019-04-28 09:31:32.915869332 +0300
+++ enlightenment-0.22.4-r1.ebuild	2019-04-28 09:34:05.592863900 +0300
@@ -30,7 +30,7 @@
 	systemd? ( sys-apps/systemd )
 	udisks? ( sys-fs/udisks:2 )
 	wayland? (
-		>=dev-libs/efl-1.21.0[drm,wayland]
+		=dev-libs/efl-1.21*[drm,wayland]
 		dev-libs/wayland
 		x11-libs/libxkbcommon
 		x11-libs/pixman
```