### PR TITLE
net-misc/scponly: fix sftp-server path detection, added maintainer

### DIFF
--- a/net-misc/scponly/files/scponly-4.8-sftp-server-path.patch
+++ b/net-misc/scponly/files/scponly-4.8-sftp-server-path.patch
@@ -1,0 +1,42 @@
+diff -urNp scponly-4.8-orig/configure scponly-4.8-dwok/configure
+--- scponly-4.8-orig/configure	2019-11-26 16:34:19.028544577 +0100
++++ scponly-4.8-dwok/configure	2019-11-26 16:33:24.571763528 +0100
+@@ -3244,7 +3244,7 @@ else
+   ;;
+   *)
+   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-as_dummy="`echo "$PATH:/usr/lib:/usr/lib64:/usr/libexec:/usr/libexec/openssh:/usr/lib/ssh:/usr/lib64/ssh:/usr/local/libexec:/usr/lib/misc:/usr/lib/openssh" | sed -e 's/:/ /'`"
++as_dummy="`echo "$PATH:/usr/lib:/usr/lib64:/usr/lib64/misc:/usr/libexec:/usr/libexec/openssh:/usr/lib/ssh:/usr/lib64/ssh:/usr/local/libexec:/usr/lib/misc:/usr/lib/openssh" | sed -e 's/:/ /'`"
+ for as_dir in $as_dummy
+ do
+   IFS=$as_save_IFS
+@@ -4240,7 +4240,7 @@ else
+   ;;
+   *)
+   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-as_dummy="`echo "$PATH:/usr/lib:/usr/lib/ssh:/usr/libexec/openssh:/usr/libexec:/usr/local/libexec" | sed -e 's/:/ /'`"
++as_dummy="`echo "$PATH:/usr/lib:/usr/lib64:/usr/lib64/misc:/usr/lib/ssh:/usr/libexec/openssh:/usr/libexec:/usr/local/libexec" | sed -e 's/:/ /'`"
+ for as_dir in $as_dummy
+ do
+   IFS=$as_save_IFS
+diff -urNp scponly-4.8-orig/configure.in scponly-4.8-dwok/configure.in
+--- scponly-4.8-orig/configure.in	2019-11-26 16:34:19.028544577 +0100
++++ scponly-4.8-dwok/configure.in	2019-11-26 16:33:28.491819749 +0100
+@@ -231,7 +231,7 @@ AC_ARG_ENABLE([quota-compat],
+ 
+ if test "x$scponly_scp_compat" != "x"; then
+ 	AC_MSG_NOTICE([enabling core WinSCP and Vanilla SCP binaries...])
+-	SCPONLY_PATH_PROG_DEFINE([PROG_SFTP_SERVER], [sftp-server],[/usr/lib:/usr/lib64:/usr/libexec:/usr/libexec/openssh:/usr/lib/ssh:/usr/lib64/ssh:/usr/local/libexec:/usr/lib/misc:/usr/lib/openssh])
++	SCPONLY_PATH_PROG_DEFINE([PROG_SFTP_SERVER], [sftp-server],[/usr/lib:/usr/lib64:/usr/lib64/misc:/usr/libexec:/usr/libexec/openssh:/usr/lib/ssh:/usr/lib64/ssh:/usr/local/libexec:/usr/lib/misc:/usr/lib/openssh])
+ 	SCPONLY_PATH_PROG_DEFINE([PROG_LS],    [ls],    [/bin:/usr/bin:/sbin:/usr/sbin])
+ 	SCPONLY_PATH_PROG_DEFINE([PROG_SCP],   [scp],   [/bin:/usr/bin:/sbin:/usr/sbin])
+ 	SCPONLY_PATH_PROG_DEFINE([PROG_RM],    [rm],    [/bin:/usr/bin:/sbin:/usr/sbin])
+@@ -297,7 +297,7 @@ if test "x$scponly_sftp_compat" != "x";
+   if test "x$scponly_explicit_sftpserver_path" = "x"; then
+       dnl Informed guess:
+       SCPONLY_PATH_PROG_DEFINE([PROG_SFTP_SERVER], [sftp-server],
+-       [/usr/lib:/usr/lib/ssh:/usr/libexec/openssh:/usr/libexec:/usr/local/libexec])
++       [/usr/lib:/usr/lib64:/usr/lib64/misc:/usr/lib/ssh:/usr/libexec/openssh:/usr/libexec:/usr/local/libexec])
+       dnl Debian uses /usr/lib
+       dnl Red Hat uses /usr/libexec/openssh
+       dnl Many a *BSD uses $PATH itself (which is implicit + checked 1st)

