### PR TITLE
texlive-modules.eclass: Fix a bug that sometimes prevents doc-installation

### DIFF
--- a/eclass/texlive-module.eclass
+++ b/eclass/texlive-module.eclass
@@ -350,8 +350,10 @@ texlive-module_src_install() {
 	done
 
 	dodir /usr/share
-	if use doc && [[ -d texmf-doc ]]; then
-		cp -pR texmf-doc "${ED}/usr/share/" || die
+	if use doc; then
+		if [[ -d texmf-doc ]]; then
+			cp -pR texmf-doc "${ED}/usr/share/" || die
+		fi
 	else
 		if [[ -d texmf-dist/doc ]]; then
 			rm -rf texmf-dist/doc || die


### PR DESCRIPTION
If the package does not create ${WORKDIR}/texmf-doc, then the eclass assumes
that no documentation should be installed.
This is assumption is incorrect, since the documentation tar-balls can put the
docs into texmf-dist and not texmf-doc, as happens with e.g. texlive-mathscience.
As a result, the documentation files are not installed anymore.

See also the bug: https://bugs.gentoo.org/714908