### PR TITLE
dev-util/mingw64-runtime: Don't install USE=libraries libs to lib64

### DIFF
--- a/dev-util/mingw64-runtime/mingw64-runtime-6.0.0-r3.ebuild
+++ b/dev-util/mingw64-runtime/mingw64-runtime-6.0.0-r3.ebuild
@@ -75,9 +75,11 @@ src_configure() {
 	# By default configure tries to set --sysroot=${prefix}. We disable
 	# this behaviour with --with-sysroot=no to use gcc's sysroot default.
 	# That way we can cross-build mingw64-runtime with cross-emerge.
+	local prefix="${EPREFIX}"$(alt_prefix)/usr
 	CHOST=${CTARGET} econf \
 		--with-sysroot=no \
-		--prefix="${EPREFIX}"$(alt_prefix)/usr \
+		--prefix="${prefix}" \
+		--libdir="${prefix}"/lib \
 		--with-headers \
 		--enable-sdk \
 		$(crt_with crt) \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/653246
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: James Le Cuirot <chewi@gentoo.org>