### PR TITLE
sci-libs/vtk: removed xkaapi dependency and kaapi useflag

### DIFF
--- a/sci-libs/vtk/vtk-8.1.0-r3.ebuild
+++ b/sci-libs/vtk/vtk-8.1.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -26,7 +26,7 @@ LICENSE="BSD LGPL-2"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 SLOT="0"
 IUSE="
-	all-modules aqua boost doc examples imaging ffmpeg gdal java json kaapi mpi
+	all-modules aqua boost doc examples imaging ffmpeg gdal java json mpi
 	mysql odbc offscreen postgres python qt5 rendering tbb theora tk tcl
 	video_cards_nvidia views web R +X xdmf2"
 
@@ -69,7 +69,6 @@ RDEPEND="
 	ffmpeg? ( virtual/ffmpeg )
 	gdal? ( sci-libs/gdal )
 	java? ( >=virtual/jdk-1.7:* )
-	kaapi? ( <sci-libs/xkaapi-3 )
 	mpi? (
 		virtual/mpi[cxx,romio]
 		python? ( dev-python/mpi4py[${PYTHON_USEDEP}] )
@@ -225,9 +224,7 @@ src_configure() {
 		mycmakeargs+=( -DJAVAC_OPTIONS=${javacargs// /;} )
 	fi
 
-	if use kaapi; then
-		mycmakeargs+=( -DVTK_SMP_IMPLEMENTATION_TYPE="Kaapi" )
-	elif use tbb; then
+	if use tbb; then
 		mycmakeargs+=( -DVTK_SMP_IMPLEMENTATION_TYPE="TBB" )
 	else
 		mycmakeargs+=( -DVTK_SMP_IMPLEMENTATION_TYPE="Sequential" )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/693046

Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>