### PR TITLE
media-tv/kodi: Add raspberry-pi USE flag

### DIFF
--- a/media-tv/kodi/kodi-18.3-r1.ebuild
+++ b/media-tv/kodi/kodi-18.3-r1.ebuild
@@ -41,11 +41,11 @@ SLOT="0"
 # use flag is called libusb so that it doesn't fool people in thinking that
 # it is _required_ for USB support. Otherwise they'll disable udev and
 # that's going to be worse.
-IUSE="airplay alsa bluetooth bluray caps cec +css dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl pulseaudio samba systemd +system-ffmpeg test +udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
+IUSE="airplay alsa bluetooth bluray caps cec +css dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl pulseaudio raspberry-pi samba systemd +system-ffmpeg test +udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	|| ( gles opengl )
-	^^ ( gbm wayland X )
+	^^ ( gbm raspberry-pi wayland X )
 	?? ( mariadb mysql )
 	udev? ( !libusb )
 	udisks? ( dbus )
@@ -66,7 +66,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	dev-libs/expat
 	dev-libs/flatbuffers
 	>=dev-libs/fribidi-0.19.7
-	cec? ( >=dev-libs/libcec-4.0 )
+	cec? ( >=dev-libs/libcec-4.0[raspberry-pi?] )
 	dev-libs/libpcre[cxx]
 	>=dev-libs/libinput-1.10.5
 	>=dev-libs/libxml2-2.9.4
@@ -78,7 +78,9 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=dev-libs/libfmt-3.0.1
 	dev-libs/libfstrcmp
 	gbm? (	media-libs/mesa[gbm] )
-	gles? ( media-libs/mesa[gles2] )
+	gles? (
+		!raspberry-pi? ( media-libs/mesa[gles2] )
+	)
 	lcms? ( media-libs/lcms:2 )
 	libusb? ( virtual/libusb:1 )
 	virtual/ttf-fonts
@@ -86,7 +88,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	!raspberry-pi? ( media-libs/mesa[egl] )
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]
@@ -100,6 +102,9 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	opengl? ( media-libs/glu )
 	!libressl? ( >=dev-libs/openssl-1.0.2l:0= )
 	libressl? ( dev-libs/libressl:0= )
+	raspberry-pi? (
+		|| ( media-libs/raspberrypi-userland media-libs/raspberrypi-userland-bin media-libs/mesa[egl,gles2,vc4] )
+	)
 	pulseaudio? ( media-sound/pulseaudio )
 	samba? ( >=net-fs/samba-3.4.6[smbclient(+)] )
 	>=sys-libs/zlib-1.2.11
@@ -275,6 +280,10 @@ src_configure() {
 			-DCORE_PLATFORM_NAME="wayland"
 			-DWAYLAND_RENDER_SYSTEM="$(usex opengl gl gles)"
 		)
+	fi
+
+	if use raspberry-pi; then
+		mycmakeargs+=( -DCORE_PLATFORM_NAME="rbpi" )
 	fi
 
 	if use X; then

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -41,11 +41,11 @@ SLOT="0"
 # use flag is called libusb so that it doesn't fool people in thinking that
 # it is _required_ for USB support. Otherwise they'll disable udev and
 # that's going to be worse.
-IUSE="airplay alsa bluetooth bluray caps cec +css dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl pulseaudio samba systemd +system-ffmpeg test +udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
+IUSE="airplay alsa bluetooth bluray caps cec +css dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl pulseaudio raspberry-pi samba systemd +system-ffmpeg test +udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	|| ( gles opengl )
-	^^ ( gbm wayland X )
+	^^ ( gbm raspberry-pi wayland X )
 	?? ( mariadb mysql )
 	udev? ( !libusb )
 	udisks? ( dbus )
@@ -66,7 +66,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	dev-libs/expat
 	dev-libs/flatbuffers
 	>=dev-libs/fribidi-0.19.7
-	cec? ( >=dev-libs/libcec-4.0 )
+	cec? ( >=dev-libs/libcec-4.0[raspberry-pi?] )
 	dev-libs/libpcre[cxx]
 	>=dev-libs/libinput-1.10.5
 	>=dev-libs/libxml2-2.9.4
@@ -78,7 +78,9 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=dev-libs/libfmt-3.0.1
 	dev-libs/libfstrcmp
 	gbm? (	media-libs/mesa[gbm] )
-	gles? ( media-libs/mesa[gles2] )
+	gles? (
+		!raspberry-pi? ( media-libs/mesa[gles2] )
+	)
 	lcms? ( media-libs/lcms:2 )
 	libusb? ( virtual/libusb:1 )
 	virtual/ttf-fonts
@@ -86,7 +88,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.8
 	>=media-libs/libass-0.13.4
-	media-libs/mesa[egl]
+	!raspberry-pi? ( media-libs/mesa[egl] )
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[encode,postproc]
@@ -100,6 +102,9 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	opengl? ( media-libs/glu )
 	!libressl? ( >=dev-libs/openssl-1.0.2l:0= )
 	libressl? ( dev-libs/libressl:0= )
+	raspberry-pi? (
+		|| ( media-libs/raspberrypi-userland media-libs/raspberrypi-userland-bin media-libs/mesa[egl,gles2,vc4] )
+	)
 	pulseaudio? ( media-sound/pulseaudio )
 	samba? ( >=net-fs/samba-3.4.6[smbclient(+)] )
 	>=sys-libs/zlib-1.2.11
@@ -275,6 +280,10 @@ src_configure() {
 			-DCORE_PLATFORM_NAME="wayland"
 			-DWAYLAND_RENDER_SYSTEM="$(usex opengl gl gles)"
 		)
+	fi
+
+	if use raspberry-pi; then
+		mycmakeargs+=( -DCORE_PLATFORM_NAME="rbpi" )
 	fi
 
 	if use X; then

--- a/media-tv/kodi/metadata.xml
+++ b/media-tv/kodi/metadata.xml
@@ -16,6 +16,7 @@
 		<flag name="nfs">Enable NFS client support</flag>
 		<flag name="nonfree">Enable non-free components</flag>
 		<flag name="dvd">Enable optical (CD/DVD drive) support</flag>
+		<flag name="raspberry-pi">Enable support for the Raspberry Pi</flag>
 		<flag name="sftp">Support browsing files over SFTP</flag>
 		<flag name="system-ffmpeg">Use system ffmpeg instead of the bundled one</flag>
 		<flag name="libusb">Use <pkg>virtual/libusb</pkg> for usb device hotplug support. This flag should only be enabled if you're running a non-Linux kernel or you don't want to use <pkg>sys-fs/udev</pkg>.</flag>

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Craig Andrews <candrews@gentoo.org> (2019-07-03)
+# Unmask Raspberry Pi support on arm.
+media-tv/kodi -raspberry-pi
+
 # Matt Turner <mattst88@gentoo.org> (2019-06-20)
 # dev-lang/spidermonkey:60[jit] fails to build on most platforms, but does
 # build on arm.

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Craig Andrews <candrews@gentoo.org> (2019-07-03)
+# Raspberry Pi support is only available on arm.
+# Mask raspberry-pi USE globally, unmask on arm.
+media-tv/kodi raspberry-pi
+
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2019-06-22)
 # mask javafx until it's keyworded on other arches
 dev-java/openjdk:11 javafx


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/686686
Package-Manager: Portage-2.3.68, Repoman-2.3.16
Signed-off-by: Craig Andrews <candrews@gentoo.org>