### PR TITLE
sys-kernel/raspberrypi-image: drop myself as maintainer

### DIFF
--- a/sys-kernel/raspberrypi-image/metadata.xml
+++ b/sys-kernel/raspberrypi-image/metadata.xml
@@ -5,14 +5,6 @@
 		<email>andrey_utkin@gentoo.org</email>
 		<name>Andrey Utkin</name>
 	</maintainer>
-	<maintainer type="person">
-		<email>ck+gentoo@bl4ckb0x.de</email>
-		<name>Conrad Kostecki</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
 	<upstream>
 		<remote-id type="github">raspberrypi/firmware</remote-id>
 	</upstream>


### PR DESCRIPTION
Since I don't have any left arm hardware, I can't test anymore those
packages, so I am droping myself as maintainer here.

Package-Manager: Portage-2.3.68, Repoman-2.3.16
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>