### PR TITLE
dev-python/mpmath-1.1.0-r1: add python 3.8

### DIFF
--- a/dev-python/mpmath/mpmath-1.1.0-r1.ebuild
+++ b/dev-python/mpmath/mpmath-1.1.0-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python{3_6,3_7,3_8} )
+
+inherit distutils-r1 eutils
+
+DESCRIPTION="Python library for arbitrary-precision floating-point arithmetic"
+HOMEPAGE="http://mpmath.org/"
+SRC_URI="https://github.com/fredrik-johansson/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+
+IUSE="gmp matplotlib test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	gmp? ( dev-python/gmpy )
+	matplotlib? ( dev-python/matplotlib[${PYTHON_USEDEP}] )"
+DEPEND="${RDEPEND}
+	test? ( dev-python/pytest[${PYTHON_USEDEP}] )"
+
+python_prepare_all() {
+	local PATCHES=(
+		"${FILESDIR}/${PN}-1.0.0.patch"
+		)
+
+	# this test requires X
+	rm ${PN}/tests/test_visualization.py || die
+
+	distutils-r1_python_prepare_all
+}
+
+python_test() {
+	pushd ${PN}/tests >/dev/null
+	${EPYTHON} runtests.py -local
+	popd >/dev/null
+}


### PR DESCRIPTION
@zmedico @gyakovlev @chutz

```
--- mpmath-1.1.0.ebuild 2020-03-09 10:45:12.164857866 -0700
+++ mpmath-1.1.0-r1.ebuild      2020-03-09 10:46:14.859902459 -0700
@@ -1,9 +1,9 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2

-EAPI=6
+EAPI=7

-PYTHON_COMPAT=( python{3_6,3_7} )
+PYTHON_COMPAT=( python{3_6,3_7,3_8} )

 inherit distutils-r1 eutils
```