### PR TITLE
sys-apps/apparmor: add Make.rules patch

### DIFF
--- a/sys-apps/apparmor/apparmor-2.13.4-r1.ebuild
+++ b/sys-apps/apparmor/apparmor-2.13.4-r1.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit systemd toolchain-funcs
+
+MY_PV="$(ver_cut 1-2)"
+
+DESCRIPTION="Userspace utils and init scripts for the AppArmor application security system"
+HOMEPAGE="https://gitlab.com/apparmor/apparmor/wikis/home"
+SRC_URI="https://launchpad.net/${PN}/${MY_PV}/${PV}/+download/${PN}-${PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="doc"
+
+RESTRICT="test" # bug 675854
+
+RDEPEND="~sys-libs/libapparmor-${PV}"
+DEPEND="${RDEPEND}
+	dev-lang/perl
+	sys-devel/bison
+	sys-devel/gettext
+	sys-devel/flex
+	doc? ( dev-tex/latex2html )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.13.4-rules.patch"
+)
+
+src_prepare() {
+	default
+
+	pushd parser > /dev/null
+
+	eapply "${FILESDIR}/${PN}-2.13.1-makefile.patch"
+	eapply "${FILESDIR}/${PN}-2.11.1-dynamic-link.patch"
+
+	# remove warning about missing file that controls features
+	# we don't currently support
+	sed -e "/installation problem/ctrue" -i rc.apparmor.functions || die
+
+	popd
+}
+
+src_compile() {
+	emake -C parser CC="$(tc-getCC)" CXX="$(tc-getCXX)" USE_SYSTEM=1 arch manpages
+	use doc && emake pdf
+}
+
+src_test() {
+	emake -C parser CXX="$(tc-getCXX)" USE_SYSTEM=1 check
+}
+
+src_install() {
+	emake -C parser DESTDIR="${D}" DISTRO="unknown" USE_SYSTEM=1 install
+
+	dodir /etc/apparmor.d/disable
+
+	newinitd "${FILESDIR}/${PN}-init" ${PN}
+	systemd_newunit "${FILESDIR}/apparmor.service" apparmor.service
+
+	use doc && dodoc techdoc.pdf
+
+	exeinto /usr/share/apparmor
+	doexe "${FILESDIR}/apparmor_load.sh"
+	doexe "${FILESDIR}/apparmor_unload.sh"
+}

--- a/sys-apps/apparmor/files/apparmor-2.13.4-rules.patch
+++ b/sys-apps/apparmor/files/apparmor-2.13.4-rules.patch
@@ -1,0 +1,22 @@
+diff --git a/common/Make.rules b/common/Make.rules
+index d2149fc..efb1f38 100644
+--- a/common/Make.rules
++++ b/common/Make.rules
+@@ -81,7 +81,7 @@ pod_clean:
+ # =====================
+ 
+ # emits defined capabilities in a simple list, e.g. "CAP_NAME CAP_NAME2"
+-CAPABILITIES=$(shell echo "\#include <linux/capability.h>" | cpp -dM | LC_ALL=C sed -n -e '/CAP_EMPTY_SET/d' -e 's/^\#define[ \t]\+CAP_\([A-Z0-9_]\+\)[ \t]\+\([0-9xa-f]\+\)\(.*\)$$/CAP_\1/p' | LC_ALL=C sort)
++CAPABILITIES=$(shell echo "#include <linux/capability.h>" | cpp -dM | LC_ALL=C sed -n -e '/CAP_EMPTY_SET/d' -e 's/^#define[ \t]\+CAP_\([A-Z0-9_]\+\)[ \t]\+\([0-9xa-f]\+\)\(.*\)$$/CAP_\1/p' | LC_ALL=C sort)
+ 
+ .PHONY: list_capabilities
+ list_capabilities: /usr/include/linux/capability.h
+@@ -102,7 +102,7 @@ FILTER_FAMILIES=PF_UNIX
+ __FILTER=$(shell echo $(strip $(FILTER_FAMILIES)) | sed -e 's/ /\\\|/g')
+ 
+ # emits the AF names in a "AF_NAME NUMBER," pattern
+-AF_NAMES=$(shell echo "\#include <sys/socket.h>" | cpp -dM | LC_ALL=C sed -n -e '/$(__FILTER)/d' -e 's/PF_LOCAL/PF_UNIX/' -e 's/^\#define[ \t]\+PF_\([A-Z0-9_]\+\)[ \t]\+\([0-9]\+\).*$$/AF_\1 \2,/p' | sort -n -k2)
++AF_NAMES=$(shell echo "#include <sys/socket.h>" | cpp -dM | LC_ALL=C sed -n -e '/$(__FILTER)/d' -e 's/PF_LOCAL/PF_UNIX/' -e 's/^#define[ \t]\+PF_\([A-Z0-9_]\+\)[ \t]\+\([0-9]\+\).*$$/AF_\1 \2,/p' | sort -n -k2)
+ 
+ .PHONY: list_af_names
+ list_af_names:


### PR DESCRIPTION
Prevent AppArmor parser errors
@kensington @mgorny Hi. Please review this PR.
I had some problems after update:
https://i.imgur.com/NlZkZ3T.png

Additional info:
https://bugs.archlinux.org/task/65847
https://gitlab.com/apparmor/apparmor/issues/74
https://gitlab.com/apparmor/apparmor/uploads/7823a72985e91c46f611cddee7ef4972/rules.patch