### PR TITLE
sci-calculators/tiemu: patch to fix abort macro issue with recent gli…

### DIFF
--- a/sci-calculators/tiemu/files/tiemu-3.03-fix-ftbfs-with-customized-abort-function.patch
+++ b/sci-calculators/tiemu/files/tiemu-3.03-fix-ftbfs-with-customized-abort-function.patch
@@ -1,0 +1,14 @@
+Description: Fix FTBFS error: '"abort" passed 1 arguments, but takes just 0'
+Author: Andreas B. Mundt <andi@debian.org> with help from #debian-science (jokva).
+Last-Update: 2018-05-19
+
+--- a/src/core/uae/sysdeps.h
++++ b/src/core/uae/sysdeps.h
+@@ -33,6 +33,7 @@
+ #define _GNU_SOURCE
+ #endif
+ #include <limits.h>
++#include <stdlib.h>
+ 
+ // Make sure that the character types take exactly 1 byte.
+ #if UCHAR_MAX != 0xFF

--- a/sci-calculators/tiemu/tiemu-3.03-r1.ebuild
+++ b/sci-calculators/tiemu/tiemu-3.03-r1.ebuild
@@ -32,6 +32,7 @@ DEPEND="${RDEPEND}
 PATCHES=(
 	"${FILESDIR}"/${P}-remove_depreciated_gtk_calls.patch
 	"${FILESDIR}"/${P}-r2820.patch
+	"${FILESDIR}"/${P}-fix-ftbfs-with-customized-abort-function.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
…bc versions

Looking at the patch I assume the bug was caused by glibc header inclusion cleanup

Patch origin: https://salsa.debian.org/science-team/tiemu/commit/363d3e4125c03e3a7b827d653a846f266e7e3e45

Bug: https://bugs.gentoo.org/66498
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Christophe Lermytte (gentoo@lermytte.be)