### PR TITLE
app-arch/libarchive: import fixes for sparse file handling

### DIFF
--- a/app-arch/libarchive/files/libarchive-3.4.0-archive_read-fix-handling-of-sparse-files.patch
+++ b/app-arch/libarchive/files/libarchive-3.4.0-archive_read-fix-handling-of-sparse-files.patch
@@ -1,0 +1,33 @@
+From 2e3e1377163355ea937d01c870e779ea32f1caa7 Mon Sep 17 00:00:00 2001
+From: Dmitry Torokhov <dtor@chromium.org>
+Date: Tue, 25 Jun 2019 10:09:44 -0700
+Subject: [PATCH] archive_read: fix handling of sparse files
+
+If a file ends with a sparse "hole" that is larger than buffer supplied
+to archive_read(), then archive_read() will return prematurely because
+archive_read_data_block() will return ARHCIVE_EOF as there is no more
+"real" data. We can fix that by not trying to refill data buffer until
+we exhaust the hole range.
+
+Fixes libarchive#1194
+---
+ libarchive/archive_read.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libarchive/archive_read.c b/libarchive/archive_read.c
+index 0e56e76e..7548054e 100644
+--- a/libarchive/archive_read.c
++++ b/libarchive/archive_read.c
+@@ -835,7 +835,8 @@ archive_read_data(struct archive *_a, void *buff, size_t s)
+ 	dest = (char *)buff;
+ 
+ 	while (s > 0) {
+-		if (a->read_data_remaining == 0) {
++		if (a->read_data_offset == a->read_data_output_offset &&
++		    a->read_data_remaining == 0) {
+ 			read_buf = a->read_data_block;
+ 			a->read_data_is_posix_read = 1;
+ 			a->read_data_requested = s;
+-- 
+2.22.0.410.gd8fdbe21b5-goog
+

--- a/app-arch/libarchive/files/libarchive-3.4.0-archive_read_next_header2-clean-old-entry-entry-data.patch
+++ b/app-arch/libarchive/files/libarchive-3.4.0-archive_read_next_header2-clean-old-entry-entry-data.patch
@@ -1,0 +1,43 @@
+From edaacc6e6452164785a89e9384d722dc214cae51 Mon Sep 17 00:00:00 2001
+From: Dmitry Torokhov <dtor@chromium.org>
+Date: Tue, 25 Jun 2019 15:17:52 -0700
+Subject: [PATCH] archive_read_next_header2: clean old entry entry data
+
+We need to clean old entry data in archive_read_next_header2 in Windows
+and Posix disk readers to ensure consistent results. One possible
+failure mode: sparse data from the previous entry is carries over to
+next non-sparse file entry, causing it to be mishandled.
+---
+ libarchive/archive_read_disk_posix.c   | 2 ++
+ libarchive/archive_read_disk_windows.c | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/libarchive/archive_read_disk_posix.c b/libarchive/archive_read_disk_posix.c
+index c4df6c94..87963c3c 100644
+--- a/libarchive/archive_read_disk_posix.c
++++ b/libarchive/archive_read_disk_posix.c
+@@ -1143,6 +1143,8 @@ _archive_read_next_header2(struct archive *_a, struct archive_entry *entry)
+ 		t->entry_fd = -1;
+ 	}
+ 
++	archive_entry_clear(entry);
++
+ 	for (;;) {
+ 		r = next_entry(a, t, entry);
+ 		if (t->entry_fd >= 0) {
+diff --git a/libarchive/archive_read_disk_windows.c b/libarchive/archive_read_disk_windows.c
+index 964de749..3a58193f 100644
+--- a/libarchive/archive_read_disk_windows.c
++++ b/libarchive/archive_read_disk_windows.c
+@@ -1110,6 +1110,8 @@ _archive_read_next_header2(struct archive *_a, struct archive_entry *entry)
+ 		t->entry_fh = INVALID_HANDLE_VALUE;
+ 	}
+ 
++	archive_entry_clear(entry);
++
+ 	while ((r = next_entry(a, t, entry)) == ARCHIVE_RETRY)
+ 		archive_entry_clear(entry);
+ 
+-- 
+2.22.0.410.gd8fdbe21b5-goog
+

--- a/app-arch/libarchive/files/libarchive-3.4.0-fix-sparse-file-offset-overflow-on-32-bit-systems.patch
+++ b/app-arch/libarchive/files/libarchive-3.4.0-fix-sparse-file-offset-overflow-on-32-bit-systems.patch
@@ -1,0 +1,49 @@
+From 77797b83e8d9ed0f691fb8cb1900de071ad68329 Mon Sep 17 00:00:00 2001
+From: Daniel Verkamp <dverkamp@chromium.org>
+Date: Fri, 4 Oct 2019 12:31:32 -0700
+Subject: [PATCH] Fix sparse file offset overflow on 32-bit systems
+
+On architectures where size_t is 32 bits but file offsets are 64 bits
+(such as 32-bit Linux with _FILE_OFFSET_BITS=64), the POSIX disk reader
+would incorrectly skip large sparse regions due to a 32-bit integer
+overflow in _archive_read_data_block().
+
+The bytes variable was used to store the difference between two 64-bit
+integers, but bytes is a size_t.  Since this value of bytes was not used
+after the block handling sparse offsets (it is always overwritten in the
+block below), replace it with an int64_t sparse_bytes variable that can
+always represent the difference without truncation.
+
+Signed-off-by: Daniel Verkamp <dverkamp@chromium.org>
+---
+ libarchive/archive_read_disk_posix.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/libarchive/archive_read_disk_posix.c b/libarchive/archive_read_disk_posix.c
+index 87963c3c..f62d182e 100644
+--- a/libarchive/archive_read_disk_posix.c
++++ b/libarchive/archive_read_disk_posix.c
+@@ -694,6 +694,7 @@ _archive_read_data_block(struct archive *_a, const void **buff,
+ 	struct tree *t = a->tree;
+ 	int r;
+ 	ssize_t bytes;
++	int64_t sparse_bytes;
+ 	size_t buffbytes;
+ 	int empty_sparse_region = 0;
+ 
+@@ -792,9 +793,9 @@ _archive_read_data_block(struct archive *_a, const void **buff,
+ 			a->archive.state = ARCHIVE_STATE_FATAL;
+ 			goto abort_read_data;
+ 		}
+-		bytes = t->current_sparse->offset - t->entry_total;
+-		t->entry_remaining_bytes -= bytes;
+-		t->entry_total += bytes;
++		sparse_bytes = t->current_sparse->offset - t->entry_total;
++		t->entry_remaining_bytes -= sparse_bytes;
++		t->entry_total += sparse_bytes;
+ 	}
+ 
+ 	/*
+-- 
+2.23.0.581.g78d2f28ef7-goog
+

--- a/app-arch/libarchive/libarchive-3.4.0-r1.ebuild
+++ b/app-arch/libarchive/libarchive-3.4.0-r1.ebuild
@@ -1,0 +1,138 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit libtool multilib-minimal toolchain-funcs
+
+DESCRIPTION="Multi-format archive and compression library"
+HOMEPAGE="https://www.libarchive.org/"
+SRC_URI="https://www.libarchive.org/downloads/${P}.tar.gz"
+
+LICENSE="BSD BSD-2 BSD-4 public-domain"
+SLOT="0/13"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 ~riscv s390 sh sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="acl blake2 +bzip2 +e2fsprogs expat +iconv kernel_linux libressl lz4 +lzma lzo nettle static-libs +threads xattr +zlib zstd"
+
+RDEPEND="
+	acl? ( virtual/acl[${MULTILIB_USEDEP}] )
+	blake2? ( app-crypt/libb2[${MULTILIB_USEDEP}] )
+	bzip2? ( app-arch/bzip2[${MULTILIB_USEDEP}] )
+	expat? ( dev-libs/expat[${MULTILIB_USEDEP}] )
+	!expat? ( dev-libs/libxml2[${MULTILIB_USEDEP}] )
+	iconv? ( virtual/libiconv[${MULTILIB_USEDEP}] )
+	kernel_linux? (
+		xattr? ( sys-apps/attr[${MULTILIB_USEDEP}] )
+	)
+	!libressl? ( dev-libs/openssl:0=[${MULTILIB_USEDEP}] )
+	libressl? ( dev-libs/libressl:0=[${MULTILIB_USEDEP}] )
+	lz4? ( >=app-arch/lz4-0_p131:0=[${MULTILIB_USEDEP}] )
+	lzma? ( app-arch/xz-utils[threads=,${MULTILIB_USEDEP}] )
+	lzo? ( >=dev-libs/lzo-2[${MULTILIB_USEDEP}] )
+	nettle? ( dev-libs/nettle:0=[${MULTILIB_USEDEP}] )
+	zlib? ( sys-libs/zlib[${MULTILIB_USEDEP}] )
+	zstd? ( app-arch/zstd[${MULTILIB_USEDEP}] )"
+DEPEND="${RDEPEND}
+	kernel_linux? (
+		virtual/os-headers
+		e2fsprogs? ( sys-fs/e2fsprogs )
+	)"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.3.3-libressl.patch
+	"${FILESDIR}"/${P}-without_zlib_build_fix.patch #693202
+	"${FILESDIR}"/${P}-archive_read-fix-handling-of-sparse-files.patch #702582
+	"${FILESDIR}"/${P}-archive_read_next_header2-clean-old-entry-entry-data.patch #702582
+	"${FILESDIR}"/${P}-fix-sparse-file-offset-overflow-on-32-bit-systems.patch #702582
+)
+
+# Various test problems, starting with the fact that sandbox
+# explodes on long paths. https://bugs.gentoo.org/598806
+RESTRICT="test"
+
+src_prepare() {
+	default
+	elibtoolize  # is required for Solaris sol2_ld linker fix
+}
+
+multilib_src_configure() {
+	export ac_cv_header_ext2fs_ext2_fs_h=$(usex e2fsprogs) #354923
+
+	local myconf=(
+		$(use_enable acl)
+		$(use_enable static-libs static)
+		$(use_enable xattr)
+		$(use_with blake2 libb2)
+		$(use_with bzip2 bz2lib)
+		$(use_with expat)
+		$(use_with !expat xml2)
+		$(use_with iconv)
+		$(use_with lz4)
+		$(use_with lzma)
+		$(use_with lzo lzo2)
+		$(use_with nettle)
+		$(use_with zlib)
+		$(use_with zstd)
+
+		# Windows-specific
+		--without-cng
+	)
+	if multilib_is_native_abi ; then
+		myconf+=(
+			--enable-bsdcat=$(tc-is-static-only && echo static || echo shared)
+			--enable-bsdcpio=$(tc-is-static-only && echo static || echo shared)
+			--enable-bsdtar=$(tc-is-static-only && echo static || echo shared)
+		)
+	else
+		myconf+=(
+			--disable-bsdcat
+			--disable-bsdcpio
+			--disable-bsdtar
+		)
+	fi
+
+	ECONF_SOURCE="${S}" econf "${myconf[@]}"
+}
+
+multilib_src_compile() {
+	if multilib_is_native_abi ; then
+		emake
+	else
+		emake libarchive.la
+	fi
+}
+
+multilib_src_test() {
+	# Replace the default src_test so that it builds tests in parallel
+	multilib_is_native_abi && emake check
+}
+
+multilib_src_install() {
+	if multilib_is_native_abi ; then
+		emake DESTDIR="${D}" install
+
+		# Create symlinks for FreeBSD
+		if ! use prefix && [[ ${CHOST} == *-freebsd* ]]; then
+			# Exclude cat for the time being #589876
+			for bin in cpio tar; do
+				dosym bsd${bin} /usr/bin/${bin}
+				echo '.so bsd${bin}.1' > "${T}"/${bin}.1
+				doman "${T}"/${bin}.1
+			done
+		fi
+	else
+		local install_targets=(
+			install-includeHEADERS
+			install-libLTLIBRARIES
+			install-pkgconfigDATA
+		)
+		emake DESTDIR="${D}" "${install_targets[@]}"
+	fi
+
+	# Libs.private: should be used from libarchive.pc instead
+	find "${ED}" -type f -name "*.la" -delete || die
+}
+
+multilib_src_install_all() {
+	cd "${S}" || die
+	einstalldocs
+}


### PR DESCRIPTION
This imports 3 patches from upstream to fix handling of some sparse
files.

Closes: https://bugs.gentoo.org/702582
Signed-off-by: Dmitry Torokhov <dtor@chromium.org>