### PR TITLE
x11-misc/menumaker: add Python 3.7 support

### DIFF
--- a/x11-misc/menumaker/menumaker-0.99.11.ebuild
+++ b/x11-misc/menumaker/menumaker-0.99.11.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{5,6} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit autotools python-r1
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.79, Repoman-2.3.16
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

Works for me and no errors when running flake8 on the source.