### PR TITLE
sci-physics/lammps: use HTTPS

### DIFF
--- a/sci-physics/lammps/lammps-20150210.ebuild
+++ b/sci-physics/lammps/lammps-20150210.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -39,8 +39,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20150515-r1.ebuild
+++ b/sci-physics/lammps/lammps-20150515-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -41,8 +41,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20150515.ebuild
+++ b/sci-physics/lammps/lammps-20150515.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -41,8 +41,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20150810.ebuild
+++ b/sci-physics/lammps/lammps-20150810.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -41,8 +41,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20151106.ebuild
+++ b/sci-physics/lammps/lammps-20151106.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20151120.ebuild
+++ b/sci-physics/lammps/lammps-20151120.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20151207.ebuild
+++ b/sci-physics/lammps/lammps-20151207.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20151208.ebuild
+++ b/sci-physics/lammps/lammps-20151208.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20151209.ebuild
+++ b/sci-physics/lammps/lammps-20151209.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20151211.ebuild
+++ b/sci-physics/lammps/lammps-20151211.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160115.ebuild
+++ b/sci-physics/lammps/lammps-20160115.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160122.ebuild
+++ b/sci-physics/lammps/lammps-20160122.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160216.ebuild
+++ b/sci-physics/lammps/lammps-20160216.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160301.ebuild
+++ b/sci-physics/lammps/lammps-20160301.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160310.ebuild
+++ b/sci-physics/lammps/lammps-20160310.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160314.ebuild
+++ b/sci-physics/lammps/lammps-20160314.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160321.ebuild
+++ b/sci-physics/lammps/lammps-20160321.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160407.ebuild
+++ b/sci-physics/lammps/lammps-20160407.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20160730.ebuild
+++ b/sci-physics/lammps/lammps-20160730.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20170109.ebuild
+++ b/sci-physics/lammps/lammps-20170109.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20170706.ebuild
+++ b/sci-physics/lammps/lammps-20170706.ebuild
@@ -15,8 +15,8 @@ convert_month() {
 MY_P=${PN}-$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:2:2}
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
-SRC_URI="http://lammps.sandia.gov/tars/${MY_P}.tar.gz"
+HOMEPAGE="https://lammps.sandia.gov/"
+SRC_URI="https://lammps.sandia.gov/tars/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-physics/lammps/lammps-20170901-r1.ebuild
+++ b/sci-physics/lammps/lammps-20170901-r1.ebuild
@@ -16,7 +16,7 @@ MY_PV="patch_$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:0:4}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
+HOMEPAGE="https://lammps.sandia.gov/"
 SRC_URI="https://github.com/lammps/lammps/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/sci-physics/lammps/lammps-20170901.ebuild
+++ b/sci-physics/lammps/lammps-20170901.ebuild
@@ -16,7 +16,7 @@ MY_PV="patch_$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:0:4}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
+HOMEPAGE="https://lammps.sandia.gov/"
 SRC_URI="https://github.com/lammps/lammps/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/sci-physics/lammps/lammps-20180117.ebuild
+++ b/sci-physics/lammps/lammps-20180117.ebuild
@@ -16,7 +16,7 @@ MY_PV="patch_$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:0:4}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
+HOMEPAGE="https://lammps.sandia.gov/"
 SRC_URI="https://github.com/lammps/lammps/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/sci-physics/lammps/lammps-20180222.ebuild
+++ b/sci-physics/lammps/lammps-20180222.ebuild
@@ -16,7 +16,7 @@ MY_PV="patch_$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:0:4}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
+HOMEPAGE="https://lammps.sandia.gov/"
 SRC_URI="https://github.com/lammps/lammps/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/sci-physics/lammps/lammps-20180308.ebuild
+++ b/sci-physics/lammps/lammps-20180308.ebuild
@@ -16,7 +16,7 @@ MY_PV="patch_$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:0:4}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
+HOMEPAGE="https://lammps.sandia.gov/"
 SRC_URI="https://github.com/lammps/lammps/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/sci-physics/lammps/lammps-20180316.ebuild
+++ b/sci-physics/lammps/lammps-20180316.ebuild
@@ -16,7 +16,7 @@ MY_PV="patch_$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:0:4}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
+HOMEPAGE="https://lammps.sandia.gov/"
 SRC_URI="https://github.com/lammps/lammps/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/sci-physics/lammps/lammps-20180822.ebuild
+++ b/sci-physics/lammps/lammps-20180822.ebuild
@@ -16,7 +16,7 @@ MY_PV="patch_$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:0:4}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
+HOMEPAGE="https://lammps.sandia.gov/"
 SRC_URI="https://github.com/lammps/lammps/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/sci-physics/lammps/lammps-20181212.ebuild
+++ b/sci-physics/lammps/lammps-20181212.ebuild
@@ -16,7 +16,7 @@ MY_PV="patch_$((10#${PV:6:2}))$(convert_month ${PV:4:2})${PV:0:4}"
 MY_P="${PN}-${MY_PV}"
 
 DESCRIPTION="Large-scale Atomic/Molecular Massively Parallel Simulator"
-HOMEPAGE="http://lammps.sandia.gov/"
+HOMEPAGE="https://lammps.sandia.gov/"
 TCOMMIT=7869c75cac38cb8a3d2ef7747ea12ec5812f5151
 SRC_URI="https://github.com/lammps/lammps/archive/${MY_PV}.tar.gz -> ${MY_P}.tar.gz
 	test? ( https://github.com/lammps/lammps-testing/archive/${TCOMMIT}.tar.gz -> ${PN}-testing-${TCOMMIT}.tar.gz )"


### PR DESCRIPTION
Hi,

simple http->https for lammps. Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>