### PR TITLE
net-firewall/nftables: Fix permissions for rules.save

### DIFF
--- a/net-firewall/nftables/files/libexec/nftables-mk.sh
+++ b/net-firewall/nftables/files/libexec/nftables-mk.sh
@@ -24,7 +24,7 @@ main() {
 		;;
 		"store")
 			local tmp_save="${NFTABLES_SAVE}.tmp"
-			umask 600;
+			umask 177
 			(
 				printf '#!/sbin/nft -f\nflush ruleset\n'
 				nft ${SAVE_OPTIONS} list ruleset

--- a/net-firewall/nftables/files/libexec/nftables.sh
+++ b/net-firewall/nftables/files/libexec/nftables.sh
@@ -25,6 +25,7 @@ main() {
             retval=$?
         ;;
         "store")
+            umask 177
             local tmp_save="${NFTABLES_SAVE}.tmp"
             if ! use_legacy; then
                 nft ${SAVE_OPTIONS} list ruleset > ${tmp_save}

--- a/net-firewall/nftables/nftables-0.9.0-r5.ebuild
+++ b/net-firewall/nftables/nftables-0.9.0-r5.ebuild
@@ -1,0 +1,103 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools linux-info systemd
+
+DESCRIPTION="Linux kernel (3.13+) firewall, NAT and packet mangling tools"
+HOMEPAGE="https://netfilter.org/projects/nftables/"
+SRC_URI="https://git.netfilter.org/nftables/snapshot/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86"
+IUSE="debug doc +gmp json +modern_kernel +readline"
+
+RDEPEND=">=net-libs/libmnl-1.0.3:0=
+	gmp? ( dev-libs/gmp:0= )
+	json? ( dev-libs/jansson )
+	readline? ( sys-libs/readline:0= )
+	>=net-libs/libnftnl-1.1.1:0="
+
+DEPEND="${RDEPEND}
+	>=app-text/docbook2X-0.8.8-r4
+	doc? ( >=app-text/dblatex-0.3.7 )
+	sys-devel/bison
+	sys-devel/flex
+	virtual/pkgconfig"
+
+S="${WORKDIR}/v${PV}"
+
+pkg_setup() {
+	if kernel_is ge 3 13; then
+		if use modern_kernel && kernel_is lt 3 18; then
+			eerror "The modern_kernel USE flag requires kernel version 3.18 or newer to work properly."
+		fi
+		CONFIG_CHECK="~NF_TABLES"
+		linux-info_pkg_setup
+	else
+		eerror "This package requires kernel version 3.13 or newer to work properly."
+	fi
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--sbindir="${EPREFIX}"/sbin
+		$(use_enable debug)
+		$(use_enable doc pdf-doc)
+		$(use_with !gmp mini_gmp)
+		$(use_with json)
+		$(use_with readline cli)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	local mksuffix=""
+	use modern_kernel && mksuffix="-mk"
+
+	exeinto /usr/libexec/${PN}
+	newexe "${FILESDIR}"/libexec/${PN}${mksuffix}.sh ${PN}.sh
+	newconfd "${FILESDIR}"/${PN}${mksuffix}.confd ${PN}
+	newinitd "${FILESDIR}"/${PN}${mksuffix}.init ${PN}
+	keepdir /var/lib/nftables
+
+	systemd_dounit "${FILESDIR}"/systemd/${PN}-restore.service
+
+	docinto /usr/share/doc/${PF}/skels
+	dodoc "${D}"/etc/nftables/*
+	rm -R "${D}"/etc/nftables
+}
+
+pkg_postinst() {
+	local save_file
+	save_file="${EROOT%/}/var/lib/nftables/rules-save"
+
+	# In order for the nftables-restore systemd service to start
+	# the save_file must exist.
+	if [[ ! -f "${save_file}" ]]; then
+		touch "${save_file}"
+	elif [[ $(( "$( stat --printf '%05a' "${save_file}" )" & 07177 )) -ne 0 ]]; then
+		ewarn "Your system has dangerous permissions for ${save_file}"
+		ewarn "It is probably affected by bug #691326."
+		ewarn "You may need to fix the permissions of the file. To do so,"
+		ewarn "you can run the command in the line below as root."
+		ewarn "    'chmod 600 \"${save_file}\"'"
+	fi
+
+	elog "If you wish to enable the firewall rules on boot (on systemd) you"
+	elog "will need to enable the nftables-restore service."
+	elog "    'systemd_enable_service basic.target ${PN}-restore.service'"
+	elog
+	elog "If you are creating firewall rules before the next system restart "
+	elog "the nftables-restore service must be manually started in order to "
+	elog "save those rules on shutdown."
+}

--- a/net-firewall/nftables/nftables-0.9.1-r1.ebuild
+++ b/net-firewall/nftables/nftables-0.9.1-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://netfilter.org/projects/nftables/files/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86"
 IUSE="debug +doc +gmp json +modern_kernel python +readline static-libs xtables"
 
 RDEPEND="
@@ -23,7 +23,7 @@ RDEPEND="
 	json? ( dev-libs/jansson )
 	python? ( ${PYTHON_DEPS} )
 	readline? ( sys-libs/readline:0= )
-	>=net-libs/libnftnl-1.1.4:0=
+	>=net-libs/libnftnl-1.1.3:0=
 	xtables? ( >=net-firewall/iptables-1.6.1 )
 "
 
@@ -40,6 +40,11 @@ BDEPEND="
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 #S="${WORKDIR}/v${PV}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-python_build.patch
+	"${FILESDIR}"/${P}-avoid_dive_into_py_subdir.patch
+)
 
 python_make() {
 	emake \
@@ -124,8 +129,14 @@ pkg_postinst() {
 
 	# In order for the nftables-restore systemd service to start
 	# the save_file must exist.
-	if [[ ! -f ${save_file} ]]; then
-		touch ${save_file}
+	if [[ ! -f "${save_file}" ]]; then
+		touch "${save_file}"
+	elif [[ $(( "$( stat --printf '%05a' "${save_file}" )" & 07177 )) -ne 0 ]]; then
+		ewarn "Your system has dangerous permissions for ${save_file}"
+		ewarn "It is probably affected by bug #691326."
+		ewarn "You may need to fix the permissions of the file. To do so,"
+		ewarn "you can run the command in the line below as root."
+		ewarn "    'chmod 600 \"${save_file}\"'"
 	fi
 
 	elog "If you wish to enable the firewall rules on boot (on systemd) you"

--- a/net-firewall/nftables/nftables-0.9.2-r1.ebuild
+++ b/net-firewall/nftables/nftables-0.9.2-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://netfilter.org/projects/nftables/files/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~sparc ~x86"
 IUSE="debug +doc +gmp json +modern_kernel python +readline static-libs xtables"
 
 RDEPEND="
@@ -23,7 +23,7 @@ RDEPEND="
 	json? ( dev-libs/jansson )
 	python? ( ${PYTHON_DEPS} )
 	readline? ( sys-libs/readline:0= )
-	>=net-libs/libnftnl-1.1.3:0=
+	>=net-libs/libnftnl-1.1.4:0=
 	xtables? ( >=net-firewall/iptables-1.6.1 )
 "
 
@@ -40,11 +40,6 @@ BDEPEND="
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 #S="${WORKDIR}/v${PV}"
-
-PATCHES=(
-	"${FILESDIR}"/${P}-python_build.patch
-	"${FILESDIR}"/${P}-avoid_dive_into_py_subdir.patch
-)
 
 python_make() {
 	emake \
@@ -129,8 +124,14 @@ pkg_postinst() {
 
 	# In order for the nftables-restore systemd service to start
 	# the save_file must exist.
-	if [[ ! -f ${save_file} ]]; then
-		touch ${save_file}
+	if [[ ! -f "${save_file}" ]]; then
+		touch "${save_file}"
+	elif [[ $(( "$( stat --printf '%05a' "${save_file}" )" & 07177 )) -ne 0 ]]; then
+		ewarn "Your system has dangerous permissions for ${save_file}"
+		ewarn "It is probably affected by bug #691326."
+		ewarn "You may need to fix the permissions of the file. To do so,"
+		ewarn "you can run the command in the line below as root."
+		ewarn "    'chmod 600 \"${save_file}\"'"
 	fi
 
 	elog "If you wish to enable the firewall rules on boot (on systemd) you"


### PR DESCRIPTION
Due to a bug, the rules.save file was created with the wrong
permissions which allowed all users to read the file with the
system rules although root privileges are usually required to
do so.

To fix this issue, the following measures have been taken:
* The umask on nftables-mk.sh is now correctly set to 177
* nftables.sh now also sets the umask before saving the rules
* The ebuilds will warn on post installation if the rules.save
  has insecure permissions
* The ebuilds have been bumped to ensure these changes are
  applied

Closes: https://bugs.gentoo.org/691326
Bug: https://bugs.gentoo.org/691326
Signed-off-by: Francisco Blas Izquierdo Riera (klondike) <klondike@gentoo.org>
Package-Manager: Portage-2.3.69, Repoman-2.3.11