### PR TITLE
net-firewall/firewalld: fix ipset location

### DIFF
--- a/net-firewall/firewalld/firewalld-0.7.3-r1.ebuild
+++ b/net-firewall/firewalld/firewalld-0.7.3-r1.ebuild
@@ -76,7 +76,7 @@ src_configure() {
 		$(use_with iptables ip6tables_restore "${EPREFIX}/sbin/ip6tables-restore")
 		$(use_with iptables ebtables "${EPREFIX}/sbin/ebtables")
 		$(use_with iptables ebtables_restore "${EPREFIX}/sbin/ebtables-restore")
-		$(use_with iptables ipset "${EPREFIX}/sbin/ipset")
+		$(use_with iptables ipset "${EPREFIX}/usr/sbin/ipset")
 		--with-systemd-unitdir="$(systemd_get_systemunitdir)"
 		--with-bashcompletiondir="$(get_bashcompdir)"
 	)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/713658
See-Also: https://github.com/firewalld/firewalld/issues/591
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Yuri Konotopov <ykonotopov@gnome.org>