### PR TITLE
dev-python/geoip-python: Python 3.7 compatibility

### DIFF
--- a/dev-python/geoip-python/geoip-python-1.3.2-r1.ebuild
+++ b/dev-python/geoip-python/geoip-python-1.3.2-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6} pypy pypy3 )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} pypy pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697648
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>