### PR TITLE
dev-lang/luajit: Introduce the gc64 use flag

### DIFF
--- a/dev-lang/luajit/luajit-2.1.0_beta3.ebuild
+++ b/dev-lang/luajit/luajit-2.1.0_beta3.ebuild
@@ -17,7 +17,7 @@ LICENSE="MIT"
 # this should probably be pkgmoved to 2.0 for sake of consistency.
 SLOT="2"
 KEYWORDS=""
-IUSE="lua52compat static-libs"
+IUSE="gc64 lua52compat static-libs"
 
 S="${WORKDIR}/${MY_P}"
 
@@ -39,7 +39,11 @@ _emake() {
 }
 
 src_compile() {
-	_emake XCFLAGS="$(usex lua52compat "-DLUAJIT_ENABLE_LUA52COMPAT" "")"
+	local xcflags=(
+		$(usex gc64 "-DLUAJIT_ENABLE_GC64" "")
+		$(usex lua52compat " -DLUAJIT_ENABLE_LUA52COMPAT" "")
+	)
+	_emake XCFLAGS="${xcflags[*]}"
 }
 
 src_install(){

--- a/dev-lang/luajit/metadata.xml
+++ b/dev-lang/luajit/metadata.xml
@@ -6,6 +6,9 @@
     <name>Rafael G. Martins</name>
   </maintainer>
   <use>
+    <flag name="gc64">
+      Enable GC64 mode allowing 64-bit GC objects
+    </flag>
     <flag name="lua52compat">
       Enable some upwards-compatible features
       from Lua 5.2 that are unlikely to break existing code.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/685010
Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>