### PR TITLE
[QA] www-client/vivaldi*: remove invalid USE flags

### DIFF
--- a/www-client/vivaldi-snapshot/metadata.xml
+++ b/www-client/vivaldi-snapshot/metadata.xml
@@ -5,10 +5,4 @@
 <email>jer@gentoo.org</email>
 <name>Jeroen Roovers</name>
 </maintainer>
-<use>
-<flag name='l10n_es-PE'>Spanish, Peru locale</flag>
-<flag name='l10n_io'>Ido locale</flag>
-<flag name='l10n_jbo'>Lojban locale</flag>
-<flag name='l10n_sc'>Sardinian locale</flag>
-</use>
 </pkgmetadata>

--- a/www-client/vivaldi-snapshot/vivaldi-snapshot-2.7.1594.4_p1.ebuild
+++ b/www-client/vivaldi-snapshot/vivaldi-snapshot-2.7.1594.4_p1.ebuild
@@ -3,9 +3,9 @@
 
 EAPI=7
 CHROMIUM_LANGS="
-	af am ar be bg bn ca cs da de de-CH el en-GB en-US eo es es-419 es-PE et eu fa fi
-	fil fr fy gd gl gu he hi hr hu hy id io is it ja jbo ka kn ko ku lt lv mk ml
-	mr ms nb nl nn pl pt-BR pt-PT ro ru sc sk sl sq sr sv sw ta te th tr uk vi
+	af am ar be bg bn ca cs da de de-CH el en-GB en-US eo es es-419 et eu fa fi
+	fil fr fy gd gl gu he hi hr hu hy id is it ja ka kn ko ku lt lv mk ml
+	mr ms nb nl nn pl pt-BR pt-PT ro ru sk sl sq sr sv sw ta te th tr uk vi
 	zh-CN zh-TW
 "
 inherit chromium-2 multilib unpacker toolchain-funcs xdg-utils

--- a/www-client/vivaldi-snapshot/vivaldi-snapshot-2.7.1609.4_p1.ebuild
+++ b/www-client/vivaldi-snapshot/vivaldi-snapshot-2.7.1609.4_p1.ebuild
@@ -3,9 +3,9 @@
 
 EAPI=7
 CHROMIUM_LANGS="
-	af am ar be bg bn ca cs da de de-CH el en-GB en-US eo es es-419 es-PE et eu fa fi
-	fil fr fy gd gl gu he hi hr hu hy id io is it ja jbo ka kn ko ku lt lv mk ml
-	mr ms nb nl nn pl pt-BR pt-PT ro ru sc sk sl sq sr sv sw ta te th tr uk vi
+	af am ar be bg bn ca cs da de de-CH el en-GB en-US eo es es-419 et eu fa fi
+	fil fr fy gd gl gu he hi hr hu hy id is it ja ka kn ko ku lt lv mk ml
+	mr ms nb nl nn pl pt-BR pt-PT ro ru sk sl sq sr sv sw ta te th tr uk vi
 	zh-CN zh-TW
 "
 inherit chromium-2 multilib unpacker toolchain-funcs xdg-utils

--- a/www-client/vivaldi/metadata.xml
+++ b/www-client/vivaldi/metadata.xml
@@ -5,10 +5,4 @@
 <email>jer@gentoo.org</email>
 <name>Jeroen Roovers</name>
 </maintainer>
-<use>
-<flag name='l10n_es-PE'>Spanish, Peru locale</flag>
-<flag name='l10n_io'>Ido locale</flag>
-<flag name='l10n_jbo'>Lojban locale</flag>
-<flag name='l10n_sc'>Sardinian locale</flag>
-</use>
 </pkgmetadata>

--- a/www-client/vivaldi/vivaldi-2.6.1566.40_p1.ebuild
+++ b/www-client/vivaldi/vivaldi-2.6.1566.40_p1.ebuild
@@ -3,9 +3,9 @@
 
 EAPI=7
 CHROMIUM_LANGS="
-	am ar be bg bn ca cs da de el en-GB en-US eo es es-419 es-PE et eu fa fi
-	fil fr fy gl gu he hi hr hu hy id io is it ja jbo ka kn ko ku lt lv mk ml
-	mr ms nb nl nn pl pt-BR pt-PT ro ru sc sk sl sq sr sv sw ta te th tr uk vi
+	am ar be bg bn ca cs da de el en-GB en-US eo es es-419 et eu fa fi
+	fil fr fy gl gu he hi hr hu hy id is it ja ka kn ko ku lt lv mk ml
+	mr ms nb nl nn pl pt-BR pt-PT ro ru sk sl sq sr sv sw ta te th tr uk vi
 	zh-CN zh-TW
 "
 inherit chromium-2 multilib unpacker toolchain-funcs xdg-utils


### PR DESCRIPTION
Since the maintainer refuses to cooperate, remove the flags to fix the CI warnings.

@gentoo/qa 