### PR TITLE
sys-libs/glibc: Fix handling of ${EPREFIX} when building cross-glibc

### DIFF
--- a/sys-libs/glibc/glibc-2.29-r2.ebuild
+++ b/sys-libs/glibc/glibc-2.29-r2.ebuild
@@ -125,6 +125,14 @@ alt_prefix() {
 	is_crosscompile && echo /usr/${CTARGET}
 }
 
+configure_eprefix() {
+	is_crosscompile || echo "${EPREFIX}"
+}
+
+install_eprefix() {
+	is_crosscompile && echo "${EPREFIX}"
+}
+
 # We need to be able to set alternative headers for compiling for non-native
 # platform. Will also become useful for testing kernel-headers without screwing
 # up the whole system.
@@ -134,7 +142,7 @@ alt_headers() {
 
 alt_build_headers() {
 	if [[ -z ${ALT_BUILD_HEADERS} ]] ; then
-		ALT_BUILD_HEADERS="${EPREFIX}$(alt_headers)"
+		ALT_BUILD_HEADERS="$(configure_eprefix)$(alt_headers)"
 		if tc-is-cross-compiler ; then
 			ALT_BUILD_HEADERS=${SYSROOT}$(alt_headers)
 			if [[ ! -e ${ALT_BUILD_HEADERS}/linux/version.h ]] ; then
@@ -578,7 +586,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${EPREFIX}/$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -I "$(install_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 
@@ -892,9 +900,9 @@ glibc_do_configure() {
 		$(use_enable profile)
 		$(use_with gd)
 		--with-headers=$(alt_build_headers)
-		--prefix="${EPREFIX}/usr"
-		--sysconfdir="${EPREFIX}/etc"
-		--localstatedir="${EPREFIX}/var"
+		--prefix="$(configure_eprefix)/usr"
+		--sysconfdir="$(configure_eprefix)/etc"
+		--localstatedir="$(configure_eprefix)/var"
 		--libdir='$(prefix)'/$(get_libdir)
 		--mandir='$(prefix)'/share/man
 		--infodir='$(prefix)'/share/info
@@ -916,8 +924,8 @@ glibc_do_configure() {
 
 	# There is no configure option for this and we need to export it
 	# since the glibc build will re-run configure on itself
-	export libc_cv_rootsbindir="${EPREFIX}/sbin"
-	export libc_cv_slibdir="${EPREFIX}/$(get_libdir)"
+	export libc_cv_rootsbindir="$(configure_eprefix)/sbin"
+	export libc_cv_slibdir="$(configure_eprefix)/$(get_libdir)"
 
 	# We take care of patching our binutils to use both hash styles,
 	# and many people like to force gnu hash style only, so disable
@@ -1046,7 +1054,7 @@ glibc_headers_configure() {
 		--build=${CBUILD_OPT:-${CBUILD}}
 		--host=${CTARGET_OPT:-${CTARGET}}
 		--with-headers=$(alt_build_headers)
-		--prefix="${EPREFIX}/usr"
+		--prefix="$(configure_eprefix)/usr"
 		${EXTRA_ECONF}
 	)
 
@@ -1136,7 +1144,7 @@ glibc_do_src_install() {
 	local builddir=$(builddir nptl)
 	cd "${builddir}"
 
-	emake install_root="${D}$(alt_prefix)" install || die
+	emake install_root="${D}$(install_eprefix)$(alt_prefix)" install || die
 
 	# This version (2.26) provides some compatibility libraries for the NIS/NIS+ support
 	# which come without headers etc. Only needed for binary packages since the
@@ -1320,7 +1328,7 @@ glibc_do_src_install() {
 glibc_headers_install() {
 	local builddir=$(builddir "headers")
 	cd "${builddir}"
-	emake install_root="${D}$(alt_prefix)" install-headers
+	emake install_root="${D}$(install_eprefix)$(alt_prefix)" install-headers
 
 	insinto $(alt_headers)/gnu
 	doins "${S}"/include/gnu/stubs.h


### PR DESCRIPTION
It was duplicating the prefix in the form `${EPREFIX}/usr/${CTARGET}/${EPREFIX}`.

This also fixes the kernel header version check, which was broken for native prefixed builds.

Bug: https://bugs.gentoo.org/642604
Package-Manager: Portage-2.3.69, Repoman-2.3.13
Signed-off-by: James Le Cuirot <chewi@gentoo.org>