### PR TITLE
games-emulation/desmume: drop dependency on gtkglext

### DIFF
--- a/games-emulation/desmume/desmume-0.9.11-r1.ebuild
+++ b/games-emulation/desmume/desmume-0.9.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -21,8 +21,7 @@ RDEPEND="
 	sys-libs/zlib
 	virtual/opengl
 	x11-libs/agg
-	>=x11-libs/gtk+-2.8.0:2
-	x11-libs/gtkglext"
+	>=x11-libs/gtk+-2.8.0:2"
 DEPEND="${RDEPEND}
 	dev-util/intltool
 	virtual/pkgconfig"


### PR DESCRIPTION
Removed in approx. in 0.9.9 [1]

[1] https://github.com/TASVideos/desmume/commit/651ed760b7ad4c40433c409b768f5411edd4779a

Closes: https://bugs.gentoo.org/698962

Signed-off-by: David Heidelberg <david@ixit.cz>