### PR TITLE
net-libs/webkit-gtk: add patch to support musl

### DIFF
--- a/net-libs/webkit-gtk/files/webkit-gtk-2.28.1-musl.patch
+++ b/net-libs/webkit-gtk/files/webkit-gtk-2.28.1-musl.patch
@@ -1,0 +1,68 @@
+--- a/Source/JavaScriptCore/runtime/MachineContext.h
++++ b/Source/JavaScriptCore/runtime/MachineContext.h
+@@ -188,7 +188,7 @@ static inline void*& stackPointerImpl(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || defined(__linux__)
+ 
+ #if CPU(X86)
+     return reinterpret_cast<void*&>((uintptr_t&) machineContext.gregs[REG_ESP]);
+@@ -335,7 +335,7 @@ static inline void*& framePointerImpl(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || defined(__linux__)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -482,7 +482,7 @@ static inline void*& instructionPointerImpl(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || defined(__linux__)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -639,7 +639,7 @@ inline void*& argumentPointer<1>(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || defined(__linux__)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -756,7 +756,7 @@ inline void*& llintInstructionPointer(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || defined(__linux__)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+ 
+--- a/Source/WebCore/xml/XPathGrammar.cpp
++++ b/Source/WebCore/xml/XPathGrammar.cpp
+@@ -966,7 +966,7 @@ int yydebug;
+ #if YYERROR_VERBOSE
+ 
+ # ifndef yystrlen
+-#  if defined __GLIBC__ && defined _STRING_H
++#  if defined __linux__ && defined _STRING_H
+ #   define yystrlen strlen
+ #  else
+ /* Return the length of YYSTR.  */
+@@ -989,7 +989,7 @@ yystrlen (yystr)
+ # endif
+ 
+ # ifndef yystpcpy
+-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
++#  if defined __linux__ && defined _STRING_H && defined _GNU_SOURCE
+ #   define yystpcpy stpcpy
+ #  else
+ /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in

--- a/net-libs/webkit-gtk/files/webkit-gtk-2.28.4-lower-stack-usage.patch
+++ b/net-libs/webkit-gtk/files/webkit-gtk-2.28.4-lower-stack-usage.patch
@@ -1,0 +1,17 @@
+diff --git a/Source/JavaScriptCore/runtime/OptionsList.h b/Source/JavaScriptCore/runtime/OptionsList.h
+index 41cab118..2ac66c7a 100644
+--- a/Source/JavaScriptCore/runtime/OptionsList.h
++++ b/Source/JavaScriptCore/runtime/OptionsList.h
+@@ -90,9 +90,9 @@ constexpr bool enableWebAssemblyStreamingApi = false;
+     \
+     v(Bool, reportMustSucceedExecutableAllocations, false, Normal, nullptr) \
+     \
+-    v(Unsigned, maxPerThreadStackUsage, 5 * MB, Normal, "Max allowed stack usage by the VM") \
+-    v(Unsigned, softReservedZoneSize, 128 * KB, Normal, "A buffer greater than reservedZoneSize that reserves space for stringifying exceptions.") \
+-    v(Unsigned, reservedZoneSize, 64 * KB, Normal, "The amount of stack space we guarantee to our clients (and to interal VM code that does not call out to clients).") \
++    v(Unsigned, maxPerThreadStackUsage, 128 * KB , Normal, "Max allowed stack usage by the VM") \
++    v(Unsigned, softReservedZoneSize, 48 * KB, Normal, "A buffer greater than reservedZoneSize that reserves space for stringifying exceptions.") \
++    v(Unsigned, reservedZoneSize, 32 * KB, Normal, "The amount of stack space we guarantee to our clients (and to interal VM code that does not call out to clients).") \
+     \
+     v(Bool, crashIfCantAllocateJITMemory, false, Normal, nullptr) \
+     v(Unsigned, jitMemoryReservationSize, 0, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)") \

--- a/net-libs/webkit-gtk/webkit-gtk-2.30.5.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.30.5.ebuild
@@ -174,6 +174,11 @@ src_prepare() {
 	eapply "${FILESDIR}"/2.28.2-non-jumbo-fix.patch
 	eapply "${FILESDIR}"/2.28.4-non-jumbo-fix2.patch
 	eapply "${FILESDIR}"/2.30.3-fix-noGL-build.patch
+	if use elibc_musl ; then
+		# Taken from https://git.alpinelinux.org/aports/tree/community/webkit2gtk/musl-fixes.patch?id=be463923b10a7268117c27c7e5515fc32457918c
+		eapply "${FILESDIR}/${PN}-2.28.1-musl.patch"
+		eapply "${FILESDIR}/${PN}-2.28.4-lower-stack-usage.patch"
+	fi
 	cmake_src_prepare
 	gnome2_src_prepare
 }
@@ -264,6 +269,10 @@ src_configure() {
 		-DPORT=GTK
 		${ruby_interpreter}
 	)
+
+	if use elibc_musl ; then
+		mycmakeargs+=( -DENABLE_SAMPLING_PROFILER=OFF )
+	fi
 
 	# Allow it to use GOLD when possible as it has all the magic to
 	# detect when to use it and using gold for this concrete package has


### PR DESCRIPTION
The difference between `::gentoo` and `::musl` `net-libs/webkit-gkt` ebuild is minimal currently which provides us nice opportunity to integrate necessary patch to `::gentoo` overlay and remove `webkit-gkt` from `::musl` overlay when this PR is merged (see gentoo/musl#285). @blueness, @anarchpenguin what do you think?