### PR TITLE
ros-catkin.eclass: Fix EAPI-7 support, support cmake.eclass

### DIFF
--- a/dev-ros/rosbag/rosbag-9999.ebuild
+++ b/dev-ros/rosbag/rosbag-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 ROS_REPO_URI="https://github.com/ros/ros_comm"
 KEYWORDS="~amd64 ~arm"

--- a/eclass/ros-catkin.eclass
+++ b/eclass/ros-catkin.eclass
@@ -12,11 +12,21 @@
 # Provides function for building ROS packages on Gentoo.
 # It supports selectively building messages, multi-python installation, live ebuilds (git only).
 
+# @ECLASS-VARIABLE: CMAKE_ECLASS
+# @INTERNAL
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# Set to "cmake-utils" for EAPI 5 and 6, "cmake" for EAPI-7.
+
 case "${EAPI:-0}" in
 	0|1|2|3|4)
 		die "EAPI='${EAPI}' is not supported"
 		;;
+	[56])
+		CMAKE_ECLASS=cmake-utils
+		;;
 	*)
+		CMAKE_ECLASS=cmake
 		;;
 esac
 
@@ -51,7 +61,7 @@ fi
 # most certainly be something pulling python anyway.
 PYTHON_COMPAT=( python3_6 )
 
-inherit ${SCM} python-r1 cmake-utils flag-o-matic
+inherit ${SCM} python-r1 ${CMAKE_ECLASS} flag-o-matic
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
@@ -134,13 +144,13 @@ HOMEPAGE="https://wiki.ros.org/${PN} ${ROS_REPO_URI}"
 
 # @FUNCTION: ros-catkin_src_prepare
 # @DESCRIPTION:
-# Calls cmake-utils_src_prepare (so that PATCHES array is handled there) and initialises the workspace
+# Calls cmake_src_prepare (so that PATCHES array is handled there) and initialises the workspace
 # by installing a recursive CMakeLists.txt to handle bundles.
 ros-catkin_src_prepare() {
 	# If no multibuild, just use cmake IN_SOURCE support
 	[ -n "${CATKIN_IN_SOURCE_BUILD}" ] && export CMAKE_IN_SOURCE_BUILD=yes
 
-	cmake-utils_src_prepare
+	${CMAKE_ECLASS}_src_prepare
 
 	if [ ! -f "${S}/CMakeLists.txt" ] ; then
 		catkin_init_workspace || die
@@ -187,7 +197,7 @@ ros-catkin_src_configure() {
 	fi
 
 	local mycmakeargs=(
-		"$(cmake-utils_use test CATKIN_ENABLE_TESTING)"
+		"-DCATKIN_ENABLE_TESTING=$(usex test)"
 		"-DCATKIN_BUILD_BINARY_PACKAGE=ON"
 		"-DCATKIN_PREFIX_PATH=${SYSROOT:-${EROOT}}/usr"
 		"${mycatkincmakeargs[@]}"
@@ -202,7 +212,7 @@ ros-catkin_src_configure() {
 		export CMAKE_USE_DIR="${BUILD_DIR}"
 	fi
 
-	cmake-utils_src_configure "${@}"
+	${CMAKE_ECLASS}_src_configure "${@}"
 }
 
 # @FUNCTION: ros-catkin_src_compile
@@ -210,7 +220,7 @@ ros-catkin_src_configure() {
 # Builds a catkin-based package.
 ros-catkin_src_compile() {
 	ros-catkin_python_setup
-	cmake-utils_src_compile "${@}"
+	${CMAKE_ECLASS}_src_compile "${@}"
 }
 
 # @FUNCTION: ros-catkin_src_test
@@ -226,8 +236,13 @@ ros-catkin_src_test() {
 		einfo "Regenerating setup_cached.sh for tests"
 		${PYTHON:-python} catkin_generated/generate_cached_setup.py || die
 	fi
-	nonfatal cmake-utils_src_make tests
-	cmake-utils_src_test "${@}"
+
+	if [[ ${CMAKE_ECLASS} = cmake-utils ]]; then
+		nonfatal cmake-utils_src_make tests
+	else
+		nonfatal cmake_build tests
+	fi
+	${CMAKE_ECLASS}_src_test "${@}"
 }
 
 # @FUNCTION: ros-catkin_src_install
@@ -240,7 +255,7 @@ ros-catkin_src_install() {
 		export CMAKE_USE_DIR="${BUILD_DIR}"
 	fi
 
-	cmake-utils_src_install "${@}"
+	${CMAKE_ECLASS}_src_install "${@}"
 	if [ ! -f "${T}/.catkin_python_symlinks_generated" -a -d "${D}/${PYTHON_SCRIPTDIR}" ]; then
 		dodir /usr/bin
 		for i in "${D}/${PYTHON_SCRIPTDIR}"/* ; do


### PR DESCRIPTION
Use of EAPI-7 was broken so far because `cmake-utils_use` is banned, actually since EAPI-6.

Closes: https://bugs.gentoo.org/705798
Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>