### PR TITLE
dev-libs/aws-sdk-cpp: Shorten the 'other' USE flag description

### DIFF
--- a/dev-libs/aws-sdk-cpp/metadata.xml
+++ b/dev-libs/aws-sdk-cpp/metadata.xml
@@ -284,76 +284,12 @@
 			This is a meta-flag for rarely needed modules that in themselves need not much build time. If
 			you would like to have any of the following modules to have their own USE flag, please open a
 			bug report and it will most probably get one.
-			Alexa for Business      : Manage Alexa devices, enroll users, and assign skills.
-			AWS Migration Hub       : A single location to track migration tasks across multiple AWS tools
-				and partner solutions.
-			Amazon Cloud Directory  : Store hundreds of millions of application-specific objects with
-				multiple relationships and schemas.
-			Amazon Comprehend       : Natural language processing (NLP) to extract insights about the
-				content of documents without the need of any special preprocessing.
-			Comprehend Medical      : Specialized Amazon Comprehend variant to extract insights from
-				clinical documents such as doctors notes or clinical trial reports.
-			Amazon Connect          : A contact center as a service (CCaS) solution that offers easy, self-
-				service configuration and enables dynamic, personal, and natural customer engagement at
-				any scale.
-			AWS Data Pipeline       : A web service to automate the movement and transformation of data.
-			AWS Data Sync           : A data-transfer service that simplifies, automates, and accelerates
-				moving and replicating data between on-premises storage systems and AWS storage services
-				over the internet or AWS Direct Connect.
-			AWS Direct Connect      : Link your internal network to an AWS Direct Connect location over a
-				standard 1 gigabit or 10 gigabit Ethernet fiber-optic cable.
-			Application Discovery   : Automatically identify applications running in on-premises data
-				centers, their associated dependencies, and their performance profile.
-			Database Migration (DMS): Migrate data from a database that is on-premises, on an Amazon
-				Relational Database Service (Amazon RDS) DB instance, or in a database on an Amazon
-				Elastic Compute Cloud (Amazon EC2) instance to a database on an AWS service.
-			Amazon DocumentDB       : Fully managed database service to set up, operate, and scale MongoDB-
-				compatible databases.
-			AWS Directory Service   : A web service to setup and run directories in the AWS cloud, or
-				connect AWS resources with an existing on-premises Microsoft Active Directory.
-			Amazon DynamoDB         : A fully managed NoSQL database with seamless scalability. Also enables
-				dax and dynamodbstreams.
-			Amazon GameLift         : A fully managed service for deploying, operating, and scaling session-
-				based multiplayer game servers in the cloud.
-			Amazon Glue             : Fully managed ETL (extract, transform, and load) service to categorize
-				data, clean it, enrich it, and move it reliably between various data stores.
-			Amazon Ground Station   : Fully managed service that enables you to control satellite
-				communications, process satellite data, and scale your satellite operations.
-			AWS Import/Export       : Accelerates transferring large amounts of data between the AWS cloud
-				and portable storage devices that are mailed to Amazon.
-			Amazon Kafka            : Amazon Managed Streaming for Apache Kafka (Amazon MSK)
-			AWS Lake Formation      : A managed service to set up, secure, and manage your data lakes.
-			Amazon MQ               : A managed message broker service for Apache ActiveMQ to set up and
-				operate message brokers in the cloud.
-			Amazon Mechanical Turk  : Request on-demand, scalable, human workforce to complete jobs that
-				humans can do better than computers, such as recognizing objects in photographs.
-			Amazon Neptune          : Fast and reliable fully managed graph database service. Supports
-				Apache TinkerPop Gremlin and W3Cs SPARQL
-			Amazon QuickSight       : A fast business analytics service to build visualizations, perform ad
-				hoc analysis, and quickly get business insights from your data.
-			Amazon Redshift         : Fully managed petabyte-scale data warehouse service.
-			Amazon Robomaker        : A service to develop, simulate, and deploy intelligent robotics
-				applications at scale.
-			AWS ServiceCatalog      : Create, manage, and distribute portfolios of approved products to end
-				users, who can then access the products they need in a personalized portal.
-			AWS ServiceDiscovery    : Use AWS Cloud Map to configure public DNS, private DNS, or HTTP
-				namespaces that microservice applications run in.
-			AWS Service Quotas      : Service for viewing and managing quotas
-			AWS Simple DB (SDB)     : A web service providing the core database functions of data indexing
-				and querying in the cloud.
-			AWS Code Signer         : Use AWS Signer for FreeRTOS to sign code that you created for any of
-				the IoT devices that Amazon Web Services supports.
-			Server Migration Service: (SMS) Combines data collection tools with automated server replication
-				to speed the migration of on-premises servers to AWS.
-			AWS Snowball            : A service to transport terabytes or petabytes of data to and from AWS
-			AWS Systems Manager     : (SSM) Organize, monitor, and automate management tasks on AWS
-				resources.
-			AWS Step Functions      : (states) A service to coordinate the components of distributed
-				applications and microservices using visual workflows.
-			AWS Storage Gateway     : Connect on-premises software with cloud-based storage.
-			Amazon Support          : Provides support for users of Amazon Web Services.
-			Simple Workflow Service : (SWF) Build applications that coordinate work across distributed
-				components.
+			The modules are:
+			AWSMigrationHub, alexaforbusiness, clouddirectory, comprehend, comprehendmedical, connect,
+			datapipeline, datasync, directconnect, discovery, dms, docdb, ds, dynamodb, gamelift, glue,
+			groundstation, importexport, kafka, lakeformation, mq, mturk-requester, neptune, quicksight,
+			redshift, robomaker, sdb, service-quotas, servicecatalog, servicediscovery, signer, sms,
+			snowball, ssm, states, storagegateway, support and swf.
 		</flag>
 		<flag name="personalize">
 			Real-time personalization and recommendations, based on the same technology used at Amazon.com.


### PR DESCRIPTION
Unfortunately that description is way too long. It has over 5k characters,
which is too much, at least for app-portage/ufed and app-portage/euses.

This commit throws away the lengthy description of each module and replaces
them with a mere list of the modules. As these are supposed to be rarely used
modules anyway, this shouldn't be a problem. If any of the modules is requested
to get its own USE flag, we can re-add its proper description.

Bug: https://bugs.gentoo.org/695262
Bug: https://bugs.gentoo.org/695462
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Sven Eden <yamakuzure@gmx.net>