### PR TITLE
app-crypt/elettra: EAPI=7 bump

### DIFF
--- a/app-crypt/elettra/elettra-1.0-r1.ebuild
+++ b/app-crypt/elettra/elettra-1.0-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+MY_P="${PN}-src-${PV}"
+
+DESCRIPTION="Plausible deniable file cryptography"
+HOMEPAGE="http://www.winstonsmith.info/julia/elettra/"
+SRC_URI="http://www.winstonsmith.info/julia/elettra/${MY_P}.tar.gz"
+
+LICENSE="WTFPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+
+RDEPEND="sys-libs/zlib
+		 app-crypt/mhash
+		 dev-libs/libmcrypt"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/${PN}"
+
+src_compile() {
+	$(tc-getCC) ${CFLAGS} ${LDFLAGS} -I. src/*.c \
+		-lz $(libmcrypt-config --cflags --libs) -lmhash \
+		-o elettra || die "compilation failed"
+}
+
+src_install() {
+	dobin elettra
+	dodoc README
+}


### PR DESCRIPTION
Hi,

This is a simple EAPI=7 bump for app-crypt/elettra.

Closes: https://bugs.gentoo.org/686492
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

```diff
--- elettra-1.0.ebuild  2018-09-30 21:33:00.246619719 +0200
+++ elettra-1.0-r1.ebuild       2019-05-21 19:25:33.790536845 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
 inherit toolchain-funcs
 
@@ -14,23 +14,21 @@
 LICENSE="WTFPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
-IUSE=""
 
 RDEPEND="sys-libs/zlib
                 app-crypt/mhash
                 dev-libs/libmcrypt"
-
 DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${PN}"
 
 src_compile() {
        $(tc-getCC) ${CFLAGS} ${LDFLAGS} -I. src/*.c \
-               -lz `libmcrypt-config --cflags --libs` -lmhash \
+               -lz $(libmcrypt-config --cflags --libs) -lmhash \
                -o elettra || die "compilation failed"
 }
 
 src_install() {
-       dobin elettra || die "dobin failed"
-       dodoc README || die "dodoc failed"
+       dobin elettra
+       dodoc README
 }
```