### PR TITLE
net-mail/offlineimap: use HTTPS

### DIFF
--- a/net-mail/offlineimap/offlineimap-6.5.6.ebuild
+++ b/net-mail/offlineimap/offlineimap-6.5.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ PYTHON_REQ_USE="threads,sqlite?,ssl?"
 inherit eutils distutils-r1
 
 DESCRIPTION="Powerful IMAP/Maildir synchronization and reader support"
-HOMEPAGE="http://offlineimap.org"
+HOMEPAGE="https://www.offlineimap.org/"
 SRC_URI="https://github.com/OfflineIMAP/${PN}/tarball/v${PV} -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-mail/offlineimap/offlineimap-6.7.0.3.ebuild
+++ b/net-mail/offlineimap/offlineimap-6.7.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ PYTHON_REQ_USE="threads,sqlite?,ssl?"
 inherit distutils-r1
 
 DESCRIPTION="Powerful IMAP/Maildir synchronization and reader support"
-HOMEPAGE="http://offlineimap.org"
+HOMEPAGE="https://www.offlineimap.org/"
 SRC_URI="https://github.com/OfflineIMAP/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-mail/offlineimap/offlineimap-7.1.5.ebuild
+++ b/net-mail/offlineimap/offlineimap-7.1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ PYTHON_REQ_USE="threads,sqlite,ssl?"
 inherit distutils-r1
 
 DESCRIPTION="Powerful IMAP/Maildir synchronization and reader support"
-HOMEPAGE="http://offlineimap.org"
+HOMEPAGE="https://www.offlineimap.org/"
 SRC_URI="https://github.com/OfflineIMAP/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-mail/offlineimap/offlineimap-7.2.1.ebuild
+++ b/net-mail/offlineimap/offlineimap-7.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ PYTHON_REQ_USE="threads,sqlite,ssl?"
 inherit distutils-r1
 
 DESCRIPTION="Powerful IMAP/Maildir synchronization and reader support"
-HOMEPAGE="http://offlineimap.org"
+HOMEPAGE="https://www.offlineimap.org/"
 SRC_URI="https://github.com/OfflineIMAP/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-mail/offlineimap/offlineimap-7.2.2.ebuild
+++ b/net-mail/offlineimap/offlineimap-7.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ PYTHON_REQ_USE="threads,sqlite,ssl?"
 inherit distutils-r1
 
 DESCRIPTION="Powerful IMAP/Maildir synchronization and reader support"
-HOMEPAGE="http://offlineimap.org"
+HOMEPAGE="https://www.offlineimap.org/"
 SRC_URI="https://github.com/OfflineIMAP/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This fixes net-mail/offlineimap to use https instead of http.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>