### PR TITLE
app-crypt/{trousers,tpm2-tss,tpm2-abrmd}: Implement GLEP 81

### DIFF
--- a/acct-group/tss/metadata.xml
+++ b/acct-group/tss/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>salah.coronya@gmail.com</email>
+		<name>Salah Coronya</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/tss/tss-0.ebuild
+++ b/acct-group/tss/tss-0.ebuild
@@ -1,0 +1,9 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+DESCRIPTION="Trusted Software Stack for TPMs group"
+ACCT_GROUP_ID=59

--- a/acct-user/tss/metadata.xml
+++ b/acct-user/tss/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>salah.coronya@gmail.com</email>
+		<name>Salah Coronya</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/tss/tss-0.ebuild
+++ b/acct-user/tss/tss-0.ebuild
@@ -1,0 +1,12 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="Trusted Software Stack for TPMs user"
+ACCT_USER_ID=59
+ACCT_USER_GROUPS=( tss )
+
+acct-user_add_deps

--- a/app-crypt/tpm2-abrmd/tpm2-abrmd-2.1.1-r1.ebuild
+++ b/app-crypt/tpm2-abrmd/tpm2-abrmd-2.1.1-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools systemd
+
+DESCRIPTION="TPM2 Access Broker & Resource Manager"
+HOMEPAGE="https://github.com/tpm2-software/tpm2-abrmd"
+SRC_URI="https://github.com/tpm2-software/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="static-libs test"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="sys-apps/dbus:=
+	dev-libs/glib:=
+	app-crypt/tpm2-tss:="
+DEPEND="${RDEPEND}
+	acct-group/tss
+	acct-user/tss
+	test? ( dev-util/cmocka )"
+BDEPEND="virtual/pkgconfig
+	dev-util/gdbus-codegen"
+
+PATCHES=(
+	"${FILESDIR}/${P}-build.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable static-libs static) \
+		$(use_enable test unit) \
+		--disable-defaultflags \
+		--with-dbuspolicydir="${EPREFIX}/etc/dbus-1/system.d" \
+		--with-systemdpresetdir="$(systemd_get_systemunitdir)/../system-preset" \
+		--with-systemdpresetdisable \
+		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+
+	newinitd "${FILESDIR}"/${PN}.initd ${PN}
+	newconfd "${FILESDIR}"/${PN}.confd ${PN}
+}

--- a/app-crypt/tpm2-tss/tpm2-tss-2.2.3-r1.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-2.2.3-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit linux-info udev
+
+DESCRIPTION="TCG Trusted Platform Module 2.0 Software Stack"
+HOMEPAGE="https://github.com/tpm2-software/tpm2-tss"
+SRC_URI="https://github.com/tpm2-software/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0/0"	# sublot is libtss2-sys number
+KEYWORDS="~amd64"
+IUSE="doc +gcrypt openssl static-libs test"
+
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="
+	gcrypt? ( !openssl )
+	openssl? ( !gcrypt )
+	|| ( gcrypt openssl )"
+
+RDEPEND="gcrypt? ( dev-libs/libgcrypt:0= )
+	openssl? ( dev-libs/openssl:0= )"
+DEPEND="${RDEPEND}
+	acct-group/tss
+	acct-user/tss
+	test? ( dev-util/cmocka )"
+BDEPEND="virtual/pkgconfig
+	doc? ( app-doc/doxygen )"
+
+pkg_setup() {
+	local CONFIG_CHECK=" \
+		~TCG_TPM
+	"
+	linux-info_pkg_setup
+	kernel_is ge 4 12 0 || ewarn "At least kernel 4.12.0 is required"
+}
+
+src_configure() {
+	econf \
+		$(use_enable doc doxygen-doc) \
+		$(use_enable static-libs static) \
+		$(use_enable test unit) \
+		--disable-defaultflags \
+		--with-crypto="$(usex gcrypt gcrypt ossl)" \
+		--with-udevrulesdir="$(get_udevdir)/rules.d" \
+		--with-udevrulesprefix=60-
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}

