### PR TITLE
ecryptfs-utils: Call eautoreconf in src_prepare

### DIFF
--- a/sys-fs/ecryptfs-utils/ecryptfs-utils-108-r3.ebuild
+++ b/sys-fs/ecryptfs-utils/ecryptfs-utils-108-r3.ebuild
@@ -44,6 +44,13 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+src_prepare() {
+	default
+	# Regenerate configure script to avoid hard coded paths e.g. /usr/lib that break
+	# cross-compilation on ARM32.
+	eautoreconf
+}
+
 src_configure() {
 	append-cppflags -D_FILE_OFFSET_BITS=64
 


### PR DESCRIPTION
The upstream tarball ships with a configure script that has
some library paths like /usr/lib hardcoded. This breaks
cross-compilation on ARM32.
Calling eautoreconf to regenerate the configure file fixes this.

Signed-off-by: Manoj Gupta <manojgupta@google.com>