### PR TITLE
net-wireless/wpa_supplicant: support USE="-smartcard -ap -wps"

### DIFF
--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.8-r1.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.8-r1.ebuild
@@ -149,8 +149,6 @@ src_configure() {
 	Kconfig_style_config EAP_OTP
 	Kconfig_style_config EAP_PAX
 	Kconfig_style_config EAP_PSK
-	Kconfig_style_config EAP_TLV
-	Kconfig_style_config EAP_EXE
 	Kconfig_style_config IEEE8021X_EAPOL
 	Kconfig_style_config PKCS12
 	Kconfig_style_config PEERKEY

--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.8-r1.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.8-r1.ebuild
@@ -237,6 +237,8 @@ src_configure() {
 
 	if use smartcard ; then
 		Kconfig_style_config SMARTCARD
+	else
+		Kconfig_style_config SMARTCARD n
 	fi
 
 	if use tdls ; then
@@ -281,6 +283,8 @@ src_configure() {
 		Kconfig_style_config WPS_UPNP
 		# Near Field Communication
 		Kconfig_style_config WPS_NFC
+	else
+		Kconfig_style_config WPS n
 	fi
 
 	# Wi-Fi Direct (WiDi)
@@ -292,6 +296,8 @@ src_configure() {
 	# Access Point Mode
 	if use ap ; then
 		Kconfig_style_config AP
+	else
+		Kconfig_style_config AP n
 	fi
 
 	# Enable essentials for AP/P2P


### PR DESCRIPTION
These are enabled in the defconfig and need to be forced off here.

Bug: https://bugs.gentoo.org/687838
Signed-off-by: Brian Norris <briannorris@chromium.org>