### PR TITLE
media-gfx/gimp: 9999.ebuild update

### DIFF
--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -2,10 +2,15 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python2_7 )
+PLOCALES="am ar ast az be bg br bs ca ca@valencia cs csb da de dz el en_CA en_GB eo
+	es et eu fa fi fr ga gd gl gu he hi hr hu id is it ja ka kk km kn ko ky
+	lt lv mk ml mr ms my nb nds ne nl nn oc pa pl pt pt_BR ro ru rw si sk sl
+	sr sr@latin sv ta te th tr tt uk vi xh yi zh_CN zh_HK zh_TW"
+
+PYTHON_COMPAT=( python3_{6,7} )
 GNOME2_EAUTORECONF=yes
 
-inherit virtualx autotools gnome2 multilib python-single-r1 git-r3
+inherit autotools git-r3 gnome2 l10n python-single-r1 virtualx
 
 DESCRIPTION="GNU Image Manipulation Program"
 HOMEPAGE="https://www.gimp.org/"
@@ -15,76 +20,94 @@ LICENSE="GPL-3 LGPL-3"
 SLOT="2"
 KEYWORDS=""
 
-LANGS="am ar ast az be bg br ca ca@valencia cs csb da de dz el en_CA en_GB eo es et eu fa fi fr ga gl gu he hi hr hu id is it ja ka kk km kn ko lt lv mk ml ms my nb nds ne nl nn oc pa pl pt pt_BR ro ru rw si sk sl sr sr@latin sv ta te th tr tt uk vi xh yi zh_CN zh_HK zh_TW"
-IUSE="alsa aalib altivec aqua debug doc openexr gnome heif postscript jpeg2k cpu_flags_x86_mmx mng python cpu_flags_x86_sse udev unwind vector-icons webp wmf xpm"
+IUSE="aalib alsa altivec aqua debug doc gnome heif javascript jpeg2k lua mng openexr postscript python udev unwind vector-icons webp wmf xpm cpu_flags_x86_mmx cpu_flags_x86_sse"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
-RDEPEND=">=dev-libs/glib-2.56.0:2
-	>=dev-libs/atk-2.2.0
-	>=x11-libs/gtk+-2.24.32:2
-	>=x11-libs/gdk-pixbuf-2.31:2
-	>=x11-libs/cairo-1.12.2
-	>=x11-libs/pango-1.29.4
-	xpm? ( x11-libs/libXpm )
-	>=media-libs/freetype-2.1.7
-	>=media-libs/harfbuzz-0.9.19
-	>=media-libs/gexiv2-0.10.6
-	>=media-libs/libmypaint-1.3.0:=
-	>=media-gfx/mypaint-brushes-1.3.0
-	>=media-libs/fontconfig-2.12.4
-	sys-libs/zlib
-	dev-libs/libxml2
-	dev-libs/libxslt
-	x11-themes/hicolor-icon-theme
-	>=media-libs/babl-0.1.66
-	>=media-libs/gegl-0.4.16:0.4[cairo]
-	aalib? ( media-libs/aalib )
-	alsa? ( media-libs/alsa-lib )
-	aqua? ( x11-libs/gtk-mac-integration )
-	gnome? ( gnome-base/gvfs )
-	virtual/jpeg:0
-	jpeg2k? ( >=media-libs/openjpeg-2.1.0:2= )
-	>=media-libs/lcms-2.8:2
-	mng? ( media-libs/libmng )
-	openexr? ( >=media-libs/openexr-1.6.1:= )
-	>=app-text/poppler-0.50[cairo]
-	>=app-text/poppler-data-0.4.7
-	>=media-libs/libpng-1.6.25:0=
-	python?	(
-		${PYTHON_DEPS}
-		>=dev-python/pygtk-2.10.4:2[${PYTHON_USEDEP}]
-		>=dev-python/pycairo-1.0.2[${PYTHON_USEDEP}]
-	)
-	>=media-libs/tiff-3.5.7:0
-	>=gnome-base/librsvg-2.40.6:2
-	webp? ( >=media-libs/libwebp-0.6.0 )
-	wmf? ( >=media-libs/libwmf-0.2.8 )
-	net-libs/glib-networking[ssl]
-	x11-libs/libXcursor
-	sys-libs/zlib
+RESTRICT="!test? ( test )"
+
+# media-libs/{babl,gegl} are required to be built with USE="introspection"
+# to fix the compilation checking of /usr/share/gir-1.0/{Babl-0.1gir,Gegl-0.4.gir}
+COMMON_DEPEND="
 	app-arch/bzip2
 	>=app-arch/xz-utils-5.0.0
