### PR TITLE
net-firewall/nftables: add doc and xtables USE flags

### DIFF
--- a/net-firewall/nftables/metadata.xml
+++ b/net-firewall/nftables/metadata.xml
@@ -14,7 +14,9 @@
 		<name>Francisco Blas Izquierdo Riera</name>
 	</maintainer>
 	<use>
+		<flag name="doc">Create man pages for the package (requires <pkg>app-text/asciidoc</pkg>)</flag>
 		<flag name="json">Enable JSON support via <pkg>dev-libs/jansson</pkg></flag>
 		<flag name="modern_kernel">Install init scripts for 3.18 or higher kernels with atomic rule updates</flag>
+		<flag name="xtables">Add libxtables support to try to automatically translate rules added by iptables-compat</flag>
 	</use>
 </pkgmetadata>

--- a/net-firewall/nftables/nftables-0.9.1.ebuild
+++ b/net-firewall/nftables/nftables-0.9.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://netfilter.org/projects/nftables/files/${P}.tar.bz2"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86"
-IUSE="debug +gmp json +modern_kernel python +readline static-libs"
+IUSE="debug +doc +gmp json +modern_kernel python +readline static-libs xtables"
 
 RDEPEND="
 	>=net-libs/libmnl-1.0.3:0=
@@ -23,11 +23,14 @@ RDEPEND="
 	json? ( dev-libs/jansson )
 	python? ( ${PYTHON_DEPS} )
 	readline? ( sys-libs/readline:0= )
-	>=net-libs/libnftnl-1.1.3:0="
+	>=net-libs/libnftnl-1.1.3:0=
+	xtables? ( >=net-firewall/iptables-1.6.1 )
+"
 
 DEPEND="${RDEPEND}"
 
 BDEPEND="
+	doc? ( app-text/asciidoc )
 	>=app-text/docbook2X-0.8.8-r4
 	sys-devel/bison
 	sys-devel/flex
@@ -82,10 +85,12 @@ src_configure() {
 		--disable-python
 		--sbindir="${EPREFIX}"/sbin
 		$(use_enable debug)
+		$(use_enable doc man-doc)
 		$(use_with !gmp mini_gmp)
 		$(use_with json)
 		$(use_with readline cli)
 		$(use_enable static-libs static)
+		$(use_with xtables)
 	)
 	econf "${myeconfargs[@]}"
 }


### PR DESCRIPTION
This commit adds some fixes on the 0.9.1 package:
* Adds the doc USE flag to control building of the man pages
* Adds the app-text/asciidoc when building the man pages
* Adds the xtables USE flag for better compatibility with iptables-compat
* Adds the net-firewall/iptables dependency when using the xtables flag

I have chosen +doc, xtables for better compatibility with prior versions.
Also whilst man pages generally make sense, the xtables USE isn't needed on pure nftables setups which are the recommended approach.

IMPORTANT: Please note that I'm not pushing a new revision as this fixes mostly build issues and the default USE flag settings are compatible with the prior revision.