### PR TITLE
dev-php/pecl-yaml: bump to EAPI=7

### DIFF
--- a/dev-php/pecl-yaml/pecl-yaml-2.0.4-r1.ebuild
+++ b/dev-php/pecl-yaml/pecl-yaml-2.0.4-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MY_PV="${PV/_rc/RC}"
+USE_PHP="php7-1 php7-2 php7-3 php7-4"
+
+inherit php-ext-pecl-r3
+
+DESCRIPTION="YAML 1.1 (YAML Ain't Markup Language) serialization for PHP"
+
+LICENSE="MIT"
+SLOT="7"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="dev-libs/libyaml"
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/yaml-${MY_PV}"
+
+PHP_EXT_ECONF_ARGS=""
+PHP_EXT_PECL_FILENAME="yaml-${MY_PV}.tgz"
+PHP_EXT_INI="yes"
+PHP_EXT_NAME="yaml"
+PHP_EXT_S="${S}"
+PHP_EXT_ZENDEXT="no"


### PR DESCRIPTION
Also dropped php5-6 support, as upstream [1] says, it's not supported.
Support for php7-4 added, as all tests passed.

Overhauled whole ebuild.

[1] https://pecl.php.net/package/yaml/2.0.4

Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>