### PR TITLE
sys-apps/sysvinit: add halt.sh

### DIFF
--- a/sys-apps/sysvinit/files/halt.sh
+++ b/sys-apps/sysvinit/files/halt.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+. /lib/gentoo/functions.sh
+
+if [ "$1" = reboot ]; then
+	einfo "Rebooting system"
+	exec /sbin/reboot -dkn
+elif [ "$INIT_HALT" = HALT ]; then
+	einfo "Halting system"
+	exec /sbin/halt -dhn
+else
+	einfo "Powering off system"
+	exec /sbin/poweroff -dhn
+fi

--- a/sys-apps/sysvinit/files/inittab-2.95
+++ b/sys-apps/sysvinit/files/inittab-2.95
@@ -1,0 +1,61 @@
+#
+# /etc/inittab:  This file describes how the INIT process should set up
+#                the system in a certain run-level.
+#
+# Author:  Miquel van Smoorenburg, <miquels@cistron.nl>
+# Modified by:  Patrick J. Volkerding, <volkerdi@ftp.cdrom.com>
+# Modified by:  Daniel Robbins, <drobbins@gentoo.org>
+# Modified by:  Martin Schlemmer, <azarah@gentoo.org>
+# Modified by:  Mike Frysinger, <vapier@gentoo.org>
+# Modified by:  Robin H. Johnson, <robbat2@gentoo.org>
+# Modified by:  William Hubbs, <williamh@gentoo.org>
+#
+
+# Default runlevel.
+id:3:initdefault:
+
+# System initialization, mount local filesystems, etc.
+si::sysinit:/sbin/openrc sysinit
+
+# Further system initialization, brings up the boot runlevel.
+rc::bootwait:/sbin/openrc boot
+
+l0u:0:wait:/sbin/telinit u
+l0:0:wait:/sbin/openrc shutdown
+l0s:0:wait:/sbin/halt.sh
+l1:1:wait:/sbin/openrc single
+l2:2:wait:/sbin/openrc nonetwork
+l3:3:wait:/sbin/openrc default
+l4:4:wait:/sbin/openrc default
+l5:5:wait:/sbin/openrc default
+l6u:6:wait:/sbin/telinit u
+l6:6:wait:/sbin/openrc reboot
+l6r:6:wait:/sbin/halt.sh reboot
+#z6:6:respawn:/sbin/sulogin
+
+# new-style single-user
+su0:S:wait:/sbin/openrc single
+su1:S:wait:/sbin/sulogin
+
+# TERMINALS
+#x1:12345:respawn:/sbin/agetty 38400 console linux
+c1:12345:respawn:/sbin/agetty 38400 tty1 linux
+c2:2345:respawn:/sbin/agetty 38400 tty2 linux
+c3:2345:respawn:/sbin/agetty 38400 tty3 linux
+c4:2345:respawn:/sbin/agetty 38400 tty4 linux
+c5:2345:respawn:/sbin/agetty 38400 tty5 linux
+c6:2345:respawn:/sbin/agetty 38400 tty6 linux
+
+# SERIAL CONSOLES
+#s0:12345:respawn:/sbin/agetty -L 9600 ttyS0 vt100
+#s1:12345:respawn:/sbin/agetty -L 9600 ttyS1 vt100
+
+# What to do at the "Three Finger Salute".
+ca:12345:ctrlaltdel:/sbin/shutdown -r now
+
+# Used by /etc/init.d/xdm to control DM startup.
+# Read the comments in /etc/init.d/xdm for more
+# info. Do NOT remove, as this will start nothing
+# extra at boot if /etc/init.d/xdm is not added
+# to the "default" runlevel.
+x:a:once:/etc/X11/startDM.sh

