### PR TITLE
www-servers/nginx-unit: Remove obsolete PHP

### DIFF
--- a/www-servers/nginx-unit/metadata.xml
+++ b/www-servers/nginx-unit/metadata.xml
@@ -17,8 +17,6 @@
 		engineering or operations.
 	</longdescription>
 	<use>
-		<flag name="php5-6">Support for PHP 5.6</flag>
-		<flag name="php7-1">Support for PHP 7.1</flag>
 		<flag name="php7-2">Support for PHP 7.2</flag>
 		<flag name="php7-3">Support for PHP 7.3</flag>
 		<flag name="php7-4">Support for PHP 7.4</flag>

--- a/www-servers/nginx-unit/nginx-unit-1.12.0-r3.ebuild
+++ b/www-servers/nginx-unit/nginx-unit-1.12.0-r3.ebuild
@@ -16,14 +16,12 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
 MY_USE="perl python ruby"
-MY_USE_PHP="php5-6 php7-1 php7-2 php7-3"
+MY_USE_PHP="php7-2 php7-3"
 IUSE="${MY_USE} ${MY_USE_PHP} ssl"
 REQUIRED_USE="|| ( ${IUSE} )
 	python? ( ${PYTHON_REQUIRED_USE} )"
 
 DEPEND="perl? ( dev-lang/perl:= )
-	php5-6? ( dev-lang/php:5.6[embed] )
-	php7-1? ( dev-lang/php:7.1[embed] )
 	php7-2? ( dev-lang/php:7.2[embed] )
 	php7-3? ( dev-lang/php:7.3[embed] )
 	python? ( ${PYTHON_DEPS} )

--- a/www-servers/nginx-unit/nginx-unit-1.13.0.ebuild
+++ b/www-servers/nginx-unit/nginx-unit-1.13.0.ebuild
@@ -16,14 +16,12 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
 MY_USE="perl python ruby"
-MY_USE_PHP="php5-6 php7-1 php7-2 php7-3"
+MY_USE_PHP="php7-2 php7-3"
 IUSE="${MY_USE} ${MY_USE_PHP} ssl"
 REQUIRED_USE="|| ( ${IUSE} )
 	python? ( ${PYTHON_REQUIRED_USE} )"
 
 DEPEND="perl? ( dev-lang/perl:= )
-	php5-6? ( dev-lang/php:5.6[embed] )
-	php7-1? ( dev-lang/php:7.1[embed] )
 	php7-2? ( dev-lang/php:7.2[embed] )
 	php7-3? ( dev-lang/php:7.3[embed] )
 	python? ( ${PYTHON_DEPS} )

--- a/www-servers/nginx-unit/nginx-unit-1.14.0.ebuild
+++ b/www-servers/nginx-unit/nginx-unit-1.14.0.ebuild
@@ -16,14 +16,12 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
 MY_USE="perl python ruby"
-MY_USE_PHP="php5-6 php7-1 php7-2 php7-3"
+MY_USE_PHP="php7-2 php7-3"
 IUSE="${MY_USE} ${MY_USE_PHP} ssl"
 REQUIRED_USE="|| ( ${IUSE} )
 	python? ( ${PYTHON_REQUIRED_USE} )"
 
 DEPEND="perl? ( dev-lang/perl:= )
-	php5-6? ( dev-lang/php:5.6[embed] )
-	php7-1? ( dev-lang/php:7.1[embed] )
 	php7-2? ( dev-lang/php:7.2[embed] )
 	php7-3? ( dev-lang/php:7.3[embed] )
 	python? ( ${PYTHON_DEPS} )

--- a/www-servers/nginx-unit/nginx-unit-1.8.0.ebuild
+++ b/www-servers/nginx-unit/nginx-unit-1.8.0.ebuild
@@ -16,13 +16,11 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64"
 MY_USE="perl python ruby"
-MY_USE_PHP="php5-6 php7-1 php7-2 php7-3"
+MY_USE_PHP="php7-2 php7-3"
 IUSE="${MY_USE} ${MY_USE_PHP}"
 REQUIRED_USE="|| ( ${IUSE} ) python? ( ${PYTHON_REQUIRED_USE} )"
 
 DEPEND="perl? ( dev-lang/perl:= )
-	php5-6? ( dev-lang/php:5.6[embed] )
-	php7-1? ( dev-lang/php:7.1[embed] )
 	php7-2? ( dev-lang/php:7.2[embed] )
 	php7-3? ( dev-lang/php:7.3[embed] )
 	python? ( ${PYTHON_DEPS} )


### PR DESCRIPTION
Remove references to PHP versions 5.6 and 7.1 which are no longer supported by Gentoo from all NGINX Unit ebuilds. Please see @juippis [comment](https://github.com/gentoo/gentoo/pull/14584#pullrequestreview-354948513).