### PR TITLE
net-analyzer/ossec-hids: Fix dependency

### DIFF
--- a/net-analyzer/ossec-hids/ossec-hids-3.6.0.ebuild
+++ b/net-analyzer/ossec-hids/ossec-hids-3.6.0.ebuild
@@ -18,6 +18,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="acct-user/ossec
 	acct-user/ossecm
 	acct-user/ossecr
+	dev-libs/libevent
 	dev-libs/libpcre2
 	mysql? ( virtual/mysql )
 	postgres? ( dev-db/postgresql:= )


### PR DESCRIPTION
Ebuild was missing dependency entry for **dev-libs/libevent**.