### PR TITLE
media-libs/libvpx: Fix building www-client/chromium-78.0.3904.34 with USE=system-libvpx

### DIFF
--- a/media-libs/libvpx/files/libvpx-1.8.0-add-frame-drop-mode.patch
+++ b/media-libs/libvpx/files/libvpx-1.8.0-add-frame-drop-mode.patch
@@ -1,0 +1,204 @@
+From 5a0242ba5c8fddbf32766bfa2ffbbd25f3cd6167 Mon Sep 17 00:00:00 2001
+From: Marco Paniconi <marpan@google.com>
+Date: Fri, 30 Aug 2019 10:58:15 -0700
+Subject: [PATCH] vp9-svc: Add new frame drop mode for SVC
+
+add SVC framedrop mode: Lower spatial layers
+are constrained to drop if current spatial layer
+needs to drop.
+
+No change in behavior to other existing modes.
+
+Change-Id: I2d37959caf8c4b453b405904831b550367f716ba
+---
+ vp9/encoder/vp9_encoder.c          | 21 +++++++--------------
+ vp9/encoder/vp9_ratectrl.c         | 29 +++++++++++++++++------------
+ vp9/encoder/vp9_ratectrl.h         |  2 ++
+ vp9/encoder/vp9_svc_layercontext.c | 27 +++++++++++++++++++++++++++
+ vp9/encoder/vp9_svc_layercontext.h |  1 +
+ vpx/vp8cx.h                        |  2 ++
+ 6 files changed, 56 insertions(+), 26 deletions(-)
+
+diff --git a/vp9/encoder/vp9_encoder.c b/vp9/encoder/vp9_encoder.c
+index 25464b3b8d..c18e3d5aaa 100644
+--- a/vp9/encoder/vp9_encoder.c
++++ b/vp9/encoder/vp9_encoder.c
+@@ -4982,12 +4982,15 @@ static void encode_frame_to_data_rate(VP9_COMP *cpi, size_t *size,
+   TX_SIZE t;
+ 
+   // SVC: skip encoding of enhancement layer if the layer target bandwidth = 0.
+-  // If in constrained layer drop mode (svc.framedrop_mode != LAYER_DROP) and
+-  // base spatial layer was dropped, no need to set svc.skip_enhancement_layer,
+-  // as whole superframe will be dropped.
++  // No need to set svc.skip_enhancement_layer if whole superframe will be
++  // dropped.
+   if (cpi->use_svc && cpi->svc.spatial_layer_id > 0 &&
+       cpi->oxcf.target_bandwidth == 0 &&
+       !(cpi->svc.framedrop_mode != LAYER_DROP &&
++        (cpi->svc.framedrop_mode != CONSTRAINED_FROM_ABOVE_DROP ||
++         cpi->svc
++             .force_drop_constrained_from_above[cpi->svc.number_spatial_layers -
++                                                1]) &&
+         cpi->svc.drop_spatial_layer[0])) {
+     cpi->svc.skip_enhancement_layer = 1;
+     vp9_rc_postencode_update_drop_frame(cpi);
+@@ -4995,17 +4998,7 @@ static void encode_frame_to_data_rate(VP9_COMP *cpi, size_t *size,
+     cpi->last_frame_dropped = 1;
+     cpi->svc.last_layer_dropped[cpi->svc.spatial_layer_id] = 1;
+     cpi->svc.drop_spatial_layer[cpi->svc.spatial_layer_id] = 1;
+-    if (cpi->svc.framedrop_mode == LAYER_DROP ||
+-        cpi->svc.drop_spatial_layer[0] == 0) {
+-      // For the case of constrained drop mode where the base is dropped
+-      // (drop_spatial_layer[0] == 1), which means full superframe dropped,
+-      // we don't increment the svc frame counters. In particular temporal
+-      // layer counter (which is incremented in vp9_inc_frame_in_layer())
+-      // won't be incremented, so on a dropped frame we try the same
+-      // temporal_layer_id on next incoming frame. This is to avoid an
+-      // issue with temporal alignement with full superframe dropping.
+-      vp9_inc_frame_in_layer(cpi);
+-    }
++    vp9_inc_frame_in_layer(cpi);
+     return;
+   }
+ 
+diff --git a/vp9/encoder/vp9_ratectrl.c b/vp9/encoder/vp9_ratectrl.c
+index 548f2645f2..4148694404 100644
+--- a/vp9/encoder/vp9_ratectrl.c
++++ b/vp9/encoder/vp9_ratectrl.c
+@@ -504,7 +504,7 @@ static int check_buffer_below_thresh(VP9_COMP *cpi, int drop_mark) {
+   }
+ }
+ 
+-static int drop_frame(VP9_COMP *cpi) {
++int vp9_test_drop(VP9_COMP *cpi) {
+   const VP9EncoderConfig *oxcf = &cpi->oxcf;
+   RATE_CONTROL *const rc = &cpi->rc;
+   SVC *svc = &cpi->svc;
+@@ -609,13 +609,15 @@ int vp9_rc_drop_frame(VP9_COMP *cpi) {
+   SVC *svc = &cpi->svc;
+   int svc_prev_layer_dropped = 0;
+   // In the constrained or full_superframe framedrop mode for svc
+-  // (framedrop_mode !=  LAYER_DROP), if the previous spatial layer was
+-  // dropped, drop the current spatial layer.
++  // (framedrop_mode != (LAYER_DROP && CONSTRAINED_FROM_ABOVE)),
++  // if the previous spatial layer was dropped, drop the current spatial layer.
+   if (cpi->use_svc && svc->spatial_layer_id > 0 &&
+       svc->drop_spatial_layer[svc->spatial_layer_id - 1])
+     svc_prev_layer_dropped = 1;
+-  if ((svc_prev_layer_dropped && svc->framedrop_mode != LAYER_DROP) ||
+-      drop_frame(cpi)) {
++  if ((svc_prev_layer_dropped && svc->framedrop_mode != LAYER_DROP &&
++       svc->framedrop_mode != CONSTRAINED_FROM_ABOVE_DROP) ||
++      svc->force_drop_constrained_from_above[svc->spatial_layer_id] ||
++      vp9_test_drop(cpi)) {
+     vp9_rc_postencode_update_drop_frame(cpi);
+     cpi->ext_refresh_frame_flags_pending = 0;
+     cpi->last_frame_dropped = 1;
+@@ -625,14 +627,17 @@ int vp9_rc_drop_frame(VP9_COMP *cpi) {
+       svc->drop_count[svc->spatial_layer_id]++;
+       svc->skip_enhancement_layer = 1;
+       if (svc->framedrop_mode == LAYER_DROP ||
++          (svc->framedrop_mode == CONSTRAINED_FROM_ABOVE_DROP &&
++           svc->force_drop_constrained_from_above[svc->number_spatial_layers -
++                                                  1] == 0) ||
+           svc->drop_spatial_layer[0] == 0) {
+-        // For the case of constrained drop mode where the base is dropped
+-        // (drop_spatial_layer[0] == 1), which means full superframe dropped,
+-        // we don't increment the svc frame counters. In particular temporal
+-        // layer counter (which is incremented in vp9_inc_frame_in_layer())
+-        // won't be incremented, so on a dropped frame we try the same
+-        // temporal_layer_id on next incoming frame. This is to avoid an
+-        // issue with temporal alignement with full superframe dropping.
++        // For the case of constrained drop mode where full superframe is
++        // dropped, we don't increment the svc frame counters.
++        // In particular temporal layer counter (which is incremented in
++        // vp9_inc_frame_in_layer()) won't be incremented, so on a dropped
++        // frame we try the same temporal_layer_id on next incoming frame.
++        // This is to avoid an issue with temporal alignement with full
++        // superframe dropping.
+         vp9_inc_frame_in_layer(cpi);
+       }
+       if (svc->spatial_layer_id == svc->number_spatial_layers - 1) {
+diff --git a/vp9/encoder/vp9_ratectrl.h b/vp9/encoder/vp9_ratectrl.h
+index 1100ce7342..7dbe17dc56 100644
+--- a/vp9/encoder/vp9_ratectrl.h
++++ b/vp9/encoder/vp9_ratectrl.h
+@@ -267,6 +267,8 @@ void vp9_rc_update_rate_correction_factors(struct VP9_COMP *cpi);
+ // Post encode drop for CBR mode.
+ int post_encode_drop_cbr(struct VP9_COMP *cpi, size_t *size);
+ 
++int vp9_test_drop(struct VP9_COMP *cpi);
++
+ // Decide if we should drop this frame: For 1-pass CBR.
+ // Changes only the decimation count in the rate control structure
+ int vp9_rc_drop_frame(struct VP9_COMP *cpi);
+diff --git a/vp9/encoder/vp9_svc_layercontext.c b/vp9/encoder/vp9_svc_layercontext.c
+index bfe803b24d..32ee6e064f 100644
+--- a/vp9/encoder/vp9_svc_layercontext.c
++++ b/vp9/encoder/vp9_svc_layercontext.c
+@@ -74,6 +74,7 @@ void vp9_init_layer_context(VP9_COMP *const cpi) {
+     svc->fb_idx_upd_tl0[sl] = -1;
+     svc->drop_count[sl] = 0;
+     svc->spatial_layer_sync[sl] = 0;
++    svc->force_drop_constrained_from_above[sl] = 0;
+   }
+   svc->max_consec_drop = INT_MAX;
+ 
+@@ -770,6 +771,32 @@ int vp9_one_pass_cbr_svc_start_layer(VP9_COMP *const cpi) {
+   svc->mi_rows[svc->spatial_layer_id] = cpi->common.mi_rows;
+   svc->mi_cols[svc->spatial_layer_id] = cpi->common.mi_cols;
+ 
++  // For constrained_from_above drop mode: before encoding superframe (i.e.,
++  // at SL0 frame) check all spatial layers (starting from top) for possible
++  // drop, and if so, set a flag to force drop of that layer and all its lower
++  // layers.
++  if (svc->spatial_layer_to_encode == svc->first_spatial_layer_to_encode) {
++    int sl;
++    for (sl = 0; sl < svc->number_spatial_layers; sl++)
++      svc->force_drop_constrained_from_above[sl] = 0;
++    if (svc->framedrop_mode == CONSTRAINED_FROM_ABOVE_DROP) {
++      for (sl = svc->number_spatial_layers - 1;
++           sl >= svc->first_spatial_layer_to_encode; sl--) {
++        int layer = sl * svc->number_temporal_layers + svc->temporal_layer_id;
++        LAYER_CONTEXT *const lc = &svc->layer_context[layer];
++        cpi->rc = lc->rc;
++        cpi->oxcf.target_bandwidth = lc->target_bandwidth;
++        if (vp9_test_drop(cpi)) {
++          int sl2;
++          // Set flag to force drop in encoding for this mode.
++          for (sl2 = sl; sl2 >= svc->first_spatial_layer_to_encode; sl2--)
++            svc->force_drop_constrained_from_above[sl2] = 1;
++          break;
++        }
++      }
++    }
++  }
++
+   if (svc->temporal_layering_mode == VP9E_TEMPORAL_LAYERING_MODE_0212) {
+     set_flags_and_fb_idx_for_temporal_mode3(cpi);
+   } else if (svc->temporal_layering_mode ==
+diff --git a/vp9/encoder/vp9_svc_layercontext.h b/vp9/encoder/vp9_svc_layercontext.h
+index 77d4382665..4b20963b1b 100644
+--- a/vp9/encoder/vp9_svc_layercontext.h
++++ b/vp9/encoder/vp9_svc_layercontext.h
+@@ -138,6 +138,7 @@ typedef struct SVC {
+   int drop_spatial_layer[VPX_MAX_LAYERS];
+   int framedrop_thresh[VPX_MAX_LAYERS];
+   int drop_count[VPX_MAX_LAYERS];
++  int force_drop_constrained_from_above[VPX_MAX_LAYERS];
+   int max_consec_drop;
+   SVC_LAYER_DROP_MODE framedrop_mode;
+ 
+diff --git a/vpx/vp8cx.h b/vpx/vp8cx.h
+index 7451621700..95e2493b1e 100644
+--- a/vpx/vp8cx.h
++++ b/vpx/vp8cx.h
+@@ -839,6 +839,8 @@ typedef enum {
+   /**< Upper layers are constrained to drop if current layer drops. */
+   LAYER_DROP,           /**< Any spatial layer can drop. */
+   FULL_SUPERFRAME_DROP, /**< Only full superframe can drop. */
++  CONSTRAINED_FROM_ABOVE_DROP,
++  /**< Lower layers are constrained to drop if current layer drops. */
+ } SVC_LAYER_DROP_MODE;
+ 
+ /*!\brief vp9 svc frame dropping parameters.

--- a/media-libs/libvpx/libvpx-1.8.0-r2.ebuild
+++ b/media-libs/libvpx/libvpx-1.8.0-r2.ebuild
@@ -1,0 +1,118 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+inherit toolchain-funcs multilib-minimal
+
+# To create a new testdata tarball:
+# 1. Unpack source tarbll or checkout git tag
+# 2. export LIBVPX_TEST_DATA_PATH=libvpx-testdata
+# 3. configure --enable-unit-tests --enable-vp9-highbitdepth
+# 4. make testdata
+# 5. tar -cjf libvpx-testdata-${MY_PV}.tar.xz libvpx-testdata
+
+LIBVPX_TESTDATA_VER=1.8.0
+
+DESCRIPTION="WebM VP8 and VP9 Codec SDK"
+HOMEPAGE="https://www.webmproject.org"
+SRC_URI="https://github.com/webmproject/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
+	test? ( mirror://gentoo/${PN}-testdata-${LIBVPX_TESTDATA_VER}.tar.xz )"
+
+LICENSE="BSD"
+SLOT="0/6"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
+IUSE="doc +highbitdepth postproc static-libs svc test +threads"
+
+REQUIRED_USE="test? ( threads )"
+
+# Disable test phase when USE="-test"
+RESTRICT="!test? ( test )"
+
+RDEPEND=""
+DEPEND="abi_x86_32? ( dev-lang/yasm )
+	abi_x86_64? ( dev-lang/yasm )
+	abi_x86_x32? ( dev-lang/yasm )
+	x86-fbsd? ( dev-lang/yasm )
+	amd64-fbsd? ( dev-lang/yasm )
+	doc? (
+		app-doc/doxygen
+		dev-lang/php
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/libvpx-1.3.0-sparc-configure.patch" # 501010
+	"${FILESDIR}/libvpx-1.8.0-ppc64le-disable-vsx.patch" #688138
+	"${FILESDIR}/libvpx-1.8.0-add-frame-drop-mode.patch" #696924
+)
+
+src_configure() {
+	# https://bugs.gentoo.org/show_bug.cgi?id=384585
+	# https://bugs.gentoo.org/show_bug.cgi?id=465988
+	# copied from php-pear-r1.eclass
+	addpredict /usr/share/snmp/mibs/.index
+	addpredict /var/lib/net-snmp/
+	addpredict /var/lib/net-snmp/mib_indexes
+	addpredict /session_mm_cli0.sem
+	multilib-minimal_src_configure
+}
+
+multilib_src_configure() {
+	unset CODECS #357487
+
+	# #498364: sse doesn't work without sse2 enabled,
+	local myconfargs=(
+		--prefix="${EPREFIX}"/usr
+		--libdir="${EPREFIX}"/usr/$(get_libdir)
+		--enable-pic
+		--enable-vp8
+		--enable-vp9
+		--enable-shared
+		--extra-cflags="${CFLAGS}"
+		$(use_enable postproc)
+		$(use_enable svc experimental)
+		$(use_enable static-libs static)
+		$(use_enable test unit-tests)
+		$(use_enable threads multithread)
+		$(use_enable highbitdepth vp9-highbitdepth)
+	)
+
+	# let the build system decide which AS to use (it honours $AS but
+	# then feeds it with yasm flags without checking...) #345161
+	tc-export AS
+	case "${CHOST}" in
+		i?86*) export AS=yasm;;
+		x86_64*) export AS=yasm;;
+	esac
+
+	# Build with correct toolchain.
+	tc-export CC CXX AR NM
+	# Link with gcc by default, the build system should override this if needed.
+	export LD="${CC}"
+
+	if multilib_is_native_abi; then
+		myconfargs+=( $(use_enable doc install-docs) $(use_enable doc docs) )
+	else
+		# not needed for multilib and will be overwritten anyway.
+		myconfargs+=( --disable-examples --disable-install-docs --disable-docs )
+	fi
+
+	echo "${S}"/configure "${myconfargs[@]}" >&2
+	"${S}"/configure "${myconfargs[@]}"
+}
+
+multilib_src_compile() {
+	# build verbose by default and do not build examples that will not be installed
+	emake verbose=yes GEN_EXAMPLES=
+}
+
+multilib_src_test() {
+	local -x LD_LIBRARY_PATH="${BUILD_DIR}"
+	local -x LIBVPX_TEST_DATA_PATH="${WORKDIR}/${PN}-testdata"
+	emake verbose=yes GEN_EXAMPLES= test
+}
+
+multilib_src_install() {
+	emake verbose=yes GEN_EXAMPLES= DESTDIR="${D}" install
+	multilib_is_native_abi && use doc && dodoc -r docs/html
+}


### PR DESCRIPTION
Building _www-client/chromium-78.0.3904.34_  against _media-libs/libvpx-1.8.0-r1_ with `USE=system-libvpx` fails with:
```
../../third_party/webrtc/modules/video_coding/codecs/vp9/vp9_impl.cc:715:40: error: use of undeclared identifier 'CONSTRAINED_FROM_ABOVE_DROP'; did you mean 'CONSTRAINED_LAYER_DROP'?
      svc_drop_frame_.framedrop_mode = CONSTRAINED_FROM_ABOVE_DROP;
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
                                       CONSTRAINED_LAYER_DROP
/usr/include/vpx/vp8cx.h:835:3: note: 'CONSTRAINED_LAYER_DROP' declared here
  CONSTRAINED_LAYER_DROP,
  ^
5 warnings and 1 error generated.
ninja: build stopped: subcommand failed.
```

The issue is referenced in [webrtc@1af0f908c83f0163f5ec1f2667e5ab5755d8f39f](https://webrtc.googlesource.com/src/+/1af0f908c83f0163f5ec1f2667e5ab5755d8f39f):
```
VP9 screenshare: use CONSTRAINED_FROM_ABOVE_DROP mode

This mode was added by libvpx team specificaly for this usecase: if a
layer is dropped, all lower layers have to be dropped also.
```
The patch is taken from https://github.com/webmproject/libvpx/commit/5a0242ba5c8fddbf32766bfa2ffbbd25f3cd6167.

Closes: https://bugs.gentoo.org/696924
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Peter Levine <plevine457@gmail.com>