### PR TITLE
dev-python/aiodns: use correct typing distribution

### DIFF
--- a/dev-python/aiodns/aiodns-2.0.0.ebuild
+++ b/dev-python/aiodns/aiodns-2.0.0.ebuild
@@ -21,6 +21,8 @@ RDEPEND=">=dev-python/pycares-3[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]"
 
+PATCHES=( "${FILESDIR}"/${P}-fix-typing-dependency.patch )
+
 python_test() {
 	"${EPYTHON}" tests.py -v || die
 }

--- a/dev-python/aiodns/files/aiodns-2.0.0-fix-typing-dependency.patch
+++ b/dev-python/aiodns/files/aiodns-2.0.0-fix-typing-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index a19d32f..ed86e49 100644
+--- a/setup.py
++++ b/setup.py
+@@ -18,7 +18,7 @@ setup(name             = "aiodns",
+       url              = "http://github.com/saghul/aiodns",
+       description      = "Simple DNS resolver for asyncio",
+       long_description = codecs.open("README.rst", encoding="utf-8").read(),
+-      install_requires = ['pycares>=3.0.0', 'typing; python_version<"3.7"'],
++      install_requires = ['pycares>=3.0.0', 'typing; python_version<"3.5"'],
+       packages         = ['aiodns'],
+       platforms        = ["POSIX", "Microsoft Windows"],
+       classifiers      = [


### PR DESCRIPTION
With the Gentoo startfiles for Python the typing distribution for
Python 3.6  and Python 3.7 is searched as external library and not as
part of the standard library.

Backport fix from https://github.com/saghul/aiodns/commit/281112107c742a3e24e8bce2cb09c3c4d9d01b6d

Closes: https://bugs.gentoo.org/692720
Package-Manager: Portage-2.3.69, Repoman-2.3.16
Signed-off-by: Gerion Entrup <gerion.entrup@flump.de>

(Could also be related to https://bugs.gentoo.org/691068)