### PR TITLE
www-servers/tornado py2 removal

### DIFF
--- a/dev-python/pyzmq/pyzmq-16.0.2.ebuild
+++ b/dev-python/pyzmq/pyzmq-16.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit flag-o-matic distutils-r1 toolchain-funcs
@@ -22,13 +22,11 @@ RDEPEND="
 	>=net-libs/zeromq-4.1.2:=
 	dev-python/py[${PYTHON_USEDEP}]
 	dev-python/cffi:=[${PYTHON_USEDEP}]
-	$(python_gen_cond_dep 'dev-python/gevent[${PYTHON_USEDEP}]' python2_7)
 "
 DEPEND="${RDEPEND}
 	dev-python/cython[${PYTHON_USEDEP}]
 	test? (
 		dev-python/pytest[${PYTHON_USEDEP}]
-		$(python_gen_cond_dep 'dev-python/unittest2[${PYTHON_USEDEP}]' -2)
 		www-servers/tornado[${PYTHON_USEDEP}]
 	)
 	doc? (

--- a/dev-python/pyzmq/pyzmq-17.1.0.ebuild
+++ b/dev-python/pyzmq/pyzmq-17.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit flag-o-matic distutils-r1 toolchain-funcs
@@ -22,13 +22,11 @@ RDEPEND="
 	>=net-libs/zeromq-4.2.2-r2:=[drafts]
 	dev-python/py[${PYTHON_USEDEP}]
 	dev-python/cffi:=[${PYTHON_USEDEP}]
-	$(python_gen_cond_dep 'dev-python/gevent[${PYTHON_USEDEP}]' python2_7)
 "
 DEPEND="${RDEPEND}
 	dev-python/cython[${PYTHON_USEDEP}]
 	test? (
 		dev-python/pytest[${PYTHON_USEDEP}]
-		$(python_gen_cond_dep 'dev-python/unittest2[${PYTHON_USEDEP}]' -2)
 		>=www-servers/tornado-5.0.2[${PYTHON_USEDEP}]
 	)
 	doc? (

--- a/dev-python/urllib3/urllib3-1.24.2.ebuild
+++ b/dev-python/urllib3/urllib3-1.24.2.ebuild
@@ -32,10 +32,12 @@ RDEPEND="
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? (
-		${RDEPEND}
-		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/pytest[${PYTHON_USEDEP}]
-		>=www-servers/tornado-4.2.1[$(python_gen_usedep python{2_7,3_{5,6,7}})]
+		$(python_gen_cond_dep "
+			${RDEPEND}
+			dev-python/mock[\${PYTHON_USEDEP}]
+			dev-python/pytest[\${PYTHON_USEDEP}]
+			>=www-servers/tornado-4.2.1[\${PYTHON_USEDEP}]
+		" 'python3*')
 	)
 "
 
@@ -53,7 +55,12 @@ python_prepare_all() {
 python_test() {
 	# FIXME: get tornado ported
 	case ${EPYTHON} in
-		python2*|python3.[567])
+		python2*)
+			ewarn "Tests are being skipped for Python 2 in order to reduce the number"
+			ewarn "of circular dependencies for Python 2 removal.  Please test"
+			ewarn "manually in a virtualenv."
+			;;
+		python3*)
 			pytest -vv || die "Tests fail with ${EPYTHON}"
 			;;
 	esac

--- a/dev-python/urllib3/urllib3-1.25.7.ebuild
+++ b/dev-python/urllib3/urllib3-1.25.7.ebuild
@@ -33,14 +33,14 @@ RDEPEND="
 BDEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? (
-		${RDEPEND}
-		dev-python/brotlipy[${PYTHON_USEDEP}]
-		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/pytest[${PYTHON_USEDEP}]
-		>=dev-python/trustme-0.5.3[${PYTHON_USEDEP}]
-		$(python_gen_cond_dep '
-			>=www-servers/tornado-4.2.1[${PYTHON_USEDEP}]
-		' python{2_7,3_{5,6,7}})
+		$(python_gen_cond_dep "
+			${RDEPEND}
+			dev-python/brotlipy[\${PYTHON_USEDEP}]
+			dev-python/mock[\${PYTHON_USEDEP}]
+			dev-python/pytest[\${PYTHON_USEDEP}]
+			>=dev-python/trustme-0.5.3[\${PYTHON_USEDEP}]
+			>=www-servers/tornado-4.2.1[\${PYTHON_USEDEP}]
+		" 'python3*')
 	)
 "
 
@@ -72,7 +72,12 @@ python_prepare_all() {
 python_test() {
 	# FIXME: get tornado ported
 	case ${EPYTHON} in
-		python2*|python3.[567])
+		python2*)
+			ewarn "Tests are being skipped for Python 2 in order to reduce the number"
+			ewarn "of circular dependencies for Python 2 removal.  Please test"
+			ewarn "manually in a virtualenv."
+			;;
+		python3*)
 			pytest -vv || die "Tests fail with ${EPYTHON}"
 			;;
 	esac

--- a/dev-python/urllib3/urllib3-1.25.8.ebuild
+++ b/dev-python/urllib3/urllib3-1.25.8.ebuild
@@ -33,14 +33,14 @@ RDEPEND="
 BDEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? (
-		${RDEPEND}
-		dev-python/brotlipy[${PYTHON_USEDEP}]
-		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/pytest[${PYTHON_USEDEP}]
-		>=dev-python/trustme-0.5.3[${PYTHON_USEDEP}]
-		$(python_gen_cond_dep '
-			>=www-servers/tornado-4.2.1[${PYTHON_USEDEP}]
-		' 'python*')
+		$(python_gen_cond_dep "
+			${RDEPEND}
+			dev-python/brotlipy[\${PYTHON_USEDEP}]
+			dev-python/mock[\${PYTHON_USEDEP}]
+			dev-python/pytest[\${PYTHON_USEDEP}]
+			>=dev-python/trustme-0.5.3[\${PYTHON_USEDEP}]
+			>=www-servers/tornado-4.2.1[\${PYTHON_USEDEP}]
+		" 'python3*')
 	)
 "
 
@@ -73,7 +73,12 @@ python_test() {
 	local -x CI=1
 	# FIXME: get tornado ported
 	case ${EPYTHON} in
-		python*)
+		python2*)
+			ewarn "Tests are being skipped for Python 2 in order to reduce the number"
+			ewarn "of circular dependencies for Python 2 removal.  Please test"
+			ewarn "manually in a virtualenv."
+			;;
+		python3*)
 			pytest -vv || die "Tests fail with ${EPYTHON}"
 			;;
 	esac

--- a/net-wireless/urh/urh-2.8.4.ebuild
+++ b/net-wireless/urh/urh-2.8.4.ebuild
@@ -26,7 +26,7 @@ DEPEND="${PYTHON_DEPS}
 		net-wireless/gnuradio[zeromq]
 		dev-python/numpy[${PYTHON_USEDEP}]
 		dev-python/psutil[${PYTHON_USEDEP}]
-		dev-python/pyzmq[python_targets_python2_7]
+		dev-python/pyzmq[${PYTHON_USEDEP}]
 		dev-python/cython[${PYTHON_USEDEP}]
 		bladerf? ( net-wireless/bladerf:= )
 		hackrf? ( net-libs/libhackrf:= )

--- a/net-wireless/urh/urh-9999.ebuild
+++ b/net-wireless/urh/urh-9999.ebuild
@@ -26,7 +26,7 @@ DEPEND="${PYTHON_DEPS}
 		net-wireless/gnuradio[zeromq]
 		dev-python/numpy[${PYTHON_USEDEP}]
 		dev-python/psutil[${PYTHON_USEDEP}]
-		dev-python/pyzmq[python_targets_python2_7]
+		dev-python/pyzmq[${PYTHON_USEDEP}]
 		dev-python/cython[${PYTHON_USEDEP}]
 		bladerf? ( net-wireless/bladerf:= )
 		hackrf? ( net-libs/libhackrf:= )

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Michał Górny <mgorny@gentoo.org> (2020-03-25)
+# Requires www-servers/tornado with py2.
+app-backup/bup web
+
 # Michał Górny <mgorny@gentoo.org> (2020-03-24)
 # Require dev-python/recommonmark with py2.
 <sys-devel/llvm-9 doc

--- a/www-servers/tornado/tornado-4.5.3.ebuild
+++ b/www-servers/tornado/tornado-4.5.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_6 )
+PYTHON_COMPAT=( python3_6 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/www-servers/tornado/tornado-5.1-r1.ebuild
+++ b/www-servers/tornado/tornado-5.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1


### PR DESCRIPTION
This resolves one of the awful circular dependencies in the ecosystem.

CC @gentoo/python, @gentoo/qa for urh revert-fix.