### PR TITLE
https://bugs.gentoo.org/702254

### DIFF
--- a/sci-libs/lapack/lapack-3.8.0.ebuild
+++ b/sci-libs/lapack/lapack-3.8.0.ebuild
@@ -33,6 +33,7 @@ src_configure() {
 		-DCBLAS=ON
 		-DLAPACKE=$(usex lapacke)
 		-DBUILD_SHARED_LIBS=ON
+		-DBUILD_DEPRECATED=ON
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
added `-DBUILD_DEPRECATED=ON` in `src_configure()`

[Bug 702254 - sci-libs/lapack - add support for deprecated routines ](https://bugs.gentoo.org/702254)
