### PR TITLE
media-sound/audiotag: fix LICENSE, EAPI=7 bump

### DIFF
--- a/media-sound/audiotag/audiotag-0.19-r1.ebuild
+++ b/media-sound/audiotag/audiotag-0.19-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit eutils
+
+DESCRIPTION="Command-line tool for mass tagging/renaming of audio files"
+HOMEPAGE="https://github.com/Daenyth/audiotag"
+SRC_URI="https://github.com/downloads/Daenyth/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="dev-lang/perl"
+
+src_install() {
+	dobin ${PN}
+	dodoc ChangeLog README
+}
+
+pkg_postinst() {
+	optfeature "for m4a/mp4 support" media-video/atomicparsley media-video/atomicparsley-wez
+	optfeature "for flac support" media-libs/flac
+	optfeature "for mp3 support" media-libs/id3lib
+	optfeature "for vorbis support" media-sound/vorbis-tools
+}

--- a/media-sound/audiotag/audiotag-0.19.ebuild
+++ b/media-sound/audiotag/audiotag-0.19.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
 
-DESCRIPTION="A command-line tool for mass tagging/renaming of audio files"
+DESCRIPTION="Command-line tool for mass tagging/renaming of audio files"
 HOMEPAGE="https://github.com/Daenyth/audiotag"
 SRC_URI="https://github.com/downloads/Daenyth/${PN}/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ~ppc ppc64 sparc x86"
 IUSE="aac flac mp3 vorbis"


### PR DESCRIPTION
Hi,

This PR updates media-sound/audiotag for EAPI7 and fixes the LICENSE
Please review.