+	>=app-text/poppler-0.69[cairo]
+	>=app-text/poppler-data-0.4.9
+	>=dev-libs/atk-2.4.0
+	>=dev-libs/glib-2.56.0:2
+	dev-libs/libxml2
+	dev-libs/libxslt
+	>=gnome-base/librsvg-2.40.6:2
+	>=media-gfx/mypaint-brushes-1.3.0
+	>=media-libs/babl-0.1.72[introspection]
+	>=media-libs/fontconfig-2.12.4
+	>=media-libs/freetype-2.1.7
+	>=media-libs/gegl-0.4.18:0.4[cairo,introspection]
+	>=media-libs/gexiv2-0.10.6
+	>=media-libs/harfbuzz-0.9.19
+	>=media-libs/lcms-2.8:2
+	>=media-libs/libmypaint-1.3.0:=
+	>=media-libs/libpng-1.6.25:0=
+	>=media-libs/tiff-3.5.7:0
+	net-libs/glib-networking[ssl]
+	sys-libs/zlib
+	virtual/jpeg:0
+	>=x11-libs/cairo-1.14.0
+	>=x11-libs/gdk-pixbuf-2.36:2
+	>=x11-libs/gtk+-3.22.29:3
+	x11-libs/libXcursor
+	>=x11-libs/pango-1.42.0
+	aalib? ( media-libs/aalib )
+	alsa? ( >=media-libs/alsa-lib-1.0.0 )
+	aqua? ( >=x11-libs/gtk-mac-integration-2.0.0 )
+	heif? ( >=media-libs/libheif-1.3.2:= )
+	javascript? ( dev-libs/gjs )
+	jpeg2k? ( >=media-libs/openjpeg-2.1.0:2= )
+	lua? ( dev-lang/luajit )
+	mng? ( media-libs/libmng:= )
+	openexr? ( >=media-libs/openexr-1.6.1:= )
 	postscript? ( app-text/ghostscript-gpl )
-	udev? ( dev-libs/libgudev:= )
-	unwind? ( sys-libs/libunwind:= )
-	heif? ( >=media-libs/libheif-1.1.0:= )"
-DEPEND="${RDEPEND}
+	python? (
+		${PYTHON_DEPS}
+		>=dev-python/pygobject-3.0:3[${PYTHON_USEDEP}]
+	)
+	udev? ( >=dev-libs/libgudev-167:= )
+	unwind? ( >=sys-libs/libunwind-1.1.0:= )
+	webp? ( >=media-libs/libwebp-0.6.0:= )
+	wmf? ( >=media-libs/libwmf-0.2.8 )
+	xpm? ( x11-libs/libXpm )
+"
+
+RDEPEND="
+	${COMMON_DEPEND}
+	x11-themes/hicolor-icon-theme
+	gnome? ( gnome-base/gvfs )
+"
+
+DEPEND="
+	${COMMON_DEPEND}
 	>=dev-lang/perl-5.10.0
-	dev-libs/appstream-glib
+	>=dev-libs/appstream-glib-0.7.7
 	dev-util/gdbus-codegen
 	dev-util/gtk-update-icon-cache
-	sys-apps/findutils
-	virtual/pkgconfig
 	>=dev-util/intltool-0.40.1
-	>=sys-devel/gettext-0.19
-	doc? ( >=dev-util/gtk-doc-1 )
-	>=sys-devel/libtool-2.2
+	sys-apps/findutils
 	>=sys-devel/autoconf-2.54
 	>=sys-devel/automake-1.11
-	dev-util/gtk-doc-am"
+	>=sys-devel/gettext-0.19
+	>=sys-devel/libtool-2.2
+	virtual/pkgconfig
+	doc? (
+		>=dev-util/gtk-doc-1.0
+		dev-util/gtk-doc-am
+	)
+"
 
