### PR TITLE
net-libs/libtorrent-rasterbar: fix boost-1.72 compat

### DIFF
--- a/net-libs/libtorrent-rasterbar/files/fix-boost-1.72.patch
+++ b/net-libs/libtorrent-rasterbar/files/fix-boost-1.72.patch
@@ -1,0 +1,14 @@
+diff -Nur a/include/libtorrent/aux_/socket_type.hpp b/include/libtorrent/aux_/socket_type.hpp
+--- a/include/libtorrent/aux_/socket_type.hpp	2019-09-24 00:28:43.000000000 +0100
++++ b/include/libtorrent/aux_/socket_type.hpp	2019-12-17 22:48:27.679305842 +0000
+@@ -184,6 +184,10 @@
+ 		using receive_buffer_size = tcp::socket::receive_buffer_size;
+ 		using send_buffer_size = tcp::socket::send_buffer_size;
+ 
++#if BOOST_VERSION >= 106600
++		using executor_type = tcp::socket::executor_type;
++#endif
++
+ 		explicit socket_type(io_service& ios): m_io_service(ios), m_type(0) {}
+ 		~socket_type();
+ 

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.0-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.0-r1.ebuild
@@ -45,7 +45,8 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/${PN/-rasterbar}-${MY_P}"
 
-PATCHES=( "${FILESDIR}"/fix-boost-1.70.patch )
+PATCHES=( "${FILESDIR}"/fix-boost-1.70.patch
+	"${FILESDIR}"/fix-boost-1.72.patch )
 
 src_prepare() {
 	mkdir "${S}"/build-aux/ || die

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.1-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.1-r1.ebuild
@@ -45,6 +45,8 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/${PN/-rasterbar}-${MY_P}"
 
+PATCHES=( "${FILESDIR}/fix-boost-1.72.patch" )
+
 src_prepare() {
 	mkdir "${S}"/build-aux/ || die
 	touch "${S}"/build-aux/config.rpath || die

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.2-r1.ebuild
@@ -45,6 +45,8 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/${PN/-rasterbar}-${MY_P}"
 
+PATCHES=( "${FILESDIR}"/fix-boost-1.72.patch )
+
 src_prepare() {
 	mkdir "${S}"/build-aux/ || die
 	touch "${S}"/build-aux/config.rpath || die


### PR DESCRIPTION
net-p2p/libtorrent-rasterbar: fix boost-1.72 compat

In file included from src/http_connection.cpp:33:
In file included from include/libtorrent/http_connection.hpp:62:
In file included from include/libtorrent/socket.hpp:57:
In file included from /usr/local/include/boost/asio/write.hpp:1262:
/usr/local/include/boost/asio/impl/write.hpp:425:40: error: no type named 'executor_type' in 'libtorrent::socket_type'
    typedef typename AsyncWriteStream::executor_type executor_type;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
/usr/local/include/boost/asio/impl/write.hpp:534:7: note: in instantiation of template class 'boost::asio::detail::initiate_async_write_buffer_sequence<libtorrent::socket_type>' requested here
      detail::initiate_async_write_buffer_sequence<AsyncWriteStream>(s),
      ^
src/http_connection.cpp:277:3: note: in instantiation of function template specialization 'boost::asio::async_write<libtorrent::socket_type, boost::asio::mutable_buffers_1, boost::_bi::bind_t<void, boost::_mfi::mf1<void, libtorrent::http_connection, const boost::system::error_code &>, boost::_bi::list2<boost::_bi::value<boost::shared_ptr<libtorrent::http_connection> >, boost::arg<1> > > >' requested here
                async_write(m_sock, boost::asio::buffer(m_sendbuffer)
                ^
src/http_connection.cpp:631:3: error: no matching function for call to 'async_write'
                async_write(m_sock, boost::asio::buffer(m_sendbuffer)
                ^~~~~~~~~~~
/usr/local/include/boost/asio/impl/write.hpp:507:1: note: candidate template ignored: substitution failure [with AsyncWriteStream = libtorrent::socket_type, ConstBufferSequence = boost::asio::mutable_buffers_1, CompletionCondition = boost::_bi::bind_t<void, boost::_mfi::mf1<void, libtorrent::http_connection, const boost::system::error_code &>, boost::_bi::list2<boost::_bi::value<boost::shared_ptr<libtorrent::http_connection> >, boost::arg<1> > >]: no type named 'executor_type' in 'libtorrent::socket_type'
async_write(AsyncWriteStream& s, const ConstBufferSequence& buffers,
^
/usr/local/include/boost/asio/impl/write.hpp:526:1: note: candidate template ignored: substitution failure [with AsyncWriteStream = libtorrent::socket_type, ConstBufferSequence = boost::asio::mutable_buffers_1, WriteHandler = boost::_bi::bind_t<void, boost::_mfi::mf1<void, libtorrent::http_connection, const boost::system::error_code &>, boost::_bi::list2<boost::_bi::value<boost::shared_ptr<libtorrent::http_connection> >, boost::arg<1> > >]
async_write(AsyncWriteStream& s, const ConstBufferSequence& buffers,
^
/usr/local/include/boost/asio/impl/write.hpp:739:1: note: candidate template ignored: requirement 'is_dynamic_buffer_v1<typename decay<mutable_buffers_1>::type>::value' was not satisfied [with AsyncWriteStream = libtorrent::socket_type, DynamicBuffer_v1 = boost::asio::mutable_buffers_1, WriteHandler = boost::_bi::bind_t<void, boost::_mfi::mf1<void, libtorrent::http_connection, const boost::system::error_code &>, boost::_bi::list2<boost::_bi::value<boost::shared_ptr<libtorrent::http_connection> >, boost::arg<1> > >]
async_write(AsyncWriteStream& s,
^
/usr/local/include/boost/asio/impl/write.hpp:758:1: note: candidate template ignored: substitution failure [with AsyncWriteStream = libtorrent::socket_type, DynamicBuffer_v1 = boost::asio::mutable_buffers_1, CompletionCondition = boost::_bi::bind_t<void, boost::_mfi::mf1<void, libtorrent::http_connection, const boost::system::error_code &>, boost::_bi::list2<boost::_bi::value<boost::shared_ptr<libtorrent::http_connection> >, boost::arg<1> > >]: no type named 'executor_type' in 'libtorrent::socket_type'
async_write(AsyncWriteStream& s,
^
/usr/local/include/boost/asio/impl/write.hpp:782:1: note: candidate template ignored: could not match 'basic_streambuf<type-parameter-0-1>' against 'boost::asio::mutable_buffers_1'
async_write(AsyncWriteStream& s,
^
/usr/local/include/boost/asio/impl/write.hpp:796:1: note: candidate template ignored: could not match 'basic_streambuf<type-parameter-0-1>' against 'boost::asio::mutable_buffers_1'
async_write(AsyncWriteStream& s,
^
/usr/local/include/boost/asio/impl/write.hpp:1009:1: note: candidate template ignored: requirement 'is_dynamic_buffer_v2<mutable_buffers_1>::value' was not satisfied [with AsyncWriteStream = libtorrent::socket_type, DynamicBuffer_v2 = boost::asio::mutable_buffers_1, WriteHandler = boost::_bi::bind_t<void, boost::_mfi::mf1<void, libtorrent::http_connection, const boost::system::error_code &>, boost::_bi::list2<boost::_bi::value<boost::shared_ptr<libtorrent::http_connection> >, boost::arg<1> > >]
async_write(AsyncWriteStream& s, DynamicBuffer_v2 buffers,
^
/usr/local/include/boost/asio/impl/write.hpp:1026:1: note: candidate template ignored: substitution failure [with AsyncWriteStream = libtorrent::socket_type, DynamicBuffer_v2 = boost::asio::mutable_buffers_1, CompletionCondition = boost::_bi::bind_t<void, boost::_mfi::mf1<void, libtorrent::http_connection, const boost::system::error_code &>, boost::_bi::list2<boost::_bi::value<boost::shared_ptr<libtorrent::http_connection> >, boost::arg<1> > >]: no type named 'executor_type' in 'libtorrent::socket_type'
async_write(AsyncWriteStream& s, DynamicBuffer_v2 buffers,
^

Obtained from:	upstream
https://github.com/arvidn/libtorrent/commit/e4b812b50b0a