### PR TITLE
media-libs/{libnsgif,gegl}: keyworded for x86, bug #674736

### DIFF
--- a/media-libs/gegl/gegl-0.4.18.ebuild
+++ b/media-libs/gegl/gegl-0.4.18.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == *9999* ]]; then
 	SRC_URI=""
 else
 	SRC_URI="http://download.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.xz"
-	KEYWORDS="~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+	KEYWORDS="~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
 fi
 
 DESCRIPTION="A graph based image processing framework"

--- a/media-libs/libnsgif/libnsgif-0.2.1-r1.ebuild
+++ b/media-libs/libnsgif/libnsgif-0.2.1-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~m68k-mint"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~m68k-mint"
 IUSE=""
 
 DEPEND="


### PR DESCRIPTION
Tried to build `media-libs/{libnsgif-0.2.1-r1,gegl-0.4.18}` within x86 chroot
after addition of `~x86` to `KEYWORDS`. Both successfully built and installed.

The package `media-libs/gegl-0.4.18` depends on `media-libs/libnsgif-0.2.1-r1`.

The `media-libs/gegl-0.4.18` was built with
`USE="cairo ffmpeg introspection lcms lensfun openexr pdf raw sdl svg tiff
umfpack v4l vala webp -debug -libav -test"`

For this case gegl-0.4.18 successfuly tests:
```
Ok:                   98
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               7
Timeout:               0
```
Bug: https://bugs.gentoo.org/698696

See attached archive for build and tests logs:
[libnsgif_gegl_build_test.zip](https://github.com/gentoo/gentoo/files/3802495/libnsgif_gegl_build_test.zip)

This patches will allow to use `~x86` in `KEYWORDS` for `media-gfx/gimp-2.10.14` 
(pull request: https://github.com/gentoo/gentoo/pull/13523)