### PR TITLE
sys-kernel/dracut-9999: fix path to the readme

### DIFF
--- a/sys-kernel/dracut/dracut-9999.ebuild
+++ b/sys-kernel/dracut/dracut-9999.ebuild
@@ -54,7 +54,7 @@ BDEPEND="
 	virtual/pkgconfig
 	"
 
-DOCS=( AUTHORS HACKING NEWS README README.generic README.kernel README.modules
+DOCS=( AUTHORS HACKING NEWS README.md README.generic README.kernel README.modules
 	README.testsuite TODO )
 
 QA_MULTILIB_PATHS="usr/lib/dracut/.*"


### PR DESCRIPTION
Upstream commit ce0344d32 renamed the README file to README.md, causing the ebuild to not find one of the DOCS.

Modify the ebuild DOCS list with the new filename.

Closes: https://bugs.gentoo.org/703370
Signed-off-by: Daniel Cordero <gentoo@xxoo.ws>