### PR TITLE
media-gfx/alembic: fix a boost_python variable

### DIFF
--- a/media-gfx/alembic/alembic-1.7.11.ebuild
+++ b/media-gfx/alembic/alembic-1.7.11.ebuild
@@ -45,6 +45,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-0003-Fix-env-var-for-renderman.patch"
 	"${FILESDIR}/${P}-0004-Fix-a-compile-issue-with-const.patch"
 	"${FILESDIR}/${P}-0005-Fix-install-locations.patch"
+	"${FILESDIR}/${P}-0006-python-PyAlembic-Tests-CMakeLists.txt-fix-variable.patch"
 )
 
 src_prepare() {

--- a/media-gfx/alembic/files/alembic-1.7.11-0006-python-PyAlembic-Tests-CMakeLists.txt-fix-variable.patch
+++ b/media-gfx/alembic/files/alembic-1.7.11-0006-python-PyAlembic-Tests-CMakeLists.txt-fix-variable.patch
@@ -1,0 +1,29 @@
+From 13b88370a862e16b417e9df6e40c2a9cba10852c Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl@gmail.com>
+Date: Fri, 2 Aug 2019 21:31:03 +0200
+Subject: [PATCH] python/PyAlembic/Tests/CMakeLists.txt: fix variable
+
+The patch fixes a boost_python related variable which didn't had
+the version suffix for python.
+
+Signed-off-by: Bernd Waibel <waebbl@gmail.com>
+---
+ python/PyAlembic/Tests/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/python/PyAlembic/Tests/CMakeLists.txt b/python/PyAlembic/Tests/CMakeLists.txt
+index c32a018..ed9b23d 100644
+--- a/python/PyAlembic/Tests/CMakeLists.txt
++++ b/python/PyAlembic/Tests/CMakeLists.txt
+@@ -57,7 +57,7 @@ TARGET_LINK_LIBRARIES(PyAlembic_Test Alembic::Alembic ${ALEMBIC_PYILMBASE_LIBS})
+ 
+ ADD_TEST(PyAlembic_Python_TEST PyAlembic_Test)
+ 
+-GET_FILENAME_COMPONENT(BOOST_LIBRARY_DIR ${Boost_PYTHON_LIBRARY} PATH)
++GET_FILENAME_COMPONENT(BOOST_LIBRARY_DIR ${Boost_PYTHON27_LIBRARY} PATH)
+ GET_FILENAME_COMPONENT(ILMBASE_LIBRARY_DIR ${ALEMBIC_ILMBASE_IMATH_LIB} PATH)
+ 
+ CONFIGURE_FILE(
+-- 
+2.22.0
+


### PR DESCRIPTION
The patch fixes an issue when USE=test is used, where the
python version suffix was not used in a variable.

Closes: https://bugs.gentoo.org/691300
Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Bernd Waibel <waebbl@gmail.com>