### PR TITLE
dev-ruby/whole_history_rating: use ls instead of git ls-files

### DIFF
--- a/dev-ruby/whole_history_rating/whole_history_rating-0.1.2.ebuild
+++ b/dev-ruby/whole_history_rating/whole_history_rating-0.1.2.ebuild
@@ -24,3 +24,8 @@ ruby_add_bdepend "
 		dev-ruby/test-unit:2
 	)
 "
+
+all_ruby_prepare (){
+	sed -i 's/git ls-files/ls -1/g' "${RUBY_FAKEGEM_GEMSPEC}" || die
+	default
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/698532
Package-Manager: Portage-2.3.77, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>