### PR TITLE
sys-boot/raspberrypi-firmware: drop myself as maintainer

### DIFF
--- a/sys-boot/raspberrypi-firmware/metadata.xml
+++ b/sys-boot/raspberrypi-firmware/metadata.xml
@@ -2,14 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>ck+gentoo@bl4ckb0x.de</email>
-		<name>Conrad Kostecki</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
-	<maintainer type="person">
 		<email>andrey_utkin@gentoo.org</email>
 		<name>Andrey Utkin</name>
 	</maintainer>


### PR DESCRIPTION
Since I don't have anymore arm hardware, I can't maintain this package
anymore probably and dropping myself as maintainer.

Package-Manager: Portage-2.3.68, Repoman-2.3.16
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>