### PR TITLE
media-libs/mesa: introduce X flag / enable wayland-only systems

### DIFF
--- a/app-emulation/gallium-nine-standalone/gallium-nine-standalone-0.3.ebuild
+++ b/app-emulation/gallium-nine-standalone/gallium-nine-standalone-0.3.ebuild
@@ -25,7 +25,7 @@ SLOT="0"
 # Steam's Proton.
 
 RDEPEND="
-	media-libs/mesa[d3d9,dri3,${MULTILIB_USEDEP}]
+	media-libs/mesa[d3d9,dri3,X(+),${MULTILIB_USEDEP}]
 	x11-libs/libX11[${MULTILIB_USEDEP}]
 	x11-libs/libXext[${MULTILIB_USEDEP}]
 	x11-libs/libxcb[${MULTILIB_USEDEP}]

--- a/app-emulation/gallium-nine-standalone/gallium-nine-standalone-0.4.ebuild
+++ b/app-emulation/gallium-nine-standalone/gallium-nine-standalone-0.4.ebuild
@@ -25,7 +25,7 @@ SLOT="0"
 # Steam's Proton.
 
 RDEPEND="
-	media-libs/mesa[d3d9,dri3,${MULTILIB_USEDEP}]
+	media-libs/mesa[d3d9,dri3,X(+),${MULTILIB_USEDEP}]
 	x11-libs/libX11[${MULTILIB_USEDEP}]
 	x11-libs/libxcb[${MULTILIB_USEDEP}]
 "

--- a/app-emulation/gallium-nine-standalone/gallium-nine-standalone-9999.ebuild
+++ b/app-emulation/gallium-nine-standalone/gallium-nine-standalone-9999.ebuild
@@ -25,7 +25,7 @@ SLOT="0"
 # Steam's Proton.
 
 RDEPEND="
-	media-libs/mesa[d3d9,dri3,${MULTILIB_USEDEP}]
+	media-libs/mesa[d3d9,dri3,X(+),${MULTILIB_USEDEP}]
 	x11-libs/libX11[${MULTILIB_USEDEP}]
 	x11-libs/libxcb[${MULTILIB_USEDEP}]
 "

--- a/dev-libs/beignet/beignet-1.3.2-r3.ebuild
+++ b/dev-libs/beignet/beignet-1.3.2-r3.ebuild
@@ -20,7 +20,7 @@ IUSE="ocl-icd ocl20"
 BDEPEND="${PYTHON_DEPS}
 	virtual/pkgconfig"
 COMMON="app-eselect/eselect-opencl
-	media-libs/mesa[${MULTILIB_USEDEP}]
+	media-libs/mesa[X(+),${MULTILIB_USEDEP}]
 	<sys-devel/clang-8.0.0:=[static-analyzer,${MULTILIB_USEDEP}]
 	>=x11-libs/libdrm-2.4.70[video_cards_intel,${MULTILIB_USEDEP}]
 	x11-libs/libXext[${MULTILIB_USEDEP}]

--- a/dev-qt/qtwebengine/qtwebengine-5.12.3.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.12.3.ebuild
@@ -39,7 +39,7 @@ RDEPEND="
 	media-libs/libpng:0=
 	>=media-libs/libvpx-1.5:=[svc]
 	media-libs/libwebp:=
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	media-libs/opus
 	sys-apps/dbus
 	sys-apps/pciutils

--- a/dev-util/android-studio/android-studio-3.3.0.20.182.5199772.ebuild
+++ b/dev-util/android-studio/android-studio-3.3.0.20.182.5199772.ebuild
@@ -47,7 +47,7 @@ RDEPEND=">=virtual/jdk-1.7
 	>=media-libs/fontconfig-2.10.92
 	>=media-libs/freetype-2.5.5
 	>=media-libs/libpng-1.2.51
-	>=media-libs/mesa-10.2.8
+	>=media-libs/mesa-10.2.8[X(+)]
 	|| ( gnome-extra/zenity kde-apps/kdialog x11-apps/xmessage x11-libs/libnotify )
 	>=sys-libs/ncurses-5.9-r3:5/5[tinfo]
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-util/android-studio/android-studio-3.4.0.18.183.5452501.ebuild
+++ b/dev-util/android-studio/android-studio-3.4.0.18.183.5452501.ebuild
@@ -52,7 +52,7 @@ RDEPEND="${DEPEND}
 	>=media-libs/fontconfig-2.10.92
 	>=media-libs/freetype-2.5.5
 	>=media-libs/libpng-1.2.51
-	>=media-libs/mesa-10.2.8
+	>=media-libs/mesa-10.2.8[X(+)]
 	|| ( gnome-extra/zenity kde-apps/kdialog x11-apps/xmessage x11-libs/libnotify )
 	>=sys-libs/ncurses-5.9-r3:5/5[tinfo]
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-util/android-studio/android-studio-3.4.1.0.183.5522156.ebuild
+++ b/dev-util/android-studio/android-studio-3.4.1.0.183.5522156.ebuild
@@ -52,7 +52,7 @@ RDEPEND="${DEPEND}
 	>=media-libs/fontconfig-2.10.92
 	>=media-libs/freetype-2.5.5
 	>=media-libs/libpng-1.2.51
-	>=media-libs/mesa-10.2.8
+	>=media-libs/mesa-10.2.8[X(+)]
 	|| ( gnome-extra/zenity kde-apps/kdialog x11-apps/xmessage x11-libs/libnotify )
 	>=sys-libs/ncurses-5.9-r3:5/5[tinfo]
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-util/apitrace/apitrace-8.0.ebuild
+++ b/dev-util/apitrace/apitrace-8.0.ebuild
@@ -20,7 +20,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 DEPEND="${PYTHON_DEPS}
 	app-arch/brotli:=
 	media-libs/libpng:0=
