### PR TITLE
net-libs/libvncserver: add fix for unaligned access crash

### DIFF
--- a/net-libs/libvncserver/files/libvncserver-0.9.12-sparc-unaligned.patch
+++ b/net-libs/libvncserver/files/libvncserver-0.9.12-sparc-unaligned.patch
@@ -1,0 +1,40 @@
+From 0cf1400c61850065de590d403f6d49e32882fd76 Mon Sep 17 00:00:00 2001
+From: Rolf Eike Beer <eike@sf-mail.de>
+Date: Tue, 28 May 2019 18:30:46 +0200
+Subject: [PATCH] fix crash because of unaligned accesses in
+ hybiReadAndDecode()
+
+---
+ libvncserver/ws_decode.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/libvncserver/ws_decode.c b/libvncserver/ws_decode.c
+index 441ebc7..10c44d1 100644
+--- a/libvncserver/ws_decode.c
++++ b/libvncserver/ws_decode.c
+@@ -327,7 +327,6 @@ hybiReadAndDecode(ws_ctx_t *wsctx, char *dst, int len, int *sockRet, int nInBuf)
+   int bufsize;
+   int nextRead;
+   unsigned char *data;
+-  uint32_t *data32;
+ 
+   /* if data was carried over, copy to start of buffer */
+   memcpy(wsctx->writePos, wsctx->carryBuf, wsctx->carrylen);
+@@ -383,10 +382,12 @@ hybiReadAndDecode(ws_ctx_t *wsctx, char *dst, int len, int *sockRet, int nInBuf)
+   /* for a possible base64 decoding, we decode multiples of 4 bytes until
+    * the whole frame is received and carry over any remaining bytes in the carry buf*/
+   data = (unsigned char *)(wsctx->writePos - toDecode);
+-  data32= (uint32_t *)data;
+ 
+   for (i = 0; i < (toDecode >> 2); i++) {
+-    data32[i] ^= wsctx->header.mask.u;
++    uint32_t tmp;
++    memcpy(&tmp, data + i * sizeof(tmp), sizeof(tmp));
++    tmp ^= wsctx->header.mask.u;
++    memcpy(data + i * sizeof(tmp), &tmp, sizeof(tmp));
+   }
+   ws_dbg("mask decoding; i=%d toDecode=%d\n", i, toDecode);
+ 
+-- 
+2.16.4
+

--- a/net-libs/libvncserver/libvncserver-0.9.12-r2.ebuild
+++ b/net-libs/libvncserver/libvncserver-0.9.12-r2.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils
+
+MY_P="LibVNCServer-${PV}"
+DESCRIPTION="library for creating vnc servers"
+HOMEPAGE="https://libvnc.github.io/"
+SRC_URI="https://github.com/LibVNC/${PN}/archive/${MY_P}.tar.gz"
+
+# libvncserver/tightvnc-filetransfer/*: GPL-2, but we don't build it
+# common/d3des.*: https://github.com/LibVNC/libvncserver/issues/88
+LICENSE="GPL-2+ LGPL-2.1+ BSD MIT"
+# no sub slot wanted (yet), see #578958
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~x86-fbsd ~amd64-linux ~x86-linux"
+IUSE="+24bpp gcrypt gnutls ipv6 +jpeg libressl lzo +png sasl ssl systemd +threads +zlib"
+# https://bugs.gentoo.org/435326
+# https://bugs.gentoo.org/550916
+REQUIRED_USE="ssl? ( !gnutls? ( threads ) ) png? ( zlib )"
+
+DEPEND="
+	gcrypt? ( >=dev-libs/libgcrypt-1.5.3:0= )
+	ssl? (
+		!gnutls? (
+			!libressl? ( >=dev-libs/openssl-1.0.2:0= )
+			libressl? ( >=dev-libs/libressl-2.7.0:0= )
+		)
+		gnutls? ( >=net-libs/gnutls-2.12.23-r6:0= )
+	)
+	jpeg? ( >=virtual/jpeg-0-r2:0 )
+	lzo? ( dev-libs/lzo )
+	png? ( >=media-libs/libpng-1.6.10:0= )
+	sasl? ( dev-libs/cyrus-sasl )
+	systemd? ( sys-apps/systemd:= )
+	zlib? ( >=sys-libs/zlib-1.2.8-r1:0= )"
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/${PN}-${MY_P}"
+
+DOCS=( AUTHORS ChangeLog NEWS README.md TODO )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-cmake-libdir.patch
+	"${FILESDIR}"/${P}-libgcrypt.patch
+	"${FILESDIR}"/${P}-sparc-unaligned.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DWITH_ZLIB=$(usex zlib ON OFF)
+		-DWITH_LZO=$(usex lzo ON OFF)
+		-DWITH_JPEG=$(usex jpeg ON OFF)
+		-DWITH_PNG=$(usex png ON OFF)
+		-DWITH_THREADS=$(usex threads ON OFF)
+		-DWITH_GNUTLS=$(usex gnutls $(usex ssl ON OFF) OFF)
+		-DWITH_OPENSSL=$(usex gnutls OFF $(usex ssl ON OFF))
+		-DWITH_GCRYPT=$(usex gcrypt ON OFF)
+		-DWITH_SYSTEMD=$(usex systemd ON OFF)
+		-DWITH_FFMPEG=OFF
+		-DWITH_24BPP=$(usex 24bpp ON OFF)
+		-DWITH_IPv6=$(usex ipv6 ON OFF)
+		-DWITH_SASL=$(usex sasl ON OFF)
+	)
+	cmake-utils_src_configure
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/686914