### PR TITLE
media-sound/wavpack: disable static libraries

### DIFF
--- a/media-sound/wavpack/wavpack-5.1.0-r1.ebuild
+++ b/media-sound/wavpack/wavpack-5.1.0-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="http://www.wavpack.com/${P}.tar.bz2"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 ~hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~x86-solaris"
-IUSE="static-libs"
+IUSE=""
 
 RDEPEND=">=virtual/libiconv-0-r1"
 DEPEND="${RDEPEND}"
@@ -32,6 +32,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	ECONF_SOURCE=${S} econf \
+		--disable-static \
 		$(multilib_native_enable apps)
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694124
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>