### PR TITLE
sys-devel/clang: Set the correct LLVM_CMAKE_PATH on Gentoo Prefix 

### DIFF
--- a/sys-devel/clang/clang-9.0.1.ebuild
+++ b/sys-devel/clang/clang-9.0.1.ebuild
@@ -96,6 +96,7 @@ multilib_src_configure() {
 	local clang_version=$(ver_cut 1-3 "${llvm_version}")
 
 	local mycmakeargs=(
+		-DLLVM_CMAKE_PATH="${EPREFIX}/usr/lib/llvm/${SLOT}/$(get_libdir)/cmake/llvm"
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${SLOT}"
 		-DCMAKE_INSTALL_MANDIR="${EPREFIX}/usr/lib/llvm/${SLOT}/share/man"
 		# relative to bindir


### PR DESCRIPTION
Trying to fix https://bugs.gentoo.org/696844, a problem on Gentoo Prefix