### PR TITLE
net-dns/bind: Allow building against >=dev-db/mysql-connector-c-8 too

### DIFF
--- a/net-dns/bind/bind-9.14.8.ebuild
+++ b/net-dns/bind/bind-9.14.8.ebuild
@@ -92,6 +92,10 @@ pkg_setup() {
 	eend ${?}
 }
 
+PATCHES=(
+	"${FILESDIR}"/mysql8-bool.patch
+)
+
 src_prepare() {
 	default
 

--- a/net-dns/bind/bind-9.14.9.ebuild
+++ b/net-dns/bind/bind-9.14.9.ebuild
@@ -92,6 +92,10 @@ pkg_setup() {
 	eend ${?}
 }
 
+PATCHES=(
+	"${FILESDIR}"/mysql8-bool.patch
+)
+
 src_prepare() {
 	default
 

--- a/net-dns/bind/files/mysql8-bool.patch
+++ b/net-dns/bind/files/mysql8-bool.patch
@@ -1,0 +1,17 @@
+diff --git a/contrib/dlz/drivers/dlz_mysql_driver.c b/contrib/dlz/drivers/dlz_mysql_driver.c
+index 2275048..1b9e0ac 100644
+--- a/contrib/dlz/drivers/dlz_mysql_driver.c
++++ b/contrib/dlz/drivers/dlz_mysql_driver.c
+@@ -789,8 +789,11 @@ mysql_create(const char *dlzname, unsigned int argc, char *argv[],
+ 	char *endp;
+ 	int j;
+ 	unsigned int flags = 0;
++#if MYSQL_VERSION_ID >= 80000
++	typedef bool my_bool;  // Workaround to make library work with MySQL client 8.0 as well as earlier versions
++#endif
+ #if MYSQL_VERSION_ID >= 50000
+-        my_bool auto_reconnect = 1;
++	my_bool auto_reconnect = 1;
+ #endif
+ 
+ 	UNUSED(driverarg);


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/692834
Signed-off-by: Jouni Kosonen jouni.kosonen@tukesoft.com

Without revision bump because it doesn't change anything to anyone who already has this succesfully installed.