### PR TITLE
[CI] profiles: Remove python2_7 from default PYTHON_TARGETS

### DIFF
--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -137,7 +137,7 @@ BOOTSTRAP_USE="unicode internal-glib pkg-config split-usr python_targets_python3
 # Default target(s) for python-r1.eclass
 # Mikle Kolyada <zlogene@gentoo.org> (2018-07-24)
 # Updated to python3_6
-PYTHON_TARGETS="python2_7 python3_6"
+PYTHON_TARGETS="python3_6"
 PYTHON_SINGLE_TARGET="python3_6"
 
 # Michał Górny <mgorny@gentoo.org> (2013-08-10)

--- a/profiles/prefix/make.defaults
+++ b/profiles/prefix/make.defaults
@@ -9,11 +9,5 @@
 USE="readline zlib ncurses ssl"
 
 
-# In Prefix, aim for Python 3 only, leaving out 2 to avoid unnecessary
-# builds
-# NOTE: Both are incremental variables: Need to drop obsolete base values.
-PYTHON_TARGETS="-python2_7 python3_6"
-PYTHON_SINGLE_TARGET="python3_6"
-
 # Move away from ruby22 fast forward to ruby24, we don't have ruby23
 RUBY_TARGETS="ruby24"


### PR DESCRIPTION
Signed-off-by: Michał Górny <mgorny@gentoo.org>