### PR TITLE
eclass/cargo.eclass: specify --path . to install

### DIFF
--- a/app-crypt/nitrocli/nitrocli-0.2.4.ebuild
+++ b/app-crypt/nitrocli/nitrocli-0.2.4.ebuild
@@ -67,7 +67,7 @@ RESTRICT="test"
 QA_FLAGS_IGNORED="/usr/bin/nitrocli"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 
 	einstalldocs
 	doman "doc/nitrocli.1"

--- a/app-crypt/nitrocli/nitrocli-0.3.0.ebuild
+++ b/app-crypt/nitrocli/nitrocli-0.3.0.ebuild
@@ -67,7 +67,7 @@ RESTRICT="test"
 QA_FLAGS_IGNORED="/usr/bin/nitrocli"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 
 	einstalldocs
 	doman "doc/nitrocli.1"

--- a/app-misc/cargo-license/cargo-license-0.3.0.ebuild
+++ b/app-misc/cargo-license/cargo-license-0.3.0.ebuild
@@ -69,6 +69,6 @@ KEYWORDS="~amd64 ~x86"
 QA_FLAGS_IGNORED="/usr/bin/cargo-license"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 	einstalldocs
 }

--- a/app-misc/rpick/rpick-0.4.0.ebuild
+++ b/app-misc/rpick/rpick-0.4.0.ebuild
@@ -90,7 +90,7 @@ DOCS=( CHANGELOG.md README.md )
 QA_FLAGS_IGNORED="usr/bin/rpick"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 
 	einstalldocs
 }

--- a/app-misc/rpick/rpick-0.5.0.ebuild
+++ b/app-misc/rpick/rpick-0.5.0.ebuild
@@ -91,7 +91,7 @@ DOCS=( CHANGELOG.md README.md )
 QA_FLAGS_IGNORED="usr/bin/rpick"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 
 	einstalldocs
 }

--- a/app-misc/skim/skim-0.5.4.ebuild
+++ b/app-misc/skim/skim-0.5.4.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 QA_FLAGS_IGNORED="usr/bin/sk"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 	dodoc CHANGELOG.md README.md
 
 	use tmux && dobin bin/sk-tmux

--- a/app-misc/skim/skim-0.5.5.ebuild
+++ b/app-misc/skim/skim-0.5.5.ebuild
@@ -57,7 +57,7 @@ RDEPEND="
 QA_FLAGS_IGNORED="usr/bin/sk"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 	dodoc CHANGELOG.md README.md
 
 	use tmux && dobin bin/sk-tmux

