### PR TITLE
sci-libs/openblas: improvements on 0.3.6

### DIFF
--- a/sci-libs/openblas/metadata.xml
+++ b/sci-libs/openblas/metadata.xml
@@ -9,15 +9,18 @@
 		<email>lumin@debian.org</email>
 		<name>Mo Zhou</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>hasan.calisir@psauxit.com</email>
+		<name>Hasan ÇALIŞIR</name>
+	</maintainer>
 	<longdescription lang="en">
 		OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.
 	</longdescription>
 	<use>
 		<flag name="dynamic">Build dynamic architecture detection at run time (for multi targets)</flag>
-		<flag name="pthread">Build with pthread threadding model</flag>
-		<flag name="serial">Build without multi-thraedding</flag>
 		<flag name="eselect-ldso">Enable BLAS/LAPACK runtime switching</flag>
 		<flag name="index-64bit">Compile a separate INTERFACE64 OpenBLAS</flag>
+		<flag name="pthread">Build with pthread threading model</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">xianyi/OpenBLAS</remote-id>


### PR DESCRIPTION
@heroxbd  @cdluminate i think we can handle openblas together. I improved ebuild structer and fixed several QA and build issues. I will look next to switch framework.

**Actual Build Behaviour:**

```
<command-line>: warning: "ASMNAME" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "ASMFNAME" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "NAME" redefined
<command-line>: note: this is the location of the previous definition
<command-line>: warning: "CNAME" redefined
<command-line>: note: this is the location of the previous definition
```
**Improvements on 0.3.6**

*OpenBLAS needs fortran compiler, added fortran-2 eclass.
*Re-ordered USE flags alphabetically.
*Dropped IUSEs (serial,static-libs) that not used anywhere in the ebuild.
*Dropped REQUIRED_USE for (openmp pthread serial),
 User can have both  global flags openmp & threads & pthreads etc. in make.conf.
*Changed (pthreads) use flag to (threads) which is global one.
*Added (src_prepare) phase for setting fortran compiler.
*There is no need custom function called (openblas_flags) with local variable,
 replaced with (src_configure) with global variable.
*Added NUM_PARALLEL support up to 32 core for OpenMP,
 Added (np2,np4,np8,np16,np32) use flags,
 Added REQUIRED_USE for (np2,np4,np8,np16,np32).
*In (src_configure), (threads) and (openmp) if clauses re-ordered,
 First check (threads) then (openmp).
*Updated (src_compile) according to global variable,
 fix twice CFLAGS & FFLAGS definition & fix twice multi-jobs.
*Fixed metadata alphebetically.
*Added (src_test) phase.
*Added dodoc.

Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>