### PR TITLE
app-admin/ansible-lint: fix dependencies

### DIFF
--- a/app-admin/ansible-lint/ansible-lint-4.0.1.ebuild
+++ b/app-admin/ansible-lint/ansible-lint-4.0.1.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7} )
+DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1
 
@@ -20,8 +21,7 @@ RESTRICT="!test? ( test )"
 CDEPEND="app-admin/ansible[${PYTHON_USEDEP}]
 		dev-python/pyyaml[${PYTHON_USEDEP}]
 		dev-python/six[${PYTHON_USEDEP}]"
-DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
-		dev-python/setuptools-git[${PYTHON_USEDEP}]
+DEPEND="<dev-python/setuptools-41.4.0[${PYTHON_USEDEP}]
 		dev-python/setuptools_scm[${PYTHON_USEDEP}]
 		dev-python/setuptools_scm_git_archive[${PYTHON_USEDEP}]
 		test? (


### PR DESCRIPTION
This PR fixes [bug 698864](https://bugs.gentoo.org/698864) by updating the
setuptools dependency of ansible-lint-4.0.1.

Related additional changes:
  - remove unused setuptools-git dependency
  - fix QA warning about DISTUTILS_USE_SETUPTOOLS

Since the package was failing install, I did not make a revbump. This problem
seems to be only present with python2.7, and I just noticed that python2.7
support has been dropped recently from this package. I believe the
dependencies are still more closely matching upstream's expectations this way.

In any case, feel free to let me know if further changes are needed on this PR!

Closes: https://bugs.gentoo.org/698864
Package-Manager: Portage-2.3.87, Repoman-2.3.20