### PR TITLE
www-client/chromium: fix building on arm64

### DIFF
--- a/www-client/chromium/chromium-76.0.3809.80.ebuild
+++ b/www-client/chromium/chromium-76.0.3809.80.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${P}
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="+closure-compile component-build cups gnome-keyring +hangouts jumbo-build kerberos neon pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc widevine"
+IUSE="+closure-compile component-build cups cpu_flags_arm_neon gnome-keyring +hangouts jumbo-build kerberos pic +proprietary-codecs pulseaudio selinux +suid +system-ffmpeg +system-icu +system-libvpx +tcmalloc widevine"
 RESTRICT="!system-ffmpeg? ( proprietary-codecs? ( bindist ) )"
 REQUIRED_USE="component-build? ( !suid )"
 
@@ -555,7 +555,7 @@ src_configure() {
 		ffmpeg_target_arch=arm64
 	elif [[ $myarch = arm ]] ; then
 		myconf_gn+=" target_cpu=\"arm\""
-		ffmpeg_target_arch=$(usex neon arm-neon arm)
+		ffmpeg_target_arch=$(usex cpu_flags_arm_neon arm-neon arm)
 	else
 		die "Failed to determine target arch, got '$myarch'."
 	fi

--- a/www-client/chromium/files/chromium-76-arm64-skia.patch
+++ b/www-client/chromium/files/chromium-76-arm64-skia.patch
@@ -1,0 +1,41 @@
+From 7aacb0b30a86936aedd1308708d1a51d951197f2 Mon Sep 17 00:00:00 2001
+From: Mike Klein <mtklein@google.com>
+Date: Tue, 02 Jul 2019 13:23:06 -0500
+Subject: [PATCH] fix GCC arm64 builds
+
+These two guards are checking if we're building for aarch64 and thus
+have F16 conversion instructions, but weren't checking if we want to use
+them (if we have them _and_ we're being compiled by Clang).  At head
+we're trying to pass a 2-byte uint16_t to a function expecting an 8-byte
+uint16x4_t, etc.
+
+Change-Id: I21f6cd2100ec81ccdd47c4ec0575107624cd7c5a
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/225257
+Reviewed-by: Herb Derby <herb@google.com>
+Commit-Queue: Mike Klein <mtklein@google.com>
+---
+
+diff --git a/third_party/skia/src/opts/SkRasterPipeline_opts.h b/third_party/skia/src/opts/SkRasterPipeline_opts.h
+index 0eae9fe..e05f36c 100644
+--- a/third_party/skia/src/opts/SkRasterPipeline_opts.h
++++ b/third_party/skia/src/opts/SkRasterPipeline_opts.h
+@@ -972,7 +972,8 @@
+ }
+ 
+ SI F from_half(U16 h) {
+-#if defined(SK_CPU_ARM64) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
++#if defined(JUMPER_IS_NEON) && defined(SK_CPU_ARM64) \
++    && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+     return vcvt_f32_f16(h);
+ 
+ #elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)
+@@ -992,7 +993,8 @@
+ }
+ 
+ SI U16 to_half(F f) {
+-#if defined(SK_CPU_ARM64) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
++#if defined(JUMPER_IS_NEON) && defined(SK_CPU_ARM64) \
++    && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+     return vcvt_f16_f32(f);
+ 
+ #elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)


### PR DESCRIPTION
Also move USE=neon to cpu_flags_arm_neon

Package-Manager: Portage-2.3.66, Repoman-2.3.16
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>