### PR TITLE
net-libs/liquid-dsp: use HTTPS

### DIFF
--- a/net-libs/liquid-dsp/liquid-dsp-1.3.0.ebuild
+++ b/net-libs/liquid-dsp/liquid-dsp-1.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools multilib
 
 DESCRIPTION="digital signal processing library for software-defined radios"
-HOMEPAGE="http://liquidsdr.org"
+HOMEPAGE="https://liquidsdr.org"
 
 LICENSE="MIT"
 SLOT="0"

--- a/net-libs/liquid-dsp/liquid-dsp-1.3.1.ebuild
+++ b/net-libs/liquid-dsp/liquid-dsp-1.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools multilib
 
 DESCRIPTION="digital signal processing library for software-defined radios"
-HOMEPAGE="http://liquidsdr.org"
+HOMEPAGE="https://liquidsdr.org"
 
 LICENSE="MIT"
 SLOT="0"

--- a/net-libs/liquid-dsp/liquid-dsp-9999.ebuild
+++ b/net-libs/liquid-dsp/liquid-dsp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools multilib
 
 DESCRIPTION="digital signal processing library for software-defined radios"
-HOMEPAGE="http://liquidsdr.org"
+HOMEPAGE="https://liquidsdr.org"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
hi, another simple http -> https fix.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>