### PR TITLE
dev-libs/leveldb: patch 1.20 for cross-compilation to ARM

### DIFF
--- a/dev-libs/leveldb/files/leveldb-1.20-sse-detect.patch
+++ b/dev-libs/leveldb/files/leveldb-1.20-sse-detect.patch
@@ -1,0 +1,16 @@
+Some non-x86 compilers accept -msse4.2 as a flag but ignore it (because it
+doesn't make sense for non-x86 machines), then fail when encountering any of
+the relevant intrinsics. Include an intrinsic in the probe for support.
+
+--- a/build_detect_platform
++++ b/build_detect_platform
+@@ -225,7 +225,7 @@ EOF
+ 
+     # Test if gcc SSE 4.2 is supported
+     $CXX $CXXFLAGS -x c++ - -o $CXXOUTPUT -msse4.2 2>/dev/null  <<EOF
+-      int main() {}
++      int main() { __builtin_ia32_crc32qi(0, 0); }
+ EOF
+     if [ "$?" = 0 ]; then
+         PLATFORM_SSEFLAGS="-msse4.2"
+

--- a/dev-libs/leveldb/leveldb-1.20.ebuild
+++ b/dev-libs/leveldb/leveldb-1.20.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="snappy? ( !static-libs )"
 
 # https://github.com/google/leveldb/issues/234
 # https://github.com/google/leveldb/issues/236
-PATCHES=( "${FILESDIR}"/{${PN}-1.18-configure.patch,${P}-memenv-so.patch} )
+PATCHES=( "${FILESDIR}"/{${PN}-1.18-configure.patch,${P}-memenv-so.patch,${P}-sse-detect.patch} )
 
 src_configure() {
 	# These vars all get picked up by build_detect_platform


### PR DESCRIPTION
We see cross-compilation failures for ARM in Chromium OS; this patch
makes the detection of SSE4.2 more robust so it doesn't incorrectly
think it's supported on ARM.

Upstream leveldb no longer uses this build system, so it's not
applicable upstream.

Signed-off-by: Peter Marheine <pmarheine@chromium.org>