### PR TITLE
sys-kernel/dracut: Add a bunch of upstream patches

### DIFF
--- a/sys-kernel/dracut/dracut-049-r3.ebuild
+++ b/sys-kernel/dracut/dracut-049-r3.ebuild
@@ -1,0 +1,176 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit bash-completion-r1 eutils linux-info systemd toolchain-funcs
+
+if [[ ${PV} == 9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/dracutdevs/dracut"
+else
+	[[ "${PV}" = *_rc* ]] || \
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+	SRC_URI="https://github.com/dracutdevs/dracut/archive/${PV}.tar.gz -> ${P}.tar.gz"
+fi
+
+DESCRIPTION="Generic initramfs generation tool"
+HOMEPAGE="https://dracut.wiki.kernel.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="selinux"
+
+# Tests need root privileges, bug #298014
+RESTRICT="test"
+
+RDEPEND="
+	app-arch/cpio
+	>=app-shells/bash-4.0:0
+	sys-apps/coreutils[xattr(-)]
+	>=sys-apps/kmod-23[tools]
+	|| (
+		>=sys-apps/sysvinit-2.87-r3
+		sys-apps/openrc[sysv-utils,selinux?]
+		sys-apps/systemd[sysv-utils]
+	)
+	>=sys-apps/util-linux-2.21
+	virtual/pkgconfig
+	virtual/udev
+
+	elibc_musl? ( sys-libs/fts-standalone )
+	selinux? (
+		sec-policy/selinux-dracut
+		sys-libs/libselinux
+		sys-libs/libsepol
+	)
+"
+DEPEND="
+	>=sys-apps/kmod-23
+	elibc_musl? ( sys-libs/fts-standalone )
+"
+
+BDEPEND="
+	app-text/asciidoc
+	app-text/docbook-xml-dtd:4.5
+	>=app-text/docbook-xsl-stylesheets-1.75.2
+	>=dev-libs/libxslt-1.1.26
+	virtual/pkgconfig
+"
+
+DOCS=( AUTHORS HACKING NEWS README README.generic README.kernel README.modules
+	README.testsuite TODO )
+
+QA_MULTILIB_PATHS="usr/lib/dracut/.*"
+
+PATCHES=(
+	"${FILESDIR}"/048-dracut-install-simplify-ldd-parsing-logic.patch
+	"${FILESDIR}"/049-40network-Don-t-include-40network-by-default.patch
+	"${FILESDIR}"/049-remove-bashism-in-various-boot-scripts.patch
+	"${FILESDIR}"/049-network-manager-call-the-online-hook-for-connected-d.patch
+	"${FILESDIR}"/049-install-dracut-install.c-install-module-dependencies.patch
+	"${FILESDIR}"/049-install-string_hash_func-should-not-be-fed-with-NULL.patch
+	"${FILESDIR}"/049-dracut.sh-Fix-udevdir-detection.patch
+	"${FILESDIR}"/049-rngd-new-module-running-early-during-boot-to-help-ge.patch
+	"${FILESDIR}"/049-fs-lib-drop-a-bashism.patch
+	"${FILESDIR}"/049-network-manager-remove-useless-use-of-basename.patch
+	"${FILESDIR}"/049-move-setting-the-systemdutildir-variable-before-it-s.patch
+	"${FILESDIR}"/049-dracut-install-Support-the-compressed-firmware-files.patch
+	"${FILESDIR}"/049-crypt-create-locking-directory-run-cryptsetup.patch
+	"${FILESDIR}"/049-network-manager-fix-getting-of-ifname-from-the-sysfs.patch
+	"${FILESDIR}"/049-configure-find-cflags-and-libs-for-fts-on-musl.patch
+)
+
+src_configure() {
+	local myconf=(
+		--prefix="${EPREFIX}/usr"
+		--sysconfdir="${EPREFIX}/etc"
+		--bashcompletiondir="$(get_bashcompdir)"
+		--systemdsystemunitdir="$(systemd_get_systemunitdir)"
+	)
+
+	tc-export CC PKG_CONFIG
+
+	echo ./configure "${myconf[@]}"
+	./configure "${myconf[@]}" || die
+
+	if [[ ${PV} != 9999 ]] ; then
+		# Source tarball from github doesn't include this file
+		echo "DRACUT_VERSION=${PV}" > dracut-version.sh || die
+	fi
+}
+
+src_install() {
+	default
+
+	insinto /etc/logrotate.d
+	newins dracut.logrotate dracut
+
+	docinto html
+	dodoc dracut.html
+}
+
+pkg_postinst() {
+	if linux-info_get_any_version && linux_config_exists; then
+		ewarn ""
+		ewarn "If the following test report contains a missing kernel"
+		ewarn "configuration option, you should reconfigure and rebuild your"
+		ewarn "kernel before booting image generated with this Dracut version."
+		ewarn ""
+
+		local CONFIG_CHECK="~BLK_DEV_INITRD ~DEVTMPFS"
+
+		# Kernel configuration options descriptions:
+		local ERROR_DEVTMPFS='CONFIG_DEVTMPFS: "Maintain a devtmpfs filesystem to mount at /dev" '
+		ERROR_DEVTMPFS+='is missing and REQUIRED'
+		local ERROR_BLK_DEV_INITRD='CONFIG_BLK_DEV_INITRD: "Initial RAM filesystem and RAM disk '
+		ERROR_BLK_DEV_INITRD+='(initramfs/initrd) support" is missing and REQUIRED'
+
+		check_extra_config
+		echo
+	else
+		ewarn ""
+		ewarn "Your kernel configuration couldn't be checked."
+		ewarn "Please check manually if following options are enabled:"
+		ewarn ""
+		ewarn "  CONFIG_BLK_DEV_INITRD"
+		ewarn "  CONFIG_DEVTMPFS"
+		ewarn ""
+	fi
+
+	elog "To get additional features, a number of optional runtime"
+	elog "dependencies may be installed:"
+	elog ""
+	optfeature "Networking support" net-misc/networkmanager
+	optfeature "Legacy networking support" net-misc/curl "net-misc/dhcp[client]" \
+		sys-apps/iproute2 "net-misc/iputils[arping]"
+	optfeature \
+		"Measure performance of the boot process for later visualisation" \
+		app-benchmarks/bootchart2 app-admin/killproc sys-process/acct
+	optfeature "Scan for Btrfs on block devices"  sys-fs/btrfs-progs
+	optfeature "Load kernel modules and drop this privilege for real init" \
+		sys-libs/libcap
+	optfeature "Support CIFS" net-fs/cifs-utils
+	optfeature "Decrypt devices encrypted with cryptsetup/LUKS" \
+		"sys-fs/cryptsetup[-static-libs]"
+	optfeature "Support for GPG-encrypted keys for crypt module" \
+		app-crypt/gnupg
+	optfeature \
+		"Allows use of dash instead of default bash (on your own risk)" \
+		app-shells/dash
+	optfeature "Support iSCSI" sys-block/open-iscsi
+	optfeature "Support Logical Volume Manager" sys-fs/lvm2
+	optfeature "Support MD devices, also known as software RAID devices" \
+		sys-fs/mdadm
+	optfeature "Support Device Mapper multipathing" sys-fs/multipath-tools
+	optfeature "Plymouth boot splash"  '>=sys-boot/plymouth-0.8.5-r5'
+	optfeature "Support network block devices" sys-block/nbd
+	optfeature "Support NFS" net-fs/nfs-utils net-nds/rpcbind
+	optfeature \
+		"Install ssh and scp along with config files and specified keys" \
+		net-misc/openssh
+	optfeature "Enable logging with rsyslog" app-admin/rsyslog
+	optfeature \
+		"Enable rngd service to help generating entropy early during boot" \
+		sys-apps/rng-tools
+}

--- a/sys-kernel/dracut/dracut-9999.ebuild
+++ b/sys-kernel/dracut/dracut-9999.ebuild
@@ -38,13 +38,17 @@ RDEPEND="
 	virtual/pkgconfig
 	virtual/udev
 
+	elibc_musl? ( sys-libs/fts-standalone )
 	selinux? (
 		sec-policy/selinux-dracut
 		sys-libs/libselinux
 		sys-libs/libsepol
 	)
-	"
-DEPEND=">=sys-apps/kmod-23"
+"
+DEPEND="
+	>=sys-apps/kmod-23
+	elibc_musl? ( sys-libs/fts-standalone )
+"
 
 BDEPEND="
 	app-text/asciidoc
@@ -52,7 +56,7 @@ BDEPEND="
 	>=app-text/docbook-xsl-stylesheets-1.75.2
 	>=dev-libs/libxslt-1.1.26
 	virtual/pkgconfig
-	"
+"
 
 DOCS=( AUTHORS HACKING NEWS README README.generic README.kernel README.modules
 	README.testsuite TODO )
@@ -151,4 +155,7 @@ pkg_postinst() {
 		"Install ssh and scp along with config files and specified keys" \
 		net-misc/openssh
 	optfeature "Enable logging with rsyslog" app-admin/rsyslog
+	optfeature \
+		"Enable rngd service to help generating entropy early during boot" \
+		sys-apps/rng-tools
 }

--- a/sys-kernel/dracut/files/049-configure-find-cflags-and-libs-for-fts-on-musl.patch
+++ b/sys-kernel/dracut/files/049-configure-find-cflags-and-libs-for-fts-on-musl.patch
@@ -1,0 +1,97 @@
+From 62f27ee6f145b5f8ca571887602cd9b0715b9e9d Mon Sep 17 00:00:00 2001
+From: Doan Tran Cong Danh <congdanhqx@gmail.com>
+Date: Wed, 6 Nov 2019 18:35:12 +0700
+Subject: [PATCH] configure: find cflags and libs for fts on musl
+To: <initramfs@vger.kernel.org>
+
+Signed-off-by: Doan Tran Cong Danh <congdanhqx@gmail.com>
+---
+ Makefile  |  2 +-
+ configure | 44 ++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 45 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 31545899..f9b42b96 100644
+--- a/Makefile
++++ b/Makefile
+@@ -62,7 +62,7 @@ install/util.o: install/util.c install/util.h install/macro.h install/log.h
+ install/strv.o: install/strv.c install/strv.h install/util.h install/macro.h install/log.h
+ 
+ install/dracut-install: $(DRACUT_INSTALL_OBJECTS)
+-	$(CC) $(LDFLAGS) -o $@ $(DRACUT_INSTALL_OBJECTS) $(LDLIBS) $(KMOD_LIBS)
++	$(CC) $(LDFLAGS) -o $@ $(DRACUT_INSTALL_OBJECTS) $(LDLIBS) $(FTS_LIBS) $(KMOD_LIBS)
+ 
+ logtee: logtee.c
+ 	$(CC) $(LDFLAGS) -o $@ $<
+diff --git a/configure b/configure
+index b55fb609..3f724ef2 100755
+--- a/configure
++++ b/configure
+@@ -7,6 +7,7 @@ prefix=/usr
+ 
+ enable_documentation=yes
+ 
++CC="${CC:-cc}"
+ PKG_CONFIG="${PKG_CONFIG:-pkg-config}"
+ 
+ # Little helper function for reading args from the commandline.
+@@ -57,6 +58,48 @@ if ! ${PKG_CONFIG} --exists --print-errors " libkmod >= 23 "; then
+     exit 1
+ fi
+ 
++cat <<EOF >conftest.c
++#include <fts.h>
++int main() {
++	return 0;
++}
++EOF
++
++${CC} $CFLAGS $LDFLAGS conftest.c >/dev/null 2>&1
++ret=$?
++rm -f conftest.c a.out
++
++# musl doesn't have fts.h included
++if test $ret -ne 0; then
++	echo "dracut needs fts development files." >&2
++	exit 1
++fi
++
++cat <<EOF >conftest.c
++#include <fts.h>
++int main(void) {
++	fts_open(0, 0, 0);
++	return 0;
++}
++EOF
++
++found=no
++for lib in "-lc" "-lfts"; do
++	${CC} $CFLAGS -Wl,$lib $LDFLAGS conftest.c >/dev/null 2>&1
++	ret=$?
++	if test $ret -eq 0; then
++		FTS_LIBS="$lib"
++		found=yes
++		break;
++	fi
++done
++rm -f conftest.c a.out
++
++if test $found = no; then
++	echo "dracut couldn't find usable fts library" >&2
++	exit 1
++fi
++
+ cat > Makefile.inc.$$ <<EOF
+ prefix ?= ${prefix}
+ libdir ?= ${libdir:-${prefix}/lib}
+@@ -68,6 +111,7 @@ enable_documentation ?= ${enable_documentation:-yes}
+ bindir ?= ${bindir:-${prefix}/bin}
+ KMOD_CFLAGS ?= $(${PKG_CONFIG} --cflags " libkmod >= 23 ")
+ KMOD_LIBS ?= $(${PKG_CONFIG} --libs " libkmod >= 23 ")
++FTS_LIBS ?= ${FTS_LIBS}
+ EOF
+ 
+ {
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-crypt-create-locking-directory-run-cryptsetup.patch
+++ b/sys-kernel/dracut/files/049-crypt-create-locking-directory-run-cryptsetup.patch
@@ -1,0 +1,32 @@
+From f39aa529c59c533ce5e75e31be1b0cce4513b3d7 Mon Sep 17 00:00:00 2001
+From: Jonas Witschel <diabonas@gmx.de>
+Date: Sat, 31 Aug 2019 17:45:11 +0200
+Subject: [PATCH] crypt: create locking directory /run/cryptsetup
+To: <initramfs@vger.kernel.org>
+
+For LUKS2 partitions cryptsetup needs a locking directory. If it does
+not exist, cryptsetup will create it, but produce a warning
+
+WARNING: Locking directory /run/cryptsetup is missing!
+
+in the process that we do not want to see in the dracut output.
+---
+ modules.d/90crypt/cryptroot-ask.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/modules.d/90crypt/cryptroot-ask.sh b/modules.d/90crypt/cryptroot-ask.sh
+index 33a823c7..e1f17975 100755
+--- a/modules.d/90crypt/cryptroot-ask.sh
++++ b/modules.d/90crypt/cryptroot-ask.sh
+@@ -8,6 +8,8 @@ NEWROOT=${NEWROOT:-"/sysroot"}
+ 
+ . /lib/dracut-lib.sh
+ 
++mkdir -m 0700 /run/cryptsetup
++
+ # if device name is /dev/dm-X, convert to /dev/mapper/name
+ if [ "${1##/dev/dm-}" != "$1" ]; then
+     device="/dev/mapper/$(dmsetup info -c --noheadings -o name "$1")"
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-dracut-install-Support-the-compressed-firmware-files.patch
+++ b/sys-kernel/dracut/files/049-dracut-install-Support-the-compressed-firmware-files.patch
@@ -1,0 +1,63 @@
+From 999cfa84582ab4ce4cc602242cb71d0af0b7d4ac Mon Sep 17 00:00:00 2001
+From: Takashi Iwai <tiwai@suse.de>
+Date: Thu, 22 Aug 2019 12:37:56 +0200
+Subject: [PATCH] dracut-install: Support the compressed firmware files
+ correctly
+To: <initramfs@vger.kernel.org>
+
+The compressed firmware support was supposed to be already
+implemented, but it didn't work as expected in the end, because dracut
+moved to use dracut-install binary.  This patch adds the support of
+XZ-compressed firmware installation to dracut-install for fixing the
+missing piece.
+
+At best the firmware files should be uncompressed in initrd, but this
+patch simply copies the compressed file as-is, as a quick workaround.
+
+BugLink: https://bugzilla.suse.com/show_bug.cgi?id=1146769
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ install/dracut-install.c | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/install/dracut-install.c b/install/dracut-install.c
+index 9e415b5e..7cda499d 100644
+--- a/install/dracut-install.c
++++ b/install/dracut-install.c
+@@ -1151,6 +1151,8 @@ static int install_firmware(struct kmod_module *mod)
+                 ret = -1;
+                 STRV_FOREACH(q, firmwaredirs) {
+                         _cleanup_free_ char *fwpath = NULL;
++                        _cleanup_free_ char *fwpath_xz = NULL;
++                        const char *fw;
+                         struct stat sb;
+                         int r;
+ 
+@@ -1160,12 +1162,21 @@ static int install_firmware(struct kmod_module *mod)
+                                 exit(EXIT_FAILURE);
+                         }
+ 
++                        fw = fwpath;
+                         if (stat(fwpath, &sb) != 0) {
+-                                log_debug("stat(%s) != 0", fwpath);
+-                                continue;
++                                r = asprintf(&fwpath_xz, "%s.xz", fwpath);
++                                if (r < 0) {
++                                        log_error("Out of memory!");
++                                        exit(EXIT_FAILURE);
++                                }
++                                if (stat(fwpath_xz, &sb) != 0) {
++                                        log_debug("stat(%s) != 0", fwpath);
++                                        continue;
++                                }
++                                fw = fwpath_xz;
+                         }
+ 
+-                        ret = dracut_install(fwpath, fwpath, false, false, true);
++                        ret = dracut_install(fw, fw, false, false, true);
+                         if (ret == 0)
+                                 log_debug("dracut_install '%s' OK", fwpath);
+                 }
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-dracut.sh-Fix-udevdir-detection.patch
+++ b/sys-kernel/dracut/files/049-dracut.sh-Fix-udevdir-detection.patch
@@ -1,0 +1,38 @@
+From dddcb809459b7a75906d4b90cf7a5ac291dc74c1 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Wed, 3 Apr 2019 15:24:47 +0800
+Subject: [PATCH] dracut.sh: Fix udevdir detection
+To: <initramfs@vger.kernel.org>
+
+In commit [9d1b81c dracut.sh: improve udevdir and systemdutildir
+fallback logic] , it checked a common binary `collect' to location
+udevdir.
+
+But upstream systemd drop binary `collect' since systemd v240
+[https://github.com/systemd/systemd/commit/a168792c2d95695fd30c0371d4b3890a9df1eafb]
+
+So check binary `ata_id' to instead.
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ dracut.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dracut.sh b/dracut.sh
+index 9098571d..fd9903b6 100755
+--- a/dracut.sh
++++ b/dracut.sh
+@@ -1311,8 +1311,8 @@ done
+ [[ -d $udevdir ]] \
+     || udevdir="$(pkg-config udev --variable=udevdir 2>/dev/null)"
+ if ! [[ -d "$udevdir" ]]; then
+-    [[ -e /lib/udev/collect ]] && udevdir=/lib/udev
+-    [[ -e /usr/lib/udev/collect ]] && udevdir=/usr/lib/udev
++    [[ -e /lib/udev/ata_id ]] && udevdir=/lib/udev
++    [[ -e /usr/lib/udev/ata_id ]] && udevdir=/usr/lib/udev
+ fi
+ 
+ [[ -d $systemdutildir ]] \
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-fs-lib-drop-a-bashism.patch
+++ b/sys-kernel/dracut/files/049-fs-lib-drop-a-bashism.patch
@@ -1,0 +1,99 @@
+From 43c8c4ce0471abbb8c0fc4b8be2515cebc636030 Mon Sep 17 00:00:00 2001
+From: Lubomir Rintel <lkundrak@v3.sk>
+Date: Fri, 21 Jun 2019 18:39:48 +0200
+Subject: [PATCH] fs-lib: drop a bashism
+To: <initramfs@vger.kernel.org>
+
+Bash 5 apparently longer propagates variable assignments to local variables
+in front of function calls when in POSIX mode:
+
+  [lkundrak@demiurge ~]$ cat feh.sh
+  print_VAR () {
+          echo "$VAR";
+  }
+
+  testfunc () {
+          local VAR="OLD"
+          VAR=NEW print_VAR
+  }
+
+  testfunc
+  [lkundrak@demiurge ~]$ bash4 --posix feh.sh
+  NEW
+  [lkundrak@demiurge ~]$ bash5 --posix feh.sh
+  OLD
+  [lkundrak@demiurge ~]$ bash5 feh.sh
+  NEW
+  [lkundrak@demiurge ~]$
+
+It works the way it did in Bash 4 in non-POSIX mode, for external programs,
+or for non-local variables. Don't ask me why -- it's probably some
+compatibility thing for some sad old people.
+
+However, this precisely happens when fsck_single() is calling into the
+fsck_drv_com(), assigned to _drv by fsck_able(). That ruins the
+TEST-70-BONDBRIDGETEAMVLAN test's server and probably more.
+
+Let's pass the fsck driver binary via the function argument instead. It's
+less messy anyway.
+---
+ modules.d/99fs-lib/fs-lib.sh | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/modules.d/99fs-lib/fs-lib.sh b/modules.d/99fs-lib/fs-lib.sh
+index d39ca1b7..11e795d9 100755
+--- a/modules.d/99fs-lib/fs-lib.sh
++++ b/modules.d/99fs-lib/fs-lib.sh
+@@ -44,22 +44,22 @@ fsck_able() {
+             ;;
+         ext?)
+             type e2fsck >/dev/null 2>&1 &&
+-            _drv="_drv=e2fsck fsck_drv_com" &&
++            _drv="fsck_drv_com e2fsck" &&
+             return 0
+             ;;
+         f2fs)
+ 	    type fsck.f2fs >/dev/null 2>&1 &&
+-	    _drv="_drv=fsck.f2fs fsck_drv_com" &&
++	    _drv="fsck_drv_com fsck.f2fs" &&
+ 	    return 0
+ 	    ;;
+         jfs)
+             type jfs_fsck >/dev/null 2>&1 &&
+-            _drv="_drv=jfs_fsck fsck_drv_com" &&
++            _drv="fsck_drv_com jfs_fsck" &&
+             return 0
+             ;;
+         reiserfs)
+             type reiserfsck >/dev/null 2>&1 &&
+-            _drv="_drv=reiserfsck fsck_drv_com" &&
++            _drv="fsck_drv_com reiserfsck" &&
+             return 0
+             ;;
+         btrfs)
+@@ -70,12 +70,12 @@ fsck_able() {
+             ;;
+         nfs*)
+             # nfs can be a nop, returning success
+-            _drv="_drv=none :" &&
++            _drv=":" &&
+             return 0
+             ;;
+         *)
+             type fsck >/dev/null 2>&1 &&
+-            _drv="_drv=fsck fsck_drv_std" &&
++            _drv="fsck_drv_std fsck" &&
+             return 0
+             ;;
+     esac
+@@ -97,6 +97,7 @@ fsck_drv_btrfs() {
+ 
+ # common code for checkers that follow usual subset of options and return codes
+ fsck_drv_com() {
++    local _drv="$1"
+     local _ret
+     local _out
+ 
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-install-dracut-install.c-install-module-dependencies.patch
+++ b/sys-kernel/dracut/files/049-install-dracut-install.c-install-module-dependencies.patch
@@ -1,0 +1,79 @@
+From c38f9e980c1ee03151dd1c6602907c6228b78d30 Mon Sep 17 00:00:00 2001
+From: Harald Hoyer <harald@redhat.com>
+Date: Tue, 4 Dec 2018 10:02:45 +0100
+Subject: [PATCH] install/dracut-install.c: install module dependencies of
+ dependencies
+To: <initramfs@vger.kernel.org>
+
+---
+ install/dracut-install.c | 28 +++++++++++++++++++++++++---
+ 1 file changed, 25 insertions(+), 3 deletions(-)
+
+diff --git a/install/dracut-install.c b/install/dracut-install.c
+index 5f352b36..d64de545 100644
+--- a/install/dracut-install.c
++++ b/install/dracut-install.c
+@@ -84,6 +84,11 @@ static bool arg_mod_filter_noname = false;
+ static int dracut_install(const char *src, const char *dst, bool isdir, bool resolvedeps, bool hashdst);
+ 
+ 
++static inline void kmod_module_unrefp(struct kmod_module **p) {
++        if (*p)
++                kmod_module_unref(*p);
++}
++#define _cleanup_kmod_module_unref_ _cleanup_(kmod_module_unrefp)
+ 
+ static inline void kmod_module_unref_listp(struct kmod_list **p) {
+         if (*p)
+@@ -1230,28 +1235,45 @@ static bool check_module_path(const char *path)
+ static int install_dependent_modules(struct kmod_list *modlist)
+ {
+         struct kmod_list *itr;
+-        struct kmod_module *mod;
+         const char *path = NULL;
+         const char *name = NULL;
+         int ret = 0;
+ 
+         kmod_list_foreach(itr, modlist) {
++		_cleanup_kmod_module_unref_ struct kmod_module *mod = NULL;
+                 mod = kmod_module_get_module(itr);
+                 path = kmod_module_get_path(mod);
+ 
++		if (check_hashmap(items_failed, path))
++			return -1;
++
++		if (check_hashmap(items, path)) {
++			continue;
++		}
++
+                 name = kmod_module_get_name(mod);
++
+                 if ((path == NULL) || (arg_mod_filter_noname && (regexec(&mod_filter_noname, name, 0, NULL, 0) == 0))) {
+-                        kmod_module_unref(mod);
+                         continue;
+                 }
++
+                 ret = dracut_install(path, &path[kerneldirlen], false, false, true);
+                 if (ret == 0) {
++			_cleanup_kmod_module_unref_list_ struct kmod_list *modlist = NULL;
++			_cleanup_kmod_module_unref_list_ struct kmod_list *modpre = NULL;
++			_cleanup_kmod_module_unref_list_ struct kmod_list *modpost = NULL;
+                         log_debug("dracut_install '%s' '%s' OK", path, &path[kerneldirlen]);
+                         install_firmware(mod);
++			modlist = kmod_module_get_dependencies(mod);
++			ret = install_dependent_modules(modlist);
++			if (ret == 0) {
++				ret = kmod_module_get_softdeps(mod, &modpre, &modpost);
++				if (ret == 0)
++					ret = install_dependent_modules(modpre);
++			}
+                 } else {
+                         log_error("dracut_install '%s' '%s' ERROR", path, &path[kerneldirlen]);
+                 }
+-                kmod_module_unref(mod);
+         }
+ 
+         return ret;
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-install-string_hash_func-should-not-be-fed-with-NULL.patch
+++ b/sys-kernel/dracut/files/049-install-string_hash_func-should-not-be-fed-with-NULL.patch
@@ -1,0 +1,38 @@
+From fc141f22869bad2e5409d1cc555c1a42ea738343 Mon Sep 17 00:00:00 2001
+From: Lukas Nykryn <lnykryn@redhat.com>
+Date: Thu, 14 Feb 2019 20:18:04 +0100
+Subject: [PATCH] install: string_hash_func should not be fed with NULL
+To: <initramfs@vger.kernel.org>
+
+If kmod_module_get_path returns NULL, we should skip that entry,
+the hash function does not like NULL pointers.
+---
+ install/dracut-install.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/install/dracut-install.c b/install/dracut-install.c
+index d64de545..9e415b5e 100644
+--- a/install/dracut-install.c
++++ b/install/dracut-install.c
+@@ -1244,6 +1244,9 @@ static int install_dependent_modules(struct kmod_list *modlist)
+                 mod = kmod_module_get_module(itr);
+                 path = kmod_module_get_path(mod);
+ 
++                if (path == NULL)
++                        continue;
++
+ 		if (check_hashmap(items_failed, path))
+ 			return -1;
+ 
+@@ -1253,7 +1256,7 @@ static int install_dependent_modules(struct kmod_list *modlist)
+ 
+                 name = kmod_module_get_name(mod);
+ 
+-                if ((path == NULL) || (arg_mod_filter_noname && (regexec(&mod_filter_noname, name, 0, NULL, 0) == 0))) {
++                if (arg_mod_filter_noname && (regexec(&mod_filter_noname, name, 0, NULL, 0) == 0)) {
+                         continue;
+                 }
+ 
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-move-setting-the-systemdutildir-variable-before-it-s.patch
+++ b/sys-kernel/dracut/files/049-move-setting-the-systemdutildir-variable-before-it-s.patch
@@ -1,0 +1,55 @@
+From c8b35bf96af1859c0c254db34a16b9cc5a2aa46b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=94=D0=B0=D0=BC=D1=98=D0=B0=D0=BD=20=D0=93=D0=B5=D0=BE?=
+ =?UTF-8?q?=D1=80=D0=B3=D0=B8=D0=B5=D0=B2=D1=81=D0=BA=D0=B8?=
+ <gdamjan@gmail.com>
+Date: Mon, 27 May 2019 18:22:14 +0200
+Subject: [PATCH] move setting the "systemdutildir" variable before it's used
+To: <initramfs@vger.kernel.org>
+
+on line 1086 it's used to check for the uefi_stub:
+"${systemdutildir}/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub"
+
+so it needs to be defined before that
+---
+ dracut.sh | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/dracut.sh b/dracut.sh
+index 183b892f..a3618f89 100755
+--- a/dracut.sh
++++ b/dracut.sh
+@@ -1009,6 +1009,16 @@ esac
+ 
+ abs_outfile=$(readlink -f "$outfile") && outfile="$abs_outfile"
+ 
++
++[[ -d $systemdutildir ]] \
++    || systemdutildir=$(pkg-config systemd --variable=systemdutildir 2>/dev/null)
++
++if ! [[ -d "$systemdutildir" ]]; then
++    [[ -e /lib/systemd/systemd-udevd ]] && systemdutildir=/lib/systemd
++    [[ -e /usr/lib/systemd/systemd-udevd ]] && systemdutildir=/usr/lib/systemd
++fi
++
++
+ if [[ $no_kernel != yes ]] && [[ -d $srcmods ]]; then
+     if ! [[ -f $srcmods/modules.dep ]]; then
+         if [[ -n "$(find "$srcmods" -name '*.ko*')" ]]; then
+@@ -1325,14 +1335,6 @@ if ! [[ -d "$udevdir" ]]; then
+     [[ -e /usr/lib/udev/ata_id ]] && udevdir=/usr/lib/udev
+ fi
+ 
+-[[ -d $systemdutildir ]] \
+-    || systemdutildir=$(pkg-config systemd --variable=systemdutildir 2>/dev/null)
+-
+-if ! [[ -d "$systemdutildir" ]]; then
+-    [[ -e /lib/systemd/systemd-udevd ]] && systemdutildir=/lib/systemd
+-    [[ -e /usr/lib/systemd/systemd-udevd ]] && systemdutildir=/usr/lib/systemd
+-fi
+-
+ [[ -d $systemdsystemunitdir ]] \
+     || systemdsystemunitdir=$(pkg-config systemd --variable=systemdsystemunitdir 2>/dev/null)
+ 
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-network-manager-call-the-online-hook-for-connected-d.patch
+++ b/sys-kernel/dracut/files/049-network-manager-call-the-online-hook-for-connected-d.patch
@@ -1,0 +1,32 @@
+From 79a17b0112995eb60c85c64d15070c52f213b28d Mon Sep 17 00:00:00 2001
+From: Lubomir Rintel <lkundrak@v3.sk>
+Date: Tue, 27 Nov 2018 15:30:48 +0100
+Subject: [PATCH] network-manager: call the online hook for connected devices
+To: <initramfs@vger.kernel.org>
+
+Look for "connection-uuid" instead of "managed" to determine the devices
+that are actually activated with a connection and call the online hook.
+
+This fixes the anaconda-net root mount, which utilizes the online hook.
+---
+ modules.d/35network-manager/nm-run.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/35network-manager/nm-run.sh b/modules.d/35network-manager/nm-run.sh
+index f6defa99..0f943631 100755
+--- a/modules.d/35network-manager/nm-run.sh
++++ b/modules.d/35network-manager/nm-run.sh
+@@ -9,8 +9,9 @@ fi
+ for _i in /sys/class/net/*/
+ do
+     state=/run/NetworkManager/devices/$(cat $_i/ifindex)
+-    grep -q managed=true $state 2>/dev/null || continue
++    grep -q connection-uuid= $state 2>/dev/null || continue
+     ifname=$(basename $_i)
+     sed -n 's/root-path/new_root_path/p' <$state >/tmp/dhclient.$ifname.dhcpopts
++    source_hook initqueue/online $ifname
+     /sbin/netroot $ifname
+ done
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-network-manager-fix-getting-of-ifname-from-the-sysfs.patch
+++ b/sys-kernel/dracut/files/049-network-manager-fix-getting-of-ifname-from-the-sysfs.patch
@@ -1,0 +1,37 @@
+From 687e17aa7f2f40d21717be9a04302c749e139d4a Mon Sep 17 00:00:00 2001
+From: Lubomir Rintel <lkundrak@v3.sk>
+Date: Wed, 30 Oct 2019 19:25:51 +0100
+Subject: [PATCH] network-manager: fix getting of ifname from the sysfs path
+To: <initramfs@vger.kernel.org>
+
+commit 5e0f8c8a4ced ('network-manager: remove useless use of basename')
+somewhat carelessly didn't take into account that $_i has a slash at
+the end which made the result of the ## substitution be just an empty
+string.
+
+The slash was put to the end of /sys/class/net/*/ to make sure we're only
+iterating directories, but it's not strictly necessary. In an unlikely case
+something else than a directory appears in /sys/class/net/, we'll already deal
+with it gracefully. Remove it.
+
+This fixes the TEST-30-ISCSI test.
+---
+ modules.d/35network-manager/nm-run.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules.d/35network-manager/nm-run.sh b/modules.d/35network-manager/nm-run.sh
+index a539d5b2..b33e0992 100755
+--- a/modules.d/35network-manager/nm-run.sh
++++ b/modules.d/35network-manager/nm-run.sh
+@@ -6,7 +6,7 @@ else
+     /usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
+ fi
+ 
+-for _i in /sys/class/net/*/
++for _i in /sys/class/net/*
+ do
+     state=/run/NetworkManager/devices/$(cat $_i/ifindex)
+     grep -q connection-uuid= $state 2>/dev/null || continue
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-network-manager-remove-useless-use-of-basename.patch
+++ b/sys-kernel/dracut/files/049-network-manager-remove-useless-use-of-basename.patch
@@ -1,0 +1,26 @@
+From 5e0f8c8a4ced36268d0077acafa1db2402776fa6 Mon Sep 17 00:00:00 2001
+From: Lubomir Rintel <lkundrak@v3.sk>
+Date: Mon, 17 Jun 2019 10:07:38 +0200
+Subject: [PATCH] network-manager: remove useless use of basename
+To: <initramfs@vger.kernel.org>
+
+---
+ modules.d/35network-manager/nm-run.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules.d/35network-manager/nm-run.sh b/modules.d/35network-manager/nm-run.sh
+index 0f943631..5f4b38ca 100755
+--- a/modules.d/35network-manager/nm-run.sh
++++ b/modules.d/35network-manager/nm-run.sh
+@@ -10,7 +10,7 @@ for _i in /sys/class/net/*/
+ do
+     state=/run/NetworkManager/devices/$(cat $_i/ifindex)
+     grep -q connection-uuid= $state 2>/dev/null || continue
+-    ifname=$(basename $_i)
++    ifname=${_i##*/}
+     sed -n 's/root-path/new_root_path/p' <$state >/tmp/dhclient.$ifname.dhcpopts
+     source_hook initqueue/online $ifname
+     /sbin/netroot $ifname
+-- 
+2.24.1
+

--- a/sys-kernel/dracut/files/049-rngd-new-module-running-early-during-boot-to-help-ge.patch
+++ b/sys-kernel/dracut/files/049-rngd-new-module-running-early-during-boot-to-help-ge.patch
@@ -1,0 +1,88 @@
+From adee5b97bc5418b6e357342bb3be20568668aa55 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Renaud=20M=C3=A9trich?= <rmetrich@redhat.com>
+Date: Thu, 11 Jul 2019 10:50:40 +0200
+Subject: [PATCH] rngd: new module running early during boot to help generating
+ entropy when system's default entropy sources are poor (e.g. use of SSD disks
+ or UEFI RNG not available)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+To: <initramfs@vger.kernel.org>
+
+On systems with low entropy at boot, the boot can take up to several
+hours, specially when NBDE is used (e.g. clevis) which makes use of
+the random number generator.
+
+Enabling rngd service at boot early, because dracut-initqueue runs,
+enables to initialize the random number generator in a couple of seconds
+instead of minutes or hours.
+
+Signed-off-by: Renaud Métrich <rmetrich@redhat.com>
+---
+ modules.d/06rngd/module-setup.sh | 39 ++++++++++++++++++++++++++++++++
+ modules.d/06rngd/rngd.service    |  7 ++++++
+ 2 files changed, 46 insertions(+)
+ create mode 100644 modules.d/06rngd/module-setup.sh
+ create mode 100644 modules.d/06rngd/rngd.service
+
+diff --git a/modules.d/06rngd/module-setup.sh b/modules.d/06rngd/module-setup.sh
+new file mode 100644
+index 00000000..43d5c2d3
+--- /dev/null
++++ b/modules.d/06rngd/module-setup.sh
+@@ -0,0 +1,39 @@
++#!/bin/bash
++# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
++#
++# Copyright (c) 2019 Red Hat, Inc.
++# Author: Renaud Métrich <rmetrich@redhat.com>
++#
++# This program is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++#
++
++depends() {
++    echo systemd
++    return 0
++}
++
++check() {
++    # if there's no rngd binary, no go.
++    require_binaries rngd || return 1
++
++    return 0
++}
++
++install() {
++    inst rngd
++    inst_simple "${moddir}/rngd.service" "${systemdsystemunitdir}/rngd.service"
++    mkdir -p "${initdir}${systemdsystemunitdir}/sysinit.target.wants"
++    ln -rfs "${initdir}${systemdsystemunitdir}/rngd.service" \
++        "${initdir}${systemdsystemunitdir}/sysinit.target.wants/rngd.service"
++}
+diff --git a/modules.d/06rngd/rngd.service b/modules.d/06rngd/rngd.service
+new file mode 100644
+index 00000000..570fbedb
+--- /dev/null
++++ b/modules.d/06rngd/rngd.service
+@@ -0,0 +1,7 @@
++[Unit]
++Description=Hardware RNG Entropy Gatherer Daemon
++DefaultDependencies=no
++Before=systemd-udevd.service
++
++[Service]
++ExecStart=/usr/sbin/rngd -f
+-- 
+2.24.1
+


### PR DESCRIPTION
* fix dracut-install crashes
* install kernel module dependencies of dependencies
* add support for compressed firmware files
* add support for rngd service
* bash-5 compatibility
* add fts-standalone dependency and configure check for musl
* fix udevdir detection

Closes: https://bugs.gentoo.org/676268
Closes: https://bugs.gentoo.org/677788
Closes: https://bugs.gentoo.org/687602
Bug: https://bugs.gentoo.org/703438