### PR TITLE
iperf-2: Fix building with latest clang

### DIFF
--- a/net-misc/iperf/files/iperf-2-bool.patch
+++ b/net-misc/iperf/files/iperf-2-bool.patch
@@ -1,0 +1,15 @@
+diff --git a/config.h b/config.h
+index d9dae4d..f9d7525 100644
+--- a/config.h
++++ b/config.h
+@@ -316,7 +316,9 @@
+ /* #undef _REENTRANT */
+ 
+ /* */
++#ifndef __cplusplus
+-#define bool int
++#define bool _Bool
++#endif
+ 
+ /* Define to empty if `const' does not conform to ANSI C. */
+ /* #undef const */

--- a/net-misc/iperf/iperf-2.0.14a.ebuild
+++ b/net-misc/iperf/iperf-2.0.14a.ebuild
@@ -24,6 +24,8 @@ src_configure() {
 		$(use_enable debug debuginfo) \
 		$(use_enable ipv6) \
 		$(use_enable threads)
+        # Modify config.h to use _Bool for C only.
+        eapply "${FILESDIR}"/${PN}-2-bool.patch
 }
 
 src_install() {


### PR DESCRIPTION
iperf was defining bool to int which breaks compiling C++ files.
Modified config.h to define bool to _Bool in C only.

This has been reported upstream but hasn't been fixed yet:
https://sourceforge.net/p/iperf/mailman/message/34860443/

Signed-off-by: Zhizhou Yang <zhizhouy@google.com>