### PR TITLE
Prepare deps for libnm-glib removal / libnm-gtk update

### DIFF
--- a/net-im/pidgin/pidgin-2.13.0-r7.ebuild
+++ b/net-im/pidgin/pidgin-2.13.0-r7.ebuild
@@ -72,7 +72,7 @@ RDEPEND="
 	tcl? ( dev-lang/tcl:0= )
 	tk? ( dev-lang/tk:0= )
 	sasl? ( dev-libs/cyrus-sasl:2 )
-	networkmanager? ( net-misc/networkmanager )
+	networkmanager? ( <net-misc/networkmanager-1.19 )
 	idn? ( net-dns/libidn:= )
 	!<x11-plugins/pidgin-facebookchat-1.69-r1"
 	# Mono support crashes pidgin

--- a/net-vpn/networkmanager-fortisslvpn/networkmanager-fortisslvpn-1.2.6-r1.ebuild
+++ b/net-vpn/networkmanager-fortisslvpn/networkmanager-fortisslvpn-1.2.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,7 +23,7 @@ RDEPEND="
 	>=net-vpn/openfortivpn-1.2.0
 	gtk? (
 		>=app-crypt/libsecret-0.18
-		>=gnome-extra/nm-applet-1.2.0
+		>=gnome-extra/nm-applet-1.2.0[gtk]
 		>=x11-libs/gtk+-3.4:3
 	)
 "

--- a/net-vpn/networkmanager-fortisslvpn/networkmanager-fortisslvpn-1.2.8-r1.ebuild
+++ b/net-vpn/networkmanager-fortisslvpn/networkmanager-fortisslvpn-1.2.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,7 +23,7 @@ RDEPEND="
 	>=net-vpn/openfortivpn-1.2.0
 	gtk? (
 		>=app-crypt/libsecret-0.18
-		>=gnome-extra/nm-applet-1.2.0
+		>=gnome-extra/nm-applet-1.2.0[gtk]
 		>=x11-libs/gtk+-3.4:3
 	)
 "

--- a/net-vpn/networkmanager-openvpn/networkmanager-openvpn-1.8.10-r1.ebuild
+++ b/net-vpn/networkmanager-openvpn/networkmanager-openvpn-1.8.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -21,7 +21,7 @@ RDEPEND="
 	>=net-vpn/openvpn-2.1
 	gtk? (
 		>=app-crypt/libsecret-0.18
-		>=gnome-extra/nm-applet-1.7.0
+		>=gnome-extra/nm-applet-1.7.0[gtk]
 		>=x11-libs/gtk+-3.4:3
 	)
 "

--- a/net-vpn/networkmanager-pptp/networkmanager-pptp-1.2.8-r1.ebuild
+++ b/net-vpn/networkmanager-pptp/networkmanager-pptp-1.2.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -22,7 +22,7 @@ RDEPEND="
 	net-dialup/pptpclient
 	gtk? (
 		>=app-crypt/libsecret-0.18
-		>=gnome-extra/nm-applet-1.2.0
+		>=gnome-extra/nm-applet-1.2.0[gtk]
 		>=x11-libs/gtk+-3.4:3
 	)
 "

--- a/net-vpn/networkmanager-vpnc/networkmanager-vpnc-1.2.6-r1.ebuild
+++ b/net-vpn/networkmanager-vpnc/networkmanager-vpnc-1.2.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -22,7 +22,7 @@ RDEPEND="
 	>=net-vpn/vpnc-0.5.3_p550
 	gtk? (
 		>=app-crypt/libsecret-0.18
-		>=gnome-extra/nm-applet-1.2.0
+		>=gnome-extra/nm-applet-1.2.0[gtk]
 		>=x11-libs/gtk+-3.4:3
 	)
 "


### PR DESCRIPTION
Related: 
 - https://bugs.gentoo.org/665338
 - 0dd37329676dcdad19fa6a3230f4231814e49047 (package.masked for now)
 - 2ab07dc8fcb3b8f9410abd584d110a9102a1028f

@mattst88 @leio 