### PR TITLE
license: add ISSL license. Source: https://software.intel.com/en-us/m…

### DIFF
--- a/licenses/ISSL
+++ b/licenses/ISSL
@@ -1,0 +1,78 @@
+Intel Simplified Software License (Version April 2018)
+
+Copyright (c) 2018 Intel Corporation.
+ 
+Use and Redistribution.  You may use and redistribute the software (the
+"Software"), without modification, provided the following conditions are met:
+
+* Redistributions must reproduce the above copyright notice and the following
+  terms of use in the Software and in the documentation and/or other materials
+  provided with the distribution.
+* Neither the name of Intel nor the names of its suppliers may be used to
+  endorse or promote products derived from this Software without specific prior
+  written permission.
+* No reverse engineering, decompilation, or disassembly of this Software is
+  permitted.
+
+Limited patent license.  Intel grants you a world-wide, royalty-free,
+non-exclusive license under patents it now or hereafter owns or controls to
+make, have made, use, import, offer to sell and sell ("Utilize") this Software,
+but solely to the extent that any such patent is necessary to Utilize the
+Software alone. The patent license shall not apply to any combinations which
+include this software. No hardware per se is licensed hereunder.
+
+Third party and other Intel programs.  "Third Party Programs" are the files
+listed in the "third-party-programs.txt" text file that is included with the
+Software and may include Intel programs under separate license terms. Third
+Party Programs, even if included with the distribution of the Materials, are
+governed by separate license terms and those license terms solely govern your
+use of those programs.
+
+DISCLAIMER.  THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT ARE
+DISCLAIMED. THIS SOFTWARE IS NOT INTENDED FOR USE IN SYSTEMS OR APPLICATIONS
+WHERE FAILURE OF THE SOFTWARE MAY CAUSE PERSONAL INJURY OR DEATH AND YOU AGREE
+THAT YOU ARE FULLY RESPONSIBLE FOR ANY CLAIMS, COSTS, DAMAGES, EXPENSES, AND
+ATTORNEYS' FEES ARISING OUT OF ANY SUCH USE, EVEN IF ANY CLAIM ALLEGES THAT
+INTEL WAS NEGLIGENT REGARDING THE DESIGN OR MANUFACTURE OF THE MATERIALS.
+
+LIMITATION OF LIABILITY.  IN NO EVENT WILL INTEL BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. YOU AGREE TO INDEMNIFY AND HOLD INTEL
+HARMLESS AGAINST ANY CLAIMS AND EXPENSES RESULTING FROM YOUR USE OR UNAUTHORIZED
+USE OF THE SOFTWARE.
+
+No support.  Intel may make changes to the Software, at any time without notice,
+and is not obligated to support, update or provide training for the Software.
+
+Termination.  Intel may terminate your right to use the Software in the event of
+your breach of this Agreement and you fail to cure the breach within a
+reasonable period of time.
+
+Feedback.  Should you provide Intel with comments, modifications, corrections,
+enhancements or other input ("Feedback") related to the Software Intel will be
+free to use, disclose, reproduce, license or otherwise distribute or exploit the
+Feedback in its sole discretion without any obligations or restrictions of any
+kind, including without limitation, intellectual property rights or licensing
+obligations.
+
+Compliance with laws.  You agree to comply with all relevant laws and
+regulations governing your use, transfer, import or export (or prohibition
+thereof) of the Software.
+
+Governing law.  All disputes will be governed by the laws of the United States
+of America and the State of Delaware without reference to conflict of law
+principles and subject to the exclusive jurisdiction of the state or federal
+courts sitting in the State of Delaware, and each party agrees that it submits
+to the personal jurisdiction and venue of those courts and waives any
+objections. The United Nations Convention on Contracts for the International
+Sale of Goods (1980) is specifically excluded and will not apply to the
+Software.
+
+*Other names and brands may be claimed as the property of others.
+

--- a/profiles/license_groups
+++ b/profiles/license_groups
@@ -65,7 +65,7 @@ FREE @FREE-SOFTWARE @FREE-DOCUMENTS
 # - IF (and only if) there is an explicit inclusion requirement,
 #   USE=bindist MUST cause a copy of the license to be installed
 #   in a file location compliant with the license
-BINARY-REDISTRIBUTABLE @FREE bh-luxi bonnie Broadcom Dina freedist intel-ucode ipw2100-fw ipw2200-fw ipw3945 linux-fw-redistributable LSI-tw_cli MicroChip-SDCC no-source-code NVIDIA-r1 qlogic-fibre-channel-firmware shmux SmartLabs sun-jlfgr unRAR
+BINARY-REDISTRIBUTABLE @FREE bh-luxi bonnie Broadcom Dina freedist intel-ucode ipw2100-fw ipw2200-fw ipw3945 linux-fw-redistributable LSI-tw_cli MicroChip-SDCC no-source-code NVIDIA-r1 qlogic-fibre-channel-firmware shmux SmartLabs sun-jlfgr unRAR ISSL
 
 ######################################################################
 


### PR DESCRIPTION
ISSL (Intel Simplified Software License) is a binary-redistributable license. Intel MKL is always licensed under ISSL.

https://software.intel.com/en-us/mkl/license-faq

@heroxbd 