### PR TITLE
net-irc/ngircd: add ~arm keyword

### DIFF
--- a/net-irc/ngircd/ngircd-24.ebuild
+++ b/net-irc/ngircd/ngircd-24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,7 +11,7 @@ SRC_URI="https://arthur.barton.de/pub/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86 ~x64-macos"
+KEYWORDS="amd64 ~arm x86 ~x64-macos"
 IUSE="debug gnutls iconv ident ipv6 libressl pam ssl tcpd test zlib"
 
 RDEPEND="


### PR DESCRIPTION
I use it two years already without any problem on Raspberry PI.