### PR TITLE
rust ebuild improvements

### DIFF
--- a/dev-lang/rust/files/1.40.0-add-soname.patch
+++ b/dev-lang/rust/files/1.40.0-add-soname.patch
@@ -1,0 +1,36 @@
+Description: Set DT_SONAME when building dylibs
+ In Rust, library filenames include a version-specific hash to help
+ the run-time linker find the correct version.  Unlike in C/C++, the
+ compiler looks for all libraries matching a glob that ignores the
+ hash and reads embedded metadata to work out versions, etc.
+ .
+ The upshot is that there is no need for the usual "libfoo.so ->
+ libfoo-1.2.3.so" symlink common with C/C++ when building with Rust,
+ and no need to communicate an alternate filename to use at run-time
+ vs compile time.  If linking to a Rust dylib from C/C++ however, a
+ "libfoo.so -> libfoo-$hash.so" symlink may well be useful and in
+ this case DT_SONAME=libfoo-$hash.so would be required.  More
+ mundanely, various tools (eg: dpkg-shlibdeps) complain if they don't
+ find DT_SONAME on shared libraries in public directories.
+ .
+ This patch passes -Wl,-soname=$outfile when building dylibs (and
+ using a GNU linker).
+Author: Angus Lees <gus@debian.org>
+Forwarded: no
+
+--- a/src/librustc_codegen_ssa/back/link.rs
++++ b/src/librustc_codegen_ssa/back/link.rs
+@@ -1034,6 +1034,13 @@
+         cmd.args(&rpath::get_rpath_flags(&mut rpath_config));
+     }
+ 
++    if (crate_type == config::CrateType::Dylib || crate_type == config::CrateType::Cdylib)
++       && t.options.linker_is_gnu {
++        let filename = String::from(out_filename.file_name().unwrap().to_str().unwrap());
++        let soname = [String::from("-Wl,-soname=") + &filename];
++        cmd.args(&soname);
++    }
++
+     // Finally add all the linker arguments provided on the command line along
+     // with any #[link_args] attributes found inside the crate
+     if let Some(ref args) = sess.opts.cg.link_args {

--- a/dev-lang/rust/metadata.xml
+++ b/dev-lang/rust/metadata.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>gyakovlev@gentoo.org</email>
+		<name>Georgy Yakovlev</name>
+	</maintainer>
 	<maintainer type="project">
 		<email>rust@gentoo.org</email>
 		<name>Rust Project</name>
@@ -9,8 +13,10 @@
 		<flag name="clippy">Install clippy component</flag>
 		<flag name="system-llvm">Use the system LLVM install</flag>
 		<flag name="nightly">Enable nightly (UNSTABLE) features</flag>
+		<flag name="parallel-compiler">Build a multi-threaded rustc</flag>
 		<flag name="rls">Install rls component</flag>
 		<flag name="rustfmt">Install rustfmt component</flag>
+		<flag name="system-bootstrap">Bootstrap using installed rust compiler</flag>
 		<flag name="wasm">Build support for the wasm32-unknown-unknown
 		target</flag>
 	</use>

--- a/dev-lang/rust/rust-1.40.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.40.0-r1.ebuild
@@ -1,0 +1,340 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy )
+
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+
+if [[ ${PV} = *beta* ]]; then
+	betaver=${PV//*beta}
+	BETA_SNAPSHOT="${betaver:0:4}-${betaver:4:2}-${betaver:6:2}"
+	MY_P="rustc-beta"
+	SLOT="beta/${PV}"
+	SRC="${BETA_SNAPSHOT}/rustc-beta-src.tar.xz"
+else
+	ABI_VER="$(ver_cut 1-2)"
+	SLOT="stable/${ABI_VER}"
+	MY_P="rustc-${PV}"
+	SRC="${MY_P}-src.tar.xz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+fi
+
+RUST_STAGE0_VERSION="1.$(($(ver_cut 2) - 1)).0"
+
+DESCRIPTION="Systems programming language from Mozilla"
+HOMEPAGE="https://www.rust-lang.org/"
+
+SRC_URI="
+	https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.xz
+	!system-bootstrap? ( $(rust_all_arch_uris rust-${RUST_STAGE0_VERSION}) )
+"
+
+ALL_LLVM_TARGETS=( AArch64 AMDGPU ARM BPF Hexagon Lanai Mips MSP430
+	NVPTX PowerPC RISCV Sparc SystemZ WebAssembly X86 XCore )
+ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
+LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/?}
+
+LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
+
+IUSE="clippy cpu_flags_x86_sse2 debug doc libressl nightly parallel-compiler rls rustfmt system-bootstrap system-llvm wasm ${ALL_LLVM_TARGETS[*]}"
+
+# Please keep the LLVM dependency block separate. Since LLVM is slotted,
+# we need to *really* make sure we're not pulling more than one slot
+# simultaneously.
+
+# How to use it:
+# 1. List all the working slots (with min versions) in ||, newest first.
+# 2. Update the := to specify *max* version, e.g. < 10.
+# 3. Specify LLVM_MAX_SLOT, e.g. 9.
+LLVM_DEPEND="
+	|| (
+		sys-devel/llvm:9[llvm_targets_WebAssembly?]
+		wasm? ( =sys-devel/lld-9* )
+	)
+	<sys-devel/llvm-10:=
+"
+LLVM_MAX_SLOT=9
+
+# FIXME:
+# this should be '>=virtual/rust-1.$(($(ver_cut 2) - 1))', but we can't do it yet
+# as the first gentoo-built rust that can bootstap new compiler is 1.40.0-r1
+BOOTSTRAP_DEPEND="|| ( =dev-lang/rust-${PF} =dev-lang/rust-bin-${PV}* )"
+
+COMMON_DEPEND="
+	sys-libs/zlib
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
+	net-libs/libssh2
+	net-libs/http-parser:=
+	net-misc/curl[ssl]
+	system-llvm? (
+		${LLVM_DEPEND}
+		dev-util/cmake
+		dev-util/ninja
+	)
+"
+
+DEPEND="${COMMON_DEPEND}
+	${PYTHON_DEPS}
+	|| (
+		>=sys-devel/gcc-4.7
+		>=sys-devel/clang-3.5
+	)
+	system-bootstrap? ( ${BOOTSTRAP_DEPEND}	)
+"
+
+RDEPEND="${COMMON_DEPEND}
+	>=app-eselect/eselect-rust-20190311
+"
+
+REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
+	parallel-compiler? ( nightly )
+	wasm? ( llvm_targets_WebAssembly )
+	x86? ( cpu_flags_x86_sse2 )
+"
+
+QA_FLAGS_IGNORED="
+	usr/bin/*-${PV}
+	usr/lib*/lib*.so
+	usr/lib/rurstlib/*/codegen-backends/librustc_codegen_llvm-llvm.so
+	usr/lib/rustlib/*/lib/lib*.so
+"
+
+QA_SONAME="usr/lib*/librustc_macros*.so"
+
+PATCHES=(
+	"${FILESDIR}"/1.36.0-libressl.patch
+	"${FILESDIR}"/1.40.0-add-soname.patch
+)
+
+S="${WORKDIR}/${MY_P}-src"
+
+toml_usex() {
+	usex "$1" true false
+}
+
+pre_build_checks() {
+	CHECKREQS_DISK_BUILD="9G"
+	eshopts_push -s extglob
+	if is-flagq '-g?(gdb)?([1-9])'; then
+		CHECKREQS_DISK_BUILD="14G"
+	fi
+	eshopts_pop
+	check-reqs_pkg_setup
+}
+
+pkg_pretend() {
+	pre_build_checks
+}
+
+pkg_setup() {
+	pre_build_checks
+	python-any-r1_pkg_setup
+	use system-llvm && llvm_pkg_setup
+}
+
+src_prepare() {
+	if ! use system-bootstrap; then
+		local rust_stage0_root="${WORKDIR}"/rust-stage0
+		local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
+
+		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
+			--destdir="${rust_stage0_root}" --prefix=/ || die
+	fi
+
+	default
+}
+
+src_configure() {
+	local rust_target="" rust_targets="" arch_cflags
+
+	# Collect rust target names to compile standard libs for all ABIs.
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_targets="${rust_targets},\"$(rust_abi $(get_abi_CHOST ${v##*.}))\""
+	done
+	if use wasm; then
+		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
+	fi
+	rust_targets="${rust_targets#,}"
+
+	local extended="true" tools="\"cargo\","
+	if use clippy; then
+		tools="\"clippy\",$tools"
+	fi
+	if use rls; then
+		tools="\"rls\",\"analysis\",\"src\",$tools"
+	fi
+	if use rustfmt; then
+		tools="\"rustfmt\",$tools"
+	fi
+
+	local rust_stage0_root
+	if use system-bootstrap; then
+		rust_stage0_root="$(rustc --print sysroot)"
+	else
+		rust_stage0_root="${WORKDIR}"/rust-stage0
+	fi
+
+	rust_target="$(rust_abi)"
+
+	cat <<- EOF > "${S}"/config.toml
+		[llvm]
+		optimize = $(toml_usex !debug)
+		release-debuginfo = $(toml_usex debug)
+		assertions = $(toml_usex debug)
+		targets = "${LLVM_TARGETS// /;}"
+		experimental-targets = ""
+		link-shared = $(toml_usex system-llvm)
+		[build]
+		build = "${rust_target}"
+		host = ["${rust_target}"]
+		target = [${rust_targets}]
+		cargo = "${rust_stage0_root}/bin/cargo"
+		rustc = "${rust_stage0_root}/bin/rustc"
+		docs = $(toml_usex doc)
+		compiler-docs = $(toml_usex doc)
+		submodules = false
+		python = "${EPYTHON}"
+		locked-deps = true
+		vendor = true
+		extended = ${extended}
+		tools = [${tools}]
+		verbose = 2
+		[install]
+		prefix = "${EPREFIX}/usr"
+		libdir = "lib"
+		docdir = "share/doc/${PF}"
+		mandir = "share/man"
+		[rust]
+		optimize = $(toml_usex !debug)
+		debug = $(toml_usex debug)
+		debug-assertions = $(toml_usex debug)
+		default-linker = "$(tc-getCC)"
+		parallel-compiler = $(toml_usex parallel-compiler)
+		channel = "$(usex nightly nightly stable)"
+		rpath = false
+		lld = $(usex system-llvm false $(toml_usex wasm))
+		[dist]
+		src-tarball = false
+	EOF
+
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_target=$(rust_abi $(get_abi_CHOST ${v##*.}))
+		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+
+		cat <<- EOF >> "${S}"/config.env
+			CFLAGS_${rust_target}=${arch_cflags}
+		EOF
+
+		cat <<- EOF >> "${S}"/config.toml
+			[target.${rust_target}]
+			cc = "$(tc-getBUILD_CC)"
+			cxx = "$(tc-getBUILD_CXX)"
+			linker = "$(tc-getCC)"
+			ar = "$(tc-getAR)"
+		EOF
+		if use system-llvm; then
+			cat <<- EOF >> "${S}"/config.toml
+				llvm-config = "$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+			EOF
+		fi
+	done
+
+	if use wasm; then
+		cat <<- EOF >> "${S}"/config.toml
+			[target.wasm32-unknown-unknown]
+			linker = "$(usex system-llvm lld rust-lld)"
+		EOF
+	fi
+}
+
+src_compile() {
+	env $(cat "${S}"/config.env)\
+		"${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) \
+		--exclude src/tools/miri || die # https://github.com/rust-lang/rust/issues/52305
+}
+
+src_install() {
+	env DESTDIR="${D}" "${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml \
+	--exclude src/tools/miri || die
+
+	# bug #689562, #689160
+	rm "${D}/etc/bash_completion.d/cargo" || die
+	rmdir "${D}"/etc{/bash_completion.d,} || die
+	dobashcomp build/tmp/dist/cargo-image/etc/bash_completion.d/cargo
+
+	mv "${ED}/usr/bin/rustc" "${ED}/usr/bin/rustc-${PV}" || die
+	mv "${ED}/usr/bin/rustdoc" "${ED}/usr/bin/rustdoc-${PV}" || die
+	mv "${ED}/usr/bin/rust-gdb" "${ED}/usr/bin/rust-gdb-${PV}" || die
+	mv "${ED}/usr/bin/rust-gdbgui" "${ED}/usr/bin/rust-gdbgui-${PV}" || die
+	mv "${ED}/usr/bin/rust-lldb" "${ED}/usr/bin/rust-lldb-${PV}" || die
+	mv "${ED}/usr/bin/cargo" "${ED}/usr/bin/cargo-${PV}" || die
+	if use clippy; then
+		mv "${ED}/usr/bin/clippy-driver" "${ED}/usr/bin/clippy-driver-${PV}" || die
+		mv "${ED}/usr/bin/cargo-clippy" "${ED}/usr/bin/cargo-clippy-${PV}" || die
+	fi
+	if use rls; then
+		mv "${ED}/usr/bin/rls" "${ED}/usr/bin/rls-${PV}" || die
+	fi
+	if use rustfmt; then
+		mv "${ED}/usr/bin/rustfmt" "${ED}/usr/bin/rustfmt-${PV}" || die
+		mv "${ED}/usr/bin/cargo-fmt" "${ED}/usr/bin/cargo-fmt-${PV}" || die
+	fi
+
+	# Move public shared libs to abi specific libdir
+	# Private and target specific libs MUST stay in /usr/lib/rustlib/${rust_target}/lib
+	if [[ $(get_libdir) != lib ]]; then
+		dodir /usr/$(get_libdir)
+		mv "${ED}/usr/lib"/*.so "${ED}/usr/$(get_libdir)/" || die
+	fi
+
+	dodoc COPYRIGHT
+
+	# note: eselect-rust adds EROOT to all paths below
+	cat <<-EOF > "${T}/provider-${P}"
+		/usr/bin/rustdoc
+		/usr/bin/rust-gdb
+		/usr/bin/rust-gdbgui
+		/usr/bin/rust-lldb
+	EOF
+	echo /usr/bin/cargo >> "${T}/provider-${P}"
+	if use clippy; then
+		echo /usr/bin/clippy-driver >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-clippy >> "${T}/provider-${P}"
+	fi
+	if use rls; then
+		echo /usr/bin/rls >> "${T}/provider-${P}"
+	fi
+	if use rustfmt; then
+		echo /usr/bin/rustfmt >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-fmt >> "${T}/provider-${P}"
+	fi
+	dodir /etc/env.d/rust
+	insinto /etc/env.d/rust
+	doins "${T}/provider-${P}"
+}
+
+pkg_postinst() {
+	eselect rust update --if-unset
+
+	elog "Rust installs a helper script for calling GDB and LLDB,"
+	elog "for your convenience it is installed under /usr/bin/rust-{gdb,lldb}-${PV}."
+
+	ewarn "cargo is now installed from dev-lang/rust{,-bin} instead of dev-util/cargo."
+	ewarn "This might have resulted in a dangling symlink for /usr/bin/cargo on some"
+	ewarn "systems. This can be resolved by calling 'sudo eselect rust set ${P}'."
+
+	if has_version app-editors/emacs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-vim to get vim support for rust."
+	fi
+}
+
+pkg_postrm() {
+	eselect rust cleanup
+}

--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -7,7 +7,7 @@
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2019-12-21)
 # For bleeding edge features and testing, not generally suitable
 # for stable systems
-dev-lang/rust nightly
+dev-lang/rust nightly parallel-compiler system-bootstrap
 
 # Andreas Sturmlechner <asturm@gentoo.org> (2019-12-18)
 # Neither sys-apps/bolt nor kde-plasma/plasma-thunderbolt are stable

--- a/virtual/rust/rust-1.40.0.ebuild
+++ b/virtual/rust/rust-1.40.0.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=7
 
+inherit multilib-build
+
 DESCRIPTION="Virtual for Rust language compiler"
 
 LICENSE=""
@@ -10,4 +12,4 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 
 BDEPEND=""
-RDEPEND="|| ( =dev-lang/rust-${PV}* =dev-lang/rust-bin-${PV}* )"
+RDEPEND="|| ( =dev-lang/rust-${PV}*[${MULTILIB_USEDEP}] =dev-lang/rust-bin-${PV}* )"


### PR DESCRIPTION
A lot of small and big fixes and improvements:

*  first of all, big change:
install  all rust private stuff to `/usr/lib/rustlib` (even on multilib it's legal to use /usr/lib/subdir, python3.7+ does that already)
this is expected rust location unless we want to pass --sysroot everywhere or patch sysroot.
This allows us to drop multilib hacks and LDPATH hacks.

Also unblocks us to enable system-bootstrap! previosly rust bootstrap was confused because it could not find stdlib. I've sucessfully bootstrapped it using both this `ebuild` and current `rust-bin`
in near future it will allow us to drop downloading stages in bootstrap and just follow normal bootstrap path `rust-bin -> rust -> rust -> rust ...`
This will require to keep some old versions around, but not much, as users always can use rust-bin to bootstrap. Currently we still keep them for a while. But due to the way we installed rust before 1.40.0-r1 is the fist capable to do `system-bootstrap`.

* also add a useflag to build multithreaded compiler. upstream already builds every compiler as multithreaded on their CI, and even enabling multithreading still leaves it sequential by default, one needs to pass `-Zthreads=<num>` nightly flags to enable thread pools, so it's gated behind `nightly` flag as well.

* IMPORTANT: I absolutely haven't tested multilib compilation.  currently `net-libs/quiche/quiche` relies on it, building multilib on my x86 laptop, but it will take a whiiile.

example filelist (I'm using powerpc64)
```Hack
qlist rust | grep -v src
/usr/share/eselect/modules/rust.eselect
/usr/share/doc/eselect-rust-20190311/ChangeLog.bz2
/usr/lib/rustlib/rust-installer-version
/usr/lib/rustlib/uninstall.sh
/usr/lib/rustlib/manifest-rust-std-powerpc64le-unknown-linux-gnu
/usr/lib/rustlib/components
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libunwind-966d7e244f8be180.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libunicode_width-802a9fa74e8b7601.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libtest-a215d318b8c82ccb.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libterm-d4ef3d1032162bc4.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libstd-75405bbdc5edd537.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/librustc_std_workspace_std-a554e2a9ceb0930b.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/librustc_std_workspace_core-cea0d46e04687fff.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/librustc_std_workspace_alloc-bd35f2b4a1521cf5.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/librustc_demangle-1de472cbbe881221.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libproc_macro-f39f1bfa4e5f5c5a.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libpanic_unwind-e637021571acb92b.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libpanic_abort-21d592c72cb056df.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/liblibc-37d6165387d0a24e.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libhashbrown-5f963b13a8dfcc09.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libgetopts-ac9e0a1b33bc298a.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libcore-b82eeebf47cc05d8.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libcompiler_builtins-1d1667af7d2f28c3.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libcfg_if-3fd916b9d5c373dc.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libbacktrace_sys-2beed708e83a2199.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libbacktrace-f2df1414c57c2ecc.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/liballoc-a5b63dace18b4fea.rlib
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libtest-a215d318b8c82ccb.so
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libstd-75405bbdc5edd537.so
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libLLVM-9-rust-1.40.0-nightly.so
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libcore-b82eeebf47cc05d8.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/librustc_std_workspace_core-cea0d46e04687fff.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/liblibc-37d6165387d0a24e.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libcompiler_builtins-1d1667af7d2f28c3.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libcfg_if-3fd916b9d5c373dc.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libpanic_abort-21d592c72cb056df.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libbacktrace_sys-2beed708e83a2199.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libunwind-966d7e244f8be180.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/librustc_demangle-1de472cbbe881221.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libbacktrace-f2df1414c57c2ecc.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/liballoc-a5b63dace18b4fea.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/librustc_std_workspace_alloc-bd35f2b4a1521cf5.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libpanic_unwind-e637021571acb92b.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libhashbrown-5f963b13a8dfcc09.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libstd-75405bbdc5edd537.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/librustc_std_workspace_std-a554e2a9ceb0930b.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libunicode_width-802a9fa74e8b7601.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libterm-d4ef3d1032162bc4.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libgetopts-ac9e0a1b33bc298a.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libproc_macro-f39f1bfa4e5f5c5a.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/analysis/libtest-a215d318b8c82ccb.json
/usr/lib/rustlib/powerpc64le-unknown-linux-gnu/codegen-backends/librustc_codegen_llvm-llvm.so
/usr/lib/rustlib/manifest-cargo
/usr/lib/rustlib/manifest-rls-preview
/usr/lib/rustlib/manifest-rustfmt-preview
/usr/lib/rustlib/manifest-clippy-preview
/usr/lib/rustlib/manifest-rust-analysis-powerpc64le-unknown-linux-gnu
/usr/lib/rustlib/install.log
/usr/lib/rustlib/manifest-rustc
/usr/lib/rustlib/etc/lldb_rust_formatters.py
/usr/lib/rustlib/etc/gdb_rust_pretty_printing.py
/usr/lib/rustlib/etc/gdb_load_rust_pretty_printers.py
/usr/lib/rustlib/etc/debugger_pretty_printers_common.py
/usr/bin/rust-gdb-1.40.0
/usr/bin/rust-gdbgui-1.40.0
/usr/bin/rust-lldb-1.40.0
/usr/bin/rustc-1.40.0
/usr/bin/cargo-clippy-1.40.0
/usr/bin/cargo-fmt-1.40.0
/usr/bin/rustdoc-1.40.0
/usr/bin/clippy-driver-1.40.0
/usr/bin/rustfmt-1.40.0
/usr/bin/cargo-1.40.0
/usr/bin/rls-1.40.0
/usr/share/doc/rust-1.40.0-r1/LICENSE-THIRD-PARTY.bz2
/usr/share/doc/rust-1.40.0-r1/README.md.old.bz2
/usr/share/doc/rust-1.40.0-r1/LICENSE-MIT.old.bz2
/usr/share/doc/rust-1.40.0-r1/LICENSE-APACHE.old.bz2
/usr/share/doc/rust-1.40.0-r1/README.md.bz2
/usr/share/doc/rust-1.40.0-r1/LICENSE-MIT.bz2
/usr/share/doc/rust-1.40.0-r1/LICENSE-APACHE.bz2
/usr/share/doc/rust-1.40.0-r1/COPYRIGHT.bz2
/usr/share/man/man1/cargo-metadata.1.bz2
/usr/share/man/man1/cargo-doc.1.bz2
/usr/share/man/man1/cargo-rustdoc.1.bz2
/usr/share/man/man1/cargo-rustc.1.bz2
/usr/share/man/man1/cargo-pkgid.1.bz2
/usr/share/man/man1/cargo-build.1.bz2
/usr/share/man/man1/cargo-generate-lockfile.1.bz2
/usr/share/man/man1/cargo-package.1.bz2
/usr/share/man/man1/cargo-update.1.bz2
/usr/share/man/man1/cargo-bench.1.bz2
/usr/share/man/man1/cargo-search.1.bz2
/usr/share/man/man1/cargo-fetch.1.bz2
/usr/share/man/man1/cargo-publish.1.bz2
/usr/share/man/man1/cargo-check.1.bz2
/usr/share/man/man1/cargo-yank.1.bz2
/usr/share/man/man1/cargo-install.1.bz2
/usr/share/man/man1/cargo-uninstall.1.bz2
/usr/share/man/man1/cargo-clean.1.bz2
/usr/share/man/man1/cargo-login.1.bz2
/usr/share/man/man1/cargo-run.1.bz2
/usr/share/man/man1/cargo-version.1.bz2
/usr/share/man/man1/cargo.1.bz2
/usr/share/man/man1/cargo-help.1.bz2
/usr/share/man/man1/cargo-owner.1.bz2
/usr/share/man/man1/cargo-vendor.1.bz2
/usr/share/man/man1/cargo-locate-project.1.bz2
/usr/share/man/man1/cargo-verify-project.1.bz2
/usr/share/man/man1/cargo-init.1.bz2
/usr/share/man/man1/cargo-test.1.bz2
/usr/share/man/man1/cargo-new.1.bz2
/usr/share/man/man1/cargo-fix.1.bz2
/usr/share/man/man1/rustdoc.1.bz2
/usr/share/man/man1/rustc.1.bz2
/usr/share/zsh/site-functions/_cargo
/usr/share/bash-completion/completions/cargo
/usr/lib64/libtest-a215d318b8c82ccb.so
/usr/lib64/libstd-75405bbdc5edd537.so
/usr/lib64/librustc_macros-83d7a7304012db4b.so
/usr/lib64/libLLVM-9-rust-1.40.0-nightly.so
/usr/lib64/librustc_driver-392e7f17f33a51e3.so
/etc/env.d/rust/provider-rust-1.40.0
/usr/lib/rust/crates/rustc-std-workspace-core-1.0.0/Cargo.toml
/usr/lib/rust/crates/rustc-std-workspace-core-1.0.0/Cargo.toml.orig
/usr/lib/rust/crates/rustc-std-workspace-core-1.0.0/.cargo-checksum.json
```


teh big diff
```diff
diff -u rust-1.40.0.ebuild rust-1.40.0-r1.ebuild 
--- rust-1.40.0.ebuild	2019-12-26 18:24:19.357631061 -0800
+++ rust-1.40.0-r1.ebuild	2019-12-29 20:04:14.324387145 -0800
@@ -18,7 +18,7 @@
 	SLOT="stable/${ABI_VER}"
 	MY_P="rustc-${PV}"
 	SRC="${MY_P}-src.tar.xz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+	KEYWORDS=""
 fi
 
 RUST_STAGE0_VERSION="1.$(($(ver_cut 2) - 1)).0"
@@ -26,8 +26,10 @@
 DESCRIPTION="Systems programming language from Mozilla"
 HOMEPAGE="https://www.rust-lang.org/"
 
-SRC_URI="https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.xz
-	$(rust_all_arch_uris rust-${RUST_STAGE0_VERSION})"
+SRC_URI="
+	https://static.rust-lang.org/dist/${SRC} -> rustc-${PV}-src.tar.xz
+	!system-bootstrap? ( $(rust_all_arch_uris rust-${RUST_STAGE0_VERSION}) )
+"
 
 ALL_LLVM_TARGETS=( AArch64 AMDGPU ARM BPF Hexagon Lanai Mips MSP430
 	NVPTX PowerPC RISCV Sparc SystemZ WebAssembly X86 XCore )
@@ -36,7 +38,7 @@
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 
-IUSE="clippy cpu_flags_x86_sse2 debug doc libressl nightly rls rustfmt system-llvm wasm ${ALL_LLVM_TARGETS[*]}"
+IUSE="clippy cpu_flags_x86_sse2 debug doc libressl nightly parallel-compiler rls rustfmt system-bootstrap system-llvm wasm ${ALL_LLVM_TARGETS[*]}"
 
 # Please keep the LLVM dependency block separate. Since LLVM is slotted,
 # we need to *really* make sure we're not pulling more than one slot
@@ -44,8 +46,8 @@
 
 # How to use it:
 # 1. List all the working slots (with min versions) in ||, newest first.
-# 2. Update the := to specify *max* version, e.g. < 9.
-# 3. Specify LLVM_MAX_SLOT, e.g. 8.
+# 2. Update the := to specify *max* version, e.g. < 10.
+# 3. Specify LLVM_MAX_SLOT, e.g. 9.
 LLVM_DEPEND="
 	|| (
 		sys-devel/llvm:9[llvm_targets_WebAssembly?]
@@ -55,6 +57,11 @@
 "
 LLVM_MAX_SLOT=9
 
+# FIXME:
+# this should be '>=virtual/rust-1.$(($(ver_cut 2) - 1))', but we can't do it yet
+# as the first gentoo-built rust that can bootstap new compiler is 1.40.0-r1
+BOOTSTRAP_DEPEND="|| ( =dev-lang/rust-${PF} =dev-lang/rust-bin-${PV}* )"
+
 COMMON_DEPEND="
 	sys-libs/zlib
 	!libressl? ( dev-libs/openssl:0= )
@@ -74,22 +81,31 @@
 		>=sys-devel/clang-3.5
 	)
 	dev-util/cmake
+	system-bootstrap? ( ${BOOTSTRAP_DEPEND}	)
 "
 
 RDEPEND="${COMMON_DEPEND}
 	>=app-eselect/eselect-rust-20190311
-	!dev-util/cargo
-	rustfmt? ( !dev-util/rustfmt )
 "
 
 REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
+	parallel-compiler? ( nightly )
 	wasm? ( llvm_targets_WebAssembly )
 	x86? ( cpu_flags_x86_sse2 )
 "
-QA_FLAGS_IGNORED="usr/bin/* usr/lib*/${P}"
+
+QA_FLAGS_IGNORED="
+	usr/bin/*-${PV}
+	usr/lib*/lib*.so
+	usr/lib/rurstlib/*/codegen-backends/librustc_codegen_llvm-llvm.so
+	usr/lib/rustlib/*/lib/lib*.so
+"
+
+QA_SONAME="usr/lib*/librustc_macros*.so"
 
 PATCHES=(
 	"${FILESDIR}"/1.36.0-libressl.patch
+	"${FILESDIR}"/1.40.0-add-soname.patch
 )
 
 S="${WORKDIR}/${MY_P}-src"
@@ -119,11 +135,13 @@
 }
 
 src_prepare() {
-	local rust_stage0_root="${WORKDIR}"/rust-stage0
-
-	local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
+	if ! use system-bootstrap; then
+		local rust_stage0_root="${WORKDIR}"/rust-stage0
+		local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
 
-	"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig --destdir="${rust_stage0_root}" --prefix=/ || die
+		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
+			--destdir="${rust_stage0_root}" --prefix=/ || die
+	fi
 
 	default
 }
@@ -151,7 +169,12 @@
 		tools="\"rustfmt\",$tools"
 	fi
 
-	local rust_stage0_root="${WORKDIR}"/rust-stage0
+	local rust_stage0_root
+	if use system-bootstrap; then
+		rust_stage0_root="$(rustc --print sysroot)"
+	else
+		rust_stage0_root="${WORKDIR}"/rust-stage0
+	fi
 
 	rust_target="$(rust_abi)"
 
@@ -170,6 +193,7 @@
 		cargo = "${rust_stage0_root}/bin/cargo"
 		rustc = "${rust_stage0_root}/bin/rustc"
 		docs = $(toml_usex doc)
+		compiler-docs = $(toml_usex doc)
 		submodules = false
 		python = "${EPYTHON}"
 		locked-deps = true
@@ -179,14 +203,15 @@
 		verbose = 2
 		[install]
 		prefix = "${EPREFIX}/usr"
-		libdir = "$(get_libdir)/${P}"
-		docdir = "share/doc/${P}"
-		mandir = "share/${P}/man"
+		libdir = "lib"
+		docdir = "share/doc/${PF}"
+		mandir = "share/man"
 		[rust]
 		optimize = $(toml_usex !debug)
 		debug = $(toml_usex debug)
 		debug-assertions = $(toml_usex debug)
 		default-linker = "$(tc-getCC)"
+		parallel-compiler = $(toml_usex parallel-compiler)
 		channel = "$(usex nightly nightly stable)"
 		rpath = false
 		lld = $(usex system-llvm false $(toml_usex wasm))
@@ -229,8 +254,6 @@
 }
 
 src_install() {
-	local rust_target abi_libdir
-
 	env DESTDIR="${D}" "${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml \
 	--exclude src/tools/miri || die
 
@@ -257,30 +280,15 @@
 		mv "${ED}/usr/bin/cargo-fmt" "${ED}/usr/bin/cargo-fmt-${PV}" || die
 	fi
 
-	# Copy shared library versions of standard libraries for all targets
-	# into the system's abi-dependent lib directories because the rust
-	# installer only does so for the native ABI.
-	for v in $(multilib_get_enabled_abi_pairs); do
-		if [ ${v##*.} = ${DEFAULT_ABI} ]; then
-			continue
-		fi
-		abi_libdir=$(get_abi_LIBDIR ${v##*.})
-		rust_target=$(rust_abi $(get_abi_CHOST ${v##*.}))
-		mkdir -p "${ED}/usr/${abi_libdir}/${P}"
-		cp "${ED}/usr/$(get_libdir)/${P}/rustlib/${rust_target}/lib"/*.so \
-		   "${ED}/usr/${abi_libdir}/${P}" || die
-	done
+	# Move public shared libs to abi specific libdir
+	# Private and target specific libs MUST stay in /usr/lib/rustlib/${rust_target}/lib
+	if [[ $(get_libdir) != lib ]]; then
+		dodir /usr/$(get_libdir)
+		mv "${ED}/usr/lib"/*.so "${ED}/usr/$(get_libdir)/" || die
+	fi
 
 	dodoc COPYRIGHT
 
-	# FIXME:
-	# Really not sure if that env is needed, specailly LDPATH
-	cat <<-EOF > "${T}"/50${P}
-		LDPATH="${EPREFIX}/usr/$(get_libdir)/${P}"
-		MANPATH="${EPREFIX}/usr/share/${P}/man"
-	EOF
-	doenvd "${T}"/50${P}
-
 	# note: eselect-rust adds EROOT to all paths below
 	cat <<-EOF > "${T}/provider-${P}"
 		/usr/bin/rustdoc
```