-	media-libs/mesa[egl?,${MULTILIB_USEDEP}]
+	media-libs/mesa[egl?,X(+),${MULTILIB_USEDEP}]
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	sys-process/procps:=
 	x11-libs/libX11

--- a/dev-util/gource/gource-0.49.ebuild
+++ b/dev-util/gource/gource-0.49.ebuild
@@ -23,7 +23,7 @@ COMMON_DEPEND="
 	dev-libs/libpcre:3
 	dev-libs/tinyxml
 	media-libs/freetype:2
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	virtual/glu:0
 "
 RDEPEND="${COMMON_DEPEND}

--- a/games-board/gambit/gambit-1.0.4.ebuild
+++ b/games-board/gambit/gambit-1.0.4.ebuild
@@ -22,7 +22,7 @@ DEPEND="dev-qt/qtcore:5
 	dev-qt/qtnetwork:5
 	dev-qt/qtopengl:5
 	dev-qt/qtwidgets:5
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	x11-libs/libX11"
 RDEPEND="${DEPEND}"
 

--- a/gnome-base/gnome-session/gnome-session-3.30.1-r1.ebuild
+++ b/gnome-base/gnome-session/gnome-session-3.30.1-r1.ebuild
@@ -23,7 +23,7 @@ COMMON_DEPEND="
 	x11-libs/libX11
 	>=gnome-base/gnome-desktop-3.18:3=
 	>=dev-libs/json-glib-0.10
-	media-libs/mesa[egl,gles2]
+	media-libs/mesa[egl,gles2,X(+)]
 	media-libs/libepoxy
 	x11-libs/libXcomposite
 

--- a/gnome-base/gnome-shell/gnome-shell-3.26.2-r4.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-3.26.2-r4.ebuild
@@ -60,7 +60,7 @@ COMMON_DEPEND="
 
 	${PYTHON_DEPS}
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 "
 # Runtime-only deps are probably incomplete and approximate.
 # Introspection deps generated using:

--- a/gnome-base/gnome-shell/gnome-shell-3.30.2-r2.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-3.30.2-r2.ebuild
@@ -58,7 +58,7 @@ DEPEND="
 
 	${PYTHON_DEPS}
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 "
 # Runtime-only deps are probably incomplete and approximate.
 # Introspection deps generated using:

--- a/kde-plasma/kinfocenter/kinfocenter-5.15.5.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.15.5.ebuild
@@ -40,7 +40,7 @@ COMMON_DEPEND="
 	ieee1394? ( sys-libs/libraw1394 )
 	opengl? (
 		$(add_qt_dep qtgui 'gles2=')
-		media-libs/mesa[gles2?]
+		media-libs/mesa[gles2?,X(+)]
 		!gles2? ( media-libs/glu )
 	)
 	pci? ( sys-apps/pciutils )

--- a/kde-plasma/kinfocenter/kinfocenter-5.16.3.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.16.3.ebuild
@@ -40,7 +40,7 @@ COMMON_DEPEND="
 	ieee1394? ( sys-libs/libraw1394 )
 	opengl? (
 		$(add_qt_dep qtgui 'gles2=')
-		media-libs/mesa[gles2?]
+		media-libs/mesa[gles2?,X(+)]
 		!gles2? ( media-libs/glu )
 	)
 	pci? ( sys-apps/pciutils )

--- a/kde-plasma/kwin/kwin-5.15.5.ebuild
+++ b/kde-plasma/kwin/kwin-5.15.5.ebuild
@@ -54,7 +54,7 @@ COMMON_DEPEND="
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/libepoxy
-	media-libs/mesa[egl,gbm,gles2?,wayland]
+	media-libs/mesa[egl,gbm,gles2?,wayland,X(+)]
 	virtual/libudev:=
 	x11-libs/libICE
 	x11-libs/libSM

--- a/kde-plasma/kwin/kwin-5.16.3.ebuild
+++ b/kde-plasma/kwin/kwin-5.16.3.ebuild
@@ -54,7 +54,7 @@ COMMON_DEPEND="
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/libepoxy
-	media-libs/mesa[egl,gbm,gles2?,wayland]
+	media-libs/mesa[egl,gbm,gles2?,wayland,X(+)]
 	virtual/libudev:=
 	x11-libs/libICE
 	x11-libs/libSM

--- a/media-gfx/asymptote/asymptote-2.41-r1.ebuild
+++ b/media-gfx/asymptote/asymptote-2.41-r1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	>=sys-libs/ncurses-5.4-r5:0=
 	>=sys-libs/readline-4.3-r5:0=
 	imagemagick? ( media-gfx/imagemagick[png] )
-	opengl? ( >=media-libs/mesa-8 )
+	opengl? ( >=media-libs/mesa-8[X(+)] )
 	offscreen? ( media-libs/mesa[osmesa] )
 	svg? ( app-text/dvisvgm )
 	sigsegv? ( dev-libs/libsigsegv )

--- a/media-gfx/asymptote/asymptote-2.47.ebuild
+++ b/media-gfx/asymptote/asymptote-2.47.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	>=sys-libs/ncurses-5.4-r5:0=
 	>=sys-libs/readline-4.3-r5:0=
 	imagemagick? ( media-gfx/imagemagick[png] )
-	opengl? ( >=media-libs/mesa-8 )
+	opengl? ( >=media-libs/mesa-8[X(+)] )
 	offscreen? ( media-libs/mesa[osmesa] )
 	svg? ( app-text/dvisvgm )
 	sigsegv? ( dev-libs/libsigsegv )

--- a/media-gfx/asymptote/asymptote-2.48-r1.ebuild
+++ b/media-gfx/asymptote/asymptote-2.48-r1.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	>=sys-libs/ncurses-5.4-r5:0=
 	>=sys-libs/readline-4.3-r5:0=
 	imagemagick? ( media-gfx/imagemagick[png] )
