### PR TITLE
net-dialup/lrzsz: fix compilation with gettext-0.20

### DIFF
--- a/net-dialup/lrzsz/files/lrzsz-0.12.20-gettext-0.20.patch
+++ b/net-dialup/lrzsz/files/lrzsz-0.12.20-gettext-0.20.patch
@@ -1,0 +1,23 @@
+diff -udr a/configure.in b/configure.in
+--- a/configure.in	1998-12-30 08:50:07.000000000 +0100
++++ b/configure.in	2019-06-01 20:38:54.918650170 +0200
+@@ -1,3 +1,4 @@
++m4_pattern_allow(.*)
+ dnl Process this file with autoconf to produce a configure script.
+ AC_INIT(src/crctab.c)
+ AM_INIT_AUTOMAKE(lrzsz, 0.12.20)
+diff -udr lrzsz-0.12.20.orig/po/Makefile.in.in lrzsz-0.12.20/po/Makefile.in.in
+--- a/po/Makefile.in.in	1998-04-26 15:22:40.000000000 +0200
++++ b/po/Makefile.in.in	2019-06-01 20:48:09.020703542 +0200
+@@ -110,9 +110,9 @@
+ install-data-no: all
+ install-data-yes: all
+ 	if test -r $(MKINSTALLDIRS); then \
+-	  $(MKINSTALLDIRS) $(datadir); \
++	  $(MKINSTALLDIRS) $(DATADIR); \
+ 	else \
+-	  $(top_srcdir)/mkinstalldirs $(datadir); \
++	  $(top_srcdir)/mkinstalldirs $(DATADIR); \
+ 	fi
+ 	@catalogs='$(CATALOGS)'; \
+ 	for cat in $$catalogs; do \

--- a/net-dialup/lrzsz/lrzsz-0.12.20-r4.ebuild
+++ b/net-dialup/lrzsz/lrzsz-0.12.20-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,10 +16,13 @@ IUSE="nls"
 
 DEPEND="nls? ( virtual/libintl )"
 
-PATCHES=( "${FILESDIR}"/${PN}-autotools.patch
+PATCHES=(
+	"${FILESDIR}"/${PN}-autotools.patch
 	"${FILESDIR}"/${PN}-implicit-decl.patch
 	"${FILESDIR}"/${P}-automake-1.12.patch
-	"${FILESDIR}"/${P}-automake-1.13.patch )
+	"${FILESDIR}"/${P}-automake-1.13.patch
+	"${FILESDIR}"/${P}-gettext-0.20.patch
+)
 
 DOCS=( AUTHORS COMPATABILITY ChangeLog NEWS \
 	README{,.cvs,.gettext,.isdn4linux,.tests} THANKS TODO )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/685696
Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>