### PR TITLE
x11-base/xcb-proto: Install 1.14 for the correct Python versions

### DIFF
--- a/x11-base/xcb-proto/xcb-proto-1.14-r1.ebuild
+++ b/x11-base/xcb-proto/xcb-proto-1.14-r1.ebuild
@@ -17,26 +17,36 @@ EGIT_REPO_URI="https://gitlab.freedesktop.org/xorg/proto/xcbproto.git"
 
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
-
-DEPEND=""
-RDEPEND="${PYTHON_DEPS}"
-BDEPEND="dev-libs/libxml2"
-
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-multilib_src_compile() {
-	default
+DEPEND=""
+RDEPEND="
+	${PYTHON_DEPS}
+"
+BDEPEND="
+	${PYTHON_DEPS}
+	dev-libs/libxml2
+"
 
-	if multilib_is_native_abi; then
-		python_foreach_impl emake -C xcbgen top_builddir="${BUILD_DIR}"
-	fi
+ECONF_SOURCE="${S}"
+
+multilib_src_configure() {
+	# Don't use Python to find sitedir here.
+	PYTHON=true default
+}
+
+src_compile() {
+	:
+}
+
+xcbgen_install() {
+	# Use eclass to find sitedir instead.
+	emake -C xcbgen install DESTDIR="${D}" pythondir="$(python_get_sitedir)"
+	python_optimize
 }
 
 multilib_src_install() {
-	default
-
-	if multilib_is_native_abi; then
-		python_foreach_impl emake -C xcbgen top_builddir="${BUILD_DIR}"
-		python_foreach_impl python_optimize
-	fi
+	# Restrict SUBDIRS to prevent xcbgen with empty sitedir.
+	emake install DESTDIR="${D}" SUBDIRS=src
+	multilib_is_native_abi && python_foreach_impl xcbgen_install
 }


### PR DESCRIPTION
On my system, I had 3.7 and 3.8 selected but it was installing for
2.7, even though that's not one of the targets! 2.7 had accidentally
become my eselected Python. configure was picking this up, detecting
the sitedir, and locking it into the Makefile, preventing
python_foreach_impl from having any effect. It is simpler and safer to
override the Makefile's pythondir with the sitedir value returned by
the eclass.

Package-Manager: Portage-2.3.96, Repoman-2.3.20
Signed-off-by: James Le Cuirot <chewi@gentoo.org>