### PR TITLE
distutils-r1 pyproject.toml support

### DIFF
--- a/dev-python/backports-tempfile/backports-tempfile-1.0.ebuild
+++ b/dev-python/backports-tempfile/backports-tempfile-1.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy )
 
 inherit distutils-r1
 

--- a/dev-python/backports-weakref/backports-weakref-1.0_p1.ebuild
+++ b/dev-python/backports-weakref/backports-weakref-1.0_p1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy )
 
 inherit distutils-r1
 

--- a/dev-python/pyproject2setuppy/metadata.xml
+++ b/dev-python/pyproject2setuppy/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>mgorny@gentoo.org</email>
+		<name>Michał Górny</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>python@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/dev-python/pyproject2setuppy/pyproject2setuppy-9999.ebuild
+++ b/dev-python/pyproject2setuppy/pyproject2setuppy-9999.ebuild
@@ -1,0 +1,32 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=manual
+PYTHON_COMPAT=( python{2_7,3_{5,6,7,8}} pypy{,3} )
+
+inherit distutils-r1 git-r3
+
+DESCRIPTION="Cheap setup.py hack to install flit & poetry-based projects"
+HOMEPAGE="https://github.com/mgorny/pyproject2setuppy"
+EGIT_REPO_URI="https://github.com/mgorny/pyproject2setuppy.git"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS=""
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/toml[${PYTHON_USEDEP}]"
+BDEPEND="${RDEPEND}
+	test? (
+		$(python_gen_cond_dep '
+			dev-python/backports-tempfile[${PYTHON_USEDEP}]
+			dev-python/mock[${PYTHON_USEDEP}]
+		' -2)
+	)"
+
+distutils_enable_tests unittest

--- a/dev-python/sphinxcontrib-github-alt/sphinxcontrib-github-alt-1.1-r1.ebuild
+++ b/dev-python/sphinxcontrib-github-alt/sphinxcontrib-github-alt-1.1-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=pyproject.toml
+PYTHON_COMPAT=( python3_{5,6,7} )
+
+inherit distutils-r1
+
+MY_PN="sphinxcontrib_github_alt"
+
+DESCRIPTION="Link to GitHub issues, pull requests, commits and users from Sphinx docs"
+HOMEPAGE="https://github.com/jupyter/sphinxcontrib_github_alt"
+SRC_URI="https://github.com/jupyter/${MY_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+RDEPEND="dev-python/sphinx[${PYTHON_USEDEP}]"
+BDEPEND=${RDEPEND}
+
+S="${WORKDIR}/${MY_PN}-${PV}"

--- a/dev-python/testpath/testpath-0.4.4-r1.ebuild
+++ b/dev-python/testpath/testpath-0.4.4-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=pyproject.toml
+PYTHON_COMPAT=( pypy{,3} python{2_7,3_{5,6,7,8}} )
+
+inherit distutils-r1
+
+DESCRIPTION="Test utilities for code working with files and commands"
+HOMEPAGE="https://github.com/jupyter/testpath https://testpath.readthedocs.io/en/latest/"
+SRC_URI="https://github.com/jupyter/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+
+DEPEND="
+	test? (
+		dev-python/pathlib2[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+	)
+"
+
+distutils_enable_tests pytest
+distutils_enable_sphinx doc

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: distutils-r1.eclass
@@ -86,6 +86,8 @@ esac
 # - no -- do not add the dependency (pure distutils package)
 # - bdepend -- add it to BDEPEND (the default)
 # - rdepend -- add it to BDEPEND+RDEPEND (when using entry_points)
+# - manual -- do not add the depedency and suppress the checks
+#             (assumes you will take care of doing it correctly)
 #
 # This variable is effective only if DISTUTILS_OPTIONAL is disabled.
 # It needs to be set before the inherit line.
@@ -116,7 +118,7 @@ _distutils_set_globals() {
 	local bdep=${rdep}
 
 	case ${DISTUTILS_USE_SETUPTOOLS} in
-		no)
+		no|manual)
 			;;
 		bdepend)
 			bdep+=" dev-python/setuptools[${PYTHON_USEDEP}]"
