### PR TITLE
leechcraft.eclass: use the `cmake` eclass for EAPI=7

### DIFF
--- a/eclass/leechcraft.eclass
+++ b/eclass/leechcraft.eclass
@@ -39,6 +39,12 @@ fi
 HOMEPAGE="https://leechcraft.org/"
 LICENSE="Boost-1.0"
 
+DEPEND="
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+"
+RDEPEND="${DEPEND}"
+
 # @ECLASS-VARIABLE: LEECHCRAFT_PLUGIN_CATEGORY
 # @DEFAULT_UNSET
 # @DESCRIPTION:


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/705820
Signed-off-by: 0xd34df00d <0xd34df00d@gmail.com>