### PR TITLE
eclass: append m4flags sysflags before input file name

### DIFF
--- a/eclass/autotools.eclass
+++ b/eclass/autotools.eclass
@@ -512,7 +512,7 @@ autotools_run_tool() {
 	fi
 
 	if ${m4flags} ; then
-		set -- "${1}" $(autotools_m4dir_include) "${@:2}" $(autotools_m4sysdir_include)
+		set -- "${1}" $(autotools_m4dir_include) $(autotools_m4sysdir_include) "${@:2}"
 	fi
 
 	# If the caller wants to probe something, then let them do it directly.


### PR DESCRIPTION
In case of autoconf 2.13, i.e. `WANT_AUTOCONF=2.1`, autoconf sometimes fails with the following error:

```
***** autoconf *****
***** PWD: .../portage/dev-lang/spidermonkey-60.5.2_p0-r2/work/mozjs-60.5.2/js/src
***** autoconf old-configure.in -l /build/arm64-usr/usr/share/aclocal

Usage: autoconf [-h] [--help] [-m dir] [--macrodir=dir]
       [-l dir] [--localdir=dir] [--version] [template-file]
```

So what happens is, `autotools_run_tool()` seems to get the correct options, `$(autotools_m4sysdir_include)`, however appends it after `${@:2}", the input file name. 
That's why autoconf fails like that.

Actually autoconf wants the tailing options to be located before the input file name, like `autoconf -l /build/arm64-usr/usr/share/aclocal old-configure.in`, which works fine.

Fix the order correctly to avoid such configure errors.
