### PR TITLE
media-libs/libepoxy: Make egl configurable

### DIFF
--- a/media-libs/libepoxy/libepoxy-1.5.3-r1.ebuild
+++ b/media-libs/libepoxy/libepoxy-1.5.3-r1.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/anholt/libepoxy"
 if [[ ${PV} = 9999* ]]; then
 	SRC_URI=""
 else
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-fbsd"
 	SRC_URI="https://github.com/anholt/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 fi
 

--- a/media-libs/libepoxy/metadata.xml
+++ b/media-libs/libepoxy/metadata.xml
@@ -5,6 +5,9 @@
 		<email>x11@gentoo.org</email>
 		<name>X11</name>
 	</maintainer>
+	<use>
+		<flag name="egl">Enable EGL support.</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">anholt/libepoxy</remote-id>
 	</upstream>


### PR DESCRIPTION
Can we make egl configurable? When cross compiling with mingw, egl pulls in mesa and other x11 libs, which are not needed for windows targets.

Signed-off-by: Gerhard Bräunlich <g.braeunlich@disroot.org>
Package-Manager: Portage-2.3.66, Repoman-2.3.11