### PR TITLE
mail-mta/netqmail: remove dot-forward as dependency

### DIFF
--- a/mail-mta/netqmail/netqmail-1.06-r8.ebuild
+++ b/mail-mta/netqmail/netqmail-1.06-r8.ebuild
@@ -66,12 +66,11 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}
-	>=net-mail/dot-forward-0.71-r3
-	>=sys-apps/ucspi-tcp-0.88-r17
+	sys-apps/ucspi-tcp
 	virtual/checkpassword
 	virtual/daemontools
 	authcram? ( >=net-mail/cmd5checkpw-0.30 )
-	ssl? ( >=sys-apps/ucspi-ssl-0.70-r1 )
+	ssl? ( sys-apps/ucspi-ssl )
 	!mail-mta/courier
 	!mail-mta/esmtp
 	!mail-mta/exim


### PR DESCRIPTION
This allows using sendmails .forward files with qmail, but doing so is entirely optional.