### PR TITLE
media-gfx/openscad: fix boost build

### DIFF
--- a/media-gfx/openscad/files/openscad-2015.03_p3_fix-boost-1.70.0-build.patch
+++ b/media-gfx/openscad/files/openscad-2015.03_p3_fix-boost-1.70.0-build.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CSGTermEvaluator.cc b/src/CSGTermEvaluator.cc
+index 6416f29..b3753cf 100644
+--- a/src/CSGTermEvaluator.cc
++++ b/src/CSGTermEvaluator.cc
+@@ -109,7 +109,7 @@ static shared_ptr<CSGTerm> evaluate_csg_term_from_geometry(const State &state,
+ 			shared_ptr<const PolySet> ps = dynamic_pointer_cast<const PolySet>(geom);
+ 			// Since is_convex() doesn't handle non-planar faces, we need to tessellate
+ 			// also in the indeterminate state so we cannot just use a boolean comparison. See #1061
+-			bool convex = ps->convexValue();
++			bool convex{ps->convexValue()};
+ 			if (ps && !convex) {
+ 				assert(ps->getDimension() == 3);
+ 				PolySet *ps_tri = new PolySet(3, ps->convexValue());

--- a/media-gfx/openscad/openscad-2015.03_p3-r1.ebuild
+++ b/media-gfx/openscad/openscad-2015.03_p3-r1.ebuild
@@ -41,7 +41,10 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-PATCHES=( "${FILESDIR}/${PN}-2015.03_p2_uic_tr_fix.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}-2015.03_p2_uic_tr_fix.patch"
+	"${FILESDIR}/${PN}-2015.03_p3_fix-boost-1.70.0-build.patch"
+)
 
 S="${WORKDIR}/${PN}-${MY_PV}"
 


### PR DESCRIPTION
Fixes a build issue with >=boost-1.69

Closes: https://bugs.gentoo.org/684038
Package-Manager: Portage-2.3.62, Repoman-2.3.12
Signed-off-by: Bernd Waibel <waebbl@gmail.com>