### PR TITLE
acct-*/amavis: New group and user (333) for mail-filter/amavisd-new

### DIFF
--- a/acct-group/amavis/amavis-0.ebuild
+++ b/acct-group/amavis/amavis-0.ebuild
@@ -1,0 +1,9 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID=333
+DESCRIPTION="Group for mail-filter/amavisd-new"

--- a/acct-group/amavis/metadata.xml
+++ b/acct-group/amavis/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>antivirus@gentoo.org</email>
+		<name>Gentoo Antivirus Project</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>gentoo@seichter.de</email>
+		<name>Ralph Seichter</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/amavis/amavis-0.ebuild
+++ b/acct-user/amavis/amavis-0.ebuild
@@ -1,0 +1,13 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+ACCT_USER_ID=333
+ACCT_USER_GROUPS=( amavis )
+ACCT_USER_HOME=/var/lib/amavishome
+DESCRIPTION="User for mail-filter/amavisd-new"
+
+acct-user_add_deps

--- a/acct-user/amavis/metadata.xml
+++ b/acct-user/amavis/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>antivirus@gentoo.org</email>
+		<name>Gentoo Antivirus Project</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>gentoo@seichter.de</email>
+		<name>Ralph Seichter</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>


### PR DESCRIPTION
Precondition for upgrading amavis ebuild according to [GLEP81](https://wiki.gentoo.org/wiki/Categories_acct-group_and_acct-user).