### PR TITLE
waf-utils.eclass: Support --docdir and --htmldir

### DIFF
--- a/eclass/waf-utils.eclass
+++ b/eclass/waf-utils.eclass
@@ -69,19 +69,12 @@ waf-utils_src_configure() {
 
 	[[ ${fail} ]] && die "Invalid use of waf-utils.eclass"
 
-	local conf_args=()
-
 	# @ECLASS-VARIABLE: WAF_BINARY
 	# @DESCRIPTION:
 	# Eclass can use different waf executable. Usually it is located in "${S}/waf".
 	: ${WAF_BINARY:="${S}/waf"}
 
-	# @ECLASS-VARIABLE: NO_WAF_LIBDIR
-	# @DEFAULT_UNSET
-	# @DESCRIPTION:
-	# Variable specifying that you don't want to set the libdir for waf script.
-	# Some scripts does not allow setting it at all and die if they find it.
-	[[ -z ${NO_WAF_LIBDIR} ]] && conf_args+=(--libdir="${EPREFIX}/usr/$(get_libdir)")
+	local conf_args=()
 
 	local waf_help=$("${WAF_BINARY}" --help 2>/dev/null)
 	if [[ ${waf_help} == *--docdir* ]]; then
@@ -89,6 +82,9 @@ waf-utils_src_configure() {
 	fi
 	if [[ ${waf_help} == *--htmldir* ]]; then
 		conf_args+=( --htmldir="${EPREFIX}"/usr/share/doc/${PF}/html )
+	fi
+	if [[ ${waf_help} == *--libdir* ]]; then
+		conf_args+=( --libdir="${EPREFIX}/usr/$(get_libdir)" )
 	fi
 
 	tc-export AR CC CPP CXX RANLIB

--- a/eclass/waf-utils.eclass
+++ b/eclass/waf-utils.eclass
@@ -69,7 +69,7 @@ waf-utils_src_configure() {
 
 	[[ ${fail} ]] && die "Invalid use of waf-utils.eclass"
 
-	local libdir=()
+	local conf_args=()
 
 	# @ECLASS-VARIABLE: WAF_BINARY
 	# @DESCRIPTION:
@@ -81,7 +81,15 @@ waf-utils_src_configure() {
 	# @DESCRIPTION:
 	# Variable specifying that you don't want to set the libdir for waf script.
 	# Some scripts does not allow setting it at all and die if they find it.
-	[[ -z ${NO_WAF_LIBDIR} ]] && libdir=(--libdir="${EPREFIX}/usr/$(get_libdir)")
+	[[ -z ${NO_WAF_LIBDIR} ]] && conf_args+=(--libdir="${EPREFIX}/usr/$(get_libdir)")
+
+	local waf_help=$("${WAF_BINARY}" --help 2>/dev/null)
+	if [[ ${waf_help} == *--docdir* ]]; then
+		conf_args+=( --docdir="${EPREFIX}"/usr/share/doc/${PF} )
+	fi
+	if [[ ${waf_help} == *--htmldir* ]]; then
+		conf_args+=( --htmldir="${EPREFIX}"/usr/share/doc/${PF}/html )
+	fi
 
 	tc-export AR CC CPP CXX RANLIB
 
@@ -91,7 +99,7 @@ waf-utils_src_configure() {
 		PKGCONFIG="$(tc-getPKG_CONFIG)"
 		"${WAF_BINARY}"
 		"--prefix=${EPREFIX}/usr"
-		"${libdir[@]}"
+		"${conf_args[@]}"
 		"${@}"
 		configure
 	)


### PR DESCRIPTION
waf can optionally set the standard GNU directories [1].
Based on the code for econf in Portage's phase-helpers.sh.

[1] https://waf.io/apidocs/tools/gnu_dirs.html

Closes: https://bugs.gentoo.org/711612

---

And "Replace NO_WAF_LIBDIR with an automatic check"

Sent to gentoo-dev:

https://archives.gentoo.org/gentoo-dev/message/661f3a012869ef7352fa8bc9efb36ba8
https://archives.gentoo.org/gentoo-dev/message/baa95828ed64286373b217209edcf54a
