### PR TITLE
Removed runtime dependency of i3blocks on i3.

### DIFF
--- a/x11-misc/i3blocks/i3blocks-1.4-r1.ebuild
+++ b/x11-misc/i3blocks/i3blocks-1.4-r1.ebuild
@@ -22,8 +22,7 @@ LICENSE="GPL-3"
 RDEPEND="app-admin/sysstat
 	media-sound/playerctl
 	sys-apps/lm_sensors
-	sys-power/acpi
-	|| ( x11-wm/i3 x11-wm/i3-gaps )"
+	sys-power/acpi"
 
 DEPEND="app-text/ronn"
 


### PR DESCRIPTION
i3blocks can be used completely independently from i3. This change allows people to use i3blocks with sway, but not having to emerge i3.