### PR TITLE
app-emulation/xen: warn about credit2 scheduler instability

### DIFF
--- a/app-emulation/xen/xen-4.12.2.ebuild
+++ b/app-emulation/xen/xen-4.12.2.ebuild
@@ -153,4 +153,13 @@ pkg_postinst() {
 	elog "You can optionally block the installation of /boot/xen-syms by an entry"
 	elog "in folder /etc/portage/env using the portage's feature INSTALL_MASK"
 	elog "e.g. echo ${msg} > /etc/portage/env/xen.conf"
+
+	ewarn
+	ewarn "Xen 4.12+ changed the default scheduler to credit2 which can cause"
+	ewarn "domU lockups on multi-cpu systems. The legacy credit scheduler seems"
+	ewarn "to work fine."
+	ewarn
+	ewarn "Add sched=credit to xen command line options to use the legacy scheduler."
+	ewarn
+	ewarn "https://wiki.gentoo.org/wiki/Xen#Xen_domU_hanging_with_Xen_4.12.2B"
 }

--- a/app-emulation/xen/xen-4.13.0-r1.ebuild
+++ b/app-emulation/xen/xen-4.13.0-r1.ebuild
@@ -153,4 +153,13 @@ pkg_postinst() {
 	elog "You can optionally block the installation of /boot/xen-syms by an entry"
 	elog "in folder /etc/portage/env using the portage's feature INSTALL_MASK"
 	elog "e.g. echo ${msg} > /etc/portage/env/xen.conf"
+
+	ewarn
+	ewarn "Xen 4.12+ changed the default scheduler to credit2 which can cause"
+	ewarn "domU lockups on multi-cpu systems. The legacy credit scheduler seems"
+	ewarn "to work fine."
+	ewarn
+	ewarn "Add sched=credit to xen command line options to use the legacy scheduler."
+	ewarn
+	ewarn "https://wiki.gentoo.org/wiki/Xen#Xen_domU_hanging_with_Xen_4.12.2B"
 }


### PR DESCRIPTION
We should get it into portage before calling stabilization on 4.12.2. Thanks