### PR TITLE
app-antivirus/clamav: Added "after sshd" to init file

### DIFF
--- a/app-antivirus/clamav/files/clamd.initd-r6
+++ b/app-antivirus/clamav/files/clamd.initd-r6
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 daemon_clamd="/usr/sbin/clamd"
@@ -9,6 +9,7 @@ daemon_milter="/usr/sbin/clamav-milter"
 extra_commands="logfix"
 
 depend() {
+	after sshd
 	use net
 	provide antivirus
 }


### PR DESCRIPTION
Even on powerful servers, launching clamd can take a significant amount of time, because parsing virus definitions has become slower and slower in recent versions (as mentioned on the ClamAV mailing list). My init file modification is meant to ensure that the SSH daemon is already running when ClamAV is launched.