### PR TITLE
app-pda/jpilot: Fix paths with plugins on newest profile.

### DIFF
--- a/app-pda/jpilot/jpilot-1.8.2-r1.ebuild
+++ b/app-pda/jpilot/jpilot-1.8.2-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools
+
+DESCRIPTION="Desktop Organizer Software for the Palm Pilot"
+HOMEPAGE="http://www.jpilot.org/"
+SRC_URI="http://jpilot.org/tarballs/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 ~arm ia64 ppc ppc64 x86"
+IUSE="nls"
+
+RDEPEND="
+	app-pda/pilot-link
+	dev-libs/libgcrypt:0=
+	x11-libs/gtk+:2"
+DEPEND="${RDEPEND}
+	nls? (
+		dev-util/intltool
+		sys-devel/gettext
+	)
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.8.2-qa-desktop-file.patch
+	"${FILESDIR}"/${PN}-1.8.2-fix-paths.patch
+)
+
+src_prepare() {
+	default
+	sed -i -e 's|_UNQUOTED(ABILIB, "lib"|_UNQUOTED(ABILIB, "'$(get_libdir)'"|' configure.in
+	mv configure.{in,ac} || die
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable nls)
+}
+
+src_install() {
+	default
+	docompress -x /usr/share/doc/${PF}/icons
+
+	# .la files for plugins are useless
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/688098