### PR TITLE
net-libs/serf: Python 3.7 and 3.8 compatibility

### DIFF
--- a/net-libs/serf/serf-1.3.9-r1.ebuild
+++ b/net-libs/serf/serf-1.3.9-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_6 python3_7 python3_8 )
 
 inherit python-any-r1 scons-utils toolchain-funcs flag-o-matic
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/703670
Package-Manager: Portage-2.3.82, Repoman-2.3.20
Signed-off-by: Craig Andrews <candrews@gentoo.org>