### PR TITLE
net-analyzer/netselect: Add filecaps support

### DIFF
--- a/net-analyzer/netselect/netselect-0.4-r2.ebuild
+++ b/net-analyzer/netselect/netselect-0.4-r2.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="Ultrafast implementation of ping"
+HOMEPAGE="http://apenwarr.ca/netselect/"
+SRC_URI="
+	https://github.com/apenwarr/${PN}/archive/${P}.tar.gz
+	ipv6? ( https://dev.gentoo.org/~jer/${P}-ipv6.patch.xz )
+"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+IUSE="ipv6"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.4-bsd.patch
+	"${FILESDIR}"/${PN}-0.4-flags.patch
+)
+
+DOCS=( HISTORY README )
+
+S=${WORKDIR}/${PN}-${P}
+
+src_prepare() {
+	use ipv6 && eapply "${WORKDIR}"/${PN}-0.4-ipv6.patch
+
+	default
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" LDFLAGS="${CFLAGS} ${LDFLAGS}"
+}
+
+src_install() {
+	dobin netselect
+
+	if ! use prefix ; then
+		fowners root:wheel /usr/bin/netselect
+		fperms 4711 /usr/bin/netselect
+	fi
+
+	einstalldocs
+
+	doman netselect.1
+}


### PR DESCRIPTION
This adds raw socket capabilities to `/usr/bin/netselect` so users can execute it without setuid.

`fcaps.eclass` adds `IUSE="+filecaps"`.  The eclass is also implemented in such a way that if `filecaps` is set in USE, it runs `chmod 711 ${D}/usr/bin/netselect ` and `filecap  cap_net_raw ${D}/usr/bin/netselect` (ownership remains the same at `root:root`).  If `filecaps` is not set however, or if the previous `filecap` command failed, it runs `chown root:wheel   ${D}/usr/bin/netselect` and `chmod 4711 ${D}/usr/bin/netselect` which leaves it with the same ownership and permissions as the original ebuild. Compare to [net-analyzer/mtr](https://github.com/gentoo/gentoo/blob/ff3f6def757847fc9154ea9f1f0b9492a7afab5a/net-analyzer/mtr/mtr-0.93-r1.ebuild) and [net-analyzer/arping](https://github.com/gentoo/gentoo/blob/f161beb5a5795bfa93f14dff464fe78d49e8187d/net-analyzer/arping/arping-2.20.ebuild).

Note, without the setuid bit, the following from `netselect.c` will cause netselect to unnecessarily output "`/usr/bin/netselect:root privileges required`" to stderr:
```
    if (geteuid () != 0)
        fprintf (stderr, "%s: root privileges required\n", argv[0]);
```
These are removed with sed when `USE=filecaps` (in lieu of yet another patch).

- **net-analyzer/netselect: Bump EAPI to 7**

- **net-analyzer/netselect: Add filecaps support**
Closes: https://bugs.gentoo.org/564902

Package-Manager: Portage-2.3.77, Repoman-2.3.17
Signed-off-by: Peter Levine <plevine457@gmail.com>