### PR TITLE
net-im/skypeforlinux: elogind is no longer required

### DIFF
--- a/net-im/skypeforlinux/skypeforlinux-8.48.0.51.ebuild
+++ b/net-im/skypeforlinux/skypeforlinux-8.48.0.51.ebuild
@@ -21,10 +21,6 @@ QA_PREBUILT="*"
 RESTRICT="mirror bindist strip" #299368
 
 RDEPEND="
-	|| (
-		sys-auth/elogind
-		sys-apps/systemd
-	)
 	app-crypt/libsecret[${MULTILIB_USEDEP}]
 	dev-libs/atk[${MULTILIB_USEDEP}]
 	dev-libs/expat[${MULTILIB_USEDEP}]

--- a/net-im/skypeforlinux/skypeforlinux-8.49.0.49.ebuild
+++ b/net-im/skypeforlinux/skypeforlinux-8.49.0.49.ebuild
@@ -21,10 +21,6 @@ QA_PREBUILT="*"
 RESTRICT="mirror bindist strip" #299368
 
 RDEPEND="
-	|| (
-		sys-auth/elogind
-		sys-apps/systemd
-	)
 	app-crypt/libsecret[${MULTILIB_USEDEP}]
 	dev-libs/atk[${MULTILIB_USEDEP}]
 	dev-libs/expat[${MULTILIB_USEDEP}]


### PR DESCRIPTION
Successfully managed to run skype without elongind in a openrc system.

Elogind seems to no longer be required.