### PR TITLE
sci-electronics/iverilog: fix DEPEND's problem

### DIFF
--- a/sci-electronics/iverilog/iverilog-10.3.ebuild
+++ b/sci-electronics/iverilog/iverilog-10.3.ebuild
@@ -35,6 +35,8 @@ RDEPEND="
 
 DEPEND="
 	dev-util/gperf
+	sys-devel/bison
+	sys-devel/flex
 	${RDEPEND}
 "
 

--- a/sci-electronics/iverilog/iverilog-9999.ebuild
+++ b/sci-electronics/iverilog/iverilog-9999.ebuild
@@ -35,6 +35,8 @@ RDEPEND="
 
 DEPEND="
 	dev-util/gperf
+	sys-devel/bison
+	sys-devel/flex
 	${RDEPEND}
 "
 


### PR DESCRIPTION
Add flex and bison to DEPEND's of the iverilog suggested by @trofi
in #14619
