### PR TITLE
USE=gles[123] renaming

### DIFF
--- a/app-office/scribus/scribus-1.5.5-r1.ebuild
+++ b/app-office/scribus/scribus-1.5.5-r1.ebuild
@@ -34,7 +34,7 @@ DEPEND="${PYTHON_DEPS}
 	dev-libs/librevenge
 	dev-libs/libxml2
 	dev-qt/qtcore:5
-	dev-qt/qtgui:5[-gles2]
+	dev-qt/qtgui:5[-gles2-only]
 	dev-qt/qtnetwork:5
 	dev-qt/qtopengl:5
 	dev-qt/qtprintsupport:5

--- a/app-office/scribus/scribus-9999.ebuild
+++ b/app-office/scribus/scribus-9999.ebuild
@@ -36,7 +36,7 @@ DEPEND="${PYTHON_DEPS}
 	dev-libs/librevenge
 	dev-libs/libxml2
 	dev-qt/qtcore:5
-	dev-qt/qtgui:5[-gles2]
+	dev-qt/qtgui:5[-gles2-only]
 	dev-qt/qtnetwork:5
 	dev-qt/qtopengl:5
 	dev-qt/qtprintsupport:5

--- a/dev-python/PyQt5/PyQt5-5.13.2.ebuild
+++ b/dev-python/PyQt5/PyQt5-5.13.2.ebuild
@@ -21,7 +21,7 @@ SLOT="0"
 KEYWORDS="amd64 arm arm64 ~ppc ~ppc64 x86"
 
 # TODO: QtNfc, QtRemoteObjects (Qt >= 5.12)
-IUSE="bluetooth dbus debug declarative designer examples gles2 gui help location multimedia
+IUSE="bluetooth dbus debug declarative designer examples gles2-only gui help location multimedia
 	network networkauth opengl positioning printsupport sensors serialport sql +ssl svg
 	testlib webchannel webkit websockets widgets x11extras xmlpatterns"
 
@@ -69,7 +69,7 @@ RDEPEND="
 	)
 	declarative? ( >=dev-qt/qtdeclarative-${QT_PV}[widgets?] )
 	designer? ( >=dev-qt/designer-${QT_PV} )
-	gui? ( >=dev-qt/qtgui-${QT_PV}[gles2=] )
+	gui? ( >=dev-qt/qtgui-${QT_PV}[gles2-only=] )
 	help? ( >=dev-qt/qthelp-${QT_PV} )
 	location? ( >=dev-qt/qtlocation-${QT_PV} )
 	multimedia? ( >=dev-qt/qtmultimedia-${QT_PV}[widgets?] )
@@ -128,9 +128,9 @@ src_configure() {
 			$(usex declarative '' --no-qml-plugin)
 			$(pyqt_use_enable designer)
 			$(usex designer '' --no-designer-plugin)
-			$(usex gles2 '--disable-feature=PyQt_Desktop_OpenGL' '')
+			$(usex gles2-only '--disable-feature=PyQt_Desktop_OpenGL' '')
 			$(pyqt_use_enable gui)
-			$(pyqt_use_enable gui $(use gles2 && echo _QOpenGLFunctions_ES2 || echo _QOpenGLFunctions_{2_0,2_1,4_1_Core}))
+			$(pyqt_use_enable gui $(use gles2-only && echo _QOpenGLFunctions_ES2 || echo _QOpenGLFunctions_{2_0,2_1,4_1_Core}))
 			$(pyqt_use_enable help)
 			$(pyqt_use_enable location)
 			$(pyqt_use_enable multimedia QtMultimedia $(usex widgets QtMultimediaWidgets ''))

--- a/dev-python/PyQt5/PyQt5-5.14.1.ebuild
+++ b/dev-python/PyQt5/PyQt5-5.14.1.ebuild
@@ -21,7 +21,7 @@ SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 
 # TODO: QtNfc, QtRemoteObjects (Qt >= 5.12)
-IUSE="bluetooth dbus debug declarative designer examples gles2 gui help location multimedia
+IUSE="bluetooth dbus debug declarative designer examples gles2-only gui help location multimedia
 	network networkauth opengl positioning printsupport sensors serialport sql +ssl svg
 	testlib webchannel webkit websockets widgets x11extras xmlpatterns"
 
@@ -69,7 +69,7 @@ RDEPEND="
 	)
 	declarative? ( >=dev-qt/qtdeclarative-${QT_PV}[widgets?] )
 	designer? ( >=dev-qt/designer-${QT_PV} )
-	gui? ( >=dev-qt/qtgui-${QT_PV}[gles2=] )
+	gui? ( >=dev-qt/qtgui-${QT_PV}[gles2-only=] )
 	help? ( >=dev-qt/qthelp-${QT_PV} )
 	location? ( >=dev-qt/qtlocation-${QT_PV} )
 	multimedia? ( >=dev-qt/qtmultimedia-${QT_PV}[widgets?] )
@@ -128,9 +128,9 @@ src_configure() {
 			$(usex declarative '' --no-qml-plugin)
 			$(pyqt_use_enable designer)
 			$(usex designer '' --no-designer-plugin)
-			$(usex gles2 '--disable-feature=PyQt_Desktop_OpenGL' '')
+			$(usex gles2-only '--disable-feature=PyQt_Desktop_OpenGL' '')
 			$(pyqt_use_enable gui)
-			$(pyqt_use_enable gui $(use gles2 && echo _QOpenGLFunctions_ES2 || echo _QOpenGLFunctions_{2_0,2_1,4_1_Core}))
+			$(pyqt_use_enable gui $(use gles2-only && echo _QOpenGLFunctions_ES2 || echo _QOpenGLFunctions_{2_0,2_1,4_1_Core}))
 			$(pyqt_use_enable help)
 			$(pyqt_use_enable location)
 			$(pyqt_use_enable multimedia QtMultimedia $(usex widgets QtMultimediaWidgets ''))

--- a/dev-python/PyQt5/metadata.xml
+++ b/dev-python/PyQt5/metadata.xml
@@ -10,7 +10,7 @@
 		<flag name="dbus">Build bindings for the QtDBus module</flag>
 		<flag name="declarative">Build bindings for the QtQml/QtQuick modules and enable the qmlscene plugin</flag>
 		<flag name="designer">Build bindings for the QtDesigner module and enable the designer plugin</flag>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="gui">Build bindings for the QtGui module</flag>
 		<flag name="help">Build bindings for the QtHelp module</flag>
 		<flag name="location">Build bindings for the QtLocation module</flag>

--- a/dev-qt/qt3d/metadata.xml
+++ b/dev-qt/qt3d/metadata.xml
@@ -8,7 +8,7 @@
 	<use>
 		<flag name="gamepad">Add support for gamepad hardware via
 			<pkg>dev-qt/qtgamepad</pkg></flag>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="qml">Build QML/QtQuick bindings</flag>
 	</use>
 	<upstream>

--- a/dev-qt/qt3d/qt3d-5.13.2.ebuild
+++ b/dev-qt/qt3d/qt3d-5.13.2.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # TODO: tools
-IUSE="gamepad gles2 qml"
+IUSE="gamepad gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtconcurrent-${PV}
@@ -20,7 +20,7 @@ DEPEND="
 	~dev-qt/qtnetwork-${PV}
 	>=media-libs/assimp-4.0.0
 	gamepad? ( ~dev-qt/qtgamepad-${PV} )
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qt3d/qt3d-5.14.1.ebuild
+++ b/dev-qt/qt3d/qt3d-5.14.1.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # TODO: tools
-IUSE="gamepad gles2 qml"
+IUSE="gamepad gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtconcurrent-${PV}
@@ -20,7 +20,7 @@ DEPEND="
 	~dev-qt/qtnetwork-${PV}
 	>=media-libs/assimp-4.0.0
 	gamepad? ( ~dev-qt/qtgamepad-${PV} )
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtdatavis3d/metadata.xml
+++ b/dev-qt/qtdatavis3d/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="qml">Build QML/QtQuick bindings and imports</flag>
 	</use>
 	<upstream>

--- a/dev-qt/qtdatavis3d/qtdatavis3d-5.13.2.ebuild
+++ b/dev-qt/qtdatavis3d/qtdatavis3d-5.13.2.ebuild
@@ -11,12 +11,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 arm64 ~x86"
 fi
 
-IUSE="gles2 qml"
+IUSE="gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtdatavis3d/qtdatavis3d-5.14.1.ebuild
+++ b/dev-qt/qtdatavis3d/qtdatavis3d-5.14.1.ebuild
@@ -11,12 +11,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 ~arm64 x86"
 fi
 
-IUSE="gles2 qml"
+IUSE="gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtdeclarative/metadata.xml
+++ b/dev-qt/qtdeclarative/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="localstorage">Build the LocalStorage import for QtQuick (requires QtSql)</flag>
 		<flag name="vulkan">Enable support for Vulkan</flag>
 		<flag name="widgets">Enable QtWidgets support</flag>

--- a/dev-qt/qtdeclarative/qtdeclarative-5.13.2-r1.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.13.2-r1.ebuild
@@ -11,17 +11,17 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~x86"
 fi
 
-IUSE="gles2 +jit localstorage +widgets"
+IUSE="gles2-only +jit localstorage +widgets"
 
 BDEPEND="${PYTHON_DEPS}"
-# qtgui[gles2=] is needed because of bug 504322
+# qtgui[gles2-only=] is needed because of bug 504322
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qttest-${PV}
 	localstorage? ( ~dev-qt/qtsql-${PV} )
-	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2=] )
+	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}
 	!<dev-qt/qtquickcontrols-5.7:5

