### PR TITLE
add version to dev-lang/rust libressl dependency

### DIFF
--- a/dev-lang/rust/rust-1.34.2.ebuild
+++ b/dev-lang/rust/rust-1.34.2.ebuild
@@ -57,7 +57,7 @@ LLVM_MAX_SLOT=8
 COMMON_DEPEND="
 	sys-libs/zlib
 	!libressl? ( dev-libs/openssl:0= )
-	libressl? ( dev-libs/libressl:0= )
+	libressl? ( <dev-libs/libressl-3.0.0:0= )
 	net-libs/libssh2
 	net-libs/http-parser:=
 	net-misc/curl[ssl]

--- a/dev-lang/rust/rust-1.35.0.ebuild
+++ b/dev-lang/rust/rust-1.35.0.ebuild
@@ -58,7 +58,7 @@ LLVM_MAX_SLOT=8
 COMMON_DEPEND="
 	sys-libs/zlib
 	!libressl? ( dev-libs/openssl:0= )
-	libressl? ( dev-libs/libressl:0= )
+	libressl? ( <dev-libs/libressl-3.0.0:0= )
 	net-libs/libssh2
 	net-libs/http-parser:=
 	net-misc/curl[ssl]

--- a/dev-lang/rust/rust-1.36.0.ebuild
+++ b/dev-lang/rust/rust-1.36.0.ebuild
@@ -58,7 +58,7 @@ LLVM_MAX_SLOT=8
 COMMON_DEPEND="
 	sys-libs/zlib
 	!libressl? ( dev-libs/openssl:0= )
-	libressl? ( dev-libs/libressl:0= )
+	libressl? ( <dev-libs/libressl-3.0.0:0= )
 	net-libs/libssh2
 	net-libs/http-parser:=
 	net-misc/curl[ssl]


### PR DESCRIPTION
It won't build with libressl3