### PR TITLE
sys-apps/systemd: network: backport fix for ListenPort in WireGuard

### DIFF
--- a/sys-apps/systemd/files/242-wireguard-listenport.patch
+++ b/sys-apps/systemd/files/242-wireguard-listenport.patch
@@ -1,0 +1,49 @@
+From a62b7bb79e9a2aa683624c32cde1c756d8466fb4 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Thu, 25 Apr 2019 00:39:04 +0200
+Subject: [PATCH] network: fix ListenPort= in [WireGuard] section
+
+This fixes a bug introduced by f1368a333e5e08575f0b45dfe41e936b106a8627.
+
+Fixes #12377.
+---
+ src/network/netdev/wireguard.c | 19 ++++++++++---------
+ 1 file changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/src/network/netdev/wireguard.c b/src/network/netdev/wireguard.c
+index f3084c0773f..5ebc5dfed84 100644
+--- a/src/network/netdev/wireguard.c
++++ b/src/network/netdev/wireguard.c
+@@ -452,22 +452,23 @@ int config_parse_wireguard_listen_port(
+                 void *userdata) {
+ 
+         uint16_t *s = data;
+-        uint16_t port = 0;
+         int r;
+ 
+         assert(rvalue);
+         assert(data);
+ 
+-        if (!streq(rvalue, "auto")) {
+-                r = parse_ip_port(rvalue, s);
+-                if (r < 0) {
+-                        log_syntax(unit, LOG_ERR, filename, line, r,
+-                                   "Invalid port specification, ignoring assignment: %s", rvalue);
+-                        return 0;
+-                }
++        if (isempty(rvalue) || streq(rvalue, "auto")) {
++                *s = 0;
++                return 0;
++        }
++
++        r = parse_ip_port(rvalue, s);
++        if (r < 0) {
++                log_syntax(unit, LOG_ERR, filename, line, r,
++                           "Invalid port specification, ignoring assignment: %s", rvalue);
++                return 0;
+         }
+ 
+-        *s = port;
+         return 0;
+ }
+ 

--- a/sys-apps/systemd/systemd-242-r2.ebuild
+++ b/sys-apps/systemd/systemd-242-r2.ebuild
@@ -1,0 +1,492 @@
+# Copyright 2011-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+if [[ ${PV} == 9999 ]]; then
+	EGIT_REPO_URI="https://github.com/systemd/systemd.git"
+	inherit git-r3
+else
+	MY_PV=${PV/_/-}
+	MY_P=${PN}-${MY_PV}
+	S=${WORKDIR}/${MY_P}
+	SRC_URI="https://github.com/systemd/systemd/archive/v${MY_PV}/${MY_P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+fi
+
+PYTHON_COMPAT=( python{3_5,3_6,3_7} )
+
+inherit bash-completion-r1 linux-info meson multilib-minimal ninja-utils pam python-any-r1 systemd toolchain-funcs udev user
+
+DESCRIPTION="System and service manager for Linux"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
+
+LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
+SLOT="0/2"
+IUSE="acl apparmor audit build cryptsetup curl dns-over-tls elfutils +gcrypt gnuefi gnutls http idn importd +kmod libidn2 +lz4 lzma nat pam pcre policykit qrcode +resolvconf +seccomp selinux +split-usr +sysv-utils test vanilla xkb"
+
+REQUIRED_USE="importd? ( curl gcrypt lzma )"
+RESTRICT="!test? ( test )"
+
+MINKV="3.11"
+
+COMMON_DEPEND=">=sys-apps/util-linux-2.30:0=[${MULTILIB_USEDEP}]
+	sys-libs/libcap:0=[${MULTILIB_USEDEP}]
+	!<sys-libs/glibc-2.16
+	acl? ( sys-apps/acl:0= )
+	apparmor? ( sys-libs/libapparmor:0= )
+	audit? ( >=sys-process/audit-2:0= )
+	cryptsetup? ( >=sys-fs/cryptsetup-1.6:0= )
+	curl? ( net-misc/curl:0= )
+	dns-over-tls? (
+		gnutls? ( >=net-libs/gnutls-3.5.3:0= )
+		!gnutls? ( >=dev-libs/openssl-1.1.0:0= )
+	)
+	elfutils? ( >=dev-libs/elfutils-0.158:0= )
+	gcrypt? ( >=dev-libs/libgcrypt-1.4.5:0=[${MULTILIB_USEDEP}] )
+	http? (
+		>=net-libs/libmicrohttpd-0.9.33:0=
+		gnutls? ( >=net-libs/gnutls-3.1.4:0= )
+	)
+	idn? (
+		libidn2? ( net-dns/libidn2:= )
+		!libidn2? ( net-dns/libidn:= )
+	)
+	importd? (
+		app-arch/bzip2:0=
+		sys-libs/zlib:0=
+	)
+	kmod? ( >=sys-apps/kmod-15:0= )
+	lz4? ( >=app-arch/lz4-0_p131:0=[${MULTILIB_USEDEP}] )
+	lzma? ( >=app-arch/xz-utils-5.0.5-r1:0=[${MULTILIB_USEDEP}] )
+	nat? ( net-firewall/iptables:0= )
+	pam? ( virtual/pam:=[${MULTILIB_USEDEP}] )
+	pcre? ( dev-libs/libpcre2 )
+	qrcode? ( media-gfx/qrencode:0= )
+	seccomp? ( >=sys-libs/libseccomp-2.3.3:0= )
+	selinux? ( sys-libs/libselinux:0= )
+	xkb? ( >=x11-libs/libxkbcommon-0.4.1:0= )"
+
+# baselayout-2.2 has /run
+RDEPEND="${COMMON_DEPEND}
+	>=sys-apps/baselayout-2.2
+	selinux? ( sec-policy/selinux-base-policy[systemd] )
+	sysv-utils? ( !sys-apps/sysvinit )
+	!sysv-utils? ( sys-apps/sysvinit )
+	resolvconf? ( !net-dns/openresolv )
+	!build? ( || (
+		sys-apps/util-linux[kill(-)]
+		sys-process/procps[kill(+)]
+		sys-apps/coreutils[kill(-)]
+	) )
+	!sys-auth/nss-myhostname
+	!<sys-kernel/dracut-044
+	!sys-fs/eudev
+	!sys-fs/udev"
+
+# sys-apps/dbus: the daemon only (+ build-time lib dep for tests)
+PDEPEND=">=sys-apps/dbus-1.9.8[systemd]
+	>=sys-apps/hwids-20150417[udev]
+	>=sys-fs/udev-init-scripts-25
+	policykit? ( sys-auth/polkit )
+	!vanilla? ( sys-apps/gentoo-systemd-integration )"
+
+# Newer linux-headers needed by ia64, bug #480218
+DEPEND="
+	>=sys-kernel/linux-headers-${MINKV}
+	gnuefi? ( >=sys-boot/gnu-efi-3.0.2 )
+"
+
+BDEPEND="
+	app-arch/xz-utils:0
+	dev-util/gperf
+	>=dev-util/meson-0.46
+	>=dev-util/intltool-0.50
+	>=sys-apps/coreutils-8.16
+	sys-devel/m4
+	virtual/pkgconfig[${MULTILIB_USEDEP}]
+	test? ( sys-apps/dbus )
+	app-text/docbook-xml-dtd:4.2
+	app-text/docbook-xml-dtd:4.5
+	app-text/docbook-xsl-stylesheets
+	dev-libs/libxslt:0
+	$(python_gen_any_dep 'dev-python/lxml[${PYTHON_USEDEP}]')
+"
+
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != buildonly ]]; then
+		if use test && has pid-sandbox ${FEATURES}; then
+			ewarn "Tests are known to fail with PID sandboxing enabled."
+			ewarn "See https://bugs.gentoo.org/674458."
+		fi
+
+		local CONFIG_CHECK="~AUTOFS4_FS ~BLK_DEV_BSG ~CGROUPS
+			~CHECKPOINT_RESTORE ~DEVTMPFS ~EPOLL ~FANOTIFY ~FHANDLE
+			~INOTIFY_USER ~IPV6 ~NET ~NET_NS ~PROC_FS ~SIGNALFD ~SYSFS
+			~TIMERFD ~TMPFS_XATTR ~UNIX
+			~CRYPTO_HMAC ~CRYPTO_SHA256 ~CRYPTO_USER_API_HASH
+			~!FW_LOADER_USER_HELPER_FALLBACK ~!GRKERNSEC_PROC ~!IDE ~!SYSFS_DEPRECATED
+			~!SYSFS_DEPRECATED_V2"
+
+		use acl && CONFIG_CHECK+=" ~TMPFS_POSIX_ACL"
+		use seccomp && CONFIG_CHECK+=" ~SECCOMP ~SECCOMP_FILTER"
+		kernel_is -lt 3 7 && CONFIG_CHECK+=" ~HOTPLUG"
+		kernel_is -lt 4 7 && CONFIG_CHECK+=" ~DEVPTS_MULTIPLE_INSTANCES"
+		kernel_is -ge 4 10 && CONFIG_CHECK+=" ~CGROUP_BPF"
+
+		if linux_config_exists; then
+			local uevent_helper_path=$(linux_chkconfig_string UEVENT_HELPER_PATH)
+			if [[ -n ${uevent_helper_path} ]] && [[ ${uevent_helper_path} != '""' ]]; then
+				ewarn "It's recommended to set an empty value to the following kernel config option:"
+				ewarn "CONFIG_UEVENT_HELPER_PATH=${uevent_helper_path}"
+			fi
+			if linux_chkconfig_present X86; then
+				CONFIG_CHECK+=" ~DMIID"
+			fi
+		fi
+
+		if kernel_is -lt ${MINKV//./ }; then
+			ewarn "Kernel version at least ${MINKV} required"
+		fi
+
+		check_extra_config
+	fi
+}
+
+pkg_setup() {
+	:
+}
+
+src_unpack() {
+	default
+	[[ ${PV} != 9999 ]] || git-r3_src_unpack
+}
+
+src_prepare() {
+	# Do NOT add patches here
+	local PATCHES=()
+
+	[[ -d "${WORKDIR}"/patches ]] && PATCHES+=( "${WORKDIR}"/patches )
+
+	# Add local patches here
+	PATCHES+=(
+		"${FILESDIR}"/242-gcc-9.patch
+		"${FILESDIR}"/242-socket-util-flush-accept.patch
+		"${FILESDIR}"/242-wireguard-listenport.patch
+	)
+
+	if ! use vanilla; then
+		PATCHES+=(
+			"${FILESDIR}/gentoo-Dont-enable-audit-by-default.patch"
+			"${FILESDIR}/gentoo-systemd-user-pam.patch"
+			"${FILESDIR}/gentoo-uucp-group-r1.patch"
+			"${FILESDIR}/gentoo-generator-path-r1.patch"
+		)
+	fi
+
+	default
+}
+
+src_configure() {
+	# Prevent conflicts with i686 cross toolchain, bug 559726
+	tc-export AR CC NM OBJCOPY RANLIB
+
+	python_setup
+
+	multilib-minimal_src_configure
+}
+
+meson_use() {
+	usex "$1" true false
+}
+
+meson_multilib() {
+	if multilib_is_native_abi; then
+		echo true
+	else
+		echo false
+	fi
+}
+
+meson_multilib_native_use() {
+	if multilib_is_native_abi && use "$1"; then
+		echo true
+	else
+		echo false
+	fi
+}
+
+multilib_src_configure() {
+	local myconf=(
+		--localstatedir="${EPREFIX}/var"
+		-Dpamlibdir="$(getpam_mod_dir)"
+		# avoid bash-completion dep
+		-Dbashcompletiondir="$(get_bashcompdir)"
+		# make sure we get /bin:/sbin in PATH
+		-Dsplit-usr=$(usex split-usr true false)
+		-Drootprefix="$(usex split-usr "${EPREFIX:-/}" "${EPREFIX}/usr")"
+		-Dsysvinit-path=
+		-Dsysvrcnd-path=
+		# Avoid infinite exec recursion, bug 642724
+		-Dtelinit-path="${EPREFIX}/lib/sysvinit/telinit"
+		# no deps
+		-Defi=$(meson_multilib)
+		-Dima=true
+		# Optional components/dependencies
+		-Dacl=$(meson_multilib_native_use acl)
+		-Dapparmor=$(meson_multilib_native_use apparmor)
+		-Daudit=$(meson_multilib_native_use audit)
+		-Dlibcryptsetup=$(meson_multilib_native_use cryptsetup)
+		-Dlibcurl=$(meson_multilib_native_use curl)
+		-Delfutils=$(meson_multilib_native_use elfutils)
+		-Dgcrypt=$(meson_use gcrypt)
+		-Dgnu-efi=$(meson_multilib_native_use gnuefi)
+		-Dgnutls=$(meson_multilib_native_use gnutls)
+		-Defi-libdir="${EPREFIX}/usr/$(get_libdir)"
+		-Dmicrohttpd=$(meson_multilib_native_use http)
+		-Dimportd=$(meson_multilib_native_use importd)
+		-Dbzip2=$(meson_multilib_native_use importd)
+		-Dzlib=$(meson_multilib_native_use importd)
+		-Dkmod=$(meson_multilib_native_use kmod)
+		-Dlz4=$(meson_use lz4)
+		-Dxz=$(meson_use lzma)
+		-Dlibiptc=$(meson_multilib_native_use nat)
+		-Dpam=$(meson_use pam)
+		-Dpcre2=$(meson_multilib_native_use pcre)
+		-Dpolkit=$(meson_multilib_native_use policykit)
+		-Dqrencode=$(meson_multilib_native_use qrcode)
+		-Dseccomp=$(meson_multilib_native_use seccomp)
+		-Dselinux=$(meson_multilib_native_use selinux)
+		-Ddbus=$(meson_multilib_native_use test)
+		-Dxkbcommon=$(meson_multilib_native_use xkb)
+		# hardcode a few paths to spare some deps
+		-Dkill-path=/bin/kill
+		-Dntp-servers="0.gentoo.pool.ntp.org 1.gentoo.pool.ntp.org 2.gentoo.pool.ntp.org 3.gentoo.pool.ntp.org"
+		# Breaks screen, tmux, etc.
+		-Ddefault-kill-user-processes=false
+
+		# multilib options
+		-Dbacklight=$(meson_multilib)
+		-Dbinfmt=$(meson_multilib)
+		-Dcoredump=$(meson_multilib)
+		-Denvironment-d=$(meson_multilib)
+		-Dfirstboot=$(meson_multilib)
+		-Dhibernate=$(meson_multilib)
+		-Dhostnamed=$(meson_multilib)
+		-Dhwdb=$(meson_multilib)
+		-Dldconfig=$(meson_multilib)
+		-Dlocaled=$(meson_multilib)
+		-Dman=$(meson_multilib)
+		-Dnetworkd=$(meson_multilib)
+		-Dquotacheck=$(meson_multilib)
+		-Drandomseed=$(meson_multilib)
+		-Drfkill=$(meson_multilib)
+		-Dsysusers=$(meson_multilib)
+		-Dtimedated=$(meson_multilib)
+		-Dtimesyncd=$(meson_multilib)
+		-Dtmpfiles=$(meson_multilib)
+		-Dvconsole=$(meson_multilib)
+	)
+
+	if multilib_is_native_abi && use idn; then
+		myconf+=(
+			-Dlibidn2=$(usex libidn2 true false)
+			-Dlibidn=$(usex libidn2 false true)
+		)
+	else
+		myconf+=(
+			-Dlibidn2=false
+			-Dlibidn=false
+		)
+	fi
+
+	if multilib_is_native_abi && use dns-over-tls; then
+		myconf+=(
+			-Ddns-over-tls=true
+			-Dopenssl=$(usex !gnutls true false)
+		)
+	else
+		myconf+=( -Ddns-over-tls=false -Dopenssl=false )
+	fi
+
+	meson_src_configure "${myconf[@]}"
+}
+
+multilib_src_compile() {
+	eninja
+}
+
+multilib_src_test() {
+	unset DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR
+	eninja test
+}
+
+multilib_src_install() {
+	DESTDIR="${D}" eninja install
+}
+
+multilib_src_install_all() {
+	local rootprefix=$(usex split-usr '' /usr)
+
+	# meson doesn't know about docdir
+	mv "${ED}"/usr/share/doc/{systemd,${PF}} || die
+
+	einstalldocs
+	dodoc "${FILESDIR}"/nsswitch.conf
+
+	if ! use resolvconf; then
+		rm -f "${ED}${rootprefix}"/sbin/resolvconf || die
+	fi
+
+	if ! use sysv-utils; then
+		rm "${ED}${rootprefix}"/sbin/{halt,init,poweroff,reboot,runlevel,shutdown,telinit} || die
+		rm "${ED}"/usr/share/man/man1/init.1 || die
+		rm "${ED}"/usr/share/man/man8/{halt,poweroff,reboot,runlevel,shutdown,telinit}.8 || die
+	fi
+
+	if ! use resolvconf && ! use sysv-utils; then
+		rmdir "${ED}${rootprefix}"/sbin || die
+	fi
+
+	# Preserve empty dirs in /etc & /var, bug #437008
+	keepdir /etc/{binfmt.d,modules-load.d,tmpfiles.d}
+	keepdir /etc/systemd/{ntp-units.d,user} /var/lib/systemd
+	keepdir /etc/udev/{hwdb.d,rules.d}
+	keepdir /var/log/journal/remote
+
+	# Symlink /etc/sysctl.conf for easy migration.
+	dosym ../sysctl.conf /etc/sysctl.d/99-sysctl.conf
+
+	local udevdir=/lib/udev
+	use split-usr || udevdir=/usr/lib/udev
+
+	rm -r "${ED}${udevdir}/hwdb.d" || die
+
+	if use split-usr; then
+		# Avoid breaking boot/reboot
+		dosym ../../../lib/systemd/systemd /usr/lib/systemd/systemd
+		dosym ../../../lib/systemd/systemd-shutdown /usr/lib/systemd/systemd-shutdown
+	fi
+}
+
+migrate_locale() {
+	local envd_locale_def="${EROOT}/etc/env.d/02locale"
+	local envd_locale=( "${EROOT}"/etc/env.d/??locale )
+	local locale_conf="${EROOT}/etc/locale.conf"
+
+	if [[ ! -L ${locale_conf} && ! -e ${locale_conf} ]]; then
+		# If locale.conf does not exist...
+		if [[ -e ${envd_locale} ]]; then
+			# ...either copy env.d/??locale if there's one
+			ebegin "Moving ${envd_locale} to ${locale_conf}"
+			mv "${envd_locale}" "${locale_conf}"
+			eend ${?} || FAIL=1
+		else
+			# ...or create a dummy default
+			ebegin "Creating ${locale_conf}"
+			cat > "${locale_conf}" <<-EOF
+				# This file has been created by the sys-apps/systemd ebuild.
+				# See locale.conf(5) and localectl(1).
+
+				# LANG=${LANG}
+			EOF
+			eend ${?} || FAIL=1
+		fi
+	fi
+
+	if [[ ! -L ${envd_locale} ]]; then
+		# now, if env.d/??locale is not a symlink (to locale.conf)...
+		if [[ -e ${envd_locale} ]]; then
+			# ...warn the user that he has duplicate locale settings
+			ewarn
+			ewarn "To ensure consistent behavior, you should replace ${envd_locale}"
+			ewarn "with a symlink to ${locale_conf}. Please migrate your settings"
+			ewarn "and create the symlink with the following command:"
+			ewarn "ln -s -n -f ../locale.conf ${envd_locale}"
+			ewarn
+		else
+			# ...or just create the symlink if there's nothing here
+			ebegin "Creating ${envd_locale_def} -> ../locale.conf symlink"
+			ln -n -s ../locale.conf "${envd_locale_def}"
+			eend ${?} || FAIL=1
+		fi
+	fi
+}
+
+save_enabled_units() {
+	ENABLED_UNITS=()
+	type systemctl &>/dev/null || return
+	for x; do
+		if systemctl --quiet --root="${ROOT:-/}" is-enabled "${x}"; then
+			ENABLED_UNITS+=( "${x}" )
+		fi
+	done
+}
+
+pkg_preinst() {
+	save_enabled_units {machines,remote-{cryptsetup,fs}}.target getty@tty1.service
+}
+
+pkg_postinst() {
+	newusergroup() {
+		enewgroup "$1"
+		enewuser "$1" -1 -1 -1 "$1"
+	}
+
+	enewgroup input
+	enewgroup kvm 78
+	enewgroup render
+	enewgroup systemd-journal
+	newusergroup systemd-bus-proxy
+	newusergroup systemd-coredump
+	newusergroup systemd-journal-gateway
+	newusergroup systemd-journal-remote
+	newusergroup systemd-journal-upload
+	newusergroup systemd-network
+	newusergroup systemd-resolve
+	newusergroup systemd-timesync
+
+	systemd_update_catalog
+
+	# Keep this here in case the database format changes so it gets updated
+	# when required. Despite that this file is owned by sys-apps/hwids.
+	if has_version "sys-apps/hwids[udev]"; then
+		udevadm hwdb --update --root="${EROOT}"
+	fi
+
+	udev_reload || FAIL=1
+
+	# Bug 465468, make sure locales are respect, and ensure consistency
+	# between OpenRC & systemd
+	migrate_locale
+
+	systemd_reenable systemd-networkd.service systemd-resolved.service
+
+	if [[ ${ENABLED_UNITS[@]} ]]; then
+		systemctl --root="${ROOT:-/}" enable "${ENABLED_UNITS[@]}"
+	fi
+
+	if [[ -L ${EROOT}/var/lib/systemd/timesync ]]; then
+		rm "${EROOT}/var/lib/systemd/timesync"
+	fi
+
+	if [[ -z ${ROOT} && -d /run/systemd/system ]]; then
+		ebegin "Reexecuting system manager"
+		systemctl daemon-reexec
+		eend $?
+	fi
+
+	if [[ ${FAIL} ]]; then
+		eerror "One of the postinst commands failed. Please check the postinst output"
+		eerror "for errors. You may need to clean up your system and/or try installing"
+		eerror "systemd again."
+		eerror
+	fi
+}
+
+pkg_prerm() {
+	# If removing systemd completely, remove the catalog database.
+	if [[ ! ${REPLACED_BY_VERSION} ]]; then
+		rm -f -v "${EROOT}"/var/lib/systemd/catalog/database
+	fi
+}


### PR DESCRIPTION
This fixes the fact that systemd-network had been ignoring ListenPort=
in [WireGuard] since v242.
See https://github.com/systemd/systemd/issues/12377

As discussed with @zx2c4 on IRC. I can push this myself if @gentoo/systemd agrees.

```diff
--- systemd-242-r1.ebuild       2019-05-09 23:23:04.427681623 +0200
+++ systemd-242-r2.ebuild       2019-05-23 10:20:01.616524258 +0200
@@ -172,6 +172,7 @@
        PATCHES+=(
                "${FILESDIR}"/242-gcc-9.patch
                "${FILESDIR}"/242-socket-util-flush-accept.patch
+               "${FILESDIR}"/242-wireguard-listenport.patch
        )
 
        if ! use vanilla; then
```