### PR TITLE
media-fonts/glass-tty-vt220: update font cache automatically

### DIFF
--- a/media-fonts/glass-tty-vt220/glass-tty-vt220-001.3-r2.ebuild
+++ b/media-fonts/glass-tty-vt220/glass-tty-vt220-001.3-r2.ebuild
@@ -33,6 +33,8 @@ src_compile() {
 }
 
 pkg_postinst() {
+	font_pkg_postinst
+
 	einfo "Since the GlassTTY VT220 font is fixed,"
 	einfo "you must use a font size of 15 for best quality."
 }


### PR DESCRIPTION
Since pkg_postinst is custom definied, the font cache is not updated
after installation. This can lead to access violations on other
packages, which try to do this.

Closes: https://bugs.gentoo.org/662960
Bug: https://bugs.gentoo.org/679858
Closes: https://bugs.gentoo.org/698526
Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>