--- a/app-misc/skim/skim-0.6.4.ebuild
+++ b/app-misc/skim/skim-0.6.4.ebuild
@@ -90,7 +90,7 @@ src_install() {
 	# prevent cargo_src_install() blowing up on man installation
 	mv man manpages || die
 
-	cargo_src_install --path=.
+	cargo_src_install
 	dodoc CHANGELOG.md README.md
 	doman manpages/man1/*
 

--- a/app-misc/skim/skim-0.6.6.ebuild
+++ b/app-misc/skim/skim-0.6.6.ebuild
@@ -94,7 +94,7 @@ src_install() {
 	# prevent cargo_src_install() blowing up on man installation
 	mv man manpages || die
 
-	cargo_src_install --path=.
+	cargo_src_install
 	dodoc CHANGELOG.md README.md
 	doman manpages/man1/*
 

--- a/app-misc/skim/skim-0.6.7.ebuild
+++ b/app-misc/skim/skim-0.6.7.ebuild
@@ -98,7 +98,7 @@ src_install() {
 	# prevent cargo_src_install() blowing up on man installation
 	mv man manpages || die
 
-	cargo_src_install --path=.
+	cargo_src_install
 	dodoc CHANGELOG.md README.md
 	doman manpages/man1/*
 

--- a/app-misc/skim/skim-0.6.8.ebuild
+++ b/app-misc/skim/skim-0.6.8.ebuild
@@ -97,7 +97,7 @@ src_install() {
 	# prevent cargo_src_install() blowing up on man installation
 	mv man manpages || die
 
-	cargo_src_install --path=.
+	cargo_src_install
 	dodoc CHANGELOG.md README.md
 	doman manpages/man1/*
 

--- a/app-shells/mcfly/mcfly-0.3.4.ebuild
+++ b/app-shells/mcfly/mcfly-0.3.4.ebuild
@@ -76,7 +76,7 @@ DEPEND=""
 RDEPEND=""
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 
 	insinto "/usr/share/${PN}"
 	doins "${PN}.bash"

--- a/app-text/fblog/fblog-1.3.1.ebuild
+++ b/app-text/fblog/fblog-1.3.1.ebuild
@@ -59,6 +59,6 @@ DOCS=( README.org sample.json.log )
 QA_FLAGS_IGNORED="/usr/bin/fblog"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 	einstalldocs
 }

--- a/dev-util/cargo-tree/cargo-tree-0.23.0.ebuild
+++ b/dev-util/cargo-tree/cargo-tree-0.23.0.ebuild
@@ -184,6 +184,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 src_install(){
-	cargo_src_install --path=.
+	cargo_src_install
 	einstalldocs
 }

--- a/dev-util/cargo-tree/cargo-tree-0.24.0.ebuild
+++ b/dev-util/cargo-tree/cargo-tree-0.24.0.ebuild
@@ -176,6 +176,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 src_install(){
-	cargo_src_install --path=.
+	cargo_src_install
 	einstalldocs
 }

--- a/dev-util/cargo-tree/cargo-tree-0.25.0.ebuild
+++ b/dev-util/cargo-tree/cargo-tree-0.25.0.ebuild
@@ -177,6 +177,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 src_install(){
-	cargo_src_install --path=.
+	cargo_src_install
 	einstalldocs
 }

--- a/dev-util/cargo-tree/cargo-tree-0.26.0.ebuild
+++ b/dev-util/cargo-tree/cargo-tree-0.26.0.ebuild
@@ -181,6 +181,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 src_install(){
-	cargo_src_install --path=.
+	cargo_src_install
 	einstalldocs
 }

--- a/dev-util/cargo-tree/cargo-tree-0.27.0.ebuild
+++ b/dev-util/cargo-tree/cargo-tree-0.27.0.ebuild
@@ -183,6 +183,6 @@ DEPEND="${RDEPEND}
 "
 
 src_install(){
-	cargo_src_install --path=.
+	cargo_src_install
 	einstalldocs
 }

--- a/dev-util/sccache/sccache-0.2.10.ebuild
+++ b/dev-util/sccache/sccache-0.2.10.ebuild
@@ -331,7 +331,7 @@ src_compile(){
 }
 
 src_install() {
-	cargo_src_install --path=. ${myfeatures:+--features "${myfeatures[*]}"} --no-default-features
+	cargo_src_install ${myfeatures:+--features "${myfeatures[*]}"} --no-default-features
 
 	keepdir /etc/sccache
 

--- a/dev-util/sccache/sccache-0.2.8-r2.ebuild
+++ b/dev-util/sccache/sccache-0.2.8-r2.ebuild
@@ -328,7 +328,7 @@ src_compile(){
 }
 
 src_install() {
-	cargo_src_install --path=. ${myfeatures:+--features "${myfeatures[*]}"} --no-default-features
+	cargo_src_install ${myfeatures:+--features "${myfeatures[*]}"} --no-default-features
 
 	keepdir /etc/sccache
 

--- a/dev-util/sccache/sccache-0.2.9.ebuild
+++ b/dev-util/sccache/sccache-0.2.9.ebuild
@@ -331,7 +331,7 @@ src_compile(){
 }
 
 src_install() {
-	cargo_src_install --path=. ${myfeatures:+--features "${myfeatures[*]}"} --no-default-features
+	cargo_src_install ${myfeatures:+--features "${myfeatures[*]}"} --no-default-features
 
 	keepdir /etc/sccache
 

--- a/dev-util/wasmer/wasmer-0.11.0.ebuild
+++ b/dev-util/wasmer/wasmer-0.11.0.ebuild
@@ -191,6 +191,6 @@ src_prepare() {
 }
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 	einstalldocs
 }

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -34,6 +34,11 @@ IUSE="${IUSE} debug"
 ECARGO_HOME="${WORKDIR}/cargo_home"
 ECARGO_VENDOR="${ECARGO_HOME}/gentoo"
 
+# @ECLASS-VARIABLE: CARGO_INSTALL_PATH
+# @DESCRIPTION:
+# Allows overriding the default cwd to run cargo install from
+${CARGO_INSTALL_PATH:=.}
+
 # @FUNCTION: cargo_crate_uris
 # @DESCRIPTION:
 # Generates the URIs to put in SRC_URI to help fetch dependencies.
@@ -156,7 +161,8 @@ cargo_src_compile() {
 cargo_src_install() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	cargo install -vv -j $(makeopts_jobs) --root="${ED}/usr" $(usex debug --debug "") "$@" \
+	cargo install -vv -j $(makeopts_jobs) --path ${CARGO_INSTALL_PATH} \
+		--root="${ED}/usr" $(usex debug --debug "") "$@" \
 		|| die "cargo install failed"
 	rm -f "${ED}/usr/.crates.toml"
 

--- a/media-video/rav1e/rav1e-9999.ebuild
+++ b/media-video/rav1e/rav1e-9999.ebuild
@@ -32,7 +32,3 @@ src_unpack() {
 		cargo_live_src_unpack
 	fi
 }
-
-src_install() {
-	cargo_src_install --path .
-}

--- a/sys-apps/bat/bat-0.12.0.ebuild
+++ b/sys-apps/bat/bat-0.12.0.ebuild
@@ -169,7 +169,7 @@ DOCS=( README.md doc/alternatives.md )
 QA_FLAGS_IGNORED="/usr/bin/bat"
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 	doman doc/bat.1
 	einstalldocs
 	insinto /usr/share/fish/vendor_completions.d/

--- a/sys-apps/exa/exa-0.9.0.ebuild
+++ b/sys-apps/exa/exa-0.9.0.ebuild
@@ -99,7 +99,7 @@ src_compile() {
 }
 
 src_install() {
-	cargo_src_install --path=./ $(usex git "" --no-default-features)
+	cargo_src_install $(usex git "" --no-default-features)
 
 	newbashcomp contrib/completions.bash exa
 

--- a/sys-apps/fd/fd-7.3.0-r1.ebuild
+++ b/sys-apps/fd/fd-7.3.0-r1.ebuild
@@ -86,7 +86,7 @@ src_compile() {
 }
 
 src_install() {
-	cargo_src_install --path=.
+	cargo_src_install
 
 	newbashcomp "${T}"/shell_completions/fd.bash fd
 	insinto /usr/share/zsh/site-functions

--- a/sys-apps/lsd/lsd-0.14.0.ebuild
+++ b/sys-apps/lsd/lsd-0.14.0.ebuild
@@ -59,6 +59,6 @@ BDEPEND=">=virtual/rust-1.31.0"
 QA_FLAGS_IGNORED="/usr/bin/lsd"
 
 src_install() {
-	cargo_src_install --path .
+	cargo_src_install
 	einstalldocs
 }

--- a/sys-apps/lsd/lsd-0.15.1.ebuild
+++ b/sys-apps/lsd/lsd-0.15.1.ebuild
@@ -62,6 +62,6 @@ BDEPEND=">=virtual/rust-1.31.0"
 QA_FLAGS_IGNORED="/usr/bin/lsd"
 
 src_install() {
-	cargo_src_install --path .
+	cargo_src_install
 	einstalldocs
 }

--- a/sys-apps/lsd/lsd-0.16.0.ebuild
+++ b/sys-apps/lsd/lsd-0.16.0.ebuild
@@ -74,6 +74,6 @@ BDEPEND=">=virtual/rust-1.31.0"
 QA_FLAGS_IGNORED="/usr/bin/lsd"
 
 src_install() {
-	cargo_src_install --path .
+	cargo_src_install
 	einstalldocs
 }

--- a/sys-apps/ripgrep/ripgrep-11.0.1.ebuild
+++ b/sys-apps/ripgrep/ripgrep-11.0.1.ebuild
@@ -115,7 +115,7 @@ src_compile() {
 }
 
 src_install() {
-	cargo_src_install --path=. $(usex pcre "--features pcre2" "")
+	cargo_src_install $(usex pcre "--features pcre2" "")
 
 	# hack to find/install generated files
 	# stamp file can be present in multiple dirs if we build additional features

--- a/sys-apps/ripgrep/ripgrep-11.0.2.ebuild
+++ b/sys-apps/ripgrep/ripgrep-11.0.2.ebuild
@@ -99,7 +99,7 @@ src_compile() {
 }
 
 src_install() {
-	cargo_src_install --path=. $(usex pcre "--features pcre2" "")
+	cargo_src_install $(usex pcre "--features pcre2" "")
 
 	# hack to find/install generated files
 	# stamp file can be present in multiple dirs if we build additional features

--- a/x11-terms/alacritty/alacritty-0.3.3-r1.ebuild
+++ b/x11-terms/alacritty/alacritty-0.3.3-r1.ebuild
@@ -320,8 +320,10 @@ QA_FLAGS_IGNORED="usr/bin/alacritty"
 
 S="${WORKDIR}/${PN}-${MY_PV}"
 
+CARGO_INSTALL_PATH="alacritty"
+
 src_install() {
-	cargo_src_install --path=alacritty
+	cargo_src_install
 
 	newbashcomp extra/completions/alacritty.bash alacritty
 

--- a/x11-terms/alacritty/alacritty-0.4.0.ebuild
+++ b/x11-terms/alacritty/alacritty-0.4.0.ebuild
@@ -335,6 +335,8 @@ QA_FLAGS_IGNORED="usr/bin/alacritty"
 
 S="${WORKDIR}/${PN}-${MY_PV}"
 
+CARGO_INSTALL_PATH="alacritty"
+
 src_unpack() {
 	if [[ "${PV}" == *9999* ]]; then
 		git-r3_src_unpack
@@ -350,7 +352,7 @@ src_prepare() {
 }
 
 src_install() {
-	cargo_src_install --path=alacritty --offline
+	cargo_src_install --offline
 
 	newbashcomp extra/completions/alacritty.bash alacritty
 

--- a/x11-terms/alacritty/alacritty-9999.ebuild
+++ b/x11-terms/alacritty/alacritty-9999.ebuild
@@ -50,6 +50,8 @@ QA_FLAGS_IGNORED="usr/bin/alacritty"
 
 S="${WORKDIR}/${PN}-${MY_PV}"
 
+CARGO_INSTALL_PATH="alacritty"
+
 src_unpack() {
 	if [[ "${PV}" == *9999* ]]; then
 		git-r3_src_unpack
@@ -60,7 +62,7 @@ src_unpack() {
 }
 
 src_install() {
-	cargo_src_install --path=alacritty --offline
+	cargo_src_install --offline
 
 	newbashcomp extra/completions/alacritty.bash alacritty
 


### PR DESCRIPTION
cargo install has long required --path . for 2018 edition crates but not
required it for 2015 edition crates. It is supported however for 2015
edition crates and works for all versions in the tree so it makes sense
to make it the default.

Closes: https://bugs.gentoo.org/703590
Signed-off-by: Doug Goldstein <cardoe@gentoo.org>