### PR TITLE
net-libs/ldns: Python 3.6 and 3.7 compatibility

### DIFF
--- a/net-libs/ldns/ldns-1.7.1.ebuild
+++ b/net-libs/ldns/ldns-1.7.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python2_7 python3_5 python3_6 )
+PYTHON_COMPAT=( python2_7 python3_5 python3_6 python3_7 )
 inherit eutils multilib-minimal python-single-r1
 
 DESCRIPTION="a library with the aim to simplify DNS programming in C"

--- a/net-libs/ldns/ldns-1.7.1.ebuild
+++ b/net-libs/ldns/ldns-1.7.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python2_7 python3_5 )
+PYTHON_COMPAT=( python2_7 python3_5 python3_6 )
 inherit eutils multilib-minimal python-single-r1
 
 DESCRIPTION="a library with the aim to simplify DNS programming in C"


### PR DESCRIPTION
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>

Seems to work to me.

Thanks!