### PR TITLE
Inline & remove mirror://alsaproject

### DIFF
--- a/dev-python/pyalsa/pyalsa-1.0.29.ebuild
+++ b/dev-python/pyalsa/pyalsa-1.0.29.ebuild
@@ -9,7 +9,7 @@ inherit distutils-r1 flag-o-matic
 
 DESCRIPTION="Python bindings for ALSA library"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/pyalsa/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/pyalsa/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-python/pyalsa/pyalsa-1.1.6.ebuild
+++ b/dev-python/pyalsa/pyalsa-1.1.6.ebuild
@@ -9,7 +9,7 @@ inherit distutils-r1 flag-o-matic
 
 DESCRIPTION="Python bindings for ALSA library"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/pyalsa/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/pyalsa/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-libs/alsa-lib/alsa-lib-1.1.2.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.1.2.ebuild
@@ -10,7 +10,7 @@ inherit autotools eutils multilib multilib-minimal python-single-r1
 
 DESCRIPTION="Advanced Linux Sound Architecture Library"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/lib/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/lib/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/media-libs/alsa-lib/alsa-lib-1.1.6-r1.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.1.6-r1.ebuild
@@ -9,7 +9,7 @@ inherit autotools multilib multilib-minimal python-single-r1
 
 DESCRIPTION="Advanced Linux Sound Architecture Library"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/lib/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/lib/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/media-libs/alsa-lib/alsa-lib-1.1.8.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.1.8.ebuild
@@ -9,7 +9,7 @@ inherit autotools multilib multilib-minimal python-single-r1
 
 DESCRIPTION="Advanced Linux Sound Architecture Library"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/lib/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/lib/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/media-libs/alsa-lib/alsa-lib-1.1.9.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.1.9.ebuild
@@ -9,7 +9,7 @@ inherit autotools multilib multilib-minimal python-single-r1
 
 DESCRIPTION="Advanced Linux Sound Architecture Library"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/lib/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/lib/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/media-libs/alsa-oss/alsa-oss-1.0.28.ebuild
