### PR TITLE
app-crypt/pesign: Say maintainer needed in metadata

### DIFF
--- a/app-crypt/pesign/metadata.xml
+++ b/app-crypt/pesign/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>david.michael@coreos.com</email>
-    <name>David Michael</name>
-  </maintainer>
-  <maintainer type="project">
-    <email>proxy-maint@gentoo.org</email>
-    <name>Proxy Maintainers</name>
-  </maintainer>
+  <!--maintainer-needed-->
   <upstream>
     <remote-id type="github">rhboot/pesign</remote-id>
   </upstream>


### PR DESCRIPTION
I was maintaining this for a previous job, but I am not using the project anymore, so it should be marked as needing a maintainer again.