### PR TITLE
media-fonts/x11fonts-jmk: fix Updating global fontcache

### DIFF
--- a/media-fonts/x11fonts-jmk/x11fonts-jmk-3.0-r4.ebuild
+++ b/media-fonts/x11fonts-jmk/x11fonts-jmk-3.0-r4.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit font
+
+MY_P="jmk-x11-fonts-${PV}"
+
+DESCRIPTION="This package contains character-cell fonts for use with X"
+HOMEPAGE="http://www.jmknoble.net/fonts/"
+SRC_URI="http://www.pobox.com/~jmknoble/fonts/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~s390 ~sh ~sparc ~x86"
+
+BDEPEND="
+	x11-misc/imake
+	>=x11-apps/mkfontscale-1.2.0
+	x11-apps/bdftopcf"
+
+DOCS=( "ChangeLog" "NEWS" "README" )
+
+PATCHES=( "${FILESDIR}"/gzip.patch )
+
+S="${WORKDIR}/${MY_P}"
+
+src_compile() {
+	xmkmf || die
+	default
+}
+
+src_install() {
+	emake install INSTALL_DIR="${ED}/usr/share/fonts/jmk"
+	einstalldocs
+}


### PR DESCRIPTION
Without inheritance of `font.eclass` the `pkg_postinst()` phase doesn't update
the global fontcache causing media-gfx/gimp sandbox install() phase issue.

The addition of `DOCS` array is required as without it after addition
of `inherit font` the `einstalldocs` functions stops installation
of files listed now in `DOCS` that were installed before.

Closes: https://bugs.gentoo.org/705502
