### PR TITLE
toolchain.eclass: enable elfv2 abi on ppc64 musl unconditionally

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1207,6 +1207,14 @@ toolchain_src_configure() {
 		is-flagq -mfloat-gprs=double && confgcc+=( --enable-e500-double )
 		[[ ${CTARGET//_/-} == *-e500v2-* ]] && confgcc+=( --enable-e500-double )
 		;;
+	ppc64)
+		# On ppc64 big endian target gcc assumes elfv1 by default,
+		# and elfv2 on little endian
+		# but musl does not support elfv1 at all on any endian ppc64
+		# see https://git.musl-libc.org/cgit/musl/tree/INSTALL
+		# https://bugs.gentoo.org/704784
+		[[ ${CTARGET} == powerpc64-*-musl ]] && confgcc+=( --with-abi=elfv2 )
+		;;
 	riscv)
 		# Add --with-abi flags to set default ABI
 		confgcc+=( --with-abi=$(gcc-abi-map ${TARGET_DEFAULT_ABI}) )


### PR DESCRIPTION
on ppc64 gcc assumes the following:
from gcc ppc64 manual:
-mabi=elfv1

    Change the current ABI to use the ELFv1 ABI. This is the default ABI
    for big-endian PowerPC 64-bit Linux. Overriding the default ABI
    requires special system support and is likely to fail in spectacular
    ways.
-mabi=elfv2

    Change the current ABI to use the ELFv2 ABI. This is the default
    ABI for little-endian PowerPC 64-bit Linux. Overriding the
    default ABI requires special system support and is likely to
    fail in spectacular ways.

Since we are taking gcc defaults, let's pass --with-abi=elfv2 on musl
targets
without it it will fail, since musl does not support elfv1 at all.
from musl INSTALL file:

* PowerPC64
    * Both little and big endian variants are supported
    * Compiler toolchain must provide 64-bit long double, not IBM
      double-double or IEEE quad
    * Compiler toolchain must use the new (ELFv2) ABI regardless of
      whether it is for little or big endian

https://git.musl-libc.org/cgit/musl/tree/INSTALL
Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>