### PR TITLE
dev-perl/Fuse: use SLOT for sys-fs/fuse

### DIFF
--- a/dev-perl/Fuse/Fuse-0.16.1-r1.ebuild
+++ b/dev-perl/Fuse/Fuse-0.16.1-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+MODULE_AUTHOR=DPATES
+inherit perl-module
+
+DESCRIPTION="Fuse module for perl"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="sys-fs/fuse:0="
+DEPEND="${RDEPEND}"
+
+# Test is whack - ChrisWhite
+#SRC_TEST="do"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697012

Signed-off-by: David Heidelberg <david@ixit.cz>