### PR TITLE
Python1

### DIFF
--- a/app-misc/khal/khal-0.10.1-r1.ebuild
+++ b/app-misc/khal/khal-0.10.1-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://lostpackets.de/khal/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 SLOT="0"
 IUSE="zsh-completion"
 

--- a/dev-python/click-threading/click-threading-0.4.4.ebuild
+++ b/dev-python/click-threading/click-threading-0.4.4.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/click-contrib/${PN}/archive/${PV}.tar.gz -> ${P}-gh.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 
 RDEPEND=">=dev-python/click-5.0[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}"

--- a/dev-python/elementpath/elementpath-1.4.1.ebuild
+++ b/dev-python/elementpath/elementpath-1.4.1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~hppa ~sparc ~x86"
+KEYWORDS="~amd64 ~arm64 ~hppa ~sparc ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/freezegun/freezegun-0.3.12-r1.ebuild
+++ b/dev-python/freezegun/freezegun-0.3.12-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 IUSE="test"
 
 RDEPEND="

--- a/dev-python/hypothesis/hypothesis-5.6.0.ebuild
+++ b/dev-python/hypothesis/hypothesis-5.6.0.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}/${PN}-${PN}-python-${PV}/${PN}-python"
 
 LICENSE="MPL-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~hppa ~x86"
+KEYWORDS="~amd64 ~arm64 ~hppa ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/jaraco-envs/jaraco-envs-1.0.1.ebuild
+++ b/dev-python/jaraco-envs/jaraco-envs-1.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/jaraco/jaraco.envs/archive/v${PV}.tar.gz -> ${P}.tar
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~hppa ~sparc ~x86"
+KEYWORDS="~amd64 ~arm64 ~hppa ~sparc ~x86"
 
 RDEPEND="dev-python/namespace-jaraco[${PYTHON_USEDEP}]
 	dev-python/path-py[${PYTHON_USEDEP}]

--- a/dev-python/jinja/jinja-2.10.3-r1.ebuild
+++ b/dev-python/jinja/jinja-2.10.3-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://github.com/pallets/jinja/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris"
 IUSE="examples test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/mako/mako-1.1.0.ebuild
+++ b/dev-python/mako/mako-1.1.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="mirror://pypi/${MY_PN:0:1}/${MY_PN}/${MY_P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
 IUSE="doc test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/ndg-httpsclient/ndg-httpsclient-0.5.1.ebuild
+++ b/dev-python/ndg-httpsclient/ndg-httpsclient-0.5.1.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}/${P/-/_}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 
 RDEPEND="
 	dev-python/pyaes[${PYTHON_USEDEP}]

--- a/dev-python/parso/parso-0.6.0.ebuild
+++ b/dev-python/parso/parso-0.6.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/davidhalter/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 ~ppc ppc64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 x86"
 IUSE="doc test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/pluggy/pluggy-0.13.1.ebuild
+++ b/dev-python/pluggy/pluggy-0.13.1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~hppa ~ppc64 sparc x86"
+KEYWORDS="~alpha amd64 ~arm64 ~hppa ~ppc64 sparc x86"
 
 RDEPEND="$(python_gen_cond_dep \
 	'dev-python/importlib_metadata[${PYTHON_USEDEP}]' -2 python3_{5,6,7} pypy3)"

--- a/dev-python/pyaes/pyaes-1.6.1-r1.ebuild
+++ b/dev-python/pyaes/pyaes-1.6.1-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="amd64 ~arm ~arm64 x86"
 IUSE=""
 
 python_test() {

--- a/dev-python/pygame/pygame-1.9.6-r1.ebuild
+++ b/dev-python/pygame/pygame-1.9.6-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~sparc ~x86"
 IUSE="doc examples midi X"
 
 DEPEND="dev-python/numpy[${PYTHON_USEDEP}]

--- a/dev-python/pypiserver/pypiserver-1.3.1-r1.ebuild
+++ b/dev-python/pypiserver/pypiserver-1.3.1-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="ZLIB MIT"
 SLOT="0"
-KEYWORDS="amd64 ~hppa x86"
+KEYWORDS="amd64 ~arm64 ~hppa x86"
 IUSE="test"
 
 RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]