-	opengl? ( media-libs/mesa media-libs/freeglut media-libs/glew:0 media-libs/glm )
+	opengl? ( media-libs/mesa[X(+)] media-libs/freeglut media-libs/glew:0 media-libs/glm )
 	offscreen? ( media-libs/mesa[osmesa] )
 	svg? ( app-text/dvisvgm )
 	sigsegv? ( dev-libs/libsigsegv )

--- a/media-gfx/asymptote/asymptote-2.49.ebuild
+++ b/media-gfx/asymptote/asymptote-2.49.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	>=sys-libs/ncurses-5.4-r5:0=
 	>=sys-libs/readline-4.3-r5:0=
 	imagemagick? ( media-gfx/imagemagick[png] )
-	opengl? ( media-libs/mesa media-libs/freeglut media-libs/glew:0 media-libs/glm )
+	opengl? ( media-libs/mesa[X(+)] media-libs/freeglut media-libs/glew:0 media-libs/glm )
 	offscreen? ( media-libs/mesa[osmesa] )
 	svg? ( app-text/dvisvgm )
 	sigsegv? ( dev-libs/libsigsegv )

--- a/media-gfx/fbida/fbida-2.12.ebuild
+++ b/media-gfx/fbida/fbida-2.12.ebuild
@@ -25,7 +25,7 @@ CDEPEND="
 	>=media-libs/freetype-2.0
 	media-libs/libepoxy
 	media-libs/libexif
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	virtual/jpeg:*
 	virtual/ttf-fonts
 	x11-libs/cairo[opengl]

--- a/media-gfx/fbida/fbida-2.13-r1.ebuild
+++ b/media-gfx/fbida/fbida-2.13-r1.ebuild
@@ -25,7 +25,7 @@ CDEPEND="
 	>=media-libs/freetype-2.0
 	media-libs/libepoxy
 	media-libs/libexif
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	virtual/jpeg:*
 	virtual/ttf-fonts
 	x11-libs/cairo[opengl]

--- a/media-gfx/fbida/fbida-2.14.ebuild
+++ b/media-gfx/fbida/fbida-2.14.ebuild
@@ -25,7 +25,7 @@ CDEPEND="
 	>=media-libs/freetype-2.0
 	media-libs/libepoxy
 	media-libs/libexif
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	virtual/jpeg:*
 	virtual/ttf-fonts
 	x11-libs/cairo[opengl]

--- a/media-gfx/fbida/fbida-9999.ebuild
+++ b/media-gfx/fbida/fbida-9999.ebuild
@@ -24,7 +24,7 @@ CDEPEND="
 	media-libs/libexif
 	media-libs/libpng:*
 	media-libs/libwebp
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	media-libs/tiff:*
 	net-misc/curl
 	virtual/jpeg:*

