### PR TITLE
app-crypt/acme-tiny: PYTHON_TARGETS+="python3_7"

### DIFF
--- a/app-crypt/acme-tiny/acme-tiny-4.0.4.ebuild
+++ b/app-crypt/acme-tiny/acme-tiny-4.0.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
 inherit distutils-r1
 
 if [[ ${PV} == 9999 ]]; then

--- a/app-crypt/acme-tiny/acme-tiny-9999.ebuild
+++ b/app-crypt/acme-tiny/acme-tiny-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
 inherit distutils-r1
 
 if [[ ${PV} == 9999 ]]; then


### PR DESCRIPTION
I've been running it on Python 3.7 for months without issues.

Package-Manager: Portage-2.3.65, Repoman-2.3.12
Signed-off-by: Philipp Ammann <philipp.ammann@posteo.de>