### PR TITLE
net-libs/libsrtp: fix building with gcc-10

### DIFF
--- a/net-libs/libsrtp/files/libsrtp-2.2.0-gcc-10.patch
+++ b/net-libs/libsrtp/files/libsrtp-2.2.0-gcc-10.patch
@@ -1,0 +1,26 @@
+diff --git a/crypto/math/datatypes.c b/crypto/math/datatypes.c
+index c0dfece..ec2fe6d 100644
+--- a/crypto/math/datatypes.c
++++ b/crypto/math/datatypes.c
+@@ -79,7 +79,7 @@ int octet_get_weight(uint8_t octet)
+ 
+ /* the value MAX_PRINT_STRING_LEN is defined in datatypes.h */
+ 
+-char bit_string[MAX_PRINT_STRING_LEN];
++static char bit_string[MAX_PRINT_STRING_LEN];
+ 
+ uint8_t srtp_nibble_to_hex_char(uint8_t nibble)
+ {
+diff --git a/test/util.c b/test/util.c
+index eb203f4..04e149c 100644
+--- a/test/util.c
++++ b/test/util.c
+@@ -47,7 +47,7 @@
+ #include <string.h>
+ #include <stdint.h>
+ 
+-char bit_string[MAX_PRINT_STRING_LEN];
++static char bit_string[MAX_PRINT_STRING_LEN];
+ 
+ static inline int hex_char_to_nibble(uint8_t c)
+ {

--- a/net-libs/libsrtp/libsrtp-2.2.0.ebuild
+++ b/net-libs/libsrtp/libsrtp-2.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,7 +25,10 @@ DEPEND="${RDEPEND}"
 
 DOCS=( CHANGES )
 
-PATCHES=( "${FILESDIR}/${P}-pcap-automagic-r0.patch" )
+PATCHES=(
+	"${FILESDIR}/${P}-pcap-automagic-r0.patch"
+	"${FILESDIR}/${P}-gcc-10.patch"
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/706608
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>

No revbump because it fixes test build failure with gcc-10 (unreleased).