### PR TITLE
games-fps/freedoom-data: Set DOOMWADPATH in freedoom launch script

### DIFF
--- a/games-fps/freedm-data/files/freedm-data-0.11.3-Set-DOOMWADPATH.patch
+++ b/games-fps/freedm-data/files/freedm-data-0.11.3-Set-DOOMWADPATH.patch
@@ -1,0 +1,38 @@
+From 19b8fe33843b1e431fb0737a57087f58c168952c Mon Sep 17 00:00:00 2001
+From: William Breathitt Gray <vilhelm.gray@gmail.com>
+Date: Fri, 6 Sep 2019 16:20:49 +0900
+Subject: [PATCH] dist/freedoom: Set DOOMWADPATH with sensible default value if
+ unset
+
+Engines such as Odamex may not have a default search path and simply
+search for freedoom1.wad relative to the current directory. This can
+cause an unexpected WAD file not found error when executing the freedoom
+script.
+
+This issue is mitigated by setting a default DOOMWADPATH environment
+variable with sensible search paths, if it is not already set. All
+engines listed in the PORTS variable support the DOOMWADPATH environment
+variable, which makes it a simple and convenient way of helping prevent
+this error.
+---
+ dist/freedoom | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/dist/freedoom b/dist/freedoom
+index 62e3c4d5..0c0961a5 100755
+--- a/dist/freedoom
++++ b/dist/freedoom
+@@ -31,6 +31,10 @@ case "$(basename "$0")" in
+         ;;
+ esac
+ 
++if [ -z "$DOOMWADPATH" ]; then
++    export DOOMWADPATH="/usr/share/doom:/usr/share/games/doom:/usr/local/share/doom:/usr/local/share/games/doom"
++fi
++
+ if [ -z "$PORT" ] && [ -h "$HOME"/.doomport ]; then
+     if [ -f "$(readlink -f "$HOME"/.doomport)" ] \
+         && [ -x "$(readlink -f "$HOME"/.doomport)" ]; then
+-- 
+2.23.0
+

--- a/games-fps/freedm-data/freedm-data-0.11.3-r2.ebuild
+++ b/games-fps/freedm-data/freedm-data-0.11.3-r2.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+
+inherit prefix python-any-r1 xdg
+
+DESCRIPTION="Game resources for FreeDM"
+HOMEPAGE="https://freedoom.github.io"
+SRC_URI="https://github.com/freedoom/freedoom/archive/v${PV}.tar.gz -> freedoom-${PV}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+BDEPEND="
+	$(python_gen_any_dep 'dev-python/pillow[${PYTHON_USEDEP}]')
+	app-text/asciidoc
+	games-util/deutex
+	virtual/imagemagick-tools[png]"
+
+S="${WORKDIR}/freedoom-${PV}"
+
+PATCHES="${FILESDIR}/${P}-Set-DOOMWADPATH.patch"
+
+DOOMWADPATH=share/doom
+
+python_check_deps() {
+	has_version -b "dev-python/pillow[${PYTHON_USEDEP}]"
+}
+
+src_prepare() {
+	# This is to enable usage of the 'PS' coder, which is
+	# disabled by default (https://bugs.gentoo.org/664236)
+	install -D -t ~/.config/ImageMagick "${FILESDIR}"/ImageMagick/policy.xml || die
+
+	xdg_src_prepare
+	eapply_user
+
+	hprefixify dist/freedoom
+}
+
+src_compile() {
+	emake wads/freedm.wad
+}
+
+src_install() {
+	emake install-freedm \
+		prefix="${ED}/usr/" \
+		bindir="bin/" \
+		mandir="share/man/" \
+		waddir="${DOOMWADPATH}/"
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	elog "FreeDM WAD file installed into ${EPREFIX}/usr/${DOOMWADPATH} directory."
+}

