### PR TITLE
net-p2p/retroshare: 0.6.5 need <libupnp-1.8.0

### DIFF
--- a/net-p2p/retroshare/retroshare-0.6.5.ebuild
+++ b/net-p2p/retroshare/retroshare-0.6.5.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	app-arch/bzip2
 	dev-libs/openssl:0=
 	>=dev-libs/rapidjson-1.1.0
-	net-libs/libupnp:0=
+	<net-libs/libupnp-1.8.0
 	sys-libs/zlib
 	control-socket? ( dev-qt/qtnetwork:5 )
 	gnome-keyring? ( gnome-base/libgnome-keyring )


### PR DESCRIPTION
RetroShare 0.6.5 woun't build with libupnp 1.8 series so specify version
  dependency in ebuild

Closes: https://bugs.gentoo.org/709514