### PR TITLE
dev-python/websocket-client: add ~arm keyword

### DIFF
--- a/dev-python/websocket-client/websocket-client-0.48.0.ebuild
+++ b/dev-python/websocket-client/websocket-client-0.48.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${MY_PN}-${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 x86 ~x64-macos"
+KEYWORDS="amd64 ~arm ~arm64 x86 ~x64-macos"
 IUSE="examples test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
I use it on Raspberry PI without any problem for over a year.