### PR TITLE
media-libs/gegl: Fix compilation error due to non-ascii symbols

### DIFF
--- a/media-libs/gegl/files/gegl-0.4.18-cltostring_force_utf8.patch
+++ b/media-libs/gegl/files/gegl-0.4.18-cltostring_force_utf8.patch
@@ -1,0 +1,30 @@
+--- a/opencl/cltostring.py	2019-10-27 02:01:07.000000000 +0300
++++ b/opencl/cltostring.py	2020-01-12 21:22:25.000000000 +0300
+@@ -1,8 +1,10 @@
+ #!/usr/bin/env python
+ from __future__ import print_function
++from __future__ import unicode_literals
+ 
+ import os
+ import sys
++import io
+ 
+ # Search for lines that look like #include "blah.h" and replace them
+ # with the contents of blah.h.
+@@ -34,12 +36,12 @@
+ 
+ 
+ if len(sys.argv) == 2:
+-  infile  = open(sys.argv[1], "r")
+-  outfile = open(sys.argv[1] + '.h',  "w")
++  infile  = io.open(sys.argv[1], "r", encoding="utf-8")
++  outfile = io.open(sys.argv[1] + '.h',  "w", encoding="utf-8")
+ 
+ elif len(sys.argv) == 3:
+-  infile  = open(sys.argv[1], "r")
+-  outfile = open(sys.argv[2], "w")
++  infile  = io.open(sys.argv[1], "r", encoding="utf-8")
++  outfile = io.open(sys.argv[2], "w", encoding="utf-8")
+ 
+ else:
+   print("Usage: %s input [output]" % sys.argv[0])

--- a/media-libs/gegl/gegl-0.4.18.ebuild
+++ b/media-libs/gegl/gegl-0.4.18.ebuild
@@ -82,9 +82,10 @@ BDEPEND="
 DOCS=( AUTHORS docs/ChangeLog docs/NEWS.txt )
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-0.4.18-drop-failing-tests.patch
-	"${FILESDIR}"/${PN}-0.4.18-program-suffix.patch
+	"${FILESDIR}"/${P}-drop-failing-tests.patch
+	"${FILESDIR}"/${P}-program-suffix.patch
 	"${FILESDIR}"/${P}-meson_cpu_detection.patch
+	"${FILESDIR}"/${P}-cltostring_force_utf8.patch
 )
 
 python_check_deps() {


### PR DESCRIPTION
This patch force using utf8 while reading files on converting .cl files
to .h files in env where for some reasons sandbox system codepage isn't utf8.

The patch provides compatibility both with python2.7 and python3.x.
When python2.7 support will be dropped the addition of
`from __future__ import unicode_literals`
`import io`
and `io.` could be removed as not neccessary for python3.x.

Closes: https://bugs.gentoo.org/705286
