### PR TITLE
dev-python/lxml: pull cython[pypy3]

### DIFF
--- a/dev-python/lxml/lxml-4.4.2.ebuild
+++ b/dev-python/lxml/lxml-4.4.2.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	virtual/pkgconfig
-	$(python_gen_cond_dep 'dev-python/cython[${PYTHON_USEDEP}]' python2_7 'python3*')
+	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( dev-python/cssselect[${PYTHON_USEDEP}] )
 	"

--- a/dev-python/lxml/lxml-4.4.3.ebuild
+++ b/dev-python/lxml/lxml-4.4.3.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	virtual/pkgconfig
-	$(python_gen_cond_dep 'dev-python/cython[${PYTHON_USEDEP}]' python2_7 'python3*')
+	dev-python/cython[${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( dev-python/cssselect[${PYTHON_USEDEP}] )
 	"


### PR DESCRIPTION
Building lxml with pypy3 compatibility requires the pypy3 version of cython.

Please merge. Thanks.