### PR TITLE
dev-db/percona-xtrabackup: require dev-libs/openssl

### DIFF
--- a/dev-db/percona-xtrabackup/percona-xtrabackup-8.0.6.ebuild
+++ b/dev-db/percona-xtrabackup/percona-xtrabackup-8.0.6.ebuild
@@ -26,6 +26,7 @@ DEPEND="
 	dev-libs/libevent:0=
 	dev-libs/libgcrypt:0=
 	dev-libs/libgpg-error
+	dev-libs/openssl:0=
 	dev-libs/protobuf:=
 	dev-libs/rapidjson
 	dev-libs/re2:=


### PR DESCRIPTION
Libressl is not (yet) supported

Closes: https://bugs.gentoo.org/690172
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>