### PR TITLE
sci-electronics/iverilog: fix overwrite installation bug of iverilog-9999

### DIFF
--- a/sci-electronics/iverilog/iverilog-9999.ebuild
+++ b/sci-electronics/iverilog/iverilog-9999.ebuild
@@ -56,6 +56,9 @@ src_prepare() {
 
 src_install() {
 	local DOCS=( *.txt )
+	# During overwrite installation, old timestamp caused file missing,
+	# https://bugs.gentoo.org/705412
+	find . -exec touch {} + || die
 	# Default build fails with parallel jobs,
 	# https://github.com/steveicarus/iverilog/pull/294
 	emake installdirs DESTDIR="${D}"


### PR DESCRIPTION
The upstream's Makefile used a very unusual
installation method. It may cause overwrite
installation bug.
A fix pull request have been send to upstream
steveicarus/iverilog#300
This ebuild fix will update all files' timestamp
before compile. This have tested on my overlay:
https://github.com/vowstar/vowstar-overlay

Closes: https://bugs.gentoo.org/705412
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Huang Rui <vowstar@gmail.com>