### PR TITLE
www-client/chromium: fix build with -O3

### DIFF
--- a/www-client/chromium/chromium-75.0.3770.100.ebuild
+++ b/www-client/chromium/chromium-75.0.3770.100.ebuild
@@ -144,6 +144,7 @@ PATCHES=(
 	"${FILESDIR}/chromium-compiler-r9.patch"
 	"${FILESDIR}/chromium-widevine-r4.patch"
 	"${FILESDIR}/chromium-fix-char_traits.patch"
+	"${FILESDIR}/chromium-angle-inline.patch"
 	"${FILESDIR}/chromium-75-fix-gn-gen.patch"
 	"${FILESDIR}/chromium-75-gcc-angle-fix.patch"
 	"${FILESDIR}/chromium-75-unique_ptr.patch"

--- a/www-client/chromium/chromium-76.0.3809.36.ebuild
+++ b/www-client/chromium/chromium-76.0.3809.36.ebuild
@@ -144,6 +144,7 @@ PATCHES=(
 	"${FILESDIR}/chromium-compiler-r10.patch"
 	"${FILESDIR}/chromium-widevine-r4.patch"
 	"${FILESDIR}/chromium-fix-char_traits.patch"
+	"${FILESDIR}/chromium-angle-inline.patch"
 	"${FILESDIR}/chromium-76-quiche.patch"
 	"${FILESDIR}/chromium-76-lss.patch"
 	"${FILESDIR}/chromium-76-gcc-vulkan.patch"

--- a/www-client/chromium/files/chromium-angle-inline.patch
+++ b/www-client/chromium/files/chromium-angle-inline.patch
@@ -1,0 +1,26 @@
+From 2ee4e7f857514f4c0cbff135a1c5f968d8814d31 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Sun, 23 Jun 2019 12:14:57 +0000
+Subject: [PATCH] explicit declaration of const GLfloat/const GLint for ValidateSamplerParameterBase
+
+---
+ third_party/angle/src/libANGLE/validationES.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/third_party/angle/src/libANGLE/validationES.cpp b/third_party/angle/src/libANGLE/validationES.cpp
+index ae353f7..fdc7ac2 100644
+--- a/third_party/angle/src/libANGLE/validationES.cpp
++++ b/third_party/angle/src/libANGLE/validationES.cpp
+@@ -6089,7 +6089,9 @@ bool ValidateSamplerParameterBase(Context *context,
+ }
+ 
+ template bool ValidateSamplerParameterBase(Context *, GLuint, GLenum, GLsizei, bool, GLfloat *);
++template bool ValidateSamplerParameterBase(Context *, GLuint, GLenum, GLsizei, bool, const GLfloat *);
+ template bool ValidateSamplerParameterBase(Context *, GLuint, GLenum, GLsizei, bool, GLint *);
++template bool ValidateSamplerParameterBase(Context *, GLuint, GLenum, GLsizei, bool, const GLint *);
+ template bool ValidateSamplerParameterBase(Context *,
+                                            GLuint,
+                                            GLenum,
+-- 
+2.21.0
+


### PR DESCRIPTION
In third_party/angle/src/libANGLE/validationES.cpp three specializations
are declared for ValidateSamplerParameterBase(). Two implicit
specializations are created in ValidateSamplerParameterfvRobustANGLE()
and ValidateSamplerParameterIivRobustANGLE(). However, with
-finline-functions (default enabled with -O3) those two implicit
symbols are optimized out. In the end linking fails with
unresolved references, because functions in
third_party/angle/src/libANGLE/validationES3.cpp use both
specializations.

Closes: https://bugs.gentoo.org/681870
Package-Manager: Portage-2.3.66, Repoman-2.3.11
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>