### PR TITLE
app-misc/elasticsearch: fix install with USE="x-pack"

### DIFF
--- a/app-misc/elasticsearch/elasticsearch-7.0.0.ebuild
+++ b/app-misc/elasticsearch/elasticsearch-7.0.0.ebuild
@@ -30,7 +30,6 @@ src_prepare() {
 	rmdir logs || die
 
 	if use x-pack; then
-		rm bin/x-pack/*.bat || die
 		rm -r modules/x-pack-ml/platform/{darwin,windows}-x86_64 || die
 	fi
 }


### PR DESCRIPTION
The `*.bat` files related to X-Pack seem to be longer included in the
archives from upstream.

Please review, and let me know if I missed something :)