### PR TITLE
net-misc/hashcash: update to EAPI=7

### DIFF
--- a/net-misc/hashcash/hashcash-1.22-r2.ebuild
+++ b/net-misc/hashcash/hashcash-1.22-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Utility to generate hashcash tokens"
+HOMEPAGE="http://www.hashcash.org"
+SRC_URI="http://www.hashcash.org/source/${P}.tgz"
+
+LICENSE="CPL-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE=""
+
+DEPEND=""
+RDEPEND="${DEPEND}"
+BDEPEND=""
+
+src_prepare() {
+	default
+	sed -i -e "/COPT_GENERIC = -O3/d" Makefile || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" generic || die
+}
+
+src_install() {
+	dobin hashcash
+	doman hashcash.1
+	dodoc CHANGELOG
+	insinto /usr/share/doc/${PF}/examples
+	doins contrib/hashcash-{request,sendmail{,.txt}} \
+		contrib/hashfork.{c,py,txt}
+}

--- a/net-misc/hashcash/metadata.xml
+++ b/net-misc/hashcash/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+  <maintainer type="person">
+    <email>ngg@ngg.hu</email>
+    <name>Gergely Nagy</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
 </pkgmetadata>

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -109,7 +109,6 @@ net-mail/yosucker
 net-misc/cgterm
 net-misc/clockspeed-conf
 net-misc/fmirror
-net-misc/hashcash
 net-misc/ng-utils
 net-misc/sendfile
 net-news/yencode


### PR DESCRIPTION
Also add myself as proxy-maintainer and remove the mask
entry from the EAPI=0 list.

Bug: https://bugs.gentoo.org/696252
Signed-off-by: Gergely Nagy <ngg@ngg.hu>