### PR TITLE
app-crypt/acme: Add support for python 3.8

### DIFF
--- a/app-crypt/acme/acme-1.0.0.ebuild
+++ b/app-crypt/acme/acme-1.0.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=(python{2_7,3_6,3_7})
+PYTHON_COMPAT=(python{2_7,3_6,3_7,3_8})
 
 if [[ ${PV} == 9999* ]]; then
 	EGIT_REPO_URI="https://github.com/certbot/certbot.git"


### PR DESCRIPTION
Signed-off-by: Sasha Finkelstein <finka1242@outlook.com>
Package-Manager: Portage-2.3.84, Repoman-2.3.20