### PR TITLE
net-analyzer/tsung: Fix QA error on Gentoo Prefix

### DIFF
--- a/net-analyzer/tsung/tsung-1.7.0.ebuild
+++ b/net-analyzer/tsung/tsung-1.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -26,7 +26,7 @@ RDEPEND="
 	${DEPEND}
 "
 src_configure() {
-	./configure --prefix="/usr" || die "econf failed"
+	./configure --prefix="$EPREFIX/usr" || die "econf failed"
 }
 
 src_compile() {


### PR DESCRIPTION
Signed-off-by: Julius Putra Tanu Setiaji <indocomsoft@gmail.com>
Closes: https://bugs.gentoo.org/698074
Package-Manager: Portage-2.3.77, Repoman-2.3.17