### PR TITLE
sci-libs/libgeodecomp: Fix file collision with libflatarray

### DIFF
--- a/sci-libs/libgeodecomp/files/libgeodecomp-0.4.0-lfa.patch
+++ b/sci-libs/libgeodecomp/files/libgeodecomp-0.4.0-lfa.patch
@@ -1,0 +1,37 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 673017f0..28704461 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -528,18 +528,20 @@ foreach(dir ${LIBDIRS})
+ endforeach(dir)
+ 
+ # install libflatarray, too
+-file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/../lib/libflatarray/src/*.hpp")
+-foreach(i ${HEADERS})
+-  install(FILES ${i} DESTINATION include/libflatarray)
+-endforeach()
+-file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/../lib/libflatarray/src/detail/*.hpp")
+-foreach(i ${HEADERS})
+-  install(FILES ${i} DESTINATION include/libflatarray/detail)
+-endforeach()
+-file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/../lib/libflatarray/src/testbed/*.hpp")
+-foreach(i ${HEADERS})
+-  install(FILES ${i} DESTINATION include/libflatarray/testbed)
+-endforeach()
++if(NOT libflatarray_FOUND)
++  file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/../lib/libflatarray/src/*.hpp")
++  foreach(i ${HEADERS})
++    install(FILES ${i} DESTINATION include/libflatarray)
++  endforeach()
++  file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/../lib/libflatarray/src/detail/*.hpp")
++  foreach(i ${HEADERS})
++    install(FILES ${i} DESTINATION include/libflatarray/detail)
++  endforeach()
++  file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/../lib/libflatarray/src/testbed/*.hpp")
++  foreach(i ${HEADERS})
++    install(FILES ${i} DESTINATION include/libflatarray/testbed)
++  endforeach()
++endif()
+ 
+ # link against the libs we need
+ set(INSTALLER_LINK_FLAGS "-L${CMAKE_INSTALL_PREFIX}/${LIB_DIR} -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/${LIB_DIR} -lgeodecomp ")

--- a/sci-libs/libgeodecomp/libgeodecomp-0.4.0-r1.ebuild
+++ b/sci-libs/libgeodecomp/libgeodecomp-0.4.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils cuda
+inherit cmake cuda
 
 DESCRIPTION="An auto-parallelizing library to speed up computer simulations"
 HOMEPAGE="http://www.libgeodecomp.org"
@@ -14,27 +14,31 @@ LICENSE="Boost-1.0"
 KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="doc mpi cuda opencl opencv silo hpx visit"
 
-RDEPEND=">=dev-libs/boost-1.48"
-DEPEND="${RDEPEND}
+BDEPEND="
 	doc? (
 		app-doc/doxygen
 		app-text/texlive
 		media-gfx/graphviz
-		)
+		)"
+RDEPEND=">=dev-libs/boost-1.48"
+DEPEND="${RDEPEND}
 	hpx? ( sys-cluster/hpx )
 	<=dev-libs/libflatarray-0.2.0
 	mpi? ( virtual/mpi )
 	cuda? ( dev-util/nvidia-cuda-toolkit )
 	opencl? ( virtual/opencl )
 	opencv? ( media-libs/opencv )
-	silo? ( sci-libs/silo )
-	visit? ( sci-visualization/visit )"
+	silo? ( sci-libs/silo )"
 
 S="${WORKDIR}/${P}"
-PATCHES=( "${FILESDIR}/${P}-scotch.patch" "${FILESDIR}/${P}-libdir.patch" )
+PATCHES=(
+	"${FILESDIR}/${P}-scotch.patch"
+	"${FILESDIR}/${P}-libdir.patch"
+	"${FILESDIR}/${P}-lfa.patch"
+)
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 	use cuda && cuda_src_prepare
 }
 
@@ -47,22 +51,23 @@ src_configure() {
 		-DWITH_SILO=$(usex silo)
 		-DWITH_SCOTCH=false
 		-DWITH_HPX=$(usex hpx)
-		-DWITH_VISIT=$(usex visit)
+		-DWITH_VISIT=false
+		-DWITH_TYPEMAPS=false
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_compile() {
-	cmake-utils_src_compile
-	use doc && cmake-utils_src_make doc
+	cmake_src_compile
+	use doc && cmake_build doc
 }
 
 src_install() {
 	DOCS=( README )
 	use doc && HTML_DOCS=( doc/html/* )
-	cmake-utils_src_install
+	cmake_src_install
 }
 
 src_test() {
-	cmake-utils_src_make check
+	cmake_build check
 }


### PR DESCRIPTION
As of commit 948ee21633c0 ("sci-libs/libgeodecomp: added dependency to
libflatarray") libgeodecomp depends on libflatarray which is correct. Therefore,
libgeodecomp uses the system installed libflatarray. However, it also bundles
its own version libflatarray and installs that one unconditionally which results
in the file collision.

Thus, simply don't install the libflatarray files whenever the system one is
used. That resolves the issue.

Bug: https://bugs.gentoo.org/688932
Package-Manager: Portage-2.3.79, Repoman-2.3.16
Signed-off-by: Kurt Kanzenbach <kurt@kmk-computers.de>