### PR TITLE
games-simulation/micropolis: fix eclass usage, don't call gcc directly

### DIFF
--- a/games-simulation/micropolis/micropolis-1.0-r1.ebuild
+++ b/games-simulation/micropolis/micropolis-1.0-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils
+
+inherit desktop eutils toolchain-funcs
 
 DESCRIPTION="Free version of the well-known city building simulation"
 HOMEPAGE="http://www.donhopkins.com/home/micropolis/"
@@ -42,7 +43,7 @@ src_prepare() {
 }
 
 src_compile() {
-	emake -C src LDFLAGS="${LDFLAGS}"
+	emake -C src LDFLAGS="${LDFLAGS}" CC="$(tc-getCC)"
 }
 
 src_install() {

--- a/games-simulation/micropolis/micropolis-1.0-r2.ebuild
+++ b/games-simulation/micropolis/micropolis-1.0-r2.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit eutils
+
+inherit desktop eutils toolchain-funcs
 
 DESCRIPTION="Free version of the well-known city building simulation"
 HOMEPAGE="http://www.donhopkins.com/home/micropolis/"
@@ -44,7 +45,7 @@ src_prepare() {
 }
 
 src_compile() {
-	emake -C src LDFLAGS="${LDFLAGS}"
+	emake -C src LDFLAGS="${LDFLAGS}" CC="$(tc-getCC)"
 }
 
 src_install() {


### PR DESCRIPTION
Since `EAPI7` the `eutils` eclass doesn't inherit the `desktop` ecalss anymore (and a few others too), which is why the ebuild would need to inherit these eclasses if needed.
`games-simulation/micropolis` uses `doicon` and `make_desktop_entry`, both coming from the `desktop` eclass.
Since the ebuild doesn't inherit the eclass both commands fail right now.

```
line 624: doicon: command not found
line 626: make_desktop_entry: command not found
```

I've fixed the ebuild (and also updated the r1) and fixed the build to not call `gcc` diretly.

I don't think my changes justify a revision bump, but if so please let me know and i'll update my PR

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>