### PR TITLE
net-irc/atheme-services: Fix missing serno.h

### DIFF
--- a/net-irc/atheme-services/atheme-services-7.2.10_p2.ebuild
+++ b/net-irc/atheme-services/atheme-services-7.2.10_p2.ebuild
@@ -25,6 +25,7 @@ RDEPEND=">=dev-libs/libmowgli-2.1.0:2
 	pcre? ( dev-libs/libpcre )
 	ssl? ( dev-libs/openssl:0= )"
 DEPEND="${RDEPEND}
+	dev-vcs/git
 	virtual/pkgconfig"
 
 PATCHES=("${FILESDIR}"/${P}-configure-logdir.patch)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=665802
Signed-off-by: Wade Cline <wadecline@hotmail.com>