### PR TITLE
dev-python/trollius: Add self._loop sanity check

### DIFF
--- a/dev-python/trollius/files/trollius-2.1-ensure-loop-availability.patch
+++ b/dev-python/trollius/files/trollius-2.1-ensure-loop-availability.patch
@@ -1,0 +1,29 @@
+From e917d6a72b9482df711213d7cbe340ec91f75f86 Mon Sep 17 00:00:00 2001
+From: "Alex.Khouderchah" <akhouderchah@chromium.org>
+Date: Wed, 15 May 2019 09:47:16 -0700
+Subject: [PATCH] Ensure self._loop is still available before resuming read
+
+In some cases (see https://github.com/KimiNewt/pyshark/issues/94),
+resume_reading is invoked after self._loop is set back to None by
+_call_connection_lost. This change simply performs a sanity check to
+ensure that self._loop is not None before calling add_reader on it.
+---
+ trollius/unix_events.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/trollius/unix_events.py b/trollius/unix_events.py
+index cdefaca..8999206 100644
+--- a/trollius/unix_events.py
++++ b/trollius/unix_events.py
+@@ -390,6 +390,8 @@ def pause_reading(self):
+         self._loop.remove_reader(self._fileno)
+ 
+     def resume_reading(self):
++        if self._loop is None:
++            return
+         self._loop.add_reader(self._fileno, self._read_ready)
+ 
+     def close(self):
+-- 
+2.21.0.1020.gf2820cf01a-goog
+

--- a/dev-python/trollius/trollius-2.1.ebuild
+++ b/dev-python/trollius/trollius-2.1.ebuild
@@ -19,6 +19,8 @@ RDEPEND="virtual/python-futures[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]"
 
+PATCHES=( "${FILESDIR}"/${P}-ensure-loop-availability.patch )
+
 python_test() {
 	"${PYTHON}" runtests.py || die "Testing failed under ${EPYTHON}"
 }


### PR DESCRIPTION
Trollius on *nix can sometimes call resume_reading when self._loop is None. This simply adds a sanity check to ensure that we don't try to use self._loop when that is the case. Since Trollius is no longer being maintained, we patch it here rather than pushing the patch to upstream Trollius.

Signed-off-by: Alex Khouderchah <akhouderchah@chromium.org>