### PR TITLE
mail-mta/postfix-3.4.5: add support for LibreSSL 2.9

### DIFF
--- a/mail-mta/postfix/postfix-3.4.5.ebuild
+++ b/mail-mta/postfix/postfix-3.4.5.ebuild
@@ -35,7 +35,7 @@ DEPEND=">=dev-libs/libpcre-3.4
 	sqlite? ( dev-db/sqlite:3 )
 	ssl? (
 		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl )
+		libressl? ( >=dev-libs/libressl-2.9.1:0= )
 	)"
 
 RDEPEND="${DEPEND}
@@ -60,10 +60,12 @@ REQUIRED_USE="ldap-bind? ( ldap sasl )"
 
 S="${WORKDIR}/${MY_SRC}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-libressl-certkey.patch"
+	"${FILESDIR}/${PN}-libressl-server.patch"
+)
+
 pkg_setup() {
-	if use libressl; then
-		die "LibreSSL patches are not yet available for postfix-3.4 releases."
-	fi
 	# Add postfix, postdrop user/group (bug #77565)
 	enewgroup postfix 207
 	enewgroup postdrop 208
@@ -76,11 +78,6 @@ src_prepare() {
 		src/util/sys_defs.h || die "sed failed"
 	# change default paths to better comply with portage standard paths
 	sed -i -e "s:/usr/local/:/usr/:g" conf/master.cf || die "sed failed"
-	# libressl support needs work for postfix-3.4
-	#eapply -p0 "${FILESDIR}/${PN}-libressl.patch" \
-	#	"${FILESDIR}/${PN}-libressl-runtime.patch" \
-	#	"${FILESDIR}/${PN}-libressl-eccurve.patch"
-	#	"${FILESDIR}/${PN}-libressl-session-tickets.patch"
 }
 
 src_configure() {


### PR DESCRIPTION
The LibreSSL patch for 3.5-20190330 works with 3.4.5. It requires LibreSSL 2.9 though, and doesn't build with 2.8. This is because Postfix 3.4+ uses OpenSSL 1.1 API calls which are not in LibreSSL versions older than 2.9.
See:
  http://www.postfix.org/announcements/postfix-3.4.0.html
  https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.9.1-relnotes.txt

Closes: https://bugs.gentoo.org/678874
Package-Manager: Portage-2.3.65, Repoman-2.3.12
Signed-off-by: Philipp Ammann <philipp.ammann@posteo.de>