### PR TITLE
virtual/libudev: drop support for sys-fs/eudev

### DIFF
--- a/virtual/libudev/libudev-232-r1.ebuild
+++ b/virtual/libudev/libudev-232-r1.ebuild
@@ -1,0 +1,15 @@
+# Copyright 2014-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit multilib-build
+
+DESCRIPTION="Virtual for libudev providers"
+SLOT="0/1"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+IUSE="systemd"
+
+RDEPEND="
+	!systemd? ( >=sys-fs/udev-232:0/0[${MULTILIB_USEDEP}] )
+	systemd? ( >=sys-apps/systemd-232:0/2[${MULTILIB_USEDEP}] )
+"


### PR DESCRIPTION
Also depend on >=sys-apps/systemd-232.
Also drop support for static-libs.
Drop riscv keyword since no providers can satisfy it.

Bug: https://bugs.gentoo.org/697550
Package-Manager: Portage-2.3.78_p4, Repoman-2.3.17_p100
Signed-off-by: Mike Gilbert <floppym@gentoo.org>