### PR TITLE
media-video/mpv: fix vulkan USE flag in version 9999.

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -99,6 +99,7 @@ COMMON_DEPEND="
 	vulkan? (
 		media-libs/shaderc
 		media-libs/vulkan-loader[X?,wayland?]
+		>=media-libs/libplacebo-1.18.0[vulkan]
 	)
 	wayland? (
 		>=dev-libs/wayland-1.6.0


### PR DESCRIPTION
Now requires a (newer) version of media-libs/libplacebo as well.

Package-Manager: Portage-2.3.66, Repoman-2.3.12

Signed-off-by: Mihai Moldovan <ionic@ionic.de>