### PR TITLE
gui-apps/mako: needs scdoc >=1.9.7 to build

### DIFF
--- a/gui-apps/mako/mako-1.4.1.ebuild
+++ b/gui-apps/mako/mako-1.4.1.ebuild
@@ -39,7 +39,7 @@ RDEPEND="
 "
 BDEPEND="
 	virtual/pkgconfig
-	app-text/scdoc
+	>=app-text/scdoc-1.9.7
 "
 
 src_configure() {

--- a/gui-apps/mako/mako-1.4.1.ebuild
+++ b/gui-apps/mako/mako-1.4.1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/emersion/${PN}.git"
 else
 	SRC_URI="https://github.com/emersion/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 arm64 x86"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
Build with scdoc 1.9.3 fails with:
```
FAILED: makoctl.1 
/bin/sh -c '/usr/bin/scdoc < ../mako-1.4.1/makoctl.1.scd > makoctl.1'
Error at 40:4: Cannot deindent in literal block
```

According to emersion/mako#213 it needs at least scdoc [1.9.7](https://git.sr.ht/~sircmpwn/scdoc/refs/1.9.7) to fix that, gentoo has only 1.10.0, and it works with that.