### PR TITLE
net-im/skypeforlinux: New release now requires libsecret

### DIFF
--- a/net-im/skypeforlinux/skypeforlinux-8.44.0.40-r1.ebuild
+++ b/net-im/skypeforlinux/skypeforlinux-8.44.0.40-r1.ebuild
@@ -25,6 +25,7 @@ RDEPEND="
 		sys-auth/elogind
 		sys-apps/systemd
 	)
+	app-crypt/libsecret[${MULTILIB_USEDEP}]
 	dev-libs/atk[${MULTILIB_USEDEP}]
 	dev-libs/expat[${MULTILIB_USEDEP}]
 	dev-libs/glib:2[${MULTILIB_USEDEP}]


### PR DESCRIPTION
* Add missing dependency on libsecret

Bug: https://bugs.gentoo.org/685528
Package-Manager: Portage-2.3.62, Repoman-2.3.11
Signed-off-by: Gino McCarty <onigino@protonmail.com>