### PR TITLE
media-sound/denemo: add missing dependency

### DIFF
--- a/media-sound/denemo/denemo-2.3.0.ebuild
+++ b/media-sound/denemo/denemo-2.3.0.ebuild
@@ -57,7 +57,10 @@ BDEPEND="
 	>=sys-devel/flex-2.6.1
 	virtual/pkgconfig
 	virtual/yacc
-	gtk-doc? ( >=dev-util/gtk-doc-1.25-r1 )
+	gtk-doc? (
+		>=dev-util/gtk-doc-1.25-r1
+		>=dev-util/gtk-doc-am-1.25-r1
+	)
 	nls? ( >=sys-devel/gettext-0.19.8.1 )
 "
 


### PR DESCRIPTION
Add dev-util/gtk-doc-am which is needed by gtk-doc USE flag.

Package-Manager: Portage-2.3.81, Repoman-2.3.20
Signed-off-by: Bernd Waibel <waebbl@gmail.com>