### PR TITLE
gnome-extra/gnome-commander: check for gcc version via toolchain-funcs.eclass

### DIFF
--- a/gnome-extra/gnome-commander/gnome-commander-1.10.0.ebuild
+++ b/gnome-extra/gnome-commander/gnome-commander-1.10.0.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 GNOME2_LA_PUNT="yes"
 
-inherit gnome2
+inherit gnome2 toolchain-funcs
 
 DESCRIPTION="A graphical, full featured, twin-panel file manager"
 HOMEPAGE="https://gcmd.github.io/"
@@ -35,7 +35,6 @@ DEPEND="
 	${RDEPEND}
 	dev-util/gtk-doc-am
 	sys-devel/gettext
-	>=sys-devel/gcc-8.2.0
 	virtual/pkgconfig
 	test? ( >=dev-cpp/gtest-1.7.0 )
 "
@@ -50,6 +49,13 @@ src_configure() {
 		$(use_with samba) \
 		$(use_with taglib) \
 		$(use_with unique)
+}
+
+pkg_pretend() {
+	if tc-is-gcc && [[ $(gcc-major-version) -lt 8 ]]; then
+		eerror "Compilation with gcc older than version 8 is not supported"
+		die "GCC to old, please use gcc-8 or above"
+	fi
 }
 
 pkg_postinst() {


### PR DESCRIPTION
This change was suggested in the discussion for merge request #11559. 