### PR TITLE
net-misc/iputils: fix build with USE="-caps"

### DIFF
--- a/net-misc/iputils/files/iputils-20190515-fix-setcap.patch
+++ b/net-misc/iputils/files/iputils-20190515-fix-setcap.patch
@@ -1,0 +1,67 @@
+From 473be6467f995865244e7e68b2fa587a4ee79551 Mon Sep 17 00:00:00 2001
+From: Michael Weiss <dev.primeos@gmail.com>
+Date: Thu, 16 May 2019 09:44:27 +0000
+Subject: [PATCH] build-sys: Make setcap really optional
+
+The setcap dependency is marked as optional but meson.build depends on
+setcap.path():
+
+meson.build:246:7: ERROR:  add_install_script args must be strings
+---
+ meson.build | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 8af9e18..95c778a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -221,10 +221,13 @@ config_h = configure_file(
+ setcap = find_program('setcap', '/usr/sbin/setcap', '/sbin/setcap', required : false)
+ if get_option('NO_SETCAP_OR_SUID')
+ 	perm_type = 'none'
++	setcap_path = '/dev/null'
+ elif cap_dep.found() and setcap.found()
+ 	perm_type = 'caps'
++	setcap_path = setcap.path()
+ else
+ 	perm_type = 'setuid'
++	setcap_path = '/dev/null'
+ endif
+ 
+ ############################################################
+@@ -243,7 +246,7 @@ if build_ping == true
+ 		join_paths(get_option('prefix'), get_option('bindir')),
+ 		'ping',
+ 		perm_type,
+-		setcap.path()
++		setcap_path
+ 	)
+ endif
+ 
+@@ -263,7 +266,7 @@ if build_traceroute6 == true
+ 		join_paths(get_option('prefix'), get_option('bindir')),
+ 		'traceroute6',
+ 		perm_type,
+-		setcap.path()
++		setcap_path
+ 	)
+ endif
+ 
+@@ -276,7 +279,7 @@ if build_clockdiff == true
+ 		join_paths(get_option('prefix'), get_option('bindir')),
+ 		'clockdiff',
+ 		perm_type,
+-		setcap.path()
++		setcap_path
+ 	)
+ endif
+ 
+@@ -306,7 +309,7 @@ if build_arping == true
+ 		join_paths(get_option('prefix'), get_option('bindir')),
+ 		'arping',
+ 		perm_type,
+-		setcap.path()
++		setcap_path
+ 	)
+ endif
+ 

--- a/net-misc/iputils/iputils-20190515.ebuild
+++ b/net-misc/iputils/iputils-20190515.ebuild
@@ -71,7 +71,9 @@ fi
 
 [ "${PV}" == "99999999" ] || S="${WORKDIR}/${PN}-s${PV}"
 
-PATCHES=()
+PATCHES=(
+	"${FILESDIR}"/${PN}-20190515-fix-setcap.patch
+)
 
 src_prepare() {
 	use SECURITY_HAZARD && PATCHES+=( "${FILESDIR}"/${PN}-20150815-nonroot-floodping.patch )


### PR DESCRIPTION
Upstream patch. Without this change, attempting to emerge
net-misc/iputils-20190515 with USE="-caps" without having
had sys-libs/libcap installed for some other reason will fail during
src_configure due to wrong type of arguments for add_install_script.

Package-Manager: Portage-2.3.67, Repoman-2.3.16
Signed-off-by: Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>