### PR TITLE
media-gfx/iscan: Removed ${ED} for PMS-compliant package managers.

### DIFF
--- a/media-gfx/iscan/iscan-2.30.4.2.ebuild
+++ b/media-gfx/iscan/iscan-2.30.4.2.ebuild
@@ -126,7 +126,7 @@ src_install() {
 		done
 		if [[ "/plug-ins" != "${gimpplugindir}" ]]; then
 			dodir ${gimpplugindir}
-			dosym "${ED%/}"/usr/bin/iscan "${gimpplugindir}"/iscan
+			dosym $(realpath -s --relative-to="${gimpplugindir}" "${EPREFIX}/usr/bin/iscan" || die) "${gimpplugindir}"/iscan
 		else
 			ewarn "No idea where to find the gimp plugin directory"
 		fi


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/699498
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Matthew Schultz <mattsch@gmail.com>