### PR TITLE
dev-python/python-language-server: fix dep versions

### DIFF
--- a/dev-python/python-language-server/python-language-server-0.31.8.ebuild
+++ b/dev-python/python-language-server/python-language-server-0.31.8.ebuild
@@ -19,10 +19,12 @@ KEYWORDS="~amd64 ~x86"
 
 BDEPEND="dev-python/versioneer[${PYTHON_USEDEP}]"
 
-RDEPEND="dev-python/jedi[${PYTHON_USEDEP}]
+RDEPEND="
+	>=dev-python/jedi-0.14.1[${PYTHON_USEDEP}]
+	<dev-python/jedi-0.16.0[${PYTHON_USEDEP}]
 	dev-python/pluggy[${PYTHON_USEDEP}]
-	dev-python/python-jsonrpc-server[${PYTHON_USEDEP}]
-	dev-python/ujson[${PYTHON_USEDEP}]"
+	>=dev-python/python-jsonrpc-server-0.3.2[${PYTHON_USEDEP}]
+	<=dev-python/ujson-1.35[${PYTHON_USEDEP}]"
 
 DEPEND="test? (
 	dev-python/autopep8[${PYTHON_USEDEP}]


### PR DESCRIPTION
Copy dependency version bounds from the upstream setup.py:
https://github.com/palantir/python-language-server/blob/0.31.8/setup.py#L38

This fixes the problem when e.g. older jedi satisfies the ebuild
dependency, but the package itself checks dependency specified it
in its setup.py at runtime, refusing to work on mismatch (see #710684).
If pyls silently accepted wrong package version it could've been worse,
though.

    Traceback (most recent call last):
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 583, in _build_master
        ws.require(__requires__)
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 900, in require
        needed = self.resolve(parse_requirements(requirements))
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 791, in resolve
        raise VersionConflict(dist, req).with_context(dependent_req)
    pkg_resources.ContextualVersionConflict: (jedi 0.12.1 (/usr/lib64/python3.6/site-packages), Requirement.parse('jedi<0.16,>=0.14.1'), {'python-language-server'})

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/lib/python-exec/python3.6/pyls", line 6, in <module>
        from pkg_resources import load_entry_point
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 3251, in <module>
        @_call_aside
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
        f(*args, **kwargs)
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
        working_set = WorkingSet._build_master()
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 585, in _build_master
        return cls._build_from_requirements(__requires__)
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 598, in _build_from_requirements
        dists = ws.resolve(reqs, Environment())
      File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 786, in resolve
        raise DistributionNotFound(req, requirers)
    pkg_resources.DistributionNotFound: The 'jedi<0.16,>=0.14.1' distribution was not found and is required by python-language-server