### PR TITLE
dev-python/nosexcover: Python 3.7 compatibility

### DIFF
--- a/dev-python/nosexcover/nosexcover-1.0.11-r1.ebuild
+++ b/dev-python/nosexcover/nosexcover-1.0.11-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy )
+
+inherit distutils-r1
+
+DESCRIPTION="Extends nose.plugins.cover to add Cobertura-style XML reports"
+HOMEPAGE="https://github.com/cmheisel/nose-xcover/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+IUSE=""
+
+DEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/nose[${PYTHON_USEDEP}]
+	>=dev-python/coverage-3.4[${PYTHON_USEDEP}]"
+RDEPEND="${DEPEND}"
+
+python_test() {
+	nosetests -v nosexcover/tests.py || die
+}

--- a/dev-python/nosexcover/nosexcover-1.0.11.ebuild
+++ b/dev-python/nosexcover/nosexcover-1.0.11.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{5,6} pypy )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/685910
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Craig Andrews <candrews@gentoo.org>