### PR TITLE
net-misc/stunnel: Fix PID file ownership

### DIFF
--- a/net-misc/stunnel/files/stunnel-r1
+++ b/net-misc/stunnel/files/stunnel-r1
@@ -21,13 +21,17 @@ get_config() {
 	[ -n "${CHROOT}" ] && CHROOT="--chroot ${CHROOT}"
 	PIDFILE=$(grep "^pid" ${STUNNEL_CONFIGFILE} | sed "s;.*= *;;")
 	PIDFILE=${PIDFILE:-/run/stunnel/${SERVICENAME}.pid}
+	SETUID=$(grep "^setuid" ${STUNNEL_CONFIGFILE} | sed "s;.*= *;;")
+	SETUID=${SETUID:-stunnel}
+	SETGID=$(grep "^setgid" ${STUNNEL_CONFIGFILE} | sed "s;.*= *;;")
+	SETGID=${SETGID:-stunnel}
 }
 
 start() {
 	get_config || return 1
 	checkpath -d -m 0775 -o root:stunnel /run/stunnel
 	if [ "$(dirname ${PIDFILE})" != "/run" ]; then
-		checkpath -d -m 0755 -o stunnel:stunnel -q $(dirname ${PIDFILE})
+		checkpath -d -m 0755 -o ${SETUID}:${SETGID} -q $(dirname ${PIDFILE})
 	fi
 	ebegin "Starting ${SVCNAME}"
 	start-stop-daemon --start --pidfile "${PIDFILE}" ${CHROOT} \


### PR DESCRIPTION
Set ownership of PID file-containing directory appropriately when setuid
and setgid options are configured.

Bug: https://bugs.gentoo.org/687046
Signed-off-by: Wade Cline <wadecline@hotmail.com>