### PR TITLE
sys-process/lsof: update HOMEPAGE, metadata

### DIFF
--- a/sys-process/lsof/lsof-4.91.ebuild
+++ b/sys-process/lsof/lsof-4.91.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ inherit flag-o-matic toolchain-funcs
 
 MY_P="${P/-/_}"
 DESCRIPTION="Lists open files for running Unix processes"
-HOMEPAGE="ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/"
+HOMEPAGE="https://github.com/lsof-org/lsof"
 SRC_URI="ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/${MY_P}.tar.bz2
 	ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/OLD/${MY_P}.tar.bz2
 	http://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/${MY_P}.tar.bz2"

--- a/sys-process/lsof/metadata.xml
+++ b/sys-process/lsof/metadata.xml
@@ -10,5 +10,6 @@
 </use>
 <upstream>
 	<remote-id type="cpe">cpe:/a:lsof_project:lsof</remote-id>
+	<remote-id type="github">lsof-org/lsof</remote-id>
 </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/653828
Signed-off-by: Wim Muskee <wimmuskee@gmail.com>

Although the bugreport says all the SRC_URI's do not work, the mirrorservice.org url actually works. So imo the bug can be closed after accepting this PR.