--- a/media-gfx/nvidia-cg-toolkit/nvidia-cg-toolkit-3.1.0013-r3.ebuild
+++ b/media-gfx/nvidia-cg-toolkit/nvidia-cg-toolkit-3.1.0013-r3.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	x11-libs/libXmu
 	x11-libs/libXt
 	media-libs/glu
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	media-libs/freeglut
 	amd64? ( abi_x86_32? (
 		>=media-libs/glu-9.0.0-r1[abi_x86_32(-)]

--- a/media-libs/libprojectm/libprojectm-2.1.0-r2.ebuild
+++ b/media-libs/libprojectm/libprojectm-2.1.0-r2.ebuild
@@ -20,7 +20,7 @@ IUSE="debug openmp video_cards_nvidia"
 RDEPEND="media-fonts/dejavu
 	>=media-libs/ftgl-2.1.3_rc5
 	media-libs/freetype:2
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	media-libs/glew:=
 	sys-libs/zlib
 	video_cards_nvidia? ( media-gfx/nvidia-cg-toolkit )"

--- a/media-libs/libprojectm/libprojectm-3.1.0-r1.ebuild
+++ b/media-libs/libprojectm/libprojectm-3.1.0-r1.ebuild
@@ -23,7 +23,7 @@ IUSE="gles2 qt5 sdl"
 
 RDEPEND="gles2? ( media-libs/mesa[gles2] )
 	media-libs/glm
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	qt5? (
 		dev-qt/qtcore:5
 		dev-qt/qtgui:5

--- a/media-libs/libprojectm/libprojectm-9999.ebuild
+++ b/media-libs/libprojectm/libprojectm-9999.ebuild
@@ -23,7 +23,7 @@ IUSE="gles2 qt5 sdl"
 
 RDEPEND="gles2? ( media-libs/mesa[gles2] )
 	media-libs/glm
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	qt5? (
 		dev-qt/qtcore:5
 		dev-qt/qtgui:5

--- a/media-libs/mesa/mesa-19.1.3.ebuild
+++ b/media-libs/mesa/mesa-19.1.3.ebuild
@@ -38,7 +38,7 @@ done
 IUSE="${IUSE_VIDEO_CARDS}
 	+classic d3d9 debug +dri3 +egl +gallium +gbm gles1 +gles2 +libglvnd +llvm
 	lm_sensors opencl osmesa pax_kernel pic selinux test unwind vaapi valgrind
-	vdpau vulkan vulkan-overlay wayland xa xvmc"
+	vdpau vulkan vulkan-overlay wayland X xa xvmc"
 
 REQUIRED_USE="
 	d3d9?   ( dri3 || ( video_cards_iris video_cards_r300 video_cards_r600 video_cards_radeonsi video_cards_nouveau video_cards_vmware ) )
@@ -66,6 +66,8 @@ REQUIRED_USE="
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
 	video_cards_vmware? ( gallium )
+	xa? ( X )
+	xvmc? ( X )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.97"
@@ -73,13 +75,6 @@ RDEPEND="
 	!app-eselect/eselect-mesa
 	>=dev-libs/expat-2.1.0-r3:=[${MULTILIB_USEDEP}]
 	>=sys-libs/zlib-1.2.8[${MULTILIB_USEDEP}]
-	>=x11-libs/libX11-1.6.2:=[${MULTILIB_USEDEP}]
-	>=x11-libs/libxshmfence-1.1:=[${MULTILIB_USEDEP}]
-	>=x11-libs/libXdamage-1.1.4-r1:=[${MULTILIB_USEDEP}]
-	>=x11-libs/libXext-1.3.2:=[${MULTILIB_USEDEP}]
-	>=x11-libs/libXxf86vm-1.1.3:=[${MULTILIB_USEDEP}]
-	>=x11-libs/libxcb-1.13:=[${MULTILIB_USEDEP}]
-	x11-libs/libXfixes:=[${MULTILIB_USEDEP}]
 	libglvnd? (
 		media-libs/libglvnd[${MULTILIB_USEDEP}]
 		!app-eselect/eselect-opengl
@@ -124,6 +119,15 @@ RDEPEND="
 	)
 	video_cards_i915? ( ${LIBDRM_DEPSTRING}[video_cards_intel] )
 	vulkan-overlay? ( dev-util/glslang:0=[${MULTILIB_USEDEP}] )
+	X? (
+		>=x11-libs/libX11-1.6.2:=[${MULTILIB_USEDEP}]
+		>=x11-libs/libxshmfence-1.1:=[${MULTILIB_USEDEP}]
+		>=x11-libs/libXdamage-1.1.4-r1:=[${MULTILIB_USEDEP}]
+		>=x11-libs/libXext-1.3.2:=[${MULTILIB_USEDEP}]
+		>=x11-libs/libXxf86vm-1.1.3:=[${MULTILIB_USEDEP}]
+		>=x11-libs/libxcb-1.13:=[${MULTILIB_USEDEP}]
+		x11-libs/libXfixes:=[${MULTILIB_USEDEP}]
+	)
 "
 for card in ${RADEON_CARDS}; do
 	RDEPEND="${RDEPEND}
@@ -210,8 +214,10 @@ unset {LLVM,CLANG}_DEPSTR{,_AMDGPU}
 
 DEPEND="${RDEPEND}
 	valgrind? ( dev-util/valgrind )
-	x11-libs/libXrandr[${MULTILIB_USEDEP}]
-	x11-base/xorg-proto
+	X? (
+		x11-libs/libXrandr[${MULTILIB_USEDEP}]
+		x11-base/xorg-proto
+	)
 "
 BDEPEND="
 	${PYTHON_DEPS}
@@ -349,7 +355,7 @@ multilib_src_configure() {
 		fi
 	fi
 
-	emesonargs+=( -Dplatforms=x11,surfaceless$(use wayland && echo ",wayland")$(use gbm && echo ",drm") )
+	emesonargs+=( -Dplatforms=surfaceless$(use X && echo ",x11")$(use wayland && echo ",wayland")$(use gbm && echo ",drm") )
 
 	if use gallium; then
 		emesonargs+=(
@@ -472,7 +478,7 @@ multilib_src_configure() {
 
 	emesonargs+=(
 		$(meson_use test build-tests)
-		-Dglx=dri
+		-Dglx=$(usex X dri disabled)
 		-Dshared-glapi=true
 		$(meson_use dri3)
 		$(meson_use egl)

--- a/media-libs/sg/sg-1.5.ebuild
+++ b/media-libs/sg/sg-1.5.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	x11-libs/libXaw
 	x11-libs/motif
 	|| (
-		( media-libs/mesa x11-libs/libGLw )
+		( media-libs/mesa[X(+)] x11-libs/libGLw )
 		media-libs/opengl-apple
 		)"
 DEPEND="

--- a/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-1.14.1.ebuild
+++ b/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-1.14.1.ebuild
@@ -44,7 +44,7 @@ REQUIRED_USE="
 GST_REQ="1.14.1"
 GL_DEPS="
 	>=media-libs/gst-plugins-base-${GST_REQ}:${SLOT}[egl?,gles2?,opengl?,wayland?,X?]
-	media-libs/mesa[gles2?,egl?,${MULTILIB_USEDEP}]
+	media-libs/mesa[gles2?,egl?,X(+),${MULTILIB_USEDEP}]
 "
 RDEPEND="
 	>=dev-libs/glib-2.40:2[${MULTILIB_USEDEP}]

--- a/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-1.14.3.ebuild
+++ b/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-1.14.3.ebuild
@@ -44,7 +44,7 @@ REQUIRED_USE="
 GST_REQ="${PV}"
 GL_DEPS="
 	>=media-libs/gst-plugins-base-${GST_REQ}:${SLOT}[egl?,gles2?,opengl?,wayland?,X?]
-	media-libs/mesa[gles2?,egl?,${MULTILIB_USEDEP}]
+	media-libs/mesa[gles2?,egl?,X(+),${MULTILIB_USEDEP}]
 "
 RDEPEND="
 	>=dev-libs/glib-2.40:2[${MULTILIB_USEDEP}]

--- a/media-radio/ax25-tools/ax25-tools-0.0.10_rc4.ebuild
+++ b/media-radio/ax25-tools/ax25-tools-0.0.10_rc4.ebuild
@@ -19,7 +19,7 @@ S=${WORKDIR}/${MY_P}
 
 DEPEND="dev-libs/libax25
 	X? ( x11-libs/libX11
-		media-libs/mesa )"
+		media-libs/mesa[X(+)] )"
 RDEPEND=${DEPEND}
 
 src_configure() {

--- a/media-sound/spotify/spotify-1.0.72-r1.ebuild
+++ b/media-sound/spotify/spotify-1.0.72-r1.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	media-libs/alsa-lib
 	media-libs/harfbuzz
 	media-libs/fontconfig
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	net-misc/curl[ssl,curl_ssl_openssl]
 	net-print/cups[ssl]
 	x11-libs/gtk+:2

--- a/media-sound/spotify/spotify-1.1.10.ebuild
+++ b/media-sound/spotify/spotify-1.1.10.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	media-libs/alsa-lib
 	media-libs/fontconfig
 	media-libs/harfbuzz
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	net-misc/curl[ssl]
 	net-print/cups[ssl]
 	|| ( media-sound/pulseaudio media-sound/apulse )

--- a/media-tv/kodi/kodi-17.3-r1.ebuild
+++ b/media-tv/kodi/kodi-17.3-r1.ebuild
@@ -71,7 +71,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	media-libs/fontconfig
 	media-libs/freetype
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? ( >=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc] )
 	mysql? ( virtual/mysql )

--- a/media-tv/kodi/kodi-17.6-r10.ebuild
+++ b/media-tv/kodi/kodi-17.6-r10.ebuild
@@ -72,7 +72,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	media-libs/fontconfig
 	media-libs/freetype
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,openssl,postproc]

--- a/media-tv/kodi/kodi-17.6-r11.ebuild
+++ b/media-tv/kodi/kodi-17.6-r11.ebuild
@@ -72,7 +72,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	media-libs/fontconfig
 	media-libs/freetype
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,openssl,postproc]

--- a/media-tv/kodi/kodi-17.6-r6.ebuild
+++ b/media-tv/kodi/kodi-17.6-r6.ebuild
@@ -71,7 +71,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	media-libs/fontconfig
 	media-libs/freetype
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,openssl,postproc]

--- a/media-tv/kodi/kodi-17.6-r7.ebuild
+++ b/media-tv/kodi/kodi-17.6-r7.ebuild
@@ -71,7 +71,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	media-libs/fontconfig
 	media-libs/freetype
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,openssl,postproc]

--- a/media-tv/kodi/kodi-17.6-r8.ebuild
+++ b/media-tv/kodi/kodi-17.6-r8.ebuild
@@ -71,7 +71,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	media-libs/fontconfig
 	media-libs/freetype
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,openssl,postproc]

--- a/media-tv/kodi/kodi-17.6-r9.ebuild
+++ b/media-tv/kodi/kodi-17.6-r9.ebuild
@@ -72,7 +72,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	media-libs/fontconfig
 	media-libs/freetype
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,openssl,postproc]

--- a/media-tv/kodi/kodi-17.6.ebuild
+++ b/media-tv/kodi/kodi-17.6.ebuild
@@ -69,7 +69,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	media-libs/fontconfig
 	media-libs/freetype
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,openssl,postproc]

