### PR TITLE
net-irc/kvirc: 9999 requires cmake 3.12, not 3.16

### DIFF
--- a/net-irc/kvirc/kvirc-9999.ebuild
+++ b/net-irc/kvirc/kvirc-9999.ebuild
@@ -34,7 +34,7 @@ IUSE="audiofile +dbus dcc_video debug doc gsm kde +nls oss +perl +phonon profile
 REQUIRED_USE="audiofile? ( oss ) python? ( ${PYTHON_REQUIRED_USE} )"
 
 BDEPEND="dev-lang/perl:0
-	>=dev-util/cmake-3.16
+	>=dev-util/cmake-3.12
 	virtual/pkgconfig
 	doc? ( app-doc/doxygen )
 	kde? ( kde-frameworks/extra-cmake-modules:5 )


### PR DESCRIPTION
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Alexey Sokolov <sokolov@google.com>