-DOCS="AUTHORS ChangeLog* HACKING NEWS README*"
+DOCS=( "AUTHORS" "HACKING" "NEWS" "README" "README.i18n" )
 
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+# Bugs 685210 (and duplicate 691070)
+PATCHES=(
+	"${FILESDIR}/${PN}-2.10_fix_test-appdata.patch"
+)
 
 pkg_setup() {
 	if use python; then
@@ -95,6 +118,15 @@ pkg_setup() {
 src_prepare() {
 	sed -i -e 's/== "xquartz"/= "xquartz"/' configure.ac || die #494864
 	sed 's:-DGIMP_DISABLE_DEPRECATED:-DGIMP_protect_DISABLE_DEPRECATED:g' -i configure.ac || die #615144
+
+	# Fix checking of gtk-doc.make if USE="-doc" like autogen.sh
+	if ! use doc ; then
+		echo "EXTRA_DIST = missing-gtk-doc" > gtk-doc.make
+	fi
+
+	# Remove disabled locales
+	_rm_locale() { sed -i -e "/${1}/d" po/LINGUAS || die "Failed to remove disabled locales"; }
+	l10n_for_each_disabled_locale_do _rm_locale
 
 	gnome2_src_prepare  # calls eautoreconf
 
@@ -124,33 +156,35 @@ src_configure() {
 		GDBUS_CODEGEN="${EPREFIX}"/usr/bin/gdbus-codegen
 
 		--enable-default-binary
-		--disable-silent-rules
 
-		$(use_with !aqua x)
+		--enable-mp
+		--with-appdata-test
+		--with-bug-report-url=https://bugs.gentoo.org/
+		--with-xmc
+		--without-libbacktrace
+		--without-webkit
+		--without-xvfb-run
+		$(use_enable altivec)
+		$(use_enable cpu_flags_x86_mmx mmx)
+		$(use_enable cpu_flags_x86_sse sse)
+		$(use_enable doc gtk_doc)
+		$(use_enable vector-icons)
 		$(use_with aalib aa)
 		$(use_with alsa)
-		$(use_enable altivec)
-		--with-appdata-test
-		--without-libbacktrace
-		--with-bug-report-url=https://bugs.gentoo.org/
-		--without-webkit
+		$(use_with !aqua x)
+		$(use_with heif libheif)
+		$(use_with javascript)
 		$(use_with jpeg2k jpeg2000)
-		$(use_with postscript gs)
-		$(use_enable cpu_flags_x86_mmx mmx)
+		$(use_with lua)
 		$(use_with mng libmng)
 		$(use_with openexr)
-		$(use_with webp)
-		$(use_with heif libheif)
-		$(use_enable python)
-		--enable-mp
-		$(use_enable cpu_flags_x86_sse sse)
+		$(use_with postscript gs)
+		$(use_with python)
 		$(use_with udev gudev)
 		$(use_with unwind libunwind)
+		$(use_with webp)
 		$(use_with wmf)
-		--with-xmc
 		$(use_with xpm libxpm)
-		$(use_enable vector-icons)
-		--without-xvfb-run
 	)
 
 	gnome2_src_configure "${myconf[@]}"
@@ -159,18 +193,6 @@ src_configure() {
 src_compile() {
 	export XDG_DATA_DIRS="${EPREFIX}"/usr/share  # bug 587004
 	gnome2_src_compile
-}
-
-_clean_up_locales() {
-	[[ -z ${LINGUAS+set} ]] && return
-	einfo "Cleaning up locales..."
-	for lang in ${LANGS}; do
-		has ${lang} ${LINGUAS} && {
-			einfo "- keeping ${lang}"
-			continue
-		}
-		rm -Rf "${ED%/}"/usr/share/locale/"${lang}"
-	done
 }
 
 # for https://bugs.gentoo.org/664938
@@ -212,7 +234,6 @@ src_install() {
 	mv "${ED%/}"/usr/share/man/man1/gimp-console{-*,}.1 || die
 
 	_rename_plugins || die
-	_clean_up_locales
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Sync 9999.ebuild with 2.10.14.ebuild and update dependencies.

Live ebuild is now depends on x11-libs/gtk+:3.
The future 2.99.x release will be prepared with GTK+-3.

New USE-flags "javascript", "lua", "python" are added
to add support of this language scripts via gobject-introspection.
This is also repair 9999.ebuild and closes below mentioned bug.

Meson build script is still experimental. No migration to it this time.

Closes: https://bugs.gentoo.org/698730
