### PR TITLE
net-misc/curl: conditionally enable alt-svc support

### DIFF
--- a/net-misc/curl/curl-7.66.0.ebuild
+++ b/net-misc/curl/curl-7.66.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://curl.haxx.se/download/${P}.tar.xz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="adns brotli http2 idn ipv6 kerberos ldap metalink +progress-meter rtmp samba ssh ssl static-libs test threads"
+IUSE="adns alt-svc brotli http2 idn ipv6 kerberos ldap metalink +progress-meter rtmp samba ssh ssl static-libs test threads"
 IUSE+=" curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
 IUSE+=" elibc_Winnt"
 
@@ -153,7 +153,7 @@ multilib_src_configure() {
 
 	ECONF_SOURCE="${S}" \
 	econf \
-		--disable-alt-svc \
+		$(use_enable alt-svc) \
 		--enable-crypto-auth \
 		--enable-dict \
 		--enable-file \

--- a/net-misc/curl/metadata.xml
+++ b/net-misc/curl/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Anthony G. Basile</name>
 	</maintainer>
 	<use>
+		<flag name="alt-svc">Enable alt-svc support</flag>
 		<flag name="brotli">Enable brotli compression support</flag>
 		<flag name="http2">Enabled HTTP/2.0 support</flag>
 		<flag name="ssh">Enabled SSH urls in curl using libssh2</flag>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694312
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>