### PR TITLE
sci-libs/cantera: 2.4.0-r1.ebuild

### DIFF
--- a/sci-libs/cantera/cantera-2.4.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r1.ebuild
@@ -20,8 +20,8 @@ KEYWORDS="~amd64 ~x86"
 IUSE="+cti fortran pch +python test"
 
 REQUIRED_USE="
-	cti? ( ${PYTHON_REQUIRED_USE} )
 	python? ( cti )
+	cti? ( ${PYTHON_REQUIRED_USE} )
 	${PYTHON_REQUIRED_USE}
 	"
 

--- a/sci-libs/cantera/cantera-2.4.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r1.ebuild
@@ -46,7 +46,6 @@ DEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/${PN}_${PV}_libdirname_variable.patch"
 	"${FILESDIR}/${PN}_${PV}_env.patch"
 	)
 

--- a/sci-libs/cantera/cantera-2.4.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	python? (
 		dev-python/numpy[${PYTHON_USEDEP}]
 	)
-	sci-libs/sundials:0=
+	<sci-libs/sundials-3.2.0:0=
 "
 
 DEPEND="

--- a/sci-libs/cantera/cantera-2.4.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{5,6} )
+PYTHON_COMPAT=( python3_{5,6,7} )
 
 FORTRAN_NEEDED=fortran
 FORTRAN_STANDARD=90

--- a/sci-libs/cantera/cantera-2.4.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r1.ebuild
@@ -1,0 +1,130 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python3_{5,6} )
+
+FORTRAN_NEEDED=fortran
+FORTRAN_STANDARD=90
+
+inherit desktop fortran-2 python-single-r1 scons-utils toolchain-funcs
+
+DESCRIPTION="Object-oriented tool suite for chemical kinetics, thermodynamics, and transport"
+HOMEPAGE="http://www.cantera.org"
+SRC_URI="https://github.com/Cantera/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+cti fortran pch +python test"
+
+REQUIRED_USE="
+	cti? ( ${PYTHON_REQUIRED_USE} )
+	python? ( cti )
+	${PYTHON_REQUIRED_USE}
+	"
+
+RDEPEND="
+	python? (
+		dev-python/numpy[${PYTHON_USEDEP}]
+	)
+	sci-libs/sundials:0=
+"
+
+DEPEND="
+	${RDEPEND}
+	dev-cpp/eigen
+	dev-libs/boost
+	dev-libs/libfmt
+	python? (
+		dev-python/cython[${PYTHON_USEDEP}]
+	)
+	test? (
+		>=dev-cpp/gtest-1.8.0
+	)
+"
+
+PATCHES=( "${FILESDIR}/${PN}_${PV}_libdirname_variable.patch" )
+
+pkg_setup() {
+	fortran-2_pkg_setup
+	python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+	# patch to work 'scons test' properly in case of set up 'renamed_shared_libraries="no"' option
+	sed -i "s/, libs=\['cantera_shared'\]//" "${S}"/test_problems/SConscript || die "failed to modify 'test_problems/SConscript'"
+	# patch env to pass CCACHE_DIR variable
+	sed -i "s/ENV={'PATH': os.environ\['PATH'\]}/ENV={'PATH': os.environ\['PATH'\], 'CCACHE_DIR': os.environ.get('CCACHE_DIR','')}/" "${S}"/SConstruct || die "failed to modify 'SConstruct'"
+}
+
+## Full list of configuration options of Cantera is presented here:
+## http://cantera.org/docs/sphinx/html/compiling/config-options.html
+
+src_configure() {
+	scons_vars=(
+		CC="$(tc-getCC)"
+		CXX="$(tc-getCXX)"
+		cc_flags="${CXXFLAGS}"
+		cxx_flags="-std=c++11"
+		debug="no"
+		FORTRAN="$(tc-getFC)"
+		FORTRANFLAGS="${CXXFLAGS}"
+		optimize_flags="-Wno-inline"
+		renamed_shared_libraries="no"
+		use_pch=$(usex pch)
+## In some cases other order can break the detection of right location of Boost: ##
+		system_fmt="y"
+		system_sundials="y"
+		system_eigen="y"
+		env_vars="all"
+		extra_inc_dirs="/usr/include/eigen3"
+	)
+	use test || scons_vars+=( googletest="none" )
+
+	scons_targets=(
+		f90_interface=$(usex fortran y n)
+		python2_package="none"
+	)
+
+	if use cti ; then
+		local scons_python=$(usex python full minimal)
+		scons_targets+=( python3_package="${scons_python}" python3_cmd="${EPYTHON}" )
+	else
+		scons_targets+=( python3_package="none" )
+	fi
+}
+
+src_compile() {
+	escons build "${scons_vars[@]}" "${scons_targets[@]}" prefix="/usr"
+}
+
+src_test() {
+	escons test
+}
+
+src_install() {
+	escons install stage_dir="${D%/}" libdirname="$(get_libdir)"
+	if ! use cti ; then
+		rm -r "${D%/}/usr/share/man" || die "Can't remove man files."
+	else
+		# Run the byte-compile of modules
+		python_optimize "${D%/}/$(python_get_sitedir)/${PN}"
+	fi
+}
+
+pkg_postinst() {
+	if use cti && ! use python ; then
+		elog "Cantera was build without 'python' use-flag therefore the CTI tool 'ck2cti'"
+		elog "will convert Chemkin files to Cantera format without verification of kinetic mechanism."
+	fi
+
+	local post_msg=$(usex fortran "and Fortran " "")
+	elog "C++ ${post_msg}samples are installed to '/usr/share/${PN}/samples/' directory."
+
+	if use python ; then
+		elog "Python examples are installed to '$(python_get_sitedir)/${PN}/examples/' directories."
+	fi
+}

