### PR TITLE
net-analyzer/greenbone-security-assistant: revbump to drop use flag

### DIFF
--- a/net-analyzer/greenbone-security-assistant/greenbone-security-assistant-8.0.1-r1.ebuild
+++ b/net-analyzer/greenbone-security-assistant/greenbone-security-assistant-8.0.1-r1.ebuild
@@ -25,7 +25,7 @@ DEPEND="
 	dev-libs/libxslt
 	>=net-analyzer/gvm-libs-10.0.1
 	net-libs/gnutls:=
-	net-libs/libmicrohttpd[messages]"
+	net-libs/libmicrohttpd"
 
 RDEPEND="
 	${DEPEND}


### PR DESCRIPTION
net-analyzer/greenbone-security-assistant: revbump to drop use flag on dependency

Package-Manager: Portage-2.3.79, Repoman-2.3.16
Signed-off-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>