### PR TITLE
sys-boot/lilo: minor fixes

### DIFF
--- a/sys-boot/lilo/files/lilo.conf
+++ b/sys-boot/lilo/files/lilo.conf
@@ -12,7 +12,7 @@ lba32
 #linear
 
 # MBR to install LILO to:
-boot = /dev/hda
+boot = /dev/sda
 map = /boot/.map
 
 # If you are having problems booting from a hardware raid-array
@@ -51,7 +51,7 @@ vga = normal
 # Linux bootable partition config begins
 #
 image = /boot/bzImage
-	root = /dev/hda3
+	root = /dev/sda3
 	#root = /devices/discs/disc0/part3
 	label = Gentoo
 	read-only # read-only for checking
@@ -62,10 +62,10 @@ image = /boot/bzImage
 #
 # DOS bootable partition config begins
 #
-other = /dev/hda1
+other = /dev/sda1
 	#other = /devices/discs/disc0/part1
 	label = Windows
-	table = /dev/hda
+	table = /dev/sda
 #
 # DOS bootable partition config ends  
 #

--- a/sys-boot/lilo/lilo-24.0-r1.ebuild
+++ b/sys-boot/lilo/lilo-24.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -9,11 +9,11 @@ DOLILO_V="0.6"
 IUSE="static minimal pxeserial device-mapper"
 
 DESCRIPTION="Standard Linux boot loader"
-HOMEPAGE="https://alioth.debian.org/projects/lilo/"
+HOMEPAGE="https://www.joonet.de/lilo/"
 
 DOLILO_TAR="dolilo-${DOLILO_V}.tar.bz2"
 SRC_URI="
-	http://lilo.alioth.debian.org/ftp/sources/${P}.tar.gz
+	https://www.joonet.de/lilo/ftp/sources/${P}.tar.gz
 	mirror://gentoo/${DOLILO_TAR}
 "
 

--- a/sys-boot/lilo/lilo-24.1.ebuild
+++ b/sys-boot/lilo/lilo-24.1.ebuild
@@ -9,11 +9,11 @@ DOLILO_V="0.6"
 IUSE="static minimal pxeserial device-mapper"
 
 DESCRIPTION="Standard Linux boot loader"
-HOMEPAGE="https://alioth.debian.org/projects/lilo/"
+HOMEPAGE="https://www.joonet.de/lilo/"
 
 DOLILO_TAR="dolilo-${DOLILO_V}.tar.bz2"
 SRC_URI="
-	http://lilo.alioth.debian.org/ftp/sources/${P}.tar.gz
+	https://www.joonet.de/lilo/ftp/sources/${P}.tar.gz
 	mirror://gentoo/${DOLILO_TAR}
 "
 

--- a/sys-boot/lilo/lilo-24.2.ebuild
+++ b/sys-boot/lilo/lilo-24.2.ebuild
@@ -9,11 +9,11 @@ DOLILO_V="0.6"
 IUSE="static minimal pxeserial device-mapper"
 
 DESCRIPTION="Standard Linux boot loader"
-HOMEPAGE="https://alioth.debian.org/projects/lilo/"
+HOMEPAGE="https://www.joonet.de/lilo/"
 
 DOLILO_TAR="dolilo-${DOLILO_V}.tar.bz2"
 SRC_URI="
-	http://lilo.alioth.debian.org/ftp/sources/${P}.tar.gz
+	https://www.joonet.de/lilo/ftp/sources/${P}.tar.gz
 	mirror://gentoo/${DOLILO_TAR}
 "
 


### PR DESCRIPTION
Replaces /dev/hda with /dev/sda in example config. The sample lilo.example.conf's in all sources already use /dev/sda.

All new sources have the same checksum as the existing sources.