### PR TITLE
net-fs/smbnetfs: fix sys-fs/fuse SLOT

### DIFF
--- a/net-fs/smbnetfs/smbnetfs-0.6.1-r1.ebuild
+++ b/net-fs/smbnetfs/smbnetfs-0.6.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86 ~x86-linux"
 IUSE="gnome-keyring"
 
-RDEPEND=">=sys-fs/fuse-2.3
+RDEPEND=">=sys-fs/fuse-2.3:0=
 	>=net-fs/samba-4.2
 	>=dev-libs/glib-2.30
 	gnome-keyring? ( app-crypt/libsecret )"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697020

Signed-off-by: David Heidelberg <david@ixit.cz>