### PR TITLE
dev-lang/erlang: introduce subslots

### DIFF
--- a/dev-erlang/ezlib/ezlib-1.0.2.ebuild
+++ b/dev-erlang/ezlib/ezlib-1.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~ia64 ppc ~sparc x86"
 
-DEPEND=">=dev-lang/erlang-17.1
+DEPEND=">=dev-lang/erlang-17.1:=
 	sys-libs/zlib"
 RDEPEND="${DEPEND}"
 

--- a/dev-erlang/ezlib/ezlib-1.0.6.ebuild
+++ b/dev-erlang/ezlib/ezlib-1.0.6.ebuild
@@ -14,7 +14,7 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~sparc ~x86"
 
-DEPEND=">=dev-lang/erlang-17.1
+DEPEND=">=dev-lang/erlang-17.1:=
 	sys-libs/zlib"
 RDEPEND="${DEPEND}"
 

--- a/dev-erlang/fast_tls/fast_tls-1.0.26.ebuild
+++ b/dev-erlang/fast_tls/fast_tls-1.0.26.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="amd64 ~arm ~ia64 ppc ~sparc x86"
 IUSE="libressl"
 
 DEPEND=">=dev-erlang/p1_utils-1.0.13
-	>=dev-lang/erlang-17.1
+	>=dev-lang/erlang-17.1:=
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )"
 RDEPEND="${DEPEND}"

--- a/dev-erlang/fast_tls/fast_tls-1.1.2.ebuild
+++ b/dev-erlang/fast_tls/fast_tls-1.1.2.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~sparc ~x86"
 IUSE="libressl"
 
 DEPEND=">=dev-erlang/p1_utils-1.0.16
-	>=dev-lang/erlang-17.1
+	>=dev-lang/erlang-17.1:=
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )"
 RDEPEND="${DEPEND}"

--- a/dev-erlang/p1_utils/p1_utils-1.0.13.ebuild
+++ b/dev-erlang/p1_utils/p1_utils-1.0.13.ebuild
@@ -14,7 +14,7 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~ia64 ppc ppc64 sparc x86"
 
-DEPEND=">=dev-lang/erlang-17.1"
+DEPEND=">=dev-lang/erlang-17.1:="
 RDEPEND="${DEPEND}"
 
 DOCS=( CHANGELOG.md  README.md )

--- a/dev-erlang/p1_utils/p1_utils-1.0.16.ebuild
+++ b/dev-erlang/p1_utils/p1_utils-1.0.16.ebuild
@@ -14,7 +14,7 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 
-DEPEND=">=dev-lang/erlang-17.1"
+DEPEND=">=dev-lang/erlang-17.1:="
 RDEPEND="${DEPEND}"
 
 DOCS=( CHANGELOG.md README.md )

--- a/dev-erlang/proper/proper-1.2.ebuild
+++ b/dev-erlang/proper/proper-1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~ia64 ppc ~sparc x86"
 
-DEPEND=">=dev-lang/erlang-17.1"
+DEPEND=">=dev-lang/erlang-17.1:="
 RDEPEND="${DEPEND}"
 
 DOCS=( README.md THANKS )

--- a/dev-erlang/proper/proper-1.3.ebuild
+++ b/dev-erlang/proper/proper-1.3.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~ia64 ppc ~sparc x86"
 
-DEPEND=">=dev-lang/erlang-17.1"
+DEPEND=">=dev-lang/erlang-17.1:="
 RDEPEND="${DEPEND}"
 
 DOCS=( README.md THANKS )

--- a/dev-lang/erlang/erlang-21.1.1.ebuild
+++ b/dev-lang/erlang/erlang-21.1.1.ebuild
@@ -18,7 +18,10 @@ SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"
 
 LICENSE="Apache-2.0"
-SLOT="0"
+# We use this subslot because Compiled HiPE Code can be loaded on the exact
+# same build of ERTS that was used when compiling the code.  See
+# http://erlang.org/doc/system_principles/misc.html for more information.
+SLOT="0/${PV}"
 KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
 IUSE="doc emacs +hipe java +kpoll libressl odbc pgo sctp ssl systemd tk wxwidgets"
 

