### PR TITLE
sci-mathematics/cvc4: enable readline support in use flags

### DIFF
--- a/sci-mathematics/cvc4/cvc4-1.7.ebuild
+++ b/sci-mathematics/cvc4/cvc4-1.7.ebuild
@@ -12,11 +12,12 @@ SRC_URI="https://github.com/CVC4/CVC4/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="+cln +statistics proofs replay"
+IUSE="+cln readline +statistics proofs replay"
 
 RDEPEND="dev-libs/antlr-c
 	dev-java/antlr:3
 	dev-libs/boost
+	readline? ( sys-libs/readline:0= )
 	cln? ( sci-libs/cln )
 	!cln? ( dev-libs/gmp:= )"
 DEPEND="${RDEPEND}"
@@ -32,6 +33,7 @@ src_configure() {
 		-DENABLE_GPL=ON
 		-DENABLE_OPTIMIZED=ON
 		-DUSE_CLN="$(usex cln ON OFF)"
+		-DUSE_READLINE="$(usex readline ON OFF)"
 		-DENABLE_STATISTICS="$(usex statistics ON OFF)"
 		-DENABLE_PROOFS="$(usex proofs ON OFF)"
 		-DENABLE_REPLAY="$(usex replay ON OFF)"

--- a/sci-mathematics/cvc4/metadata.xml
+++ b/sci-mathematics/cvc4/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="cln">Use sci-libs/cln</flag>
+		<flag name="readline">Enables support for libreadline</flag>
 		<flag name="statistics">Include statistics</flag>
 		<flag name="replay">Turn on the replay feature</flag>
 		<flag name="proofs">Support for proof generation</flag>


### PR DESCRIPTION
Sorry, I missed it the first time.

Package-Manager: Portage-2.3.66, Repoman-2.3.16
Signed-off-by: Denis Efremov <efremov@linux.com>