### PR TITLE
dev-python/ebuildtester: Python 3.7 support, EAPI 7 and fix dependencies

### DIFF
--- a/dev-python/ebuildtester/ebuildtester-0.1.14.ebuild
+++ b/dev-python/ebuildtester/ebuildtester-0.1.14.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7} )
 
 inherit bash-completion-r1 distutils-r1
 
@@ -22,7 +22,7 @@ RDEPEND="
 "
 
 DEPEND="
-	dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/setuptools_scm[${PYTHON_USEDEP}]
 	dev-python/sphinx[${PYTHON_USEDEP}]
 "
 


### PR DESCRIPTION
Signed-off-by: Viktar Patotski <xp.vit.blr@gmail.com>
corrected ebuild was tested using ebuildtester-9999
Bug: https://bugs.gentoo.org/686850
Bug: https://bugs.gentoo.org/685274
Closes: https://bugs.gentoo.org/686850
Closes: https://bugs.gentoo.org/685274