### PR TITLE
mail-client/neomutt: fix doc build

### DIFF
--- a/mail-client/neomutt/neomutt-20191102.ebuild
+++ b/mail-client/neomutt/neomutt-20191102.ebuild
@@ -67,8 +67,7 @@ RDEPEND="${CDEPEND}
 
 src_configure() {
 	local myconf=(
-		"$(use_enable doc)"
-		"$(usex doc --full-doc)"
+		"$(usex doc --full-doc --disable-doc)"
 		"$(use_enable nls)"
 		"$(use_enable notmuch)"
 

--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} =~ 99999999$ ]]; then
 	EGIT_REPO_URI="https://github.com/neomutt/neomutt.git"
 	EGIT_CHECKOUT_DIR="${WORKDIR}/neomutt-${P}"
 else
-	SRC_URI="https://github.com/${PN}/${PN}/archive/${P}.tar.gz"
+	SRC_URI="https://github.com/${PN}/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
 
@@ -69,8 +69,7 @@ S="${WORKDIR}/${PN}-${P}"
 
 src_configure() {
 	local myconf=(
-		"$(use_enable doc)"
-		"$(usex doc --full-doc)"
+		"$(usex doc --full-doc --disable-doc)"
 		"$(use_enable nls)"
 		"$(use_enable notmuch)"
 


### PR DESCRIPTION
Also sync live ebuild with latest release.

Bug: https://bugs.gentoo.org/699158
Bug: https://bugs.gentoo.org/699166
Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>