### PR TITLE
net-misc/networkmanager: Fixing kernel config check

### DIFF
--- a/net-misc/networkmanager/networkmanager-1.16.0.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.16.0.ebuild
@@ -139,7 +139,11 @@ pkg_pretend() {
 
 pkg_setup() {
 	if use connection-sharing; then
-		CONFIG_CHECK="~NF_NAT_IPV4 ~NF_NAT_MASQUERADE_IPV4"
+		if kernel_is lt 5 1; then
+			CONFIG_CHECK="~NF_NAT_IPV4 ~NF_NAT_MASQUERADE_IPV4"
+		else
+			CONFIG_CHECK="~NF_NAT ~NF_NAT_MASQUERADE"
+		fi
 		linux-info_pkg_setup
 	fi
 	enewgroup plugdev

--- a/net-misc/networkmanager/networkmanager-1.16.2.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.16.2.ebuild
@@ -139,7 +139,11 @@ pkg_pretend() {
 
 pkg_setup() {
 	if use connection-sharing; then
-		CONFIG_CHECK="~NF_NAT_IPV4 ~NF_NAT_MASQUERADE_IPV4"
+		if kernel_is lt 5 1; then
+			CONFIG_CHECK="~NF_NAT_IPV4 ~NF_NAT_MASQUERADE_IPV4"
+		else
+			CONFIG_CHECK="~NF_NAT ~NF_NAT_MASQUERADE"
+		fi
 		linux-info_pkg_setup
 	fi
 	enewgroup plugdev

--- a/net-misc/networkmanager/networkmanager-1.18.2.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.18.2.ebuild
@@ -138,7 +138,11 @@ pkg_pretend() {
 
 pkg_setup() {
 	if use connection-sharing; then
-		CONFIG_CHECK="~NF_NAT_IPV4 ~NF_NAT_MASQUERADE_IPV4"
+		if kernel_is lt 5 1; then
+			CONFIG_CHECK="~NF_NAT_IPV4 ~NF_NAT_MASQUERADE_IPV4"
+		else
+			CONFIG_CHECK="~NF_NAT ~NF_NAT_MASQUERADE"
+		fi
 		linux-info_pkg_setup
 	fi
 	enewgroup plugdev


### PR DESCRIPTION
Not sure if this warrants a new revision or not.

`CONFIG_NF_NAT_IPV4` and `CONFIG_NF_NAT_IPV6` were merged into `CONFIG_NF_NAT` on:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3bf195ae6037e310d693ff3313401cfaf1261b71

`CONFIG_NF_NAT_MASQUERADE_IPV4` and `CONFIG_NF_NAT_MASQUERADE_IPV6` were merged into `CONFIG_NF_NAT_MASQUERADE` on:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d1aca8ab3104aa7131f5ab144c6f586b54df084b