### PR TITLE
net-misc/httpie: Address test failure during stabilisation

### DIFF
--- a/net-misc/httpie/files/test_ssl.patch
+++ b/net-misc/httpie/files/test_ssl.patch
@@ -1,0 +1,11 @@
+--- a/tests/test_ssl.py	2018-11-14 16:36:19.000000000 +0100
++++ b/tests/test_ssl.py	2019-06-29 16:28:09.466528486 +0200
+@@ -45,7 +45,7 @@
+     except ssl_errors as e:
+         if ssl_version == 'ssl3':
+             # pytest-httpbin doesn't support ssl3
+-            assert 'SSLV3_ALERT_HANDSHAKE_FAILURE' in str(e)
++            assert 'SSLV3_ALERT_HANDSHAKE_FAILURE' in str(e) or 'handshake failure' in str(e)
+         else:
+             raise
+ 

--- a/net-misc/httpie/httpie-1.0.2-r1.ebuild
+++ b/net-misc/httpie/httpie-1.0.2-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_REQ_USE="ssl(+)"
+
+inherit bash-completion-r1 distutils-r1
+
+DESCRIPTION="Modern command line HTTP client"
+HOMEPAGE="https://httpie.org/ https://pypi.org/project/httpie/"
+SRC_URI="https://github.com/jakubroztocil/httpie/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+
+RDEPEND="dev-python/pygments[${PYTHON_USEDEP}]
+	>=dev-python/requests-2.19.1[${PYTHON_USEDEP}]"
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
+	test? (
+		${RDEPEND}
+		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/pyopenssl[${PYTHON_USEDEP}]
+		dev-python/pytest-httpbin[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+	)"
+
+# Extend list of expected strings in test
+PATCHES=( "${FILESDIR}/test_ssl.patch" )
+
+python_test() {
+	pytest -vv || die "Tests failed with ${EPYTHON}"
+}
+
+python_install_all() {
+	newbashcomp extras/httpie-completion.bash http
+	insinto /usr/share/fish/vendor_completions.d
+	newins extras/httpie-completion.fish http.fish
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
* test_ssl.py states that "pytest-httpbin doesn't support ssl3" and asserts that a caught exception contains a certain string. A patch in this ebuild extends the list of expected strings.

* Added dependency to dev-python/mock.