### PR TITLE
www-client/chromium: add note about native file dialog on KDE

### DIFF
--- a/www-client/chromium/chromium-73.0.3683.75.ebuild
+++ b/www-client/chromium/chromium-73.0.3683.75.ebuild
@@ -136,6 +136,10 @@ are not displayed properly:
 To fix broken icons on the Downloads page, you should install an icon
 theme that covers the appropriate MIME types, and configure this as your
 GTK+ icon theme.
+
+In order to have a native file dialog in an KDE desktop environment, please
+install:
+- kde-apps/kdialog
 "
 
 PATCHES=(

--- a/www-client/chromium/chromium-73.0.3683.86.ebuild
+++ b/www-client/chromium/chromium-73.0.3683.86.ebuild
@@ -136,6 +136,10 @@ are not displayed properly:
 To fix broken icons on the Downloads page, you should install an icon
 theme that covers the appropriate MIME types, and configure this as your
 GTK+ icon theme.
+
+In order to have a native file dialog in an KDE desktop environment, please
+install:
+- kde-apps/kdialog
 "
 
 PATCHES=(

--- a/www-client/chromium/chromium-74.0.3729.169.ebuild
+++ b/www-client/chromium/chromium-74.0.3729.169.ebuild
@@ -139,6 +139,10 @@ are not displayed properly:
 To fix broken icons on the Downloads page, you should install an icon
 theme that covers the appropriate MIME types, and configure this as your
 GTK+ icon theme.
+
+In order to have a native file dialog in an KDE desktop environment, please
+install:
+- kde-apps/kdialog
 "
 
 PATCHES=(


### PR DESCRIPTION
Add a note about native file dialog on KDE:
In order to have a native file dialog users need to install kde-apps/kdialog.

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>
Closes: https://bugs.gentoo.org/687016