### PR TITLE
dev-cpp/sourcetrail Add RESTIRCT to prohibit mirroring

### DIFF
--- a/dev-cpp/sourcetrail/sourcetrail-2018.3.55-r1.ebuild
+++ b/dev-cpp/sourcetrail/sourcetrail-2018.3.55-r1.ebuild
@@ -9,10 +9,11 @@ DESCRIPTION="A cross-platform source explorer for C/C++ and Java"
 HOMEPAGE="https://www.sourcetrail.com/"
 SRC_URI="https://www.sourcetrail.com/downloads/${PV}/linux/64bit -> ${P}.tar.gz"
 
-LICENSE="Sourcetrail || ( GPL-2 GPL-3 LGPL-3 ) FDL-1.3 BSD"
+LICENSE="Sourcetrail || ( GPL-2 GPL-3 LGPL-3 ) BSD"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE="examples selinux"
+RESTRICT="mirror bindist"
 
 DEPEND="dev-util/patchelf"
 

--- a/dev-cpp/sourcetrail/sourcetrail-2019.1.11.ebuild
+++ b/dev-cpp/sourcetrail/sourcetrail-2019.1.11.ebuild
@@ -9,10 +9,11 @@ DESCRIPTION="A cross-platform source explorer for C/C++ and Java"
 HOMEPAGE="https://www.sourcetrail.com/"
 SRC_URI="https://www.sourcetrail.com/downloads/${PV}/linux/64bit -> ${P}.tar.gz"
 
-LICENSE="Sourcetrail || ( GPL-2 GPL-3 LGPL-3 ) FDL-1.3 BSD"
+LICENSE="Sourcetrail || ( GPL-2 GPL-3 LGPL-3 ) BSD"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE="examples selinux"
+RESTRICT="mirror bindist"
 
 DEPEND="dev-util/patchelf"
 


### PR DESCRIPTION
Add RESTIRCT keyword so that we do not mirror the tarballs because of
license issues.

Closes: https://bugs.gentoo.org/687018