### PR TITLE
dev-python/humanize: Build requires dev-python/setuptools_scm

### DIFF
--- a/dev-python/humanize/humanize-1.0.0.ebuild
+++ b/dev-python/humanize/humanize-1.0.0.ebuild
@@ -22,6 +22,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 BDEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/setuptools_scm[${PYTHON_USEDEP}]
 	test? ( dev-python/freezegun[${PYTHON_USEDEP}] )
 "
 

--- a/dev-python/humanize/humanize-2.0.0.ebuild
+++ b/dev-python/humanize/humanize-2.0.0.ebuild
@@ -22,6 +22,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 BDEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/setuptools_scm[${PYTHON_USEDEP}]
 	test? (
 		dev-python/freezegun[${PYTHON_USEDEP}]
 		dev-python/pytest[${PYTHON_USEDEP}]


### PR DESCRIPTION
When I try to build `>=dev-python/humanize-1.0.0` without first installing `dev-python/setuptools_scm`, the following errors occur.

```
>>> [ 13:14 ] Emerging (1 of 1) dev-python/humanize-2.0.0::gentoo
 * humanize-2.0.0.tar.gz BLAKE2B SHA512 size ;-) ...                                                                                                                                                                                                                           [ ok ]
>>> Unpacking source...
>>> Unpacking humanize-2.0.0.tar.gz to /var/portage/portage/dev-python/humanize-2.0.0/work
>>> Source unpacked in /var/portage/portage/dev-python/humanize-2.0.0/work
>>> Preparing source in /var/portage/portage/dev-python/humanize-2.0.0/work/humanize-2.0.0 ...
>>> Source prepared.
>>> Configuring source in /var/portage/portage/dev-python/humanize-2.0.0/work/humanize-2.0.0 ...
>>> Source configured.
>>> Compiling source in /var/portage/portage/dev-python/humanize-2.0.0/work/humanize-2.0.0 ...
 * python3_6: running distutils-r1_run_phase distutils-r1_python_compile
python3.6 setup.py build -j 8
WARNING: The pip package is not available, falling back to EasyInstall for handling setup_requires/test_requires; this is deprecated and will be removed in a future version.
Download error on https://pypi.org/simple/setuptools_scm/: [Errno -3] Temporary failure in name resolution -- Some packages may not be found!
Download error on https://pypi.org/simple/setuptools-scm/: [Errno -3] Temporary failure in name resolution -- Some packages may not be found!
Couldn't find index page for 'setuptools_scm' (maybe misspelled?)
Download error on https://pypi.org/simple/: [Errno -3] Temporary failure in name resolution -- Some packages may not be found!
No local packages or working download links found for setuptools_scm
Traceback (most recent call last):
  File "/usr/lib64/python3.6/site-packages/setuptools/installer.py", line 62, in fetch_build_egg
    pkg_resources.get_distribution('pip')
  File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 481, in get_distribution
    dist = get_provider(dist)
  File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 357, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pip' distribution was not found and is required by the application

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "setup.py", line 48, in <module>
    "Topic :: Text Processing :: General",
  File "/usr/lib64/python3.6/site-packages/setuptools/__init__.py", line 144, in setup
    _install_setup_requires(attrs)
  File "/usr/lib64/python3.6/site-packages/setuptools/__init__.py", line 139, in _install_setup_requires
    dist.fetch_build_eggs(dist.setup_requires)
  File "/usr/lib64/python3.6/site-packages/setuptools/dist.py", line 721, in fetch_build_eggs
    replace_conflicting=True,
  File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 782, in resolve
    replace_conflicting=replace_conflicting
  File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 1065, in best_match
    return self.obtain(req, installer)
  File "/usr/lib64/python3.6/site-packages/pkg_resources/__init__.py", line 1077, in obtain
    return installer(requirement)
  File "/usr/lib64/python3.6/site-packages/setuptools/dist.py", line 777, in fetch_build_egg
    return fetch_build_egg(self, req)
  File "/usr/lib64/python3.6/site-packages/setuptools/installer.py", line 70, in fetch_build_egg
    return _legacy_fetch_build_egg(dist, req)
  File "/usr/lib64/python3.6/site-packages/setuptools/installer.py", line 53, in _legacy_fetch_build_egg
    return cmd.easy_install(req)
  File "/usr/lib64/python3.6/site-packages/setuptools/command/easy_install.py", line 679, in easy_install
    raise DistutilsError(msg)
distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('setuptools_scm')
 * ERROR: dev-python/humanize-2.0.0::gentoo failed (compile phase):
 *   (no error message)
 * 
 * Call stack:
 *     ebuild.sh, line  125:  Called src_compile
 *   environment, line 2852:  Called distutils-r1_src_compile
 *   environment, line  972:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_compile'
 *   environment, line  437:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 2423:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 1808:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 1806:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line  681:  Called distutils-r1_run_phase 'distutils-r1_python_compile'
 *   environment, line  963:  Called distutils-r1_python_compile
 *   environment, line  833:  Called esetup.py 'build' '-j' '8'
 *   environment, line 1352:  Called die
 * The specific snippet of code:
 *       "${@}" || die "${die_args[@]}";
 * 
 * If you need support, post the output of `emerge --info '=dev-python/humanize-2.0.0::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/humanize-2.0.0::gentoo'`.
 * The complete build log is located at '/var/portage/portage/dev-python/humanize-2.0.0/temp/build.log'.
 * The ebuild environment file is located at '/var/portage/portage/dev-python/humanize-2.0.0/temp/environment'.
 * Working directory: '/var/portage/portage/dev-python/humanize-2.0.0/work/humanize-2.0.0'
 * S: '/var/portage/portage/dev-python/humanize-2.0.0/work/humanize-2.0.0'

>>> [ 13:14 ] Failed to emerge dev-python/humanize-2.0.0
```