### PR TITLE
dev-libs/spdlog: fix wrong dependency version

### DIFF
--- a/dev-libs/spdlog/spdlog-1.2.1.ebuild
+++ b/dev-libs/spdlog/spdlog-1.2.1.ebuild
@@ -21,7 +21,7 @@ SLOT="0/1"
 IUSE="test"
 
 DEPEND="
-	>=dev-libs/libfmt-5.0.0
+	dev-libs/libfmt:0/5
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-libs/spdlog/spdlog-1.3.1.ebuild
+++ b/dev-libs/spdlog/spdlog-1.3.1.ebuild
@@ -21,7 +21,7 @@ SLOT="0/1"
 IUSE="test"
 
 DEPEND="
-	>=dev-libs/libfmt-5.0.0
+	dev-libs/libfmt:0/5
 "
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/693918
