### PR TITLE
games-emulation/dolphin: added missing dependency

### DIFF
--- a/games-emulation/dolphin/dolphin-9999.ebuild
+++ b/games-emulation/dolphin/dolphin-9999.ebuild
@@ -68,6 +68,9 @@ DEPEND="${RDEPEND}
 	sys-devel/gettext
 	virtual/pkgconfig"
 
+# vulkan-loader required for vulkan backend
+RDEPEND="${RDEPEND} media-libs/vulkan-loader"
+
 src_prepare() {
 	cmake-utils_src_prepare
 


### PR DESCRIPTION
Latest dev build requires media-libs/vulkan-loader
to use vulkan backend.

Package-Manager: Portage-2.3.76, Repoman-2.3.17