### PR TITLE
net-analyzer/nagios-core: fix cgi-bin path for apache

### DIFF
--- a/net-analyzer/nagios-core/files/99_nagios4-r1.conf
+++ b/net-analyzer/nagios-core/files/99_nagios4-r1.conf
@@ -1,6 +1,6 @@
 <IfDefine NAGIOS>
 
-  ScriptAlias /nagios/cgi-bin/ @CGIBINDIR@
+  ScriptAlias /nagios/cgi-bin @CGIBINDIR@
   <Directory "@CGIBINDIR@">
     AllowOverride AuthConfig
     Options ExecCGI

--- a/net-analyzer/nagios-core/nagios-core-4.4.5-r5.ebuild
+++ b/net-analyzer/nagios-core/nagios-core-4.4.5-r5.ebuild
@@ -105,8 +105,8 @@ src_configure() {
 	# The paths in the web server configuration files need to match
 	# those passed to econf above.
 	cp "${FILESDIR}/99_nagios4-r1.conf" \
-	   "${FILESDIR}/lighttpd_nagios4-r1.conf" \
-	   "${T}/" || die "failed to create copies of web server conf files"
+		"${FILESDIR}/lighttpd_nagios4-r1.conf" \
+		"${T}/" || die "failed to create copies of web server conf files"
 
 	sed -e "s|@CGIBINDIR@|${EPREFIX}/usr/$(get_libdir)/nagios/cgi-bin|g" \
 		-e "s|@WEBDIR@|${EPREFIX}/usr/share/nagios/htdocs|" \
@@ -189,7 +189,7 @@ src_install() {
 		if use apache2 ; then
 			# Install the Nagios configuration file for Apache.
 			insinto "/etc/apache2/modules.d"
-			doins "${T}/99_nagios4-r1.conf"
+			newins "${T}/99_nagios4-r1.conf" "99_nagios4.conf"
 		elif use lighttpd ; then
 			# Install the Nagios configuration file for Lighttpd.
 			insinto /etc/lighttpd


### PR DESCRIPTION
1) 
On 17.1 amd64:
````
[Thu Nov 14 07:19:26.608124 2019] [cgi:error] [pid 27160] AH02811: script not found or unable to stat: /usr/lib64/nagios/cgi-binstatus.cgi, referer: https://nagios/nagios/cgi-bin/...
````

Before it was: ScriptAlias /nagios/cgi-bin/ /usr/lib/nagios/cgi-bin/
Now it's: ScriptAlias /nagios/cgi-bin/ /usr/lib64/nagios/cgi-bin

So there is a mismatch and it fails.

2)
keep the apache config in the old path: /etc/apache2/modules.d/99_nagios4.conf