### PR TITLE
 media-libs/giflib: fix missing quantize api symbols

### DIFF
--- a/dev-dotnet/libgdiplus/libgdiplus-5.6.1-r2.ebuild
+++ b/dev-dotnet/libgdiplus/libgdiplus-5.6.1-r2.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit eutils
+
+DESCRIPTION="Library for using System.Drawing with mono"
+HOMEPAGE="http://www.mono-project.com"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+SRC_URI="http://download.mono-project.com/sources/${PN}/${P}.tar.gz"
+
+IUSE="cairo"
+
+#skip tests due https://bugs.gentoo.org/687784
+RESTRICT="test"
+
+RDEPEND=">=dev-libs/glib-2.2.3:2
+	>=media-libs/freetype-2.3.7
+	>=media-libs/fontconfig-2.6
+	>=media-libs/libpng-1.4:0
+	x11-libs/libXrender
+	x11-libs/libX11
+	x11-libs/libXt
+	>=x11-libs/cairo-1.8.4[X]
+	media-libs/libexif
+	>=media-libs/giflib-5.1.2
+	virtual/jpeg:0
+	media-libs/tiff:0
+	!cairo? ( >=x11-libs/pango-1.20 )"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-cofigure.patch"
+)
+
+src_configure() {
+	econf \
+		--disable-dependency-tracking \
+		--disable-static \
+		$(usex cairo "" "--with-pango")
+}
+
+src_install () {
+	default
+
+	dotnet_multilib_comply
+	local commondoc=( AUTHORS ChangeLog README TODO )
+	for docfile in "${commondoc[@]}"; do
+		[[ -e "${docfile}" ]] && dodoc "${docfile}"
+	done
+	[[ "${DOCS[@]}" ]] && dodoc "${DOCS[@]}"
+	prune_libtool_files
+}

--- a/media-libs/giflib/files/giflib-5.1.9-fix-missing-quantize-api-symbols.patch
+++ b/media-libs/giflib/files/giflib-5.1.9-fix-missing-quantize-api-symbols.patch
@@ -1,0 +1,32 @@
+From ff8d9a59e79b79657e64430730c35835a84db619 Mon Sep 17 00:00:00 2001
+From: anthraxx <levente@leventepolyak.net>
+Date: Tue, 2 Apr 2019 11:46:18 +0200
+Subject: [PATCH] fix missing quantize API symbols
+
+GifQuantizeBuffer is required by many libs and applications
+like mplayer, libgdiplus (mono) and others.
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index e4ded69..17d0a5c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,11 +29,11 @@ LIBPOINT=0
+ LIBVER=$(LIBMAJOR).$(LIBMINOR).$(LIBPOINT)
+ 
+ SOURCES = dgif_lib.c egif_lib.c gifalloc.c gif_err.c gif_font.c \
+-	gif_hash.c openbsd-reallocarray.c
++	gif_hash.c openbsd-reallocarray.c quantize.c
+ HEADERS = gif_hash.h  gif_lib.h  gif_lib_private.h
+ OBJECTS = $(SOURCES:.c=.o)
+ 
+-USOURCES = qprintf.c quantize.c getarg.c 
++USOURCES = qprintf.c getarg.c
+ UHEADERS = getarg.h
+ UOBJECTS = $(USOURCES:.c=.o)
+ 
+-- 
+2.21.0
+

