### PR TITLE
media-tv/mythtv: bug fix mythtv-29.1-r2.ebuild source directory name

### DIFF
--- a/media-tv/mythtv/mythtv-29.1-r2.ebuild
+++ b/media-tv/mythtv/mythtv-29.1-r2.ebuild
@@ -131,7 +131,7 @@ DEPEND="${COMMON}
 	x11-base/xorg-proto
 "
 
-S="${WORKDIR}/${PF}/mythtv"
+S="${WORKDIR}/${P}-r1/mythtv"
 
 DISABLE_AUTOFORMATTING="yes"
 DOC_CONTENTS="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/674216
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Wilson Michaels <thebitpit@earthlink.net>