### PR TITLE
sci-visualization/paraview: fix subslot operator

### DIFF
--- a/sci-visualization/paraview/paraview-5.6.1.ebuild
+++ b/sci-visualization/paraview/paraview-5.6.1.ebuild
@@ -29,7 +29,7 @@ REQUIRED_USE="python? ( mpi ${PYTHON_REQUIRED_USE} )
 RDEPEND="
 	app-arch/lz4
 	dev-libs/expat
-	dev-libs/jsoncpp
+	dev-libs/jsoncpp:=
 	dev-libs/libxml2:2
 	dev-libs/protobuf:=
 	dev-libs/pugixml


### PR DESCRIPTION
The patch adds a missing subslot operator on dev-libs/jsoncpp.

Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Bernd Waibel <waebbl@gmail.com>