### PR TITLE
net-mail/cmd5checkpw: use a special group instead of a user

### DIFF
--- a/acct-group/cmd5checkpw/cmd5checkpw-0.ebuild
+++ b/acct-group/cmd5checkpw/cmd5checkpw-0.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID=212

--- a/acct-group/cmd5checkpw/metadata.xml
+++ b/acct-group/cmd5checkpw/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>eike@sf-mail.de</email>
+		<name>Rolf Eike Beer</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/net-mail/cmd5checkpw/cmd5checkpw-0.30-r3.ebuild
+++ b/net-mail/cmd5checkpw/cmd5checkpw-0.30-r3.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit fixheadtails
+
+MY_VER=$(ver_rs 1- "")
+
+DESCRIPTION="A checkpassword compatible authentication program that used CRAM-MD5 authentication mode"
+SRC_URI="https://www.fehcom.de/qmail/auth/${PN}-${MY_VER}_tgz.bin -> ${P}.tar.gz"
+HOMEPAGE="https://www.fehcom.de/qmail/smtpauth.html"
+
+LICENSE="public-domain RSA"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+IUSE=""
+
+DEPEND="acct-group/cmd5checkpw"
+RDEPEND="${DEPEND}"
+
+pkg_setup() {
+	if has_version "<net-mail/cmd5checkpw-0.30"; then
+		ewarn
+		ewarn "this version is in NO WAY COMPATIBLE with cmd5checkpw-0.2x"
+		ewarn "it actually receives the authentication credentials"
+		ewarn "in a different order then the old implementation"
+		ewarn "see bug #100693 for details"
+		ewarn "this version IS needed by >=qmail-1.03-r16"
+		ewarn
+	fi
+}
+
+PATCHES=(
+	"${FILESDIR}"/euid_${MY_VER}.diff
+	"${FILESDIR}"/reloc.diff
+)
+
+src_prepare() {
+	default
+
+	ht_fix_file Makefile
+}
+
+src_compile() {
+	emake CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS} -o cmd5checkpw"
+}
+
+src_install() {
+	insinto /etc
+	insopts -m 640 -o root -g cmd5checkpw
+	doins "${FILESDIR}"/poppasswd
+
+	exeinto /usr/bin
+	exeopts -o root -g cmd5checkpw -m 2755
+	doexe cmd5checkpw
+
+	doman cmd5checkpw.8
+	einstalldocs
+}
+
+pkg_postinst() {
+	chmod 640 "${EROOT}"/etc/poppasswd || die
+	chown root:cmd5checkpw "${EROOT}"/etc/poppasswd || die
+}


### PR DESCRIPTION
found during the last review when I cleaned up the ebuild.

GID is the same as the previous uid. See https://archives.gentoo.org/gentoo-dev/message/6376f2ca14ed1a79d3d80f4dd29f1b60