### PR TITLE
sys-fs/inotify-tools:

### DIFF
--- a/sys-fs/inotify-tools/files/inotify-tools-rm-unused-cmd-arg.patch
+++ b/sys-fs/inotify-tools/files/inotify-tools-rm-unused-cmd-arg.patch
@@ -1,0 +1,11 @@
+--- inotify-tools-3.20.1/src/Makefile.am	2018-01-06 14:10:51.000000000 +0300
++++ inotify-tools-3.20.1.new/src/Makefile.am	2020-02-23 20:36:47.957640068 +0300
+@@ -2,7 +2,7 @@
+ inotifywait_SOURCES = inotifywait.c common.c common.h
+ inotifywatch_SOURCES = inotifywatch.c common.c common.h
+ 
+-AM_CFLAGS = -Wall -Werror -Wpointer-arith -std=c99 -I../libinotifytools/src -L../libinotifytools/src
++AM_CFLAGS = -Wall -Werror -Wpointer-arith -std=c99 -I../libinotifytools/src
+ AM_CPPFLAGS = -I$(top_srcdir)/libinotifytools/src
+ LDADD = ../libinotifytools/src/libinotifytools.la
+ 

--- a/sys-fs/inotify-tools/inotify-tools-3.20.1.ebuild
+++ b/sys-fs/inotify-tools/inotify-tools-3.20.1.ebuild
@@ -17,6 +17,8 @@ IUSE="doc"
 DEPEND="doc? ( app-doc/doxygen )"
 RDEPEND=""
 
+PATCHES=( "${FILESDIR}/${PN}-rm-unused-cmd-arg.patch" )
+
 src_prepare() {
 	default
 	eautoreconf

--- a/sys-fs/inotify-tools/inotify-tools-3.20.2.2.ebuild
+++ b/sys-fs/inotify-tools/inotify-tools-3.20.2.2.ebuild
@@ -17,6 +17,8 @@ IUSE="doc"
 DEPEND="doc? ( app-doc/doxygen )"
 RDEPEND=""
 
+PATCHES=( "${FILESDIR}/${PN}-rm-unused-cmd-arg.patch" )
+
 src_prepare() {
 	default
 	eautoreconf


### PR DESCRIPTION
removed unused command line argument,
as the result there is supported clang compiler

Signed-off-by: Denis Pronin <dannftk@yandex.ru>