### PR TITLE
 net-dns/ddclient: drop user eclass 

### DIFF
--- a/acct-group/ddclient/ddclient-0.ebuild
+++ b/acct-group/ddclient/ddclient-0.ebuild
@@ -1,0 +1,10 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+DESCRIPTION="A group for the dynamic DNS client"
+
+ACCT_GROUP_ID="487"

--- a/acct-group/ddclient/metadata.xml
+++ b/acct-group/ddclient/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>ck+gentoo@bl4ckb0x.de</email>
+		<name>Conrad Kostecki</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/ddclient/ddclient-0.ebuild
+++ b/acct-user/ddclient/ddclient-0.ebuild
@@ -1,0 +1,13 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="A user for the dynamic DNS client"
+
+ACCT_USER_GROUPS=( "ddclient" )
+ACCT_USER_ID="487"
+
+acct-user_add_deps

--- a/acct-user/ddclient/metadata.xml
+++ b/acct-user/ddclient/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>ck+gentoo@bl4ckb0x.de</email>
+		<name>Conrad Kostecki</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/net-dns/ddclient/ddclient-3.9.0-r3.ebuild
+++ b/net-dns/ddclient/ddclient-3.9.0-r3.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit systemd
+
+DESCRIPTION="Perl client used to update dynamic DNS entries"
+HOMEPAGE="https://sourceforge.net/projects/ddclient/"
+SRC_URI="mirror://sourceforge/ddclient/${P}.tar.gz"
+
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+LICENSE="GPL-2+"
+SLOT="0"
+IUSE="examples iproute2"
+
+RDEPEND="
+	acct-group/ddclient
+	acct-user/ddclient
+	dev-lang/perl
+	dev-perl/Data-Validate-IP
+	dev-perl/Digest-SHA1
+	dev-perl/IO-Socket-INET6
+	dev-perl/IO-Socket-SSL
+	virtual/perl-Digest-SHA
+	virtual/perl-JSON-PP
+	iproute2? ( sys-apps/iproute2 )
+"
+
+src_prepare() {
+	# Remove PID setting, to reliably setup the environment for the init script
+	sed -e '/^pid/d' -i sample-etc_ddclient.conf || die
+
+	# Remove windows executable
+	if use examples; then
+		rm sample-etc_dhcpc_dhcpcd-eth0.exe || die
+	fi
+
+	# Use sys-apps/iproute2 instead of sys-apps/net-tools
+	use iproute2 && eapply "${FILESDIR}"/${P}-use_iproute2.patch
+
+	default
+}
+
+src_install() {
+	dobin ddclient
+
+	insinto /etc/ddclient
+	insopts -m 0600 -o ddclient -g ddclient
+	newins sample-etc_ddclient.conf ddclient.conf
+
+	newinitd "${FILESDIR}"/ddclient.initd-r6 ddclient
+	systemd_newunit "${FILESDIR}"/ddclient.service-r1 ddclient.service
+	systemd_newtmpfilesd "${FILESDIR}"/ddclient.tmpfiles ddclient.conf
+
+	dodoc Change* README* RELEASENOTE TODO UPGRADE
+
+	if use examples; then
+		docinto examples
+		dodoc sample-*
+	fi
+}


### PR DESCRIPTION
Dropped user eclass in favour of acct-* packages.

Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>