### PR TITLE
dev-libs/icu: add patch to fix integer overflow

### DIFF
--- a/dev-libs/icu/files/icu-65.1-integer-overflow.patch
+++ b/dev-libs/icu/files/icu-65.1-integer-overflow.patch
@@ -1,0 +1,118 @@
+From b7d08bc04a4296982fcef8b6b8a354a9e4e7afca Mon Sep 17 00:00:00 2001
+From: Frank Tang <ftang@chromium.org>
+Date: Sat, 1 Feb 2020 02:39:04 +0000
+Subject: [PATCH] ICU-20958 Prevent SEGV_MAPERR in append
+
+See #971
+---
+ common/unistr.cpp          |  6 ++-
+ test/intltest/ustrtest.cpp | 62 +++++++++++++++++++++++++
+ test/intltest/ustrtest.h   |  1 +
+ 3 files changed, 68 insertions(+), 1 deletion(-)
+
+diff --git a/common/unistr.cpp b/common/unistr.cpp
+index 901bb3358ba..077b4d6ef20 100644
+--- a/common/unistr.cpp
++++ b/common/unistr.cpp
+@@ -1563,7 +1563,11 @@ UnicodeString::doAppend(const UChar *srcChars, int32_t srcStart, int32_t srcLeng
+   }
+ 
+   int32_t oldLength = length();
+-  int32_t newLength = oldLength + srcLength;
++  int32_t newLength;
++  if (uprv_add32_overflow(oldLength, srcLength, &newLength)) {
++    setToBogus();
++    return *this;
++  }
+ 
+   // Check for append onto ourself
+   const UChar* oldArray = getArrayStart();
+diff --git a/test/intltest/ustrtest.cpp b/test/intltest/ustrtest.cpp
+index b6515ea813c..ad38bdf53a3 100644
+--- a/test/intltest/ustrtest.cpp
++++ b/test/intltest/ustrtest.cpp
+@@ -67,6 +67,7 @@ void UnicodeStringTest::runIndexedTest( int32_t index, UBool exec, const char* &
+     TESTCASE_AUTO(TestWCharPointers);
+     TESTCASE_AUTO(TestNullPointers);
+     TESTCASE_AUTO(TestUnicodeStringInsertAppendToSelf);
++    TESTCASE_AUTO(TestLargeAppend);
+     TESTCASE_AUTO_END;
+ }
+ 
+@@ -2310,3 +2311,64 @@ void UnicodeStringTest::TestUnicodeStringInsertAppendToSelf() {
+     str.insert(2, sub);
+     assertEquals("", u"abbcdcde", str);
+ }
++
++void UnicodeStringTest::TestLargeAppend() {
++    if(quick) return;
++
++    IcuTestErrorCode status(*this, "TestLargeAppend");
++    // Make a large UnicodeString
++    int32_t len = 0xAFFFFFF;
++    UnicodeString str;
++    char16_t *buf = str.getBuffer(len);
++    // A fast way to set buffer to valid Unicode.
++    // 4E4E is a valid unicode character
++    uprv_memset(buf, 0x4e, len * 2);
++    str.releaseBuffer(len);
++    UnicodeString dest;
++    // Append it 16 times
++    // 0xAFFFFFF times 16 is 0xA4FFFFF1,
++    // which is greater than INT32_MAX, which is 0x7FFFFFFF.
++    int64_t total = 0;
++    for (int32_t i = 0; i < 16; i++) {
++        dest.append(str);
++        total += len;
++        if (total <= INT32_MAX) {
++            assertFalse("dest is not bogus", dest.isBogus());
++        } else {
++            assertTrue("dest should be bogus", dest.isBogus());
++        }
++    }
++    dest.remove();
++    total = 0;
++    for (int32_t i = 0; i < 16; i++) {
++        dest.append(str);
++        total += len;
++        if (total + len <= INT32_MAX) {
++            assertFalse("dest is not bogus", dest.isBogus());
++        } else if (total <= INT32_MAX) {
++            // Check that a string of exactly the maximum size works
++            UnicodeString str2;
++            int32_t remain = INT32_MAX - total;
++            char16_t *buf2 = str2.getBuffer(remain);
++            if (buf2 == nullptr) {
++                // if somehow memory allocation fail, return the test
++                return;
++            }
++            uprv_memset(buf2, 0x4e, remain * 2);
++            str2.releaseBuffer(remain);
++            dest.append(str2);
++            total += remain;
++            assertEquals("When a string of exactly the maximum size works", (int64_t)INT32_MAX, total);
++            assertEquals("When a string of exactly the maximum size works", INT32_MAX, dest.length());
++            assertFalse("dest is not bogus", dest.isBogus());
++
++            // Check that a string size+1 goes bogus
++            str2.truncate(1);
++            dest.append(str2);
++            total++;
++            assertTrue("dest should be bogus", dest.isBogus());
++        } else {
++            assertTrue("dest should be bogus", dest.isBogus());
++        }
++    }
++}
+diff --git a/test/intltest/ustrtest.h b/test/intltest/ustrtest.h
+index 218befdcc68..4a356a92c7a 100644
+--- a/test/intltest/ustrtest.h
++++ b/test/intltest/ustrtest.h
+@@ -97,6 +97,7 @@ class UnicodeStringTest: public IntlTest {
+     void TestWCharPointers();
+     void TestNullPointers();
+     void TestUnicodeStringInsertAppendToSelf();
++    void TestLargeAppend();
+ };
+ 
+ #endif

