### PR TITLE
net-misc/smbc: fix LICENSE, EAPI=7 bump

### DIFF
--- a/net-misc/smbc/smbc-1.2.2-r2.ebuild
+++ b/net-misc/smbc/smbc-1.2.2-r2.ebuild
@@ -1,17 +1,17 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="2"
 
 inherit autotools eutils
 
-DESCRIPTION="A text mode (ncurses) SMB network commander. Features: resume and UTF-8"
+DESCRIPTION="Text mode (ncurses) SMB network commander. Features: resume and UTF-8"
 HOMEPAGE="https://sourceforge.net/projects/smbc/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tgz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS=" ~ppc ~x86"
+KEYWORDS="~ppc ~x86"
 IUSE="nls debug"
 
 DEPEND="net-fs/samba

--- a/net-misc/smbc/smbc-1.2.2-r3.ebuild
+++ b/net-misc/smbc/smbc-1.2.2-r3.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Text mode (ncurses) SMB network commander. Features: resume and UTF-8"
+HOMEPAGE="https://sourceforge.net/projects/smbc/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tgz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~ppc ~x86"
+IUSE="nls debug"
+
+DEPEND="dev-libs/popt
+	net-fs/samba
+	sys-libs/ncurses
+	nls? ( sys-devel/gettext )"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+	mv configure.{in,ac} || die
+	eapply "${FILESDIR}"/${P}-cflags.patch
+	eapply "${FILESDIR}"/${P}-size_t.patch
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable nls) \
+		$(use_with debug)
+}
+
+src_install() {
+	default
+	mkdir -p "${D}/usr/share/doc"
+	mv -v "${D}/usr/share/"{${PN},doc/${PF}} || die
+}


### PR DESCRIPTION
Hi,

This PR updates net-misc/smbc for EAPI=7 and fixes it's LICENSE.
Please note that i haven't tested my changes yet as i don't have a x86 machine around.

Please review.

```diff
--- smbc-1.2.2-r2.ebuild        2019-05-19 17:31:11.177377351 +0200
+++ smbc-1.2.2-r3.ebuild        2019-05-19 17:35:34.418664938 +0200
@@ -1,9 +1,9 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="2"
+EAPI=7
 
-inherit autotools eutils
+inherit autotools
 
 DESCRIPTION="Text mode (ncurses) SMB network commander. Features: resume and UTF-8"
 HOMEPAGE="https://sourceforge.net/projects/smbc/"
@@ -14,27 +14,28 @@
 KEYWORDS="~ppc ~x86"
 IUSE="nls debug"
 
-DEPEND="net-fs/samba
+DEPEND="dev-libs/popt
+       net-fs/samba
        sys-libs/ncurses
-       dev-libs/popt
        nls? ( sys-devel/gettext )"
 RDEPEND="${DEPEND}"
 
 src_prepare() {
-       epatch "${FILESDIR}"/${P}-cflags.patch
-       epatch "${FILESDIR}"/${P}-size_t.patch
+       default
+       mv configure.{in,ac} || die
+       eapply "${FILESDIR}"/${P}-cflags.patch
+       eapply "${FILESDIR}"/${P}-size_t.patch
        eautoreconf
 }
 
 src_configure() {
        econf \
                $(use_enable nls) \
-               $(use_with debug) \
-               || die "econf failed"
+               $(use_with debug)
 }
 
 src_install() {
-       emake DESTDIR="${D}" install || die "emake install failed"
+       default
        mkdir -p "${D}/usr/share/doc"
-       mv -v "${D}/usr/share/"{${PN},doc/${PF}}
+       mv -v "${D}/usr/share/"{${PN},doc/${PF}} || die
 }
```
