### PR TITLE
app-emulation/spice-vdagent: add missing x11-libs/libdrm dependency

### DIFF
--- a/app-emulation/spice-vdagent/spice-vdagent-0.19.0.ebuild
+++ b/app-emulation/spice-vdagent/spice-vdagent-0.19.0.ebuild
@@ -22,6 +22,7 @@ CDEPEND="
 	>=app-emulation/spice-protocol-0.14.0
 	media-libs/alsa-lib
 	>=x11-libs/libpciaccess-0.10
+	x11-libs/libdrm
 	x11-libs/libXfixes
 	x11-libs/libXrandr
 	x11-libs/libX11


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>
Closes: https://bugs.gentoo.org/692094