### PR TITLE
media-video/aegisub: patch Makefile to work with make-4.3

### DIFF
--- a/media-video/aegisub/aegisub-3.2.2_p20160518-r4.ebuild
+++ b/media-video/aegisub/aegisub-3.2.2_p20160518-r4.ebuild
@@ -1,0 +1,150 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+WX_GTK_VER=3.0
+PLOCALES="ar bg ca cs da de el es eu fa fi fr_FR gl hu id it ja ko nl pl pt_BR pt_PT ru sr_RS sr_RS@latin uk_UA vi zh_CN zh_TW"
+COMMIT_ID="b118fe7e7a5c37540e2f0aa75af105e272bad234"
+
+inherit autotools flag-o-matic gnome2-utils l10n wxwidgets xdg-utils vcs-snapshot
+
+DESCRIPTION="Advanced subtitle editor"
+HOMEPAGE="http://www.aegisub.org/ https://github.com/Aegisub/Aegisub"
+SRC_URI="https://github.com/Aegisub/Aegisub/archive/${COMMIT_ID}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+alsa debug +fftw openal oss portaudio pulseaudio spell test +uchardet"
+RESTRICT="!test? ( test )"
+
+# aegisub bundles luabins (https://github.com/agladysh/luabins).
+# Unfortunately, luabins upstream is practically dead since 2010.
+# Thus unbundling luabins isn't worth the effort.
+RDEPEND="
+	x11-libs/wxGTK:${WX_GTK_VER}[X,opengl,debug?]
+	dev-lang/luajit:2[lua52compat]
+	dev-libs/boost:=[icu,nls,threads]
+	dev-libs/icu:=
+	media-libs/ffmpegsource:=
+	media-libs/fontconfig
+	media-libs/freetype
+	media-libs/libass:=[fontconfig]
+	sys-libs/zlib
+	virtual/libiconv
+	virtual/opengl
+	alsa? ( media-libs/alsa-lib )
+	fftw? ( >=sci-libs/fftw-3.3:= )
+	openal? ( media-libs/openal )
+	portaudio? ( =media-libs/portaudio-19* )
+	pulseaudio? ( media-sound/pulseaudio )
+	spell? ( app-text/hunspell:= )
+	uchardet? ( app-i18n/uchardet )
+"
+DEPEND="${RDEPEND}
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig
+	test? (
+		>=dev-cpp/gtest-1.8.1
+		dev-lua/busted
+		dev-lua/luarocks
+	)
+"
+
+REQUIRED_USE="|| ( alsa openal oss portaudio pulseaudio )"
+
+PATCHES=(
+	"${FILESDIR}/${PV}/${P}-fix-system-luajit-build.patch"
+	"${FILESDIR}/${PV}/${P}-respect-compiler-flags.patch"
+	"${FILESDIR}/${PV}/${P}-support-system-gtest.patch"
+	"${FILESDIR}/${PV}/${P}-fix-icu59-build.patch"
+	"${FILESDIR}/${PV}/${P}-fix-icu62-build.patch"
+	"${FILESDIR}/${PV}/${P}-fix-boost170-build.patch"
+	"${FILESDIR}/${PV}/${P}-fix-makefile-for-make4.3.patch"
+)
+
+aegisub_check_compiler() {
+	if [[ ${MERGE_TYPE} != "binary" ]] && ! test-flag-CXX -std=c++11; then
+		die "Your compiler lacks C++11 support. Use GCC>=4.7.0 or Clang>=3.3."
+	fi
+}
+
+pkg_pretend() {
+	aegisub_check_compiler
+}
+
+pkg_setup() {
+	aegisub_check_compiler
+}
+
+src_prepare() {
+	default_src_prepare
+
+	# Remove tests that require unavailable uuid Lua module.
+	rm automation/tests/modules/lfs.moon || die
+
+	remove_locale() {
+		rm "po/${1}.po" || die
+	}
+
+	l10n_find_plocales_changes 'po' '' '.po'
+	l10n_for_each_disabled_locale_do remove_locale
+
+	# See http://devel.aegisub.org/ticket/1914
+	config_rpath_update "${S}"/config.rpath
+
+	eautoreconf
+
+	cat <<- EOF > build/git_version.h || die
+		#define BUILD_GIT_VERSION_NUMBER 8897
+		#define BUILD_GIT_VERSION_STRING "${PV}"
+		#define TAGGED_RELEASE 0
+	EOF
+}
+
+src_configure() {
+	# Prevent access violations from OpenAL detection. See Gentoo bug 508184.
+	use openal && export agi_cv_with_openal="yes"
+
+	setup-wxwidgets
+	local myeconfargs=(
+		--disable-update-checker
+		--with-ffms2
+		--with-system-luajit
+		$(use_enable debug)
+		$(use_with alsa)
+		$(use_with fftw fftw3)
+		$(use_with openal)
+		$(use_with oss)
+		$(use_with portaudio)
+		$(use_with pulseaudio libpulse)
+		$(use_with spell hunspell)
+		$(use_with uchardet)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	emake WITH_SYSTEM_GTEST=$(usex test)
+}
+
+src_test() {
+	emake test-automation
+	emake test-libaegisub
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	xdg_desktop_database_update
+}

--- a/media-video/aegisub/files/3.2.2_p20160518/aegisub-3.2.2_p20160518-fix-makefile-for-make4.3.patch
+++ b/media-video/aegisub/files/3.2.2_p20160518/aegisub-3.2.2_p20160518-fix-makefile-for-make4.3.patch
@@ -1,0 +1,21 @@
+commit f4cc905c69ca69c68cb95674cefce4abc37ce046
+Author: wangqr <wangqr@wangqr.tk>
+Date:   Mon Feb 17 14:42:07 2020 +0800
+
+    Use target name without directory in $*_OBJ macro
+    
+    Fix Aegisub/Aegisub#171
+
+diff --git a/Makefile.target b/Makefile.target
+index 516ef3c24..5c4c5d259 100644
+--- a/Makefile.target
++++ b/Makefile.target
+@@ -112,7 +112,7 @@ POST_FLAGS = $($@_FLAGS) -c -o $@ $<
+ # Libraries contain all object files they depend on (but they may depend on other files)
+ # Not using libtool on OS X because it has an unsilenceable warning about a
+ # compatibility issue with BSD 4.3 (wtf)
+-lib%.a: $$($$*_OBJ)
++lib%.a: $$($$(*F)_OBJ)
+ 	@$(BIN_MKDIR_P) $(dir $@)
+ 	$(BIN_AR) cru $@ $(filter %.o,$^)
+ 	$(BIN_RANLIB) $@


### PR DESCRIPTION
upstream pull reqeust: https://github.com/Aegisub/Aegisub/pull/174

Package-Manager: Portage-2.3.94, Repoman-2.3.21
Bug: https://bugs.gentoo.org/713120
X-Thanks: Petr Zima <zima@matfyz.cz>
Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>