### PR TITLE
mail-client/neomutt: fix configure with ccache

### DIFF
--- a/mail-client/neomutt/neomutt-20180716.ebuild
+++ b/mail-client/neomutt/neomutt-20180716.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -94,7 +94,7 @@ src_configure() {
 		"$(use_enable gnutls)"
 	)
 
-	econf "${myconf[@]}"
+	econf CCACHE=none "${myconf[@]}"
 }
 
 src_install() {

--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -94,7 +94,7 @@ src_configure() {
 		"$(use_enable gnutls)"
 	)
 
-	econf "${myconf[@]}"
+	econf CCACHE=none "${myconf[@]}"
 }
 
 src_install() {


### PR DESCRIPTION
If you have dev-util/ccache installed but not FEATURES="ccache", neomutt's
configure process will detect and try to use it. You can override this
by setting an env var, CCACHE, to 'none' (and only that, see line 1132
or so of neomutt's source file auto.def).

Without this change, you will get the following sort of error:
```
>>> Configuring source in /tmp/portage/mail-client/neomutt-20180716/work/neomutt-neomutt-20180716 ...
./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu ...
Host System...x86_64-pc-linux-gnu
Note: defaultprefix is deprecated. Use options-defaults to set default options
Build System...x86_64-pc-linux-gnu
C compiler...ccache x86_64-pc-linux-gnu-gcc -O2 -pipe -march=znver1
C++ compiler...ccache x86_64-pc-linux-gnu-c++ -O2 -pipe -march=znver1
Build C compiler...cc
 * ACCESS DENIED:  utimes:       /var/cache/ccache
```
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>