### PR TITLE
www-client/chromium: fix compiler patch for dev channel

### DIFF
--- a/www-client/chromium/files/chromium-compiler-r12.patch
+++ b/www-client/chromium/files/chromium-compiler-r12.patch
@@ -1,17 +1,17 @@
-From 4ee82d093d26ab2fcdb989fd62f55b0588afdde0 Mon Sep 17 00:00:00 2001
+From 137de121a36f9349ad8435fee57940facef82878 Mon Sep 17 00:00:00 2001
 From: Mike Gilbert <floppym@gentoo.org>
-Date: Sat, 15 Feb 2020 12:11:49 +0000
+Date: Fri, 26 Feb 2020 10:09:23 +0000
 Subject: [PATCH] Disable various compiler configs
 
 ---
- build/config/compiler/BUILD.gn | 70 ++++++++++++----------------------
- 1 file changed, 25 insertions(+), 45 deletions(-)
+ build/config/compiler/BUILD.gn | 67 ++++++++++++----------------------
+ 1 file changed, 23 insertions(+), 44 deletions(-)
 
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index e40194e..f2bd02e 100644
+index 85bc736..a85bd12 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -260,8 +260,6 @@ config("compiler") {
+@@ -261,8 +261,6 @@ config("compiler") {
  
    configs += [
      # See the definitions below.
@@ -20,7 +20,7 @@ index e40194e..f2bd02e 100644
      ":compiler_codegen",
      ":compiler_deterministic",
    ]
-@@ -486,26 +484,6 @@ config("compiler") {
+@@ -487,26 +485,6 @@ config("compiler") {
      }
    }
  
@@ -37,7 +37,7 @@ index e40194e..f2bd02e 100644
 -      "-instcombine-lower-dbg-declare=0",
 -    ]
 -
--    if (target_os != "chromeos") {
+-    if (!is_chromeos && default_toolchain != "//build/toolchain/cros:target") {
 -      # TODO(https://crbug.com/1049161): Remove '-DCLANG_SPAWN_CC1=ON' from build.py instead
 -      # once this change has marinated a bit.
 -      cflags += [ "-fintegrated-cc1" ]
@@ -47,7 +47,7 @@ index e40194e..f2bd02e 100644
    # C11/C++11 compiler flags setup.
    # ---------------------------
    if (is_linux || is_android || (is_nacl && is_clang) || current_os == "aix") {
-@@ -1452,6 +1430,12 @@ config("default_warnings") {
+@@ -1442,6 +1420,12 @@ config("default_warnings") {
          cflags_cc += [ "-Wno-class-memaccess" ]
        }
  
@@ -60,7 +60,7 @@ index e40194e..f2bd02e 100644
        # -Wunused-local-typedefs is broken in gcc,
        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63872
        cflags += [ "-Wno-unused-local-typedefs" ]
-@@ -1577,7 +1561,7 @@ config("chromium_code") {
+@@ -1572,7 +1556,7 @@ config("chromium_code") {
        defines = [ "_HAS_NODISCARD" ]
      }
    } else {
@@ -69,7 +69,7 @@ index e40194e..f2bd02e 100644
      if (treat_warnings_as_errors) {
        cflags += [ "-Werror" ]
  
-@@ -1586,10 +1570,6 @@ config("chromium_code") {
+@@ -1581,10 +1565,6 @@ config("chromium_code") {
        # well.
        ldflags = [ "-Werror" ]
      }
@@ -80,7 +80,7 @@ index e40194e..f2bd02e 100644
  
      # In Chromium code, we define __STDC_foo_MACROS in order to get the
      # C99 macros on Mac and Linux.
-@@ -1598,15 +1578,6 @@ config("chromium_code") {
+@@ -1593,15 +1573,6 @@ config("chromium_code") {
        "__STDC_FORMAT_MACROS",
      ]
  
@@ -96,7 +96,7 @@ index e40194e..f2bd02e 100644
      if (is_mac) {
        cflags_objc = [ "-Wobjc-missing-property-synthesis" ]
        cflags_objcc = [ "-Wobjc-missing-property-synthesis" ]
-@@ -2010,7 +1981,8 @@ config("default_stack_frames") {
+@@ -1993,7 +1964,8 @@ config("default_stack_frames") {
  }
  
  # Default "optimization on" config.
@@ -104,19 +104,9 @@ index e40194e..f2bd02e 100644
 +config("optimize") { }
 +config("xoptimize") {
    if (is_win) {
-     # TODO(thakis): Remove is_clang here, https://crbug.com/598772
-     if (is_official_build && full_wpo_on_official && !is_clang) {
-@@ -2036,7 +2008,8 @@ config("optimize") {
- }
- 
- # Same config as 'optimize' but without the WPO flag.
--config("optimize_no_wpo") {
-+config("optimize_no_wpo") { }
-+config("xoptimize_no_wpo") {
-   if (is_win) {
-     # Favor size over speed, /O1 must be before the common flags. The GYP
-     # build also specifies /Os and /GF but these are implied by /O1.
-@@ -2059,7 +2032,8 @@ config("optimize_no_wpo") {
+     # Favor size over speed, /O1 must be before the common flags.
+     # /O1 implies /Os and /GF.
+@@ -2016,7 +1988,8 @@ config("optimize") {
  }
  
  # Turn off optimizations.
@@ -126,7 +116,7 @@ index e40194e..f2bd02e 100644
    if (is_win) {
      cflags = [
        "/Od",  # Disable optimization.
-@@ -2093,7 +2067,8 @@ config("no_optimize") {
+@@ -2050,7 +2023,8 @@ config("no_optimize") {
  # Turns up the optimization level. On Windows, this implies whole program
  # optimization and link-time code generation which is very expensive and should
  # be used sparingly.
@@ -136,7 +126,7 @@ index e40194e..f2bd02e 100644
    if (is_nacl && is_nacl_irt) {
      # The NaCl IRT is a special case and always wants its own config.
      # Various components do:
-@@ -2132,7 +2107,8 @@ config("optimize_max") {
+@@ -2089,7 +2063,8 @@ config("optimize_max") {
  #
  # TODO(crbug.com/621335) - rework how all of these configs are related
  # so that we don't need this disclaimer.
@@ -146,7 +136,7 @@ index e40194e..f2bd02e 100644
    if (is_nacl && is_nacl_irt) {
      # The NaCl IRT is a special case and always wants its own config.
      # Various components do:
-@@ -2162,7 +2138,8 @@ config("optimize_speed") {
+@@ -2119,7 +2094,8 @@ config("optimize_speed") {
    }
  }
  
@@ -156,7 +146,7 @@ index e40194e..f2bd02e 100644
    cflags = [ "-O1" ] + common_optimize_on_cflags
    ldflags = common_optimize_on_ldflags
    visibility = [ ":default_optimization" ]
-@@ -2278,7 +2255,8 @@ config("win_pdbaltpath") {
+@@ -2235,7 +2211,8 @@ config("win_pdbaltpath") {
  }
  
  # Full symbols.
@@ -166,7 +156,7 @@ index e40194e..f2bd02e 100644
    if (is_win) {
      if (use_goma || is_clang) {
        # Note that with VC++ this requires is_win_fastlink, enforced elsewhere.
-@@ -2388,7 +2366,8 @@ config("symbols") {
+@@ -2361,7 +2338,8 @@ config("symbols") {
  # Minimal symbols.
  # This config guarantees to hold symbol for stack trace which are shown to user
  # when crash happens in unittests running on buildbot.
@@ -176,7 +166,7 @@ index e40194e..f2bd02e 100644
    if (is_win) {
      # Functions, files, and line tables only.
      cflags = []
-@@ -2443,7 +2422,8 @@ config("minimal_symbols") {
+@@ -2416,7 +2394,8 @@ config("minimal_symbols") {
  }
  
  # No symbols.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/711010
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>