### PR TITLE
app-doc/linkers-and-loaders: EAPI=7 update, use HTTPS

### DIFF
--- a/app-doc/linkers-and-loaders/linkers-and-loaders-1-r1.ebuild
+++ b/app-doc/linkers-and-loaders/linkers-and-loaders-1-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="The Linkers and Loaders book"
+HOMEPAGE="https://linker.iecc.com/"
+SRC_URI="https://wh0rd.org/books/${P}.tar.lzma"
+
+LICENSE="all-rights-reserved"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="doc"
+RESTRICT="mirror bindist"
+
+BDEPEND="app-arch/xz-utils"
+
+S=${WORKDIR}
+
+src_install() {
+	use doc && dodoc *.txt *.rtf
+	dodoc *.pdf
+	docinto html
+	dodoc *.html *.jpg
+}

--- a/app-doc/linkers-and-loaders/linkers-and-loaders-1.ebuild
+++ b/app-doc/linkers-and-loaders/linkers-and-loaders-1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
 
-DESCRIPTION="the Linkers and Loaders book"
-HOMEPAGE="http://linker.iecc.com/"
-SRC_URI="http://wh0rd.org/books/${P}.tar.lzma"
+DESCRIPTION="The Linkers and Loaders book"
+HOMEPAGE="https://linker.iecc.com/"
+SRC_URI="https://wh0rd.org/books/${P}.tar.lzma"
 
 LICENSE="all-rights-reserved"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR updates app-doc/linkers-and-loaders for EAPI=7 and uses HTTPS.
