### PR TITLE
dev-python/docker-py-4.2.0-r1: add python 3.8 support

### DIFF
--- a/dev-python/docker-py/docker-py-4.2.0-r1.ebuild
+++ b/dev-python/docker-py/docker-py-4.2.0-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{6,7,8} )
+
+inherit distutils-r1
+
+DESCRIPTION="Python client for Docker"
+HOMEPAGE="https://github.com/docker/docker-py"
+SRC_URI="https://github.com/docker/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="doc test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	!~dev-python/requests-2.18.0[${PYTHON_USEDEP}]
+	>=dev-python/requests-2.14.2[${PYTHON_USEDEP}]
+	>=dev-python/six-1.4.0[${PYTHON_USEDEP}]
+	>=dev-python/websocket-client-0.32.0[${PYTHON_USEDEP}]
+"
+DEPEND="
+	test? (
+		${RDEPEND}
+		>=dev-python/mock-1.0.1[${PYTHON_USEDEP}]
+		>=dev-python/paramiko-2.4.2[${PYTHON_USEDEP}]
+		>=dev-python/pytest-2.9.1[${PYTHON_USEDEP}]
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix_splitnport.patch
+)
+
+distutils_enable_sphinx docs \
+	'dev-python/recommonmark' \
+	'>=dev-python/sphinx-1.4.6'
+
+python_test() {
+	pytest -vv tests/unit/ || die "tests failed under ${EPYTHON}"
+}

--- a/dev-python/docker-py/files/docker-py-4.2.0-fix_splitnport.patch
+++ b/dev-python/docker-py/files/docker-py-4.2.0-fix_splitnport.patch
@@ -1,0 +1,59 @@
+diff --git a/docker/utils/utils.py b/docker/utils/utils.py
+index 447760b..3996d08 100644
+--- a/docker/utils/utils.py
++++ b/docker/utils/utils.py
+@@ -17,10 +17,9 @@ from ..constants import DEFAULT_NPIPE
+ from ..constants import BYTE_UNITS
+ 
+ if six.PY2:
+-    from urllib import splitnport
+     from urlparse import urlparse
+ else:
+-    from urllib.parse import splitnport, urlparse
++    from urllib.parse import urlparse
+ 
+ 
+ def create_ipam_pool(*args, **kwargs):
+@@ -278,7 +277,7 @@ def parse_host(addr, is_win32=False, tls=False):
+             if proto != 'ssh':
+                 raise errors.DockerException(
+                     'Invalid bind address format: port is required:'
+-                    ' {}'.format(addr)
++                    ' {}://{}'.format(proto, addr)
+                 )
+             port = 22
+ 
+@@ -295,6 +294,33 @@ def parse_host(addr, is_win32=False, tls=False):
+         return "{}://{}".format(proto, path).rstrip('/')
+     return '{0}://{1}:{2}{3}'.format(proto, host, port, path).rstrip('/')
+ 
++def splitnport(netloc):
++    import re
++
++    host_port_re1 = re.compile(r"^(.*):([0-9]*)$", re.DOTALL)
++    host_port_re2 = re.compile(r"^(.*)$", re.DOTALL)
++
++    host = None
++    port = None
++
++    match = host_port_re1.match(netloc)
++
++    if match:
++        host, port = match.groups()
++    else:
++        match = host_port_re2.match(netloc)
++        if match:
++            host = match.groups()[0]
++            port = None
++
++    if host == '':
++        host = None
++    if port == '':
++        port = None
++
++    port = int(port) if port else 0
++
++    return host, port or None
+ 
+ def parse_devices(devices):
+     device_list = []


### PR DESCRIPTION
@zmedico @gyakovlev @chutz

