### PR TITLE
 app-misc/lcdproc: readd ~ppc64 keyword

### DIFF
--- a/app-misc/lcdproc/lcdproc-0.5.9.ebuild
+++ b/app-misc/lcdproc/lcdproc-0.5.9.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="http://www.lcdproc.org/"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${PV}/${P}.tar.gz
 	https://raw.githubusercontent.com/lcdproc/lcdproc/master/docs/lcdproc-user/drivers/linux_input.docbook"
 
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="amd64 ~ppc ~ppc64 x86"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="debug doc ethlcd extra-charmaps freetype menu nfs png samba test-menu"

--- a/dev-libs/serdisplib/serdisplib-2.01-r1.ebuild
+++ b/dev-libs/serdisplib/serdisplib-2.01-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 IUSE="threads tools"
 
 # Define the list of valid lcd devices.

--- a/x11-libs/libdlo/libdlo-0.1.2-r1.ebuild
+++ b/x11-libs/libdlo/libdlo-0.1.2-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://people.freedesktop.org/~berniet/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc x86"
+KEYWORDS="amd64 ppc ~ppc64 x86"
 IUSE="static-libs test-program"
 
 RDEPEND="virtual/libusb:0="


### PR DESCRIPTION
Thanks to the hard work of ernsteiswuerfel, we can finally readd the
~ppc64 keyword to app-misc/lcdproc, as all tests passed.

Closes: https://bugs.gentoo.org/671028
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>