### PR TITLE
net-vpn/networkmanager-wireguard: force gtk for glib

### DIFF
--- a/net-vpn/networkmanager-wireguard/networkmanager-wireguard-0_pre20181128.ebuild
+++ b/net-vpn/networkmanager-wireguard/networkmanager-wireguard-0_pre20181128.ebuild
@@ -16,6 +16,7 @@ LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="+glib +gtk +nls"
+REQUIRED_USE="glib? ( gtk )"
 
 RDEPEND="
 	net-misc/networkmanager

--- a/net-vpn/networkmanager-wireguard/networkmanager-wireguard-9999.ebuild
+++ b/net-vpn/networkmanager-wireguard/networkmanager-wireguard-9999.ebuild
@@ -13,6 +13,7 @@ EGIT_REPO_URI="https://github.com/max-moser/network-manager-wireguard"
 LICENSE="GPL-2+"
 SLOT="0"
 IUSE="+glib +gtk +nls"
+REQUIRED_USE="glib? ( gtk )"
 
 RDEPEND="
 	net-misc/networkmanager


### PR DESCRIPTION
This package needs enabled 'gtk', if 'glib' is enabled.

Closes: https://bugs.gentoo.org/699656
Package-Manager: Portage-2.3.78, Repoman-2.3.17
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>