### PR TITLE
net-mail/vacation: upgrade to EAPI7

### DIFF
--- a/net-mail/vacation/vacation-1.2.7.0-r1.ebuild
+++ b/net-mail/vacation/vacation-1.2.7.0-r1.ebuild
@@ -17,25 +17,19 @@ RDEPEND="virtual/mta
 DEPEND="${RDEPEND}
 	!mail-mta/sendmail"
 
-src_unpack() {
-	unpack ${A}
-	cd "${S}"
-}
-
 src_prepare() {
-	eapply_user
+	default
 
 	sed -i -e "s:install -s -m:install -m:" Makefile || die "sed failed!"
 	sed -i -e "s:-Xlinker:${LDFLAGS} -Xlinker:" Makefile || die "sed failed!"
 }
 
 src_compile () {
-	emake CC=$(tc-getCC) ARCH=$(tc-arch-kernel) CFLAGS="${CFLAGS} -DMAIN" || die "emake failed."
+	emake CC=$(tc-getCC) ARCH=$(tc-arch-kernel) CFLAGS="${CFLAGS} -DMAIN"
 }
 
 src_install () {
 	dodir /usr/bin
 	dodir /usr/share/man/man1
-	emake BINDIR="${D}/usr/bin" MANDIR="${D}/usr/share/man/man" install || die \
-	"make install failed"
+	emake BINDIR="${D}/usr/bin" MANDIR="${D}/usr/share/man/man" install
 }

--- a/net-mail/vacation/vacation-1.2.7.0-r1.ebuild
+++ b/net-mail/vacation/vacation-1.2.7.0-r1.ebuild
@@ -25,7 +25,7 @@ src_prepare() {
 }
 
 src_compile () {
-	emake CC=$(tc-getCC) ARCH=$(tc-arch-kernel) CFLAGS="${CFLAGS} -DMAIN"
+	emake CFLAGS="${CFLAGS} -DMAIN"
 }
 
 src_install () {

--- a/net-mail/vacation/vacation-1.2.7.0-r1.ebuild
+++ b/net-mail/vacation/vacation-1.2.7.0-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit eutils toolchain-funcs
+
+DESCRIPTION="automatic mail answering program"
+HOMEPAGE="http://vacation.sourceforge.net/"
+SRC_URI="mirror://sourceforge/vacation/${P}.tar.gz"
+LICENSE="GPL-2"
+KEYWORDS="~alpha ~amd64 ~x86"
+SLOT="0"
+
+RDEPEND="virtual/mta
+	sys-libs/gdbm"
+DEPEND="${RDEPEND}
+	!mail-mta/sendmail"
+
+src_unpack() {
+	unpack ${A}
+	cd "${S}"
+}
+
+src_prepare() {
+	eapply_user
+
+	sed -i -e "s:install -s -m:install -m:" Makefile || die "sed failed!"
+	sed -i -e "s:-Xlinker:${LDFLAGS} -Xlinker:" Makefile || die "sed failed!"
+}
+
+src_compile () {
+	emake CC=$(tc-getCC) ARCH=$(tc-arch-kernel) CFLAGS="${CFLAGS} -DMAIN" || die "emake failed."
+}
+
+src_install () {
+	dodir /usr/bin
+	dodir /usr/share/man/man1
+	emake BINDIR="${D}/usr/bin" MANDIR="${D}/usr/share/man/man" install || die \
+	"make install failed"
+}

--- a/net-mail/vacation/vacation-1.2.7.0-r1.ebuild
+++ b/net-mail/vacation/vacation-1.2.7.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="automatic mail answering program"
 HOMEPAGE="http://vacation.sourceforge.net/"
@@ -12,16 +12,15 @@ LICENSE="GPL-2"
 KEYWORDS="~alpha ~amd64 ~x86"
 SLOT="0"
 
-RDEPEND="virtual/mta
-	sys-libs/gdbm"
-DEPEND="${RDEPEND}
-	!mail-mta/sendmail"
+RDEPEND="!mail-mta/sendmail
+	sys-libs/gdbm
+	virtual/mta"
+DEPEND="${RDEPEND}"
 
 src_prepare() {
 	default
 
-	sed -i -e "s:install -s -m:install -m:" Makefile || die "sed failed!"
-	sed -i -e "s:-Xlinker:${LDFLAGS} -Xlinker:" Makefile || die "sed failed!"
+	sed -i -e "s:install -s -m:install -m:" -e "s:-Xlinker:${LDFLAGS} -Xlinker:" Makefile || die "sed failed!"
 }
 
 src_compile () {
@@ -29,7 +28,5 @@ src_compile () {
 }
 
 src_install () {
-	dodir /usr/bin
-	dodir /usr/share/man/man1
 	emake BINDIR="${D}/usr/bin" MANDIR="${D}/usr/share/man/man" install
 }


### PR DESCRIPTION
fixes build error on incorrect man page path

Bug: https://bugs.gentoo.org/696252
Signed-off-by: Jörg Habenicht <j.habenicht@gmx.de>
Package-Manager: Portage-2.3.76, Repoman-2.3.16