### PR TITLE
mail-mta/qmail-ldap: cleanup dependency

### DIFF
--- a/mail-mta/qmail-ldap/qmail-ldap-1.03-r8.ebuild
+++ b/mail-mta/qmail-ldap/qmail-ldap-1.03-r8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=0
@@ -69,7 +69,7 @@ RDEPEND="
 	!mail-mta/opensmtpd
 	!mail-mta/ssmtp
 	>=sys-apps/ucspi-tcp-0.88-r17
-	ssl? ( >=sys-apps/ucspi-ssl-0.70-r1 )
+	ssl? ( sys-apps/ucspi-ssl )
 	virtual/daemontools
 	>=net-mail/dot-forward-0.71-r3
 	${DEPEND}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/686430
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Aleksandr Efros <powerman-asdf@yandex.ru>