### PR TITLE
net-misc/ipv6calc: update HOMEPAGE, SRC_URI, metadata

### DIFF
--- a/net-misc/ipv6calc/ipv6calc-1.0.0.ebuild
+++ b/net-misc/ipv6calc/ipv6calc-1.0.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
 
 DESCRIPTION="IPv6 address calculator"
-HOMEPAGE="http://www.deepspace6.net/projects/ipv6calc.html"
-SRC_URI="ftp://ftp.bieringer.de/pub/linux/IPv6/ipv6calc/${P}.tar.gz"
+HOMEPAGE="https://www.deepspace6.net/projects/ipv6calc.html"
+SRC_URI="https://github.com/pbiering/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/ipv6calc/ipv6calc-2.1.0.ebuild
+++ b/net-misc/ipv6calc/ipv6calc-2.1.0.ebuild
@@ -4,7 +4,7 @@
 EAPI="7"
 
 DESCRIPTION="IPv6 address calculator"
-HOMEPAGE="http://www.deepspace6.net/projects/ipv6calc.html"
+HOMEPAGE="https://www.deepspace6.net/projects/ipv6calc.html"
 SRC_URI="https://github.com/pbiering/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-misc/ipv6calc/metadata.xml
+++ b/net-misc/ipv6calc/metadata.xml
@@ -5,4 +5,7 @@
 		<email>blueness@gentoo.org</email>
 		<name>Anthony G. Basile</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">pbiering/ipv6calc</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/680174
Signed-off-by: Wim Muskee <wimmuskee@gmail.com>

I compared the checksums for the GH 1.0.0 download and the existing one; they are the same.