### PR TITLE
dev-lang/php: Do not depend on <www-servers/apache-2.4 anymore

### DIFF
--- a/dev-lang/php/php-5.6.40-r4.ebuild
+++ b/dev-lang/php/php-5.6.40-r4.ebuild
@@ -50,8 +50,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre-8.32[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1
 					sys-libs/db:4.8

--- a/dev-lang/php/php-5.6.40-r5.ebuild
+++ b/dev-lang/php/php-5.6.40-r5.ebuild
@@ -50,8 +50,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre-8.32[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1
 					sys-libs/db:4.8

--- a/dev-lang/php/php-7.1.30.ebuild
+++ b/dev-lang/php/php-7.1.30.ebuild
@@ -47,8 +47,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre-8.32[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1
 					sys-libs/db:4.8

--- a/dev-lang/php/php-7.1.31.ebuild
+++ b/dev-lang/php/php-7.1.31.ebuild
@@ -47,8 +47,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre-8.32[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1
 					sys-libs/db:4.8

--- a/dev-lang/php/php-7.2.20.ebuild
+++ b/dev-lang/php/php-7.2.20.ebuild
@@ -47,8 +47,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre-8.32[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	argon2? ( app-crypt/argon2:= )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1

--- a/dev-lang/php/php-7.2.21.ebuild
+++ b/dev-lang/php/php-7.2.21.ebuild
@@ -47,8 +47,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre-8.32[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	argon2? ( app-crypt/argon2:= )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1

--- a/dev-lang/php/php-7.3.7-r1.ebuild
+++ b/dev-lang/php/php-7.3.7-r1.ebuild
@@ -50,8 +50,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre2-10.30[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	argon2? ( app-crypt/argon2:= )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1

--- a/dev-lang/php/php-7.3.8.ebuild
+++ b/dev-lang/php/php-7.3.8.ebuild
@@ -50,8 +50,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre2-10.30[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	argon2? ( app-crypt/argon2:= )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1

--- a/dev-lang/php/php-7.4.0_beta1.ebuild
+++ b/dev-lang/php/php-7.4.0_beta1.ebuild
@@ -52,8 +52,7 @@ COMMON_DEPEND="
 	>=app-eselect/eselect-php-0.9.1[apache2?,fpm?]
 	>=dev-libs/libpcre2-10.30[unicode]
 	fpm? ( acl? ( sys-apps/acl ) )
-	apache2? ( || ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=]
-		<www-servers/apache-2.4[threads=] ) )
+	apache2? ( >=www-servers/apache-2.4[apache2_modules_unixd,threads=] )
 	argon2? ( app-crypt/argon2:= )
 	berkdb? ( || (	sys-libs/db:5.3
 					sys-libs/db:5.1


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/692090
Package-Manager: Portage-2.3.71, Repoman-2.3.17
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>