### PR TITLE
acct-user/mythtv: Add cdrom group to mythtv user

### DIFF
--- a/acct-user/mythtv/mythtv-0.ebuild
+++ b/acct-user/mythtv/mythtv-0.ebuild
@@ -7,7 +7,7 @@ inherit acct-user
 
 DESCRIPTION="Mythtv mythbackend server/deamon user"
 ACCT_USER_ID=117
-ACCT_USER_GROUPS=( mythtv video audio tty )
+ACCT_USER_GROUPS=( mythtv video audio cdrom tty )
 ACCT_USER_SHELL=/bin/bash
 ACCT_USER_HOME=/var/lib/mythtv
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/697798
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Wilson Michaels <thebitpit@earthlink.net>