### PR TITLE
sys-boot/tboot: Shell expansion doesn't work within quotes

### DIFF
--- a/sys-boot/tboot/tboot-1.9.11.ebuild
+++ b/sys-boot/tboot/tboot-1.9.11.ebuild
@@ -60,7 +60,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	cp "${ROOT}/usr/lib/tboot/boot/*" "${ROOT}/boot/" || die
+	cp "${ROOT}/usr/lib/tboot/boot/"* "${ROOT}/boot/" || die
 
 	ewarn "Please remember to download the SINIT AC Module relevant"
 	ewarn "for your platform from:"


### PR DESCRIPTION
Package-Manager: Portage-2.3.89, Repoman-2.3.20