### PR TITLE
dev-python/python-sense-hat: drop amd64 keyword

### DIFF
--- a/dev-python/python-sense-hat/python-sense-hat-2.2.0-r1.ebuild
+++ b/dev-python/python-sense-hat/python-sense-hat-2.2.0-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/RPi-Distro/python-sense-hat/archive/v${PV}.tar.gz ->
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm arm64"
+KEYWORDS="arm arm64"
 
 RDEPEND="
 	dev-python/numpy[${PYTHON_USEDEP}]


### PR DESCRIPTION
Since this package is for ARM/ARM64 only, the AMD64 keyword makes no
sense and was by mistake added.

Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>