### PR TITLE
dev-python/pygtk: EAPI-6, pango-1.44, numpy

### DIFF
--- a/dev-python/pygtk/files/pygtk-2.24.0-pango-1.44.patch
+++ b/dev-python/pygtk/files/pygtk-2.24.0-pango-1.44.patch
@@ -1,0 +1,41 @@
+From 4aaa48eb80c6802aec6d03e5695d2a0ff20e0fc2 Mon Sep 17 00:00:00 2001
+From: Jordan Petridis <jpetridis@gnome.org>
+Date: Thu, 24 Oct 2019 22:58:36 +0200
+Subject: [PATCH] Drop the PangoFont find_shaper virtual method
+
+This API has been removed from Pango 1.44.6, because it was completely
+unused by anything.
+
+However, PyGTK tries to bind everything, even unused API.
+
+Removing this from PyGTK means we can build it against the latest Pango
+again.
+
+https://gitlab.gnome.org/GNOME/pango/issues/417
+---
+ pango.defs | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/pango.defs b/pango.defs
+index 6935c964..da968f58 100644
+--- a/pango.defs
++++ b/pango.defs
+@@ -1391,15 +1391,6 @@
+   )
+ )
+ 
+-(define-virtual find_shaper
+-  (of-object "PangoFont")
+-  (return-type "PangoEngineShape*")
+-  (parameters
+-    '("PangoLanguage*" "lang")
+-    '("guint32" "ch")
+-  )
+-)
+-
+ (define-virtual get_glyph_extents
+   (of-object "PangoFont")
+   (return-type "none")
+-- 
+2.24.1
+

--- a/dev-python/pygtk/files/pygtk-2.24.0-test-fail.patch
+++ b/dev-python/pygtk/files/pygtk-2.24.0-test-fail.patch
@@ -1,5 +1,5 @@
---- tests/runtests.py
-+++ tests/runtests.py
+--- a/tests/runtests.py
++++ b/tests/runtests.py
 @@ -41,4 +41,5 @@
      suite.addTest(loader.loadTestsFromName(name))
  

--- a/dev-python/pygtk/pygtk-2.24.0-r5.ebuild
+++ b/dev-python/pygtk/pygtk-2.24.0-r5.ebuild
@@ -50,6 +50,8 @@ PATCHES=(
 	"${FILESDIR}/${P}-test_dialog.patch"
 	# Fix build on Darwin
 	"${FILESDIR}/${PN}-2.24.0-quartz-objc.patch"
+	# x11-libs/pango-1.44
+	"${FILESDIR}/${PN}-2.24.0-pango-1.44.patch"
 )
 
 src_prepare() {

--- a/dev-python/pygtk/pygtk-2.24.0-r5.ebuild
+++ b/dev-python/pygtk/pygtk-2.24.0-r5.ebuild
@@ -1,0 +1,111 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+GNOME_TARBALL_SUFFIX="bz2"
+PYTHON_COMPAT=( python2_7 )
+inherit autotools flag-o-matic gnome2 python-r1 virtualx
+
+DESCRIPTION="GTK+2 bindings for Python"
+HOMEPAGE="https://gitlab.gnome.org/Archive/pygtk"
+
+LICENSE="LGPL-2.1"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc examples test"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="${PYTHON_DEPS}
+	>=dev-libs/glib-2.8:2
+	>=x11-libs/pango-1.16
+	>=dev-libs/atk-1.12
+	>=x11-libs/gtk+-2.24:2
+	>=dev-python/pycairo-1.0.2[${PYTHON_USEDEP}]
+	>=dev-python/pygobject-2.26.8-r53:2[${PYTHON_USEDEP}]
+	|| (
+		>=dev-python/numpy-python2-1.16.5[${PYTHON_USEDEP}]
+		<dev-python/numpy-1.17.4[${PYTHON_USEDEP}]
+	)
+	>=gnome-base/libglade-2.5:2.0
+"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	doc? (
+		dev-libs/libxslt
+		>=app-text/docbook-xsl-stylesheets-1.70.1 )
+"
+
+PATCHES=(
+	# Fix declaration of codegen in .pc
+	"${FILESDIR}/${PN}-2.13.0-fix-codegen-location.patch"
+	"${FILESDIR}/${PN}-2.14.1-libdir-pc.patch"
+	# Fix leaks of Pango objects
+	"${FILESDIR}/${PN}-2.24.0-fix-leaks.patch"
+	# Fail when tests are failing, bug #391307
+	"${FILESDIR}/${PN}-2.24.0-test-fail.patch"
+	# Fix broken tests, https://bugzilla.gnome.org/show_bug.cgi?id=709304
+	"${FILESDIR}/${P}-test_dialog.patch"
+	# Fix build on Darwin
+	"${FILESDIR}/${PN}-2.24.0-quartz-objc.patch"
+)
+
+src_prepare() {
+	default
+
+	# Examples is handled "manually"
+	sed -e 's/\(SUBDIRS = .* \)examples/\1/' \
+		-i Makefile.am Makefile.in || die
+
+	sed -e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' \
+		-i configure.ac || die #466968
+
+	AT_M4DIR="m4" eautoreconf
+
+	prepare_pygtk() {
+		mkdir -p "${BUILD_DIR}" || die
+	}
+	python_foreach_impl prepare_pygtk
+}
+
+src_configure() {
+	use hppa && append-flags -ffunction-sections
+	configure_pygtk() {
+		ECONF_SOURCE="${S}" gnome2_src_configure \
+			$(use_enable doc docs) \
+			--with-glade \
+			--enable-thread
+	}
+	python_foreach_impl run_in_build_dir configure_pygtk
+}
+
+src_compile() {
+	python_foreach_impl run_in_build_dir gnome2_src_compile
+}
+
+src_test() {
+	# Let tests pass without permissions problems, bug #245103
+	gnome2_environment_reset
+	unset DBUS_SESSION_BUS_ADDRESS
+
+	testing() {
+		cd tests
+		virtx emake check-local
+	}
+	python_foreach_impl run_in_build_dir testing
+}
+
+src_install() {
+	dodoc AUTHORS ChangeLog INSTALL MAPPING NEWS README THREADS TODO
+
+	if use examples; then
+		rm examples/Makefile* || die
+		insinto /usr/share/doc/${PF}
+		doins -r examples
+	fi
+
+	python_foreach_impl run_in_build_dir gnome2_src_install
+	find "${D}" -name '*.la' -type f -delete || die
+}

--- a/dev-python/pygtk/pygtk-2.24.0-r5.ebuild
+++ b/dev-python/pygtk/pygtk-2.24.0-r5.ebuild
@@ -25,10 +25,6 @@ RDEPEND="${PYTHON_DEPS}
 	>=x11-libs/gtk+-2.24:2
 	>=dev-python/pycairo-1.0.2[${PYTHON_USEDEP}]
 	>=dev-python/pygobject-2.26.8-r53:2[${PYTHON_USEDEP}]
-	|| (
-		>=dev-python/numpy-python2-1.16.5[${PYTHON_USEDEP}]
-		<dev-python/numpy-1.17.4[${PYTHON_USEDEP}]
-	)
 	>=gnome-base/libglade-2.5:2.0
 "
 DEPEND="${RDEPEND}
@@ -77,6 +73,7 @@ src_configure() {
 	configure_pygtk() {
 		ECONF_SOURCE="${S}" gnome2_src_configure \
 			$(use_enable doc docs) \
+			--disable-numpy \
 			--with-glade \
 			--enable-thread
 	}


### PR DESCRIPTION
```diff
--- pygtk-2.24.0-r4.ebuild      2020-03-15 20:12:07.995897861 +0100
+++ pygtk-2.24.0-r5.ebuild      2020-03-15 20:28:15.301829211 +0100
@@ -1,23 +1,23 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
-GCONF_DEBUG="no"
+EAPI=6
+
 GNOME_TARBALL_SUFFIX="bz2"
 PYTHON_COMPAT=( python2_7 )
-
-inherit autotools eutils flag-o-matic gnome2 ltprune python-r1 virtualx
+inherit autotools flag-o-matic gnome2 python-r1 virtualx
 
 DESCRIPTION="GTK+2 bindings for Python"
-HOMEPAGE="http://www.pygtk.org/"
+HOMEPAGE="https://gitlab.gnome.org/Archive/pygtk"
 
 LICENSE="LGPL-2.1"
 SLOT="2"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ia64 ~mips ppc ppc64 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc examples test"
-RESTRICT="!test? ( test )"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
+RESTRICT="!test? ( test )"
+
 RDEPEND="${PYTHON_DEPS}
        >=dev-libs/glib-2.8:2
        >=x11-libs/pango-1.16
@@ -25,10 +25,6 @@
        >=x11-libs/gtk+-2.24:2
        >=dev-python/pycairo-1.0.2[${PYTHON_USEDEP}]
        >=dev-python/pygobject-2.26.8-r53:2[${PYTHON_USEDEP}]
-       || (
-               >=dev-python/numpy-python2-1.16.5[${PYTHON_USEDEP}]
-               <dev-python/numpy-1.17.4[${PYTHON_USEDEP}]
-       )
        >=gnome-base/libglade-2.5:2.0
 "
 DEPEND="${RDEPEND}
@@ -38,28 +34,31 @@
                >=app-text/docbook-xsl-stylesheets-1.70.1 )
 "
 
-src_prepare() {
+PATCHES=(
        # Fix declaration of codegen in .pc
-       epatch "${FILESDIR}/${PN}-2.13.0-fix-codegen-location.patch"
-       epatch "${FILESDIR}/${PN}-2.14.1-libdir-pc.patch"
-
+       "${FILESDIR}/${PN}-2.13.0-fix-codegen-location.patch"
+       "${FILESDIR}/${PN}-2.14.1-libdir-pc.patch"
        # Fix leaks of Pango objects
-       epatch "${FILESDIR}/${PN}-2.24.0-fix-leaks.patch"
-
+       "${FILESDIR}/${PN}-2.24.0-fix-leaks.patch"
        # Fail when tests are failing, bug #391307
-       epatch "${FILESDIR}/${PN}-2.24.0-test-fail.patch"
-
+       "${FILESDIR}/${PN}-2.24.0-test-fail.patch"
        # Fix broken tests, https://bugzilla.gnome.org/show_bug.cgi?id=709304
-       epatch "${FILESDIR}/${P}-test_dialog.patch"
-
+       "${FILESDIR}/${P}-test_dialog.patch"
        # Fix build on Darwin
-       epatch "${FILESDIR}/${PN}-2.24.0-quartz-objc.patch"
+       "${FILESDIR}/${PN}-2.24.0-quartz-objc.patch"
+       # x11-libs/pango-1.44
+       "${FILESDIR}/${PN}-2.24.0-pango-1.44.patch"
+)
+
+src_prepare() {
+       default
 
        # Examples is handled "manually"
        sed -e 's/\(SUBDIRS = .* \)examples/\1/' \
                -i Makefile.am Makefile.in || die
 
-       sed -i -e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' configure.ac || die #466968
+       sed -e 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' \
+               -i configure.ac || die #466968
 
        AT_M4DIR="m4" eautoreconf
 
@@ -74,6 +73,7 @@
        configure_pygtk() {
                ECONF_SOURCE="${S}" gnome2_src_configure \
                        $(use_enable doc docs) \
+                       --disable-numpy \
                        --with-glade \
                        --enable-thread
        }
@@ -91,7 +91,7 @@
 
        testing() {
                cd tests
-               Xemake check-local
+               virtx emake check-local
        }
        python_foreach_impl run_in_build_dir testing
 }
@@ -100,11 +100,11 @@
        dodoc AUTHORS ChangeLog INSTALL MAPPING NEWS README THREADS TODO
 
        if use examples; then
-               rm examples/Makefile*
+               rm examples/Makefile* || die
                insinto /usr/share/doc/${PF}
                doins -r examples
        fi
 
        python_foreach_impl run_in_build_dir gnome2_src_install
-       prune_libtool_files --modules
+       find "${D}" -name '*.la' -type f -delete || die
 }
```