### PR TITLE
net-p2p/deluge: fix deluge-web.service unit file

### DIFF
--- a/net-p2p/deluge/deluge-2.0.3.ebuild
+++ b/net-p2p/deluge/deluge-2.0.3.ebuild
@@ -99,7 +99,7 @@ python_install_all() {
 	if use webinterface; then
 		newinitd "${FILESDIR}/deluge-web.init" deluge-web
 		newconfd "${FILESDIR}/deluge-web.conf" deluge-web
-		systemd_newunit "${FILESDIR}/deluge-web.service-2" deluge-web.service
+		systemd_newunit "${FILESDIR}/deluge-web.service-3" deluge-web.service
 		systemd_install_serviced "${FILESDIR}/deluge-web.service.conf"
 	else
 		rm -rf "${D}/usr/$(get_libdir)/python2.7/site-packages/deluge/ui/web/" || die

--- a/net-p2p/deluge/files/deluge-web.service-3
+++ b/net-p2p/deluge/files/deluge-web.service-3
@@ -1,0 +1,10 @@
+[Unit]
+Description=Deluge WebUI
+Documentation=man:deluge-web
+After=deluged.service
+
+[Service]
+ExecStart=/usr/bin/deluge-web -d -c ${DELUGED_HOME} ${DELUGED_OPTS}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697856
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>
Package-Manager: Portage-2.3.76, Repoman-2.3.16