### PR TITLE
[QA] Fix missing eend arg

### DIFF
--- a/app-emulation/glean/files/glean.initd
+++ b/app-emulation/glean/files/glean.initd
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 
 description="Simple program to write static config from config-drive"
 
@@ -11,5 +11,5 @@ depend() {
 start() {
 	ebegin "Starting Glean"
 	/usr/bin/glean.sh
-	eend
+	eend $?
 }

--- a/app-emulation/virtualbox-guest-additions/virtualbox-guest-additions-6.0.12.ebuild
+++ b/app-emulation/virtualbox-guest-additions/virtualbox-guest-additions-6.0.12.ebuild
@@ -68,7 +68,7 @@ src_prepare() {
 	pushd src/VBox/Additions &>/dev/null || die
 	ebegin "Extracting guest kernel module sources"
 	kmk GuestDrivers-src vboxguest-src vboxsf-src vboxvideo-src &>/dev/null || die
-	eend
+	eend $?
 	popd &>/dev/null || die
 
 	pushd src/VBox &>/dev/null || die

--- a/app-emulation/virtualbox-guest-additions/virtualbox-guest-additions-6.0.14.ebuild
+++ b/app-emulation/virtualbox-guest-additions/virtualbox-guest-additions-6.0.14.ebuild
@@ -68,7 +68,7 @@ src_prepare() {
 	pushd src/VBox/Additions &>/dev/null || die
 	ebegin "Extracting guest kernel module sources"
 	kmk GuestDrivers-src vboxguest-src vboxsf-src vboxvideo-src &>/dev/null || die
-	eend
+	eend $?
 	popd &>/dev/null || die
 
 	# PaX fixes (see bug #298988)

--- a/app-emulation/virtualbox-guest-additions/virtualbox-guest-additions-6.1.0.ebuild
+++ b/app-emulation/virtualbox-guest-additions/virtualbox-guest-additions-6.1.0.ebuild
@@ -68,7 +68,7 @@ src_prepare() {
 	pushd src/VBox/Additions &>/dev/null || die
 	ebegin "Extracting guest kernel module sources"
 	kmk GuestDrivers-src vboxguest-src vboxsf-src vboxvideo-src &>/dev/null || die
-	eend
+	eend $?
 	popd &>/dev/null || die
 
 	# PaX fixes (see bug #298988)

--- a/app-emulation/xen-tools/files/xendomains.initd-r2
+++ b/app-emulation/xen-tools/files/xendomains.initd-r2
@@ -45,12 +45,7 @@ start() {
 		&& ${screen_cmd} logfile flush ${SCREEN_LOG_INTERVAL:-1} \
 		&& ${screen_cmd} log on \
 		&& ${screen_cmd} deflog on ) >/dev/null
-		if [ $? -ne 0 ] ; then
-			eend 1
-			return 1
-		else
-			eend
-		fi
+		eend $? || return 1
 	fi
 	# Create all domains with config files in AUTODIR.
 	for dom in $(ls "${AUTODIR:=/etc/xen/auto}/"* 2>/dev/null | sort); do

--- a/dev-db/pgpool2/files/pgpool2.initd
+++ b/dev-db/pgpool2/files/pgpool2.initd
@@ -46,7 +46,7 @@ start() {
         --pidfile ${PIDFILE} \
         --exec /usr/bin/pgpool
 
-    eend
+    eend $?
 }
 
 stop() {
@@ -71,7 +71,7 @@ stop() {
         --pidfile ${PIDFILE} \
         --retry ${retries}
 
-    eend
+    eend $?
 }
 
 reload() {

--- a/dev-python/dill/dill-0.3.0.ebuild
+++ b/dev-python/dill/dill-0.3.0.ebuild
@@ -20,7 +20,7 @@ python_test() {
 	for t in tests/test_*.py; do
 		ebegin "\t${t}"
 		"${EPYTHON}" "${t}"
-		eend || fail=1
+		eend ${?} || fail=1
 	done
 
 	[[ ${fail} ]] && die "Tests fail with ${EPYTHON}"

--- a/dev-python/dill/dill-0.3.1.1.ebuild
+++ b/dev-python/dill/dill-0.3.1.1.ebuild
@@ -20,7 +20,7 @@ python_test() {
 	for t in tests/test_*.py; do
 		ebegin "\t${t}"
 		"${EPYTHON}" "${t}"
-		eend || fail=1
+		eend ${?} || fail=1
 	done
 
 	[[ ${fail} ]] && die "Tests fail with ${EPYTHON}"

--- a/dev-tex/envlab/envlab-1.2-r1.ebuild
+++ b/dev-tex/envlab/envlab-1.2-r1.ebuild
@@ -30,7 +30,7 @@ src_compile() {
 	pdflatex elguide.tex || die "compiling #2 failed"
 	pdflatex envlab.drv || die "compiling #3 failed"
 	pdflatex envlab.drv || die "compiling #3 failed"
-	eend
+	eend $?
 }
 
 src_install() {

--- a/dev-tex/pythontex/pythontex-0.16.ebuild
+++ b/dev-tex/pythontex/pythontex-0.16.ebuild
@@ -31,7 +31,7 @@ src_compile() {
 	ebegin "Compiling ${PN}"
 	rm ${PN}.sty || die
 	VARTEXFONTS="${T}/fonts" latex ${PN}.ins extra || die
-	eend
+	eend $?
 }
 
 src_install() {

--- a/dev-util/electron/electron-2.0.17-r2.ebuild
+++ b/dev-util/electron/electron-2.0.17-r2.ebuild
@@ -515,7 +515,7 @@ src_prepare() {
 	ebegin "Unbundling libraries"
 	build/linux/unbundle/remove_bundled_libraries.py \
 		"${keeplibs[@]}" --do-remove || die
-	eend
+	eend $?
 
 	cd "${S}" || die
 

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-10.1.243.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-10.1.243.ebuild
@@ -105,7 +105,7 @@ src_install() {
 			while IFS="" read -d $'\0' -r f; do
 				docompress -x "${f#${ED}}"
 			done < <(find "${ED}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
-		eend
+		eend $?
 	fi
 
 	ebegin "Cleaning before installation..."
@@ -113,7 +113,7 @@ src_install() {
 			rm -f "${f}" || die
 		done
 		find -type f \( -name '*.o' -o -name '*.pdf' -o -name 'readme.txt' \) -delete || die
-	eend
+	eend $?
 
 	ebegin "Moving files..."
 		while IFS="" read -d $'\0' -r f; do
@@ -129,7 +129,7 @@ src_install() {
 				doins "${f}"
 			fi
 		done < <(find . -type f -print0)
-	eend
+	eend $?
 }
 
 pkg_postinst() {

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-6.5.19.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-6.5.19.ebuild
@@ -122,7 +122,7 @@ src_install() {
 		ebegin "Installing docs ..."
 			treecopy $(find -type f \( -name readme.txt -o -name "*.pdf" \)) "${ED}"/usr/share/doc/${PF}/
 			docompress -x $(find "${ED}"/usr/share/doc/${PF}/ -type f -name readme.txt | sed -e "s:${ED}::")
-		eend
+		eend $?
 	fi
 
 	crap+=" *.txt Samples.htm*"
@@ -134,7 +134,7 @@ src_install() {
 			fi
 		done
 		find -type f \( -name "*.o" -o -name "*.pdf" -o -name "readme.txt" \) -delete || die
-	eend
+	eend $?
 
 	ebegin "Moving files..."
 		for f in $(find .); do
@@ -152,5 +152,5 @@ src_install() {
 				fi
 			fi
 	done
-	eend
+	eend $?
 }

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-7.5.18.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-7.5.18.ebuild
@@ -109,7 +109,7 @@ src_install() {
 		ebegin "Installing docs ..."
 			treecopy $(find -type f \( -name readme.txt -o -name "*.pdf" \)) "${ED}"/usr/share/doc/${PF}/
 			docompress -x $(find "${ED}"/usr/share/doc/${PF}/ -type f -name readme.txt | sed -e "s:${ED}::")
-		eend
+		eend $?
 	fi
 
 	crap+=" *.txt Samples.htm*"
@@ -121,7 +121,7 @@ src_install() {
 			fi
 		done
 		find -type f \( -name "*.o" -o -name "*.pdf" -o -name "readme.txt" \) -delete || die
-	eend
+	eend $?
 
 	ebegin "Moving files..."
 		for f in $(find .); do
@@ -139,5 +139,5 @@ src_install() {
 				fi
 			fi
 	done
-	eend
+	eend $?
 }

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-8.0.44-r1.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-8.0.44-r1.ebuild
@@ -115,7 +115,7 @@ src_install() {
 			while IFS="" read -d $'\0' -r f; do
 				docompress -x "${f#${ED%/}}"
 			done < <(find "${ED%/}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
-		eend
+		eend $?
 	fi
 
 	ebegin "Cleaning before installation..."
@@ -123,7 +123,7 @@ src_install() {
 			rm -f "${f}" || die
 		done
 		find -type f \( -name '*.o' -o -name '*.pdf' -o -name 'readme.txt' \) -delete || die
-	eend
+	eend $?
 
 	ebegin "Moving files..."
 		while IFS="" read -d $'\0' -r f; do
@@ -139,5 +139,5 @@ src_install() {
 				doins "${f}"
 			fi
 		done < <(find . -type f -print0)
-	eend
+	eend $?
 }

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-8.0.61.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-8.0.61.ebuild
@@ -116,7 +116,7 @@ src_install() {
 			while IFS="" read -d $'\0' -r f; do
 				docompress -x "${f#${ED%/}}"
 			done < <(find "${ED%/}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
-		eend
+		eend $?
 	fi
 
 	ebegin "Cleaning before installation..."
@@ -124,7 +124,7 @@ src_install() {
 			rm -f "${f}" || die
 		done
 		find -type f \( -name '*.o' -o -name '*.pdf' -o -name 'readme.txt' \) -delete || die
-	eend
+	eend $?
 
 	ebegin "Moving files..."
 		while IFS="" read -d $'\0' -r f; do
@@ -140,5 +140,5 @@ src_install() {
 				doins "${f}"
 			fi
 		done < <(find . -type f -print0)
-	eend
+	eend $?
 }

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-9.0.176.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-9.0.176.ebuild
@@ -116,7 +116,7 @@ src_install() {
 			while IFS="" read -d $'\0' -r f; do
 				docompress -x "${f#${ED%/}}"
 			done < <(find "${ED%/}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
-		eend
+		eend $?
 	fi
 
 	ebegin "Cleaning before installation..."
@@ -124,7 +124,7 @@ src_install() {
 			rm -f "${f}" || die
 		done
 		find -type f \( -name '*.o' -o -name '*.pdf' -o -name 'readme.txt' \) -delete || die
-	eend
+	eend $?
 
 	ebegin "Moving files..."
 		while IFS="" read -d $'\0' -r f; do
@@ -140,5 +140,5 @@ src_install() {
 				doins "${f}"
 			fi
 		done < <(find . -type f -print0)
-	eend
+	eend $?
 }

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-9.1.85.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-9.1.85.ebuild
@@ -116,7 +116,7 @@ src_install() {
 			while IFS="" read -d $'\0' -r f; do
 				docompress -x "${f#${ED%/}}"
 			done < <(find "${ED%/}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
-		eend
+		eend $?
 	fi
 
 	ebegin "Cleaning before installation..."
@@ -124,7 +124,7 @@ src_install() {
 			rm -f "${f}" || die
 		done
 		find -type f \( -name '*.o' -o -name '*.pdf' -o -name 'readme.txt' \) -delete || die
-	eend
+	eend $?
 
 	ebegin "Moving files..."
 		while IFS="" read -d $'\0' -r f; do
@@ -140,5 +140,5 @@ src_install() {
 				doins "${f}"
 			fi
 		done < <(find . -type f -print0)
-	eend
+	eend $?
 }

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-9.2.88.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-9.2.88.ebuild
@@ -116,7 +116,7 @@ src_install() {
 			while IFS="" read -d $'\0' -r f; do
 				docompress -x "${f#${ED%/}}"
 			done < <(find "${ED%/}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
-		eend
+		eend $?
 	fi
 
 	ebegin "Cleaning before installation..."
@@ -124,7 +124,7 @@ src_install() {
 			rm -f "${f}" || die
 		done
 		find -type f \( -name '*.o' -o -name '*.pdf' -o -name 'readme.txt' \) -delete || die
-	eend
+	eend $?
 
 	ebegin "Moving files..."
 		while IFS="" read -d $'\0' -r f; do
@@ -140,5 +140,5 @@ src_install() {
 				doins "${f}"
 			fi
 		done < <(find . -type f -print0)
-	eend
+	eend $?
 }

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.0.130.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.0.130.ebuild
@@ -91,7 +91,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -rf "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.1.105-r1.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.1.105-r1.ebuild
@@ -87,7 +87,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -rf "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.1.168.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.1.168.ebuild
@@ -87,7 +87,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -rf "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.1.243-r1.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.1.243-r1.ebuild
@@ -95,7 +95,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -r "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.2.89.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-10.2.89.ebuild
@@ -95,7 +95,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -r "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-6.5.14.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-6.5.14.ebuild
@@ -106,7 +106,7 @@ src_install() {
 	ebegin "Cleaning ${i}..."
 		if [[ -e ${i} ]]; then
 			find ${i} -delete || die
-			eend
+			eend $?
 		else
 			eend $1
 		fi

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-6.5.19-r1.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-6.5.19-r1.ebuild
@@ -106,7 +106,7 @@ src_install() {
 	ebegin "Cleaning ${i}..."
 		if [[ -e ${i} ]]; then
 			find ${i} -delete || die
-			eend
+			eend $?
 		else
 			eend $1
 		fi

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-7.5.18-r2.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-7.5.18-r2.ebuild
@@ -93,7 +93,7 @@ src_install() {
 	ebegin "Cleaning ${i}..."
 		if [[ -e ${i} ]]; then
 			find ${i} -delete || die
-			eend
+			eend $?
 		else
 			eend $1
 		fi

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-8.0.44.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-8.0.44.ebuild
@@ -90,7 +90,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -rf "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-8.0.61.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-8.0.61.ebuild
@@ -91,7 +91,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -rf "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-9.0.176.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-9.0.176.ebuild
@@ -91,7 +91,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -rf "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-9.1.85.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-9.1.85.ebuild
@@ -91,7 +91,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -rf "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-9.2.88.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-9.2.88.ebuild
@@ -91,7 +91,7 @@ src_install() {
 	for i in "${remove[@]}"; do
 		ebegin "Cleaning ${i}..."
 		rm -rf "${i}" || die
-		eend
+		eend $?
 	done
 
 	dodir ${cudadir}

--- a/eclass/elisp-common.eclass
+++ b/eclass/elisp-common.eclass
@@ -457,7 +457,7 @@ elisp-site-regen() {
 		# was actually no change.
 		# A case is a remerge where we have doubled output.
 		rm -f "${T}"/site-gentoo.el
-		eend
+		eend $?
 		einfo "... no changes."
 	else
 		mv "${T}"/site-gentoo.el "${sitelisp}"/site-gentoo.el

--- a/eclass/gnome2.eclass
+++ b/eclass/gnome2.eclass
@@ -299,7 +299,7 @@ gnome2_src_install() {
 			if ! use_if_iuse static-libs ; then
 				find "${D}" -name '*.la' -exec rm -f {} + || die "la file removal failed"
 			fi
-			eend
+			eend $?
 		fi
 	else
 		case "${GNOME2_LA_PUNT}" in

--- a/eclass/go-module.eclass
+++ b/eclass/go-module.eclass
@@ -137,7 +137,7 @@ go-module_src_unpack() {
 		mkdir -p "${S}/vendor/${import}" || die
 		tar -C "${S}/vendor/${import}" -x --strip-components 1 \
 			-f "${DISTDIR}/${tarball}" || die
-		eend
+		eend $?
 	done
 }
 

--- a/eclass/rpm.eclass
+++ b/eclass/rpm.eclass
@@ -120,7 +120,7 @@ rpm_spec_epatch() {
 		epatch "${dir:+${dir}/}$*"
 	done
 
-	eend
+	eend $?
 }
 
 EXPORT_FUNCTIONS src_unpack

--- a/mail-filter/MailScanner/MailScanner-4.84.5.2.ebuild
+++ b/mail-filter/MailScanner/MailScanner-4.84.5.2.ebuild
@@ -319,7 +319,7 @@ pkg_postinst() {
 			/etc/MailScanner/MailScanner.conf.pre_upgrade.${MY_PV} \
 			/etc/MailScanner/MailScanner.conf.${MY_PV} \
 			> /etc/MailScanner/MailScanner.conf 2> /dev/null
-		eend
+		eend $?
 	else
 		cp /etc/MailScanner/MailScanner.conf.sample \
 			/etc/MailScanner/MailScanner.conf

--- a/mail-filter/policyd/policyd-1.82-r3.ebuild
+++ b/mail-filter/policyd/policyd-1.82-r3.ebuild
@@ -35,7 +35,7 @@ src_prepare() {
 	    -e s:DEBUG=3:DEBUG=0:g \
 	    -e s:DATABASE_KEEPALIVE=0:DATABASE_KEEPALIVE=1:g \
 	    policyd.conf || die "sed failed"
-	eend
+	eend $?
 }
 
 src_compile() {

--- a/mail-mta/postfix/files/postfix.rc6.2.7
+++ b/mail-mta/postfix/files/postfix.rc6.2.7
@@ -45,7 +45,7 @@ start() {
 stop() {
 	ebegin "Stopping postfix ${CONF_MESSAGE}"
 	/usr/sbin/postfix ${CONF_PARAM} stop >/dev/null 2>&1
-	eend
+	eend $?
 }
 
 status() {

--- a/media-libs/netpbm/files/make-tarball.sh
+++ b/media-libs/netpbm/files/make-tarball.sh
@@ -12,13 +12,13 @@ if [[ $# -eq 0 ]] ; then
 	PV=$(svn ls | sort -V | tail -1) || die
 	[[ -z ${PV} ]] && die
 	PV=${PV%/}
-	eend
+	eend $?
 	einfo "Using PV=${PV}"
 
 	if [[ ! -d ${PV} ]] ; then
 		ebegin "Checking out ${PV}"
 		svn up -q ${PV}
-		eend || die
+		eend $? || die
 	fi
 fi
 

--- a/net-analyzer/snmptt/files/snmptt.initd-r1
+++ b/net-analyzer/snmptt/files/snmptt.initd-r1
@@ -9,11 +9,11 @@ depend() {
 start() {
 	ebegin "Starting snmptt"
 	start-stop-daemon --start --pidfile /run/snmptt.pid --exec /usr/sbin/snmptt
-	eend
+	eend $?
 }
 
 stop() {
 	ebegin "Stopping snmptt"
 	start-stop-daemon --stop --pidfile /run/snmptt.pid
-	eend
+	eend $?
 }

--- a/net-analyzer/snort/snort-2.9.12.ebuild
+++ b/net-analyzer/snort/snort-2.9.12.ebuild
@@ -61,7 +61,7 @@ src_prepare() {
 			"${WORKDIR}/${P}/src/dynamic-preprocessors/$i/Makefile.am" \
 			|| die "sed for $i failed."
 	done
-	eend
+	eend $?
 
 	mv configure.{in,ac} || die
 

--- a/net-analyzer/snort/snort-2.9.15.ebuild
+++ b/net-analyzer/snort/snort-2.9.15.ebuild
@@ -61,7 +61,7 @@ src_prepare() {
 			"${WORKDIR}/${P}/src/dynamic-preprocessors/$i/Makefile.am" \
 			|| die "sed for $i failed."
 	done
-	eend
+	eend $?
 
 	mv configure.{in,ac} || die
 

--- a/net-analyzer/snort/snort-2.9.8.3-r2.ebuild
+++ b/net-analyzer/snort/snort-2.9.8.3-r2.ebuild
@@ -60,7 +60,7 @@ src_prepare() {
 			"${WORKDIR}/${P}/src/dynamic-preprocessors/$i/Makefile.am" \
 			|| die "sed for $i failed."
 	done
-	eend
+	eend $?
 
 	AT_M4DIR=m4 eautoreconf
 }

--- a/net-misc/cbqinit/files/rc_cbqinit-r1
+++ b/net-misc/cbqinit/files/rc_cbqinit-r1
@@ -26,5 +26,5 @@ start() {
 stop() {
 	ebegin "Stopping cbqinit"
 	/usr/sbin/cbqinit stop
-	eend
+	eend $?
 }

--- a/net-misc/dahdi-tools/files/dahdi-autoconf.init2
+++ b/net-misc/dahdi-tools/files/dahdi-autoconf.init2
@@ -29,7 +29,7 @@ dahdi_load_modules() {
 		if [ "${status}" = "-" -a "${!mod_vname-notloaded}" = "notloaded" ]; then
 			ebegin "Loading module $mod"
 			/sbin/modprobe $mod
-			eend
+			eend $?
 
 			[ $? -eq 0 ] && eval "$mod_vname=loaded"
 		fi

--- a/net-misc/ip-sentinel/ip-sentinel-0.12.ebuild
+++ b/net-misc/ip-sentinel/ip-sentinel-0.12.ebuild
@@ -53,7 +53,7 @@ pkg_config() {
 		ebegin "Setting up the chroot directory"
 			mkdir -m 0755 -p "${CHROOT}/etc"
 			cp -R /etc/ip-sentinel.cfg "${CHROOT}/etc"
-		eend
+		eend $?
 
 		if [ "`grep '^#[[:blank:]]\?CHROOT' /etc/conf.d/ip-sentinel`" ] ; then
 			sed -e '/^#[[:blank:]]\?CHROOT/s/^#[[:blank:]]\?//' \

--- a/net-nds/openldap/openldap-2.4.45.ebuild
+++ b/net-nds/openldap/openldap-2.4.45.ebuild
@@ -741,7 +741,7 @@ multilib_src_install() {
 		use prefix || fowners root:ldap /etc/openldap/slapd.conf
 		fperms 0640 /etc/openldap/slapd.conf
 		cp "${configfile}" "${configfile}".default
-		eend
+		eend $?
 
 		# install our own init scripts and systemd unit files
 		einfo "Install init scripts"

--- a/net-nds/openldap/openldap-2.4.48.ebuild
+++ b/net-nds/openldap/openldap-2.4.48.ebuild
@@ -759,7 +759,7 @@ multilib_src_install() {
 		use prefix || fowners root:ldap /etc/openldap/slapd.conf
 		fperms 0640 /etc/openldap/slapd.conf
 		cp "${configfile}" "${configfile}".default || die
-		eend
+		eend $?
 
 		# install our own init scripts and systemd unit files
 		einfo "Install init scripts"

--- a/sci-biology/cutg/cutg-160-r1.ebuild
+++ b/sci-biology/cutg/cutg-160-r1.ebuild
@@ -25,7 +25,7 @@ src_compile() {
 		ebegin "Indexing CUTG for usage with EMBOSS."
 		EMBOSS_DATA="." cutgextract -auto -directory "${S}" || die \
 			"Indexing CUTG failed."
-		eend
+		eend $?
 	fi
 }
 

--- a/sci-libs/mpir/mpir-2.6.0-r2.ebuild
+++ b/sci-libs/mpir/mpir-2.6.0-r2.ebuild
@@ -47,7 +47,7 @@ src_prepare() {
 			%endif
 		EOF
 	done
-	eend
+	eend $?
 	eautoreconf
 }
 

--- a/sci-libs/mpir/mpir-2.7.2.ebuild
+++ b/sci-libs/mpir/mpir-2.7.2.ebuild
@@ -51,7 +51,7 @@ src_prepare() {
 			%endif
 		EOF
 	done
-	eend
+	eend $?
 	eautoreconf
 }
 

--- a/sci-libs/mpir/mpir-3.0.0.ebuild
+++ b/sci-libs/mpir/mpir-3.0.0.ebuild
@@ -51,7 +51,7 @@ src_prepare() {
 			%endif
 		EOF
 	done
-	eend
+	eend $?
 	eautoreconf
 }
 

--- a/x11-wm/page/page-1.9.9-r2.ebuild
+++ b/x11-wm/page/page-1.9.9-r2.ebuild
@@ -35,7 +35,7 @@ src_install() {
 	ebegin "Changing references from 'page' to 'pagewm'"
 	mv "${D}"usr/bin/page "${D}"usr/bin/pagewm || die "Could not rename binary!"
 	sed -i -e "s:/usr/bin/page:/usr/bin/pagewm:" "${D}"usr/share/applications/page.desktop || die "Could not change .desktop file!"
-	eend
+	eend $?
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Per PMS, `eend` must explicitly be supplied with the exit status. However, Portage implementation wrongly assumes all arguments are optional. What's worse, it defaults to `0` when not provided which sometimes leads to silly mistakes (such as a particular @mgorny assuming it has a reasonable default of `$?`).

Fix all instances I could find to explicitly pass `$?`. In many of those cases `0` would also be fine since it's never reached otherwise (`|| die` in preceding line) but there's no harm in using `$?` and it's less error-prone.

CC @gentoo/qa 