### PR TITLE
net-proxy/squid: Add cross-compilation patch

### DIFF
--- a/net-proxy/squid/files/squid-4.8-max-fd.patch
+++ b/net-proxy/squid/files/squid-4.8-max-fd.patch
@@ -1,0 +1,17 @@
+Patch the autoconf file to use the fallback MAXFD number when cross-compiling.
+Without this patch the configure step fails due to trying to execute a binary
+while cross compiling.
+
+diff --git a/acinclude/os-deps.m4 b/acinclude/os-deps.m4
+index b507175..fb035f8 100644
+--- a/acinclude/os-deps.m4
++++ b/acinclude/os-deps.m4
+@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
+ 	fprintf (fp, "%d\n", i & ~0x3F);
+ 	return 0;
+ }
+-  ]])],[squid_filedescriptors_limit=`cat conftestval`],[],[])
++  ]])],[squid_filedescriptors_limit=`cat conftestval`],[],[squid_filedescriptors_limit=256])
+   dnl Microsoft MSVCRT.DLL supports 2048 maximum FDs
+   AS_CASE(["$host_os"],[mingw|mingw32],[squid_filedescriptors_limit="2048"])
+   AC_MSG_RESULT($squid_filedescriptors_limit)

--- a/net-proxy/squid/squid-4.8.ebuild
+++ b/net-proxy/squid/squid-4.8.ebuild
@@ -78,6 +78,7 @@ pkg_setup() {
 
 src_prepare() {
 	eapply "${FILESDIR}/${PN}-4.3-gentoo.patch"
+	eapply "${FILESDIR}/${PN}-4.8-max-fd.patch"
 	sed -i -e 's:/usr/local/squid/etc:/etc/squid:' \
 		INSTALL QUICKSTART \
 		scripts/fileno-to-pathname.pl \


### PR DESCRIPTION
Add a patch to the configure script to fall back to the default number
of max file descriptors instead of trying to run a test binary when
cross-compiling.

Signed-off-by: Chris McDonald <cjmcdonald@chromium.org>