### PR TITLE
(no qt/kde) USE=gles{2,} renaming

### DIFF
--- a/games-emulation/mupen64plus-core/metadata.xml
+++ b/games-emulation/mupen64plus-core/metadata.xml
@@ -7,7 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="debugger">Build the debugger</flag>
-		<flag name="gles2">Use GLES2 instead of OpenGL</flag>
+		<flag name="gles2-only">Use GLES2 instead of OpenGL</flag>
 		<flag name="new-dynarec">Enable new experimental dynamic recompiler implementation (only for x86 and arm)</flag>
 		<flag name="opencv">Support video capture via <pkg>media-libs/opencv</pkg></flag>
 		<flag name="osd">Overlay emulator messages using on-screen-display</flag>

--- a/games-emulation/mupen64plus-core/mupen64plus-core-2.5.9.ebuild
+++ b/games-emulation/mupen64plus-core/mupen64plus-core-2.5.9.ebuild
@@ -13,12 +13,12 @@ SRC_URI="https://github.com/mupen64plus/${PN}/releases/download/${PV}/${MY_P}.ta
 LICENSE="GPL-2+"
 SLOT="0/2-sdl2"
 KEYWORDS="~amd64 ~x86"
-IUSE="debugger gles2 lirc new-dynarec opencv +osd cpu_flags_x86_sse"
+IUSE="debugger gles2-only lirc new-dynarec opencv +osd cpu_flags_x86_sse"
 
 RDEPEND="media-libs/libpng:0=
 	media-libs/libsdl2:0=[joystick,opengl,video]
 	sys-libs/zlib:0=[minizip]
