### PR TITLE
media-libs/exempi:

### DIFF
--- a/media-libs/exempi/exempi-2.4.5-r1.ebuild
+++ b/media-libs/exempi/exempi-2.4.5-r1.ebuild
@@ -30,6 +30,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.4.2-iconv.patch
 	"${FILESDIR}"/${P}-CVE-2018-12648.patch
+	"${FILESDIR}"/${P}-p2_support_gcc_9_2_0_cxx17.patch
 )
 
 src_prepare() {

--- a/media-libs/exempi/files/exempi-2.4.5-p2_support_gcc_9_2_0_cxx17.patch
+++ b/media-libs/exempi/files/exempi-2.4.5-p2_support_gcc_9_2_0_cxx17.patch
@@ -1,0 +1,11 @@
+--- a/XMPFiles/source/FormatSupport/P2_Support.hpp	2020-02-10 22:21:55.853530993 +0300
++++ b/XMPFiles/source/FormatSupport/P2_Support.hpp	2020-02-10 22:23:02.931728502 +0300
+@@ -79,7 +79,7 @@
+ }; // class P2_Clip
+ struct P2SpannedClip_Order
+ {
+-	bool operator()( P2_Clip* lhs,  P2_Clip* rhs)   
++	bool operator()( P2_Clip* lhs,  P2_Clip* rhs) const
+ 	{  
+ 		return lhs->GetOffsetInShot() < rhs->GetOffsetInShot();
+ 	}


### PR DESCRIPTION
support gcc-9.2.0 with c++17 by applying a patch

P2_Support.hpp: operator() of predicate 'P2SpannedClip_Order' is made to be 'const'
fixed static_assert 'is_invocable_v<const _Compare&, const _Key&, const _Key&>'

a new patch 'exempi-2.4.5-p2_support_gcc_9_2_0_cxx17.patch' provided

Signed-off-by: Denis Pronin <dannftk@yandex.ru>

Package-Manager: Portage-2.3.84, Repoman-2.3.20