### PR TITLE
 dev-libs/serdisplib: add ~ppc keyword

### DIFF
--- a/dev-libs/serdisplib/serdisplib-2.01.ebuild
+++ b/dev-libs/serdisplib/serdisplib-2.01.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="threads tools"
 
 # Define the list of valid lcd devices.

--- a/x11-libs/libdlo/libdlo-0.1.2-r1.ebuild
+++ b/x11-libs/libdlo/libdlo-0.1.2-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://people.freedesktop.org/~berniet/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~ppc x86"
 IUSE="static-libs test-program"
 
 RDEPEND="virtual/libusb:0="


### PR DESCRIPTION
dev-libs/serdisplib: add ~ppc keyword
x11-libs/libdlo: add ~ppc keyword
Thanks to ernsteiswuerfel, ~ppc keyword can be added.

Closes: https://bugs.gentoo.org/690412
Package-Manager: Portage-2.3.71, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>

