### PR TITLE
Fix tc-cpp-is-true to work with clang

### DIFF
--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -207,14 +207,13 @@ tc-cpp-is-true() {
 	local CONDITION=${1}
 	shift
 
-	local RESULT=$($(tc-getTARGET_CPP) "${@}" -P - <<-EOF 2>/dev/null
-			#if ${CONDITION}
-			true
-			#endif
-		EOF
-	)
-
-	[[ ${RESULT} == true ]]
+	$(tc-getTARGET_CPP) "${@}" -P - <<-EOF >/dev/null 2>&1
+		#if ${CONDITION}
+		true
+		#else
+		#error false
+		#endif
+	EOF
 }
 
 # @FUNCTION: tc-detect-is-softfloat


### PR DESCRIPTION
Clang's preprocessor likes to output a leading newline, which makes
the comparison always fail. Strip whitespace to work around that.

Bug: https://bugs.gentoo.org/698912

Signed-off-by: Mattias Nissler <mnissler@chromium.org>