### PR TITLE
dev-python/fusepy: bump EAPI, fix slot for sys-fs/fuse

### DIFF
--- a/dev-python/fusepy/fusepy-2.0.4-r2.ebuild
+++ b/dev-python/fusepy/fusepy-2.0.4-r2.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
+
+inherit distutils-r1
+
+DESCRIPTION="Python FUSE bindings using ctypes"
+HOMEPAGE="https://github.com/fusepy/fusepy"
+SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="BSD"
+KEYWORDS="~amd64 ~x86"
+SLOT="0"
+IUSE=""
+
+DEPEND=">=sys-fs/fuse-2.9.7:0="
+RDEPEND="
+	${DEPEND}
+	!dev-python/fuse-python"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697016

Signed-off-by: David Heidelberg <david@ixit.cz>