### PR TITLE
app-shells/bash: fix CVE-2019-18276 (priv-dropping bug)

### DIFF
--- a/app-shells/bash/bash-5.0_p11-r1.ebuild
+++ b/app-shells/bash/bash-5.0_p11-r1.ebuild
@@ -1,0 +1,266 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic toolchain-funcs multilib prefix
+
+# Official patchlevel
+# See ftp://ftp.cwru.edu/pub/bash/bash-5.0-patches/
+PLEVEL=${PV##*_p}
+MY_PV=${PV/_p*}
+MY_PV=${MY_PV/_/-}
+MY_P=${PN}-${MY_PV}
+is_release() {
+	case ${PV} in
+	*_alpha*|*_beta*|*_rc*) return 1 ;;
+	*) return 0 ;;
+	esac
+}
+[[ ${PV} != *_p* ]] && PLEVEL=0
+patches() {
+	local opt=$1 plevel=${2:-${PLEVEL}} pn=${3:-${PN}} pv=${4:-${MY_PV}}
+	[[ ${plevel} -eq 0 ]] && return 1
+	eval set -- {1..${plevel}}
+	set -- $(printf "${pn}${pv/\.}-%03d " "$@")
+	if [[ ${opt} == -s ]] ; then
+		echo "${@/#/${DISTDIR}/}"
+	else
+		local u
+		for u in ftp://ftp.cwru.edu/pub/bash mirror://gnu/${pn} ; do
+			printf "${u}/${pn}-${pv}-patches/%s " "$@"
+		done
+	fi
+}
+
+# The version of readline this bash normally ships with.
+READLINE_VER="8.0"
+
+DESCRIPTION="The standard GNU Bourne again shell"
+HOMEPAGE="http://tiswww.case.edu/php/chet/bash/bashtop.html"
+if is_release ; then
+	SRC_URI="mirror://gnu/bash/${MY_P}.tar.gz $(patches)"
+else
+	SRC_URI="ftp://ftp.cwru.edu/pub/bash/${MY_P}.tar.gz"
+fi
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="afs bashlogger examples mem-scramble +net nls plugins +readline"
+
+DEPEND="
+	>=sys-libs/ncurses-5.2-r2:0=
+	nls? ( virtual/libintl )
+	readline? ( >=sys-libs/readline-${READLINE_VER}:0= )
+"
+RDEPEND="
+	${DEPEND}
+	!<sys-apps/portage-2.1.6.7_p1
+"
+# we only need yacc when the .y files get patched (bash42-005)
+#DEPEND+=" virtual/yacc"
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	# Patches from Chet sent to bashbug ml
+	"${FILESDIR}"/${PN}-5.0-history-append.patch
+	"${FILESDIR}"/${PN}-5.0-syslog-history-extern.patch
+	# fix CVE-2019-18276
+	"${FILESDIR}"/${PN}-5.0_p11-disable_priv_mode.patch
+)
+
+pkg_setup() {
+	if is-flag -malign-double ; then #7332
+		eerror "Detected bad CFLAGS '-malign-double'.  Do not use this"
+		eerror "as it breaks LFS (struct stat64) on x86."
+		die "remove -malign-double from your CFLAGS mr ricer"
+	fi
+	if use bashlogger ; then
+		ewarn "The logging patch should ONLY be used in restricted (i.e. honeypot) envs."
+		ewarn "This will log ALL output you enter into the shell, you have been warned."
+	fi
+}
+
+src_unpack() {
+	unpack ${MY_P}.tar.gz
+}
+
+src_prepare() {
+	# Include official patches
+	[[ ${PLEVEL} -gt 0 ]] && eapply -p0 $(patches -s)
+
+	# Clean out local libs so we know we use system ones w/releases.
+	if is_release ; then
+		rm -rf lib/{readline,termcap}/*
+		touch lib/{readline,termcap}/Makefile.in # for config.status
+		sed -ri -e 's:\$[(](RL|HIST)_LIBSRC[)]/[[:alpha:]]*.h::g' Makefile.in || die
+	fi
+
+	# Prefixify hardcoded path names. No-op for non-prefix.
+	hprefixify pathnames.h.in
+
+	# Avoid regenerating docs after patches #407985
+	sed -i -r '/^(HS|RL)USER/s:=.*:=:' doc/Makefile.in || die
+	touch -r . doc/*
+
+	eapply -p0 "${PATCHES[@]}"
+	eapply_user
+}
+
+src_configure() {
+	local myconf=(
+		--disable-profiling
+		--docdir='$(datarootdir)'/doc/${PF}
+		--htmldir='$(docdir)/html'
+		--with-curses
+		$(use_enable mem-scramble)
+		$(use_enable net net-redirections)
+		$(use_enable readline)
+		$(use_enable readline bang-history)
+		$(use_enable readline history)
+		$(use_with afs)
+		$(use_with mem-scramble bash-malloc)
+	)
+
+	# For descriptions of these, see config-top.h
+	# bashrc/#26952 bash_logout/#90488 ssh/#24762 mktemp/#574426
+	append-cppflags \
+		-DDEFAULT_PATH_VALUE=\'\"${EPREFIX}/usr/local/sbin:${EPREFIX}/usr/local/bin:${EPREFIX}/usr/sbin:${EPREFIX}/usr/bin:${EPREFIX}/sbin:${EPREFIX}/bin\"\' \
+		-DSTANDARD_UTILS_PATH=\'\"${EPREFIX}/bin:${EPREFIX}/usr/bin:${EPREFIX}/sbin:${EPREFIX}/usr/sbin\"\' \
+		-DSYS_BASHRC=\'\"${EPREFIX}/etc/bash/bashrc\"\' \
+		-DSYS_BASH_LOGOUT=\'\"${EPREFIX}/etc/bash/bash_logout\"\' \
+		-DNON_INTERACTIVE_LOGIN_SHELLS \
+		-DSSH_SOURCE_BASHRC \
+		$(use bashlogger && echo -DSYSLOG_HISTORY)
+
+	# Don't even think about building this statically without
+	# reading Bug 7714 first.  If you still build it statically,
+	# don't come crying to us with bugs ;).
+	#use static && export LDFLAGS="${LDFLAGS} -static"
+	use nls || myconf+=( --disable-nls )
+
+	# Historically, we always used the builtin readline, but since
+	# our handling of SONAME upgrades has gotten much more stable
+	# in the PM (and the readline ebuild itself preserves the old
+	# libs during upgrades), linking against the system copy should
+	# be safe.
+	# Exact cached version here doesn't really matter as long as it
+	# is at least what's in the DEPEND up above.
+	export ac_cv_rl_version=${READLINE_VER%%_*}
+
+	# Force linking with system curses ... the bundled termcap lib
+	# sucks bad compared to ncurses.  For the most part, ncurses
+	# is here because readline needs it.  But bash itself calls
+	# ncurses in one or two small places :(.
+
+	if is_release ; then
+		# Use system readline only with released versions.
+		myconf+=( --with-installed-readline=. )
+	fi
+
+	if use plugins; then
+		append-ldflags -Wl,-rpath,/usr/$(get_libdir)/bash
+	else
+		# Disable the plugins logic by hand since bash doesn't
+		# provide a way of doing it.
+		export ac_cv_func_dl{close,open,sym}=no \
+			ac_cv_lib_dl_dlopen=no ac_cv_header_dlfcn_h=no
+		sed -i \
+			-e '/LOCAL_LDFLAGS=/s:-rdynamic::' \
+			configure || die
+	fi
+	tc-export AR #444070
+	econf "${myconf[@]}"
+}
+
+src_compile() {
+	emake
+
+	if use plugins ; then
+		emake -C examples/loadables all others
+	fi
+}
+
+src_install() {
+	local d f
+
+	default
+
+	dodir /bin
+	mv "${ED}"/usr/bin/bash "${ED}"/bin/ || die
+	dosym bash /bin/rbash
+
+	insinto /etc/bash
+	doins "${FILESDIR}"/bash_logout
+	doins "$(prefixify_ro "${FILESDIR}"/bashrc)"
+	keepdir /etc/bash/bashrc.d
+	insinto /etc/skel
+	for f in bash{_logout,_profile,rc} ; do
+		newins "${FILESDIR}"/dot-${f} .${f}
+	done
+
+	local sed_args=(
+		-e "s:#${USERLAND}#@::"
+		-e '/#@/d'
+	)
+	if ! use readline ; then
+		sed_args+=( #432338
+			-e '/^shopt -s histappend/s:^:#:'
+			-e 's:use_color=true:use_color=false:'
+		)
+	fi
+	sed -i \
+		"${sed_args[@]}" \
+		"${ED}"/etc/skel/.bashrc \
+		"${ED}"/etc/bash/bashrc || die
+
+	if use plugins ; then
+		exeinto /usr/$(get_libdir)/bash
+		doexe $(echo examples/loadables/*.o | sed 's:\.o::g')
+		insinto /usr/include/bash-plugins
+		doins *.h builtins/*.h include/*.h lib/{glob/glob.h,tilde/tilde.h}
+	fi
+
+	if use examples ; then
+		for d in examples/{functions,misc,scripts,startup-files} ; do
+			exeinto /usr/share/doc/${PF}/${d}
+			insinto /usr/share/doc/${PF}/${d}
+			for f in ${d}/* ; do
+				if [[ ${f##*/} != PERMISSION ]] && [[ ${f##*/} != *README ]] ; then
+					doexe ${f}
+				else
+					doins ${f}
+				fi
+			done
+		done
+	fi
+
+	doman doc/*.1
+	newdoc CWRU/changelog ChangeLog
+	dosym bash.info /usr/share/info/bashref.info
+}
+
+pkg_preinst() {
+	if [[ -e ${EROOT}/etc/bashrc ]] && [[ ! -d ${EROOT}/etc/bash ]] ; then
+		mkdir -p "${EROOT}"/etc/bash
+		mv -f "${EROOT}"/etc/bashrc "${EROOT}"/etc/bash/
+	fi
+
+	if [[ -L ${EROOT}/bin/sh ]] ; then
+		# rewrite the symlink to ensure that its mtime changes. having /bin/sh
+		# missing even temporarily causes a fatal error with paludis.
+		local target=$(readlink "${EROOT}"/bin/sh)
+		local tmp=$(emktemp "${EROOT}"/bin)
+		ln -sf "${target}" "${tmp}"
+		mv -f "${tmp}" "${EROOT}"/bin/sh
+	fi
+}
+
+pkg_postinst() {
+	# If /bin/sh does not exist, provide it
+	if [[ ! -e ${EROOT}/bin/sh ]] ; then
+		ln -sf bash "${EROOT}"/bin/sh
+	fi
+}

--- a/app-shells/bash/files/bash-5.0_p11-disable_priv_mode.patch
+++ b/app-shells/bash/files/bash-5.0_p11-disable_priv_mode.patch
@@ -1,0 +1,85 @@
+diff -urP ../bash-5.0.orig/config.h.in config.h.in
+--- ../bash-5.0.orig/config.h.in	2018-12-04 09:54:17.000000000 -0700
++++ config.h.in	2019-12-10 11:34:42.157926317 -0700
+@@ -1,6 +1,6 @@
+ /* config.h -- Configuration file for bash. */
+ 
+-/* Copyright (C) 1987-2009,2011-2012 Free Software Foundation, Inc.
++/* Copyright (C) 1987-2009,2011-2012,2013-2019 Free Software Foundation, Inc.
+ 
+    This file is part of GNU Bash, the Bourne Again SHell.
+ 
+@@ -807,6 +807,14 @@
+ #undef HAVE_SETREGID
+ #undef HAVE_DECL_SETREGID
+ 
++/* Define if you have the setregid function.  */
++#undef HAVE_SETRESGID
++#undef HAVE_DECL_SETRESGID
++
++/* Define if you have the setresuid function.  */
++#undef HAVE_SETRESUID
++#undef HAVE_DECL_SETRESUID
++
+ /* Define if you have the setvbuf function.  */
+ #undef HAVE_SETVBUF
+ 
+diff -urP ../bash-5.0.orig/configure configure
+--- ../bash-5.0.orig/configure	2019-01-02 07:43:31.000000000 -0700
++++ configure	2019-12-10 11:34:42.166926317 -0700
+@@ -10281,6 +10281,17 @@
+ #define HAVE_DECL_SETREGID $ac_have_decl
+ _ACEOF
+ 
++ac_fn_c_check_decl "$LINENO" "" "ac_cv_have_decl_" "$ac_includes_default"
++if test "x$ac_cv_have_decl_" = xyes; then :
++  ac_have_decl=1
++else
++  ac_have_decl=0
++fi
++
++cat >>confdefs.h <<_ACEOF
++#define HAVE_DECL_ $ac_have_decl
++_ACEOF
++(setresuid, setresgid)
+ ac_fn_c_check_decl "$LINENO" "strcpy" "ac_cv_have_decl_strcpy" "$ac_includes_default"
+ if test "x$ac_cv_have_decl_strcpy" = xyes; then :
+   ac_have_decl=1
+diff -urP ../bash-5.0.orig/configure.ac configure.ac
+--- ../bash-5.0.orig/configure.ac	2019-01-02 07:39:11.000000000 -0700
++++ configure.ac	2019-12-10 11:34:42.168926317 -0700
+@@ -810,6 +810,7 @@
+ AC_CHECK_DECLS([printf])
+ AC_CHECK_DECLS([sbrk])
+ AC_CHECK_DECLS([setregid])
++AC_CHECK_DECLS[(setresuid, setresgid])
+ AC_CHECK_DECLS([strcpy])
+ AC_CHECK_DECLS([strsignal])
+ 
+diff -urP ../bash-5.0.orig/shell.c shell.c
+--- ../bash-5.0.orig/shell.c	2018-12-06 09:28:21.000000000 -0700
++++ shell.c	2019-12-10 11:34:42.170926317 -0700
+@@ -1293,7 +1293,11 @@
+ {
+   int e;
+ 
++#if HAVE_DECL_SETRESUID
++  if (setresuid (current_user.uid, current_user.uid, current_user.uid) < 0)
++#else
+   if (setuid (current_user.uid) < 0)
++#endif
+     {
+       e = errno;
+       sys_error (_("cannot set uid to %d: effective uid %d"), current_user.uid, current_user.euid);
+@@ -1302,7 +1306,11 @@
+ 	exit (e);
+ #endif
+     }
++#if HAVE_DECL_SETRESGID
++  if (setresgid (current_user.gid, current_user.gid, current_user.gid) < 0)
++#else
+   if (setgid (current_user.gid) < 0)
++#endif
+     sys_error (_("cannot set gid to %d: effective gid %d"), current_user.gid, current_user.egid);
+ 
+   current_user.euid = current_user.uid;


### PR DESCRIPTION
Cherry-picked the relevant parts of
https://git.savannah.gnu.org/cgit/bash.git/commit/?h=devel&id=951bdaad7a18cc0dc1036bba86b18b90874d39ff
and modified the patches to apply.

Note that the existing bash-5.0*patch files are applied with -p0, which
is not the norm for eapply, etc.  I simply followed what was required
to work with the rest of the existing patches.

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/702488
Package-Manager: Portage-2.3.79, Repoman-2.3.18