### PR TITLE
dev-util/scons-3.0.5-r1: fix unresolved & unpredictable test failures

### DIFF
--- a/dev-util/scons/files/scons-3.0.5-jdk-include-path.patch
+++ b/dev-util/scons/files/scons-3.0.5-jdk-include-path.patch
@@ -1,0 +1,14 @@
+diff -Nur old/scons-3.0.5/src/engine/SCons/Tool/JavaCommon.py new/scons-3.0.5/src/engine/SCons/Tool/JavaCommon.py
+--- old/src/engine/SCons/Tool/JavaCommon.py	2019-03-27 02:16:32.000000000 +0300
++++ new/src/engine/SCons/Tool/JavaCommon.py	2019-06-04 10:44:01.000000000 +0300
+@@ -403,7 +403,8 @@
+ java_macos_version_include_dir = '/System/Library/Frameworks/JavaVM.framework/Versions/%s*/Headers/'
+ 
+-java_linux_include_dirs = ['/usr/lib/jvm/default-java/include',
+-                        '/usr/lib/jvm/java-*/include']
++java_linux_include_dirs = ['/usr/lib/jvm/*/include',
++                        '/opt/*jdk-bin-*/include',
++                        '/usr/lib*/openjdk-*/include']
+ # Need to match path like below (from Centos 7)
+ # /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.191.b12-0.el7_5.x86_64/include/
+ java_linux_version_include_dirs = ['/usr/lib/jvm/java-*-sun-%s*/include',

--- a/dev-util/scons/files/scons-3.0.5-jni.h-include-path.patch
+++ b/dev-util/scons/files/scons-3.0.5-jni.h-include-path.patch
@@ -1,0 +1,14 @@
+diff -Nur old/testing/framework/TestSCons.py new/testing/framework/TestSCons.py
+--- old/testing/framework/TestSCons.py	2019-03-27 02:15:48.000000000 +0300
++++ new/testing/framework/TestSCons.py	2019-06-07 16:13:48.000000000 +0300
+@@ -742,7 +742,8 @@
+             version=''
+             jni_dirs = ['/System/Library/Frameworks/JavaVM.framework/Headers/jni.h',
+-                        '/usr/lib/jvm/default-java/include/jni.h',
+-                        '/usr/lib/jvm/java-*-oracle/include/jni.h']
++                        '/usr/lib/jvm/*/include/jni.h',
++                        '/opt/*jdk-bin-*/include/jni.h',
++                        '/usr/lib*/openjdk-*/include/jni.h']
+         else:
+             jni_dirs = ['/System/Library/Frameworks/JavaVM.framework/Versions/%s*/Headers/jni.h'%version]
+         jni_dirs.extend(['/usr/lib/jvm/java-*-sun-%s*/include/jni.h'%version,

--- a/dev-util/scons/scons-3.0.5-r1.ebuild
+++ b/dev-util/scons/scons-3.0.5-r1.ebuild
@@ -43,14 +43,11 @@ src_unpack() {
 	# inside src/ subdirectory to make our life easier
 	if use test; then
 		unpack "${P}.gh.tar.gz"
-		rm -r "${P}/src" || die
 	else
-		mkdir "${P}" || die
+		mkdir -p "${P}"/src || die
 	fi
 
-	cd "${P}" || die
-	unpack "${P}.tar.gz"
-	mv "${P}" src || die
+	tar -C "${P}"/src --strip-components=1 -xzf "${DISTDIR}/${P}.tar.gz" || die
 }
 
 src_prepare() {

--- a/dev-util/scons/scons-3.0.5-r1.ebuild
+++ b/dev-util/scons/scons-3.0.5-r1.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python{2_7,3_{5,6}} )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1
+
+DESCRIPTION="Extensible Python-based build utility"
+HOMEPAGE="http://www.scons.org/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz
+	doc? (
+		http://www.scons.org/doc/${PV}/PDF/${PN}-user.pdf -> ${P}-user.pdf
+		http://www.scons.org/doc/${PV}/HTML/${PN}-user.html -> ${P}-user.html
+	)
+	test? ( https://github.com/scons/scons/archive/${PV}.tar.gz -> ${P}.gh.tar.gz )"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc test"
+# unresolved & unpredictable test failures
+RESTRICT="test"
+
+S=${WORKDIR}/${P}/src
+
+PATCHES=(
+	# support env passthrough for Gentoo ebuilds
+	"${FILESDIR}"/scons-3.0.1-env-passthrough.patch
+	# respect CC, CXX, C*FLAGS, LDFLAGS by default
+	"${FILESDIR}"/scons-3.0.3-respect-cc-etc-r1.patch
+)
+
+src_unpack() {
+	# use the git directory structure, but put pregenerated release
+	# inside src/ subdirectory to make our life easier
+	if use test; then
+		unpack "${P}.gh.tar.gz"
+		rm -r "${P}/src" || die
+	else
+		mkdir "${P}" || die
+	fi
+
+	cd "${P}" || die
+	unpack "${P}.tar.gz"
+	mv "${P}" src || die
+}
+
+src_prepare() {
+	# apply patches relatively to top directory
+	cd "${WORKDIR}/${P}" || die
+	distutils-r1_src_prepare
+
+	# remove half-broken, useless custom commands
+	# and fix manpage install location
+	sed -i -e '/cmdclass/,/},$/d' \
+		-e '/data_files/s:man/:share/man/:' "${S}"/setup.py || die
+}
+
+python_test() {
+	cd "${WORKDIR}/${P}" || die
+	"${EPYTHON}" runtest.py -as \
+		-j "$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")" \
+		--builddir "${BUILD_DIR}/lib" ||
+		die "Tests fail with ${EPYTHON}"
+}
+
+python_install_all() {
+	local DOCS=( {CHANGES,README,RELEASE}.txt )
+	distutils-r1_python_install_all
+	rm "${ED%/}/usr/bin/scons.bat" || die
+
+	use doc && dodoc "${DISTDIR}"/${P}-user.{pdf,html}
+}

--- a/dev-util/scons/scons-3.0.5-r1.ebuild
+++ b/dev-util/scons/scons-3.0.5-r1.ebuild
@@ -36,6 +36,8 @@ PATCHES=(
 	"${FILESDIR}"/scons-3.0.1-env-passthrough.patch
 	# respect CC, CXX, C*FLAGS, LDFLAGS by default
 	"${FILESDIR}"/scons-3.0.3-respect-cc-etc-r1.patch
+	# add Gentoo JDK include installation paths
+	"${FILESDIR}"/scons-3.0.5-jdk-include-path.patch
 )
 
 src_unpack() {
@@ -59,6 +61,10 @@ src_prepare() {
 	# and fix manpage install location
 	sed -i -e '/cmdclass/,/},$/d' \
 		-e '/data_files/s:man/:share/man/:' "${S}"/setup.py || die
+	if use test; then
+		# addtional fix for Gentoo JDK installation paths to find include directory with jni.h
+		eapply "${FILESDIR}"/scons-3.0.5-jni.h-include-path.patch
+	fi
 }
 
 python_test() {

--- a/dev-util/scons/scons-3.0.5-r1.ebuild
+++ b/dev-util/scons/scons-3.0.5-r1.ebuild
@@ -62,6 +62,8 @@ src_prepare() {
 }
 
 python_test() {
+	# set variable from escons() of scons-util.eclass to make env-passthrough patch work within test env
+	local -x GENTOO_SCONS_ENV_PASSTHROUGH=1
 	cd "${WORKDIR}/${P}" || die
 	"${EPYTHON}" runtest.py -a --passed \
 		-j "$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")" \

--- a/dev-util/scons/scons-3.0.5-r1.ebuild
+++ b/dev-util/scons/scons-3.0.5-r1.ebuild
@@ -64,6 +64,8 @@ src_prepare() {
 python_test() {
 	# set variable from escons() of scons-util.eclass to make env-passthrough patch work within test env
 	local -x GENTOO_SCONS_ENV_PASSTHROUGH=1
+	# unset some env variables to pass appropriate tests
+	unset AR AS ASFLAGS CC CXX CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
 	cd "${WORKDIR}/${P}" || die
 	"${EPYTHON}" runtest.py -a --passed \
 		-j "$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")" \

--- a/dev-util/scons/scons-3.0.5-r1.ebuild
+++ b/dev-util/scons/scons-3.0.5-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_{5,6}} )
+PYTHON_COMPAT=( python{2_7,3_{5,6,7}} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1


### PR DESCRIPTION
This pull request fix the following 
1. Test exit status now doesn't result in FAIL of test phase in case of presence of "no result" without "failed".
2. Fix src_unpack() to store files required for some Docbook tests.
3. Fix passthrough of $PATH env to test env (to repair Clang tests).
4. Unset CC, CXX, C*FLAGS, LDFLAGS withon python_test() (to repair appropriate tests).
5. Repair JDK include installation paths (repair one Java and one SWIG test).
6. Add PYTHON_COMPAT=( python3_7 ).

--------------

@mgorny , please review this pull request.