### PR TITLE
dev-php/awl: dev-php/awl: remove postgres use flag from dev-lang/php

### DIFF
--- a/dev-php/awl/awl-0.59.ebuild
+++ b/dev-php/awl/awl-0.59.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="test"
 
 DEPEND="test? ( dev-php/phpunit )"
-RDEPEND="dev-lang/php:*[pdo,postgres,xml]"
+RDEPEND="dev-lang/php:*[pdo,xml]"
 
 S="${WORKDIR}"
 

--- a/dev-php/awl/awl-0.60.ebuild
+++ b/dev-php/awl/awl-0.60.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="test"
 
 BDEPEND="test? ( dev-php/phpunit )"
-RDEPEND="dev-lang/php:*[pdo,postgres,xml]"
+RDEPEND="dev-lang/php:*[pdo,xml]"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/698294
Signed-off-by: Richard hering richard@internethering.de
Package-Manager: Portage-2.3.78, Repoman-2.3.17