### PR TITLE
dev-python/click-*: apply distutils_enable_test, update py compat

### DIFF
--- a/dev-python/click-log/click-log-0.1.8.ebuild
+++ b/dev-python/click-log/click-log-0.1.8.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
 
 inherit distutils-r1
 
@@ -13,15 +13,10 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="test"
-RESTRICT="!test? ( test )"
 
 RDEPEND="dev-python/click[${PYTHON_USEDEP}]"
-DEPEND="${RDEPEND}
-	test? ( dev-python/pytest[${PYTHON_USEDEP}] )"
+DEPEND="${RDEPEND}"
 
 DOCS=( README.rst )
 
-python_test() {
-	py.test -v || die "Tests fail with ${EPYTHON}"
-}
+distutils_enable_tests pytest

--- a/dev-python/click-log/click-log-0.2.1.ebuild
+++ b/dev-python/click-log/click-log-0.2.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
 
 inherit distutils-r1
 
@@ -13,15 +13,10 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="test"
-RESTRICT="!test? ( test )"
 
 RDEPEND="dev-python/click[${PYTHON_USEDEP}]"
-DEPEND="${RDEPEND}
-	test? ( dev-python/pytest[${PYTHON_USEDEP}] )"
+DEPEND="${RDEPEND}"
 
 DOCS=( README.rst )
 
-python_test() {
-	py.test -v || die "Tests fail with ${EPYTHON}"
-}
+distutils_enable_tests pytest

--- a/dev-python/click-log/click-log-0.3.2.ebuild
+++ b/dev-python/click-log/click-log-0.3.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
 
 inherit distutils-r1
 
@@ -13,15 +13,10 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="test"
-RESTRICT="!test? ( test )"
 
 RDEPEND="dev-python/click[${PYTHON_USEDEP}]"
-DEPEND="${RDEPEND}
-	test? ( dev-python/pytest[${PYTHON_USEDEP}] )"
+DEPEND="${RDEPEND}"
 
 DOCS=( README.rst )
 
-python_test() {
-	py.test -v || die "Tests fail with ${EPYTHON}"
-}
+distutils_enable_tests pytest

--- a/dev-python/click-threading/click-threading-0.3.0.ebuild
+++ b/dev-python/click-threading/click-threading-0.3.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{2_7,3_5,3_6,3_7} )
 
 inherit distutils-r1
 
@@ -13,15 +13,10 @@ SRC_URI="https://github.com/click-contrib/${PN}/archive/${PV}.tar.gz -> ${P}-gh.
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="test"
-RESTRICT="!test? ( test )"
 
 RDEPEND=">=dev-python/click-5.0[${PYTHON_USEDEP}]"
-DEPEND="${RDEPEND}
-	test? ( dev-python/pytest[${PYTHON_USEDEP}] )"
+DEPEND="${RDEPEND}"
 
 DOCS=( README.rst )
 
-python_test() {
-	py.test -v || die "Tests fail with ${EPYTHON}"
-}
+distutils_enable_tests pytest

--- a/dev-python/click-threading/click-threading-0.4.4.ebuild
+++ b/dev-python/click-threading/click-threading-0.4.4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_5,3_6} )
+PYTHON_COMPAT=( python{3_5,3_6,3_7} )
 
 inherit distutils-r1
 
@@ -13,15 +13,10 @@ SRC_URI="https://github.com/click-contrib/${PN}/archive/${PV}.tar.gz -> ${P}-gh.
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="test"
-RESTRICT="!test? ( test )"
 
 RDEPEND=">=dev-python/click-5.0[${PYTHON_USEDEP}]"
-DEPEND="${RDEPEND}
-	test? ( dev-python/pytest[${PYTHON_USEDEP}] )"
+DEPEND="${RDEPEND}"
 
 DOCS=( README.rst )
 
-python_test() {
-	py.test -v || die "Tests fail with ${EPYTHON}"
-}
+distutils_enable_tests pytest


### PR DESCRIPTION
Where the distutils_enable_tests deals with test USE, pytest dep and the python_test function.
Did not bother fixing failing py27 test in https://bugs.gentoo.org/660650, since py27 is EOL; just removed py27 compat.