### PR TITLE
dev-libs/jemalloc: Add use flag prof

### DIFF
--- a/dev-libs/jemalloc/jemalloc-5.0.1.ebuild
+++ b/dev-libs/jemalloc/jemalloc-5.0.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/jemalloc/jemalloc/releases/download/${PV}/${P}.tar.b
 LICENSE="BSD"
 SLOT="0/2"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
-IUSE="debug hardened +hugepages lazy-lock static-libs stats xmalloc"
+IUSE="debug hardened +hugepages lazy-lock prof static-libs stats xmalloc"
 HTML_DOCS=( doc/jemalloc.html )
 PATCHES=( "${FILESDIR}/${PN}-5.0.1-strip-optimization.patch"
 	"${FILESDIR}/${PN}-4.5.0-fix_html_install.patch"
@@ -40,6 +40,7 @@ multilib_src_configure() {
 		$(use_enable debug) \
 		$(use_enable lazy-lock) \
 		$(use_enable hugepages thp) \
+		$(use_enable prof) \
 		$(use_enable stats) \
 		$(use_enable xmalloc) \
 		"${myconf[@]}"

--- a/dev-libs/jemalloc/jemalloc-5.1.0.ebuild
+++ b/dev-libs/jemalloc/jemalloc-5.1.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/jemalloc/jemalloc/releases/download/${PV}/${P}.tar.b
 LICENSE="BSD"
 SLOT="0/2"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
-IUSE="debug hardened lazy-lock static-libs stats xmalloc"
+IUSE="debug hardened lazy-lock prof static-libs stats xmalloc"
 HTML_DOCS=( doc/jemalloc.html )
 PATCHES=( "${FILESDIR}/${PN}-5.0.1-strip-optimization.patch"
 	"${FILESDIR}/${PN}-4.5.0-fix_html_install.patch"
@@ -39,6 +39,7 @@ multilib_src_configure() {
 	econf  \
 		$(use_enable debug) \
 		$(use_enable lazy-lock) \
+		$(use_enable prof) \
 		$(use_enable stats) \
 		$(use_enable xmalloc) \
 		"${myconf[@]}"

--- a/dev-libs/jemalloc/jemalloc-5.2.0.ebuild
+++ b/dev-libs/jemalloc/jemalloc-5.2.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/jemalloc/jemalloc/releases/download/${PV}/${P}.tar.b
 LICENSE="BSD"
 SLOT="0/2"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
-IUSE="debug hardened lazy-lock static-libs stats xmalloc"
+IUSE="debug hardened lazy-lock prof static-libs stats xmalloc"
 HTML_DOCS=( doc/jemalloc.html )
 PATCHES=( "${FILESDIR}/${PN}-5.2.0-gentoo-fixups.patch" )
 
@@ -38,6 +38,7 @@ multilib_src_configure() {
 	econf  \
 		$(use_enable debug) \
 		$(use_enable lazy-lock) \
+		$(use_enable prof) \
 		$(use_enable stats) \
 		$(use_enable xmalloc) \
 		"${myconf[@]}"

--- a/dev-libs/jemalloc/metadata.xml
+++ b/dev-libs/jemalloc/metadata.xml
@@ -11,6 +11,7 @@
 	<use>
 		<flag name="hugepages">Enable transparent huge page support</flag>
 		<flag name="lazy-lock">Enable lazy locking (only lock when multi-threaded)</flag>
+		<flag name="prof">Enable allocation profiling</flag>
 		<flag name="stats">Enable statistics calculation/reporting</flag>
 		<flag name="xmalloc">Add support for xmalloc (abort-on-out-of-memory)</flag>
 	</use>


### PR DESCRIPTION
Add use flag prof  to enable or disable allocation profiling.

Signed-off-by: Han Han <hanhanzhiyeqianke@gmail.com>