### PR TITLE
Create eselect-vala-0.1.2.ebuild

### DIFF
--- a/app-eselect/eselect-vala/eselect-vala-0.1.2.ebuild
+++ b/app-eselect/eselect-vala/eselect-vala-0.1.2.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2011 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+EAPI=6
+
+DESCRIPTION="Eselect module to maintain vala compiler symlink"
+HOMEPAGE="http://code.google.com/p/eselect-vala/"
+
+SRC_URI="https://github.com/Bodyfarm/eselect-vala/raw/master/eselect-vala-0.1.2.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~arm ~arm64"
+IUSE=""
+
+RDEPEND="app-admin/eselect
+	dev-lang/vala"
+DEPEND="${RDEPEND}
+	>=sys-devel/m4-1.4.13"
+
+DOCS="AUTHORS README"
+
+src_install() {
+	emake DESTDIR="${D}" install
+	dodoc ${DOCS}
+}


### PR DESCRIPTION
https://github.com/Bodyfarm/eselect-vala/tree/master repo can be given back to gentoo..

while this often fixes the vala symlinks , and has been a tool of use. 
https://github.com/Bodyfarm/eselect-vala/issues/2

repo can be Gentoo's lockstock n barrel , i just rescued from Google codes fire... 

anyway why should i keep "Hording it"