### PR TITLE
sys-apps/kmod: rename 'ssl' USE flag to 'pkcs7'

### DIFF
--- a/sys-apps/kmod/kmod-26-r2.ebuild
+++ b/sys-apps/kmod/kmod-26-r2.ebuild
@@ -21,7 +21,7 @@ HOMEPAGE="https://git.kernel.org/?p=utils/kernel/kmod/kmod.git"
 
 LICENSE="LGPL-2"
 SLOT="0"
-IUSE="debug doc libressl lzma python ssl static-libs +tools zlib"
+IUSE="debug doc libressl lzma pkcs7 python static-libs +tools zlib"
 
 # Upstream does not support running the test suite with custom configure flags.
 # I was also told that the test suite is intended for kmod developers.
@@ -36,7 +36,7 @@ RDEPEND="!sys-apps/module-init-tools
 	!<sys-apps/systemd-216-r3
 	lzma? ( >=app-arch/xz-utils-5.0.4-r1 )
 	python? ( ${PYTHON_DEPS} )
-	ssl? (
+	pkcs7? (
 		!libressl? ( >=dev-libs/openssl-1.1.0:0= )
 		libressl? ( dev-libs/libressl:0= )
 	)
@@ -93,7 +93,7 @@ src_configure() {
 		$(use_enable static-libs static)
 		$(use_enable tools)
 		$(use_with lzma xz)
-		$(use_with ssl openssl)
+		$(use_with pkcs7 openssl)
 		$(use_with zlib)
 	)
 

--- a/sys-apps/kmod/kmod-9999.ebuild
+++ b/sys-apps/kmod/kmod-9999.ebuild
@@ -21,7 +21,7 @@ HOMEPAGE="https://git.kernel.org/?p=utils/kernel/kmod/kmod.git"
 
 LICENSE="LGPL-2"
 SLOT="0"
-IUSE="debug doc lzma python ssl static-libs +tools zlib"
+IUSE="debug doc lzma pkcs7 python static-libs +tools zlib"
 
 # Upstream does not support running the test suite with custom configure flags.
 # I was also told that the test suite is intended for kmod developers.
@@ -36,7 +36,7 @@ RDEPEND="!sys-apps/module-init-tools
 	!<sys-apps/systemd-216-r3
 	lzma? ( >=app-arch/xz-utils-5.0.4-r1 )
 	python? ( ${PYTHON_DEPS} )
-	ssl? ( >=dev-libs/openssl-1.1.0:0= )
+	pkcs7? ( >=dev-libs/openssl-1.1.0:0= )
 	zlib? ( >=sys-libs/zlib-1.2.6 )" #427130
 DEPEND="${RDEPEND}
 	doc? ( dev-util/gtk-doc )
@@ -86,7 +86,7 @@ src_configure() {
 		$(use_enable static-libs static)
 		$(use_enable tools)
 		$(use_with lzma xz)
-		$(use_with ssl openssl)
+		$(use_with pkcs7 openssl)
 		$(use_with zlib)
 	)
 

--- a/sys-apps/kmod/metadata.xml
+++ b/sys-apps/kmod/metadata.xml
@@ -10,6 +10,7 @@
 </maintainer>
 <use>
 	<flag name="lzma">Enable support for XZ compressed modules</flag>
+	<flag name="pkcs7">Enable PKCS#7 signature parsing for modinfo.</flag>
 	<flag name="tools">Install module loading/unloading tools.</flag>
 	<flag name="zlib">Enable support for gzipped modules</flag>
 </use>


### PR DESCRIPTION
This better expresses the effect of the --with-openssl configure option.
See NEWS for more details.

This also has the nice side-effect of disabling the dependency on
opensssl by default, which makes kmod work without /usr mounted in early
boot.

Closes: https://bugs.gentoo.org/700128
Package-Manager: Portage-2.3.79_p3, Repoman-2.3.18_p2
Signed-off-by: Mike Gilbert <floppym@gentoo.org>