### PR TITLE
dev-libs/libcaldav: fix LICENSE, EAPI=7 bump

### DIFF
--- a/dev-libs/libcaldav/libcaldav-0.6.2-r1.ebuild
+++ b/dev-libs/libcaldav/libcaldav-0.6.2-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="C library implementing client support for CalDAV"
+HOMEPAGE="http://libcaldav.sourceforge.net/"
+SRC_URI="mirror://sourceforge/libcaldav/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc"
+
+RDEPEND="
+	dev-libs/glib
+	net-misc/curl[ssl,gnutls(+),curl_ssl_gnutls(+)]
+"
+DEPEND="${RDEPEND}
+	doc? (
+		app-doc/doxygen
+		virtual/latex-base
+		dev-texlive/texlive-latexextra
+	)
+"
+
+src_configure() {
+	econf $(use_enable doc)
+}

--- a/dev-libs/libcaldav/libcaldav-0.6.2.ebuild
+++ b/dev-libs/libcaldav/libcaldav-0.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4
@@ -9,7 +9,7 @@ DESCRIPTION="C library implementing client support for CalDAV"
 HOMEPAGE="http://libcaldav.sourceforge.net/"
 SRC_URI="mirror://sourceforge/libcaldav/${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="doc"


### PR DESCRIPTION
Hi,

This PR updates dev-libs/libcaldav for EAPI=7. 
Please review.