### PR TITLE
app-emulation/libpod: Add missing seccomp.json and crun runtime dep

### DIFF
--- a/app-emulation/libpod/libpod-1.6.3-r1.ebuild
+++ b/app-emulation/libpod/libpod-1.6.3-r1.ebuild
@@ -21,7 +21,7 @@ RESTRICT="test"
 COMMON_DEPEND="
 	app-crypt/gpgme:=
 	>=app-emulation/conmon-2.0.0
-	>=app-emulation/runc-1.0.0_rc6
+	|| ( >=app-emulation/runc-1.0.0_rc6 app-emulation/crun )
 	dev-libs/libassuan:=
 	dev-libs/libgpg-error:=
 	sys-fs/lvm2
@@ -92,6 +92,9 @@ src_install() {
 	insinto /etc/containers
 	newins test/registries.conf registries.conf.example
 	newins test/policy.json policy.json.example
+
+	insinto /usr/share/containers
+	doins seccomp.json
 
 	newinitd "${FILESDIR}"/podman.initd podman
 


### PR DESCRIPTION
seccomp.json needs to be installed in /usr/share/containers and will be used by libpod as well as buildah. Without it, some containers will not work due to seccomp usage that is otherwise blocked.

Fedora has switched to crun as the default container runtime. At the moment it is the only runtime that supports CGroup v2 which in-turn greatly helps with rootless mode. Support crun as an alternative to
the runc dependency.