### PR TITLE
dev-python/gevent: Fix cross compilation

### DIFF
--- a/dev-python/gevent/files/gevent-1.4.0-cross-compile-includes.patch
+++ b/dev-python/gevent/files/gevent-1.4.0-cross-compile-includes.patch
@@ -1,0 +1,32 @@
+This patch fixes the build includes when cross compiling.
+Without it, the host include path /usr/include/python2.7
+is provided to the compiler, along with the cross arch
+specific include path, /<**>/<arch>/usr/include/python2.7.
+This can yield the following compilation error:
+error: includez location '/usr/include/python2.7' is unsafe
+for cross-compilation
+
+Patch by Craig Hesling.
+
+https://bugs.gentoo.org/707024
+
+--- a/setup.py
++++ b/setup.py
+@@ -5,6 +5,7 @@ import sys
+ import os
+ import os.path
+ import sysconfig
++from distutils import sysconfig as dist_sysconfig
+ 
+ # setuptools is *required* on Windows
+ # (https://bugs.python.org/issue23246) and for PyPy. No reason not to
+@@ -52,7 +53,7 @@ from _setupares import ARES
+ # Get access to the greenlet header file.
+ # The sysconfig dir is not enough if we're in a virtualenv
+ # See https://github.com/pypa/pip/issues/4610
+-include_dirs = [sysconfig.get_path("include")]
++include_dirs = [dist_sysconfig.get_python_inc()]
+ venv_include_dir = os.path.join(sys.prefix, 'include', 'site',
+                                 'python' + sysconfig.get_python_version())
+ venv_include_dir = os.path.abspath(venv_include_dir)
+

--- a/dev-python/gevent/files/gevent-1.4.0-cross-compile-libev.patch
+++ b/dev-python/gevent/files/gevent-1.4.0-cross-compile-libev.patch
@@ -1,0 +1,28 @@
+This patch fixes the embedded libev's ./configure invocation
+for use in a cross compilation environment.
+
+Even though we disabled the use/build of gevent's embedded
+libev and c-ares libs, there is still one independent
+build step in setup.py that wants to run the embedded
+libev build system.
+The setup.py comment says the following:
+# We're not embedding libev but we do want
+# to build the CFFI module. We need to configure libev
+# because the CORE Extension won't.
+
+Patch by Craig Hesling.
+
+https://bugs.gentoo.org/707024
+
+--- a/_setuplibev.py
++++ b/_setuplibev.py
+@@ -31,7 +31,7 @@ LIBEV_EMBED = should_embed('libev')
+ # and the PyPy branch will clean it up.
+ libev_configure_command = ' '.join([
+     "(cd ", quoted_dep_abspath('libev'),
+-    " && sh ./configure ",
++    " && sh ./configure --build=${CBUILD} --host=${CHOST} ",
+     " && cp config.h \"$OLDPWD\"",
+     ")",
+     '> configure-output.txt'
+

--- a/dev-python/gevent/gevent-1.4.0.ebuild
+++ b/dev-python/gevent/gevent-1.4.0.ebuild
@@ -30,6 +30,11 @@ DEPEND="${RDEPEND}
 # It also seems that they require network access.
 RESTRICT="test"
 
+PATCHES=(
+	"${FILESDIR}/${P}-cross-compile-includes.patch"
+	"${FILESDIR}/${P}-cross-compile-libev.patch"
+)
+
 python_prepare_all() {
 	export LIBEV_EMBED="false"
 	export CARES_EMBED="false"


### PR DESCRIPTION
These patches fix cross compiling for the dev-python/gevent-1.4.0 package.
Note that cross compiling is still broken for 1.3.7.

https://bugs.gentoo.org/707024