### PR TITLE
net-misc/netkit-telnetd: Fix 'sed' delimiter

### DIFF
--- a/net-misc/netkit-telnetd/netkit-telnetd-0.17-r12.ebuild
+++ b/net-misc/netkit-telnetd/netkit-telnetd-0.17-r12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -46,7 +46,7 @@ src_prepare() {
 
 	# Fix portability issues.
 	sed -i \
-		-e 's:echo -n:printf %s:' \
+		-e 's/echo -n/printf %s/' \
 		configure || die
 	default
 }
@@ -58,9 +58,9 @@ src_configure() {
 	./configure --prefix=/usr || die
 
 	sed -i \
-		-e "s:-pipe -O2:${CFLAGS}:" \
-		-e "s:^\(LDFLAGS=\).*:\1${LDFLAGS}:" \
-		-e "s:-Wpointer-arith::" \
+		-e "s/-pipe -O2/${CFLAGS}/" \
+		-e "s/^\(LDFLAGS=\).*/\1${LDFLAGS}/" \
+		-e "s/-Wpointer-arith//" \
 		MCONFIG || die
 }
 


### PR DESCRIPTION
Also fixes copyright date and attribution

Closes: https://bugs.gentoo.org/711050
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>
Package-Manager: Portage-2.3.89, Repoman-2.3.20