### PR TITLE
qmail.eclass: hide qmail-pop3 behind a use flag

### DIFF
--- a/mail-mta/netqmail/metadata.xml
+++ b/mail-mta/netqmail/metadata.xml
@@ -14,6 +14,7 @@
 		<flag name="gencertdaily">Generate SSL certificates daily instead of
 			hourly</flag>
 		<flag name="highvolume">Prepare netqmail for high volume servers</flag>
+		<flag name="pop3">Include POP3 server</flag>
 	</use>
 	<upstream>
 		<remote-id type="sourceforge">qmail-spp</remote-id>

--- a/mail-mta/netqmail/netqmail-1.06-r11.ebuild
+++ b/mail-mta/netqmail/netqmail-1.06-r11.ebuild
@@ -42,7 +42,7 @@ SRC_URI="mirror://qmail/${P}.tar.gz
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~x86"
-IUSE="authcram gencertdaily highvolume libressl +pop3 qmail-spp ssl vanilla"
+IUSE="authcram gencertdaily highvolume libressl pop3 qmail-spp ssl vanilla"
 REQUIRED_USE="vanilla? ( !ssl !qmail-spp !highvolume )"
 RESTRICT="test"
 
@@ -70,7 +70,9 @@ RDEPEND="${DEPEND}
 	virtual/checkpassword
 	virtual/daemontools
 	authcram? ( >=net-mail/cmd5checkpw-0.30 )
-	ssl? ( sys-apps/ucspi-ssl )
+	ssl? (
+		pop3? ( sys-apps/ucspi-ssl )
+	)
 	!mail-mta/courier
 	!mail-mta/esmtp
 	!mail-mta/exim

--- a/mail-mta/netqmail/netqmail-1.06-r4.ebuild
+++ b/mail-mta/netqmail/netqmail-1.06-r4.ebuild
@@ -37,7 +37,7 @@ SRC_URI="mirror://qmail/${P}.tar.gz
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="alpha amd64 arm hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86"
-IUSE="authcram gencertdaily highvolume libressl qmail-spp ssl vanilla"
+IUSE="authcram gencertdaily highvolume libressl +pop3 qmail-spp ssl vanilla"
 REQUIRED_USE='vanilla? ( !ssl !qmail-spp !highvolume )'
 RESTRICT="test"
 


### PR DESCRIPTION
Other solutions offer much more features and better security, so do not install this by default. Keep it for the moment for those who explicitely want it.

See: https://archives.gentoo.org/gentoo-dev/message/7c6e06b10d40d8f7f9a2564d8c41e319