### PR TITLE
sci-libs/cantera: Fix missing RDEPEND="${PYTHON_DEPS}" warning

### DIFF
--- a/sci-libs/cantera/cantera-2.4.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r1.ebuild
@@ -21,11 +21,11 @@ IUSE="+cti fortran pch +python test"
 
 REQUIRED_USE="
 	python? ( cti )
-	cti? ( ${PYTHON_REQUIRED_USE} )
 	${PYTHON_REQUIRED_USE}
 	"
 
 RDEPEND="
+	${PYTHON_DEPS}
 	python? (
 		dev-python/numpy[${PYTHON_USEDEP}]
 	)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/691404