### PR TITLE
dev-libs/libtomfloat: fix HOMEPAGE, SRC_URI and EAPI=7 bump

### DIFF
--- a/dev-libs/libtomfloat/libtomfloat-0.02-r1.ebuild
+++ b/dev-libs/libtomfloat/libtomfloat-0.02-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="library for floating point number manipulation"
+HOMEPAGE="http://www.libtom.net/"
+SRC_URI="https://github.com/libtom/libtomfloat/releases/download/${PV}/ltf-${PV}.tar.bz2"
+
+LICENSE="WTFPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="dev-libs/libtommath"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+	sed -i \
+		-e 's:\<ar\>:$(AR):' \
+		-e 's:\<ranlib\>:$(RANLIB):' \
+		-e "/^LIBPATH/s:/lib:/$(get_libdir):" \
+		makefile || die
+	tc-export AR CC RANLIB
+}
+
+src_install() {
+	default
+	dodoc changes.txt float.pdf WARNING
+	docinto demos ; dodoc demos/ex1.c
+}

--- a/dev-libs/libtomfloat/libtomfloat-0.02.ebuild
+++ b/dev-libs/libtomfloat/libtomfloat-0.02.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
@@ -6,8 +6,8 @@ EAPI="4"
 inherit toolchain-funcs multilib
 
 DESCRIPTION="library for floating point number manipulation"
-HOMEPAGE="http://libtom.org/"
-SRC_URI="http://libtom.org/files/ltf-${PV}.tar.bz2"
+HOMEPAGE="http://www.libtom.net/"
+SRC_URI="https://github.com/libtom/libtomfloat/releases/download/${PV}/ltf-${PV}.tar.bz2"
 
 LICENSE="WTFPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This updates dev-libs/libtomfloat for EAPI=7. Also fixes the HOMEPAGE and SRC_URI.
Please review.