### PR TITLE
sys-apps/debianutils: Introduce USE=systemd-boot

### DIFF
--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Michał Górny <mgorny@gentoo.org> (2019-12-05)
+# sys-apps/systemd not keyworded here.
+sys-apps/debianutils systemd-boot
+
 # Sergei Trofimovich <slyfox@gentoo.org> (2019-12-02)
 # dev-util/systemtap is not keyworded on riscv
 sys-libs/glibc systemtap

--- a/profiles/features/prefix/package.use.mask
+++ b/profiles/features/prefix/package.use.mask
@@ -9,6 +9,7 @@ gnome-base/gnome-extra-apps share
 # avoid sys-apps/systemd
 net-analyzer/wireshark sdjournal
 sys-apps/dbus-broker launcher
+sys-apps/debianutils systemd-boot
 www-servers/uwsgi uwsgi_plugins_systemd_logger
 
 # Benda Xu <heroxbd@gentoo.org> (2016-07-28)

--- a/profiles/features/selinux/package.use.mask
+++ b/profiles/features/selinux/package.use.mask
@@ -32,6 +32,7 @@ x11-terms/gnome-terminal gnome-shell
 x11-themes/arc-theme gnome-shell
 x11-themes/zukitwo gnome-shell
 net-wireless/bluez user-session
+sys-apps/debianutils systemd-boot
 
 # Jason Zaman <perfinion@gentoo.org> (2019-12-01)
 # SELinux userspace 3.0 dropped python2.7 support

--- a/sys-apps/debianutils/debianutils-4.9.ebuild
+++ b/sys-apps/debianutils/debianutils-4.9.ebuild
@@ -12,7 +12,10 @@ SRC_URI="mirror://debian/pool/main/d/${PN}/${PN}_${PV}.tar.xz"
 LICENSE="BSD GPL-2 SMAIL"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86 ~x86-linux"
-IUSE="+installkernel static"
+IUSE="+installkernel split-usr static systemd-boot"
+
+# this is for kernel-install script, so [gnuefi] not necessary
+RDEPEND="systemd-boot? ( || ( sys-apps/systemd sys-apps/systemd-boot ) )"
 
 PATCHES=( "${FILESDIR}"/${PN}-3.4.2-no-bs-namespace.patch )
 
@@ -24,7 +27,11 @@ src_configure() {
 src_install() {
 	into /
 	dobin tempfile run-parts
-	if use installkernel ; then
+	if use systemd-boot ; then
+		dodir /sbin
+		dosym ../$(usex split-usr 'usr/' '')bin/kernel-install \
+			/sbin/installkernel
+	elif use installkernel ; then
 		dosbin installkernel
 	fi
 
@@ -32,7 +39,9 @@ src_install() {
 	dosbin savelog
 
 	doman tempfile.1 run-parts.8 savelog.8
-	use installkernel && doman installkernel.8
+	if use installkernel && ! use systemd-boot; then
+		doman installkernel.8
+	fi
 	cd debian || die
 	dodoc changelog control
 	keepdir /etc/kernel/postinst.d

--- a/sys-apps/debianutils/metadata.xml
+++ b/sys-apps/debianutils/metadata.xml
@@ -7,5 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name='installkernel'>Install /sbin/installkernel script (for Linux)</flag>
+		<flag name='systemd-boot'>Symlink /sbin/installkernel to kernel-install,
+			to make kernel's "make install" facilitate systemd-boot layout</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Introduce a 'systemd-boot' flag to toggle symlinking systemd's kernel-
install to installkernel, rather than installing the standard Debian
script.  This makes the kernel's 'make install' target use systemd-boot
install layout.

While technically this could be introduced separately (e.g. a separate
package requiring sys-apps/debianutils[-installkernel]), adding it
as a USE flag involves much less complexity and improves visibility.
In particular, it makes it possible to toggle the option via one USE
flag switch vs having to do some external action plus disable
installkernel flag.

Signed-off-by: Michał Górny <mgorny@gentoo.org>