### PR TITLE
net-misc/asterisk-core-sounds: blocker against old asterisk-extra-sounds

### DIFF
--- a/net-misc/asterisk-core-sounds/asterisk-core-sounds-1.6.1.ebuild
+++ b/net-misc/asterisk-core-sounds/asterisk-core-sounds-1.6.1.ebuild
@@ -29,6 +29,8 @@ KEYWORDS="~amd64 ~ppc ~x86"
 
 S="${WORKDIR}"
 
+RDEPEND="!<net-misc/asterisk-extra-sounds-1.5.2"
+
 src_unpack() {
 	local ar
 	local c


### PR DESCRIPTION
Package-Manager: Portage-2.3.79, Repoman-2.3.16
Signed-off-by: Jaco Kroon <jaco@uls.co.za>
Closes: https://bugs.gentoo.org/701348