### PR TITLE
media-libs/libvpx: fix building on ppc

### DIFF
--- a/media-libs/libvpx/libvpx-1.7.0.ebuild
+++ b/media-libs/libvpx/libvpx-1.7.0.ebuild
@@ -95,6 +95,9 @@ multilib_src_configure() {
 		x86_64*) export AS=yasm;;
 	esac
 
+	# powerpc toolchain is not recognized anymore, #694368
+	[[ ${CHOST} == powerpc-* ]] && myconfargs+=( --force-target=generic-gnu )
+
 	# Build with correct toolchain.
 	tc-export CC CXX AR NM
 	# Link with gcc by default, the build system should override this if needed.

--- a/media-libs/libvpx/libvpx-1.8.0-r1.ebuild
+++ b/media-libs/libvpx/libvpx-1.8.0-r1.ebuild
@@ -84,6 +84,9 @@ multilib_src_configure() {
 		x86_64*) export AS=yasm;;
 	esac
 
+	# powerpc toolchain is not recognized anymore, #694368
+	[[ ${CHOST} == powerpc-* ]] && myconfargs+=( --force-target=generic-gnu )
+
 	# Build with correct toolchain.
 	tc-export CC CXX AR NM
 	# Link with gcc by default, the build system should override this if needed.

--- a/media-libs/libvpx/libvpx-1.8.0.ebuild
+++ b/media-libs/libvpx/libvpx-1.8.0.ebuild
@@ -96,6 +96,9 @@ multilib_src_configure() {
 		x86_64*) export AS=yasm;;
 	esac
 
+	# powerpc toolchain is not recognized anymore, #694368
+	[[ ${CHOST} == powerpc-* ]] && myconfargs+=( --force-target=generic-gnu )
+
 	# Build with correct toolchain.
 	tc-export CC CXX AR NM
 	# Link with gcc by default, the build system should override this if needed.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694368
Thanks-to: ernsteiswuerfel <erhard_f@mailbox.org>
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>