### PR TITLE
net-misc/curl: No automagic dependencies on quiche, nghttp3, ngtcp2

### DIFF
--- a/net-misc/curl/curl-7.66.0.ebuild
+++ b/net-misc/curl/curl-7.66.0.ebuild
@@ -201,6 +201,9 @@ multilib_src_configure() {
 		$(use_with kerberos gssapi "${EPREFIX}"/usr) \
 		$(use_with metalink libmetalink) \
 		$(use_with http2 nghttp2) \
+		--without-nghttp3 \
+		--without-ngtcp2 \
+		--without-quiche \
 		$(use_with rtmp librtmp) \
 		$(use_with brotli) \
 		--without-schannel \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694316
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>