### PR TITLE
WIP: ppc64le profile love

### DIFF
--- a/profiles/arch/powerpc/ppc64/64le/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/64le/package.use.mask
@@ -1,0 +1,6 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2019-08-14)
+# works on ppc64le
+media-libs/mesa -llvm

--- a/profiles/arch/powerpc/ppc64/64le/use.mask
+++ b/profiles/arch/powerpc/ppc64/64le/use.mask
@@ -8,3 +8,7 @@ big-endian
 # Chris Gianelloni <wolf31o2@gentoo.org> (2008-02-13)
 # Mask multilib, since we cannot use it.
 multilib
+
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2019-08-14)
+# # works on ppc64le
+-video_cards_amdgpu

--- a/profiles/arch/powerpc/ppc64/64le/use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/64le/use.stable.mask
@@ -1,0 +1,6 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2019-08-14)
+# works on ppc64le, but not yet stable
+video_cards_amdgpu

--- a/profiles/arch/powerpc/ppc64/package.mask
+++ b/profiles/arch/powerpc/ppc64/package.mask
@@ -1,5 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2019-08-14)
+# buggy on big-endian
+x11-drivers/xf86-video-amdgpu
 
 # Arfrever Frehtes Taifersar Arahesis <arfrever.fta@gmail.com> (2018-02-21)
 # Mozc supports only little-endian architectures.

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-19.0.1.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-19.0.1.ebuild
@@ -8,7 +8,7 @@ inherit xorg-3
 if [[ ${PV} == 9999* ]]; then
 	SRC_URI=""
 else
-	KEYWORDS="amd64 x86"
+	KEYWORDS="amd64 ~ppc64 x86"
 fi
 
 DESCRIPTION="Accelerated Open Source driver for AMDGPU cards"

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
@@ -8,7 +8,7 @@ inherit xorg-3
 if [[ ${PV} == 9999* ]]; then
 	SRC_URI=""
 else
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~ppc64 ~x86"
 fi
 
 DESCRIPTION="Accelerated Open Source driver for AMDGPU cards"


### PR DESCRIPTION
@mattst88 as promised, starting with amdgpu keywording and unmasks for LE.
it's known to be quite broken on BE.

tested on talos II with Vega64 and 7100WX and works great.