### PR TITLE
dev-lang/jimtcl-0.78-r2: Clean up

### DIFF
--- a/dev-lang/jimtcl/files/jimtcl-0.78-no-bootstrap.patch
+++ b/dev-lang/jimtcl/files/jimtcl-0.78-no-bootstrap.patch
@@ -1,0 +1,35 @@
+From f59809579339c0a16fb2519e590b98b611438064 Mon Sep 17 00:00:00 2001
+From: Eugene Bright <eugene@bright.gdn>
+Date: Sat, 20 Jul 2019 21:00:54 +0300
+Subject: [PATCH] autosetup/autosetup-find-tclsh: Rely on tclsh
+
+Never try to compile jimsh0. Use tclsh as build time dependency.
+---
+ autosetup/autosetup-find-tclsh | 12 ++----------
+ 1 file changed, 2 insertions(+), 10 deletions(-)
+
+diff --git a/autosetup/autosetup-find-tclsh b/autosetup/autosetup-find-tclsh
+index dfe70f8..78b521e 100755
+--- a/autosetup/autosetup-find-tclsh
++++ b/autosetup/autosetup-find-tclsh
+@@ -3,15 +3,7 @@
+ # If not found, builds a bootstrap jimsh from source
+ # Prefer $autosetup_tclsh if is set in the environment
+ d=`dirname "$0"`
+-{ "$d/jimsh0" "$d/autosetup-test-tclsh"; } 2>/dev/null && exit 0
+ PATH="$PATH:$d"; export PATH
+-for tclsh in $autosetup_tclsh jimsh tclsh tclsh8.5 tclsh8.6; do
+-	{ $tclsh "$d/autosetup-test-tclsh"; } 2>/dev/null && exit 0
+-done
+-echo 1>&2 "No installed jimsh or tclsh, building local bootstrap jimsh0"
+-for cc in ${CC_FOR_BUILD:-cc} gcc; do
+-	{ $cc -o "$d/jimsh0" "$d/jimsh0.c"; } 2>/dev/null || continue
+-	"$d/jimsh0" "$d/autosetup-test-tclsh" && exit 0
+-done
+-echo 1>&2 "No working C compiler found. Tried ${CC_FOR_BUILD:-cc} and gcc."
++tclsh "$d/autosetup-test-tclsh" 2>/dev/null && exit 0
++echo 1>&2 "Please install dev-lang/tcl:0"
+ echo false
+-- 
+2.20.1
+

--- a/dev-lang/jimtcl/jimtcl-0.78-r2.ebuild
+++ b/dev-lang/jimtcl/jimtcl-0.78-r2.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit eutils
+
+SRC_URI="https://github.com/msteveb/jimtcl/archive/${PV}.tar.gz -> ${P}.tar.gz"
+KEYWORDS="~amd64 ~arm ~arm64 ~m68k ~mips ~s390 ~sh ~x86"
+
+DESCRIPTION="Small footprint implementation of Tcl programming language"
+HOMEPAGE="http://jim.tcl.tk/"
+
+LICENSE="LGPL-2"
+SLOT="0/78" # SONAME=libjim.so.0.78
+IUSE="doc static-libs"
+
+RDEPEND=""
+DEPEND="
+	doc? ( app-text/asciidoc )
+	app-arch/unzip
+	dev-lang/tcl:0
+"
+
+PATCHES="
+	${FILESDIR}/${PN}-0.78-no-bootstrap.patch
+"
+
+src_configure() {
+	CCACHE=None econf --with-jim-shared
+	if use static-libs ; then
+		# The build does not support doing both simultaneously.
+		mkdir static-libs || die
+		cd static-libs || die
+		CCACHE=None ECONF_SOURCE=${S} econf
+	fi
+}
+
+src_compile() {
+	# Must build static-libs first.
+	use static-libs && emake -C static-libs libjim.a
+	emake all
+	use doc && emake docs
+}
+
+src_install() {
+	dobin jimsh
+	use static-libs && dolib.a static-libs/libjim.a
+	ln -sf libjim.so.* libjim.so || die
+	dolib.so libjim.so*
+	insinto /usr/include
+	doins jim.h jimautoconf.h jim-subcmd.h jim-signal.h \
+		jim-win32compat.h jim-eventloop.h jim-config.h
+	dodoc AUTHORS README TODO
+	use doc && dohtml Tcl.html
+}

--- a/dev-lang/jimtcl/jimtcl-0.78-r2.ebuild
+++ b/dev-lang/jimtcl/jimtcl-0.78-r2.ebuild
@@ -52,5 +52,8 @@ src_install() {
 	doins jim.h jimautoconf.h jim-subcmd.h jim-signal.h \
 		jim-win32compat.h jim-eventloop.h jim-config.h
 	dodoc AUTHORS README TODO
-	use doc && dohtml Tcl.html
+	if use doc; then
+		docinto html
+		dodoc Tcl.html
+	fi
 }


### PR DESCRIPTION
Comply with EAPI=7.

Revive bootstrap forcing patch.

Closes: https://bugs.gentoo.org/689378
Closes:  https://bugs.gentoo.org/675276

Signed-off-by: Eugene Bright <eugene@bright.gdn>