### PR TITLE
app-shells/hstr: force tinfow use.

### DIFF
--- a/app-shells/hstr/files/hstr-1.23-tinfo.patch
+++ b/app-shells/hstr/files/hstr-1.23-tinfo.patch
@@ -5,7 +5,7 @@
  AC_CHECK_LIB(readline, using_history, [], [AC_MSG_ERROR([Could not find readline library])])
  # ncurses might be linked in libtinfo
 -#AC_CHECK_LIB(tinfo, keypad, [], [AC_MSG_ERROR([Could not find tinfo library])])
-+AC_SEARCH_LIBS(keypad, tinfo, [], [AC_MSG_ERROR([Could not find tinfo library])])
++AC_SEARCH_LIBS(tinfow, tinfo, [], [AC_MSG_ERROR([Could not find tinfow library])])
  
  # Checks for header files.
  AC_CHECK_HEADER(assert.h)

--- a/app-shells/hstr/hstr-2.0.ebuild
+++ b/app-shells/hstr/hstr-2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ LICENSE="Apache-2.0"
 KEYWORDS="amd64 x86 ~amd64-fbsd"
 
 RDEPEND="
-	sys-libs/ncurses:0="
+	sys-libs/ncurses:0=[unicode]"
 
 DEPEND="
 	${RDEPEND}


### PR DESCRIPTION
Courtesy of vapier@gentoo.org.

Closes: https://bugs.gentoo.org/651720
Signed-off-by: Patrice Clement <monsieurp@gentoo.org>
Package-Manager: Portage-2.3.62, Repoman-2.3.11