### PR TITLE
>=www-client/firefox-68.1.0: reenable webrtc for arm

### DIFF
--- a/www-client/firefox/firefox-68.1.0.ebuild
+++ b/www-client/firefox/firefox-68.1.0.ebuild
@@ -553,9 +553,6 @@ src_configure() {
 
 	mozconfig_annotate '' --enable-extensions="${MEXTENSIONS}"
 
-	# disable webrtc for now, bug 667642
-	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
-
 	# allow elfhack to work in combination with unstripped binaries
 	# when they would normally be larger than 2GiB.
 	append-ldflags "-Wl,--compress-debug-sections=zlib"

--- a/www-client/firefox/firefox-69.0.1.ebuild
+++ b/www-client/firefox/firefox-69.0.1.ebuild
@@ -555,9 +555,6 @@ src_configure() {
 
 	mozconfig_annotate '' --enable-extensions="${MEXTENSIONS}"
 
-	# disable webrtc for now, bug 667642
-	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
-
 	# allow elfhack to work in combination with unstripped binaries
 	# when they would normally be larger than 2GiB.
 	append-ldflags "-Wl,--compress-debug-sections=zlib"

--- a/www-client/firefox/firefox-69.0.2.ebuild
+++ b/www-client/firefox/firefox-69.0.2.ebuild
@@ -555,9 +555,6 @@ src_configure() {
 
 	mozconfig_annotate '' --enable-extensions="${MEXTENSIONS}"
 
-	# disable webrtc for now, bug 667642
-	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
-
 	# allow elfhack to work in combination with unstripped binaries
 	# when they would normally be larger than 2GiB.
 	append-ldflags "-Wl,--compress-debug-sections=zlib"


### PR DESCRIPTION
the bug has been discovered in firefox-62.0, and was mitigated by turning webrtc off for arm. This has been fixed by upstream in the meantime for firefox-68.0-esr and newer. 

Closes: https://bugs.gentoo.org/667642

@anarchpenguin or @Whissi okay for you? 