### PR TITLE
x11-terms/kitty-terminfo: remove unnecessary dependency

### DIFF
--- a/x11-terms/kitty-terminfo/kitty-terminfo-0.16.0.ebuild
+++ b/x11-terms/kitty-terminfo/kitty-terminfo-0.16.0.ebuild
@@ -23,8 +23,6 @@ RDEPEND="${PYTHON_DEPS}"
 
 DEPEND="${RDEPEND}"
 
-BDEPEND="virtual/pkgconfig"
-
 PATCHES=(
 	"${FILESDIR}"/kitty-terminfo-setup.patch
 )


### PR DESCRIPTION
Remove dependency on `virtual/pkgconfig` since it is not being used.

Signed-off-by: Pablo Orduna <pabloorduna98@gmail.com>