### PR TITLE
sci-libs/dlib: fix faulty cmake export

### DIFF
--- a/sci-libs/dlib/dlib-19.16.ebuild
+++ b/sci-libs/dlib/dlib-19.16.ebuild
@@ -62,6 +62,7 @@ python_configure_all() {
 
 src_configure() {
 	local mycmakeargs=(
+		-DBUILD_SHARED_LIBS="$(usex static-libs OFF ON)"
 		-DDLIB_ENABLE_ASSERTS="$(usex debug)"
 		-DDLIB_ENABLE_STACK_TRACE="$(usex debug)"
 		-DDLIB_GIF_SUPPORT="$(usex gif)"

--- a/sci-libs/dlib/dlib-19.4.ebuild
+++ b/sci-libs/dlib/dlib-19.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -38,6 +38,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
+		-DBUILD_SHARED_LIBS="$(usex static-libs OFF ON)"
 		-DLIB_INSTALL_DIR="$(get_libdir)"
 		-DDLIB_ENABLE_ASSERTS="$(usex debug)"
 		-DDLIB_ENABLE_STACK_TRACE="$(usex debug)"

--- a/sci-libs/dlib/dlib-19.7.ebuild
+++ b/sci-libs/dlib/dlib-19.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -37,6 +37,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
+		-DBUILD_SHARED_LIBS="$(usex static-libs OFF ON)"
 		-DLIB_INSTALL_DIR="$(get_libdir)"
 		-DDLIB_ENABLE_ASSERTS="$(usex debug)"
 		-DDLIB_ENABLE_STACK_TRACE="$(usex debug)"

--- a/sci-libs/dlib/dlib-19.9.ebuild
+++ b/sci-libs/dlib/dlib-19.9.ebuild
@@ -39,6 +39,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
+		-DBUILD_SHARED_LIBS="$(usex static-libs OFF ON)"
 		-DLIB_INSTALL_DIR="$(get_libdir)"
 		-DDLIB_ENABLE_ASSERTS="$(usex debug)"
 		-DDLIB_ENABLE_STACK_TRACE="$(usex debug)"


### PR DESCRIPTION
Previously the cmake export file would assume that the exported library
was always a static library causing the cmake export to not work as
expected.  Now, it passes a flag which causes the library to emit a
correct export and only build the requested form of the library.

Package-Manager: Portage-2.3.84, Repoman-2.3.20