### PR TITLE
dev-python/libvirt-python-9999: Drop support for python2

### DIFF
--- a/dev-python/libvirt-python/libvirt-python-9999.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_6,3_7} )
+PYTHON_COMPAT=( python{3_6,3_7} )
 
 MY_P="${P/_rc/-rc}"
 


### PR DESCRIPTION
Upstream has dropped support for python 2 in b22e4f2.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>