### PR TITLE
app-text/robodoc: revision to build against musl

### DIFF
--- a/app-text/robodoc/files/robodoc-4.99.43_clean_libc.patch
+++ b/app-text/robodoc/files/robodoc-4.99.43_clean_libc.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/troff_generator.c b/Source/troff_generator.c
+index 1b123b8..94ddcda 100644
+--- a/Source/troff_generator.c
++++ b/Source/troff_generator.c
+@@ -30,7 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include <ctype.h>
+ 
+ #include <sys/param.h>
+-#include <sys/unistd.h>
++#include <unistd.h>
+ 
+ #include "troff_generator.h"
+ #include "util.h"

--- a/app-text/robodoc/metadata.xml
+++ b/app-text/robodoc/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>4z0r@ovidiu.at</email>
+		<email>ovi@ovidiu.at</email>
 		<name>Ovidiu - Dan Bogat</name>
 	</maintainer>
 	<maintainer type="project">

--- a/app-text/robodoc/robodoc-4.99.43-r1.ebuild
+++ b/app-text/robodoc/robodoc-4.99.43-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Automating Software Documentation"
+HOMEPAGE="https://www.xs4all.nl/~rfsber/Robo/robodoc.html"
+SRC_URI="https://rfsber.home.xs4all.nl/Robo/archives/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="examples"
+
+PATCHES=(
+	"${FILESDIR}/${P}_clean_libc.patch"
+	)
+
+RDEPEND=">=dev-util/ctags-5.3.1"
+DEPEND="${RDEPEND}"
+
+src_install() {
+	default
+
+	insinto /usr/share/${PN}
+	doins Contributions/*
+
+	if use examples; then
+		insinto /usr/share/${PN}
+		doins -r Examples/PerlExample
+	fi
+}


### PR DESCRIPTION
Reported-by: Toralf Foerster <toralf@gentoo.org>
Closes: https://bugs.gentoo.org/713616
Signed-off-by: Ovidiu-Dan Bogat <ovi@ovidiu.at>
Package-Manager: Portage-2.3.89, Repoman-2.3.20