### PR TITLE
acct-user/alias: add dependency for qmail group

### DIFF
--- a/acct-user/alias/alias-0.ebuild
+++ b/acct-user/alias/alias-0.ebuild
@@ -13,3 +13,6 @@ ACCT_USER_HOME_PERMS=02755
 ACCT_USER_GROUPS=( nofiles )
 
 acct-user_add_deps
+
+DEPEND+=" acct-group/qmail "
+RDEPEND+=" acct-group/qmail "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/695382

@mgorny 