### PR TITLE
sys-apps/systemd: remove pdepend on sys-fs/udev-init-scripts

### DIFF
--- a/sys-apps/systemd/systemd-242-r6.ebuild
+++ b/sys-apps/systemd/systemd-242-r6.ebuild
@@ -111,7 +111,6 @@ RDEPEND="${COMMON_DEPEND}
 # sys-apps/dbus: the daemon only (+ build-time lib dep for tests)
 PDEPEND=">=sys-apps/dbus-1.9.8[systemd]
 	>=sys-apps/hwids-20150417[udev]
-	>=sys-fs/udev-init-scripts-25
 	policykit? ( sys-auth/polkit )
 	!vanilla? ( sys-apps/gentoo-systemd-integration )"
 

--- a/sys-apps/systemd/systemd-242-r7.ebuild
+++ b/sys-apps/systemd/systemd-242-r7.ebuild
@@ -111,7 +111,6 @@ RDEPEND="${COMMON_DEPEND}
 # sys-apps/dbus: the daemon only (+ build-time lib dep for tests)
 PDEPEND=">=sys-apps/dbus-1.9.8[systemd]
 	>=sys-apps/hwids-20150417[udev]
-	>=sys-fs/udev-init-scripts-25
 	policykit? ( sys-auth/polkit )
 	!vanilla? ( sys-apps/gentoo-systemd-integration )"
 

--- a/sys-apps/systemd/systemd-243.ebuild
+++ b/sys-apps/systemd/systemd-243.ebuild
@@ -108,7 +108,6 @@ RDEPEND="${COMMON_DEPEND}
 # sys-apps/dbus: the daemon only (+ build-time lib dep for tests)
 PDEPEND=">=sys-apps/dbus-1.9.8[systemd]
 	>=sys-apps/hwids-20150417[udev]
-	>=sys-fs/udev-init-scripts-25
 	policykit? ( sys-auth/polkit )
 	!vanilla? ( sys-apps/gentoo-systemd-integration )"
 

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -108,7 +108,6 @@ RDEPEND="${COMMON_DEPEND}
 # sys-apps/dbus: the daemon only (+ build-time lib dep for tests)
 PDEPEND=">=sys-apps/dbus-1.9.8[systemd]
 	>=sys-apps/hwids-20150417[udev]
-	>=sys-fs/udev-init-scripts-25
 	policykit? ( sys-auth/polkit )
 	!vanilla? ( sys-apps/gentoo-systemd-integration )"
 


### PR DESCRIPTION
sys-fs/udev-init-scripts provides the following content:
  /etc/conf.d/udev-trigger
  /etc/conf.d/udev-settle
  /etc/conf.d/udev
  /etc/init.d/udev-trigger
  /etc/init.d/udev-settle
  /etc/init.d/udev

none of them are used by sys-apps/systemd since they can only be
consumed by openrc

Bug: https://bugs.gentoo.org/695654

Package-Manager: Portage-2.3.69, Repoman-2.3.16