### PR TITLE
app-portage/gentoopm and app-portage/smart-live-rebuild: Python 3.8 compatibility

### DIFF
--- a/app-portage/gentoopm/gentoopm-0.3.1.ebuild
+++ b/app-portage/gentoopm/gentoopm-0.3.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} pypy )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7,3_8} pypy )
 
 inherit distutils-r1
 

--- a/app-portage/gentoopm/gentoopm-9999.ebuild
+++ b/app-portage/gentoopm/gentoopm-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} pypy )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7,3_8} pypy )
 
 EGIT_REPO_URI="https://github.com/mgorny/gentoopm.git"
 inherit distutils-r1 git-r3

--- a/app-portage/smart-live-rebuild/smart-live-rebuild-1.3.6.ebuild
+++ b/app-portage/smart-live-rebuild/smart-live-rebuild-1.3.6.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7,3_8} )
 
 inherit distutils-r1
 

--- a/app-portage/smart-live-rebuild/smart-live-rebuild-9999.ebuild
+++ b/app-portage/smart-live-rebuild/smart-live-rebuild-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7,3_8} )
 
 EGIT_REPO_URI="https://github.com/mgorny/${PN}.git"
 inherit distutils-r1 git-r3


### PR DESCRIPTION
* app-portage/gentoopm: Python 3.8 compatibility
* app-portage/smart-live-rebuild: Python 3.8 compatibility

Tests pass and it works (I ran `emerge --keep-going @smart-live-rebuild`) so it seems good to me.