### PR TITLE
net-analyzer/gspoof: fix eclass usage

### DIFF
--- a/net-analyzer/gspoof/gspoof-3.2-r3.ebuild
+++ b/net-analyzer/gspoof/gspoof-3.2-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools eutils
+inherit autotools desktop
 
 DESCRIPTION="A simple GTK/command line TCP/IP packet generator"
 HOMEPAGE="http://gspoof.sourceforge.net/"


### PR DESCRIPTION
`newicon` fails while installing `net-analyzer/gspoof` because the ebuild doesn't inherit the `desktop` eclass.
I've updated the ebuild and replace `eutils` with `desktop`

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>