### PR TITLE
sci-electronics/kicad: Enforce non-deprecated media-libs/glm version

### DIFF
--- a/sci-electronics/kicad/kicad-5.1.4.ebuild
+++ b/sci-electronics/kicad/kicad-5.1.4.ebuild
@@ -31,7 +31,7 @@ COMMON_DEPEND="x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
 	>=dev-libs/boost-1.61:=[context,nls,threads,python?,${PYTHON_USEDEP}]
 	github? ( net-misc/curl:=[ssl] )
 	media-libs/glew:0=
-	media-libs/glm
+	>=media-libs/glm-0.9.9.1
 	media-libs/freeglut
 	media-libs/mesa[X(+)]
 	ngspice? (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/699350
Package-Manager: Portage-2.3.79, Repoman-2.3.18
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>