### PR TITLE
Inline mirror://gnome

### DIFF
--- a/dev-python/gnome-python-base/gnome-python-base-2.28.1-r1.ebuild
+++ b/dev-python/gnome-python-base/gnome-python-base-2.28.1-r1.ebuild
@@ -13,7 +13,7 @@ MY_PN="gnome-python"
 DESCRIPTION="Provides the base files for the gnome-python bindings"
 HOMEPAGE="http://pygtk.org/"
 PVP="$(get_version_component_range 1-2)"
-SRC_URI="mirror://gnome/sources/${MY_PN}/${PVP}/${MY_PN}-${PV}.tar.bz2"
+SRC_URI="https://download.gnome.org/sources/${MY_PN}/${PVP}/${MY_PN}-${PV}.tar.bz2"
 
 IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/dev-python/gnome-python-extras-base/gnome-python-extras-base-2.25.3-r1.ebuild
+++ b/dev-python/gnome-python-extras-base/gnome-python-extras-base-2.25.3-r1.ebuild
@@ -11,7 +11,7 @@ MY_PN="gnome-python-extras"
 DESCRIPTION="Provides python the base files for the Gnome Python Desktop bindings"
 HOMEPAGE="http://pygtk.org/"
 PVP="$(ver_cut 1-2)"
-SRC_URI="mirror://gnome/sources/${MY_PN}/${PVP}/${MY_PN}-${PV}.tar.bz2"
+SRC_URI="https://download.gnome.org/sources/${MY_PN}/${PVP}/${MY_PN}-${PV}.tar.bz2"
 
 IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/eclass/gnome.org.eclass
+++ b/eclass/gnome.org.eclass
@@ -48,6 +48,6 @@ fi
 # Major and minor numbers of the version number.
 : ${GNOME_ORG_PVP:=$(ver_cut 1-2)}
 
-SRC_URI="mirror://gnome/sources/${GNOME_ORG_MODULE}/${GNOME_ORG_PVP}/${GNOME_ORG_MODULE}-${PV}.tar.${GNOME_TARBALL_SUFFIX}"
+SRC_URI="https://download.gnome.org/sources/${GNOME_ORG_MODULE}/${GNOME_ORG_PVP}/${GNOME_ORG_MODULE}-${PV}.tar.${GNOME_TARBALL_SUFFIX}"
 
 S="${WORKDIR}/${GNOME_ORG_MODULE}-${PV}"

--- a/gnome-extra/chrome-gnome-shell/chrome-gnome-shell-10-r1.ebuild
+++ b/gnome-extra/chrome-gnome-shell/chrome-gnome-shell-10-r1.ebuild
@@ -9,7 +9,7 @@ inherit cmake-utils python-single-r1
 
 DESCRIPTION="GNOME Shell integration for Chrome/Chromium, Firefox, Vivaldi, Opera browsers"
 HOMEPAGE="https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome"
-SRC_URI="mirror://gnome/sources/${PN}/${PV}/${P}.tar.xz"
+SRC_URI="https://download.gnome.org/sources/${PN}/${PV}/${P}.tar.xz"
 
 LICENSE="GPL-3+"
 SLOT="0"

--- a/gnome-extra/chrome-gnome-shell/chrome-gnome-shell-10.ebuild
+++ b/gnome-extra/chrome-gnome-shell/chrome-gnome-shell-10.ebuild
@@ -9,7 +9,7 @@ inherit cmake-utils python-single-r1
 
 DESCRIPTION="GNOME Shell integration for Chrome/Chromium, Firefox, Vivaldi, Opera browsers"
 HOMEPAGE="https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome"
-SRC_URI="mirror://gnome/sources/${PN}/${PV}/${P}.tar.xz"
+SRC_URI="https://download.gnome.org/sources/${PN}/${PV}/${P}.tar.xz"
 
 LICENSE="GPL-3+"
 SLOT="0"

--- a/media-libs/gexiv2/gexiv2-0.10.10-r1.ebuild
+++ b/media-libs/gexiv2/gexiv2-0.10.10-r1.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.gnome.org/GNOME/gexiv2.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://gnome/sources/${PN}/$(ver_cut 1-2)/${P}.tar.xz"
+	SRC_URI="https://download.gnome.org/sources/${PN}/$(ver_cut 1-2)/${P}.tar.xz"
 	KEYWORDS="alpha amd64 arm arm64 ~hppa ia64 ppc ppc64 sparc x86 ~amd64-fbsd"
 fi
 

