### PR TITLE
net-analyzer/fail2ban: bump PYTHON_COMPAT

### DIFF
--- a/net-analyzer/fail2ban/fail2ban-0.10.4-r2.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-0.10.4-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python{2_7,3_6} )
+PYTHON_COMPAT=( python2_7 python3_{6,7} )
 DISTUTILS_SINGLE_IMPL=1
 
 inherit distutils-r1 systemd

--- a/net-analyzer/fail2ban/fail2ban-0.10.4.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-0.10.4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_6} )
+PYTHON_COMPAT=( python2_7 python3_{6,7} )
 DISTUTILS_SINGLE_IMPL=1
 
 inherit distutils-r1 eutils systemd vcs-snapshot

--- a/net-analyzer/fail2ban/fail2ban-0.10.5-r1.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-0.10.5-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python{2_7,3_6} )
+PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
 DISTUTILS_SINGLE_IMPL=1
 
 inherit bash-completion-r1 distutils-r1 systemd

--- a/net-analyzer/fail2ban/fail2ban-0.11.1-r1.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-0.11.1-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python{2_7,3_6} )
+PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
 DISTUTILS_SINGLE_IMPL=1
 
 inherit bash-completion-r1 distutils-r1 systemd

--- a/net-analyzer/fail2ban/fail2ban-99999999.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-99999999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python{2_7,3_6} )
+PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
 DISTUTILS_SINGLE_IMPL=1
 
 inherit bash-completion-r1 distutils-r1 git-r3 systemd


### PR DESCRIPTION
Enable python 3.7 for fail2ban-0.10.4 and 3.7, 3.8 for newer versions - like it is officialy supported and tested by travis.
https://travis-ci.org/fail2ban/fail2ban/branches