### PR TITLE
net-misc/chrony: Privilege separation support, enable seccomp

### DIFF
--- a/net-misc/chrony/chrony-3.5-r3.ebuild
+++ b/net-misc/chrony/chrony-3.5-r3.ebuild
@@ -2,15 +2,15 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit git-r3 tmpfiles systemd toolchain-funcs
+inherit systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="NTP client and server programs"
 HOMEPAGE="https://chrony.tuxfamily.org/"
-EGIT_REPO_URI="https://git.tuxfamily.org/chrony/chrony.git/"
+SRC_URI="https://download.tuxfamily.org/${PN}/${P/_/-}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 
-KEYWORDS=""
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="
 	+adns caps +cmdmon html ipv6 libedit +ntp +phc pps readline +refclock +rtc
 	seccomp selinux
@@ -28,14 +28,16 @@ CDEPEND="
 DEPEND="
 	${CDEPEND}
 	caps? ( acct-group/ntp acct-user/ntp )
-	dev-ruby/asciidoctor
+	html? ( dev-ruby/asciidoctor )
 	pps? ( net-misc/pps-tools )
 "
 RDEPEND="
 	${CDEPEND}
 	selinux? ( sec-policy/selinux-chronyd )
 "
+
 RESTRICT=test
+
 S="${WORKDIR}/${P/_/-}"
 
 PATCHES=(
@@ -106,7 +108,7 @@ src_configure() {
 }
 
 src_compile() {
-	emake all docs
+	emake all docs $(usex html '' 'ADOC=true')
 }
 
 src_install() {
@@ -123,8 +125,10 @@ src_install() {
 
 	newtmpfiles - chronyd.conf <<<"d /run/chrony 0750 $(usex caps 'ntp ntp' 'root root')"
 
-	docinto html
-	dodoc doc/*.html
+	if use html; then
+		docinto html
+		dodoc doc/*.html
+	fi
 
 	keepdir /var/{lib,log}/chrony
 

--- a/net-misc/chrony/chrony-4.0_pre1-r1.ebuild
+++ b/net-misc/chrony/chrony-4.0_pre1-r1.ebuild
@@ -12,16 +12,18 @@ SLOT="0"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
 IUSE="
-	+adns +caps +cmdmon html ipv6 libedit +ntp +phc pps readline +refclock +rtc
-	+seccomp selinux
+	+adns +caps +cmdmon html ipv6 libedit +nettle +ntp +phc pps readline +refclock +rtc
+	+seccomp +sechash selinux
 "
 REQUIRED_USE="
 	?? ( libedit readline )
+	sechash? ( nettle )
 "
 
 CDEPEND="
 	caps? ( sys-libs/libcap )
 	libedit? ( dev-libs/libedit )
+	nettle? ( dev-libs/nettle )
 	readline? ( >=sys-libs/readline-4.1-r4:= )
 	seccomp? ( sys-libs/libseccomp )
 "
@@ -91,15 +93,16 @@ src_configure() {
 		$(usex caps '' --disable-linuxcaps)
 		$(usex cmdmon '' --disable-cmdmon)
 		$(usex ipv6 '' --disable-ipv6)
+		$(usex nettle '' --without-nettle)
 		$(usex ntp '' --disable-ntp)
 		$(usex phc '' --disable-phc)
 		$(usex pps '' --disable-pps)
 		$(usex refclock '' --disable-refclock)
 		$(usex rtc '' --disable-rtc)
+		$(usex sechash '' --disable-sechash)
 		${CHRONY_EDITLINE}
 		${EXTRA_ECONF}
 		--chronysockdir="${EPREFIX}/run/chrony"
-		--disable-sechash
 		--docdir="${EPREFIX}/usr/share/doc/${PF}"
 		--mandir="${EPREFIX}/usr/share/man"
 		--prefix="${EPREFIX}/usr"

--- a/net-misc/chrony/files/chrony-3.5-r3-systemd-gentoo.patch
+++ b/net-misc/chrony/files/chrony-3.5-r3-systemd-gentoo.patch
@@ -1,0 +1,12 @@
+--- a/examples/chronyd.service
++++ b/examples/chronyd.service
+@@ -8,8 +8,7 @@
+ [Service]
+ Type=forking
+ PIDFile=/run/chrony/chronyd.pid
+-EnvironmentFile=-/etc/sysconfig/chronyd
+-ExecStart=/usr/sbin/chronyd $OPTIONS
++ExecStart=/usr/sbin/chronyd -u ntp -F 1
+ PrivateTmp=yes
+ ProtectHome=yes
+ ProtectSystem=full

--- a/net-misc/chrony/files/chronyd.conf
+++ b/net-misc/chrony/files/chronyd.conf
@@ -9,4 +9,4 @@ CFGFILE="/etc/chrony/chrony.conf"
 # The combination of "-s -r" allows chronyd to perform long term averaging of
 # the gain or loss rate across system reboots and shutdowns.
 
-ARGS="-u ntp"
+ARGS="-u ntp -F 1"

--- a/net-misc/chrony/files/chronyd.conf
+++ b/net-misc/chrony/files/chronyd.conf
@@ -9,4 +9,4 @@ CFGFILE="/etc/chrony/chrony.conf"
 # The combination of "-s -r" allows chronyd to perform long term averaging of
 # the gain or loss rate across system reboots and shutdowns.
 
-ARGS=""
+ARGS="-u ntp"


### PR DESCRIPTION
- When caps is enabled, drop to the user ntp (acct-user/ntp), as opposed to remaining root.
   (Adds a tmpfile.d entry for /run/chrony to ensure correct permissions.)

- We already have USE=seccomp but chronyd won't do anything unless -F is set to 1. We could also set -F -1 which will log any syscalls which would've been blocked but won't deny them.

Closes: https://bugs.gentoo.org/711058
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>