### PR TITLE
sys-fabric/infiniband-diags: missing dependency on dev-libs/glib

### DIFF
--- a/sys-fabric/infiniband-diags/infiniband-diags-1.6.4.ebuild
+++ b/sys-fabric/infiniband-diags/infiniband-diags-1.6.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -17,6 +17,7 @@ IUSE=""
 DEPEND="
 	sys-fabric/libibumad:${SLOT}
 	sys-fabric/libibmad:${SLOT}
-	sys-fabric/opensm:${SLOT}"
+	sys-fabric/opensm:${SLOT}
+	dev-libs/glib"
 RDEPEND="${DEPEND}"
 block_other_ofed_versions


### PR DESCRIPTION
Signed-off-by: Steven Johnson <steven.gregory.johnson@gmail.com>
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Closes: https://bugs.gentoo.org/514256