### PR TITLE
net-im/signal-desktop-bin: set suid bit for chrome-sandbox

### DIFF
--- a/net-im/signal-desktop-bin/signal-desktop-bin-1.29.6.ebuild
+++ b/net-im/signal-desktop-bin/signal-desktop-bin-1.29.6.ebuild
@@ -50,6 +50,7 @@ src_install() {
 	doins -r usr/share/applications
 	doins -r usr/share/icons
 	fperms +x /opt/Signal/signal-desktop /opt/Signal/chrome-sandbox
+	fperms u+s /opt/Signal/chrome-sandbox
 	pax-mark m opt/Signal/signal-desktop opt/Signal/chrome-sandbox
 
 	dosym ../../opt/Signal/${MY_PN} /usr/bin/${MY_PN}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/700758
Signed-off-by: Robert Siebeck <gentoo.2019@r123.de>