### PR TITLE
net-mail/autorespond: EAPI=7, update HOMEPAGE, SRC_URI

### DIFF
--- a/net-mail/autorespond/autorespond-2.0.4.ebuild
+++ b/net-mail/autorespond/autorespond-2.0.4.ebuild
@@ -1,29 +1,22 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
+EAPI=7
 
-inherit eutils
-
-DEBIAN_PV="1"
-DEBIAN_P="${P/-/_}-${DEBIAN_PV}"
 DESCRIPTION="Autoresponder add on package for qmailadmin"
-HOMEPAGE="http://inter7.com/devel/"
+HOMEPAGE="http://inter7.com/software/"
 SRC_URI="mirror://sourceforge/qmailadmin/${P}.tar.gz
-	mirror://debian/pool/contrib/${PN:0:1}/${PN}/${DEBIAN_P}.diff.gz"
+	mirror://gentoo/${PN}_${PV}-1.diff.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc s390 sh sparc x86"
-IUSE=""
 
 RDEPEND="virtual/qmail"
-DEPEND=""
-
-src_unpack() {
-	unpack ${P}.tar.gz
-	epatch "${DISTDIR}"/${DEBIAN_P}.diff.gz
-}
+PATCHES=(
+	"${WORKDIR}/autorespond_2.0.4-1.diff"
+)
+DOCS=( README help_message qmail-auto ChangeLog )
 
 src_compile() {
 	emake CFLAGS="${CFLAGS}" || die
@@ -32,7 +25,6 @@ src_compile() {
 src_install () {
 	into /var/qmail
 	dobin autorespond || die "dobin failed"
-	into /usr
-	dodoc README help_message qmail-auto ChangeLog
 	doman *.1
+	einstalldocs
 }

--- a/net-mail/autorespond/autorespond-2.0.5.ebuild
+++ b/net-mail/autorespond/autorespond-2.0.5.ebuild
@@ -1,26 +1,21 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=0
-
-inherit eutils
+EAPI=7
 
 DESCRIPTION="Autoresponder add on package for qmailadmin"
-HOMEPAGE="http://inter7.com/devel/"
-SRC_URI="http://inter7.com/devel/${P}.tar.gz"
+HOMEPAGE="http://www.inter7.com/software/"
+SRC_URI="http://qmail.ixip.net/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~s390 ~sh ~sparc ~x86"
-IUSE=""
 
 RDEPEND="virtual/qmail"
-DEPEND=""
-
-src_unpack() {
-	unpack ${A}
-	epatch "${FILESDIR}"/${P}-no-include-bounce.patch
-}
+PATCHES=(
+	"${FILESDIR}/${P}-no-include-bounce.patch"
+)
+DOCS=( README help_message qmail-auto )
 
 src_compile() {
 	emake CFLAGS="${CFLAGS}" || die
@@ -29,9 +24,8 @@ src_compile() {
 src_install () {
 	into /var/qmail
 	dobin autorespond || die "dobin failed"
-	into /usr
-	dodoc README help_message qmail-auto #ChangeLog
 	doman *.1
+	einstalldocs
 }
 
 pkg_postinst() {


### PR DESCRIPTION
* Debian mirror for 2.0.4 diff no longer available, linking to Gentoo mirror
* 2.0.5 qmail.ixip.net download has same checksum as listed in Manifest