### PR TITLE
app-admin/gam-server: supported building with clang

### DIFF
--- a/app-admin/gam-server/files/gam-server-0.1.10-clang.patch
+++ b/app-admin/gam-server/files/gam-server-0.1.10-clang.patch
@@ -1,0 +1,11 @@
+--- a/server/gam_eq.c	2007-07-04 17:36:49.000000000 +0400
++++ b/server/gam_eq.c	2020-02-22 12:04:48.311099825 +0300
+@@ -124,7 +124,7 @@
+ {
+ 	gboolean done_work = FALSE;
+ 	if (!eq)
+-		return;
++		return done_work;
+ 
+ #ifdef GAM_EQ_VERBOSE
+ 	GAM_DEBUG(DEBUG_INFO, "gam_eq: Flushing event queue for %s\n", gam_connection_get_pidname (conn));

--- a/app-admin/gam-server/gam-server-0.1.10-r2.ebuild
+++ b/app-admin/gam-server/gam-server-0.1.10-r2.ebuild
@@ -48,6 +48,9 @@ src_prepare() {
 	# Fix deadlocks with glib-2.32, bug #413331, upstream #667230
 	epatch "${FILESDIR}/${P}-ih_sub_cancel-deadlock.patch"
 
+	# Fix missing result returned in gam_eq.c, gam_eq_flush function, line 127
+	epatch "${FILESDIR}/${P}-clang.patch"
+
 	# Drop DEPRECATED flags
 	sed -i -e 's:-DG_DISABLE_DEPRECATED:$(NULL):g' server/Makefile.am || die
 


### PR DESCRIPTION
supported building with clang, fixed missing value returned

clang does not allow you to return nothing when a function is supposed to return a value

Signed-off-by: Denis Pronin <dannftk@yandex.ru>