### PR TITLE
dev-util/lsuio: use HTTPS, EAPI=7

### DIFF
--- a/dev-util/lsuio/lsuio-0.2.0-r1.ebuild
+++ b/dev-util/lsuio/lsuio-0.2.0-r1.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="List available userspace I/O (UIO) devices"
+HOMEPAGE="https://www.osadl.org/UIO.uio.0.html"
+SRC_URI="http://www.osadl.org/projects/downloads/UIO/user/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"

--- a/dev-util/lsuio/lsuio-0.2.0.ebuild
+++ b/dev-util/lsuio/lsuio-0.2.0.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
 
 inherit eutils
 
-DESCRIPTION="list available userspace I/O (UIO) devices"
-HOMEPAGE="http://www.osadl.org/UIO.uio.0.html"
+DESCRIPTION="List available userspace I/O (UIO) devices"
+HOMEPAGE="https://www.osadl.org/UIO.uio.0.html"
 SRC_URI="http://www.osadl.org/projects/downloads/UIO/user/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

This is another simple EAPI=7 bump. Also fixes the HOMEPAGE to use https.
