### PR TITLE
net-im/psi: add net-libs/http-parser dependency

### DIFF
--- a/net-im/psi/psi-9999.ebuild
+++ b/net-im/psi/psi-9999.ebuild
@@ -47,6 +47,7 @@ DEPEND="
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
 	net-dns/libidn:0
+	net-libs/http-parser:=
 	sys-libs/zlib[minizip]
 	x11-libs/libX11
 	x11-libs/libxcb


### PR DESCRIPTION
Psi now uses system http-parser if found.