### PR TITLE
ghc-package.eclass: Handle missing ghc in lookups

### DIFF
--- a/eclass/ghc-package.eclass
+++ b/eclass/ghc-package.eclass
@@ -22,14 +22,20 @@ esac
 # @DESCRIPTION:
 # returns the name of the ghc executable
 ghc-getghc() {
-	type -P ${HC:-ghc}
+	if ! type -P ${HC:-ghc}; then
+		ewarn "ghc not found"
+		type -P false
+	fi
 }
 
 # @FUNCTION: ghc-getghcpkg
 # @DESCRIPTION:
 # Internal function determines returns the name of the ghc-pkg executable
 ghc-getghcpkg() {
-	type -P ${HC_PKG:-ghc-pkg}
+	if ! type -P ${HC_PKG:-ghc-pkg}; then
+		ewarn "ghc-pkg not found"
+		type -P false
+	fi
 }
 
 # @FUNCTION: ghc-getghcpkgbin


### PR DESCRIPTION
ghc-getghc() and ghc-getghcpkg() both assume that they can find an
installed binary.  If ghc isn't installed (e.g., because it's being
being rebuilt or has been unmerged), there is no such binary. This
causes the intended arguments to be run as a command, which produces
"command not found" QA Notices.

If ghc can't be found, return "false" instead.  The false command will
harmlessly absorb the other command-line arguments.  This doesn't
produce any difference in the final result because the invalid commands
were failing anyway.

Bug: https://bugs.gentoo.org/683144
Signed-off-by: Benjamin Gordon <bmgordon@chromium.org>