### PR TITLE
net-ftp/frox: fix building with -fno-common (default for GCC 10)

### DIFF
--- a/net-ftp/frox/files/frox-0.7.18-no-common.patch
+++ b/net-ftp/frox/files/frox-0.7.18-no-common.patch
@@ -1,0 +1,63 @@
+Fix compilation with -fno-common (default for GCC 10)
+
+Signed-off-by: Marek Behún kabel@blackhole.sk>
+---
+diff --git a/lib/sstrlib/sstr_private.h b/lib/sstrlib/sstr_private.h
+--- a/lib/sstrlib/sstr_private.h
++++ b/lib/sstrlib/sstr_private.h
+@@ -32,6 +32,6 @@ struct _sstr {
+ };
+ 
+ int sstr_alloc_space(sstr * p, int len);
+-void (*on_error) (void);
++extern void (*on_error) (void);
+ 
+ #endif /*SSTR_PRIVATE_H */
+diff --git a/src/common.h b/src/common.h
+--- a/src/common.h
++++ b/src/common.h
+@@ -184,7 +184,7 @@ typedef struct _session_info {
+ /*******************
+ **Global Variables**
+ ********************/
+-session_info *info;
++extern session_info *info;
+ extern pid_t cmgrpid, tdatapid;
+ 
+ #endif /* COMMON_H */
+diff --git a/src/ftp-cmds.c b/src/ftp-cmds.c
+--- a/src/ftp-cmds.c
++++ b/src/ftp-cmds.c
+@@ -38,6 +38,8 @@ void xfer_command(sstr * cmd, sstr * arg
+ void cwd_command(sstr * cmd, sstr * arg);
+ void pasv_reply(sstr * msg);
+ 
++struct cmd_struct *ftp_cmds;
++
+ void ftpcmds_init()
+ {
+ 	static struct cmd_struct list[] = {	/*Pinched in part SUSE */
+diff --git a/src/ftp-cmds.h b/src/ftp-cmds.h
+--- a/src/ftp-cmds.h
++++ b/src/ftp-cmds.h
+@@ -33,7 +33,7 @@ struct cmd_struct {
+ 	void (*cmd) (sstr * cmd, sstr * arg);
+ };
+ 
+-struct cmd_struct *ftp_cmds;
++extern struct cmd_struct *ftp_cmds;
+ void user_munge(sstr * cmd, sstr * arg);
+ 
+ 
+diff --git a/src/main.c b/src/main.c
+--- a/src/main.c
++++ b/src/main.c
+@@ -62,6 +62,8 @@ static struct client_info {
+ void add_client(pid_t, struct sockaddr_in client);
+ void rm_client(pid_t pid);
+ 
++session_info *info;
++
+ #ifdef ENABLE_CHANGEPROC
+ int main(int argc, char *argv[], char *envp[])
+ #else

--- a/net-ftp/frox/frox-0.7.18-r6.ebuild
+++ b/net-ftp/frox/frox-0.7.18-r6.ebuild
@@ -45,6 +45,7 @@ src_prepare() {
 	eapply "${FILESDIR}/${PV}-respect-CFLAGS.patch"
 	eapply "${FILESDIR}/${PV}-netfilter-includes.patch"
 	eapply "${FILESDIR}/${P}-config.patch"
+	eapply "${FILESDIR}/${P}-no-common.patch"
 
 	if use clamav ; then
 		sed -i -e "s:^# VirusScanner.*:# VirusScanner '\"/usr/bin/clamscan\" \"%s\"':" \


### PR DESCRIPTION
Fix some definitions so that the package builds for GCC 10, where
-fno-common is default.

Bug: https://bugs.gentoo.org/707618
Signed-off-by: Marek Behún <kabel@blackhole.sk>