### PR TITLE
Python2

### DIFF
--- a/app-eselect/eselect-python/eselect-python-20190417.ebuild
+++ b/app-eselect/eselect-python/eselect-python-20190417.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "99999999" ]] ; then
 	EGIT_REPO_URI="git://anongit.gentoo.org/proj/${PN}.git"
 else
 	SRC_URI="https://dev.gentoo.org/~mgorny/dist/${P}.tar.bz2"
-	KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~riscv s390 ~sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~riscv s390 ~sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 fi
 
 DESCRIPTION="Eselect module for management of multiple Python versions"

--- a/dev-lang/python/python-2.7.17-r1.ebuild
+++ b/dev-lang/python/python-2.7.17-r1.ebuild
@@ -18,7 +18,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="PSF-2"
 SLOT="${PYVER}"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86"
 IUSE="-berkdb bluetooth build elibc_uclibc examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl +threads tk +wide-unicode wininst +xml"
 
 # Do not add a dependency on dev-lang/python to this ebuild.

--- a/dev-lang/python/python-3.6.10.ebuild
+++ b/dev-lang/python/python-3.6.10.ebuild
@@ -18,7 +18,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="PSF-2"
 SLOT="${PYVER}/${PYVER}m"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86"
 IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test +threads tk wininst +xml"
 RESTRICT="!test? ( test )"
 

--- a/dev-lang/python/python-3.7.6.ebuild
+++ b/dev-lang/python/python-3.7.6.ebuild
@@ -18,7 +18,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="PSF-2"
 SLOT="${PYVER}/${PYVER}m"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~riscv s390 ~sh sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~riscv s390 ~sh sparc x86"
 IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/PyQt5-sip/PyQt5-sip-4.19.19.ebuild
+++ b/dev-python/PyQt5-sip/PyQt5-sip-4.19.19.ebuild
@@ -20,7 +20,7 @@ fi
 # Sub-slot based on SIP_API_MAJOR_NR from siplib/sip.h
 SLOT="0/12"
 LICENSE="|| ( GPL-2 GPL-3 SIP )"
-KEYWORDS="amd64 arm ~arm64 ~ppc ~ppc64 x86"
+KEYWORDS="amd64 arm arm64 ~ppc ~ppc64 x86"
 IUSE=""
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/dev-python/PyQt5/PyQt5-5.13.2.ebuild
+++ b/dev-python/PyQt5/PyQt5-5.13.2.ebuild
@@ -18,7 +18,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~ppc ~ppc64 x86"
+KEYWORDS="amd64 arm arm64 ~ppc ~ppc64 x86"
 
 # TODO: QtNfc, QtRemoteObjects (Qt >= 5.12)
 IUSE="bluetooth dbus debug declarative designer examples gles2 gui help location multimedia

--- a/dev-python/PyQtWebEngine/PyQtWebEngine-5.13.2.ebuild
+++ b/dev-python/PyQtWebEngine/PyQtWebEngine-5.13.2.ebuild
@@ -18,7 +18,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE="debug"
 
 REQUIRED_USE="

--- a/dev-python/bottleneck/bottleneck-1.2.1-r1.ebuild
+++ b/dev-python/bottleneck/bottleneck-1.2.1-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/kwgoodman/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 SLOT="0"
 LICENSE="BSD"
-KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm64 x86 ~amd64-linux ~x86-linux"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/cryptography/cryptography-2.8-r1.ebuild
+++ b/dev-python/cryptography/cryptography-2.8-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
 
 LICENSE="|| ( Apache-2.0 BSD )"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="libressl idna test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/cssutils/cssutils-1.0.2-r2.ebuild
+++ b/dev-python/cssutils/cssutils-1.0.2-r2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ppc x86"
+KEYWORDS="amd64 arm arm64 ppc x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/cython/cython-0.29.14-r1.ebuild
+++ b/dev-python/cython/cython-0.29.14-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/cython/cython/archive/${PV}.tar.gz -> ${P}.gh.tar.gz
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~riscv s390 ~sh sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 ~riscv s390 ~sh sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
 IUSE="emacs test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/future/future-0.18.2.ebuild
+++ b/dev-python/future/future-0.18.2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sparc x86 ~amd64-linux ~x86-linux"
 IUSE="doc"
 
 distutils_enable_tests pytest

