### PR TITLE
dev-python/thrift: amd64, x86 stable

### DIFF
--- a/dev-python/thrift/thrift-0.11.0.ebuild
+++ b/dev-python/thrift/thrift-0.11.0.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python{2_7,3_5,3_6} )
 inherit distutils-r1
 
 DESCRIPTION="Python implementation of Thrift"
-HOMEPAGE="https://thrift.apache.org"
+HOMEPAGE="https://pypi.org/project/thrift/ https://thrift.apache.org/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"

--- a/dev-python/thrift/thrift-0.11.0.ebuild
+++ b/dev-python/thrift/thrift-0.11.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 x86 amd64-linux x86-linux"
 
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]


### PR DESCRIPTION
This version is more than year old https://pypi.org/project/thrift/#history, no bugs at https://bugs.gentoo.org/buglist.cgi?quicksearch=thrift&list_id=4429116