### PR TITLE
net-libs/libtorrent-rasterbar: Python 3.7 compatibility

### DIFF
--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{5,6} )
-PYTHON_REQ_USE="threads"
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+PYTHON_REQ_USE="threads(+)"
 DISTUTILS_OPTIONAL=true
 DISTUTILS_IN_SOURCE_BUILD=true
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>