### PR TITLE
sci-libs/libgeodecomp: Fix VisIt removal

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -59,10 +59,6 @@ dev-python/statsmodels doc
 # Requires dev-python/astropy that's being removed.
 sci-visualization/veusz fits
 
-# Andreas Sturmlechner <asturm@gentoo.org> (2019-11-28)
-# sci-visualization/visit was last-rited, bug #657952
-sci-libs/libgeodecomp visit
-
 # Michał Górny <mgorny@gentoo.org> (2019-11-25)
 # Requires old version of dev-python/sphinx that's being removed.
 ~dev-python/fabric-2.3.1 doc

--- a/sci-libs/libgeodecomp/libgeodecomp-0.4.0-r1.ebuild
+++ b/sci-libs/libgeodecomp/libgeodecomp-0.4.0-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="http://www.libgeodecomp.org/archive/${P}.tar.bz2"
 SLOT="0"
 LICENSE="Boost-1.0"
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE="doc mpi cuda opencl opencv silo hpx visit"
+IUSE="cuda doc hpx mpi opencl opencv silo"
 
 BDEPEND="
 	doc? (

--- a/sci-libs/libgeodecomp/metadata.xml
+++ b/sci-libs/libgeodecomp/metadata.xml
@@ -28,8 +28,5 @@
     <flag name="hpx">
       Enables HPX backend
     </flag>
-    <flag name="visit">
-      Enables VisIt related code
-    </flag>
   </use>
 </pkgmetadata>


### PR DESCRIPTION
Commit 06a2e799559c ("sci-libs/libgeodecomp: Fix file collision with
libflatarray") started the removal of the VisIt use flag. However, it's not
complete. Remove the last references to it.

Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Kurt Kanzenbach <kurt@kmk-computers.de>