### PR TITLE
net-mail/dot-forward: add back missing dependency

### DIFF
--- a/net-mail/dot-forward/dot-forward-0.71-r3.ebuild
+++ b/net-mail/dot-forward/dot-forward-0.71-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=0
 
-inherit eutils fixheadtails
+inherit eutils fixheadtails qmail
 
 DESCRIPTION="reads sendmail's .forward files under qmail"
 HOMEPAGE="http://cr.yp.to/dot-forward.html"


### PR DESCRIPTION
The qmail eclass is also needed for qmail_set_cc.

Broken in 59c843408f8d826c0a698bd24747deaeaad35734