### PR TITLE
dev-python/wsaccel: add python target 3.7

### DIFF
--- a/dev-python/wsaccel/wsaccel-0.6.2_p20170108.ebuild
+++ b/dev-python/wsaccel/wsaccel-0.6.2_p20170108.ebuild
@@ -4,7 +4,7 @@
 EAPI=5
 
 COMMIT="0fbd074c257c51b73de05b25ccb6488801320a32"
-PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
* now supporting python 3.7
* no revbump because it won't change the final execution for the other python impls and 3.7 wasn't installable before