### PR TITLE
mail-filter/rspamd: fix hyperscan support on i386

### DIFF
--- a/mail-filter/rspamd/files/rspamd-2.2-i386-hyperscan.patch
+++ b/mail-filter/rspamd/files/rspamd-2.2-i386-hyperscan.patch
@@ -1,0 +1,15 @@
+diff --git a/cmake/Hyperscan.cmake b/cmake/Hyperscan.cmake
+index 3dd774511..b8f83a3bb 100644
+--- a/cmake/Hyperscan.cmake
++++ b/cmake/Hyperscan.cmake
+@@ -1,8 +1,8 @@
+ option (ENABLE_HYPERSCAN    "Enable hyperscan for fast regexp processing [default: OFF]" OFF)
+ 
+ if (ENABLE_HYPERSCAN MATCHES "ON")
+-    if (NOT "${ARCH}" STREQUAL "x86_64")
+-        MESSAGE(FATAL_ERROR "Hyperscan is supported only on x86_64 architecture")
++    if (NOT ("${ARCH}" STREQUAL "x86_64" OR "${ARCH}" STREQUAL "i386"))
++        MESSAGE(FATAL_ERROR "Hyperscan is supported only on x86_64/i386 architectures")
+     endif ()
+     ProcessPackage (HYPERSCAN LIBRARY hs INCLUDE hs.h INCLUDE_SUFFIXES
+             hs include/hs

--- a/mail-filter/rspamd/rspamd-2.2.ebuild
+++ b/mail-filter/rspamd/rspamd-2.2.ebuild
@@ -41,6 +41,8 @@ RDEPEND="
 	!pcre2? ( dev-libs/libpcre[jit=] )"
 DEPEND="${RDEPEND}"
 
+PATCHES=( "${FILESDIR}/${P}-i386-hyperscan.patch" )
+
 src_prepare() {
 	cmake_src_prepare
 


### PR DESCRIPTION
The patch is taken from upstream.