### PR TITLE
dev-util/idea-community: fix removing bundled .so files

### DIFF
--- a/dev-util/idea-community/idea-community-2019.3.3.193.6494.35.ebuild
+++ b/dev-util/idea-community/idea-community-2019.3.3.193.6494.35.ebuild
@@ -84,13 +84,13 @@ src_prepare() {
 		mv "${WORKDIR}/jre" ./"${JRE_DIR}"
 	fi
 
-	rm -vf "${S}"/"${JRE_DIR}"/lib/*/libavplugin* || die
+	rm -vf "${S}"/"${JRE_DIR}"/lib/libavplugin* || die
 	rm -vf "${S}"/plugins/maven/lib/maven3/lib/jansi-native/*/libjansi* || die
 	rm -vrf "${S}"/lib/pty4j-native/linux/ppc64le || die
 	rm -vf "${S}"/bin/libdbm64* || die
 
 	if [[ -d "${S}"/"${JRE_DIR}" ]]; then
-		for file in "${S}"/"${JRE_DIR}"/lib/amd64/{libfxplugins.so,libjfxmedia.so}
+		for file in "${S}"/"${JRE_DIR}"/lib/{libfxplugins.so,libjfxmedia.so}
 		do
 			patchelf --set-rpath '$ORIGIN' $file || die
 		done


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/711886
Package-Manager: Portage-2.3.96, Repoman-2.3.22
Signed-off-by: Georg Rudoy <0xd34df00d@gmail.com>