### PR TITLE
sys-libs/readline: fix HOMEPAGE, use HTTPS

### DIFF
--- a/sys-libs/readline/readline-4.3_p5.ebuild
+++ b/sys-libs/readline/readline-4.3_p5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # This version is just for the ABI .4 library
@@ -29,7 +29,7 @@ patches() {
 }
 
 DESCRIPTION="Another cute console display library"
-HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
+HOMEPAGE="https://tiswww.case.edu/php/chet/readline/rltop.html"
 SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz $(patches)"
 
 LICENSE="GPL-2"

--- a/sys-libs/readline/readline-5.2_p14.ebuild
+++ b/sys-libs/readline/readline-5.2_p14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # This version is just for the ABI .5 library
@@ -29,7 +29,7 @@ patches() {
 }
 
 DESCRIPTION="Another cute console display library"
-HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
+HOMEPAGE="https://tiswww.case.edu/php/chet/readline/rltop.html"
 SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz $(patches)"
 
 LICENSE="GPL-2"

--- a/sys-libs/readline/readline-6.3_p8-r3.ebuild
+++ b/sys-libs/readline/readline-6.3_p8-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -28,7 +28,7 @@ patches() {
 }
 
 DESCRIPTION="Another cute console display library"
-HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
+HOMEPAGE="https://tiswww.case.edu/php/chet/readline/rltop.html"
 SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz $(patches)"
 
 LICENSE="GPL-3"

--- a/sys-libs/readline/readline-7.0_p3-r1.ebuild
+++ b/sys-libs/readline/readline-7.0_p3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -28,7 +28,7 @@ patches() {
 }
 
 DESCRIPTION="Another cute console display library"
-HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
+HOMEPAGE="https://tiswww.case.edu/php/chet/readline/rltop.html"
 
 case ${PV} in
 	*_alpha*|*_beta*|*_rc*)

--- a/sys-libs/readline/readline-7.0_p3.ebuild
+++ b/sys-libs/readline/readline-7.0_p3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -28,7 +28,7 @@ patches() {
 }
 
 DESCRIPTION="Another cute console display library"
-HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
+HOMEPAGE="https://tiswww.case.edu/php/chet/readline/rltop.html"
 case ${PV} in
 *_alpha*|*_beta*|*_rc*) SRC_URI+=" ftp://ftp.cwru.edu/pub/bash/${MY_P}.tar.gz" ;;
 *) SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz $(patches)" ;;

--- a/sys-libs/readline/readline-7.0_p5.ebuild
+++ b/sys-libs/readline/readline-7.0_p5.ebuild
@@ -28,7 +28,7 @@ patches() {
 }
 
 DESCRIPTION="Another cute console display library"
-HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
+HOMEPAGE="https://tiswww.case.edu/php/chet/readline/rltop.html"
 
 case ${PV} in
 	*_alpha*|*_beta*|*_rc*)

--- a/sys-libs/readline/readline-8.0.ebuild
+++ b/sys-libs/readline/readline-8.0.ebuild
@@ -28,7 +28,7 @@ patches() {
 }
 
 DESCRIPTION="Another cute console display library"
-HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
+HOMEPAGE="https://tiswww.case.edu/php/chet/readline/rltop.html"
 
 case ${PV} in
 	*_alpha*|*_beta*|*_rc*)


### PR DESCRIPTION
hi,

this fixes the HOMEPAGE of sys-libs/readline and also uses HTTPS.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>