### PR TITLE
app-emulation/qemu-9999: Introduce RX softmmu target

### DIFF
--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -45,7 +45,7 @@ COMMON_TARGETS="aarch64 alpha arm cris hppa i386 m68k microblaze microblazeel
 	mips mips64 mips64el mipsel nios2 or1k ppc ppc64 riscv32 riscv64 s390x
 	sh4 sh4eb sparc sparc64 x86_64 xtensa xtensaeb"
 IUSE_SOFTMMU_TARGETS="${COMMON_TARGETS}
-	lm32 moxie tricore unicore32"
+	lm32 moxie rx tricore unicore32"
 IUSE_USER_TARGETS="${COMMON_TARGETS}
 	aarch64_be armeb mipsn32 mipsn32el ppc64abi32 ppc64le sparc32plus
 	tilegx"

--- a/profiles/desc/qemu_softmmu_targets.desc
+++ b/profiles/desc/qemu_softmmu_targets.desc
@@ -26,6 +26,7 @@ ppc64 - system emulation target
 ppc - system emulation target
 riscv32 - system emulation target
 riscv64 - system emulation target
+rx - Renesas RX system emulation target
 s390x - system emulation target
 sh4eb - system emulation target
 sh4 - system emulation target


### PR DESCRIPTION
In recent upstream patches (v4.2.0-2645-gc8c35e5f51 and friends),
qemu introduced new softmmu target: Renesas RX. Update our list
of softmmu targets.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>