### PR TITLE
eclass: delete /usr/.crates2.json in cargo_src_install

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -179,6 +179,7 @@ cargo_src_install() {
 		--root="${ED}/usr" $(usex debug --debug "") "$@" \
 		|| die "cargo install failed"
 	rm -f "${ED}/usr/.crates.toml"
+	rm -f "${ED}/usr/.crates2.json"
 
 	[ -d "${S}/man" ] && doman "${S}/man" || return 0
 }


### PR DESCRIPTION
Cargo may create this file (like `/usr/.crates.toml`). Deleting it prevents file collisions when an ebuild uses `cargo_src_install`.

For reference: https://github.com/rust-lang/cargo/blob/fb4415090f600bae51b0747bef2e7049070cd6ee/src/cargo/ops/common_for_install_and_uninstall.rs#L96