### PR TITLE
sci-libs/sundials: fix LICENSE installation patches

### DIFF
--- a/sci-libs/sundials/files/sundials-4.0.2-fix-license-install-path.patch
+++ b/sci-libs/sundials/files/sundials-4.0.2-fix-license-install-path.patch
@@ -1,7 +1,12 @@
 diff -Nur old/CMakeLists.txt new/CMakeLists.txt
 --- old/CMakeLists.txt	2019-01-23 01:05:44.000000000 +0300
 +++ new/CMakeLists.txt	2019-06-23 00:35:57.000000000 +0300
-@@ -1214,6 +1214,6 @@
+@@ -1210,10 +1210,10 @@
+ # install license and notice files
+ INSTALL(
+   FILES ${PROJECT_SOURCE_DIR}/LICENSE
+-  DESTINATION include/sundials
++  DESTINATION share/doc/sundials-4.0.2
    )
  INSTALL(
    FILES ${PROJECT_SOURCE_DIR}/NOTICE

--- a/sci-libs/sundials/files/sundials-4.1.0-fix-license-install-path.patch
+++ b/sci-libs/sundials/files/sundials-4.1.0-fix-license-install-path.patch
@@ -1,7 +1,12 @@
 diff -Nur old/CMakeLists.txt new/CMakeLists.txt
 --- old/CMakeLists.txt	2019-02-12 21:50:51.000000000 +0300
 +++ new/CMakeLists.txt	2019-06-23 00:39:23.000000000 +0300
-@@ -1172,6 +1172,6 @@
+@@ -1168,10 +1168,10 @@
+ # install license and notice files
+ INSTALL(
+   FILES ${PROJECT_SOURCE_DIR}/LICENSE
+-  DESTINATION include/sundials
++  DESTINATION share/doc/sundials-4.1.0
    )
  INSTALL(
    FILES ${PROJECT_SOURCE_DIR}/NOTICE


### PR DESCRIPTION
Sundials 4.x add NOTICE files besides LICENSE files
and current fix-licence-patches contain only fix for installation path
of NOTICE files and don't fix paths for LICENSE.

@tamiko 
please review this fix pr