### PR TITLE
net-vpn/wireguard: make wg-quick optional

### DIFF
--- a/net-vpn/wireguard/metadata.xml
+++ b/net-vpn/wireguard/metadata.xml
@@ -6,9 +6,10 @@
 		<name>Jason A. Donenfeld</name>
 	</maintainer>
 	<use>
-		<flag name="tools">Compile the wg(8) tool and related helpers. You probably want this enabled.</flag>
+		<flag name="debug">Enable verbose debug reporting in dmesg of various WireGuard peer and device information.</flag>
 		<flag name="module">Compile the actual WireGuard kernel module. Most certainly you want this enabled, unless you're doing something strange.</flag>
 		<flag name="module-src">Install the module source code to /usr/src, in case you like building kernel modules yourself.</flag>
-		<flag name="debug">Enable verbose debug reporting in dmesg of various WireGuard peer and device information.</flag>
+		<flag name="tools">Compile the wg(8) tool and related helpers. You probably want this enabled.</flag>
+		<flag name="wg-quick">Compile the wg-quick(8) tool. Requires iptables.</flag>
 	</use>
 </pkgmetadata>

--- a/net-vpn/wireguard/wireguard-0.0.20191127-r1.ebuild
+++ b/net-vpn/wireguard/wireguard-0.0.20191127-r1.ebuild
@@ -21,10 +21,15 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="debug +module +tools module-src"
+IUSE="debug +module module-src +tools +wg-quick"
 
-DEPEND="tools? ( net-libs/libmnl net-firewall/iptables )"
+DEPEND="
+	tools? ( net-libs/libmnl )
+	wg-quick? ( net-firewall/iptables )
+"
 RDEPEND="${DEPEND}"
+
+REQUIRED_USE="wg-quick? ( tools )"
 
 MODULE_NAMES="wireguard(kernel/drivers/net:src)"
 BUILD_TARGETS="module"
@@ -67,7 +72,7 @@ src_install() {
 		emake \
 			WITH_BASHCOMPLETION=yes \
 			WITH_SYSTEMDUNITS=yes \
-			WITH_WGQUICK=yes \
+			WITH_WGQUICK=$(usex wg-quick yes no) \
 			DESTDIR="${D}" \
 			BASHCOMPDIR="$(get_bashcompdir)" \
 			PREFIX="${EPREFIX}/usr" \

--- a/net-vpn/wireguard/wireguard-9999.ebuild
+++ b/net-vpn/wireguard/wireguard-9999.ebuild
@@ -21,10 +21,15 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="debug +module +tools module-src"
+IUSE="debug +module module-src +tools +wg-quick"
 
-DEPEND="tools? ( net-libs/libmnl net-firewall/iptables )"
+DEPEND="
+	tools? ( net-libs/libmnl )
+	wg-quick? ( net-firewall/iptables )
+"
 RDEPEND="${DEPEND}"
+
+REQUIRED_USE="wg-quick? ( tools )"
 
 MODULE_NAMES="wireguard(kernel/drivers/net:src)"
 BUILD_TARGETS="module"
@@ -66,7 +71,7 @@ src_install() {
 		emake \
 			WITH_BASHCOMPLETION=yes \
 			WITH_SYSTEMDUNITS=yes \
-			WITH_WGQUICK=yes \
+			WITH_WGQUICK=$(usex wg-quick yes no) \
 			DESTDIR="${D}" \
 			BASHCOMPDIR="$(get_bashcompdir)" \
 			PREFIX="${EPREFIX}/usr" \


### PR DESCRIPTION
...along with its iptables dependency.

I'm happily running Wireguard with nftables and have no need for neither wg-quick nor iptables :-)