### PR TITLE
eclass/texlive-common: call non-empty ${ROOT}

### DIFF
--- a/eclass/texlive-common.eclass
+++ b/eclass/texlive-common.eclass
@@ -140,7 +140,7 @@ dobin_texmf_scripts() {
 
 etexmf-update() {
 	if has_version 'app-text/texlive-core' ; then
-		if [ "$ROOT" = "/" ] && [ -x "${EPREFIX}"/usr/sbin/texmf-update ] ; then
+		if [ -n ${ROOT%/} ] && [ -x "${EPREFIX}"/usr/sbin/texmf-update ] ; then
 			"${EPREFIX}"/usr/sbin/texmf-update
 		else
 			ewarn "Cannot run texmf-update for some reason."
@@ -158,7 +158,7 @@ etexmf-update() {
 
 efmtutil-sys() {
 	if has_version 'app-text/texlive-core' ; then
-		if [ "$ROOT" = "/" ] && [ -x "${EPREFIX}"/usr/bin/fmtutil-sys ] ; then
+		if [ -n ${ROOT%/} ] && [ -x "${EPREFIX}"/usr/bin/fmtutil-sys ] ; then
 			einfo "Rebuilding formats"
 			"${EPREFIX}"/usr/bin/fmtutil-sys --all &> /dev/null
 		else


### PR DESCRIPTION
EAPI=7 introduces empty ROOT variable if the actual root
is defined as "/", this leads to the false-negative
texmf-update and fmtutil calls.

Closes: https://bugs.gentoo.org/687306

Signed-off-by: Mikle Kolyada <zlogene@gentoo.org>

@aballier 