### PR TITLE
games-emulation/pcsx2: fix dependencies

### DIFF
--- a/games-emulation/pcsx2/pcsx2-9999.ebuild
+++ b/games-emulation/pcsx2/pcsx2-9999.ebuild
@@ -28,11 +28,11 @@ RDEPEND="
 	sys-libs/zlib[abi_x86_32(-)]
 	virtual/libudev[abi_x86_32(-)]
 	virtual/opengl[abi_x86_32(-)]
-	x11-libs/gtk+:2[abi_x86_32(-)]
+	x11-libs/gtk+:3[abi_x86_32(-)]
 	x11-libs/libICE[abi_x86_32(-)]
 	x11-libs/libX11[abi_x86_32(-)]
 	x11-libs/libXext[abi_x86_32(-)]
-	x11-libs/wxGTK:3.0-gtk3[abi_x86_32(-),-sdl,X]
+	>=x11-libs/wxGTK-3.0.4-r301:3.0-gtk3[abi_x86_32(-),X]
 "
 # Ensure no incompatible headers from eselect-opengl are installed, bug #510730
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/696866
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Yuri Konotopov <ykonotopov@gnome.org>