### PR TITLE
media-libs/zimg: disable static libraries

### DIFF
--- a/media-libs/zimg/zimg-2.8.ebuild
+++ b/media-libs/zimg/zimg-2.8.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/sekrit-twc/zimg"
 
 LICENSE="WTFPL-2"
 SLOT="0"
-IUSE="static-libs cpu_flags_x86_sse"
+IUSE="cpu_flags_x86_sse"
 
 src_prepare() {
 	default
@@ -27,5 +27,6 @@ src_prepare() {
 
 multilib_src_configure() {
 	ECONF_SOURCE="${S}" econf \
+		--disable-static \
 		$(use_enable cpu_flags_x86_sse x86simd)
 }

--- a/media-libs/zimg/zimg-9999.ebuild
+++ b/media-libs/zimg/zimg-9999.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/sekrit-twc/zimg"
 
 LICENSE="WTFPL-2"
 SLOT="0"
-IUSE="static-libs cpu_flags_x86_sse"
+IUSE="cpu_flags_x86_sse"
 
 src_prepare() {
 	default
@@ -27,5 +27,6 @@ src_prepare() {
 
 multilib_src_configure() {
 	ECONF_SOURCE="${S}" econf \
+		--disable-static \
 		$(use_enable cpu_flags_x86_sse x86simd)
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694132
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>