### PR TITLE
app-editors/neovim: fix live deps

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -28,6 +28,7 @@ BDEPEND="
 "
 
 DEPEND="
+	dev-libs/libutf8proc:=
 	dev-libs/libuv:0=
 	>=dev-libs/libvterm-0.1
 	dev-libs/msgpack:0=


### PR DESCRIPTION
The dependency on dev-libs/libutf8proc was accidentally removed in a68e2628f13
Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: Bernardo Meurer <bernardo@standard.ai>