### PR TITLE
www-client/firefox-bin: Fix QA Notice

### DIFF
--- a/www-client/firefox-bin/firefox-bin-68.0.2.ebuild
+++ b/www-client/firefox-bin/firefox-bin-68.0.2.ebuild
@@ -105,11 +105,6 @@ src_install() {
 	sed -i -e "s:@NAME@:${name}:" -e "s:@ICON@:${icon}:" \
 		"${ED}usr/share/applications/${PN}.desktop" || die
 
-	# Add StartupNotify=true bug 237317
-	if use startup-notification; then
-		echo "StartupNotify=true" >> "${ED}"usr/share/applications/${PN}.desktop
-	fi
-
 	# Install firefox in /opt
 	dodir ${MOZILLA_FIVE_HOME%/*}
 	mv "${S}" "${ED}"${MOZILLA_FIVE_HOME} || die


### PR DESCRIPTION
The deleted lines were introduced to fix bug [237317](https://bugs.gentoo.org/237317). At least for firefox-bin 68.0.2, the `StartupNotify` key is alread in the desktop file, resulting in the following QA Notice `/usr/share/applications/firefox-bin.desktop: error: file contains multiple keys named "StartupNotify" in group "Desktop Entry"`. This is fixed by removing the appropriate lines in the ebuild.

