### PR TITLE
sys-apps/man-db: explicitly use berkdb or gdbm

### DIFF
--- a/sys-apps/man-db/man-db-2.7.6.1-r2.ebuild
+++ b/sys-apps/man-db/man-db-2.7.6.1-r2.ebuild
@@ -12,12 +12,11 @@ SRC_URI="mirror://nongnu/${PN}/${P}.tar.xz"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 ~riscv s390 sh sparc x86 ~amd64-linux ~x86-linux"
-IUSE="berkdb +gdbm +manpager nls selinux static-libs zlib"
+IUSE="+berkdb gdbm +manpager nls selinux static-libs zlib"
 
 CDEPEND=">=dev-libs/libpipeline-1.4.0
 	berkdb? ( sys-libs/db:= )
 	gdbm? ( sys-libs/gdbm:= )
-	!berkdb? ( !gdbm? ( sys-libs/gdbm:= ) )
 	sys-apps/groff
 	zlib? ( sys-libs/zlib )
 	!sys-apps/man"
@@ -32,15 +31,12 @@ RDEPEND="${CDEPEND}
 	selinux? ( sec-policy/selinux-mandb )
 "
 PDEPEND="manpager? ( app-text/manpager )"
+REQUIRED_USE="^^ ( berkdb gdbm )"
 
 pkg_setup() {
 	# Create user now as Makefile in src_install does setuid/chown
 	enewgroup man 15
 	enewuser man 13 -1 /usr/share/man man
-
-	if (use gdbm && use berkdb) || (use !gdbm && use !berkdb) ; then #496150
-		ewarn "Defaulting to USE=gdbm due to ambiguous berkdb/gdbm USE flag settings"
-	fi
 }
 
 src_configure() {

--- a/sys-apps/man-db/man-db-2.8.6.1.ebuild
+++ b/sys-apps/man-db/man-db-2.8.6.1.ebuild
@@ -17,7 +17,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="berkdb +gdbm +manpager nls +seccomp selinux static-libs zlib"
+IUSE="+berkdb gdbm +manpager nls +seccomp selinux static-libs zlib"
 
 CDEPEND="
 	!sys-apps/man
@@ -25,7 +25,6 @@ CDEPEND="
 	sys-apps/groff
 	berkdb? ( sys-libs/db:= )
 	gdbm? ( sys-libs/gdbm:= )
-	!berkdb? ( !gdbm? ( sys-libs/gdbm:= ) )
 	seccomp? ( sys-libs/libseccomp )
 	zlib? ( sys-libs/zlib )
 "
@@ -45,12 +44,7 @@ RDEPEND="
 	selinux? ( sec-policy/selinux-mandb )
 "
 PDEPEND="manpager? ( app-text/manpager )"
-
-pkg_setup() {
-	if (use gdbm && use berkdb) || (use !gdbm && use !berkdb) ; then #496150
-		ewarn "Defaulting to USE=gdbm due to ambiguous berkdb/gdbm USE flag settings"
-	fi
-}
+REQUIRED_USE="^^ ( berkdb gdbm )"
 
 src_configure() {
 	export ac_cv_lib_z_gzopen=$(usex zlib)

--- a/sys-apps/man-db/man-db-2.8.7.ebuild
+++ b/sys-apps/man-db/man-db-2.8.7.ebuild
@@ -17,7 +17,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="berkdb +gdbm +manpager nls +seccomp selinux static-libs zlib"
+IUSE="+berkdb gdbm +manpager nls +seccomp selinux static-libs zlib"
 
 CDEPEND="
 	!sys-apps/man
@@ -25,7 +25,6 @@ CDEPEND="
 	sys-apps/groff
 	berkdb? ( sys-libs/db:= )
 	gdbm? ( sys-libs/gdbm:= )
-	!berkdb? ( !gdbm? ( sys-libs/gdbm:= ) )
 	seccomp? ( sys-libs/libseccomp )
 	zlib? ( sys-libs/zlib )
 "
@@ -45,12 +44,7 @@ RDEPEND="
 	selinux? ( sec-policy/selinux-mandb )
 "
 PDEPEND="manpager? ( app-text/manpager )"
-
-pkg_setup() {
-	if (use gdbm && use berkdb) || (use !gdbm && use !berkdb) ; then #496150
-		ewarn "Defaulting to USE=gdbm due to ambiguous berkdb/gdbm USE flag settings"
-	fi
-}
+REQUIRED_USE="^^ ( berkdb gdbm )"
 
 src_configure() {
 	export ac_cv_lib_z_gzopen=$(usex zlib)

--- a/sys-apps/man-db/man-db-9999.ebuild
+++ b/sys-apps/man-db/man-db-9999.ebuild
@@ -17,7 +17,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="berkdb +gdbm +manpager nls +seccomp selinux static-libs zlib"
+IUSE="+berkdb gdbm +manpager nls +seccomp selinux static-libs zlib"
 
 CDEPEND="
 	!sys-apps/man
@@ -25,7 +25,6 @@ CDEPEND="
 	sys-apps/groff
 	berkdb? ( sys-libs/db:= )
 	gdbm? ( sys-libs/gdbm:= )
-	!berkdb? ( !gdbm? ( sys-libs/gdbm:= ) )
 	seccomp? ( sys-libs/libseccomp )
 	zlib? ( sys-libs/zlib )
 "
@@ -45,12 +44,7 @@ RDEPEND="
 	selinux? ( sec-policy/selinux-mandb )
 "
 PDEPEND="manpager? ( app-text/manpager )"
-
-pkg_setup() {
-	if (use gdbm && use berkdb) || (use !gdbm && use !berkdb) ; then #496150
-		ewarn "Defaulting to USE=gdbm due to ambiguous berkdb/gdbm USE flag settings"
-	fi
-}
+REQUIRED_USE="^^ ( berkdb gdbm )"
 
 src_configure() {
 	export ac_cv_lib_z_gzopen=$(usex zlib)


### PR DESCRIPTION
REQUIRED_USE is supported since EAPI 4 and offer the ability to
explicitly require a USE flag to be enabled. berkdb is enabled by
default in profiles/default/linux/make.defaults while gdbm is
enabled by default in no profile.

This change remove the warning made in pkg_setup and defer berkdb vs
gdbm USE flag handling to the package manager. This change also move the
default to berkdb to align with defaults in profile.

Package-Manager: Portage-2.3.76, Repoman-2.3.16