### PR TITLE
sys-boot/grub: remove dependency on xen-tools

### DIFF
--- a/sys-boot/grub/grub-2.02-r4.ebuild
+++ b/sys-boot/grub/grub-2.02-r4.ebuild
@@ -94,8 +94,6 @@ DEPEND="${COMMON_DEPEND}
 		media-libs/freetype:2
 		virtual/pkgconfig
 	)
-	grub_platforms_xen? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-32? ( app-emulation/xen-tools:= )
 	static? (
 		app-arch/xz-utils[static-libs(+)]
 		truetype? (

--- a/sys-boot/grub/grub-2.04-r1.ebuild
+++ b/sys-boot/grub/grub-2.04-r1.ebuild
@@ -103,9 +103,6 @@ DEPEND="
 	truetype? ( media-libs/freetype:2= )
 	ppc? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
 	ppc64? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
-	grub_platforms_xen? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-32? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-pvh? ( app-emulation/xen-tools:= )
 "
 RDEPEND="${DEPEND}
 	kernel_linux? (

--- a/sys-boot/grub/grub-2.05_alpha20200110.ebuild
+++ b/sys-boot/grub/grub-2.05_alpha20200110.ebuild
@@ -94,9 +94,6 @@ DEPEND="
 	truetype? ( media-libs/freetype:2= )
 	ppc? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
 	ppc64? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
-	grub_platforms_xen? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-32? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-pvh? ( app-emulation/xen-tools:= )
 "
 RDEPEND="${DEPEND}
 	kernel_linux? (

--- a/sys-boot/grub/grub-2.05_alpha20200228.ebuild
+++ b/sys-boot/grub/grub-2.05_alpha20200228.ebuild
@@ -94,9 +94,6 @@ DEPEND="
 	truetype? ( media-libs/freetype:2= )
 	ppc? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
 	ppc64? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
-	grub_platforms_xen? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-32? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-pvh? ( app-emulation/xen-tools:= )
 "
 RDEPEND="${DEPEND}
 	kernel_linux? (

--- a/sys-boot/grub/grub-9999.ebuild
+++ b/sys-boot/grub/grub-9999.ebuild
@@ -102,9 +102,6 @@ DEPEND="
 	truetype? ( media-libs/freetype:2= )
 	ppc? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
 	ppc64? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
-	grub_platforms_xen? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-32? ( app-emulation/xen-tools:= )
-	grub_platforms_xen-pvh? ( app-emulation/xen-tools:= )
 "
 RDEPEND="${DEPEND}
 	kernel_linux? (


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/711442
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Jonas Licht <jonas.licht@fem.tu-ilmenau.de>