### PR TITLE
Chromium cross fixes for arm [need help] [do not merge]

### DIFF
--- a/www-client/chromium/chromium-76.0.3809.25.ebuild
+++ b/www-client/chromium/chromium-76.0.3809.25.ebuild
@@ -42,7 +42,6 @@ COMMON_DEPEND="
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
 	system-libvpx? ( media-libs/libvpx:=[postproc,svc] )
-	>=media-libs/openh264-1.6.0:=
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? (
 		>=media-video/ffmpeg-4:=
@@ -157,6 +156,7 @@ PATCHES=(
 	"${FILESDIR}/chromium-76-gcc-ambiguous-nodestructor.patch"
 	"${FILESDIR}/chromium-76-gcc-include.patch"
 	"${FILESDIR}/chromium-76-gcc-pure-virtual.patch"
+	"${FILESDIR}/openh264.patch"
 )
 
 pre_build_checks() {
@@ -465,7 +465,6 @@ src_configure() {
 		libwebp
 		libxml
 		libxslt
-		openh264
 		re2
 		snappy
 		yasm

--- a/www-client/chromium/files/openh264.patch
+++ b/www-client/chromium/files/openh264.patch
@@ -1,0 +1,15 @@
+description: disable support for openh264, will be added later
+author: Michael Gilbert <mgilbert@debian.org>
+
+--- a/third_party/webrtc/webrtc.gni
++++ b/third_party/webrtc/webrtc.gni
+@@ -154,8 +154,7 @@ declare_args() {
+   #
+   # Enabling H264 when building with MSVC is currently not supported, see
+   # bugs.webrtc.org/9213#c13 for more info.
+-  rtc_use_h264 =
+-      proprietary_codecs && !is_android && !is_ios && !(is_win && !is_clang)
++  rtc_use_h264 = false
+ 
+   # By default, use normal platform audio support or dummy audio, but don't
+   # use file-based audio playout and record.


### PR DESCRIPTION
First problem that I did encounter is: openh264 fails to cross-compile, and since it's rather unlikely that it's ever going to be needed on a slow arm device, I removed it via the patch. 