### PR TITLE
dev-libs/libbegemot: use HTTPS, EAPI=7 bump

### DIFF
--- a/dev-libs/libbegemot/libbegemot-1.11-r1.ebuild
+++ b/dev-libs/libbegemot/libbegemot-1.11-r1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit libtool
+
+DESCRIPTION="begemot utility function library"
+HOMEPAGE="https://people.freebsd.org/~harti/"
+SRC_URI="https://people.freebsd.org/~harti/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~amd64-fbsd ~x86-fbsd"
+
+src_prepare() {
+	default
+	elibtoolize
+}
+
+src_compile() {
+	emake -j1
+}

--- a/dev-libs/libbegemot/libbegemot-1.11.ebuild
+++ b/dev-libs/libbegemot/libbegemot-1.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
@@ -6,8 +6,8 @@ EAPI=0
 inherit libtool
 
 DESCRIPTION="begemot utility function library"
-HOMEPAGE="http://people.freebsd.org/~harti/"
-SRC_URI="http://people.freebsd.org/~harti/${PN}/${P}.tar.gz"
+HOMEPAGE="https://people.freebsd.org/~harti/"
+SRC_URI="https://people.freebsd.org/~harti/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Hi,

Another simple EAPI=7 and also uses https for HOMEPAGE and SRC_URI.
Please review.