### PR TITLE
profiles: {ppc,alpha}: mask USE=bpf for v4l-utils

### DIFF
--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Andrey Utkin <andrey_utkin@gentoo.org> (2020-03-11)
+# USE=bpf depends on sys-devel/clang which is not keyworded on alpha.
+media-tv/v4l-utils bpf
+
 # Patrick McLean <chutzpah@gentoo.org> (2020-02-15)
 # Mask until dev-libs/libfido2 is keyworded
 net-misc/openssh security-key

--- a/profiles/arch/powerpc/ppc32/package.use.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Andrey Utkin <andrey_utkin@gentoo.org> (2020-03-11)
+# USE=bpf depends on sys-devel/clang which is not keyworded on ppc.
+media-tv/v4l-utils bpf
+
 # Matthew Thode <prometheanfire@gentoo.org> (2020-02-17)
 # Mask until net-analyzer/icinga2 is keyworded
 net-analyzer/pnp4nagios icinga


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/678940

Of special interest to alpha and ppc arches teams.
Any feedback from others is appreciated, too.

It is currently impossible to keep v4l-utils keyworded for alpha and ppc because v4l-utils ebuild happens to make it possible to enable "bpf" option which requires clang, and clang is not keyworded on alpha and ppc.