### PR TITLE
app-portage/esearch: Mark as Python 3.7 compatible

### DIFF
--- a/app-portage/esearch/esearch-1.3-r2.ebuild
+++ b/app-portage/esearch/esearch-1.3-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=(python{2_7,3_5,3_6})
+PYTHON_COMPAT=(python{2_7,3_5,3_6,3_7})
 PYTHON_REQ_USE="readline(+)"
 
 inherit distutils-r1

--- a/app-portage/esearch/esearch-9999.ebuild
+++ b/app-portage/esearch/esearch-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=(python{2_7,3_5,3_6})
+PYTHON_COMPAT=(python{2_7,3_5,3_6,3_7})
 PYTHON_REQ_USE="readline(+)"
 
 inherit distutils-r1 git-r3


### PR DESCRIPTION
Package-Manager: Portage-2.3.66, Repoman-2.3.12