### PR TITLE
net-analyzer/suricata --runstatedir configure option does not exist

### DIFF
--- a/net-analyzer/suricata/suricata-5.0.1-r1.ebuild
+++ b/net-analyzer/suricata/suricata-5.0.1-r1.ebuild
@@ -84,7 +84,6 @@ src_prepare() {
 src_configure() {
 	local myeconfargs=(
 		"--localstatedir=/var" \
-		"--runstatedir=/run" \
 		"--enable-non-bundled-htp" \
 		"--enable-gccmarch-native=no" \
 		"--enable-python" \


### PR DESCRIPTION
--runstatedir configure option does not exist in new builds which causes configure phase to fail.

Solution: Remove it.