### PR TITLE
Mask dev-lang/php:5.6 for removal

### DIFF
--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -169,4 +169,4 @@ POSTGRES_TARGETS="postgres10 postgres11"
 # Moreover, it should only contain targets that have a stable version
 # of PHP, to avoid pulling in an unstable PHP on stable systems.
 #
-PHP_TARGETS="php5-6 php7-1"
+PHP_TARGETS="php7-1"

--- a/profiles/base/use.mask
+++ b/profiles/base/use.mask
@@ -4,6 +4,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Thomas Deutschmann <whissi@gentoo.org> (6 Jun 2019)
+# EOL since Jan 2019. Removal in 30 days.
+php_targets_php5-6
+
 # Hans de Graaff <graaff@gentoo.org> (7 Apr 2019)
 # Mask Ruby 2.3 as EOL
 ruby_targets_ruby23

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -29,6 +29,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Thomas Deutschmann <whissi@gentoo.org> (6 Jun 2019)
+# EOL since Jan 2019. Removal in 30 days.
+dev-lang/php:5.6
+
 # Andreas K. Hüttel <dilfridge@gentoo.org> (5 Jun 2019)
 # Unhandled version bumps since 2015, bug 293306. EAPI=2.
 # Removal in 30 days unless updated.


### PR DESCRIPTION
Let's see if we can get rid of dev-lang/php:5.6...