### PR TITLE
media-libs/mesa: add USE=video_cards_zink for OpenGL over Vulkan support

### DIFF
--- a/media-libs/mesa/mesa-19.3.2.ebuild
+++ b/media-libs/mesa/mesa-19.3.2.ebuild
@@ -216,6 +216,7 @@ unset {LLVM,CLANG}_DEPSTR{,_AMDGPU}
 
 DEPEND="${RDEPEND}
 	valgrind? ( dev-util/valgrind )
+	vulkan? ( media-libs/vulkan-loader[${MULTILIB_USEDEP}] )
 	X? (
 		x11-libs/libXrandr[${MULTILIB_USEDEP}]
 		x11-base/xorg-proto

--- a/media-libs/mesa/mesa-19.3.2.ebuild
+++ b/media-libs/mesa/mesa-19.3.2.ebuild
@@ -29,7 +29,7 @@ RESTRICT="
 "
 
 RADEON_CARDS="r100 r200 r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -67,6 +67,7 @@ REQUIRED_USE="
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
 	video_cards_vmware? ( gallium )
+	video_cards_zink? ( gallium vulkan )
 	xa? ( X )
 	xvmc? ( X )
 "
@@ -421,6 +422,7 @@ multilib_src_configure() {
 		gallium_enable video_cards_vc4 vc4
 		gallium_enable video_cards_vivante etnaviv
 		gallium_enable video_cards_vmware svga
+		gallium_enable video_cards_zink zink
 		gallium_enable video_cards_nouveau nouveau
 
 		# Only one i915 driver (classic vs gallium). Default to classic.

--- a/media-libs/mesa/mesa-19.3.3.ebuild
+++ b/media-libs/mesa/mesa-19.3.3.ebuild
@@ -216,6 +216,7 @@ unset {LLVM,CLANG}_DEPSTR{,_AMDGPU}
 
 DEPEND="${RDEPEND}
 	valgrind? ( dev-util/valgrind )
+	vulkan? ( media-libs/vulkan-loader[${MULTILIB_USEDEP}] )
 	X? (
 		x11-libs/libXrandr[${MULTILIB_USEDEP}]
 		x11-base/xorg-proto

--- a/media-libs/mesa/mesa-19.3.3.ebuild
+++ b/media-libs/mesa/mesa-19.3.3.ebuild
@@ -29,7 +29,7 @@ RESTRICT="
 "
 
 RADEON_CARDS="r100 r200 r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -67,6 +67,7 @@ REQUIRED_USE="
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
 	video_cards_vmware? ( gallium )
+	video_cards_zink? ( gallium vulkan )
 	xa? ( X )
 	xvmc? ( X )
 "
@@ -421,6 +422,7 @@ multilib_src_configure() {
 		gallium_enable video_cards_vc4 vc4
 		gallium_enable video_cards_vivante etnaviv
 		gallium_enable video_cards_vmware svga
+		gallium_enable video_cards_zink zink
 		gallium_enable video_cards_nouveau nouveau
 
 		# Only one i915 driver (classic vs gallium). Default to classic.

--- a/media-libs/mesa/mesa-20.0.0_rc2.ebuild
+++ b/media-libs/mesa/mesa-20.0.0_rc2.ebuild
@@ -216,6 +216,7 @@ unset {LLVM,CLANG}_DEPSTR{,_AMDGPU}
 
 DEPEND="${RDEPEND}
 	valgrind? ( dev-util/valgrind )
+	vulkan? ( media-libs/vulkan-loader[${MULTILIB_USEDEP}] )
 	X? (
 		x11-libs/libXrandr[${MULTILIB_USEDEP}]
 		x11-base/xorg-proto

--- a/media-libs/mesa/mesa-20.0.0_rc2.ebuild
+++ b/media-libs/mesa/mesa-20.0.0_rc2.ebuild
@@ -29,7 +29,7 @@ RESTRICT="
 "
 
 RADEON_CARDS="r100 r200 r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -67,6 +67,7 @@ REQUIRED_USE="
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
 	video_cards_vmware? ( gallium )
+	video_cards_zink? ( gallium vulkan )
 	xa? ( X )
 	xvmc? ( X )
 "
@@ -421,6 +422,7 @@ multilib_src_configure() {
 		gallium_enable video_cards_vc4 vc4
 		gallium_enable video_cards_vivante etnaviv
 		gallium_enable video_cards_vmware svga
+		gallium_enable video_cards_zink zink
 		gallium_enable video_cards_nouveau nouveau
 
 		# Only one i915 driver (classic vs gallium). Default to classic.

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -217,6 +217,7 @@ unset {LLVM,CLANG}_DEPSTR{,_AMDGPU}
 
 DEPEND="${RDEPEND}
 	valgrind? ( dev-util/valgrind )
+	vulkan? ( media-libs/vulkan-loader[${MULTILIB_USEDEP}] )
 	X? (
 		x11-libs/libXrandr[${MULTILIB_USEDEP}]
 		x11-base/xorg-proto

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -29,7 +29,7 @@ RESTRICT="
 "
 
 RADEON_CARDS="r100 r200 r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -67,6 +67,7 @@ REQUIRED_USE="
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
 	video_cards_vmware? ( gallium )
+	video_cards_zink? ( gallium vulkan )
 	xa? ( X )
 	xvmc? ( X )
 "
@@ -422,6 +423,7 @@ multilib_src_configure() {
 		gallium_enable video_cards_vc4 vc4
 		gallium_enable video_cards_vivante etnaviv
 		gallium_enable video_cards_vmware svga
+		gallium_enable video_cards_zink zink
 		gallium_enable video_cards_nouveau nouveau
 
 		# Only one i915 driver (classic vs gallium). Default to classic.

--- a/profiles/desc/video_cards.desc
+++ b/profiles/desc/video_cards.desc
@@ -42,3 +42,4 @@ virgl - VIDEO_CARDS setting to build driver for virgil (virtual 3D GPU)
 virtualbox - VIDEO_CARDS setting to build driver for virtualbox emulation
 vivante - VIDEO_CARDS setting to build etnaviv driver for vivante video cards
 vmware - VIDEO_CARDS setting to build driver for vmware video cards
+zink - VIDEO_CARDS setting to build driver for OpenGL over Vulkan support


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/708838