### PR TITLE
media-libs/dav1d: Subslot bump w/ associated revbump

### DIFF
--- a/media-libs/dav1d/dav1d-0.6.0-r1.ebuild
+++ b/media-libs/dav1d/dav1d-0.6.0-r1.ebuild
@@ -18,7 +18,7 @@ DESCRIPTION="dav1d is an AV1 Decoder :)"
 HOMEPAGE="https://code.videolan.org/videolan/dav1d"
 
 LICENSE="BSD-2"
-SLOT="0/3"
+SLOT="0/4"
 IUSE="+8bit +10bit +asm"
 
 ASM_DEPEND=">=dev-lang/nasm-2.13.02"


### PR DESCRIPTION
dav1d 0.6.0 uses new SONAME versions. e.g dav1d 0.5.2 has `/usr/lib/libdav1d.so.3` with SONAME `libdav1d.so.3` while 0.6.0 has those, but s/3/4/g