### PR TITLE
sys-apps/util-linux: Python 3.8 compatibility

### DIFF
--- a/sys-apps/util-linux/util-linux-2.35_rc2.ebuild
+++ b/sys-apps/util-linux/util-linux-2.35_rc2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{6,7} )
+PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
 
 inherit toolchain-funcs libtool flag-o-matic bash-completion-r1 usr-ldscript \
 	pam python-r1 multilib-minimal multiprocessing systemd

--- a/sys-apps/util-linux/util-linux-9999.ebuild
+++ b/sys-apps/util-linux/util-linux-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{6,7} )
+PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
 
 inherit toolchain-funcs libtool flag-o-matic bash-completion-r1 usr-ldscript \
 	pam python-r1 multilib-minimal multiprocessing systemd


### PR DESCRIPTION
All tests pass.

Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Craig Andrews <candrews@gentoo.org>