### PR TITLE
media-libs/opus: Enable building with -ffast-math and -Ofast

### DIFF
--- a/media-libs/opus/opus-1.3.1-r1.ebuild
+++ b/media-libs/opus/opus-1.3.1-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic multilib-minimal
+
+DESCRIPTION="Open codec for interactive speech and music transmission over the Internet"
+HOMEPAGE="https://opus-codec.org/"
+SRC_URI="https://archive.mozilla.org/pub/opus/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd"
+INTRINSIC_FLAGS="cpu_flags_x86_sse cpu_flags_arm_neon"
+IUSE="custom-modes doc static-libs ${INTRINSIC_FLAGS}"
+
+DEPEND="doc? (
+		app-doc/doxygen
+		media-gfx/graphviz
+	)"
+
+multilib_src_configure() {
+	local myeconfargs=(
+		$(use_enable custom-modes)
+		$(use_enable doc)
+		$(use_enable static-libs static)
+	)
+	for i in ${INTRINSIC_FLAGS} ; do
+		use ${i} && myeconfargs+=( --enable-intrinsics )
+	done
+	if is-flagq -ffast-math || is-flagq -Ofast; then
+		myeconfargs+=( "--enable-float-approx" )
+	fi
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	default
+	find "${ED}" -name "*.la" -delete || die
+}


### PR DESCRIPTION
Currently building media-libs/opus with `--fastmath `or `-Ofast` C{XX}FLAGS results in the following build failure.

```
/var/tmp/portage/media-libs/opus-1.3.1-r1/work/opus-1.3.1/celt/arch.h:198:2: error: #error Cannot build libopus with -ffast-math unless FLOAT_APPROX is defined. This could result in crashes on extreme (e.g. NaN) input
  198 | #error Cannot build libopus with -ffast-math unless FLOAT_APPROX is defined. This could result in crashes on extreme (e.g. NaN) input
      |  ^~~~~
```
opus supports the configure switch `--enable-float-approx`, which defines `FLOAT_APPROX`, which enables versions of internal functions that are safe for floating point approximations and can be used with `--fastmath `or `-Ofast`.

Similar in name and use to the `fastmath` USE flag in media-gfx/yafaray, this adds support for the `--enable-float-approx` configure switch.

Package-Manager: Portage-2.3.66, Repoman-2.3.12
Closes: https://bugs.gentoo.org/621978
Signed-off-by: Peter Levine <plevine457@gmail.com>