### PR TITLE
net-p2p/ktorrent: add ~arm64 keyword

### DIFF
--- a/net-p2p/ktorrent/ktorrent-5.1.2-r1.ebuild
+++ b/net-p2p/ktorrent/ktorrent-5.1.2-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://kde.org/applications/internet/ktorrent/"
 [[ ${KDE_BUILD_TYPE} = release ]] && SRC_URI="mirror://kde/stable/${PN}/${PV/%.0}/${P}.tar.xz"
 
 LICENSE="GPL-2"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+bwscheduler +downloadorder +infowidget +ipfilter +kross +logviewer +magnetgenerator
 +mediaplayer rss +scanfolder +search +shutdown +stats +upnp +zeroconf"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/693586

Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Andrius Štikonas <andrius@stikonas.eu>