### PR TITLE
acct-user/gvm: Request acct-*/gvm (UID-GID 495)

### DIFF
--- a/acct-group/gvm/gvm-0.ebuild
+++ b/acct-group/gvm/gvm-0.ebuild
@@ -1,0 +1,9 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+DESCRIPTION="Greenbone vulnerability management program group"
+ACCT_GROUP_ID=495

--- a/acct-group/gvm/metadata.xml
+++ b/acct-group/gvm/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>hasan.calisir@psauxit.com</email>
+		<name>Hasan ÇALIŞIR</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+		</maintainer>
+</pkgmetadata>

--- a/acct-user/gvm/gvm-0.ebuild
+++ b/acct-user/gvm/gvm-0.ebuild
@@ -1,0 +1,13 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="Greenbone vulnerability management program user"
+ACCT_USER_ID=495
+ACCT_USER_HOME=/var/lib/gvm
+ACCT_USER_GROUPS=( gvm )
+
+acct-user_add_deps

--- a/acct-user/gvm/metadata.xml
+++ b/acct-user/gvm/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+        <maintainer type="person">
+                <email>hasan.calisir@psauxit.com</email>
+                <name>Hasan ÇALIŞIR</name>
+        </maintainer>
+        <maintainer type="project">
+                <email>proxy-maint@gentoo.org</email>
+                <name>Proxy Maintainers</name>
+        </maintainer>
+</pkgmetadata>


### PR DESCRIPTION
CI will not happy but i don't have direct commit-acces. Also i will send this dev-list too.

gvm (previously named OpenVAS) doesn't have a fixed ID in fedora or arch. I assigned free 495.

**Why we need USER?**

Community edition of gvm uses only rsync to updating feeds and rsyncing under root is not secure. Because of that i packaged gvm to run under user 'gvm'. All services & init scripts and vulnerability feed updates must run under user 'gvm' expect openvas-scanner, it needs root privileges for extra checks. Upstream strongly recommends this.

Thanks @juippis 
https://github.com/gentoo/gentoo/pull/12542