### PR TITLE
media-libs/shaderc-2019.0 Remove python2 support

### DIFF
--- a/media-libs/shaderc/shaderc-2019.0.ebuild
+++ b/media-libs/shaderc/shaderc-2019.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{3_5,3_6,3_7} )
 
 inherit cmake-multilib python-any-r1
 


### PR DESCRIPTION
This app errors when using python2, add python 3.7 too

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>