### PR TITLE
dev-python/mysql-connector-python: Adding missing dev-python/dnspytho…

### DIFF
--- a/dev-python/mysql-connector-python/mysql-connector-python-8.0.18.ebuild
+++ b/dev-python/mysql-connector-python/mysql-connector-python-8.0.18.ebuild
@@ -20,6 +20,7 @@ BDEPEND=">=dev-libs/protobuf-3.6.1"
 RDEPEND="
 	>=dev-db/mysql-connector-c-8.0
 	>=dev-python/protobuf-python-3.6.1[${PYTHON_USEDEP}]
+	dev-python/dnspython
 "
 # tests/mysqld.py does not like MariaDB version strings.
 # See the regex MySQLServerBase._get_version.

--- a/dev-python/mysql-connector-python/mysql-connector-python-8.0.19.ebuild
+++ b/dev-python/mysql-connector-python/mysql-connector-python-8.0.19.ebuild
@@ -20,6 +20,7 @@ BDEPEND=">=dev-libs/protobuf-3.6.1"
 RDEPEND="
 	>=dev-db/mysql-connector-c-8.0
 	>=dev-python/protobuf-python-3.6.1[${PYTHON_USEDEP}]
+	dev-python/dnspython
 "
 # tests/mysqld.py does not like MariaDB version strings.
 # See the regex MySQLServerBase._get_version.


### PR DESCRIPTION
…n dependency

Bug: https://bugs.gentoo.org/714176
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Alarig Le Lay <alarig@swordarmor.fr>