### PR TITLE
media-libs/libepoxy: Don't build tests unless USE=test is enabled

### DIFF
--- a/media-libs/libepoxy/libepoxy-1.5.3-r1.ebuild
+++ b/media-libs/libepoxy/libepoxy-1.5.3-r1.ebuild
@@ -43,6 +43,7 @@ multilib_src_configure() {
 		-Degl=$(usex egl)
 		-Dglx=$(usex X)
 		-Dx11=$(usex X true false)
+		-Dtests=$(usex test true false)
 	)
 	meson_src_configure
 }

--- a/media-libs/libepoxy/libepoxy-9999.ebuild
+++ b/media-libs/libepoxy/libepoxy-9999.ebuild
@@ -43,6 +43,7 @@ multilib_src_configure() {
 		-Degl=$(usex egl)
 		-Dglx=$(usex X)
 		-Dx11=$(usex X true false)
+		-Dtests=$(usex test true false)
 	)
 	meson_src_configure
 }


### PR DESCRIPTION
They actually fail to build on my ARM system but that's another story.

Package-Manager: Portage-2.3.71, Repoman-2.3.17
Signed-off-by: James Le Cuirot <chewi@gentoo.org>