### PR TITLE
app-emulation/libvirt-9999: build out of tree

### DIFF
--- a/app-emulation/libvirt/libvirt-5.2.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-5.2.0-r2.ebuild
@@ -341,6 +341,9 @@ src_install() {
 	rm -rf "${D}"/etc/sysconfig
 	rm -rf "${D}"/var
 
+	newbashcomp "${S}/tools/bash-completion/vsh" virsh
+	bashcomp_alias virsh virt-admin
+
 	use libvirtd || return 0
 	# From here, only libvirtd-related instructions, be warned!
 
@@ -356,9 +359,6 @@ src_install() {
 
 	newconfd "${FILESDIR}/libvirtd.confd-r5" libvirtd || die
 	newconfd "${FILESDIR}/libvirt-guests.confd" libvirt-guests || die
-
-	newbashcomp "${S}/tools/bash-completion/vsh" virsh
-	bashcomp_alias virsh virt-admin
 
 	DOC_CONTENTS=$(<"${FILESDIR}/README.gentoo-r2")
 	DISABLE_AUTOFORMATTING=true

--- a/app-emulation/libvirt/libvirt-5.5.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-5.5.0-r1.ebuild
@@ -336,6 +336,9 @@ src_install() {
 	rm -rf "${D}"/etc/sysconfig
 	rm -rf "${D}"/var
 
+	newbashcomp "${S}/tools/bash-completion/vsh" virsh
+	bashcomp_alias virsh virt-admin
+
 	use libvirtd || return 0
 	# From here, only libvirtd-related instructions, be warned!
 
@@ -351,9 +354,6 @@ src_install() {
 
 	newconfd "${FILESDIR}/libvirtd.confd-r5" libvirtd || die
 	newconfd "${FILESDIR}/libvirt-guests.confd" libvirt-guests || die
-
-	newbashcomp "${S}/tools/bash-completion/vsh" virsh
-	bashcomp_alias virsh virt-admin
 
 	DOC_CONTENTS=$(<"${FILESDIR}/README.gentoo-r2")
 	DISABLE_AUTOFORMATTING=true

--- a/app-emulation/libvirt/libvirt-5.6.0.ebuild
+++ b/app-emulation/libvirt/libvirt-5.6.0.ebuild
@@ -336,6 +336,9 @@ src_install() {
 	rm -rf "${D}"/etc/sysconfig
 	rm -rf "${D}"/var
 
+	newbashcomp "${S}/tools/bash-completion/vsh" virsh
+	bashcomp_alias virsh virt-admin
+
 	use libvirtd || return 0
 	# From here, only libvirtd-related instructions, be warned!
 
@@ -351,9 +354,6 @@ src_install() {
 
 	newconfd "${FILESDIR}/libvirtd.confd-r5" libvirtd || die
 	newconfd "${FILESDIR}/libvirt-guests.confd" libvirt-guests || die
-
-	newbashcomp "${S}/tools/bash-completion/vsh" virsh
-	bashcomp_alias virsh virt-admin
 
 	DOC_CONTENTS=$(<"${FILESDIR}/README.gentoo-r2")
 	DISABLE_AUTOFORMATTING=true

--- a/app-emulation/libvirt/libvirt-5.8.0.ebuild
+++ b/app-emulation/libvirt/libvirt-5.8.0.ebuild
@@ -340,6 +340,9 @@ src_install() {
 	rm -rf "${D}"/var
 	rm -rf "${D}"/run
 
+	newbashcomp "${S}/tools/bash-completion/vsh" virsh
+	bashcomp_alias virsh virt-admin
+
 	use libvirtd || return 0
 	# From here, only libvirtd-related instructions, be warned!
 
@@ -355,9 +358,6 @@ src_install() {
 
 	newconfd "${FILESDIR}/libvirtd.confd-r5" libvirtd || die
 	newconfd "${FILESDIR}/libvirt-guests.confd" libvirt-guests || die
-
-	newbashcomp "${S}/tools/bash-completion/vsh" virsh
-	bashcomp_alias virsh virt-admin
 
 	DOC_CONTENTS=$(<"${FILESDIR}/README.gentoo-r2")
 	DISABLE_AUTOFORMATTING=true

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -337,6 +337,9 @@ src_install() {
 	rm -rf "${D}"/etc/sysconfig
 	rm -rf "${D}"/var
 
+	newbashcomp "${S}/tools/bash-completion/vsh" virsh
+	bashcomp_alias virsh virt-admin
+
 	use libvirtd || return 0
 	# From here, only libvirtd-related instructions, be warned!
 
@@ -352,9 +355,6 @@ src_install() {
 
 	newconfd "${FILESDIR}/libvirtd.confd-r5" libvirtd || die
 	newconfd "${FILESDIR}/libvirt-guests.confd" libvirt-guests || die
-
-	newbashcomp "${S}/tools/bash-completion/vsh" virsh
-	bashcomp_alias virsh virt-admin
 
 	DOC_CONTENTS=$(<"${FILESDIR}/README.gentoo-r2")
 	DISABLE_AUTOFORMATTING=true

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{5,6,7} )
 
-inherit autotools bash-completion-r1 eutils linux-info python-any-r1 readme.gentoo-r1 systemd
+inherit autotools out-of-source bash-completion-r1 eutils linux-info python-any-r1 readme.gentoo-r1 systemd
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
@@ -239,7 +239,7 @@ src_prepare() {
 	eautoreconf
 }
 
-src_configure() {
+my_src_configure() {
 	local myeconfargs=(
 		$(use_with apparmor)
 		$(use_with apparmor apparmor-profiles)
@@ -295,6 +295,7 @@ src_configure() {
 		--disable-werror
 
 		--localstatedir=/var
+		--enable-dependency-tracking
 	)
 
 	if use virtualbox && has_version app-emulation/virtualbox-ose; then
@@ -308,13 +309,11 @@ src_configure() {
 	if [[ ${PV} = *9999* ]]; then
 		# Restore gnulib's config.sub and config.guess
 		# bug #377279
-		(cd .gnulib && git reset --hard > /dev/null)
+		(cd ${S}/.gnulib && git reset --hard > /dev/null)
 	fi
 }
 
-src_test() {
-	cd "${BUILD_DIR}"
-
+my_src_test() {
 	# remove problematic tests, bug #591416, bug #591418
 	sed -i -e 's#commandtest$(EXEEXT) # #' \
 		-e 's#virfirewalltest$(EXEEXT) # #' \
@@ -326,7 +325,7 @@ src_test() {
 	HOME="${T}" emake check || die "tests failed"
 }
 
-src_install() {
+my_src_install() {
 	emake DESTDIR="${D}" \
 		SYSTEMD_UNIT_DIR="$(systemd_get_systemunitdir)" install
 

--- a/app-emulation/libvirt/metadata.xml
+++ b/app-emulation/libvirt/metadata.xml
@@ -76,9 +76,7 @@
 	</flag>
 	<flag name="macvtap">
 		Support for MAC-based TAP (macvlan/macvtap). For networking instead
-		of the normal TUN/TAP. It has its advantages and disadvantages.
-		macvtap support requires very new kernels and is
-		currently evolving. Support for this is experimental at best.
+		of the normal TUN/TAP.
 	</flag>
 	<flag name="vepa">Virtual Ethernet Port Aggregator (VEPA) / 802.1Qbg
 		support. Relies on macvtap support.</flag>


### PR DESCRIPTION
Libvirt forbade in tree builds in preparation to switch to meson:

https://libvirt.org/git/?p=libvirt.git;a=commitdiff;h=f96395e78eaccffbf128336382c74b1250f04032