### PR TITLE
dev-python/pypy3: attempt to fix headers install_dir

### DIFF
--- a/dev-python/pypy3/files/7.0.0-gentoo-path.patch
+++ b/dev-python/pypy3/files/7.0.0-gentoo-path.patch
@@ -27,7 +27,7 @@ index 77a1827d4b..255603967f 100644
 +    'gentoo': {
 +        'purelib': '$base/site-packages',
 +        'platlib': '$base/site-packages',
-+        'headers': '$base/include',
++        'headers': '$base/include/$dist_name',
 +        'scripts': '@EPREFIX@/usr/bin',
 +        'data'   : '@EPREFIX@/usr',
 +        },


### PR DESCRIPTION
I'm not sure whether this is actually the right fix, it may cause other issues. This PR is here as a point of reference.
Related to: https://bugs.gentoo.org/465546
Bug: https://bugs.gentoo.org/729962
@mgorny