--- a/net-misc/scponly/metadata.xml
+++ b/net-misc/scponly/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>hlein@korelogic.com</email>
+		<name>Hank Leininger</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription lang="en">
 		scponly is an alternative 'shell' (of sorts) for system administrators
 		who would like to provide access to remote users to both read and write

--- a/net-misc/scponly/scponly-4.8-r7.ebuild
+++ b/net-misc/scponly/scponly-4.8-r7.ebuild
@@ -1,0 +1,250 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib readme.gentoo-r1 toolchain-funcs user
+
+DESCRIPTION="A tiny pseudoshell which only permits scp and sftp"
+HOMEPAGE="https://github.com/scponly/scponly"
+SRC_URI="mirror://sourceforge/scponly/${P}.tgz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE="+sftp scp winscp gftp rsync unison subversion wildcards quota passwd logging"
+REQUIRED_USE="
+	|| ( sftp scp winscp rsync unison subversion )
+"
+
+RDEPEND="
+	sys-apps/sed
+	net-misc/openssh
+	quota? ( sys-fs/quota )
+	rsync? ( net-misc/rsync )
+	subversion? ( dev-vcs/subversion )
+	unison? ( net-misc/unison:= )
+"
+DEPEND="${RDEPEND}"
+
+myuser="scponly"
+myhome="/home/${myuser}"
+mysubdir="/pub"
+
+PATCHES=(
+	"${FILESDIR}/${P}-rsync.patch"
+	"${FILESDIR}/${P}-gcc4.4.0.patch"
+	"${FILESDIR}/${P}-sftp-server-path.patch"
+)
+
+DOC_CONTENTS="
+	You might want to run\n
+	emerge --config =${CATEGORY}/${PF}\n
+	\nto setup the chroot. Otherwise you will have to setup chroot manually
+	Please read the docs in /usr/share/doc/${PF} for more informations, also
+	the SECURITY file.
+"
+
+src_configure() {
+	CFLAGS="${CFLAGS} ${LDFLAGS}" econf \
+		--with-sftp-server="/usr/$(get_libdir)/misc/sftp-server" \
+		--disable-restrictive-names \
+		--enable-chrooted-binary \
+		--enable-chroot-checkdir \
+		$(use_enable winscp winscp-compat) \
+		$(use_enable gftp gftp-compat) \
+		$(use_enable scp scp-compat) \
+		$(use_enable sftp sftp) \
+		$(use_enable quota quota-compat) \
+		$(use_enable passwd passwd-compat) \
+		$(use_enable rsync rsync-compat) \
+		$(use_enable unison unison-compat) \
+		$(use_enable subversion svn-compat) \
+		$(use_enable subversion svnserv-compat) \
+		$(use_enable logging sftp-logging-compat) \
+		$(use_enable wildcards wildcards)
+}
+
+src_compile() {
+	emake CC=$(tc-getCC)
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	dodoc AUTHOR BUILDING-JAILS.TXT CHANGELOG CONTRIB README SECURITY TODO
+
+	( docinto chroot; dodoc setup_chroot.sh config.h )
+	# don't compress setup-script, so it is usable if necessary
+	docompress -x /usr/share/doc/${PF}/chroot
+
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	# two slashes ('//') are used by scponlyc to determine the chroot point.
+	enewgroup "${myuser}"
+	enewuser "${myuser}" -1 /usr/sbin/scponlyc "${myhome}//" "${myuser}"
+
+	readme.gentoo_print_elog
+}
+
+pkg_config() {
+	# pkg_postinst is based on ${S}/setup_chroot.sh.
+
+	einfo "Collecting binaries and libraries..."
+
+	# Binaries launched in sftp compat mode
+	if has_version "=${CATEGORY}/${PF}[sftp]" ; then
+		BINARIES="/usr/$(get_libdir)/misc/sftp-server"
+	fi
+
+	# Binaries launched by vanilla- and WinSCP modes
+	if has_version "=${CATEGORY}/${PF}[scp]" || \
+		has_version "=${CATEGORY}/${PF}[winscp]" ; then
+		BINARIES="${BINARIES} /usr/bin/scp /bin/ls /bin/rm /bin/ln /bin/mv"
+		BINARIES="${BINARIES} /bin/chmod /bin/chown /bin/chgrp /bin/mkdir /bin/rmdir"
+	fi
+
+	# Binaries launched in WinSCP compatibility mode
+	if has_version "=${CATEGORY}/${PF}[winscp]" ; then
+		BINARIES="${BINARIES} /bin/pwd /bin/groups /usr/bin/id /bin/echo"
+	fi
+
+	# Rsync compatability mode
+	if has_version "=${CATEGORY}/${PF}[rsync]" ; then
+		BINARIES="${BINARIES} /usr/bin/rsync"
+	fi
+
+	# Unison compatability mode
+	if has_version "=${CATEGORY}/${PF}[unison]" ; then
+		BINARIES="${BINARIES} /usr/bin/unison"
+	fi
+
+	# subversion cli/svnserv compatibility
+	if has_version "=${CATEGORY}/${PF}[subversion]" ; then
+		BINARIES="${BINARIES} /usr/bin/svn /usr/bin/svnserve"
+	fi
+
+	# passwd compatibility
+	if has_version "=${CATEGORY}/${PF}[passwd]" ; then
+		BINARIES="${BINARIES} /usr/bin/passwd"
+	fi
+
+	# quota compatibility
+	if has_version "=${CATEGORY}/${PF}[quota]" ; then
+		BINARIES="${BINARIES} /usr/bin/quota"
+	fi
+
+	# build lib dependencies
+	LIB_LIST=$(ldd ${BINARIES} | sed -n 's:.* => \(/[^ ]\+\).*:\1:p' | sort -u)
+
+	# search and add ld*.so
+	for LIB in /$(get_libdir)/ld.so /libexec/ld-elf.so /libexec/ld-elf.so.1 \
+		/usr/libexec/ld.so /$(get_libdir)/ld-linux*.so.2 /usr/libexec/ld-elf.so.1; do
+		[ -f "${LIB}" ] && LIB_LIST="${LIB_LIST} ${LIB}"
+	done
+
+	# search and add libnss_*.so
+	for LIB in /$(get_libdir)/libnss_{compat,files}*.so.*; do
+		[ -f "${LIB}" ] && LIB_LIST="${LIB_LIST} ${LIB}"
+	done
+
+	# create base dirs
+	if [ ! -d "${myhome}" ]; then
+		einfo "Creating ${myhome}"
+		install -o0 -g0 -m0755 -d "${myhome}"
+	else
+		einfo "Setting owner for ${myhome}"
+		chown 0:0 "${myhome}"
+	fi
+
+	if [ ! -d "${myhome}/etc" ]; then
+		einfo "Creating ${myhome}/etc"
+		install -o0 -g0 -m0755 -d "${myhome}/etc"
+	fi
+
+	if [ ! -d "${myhome}/$(get_libdir)" ]; then
+		einfo "Creating ${myhome}/$(get_libdir)"
+		install -o0 -g0 -m0755 -d "${myhome}/$(get_libdir)"
+	fi
+
+	if [ ! -e "${myhome}/lib" ]; then
+		einfo "Creating ${myhome}/lib"
+		ln -snf $(get_libdir) "${myhome}/lib"
+	fi
+
+	if [ ! -d "${myhome}/usr/$(get_libdir)" ]; then
+		einfo "Creating ${myhome}/usr/$(get_libdir)"
+		install -o0 -g0 -m0755 -d "${myhome}/usr/$(get_libdir)"
+	fi
+
+	if [ ! -e "${myhome}/usr/lib" ]; then
+		einfo "Creating ${myhome}/usr/lib"
+		ln -snf $(get_libdir) "${myhome}/usr/lib"
+	fi
+
+	if [ ! -d "${myhome}${mysubdir}" ]; then
+		einfo "Creating ${myhome}${mysubdir} directory for uploading files"
+		install -o${myuser} -g${myuser} -m0755 -d "${myhome}${mysubdir}"
+	fi
+
+	# create /dev/null (Bug 135505)
+	if [ ! -e "${myhome}/dev/null" ]; then
+		install -o0 -g0 -m0755 -d "${myhome}/dev"
+		mknod -m0777 "${myhome}/dev/null" c 1 3
+	fi
+
+	# install binaries
+	for BIN in ${BINARIES}; do
+		einfo "Install ${BIN}"
+		install -o0 -g0 -m0755 -d "${myhome}$(dirname ${BIN})"
+		if [ "${BIN}" = "/usr/bin/passwd" ]; then  # needs suid
+			install -p -o0 -g0 -m04711 "${BIN}" "${myhome}/${BIN}"
+		else
+			install -p -o0 -g0 -m0755 "${BIN}" "${myhome}/${BIN}"
+		fi
+	done
+
+	# install libs
+	for LIB in ${LIB_LIST}; do
+		einfo "Install ${LIB}"
+		install -o0 -g0 -m0755 -d "${myhome}$(dirname ${LIB})"
+		install -p -o0 -g0 -m0755 "${LIB}" "${myhome}/${LIB}"
+	done
+
+	# create ld.so.conf
+	einfo "Creating /etc/ld.so.conf"
+	for LIB in ${LIB_LIST}; do
+		dirname ${LIB}
+	done | sort -u | while read DIR; do
+		if ! grep 2>/dev/null -q "^${DIR}$" "${myhome}/etc/ld.so.conf"; then
+			echo "${DIR}" >> "${myhome}/etc/ld.so.conf"
+		fi
+	done
+	ldconfig -r "${myhome}"
+
+	# update shells
+	einfo "Updating /etc/shells"
+	grep 2>/dev/null -q "^/usr/bin/scponly$" /etc/shells \
+		|| echo "/usr/bin/scponly" >> /etc/shells
+
+	grep 2>/dev/null -q "^/usr/sbin/scponlyc$" /etc/shells \
+		|| echo "/usr/sbin/scponlyc" >> /etc/shells
+
+	# create /etc/passwd
+	if [ ! -e "${myhome}/etc/passwd" ]; then
+		(
+			echo "root:x:0:0:root:/:/bin/sh"
+			sed -n "s|^\(${myuser}:[^:]*:[^:]*:[^:]*:[^:]*:\).*|\1${mysubdir}:/bin/sh|p" /etc/passwd
+		) > "${myhome}/etc/passwd"
+	fi
+
+	# create /etc/group
+	if [ ! -e "${myhome}/etc/group" ]; then
+		(
+			echo "root:x:0:"
+			sed -n "s|^\(${myuser}:[^:]*:[^:]*:\).*|\1|p" /etc/group
+		) > "${myhome}/etc/group"
+	fi
+}


### PR DESCRIPTION
scponly will no longer build, because it cannot find sftp-server.  I
think it is because of the lib64 path changes in profile 17.1.  Attila
T�th already provided this fix in b.g.o#701368, I am just submitting a
PR to help it along.

Also added myself as a proxy maintainer, since I use scponly and it is
maintainer-needed.

I am aware that scponly still uses 'user' instead of following
GLEP 81; I will submit a separate PR to fix that.

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/701368
Package-Manager: Portage-2.3.81, Repoman-2.3.20