### PR TITLE
net-firewall/nftables: Port missing changes to 0.9.3 and depend on >=net-libs/libnftnl-1.1.5 

### DIFF
--- a/net-firewall/nftables/nftables-0.9.3-r1.ebuild
+++ b/net-firewall/nftables/nftables-0.9.3-r1.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	json? ( dev-libs/jansson )
 	python? ( ${PYTHON_DEPS} )
 	readline? ( sys-libs/readline:0= )
-	>=net-libs/libnftnl-1.1.4:0=
+	>=net-libs/libnftnl-1.1.5:0=
 	xtables? ( >=net-firewall/iptables-1.6.1 )
 "
 

--- a/net-firewall/nftables/nftables-0.9.3-r1.ebuild
+++ b/net-firewall/nftables/nftables-0.9.3-r1.ebuild
@@ -66,9 +66,9 @@ src_prepare() {
 	default
 
 	# fix installation path for doc stuff
-	sed '/^pkgsysconfdir/s@${sysconfdir}.*$@${docdir}@' \
+	sed '/^pkgsysconfdir/s@${sysconfdir}.*$@${docdir}/skels@' \
 		-i files/nftables/Makefile.am || die
-	sed '/^pkgsysconfdir/s@${sysconfdir}.*$@${docdir}/osf@' \
+	sed '/^pkgsysconfdir/s@${sysconfdir}.*$@${docdir}/skels/osf@' \
 		-i files/osf/Makefile.am || die
 
 	eautoreconf


### PR DESCRIPTION
This pull requests ports forward the missing doc handling changes to 0.9.3. It also makes sure the dependency is for libnftnl-1.1.5 as 1.1.4 causes compilation errors (see bug https://bugs.gentoo.org/701976 )

As the doc changes change installation paths of some files I'm revbumping it.