### PR TITLE
net-vpn/i2pd: 2.25.0 add proxy-maint and bump EAPI

### DIFF
--- a/net-vpn/i2pd/files/i2pd-2.25.0-lib-path.patch
+++ b/net-vpn/i2pd/files/i2pd-2.25.0-lib-path.patch
@@ -1,0 +1,22 @@
+diff --git a/build/CMakeLists.txt b/build/CMakeLists.txt
+index 949f6a46..a6d29990 100644
+--- a/build/CMakeLists.txt
++++ b/build/CMakeLists.txt
+@@ -103,8 +103,6 @@ set_target_properties(libi2pd PROPERTIES PREFIX "")
+ if (WITH_LIBRARY)
+   install(TARGETS libi2pd
+     EXPORT libi2pd
+-    ARCHIVE DESTINATION lib
+-    LIBRARY DESTINATION lib
+     COMPONENT Libraries)
+ # TODO Make libi2pd available to 3rd party projects via CMake as imported target
+ # FIXME This pulls stdafx
+@@ -135,8 +133,6 @@ set_target_properties(libi2pdclient PROPERTIES PREFIX "")
+ if (WITH_LIBRARY)
+   install(TARGETS libi2pdclient
+     EXPORT libi2pdclient
+-    ARCHIVE DESTINATION lib
+-    LIBRARY DESTINATION lib
+     COMPONENT Libraries)
+ endif()
+ 

--- a/net-vpn/i2pd/files/i2pd-2.25.0-link.patch
+++ b/net-vpn/i2pd/files/i2pd-2.25.0-link.patch
@@ -1,0 +1,13 @@
+diff --git a/build/CMakeLists.txt b/build/CMakeLists.txt
+index e50bbc865..949f6a46e 100644
+https://github.com/PurpleI2P/i2pd/issues/1353
+--- a/build/CMakeLists.txt
++++ b/build/CMakeLists.txt
+@@ -470,6 +470,7 @@ if (WITH_BINARY)
+   if (WITH_STATIC)
+     set(DL_LIB ${CMAKE_DL_LIBS})
+   endif()
++  target_link_libraries(libi2pd ${Boost_LIBRARIES} ${ZLIB_LIBRARY})
+   target_link_libraries( "${PROJECT_NAME}" libi2pd libi2pdclient ${DL_LIB} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MINGW_EXTRA} ${DL_LIB} ${CMAKE_REQUIRED_LIBRARIES})
+ 
+   install(TARGETS "${PROJECT_NAME}" RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime)

