### PR TITLE
sys-apps/kbd: fix pam config to be created for vlock

### DIFF
--- a/sys-apps/kbd/kbd-2.1.0.ebuild
+++ b/sys-apps/kbd/kbd-2.1.0.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=7
 
+inherit pam
+
 if [[ ${PV} == "9999" ]] ; then
 	inherit autotools git-r3
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/legion/kbd.git"
@@ -67,4 +69,5 @@ src_install() {
 	default
 	docinto html
 	dodoc docs/doc/*.html
+	use pam && pamd_mimic_system vlock auth account
 }


### PR DESCRIPTION
Added pam eclass and create pam config file when `pam` flag is enabled.
`vlock` command needs it to work correctly.

Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Takeshi Ito <85nrdzgv@gmail.com>