### PR TITLE
sys-block/arcconf: fix x86 install

### DIFF
--- a/sys-block/arcconf/arcconf-2.01.22270-r1.ebuild
+++ b/sys-block/arcconf/arcconf-2.01.22270-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -38,5 +38,5 @@ pkg_setup() {
 }
 
 src_install() {
-	dobin linux$(usex amd64 '_x64')/cmdline/arcconf
+	dobin linux$(usex amd64 '_x64' '')/cmdline/arcconf
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/687388
Package-Manager: Portage-2.3.67, Repoman-2.3.13
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>