### PR TITLE
sci-electronics/iverilog: fix 10.3 gcc-10 build problem

### DIFF
--- a/sci-electronics/iverilog/files/iverilog-10.3-fno-common.patch
+++ b/sci-electronics/iverilog/files/iverilog-10.3-fno-common.patch
@@ -1,0 +1,33 @@
+https://bugs.gentoo.org/706366
+--- a/driver/cflexor.lex
++++ b/driver/cflexor.lex
+@@ -27,6 +27,8 @@
+ # include  "globals.h"
+ # include  <string.h>
+ 
++char *current_file = NULL;
++
+ static int comment_enter;
+ static char* trim_trailing_white(char*txt, int trim);
+ 
+--- a/driver/cfparse_misc.h
++++ b/driver/cfparse_misc.h
+@@ -39,6 +39,6 @@ int cferror(const char *);
+ int cfparse(void);
+ void switch_to_command_file(const char *);
+ void destroy_lexor(void);
+-char *current_file;
++extern char *current_file;
+ 
+ #endif /* IVL_cfparse_misc_H */
+--- a/libveriuser/priv.h
++++ b/libveriuser/priv.h
+@@ -31,6 +31,6 @@ extern char* __acc_newstring(const char*txt);
+ /*
+  * Trace file for logging ACC and TF calls.
+  */
+-FILE* pli_trace;
++extern FILE* pli_trace;
+ 
+ #endif /* IVL_priv_H */
+

--- a/sci-electronics/iverilog/iverilog-10.3.ebuild
+++ b/sci-electronics/iverilog/iverilog-10.3.ebuild
@@ -40,6 +40,7 @@ DEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-10.3-file-missing.patch #705412
+	"${FILESDIR}"/${PN}-10.3-fno-common.patch #706366
 )
 
 src_prepare() {


### PR DESCRIPTION
gcc-10 and above flipped a default from -fcommon to -fno-common:
https://gcc.gnu.org/PR85678

Usually all it takes is to add a few 'extern' declarations and
move definitions from header files to modules. I've port iverilog
to gcc-10 accroding to this guide:
https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common

A commit has been sent to upstream:
steveicarus/iverilog#302

Closes: https://bugs.gentoo.org/706366
Package-Manager: Portage-2.3.85, Repoman-2.3.20
Signed-off-by: Huang Rui vowstar@gmail.com