### PR TITLE
app-editors/gummi: Drop KEYWORDS for pre-release

### DIFF
--- a/app-editors/gummi/gummi-0.7.999.ebuild
+++ b/app-editors/gummi/gummi-0.7.999.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/alexandervdm/${PN}/releases/download/${PV}/${P}.tar.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS=""
 IUSE=""
 
 RDEPEND="


### PR DESCRIPTION
Spell-checking does not work. Keep 0.7.999 un-keyworded for
testing purposes. Re-add keywords once 0.8.0 final is out.

Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Christian Tietz <christian.tietz@mailbox.org>