### PR TITLE
media-libs/openjpeg: Patch CVEs in SLOT:2

### DIFF
--- a/media-libs/openjpeg/files/openjpeg-2.3.1-CVE-2020-6851.patch
+++ b/media-libs/openjpeg/files/openjpeg-2.3.1-CVE-2020-6851.patch
@@ -1,0 +1,29 @@
+From 024b8407392cb0b82b04b58ed256094ed5799e04 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 11 Jan 2020 01:51:19 +0100
+Subject: [PATCH] opj_j2k_update_image_dimensions(): reject images whose
+ coordinates are beyond INT_MAX (fixes #1228)
+
+---
+ src/lib/openjp2/j2k.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/lib/openjp2/j2k.c b/src/lib/openjp2/j2k.c
+index 14f6ff41a..922550eb1 100644
+--- a/src/lib/openjp2/j2k.c
++++ b/src/lib/openjp2/j2k.c
+@@ -9221,6 +9221,14 @@ static OPJ_BOOL opj_j2k_update_image_dimensions(opj_image_t* p_image,
+     l_img_comp = p_image->comps;
+     for (it_comp = 0; it_comp < p_image->numcomps; ++it_comp) {
+         OPJ_INT32 l_h, l_w;
++        if (p_image->x0 > (OPJ_UINT32)INT_MAX ||
++                p_image->y0 > (OPJ_UINT32)INT_MAX ||
++                p_image->x1 > (OPJ_UINT32)INT_MAX ||
++                p_image->y1 > (OPJ_UINT32)INT_MAX) {
++            opj_event_msg(p_manager, EVT_ERROR,
++                          "Image coordinates above INT_MAX are not supported\n");
++            return OPJ_FALSE;
++        }
+ 
+         l_img_comp->x0 = (OPJ_UINT32)opj_int_ceildiv((OPJ_INT32)p_image->x0,
+                          (OPJ_INT32)l_img_comp->dx);

--- a/media-libs/openjpeg/files/openjpeg-2.3.1-CVE-2020-8112.patch
+++ b/media-libs/openjpeg/files/openjpeg-2.3.1-CVE-2020-8112.patch
@@ -1,0 +1,43 @@
+From 05f9b91e60debda0e83977e5e63b2e66486f7074 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Thu, 30 Jan 2020 00:59:57 +0100
+Subject: [PATCH] opj_tcd_init_tile(): avoid integer overflow
+
+That could lead to later assertion failures.
+
+Fixes #1231 / CVE-2020-8112
+---
+ src/lib/openjp2/tcd.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/openjp2/tcd.c b/src/lib/openjp2/tcd.c
+index deecc4dff..aa419030a 100644
+--- a/src/lib/openjp2/tcd.c
++++ b/src/lib/openjp2/tcd.c
+@@ -905,8 +905,24 @@ static INLINE OPJ_BOOL opj_tcd_init_tile(opj_tcd_t *p_tcd, OPJ_UINT32 p_tile_no,
+             /* p. 64, B.6, ISO/IEC FDIS15444-1 : 2000 (18 august 2000)  */
+             l_tl_prc_x_start = opj_int_floordivpow2(l_res->x0, (OPJ_INT32)l_pdx) << l_pdx;
+             l_tl_prc_y_start = opj_int_floordivpow2(l_res->y0, (OPJ_INT32)l_pdy) << l_pdy;
+-            l_br_prc_x_end = opj_int_ceildivpow2(l_res->x1, (OPJ_INT32)l_pdx) << l_pdx;
+-            l_br_prc_y_end = opj_int_ceildivpow2(l_res->y1, (OPJ_INT32)l_pdy) << l_pdy;
++            {
++                OPJ_UINT32 tmp = ((OPJ_UINT32)opj_int_ceildivpow2(l_res->x1,
++                                  (OPJ_INT32)l_pdx)) << l_pdx;
++                if (tmp > (OPJ_UINT32)INT_MAX) {
++                    opj_event_msg(manager, EVT_ERROR, "Integer overflow\n");
++                    return OPJ_FALSE;
++                }
++                l_br_prc_x_end = (OPJ_INT32)tmp;
++            }
++            {
++                OPJ_UINT32 tmp = ((OPJ_UINT32)opj_int_ceildivpow2(l_res->y1,
++                                  (OPJ_INT32)l_pdy)) << l_pdy;
++                if (tmp > (OPJ_UINT32)INT_MAX) {
++                    opj_event_msg(manager, EVT_ERROR, "Integer overflow\n");
++                    return OPJ_FALSE;
++                }
++                l_br_prc_y_end = (OPJ_INT32)tmp;
++            }
+             /*fprintf(stderr, "\t\t\tprc_x_start=%d, prc_y_start=%d, br_prc_x_end=%d, br_prc_y_end=%d \n", l_tl_prc_x_start, l_tl_prc_y_start, l_br_prc_x_end ,l_br_prc_y_end );*/
+ 
+             l_res->pw = (l_res->x0 == l_res->x1) ? 0U : (OPJ_UINT32)((

--- a/media-libs/openjpeg/openjpeg-2.3.1-r1.ebuild
+++ b/media-libs/openjpeg/openjpeg-2.3.1-r1.ebuild
@@ -1,0 +1,135 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS=cmake
+inherit cmake-multilib
+
+# Make sure that test data are not newer than release;
+# otherwise we will see "Found-But-No-Test" test failures!
+MY_TESTDATA_COMMIT="25632d6deca2e567d30ef476b4abe63916c36f6e"
+
+DESCRIPTION="Open-source JPEG 2000 library"
+HOMEPAGE="https://www.openjpeg.org"
+SRC_URI="https://github.com/uclouvain/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
+	test? ( https://github.com/uclouvain/openjpeg-data/archive/${MY_TESTDATA_COMMIT}.tar.gz -> ${PN}-data_20180620.tar.gz )"
+
+LICENSE="BSD-2"
+SLOT="2/7" # based on SONAME
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc static-libs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	media-libs/lcms:2
+	media-libs/libpng:0=
+	media-libs/tiff:0
+	sys-libs/zlib:="
+DEPEND="${RDEPEND}"
+BDEPEND="
+	doc? ( app-doc/doxygen )"
+
+DOCS=( AUTHORS.md CHANGELOG.md NEWS.md README.md THANKS.md )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.3.1-gnuinstalldirs.patch" # bug 667150
+	"${FILESDIR}/${PN}-2.3.1-CVE-2020-6851.patch"
+	"${FILESDIR}/${PN}-2.3.1-CVE-2020-8112.patch"
+)
+
+src_prepare() {
+	if use test; then
+		mv "${WORKDIR}"/openjpeg-data-${MY_TESTDATA_COMMIT} "${WORKDIR}"/data ||
+			die "Failed to rename test data"
+	fi
+
+	cmake_src_prepare
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DBUILD_PKGCONFIG_FILES=ON	# always build pkgconfig files, bug #539834
+		-DBUILD_TESTING="$(multilib_native_usex test)"
+		-DBUILD_DOC=$(multilib_native_usex doc ON OFF)
+		-DBUILD_CODEC=$(multilib_is_native_abi && echo ON || echo OFF)
+		-DBUILD_STATIC_LIBS=$(usex static-libs)
+	)
+
+	cmake_src_configure
+}
+
+multilib_src_test() {
+	if ! multilib_is_native_abi ; then
+		elog "Cannot run tests for non-multilib abi."
+		return 0
+	fi
+
+	local myctestargs=
+
+	pushd "${BUILD_DIR}" > /dev/null || die
+	[[ -e CTestTestfile.cmake ]] || die "Test suite not available! Check source!"
+
+	[[ -n ${TEST_VERBOSE} ]] && myctestargs+=( --extra-verbose --output-on-failure )
+
+	echo ctest "${myctestargs[@]}" "$@"
+	if ctest "${myctestargs[@]}" "$@" ; then
+		einfo "Tests succeeded."
+		popd > /dev/null || die
+		return 0
+	else
+		local FAILEDTEST_LOG="${BUILD_DIR}/Testing/Temporary/LastTestsFailed.log"
+
+		if [[ ! -f "${FAILEDTEST_LOG}" ]] ; then
+			# Should never happen
+			die "Cannot analyze test failures: LastTestsFailed.log is missing!"
+		fi
+
+		echo ""
+		einfo "Note: Upstream is maintaining a list of known test failures."
+		einfo "We will now compare our test results against this list and sort out any known failure."
+
+		local KNOWN_FAILURES_LIST="${T}/known_failures_compiled.txt"
+		cat "${S}/tools/travis-ci/knownfailures-all.txt" > "${KNOWN_FAILURES_LIST}" || die
+
+		local ARCH_SPECIFIC_FAILURES=
+		if use amd64 ; then
+			ARCH_SPECIFIC_FAILURES="$(find "${S}/tools/travis-ci/" -name 'knownfailures-*x86_64*.txt' -print0 | sort -z | tail -z -n 1 | tr -d '\0')"
+		elif use x86 || use arm || use arm64; then
+			ARCH_SPECIFIC_FAILURES="$(find "${S}/tools/travis-ci/" -name 'knownfailures-*i386*.txt' -print0 | sort -z | tail -z -n 1 | tr -d '\0')"
+		fi
+
+		if [[ -f "${ARCH_SPECIFIC_FAILURES}" ]] ; then
+			einfo "Adding architecture specific failures (${ARCH_SPECIFIC_FAILURES}) to known failures list ..."
+			cat "${ARCH_SPECIFIC_FAILURES}" >> "${KNOWN_FAILURES_LIST}" || die
+		fi
+
+		# Logic copied from $S/tools/travis-ci/run.sh
+		local FAILEDTEST=
+		local FAILURES_LOG="${BUILD_DIR}/Testing/Temporary/failures.txt"
+		local HAS_UNKNOWN_TEST_FAILURES=0
+
+		echo ""
+
+		awk -F: '{ print $2 }' "${FAILEDTEST_LOG}" > "${FAILURES_LOG}"
+		while read FAILEDTEST; do
+			# is this failure known?
+			if grep -x "${FAILEDTEST}" "${KNOWN_FAILURES_LIST}" > /dev/null; then
+				ewarn "Test '${FAILEDTEST}' is known to fail, ignoring ..."
+				continue
+			fi
+
+			eerror "New/unknown test failure found: '${FAILEDTEST}'"
+			HAS_UNKNOWN_TEST_FAILURES=1
+		done < "${FAILURES_LOG}"
+
+		if [[ ${HAS_UNKNOWN_TEST_FAILURES} -ne 0 ]]; then
+			die "Test suite failed. New/unknown test failure(s) found!"
+		else
+			echo ""
+			einfo "Test suite passed. No new/unknown test failure(s) found!"
+		fi
+
+		return 0
+	fi
+}


### PR DESCRIPTION
Uses upstream patches to fix CVE-2020-6851, CVE-2020-8112.

Bug: https://bugs.gentoo.org/707926
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>