### PR TITLE
app-backup/duplicity: Add maintainer and description

### DIFF
--- a/app-backup/duplicity/metadata.xml
+++ b/app-backup/duplicity/metadata.xml
@@ -5,6 +5,11 @@
 		<email>rich0@gentoo.org</email>
 		<name>Rich Freeman</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>gentoo@seichter.de</email>
+		<name>Ralph Seichter</name>
+	</maintainer>
+	<longdescription>Encrypted bandwidth-efficient backup using the rsync algorithm</longdescription>
 	<use>
 		<flag name="s3">Support for backing up to the Amazon S3 system</flag>
 	</use>


### PR DESCRIPTION
Adding myself as a secondary maintainer, see [here](https://archives.gentoo.org/gentoo-dev/message/b2b640f2929686ecf6e92bf63dbbe8c2). This commit also adds a long description field.

Pinging @rich0 because he is the current maintainer.