--- a/net-vpn/i2pd/i2pd-2.25.0-r1.ebuild
+++ b/net-vpn/i2pd/i2pd-2.25.0-r1.ebuild
@@ -1,0 +1,122 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit systemd user cmake-utils toolchain-funcs
+
+DESCRIPTION="A C++ daemon for accessing the I2P anonymous network"
+HOMEPAGE="https://github.com/PurpleI2P/i2pd"
+SRC_URI="https://github.com/PurpleI2P/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~x86"
+IUSE="cpu_flags_x86_aes cpu_flags_x86_avx i2p-hardening libressl static +upnp websocket"
+
+# if using libressl, require >=boost-1.65, see #597798
+RDEPEND="
+	!static? (
+		dev-libs/boost:=[threads]
+		!libressl? ( dev-libs/openssl:0=[-bindist] )
+		libressl? (
+			dev-libs/libressl:0=
+			>=dev-libs/boost-1.65:=
+		)
+		upnp? ( net-libs/miniupnpc )
+	)"
+DEPEND="${RDEPEND}
+	static? (
+		dev-libs/boost:=[static-libs,threads]
+		!libressl? ( dev-libs/openssl:0=[static-libs] )
+		libressl? (
+			dev-libs/libressl:0=[static-libs]
+			>=dev-libs/boost-1.65:=
+		)
+		sys-libs/zlib:=[static-libs]
+		upnp? ( net-libs/miniupnpc[static-libs] )
+	)
+	websocket? ( dev-cpp/websocketpp )"
+
+I2PD_USER=i2pd
+I2PD_GROUP=i2pd
+
+CMAKE_USE_DIR="${S}/build"
+
+DOCS=( README.md contrib/i2pd.conf contrib/tunnels.conf )
+
+PATCHES=( "${FILESDIR}/${PN}-2.14.0-fix_installed_components.patch"
+	"${FILESDIR}/i2pd-2.25.0-link.patch"
+	"${FILESDIR}/i2pd-2.25.0-lib-path.patch" )
+
+pkg_pretend() {
+	if tc-is-gcc && ! ver_test "$(gcc-version)" -ge "4.7"; then
+		die "At least gcc 4.7 is required"
+	fi
+	if use i2p-hardening && ! tc-is-gcc; then
+		die "i2p-hardening requires gcc"
+	fi
+}
+
+src_configure() {
+	mycmakeargs=(
+		-DWITH_AESNI=$(usex cpu_flags_x86_aes ON OFF)
+		-DWITH_AVX=$(usex cpu_flags_x86_avx ON OFF)
+		-DWITH_HARDENING=$(usex i2p-hardening ON OFF)
+		-DWITH_PCH=OFF
+		-DWITH_STATIC=$(usex static ON OFF)
+		-DWITH_UPNP=$(usex upnp ON OFF)
+		-DWITH_WEBSOCKETS=$(usex websocket ON OFF)
+		-DWITH_LIBRARY=ON
+		-DWITH_BINARY=ON
+	)
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+
+	# config
+	insinto /etc/i2pd
+	doins contrib/i2pd.conf
+	doins contrib/tunnels.conf
+
+	# grant i2pd group read and write access to config files
+	fowners "root:${I2PD_GROUP}" \
+		/etc/i2pd/i2pd.conf \
+		/etc/i2pd/tunnels.conf
+	fperms 660 \
+		/etc/i2pd/i2pd.conf \
+		/etc/i2pd/tunnels.conf
+
+	# working directory
+	keepdir /var/lib/i2pd
+	insinto /var/lib/i2pd
+	doins -r contrib/certificates
+	fowners "${I2PD_USER}:${I2PD_GROUP}" /var/lib/i2pd/
+	fperms 700 /var/lib/i2pd/
+
+	# add /var/lib/i2pd/certificates to CONFIG_PROTECT
+	doenvd "${FILESDIR}/99i2pd"
+
+	# openrc and systemd daemon routines
+	newconfd "${FILESDIR}/i2pd-2.6.0-r3.confd" i2pd
+	newinitd "${FILESDIR}/i2pd-2.6.0-r3.initd" i2pd
+	systemd_newunit "${FILESDIR}/i2pd-2.6.0-r3.service" i2pd.service
+
+	# logrotate
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}/i2pd-2.6.0-r3.logrotate" i2pd
+}
+
+pkg_setup() {
+	enewgroup "${I2PD_GROUP}"
+	enewuser "${I2PD_USER}" -1 -1 /var/lib/run/i2pd "${I2PD_GROUP}"
+}
+
+pkg_postinst() {
+	if [[ -f ${EROOT%/}/etc/i2pd/subscriptions.txt ]]; then
+		ewarn
+		ewarn "Configuration of the subscriptions has been moved from"
+		ewarn "subscriptions.txt to i2pd.conf. We recommend updating"
+		ewarn "i2pd.conf accordingly and deleting subscriptions.txt."
+	fi
+}

--- a/net-vpn/i2pd/metadata.xml
+++ b/net-vpn/i2pd/metadata.xml
@@ -5,6 +5,10 @@
 		<email>kaikaikai@yandex.ru</email>
 		<name>Alexey Korepanov</name>
 	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<maintainer type="person">
 		<email>klondike@gentoo.org</email>
 		<name>Francisco Blas Izquierdo Riera</name>


### PR DESCRIPTION
Regular bump, no changes to 2.24.0. Old cleaned up to leave 3 latest versions.

@blueness please do not ignore.