### PR TITLE
sys-apps/pcsc-tools: fix bug 698268, improve ebuild

### DIFF
--- a/sys-apps/pcsc-tools/pcsc-tools-1.5.3.ebuild
+++ b/sys-apps/pcsc-tools/pcsc-tools-1.5.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit eutils fdo-mime multilib toolchain-funcs
+inherit desktop toolchain-funcs xdg-utils
 
 DESCRIPTION="PC/SC Architecture smartcard tools"
 HOMEPAGE="http://ludovic.rousseau.free.fr/softwares/pcsc-tools/"
@@ -23,11 +23,6 @@ BDEPEND="virtual/pkgconfig"
 DOCS=(
 	README Changelog
 )
-
-src_prepare() {
-	default
-	sed -i -e 's:-Wall -O2:$(CFLAGS):g' Makefile
-}
 
 src_compile() {
 	# explicitly only build the pcsc_scan application, or the man
@@ -59,9 +54,9 @@ src_install() {
 }
 
 pkg_postinst() {
-	use gtk && fdo-mime_desktop_database_update
+	use gtk && xdg_desktop_database_update
 }
 
 pkg_postrm() {
-	fdo-mime_desktop_database_update
+	xdg_desktop_database_update
 }


### PR DESCRIPTION
Hi,

This ebuild missed to inherit the ```desktop``` eclass (bug 698268) and i also removed the ```eutils``` and ```multilib``` eclass (not used) and updated the ebuild to use ```xdg-utils``` instead of ```fdo-mime```.

The ebuild also used ```sed``` for the Makefile. There were 2 problems with that.
1. the command missed a ```|| die```
2. because of the missing die we also didn't noticed that the command actually failed. (the Makefile is there after src_configure)
However, i've removed ```src_prepare``` completely since the generated Makefile already uses the local system ```CFLAGS```. I guess this was fixed upstream sometime ago?

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>
Closes: https://bugs.gentoo.org/698268