### PR TITLE
sys-libs/libcxx-9.0.0: fix error when compiling with clang+compiler-rt

### DIFF
--- a/sys-libs/libcxx/libcxx-9.0.0.ebuild
+++ b/sys-libs/libcxx/libcxx-9.0.0.ebuild
@@ -93,7 +93,7 @@ src_configure() {
 multilib_src_configure() {
 	# we want -lgcc_s for unwinder, and for compiler runtime when using
 	# gcc, clang with gcc runtime (or any unknown compiler)
-	local extra_libs=() want_gcc_s=ON
+	local extra_libs=() want_gcc_s=ON want_compiler_rt=OFF
 	if use libunwind; then
 		# work-around missing -lunwind upstream
 		extra_libs+=( -lunwind )
@@ -104,6 +104,7 @@ multilib_src_configure() {
 			   ${LDFLAGS} -print-libgcc-file-name)
 			if [[ ${compiler_rt} == *libclang_rt* ]]; then
 				want_gcc_s=OFF
+				want_compiler_rt=ON
 				extra_libs+=( "${compiler_rt}" )
 			fi
 		fi
@@ -130,6 +131,7 @@ multilib_src_configure() {
 		-DLIBCXX_HAS_MUSL_LIBC=$(usex elibc_musl)
 		-DLIBCXX_HAS_GCC_S_LIB=${want_gcc_s}
 		-DLIBCXX_INCLUDE_TESTS=$(usex test)
+		-DLIBCXX_USE_COMPILER_RT=${want_compiler_rt}
 		-DCMAKE_SHARED_LINKER_FLAGS="${extra_libs[*]} ${LDFLAGS}"
 	)
 

--- a/sys-libs/libcxxabi/libcxxabi-9.0.0.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-9.0.0.ebuild
@@ -45,6 +45,18 @@ pkg_setup() {
 }
 
 multilib_src_configure() {
+	# link against compiler-rt instead of libgcc if we are using clang with libunwind
+	local want_compiler_rt=OFF
+	if use libunwind; then
+		if tc-is-clang; then
+			local compiler_rt=$($(tc-getCC) ${CFLAGS} ${CPPFLAGS} \
+			   ${LDFLAGS} -print-libgcc-file-name)
+			if [[ ${compiler_rt} == *libclang_rt* ]]; then
+				want_compiler_rt=ON
+			fi
+		fi
+	fi
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
 		-DLIBCXXABI_LIBDIR_SUFFIX=${libdir#lib}
@@ -52,6 +64,7 @@ multilib_src_configure() {
 		-DLIBCXXABI_ENABLE_STATIC=$(usex static-libs)
 		-DLIBCXXABI_USE_LLVM_UNWINDER=$(usex libunwind)
 		-DLIBCXXABI_INCLUDE_TESTS=$(usex test)
+		-DLIBCXXABI_USE_COMPILER_RT=${want_compiler_rt}
 
 		-DLIBCXXABI_LIBCXX_INCLUDES="${WORKDIR}"/libcxx/include
 		# upstream is omitting standard search path for this


### PR DESCRIPTION
According to https://clang.llvm.org/docs/Toolchain.html#compiler-rt-llvm, `-DLIBCXX_USE_COMPILER_RT=YES` and `-DLIBCXXABI_USE_COMPILER_RT=YES` are explicitly needed to compile with clang+compiler-rt.

Otherwise libcxx will fail to build due to error like:
undefined reference to '__udivdi3'