### PR TITLE
sys-fs/fuseiso: fix sys-fs/fuse dep and bump to EAPI=7

### DIFF
--- a/sys-fs/fuseiso/fuseiso-20070708-r2.ebuild
+++ b/sys-fs/fuseiso/fuseiso-20070708-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 DESCRIPTION="Fuse module to mount ISO9660"
 HOMEPAGE="https://sourceforge.net/projects/fuseiso"
@@ -11,11 +11,12 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ~ppc64 x86"
 
-RDEPEND="sys-fs/fuse:=
+RDEPEND="sys-fs/fuse:0=
 	sys-libs/zlib
 	dev-libs/glib:2"
-DEPEND="${RDEPEND}
-	virtual/pkgconfig"
+
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
 
 DOCS=( AUTHORS ChangeLog NEWS README )
 PATCHES=( ${FILESDIR}/${P}-largeiso.patch ${FILESDIR}/${P}-fix-typo.patch )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/673650
Closes: https://github.com/gentoo/gentoo/pull/12188
Signed-off-by: xiaoqiang.zhao <zhaoxiaoqiang007@gmail.com>