### PR TITLE
net-dns/dnssec-root: define dev-perl/XML-XPath as a build dep

### DIFF
--- a/net-dns/dnssec-root/dnssec-root-20181220.ebuild
+++ b/net-dns/dnssec-root/dnssec-root-20181220.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh ~s
 IUSE=""
 
 RDEPEND=""
-DEPEND=">=dev-perl/XML-XPath-1.420.0"
+BDEPEND=">=dev-perl/XML-XPath-1.420.0"
 
 src_unpack() {
 	mkdir "${S}" || die


### PR DESCRIPTION
xpath is needed on the build host rather the target

Bug: https://bugs.gentoo.org/701510
Package-Manager: Portage-2.3.79, Repoman-2.3.16