### PR TITLE
app-emulation/crun: restrict tests

### DIFF
--- a/app-emulation/crun/crun-0.10.6.ebuild
+++ b/app-emulation/crun/crun-0.10.6.ebuild
@@ -29,6 +29,11 @@ BDEPEND="
 	doc? ( dev-go/go-md2man )
 "
 
+# the crun test suite is comprehensive to the extent that tests will fail
+# within a sandbox environment, due to the nature of the priveledges
+# required to create linux "containers."
+RESTRICT="test"
+
 DOCS=README.md
 
 src_configure() {


### PR DESCRIPTION
the crun test suite is comprehensive to the extent that tests will fail
within a sandbox environment, due to the nature of the priveledges
required to create linux "containers."

for now I am restricting tests until the time when I can find the time
to determine a subset of tests that will run within a sandbox.

Closes: https://bugs.gentoo.org/700724
Package-Manager: Portage-2.3.79, Repoman-2.3.18
Signed-off-by: Dan Molik <dan@danmolik.com>