--- a/sci-libs/cantera/cantera-2.4.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	python? (
 		dev-python/numpy[${PYTHON_USEDEP}]
 	)
-	<sci-libs/sundials-3.2.0:0=
+	<sci-libs/sundials-4.0.0:0=
 "
 
 DEPEND="
@@ -45,19 +45,14 @@ DEPEND="
 	)
 "
 
-PATCHES=( "${FILESDIR}/${PN}_${PV}_libdirname_variable.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}_${PV}_libdirname_variable.patch"
+	"${FILESDIR}/${PN}_${PV}_env.patch"
+	)
 
 pkg_setup() {
 	fortran-2_pkg_setup
 	python-single-r1_pkg_setup
-}
-
-src_prepare() {
-	default
-	# patch to work 'scons test' properly in case of set up 'renamed_shared_libraries="no"' option
-	sed -i "s/, libs=\['cantera_shared'\]//" "${S}"/test_problems/SConscript || die "failed to modify 'test_problems/SConscript'"
-	# patch env to pass CCACHE_DIR variable
-	sed -i "s/ENV={'PATH': os.environ\['PATH'\]}/ENV={'PATH': os.environ\['PATH'\], 'CCACHE_DIR': os.environ.get('CCACHE_DIR','')}/" "${S}"/SConstruct || die "failed to modify 'SConstruct'"
 }
 
 ## Full list of configuration options of Cantera is presented here:

--- a/sci-libs/cantera/cantera-2.4.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 PYTHON_COMPAT=( python3_{5,6,7} )
 
@@ -100,12 +100,12 @@ src_test() {
 }
 
 src_install() {
-	escons install stage_dir="${D%/}" libdirname="$(get_libdir)"
+	escons install stage_dir="${D}" libdirname="$(get_libdir)"
 	if ! use cti ; then
-		rm -r "${D%/}/usr/share/man" || die "Can't remove man files."
+		rm -r "${D}/usr/share/man" || die "Can't remove man files."
 	else
 		# Run the byte-compile of modules
-		python_optimize "${D%/}/$(python_get_sitedir)/${PN}"
+		python_optimize "${D}/$(python_get_sitedir)/${PN}"
 	fi
 }
 

--- a/sci-libs/cantera/files/cantera_2.4.0_env.patch
+++ b/sci-libs/cantera/files/cantera_2.4.0_env.patch
@@ -10,7 +10,20 @@ diff -Nur old/cantera-2.4.0/SConstruct new/cantera-2.4.0/SConstruct
                    toolchain=toolchain,
                    **extraEnvArgs)
  
-@@ -1061,7 +1061,7 @@
+@@ -727,11 +727,8 @@
+ env['cantera_pure_version'] = '.'.join(str(x) for x in ctversion.version)
+ env['cantera_short_version'] = '.'.join(str(x) for x in ctversion.version[:2])
+ 
+-try:
+-    env['git_commit'] = getCommandOutput('git', 'rev-parse', '--short', 'HEAD')
+-except Exception:
+-    env['git_commit'] = 'unknown'
++env['git_commit'] = 'unknown'
+ 
+ # Print values of all build options:
+ print("Configuration variables read from 'cantera.conf' and command line:")
+ for line in open('cantera.conf'):
+@@ -1062,7 +1062,7 @@
  
      # Ignore the minor version, e.g. 2.4.x -> 2.4
      env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])

--- a/sci-libs/cantera/files/cantera_2.4.0_env.patch
+++ b/sci-libs/cantera/files/cantera_2.4.0_env.patch
@@ -1,6 +1,6 @@
 diff -Nur old/cantera-2.4.0/SConstruct new/cantera-2.4.0/SConstruct
 --- old/SConstruct	2018-08-24 16:24:45.000000000 +0300
-+++ new/SConstruct	2019-06-22 00:18:41.000000000 +0300
++++ new/SConstruct	2019-07-17 15:50:06.000000000 +0300
 @@ -189,7 +189,7 @@
      toolchain = ['default']
  
@@ -10,7 +10,22 @@ diff -Nur old/cantera-2.4.0/SConstruct new/cantera-2.4.0/SConstruct
                    toolchain=toolchain,
                    **extraEnvArgs)
  
