### PR TITLE
dev-java/openjdk: SLOT 8: fix build with newer compilers

### DIFF
--- a/dev-java/openjdk/files/openjdk-8-hotspot-support-COMPILER_WARNINGS_FATAL-on-linux.patch
+++ b/dev-java/openjdk/files/openjdk-8-hotspot-support-COMPILER_WARNINGS_FATAL-on-linux.patch
@@ -1,0 +1,28 @@
+diff -pNur a/make/linux/makefiles/adlc.make b/make/linux/makefiles/adlc.make
+--- a/make/linux/makefiles/adlc.make	2019-04-01 14:24:58.000000000 +0200
++++ b/make/linux/makefiles/adlc.make	2019-05-09 13:51:11.777089942 +0200
+@@ -66,7 +66,9 @@ CXXFLAGS += -DASSERT
+ 
+ # CFLAGS_WARN holds compiler options to suppress/enable warnings.
+ # Compiler warnings are treated as errors
+-CFLAGS_WARN = $(WARNINGS_ARE_ERRORS)
++ifneq ($(COMPILER_WARNINGS_FATAL),false)
++  CFLAGS_WARN = $(WARNINGS_ARE_ERRORS)
++endif
+ CFLAGS += $(CFLAGS_WARN)
+ 
+ OBJECTNAMES = \
+diff -pNur a/make/linux/makefiles/gcc.make b/make/linux/makefiles/gcc.make
+--- a/make/linux/makefiles/gcc.make	2019-04-01 14:24:58.000000000 +0200
++++ b/make/linux/makefiles/gcc.make	2019-05-09 13:53:03.268563373 +0200
+@@ -201,7 +201,9 @@ else
+ endif
+ 
+ # Compiler warnings are treated as errors
+-WARNINGS_ARE_ERRORS = -Werror
++ifneq ($(COMPILER_WARNINGS_FATAL),false)
++  WARNINGS_ARE_ERRORS = -Werror
++endif
+ 
+ ifeq ($(USE_CLANG), true)
+   # However we need to clean the code up before we can unrestrictedly enable this option with Clang

--- a/dev-java/openjdk/files/openjdk-8-pass-COMPILER_WARNINGS_FATAL-down.patch
+++ b/dev-java/openjdk/files/openjdk-8-pass-COMPILER_WARNINGS_FATAL-down.patch
@@ -1,0 +1,61 @@
+diff -pNur jdk8u-jdk8u212-b03-orig/common/autoconf/configure.ac jdk8u-jdk8u212-b03/common/autoconf/configure.ac
+--- jdk8u-jdk8u212-b03-orig/common/autoconf/configure.ac	2019-05-09 13:06:18.546906385 +0200
++++ jdk8u-jdk8u212-b03/common/autoconf/configure.ac	2019-05-09 13:08:09.423356712 +0200
+@@ -188,6 +188,7 @@ PLATFORM_SETUP_OPENJDK_TARGET_BITS
+ PLATFORM_SETUP_OPENJDK_TARGET_ENDIANNESS
+ 
+ # Configure flags for the tools
++FLAGS_SETUP_WARNINGS
+ FLAGS_SETUP_COMPILER_FLAGS_FOR_LIBS
+ FLAGS_SETUP_COMPILER_FLAGS_FOR_OPTIMIZATION
+ FLAGS_SETUP_COMPILER_FLAGS_FOR_JDK
+diff -pNur jdk8u-jdk8u212-b03-orig/common/autoconf/flags.m4 jdk8u-jdk8u212-b03/common/autoconf/flags.m4
+--- jdk8u-jdk8u212-b03-orig/common/autoconf/flags.m4	2019-05-09 13:06:18.546906385 +0200
++++ jdk8u-jdk8u212-b03/common/autoconf/flags.m4	2019-05-09 13:08:09.423356712 +0200
+@@ -220,6 +220,34 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAG
+   # of the target platform.
+ ])
+ 
++AC_DEFUN([FLAGS_SETUP_WARNINGS],
++[
++  AC_ARG_ENABLE([warnings-as-errors], [AS_HELP_STRING([--disable-warnings-as-errors],
++      [do not consider native warnings to be an error @<:@enabled@:>@])])
++
++  # Set default value.
++  if test "x$TOOLCHAIN_TYPE" = xxlc; then
++    COMPILER_WARNINGS_FATAL=false
++  else
++    COMPILER_WARNINGS_FATAL=true
++  fi
++
++  AC_MSG_CHECKING([if native warnings are errors])
++  if test "x$enable_warnings_as_errors" = "xyes"; then
++    AC_MSG_RESULT([yes (explicitly set)])
++    COMPILER_WARNINGS_FATAL=true
++  elif test "x$enable_warnings_as_errors" = "xno"; then
++    AC_MSG_RESULT([no (explicitly set)])
++    COMPILER_WARNINGS_FATAL=false
++  elif test "x$enable_warnings_as_errors" = "x"; then
++    AC_MSG_RESULT([${COMPILER_WARNINGS_FATAL} (default)])
++  else
++    AC_MSG_ERROR([--enable-warnings-as-errors accepts no argument])
++  fi
++
++  AC_SUBST(COMPILER_WARNINGS_FATAL)
++])
++
+ # Documentation on common flags used for solstudio in HIGHEST.
+ #
+ # WARNING: Use of OPTIMIZATION_LEVEL=HIGHEST in your Makefile needs to be
+diff -pNur jdk8u-jdk8u212-b03-orig/common/autoconf/spec.gmk.in jdk8u-jdk8u212-b03/common/autoconf/spec.gmk.in
+--- jdk8u-jdk8u212-b03-orig/common/autoconf/spec.gmk.in	2019-05-09 13:06:18.546906385 +0200
++++ jdk8u-jdk8u212-b03/common/autoconf/spec.gmk.in	2019-05-09 13:08:09.424356716 +0200
+@@ -351,6 +351,8 @@ CXX_O_FLAG_NONE:=@CXX_O_FLAG_NONE@
+ C_FLAG_DEPS:=@C_FLAG_DEPS@
+ CXX_FLAG_DEPS:=@CXX_FLAG_DEPS@
+ 
++COMPILER_WARNINGS_FATAL:=@COMPILER_WARNINGS_FATAL@
++
+ # Tools that potentially need to be cross compilation aware.
+ CC:=@FIXPATH@ @CCACHE@ @CC@
+ 

