### PR TITLE
 powerpc/package.use.mask: mask glcd driver on ppc/ppc64

### DIFF
--- a/app-misc/glcdprocdriver/glcdprocdriver-0.1.2.ebuild
+++ b/app-misc/glcdprocdriver/glcdprocdriver-0.1.2.ebuild
@@ -9,11 +9,13 @@ MY_P="${MY_PN}-${PV}"
 inherit toolchain-funcs
 
 DESCRIPTION="A glue between the graphlcd-base library from the GraphLCD project"
-HOMEPAGE="https://lucianm.github.io/GLCDprocDriver
-	https://github.com/lucianm/GLCDprocDriver"
+HOMEPAGE="
+	https://lucianm.github.io/GLCDprocDriver
+	https://github.com/lucianm/GLCDprocDriver
+"
 SRC_URI="https://github.com/lucianm/${MY_PN}/archive/0.1.2.tar.gz -> ${MY_P}.tar.gz"
 
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="amd64 x86"
 SLOT="0"
 LICENSE="GPL-2"
 

--- a/app-misc/graphlcd-base/graphlcd-base-1.0.2.ebuild
+++ b/app-misc/graphlcd-base/graphlcd-base-1.0.2.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="Contains the lowlevel lcd drivers for GraphLCD"
 HOMEPAGE="https://projects.vdr-developer.org/projects/graphlcd-base"
 SRC_URI="https://projects.vdr-developer.org/git/${PN}.git/snapshot/${P}.tar.bz2"
 
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="amd64 x86"
 SLOT="0"
 LICENSE="GPL-2"
 IUSE="fontconfig freetype g15 graphicsmagick imagemagick lcd_devices_ax206dpf lcd_devices_picolcd_256x64 lcd_devices_vnc"
@@ -27,6 +27,7 @@ RDEPEND="
 "
 
 DEPEND="${RDEPEND}"
+
 BDEPEND="virtual/pkgconfig"
 
 DOCS=( "HISTORY" "README" "TODO" "docs/." )

--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Conrad Kostecki <ck+gentoo@bl4ckb0x.de> (2019-08-07)
+# app-misc/graphlcd-base won't work on PowerPC/PowerPC64
+app-misc/lcdproc lcd_devices_glcd
+
 # Matt Turner <mattst88@gentoo.org> (2019-08-04)
 # Dependency app-crypt/jitterentropy is keyworded for ppc/ppc64
 sys-apps/rng-tools -jitterentropy

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -1,10 +1,6 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Conrad Kostecki <ck+gentoo@bl4ckb0x.de> (2019-07-21)
-# app-misc/graphlcd-base won't work on PowerPC
-app-misc/lcdproc lcd_devices_glcd
-
 # Jimi Huotari <chiitoo@gentoo.org> (2019-07-28)
 # Mask unkeyworded, untested dependencies.
 # https://bugs.gentoo.org/689606


### PR DESCRIPTION
powerpc/package.use.mask: mask glcd driver on ppc/ppc64
Closes: https://bugs.gentoo.org/691672
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>


app-misc/glcdprocdriver: drop ~ppc keyword
Due usage of <sys/io.h>, it can't be compiled anymore on ~ppc.
Bug: https://bugs.gentoo.org/691672
Package-Manager: Portage-2.3.71, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>


app-misc/graphlcd-base: drop ~ppc keyword
Due usage of <sys/io.h>, it can't be compiled anymore on ~ppc.
Bug: https://bugs.gentoo.org/691672
Package-Manager: Portage-2.3.71, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>