### PR TITLE
net-misc/asterisk-core-sounds: Don't force install gsm.

### DIFF
--- a/net-misc/asterisk-core-sounds/asterisk-core-sounds-1.6.1-r1.ebuild
+++ b/net-misc/asterisk-core-sounds/asterisk-core-sounds-1.6.1-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+DESCRIPTION="Core sounds for asterisk"
+HOMEPAGE="https://www.asterisk.org/"
+MY_L10N="^en en_AU en_GB es fr it ja ru sv" # ^ is used to indicate to the loops below to NOT set this as an optional
+CODECS="alaw g722 g729 +gsm siren7 siren14 sln16 ulaw wav"
+
+SRC_URI=""
+IUSE="${CODECS}"
+for l in ${MY_L10N}; do
+	[[ "${l}" != ^* ]] && IUSE+=" l10n_${l//_/-}" && SRC_URI+=" l10n_${l//_/-}? ("
+	for c in ${CODECS}; do
+		SRC_URI+=" ${c#+}? ( https://downloads.asterisk.org/pub/telephony/sounds/releases/${PN}-${l#^}-${c#+}-${PV}.tar.gz )"
+	done
+	[[ "${l}" = ^* ]] || SRC_URI+=" )"
+done
+
+REQUIRED_USE="|| ( ${CODECS//+/} )"
+
+LICENSE="CC-BY-SA-3.0"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+S="${WORKDIR}"
+
+RDEPEND="!<net-misc/asterisk-extra-sounds-1.5.2"
+
+src_unpack() {
+	local ar
+	local c
+
+	for ar in ${A}; do
+		l="${ar#${PN}-}"
+		l=${l%%-*}
+		c="${ar#${PN}-*-}"
+		c=${c%%-*}
+		ebegin "Unpacking ${c} audio files for \"${l}\""
+			[ -d "${WORKDIR}/${l}" ] || mkdir "${WORKDIR}/${l}" || die "Error creating unpack directory"
+			tar xf "${DISTDIR}/${ar}" -C "${WORKDIR}/${l}" || die "Error unpacking ${ar}"
+		eend $?
+	done
+}
+
+src_install() {
+	local l
+	local pf
+	for l in ${MY_L10N}; do
+		if [[ "${l}" = ^* ]] || use l10n_${l//_/-}; then
+			l="${l#^}"
+			dodoc ${l}/${PN#asterisk-}-${l}.txt
+			rm ${l}/${PN#asterisk-}-${l}.txt
+			for pf in CHANGES CREDITS LICENSE; do
+				dodoc ${l}/${pf}-${PN%-sounds}-${l}-${PV}
+				rm ${l}/${pf}-${PN%-sounds}-${l}-${PV}
+			done
+		fi
+	done
+
+	diropts -m 0755 -o root -g root
+	insopts -m 0644 -o root -g root
+
+	ebegin "Installing audio files"
+		insinto /var/lib/asterisk/sounds
+		doins -r .
+	eend $?
+}


### PR DESCRIPTION
This clones the REQUIRED_USE mechanism from asterisk-extra-sounds in
order to provide the user with more flexibility.

Version bump due to alteration of USE flags.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jaco Kroon <jaco@uls.co.za>