### PR TITLE
app-emulation/spice-vdagent: Use checkpath instead of mkdir

### DIFF
--- a/app-emulation/spice-vdagent/files/spice-vdagent.initd-3
+++ b/app-emulation/spice-vdagent/files/spice-vdagent.initd-3
@@ -37,7 +37,7 @@ start() {
     fi
 
     # recreate the directory since /var/run may reside on a ramdisk
-    mkdir -p /var/run/spice-vdagentd
+    checkpath -D /var/run/spice-vdagentd
 
     # cleanup stalled socket
     rm -f /var/run/spice-vdagentd/spice-vdagent-sock

--- a/app-emulation/spice-vdagent/files/spice-vdagent.initd-4
+++ b/app-emulation/spice-vdagent/files/spice-vdagent.initd-4
@@ -37,7 +37,7 @@ start() {
     fi
 
     # recreate the directory since /var/run may reside on a ramdisk
-    mkdir -p /var/run/spice-vdagentd
+    checkpath -D /var/run/spice-vdagentd
 
     # cleanup stalled socket
     rm -f /var/run/spice-vdagentd/spice-vdagent-sock


### PR DESCRIPTION
checkpath is more openrc-like and integrates better with SELinux