### PR TITLE
net-misc/teamviewer: Update init.d path on ebuild

### DIFF
--- a/net-misc/teamviewer/teamviewer-15.0.8397.ebuild
+++ b/net-misc/teamviewer/teamviewer-15.0.8397.ebuild
@@ -70,7 +70,7 @@ src_install() {
 	done
 
 	# No slotting here, binary expects this service path
-	newinitd "${FILESDIR}"/teamviewerd14.init teamviewerd
+	newinitd "${FILESDIR}"/teamviewerd15.init teamviewerd
 	systemd_dounit tv_bin/script/teamviewerd.service
 
 	insinto /usr/share/dbus-1/services


### PR DESCRIPTION
/etc/init.d/teamviewerd needs to point to /opt/teamviewer15/tv_bin/teamviewerd

Bug: https://bugs.gentoo.org/703086
Closes: https://bugs.gentoo.org/703086
Signed-off-by: Jeffrey Jensen <jeffreyjensen1989@live.com>