### PR TITLE
app-doc/gimp-help: fix missing python_check_deps()

### DIFF
--- a/app-doc/gimp-help/gimp-help-2.10.0.ebuild
+++ b/app-doc/gimp-help/gimp-help-2.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,6 +22,10 @@ BDEPEND="${PYTHON_DEPS}
 DEPEND="$(python_gen_any_dep 'dev-libs/libxml2[python,${PYTHON_USEDEP}]')
 	dev-libs/libxslt
 "
+
+python_check_deps() {
+	has_version "dev-libs/libxml2[${PYTHON_USEDEP}]"
+}
 
 src_configure() {
 	econf --without-gimp

--- a/app-doc/gimp-help/gimp-help-2.8.2.ebuild
+++ b/app-doc/gimp-help/gimp-help-2.8.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -20,6 +20,10 @@ DEPEND="${PYTHON_DEPS}
 	dev-libs/libxslt
 	sys-devel/gettext
 "
+
+python_check_deps() {
+	has_version "dev-libs/libxml2[${PYTHON_USEDEP}]"
+}
 
 src_configure() {
 	econf --without-gimp


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/708566
