### PR TITLE
Feature/clion licenses

### DIFF
--- a/dev-util/clion/clion-2019.2.1.ebuild
+++ b/dev-util/clion/clion-2019.2.1.ebuild
@@ -9,8 +9,11 @@ DESCRIPTION="A complete toolset for C and C++ development"
 HOMEPAGE="https://www.jetbrains.com/clion"
 SRC_URI="https://download.jetbrains.com/cpp/CLion-${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="IDEA
-	|| ( IDEA_Academic IDEA_Classroom IDEA_OpenSource IDEA_Personal )"
+LICENSE="|| ( IDEA IDEA_Academic IDEA_Classroom IDEA_OpenSource IDEA_Personal )
+	Apache-1.1 Apache-2.0 BSD BSD-2 CC0-1.0 CDDL-1.1 CPL-0.5 CPL-1.0
+	EPL-1.0 EPL-2.0 GPL-2 GPL-2-with-classpath-exception GPL-3 ISC
+	JDOM LGPL-2.1+ LGPL-3 MIT MPL-1.0 MPL-1.1 OFL public-domain 
+	PSF-2 UoI-NCSA ZLIB"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 RESTRICT="bindist mirror splitdebug"

--- a/dev-util/clion/clion-2019.2.1.ebuild
+++ b/dev-util/clion/clion-2019.2.1.ebuild
@@ -13,7 +13,7 @@ LICENSE="IDEA
 	|| ( IDEA_Academic IDEA_Classroom IDEA_OpenSource IDEA_Personal )"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-RESTRICT="mirror splitdebug"
+RESTRICT="bindist mirror splitdebug"
 IUSE="custom-jdk"
 
 # RDEPENDS may cause false positives in repoman.


### PR DESCRIPTION
dev-util/clion: add bindist restriction
dev-util/clion: add licenses for bundled libraries

Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Christian Strahl <c.a.strahl@gmail.com>

Closes: https://bugs.gentoo.org/694266