### PR TITLE
x11-misc/sddm: Create /var/lib/sddm dir

### DIFF
--- a/x11-misc/sddm/sddm-0.18.1-r1.ebuild
+++ b/x11-misc/sddm/sddm-0.18.1-r1.ebuild
@@ -94,6 +94,8 @@ src_install() {
 		-e "/^ReuseSession/s/false/true/" \
 		-e "/^EnableHiDPI/s/false/true/" \
 		-i "${D}/${confd}"/00default.conf || die
+
+	keepdir "/var/lib/${PN}"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
I've upgraded the package recently and when rebooting my machine
I've seen nothing but a black screen and cursor. All the symptoms
like [1]. In the /var/log/sddm.log there was this hint:

[06:53:33.338] (EE) HELPER: chdir( /var/lib/sddm ) failed for user:  "sddm"
[06:53:33.338] (EE) HELPER: verify directory exist and has sufficient permissions

And indeed, if I create the directory then sddm starts working
again. In fact, Fedora's RPMs are creating an empty directory
too.

1: https://bugs.gentoo.org/584960
Signed-off-by: Michal Privoznik <mprivozn@redhat.com>