### PR TITLE
app-doc/gnucash-docs: Sanitize L10N handling

### DIFF
--- a/app-doc/gnucash-docs/gnucash-docs-3.6-r1.ebuild
+++ b/app-doc/gnucash-docs/gnucash-docs-3.6-r1.ebuild
@@ -3,10 +3,7 @@
 
 EAPI=6
 
-PLOCALES="C de it ja pt ru"
-PLOCALE_BACKUP="C"
-
-inherit autotools gnome2 l10n
+inherit autotools gnome2
 
 DESCRIPTION="Documentation package for GnuCash"
 HOMEPAGE="http://www.gnucash.org/"
@@ -15,10 +12,8 @@ SRC_URI="https://github.com/Gnucash/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 SLOT="0"
 LICENSE="GPL-2 FDL-1.1"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
-
-for my_locale in ${PLOCALES}; do
-	IUSE+=" l10n_${my_locale}"
-done
+LOCALES=( de it ja pt ru )
+IUSE="${LOCALES[*]/#/l10n_}"
 
 DEPEND="
 	app-text/docbook-xml-dtd
@@ -27,18 +22,6 @@ DEPEND="
 	dev-libs/libxml2
 	dev-libs/libxslt
 "
-
-my_l10n_get_locales() {
-	local l locales
-	for l in ${PLOCALES[@]}; do
-		use "l10n_${l}" && locales+=( $l )
-	done
-	if [[ ${#locales[@]} -gt 0 ]]; then
-		echo ${locales[@]}
-	else
-		echo $PLOCALE_BACKUP
-	fi
-}
 
 src_prepare() {
 	default
@@ -53,7 +36,7 @@ src_install() {
 	local doc_type my_lang
 
 	for doc_type in help guide; do
-		for my_lang in $(my_l10n_get_locales); do
+		for my_lang in C ${L10N}; do
 			case $my_lang in
 				# Both help and guides translated
 				C|de|it|pt) ;;
@@ -61,7 +44,7 @@ src_install() {
 					if [[ ${doc_type} = "help" ]] ; then
 						elog "Help documentation hasn't been translated for $my_lang"
 						elog "Will do English instead."
-						my_lang=C
+						continue
 					fi
 					;;
 				*)
@@ -69,12 +52,10 @@ src_install() {
 					;;
 			esac
 
-			cd "${S}/${doc_type}/${my_lang}" || die
-			emake DESTDIR="${D}" install
+			emake -C "${doc_type}/${my_lang}" DESTDIR="${D}" install
 		done
 	done
 
-	cd "${S}" || die
 	einstalldocs
 }
 


### PR DESCRIPTION
- remove L10N=C, C locale is now installed unconditionally
- remove unused l10n.eclass
- simplify the code

Bug: https://bugs.gentoo.org/689474
Signed-off-by: Michał Górny <mgorny@gentoo.org>

// If it looks fine, I can redo it for older versions.