### PR TITLE
media-fonts/liberation-fonts: drop broken python2 compat

### DIFF
--- a/media-fonts/liberation-fonts/liberation-fonts-2.00.5.ebuild
+++ b/media-fonts/liberation-fonts/liberation-fonts-2.00.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+PYTHON_COMPAT=( python3_{5,6,7} )
 
 inherit font python-any-r1
 
@@ -27,7 +27,6 @@ DEPEND="
 		media-gfx/fontforge
 		dev-python/fonttools
 	)"
-RDEPEND=""
 
 pkg_setup() {
 	if use fontforge; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694918
Package-Manager: Portage-2.3.77, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>