### PR TITLE
Bug 708908

### DIFF
--- a/app-arch/lzma/lzma-9.20-r1.ebuild
+++ b/app-arch/lzma/lzma-9.20-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/sevenzip/${MY_P}.tar.bz2 -> ${P}.tar.bz2"
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="doc"
 
 S=${WORKDIR}

--- a/app-editors/okteta/okteta-0.26.3.ebuild
+++ b/app-editors/okteta/okteta-0.26.3.ebuild
@@ -17,7 +17,7 @@ https://utils.kde.org/projects/okteta/"
 
 if [[ ${KDE_BUILD_TYPE} = release ]]; then
 	SRC_URI="mirror://kde/stable/${PN}/${PV}/src/${P}.tar.xz"
-	KEYWORDS="amd64 x86"
+	KEYWORDS="amd64 ~arm64 x86"
 fi
 
 LICENSE="GPL-2 handbook? ( FDL-1.2 )"

--- a/dev-libs/libfmt/libfmt-6.1.2.ebuild
+++ b/dev-libs/libfmt/libfmt-6.1.2.ebuild
@@ -18,7 +18,7 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/fmtlib/fmt/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ppc ppc64 x86"
+	KEYWORDS="amd64 ~arm64 ppc ppc64 x86"
 	S="${WORKDIR}/fmt-${PV}"
 fi
 

--- a/dev-libs/libzip/libzip-1.6.1.ebuild
+++ b/dev-libs/libzip/libzip-1.6.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://www.nih.at/libzip/${P}.tar.xz"
 
 LICENSE="BSD"
 SLOT="0/5"
-KEYWORDS="~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x86-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x86-macos"
 IUSE="bzip2 doc gnutls libressl lzma mbedtls ssl static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/dev-libs/spdlog/spdlog-1.5.0.ebuild
+++ b/dev-libs/spdlog/spdlog-1.5.0.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/gabime/${PN}"
 else
 	SRC_URI="https://github.com/gabime/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
 LICENSE="MIT"

--- a/dev-util/astyle/astyle-3.1-r2.ebuild
+++ b/dev-util/astyle/astyle-3.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/astyle/astyle_${PV}_linux.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/3.1"
-KEYWORDS="amd64 ~ppc ~ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="amd64 ~arm64 ~ppc ~ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="examples java static-libs"
 
 DEPEND="app-arch/xz-utils

--- a/dev-util/kdevelop-pg-qt/kdevelop-pg-qt-2.2.1.ebuild
+++ b/dev-util/kdevelop-pg-qt/kdevelop-pg-qt-2.2.1.ebuild
@@ -8,7 +8,7 @@ inherit ecm kde.org
 
 if [[ ${KDE_BUILD_TYPE} = release ]]; then
 	SRC_URI="mirror://kde/stable/${PN}/${PV}/src/${P}.tar.xz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
 DESCRIPTION="LL(1) parser generator used mainly by KDevelop language plugins"

--- a/dev-util/kdevelop/kdevelop-5.5.0.ebuild
+++ b/dev-util/kdevelop/kdevelop-5.5.0.ebuild
@@ -13,7 +13,7 @@ VIRTUALX_REQUIRED="test"
 inherit ecm kde.org
 
 if [[ ${KDE_BUILD_TYPE} = release ]]; then
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
 DESCRIPTION="Integrated Development Environment, supporting KF5/Qt, C/C++ and much more"


### PR DESCRIPTION
~arm64 keywords to address #bug 708908, #bug 708910, #bug 706986 and #bug 709294.
All the required dependencies identified by repoman are included at no extra charge.
Tests, where they exist, all pass.  
