### PR TITLE
net-mail/dovecot: Updated upgrade notes URLs in elog

### DIFF
--- a/net-mail/dovecot/dovecot-2.2.36.4.ebuild
+++ b/net-mail/dovecot/dovecot-2.2.36.4.ebuild
@@ -283,5 +283,5 @@ pkg_postinst() {
 		install_cert /etc/ssl/dovecot/server
 	fi
 
-	elog "Please read http://wiki2.dovecot.org/Upgrading/ for upgrade notes."
+	elog "Please read https://doc.dovecot.org/installation_guide/upgrading/ for upgrade notes."
 }

--- a/net-mail/dovecot/dovecot-2.3.10.ebuild
+++ b/net-mail/dovecot/dovecot-2.3.10.ebuild
@@ -282,5 +282,5 @@ pkg_postinst() {
 		install_cert /etc/ssl/dovecot/server
 	fi
 
-	elog "Please read https://wiki2.dovecot.org/Upgrading/ for upgrade notes."
+	elog "Please read https://doc.dovecot.org/installation_guide/upgrading/ for upgrade notes."
 }

--- a/net-mail/dovecot/dovecot-2.3.7.2.ebuild
+++ b/net-mail/dovecot/dovecot-2.3.7.2.ebuild
@@ -287,5 +287,5 @@ pkg_postinst() {
 		install_cert /etc/ssl/dovecot/server
 	fi
 
-	elog "Please read https://wiki2.dovecot.org/Upgrading/ for upgrade notes."
+	elog "Please read https://doc.dovecot.org/installation_guide/upgrading/ for upgrade notes."
 }

--- a/net-mail/dovecot/dovecot-2.3.9.3.ebuild
+++ b/net-mail/dovecot/dovecot-2.3.9.3.ebuild
@@ -282,5 +282,5 @@ pkg_postinst() {
 		install_cert /etc/ssl/dovecot/server
 	fi
 
-	elog "Please read https://wiki2.dovecot.org/Upgrading/ for upgrade notes."
+	elog "Please read https://doc.dovecot.org/installation_guide/upgrading/ for upgrade notes."
 }


### PR DESCRIPTION
Signed-off-by: Jaak Ristioja <jaak@ristioja.ee>

https://wiki2.dovecot.org/Upgrading/ now hosts a page with a note that the information has been moved to https://doc.dovecot.org/installation_guide/upgrading/. This updates the URLs in all the ebuilds.