### PR TITLE
dev-embedded/openocd: depend on >=libjaylink-0.2

### DIFF
--- a/dev-embedded/openocd/openocd-9999.ebuild
+++ b/dev-embedded/openocd/openocd-9999.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	acct-group/plugdev
 	>=dev-lang/jimtcl-0.76:0=
 	cmsis-dap? ( dev-libs/hidapi )
-	jlink? ( dev-embedded/libjaylink )
+	jlink? ( >=dev-embedded/libjaylink-0.2 )
 	usb? (
 		virtual/libusb:0
 		virtual/libusb:1


### PR DESCRIPTION
The live ebuild fails with:

  checking for libjaylink >= 0.2... no
  configure: error: libjaylink-0.2 is required for the SEGGER J-Link Programmer

I see no release for libjaylink-0.2 but libjaylink-9999 works

Package-Manager: Portage-2.3.79, Repoman-2.3.18
Signed-off-by: Göktürk Yüksek <gokturk@gentoo.org>