### PR TITLE
foldingathome: systemd cleanup, various fixues.

### DIFF
--- a/sci-biology/foldingathome/foldingathome-7.5.1-r2.ebuild
+++ b/sci-biology/foldingathome/foldingathome-7.5.1-r2.ebuild
@@ -25,7 +25,9 @@ RDEPEND="app-arch/bzip2
 	)
 	sys-devel/gcc
 	sys-libs/glibc
-	sys-libs/zlib"
+	sys-libs/zlib
+	acct-group/video
+"
 
 S="${WORKDIR}/fahclient_${PV}-64bit-release"
 
@@ -44,7 +46,7 @@ pkg_setup() {
 	elog ""
 
 	enewgroup foldingathome
-	enewuser foldingathome -1 -1 "${EPREFIX}"/opt/foldingathome
+	enewuser foldingathome -1 -1 "${EPREFIX}"/opt/foldingathome video
 }
 
 src_install() {
@@ -83,12 +85,16 @@ Documentation=https://foldingathome.org
 [Service]
 Type=simple
 User=foldingathome
+Group=foldingathome
+Nice=19
 WorkingDirectory=${EPREFIX}/opt/foldingathome
-PIDFile=/run/fahclient.pid
-ExecStart=${EPREFIX}/opt/foldingathome/FAHClient -v
-#ExecReload=${EPREFIX}/opt/foldingathome/FAHClient -v restart
-#ExecStop=${EPREFIX}/opt/foldingathome/FAHClient -v stop
-KillMode=process
+ExecStart=${EPREFIX}/opt/foldingathome/FAHClient --fork=false --pid=false --respawn=false --service=false
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectSystem=full
+RestrictRealtime=true
+ProtectControlGroups=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
1) force the `foldingathome` user group for the process for obvious
  reasons.
2) link in the video group and add it to the foldingathome user- this
  is necessary for GPU utilization.
3) force nice=19 from systemd level.  The batch processing attempts to
  do this for workers, but we might as well force it for the scheduler.
4) Add explicit configuration directives to force- irregardless of host config-
  the scheduler to be foreground'd and running in a fashion that integrates w/
  systemd more sanely.
5) Lockdown some basic systemd security while I'm in here.
6) Finally, drop the pidfile directive for systemd.  Foreground process-
  no pidfile to track (nor should we have the unit create it).

Bug: https://bugs.gentoo.org/712744
Signed-off-by: Brian Harring <ferringb@gmail.com>