### PR TITLE
meson.eclass: fix cross compile file for mingw

### DIFF
--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Gentoo Authors
+# Copyright 2017-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: meson.eclass
@@ -154,6 +154,7 @@ _meson_create_cross_file() {
 	objcpp = $(_meson_env_array "$(tc-getPROG OBJCXX c++)")
 	pkgconfig = '$(tc-getPKG_CONFIG)'
 	strip = $(_meson_env_array "$(tc-getSTRIP)")
+	windres = $(_meson_env_array "$(tc-getRC)")
 
 	[properties]
 	c_args = $(_meson_env_array "${CFLAGS} ${CPPFLAGS}")


### PR DESCRIPTION
This is necessary for cross compiling for example x11-libs/gdk-pixbuf

An other solution would be to include
windres = $(_meson_env_array "$(tc-getRC)")
regardless ot the target.

@floppym and or William Hubbs: Can you take a look at this?

Signed-off-by: Gerhard Bräunlich <g.braeunlich@disroot.org>