### PR TITLE
media-libs/tiff: Fix for CVE-2019-7663

### DIFF
--- a/media-libs/tiff/files/tiff-4.0.10-CVE-2019-7663-tiffcpIntegerOverflow.patch
+++ b/media-libs/tiff/files/tiff-4.0.10-CVE-2019-7663-tiffcpIntegerOverflow.patch
@@ -1,0 +1,73 @@
+From 2b0d0e699730d1f26bbeba8397bfdf0e9e01e59d Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Mon, 11 Feb 2019 10:05:33 +0100
+Subject: [PATCH 1/2] check that (Tile Width)*(Samples/Pixel) do no overflow
+
+fixes bug 2833
+---
+ tools/tiffcp.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/tools/tiffcp.c b/tools/tiffcp.c
+index 2f406e2d7..f0ee2c029 100644
+--- a/tools/tiffcp.c
++++ b/tools/tiffcp.c
+@@ -1408,7 +1408,7 @@ DECLAREreadFunc(readSeparateTilesIntoBuffer)
+ 	int status = 1;
+ 	uint32 imagew = TIFFRasterScanlineSize(in);
+ 	uint32 tilew = TIFFTileRowSize(in);
+-	int iskew  = imagew - tilew*spp;
++	int iskew;
+ 	tsize_t tilesize = TIFFTileSize(in);
+ 	tdata_t tilebuf;
+ 	uint8* bufp = (uint8*) buf;
+@@ -1416,6 +1416,12 @@ DECLAREreadFunc(readSeparateTilesIntoBuffer)
+ 	uint32 row;
+ 	uint16 bps = 0, bytes_per_sample;
+ 
++	if (spp > (0x7fffffff / tilew))
++	{
++		TIFFError(TIFFFileName(in), "Error, cannot handle that much samples per tile row (Tile Width * Samples/Pixel)");
++		return 0;
++	}
++	iskew = imagew - tilew*spp;
+ 	tilebuf = _TIFFmalloc(tilesize);
+ 	if (tilebuf == 0)
+ 		return 0;
+-- 
+2.21.0
+
+
+From 7cc76e9bc40bc8eb329a718ab26ecef7dd1afd94 Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Mon, 11 Feb 2019 21:42:03 +0100
+Subject: [PATCH 2/2] tiffcp.c: use INT_MAX
+
+---
+ tools/tiffcp.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tools/tiffcp.c b/tools/tiffcp.c
+index f0ee2c029..8c81aa4f2 100644
+--- a/tools/tiffcp.c
++++ b/tools/tiffcp.c
+@@ -41,6 +41,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <limits.h>
+ 
+ #include <ctype.h>
+ 
+@@ -1416,7 +1417,7 @@ DECLAREreadFunc(readSeparateTilesIntoBuffer)
+ 	uint32 row;
+ 	uint16 bps = 0, bytes_per_sample;
+ 
+-	if (spp > (0x7fffffff / tilew))
++	if (spp > (INT_MAX / tilew))
+ 	{
+ 		TIFFError(TIFFFileName(in), "Error, cannot handle that much samples per tile row (Tile Width * Samples/Pixel)");
+ 		return 0;
+-- 
+2.21.0
+

--- a/media-libs/tiff/tiff-4.0.10-r2.ebuild
+++ b/media-libs/tiff/tiff-4.0.10-r2.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools libtool multilib-minimal
+
+DESCRIPTION="Tag Image File Format (TIFF) library"
+HOMEPAGE="http://libtiff.maptools.org"
+SRC_URI="https://download.osgeo.org/libtiff/${P}.tar.gz"
+
+LICENSE="libtiff"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 ~riscv s390 sh sparc x86 ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+cxx jbig jpeg lzma static-libs test webp zlib zstd"
+
+RDEPEND="
+	jbig? ( >=media-libs/jbigkit-2.1:=[${MULTILIB_USEDEP}] )
+	jpeg? ( >=virtual/jpeg-0-r2:0=[${MULTILIB_USEDEP}] )
+	lzma? ( >=app-arch/xz-utils-5.0.5-r1[${MULTILIB_USEDEP}] )
+	webp? ( media-libs/libwebp:=[${MULTILIB_USEDEP}] )
+	zlib? ( >=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}] )
+	zstd? ( >=app-arch/zstd-1.3.7-r1:=[${MULTILIB_USEDEP}] )
+"
+DEPEND="${RDEPEND}"
+
+REQUIRED_USE="test? ( jpeg )" #483132
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.0.7-pdfium-0006-HeapBufferOverflow-ChopUpSingleUncompressedStrip.patch
+	"${FILESDIR}"/${PN}-4.0.7-pdfium-0008-HeapBufferOverflow-ChopUpSingleUncompressedStrip.patch
+	"${FILESDIR}"/${P}-CVE-2019-7663-tiffcpIntegerOverflow.patch
+)
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/tiffconf.h
+)
+
+src_prepare() {
+	default
+
+	# tiffcp-thumbnail.sh fails as thumbnail binary doesn't get built anymore since tiff-4.0.7
+	sed '/tiffcp-thumbnail\.sh/d' -i test/Makefile.am || die
+
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--without-x
+		--with-docdir="${EPREFIX}"/usr/share/doc/${PF}
+		$(use_enable cxx)
+		$(use_enable jbig)
+		$(use_enable jpeg)
+		$(use_enable lzma)
+		$(use_enable static-libs static)
+		$(use_enable webp)
+		$(use_enable zlib)
+		$(use_enable zstd)
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+
+	# remove useless subdirs
+	if ! multilib_is_native_abi ; then
+		sed -i \
+			-e 's/ tools//' \
+			-e 's/ contrib//' \
+			-e 's/ man//' \
+			-e 's/ html//' \
+			Makefile || die
+	fi
+}
+
+multilib_src_test() {
+	if ! multilib_is_native_abi ; then
+		emake -C tools
+	fi
+	emake check
+}
+
+multilib_src_install_all() {
+	find "${ED}" -name '*.la' -delete || die
+	rm "${ED}"/usr/share/doc/${PF}/{COPYRIGHT,README*,RELEASE-DATE,TODO,VERSION} || die
+}


### PR DESCRIPTION
From upstream at https://gitlab.com/libtiff/libtiff/merge_requests/60

Bug: https://bugs.gentoo.org/690732
Signed-off-by: Benjamin Gordon <bmgordon@chromium.org>