### PR TITLE
profiles: desktop: Add USE icu to make.defaults

### DIFF
--- a/profiles/targets/desktop/gnome/package.use
+++ b/profiles/targets/desktop/gnome/package.use
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Needed by gnome-photos
@@ -30,9 +30,6 @@ app-accessibility/speech-dispatcher python
 
 # Pulled in by grilo-plugins which is needed for gnome-music
 media-libs/grilo playlist
-
-# Required for webkit-gtk-2
-media-libs/harfbuzz icu
 
 # Pulled in by tracker and grilo-plugins, has REQUIRED_USE="?? ( gtk qt5 )"
 media-libs/libmediaart gtk -qt5

--- a/profiles/targets/desktop/make.defaults
+++ b/profiles/targets/desktop/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-USE="a52 aac acpi alsa bluetooth branding cairo cdda cdr consolekit cups dbus dri dts dvd dvdr emboss encode exif fam flac gif glamor gpm gtk jpeg lcms ldap libnotify mad mng mp3 mp4 mpeg ogg opengl pango pdf png policykit ppds qt5 sdl spell startup-notification svg tiff truetype vorbis udev udisks unicode upower usb wxwidgets X xcb x264 xml xv xvid"
+USE="a52 aac acpi alsa bluetooth branding cairo cdda cdr consolekit cups dbus dri dts dvd dvdr emboss encode exif fam flac gif glamor gpm gtk icu jpeg lcms ldap libnotify mad mng mp3 mp4 mpeg ogg opengl pango pdf png policykit ppds qt5 sdl spell startup-notification svg tiff truetype vorbis udev udisks unicode upower usb wxwidgets X xcb x264 xml xv xvid"

--- a/profiles/targets/desktop/package.use
+++ b/profiles/targets/desktop/package.use
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Lars Wendler <polynomial-c@gentoo.org> (2019-03-20)
@@ -21,10 +21,6 @@ app-arch/unzip natspec
 # Required by dev-qt/qtcore
 dev-libs/libpcre pcre16
 dev-libs/libpcre2 pcre16
-
-# Andreas Sturmlechner <asturm@gentoo.org> (2017-11-30)
-# Required by kde-frameworks/kcoreaddons
-dev-qt/qtcore:5 icu
 
 # Andreas Sturmlechner <asturm@gentoo.org> (2017-11-30)
 # Required by kde-frameworks/kwayland

--- a/profiles/targets/desktop/plasma/package.use
+++ b/profiles/targets/desktop/plasma/package.use
@@ -1,8 +1,5 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-
-# Required by >=dev-qt/qtwebengine-5.9
-dev-libs/libxml2 icu
 
 # Required by app-editors/okteta
 dev-qt/qtscript:5 scripttools


### PR DESCRIPTION
A lot of desktop packages depend on libraries built with USE icu to work;
some, but not nearly enough are currently handled by individual package.use,
leaving users to fix default conflicts.

desktop profile should rather have it enabled globally.