--- a/media-libs/gexiv2/gexiv2-0.12.0.ebuild
+++ b/media-libs/gexiv2/gexiv2-0.12.0.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.gnome.org/GNOME/gexiv2.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://gnome/sources/${PN}/$(ver_cut 1-2)/${P}.tar.xz"
+	SRC_URI="https://download.gnome.org/sources/${PN}/$(ver_cut 1-2)/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd"
 fi
 

--- a/media-libs/gexiv2/gexiv2-9999.ebuild
+++ b/media-libs/gexiv2/gexiv2-9999.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.gnome.org/GNOME/gexiv2.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://gnome/sources/${PN}/$(ver_cut 1-2)/${P}.tar.xz"
+	SRC_URI="https://download.gnome.org/sources/${PN}/$(ver_cut 1-2)/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd"
 fi
 

--- a/media-libs/imlib/imlib-1.9.15-r5.ebuild
+++ b/media-libs/imlib/imlib-1.9.15-r5.ebuild
@@ -7,7 +7,7 @@ inherit autotools multilib-minimal
 PVP=(${PV//[-\._]/ })
 DESCRIPTION="Image loading and rendering library"
 HOMEPAGE="http://ftp.acc.umu.se/pub/GNOME/sources/imlib/1.9/"
-SRC_URI="mirror://gnome/sources/${PN}/${PVP[0]}.${PVP[1]}/${P}.tar.bz2
+SRC_URI="https://download.gnome.org/sources/${PN}/${PVP[0]}.${PVP[1]}/${P}.tar.bz2
 	mirror://gentoo/gtk-1-for-imlib.m4.bz2"
 
 LICENSE="GPL-2"

--- a/profiles/thirdpartymirrors
+++ b/profiles/thirdpartymirrors
@@ -6,7 +6,6 @@ debian		https://deb.debian.org/debian/ http://ftp.au.debian.org/debian/ http://f
 gentoo		https://gentoo.osuosl.org/distfiles https://ftp.halifax.rwth-aachen.de/gentoo/distfiles http://gentoo-distfiles.mirrors.tds.net/distfiles https://gentoo.ussg.indiana.edu/distfiles
 gimp		https://ftp.fau.de/gimp/gimp/ ftp://ftp.fau.de/gimp/gimp/ https://artfiles.org/gimp.org/pub/gimp/ https://www.mirrorservice.org/sites/ftp.gimp.org/pub/gimp/ ftp://ftp.mirrorservice.org/sites/ftp.gimp.org/pub/gimp/ http://pirbot.com/mirrors/gimp/gimp/
 gmt		http://ftp.iris.washington.edu/pub/gmt/ ftp://ftp.soest.hawaii.edu/gmt/ ftp://ftp.iris.washington.edu/pub/gmt/ ftp://ftp.star.nesdis.noaa.gov/pub/sod/lsa/gmt
-gnome		https://download.gnome.org/
 gnu		https://ftp.gnu.org/gnu/ https://ftpmirror.gnu.org/ https://artfiles.org/gnu.org/ https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/
 gnu-alpha	https://www.mirrorservice.org/sites/alpha.gnu.org/gnu/ https://gnualpha.uib.no/ https://mirrors.fe.up.pt/pub/gnu-alpha/ http://alpha.gnu.org/gnu/ http://www.nic.funet.fi/pub/gnu/alpha/gnu/ http://mirror.lihnidos.org/GNU/alpha/gnu/ http://mirrors.ibiblio.org/gnu/alpha/gnu/ ftp://ftp.funet.fi/pub/gnu/alpha/gnu/ ftp://gnualpha.uib.no/pub/gnualpha/ ftp://mirrors.fe.up.pt/pub/gnu-alpha/ ftp://alpha.gnu.org/gnu/
 gnupg		https://artfiles.org/gnupg.org/ https://www.mirrorservice.org/sites/ftp.gnupg.org/ https://ftp.heanet.ie/mirrors/ftp.gnupg.org/gcrypt/ https://mirrors.dotsrc.org/gcrypt/ ftp://ftp.gnupg.org/gcrypt/

--- a/x11-themes/experience/experience-3.04-r1.ebuild
+++ b/x11-themes/experience/experience-3.04-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 DESCRIPTION="GTK+2 themes which copy and improve the look of XP Luna"
 HOMEPAGE="https://web.archive.org/web/20130730053042/https://art.gnome.org/themes/gtk2/1058"
-SRC_URI="mirror://gnome/teams/art.gnome.org/themes/gtk2/GTK2-EXperience.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://download.gnome.org/teams/art.gnome.org/themes/gtk2/GTK2-EXperience.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
The gnome mirror group specifies only one mirror. Inline it in ebuilds and eclass, and remove the redundant thirdpartymirrors entry.