### PR TITLE
sci-chemistry/votca-csg: 1.4 doesn't support gmx-2019

### DIFF
--- a/sci-chemistry/votca-csg/votca-csg-1.4.ebuild
+++ b/sci-chemistry/votca-csg/votca-csg-1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -29,7 +29,7 @@ SLOT="0"
 
 RDEPEND="
 	~sci-libs/votca-tools-${PV}
-	gromacs? ( sci-chemistry/gromacs:= )
+	gromacs? ( <sci-chemistry/gromacs-2019_beta1:= )
 	hdf5? ( sci-libs/hdf5 )
 	dev-lang/perl
 	app-shells/bash:*"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/685028
Package-Manager: Portage-2.3.62, Repoman-2.3.11
Signed-off-by: Christoph Junghans <junghans@gentoo.org>