### PR TITLE
net-p2p/retroshare: avoid broken doxygen-1.8.16

### DIFF
--- a/net-p2p/retroshare/retroshare-0.6.5.ebuild
+++ b/net-p2p/retroshare/retroshare-0.6.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -50,7 +50,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	gui? ( dev-qt/designer:5 )
 	jsonapi? (
-		app-doc/doxygen
+		|| ( <app-doc/doxygen-1.8.16 >=app-doc/doxygen-1.8.17 )
 		dev-util/cmake
 	)
 	dev-qt/qtcore:5


### PR DESCRIPTION
Fix bug https://bugs.gentoo.org/show_bug.cgi?id=709252 and
  https://bugs.gentoo.org/699164 due to doxygen 1.8.16 bug
  https://github.com/doxygen/doxygen/issues/7236