### PR TITLE
sys-block/blktrace: Be sure rbtree is not compiled twice

### DIFF
--- a/sys-block/blktrace/blktrace-1.2.0-r1.ebuild
+++ b/sys-block/blktrace/blktrace-1.2.0-r1.ebuild
@@ -35,6 +35,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-overlapping-io-stats.patch
 	"${FILESDIR}"/${PN}-1.2.0-ldflags.patch #335741
 	"${FILESDIR}"/${PN}-1.2.0-parallel-build.patch #335741
+	"${FILESDIR}"/${PN}-1.2.0-parallel-rbtree.patch #705594
 )
 
 src_compile() {

--- a/sys-block/blktrace/files/blktrace-1.2.0-parallel-rbtree.patch
+++ b/sys-block/blktrace/files/blktrace-1.2.0-parallel-rbtree.patch
@@ -1,0 +1,40 @@
+https://git.kernel.dk/cgit/blktrace/patch/?id=f4f8ef7cdea138cfaa2f3ca0ee31fa23d3bcf1cc
+
+From f4f8ef7cdea138cfaa2f3ca0ee31fa23d3bcf1cc Mon Sep 17 00:00:00 2001
+From: Gwendal Grignou <gwendal@chromium.org>
+Date: Thu, 16 Jan 2020 12:33:26 -0800
+Subject: fix parallel build of btt and blkiomon
+
+rbtree.c is used by both binaries. It is possible that when make -C btt
+is invoked rbtree.o does not exist yet, but is already schedule by the
+compilation of blkiomon. That could result in recompiling rbtree.o again
+for btt/btt.
+In that case, at install time, make will recompile blkiomon which can
+fail in gentoo, because CC variable is not overriden by ebuild script at
+install time. (see https://bugs.gentoo.org/705594)
+
+Add a dependency on SUBDIRS to wait for all binary in . to be compiled.
+It will guarante rbtree.o exists.
+
+Signed-off-by: Gwendal Grignou <gwendal@chromium.org>
+Signed-off-by: Jens Axboe <axboe@kernel.dk>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 5917814..eb3c6a1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -14,7 +14,7 @@ all: $(ALL) $(SUBDIRS)
+ 
+ # We always descend into subdirs because they contain their own dependency
+ # information which we don't track in this top level Makefile.
+-$(SUBDIRS):
++$(SUBDIRS): $(PROGS)
+ 	$(MAKE) -C $@
+ .PHONY: $(SUBDIRS)
+ 
+-- 
+cgit v1.2.1-26-g8fc0
+


### PR DESCRIPTION
Ensure all binaries are compiled on . before compiling other directory,
as btt/btt and blkiomon need the same file, rbtree.o.

See https://bugs.gentoo.org/705594

Signed-off-by: Gwendal Grignou <gwendal@chromium.org>