### PR TITLE
net-misc/nyx: Python 3.7 and 3.8 compatibility

### DIFF
--- a/net-misc/nyx/nyx-2.1.0.ebuild
+++ b/net-misc/nyx/nyx-2.1.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=(python{2_7,3_6})
+PYTHON_COMPAT=(python{2_7,3_6,3_7,3_8})
 
 inherit vcs-snapshot distutils-r1
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Craig Andrews <candrews@gentoo.org>