### PR TITLE
www-client/surf: Introduce tabbed use flag and bug fix

### DIFF
--- a/www-client/surf/files/surf-2.0-gentoo.patch
+++ b/www-client/surf/files/surf-2.0-gentoo.patch
@@ -29,8 +29,8 @@
  CPPFLAGS = -DVERSION=\"${VERSION}\" -DWEBEXTDIR=\"${LIBPREFIX}\" -D_DEFAULT_SOURCE
 -CFLAGS = -std=c99 -pedantic -Wall -Os ${INCS} ${CPPFLAGS}
 -LDFLAGS = -s ${LIBS}
-+CFLAGS = -std=c99 -pedantic -Wall ${INCS} ${CPPFLAGS}
-+LDFLAGS = ${LIBS}
++CFLAGS += -std=c99 -pedantic -Wall ${INCS} ${CPPFLAGS}
++LDFLAGS += ${LIBS}
  
  # Solaris
  #CFLAGS = -fast ${INCS} -DVERSION=\"${VERSION}\"

--- a/www-client/surf/metadata.xml
+++ b/www-client/surf/metadata.xml
@@ -4,5 +4,6 @@
 <!-- maintainer-needed -->
 <use>
 <flag name="savedconfig">Without a saved config.h, this package depends on <pkg>net-misc/curl</pkg> and <pkg>x11-terms/st</pkg> for a default download mechanism</flag>
+<flag name="tabbed">Install surf-open.sh script for running surf in <pkg>x11-misc/tabbed</pkg></flag>
 </use>
 </pkgmetadata>

--- a/www-client/surf/surf-9999.ebuild
+++ b/www-client/surf/surf-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,6 +12,7 @@ EGIT_BRANCH="surf-webkit2"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS=""
+IUSE="tabbed"
 
 COMMON_DEPEND="
 	app-crypt/gcr[gtk]
@@ -33,6 +34,7 @@ RDEPEND="
 		x11-apps/xprop
 		x11-terms/st
 	)
+	tabbed? ( x11-misc/tabbed )
 "
 PATCHES=(
 	"${FILESDIR}"/${PN}-9999-gentoo.patch
@@ -61,6 +63,10 @@ src_prepare() {
 
 src_install() {
 	default
+
+	if use tabbed; then
+		dobin surf-open.sh
+	fi
 
 	save_config config.h
 }


### PR DESCRIPTION
Surf is shipped with `surf-open.sh` script for running surf in [`tabbed`](http://tools.suckless.org/tabbed). The newly introduced use flag installs this script and appends `x11-misc/tabbed` to a runtime dependency list.