### PR TITLE
net-misc/bird: Adding libssh support (mendatory for RPKI)

### DIFF
--- a/net-misc/bird/bird-2.0.7.ebuild
+++ b/net-misc/bird/bird-2.0.7.ebuild
@@ -1,28 +1,34 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="A routing daemon implementing OSPF, RIPv2 & BGP for IPv4 & IPv6"
-HOMEPAGE="http://bird.network.cz"
+HOMEPAGE="https://bird.network.cz"
 SRC_URI="ftp://bird.network.cz/pub/${PN}/${P}.tar.gz"
 LICENSE="GPL-2"
 
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86 ~x64-macos"
-IUSE="+client debug"
+IUSE="+client debug libssh"
 
-RDEPEND="client? ( sys-libs/ncurses )
-	client? ( sys-libs/readline )"
-DEPEND="sys-devel/flex
+RDEPEND="client? ( sys-libs/ncurses:= )
+	client? ( sys-libs/readline:= )
+	libssh? ( net-libs/libssh:= )"
+BDEPEND="sys-devel/flex
 	sys-devel/bison
 	sys-devel/m4"
+
+PATCHES=(
+	"${FILESDIR}/${P}-ipv6-rpki.patch"
+)
 
 src_configure() {
 	econf \
 		--localstatedir="${EPREFIX}/var" \
 		$(use_enable client) \
-		$(use_enable debug)
+		$(use_enable debug) \
+		$(use_enable libssh)
 }
 
 src_install() {

--- a/net-misc/bird/files/bird-2.0.7-ipv6-rpki.patch
+++ b/net-misc/bird/files/bird-2.0.7-ipv6-rpki.patch
@@ -1,0 +1,32 @@
+diff --git a/proto/rpki/transport.c b/proto/rpki/transport.c
+index 182667be..9dcb7c5c 100644
+Patch needed for IPv6 FQDN RPKI caches, see ML archive and upstream git URL
+https://bird.network.cz/pipermail/bird-users/2020-January/014162.html
+https://gitlab.nic.cz/labs/bird/-/commit/4e23b499696da81acf0ed5ad181573b94ccdb9a3
+--- a/proto/rpki/transport.c
++++ b/proto/rpki/transport.c
+@@ -26,7 +26,6 @@
+ static ip_addr
+ rpki_hostname_autoresolv(const char *host)
+ {
+-  ip_addr addr = {};
+   struct addrinfo *res;
+   struct addrinfo hints = {
+       .ai_family = AF_UNSPEC,
+@@ -44,12 +43,10 @@ rpki_hostname_autoresolv(const char *host)
+     return IPA_NONE;
+   }
+ 
+-  sockaddr sa = {
+-      .sa = *res->ai_addr,
+-  };
+-
++  ip_addr addr = IPA_NONE;
+   uint unused;
+-  sockaddr_read(&sa, res->ai_family, &addr, NULL, &unused);
++
++  sockaddr_read((sockaddr *) res->ai_addr, res->ai_family, &addr, NULL, &unused);
+ 
+   freeaddrinfo(res);
+   return addr;
+

--- a/net-misc/bird/files/initd-bird-2
+++ b/net-misc/bird/files/initd-bird-2
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Copyright 2019 Alarig Le Lay <alarig@grifon.fr>
 # Distributed under the terms of the GNU General Public License v2
 

--- a/net-misc/bird/metadata.xml
+++ b/net-misc/bird/metadata.xml
@@ -7,5 +7,9 @@
 	</maintainer>
 	<use>
 		<flag name="client">Build the ncurses/readline full featured CLI</flag>
+		<flag name="libssh">
+			Enables <pkg>net-libs/libssh</pkg> binding, mendatory for RPKI
+			support
+		</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/711114
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Alarig Le Lay <alarig@swordarmor.fr>