### PR TITLE
media-libs/volpack: EAPI=7 update

### DIFF
--- a/media-libs/volpack/volpack-1.0_p7-r1.ebuild
+++ b/media-libs/volpack/volpack-1.0_p7-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MYP=${PN}-${PV/_p/c}
+
+DESCRIPTION="Volume rendering library"
+HOMEPAGE="http://amide.sourceforge.net/packages.html"
+SRC_URI="mirror://sourceforge/amide/${MYP}.tgz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc examples static-libs"
+
+DEPEND="sys-devel/m4"
+
+S="${WORKDIR}/${MYP}"
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_compile() {
+	emake -j1
+}
+
+src_install() {
+	default
+	if use doc; then
+		dodoc doc/*.pdf
+		docinto html
+		dodoc doc/*.html
+	fi
+	if use examples; then
+		insinto /usr/share/doc/${PF}
+		doins -r examples
+	fi
+}


### PR DESCRIPTION
Hi,

Another simple EAPI=7 bump. Please review.


```diff
--- volpack-1.0_p7.ebuild       2017-03-19 10:57:13.516786258 +0100
+++ volpack-1.0_p7-r1.ebuild    2019-05-13 19:49:37.881025958 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
 
 MYP=${PN}-${PV/_p/c}
 
@@ -14,9 +14,7 @@
 KEYWORDS="~amd64 ~x86"
 IUSE="doc examples static-libs"
 
-RDEPEND=""
-DEPEND="${RDEPEND}
-       sys-devel/m4"
+DEPEND="sys-devel/m4"
 
 S="${WORKDIR}/${MYP}"
 
@@ -30,10 +28,13 @@
 
 src_install() {
        default
-       use doc && dodoc doc/*.pdf && dohtml doc/*.html
+       if use doc; then
+               dodoc doc/*.pdf
+               docinto html
+               dodoc doc/*.html
+       fi
        if use examples; then
                insinto /usr/share/doc/${PF}
                doins -r examples
        fi
-
 }
```

Closes: https://bugs.gentoo.org/685882
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>