### PR TITLE
*/*: [QA] Remove redundant `|| die` on virtx

### DIFF
--- a/app-accessibility/at-spi2-atk/at-spi2-atk-2.30.1.ebuild
+++ b/app-accessibility/at-spi2-atk/at-spi2-atk-2.30.1.ebuild
@@ -34,7 +34,7 @@ multilib_src_compile() {
 }
 
 multilib_src_test() {
-	virtx dbus-run-session meson test -C "${BUILD_DIR}" || die 'tests failed'
+	virtx dbus-run-session meson test -C "${BUILD_DIR}"
 }
 
 multilib_src_install() {

--- a/app-accessibility/at-spi2-atk/at-spi2-atk-2.32.0.ebuild
+++ b/app-accessibility/at-spi2-atk/at-spi2-atk-2.32.0.ebuild
@@ -35,7 +35,7 @@ multilib_src_compile() {
 }
 
 multilib_src_test() {
-	virtx dbus-run-session meson test -C "${BUILD_DIR}" || die 'tests failed'
+	virtx dbus-run-session meson test -C "${BUILD_DIR}"
 }
 
 multilib_src_install() {

--- a/app-accessibility/at-spi2-atk/at-spi2-atk-2.34.0.ebuild
+++ b/app-accessibility/at-spi2-atk/at-spi2-atk-2.34.0.ebuild
@@ -35,7 +35,7 @@ multilib_src_compile() {
 }
 
 multilib_src_test() {
-	virtx dbus-run-session meson test -C "${BUILD_DIR}" || die 'tests failed'
+	virtx dbus-run-session meson test -C "${BUILD_DIR}"
 }
 
 multilib_src_install() {

--- a/dev-libs/gjs/gjs-1.56.2.ebuild
+++ b/dev-libs/gjs/gjs-1.56.2.ebuild
@@ -63,5 +63,5 @@ src_install() {
 }
 
 src_test() {
-	virtx dbus-run-session emake check || die
+	virtx dbus-run-session emake check
 }

--- a/dev-libs/libunique/libunique-1.1.6-r2.ebuild
+++ b/dev-libs/libunique/libunique-1.1.6-r2.ebuild
@@ -60,5 +60,5 @@ src_configure() {
 src_test() {
 	cd "${S}/tests"
 	cp "${FILESDIR}/run-tests" . || die "Unable to cp \${FILESDIR}/run-tests"
-	virtx emake -f run-tests || die "Tests failed"
+	virtx emake -f run-tests
 }

--- a/dev-libs/libunique/libunique-3.0.2-r1.ebuild
+++ b/dev-libs/libunique/libunique-3.0.2-r1.ebuild
@@ -42,5 +42,5 @@ src_configure() {
 src_test() {
 	cd "${S}/tests"
 	cp "${FILESDIR}/run-tests" . || die "Unable to cp \${FILESDIR}/run-tests"
-	virtx emake -f run-tests || die "Tests failed"
+	virtx emake -f run-tests
 }

--- a/dev-perl/Tk/Tk-804.34.0.ebuild
+++ b/dev-perl/Tk/Tk-804.34.0.ebuild
@@ -60,5 +60,5 @@ src_prepare() {
 	mv "${T}/stash/testimg.jpg" "${S}/JPEG/jpeg/testimg.jpg" || die "can't restore testimg.jpg"
 }
 src_test() {
-	virtx perl-module_src_test || die "src_test failed"
+	virtx perl-module_src_test
 }

--- a/dev-python/astroml/astroml-0.3.ebuild
+++ b/dev-python/astroml/astroml-0.3.ebuild
@@ -33,7 +33,7 @@ S="${WORKDIR}/${MYP}"
 DOCS=( CHANGES.rst README.rst )
 
 python_test() {
-	virtx nosetests --verbose || die
+	virtx nosetests --verbose
 }
 
 python_install_all() {

--- a/dev-python/cairocffi/cairocffi-0.8.0.ebuild
+++ b/dev-python/cairocffi/cairocffi-0.8.0.ebuild
@@ -45,7 +45,7 @@ python_compile_all() {
 }
 
 python_test() {
-	virtx py.test -v --pyargs cairocffi || die "testsuite failed under ${EPYTHON}"
+	virtx py.test -v --pyargs cairocffi
 }
 
 python_install_all() {

--- a/dev-python/cairocffi/cairocffi-0.9.0.ebuild
+++ b/dev-python/cairocffi/cairocffi-0.9.0.ebuild
@@ -43,7 +43,7 @@ python_compile_all() {
 }
 
 python_test() {
-	virtx py.test -v --pyargs cairocffi -o addopts= || die "testsuite failed under ${EPYTHON}"
+	virtx py.test -v --pyargs cairocffi -o addopts=
 }
 
 python_install_all() {

--- a/dev-python/cairocffi/cairocffi-1.0.2.ebuild
+++ b/dev-python/cairocffi/cairocffi-1.0.2.ebuild
@@ -48,7 +48,7 @@ python_compile_all() {
 }
 
 python_test() {
-	virtx py.test -v --pyargs cairocffi || die "testsuite failed under ${EPYTHON}"
+	virtx py.test -v --pyargs cairocffi
 }
 
 python_install_all() {

--- a/dev-python/cliff/cliff-2.12.0-r2.ebuild
+++ b/dev-python/cliff/cliff-2.12.0-r2.ebuild
@@ -50,5 +50,5 @@ RDEPEND="
 python_test() {
 	stestr init || die "stestr init failed under ${EPYTHON}"
 	# needs outside access, so blacklist the test
-	virtx stestr run --black-regex cliff.tests.test_app.TestIO.test_writer_encoding || die "stestr run failed under ${EPYTHON}"
+	virtx stestr run --black-regex cliff.tests.test_app.TestIO.test_writer_encoding
 }

--- a/dev-python/fonttools/fonttools-3.44.0.ebuild
+++ b/dev-python/fonttools/fonttools-3.44.0.ebuild
@@ -50,5 +50,5 @@ python_prepare_all() {
 
 python_test() {
 	# virtualx used when matplotlib is installed causing plot module tests to run
-	virtx pytest -vv Tests fontTools || die "pytest failed"
+	virtx pytest -vv Tests fontTools
 }

--- a/dev-python/fonttools/fonttools-4.0.1.ebuild
+++ b/dev-python/fonttools/fonttools-4.0.1.ebuild
@@ -47,5 +47,5 @@ python_prepare_all() {
 
 python_test() {
 	# virtualx used when matplotlib is installed causing plot module tests to run
-	virtx pytest -vv Tests fontTools || die "pytest failed"
+	virtx pytest -vv Tests fontTools
 }

--- a/dev-python/fonttools/fonttools-4.1.0.ebuild
+++ b/dev-python/fonttools/fonttools-4.1.0.ebuild
@@ -47,5 +47,5 @@ python_prepare_all() {
 
 python_test() {
 	# virtualx used when matplotlib is installed causing plot module tests to run
-	virtx pytest -vv Tests fontTools || die "pytest failed"
+	virtx pytest -vv Tests fontTools
 }

--- a/dev-python/glue-vispy-viewers/glue-vispy-viewers-0.7.2.ebuild
+++ b/dev-python/glue-vispy-viewers/glue-vispy-viewers-0.7.2.ebuild
@@ -41,5 +41,5 @@ DEPEND="
 python_test() {
 	cd "${BUILD_DIR}"/lib || die
 	echo "backend: Agg" > matplotlibrc
-	virtx py.test || die
+	virtx py.test
 }

--- a/dev-python/matplotlib2tikz/matplotlib2tikz-0.6.18.ebuild
+++ b/dev-python/matplotlib2tikz/matplotlib2tikz-0.6.18.ebuild
@@ -34,5 +34,5 @@ RESTRICT="test"
 
 python_test() {
 	local -x MPLBACKEND=Agg
-	virtx py.test -v || die "Tests failed with ${EPYTHON}"
+	virtx py.test -v
 }

--- a/dev-python/networkx/networkx-1.11-r1.ebuild
+++ b/dev-python/networkx/networkx-1.11-r1.ebuild
@@ -62,7 +62,7 @@ python_compile_all() {
 }
 
 python_test() {
-	virtx nosetests -vv || die
+	virtx nosetests -vv
 }
 
 python_install_all() {

--- a/dev-python/networkx/networkx-1.11.ebuild
+++ b/dev-python/networkx/networkx-1.11.ebuild
@@ -62,7 +62,7 @@ python_compile_all() {
 }
 
 python_test() {
-	virtx nosetests -vv || die
+	virtx nosetests -vv
 }
 
 python_install_all() {

--- a/dev-python/networkx/networkx-2.1.ebuild
+++ b/dev-python/networkx/networkx-2.1.ebuild
@@ -49,7 +49,7 @@ PATCHES=(
 )
 
 python_test() {
-	virtx nosetests -vv || die
+	virtx nosetests -vv
 }
 
 python_install_all() {

--- a/dev-python/networkx/networkx-2.2.ebuild
+++ b/dev-python/networkx/networkx-2.2.ebuild
@@ -48,7 +48,7 @@ PATCHES=(
 )
 
 python_test() {
-	virtx nosetests -vv || die
+	virtx nosetests -vv
 }
 
 python_install_all() {

--- a/dev-python/networkx/networkx-2.4.ebuild
+++ b/dev-python/networkx/networkx-2.4.ebuild
@@ -49,7 +49,7 @@ PATCHES=(
 )
 
 python_test() {
-	virtx nosetests -vv || die
+	virtx nosetests -vv
 }
 
 python_install_all() {

--- a/dev-python/notify2/notify2-0.3.1-r1.ebuild
+++ b/dev-python/notify2/notify2-0.3.1-r1.ebuild
@@ -18,7 +18,7 @@ IUSE="examples"
 RDEPEND="dev-python/dbus-python[${PYTHON_USEDEP}]"
 
 python_test() {
-	virtx ${EPYTHON} test_notify2.py || die
+	virtx ${EPYTHON} test_notify2.py
 }
 
 python_install_all() {

--- a/dev-python/notify2/notify2-0.3.1.ebuild
+++ b/dev-python/notify2/notify2-0.3.1.ebuild
@@ -18,7 +18,7 @@ IUSE="examples"
 RDEPEND="dev-python/dbus-python[${PYTHON_USEDEP}]"
 
 python_test() {
-	virtx ${EPYTHON} test_notify2.py || die
+	virtx ${EPYTHON} test_notify2.py
 }
 
 python_install_all() {

--- a/dev-python/notify2/notify2-0.3.ebuild
+++ b/dev-python/notify2/notify2-0.3.ebuild
@@ -18,7 +18,7 @@ IUSE="examples"
 RDEPEND="dev-python/dbus-python[${PYTHON_USEDEP}]"
 
 python_test() {
-	virtx ${EPYTHON} test_notify2.py || die
+	virtx ${EPYTHON} test_notify2.py
 }
 
 python_install_all() {

--- a/dev-python/pandas/pandas-0.19.1.ebuild
+++ b/dev-python/pandas/pandas-0.19.1.ebuild
@@ -118,7 +118,7 @@ python_compile_all() {
 	if use doc; then
 		cd "${BUILD_DIR}"/lib || die
 		cp -ar "${S}"/doc . && cd doc || die
-		LANG=C PYTHONPATH=. virtx ${EPYTHON} make.py html || die
+		LANG=C PYTHONPATH=. virtx ${EPYTHON} make.py html
 	fi
 }
 

--- a/dev-python/pandas/pandas-0.23.4.ebuild
+++ b/dev-python/pandas/pandas-0.23.4.ebuild
@@ -130,7 +130,7 @@ python_compile_all() {
 	if use doc; then
 		cd "${BUILD_DIR}"/lib || die
 		cp -ar "${S}"/doc . && cd doc || die
-		LANG=C PYTHONPATH=. virtx ${EPYTHON} make.py html || die
+		LANG=C PYTHONPATH=. virtx ${EPYTHON} make.py html
 	fi
 }
 

--- a/dev-python/pandas/pandas-0.24.2.ebuild
+++ b/dev-python/pandas/pandas-0.24.2.ebuild
@@ -126,7 +126,7 @@ python_compile_all() {
 	if use doc; then
 		cd "${BUILD_DIR}"/lib || die
 		cp -ar "${S}"/doc . && cd doc || die
-		LANG=C PYTHONPATH=. virtx ${EPYTHON} make.py html || die
+		LANG=C PYTHONPATH=. virtx ${EPYTHON} make.py html
 	fi
 }
 

--- a/dev-python/pandas/pandas-9999.ebuild
+++ b/dev-python/pandas/pandas-9999.ebuild
@@ -128,7 +128,7 @@ python_compile_all() {
 	if use doc; then
 		cd "${BUILD_DIR}"/lib || die
 		cp -ar "${S}"/doc . && cd doc || die
-		LANG=C PYTHONPATH=. virtx ${EPYTHON} make.py html || die
+		LANG=C PYTHONPATH=. virtx ${EPYTHON} make.py html
 	fi
 }
 

--- a/dev-python/pytest-mpl/pytest-mpl-0.8.ebuild
+++ b/dev-python/pytest-mpl/pytest-mpl-0.8.ebuild
@@ -27,5 +27,5 @@ DEPEND="${RDEPEND}
 
 python_test() {
 	echo "backend : Agg" > "${T}"/matplotlibrc || die
-	MPLCONFIGDIR="${T}" virtx py.test -v || die
+	MPLCONFIGDIR="${T}" virtx py.test -v
 }

--- a/dev-python/rpy/rpy-2.9.0.ebuild
+++ b/dev-python/rpy/rpy-2.9.0.ebuild
@@ -48,5 +48,5 @@ python_compile() {
 
 python_test() {
 	cd "${BUILD_DIR}"/lib || die
-	virtx "${EPYTHON}" -m 'rpy2.tests' || die
+	virtx "${EPYTHON}" -m 'rpy2.tests'
 }

--- a/dev-python/seaborn/seaborn-0.7.1.ebuild
+++ b/dev-python/seaborn/seaborn-0.7.1.ebuild
@@ -35,5 +35,5 @@ python_test() {
 	cat > matplotlibrc <<- EOF || die
 	backend : Agg
 	EOF
-	virtx nosetests --verbosity=3 || die
+	virtx nosetests --verbosity=3
 }

--- a/dev-python/seaborn/seaborn-0.8.1.ebuild
+++ b/dev-python/seaborn/seaborn-0.8.1.ebuild
@@ -35,5 +35,5 @@ python_test() {
 	cat > matplotlibrc <<- EOF || die
 	backend : Agg
 	EOF
-	virtx nosetests --verbosity=3 || die
+	virtx nosetests --verbosity=3
 }

--- a/dev-python/seaborn/seaborn-0.9.0.ebuild
+++ b/dev-python/seaborn/seaborn-0.9.0.ebuild
@@ -35,5 +35,5 @@ python_test() {
 	cat > matplotlibrc <<- EOF || die
 	backend : Agg
 	EOF
-	virtx nosetests --verbosity=3 || die
+	virtx nosetests --verbosity=3
 }

--- a/dev-python/statsmodels/statsmodels-0.8.0.ebuild
+++ b/dev-python/statsmodels/statsmodels-0.8.0.ebuild
@@ -57,7 +57,7 @@ python_compile_all() {
 
 python_test() {
 	cd "${BUILD_DIR}" || die
-	virtx nosetests -v || die
+	virtx nosetests -v
 }
 
 python_install_all() {

--- a/dev-python/wxpython/wxpython-4.0.6.ebuild
+++ b/dev-python/wxpython/wxpython-4.0.6.ebuild
@@ -86,5 +86,5 @@ python_install() {
 }
 
 python_test() {
-	virtx pytest -vv unittests || die "Test failed with ${EPYTHON}"
+	virtx pytest -vv unittests
 }

--- a/dev-python/xcffib/xcffib-0.8.1.ebuild
+++ b/dev-python/xcffib/xcffib-0.8.1.ebuild
@@ -35,5 +35,5 @@ DEPEND="
 PATCHES=( "${FILESDIR}"/${PN}-0.4.2-test-imports.patch )
 
 python_test() {
-	virtx nosetests -d -v || die
+	virtx nosetests -d -v
 }

--- a/dev-ruby/capybara/capybara-2.18.0.ebuild
+++ b/dev-ruby/capybara/capybara-2.18.0.ebuild
@@ -46,5 +46,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} -Ilib -S rspec-3 spec || die "Tests failed."
+	virtx ${RUBY} -Ilib -S rspec-3 spec
 }

--- a/dev-ruby/capybara/capybara-3.26.0.ebuild
+++ b/dev-ruby/capybara/capybara-3.26.0.ebuild
@@ -57,5 +57,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} -Ilib -S rspec-3 spec || die "Tests failed."
+	virtx ${RUBY} -Ilib -S rspec-3 spec
 }

--- a/dev-ruby/capybara/capybara-3.27.0.ebuild
+++ b/dev-ruby/capybara/capybara-3.27.0.ebuild
@@ -56,5 +56,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} -Ilib -S rspec-3 spec || die "Tests failed."
+	virtx ${RUBY} -Ilib -S rspec-3 spec
 }

--- a/dev-ruby/capybara/capybara-3.28.0.ebuild
+++ b/dev-ruby/capybara/capybara-3.28.0.ebuild
@@ -56,5 +56,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} -Ilib -S rspec-3 spec || die "Tests failed."
+	virtx ${RUBY} -Ilib -S rspec-3 spec
 }

--- a/dev-ruby/capybara/capybara-3.29.0.ebuild
+++ b/dev-ruby/capybara/capybara-3.29.0.ebuild
@@ -56,5 +56,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} -Ilib -S rspec-3 spec || die "Tests failed."
+	virtx ${RUBY} -Ilib -S rspec-3 spec
 }

--- a/dev-ruby/ruby-clutter-gstreamer/ruby-clutter-gstreamer-3.3.2.ebuild
+++ b/dev-ruby/ruby-clutter-gstreamer/ruby-clutter-gstreamer-3.3.2.ebuild
@@ -38,7 +38,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-clutter-gstreamer/ruby-clutter-gstreamer-3.3.6.ebuild
+++ b/dev-ruby/ruby-clutter-gstreamer/ruby-clutter-gstreamer-3.3.6.ebuild
@@ -38,7 +38,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-clutter-gstreamer/ruby-clutter-gstreamer-3.3.7.ebuild
+++ b/dev-ruby/ruby-clutter-gstreamer/ruby-clutter-gstreamer-3.3.7.ebuild
@@ -38,7 +38,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-clutter-gtk/ruby-clutter-gtk-3.3.2.ebuild
+++ b/dev-ruby/ruby-clutter-gtk/ruby-clutter-gtk-3.3.2.ebuild
@@ -40,7 +40,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-clutter-gtk/ruby-clutter-gtk-3.3.6.ebuild
+++ b/dev-ruby/ruby-clutter-gtk/ruby-clutter-gtk-3.3.6.ebuild
@@ -40,7 +40,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-clutter-gtk/ruby-clutter-gtk-3.3.7.ebuild
+++ b/dev-ruby/ruby-clutter-gtk/ruby-clutter-gtk-3.3.7.ebuild
@@ -40,7 +40,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-clutter/ruby-clutter-3.3.2.ebuild
+++ b/dev-ruby/ruby-clutter/ruby-clutter-3.3.2.ebuild
@@ -44,7 +44,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-clutter/ruby-clutter-3.3.6.ebuild
+++ b/dev-ruby/ruby-clutter/ruby-clutter-3.3.6.ebuild
@@ -44,7 +44,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-clutter/ruby-clutter-3.3.7.ebuild
+++ b/dev-ruby/ruby-clutter/ruby-clutter-3.3.7.ebuild
@@ -44,7 +44,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-gdk3/ruby-gdk3-3.3.2.ebuild
+++ b/dev-ruby/ruby-gdk3/ruby-gdk3-3.3.2.ebuild
@@ -37,7 +37,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-gdk3/ruby-gdk3-3.3.6.ebuild
+++ b/dev-ruby/ruby-gdk3/ruby-gdk3-3.3.6.ebuild
@@ -37,7 +37,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-gdk3/ruby-gdk3-3.3.7.ebuild
+++ b/dev-ruby/ruby-gdk3/ruby-gdk3-3.3.7.ebuild
@@ -37,7 +37,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-gstreamer/ruby-gstreamer-3.3.2.ebuild
+++ b/dev-ruby/ruby-gstreamer/ruby-gstreamer-3.3.2.ebuild
@@ -32,5 +32,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gstreamer/ruby-gstreamer-3.3.6.ebuild
+++ b/dev-ruby/ruby-gstreamer/ruby-gstreamer-3.3.6.ebuild
@@ -32,5 +32,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gstreamer/ruby-gstreamer-3.3.7.ebuild
+++ b/dev-ruby/ruby-gstreamer/ruby-gstreamer-3.3.7.ebuild
@@ -32,5 +32,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtk2/ruby-gtk2-3.3.2.ebuild
+++ b/dev-ruby/ruby-gtk2/ruby-gtk2-3.3.2.ebuild
@@ -34,5 +34,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtk2/ruby-gtk2-3.3.6.ebuild
+++ b/dev-ruby/ruby-gtk2/ruby-gtk2-3.3.6.ebuild
@@ -34,5 +34,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtk2/ruby-gtk2-3.3.7.ebuild
+++ b/dev-ruby/ruby-gtk2/ruby-gtk2-3.3.7.ebuild
@@ -34,5 +34,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtk3/ruby-gtk3-3.3.2.ebuild
+++ b/dev-ruby/ruby-gtk3/ruby-gtk3-3.3.2.ebuild
@@ -37,5 +37,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtk3/ruby-gtk3-3.3.6.ebuild
+++ b/dev-ruby/ruby-gtk3/ruby-gtk3-3.3.6.ebuild
@@ -37,5 +37,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtk3/ruby-gtk3-3.3.7.ebuild
+++ b/dev-ruby/ruby-gtk3/ruby-gtk3-3.3.7.ebuild
@@ -37,5 +37,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtksourceview/ruby-gtksourceview-3.3.2.ebuild
+++ b/dev-ruby/ruby-gtksourceview/ruby-gtksourceview-3.3.2.ebuild
@@ -28,5 +28,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtksourceview/ruby-gtksourceview-3.3.6.ebuild
+++ b/dev-ruby/ruby-gtksourceview/ruby-gtksourceview-3.3.6.ebuild
@@ -28,5 +28,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtksourceview/ruby-gtksourceview-3.3.7.ebuild
+++ b/dev-ruby/ruby-gtksourceview/ruby-gtksourceview-3.3.7.ebuild
@@ -28,5 +28,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }

--- a/dev-ruby/ruby-gtksourceview3/ruby-gtksourceview3-3.3.2.ebuild
+++ b/dev-ruby/ruby-gtksourceview3/ruby-gtksourceview3-3.3.2.ebuild
@@ -30,7 +30,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-gtksourceview3/ruby-gtksourceview3-3.3.6.ebuild
+++ b/dev-ruby/ruby-gtksourceview3/ruby-gtksourceview3-3.3.6.ebuild
@@ -30,7 +30,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-gtksourceview3/ruby-gtksourceview3-3.3.7.ebuild
+++ b/dev-ruby/ruby-gtksourceview3/ruby-gtksourceview3-3.3.7.ebuild
@@ -30,7 +30,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-vte3/ruby-vte3-3.3.2.ebuild
+++ b/dev-ruby/ruby-vte3/ruby-vte3-3.3.2.ebuild
@@ -32,7 +32,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-vte3/ruby-vte3-3.3.6.ebuild
+++ b/dev-ruby/ruby-vte3/ruby-vte3-3.3.6.ebuild
@@ -32,7 +32,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-vte3/ruby-vte3-3.3.7.ebuild
+++ b/dev-ruby/ruby-vte3/ruby-vte3-3.3.7.ebuild
@@ -32,7 +32,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	virtx ${RUBY} test/run-test.rb || die
+	virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-webkit2-gtk/ruby-webkit2-gtk-3.3.2.ebuild
+++ b/dev-ruby/ruby-webkit2-gtk/ruby-webkit2-gtk-3.3.2.ebuild
@@ -37,7 +37,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	DCONF_PROFILE="${T}" virtx ${RUBY} test/run-test.rb || die
+	DCONF_PROFILE="${T}" virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-webkit2-gtk/ruby-webkit2-gtk-3.3.6.ebuild
+++ b/dev-ruby/ruby-webkit2-gtk/ruby-webkit2-gtk-3.3.6.ebuild
@@ -37,7 +37,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	DCONF_PROFILE="${T}" virtx ${RUBY} test/run-test.rb || die
+	DCONF_PROFILE="${T}" virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/dev-ruby/ruby-webkit2-gtk/ruby-webkit2-gtk-3.3.7.ebuild
+++ b/dev-ruby/ruby-webkit2-gtk/ruby-webkit2-gtk-3.3.7.ebuild
@@ -37,7 +37,7 @@ each_ruby_compile() {
 }
 
 each_ruby_test() {
-	DCONF_PROFILE="${T}" virtx ${RUBY} test/run-test.rb || die
+	DCONF_PROFILE="${T}" virtx ${RUBY} test/run-test.rb
 }
 
 each_ruby_install() {

--- a/games-util/lutris/lutris-0.5.3.ebuild
+++ b/games-util/lutris/lutris-0.5.3.ebuild
@@ -55,7 +55,7 @@ python_install_all() {
 }
 
 python_test() {
-	virtx nosetests -v || die
+	virtx nosetests -v
 }
 
 pkg_preinst() {

--- a/games-util/lutris/lutris-0.5.4.ebuild
+++ b/games-util/lutris/lutris-0.5.4.ebuild
@@ -55,7 +55,7 @@ python_install_all() {
 }
 
 python_test() {
-	virtx nosetests -v || die
+	virtx nosetests -v
 }
 
 pkg_preinst() {

--- a/games-util/lutris/lutris-9999.ebuild
+++ b/games-util/lutris/lutris-9999.ebuild
@@ -55,7 +55,7 @@ python_install_all() {
 }
 
 python_test() {
-	virtx nosetests -v || die
+	virtx nosetests -v
 }
 
 pkg_preinst() {

--- a/sci-libs/scikits_image/scikits_image-0.13.0-r1.ebuild
+++ b/sci-libs/scikits_image/scikits_image-0.13.0-r1.ebuild
@@ -45,7 +45,7 @@ python_test() {
 	echo "backend : Agg" > matplotlibrc || die
 	#echo "backend.qt4 : PyQt4" >> matplotlibrc || die
 	#echo "backend.qt4 : PySide" >> matplotlibrc || die
-	MPLCONFIGDIR=. virtx nosetests --exe -v skimage || die
+	MPLCONFIGDIR=. virtx nosetests --exe -v skimage
 }
 
 pkg_postinst() {

--- a/sci-libs/scikits_image/scikits_image-0.13.0.ebuild
+++ b/sci-libs/scikits_image/scikits_image-0.13.0.ebuild
@@ -45,7 +45,7 @@ python_test() {
 	echo "backend : Agg" > matplotlibrc || die
 	#echo "backend.qt4 : PyQt4" >> matplotlibrc || die
 	#echo "backend.qt4 : PySide" >> matplotlibrc || die
-	MPLCONFIGDIR=. virtx nosetests --exe -v skimage || die
+	MPLCONFIGDIR=. virtx nosetests --exe -v skimage
 }
 
 pkg_postinst() {

--- a/www-client/firefox/firefox-52.9.0.ebuild
+++ b/www-client/firefox/firefox-52.9.0.ebuild
@@ -268,7 +268,7 @@ src_compile() {
 		[[ -n "${cards}" ]] && addpredict "${cards}"
 
 		MOZ_MAKE_FLAGS="${MAKEOPTS}" SHELL="${SHELL:-${EPREFIX%/}/bin/bash}" \
-		virtx emake -f client.mk profiledbuild || die "virtx emake failed"
+		virtx emake -f client.mk profiledbuild
 	else
 		MOZ_MAKE_FLAGS="${MAKEOPTS}" SHELL="${SHELL:-${EPREFIX%/}/bin/bash}" \
 		emake -f client.mk realbuild


### PR DESCRIPTION
* `virtx` never required || die to begin with.

Signed-off-by: David Seifert <soap@gentoo.org>