### PR TITLE
net-misc/getdate: Fix build with glibc-2.31, revbump

### DIFF
--- a/net-misc/getdate/files/getdate-glibc-2.31.patch
+++ b/net-misc/getdate/files/getdate-glibc-2.31.patch
@@ -1,0 +1,13 @@
+--- a/getdate.c
++++ b/getdate.c
+@@ -214,7 +214,9 @@
+                                /* Dangerous!  Could upset cron and other
+                                 * timer related events.
+                                 */
+-    stime(&new_time);
++    struct timespec s = {0};
++    s.tv_sec = new_time;
++    clock_settime(CLOCK_REALTIME, &s);
+     print_samples(host, first_sample, second_sample);
+     printf("getdate: set time to %s to match host %s\n",
+           time_to_str(new_time),

--- a/net-misc/getdate/getdate-1.2-r2.ebuild
+++ b/net-misc/getdate/getdate-1.2-r2.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MY_PN="${PN}_rfc868"
+MY_P="${MY_PN}-${PV}"
+
+inherit toolchain-funcs
+
+DESCRIPTION="Network Date/Time Query and Set Local Date/Time Utility"
+HOMEPAGE="http://www.ibiblio.org/pub/Linux/system/network/misc/"
+SRC_URI="http://www.ibiblio.org/pub/Linux/system/network/misc/${MY_P}.tar.gz"
+
+LICENSE="GPL-1+"
+SLOT="0"
+KEYWORDS="~amd64 ~mips ~ppc ~x86"
+IUSE=""
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-glibc-2.31.patch"
+)
+
+src_prepare() {
+	sed -i -e "/errno.h/ a\#include <string.h>" getdate.c || die
+	# Respect CFLAGS
+	sed -i -e "/CFLAGS/d" Makefile || die
+
+	default
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin getdate
+	doman getdate.8
+	dodoc README getdate-cron
+}


### PR DESCRIPTION
Patches getdate to not use stime (removed in glibc-2.31).
Tested and adjusts time fine.

Closes: https://bugs.gentoo.org/709642
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>