### PR TITLE
dev-libs/vanessa-adt: fix LICENSE, add EAPI=7 ebuild

### DIFF
--- a/dev-libs/vanessa-adt/vanessa-adt-0.0.6.ebuild
+++ b/dev-libs/vanessa-adt/vanessa-adt-0.0.6.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Abstract Data Types. Includes queue, dynamic array, hash and key va
 HOMEPAGE="http://horms.net/projects/vanessa/"
 SRC_URI="http://horms.net/projects/vanessa/download/${MY_PN}/${PV}/${MY_P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~ppc x86"
 IUSE=""

--- a/dev-libs/vanessa-adt/vanessa-adt-0.0.9-r1.ebuild
+++ b/dev-libs/vanessa-adt/vanessa-adt-0.0.9-r1.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MY_PN="${PN/-/_}"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="Abstract Data Types. Includes queue, dynamic array, hash and key value ADT"
+HOMEPAGE="http://horms.net/projects/vanessa/"
+SRC_URI="http://horms.net/projects/vanessa/download/${MY_PN}/${PV}/${MY_P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND=">=dev-libs/vanessa-logger-0.0.7"
+S="${WORKDIR}/${MY_P}"

--- a/dev-libs/vanessa-adt/vanessa-adt-0.0.9.ebuild
+++ b/dev-libs/vanessa-adt/vanessa-adt-0.0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
@@ -10,7 +10,7 @@ DESCRIPTION="Abstract Data Types. Includes queue, dynamic array, hash and key va
 HOMEPAGE="http://horms.net/projects/vanessa/"
 SRC_URI="http://horms.net/projects/vanessa/download/${MY_PN}/${PV}/${MY_P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
 IUSE=""


### PR DESCRIPTION
Hi,

This fixes dev-libs/vanessa-adt's LICENSE and adds a EAPI=7 ebuild.
Please review.