### PR TITLE
sys-apps/xdg-dbus-proxy: add patch to support musl

### DIFF
--- a/sys-apps/xdg-dbus-proxy/files/xdg-dbus-proxy-0.1.2-musl.patch
+++ b/sys-apps/xdg-dbus-proxy/files/xdg-dbus-proxy-0.1.2-musl.patch
@@ -1,0 +1,23 @@
+diff --git a/dbus-proxy.c b/dbus-proxy.c
+index 163df21..4b07931 100644
+--- a/dbus-proxy.c
++++ b/dbus-proxy.c
+@@ -30,6 +30,15 @@
+ #include <errno.h>
+ 
+ #include "flatpak-proxy.h"
++// Taken from glibc unistd.h
++#ifndef TEMP_FAILURE_RETRY
++# define TEMP_FAILURE_RETRY(expression) \
++  (__extension__                                                              \
++    ({ long int __result;                                                     \
++       do __result = (long int) (expression);                                 \
++       while (__result == -1L && errno == EINTR);                             \
++       __result; }))
++#endif
+ 
+ static const char *argv0;
+ static GList *proxies;
+-- 
+2.24.1
+

--- a/sys-apps/xdg-dbus-proxy/xdg-dbus-proxy-0.1.2.ebuild
+++ b/sys-apps/xdg-dbus-proxy/xdg-dbus-proxy-0.1.2.ebuild
@@ -22,6 +22,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+# Musl patch is taken from https://github.com/flatpak/xdg-dbus-proxy/pull/13
+# which is already merged to the mainstream and should be removed after version bump.
+PATCHES=( "${FILESDIR}/${P}-musl.patch" )
+
 src_configure() {
 	econf --enable-man
 }


### PR DESCRIPTION
The patch is taken from flatpak/xdg-dbus-proxy#13, which is already merged in upstream.