### PR TITLE
app-misc/rpick: stabilize 0.4.0 for amd64

### DIFF
--- a/app-misc/rpick/rpick-0.4.0.ebuild
+++ b/app-misc/rpick/rpick-0.4.0.ebuild
@@ -82,7 +82,7 @@ SRC_URI="$(cargo_crate_uris ${CRATES})"
 
 LICENSE="GPL-3 Apache-2.0 BSD-2 CC0-1.0 ISC MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 ~x86"
 
 DOCS=( CHANGELOG.md README.md )
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.79, Repoman-2.3.16
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>