### PR TITLE
qmail eclass: do not install man templates to section 8

### DIFF
--- a/eclass/qmail.eclass
+++ b/eclass/qmail.eclass
@@ -227,12 +227,6 @@ qmail_config_install() {
 qmail_man_install() {
 	einfo "Installing manpages and documentation"
 
-	# those are tagged for section 8 but named for
-	# section 9 (which does not exist anyway)
-	for i in *.9; do
-		mv ${i} ${i/.9/.8}
-	done
-
 	into /usr
 	doman *.[1578]
 	dodoc BLURB* CHANGES FAQ INSTALL* PIC* README* REMOVE* SECURITY \


### PR DESCRIPTION
The files named *.9 are actually only templates for the real manpages, some of them _not_ in section 8 at all. Those are properly gerated and installed anyway, so just leave these alone as they were never meant to be installed.