--- a/dev-python/pyproject2setuppy/pyproject2setuppy-2.ebuild
+++ b/dev-python/pyproject2setuppy/pyproject2setuppy-2.ebuild
@@ -16,7 +16,7 @@ SRC_URI="
 
 LICENSE="BSD-2"
 SLOT="0"
-KEYWORDS="~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 
 RDEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]

--- a/dev-python/pytest/pytest-4.6.9.ebuild
+++ b/dev-python/pytest/pytest-4.6.9.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~hppa x86"
+KEYWORDS="amd64 ~arm64 ~hppa x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/pytest/pytest-5.3.5.ebuild
+++ b/dev-python/pytest/pytest-5.3.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~hppa ~x86"
+KEYWORDS="~amd64 ~arm64 ~hppa ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/readme_renderer/readme_renderer-24.0-r1.ebuild
+++ b/dev-python/readme_renderer/readme_renderer-24.0-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~hppa ~sparc x86"
+KEYWORDS="amd64 ~arm64 ~hppa ~sparc x86"
 
 RDEPEND="
 	>=dev-python/bleach-2.1.0[${PYTHON_USEDEP}]

--- a/dev-python/sphinxcontrib-github-alt/sphinxcontrib-github-alt-1.1-r2.ebuild
+++ b/dev-python/sphinxcontrib-github-alt/sphinxcontrib-github-alt-1.1-r2.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://github.com/jupyter/${MY_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="BSD-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND="dev-python/sphinx[${PYTHON_USEDEP}]"
 BDEPEND=${RDEPEND}

--- a/dev-python/testpath/testpath-0.4.4-r1.ebuild
+++ b/dev-python/testpath/testpath-0.4.4-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/jupyter/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~sparc ~x86"
 
 DEPEND="
 	test? (

--- a/dev-python/tqdm/tqdm-4.40.0.ebuild
+++ b/dev-python/tqdm/tqdm-4.40.0.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/tqdm/tqdm"
 else
 	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
-	KEYWORDS="amd64 ~hppa ~sparc x86"
+	KEYWORDS="amd64 ~arm64 ~hppa ~sparc x86"
 fi
 
 DESCRIPTION="Add a progress meter to your loops in a second"

--- a/dev-python/twine/twine-1.15.0.ebuild
+++ b/dev-python/twine/twine-1.15.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/pypa/twine/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~hppa ~sparc x86"
+KEYWORDS="amd64 ~arm64 ~hppa ~sparc x86"
 IUSE="test"
 
 CDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-python/twine/twine-3.1.1.ebuild
+++ b/dev-python/twine/twine-3.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/pypa/twine/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="test"
 
 CDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-python/vdirsyncer/vdirsyncer-0.16.7.ebuild
+++ b/dev-python/vdirsyncer/vdirsyncer-0.16.7.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/pimutils/vdirsyncer"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 SLOT="0"
 IUSE="test"
 RESTRICT="!test? ( test )"

--- a/dev-python/xmlschema/xmlschema-1.1.1.ebuild
+++ b/dev-python/xmlschema/xmlschema-1.1.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~hppa ~x86"
+KEYWORDS="~amd64 ~arm64 ~hppa ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/zstandard/zstandard-0.13.0.ebuild
+++ b/dev-python/zstandard/zstandard-0.13.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="BSD"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/media-libs/portmidi/portmidi-217-r3.ebuild
+++ b/media-libs/portmidi/portmidi-217-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ SRC_URI="mirror://sourceforge/portmedia/${PN}-src-${PV}.zip"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~sparc ~x86"
 IUSE="debug doc java python static-libs test-programs"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"

--- a/media-libs/sdl-ttf/sdl-ttf-2.0.11-r1.ebuild
+++ b/media-libs/sdl-ttf/sdl-ttf-2.0.11-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://www.libsdl.org/projects/SDL_ttf/release/${MY_P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~x86-solaris"
 IUSE="static-libs X"
 
 RDEPEND="


### PR DESCRIPTION
Some arm64 python (re)keywords and a few stabilisations thrown in too. 

There are two versions of pytest and twine
dev-python/pytest-4.6.9.tbz2
dev-python/pytest-5.3.5.tbz2

dev-python/twine-1.15.0.tbz2
dev-python/twine-3.1.1.tbz2

The prevailing wisdom is to continue to support python2, rather than mask it on a per package basis.

