### PR TITLE
acct-user/minetest: Add home directory

### DIFF
--- a/acct-user/minetest/minetest-1.ebuild
+++ b/acct-user/minetest/minetest-1.ebuild
@@ -1,0 +1,14 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="A user for the Minetest server"
+
+ACCT_USER_GROUPS=( "minetest" )
+ACCT_USER_ID="480"
+ACCT_USER_HOME="/var/lib/minetest"
+
+acct-user_add_deps


### PR DESCRIPTION
Minetest requires a home directory to store user data. This patch adds
/var/lib/minetest as the default home directory for the minetest user.

Bug: https://bugs.gentoo.org/709530
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>