### PR TITLE
net-misc/youtube-viewer: Add ewarn message about API requirement

### DIFF
--- a/net-misc/youtube-viewer/youtube-viewer-3.7.4-r1.ebuild
+++ b/net-misc/youtube-viewer/youtube-viewer-3.7.4-r1.ebuild
@@ -80,6 +80,10 @@ pkg_postinst() {
 	elog
 	elog "Check the configuration file in ~/.config/youtube-viewer/"
 	elog "and configure your video player backend."
+	elog
+	ewarn "Starting with version 3.7.4, youtube-viewer requires the user to"
+	ewarn "get their own API key to function. Please refer to README.md or"
+	ewarn "https://github.com/trizen/youtube-viewer#logging-in for details!"
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Starting with version 3.7.4, youtube-viewer requires the user
to get their own API key to function.

Package-Manager: Portage-2.3.93, Repoman-2.3.20
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>