### PR TITLE
app-antivirus/clamtk: fix CI python warnings

### DIFF
--- a/app-antivirus/clamtk/clamtk-6.00-r1.ebuild
+++ b/app-antivirus/clamtk/clamtk-6.00-r1.ebuild
@@ -45,7 +45,10 @@ RDEPEND="
 	virtual/perl-MIME-Base64
 	virtual/perl-Time-Piece
 	x11-themes/faenza-icon-theme
-	nautilus? ( dev-python/nautilus-python[${PYTHON_USEDEP}] )
+	nautilus? (
+		${PYTHON_DEPS}
+		dev-python/nautilus-python[${PYTHON_USEDEP}]
+	)
 "
 
 BDEPEND="nls? ( sys-devel/gettext )"

--- a/app-antivirus/clamtk/clamtk-6.01-r1.ebuild
+++ b/app-antivirus/clamtk/clamtk-6.01-r1.ebuild
@@ -45,7 +45,10 @@ RDEPEND="
 	virtual/perl-MIME-Base64
 	virtual/perl-Time-Piece
 	x11-themes/faenza-icon-theme
-	nautilus? ( dev-python/nautilus-python[${PYTHON_USEDEP}] )
+	nautilus? (
+		${PYTHON_DEPS}
+		dev-python/nautilus-python[${PYTHON_USEDEP}]
+	)
 "
 
 BDEPEND="nls? ( sys-devel/gettext )"


### PR DESCRIPTION
Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>