### PR TITLE
www-client/chromium: really add arm64 patch to ebuild

### DIFF
--- a/www-client/chromium/chromium-76.0.3809.80.ebuild
+++ b/www-client/chromium/chromium-76.0.3809.80.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${FILESDIR}/chromium-widevine-r4.patch"
 	"${FILESDIR}/chromium-fix-char_traits.patch"
 	"${FILESDIR}/chromium-angle-inline.patch"
+	"${FILESDIR}/chromium-76-arm64-skia.patch"
 	"${FILESDIR}/chromium-76-quiche.patch"
 	"${FILESDIR}/chromium-76-gcc-vulkan.patch"
 	"${FILESDIR}/chromium-76-gcc-private.patch"


### PR DESCRIPTION
Package-Manager: Portage-2.3.66, Repoman-2.3.16
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>