### PR TITLE
dev-libs/criterion: fix DEPEND/RDEPEND variable names

### DIFF
--- a/dev-libs/criterion/criterion-2.3.3.ebuild
+++ b/dev-libs/criterion/criterion-2.3.3.ebuild
@@ -16,8 +16,8 @@ KEYWORDS="~amd64"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
-REPEND="dev-libs/nanomsg:="
-DDEPEND="${DEPEND}
+RDEPEND="dev-libs/nanomsg:="
+DEPEND="${RDEPEND}
 	test? ( dev-util/cram )"
 BDEPEND="virtual/pkgconfig"
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/703388
Package-Manager: Portage-2.3.82, Repoman-2.3.20
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>