### PR TITLE
x11-apps/igt-gpu-tools: add USE=libressl

### DIFF
--- a/x11-apps/igt-gpu-tools/igt-gpu-tools-1.23-r1.ebuild
+++ b/x11-apps/igt-gpu-tools/igt-gpu-tools-1.23-r1.ebuild
@@ -20,7 +20,7 @@ else
 fi
 LICENSE="MIT"
 SLOT="0"
-IUSE="chamelium doc man overlay sound valgrind video_cards_amdgpu video_cards_intel video_cards_nouveau X xv"
+IUSE="chamelium doc libressl man overlay sound valgrind video_cards_amdgpu video_cards_intel video_cards_nouveau X xv"
 REQUIRED_USE="
 	|| ( video_cards_amdgpu video_cards_intel video_cards_nouveau )
 	overlay? (
@@ -32,7 +32,6 @@ RESTRICT="test"
 
 RDEPEND="
 	dev-libs/glib:2
-	dev-libs/openssl:=
 	sys-apps/kmod:=
 	sys-libs/libunwind:=
 	sys-libs/zlib:=
@@ -46,6 +45,8 @@ RDEPEND="
 		sci-libs/gsl
 		x11-libs/pixman
 	)
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
 	overlay? (
 		>=x11-libs/libXrandr-1.3
 		xv? (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/685812
Package-Manager: Portage-2.3.66, Repoman-2.3.12
Signed-off-by: Stefan Strogin <steils@gentoo.org>