### PR TITLE
net-libs/wvstreams: add USE=libressl and patch for LibreSSL support

### DIFF
--- a/net-libs/wvstreams/files/wvstreams-4.6.1_p14-libressl.patch
+++ b/net-libs/wvstreams/files/wvstreams-4.6.1_p14-libressl.patch
@@ -1,0 +1,114 @@
+From cb8a81da928054c2e8174d671f2abc88f4f35b87 Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <steils@gentoo.org>
+Date: Mon, 10 Jun 2019 17:07:06 +0300
+Subject: [PATCH] Fix LibreSSL support
+
+---
+ crypto/wvocsp.cc    | 34 ++++++++++++++++++++++++++++++++++
+ crypto/wvx509mgr.cc | 14 ++++++++++++++
+ include/wvdigest.h  |  1 +
+ 3 files changed, 49 insertions(+)
+
+diff --git a/crypto/wvocsp.cc b/crypto/wvocsp.cc
+index 7d5da072..7a157f90 100644
+--- a/crypto/wvocsp.cc
++++ b/crypto/wvocsp.cc
+@@ -130,6 +130,7 @@ bool WvOCSPResp::signedbycert(const WvX509 &cert) const
+ }
+ 
+ 
++#ifndef LIBRESSL_VERSION_NUMBER
+ WvX509 WvOCSPResp::get_signing_cert() const
+ {
+     const STACK_OF(X509) *certs = OCSP_resp_get0_certs(bs);
+@@ -143,6 +144,39 @@ WvX509 WvOCSPResp::get_signing_cert() const
+ 
+     return WvX509();
+ }
++#else
++WvX509 WvOCSPResp::get_signing_cert() const
++{
++    if (!bs || !sk_X509_num(bs->certs))
++        return WvX509();
++
++    // note: the following bit of code is taken almost verbatim from
++    // ocsp_vfy.c in OpenSSL 0.9.8. Copyright and attribution should
++    // properly belong to them
++
++    OCSP_RESPID *id = bs->tbsResponseData->responderId;
++
++    if (id->type == V_OCSP_RESPID_NAME)
++    {
++        X509 *x = X509_find_by_subject(bs->certs, id->value.byName);
++        if (x)
++            return WvX509(X509_dup(x));
++    }
++
++    if (id->value.byKey->length != SHA_DIGEST_LENGTH) return NULL;
++    unsigned char tmphash[SHA_DIGEST_LENGTH];
++    unsigned char *keyhash = id->value.byKey->data;
++    for (int i = 0; i < sk_X509_num(bs->certs); i++)
++    {
++        X509 *x = sk_X509_value(bs->certs, i);
++        X509_pubkey_digest(x, EVP_sha1(), tmphash, NULL);
++        if(!memcmp(keyhash, tmphash, SHA_DIGEST_LENGTH))
++            return WvX509(X509_dup(x));
++    }
++
++    return WvX509();
++}
++#endif /* LIBRESSL_VERSION_NUMBER */
+ 
+ 
+ WvOCSPResp::Status WvOCSPResp::get_status(const WvX509 &cert, 
+diff --git a/crypto/wvx509mgr.cc b/crypto/wvx509mgr.cc
+index 156d3a49..e2bb3ffe 100644
+--- a/crypto/wvx509mgr.cc
++++ b/crypto/wvx509mgr.cc
+@@ -350,8 +350,15 @@ bool WvX509Mgr::signcert(WvX509 &unsignedcert) const
+         return false;
+     }
+ 
++#ifndef LIBRESSL_VERSION_NUMBER
+     uint32_t ex_flags = X509_get_extension_flags(cert);
+     uint32_t ex_kusage = X509_get_key_usage(cert);
++#else
++    X509_check_purpose(cert, -1, -1);
++    uint32_t ex_flags = cert->ex_flags;
++    uint32_t ex_kusage = (cert->ex_flags & EXFLAG_KUSAGE) ?
++                         cert->ex_kusage : UINT32_MAX;
++#endif
+     if (cert == unsignedcert.cert)
+     {
+ 	debug("Self Signing!\n");
+@@ -392,8 +399,15 @@ bool WvX509Mgr::signcert(WvX509 &unsignedcert) const
+ 
+ bool WvX509Mgr::signcrl(WvCRL &crl) const
+ {
++#ifndef LIBRESSL_VERSION_NUMBER
+     uint32_t ex_flags = X509_get_extension_flags(cert);
+     uint32_t ex_kusage = X509_get_key_usage(cert);
++#else
++    X509_check_purpose(cert, -1, -1);
++    uint32_t ex_flags = cert->ex_flags;
++    uint32_t ex_kusage = (cert->ex_flags & EXFLAG_KUSAGE) ?
++                         cert->ex_kusage : UINT32_MAX;
++#endif
+     if (!isok() || !crl.isok())
+     {
+         debug(WvLog::Warning, "Asked to sign CRL, but certificate or CRL (or "
+diff --git a/include/wvdigest.h b/include/wvdigest.h
+index f2eed401..e637fb49 100644
+--- a/include/wvdigest.h
++++ b/include/wvdigest.h
+@@ -10,6 +10,7 @@
+ #include "wvencoder.h"
+ #include <stdint.h>
+ #include <openssl/evp.h>
++#include <openssl/hmac.h>
+ 
+ 
+ /**
+-- 
+2.21.0
+

--- a/net-libs/wvstreams/wvstreams-4.6.1_p14-r1.ebuild
+++ b/net-libs/wvstreams/wvstreams-4.6.1_p14-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~sparc ~x86"
-IUSE="pam doc +ssl +dbus debug boost"
+IUSE="boost +dbus debug doc libressl pam"
 
 #Tests fail if openssl is not compiled with -DPURIFY. Gentoo's isn't. FAIL!
 RESTRICT="test"
@@ -24,10 +24,11 @@ RESTRICT="test"
 #more tightly this time. Probably for the better since upstream xplc seems dead.
 
 RDEPEND="
-	>=dev-libs/openssl-1.1:0=
 	sys-libs/readline:0=
 	sys-libs/zlib
 	dbus? ( >=sys-apps/dbus-1.4.20 )
+	!libressl? ( >=dev-libs/openssl-1.1:0= )
+	libressl? ( dev-libs/libressl:0= )
 	pam? ( virtual/pam )
 "
 DEPEND="
@@ -49,6 +50,7 @@ src_prepare() {
 	default
 
 	eapply $(awk '{ print "'"${WORKDIR}"'/debian/patches/" $0; }' < "${WORKDIR}"/debian/patches/series)
+	eapply "${FILESDIR}"/${P}-libressl.patch # bug 687096
 
 	eautoreconf
 }

--- a/net-libs/wvstreams/wvstreams-99999.ebuild
+++ b/net-libs/wvstreams/wvstreams-99999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,13 +12,14 @@ EGIT_REPO_URI="${HOMEPAGE}"
 LICENSE="GPL-2"
 SLOT="0/5.0"
 KEYWORDS=""
-IUSE="+dbus debug doc pam static-libs +zlib"
+IUSE="+dbus debug doc libressl pam static-libs +zlib"
 
 RDEPEND="
-	<dev-libs/openssl-1.1:0=
 	sys-libs/readline:0=
 	sys-libs/zlib
 	dbus? ( >=sys-apps/dbus-1.4.20 )
+	!libressl? ( <dev-libs/openssl-1.1:0= )
+	libressl? ( dev-libs/libressl:0= )
 	pam? ( virtual/pam )
 "
 DEPEND="


### PR DESCRIPTION
Drop the redundant "ssl" flag, since wvstreams is always built with SSL
support.

Closes: https://bugs.gentoo.org/687096
Package-Manager: Portage-2.3.67, Repoman-2.3.14
Signed-off-by: Stefan Strogin <steils@gentoo.org>