### PR TITLE
dev-libs/libbpf: Remove GPL-2 from licenses

### DIFF
--- a/dev-libs/libbpf/libbpf-0.0.3.ebuild
+++ b/dev-libs/libbpf/libbpf-0.0.3.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="https://github.com/libbpf/libbpf"
 DESCRIPTION="Stand-alone build of libbpf from the Linux kernel"
 SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-2 LGPL-2.1 BSD-2"
+LICENSE="LGPL-2.1 BSD-2"
 SLOT="0/${PV}"
 KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+static-libs"

--- a/dev-libs/libbpf/libbpf-0.0.5.ebuild
+++ b/dev-libs/libbpf/libbpf-0.0.5.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="https://github.com/libbpf/libbpf"
 DESCRIPTION="Stand-alone build of libbpf from the Linux kernel"
 SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-2 LGPL-2.1 BSD-2"
+LICENSE="LGPL-2.1 BSD-2"
 SLOT="0/${PV}"
 KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+static-libs"

--- a/dev-libs/libbpf/libbpf-0.0.6.ebuild
+++ b/dev-libs/libbpf/libbpf-0.0.6.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="https://github.com/libbpf/libbpf"
 DESCRIPTION="Stand-alone build of libbpf from the Linux kernel"
 SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-2 LGPL-2.1 BSD-2"
+LICENSE="LGPL-2.1 BSD-2"
 SLOT="0/${PV}"
 KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="+static-libs"


### PR DESCRIPTION
https://github.com/libbpf/libbpf/blob/master/LICENSE states that
LGPL-2.1 or BSD-2-Clause licenses are to be used.

Signed-off-by: jkelecic <josip.kelecic@sartura.hr>