### PR TITLE
www-misc/htdig: disable static libraries

### DIFF
--- a/www-misc/htdig/htdig-3.2.0_beta6-r5.ebuild
+++ b/www-misc/htdig/htdig-3.2.0_beta6-r5.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit autotools
 
@@ -44,6 +44,7 @@ src_prepare() {
 
 src_configure() {
 	local myeconfargs=(
+		--disable-static
 		--with-config-dir="${EPREFIX}"/etc/${PN}
 		--with-default-config-file="${EPREFIX}"/etc/${PN}/${PN}.conf
 		--with-database-dir="${EPREFIX}"/var/lib/${PN}/db


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/378207
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>