### PR TITLE
dev-python/python-musicbrainz-ngs: python3.7 and fix test cases

### DIFF
--- a/dev-python/python-musicbrainz-ngs/files/0.6-fix-test-submit.patch
+++ b/dev-python/python-musicbrainz-ngs/files/0.6-fix-test-submit.patch
@@ -1,0 +1,32 @@
+diff --git a/test/test_submit.py b/test/test_submit.py
+index bce5362..2d13811 100644
+--- a/test/test_submit.py
++++ b/test/test_submit.py
+@@ -1,13 +1,23 @@
+ import unittest
+-import os
+-import sys
+-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+-
+ import musicbrainzngs
+ from musicbrainzngs import musicbrainz
+ from test import _common
+ 
++
+ class SubmitTest(unittest.TestCase):
++
++    def setUp(self):
++        self.orig_opener = musicbrainzngs.compat.build_opener
++        musicbrainz.set_useragent("test_client", "1.0")
++        musicbrainz.auth("user", "password")
++
++    def tearDown(self):
++        musicbrainzngs.compat.build_opener = self.orig_opener
++        musicbrainz._useragent = ""
++        musicbrainz._client = ""
++        musicbrainz.user = ""
++        musicbrainz.password = ""
++
+     def test_submit_tags(self):
+         self.opener = _common.FakeOpener("<response/>")
+         musicbrainzngs.compat.build_opener = lambda *args: self.opener

--- a/dev-python/python-musicbrainz-ngs/python-musicbrainz-ngs-0.6.ebuild
+++ b/dev-python/python-musicbrainz-ngs/python-musicbrainz-ngs-0.6.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit distutils-r1
 
@@ -19,6 +19,8 @@ KEYWORDS="amd64 x86"
 IUSE="doc examples test"
 
 S="${WORKDIR}/${MY_PN}-${PV}"
+
+PATCHES="${FILESDIR}/0.6-fix-test-submit.patch"
 
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/689178
Closes: https://bugs.gentoo.org/653426

Package-Manager: Portage-2.3.66, Repoman-2.3.11
Signed-off-by: Gerion Entrup <gerion.entrup@flump.de>

The patch is actually the backported file from the current Git head of upstream.
If you want, I can split into two commits.