### PR TITLE
dev-ros/rviz: EAPI 7, force single-precision ogre

### DIFF
--- a/dev-ros/rviz/rviz-1.13.1-r2.ebuild
+++ b/dev-ros/rviz/rviz-1.13.1-r2.ebuild
@@ -1,12 +1,12 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI="7"
 
 ROS_REPO_URI="https://github.com/ros-visualization/rviz"
-KEYWORDS=""
+KEYWORDS="~amd64"
 
-inherit ros-catkin virtualx
+inherit ros-catkin
 
 DESCRIPTION="3D visualization tool for ROS"
 LICENSE="BSD"
@@ -64,8 +64,4 @@ DEPEND="${RDEPEND}
 src_configure() {
 	local mycatkincmakeargs=( "-DUseQt5=ON" )
 	ros-catkin_src_configure
-}
-
-src_test() {
-	virtx ros-catkin_src_test
 }

--- a/dev-ros/rviz/rviz-1.13.3-r1.ebuild
+++ b/dev-ros/rviz/rviz-1.13.3-r1.ebuild
@@ -1,12 +1,12 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI="7"
 
 ROS_REPO_URI="https://github.com/ros-visualization/rviz"
-KEYWORDS=""
+KEYWORDS="~amd64"
 
-inherit ros-catkin virtualx
+inherit ros-catkin
 
 DESCRIPTION="3D visualization tool for ROS"
 LICENSE="BSD"
@@ -64,8 +64,4 @@ DEPEND="${RDEPEND}
 src_configure() {
 	local mycatkincmakeargs=( "-DUseQt5=ON" )
 	ros-catkin_src_configure
-}
-
-src_test() {
-	virtx ros-catkin_src_test
 }

--- a/dev-ros/rviz/rviz-1.13.6-r1.ebuild
+++ b/dev-ros/rviz/rviz-1.13.6-r1.ebuild
@@ -1,10 +1,10 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI="7"
 
 ROS_REPO_URI="https://github.com/ros-visualization/rviz"
-KEYWORDS=""
+KEYWORDS="~amd64"
 
 inherit ros-catkin virtualx
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/710540
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>