### PR TITLE
x11-libs/fltk

### DIFF
--- a/x11-libs/fltk/files/fltk-deparent-fix.patch
+++ b/x11-libs/fltk/files/fltk-deparent-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Fl_Tree_Item.cxx b/src/Fl_Tree_Item.cxx
+index 901eee6c9..17b33d85c 100644
+--- a/src/Fl_Tree_Item.cxx
++++ b/src/Fl_Tree_Item.cxx
+@@ -549,7 +549,7 @@ int Fl_Tree_Item::move(Fl_Tree_Item *item, int op, int pos) {
+   } else {					// different parent?
+     if ( to > to_parent->children() )		// try to prevent a reparent() error
+       return -4;
+-    if ( from_parent->deparent(from) < 0 )	// deparent self from current parent
++    if ( from_parent->deparent(from) == NULL )	// deparent self from current parent
+       return -5;
+     if ( to_parent->reparent(this, to) < 0 ) {	// reparent self to new parent at position 'to'
+       to_parent->reparent(this, 0);		// failed? shouldn't happen, reparent at 0

--- a/x11-libs/fltk/fltk-1.3.3-r3.ebuild
+++ b/x11-libs/fltk/fltk-1.3.3-r3.ebuild
@@ -44,7 +44,8 @@ src_prepare() {
 		"${FILESDIR}"/${PN}-1.3.3-visibility.patch \
 		"${FILESDIR}"/${PN}-1.3.3-fl_open_display.patch \
 		"${FILESDIR}"/${PN}-1.3.3-fltk-config.patch \
-		"${FILESDIR}"/${PN}-1.3.3-xutf8-visibility.patch
+		"${FILESDIR}"/${PN}-1.3.3-xutf8-visibility.patch \
+		"${FILESDIR}"/${PN}-deparent-fix.patch
 
 	sed -i \
 		-e 's:@HLINKS@::g' FL/Makefile.in || die


### PR DESCRIPTION
fixed incorrect comparison of result of deparent with zero

as the result there is clang supported as a compiler

based on the [commit](https://github.com/fltk/fltk/commit/1f7eb7bc4e2774ac64b7e30c61ff629be05fe320) of the upstream repository

Signed-off-by: Denis Pronin <dannftk@yandex.ru>