### PR TITLE
media-libs/gstreamer-editing-services: support python3_7

### DIFF
--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.14.3.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.14.3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 GNOME2_LA_PUNT="yes"
 
 inherit bash-completion-r1 gnome2 python-r1


### PR DESCRIPTION
Compile tested.

Signed-off-by: David Heidelberg <david@ixit.cz>