### PR TITLE
app-emulation/lxd: fix sys-fs/fuse SLOT

### DIFF
--- a/app-emulation/lxd/lxd-3.16-r1.ebuild
+++ b/app-emulation/lxd/lxd-3.16-r1.ebuild
@@ -45,7 +45,7 @@ RDEPEND="
 		net-libs/libnsl:0=
 		net-misc/rsync[xattr]
 		sys-apps/iproute2[ipv6?]
-		sys-fs/fuse
+		sys-fs/fuse:0=
 		sys-fs/lxcfs
 		sys-fs/squashfs-tools
 		virtual/acl


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697010

Signed-off-by: David Heidelberg <david@ixit.cz>