### PR TITLE
app-misc/elasticsearch: remove x-pack cleanup

### DIFF
--- a/app-misc/elasticsearch/elasticsearch-7.2.0.ebuild
+++ b/app-misc/elasticsearch/elasticsearch-7.2.0.ebuild
@@ -28,10 +28,6 @@ src_prepare() {
 
 	rm LICENSE.txt NOTICE.txt || die
 	rmdir logs || die
-
-	if use x-pack; then
-		rm -r modules/x-pack-ml/platform/{darwin,windows}-x86_64 || die
-	fi
 }
 
 src_install() {


### PR DESCRIPTION
It seems like the content of the upstream tarball is correct now and we
don't need to clean it up anymore.

Closes: https://bugs.gentoo.org/689524
Package-Manager: Portage-2.3.68, Repoman-2.3.16