### PR TITLE
lxde-base/lxlauncher: EAPI 7 bump

### DIFF
--- a/lxde-base/lxlauncher/lxlauncher-0.2.5.ebuild
+++ b/lxde-base/lxlauncher/lxlauncher-0.2.5.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=7
 
 DESCRIPTION="An open source clone of the Asus launcher for EeePC"
 HOMEPAGE="https://wiki.lxde.org/en/LXLauncher"
@@ -20,10 +20,6 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	dev-util/intltool
 	sys-devel/gettext
-	lxde-base/menu-cache
-	!lxde-base/lxlauncher-gmenu"
+	lxde-base/menu-cache"
 
-src_install() {
-	emake DESTDIR="${D}" install
-	dodoc AUTHORS ChangeLog README
-}
+DOCS=( AUTHORS ChangeLog README )


### PR DESCRIPTION
Also removed blocking of non-existing package lxde-base/lxlauncher-gmenu

Package-Manager: Portage-2.3.69, Repoman-2.3.16