### PR TITLE
haskell-cabal.eclass: Fix MissingTestRestrict

### DIFF
--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: haskell-cabal.eclass
@@ -137,6 +137,7 @@ fi
 
 if [[ -n "${CABAL_TEST_SUITE}" ]]; then
 	IUSE="${IUSE} test"
+	RESTRICT+=" !test? ( test )"
 fi
 
 # returns the version of cabal currently in use.


### PR DESCRIPTION
This fixes 564 cases of MissingTestRestrict.  According to md5-cache
inspection, no other changes in metadata occur.

Signed-off-by: Michał Górny <mgorny@gentoo.org>