### PR TITLE
app-text/docbook-sgml-dtd: Update ebuilds to use BDEPEND

### DIFF
--- a/app-text/docbook-sgml-dtd/docbook-sgml-dtd-3.0-r5.ebuild
+++ b/app-text/docbook-sgml-dtd/docbook-sgml-dtd-3.0-r5.ebuild
@@ -14,7 +14,7 @@ SLOT="${PV}"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE=""
 
-DEPEND=">=app-arch/unzip-5.41"
+BDEPEND=">=app-arch/unzip-5.41"
 
 S="${WORKDIR}"
 PATCHES=( "${FILESDIR}"/${P}-catalog.diff )

--- a/app-text/docbook-sgml-dtd/docbook-sgml-dtd-3.1-r5.ebuild
+++ b/app-text/docbook-sgml-dtd/docbook-sgml-dtd-3.1-r5.ebuild
@@ -14,7 +14,7 @@ SLOT="${PV}"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE=""
 
-DEPEND=">=app-arch/unzip-5.41"
+BDEPEND=">=app-arch/unzip-5.41"
 
 S="${WORKDIR}"
 PATCHES=( "${FILESDIR}"/${P}-catalog.diff )

--- a/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.0-r5.ebuild
+++ b/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.0-r5.ebuild
@@ -14,7 +14,7 @@ SLOT="${PV}"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE=""
 
-DEPEND=">=app-arch/unzip-5.41"
+BDEPEND=">=app-arch/unzip-5.41"
 
 S="${WORKDIR}"
 PATCHES=( "${FILESDIR}"/${P}-catalog.diff )

--- a/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.1-r5.ebuild
+++ b/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.1-r5.ebuild
@@ -4,17 +4,17 @@
 EAPI=7
 inherit sgml-catalog-r1
 
-MY_P="docbook-${PV}"
+MY_P="docbk${PV/./}"
 DESCRIPTION="Docbook SGML DTD ${PV}"
 HOMEPAGE="https://docbook.org/sgml/"
-SRC_URI="https://docbook.org/sgml/${PV}/${MY_P}.zip"
+SRC_URI="https://www.oasis-open.org/docbook/sgml/${PV}/${MY_P}.zip"
 
 LICENSE="docbook"
 SLOT="${PV}"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE=""
 
-DEPEND=">=app-arch/unzip-5.41"
+BDEPEND=">=app-arch/unzip-5.41"
 
 S="${WORKDIR}"
 PATCHES=( "${FILESDIR}"/${P}-catalog.diff )
@@ -28,11 +28,11 @@ src_install() {
 		CATALOG "${EPREFIX}/usr/share/sgml/docbook/sgml-dtd-${PV}/catalog"
 		CATALOG "${EPREFIX}/etc/sgml/sgml-docbook.cat"
 	EOF
-	dodoc ChangeLog README
+	dodoc *.txt
 }
 
 pkg_preinst() {
-	# work-around -r0 postrm removing it
+	# work-around -r3 postrm removing it
 	cp "${ED}"/etc/sgml/sgml-docbook-${PV}.cat "${T}" || die
 }
 

--- a/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.2-r4.ebuild
+++ b/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.2-r4.ebuild
@@ -7,32 +7,32 @@ inherit sgml-catalog-r1
 MY_P="docbook-${PV}"
 DESCRIPTION="Docbook SGML DTD ${PV}"
 HOMEPAGE="https://docbook.org/sgml/"
-SRC_URI="https://docbook.org/sgml/${PV}/${MY_P}.zip"
+SRC_URI="https://www.oasis-open.org/docbook/sgml/${PV}/${MY_P}.zip"
 
 LICENSE="docbook"
 SLOT="${PV}"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE=""
 
