### PR TITLE
media-sound/loudness-scanner: new ebuild

### DIFF
--- a/media-sound/loudness-scanner/loudness-scanner-9999.ebuild
+++ b/media-sound/loudness-scanner/loudness-scanner-9999.ebuild
@@ -1,0 +1,72 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils git-r3
+
+DESCRIPTION="Scans your music files and tags them with loudness information"
+HOMEPAGE="https://github.com/jiixyj/loudness-scanner/"
+EGIT_REPO_URI="https://github.com/jiixyj/loudness-scanner.git"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS=""
+IUSE="ffmpeg gtk mpg123 musepack qt5 sndfile"
+REQUIRED_USE="|| ( sndfile ffmpeg mpg123 musepack )"
+
+DEPEND="
+	dev-libs/glib
+	media-libs/libebur128
+	media-libs/taglib
+	ffmpeg? ( media-video/ffmpeg )
+	mpg123? ( media-sound/mpg123 )
+	musepack? ( media-sound/musepack-tools )
+	sndfile? ( media-libs/libsndfile )
+	gtk? (
+		gnome-base/librsvg:2
+		x11-libs/cairo
+		x11-libs/gtk+:2
+	)
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtsvg:5
+		dev-qt/qtwidgets:5
+	)
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	cmake-utils_src_prepare
+	sed -i -e 's|".",|"'${EROOT}'/usr/'$(get_libdir)'/loudness-scanner",|g' \
+		"${S}"/scanner/inputaudio/input.c
+}
+
+src_configure() {
+	local -a mycmakeargs=(
+		-DCMAKE_SKIP_RPATH=ON
+		-DBUILD_SHARED_LIBS:BOOL=OFF # use static internal libraries
+		-DDISABLE_FFMPEG:BOOL=$(usex ffmpeg no yes)
+		-DDISABLE_GSTREAMER:BOOL=ON # depends on obsolete gstreamer-0.10
+		-DDISABLE_GTK2:BOOL=$(usex gtk no yes)
+		-DDISABLE_MPCDEC:BOOL=$(usex musepack no yes)
+		-DDISABLE_MPG123:BOOL=$(usex mpg123 no yes)
+		-DDISABLE_QT4:BOOL=ON
+		-DDISABLE_QT5:BOOL=$(usex qt5 no yes)
+		-DDISABLE_RSVG2:BOOL=$(usex gtk no yes)
+		-DDISABLE_SNDFILE:BOOL=$(usex sndfile no yes)
+	)
+	cmake-utils_src_configure
+}
+
+src_install() {
+	dobin "${BUILD_DIR}"/loudness
+	use gtk && dobin "${BUILD_DIR}"/loudness-drop-gtk
+	use qt5 && dobin "${BUILD_DIR}"/loudness-drop-qt5
+
+	insinto /usr/$(get_libdir)/loudness-scanner
+	doins "${BUILD_DIR}"/libinput_*.so
+
+	einstalldocs
+}

--- a/media-sound/loudness-scanner/metadata.xml
+++ b/media-sound/loudness-scanner/metadata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>tamiko@gentoo.org</email>
+		<name>Matthias Maier</name>
+	</maintainer>
+	<maintainer type="person">
+		<name>Stefan Briesenick</name>
+		<email>gentoo@sbriesen.de</email>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<longdescription lang="en">
+		loudness-scanner is a tool that scans your music files according
+		to the EBU R128 standard for loudness normalisation. It optionally
+		adds ReplayGain compatible tags to the files.
+	</longdescription>
+	<use>
+		<flag name="mpg123">build the mpg123 plugin</flag>
+		<flag name="musepack">build the musepack plugin</flag>
+		<flag name="sndfile">build the sndfile plugin</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">jiixyj/loudness-scanner</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/550342
Package-Manager: Portage-2.3.68, Repoman-2.3.16