### PR TITLE
net-analyzer/scapy: update HOMEPAGE, use HTTPS

### DIFF
--- a/net-analyzer/scapy/scapy-2.3.2-r1.ebuild
+++ b/net-analyzer/scapy/scapy-2.3.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit eutils distutils-r1
 
 DESCRIPTION="A Python interactive packet manipulation program for mastering the network"
-HOMEPAGE="http://www.secdev.org/projects/scapy/"
+HOMEPAGE="https://scapy.net/ https://github.com/secdev/scapy"
 SRC_URI="https://github.com/secdev/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-analyzer/scapy/scapy-2.4.0.ebuild
+++ b/net-analyzer/scapy/scapy-2.4.0.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python{2_7,3_{5,6}} )
 inherit distutils-r1 readme.gentoo-r1
 
 DESCRIPTION="A Python interactive packet manipulation program for mastering the network"
-HOMEPAGE="http://www.secdev.org/projects/scapy/ https://github.com/secdev/scapy"
+HOMEPAGE="https://scapy.net/ https://github.com/secdev/scapy"
 SRC_URI="https://github.com/secdev/${PN}/archive/v${PV/_/}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-analyzer/scapy/scapy-2.4.2.ebuild
+++ b/net-analyzer/scapy/scapy-2.4.2.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python{2_7,3_{5,6,7}} )
 inherit distutils-r1 readme.gentoo-r1
 
 DESCRIPTION="A Python interactive packet manipulation program for mastering the network"
-HOMEPAGE="http://www.secdev.org/projects/scapy/ https://github.com/secdev/scapy"
+HOMEPAGE="https://scapy.net/ https://github.com/secdev/scapy"
 SRC_URI="https://github.com/secdev/${PN}/archive/v${PV/_/}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-analyzer/scapy/scapy-9999.ebuild
+++ b/net-analyzer/scapy/scapy-9999.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python{2_7,3_{5,6}} )
 inherit distutils-r1 git-r3 readme.gentoo-r1
 
 DESCRIPTION="A Python interactive packet manipulation program for mastering the network"
-HOMEPAGE="http://www.secdev.org/projects/scapy/ https://github.com/secdev/scapy"
+HOMEPAGE="https://scapy.net/ https://github.com/secdev/scapy"
 EGIT_REPO_URI="https://github.com/secdev/${PN}"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This fixes net-analyzer/scapy to use https instead http.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>