### PR TITLE
arch/amd64: stable py3.7

### DIFF
--- a/dev-lang/python/python-3.7.5-r1.ebuild
+++ b/dev-lang/python/python-3.7.5-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://www.python.org/ftp/python/${PV}/${MY_P}.tar.xz
 
 LICENSE="PSF-2"
 SLOT="3.7/3.7m"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86"
 IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 

--- a/profiles/arch/amd64/use.stable.mask
+++ b/profiles/arch/amd64/use.stable.mask
@@ -9,9 +9,7 @@
 audacious
 
 # Mike Gilbert <floppym@gentoo.org> (2017-06-08)
-# dev-lang/python:3.7 is not stable.
-python_targets_python3_7
-python_single_target_python3_7
+# dev-lang/python:3.8 is not stable.
 python_targets_python3_8
 python_single_target_python3_8
 


### PR DESCRIPTION
Signed-off-by: Aaron Bauman <bman@gentoo.org>