### PR TITLE
profiles/package.mask: mask dev-java/smack

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -29,6 +29,32 @@
 
 #--- END OF EXAMPLES ---
 
+# Aaron Bauman <bman@gentoo.org> (2019-08-14)
+# longstanding sec vulns, unpatched, not maintained
+# bug #509354, #519216, #603440
+# list includes rdeps. Removal in 30 days.
+dev-java/smack
+dev-java/netbeans-ide
+dev-java/netbeans-apisupport
+dev-java/netbeans-cnd
+dev-java/netbeans-dlight
+dev-java/netbeans-enterprise
+dev-java/netbeans-enterprise
+dev-java/netbeans-ergonomics
+dev-java/netbeans-extide
+dev-java/netbeans-groovy
+dev-java/netbeans-java
+dev-java/netbeans-java
+dev-java/netbeans-javacard
+dev-java/netbeans-javafx
+dev-java/netbeans-mobility
+dev-java/netbeans-nb
+dev-java/netbeans-php
+dev-java/netbeans-profiler
+dev-java/netbeans-webcommon
+dev-java/netbeans-websvccommon
+dev-util/netbeans
+
 # Mike Gilbert <floppym@gentoo.org> (2019-08-13)
 # Dev channel releases are only for people who
 # are developers or want more experimental features


### PR DESCRIPTION
* Package has longstanding vulnerabilities
* Unmaintained in Gentoo

Bug: https://bugs.gentoo.org/509354
Bug: https://bugs.gentoo.org/519216
Bug: https://bugs.gentoo.org/603440

Signed-off-by: Aaron Bauman <bman@gentoo.org>