### PR TITLE
sys-devel/distcc: support python3.7 in 3.3.3

### DIFF
--- a/sys-devel/distcc/distcc-3.3.3.ebuild
+++ b/sys-devel/distcc/distcc-3.3.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7} )
 
 inherit autotools flag-o-matic python-single-r1 systemd \
 	toolchain-funcs user xdg-utils prefix


### PR DESCRIPTION
Very simple update. 

```
[ebuild   R    ] sys-devel/distcc-3.3.3::testworld  USE="-gnome -gssapi -gtk -hardened -ipv6 (-selinux) -xinetd -zeroconf" PYTHON_SINGLE_TARGET="python3_7 -python3_6" PYTHON_TARGETS="python3_7 -python3_6" 0 KiB
```
Succesfully updated my laptop using this in host system that has no python3.6 installed, so it seems to work.