### PR TITLE
media-sound/mp3c: Fix linking with recent compilers

### DIFF
--- a/media-sound/mp3c/files/mp3c-fix-linking.patch
+++ b/media-sound/mp3c/files/mp3c-fix-linking.patch
@@ -1,0 +1,11 @@
+--- a/configure.old       2006-07-30 17:07:27.000000000 +0200
++++ a/configure   2019-09-06 18:46:50.587538700 +0200
+@@ -6697,7 +6697,7 @@
+ #define HAVE_LIBNCURSES 1
+ _ACEOF
+ 
+-  LIBS="-lncurses $LIBS"
++  LIBS="-ltinfo -lncurses $LIBS"
+ 
+ fi
+

--- a/media-sound/mp3c/mp3c-0.31-r2.ebuild
+++ b/media-sound/mp3c/mp3c-0.31-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit eutils
+
+IUSE="mp3 vorbis"
+
+DESCRIPTION="console based mp3 ripper, with cddb support"
+HOMEPAGE="http://wspse.de/WSPse/Linux-MP3c.php3"
+SRC_URI="ftp://ftp.wspse.de/pub/linux/wspse/${P}.tar.bz2"
+
+RDEPEND="mp3? ( media-sound/lame
+	>=media-sound/mp3info-0.8.4-r1 )
+	virtual/cdrtools
+	vorbis? ( media-sound/vorbis-tools )"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+PATCHES=(
+	"${FILESDIR}/${PN}-buffer.patch"
+	"${FILESDIR}/${PN}-fix-linking.patch"
+)
+
+src_configure() {
+	econf $(use_enable vorbis oggdefaults) || die "econf failed !"
+}
+
+src_install () {
+	make DESTDIR="${D}" install || die
+	dodoc AUTHORS *README BUGS CDDB_HOWTO ChangeLog FAQ NEWS OTHERS TODO
+}


### PR DESCRIPTION
Also bump to EAPI-7

Closes: https://bugs.gentoo.org/691080
Closes: https://bugs.gentoo.org/689980
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>
Package-Manager: Portage-2.3.69, Repoman-2.3.16