### PR TITLE
media-video/orion: fix eclass usage

### DIFF
--- a/media-video/orion/orion-1.6.1.ebuild
+++ b/media-video/orion/orion-1.6.1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils qmake-utils
+inherit desktop qmake-utils
 
 DESCRIPTION="Cross-platform Twitch client"
 HOMEPAGE="https://alamminsalo.github.io/orion/"

--- a/media-video/orion/orion-1.6.5.ebuild
+++ b/media-video/orion/orion-1.6.5.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit eutils qmake-utils
+inherit desktop qmake-utils
 
 DESCRIPTION="Cross-platform Twitch client"
 HOMEPAGE="https://alamminsalo.github.io/orion/"


### PR DESCRIPTION
Hi,

This is a minor fix for the `orion-1.6.5.ebuild`.
Right now the `domenu` command fails because the ebuild doesn't inherit the `desktop` eclass (eutils doesn't inherit it anymore since EAPI7).
I've updated the ebuild, removed the `eutils` eclass (not needed) and added the `desktop` eclass. I've also update `orion-1.6.1`


Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>