### PR TITLE
net-misc/chrony: add nettle useflag to enable other key hashes than MD5

### DIFF
--- a/net-misc/chrony/chrony-3.5-r3.ebuild
+++ b/net-misc/chrony/chrony-3.5-r3.ebuild
@@ -12,7 +12,7 @@ SLOT="0"
 
 KEYWORDS="~alpha amd64 arm hppa ppc ppc64 sparc x86"
 IUSE="
-	+adns caps +cmdmon html ipv6 libedit +ntp +phc pps readline +refclock +rtc
+	+adns caps +cmdmon html ipv6 libedit nettle +ntp +phc pps readline +refclock +rtc
 	seccomp selinux
 "
 REQUIRED_USE="
@@ -22,6 +22,7 @@ REQUIRED_USE="
 CDEPEND="
 	caps? ( sys-libs/libcap )
 	libedit? ( dev-libs/libedit )
+	nettle? ( dev-libs/nettle )
 	readline? ( >=sys-libs/readline-4.1-r4:= )
 	seccomp? ( sys-libs/libseccomp )
 "
@@ -68,6 +69,7 @@ src_configure() {
 
 	# not an autotools generated script
 	local myconf=(
+		$(!usex nettle '' --disable-sechash)
 		$(use_enable seccomp scfilter)
 		$(usex adns '' --disable-asyncdns)
 		$(usex caps '' --disable-linuxcaps)
@@ -81,7 +83,6 @@ src_configure() {
 		${CHRONY_EDITLINE}
 		${EXTRA_ECONF}
 		--chronysockdir="${EPREFIX}/run/chrony"
-		--disable-sechash
 		--docdir="${EPREFIX}/usr/share/doc/${PF}"
 		--mandir="${EPREFIX}/usr/share/man"
 		--prefix="${EPREFIX}/usr"

--- a/net-misc/chrony/metadata.xml
+++ b/net-misc/chrony/metadata.xml
@@ -21,6 +21,7 @@ Chrony はコンピュータのシステム・クロックの精度を保つた�
 <flag name="adns">Support for asynchronous DNS</flag>
 <flag name="cmdmon">Support for command and monitoring</flag>
 <flag name="html">Install HTML documentation</flag>
+<flag name="nettle">Support for the nettle low-level cryptographic library</flag>
 <flag name="ntp">Support for the Network Time Protocol (NTP)</flag>
 <flag name="phc">Support for the PTP (Precision Time Protocol) Hardware Clock (PHC) interface</flag>
 <flag name="pps">Support for the Linux Pulse Per Second (PPS) interface</flag>


### PR DESCRIPTION
To enable other hashes than MD5.
It may be changed to nss, libtomcrypt, or maybe add three different useflags.