### PR TITLE
games-server/steamcmd: drop user eclass

### DIFF
--- a/acct-group/steamcmd/metadata.xml
+++ b/acct-group/steamcmd/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>ck+gentoo@bl4ckb0x.de</email>
+		<name>Conrad Kostecki</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/steamcmd/steamcmd-0.ebuild
+++ b/acct-group/steamcmd/steamcmd-0.ebuild
@@ -1,0 +1,10 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+DESCRIPTION="A group for the SteamCMD server"
+
+ACCT_GROUP_ID="489"

--- a/acct-user/steamcmd/metadata.xml
+++ b/acct-user/steamcmd/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>ck+gentoo@bl4ckb0x.de</email>
+		<name>Conrad Kostecki</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/steamcmd/steamcmd-0.ebuild
+++ b/acct-user/steamcmd/steamcmd-0.ebuild
@@ -1,0 +1,14 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="A user for the SteamCMD server"
+
+ACCT_USER_GROUPS=( "steamcmd" )
+ACCT_USER_HOME="/opt/steamcmd"
+ACCT_USER_ID="489"
+
+acct-user_add_deps

--- a/games-server/steamcmd/steamcmd-1.0-r2.ebuild
+++ b/games-server/steamcmd/steamcmd-1.0-r2.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit readme.gentoo-r1 user
+
+DESCRIPTION="This is the command-line version of the Steam client for dedicated servers"
+HOMEPAGE="https://developer.valvesoftware.com/wiki/SteamCMD"
+SRC_URI="https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1+ Steam"
+SLOT="0"
+KEYWORDS="-* ~amd64 ~x86"
+
+RDEPEND="
+	acct-group/steamcmd
+	acct-user/steamcmd
+	app-misc/screen
+"
+
+RESTRICT="bindist mirror"
+
+S="${WORKDIR}"
+
+QA_PREBUILT="
+	opt/steamcmd/linux32/libstdc++.so.6
+	opt/steamcmd/linux32/steamcmd
+"
+
+src_install() {
+	diropts -o steamcmd -g steamcmd
+	dodir /opt/steamcmd
+	keepdir /opt/steamcmd/{.steam,.steam/sdk32,linux32}
+
+	exeopts -o steamcmd -g steamcmd
+	exeinto /opt/steamcmd
+	doexe steamcmd.sh
+
+	exeopts -o steamcmd -g steamcmd
+	exeinto /opt/steamcmd/linux32
+	doexe linux32/steamcmd linux32/libstdc++.so.6
+
+	newinitd "${FILESDIR}"/steamcmd.initd-r1 steamcmd
+	newconfd "${FILESDIR}"/steamcmd.confd-r1 steamcmd
+
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
Dropped user eclass in favour of acct-* packages.

Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>