### PR TITLE
app-office/gnumeric: Improve Python support

### DIFF
--- a/app-office/gnumeric/gnumeric-1.12.43.ebuild
+++ b/app-office/gnumeric/gnumeric-1.12.43.ebuild
@@ -16,7 +16,9 @@ KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
 
 IUSE="+introspection libgda perl python"
 # python-loader plugin is python2.7 only
-REQUIRED_USE="python? ( $(python_gen_useflags -2) )"
+REQUIRED_USE="
+	introspection? ( ${PYTHON_REQUIRED_USE} )
+	python? ( || ( $(python_gen_useflags -2) ) )"
 
 # Missing gnome-extra/libgnomedb required version in tree
 # but its upstream is dead and will be dropped soon.
@@ -37,9 +39,10 @@ RDEPEND="
 	>=x11-libs/gtk+-3.8.7:3
 	x11-libs/cairo:=[svg]
 
-	introspection? ( >=dev-libs/gobject-introspection-1:= )
+	introspection? ( ${PYTHON_DEPS}
+	>=dev-libs/gobject-introspection-1:= )
 	perl? ( dev-lang/perl:= )
-	python? ( ${PYTHON_DEPS}
+	python? ( $(python_gen_impl_dep '' -2)
 		>=dev-python/pygobject-3:3[${PYTHON_USEDEP}] )
 	libgda? ( gnome-extra/libgda:5[gtk] )
 "
@@ -59,7 +62,7 @@ src_prepare() {
 
 src_configure() {
 	if use python ; then
-		python_setup 'python2*'
+		python_setup -2
 	fi
 	gnome2_src_configure \
 		--disable-static \
@@ -72,6 +75,8 @@ src_configure() {
 
 src_install() {
 	gnome2_src_install
-	python_moduleinto gi.overrides
-	python_foreach_impl python_domodule introspection/gi/overrides/Gnm.py
+	if use introspection; then
+		python_moduleinto gi.overrides
+		python_foreach_impl python_domodule introspection/gi/overrides/Gnm.py
+	fi
 }

--- a/app-office/gnumeric/gnumeric-1.12.44.ebuild
+++ b/app-office/gnumeric/gnumeric-1.12.44.ebuild
@@ -16,7 +16,9 @@ KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
 
 IUSE="+introspection libgda perl python"
 # python-loader plugin is python2.7 only
-REQUIRED_USE="python? ( $(python_gen_useflags -2) )"
+REQUIRED_USE="
+	introspection? ( ${PYTHON_REQUIRED_USE} )
+	python? ( || ( $(python_gen_useflags -2) ) )"
 
 # Missing gnome-extra/libgnomedb required version in tree
 # but its upstream is dead and will be dropped soon.
@@ -37,9 +39,10 @@ RDEPEND="
 	>=x11-libs/gtk+-3.8.7:3
 	x11-libs/cairo:=[svg]
 
-	introspection? ( >=dev-libs/gobject-introspection-1:= )
+	introspection? ( ${PYTHON_DEPS}
+	>=dev-libs/gobject-introspection-1:= )
 	perl? ( dev-lang/perl:= )
-	python? ( ${PYTHON_DEPS}
+	python? ( $(python_gen_impl_dep '' -2)
 		>=dev-python/pygobject-3:3[${PYTHON_USEDEP}] )
 	libgda? ( gnome-extra/libgda:5[gtk] )
 "
@@ -59,7 +62,7 @@ src_prepare() {
 
 src_configure() {
 	if use python ; then
-		python_setup 'python2*'
+		python_setup -2
 	fi
 	gnome2_src_configure \
 		--disable-static \
@@ -72,6 +75,8 @@ src_configure() {
 
 src_install() {
 	gnome2_src_install
-	python_moduleinto gi.overrides
-	python_foreach_impl python_domodule introspection/gi/overrides/Gnm.py
+	if use introspection; then
+		python_moduleinto gi.overrides
+		python_foreach_impl python_domodule introspection/gi/overrides/Gnm.py
+	fi
 }


### PR DESCRIPTION
Add missing PYTHON_REQUIRED_USE and PYTHON_DEPS for gi.overrides
install.  While at it, make it conditional to USE=introspection.
Reduce deps for USE=python to Python 2 variants.

Closes: https://bugs.gentoo.org/690552
Signed-off-by: Michał Górny <mgorny@gentoo.org>