--- a/media-libs/giflib/files/giflib-5.2.0-revert-quantize-api-removal.patch
+++ b/media-libs/giflib/files/giflib-5.2.0-revert-quantize-api-removal.patch
@@ -1,0 +1,77 @@
+diff -ur giflib-5.2.1.orig/getarg.h giflib-5.2.1/getarg.h
+--- giflib-5.2.1.orig/getarg.h	2019-06-24 09:32:56.000000000 +0200
++++ giflib-5.2.1/getarg.h	2019-07-05 22:30:10.000000000 +0200
+@@ -34,15 +34,6 @@
+ extern void GifQprintf(char *Format, ...);
+ extern void PrintGifError(int ErrorCode);
+ 
+-/******************************************************************************
+- Color table quantization
+-******************************************************************************/
+-int GifQuantizeBuffer(unsigned int Width, unsigned int Height,
+-                   int *ColorMapSize, GifByteType * RedInput,
+-                   GifByteType * GreenInput, GifByteType * BlueInput,
+-                   GifByteType * OutputBuffer,
+-                   GifColorType * OutputColorMap);
+-
+ /* These used to live in the library header */
+ #define GIF_MESSAGE(Msg) fprintf(stderr, "\n%s: %s\n", PROGRAM_NAME, Msg)
+ #define GIF_EXIT(Msg)    { GIF_MESSAGE(Msg); exit(-3); }
+diff -ur giflib-5.2.1.orig/giffilter.c giflib-5.2.1/giffilter.c
+--- giflib-5.2.1.orig/giffilter.c	2019-06-24 09:26:43.000000000 +0200
++++ giflib-5.2.1/giffilter.c	2019-07-05 22:30:32.000000000 +0200
+@@ -25,8 +25,8 @@
+ #include <string.h>
+ #include <fcntl.h>
+ 
+-#include "gif_lib.h"
+ #include "getarg.h"
++#include "gif_lib.h"
+ 
+ #define PROGRAM_NAME	"giffilter"
+ 
+diff -ur giflib-5.2.1.orig/gif_lib.h giflib-5.2.1/gif_lib.h
+--- giflib-5.2.1.orig/gif_lib.h	2019-06-24 18:16:13.000000000 +0200
++++ giflib-5.2.1/gif_lib.h	2019-07-05 22:27:25.000000000 +0200
+@@ -217,6 +217,15 @@
+ 
+ 
+ /******************************************************************************
++ Color table quantization (deprecated)
++******************************************************************************/
++int GifQuantizeBuffer(unsigned int Width, unsigned int Height,
++                   int *ColorMapSize, GifByteType * RedInput,
++                   GifByteType * GreenInput, GifByteType * BlueInput,
++                   GifByteType * OutputBuffer,
++                   GifColorType * OutputColorMap);
++
++/******************************************************************************
+  Error handling and reporting.
+ ******************************************************************************/
+ extern const char *GifErrorString(int ErrorCode);     /* new in 2012 - ESR */
+diff -ur giflib-5.2.1.orig/gifsponge.c giflib-5.2.1/gifsponge.c
+--- giflib-5.2.1.orig/gifsponge.c	2019-06-24 09:28:45.000000000 +0200
++++ giflib-5.2.1/gifsponge.c	2019-07-05 22:30:37.000000000 +0200
+@@ -25,8 +25,8 @@
+ #include <string.h>
+ #include <fcntl.h>
+ 
+-#include "gif_lib.h"
+ #include "getarg.h"
++#include "gif_lib.h"
+ 
+ #define PROGRAM_NAME	"gifsponge"
+ 
+diff -ur giflib-5.2.1.orig/giftool.c giflib-5.2.1/giftool.c
+--- giflib-5.2.1.orig/giftool.c	2019-06-24 09:29:02.000000000 +0200
++++ giflib-5.2.1/giftool.c	2019-07-05 22:30:48.000000000 +0200
+@@ -13,8 +13,8 @@
+ #include <stdbool.h>
+ 
+ #include "getopt.h"
+-#include "gif_lib.h"
+ #include "getarg.h"
++#include "gif_lib.h"
+ 
+ #define PROGRAM_NAME	"giftool"
+ 

