### PR TITLE
media-libs/libwebp: migrate to CPU_FLAGS_ARM

### DIFF
--- a/media-libs/libwebp/libwebp-1.0.2.ebuild
+++ b/media-libs/libwebp/libwebp-1.0.2.ebuild
@@ -14,7 +14,7 @@ LICENSE="BSD"
 SLOT="0/7" # subslot = libwebp soname version
 [[ "${PV}" = *_rc* ]] || \
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="cpu_flags_x86_sse2 cpu_flags_x86_sse4_1 gif +jpeg neon opengl +png static-libs swap-16bit-csp tiff"
+IUSE="cpu_flags_arm_neon cpu_flags_x86_sse2 cpu_flags_x86_sse4_1 gif +jpeg opengl +png static-libs swap-16bit-csp tiff"
 
 # TODO: dev-lang/swig bindings in swig/ subdirectory
 RDEPEND="gif? ( media-libs/giflib:= )
@@ -51,7 +51,7 @@ multilib_src_configure() {
 
 		$(use_enable cpu_flags_x86_sse2 sse2)
 		$(use_enable cpu_flags_x86_sse4_1 sse4.1)
-		$(use_enable neon)
+		$(use_enable cpu_flags_arm_neon neon)
 
 		# Only used for gif2webp binary wrt #486646
 		$(multilib_native_use_enable gif)

--- a/media-libs/libwebp/libwebp-1.0.3.ebuild
+++ b/media-libs/libwebp/libwebp-1.0.3.ebuild
@@ -14,7 +14,7 @@ LICENSE="BSD"
 SLOT="0/7" # subslot = libwebp soname version
 [[ "${PV}" = *_rc* ]] || \
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="cpu_flags_x86_sse2 cpu_flags_x86_sse4_1 gif +jpeg neon opengl +png static-libs swap-16bit-csp tiff"
+IUSE="cpu_flags_arm_neon cpu_flags_x86_sse2 cpu_flags_x86_sse4_1 gif +jpeg opengl +png static-libs swap-16bit-csp tiff"
 
 # TODO: dev-lang/swig bindings in swig/ subdirectory
 RDEPEND="gif? ( media-libs/giflib:= )
@@ -51,7 +51,7 @@ multilib_src_configure() {
 
 		$(use_enable cpu_flags_x86_sse2 sse2)
 		$(use_enable cpu_flags_x86_sse4_1 sse4.1)
-		$(use_enable neon)
+		$(use_enable cpu_flags_arm_neon neon)
 
 		# Only used for gif2webp binary wrt #486646
 		$(multilib_native_use_enable gif)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/694078
Package-Manager: Portage-2.3.79, Repoman-2.3.16
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>