### PR TITLE
dev-lisp/roswell: fix fill collision with libroutersos

### DIFF
--- a/dev-lisp/roswell/roswell-19.3.10.97.ebuild
+++ b/dev-lisp/roswell/roswell-19.3.10.97.ebuild
@@ -14,6 +14,8 @@ LICENSE="MIT"
 
 KEYWORDS="~amd64 ~x86"
 
+RDEPEND="!net-libs/librouteros"
+
 src_prepare() {
 	default
 	eautoreconf


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/691754
Signed-off-by: YUE Daian <sheepduke@gmail.com>