### PR TITLE
libreoffice-bin dep version bump dev-libs/icu-64.2

### DIFF
--- a/app-office/libreoffice-bin/libreoffice-bin-6.1.5.2.ebuild
+++ b/app-office/libreoffice-bin/libreoffice-bin-6.1.5.2.ebuild
@@ -58,7 +58,7 @@ BIN_COMMON_DEPEND="
 	=app-text/libexttextcat-3.4*
 	=app-text/libmwaw-0.3*
 	dev-libs/boost:0/1.65.0
-	dev-libs/icu:0/63.1
+	dev-libs/icu:0/64.2
 	>=media-gfx/graphite2-1.3.10
 	media-libs/harfbuzz:0/0.9.18[icu]
 	media-libs/libpng:0/16


### PR DESCRIPTION
Dependency version bump to dev-libs/icu-64.2.

```text
WARNING: One or more updates/rebuilds have been skipped due to a dependency conflict:

dev-libs/icu:0

  (dev-libs/icu-64.2:0/64.2::gentoo, ebuild scheduled for merge) conflicts with
    dev-libs/icu:0/63.1= required by (app-office/libreoffice-bin-6.1.5.2:0/0::gentoo, instal
                ^^^^^^^^
    dev-libs/icu:0/63.1 required by (app-office/libreoffice-bin-6.1.5.2:0/0::gentoo, install
                ^^^^^^^
```

I have not tested yet the new version bump so you may wish to test before hand to ensure it works before merging.

:smiley: