### PR TITLE
dev-libs/log4shib: fix SRC_URI, EAPI=7 bump

### DIFF
--- a/dev-libs/log4shib/log4shib-1.0.4-r1.ebuild
+++ b/dev-libs/log4shib/log4shib-1.0.4-r1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Internet2 version for OpenSAML of log4cpp logging framework"
+HOMEPAGE="https://wiki.shibboleth.net/confluence/display/OpenSAML/log4shib"
+SRC_URI="https://shibboleth.net/downloads/${PN}/${PV}/${P}.tar.gz"
+
+KEYWORDS="~amd64 ~x86"
+LICENSE="LGPL-2.1"
+SLOT="0"
+IUSE="debug doc static-libs"
+
+BDEPEND="doc? ( app-doc/doxygen )"
+
+src_configure() {
+	econf --without-idsa \
+		$(use_enable debug) \
+		$(use_enable doc doxygen) \
+		$(use_enable static-libs static)
+}

--- a/dev-libs/log4shib/log4shib-1.0.4.ebuild
+++ b/dev-libs/log4shib/log4shib-1.0.4.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
 
 DESCRIPTION="Internet2 version for OpenSAML of log4cpp logging framework"
 HOMEPAGE="https://wiki.shibboleth.net/confluence/display/OpenSAML/log4shib"
-SRC_URI="http://shibboleth.internet2.edu/downloads/${PN}/${PV}/${P}.tar.gz"
+SRC_URI="https://shibboleth.net/downloads/${PN}/${PV}/${P}.tar.gz"
 
 KEYWORDS="~amd64 ~x86"
 LICENSE="LGPL-2.1"


### PR DESCRIPTION
Hi,

Another simple EAPI=7 bump which also fixes the SRC_URI.
Please review.