### PR TITLE
x11-terms/kitty: add kitty-terminfo as a dependency

### DIFF
--- a/x11-terms/kitty/kitty-0.16.0-r3.ebuild
+++ b/x11-terms/kitty/kitty-0.16.0-r3.ebuild
@@ -1,0 +1,103 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6,7,8} )
+
+inherit eutils python-single-r1 toolchain-funcs xdg
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://github.com/kovidgoyal/kitty.git"
+	inherit git-r3
+else
+	SRC_URI="https://github.com/kovidgoyal/kitty/releases/download/v${PV}/${P}.tar.xz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+DESCRIPTION="A modern, hackable, featureful, OpenGL-based terminal emulator"
+HOMEPAGE="https://github.com/kovidgoyal/kitty"
+
+LICENSE="GPL-3"
+SLOT="0"
+IUSE="debug wayland"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	media-libs/fontconfig
+	media-libs/freetype:2
+	>=media-libs/harfbuzz-1.5.0:=
+	media-libs/libcanberra
+	media-libs/libpng:0=
+	sys-apps/dbus
+	sys-libs/zlib
+	x11-libs/libxcb[xkb]
+	x11-libs/libXcursor
+	x11-libs/libXi
+	x11-libs/libXinerama
+	x11-libs/libxkbcommon[X]
+	x11-libs/libXrandr
+	x11-terms/kitty-terminfo
+	wayland? (
+		dev-libs/wayland
+		>=dev-libs/wayland-protocols-1.17
+	)
+"
+
+DEPEND="${RDEPEND}
+	media-libs/mesa[X(+)]
+	sys-libs/ncurses
+"
+
+BDEPEND="virtual/pkgconfig"
+
+[[ ${PV} == *9999 ]] && BDEPEND+=" >=dev-python/sphinx-1.7"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.15.1-flags.patch
+	"${FILESDIR}"/${PN}-0.14.4-svg-icon.patch
+	"${FILESDIR}"/${PN}-0.16.0-remove-terminfo.patch
+)
+
+src_prepare() {
+	default
+
+	# disable wayland as required
+	if ! use wayland; then
+		sed -i "/'x11 wayland'/s/ wayland//" setup.py || die
+	fi
+
+	# respect doc dir
+	sed -i "/htmldir =/s/appname/'${PF}'/" setup.py || die
+
+	tc-export CC
+}
+
+src_compile() {
+	"${EPYTHON}" setup.py \
+		--verbose $(usex debug --debug "") \
+		--libdir-name $(get_libdir) \
+		linux-package || die "Failed to compile kitty."
+}
+
+src_test() {
+	export KITTY_CONFIG_DIRECTORY=${T}
+	"${EPYTHON}" test.py || die
+}
+
+src_install() {
+	insinto /usr
+	doins -r linux-package/*
+	dobin linux-package/bin/kitty
+	python_fix_shebang "${ED}"
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+	optfeature "Displaying images in the terminal" virtual/imagemagick-tools
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
Add kitty-terminfo as a dependency because the kitty terminal emulator is not completely usable in some cases if the file is missing.

Signed-off-by: Pablo Orduna <pabloorduna98@gmail.com>

Closes: https://bugs.gentoo.org/713846