### PR TITLE
app-emulation/qemu: Add use flag jemalloc

### DIFF
--- a/app-emulation/qemu/metadata.xml
+++ b/app-emulation/qemu/metadata.xml
@@ -40,6 +40,7 @@
 		<flag name="snappy">Enable support for snappy compression</flag>
 		<flag name="systemtap">Enable SystemTAP/DTrace tracing</flag>
 		<flag name="tci">Enable the TCG Interpreter which can speed up or slowdown workloads depending on the host and guest CPUs being emulated. In the future it will be a runtime option but for now its compile time.</flag>
+		<flag name="jemalloc">Enable jemalloc allocator support</flag>
 		<flag name="jpeg">Enable jpeg image support for the VNC console server</flag>
 		<flag name="png">Enable png image support for the VNC console server</flag>
 		<flag name="usb">Enable USB passthrough via <pkg>dev-libs/libusb</pkg></flag>

--- a/app-emulation/qemu/qemu-4.0.0-r3.ebuild
+++ b/app-emulation/qemu/qemu-4.0.0-r3.ebuild
@@ -28,7 +28,7 @@ HOMEPAGE="http://www.qemu.org http://www.linux-kvm.org"
 LICENSE="GPL-2 LGPL-2 BSD-2"
 SLOT="0"
 IUSE="accessibility +aio alsa bzip2 capstone +caps +curl debug doc
-	+fdt glusterfs gnutls gtk infiniband iscsi +jpeg kernel_linux
+	+fdt glusterfs gnutls gtk infiniband iscsi jemalloc +jpeg kernel_linux
 	kernel_FreeBSD lzo ncurses nfs nls numa opengl +pin-upstream-blobs +png
 	pulseaudio python rbd sasl +seccomp sdl selinux smartcard snappy
 	spice ssh static static-user systemtap tci test usb usbredir vde
@@ -108,6 +108,7 @@ SOFTMMU_TOOLS_DEPEND="
 		sys-fabric/librdmacm:=[static-libs(+)]
 	)
 	iscsi? ( net-libs/libiscsi )
+	jemalloc? ( dev-libs/jemalloc )
 	jpeg? ( virtual/jpeg:0=[static-libs(+)] )
 	lzo? ( dev-libs/lzo:2[static-libs(+)] )
 	ncurses? (
@@ -437,6 +438,7 @@ qemu_src_configure() {
 		$(conf_notuser gtk)
 		$(conf_notuser infiniband rdma)
 		$(conf_notuser iscsi libiscsi)
+		$(conf_notuser jemalloc jemalloc)
 		$(conf_notuser jpeg vnc-jpeg)
 		$(conf_notuser kernel_linux kvm)
 		$(conf_notuser lzo)

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -28,7 +28,7 @@ HOMEPAGE="http://www.qemu.org http://www.linux-kvm.org"
 LICENSE="GPL-2 LGPL-2 BSD-2"
 SLOT="0"
 IUSE="accessibility +aio alsa bzip2 capstone +caps +curl debug doc
-	+fdt glusterfs gnutls gtk infiniband iscsi +jpeg kernel_linux
+	+fdt glusterfs gnutls gtk infiniband iscsi +jpeg jemalloc kernel_linux
 	kernel_FreeBSD lzo ncurses nfs nls numa opengl +pin-upstream-blobs +png
 	pulseaudio python rbd sasl +seccomp sdl selinux smartcard snappy
 	spice ssh static static-user systemtap tci test usb usbredir vde
@@ -108,6 +108,7 @@ SOFTMMU_TOOLS_DEPEND="
 		sys-fabric/librdmacm:=[static-libs(+)]
 	)
 	iscsi? ( net-libs/libiscsi )
+	jemalloc? ( dev-libs/jemalloc )
 	jpeg? ( virtual/jpeg:0=[static-libs(+)] )
 	lzo? ( dev-libs/lzo:2[static-libs(+)] )
 	ncurses? (
@@ -435,6 +436,7 @@ qemu_src_configure() {
 		$(conf_notuser gtk)
 		$(conf_notuser infiniband rdma)
 		$(conf_notuser iscsi libiscsi)
+		$(conf_notuser jemalloc jemalloc)
 		$(conf_notuser jpeg vnc-jpeg)
 		$(conf_notuser kernel_linux kvm)
 		$(conf_notuser lzo)


### PR DESCRIPTION
Add flag jemalloc to enable or disable jemalloc memory jemalloc support
for qemu.

Signed-off-by: Han Han <hanhanzhiyeqianke@gmail.com>