### PR TITLE
net-libs/libvncserver: Add a bunch of upstream fixes

### DIFF
--- a/net-libs/libvncserver/files/libvncserver-0.9.12-CVE-2018-20750.patch
+++ b/net-libs/libvncserver/files/libvncserver-0.9.12-CVE-2018-20750.patch
@@ -1,0 +1,47 @@
+From 09e8fc02f59f16e2583b34fe1a270c238bd9ffec Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Mon, 7 Jan 2019 10:40:01 +0100
+Subject: [PATCH 01/51] Limit lenght to INT_MAX bytes in
+ rfbProcessFileTransferReadBuffer()
+
+This ammends 15bb719c03cc70f14c36a843dcb16ed69b405707 fix for a heap
+out-of-bound write access in rfbProcessFileTransferReadBuffer() when
+reading a transfered file content in a server. The former fix did not
+work on platforms with a 32-bit int type (expected by rfbReadExact()).
+
+CVE-2018-15127
+<https://github.com/LibVNC/libvncserver/issues/243>
+<https://github.com/LibVNC/libvncserver/issues/273>
+---
+ libvncserver/rfbserver.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/libvncserver/rfbserver.c b/libvncserver/rfbserver.c
+index 7af8490..f2edbee 100644
+--- a/libvncserver/rfbserver.c
++++ b/libvncserver/rfbserver.c
+@@ -88,6 +88,8 @@
+ #include <errno.h>
+ /* strftime() */
+ #include <time.h>
++/* INT_MAX */
++#include <limits.h>
+ 
+ #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
+ #include "rfbssl.h"
+@@ -1472,8 +1474,11 @@ char *rfbProcessFileTransferReadBuffer(rfbClientPtr cl, uint32_t length)
+        0XFFFFFFFF, i.e. SIZE_MAX for 32-bit systems. On 64-bit systems, a length of 0XFFFFFFFF
+        will safely be allocated since this check will never trigger and malloc() can digest length+1
+        without problems as length is a uint32_t.
++       We also later pass length to rfbReadExact() that expects a signed int type and
++       that might wrap on platforms with a 32-bit int type if length is bigger
++       than 0X7FFFFFFF.
+     */
+-    if(length == SIZE_MAX) {
++    if(length == SIZE_MAX || length > INT_MAX) {
+ 	rfbErr("rfbProcessFileTransferReadBuffer: too big file transfer length requested: %u", (unsigned int)length);
+ 	rfbCloseClient(cl);
+ 	return NULL;
+-- 
+2.23.0
+

--- a/net-libs/libvncserver/files/libvncserver-0.9.12-CVE-2019-15681.patch
+++ b/net-libs/libvncserver/files/libvncserver-0.9.12-CVE-2019-15681.patch
@@ -1,0 +1,26 @@
+From d01e1bb4246323ba6fcee3b82ef1faa9b1dac82a Mon Sep 17 00:00:00 2001
+From: Christian Beier <dontmind@freeshell.org>
+Date: Mon, 19 Aug 2019 22:32:25 +0200
+Subject: [PATCH 48/51] rfbserver: don't leak stack memory to the remote
+
+Thanks go to Pavel Cheremushkin of Kaspersky for reporting.
+---
+ libvncserver/rfbserver.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libvncserver/rfbserver.c b/libvncserver/rfbserver.c
+index 3bacc89..310e548 100644
+--- a/libvncserver/rfbserver.c
++++ b/libvncserver/rfbserver.c
+@@ -3724,6 +3724,8 @@ rfbSendServerCutText(rfbScreenInfoPtr rfbScreen,char *str, int len)
+     rfbServerCutTextMsg sct;
+     rfbClientIteratorPtr iterator;
+ 
++    memset((char *)&sct, 0, sizeof(sct));
++
+     iterator = rfbGetClientIterator(rfbScreen);
+     while ((cl = rfbClientIteratorNext(iterator)) != NULL) {
+         sct.type = rfbServerCutText;
+-- 
+2.23.0
+

--- a/net-libs/libvncserver/files/libvncserver-0.9.12-cmake-libdir.patch
+++ b/net-libs/libvncserver/files/libvncserver-0.9.12-cmake-libdir.patch
@@ -1,6 +1,27 @@
---- libvncserver-LibVNCServer-0.9.12/CMakeLists.txt
-+++ libvncserver-LibVNCServer-0.9.12/CMakeLists.txt
-@@ -666,8 +666,8 @@
+From 3348a7e42e86dfb98dd7458ad29def476cf6096f Mon Sep 17 00:00:00 2001
+From: Christian Beier <dontmind@freeshell.org>
+Date: Sat, 9 Feb 2019 13:23:26 +0100
+Subject: [PATCH 02/51] CMake: replace hardcoded 'lib' with
+ ${CMAKE_INSTALL_LIBDIR}
+
+Closes #281
+---
+ CMakeLists.txt | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 873cc7b..55f7e65 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,6 +9,7 @@ include(CheckTypeSize)
+ include(TestBigEndian)
+ include(CheckCSourceCompiles)
+ include(CheckCSourceRuns)
++include(GNUInstallDirs)
+ 
+ enable_testing()
+ 
+@@ -666,8 +667,8 @@ get_link_libraries(PRIVATE_LIBS vncclient)
  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libvncclient.pc.cmakein ${CMAKE_CURRENT_BINARY_DIR}/libvncclient.pc @ONLY)
  
  
@@ -11,7 +32,7 @@
  install_files(/include/rfb FILES
      rfb/keysym.h
      rfb/rfb.h
-@@ -677,7 +677,7 @@
+@@ -677,7 +678,7 @@ install_files(/include/rfb FILES
      rfb/rfbregion.h
  )
  
@@ -20,3 +41,6 @@
      libvncserver.pc
      libvncclient.pc
  )
+-- 
+2.23.0
+

--- a/net-libs/libvncserver/files/libvncserver-0.9.12-fix-tight-raw-decoding.patch
+++ b/net-libs/libvncserver/files/libvncserver-0.9.12-fix-tight-raw-decoding.patch
@@ -1,0 +1,40 @@
+From 6b87d6154200667a66212f80068f7468eaa0f048 Mon Sep 17 00:00:00 2001
+From: DRC <information@virtualgl.org>
+Date: Sat, 28 Sep 2019 14:54:30 -0500
+Subject: [PATCH 50/51] LibVNCClient: Fix regression in Tight/Raw decoding
+
+Introduced by d7b1462 in LibVNCServer 0.9.12.  This regression caused
+the pixels in some RFB rectangles to become corrupted/garbled when the
+Tight encoding was used, without the JPEG subencoding, with a 15-bit or
+16-bit color depth.
+
+Fixes #335
+Fixes https://gitlab.com/Remmina/Remmina/issues/1824
+---
+ libvncclient/tight.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/libvncclient/tight.c b/libvncclient/tight.c
+index df01812..0586f47 100644
+--- a/libvncclient/tight.c
++++ b/libvncclient/tight.c
+@@ -1,5 +1,5 @@
+ /*
+- *  Copyright (C) 2017 D. R. Commander.  All Rights Reserved.
++ *  Copyright (C) 2017, 2019 D. R. Commander.  All Rights Reserved.
+  *  Copyright (C) 2004-2008 Sun Microsystems, Inc.  All Rights Reserved.
+  *  Copyright (C) 2004 Landmark Graphics Corporation.  All Rights Reserved.
+  *  Copyright (C) 2000, 2001 Const Kaplinsky.  All Rights Reserved.
+@@ -360,7 +360,8 @@ FilterCopyBPP (rfbClient* client, int srcx, int srcy, int numRows)
+ #endif
+ 
+   for (y = 0; y < numRows; y++)
+-    memcpy (&dst[y*client->width], &client->buffer[y*client->rectWidth],
++    memcpy (&dst[y*client->width],
++            &client->buffer[y * client->rectWidth * (BPP / 8)],
+             client->rectWidth * (BPP / 8));
+ }
+ 
+-- 
+2.23.0
+

--- a/net-libs/libvncserver/files/libvncserver-0.9.12-pkgconfig-libdir.patch
+++ b/net-libs/libvncserver/files/libvncserver-0.9.12-pkgconfig-libdir.patch
@@ -1,0 +1,41 @@
+From 36a71279ed5b10effecd879caf6c3791842ca713 Mon Sep 17 00:00:00 2001
+From: Christian Beier <dontmind@freeshell.org>
+Date: Thu, 28 Mar 2019 21:06:36 +0100
+Subject: [PATCH 03/51] CMake: replace 'lib' with ${CMAKE_INSTALL_LIBDIR} for
+ pkgconfig files as well
+
+Thanks to https://github.com/ikelos for spotting this ;-)
+
+Closes #290
+---
+ libvncclient.pc.cmakein | 2 +-
+ libvncserver.pc.cmakein | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libvncclient.pc.cmakein b/libvncclient.pc.cmakein
+index 169a8b7..445f7e7 100644
+--- a/libvncclient.pc.cmakein
++++ b/libvncclient.pc.cmakein
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=@CMAKE_INSTALL_PREFIX@/lib
++libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+ includedir=@CMAKE_INSTALL_PREFIX@/include
+ 
+ Name: LibVNCClient
+diff --git a/libvncserver.pc.cmakein b/libvncserver.pc.cmakein
+index f38d74f..c689806 100644
+--- a/libvncserver.pc.cmakein
++++ b/libvncserver.pc.cmakein
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=@CMAKE_INSTALL_PREFIX@/lib
++libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+ includedir=@CMAKE_INSTALL_PREFIX@/include
+ 
+ Name: LibVNCServer
+-- 
+2.23.0
+

--- a/net-libs/libvncserver/libvncserver-0.9.12-r3.ebuild
+++ b/net-libs/libvncserver/libvncserver-0.9.12-r3.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils
+
+MY_P="LibVNCServer-${PV}"
+DESCRIPTION="library for creating vnc servers"
+HOMEPAGE="https://libvnc.github.io/"
+SRC_URI="https://github.com/LibVNC/${PN}/archive/${MY_P}.tar.gz"
+
+# libvncserver/tightvnc-filetransfer/*: GPL-2, but we don't build it
+# common/d3des.*: https://github.com/LibVNC/libvncserver/issues/88
+LICENSE="GPL-2+ LGPL-2.1+ BSD MIT"
+# no sub slot wanted (yet), see #578958
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="+24bpp gcrypt gnutls ipv6 +jpeg libressl lzo +png sasl ssl systemd +threads +zlib"
+# https://bugs.gentoo.org/690202
+# https://bugs.gentoo.org/435326
+# https://bugs.gentoo.org/550916
+REQUIRED_USE="jpeg? ( zlib ) png? ( zlib ) ssl? ( !gnutls? ( threads ) )"
+
+DEPEND="
+	gcrypt? ( >=dev-libs/libgcrypt-1.5.3:0= )
+	ssl? (
+		!gnutls? (
+			!libressl? ( >=dev-libs/openssl-1.0.2:0= )
+			libressl? ( >=dev-libs/libressl-2.7.0:0= )
+		)
+		gnutls? ( >=net-libs/gnutls-2.12.23-r6:0= )
+	)
+	jpeg? ( >=virtual/jpeg-0-r2:0 )
+	lzo? ( dev-libs/lzo )
+	png? ( >=media-libs/libpng-1.6.10:0= )
+	sasl? ( dev-libs/cyrus-sasl )
+	systemd? ( sys-apps/systemd:= )
+	zlib? ( >=sys-libs/zlib-1.2.8-r1:0= )"
+RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/${PN}-${MY_P}"
+
+DOCS=( AUTHORS ChangeLog NEWS README.md TODO )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-cmake-libdir.patch
+	"${FILESDIR}"/${P}-pkgconfig-libdir.patch
+	"${FILESDIR}"/${P}-libgcrypt.patch
+	"${FILESDIR}"/${P}-sparc-unaligned.patch
+	"${FILESDIR}"/${P}-CVE-2018-20750.patch
+	"${FILESDIR}"/${P}-CVE-2019-15681.patch
+	"${FILESDIR}"/${P}-fix-tight-raw-decoding.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DWITH_ZLIB=$(usex zlib ON OFF)
+		-DWITH_LZO=$(usex lzo ON OFF)
+		-DWITH_JPEG=$(usex jpeg ON OFF)
+		-DWITH_PNG=$(usex png ON OFF)
+		-DWITH_THREADS=$(usex threads ON OFF)
+		-DWITH_GNUTLS=$(usex gnutls $(usex ssl ON OFF) OFF)
+		-DWITH_OPENSSL=$(usex gnutls OFF $(usex ssl ON OFF))
+		-DWITH_GCRYPT=$(usex gcrypt ON OFF)
+		-DWITH_SYSTEMD=$(usex systemd ON OFF)
+		-DWITH_FFMPEG=OFF
+		-DWITH_24BPP=$(usex 24bpp ON OFF)
+		-DWITH_IPv6=$(usex ipv6 ON OFF)
+		-DWITH_SASL=$(usex sasl ON OFF)
+	)
+	cmake-utils_src_configure
+}


### PR DESCRIPTION
* fix CVE-2018-20750 (the fix for CVE-2018-15127 was incomplete)
* fix CVE-2019-15681
* fix libdir in pkgconfig files
* fix regression in Tight/Raw decoding

Bug: https://bugs.gentoo.org/699036
Closes: https://bugs.gentoo.org/676942
Closes: https://bugs.gentoo.org/691848
Package-Manager: Portage-2.3.76, Repoman-2.3.16