### PR TITLE
app-i18n/ibus-handwrite: cannot depend on gtkglext

### DIFF
--- a/app-i18n/ibus-handwrite/ibus-handwrite-3.0.0.ebuild
+++ b/app-i18n/ibus-handwrite/ibus-handwrite-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -14,7 +14,6 @@ IUSE="nls +zinnia"
 
 RDEPEND="app-i18n/ibus
 	x11-libs/gtk+:3
-	x11-libs/gtkglext
 	nls? ( virtual/libintl )
 	zinnia? (
 		app-i18n/zinnia


### PR DESCRIPTION
- no occurence is found [1]
- is ported to GTK3, while gtkglext is GTK2 library

[1] https://github.com/microcai/ibus-handwrite/search?q=gtkglext&unscoped_q=gtkglext

Closes: https://bugs.gentoo.org/698958

Signed-off-by: David Heidelberg <david@ixit.cz>