### PR TITLE
www-client/firefox: reenable elf-hack for arm

### DIFF
--- a/eclass/mozconfig-v6.60.eclass
+++ b/eclass/mozconfig-v6.60.eclass
@@ -361,8 +361,6 @@ mozconfig_config() {
 	if use clang ; then
 		# https://bugzilla.mozilla.org/show_bug.cgi?id=1423822
 		mozconfig_annotate 'elf-hack is broken when using Clang' --disable-elf-hack
-	elif use arm ; then
-		mozconfig_annotate 'elf-hack is broken on arm' --disable-elf-hack
 	fi
 
 	# Modifications to better support ARM, bug 553364


### PR DESCRIPTION
this was fixed in patchlevel 06 from a few days ago. 

@Whissi 