### PR TITLE
dev-embedded/u-boot-tools: remove easylogo

### DIFF
--- a/dev-embedded/u-boot-tools/u-boot-tools-2019.10.ebuild
+++ b/dev-embedded/u-boot-tools/u-boot-tools-2019.10.ebuild
@@ -50,7 +50,6 @@ src_test() { :; }
 src_install() {
 	cd tools || die
 	dobin bmp_logo dumpimage fdtgrep gen_eth_addr img2srec mkenvimage mkimage
-	dobin easylogo/easylogo
 	dobin env/fw_printenv
 	dosym fw_printenv /usr/bin/fw_setenv
 	insinto /etc


### PR DESCRIPTION
Has been removed from u-boot as of upstream commit
44de15d6867c246e7a09ef061d3de56e1799a606

Package-Manager: Portage-2.3.81, Repoman-2.3.20
Signed-off-by: Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>