### PR TITLE
app-backup/restic: add missing licenses

### DIFF
--- a/app-backup/restic/restic-0.9.4.ebuild
+++ b/app-backup/restic/restic-0.9.4.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://restic.github.io/"
 SRC_URI="https://github.com/restic/restic/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 EGO_PN="github.com/restic/restic"
 
-LICENSE="BSD-2"
+LICENSE="Apache-2.0 BSD BSD-2 LGPL-3-with-linking-exception MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE="test"

--- a/app-backup/restic/restic-0.9.5.ebuild
+++ b/app-backup/restic/restic-0.9.5.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://restic.github.io/"
 SRC_URI="https://github.com/restic/restic/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 EGO_PN="github.com/restic/restic"
 
-LICENSE="BSD-2"
+LICENSE="Apache-2.0 BSD BSD-2 LGPL-3-with-linking-exception MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 IUSE=""


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694724
Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: David Roman <davidroman96@gmail.com>