### PR TITLE
mail-mta/netqmail: cleanup dependency

### DIFF
--- a/mail-mta/netqmail/netqmail-1.06-r4.ebuild
+++ b/mail-mta/netqmail/netqmail-1.06-r4.ebuild
@@ -73,7 +73,7 @@ RDEPEND="
 	!<mail-mta/ssmtp-2.64-r2
 	!>=mail-mta/ssmtp-2.64-r2[mta]
 	>=sys-apps/ucspi-tcp-0.88-r17
-	ssl? ( >=sys-apps/ucspi-ssl-0.70-r1 )
+	ssl? ( sys-apps/ucspi-ssl )
 	virtual/daemontools
 	>=net-mail/dot-forward-0.71-r3
 	virtual/checkpassword

--- a/mail-mta/netqmail/netqmail-1.06-r7.ebuild
+++ b/mail-mta/netqmail/netqmail-1.06-r7.ebuild
@@ -71,7 +71,7 @@ RDEPEND="${DEPEND}
 	virtual/checkpassword
 	virtual/daemontools
 	authcram? ( >=net-mail/cmd5checkpw-0.30 )
-	ssl? ( >=sys-apps/ucspi-ssl-0.70-r1 )
+	ssl? ( sys-apps/ucspi-ssl )
 	!mail-mta/courier
 	!mail-mta/esmtp
 	!mail-mta/exim


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/686430
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Aleksandr Efros <powerman-asdf@yandex.ru>