### PR TITLE
Suppress meaningless errors from /etc/init.d/xdm during shutdown

### DIFF
--- a/x11-base/xorg-server/files/xdm.initd-11
+++ b/x11-base/xorg-server/files/xdm.initd-11
@@ -207,7 +207,8 @@ stop() {
 
 	ebegin "Stopping ${myservice}"
 
-	if start-stop-daemon --quiet --test --stop --exec "${myexe}"; then
+        # Repeat --quiet twice to suppress meaningless errors.
+	if start-stop-daemon --quiet --quiet --test --stop --exec "${myexe}"; then
 		start-stop-daemon --stop --exec "${myexe}" --retry TERM/5/TERM/5 \
 			${mypidfile:+--pidfile} ${mypidfile} \
 			${myname:+--name} ${myname}


### PR DESCRIPTION
I don't need to see "xdm: no matching processes found" during shutdown because that error is pretty meaningless.