### PR TITLE
net-im/bitlbee: Add myself as proxy maintainer

### DIFF
--- a/net-im/bitlbee/metadata.xml
+++ b/net-im/bitlbee/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!--maintainer-needed-->
+	<maintainer type="person">
+		<email>arkamar@atlas.cz</email>
+		<name>Petr Vaněk</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<use>
 		<flag name="libevent">Use libevent for event handling</flag>
 		<flag name="msn">Enable MSN Messenger IM protocol support.</flag>


### PR DESCRIPTION
I would like to proxy-maint this one. I use it on daily bases and I already proxy-main [bitlbee-facebook](https://packages.gentoo.org/packages/net-im/bitlbee-facebook).