### PR TITLE
sci-electronics/iverilog: fix overwrite installation bug

### DIFF
--- a/sci-electronics/iverilog/files/iverilog-10.3-file-missing.patch
+++ b/sci-electronics/iverilog/files/iverilog-10.3-file-missing.patch
@@ -1,0 +1,191 @@
+https://bugs.gentoo.org/705412
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -327,6 +327,7 @@ else
+ WIN32_INSTALL = $(bindir)/iverilog-vpi$(suffix)
+ endif
+ 
++.PHONY:  all installdirs $(libdir)/ivl$(suffix)/ivl@EXEEXT@  $(libdir)/ivl$(suffix)/include/constants.vams $(libdir)/ivl$(suffix)/include/disciplines.vams $(includedir)/ivl_target.h $(includedir)/_pli_types.h $(includedir)/sv_vpi_user.h $(includedir)/vpi_user.h $(includedir)/acc_user.h $(includedir)/veriuser.h $(WIN32_INSTALL) $(INSTALL_DOC)
+ install: all installdirs $(libdir)/ivl$(suffix)/ivl@EXEEXT@  $(libdir)/ivl$(suffix)/include/constants.vams $(libdir)/ivl$(suffix)/include/disciplines.vams $(includedir)/ivl_target.h $(includedir)/_pli_types.h $(includedir)/sv_vpi_user.h $(includedir)/vpi_user.h $(includedir)/acc_user.h $(includedir)/veriuser.h $(WIN32_INSTALL) $(INSTALL_DOC)
+ 	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) $@ && ) true
+ 
+--- a/cadpli/Makefile.in
++++ b/cadpli/Makefile.in
+@@ -79,6 +79,7 @@ endif
+ cadpli.vpl: $O ../vvp/libvpi.a ../libveriuser/libveriuser.o
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O ../libveriuser/libveriuser.o $(SYSTEM_VPI_LDFLAGS)
+ 
++.PHONY: all installdirs $(vpidir)/cadpli.vpl
+ install: all installdirs $(vpidir)/cadpli.vpl
+ 
+ $(vpidir)/cadpli.vpl: ./cadpli.vpl
+--- a/driver-vpi/Makefile.in
++++ b/driver-vpi/Makefile.in
+@@ -93,6 +93,7 @@ res.o: res.rc
+ 	$(WINDRES) -i res.rc -o res.o
+ #
+ 
++.PHONY: all installdirs $(bindir)/iverilog-vpi$(suffix)@EXEEXT@
+ install: all installdirs $(bindir)/iverilog-vpi$(suffix)@EXEEXT@
+ 
+ $(bindir)/iverilog-vpi$(suffix)@EXEEXT@: ./iverilog-vpi@EXEEXT@
+--- a/driver/Makefile.in
++++ b/driver/Makefile.in
+@@ -127,6 +127,7 @@ INSTALL_DOC = $(mandir)/man1/iverilog$(suffix).1
+ INSTALL_DOCDIR = $(mandir)/man1
+ endif
+ 
++.PHONY: all installdirs $(bindir)/iverilog$(suffix)@EXEEXT@ $(INSTALL_DOC)
+ install: all installdirs $(bindir)/iverilog$(suffix)@EXEEXT@ $(INSTALL_DOC)
+ 
+ $(bindir)/iverilog$(suffix)@EXEEXT@: ./iverilog@EXEEXT@
+--- a/ivlpp/Makefile.in
++++ b/ivlpp/Makefile.in
+@@ -71,6 +71,7 @@ ivlpp@EXEEXT@: $O
+ lexor.c: $(srcdir)/lexor.lex
+ 	$(LEX) -t $< > $@
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/ivlpp@EXEEXT@
+ install: all installdirs $(libdir)/ivl$(suffix)/ivlpp@EXEEXT@
+ 
+ $(libdir)/ivl$(suffix)/ivlpp@EXEEXT@: ivlpp@EXEEXT@
+--- a/tgt-blif/Makefile.in
++++ b/tgt-blif/Makefile.in
+@@ -81,6 +81,7 @@ endif
+ blif.tgt: $O $(TGTDEPLIBS)
+ 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/blif.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/blif.conf $(libdir)/ivl$(suffix)/blif-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/blif.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/blif.conf $(libdir)/ivl$(suffix)/blif-s.conf
+ 
+ $(libdir)/ivl$(suffix)/blif.tgt: ./blif.tgt
+--- a/tgt-fpga/Makefile.in
++++ b/tgt-fpga/Makefile.in
+@@ -100,6 +100,7 @@ INSTALL_DOC = $(mandir)/man1/iverilog-fpga$(suffix).1
+ INSTALL_DOCDIR = $(mandir)/man1
+ endif
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/fpga.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/fpga.conf $(libdir)/ivl$(suffix)/fpga-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/fpga.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/fpga.conf $(libdir)/ivl$(suffix)/fpga-s.conf
+ 
+ $(libdir)/ivl$(suffix)/fpga.tgt: ./fpga.tgt
+--- a/tgt-null/Makefile.in
++++ b/tgt-null/Makefile.in
+@@ -80,6 +80,7 @@ endif
+ null.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/null.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/null.conf $(libdir)/ivl$(suffix)/null-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/null.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/null.conf $(libdir)/ivl$(suffix)/null-s.conf
+ 
+ $(libdir)/ivl$(suffix)/null.tgt: ./null.tgt
+--- a/tgt-pal/Makefile.in
++++ b/tgt-pal/Makefile.in
+@@ -79,6 +79,7 @@ endif
+ pal.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS) -lipal
+ 
++.PHONY: all installdirs $(libdir)/ivl/pal.tgt
+ install: all installdirs $(libdir)/ivl/pal.tgt
+ 
+ $(libdir)/ivl/pal.tgt: ./pal.tgt
+--- a/tgt-pcb/Makefile.in
++++ b/tgt-pcb/Makefile.in
+@@ -104,6 +104,7 @@ endif
+ pcb.tgt: $O $(TGTDEPLIBS)
+ 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/pcb.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/pcb.conf $(libdir)/ivl$(suffix)/pcb-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/pcb.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/pcb.conf $(libdir)/ivl$(suffix)/pcb-s.conf
+ 
+ $(libdir)/ivl$(suffix)/pcb.tgt: ./pcb.tgt
+--- a/tgt-sizer/Makefile.in
++++ b/tgt-sizer/Makefile.in
+@@ -80,6 +80,7 @@ endif
+ sizer.tgt: $O $(TGTDEPLIBS)
+ 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/sizer.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/sizer.conf $(libdir)/ivl$(suffix)/sizer-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/sizer.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/sizer.conf $(libdir)/ivl$(suffix)/sizer-s.conf
+ 
+ $(libdir)/ivl$(suffix)/sizer.tgt: ./sizer.tgt
+--- a/tgt-stub/Makefile.in
++++ b/tgt-stub/Makefile.in
+@@ -81,6 +81,7 @@ endif
+ stub.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/stub.tgt $(libdir)/ivl$(suffix)/stub.conf $(libdir)/ivl$(suffix)/stub-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/stub.tgt \
+ 	$(libdir)/ivl$(suffix)/stub.conf $(libdir)/ivl$(suffix)/stub-s.conf
+ 
+--- a/tgt-verilog/Makefile.in
++++ b/tgt-verilog/Makefile.in
+@@ -79,6 +79,7 @@ endif
+ verilog.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
++.PHONY: all installdirs $(libdir)/ivl/verilog.tgt $(includedir)/vpi_user.h
+ install: all installdirs $(libdir)/ivl/verilog.tgt \
+ 	$(includedir)/vpi_user.h
+ 
+--- a/tgt-vhdl/Makefile.in
++++ b/tgt-vhdl/Makefile.in
+@@ -89,6 +89,7 @@ stamp-vhdl_config-h: $(srcdir)/vhdl_config.h.in ../config.status
+ 	cd ..; ./config.status --header=tgt-vhdl/vhdl_config.h
+ vhdl_config.h: stamp-vhdl_config-h
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/vhdl.tgt $(libdir)/ivl$(suffix)/vhdl.conf $(libdir)/ivl$(suffix)/vhdl-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/vhdl.tgt $(libdir)/ivl$(suffix)/vhdl.conf \
+ 	$(libdir)/ivl$(suffix)/vhdl-s.conf
+ 
+--- a/tgt-vlog95/Makefile.in
++++ b/tgt-vlog95/Makefile.in
+@@ -80,6 +80,7 @@ endif
+ vlog95.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O -lm $(TGTLDFLAGS)
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/vlog95.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/vlog95.conf $(libdir)/ivl$(suffix)/vlog95-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/vlog95.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/vlog95.conf $(libdir)/ivl$(suffix)/vlog95-s.conf
+ 
+ $(libdir)/ivl$(suffix)/vlog95.tgt: ./vlog95.tgt
+--- a/tgt-vvp/Makefile.in
++++ b/tgt-vvp/Makefile.in
+@@ -103,6 +103,7 @@ stamp-vvp_config-h: $(srcdir)/vvp_config.h.in ../config.status
+ 	cd ..; ./config.status --header=tgt-vvp/vvp_config.h
+ vvp_config.h: stamp-vvp_config-h
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/vvp.tgt $(libdir)/ivl$(suffix)/vvp.conf $(libdir)/ivl$(suffix)/vvp-s.conf
+ install: all installdirs $(libdir)/ivl$(suffix)/vvp.tgt $(libdir)/ivl$(suffix)/vvp.conf $(libdir)/ivl$(suffix)/vvp-s.conf
+ 
+ $(libdir)/ivl$(suffix)/vvp.tgt: ./vvp.tgt
+--- a/vhdlpp/Makefile.in
++++ b/vhdlpp/Makefile.in
+@@ -127,6 +127,7 @@ lexor_keyword.o: lexor_keyword.cc parse.h
+ lexor_keyword.cc: $(srcdir)/lexor_keyword.gperf
+ 	gperf -o -i 7 --ignore-case -C -k 1-4,6,9,$$ -H keyword_hash -N check_identifier -t $(srcdir)/lexor_keyword.gperf > lexor_keyword.cc || (rm -f lexor_keyword.cc ; false)
+ 
++.PHONY: all installdirs $(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@
+ install: all installdirs $(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@
+ 
+ $(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@: vhdlpp@EXEEXT@
+--- a/vpi/Makefile.in
++++ b/vpi/Makefile.in
+@@ -171,6 +171,7 @@ stamp-vpi_config-h: $(srcdir)/vpi_config.h.in ../config.status
+ 	cd ..; ./config.status --header=vpi/vpi_config.h
+ vpi_config.h: stamp-vpi_config-h
+ 
++.PHONY: all installdirs $(vpidir)/system.vpi $(vpidir)/system.sft $(vpidir)/va_math.vpi $(vpidir)/va_math.sft $(vpidir)/v2005_math.vpi $(vpidir)/v2005_math.sft $(vpidir)/v2009.vpi $(vpidir)/v2009.sft $(vpidir)/vhdl_sys.vpi $(vpidir)/vhdl_sys.sft $(vpidir)/vpi_debug.vpi
+ install: all installdirs \
+     $(vpidir)/system.vpi $(vpidir)/system.sft \
+     $(vpidir)/va_math.vpi $(vpidir)/va_math.sft \
+--- a/vvp/Makefile.in
++++ b/vvp/Makefile.in
+@@ -205,6 +205,7 @@ stamp-config-h: $(srcdir)/config.h.in ../config.status
+ 	cd ..; ./config.status --header=vvp/config.h
+ config.h: stamp-config-h
+ 
++.PHONY: all installdirs $(bindir)/vvp$(suffix)@EXEEXT@ $(libdir)/libvpi$(suffix).a $(INSTALL_DOC)
+ install: all installdirs $(bindir)/vvp$(suffix)@EXEEXT@ $(libdir)/libvpi$(suffix).a $(INSTALL_DOC)
+ 
+ $(bindir)/vvp$(suffix)@EXEEXT@: ./vvp@EXEEXT@

--- a/sci-electronics/iverilog/files/iverilog-9999-file-missing.patch
+++ b/sci-electronics/iverilog/files/iverilog-9999-file-missing.patch
@@ -1,0 +1,644 @@
+https://bugs.gentoo.org/705412
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -308,67 +308,62 @@ version_tag.h version:
+ 
+ ifeq (@MINGW32@,yes)
+ ifeq ($(MAN),none)
+-INSTALL_DOC = $(mandir)/man1/iverilog-vpi$(suffix).1
++INSTALL_DOC = installman
+ else
+ ifeq ($(PS2PDF),none)
+-INSTALL_DOC = $(mandir)/man1/iverilog-vpi$(suffix).1
++INSTALL_DOC = installman
+ else
+-INSTALL_DOC = $(prefix)/iverilog-vpi$(suffix).pdf $(mandir)/man1/iverilog-vpi$(suffix).1
++INSTALL_DOC = installpdf installman
+ all: dep iverilog-vpi.pdf
+ endif
+ endif
+ INSTALL_DOCDIR = $(mandir)/man1
+ else
+-INSTALL_DOC = $(mandir)/man1/iverilog-vpi$(suffix).1
++INSTALL_DOC = installman
+ INSTALL_DOCDIR = $(mandir)/man1
+ endif
+ 
+ ifeq (@MINGW32@,yes)
+ WIN32_INSTALL =
+ else
+-WIN32_INSTALL = $(bindir)/iverilog-vpi$(suffix)
++WIN32_INSTALL = installwin32
+ endif
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/ivl@EXEEXT@  $(libdir)/ivl$(suffix)/include/constants.vams $(libdir)/ivl$(suffix)/include/disciplines.vams $(includedir)/ivl_target.h $(includedir)/_pli_types.h $(includedir)/sv_vpi_user.h $(includedir)/vpi_user.h $(includedir)/acc_user.h $(includedir)/veriuser.h $(WIN32_INSTALL) $(INSTALL_DOC)
++install: all installdirs installfiles
+ 	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) $@ && ) true
+ 
+-$(bindir)/iverilog-vpi$(suffix): ./iverilog-vpi installdirs
++F = ./ivl@EXEEXT@ \
++	$(srcdir)/constants.vams \
++	$(srcdir)/disciplines.vams \
++	$(srcdir)/ivl_target.h \
++	./_pli_types.h \
++	$(srcdir)/sv_vpi_user.h \
++	$(srcdir)/vpi_user.h \
++	$(srcdir)/acc_user.h \
++	$(srcdir)/veriuser.h \
++	$(INSTALL_DOC) \
++	$(WIN32_INSTALL)
++
++installwin32: ./iverilog-vpi installdirs
+ 	$(INSTALL_SCRIPT) ./iverilog-vpi "$(DESTDIR)$(bindir)/iverilog-vpi$(suffix)"
+ 
+-$(libdir)/ivl$(suffix)/ivl@EXEEXT@: ./ivl@EXEEXT@ installdirs
+-	$(INSTALL_PROGRAM) ./ivl@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivl@EXEEXT@"
++installman: iverilog-vpi.man installdirs
++	$(INSTALL_DATA) iverilog-vpi.man "$(DESTDIR)$(mandir)/man1/iverilog-vpi$(suffix).1"
+ 
+-$(libdir)/ivl$(suffix)/include/constants.vams: $(srcdir)/constants.vams installdirs
+-	$(INSTALL_DATA) $(srcdir)/constants.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/constants.vams"
++installpdf: iverilog-vpi.pdf installdirs
++	$(INSTALL_DATA) iverilog-vpi.pdf "$(DESTDIR)$(prefix)/iverilog-vpi$(suffix).pdf"
+ 
+-$(libdir)/ivl$(suffix)/include/disciplines.vams: $(srcdir)/disciplines.vams installdirs
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./ivl@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivl@EXEEXT@"
++	$(INSTALL_DATA) $(srcdir)/constants.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/constants.vams"
+ 	$(INSTALL_DATA) $(srcdir)/disciplines.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/disciplines.vams"
+-
+-$(includedir)/ivl_target.h: $(srcdir)/ivl_target.h installdirs
+ 	$(INSTALL_DATA) $(srcdir)/ivl_target.h "$(DESTDIR)$(includedir)/ivl_target.h"
+-
+-$(includedir)/_pli_types.h: _pli_types.h installdirs
+-	$(INSTALL_DATA) $< "$(DESTDIR)$(includedir)/_pli_types.h"
+-
+-$(includedir)/sv_vpi_user.h: $(srcdir)/sv_vpi_user.h installdirs
++	$(INSTALL_DATA) ./_pli_types.h "$(DESTDIR)$(includedir)/_pli_types.h"
+ 	$(INSTALL_DATA) $(srcdir)/sv_vpi_user.h "$(DESTDIR)$(includedir)/sv_vpi_user.h"
+-
+-$(includedir)/vpi_user.h: $(srcdir)/vpi_user.h installdirs
+ 	$(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
+-
+-$(includedir)/acc_user.h: $(srcdir)/acc_user.h installdirs
+ 	$(INSTALL_DATA) $(srcdir)/acc_user.h "$(DESTDIR)$(includedir)/acc_user.h"
+-
+-$(includedir)/veriuser.h: $(srcdir)/veriuser.h installdirs
+ 	$(INSTALL_DATA) $(srcdir)/veriuser.h "$(DESTDIR)$(includedir)/veriuser.h"
+ 
+-$(mandir)/man1/iverilog-vpi$(suffix).1: iverilog-vpi.man installdirs
+-	$(INSTALL_DATA) iverilog-vpi.man "$(DESTDIR)$(mandir)/man1/iverilog-vpi$(suffix).1"
+-
+-$(prefix)/iverilog-vpi$(suffix).pdf: iverilog-vpi.pdf installdirs
+-	$(INSTALL_DATA) iverilog-vpi.pdf "$(DESTDIR)$(prefix)/iverilog-vpi$(suffix).pdf"
+-
+-
+ installdirs: $(srcdir)/mkinstalldirs
+ 	$(srcdir)/mkinstalldirs "$(DESTDIR)$(bindir)" \
+ 	    "$(DESTDIR)$(includedir)" \
+--- a/cadpli/Makefile.in
++++ b/cadpli/Makefile.in
+@@ -79,9 +79,11 @@ endif
+ cadpli.vpl: $O ../vpi/libvpi.a ../libveriuser/libveriuser.o
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O ../libveriuser/libveriuser.o $(SYSTEM_VPI_LDFLAGS)
+ 
+-install: all installdirs $(vpidir)/cadpli.vpl
++install: all installdirs installfiles
+ 
+-$(vpidir)/cadpli.vpl: ./cadpli.vpl
++F = ./cadpli.vpl
++
++installfiles: $(F) installdirs
+ 	$(INSTALL_PROGRAM) ./cadpli.vpl "$(DESTDIR)$(vpidir)/cadpli.vpl"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+--- a/driver-vpi/Makefile.in
++++ b/driver-vpi/Makefile.in
+@@ -94,9 +94,11 @@ res.o: res.rc
+ 	$(WINDRES) -i res.rc -o res.o
+ #
+ 
+-install: all installdirs $(bindir)/iverilog-vpi$(suffix)@EXEEXT@
++install: all installdirs installfiles
+ 
+-$(bindir)/iverilog-vpi$(suffix)@EXEEXT@: ./iverilog-vpi@EXEEXT@
++F = ./iverilog-vpi@EXEEXT@
++
++installfiles: $(F) installdirs
+ 	$(INSTALL_PROGRAM) ./iverilog-vpi@EXEEXT@ "$(bindir)/iverilog-vpi$(suffix)@EXEEXT@"
+ ifeq (@WIN32@,yes)
+ ifneq ($(HOSTCC),$(CC))
+--- a/driver/Makefile.in
++++ b/driver/Makefile.in
+@@ -112,32 +112,35 @@ iverilog.pdf: iverilog.ps
+ 
+ ifeq (@MINGW32@,yes)
+ ifeq ($(MAN),none)
+-INSTALL_DOC = $(mandir)/man1/iverilog$(suffix).1
++INSTALL_DOC = installman
+ else
+ ifeq ($(PS2PDF),none)
+-INSTALL_DOC = $(mandir)/man1/iverilog$(suffix).1
++INSTALL_DOC = installman
+ else
+-INSTALL_DOC = $(prefix)/iverilog$(suffix).pdf $(mandir)/man1/iverilog$(suffix).1
++INSTALL_DOC = installpdf installman
+ all: iverilog.pdf
+ endif
+ endif
+ INSTALL_DOCDIR = $(mandir)/man1
+ else
+-INSTALL_DOC = $(mandir)/man1/iverilog$(suffix).1
++INSTALL_DOC = installman
+ INSTALL_DOCDIR = $(mandir)/man1
+ endif
+ 
+-install: all installdirs $(bindir)/iverilog$(suffix)@EXEEXT@ $(INSTALL_DOC)
++install: all installdirs installfiles
+ 
+-$(bindir)/iverilog$(suffix)@EXEEXT@: ./iverilog@EXEEXT@
+-	$(INSTALL_PROGRAM) ./iverilog@EXEEXT@ "$(DESTDIR)$(bindir)/iverilog$(suffix)@EXEEXT@"
++F = ./iverilog@EXEEXT@ \
++	$(INSTALL_DOC)
+ 
+-$(mandir)/man1/iverilog$(suffix).1: iverilog.man
++installman: iverilog.man installdirs
+ 	$(INSTALL_DATA) iverilog.man "$(DESTDIR)$(mandir)/man1/iverilog$(suffix).1"
+ 
+-$(prefix)/iverilog$(suffix).pdf: iverilog.pdf
++installpdf: iverilog.pdf installdirs
+ 	$(INSTALL_DATA) iverilog.pdf "$(DESTDIR)$(prefix)/iverilog$(suffix).pdf"
+ 
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./iverilog@EXEEXT@ "$(DESTDIR)$(bindir)/iverilog$(suffix)@EXEEXT@"
++
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(INSTALL_DOCDIR)"
+ 
+--- a/ivlpp/Makefile.in
++++ b/ivlpp/Makefile.in
+@@ -71,9 +71,11 @@ ivlpp@EXEEXT@: $O
+ lexor.c: $(srcdir)/lexor.lex
+ 	$(LEX) -t $< > $@
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/ivlpp@EXEEXT@
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/ivlpp@EXEEXT@: ivlpp@EXEEXT@
++F = ivlpp@EXEEXT@
++
++installfiles: $(F) installdirs
+ 	$(INSTALL_PROGRAM) ./ivlpp@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivlpp@EXEEXT@"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+--- a/libveriuser/Makefile.in
++++ b/libveriuser/Makefile.in
+@@ -103,9 +103,11 @@ libveriuser.a: libveriuser.o
+ 	$(CC) $(CPPFLAGS) $(CFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o
+ 	mv $*.d dep
+ 
+-install:: all installdirs $(libdir)/libveriuser$(suffix).a $(INSTALL32)
++install:: all installdirs installfiles
+ 
+-$(libdir)/libveriuser$(suffix).a: ./libveriuser.a
++F = ./libveriuser.a
++
++installfiles: $(F) installdirs
+ 	$(INSTALL_DATA) ./libveriuser.a "$(DESTDIR)$(libdir)/libveriuser$(suffix).a"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+--- a/tgt-blif/Makefile.in
++++ b/tgt-blif/Makefile.in
+@@ -83,18 +83,17 @@ endif
+ blif.tgt: $O $(TGTDEPLIBS)
+ 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/blif.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/blif.conf $(libdir)/ivl$(suffix)/blif-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/blif.tgt: ./blif.tgt
+-	$(INSTALL_PROGRAM) ./blif.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/blif.tgt"
++F = ./blif.tgt \
++	$(srcdir)/blif.conf \
++	$(srcdir)/blif-s.conf
+ 
+-$(libdir)/ivl$(suffix)/blif.conf: $(srcdir)/blif.conf
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./blif.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/blif.tgt"
+ 	$(INSTALL_DATA) $(srcdir)/blif.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/blif.conf"
+-
+-$(libdir)/ivl$(suffix)/blif-s.conf: $(srcdir)/blif-s.conf
+ 	$(INSTALL_DATA) $(srcdir)/blif-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/blif-s.conf"
+ 
+-
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"
+ 
+--- a/tgt-fpga/Makefile.in
++++ b/tgt-fpga/Makefile.in
+@@ -93,38 +93,38 @@ iverilog-fpga.pdf: iverilog-fpga.ps
+ 	ps2pdf iverilog-fpga.ps iverilog-fpga.pdf
+ 
+ ifeq (@WIN32@,yes)
+-INSTALL_DOC = $(prefix)/iverilog-fpga$(suffix).pdf $(mandir)/man1/iverilog-fpga$(suffix).1
++INSTALL_DOC = installpdf installman
+ INSTALL_DOCDIR = $(mandir)/man1
+ all: iverilog-fpga.pdf
+ else
+-INSTALL_DOC = $(mandir)/man1/iverilog-fpga$(suffix).1
++INSTALL_DOC = installman
+ INSTALL_DOCDIR = $(mandir)/man1
+ endif
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/fpga.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/fpga.conf $(libdir)/ivl$(suffix)/fpga-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/fpga.tgt: ./fpga.tgt
+-	$(INSTALL_PROGRAM) ./fpga.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
+-
+-$(libdir)/ivl$(suffix)/fpga.conf: $(srcdir)/fpga.conf
+-	$(INSTALL_DATA) $(srcdir)/fpga.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.conf"
+-
+-$(libdir)/ivl$(suffix)/fpga-s.conf: $(srcdir)/fpga-s.conf
+-	$(INSTALL_DATA) $(srcdir)/fpga-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga-s.conf"
++F = ./fpga.tgt \
++	$(srcdir)/fpga.conf \
++	$(srcdir)/fpga-s.conf \
++	$(INSTALL_DOC)
+ 
+-
+-$(mandir)/man1/iverilog-fpga$(suffix).1: $(srcdir)/iverilog-fpga.man
++installman: $(srcdir)/iverilog-fpga.man installdirs
+ 	$(INSTALL_DATA) $(srcdir)/iverilog-fpga.man "$(DESTDIR)$(mandir)/man1/iverilog-fpga$(suffix).1"
+ 
+-$(prefix)/iverilog-fpga$(suffix).pdf: iverilog-fpga.pdf
++installpdf: iverilog-fpga.pdf installdirs
+ 	$(INSTALL_DATA) iverilog-fpga.pdf "$(DESTDIR)$(prefix)/iverilog-fpga$(suffix).pdf"
+ 
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./fpga.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
++	$(INSTALL_DATA) $(srcdir)/fpga.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.conf"
++	$(INSTALL_DATA) $(srcdir)/fpga-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga-s.conf"
++
+ installdirs: $(srcdir)/../mkinstalldirs
+-	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"
++	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)" "$(DESTDIR)$(INSTALL_DOCDIR)"
+ 
+ uninstall:
+ 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
+-	rm -f "$(DESTDIR)$(INSTALL_DOC)"
++	rm -f "$(DESTDIR)$(prefix)/iverilog-fpga$(suffix).pdf" "$(DESTDIR)$(mandir)/man1/iverilog-fpga$(suffix).1"
+ 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga-s.conf"
+ 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.conf"
+ 
+--- a/tgt-null/Makefile.in
++++ b/tgt-null/Makefile.in
+@@ -81,18 +81,17 @@ endif
+ null.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/null.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/null.conf $(libdir)/ivl$(suffix)/null-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/null.tgt: ./null.tgt
+-	$(INSTALL_PROGRAM) ./null.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/null.tgt"
++F = ./null.tgt \
++	$(srcdir)/null.conf \
++	$(srcdir)/null-s.conf
+ 
+-$(libdir)/ivl$(suffix)/null.conf: $(srcdir)/null.conf
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./null.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/null.tgt"
+ 	$(INSTALL_DATA) $(srcdir)/null.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/null.conf"
+-
+-$(libdir)/ivl$(suffix)/null-s.conf: $(srcdir)/null-s.conf
+ 	$(INSTALL_DATA) $(srcdir)/null-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/null-s.conf"
+ 
+-
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"
+ 
+--- a/tgt-pal/Makefile.in
++++ b/tgt-pal/Makefile.in
+@@ -80,11 +80,12 @@ endif
+ pal.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS) -lipal
+ 
+-install: all installdirs $(libdir)/ivl/pal.tgt
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl/pal.tgt: ./pal.tgt
+-	$(INSTALL_PROGRAM) ./pal.tgt "$(DESTDIR)$(libdir)/ivl/pal.tgt"
++F = ./pal.tgt
+ 
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./pal.tgt "$(DESTDIR)$(libdir)/ivl/pal.tgt"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)/$(libdir)/ivl"
+--- a/tgt-pcb/Makefile.in
++++ b/tgt-pcb/Makefile.in
+@@ -105,18 +105,17 @@ endif
+ pcb.tgt: $O $(TGTDEPLIBS)
+ 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/pcb.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/pcb.conf $(libdir)/ivl$(suffix)/pcb-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/pcb.tgt: ./pcb.tgt
+-	$(INSTALL_PROGRAM) ./pcb.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb.tgt"
++F = ./pcb.tgt \
++	$(srcdir)/pcb.conf \
++	$(srcdir)/pcb-s.conf
+ 
+-$(libdir)/ivl$(suffix)/pcb.conf: $(srcdir)/pcb.conf
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./pcb.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb.tgt"
+ 	$(INSTALL_DATA) $(srcdir)/pcb.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb.conf"
+-
+-$(libdir)/ivl$(suffix)/pcb-s.conf: $(srcdir)/pcb-s.conf
+ 	$(INSTALL_DATA) $(srcdir)/pcb-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb-s.conf"
+ 
+-
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"
+ 
+--- a/tgt-sizer/Makefile.in
++++ b/tgt-sizer/Makefile.in
+@@ -81,18 +81,17 @@ endif
+ sizer.tgt: $O $(TGTDEPLIBS)
+ 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/sizer.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/sizer.conf $(libdir)/ivl$(suffix)/sizer-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/sizer.tgt: ./sizer.tgt
+-	$(INSTALL_PROGRAM) ./sizer.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer.tgt"
++F = ./sizer.tgt \
++	$(srcdir)/sizer.conf \
++	$(srcdir)/sizer-s.conf
+ 
+-$(libdir)/ivl$(suffix)/sizer.conf: $(srcdir)/sizer.conf
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./sizer.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer.tgt"
+ 	$(INSTALL_DATA) $(srcdir)/sizer.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer.conf"
+-
+-$(libdir)/ivl$(suffix)/sizer-s.conf: $(srcdir)/sizer-s.conf
+ 	$(INSTALL_DATA) $(srcdir)/sizer-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer-s.conf"
+ 
+-
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"
+ 
+--- a/tgt-stub/Makefile.in
++++ b/tgt-stub/Makefile.in
+@@ -82,17 +82,16 @@ endif
+ stub.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/stub.tgt \
+-	$(libdir)/ivl$(suffix)/stub.conf $(libdir)/ivl$(suffix)/stub-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/stub.tgt: ./stub.tgt
+-	$(INSTALL_PROGRAM) ./stub.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.tgt"
+-
+-$(libdir)/ivl$(suffix)/stub.conf: stub.conf
+-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.conf"
++F = ./stub.tgt \
++	./stub.conf \
++	./stub-s.conf
+ 
+-$(libdir)/ivl$(suffix)/stub-s.conf: stub-s.conf
+-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/stub-s.conf"
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./stub.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.tgt"
++	$(INSTALL_DATA) ./stub.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.conf"
++	$(INSTALL_DATA) ./stub-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub-s.conf"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"
+--- a/tgt-verilog/Makefile.in
++++ b/tgt-verilog/Makefile.in
+@@ -80,12 +80,14 @@ endif
+ verilog.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
+ 
+-install: all installdirs $(libdir)/ivl/verilog.tgt \
+-	$(includedir)/vpi_user.h
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl/verilog.tgt: ./verilog.tgt
+-	$(INSTALL_PROGRAM) ./verilog.tgt "$(DESTDIR)$(libdir)/ivl/verilog.tgt"
++F = ./verilog.tgt \
++	$(srcdir)/vpi_user.h
+ 
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./verilog.tgt "$(DESTDIR)$(libdir)/ivl/verilog.tgt"
++	$(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl"
+--- a/tgt-vhdl/Makefile.in
++++ b/tgt-vhdl/Makefile.in
+@@ -90,17 +90,16 @@ stamp-vhdl_config-h: $(srcdir)/vhdl_config.h.in ../config.status
+ 	cd ..; ./config.status --header=tgt-vhdl/vhdl_config.h
+ vhdl_config.h: stamp-vhdl_config-h
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/vhdl.tgt $(libdir)/ivl$(suffix)/vhdl.conf \
+-	$(libdir)/ivl$(suffix)/vhdl-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/vhdl.tgt: ./vhdl.tgt
+-	$(INSTALL_PROGRAM) ./vhdl.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.tgt"
+-
+-$(libdir)/ivl$(suffix)/vhdl.conf: vhdl.conf
+-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.conf"
++F = ./vhdl.tgt \
++	./vhdl.conf \
++	./vhdl-s.conf
+ 
+-$(libdir)/ivl$(suffix)/vhdl-s.conf: vhdl-s.conf
+-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl-s.conf"
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./vhdl.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.tgt"
++	$(INSTALL_DATA) ./vhdl.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.conf"
++	$(INSTALL_DATA) ./vhdl-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl-s.conf"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"
+--- a/tgt-vlog95/Makefile.in
++++ b/tgt-vlog95/Makefile.in
+@@ -81,18 +81,17 @@ endif
+ vlog95.tgt: $O $(TGTDEPLIBS)
+ 	$(CC) @shared@ $(LDFLAGS) -o $@ $O -lm $(TGTLDFLAGS)
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/vlog95.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/vlog95.conf $(libdir)/ivl$(suffix)/vlog95-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/vlog95.tgt: ./vlog95.tgt
+-	$(INSTALL_PROGRAM) ./vlog95.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95.tgt"
++F = ./vlog95.tgt \
++	$(srcdir)/vlog95.conf \
++	$(srcdir)/vlog95-s.conf
+ 
+-$(libdir)/ivl$(suffix)/vlog95.conf: $(srcdir)/vlog95.conf
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./vlog95.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95.tgt"
+ 	$(INSTALL_DATA) $(srcdir)/vlog95.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95.conf"
+-
+-$(libdir)/ivl$(suffix)/vlog95-s.conf: $(srcdir)/vlog95-s.conf
+ 	$(INSTALL_DATA) $(srcdir)/vlog95-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95-s.conf"
+ 
+-
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"
+ 
+--- a/tgt-vvp/Makefile.in
++++ b/tgt-vvp/Makefile.in
+@@ -104,17 +104,16 @@ stamp-vvp_config-h: $(srcdir)/vvp_config.h.in ../config.status
+ 	cd ..; ./config.status --header=tgt-vvp/vvp_config.h
+ vvp_config.h: stamp-vvp_config-h
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/vvp.tgt $(libdir)/ivl$(suffix)/vvp.conf $(libdir)/ivl$(suffix)/vvp-s.conf
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/vvp.tgt: ./vvp.tgt
+-	$(INSTALL_PROGRAM) ./vvp.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.tgt"
+-
+-$(libdir)/ivl$(suffix)/vvp.conf: vvp.conf
+-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.conf"
+-
+-$(libdir)/ivl$(suffix)/vvp-s.conf: vvp-s.conf
+-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp-s.conf"
++F = ./vvp.tgt \
++	./vvp.conf \
++	./vvp-s.conf
+ 
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./vvp.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.tgt"
++	$(INSTALL_DATA) ./vvp.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.conf"
++	$(INSTALL_DATA) ./vvp-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp-s.conf"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"
+--- a/vhdlpp/Makefile.in
++++ b/vhdlpp/Makefile.in
+@@ -127,9 +127,11 @@ lexor_keyword.o: lexor_keyword.cc parse.h
+ lexor_keyword.cc: $(srcdir)/lexor_keyword.gperf
+ 	gperf -o -i 7 --ignore-case -C -k 1-4,6,9,$$ -H keyword_hash -N check_identifier -t $(srcdir)/lexor_keyword.gperf > lexor_keyword.cc || (rm -f lexor_keyword.cc ; false)
+ 
+-install: all installdirs $(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@
++install: all installdirs installfiles
+ 
+-$(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@: vhdlpp@EXEEXT@
++F = vhdlpp@EXEEXT@
++
++installfiles: $(F) installdirs
+ 	$(INSTALL_PROGRAM) ./vhdlpp@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+--- a/vpi/Makefile.in
++++ b/vpi/Makefile.in
+@@ -187,38 +187,25 @@ stamp-vpi_config-h: $(srcdir)/vpi_config.h.in ../config.status
+ 	cd ..; ./config.status --header=vpi/vpi_config.h
+ vpi_config.h: stamp-vpi_config-h
+ 
+-install: all installdirs \
+-    $(libdir)/libvpi$(suffix).a \
+-    $(vpidir)/system.vpi \
+-    $(vpidir)/va_math.vpi \
+-    $(vpidir)/v2005_math.vpi \
+-    $(vpidir)/v2009.vpi \
+-    $(vpidir)/vhdl_sys.vpi \
+-    $(vpidir)/vhdl_textio.vpi \
+-    $(vpidir)/vpi_debug.vpi
+-
+-$(libdir)/libvpi$(suffix).a : ./libvpi.a
+-	$(INSTALL_DATA) libvpi.a "$(DESTDIR)$(libdir)/libvpi$(suffix).a"
+-
+-$(vpidir)/system.vpi: ./system.vpi
++install: all installdirs installfiles
++
++F = ./libvpi.a \
++	./system.vpi \
++	./va_math.vpi \
++	./v2005_math.vpi \
++	./v2009.vpi \
++	./vhdl_sys.vpi \
++	./vhdl_textio.vpi \
++	./vpi_debug.vpi
++
++installfiles: $(F) installdirs
++	$(INSTALL_DATA) ./libvpi.a "$(DESTDIR)$(libdir)/libvpi$(suffix).a"
+ 	$(INSTALL_PROGRAM) ./system.vpi "$(DESTDIR)$(vpidir)/system.vpi"
+-
+-$(vpidir)/va_math.vpi: ./va_math.vpi
+ 	$(INSTALL_PROGRAM) ./va_math.vpi "$(DESTDIR)$(vpidir)/va_math.vpi"
+-
+-$(vpidir)/v2005_math.vpi: ./v2005_math.vpi
+ 	$(INSTALL_PROGRAM) ./v2005_math.vpi "$(DESTDIR)$(vpidir)/v2005_math.vpi"
+-
+-$(vpidir)/v2009.vpi: ./v2009.vpi
+ 	$(INSTALL_PROGRAM) ./v2009.vpi "$(DESTDIR)$(vpidir)/v2009.vpi"
+-
+-$(vpidir)/vhdl_sys.vpi: ./vhdl_sys.vpi
+ 	$(INSTALL_PROGRAM) ./vhdl_sys.vpi "$(DESTDIR)$(vpidir)/vhdl_sys.vpi"
+-
+-$(vpidir)/vhdl_textio.vpi: ./vhdl_textio.vpi
+ 	$(INSTALL_PROGRAM) ./vhdl_textio.vpi "$(DESTDIR)$(vpidir)/vhdl_textio.vpi"
+-
+-$(vpidir)/vpi_debug.vpi: ./vpi_debug.vpi
+ 	$(INSTALL_PROGRAM) ./vpi_debug.vpi "$(DESTDIR)$(vpidir)/vpi_debug.vpi"
+ 
+ installdirs: $(srcdir)/../mkinstalldirs
+--- a/vvp/Makefile.in
++++ b/vvp/Makefile.in
+@@ -162,18 +162,18 @@ vvp.pdf: vvp.ps
+ 
+ ifeq (@MINGW32@,yes)
+ ifeq ($(MAN),none)
+-INSTALL_DOC = $(mandir)/man1/vvp$(suffix).1
++INSTALL_DOC = installman
+ else
+ ifeq ($(PS2PDF),none)
+-INSTALL_DOC = $(mandir)/man1/vvp$(suffix).1
++INSTALL_DOC = installman
+ else
+-INSTALL_DOC = $(prefix)/vvp$(suffix).pdf $(mandir)/man1/vvp$(suffix).1
++INSTALL_DOC = installpdf installman
+ all: vvp.pdf
+ endif
+ endif
+ INSTALL_DOCDIR = $(mandir)/man1
+ else
+-INSTALL_DOC = $(mandir)/man1/vvp$(suffix).1
++INSTALL_DOC = installman
+ INSTALL_DOCDIR = $(mandir)/man1
+ endif
+ 
+@@ -182,17 +182,19 @@ stamp-config-h: $(srcdir)/config.h.in ../config.status
+ 	cd ..; ./config.status --header=vvp/config.h
+ config.h: stamp-config-h
+ 
+-install: all installdirs $(bindir)/vvp$(suffix)@EXEEXT@ $(INSTALL_DOC)
++install: all installdirs installfiles
+ 
+-$(bindir)/vvp$(suffix)@EXEEXT@: ./vvp@EXEEXT@
+-	$(INSTALL_PROGRAM) ./vvp@EXEEXT@ "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
++F = ./vvp@EXEEXT@ $(INSTALL_DOC)
+ 
+-$(mandir)/man1/vvp$(suffix).1: vvp.man
++installman: vvp.man installdirs
+ 	$(INSTALL_DATA) vvp.man "$(DESTDIR)$(mandir)/man1/vvp$(suffix).1"
+ 
+-$(prefix)/vvp$(suffix).pdf: vvp.pdf
++installpdf: vvp.pdf installdirs
+ 	$(INSTALL_DATA) vvp.pdf "$(DESTDIR)$(prefix)/vvp$(suffix).pdf"
+ 
++installfiles: $(F) installdirs
++	$(INSTALL_PROGRAM) ./vvp@EXEEXT@ "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
++
+ installdirs: $(srcdir)/../mkinstalldirs
+ 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)" "$(DESTDIR)$(INSTALL_DOCDIR)"
+ 

--- a/sci-electronics/iverilog/iverilog-10.3.ebuild
+++ b/sci-electronics/iverilog/iverilog-10.3.ebuild
@@ -38,6 +38,10 @@ DEPEND="
 	${RDEPEND}
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-10.3-file-missing.patch #705412
+)
+
 src_prepare() {
 	default
 

--- a/sci-electronics/iverilog/iverilog-9999.ebuild
+++ b/sci-electronics/iverilog/iverilog-9999.ebuild
@@ -38,6 +38,10 @@ DEPEND="
 	${RDEPEND}
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-9999-file-missing.patch #705412
+)
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
The upstream's Makefile used a very unusual
installation method. It may cause overwrite
installation bug.
A fix pull request have been send to upstream
https://github.com/steveicarus/iverilog/pull/300
This ebuild fix will update all files' timestamp
before compile. This have tested on my overlay:
https://github.com/vowstar/vowstar-overlay

Closes: https://bugs.gentoo.org/705412
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Huang Rui <vowstar@gmail.com>