### PR TITLE
www-client/chromium: fix build with icu-65

### DIFF
--- a/www-client/chromium/chromium-79.0.3941.4.ebuild
+++ b/www-client/chromium/chromium-79.0.3941.4.ebuild
@@ -150,6 +150,7 @@ PATCHES=(
 	"${FILESDIR}/chromium-79-swiftshader-linux.patch"
 	"${FILESDIR}/chromium-79-system-hb.patch"
 	"${FILESDIR}/chromium-79-include.patch"
+	"${FILESDIR}/chromium-79-icu-65.patch"
 	"${FILESDIR}/chromium-79-gcc-ambiguous-nodestructor.patch"
 	"${FILESDIR}/chromium-79-gcc-permissive.patch"
 	"${FILESDIR}/chromium-79-gcc-alignas.patch"

--- a/www-client/chromium/files/chromium-79-icu-65.patch
+++ b/www-client/chromium/files/chromium-79-icu-65.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/blink/renderer/core/dom/document.cc b/third_party/blink/renderer/core/dom/document.cc
+index 5a62770..1fae2aa 100644
+--- a/third_party/blink/renderer/core/dom/document.cc
++++ b/third_party/blink/renderer/core/dom/document.cc
+@@ -6192,7 +6192,7 @@ static ParseQualifiedNameResult ParseQualifiedNameInternal(
+ 
+   for (unsigned i = 0; i < length;) {
+     UChar32 c;
+-    U16_NEXT(characters, i, length, c)
++    U16_NEXT(characters, i, length, c);
+     if (c == ':') {
+       if (saw_colon)
+         return ParseQualifiedNameResult(kQNMultipleColons);


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/698564
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>