### PR TITLE
sci-mathematics/cvc4: statistics,replay,proofs use flags

### DIFF
--- a/sci-mathematics/cvc4/cvc4-1.7.ebuild
+++ b/sci-mathematics/cvc4/cvc4-1.7.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/CVC4/CVC4/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="+cln"
+IUSE="+cln +statistics proofs replay"
 
 RDEPEND="dev-libs/antlr-c
 	dev-java/antlr:3
@@ -30,7 +30,11 @@ src_configure() {
 	local mycmakeargs=(
 		-DANTLR_BINARY=/usr/bin/antlr3
 		-DENABLE_GPL=ON
+		-DENABLE_OPTIMIZED=ON
 		-DUSE_CLN="$(usex cln ON OFF)"
+		-DENABLE_STATISTICS="$(usex statistics ON OFF)"
+		-DENABLE_PROOFS="$(usex proofs ON OFF)"
+		-DENABLE_REPLAY="$(usex replay ON OFF)"
 	)
 	cmake-utils_src_configure
 }

--- a/sci-mathematics/cvc4/metadata.xml
+++ b/sci-mathematics/cvc4/metadata.xml
@@ -7,6 +7,9 @@
 	</maintainer>
 	<use>
 		<flag name="cln">Use sci-libs/cln</flag>
+		<flag name="statistics">Include statistics</flag>
+		<flag name="replay">Turn on the replay feature</flag>
+		<flag name="proofs">Support for proof generation</flag>
 	</use>
 	<longdescription lang="en">
 		CVC4 is an efficient open-source automatic theorem prover for


### PR DESCRIPTION
Add statistics,replay,proofs use flags. Why3, for example, relies on statistics is enabled in cvc4 by default.

Package-Manager: Portage-2.3.66, Repoman-2.3.11
Signed-off-by: Denis Efremov <efremov@linux.com>