### PR TITLE
acct-gvm: acct-*/gvm (UID-GID 495)

### DIFF
--- a/acct-group/gvm/gvm-0.ebuild
+++ b/acct-group/gvm/gvm-0.ebuild
@@ -1,0 +1,9 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+DESCRIPTION="Greenbone vulnerability management program group"
+ACCT_GROUP_ID=495

--- a/acct-group/gvm/metadata.xml
+++ b/acct-group/gvm/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>hasan.calisir@psauxit.com</email>
+		<name>Hasan ÇALIŞIR</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+		</maintainer>
+</pkgmetadata>

--- a/acct-user/gvm/gvm-0.ebuild
+++ b/acct-user/gvm/gvm-0.ebuild
@@ -1,0 +1,13 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="Greenbone vulnerability management program user"
+ACCT_USER_ID=495
+ACCT_USER_HOME=/var/lib/gvm
+ACCT_USER_GROUPS=( gvm )
+
+acct-user_add_deps

--- a/acct-user/gvm/metadata.xml
+++ b/acct-user/gvm/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+        <maintainer type="person">
+                <email>hasan.calisir@psauxit.com</email>
+                <name>Hasan ÇALIŞIR</name>
+        </maintainer>
+        <maintainer type="project">
+                <email>proxy-maint@gentoo.org</email>
+                <name>Proxy Maintainers</name>
+        </maintainer>
+</pkgmetadata>


### PR DESCRIPTION
Shared with gentoo-dev list on _Sat, 03 Aug 2019_ and **495** has been reserved;
https://www.mail-archive.com/gentoo-dev@lists.gentoo.org/msg85732.html
https://wiki.gentoo.org/wiki/Project:Quality_Assurance/UID_GID_Assignment

----------------------------------
Added missing sign-off as requested by @juippis;
https://github.com/gentoo/gentoo/pull/12609