### PR TITLE
net-misc/dahdi-tools: add gcc -fno-common patch.

### DIFF
--- a/net-misc/dahdi-tools/dahdi-tools-3.1.0.ebuild
+++ b/net-misc/dahdi-tools/dahdi-tools-3.1.0.ebuild
@@ -16,6 +16,7 @@ IUSE="ppp"
 PATCHES=(
 	"${FILESDIR}/dahdi-nondigium-blacklist.patch"
 	"${FILESDIR}/dahdi-tools-3.1.0-parallel-make-no-config.patch"
+	"${FILESDIR}/dahdi-tools-3.1.0-fno-common.patch"
 )
 
 DEPEND="dev-libs/newt

--- a/net-misc/dahdi-tools/files/dahdi-tools-3.1.0-fno-common.patch
+++ b/net-misc/dahdi-tools/files/dahdi-tools-3.1.0-fno-common.patch
@@ -1,0 +1,39 @@
+diff --git a/xpp/mpptalk.c b/xpp/mpptalk.c
+index fdb34f1..8fb3687 100644
+--- a/xpp/mpptalk.c
++++ b/xpp/mpptalk.c
+@@ -237,7 +237,7 @@ union XTALK_PDATA(MPP) {
+ 		MEMBER(MPP, TWS_PORT_GET_REPLY);
+ 		MEMBER(MPP, TWS_PWR_GET);
+ 		MEMBER(MPP, TWS_PWR_GET_REPLY);
+-} PACKED members;
++} PACKED;
+ 
+ /*
+  * Statuses
+diff --git a/xpp/xtalk/xtalk_raw.c b/xpp/xtalk/xtalk_raw.c
+index 49e47d5..251a502 100644
+--- a/xpp/xtalk/xtalk_raw.c
++++ b/xpp/xtalk/xtalk_raw.c
+@@ -48,7 +48,7 @@ CMD_DEF(XTALK, ACK,
+ 
+ union XTALK_PDATA(XTALK) {
+ 	MEMBER(XTALK, ACK);
+-} PACKED members;
++} PACKED;
+ 
+ const struct xtalk_protocol	xtalk_raw_proto = {
+ 	.name	= "XTALK-RAW",
+diff --git a/xpp/xtalk/xtalk_sync.c b/xpp/xtalk/xtalk_sync.c
+index 18a5cad..ffa79d2 100644
+--- a/xpp/xtalk/xtalk_sync.c
++++ b/xpp/xtalk/xtalk_sync.c
+@@ -60,7 +60,7 @@ union XTALK_PDATA(XTALK) {
+ 	MEMBER(XTALK, ACK);
+ 	MEMBER(XTALK, PROTO_GET);
+ 	MEMBER(XTALK, PROTO_GET_REPLY);
+-} PACKED members;
++} PACKED;
+ 
+ const struct xtalk_protocol	xtalk_sync_proto = {
+ 	.name	= "XTALK-SYNC",


### PR DESCRIPTION
Patch submitted upstream: https://issues.asterisk.org/jira/browse/DAHTOOL-85

Closes: https://bugs.gentoo.org/706832
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jaco Kroon <jaco@uls.co.za>