### PR TITLE
dev-util/bsdiff: Fix CVE-2014-9862

### DIFF
--- a/dev-util/bsdiff/bsdiff-4.3-r4.ebuild
+++ b/dev-util/bsdiff/bsdiff-4.3-r4.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit eutils flag-o-matic toolchain-funcs
+
+DESCRIPTION="bsdiff: Binary Differencer using a suffix alg"
+HOMEPAGE="http://www.daemonology.net/bsdiff/"
+SRC_URI="http://www.daemonology.net/bsdiff/${P}.tar.gz"
+
+SLOT="0"
+LICENSE="BSD-2"
+KEYWORDS="~alpha amd64 ~arm hppa ia64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+
+DEPEND="app-arch/bzip2"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-CVE-2014-9862.patch"
+)
+
+src_compile() {
+	doecho() {
+		echo "$@"
+		"$@"
+	}
+	append-lfs-flags
+	doecho $(tc-getCC) ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o bsdiff bsdiff.c -lbz2 || die "failed compiling bsdiff"
+	doecho $(tc-getCC) ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o bspatch bspatch.c -lbz2 || die "failed compiling bspatch"
+}
+
+src_install() {
+	dobin bs{diff,patch}
+	doman bs{diff,patch}.1
+}

--- a/dev-util/bsdiff/files/bsdiff-4.3-CVE-2014-9862.patch
+++ b/dev-util/bsdiff/files/bsdiff-4.3-CVE-2014-9862.patch
@@ -1,0 +1,15 @@
+diff --git a/bspatch.c b/bspatch.c
+index 8d95633..ab77722 100644
+--- a/bspatch.c
++++ b/bspatch.c
+
+@@ -187,6 +187,10 @@
+ 		};
+ 
+ 		/* Sanity-check */
++		if ((ctrl[0] < 0) || (ctrl[1] < 0))
++			errx(1,"Corrupt patch\n");
++
++		/* Sanity-check */
+ 		if(newpos+ctrl[0]>newsize)
+ 			errx(1,"Corrupt patch\n");


### PR DESCRIPTION
Includes a patch from ChromiumOS.

Bug: https://bugs.gentoo.org/701848
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>