### PR TITLE
dev-libs/aws-c-event-stream: Fix dependencies (#695206)

### DIFF
--- a/dev-libs/aws-c-event-stream/aws-c-event-stream-0.1.3.ebuild
+++ b/dev-libs/aws-c-event-stream/aws-c-event-stream-0.1.3.ebuild
@@ -15,7 +15,10 @@ KEYWORDS="~amd64 ~x86"
 
 IUSE="test"
 
-DEPEND="dev-libs/aws-c-common"
+DEPEND="
+	dev-libs/aws-c-common
+	dev-libs/aws-checksums
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PV}-add_missing_cmake_install_prefix.patch


### PR DESCRIPTION
Unfortunately I forgot to add dev-libs/aws-checksums to the list of
dependencies.
This is explicitly not a revision bump, as this would cause rebuilds
for everybody who has already merged this successfully.

Bug: https://bugs.gentoo.org/695206
Closes: https://bugs.gentoo.org/695206
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Sven Eden <yamakuzure@gmx.net>