### PR TITLE
net-dns/ddclient: drop non-existent ~x86-fbsd keyword

### DIFF
--- a/net-dns/ddclient/ddclient-3.9.0-r3.ebuild
+++ b/net-dns/ddclient/ddclient-3.9.0-r3.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="Perl client used to update dynamic DNS entries"
 HOMEPAGE="https://sourceforge.net/projects/ddclient/"
 SRC_URI="mirror://sourceforge/ddclient/${P}.tar.gz"
 
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
 LICENSE="GPL-2+"
 SLOT="0"
 IUSE="examples iproute2"


### PR DESCRIPTION
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>