### PR TITLE
dev-lisp/asdf: remove duplicate SLOT variable

### DIFF
--- a/dev-lisp/asdf/asdf-3.1.5.ebuild
+++ b/dev-lisp/asdf/asdf-3.1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -10,11 +10,9 @@ HOMEPAGE="http://common-lisp.net/project/asdf/"
 SRC_URI="http://common-lisp.net/project/${PN}/archives/${P}.tar.gz"
 
 LICENSE="MIT"
-SLOT="0"
+SLOT="0/${PVR}"
 KEYWORDS="alpha amd64 ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="doc"
-
-SLOT="0/${PVR}"
 
 DEPEND="!dev-lisp/cl-${PN}
 		!<dev-lisp/asdf-2.33-r3

--- a/dev-lisp/asdf/asdf-3.3.1.ebuild
+++ b/dev-lisp/asdf/asdf-3.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,11 +10,9 @@ HOMEPAGE="http://common-lisp.net/project/asdf/"
 SRC_URI="http://common-lisp.net/project/${PN}/archives/${P}.tar.gz"
 
 LICENSE="MIT"
-SLOT="0"
+SLOT="0/${PVR}"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="doc"
-
-SLOT="0/${PVR}"
 
 DEPEND="!dev-lisp/cl-${PN}
 		!<dev-lisp/asdf-2.33-r3

--- a/dev-lisp/asdf/asdf-3.3.2-r1.ebuild
+++ b/dev-lisp/asdf/asdf-3.3.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,11 +10,9 @@ HOMEPAGE="http://common-lisp.net/project/asdf/"
 SRC_URI="http://common-lisp.net/project/${PN}/archives/${P}.tar.gz"
 
 LICENSE="MIT"
-SLOT="0"
+SLOT="0/${PVR}"
 KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="doc test"
-
-SLOT="0/${PVR}"
 
 DEPEND="!dev-lisp/cl-${PN}
 		!<dev-lisp/asdf-2.33-r3

--- a/dev-lisp/asdf/asdf-3.3.2.ebuild
+++ b/dev-lisp/asdf/asdf-3.3.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,11 +10,9 @@ HOMEPAGE="http://common-lisp.net/project/asdf/"
 SRC_URI="http://common-lisp.net/project/${PN}/archives/${P}.tar.gz"
 
 LICENSE="MIT"
-SLOT="0"
+SLOT="0/${PVR}"
 KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~x86-solaris"
 IUSE="doc"
-
-SLOT="0/${PVR}"
 
 DEPEND="!dev-lisp/cl-${PN}
 		!<dev-lisp/asdf-2.33-r3


### PR DESCRIPTION
The `SLOT` variable is set to `SLOT="0/${PVR}"` 4 lines after this deletion.