### PR TITLE
app-benchmarks/bonnie++: fix SRC_URI, use HTTPS

### DIFF
--- a/app-benchmarks/bonnie++/bonnie++-1.97.2.ebuild
+++ b/app-benchmarks/bonnie++/bonnie++-1.97.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="Hard drive bottleneck testing benchmark suite"
-HOMEPAGE="http://www.coker.com.au/bonnie++/"
-SRC_URI="http://www.coker.com.au/bonnie++/experimental/${P}.tgz"
+HOMEPAGE="https://www.coker.com.au/bonnie++/"
+SRC_URI="https://www.coker.com.au/${PN}/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-benchmarks/bonnie++/bonnie++-1.97.3.ebuild
+++ b/app-benchmarks/bonnie++/bonnie++-1.97.3.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="Hard drive bottleneck testing benchmark suite"
-HOMEPAGE="http://www.coker.com.au/bonnie++/"
-SRC_URI="http://www.coker.com.au/bonnie++/experimental/${P}.tgz"
+HOMEPAGE="https://www.coker.com.au/bonnie++/"
+SRC_URI="https://www.coker.com.au/${PN}/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
this fixes the SRC_URI and uses https instead of http.
Please review.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>