--- a/dev-qt/qtdeclarative/qtdeclarative-5.14.1-r1.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.14.1-r1.ebuild
@@ -11,17 +11,17 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 ~arm ~arm64 ~hppa ppc ppc64 x86"
 fi
 
-IUSE="gles2 +jit localstorage vulkan +widgets"
+IUSE="gles2-only +jit localstorage vulkan +widgets"
 
 BDEPEND="${PYTHON_DEPS}"
-# qtgui[gles2=] is needed because of bug 504322
+# qtgui[gles2-only=] is needed because of bug 504322
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,vulkan=]
+	~dev-qt/qtgui-${PV}[gles2-only=,vulkan=]
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qttest-${PV}
 	localstorage? ( ~dev-qt/qtsql-${PV} )
-	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2=] )
+	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}
 	!<dev-qt/qtquickcontrols-5.7:5

--- a/dev-qt/qtgui/metadata.xml
+++ b/dev-qt/qtgui/metadata.xml
@@ -9,7 +9,7 @@
 		<flag name="egl">Enable EGL integration</flag>
 		<flag name="eglfs">Build the EGL Full Screen/Single Surface platform plugin</flag>
 		<flag name="evdev">Enable support for input devices via evdev</flag>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="ibus">Build the IBus input method plugin</flag>
 		<flag name="libinput">Enable support for input devices via <pkg>dev-libs/libinput</pkg></flag>
 		<flag name="tslib">Enable support for touchscreen devices via <pkg>x11-libs/tslib</pkg></flag>

--- a/dev-qt/qtgui/qtgui-5.13.2.ebuild
+++ b/dev-qt/qtgui/qtgui-5.13.2.ebuild
@@ -13,7 +13,7 @@ fi
 
 # TODO: linuxfb
 
-IUSE="accessibility dbus egl eglfs evdev +gif gles2 ibus
+IUSE="accessibility dbus egl eglfs evdev +gif gles2-only ibus
 	jpeg +libinput +png tslib tuio +udev vnc wayland +xcb"
 REQUIRED_USE="
 	|| ( eglfs xcb )
@@ -21,7 +21,7 @@ REQUIRED_USE="
 	eglfs? ( egl )
 	ibus? ( dbus )
 	libinput? ( udev )
-	xcb? ( gles2? ( egl ) )
+	xcb? ( gles2-only? ( egl ) )
 "
 
 RDEPEND="
@@ -40,7 +40,7 @@ RDEPEND="
 		x11-libs/libdrm
 	)
 	evdev? ( sys-libs/mtdev )