-DEPEND=">=app-arch/unzip-5.41"
+BDEPEND=">=app-arch/unzip-5.41"
 
 S="${WORKDIR}"
 PATCHES=( "${FILESDIR}"/${P}-catalog.diff )
 
 src_install() {
 	insinto /usr/share/sgml/docbook/sgml-dtd-${PV}
-	doins *.dcl *.dtd *.mod *.xml
+	doins *.dcl *.dtd *.mod
 	newins docbook.cat catalog
 	insinto /etc/sgml
 	newins - sgml-docbook-${PV}.cat <<-EOF
 		CATALOG "${EPREFIX}/usr/share/sgml/docbook/sgml-dtd-${PV}/catalog"
 		CATALOG "${EPREFIX}/etc/sgml/sgml-docbook.cat"
 	EOF
-	dodoc README
+	dodoc ChangeLog README
 }
 
 pkg_preinst() {
-	# work-around -r0 postrm removing it
+	# work-around -r2 postrm removing it
 	cp "${ED}"/etc/sgml/sgml-docbook-${PV}.cat "${T}" || die
 }
 

--- a/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.3-r4.ebuild
+++ b/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.3-r4.ebuild
@@ -7,14 +7,14 @@ inherit sgml-catalog-r1
 MY_P="docbook-${PV}"
 DESCRIPTION="Docbook SGML DTD ${PV}"
 HOMEPAGE="https://docbook.org/sgml/"
-SRC_URI="https://www.oasis-open.org/docbook/sgml/${PV}/${MY_P}.zip"
+SRC_URI="https://docbook.org/sgml/${PV}/${MY_P}.zip"
 
 LICENSE="docbook"
 SLOT="${PV}"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE=""
 
-DEPEND=">=app-arch/unzip-5.41"
+BDEPEND=">=app-arch/unzip-5.41"
 
 S="${WORKDIR}"
 PATCHES=( "${FILESDIR}"/${P}-catalog.diff )

--- a/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.4-r2.ebuild
+++ b/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.4-r2.ebuild
@@ -14,7 +14,7 @@ SLOT="${PV}"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE=""
 
-DEPEND=">=app-arch/unzip-5.41"
+BDEPEND=">=app-arch/unzip-5.41"
 
 S="${WORKDIR}"
 PATCHES=( "${FILESDIR}"/${P}-catalog.diff )
@@ -32,7 +32,7 @@ src_install() {
 }
 
 pkg_preinst() {
-	# work-around -r2 postrm removing it
+	# work-around -r0 postrm removing it
 	cp "${ED}"/etc/sgml/sgml-docbook-${PV}.cat "${T}" || die
 }
 

--- a/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.5-r2.ebuild
+++ b/app-text/docbook-sgml-dtd/docbook-sgml-dtd-4.5-r2.ebuild
@@ -4,35 +4,35 @@
 EAPI=7
 inherit sgml-catalog-r1
 
-MY_P="docbk${PV/./}"
+MY_P="docbook-${PV}"
 DESCRIPTION="Docbook SGML DTD ${PV}"
 HOMEPAGE="https://docbook.org/sgml/"
-SRC_URI="https://www.oasis-open.org/docbook/sgml/${PV}/${MY_P}.zip"
+SRC_URI="https://docbook.org/sgml/${PV}/${MY_P}.zip"
 
 LICENSE="docbook"
 SLOT="${PV}"
 KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris"
 IUSE=""
 
-DEPEND=">=app-arch/unzip-5.41"
+BDEPEND=">=app-arch/unzip-5.41"
 
 S="${WORKDIR}"
 PATCHES=( "${FILESDIR}"/${P}-catalog.diff )
 
 src_install() {
 	insinto /usr/share/sgml/docbook/sgml-dtd-${PV}
-	doins *.dcl *.dtd *.mod
+	doins *.dcl *.dtd *.mod *.xml
 	newins docbook.cat catalog
 	insinto /etc/sgml
 	newins - sgml-docbook-${PV}.cat <<-EOF
 		CATALOG "${EPREFIX}/usr/share/sgml/docbook/sgml-dtd-${PV}/catalog"
 		CATALOG "${EPREFIX}/etc/sgml/sgml-docbook.cat"
 	EOF
-	dodoc *.txt
+	dodoc README
 }
 
 pkg_preinst() {
-	# work-around -r3 postrm removing it
+	# work-around -r0 postrm removing it
 	cp "${ED}"/etc/sgml/sgml-docbook-${PV}.cat "${T}" || die
 }
 


### PR DESCRIPTION
Presumably `unzip` is used to unpack items for the purpose of the build,
and as such should be in BDEPEND rather than DEPEND.