### PR TITLE
media-tv/v4l-utils: use HTTPS

### DIFF
--- a/media-tv/v4l-utils/v4l-utils-1.10.1.ebuild
+++ b/media-tv/v4l-utils/v4l-utils-1.10.1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit eutils flag-o-matic udev
 
 DESCRIPTION="Separate utilities ebuild from upstream v4l-utils package"
-HOMEPAGE="http://git.linuxtv.org/v4l-utils.git"
-SRC_URI="http://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
+HOMEPAGE="https://git.linuxtv.org/v4l-utils.git"
+SRC_URI="https://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"

--- a/media-tv/v4l-utils/v4l-utils-1.12.3.ebuild
+++ b/media-tv/v4l-utils/v4l-utils-1.12.3.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit eutils flag-o-matic udev
 
 DESCRIPTION="Separate utilities ebuild from upstream v4l-utils package"
-HOMEPAGE="http://git.linuxtv.org/v4l-utils.git"
-SRC_URI="http://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
+HOMEPAGE="https://git.linuxtv.org/v4l-utils.git"
+SRC_URI="https://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"

--- a/media-tv/v4l-utils/v4l-utils-1.12.5.ebuild
+++ b/media-tv/v4l-utils/v4l-utils-1.12.5.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit eutils flag-o-matic udev
 
 DESCRIPTION="Separate utilities ebuild from upstream v4l-utils package"
-HOMEPAGE="http://git.linuxtv.org/v4l-utils.git"
-SRC_URI="http://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
+HOMEPAGE="https://git.linuxtv.org/v4l-utils.git"
+SRC_URI="https://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"

--- a/media-tv/v4l-utils/v4l-utils-1.14.1.ebuild
+++ b/media-tv/v4l-utils/v4l-utils-1.14.1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit flag-o-matic udev xdg-utils
 
 DESCRIPTION="Separate utilities ebuild from upstream v4l-utils package"
-HOMEPAGE="http://git.linuxtv.org/v4l-utils.git"
-SRC_URI="http://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
+HOMEPAGE="https://git.linuxtv.org/v4l-utils.git"
+SRC_URI="https://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"

--- a/media-tv/v4l-utils/v4l-utils-1.16.3-r1.ebuild
+++ b/media-tv/v4l-utils/v4l-utils-1.16.3-r1.ebuild
@@ -5,8 +5,8 @@ EAPI=7
 inherit flag-o-matic udev xdg-utils
 
 DESCRIPTION="Separate utilities ebuild from upstream v4l-utils package"
-HOMEPAGE="http://git.linuxtv.org/v4l-utils.git"
-SRC_URI="http://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
+HOMEPAGE="https://git.linuxtv.org/v4l-utils.git"
+SRC_URI="https://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"

--- a/media-tv/v4l-utils/v4l-utils-1.16.3.ebuild
+++ b/media-tv/v4l-utils/v4l-utils-1.16.3.ebuild
@@ -5,8 +5,8 @@ EAPI=7
 inherit flag-o-matic udev xdg-utils
 
 DESCRIPTION="Separate utilities ebuild from upstream v4l-utils package"
-HOMEPAGE="http://git.linuxtv.org/v4l-utils.git"
-SRC_URI="http://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
+HOMEPAGE="https://git.linuxtv.org/v4l-utils.git"
+SRC_URI="https://linuxtv.org/downloads/v4l-utils/${P}.tar.bz2"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"


### PR DESCRIPTION
Hi,

This updates media-tv/v4l-utils to use https instead of http.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>