### PR TITLE
www-client/netsurf: BDEPEND+="app-editors/vim"

### DIFF
--- a/www-client/netsurf/netsurf-3.9.ebuild
+++ b/www-client/netsurf/netsurf-3.9.ebuild
@@ -48,6 +48,7 @@ RDEPEND="
 		!svgtiny? ( gnome-base/librsvg:2 ) )
 	webp? ( >=media-libs/libwebp-0.3.0 )"
 BDEPEND="
+	duktape? ( app-editors/vim-core )
 	dev-libs/check
 	dev-perl/HTML-Parser
 	>=dev-util/netsurf-buildsystem-1.7-r1"


### PR DESCRIPTION
Netsurf 3.9 (more specifically Duktape) requires `xxd` to be present. That command is provided by `app-editors/vim-core`.

Closes: https://bugs.gentoo.org/702080
Package-Manager: Portage-2.3.80, Repoman-2.3.19
Signed-off-by: Philipp Ammann <philipp.ammann@posteo.de>