### PR TITLE
games-action/minetest: Add patch to find newer JsonCpp

### DIFF
--- a/games-action/minetest/files/5.1.0-FindJson.patch
+++ b/games-action/minetest/files/5.1.0-FindJson.patch
@@ -1,0 +1,31 @@
+From 706b6aad06a112f55105f08b6acd130b276a06ca Mon Sep 17 00:00:00 2001
+From: William Breathitt Gray <vilhelm.gray@gmail.com>
+Date: Sat, 16 Nov 2019 13:14:24 -0500
+Subject: [PATCH] Fix find_path for newer jsoncpp installations
+
+The upstream JsonCpp project has renamed the `json/features.h` file to
+`json/json_features.h`. This patch fixes the JsonCpp installation search
+by looking for `json/allocator.h` which has not been renamed on newer
+versions of JsonCpp.
+
+Fixes: https://github.com/minetest/minetest/issues/9119
+---
+ cmake/Modules/FindJson.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/Modules/FindJson.cmake b/cmake/Modules/FindJson.cmake
+index 26339a29..53ddf459 100644
+--- a/cmake/Modules/FindJson.cmake
++++ b/cmake/Modules/FindJson.cmake
+@@ -8,7 +8,7 @@ option(ENABLE_SYSTEM_JSONCPP "Enable using a system-wide JSONCPP.  May cause seg
+ 
+ if(ENABLE_SYSTEM_JSONCPP)
+ 	find_library(JSON_LIBRARY NAMES jsoncpp)
+-	find_path(JSON_INCLUDE_DIR json/features.h PATH_SUFFIXES jsoncpp)
++	find_path(JSON_INCLUDE_DIR json/allocator.h PATH_SUFFIXES jsoncpp)
+ 
+ 	include(FindPackageHandleStandardArgs)
+ 	find_package_handle_standard_args(JSONCPP DEFAULT_MSG JSON_LIBRARY JSON_INCLUDE_DIR)
+-- 
+2.24.0
+

--- a/games-action/minetest/files/minetestserver.initd
+++ b/games-action/minetest/files/minetestserver.initd
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 description="Minetest dedicated server"

--- a/games-action/minetest/minetest-5.1.0-r1.ebuild
+++ b/games-action/minetest/minetest-5.1.0-r1.ebuild
@@ -1,0 +1,140 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils xdg
+
+DESCRIPTION="A free open-source voxel game engine with easy modding and game creation"
+HOMEPAGE="https://www.minetest.net"
+SRC_URI="https://github.com/${PN}/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1+ CC-BY-SA-3.0 OFL-1.1 Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+client +curl doc +leveldb ncurses nls postgres redis +server +sound spatial +truetype"
+REQUIRED_USE="|| ( client server )"
+
+RDEPEND="
+	dev-db/sqlite:3
+	dev-games/irrlicht
+	dev-lang/luajit:2
+	dev-libs/gmp:0=
+	dev-libs/jsoncpp:=
+	sys-libs/zlib
+	client? (
+		app-arch/bzip2
+		media-libs/libpng:0=
+		virtual/jpeg:0
+		virtual/opengl
+		x11-libs/libX11
+		x11-libs/libXxf86vm
+		sound? (
+			media-libs/libogg
+			media-libs/libvorbis
+			media-libs/openal
+		)
+		truetype? ( media-libs/freetype:2 )
+	)
+	curl? ( net-misc/curl )
+	leveldb? ( dev-libs/leveldb:= )
+	ncurses? ( sys-libs/ncurses:0= )
+	nls? ( virtual/libintl )
+	postgres? ( >=dev-db/postgresql-9.5:= )
+	redis? ( dev-libs/hiredis:= )
+	server? (
+		acct-group/minetest
+		acct-user/minetest
+	)
+	spatial? ( sci-libs/libspatialindex:= )"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	doc? (
+		app-doc/doxygen
+		media-gfx/graphviz
+	)
+	nls? ( sys-devel/gettext )"
+
+PATCHES="${FILESDIR}/${PV}-FindJson.patch"
+
+src_prepare() {
+	cmake-utils_src_prepare
+	# set paths
+	sed \
+		-e "s#@BINDIR@#${EPREFIX}/usr/bin#g" \
+		-e "s#@GROUP@#${PN}#g" \
+		"${FILESDIR}"/minetestserver.confd > "${T}"/minetestserver.confd || die
+
+	# remove bundled libraries
+	rm -rf lib || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_CLIENT=$(usex client)
+		-DBUILD_SERVER=$(usex server)
+		-DCUSTOM_BINDIR="${EPREFIX}/usr/bin"
+		-DCUSTOM_DOCDIR="${EPREFIX}/usr/share/doc/${PF}"
+		-DCUSTOM_EXAMPLE_CONF_DIR="${EPREFIX}/usr/share/doc/${PF}"
+		-DCUSTOM_LOCALEDIR="${EPREFIX}/usr/share/${PN}/locale"
+		-DCUSTOM_SHAREDIR="${EPREFIX}/usr/share/${PN}"
+		-DENABLE_CURL=$(usex curl)
+		-DENABLE_CURSES=$(usex ncurses)
+		-DENABLE_FREETYPE=$(usex truetype)
+		-DENABLE_GETTEXT=$(usex nls)
+		-DENABLE_GLES=0
+		-DENABLE_LEVELDB=$(usex leveldb)
+		-DENABLE_LUAJIT=1
+		-DENABLE_POSTGRESQL=$(usex postgres)
+		-DENABLE_REDIS=$(usex redis)
+		-DENABLE_SPATIAL=$(usex spatial)
+		-DENABLE_SOUND=$(usex sound)
+		-DENABLE_SYSTEM_GMP=1
+		-DENABLE_SYSTEM_JSONCPP=1
+		-DRUN_IN_PLACE=0
+	)
+
+	use server && mycmakeargs+=(
+		-DIRRLICHT_INCLUDE_DIR="${EPREFIX}/usr/include/irrlicht"
+	)
+
+	cmake-utils_src_configure
+}
+
+src_compile() {
+	cmake-utils_src_compile
+
+	if use doc ; then
+		cmake-utils_src_compile doc
+		HTML_DOCS=( "${BUILD_DIR}"/doc/html/. )
+	fi
+}
+
+src_install() {
+	cmake-utils_src_install
+
+	if use server ; then
+		keepdir /var/log/minetest
+		fowners minetest:minetest /var/log/minetest
+
+		newconfd "${T}"/minetestserver.confd minetest-server
+		newinitd "${FILESDIR}"/minetestserver.initd minetest-server
+	fi
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	if use server ; then
+		elog
+		elog "Configure your server via /etc/conf.d/minetest-server"
+		elog
+	fi
+
+	elog
+	elog "The version 5.x series is not compatible to the version 0.4 series."
+	elog "This applies to clients and servers, other content such as mods,"
+	elog "texture packs and worlds is unaffected and backwards-compatible"
+	elog "as usual."
+	elog
+}


### PR DESCRIPTION
The luajit flag is also removed since we should always build using the
system-provided LuaJIT rather than the bundled Lua library.

Closes: https://bugs.gentoo.org/700220
Package-Manager: Portage-2.3.79, Repoman-2.3.18
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>