### PR TITLE
media-plugins/kodi-pvr-vdr-vnsi: replace unused kodi-platform dependency

### DIFF
--- a/media-plugins/kodi-pvr-vdr-vnsi/kodi-pvr-vdr-vnsi-3.6.3-r1.ebuild
+++ b/media-plugins/kodi-pvr-vdr-vnsi/kodi-pvr-vdr-vnsi-3.6.3-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils kodi-addon
+
+DESCRIPTION="Kodi PVR addon VNSI"
+HOMEPAGE="https://github.com/kodi-pvr/pvr.vdr.vnsi"
+SRC_URI=""
+
+case ${PV} in
+9999)
+	SRC_URI=""
+	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.vdr.vnsi.git"
+	inherit git-r3
+	;;
+*)
+	KEYWORDS="~amd64 ~x86"
+	CODENAME="Leia"
+	SRC_URI="https://github.com/kodi-pvr/pvr.vdr.vnsi/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/pvr.vdr.vnsi-${PV}-${CODENAME}"
+	;;
+esac
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+DEPEND="
+	dev-libs/libplatform
+	=media-tv/kodi-18*
+	virtual/opengl
+	"
+
+RDEPEND="
+	${DEPEND}
+	"
+
+src_prepare() {
+	# remove check for unused media-libs/kodi-platform
+	sed -i "/kodiplatform/d" CMakeLists.txt || die
+	cmake-utils_src_prepare
+}


### PR DESCRIPTION
Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

Backport of upstream patch for Matrix:
https://github.com/kodi-pvr/pvr.vdr.vnsi/commit/d8af242ba923590330c65fded9034c1ac9b6157c

I think it is worthwhile to get rid of a dependency on media-libs/kodi-platform. Also was hiding the need for dev-libs/libplatform.

EAPI 7 works fine for me too.

```diff
--- kodi-pvr-vdr-vnsi-3.6.3.ebuild
+++ kodi-pvr-vdr-vnsi-3.6.3-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit cmake-utils kodi-addon
 
@@ -28,11 +28,17 @@
 IUSE=""
 
 DEPEND="
+	dev-libs/libplatform
 	=media-tv/kodi-18*
-	=media-libs/kodi-platform-18*
 	virtual/opengl
 	"
 
 RDEPEND="
 	${DEPEND}
 	"
+
+src_prepare() {
+	# remove check for unused media-libs/kodi-platform
+	sed -i "/kodiplatform/d" CMakeLists.txt || die
+	cmake-utils_src_prepare
+}
```