### PR TITLE
mail-client/trojita: Fix USE=addressbook vs USE=abook vs USE=kde

### DIFF
--- a/mail-client/trojita/metadata.xml
+++ b/mail-client/trojita/metadata.xml
@@ -14,7 +14,7 @@
 		<name>Gentoo KDE Project</name>
 	</maintainer>
 	<use>
-		<flag name="addressbook">Build <pkg>kde-apps/akonadi</pkg> addressbook plugin</flag>
+		<flag name="kde">Build <pkg>kde-apps/akonadi</pkg> addressbook plugin</flag>
 		<flag name="password">Store passwords securely via <pkg>dev-libs/qtkeychain</pkg></flag>
 	</use>
 	<upstream>

--- a/mail-client/trojita/trojita-9999.ebuild
+++ b/mail-client/trojita/trojita-9999.ebuild
@@ -58,7 +58,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DWITH_ABOOKADDRESSBOOK_PLUGIN=OFF
+		-DWITH_ABOOKADDRESSBOOK_PLUGIN=ON
 		-DWITH_AKONADIADDRESSBOOK_PLUGIN=$(usex addressbook)
 		-DWITH_CRYPTO_MESSAGES=$(usex crypt)
 		-DWITH_GPGMEPP=$(usex crypt)

--- a/mail-client/trojita/trojita-9999.ebuild
+++ b/mail-client/trojita/trojita-9999.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="http://trojita.flaska.net/"
 
 LICENSE="|| ( GPL-2 GPL-3 )"
 SLOT="0"
-IUSE="addressbook +crypt +dbus debug +password +spell test +zlib"
+IUSE="+crypt +dbus debug kde +password +spell test +zlib"
 
 REQUIRED_USE="password? ( dbus )"
 
@@ -34,12 +34,12 @@ DEPEND="
 	dev-qt/qtsvg:5
 	dev-qt/qtwebkit:5
 	dev-qt/qtwidgets:5
-	addressbook? ( kde-apps/akonadi-contacts:5 )
 	crypt? (
 		>=app-crypt/gpgme-1.8.0[cxx,qt5]
 		dev-libs/mimetic
 	)
 	dbus? ( dev-qt/qtdbus:5 )
+	kde? ( kde-apps/akonadi-contacts:5 )
 	password? ( dev-libs/qtkeychain[qt5(+)] )
 	spell? ( kde-frameworks/sonnet:5 )
 	zlib? ( sys-libs/zlib )
@@ -59,7 +59,7 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DWITH_ABOOKADDRESSBOOK_PLUGIN=ON
-		-DWITH_AKONADIADDRESSBOOK_PLUGIN=$(usex addressbook)
+		-DWITH_AKONADIADDRESSBOOK_PLUGIN=$(usex kde)
 		-DWITH_CRYPTO_MESSAGES=$(usex crypt)
 		-DWITH_GPGMEPP=$(usex crypt)
 		-DWITH_MIMETIC=$(usex crypt)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/692214
Cc: @a17r 

## Unconditionally enable the abook plugin
    
Trojita supports different implementations of an "address book" via plugins that are loaded at runtime. Only one plugin can be active at a time, but any number of them can be built and installed. The user can pick and select an appropriate plugin via a GUI configuration.

There is no need to disable the "abook" plugin, and upstream expects this plugin to be always available. There are no external dependencies, and the `abook` binary is not used.
    
Fixes: e0e382d4f9341

## USE=kde for Akonadi address book
    
Because Trojita supports more plugins for managing contacts (see previous commit for details), activating an Akonadi-specific plugin via a pretty generic USE flag is a bit confusing. I do not think that there is a lot of people using Akonadi outside of KDE+Plasma, so let's call this USE flag "KDE" instead of "addressbook".