### PR TITLE
net-mail/pflogsumm: add support for BDAT

### DIFF
--- a/net-mail/pflogsumm/files/pflogsumm-bdat.patch
+++ b/net-mail/pflogsumm/files/pflogsumm-bdat.patch
@@ -1,0 +1,13 @@
+diff --git a/pflogsumm.pl b/pflogsumm.pl
+index 31de5bd..b3bedf9 100755
+--- a/pflogsumm.pl
++++ b/pflogsumm.pl
+@@ -1650,7 +1650,7 @@ sub proc_smtpd_reject {
+     # Next: get the reject "reason"
+     $rejReas = $rejRmdr;
+     unless(defined($opts{'verbMsgDetail'})) {
+-	if($rejTyp eq "RCPT" || $rejTyp eq "DATA" || $rejTyp eq "CONNECT") {	# special treatment :-(
++	if($rejTyp eq "RCPT" || $rejTyp eq "DATA" || $rejTyp eq "BDAT" || $rejTyp eq "CONNECT") {	# special treatment :-(
+ 	    # If there are "<>"s immediately following the reject code, that's
+ 	    # an email address or HELO string.  There can be *anything* in
+ 	    # those--incl. stuff that'll screw up subsequent parsing.  So just

--- a/net-mail/pflogsumm/pflogsumm-1.1.5-r2.ebuild
+++ b/net-mail/pflogsumm/pflogsumm-1.1.5-r2.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Pflogsumm is a log analyzer for Postfix logs"
+HOMEPAGE="https://jimsun.linxnet.com/postfix_contrib.html"
+SRC_URI="https://jimsun.linxnet.com/downloads/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~sparc ~x86"
+
+RDEPEND="dev-lang/perl
+	dev-perl/Date-Calc"
+
+DOCS=( ChangeLog pflogsumm-faq.txt README ToDo )
+PATCHES=( "${FILESDIR}/${PN}-bdat.patch" ) # Bug 699976
+
+src_install() {
+	default
+	doman pflogsumm.1
+	dobin pflogsumm.pl
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/699976
Patch-by: Maxim Britov <ungift-ed@ya.ru>
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>