### PR TITLE
Cargo QoL eclass changes

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -153,6 +153,8 @@ cargo_gen_config() {
 	[term]
 	verbose = true
 	EOF
+	# honor NOCOLOR setting
+	[[ "${NOCOLOR}" = true || "${NOCOLOR}" = yes ]] && echo "color = 'never'" >> "${ECARGO_HOME}/config"
 }
 
 # @FUNCTION: cargo_src_compile

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -12,12 +12,8 @@
 if [[ -z ${_CARGO_ECLASS} ]]; then
 _CARGO_ECLASS=1
 
-if [[ ${PV} == *9999* ]]; then
-	# we need at least this for cargo vendor subommand
-	CARGO_DEPEND=">=virtual/cargo-1.37.0"
-else
-	CARGO_DEPEND="virtual/cargo"
-fi
+# we need this for 'cargo vendor' subcommand and net.offline config knob
+CARGO_DEPEND=">=virtual/cargo-1.37.0"
 
 case ${EAPI} in
 	6) DEPEND="${CARGO_DEPEND}";;

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -125,7 +125,14 @@ cargo_live_src_unpack() {
 
 # @FUNCTION: cargo_gen_config
 # @DESCRIPTION:
-# Generate the $CARGO_HOME/config necessary to use our local registry
+# Generate the $CARGO_HOME/config necessary to use our local registry and settings.
+# Cargo can also be configured through environment variables in addition to the TOML syntax below.
+# For each configuration key below of the form foo.bar the environment variable CARGO_FOO_BAR
+# can also be used to define the value.
+# Environment variables will take precedent over TOML configuration,
+# and currently only integer, boolean, and string keys are supported.
+# For example the build.jobs key can also be defined by CARGO_BUILD_JOBS.
+# Or setting CARGO_TERM_VERBOSE=false in make.conf will make build quieter.
 cargo_gen_config() {
 	debug-print-function ${FUNCNAME} "$@"
 
@@ -142,6 +149,9 @@ cargo_gen_config() {
 
 	[build]
 	jobs = $(makeopts_jobs)
+
+	[term]
+	verbose = true
 	EOF
 }
 
@@ -153,7 +163,7 @@ cargo_src_compile() {
 
 	export CARGO_HOME="${ECARGO_HOME}"
 
-	cargo build -vv $(usex debug "" --release) "$@" \
+	cargo build $(usex debug "" --release) "$@" \
 		|| die "cargo build failed"
 }
 
@@ -163,7 +173,7 @@ cargo_src_compile() {
 cargo_src_install() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	cargo install -vv --path ${CARGO_INSTALL_PATH} \
+	cargo install --path ${CARGO_INSTALL_PATH} \
 		--root="${ED}/usr" $(usex debug --debug "") "$@" \
 		|| die "cargo install failed"
 	rm -f "${ED}/usr/.crates.toml"
@@ -177,7 +187,7 @@ cargo_src_install() {
 cargo_src_test() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	cargo test -vv $(usex debug "" --release) "$@" \
+	cargo test $(usex debug "" --release) "$@" \
 		|| die "cargo test failed"
 }
 

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -139,6 +139,9 @@ cargo_gen_config() {
 
 	[net]
 	offline = true
+
+	[build]
+	jobs = $(makeopts_jobs)
 	EOF
 }
 
@@ -150,7 +153,7 @@ cargo_src_compile() {
 
 	export CARGO_HOME="${ECARGO_HOME}"
 
-	cargo build -vv -j $(makeopts_jobs) $(usex debug "" --release) "$@" \
+	cargo build -vv $(usex debug "" --release) "$@" \
 		|| die "cargo build failed"
 }
 
@@ -160,7 +163,7 @@ cargo_src_compile() {
 cargo_src_install() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	cargo install -vv -j $(makeopts_jobs) --path ${CARGO_INSTALL_PATH} \
+	cargo install -vv --path ${CARGO_INSTALL_PATH} \
 		--root="${ED}/usr" $(usex debug --debug "") "$@" \
 		|| die "cargo install failed"
 	rm -f "${ED}/usr/.crates.toml"
@@ -174,7 +177,7 @@ cargo_src_install() {
 cargo_src_test() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	cargo test -vv -j $(makeopts_jobs) $(usex debug "" --release) "$@" \
+	cargo test -vv $(usex debug "" --release) "$@" \
 		|| die "cargo test failed"
 }
 

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -136,6 +136,9 @@ cargo_gen_config() {
 	[source.crates-io]
 	replace-with = "gentoo"
 	local-registry = "/nonexistant"
+
+	[net]
+	offline = true
 	EOF
 }
 

--- a/x11-terms/alacritty/alacritty-0.4.0.ebuild
+++ b/x11-terms/alacritty/alacritty-0.4.0.ebuild
@@ -350,7 +350,7 @@ src_prepare() {
 }
 
 src_install() {
-	CARGO_INSTALL_PATH="alacritty" cargo_src_install --offline
+	CARGO_INSTALL_PATH="alacritty" cargo_src_install
 
 	newbashcomp extra/completions/alacritty.bash alacritty
 

--- a/x11-terms/alacritty/alacritty-9999.ebuild
+++ b/x11-terms/alacritty/alacritty-9999.ebuild
@@ -60,7 +60,7 @@ src_unpack() {
 }
 
 src_install() {
-	CARGO_INSTALL_PATH="alacritty" cargo_src_install --offline
+	CARGO_INSTALL_PATH="alacritty" cargo_src_install
 
 	newbashcomp extra/completions/alacritty.bash alacritty
 


### PR DESCRIPTION
some minor changes users requested a lot.

rationale for using config values instead of command-line args is that command-line args override config values and can still be passed on command-line without error, giving ebuild/eclass maintainers some freedom.

also environment variables affecting cargo will be preferred over TOML configuration. 

for example, imagine a situation where project should be build with -j1, passing `cargo_src_compile -j1` with current approach will generate an error.
`error: The argument '--jobs <N>' was provided more than once, but cannot be used multiple times`
passing `-j1` with `config.toml` approach will work just fine.

or running `CARGO_BUILD_JOBS=1 emerge something`

the order cargo looks for variables is` toml -> env -> command-line`

unconditional `--offline` via `net.offline=true` is now possible as old rust versions are gone.
`cargo_live_src_unpack` is unaffected by unconditional `--offline` as config gets written AFTER the vendoring happens.

`NOCOLOR` support has been requested multiple times for easier log grepping and accessibility purposes by @williamh

@gentoo/rust 
