### PR TITLE
dev-libs/roct-thunk-interface: cmake-utils.eclass -> cmake.eclass

### DIFF
--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-2.0.0.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-2.0.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils linux-info
+inherit cmake linux-info
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/"
@@ -29,5 +29,5 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-2.10.0.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-2.10.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils linux-info
+inherit cmake linux-info
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/"
@@ -26,18 +26,18 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/"
 		-DCPACK_PACKAGING_INSTALL_PREFIX="${EPREFIX}/usr"
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 src_compile() {
-	cmake-utils_src_compile build-dev
+	cmake_src_compile build-dev
 }
 src_install() {
-	cmake-utils_src_install install-dev
+	cmake_src_install install-dev
 }

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-2.6.0.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-2.6.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils linux-info
+inherit cmake linux-info
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/"
@@ -32,11 +32,11 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 src_compile() {
-	cmake-utils_src_compile build-dev
+	cmake_src_compile build-dev
 }
 src_install() {
-	cmake-utils_src_install install-dev
+	cmake_src_install install-dev
 }

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-2.7.0.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-2.7.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils linux-info
+inherit cmake linux-info
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/"
@@ -32,11 +32,11 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 src_compile() {
-	cmake-utils_src_compile build-dev
+	cmake_src_compile build-dev
 }
 src_install() {
-	cmake-utils_src_install install-dev
+	cmake_src_install install-dev
 }

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-2.8.0.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-2.8.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils linux-info
+inherit cmake linux-info
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/"
@@ -32,11 +32,11 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 src_compile() {
-	cmake-utils_src_compile build-dev
+	cmake_src_compile build-dev
 }
 src_install() {
-	cmake-utils_src_install install-dev
+	cmake_src_install install-dev
 }

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-2.9.0-r1.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-2.9.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils linux-info
+inherit cmake linux-info
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/"
@@ -26,18 +26,18 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/"
 		-DCPACK_PACKAGING_INSTALL_PREFIX="${EPREFIX}/usr"
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 src_compile() {
-	cmake-utils_src_compile build-dev
+	cmake_src_compile build-dev
 }
 src_install() {
-	cmake-utils_src_install install-dev
+	cmake_src_install install-dev
 }

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-3.0.0.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-3.0.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils linux-info
+inherit cmake linux-info
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/"
@@ -26,18 +26,18 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/"
 		-DCPACK_PACKAGING_INSTALL_PREFIX="${EPREFIX}/usr"
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 src_compile() {
-	cmake-utils_src_compile build-dev
+	cmake_src_compile build-dev
 }
 src_install() {
-	cmake-utils_src_install install-dev
+	cmake_src_install install-dev
 }

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-9999.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils linux-info
+inherit cmake linux-info
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/"
@@ -26,18 +26,18 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die
-	cmake-utils_src_prepare
+	cmake_src_prepare
 }
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/"
 		-DCPACK_PACKAGING_INSTALL_PREFIX="${EPREFIX}/usr"
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 src_compile() {
-	cmake-utils_src_compile build-dev
+	cmake_src_compile build-dev
 }
 src_install() {
-	cmake-utils_src_install install-dev
+	cmake_src_install install-dev
 }


### PR DESCRIPTION
Signed-off-by: Wilfried Holzke <gentoo@holzke.net>
Package-Manager: Portage-2.3.79, Repoman-2.3.16