### PR TITLE
{sys-devel/gcc,dev-lang/gnat-gpl}: add a USE for building GCC with LTO

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -174,6 +174,7 @@ if [[ ${PN} != "kgcc64" && ${PN} != gcc-* ]] ; then
 	tc_version_is_at_least 8.0 &&
 		IUSE+=" systemtap" TC_FEATURES+=(systemtap)
 	tc_version_is_at_least 9.0 && IUSE+=" d"
+	tc_version_is_at_least 9.1 && IUSE+=" lto"
 fi
 
 SLOT="${GCC_CONFIG_VER}"
@@ -991,6 +992,11 @@ toolchain_src_configure() {
 	# going to link in -lrt to all C++ apps.  #411681
 	if tc_version_is_at_least 4.4 && is_cxx ; then
 		confgcc+=( --enable-libstdcxx-time )
+	fi
+
+	# Build compiler using LTO
+	if tc_version_is_at_least 9.1 && use_if_iuse lto ; then
+		confgcc+=( --with-build-config=bootstrap-lto )
 	fi
 
 	# Support to disable pch when building libstdcxx

--- a/sys-devel/gcc/metadata.xml
+++ b/sys-devel/gcc/metadata.xml
@@ -21,6 +21,7 @@
       This will slow down the compiler a bit as it forces all of the toolchain to be shared libs.</flag>
     <flag name="libssp">Build SSP support into a dedicated library rather than use the
       code in the C library (DO NOT ENABLE THIS IF YOU DON'T KNOW WHAT IT DOES)</flag>
+    <flag name="lto">Build using Link Time Optimizations (LTO)</flag>
     <flag name="mpx">Enable support for Intel Memory Protection Extensions (MPX)</flag>
     <flag name="mudflap">Add support for mudflap, a pointer use checking library</flag>
     <flag name="nopie">Disable PIE support (NOT FOR GENERAL USE)</flag>


### PR DESCRIPTION
GCC as of version 4.4 supports building itself with Link Time Optimizations enabled. Since the infrastructure was already present in toolchain.eclass, I simply modified it to expose the functionality via the `lto` USE flag. A check is present to ensure that GCC is new enough to enable this functionality.

Ping @gentoo/toolchain

Package-Manager: Portage-2.3.66, Repoman-2.3.12