### PR TITLE
dev-libs/libevent-2.1.11.ebuild --enable-malloc-replacement

### DIFF
--- a/dev-libs/libevent/libevent-2.1.11.ebuild
+++ b/dev-libs/libevent/libevent-2.1.11.ebuild
@@ -41,6 +41,7 @@ multilib_src_configure() {
 	ECONF_SOURCE="${S}" \
 	econf \
 		--disable-samples \
+		--enable-malloc-replacement \
 		$(use_enable debug debug-mode) \
 		$(use_enable debug malloc-replacement) \
 		$(use_enable ssl openssl) \


### PR DESCRIPTION
event_set_mem_functions not compiled if  --enable-malloc-replacement is not set

The bug is the following:
https://bugs.gentoo.org/710860

Signed-off-by: Angelo Mantellini manangel@cisco.com