### PR TITLE
net-misc/tigervnc: Fix doc install dir

### DIFF
--- a/net-misc/tigervnc/tigervnc-1.9.0-r1.ebuild
+++ b/net-misc/tigervnc/tigervnc-1.9.0-r1.ebuild
@@ -85,6 +85,10 @@ src_prepare() {
 		cp -r "${WORKDIR}"/xorg-server-${XSERVER_VERSION}/. unix/xserver || die
 	fi
 
+	# do not rely on the build system to install docs
+	sed -i 's:^\(install(.* DESTINATION ${DOC_DIR})\):#\1:' \
+		cmake/BuildPackages.cmake || die
+
 	cmake-utils_src_prepare
 
 	if use server ; then


### PR DESCRIPTION
Do not rely on the build system to install docs.

Package-Manager: Portage-2.3.76, Repoman-2.3.16