### PR TITLE
dev-python/josepy: Add support for python 3.8

### DIFF
--- a/dev-python/josepy/josepy-1.2.0.ebuild
+++ b/dev-python/josepy/josepy-1.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_5 python3_6 python3_7 )
+PYTHON_COMPAT=( python2_7 python3_5 python3_6 python3_7 python3_8 )
 inherit distutils-r1
 
 DESCRIPTION="JOSE protocol implementation in Python"


### PR DESCRIPTION
Package-Manager: Portage-2.3.83, Repoman-2.3.20