### PR TITLE
media-fonts/fira-code: add ttf USE flag

### DIFF
--- a/media-fonts/fira-code/fira-code-2.ebuild
+++ b/media-fonts/fira-code/fira-code-2.ebuild
@@ -13,15 +13,23 @@ https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip"
 LICENSE="OFL-1.1"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 x86"
-IUSE=""
+IUSE="ttf"
 
 S="${WORKDIR}/FiraCode-${PV}"
-FONT_S="${S}/distr/otf"
-FONT_SUFFIX="otf"
 
 DOCS="README.md"
 
 DEPEND="app-arch/unzip"
+
+pkg_setup() {
+	if ! use ttf; then
+		export FONT_S="${S}/distr/otf"
+		export FONT_SUFFIX="otf"
+	else
+		export FONT_S="${S}/distr/ttf"
+		export FONT_SUFFIX="ttf"
+	fi
+}
 
 src_prepare() {
 	default

--- a/media-fonts/fira-code/fira-code-3.ebuild
+++ b/media-fonts/fira-code/fira-code-3.ebuild
@@ -13,15 +13,23 @@ https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip"
 LICENSE="OFL-1.1"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~x86"
-IUSE=""
+IUSE="ttf"
 
 S="${WORKDIR}/FiraCode-${PV}"
-FONT_S="${S}/distr/otf"
-FONT_SUFFIX="otf"
 
 DOCS="README.md"
 
 DEPEND="app-arch/unzip"
+
+pkg_setup() {
+	if ! use ttf; then
+		export FONT_S="${S}/distr/otf"
+		export FONT_SUFFIX="otf"
+	else
+		export FONT_S="${S}/distr/ttf"
+		export FONT_SUFFIX="ttf"
+	fi
+}
 
 src_prepare() {
 	default

--- a/media-fonts/fira-code/metadata.xml
+++ b/media-fonts/fira-code/metadata.xml
@@ -12,4 +12,7 @@
 	<upstream>
 		<remote-id type="github">tonsky/FiraCode</remote-id>
 	</upstream>
+	<use>
+		<flag name="ttf">Install TTF files instead of OTF.</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
The ttf USE flag installs TTF files instead of OTF files (except for the Symbol font).

Fira Code 2 has significantly changed metrics and the OTF files tend to render blurry for certain characters (f, _) with the same fontconfig. The TTF files do not have this problem.

Related thread: https://github.com/tonsky/FiraCode/issues/798#issuecomment-544230516