### PR TITLE
app-laptop/tpacpi-bat: fix setting thresholds in init script

### DIFF
--- a/app-laptop/tpacpi-bat/files/tpacpi-bat.initd.3
+++ b/app-laptop/tpacpi-bat/files/tpacpi-bat.initd.3
@@ -1,0 +1,77 @@
+#!/sbin/openrc-run
+# Copyright (C) 2012-2016 Christoph Junghans <junghans@gentoo.org>
+#
+# Distributed under the terms of the GNU General Public License, v2 or later
+
+extra_started_commands="low high info"
+
+depend() {
+	after modules
+}
+
+start() {
+	local state1
+
+	ebegin "Making sure that module 'acpi_call' is loaded"
+	modprobe acpi_call
+	state1=$?
+	eend ${state1}
+
+	[ "${state1}" -ne "0" ] && return 1
+
+	ebegin "Starting ${SVCNAME}"
+	set_all ${TPACPI_BAT_THRESH_START} ${TPACPI_BAT_THRESH_STOP}
+	eend $?
+}
+
+stop() {
+	einfo "Nothing required to be done to stop ${SVCNAME}"
+}
+
+require_started() {
+	if ! service_started; then
+		"${RC_SERVICE}" start || return $?
+	fi
+}
+
+high() {
+	require_started
+
+	einfo "Switching ${SVCNAME} to high thesholds"
+	set_all ${TPACPI_BAT_HIGH_THRESH_START} ${TPACPI_BAT_HIGH_THRESH_STOP}
+}
+
+low() {
+	require_started
+
+	einfo "Switching ${SVCNAME} to low thesholds"
+	set_all ${TPACPI_BAT_LOW_THRESH_START} ${TPACPI_BAT_LOW_THRESH_STOP}
+}
+
+set_all() {
+	local tstart=$1
+	local tstop=$2
+	local bat
+
+	for bat in ${BATS}; do
+		ebegin "  setting thresholds for ${bat}: $tstart $tstop"
+		/usr/bin/tpacpi-bat -s startThreshold ${bat} ${tstart}
+		/usr/bin/tpacpi-bat -s stopThreshold ${bat} ${tstop}
+		/usr/bin/tpacpi-bat -s startThreshold ${bat} ${tstart}
+		eend $?
+	done
+}
+
+info() {
+	local tstart
+	local tstop
+	local bat
+
+	require_started
+
+	for bat in ${BATS}; do
+		tstart=$(/usr/bin/tpacpi-bat -g startThreshold ${bat})
+		tstop=$(/usr/bin/tpacpi-bat -g stopThreshold ${bat})
+		einfo "Battery ${bat}: ${tstart} ${tstop}"
+	done
+}

--- a/app-laptop/tpacpi-bat/tpacpi-bat-3.1-r1.ebuild
+++ b/app-laptop/tpacpi-bat/tpacpi-bat-3.1-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit systemd
+
+if [ "${PV}" = "9999" ]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/teleshoes/tpacpi-bat.git"
+	KEYWORDS=""
+else
+	SRC_URI="https://github.com/teleshoes/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+fi
+DESCRIPTION="Control battery thresholds of recent ThinkPads, not supported by tp_smapi"
+HOMEPAGE="https://github.com/teleshoes/tpacpi-bat"
+
+LICENSE="GPL-3"
+SLOT="0"
+IUSE=""
+
+DEPEND=""
+RDEPEND="sys-power/acpi_call
+	dev-lang/perl"
+
+src_install() {
+	dodoc README.md battery_asl
+	dobin tpacpi-bat
+	newinitd "${FILESDIR}"/${PN}.initd.3 ${PN}
+	newconfd "${FILESDIR}"/${PN}.confd.1 ${PN}
+	systemd_newunit examples/systemd_fixed_threshold/tpacpi.service \
+		${PN}.service
+}


### PR DESCRIPTION
app-laptop/tpacpi-bat: fix setting thresholds in init script
    
Some models seem to not transistion well from low to high when setting
first "start" and later "stop". Turning this around would make the
transistion from high to low fail.
So go for "start", "stop", "start" setting the latter twice. That allows
for both transistions to work as expected.
    
Signed-off-by: Henning Schild <henning@hennsch.de>