### PR TITLE
sci-libs/cantera: add support sci-libs/sundials-5.0, dev-lang/python-3.8

### DIFF
--- a/sci-libs/cantera/cantera-2.4.0-r2.ebuild
+++ b/sci-libs/cantera/cantera-2.4.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7,8} )
 
 FORTRAN_NEEDED=fortran
 FORTRAN_STANDARD=90
@@ -30,7 +30,7 @@ RDEPEND="
 	python? (
 		dev-python/numpy[${PYTHON_USEDEP}]
 	)
-	<sci-libs/sundials-5.0.0:0=
+	<sci-libs/sundials-5.1.0:0=
 "
 
 DEPEND="

--- a/sci-libs/cantera/files/cantera_2.4.0_sundials4.patch
+++ b/sci-libs/cantera/files/cantera_2.4.0_sundials4.patch
@@ -47,7 +47,7 @@ diff -Nur old/SConstruct new/SConstruct
      # Ignore the minor version, e.g. 2.4.x -> 2.4
      env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
 -    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2'):
-+    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2','4.0','4.1'):
++    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2','4.0','4.1','5.0'):
          print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
          sys.exit(1)
      print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)


### PR DESCRIPTION
Simple fix for Sundials-5.0 and Python-3.8 compatibility so there is no revision bump.
The Sundials-5.0 has the same API as Sundials-4.x for CVODES function.