@@ -436,6 +438,7 @@ distutils_enable_tests() {
 # incorrectly.
 _distutils_verify_use_setuptools() {
 	[[ ${DISTUTILS_OPTIONAL} ]] && return
+	[[ ${DISTUTILS_USE_SETUPTOOLS} == manual ]] && return
 
 	# ok, those are cheap greps.  we can try toimprove them if we hit
 	# false positives.

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -86,6 +86,8 @@ esac
 # - no -- do not add the dependency (pure distutils package)
 # - bdepend -- add it to BDEPEND (the default)
 # - rdepend -- add it to BDEPEND+RDEPEND (when using entry_points)
+# - pyproject.toml -- use pyproject2setuptools to install a project
+#                     using pyproject.toml (flit, poetry...)
 # - manual -- do not add the depedency and suppress the checks
 #             (assumes you will take care of doing it correctly)
 #
@@ -126,6 +128,9 @@ _distutils_set_globals() {
 		rdepend)
 			bdep+=" dev-python/setuptools[${PYTHON_USEDEP}]"
 			rdep+=" dev-python/setuptools[${PYTHON_USEDEP}]"
+			;;
+		pyproject.toml)
+			bdep+=" dev-python/pyproject2setuppy[${PYTHON_USEDEP}]"
 			;;
 		*)
 			die "Invalid DISTUTILS_USE_SETUPTOOLS=${DISTUTILS_USE_SETUPTOOLS}"
@@ -439,6 +444,7 @@ distutils_enable_tests() {
 _distutils_verify_use_setuptools() {
 	[[ ${DISTUTILS_OPTIONAL} ]] && return
 	[[ ${DISTUTILS_USE_SETUPTOOLS} == manual ]] && return
+	[[ ${DISTUTILS_USE_SETUPTOOLS} == pyproject.toml ]] && return
 
 	# ok, those are cheap greps.  we can try toimprove them if we hit
 	# false positives.
@@ -560,6 +566,28 @@ _distutils-r1_disable_ez_setup() {
 	fi
 }
 
+# @FUNCTION: _distutils-r1_handle_pyproject_toml
+# @INTERNAL
+# @DESCRIPTION:
+# Generate setup.py for pyproject.toml if requested.
+_distutils-r1_handle_pyproject_toml() {
+	if [[ ! -f setup.py && -f pyproject.toml ]]; then
+		if [[ ${DISTUTILS_USE_SETUPTOOLS} == pyproject.toml ]]; then
+			cat > setup.py <<-EOF || die
+				#!/usr/bin/env python
+				from pyproject2setuppy.main import main
+				main()
+			EOF
+			chmod +x setup.py || die
+		else
+			eerror "No setup.py found but pyproject.toml is present.  In order to enable"
+			eerror "pyproject.toml support in distutils-r1, set:"
+			eerror "  DISTUTILS_USE_SETUPTOOLS=pyproject.toml"
+			die "No setup.py found and DISTUTILS_USE_SETUPTOOLS!=pyproject.toml"
+		fi
+	fi
+}
+
 # @FUNCTION: distutils-r1_python_prepare_all
 # @DESCRIPTION:
 # The default python_prepare_all(). It applies the patches from PATCHES
@@ -588,6 +616,7 @@ distutils-r1_python_prepare_all() {
 	fi
 
 	_distutils-r1_disable_ez_setup
+	_distutils-r1_handle_pyproject_toml
 
 	if [[ ${DISTUTILS_IN_SOURCE_BUILD} && ! ${DISTUTILS_SINGLE_IMPL} ]]
 	then


### PR DESCRIPTION
CC @gentoo/python 

So far just the live ebuild (so CI wouldn't be happy)<del> and Python 3 only. I'm not sure if it's worthwhile to port it to py2 given that only new packages will use `pyproject.toml`.</del> Supports minimal subset of flit and poetry.