### PR TITLE
net-misc/anydesk: add missing RDEPEND on sys-apps/pciutils.

### DIFF
--- a/net-misc/anydesk/anydesk-5.5.0.ebuild
+++ b/net-misc/anydesk/anydesk-5.5.0.ebuild
@@ -28,6 +28,7 @@ RDEPEND="
 	media-libs/freetype:2
 	media-libs/glu
 	media-libs/mesa[X(+)]
+	sys-apps/pciutils
 	sys-auth/polkit
 	x11-libs/cairo
 	x11-libs/gdk-pixbuf:2


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/701452
Package-Manager: Portage-2.3.79, Repoman-2.3.16
Signed-off-by: Jaco Kroon <jaco@uls.co.za>