### PR TITLE
 sys-libs/tdb patch

### DIFF
--- a/sys-libs/tdb/files/tdb-1.4.3-xattrs-escape-warns.patch
+++ b/sys-libs/tdb/files/tdb-1.4.3-xattrs-escape-warns.patch
@@ -1,0 +1,16 @@
+--- a/lib/replace/system/filesys.h 2019-12-10 14:01:31.000000000 +0300
++++ b/lib/replace/system/filesys.h 2020-04-01 00:07:33.046855175 +0300
+@@ -114,10 +114,10 @@
+ #endif
+ 
+ /* mutually exclusive (SuSE 8.2) */
+-#if defined(HAVE_ATTR_XATTR_H)
+-#include <attr/xattr.h>
+-#elif defined(HAVE_SYS_XATTR_H)
++#if defined(HAVE_SYS_XATTR_H)
+ #include <sys/xattr.h>
++#elif defined(HAVE_ATTR_XATTR_H)
++#include <attr/xattr.h>
+ #endif
+ 
+ #ifdef HAVE_SYS_EA_H

--- a/sys-libs/tdb/tdb-1.4.3.ebuild
+++ b/sys-libs/tdb/tdb-1.4.3.ebuild
@@ -30,6 +30,10 @@ WAF_BINARY="${S}/buildtools/bin/waf"
 
 RESTRICT="test"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-xattrs-escape-warns.patch
+)
+
 src_prepare() {
 	default
 	python_fix_shebang .


### PR DESCRIPTION
Provided the patch applying favoring sys/xattr.h over attr/xattr.h

Signed-off-by: Denis Pronin <dannftk@yandex.ru>

Package-Manager: Portage-2.3.84, Repoman-2.3.20