### PR TITLE
dev-libs/libressl-2.9.2: restore non-glibc support

### DIFF
--- a/dev-libs/libressl/files/libressl-2.9.2-musl.patch
+++ b/dev-libs/libressl/files/libressl-2.9.2-musl.patch
@@ -1,0 +1,28 @@
+diff -rup a/crypto/compat/getprogname_linux.c b/crypto/compat/getprogname_linux.c
+--- a/crypto/compat/getprogname_linux.c	2019-05-07 07:05:51.000000000 +0000
++++ b/crypto/compat/getprogname_linux.c	2019-05-22 07:06:20.780029886 +0000
+@@ -12,23 +12,14 @@ getprogname(void)
+ 	 * Since Android is using portions of OpenBSD libc, it should have
+ 	 * a symbol called __progname [1].
+ 	 *
+-	 * Regarding program_invocation_short_name, it is a GNU libc ext [2] and
+-	 * so make it conditional to __GLIBC__ [3].
+-	 *
+ 	 * .. [0] https://github.com/aosp-mirror/platform_bionic/blob/1eb6d3/libc/include/stdlib.h#L160
+ 	 *
+ 	 * .. [1] https://github.com/aosp-mirror/platform_bionic/commit/692207
+-	 *
+-	 * .. [2] https://linux.die.net/man/3/program_invocation_short_name
+-	 *
+-	 * .. [3] https://android.googlesource.com/platform/system/core/+/2819c0/base/logging.cpp#65
+ 	 */
+ #if defined(__ANDROID_API__) && __ANDROID_API__ < 21
+ 	extern const char *__progname;
+ 	return __progname;
+-#elif defined(__GLIBC__)
+-	return program_invocation_short_name;
+ #else
+-#error "Cannot emulate getprogname"
++	return program_invocation_short_name;
+ #endif
+ }

--- a/dev-libs/libressl/libressl-2.9.2.ebuild
+++ b/dev-libs/libressl/libressl-2.9.2.ebuild
@@ -41,6 +41,7 @@ src_prepare() {
 	fi
 
 	eapply "${FILESDIR}"/${PN}-2.8.3-solaris10.patch
+	eapply "${FILESDIR}"/${P}-musl.patch
 	eapply_user
 
 	elibtoolize  # for Solaris


### PR DESCRIPTION
LibreSSL 2.9.2 introduced a check for `__GLIBC__` which is obviously not available on musl (and there is no `__MUSL__` macro). This patch restores the behaviour of 2.9.1 on all systems except Android.

Package-Manager: Portage-2.3.66, Repoman-2.3.12
Signed-off-by: Philipp Ammann <philipp.ammann@posteo.de>