### PR TITLE
games-fps/gzdoom: Prevent build error on -fluidsynth

### DIFF
--- a/games-fps/gzdoom/files/gzdoom-4.1.3-install_soundfonts.patch
+++ b/games-fps/gzdoom/files/gzdoom-4.1.3-install_soundfonts.patch
@@ -1,0 +1,34 @@
+From 2d1c7ba17cac3ccd201e77ad01a9dd06ab22cb2e Mon Sep 17 00:00:00 2001
+From: William Breathitt Gray <vilhelm.gray@gmail.com>
+Date: Thu, 13 Jun 2019 18:01:08 +0900
+Subject: [PATCH] Install soundfonts and WOPL/WOPN banks
+
+The INSTALL_SOUNDFONT_PATH cache entry is used to configure the
+installation directory.
+---
+ src/CMakeLists.txt | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 0bb16f39e..4ff15062d 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1451,6 +1451,15 @@ add_custom_command(TARGET zdoom POST_BUILD
+ 	${CMAKE_SOURCE_DIR}/fm_banks/gs-by-papiezak-and-sneakernets.wopn $<TARGET_FILE_DIR:zdoom>/fm_banks/gs-by-papiezak-and-sneakernets.wopn
+ )
+ 
++if( WIN32 )
++	set( INSTALL_SOUNDFONT_PATH . CACHE STRING "Directory where soundfonts and WOPL/WOPN banks will be placed during install." )
++else()
++	set( INSTALL_SOUNDFONT_PATH share/games/doom CACHE STRING "Directory where soundfonts and WOPL/WOPN banks will be placed during install." )
++endif()
++install(FILES "${PROJECT_BINARY_DIR}/soundfonts" "${PROJECT_BINARY_DIR}/fm_banks"
++		DESTINATION ${INSTALL_SOUNDFONT_PATH}
++		COMPONENT "Soundfont resources")
++
+ if( CMAKE_COMPILER_IS_GNUCXX )
+ 	# GCC misoptimizes this file
+ 	set_source_files_properties( oplsynth/fmopl.cpp PROPERTIES COMPILE_FLAGS "-fno-tree-dominator-opts -fno-tree-fre" )
+-- 
+2.21.0
+

--- a/games-fps/gzdoom/gzdoom-4.1.3.ebuild
+++ b/games-fps/gzdoom/gzdoom-4.1.3.ebuild
@@ -12,24 +12,21 @@ SRC_URI="https://github.com/coelckers/${PN}/archive/g${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="BSD BZIP2 DUMB-0.9.3 GPL-3 LGPL-3 MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="fluidsynth gtk gtk2 +openal openmp"
+IUSE="gtk gtk2 openmp"
 
 DEPEND="
 	media-libs/libsdl2[opengl]
+	media-libs/libsndfile
+	media-libs/openal
+	media-sound/fluidsynth:=
+	media-sound/mpg123
 	sys-libs/zlib
 	virtual/jpeg:0
 	gtk? (
 		gtk2? ( x11-libs/gtk+:2 )
 		!gtk2? ( x11-libs/gtk+:3 )
 	)"
-RDEPEND="
-	${DEPEND}
-	fluidsynth? ( media-sound/fluidsynth:= )
-	openal? (
-		media-libs/libsndfile
-		media-libs/openal
-		media-sound/mpg123
-	)"
+RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}-g${PV}"
 PATCHES="${FILESDIR}/${P}-fluidsynth2.patch"
@@ -48,7 +45,7 @@ src_configure() {
 		-DDYN_SNDFILE=OFF
 		-DDYN_MPG123=OFF
 		-DNO_GTK="$(usex !gtk)"
-		-DNO_OPENAL="$(usex !openal)"
+		-DNO_OPENAL=OFF
 		-DNO_OPENMP="$(usex !openmp)"
 	)
 	cmake-utils_src_configure

--- a/games-fps/gzdoom/gzdoom-4.1.3.ebuild
+++ b/games-fps/gzdoom/gzdoom-4.1.3.ebuild
@@ -29,7 +29,10 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}-g${PV}"
-PATCHES="${FILESDIR}/${P}-fluidsynth2.patch"
+PATCHES=(
+	"${FILESDIR}/${P}-fluidsynth2.patch"
+	"${FILESDIR}/${P}-install_soundfonts.patch"
+)
 
 src_prepare() {
 	rm -rf docs/licenses || die
@@ -40,6 +43,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DINSTALL_DOCS_PATH="${EPREFIX}/usr/share/doc/${PF}"
 		-DINSTALL_PK3_PATH="${EPREFIX}/usr/share/doom"
+		-DINSTALL_SOUNDFONT_PATH="${EPREFIX}/usr/share/doom"
 		-DDYN_FLUIDSYNTH=OFF
 		-DDYN_OPENAL=OFF
 		-DDYN_SNDFILE=OFF

--- a/games-fps/gzdoom/metadata.xml
+++ b/games-fps/gzdoom/metadata.xml
@@ -17,7 +17,6 @@
 		<name>Gentoo Games Project</name>
 	</maintainer>
 	<use>
-		<flag name="fluidsynth">Use <pkg>media-sound/fluidsynth</pkg> for MIDI support</flag>
 		<flag name="gtk2">Enable support for GTK+2 instead of GTK+3</flag>
 	</use>
 	<upstream>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/687922
Package-Manager: Portage-2.3.67, Repoman-2.3.14
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>