### PR TITLE
media-sound/spotify: use apulse if available

### DIFF
--- a/media-sound/spotify/spotify-1.1.5-r1.ebuild
+++ b/media-sound/spotify/spotify-1.1.5-r1.ebuild
@@ -75,6 +75,7 @@ src_install() {
 	dodir /usr/bin
 	cat <<-EOF >"${D}"/usr/bin/spotify || die
 		#! /bin/sh
+		LD_LIBRARY_PATH="/usr/$(get_libdir)/apulse" \\
 		exec ${SPOTIFY_HOME}/spotify "\$@"
 	EOF
 	fperms +x /usr/bin/spotify


### PR DESCRIPTION
Adding apulse libraries to LD_LIBRARY_PATH make spotify work
even if pulseaudio is not installed. If pulseaudio is installed
instead of apulse, this has no effect.

Signed-off-by: Gergely Nagy <ngg@ngg.hu>