### PR TITLE
media-gfx/opencsg: fix build failure with GLES2

### DIFF
--- a/media-gfx/opencsg/files/opencsg-1.4.2-includepath.patch
+++ b/media-gfx/opencsg/files/opencsg-1.4.2-includepath.patch
@@ -3,8 +3,8 @@
 
 Gentoo-bug: 623840
 
---- a/src.pro
-+++ b/src.pro
+--- a/src/src.pro
++++ b/src/src.pro
 @@ -7,14 +7,14 @@
  }
  

--- a/media-gfx/opencsg/metadata.xml
+++ b/media-gfx/opencsg/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>waebbl@gmail.com</email>
+		<name>Bernd Waibel</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<description>Gentoo Proxy Maintainer Team</description>
+	</maintainer>
 	<longdescription>
 		OpenCSG is a library that does image-based CSG rendering using
 		OpenGL. OpenCSG is written in C++ and supports most modern

--- a/media-gfx/opencsg/opencsg-1.4.2-r1.ebuild
+++ b/media-gfx/opencsg/opencsg-1.4.2-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit qmake-utils
 
@@ -13,15 +13,29 @@ SRC_URI="http://www.opencsg.org/${MY_P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="doc"
 
-RDEPEND="media-libs/glew:0="
-DEPEND="${RDEPEND}
-	dev-qt/qtcore:5
-	media-libs/mesa[gles2]
+RDEPEND="
+	dev-libs/libbsd
+	media-libs/glew:0=
+	virtual/opengl
+	x11-libs/libX11
+	x11-libs/libXau
+	x11-libs/libXdmcp
+	x11-libs/libXext
+	x11-libs/libxcb:=
 "
 
-S="${WORKDIR}/${MY_P}/src"
+# qtgui is needed for opengles2 feature by
+# /usr/lib64/qt5/mkspecs/feature/unix/opengl.prf
+DEPEND="${RDEPEND}
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+"
+
+S="${WORKDIR}/${MY_P}"
+
+DOCS=( build.txt changelog.txt )
 
 PATCHES=(
 	"${FILESDIR}/${P}-includepath.patch"
@@ -31,13 +45,21 @@ src_prepare() {
 	default
 
 	# removes duplicated headers
-	rm -r ../glew || die "failed to remove bundled glew"
+	rm -r glew || die "failed to remove bundled glew"
 }
 
 src_configure() {
-	eqmake5 src.pro INSTALLDIR="/usr" LIBDIR="$(get_libdir)"
+	eqmake5 opencsg.pro INSTALLDIR="${EPREFIX}/usr" LIBDIR="$(get_libdir)"
+}
+
+src_compile() {
+	# rebuild Makefiles in subdirs
+	emake INSTALLDIR="${EPREFIX}/usr" LIBDIR="$(get_libdir)" qmake_all
+	emake sub-src
 }
 
 src_install() {
-	emake INSTALL_ROOT="${D}" install
+	emake -C src INSTALL_ROOT="${ED}" install
+	use doc && local HTML_DOCS=( doc/. )
+	einstalldocs
 }


### PR DESCRIPTION
Fix an issue where qmake isn't able to find opengles2 feature.
Add myself as proxy-maintainer.

Closes: https://bugs.gentoo.org/639314
Reported-by: Toralf Förster <toralf@gentoo.org>
Package-Manager: Portage-2.3.76, Repoman-2.3.17
Signed-off-by: Bernd Waibel <waebbl@gmail.com>