### PR TITLE
app-misc/solaar: Ensure python_prepare_all() is called

### DIFF
--- a/app-misc/solaar/solaar-1.0.1-r1.ebuild
+++ b/app-misc/solaar/solaar-1.0.1-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=no
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+
+inherit linux-info udev xdg distutils-r1
+
+DESCRIPTION="A Linux device manager for Logitech's Unifying Receiver peripherals"
+HOMEPAGE="https://pwr-solaar.github.io/Solaar/"
+SRC_URI="https://github.com/pwr-Solaar/Solaar/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="doc"
+
+RDEPEND="
+	acct-group/plugdev
+	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	>=dev-python/pyudev-0.13[${PYTHON_USEDEP}]
+	x11-libs/gtk+:3[introspection]"
+
+S=${WORKDIR}/Solaar-${PV}
+
+CONFIG_CHECK="~HID_LOGITECH_DJ ~HIDRAW"
+
+python_prepare_all() {
+	# don't autostart (bug #494608)
+	sed -i '/yield autostart_path/d' setup.py || die
+
+	# grant plugdev group rw access
+	sed -i 's/#MODE=/MODE=/' rules.d/42-logitech-unify-permissions.rules || die
+
+	distutils-r1_python_prepare_all
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+
+	udev_dorules rules.d/*.rules
+
+	dodoc docs/devices.md
+	if use doc; then
+		dodoc -r docs/*
+	fi
+}


### PR DESCRIPTION
This was my mistake in 1.0.1, not spotting that xdg.eclass also exports src_prepare. It is important for the program to be usable by non-root users.
Also update for new DISTUTILS_USE_SETUPTOOLS.

```diff
--- solaar-1.0.1.ebuild
+++ solaar-1.0.1-r1.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=no
 PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
 
 inherit distutils-r1 linux-info udev xdg
@@ -25,6 +27,11 @@
 
 CONFIG_CHECK="~HID_LOGITECH_DJ ~HIDRAW"
 
+src_prepare() {
+	distutils-r1_src_prepare
+	xdg_src_prepare
+}
+
 python_prepare_all() {
 	# don't autostart (bug #494608)
 	sed -i '/yield autostart_path/d' setup.py || die
```