### PR TITLE
app-admin/procinfo-ng

### DIFF
--- a/app-admin/procinfo-ng/files/procinfo-ng-2.0.304-use-cxxflags.patch
+++ b/app-admin/procinfo-ng/files/procinfo-ng-2.0.304-use-cxxflags.patch
@@ -1,0 +1,50 @@
+--- a/configure.in
++++ b/configure.in
+@@ -38,10 +38,10 @@
+ [ enable_maintainer_mode=yes ])
+ 
+ if test "$enable_maintainer_mode" = "yes"; then
+-	CFLAGS="-O0 -g3 --pipe -Wall"
++	CXXFLAGS="-O0 -g3 --pipe -Wall"
+	LDFLAGS="-lncurses"
+ else
+-	CFLAGS="$CFLAGS -pipe -Wall"
++	CXXFLAGS="$CXXFLAGS -pipe -Wall"
+	LDFLAGS="-s -lncurses"
+ fi
+ 
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -15,15 +15,15 @@
+ 
+ ### Add to taste:
+ 
+-# CFLAGS  = -g 
++# CXXFLAGS  = -g 
+ # LDFLAGS = -g
+ 
+-# CFLAGS += -DPROC_DIR=\"extra2/\"
++# CXXFLAGS += -DPROC_DIR=\"extra2/\"
+ 
+-# CFLAGS += -DDEBUG
++# CXXFLAGS += -DDEBUG
+ # LDLIBS += -ldmalloc
+ 
+-# CFLAGS += -pg
++# CXXFLAGS += -pg
+ # LDFLAGS = -pg
+ 
+ ### End of configurable options.
+@@ -44,10 +44,10 @@
+ cygwin_procstat.cpp cygwin_rendercpupagestat.cpp \
+ lib/routines.cpp lib/timeRoutines.cpp lib/prettyPrint.cpp \
+ Makefile
+-	$(CXX) $(CFLAGS) $(LDFLAGS) procinfo.cpp -o $@ $(LIBS)
++	$(CXX) $(CXXFLAGS) $(LDFLAGS) procinfo.cpp -o $@ $(LIBS)
+ 
+ #procinfo.o: procinfo.cpp procinfo.h
+-#	$(XX) $(CFLAGS) procinfo.cpp -o procinfo.o
++#	$(CXX) $(CXXFLAGS) procinfo.cpp -o procinfo.o
+ 
+ install: procinfo procinfo.8
+ 	-mkdir -p $(DESTDIR)/$(prefix)/bin

--- a/app-admin/procinfo-ng/files/procinfo-ng-2.0.304-use-pkgconfig.patch
+++ b/app-admin/procinfo-ng/files/procinfo-ng-2.0.304-use-pkgconfig.patch
@@ -1,0 +1,14 @@
+diff -Naur procinfo-ng-2.0.304/configure.in procinfo-ng-2.0.304.new/configure.in
+--- a/configure.in
++++ b/configure.in
+@@ -45,6 +45,10 @@
+ 	LDFLAGS="-s -lncurses"
+ fi
+ 
++PKG_CHECK_MODULES([NCURSES], [ncurses])
++CPPFLAGS+=" ${NCURSES_CFLAGS}"
++LIBS+=" ${NCURSES_LIBS}"
++
+ AC_OUTPUT(Makefile)
+ #AC_CONFIG_FILES([Makefile])
+ #AC_OUTPUT

--- a/app-admin/procinfo-ng/procinfo-ng-2.0.304-r1.ebuild
+++ b/app-admin/procinfo-ng/procinfo-ng-2.0.304-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -23,6 +23,8 @@ DEPEND="${RDEPEND}
 PATCHES=(
 	"${FILESDIR}"/${P}-as-needed.patch
 	"${FILESDIR}"/${P}-man.patch
+	"${FILESDIR}"/${P}-use-cxxflags.patch
+	"${FILESDIR}"/${P}-use-pkgconfig.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
provided patches those:
  * use CXXFLAGS instead of CFLAGS as CXX compiler is used rather than CC
  * link against what 'pkg-config --libs ncurses' returns

Signed-off-by: Denis Pronin <dannftk@yandex.ru>

Package-Manager: Portage-2.3.84, Repoman-2.3.20