### PR TITLE
app-emulation/xen: drop keywords for 4.13.0-rc1

### DIFF
--- a/app-emulation/xen-pvgrub/xen-pvgrub-4.13.0_rc1.ebuild
+++ b/app-emulation/xen-pvgrub/xen-pvgrub-4.13.0_rc1.ebuild
@@ -35,7 +35,8 @@ DESCRIPTION="allows to boot Xen domU kernels from a menu.lst laying inside guest
 HOMEPAGE="https://www.xenproject.org"
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+#KEYWORDS="~amd64 ~x86"
+KEYWORDS=""
 IUSE=""
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/app-emulation/xen-tools/xen-tools-4.13.0_rc1.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.13.0_rc1.ebuild
@@ -16,7 +16,8 @@ if [[ $PV == *9999 ]]; then
 	EGIT_REPO_URI="git://xenbits.xen.org/${REPO}"
 	S="${WORKDIR}/${REPO}"
 else
-	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+	#KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+	KEYWORDS=""
 	UPSTREAM_VER=
 	SECURITY_VER=
 	# xen-tools's gentoo patches tarball

--- a/app-emulation/xen/xen-4.13.0_rc1.ebuild
+++ b/app-emulation/xen/xen-4.13.0_rc1.ebuild
@@ -15,7 +15,8 @@ if [[ $PV == *9999 ]]; then
 	EGIT_REPO_URI="git://xenbits.xen.org/xen.git"
 	SRC_URI=""
 else
-	KEYWORDS="~amd64 ~arm -x86"
+	#KEYWORDS="~amd64 ~arm -x86"
+	KEYWORDS=""
 	UPSTREAM_VER=
 	SECURITY_VER=
 	GENTOO_VER=


### PR DESCRIPTION
Let's keep 4.11 stable, 4.12 testing and 4.13 only for hardcore testers. Re-add keywords after 4.13 is final.