### PR TITLE
media-tv/linuxtv-dvb-apps: Fix build with glibc-2.31, revbump, EAPI=7

### DIFF
--- a/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-glibc-2.31.patch
+++ b/media-tv/linuxtv-dvb-apps/files/linuxtv-dvb-apps-glibc-2.31.patch
@@ -1,0 +1,14 @@
+--- a/util/dvbdate/dvbdate.c
++++ b/util/dvbdate/dvbdate.c
+@@ -309,7 +309,10 @@
+  */
+ int set_time(time_t * new_time)
+ {
+-	if (stime(new_time)) {
++	struct timespec s = {0};
++	s.tv_sec = new_time;
++
++	if (clock_settime(CLOCK_REALTIME, &s)) {
+ 		perror("Unable to set time");
+ 		return -1;
+ 	}

--- a/media-tv/linuxtv-dvb-apps/linuxtv-dvb-apps-1.1.1.20140321-r1.ebuild
+++ b/media-tv/linuxtv-dvb-apps/linuxtv-dvb-apps-1.1.1.20140321-r1.ebuild
@@ -1,0 +1,93 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs vcs-snapshot
+
+HOMEPAGE="https://www.linuxtv.org/"
+DESCRIPTION="Small utils for DVB to scan, zap, view signal strength"
+SRC_URI="https://www.linuxtv.org/hg/dvb-apps/archive/3d43b280298c.tar.bz2 -> ${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
+IUSE="alevt usb"
+
+RDEPEND="
+        alevt? (
+                !media-video/alevt
+                media-libs/libpng:0=
+                media-libs/zvbi[v4l]
+                sys-libs/zlib
+                x11-libs/libX11
+        )
+        usb? ( virtual/libusb:0 )
+"
+DEPEND="${RDEPEND}
+        dev-lang/perl
+        virtual/linuxtv-dvb-headers
+"
+RDEPEND+="
+        media-tv/dtv-scan-tables
+"
+
+PATCHES=(
+        "${FILESDIR}"/${PN}-1.1.1.20100223-ldflags.patch
+        "${FILESDIR}"/${PN}-1.1.1.20100223-alevt.patch
+        "${FILESDIR}"/${PN}-1.1.1.20100223-perl526.patch
+        "${FILESDIR}"/${PN}-no-ca_set_pid.patch
+        "${FILESDIR}"/${PN}-glibc-2.31.patch
+)
+
+src_prepare() {
+        default
+
+        # do not compile test-progs, incompatible with videodev2.h
+        sed -i '/-C test/d' Makefile || die
+
+        # remove copy of header-files
+        rm -rv "${S}"/include/ || die
+}
+
+src_compile() {
+        emake V=1 CC=$(tc-getCC) $(usex usb "ttusb_dec_reset=1" "")
+        use alevt && emake -C util/alevt CC=$(tc-getCC) OPT="${CFLAGS}"
+}
+
+src_install() {
+        emake V=1 prefix="${EPREFIX}/usr" libdir="${EPREFIX}/usr/$(get_libdir)" \
+                $(usex usb "ttusb_dec_reset=1" "") \
+                DESTDIR="${D}" INSTDIR="${T}" install
+
+        if use alevt ; then
+                dodir /usr/share/{applications,man/man1}
+                emake -C util/alevt DESTDIR="${D}" install
+        fi
+
+        # rename scan to scan-dvb
+        mv "${ED}"/usr/bin/scan{,-dvb} || die
+
+        # install zap-files
+        local dir=""
+        for dir in dvb-{s,c,t} atsc ; do
+                insinto /usr/share/dvb/zap/${dir}
+                doins "${S}"/util/szap/channels-conf/${dir}/*
+        done
+
+        # install remote-key files
+        insinto /usr/share/dvb/av7110_loadkeys
+        doins util/av7110_loadkeys/*.rc*
+
+        # install Documentation
+        dodoc README
+        newdoc util/scan/README README.scan-dvb
+        newdoc util/szap/README README.zap
+        newdoc util/av7110_loadkeys/README README.av7110_loadkeys
+
+        use usb && newdoc util/ttusb_dec_reset/README README.ttusb_dec_reset
+}
+
+pkg_postinst() {
+        elog "/usr/bin/scan has been installed as scan-dvb."
+}


### PR DESCRIPTION
* Patch to allow build with glibc-2.31
* EAPI bumped 6 -> 7 (no actual changes needed)
* Revbump to -r1

Closes: https://bugs.gentoo.org/711988
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>