### PR TITLE
Mask dev-python/pygtkglext and revdeps for removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -32,6 +32,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Andreas Sturmlechner <asturm@gentoo.org> (2020-02-02)
+# Ancient, dead, py27-only, all revdeps masked for removal, bugs 651346, 696974
+# Masked for removal in 30 days.
+dev-python/pygtkglext
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-01-31)
 # py2-only, 8.0 release is broken, upstream appears dormant, bug 707564,
 # blocks dev-python/pybluez py2 cleanup. Use kde-misc/kdeconnect instead.


### PR DESCRIPTION
Overarching goal: https://bugs.gentoo.org/698950