### PR TITLE
gentoo/gentoo net-analyzer/bwping: fix tests with FEATURES=userpriv, fix HOMEPAGE

### DIFF
--- a/net-analyzer/bwping/bwping-1.14.ebuild
+++ b/net-analyzer/bwping/bwping-1.14.ebuild
@@ -4,10 +4,17 @@
 EAPI=7
 
 DESCRIPTION="A tool to measure bandwidth and RTT between two hosts using ICMP"
-HOMEPAGE="https://bwping.sourceforge.net/"
+HOMEPAGE="https://bwping.sourceforge.io/"
 SRC_URI="mirror://sourceforge/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~sparc ~x86 ~x86-fbsd"
-RESTRICT="test"
+
+src_test() {
+	if has userpriv ${FEATURES} ; then
+		ewarn "Test suite is disabled, set FEATURES=-userpriv to enable."
+	else
+		default
+	fi
+}


### PR DESCRIPTION
* Remove RESTRICT="test", check for userpriv in FEATURES instead;
* HTTPS-enabled SourceForge-hosted websites are in .io domain, not in .net, and it seems that .net -> .io redirect doesn't work for them.

Signed-off-by: Oleg Derevenetz oleg.derevenetz@gmail.com
