### PR TITLE
Gnome: Libpeas python3.7 targets

### DIFF
--- a/app-editors/gedit-plugins/gedit-plugins-3.32.2.ebuild
+++ b/app-editors/gedit-plugins/gedit-plugins-3.32.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="6"
 GNOME2_LA_PUNT="yes" # plugins are dlopened
-PYTHON_COMPAT=( python3_{5,6} )
+PYTHON_COMPAT=( python3_{5,6,7} )
 PYTHON_REQ_USE="xml"
 VALA_MIN_API_VERSION="0.28"
 

--- a/app-editors/gedit/gedit-3.32.2.ebuild
+++ b/app-editors/gedit/gedit-3.32.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="6"
 GNOME2_LA_PUNT="yes" # plugins are dlopened
-PYTHON_COMPAT=( python3_{5,6} )
+PYTHON_COMPAT=( python3_{5,6,7} )
 VALA_MIN_API_VERSION="0.26"
 VALA_USE_DEPEND="vapigen"
 

--- a/media-gfx/eog-plugins/eog-plugins-3.26.3.ebuild
+++ b/media-gfx/eog-plugins/eog-plugins-3.26.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 GNOME2_LA_PUNT="yes"
-PYTHON_COMPAT=( python{3_5,3_6} )
+PYTHON_COMPAT=( python{3_5,3_6,3_7} )
 
 inherit gnome2 python-single-r1
 

--- a/media-sound/rhythmbox/rhythmbox-3.4.3.ebuild
+++ b/media-sound/rhythmbox/rhythmbox-3.4.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 GNOME2_LA_PUNT="yes"
-PYTHON_COMPAT=( python3_{5,6} )
+PYTHON_COMPAT=( python3_{5,6,7} )
 PYTHON_REQ_USE="xml"
 
 inherit eutils gnome2 python-single-r1 multilib virtualx

--- a/media-video/totem/totem-3.30.0.ebuild
+++ b/media-video/totem/totem-3.30.0.ebuild
@@ -2,8 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{3_5,3_6} )
-PYTHON_REQ_USE="threads"
+PYTHON_COMPAT=( python{3_5,3_6,3_7} )
+PYTHON_REQ_USE="threads(+)"
 
 inherit gnome.org gnome2-utils meson vala xdg python-single-r1
 


### PR DESCRIPTION
Just PYTHON_COMPAT update, no EAPI bumps or anything else. 

```
[ebuild   R    ] app-editors/gedit-3.32.2::testworld  USE="introspection python spell test -gtk-doc -vala" PYTHON_SINGLE_TARGET="python3_7 -python3_5 -python3_6" PYTHON_TARGETS="python3_5 python3_6 python3_7" 0 KiB
[ebuild   R    ] media-gfx/eog-3.28.4:1::gentoo  USE="exif introspection jpeg lcms svg tiff -gtk-doc -xmp" 0 KiB
[ebuild   R    ] media-sound/rhythmbox-3.4.3::testworld  USE="dbus libnotify python test udev -cdr -daap -gnome-keyring -ipod -lirc -mtp -nsplugin -upnp-av" PYTHON_SINGLE_TARGET="python3_7 -python3_5 -python3_6" PYTHON_TARGETS="python3_5 python3_6 python3_7" 0 KiB
[ebuild   R    ] media-video/totem-3.30.0::testworld  USE="introspection nautilus python test -cdr -gtk-doc -lirc -vala" PYTHON_SINGLE_TARGET="python3_7 -python3_5 -python3_6" PYTHON_TARGETS="python3_5 python3_6 python3_7" 0 KiB
[ebuild   R    ] app-editors/gedit-plugins-3.32.2::testworld  USE="python -charmap -git -terminal -vala" PYTHON_SINGLE_TARGET="python3_7 -python3_5 -python3_6" PYTHON_TARGETS="python3_5 python3_6 python3_7" 0 KiB
[ebuild   R    ] media-gfx/eog-plugins-3.26.3::testworld  USE="exif python -map -picasa" PYTHON_SINGLE_TARGET="python3_7 -python3_5 -python3_6" PYTHON_TARGETS="python3_5 python3_6 python3_7" 0 KiB
```