### PR TITLE
mail-client/roundcube: POST-UPGRADE UTF-8 files to ASCII

### DIFF
--- a/mail-client/roundcube/files/POST-UPGRADE.txt
+++ b/mail-client/roundcube/files/POST-UPGRADE.txt
@@ -5,7 +5,7 @@ Post-Upgrade Activities
    ./bin/indexcontacts.sh.
 3. When upgrading from version older than 0.6-beta you should make sure your
    folder settings contain a namespace prefix if necessary. For example Courier
-   users should add “INBOX.” prefix to folder names in main configuration file.
+   users should add "INBOX." prefix to folder names in main configuration file.
 4. Check system requirements in INSTALL file.
 5. If you previously installed plugins through composer, update dependencies by
    running:

--- a/mail-client/roundcube/files/POST-UPGRADE_complete.txt
+++ b/mail-client/roundcube/files/POST-UPGRADE_complete.txt
@@ -5,7 +5,7 @@ Post-Upgrade Activities
    ./bin/indexcontacts.sh.
 3. When upgrading from version older than 0.6-beta you should make sure your
    folder settings contain a namespace prefix if necessary. For example Courier
-   users should add “INBOX.” prefix to folder names in main configuration file.
+   users should add "INBOX." prefix to folder names in main configuration file.
 4. Check system requirements in INSTALL file.
 5. Update your database and configurations by running:
    ./bin/update.sh


### PR DESCRIPTION
Just ran `iconv -f utf-8 -t ascii//TRANSLIT` on `files/POST-UPGRADE*`.

Closes: https://bugs.gentoo.org/700466
Closes: https://github.com/gentoo/gentoo/pull/14283
Package-Manager: Portage-2.3.79, Repoman-2.3.16
Signed-off-by: Philippe Chaintreuil <gentoo_bugs_peep@parallaxshift.com>