### PR TITLE
dev-python/kconfiglib: mark as compatible with Python 2.7 and PyPy

### DIFF
--- a/dev-python/kconfiglib/kconfiglib-12.12.1.ebuild
+++ b/dev-python/kconfiglib/kconfiglib-12.12.1.ebuild
@@ -2,8 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-# menuconfig script doesn't work on py2 so skip it
-PYTHON_COMPAT=( python3_{5,6,7} pypy3 )
+PYTHON_COMPAT=( python{2_7,3_{5,6,7}} pypy{,3} )
 PYTHON_REQ_USE="ncurses"
 
 inherit distutils-r1


### PR DESCRIPTION
menuconfig.py has been Python 2.7-compatible since Kconfiglib 12.2.0.
All utilities now run under Python 2.7 and Python 3.2+.

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>