### PR TITLE
sci-libs/arpack: disable static libraries

### DIFF
--- a/sci-libs/arpack/arpack-3.1.5.ebuild
+++ b/sci-libs/arpack/arpack-3.1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -20,7 +20,7 @@ SRC_URI="
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="amd64 ~arm hppa ppc ppc64 x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE="doc examples mpi static-libs"
+IUSE="doc examples mpi"
 
 RDEPEND="
 	virtual/blas
@@ -34,6 +34,7 @@ S="${WORKDIR}/${MY_P/_/-}"
 src_configure() {
 	tc-export PKG_CONFIG
 	local myeconfargs=(
+		--disable-static
 		--with-blas="$($(tc-getPKG_CONFIG) --libs blas)"
 		--with-lapack="$($(tc-getPKG_CONFIG) --libs lapack)"
 		$(use_enable mpi)

--- a/sci-libs/arpack/arpack-3.4.0.ebuild
+++ b/sci-libs/arpack/arpack-3.4.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit autotools eutils fortran-2 toolchain-funcs
 
@@ -16,7 +16,7 @@ SRC_URI="
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE="doc examples mpi static-libs"
+IUSE="doc examples mpi"
 
 RDEPEND="
 	virtual/blas
@@ -34,6 +34,7 @@ src_prepare() {
 
 src_configure() {
 	econf \
+		--disable-static \
 		--with-blas="$($(tc-getPKG_CONFIG) --libs blas)" \
 		--with-lapack="$($(tc-getPKG_CONFIG) --libs lapack)" \
 		$(use_enable mpi)

--- a/sci-libs/arpack/arpack-3.5.0.ebuild
+++ b/sci-libs/arpack/arpack-3.5.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit autotools eutils fortran-2 toolchain-funcs
 
@@ -16,7 +16,7 @@ SRC_URI="
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE="doc examples mpi static-libs"
+IUSE="doc examples mpi"
 
 RDEPEND="
 	virtual/blas
@@ -34,6 +34,7 @@ src_prepare() {
 
 src_configure() {
 	econf \
+		--disable-static
 		--with-blas="$($(tc-getPKG_CONFIG) --libs blas)" \
 		--with-lapack="$($(tc-getPKG_CONFIG) --libs lapack)" \
 		$(use_enable mpi)

--- a/sci-libs/arpack/arpack-9999.ebuild
+++ b/sci-libs/arpack/arpack-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit autotools eutils fortran-2 toolchain-funcs
 
@@ -19,7 +19,7 @@ DESCRIPTION="Arnoldi package library to solve large scale eigenvalue problems"
 HOMEPAGE="http://www.caam.rice.edu/software/ARPACK/ https://github.com/opencollab/arpack-ng"
 LICENSE="BSD"
 SLOT="0"
-IUSE="examples mpi static-libs"
+IUSE="examples mpi"
 
 RDEPEND="
 	virtual/blas
@@ -35,6 +35,7 @@ src_prepare() {
 
 src_configure() {
 	econf \
+		--disable-static \
 		--with-blas="$($(tc-getPKG_CONFIG) --libs blas)" \
 		--with-lapack="$($(tc-getPKG_CONFIG) --libs lapack)" \
 		$(use_enable mpi)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694130
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>