### PR TITLE
sci-visualization/paraview: Add missing qtxmlpatterns dependency

### DIFF
--- a/sci-visualization/paraview/paraview-5.8.0-r1.ebuild
+++ b/sci-visualization/paraview/paraview-5.8.0-r1.ebuild
@@ -85,6 +85,7 @@ RDEPEND="
 		dev-qt/qtsql:5
 		dev-qt/qttest:5
 		dev-qt/qtx11extras:5
+		dev-qt/qtxmlpatterns:5
 	)
 	sqlite? ( dev-db/sqlite:3 )
 	tcl? ( dev-lang/tcl:0= )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/712306

Signed-off-by: Simon van der Veldt <simon.vanderveldt@gmail.com>

Does a change like this warrant a revbump?