### PR TITLE
dev-lang/go stable 1.13.6 on amd64 and x86

### DIFF
--- a/dev-lang/go/go-1.13.6.ebuild
+++ b/dev-lang/go/go-1.13.6.ebuild
@@ -21,7 +21,7 @@ case ${PV}  in
 	case ${PV} in
 	*_beta*|*_rc*) ;;
 	*)
-		KEYWORDS="-* ~amd64 ~arm ~arm64 ~ppc64 ~s390 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
+		KEYWORDS="-* amd64 ~arm ~arm64 ~ppc64 ~s390 x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
 		# The upstream tests fail under portage but pass if the build is
 		# run according to their documentation [1].
 		# I am restricting the tests on released versions until this is


### PR DESCRIPTION
I'm stabilize on both it.