### PR TITLE
sys-fs/dmg2img: add USE=libressl

### DIFF
--- a/sys-fs/dmg2img/dmg2img-1.6.7-r1.ebuild
+++ b/sys-fs/dmg2img/dmg2img-1.6.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,11 +11,12 @@ SRC_URI="http://vu1tur.eu.org/tools/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE=""
+IUSE="libressl"
 
-RDEPEND="dev-libs/openssl:0=
-	app-arch/bzip2
-	sys-libs/zlib"
+RDEPEND="app-arch/bzip2
+	sys-libs/zlib
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )"
 DEPEND="${RDEPEND}"
 
 PATCHES=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/684892
Package-Manager: Portage-2.3.66, Repoman-2.3.12
Signed-off-by: Stefan Strogin <steils@gentoo.org>