### PR TITLE
dev-libs/libofx: fix RDEPEND on libxmlpp

### DIFF
--- a/dev-libs/libofx/files/libofx-0.9.14-0001-Makefile.am-remove-INSTALL-from-docs.patch
+++ b/dev-libs/libofx/files/libofx-0.9.14-0001-Makefile.am-remove-INSTALL-from-docs.patch
@@ -1,0 +1,28 @@
+From a8f965718de5c046fa64344b6bae521cbd5a6a20 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl@gmail.com>
+Date: Wed, 21 Aug 2019 10:50:46 +0200
+Subject: [PATCH] Makefile.am: remove INSTALL from docs
+
+Gentoo specific: Remove the missing INSTALL file from Makefile.am
+This could have been copied by eautoreconf, but unfortunately isn't.
+
+Signed-off-by: Bernd Waibel <waebbl@gmail.com>
+---
+ Makefile.am | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 3a83560..fd81144 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -11,7 +11,6 @@ docdir = $(datadir)/doc/libofx
+ doc_DATA = \
+   AUTHORS \
+   COPYING \
+-  INSTALL \
+   NEWS \
+   README \
+   ChangeLog \
+-- 
+2.22.0
+

--- a/dev-libs/libofx/libofx-0.9.14-r1.ebuild
+++ b/dev-libs/libofx/libofx-0.9.14-r1.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="A library to support the Open Financial eXchange XML format"
+HOMEPAGE="https://github.com/libofx/libofx"
+SRC_URI="https://github.com/${PN}/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0/7"
+KEYWORDS="~amd64 ~hppa ~x86"
+IUSE="static-libs test"
+
+RDEPEND="
+	>=dev-cpp/libxmlpp-2.40.1:2.6
+	>=net-misc/curl-7.9.7
+	virtual/libiconv
+"
+DEPEND="
+	${RDEPEND}
+	>app-text/opensp-1.5
+"
+BDEPEND="
+	dev-util/gengetopt
+	sys-apps/help2man
+	virtual/pkgconfig
+	test? ( app-crypt/gnupg )
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-0001-Makefile.am-remove-INSTALL-from-docs.patch"
+)
+
+# workaround needed for ofxconnect to compile
+MAKEOPTS="-j1"
+
+src_prepare() {
+	default
+	eautoreconf
+
+	# we will tell you where we wants the docs!
+	sed -i -e 's:docdir.*::' Makefile.am || die
+
+	# configure arguments alone don't disable everything
+	sed -e "/^SUBDIRS/s/doc//" -i Makefile.am || die
+
+	append-cxxflags -std=c++14
+}
+
+src_configure() {
+	econf --docdir=/usr/share/doc/${PF}
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+	if ! use static-libs; then
+		find "${D}" -type f -name '*.a' -delete || die
+	fi
+}


### PR DESCRIPTION
	* Moves dependency on dev-cpp/libxmlpp:2.6 from DEPEND to RDEPEND
	* Add BDEPEND
	* Remove 'touch INSTALL' in src_prepare and patch Makefile.am instead
	* Don't install static lib if USE flag is not set
	* Adds patch from Alexandre Ferreira on b.g.o to install DTD correctly

Thanks to Alexandre Ferreira for the fix on DTD and DCL files.

Suggested-by: Alexandre Ferreira <alexandref75@gmail.com>
Closes: https://bugs.gentoo.org/692658
Closes: https://bugs.gentoo.org/692664
Package-Manager: Portage-2.3.72, Repoman-2.3.17
Signed-off-by: Bernd Waibel <waebbl@gmail.com>