### PR TITLE
signal-desktop-bin-1.32.1: add info about tray icon on Xfce

### DIFF
--- a/net-im/signal-desktop-bin/signal-desktop-bin-1.32.1.ebuild
+++ b/net-im/signal-desktop-bin/signal-desktop-bin-1.32.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 MY_PN="${PN/-bin/}"
 
-inherit pax-utils unpacker xdg-utils
+inherit eutils pax-utils unpacker xdg-utils
 
 DESCRIPTION="Allows you to send and receive messages of Signal Messenger on your computer"
 HOMEPAGE="https://signal.org/
@@ -71,6 +71,8 @@ src_install() {
 pkg_postinst() {
 	xdg_desktop_database_update
 	xdg_icon_cache_update
+
+	optfeature "using the tray icon in Xfce desktop environments" xfce-extra/xfce4-statusnotifier-plugin
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/712006