### PR TITLE
sys-apps/s6-linux-init: Fix sysv-utils location and deps

### DIFF
--- a/sys-apps/s6-linux-init/s6-linux-init-1.0.2.0.ebuild
+++ b/sys-apps/s6-linux-init/s6-linux-init-1.0.2.0.ebuild
@@ -17,6 +17,10 @@ REQUIRED_USE="static? ( static-libs )"
 RDEPEND=">=dev-lang/execline-2.5.1.0:=[static-libs?]
 	>=dev-libs/skalibs-2.8.1.0:=[static-libs?]
 	>=sys-apps/s6-2.8.0.1:=[static-libs?]
+	sysv-utils? (
+		!sys-apps/systemd[sysv-utils]
+		!sys-apps/sysvinit
+	)
 "
 DEPEND="${RDEPEND}"
 
@@ -51,6 +55,7 @@ src_install() {
 
 	if use sysv-utils ; then
 		"${D}/bin/s6-linux-init-maker" -f "${D}/etc/s6-linux-init/skel" "${T}/dir" || die
+		into /
 		dosbin "${T}/dir/bin"/{halt,poweroff,reboot,shutdown,telinit}
 	fi
 }


### PR DESCRIPTION
Put the sysv compat utilities in `/sbin`, not `/usr/sbin`, and conflict with other packages that provide these utilities. Both of these were oversights on my part.

Closes: https://bugs.gentoo.org/688456