### PR TITLE
net-analyzer/ospd-openvas-1.0.0: add python targets 3.7 and 3.8

### DIFF
--- a/net-analyzer/ospd-openvas/ospd-openvas-1.0.0.ebuild
+++ b/net-analyzer/ospd-openvas/ospd-openvas-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7,8} )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 inherit distutils-r1 systemd
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/714770
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jonas Licht <jonas.licht@fem.tu-ilmenau.de>