### PR TITLE
net-p2p/deluge: add forgotten ~arm keyword after update

### DIFF
--- a/net-p2p/deluge/deluge-2.0.3-r3.ebuild
+++ b/net-p2p/deluge/deluge-2.0.3-r3.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://git.deluge-torrent.org/${PN}"
 else
 	SRC_URI="http://download.deluge-torrent.org/source/2.0/${P}.tar.xz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm ~x86"
 fi
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/705486
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>