### PR TITLE
sci-electronics/kicad: Fix 5.1.x build issues with swig-4.0.0

### DIFF
--- a/sci-electronics/kicad/files/kicad-5.1.0-swig-4.0.0.patch
+++ b/sci-electronics/kicad/files/kicad-5.1.0-swig-4.0.0.patch
@@ -1,0 +1,12 @@
+--- a/scripting/build_tools/fix_swig_imports.py	2019-04-22 23:14:54.000000000 +0200
++++ b/scripting/build_tools/fix_swig_imports.py	2019-07-18 15:44:24.255754237 +0200
+@@ -40,6 +40,9 @@
+ txt = b""
+ 
+ for l in lines:
++    if l.startswith(b"if _swig_python_version_info < (2, 7, 0):"):     # ok with swig version >= 4.0.0
++        l = l.replace(b"_swig_python_version_info < (2, 7, 0)", b"False")
++        doneOk = True
+     if l.startswith(b"if _swig_python_version_info >= (2, 7, 0):"):     # ok with swig version >= 3.0.10
+         l = l.replace(b"_swig_python_version_info >= (2, 7, 0)", b"False")
+         doneOk = True

--- a/sci-electronics/kicad/kicad-5.1.0-r1.ebuild
+++ b/sci-electronics/kicad/kicad-5.1.0-r1.ebuild
@@ -51,6 +51,7 @@ CHECKREQS_DISK_BUILD="800M"
 
 PATCHES=(
 	"${FILESDIR}"/"${PN}-5.1.0-help.patch"
+	"${FILESDIR}"/"${PN}-5.1.0-swig-4.0.0.patch"
 )
 
 pkg_setup() {

--- a/sci-electronics/kicad/kicad-5.1.2-r1.ebuild
+++ b/sci-electronics/kicad/kicad-5.1.2-r1.ebuild
@@ -51,6 +51,7 @@ CHECKREQS_DISK_BUILD="800M"
 
 PATCHES=(
 	"${FILESDIR}"/"${PN}-5.1.0-help.patch"
+	"${FILESDIR}"/"${PN}-5.1.0-swig-4.0.0.patch"
 )
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/690146
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
Package-Manager: Portage-2.3.69, Repoman-2.3.16