### PR TITLE
net-analyzer/fping: Add support for USE="filecaps"

### DIFF
--- a/net-analyzer/fping/fping-4.2-r1.ebuild
+++ b/net-analyzer/fping/fping-4.2-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit fcaps
+
+DESCRIPTION="A utility to ping multiple hosts at once"
+HOMEPAGE="https://fping.org/"
+SRC_URI="https://fping.org/dist/${P}.tar.gz"
+
+LICENSE="fping"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x86-macos"
+IUSE="ipv6 suid"
+REQUIRED_USE="filecaps? ( !suid )"
+
+src_configure() {
+	econf $(use_enable ipv6)
+}
+
+src_install() {
+	default
+
+	use suid && fperms u+s /usr/sbin/fping
+}
+
+pkg_postinst() {
+	use filecaps &&	fcaps cap_net_raw+ep /usr/sbin/fping
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/698662
Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: Nils Freydank <holgersson@posteo.de>