### PR TITLE
dev-python/anyjson: EAPI and python bump

### DIFF
--- a/dev-python/anyjson/anyjson-0.3.3-r2.ebuild
+++ b/dev-python/anyjson/anyjson-0.3.3-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+PYTHON_COMPAT=( python3_{6,7} )
+
+inherit distutils-r1
+
+DESCRIPTION="Wraps the best available JSON implementation available in a common interface"
+HOMEPAGE="https://bitbucket.org/runeh/anyjson"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+# please keep all supported implementations in 'test?'
+# to make sure the package is used in the widest way
+DEPEND="${RDEPEND}
+	test? (
+		dev-python/nose[${PYTHON_USEDEP}]
+	)"
+
+python_test() {
+	cp -r -l tests "${BUILD_DIR}" || die
+	if [[ ${EPYTHON} == python3* ]]; then
+		2to3 -w --no-diffs "${BUILD_DIR}/tests" || die
+	fi
+
+	nosetests -w "${BUILD_DIR}/tests" || die "Tests fail with ${EPYTHON}"
+}


### PR DESCRIPTION
tests are working

Package-Manager: Portage-2.3.94, Repoman-2.3.20
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>