### PR TITLE
net-im/bitlbee: Install pkgconfig to /usr/$(get_libdir)/pkgconfig

### DIFF
--- a/net-im/bitlbee/bitlbee-3.5.1.ebuild
+++ b/net-im/bitlbee/bitlbee-3.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -114,6 +114,7 @@ src_configure() {
 		--datadir=/usr/share/bitlbee \
 		--etcdir=/etc/bitlbee \
 		--plugindir=/usr/$(get_libdir)/bitlbee \
+		--pcdir=/usr/$(get_libdir)/pkgconfig \
 		--systemdsystemunitdir=$(systemd_get_systemunitdir) \
 		--doc=1 \
 		--strip=0 \

--- a/net-im/bitlbee/bitlbee-3.6.ebuild
+++ b/net-im/bitlbee/bitlbee-3.6.ebuild
@@ -109,6 +109,7 @@ src_configure() {
 		--datadir=/usr/share/bitlbee \
 		--etcdir=/etc/bitlbee \
 		--plugindir=/usr/$(get_libdir)/bitlbee \
+		--pcdir=/usr/$(get_libdir)/pkgconfig \
 		--systemdsystemunitdir=$(systemd_get_systemunitdir) \
 		--doc=1 \
 		--strip=0 \

--- a/net-im/bitlbee/bitlbee-9999.ebuild
+++ b/net-im/bitlbee/bitlbee-9999.ebuild
@@ -109,6 +109,7 @@ src_configure() {
 		--datadir=/usr/share/bitlbee \
 		--etcdir=/etc/bitlbee \
 		--plugindir=/usr/$(get_libdir)/bitlbee \
+		--pcdir=/usr/$(get_libdir)/pkgconfig \
 		--systemdsystemunitdir=$(systemd_get_systemunitdir) \
 		--doc=1 \
 		--strip=0 \


### PR DESCRIPTION
This commit indirectly solves issues [#678128](https://bugs.gentoo.org/678128) and [#678510](https://bugs.gentoo.org/678510) because `pkg-config` searches `bitlbee.pc` in `/usr/lib64/pkgconfig` by default for `ARCH=amd64`.