### PR TITLE
dev-lang/erlang: Fix based on old ebuild files

### DIFF
--- a/dev-lang/erlang/erlang-21.1.1.ebuild
+++ b/dev-lang/erlang/erlang-21.1.1.ebuild
@@ -70,8 +70,7 @@ src_configure() {
 		$(use_with java javac)
 		$(use_with odbc)
 		$(use_enable sctp)
-		$(use_with ssl)
-		$(usex ssl "--with-ssl-rpath" "")
+		$(use_with ssl ssl "${EPREFIX}"/usr)
 		$(use_enable ssl dynamic-ssl-lib)
 		$(use_enable systemd)
 		$(use_enable pgo)
@@ -113,7 +112,7 @@ src_install() {
 	[[ -z "${erl_erts_ver}" ]] && die "Couldn't determine erts version"
 	[[ -z "${erl_interface_ver}" ]] && die "Couldn't determine interface version"
 
-	emake INSTALL_PREFIX="${ED}" install
+	emake INSTALL_PREFIX="${D}" install
 
 	if use doc ; then
 		local DOCS=( "AUTHORS" "HOWTO"/* "README.md" "CONTRIBUTING.md" "${WORKDIR}"/doc/. "${WORKDIR}"/lib/. "${WORKDIR}"/erts-* )

--- a/dev-lang/erlang/erlang-21.2.6.ebuild
+++ b/dev-lang/erlang/erlang-21.2.6.ebuild
@@ -70,8 +70,7 @@ src_configure() {
 		$(use_with java javac)
 		$(use_with odbc)
 		$(use_enable sctp)
-		$(use_with ssl)
-		$(usex ssl "--with-ssl-rpath" "")
+		$(use_with ssl ssl "${EPREFIX}"/usr)
 		$(use_enable ssl dynamic-ssl-lib)
 		$(use_enable systemd)
 		$(use_enable pgo)
@@ -113,7 +112,7 @@ src_install() {
 	[[ -z "${erl_erts_ver}" ]] && die "Couldn't determine erts version"
 	[[ -z "${erl_interface_ver}" ]] && die "Couldn't determine interface version"
 
-	emake INSTALL_PREFIX="${ED}" install
+	emake INSTALL_PREFIX="${D}" install
 
 	if use doc ; then
 		local DOCS=( "AUTHORS" "HOWTO"/* "README.md" "CONTRIBUTING.md" "${WORKDIR}"/doc/. "${WORKDIR}"/lib/. "${WORKDIR}"/erts-* )

--- a/dev-lang/erlang/erlang-21.2.7.ebuild
+++ b/dev-lang/erlang/erlang-21.2.7.ebuild
@@ -70,8 +70,7 @@ src_configure() {
 		$(use_with java javac)
 		$(use_with odbc)
 		$(use_enable sctp)
-		$(use_with ssl)
-		$(usex ssl "--with-ssl-rpath" "")
+		$(use_with ssl ssl "${EPREFIX}"/usr)
 		$(use_enable ssl dynamic-ssl-lib)
 		$(use_enable systemd)
 		$(use_enable pgo)
@@ -113,7 +112,7 @@ src_install() {
 	[[ -z "${erl_erts_ver}" ]] && die "Couldn't determine erts version"
 	[[ -z "${erl_interface_ver}" ]] && die "Couldn't determine interface version"
 
-	emake INSTALL_PREFIX="${ED}" install
+	emake INSTALL_PREFIX="${D}" install
 
 	if use doc ; then
 		local DOCS=( "AUTHORS" "HOWTO"/* "README.md" "CONTRIBUTING.md" "${WORKDIR}"/doc/. "${WORKDIR}"/lib/. "${WORKDIR}"/erts-* )

--- a/dev-lang/erlang/erlang-21.3.ebuild
+++ b/dev-lang/erlang/erlang-21.3.ebuild
@@ -70,8 +70,7 @@ src_configure() {
 		$(use_with java javac)
 		$(use_with odbc)
 		$(use_enable sctp)
-		$(use_with ssl)
-		$(usex ssl "--with-ssl-rpath" "")
+		$(use_with ssl ssl "${EPREFIX}"/usr)
 		$(use_enable ssl dynamic-ssl-lib)
 		$(use_enable systemd)
 		$(use_enable pgo)
@@ -113,7 +112,7 @@ src_install() {
 	[[ -z "${erl_erts_ver}" ]] && die "Couldn't determine erts version"
 	[[ -z "${erl_interface_ver}" ]] && die "Couldn't determine interface version"
 
-	emake INSTALL_PREFIX="${ED}" install
+	emake INSTALL_PREFIX="${D}" install
 
 	if use doc ; then
 		local DOCS=( "AUTHORS" "HOWTO"/* "README.md" "CONTRIBUTING.md" "${WORKDIR}"/doc/. "${WORKDIR}"/lib/. "${WORKDIR}"/erts-* )


### PR DESCRIPTION
* Change ${ED} to ${D} as emake INSTALL_PREFIX as in the old ebuild
* Remove empty ssl-rpath in econfigure, and re-add the path to OpenSSL
  library in "use_with ssl"

Signed-off-by: Julius Putra Tanu Setiaji <indocomsoft@gmail.com>
Closes: https://bugs.gentoo.org/684816
Package-Manager: Portage-2.3.66, Repoman-2.3.12