### PR TITLE
app-crypt/kbfs: fix sys-fs/fuse SLOT

### DIFF
--- a/app-crypt/kbfs/kbfs-2.11.0-r1.ebuild
+++ b/app-crypt/kbfs/kbfs-2.11.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,7 +17,7 @@ IUSE=""
 DEPEND=""
 RDEPEND="
 	app-crypt/gnupg
-	sys-fs/fuse
+	sys-fs/fuse:0=
 	"
 
 src_unpack() {

--- a/app-crypt/kbfs/kbfs-9999.ebuild
+++ b/app-crypt/kbfs/kbfs-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,7 +17,7 @@ IUSE="git"
 DEPEND=""
 RDEPEND="
 	app-crypt/gnupg
-	sys-fs/fuse
+	sys-fs/fuse:0=
 	"
 
 src_unpack() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697008

Signed-off-by: David Heidelberg <david@ixit.cz>