### PR TITLE
net-dns/getdns: remove myself as maintainer

### DIFF
--- a/net-dns/getdns/metadata.xml
+++ b/net-dns/getdns/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>gentoo@retornaz.com</email>
-		<name>Quentin Retornaz</name>
-	</maintainer>
-	<maintainer type="person">
 		<email>blueness@gentoo.org</email>
 		<name>Anthony G. Basile</name>
 	</maintainer>


### PR DESCRIPTION
Due to upstream choice to drop `dev-libs/libressl` support, I’m not really interested to maintain this package anymore. I’m proposing `1.6.0_beta1` bump in a pull request as my last contribution for this package.