+++ b/media-libs/alsa-oss/alsa-oss-1.0.28.ebuild
@@ -10,7 +10,7 @@ S="${WORKDIR}/${MY_P}"
 
 DESCRIPTION="Advanced Linux Sound Architecture OSS compatibility layer"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/oss-lib/${MY_P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/oss-lib/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-libs/alsa-oss/alsa-oss-1.1.6.ebuild
+++ b/media-libs/alsa-oss/alsa-oss-1.1.6.ebuild
@@ -10,7 +10,7 @@ S="${WORKDIR}/${MY_P}"
 
 DESCRIPTION="Advanced Linux Sound Architecture OSS compatibility layer"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/oss-lib/${MY_P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/oss-lib/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-libs/alsa-oss/alsa-oss-1.1.8.ebuild
+++ b/media-libs/alsa-oss/alsa-oss-1.1.8.ebuild
@@ -10,7 +10,7 @@ S="${WORKDIR}/${MY_P}"
 
 DESCRIPTION="Advanced Linux Sound Architecture OSS compatibility layer"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/oss-lib/${MY_P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/oss-lib/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/alsa-plugins/alsa-plugins-1.1.1-r1.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.1.1-r1.ebuild
@@ -6,7 +6,7 @@ inherit autotools eutils flag-o-matic multilib multilib-minimal
 
 DESCRIPTION="ALSA extra plugins"
 HOMEPAGE="http://www.alsa-project.org/"
-SRC_URI="mirror://alsaproject/plugins/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/plugins/${P}.tar.bz2"
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"

--- a/media-plugins/alsa-plugins/alsa-plugins-1.1.6.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.1.6.ebuild
@@ -6,7 +6,7 @@ inherit autotools flag-o-matic multilib multilib-minimal
 
 DESCRIPTION="ALSA extra plugins"
 HOMEPAGE="http://www.alsa-project.org/"
-SRC_URI="mirror://alsaproject/plugins/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/plugins/${P}.tar.bz2"
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"

--- a/media-plugins/alsa-plugins/alsa-plugins-1.1.8.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.1.8.ebuild
@@ -6,7 +6,7 @@ inherit autotools flag-o-matic multilib multilib-minimal
 
 DESCRIPTION="ALSA extra plugins"
 HOMEPAGE="http://www.alsa-project.org/"
-SRC_URI="mirror://alsaproject/plugins/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/plugins/${P}.tar.bz2"
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"

--- a/media-plugins/alsa-plugins/alsa-plugins-1.1.9-r1.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.1.9-r1.ebuild
@@ -6,7 +6,7 @@ inherit autotools flag-o-matic multilib multilib-minimal
 
 DESCRIPTION="ALSA extra plugins"
 HOMEPAGE="http://www.alsa-project.org/"
-SRC_URI="mirror://alsaproject/plugins/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/plugins/${P}.tar.bz2"
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"

--- a/media-plugins/alsa-plugins/alsa-plugins-1.1.9.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.1.9.ebuild
@@ -6,7 +6,7 @@ inherit autotools flag-o-matic multilib multilib-minimal
 
 DESCRIPTION="ALSA extra plugins"
 HOMEPAGE="http://www.alsa-project.org/"
-SRC_URI="mirror://alsaproject/plugins/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/plugins/${P}.tar.bz2"
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"

--- a/media-sound/alsa-tools/alsa-tools-1.1.0.ebuild
+++ b/media-sound/alsa-tools/alsa-tools-1.1.0.ebuild
@@ -6,7 +6,7 @@ inherit autotools eutils flag-o-matic
 
 DESCRIPTION="Advanced Linux Sound Architecture tools"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/tools/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/tools/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0.9"

--- a/media-sound/alsa-tools/alsa-tools-1.1.6.ebuild
+++ b/media-sound/alsa-tools/alsa-tools-1.1.6.ebuild
@@ -6,7 +6,7 @@ inherit autotools flag-o-matic gnome2-utils xdg-utils
 
 DESCRIPTION="Advanced Linux Sound Architecture tools"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/tools/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/tools/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0.9"

--- a/media-sound/alsa-tools/alsa-tools-1.1.7.ebuild
+++ b/media-sound/alsa-tools/alsa-tools-1.1.7.ebuild
@@ -6,7 +6,7 @@ inherit autotools flag-o-matic gnome2-utils xdg-utils
 
 DESCRIPTION="Advanced Linux Sound Architecture tools"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/tools/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/tools/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0.9"

--- a/media-sound/alsa-utils/alsa-utils-1.1.2.ebuild
+++ b/media-sound/alsa-utils/alsa-utils-1.1.2.ebuild
@@ -6,7 +6,7 @@ inherit eutils systemd udev
 
 DESCRIPTION="Advanced Linux Sound Architecture Utils (alsactl, alsamixer, etc.)"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/utils/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/utils/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0.9"

--- a/media-sound/alsa-utils/alsa-utils-1.1.6.ebuild
+++ b/media-sound/alsa-utils/alsa-utils-1.1.6.ebuild
@@ -6,7 +6,7 @@ inherit systemd udev
 
 DESCRIPTION="Advanced Linux Sound Architecture Utils (alsactl, alsamixer, etc.)"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/utils/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/utils/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0.9"

--- a/media-sound/alsa-utils/alsa-utils-1.1.8.ebuild
+++ b/media-sound/alsa-utils/alsa-utils-1.1.8.ebuild
@@ -6,7 +6,7 @@ inherit systemd udev
 
 DESCRIPTION="Advanced Linux Sound Architecture Utils (alsactl, alsamixer, etc.)"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/utils/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/utils/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0.9"

--- a/media-sound/alsa-utils/alsa-utils-1.1.9.ebuild
+++ b/media-sound/alsa-utils/alsa-utils-1.1.9.ebuild
@@ -6,7 +6,7 @@ inherit systemd udev
 
 DESCRIPTION="Advanced Linux Sound Architecture Utils (alsactl, alsamixer, etc.)"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/utils/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/utils/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0.9"

--- a/profiles/thirdpartymirrors
+++ b/profiles/thirdpartymirrors
@@ -1,4 +1,3 @@
-alsaproject	ftp://ftp.alsa-project.org/pub
 apache		http://apache.lauf-forum.at/ http://apache.mirror.digionline.de/ http://apache.mirror.iphh.net/ http://artfiles.org/apache.org/ http://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.apache.org/dist/ http://ftp.fau.de/apache/ http://ftp.halifax.rwth-aachen.de/apache/ http://ftp.heikorichter.name/apache/ http://mirror.23media.de/apache/ http://apache.mirrors.hoobly.com/ http://www.gtlib.gatech.edu/pub/apache/ http://apache.osuosl.org/
 cpan		http://cpan.metacpan.org http://search.cpan.org/CPAN http://www.cpan.org
 cran		http://cran.r-project.org http://cran.us.r-project.org

--- a/sys-firmware/alsa-firmware/alsa-firmware-1.0.29.ebuild
+++ b/sys-firmware/alsa-firmware/alsa-firmware-1.0.29.ebuild
@@ -6,7 +6,7 @@ inherit udev
 
 DESCRIPTION="Advanced Linux Sound Architecture firmware"
 HOMEPAGE="https://alsa-project.org/"
-SRC_URI="mirror://alsaproject/firmware/${P}.tar.bz2"
+SRC_URI="https://www.alsa-project.org/files/pub/firmware/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
The alsaproject mirror does not list multiple servers since 2017. Inline it.