### PR TITLE
app-backup/btrbk: add USE=+mbuffer

### DIFF
--- a/app-backup/btrbk/btrbk-0.29.0.ebuild
+++ b/app-backup/btrbk/btrbk-0.29.0.ebuild
@@ -19,13 +19,13 @@ DESCRIPTION="Tool for creating snapshots and remote backups of btrfs subvolumes"
 HOMEPAGE="https://digint.ch/btrbk/"
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="+doc"
+IUSE="+mbuffer +doc"
 
 DEPEND="doc? ( >=dev-ruby/asciidoctor-1.5.7 )"
 
 RDEPEND="dev-lang/perl
 	net-misc/openssh
-	>=sys-block/mbuffer-20180505
+	mbuffer? ( >=sys-block/mbuffer-20180505 )
 	>=sys-fs/btrfs-progs-4.12"
 
 src_compile() {

--- a/app-backup/btrbk/btrbk-9999.ebuild
+++ b/app-backup/btrbk/btrbk-9999.ebuild
@@ -19,13 +19,13 @@ DESCRIPTION="Tool for creating snapshots and remote backups of btrfs subvolumes"
 HOMEPAGE="https://digint.ch/btrbk/"
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="+doc"
+IUSE="+mbuffer +doc"
 
 DEPEND="doc? ( >=dev-ruby/asciidoctor-1.5.7 )"
 
 RDEPEND="dev-lang/perl
 	net-misc/openssh
-	>=sys-block/mbuffer-20180505
+	mbuffer? ( >=sys-block/mbuffer-20180505 )
 	>=sys-fs/btrfs-progs-4.12"
 
 src_compile() {

--- a/app-backup/btrbk/metadata.xml
+++ b/app-backup/btrbk/metadata.xml
@@ -24,5 +24,6 @@
     </upstream>
     <use>
         <flag name='pv'>Use sys-apps/pv to enable progress bar functionality</flag>
+        <flag name='mbuffer'>Use sys-block/mbuffer to enable progress bar and buffering/limiting functionality</flag>
     </use>
 </pkgmetadata>


### PR DESCRIPTION
mbuffer is not a strict dependency: on many it is only used by btrbk if
progress-bar and/or buffering/limiting is enabled.