### PR TITLE
media-libs/mesa: Add dependency on glslang when enabling vulkan-overlay

### DIFF
--- a/media-libs/mesa/mesa-19.1.0_rc1.ebuild
+++ b/media-libs/mesa/mesa-19.1.0_rc1.ebuild
@@ -123,6 +123,7 @@ RDEPEND="
 		!video_cards_i965? ( ${LIBDRM_DEPSTRING}[video_cards_intel] )
 	)
 	video_cards_i915? ( ${LIBDRM_DEPSTRING}[video_cards_intel] )
+	vulkan-overlay? ( dev-util/glslang:0=[${MULTILIB_USEDEP}] )
 "
 for card in ${RADEON_CARDS}; do
 	RDEPEND="${RDEPEND}

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -123,6 +123,7 @@ RDEPEND="
 		!video_cards_i965? ( ${LIBDRM_DEPSTRING}[video_cards_intel] )
 	)
 	video_cards_i915? ( ${LIBDRM_DEPSTRING}[video_cards_intel] )
+	vulkan-overlay? ( dev-util/glslang:0=[${MULTILIB_USEDEP}] )
 "
 for card in ${RADEON_CARDS}; do
 	RDEPEND="${RDEPEND}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/685490
Signed-off-by: Mike Lothian <mike@fireburn.co.uk>