### PR TITLE
net-misc/nyx: require python with sqlite; EAPI 7; pypy3

### DIFF
--- a/net-misc/nyx/nyx-2.1.0-r1.ebuild
+++ b/net-misc/nyx/nyx-2.1.0-r1.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=6
 PYTHON_COMPAT=(python{3_6,3_7,3_8})
+PYTHON_REQ_USE='sqlite(-)'
 
 inherit vcs-snapshot distutils-r1
 
@@ -24,5 +25,5 @@ RESTRICT="!test? ( test )"
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]"
 RDEPEND="
-	net-libs/stem
+	net-libs/stem[${PYTHON_USEDEP}]
 	net-vpn/tor"

--- a/net-misc/nyx/nyx-2.1.0-r1.ebuild
+++ b/net-misc/nyx/nyx-2.1.0-r1.ebuild
@@ -1,11 +1,13 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-PYTHON_COMPAT=(python{3_6,3_7,3_8})
-PYTHON_REQ_USE='sqlite(-)'
+EAPI=7
 
-inherit vcs-snapshot distutils-r1
+PYTHON_COMPAT=(python3_{6,7,8} pypy3)
+PYTHON_REQ_USE='sqlite(-)'
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
+inherit distutils-r1
 
 DESCRIPTION="Utility to monitor real time Tor status information"
 HOMEPAGE="https://nyx.torproject.org"
@@ -22,8 +24,6 @@ SLOT="0"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
-DEPEND="
-	dev-python/setuptools[${PYTHON_USEDEP}]"
 RDEPEND="
 	net-libs/stem[${PYTHON_USEDEP}]
 	net-vpn/tor"


### PR DESCRIPTION
Depends on pypy3 in net-libs/stem (https://github.com/gentoo/gentoo/pull/14745)

See https://github.com/torproject/nyx/blob/796089d28debb1c4f6d4ee645214e3fc61068a12/nyx/__init__.py#L93-L96