### PR TITLE
www-misc/monitorix: Updated maintainer's email

### DIFF
--- a/www-misc/monitorix/metadata.xml
+++ b/www-misc/monitorix/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>dwosky@zoho.com</email>
+		<email>dwosky@pm.me</email>
 		<name>Pedro Arizmendi</name>
 	</maintainer>
 	<maintainer type="project">


### PR DESCRIPTION
I have an issue with Zoho and it isn't allowing me to send any email to gentoo.org domain, so I'm changing it.

Signed-off-by: Pedro Arizmendi <dwosky@pm.me>
Bug: https://bugs.gentoo.org/632938
Package-Manager: Portage-2.3.62, Repoman-2.3.11