--- a/media-libs/giflib/giflib-5.1.9-r1.ebuild
+++ b/media-libs/giflib/giflib-5.1.9-r1.ebuild
@@ -1,0 +1,78 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal toolchain-funcs
+
+DESCRIPTION="Library to handle, display and manipulate GIF images"
+HOMEPAGE="https://sourceforge.net/projects/giflib/"
+SRC_URI="mirror://sourceforge/giflib/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0/7"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc static-libs"
+
+DEPEND="doc? ( app-text/xmlto )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.1.9-gentoo.patch
+	"${FILESDIR}"/${PN}-5.1.9-fix-missing-quantize-api-symbols.patch
+)
+
+src_prepare() {
+	default
+	multilib_copy_sources
+}
+
+multilib_src_compile() {
+	# Use reallocarray() from libc if available.
+	if $(tc-getCC) ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -D_GNU_SOURCE -o "${T}/reallocarray_test" -x c - <<< $'#include <stdlib.h>\nint main() {void *p = reallocarray(NULL, 0, 0);}' 2> /dev/null; then
+		local -x CPPFLAGS="${CPPFLAGS} -D_GNU_SOURCE -DHAVE_REALLOCARRAY"
+		sed -e "s/ openbsd-reallocarray\.c//" -i Makefile || die
+		rm openbsd-reallocarray.c || die
+	fi
+
+	emake \
+		CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS} -std=gnu99 -fPIC -Wno-format-truncation" \
+		LDFLAGS="${LDFLAGS}" \
+		OFLAGS="" \
+		all
+
+	if use doc && multilib_is_native_abi; then
+		emake -C doc
+	fi
+}
+
+multilib_src_install() {
+	emake \
+		DESTDIR="${D}" \
+		PREFIX="${EPREFIX}/usr" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
+		install
+
+	if ! use static-libs ; then
+		find "${ED}" -name "*.a" -delete || die
+	fi
+
+	if use doc && multilib_is_native_abi; then
+		docinto html
+		dodoc doc/*.html
+	fi
+}
+
+multilib_src_install_all() {
+	docinto
+	dodoc ChangeLog NEWS README TODO
+	if use doc ; then
+		dodoc doc/*.txt
+		docinto html
+		dodoc -r doc/whatsinagif
+	fi
+}
+
+multilib_src_test() {
+	emake -j1 check
+}

--- a/media-libs/giflib/giflib-5.2.1-r1.ebuild
+++ b/media-libs/giflib/giflib-5.2.1-r1.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal toolchain-funcs
+
+DESCRIPTION="Library to handle, display and manipulate GIF images"
+HOMEPAGE="https://sourceforge.net/projects/giflib/"
+SRC_URI="mirror://sourceforge/giflib/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0/7"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc static-libs"
+
+DEPEND="doc? ( app-text/xmlto )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.1.9-gentoo.patch
+	"${FILESDIR}"/${PN}-5.1.9-fix-missing-quantize-api-symbols.patch
+	"${FILESDIR}"/${PN}-5.2.0-revert-quantize-api-removal.patch
+)
+
+src_prepare() {
+	default
+	multilib_copy_sources
+}
+
+multilib_src_compile() {
+	# Use reallocarray() from libc if available.
+	if $(tc-getCC) ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -D_GNU_SOURCE -o "${T}/reallocarray_test" -x c - <<< $'#include <stdlib.h>\nint main() {void *p = reallocarray(NULL, 0, 0);}' 2> /dev/null; then
+		local -x CPPFLAGS="${CPPFLAGS} -D_GNU_SOURCE -DHAVE_REALLOCARRAY"
+		sed -e "s/ openbsd-reallocarray\.c//" -i Makefile || die
+		rm openbsd-reallocarray.c || die
+	fi
+
+	emake \
+		CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS} -std=gnu99 -fPIC -Wno-format-truncation" \
+		LDFLAGS="${LDFLAGS}" \
+		OFLAGS="" \
+		all
+
+	if use doc && multilib_is_native_abi; then
+		emake -C doc
+	fi
+}
+
+multilib_src_install() {
+	emake \
+		DESTDIR="${D}" \
+		PREFIX="${EPREFIX}/usr" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
+		install
+
+	if ! use static-libs ; then
+		find "${ED}" -name "*.a" -delete || die
+	fi
+
+	if use doc && multilib_is_native_abi; then
+		docinto html
+		dodoc doc/*.html
+	fi
+}
+
+multilib_src_install_all() {
+	docinto
+	dodoc ChangeLog NEWS README TODO
+	if use doc ; then
+		dodoc doc/*.txt
+		docinto html
+		dodoc -r doc/whatsinagif
+	fi
+}
+
+multilib_src_test() {
+	emake -j1 check
+}


### PR DESCRIPTION
Starting with version 5.1.9 the libgif.so shared library was split
into libgif.so and libutil.so and put the deprecated function
(GifQuantizeBuffer) into the libutil.so, but the Makefile for
media-libs/giflib only installs libgif.so.
This breaks the compilation of dev-dotnet/libgdiplus.
Until this is fixed by upstream, a patch by arch linux fixes this.

Package-Manager: Portage-2.3.67, Repoman-2.3.16
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>