### PR TITLE
net-proxy/redsocks: fix command args in initd

### DIFF
--- a/net-proxy/redsocks/files/redsocks.init-r1
+++ b/net-proxy/redsocks/files/redsocks.init-r1
@@ -1,0 +1,43 @@
+#!/sbin/openrc-run
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+command=${REDSOCKS_BINARY:=/usr/sbin/redsocks}
+: ${REDSOCKS_CONFIG:=/etc/redsocks.conf}
+pidfile=${REDSOCKS_PIDFILE:=/run/redsocks/redsocks.pid}
+command_args="-p ${pidfile} -c ${REDSOCKS_CONFIG}"
+
+extra_commands="checkconfig"
+extra_started_commands="reload"
+
+depend() {
+	need localmount
+	use dns
+}
+
+checkconfig() {
+	if [ ! -f "${REDSOCKS_CONFIG}" ] ; then
+		eerror "No ${REDSOCKS_CONFIG} file exists!"
+		return 1
+	fi
+
+        "${command}" -t -c ${REDSOCKS_CONFIG} || return 1
+}
+
+start_pre() {
+        checkconfig || return 1
+}
+
+stop_pre() {
+        if [ "${RC_CMD}" = "restart" ] ; then
+                checkconfig || return 1
+        fi
+}
+
+reload() {
+        checkconfig || return 1
+
+        ebegin "Reloading ${SVCNAME}"
+        start-stop-daemon --signal HUP --pidfile "${pidfile}"
+        eend $?
+}

--- a/net-proxy/redsocks/redsocks-0.5-r1.ebuild
+++ b/net-proxy/redsocks/redsocks-0.5-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+if [[ ${PV} != *9999* ]]; then
+	SRC_URI="https://github.com/darkk/${PN}/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+else
+	GIT_ECLASS="git-r3"
+	EGIT_REPO_URI="https://github.com/darkk/${PN}.git"
+fi
+
+inherit systemd toolchain-funcs user ${GIT_ECLASS}
+
+DESCRIPTION="Transparent redirector of any TCP connection to proxy"
+HOMEPAGE="http://darkk.net.ru/redsocks/"
+LICENSE="Apache-2.0 LGPL-2.1+ ZLIB"
+SLOT="0"
+IUSE="doc"
+RESTRICT="test"
+
+DEPEND="dev-libs/libevent:0="
+RDEPEND="${DEPEND}
+	net-firewall/iptables"
+
+[[ ${PV} != *9999 ]] && S="${WORKDIR}"/"${PN}"-release-"${PV}"
+
+pkg_setup() {
+	enewgroup redsocks
+	enewuser redsocks -1 -1 /run/redsocks redsocks
+}
+
+src_compile() {
+	CC="$(tc-getCC)" emake
+}
+
+src_install() {
+	dosbin redsocks
+	doman debian/redsocks.8
+	use doc && dodoc README doc/*
+	insinto /etc
+	newins debian/redsocks.conf redsocks.conf
+
+	newinitd "${FILESDIR}"/redsocks.init-r1 redsocks
+	newconfd "${FILESDIR}"/redsocks.conf redsocks
+
+	systemd_dounit "${FILESDIR}"/redsocks.service
+}


### PR DESCRIPTION
Hello,
This pull request is made just to fix the missing `--` between command and its args in initd making it failing.