--- a/dev-java/openjdk/openjdk-8.202_p08.ebuild
+++ b/dev-java/openjdk/openjdk-8.202_p08.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit check-reqs eapi7-ver flag-o-matic java-pkg-2 java-vm-2 multiprocessing pax-utils toolchain-funcs
+inherit check-reqs eapi7-ver flag-o-matic java-pkg-2 java-vm-2 multiprocessing pax-utils toolchain-funcs autotools
 
 MY_PV=$(ver_rs 1 'u' 2 '-' ${PV//p/b})
 
@@ -73,6 +73,10 @@ PDEPEND="webstart? ( >=dev-java/icedtea-web-1.6.1:0 )
 
 S="${WORKDIR}/jdk${SLOT}u-jdk${MY_PV}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-${SLOT}-pass-COMPILER_WARNINGS_FATAL-down.patch"
+)
+
 # The space required to build varies wildly depending on USE flags,
 # ranging from 2GB to 16GB. This function is certainly not exact but
 # should be close enough to be useful.
@@ -136,6 +140,11 @@ src_prepare() {
 
 	# linux 5 is ok https://bugs.gentoo.org/679506
 	sed -i '/^SUPPORTED_OS_VERSION/ s/ 4%/ 4% 5%/' hotspot/make/linux/Makefile || die
+
+	( cd hotspot && eapply -p1 "${FILESDIR}/${PN}-${SLOT}-hotspot-support-COMPILER_WARNINGS_FATAL-on-linux.patch" )
+
+	# Regenerate configure script.
+	bash common/autoconf/autogen.sh
 }
 
 src_configure() {
@@ -144,8 +153,6 @@ src_configure() {
 
 	# Work around stack alignment issue, bug #647954.
 	use x86 && append-flags -mincoming-stack-boundary=2
-
-	append-flags -Wno-error
 
 	local myconf=(
 			--disable-ccache
@@ -163,6 +170,7 @@ src_configure() {
 			--with-milestone="gentoo"
 			--with-zlib=system
 			--with-native-debug-symbols=$(usex debug internal none)
+			--disable-warnings-as-errors
 			$(usex headless-awt --disable-headful '')
 		)
 


### PR DESCRIPTION
The bundled hotspot version in openjdk:8 appends -Werror in a hardcoded
fashion *after* any user- (or system-) provided compiler flags.

Newer versions of GCC choke on the code.

Extend the build system by the artifact that used to be
COMPILER_WARNINGS_FATAL, guard the sections hardcoding -Werror with it,
add a new configure flag called --disable-warnings-as-errors (and hence
also regenerate configure) and use that new configure flag to finally
disable -Werror again.

Backporting a complete solution from openjdk:11 does not make sense in
this case, since openjdk:8 is essentially on life support with no big
changes expected.

Closes: https://bugs.gentoo.org/685426

Package-Manager: Portage-2.3.66, Repoman-2.3.12

Signed-off-by: Mihai Moldovan <ionic@ionic.de>