### PR TITLE
net-im/dino: add new dependency on net-libs/libsignal-protocol-c

### DIFF
--- a/net-im/dino/dino-9999.ebuild
+++ b/net-im/dino/dino-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -32,6 +32,7 @@ RDEPEND="
 	x11-libs/gdk-pixbuf:2
 	x11-libs/gtk+:3
 	x11-libs/pango
+	net-libs/libsignal-protocol-c
 	gpg? ( app-crypt/gpgme:1 )
 	http? ( net-libs/libsoup:2.4 )
 	omemo? (


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/706116
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Jonas Licht <jonas.licht@fem.tu-ilmenau.de>