### PR TITLE
net-vpn/strongswan: bump to 5.8.1-r1

### DIFF
--- a/net-vpn/strongswan/metadata.xml
+++ b/net-vpn/strongswan/metadata.xml
@@ -19,6 +19,8 @@
 		<flag name="eap">Enable support for the different EAP modules that are supported</flag>
 		<flag name="farp">Enable faking of ARP responses for virtual IP addresses assigned to clients (IKEv2 only)</flag>
 		<flag name="gcrypt">Enable <pkg>dev-libs/libgcrypt</pkg> plugin which provides 3DES, AES, Blowfish, Camellia, CAST, DES, Serpent and Twofish ciphers along with MD4, MD5 and SHA1/2 hash algorithms, RSA and DH groups 1,2,5,14-18 and 22-24(4.4+). Also includes a software random number generator.</flag>
+		<flag name="ikev1">Enable IKEv1 support</flag>
+		<flag name="legacy-ipsec-script">Enable legacy ipsec script</flag>
 		<flag name="non-root">Force IKEv1/IKEv2 daemons to normal user privileges. This might impose some restrictions mainly to the IKEv1 daemon. Disable only if you really require superuser privileges.</flag>
 		<flag name="openssl">Enable <pkg>dev-libs/openssl</pkg> plugin which is required for Elliptic Curve Cryptography (DH groups 19-21,25,26) and ECDSA. Also provides 3DES, AES, Blowfish, Camellia, CAST, DES, IDEA and RC5 ciphers along with MD2, MD4, MD5 and SHA1/2 hash algorithms, RSA and DH groups 1,2,5,14-18 and 22-24(4.4+) <pkg>dev-libs/openssl</pkg> has to be compiled with USE="-bindist".</flag>
 		<flag name="pkcs11">Enable pkcs11 support</flag>

--- a/net-vpn/strongswan/strongswan-5.8.1-r1.ebuild
+++ b/net-vpn/strongswan/strongswan-5.8.1-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://download.strongswan.org/${P}.tar.bz2"
 LICENSE="GPL-2 RSA DES"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
-IUSE="+caps curl +constraints debug dhcp eap farp gcrypt +gmp ldap mysql networkmanager +non-root +openssl selinux sqlite systemd pam pkcs11"
+IUSE="+caps curl +constraints debug dhcp eap farp gcrypt +gmp ldap mysql networkmanager +non-root +openssl selinux sqlite systemd pam pkcs11 ikev1 +legacy-ipsec-script"
 
 STRONGSWAN_PLUGINS_STD="led lookip systime-fix unity vici"
 STRONGSWAN_PLUGINS_OPT="aesni blowfish ccm chapoly ctr forecast gcm ha ipseckey newhope ntru padlock rdrand save-keys unbound whitelist"
@@ -134,7 +134,7 @@ src_configure() {
 
 	econf \
 		--disable-static \
-		--enable-ikev1 \
+		$(use_enable ikev1 ikev1) \
 		--enable-ikev2 \
 		--enable-swanctl \
 		--enable-socket-dynamic \
@@ -169,6 +169,9 @@ src_configure() {
 		$(use_enable pkcs11) \
 		$(use_enable sqlite) \
 		$(use_enable systemd) \
+		$(use_enable legacy-ipsec-script charon) \
+		$(use_enable legacy-ipsec-script stroke) \
+		$(use_enable legacy-ipsec-script scepclient) \
 		$(use_with caps capabilities libcap) \
 		--with-piddir=/run \
 		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)" \
@@ -196,15 +199,17 @@ src_install() {
 	fi
 
 	diropts -m 0750 -o ${dir_ugid} -g ${dir_ugid}
-	dodir /etc/ipsec.d \
-		/etc/ipsec.d/aacerts \
-		/etc/ipsec.d/acerts \
-		/etc/ipsec.d/cacerts \
-		/etc/ipsec.d/certs \
-		/etc/ipsec.d/crls \
-		/etc/ipsec.d/ocspcerts \
-		/etc/ipsec.d/private \
-		/etc/ipsec.d/reqs
+	if use legacy-ipsec-script; then
+		dodir /etc/ipsec.d \
+			/etc/ipsec.d/aacerts \
+			/etc/ipsec.d/acerts \
+			/etc/ipsec.d/cacerts \
+			/etc/ipsec.d/certs \
+			/etc/ipsec.d/crls \
+			/etc/ipsec.d/ocspcerts \
+			/etc/ipsec.d/private \
+			/etc/ipsec.d/reqs
+	fi
 
 	dodoc NEWS README TODO || die
 


### PR DESCRIPTION
Also introduce two new useflags to disable legacy IKEv1 and ipsec script (replaced by swanctl) support.