--- a/media-tv/kodi/kodi-18.0.ebuild
+++ b/media-tv/kodi/kodi-18.0.ebuild
@@ -87,7 +87,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.0_rc2.ebuild
+++ b/media-tv/kodi/kodi-18.0_rc2.ebuild
@@ -86,7 +86,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.0_rc3.ebuild
+++ b/media-tv/kodi/kodi-18.0_rc3.ebuild
@@ -87,7 +87,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.0_rc4.ebuild
+++ b/media-tv/kodi/kodi-18.0_rc4.ebuild
@@ -87,7 +87,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.0_rc5.ebuild
+++ b/media-tv/kodi/kodi-18.0_rc5.ebuild
@@ -87,7 +87,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.1.ebuild
+++ b/media-tv/kodi/kodi-18.1.ebuild
@@ -87,7 +87,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.1_rc1.ebuild
+++ b/media-tv/kodi/kodi-18.1_rc1.ebuild
@@ -87,7 +87,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.2.ebuild
+++ b/media-tv/kodi/kodi-18.2.ebuild
@@ -87,7 +87,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.2_rc1.ebuild
+++ b/media-tv/kodi/kodi-18.2_rc1.ebuild
@@ -87,7 +87,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-18.3.ebuild
+++ b/media-tv/kodi/kodi-18.3.ebuild
@@ -86,7 +86,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -88,7 +88,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	!raspberry-pi? ( media-libs/mesa[egl] )
+	!raspberry-pi? ( media-libs/mesa[egl,X(+)] )
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]

--- a/media-video/movit/movit-1.2.0.ebuild
+++ b/media-video/movit/movit-1.2.0.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 KEYWORDS="amd64 arm64 ~ppc64 x86"
 IUSE=""
 
-RDEPEND="media-libs/mesa
+RDEPEND="media-libs/mesa[X(+)]
 	>=dev-cpp/eigen-3.2.0:3
 	media-libs/libepoxy
 	sci-libs/fftw

--- a/media-video/movit/movit-1.6.1.ebuild
+++ b/media-video/movit/movit-1.6.1.ebuild
@@ -19,7 +19,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
-RDEPEND="media-libs/mesa
+RDEPEND="media-libs/mesa[X(+)]
 	>=dev-cpp/eigen-3.2.0:3
 	media-libs/libepoxy
 	>=sci-libs/fftw-3

--- a/media-video/movit/movit-1.6.2.ebuild
+++ b/media-video/movit/movit-1.6.2.ebuild
@@ -19,7 +19,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 IUSE=""
 
-RDEPEND="media-libs/mesa
+RDEPEND="media-libs/mesa[X(+)]
 	>=dev-cpp/eigen-3.2.0:3
 	media-libs/libepoxy
 	>=sci-libs/fftw-3

