### PR TITLE
dev-ros/rosbag: follow upstream, switch to pycryptodome

### DIFF
--- a/dev-ros/rosbag/rosbag-1.14.3-r2.ebuild
+++ b/dev-ros/rosbag/rosbag-1.14.3-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 ROS_REPO_URI="https://github.com/ros/ros_comm"
 KEYWORDS="~amd64 ~arm"
@@ -28,7 +28,7 @@ RDEPEND="
 	dev-ros/genpy[${PYTHON_USEDEP}]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-libs/console_bridge:=
-	dev-python/pycrypto[${PYTHON_USEDEP}]
+	dev-python/pycryptodome[${PYTHON_USEDEP}]
 	dev-python/python-gnupg[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/rosbag/rosbag-9999.ebuild
+++ b/dev-ros/rosbag/rosbag-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 ROS_REPO_URI="https://github.com/ros/ros_comm"
 KEYWORDS="~amd64 ~arm"
@@ -28,7 +28,7 @@ RDEPEND="
 	dev-ros/genpy[${PYTHON_USEDEP}]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-libs/console_bridge:=
-	dev-python/pycrypto[${PYTHON_USEDEP}]
+	dev-python/pycryptodome[${PYTHON_USEDEP}]
 	dev-python/python-gnupg[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>