```
--- docker-py-4.2.0.ebuild      2020-03-11 11:13:28.940357036 -0700
+++ docker-py-4.2.0-r1.ebuild   2020-03-11 15:55:37.134992088 -0700
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2

 EAPI=7
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7,8} )

 inherit distutils-r1

@@ -27,22 +27,18 @@
                ${RDEPEND}
                >=dev-python/mock-1.0.1[${PYTHON_USEDEP}]
                >=dev-python/paramiko-2.4.2[${PYTHON_USEDEP}]
-               dev-python/pytest-runner[${PYTHON_USEDEP}]
                >=dev-python/pytest-2.9.1[${PYTHON_USEDEP}]
        )
-       doc? (
-               dev-python/recommonmark[${PYTHON_USEDEP}]
-               >=dev-python/sphinx-1.4.6[${PYTHON_USEDEP}]
-       )
 "

-python_compile_all() {
-       if use doc; then
-               sphinx-build docs html || die "docs failed to build"
-               HTML_DOCS=( html/. )
-       fi
-}
+PATCHES=(
+       "${FILESDIR}"/${P}-fix_splitnport.patch
+)
+
+distutils_enable_sphinx docs \
+       'dev-python/recommonmark' \
+       '>=dev-python/sphinx-1.4.6'

 python_test() {
-       py.test tests/unit/ || die "tests failed under ${EPYTHON}"
+       pytest -vv tests/unit/ || die "tests failed under ${EPYTHON}"
 }
```

The patch fixes this future error:
```
docker/utils/utils.py:276: DeprecationWarning: urllib.parse.splitnport() is deprecated as of 3.8, use urllib.parse.urlparse() instead
```

```
>>> Test phase: dev-python/docker-py-4.2.0-r1
 * python3_6: running distutils-r1_run_phase python_test
============================= test session starts ==============================
platform linux -- Python 3.6.10, pytest-4.6.9, py-1.8.0, pluggy-0.13.1
rootdir: /data/scratch/portage/tmp/portage/dev-python/docker-py-4.2.0-r1/work/docker-py-4.2.0, inifile: pytest.ini
plugins: cov-2.8.1, nbval-0.9.5, flaky-3.6.1
collected 553 items

tests/unit/api_build_test.py .........s...                               [  2%]
tests/unit/api_container_test.py ....................................... [  9%]
.........................................................                [ 19%]
tests/unit/api_exec_test.py .....                                        [ 20%]
tests/unit/api_image_test.py .........................                   [ 25%]
tests/unit/api_network_test.py ......                                    [ 26%]
tests/unit/api_test.py .....................................             [ 32%]
tests/unit/api_volume_test.py ..........                                 [ 34%]
tests/unit/auth_test.py ................................................ [ 43%]
........                                                                 [ 44%]
tests/unit/client_test.py ..........                                     [ 46%]
tests/unit/context_test.py .....s                                        [ 47%]
tests/unit/dockertypes_test.py ......................................... [ 55%]
.....x............                                                       [ 58%]
tests/unit/errors_test.py ..................                             [ 61%]
tests/unit/models_containers_test.py ................................... [ 67%]
...                                                                      [ 68%]
tests/unit/models_images_test.py ................                        [ 71%]
tests/unit/models_networks_test.py ......                                [ 72%]
tests/unit/models_resources_test.py ..                                   [ 72%]
tests/unit/models_services_test.py .                                     [ 73%]
tests/unit/ssladapter_test.py ......                                     [ 74%]
tests/unit/swarm_test.py ...                                             [ 74%]
tests/unit/types_containers_test.py .                                    [ 74%]
tests/unit/utils_build_test.py ...s.......................s............. [ 82%]
...                                                                      [ 82%]
tests/unit/utils_config_test.py .....s....                               [ 84%]
tests/unit/utils_json_stream_test.py .......                             [ 85%]
tests/unit/utils_proxy_test.py .....                                     [ 86%]
tests/unit/utils_test.py ...........................................s... [ 95%]
..........................                                               [100%]

=========================== short test summary info ============================
XFAIL tests/unit/dockertypes_test.py::MountTest::test_parse_mount_bind_windows
SKIPPED [1] tests/unit/api_build_test.py:169: Windows-specific syntax
SKIPPED [1] tests/unit/context_test.py:18: Windows specific path check
SKIPPED [1] tests/unit/utils_build_test.py:232: Backslash patterns only on Windows
SKIPPED [1] tests/unit/utils_build_test.py:254: Backslash patterns only on Windows
SKIPPED [1] tests/unit/utils_config_test.py:58: condition: sys.platform != 'win32'
SKIPPED [1] tests/unit/utils_test.py:486: shlex doesn't support bytes in py3
=============== 546 passed, 6 skipped, 1 xfailed in 5.47 seconds ===============
```

