### PR TITLE
sys-apps/shadow: Clean up pam config

### DIFF
--- a/sys-apps/shadow/files/pam.d-include/shadow
+++ b/sys-apps/shadow/files/pam.d-include/shadow
@@ -1,7 +1,6 @@
 #%PAM-1.0 
 
 auth       sufficient	pam_rootok.so
-auth       required		pam_permit.so
 
 account    include		system-auth
 

--- a/sys-apps/shadow/shadow-4.8-r2.ebuild
+++ b/sys-apps/shadow/shadow-4.8-r2.ebuild
@@ -144,16 +144,11 @@ src_install() {
 		set_login_opt ENCRYPT_METHOD SHA512
 		set_login_opt CONSOLE
 	else
-		dopamd "${FILESDIR}"/pam.d-include/shadow
-
-		for x in chpasswd chgpasswd newusers; do
+		for x in chsh chfn ; do
 			newpamd "${FILESDIR}"/pam.d-include/passwd ${x}
 		done
 
-		for x in chage chsh chfn \
-				 user{add,del,mod} group{add,del,mod} ; do
-			newpamd "${FILESDIR}"/pam.d-include/shadow ${x}
-		done
+		newpamd "${FILESDIR}"/pam.d-include/shadow groupmems
 
 		# comment out login.defs options that pam hates
 		local opt sed_args=()


### PR DESCRIPTION
Triggered by https://bugs.gentoo.org/702252 below changes clean up the pam configuration of sys-apps/shadow to:

* make the distinction between user self-service and administrative tools clear and assign the right configs to them
* not allow everyone access to admin tools without authentication and require explicit admin action to delegate access to them
* not install unused pam configuration files
* explicitly handle the groupmems tool

Care is taken to build this up step by step in multiple commits with verbose explanations since this obviously is security-sensitive.