### PR TITLE
net-dns/bind: Add support for the GeoIP2 API.

### DIFF
--- a/net-dns/bind/bind-9.15.2.ebuild
+++ b/net-dns/bind/bind-9.15.2.ebuild
@@ -38,7 +38,7 @@ LICENSE="Apache-2.0 BSD BSD-2 GPL-2 HPND ISC MPL-2.0"
 SLOT="0"
 KEYWORDS=""
 # -berkdb by default re bug 602682
-IUSE="-berkdb +caps dlz dnstap doc dnsrps fixed-rrset geoip gost gssapi
+IUSE="-berkdb +caps dlz dnstap doc dnsrps fixed-rrset geoip2 gost gssapi
 json ldap libressl lmdb mysql odbc postgres python selinux ssl static-libs
 urandom xml +zlib"
 # sdb-ldap - patch broken
@@ -64,7 +64,7 @@ DEPEND="
 	postgres? ( dev-db/postgresql:= )
 	caps? ( >=sys-libs/libcap-2.1.0 )
 	xml? ( dev-libs/libxml2 )
-	geoip? ( >=dev-libs/geoip-1.4.6 )
+	geoip2? ( dev-libs/libmaxminddb )
 	gssapi? ( virtual/krb5 )
 	json? ( dev-libs/json-c:= )
 	lmdb? ( dev-db/lmdb )
@@ -159,8 +159,6 @@ src_configure() {
 		$(use_with zlib)
 	)
 
-	use geoip && myeconfargs+=( --enable-geoip )
-
 	# bug #158664
 #	gcc-specs-ssp && replace-flags -O[23s] -O
 
@@ -253,10 +251,11 @@ src_install() {
 	# bug 450406
 	dosym named.cache /var/bind/root.cache
 
-	dosym /var/bind/pri /etc/bind/pri
-	dosym /var/bind/sec /etc/bind/sec
-	dosym /var/bind/dyn /etc/bind/dyn
+	dosym "${ED%/}/var/bind/pri" "/etc/bind/pri"
+	dosym "${ED%/}/var/bind/sec" "/etc/bind/sec"
+	dosym "${ED%/}/var/bind/dyn" "/etc/bind/dyn"
 	keepdir /var/bind/{pri,sec,dyn}
+	keepdir /var/log/named
 
 	dodir /var/log/named
 
@@ -380,4 +379,6 @@ pkg_config() {
 
 	elog "You may need to add the following line to your syslog-ng.conf:"
 	elog "source jail { unix-stream(\"${CHROOT}/dev/log\"); };"
+	elog "Additional support for GeoIP2 can be get from"
+	optfeature "Automatic updates of GeoIP2 binary databases" net-misc/geoipupdate
 }

--- a/net-dns/bind/metadata.xml
+++ b/net-dns/bind/metadata.xml
@@ -15,6 +15,7 @@
 		<flag name="dnsrps">Enable the DNS Response Policy Service (DNSRPS) API, a mechanism to allow an external response policy provider</flag>
 		<flag name="dlz">Enables dynamic loaded zones, 3rd party extension</flag>
 		<flag name="fixed-rrset">Enables fixed rrset-order option</flag>
+		<flag name="geoip2">Enable GeoIP2 API from MaxMind</flag>
 		<flag name="gost">Enables gost OpenSSL engine support</flag>
 		<flag name="gssapi">Enable gssapi support</flag>
 		<flag name="json">Enable JSON statistics channel</flag>

--- a/profiles/arch/arm/package.use.stable.mask
+++ b/profiles/arch/arm/package.use.stable.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Hasan ÇALIŞIR <hasan.calisir@psauxit.com> (2019-08-19)
+# Needs dev-libs/libmaxminddb stable for GeoIP2 API support
+net-dns/bind geoip2
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2019-02-10)
 # Needs kde-frameworks/{kwallet,ki18n,kconfig} stable
 dev-vcs/subversion kwallet


### PR DESCRIPTION
@zlogene @idl0r 

Legacy GeoIP databases were discontinued
on January 2, 2019.

*Updated GeoIP support to new API GeoLite2 from Maxmind.
*Fixed dosym relative path.
*Added keepdir for /var/log/named.

Notes:

> Some geoip ACL settings that were available with legacy GeoIP, including searches for netspeed, org, and three-letter ISO country codes, will no longer work when using GeoIP2. Supported GeoIP2 database types are country, city, domain, isp, and as. All of these databases support both IPv4 and IPv6 lookups.

1) I keeped legacy GeoIP for stable 9.14.4 and completely removed on development 9.15.2. 

----------------------------------------------------

> The default path to the GeoIP2 databases will be set based on the location of the libmaxminddb library; for example, if it is in /usr/local/lib, then the default path will be /usr/local/share/GeoIP. 

2) This only works for 9.15.2.
On 9.14.4 bind looks for binary databases in **/usr/share/GeoIP2** instead of **/usr/share/GeoIP**

-------------------------------------------------------

> Geolocation support will be compiled in by default if the libmaxminddb library is found at compile time.

3) This works for only 9.15.2.
So we don't need `use geoip && myeconfargs+=( --enable-geoip )` for 9.15.2.

Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>