### PR TITLE
media-fonts/liberation-fonts: fix compilation with python3

### DIFF
--- a/media-fonts/liberation-fonts/liberation-fonts-2.00.5.ebuild
+++ b/media-fonts/liberation-fonts/liberation-fonts-2.00.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit font python-any-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694918
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>