### PR TITLE
app-metrics/{various}: add transitive licenses for go packages

### DIFF
--- a/app-emulation/cadvisor/cadvisor-0.34.0.ebuild
+++ b/app-emulation/cadvisor/cadvisor-0.34.0.ebuild
@@ -12,7 +12,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Analyzes resource usage and performance characteristics of running containers"
 HOMEPAGE="https://github.com/google/cadvisor"
 
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 ISC MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/alertmanager/alertmanager-0.18.0.ebuild
+++ b/app-metrics/alertmanager/alertmanager-0.18.0.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Alertmanager for alerts sent by client applications such as Prometheus"
 HOMEPAGE="https://github.com/prometheus/alertmanager"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT MPL-2.0"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/alertmanager/alertmanager-0.19.0.ebuild
+++ b/app-metrics/alertmanager/alertmanager-0.19.0.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Alertmanager for alerts sent by client applications such as Prometheus"
 HOMEPAGE="https://github.com/prometheus/alertmanager"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT MPL-2.0"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/bind_exporter/bind_exporter-0.2.0_p20190226.ebuild
+++ b/app-metrics/bind_exporter/bind_exporter-0.2.0_p20190226.ebuild
@@ -12,7 +12,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Prometheus exporter for BIND"
 HOMEPAGE="https://github.com/digitalocean/bind_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/blackbox_exporter/blackbox_exporter-0.15.1.ebuild
+++ b/app-metrics/blackbox_exporter/blackbox_exporter-0.15.1.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Prometheus exporter for blackbox probing via HTTP, HTTPS, DNS, TCP and ICMP"
 HOMEPAGE="https://github.com/prometheus/blackbox_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/blackbox_exporter/blackbox_exporter-0.16.0.ebuild
+++ b/app-metrics/blackbox_exporter/blackbox_exporter-0.16.0.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Prometheus exporter for blackbox probing via HTTP, HTTPS, DNS, TCP and ICMP"
 HOMEPAGE="https://github.com/prometheus/blackbox_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/burrow_exporter/burrow_exporter-0.0.6-r1.ebuild
