### PR TITLE
*/*: Switch proxy-maint to cmake.eclass

### DIFF
--- a/app-arch/innoextract/innoextract-1.8.ebuild
+++ b/app-arch/innoextract/innoextract-1.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="A tool to unpack installers created by Inno Setup"
 HOMEPAGE="https://constexpr.org/innoextract/"
@@ -29,5 +29,5 @@ src_configure() {
 		-DWITH_CONV=$(usex iconv iconv builtin)
 	)
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/dev-db/cpp-driver/cpp-driver-2.11.0.ebuild
+++ b/dev-db/cpp-driver/cpp-driver-2.11.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="DataStax C/C++ Driver for Cassandra"
 HOMEPAGE="https://datastax.github.io/cpp-driver/"
@@ -24,5 +24,5 @@ DEPEND="${RDEPEND}"
 
 src_configure() {
 	local mycmakeargs=( -DCASS_USE_OPENSSL=$(usex ssl) )
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/dev-libs/hyperscan/hyperscan-5.1.0.ebuild
+++ b/dev-libs/hyperscan/hyperscan-5.1.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit cmake-utils python-r1
+inherit cmake python-r1
 
 DESCRIPTION="High-performance regular expression matching library"
 HOMEPAGE="https://01.org/hyperscan"
@@ -33,5 +33,5 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=$(usex static-libs OFF ON)
 		-DBUILD_STATIC_AND_SHARED=$(usex static-libs ON OFF)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/dev-libs/hyperscan/hyperscan-5.1.1.ebuild
+++ b/dev-libs/hyperscan/hyperscan-5.1.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit cmake-utils python-r1 flag-o-matic
+inherit cmake python-r1 flag-o-matic
 
 DESCRIPTION="High-performance regular expression matching library"
 SRC_URI="https://github.com/01org/hyperscan/archive/v${PV}.tar.gz -> ${P}.tar.gz"
@@ -27,7 +27,7 @@ REQUIRED_USE="cpu_flags_x86_ssse3 ${PYTHON_REQUIRED_USE}"
 src_prepare() {
 	# upstream workaround
 	append-cxxflags -Wno-redundant-move
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 
 src_configure() {
@@ -35,5 +35,5 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=$(usex static-libs OFF ON)
 		-DBUILD_STATIC_AND_SHARED=$(usex static-libs ON OFF)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/dev-libs/hyperscan/hyperscan-5.2.0.ebuild
+++ b/dev-libs/hyperscan/hyperscan-5.2.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit cmake-utils python-r1 flag-o-matic
+inherit cmake python-r1 flag-o-matic
 
 DESCRIPTION="High-performance regular expression matching library"
 SRC_URI="https://github.com/01org/hyperscan/archive/v${PV}.tar.gz -> ${P}.tar.gz"
@@ -27,7 +27,7 @@ REQUIRED_USE="cpu_flags_x86_ssse3 ${PYTHON_REQUIRED_USE}"
 src_prepare() {
 	# upstream workaround
 	append-cxxflags -Wno-redundant-move
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 
 src_configure() {
@@ -35,5 +35,5 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=$(usex static-libs OFF ON)
 		-DBUILD_STATIC_AND_SHARED=$(usex static-libs ON OFF)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/dev-util/edb-debugger/edb-debugger-1.0.0-r3.ebuild
+++ b/dev-util/edb-debugger/edb-debugger-1.0.0-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="edb is a cross platform x86/x86-64 debugger, inspired by Ollydbg"
 HOMEPAGE="https://github.com/eteran/edb-debugger"
@@ -47,5 +47,5 @@ src_prepare() {
 		sed -i -e '/pkg_check_modules(GRAPHVIZ/d' CMakeLists.txt || die
 	fi
 
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }

--- a/dev-util/edb-debugger/edb-debugger-1.1.0-r1.ebuild
+++ b/dev-util/edb-debugger/edb-debugger-1.1.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="edb is a cross platform x86/x86-64 debugger, inspired by Ollydbg"
 HOMEPAGE="https://github.com/eteran/edb-debugger"
@@ -45,5 +45,5 @@ src_prepare() {
 		sed -i -e '/pkg_check_modules(GRAPHVIZ/d' CMakeLists.txt || die
 	fi
 
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }

--- a/dev-util/edb-debugger/edb-debugger-9999.ebuild
+++ b/dev-util/edb-debugger/edb-debugger-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils git-r3
+inherit cmake git-r3
 
 DESCRIPTION="edb is a cross platform x86/x86-64 debugger, inspired by Ollydbg"
 HOMEPAGE="https://github.com/eteran/edb-debugger"
@@ -38,12 +38,12 @@ src_prepare() {
 	if ! use graphviz; then
 		sed -i -e '/pkg_check_modules(GRAPHVIZ/d' CMakeLists.txt || die
 	fi
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 
 src_configure() {
 	local mycmakeargs=(
 		-DBUILD_JUMBO=$(usex jumbo-build)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/dev-util/kdstatemachineeditor/kdstatemachineeditor-1.2.4.ebuild
+++ b/dev-util/kdstatemachineeditor/kdstatemachineeditor-1.2.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils qmake-utils
+inherit cmake qmake-utils
 
 DESCRIPTION="Framework for creating Qt State Machine metacode using graphical user interfaces"
 HOMEPAGE="https://github.com/KDAB/KDStateMachineEditor"
@@ -49,5 +49,5 @@ src_configure() {
 		-DBUILD_TESTING=$(usex test)
 		-DECM_MKSPECS_INSTALL_DIR=$(qt5_get_mkspecsdir)/modules
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/dev-util/kdstatemachineeditor/kdstatemachineeditor-9999.ebuild
+++ b/dev-util/kdstatemachineeditor/kdstatemachineeditor-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils qmake-utils
+inherit cmake qmake-utils
 
 DESCRIPTION="Framework for creating Qt State Machine metacode using graphical user interfaces"
 HOMEPAGE="https://github.com/KDAB/KDStateMachineEditor"
@@ -49,5 +49,5 @@ src_configure() {
 		-DBUILD_TESTING=$(usex test)
 		-DECM_MKSPECS_INSTALL_DIR=$(qt5_get_mkspecsdir)/modules
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/mail-filter/rspamd/rspamd-2.2.ebuild
+++ b/mail-filter/rspamd/rspamd-2.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils pax-utils systemd tmpfiles
+inherit cmake pax-utils systemd tmpfiles
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/vstakhov/rspamd.git"
@@ -42,7 +42,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 
 	sed -i -e '/PROJECT/s/LANGUAGES C ASM/LANGUAGES C CXX ASM/' CMakeLists.txt \
 		|| die "sed CMakeLists.txt failed"
@@ -63,15 +63,15 @@ src_configure() {
 		-DENABLE_LUAJIT=$(usex jit ON OFF)
 		-DENABLE_PCRE2=$(usex pcre2 ON OFF)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_test() {
-	cmake-utils_src_test
+	cmake_src_test
 }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 
 	newconfd "${FILESDIR}"/rspamd.conf rspamd
 	newinitd "${FILESDIR}/rspamd-r7.init" rspamd

--- a/mail-filter/rspamd/rspamd-9999.ebuild
+++ b/mail-filter/rspamd/rspamd-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils pax-utils systemd tmpfiles
+inherit cmake pax-utils systemd tmpfiles
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/vstakhov/rspamd.git"
@@ -42,7 +42,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 
 	sed -i -e 's/User=_rspamd/User=rspamd/g' \
 		rspamd.service \
@@ -61,15 +61,15 @@ src_configure() {
 		-DENABLE_LUAJIT=$(usex jit ON OFF)
 		-DENABLE_PCRE2=$(usex pcre2 ON OFF)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_test() {
-	cmake-utils_src_test
+	cmake_src_test
 }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 
 	newconfd "${FILESDIR}"/rspamd.conf rspamd
 	newinitd "${FILESDIR}/rspamd-r7.init" rspamd

--- a/media-libs/libsoundio/libsoundio-2.0.0.ebuild
+++ b/media-libs/libsoundio/libsoundio-2.0.0.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=7
 
+CMAKE_ECLASS=cmake
 inherit cmake-multilib
 
 DESCRIPTION="C library for cross-platform real-time audio input and output"
@@ -30,5 +31,5 @@ multilib_src_configure() {
 		-DBUILD_EXAMPLE_PROGRAMS=$(multilib_native_usex examples)
 		-DBUILD_TESTS=no
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/media-sound/loudness-scanner/loudness-scanner-0.5.1_p20190709.ebuild
+++ b/media-sound/loudness-scanner/loudness-scanner-0.5.1_p20190709.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Scans your music files and tags them with loudness information"
 HOMEPAGE="https://github.com/jiixyj/loudness-scanner/"
@@ -40,7 +40,7 @@ RDEPEND="${DEPEND}"
 S="${WORKDIR}/${PN}"
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 	sed -i -e 's|".",|"'${EROOT}'/usr/'$(get_libdir)'/loudness-scanner",|g' \
 		"${S}"/scanner/inputaudio/input.c
 }
@@ -59,7 +59,7 @@ src_configure() {
 		-DDISABLE_RSVG2:BOOL=$(usex gtk no yes)
 		-DDISABLE_SNDFILE:BOOL=$(usex sndfile no yes)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_install() {

--- a/media-sound/loudness-scanner/loudness-scanner-9999.ebuild
+++ b/media-sound/loudness-scanner/loudness-scanner-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils git-r3
+inherit cmake git-r3
 
 DESCRIPTION="Scans your music files and tags them with loudness information"
 HOMEPAGE="https://github.com/jiixyj/loudness-scanner/"
@@ -38,7 +38,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 	sed -i -e 's|".",|"'${EROOT}'/usr/'$(get_libdir)'/loudness-scanner",|g' \
 		"${S}"/scanner/inputaudio/input.c
 }
@@ -57,7 +57,7 @@ src_configure() {
 		-DDISABLE_RSVG2:BOOL=$(usex gtk no yes)
 		-DDISABLE_SNDFILE:BOOL=$(usex sndfile no yes)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_install() {

--- a/net-libs/libsignal-protocol-c/libsignal-protocol-c-2.3.2.ebuild
+++ b/net-libs/libsignal-protocol-c/libsignal-protocol-c-2.3.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit multilib cmake-utils
+inherit cmake
 
 DESCRIPTION="Signal Protocol C Library"
 HOMEPAGE="https://www.whispersystems.org/"

--- a/net-libs/libsignal-protocol-c/libsignal-protocol-c-9999.ebuild
+++ b/net-libs/libsignal-protocol-c/libsignal-protocol-c-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit git-r3 multilib cmake-utils
+inherit git-r3 cmake
 
 DESCRIPTION="Signal Protocol C Library"
 HOMEPAGE="https://www.whispersystems.org/"

--- a/net-libs/tox/tox-0.2.10.ebuild
+++ b/net-libs/tox/tox-0.2.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils systemd
+inherit cmake systemd
 
 MY_P="c-toxcore-${PV}"
 DESCRIPTION="Encrypted P2P, messaging, and audio/video calling platform"
@@ -38,7 +38,7 @@ RDEPEND="
 S="${WORKDIR}/${MY_P}"
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 	#remove faulty tests
 	for testname in bootstrap lan_discovery save_compatibility tcp_relay tox_many_tcp; do
 		sed -i -e "/^auto_test(${testname})$/d" CMakeLists.txt || die
@@ -81,11 +81,11 @@ src_configure() {
 		einfo "Logging disabled"
 	fi
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 
 	if use daemon; then
 		newinitd "${FILESDIR}"/initd tox-dht-daemon

--- a/net-libs/tox/tox-0.2.9-r1.ebuild
+++ b/net-libs/tox/tox-0.2.9-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils systemd
+inherit cmake systemd
 
 MY_P="c-toxcore-${PV}"
 DESCRIPTION="Encrypted P2P, messaging, and audio/video calling platform"
@@ -31,7 +31,7 @@ RDEPEND="${DEPEND}
 S="${WORKDIR}/${MY_P}"
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 	#remove faulty tests
 	for testname in bootstrap lan_discovery save_compatibility tcp_relay tox_many_tcp; do
 		sed -i -e "/^auto_test(${testname})$/d" CMakeLists.txt || die
@@ -74,11 +74,11 @@ src_configure() {
 		einfo "Logging disabled"
 	fi
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 
 	if use daemon; then
 		newinitd "${FILESDIR}"/initd tox-dht-daemon

--- a/net-libs/tox/tox-9999.ebuild
+++ b/net-libs/tox/tox-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils git-r3 systemd
+inherit cmake git-r3 systemd
 
 DESCRIPTION="Encrypted P2P, messaging, and audio/video calling platform"
 HOMEPAGE="https://tox.chat"
@@ -33,7 +33,7 @@ DEPEND="${COMMON_DEPEND}"
 RDEPEND="${COMMON_DEPEND}"
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 	#remove faulty tests
 	for testname in bootstrap lan_discovery save_compatibility tcp_relay tox_many_tcp; do
 		sed -i -e "/^auto_test(${testname})$/d" CMakeLists.txt || die
@@ -74,11 +74,11 @@ src_configure() {
 		mycmakeargs+=(-DMIN_LOGGER_LEVEL="")
 		einfo "Logging Disabled"
 	fi
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 
 	if use daemon; then
 		newinitd "${FILESDIR}"/initd tox-dht-daemon


### PR DESCRIPTION
- Only concerns EAPI-7 ported ebuilds
- See also: https://archives.gentoo.org/gentoo-dev/message/3aa1a3aeebad353a7cefcb86a8101943
- Please ACK your packages