### PR TITLE
dev-qt/qtwebengine: 5.14.1 version is enabled to support clang

### DIFF
--- a/dev-qt/qtwebengine/files/qtwebengine-5.14.1-clang.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.14.1-clang.patch
@@ -1,0 +1,13 @@
+--- a/src/3rdparty/gn/build/gen.py
++++ b/src/3rdparty/gn/build/gen.py
+@@ -358,9 +358,7 @@
+ 
+     if platform.is_linux():
+       ldflags.append('-Wl,--as-needed')
+-
+-      if not options.no_static_libstdcpp:
+-        ldflags.append('-static-libstdc++')
++      ldflags.append('-static -rtlib=libgcc')
+ 
+       # This is needed by libc++.
+       libs.append('-ldl')

--- a/dev-qt/qtwebengine/qtwebengine-5.14.1.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.14.1.ebuild
@@ -79,6 +79,7 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}/${P}-disable-fatal-warnings.patch" # bug 695446
+	"${FILESDIR}/${P}-clang.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
5.14.1 version is enabled to support clang

Signed-off-by: Denis Pronin <dannftk@yandex.ru>