### PR TITLE
app-emulation/qemu: add doc use flag

### DIFF
--- a/app-emulation/qemu/metadata.xml
+++ b/app-emulation/qemu/metadata.xml
@@ -15,6 +15,7 @@
 		<flag name="alsa">Enable alsa output for sound emulation</flag>
 		<flag name="capstone">Enable disassembly support with <pkg>dev-libs/capstone</pkg></flag>
 		<flag name="curl">Support ISOs / -cdrom directives vis HTTP or HTTPS.</flag>
+		<flag name="doc">Enables generation of documentation</flag>
 		<flag name="fdt">Enables firmware device tree support</flag>
 		<flag name="glusterfs">Enables GlusterFS cluster fileystem via
 			<pkg>sys-cluster/glusterfs</pkg></flag>

--- a/app-emulation/qemu/qemu-4.0.0.ebuild
+++ b/app-emulation/qemu/qemu-4.0.0.ebuild
@@ -27,7 +27,7 @@ HOMEPAGE="http://www.qemu.org http://www.linux-kvm.org"
 
 LICENSE="GPL-2 LGPL-2 BSD-2"
 SLOT="0"
-IUSE="accessibility +aio alsa bzip2 capstone +caps +curl debug
+IUSE="accessibility +aio alsa bzip2 capstone +caps +curl debug doc
 	+fdt glusterfs gnutls gtk infiniband iscsi +jpeg kernel_linux
 	kernel_FreeBSD lzo ncurses nfs nls numa opengl +pin-upstream-blobs +png
 	pulseaudio python rbd sasl +seccomp sdl selinux smartcard snappy
@@ -171,7 +171,7 @@ PPC64_FIRMWARE_DEPEND="
 BDEPEND="
 	${PYTHON_DEPS}
 	dev-lang/perl
-	dev-python/sphinx
+	doc? ( dev-python/sphinx )
 	sys-apps/texinfo
 	virtual/pkgconfig
 	gtk? ( nls? ( sys-devel/gettext ) )
@@ -406,7 +406,7 @@ qemu_src_configure() {
 		--host-cc="$(tc-getBUILD_CC)"
 		$(use_enable debug debug-info)
 		$(use_enable debug debug-tcg)
-		--enable-docs
+		$(use_enable doc docs)
 		$(use_enable tci tcg-interpreter)
 		$(use_enable xattr attr)
 	)


### PR DESCRIPTION
Since building documentation is optionnal, this patchs adds the doc use flag.

Package-Manager: Portage-2.3.62, Repoman-2.3.11