### PR TITLE
lxqt-base/lxqt-meta: keyword 0.14.1-r1 for ppc64, bug #689606

### DIFF
--- a/dev-libs/libqtxdg/libqtxdg-3.3.1.ebuild
+++ b/dev-libs/libqtxdg/libqtxdg-3.3.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+ Nokia-Qt-LGPL-Exception-1.1"

--- a/kde-frameworks/kwayland/kwayland-5.60.0.ebuild
+++ b/kde-frameworks/kwayland/kwayland-5.60.0.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Qt-style client and server library wrapper for Wayland libraries"
 HOMEPAGE="https://cgit.kde.org/kwayland.git"
 
 LICENSE="LGPL-2.1"
-KEYWORDS="amd64 ~arm arm64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
 IUSE=""
 
 DEPEND="

--- a/kde-frameworks/solid/solid-5.60.0.ebuild
+++ b/kde-frameworks/solid/solid-5.60.0.ebuild
@@ -8,7 +8,7 @@ inherit kde5
 
 DESCRIPTION="Provider for platform independent hardware discovery, abstraction and management"
 LICENSE="LGPL-2.1+"
-KEYWORDS="amd64 ~arm arm64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
 IUSE="nls"
 
 BDEPEND="

--- a/kde-plasma/libkscreen/libkscreen-5.16.4.ebuild
+++ b/kde-plasma/libkscreen/libkscreen-5.16.4.ebuild
@@ -10,7 +10,7 @@ inherit kde5
 
 DESCRIPTION="Plasma screen management library"
 SLOT="5/7"
-KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 IUSE=""
 
 DEPEND="

--- a/lxde-base/lxmenu-data/lxmenu-data-0.1.5.ebuild
+++ b/lxde-base/lxmenu-data/lxmenu-data-0.1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,7 +9,7 @@ SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 ppc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=""

--- a/lxqt-base/liblxqt/liblxqt-0.14.1.ebuild
+++ b/lxqt-base/liblxqt/liblxqt-0.14.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+ BSD"

--- a/lxqt-base/lxqt-about/lxqt-about-0.14.1.ebuild
+++ b/lxqt-base/lxqt-about/lxqt-about-0.14.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"

--- a/lxqt-base/lxqt-config/lxqt-config-0.14.1.ebuild
+++ b/lxqt-base/lxqt-config/lxqt-config-0.14.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="GPL-2 GPL-2+ GPL-3 LGPL-2 LGPL-2+ LGPL-2.1+ WTFPL-2"

--- a/lxqt-base/lxqt-globalkeys/lxqt-globalkeys-0.14.1.ebuild
+++ b/lxqt-base/lxqt-globalkeys/lxqt-globalkeys-0.14.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"

--- a/lxqt-base/lxqt-meta/lxqt-meta-0.14.1-r1.ebuild
+++ b/lxqt-base/lxqt-meta/lxqt-meta-0.14.1-r1.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="Meta ebuild for LXQt, the Lightweight Desktop Environment"
 HOMEPAGE="https://lxqt.org/"
 
 if [[ ${PV} != *9999* ]]; then
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="metapackage"

--- a/lxqt-base/lxqt-notificationd/lxqt-notificationd-0.14.1.ebuild
+++ b/lxqt-base/lxqt-notificationd/lxqt-notificationd-0.14.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"

--- a/lxqt-base/lxqt-openssh-askpass/lxqt-openssh-askpass-0.14.1.ebuild
+++ b/lxqt-base/lxqt-openssh-askpass/lxqt-openssh-askpass-0.14.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"

--- a/lxqt-base/lxqt-panel/lxqt-panel-0.14.1.ebuild
+++ b/lxqt-base/lxqt-panel/lxqt-panel-0.14.1.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"

--- a/lxqt-base/lxqt-policykit/lxqt-policykit-0.14.1.ebuild
+++ b/lxqt-base/lxqt-policykit/lxqt-policykit-0.14.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"

--- a/lxqt-base/lxqt-qtplugin/lxqt-qtplugin-0.14.0.ebuild
+++ b/lxqt-base/lxqt-qtplugin/lxqt-qtplugin-0.14.0.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"

--- a/lxqt-base/lxqt-runner/lxqt-runner-0.14.1.ebuild
+++ b/lxqt-base/lxqt-runner/lxqt-runner-0.14.1.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"

--- a/lxqt-base/lxqt-session/lxqt-session-0.14.1.ebuild
+++ b/lxqt-base/lxqt-session/lxqt-session-0.14.1.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 IUSE="+themes +udev"

--- a/media-gfx/lximage-qt/lximage-qt-0.14.1-r1.ebuild
+++ b/media-gfx/lximage-qt/lximage-qt-0.14.1-r1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="GPL-2+ LGPL-2.1+"

--- a/x11-misc/obconf-qt/obconf-qt-0.14.1.ebuild
+++ b/x11-misc/obconf-qt/obconf-qt-0.14.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="GPL-2+"

--- a/x11-misc/sddm/sddm-0.18.1-r1.ebuild
+++ b/x11-misc/sddm/sddm-0.18.1-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${PV}/${P}.tar.xz"
 
 LICENSE="GPL-2+ MIT CC-BY-3.0 CC-BY-SA-3.0 public-domain"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
 IUSE="consolekit elogind +pam systemd test"
 
 REQUIRED_USE="?? ( elogind systemd )"

--- a/x11-themes/lxqt-themes/lxqt-themes-0.14.0.ebuild
+++ b/x11-themes/lxqt-themes/lxqt-themes-0.14.0.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
 else
 	SRC_URI="https://downloads.lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 fi
 
 LICENSE="LGPL-2.1+"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/689606

Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Erhard Furtner <erhard_f@mailbox.org>