### PR TITLE
media-gfx/qimgv: change exif flag to exiv2 flag

### DIFF
--- a/media-gfx/qimgv/qimgv-0.8.2-r1.ebuild
+++ b/media-gfx/qimgv/qimgv-0.8.2-r1.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 	media-video/mpv[libmpv]
-	exif? ( media-libs/libexif )
+	exif? ( media-gfx/exiv2:0 )
 	kde? ( kde-frameworks/kwindowsystem:5 )
 "
 RDEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/693920