### PR TITLE
profiles/package.mask: mask for removal media-tv/tvbrowser.

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -29,6 +29,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Patrice Clement <monsieurp@gentoo.org> (06 May 2019)
+# Broken build. Outdated version. No interest from the Java team to maintain
+# it. Removal in 30 days. Bug #581720.
+media-tv/tvbrowser
+
 # Stefan Strogin <stefan.strogin@gmail.com> (05 May 2019)
 # Depends on >=dev-libs/bglibs-2.04. Bug #670694.
 >=sys-process/bcron-0.11


### PR DESCRIPTION
Signed-off-by: Patrice Clement <monsieurp@gentoo.org>
Bug: https://bugs.gentoo.org/581720