### PR TITLE
dev-ruby/rdoc: Drop ruby23

### DIFF
--- a/dev-ruby/rdoc/rdoc-5.1.0.ebuild
+++ b/dev-ruby/rdoc/rdoc-5.1.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-USE_RUBY="ruby23 ruby24"
+USE_RUBY="ruby24"
 
 RUBY_FAKEGEM_TASK_DOC=""
 RUBY_FAKEGEM_DOCDIR="doc"

--- a/dev-ruby/rdoc/rdoc-6.1.1.ebuild
+++ b/dev-ruby/rdoc/rdoc-6.1.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-USE_RUBY="ruby23 ruby24 ruby25 ruby26"
+USE_RUBY="ruby24 ruby25 ruby26"
 
 RUBY_FAKEGEM_TASK_DOC=""
 RUBY_FAKEGEM_DOCDIR="doc"


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/685738

Signed-off by: Paolo Pedroni <paolo.pedroni@iol.it>