### PR TITLE
dev-db/mongodb: prepare for arm64 keywording

### DIFF
--- a/dev-db/mongodb/mongodb-4.2.1.ebuild
+++ b/dev-db/mongodb/mongodb-4.2.1.ebuild
@@ -101,6 +101,7 @@ src_configure() {
 		--use-system-zstd
 	)
 
+	use arm64 && scons_opts+=( --use-hardware-crc32=off ) # Bug 701300
 	use debug && scons_opts+=( --dbg=on )
 	use kerberos && scons_opts+=( --use-sasl-client )
 	use lto && scons_opts+=( --lto=on )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/701300
Tested-by: Julian Weinert <julian@jweinert.de>
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>