### PR TITLE
x11-wm/awesome: fix eclass usage

### DIFF
--- a/x11-wm/awesome/awesome-9999.ebuild
+++ b/x11-wm/awesome/awesome-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils eutils git-r3 pax-utils
+inherit cmake-utils desktop git-r3 pax-utils
 
 DESCRIPTION="A dynamic floating and tiling window manager"
 HOMEPAGE="https://awesomewm.org/"


### PR DESCRIPTION
`domenu` fails right now because the ebuild doesn't inherit the `desktop` eclass. I've updated the ebuild and replaced `eutils` with the `desktop` eclass. (like the 4.3 ebuild)

Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>