### PR TITLE
app-emulation/virt-viewer: Add libvirt USE flag as deps are optional

### DIFF
--- a/app-emulation/virt-viewer/metadata.xml
+++ b/app-emulation/virt-viewer/metadata.xml
@@ -6,6 +6,8 @@
 		<name>Gentoo Virtualization Project</name>
 	</maintainer>
 	<use>
+		<flag name="libvirt">Support connecting to virtual machines
+			managed by libvirt.</flag>
 		<flag name="spice">Support connecting to SPICE-enabled virtual
 			machines.</flag>
 		<flag name="vnc">Support connecting to VNC-enabled virtual

--- a/app-emulation/virt-viewer/virt-viewer-8.0.ebuild
+++ b/app-emulation/virt-viewer/virt-viewer-8.0.ebuild
@@ -11,12 +11,14 @@ SRC_URI="http://virt-manager.org/download/sources/${PN}/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="sasl +spice +vnc"
+IUSE="+libvirt sasl +spice +vnc"
 
-RDEPEND=">=app-emulation/libvirt-0.10.0[sasl?]
-	app-emulation/libvirt-glib
-	>=dev-libs/libxml2-2.6
+RDEPEND=">=dev-libs/libxml2-2.6
 	x11-libs/gtk+:3
+	libvirt? (
+		>=app-emulation/libvirt-0.10.0[sasl?]
+		app-emulation/libvirt-glib
+	)
 	spice? ( >=net-misc/spice-gtk-0.35[sasl?,gtk3] )
 	vnc? ( >=net-libs/gtk-vnc-0.5.0[sasl?,gtk3(+)] )"
 DEPEND="${RDEPEND}
@@ -31,6 +33,7 @@ src_configure() {
 	gnome2_src_configure \
 		--disable-update-mimedb \
 		--without-ovirt \
+		$(use_with libvirt) \
 		$(use_with vnc gtk-vnc) \
 		$(use_with spice spice-gtk)
 }

--- a/app-emulation/virt-viewer/virt-viewer-8.0.ebuild
+++ b/app-emulation/virt-viewer/virt-viewer-8.0.ebuild
@@ -5,8 +5,8 @@ EAPI=6
 inherit gnome2
 
 DESCRIPTION="Graphical console client for connecting to virtual machines"
-HOMEPAGE="http://virt-manager.org/"
-SRC_URI="http://virt-manager.org/download/sources/${PN}/${P}.tar.gz"
+HOMEPAGE="https://virt-manager.org/"
+SRC_URI="https://virt-manager.org/download/sources/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
I was going to bump this to EAPI 7 (it could benefit from BDEPEND) but I couldn't because of gnome2.eclass. Having said that, it builds fine without this eclass and I wonder if all it really needs is xdg.eclass.