### PR TITLE
sys-boot/gnu-efi: Fix building with clang-9

### DIFF
--- a/sys-boot/gnu-efi/files/gnu-efi-3.0.9-fix-clang-build.patch
+++ b/sys-boot/gnu-efi/files/gnu-efi-3.0.9-fix-clang-build.patch
@@ -1,0 +1,19 @@
+Bug: https://bugs.gentoo.org/695612
+Upstream: https://sourceforge.net/p/gnu-efi/patches/70/
+
+--- a/Make.defaults
++++ b/Make.defaults
+@@ -110,10 +110,10 @@
+                             || ( [ $(GCCVERSION) -eq "4" ]      \
+                                  && [ $(GCCMINOR) -ge "7" ] ) ) \
+                           && echo 1)
+-  ifeq ($(GCCNEWENOUGH),1)
+-    CPPFLAGS += -DGNU_EFI_USE_MS_ABI -maccumulate-outgoing-args --std=c11
+-  else ifeq ($(USING_CLANG),clang)
++  ifeq ($(USING_CLANG),clang)
+     CPPFLAGS += -DGNU_EFI_USE_MS_ABI --std=c11
++  else ifeq ($(GCCNEWENOUGH),1)
++    CPPFLAGS += -DGNU_EFI_USE_MS_ABI -maccumulate-outgoing-args --std=c11
+   endif
+ 
+   CFLAGS += -mno-red-zone

--- a/sys-boot/gnu-efi/gnu-efi-3.0.9.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.9.ebuild
@@ -24,9 +24,11 @@ IUSE="abi_x86_32 abi_x86_64 custom-cflags"
 QA_EXECSTACK="usr/*/lib*efi.a:* usr/*/crt*.o"
 RESTRICT="strip"
 
+PATCHES=( "${FILESDIR}"/${PN}-3.0.9-fix-clang-build.patch )
+
 src_prepare() {
-	sed -i -e "s/-Werror//" Make.defaults || die
 	default
+	sed -i -e "s/-Werror//" Make.defaults || die
 }
 
 efimake() {


### PR DESCRIPTION
Building _gnu-efi-3.0.9_ with clang-9.0.0 fails with `error: unknown argument: '-maccumulate-outgoing-args'`

_Make.defaults_ ends up evaluating clang's version as a valid `GCCVERSION` and procedes to add `-maccumulate-outgoing-args` to CFLAGS/CPPFLAGS.  The simplest fix is to change the affected `if` statement to test `USING_CLANG` first, as the statement `USING_CLANG  := $(shell $(CC) -v 2>&1 | grep -q 'clang version' && echo clang)` will never evaluate to "clang" if the compiler is GCC.

Reported upstream: https://sourceforge.net/p/gnu-efi/patches/70/

Also moves `src_prepare()`'s `default` before the `sed` statement to avoid any potential userpatch failures.

Closes: https://bugs.gentoo.org/695612
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Peter Levine <plevine457@gmail.com>