### PR TITLE
dev-util/rocminfo: New revision to set target.lst by env var

### DIFF
--- a/dev-util/rocminfo/files/rocminfo-2.8.0-add-env-var.patch
+++ b/dev-util/rocminfo/files/rocminfo-2.8.0-add-env-var.patch
@@ -1,0 +1,20 @@
+diff --git a/rocm_agent_enumerator b/rocm_agent_enumerator
+index 7a73339..78e8215 100755
+--- a/rocm_agent_enumerator
++++ b/rocm_agent_enumerator
+@@ -55,9 +55,11 @@ def getGCNISA(line, match_from_beginning = False):
+ def readFromTargetLstFile():
+   target_list = []
+ 
+-  # locate target.lst which should be placed at the same directory with this
+-  # script
+-  target_lst_path = os.path.join(CWD, "target.lst")
++  # locate target.lst using environment variable or
++  # it should be placed at the same directory with this script
++  target_lst_path = os.environ.get("ROCM_TARGET_LST");
++  if target_lst_path == None:
++    target_lst_path = os.path.join(CWD, "target.lst")
+   if os.path.isfile(target_lst_path):
+     target_lst_file = open(target_lst_path, 'r')
+     for line in target_lst_file:
+

--- a/dev-util/rocminfo/rocminfo-2.8.0-r1.ebuild
+++ b/dev-util/rocminfo/rocminfo-2.8.0-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils
+
+if [[ ${PV} == *9999 ]] ; then
+	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/rocminfo/"
+	inherit git-r3
+else
+	SRC_URI="https://github.com/RadeonOpenCompute/rocminfo/archive/roc-${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+	S="${WORKDIR}/rocminfo-roc-${PV}"
+fi
+
+DESCRIPTION="ROCm Application for Reporting System Info"
+HOMEPAGE="https://github.com/RadeonOpenCompute/rocminfo"
+LICENSE="MIT"
+SLOT="0/$(ver_cut 1-2)"
+
+RDEPEND="dev-libs/rocr-runtime"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/rocminfo-2.8.0-add-env-var.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DROCM_DIR="${ESYSROOT}/usr"
+		-DROCR_INC_DIR="${ESYSROOT}/usr/include"
+		-DROCR_LIB_DIR="${EPREFIX}/usr/$(get_libdir)"
+	)
+	cmake-utils_src_configure
+}


### PR DESCRIPTION
Signed-off-by: Wilfried Holzke <gentoo@holzke.net>
Package-Manager: Portage-2.3.69, Repoman-2.3.16

Created already an upstream PR for the patch: https://github.com/RadeonOpenCompute/rocminfo/pull/26