### PR TITLE
python-utils-r1.eclass: Bump minimal Python versions

### DIFF
--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -374,17 +374,15 @@ _python_export() {
 				local d
 				case ${impl} in
 					python2.7)
-						PYTHON_PKG_DEP='>=dev-lang/python-2.7.5-r2:2.7';;
-					python3.3)
-						PYTHON_PKG_DEP='>=dev-lang/python-3.3.2-r2:3.3';;
-					python*)
-						PYTHON_PKG_DEP="dev-lang/python:${impl#python}";;
-					pypy)
-						PYTHON_PKG_DEP='>=dev-python/pypy-5:0=';;
+						PYTHON_PKG_DEP='>=dev-lang/python-2.7.17-r1:2.7';;
+					python3.6)
+						PYTHON_PKG_DEP=">=dev-lang/python-3.6.10:3.6";;
+					python3.7)
+						PYTHON_PKG_DEP=">=dev-lang/python-3.7.6:3.7";;
+					python3.8)
+						PYTHON_PKG_DEP=">=dev-lang/python-3.8.2:3.8";;
 					pypy3)
-						PYTHON_PKG_DEP='>=dev-python/pypy3-5:0=';;
-					jython2.7)
-						PYTHON_PKG_DEP='dev-java/jython:2.7';;
+						PYTHON_PKG_DEP='>=dev-python/pypy3-7.3.0:0=';;
 					*)
 						die "Invalid implementation: ${impl}"
 				esac


### PR DESCRIPTION
Bump minimal Python versions to current stable to save ebuilds from
having to hack around the dependencies.

Signed-off-by: Michał Górny <mgorny@gentoo.org>

CC @gentoo/python 