### PR TITLE
media-sound/pulseaudio-modules-bt: add USE flags

### DIFF
--- a/media-sound/pulseaudio-modules-bt/metadata.xml
+++ b/media-sound/pulseaudio-modules-bt/metadata.xml
@@ -1,10 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>zx2c4@gentoo.org</email>
-</maintainer>
-<maintainer type="person">
-	<email>pacho@gentoo.org</email>
-</maintainer>
+	<maintainer type="person">
+		<email>zx2c4@gentoo.org</email>
+	</maintainer>
+	<maintainer type="person">
+		<email>pacho@gentoo.org</email>
+	</maintainer>
+	<use>
+		<flag name="fdk">
+		AAC encoding support using media-libs/fdk-aac
+		</flag>
+		<flag name="ffmpeg">
+		APTX, APTX-HD encoding support
+		</flag>
+		<flag name="ldac">
+		LDAC encoding support, using media-libs/libldac
+		</flag>
+		<flag name="native-headset">
+		Build with native HSP (Headset Profile) headset for bluez 5
+		</flag>
+		<flag name="ofono-headset">
+		Build with oFono HFP (Hands Free Profile) headset for bluez 5, requires net-misc/ofono.
+		</flag>
+	</use>
 </pkgmetadata>

--- a/media-sound/pulseaudio-modules-bt/pulseaudio-modules-bt-1.3-r1.ebuild
+++ b/media-sound/pulseaudio-modules-bt/pulseaudio-modules-bt-1.3-r1.ebuild
@@ -16,16 +16,16 @@ SRC_URI="
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE=""
+IUSE="fdk +ffmpeg +ldac +native-headset ofono-headset"
 
 DEPEND="
-	media-libs/fdk-aac:0=
-	virtual/ffmpeg
+	fdk? ( media-libs/fdk-aac:0= )
+	ffmpeg? ( virtual/ffmpeg )
 	media-libs/sbc
-	media-libs/libldac
+	ldac? ( media-libs/libldac )
 	>=net-wireless/bluez-5
 	>=sys-apps/dbus-1.0.0
-	>=net-misc/ofono-1.13
+	ofono-headset? ( >=net-misc/ofono-1.13 )
 	>=media-sound/pulseaudio-${PULSE_VER}[-bluetooth]
 "
 # Ordinarily media-libs/libldac should be in DEPEND too, but for now upstream repo is using a ldac submodule instead.
@@ -52,6 +52,18 @@ load-module module-bluetooth-policy
 load-module module-bluetooth-discover
 .endif
 "
+
+src_configure() {
+	local mycmakeargs=(
+		-DCODEC_AAC_FDK=$(usex fdk "ON" "OFF")
+		-DCODEC_APTX_FF=$(usex ffmpeg "ON" "OFF")
+		-DCODEC_APTX_HD_FF=$(usex ffmpeg "ON" "OFF")
+		-DCODEC_LDAC=$(usex ldac "ON" "OFF")
+		-DNATIVE_HEADSET=$(usex native-headset "ON" "OFF")
+		-DOFONO_HEADSET=$(usex ofono-headset "ON" "OFF")
+	)
+	cmake-utils_src_configure
+}
 
 src_prepare() {
 	cmake-utils_src_prepare

--- a/media-sound/pulseaudio-modules-bt/pulseaudio-modules-bt-9999.ebuild
+++ b/media-sound/pulseaudio-modules-bt/pulseaudio-modules-bt-9999.ebuild
@@ -17,16 +17,16 @@ EGIT_OVERRIDE_COMMIT_PULSEAUDIO_PULSEAUDIO="v13.0"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="fdk +ffmpeg +ldac +native-headset ofono-headset"
 
 DEPEND="
-	media-libs/fdk-aac:0=
-	virtual/ffmpeg
+	fdk? ( media-libs/fdk-aac:0= )
+	ffmpeg? ( virtual/ffmpeg )
 	media-libs/sbc
-	media-libs/libldac
+	ldac? ( media-libs/libldac )
 	>=net-wireless/bluez-5
 	>=sys-apps/dbus-1.0.0
-	>=net-misc/ofono-1.13
+	ofono-headset? ( >=net-misc/ofono-1.13 )
 	>=media-sound/pulseaudio-13[-bluetooth]
 "
 # Ordinarily media-libs/libldac should be in DEPEND too, but for now upstream repo is using a ldac submodule instead.
@@ -54,6 +54,18 @@ load-module module-bluetooth-policy
 load-module module-bluetooth-discover
 .endif
 "
+
+src_configure() {
+	local mycmakeargs=(
+		-DCODEC_AAC_FDK=$(usex fdk "ON" "OFF")
+		-DCODEC_APTX_FF=$(usex ffmpeg "ON" "OFF")
+		-DCODEC_APTX_HD_FF=$(usex ffmpeg "ON" "OFF")
+		-DCODEC_LDAC=$(usex ldac "ON" "OFF")
+		-DNATIVE_HEADSET=$(usex native-headset "ON" "OFF")
+		-DOFONO_HEADSET=$(usex ofono-headset "ON" "OFF")
+	)
+	cmake-utils_src_configure
+}
 
 src_install() {
 	cmake-utils_src_install


### PR DESCRIPTION
Proposal of pulseaudio-modules-bt following their github documentation.

I didn't wanted to put those changes at 9999 version, as might change in future.

Already compiled from my side, and works fine.

Thanks.