### PR TITLE
dev-libs/tvision: fix to handle overloaded abs properly with >=gcc-7*

### DIFF
--- a/dev-libs/tvision/files/tvision-2.2.1.4-fix-overloaded-abs.patch
+++ b/dev-libs/tvision/files/tvision-2.2.1.4-fix-overloaded-abs.patch
@@ -1,0 +1,100 @@
+From 85185e7787b34545faf095b64935d80982b5cf81 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl@gmail.com>
+Date: Wed, 12 Jun 2019 11:52:16 +0200
+Subject: [PATCH] Patches from upstream to address abs issue with >gcc-6 See
+ https://sourceforge.net/p/tvision/bugs/17/
+
+The patches declare inline static abs functions where they are
+needed to make gcc happy.
+
+Signed-off-by: Bernd Waibel <waebbl@gmail.com>
+---
+ classes/dos/sescreen.cc | 6 ++++++
+ classes/tdesktop.cc     | 6 ++++++
+ classes/x11/x11src.cc   | 6 ++++++
+ 3 files changed, 18 insertions(+)
+
+diff --git a/classes/dos/sescreen.cc b/classes/dos/sescreen.cc
+index 4dd3195..8a500d5 100644
+--- a/classes/dos/sescreen.cc
++++ b/classes/dos/sescreen.cc
+@@ -248,6 +248,12 @@ static int is_plane_mode = 0;
+ static int TextModeXres;
+ static int TextModeYres;
+ 
++inline
++static unsigned abs(unsigned v)
++{
++ return unsigned(abs(int(v)));
++}
++
+ /*****************************************************************************
+ 
+ ***************************  VESA BIOS ROUTINES ******************************
+diff --git a/classes/tdesktop.cc b/classes/tdesktop.cc
+index 38f1be4..26447eb 100644
+--- a/classes/tdesktop.cc
++++ b/classes/tdesktop.cc
+@@ -26,6 +26,12 @@ Modified cursor behavior while desktop locked by Salvador E. Tropea (SET)
+ #define Uses_TVCodePage
+ #include <tv.h>
+ 
++inline
++static unsigned abs(unsigned v)
++{
++ return unsigned(abs(int(v)));
++}
++
+ TDeskInit::TDeskInit( TBackground *(*cBackground)( TRect ) ) :
+     createBackground( cBackground )
+ {
+diff --git a/classes/x11/x11src.cc b/classes/x11/x11src.cc
+index 538457e..dc350df 100644
+--- a/classes/x11/x11src.cc
++++ b/classes/x11/x11src.cc
+@@ -141,6 +141,12 @@ void    (*TScreenX11::writeLine)(int x, int y, int w, void *str, unsigned color)
+ void    (*TScreenX11::redrawBuf)(int x, int y, unsigned w, unsigned off)=
+                 TScreenX11::redrawBufCP;
+ 
++inline
++static unsigned abs(unsigned v)
++{
++ return unsigned(abs(int(v)));
++}
++
+ TScreenX11::~TScreenX11()
+ {
+  STOP_UPDATE_THREAD;
+-- 
+2.21.0
+
+From 9b9f1aea8c9972ab9c1e633835ed4359d7fe000c Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl@gmail.com>
+Date: Wed, 12 Jun 2019 12:05:58 +0200
+Subject: [PATCH] classes/tdisplay.c: Also add abs patch to tdisplay.cc
+
+Signed-off-by: Bernd Waibel <waebbl@gmail.com>
+---
+ classes/tdisplay.cc | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/classes/tdisplay.cc b/classes/tdisplay.cc
+index 9225d48..569bc1d 100644
+--- a/classes/tdisplay.cc
++++ b/classes/tdisplay.cc
+@@ -22,6 +22,12 @@ same used in original Turbo Vision for compatibility purposes.
+ #define Uses_TVCodePage
+ #include <tv.h>
+ 
++inline
++static unsigned abs(unsigned v)
++{
++	return unsigned(abs(int(v)));
++}
++
+ // Remove me please!
+ int TDisplay::dual_display=0;
+ 
+-- 
+2.21.0
+

--- a/dev-libs/tvision/tvision-2.2.1.4.ebuild
+++ b/dev-libs/tvision/tvision-2.2.1.4.ebuild
@@ -1,11 +1,12 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
+
+MY_PVR=$(ver_rs 3 -)
 
 DESCRIPTION="Text User Interface that implements the well known CUA widgets"
 HOMEPAGE="http://tvision.sourceforge.net/"
-MY_PVR=${PVR:0:5}-${PVR:6}
 SRC_URI="mirror://sourceforge/tvision/rhtvision_${MY_PVR}.tar.gz"
 
 LICENSE="GPL-2"
@@ -33,7 +34,7 @@ RDEPEND="
 		x11-libs/libXext
 		x11-libs/libXmu
 		x11-libs/libXt
-		x11-libs/libxcb
+		x11-libs/libxcb:=
 	)"
 DEPEND="${RDEPEND}"
 
@@ -43,6 +44,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-build-system.patch"
 	"${FILESDIR}/${P}-gcc6.patch"
 	"${FILESDIR}/${P}-flags.patch"
+	"${FILESDIR}/${P}-fix-overloaded-abs.patch"
 )
 
 src_configure() {
@@ -63,8 +65,5 @@ src_install() {
 	dosym rhtvision /usr/include/tvision
 
 	# remove CVS directory which gets copied over
-	rm -rf "${ED%/}/usr/share/doc/${P}/html/CVS" || die
-
-	# TODO: remove locales which are not needed, depending on current user
-	# locale settings. How?
+	rm -r "${ED}/usr/share/doc/${P}/html/CVS" || die
 }


### PR DESCRIPTION
With gcc-7, they way overloaded functions are handled has changed,
which led to build failures. This has been addressed by upstream,
see https://sourceforge.net/p/tvision/bugs/17/

Closes: https://bugs.gentoo.org/639492
Package-Manager: Portage-2.3.67, Repoman-2.3.14
Signed-off-by: Bernd Waibel <waebbl@gmail.com>