### PR TITLE
dev-python/crcmod: mark as compatible with Python 3.7

### DIFF
--- a/dev-python/crcmod/crcmod-1.7-r2.ebuild
+++ b/dev-python/crcmod/crcmod-1.7-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python{2_7,3_5,3_6} pypy )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} pypy )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Signed-off-by: Christian Hagau <ach@hagau.se>