--- a/app-crypt/trousers/trousers-0.3.14-r2.ebuild
+++ b/app-crypt/trousers/trousers-0.3.14-r2.ebuild
@@ -1,0 +1,102 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools linux-info readme.gentoo-r1 systemd udev
+
+DESCRIPTION="An open-source TCG Software Stack (TSS) v1.1 implementation"
+HOMEPAGE="http://trousers.sf.net"
+SRC_URI="mirror://sourceforge/trousers/${PN}/${P}.tar.gz"
+
+LICENSE="CPL-1.0 GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~m68k ~ppc ~ppc64 ~s390 ~sh ~x86"
+IUSE="doc libressl selinux" # gtk
+
+# gtk support presently does NOT compile.
+#	gtk? ( >=x11-libs/gtk+-2 )
+
+DEPEND="acct-group/tss
+	acct-user/tss
+	>=dev-libs/glib-2
+	!libressl? ( >=dev-libs/openssl-0.9.7:0= )
+	libressl? ( dev-libs/libressl:0= )"
+RDEPEND="${DEPEND}
+	selinux? ( sec-policy/selinux-tcsd )"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.3.13-nouseradd.patch"
+	"${FILESDIR}/${P}-libressl.patch"
+)
+
+DOCS="AUTHORS ChangeLog NICETOHAVES README TODO"
+
+DOC_CONTENTS="
+	If you have problems starting tcsd, please check permissions and
+	ownership on /dev/tpm* and ~tss/system.data
+"
+
+S="${WORKDIR}"
+
+pkg_setup() {
+	# Check for driver (not sure it can be an rdep, because ot depends on the
+	# version of virtual/linux-sources... Is that supported by portage?)
+	linux-info_pkg_setup
+	local tpm_kernel_version tpm_kernel_present tpm_module
+	kernel_is ge 2 6 12 && tpm_kernel_version="yes"
+	if linux_config_exists; then
+		linux_chkconfig_present TCG_TPM && tpm_kernel_present="yes"
+	else
+		ewarn "No kernel configuration could be found."
+	fi
+	has_version app-crypt/tpm-emulator && tpm_module="yes"
+	if [[ -n "${tpm_kernel_present}" ]]; then
+		einfo "Good, you seem to have in-kernel TPM support."
+	elif [[ -n "${tpm_module}" ]]; then
+		einfo "Good, you seem to have TPM support with the external module."
+		if [[ -n "${tpm_kernel_version}" ]]; then
+			elog
+			elog "Note that since you have a >=2.6.12 kernel, you could use"
+			elog "the in-kernel driver instead of (CONFIG_TCG_TPM)."
+		fi
+	elif [[ -n "${tpm_kernel_version}" ]]; then
+		eerror
+		eerror "To use this package, you will have to activate TPM support"
+		eerror "in your kernel configuration. That's at least CONFIG_TCG_TPM,"
+		eerror "plus probably a chip specific driver (like CONFIG_TCG_ATMEL)."
+		eerror
+	else
+		eerror
+		eerror "To use this package, you should install a TPM driver."
+		eerror "You can have the following options:"
+		eerror "  - install app-crypt/tpm-emulator"
+		eerror "  - switch to a >=2.6.12 kernel and compile the kernel module"
+		eerror
+	fi
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# econf --with-gui=$(usex gtk gtk openssl)
+	econf --with-gui=openssl
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+
+	keepdir /var/lib/tpm
+	use doc && dodoc doc/*
+	newinitd "${FILESDIR}"/tcsd.initd tcsd
+	newconfd "${FILESDIR}"/tcsd.confd tcsd
+	systemd_dounit "${FILESDIR}"/tcsd.service
+	udev_dorules "${FILESDIR}"/61-trousers.rules
+	fowners tss:tss /var/lib/tpm
+	readme.gentoo_create_doc
+}


### PR DESCRIPTION
All 3 packages create the 'tss' user, so this factors it out. (Not included is app-crypt/tpm-emulator, as its only EAPI 6, it hasn't had a release in at least 5 years, and only emulates TPM 1.2)