### PR TITLE
x11-terms/kitty: add imagemagick as optfeature

### DIFF
--- a/x11-terms/kitty/kitty-0.16.0.ebuild
+++ b/x11-terms/kitty/kitty-0.16.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit python-single-r1 toolchain-funcs xdg
+inherit python-single-r1 toolchain-funcs xdg eutils
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/kovidgoyal/kitty.git"
@@ -38,7 +38,6 @@ RDEPEND="
 	x11-libs/libXrandr
 	sys-apps/dbus
 	sys-libs/zlib
-	virtual/imagemagick-tools
 	wayland? (
 		dev-libs/wayland
 		>=dev-libs/wayland-protocols-1.17
@@ -94,6 +93,7 @@ src_install() {
 
 pkg_postinst() {
 	xdg_icon_cache_update
+	optfeature "Displaying images in the terminal" virtual/imagemagick-tools
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Removed imagemagick from RDEPEND since it is only required if the user wants to output images in the terminal. It has been added as `optfeature`.

Signed-off-by: Pablo Orduna <pabloorduna98@gmail.com>