### PR TITLE
net-wireless/wpa_supplicant: Fix mandatory dbus

### DIFF
--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.8.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.8.ebuild
@@ -168,6 +168,10 @@ src_configure() {
 		Kconfig_style_config CTRL_IFACE_DBUS
 		Kconfig_style_config CTRL_IFACE_DBUS_NEW
 		Kconfig_style_config CTRL_IFACE_DBUS_INTRO
+	else
+		Kconfig_style_config CTRL_IFACE_DBUS n
+		Kconfig_style_config CTRL_IFACE_DBUS_NEW n
+		Kconfig_style_config CTRL_IFACE_DBUS_INTRO n
 	fi
 
 	if use eapol_test ; then


### PR DESCRIPTION
The default configuration requires dbus.
It is disabled when the dbus flag is not set.

Closes: https://bugs.gentoo.org/684284
Signed-off-by: Gábor Oszkár Dénes <gaboroszkar@protonmail.com>
Package-Manager: Portage-2.3.66, Repoman-2.3.11