### PR TITLE
powerpc/ppc64/package.use.mask: mask glcd lcd driver on ppc64

### DIFF
--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Conrad Kostecki <ck+gentoo@bl4ckb0x.de> (2019-07-21)
+# app-misc/graphlcd-base won't work on PowerPC
+app-misc/lcdproc lcd_devices_glcd
+
 # Jimi Huotari <chiitoo@gentoo.org> (2019-07-28)
 # Mask unkeyworded, untested dependencies.
 # https://bugs.gentoo.org/689606


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/671028
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>