### PR TITLE
dev-games/openscenegraph: remove gtkglext dependency

### DIFF
--- a/dev-games/openscenegraph/openscenegraph-3.5.5.ebuild
+++ b/dev-games/openscenegraph/openscenegraph-3.5.5.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://github.com/${PN}/${MY_PN}/archive/${MY_P}.tar.gz"
 LICENSE="wxWinLL-3 LGPL-2.1"
 SLOT="0/145" # NOTE: CHECK WHEN BUMPING! Subslot is SOVERSION
 KEYWORDS="amd64 ~hppa ~ia64 ppc ppc64 x86"
-IUSE="asio curl debug doc examples ffmpeg fltk fox gdal gif glut gstreamer gtk jpeg
+IUSE="asio curl debug doc examples ffmpeg fltk fox gdal gif glut gstreamer jpeg
 las libav lua openexr openinventor osgapps pdf png sdl sdl2 svg tiff
 truetype vnc wxwidgets xine xrandr zlib"
 
@@ -34,7 +34,6 @@ RDEPEND="
 		fltk? ( x11-libs/fltk:1[opengl] )
 		fox? ( x11-libs/fox:1.6[opengl] )
 		glut? ( media-libs/freeglut )
-		gtk? ( x11-libs/gtkglext )
 		sdl2? ( media-libs/libsdl2 )
 		wxwidgets? ( x11-libs/wxGTK:${WX_GTK_VER}[opengl,X] )
 	)
@@ -109,7 +108,7 @@ src_configure() {
 		-DWITH_GIFLIB=$(usex gif)
 		-DWITH_GStreamer=$(usex gstreamer)
 		-DWITH_GLIB=$(usex gstreamer)
-		-DWITH_GtkGl=$(usex gtk)
+		-DWITH_GtkGl=OFF
 		-DWITH_JPEG=$(usex jpeg)
 		-DWITH_Jasper=OFF
 		-DWITH_LIBLAS=$(usex las)

--- a/dev-games/openscenegraph/openscenegraph-3.6.4.ebuild
+++ b/dev-games/openscenegraph/openscenegraph-3.6.4.ebuild
@@ -16,7 +16,7 @@ LICENSE="wxWinLL-3 LGPL-2.1"
 SLOT="0/158" # NOTE: CHECK WHEN BUMPING! Subslot is SOVERSION
 KEYWORDS="~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~x86"
 IUSE="asio curl dicom debug doc egl examples ffmpeg fltk fox gdal gif glut
-gstreamer gtk jpeg las libav lua openexr openinventor osgapps pdf png sdl sdl2
+gstreamer jpeg las libav lua openexr openinventor osgapps pdf png sdl sdl2
 svg tiff truetype vnc wxwidgets xrandr +zlib"
 
 REQUIRED_USE="sdl2? ( sdl ) dicom? ( zlib ) openexr? ( zlib )"
@@ -39,7 +39,6 @@ RDEPEND="
 		fltk? ( x11-libs/fltk:1[opengl] )
 		fox? ( x11-libs/fox:1.6[opengl] )
 		glut? ( media-libs/freeglut )
-		gtk? ( x11-libs/gtkglext )
 		sdl2? ( media-libs/libsdl2 )
 		wxwidgets? ( x11-libs/wxGTK:${WX_GTK_VER}[opengl,X] )
 	)
@@ -112,7 +111,7 @@ src_configure() {
 		$(cmake-utils_use_find_package gif GIFLIB)
 		$(cmake-utils_use_find_package gstreamer GLIB)
 		$(cmake-utils_use_find_package gstreamer GStreamer)
-		$(cmake-utils_use_find_package gtk GtkGl)
+		-DWITH_GtkGl=OFF
 		$(cmake-utils_use_find_package jpeg JPEG)
 		-DCMAKE_DISABLE_FIND_PACKAGE_Jasper=ON
 		$(cmake-utils_use_find_package las LIBLAS)


### PR DESCRIPTION
... This was contributed many years ago, I don't personally use it, so don't
know whether it still works. It's just a compile option so if you have gtk 2.0
installed then there shouldn't be any problem. ...

https://github.com/openscenegraph/OpenSceneGraph/issues/850#issuecomment-565032844

Closes: https://bugs.gentoo.org/703674

Signed-off-by: David Heidelberg <david@ixit.cz>