### PR TITLE
Fix linux PTP build to be flexible about compiler

### DIFF
--- a/net-misc/linuxptp/linuxptp-1.8.ebuild
+++ b/net-misc/linuxptp/linuxptp-1.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-inherit linux-info
+inherit linux-info toolchain-funcs
 
 DESCRIPTION="The Linux Precision Time Protocol (PTP) implementation"
 HOMEPAGE="http://linuxptp.sourceforge.net/"
@@ -21,7 +21,7 @@ CONFIG_CHECK="~PPS ~NETWORK_PHY_TIMESTAMPING ~PTP_1588_CLOCK"
 
 src_compile() {
 	export EXTRA_CFLAGS=${CFLAGS}
-	emake prefix=/usr mandir=/usr/share/man
+	emake prefix=/usr mandir=/usr/share/man CC=$(tc-getCC) CXX=$(tc-getCXX)
 }
 
 src_install() {


### PR DESCRIPTION
Use tc-getCC and tc-getCXX to use the system toolchain compilers
instead of a potentially broken default.

Signed-off-by: Paul Stewart <pstew@google.com>