### PR TITLE
dev-util/btyacc: license change

### DIFF
--- a/dev-util/btyacc/btyacc-3.0-r3.ebuild
+++ b/dev-util/btyacc/btyacc-3.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ DESCRIPTION="Backtracking YACC - modified from Berkeley YACC"
 HOMEPAGE="http://www.siber.com/btyacc"
 SRC_URI="http://www.siber.com/btyacc/${MY_P}.tar.gz"
 
-LICENSE="freedist"
+LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86 ~x86-linux ~ppc-macos ~x86-macos"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/693086
Package-Manager: Portage-2.3.77, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>