### PR TITLE
[CI] ruby-ng.eclass: Include (-) in RUBY_TARGETS USE-dependencies

### DIFF
--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -137,7 +137,7 @@ ruby_samelib() {
 	local res=
 	for _ruby_implementation in $(_ruby_get_all_impls); do
 		has -${_ruby_implementation} $@ || \
-			res="${res}ruby_targets_${_ruby_implementation}?,"
+			res="${res}ruby_targets_${_ruby_implementation}?(-),"
 	done
 
 	echo "[${res%,}]"
@@ -151,9 +151,9 @@ _ruby_atoms_samelib_generic() {
 			"||" | "(" | ")" | *"?")
 				echo "${token}" ;;
 			*])
-				echo "${token%[*}[RUBYTARGET,${token/*[}" ;;
+				echo "${token%[*}[RUBYTARGET(-),${token/*[}" ;;
 			*)
-				echo "${token}[RUBYTARGET]" ;;
+				echo "${token}[RUBYTARGET(-)]" ;;
 		esac
 	done
 	echo ")"


### PR DESCRIPTION
Using 2-style USE dependencies on packages not having the flag
in question is forbidden by PMS.

Signed-off-by: Michał Górny <mgorny@gentoo.org>