-	gles2? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2] )
 	jpeg? ( virtual/jpeg:0 )
 	libinput? (
 		dev-libs/libinput:=
@@ -96,8 +96,8 @@ QT5_GENTOO_CONFIG=(
 	:system-freetype:FREETYPE
 	!:no-freetype:
 	!gif:no-gif:
-	gles2::OPENGL_ES
-	gles2:opengles2:OPENGL_ES_2
+	gles2-only::OPENGL_ES
+	gles2-only:opengles2:OPENGL_ES_2
 	!:no-gui:
 	:system-harfbuzz:
 	!:no-harfbuzz:
@@ -165,7 +165,7 @@ src_configure() {
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use png libpng system)
 		$(qt_use tslib)
 		$(qt_use udev libudev)

--- a/dev-qt/qtgui/qtgui-5.14.1-r3.ebuild
+++ b/dev-qt/qtgui/qtgui-5.14.1-r3.ebuild
@@ -15,7 +15,7 @@ fi
 
 # TODO: linuxfb
 
-IUSE="accessibility dbus egl eglfs evdev +gif gles2 ibus jpeg
+IUSE="accessibility dbus egl eglfs evdev +gif gles2-only ibus jpeg
 	+libinput +png tslib tuio +udev vnc vulkan wayland +X"
 REQUIRED_USE="
 	|| ( eglfs X )
@@ -23,7 +23,7 @@ REQUIRED_USE="
 	eglfs? ( egl )
 	ibus? ( dbus )
 	libinput? ( udev )
-	X? ( gles2? ( egl ) )
+	X? ( gles2-only? ( egl ) )
 "
 
 COMMON_DEPEND="
@@ -42,7 +42,7 @@ COMMON_DEPEND="
 		x11-libs/libdrm
 	)
 	evdev? ( sys-libs/mtdev )
-	gles2? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2] )
 	jpeg? ( virtual/jpeg:0 )
 	libinput? (
 		dev-libs/libinput:=
@@ -106,8 +106,8 @@ QT5_GENTOO_CONFIG=(
 	:system-freetype:FREETYPE
 	!:no-freetype:
 	!gif:no-gif:
-	gles2::OPENGL_ES
-	gles2:opengles2:OPENGL_ES_2
+	gles2-only::OPENGL_ES
+	gles2-only:opengles2:OPENGL_ES_2
 	!:no-gui:
 	:system-harfbuzz:
 	!:no-harfbuzz:
@@ -176,7 +176,7 @@ src_configure() {
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use png libpng system)
 		$(qt_use tslib)
 		$(qt_use vulkan)

--- a/dev-qt/qtmultimedia/metadata.xml
+++ b/dev-qt/qtmultimedia/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="gstreamer">Enable audio support via <pkg>media-libs/gstreamer</pkg> using SLOT 1.0</flag>
 		<flag name="qml">Build QML/QtQuick bindings and imports</flag>
 		<flag name="widgets">Build the QtMultimediaWidgets module</flag>

--- a/dev-qt/qtmultimedia/qtmultimedia-5.13.2-r1.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.13.2-r1.ebuild
@@ -10,11 +10,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~sparc ~x86"
 fi
 
-IUSE="alsa gles2 gstreamer openal pulseaudio qml widgets"
+IUSE="alsa gles2-only gstreamer openal pulseaudio qml widgets"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtnetwork-${PV}
 	alsa? ( media-libs/alsa-lib )
 	gstreamer? (
@@ -26,12 +26,12 @@ RDEPEND="
 	pulseaudio? ( media-sound/pulseaudio[glib] )
 	qml? (
 		~dev-qt/qtdeclarative-${PV}
-		gles2? ( ~dev-qt/qtgui-${PV}[egl] )
+		gles2-only? ( ~dev-qt/qtgui-${PV}[egl] )
 		openal? ( media-libs/openal )
 	)
 	widgets? (
 		~dev-qt/qtopengl-${PV}
-		~dev-qt/qtwidgets-${PV}[gles2=]
+		~dev-qt/qtwidgets-${PV}[gles2-only=]
 	)
 "
 DEPEND="${RDEPEND}

--- a/dev-qt/qtmultimedia/qtmultimedia-5.14.1.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.14.1.ebuild
@@ -10,11 +10,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 ~arm ~arm64 ~hppa ppc ppc64 ~sparc x86"
 fi
 
-IUSE="alsa gles2 gstreamer openal pulseaudio qml widgets"
+IUSE="alsa gles2-only gstreamer openal pulseaudio qml widgets"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtnetwork-${PV}
 	alsa? ( media-libs/alsa-lib )
 	gstreamer? (
@@ -26,12 +26,12 @@ RDEPEND="
 	pulseaudio? ( media-sound/pulseaudio[glib] )
 	qml? (
 		~dev-qt/qtdeclarative-${PV}
-		gles2? ( ~dev-qt/qtgui-${PV}[egl] )
+		gles2-only? ( ~dev-qt/qtgui-${PV}[egl] )
 		openal? ( media-libs/openal )
 	)
 	widgets? (
 		~dev-qt/qtopengl-${PV}
-		~dev-qt/qtwidgets-${PV}[gles2=]
+		~dev-qt/qtwidgets-${PV}[gles2-only=]
 	)
 "
 DEPEND="${RDEPEND}

--- a/dev-qt/qtopengl/metadata.xml
+++ b/dev-qt/qtopengl/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>

--- a/dev-qt/qtopengl/qtopengl-5.13.2.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.13.2.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~sparc ~x86"
 fi
 
-IUSE="gles2"
+IUSE="gles2-only"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl
 "
 RDEPEND="${DEPEND}"
@@ -28,7 +28,7 @@ QT5_TARGET_SUBDIRS=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtopengl/qtopengl-5.14.1.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.14.1.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 ~arm ~arm64 ~hppa ppc ppc64 ~sparc x86"
 fi
 
-IUSE="gles2"
+IUSE="gles2-only"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl
 "
 RDEPEND="${DEPEND}"
@@ -28,7 +28,7 @@ QT5_TARGET_SUBDIRS=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtprintsupport/metadata.xml
+++ b/dev-qt/qtprintsupport/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>

--- a/dev-qt/qtprintsupport/qtprintsupport-5.13.2-r1.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.13.2-r1.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="cups gles2"
+IUSE="cups gles2-only"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )
 "
 DEPEND="${RDEPEND}
@@ -38,7 +38,7 @@ PATCHES=( "${FILESDIR}/${P}-no-cups.patch" ) # bug #704936, QTBUG-80945
 src_configure() {
 	local myconf=(
 		$(qt_use cups)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtprintsupport/qtprintsupport-5.13.2.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.13.2.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~sparc ~x86"
 fi
 
-IUSE="cups gles2"
+IUSE="cups gles2-only"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )
 "
 DEPEND="${RDEPEND}
@@ -36,7 +36,7 @@ QT5_GENTOO_CONFIG=(
 src_configure() {
 	local myconf=(
 		$(qt_use cups)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtprintsupport/qtprintsupport-5.14.1.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.14.1.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 ~arm ~arm64 ~hppa ppc ppc64 ~sparc x86"
 fi
 
-IUSE="cups gles2"
+IUSE="cups gles2-only"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )
 "
 DEPEND="${RDEPEND}
@@ -36,7 +36,7 @@ QT5_GENTOO_CONFIG=(
 src_configure() {
 	local myconf=(
 		$(qt_use cups)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtwayland/qtwayland-5.14.1-r3.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.14.1-r3.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-0.2.0
 	vulkan? ( dev-util/vulkan-headers )
 	X? (
-		~dev-qt/qtgui-${PV}[-gles2]
+		~dev-qt/qtgui-${PV}[-gles2-only]
 		x11-libs/libX11
 		x11-libs/libXcomposite
 	)

--- a/dev-qt/qtwebkit/metadata.xml
+++ b/dev-qt/qtwebkit/metadata.xml
@@ -7,7 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="geolocation">Enable physical position determination via <pkg>dev-qt/qtpositioning</pkg></flag>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="gstreamer">Enable HTML5 audio/video support via <pkg>media-libs/gstreamer</pkg> using SLOT 1.0</flag>
 		<flag name="hyphen">Enable hyphenation support via <pkg>dev-libs/hyphen</pkg></flag>
 		<flag name="multimedia">Enable HTML5 audio/video support via <pkg>dev-qt/qtmultimedia</pkg></flag>

--- a/dev-qt/qtwebkit/qtwebkit-5.212.0_pre20190629.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.212.0_pre20190629.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/annulen/webkit/releases/download/${MY_P}/${MY_P}.tar
 LICENSE="BSD LGPL-2+"
 SLOT="5/5.212"
 KEYWORDS="amd64 arm arm64 ~ppc ppc64 x86"
-IUSE="geolocation gles2 +gstreamer +hyphen +jit multimedia nsplugin opengl orientation +printsupport qml webp X"
+IUSE="geolocation gles2-only +gstreamer +hyphen +jit multimedia nsplugin opengl orientation +printsupport qml webp X"
 
 REQUIRED_USE="
 	nsplugin? ( X )
@@ -55,8 +55,8 @@ DEPEND="
 	hyphen? ( dev-libs/hyphen )
 	multimedia? ( >=dev-qt/qtmultimedia-${QT_MIN_VER}[widgets] )
 	opengl? (
-		>=dev-qt/qtgui-${QT_MIN_VER}[gles2=]
-		>=dev-qt/qtopengl-${QT_MIN_VER}[gles2=]
+		>=dev-qt/qtgui-${QT_MIN_VER}[gles2-only=]
+		>=dev-qt/qtopengl-${QT_MIN_VER}[gles2-only=]
 	)
 	orientation? ( >=dev-qt/qtsensors-${QT_MIN_VER} )
 	printsupport? ( >=dev-qt/qtprintsupport-${QT_MIN_VER} )

--- a/dev-qt/qtwebkit/qtwebkit-5.212.0_pre20200309.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.212.0_pre20200309.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://www.qt.io/"
 
 LICENSE="BSD LGPL-2+"
 SLOT="5/5.212"
-IUSE="geolocation gles2 +gstreamer +hyphen +jit multimedia nsplugin opengl orientation +printsupport qml webp X"
+IUSE="geolocation gles2-only +gstreamer +hyphen +jit multimedia nsplugin opengl orientation +printsupport qml webp X"
 
 REQUIRED_USE="
 	nsplugin? ( X )
@@ -63,8 +63,8 @@ DEPEND="
 	hyphen? ( dev-libs/hyphen )
 	multimedia? ( >=dev-qt/qtmultimedia-${QT_MIN_VER}[widgets] )
 	opengl? (
-		>=dev-qt/qtgui-${QT_MIN_VER}[gles2=]
-		>=dev-qt/qtopengl-${QT_MIN_VER}[gles2=]
+		>=dev-qt/qtgui-${QT_MIN_VER}[gles2-only=]
+		>=dev-qt/qtopengl-${QT_MIN_VER}[gles2-only=]
 	)
 	orientation? ( >=dev-qt/qtsensors-${QT_MIN_VER} )
 	printsupport? ( >=dev-qt/qtprintsupport-${QT_MIN_VER} )

--- a/dev-qt/qtwidgets/metadata.xml
+++ b/dev-qt/qtwidgets/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>

--- a/dev-qt/qtwidgets/qtwidgets-5.13.2.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.13.2.ebuild
@@ -12,11 +12,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # keep IUSE defaults in sync with qtgui
-IUSE="gles2 gtk +png +xcb"
+IUSE="gles2-only gtk +png +xcb"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,png=,xcb?]
+	~dev-qt/qtgui-${PV}[gles2-only=,png=,xcb?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]
 		x11-libs/gtk+:3
@@ -44,7 +44,7 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use gtk)
 		-gui
 		$(qt_use png libpng system)

--- a/dev-qt/qtwidgets/qtwidgets-5.14.1.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.14.1.ebuild
@@ -13,11 +13,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # keep IUSE defaults in sync with qtgui
-IUSE="gles2 gtk +png +X"
+IUSE="gles2-only gtk +png +X"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,png=,X?]
+	~dev-qt/qtgui-${PV}[gles2-only=,png=,X?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]
 		x11-libs/gtk+:3
@@ -45,7 +45,7 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use gtk)
 		-gui
 		$(qt_use png libpng system)

--- a/dev-util/apitrace/apitrace-9.0-r1.ebuild
+++ b/dev-util/apitrace/apitrace-9.0-r1.ebuild
@@ -29,9 +29,9 @@ DEPEND="${PYTHON_DEPS}
 	x11-libs/libX11
 	qt5? (
 		dev-qt/qtcore:5
-		dev-qt/qtgui:5[-gles2]
+		dev-qt/qtgui:5[-gles2-only]
 		dev-qt/qtnetwork:5
-		dev-qt/qtwidgets:5[-gles2]
+		dev-qt/qtwidgets:5[-gles2-only]
 	)
 "
 RDEPEND="${DEPEND}"

--- a/games-emulation/mupen64plus-core/metadata.xml
+++ b/games-emulation/mupen64plus-core/metadata.xml
@@ -7,7 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="debugger">Build the debugger</flag>
-		<flag name="gles2">Use GLES2 instead of OpenGL</flag>
+		<flag name="gles2-only">Use GLES2 instead of OpenGL</flag>
 		<flag name="new-dynarec">Enable new experimental dynamic recompiler implementation (only for x86 and arm)</flag>
 		<flag name="opencv">Support video capture via <pkg>media-libs/opencv</pkg></flag>
 		<flag name="osd">Overlay emulator messages using on-screen-display</flag>

--- a/games-emulation/mupen64plus-core/mupen64plus-core-2.5.9.ebuild
+++ b/games-emulation/mupen64plus-core/mupen64plus-core-2.5.9.ebuild
@@ -13,12 +13,12 @@ SRC_URI="https://github.com/mupen64plus/${PN}/releases/download/${PV}/${MY_P}.ta
 LICENSE="GPL-2+"
 SLOT="0/2-sdl2"
 KEYWORDS="~amd64 ~x86"
-IUSE="debugger gles2 lirc new-dynarec opencv +osd cpu_flags_x86_sse"
+IUSE="debugger gles2-only lirc new-dynarec opencv +osd cpu_flags_x86_sse"
 
 RDEPEND="media-libs/libpng:0=
 	media-libs/libsdl2:0=[joystick,opengl,video]
 	sys-libs/zlib:0=[minizip]
-	gles2? ( media-libs/libsdl2:0[gles] )
+	gles2-only? ( media-libs/libsdl2:0[gles] )
 	lirc? ( app-misc/lirc:0 )
 	opencv? ( media-libs/opencv:= )
 	osd? (
@@ -30,7 +30,7 @@ RDEPEND="media-libs/libpng:0=
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
-REQUIRED_USE="gles2? ( !osd )"
+REQUIRED_USE="gles2-only? ( !osd )"
 S=${WORKDIR}/${MY_P}
 
 PATCHES=( "${FILESDIR}"/${PN}-2.5.9-fix-gcc10-fno-common.patch )
@@ -82,7 +82,7 @@ src_compile() {
 		OPENCV=$(usex opencv 1 0)
 		DEBUGGER=$(usex debugger 1 0)
 		NEW_DYNAREC=$(usex new-dynarec 1 0)
-		USE_GLES=$(usex gles2 1 0)
+		USE_GLES=$(usex gles2-only 1 0)
 	)
 
 	use amd64 && MAKEARGS+=( HOST_CPU=x86_64 )

--- a/games-emulation/mupen64plus-video-glide64mk2/metadata.xml
+++ b/games-emulation/mupen64plus-video-glide64mk2/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Michał Górny</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES2 instead of OpenGL</flag>
+		<flag name="gles2-only">Use GLES2 instead of OpenGL</flag>
 		<flag name="hires">Support hi-resolution textures (requires <pkg>dev-libs/boost</pkg>)</flag>
 	</use>
 	<upstream>

--- a/games-emulation/mupen64plus-video-glide64mk2/mupen64plus-video-glide64mk2-2.5.9.ebuild
+++ b/games-emulation/mupen64plus-video-glide64mk2/mupen64plus-video-glide64mk2-2.5.9.ebuild
@@ -14,14 +14,14 @@ SRC_URI="https://github.com/mupen64plus/${PN}/releases/download/${PV}/${MY_P}.ta
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="gles2 hires cpu_flags_x86_sse"
+IUSE="gles2-only hires cpu_flags_x86_sse"
 
-RDEPEND=">=games-emulation/mupen64plus-core-2.5:0=[gles2=]
+RDEPEND=">=games-emulation/mupen64plus-core-2.5:0=[gles2-only=]
 	media-libs/libpng:0=
 	media-libs/libsdl2:0=[video]
 	sys-libs/zlib:0=
 	virtual/opengl:0=
-	gles2? ( media-libs/libsdl2:0[gles] )
+	gles2-only? ( media-libs/libsdl2:0[gles] )
 	hires? ( dev-libs/boost:0= )"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
@@ -72,7 +72,7 @@ src_compile() {
 		NOSSE=$(usex cpu_flags_x86_sse 0 1)
 		HIRES=$(usex hires 1 0)
 		USE_FRAMESKIPPER=1
-		USE_GLES=$(usex gles2 1 0)
+		USE_GLES=$(usex gles2-only 1 0)
 		# use bundled lib
 		# https://bugs.gentoo.org/654470
 		TXCDXTN=0

--- a/games-emulation/mupen64plus-video-rice/metadata.xml
+++ b/games-emulation/mupen64plus-video-rice/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Michał Górny</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES2 instead of OpenGL</flag>
+		<flag name="gles2-only">Use GLES2 instead of OpenGL</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">mupen64plus/mupen64plus-video-rice</remote-id>

--- a/games-emulation/mupen64plus-video-rice/mupen64plus-video-rice-2.5.9.ebuild
+++ b/games-emulation/mupen64plus-video-rice/mupen64plus-video-rice-2.5.9.ebuild
@@ -13,13 +13,13 @@ SRC_URI="https://github.com/mupen64plus/${PN}/releases/download/${PV}/${MY_P}.ta
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="gles2 cpu_flags_x86_sse"
+IUSE="gles2-only cpu_flags_x86_sse"
 
-RDEPEND=">=games-emulation/mupen64plus-core-2.5:0=[gles2=]
+RDEPEND=">=games-emulation/mupen64plus-core-2.5:0=[gles2-only=]
 	media-libs/libpng:0=
 	media-libs/libsdl2:0=[video]
 	virtual/opengl:0=
-	gles2? ( media-libs/libsdl2:0[gles] )"
+	gles2-only? ( media-libs/libsdl2:0[gles] )"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
@@ -67,7 +67,7 @@ src_compile() {
 		SDL_LDLIBS="$($(tc-getPKG_CONFIG) --libs sdl2)"
 
 		NO_ASM=$(usex cpu_flags_x86_sse 0 1)
-		USE_GLES=$(usex gles2 1 0)
+		USE_GLES=$(usex gles2-only 1 0)
 	)
 
 	use amd64 && MAKEARGS+=( HOST_CPU=x86_64 )

--- a/games-fps/doomsday/doomsday-2.1.1-r1.ebuild
+++ b/games-fps/doomsday/doomsday-2.1.1-r1.ebuild
@@ -17,7 +17,7 @@ IUSE="demo fmod freedoom fluidsynth openal tools"
 
 RDEPEND="
 	dev-qt/qtcore:5=
-	dev-qt/qtgui:5=[-gles2]
+	dev-qt/qtgui:5=[-gles2-only]
 	dev-qt/qtnetwork:5=
 	dev-qt/qtopengl:5=
 	dev-qt/qtwidgets:5=

--- a/kde-apps/analitza/analitza-19.12.3-r1.ebuild
+++ b/kde-apps/analitza/analitza-19.12.3-r1.ebuild
@@ -20,7 +20,7 @@ BDEPEND="
 "
 DEPEND="
 	>=dev-qt/qtdeclarative-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5[-gles2]
+	>=dev-qt/qtgui-${QTMIN}:5[-gles2-only]
 	>=dev-qt/qtprintsupport-${QTMIN}:5
 	>=dev-qt/qtsvg-${QTMIN}:5
 	>=dev-qt/qtwidgets-${QTMIN}:5

--- a/kde-apps/kdenlive/kdenlive-19.12.3-r1.ebuild
+++ b/kde-apps/kdenlive/kdenlive-19.12.3-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://kdenlive.org/en/"
 LICENSE="GPL-2"
 SLOT="5"
 KEYWORDS="amd64 arm64 ~ppc64 x86"
-IUSE="freesound gles2 semantic-desktop share v4l"
+IUSE="freesound gles2-only semantic-desktop share v4l"
 
 BDEPEND="
 	sys-devel/gettext
@@ -26,7 +26,7 @@ DEPEND="
 	>=dev-qt/qtconcurrent-${QTMIN}:5
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtdeclarative-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5[gles2=]
+	>=dev-qt/qtgui-${QTMIN}:5[gles2-only=]
 	>=dev-qt/qtmultimedia-${QTMIN}:5
 	>=dev-qt/qtnetwork-${QTMIN}:5
 	>=dev-qt/qtsvg-${QTMIN}:5

--- a/kde-apps/kdenlive/metadata.xml
+++ b/kde-apps/kdenlive/metadata.xml
@@ -7,7 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="freesound">Enable freesound.org credentials support via <pkg>dev-qt/qtwebkit</pkg> to download files</flag>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="share">Enable support for a share menu using <pkg>kde-frameworks/purpose</pkg></flag>
 	</use>
 </pkgmetadata>

--- a/kde-frameworks/plasma/metadata.xml
+++ b/kde-frameworks/plasma/metadata.xml
@@ -6,6 +6,6 @@
 		<name>Gentoo KDE Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gles2-only">Use GLES 2.0 or later instead of full OpenGL</flag>
 	</use>
 </pkgmetadata>

--- a/kde-frameworks/plasma/plasma-5.67.0-r2.ebuild
+++ b/kde-frameworks/plasma/plasma-5.67.0-r2.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="Plasma framework"
 
 LICENSE="LGPL-2+"
 KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
-IUSE="gles2 wayland X"
+IUSE="gles2-only wayland X"
 
 # drop qtgui subslot operator when QT_MINIMAL >= 5.14.0
 BDEPEND="
@@ -22,7 +22,7 @@ BDEPEND="
 RDEPEND="
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtdeclarative-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5=[gles2=]
+	>=dev-qt/qtgui-${QTMIN}:5=[gles2-only=]
 	>=dev-qt/qtquickcontrols-${QTMIN}:5
 	>=dev-qt/qtsql-${QTMIN}:5
 	>=dev-qt/qtsvg-${QTMIN}:5
@@ -45,7 +45,7 @@ RDEPEND="
 	=kde-frameworks/kwidgetsaddons-${PVCUT}*:5
 	=kde-frameworks/kwindowsystem-${PVCUT}*:5
 	=kde-frameworks/kxmlgui-${PVCUT}*:5
-	!gles2? ( virtual/opengl )
+	!gles2-only? ( virtual/opengl )
 	wayland? (
 		=kde-frameworks/kwayland-${PVCUT}*:5
 		media-libs/mesa[egl]
@@ -69,7 +69,7 @@ PATCHES=(
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake_use_find_package !gles2 OpenGL)
+		$(cmake_use_find_package !gles2-only OpenGL)
 		$(cmake_use_find_package wayland EGL)
 		$(cmake_use_find_package wayland KF5Wayland)
 		$(cmake_use_find_package X X11)

--- a/kde-frameworks/plasma/plasma-5.68.0.ebuild
+++ b/kde-frameworks/plasma/plasma-5.68.0.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="Plasma framework"
 
 LICENSE="LGPL-2+"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="gles2 wayland X"
+IUSE="gles2-only wayland X"
 
 # drop qtgui subslot operator when QT_MINIMAL >= 5.14.0
 BDEPEND="
@@ -22,7 +22,7 @@ BDEPEND="
 RDEPEND="
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtdeclarative-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5=[gles2=]
+	>=dev-qt/qtgui-${QTMIN}:5=[gles2-only=]
 	>=dev-qt/qtquickcontrols-${QTMIN}:5
 	>=dev-qt/qtsql-${QTMIN}:5
 	>=dev-qt/qtsvg-${QTMIN}:5
@@ -45,7 +45,7 @@ RDEPEND="
 	=kde-frameworks/kwidgetsaddons-${PVCUT}*:5
 	=kde-frameworks/kwindowsystem-${PVCUT}*:5
 	=kde-frameworks/kxmlgui-${PVCUT}*:5
-	!gles2? ( virtual/opengl )
+	!gles2-only? ( virtual/opengl )
 	wayland? (
 		=kde-frameworks/kwayland-${PVCUT}*:5
 		media-libs/mesa[egl]
@@ -64,7 +64,7 @@ RESTRICT+=" test"
 
 src_configure() {
 	local mycmakeargs=(
-		$(cmake_use_find_package !gles2 OpenGL)
+		$(cmake_use_find_package !gles2-only OpenGL)
 		$(cmake_use_find_package wayland EGL)
 		$(cmake_use_find_package wayland KF5Wayland)
 		$(cmake_use_find_package X X11)

--- a/kde-plasma/kinfocenter/kinfocenter-5.17.5.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.17.5.ebuild
@@ -44,9 +44,13 @@ COMMON_DEPEND="
 	x11-libs/libX11
 	ieee1394? ( sys-libs/libraw1394 )
 	opengl? (
-		>=dev-qt/qtgui-${QTMIN}:5[gles2=]
+		>=dev-qt/qtgui-${QTMIN}:5
 		media-libs/mesa[gles2?,X(+)]
-		!gles2? ( media-libs/glu )
+		gles2? ( dev-qt/qtgui[gles2-only] )
+		!gles2? (
+			media-libs/glu
+			dev-qt/qtgui[-gles2-only]
+		)
 	)
 	pci? ( sys-apps/pciutils )
 	wayland? (

--- a/kde-plasma/kinfocenter/kinfocenter-5.17.5.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.17.5.ebuild
@@ -15,9 +15,9 @@ SRC_URI+=" https://www.gentoo.org/assets/img/logo/gentoo-3d-small.png -> glogo-s
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
 KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
-IUSE="gles2 ieee1394 +opengl +pci wayland"
+IUSE="gles2-only ieee1394 +opengl +pci wayland"
 
-REQUIRED_USE="wayland? ( || ( gles2 opengl ) )"
+REQUIRED_USE="wayland? ( || ( gles2-only opengl ) )"
 
 BDEPEND=">=dev-util/cmake-3.14.3"
 COMMON_DEPEND="
@@ -44,13 +44,9 @@ COMMON_DEPEND="
 	x11-libs/libX11
 	ieee1394? ( sys-libs/libraw1394 )
 	opengl? (
-		>=dev-qt/qtgui-${QTMIN}:5
-		media-libs/mesa[gles2?,X(+)]
-		gles2? ( dev-qt/qtgui[gles2-only] )
-		!gles2? (
-			media-libs/glu
-			dev-qt/qtgui[-gles2-only]
-		)
+		>=dev-qt/qtgui-${QTMIN}:5[gles2-only=]
+		gles2-only? ( media-libs/mesa[gles2,X(+)] )
+		!gles2-only? ( media-libs/glu )
 	)
 	pci? ( sys-apps/pciutils )
 	wayland? (

--- a/kde-plasma/kinfocenter/kinfocenter-5.18.3.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.18.3.ebuild
@@ -45,9 +45,13 @@ COMMON_DEPEND="
 	x11-libs/libX11
 	ieee1394? ( sys-libs/libraw1394 )
 	opengl? (
-		>=dev-qt/qtgui-${QTMIN}:5[gles2=]
+		>=dev-qt/qtgui-${QTMIN}:5
 		media-libs/mesa[gles2?,X(+)]
-		!gles2? ( media-libs/glu )
+		gles2? ( dev-qt/qtgui[gles2-only] )
+		!gles2? (
+			media-libs/glu
+			dev-qt/qtgui[-gles2-only]
+		)
 	)
 	pci? ( sys-apps/pciutils )
 	wayland? (
@@ -72,7 +76,7 @@ src_configure() {
 		$(cmake_use_find_package wayland KF5Wayland)
 	)
 
-	if has_version "dev-qt/qtgui[gles2]"; then
+	if has_version "dev-qt/qtgui[gles2-only]"; then
 		mycmakeargs+=( $(cmake_use_find_package gles2 OpenGLES) )
 	else
 		mycmakeargs+=( $(cmake_use_find_package opengl OpenGL) )

--- a/kde-plasma/kinfocenter/kinfocenter-5.18.3.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.18.3.ebuild
@@ -16,9 +16,9 @@ SRC_URI+=" https://www.gentoo.org/assets/img/logo/gentoo-3d-small.png -> glogo-s
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="gles2 ieee1394 +opengl +pci wayland"
+IUSE="gles2-only ieee1394 +opengl +pci wayland"
 
-REQUIRED_USE="wayland? ( || ( gles2 opengl ) )"
+REQUIRED_USE="wayland? ( || ( gles2-only opengl ) )"
 
 BDEPEND=">=dev-util/cmake-3.14.3"
 COMMON_DEPEND="
@@ -45,13 +45,9 @@ COMMON_DEPEND="
 	x11-libs/libX11
 	ieee1394? ( sys-libs/libraw1394 )
 	opengl? (
-		>=dev-qt/qtgui-${QTMIN}:5
-		media-libs/mesa[gles2?,X(+)]
-		gles2? ( dev-qt/qtgui[gles2-only] )
-		!gles2? (
-			media-libs/glu
-			dev-qt/qtgui[-gles2-only]
-		)
+		>=dev-qt/qtgui-${QTMIN}:5[gles2-only=]
+		gles2-only? ( media-libs/mesa[gles2,X(+)] )
+		!gles2-only? ( media-libs/glu )
 	)
 	pci? ( sys-apps/pciutils )
 	wayland? (

--- a/kde-plasma/kinfocenter/metadata.xml
+++ b/kde-plasma/kinfocenter/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo KDE Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Show OpenGL ES information in kinfocenter</flag>
+		<flag name="gles2-only">Show OpenGL ES information in kinfocenter rather than full OpenGL</flag>
 		<flag name="pci">Show advanced PCI information</flag>
 	</use>
 </pkgmetadata>

--- a/kde-plasma/kwin/kwin-5.17.5.ebuild
+++ b/kde-plasma/kwin/kwin-5.17.5.ebuild
@@ -15,7 +15,7 @@ DESCRIPTION="Flexible, composited Window Manager for windowing systems on Linux"
 LICENSE="GPL-2+"
 SLOT="5"
 KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
-IUSE="caps gles2 multimedia"
+IUSE="caps gles2-only multimedia"
 
 COMMON_DEPEND="
 	>=kde-frameworks/kactivities-${KFMIN}:5
@@ -48,7 +48,7 @@ COMMON_DEPEND="
 	>=kde-plasma/kscreenlocker-${PVCUT}:5
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtdeclarative-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5=[gles2=]
+	>=dev-qt/qtgui-${QTMIN}:5=[gles2-only=]
 	>=dev-qt/qtscript-${QTMIN}:5
 	>=dev-qt/qtsensors-${QTMIN}:5
 	>=dev-qt/qtwidgets-${QTMIN}:5
@@ -58,7 +58,8 @@ COMMON_DEPEND="
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/libepoxy
-	media-libs/mesa[egl,gbm,gles2?,wayland,X(+)]
+	media-libs/mesa[egl,gbm,wayland,X(+)]
+	gles2-only? ( media-libs/mesa[gles2] )
 	virtual/libudev:=
 	x11-libs/libICE
 	x11-libs/libSM

--- a/kde-plasma/kwin/kwin-5.18.3.ebuild
+++ b/kde-plasma/kwin/kwin-5.18.3.ebuild
@@ -16,7 +16,7 @@ DESCRIPTION="Flexible, composited Window Manager for windowing systems on Linux"
 LICENSE="GPL-2+"
 SLOT="5"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="caps gles2 multimedia"
+IUSE="caps gles2-only multimedia"
 
 COMMON_DEPEND="
 	>=kde-frameworks/kactivities-${KFMIN}:5
@@ -49,7 +49,7 @@ COMMON_DEPEND="
 	>=kde-plasma/kscreenlocker-${PVCUT}:5
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtdeclarative-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5=[gles2=]
+	>=dev-qt/qtgui-${QTMIN}:5=[gles2-only=]
 	>=dev-qt/qtscript-${QTMIN}:5
 	>=dev-qt/qtsensors-${QTMIN}:5
 	>=dev-qt/qtwidgets-${QTMIN}:5
@@ -59,7 +59,8 @@ COMMON_DEPEND="
 	media-libs/fontconfig
 	media-libs/freetype
 	media-libs/libepoxy
-	media-libs/mesa[egl,gbm,gles2?,wayland,X(+)]
+	media-libs/mesa[egl,gbm,wayland,X(+)]
+	gles2-only? ( media-libs/mesa[gles2] )
 	virtual/libudev:=
 	x11-libs/libICE
 	x11-libs/libSM

--- a/kde-plasma/kwin/metadata.xml
+++ b/kde-plasma/kwin/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo KDE Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use OpenGL ES 2 instead of full GL</flag>
+		<flag name="gles2-only">Use OpenGL ES 2 instead of full GL</flag>
 		<flag name="multimedia">Enable effect video button in desktop effects KCM</flag>
 	</use>
 </pkgmetadata>

--- a/media-gfx/digikam/digikam-6.4.0-r1.ebuild
+++ b/media-gfx/digikam/digikam-6.4.0-r1.ebuild
@@ -36,7 +36,7 @@ COMMON_DEPEND="
 	dev-libs/expat
 	>=dev-qt/qtconcurrent-${QTMIN}:5
 	>=dev-qt/qtdbus-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5[-gles2]
+	>=dev-qt/qtgui-${QTMIN}:5[-gles2-only]
 	>=dev-qt/qtnetwork-${QTMIN}:5
 	>=dev-qt/qtprintsupport-${QTMIN}:5
 	>=dev-qt/qtsql-${QTMIN}:5[mysql?]

--- a/media-gfx/krita/krita-4.2.8.2-r3.ebuild
+++ b/media-gfx/krita/krita-4.2.8.2-r3.ebuild
@@ -39,7 +39,7 @@ RDEPEND="${PYTHON_DEPS}
 	>=dev-qt/qtconcurrent-${QTMIN}:5
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtdeclarative-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5=[-gles2]
+	>=dev-qt/qtgui-${QTMIN}:5=[-gles2-only]
 	>=dev-qt/qtnetwork-${QTMIN}:5
 	>=dev-qt/qtprintsupport-${QTMIN}:5
 	>=dev-qt/qtsvg-${QTMIN}:5

--- a/media-gfx/openscad/openscad-2015.03_p3-r2.ebuild
+++ b/media-gfx/openscad/openscad-2015.03_p3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -28,7 +28,7 @@ DEPEND="
 	dev-libs/mpfr:0=
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
-	dev-qt/qtgui:5[-gles2]
+	dev-qt/qtgui:5[-gles2-only]
 	dev-qt/qtopengl:5
 	media-gfx/opencsg
 	media-libs/fontconfig:1.0

--- a/media-gfx/openscad/openscad-2019.05-r2.ebuild
+++ b/media-gfx/openscad/openscad-2019.05-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -34,7 +34,7 @@ RDEPEND="
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5
-	dev-qt/qtgui:5[-gles2]
+	dev-qt/qtgui:5[-gles2-only]
 	dev-qt/qtmultimedia:5
 	dev-qt/qtnetwork:5
 	dev-qt/qtopengl:5

--- a/media-gfx/openscad/openscad-9999.ebuild
+++ b/media-gfx/openscad/openscad-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -26,8 +26,8 @@ DEPEND="
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5
-	dev-qt/qtgui:5[-gles2]
-	dev-qt/qtmultimedia:5[-gles2]
+	dev-qt/qtgui:5[-gles2-only]
+	dev-qt/qtmultimedia:5[-gles2-only]
 	dev-qt/qtopengl:5
 	media-gfx/opencsg
 	media-libs/fontconfig:1.0

--- a/media-sound/fmit/fmit-1.0.15-r3.ebuild
+++ b/media-sound/fmit/fmit-1.0.15-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,7 +16,7 @@ IUSE="alsa jack oss portaudio"
 
 RDEPEND="
 	dev-qt/qtcore:5
-	dev-qt/qtgui:5[-gles2]
+	dev-qt/qtgui:5[-gles2-only]
 	dev-qt/qtmultimedia:5
 	dev-qt/qtopengl:5
 	dev-qt/qtsvg:5

--- a/media-sound/qmmp/qmmp-1.3.2-r1.ebuild
+++ b/media-sound/qmmp/qmmp-1.3.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -73,7 +73,7 @@ RDEPEND="
 	musepack? ( >=media-sound/musepack-tools-444 )
 	opus? ( media-libs/opusfile )
 	projectm? (
-		dev-qt/qtgui:5[-gles2]
+		dev-qt/qtgui:5[-gles2-only]
 		dev-qt/qtopengl:5
 		media-libs/libprojectm:=
 	)

--- a/media-sound/qmmp/qmmp-1.3.5-r1.ebuild
+++ b/media-sound/qmmp/qmmp-1.3.5-r1.ebuild
@@ -72,7 +72,7 @@ RDEPEND="
 	musepack? ( >=media-sound/musepack-tools-444 )
 	opus? ( media-libs/opusfile )
 	projectm? (
-		dev-qt/qtgui:5[-gles2]
+		dev-qt/qtgui:5[-gles2-only]
 		dev-qt/qtopengl:5
 		media-libs/libprojectm:=
 	)

--- a/media-sound/qmmp/qmmp-1.3.6-r1.ebuild
+++ b/media-sound/qmmp/qmmp-1.3.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -72,7 +72,7 @@ RDEPEND="
 	musepack? ( >=media-sound/musepack-tools-444 )
 	opus? ( media-libs/opusfile )
 	projectm? (
-		dev-qt/qtgui:5[-gles2]
+		dev-qt/qtgui:5[-gles2-only]
 		dev-qt/qtopengl:5
 		media-libs/libprojectm:=
 	)

--- a/media-sound/qmmp/qmmp-9999.ebuild
+++ b/media-sound/qmmp/qmmp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -72,7 +72,7 @@ RDEPEND="
 	musepack? ( >=media-sound/musepack-tools-444 )
 	opus? ( media-libs/opusfile )
 	projectm? (
-		dev-qt/qtgui:5[-gles2]
+		dev-qt/qtgui:5[-gles2-only]
 		dev-qt/qtopengl:5
 		media-libs/libprojectm:=
 	)

--- a/profiles/targets/desktop/package.use.mask
+++ b/profiles/targets/desktop/package.use.mask
@@ -1,20 +1,20 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# USE=gles2 in the following packages disables full OpenGL
+# USE=gles2-only disables full OpenGL
 # Upstream does not test for that case and packages frequently
 # fail to build or run if set.
-dev-python/PyQt5 gles2
-dev-qt/qt3d gles2
-dev-qt/qtdatavis3d gles2
-dev-qt/qtdeclarative gles2
-dev-qt/qtgui gles2
-dev-qt/qtmultimedia gles2
-dev-qt/qtopengl gles2
-dev-qt/qtprintsupport gles2
-dev-qt/qtwebkit gles2
-dev-qt/qtwidgets gles2
-kde-apps/kdenlive gles2
-kde-frameworks/plasma gles2
-kde-plasma/kinfocenter gles2
-kde-plasma/kwin gles2
+dev-python/PyQt5 gles2-only
+dev-qt/qt3d gles2-only
+dev-qt/qtdatavis3d gles2-only
+dev-qt/qtdeclarative gles2-only
+dev-qt/qtgui gles2-only
+dev-qt/qtmultimedia gles2-only
+dev-qt/qtopengl gles2-only
+dev-qt/qtprintsupport gles2-only
+dev-qt/qtwebkit gles2-only
+dev-qt/qtwidgets gles2-only
+kde-apps/kdenlive gles2-only
+kde-frameworks/plasma gles2-only
+kde-plasma/kinfocenter gles2-only
+kde-plasma/kwin gles2-only

--- a/sci-visualization/paraview/paraview-5.6.1-r2.ebuild
+++ b/sci-visualization/paraview/paraview-5.6.1-r2.ebuild
@@ -52,7 +52,7 @@ RDEPEND="
 	coprocessing? (
 		plugins? (
 			dev-python/PyQt5
-			dev-qt/qtgui:5[-gles2]
+			dev-qt/qtgui:5[-gles2-only]
 		)
 	)
 	ffmpeg? ( virtual/ffmpeg )
@@ -78,9 +78,9 @@ RDEPEND="
 	)
 	qt5? (
 		dev-qt/designer:5
-		dev-qt/qtgui:5[-gles2]
+		dev-qt/qtgui:5[-gles2-only]
 		dev-qt/qthelp:5
-		dev-qt/qtopengl:5[-gles2]
+		dev-qt/qtopengl:5[-gles2-only]
 		dev-qt/qtsql:5
 		dev-qt/qttest:5
 		dev-qt/qtwebengine:5[widgets]

--- a/sci-visualization/paraview/paraview-5.8.0-r1.ebuild
+++ b/sci-visualization/paraview/paraview-5.8.0-r1.ebuild
@@ -53,7 +53,7 @@ RDEPEND="
 	coprocessing? (
 		plugins? (
 			dev-python/PyQt5
-			dev-qt/qtgui:5[-gles2]
+			dev-qt/qtgui:5[-gles2-only]
 		)
 	)
 	ffmpeg? ( virtual/ffmpeg )
@@ -79,9 +79,9 @@ RDEPEND="
 	)
 	qt5? (
 		dev-qt/designer:5
-		dev-qt/qtgui:5[-gles2]
+		dev-qt/qtgui:5[-gles2-only]
 		dev-qt/qthelp:5
-		dev-qt/qtopengl:5[-gles2]
+		dev-qt/qtopengl:5[-gles2-only]
 		dev-qt/qtsql:5
 		dev-qt/qttest:5
 		dev-qt/qtx11extras:5

--- a/www-plugins/freshplayerplugin/freshplayerplugin-0.3.9.ebuild
+++ b/www-plugins/freshplayerplugin/freshplayerplugin-0.3.9.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/i-rinat/freshplayerplugin"
 DESCRIPTION="PPAPI-host NPAPI-plugin adapter for flashplayer in npapi based browsers"
 SRC_URI="https://github.com/i-rinat/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 SLOT=0
-IUSE="gles2 jack libav libressl pulseaudio v4l vaapi vdpau"
+IUSE="gles2-only jack libav libressl pulseaudio v4l vaapi vdpau"
 
 KEYWORDS="amd64"
 
@@ -26,7 +26,8 @@ COMMON_DEPEND="
 	dev-libs/libevent:=[threads]
 	media-libs/alsa-lib:=
 	media-libs/freetype:2=
-	media-libs/mesa:=[egl,gles2?]
+	media-libs/mesa:=[egl]
+	gles2-only? ( media-libs/mesa[gles2] )
 	x11-libs/cairo:=[X]
 	x11-libs/libXcursor:=
 	x11-libs/libXrandr:=
@@ -65,7 +66,7 @@ src_configure() {
 	mycmakeargs=(
 		-DWITH_JACK=$(usex jack)
 		-DWITH_PULSEAUDIO=$(usex pulseaudio)
-		-DWITH_GLES2=$(usex gles2)
+		-DWITH_GLES2=$(usex gles2-only)
 		-DWITH_LIBV4L2=$(usex v4l)
 		-DCMAKE_SKIP_RPATH=1
 	)

--- a/www-plugins/freshplayerplugin/metadata.xml
+++ b/www-plugins/freshplayerplugin/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<!--maintainer-needed-->
 	<use>
-		<flag name="gles2">Use system GLESv2 libraries instead of ANGLE for shader translation</flag>
+		<flag name="gles2-only">Use system GLESv2 libraries instead of ANGLE for shader translation</flag>
 		<flag name="v4l">Use libv4l2 for colorspace conversion</flag>
 	</use>
 	<upstream>

--- a/www-plugins/lightspark/lightspark-0.8.2.ebuild
+++ b/www-plugins/lightspark/lightspark-0.8.2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/lightspark/lightspark/archive/${PV}.tar.gz -> ${P}.t
 LICENSE="LGPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="cpu_flags_x86_sse2 curl ffmpeg gles libav nsplugin ppapi profile rtmp"
+IUSE="cpu_flags_x86_sse2 curl ffmpeg gles2-only libav nsplugin ppapi profile rtmp"
 
 # Note: no LLVM since it's broken upstream
 RDEPEND="app-arch/xz-utils:0=
@@ -34,8 +34,8 @@ RDEPEND="app-arch/xz-utils:0=
 		libav? ( <media-video/libav-13_pre:0= )
 		!libav? ( media-video/ffmpeg:0= )
 	)
-	gles? ( media-libs/mesa:0=[gles2] )
-	!gles? (
+	gles2-only? ( media-libs/mesa:0=[gles2] )
+	!gles2-only? (
 		>=media-libs/glew-1.5.3:0=
 		virtual/opengl:0=
 	)
@@ -50,7 +50,7 @@ S=${WORKDIR}/${P/_rc*/}
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_CURL=$(usex curl)
-		-DENABLE_GLES2=$(usex gles)
+		-DENABLE_GLES2=$(usex gles2-only)
 		-DENABLE_LIBAVCODEC=$(usex ffmpeg)
 		-DENABLE_RTMP=$(usex rtmp)
 

--- a/www-plugins/lightspark/metadata.xml
+++ b/www-plugins/lightspark/metadata.xml
@@ -10,7 +10,7 @@
 		<name>Michał Górny</name>
 	</maintainer>
 	<use>
-		<flag name="gles">Replace default OpenGL renderer with GLESv2</flag>
+		<flag name="gles2-only">Replace default OpenGL renderer with GLESv2</flag>
 		<flag name="ppapi">Install the PPAPI plugin (for Chromium)</flag>
 		<flag name="rtmp">Enable Real Time Messaging Protocol using librtmp</flag>
 	</use>


### PR DESCRIPTION
Notes:
- Commits aren't strictly atomic because of the dependency graph, can fix if needed
- It seems that `sci-libs/opencascade:gles2` is actually about adding support for GLES

Related: https://bugs.gentoo.org/627758
Related: https://archives.gentoo.org/gentoo-dev/message/ab302ac2ab641b1e82acad7d32308266