### PR TITLE
games-board/pychess: add missing 0.99.4 dependencies

### DIFF
--- a/games-board/pychess/pychess-0.99.4.ebuild
+++ b/games-board/pychess/pychess-0.99.4.ebuild
@@ -17,8 +17,11 @@ KEYWORDS="~amd64 ~x86"
 IUSE="gstreamer"
 
 DEPEND="
+	dev-python/pexpect[${PYTHON_USEDEP}]
+	dev-python/psutil[${PYTHON_USEDEP}]
 	dev-python/pycairo[${PYTHON_USEDEP}]
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	dev-python/sqlalchemy[${PYTHON_USEDEP},sqlite]
 	gnome-base/librsvg:2
 	x11-libs/gtksourceview:3.0
 	x11-libs/pango


### PR DESCRIPTION
I tried to emerge and run pychess on another machine. The package dependency list was in a worse state than I initially expected when I bumped it to version 0.99.4.

Please merge. Thanks.

Signed-off-by: Jan Ziak <0xe2.0x9a.0x9b@gmail.com>