### PR TITLE
dev-libs/libidmef: EAPI=7 update

### DIFF
--- a/dev-libs/libidmef/libidmef-1.0.3-r1.ebuild
+++ b/dev-libs/libidmef/libidmef-1.0.3-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Implementation of the IDMEF XML draft"
+HOMEPAGE="https://sourceforge.net/projects/libidmef/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug static-libs"
+
+DEPEND=">=dev-libs/libxml2-2.5.10"
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/${PN}"
+
+src_configure() {
+	econf \
+		$(use_enable debug) \
+		$(use_enable static-libs static)
+}


### PR DESCRIPTION
Hi,

This PR updates dev-libs/libidmef for EAPI=7.

Closes: https://bugs.gentoo.org/685218
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

```diff
--- libidmef-1.0.3.ebuild       2017-03-19 10:57:11.389786353 +0100
+++ libidmef-1.0.3-r1.ebuild    2019-05-06 20:24:48.884992277 +0200
@@ -1,9 +1,7 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
-
-inherit eutils
+EAPI=7
 
 DESCRIPTION="Implementation of the IDMEF XML draft"
 HOMEPAGE="https://sourceforge.net/projects/libidmef/"
@@ -19,8 +17,6 @@
 
 S="${WORKDIR}/${PN}"
 
-DOCS=( AUTHORS ChangeLog FAQ NEWS README TODO )
-
 src_configure() {
        econf \
                $(use_enable debug) \
```