### PR TITLE
liborcus - libixion and mdds version bump

### DIFF
--- a/dev-libs/liborcus/liborcus-0.13.4.ebuild
+++ b/dev-libs/liborcus/liborcus-0.13.4.ebuild
@@ -25,10 +25,10 @@ RDEPEND="
 	dev-libs/boost:=
 	sys-libs/zlib
 	python? ( ${PYTHON_DEPS} )
-	spreadsheet-model? ( =dev-libs/libixion-0.13*:= )
+	spreadsheet-model? ( =dev-libs/libixion-0.14*:= )
 "
 DEPEND="${RDEPEND}
-	=dev-util/mdds-1.3*:1
+	=dev-util/mdds-1.4*:1
 "
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"


### PR DESCRIPTION
Signed-off-by: Lilly Chalupowski <lillypadgirl86@gmail.com>

```text
dev-libs/libixion:0

  (dev-libs/libixion-0.14.1:0/0.14::gentoo, ebuild scheduled for merge) conflicts
with
    =dev-libs/libixion-0.13*:= required by (dev-libs/liborcus-0.13.4:0/0.13::gentoo,
installed)
    ^                  ^^^^^
    =dev-libs/libixion-0.13*:0/0.13= required by
(dev-libs/liborcus-0.13.4:0/0.13::gentoo, installed)
    ^                  ^^^^^^^^^^^^^

dev-util/mdds:1

  (dev-util/mdds-1.4.3:1/1.4::gentoo, ebuild scheduled for merge) conflicts with
    =dev-util/mdds-1.3*:1 required by (dev-libs/liborcus-0.13.4:0/0.13::gentoo,
installed)
    ^              ^^^^
    =dev-util/mdds-1.3*:1= required by (dev-libs/libixion-0.13.0:0/0.13::gentoo,
ebuild scheduled for merge)
    ^              ^^^^
```