```
 * python3_8: running distutils-r1_run_phase python_test
============================= test session starts ==============================
platform linux -- Python 3.8.2, pytest-4.6.9, py-1.8.0, pluggy-0.13.1
rootdir: /data/scratch/portage/tmp/portage/dev-python/docker-py-4.2.0-r1/work/docker-py-4.2.0, inifile: pytest.ini
plugins: cov-2.8.1, nbval-0.9.5, flaky-3.6.1
collected 553 items

tests/unit/api_build_test.py .........s...                               [  2%]
tests/unit/api_container_test.py ....................................... [  9%]
.........................................................                [ 19%]
tests/unit/api_exec_test.py .....                                        [ 20%]
tests/unit/api_image_test.py .........................                   [ 25%]
tests/unit/api_network_test.py ......                                    [ 26%]
tests/unit/api_test.py .....................................             [ 32%]
tests/unit/api_volume_test.py ..........                                 [ 34%]
tests/unit/auth_test.py ................................................ [ 43%]
........                                                                 [ 44%]
tests/unit/client_test.py ..........                                     [ 46%]
tests/unit/context_test.py .....s                                        [ 47%]
tests/unit/dockertypes_test.py ......................................... [ 55%]
.....x............                                                       [ 58%]
tests/unit/errors_test.py ..................                             [ 61%]
tests/unit/models_containers_test.py ................................... [ 67%]
...                                                                      [ 68%]
tests/unit/models_images_test.py ................                        [ 71%]
tests/unit/models_networks_test.py ......                                [ 72%]
tests/unit/models_resources_test.py ..                                   [ 72%]
tests/unit/models_services_test.py .                                     [ 73%]
tests/unit/ssladapter_test.py ......                                     [ 74%]
tests/unit/swarm_test.py ...                                             [ 74%]
tests/unit/types_containers_test.py .                                    [ 74%]
tests/unit/utils_build_test.py ...s.......................s............. [ 82%]
...                                                                      [ 82%]
tests/unit/utils_config_test.py .....s....                               [ 84%]
tests/unit/utils_json_stream_test.py .......                             [ 85%]
tests/unit/utils_proxy_test.py .....                                     [ 86%]
tests/unit/utils_test.py ...........................................s... [ 95%]
..........................                                               [100%]

=============================== warnings summary ===============================
/usr/lib/python3.8/site-packages/socks.py:58
  /usr/lib/python3.8/site-packages/socks.py:58: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Callable

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================== short test summary info ============================
XFAIL tests/unit/dockertypes_test.py::MountTest::test_parse_mount_bind_windows
SKIPPED [1] tests/unit/api_build_test.py:169: Windows-specific syntax
SKIPPED [1] tests/unit/context_test.py:18: Windows specific path check
SKIPPED [1] tests/unit/utils_build_test.py:232: Backslash patterns only on Windows
SKIPPED [1] tests/unit/utils_build_test.py:254: Backslash patterns only on Windows
SKIPPED [1] tests/unit/utils_config_test.py:58: condition: sys.platform != 'win32'
SKIPPED [1] tests/unit/utils_test.py:486: shlex doesn't support bytes in py3
========= 546 passed, 6 skipped, 1 xfailed, 1 warnings in 5.18 seconds =========
```