### PR TITLE
x11-misc/xbindkeys: Fix key mask patch

### DIFF
--- a/x11-misc/xbindkeys/files/xbindkeys-apply-mask-on-release-event-status.patch
+++ b/x11-misc/xbindkeys/files/xbindkeys-apply-mask-on-release-event-status.patch
@@ -1,11 +1,16 @@
-commit ceb7093f8d77cf5952e8e7778db02a6f3e8d8872
-Author: Alberto <address@hidden>
-Date:   Mon Feb 10 09:21:57 2014 +0200
+From d4a943caa3d700a5edb18d5ab528e8cf7f6d54c9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alberto=20S=E1nchez=20Molero?= <alsamolero@gmail.com>
+Date: Mon, 10 Feb 2014 21:11:05 +0100
+Subject: Fix keyboard layout problems - Ignore 13th and 14th bits of button
+ state
 
-    fix keyboard layout problems
+Author:    Alberto Sanchez Molero <alsamolero@gmail.com>
+---
+ xbindkeys.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/xbindkeys.c b/xbindkeys.c
-index b0adef9..162e47e 100644
+index b0adef9..5b1b86b 100644
 --- a/xbindkeys.c
 +++ b/xbindkeys.c
 @@ -377,7 +377,7 @@ event_loop (Display * d)
@@ -13,7 +18,7 @@ index b0adef9..162e47e 100644
  	    }
  
 -	  e.xbutton.state &= ~(numlock_mask | capslock_mask | scrolllock_mask
-+	  e.xbutton.state &= 0x1FFF && ~(numlock_mask | capslock_mask | scrolllock_mask
++	  e.xbutton.state &= 0x1FFF & ~(numlock_mask | capslock_mask | scrolllock_mask
  			       | Button1Mask | Button2Mask | Button3Mask
  			       | Button4Mask | Button5Mask);
  
@@ -22,7 +27,10 @@ index b0adef9..162e47e 100644
  	    }
  
 -	  e.xbutton.state &= ~(numlock_mask | capslock_mask | scrolllock_mask
-+	  e.xbutton.state &= 0x1FFF && ~(numlock_mask | capslock_mask | scrolllock_mask
++	  e.xbutton.state &= 0x1FFF & ~(numlock_mask | capslock_mask | scrolllock_mask
  			       | Button1Mask | Button2Mask | Button3Mask
  			       | Button4Mask | Button5Mask);
  
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
Change logical to bitwise AND while applying the mask on the key value in the applied patch. The patch was added in the request #12938, but the previous version of it occasionally wasn't correct.