### PR TITLE
sys-apps/netloc: incompatible with >=hwloc-2.0

### DIFF
--- a/sys-apps/netloc/netloc-0.5.ebuild
+++ b/sys-apps/netloc/netloc-0.5.ebuild
@@ -18,7 +18,7 @@ IUSE=""
 
 DEPEND="
 	dev-libs/jansson
-	sys-apps/hwloc"
+	<sys-apps/hwloc-2.0"
 RDEPEND="${DEPEND}"
 
 src_configure() {


### PR DESCRIPTION
see https://www.open-mpi.org/software/netloc/v0.5/

Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>