### PR TITLE
net-fs/samba: Avoid python dep constraints when not building bindings

### DIFF
--- a/net-fs/samba/samba-4.10.10.ebuild
+++ b/net-fs/samba/samba-4.10.10.ebuild
@@ -55,9 +55,14 @@ CDEPEND="
 	sys-libs/libcap
 	sys-libs/ncurses:0=[${MULTILIB_USEDEP}]
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.1.16[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tdb-1.3.18[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tevent-0.9.39[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.1.16[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tdb-1.3.18[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tevent-0.9.39[python?,${MULTILIB_USEDEP}]
+	python? (
+		>=sys-libs/talloc-2.1.16[${PYTHON_USEDEP}]
+		>=sys-libs/tdb-1.3.18[${PYTHON_USEDEP}]
+		>=sys-libs/tevent-0.9.39[${PYTHON_USEDEP}]
+	)
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	pam? ( sys-libs/pam )

--- a/net-fs/samba/samba-4.11.2.ebuild
+++ b/net-fs/samba/samba-4.11.2.ebuild
@@ -57,9 +57,14 @@ CDEPEND="
 	sys-libs/libcap
 	sys-libs/ncurses:0=[${MULTILIB_USEDEP}]
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.2.0[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tdb-1.4.2[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tevent-0.10.0[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.2.0[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tdb-1.4.2[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tevent-0.10.0[python?,${MULTILIB_USEDEP}]
+	python? (
+		>=sys-libs/talloc-2.2.0[${PYTHON_USEDEP}]
+		>=sys-libs/tdb-1.4.2[${PYTHON_USEDEP}]
+		>=sys-libs/tevent-0.10.0[${PYTHON_USEDEP}]
+	)
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	pam? ( sys-libs/pam )

--- a/net-fs/samba/samba-4.8.12.ebuild
+++ b/net-fs/samba/samba-4.8.12.ebuild
@@ -55,9 +55,14 @@ CDEPEND="
 	sys-libs/libcap
 	sys-libs/ncurses:0=[${MULTILIB_USEDEP}]
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.1.11[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tdb-1.3.15[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tevent-0.9.36[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.1.11[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tdb-1.3.15[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tevent-0.9.36[python?,${MULTILIB_USEDEP}]
+	python? (
+		>=sys-libs/talloc-2.1.11[${PYTHON_USEDEP}]
+		>=sys-libs/tdb-1.3.15[${PYTHON_USEDEP}]
+		>=sys-libs/tevent-0.9.36[${PYTHON_USEDEP}]
+	)
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	pam? ( sys-libs/pam )

--- a/net-fs/samba/samba-4.9.16.ebuild
+++ b/net-fs/samba/samba-4.9.16.ebuild
@@ -55,9 +55,14 @@ CDEPEND="
 	sys-libs/libcap
 	sys-libs/ncurses:0=[${MULTILIB_USEDEP}]
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.1.14[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tdb-1.3.16[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
-	>=sys-libs/tevent-0.9.37[python?,${PYTHON_USEDEP},${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.1.14[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tdb-1.3.16[python?,${MULTILIB_USEDEP}]
+	>=sys-libs/tevent-0.9.37[python?,${MULTILIB_USEDEP}]
+	python? (
+		>=sys-libs/talloc-2.1.14[${PYTHON_USEDEP}]
+		>=sys-libs/tdb-1.3.16[${PYTHON_USEDEP}]
+		>=sys-libs/tevent-0.9.37[${PYTHON_USEDEP}]
+	)
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	pam? ( sys-libs/pam )


### PR DESCRIPTION
Samba uses a Python-based build system. If Python bindings are not being
built, the Python dependency is purely build-time and there's no reason
to propagate the python version constraint.