### PR TITLE
net-irc/quassel: Drop QtScript dependency

### DIFF
--- a/net-irc/quassel/quassel-9999.ebuild
+++ b/net-irc/quassel/quassel-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,7 +23,6 @@ IUSE="bundled-icons crypt +dbus debug kde ldap monolithic oxygen postgres +serve
 snorenotify +ssl syslog urlpreview X"
 
 SERVER_RDEPEND="
-	dev-qt/qtscript:5
 	crypt? ( app-crypt/qca:2[qt5(+),ssl] )
 	ldap? ( net-nds/openldap )
 	postgres? ( dev-qt/qtsql:5[postgres] )


### PR DESCRIPTION
Upstream dropped the QtScript dependency for the master branch,
so remove it from the live ebuild as well.

Package-Manager: Portage-2.3.72, Repoman-2.3.17
Signed-off-by: Manuel Nickschas <sputnick@quassel-irc.org>