### PR TITLE
games-util/xboxdrv: add python-3.7 support

### DIFF
--- a/games-util/xboxdrv/xboxdrv-0.8.8_p20190118.ebuild
+++ b/games-util/xboxdrv/xboxdrv-0.8.8_p20190118.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_6 )
+PYTHON_COMPAT=( python2_7 python3_{6,7} )
 
 inherit linux-info python-any-r1 scons-utils toolchain-funcs systemd udev
 


### PR DESCRIPTION
Hey, 

very simple update that seems to work. My last package that prevents full switch to python3.7. 
I noticed upstream has been working on py3 support, so maybe it's soon time to switch back?
https://gitlab.com/xboxdrv/xboxdrv/commits/develop