### PR TITLE
dev-ruby/racc: depend on dev-lang/ruby[ssl]

### DIFF
--- a/dev-ruby/racc/racc-1.4.14.ebuild
+++ b/dev-ruby/racc/racc-1.4.14.ebuild
@@ -20,6 +20,8 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc test"
 
+ruby_add_rdepend "virtual/ruby-ssl"
+
 ruby_add_bdepend "dev-ruby/rake
 	test? ( >=dev-ruby/minitest-4.0:0 )"
 

--- a/dev-ruby/racc/racc-1.4.16-r1.ebuild
+++ b/dev-ruby/racc/racc-1.4.16-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -21,6 +21,8 @@ SLOT="0"
 
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc test"
+
+ruby_add_rdepend "virtual/ruby-ssl"
 
 ruby_add_bdepend "dev-ruby/rake
 	test? ( dev-ruby/minitest )"


### PR DESCRIPTION
If dev-lang/ruby is built with `USE='-ssl'`, then the following error occurs in the install phase:

```
>>> Install racc-1.4.16-r1 into '/tmp/portage/dev-ruby/racc-1.4.16-r1/image' category dev-ruby
 * Running install phase for ruby24 ...
/usr/lib64/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- openssl (LoadError)
        from /usr/lib64/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:92:in `require'
        from /usr/lib64/ruby/site_ruby/2.4.0/rubygems/specification.rb:2426:in `to_ruby'
        from -e:1:in `<main>'
 * ERROR: dev-ruby/racc-1.4.16-r1::gentoo failed (install phase):
 *   Unable to generate gemspec file.
 *
 * Call stack:
 *          isolated-functions.bash, line  333:  called src_install
 *                      environment, line 2890:  called ruby-ng_src_install
 *                      environment, line 2534:  called _ruby_each_implementation 'each_ruby_install'
 *                      environment, line 1508:  called _ruby_invoke_environment 'ruby24' 'each_ruby_install'
 *                      environment, line 1629:  called each_ruby_install
 *                      environment, line 1825:  called each_fakegem_install
 *                      environment, line 1789:  called ruby_fakegem_install_gemspec
 *                      environment, line 2786:  called die
 ```