### PR TITLE
net-analyzer/netdata: Use dbengine by default

### DIFF
--- a/net-analyzer/netdata/netdata-1.18.1-r1.ebuild
+++ b/net-analyzer/netdata/netdata-1.18.1-r1.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/netdata/netdata https://my-netdata.io/"
 
 LICENSE="GPL-3+ MIT BSD"
 SLOT="0"
-IUSE="caps +compression cpu_flags_x86_sse2 cups dbengine ipmi mysql nfacct nodejs postgres +python tor xen"
+IUSE="caps +compression cpu_flags_x86_sse2 cups +dbengine ipmi mysql nfacct nodejs postgres +python tor xen"
 REQUIRED_USE="
 	mysql? ( python )
 	python? ( ${PYTHON_REQUIRED_USE} )

--- a/net-analyzer/netdata/netdata-1.18.1.ebuild
+++ b/net-analyzer/netdata/netdata-1.18.1.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/netdata/netdata https://my-netdata.io/"
 
 LICENSE="GPL-3+ MIT BSD"
 SLOT="0"
-IUSE="caps +compression cpu_flags_x86_sse2 cups dbengine ipmi mysql nfacct nodejs postgres +python tor xen"
+IUSE="caps +compression cpu_flags_x86_sse2 cups +dbengine ipmi mysql nfacct nodejs postgres +python tor xen"
 REQUIRED_USE="
 	mysql? ( python )
 	python? ( ${PYTHON_REQUIRED_USE} )

--- a/net-analyzer/netdata/netdata-9999.ebuild
+++ b/net-analyzer/netdata/netdata-9999.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/netdata/netdata https://my-netdata.io/"
 
 LICENSE="GPL-3+ MIT BSD"
 SLOT="0"
-IUSE="caps +compression cpu_flags_x86_sse2 cups dbengine ipmi mysql nfacct nodejs postgres +python tor xen"
+IUSE="caps +compression cpu_flags_x86_sse2 cups +dbengine ipmi mysql nfacct nodejs postgres +python tor xen"
 REQUIRED_USE="
 	mysql? ( python )
 	python? ( ${PYTHON_REQUIRED_USE} )


### PR DESCRIPTION
Netdata uses database engine as a default method of storing metrics since v1.18.0, see [1].

[1] https://github.com/netdata/netdata/releases/tag/v1.18.0