### PR TITLE
app-cdr/xfburn: fix deps for newer xfce-base/libxfce4ui

### DIFF
--- a/app-cdr/xfburn/xfburn-0.5.5-r1.ebuild
+++ b/app-cdr/xfburn/xfburn-0.5.5-r1.ebuild
@@ -19,7 +19,7 @@ RDEPEND=">=dev-libs/glib-2.32:=
 	>=dev-libs/libisofs-0.6.2:=
 	>=x11-libs/gtk+-2.24:2=
 	<xfce-base/exo-0.12.5-r100:=
-	>=xfce-base/libxfce4ui-4.10:=
+	>=xfce-base/libxfce4ui-4.10:=[gtk2(+)]
 	gstreamer? (
 		media-libs/gstreamer:1.0=
 		media-libs/gst-plugins-base:1.0= )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/692838
Package-Manager: Portage-2.3.73, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>