### PR TITLE
app-i18n/ibus-libpinyin: Version 1.10.0 Stabilization

### DIFF
--- a/app-i18n/ibus-libpinyin/ibus-libpinyin-1.10.0.ebuild
+++ b/app-i18n/ibus-libpinyin/ibus-libpinyin-1.10.0.ebuild
@@ -18,7 +18,7 @@ SRC_URI="https://github.com/libpinyin/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 IUSE="boost lua opencc"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/697064
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Graham Ramsey <graham.ramsey@gmail.com>