### PR TITLE
net-dns/getdns: fix USE flags names

### DIFF
--- a/net-dns/getdns/getdns-1.5.1.ebuild
+++ b/net-dns/getdns/getdns-1.5.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://getdnsapi.net/releases/${P//./-}/${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="doc +getdns_query +getdns_server_mon +idn libev libevent libressl libuv static-libs stubby +threads +unbound"
+IUSE="doc +getdns-query +getdns-server-mon +idn libev libevent libressl libuv static-libs stubby +threads +unbound"
 
 # https://bugs.gentoo.org/661760
 # https://github.com/getdnsapi/getdns/issues/407
@@ -43,8 +43,8 @@ src_configure() {
 	econf \
 		--runstatedir=/var/run \
 		$(use_enable static-libs static) \
-		$(use_with getdns_query) \
-		$(use_with getdns_server_mon) \
+		$(use_with getdns-query getdns_query) \
+		$(use_with getdns-server-mon getdns_server_mon) \
 		$(use_with idn libidn2) \
 		$(use_with libev) \
 		$(use_with libevent) \

--- a/net-dns/getdns/getdns-1.5.2-r2.ebuild
+++ b/net-dns/getdns/getdns-1.5.2-r2.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://getdnsapi.net/releases/${P//./-}/${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="doc +getdns_query +getdns_server_mon gnutls +idn libev libevent libuv nettle static-libs stubby +threads +unbound"
+IUSE="doc +getdns-query +getdns-server-mon gnutls +idn libev libevent libuv nettle static-libs stubby +threads +unbound"
 
 REQUIRED_USE="gnutls? ( nettle )"
 
@@ -46,8 +46,8 @@ src_configure() {
 	econf \
 		--runstatedir=/var/run \
 		$(use_enable static-libs static) \
-		$(use_with getdns_query) \
-		$(use_with getdns_server_mon) \
+		$(use_with getdns-query getdns_query) \
+		$(use_with getdns-server-mon getdns_server_mon) \
 		$(usex gnutls '--with-gnutls' '' '' '') \
 		$(use_with idn libidn2) \
 		$(use_with libev) \

--- a/net-dns/getdns/metadata.xml
+++ b/net-dns/getdns/metadata.xml
@@ -11,8 +11,8 @@
 	</maintainer>
 	<use>
 		<flag name="stubby">Add Stubby DNS Privacy Deamon</flag>
-		<flag name="getdns_query">Add getdns_query tool</flag>
-		<flag name="getdns_server_mon">Add getdns_server_mon tool</flag>
+		<flag name="getdns-query">Add getdns_query tool</flag>
+		<flag name="getdns-server-mon">Add getdns_server_mon tool</flag>
 		<flag name="unbound">Enable <pkg>net-dns/unbound</pkg> libraries support</flag>
 		<flag name="libevent">Enable <pkg>dev-libs/libevent</pkg> support</flag>
 		<flag name="libev">Enable <pkg>dev-libs/libev</pkg> support</flag>


### PR DESCRIPTION
This pull request fix USE flags names for getdns-query and getdns-server-mon to remove underscore reserved characters.
I’ve linked the bug with just Bug in commit message and not Closes because there is other stuff to fix like packages for system user and group.