### PR TITLE
app-misc/ttyrec: fix building with glibc 2.30

### DIFF
--- a/app-misc/ttyrec/files/ttyrec-1.0.8-glibc-2.30.patch
+++ b/app-misc/ttyrec/files/ttyrec-1.0.8-glibc-2.30.patch
@@ -1,0 +1,30 @@
+diff --git a/ttyrec.c b/ttyrec.c
+index 3392f70..86a59ee 100644
+--- a/ttyrec.c
++++ b/ttyrec.c
+@@ -57,7 +57,9 @@
+ 
+ #if defined(SVR4)
+ #include <fcntl.h>
++#if !(defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(__linux__))
+ #include <stropts.h>
++#endif
+ #endif /* SVR4 */
+ 
+ #include <sys/time.h>
+@@ -449,6 +451,7 @@ getslave()
+ 		perror("open(fd, O_RDWR)");
+ 		fail();
+ 	}
++#ifndef __linux__
+ 	if (isastream(slave)) {
+ 		if (ioctl(slave, I_PUSH, "ptem") < 0) {
+ 			perror("ioctl(fd, I_PUSH, ptem)");
+@@ -466,6 +469,7 @@ getslave()
+ #endif
+ 		(void) ioctl(0, TIOCGWINSZ, (char *)&win);
+ 	}
++#endif
+ #else /* !SVR4 */
+ #ifndef HAVE_openpty
+ 	line[strlen("/dev/")] = 't';

--- a/app-misc/ttyrec/ttyrec-1.0.8-r2.ebuild
+++ b/app-misc/ttyrec/ttyrec-1.0.8-r2.ebuild
@@ -12,7 +12,10 @@ SRC_URI="http://0xcc.net/ttyrec/${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
-PATCHES=( "${FILESDIR}/${P}-flags.patch" )
+PATCHES=(
+	"${FILESDIR}/${P}-flags.patch"
+	"${FILESDIR}/${P}-glibc-2.30.patch"
+)
 
 src_compile() {
 	# Bug 106530


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/691908
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>