### PR TITLE
media-sound/gtick: Various fixes

### DIFF
--- a/media-sound/gtick/files/gtick-0.5.4-desktop.patch
+++ b/media-sound/gtick/files/gtick-0.5.4-desktop.patch
@@ -1,0 +1,32 @@
+Downstream patch. No upstream activity since 2014.
+
+From b07f665d712fdbebfd506ef6301fc9ac71660e96 Mon Sep 17 00:00:00 2001
+From: Alexander Tsoy <alexander@tsoy.me>
+Date: Thu, 19 Mar 2020 21:17:22 +0300
+Subject: [PATCH 2/2] Fix desktop file
+
+---
+ gtick.desktop | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/gtick.desktop b/gtick.desktop
+index 05cf5ed..a31dee3 100644
+--- a/gtick.desktop
++++ b/gtick.desktop
+@@ -5,9 +5,10 @@ Name=GTick
+ Comment=a GTK-based metronome
+ Comment[pt]=Um metrônomo baseado em GTK
+ Comment[pt-br]=Um metrônomo baseado em GTK
+-Exec=/usr/bin/gtick
+-Icon=/usr/share/icons/hicolor/64x64/apps/gtick.xpm
++Exec=gtick
++Icon=gtick
+ Terminal=false
+ Type=Application
+ Categories=GTK;AudioVideo;Audio;
+-GenericName[pt_BR]=
++GenericName=Graphical Metronome
++StartupNotify=true
+-- 
+2.24.1
+

--- a/media-sound/gtick/files/gtick-0.5.4-fno-common.patch
+++ b/media-sound/gtick/files/gtick-0.5.4-fno-common.patch
@@ -1,0 +1,27 @@
+Downstream patch. No upstream activity since 2014.
+
+From 23f5585ba3dcf276cd3f71c25f710e68823f97e9 Mon Sep 17 00:00:00 2001
+From: Alexander Tsoy <alexander@tsoy.me>
+Date: Tue, 17 Mar 2020 17:14:50 +0300
+Subject: [PATCH 1/2] Fix building with -fno-common
+
+---
+ src/optionlexer.l | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/optionlexer.l b/src/optionlexer.l
+index df79dd5..97ed29d 100644
+--- a/src/optionlexer.l
++++ b/src/optionlexer.l
+@@ -40,7 +40,7 @@
+ #include "optionlexer.h"
+ 
+ char* option_filename;
+-YYLTYPE option_lloc;
++#define YYLTYPE option_lloc;
+ 
+ void option_locate();
+ %}
+-- 
+2.24.1
+

--- a/media-sound/gtick/gtick-0.5.4-r1.ebuild
+++ b/media-sound/gtick/gtick-0.5.4-r1.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop xdg-utils
+
+DESCRIPTION="Metronome application supporting different meters and speeds ranging"
+HOMEPAGE="https://www.antcom.de/gtick"
+SRC_URI="https://www.antcom.de/gtick/download/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE="nls sndfile"
+
+RDEPEND="media-sound/pulseaudio
+	x11-libs/gtk+:2
+	sndfile? ( media-libs/libsndfile )"
+DEPEND="${RDEPEND}"
+BDEPEND="sys-devel/bison
+	sys-devel/flex
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )"
+
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-desktop.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i 's:^\(appdatadir = .*/\)appdata:\1metainfo:' \
+		Makefile.in || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable nls)
+		$(use_with sndfile)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	local res
+
+	default
+
+	for res in 32 48 64; do
+		newicon -s ${res} src/icon${res}x${res}.xpm gtick.xpm
+	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}

--- a/media-sound/gtick/metadata.xml
+++ b/media-sound/gtick/metadata.xml
@@ -5,4 +5,12 @@
 		<email>sound@gentoo.org</email>
 		<name>Gentoo Sound project</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>alexander@tsoy.me</email>
+		<name>Alexander Tsoy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
* Fix build with -fno-common
* Don't install duplicate desktop entry
* Fix .desktop file
* Install additional icons and update icons cache
* Move AppStream metadata into /usr/share/metainfo
* Change license to GPL3+

Closes: https://bugs.gentoo.org/683436
Closes: https://bugs.gentoo.org/709396