--- a/media-video/simplescreenrecorder/simplescreenrecorder-0.3.11-r2.ebuild
+++ b/media-video/simplescreenrecorder/simplescreenrecorder-0.3.11-r2.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	media-libs/alsa-lib:0=
-	media-libs/mesa[${MULTILIB_USEDEP}]
+	media-libs/mesa[${MULTILIB_USEDEP},X(+)]
 	|| (
 		media-video/ffmpeg[vorbis?,vpx?,x264?,mp3?,theora?]
 		media-video/libav[vorbis?,vpx?,x264?,mp3?,theora?]

--- a/media-video/simplescreenrecorder/simplescreenrecorder-9999.ebuild
+++ b/media-video/simplescreenrecorder/simplescreenrecorder-9999.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	media-libs/alsa-lib:0=
-	media-libs/mesa[${MULTILIB_USEDEP}]
+	media-libs/mesa[${MULTILIB_USEDEP},X(+)]
 	|| (
 		media-video/ffmpeg[vorbis?,vpx?,x264?,mp3?,theora?]
 		media-video/libav[vorbis?,vpx?,x264?,mp3?,theora?]

--- a/net-im/signal-desktop-bin/signal-desktop-bin-1.25.3.ebuild
+++ b/net-im/signal-desktop-bin/signal-desktop-bin-1.25.3.ebuild
@@ -19,7 +19,7 @@ IUSE=""
 
 RDEPEND="
 	dev-libs/nss
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	net-print/cups
 	x11-libs/gtk+:3[X]
 	x11-libs/libXScrnSaver

--- a/net-misc/anydesk/anydesk-4.0.1-r1.ebuild
+++ b/net-misc/anydesk/anydesk-4.0.1-r1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/glu
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	sys-auth/polkit
 	x11-libs/cairo
 	x11-libs/gdk-pixbuf

--- a/net-misc/anydesk/anydesk-5.0.0.ebuild
+++ b/net-misc/anydesk/anydesk-5.0.0.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/glu
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	sys-auth/polkit
 	x11-libs/cairo
 	x11-libs/gdk-pixbuf

--- a/sci-chemistry/molmol/molmol-2k_p2-r5.ebuild
+++ b/sci-chemistry/molmol/molmol-2k_p2-r5.ebuild
@@ -29,9 +29,9 @@ IUSE=""
 
 RDEPEND="
 	|| (
-		(	media-libs/mesa
+		(	media-libs/mesa[X(+)]
 			x11-libs/libGLw )
-		media-libs/mesa[motif] )
+		media-libs/mesa[motif,X(+)] )
 	media-libs/libpng:0=
 	media-libs/tiff:0
 	sys-libs/zlib

--- a/sci-chemistry/wxmacmolplt/wxmacmolplt-7.5-r1.ebuild
+++ b/sci-chemistry/wxmacmolplt/wxmacmolplt-7.5-r1.ebuild
@@ -18,7 +18,7 @@ IUSE="flash"
 
 RDEPEND="
 	media-libs/glew:0=
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
 	flash? ( media-libs/ming )"
 DEPEND="${RDEPEND}

--- a/sci-electronics/kicad/kicad-4.0.7.ebuild
+++ b/sci-electronics/kicad/kicad-4.0.7.ebuild
@@ -44,7 +44,7 @@ COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 	)
 	media-libs/glew:0=
 	media-libs/freeglut
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	sys-libs/zlib
 	x11-libs/cairo"
 DEPEND="${COMMON_DEPEND}

--- a/sci-electronics/kicad/kicad-5.0.1.ebuild
+++ b/sci-electronics/kicad/kicad-5.0.1.ebuild
@@ -32,7 +32,7 @@ COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 	media-libs/glew:0=
 	media-libs/glm
 	media-libs/freeglut
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	ngspice? (
 		sci-electronics/ngspice[shared]
 	)

--- a/sci-electronics/kicad/kicad-5.1.0.ebuild
+++ b/sci-electronics/kicad/kicad-5.1.0.ebuild
@@ -33,7 +33,7 @@ COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 	media-libs/glew:0=
 	media-libs/glm
 	media-libs/freeglut
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	ngspice? (
 		sci-electronics/ngspice[shared]
 	)

--- a/sci-electronics/kicad/kicad-5.1.2.ebuild
+++ b/sci-electronics/kicad/kicad-5.1.2.ebuild
@@ -33,7 +33,7 @@ COMMON_DEPEND="x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
 	media-libs/glew:0=
 	media-libs/glm
 	media-libs/freeglut
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	ngspice? (
 		sci-electronics/ngspice[shared]
 	)

--- a/sci-geosciences/mapserver/mapserver-7.0.5.ebuild
+++ b/sci-geosciences/mapserver/mapserver-7.0.5.ebuild
@@ -50,7 +50,7 @@ RDEPEND="
 	mysql? ( virtual/mysql )
 	opengl? (
 		media-libs/ftgl
-		media-libs/mesa
+		media-libs/mesa[X(+)]
 	)
 	perl? ( dev-lang/perl:= )
 	postgis? ( dev-db/postgis )

--- a/sci-geosciences/mapserver/mapserver-7.0.7.ebuild
+++ b/sci-geosciences/mapserver/mapserver-7.0.7.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 	mysql? ( virtual/mysql )
 	opengl? (
 		media-libs/ftgl
-		media-libs/mesa
+		media-libs/mesa[X(+)]
 	)
 	oracle? (
 		dev-db/oracle-instantclient:=

--- a/sci-geosciences/mapserver/mapserver-7.2.2.ebuild
+++ b/sci-geosciences/mapserver/mapserver-7.2.2.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	mysql? ( virtual/mysql )
 	opengl? (
 		media-libs/ftgl
-		media-libs/mesa
+		media-libs/mesa[X(+)]
 	)
 	oracle? (
 		dev-db/oracle-instantclient:=

--- a/sci-visualization/gfsview/gfsview-20120706-r1.ebuild
+++ b/sci-visualization/gfsview/gfsview-20120706-r1.ebuild
@@ -19,7 +19,7 @@ IUSE="static-libs"
 RDEPEND="
 	sci-libs/gerris
 	media-libs/ftgl
-	media-libs/mesa[osmesa]
+	media-libs/mesa[osmesa,X(+)]
 	x11-libs/gtk+:2
 	>=x11-libs/gtkglext-1.0.6
 	x11-libs/startup-notification

--- a/sys-apps/kmscon/kmscon-8.ebuild
+++ b/sys-apps/kmscon/kmscon-8.ebuild
@@ -19,6 +19,7 @@ COMMON_DEPEND="
 	>=virtual/udev-172
 	x11-libs/libxkbcommon
 	dev-libs/libtsm
+	media-libs/mesa[X(+)]
 	drm? ( x11-libs/libdrm
 		>=media-libs/mesa-8.0.3[egl,gbm] )
 	gles2? ( >=media-libs/mesa-8.0.3[gles2] )

--- a/virtual/opencl/opencl-0-r5.ebuild
+++ b/virtual/opencl/opencl-0-r5.ebuild
@@ -14,7 +14,7 @@ IUSE="${CARDS[@]/#/video_cards_}"
 # amdgpu-pro-opencl and intel-ocl-sdk are amd64-only
 RDEPEND="app-eselect/eselect-opencl
 	|| (
-		>=media-libs/mesa-9.1.6[opencl,${MULTILIB_USEDEP}]
+		>=media-libs/mesa-9.1.6[opencl,X(+),${MULTILIB_USEDEP}]
 		video_cards_amdgpu? (
 			abi_x86_64? ( !abi_x86_32? ( dev-libs/amdgpu-pro-opencl ) ) )
 		video_cards_i965? (

--- a/virtual/opencl/opencl-0-r6.ebuild
+++ b/virtual/opencl/opencl-0-r6.ebuild
@@ -14,7 +14,7 @@ IUSE="${CARDS[@]/#/video_cards_}"
 # amdgpu-pro-opencl and intel-ocl-sdk are amd64-only
 RDEPEND="app-eselect/eselect-opencl
 	|| (
-		>=media-libs/mesa-9.1.6[opencl,${MULTILIB_USEDEP}]
+		>=media-libs/mesa-9.1.6[opencl,X(+),${MULTILIB_USEDEP}]
 		video_cards_amdgpu? (
 			abi_x86_64? ( !abi_x86_32? ( dev-libs/amdgpu-pro-opencl ) ) )
 		video_cards_i965? (

--- a/x11-apps/radeon-profile/radeon-profile-20190311.ebuild
+++ b/x11-apps/radeon-profile/radeon-profile-20190311.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	dev-qt/qtconcurrent:5
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	x11-libs/libdrm
 "
 

--- a/x11-apps/radeon-profile/radeon-profile-20190603.ebuild
+++ b/x11-apps/radeon-profile/radeon-profile-20190603.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	dev-qt/qtconcurrent:5
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	x11-libs/libdrm
 "
 

--- a/x11-apps/radeon-profile/radeon-profile-99999999.ebuild
+++ b/x11-apps/radeon-profile/radeon-profile-99999999.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	dev-qt/qtconcurrent:5
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	x11-libs/libdrm
 "
 

--- a/x11-libs/cairo/cairo-1.16.0-r3.ebuild
+++ b/x11-libs/cairo/cairo-1.16.0-r3.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	>=x11-libs/pixman-0.32.4[${MULTILIB_USEDEP}]
 	gles2? ( >=media-libs/mesa-9.1.6[gles2,${MULTILIB_USEDEP}] )
 	glib? ( >=dev-libs/glib-2.34.3:2[${MULTILIB_USEDEP}] )
-	opengl? ( >=media-libs/mesa-9.1.6[egl,${MULTILIB_USEDEP}] )
+	opengl? ( >=media-libs/mesa-9.1.6[egl,X(+),${MULTILIB_USEDEP}] )
 	X? (
 		>=x11-libs/libXrender-0.9.8[${MULTILIB_USEDEP}]
 		>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]

--- a/x11-libs/cairo/cairo-9999.ebuild
+++ b/x11-libs/cairo/cairo-9999.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	>=x11-libs/pixman-0.32.4[${MULTILIB_USEDEP}]
 	gles2? ( >=media-libs/mesa-9.1.6[gles2,${MULTILIB_USEDEP}] )
 	glib? ( >=dev-libs/glib-2.34.3:2[${MULTILIB_USEDEP}] )
-	opengl? ( >=media-libs/mesa-9.1.6[egl,${MULTILIB_USEDEP}] )
+	opengl? ( >=media-libs/mesa-9.1.6[egl,X(+),${MULTILIB_USEDEP}] )
 	X? (
 		>=x11-libs/libXrender-0.9.8[${MULTILIB_USEDEP}]
 		>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]

--- a/x11-libs/gtk+/gtk+-3.24.1.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.1.ebuild
@@ -51,6 +51,7 @@ COMMON_DEPEND="
 	)
 	X? (
 		>=app-accessibility/at-spi2-atk-2.5.3[${MULTILIB_USEDEP}]
+		media-libs/mesa[X(+),${MULTILIB_USEDEP}]
 		x11-libs/libX11[${MULTILIB_USEDEP}]
 		>=x11-libs/libXi-1.3[${MULTILIB_USEDEP}]
 		x11-libs/libXext[${MULTILIB_USEDEP}]

--- a/x11-libs/gtk+/gtk+-3.24.10.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.10.ebuild
@@ -52,6 +52,7 @@ COMMON_DEPEND="
 	)
 	X? (
 		>=app-accessibility/at-spi2-atk-2.5.3[${MULTILIB_USEDEP}]
+		media-libs/mesa[X(+),${MULTILIB_USEDEP}]
 		x11-libs/libX11[${MULTILIB_USEDEP}]
 		>=x11-libs/libXi-1.3[${MULTILIB_USEDEP}]
 		x11-libs/libXext[${MULTILIB_USEDEP}]

--- a/x11-libs/gtk+/gtk+-3.24.4-r1.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.4-r1.ebuild
@@ -51,6 +51,7 @@ COMMON_DEPEND="
 	)
 	X? (
 		>=app-accessibility/at-spi2-atk-2.5.3[${MULTILIB_USEDEP}]
+		media-libs/mesa[X(+),${MULTILIB_USEDEP}]
 		x11-libs/libX11[${MULTILIB_USEDEP}]
 		>=x11-libs/libXi-1.3[${MULTILIB_USEDEP}]
 		x11-libs/libXext[${MULTILIB_USEDEP}]

--- a/x11-libs/gtk+/gtk+-3.24.8.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.8.ebuild
@@ -53,6 +53,7 @@ COMMON_DEPEND="
 	)
 	X? (
 		>=app-accessibility/at-spi2-atk-2.5.3[${MULTILIB_USEDEP}]
+		media-libs/mesa[X(+),${MULTILIB_USEDEP}]
 		x11-libs/libX11[${MULTILIB_USEDEP}]
 		>=x11-libs/libXi-1.3[${MULTILIB_USEDEP}]
 		x11-libs/libXext[${MULTILIB_USEDEP}]

--- a/x11-misc/rss-glx/rss-glx-0.9.1-r1.ebuild
+++ b/x11-misc/rss-glx/rss-glx-0.9.1-r1.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	x11-libs/libX11
 	x11-libs/libXext
 	>=media-libs/glew-1.5.1:=
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	>=media-gfx/imagemagick-6.4:=
 	>=x11-misc/xscreensaver-5.08-r2
 	bzip2? ( app-arch/bzip2 )

--- a/x11-plugins/e16-epplets/e16-epplets-0.16.ebuild
+++ b/x11-plugins/e16-epplets/e16-epplets-0.16.ebuild
@@ -18,7 +18,7 @@ BDEPEND="
 CDEPEND="
 	cdaudio? ( media-libs/libcdaudio )
 	libgtop? ( gnome-base/libgtop )
-	opengl? ( media-libs/glu media-libs/mesa )
+	opengl? ( media-libs/glu media-libs/mesa[X(+)] )
 	>=media-libs/imlib2-1.2.0
 	x11-libs/libX11
 	x11-libs/libXext

--- a/x11-terms/kitty/kitty-0.14.2.ebuild
+++ b/x11-terms/kitty/kitty-0.14.2.ebuild
@@ -46,7 +46,7 @@ RDEPEND="
 	imagemagick? ( virtual/imagemagick-tools )
 "
 DEPEND="${RDEPEND}
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	sys-libs/ncurses
 	virtual/pkgconfig
 "

--- a/x11-terms/kitty/kitty-9999.ebuild
+++ b/x11-terms/kitty/kitty-9999.ebuild
@@ -46,7 +46,7 @@ RDEPEND="
 	imagemagick? ( virtual/imagemagick-tools )
 "
 DEPEND="${RDEPEND}
-	media-libs/mesa
+	media-libs/mesa[X(+)]
 	sys-libs/ncurses
 	virtual/pkgconfig
 "

--- a/x11-wm/e16/e16-1.0.19.ebuild
+++ b/x11-wm/e16/e16-1.0.19.ebuild
@@ -22,7 +22,7 @@ CDEPEND="
 	dbus? ( sys-apps/dbus )
 	doc? ( app-doc/e16-docs )
 	nls? ( virtual/libintl )
-	opengl? ( media-libs/glu media-libs/mesa )
+	opengl? ( media-libs/glu media-libs/mesa[X(+)] )
 	pango? ( x11-libs/pango[X] )
 	sound? (
 		|| ( media-sound/pulseaudio media-sound/apulse[sdk] )

--- a/x11-wm/mutter/mutter-3.26.2-r1.ebuild
+++ b/x11-wm/mutter/mutter-3.26.2-r1.ebuild
@@ -51,7 +51,7 @@ RDEPEND="
 	x11-misc/xkeyboard-config
 
 	gnome-extra/zenity
-	media-libs/mesa[egl]
+	media-libs/mesa[egl,X(+)]
 
 	gles2? ( media-libs/mesa[gles2] )
 	input_devices_wacom? ( >=dev-libs/libwacom-0.13 )

--- a/x11-wm/mutter/mutter-3.30.2-r1.ebuild
+++ b/x11-wm/mutter/mutter-3.30.2-r1.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 	x11-misc/xkeyboard-config
 
 	gnome-extra/zenity
-	media-libs/mesa[X(+),egl,gles2?]
+	media-libs/mesa[X(+),egl,gles2?,X(+)]
 
 	input_devices_wacom? ( >=dev-libs/libwacom-0.13 )
 	introspection? ( >=dev-libs/gobject-introspection-1.42:= )


### PR DESCRIPTION
See https://bugs.gentoo.org/560096. This is a continuation of #4374.

This PR introduces an X use-flag for Mesa. This makes it possible to build Mesa without GLX and therefore without XLib & friends. To make existing packages not break I've `sed`ed the entire tree and replaced most dependencies on `media-libs/mesa` with `media-libs/mesa[X(+)]`. Exceptions are:
* no change if ebuild depends on virtual/opengl
* obvious packages (such as weston) didn't get the mesa[X] dependency

# Obvious
* dev-cpp/waylandpp
* dev-games/ogre (only for USE=opengl)
* dev-libs/efl (only for USE="opengl X")
* dev-libs/weston
* dev-qt/qtgui (only for USE="xcb")
* dev-qt/qtwayland
* gui-libs/wlroots
* kde-frameworks/kwayland
* x11-libs/libva-intel-driver (depends on mesa[X] via x11-libs/libva[X] -> virtual/opengl)

# DONE
* dev-qt/qtgui
* media-libs/libepoxy
* x11-libs/cairo
* x11-libs/gtk+

# TODO
* sci-electronics/kicad (uses wxGTK, I'll test this myself)
* sys-apps/kmscon (added `COMMON_DEPEND="media-libs/mesa[X(+)]"` as stop-gap)
* x11-terms/kitty (gles headers are #include'd)
* media-plugins/gst-plugins-vaapi (does `if use opengl || use gles2` in `src_configure`)
* media-tv/kodi (it should be easy to make GLX optional but I have no way of testing it)