### PR TITLE
net-im/signal-desktop-bin: fix permissions for installed files

### DIFF
--- a/net-im/signal-desktop-bin/signal-desktop-bin-1.28.0.ebuild
+++ b/net-im/signal-desktop-bin/signal-desktop-bin-1.28.0.ebuild
@@ -49,8 +49,8 @@ src_install() {
 	insinto /usr/share
 	doins -r usr/share/applications
 	doins -r usr/share/icons
-	fperms +x /opt/Signal/signal-desktop
-	pax-mark m opt/Signal/signal-desktop
+	fperms +x /opt/Signal/signal-desktop /opt/Signal/chrome-sandbox
+	pax-mark m opt/Signal/signal-desktop /opt/Signal/chrome-sandbox
 
 	dosym ../../opt/Signal/${MY_PN} /usr/bin/${MY_PN}
 	dosym ../../usr/lib64/libEGL.so opt/Signal/libEGL.so


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/700758

Signed-off-by: Robert Siebeck <gentoo.2019@r123.de>