### PR TITLE
net-libs/libtorrent-rasterbar: Fix building with Boost 1.72

### DIFF
--- a/net-libs/libtorrent-rasterbar/files/fix-boost-1.72.patch
+++ b/net-libs/libtorrent-rasterbar/files/fix-boost-1.72.patch
@@ -1,0 +1,23 @@
+From e4b812b50b0a7dfd430b00d0851be19e83845ac8 Mon Sep 17 00:00:00 2001
+From: Arvid Norberg <arvid@cs.umu.se>
+Date: Wed, 13 Nov 2019 15:36:05 +0000
+Subject: [PATCH] add executor_type to socket_type
+
+---
+ include/libtorrent/aux_/socket_type.hpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/include/libtorrent/aux_/socket_type.hpp b/include/libtorrent/aux_/socket_type.hpp
+index 1342d39adf..7cbe90fd68 100644
+--- a/include/libtorrent/aux_/socket_type.hpp
++++ b/include/libtorrent/aux_/socket_type.hpp
+@@ -184,6 +184,10 @@ namespace aux {
+ 		using receive_buffer_size = tcp::socket::receive_buffer_size;
+ 		using send_buffer_size = tcp::socket::send_buffer_size;
+ 
++#if BOOST_VERSION >= 106600
++		using executor_type = tcp::socket::executor_type;
++#endif
++
+ 		explicit socket_type(io_service& ios): m_io_service(ios), m_type(0) {}
+ 		~socket_type();

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
@@ -45,6 +45,8 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/${PN/-rasterbar}-${MY_P}"
 
+PATCHES=( "${FILESDIR}"/fix-boost-1.72.patch )
+
 src_prepare() {
 	mkdir "${S}"/build-aux/ || die
 	touch "${S}"/build-aux/config.rpath || die


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/703014
Package-Manager: Portage-2.3.82, Repoman-2.3.20
Signed-off-by: Craig Andrews <candrews@gentoo.org>