--- a/dev-lang/erlang/erlang-22.1.1.ebuild
+++ b/dev-lang/erlang/erlang-22.1.1.ebuild
@@ -18,7 +18,10 @@ SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"
 
 LICENSE="Apache-2.0"
-SLOT="0"
+# We use this subslot because Compiled HiPE Code can be loaded on the exact
+# same build of ERTS that was used when compiling the code.  See
+# http://erlang.org/doc/system_principles/misc.html for more information.
+SLOT="0/${PV}"
 KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
 IUSE="doc emacs +hipe java +kpoll libressl odbc sctp ssl systemd tk wxwidgets"
 

--- a/dev-lang/erlang/erlang-22.1.4.ebuild
+++ b/dev-lang/erlang/erlang-22.1.4.ebuild
@@ -18,7 +18,10 @@ SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"
 
 LICENSE="Apache-2.0"
-SLOT="0"
+# We use this subslot because Compiled HiPE Code can be loaded on the exact
+# same build of ERTS that was used when compiling the code.  See
+# http://erlang.org/doc/system_principles/misc.html for more information.
+SLOT="0/${PV}"
 KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
 IUSE="doc emacs +hipe java +kpoll libressl odbc sctp ssl systemd tk wxwidgets"
 

--- a/dev-lang/erlang/erlang-22.1.7.ebuild
+++ b/dev-lang/erlang/erlang-22.1.7.ebuild
@@ -18,7 +18,10 @@ SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"
 
 LICENSE="Apache-2.0"
-SLOT="0"
+# We use this subslot because Compiled HiPE Code can be loaded on the exact
+# same build of ERTS that was used when compiling the code.  See
+# http://erlang.org/doc/system_principles/misc.html for more information.
+SLOT="0/${PV}"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
 IUSE="doc emacs +hipe java +kpoll libressl odbc sctp ssl systemd tk wxwidgets"
 

--- a/dev-lang/erlang/erlang-22.1.8-r1.ebuild
+++ b/dev-lang/erlang/erlang-22.1.8-r1.ebuild
@@ -18,7 +18,10 @@ SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"
 
 LICENSE="Apache-2.0"
-SLOT="0"
+# We use this subslot because Compiled HiPE Code can be loaded on the exact
+# same build of ERTS that was used when compiling the code.  See
+# http://erlang.org/doc/system_principles/misc.html for more information.
+SLOT="0/${PV}"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
 IUSE="doc emacs +hipe java +kpoll libressl odbc sctp ssl systemd tk wxwidgets"
 

--- a/dev-lang/erlang/erlang-22.1.8.ebuild
+++ b/dev-lang/erlang/erlang-22.1.8.ebuild
@@ -18,7 +18,10 @@ SRC_URI="https://github.com/erlang/otp/archive/OTP-${PV}.tar.gz -> ${P}.tar.gz
 	doc? ( http://erlang.org/download/otp_doc_html_${UPSTREAM_V}.tar.gz -> ${PN}_doc_html_${UPSTREAM_V}.tar.gz )"
 
 LICENSE="Apache-2.0"
-SLOT="0"
+# We use this subslot because Compiled HiPE Code can be loaded on the exact
+# same build of ERTS that was used when compiling the code.  See
+# http://erlang.org/doc/system_principles/misc.html for more information.
+SLOT="0/${PV}"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris"
 IUSE="doc emacs +hipe java +kpoll libressl odbc sctp ssl systemd tk wxwidgets"
 

--- a/dev-util/rebar/rebar-2.6.4.ebuild
+++ b/dev-util/rebar/rebar-2.6.4.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="amd64 ~arm ~ia64 ppc ppc64 sparc x86"
 IUSE=""
 
-RDEPEND="dev-lang/erlang"
+RDEPEND="dev-lang/erlang:="
 DEPEND="${RDEPEND}"
 
 src_test() {


### PR DESCRIPTION
This PR introduces subslots in erlang and subscribes few packages to it.

I believe we should support subslots in erlang in similar fashion like `dev-lang/go` for example. I have chosen `0/${PV}` because time to time it happens that patch version fixes some bugs in compiler and therefore we want to recompile all erlang dependent packages.

Well, I am not sure if this is a correct way how to introduce subslots to any package, but I did not find any satisfactory guidelines. Please, tell me what do you think.