### PR TITLE
x11-apps/igt-gpu-tools: update USE flags after the Meson switch

### DIFF
--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Denis Lisov <dennis.lissov@gmail.com> (09 May 2019)
+# Overlay can only be built on amd64 and x86
+x11-apps/igt-gpu-tools -overlay
+
 # Sergei Trofimovich <slyfox@gentoo.org> (16 Mar 2019)
 # sys-block/megactl works on x86 and amd64
 www-apps/phpsysinfo -megactl

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Denis Lisov <dennis.lissov@gmail.com> (09 May 2019)
+# Overlay can only be built on amd64 and x86
+x11-apps/igt-gpu-tools overlay
+
 # Sergei Trofimovich <slyfox@gentoo.org> (16 Mar 2019)
 # sys-block/megactl works only on amd64 and x86 so far, bug #670564
 www-apps/phpsysinfo megactl

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -3,6 +3,10 @@
 
 # This file requires >=portage-2.1.1
 
+# Denis Lisov <dennis.lissov@gmail.com> (09 May 2019)
+# Overlay can only be built on amd64 and x86
+x11-apps/igt-gpu-tools -overlay
+
 # Sergei Trofimovich <slyfox@gentoo.org> (16 Mar 2019)
 # sys-block/megactl works on x86 and amd64
 www-apps/phpsysinfo -megactl

--- a/profiles/base/package.use.force
+++ b/profiles/base/package.use.force
@@ -24,12 +24,6 @@ net-misc/netkit-bootparamd libtirpc
 sci-astronomy/esomidas libtirpc
 sys-cluster/glusterfs libtirpc
 
-# Matt Turner <mattst88@gentoo.org> (13 Jun 2018)
-# Upstream is transitioning to Meson, but does not yet have any configuration
-# options. Until those configuration options are provided, force USE flags on
-# to avoid automagic deps.
->=x11-apps/igt-gpu-tools-1.23 alsa chamelium doc glib gsl sound valgrind video_cards_amdgpu video_cards_intel video_cards_nouveau X xrandr xv
-
 # NP-Hardass <NP-Hardass@gentoo.org> (10 Apr 2017)
 # Always force patch on appropriate variant to ensure
 # similar experience when using app-emulation/wine-any

--- a/x11-apps/igt-gpu-tools/igt-gpu-tools-1.23-r1.ebuild
+++ b/x11-apps/igt-gpu-tools/igt-gpu-tools-1.23-r1.ebuild
@@ -20,7 +20,7 @@ else
 fi
 LICENSE="MIT"
 SLOT="0"
-IUSE="chamelium doc man overlay runner unwind valgrind video_cards_amdgpu video_cards_intel video_cards_nouveau X xv"
+IUSE="chamelium doc man overlay sound valgrind video_cards_amdgpu video_cards_intel video_cards_nouveau X xv"
 REQUIRED_USE="
 	|| ( video_cards_amdgpu video_cards_intel video_cards_nouveau )
 	overlay? (
@@ -31,8 +31,8 @@ REQUIRED_USE="
 RESTRICT="test"
 
 RDEPEND="
-	dev-libs/elfutils
 	dev-libs/glib:2
+	dev-libs/openssl:=
 	sys-apps/kmod:=
 	sys-libs/libunwind:=
 	sys-libs/zlib:=
@@ -41,11 +41,10 @@ RDEPEND="
 	>=x11-libs/cairo-1.12.0[X?]
 	>=x11-libs/libdrm-2.4.82[video_cards_amdgpu?,video_cards_intel?,video_cards_nouveau?]
 	>=x11-libs/libpciaccess-0.10
-	x11-libs/pixman
 	chamelium? (
-		dev-libs/xmlrpc-c[curl]
+		dev-libs/xmlrpc-c
 		sci-libs/gsl
-		media-libs/alsa-lib:=
+		x11-libs/pixman
 	)
 	overlay? (
 		>=x11-libs/libXrandr-1.3
@@ -55,8 +54,10 @@ RDEPEND="
 			x11-libs/libXv
 		)
 	)
-	runner? ( dev-libs/json-c:= )
-	unwind? ( sys-libs/libunwind )
+	sound? (
+		sci-libs/gsl
+		media-libs/alsa-lib:=
+	)
 	valgrind? ( dev-util/valgrind )
 	"
 DEPEND="${RDEPEND}
@@ -73,7 +74,8 @@ DEPEND="${RDEPEND}
 "
 
 src_prepare() {
-	sed -e "s/find_program('rst2man-3'/find_program('rst2man.py', 'rst2man-3'/" -i man/meson.build
+	sed -e "s/rst2man/rst2man.py/" -i man/rst2man.sh
+	sed -e "s/find_program('rst2man'/find_program('rst2man.py'/" -i man/meson.build
 	default_src_prepare
 }
 
@@ -88,15 +90,14 @@ src_configure() {
 	use overlay && use X && overlay_backends+="x,"
 
 	local emesonargs=(
+		-Dbuild_audio=$(usex sound true false)
 		-Dbuild_chamelium=$(usex chamelium true false)
 		-Dbuild_docs=$(usex doc true false)
 		-Dbuild_man=$(usex man true false)
 		-Dbuild_overlay=$(usex overlay true false)
-		-Dbuild_runner=$(usex runner true false)
 		-Dbuild_tests=$(usex doc true false) # Test build is required for docs
 		-Doverlay_backends=${overlay_backends%?}
 		-Dwith_libdrm=${gpus%?}
-		-Dwith_libunwind=$(usex unwind true false)
 		-Dwith_valgrind=$(usex valgrind true false)
 	)
 	meson_src_configure

--- a/x11-apps/igt-gpu-tools/metadata.xml
+++ b/x11-apps/igt-gpu-tools/metadata.xml
@@ -8,7 +8,12 @@
 <use>
  <flag name="chamelium">Enables support for building Chamelium tests</flag>
  <flag name="glib">Support reading config files via glib helpers</flag>
+ <flag name="man">Build and install man pages</flag>
+ <flag name="overlay">Build the intel-gpu-overlay utility</flag>
+ <flag name="runner">Build the test runner</flag>
  <flag name="valgrind">Support valgrind annotations</flag>
  <flag name="xrandr">Enable support for the X RandR extension</flag>
+ <flag name="xv">Enable intel-gpu-overlay xv backend</flag>
+ <flag name="X">Enable intel-gpu-overlay xlib/cairo backend</flag>
 </use>
 </pkgmetadata>


### PR DESCRIPTION
Initially the igt-gpu-tools meson build system had all dependencies mandatory so all USE flags were forced on. The configurability had already been restored by the time 1.23 was released.

This commit restores the ability to disable optional dependencies (such as VIDEO_CARDS values you don't need otherwise) and restructures the USE flags from dependency-based (alsa, gsl, xrandr) to feature-based (sound, overlay). The 1.23 flags match the Meson configuration in 1.23, the 9999 flags match the master branch as of today.

Future questions:
- [ ] The overlay's xlib backend has no additional dependencies over xv. Should it be configurable or always enabled if overlay is enabled?
- [ ] Upstream specifically checks in git master that the user does not build with NDEBUG. Should the ebuild filter `-DNDEBUG` out from `CFLAGS`, do something else or just ignore this for now?