### PR TITLE
dev-python/statsmodels: stabilization

### DIFF
--- a/dev-python/statsmodels/statsmodels-0.10.2.ebuild
+++ b/dev-python/statsmodels/statsmodels-0.10.2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
 IUSE="doc examples test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/714524
Package-Manager: Portage-2.3.95, Repoman-2.3.21
Signed-off-by: Horea Christian <chr@chymera.eu>