### PR TITLE
dev-util/gn: fix install with USE=vim-syntax

### DIFF
--- a/dev-util/gn/gn-0.1726.ebuild
+++ b/dev-util/gn/gn-0.1726.ebuild
@@ -59,6 +59,6 @@ src_install() {
 
 	if use vim-syntax; then
 		insinto /usr/share/vim/vimfiles
-		doins -r tools/gn/misc/vim/{autoload,ftdetect,ftplugin,syntax}
+		doins -r misc/vim/{autoload,ftdetect,ftplugin,syntax}
 	fi
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/712604
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>