### PR TITLE
net-p2p/deluge: fix deluge-web.init file

### DIFF
--- a/net-p2p/deluge/deluge-2.0.3-r3.ebuild
+++ b/net-p2p/deluge/deluge-2.0.3-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python2_7 python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7} )
 DISTUTILS_SINGLE_IMPL=1
 inherit distutils-r1 systemd
 
@@ -85,31 +85,33 @@ esetup.py() {
 python_install_all() {
 	distutils-r1_python_install_all
 	if ! use console ; then
-		rm -rf "${D}/usr/$(get_libdir)/python2.7/site-packages/deluge/ui/console/" || die
-		rm -f "${D}/usr/bin/deluge-console" || die
-		rm -f "${D}/usr/share/man/man1/deluge-console.1" ||die
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/console/" || die
+		rm "${D}/usr/bin/deluge-console" || die
+		rm "${D}/usr/share/man/man1/deluge-console.1" ||die
 	fi
 	if ! use gtk ; then
-		rm -rf "${D}/usr/$(get_libdir)/python2.7/site-packages/deluge/ui/gtkui/" || die
-		rm -rf "${D}/usr/share/icons/" || die
-		rm -f "${D}/usr/bin/deluge-gtk" || die
-		rm -f "${D}/usr/share/man/man1/deluge-gtk.1" || die
-		rm -f "${D}/usr/share/applications/deluge.desktop" || die
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/gtk3/" || die
+		rm -r "${D}/usr/share/icons/" || die
+		rm "${D}/usr/bin/deluge-gtk" || die
+		rm "${D}/usr/share/man/man1/deluge-gtk.1" || die
+		rm "${D}/usr/share/applications/deluge.desktop" || die
 	fi
 	if use webinterface; then
-		newinitd "${FILESDIR}/deluge-web.init" deluge-web
+		newinitd "${FILESDIR}/deluge-web.init-2" deluge-web
 		newconfd "${FILESDIR}/deluge-web.conf" deluge-web
 		systemd_newunit "${FILESDIR}/deluge-web.service-3" deluge-web.service
 		systemd_install_serviced "${FILESDIR}/deluge-web.service.conf"
 	else
-		rm -rf "${D}/usr/$(get_libdir)/python2.7/site-packages/deluge/ui/web/" || die
-		rm -f "${D}/usr/bin/deluge-web" || die
-		rm -f "${D}/usr/share/man/man1/deluge-web.1" || die
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/web/" || die
+		rm "${D}/usr/bin/deluge-web" || die
+		rm "${D}/usr/share/man/man1/deluge-web.1" || die
 	fi
 	newinitd "${FILESDIR}"/deluged.init-2 deluged
 	newconfd "${FILESDIR}"/deluged.conf-2 deluged
 	systemd_newunit "${FILESDIR}"/deluged.service-2 deluged.service
 	systemd_install_serviced "${FILESDIR}"/deluged.service.conf
+
+	python_optimize
 }
 
 pkg_postinst() {

--- a/net-p2p/deluge/deluge-9999.ebuild
+++ b/net-p2p/deluge/deluge-9999.ebuild
@@ -85,31 +85,33 @@ esetup.py() {
 python_install_all() {
 	distutils-r1_python_install_all
 	if ! use console ; then
-		rm -rf "${D}/usr/$(get_libdir)/python2.7/site-packages/deluge/ui/console/" || die
-		rm -f "${D}/usr/bin/deluge-console" || die
-		rm -f "${D}/usr/share/man/man1/deluge-console.1" ||die
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/console/" || die
+		rm "${D}/usr/bin/deluge-console" || die
+		rm "${D}/usr/share/man/man1/deluge-console.1" ||die
 	fi
 	if ! use gtk ; then
-		rm -rf "${D}/usr/$(get_libdir)/python2.7/site-packages/deluge/ui/gtkui/" || die
-		rm -rf "${D}/usr/share/icons/" || die
-		rm -f "${D}/usr/bin/deluge-gtk" || die
-		rm -f "${D}/usr/share/man/man1/deluge-gtk.1" || die
-		rm -f "${D}/usr/share/applications/deluge.desktop" || die
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/gtk3/" || die
+		rm -r "${D}/usr/share/icons/" || die
+		rm "${D}/usr/bin/deluge-gtk" || die
+		rm "${D}/usr/share/man/man1/deluge-gtk.1" || die
+		rm "${D}/usr/share/applications/deluge.desktop" || die
 	fi
 	if use webinterface; then
-		newinitd "${FILESDIR}/deluge-web.init" deluge-web
+		newinitd "${FILESDIR}/deluge-web.init-2" deluge-web
 		newconfd "${FILESDIR}/deluge-web.conf" deluge-web
 		systemd_newunit "${FILESDIR}/deluge-web.service-3" deluge-web.service
 		systemd_install_serviced "${FILESDIR}/deluge-web.service.conf"
 	else
-		rm -rf "${D}/usr/$(get_libdir)/python2.7/site-packages/deluge/ui/web/" || die
-		rm -f "${D}/usr/bin/deluge-web" || die
-		rm -f "${D}/usr/share/man/man1/deluge-web.1" || die
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/web/" || die
+		rm "${D}/usr/bin/deluge-web" || die
+		rm "${D}/usr/share/man/man1/deluge-web.1" || die
 	fi
 	newinitd "${FILESDIR}"/deluged.init-2 deluged
 	newconfd "${FILESDIR}"/deluged.conf-2 deluged
 	systemd_newunit "${FILESDIR}"/deluged.service-2 deluged.service
 	systemd_install_serviced "${FILESDIR}"/deluged.service.conf
+
+	python_optimize
 }
 
 pkg_postinst() {

--- a/net-p2p/deluge/files/deluge-web.init-2
+++ b/net-p2p/deluge/files/deluge-web.init-2
@@ -1,0 +1,53 @@
+#!/sbin/openrc-run
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License, v2 or later
+
+depend() {
+	need net
+}
+
+checkconfig() {
+	if [ "${DELUGE_WEB_USER}" = "" ] ; then
+		eerror "Please edit /etc/conf.d/deluge-web"
+		eerror "You have to specify a user to run deluge-web as, as we will not run it as root!"
+		eerror "Modify DELUGE_WEB_USER to your needs (you can also add a group, after a colon)"
+		return 1
+	fi
+	if ! getent passwd "${DELUGE_WEB_USER%:*}" >/dev/null ; then
+		eerror "Please edit /etc/conf.d/deluge-web"
+		eerror "Your user has to exist!"
+		return 1
+	fi
+	if [ "${DELUGE_WEB_USER%:*}" = "${DELUGE_WEB_USER}" ] ; then
+		return 0
+	else
+		if ! getent group "${DELUGE_WEB_USER#*:}" >/dev/null ; then
+			eerror "Please edit /etc/conf.d/deluge-web"
+			eerror "Your group has to exist too!"
+			return 1
+		fi
+	fi	
+	return 0
+}
+
+start() {
+	checkconfig || return $?
+	if [ "${DELUGE_WEB_HOME}" = "" ] ; then
+		DELUGE_WEB_USER_HOME=$(getent passwd "${DELUGE_WEB_USER%:*}" | cut -d ':' -f 6)
+	else
+		DELUGE_WEB_USER_HOME=${DELUGE_WEB_HOME}
+	fi
+	ebegin "Starting Deluge-Web"
+	start-stop-daemon --start --background --pidfile \
+	/run/deluge-web.pid  --make-pidfile \
+	--exec /usr/bin/deluge-web --user "${DELUGE_WEB_USER%:*}" \
+	-e HOME="${DELUGE_WEB_USER_HOME}" -- --do-not-daemonize ${DELUGE_WEB_OPTS}
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping Deluge-Web"
+	start-stop-daemon --stop --user "${DELUGE_WEB_USER%:*}" \
+	--pidfile /run/deluge-web.pid
+	eend $?
+}


### PR DESCRIPTION
Also fixes installation of unwanted files and byte compilation of
python modules. Remove old.

Closes: https://bugs.gentoo.org/705914

Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>