### PR TITLE
net-misc/iputils: fix compilation, missing docbook-xsl-ns-stylesheets

### DIFF
--- a/net-misc/iputils/iputils-99999999.ebuild
+++ b/net-misc/iputils/iputils-99999999.ebuild
@@ -68,6 +68,7 @@ if [[ ${PV} == "99999999" ]] ; then
 		app-text/docbook-xml-dtd:4.5
 		app-text/docbook-xsl-ns-stylesheets
 		app-text/docbook-xsl-stylesheets
+		app-text/docbook-xsl-ns-stylesheets
 		dev-libs/libxslt:0
 	"
 fi


### PR DESCRIPTION
Add dependency on app-text/docbook-xsl-ns-stylesheets required for
build.

Signed-off-by: David Heidelberg <david@ixit.cz>