### PR TITLE
dev-python/pydiff: Python 3.7 compatibility

### DIFF
--- a/dev-python/pydiff/pydiff-0.2-r1.ebuild
+++ b/dev-python/pydiff/pydiff-0.2-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="Diffs two Python files at the bytecode level"
+HOMEPAGE="https://github.com/myint/pydiff"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+python_test() {
+	"${PYTHON}" test_pydiff.py || die "Tests failed under ${EPYTHON}"
+}

--- a/dev-python/pydiff/pydiff-0.2.ebuild
+++ b/dev-python/pydiff/pydiff-0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 python3_{5,6} pypy pypy3 )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697656
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>