### PR TITLE
dev-libs/libcec: Python 3.7 compatibility

### DIFF
--- a/dev-libs/libcec/libcec-4.0.4-r1.ebuild
+++ b/dev-libs/libcec/libcec-4.0.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
 MY_PV=${PV/_p/-}
 MY_P=${PN}-${MY_PV}
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697652
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>