### PR TITLE
app-crypt/hashalot: fix LICENSE, update HOMEPAGE, EAPI=7

### DIFF
--- a/app-crypt/hashalot/hashalot-0.3-r2.ebuild
+++ b/app-crypt/hashalot/hashalot-0.3-r2.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
 
-DESCRIPTION="CryptoAPI utils"
-HOMEPAGE="http://www.kerneli.org/"
+DESCRIPTION="Reads a passphrase and prints a hash"
+HOMEPAGE="http://www.paranoiacs.org/~sluskyb/"
 SRC_URI="http://www.paranoiacs.org/~sluskyb/hacks/hashalot/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="alpha amd64 arm hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86"
 IUSE=""

--- a/app-crypt/hashalot/hashalot-0.3-r3.ebuild
+++ b/app-crypt/hashalot/hashalot-0.3-r3.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Reads a passphrase and prints a hash"
+HOMEPAGE="http://www.paranoiacs.org/~sluskyb/"
+SRC_URI="http://www.paranoiacs.org/~sluskyb/hacks/hashalot/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+
+src_test() {
+	make check-TESTS || die
+}


### PR DESCRIPTION
Hi,

Another simple EAPI=7 bump, also fixes the LICENSE and HOMEPAGE.
Please review.