### PR TITLE
app-portage/genlop: Correctly filter sandboxes.

### DIFF
--- a/app-portage/genlop/files/genlop-0.30.10-sandbox.patch
+++ b/app-portage/genlop/files/genlop-0.30.10-sandbox.patch
@@ -1,0 +1,12 @@
+diff -urN genlop-0.30.10.ORIG/genlop genlop-0.30.10/genlop
+--- genlop-0.30.10.ORIG/genlop	2019-05-09 15:11:22.111534471 +0200
++++ genlop-0.30.10/genlop	2019-05-09 15:11:46.377416100 +0200
+@@ -699,7 +699,7 @@
+ 	# not check for sanity and have users check their FEATURES instead.
+ 	my @targets      = ();
+ 	my @sandbox_pids = ();
+-	my @sandbox_procs = qx{ps ax -o pid,args | tail -n +2 | sed -e's/^ *//' | grep ' sandbox ' | grep -v ' grep '};
++	my @sandbox_procs = qx{ps ax -o pid,args | tail -n +2 | sed -e's/^ *//' | grep ' sandbox ' | grep -v 'pid-ns-init ' | grep -v ' grep '};
+ 	my ($e_curmerge, $e_lastmerge);
+ 	foreach (@sandbox_procs)
+ 	{

--- a/app-portage/genlop/genlop-0.30.10-r2.ebuild
+++ b/app-portage/genlop/genlop-0.30.10-r2.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+inherit base bash-completion-r1
+
+DESCRIPTION="A nice emerge.log parser"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Perl"
+SRC_URI="https://dev.gentoo.org/~dilfridge/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd"
+IUSE=""
+
+DEPEND="dev-lang/perl
+	 dev-perl/Date-Manip
+	 dev-perl/libwww-perl"
+RDEPEND="${DEPEND}"
+
+# Populate the patches array for any patches for -rX releases
+PATCHES=( "${FILESDIR}"/${P}-sync.patch "${FILESDIR}"/${P}-sandbox.patch )
+
+src_install() {
+	dobin genlop
+	dodoc README Changelog
+	doman genlop.1
+	newbashcomp genlop.bash-completion genlop
+}


### PR DESCRIPTION
Embed the patch provided by Joe Breuer to fix `genlop -c`.

The underlying cause seems to be that genlop looks for running emerges
by filtering over sandbox processes. A change to portage (or something)
introduced the pid-ns-init process to the call tree, which is also
selected by genlop looking for sandbox processes. This is what causes
each emerge to show up twice - once matched on the pid-ns-init process,
once on the sandbox process itself.

See https://bugs.gentoo.org/677890#c7 for more details.

Closes: https://bugs.gentoo.org/677890
Signed-off-by: Gabriel Linder <linder.gabriel@gmail.com>
Package-Manager: Portage-2.3.62, Repoman-2.3.12