### PR TITLE
net-analyzer/tcpdump: Use correct openssl for cross-compilation

### DIFF
--- a/net-analyzer/tcpdump/tcpdump-4.9.3.ebuild
+++ b/net-analyzer/tcpdump/tcpdump-4.9.3.ebuild
@@ -54,7 +54,7 @@ src_configure() {
 		$(use_enable samba smb) \
 		$(use_with drop-root chroot '') \
 		$(use_with smi) \
-		$(use_with ssl crypto "${EPREFIX}/usr") \
+		$(use_with ssl crypto "${ESYSROOT}/usr") \
 		$(usex drop-root "--with-user=tcpdump" "")
 }
 


### PR DESCRIPTION
Use ${ESYSROOT} to reference the openssl installation location such that
the proper path gets used when cross-compiling.

Bug: https://bugs.gentoo.org/699802

Signed-off-by: Mattias Nissler <mnissler@chromium.org>