-	gles2? ( media-libs/libsdl2:0[gles] )
+	gles2-only? ( media-libs/libsdl2:0[gles] )
 	lirc? ( app-misc/lirc:0 )
 	opencv? ( media-libs/opencv:= )
 	osd? (
@@ -30,7 +30,7 @@ RDEPEND="media-libs/libpng:0=
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
-REQUIRED_USE="gles2? ( !osd )"
+REQUIRED_USE="gles2-only? ( !osd )"
 S=${WORKDIR}/${MY_P}
 
 PATCHES=( "${FILESDIR}"/${PN}-2.5.9-fix-gcc10-fno-common.patch )
@@ -82,7 +82,7 @@ src_compile() {
 		OPENCV=$(usex opencv 1 0)
 		DEBUGGER=$(usex debugger 1 0)
 		NEW_DYNAREC=$(usex new-dynarec 1 0)
-		USE_GLES=$(usex gles2 1 0)
+		USE_GLES=$(usex gles2-only 1 0)
 	)
 
 	use amd64 && MAKEARGS+=( HOST_CPU=x86_64 )

--- a/games-emulation/mupen64plus-video-glide64mk2/metadata.xml
+++ b/games-emulation/mupen64plus-video-glide64mk2/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Michał Górny</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES2 instead of OpenGL</flag>
+		<flag name="gles2-only">Use GLES2 instead of OpenGL</flag>
 		<flag name="hires">Support hi-resolution textures (requires <pkg>dev-libs/boost</pkg>)</flag>
 	</use>
 	<upstream>

--- a/games-emulation/mupen64plus-video-glide64mk2/mupen64plus-video-glide64mk2-2.5.9.ebuild
+++ b/games-emulation/mupen64plus-video-glide64mk2/mupen64plus-video-glide64mk2-2.5.9.ebuild
@@ -14,14 +14,14 @@ SRC_URI="https://github.com/mupen64plus/${PN}/releases/download/${PV}/${MY_P}.ta
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="gles2 hires cpu_flags_x86_sse"
+IUSE="gles2-only hires cpu_flags_x86_sse"
 
-RDEPEND=">=games-emulation/mupen64plus-core-2.5:0=[gles2=]
+RDEPEND=">=games-emulation/mupen64plus-core-2.5:0=[gles2-only=]
 	media-libs/libpng:0=
 	media-libs/libsdl2:0=[video]
 	sys-libs/zlib:0=
 	virtual/opengl:0=
-	gles2? ( media-libs/libsdl2:0[gles] )
+	gles2-only? ( media-libs/libsdl2:0[gles] )
 	hires? ( dev-libs/boost:0= )"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
@@ -72,7 +72,7 @@ src_compile() {
 		NOSSE=$(usex cpu_flags_x86_sse 0 1)
 		HIRES=$(usex hires 1 0)
 		USE_FRAMESKIPPER=1
-		USE_GLES=$(usex gles2 1 0)
+		USE_GLES=$(usex gles2-only 1 0)
 		# use bundled lib
 		# https://bugs.gentoo.org/654470
 		TXCDXTN=0

--- a/games-emulation/mupen64plus-video-rice/metadata.xml
+++ b/games-emulation/mupen64plus-video-rice/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Michał Górny</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES2 instead of OpenGL</flag>
+		<flag name="gles2-only">Use GLES2 instead of OpenGL</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">mupen64plus/mupen64plus-video-rice</remote-id>

--- a/games-emulation/mupen64plus-video-rice/mupen64plus-video-rice-2.5.9.ebuild
+++ b/games-emulation/mupen64plus-video-rice/mupen64plus-video-rice-2.5.9.ebuild
@@ -13,13 +13,13 @@ SRC_URI="https://github.com/mupen64plus/${PN}/releases/download/${PV}/${MY_P}.ta
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="gles2 cpu_flags_x86_sse"
+IUSE="gles2-only cpu_flags_x86_sse"
 
-RDEPEND=">=games-emulation/mupen64plus-core-2.5:0=[gles2=]
+RDEPEND=">=games-emulation/mupen64plus-core-2.5:0=[gles2-only=]
 	media-libs/libpng:0=
 	media-libs/libsdl2:0=[video]
 	virtual/opengl:0=
-	gles2? ( media-libs/libsdl2:0[gles] )"
+	gles2-only? ( media-libs/libsdl2:0[gles] )"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
@@ -67,7 +67,7 @@ src_compile() {
 		SDL_LDLIBS="$($(tc-getPKG_CONFIG) --libs sdl2)"
 
 		NO_ASM=$(usex cpu_flags_x86_sse 0 1)
-		USE_GLES=$(usex gles2 1 0)
+		USE_GLES=$(usex gles2-only 1 0)
 	)
 
 	use amd64 && MAKEARGS+=( HOST_CPU=x86_64 )

--- a/www-plugins/freshplayerplugin/freshplayerplugin-0.3.9.ebuild
+++ b/www-plugins/freshplayerplugin/freshplayerplugin-0.3.9.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/i-rinat/freshplayerplugin"
 DESCRIPTION="PPAPI-host NPAPI-plugin adapter for flashplayer in npapi based browsers"
 SRC_URI="https://github.com/i-rinat/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 SLOT=0
-IUSE="gles2 jack libav libressl pulseaudio v4l vaapi vdpau"
+IUSE="gles2-only jack libav libressl pulseaudio v4l vaapi vdpau"
 
 KEYWORDS="amd64"
 
@@ -26,7 +26,8 @@ COMMON_DEPEND="
 	dev-libs/libevent:=[threads]
 	media-libs/alsa-lib:=
 	media-libs/freetype:2=
-	media-libs/mesa:=[egl,gles2?]
+	media-libs/mesa:=[egl]
+	gles2-only? ( media-libs/mesa[gles2] )
 	x11-libs/cairo:=[X]
 	x11-libs/libXcursor:=
 	x11-libs/libXrandr:=
@@ -65,7 +66,7 @@ src_configure() {
 	mycmakeargs=(
 		-DWITH_JACK=$(usex jack)
 		-DWITH_PULSEAUDIO=$(usex pulseaudio)
-		-DWITH_GLES2=$(usex gles2)
+		-DWITH_GLES2=$(usex gles2-only)
 		-DWITH_LIBV4L2=$(usex v4l)
 		-DCMAKE_SKIP_RPATH=1
 	)

--- a/www-plugins/freshplayerplugin/metadata.xml
+++ b/www-plugins/freshplayerplugin/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<!--maintainer-needed-->
 	<use>
-		<flag name="gles2">Use system GLESv2 libraries instead of ANGLE for shader translation</flag>
+		<flag name="gles2-only">Use system GLESv2 libraries instead of ANGLE for shader translation</flag>
 		<flag name="v4l">Use libv4l2 for colorspace conversion</flag>
 	</use>
 	<upstream>

--- a/www-plugins/lightspark/lightspark-0.8.2.ebuild
+++ b/www-plugins/lightspark/lightspark-0.8.2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/lightspark/lightspark/archive/${PV}.tar.gz -> ${P}.t
 LICENSE="LGPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="cpu_flags_x86_sse2 curl ffmpeg gles libav nsplugin ppapi profile rtmp"
+IUSE="cpu_flags_x86_sse2 curl ffmpeg gles2-only libav nsplugin ppapi profile rtmp"
 
 # Note: no LLVM since it's broken upstream
 RDEPEND="app-arch/xz-utils:0=
@@ -34,8 +34,8 @@ RDEPEND="app-arch/xz-utils:0=
 		libav? ( <media-video/libav-13_pre:0= )
 		!libav? ( media-video/ffmpeg:0= )
 	)
-	gles? ( media-libs/mesa:0=[gles2] )
-	!gles? (
+	gles2-only? ( media-libs/mesa:0=[gles2] )
+	!gles2-only? (
 		>=media-libs/glew-1.5.3:0=
 		virtual/opengl:0=
 	)
@@ -50,7 +50,7 @@ S=${WORKDIR}/${P/_rc*/}
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_CURL=$(usex curl)
-		-DENABLE_GLES2=$(usex gles)
+		-DENABLE_GLES2=$(usex gles2-only)
 		-DENABLE_LIBAVCODEC=$(usex ffmpeg)
 		-DENABLE_RTMP=$(usex rtmp)
 

--- a/www-plugins/lightspark/metadata.xml
+++ b/www-plugins/lightspark/metadata.xml
@@ -10,7 +10,7 @@
 		<name>Michał Górny</name>
 	</maintainer>
 	<use>
-		<flag name="gles">Replace default OpenGL renderer with GLESv2</flag>
+		<flag name="gles2-only">Replace default OpenGL renderer with GLESv2</flag>
 		<flag name="ppapi">Install the PPAPI plugin (for Chromium)</flag>
 		<flag name="rtmp">Enable Real Time Messaging Protocol using librtmp</flag>
 	</use>


### PR DESCRIPTION
Cherry-picking of https://github.com/gentoo/gentoo/pull/13742 without the Qt/KDE parts, so hopefully it can be merged quicker.