### PR TITLE
Require nv-codec-headers >= 8.2.15.7 in mpv 0.30.0[cuda]

### DIFF
--- a/media-video/mpv/mpv-0.30.0.ebuild
+++ b/media-video/mpv/mpv-0.30.0.ebuild
@@ -123,7 +123,7 @@ COMMON_DEPEND="
 DEPEND="${COMMON_DEPEND}
 	${PYTHON_DEPS}
 	virtual/pkgconfig
-	cuda? ( >=media-libs/nv-codec-headers-8.1.24.1 )
+	cuda? ( >=media-libs/nv-codec-headers-8.2.15.7 )
 	doc? (  dev-python/docutils
 			dev-python/rst2pdf )
 	dvb? ( virtual/linuxtv-dvb-headers )


### PR DESCRIPTION
`=media-video/mpv-0.30.0[cuda]` configure fails with the following error message if nv-codec-headers version is < 8.2.15.7:

    Checking for CUDA Headers and dynamic loader: no
    ('ffnvcodec >= 8.2.15.7' not found)

[mpv-0.30.0_build.log](https://github.com/gentoo/gentoo/files/3800916/mpv-0.30.0_build.log)

This change pulls in `=media-libs/nv-codec-headers-9.0.18.1` for me, and mpv compiles and runs successfully.

Bug report: https://bugs.gentoo.org/699176

Signed-off-by: Nicholas Meyer <nickaristocrates@gmail.com>