+++ b/app-metrics/burrow_exporter/burrow_exporter-0.0.6-r1.ebuild
@@ -25,7 +25,7 @@ DESCRIPTION="Prometheus exporter for Burrow"
 HOMEPAGE="https://github.com/jirwin/burrow_exporter"
 SRC_URI="${ARCHIVE_URI}
 	${EGO_VENDOR_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/burrow_exporter/burrow_exporter-0.0.6.ebuild
+++ b/app-metrics/burrow_exporter/burrow_exporter-0.0.6.ebuild
@@ -25,7 +25,7 @@ DESCRIPTION="Prometheus exporter for Burrow"
 HOMEPAGE="https://github.com/jirwin/burrow_exporter"
 SRC_URI="${ARCHIVE_URI}
 	${EGO_VENDOR_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/consul_exporter/consul_exporter-0.4.0.ebuild
+++ b/app-metrics/consul_exporter/consul_exporter-0.4.0.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Prometheus exporter for consul metrics"
 HOMEPAGE="https://github.com/prometheus/consul_exporter"
 SRC_URI="https://${EGO_PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT MPL-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-metrics/elasticsearch_exporter/elasticsearch_exporter-1.0.2.ebuild
+++ b/app-metrics/elasticsearch_exporter/elasticsearch_exporter-1.0.2.ebuild
@@ -12,7 +12,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Elasticsearch stats exporter for Prometheus"
 HOMEPAGE="https://github.com/justwatchcom/elasticsearch_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/elasticsearch_exporter/elasticsearch_exporter-1.0.4_rc1.ebuild
+++ b/app-metrics/elasticsearch_exporter/elasticsearch_exporter-1.0.4_rc1.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Elasticsearch stats exporter for Prometheus"
 HOMEPAGE="https://github.com/justwatchcom/elasticsearch_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/elasticsearch_exporter/elasticsearch_exporter-1.1.0.ebuild
+++ b/app-metrics/elasticsearch_exporter/elasticsearch_exporter-1.1.0.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Elasticsearch stats exporter for Prometheus"
 HOMEPAGE="https://github.com/justwatchcom/elasticsearch_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/elasticsearch_exporter/elasticsearch_exporter-1.1.0_rc1.ebuild
+++ b/app-metrics/elasticsearch_exporter/elasticsearch_exporter-1.1.0_rc1.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Elasticsearch stats exporter for Prometheus"
 HOMEPAGE="https://github.com/justwatchcom/elasticsearch_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/github-exporter/github-exporter-04-r1.ebuild
+++ b/app-metrics/github-exporter/github-exporter-04-r1.ebuild
@@ -26,7 +26,7 @@ HOMEPAGE="https://github.com/infinityworks/github-exporter"
 SRC_URI="https://${EGO_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 	${EGO_VENDOR_URI}"
 
-LICENSE="MIT"
+LICENSE="MIT Apache-2.0 BSD"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-metrics/github-exporter/github-exporter-04.ebuild
+++ b/app-metrics/github-exporter/github-exporter-04.ebuild
@@ -26,7 +26,7 @@ HOMEPAGE="https://github.com/infinityworks/github-exporter"
 SRC_URI="https://${EGO_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 	${EGO_VENDOR_URI}"
 
-LICENSE="MIT"
+LICENSE="MIT Apache-2.0 BSD"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-metrics/grok_exporter/grok_exporter-0.2.6.ebuild
+++ b/app-metrics/grok_exporter/grok_exporter-0.2.6.ebuild
@@ -22,7 +22,7 @@ DESCRIPTION="Unstructured log data exporter for Prometheus"
 HOMEPAGE="https://github.com/fstab/Grok_exporter"
 SRC_URI="https://${EGO_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 	${EGO_VENDOR_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-metrics/memcached_exporter/memcached_exporter-0.5.0.ebuild
+++ b/app-metrics/memcached_exporter/memcached_exporter-0.5.0.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="Prometheus exporter for memcached"
 HOMEPAGE="https://github.com/prometheus/memcached_exporter"
 SRC_URI="https://${EGO_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-metrics/mongodb_exporter/mongodb_exporter-0.6.2-r1.ebuild
+++ b/app-metrics/mongodb_exporter/mongodb_exporter-0.6.2-r1.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Prometheus exporter for MongoDB"
 HOMEPAGE="https://github.com/percona/mongodb_exporter"
 SRC_URI="https://${EGO_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 AGPL-3 BSD MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-metrics/mysqld_exporter/mysqld_exporter-0.10.0-r1.ebuild
+++ b/app-metrics/mysqld_exporter/mysqld_exporter-0.10.0-r1.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Prometheus exporter for MySQL server metrics"
 HOMEPAGE="https://github.com/prometheus/mysqld_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT MPL-2.0"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/mysqld_exporter/mysqld_exporter-0.11.0.ebuild
+++ b/app-metrics/mysqld_exporter/mysqld_exporter-0.11.0.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Prometheus exporter for MySQL server metrics"
 HOMEPAGE="https://github.com/prometheus/mysqld_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT MPL-2.0"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/nginx-vts-exporter/nginx-vts-exporter-0.10.3.ebuild
+++ b/app-metrics/nginx-vts-exporter/nginx-vts-exporter-0.10.3.ebuild
@@ -12,7 +12,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Nginx virtual host traffic stats exporter for Prometheus"
 HOMEPAGE="https://github.com/hnlq715/nginx-vts-exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="MIT"
+LICENSE="MIT Apache-2.0 BSD"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/node_exporter/node_exporter-0.18.1.ebuild
+++ b/app-metrics/node_exporter/node_exporter-0.18.1.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="amd64"
 DESCRIPTION="Prometheus exporter for machine metrics"
 HOMEPAGE="https://github.com/prometheus/node_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/openvpn_exporter/openvpn_exporter-0.2.1.ebuild
+++ b/app-metrics/openvpn_exporter/openvpn_exporter-0.2.1.ebuild
@@ -23,7 +23,7 @@ DESCRIPTION="Prometheus Exporter for OpenVPN"
 HOMEPAGE="https://github.com/kumina/openvpn_exporter"
 SRC_URI="${ARCHIVE_URI}
 	${EGO_VENDOR_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/postfix_exporter/postfix_exporter-0.1.2.ebuild
+++ b/app-metrics/postfix_exporter/postfix_exporter-0.1.2.ebuild
@@ -23,7 +23,7 @@ DESCRIPTION="Prometheus Exporter for Postfix"
 HOMEPAGE="https://github.com/kumina/postfix_exporter"
 SRC_URI="${ARCHIVE_URI}
 	${EGO_VENDOR_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 IUSE="systemd"
 

--- a/app-metrics/postgres_exporter/postgres_exporter-0.4.7.ebuild
+++ b/app-metrics/postgres_exporter/postgres_exporter-0.4.7.ebuild
@@ -11,7 +11,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="PostgreSQL stats exporter for Prometheus"
 HOMEPAGE="https://github.com/wrouesnel/postgres_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/prometheus/prometheus-2.13.1.ebuild
+++ b/app-metrics/prometheus/prometheus-2.13.1.ebuild
@@ -12,7 +12,7 @@ KEYWORDS="amd64"
 DESCRIPTION="Prometheus monitoring system and time series database"
 HOMEPAGE="https://github.com/prometheus/prometheus"
 SRC_URI="https://${EGO_PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 ISC MIT MPL-2.0"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/rabbitmq_exporter/rabbitmq_exporter-0.29.0.ebuild
+++ b/app-metrics/rabbitmq_exporter/rabbitmq_exporter-0.29.0.ebuild
@@ -24,7 +24,7 @@ DESCRIPTION="Rabbitmq exporter for Prometheus"
 HOMEPAGE="https://github.com/kbudde/rabbitmq_exporter"
 SRC_URI="https://${EGO_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 	${EGO_VENDOR_URI}"
-LICENSE="Apache-2.0"
+LICENSE="MIT Apache-2.0 BSD"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/app-metrics/snmp_exporter/snmp_exporter-0.15.0.ebuild
+++ b/app-metrics/snmp_exporter/snmp_exporter-0.15.0.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Prometheus exporter for snmp metrics"
 HOMEPAGE="https://github.com/prometheus/snmp_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"
 IUSE=""
 

--- a/app-metrics/vault_exporter/vault_exporter-0.1.2.ebuild
+++ b/app-metrics/vault_exporter/vault_exporter-0.1.2.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64"
 DESCRIPTION="Vault exporter for Prometheus"
 HOMEPAGE="https://github.com/grapeshot/vault_exporter"
 SRC_URI="${ARCHIVE_URI}"
-LICENSE="Apache-2.0"
+LICENSE="Apache-2.0 BSD MIT MPL-2.0"
 SLOT="0"
 IUSE=""
 


### PR DESCRIPTION
This adds the required licenses of transitive dependencies to various go ebuilds.
Verified via go-licenses tool as described in https://bugs.gentoo.org/694792.

Bug: https://bugs.gentoo.org/695212
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
