### PR TITLE
dev-lua/luv: Fix lack of dev-lang/lua in DEPEND

### DIFF
--- a/dev-lua/luv/luv-1.30.1_p0.ebuild
+++ b/dev-lua/luv/luv-1.30.1_p0.ebuild
@@ -23,14 +23,12 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="luajit test"
 
-BDEPEND="
-	virtual/pkgconfig
-	test? (
-		luajit? ( dev-lang/luajit:2 )
-		!luajit? ( dev-lang/lua:0 )
-	)
+BDEPEND="virtual/pkgconfig"
+DEPEND="
+	dev-libs/libuv:=
+	luajit? ( dev-lang/luajit:2 )
+	!luajit? ( dev-lang/lua:0 )
 "
-DEPEND="dev-libs/libuv:="
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${MY_P}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/693614
Package-Manager: Portage-2.3.75, Repoman-2.3.17
Signed-off-by: Bernardo Meurer <bernardo@standard.ai>