### PR TITLE
media-libs/libmypaint: python2 removal

### DIFF
--- a/media-libs/libmypaint/files/libmypaint-1.4.0-adjust-generation-script-to-be-runnable-in-Py3.patch
+++ b/media-libs/libmypaint/files/libmypaint-1.4.0-adjust-generation-script-to-be-runnable-in-Py3.patch
@@ -1,0 +1,31 @@
+From 748e735e7fffd2524bb3552fd79b2a2c13f60711 Mon Sep 17 00:00:00 2001
+From: Jesper Lloyd <jpl.lloyd@gmail.com>
+Date: Wed, 11 Dec 2019 18:02:35 +0100
+Subject: [PATCH] Adjust generation script to be runnable in Py3
+
+---
+ generate.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/generate.py b/generate.py
+index 6ab3dd0e..1e0b4ee9 100644
+--- a/generate.py
++++ b/generate.py
+@@ -26,6 +26,7 @@
+ import json
+ from collections import namedtuple
+ 
++PY3 = sys.version_info >= (3,)
+ 
+ _SETTINGS = []  # brushsettings.settings
+ _SETTING_ORDER = [
+@@ -82,7 +83,8 @@ def validate(self):
+ 
+ def _init_globals_from_json(filename):
+     """Populate global variables above from the canonical JSON definition."""
+-    with open(filename, "rb") as fp:
++    flag = "r" if PY3 else "rb"
++    with open(filename, flag) as fp:
+         defs = json.load(fp)
+     for input_def in defs["inputs"]:
+         input = _BrushInput(**input_def)

--- a/media-libs/libmypaint/files/libmypaint-1.4.0-drop-python2-requirement-recommendation.patch
+++ b/media-libs/libmypaint/files/libmypaint-1.4.0-drop-python2-requirement-recommendation.patch
@@ -1,0 +1,34 @@
+From 68e2c33add0aec09f1898aa80ef4f822bed67b87 Mon Sep 17 00:00:00 2001
+From: Jesper Lloyd <jpl.lloyd@gmail.com>
+Date: Tue, 17 Dec 2019 17:36:22 +0100
+Subject: [PATCH] Drop python2 requirement/recommendation
+
+---
+ README.md   | 2 +-
+ autogen.sh  | 2 +-
+ generate.py | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/README.md b/README.md
+index 96c748da..fae90566 100644
+--- a/README.md
++++ b/README.md
+@@ -35,7 +35,7 @@ to get started with a standard configuration:
+ 
+ When building from git:
+ 
+-    $ sudo apt install -y python2.7 autotools-dev intltool gettext libtool
++    $ sudo apt install -y python autotools-dev intltool gettext libtool
+ 
+ ### Install dependencies (Red Hat and derivatives)
+ 
+diff --git a/generate.py b/generate.py
+index b613f91d..cd7e99e8 100644
+--- a/generate.py
++++ b/generate.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python2
++#!/usr/bin/env python
+ # libmypaint - The MyPaint Brush Library
+ # Copyright (C) 2007-2012 Martin Renold <martinxyz@gmx.ch>
+ # Copyright (C) 2012-2016 by the MyPaint Development Team.

--- a/media-libs/libmypaint/libmypaint-1.4.0-r1.ebuild
+++ b/media-libs/libmypaint/libmypaint-1.4.0-r1.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{6,7,8} )
+
+inherit autotools python-any-r1 xdg-utils toolchain-funcs
+
+MY_PV=${PV/_beta/-beta.}
+MY_P=${PN}-${MY_PV}
+
+DESCRIPTION="Library for making brushstrokes"
+HOMEPAGE="https://github.com/mypaint/libmypaint"
+SRC_URI="https://github.com/mypaint/libmypaint/releases/download/v${MY_PV}/${MY_P}.tar.xz"
+
+LICENSE="ISC"
+SLOT="0/$(ver_cut 1-2)"  # https://github.com/mypaint/libmypaint/wiki/Versioning
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="gegl introspection nls openmp"
+
+CDEPEND="
+	dev-libs/glib:2
+	dev-libs/json-c:=
+	gegl? (
+		media-libs/babl
+		>=media-libs/gegl-0.4.14:0.4[introspection?]
+	)
+	introspection? ( >=dev-libs/gobject-introspection-1.32 )
+	openmp? ( sys-devel/gcc:*[openmp] )
+	nls? ( sys-devel/gettext )
+	"
+DEPEND="${CDEPEND}
+	${PYTHON_DEPS}
+	nls? ( dev-util/intltool )
+	"
+RDEPEND="${CDEPEND}
+	!<media-gfx/mypaint-1.2.1
+	"
+
+S="${WORKDIR}"/${MY_P}
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.4.0-drop-libmypaint-gegl-versioning.patch
+	"${FILESDIR}"/${PN}-1.4.0-gegl-0.4.14.patch
+	"${FILESDIR}"/${PN}-1.4.0-adjust-generation-script-to-be-runnable-in-Py3.patch
+	"${FILESDIR}"/${PN}-1.4.0-drop-python2-requirement-recommendation.patch
+)
+
+src_prepare() {
+	xdg_environment_reset
+	default
+	eautoreconf
+}
+
+src_configure() {
+	tc-ld-disable-gold  # bug 589266
+	econf \
+			--disable-debug \
+			--disable-docs \
+			$(use_enable gegl) \
+			--disable-gperftools \
+			$(use_enable nls i18n) \
+			$(use_enable introspection) \
+			$(use_enable openmp) \
+			--disable-profiling
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -type f -delete || die
+}


### PR DESCRIPTION
This changeset applies selected patches from upstream and makes
PYTHON_COMPAT 3.x-only. No references to python2 remain.
Also revbumped and ~marked all keywords.

Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
