### PR TITLE
app-crypt/nitrocli: Keyword for x86

### DIFF
--- a/app-crypt/nitrocli/nitrocli-0.2.2-r2.ebuild
+++ b/app-crypt/nitrocli/nitrocli-0.2.2-r2.ebuild
@@ -55,7 +55,7 @@ SRC_URI="$(cargo_crate_uris ${CRATES})"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 BDEPEND="

--- a/app-crypt/nitrocli/nitrocli-0.2.3-r1.ebuild
+++ b/app-crypt/nitrocli/nitrocli-0.2.3-r1.ebuild
@@ -46,7 +46,7 @@ SRC_URI="$(cargo_crate_uris ${CRATES})"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 BDEPEND="


### PR DESCRIPTION
In [bug 686634](https://bugs.gentoo.org/686634) Andrew Savchenko confirmed that nitrocli works fine on x86.
Add a keyword for it.