### PR TITLE
dev-ml/camlp4: restrict ocaml version

### DIFF
--- a/dev-ml/camlp4/camlp4-4.04_p1.ebuild
+++ b/dev-ml/camlp4/camlp4-4.04_p1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -15,7 +15,9 @@ SLOT="0/${PV}"
 KEYWORDS="alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
 IUSE="+ocamlopt"
 
-DEPEND=">=dev-lang/ocaml-4.04_beta:=[ocamlopt?]"
+DEPEND="
+	=dev-lang/ocaml-4.04*:=[ocamlopt?]
+"
 RDEPEND="${DEPEND}
 	!<dev-lang/ocaml-4.02
 	!<dev-ml/findlib-1.5.5-r1"

--- a/dev-ml/camlp4/camlp4-4.05_p1.ebuild
+++ b/dev-ml/camlp4/camlp4-4.05_p1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5


### PR DESCRIPTION
It doesn't build if the ocaml version doesn't match
the version of the package

Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>