### PR TITLE
games-emulation/pcsx2: append -mxsave compiler flag with gcc >= 8.2

### DIFF
--- a/games-emulation/pcsx2/pcsx2-9999.ebuild
+++ b/games-emulation/pcsx2/pcsx2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -44,6 +44,12 @@ pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary && $(tc-getCC) == *gcc* ]]; then
 		if [[ $(gcc-major-version) -lt 4 || $(gcc-major-version) == 4 && $(gcc-minor-version) -lt 8 ]] ; then
 			die "${PN} does not compile with gcc less than 4.8"
+		fi
+
+		# -mxsave flag is needed when GCC >= 8.2 is used
+		# https://bugs.gentoo.org/685156
+		if [[ $(gcc-major-version) -gt 8 || $(gcc-major-version) == 8 && $(gcc-minor-version) -ge 2 ]]; then
+			append-flags -mxsave
 		fi
 	fi
 }

--- a/games-emulation/pcsx2/pcsx2-9999.ebuild
+++ b/games-emulation/pcsx2/pcsx2-9999.ebuild
@@ -42,10 +42,6 @@ DEPEND="${RDEPEND}
 
 pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary && $(tc-getCC) == *gcc* ]]; then
-		if [[ $(gcc-major-version) -lt 4 || $(gcc-major-version) == 4 && $(gcc-minor-version) -lt 8 ]] ; then
-			die "${PN} does not compile with gcc less than 4.8"
-		fi
-
 		# -mxsave flag is needed when GCC >= 8.2 is used
 		# https://bugs.gentoo.org/685156
 		if [[ $(gcc-major-version) -gt 8 || $(gcc-major-version) == 8 && $(gcc-minor-version) -ge 2 ]]; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/685156

Signed-off-by: Yuri Konotopov <ykonotopov@gnome.org>