### PR TITLE
x11-base/xorg-server: Now needs mesa[X] introduced in mesa-9999

### DIFF
--- a/x11-base/xorg-server/xorg-server-1.20.5.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.20.5.ebuild
@@ -68,7 +68,7 @@ CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	!minimal? (
 		>=x11-libs/libX11-1.1.5
 		>=x11-libs/libXext-1.0.5
-		>=media-libs/mesa-18
+		>=media-libs/mesa-18[X(+)]
 	)
 	udev? ( virtual/libudev:= )
 	unwind? ( sys-libs/libunwind )

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -67,7 +67,7 @@ CDEPEND=">=app-eselect/eselect-opengl-1.3.0
 	!minimal? (
 		>=x11-libs/libX11-1.1.5
 		>=x11-libs/libXext-1.0.5
-		>=media-libs/mesa-18
+		>=media-libs/mesa-18[X(+)]
 	)
 	udev? ( virtual/libudev:= )
 	unwind? ( sys-libs/libunwind )


### PR DESCRIPTION
Otherwise pkg-config fails to find the "gl" module.

Package-Manager: Portage-2.3.71, Repoman-2.3.17
Signed-off-by: James Le Cuirot <chewi@gentoo.org>