### PR TITLE
proxy-maint: maintainer email change

### DIFF
--- a/dev-util/codeblocks/metadata.xml
+++ b/dev-util/codeblocks/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <maintainer type="person">
-    <email>torokhov_s_a@mail.ru</email>
+    <email>torokhov-s-a@yandex.ru</email>
     <name>Sergey Torokhov</name>
   </maintainer>
   <maintainer type="project">

--- a/sci-libs/cantera/metadata.xml
+++ b/sci-libs/cantera/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <maintainer type="person">
-    <email>torokhov_s_a@mail.ru</email>
+    <email>torokhov-s-a@yandex.ru</email>
     <name>Sergey Torokhov</name>
   </maintainer>
   <maintainer type="project">


### PR DESCRIPTION
Change maintainer email of `dev-util/codeblocks` and `sci-libs/cantera` packages.

Bug: https://bugs.gentoo.org/672596

@leio or @mgorny 
could you review this pull request?