### PR TITLE
dev-qt/qtwebengine: fix building on x86

### DIFF
--- a/dev-qt/qtwebengine/files/qtwebengine-5.14.1-disable-fatal-warnings.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.14.1-disable-fatal-warnings.patch
@@ -1,0 +1,12 @@
+diff --git a/src/buildtools/config/common.pri b/src/buildtools/config/common.pri
+index 97d3953..dd3d222 100644
+--- a/src/buildtools/config/common.pri
++++ b/src/buildtools/config/common.pri
+@@ -25,6 +25,7 @@ gn_args += \
+     v8_use_external_startup_data=false \
+     toolkit_views=false \
+     treat_warnings_as_errors=false \
++    fatal_linker_warnings=false \
+     safe_browsing_mode=0 \
+     optimize_webui=false \
+     forbid_non_component_debug_builds=false

--- a/dev-qt/qtwebengine/qtwebengine-5.14.1.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.14.1.ebuild
@@ -77,6 +77,10 @@ DEPEND="${RDEPEND}
 	sys-devel/bison
 "
 
+PATCHES=(
+	"${FILESDIR}/${P}-disable-fatal-warnings.patch" # bug 695446
+)
+
 src_prepare() {
 	if ! use jumbo-build; then
 		sed -i -e 's|use_jumbo_build=true|use_jumbo_build=false|' \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/695446
Package-Manager: Portage-2.3.76, Repoman-2.3.16
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>