### PR TITLE
sys-libs/efivar: fix compiling makeguids on older hosts

### DIFF
--- a/sys-libs/efivar/efivar-37-r1.ebuild
+++ b/sys-libs/efivar/efivar-37-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit flag-o-matic toolchain-funcs
+
+DESCRIPTION="Tools and library to manipulate EFI variables"
+HOMEPAGE="https://github.com/rhinstaller/efivar"
+SRC_URI="https://github.com/rhinstaller/efivar/releases/download/${PV}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0/1"
+KEYWORDS="amd64 ~arm ~arm64 ia64 x86"
+
+RDEPEND="dev-libs/popt"
+DEPEND="${RDEPEND}
+	>=sys-kernel/linux-headers-3.18
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-makeguids_fix_host_compile.patch"
+)
+
+src_prepare() {
+	default
+	sed -i -e 's/-Werror //' gcc.specs || die
+}
+
+src_configure() {
+	tc-export CC
+	export CC_FOR_BUILD=$(tc-getBUILD_CC)
+	tc-ld-disable-gold
+	export libdir="/usr/$(get_libdir)"
+	unset LIBS # Bug 562004
+
+	if [[ -n ${GCC_SPECS} ]]; then
+		# The environment overrides the command line.
+		GCC_SPECS+=":${S}/gcc.specs"
+	fi
+}

--- a/sys-libs/efivar/files/efivar-37-makeguids_fix_host_compile.patch
+++ b/sys-libs/efivar/files/efivar-37-makeguids_fix_host_compile.patch
@@ -1,0 +1,36 @@
+From 81346196bb262156fd436c78323d161af61dd6c1 Mon Sep 17 00:00:00 2001
+From: Dmitry Torokhov <dtor@chromium.org>
+Date: Tue, 6 Aug 2019 09:22:25 -0700
+Subject: [PATCH] Make sure makeguids helper is compiled for the host's arch
+
+Currently makeguids is compiled with the same flags/settings as the rest
+of the package, which does not work in case of cross-compiles when arch
+of the build host and the target host are different. Let's force
+compiling for the native host arch to avoid this issue.
+
+Note that this is not a full cross-compile solution as this does not
+account for potential differences in host/target compilers (versions,
+clang vs gcc, etc), but it removes one of the issue with package build
+aborting due to invalid instruction on the host.
+
+Signed-off-by: Dmitry Torokhov <dtor@chromium.org>
+---
+ src/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index addfaa0..3729d2b 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -52,7 +52,7 @@ include/efivar/efivar-guids.h : makeguids guids.txt
+ 	./makeguids guids.txt guids.bin names.bin \
+ 		guid-symbols.c include/efivar/efivar-guids.h
+ 
+-makeguids : CPPFLAGS+=-DEFIVAR_BUILD_ENVIRONMENT
++makeguids : CPPFLAGS+=-DEFIVAR_BUILD_ENVIRONMENT -march=native
+ makeguids : LIBS=dl
+ makeguids : $(MAKEGUIDS_SOURCES)
+ makeguids : CCLD=$(CCLD_FOR_BUILD)
+-- 
+2.23.0.866.gb869b98d4c-goog
+


### PR DESCRIPTION
This imports a fix for build failures when compiling on older hosts for
a newer microarchitectures.

Signed-off-by: Dmitry Torokhov <dtor@chromium.org>