--- a/sys-apps/sysvinit/sysvinit-2.95-r1.ebuild
+++ b/sys-apps/sysvinit/sysvinit-2.95-r1.ebuild
@@ -1,0 +1,140 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs flag-o-matic
+
+DESCRIPTION="/sbin/init - parent of all processes"
+HOMEPAGE="https://savannah.nongnu.org/projects/sysvinit"
+SRC_URI="mirror://nongnu/${PN}/${P/_/-}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+[[ "${PV}" == *beta* ]] || \
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86"
+IUSE="selinux ibm static kernel_FreeBSD"
+
+CDEPEND="
+	selinux? (
+		>=sys-libs/libselinux-1.28
+	)"
+DEPEND="${CDEPEND}
+	virtual/os-headers"
+RDEPEND="${CDEPEND}
+	sys-apps/gentoo-functions
+	selinux? ( sec-policy/selinux-shutdown )
+	!<sys-apps/openrc-0.13
+"
+
+S="${WORKDIR}/${P/_*}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.86-kexec.patch" #80220
+	"${FILESDIR}/${PN}-2.94_beta-shutdown-single.patch" #158615
+	"${FILESDIR}/${PN}-2.95_beta-shutdown-h.patch" #449354
+)
+
+src_prepare() {
+	default
+
+	sed -i \
+		-e '/^CPPFLAGS =$/d' \
+		-e '/^override CFLAGS +=/s/ -fstack-protector-strong//' \
+		src/Makefile || die
+
+	# last/lastb/mesg/mountpoint/sulogin/utmpdump/wall have moved to util-linux
+	sed -i -r \
+		-e '/^(USR)?S?BIN/s:\<(last|lastb|mesg|mountpoint|sulogin|utmpdump|wall)\>::g' \
+		-e '/^MAN[18]/s:\<(last|lastb|mesg|mountpoint|sulogin|utmpdump|wall)[.][18]\>::g' \
+		src/Makefile || die
+
+	# pidof has moved to >=procps-3.3.9
+	sed -i -r \
+		-e '/\/bin\/pidof/d' \
+		-e '/^MAN8/s:\<pidof.8\>::g' \
+		src/Makefile || die
+
+	# logsave is already in e2fsprogs
+	sed -i -r \
+		-e '/^(USR)?S?BIN/s:\<logsave\>::g' \
+		-e '/^MAN8/s:\<logsave.8\>::g' \
+		src/Makefile || die
+
+	# Mung inittab for specific architectures
+	cd "${WORKDIR}" || die
+	cp "${FILESDIR}"/inittab-2.95 inittab || die "cp inittab"
+	local insert=()
+	use ppc && insert=( '#psc0:12345:respawn:/sbin/agetty 115200 ttyPSC0 linux' )
+	use arm && insert=( '#f0:12345:respawn:/sbin/agetty 9600 ttyFB0 vt100' )
+	use arm64 && insert=( 'f0:12345:respawn:/sbin/agetty 9600 ttyAMA0 vt100' )
+	use hppa && insert=( 'b0:12345:respawn:/sbin/agetty 9600 ttyB0 vt100' )
+	use s390 && insert=( 's0:12345:respawn:/sbin/agetty 38400 console dumb' )
+	if use ibm ; then
+		insert+=(
+			'#hvc0:2345:respawn:/sbin/agetty -L 9600 hvc0'
+			'#hvsi:2345:respawn:/sbin/agetty -L 19200 hvsi0'
+		)
+	fi
+	(use arm || use mips || use sh || use sparc) && sed -i '/ttyS0/s:#::' inittab
+	if use kernel_FreeBSD ; then
+		sed -i \
+			-e 's/linux/cons25/g' \
+			-e 's/ttyS0/cuaa0/g' \
+			-e 's/ttyS1/cuaa1/g' \
+			inittab #121786
+	fi
+	if use x86 || use amd64 ; then
+		sed -i \
+			-e '/ttyS[01]/s:9600:115200:' \
+			inittab
+	fi
+	if [[ ${#insert[@]} -gt 0 ]] ; then
+		printf '%s\n' '' '# Architecture specific features' "${insert[@]}" >> inittab
+	fi
+}
+
+src_compile() {
+	tc-export CC
+	append-lfs-flags
+	export DISTRO= #381311
+	export VERSION="${PV}"
+	use static && append-ldflags -static
+	emake -C src $(usex selinux 'WITH_SELINUX=yes' '')
+}
+
+src_install() {
+	emake -C src install ROOT="${D}"
+	dodoc README doc/*
+
+	insinto /etc
+	doins "${WORKDIR}"/inittab
+
+	# dead symlink
+	rm "${ED}"/usr/bin/lastb || die
+
+	newinitd "${FILESDIR}"/bootlogd.initd bootlogd
+	into /
+	dosbin "${FILESDIR}"/halt.sh
+}
+
+pkg_postinst() {
+	# Reload init to fix unmounting problems of / on next reboot.
+	# This is really needed, as without the new version of init cause init
+	# not to quit properly on reboot, and causes a fsck of / on next reboot.
+	if [[ ${ROOT} == / ]] ; then
+		if [[ -e /dev/initctl && ! -e /run/initctl ]]; then
+			ln -s /dev/initctl /run/initctl
+		fi
+		# Do not return an error if this fails
+		/sbin/telinit U &>/dev/null
+	fi
+
+	elog "The last/lastb/mesg/mountpoint/sulogin/utmpdump/wall tools have been moved to"
+	elog "sys-apps/util-linux. The pidof tool has been moved to sys-process/procps."
+
+	# Required for new bootlogd service
+	if [[ ! -e "${EROOT}/var/log/boot" ]] ; then
+		touch "${EROOT}/var/log/boot"
+	fi
+}


### PR DESCRIPTION
This script looks at the INIT_HALT environment variable and calls either
halt or poweroff.

Support for calling reboot is also present, along with a friendly einfo
message.

Package-Manager: Portage-2.3.71, Repoman-2.3.16_p24
Signed-off-by: Mike Gilbert <floppym@gentoo.org>