### PR TITLE
profiles: update arm64 le profile statuses

### DIFF
--- a/profiles/profiles.desc
+++ b/profiles/profiles.desc
@@ -87,10 +87,10 @@ arm             default/linux/arm/17.0/armv7a/developer         dev
 
 # ARM64 Profiles
 # @MAINTAINER: arm64@gentoo.org
-arm64           default/linux/arm64/17.0                        dev
-arm64           default/linux/arm64/17.0/desktop                exp
+arm64           default/linux/arm64/17.0                        stable
+arm64           default/linux/arm64/17.0/desktop                dev
 arm64           default/linux/arm64/17.0/desktop/systemd        dev
-arm64           default/linux/arm64/17.0/developer              exp
+arm64           default/linux/arm64/17.0/developer              dev
 arm64           default/linux/arm64/17.0/systemd                dev
 
 # ARM64 Profiles (big-endian)


### PR DESCRIPTION
* 17.0 is now stable
* All other profiles are bumped or remain at dev status
* Further testing needed for desktop profiles
* systemd has been supported for some time

Signed-off-by: Aaron Bauman <bman@gentoo.org>