### PR TITLE
games-fps/gzdoom: Remove cephes from LICENSES list

### DIFF
--- a/games-fps/gzdoom/gzdoom-4.1.2.ebuild
+++ b/games-fps/gzdoom/gzdoom-4.1.2.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="A modder-friendly OpenGL source port based on the DOOM engine"
 HOMEPAGE="https://zdoom.org"
 SRC_URI="https://github.com/coelckers/${PN}/archive/g${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="BSD BZIP2 cephes DUMB-0.9.3 GPL-3 LGPL-3 MIT"
+LICENSE="BSD BZIP2 DUMB-0.9.3 GPL-3 LGPL-3 MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="fluidsynth gtk gtk2 openal openmp"

--- a/licenses/cephes
+++ b/licenses/cephes
@@ -1,9 +1,0 @@
-   Some software in this archive may be from the book _Methods and
-Programs for Mathematical Functions_ (Prentice-Hall or Simon & Schuster
-International, 1989) or from the Cephes Mathematical Library, a
-commercial product. In either event, it is copyrighted by the author.
-What you see here may be used freely but it comes with no support or
-guarantee.
-
-   Stephen L. Moshier
-   moshier@na-net.ornl.gov


### PR DESCRIPTION
The Cephes code used in GZDoom is provided under the BSD license, so the
cephes license is not necessary.
See also <https://lists.debian.org/debian-legal/2004/12/msg00295.html>.

Bug: https://bugs.gentoo.org/687276
Package-Manager: Portage-2.3.67, Repoman-2.3.13
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>