### PR TITLE
net-libs/grpc: Fix files installed outside prefix

### DIFF
--- a/net-libs/grpc/grpc-1.12.0.ebuild
+++ b/net-libs/grpc/grpc-1.12.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -59,7 +59,7 @@ src_compile() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=true \
 		install

--- a/net-libs/grpc/grpc-1.12.1-r1.ebuild
+++ b/net-libs/grpc/grpc-1.12.1-r1.ebuild
@@ -134,7 +134,7 @@ python_compile_all() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=true \
 		install

--- a/net-libs/grpc/grpc-1.13.0-r1.ebuild
+++ b/net-libs/grpc/grpc-1.13.0-r1.ebuild
@@ -138,7 +138,7 @@ python_compile_all() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install

--- a/net-libs/grpc/grpc-1.13.1.ebuild
+++ b/net-libs/grpc/grpc-1.13.1.ebuild
@@ -137,7 +137,7 @@ python_compile_all() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install

--- a/net-libs/grpc/grpc-1.14.2.ebuild
+++ b/net-libs/grpc/grpc-1.14.2.ebuild
@@ -137,7 +137,7 @@ python_compile_all() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install

--- a/net-libs/grpc/grpc-1.15.0.ebuild
+++ b/net-libs/grpc/grpc-1.15.0.ebuild
@@ -137,7 +137,7 @@ python_compile_all() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install

--- a/net-libs/grpc/grpc-1.16.1.ebuild
+++ b/net-libs/grpc/grpc-1.16.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -69,7 +69,7 @@ src_compile() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install

--- a/net-libs/grpc/grpc-1.17.1.ebuild
+++ b/net-libs/grpc/grpc-1.17.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -73,7 +73,7 @@ src_compile() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install

--- a/net-libs/grpc/grpc-1.18.0.ebuild
+++ b/net-libs/grpc/grpc-1.18.0.ebuild
@@ -73,7 +73,7 @@ src_compile() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install

--- a/net-libs/grpc/grpc-1.19.0.ebuild
+++ b/net-libs/grpc/grpc-1.19.0.ebuild
@@ -71,7 +71,7 @@ src_compile() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install

--- a/net-libs/grpc/grpc-1.20.1.ebuild
+++ b/net-libs/grpc/grpc-1.20.1.ebuild
@@ -71,7 +71,7 @@ src_compile() {
 
 src_install() {
 	emake \
-		prefix="${D}"/usr \
+		prefix="${ED%/}"/usr \
 		INSTALL_LIBDIR="$(get_libdir)" \
 		STRIP=/bin/true \
 		install


### PR DESCRIPTION
I was getting `Aborting due to QA concerns: there are files installed outside the prefix` when emerging `net-libs/grpc`.

This PR should fix this.