### PR TITLE
dev-util/lcov: Add missing dependencies for 9999

### DIFF
--- a/dev-util/lcov/lcov-9999.ebuild
+++ b/dev-util/lcov/lcov-9999.ebuild
@@ -23,6 +23,8 @@ IUSE="png"
 RDEPEND="
 	dev-lang/perl
 	png? ( dev-perl/GD[png] )
+	dev-perl/JSON
+	dev-perl/PerlIO-gzip
 "
 
 src_prepare() {


### PR DESCRIPTION
lcov [added](https://github.com/linux-test-project/lcov/commit/75fbae1cfc5027f818a0bb865bf6f96fab3202da) gcc 9 support (not released yet) intorducing a few new dependencies. This makes the ebuild dependencies list up-to-date with the upstream.