### PR TITLE
profiles: mark one riscv profile dev

### DIFF
--- a/profiles/profiles.desc
+++ b/profiles/profiles.desc
@@ -254,7 +254,7 @@ ppc64		default/linux/powerpc/ppc64/17.0/64bit-userland/little-endian/systemd	exp
 
 # RISC-V Profiles
 # @MAINTAINER: riscv@gentoo.org
-riscv		default/linux/riscv/17.0/rv64gc			exp
+riscv		default/linux/riscv/17.0/rv64gc			dev
 riscv		default/linux/riscv/17.0/rv64gc/lp64d		exp
 
 # S390 Profiles


### PR DESCRIPTION
for ci testing only -a

Signed-off-by: Andreas K. Hüttel <dilfridge@gentoo.org>