### PR TITLE
dev-python/css-parser: add Python3.7 support, EAPI=7

### DIFF
--- a/dev-python/css-parser/css-parser-1.0.4-r1.ebuild
+++ b/dev-python/css-parser/css-parser-1.0.4-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python{2_7,3_{5,6,7}} pypy )
+
+inherit distutils-r1
+
+DESCRIPTION="A CSS Cascading Style Sheets library (fork of cssutils)"
+HOMEPAGE="https://pypi.org/project/css-parser/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="LGPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+
+BDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"


### PR DESCRIPTION
- Bumped to `EAPI=7`
- Added python3.7 support
- changed `dev-python/setuptools` to be in `BDEPEND` instead of `RDEPEND`
- removed `python_prepare_all` as it automatically calls `distutils-r1_python_prepare_all` (tested).

Package-Manager: Portage-2.3.66, Repoman-2.3.12