### PR TITLE
net-misc/curl: HTTP/3 support

### DIFF
--- a/net-misc/curl/curl-7.66.0.ebuild
+++ b/net-misc/curl/curl-7.66.0.ebuild
@@ -14,6 +14,7 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="adns alt-svc brotli http2 idn ipv6 kerberos ldap metalink +progress-meter rtmp samba ssh ssl static-libs test threads"
 IUSE+=" curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
+IUSE+=" nghttp3 quiche"
 IUSE+=" elibc_Winnt"
 
 #lead to lots of false negatives, bug #285669
@@ -43,6 +44,11 @@ RDEPEND="ldap? ( net-nds/openldap[${MULTILIB_USEDEP}] )
 		)
 	)
 	http2? ( net-libs/nghttp2[${MULTILIB_USEDEP}] )
+	nghttp3? (
+		net-libs/nghttp3[${MULTILIB_USEDEP}]
+		net-libs/ngtcp2[ssl,${MULTILIB_USEDEP}]
+	)
+	quiche? ( net-libs/quiche[${MULTILIB_USEDEP}] )
 	idn? ( net-dns/libidn2:0=[static-libs?,${MULTILIB_USEDEP}] )
 	adns? ( net-dns/c-ares:0[${MULTILIB_USEDEP}] )
 	kerberos? ( >=virtual/krb5-0-r1[${MULTILIB_USEDEP}] )
@@ -201,9 +207,9 @@ multilib_src_configure() {
 		$(use_with kerberos gssapi "${EPREFIX}"/usr) \
 		$(use_with metalink libmetalink) \
 		$(use_with http2 nghttp2) \
-		--without-nghttp3 \
-		--without-ngtcp2 \
-		--without-quiche \
+		$(use_with nghttp3) \
+		$(use_with nghttp3 ngtcp2) \
+		$(use_with quiche) \
 		$(use_with rtmp librtmp) \
 		$(use_with brotli) \
 		--without-schannel \
@@ -229,6 +235,14 @@ multilib_src_configure() {
 	if use http2; then
 		libs+=( "-lnghttp2" )
 		priv+=( "libnghttp2" )
+	fi
+	if use quiche; then
+		libs+=( "-lquiche" )
+		priv+=( "libquiche" )
+	fi
+	if use nghttp3; then
+		libs+=( "-lnghttp3" "-lngtcp2" )
+		priv+=( "libnghttp3" "-libtcp2" )
 	fi
 	if use ssl && use curl_ssl_openssl; then
 		libs+=( "-lssl" "-lcrypto" )

--- a/net-misc/curl/metadata.xml
+++ b/net-misc/curl/metadata.xml
@@ -8,8 +8,10 @@
 	<use>
 		<flag name="alt-svc">Enable alt-svc support</flag>
 		<flag name="brotli">Enable brotli compression support</flag>
-		<flag name="http2">Enabled HTTP/2.0 support</flag>
-		<flag name="ssh">Enabled SSH urls in curl using libssh2</flag>
+		<flag name="http2">Enable HTTP/2.0 support</flag>
+		<flag name="nghttp3">Enable HTTP/3.0 support using <pkg>net-libs/nghttp3</pkg> and <pkg>net-libs/ngtcp2</pkg></flag>
+		<flag name="quiche">Enable HTTP/3.0 support using <pkg>net-libs/quiche</pkg></flag>
+		<flag name="ssh">Enable SSH urls in curl using libssh2</flag>
 		<flag name="metalink">Enable metalink support</flag>
 		<flag name="progress-meter">Enable the progress meter</flag>
 		<flag name="ssl">Enable crypto engine support (via openssl if USE='-gnutls -nss')</flag>

--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Craig Andrews <candrews@gentoo.org> (2019-10-08)
+# net-misc/quiche is available on this arch
+net-misc/curl -quiche
+
 # Luke Dashjr <luke-jr+gentoobugs@utopios.org> (2019-09-21)
 # iasl is stable on amd64
 sys-firmware/seabios -debug

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,16 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Craig Andrews <candrews@gentoo.org> (2019-10-08)
+# net-libs/quiche is not available on all arches
+# Track addition arch keywording of quiche at:
+# https://bugs.gentoo.org/694320
+net-misc/curl quiche
+
+# Craig Andrews <candrews@gentoo.org> (2019-10-08)
+# net-libs/nghttp3 net-libs/ngtcp2[ssl] are not available on all arches
+net-misc/curl nghttp3
+
 # Nick Sarnie <sarnex@gentoo.org> (2019-10-14)
 # No longer updated or supported by the Wine project
 # wine-d3d9 superceeded by nine-standalone

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -34,6 +34,7 @@ app-i18n/xcin unicode
 # OpenSSL (as of version 1.1.1) doesn't have APIs for QUIC support
 # see https://github.com/openssl/openssl/pull/8797
 net-libs/ngtcp2 ssl
+net-libs/curl nghttp3
 
 # Michał Górny <mgorny@gentoo.org> (2019-09-08)
 # LLVM 5 is being removed.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694308
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>