### PR TITLE
mail-client/mutt: update url

### DIFF
--- a/mail-client/mutt/mutt-1.10.1.ebuild
+++ b/mail-client/mutt/mutt-1.10.1.ebuild
@@ -277,6 +277,6 @@ pkg_postinst() {
 	if use gpgme ; then
 		ewarn "Note: in order for Mutt to actually use the gpgme backend"
 		ewarn "      you MUST include 'set crypt_use_gpgme=yes' in .muttrc"
-		ewarn "      https://dev.mutt.org/doc/manual.html#crypt-use-gpgme"
+		ewarn "      https://www.mutt.org/doc/manual/#crypt-use-gpgme"
 	fi
 }

--- a/mail-client/mutt/mutt-1.11.4.ebuild
+++ b/mail-client/mutt/mutt-1.11.4.ebuild
@@ -283,6 +283,6 @@ pkg_postinst() {
 	if use gpgme ; then
 		ewarn "Note: in order for Mutt to actually use the gpgme backend"
 		ewarn "      you MUST include 'set crypt_use_gpgme=yes' in .muttrc"
-		ewarn "      https://dev.mutt.org/doc/manual.html#crypt-use-gpgme"
+		ewarn "      https://www.mutt.org/doc/manual/#crypt-use-gpgme"
 	fi
 }

--- a/mail-client/mutt/mutt-1.12.1.ebuild
+++ b/mail-client/mutt/mutt-1.12.1.ebuild
@@ -284,6 +284,6 @@ pkg_postinst() {
 	if use gpgme ; then
 		ewarn "Note: in order for Mutt to actually use the gpgme backend"
 		ewarn "      you MUST include 'set crypt_use_gpgme=yes' in .muttrc"
-		ewarn "      https://dev.mutt.org/doc/manual.html#crypt-use-gpgme"
+		ewarn "      https://www.mutt.org/doc/manual/#crypt-use-gpgme"
 	fi
 }

--- a/mail-client/mutt/mutt-1.12.2-r1.ebuild
+++ b/mail-client/mutt/mutt-1.12.2-r1.ebuild
@@ -284,6 +284,6 @@ pkg_postinst() {
 	if use gpgme ; then
 		ewarn "Note: in order for Mutt to actually use the gpgme backend"
 		ewarn "      you MUST include 'set crypt_use_gpgme=yes' in .muttrc"
-		ewarn "      https://dev.mutt.org/doc/manual.html#crypt-use-gpgme"
+		ewarn "      https://www.mutt.org/doc/manual/#crypt-use-gpgme"
 	fi
 }

--- a/mail-client/mutt/mutt-1.12.2-r2.ebuild
+++ b/mail-client/mutt/mutt-1.12.2-r2.ebuild
@@ -267,6 +267,6 @@ pkg_postinst() {
 	if use gpgme ; then
 		ewarn "Note: in order for Mutt to actually use the gpgme backend"
 		ewarn "      you MUST include 'set crypt_use_gpgme=yes' in .muttrc"
-		ewarn "      https://dev.mutt.org/doc/manual.html#crypt-use-gpgme"
+		ewarn "      https://www.mutt.org/doc/manual/#crypt-use-gpgme"
 	fi
 }


### PR DESCRIPTION
The `dev.mutt.org` does not exist anymore. This change is mentioned at the end of [this email](https://marc.info/?l=mutt-dev&m=151734427401507&w=2). I didn't find any other info about it.