### PR TITLE
net-wireless/crda: corrected dependencies for $(LIBREG) to support clang as well as gcc

### DIFF
--- a/net-wireless/crda/crda-4.14.ebuild
+++ b/net-wireless/crda/crda-4.14.ebuild
@@ -41,6 +41,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-libressl.patch
 	"${FILESDIR}"/${PN}-ldflags.patch
 	"${FILESDIR}"/${PN}-4.14-do-not-compress-doc.patch
+	"${FILESDIR}"/${PN}-correct-deps.patch
 )
 
 src_prepare() {

--- a/net-wireless/crda/files/crda-correct-deps.patch
+++ b/net-wireless/crda/files/crda-correct-deps.patch
@@ -1,0 +1,15 @@
+diff -Naur crda-3.18/Makefile crda-3.18.new/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -113,9 +113,9 @@
+ 	$(NQ) '  Trusted pubkeys:' $(wildcard $(PUBKEY_DIR)/*.pem)
+ 	$(Q)./utils/key2pub.py $(wildcard $(PUBKEY_DIR)/*.pem) $@
+ 
+-$(LIBREG): regdb.h reglib.h reglib.c
++$(LIBREG): reglib.c regdb.h reglib.h
+ 	$(NQ) '  CC  ' $@
+-	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ -shared -Wl,-soname,$(LIBREG) $^ $(filter-out -lreg,$(LDLIBS))
++	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ -shared -Wl,-soname,$(LIBREG) $< $(filter-out -lreg,$(LDLIBS))
+ 
+ install-libreg-headers:
+ 	$(NQ) '  INSTALL  libreg-headers'


### PR DESCRIPTION
There is a [commit](https://git.kernel.org/pub/scm/linux/kernel/git/mcgrof/crda.git/commit/?id=9856751feaf7b102547cea678a5da6c94252d83d) in the upstream that does this

clang cannot compile *.h files along with *.c, generally *.h files are not thought to be in compiling list

*.h files have been removed from the compilation list

Signed-off-by: Denis Pronin <dannftk@yandex.ru>