### PR TITLE
media-video/aegisub: Enable testing with >=dev-cpp/gtest-1.8.1

### DIFF
--- a/media-video/aegisub/aegisub-3.2.2_p20160518-r2.ebuild
+++ b/media-video/aegisub/aegisub-3.2.2_p20160518-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -46,7 +46,7 @@ DEPEND="${RDEPEND}
 	sys-devel/gettext
 	virtual/pkgconfig
 	test? (
-		~dev-cpp/gtest-1.7.0
+		>=dev-cpp/gtest-1.8.1
 		dev-lua/busted
 		dev-lua/luarocks
 	)

--- a/media-video/aegisub/files/3.2.2_p20160518/aegisub-3.2.2_p20160518-support-system-gtest.patch
+++ b/media-video/aegisub/files/3.2.2_p20160518/aegisub-3.2.2_p20160518-support-system-gtest.patch
@@ -24,13 +24,13 @@ index 8c30c1d..c5bf049 100644
  GTEST_ROOT ?= $(TOP)vendor/googletest
  GTEST_FILE := ${GTEST_ROOT}/src/gtest-all
 +GTEST_CPPFLAGS := -I$(GTEST_ROOT) -I$(GTEST_ROOT)/include
-+GTEST_CXXFLAGS := $(CFLAGS_PTHREAD)
 +GTEST_LIBS := $(LIBS_PTHREAD)
 +else
-+GTEST_CPPFLAGS := $(shell gtest-config --cppflags)
-+GTEST_CXXFLAGS := $(shell gtest-config --cxxflags)
-+GTEST_LIBS := $(shell gtest-config --libs)
++GTEST_CPPFLAGS := $(shell pkg-config --cflags-only-I gtest)
++GTEST_LIBS := $(shell pkg-config --libs gtest)
 +endif
++
++GTEST_CXXFLAGS := $(CFLAGS_PTHREAD)
 
  run_PCH := $(d)support/tests_pre.h
  run_CPPFLAGS := -I$(TOP)libaegisub/include -I$(TOP) -I$(d)support \


### PR DESCRIPTION
I maintain _dev-cpp/gtest_ .  This is the last package to depend on _dev-cpp/gtest-1.7.0_ and I would love to eventually purge it from the tree.  Tests build, run, and pass just fine with _>=dev-cpp/gtest-1.8.1_ though a few unrelated lua tests sporadically fail, likely due to https://github.com/Aegisub/Aegisub/issues/99.

Note, the patch was modified to pass `$(CFLAGS_PTHREAD)` as a value for `GTEST_CXXFLAGS`.  The value of `$(shell pkg-config --cflags gtest)` or `$(shell pkg-config --cflags-only-other gtest)` would have included `-lpthread` while compiling a pre-compiled header.  This, for some reason, triggers gcc into building it as an executable and the build fails since it can't find `main()`.

Tested with _dev-cpp/gtest-1.8.1-r2_ and _dev-cpp/gtest-1.9.0_pre20190607_

Package-Manager: Portage-2.3.67, Repoman-2.3.13
Signed-off-by: Peter Levine <plevine457@gmail.com>