### PR TITLE
dev-util/cmake: use correct pattern to undo cmake eclass modifications

### DIFF
--- a/dev-util/cmake/cmake-3.14.3.ebuild
+++ b/dev-util/cmake/cmake-3.14.3.ebuild
@@ -101,7 +101,7 @@ cmake_src_bootstrap() {
 cmake_src_test() {
 	# fix OutDir and SelectLibraryConfigurations tests
 	# these are altered thanks to our eclass
-	sed -i -e 's:#IGNORE ::g' \
+	sed -i -e 's:^#_cmake_modify_IGNORE ::g' \
 		"${S}"/Tests/{OutDir,CMakeOnly/SelectLibraryConfigurations}/CMakeLists.txt \
 		|| die
 

--- a/dev-util/cmake/cmake-3.14.3.ebuild
+++ b/dev-util/cmake/cmake-3.14.3.ebuild
@@ -119,12 +119,14 @@ cmake_src_test() {
 	#    RunCMake.CompilerLauncher: also requires fortran
 	#    RunCMake.CPack_RPM: breaks if app-arch/rpm is installed because
 	#        debugedit binary is not in the expected location
+	#    RunCMake.CPack_DEB: breaks if app-arch/dpkg is installed because
+	#        it can't find a deb package that owns libc
 	#    TestUpload, which requires network access
 	"${BUILD_DIR}"/bin/ctest \
 		-j "$(makeopts_jobs)" \
 		--test-load "$(makeopts_loadavg)" \
 		${ctestargs} \
-		-E "(BootstrapTest|BundleUtilities|CMakeOnly.AllFindModules|CompileOptions|CTest.UpdateCVS|Fortran|RunCMake.CompilerLauncher|RunCMake.CPack_RPM|TestUpload)" \
+		-E "(BootstrapTest|BundleUtilities|CMakeOnly.AllFindModules|CompileOptions|CTest.UpdateCVS|Fortran|RunCMake.CompilerLauncher|RunCMake.CPack_(DEB|RPM)|TestUpload)" \
 		|| die "Tests failed"
 
 	popd > /dev/null

--- a/dev-util/cmake/cmake-3.14.5.ebuild
+++ b/dev-util/cmake/cmake-3.14.5.ebuild
@@ -101,7 +101,7 @@ cmake_src_bootstrap() {
 cmake_src_test() {
 	# fix OutDir and SelectLibraryConfigurations tests
 	# these are altered thanks to our eclass
-	sed -i -e 's:#IGNORE ::g' \
+	sed -i -e 's:^#_cmake_modify_IGNORE ::g' \
 		"${S}"/Tests/{OutDir,CMakeOnly/SelectLibraryConfigurations}/CMakeLists.txt \
 		|| die
 

--- a/dev-util/cmake/cmake-3.14.5.ebuild
+++ b/dev-util/cmake/cmake-3.14.5.ebuild
@@ -119,12 +119,14 @@ cmake_src_test() {
 	#    RunCMake.CompilerLauncher: also requires fortran
 	#    RunCMake.CPack_RPM: breaks if app-arch/rpm is installed because
 	#        debugedit binary is not in the expected location
+	#    RunCMake.CPack_DEB: breaks if app-arch/dpkg is installed because
+	#        it can't find a deb package that owns libc
 	#    TestUpload, which requires network access
 	"${BUILD_DIR}"/bin/ctest \
 		-j "$(makeopts_jobs)" \
 		--test-load "$(makeopts_loadavg)" \
 		${ctestargs} \
-		-E "(BootstrapTest|BundleUtilities|CMakeOnly.AllFindModules|CompileOptions|CTest.UpdateCVS|Fortran|RunCMake.CompilerLauncher|RunCMake.CPack_RPM|TestUpload)" \
+		-E "(BootstrapTest|BundleUtilities|CMakeOnly.AllFindModules|CompileOptions|CTest.UpdateCVS|Fortran|RunCMake.CompilerLauncher|RunCMake.CPack_(DEB|RPM)|TestUpload)" \
 		|| die "Tests failed"
 
 	popd > /dev/null

--- a/dev-util/cmake/cmake-3.15.0_rc3.ebuild
+++ b/dev-util/cmake/cmake-3.15.0_rc3.ebuild
@@ -101,7 +101,7 @@ cmake_src_bootstrap() {
 cmake_src_test() {
 	# fix OutDir and SelectLibraryConfigurations tests
 	# these are altered thanks to our eclass
-	sed -i -e 's:#IGNORE ::g' \
+	sed -i -e 's:^#_cmake_modify_IGNORE ::g' \
 		"${S}"/Tests/{OutDir,CMakeOnly/SelectLibraryConfigurations}/CMakeLists.txt \
 		|| die
 

--- a/dev-util/cmake/cmake-3.15.0_rc3.ebuild
+++ b/dev-util/cmake/cmake-3.15.0_rc3.ebuild
@@ -119,12 +119,14 @@ cmake_src_test() {
 	#    RunCMake.CompilerLauncher: also requires fortran
 	#    RunCMake.CPack_RPM: breaks if app-arch/rpm is installed because
 	#        debugedit binary is not in the expected location
+	#    RunCMake.CPack_DEB: breaks if app-arch/dpkg is installed because
+	#        it can't find a deb package that owns libc
 	#    TestUpload, which requires network access
 	"${BUILD_DIR}"/bin/ctest \
 		-j "$(makeopts_jobs)" \
 		--test-load "$(makeopts_loadavg)" \
 		${ctestargs} \
-		-E "(BootstrapTest|BundleUtilities|CMakeOnly.AllFindModules|CompileOptions|CTest.UpdateCVS|Fortran|RunCMake.CompilerLauncher|RunCMake.CPack_RPM|TestUpload)" \
+		-E "(BootstrapTest|BundleUtilities|CMakeOnly.AllFindModules|CompileOptions|CTest.UpdateCVS|Fortran|RunCMake.CompilerLauncher|RunCMake.CPack_(DEB|RPM)|TestUpload)" \
 		|| die "Tests failed"
 
 	popd > /dev/null


### PR DESCRIPTION
Fixes: 6b7998b644e6f4469a7cb4c64776013a74363866
Closes: https://bugs.gentoo.org/686266