### PR TITLE
dev-libs/libsass: please mask dev-libs/libsass-3.6.3

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -32,6 +32,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Andrew Ammerlaan <andrewammerlaan@riseup.net> (2020-01-26)
+# Proxy Maintainers <proxy-maint@gentoo.org>
+# v3.6.3 uses huge amounts of memory: Bug #705682
+# v3.6.1 is the latest version without this issue
+=dev-libs/libsass-3.6.3
+
 # Victor Payno <vpayno+gentoo@gmail.com> (2020-01-23)
 # Requires slotted lua.
 =dev-lang/lua-5.1.5-r103


### PR DESCRIPTION
Uses huge amounts of memory
Version 3.6.1 is the latest working version

I suggest to mask this version for now.
I'll keep an eye out for a new release by upstream or a patch.

Bug: https://bugs.gentoo.org/705682
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>