### PR TITLE
dev-libs/libflatarray: Fix QA issue

### DIFF
--- a/dev-libs/libflatarray/libflatarray-0.2.0.ebuild
+++ b/dev-libs/libflatarray/libflatarray-0.2.0.ebuild
@@ -27,7 +27,6 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DWITH_CUDA=$(usex cuda)
-		-DWITH_SILO=false
 	)
 	cmake-utils_src_configure
 }

--- a/dev-libs/libflatarray/libflatarray-0.3.0.ebuild
+++ b/dev-libs/libflatarray/libflatarray-0.3.0.ebuild
@@ -27,7 +27,6 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DWITH_CUDA=$(usex cuda)
-		-DWITH_SILO=false
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
Resolve the following QA warning:

 * One or more CMake variables were not used by the project:
 *   WITH_SILO

There is no WITH_SILO option. Remove it.

Bug: https://bugs.gentoo.org/659392
Signed-off-by: Kurt Kanzenbach <kurt@kmk-computers.de>