### PR TITLE
sci-mathematics/coq: fix eclass usage

### DIFF
--- a/sci-mathematics/coq/coq-8.9.1-r1.ebuild
+++ b/sci-mathematics/coq/coq-8.9.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-inherit eutils multilib
+inherit desktop multilib
 
 MY_PV=${PV/_p/pl}
 MY_P=${PN}-${MY_PV}


### PR DESCRIPTION
`make_desktop_entry` fails when installing `sci-mathematics/coq` with `USE=gtk` enabled because the ebuild doesn't inherit the `desktop` eclass.
I've updated the ebuild and replaced `eutils` with the `desktop` eclass.


Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>