### PR TITLE
app-admin/rasdaemon: fix sqlite use flag

### DIFF
--- a/app-admin/rasdaemon/rasdaemon-0.6.2-r4.ebuild
+++ b/app-admin/rasdaemon/rasdaemon-0.6.2-r4.ebuild
@@ -33,6 +33,7 @@ pkg_setup() {
 
 src_configure() {
 	local myconf=(
+		$(use_enable sqlite sqlite3)
 		--enable-abrt-report
 		--enable-aer
 		--enable-arm
@@ -40,13 +41,9 @@ src_configure() {
 		--enable-hisi-ns-decode
 		--enable-mce
 		--enable-non-standard
-		--enable-sqlite3
 		--includedir="/usr/include/${PN}"
 		--localstatedir=/var
 	)
-	if use sqlite ; then
-		myconf="${myconf} --enable-sqlite3)"
-	fi
 
 	econf "${myconf[@]}"
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/687056
Package-Manager: Portage-2.3.67, Repoman-2.3.13
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>