### PR TITLE
app-admin/gam-server: Support building app-admin/gam-server with clang and update EAPI to 7

### DIFF
--- a/app-admin/gam-server/files/gam-server-0.1.10-clang-fix.patch
+++ b/app-admin/gam-server/files/gam-server-0.1.10-clang-fix.patch
@@ -1,0 +1,16 @@
+Bug: https://bugs.gentoo.org/509696
+
+Don't rely on GCC's void to 0 implicit conversion
+for void return statements.
+
+--- a/server/gam_eq.c
++++ b/server/gam_eq.c
+@@ -124,7 +124,7 @@
+ {
+ 	gboolean done_work = FALSE;
+ 	if (!eq)
+-		return;
++		return done_work;
+ 
+ #ifdef GAM_EQ_VERBOSE
+ 	GAM_DEBUG(DEBUG_INFO, "gam_eq: Flushing event queue for %s\n", gam_connection_get_pidname (conn));

--- a/app-admin/gam-server/files/gam-server-0.1.10-crosscompile-fix.patch
+++ b/app-admin/gam-server/files/gam-server-0.1.10-crosscompile-fix.patch
@@ -1,5 +1,5 @@
---- configure.in.orig	2009-04-26 23:00:43.445135823 +0300
-+++ configure.in	2009-04-26 23:25:04.042489243 +0300
+--- a/configure.in.orig	2009-04-26 23:00:43.445135823 +0300
++++ b/configure.in	2009-04-26 23:25:04.042489243 +0300
 @@ -389,8 +389,7 @@
  
  AC_MSG_CHECKING(abstract socket namespace)

--- a/app-admin/gam-server/gam-server-0.1.10-r3.ebuild
+++ b/app-admin/gam-server/gam-server-0.1.10-r3.ebuild
@@ -1,0 +1,88 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+GNOME_ORG_MODULE="gamin"
+GNOME_TARBALL_SUFFIX="bz2"
+
+inherit autotools flag-o-matic libtool multilib gnome.org
+
+DESCRIPTION="Library providing the FAM File Alteration Monitor API"
+HOMEPAGE="https://www.gnome.org/~veillard/gamin/"
+SRC_URI="${SRC_URI}
+	mirror://gentoo/gamin-0.1.9-freebsd.patch.bz2
+	https://pkgconfig.freedesktop.org/releases/pkg-config-0.26.tar.gz" # pkg.m4 for eautoreconf
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-solaris"
+IUSE="debug kernel_linux"
+
+RDEPEND=">=dev-libs/glib-2:2
+	>=dev-libs/libgamin-0.1.10
+	!app-admin/fam
+	!<app-admin/gamin-0.1.10"
+
+DEPEND="${RDEPEND}"
+
+#S=${WORKDIR}/${MY_P}
+
+PATCHES=(
+	# Fix compile warnings; bug #188923
+	"${WORKDIR}/gamin-0.1.9-freebsd.patch"
+
+	# Fix file-collision due to shared library, upstream bug #530635
+	"${FILESDIR}/${PN}-0.1.10-noinst-lib.patch"
+
+	# Fix compilation with latest glib, bug #382783
+	"${FILESDIR}/${PN}-0.1.10-G_CONST_RETURN-removal.patch"
+
+	# Fix crosscompilation issues, bug #267604
+	"${FILESDIR}/${PN}-0.1.10-crosscompile-fix.patch"
+
+	# Enable linux specific features on armel, upstream bug #588338
+	"${FILESDIR}/${PN}-0.1.10-armel-features.patch"
+
+	# Fix deadlocks with glib-2.32, bug #413331, upstream #667230
+	"${FILESDIR}/${PN}-0.1.10-ih_sub_cancel-deadlock.patch"
+)
+
+src_prepare() {
+	mv -vf "${WORKDIR}"/pkg-config-*/pkg.m4 "${WORKDIR}"/ || die
+
+	default
+
+	# Drop DEPRECATED flags
+	sed -i -e 's:-DG_DISABLE_DEPRECATED:$(NULL):g' server/Makefile.am || die
+
+	sed -i \
+		-e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' \
+		-e 's:AM_PROG_CC_STDC:AC_PROG_CC:' \
+		configure.in || die #466948
+
+	# autoconf is required as the user-cflags patch modifies configure.in
+	# however, elibtoolize is also required, so when the above patch is
+	# removed, replace the following call with a call to elibtoolize
+	AT_M4DIR="${WORKDIR}" eautoreconf
+}
+
+src_configure() {
+	# fixes bug 225403
+	#append-flags "-D_GNU_SOURCE"
+
+	# Solaris' patchs adds this to configure, but it conflicts with
+	# Gentoo's FreeBSD patch.
+	[[ ${CHOST} == *-solaris* ]] && append-libs socket nsl
+
+	if ! has_version virtual/pkgconfig; then
+		export DAEMON_CFLAGS="-I${EPREFIX}/usr/include/glib-2.0 -I${EPREFIX}/usr/$(get_libdir)/glib-2.0/include"
+		export DAEMON_LIBS="-lglib-2.0"
+	fi
+
+	econf \
+		--disable-debug \
+		--disable-libgamin \
+		--without-python \
+		$(use_enable kernel_linux inotify) \
+		$(use_enable debug debug-api)
+}

--- a/app-admin/gam-server/gam-server-0.1.10-r3.ebuild
+++ b/app-admin/gam-server/gam-server-0.1.10-r3.ebuild
@@ -45,6 +45,9 @@ PATCHES=(
 
 	# Fix deadlocks with glib-2.32, bug #413331, upstream #667230
 	"${FILESDIR}/${PN}-0.1.10-ih_sub_cancel-deadlock.patch"
+
+	# Fix building with clang, bug #509696
+	"${FILESDIR}/${PN}-0.1.10-clang-fix.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
gam-server package is old and outdated and should eventually be removed.  But until it is, it might as well support being built with clang.  And if so, its EAPI might as well be updated too.

- **Update to EAPI 7**
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Peter Levine <plevine457@gmail.com>

- **Fix building with clang**
In GCC, a void return statement in a function that doesn't return void
returns 0 as a compatibility measure for archaic K&R C. Reliance on such
behavior causes failure with clang. Explicitly return the intended
return variable which is initialized to 0.
Closes: https://bugs.gentoo.org/509696

Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Peter Levine <plevine457@gmail.com>