### PR TITLE
app-admin/syslog-ng: fix building with CFLAGS=-fno-common

### DIFF
--- a/app-admin/syslog-ng/files/patches/syslog-ng-fno-common.patch
+++ b/app-admin/syslog-ng/files/patches/syslog-ng-fno-common.patch
@@ -1,0 +1,320 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e9b4183fc..1f8f16c13 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -331,8 +331,7 @@ endif()
+ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -j $$(nproc) --output-on-failure)
+ 
+ set(IMPORTANT_WARNINGS
+-  -Wshadow
+-  -fcommon)
++  -Wshadow)
+ 
+ set(ACCEPTABLE_WARNINGS
+   -Wno-stack-protector
+diff --git a/Makefile.am b/Makefile.am
+index 8b24eeaed..86c090638 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -54,8 +54,7 @@ AM_CPPFLAGS		= -I$(top_srcdir)/lib -I$(top_srcdir)/modules -I$(top_builddir)/lib
+ 
+ # Important warnings
+ AM_CFLAGS = \
+-	-Wshadow \
+-	-fcommon
++	-Wshadow
+ 
+ # Acceptable warnings
+ AM_CFLAGS += \
+diff --git a/lib/logmsg/tests/test_log_message.c b/lib/logmsg/tests/test_log_message.c
+index 245568ce5..e51d78b94 100644
+--- a/lib/logmsg/tests/test_log_message.c
++++ b/lib/logmsg/tests/test_log_message.c
+@@ -32,6 +32,8 @@
+ #include <stdlib.h>
+ #include <glib/gprintf.h>
+ 
++MsgFormatOptions parse_options;
++
+ typedef struct _LogMessageTestParams
+ {
+   LogMessage *message;
+@@ -151,7 +153,7 @@ void
+ setup(void)
+ {
+   app_startup();
+-  init_and_load_syslogformat_module();
++  init_parse_options_and_load_syslogformat(&parse_options);
+ }
+ 
+ void
+diff --git a/libtest/cr_template.c b/libtest/cr_template.c
+index 35e47aa3f..4f0913368 100644
+--- a/libtest/cr_template.c
++++ b/libtest/cr_template.c
+@@ -34,10 +34,12 @@
+ 
+ #include "msg_parse_lib.h"
+ 
++static MsgFormatOptions parse_options;
++
+ void
+ init_template_tests(void)
+ {
+-  init_and_load_syslogformat_module();
++  init_parse_options_and_load_syslogformat(&parse_options);
+ }
+ 
+ void
+diff --git a/libtest/msg_parse_lib.c b/libtest/msg_parse_lib.c
+index ae0d1654b..b3c7cb652 100644
+--- a/libtest/msg_parse_lib.c
++++ b/libtest/msg_parse_lib.c
+@@ -27,15 +27,13 @@
+ 
+ #include <criterion/criterion.h>
+ 
+-MsgFormatOptions parse_options;
+-
+ void
+-init_and_load_syslogformat_module(void)
++init_parse_options_and_load_syslogformat(MsgFormatOptions *parse_options)
+ {
+   configuration = cfg_new_snippet();
+   cfg_load_module(configuration, "syslogformat");
+-  msg_format_options_defaults(&parse_options);
+-  msg_format_options_init(&parse_options, configuration);
++  msg_format_options_defaults(parse_options);
++  msg_format_options_init(parse_options, configuration);
+ }
+ 
+ void
+diff --git a/libtest/msg_parse_lib.h b/libtest/msg_parse_lib.h
+index d86f178c2..5a9b4277b 100644
+--- a/libtest/msg_parse_lib.h
++++ b/libtest/msg_parse_lib.h
+@@ -30,9 +30,7 @@
+ #include "cfg.h"
+ #include "logmsg/logmsg.h"
+ 
+-extern MsgFormatOptions parse_options;
+-
+-void init_and_load_syslogformat_module(void);
++void init_parse_options_and_load_syslogformat(MsgFormatOptions *parse_options);
+ void deinit_syslogformat_module(void);
+ 
+ void assert_log_messages_equal(LogMessage *log_message_a, LogMessage *log_message_b);
+diff --git a/libtest/proto_lib.c b/libtest/proto_lib.c
+index b69195865..105e390b9 100644
+--- a/libtest/proto_lib.c
++++ b/libtest/proto_lib.c
+@@ -23,7 +23,7 @@
+  */
+ 
+ #include "proto_lib.h"
+-#include "msg_parse_lib.h"
++#include "cfg.h"
+ 
+ #include <string.h>
+ #include <criterion/criterion.h>
+@@ -164,7 +164,8 @@ assert_proto_server_fetch_ignored_eof(LogProtoServer *proto)
+ void
+ init_proto_tests(void)
+ {
+-  init_and_load_syslogformat_module();
++  configuration = cfg_new_snippet();
++  cfg_load_module(configuration, "syslogformat");
+   log_proto_server_options_defaults(&proto_server_options);
+ }
+ 
+@@ -172,5 +173,7 @@ void
+ deinit_proto_tests(void)
+ {
+   log_proto_server_options_destroy(&proto_server_options);
+-  deinit_syslogformat_module();
++
++  if (configuration)
++    cfg_free(configuration);
+ }
+diff --git a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+index 79a4b97ad..d4d0d45a9 100644
+--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
++++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+@@ -31,6 +31,8 @@
+ 
+ #include <criterion/criterion.h>
+ 
++MsgFormatOptions parse_options;
++
+ static LogMessage *
+ kmsg_parse_message(const gchar *raw_message_str)
+ {
+diff --git a/modules/python/tests/test_python_logmsg.c b/modules/python/tests/test_python_logmsg.c
+index 9a0343b07..51651ee9d 100644
+--- a/modules/python/tests/test_python_logmsg.c
++++ b/modules/python/tests/test_python_logmsg.c
+@@ -30,6 +30,8 @@
+ static PyObject *_python_main;
+ static PyObject *_python_main_dict;
+ 
++MsgFormatOptions parse_options;
++
+ static void
+ _py_init_interpreter(void)
+ {
+@@ -95,7 +97,7 @@ void setup(void)
+ {
+   app_startup();
+ 
+-  init_and_load_syslogformat_module();
++  init_parse_options_and_load_syslogformat(&parse_options);
+ 
+   _py_init_interpreter();
+   _init_python_main();
+diff --git a/modules/stardate/tests/test_stardate.c b/modules/stardate/tests/test_stardate.c
+index e48cfb6cd..7d55fc1d0 100644
+--- a/modules/stardate/tests/test_stardate.c
++++ b/modules/stardate/tests/test_stardate.c
+@@ -33,6 +33,8 @@
+ 
+ #include "msg_parse_lib.h"
+ 
++MsgFormatOptions parse_options;
++
+ void
+ stardate_assert(const gchar *msg_str, const int precision, const gchar *expected)
+ {
+@@ -58,6 +60,7 @@ void
+ setup(void)
+ {
+   app_startup();
++  init_parse_options_and_load_syslogformat(&parse_options);
+   init_template_tests();
+   cfg_load_module(configuration, "stardate");
+ }
+@@ -66,6 +69,7 @@ void
+ teardown(void)
+ {
+   deinit_template_tests();
++  deinit_syslogformat_module();
+   app_shutdown();
+ }
+ 
+diff --git a/persist-tool/add.h b/persist-tool/add.h
+index 981e0cc61..2d3524cb0 100644
+--- a/persist-tool/add.h
++++ b/persist-tool/add.h
+@@ -32,8 +32,8 @@
+ #include "cfg.h"
+ #include "persist-tool.h"
+ 
+-gchar *persist_state_dir;
+-gchar *persist_state_name;
++extern gchar *persist_state_dir;
++extern gchar *persist_state_name;
+ 
+ gint add_main(int argc, char *argv[]);
+ 
+diff --git a/persist-tool/generate.h b/persist-tool/generate.h
+index 237a8ae24..34f7dfec9 100644
+--- a/persist-tool/generate.h
++++ b/persist-tool/generate.h
+@@ -32,8 +32,8 @@
+ #include "persist-state.h"
+ #include "cfg.h"
+ 
+-gboolean force_generate;
+-gchar *generate_output_dir;
++extern gboolean force_generate;
++extern gchar *generate_output_dir;
+ 
+ gint generate_main(int argc, char *argv[]);
+ 
+diff --git a/persist-tool/persist-tool.c b/persist-tool/persist-tool.c
+index fd96c856d..4e4adc88f 100644
+--- a/persist-tool/persist-tool.c
++++ b/persist-tool/persist-tool.c
+@@ -135,11 +135,17 @@ void persist_tool_free(PersistTool *self)
+   g_free(self);
+ }
+ 
++gchar *persist_state_dir;
++gchar *persist_state_name;
++gboolean force_generate;
++gchar *generate_output_dir;
++
+ static GOptionEntry dump_options[] =
+ {
+   { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+ };
+ 
++
+ static GOptionEntry add_options[] =
+ {
+   { "output-dir", 'o', 0, G_OPTION_ARG_STRING, &persist_state_dir, "The directory where persist file is located.", "<directory>" },
+diff --git a/tests/unit/test_clone_logmsg.c b/tests/unit/test_clone_logmsg.c
+index 57c0b181f..7b738b1e5 100644
+--- a/tests/unit/test_clone_logmsg.c
++++ b/tests/unit/test_clone_logmsg.c
+@@ -38,6 +38,8 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ 
++MsgFormatOptions parse_options;
++
+ void
+ assert_new_log_message_attributes(LogMessage *log_message)
+ {
+@@ -69,7 +71,7 @@ void
+ setup(void)
+ {
+   app_startup();
+-  init_and_load_syslogformat_module();
++  init_parse_options_and_load_syslogformat(&parse_options);
+ }
+ 
+ void
+diff --git a/tests/unit/test_matcher.c b/tests/unit/test_matcher.c
+index a92c8e458..d43755bea 100644
+--- a/tests/unit/test_matcher.c
++++ b/tests/unit/test_matcher.c
+@@ -31,6 +31,8 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
++MsgFormatOptions parse_options;
++
+ static LogMessage *
+ _create_log_message(const gchar *log)
+ {
+@@ -128,7 +130,7 @@ void
+ setup(void)
+ {
+   app_startup();
+-  init_and_load_syslogformat_module();
++  init_parse_options_and_load_syslogformat(&parse_options);
+ }
+ 
+ void
+diff --git a/tests/unit/test_msgparse.c b/tests/unit/test_msgparse.c
+index 6b9e1045f..0ed91f638 100644
+--- a/tests/unit/test_msgparse.c
++++ b/tests/unit/test_msgparse.c
+@@ -49,6 +49,8 @@ struct sdata_pair
+ struct sdata_pair ignore_sdata_pairs[] = { { NULL, NULL } };
+ struct sdata_pair empty_sdata_pairs[] = { { NULL, NULL } };
+ 
++MsgFormatOptions parse_options;
++
+ static unsigned long
+ _absolute_value(signed long diff)
+ {
+@@ -130,7 +132,7 @@ setup(void)
+   app_startup();
+   setenv("TZ", "MET-1METDST", TRUE);
+   tzset();
+-  init_and_load_syslogformat_module();
++  init_parse_options_and_load_syslogformat(&parse_options);
+   /* Fri Feb  8 09:37:49 CET 2019 */
+   fake_time(1549615069);
+ }

--- a/app-admin/syslog-ng/syslog-ng-3.25.1.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-3.25.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -49,6 +49,8 @@ BDEPEND="
 DOCS=( AUTHORS NEWS.md CONTRIBUTING.md contrib/syslog-ng.conf.{HP-UX,RedHat,SunOS,doc}
 	contrib/syslog2ng "${T}/syslog-ng.conf.gentoo.hardened"
 	"${T}/syslog-ng.logrotate.hardened" "${FILESDIR}/README.hardened" )
+
+PATCHES=( "${FILESDIR}/patches/${PN}-fno-common.patch" )
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/707124
Package-Manager: Portage-2.3.85, Repoman-2.3.20
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>