### PR TITLE
dev-util/ragel: disable static library and license change

### DIFF
--- a/dev-util/ragel/ragel-7.0.0.10-r1.ebuild
+++ b/dev-util/ragel/ragel-7.0.0.10-r1.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="Compiles finite state machines from regular languages into executab
 HOMEPAGE="https://www.colm.net/open-source/ragel/"
 SRC_URI="https://www.colm.net/files/ragel/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="vim-syntax"

--- a/dev-util/ragel/ragel-7.0.0.10-r2.ebuild
+++ b/dev-util/ragel/ragel-7.0.0.10-r2.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="Compiles finite state machines from regular languages into executab
 HOMEPAGE="https://www.colm.net/open-source/ragel/"
 SRC_URI="https://www.colm.net/files/ragel/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="vim-syntax"

--- a/dev-util/ragel/ragel-7.0.0.10-r2.ebuild
+++ b/dev-util/ragel/ragel-7.0.0.10-r2.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Compiles finite state machines from regular languages into executable code"
+HOMEPAGE="https://www.colm.net/open-source/ragel/"
+SRC_URI="https://www.colm.net/files/ragel/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="vim-syntax"
+
+DEPEND="~dev-util/colm-0.13.0.5"
+RDEPEND="${DEPEND}"
+PATCHES=( "${FILESDIR}/${P}-use-pkginclude.patch" )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure(){
+	econf --disable-static
+}
+
+src_test() {
+	cd "${S}"/test || die
+	./runtests.in || die
+}
+
+src_install() {
+	if use vim-syntax; then
+		insinto /usr/share/vim/vimfiles/syntax
+		doins ragel.vim
+	fi
+	default
+	find "${D}" -name '*.la' -delete || die
+}

--- a/dev-util/ragel/ragel-7.0.0.10.ebuild
+++ b/dev-util/ragel/ragel-7.0.0.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,7 +7,7 @@ DESCRIPTION="Compiles finite state machines from regular languages into executab
 HOMEPAGE="https://www.colm.net/open-source/ragel/"
 SRC_URI="https://www.colm.net/files/ragel/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~x86"
 IUSE="vim-syntax"


### PR DESCRIPTION
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>