### PR TITLE
net-libs/libnet: add patch to support musl

### DIFF
--- a/net-libs/libnet/files/libnet-1.2-int64_t.patch
+++ b/net-libs/libnet/files/libnet-1.2-int64_t.patch
@@ -1,0 +1,15 @@
+--- a/include/libnet/libnet-structures.h
++++ b/include/libnet/libnet-structures.h
+@@ -49,9 +49,9 @@ struct libnet_port_list_chain
+ /* libnet statistics structure */
+ struct libnet_stats
+ {
+-    __int64_t packets_sent;               /* packets sent */
+-    __int64_t packet_errors;              /* packets errors */
+-    __int64_t bytes_written;              /* bytes written */
++    int64_t packets_sent;               /* packets sent */
++    int64_t packet_errors;              /* packets errors */
++    int64_t bytes_written;              /* bytes written */
+ };
+ 
+ 

--- a/net-libs/libnet/libnet-1.2.ebuild
+++ b/net-libs/libnet/libnet-1.2.ebuild
@@ -16,6 +16,10 @@ DOCS=(
 	ChangeLog.md README.md doc/MIGRATION.md
 )
 
+# This patch is taken from master branch in mainstream commit a1659e2.  It is
+# necessary in order to support musl libc.
+PATCHES=( "${FILESDIR}/${P}-int64_t.patch" )
+
 src_configure() {
 	econf $(use_enable static-libs static)
 }


### PR DESCRIPTION
It is necessary to apply this patch in order to support musl libc, otherwise the compilation fails with following error
```
/bin/sh ../libtool  --tag=CC   --mode=compile x86_64-gentoo-linux-musl-gcc -DHAVE_CONFIG_H -I. -I../include  -I../include -I./../include   -march=native -O2 -pipe -c -o libnet_asn1.lo libnet_asn1.c
libtool: compile:  x86_64-gentoo-linux-musl-gcc -DHAVE_CONFIG_H -I. -I../include -I../include -I./../include -march=native -O2 -pipe -c libnet_asn1.c  -fPIC -DPIC -o .libs/libnet_asn1.o
In file included from ../include/libnet.h:107,
                 from common.h:63,
                 from libnet_asn1.c:56:
../include/./libnet/libnet-structures.h:52:5: error: unknown type name ‘__int64_t’
   52 |     __int64_t packets_sent;               /* packets sent */
      |     ^~~~~~~~~
../include/./libnet/libnet-structures.h:53:5: error: unknown type name ‘__int64_t’
   53 |     __int64_t packet_errors;              /* packets errors */
      |     ^~~~~~~~~
../include/./libnet/libnet-structures.h:54:5: error: unknown type name ‘__int64_t’
   54 |     __int64_t bytes_written;              /* bytes written */
      |     ^~~~~~~~~
make[1]: *** [Makefile:549: libnet_asn1.lo] Error 1
make: *** [Makefile:552: all-recursive] Error 1
```
