### PR TITLE
dev-qt/qtgui: Block known old users of _populate_Gui_plugin_properties

### DIFF
--- a/dev-qt/qtgui/qtgui-5.14.0.ebuild
+++ b/dev-qt/qtgui/qtgui-5.14.0.ebuild
@@ -24,7 +24,7 @@ REQUIRED_USE="
 	xcb? ( gles2? ( egl ) )
 "
 
-RDEPEND="
+COMMON_DEPEND="
 	dev-libs/glib:2
 	~dev-qt/qtcore-${PV}
 	dev-util/gtk-update-icon-cache
@@ -63,9 +63,16 @@ RDEPEND="
 		x11-libs/xcb-util-wm
 	)
 "
-DEPEND="${RDEPEND}
+DEPEND="${COMMON_DEPEND}
 	evdev? ( sys-kernel/linux-headers )
 	udev? ( sys-kernel/linux-headers )
+"
+# bug 703306, _populate_Gui_plugin_properties breaks installed cmake modules
+RDEPEND="${COMMON_DEPEND}
+	!<dev-qt/qtimageformats-5.14.0:5
+	!<dev-qt/qtsvg-5.14.0:5
+	!<dev-qt/qtvirtualkeyboard-5.14.0:5
+	!<dev-qt/qtwayland-5.14.0:5
 "
 PDEPEND="
 	ibus? ( app-i18n/ibus )


### PR DESCRIPTION
With sufficiently parallelised emerge, if dev-qt/qtgui reverse dependencies are
scheduled before modules installing Qt5Gui plugins have been rebuilt, these
revdeps will fail cmake after an incompatible change in macro args.

Bug: https://bugs.gentoo.org/703306
Package-Manager: Portage-2.3.82, Repoman-2.3.20
Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>