### PR TITLE
Update qterminal-0.14.1.ebuild

### DIFF
--- a/x11-terms/qterminal/qterminal-0.14.1.ebuild
+++ b/x11-terms/qterminal/qterminal-0.14.1.ebuild
@@ -22,6 +22,7 @@ SLOT="0"
 BDEPEND=">=dev-util/lxqt-build-tools-0.6.0"
 DEPEND="
 	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
 	dev-qt/qtgui:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5


### PR DESCRIPTION
without qtdbus build fails with message

CMake Error at CMakeLists.txt:27 (find_package):
  By not providing "FindQt5DBus.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Qt5DBus", but
  CMake did not find one.

  Could not find a package configuration file provided by "Qt5DBus"
  (requested version 5.7.1) with any of the following names:

    Qt5DBusConfig.cmake
    qt5dbus-config.cmake

  Add the installation prefix of "Qt5DBus" to CMAKE_PREFIX_PATH or set
  "Qt5DBus_DIR" to a directory containing one of the above files.  If
  "Qt5DBus" provides a separate development package or SDK, be sure it has
  been installed.


-- Configuring incomplete, errors occurred!