### PR TITLE
net-dns/dnsmasq: don't define PATCHES twice

### DIFF
--- a/net-dns/dnsmasq/dnsmasq-2.80-r1.ebuild
+++ b/net-dns/dnsmasq/dnsmasq-2.80-r1.ebuild
@@ -16,10 +16,6 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~spa
 IUSE="auth-dns conntrack dbus +dhcp dhcp-tools dnssec +dumpfile id idn libidn2"
 IUSE+=" +inotify ipv6 lua nls script selinux static tftp"
 
-PATCHES=(
-	"${FILESDIR}/${P}-nettle-3.5.patch"
-)
-
 DM_LINGUAS=(de es fi fr id it no pl pt_BR ro)
 
 BDEPEND="app-arch/xz-utils
@@ -58,7 +54,8 @@ REQUIRED_USE="dhcp-tools? ( dhcp )
 	libidn2? ( idn )"
 
 PATCHES=(
-	"${FILESDIR}/dnsmasq-2.80-linux-headers-5.2.patch"
+	"${FILESDIR}/${P}-linux-headers-5.2.patch"
+	"${FILESDIR}/${P}-nettle-3.5.patch"
 )
 
 use_have() {


### PR DESCRIPTION
Since last commit, PATCHES has been definde twice, which results, that
the nettle patch isn't applied anymore and compilation can fail.

Package-Manager: Portage-2.3.71, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>