-@@ -727,11 +727,8 @@
+@@ -327,6 +327,14 @@
+         'prefix',
+         'Set this to the directory where Cantera should be installed.',
+         defaults.prefix, PathVariable.PathAccept),
++    PathVariable(
++        'libdirname',
++        """Set this to the directory where Cantera libraries should be installed.
++           Some distributions (e.g. Fedora/RHEL) use 'lib64' instead of 'lib' on 64-bit systems
++           or could use some other library directory name instead of 'lib' depends
++           on architecture and profile (e.g. Gentoo 'libx32' on x32 profile).
++           If user didn't set 'libdirname' configuration variable set it to default value 'lib'""",
++        'lib', PathVariable.PathAccept),
+     EnumVariable(
+         'python_package',
+         """If you plan to work in Python, then you need the ``full`` Cantera Python
+@@ -723,10 +731,7 @@
  env['cantera_pure_version'] = '.'.join(str(x) for x in ctversion.version)
  env['cantera_short_version'] = '.'.join(str(x) for x in ctversion.version[:2])
  
@@ -22,8 +37,7 @@ diff -Nur old/cantera-2.4.0/SConstruct new/cantera-2.4.0/SConstruct
  
  # Print values of all build options:
  print("Configuration variables read from 'cantera.conf' and command line:")
- for line in open('cantera.conf'):
-@@ -1062,7 +1062,7 @@
+@@ -1061,7 +1066,7 @@
  
      # Ignore the minor version, e.g. 2.4.x -> 2.4
      env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
@@ -32,9 +46,22 @@ diff -Nur old/cantera-2.4.0/SConstruct new/cantera-2.4.0/SConstruct
          print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
          sys.exit(1)
      print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)
+@@ -1465,12 +1470,6 @@
+ # *** Set additional configuration variables ***
+ # **********************************************
+ 
+-# Some distributions (e.g. Fedora/RHEL) use 'lib64' instead of 'lib' on 64-bit systems
+-if any(name.startswith('/usr/lib64/python') for name in sys.path):
+-    env['libdirname'] = 'lib64'
+-else:
+-    env['libdirname'] = 'lib'
+-
+ # On Debian-based systems, need to special-case installation to
+ # /usr/local because of dist-packages vs site-packages
+ env['debian'] = any(name.endswith('dist-packages') for name in sys.path)
 diff -Nur old/cantera-2.4.0/test_problems/SConscript new/cantera-2.4.0/test_problems/SConscript
 --- old/test_problems/SConscript	2018-08-24 16:24:45.000000000 +0300
-+++ new/test_problems/SConscript	2019-06-22 00:13:29.000000000 +0300
++++ new/test_problems/SConscript	2019-07-17 15:41:35.000000000 +0300
 @@ -282,7 +282,7 @@
  CompileAndTest('VPsilane_test', 'VPsilane_test', 'VPsilane_test', 'output_blessed.txt')
  

--- a/sci-libs/cantera/files/cantera_2.4.0_env.patch
+++ b/sci-libs/cantera/files/cantera_2.4.0_env.patch
@@ -1,0 +1,33 @@
+diff -Nur old/cantera-2.4.0/SConstruct new/cantera-2.4.0/SConstruct
+--- old/SConstruct	2018-08-24 16:24:45.000000000 +0300
++++ new/SConstruct	2019-06-22 00:18:41.000000000 +0300
+@@ -189,7 +189,7 @@
+     toolchain = ['default']
+ 
+ env = Environment(tools=toolchain+['textfile', 'subst', 'recursiveInstall', 'wix', 'gch'],
+-                  ENV={'PATH': os.environ['PATH']},
++                  ENV={'PATH': os.environ['PATH'], 'CCACHE_DIR': os.environ.get('CCACHE_DIR','')},
+                   toolchain=toolchain,
+                   **extraEnvArgs)
+ 
+@@ -1061,7 +1061,7 @@
+ 
+     # Ignore the minor version, e.g. 2.4.x -> 2.4
+     env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
+-    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1'):
++    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2'):
+         print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
+         sys.exit(1)
+     print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)
+diff -Nur old/cantera-2.4.0/test_problems/SConscript new/cantera-2.4.0/test_problems/SConscript
+--- old/test_problems/SConscript	2018-08-24 16:24:45.000000000 +0300
++++ new/test_problems/SConscript	2019-06-22 00:13:29.000000000 +0300
+@@ -282,7 +282,7 @@
+ CompileAndTest('VPsilane_test', 'VPsilane_test', 'VPsilane_test', 'output_blessed.txt')
+ 
+ CompileAndTest('clib', 'clib_test', 'clib_test', 'output_blessed.txt',
+-               extensions=['^clib_test.c'], libs=['cantera_shared'])
++               extensions=['^clib_test.c'])
+ 
+ # Force explicitly-named tests to run even if SCons thinks they're up to date
+ for command in COMMAND_LINE_TARGETS:


### PR DESCRIPTION
This pull request add `sci-libs/cantera-2.4.0-r1.ebuild` that:
* fix use of default "-O3" build flag
* move `sed` patches from `src_prepare()` section to external patch-file `cantera-2.4.0_env.patch`
and fix build with `<sci-libs/sundials-4.0.0`
* fix ebuild to satisfy GLEP73BackAlteration
* add PYTHON_COMPAT=( python3_7 )