--- a/dev-python/lxml/lxml-4.4.2.ebuild
+++ b/dev-python/lxml/lxml-4.4.2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/lxml/lxml/archive/${P}.tar.gz"
 
 LICENSE="BSD ElementTree GPL-2 PSF-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 ~riscv s390 ~sh sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 ~riscv s390 ~sh sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc examples +threads test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/markdown/markdown-3.1.1-r1.ebuild
+++ b/dev-python/markdown/markdown-3.1.1-r1.ebuild
@@ -20,7 +20,7 @@ IUSE="doc"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 
 DEPEND="test? (
 	dev-python/pygments[${PYTHON_USEDEP}]

--- a/dev-python/miniupnpc/miniupnpc-2.1.20190824.ebuild
+++ b/dev-python/miniupnpc/miniupnpc-2.1.20190824.ebuild
@@ -13,7 +13,7 @@ SRC_URI="http://miniupnp.free.fr/files/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 x86"
+KEYWORDS="amd64 arm64 ppc ppc64 x86"
 IUSE=""
 
 RDEPEND=">=net-libs/miniupnpc-${PV}:0="

--- a/dev-python/pybind11/pybind11-2.4.3.ebuild
+++ b/dev-python/pybind11/pybind11-2.4.3.ebuild
@@ -13,5 +13,5 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE=""

--- a/dev-python/pygments/pygments-2.5.2.ebuild
+++ b/dev-python/pygments/pygments-2.5.2.ebuild
@@ -18,7 +18,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sh sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/pytest-runner/pytest-runner-5.2.ebuild
+++ b/dev-python/pytest-runner/pytest-runner-5.2.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://pypi.org/project/pytest-runner/ https://github.com/pytest-dev/
 SRC_URI="mirror://pypi/p/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86"
 SLOT="0"
 IUSE="test"
 

--- a/dev-python/qscintilla-python/qscintilla-python-2.11.4.ebuild
+++ b/dev-python/qscintilla-python/qscintilla-python-2.11.4.ebuild
@@ -19,7 +19,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 IUSE="debug"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/dev-python/sip/sip-4.19.19.ebuild
+++ b/dev-python/sip/sip-4.19.19.ebuild
@@ -20,7 +20,7 @@ fi
 # Sub-slot based on SIP_API_MAJOR_NR from siplib/sip.h
 SLOT="0/12"
 LICENSE="|| ( GPL-2 GPL-3 SIP )"
-KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ia64 ppc ppc64 ~sparc x86"
 IUSE="doc"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/dev-python/werkzeug/werkzeug-0.16.0.ebuild
+++ b/dev-python/werkzeug/werkzeug-0.16.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://github.com/pallets/werkzeug/archive/${PV}.tar.gz -> ${P}.gh.tar
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 
 RDEPEND="dev-python/simplejson[${PYTHON_USEDEP}]"
 DEPEND="

--- a/net-libs/miniupnpc/miniupnpc-2.1.20190824.ebuild
+++ b/net-libs/miniupnpc/miniupnpc-2.1.20190824.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="http://miniupnp.free.fr/files/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/17"
-KEYWORDS="amd64 arm ~arm64 hppa ~mips ppc ppc64 s390 sparc x86"
+KEYWORDS="amd64 arm arm64 hppa ~mips ppc ppc64 s390 sparc x86"
 IUSE="ipv6 kernel_linux static-libs"
 
 RDEPEND=""

--- a/sci-libs/arpack/arpack-3.5.0.ebuild
+++ b/sci-libs/arpack/arpack-3.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ SRC_URI="
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="doc examples mpi"
 
 RDEPEND="

--- a/sci-libs/scipy/scipy-1.4.1.ebuild
+++ b/sci-libs/scipy/scipy-1.4.1.ebuild
@@ -23,7 +23,7 @@ LICENSE="BSD LGPL-2"
 SLOT="0"
 IUSE="doc sparse test"
 RESTRICT="!test? ( test )"
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 
 CDEPEND="
 	>=dev-python/numpy-1.10[lapack,${PYTHON_USEDEP}]

--- a/x11-libs/qscintilla/qscintilla-2.11.4.ebuild
+++ b/x11-libs/qscintilla/qscintilla-2.11.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0/15"
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 IUSE="designer doc"
 
 RDEPEND="


### PR DESCRIPTION
A few more arm64 stabilisations and ~arm64 keywords.
Python-3.6.10 and Python-3.7.6 do not pass tests but I understand that's a feature.  

A few of the ~arm64 keywords are a response to stabilisation requests for unkeyworded packages on arm64.  