### PR TITLE
targets/desktop/make.defaults: Remove fam as a default USE flag

### DIFF
--- a/profiles/targets/desktop/make.defaults
+++ b/profiles/targets/desktop/make.defaults
@@ -1,4 +1,4 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-USE="a52 aac acpi alsa bluetooth branding cairo cdda cdr consolekit cups dbus dri dts dvd dvdr emboss encode exif fam flac gif gpm gtk icu jpeg lcms ldap libnotify mad mng mp3 mp4 mpeg ogg opengl pango pdf png policykit ppds qt5 sdl spell startup-notification svg tiff truetype vorbis udev udisks unicode upower usb wxwidgets X xcb x264 xml xv xvid"
+USE="a52 aac acpi alsa bluetooth branding cairo cdda cdr consolekit cups dbus dri dts dvd dvdr emboss encode exif flac gif gpm gtk icu jpeg lcms ldap libnotify mad mng mp3 mp4 mpeg ogg opengl pango pdf png policykit ppds qt5 sdl spell startup-notification svg tiff truetype vorbis udev udisks unicode upower usb wxwidgets X xcb x264 xml xv xvid"


### PR DESCRIPTION
Both packages that could satisfy _virtual/fam_, _app-admin/gamin_ and _app-admin/fam_, are unmaintained and should eventually be removed. 

The following is a list of packages in the Gentoo repo depending on _virtual/fam_, _dev-libs/libgamin_, _app-admin/fam_, _app-admin/gam-server_, or _app-admin/gamin_ (as per `equery d -a <PKG>`), versions and mutual dependencies omitted:
```
app-admin/apachetop (fam ? virtual/fam)
app-admin/bcfg2 (!kernel_linux ? virtual/fam)
app-admin/bcfg2 (server ? dev-libs/libgamin[python,python_targets_python2_7(-)?,-python_single_target_python2_7(-)])
dev-libs/glib (fam ? >=virtual/fam-0-r1[abi_x86_32(-)?,abi_x86_64(-)?,abi_x86_x32(-)?,abi_mips_n32(-)?,abi_mips_n64(-)?,abi_mips_o32(-)?,abi_riscv_lp64d(-)?,abi_riscv_lp64(-)?,abi_s390_32(-)?,abi_s390_64(-)?])
dev-util/codeblocks (contrib ? dev-libs/libgamin)
dev-util/codeblocks (contrib ? app-admin/gamin)
dev-util/omake (fam ? virtual/fam)
kde-frameworks/kcoreaddons (fam ? virtual/fam)
mail-client/cone (fam ? virtual/fam)
mail-filter/maildrop (fam ? virtual/fam)
mail-mta/courier (fam ? virtual/fam)
net-fs/samba (fam ? virtual/fam)
net-ftp/pureadmin (virtual/fam)
net-mail/courier-imap (fam ? virtual/fam)
net-mail/gnubiff (fam ? virtual/fam)
www-servers/lighttpd (fam ? virtual/fam)
www-servers/lighttpd (dev-libs/libgamin)
```
The only packages that seem to be desktop oriented, or dependant components or libraries of such, are _dev-libs/glib_, _dev-util/codeblocks_, _kde-frameworks/kcoreaddons_, and _net-fs/samba_.  Nothing depends on _dev-util/codeblocks_, let alone _dev-util/codeblock[contrib]_,  The other three have already masked the `fam` USE flag in _default/linux_ profiles.  It seems to me that if there is an overarching need for a defaulted `fam` USE flag for such packages in a non-linux prefix profile, it would be best to deal with it in that prefix's _make.defaults_ file instead (or _prefix/make.defaults_, more generally).

- **targets/desktop/make.defaults: Remove fam as a default USE flag**
Both virtual/fam providers aren't being actively maintained and nothing in profiles/targets/desktop appears to depend on it.

Closes: https://bugs.gentoo.org/697476
Closes: #13123
Package-Manager: Portage-2.3.76
Signed-off-by: Peter Levine <plevine457@gmail.com>