### PR TITLE
app-cdr/dvdisaster: mitigate -fno-common/gcc10 compile error

### DIFF
--- a/app-cdr/dvdisaster/dvdisaster-0.79.5.ebuild
+++ b/app-cdr/dvdisaster/dvdisaster-0.79.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit desktop gnome2-utils toolchain-funcs
+inherit desktop flag-o-matic gnome2-utils toolchain-funcs
 
 DESCRIPTION="Tool for creating error correction data (ecc) for optical media (DVD, CD, BD)"
 HOMEPAGE="http://dvdisaster.net/"
@@ -32,6 +32,7 @@ DEPEND="${RDEPEND}
 "
 
 src_configure() {
+	append-cflags -fcommon
 	./configure \
 		--prefix=/usr \
 		--bindir=/usr/bin \


### PR DESCRIPTION
Add "-fcommon" cflag using flag-o-matic

Closes: https://bugs.gentoo.org/709520
Signed-off-by: Daniel Kenzelmann <gentoo@k8n.de>