### PR TITLE
sys-apps/sysvinit: add 'halt' init script

### DIFF
--- a/sys-apps/sysvinit/files/halt
+++ b/sys-apps/sysvinit/files/halt
@@ -1,0 +1,24 @@
+#!/sbin/openrc-run
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Add this service to the shutdown runlevel to make shutdown -hH work properly.
+
+depend() {
+	after killprocs mount-ro savecache
+}
+
+start() {
+	if [ "$RC_REBOOT" = YES ]; then
+		ebegin "Rebooting system"
+		reboot -d
+	elif [ "$INIT_HALT" = HALT ]; then
+		ebegin "Halting system"
+		halt -d
+	else
+		ebegin "Powering off system"
+		poweroff -d
+	fi
+	# We should never get here.
+	eend $?
+}

--- a/sys-apps/sysvinit/sysvinit-2.95.ebuild
+++ b/sys-apps/sysvinit/sysvinit-2.95.ebuild
@@ -113,6 +113,7 @@ src_install() {
 	rm "${ED}"/usr/bin/lastb || die
 
 	newinitd "${FILESDIR}"/bootlogd.initd bootlogd
+	doinitd "${FILESDIR}"/halt
 }
 
 pkg_postinst() {


### PR DESCRIPTION
When added to the shutdown runlevel, this allows shutdown -hH to work
properly.

Package-Manager: Portage-2.3.71, Repoman-2.3.16_p24
Signed-off-by: Mike Gilbert <floppym@gentoo.org>