### PR TITLE
media-sound/spotify: remove gconf dependency

### DIFF
--- a/media-sound/spotify/spotify-1.1.10-r1.ebuild
+++ b/media-sound/spotify/spotify-1.1.10-r1.ebuild
@@ -20,7 +20,6 @@ RDEPEND="
 	dev-libs/nss
 	dev-python/dbus-python
 	dev-python/pygobject:3
-	gnome-base/gconf
 	libnotify? ( x11-libs/libnotify )
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )


### PR DESCRIPTION
It's actually not used anymore by the binary

Closes: https://bugs.gentoo.org/701438
Signed-off-by: Mathy Vanvoorden <mathy@vanvoorden.be>