### PR TITLE
Cleanup ebuild rot.

### DIFF
--- a/dev-ml/camlp4/camlp4-4.04_p1.ebuild
+++ b/dev-ml/camlp4/camlp4-4.04_p1.ebuild
@@ -16,9 +16,7 @@ KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-lin
 IUSE="+ocamlopt"
 
 DEPEND="=dev-lang/ocaml-4.04*:=[ocamlopt?]"
-RDEPEND="${DEPEND}
-	!<dev-lang/ocaml-4.02
-	!<dev-ml/findlib-1.5.5-r1"
+RDEPEND="${DEPEND}"
 DEPEND="${DEPEND}
 	dev-ml/ocamlbuild"
 

--- a/dev-ml/camlp4/camlp4-4.05_p1.ebuild
+++ b/dev-ml/camlp4/camlp4-4.05_p1.ebuild
@@ -16,9 +16,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~a
 IUSE="+ocamlopt"
 
 DEPEND="=dev-lang/ocaml-4.05*:=[ocamlopt?]"
-RDEPEND="${DEPEND}
-	!<dev-lang/ocaml-4.02
-	!<dev-ml/findlib-1.5.5-r1"
+RDEPEND="${DEPEND}"
 DEPEND="${DEPEND}
 	dev-ml/ocamlbuild"
 

--- a/dev-ml/camlp4/camlp4-4.08_p1.ebuild
+++ b/dev-ml/camlp4/camlp4-4.08_p1.ebuild
@@ -16,9 +16,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~a
 IUSE="+ocamlopt"
 
 DEPEND=">=dev-lang/ocaml-4.09.0:=[ocamlopt?]"
-RDEPEND="${DEPEND}
-	!<dev-lang/ocaml-4.02
-	!<dev-ml/findlib-1.5.5-r1"
+RDEPEND="${DEPEND}"
 DEPEND="${DEPEND}
 	dev-ml/ocamlbuild"
 


### PR DESCRIPTION
As I understand, the `RDEPEND=!<dev-lang/ocaml-4.02 >=dev-lang/ocaml-4.02:=[ocamlopt?] ...` implies that `=dev-ml/camlp4-4.08_p1` and `<dev-lang/ocaml-4.02` can't be installed at the same time.

I'm led to believe the lines are rot, and suggesting cleanup. Line was inherited from 2015 CVS to GIT migration.

Oldest versions in repo are:

```
=dev-ml/findlib-1.7.1:0/0::gentoo
=dev-lang/ocaml-4.04.2-r1:0/4.04.2::gentoo
```