### PR TITLE
dev-python/spyder: allow newer parso versions

### DIFF
--- a/dev-python/spyder/files/spyder-4.1.1-allow-newer-parso.patch
+++ b/dev-python/spyder/files/spyder-4.1.1-allow-newer-parso.patch
@@ -1,0 +1,39 @@
+diff --git a/requirements/conda.txt b/requirements/conda.txt
+index 2e5e4e1..e5f427e 100644
+--- a/requirements/conda.txt
++++ b/requirements/conda.txt
+@@ -14,7 +14,7 @@ keyring
+ nbconvert >=4.0
+ numpydoc >=0.6.0
+ Paramiko >=2.4.0
+-parso =0.5.2
++parso >=0.5.2
+ pexpect >=4.4.0
+ pickleshare >=0.4
+ psutil >=5.3
+diff --git a/setup.py b/setup.py
+index 2d5d58b..f008824 100644
+--- a/setup.py
++++ b/setup.py
+@@ -218,7 +218,7 @@ install_requires = [
+     'numpydoc>=0.6.0',
+     # Required to get SSH connections to remote kernels
+     'paramiko>=2.4.0;platform_system=="Windows"',
+-    'parso==0.5.2',
++    'parso>=0.5.2',
+     'pexpect>=4.4.0',
+     'pickleshare>=0.4',
+     'psutil>=5.3',
+diff --git a/spyder/dependencies.py b/spyder/dependencies.py
+index 7c88ab6..60950a8 100644
+--- a/spyder/dependencies.py
++++ b/spyder/dependencies.py
+@@ -41,7 +41,7 @@ KEYRING_REQVER = None
+ NBCONVERT_REQVER = '>=4.0'
+ NUMPYDOC_REQVER = '>=0.6.0'
+ PARAMIKO_REQVER = '>=2.4.0'
+-PARSO_REQVER = '=0.5.2'
++PARSO_REQVER = '>=0.5.2'
+ PEXPECT_REQVER = '>=4.4.0'
+ PICKLESHARE_REQVER = '>=0.4'
+ PSUTIL_REQVER = '>=5.3'

--- a/dev-python/spyder/spyder-4.1.1.ebuild
+++ b/dev-python/spyder/spyder-4.1.1.ebuild
@@ -33,7 +33,7 @@ RDEPEND="
 	dev-python/keyring[${PYTHON_USEDEP}]
 	>=dev-python/nbconvert-4.0[${PYTHON_USEDEP}]
 	>=dev-python/numpydoc-0.6.0[${PYTHON_USEDEP}]
-	~dev-python/parso-0.5.2[${PYTHON_USEDEP}]
+	>=dev-python/parso-0.5.2[${PYTHON_USEDEP}]
 	>=dev-python/pexpect-4.4.0[${PYTHON_USEDEP}]
 	>=dev-python/pickleshare-0.4[${PYTHON_USEDEP}]
 	>=dev-python/psutil-5.3[${PYTHON_USEDEP}]
@@ -69,8 +69,11 @@ DEPEND="test? (
 # Based on the courtesy of Arfrever
 # This patch removes a call to update-desktop-database during build
 # This fails because access is denied to this command during build
-PATCHES=( "${FILESDIR}/${P}-build.patch"
-	"${FILESDIR}/${P}-py3-only.patch" )
+PATCHES=(
+	"${FILESDIR}/${P}-build.patch"
+	"${FILESDIR}/${P}-py3-only.patch"
+	"${FILESDIR}/${P}-allow-newer-parso.patch"
+)
 
 distutils_enable_tests pytest
 distutils_enable_sphinx docs/doc --no-autodoc


### PR DESCRIPTION
As per request by @mgorny in https://bugs.gentoo.org/715148


Bug: https://bugs.gentoo.org/715148
Package-Manager: Portage-2.3.96, Repoman-2.3.22
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>