### PR TITLE
net-libs/libtorrent-rasterbar: Use correct libboost_python* library

### DIFF
--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.10-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.10-r1.ebuild
@@ -1,0 +1,104 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_REQ_USE="threads"
+DISTUTILS_OPTIONAL=true
+DISTUTILS_IN_SOURCE_BUILD=true
+
+inherit distutils-r1 flag-o-matic
+
+MY_PV=$(ver_rs 1-2 '_')
+
+DESCRIPTION="C++ BitTorrent implementation focusing on efficiency and scalability"
+HOMEPAGE="https://libtorrent.org"
+SRC_URI="https://github.com/arvidn/libtorrent/releases/download/libtorrent-${MY_PV}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/9"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+IUSE="debug +dht doc examples libressl python +ssl static-libs test"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	dev-libs/boost:=[threads]
+	virtual/libiconv
+	examples? ( !net-p2p/mldonkey )
+	python? (
+		${PYTHON_DEPS}
+		dev-libs/boost:=[python,${PYTHON_USEDEP}]
+	)
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:= )
+	)
+"
+DEPEND="${RDEPEND}
+	sys-devel/libtool
+"
+
+src_prepare() {
+	default
+
+	# bug 578026
+	# prepend -L${S}/... to ensure bindings link against the lib we just built
+	sed -i -e "s|^|-L${S}/src/.libs |" bindings/python/link_flags.in || die
+
+	# prepend -I${S}/... to ensure bindings use the right headers
+	sed -i -e "s|^|-I${S}/src/include |" bindings/python/compile_flags.in || die
+
+	use python && distutils-r1_src_prepare
+}
+
+src_configure() {
+	append-cxxflags -std=c++11 # bug 634506
+
+	local myeconfargs=(
+		$(use_enable debug)
+		$(use_enable debug logging)
+		$(use_enable debug disk-stats)
+		$(use_enable dht dht $(usex debug logging $(usex ('yes' 'no'))))
+		$(use_enable examples)
+		$(use_enable ssl encryption)
+		$(use_enable static-libs static)
+		$(use_enable test tests)
+		--with-libiconv
+	)
+	econf "${myeconfargs[@]}"
+
+	if use python; then
+		python_configure() {
+			econf "${myeconfargs[@]}" \
+				--enable-python-binding \
+				--with-boost-python="boost_${EPYTHON/./}"
+		}
+		distutils-r1_src_configure
+	fi
+}
+
+src_compile() {
+	default
+
+	python_compile() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_compile
+	}
+	use python && distutils-r1_src_compile
+}
+
+src_install() {
+	use doc && HTML_DOCS+=( "${S}"/docs )
+
+	default
+
+	python_install() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_install
+	}
+	use python && distutils-r1_src_install
+
+	find "${D}" -name '*.la' -delete || die
+}

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.12-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.12-r1.ebuild
@@ -1,0 +1,104 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_REQ_USE="threads"
+DISTUTILS_OPTIONAL=true
+DISTUTILS_IN_SOURCE_BUILD=true
+
+inherit distutils-r1 flag-o-matic
+
+MY_PV=$(ver_rs 1-2 '_')
+
+DESCRIPTION="C++ BitTorrent implementation focusing on efficiency and scalability"
+HOMEPAGE="https://libtorrent.org"
+SRC_URI="https://github.com/arvidn/libtorrent/releases/download/libtorrent_${MY_PV}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/9"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+IUSE="debug +dht doc examples libressl python +ssl static-libs test"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	dev-libs/boost:=[threads]
+	virtual/libiconv
+	examples? ( !net-p2p/mldonkey )
+	python? (
+		${PYTHON_DEPS}
+		dev-libs/boost:=[python,${PYTHON_USEDEP}]
+	)
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:= )
+	)
+"
+DEPEND="${RDEPEND}
+	sys-devel/libtool
+"
+
+src_prepare() {
+	default
+
+	# bug 578026
+	# prepend -L${S}/... to ensure bindings link against the lib we just built
+	sed -i -e "s|^|-L${S}/src/.libs |" bindings/python/link_flags.in || die
+
+	# prepend -I${S}/... to ensure bindings use the right headers
+	sed -i -e "s|^|-I${S}/src/include |" bindings/python/compile_flags.in || die
+
+	use python && distutils-r1_src_prepare
+}
+
+src_configure() {
+	append-cxxflags -std=c++11 # bug 634506
+
+	local myeconfargs=(
+		$(use_enable debug)
+		$(use_enable debug logging)
+		$(use_enable debug disk-stats)
+		$(use_enable dht dht $(usex debug logging $(usex ('yes' 'no'))))
+		$(use_enable examples)
+		$(use_enable ssl encryption)
+		$(use_enable static-libs static)
+		$(use_enable test tests)
+		--with-libiconv
+	)
+	econf "${myeconfargs[@]}"
+
+	if use python; then
+		python_configure() {
+			econf "${myeconfargs[@]}" \
+				--enable-python-binding \
+				--with-boost-python="boost_${EPYTHON/./}"
+		}
+		distutils-r1_src_configure
+	fi
+}
+
+src_compile() {
+	default
+
+	python_compile() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_compile
+	}
+	use python && distutils-r1_src_compile
+}
+
+src_install() {
+	use doc && HTML_DOCS+=( "${S}"/docs )
+
+	default
+
+	python_install() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_install
+	}
+	use python && distutils-r1_src_install
+
+	find "${D}" -name '*.la' -delete || die
+}

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.13-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.13-r1.ebuild
@@ -1,0 +1,104 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_REQ_USE="threads"
+DISTUTILS_OPTIONAL=true
+DISTUTILS_IN_SOURCE_BUILD=true
+
+inherit distutils-r1 flag-o-matic
+
+MY_PV=$(ver_rs 1-2 '_')
+
+DESCRIPTION="C++ BitTorrent implementation focusing on efficiency and scalability"
+HOMEPAGE="https://libtorrent.org"
+SRC_URI="https://github.com/arvidn/libtorrent/releases/download/libtorrent-${MY_PV}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/9"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+IUSE="debug +dht doc examples libressl python +ssl static-libs test"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	dev-libs/boost:=[threads]
+	virtual/libiconv
+	examples? ( !net-p2p/mldonkey )
+	python? (
+		${PYTHON_DEPS}
+		dev-libs/boost:=[python,${PYTHON_USEDEP}]
+	)
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:= )
+	)
+"
+DEPEND="${RDEPEND}
+	sys-devel/libtool
+"
+
+src_prepare() {
+	default
+
+	# bug 578026
+	# prepend -L${S}/... to ensure bindings link against the lib we just built
+	sed -i -e "s|^|-L${S}/src/.libs |" bindings/python/link_flags.in || die
+
+	# prepend -I${S}/... to ensure bindings use the right headers
+	sed -i -e "s|^|-I${S}/src/include |" bindings/python/compile_flags.in || die
+
+	use python && distutils-r1_src_prepare
+}
+
+src_configure() {
+	append-cxxflags -std=c++11 # bug 634506
+
+	local myeconfargs=(
+		$(use_enable debug)
+		$(use_enable debug disk-stats)
+		$(use_enable debug logging)
+		$(use_enable dht)
+		$(use_enable examples)
+		$(use_enable ssl encryption)
+		$(use_enable static-libs static)
+		$(use_enable test tests)
+		--with-libiconv
+	)
+	econf "${myeconfargs[@]}"
+
+	if use python; then
+		python_configure() {
+			econf "${myeconfargs[@]}" \
+				--enable-python-binding \
+				--with-boost-python="boost_${EPYTHON/./}"
+		}
+		distutils-r1_src_configure
+	fi
+}
+
+src_compile() {
+	default
+
+	python_compile() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_compile
+	}
+	use python && distutils-r1_src_compile
+}
+
+src_install() {
+	use doc && HTML_DOCS+=( "${S}"/docs )
+
+	default
+
+	python_install() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_install
+	}
+	use python && distutils-r1_src_install
+
+	find "${D}" -name '*.la' -delete || die
+}

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.0-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.0-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_REQ_USE="threads"
+DISTUTILS_OPTIONAL=true
+DISTUTILS_IN_SOURCE_BUILD=true
+
+inherit autotools distutils-r1 flag-o-matic
+
+MY_PV=$(ver_rs 1-2 '_')
+MY_P=${PN/-rasterbar}_${MY_PV}
+
+DESCRIPTION="C++ BitTorrent implementation focusing on efficiency and scalability"
+HOMEPAGE="https://libtorrent.org"
+SRC_URI="https://github.com/arvidn/libtorrent/archive/${MY_P}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/9"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+IUSE="debug +dht doc examples libressl python +ssl static-libs test"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	dev-libs/boost:=[threads]
+	virtual/libiconv
+	examples? ( !net-p2p/mldonkey )
+	python? (
+		${PYTHON_DEPS}
+		dev-libs/boost:=[python,${PYTHON_USEDEP}]
+	)
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:= )
+	)
+"
+DEPEND="${RDEPEND}
+	sys-devel/libtool
+"
+
+S="${WORKDIR}/${PN/-rasterbar}-${MY_P}"
+
+PATCHES=( "${FILESDIR}"/fix-boost-1.70.patch )
+
+src_prepare() {
+	mkdir "${S}"/build-aux/ || die
+	touch "${S}"/build-aux/config.rpath || die
+	eautoreconf
+
+	default
+
+	# bug 578026
+	# prepend -L${S}/... to ensure bindings link against the lib we just built
+	sed -i -e "s|^|-L${S}/src/.libs |" bindings/python/link_flags.in || die
+
+	# prepend -I${S}/... to ensure bindings use the right headers
+	sed -i -e "s|^|-I${S}/src/include |" bindings/python/compile_flags.in || die
+
+	use python && distutils-r1_src_prepare
+}
+
+src_configure() {
+	append-cxxflags -std=c++11 # bug 634506
+
+	local myeconfargs=(
+		$(use_enable debug)
+		$(use_enable debug export-all)
+		$(use_enable dht dht $(usex debug logging $(usex ('yes' 'no'))))
+		$(use_enable examples)
+		$(use_enable ssl encryption)
+		$(use_enable static-libs static)
+		$(use_enable test tests)
+		--with-libiconv
+	)
+	econf "${myeconfargs[@]}"
+
+	if use python; then
+		python_configure() {
+			econf "${myeconfargs[@]}" \
+				--enable-python-binding \
+				--with-boost-python="boost_${EPYTHON/./}"
+		}
+		distutils-r1_src_configure
+	fi
+}
+
+src_compile() {
+	default
+
+	python_compile() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_compile
+	}
+	use python && distutils-r1_src_compile
+}
+
+src_install() {
+	use doc && HTML_DOCS+=( "${S}"/docs )
+
+	default
+
+	python_install() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_install
+	}
+	use python && distutils-r1_src_install
+
+	find "${D}" -name '*.la' -delete || die
+}

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.1-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.1-r1.ebuild
@@ -1,0 +1,111 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_REQ_USE="threads"
+DISTUTILS_OPTIONAL=true
+DISTUTILS_IN_SOURCE_BUILD=true
+
+inherit autotools distutils-r1 flag-o-matic
+
+MY_PV=$(ver_rs 1-2 '_')
+MY_P=${PN/-rasterbar}-${MY_PV}
+
+DESCRIPTION="C++ BitTorrent implementation focusing on efficiency and scalability"
+HOMEPAGE="https://libtorrent.org https://github.com/arvidn/libtorrent"
+SRC_URI="https://github.com/arvidn/libtorrent/archive/${MY_P}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/9"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+IUSE="debug +dht doc examples libressl python +ssl static-libs test"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	dev-libs/boost:=[threads]
+	virtual/libiconv
+	examples? ( !net-p2p/mldonkey )
+	python? (
+		${PYTHON_DEPS}
+		dev-libs/boost:=[python,${PYTHON_USEDEP}]
+	)
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:= )
+	)
+"
+DEPEND="${RDEPEND}
+	sys-devel/libtool
+"
+
+S="${WORKDIR}/${PN/-rasterbar}-${MY_P}"
+
+src_prepare() {
+	mkdir "${S}"/build-aux/ || die
+	touch "${S}"/build-aux/config.rpath || die
+	eautoreconf
+
+	default
+
+	# bug 578026
+	# prepend -L${S}/... to ensure bindings link against the lib we just built
+	sed -i -e "s|^|-L${S}/src/.libs |" bindings/python/link_flags.in || die
+
+	# prepend -I${S}/... to ensure bindings use the right headers
+	sed -i -e "s|^|-I${S}/src/include |" bindings/python/compile_flags.in || die
+
+	use python && distutils-r1_src_prepare
+}
+
+src_configure() {
+	append-cxxflags -std=c++11 # bug 634506
+
+	local myeconfargs=(
+		$(use_enable debug)
+		$(use_enable debug export-all)
+		$(use_enable debug logging)
+		$(use_enable dht)
+		$(use_enable examples)
+		$(use_enable ssl encryption)
+		$(use_enable static-libs static)
+		$(use_enable test tests)
+		--with-libiconv
+	)
+	econf "${myeconfargs[@]}"
+
+	if use python; then
+		python_configure() {
+			econf "${myeconfargs[@]}" \
+				--enable-python-binding \
+				--with-boost-python="boost_${EPYTHON/./}"
+		}
+		distutils-r1_src_configure
+	fi
+}
+
+src_compile() {
+	default
+
+	python_compile() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_compile
+	}
+	use python && distutils-r1_src_compile
+}
+
+src_install() {
+	use doc && HTML_DOCS+=( "${S}"/docs )
+
+	default
+
+	python_install() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_install
+	}
+	use python && distutils-r1_src_install
+
+	find "${D}" -name '*.la' -delete || die
+}

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
@@ -1,0 +1,111 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_REQ_USE="threads"
+DISTUTILS_OPTIONAL=true
+DISTUTILS_IN_SOURCE_BUILD=true
+
+inherit autotools distutils-r1 flag-o-matic
+
+MY_PV=$(ver_rs 1-2 '_')
+MY_P=${PN/-rasterbar}-${MY_PV}
+
+DESCRIPTION="C++ BitTorrent implementation focusing on efficiency and scalability"
+HOMEPAGE="https://libtorrent.org https://github.com/arvidn/libtorrent"
+SRC_URI="https://github.com/arvidn/libtorrent/archive/${MY_P}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/9"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+IUSE="debug +dht doc examples libressl python +ssl static-libs test"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	dev-libs/boost:=[threads]
+	virtual/libiconv
+	examples? ( !net-p2p/mldonkey )
+	python? (
+		${PYTHON_DEPS}
+		dev-libs/boost:=[python,${PYTHON_USEDEP}]
+	)
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:= )
+	)
+"
+DEPEND="${RDEPEND}
+	sys-devel/libtool
+"
+
+S="${WORKDIR}/${PN/-rasterbar}-${MY_P}"
+
+src_prepare() {
+	mkdir "${S}"/build-aux/ || die
+	touch "${S}"/build-aux/config.rpath || die
+	eautoreconf
+
+	default
+
+	# bug 578026
+	# prepend -L${S}/... to ensure bindings link against the lib we just built
+	sed -i -e "s|^|-L${S}/src/.libs |" bindings/python/link_flags.in || die
+
+	# prepend -I${S}/... to ensure bindings use the right headers
+	sed -i -e "s|^|-I${S}/src/include |" bindings/python/compile_flags.in || die
+
+	use python && distutils-r1_src_prepare
+}
+
+src_configure() {
+	append-cxxflags -std=c++11 # bug 634506
+
+	local myeconfargs=(
+		$(use_enable debug)
+		$(use_enable debug export-all)
+		$(use_enable debug logging)
+		$(use_enable dht)
+		$(use_enable examples)
+		$(use_enable ssl encryption)
+		$(use_enable static-libs static)
+		$(use_enable test tests)
+		--with-libiconv
+	)
+	econf "${myeconfargs[@]}"
+
+	if use python; then
+		python_configure() {
+			econf "${myeconfargs[@]}" \
+				--enable-python-binding \
+				--with-boost-python="boost_${EPYTHON/./}"
+		}
+		distutils-r1_src_configure
+	fi
+}
+
+src_compile() {
+	default
+
+	python_compile() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_compile
+	}
+	use python && distutils-r1_src_compile
+}
+
+src_install() {
+	use doc && HTML_DOCS+=( "${S}"/docs )
+
+	default
+
+	python_install() {
+		cd "${BUILD_DIR}/../bindings/python" || die
+		distutils-r1_python_install
+	}
+	use python && distutils-r1_src_install
+
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/690726
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>