### PR TITLE
dev-lang/erlang: Update virtual/emacs dependency.

### DIFF
--- a/dev-lang/erlang/erlang-22.2.1.ebuild
+++ b/dev-lang/erlang/erlang-22.2.1.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	acct-user/epmd
 	sys-libs/ncurses:0
 	sys-libs/zlib
-	emacs? ( virtual/emacs )
+	emacs? ( >=app-editors/emacs-23.1:* )
 	java? ( >=virtual/jdk-1.8:* )
 	odbc? ( dev-db/unixODBC )
 	sctp? ( net-misc/lksctp-tools )


### PR DESCRIPTION
This fixes recent QA warning https://qa-reports.gentoo.org/output/gentoo-ci/90c3340/output.html#dev-lang/erlang. This change has been introduced by @ulm in other elrang versions.
