### PR TITLE
sci-electronics/eagle: correctly express dependency on OpenSSL 1.0

### DIFF
--- a/sci-electronics/eagle/eagle-7.3.0.ebuild
+++ b/sci-electronics/eagle/eagle-7.3.0.ebuild
@@ -21,7 +21,7 @@ RESTRICT="mirror bindist"
 
 RDEPEND="
 	sys-libs/glibc
-	dev-libs/openssl:0
+	|| ( =dev-libs/openssl-1.0*:0 dev-libs/openssl-compat:1.0.0 )
 	>=sys-libs/zlib-1.2.8-r1
 	>=media-libs/freetype-2.5.0.1
 	>=media-libs/fontconfig-2.10.92

--- a/sci-electronics/eagle/eagle-7.4.0.ebuild
+++ b/sci-electronics/eagle/eagle-7.4.0.ebuild
@@ -21,7 +21,7 @@ RESTRICT="mirror bindist"
 
 RDEPEND="
 	sys-libs/glibc
-	dev-libs/openssl:0
+	|| ( =dev-libs/openssl-1.0*:0 dev-libs/openssl-compat:1.0.0 )
 	>=sys-libs/zlib-1.2.8-r1
 	>=media-libs/freetype-2.5.0.1
 	>=media-libs/fontconfig-2.10.92

--- a/sci-electronics/eagle/eagle-7.6.0.ebuild
+++ b/sci-electronics/eagle/eagle-7.6.0.ebuild
@@ -21,7 +21,7 @@ RESTRICT="mirror bindist"
 
 RDEPEND="
 	sys-libs/glibc
-	dev-libs/openssl:0
+	|| ( =dev-libs/openssl-1.0*:0 dev-libs/openssl-compat:1.0.0 )
 	>=sys-libs/zlib-1.2.8-r1
 	>=media-libs/freetype-2.5.0.1
 	>=media-libs/fontconfig-2.10.92

--- a/sci-electronics/eagle/eagle-7.7.0.ebuild
+++ b/sci-electronics/eagle/eagle-7.7.0.ebuild
@@ -21,7 +21,7 @@ RESTRICT="mirror bindist"
 
 RDEPEND="
 	sys-libs/glibc
-	dev-libs/openssl:0
+	|| ( =dev-libs/openssl-1.0*:0 dev-libs/openssl-compat:1.0.0 )
 	>=sys-libs/zlib-1.2.8-r1
 	>=media-libs/freetype-2.5.0.1
 	>=media-libs/fontconfig-2.10.92


### PR DESCRIPTION
Replace dev-libs/openssl:0 dependency by

	|| ( =dev-libs/openssl-1.0*:0 dev-libs/openssl-compat:1.0.0 )

allowing either to supply lib{crypto,libssl}.so.1.0.0 needed by the eagle binaries.

Bug: https://bugs.gentoo.org/673892
Signed-off-by: Christophe Lermytte (gentoo@lermytte.be)