--- a/dev-libs/icu/icu-65.1-r1.ebuild
+++ b/dev-libs/icu/icu-65.1-r1.ebuild
@@ -1,0 +1,143 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6,7} )
+inherit autotools flag-o-matic multilib-minimal python-any-r1 toolchain-funcs
+
+DESCRIPTION="International Components for Unicode"
+HOMEPAGE="http://www.icu-project.org/"
+SRC_URI="https://github.com/unicode-org/icu/releases/download/release-${PV//./-}/icu4c-${PV//./_}-src.tgz"
+
+LICENSE="BSD"
+
+SLOT="0/${PV}"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+IUSE="debug doc examples static-libs"
+
+BDEPEND="${PYTHON_DEPS}
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen[dot] )
+"
+
+S="${WORKDIR}/${PN}/source"
+
+MULTILIB_CHOST_TOOLS=(
+	/usr/bin/icu-config
+)
+
+PATCHES=(
+	"${FILESDIR}/${PN}-65.1-remove-bashisms.patch"
+	"${FILESDIR}/${PN}-64.2-darwin.patch"
+	"${FILESDIR}/${PN}-64.1-data_archive_generation.patch"
+	"${FILESDIR}/${PN}-65.1-integer-overflow.patch" # bug 710758
+)
+
+src_prepare() {
+	default
+
+	local variable
+
+	# Disable renaming as it is stupid thing to do
+	sed -i \
+		-e "s/#define U_DISABLE_RENAMING 0/#define U_DISABLE_RENAMING 1/" \
+		common/unicode/uconfig.h || die
+
+	# Fix linking of icudata
+	sed -i \
+		-e "s:LDFLAGSICUDT=-nodefaultlibs -nostdlib:LDFLAGSICUDT=:" \
+		config/mh-linux || die
+
+	# Append doxygen configuration to configure
+	sed -i \
+		-e 's:icudefs.mk:icudefs.mk Doxyfile:' \
+		configure.ac || die
+
+	eautoreconf
+}
+
+src_configure() {
+	append-cxxflags -std=c++14
+
+	if tc-is-cross-compiler; then
+		mkdir "${WORKDIR}"/host || die
+		pushd "${WORKDIR}"/host >/dev/null || die
+
+		CFLAGS="" CXXFLAGS="" ASFLAGS="" LDFLAGS="" \
+		CC="$(tc-getBUILD_CC)" CXX="$(tc-getBUILD_CXX)" AR="$(tc-getBUILD_AR)" \
+		RANLIB="$(tc-getBUILD_RANLIB)" LD="$(tc-getBUILD_LD)" \
+		"${S}"/configure --disable-renaming --disable-debug \
+			--disable-samples --enable-static || die
+		emake
+
+		popd >/dev/null || die
+	fi
+
+	multilib-minimal_src_configure
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--disable-renaming
+		--disable-samples
+		--disable-layoutex
+		$(use_enable debug)
+		$(use_enable static-libs static)
+		$(multilib_native_use_enable examples samples)
+	)
+
+	tc-is-cross-compiler && myeconfargs+=(
+		--with-cross-build="${WORKDIR}"/host
+	)
+
+	# icu tries to use clang by default
+	tc-export CC CXX
+
+	# make sure we configure with the same shell as we run icu-config
+	# with, or ECHO_N, ECHO_T and ECHO_C will be wrongly defined
+	export CONFIG_SHELL="${EPREFIX}/bin/sh"
+	# probably have no /bin/sh in prefix-chain
+	[[ -x ${CONFIG_SHELL} ]] || CONFIG_SHELL="${BASH}"
+
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_compile() {
+	default
+
+	if multilib_is_native_abi && use doc; then
+		doxygen -u Doxyfile || die
+		doxygen Doxyfile || die
+	fi
+}
+
+multilib_src_test() {
+	# INTLTEST_OPTS: intltest options
+	#   -e: Exhaustive testing
+	#   -l: Reporting of memory leaks
+	#   -v: Increased verbosity
+	# IOTEST_OPTS: iotest options
+	#   -e: Exhaustive testing
+	#   -v: Increased verbosity
+	# CINTLTST_OPTS: cintltst options
+	#   -e: Exhaustive testing
+	#   -v: Increased verbosity
+	emake -j1 VERBOSE="1" check
+}
+
+multilib_src_install() {
+	default
+
+	if multilib_is_native_abi && use doc; then
+		docinto html
+		dodoc -r doc/html/*
+	fi
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	docinto html
+	dodoc ../readme.html
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/710758
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>