### PR TITLE
net-analyzer/metasploit: drop openvas-omp support properly

### DIFF
--- a/net-analyzer/metasploit/metasploit-4.17.21-r6.ebuild
+++ b/net-analyzer/metasploit/metasploit-4.17.21-r6.ebuild
@@ -92,7 +92,7 @@ RUBY_COMMON_DEPEND="virtual/ruby-ssl
 	dev-ruby/ruby-macho
 	dev-ruby/rubyntlm
 	dev-ruby/ruby_smb:*
-	dev-ruby/rubyzip
+	dev-ruby/rubyzip:*
 	dev-ruby/sqlite3
 	dev-ruby/sshkey
 	dev-ruby/tzinfo:*
@@ -215,6 +215,12 @@ all_ruby_prepare() {
 	#if ! use nessus; then
 		sed -i -e "/nessus/d" metasploit-framework.gemspec || die
 	#fi
+
+	#OpenVAS support dropped on net-analyzer/metasploit. Bug:692076
+	#openvas-omp is deprecated and masked for removal. Bug:692076
+	#Remove openvas-omp in gemspec. Bug:698762
+	sed -i -e "/openvas-omp/d" metasploit-framework.gemspec || die
+
 	#even if we pass --without=blah bundler still calculates the deps and messes us up
 	if ! use development; then
 		sed -i -e "/^group :development do/,/^end$/d" Gemfile || die

--- a/net-analyzer/metasploit/metasploit-9999.ebuild
+++ b/net-analyzer/metasploit/metasploit-9999.ebuild
@@ -91,7 +91,7 @@ RUBY_COMMON_DEPEND="virtual/ruby-ssl
 	dev-ruby/ruby-macho
 	dev-ruby/rubyntlm
 	dev-ruby/ruby_smb:*
-	dev-ruby/rubyzip
+	dev-ruby/rubyzip:*
 	dev-ruby/sqlite3
 	dev-ruby/sshkey
 	dev-ruby/tzinfo:*
@@ -214,6 +214,12 @@ all_ruby_prepare() {
 	#if ! use nessus; then
 		sed -i -e "/nessus/d" metasploit-framework.gemspec || die
 	#fi
+
+	#OpenVAS support dropped on net-analyzer/metasploit. Bug:692076
+	#openvas-omp is deprecated and masked for removal. Bug:692076
+	#Remove openvas-omp in gemspec. Bug:698762
+	sed -i -e "/openvas-omp/d" metasploit-framework.gemspec || die
+
 	#even if we pass --without=blah bundler still calculates the deps and messes us up
 	if ! use development; then
 		sed -i -e "/^group :development do/,/^end$/d" Gemfile || die


### PR DESCRIPTION
Fix: https://bugs.gentoo.org/698762

We recently dropped openvas-omp support on net-analyzer/metasploit.

@ZeroChaos- @juippis  it seems the below code we recently removed causes the error:

```
if ! use openvas; then
	sed -i -e "/openvas-omp/d" metasploit-framework.gemspec || die
fi
```
Because openvas-omp support has been already dropped we need to remove this from gemspec in default:

`sed -i -e "/openvas-omp/d" metasploit-framework.gemspec || die`

--------------------------------------

Closes: https://bugs.gentoo.org/698762
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>