### PR TITLE
sys-apps/etckeeper: Fix QA warnings about /var subfolders

### DIFF
--- a/sys-apps/etckeeper/etckeeper-1.18.6-r1.ebuild
+++ b/sys-apps/etckeeper/etckeeper-1.18.6-r1.ebuild
@@ -55,6 +55,13 @@ src_install(){
 		exeinto /etc/cron.daily
 		newexe debian/cron.daily etckeeper
 	fi
+
+	# remove subdirectories of /var which cause QA warnings
+	# bug #513374
+	rmdir "${ED%/}"/var/cache/etckeeper >/dev/null ||
+						die "Cannot remove /var subfolders (1)"
+	rmdir "${ED%/}"/var/cache >/dev/null || die "Cannot remove /var subfolders (2)"
+	rmdir "${ED%/}"/var >/dev/null	     || die "Cannot remove /var subfolders (3)"
 }
 
 pkg_postinst(){

--- a/sys-apps/etckeeper/etckeeper-1.18.6.ebuild
+++ b/sys-apps/etckeeper/etckeeper-1.18.6.ebuild
@@ -55,6 +55,13 @@ src_install(){
 		exeinto /etc/cron.daily
 		newexe debian/cron.daily etckeeper
 	fi
+
+	# remove subdirectories of /var which cause QA warnings
+	# bug #513374
+	rmdir "${ED%/}"/var/cache/etckeeper >/dev/null ||
+						die "Cannot remove /var subfolders (1)"
+	rmdir "${ED%/}"/var/cache >/dev/null || die "Cannot remove /var subfolders (2)"
+	rmdir "${ED%/}"/var >/dev/null	     || die "Cannot remove /var subfolders (3)"
 }
 
 pkg_postinst(){

--- a/sys-apps/etckeeper/etckeeper-1.18.7.ebuild
+++ b/sys-apps/etckeeper/etckeeper-1.18.7.ebuild
@@ -60,6 +60,13 @@ src_install(){
 		exeinto /etc/cron.daily
 		newexe debian/cron.daily etckeeper
 	fi
+
+	# remove subdirectories of /var which cause QA warnings
+	# bug #513374
+	rmdir "${ED%/}"/var/cache/etckeeper >/dev/null ||
+						die "Cannot remove /var subfolders (1)"
+	rmdir "${ED%/}"/var/cache >/dev/null || die "Cannot remove /var subfolders (2)"
+	rmdir "${ED%/}"/var >/dev/null	     || die "Cannot remove /var subfolders (3)"
 }
 
 pkg_postinst(){

--- a/sys-apps/etckeeper/etckeeper-1.18.8.ebuild
+++ b/sys-apps/etckeeper/etckeeper-1.18.8.ebuild
@@ -60,6 +60,13 @@ src_install(){
 		exeinto /etc/cron.daily
 		newexe debian/cron.daily etckeeper
 	fi
+
+	# remove subdirectories of /var which cause QA warnings
+	# bug #513374
+	rmdir "${ED%/}"/var/cache/etckeeper >/dev/null ||
+						die "Cannot remove /var subfolders (1)"
+	rmdir "${ED%/}"/var/cache >/dev/null || die "Cannot remove /var subfolders (2)"
+	rmdir "${ED%/}"/var >/dev/null	     || die "Cannot remove /var subfolders (3)"
 }
 
 pkg_postinst(){


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/513374
Package-Manager: Portage-2.3.49, Repoman-2.3.11
Signed-off-by: M. J. Everitt <m.j.everitt@iee.org>