### PR TITLE
dev-python/html5-parser: add Python3.7 support

### DIFF
--- a/dev-python/html5-parser/html5-parser-0.4.5.ebuild
+++ b/dev-python/html5-parser/html5-parser-0.4.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit distutils-r1 toolchain-funcs
 


### PR DESCRIPTION
Passes compilation and tests.
I'm using it for some days, works well.

Package-Manager: Portage-2.3.66, Repoman-2.3.12