### PR TITLE
www-client/chromium: fix building with icu-65 in stable channel

### DIFF
--- a/www-client/chromium/chromium-78.0.3904.70.ebuild
+++ b/www-client/chromium/chromium-78.0.3904.70.ebuild
@@ -158,6 +158,7 @@ PATCHES=(
 	"${FILESDIR}/chromium-78-gcc-std-vector.patch"
 	"${FILESDIR}/chromium-78-gcc-noexcept.patch"
 	"${FILESDIR}/chromium-78-gcc-alignas.patch"
+	"${FILESDIR}/chromium-79-icu-65.patch"
 )
 
 pre_build_checks() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/698930
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>