### PR TITLE
games-engines/odamex: Call setup-wxwidgets

### DIFF
--- a/games-engines/odamex/odamex-0.8.1.ebuild
+++ b/games-engines/odamex/odamex-0.8.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-WX_GTK_VER="3.0"
+WX_GTK_VER="3.0-gtk3"
 inherit cmake-utils desktop wxwidgets xdg
 
 DESCRIPTION="Online multiplayer free software engine for DOOM"
@@ -39,6 +39,9 @@ PATCHES=(
 
 src_prepare() {
 	rm -r libraries/libminiupnpc odamex.wad || die
+
+	setup-wxwidgets
+
 	cmake-utils_src_prepare
 }
 


### PR DESCRIPTION
The wxwidgets eclass requires setup-wxwidgets to be called to set up the
environment for wxGTK. In addition, WX_GTK_VER is updated to select the
3.0-gtk3 slot.

Package-Manager: Portage-2.3.73, Repoman-2.3.17
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>