### PR TITLE
net-libs/libtorrent-rasterbar: support Gentoo Prefix

### DIFF
--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.3.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.3.ebuild
@@ -73,6 +73,7 @@ src_configure() {
 		$(use_enable ssl encryption)
 		$(use_enable static-libs static)
 		$(use_enable test tests)
+		--with-boost="${EPREFIX}/usr"
 		--with-libiconv
 	)
 	econf "${myeconfargs[@]}"


### PR DESCRIPTION
Without this, ./configure via ax_boost_base finds boost library on the
host system instead of in the prefix.

Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Alexey Sokolov <sokolov@google.com>
Closes: https://bugs.gentoo.org/716448