### PR TITLE
sci-libs/libmed: fix hdf5 dependency version

### DIFF
--- a/sci-libs/libmed/libmed-4.0.0-r1.ebuild
+++ b/sci-libs/libmed/libmed-4.0.0-r1.ebuild
@@ -28,7 +28,7 @@ IUSE="doc fortran mpi python test"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RDEPEND="
-	>=sci-libs/hdf5-1.10.0[fortran=,mpi=]
+	>=sci-libs/hdf5-1.10.2:=[fortran=,mpi=]
 	mpi? ( virtual/mpi[fortran=] )
 	python? ( ${PYTHON_DEPS} )
 "


### PR DESCRIPTION
Needs at least hdf5-1.10.2 as noted in configure.ac.

Reported-by: Brian G. <gissf1@yahoo.com>
Closes: https://bugs.gentoo.org/688078
Package-Manager: Portage-2.3.67, Repoman-2.3.14
Signed-off-by: Bernd Waibel <waebbl@gmail.com>