### PR TITLE
net-mail/mu: Stop blocking mailutils

### DIFF
--- a/net-mail/mu/mu-0.9.18-r2.ebuild
+++ b/net-mail/mu/mu-0.9.18-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,14 +14,11 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="emacs"
 
-# net-mail/mailutils also installes /usr/bin/mu.  Block it until somebody
-# really wants both installed at the same time.
 DEPEND="
 	dev-libs/gmime:2.6
 	dev-libs/xapian
 	dev-libs/glib:2
-	emacs? ( >=app-editors/emacs-23.1:* )
-	!net-mail/mailutils"
+	emacs? ( >=app-editors/emacs-23.1:* )"
 RDEPEND="${DEPEND}"
 
 SITEFILE="70mu-gentoo.el"

--- a/net-mail/mu/mu-1.0.ebuild
+++ b/net-mail/mu/mu-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,14 +14,11 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="emacs"
 
-# net-mail/mailutils also installes /usr/bin/mu.  Block it until somebody
-# really wants both installed at the same time.
 DEPEND="
 	dev-libs/gmime:2.6
 	dev-libs/xapian
 	dev-libs/glib:2
-	emacs? ( >=app-editors/emacs-23.1:* )
-	!net-mail/mailutils"
+	emacs? ( >=app-editors/emacs-23.1:* )"
 RDEPEND="${DEPEND}"
 
 SITEFILE="70mu-gentoo.el"

--- a/net-mail/mu/mu-1.3.5.ebuild
+++ b/net-mail/mu/mu-1.3.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,15 +14,12 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="emacs guile"
 
-# net-mail/mailutils also installes /usr/bin/mu.  Block it until somebody
-# really wants both installed at the same time.
 DEPEND="
 	dev-libs/gmime:3.0
 	>=dev-libs/xapian-1.4
 	dev-libs/glib:2
 	emacs? ( >=app-editors/emacs-24.4:* )
-	guile? ( >=dev-scheme/guile-2.0 )
-	!net-mail/mailutils"
+	guile? ( >=dev-scheme/guile-2.0 )"
 RDEPEND="${DEPEND}"
 BDEPEND="virtual/pkgconfig"
 

--- a/net-mail/mu/mu-1.3.6-r1.ebuild
+++ b/net-mail/mu/mu-1.3.6-r1.ebuild
@@ -24,11 +24,7 @@ DEPEND="
 		net-libs/webkit-gtk:4
 		x11-libs/gtk+:3
 	)"
-# net-mail/mailutils also installes /usr/bin/mu.  Block it until somebody
-# really wants both installed at the same time.
-RDEPEND="
-	${DEPEND}
-	!net-mail/mailutils"
+RDEPEND="${DEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 SITEFILE="70mu-gentoo-autoload.el"

--- a/net-mail/mu/mu-1.3.6.ebuild
+++ b/net-mail/mu/mu-1.3.6.ebuild
@@ -24,11 +24,7 @@ DEPEND="
 		net-libs/webkit-gtk:4
 		x11-libs/gtk+:3
 	)"
-# net-mail/mailutils also installes /usr/bin/mu.  Block it until somebody
-# really wants both installed at the same time.
-RDEPEND="
-	${DEPEND}
-	!net-mail/mailutils"
+RDEPEND="${DEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 SITEFILE="70mu-gentoo.el"


### PR DESCRIPTION
After version 2.99.99, the mailutils binary mu was renamed to mailutils and so they can now be installed simultaneously.

Closes: https://bugs.gentoo.org/710388
Signed-off-by: Matt Smith <matt@offtopica.uk>
Package-Manager: Portage-2.3.89, Repoman-2.3.20