### PR TITLE
ros-catkin.eclass: improve EAPI 7 compatibility

### DIFF
--- a/eclass/ros-catkin.eclass
+++ b/eclass/ros-catkin.eclass
@@ -186,7 +186,7 @@ ros-catkin_src_configure() {
 	fi
 
 	local mycmakeargs=(
-		"$(cmake-utils_use test CATKIN_ENABLE_TESTING)"
+		"-DCATKIN_ENABLE_TESTING=$(usex test)"
 		"-DCATKIN_BUILD_BINARY_PACKAGE=ON"
 		"-DCATKIN_PREFIX_PATH=${SYSROOT:-${EROOT}}/usr"
 		"${mycatkincmakeargs[@]}"

--- a/eclass/ros-catkin.eclass
+++ b/eclass/ros-catkin.eclass
@@ -47,7 +47,7 @@ fi
 # version. The idea here is to have a ROS_COMPAT in the same vein as
 # PYTHON_COMPAT where packages would define what distro they can work on, then
 # we'd have ros_distro_gentoo_python_2_7 & co plus the OSRF ones (lunar, etc.).
-# Note that this uncondtionally pulls python but in the ROS world there will
+# Note that this unconditionally pulls python but in the ROS world there will
 # most certainly be something pulling python anyway.
 PYTHON_COMPAT=( python2_7 )
 


### PR DESCRIPTION
Signed-off-by: Alessandro Barbieri lssndrbarbieri@gmail.com

`cmake-utils_use is banned in EAPI 6 and later: use -D<related_CMake_variable>="$(usex test)" instead`