### PR TITLE
*/*: Add default enabled 'threads(+)' USEDEP on dev-libs/boost

### DIFF
--- a/app-backup/snapper/snapper-0.5.6-r1.ebuild
+++ b/app-backup/snapper/snapper-0.5.6-r1.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="lvm pam xattr"
 
-RDEPEND="dev-libs/boost:=[threads]
+RDEPEND="dev-libs/boost:=[threads(+)]
 	dev-libs/libxml2
 	dev-libs/icu:=
 	sys-apps/acl

--- a/app-backup/snapper/snapper-0.8.3.ebuild
+++ b/app-backup/snapper/snapper-0.8.3.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="lvm pam xattr"
 
-RDEPEND="dev-libs/boost:=[threads]
+RDEPEND="dev-libs/boost:=[threads(+)]
 	dev-libs/libxml2
 	dev-libs/icu:=
 	sys-apps/acl

--- a/app-backup/snapper/snapper-0.8.4.ebuild
+++ b/app-backup/snapper/snapper-0.8.4.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="lvm pam xattr"
 
-RDEPEND="dev-libs/boost:=[threads]
+RDEPEND="dev-libs/boost:=[threads(+)]
 	dev-libs/libxml2
 	dev-libs/icu:=
 	sys-apps/acl

--- a/app-i18n/librime/librime-1.4.0.ebuild
+++ b/app-i18n/librime/librime-1.4.0.ebuild
@@ -18,7 +18,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="app-i18n/opencc:=
 	dev-cpp/glog:=
 	dev-cpp/yaml-cpp:=
-	dev-libs/boost:=[nls,threads]
+	dev-libs/boost:=[nls,threads(+)]
 	dev-libs/leveldb:=
 	dev-libs/marisa:="
 DEPEND="${RDEPEND}

--- a/app-i18n/librime/librime-1.5.3.ebuild
+++ b/app-i18n/librime/librime-1.5.3.ebuild
@@ -30,7 +30,7 @@ BDEPEND=""
 RDEPEND="app-i18n/opencc:0=
 	dev-cpp/glog:0=
 	dev-cpp/yaml-cpp:0=
-	dev-libs/boost:0=[nls,threads]
+	dev-libs/boost:0=[nls,threads(+)]
 	dev-libs/leveldb:0=
 	dev-libs/marisa:0="
 DEPEND="${RDEPEND}

--- a/app-text/sigil/sigil-0.9.13.ebuild
+++ b/app-text/sigil/sigil-0.9.13.ebuild
@@ -21,7 +21,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="
 	${PYTHON_DEPS}
 	app-text/hunspell:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/libpcre:3=[pcre16]
 	dev-libs/mathjax
 	dev-libs/xerces-c[icu]

--- a/app-text/sigil/sigil-0.9.16.ebuild
+++ b/app-text/sigil/sigil-0.9.16.ebuild
@@ -21,7 +21,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="
 	${PYTHON_DEPS}
 	app-text/hunspell:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/libpcre:3=[pcre16]
 	dev-libs/xerces-c[icu]
 	dev-python/css-parser[${PYTHON_USEDEP}]

--- a/app-text/sigil/sigil-0.9.18.ebuild
+++ b/app-text/sigil/sigil-0.9.18.ebuild
@@ -21,7 +21,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="
 	${PYTHON_DEPS}
 	app-text/hunspell:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/libpcre:3=[pcre16]
 	dev-libs/xerces-c[icu]
 	dev-python/css-parser[${PYTHON_USEDEP}]

--- a/app-vim/youcompleteme/youcompleteme-99999999.ebuild
+++ b/app-vim/youcompleteme/youcompleteme-99999999.ebuild
@@ -25,7 +25,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 COMMON_DEPEND="
 	${PYTHON_DEPS}
 	clang? ( >=sys-devel/clang-3.3 )
-	dev-libs/boost[python,threads,${PYTHON_USEDEP}]
+	dev-libs/boost[python,threads(+),${PYTHON_USEDEP}]
 	|| (
 		app-editors/vim[python,${PYTHON_USEDEP}]
 		app-editors/gvim[python,${PYTHON_USEDEP}]

--- a/dev-cpp/libxsd-frontend/libxsd-frontend-2.0.0.ebuild
+++ b/dev-cpp/libxsd-frontend/libxsd-frontend-2.0.0.ebuild
@@ -15,7 +15,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-libs/xerces-c-3.0.0
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/libcutl"
 DEPEND="${RDEPEND}
 	>=dev-util/build-0.3.10"

--- a/dev-libs/console_bridge/console_bridge-0.4.0.ebuild
+++ b/dev-libs/console_bridge/console_bridge-0.4.0.ebuild
@@ -25,5 +25,5 @@ LICENSE="BSD"
 SLOT="0/4"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]"
+RDEPEND="dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-libs/console_bridge/console_bridge-0.4.2.ebuild
+++ b/dev-libs/console_bridge/console_bridge-0.4.2.ebuild
@@ -25,5 +25,5 @@ LICENSE="BSD"
 SLOT="0/4"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]"
+RDEPEND="dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-libs/console_bridge/console_bridge-0.4.3.ebuild
+++ b/dev-libs/console_bridge/console_bridge-0.4.3.ebuild
@@ -25,5 +25,5 @@ LICENSE="BSD"
 SLOT="0/4"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]"
+RDEPEND="dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-libs/console_bridge/console_bridge-9999.ebuild
+++ b/dev-libs/console_bridge/console_bridge-9999.ebuild
@@ -25,5 +25,5 @@ LICENSE="BSD"
 SLOT="0/4"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]"
+RDEPEND="dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-libs/urdfdom/urdfdom-1.0.0-r1.ebuild
+++ b/dev-libs/urdfdom/urdfdom-1.0.0-r1.ebuild
@@ -28,7 +28,7 @@ IUSE=""
 RDEPEND=">=dev-libs/urdfdom_headers-1.0.0
 	>=dev-libs/console_bridge-0.3:=
 	dev-libs/tinyxml
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"
 
 src_prepare() {

--- a/dev-libs/urdfdom/urdfdom-1.0.3.ebuild
+++ b/dev-libs/urdfdom/urdfdom-1.0.3.ebuild
@@ -28,7 +28,7 @@ IUSE=""
 RDEPEND=">=dev-libs/urdfdom_headers-1.0.0
 	>=dev-libs/console_bridge-0.3:=
 	dev-libs/tinyxml
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"
 
 src_prepare() {

--- a/dev-libs/urdfdom/urdfdom-9999.ebuild
+++ b/dev-libs/urdfdom/urdfdom-9999.ebuild
@@ -28,7 +28,7 @@ IUSE=""
 RDEPEND=">=dev-libs/urdfdom_headers-1.0.0
 	>=dev-libs/console_bridge-0.3:=
 	dev-libs/tinyxml
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"
 
 src_prepare() {

--- a/dev-python/tagpy/tagpy-2018.1.ebuild
+++ b/dev-python/tagpy/tagpy-2018.1.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="amd64 ppc ppc64 ~sparc x86"
 IUSE="examples"
 
 RDEPEND="
-	dev-libs/boost:=[python,threads,${PYTHON_USEDEP}]
+	dev-libs/boost:=[python,threads(+),${PYTHON_USEDEP}]
 	>=media-libs/taglib-1.8
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/actionlib/actionlib-1.11.13.ebuild
+++ b/dev-ros/actionlib/actionlib-1.11.13.ebuild
@@ -15,7 +15,7 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]
+RDEPEND="dev-libs/boost:=[threads(+)]
 	dev-ros/roscpp
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	"

--- a/dev-ros/actionlib/actionlib-1.11.14.ebuild
+++ b/dev-ros/actionlib/actionlib-1.11.14.ebuild
@@ -15,7 +15,7 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]
+RDEPEND="dev-libs/boost:=[threads(+)]
 	dev-ros/roscpp
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	"

--- a/dev-ros/actionlib/actionlib-1.11.15.ebuild
+++ b/dev-ros/actionlib/actionlib-1.11.15.ebuild
@@ -15,7 +15,7 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]
+RDEPEND="dev-libs/boost:=[threads(+)]
 	dev-ros/roscpp
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	"

--- a/dev-ros/actionlib/actionlib-9999.ebuild
+++ b/dev-ros/actionlib/actionlib-9999.ebuild
@@ -15,7 +15,7 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]
+RDEPEND="dev-libs/boost:=[threads(+)]
 	dev-ros/roscpp
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	"

--- a/dev-ros/actionlib_tutorials/actionlib_tutorials-0.1.10.ebuild
+++ b/dev-ros/actionlib_tutorials/actionlib_tutorials-0.1.10.ebuild
@@ -19,6 +19,6 @@ IUSE=""
 RDEPEND="
 	dev-ros/roscpp
 	dev-ros/actionlib
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/actionlib_tutorials/actionlib_tutorials-0.1.11.ebuild
+++ b/dev-ros/actionlib_tutorials/actionlib_tutorials-0.1.11.ebuild
@@ -19,6 +19,6 @@ IUSE=""
 RDEPEND="
 	dev-ros/roscpp
 	dev-ros/actionlib
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/actionlib_tutorials/actionlib_tutorials-0.1.8.ebuild
+++ b/dev-ros/actionlib_tutorials/actionlib_tutorials-0.1.8.ebuild
@@ -19,6 +19,6 @@ IUSE=""
 RDEPEND="
 	dev-ros/roscpp
 	dev-ros/actionlib
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/actionlib_tutorials/actionlib_tutorials-9999.ebuild
+++ b/dev-ros/actionlib_tutorials/actionlib_tutorials-9999.ebuild
@@ -19,6 +19,6 @@ IUSE=""
 RDEPEND="
 	dev-ros/roscpp
 	dev-ros/actionlib
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/audio_capture/audio_capture-0.3.1.ebuild
+++ b/dev-ros/audio_capture/audio_capture-0.3.1.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/audio_common_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/gstreamer:1.0
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/audio_capture/audio_capture-0.3.2.ebuild
+++ b/dev-ros/audio_capture/audio_capture-0.3.2.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/audio_common_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/gstreamer:1.0
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/audio_capture/audio_capture-0.3.3.ebuild
+++ b/dev-ros/audio_capture/audio_capture-0.3.3.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/audio_common_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/gstreamer:1.0
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/audio_capture/audio_capture-9999.ebuild
+++ b/dev-ros/audio_capture/audio_capture-9999.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/audio_common_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/gstreamer:1.0
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/audio_play/audio_play-0.3.1.ebuild
+++ b/dev-ros/audio_play/audio_play-0.3.1.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/audio_common_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/gstreamer:1.0
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/audio_play/audio_play-0.3.2.ebuild
+++ b/dev-ros/audio_play/audio_play-0.3.2.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/audio_common_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/gstreamer:1.0
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/audio_play/audio_play-0.3.3.ebuild
+++ b/dev-ros/audio_play/audio_play-0.3.3.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/audio_common_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/gstreamer:1.0
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/audio_play/audio_play-9999.ebuild
+++ b/dev-ros/audio_play/audio_play-9999.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/audio_common_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/gstreamer:1.0
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/base_local_planner/base_local_planner-1.16.1.ebuild
+++ b/dev-ros/base_local_planner/base_local_planner-1.16.1.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	dev-ros/tf2_ros
 	dev-ros/visualization_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/voxel_grid
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/tf2_geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/base_local_planner/base_local_planner-1.16.2.ebuild
+++ b/dev-ros/base_local_planner/base_local_planner-1.16.2.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	dev-ros/tf2_ros
 	dev-ros/visualization_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/voxel_grid
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	dev-ros/cmake_modules

--- a/dev-ros/base_local_planner/base_local_planner-9999.ebuild
+++ b/dev-ros/base_local_planner/base_local_planner-9999.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	dev-ros/tf2_ros
 	dev-ros/visualization_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/voxel_grid
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	dev-ros/cmake_modules

--- a/dev-ros/class_loader/class_loader-0.4.1-r1.ebuild
+++ b/dev-ros/class_loader/class_loader-0.4.1-r1.ebuild
@@ -14,7 +14,7 @@ SLOT="0/melodic2"
 IUSE=""
 
 RDEPEND="dev-libs/poco
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cmake_modules
 	dev-libs/console_bridge:="
 DEPEND="${RDEPEND}"

--- a/dev-ros/class_loader/class_loader-9999.ebuild
+++ b/dev-ros/class_loader/class_loader-9999.ebuild
@@ -14,7 +14,7 @@ SLOT="0/melodic2"
 IUSE=""
 
 RDEPEND="dev-libs/poco
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cmake_modules
 	dev-libs/console_bridge:="
 DEPEND="${RDEPEND}"

--- a/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.15.1-r1.ebuild
+++ b/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.15.1-r1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/tf
 	dev-cpp/eigen:3
 	sci-libs/pcl
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.15.2.ebuild
+++ b/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.15.2.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/tf
 	dev-cpp/eigen:3
 	sci-libs/pcl
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.16.0.ebuild
+++ b/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.16.0.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/tf2_ros
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.16.1.ebuild
+++ b/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.16.1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/tf2_ros
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.16.2.ebuild
+++ b/dev-ros/clear_costmap_recovery/clear_costmap_recovery-1.16.2.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/tf2_ros
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/clear_costmap_recovery/clear_costmap_recovery-9999.ebuild
+++ b/dev-ros/clear_costmap_recovery/clear_costmap_recovery-9999.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/tf2_ros
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/control_toolbox/control_toolbox-1.14.0.ebuild
+++ b/dev-ros/control_toolbox/control_toolbox-1.14.0.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/dynamic_reconfigure
 	dev-ros/realtime_tools
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/tinyxml
 	dev-ros/control_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 "

--- a/dev-ros/control_toolbox/control_toolbox-1.15.0.ebuild
+++ b/dev-ros/control_toolbox/control_toolbox-1.15.0.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/dynamic_reconfigure
 	dev-ros/realtime_tools
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/tinyxml
 	dev-ros/control_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 "

--- a/dev-ros/control_toolbox/control_toolbox-1.16.0.ebuild
+++ b/dev-ros/control_toolbox/control_toolbox-1.16.0.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/dynamic_reconfigure
 	dev-ros/realtime_tools
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/tinyxml
 	dev-ros/control_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 "

--- a/dev-ros/control_toolbox/control_toolbox-9999.ebuild
+++ b/dev-ros/control_toolbox/control_toolbox-9999.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/dynamic_reconfigure
 	dev-ros/realtime_tools
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/tinyxml
 	dev-ros/control_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 "

--- a/dev-ros/costmap_2d/costmap_2d-1.16.1.ebuild
+++ b/dev-ros/costmap_2d/costmap_2d-1.16.1.ebuild
@@ -33,7 +33,7 @@ RDEPEND="
 	dev-ros/tf2_sensor_msgs
 
 	dev-cpp/eigen:3
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/tinyxml2:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/costmap_2d/costmap_2d-1.16.2.ebuild
+++ b/dev-ros/costmap_2d/costmap_2d-1.16.2.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	dev-ros/tf2_sensor_msgs
 
 	dev-cpp/eigen:3
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/tinyxml2:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/costmap_2d/costmap_2d-9999.ebuild
+++ b/dev-ros/costmap_2d/costmap_2d-9999.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	dev-ros/tf2_sensor_msgs
 
 	dev-cpp/eigen:3
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/tinyxml2:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/cpp_common/cpp_common-0.6.10.ebuild
+++ b/dev-ros/cpp_common/cpp_common-0.6.10.ebuild
@@ -15,5 +15,5 @@ IUSE=""
 
 RDEPEND="
 	dev-libs/console_bridge:=
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/cpp_common/cpp_common-0.6.11.ebuild
+++ b/dev-ros/cpp_common/cpp_common-0.6.11.ebuild
@@ -15,5 +15,5 @@ IUSE=""
 
 RDEPEND="
 	dev-libs/console_bridge:=
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/cpp_common/cpp_common-0.6.12.ebuild
+++ b/dev-ros/cpp_common/cpp_common-0.6.12.ebuild
@@ -15,5 +15,5 @@ IUSE=""
 
 RDEPEND="
 	dev-libs/console_bridge:=
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/cpp_common/cpp_common-0.6.7-r1.ebuild
+++ b/dev-ros/cpp_common/cpp_common-0.6.7-r1.ebuild
@@ -15,5 +15,5 @@ IUSE=""
 
 RDEPEND="
 	dev-libs/console_bridge:=
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/cpp_common/cpp_common-0.6.8.ebuild
+++ b/dev-ros/cpp_common/cpp_common-0.6.8.ebuild
@@ -15,5 +15,5 @@ IUSE=""
 
 RDEPEND="
 	dev-libs/console_bridge:=
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/cpp_common/cpp_common-0.6.9.ebuild
+++ b/dev-ros/cpp_common/cpp_common-0.6.9.ebuild
@@ -15,5 +15,5 @@ IUSE=""
 
 RDEPEND="
 	dev-libs/console_bridge:=
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/cpp_common/cpp_common-9999.ebuild
+++ b/dev-ros/cpp_common/cpp_common-9999.ebuild
@@ -15,5 +15,5 @@ IUSE=""
 
 RDEPEND="
 	dev-libs/console_bridge:=
-	dev-libs/boost:=[threads]"
+	dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/cv_bridge/cv_bridge-1.13.0.ebuild
+++ b/dev-ros/cv_bridge/cv_bridge-1.13.0.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/rosconsole
 	>=media-libs/opencv-3:=[contrib(+)]
-	dev-libs/boost:=[threads,python,${PYTHON_USEDEP}]
+	dev-libs/boost:=[threads(+),python,${PYTHON_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/cv_bridge/cv_bridge-9999.ebuild
+++ b/dev-ros/cv_bridge/cv_bridge-9999.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/rosconsole
 	>=media-libs/opencv-3:=[contrib(+)]
-	dev-libs/boost:=[threads,python,${PYTHON_USEDEP}]
+	dev-libs/boost:=[threads(+),python,${PYTHON_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/dwa_local_planner/dwa_local_planner-1.16.1.ebuild
+++ b/dev-ros/dwa_local_planner/dwa_local_planner-1.16.1.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 
 	dev-ros/tf2_geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/dwa_local_planner/dwa_local_planner-1.16.2.ebuild
+++ b/dev-ros/dwa_local_planner/dwa_local_planner-1.16.2.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	dev-ros/tf2_geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/tf2_ros
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/dwa_local_planner/dwa_local_planner-9999.ebuild
+++ b/dev-ros/dwa_local_planner/dwa_local_planner-9999.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	dev-ros/tf2_geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/tf2_ros
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/dynamic_reconfigure/dynamic_reconfigure-1.5.48.ebuild
+++ b/dev-ros/dynamic_reconfigure/dynamic_reconfigure-1.5.48.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/roscpp
 "

--- a/dev-ros/dynamic_reconfigure/dynamic_reconfigure-1.5.49.ebuild
+++ b/dev-ros/dynamic_reconfigure/dynamic_reconfigure-1.5.49.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/roscpp
 "

--- a/dev-ros/dynamic_reconfigure/dynamic_reconfigure-1.6.0.ebuild
+++ b/dev-ros/dynamic_reconfigure/dynamic_reconfigure-1.6.0.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/roscpp
 "

--- a/dev-ros/dynamic_reconfigure/dynamic_reconfigure-9999.ebuild
+++ b/dev-ros/dynamic_reconfigure/dynamic_reconfigure-9999.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/roscpp
 "

--- a/dev-ros/filters/filters-1.8.1-r1.ebuild
+++ b/dev-ros/filters/filters-1.8.1-r1.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 	dev-ros/pluginlib"
 DEPEND="${RDEPEND}

--- a/dev-ros/filters/filters-9999.ebuild
+++ b/dev-ros/filters/filters-9999.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 	dev-ros/pluginlib"
 DEPEND="${RDEPEND}

--- a/dev-ros/gazebo_ros/gazebo_ros-2.6.2.ebuild
+++ b/dev-ros/gazebo_ros/gazebo_ros-2.6.2.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	dev-ros/tf[${PYTHON_USEDEP}]
 	dev-ros/dynamic_reconfigure
 	dev-libs/libxml2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/gazebo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]

--- a/dev-ros/gazebo_ros/gazebo_ros-2.7.3.ebuild
+++ b/dev-ros/gazebo_ros/gazebo_ros-2.7.3.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/tf[${PYTHON_USEDEP}]
 	dev-ros/dynamic_reconfigure
 	dev-libs/libxml2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/gazebo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]

--- a/dev-ros/gazebo_ros/gazebo_ros-2.7.4.ebuild
+++ b/dev-ros/gazebo_ros/gazebo_ros-2.7.4.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/tf[${PYTHON_USEDEP}]
 	dev-ros/dynamic_reconfigure
 	dev-libs/libxml2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/gazebo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]

--- a/dev-ros/gazebo_ros/gazebo_ros-2.8.4.ebuild
+++ b/dev-ros/gazebo_ros/gazebo_ros-2.8.4.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/tf[${PYTHON_USEDEP}]
 	dev-ros/dynamic_reconfigure
 	dev-libs/libxml2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/gazebo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]

--- a/dev-ros/gazebo_ros/gazebo_ros-2.8.5.ebuild
+++ b/dev-ros/gazebo_ros/gazebo_ros-2.8.5.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/tf[${PYTHON_USEDEP}]
 	dev-ros/dynamic_reconfigure
 	dev-libs/libxml2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/gazebo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]

--- a/dev-ros/gazebo_ros/gazebo_ros-9999.ebuild
+++ b/dev-ros/gazebo_ros/gazebo_ros-9999.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/tf[${PYTHON_USEDEP}]
 	dev-ros/dynamic_reconfigure
 	dev-libs/libxml2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/gazebo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]

--- a/dev-ros/gazebo_ros_control/gazebo_ros_control-2.6.2-r1.ebuild
+++ b/dev-ros/gazebo_ros_control/gazebo_ros_control-2.6.2-r1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	>=dev-ros/urdf-1.12.3-r1
 	dev-libs/urdfdom:=
 	sci-electronics/gazebo:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/gazebo_ros_control/gazebo_ros_control-2.7.3.ebuild
+++ b/dev-ros/gazebo_ros_control/gazebo_ros_control-2.7.3.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-ros/urdf-1.12.3-r1
 	dev-libs/urdfdom:=
 	sci-electronics/gazebo:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/gazebo_ros_control/gazebo_ros_control-2.7.4.ebuild
+++ b/dev-ros/gazebo_ros_control/gazebo_ros_control-2.7.4.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-ros/urdf-1.12.3-r1
 	dev-libs/urdfdom:=
 	sci-electronics/gazebo:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/gazebo_ros_control/gazebo_ros_control-2.8.4.ebuild
+++ b/dev-ros/gazebo_ros_control/gazebo_ros_control-2.8.4.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-ros/urdf-1.12.3-r1
 	dev-libs/urdfdom:=
 	sci-electronics/gazebo:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/gazebo_ros_control/gazebo_ros_control-2.8.5.ebuild
+++ b/dev-ros/gazebo_ros_control/gazebo_ros_control-2.8.5.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-ros/urdf-1.12.3-r1
 	dev-libs/urdfdom:=
 	sci-electronics/gazebo:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/gazebo_ros_control/gazebo_ros_control-9999.ebuild
+++ b/dev-ros/gazebo_ros_control/gazebo_ros_control-9999.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-ros/urdf-1.12.3-r1
 	dev-libs/urdfdom:=
 	sci-electronics/gazebo:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/hector_mapping/hector_mapping-0.3.5.ebuild
+++ b/dev-ros/hector_mapping/hector_mapping-0.3.5.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	dev-ros/message_filters
 	dev-ros/laser_geometry
 	dev-ros/tf_conversions
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	dev-cpp/eigen:3"

--- a/dev-ros/hector_mapping/hector_mapping-9999.ebuild
+++ b/dev-ros/hector_mapping/hector_mapping-9999.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	dev-ros/message_filters
 	dev-ros/laser_geometry
 	dev-ros/tf_conversions
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	dev-cpp/eigen:3"

--- a/dev-ros/image_cb_detector/image_cb_detector-0.10.14-r1.ebuild
+++ b/dev-ros/image_cb_detector/image_cb_detector-0.10.14-r1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]
 	dev-ros/calibration_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/rospy[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 PATCHES=( "${FILESDIR}/gcc6.patch" "${FILESDIR}/c11.patch" "${FILESDIR}/boost170.patch" )

--- a/dev-ros/image_cb_detector/image_cb_detector-9999.ebuild
+++ b/dev-ros/image_cb_detector/image_cb_detector-9999.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]
 	dev-ros/calibration_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/rospy[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 PATCHES=( "${FILESDIR}/gcc6.patch" "${FILESDIR}/c11.patch" )

--- a/dev-ros/image_proc/image_proc-1.12.22-r1.ebuild
+++ b/dev-ros/image_proc/image_proc-1.12.22-r1.ebuild
@@ -24,6 +24,6 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	media-libs/opencv:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/image_proc/image_proc-1.12.23.ebuild
+++ b/dev-ros/image_proc/image_proc-1.12.23.ebuild
@@ -24,6 +24,6 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	media-libs/opencv:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/image_proc/image_proc-9999.ebuild
+++ b/dev-ros/image_proc/image_proc-9999.ebuild
@@ -24,6 +24,6 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	media-libs/opencv:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/image_view/image_view-1.12.23.ebuild
+++ b/dev-ros/image_view/image_view-1.12.23.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/opencv:=
 	x11-libs/gtk+:2
 	dev-ros/camera_calibration_parsers

--- a/dev-ros/image_view/image_view-9999.ebuild
+++ b/dev-ros/image_view/image_view-9999.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/opencv:=
 	x11-libs/gtk+:2
 	dev-ros/camera_calibration_parsers

--- a/dev-ros/imu_filter_madgwick/imu_filter_madgwick-1.2.1.ebuild
+++ b/dev-ros/imu_filter_madgwick/imu_filter_madgwick-1.2.1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/pluginlib
 	dev-ros/message_filters
 	dev-ros/dynamic_reconfigure
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rosunit )

--- a/dev-ros/imu_filter_madgwick/imu_filter_madgwick-9999.ebuild
+++ b/dev-ros/imu_filter_madgwick/imu_filter_madgwick-9999.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	dev-ros/pluginlib
 	dev-ros/message_filters
 	dev-ros/dynamic_reconfigure
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rosunit )

--- a/dev-ros/interval_intersection/interval_intersection-0.10.14.ebuild
+++ b/dev-ros/interval_intersection/interval_intersection-0.10.14.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/actionlib
 	dev-ros/calibration_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/rosconsole

--- a/dev-ros/interval_intersection/interval_intersection-9999.ebuild
+++ b/dev-ros/interval_intersection/interval_intersection-9999.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/actionlib
 	dev-ros/calibration_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/rosconsole

--- a/dev-ros/joint_states_settler/joint_states_settler-0.10.14.ebuild
+++ b/dev-ros/joint_states_settler/joint_states_settler-0.10.14.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/actionlib
 	dev-ros/rosconsole
 	dev-ros/roscpp

--- a/dev-ros/joint_states_settler/joint_states_settler-9999.ebuild
+++ b/dev-ros/joint_states_settler/joint_states_settler-9999.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/actionlib
 	dev-ros/rosconsole
 	dev-ros/roscpp

--- a/dev-ros/laser_cb_detector/laser_cb_detector-0.10.14.ebuild
+++ b/dev-ros/laser_cb_detector/laser_cb_detector-0.10.14.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/actionlib[${PYTHON_USEDEP}]
 	dev-ros/cv_bridge
 	media-libs/opencv:=

--- a/dev-ros/laser_cb_detector/laser_cb_detector-9999.ebuild
+++ b/dev-ros/laser_cb_detector/laser_cb_detector-9999.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/actionlib[${PYTHON_USEDEP}]
 	dev-ros/cv_bridge
 	media-libs/opencv:=

--- a/dev-ros/laser_geometry/laser_geometry-1.6.4.ebuild
+++ b/dev-ros/laser_geometry/laser_geometry-1.6.4.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/tf
 	dev-ros/tf2_ros[${PYTHON_USEDEP}]
 	dev-cpp/eigen:3

--- a/dev-ros/laser_geometry/laser_geometry-9999.ebuild
+++ b/dev-ros/laser_geometry/laser_geometry-9999.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP},${CATKIN_MESSAGES_PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/tf
 	dev-ros/tf2_ros[${PYTHON_USEDEP}]
 	dev-cpp/eigen:3

--- a/dev-ros/message_filters/message_filters-1.14.3-r1.ebuild
+++ b/dev-ros/message_filters/message_filters-1.14.3-r1.ebuild
@@ -18,7 +18,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/rosconsole
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/genpy[${PYTHON_USEDEP}]
 	dev-ros/roslib[${PYTHON_USEDEP}]
 	dev-python/rospkg[${PYTHON_USEDEP}]"

--- a/dev-ros/message_filters/message_filters-9999.ebuild
+++ b/dev-ros/message_filters/message_filters-9999.ebuild
@@ -18,7 +18,7 @@ IUSE=""
 RDEPEND="
 	dev-ros/rosconsole
 	dev-ros/roscpp
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/genpy[${PYTHON_USEDEP}]
 	dev-ros/roslib[${PYTHON_USEDEP}]
 	dev-python/rospkg[${PYTHON_USEDEP}]"

--- a/dev-ros/monocam_settler/monocam_settler-0.10.13.ebuild
+++ b/dev-ros/monocam_settler/monocam_settler-0.10.13.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/rosconsole
 	dev-ros/roscpp_serialization
 	dev-ros/settlerlib
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-cpp/gtest )"

--- a/dev-ros/monocam_settler/monocam_settler-0.10.14.ebuild
+++ b/dev-ros/monocam_settler/monocam_settler-0.10.14.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/rosconsole
 	dev-ros/roscpp_serialization
 	dev-ros/settlerlib
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-cpp/gtest )"

--- a/dev-ros/monocam_settler/monocam_settler-9999.ebuild
+++ b/dev-ros/monocam_settler/monocam_settler-9999.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-ros/rosconsole
 	dev-ros/roscpp_serialization
 	dev-ros/settlerlib
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-cpp/gtest )"

--- a/dev-ros/move_slow_and_clear/move_slow_and_clear-1.16.1.ebuild
+++ b/dev-ros/move_slow_and_clear/move_slow_and_clear-1.16.1.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-ros/pluginlib
 	dev-ros/roscpp
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/eigen:3
 	dev-libs/console_bridge:=
 "

--- a/dev-ros/move_slow_and_clear/move_slow_and_clear-1.16.2.ebuild
+++ b/dev-ros/move_slow_and_clear/move_slow_and_clear-1.16.2.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-ros/pluginlib
 	dev-ros/roscpp
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/eigen:3
 	dev-libs/console_bridge:=
 "

--- a/dev-ros/move_slow_and_clear/move_slow_and_clear-9999.ebuild
+++ b/dev-ros/move_slow_and_clear/move_slow_and_clear-9999.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-ros/pluginlib
 	dev-ros/roscpp
 
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/eigen:3
 	dev-libs/console_bridge:=
 "

--- a/dev-ros/navfn/navfn-1.16.0.ebuild
+++ b/dev-ros/navfn/navfn-1.16.0.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	dev-cpp/eigen:3
 	x11-libs/fltk
 	media-libs/netpbm
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/navfn/navfn-1.16.1.ebuild
+++ b/dev-ros/navfn/navfn-1.16.1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	dev-cpp/eigen:3
 	x11-libs/fltk
 	media-libs/netpbm
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/navfn/navfn-1.16.2.ebuild
+++ b/dev-ros/navfn/navfn-1.16.2.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	dev-cpp/eigen:3
 	x11-libs/fltk
 	media-libs/netpbm
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/navfn/navfn-9999.ebuild
+++ b/dev-ros/navfn/navfn-9999.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	dev-cpp/eigen:3
 	x11-libs/fltk
 	media-libs/netpbm
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/nodelet_topic_tools/nodelet_topic_tools-1.9.16.ebuild
+++ b/dev-ros/nodelet_topic_tools/nodelet_topic_tools-1.9.16.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/dynamic_reconfigure[${PYTHON_USEDEP}]
 	dev-ros/message_filters
 	dev-ros/nodelet

--- a/dev-ros/nodelet_topic_tools/nodelet_topic_tools-9999.ebuild
+++ b/dev-ros/nodelet_topic_tools/nodelet_topic_tools-9999.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/dynamic_reconfigure[${PYTHON_USEDEP}]
 	dev-ros/message_filters
 	dev-ros/nodelet

--- a/dev-ros/openni2_camera/openni2_camera-0.3.0-r1.ebuild
+++ b/dev-ros/openni2_camera/openni2_camera-0.3.0-r1.ebuild
@@ -24,6 +24,6 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-libs/OpenNI2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/openni2_camera/openni2_camera-0.4.0.ebuild
+++ b/dev-ros/openni2_camera/openni2_camera-0.4.0.ebuild
@@ -24,6 +24,6 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-libs/OpenNI2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/openni2_camera/openni2_camera-0.4.2.ebuild
+++ b/dev-ros/openni2_camera/openni2_camera-0.4.2.ebuild
@@ -24,6 +24,6 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-libs/OpenNI2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/openni2_camera/openni2_camera-9999.ebuild
+++ b/dev-ros/openni2_camera/openni2_camera-9999.ebuild
@@ -24,6 +24,6 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-libs/OpenNI2
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/pcl_ros/pcl_ros-1.5.4.ebuild
+++ b/dev-ros/pcl_ros/pcl_ros-1.5.4.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	dev-ros/nodelet_topic_tools
 	sci-libs/pcl:=[qhull]
 	>=dev-ros/pcl_conversions-0.2.1-r1
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/pcl_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]

--- a/dev-ros/pcl_ros/pcl_ros-1.6.1.ebuild
+++ b/dev-ros/pcl_ros/pcl_ros-1.6.1.ebuild
@@ -32,7 +32,7 @@ RDEPEND="
 	dev-ros/nodelet_topic_tools
 	sci-libs/pcl:=[qhull]
 	>=dev-ros/pcl_conversions-0.2.1-r1
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/pcl_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]

--- a/dev-ros/pcl_ros/pcl_ros-1.6.2.ebuild
+++ b/dev-ros/pcl_ros/pcl_ros-1.6.2.ebuild
@@ -32,7 +32,7 @@ RDEPEND="
 	dev-ros/nodelet_topic_tools
 	sci-libs/pcl:=[qhull]
 	>=dev-ros/pcl_conversions-0.2.1-r1
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/pcl_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]

--- a/dev-ros/pcl_ros/pcl_ros-9999.ebuild
+++ b/dev-ros/pcl_ros/pcl_ros-9999.ebuild
@@ -32,7 +32,7 @@ RDEPEND="
 	dev-ros/nodelet_topic_tools
 	sci-libs/pcl:=[qhull]
 	>=dev-ros/pcl_conversions-0.2.1-r1
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/pcl_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/std_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]

--- a/dev-ros/random_numbers/random_numbers-0.3.1.ebuild
+++ b/dev-ros/random_numbers/random_numbers-0.3.1.ebuild
@@ -13,5 +13,5 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]"
+RDEPEND="dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/random_numbers/random_numbers-0.3.2.ebuild
+++ b/dev-ros/random_numbers/random_numbers-0.3.2.ebuild
@@ -13,5 +13,5 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]"
+RDEPEND="dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/random_numbers/random_numbers-9999.ebuild
+++ b/dev-ros/random_numbers/random_numbers-9999.ebuild
@@ -13,5 +13,5 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]"
+RDEPEND="dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"

--- a/dev-ros/robot_pose_ekf/robot_pose_ekf-1.14.0.ebuild
+++ b/dev-ros/robot_pose_ekf/robot_pose_ekf-1.14.0.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	sci-libs/orocos-bfl
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest[${PYTHON_USEDEP}] )

--- a/dev-ros/robot_pose_ekf/robot_pose_ekf-1.14.2.ebuild
+++ b/dev-ros/robot_pose_ekf/robot_pose_ekf-1.14.2.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	sci-libs/orocos-bfl
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest[${PYTHON_USEDEP}] )

--- a/dev-ros/robot_pose_ekf/robot_pose_ekf-1.15.1.ebuild
+++ b/dev-ros/robot_pose_ekf/robot_pose_ekf-1.15.1.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	sci-libs/orocos-bfl
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest[${PYTHON_USEDEP}] )

--- a/dev-ros/robot_pose_ekf/robot_pose_ekf-1.15.2.ebuild
+++ b/dev-ros/robot_pose_ekf/robot_pose_ekf-1.15.2.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	sci-libs/orocos-bfl
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest[${PYTHON_USEDEP}] )

--- a/dev-ros/robot_pose_ekf/robot_pose_ekf-9999.ebuild
+++ b/dev-ros/robot_pose_ekf/robot_pose_ekf-9999.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	sci-libs/orocos-bfl
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest[${PYTHON_USEDEP}] )

--- a/dev-ros/rosconsole/rosconsole-1.13.7.ebuild
+++ b/dev-ros/rosconsole/rosconsole-1.13.7.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	dev-ros/cpp_common
 	dev-ros/rostime
 	dev-ros/rosunit
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	log4cxx? ( dev-libs/log4cxx )
 	!log4cxx? ( glog? ( dev-cpp/glog ) )
 "

--- a/dev-ros/rosconsole/rosconsole-1.13.9.ebuild
+++ b/dev-ros/rosconsole/rosconsole-1.13.9.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	dev-ros/cpp_common
 	dev-ros/rostime
 	dev-ros/rosunit
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	log4cxx? ( dev-libs/log4cxx )
 	!log4cxx? ( glog? ( dev-cpp/glog ) )
 "

--- a/dev-ros/rosconsole/rosconsole-9999.ebuild
+++ b/dev-ros/rosconsole/rosconsole-9999.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	dev-ros/cpp_common
 	dev-ros/rostime
 	dev-ros/rosunit
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	log4cxx? ( dev-libs/log4cxx )
 	!log4cxx? ( glog? ( dev-cpp/glog ) )
 "

--- a/dev-ros/roscpp_tutorials/roscpp_tutorials-0.6.1.ebuild
+++ b/dev-ros/roscpp_tutorials/roscpp_tutorials-0.6.1.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rostime
 	dev-ros/roscpp
 	dev-ros/rosconsole

--- a/dev-ros/roscpp_tutorials/roscpp_tutorials-0.7.0.ebuild
+++ b/dev-ros/roscpp_tutorials/roscpp_tutorials-0.7.0.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rostime
 	dev-ros/roscpp
 	dev-ros/rosconsole

--- a/dev-ros/roscpp_tutorials/roscpp_tutorials-0.7.1.ebuild
+++ b/dev-ros/roscpp_tutorials/roscpp_tutorials-0.7.1.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rostime
 	dev-ros/roscpp
 	dev-ros/rosconsole

--- a/dev-ros/roscpp_tutorials/roscpp_tutorials-0.8.0.ebuild
+++ b/dev-ros/roscpp_tutorials/roscpp_tutorials-0.8.0.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rostime
 	dev-ros/roscpp
 	dev-ros/rosconsole

--- a/dev-ros/roscpp_tutorials/roscpp_tutorials-0.8.1.ebuild
+++ b/dev-ros/roscpp_tutorials/roscpp_tutorials-0.8.1.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rostime
 	dev-ros/roscpp
 	dev-ros/rosconsole

--- a/dev-ros/roscpp_tutorials/roscpp_tutorials-0.9.0.ebuild
+++ b/dev-ros/roscpp_tutorials/roscpp_tutorials-0.9.0.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rostime
 	dev-ros/roscpp
 	dev-ros/rosconsole

--- a/dev-ros/roscpp_tutorials/roscpp_tutorials-0.9.1.ebuild
+++ b/dev-ros/roscpp_tutorials/roscpp_tutorials-0.9.1.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rostime
 	dev-ros/roscpp
 	dev-ros/rosconsole

--- a/dev-ros/roscpp_tutorials/roscpp_tutorials-9999.ebuild
+++ b/dev-ros/roscpp_tutorials/roscpp_tutorials-9999.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rostime
 	dev-ros/roscpp
 	dev-ros/rosconsole

--- a/dev-ros/roslib/roslib-1.14.0-r1.ebuild
+++ b/dev-ros/roslib/roslib-1.14.0-r1.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-python/rospkg-1.0.37[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospack
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/roslib/roslib-1.14.1.ebuild
+++ b/dev-ros/roslib/roslib-1.14.1.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-python/rospkg-1.0.37[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospack
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/roslib/roslib-1.14.2.ebuild
+++ b/dev-ros/roslib/roslib-1.14.2.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-python/rospkg-1.0.37[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospack
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/roslib/roslib-1.14.3.ebuild
+++ b/dev-ros/roslib/roslib-1.14.3.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-python/rospkg-1.0.37[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospack
 	dev-ros/ros_environment
 "

--- a/dev-ros/roslib/roslib-1.14.4.ebuild
+++ b/dev-ros/roslib/roslib-1.14.4.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-python/rospkg-1.0.37[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospack
 	dev-ros/ros_environment
 "

--- a/dev-ros/roslib/roslib-1.14.6.ebuild
+++ b/dev-ros/roslib/roslib-1.14.6.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-python/rospkg-1.0.37[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospack
 	dev-ros/ros_environment
 "

--- a/dev-ros/roslib/roslib-9999.ebuild
+++ b/dev-ros/roslib/roslib-9999.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	>=dev-python/rospkg-1.0.37[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospack
 	dev-ros/ros_environment
 "

--- a/dev-ros/rosserial_server/rosserial_server-0.8.0.ebuild
+++ b/dev-ros/rosserial_server/rosserial_server-0.8.0.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/rosserial_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/topic_tools
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 PATCHES=( "${FILESDIR}/boost170.patch" )

--- a/dev-ros/rosserial_server/rosserial_server-9999.ebuild
+++ b/dev-ros/rosserial_server/rosserial_server-9999.ebuild
@@ -17,6 +17,6 @@ RDEPEND="
 	dev-ros/roscpp
 	dev-ros/rosserial_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/topic_tools
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/rostest/rostest-1.13.0.ebuild
+++ b/dev-ros/rostest/rostest-1.13.0.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostest/rostest-1.13.1.ebuild
+++ b/dev-ros/rostest/rostest-1.13.1.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostest/rostest-1.13.2.ebuild
+++ b/dev-ros/rostest/rostest-1.13.2.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostest/rostest-1.13.4.ebuild
+++ b/dev-ros/rostest/rostest-1.13.4.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostest/rostest-1.13.5.ebuild
+++ b/dev-ros/rostest/rostest-1.13.5.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostest/rostest-1.13.6.ebuild
+++ b/dev-ros/rostest/rostest-1.13.6.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostest/rostest-1.14.2.ebuild
+++ b/dev-ros/rostest/rostest-1.14.2.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostest/rostest-1.14.3.ebuild
+++ b/dev-ros/rostest/rostest-1.14.3.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostest/rostest-9999.ebuild
+++ b/dev-ros/rostest/rostest-9999.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 RDEPEND="
 	dev-ros/rosunit[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 RDEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.5.6.ebuild
+++ b/dev-ros/rostime/rostime-0.5.6.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.5.7.ebuild
+++ b/dev-ros/rostime/rostime-0.5.7.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.0.ebuild
+++ b/dev-ros/rostime/rostime-0.6.0.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.1.ebuild
+++ b/dev-ros/rostime/rostime-0.6.1.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.10.ebuild
+++ b/dev-ros/rostime/rostime-0.6.10.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.11.ebuild
+++ b/dev-ros/rostime/rostime-0.6.11.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.12.ebuild
+++ b/dev-ros/rostime/rostime-0.6.12.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.2.ebuild
+++ b/dev-ros/rostime/rostime-0.6.2.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.3.ebuild
+++ b/dev-ros/rostime/rostime-0.6.3.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.4.ebuild
+++ b/dev-ros/rostime/rostime-0.6.4.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.5.ebuild
+++ b/dev-ros/rostime/rostime-0.6.5.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.7.ebuild
+++ b/dev-ros/rostime/rostime-0.6.7.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.8.ebuild
+++ b/dev-ros/rostime/rostime-0.6.8.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-0.6.9.ebuild
+++ b/dev-ros/rostime/rostime-0.6.9.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rostime/rostime-9999.ebuild
+++ b/dev-ros/rostime/rostime-9999.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/cpp_common
 "
 DEPEND="${RDEPEND}

--- a/dev-ros/rviz/rviz-1.13.1-r1.ebuild
+++ b/dev-ros/rviz/rviz-1.13.1-r1.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/assimp
 	<dev-games/ogre-1.10:=
 	virtual/opengl

--- a/dev-ros/rviz/rviz-1.13.3.ebuild
+++ b/dev-ros/rviz/rviz-1.13.3.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/assimp
 	<dev-games/ogre-1.10:=
 	virtual/opengl

--- a/dev-ros/rviz/rviz-9999.ebuild
+++ b/dev-ros/rviz/rviz-9999.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	media-libs/assimp
 	<dev-games/ogre-1.10:=
 	virtual/opengl

--- a/dev-ros/self_test/self_test-1.8.10.ebuild
+++ b/dev-ros/self_test/self_test-1.8.10.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/diagnostic_updater
 	dev-ros/roscpp
 	dev-ros/rostest
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest )"

--- a/dev-ros/self_test/self_test-1.8.8.ebuild
+++ b/dev-ros/self_test/self_test-1.8.8.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/diagnostic_updater
 	dev-ros/roscpp
 	dev-ros/rostest
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest )"

--- a/dev-ros/self_test/self_test-1.8.9.ebuild
+++ b/dev-ros/self_test/self_test-1.8.9.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/diagnostic_updater
 	dev-ros/roscpp
 	dev-ros/rostest
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest )"

--- a/dev-ros/self_test/self_test-1.9.0.ebuild
+++ b/dev-ros/self_test/self_test-1.9.0.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/diagnostic_updater
 	dev-ros/roscpp
 	dev-ros/rostest
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest )"

--- a/dev-ros/self_test/self_test-1.9.2.ebuild
+++ b/dev-ros/self_test/self_test-1.9.2.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/diagnostic_updater
 	dev-ros/roscpp
 	dev-ros/rostest
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest )"

--- a/dev-ros/self_test/self_test-1.9.3.ebuild
+++ b/dev-ros/self_test/self_test-1.9.3.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/diagnostic_updater
 	dev-ros/roscpp
 	dev-ros/rostest
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest )"

--- a/dev-ros/self_test/self_test-9999.ebuild
+++ b/dev-ros/self_test/self_test-9999.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-ros/diagnostic_updater
 	dev-ros/roscpp
 	dev-ros/rostest
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/rostest )"

--- a/dev-ros/stage_ros/stage_ros-1.7.5.ebuild
+++ b/dev-ros/stage_ros/stage_ros-1.7.5.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/geometry_msgs
 	dev-ros/nav_msgs
 	dev-ros/roscpp

--- a/dev-ros/stage_ros/stage_ros-1.8.0.ebuild
+++ b/dev-ros/stage_ros/stage_ros-1.8.0.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/geometry_msgs
 	dev-ros/nav_msgs
 	dev-ros/roscpp

--- a/dev-ros/stage_ros/stage_ros-9999.ebuild
+++ b/dev-ros/stage_ros/stage_ros-9999.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/geometry_msgs
 	dev-ros/nav_msgs
 	dev-ros/roscpp

--- a/dev-ros/stereo_image_proc/stereo_image_proc-1.12.22-r1.ebuild
+++ b/dev-ros/stereo_image_proc/stereo_image_proc-1.12.22-r1.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/stereo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	media-libs/opencv:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/stereo_image_proc/stereo_image_proc-1.12.23.ebuild
+++ b/dev-ros/stereo_image_proc/stereo_image_proc-1.12.23.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/stereo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	media-libs/opencv:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/stereo_image_proc/stereo_image_proc-9999.ebuild
+++ b/dev-ros/stereo_image_proc/stereo_image_proc-9999.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	dev-ros/sensor_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	dev-ros/stereo_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
 	media-libs/opencv:=
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/console_bridge:=
 "
 DEPEND="${RDEPEND}"

--- a/dev-ros/test_rosbag/test_rosbag-1.13.0.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-1.13.0.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_rosbag/test_rosbag-1.13.1.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-1.13.1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_rosbag/test_rosbag-1.13.2.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-1.13.2.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_rosbag/test_rosbag-1.13.4.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-1.13.4.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_rosbag/test_rosbag-1.13.5.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-1.13.5.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_rosbag/test_rosbag-1.13.6.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-1.13.6.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_rosbag/test_rosbag-1.14.2.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-1.14.2.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_rosbag/test_rosbag-1.14.3.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-1.14.3.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_rosbag/test_rosbag-9999.ebuild
+++ b/dev-ros/test_rosbag/test_rosbag-9999.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-libs/boost[threads]
+		dev-libs/boost[threads(+)]
 		app-arch/bzip2
 		dev-ros/rosout
 		dev-python/nose[${PYTHON_USEDEP}]

--- a/dev-ros/test_roscpp/test_roscpp-1.14.3-r1.ebuild
+++ b/dev-ros/test_roscpp/test_roscpp-1.14.3-r1.ebuild
@@ -23,7 +23,7 @@ DEPEND="${RDEPEND}
 	dev-ros/rostest[${PYTHON_USEDEP}]
 	dev-ros/rosunit[${PYTHON_USEDEP}]
 	dev-ros/std_srvs[${CATKIN_MESSAGES_CXX_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	test? (
 		dev-cpp/gtest
 	)

--- a/dev-ros/test_roscpp/test_roscpp-9999.ebuild
+++ b/dev-ros/test_roscpp/test_roscpp-9999.ebuild
@@ -23,7 +23,7 @@ DEPEND="${RDEPEND}
 	dev-ros/rostest[${PYTHON_USEDEP}]
 	dev-ros/rosunit[${PYTHON_USEDEP}]
 	dev-ros/std_srvs[${CATKIN_MESSAGES_CXX_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	test? (
 		dev-cpp/gtest
 	)

--- a/dev-ros/test_tf2/test_tf2-0.6.1.ebuild
+++ b/dev-ros/test_tf2/test_tf2-0.6.1.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 	dev-ros/tf2_msgs
 	sci-libs/orocos_kdl
 	dev-python/python_orocos_kdl[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/gtest"
 
 mycatkincmakeargs=( "-DCATKIN_ENABLE_TESTING=ON" )

--- a/dev-ros/test_tf2/test_tf2-0.6.2.ebuild
+++ b/dev-ros/test_tf2/test_tf2-0.6.2.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 	dev-ros/tf2_msgs
 	sci-libs/orocos_kdl
 	dev-python/python_orocos_kdl[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/gtest"
 
 mycatkincmakeargs=( "-DCATKIN_ENABLE_TESTING=ON" )

--- a/dev-ros/test_tf2/test_tf2-0.6.3.ebuild
+++ b/dev-ros/test_tf2/test_tf2-0.6.3.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 	dev-ros/tf2_msgs
 	sci-libs/orocos_kdl
 	dev-python/python_orocos_kdl[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/gtest"
 
 mycatkincmakeargs=( "-DCATKIN_ENABLE_TESTING=ON" )

--- a/dev-ros/test_tf2/test_tf2-0.6.5.ebuild
+++ b/dev-ros/test_tf2/test_tf2-0.6.5.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 	dev-ros/tf2_msgs
 	sci-libs/orocos_kdl
 	dev-python/python_orocos_kdl[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/gtest"
 
 mycatkincmakeargs=( "-DCATKIN_ENABLE_TESTING=ON" )

--- a/dev-ros/test_tf2/test_tf2-9999.ebuild
+++ b/dev-ros/test_tf2/test_tf2-9999.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 	dev-ros/tf2_msgs
 	sci-libs/orocos_kdl
 	dev-python/python_orocos_kdl[${PYTHON_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/gtest"
 
 mycatkincmakeargs=( "-DCATKIN_ENABLE_TESTING=ON" )

--- a/dev-ros/tf/tf-1.12.0.ebuild
+++ b/dev-ros/tf/tf-1.12.0.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/angles
 	dev-ros/message_filters
 	dev-ros/rosconsole

--- a/dev-ros/tf/tf-9999.ebuild
+++ b/dev-ros/tf/tf-9999.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/angles
 	dev-ros/message_filters
 	dev-ros/rosconsole

--- a/dev-ros/tf2/tf2-0.6.5-r1.ebuild
+++ b/dev-ros/tf2/tf2-0.6.5-r1.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-libs/console_bridge:=
 	dev-ros/rostime
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/roscpp )

--- a/dev-ros/tf2/tf2-9999.ebuild
+++ b/dev-ros/tf2/tf2-9999.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	dev-libs/console_bridge:=
 	dev-ros/rostime
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}
 	test? ( dev-ros/roscpp )

--- a/dev-ros/tf2_ros/tf2_ros-0.6.1.ebuild
+++ b/dev-ros/tf2_ros/tf2_ros-0.6.1.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/message_filters
 	dev-ros/roscpp
 	dev-ros/rosgraph
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/tf2
 	dev-ros/tf2_py[${PYTHON_USEDEP}]

--- a/dev-ros/tf2_ros/tf2_ros-0.6.2.ebuild
+++ b/dev-ros/tf2_ros/tf2_ros-0.6.2.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/message_filters
 	dev-ros/roscpp
 	dev-ros/rosgraph
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/tf2
 	dev-ros/tf2_py[${PYTHON_USEDEP}]

--- a/dev-ros/tf2_ros/tf2_ros-0.6.3.ebuild
+++ b/dev-ros/tf2_ros/tf2_ros-0.6.3.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/message_filters
 	dev-ros/roscpp
 	dev-ros/rosgraph
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/tf2
 	dev-ros/tf2_py[${PYTHON_USEDEP}]

--- a/dev-ros/tf2_ros/tf2_ros-0.6.5.ebuild
+++ b/dev-ros/tf2_ros/tf2_ros-0.6.5.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/message_filters
 	dev-ros/roscpp
 	dev-ros/rosgraph
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/tf2
 	dev-ros/tf2_py[${PYTHON_USEDEP}]

--- a/dev-ros/tf2_ros/tf2_ros-9999.ebuild
+++ b/dev-ros/tf2_ros/tf2_ros-9999.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/message_filters
 	dev-ros/roscpp
 	dev-ros/rosgraph
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rospy[${PYTHON_USEDEP}]
 	dev-ros/tf2
 	dev-ros/tf2_py[${PYTHON_USEDEP}]

--- a/dev-ros/turtlesim/turtlesim-0.8.1.ebuild
+++ b/dev-ros/turtlesim/turtlesim-0.8.1.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rosconsole
 	dev-ros/roscpp
 	dev-ros/roscpp_serialization

--- a/dev-ros/turtlesim/turtlesim-0.9.0.ebuild
+++ b/dev-ros/turtlesim/turtlesim-0.9.0.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rosconsole
 	dev-ros/roscpp
 	dev-ros/roscpp_serialization

--- a/dev-ros/turtlesim/turtlesim-0.9.1.ebuild
+++ b/dev-ros/turtlesim/turtlesim-0.9.1.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rosconsole
 	dev-ros/roscpp
 	dev-ros/roscpp_serialization

--- a/dev-ros/turtlesim/turtlesim-9999.ebuild
+++ b/dev-ros/turtlesim/turtlesim-9999.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/rosconsole
 	dev-ros/roscpp
 	dev-ros/roscpp_serialization

--- a/dev-ros/urdf/urdf-1.13.1-r1.ebuild
+++ b/dev-ros/urdf/urdf-1.13.1-r1.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/urdfdom
 	dev-libs/urdfdom_headers
 	dev-ros/urdf_parser_plugin

--- a/dev-ros/urdf/urdf-9999.ebuild
+++ b/dev-ros/urdf/urdf-9999.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/urdfdom
 	dev-libs/urdfdom_headers
 	dev-ros/urdf_parser_plugin

--- a/dev-ros/visp_auto_tracker/visp_auto_tracker-0.10.0.ebuild
+++ b/dev-ros/visp_auto_tracker/visp_auto_tracker-0.10.0.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-ros/visp_bridge
 	dev-ros/visp_tracker
 	sci-libs/ViSP:=[dmtx,zbar]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 if [ "${PV#9999}" = "${PV}" ] ; then

--- a/dev-ros/visp_auto_tracker/visp_auto_tracker-0.11.1.ebuild
+++ b/dev-ros/visp_auto_tracker/visp_auto_tracker-0.11.1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-ros/visp_bridge
 	dev-ros/visp_tracker
 	sci-libs/ViSP:=[dmtx,zbar]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 if [ "${PV#9999}" = "${PV}" ] ; then

--- a/dev-ros/visp_auto_tracker/visp_auto_tracker-9999.ebuild
+++ b/dev-ros/visp_auto_tracker/visp_auto_tracker-9999.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-ros/visp_bridge
 	dev-ros/visp_tracker
 	sci-libs/ViSP:=[dmtx,zbar]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 "
 DEPEND="${RDEPEND}"
 if [ "${PV#9999}" = "${PV}" ] ; then

--- a/dev-ros/visp_tracker/visp_tracker-0.10.0-r2.ebuild
+++ b/dev-ros/visp_tracker/visp_tracker-0.10.0-r2.ebuild
@@ -18,7 +18,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/dynamic_reconfigure
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_PYTHON_USEDEP}]
 	dev-ros/image_proc

--- a/dev-ros/visp_tracker/visp_tracker-0.11.1.ebuild
+++ b/dev-ros/visp_tracker/visp_tracker-0.11.1.ebuild
@@ -18,7 +18,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/dynamic_reconfigure
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_PYTHON_USEDEP}]
 	dev-ros/image_proc

--- a/dev-ros/visp_tracker/visp_tracker-9999.ebuild
+++ b/dev-ros/visp_tracker/visp_tracker-9999.ebuild
@@ -18,7 +18,7 @@ SLOT="0"
 IUSE=""
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-ros/dynamic_reconfigure
 	dev-ros/geometry_msgs[${CATKIN_MESSAGES_PYTHON_USEDEP}]
 	dev-ros/image_proc

--- a/dev-util/source-highlight/source-highlight-3.1.8-r1.ebuild
+++ b/dev-util/source-highlight/source-highlight-3.1.8-r1.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~s
 SLOT="0"
 IUSE="doc static-libs"
 
-RDEPEND=">=dev-libs/boost-1.62.0:=[threads]
+RDEPEND=">=dev-libs/boost-1.62.0:=[threads(+)]
 	dev-util/ctags"
 DEPEND="${RDEPEND}"
 BDEPEND=""

--- a/dev-util/source-highlight/source-highlight-3.1.8.ebuild
+++ b/dev-util/source-highlight/source-highlight-3.1.8.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc 
 SLOT="0"
 IUSE="doc static-libs"
 
-RDEPEND=">=dev-libs/boost-1.62.0:=[threads]
+RDEPEND=">=dev-libs/boost-1.62.0:=[threads(+)]
 	dev-util/ctags"
 DEPEND="${RDEPEND}"
 

--- a/dev-util/source-highlight/source-highlight-3.1.9.ebuild
+++ b/dev-util/source-highlight/source-highlight-3.1.9.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~s
 SLOT="0"
 IUSE="doc static-libs"
 
-RDEPEND=">=dev-libs/boost-1.62.0:=[threads]
+RDEPEND=">=dev-libs/boost-1.62.0:=[threads(+)]
 	dev-util/ctags"
 DEPEND="${RDEPEND}"
 BDEPEND=""

--- a/games-engines/openmw/openmw-0.45.0.ebuild
+++ b/games-engines/openmw/openmw-0.45.0.ebuild
@@ -20,7 +20,7 @@ IUSE="doc devtools +qt5"
 RDEPEND="
 	dev-games/mygui
 	>=dev-games/openscenegraph-3.5.5:=[ffmpeg,jpeg,png,sdl,svg,truetype,zlib]
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/tinyxml[stl]
 	media-libs/libsdl2[joystick,opengl,video]
 	media-libs/openal

--- a/games-strategy/freeorion/freeorion-0.4.7.1-r4.ebuild
+++ b/games-strategy/freeorion/freeorion-0.4.7.1-r4.ebuild
@@ -26,7 +26,7 @@ IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="
-	>=dev-libs/boost-1.56:=[python,threads,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.56:=[python,threads(+),${PYTHON_USEDEP}]
 	media-libs/freealut
 	media-libs/freetype
 	media-libs/glew:=

--- a/games-strategy/freeorion/freeorion-0.4.8_p20190501.ebuild
+++ b/games-strategy/freeorion/freeorion-0.4.8_p20190501.ebuild
@@ -34,7 +34,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 RDEPEND="
-	>=dev-libs/boost-1.58:=[python,threads,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.58:=[python,threads(+),${PYTHON_USEDEP}]
 	!dedicated? (
 		media-libs/freealut
 		>=media-libs/freetype-2.5.5

--- a/games-strategy/freeorion/freeorion-9999.ebuild
+++ b/games-strategy/freeorion/freeorion-9999.ebuild
@@ -34,7 +34,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 RDEPEND="
-	>=dev-libs/boost-1.58:=[python,threads,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.58:=[python,threads(+),${PYTHON_USEDEP}]
 	!dedicated? (
 		media-libs/freealut
 		>=media-libs/freetype-2.5.5

--- a/games-strategy/glob2/glob2-0.9.4.4-r2.ebuild
+++ b/games-strategy/glob2/glob2-0.9.4.4-r2.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="
-	>=dev-libs/boost-1.34[threads]
+	>=dev-libs/boost-1.34[threads(+)]
 	dev-libs/fribidi
 	media-libs/libsdl[opengl]
 	media-libs/libvorbis

--- a/games-strategy/wesnoth/wesnoth-1.14.7.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.14.7.ebuild
@@ -18,7 +18,7 @@ fi
 IUSE="dbus dedicated doc fribidi libressl nls openmp server"
 
 RDEPEND="
-	>=dev-libs/boost-1.50:=[nls,threads,icu]
+	>=dev-libs/boost-1.50:=[nls,threads(+),icu]
 	>=media-libs/libsdl2-2.0.4:0[joystick,video,X]
 	!dedicated? (
 		dev-libs/glib:2

--- a/games-strategy/wesnoth/wesnoth-1.14.9.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.14.9.ebuild
@@ -19,7 +19,7 @@ fi
 IUSE="dbus dedicated doc fribidi libressl nls server"
 
 RDEPEND="
-	>=dev-libs/boost-1.50:=[nls,threads,icu]
+	>=dev-libs/boost-1.50:=[nls,threads(+),icu]
 	>=media-libs/libsdl2-2.0.4:0[joystick,video,X]
 	!dedicated? (
 		dev-libs/glib:2

--- a/games-strategy/wesnoth/wesnoth-1.15.2.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.15.2.ebuild
@@ -19,7 +19,7 @@ fi
 IUSE="dbus dedicated doc fribidi libressl nls server"
 
 RDEPEND="
-	>=dev-libs/boost-1.50:=[nls,threads,icu]
+	>=dev-libs/boost-1.50:=[nls,threads(+),icu]
 	>=media-libs/libsdl2-2.0.4:0[joystick,video,X]
 	!dedicated? (
 		dev-libs/glib:2

--- a/media-gfx/digikam/digikam-6.3.0-r1.ebuild
+++ b/media-gfx/digikam/digikam-6.3.0-r1.ebuild
@@ -102,7 +102,7 @@ COMMON_DEPEND="
 "
 DEPEND="${COMMON_DEPEND}
 	dev-cpp/eigen:3
-	dev-libs/boost[threads]
+	dev-libs/boost[threads(+)]
 "
 RDEPEND="${COMMON_DEPEND}
 	mysql? ( virtual/mysql[server] )

--- a/media-gfx/slic3r/slic3r-1.1.7.ebuild
+++ b/media-gfx/slic3r/slic3r-1.1.7.ebuild
@@ -16,7 +16,7 @@ IUSE="+gui test"
 
 # check Build.PL for dependencies
 RDEPEND="!=dev-lang/perl-5.16*
-	>=dev-libs/boost-1.55[threads]
+	>=dev-libs/boost-1.55[threads(+)]
 	dev-perl/Class-XSAccessor
 	dev-perl/Encode-Locale
 	dev-perl/IO-stringy

--- a/media-gfx/slic3r/slic3r-1.3.0-r1.ebuild
+++ b/media-gfx/slic3r/slic3r-1.3.0-r1.ebuild
@@ -16,7 +16,7 @@ IUSE="+gui test"
 
 # check Build.PL for dependencies
 RDEPEND="!=dev-lang/perl-5.16*
-	>=dev-libs/boost-1.55[threads]
+	>=dev-libs/boost-1.55[threads(+)]
 	dev-perl/Class-XSAccessor
 	dev-perl/Devel-CheckLib
 	dev-perl/Devel-Size

--- a/media-gfx/slic3r/slic3r-9999.ebuild
+++ b/media-gfx/slic3r/slic3r-9999.ebuild
@@ -17,7 +17,7 @@ IUSE="+gui test"
 
 # check Build.PL for dependencies
 RDEPEND="!=dev-lang/perl-5.16*
-	>=dev-libs/boost-1.55[threads]
+	>=dev-libs/boost-1.55[threads(+)]
 	dev-perl/Class-XSAccessor
 	dev-perl/Devel-CheckLib
 	dev-perl/Devel-Size

--- a/media-plugins/vdr-fritzbox/vdr-fritzbox-1.5.3-r1.ebuild
+++ b/media-plugins/vdr-fritzbox/vdr-fritzbox-1.5.3-r1.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 
 DEPEND="
 	dev-libs/libgcrypt:0
-	dev-libs/boost[threads]
+	dev-libs/boost[threads(+)]
 	>=media-video/vdr-1.7.34
 "
 RDEPEND="${DEPEND}"

--- a/media-sound/mp3diags/mp3diags-1.5.01.ebuild
+++ b/media-sound/mp3diags/mp3diags-1.5.01.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64"
 IUSE=""
 
 DEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5

--- a/media-sound/ncmpcpp/ncmpcpp-0.7.7.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-0.7.7.ebuild
@@ -16,7 +16,7 @@ RDEPEND="
 	!dev-libs/boost:0/1.57.0
 	>=media-libs/libmpdclient-2.1
 	dev-libs/boost:=[icu]
-	dev-libs/boost:=[nls,threads]
+	dev-libs/boost:=[nls,threads(+)]
 	dev-libs/icu:=
 	sys-libs/ncurses:=[unicode]
 	sys-libs/readline:*

--- a/media-sound/ncmpcpp/ncmpcpp-0.8.2-r1.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-0.8.2-r1.ebuild
@@ -15,7 +15,7 @@ IUSE="clock outputs taglib visualizer"
 RDEPEND="
 	!dev-libs/boost:0/1.57.0
 	>=media-libs/libmpdclient-2.1
-	dev-libs/boost:=[icu,nls,threads]
+	dev-libs/boost:=[icu,nls,threads(+)]
 	dev-libs/icu:=
 	net-misc/curl
 	sys-libs/ncurses:=[unicode]

--- a/media-sound/ncmpcpp/ncmpcpp-9999.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-9999.ebuild
@@ -16,7 +16,7 @@ IUSE="clock outputs taglib visualizer"
 RDEPEND="
 	!dev-libs/boost:0/1.57.0
 	>=media-libs/libmpdclient-2.1
-	dev-libs/boost:=[icu,nls,threads]
+	dev-libs/boost:=[icu,nls,threads(+)]
 	dev-libs/icu:=
 	net-misc/curl
 	sys-libs/ncurses:=[unicode]

--- a/media-video/aegisub/aegisub-3.2.2_p20160518-r2.ebuild
+++ b/media-video/aegisub/aegisub-3.2.2_p20160518-r2.ebuild
@@ -24,7 +24,7 @@ IUSE="+alsa debug +fftw openal oss portaudio pulseaudio spell test +uchardet"
 RDEPEND="
 	x11-libs/wxGTK:${WX_GTK_VER}[X,opengl,debug?]
 	dev-lang/luajit:2[lua52compat]
-	dev-libs/boost:=[icu,nls,threads]
+	dev-libs/boost:=[icu,nls,threads(+)]
 	dev-libs/icu:=
 	media-libs/ffmpegsource:=
 	media-libs/fontconfig

--- a/media-video/aegisub/aegisub-3.2.2_p20160518-r3.ebuild
+++ b/media-video/aegisub/aegisub-3.2.2_p20160518-r3.ebuild
@@ -24,7 +24,7 @@ IUSE="+alsa debug +fftw openal oss portaudio pulseaudio spell test +uchardet"
 RDEPEND="
 	x11-libs/wxGTK:${WX_GTK_VER}[X,opengl,debug?]
 	dev-lang/luajit:2[lua52compat]
-	dev-libs/boost:=[icu,nls,threads]
+	dev-libs/boost:=[icu,nls,threads(+)]
 	dev-libs/icu:=
 	media-libs/ffmpegsource:=
 	media-libs/fontconfig

--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -26,7 +26,7 @@ RESTRICT="test"
 RDEPEND="
 	x11-libs/wxGTK:${WX_GTK_VER}[X,opengl,debug?]
 	dev-lang/luajit:2[lua52compat]
-	dev-libs/boost:=[icu,nls,threads]
+	dev-libs/boost:=[icu,nls,threads(+)]
 	dev-libs/icu:=
 	media-libs/ffmpegsource:=
 	media-libs/fontconfig

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.10-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.10-r1.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	virtual/libiconv
 	examples? ( !net-p2p/mldonkey )
 	python? (

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.12-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.12-r1.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	virtual/libiconv
 	examples? ( !net-p2p/mldonkey )
 	python? (

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.13-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.1.13-r1.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	virtual/libiconv
 	examples? ( !net-p2p/mldonkey )
 	python? (

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.0-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.0-r1.ebuild
@@ -27,7 +27,7 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	virtual/libiconv
 	examples? ( !net-p2p/mldonkey )
 	python? (

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.1-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.1-r1.ebuild
@@ -27,7 +27,7 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	virtual/libiconv
 	examples? ( !net-p2p/mldonkey )
 	python? (

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
@@ -27,7 +27,7 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	virtual/libiconv
 	examples? ( !net-p2p/mldonkey )
 	python? (

--- a/net-libs/nghttp2/nghttp2-1.39.2.ebuild
+++ b/net-libs/nghttp2/nghttp2-1.39.2.ebuild
@@ -31,7 +31,7 @@ SSL_DEPEND="
 RDEPEND="
 	cxx? (
 		${SSL_DEPEND}
-		dev-libs/boost:=[${MULTILIB_USEDEP},threads]
+		dev-libs/boost:=[${MULTILIB_USEDEP},threads(+)]
 	)
 	hpack-tools? ( >=dev-libs/jansson-2.5 )
 	jemalloc? ( dev-libs/jemalloc[${MULTILIB_USEDEP}] )

--- a/net-libs/nghttp2/nghttp2-1.40.0.ebuild
+++ b/net-libs/nghttp2/nghttp2-1.40.0.ebuild
@@ -31,7 +31,7 @@ SSL_DEPEND="
 RDEPEND="
 	cxx? (
 		${SSL_DEPEND}
-		dev-libs/boost:=[${MULTILIB_USEDEP},threads]
+		dev-libs/boost:=[${MULTILIB_USEDEP},threads(+)]
 	)
 	hpack-tools? ( >=dev-libs/jansson-2.5 )
 	jemalloc? ( dev-libs/jemalloc[${MULTILIB_USEDEP}] )

--- a/net-libs/nghttp2/nghttp2-9999.ebuild
+++ b/net-libs/nghttp2/nghttp2-9999.ebuild
@@ -31,7 +31,7 @@ SSL_DEPEND="
 RDEPEND="
 	cxx? (
 		${SSL_DEPEND}
-		dev-libs/boost:=[${MULTILIB_USEDEP},threads]
+		dev-libs/boost:=[${MULTILIB_USEDEP},threads(+)]
 	)
 	hpack-tools? ( >=dev-libs/jansson-2.5 )
 	jemalloc? ( dev-libs/jemalloc[${MULTILIB_USEDEP}] )

--- a/net-vpn/freelan/freelan-2.2.ebuild
+++ b/net-vpn/freelan/freelan-2.2.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~amd64"
 IUSE="debug"
 
 DEPEND="
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/openssl:0=
 	net-misc/curl:=
 	virtual/libiconv

--- a/net-vpn/i2pd/i2pd-2.27.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.27.0.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	acct-user/i2pd
 	acct-group/i2pd
 	!static? (
-		dev-libs/boost:=[threads]
+		dev-libs/boost:=[threads(+)]
 		!libressl? ( dev-libs/openssl:0=[-bindist] )
 		libressl? (
 			dev-libs/libressl:0=
@@ -28,7 +28,7 @@ RDEPEND="
 	)"
 DEPEND="${RDEPEND}
 	static? (
-		dev-libs/boost:=[static-libs,threads]
+		dev-libs/boost:=[static-libs,threads(+)]
 		!libressl? ( dev-libs/openssl:0=[static-libs] )
 		libressl? (
 			dev-libs/libressl:0=[static-libs]

--- a/net-vpn/i2pd/i2pd-2.28.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.28.0.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	acct-user/i2pd
 	acct-group/i2pd
 	!static? (
-		dev-libs/boost:=[threads]
+		dev-libs/boost:=[threads(+)]
 		!libressl? ( dev-libs/openssl:0=[-bindist] )
 		libressl? (
 			dev-libs/libressl:0=
@@ -28,7 +28,7 @@ RDEPEND="
 	)"
 DEPEND="${RDEPEND}
 	static? (
-		dev-libs/boost:=[static-libs,threads]
+		dev-libs/boost:=[static-libs,threads(+)]
 		!libressl? ( dev-libs/openssl:0=[static-libs] )
 		libressl? (
 			dev-libs/libressl:0=[static-libs]

--- a/net-vpn/i2pd/i2pd-2.29.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.29.0.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	acct-user/i2pd
 	acct-group/i2pd
 	!static? (
-		dev-libs/boost:=[threads]
+		dev-libs/boost:=[threads(+)]
 		!libressl? ( dev-libs/openssl:0=[-bindist] )
 		libressl? (
 			dev-libs/libressl:0=
@@ -29,7 +29,7 @@ RDEPEND="
 	)"
 DEPEND="${RDEPEND}
 	static? (
-		dev-libs/boost:=[static-libs,threads]
+		dev-libs/boost:=[static-libs,threads(+)]
 		!libressl? ( dev-libs/openssl:0=[static-libs] )
 		libressl? (
 			dev-libs/libressl:0=[static-libs]

--- a/net-wireless/gr-baz/gr-baz-9999.ebuild
+++ b/net-wireless/gr-baz/gr-baz-9999.ebuild
@@ -23,7 +23,7 @@ IUSE="armadillo doc rtlsdr uhd"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
-	dev-libs/boost:=[threads,${PYTHON_USEDEP}]
+	dev-libs/boost:=[threads(+),${PYTHON_USEDEP}]
 	>=net-wireless/gnuradio-3.7.0:=[${PYTHON_USEDEP}]
 	armadillo? ( sci-libs/armadillo )
 	rtlsdr? ( virtual/libusb:1 )

--- a/sci-biology/mira/mira-4.0.2.ebuild
+++ b/sci-biology/mira/mira-4.0.2.ebuild
@@ -24,7 +24,7 @@ KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux ~x86-macos"
 IUSE="doc"
 
 CDEPEND="
-	dev-libs/boost[threads]
+	dev-libs/boost[threads(+)]
 	dev-util/google-perftools"
 DEPEND="${CDEPEND}
 	sys-devel/flex

--- a/sci-biology/tophat/tophat-2.1.1-r4.ebuild
+++ b/sci-biology/tophat/tophat-2.1.1-r4.ebuild
@@ -18,7 +18,7 @@ IUSE="debug"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-python/intervaltree[${PYTHON_USEDEP}]
 	dev-python/sortedcontainers[${PYTHON_USEDEP}]
 	sci-biology/samtools:0.1-legacy

--- a/sci-chemistry/autodock_vina/autodock_vina-1.1.2.ebuild
+++ b/sci-chemistry/autodock_vina/autodock_vina-1.1.2.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="amd64 x86"
 LICENSE="Apache-2.0"
 IUSE="debug"
 
-RDEPEND="dev-libs/boost[threads]"
+RDEPEND="dev-libs/boost[threads(+)]"
 DEPEND="${RDEPEND}"
 
 S="${WORKDIR}"/${MY_P}/build/linux/release

--- a/sci-chemistry/dssp/dssp-2.2.1-r1.ebuild
+++ b/sci-chemistry/dssp/dssp-2.2.1-r1.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
-RDEPEND="dev-libs/boost:=[threads]"
+RDEPEND="dev-libs/boost:=[threads(+)]"
 DEPEND="${RDEPEND}"
 
 PATCHES=(

--- a/sci-electronics/gazebo/gazebo-10.0.0.ebuild
+++ b/sci-electronics/gazebo/gazebo-10.0.0.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtcore:5
 	dev-qt/qtopengl:5
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	sci-libs/gdal:=
 	virtual/libusb:1
 	dev-libs/libspnav

--- a/sci-electronics/gazebo/gazebo-10.1.0.ebuild
+++ b/sci-electronics/gazebo/gazebo-10.1.0.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtcore:5
 	dev-qt/qtopengl:5
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	sci-libs/gdal:=
 	virtual/libusb:1
 	dev-libs/libspnav

--- a/sci-electronics/gazebo/gazebo-9.4.1.ebuild
+++ b/sci-electronics/gazebo/gazebo-9.4.1.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtcore:5
 	dev-qt/qtopengl:5
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	sci-libs/gdal:=
 	virtual/libusb:1
 	dev-libs/libspnav

--- a/sci-electronics/gazebo/gazebo-9.6.0.ebuild
+++ b/sci-electronics/gazebo/gazebo-9.6.0.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtcore:5
 	dev-qt/qtopengl:5
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	sci-libs/gdal:=
 	virtual/libusb:1
 	dev-libs/libspnav

--- a/sci-electronics/kicad/kicad-4.0.7.ebuild
+++ b/sci-electronics/kicad/kicad-4.0.7.ebuild
@@ -37,7 +37,7 @@ COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 		dev-python/wxpython:${WX_GTK_VER}[opengl,${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
-	>=dev-libs/boost-1.61:=[context,nls,threads,python?,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.61:=[context,nls,threads(+),python?,${PYTHON_USEDEP}]
 	github? (
 		libressl? ( dev-libs/libressl:0= )
 		!libressl? ( dev-libs/openssl:0= )

--- a/sci-electronics/kicad/kicad-5.0.1.ebuild
+++ b/sci-electronics/kicad/kicad-5.0.1.ebuild
@@ -27,7 +27,7 @@ COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 		dev-python/wxpython:${WX_GTK_VER}[opengl,${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
-	>=dev-libs/boost-1.61:=[context,nls,threads,python?,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.61:=[context,nls,threads(+),python?,${PYTHON_USEDEP}]
 	github? ( net-misc/curl:=[ssl] )
 	media-libs/glew:0=
 	media-libs/glm

--- a/sci-electronics/kicad/kicad-5.1.0-r1.ebuild
+++ b/sci-electronics/kicad/kicad-5.1.0-r1.ebuild
@@ -28,7 +28,7 @@ COMMON_DEPEND=">=x11-libs/wxGTK-3.0.2:${WX_GTK_VER}[X,opengl]
 		dev-python/wxpython:${WX_GTK_VER}[opengl,${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
-	>=dev-libs/boost-1.61:=[context,nls,threads,python?,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.61:=[context,nls,threads(+),python?,${PYTHON_USEDEP}]
 	github? ( net-misc/curl:=[ssl] )
 	media-libs/glew:0=
 	media-libs/glm

--- a/sci-electronics/kicad/kicad-5.1.2-r1.ebuild
+++ b/sci-electronics/kicad/kicad-5.1.2-r1.ebuild
@@ -28,7 +28,7 @@ COMMON_DEPEND="x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
 		dev-python/wxpython:4.0[${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
-	>=dev-libs/boost-1.61:=[context,nls,threads,python?,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.61:=[context,nls,threads(+),python?,${PYTHON_USEDEP}]
 	github? ( net-misc/curl:=[ssl] )
 	media-libs/glew:0=
 	media-libs/glm

--- a/sci-electronics/kicad/kicad-5.1.4.ebuild
+++ b/sci-electronics/kicad/kicad-5.1.4.ebuild
@@ -28,7 +28,7 @@ COMMON_DEPEND="x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
 		dev-python/wxpython:4.0[${PYTHON_USEDEP}]
 		${PYTHON_DEPS}
 	)
-	>=dev-libs/boost-1.61:=[context,nls,threads,python?,${PYTHON_USEDEP}]
+	>=dev-libs/boost-1.61:=[context,nls,threads(+),python?,${PYTHON_USEDEP}]
 	github? ( net-misc/curl:=[ssl] )
 	media-libs/glew:0=
 	>=media-libs/glm-0.9.9.1

--- a/sci-geosciences/mapnik/mapnik-3.0.18.ebuild
+++ b/sci-geosciences/mapnik/mapnik-3.0.18.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="cairo debug doc gdal osmfonts postgres sqlite"
 
 RDEPEND="
-	>=dev-libs/boost-1.48:=[threads]
+	>=dev-libs/boost-1.48:=[threads(+)]
 	dev-libs/icu:=
 	sys-libs/zlib
 	media-libs/freetype

--- a/sci-geosciences/mapnik/mapnik-3.0.9-r1.ebuild
+++ b/sci-geosciences/mapnik/mapnik-3.0.9-r1.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="cairo debug doc gdal postgres sqlite"
 
 RDEPEND="
-	>=dev-libs/boost-1.48:=[threads]
+	>=dev-libs/boost-1.48:=[threads(+)]
 	dev-libs/icu:=
 	sys-libs/zlib
 	media-libs/freetype

--- a/sci-libs/ViSP/ViSP-3.0.1-r1.ebuild
+++ b/sci-libs/ViSP/ViSP-3.0.1-r1.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	jpeg? ( virtual/jpeg:0 )
 	lapack? ( virtual/lapack )
 	motif? ( media-libs/SoXt )
-	ogre? ( dev-games/ogre[ois(+)] dev-libs/boost:=[threads] )
+	ogre? ( dev-games/ogre[ois(+)] dev-libs/boost:=[threads(+)] )
 	opencv? ( media-libs/opencv:= )
 	png? ( media-libs/libpng:0= )
 	usb? ( virtual/libusb:1 )

--- a/sci-libs/ViSP/ViSP-3.1.0-r1.ebuild
+++ b/sci-libs/ViSP/ViSP-3.1.0-r1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	jpeg? ( virtual/jpeg:0 )
 	lapack? ( virtual/lapack )
 	motif? ( media-libs/SoXt )
-	ogre? ( dev-games/ogre[ois(+)] dev-libs/boost:=[threads] )
+	ogre? ( dev-games/ogre[ois(+)] dev-libs/boost:=[threads(+)] )
 	opencv? ( media-libs/opencv:= )
 	png? ( media-libs/libpng:0= )
 	usb? ( virtual/libusb:1 )

--- a/sci-libs/ViSP/ViSP-3.2.0-r2.ebuild
+++ b/sci-libs/ViSP/ViSP-3.2.0-r2.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	jpeg? ( virtual/jpeg:0 )
 	lapack? ( virtual/lapack )
 	motif? ( media-libs/SoXt )
-	ogre? ( dev-games/ogre[ois(+)] dev-libs/boost:=[threads] )
+	ogre? ( dev-games/ogre[ois(+)] dev-libs/boost:=[threads(+)] )
 	opencv? ( media-libs/opencv:= )
 	png? ( media-libs/libpng:0= )
 	usb? ( virtual/libusb:1 )

--- a/sci-libs/coinor-cppad/coinor-cppad-20140519-r1.ebuild
+++ b/sci-libs/coinor-cppad/coinor-cppad-20140519-r1.ebuild
@@ -19,7 +19,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc examples"
 
 RDEPEND="
-	dev-libs/boost[threads]
+	dev-libs/boost[threads(+)]
 	sci-libs/adolc:0=
 	sci-libs/ipopt:0="
 DEPEND="${RDEPEND}

--- a/sci-libs/fcl/fcl-0.5.0.ebuild
+++ b/sci-libs/fcl/fcl-0.5.0.ebuild
@@ -28,7 +28,7 @@ IUSE="cpu_flags_x86_sse"
 RDEPEND="
 	sci-libs/octomap
 	sci-libs/flann
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	sci-libs/libccd"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"

--- a/sci-libs/fcl/fcl-9999.ebuild
+++ b/sci-libs/fcl/fcl-9999.ebuild
@@ -28,7 +28,7 @@ IUSE="cpu_flags_x86_sse"
 RDEPEND="
 	sci-libs/octomap
 	sci-libs/flann
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	sci-libs/libccd"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"

--- a/sci-libs/pcl/pcl-1.9.1.ebuild
+++ b/sci-libs/pcl/pcl-1.9.1.ebuild
@@ -28,7 +28,7 @@ IUSE="cuda doc opengl openni openni2 pcap png +qhull qt5 usb vtk cpu_flags_x86_s
 
 RDEPEND="
 	>=sci-libs/flann-1.7.1
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/eigen:3
 	opengl? ( virtual/opengl media-libs/freeglut )
 	openni? ( dev-libs/OpenNI )

--- a/sci-libs/pcl/pcl-9999.ebuild
+++ b/sci-libs/pcl/pcl-9999.ebuild
@@ -28,7 +28,7 @@ IUSE="cuda doc opengl openni openni2 pcap png +qhull qt5 usb vtk cpu_flags_x86_s
 
 RDEPEND="
 	>=sci-libs/flann-1.7.1
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-cpp/eigen:3
 	opengl? ( virtual/opengl media-libs/freeglut )
 	openni? ( dev-libs/OpenNI )

--- a/sci-mathematics/cgal/cgal-4.11.3.ebuild
+++ b/sci-mathematics/cgal/cgal-4.11.3.ebuild
@@ -20,7 +20,7 @@ IUSE="doc examples +gmp mpfi ntl qt5"
 
 RDEPEND="
 	dev-cpp/eigen
-	dev-libs/boost:=[threads]
+	dev-libs/boost:=[threads(+)]
 	dev-libs/mpfr:0=
 	sys-libs/zlib:=
 	x11-libs/libX11:=

--- a/sys-cluster/ceph/ceph-12.2.11.ebuild
+++ b/sys-cluster/ceph/ceph-12.2.11.ebuild
@@ -60,7 +60,7 @@ COMMON_DEPEND="
 		net-misc/curl:=[curl_ssl_openssl,static-libs?]
 	)
 	system-boost? (
-		=dev-libs/boost-1.66*:=[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+		=dev-libs/boost-1.66*:=[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 	)
 	jemalloc? ( dev-libs/jemalloc:=[static-libs?] )
 	!jemalloc? ( >=dev-util/google-perftools-2.4:=[static-libs?] )

--- a/sys-cluster/ceph/ceph-12.2.12-r2.ebuild
+++ b/sys-cluster/ceph/ceph-12.2.12-r2.ebuild
@@ -60,7 +60,7 @@ COMMON_DEPEND="
 		net-misc/curl:=[curl_ssl_openssl,static-libs?]
 	)
 	system-boost? (
-		=dev-libs/boost-1.66*:=[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+		=dev-libs/boost-1.66*:=[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 	)
 	jemalloc? ( dev-libs/jemalloc:=[static-libs?] )
 	!jemalloc? ( >=dev-util/google-perftools-2.4:=[static-libs?] )

--- a/sys-cluster/ceph/ceph-12.2.8-r1.ebuild
+++ b/sys-cluster/ceph/ceph-12.2.8-r1.ebuild
@@ -60,7 +60,7 @@ COMMON_DEPEND="
 		net-misc/curl:=[curl_ssl_openssl,static-libs?]
 	)
 	system-boost? (
-		=dev-libs/boost-1.66*:=[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+		=dev-libs/boost-1.66*:=[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 	)
 	jemalloc? ( dev-libs/jemalloc:=[static-libs?] )
 	!jemalloc? ( >=dev-util/google-perftools-2.4:=[static-libs?] )

--- a/sys-cluster/ceph/ceph-13.2.5-r4.ebuild
+++ b/sys-cluster/ceph/ceph-13.2.5-r4.ebuild
@@ -72,7 +72,7 @@ COMMON_DEPEND="
 		)
 	)
 	system-boost? (
-		>=dev-libs/boost-1.67:=[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+		>=dev-libs/boost-1.67:=[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 	)
 	jemalloc? ( dev-libs/jemalloc:=[static-libs?] )
 	!jemalloc? ( >=dev-util/google-perftools-2.4:=[static-libs?] )

--- a/sys-cluster/ceph/ceph-13.2.6.ebuild
+++ b/sys-cluster/ceph/ceph-13.2.6.ebuild
@@ -72,7 +72,7 @@ COMMON_DEPEND="
 		)
 	)
 	system-boost? (
-		>=dev-libs/boost-1.67:=[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+		>=dev-libs/boost-1.67:=[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 	)
 	jemalloc? ( dev-libs/jemalloc:=[static-libs?] )
 	!jemalloc? ( >=dev-util/google-perftools-2.4:=[static-libs?] )

--- a/sys-cluster/ceph/ceph-14.2.4-r1.ebuild
+++ b/sys-cluster/ceph/ceph-14.2.4-r1.ebuild
@@ -73,10 +73,10 @@ COMMON_DEPEND="
 	)
 	system-boost? (
 		|| (
-			~dev-libs/boost-1.70.0[threads,context,python,static-libs?,${PYTHON_USEDEP}]
-			~dev-libs/boost-1.67.0[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+			~dev-libs/boost-1.70.0[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
+			~dev-libs/boost-1.67.0[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 		)
-		dev-libs/boost:=[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+		dev-libs/boost:=[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 	)
 	jemalloc? ( dev-libs/jemalloc:=[static-libs?] )
 	!jemalloc? ( >=dev-util/google-perftools-2.4:=[static-libs?] )

--- a/sys-cluster/ceph/ceph-14.2.4-r2.ebuild
+++ b/sys-cluster/ceph/ceph-14.2.4-r2.ebuild
@@ -82,10 +82,10 @@ COMMON_DEPEND="
 	)
 	system-boost? (
 		|| (
-			~dev-libs/boost-1.70.0[threads,context,python,static-libs?,${PYTHON_USEDEP}]
-			~dev-libs/boost-1.67.0[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+			~dev-libs/boost-1.70.0[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
+			~dev-libs/boost-1.67.0[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 		)
-		dev-libs/boost:=[threads,context,python,static-libs?,${PYTHON_USEDEP}]
+		dev-libs/boost:=[threads(+),context,python,static-libs?,${PYTHON_USEDEP}]
 	)
 	jemalloc? ( dev-libs/jemalloc:=[static-libs?] )
 	!jemalloc? ( >=dev-util/google-perftools-2.4:=[static-libs?] )

--- a/sys-process/usbtop/usbtop-0.2.ebuild
+++ b/sys-process/usbtop/usbtop-0.2.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="net-libs/libpcap:=[usb]
-		dev-libs/boost:=[threads]"
+		dev-libs/boost:=[threads(+)]"
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}-release-${PV}"


### PR DESCRIPTION
* Once dev-libs/boost-1.72 arrives, all consumers will rebuild
  and get their VDB entries updated.
* Once dev-libs/boost-1.73 arrives, we will remove 'threads(+)'
  from all boost revdeps.

Signed-off-by: David Seifert <soap@gentoo.org>