### PR TITLE
dev-lisp/c2ffi: Clang-based FFI wrapper generator for Common Lisp

### DIFF
--- a/dev-lisp/c2ffi/c2ffi-8.0.0.9999.ebuild
+++ b/dev-lisp/c2ffi/c2ffi-8.0.0.9999.ebuild
@@ -1,0 +1,21 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Clang-based FFI wrapper generator for Common Lisp"
+HOMEPAGE="https://github.com/rpav/c2ffi"
+
+EGIT_REPO_URI="https://github.com/rpav/c2ffi.git"
+EGIT_BRANCH="llvm-8.0.0"
+
+inherit cmake-utils git-r3
+
+LICENSE="LGPL-2.1"
+SLOT="8"
+IUSE=""
+
+DEPEND="sys-devel/llvm:8
+	sys-devel/clang:8
+"
+RDEPEND="${DEPEND}"

--- a/dev-lisp/c2ffi/metadata.xml
+++ b/dev-lisp/c2ffi/metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<maintainer type="person">
+	<email>h.judt@gmx.at</email>
+	<name>Harald Judt</name>
+</maintainer>
+<maintainer type="project">
+	<email>proxy-maint@gentoo.org</email>
+	<name>Proxy Maintainers</name>
+</maintainer>
+<upstream>
+	<remote-id type="github">rpav/c2ffi</remote-id>
+</upstream>
+</pkgmetadata>


### PR DESCRIPTION
dev-lisp/c2ffi-8.0.0.9999: Clang-based FFI wrapper generator for
Common Lisp. This ebuild checks out the appropriate branch from the
github repository.

Signed-off-by: Harald Judt <h.judt@gmx.at>