### PR TITLE
dev-cpp/tbb: Fix building with clang

### DIFF
--- a/dev-cpp/tbb/tbb-2019.8.ebuild
+++ b/dev-cpp/tbb/tbb-2019.8.ebuild
@@ -80,9 +80,9 @@ local_src_compile() {
 	esac
 
 	case "$(tc-getCXX)" in
+		*clang*) comp="clang" ;;
 		*g++*) comp="gcc" ;;
 		*ic*c) comp="icc" ;;
-		*clang*) comp="clang" ;;
 		*) die "compiler $(tc-getCXX) not supported by build system" ;;
 	esac
 


### PR DESCRIPTION
In the statement:
```
case "$(tc-getCXX)" in
	*g++*) comp="gcc" ;;
	*ic*c) comp="icc" ;;
	*clang*) comp="clang" ;;
	*) die "compiler $(tc-getCXX) not supported by build system" ;;
esac
```
`clang++` is inadvertently matched to `*g++*` before `*clang*` ever gets parsed, leading to build failure.  Switching the order to ensure `*clang*` precedes `*g++*` is a simple, effective solution.

Closes: https://bugs.gentoo.org/662990
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Peter Levine <plevine457@gmail.com>