### PR TITLE
net-misc/ntpclient: fix compilation with >=linux-headers-5.2

### DIFF
--- a/net-misc/ntpclient/files/ntpclient-2018.244-linux-headers-5.2.patch
+++ b/net-misc/ntpclient/files/ntpclient-2018.244-linux-headers-5.2.patch
@@ -1,0 +1,10 @@
+--- a/src/ntpclient.c	2018-08-27 20:38:12.000000000 +0200
++++ b/src/ntpclient.c	2019-08-19 20:11:59.000000000 +0200
+@@ -40,6 +40,7 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #ifdef PRECISION_SIOCGSTAMP
++#include <linux/sockios.h>
+ #include <sys/ioctl.h>
+ #endif
+ #ifdef USE_OBSOLETE_GETTIMEOFDAY

--- a/net-misc/ntpclient/ntpclient-2018.244-r1.ebuild
+++ b/net-misc/ntpclient/ntpclient-2018.244-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MY_PV="${PV/./_}"
+MY_P="${PN}-${MY_PV}"
+
+DESCRIPTION="A NTP (RFC-1305 and RFC-4330) client for unix-alike systems"
+HOMEPAGE="https://github.com/troglobit/ntpclient"
+SRC_URI="https://github.com/troglobit/${PN}/releases/download/${MY_PV}/${MY_P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="debug embedded obsolete +syslog"
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-linux-headers-5.2.patch"
+)
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable debug)
+		$(use_enable debug replay)
+		$(use_enable embedded mini)
+		$(use_enable obsolete)
+		$(use_enable !obsolete siocgstamp)
+		$(use_enable syslog)
+	)
+
+	econf "${myeconfargs[@]}"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/692544
Package-Manager: Portage-2.3.71, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>