### PR TITLE
media-video/smplayer: use HTTPS

### DIFF
--- a/media-video/smplayer/smplayer-18.10.0.ebuild
+++ b/media-video/smplayer/smplayer-18.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ PLOCALE_BACKUP="en_US"
 inherit gnome2-utils l10n qmake-utils toolchain-funcs xdg-utils
 
 DESCRIPTION="Great Qt GUI front-end for mplayer/mpv"
-HOMEPAGE="http://www.smplayer.eu/"
+HOMEPAGE="https://www.smplayer.eu/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2+ BSD-2"

--- a/media-video/smplayer/smplayer-18.6.0.ebuild
+++ b/media-video/smplayer/smplayer-18.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ PLOCALE_BACKUP="en_US"
 inherit gnome2-utils l10n qmake-utils toolchain-funcs xdg-utils
 
 DESCRIPTION="Great Qt GUI front-end for mplayer/mpv"
-HOMEPAGE="http://www.smplayer.eu/"
+HOMEPAGE="https://www.smplayer.eu/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2+ BSD-2"

--- a/media-video/smplayer/smplayer-19.1.0-r1.ebuild
+++ b/media-video/smplayer/smplayer-19.1.0-r1.ebuild
@@ -11,7 +11,7 @@ PLOCALE_BACKUP="en_US"
 inherit l10n qmake-utils toolchain-funcs xdg
 
 DESCRIPTION="Great Qt GUI front-end for mplayer/mpv"
-HOMEPAGE="http://www.smplayer.eu/"
+HOMEPAGE="https://www.smplayer.eu/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2+ BSD-2"

--- a/media-video/smplayer/smplayer-19.1.0.ebuild
+++ b/media-video/smplayer/smplayer-19.1.0.ebuild
@@ -11,7 +11,7 @@ PLOCALE_BACKUP="en_US"
 inherit gnome2-utils l10n qmake-utils toolchain-funcs xdg-utils
 
 DESCRIPTION="Great Qt GUI front-end for mplayer/mpv"
-HOMEPAGE="http://www.smplayer.eu/"
+HOMEPAGE="https://www.smplayer.eu/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2+ BSD-2"


### PR DESCRIPTION
Hi,

This fixes media-video/smplayer to use https instead of http.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>