### PR TITLE
dev-util/bazel: Add gRPC patch for glibc 2.30

### DIFF
--- a/dev-util/bazel/bazel-1.2.0.ebuild
+++ b/dev-util/bazel/bazel-1.2.0.ebuild
@@ -24,6 +24,10 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}"
 
+PATCHES=(
+	"${FILESDIR}/${PV}-grpc-gettid.patch"
+)
+
 bazel-get-flags() {
 	local i fs=()
 	for i in ${CFLAGS}; do

--- a/dev-util/bazel/files/1.2.0-grpc-gettid.patch
+++ b/dev-util/bazel/files/1.2.0-grpc-gettid.patch
@@ -1,0 +1,78 @@
+From 57586a1ca7f17b1916aed3dea4ff8de872dbf853 Mon Sep 17 00:00:00 2001
+From: Benjamin Peterson <benjamin@dropbox.com>
+Date: Fri, 3 May 2019 08:11:00 -0700
+Subject: [PATCH] Rename gettid() functions.
+
+glibc 2.30 will declare its own gettid; see https://sourceware.org/git/?p=glibc.git;a=commit;h=1d0fc213824eaa2a8f8c4385daaa698ee8fb7c92. Rename the grpc versions to avoid naming conflicts.
+---
+ src/core/lib/gpr/log_linux.cc          | 6 ++----
+ src/core/lib/gpr/log_posix.cc          | 4 ++--
+ src/core/lib/iomgr/ev_epollex_linux.cc | 4 ++--
+ 3 files changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/third_party/grpc/src/core/lib/gpr/log_linux.cc b/src/core/lib/gpr/log_linux.cc
+index 81026e5689b..8b597b4cf2f 100644
+--- a/third_party/grpc/src/core/lib/gpr/log_linux.cc
++++ b/third_party/grpc/src/core/lib/gpr/log_linux.cc
+@@ -40,7 +40,7 @@
+ #include <time.h>
+ #include <unistd.h>
+
+-static long gettid(void) { return syscall(__NR_gettid); }
++static long sys_gettid(void) { return syscall(__NR_gettid); }
+
+ void gpr_log(const char* file, int line, gpr_log_severity severity,
+              const char* format, ...) {
+@@ -70,7 +70,7 @@ void gpr_default_log(gpr_log_func_args* args) {
+   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
+   struct tm tm;
+   static __thread long tid = 0;
+-  if (tid == 0) tid = gettid();
++  if (tid == 0) tid = sys_gettid();
+
+   timer = static_cast<time_t>(now.tv_sec);
+   final_slash = strrchr(args->file, '/');
+diff --git a/third_party/grpc/src/core/lib/gpr/log_posix.cc b/src/core/lib/gpr/log_posix.cc
+index b6edc14ab6b..2f7c6ce3760 100644
+--- a/third_party/grpc/src/core/lib/gpr/log_posix.cc
++++ b/third_party/grpc/src/core/lib/gpr/log_posix.cc
+@@ -31,7 +31,7 @@
+ #include <string.h>
+ #include <time.h>
+
+-static intptr_t gettid(void) { return (intptr_t)pthread_self(); }
++static intptr_t sys_gettid(void) { return (intptr_t)pthread_self(); }
+
+ void gpr_log(const char* file, int line, gpr_log_severity severity,
+              const char* format, ...) {
+@@ -86,7 +86,7 @@ void gpr_default_log(gpr_log_func_args* args) {
+   char* prefix;
+   gpr_asprintf(&prefix, "%s%s.%09d %7" PRIdPTR " %s:%d]",
+                gpr_log_severity_string(args->severity), time_buffer,
+-               (int)(now.tv_nsec), gettid(), display_file, args->line);
++               (int)(now.tv_nsec), sys_gettid(), display_file, args->line);
+
+   fprintf(stderr, "%-70s %s\n", prefix, args->message);
+   gpr_free(prefix);
+diff --git a/third_party/grpc/src/core/lib/iomgr/ev_epollex_linux.cc b/src/core/lib/iomgr/ev_epollex_linux.cc
+index c2d80c08ddb..4a83cb6c215 100644
+--- a/third_party/grpc/src/core/lib/iomgr/ev_epollex_linux.cc
++++ b/third_party/grpc/src/core/lib/iomgr/ev_epollex_linux.cc
+@@ -1077,7 +1077,7 @@ static void end_worker(grpc_pollset* pollset, grpc_pollset_worker* worker,
+ }
+
+ #ifndef NDEBUG
+-static long gettid(void) { return syscall(__NR_gettid); }
++static long sys_gettid(void) { return syscall(__NR_gettid); }
+ #endif
+
+ /* pollset->mu lock must be held by the caller before calling this.
+@@ -1097,7 +1097,7 @@ static grpc_error* pollset_work(grpc_pollset* pollset,
+ #define WORKER_PTR (&worker)
+ #endif
+ #ifndef NDEBUG
+-  WORKER_PTR->originator = gettid();
++  WORKER_PTR->originator = sys_gettid();
+ #endif
+   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
+     gpr_log(GPR_INFO,


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/701398
Package-Manager: Portage-2.3.80, Repoman-2.3.19
Signed-off-by: Julius Putra Tanu Setiaji <indocomsoft@gmail.com>