### PR TITLE
media-libs/mesa: depends on libdrm-2.4.100

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -71,7 +71,7 @@ REQUIRED_USE="
 	xvmc? ( X )
 "
 
-LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.99"
+LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.100"
 RDEPEND="
 	!app-eselect/eselect-mesa
 	>=dev-libs/expat-2.1.0-r3:=[${MULTILIB_USEDEP}]


### PR DESCRIPTION
Fixes `ERROR: Invalid version of dependency, need 'libdrm_amdgpu' ['>=2.4.100'] found '2.4.99'.`