### PR TITLE
*/*: Switch gnome proj to cmake.eclass

### DIFF
--- a/dev-libs/libgit2/libgit2-0.28.4.ebuild
+++ b/dev-libs/libgit2/libgit2-0.28.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python{2_7,3_{5,6,7}} )
-inherit cmake-utils python-any-r1
+inherit cmake python-any-r1
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/${PN}/${PN}.git"
@@ -46,7 +46,7 @@ src_configure() {
 		-DUSE_SSH=$(usex ssh)
 		-DTHREADSAFE=$(usex threads)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_test() {
@@ -56,12 +56,12 @@ src_test() {
 		ewarn "Skipping tests: non-root privileges are required for all tests to pass"
 	else
 		local TEST_VERBOSE=1
-		cmake-utils_src_test -R offline
+		cmake_src_test -R offline
 	fi
 }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 	dodoc docs/*.{md,txt}
 
 	if use examples ; then

--- a/gui-libs/libwpe/libwpe-1.4.0.1.ebuild
+++ b/gui-libs/libwpe/libwpe-1.4.0.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Platform-agnostic interfaces for WPE WebKit"
 HOMEPAGE="https://wpewebkit.org/"
@@ -29,5 +29,5 @@ src_configure() {
 		-DBUILD_DOCS=OFF # hotdoc not packaged
 	)
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/gui-libs/wpebackend-fdo/wpebackend-fdo-1.4.0.ebuild
+++ b/gui-libs/wpebackend-fdo/wpebackend-fdo-1.4.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="WPE backend designed for Linux desktop systems"
 HOMEPAGE="https://wpewebkit.org/"
@@ -35,5 +35,5 @@ src_configure() {
 		-DBUILD_DOCS=OFF # hotdoc not packaged
 	)
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }


### PR DESCRIPTION
cmake.class is a slot-in replacement for cmake-utils EAPI-7 (for the most part).