### PR TITLE
net-misc/tigervnc: Allow building against libglvnd

### DIFF
--- a/net-misc/tigervnc/tigervnc-1.9.0-r1.ebuild
+++ b/net-misc/tigervnc/tigervnc-1.9.0-r1.ebuild
@@ -91,6 +91,7 @@ src_prepare() {
 		cd unix/xserver || die
 		eapply "${FILESDIR}"/xserver120.patch
 		eapply "${FILESDIR}"/xserver120-drmfourcc-header.patch
+		sed -i -e 's/"gl >= .*"/"gl"/' configure.ac || die
 		eautoreconf
 	fi
 }


### PR DESCRIPTION
The fix is copied over from x11-base/xorg-server

Closes: https://bugs.gentoo.org/697972
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Alexander Tsoy <alexander@tsoy.me>