### PR TITLE
dev-libs/vanessa-logger: fix LICENSE, EAPI=7 bump

### DIFF
--- a/dev-libs/vanessa-logger/vanessa-logger-0.0.10-r1.ebuild
+++ b/dev-libs/vanessa-logger/vanessa-logger-0.0.10-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MY_PN="${PN/-/_}"
+MY_P="${MY_PN}-${PV}"
+DESCRIPTION="Generic logging layer that to log to syslog, an open file handle or a file name"
+HOMEPAGE="http://horms.net/projects/vanessa/"
+SRC_URI="http://horms.net/projects/vanessa/download/${MY_PN}/${PV}/${MY_P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+S="${WORKDIR}/${MY_P}"
+DOCS="AUTHORS NEWS README TODO sample/*.c sample/*.h"

--- a/dev-libs/vanessa-logger/vanessa-logger-0.0.10.ebuild
+++ b/dev-libs/vanessa-logger/vanessa-logger-0.0.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
@@ -9,7 +9,7 @@ DESCRIPTION="Generic logging layer that to log to syslog, an open file handle or
 HOMEPAGE="http://horms.net/projects/vanessa/"
 SRC_URI="http://horms.net/projects/vanessa/download/${MY_PN}/${PV}/${MY_P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ~ppc x86"
 IUSE=""


### PR DESCRIPTION
Hi,

This PR update dev-libs/vanessa-logger's LICENSE and adds a EAPI7 ebuild.
Please review.