--- a/games-fps/freedoom-data/files/freedoom-data-0.11.3-Set-DOOMWADPATH.patch
+++ b/games-fps/freedoom-data/files/freedoom-data-0.11.3-Set-DOOMWADPATH.patch
@@ -1,0 +1,38 @@
+From 19b8fe33843b1e431fb0737a57087f58c168952c Mon Sep 17 00:00:00 2001
+From: William Breathitt Gray <vilhelm.gray@gmail.com>
+Date: Fri, 6 Sep 2019 16:20:49 +0900
+Subject: [PATCH] dist/freedoom: Set DOOMWADPATH with sensible default value if
+ unset
+
+Engines such as Odamex may not have a default search path and simply
+search for freedoom1.wad relative to the current directory. This can
+cause an unexpected WAD file not found error when executing the freedoom
+script.
+
+This issue is mitigated by setting a default DOOMWADPATH environment
+variable with sensible search paths, if it is not already set. All
+engines listed in the PORTS variable support the DOOMWADPATH environment
+variable, which makes it a simple and convenient way of helping prevent
+this error.
+---
+ dist/freedoom | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/dist/freedoom b/dist/freedoom
+index 62e3c4d5..0c0961a5 100755
+--- a/dist/freedoom
++++ b/dist/freedoom
+@@ -31,6 +31,10 @@ case "$(basename "$0")" in
+         ;;
+ esac
+ 
++if [ -z "$DOOMWADPATH" ]; then
++    export DOOMWADPATH="/usr/share/doom:/usr/share/games/doom:/usr/local/share/doom:/usr/local/share/games/doom"
++fi
++
+ if [ -z "$PORT" ] && [ -h "$HOME"/.doomport ]; then
+     if [ -f "$(readlink -f "$HOME"/.doomport)" ] \
+         && [ -x "$(readlink -f "$HOME"/.doomport)" ]; then
+-- 
+2.23.0
+

--- a/games-fps/freedoom-data/freedoom-data-0.11.3-r2.ebuild
+++ b/games-fps/freedoom-data/freedoom-data-0.11.3-r2.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+
+inherit prefix python-any-r1 xdg
+
+DESCRIPTION="Game resources for Freedoom: Phase 1+2"
+HOMEPAGE="https://freedoom.github.io"
+SRC_URI="https://github.com/freedoom/freedoom/archive/v${PV}.tar.gz -> freedoom-${PV}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+BDEPEND="
+	$(python_gen_any_dep 'dev-python/pillow[${PYTHON_USEDEP}]')
+	app-text/asciidoc
+	games-util/deutex
+	virtual/imagemagick-tools[png]"
+
+S="${WORKDIR}/freedoom-${PV}"
+
+PATCHES="${FILESDIR}/${P}-Set-DOOMWADPATH.patch"
+
+DOOMWADPATH=share/doom
+
+python_check_deps() {
+	has_version -b "dev-python/pillow[${PYTHON_USEDEP}]"
+}
+
+src_prepare() {
+	# This is to enable usage of the 'PS' coder, which is
+	# disabled by default (https://bugs.gentoo.org/664236)
+	install -D -t ~/.config/ImageMagick "${FILESDIR}"/ImageMagick/policy.xml || die
+
+	xdg_src_prepare
+	eapply_user
+
+	hprefixify dist/freedoom
+}
+
+src_compile() {
+	emake wads/freedoom{1,2}.wad
+}
+
+src_install() {
+	emake install-freedoom{1,2} \
+		prefix="${ED}/usr/" \
+		bindir="bin/" \
+		mandir="share/man/" \
+		waddir="${DOOMWADPATH}/"
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	elog "Freedoom WAD files installed into ${EPREFIX}/usr/${DOOMWADPATH} directory."
+}


### PR DESCRIPTION
Engines such as Odamex may not have a default search path and simply
search for freedoom1.wad relative to the current directory. This can
cause an unexpected WAD file not found error when executing the freedoom
script.

This issue is mitigated by setting a default DOOMWADPATH environment
variable with sensible search paths, if it is not already set. All
engines listed in the PORTS variable support the DOOMWADPATH environment
variable, which makes it a simple and convenient way of helping prevent
this error.