### PR TITLE
Adding aqbanking-5.99.33_beta and gwenhywfar-4.99.16_beta

### DIFF
--- a/net-libs/aqbanking/aqbanking-5.99.33_beta.ebuild
+++ b/net-libs/aqbanking/aqbanking-5.99.33_beta.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+EAPI=7
+
+DESCRIPTION="Generic Online Banking Interface"
+HOMEPAGE="https://www.aquamaniac.de/sites/aqbanking/index.php"
+MY_PV="5.99.33beta"
+S=${WORKDIR}/${PN}-${MY_PV}
+#S=${WORKDIR}/${PN}-${PV/-/_}
+SRC_URI="https://www.aquamaniac.de/rdm/attachments/download/145/${PN}-${MY_PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE="chipcard debug doc ebics examples ofx"
+
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen )
+"
+RDEPEND="
+	app-misc/ktoblzcheck
+	dev-libs/gmp:0=
+	sys-libs/gwenhywfar:=
+	virtual/libintl
+	chipcard? ( >=sys-libs/libchipcard-5.0.2 )
+	ebics? ( dev-libs/xmlsec[gcrypt,gnutls] )
+	ofx? ( >=dev-libs/libofx-0.9.5 )
+"
+DEPEND="${RDEPEND}"
+
+# DOCS=( AUTHORS ChangeLog NEWS README TODO )
+
+MAKEOPTS="${MAKEOPTS} -j1" # 5.7.8 still fails with > -j1
+
+src_configure() {
+	local backends="aqhbci aqnone aqpaypal"
+	use ofx && backends="${backends} aqofxconnect"
+	use ebics && backends="${backends} aqebics"
+
+	econf \
+		$(use_enable debug) \
+		$(use_enable doc full-doc) \
+		--with-backends="${backends}" \
+		--with-docpath=/usr/share/doc/${PF}/apidoc
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	rm -rv "${ED}"/usr/share/doc/ || die
+
+	einstalldocs
+
+#	newdoc src/plugins/backends/aqhbci/tools/aqhbci-tool/README \
+		README.aqhbci-tool
+
+	if use examples; then
+		docinto tutorials
+		dodoc tutorials/*.{c,h} tutorials/README
+	fi
+
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/sys-libs/gwenhywfar/gwenhywfar-4.99.16_beta.ebuild
+++ b/sys-libs/gwenhywfar/gwenhywfar-4.99.16_beta.ebuild
@@ -1,0 +1,111 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit qmake-utils
+
+DESCRIPTION="Multi-platform helper library for other libraries"
+HOMEPAGE="https://www.aquamaniac.de/sites/aqbanking/index.php"
+MY_PV="4.99.16beta"
+S=${WORKDIR}/${PN}-${MY_PV}
+SRC_URI="https://www.aquamaniac.de/rdm/attachments/download/140/${PN}-${MY_PV}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0/60" # correspond with libgwenhywfar.so version
+KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+IUSE="debug designer doc fox gtk libressl qml qt5 sensors serialport test webkit"
+
+REQUIRED_USE="designer? ( qt5 ) qml? ( qt5 ) sensors? ( qt5 ) serialport? ( qt5 ) webkit? ( qt5 )"
+
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen )
+"
+RDEPEND="
+	dev-libs/libgcrypt:0=
+	dev-libs/libgpg-error
+	libressl? ( dev-libs/libressl:0= )
+	!libressl? ( dev-libs/openssl:0= )
+	net-libs/gnutls:=
+	virtual/libiconv
+	virtual/libintl
+	virtual/opengl
+	designer? ( dev-qt/designer:5 )
+	fox? ( x11-libs/fox:1.6 )
+	gtk? ( x11-libs/gtk+:3 )
+	qml? ( dev-qt/qtdeclarative:5 )
+	qt5? (
+		dev-qt/qtconcurrent:5
+		dev-qt/qtcore:5
+		dev-qt/qtdbus:5
+		dev-qt/qtgui:5
+		dev-qt/qthelp:5
+		dev-qt/qtmultimedia:5[widgets]
+		dev-qt/qtnetwork:5
+		dev-qt/qtopengl:5
+		dev-qt/qtprintsupport:5
+		dev-qt/qtscript:5
+		dev-qt/qtsql:5
+		dev-qt/qtsvg:5
+		dev-qt/qtwidgets:5
+		dev-qt/qtx11extras:5
+		dev-qt/qtxml:5
+		dev-qt/qtxmlpatterns:5
+	)
+	sensors? ( dev-qt/qtsensors:5 )
+	serialport? ( dev-qt/qtserialport:5 )
+	test? ( dev-qt/qttest:5 )
+	webkit? ( dev-qt/qtwebkit:5 )
+"
+DEPEND="${RDEPEND}"
+
+# broken upstream, reported but got no reply
+RESTRICT="test"
+
+src_configure() {
+	disableQtModule() {
+		local module
+		for module in ${@}; do
+			sed -e "/qtHaveModule(${module})/s|^|#DONT|" -i configure || die
+		done
+	}
+
+	use designer || disableQtModule designer uitools
+	use qml || disableQtModule qml qmltest
+	use sensors || disableQtModule sensors
+	use serialport || disableQtModule serialport
+	use test || disableQtModule testlib
+	use webkit || disableQtModule webkit webkitwidgets
+
+	local guis=()
+	use fox && guis+=( fox16 )
+	use gtk && guis+=( gtk3 )
+	use qt5 && guis+=( qt5 )
+
+	local myeconfargs=(
+		--enable-ssl
+		$(use_enable debug)
+		$(use_enable doc full-doc)
+		--with-docpath="${EPREFIX}/usr/share/doc/${PF}/apidoc"
+	)
+	use qt5 && myeconfargs+=(
+		--with-qt5-moc="$(qt5_get_bindir)/moc"
+		--with-qt5-qmake="$(qt5_get_bindir)/qmake"
+	)
+
+	guis_config="--with-guis=${guis[@]}"
+	econf "${myeconfargs[@]}" "${guis_config}"
+}
+
+src_compile() {
+	emake
+	use doc && emake srcdoc
+}
+
+src_install() {
+	default
+	use doc && emake DESTDIR="${D}" install-srcdoc
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Atoms are required for PSD2 support. Any financial transaction api in europe has to enforce this.