### PR TITLE
net-misc/dahdi-tools: musl compile fixes.

### DIFF
--- a/net-misc/dahdi-tools/dahdi-tools-3.1.0.ebuild
+++ b/net-misc/dahdi-tools/dahdi-tools-3.1.0.ebuild
@@ -17,6 +17,8 @@ PATCHES=(
 	"${FILESDIR}/dahdi-nondigium-blacklist.patch"
 	"${FILESDIR}/dahdi-tools-3.1.0-parallel-make-no-config.patch"
 	"${FILESDIR}/dahdi-tools-3.1.0-fno-common.patch"
+	"${FILESDIR}/dahdi-tools-3.1.0-execinfo.patch"
+	"${FILESDIR}/dahdi-tools-3.1.0-cplusplusexternc.patch"
 )
 
 DEPEND="dev-libs/newt

--- a/net-misc/dahdi-tools/files/dahdi-tools-3.1.0-cplusplusexternc.patch
+++ b/net-misc/dahdi-tools/files/dahdi-tools-3.1.0-cplusplusexternc.patch
@@ -1,0 +1,26 @@
+diff --git a/./dahdi-tools-3.1.0/xpp/hexfile.h.o b/./dahdi-tools-3.1.0/xpp/hexfile.h
+index 33ff50d..3d03f98 100644
+--- a/xpp/hexfile.h
++++ b/xpp/hexfile.h
+@@ -70,7 +70,9 @@ struct hexdata {
+ };
+ 
+ 
+-__BEGIN_DECLS
++#ifdef __cpluplus
++extern "C" {
++#endif
+ 
+ typedef void (*parse_hexfile_report_func_t)(int level, const char *msg, ...)
+ #ifdef	__GNUC__
+@@ -86,6 +88,9 @@ int dump_hexfile2(struct hexdata *hexdata, const char *outfile, uint8_t maxwidth
+ void dump_binary(struct hexdata *hexdata, const char *outfile);
+ void gen_hexline(const uint8_t *data, uint16_t addr, size_t len, FILE *output);
+ int bsd_checksum(struct hexdata *hexdata);
+-__END_DECLS
++
++#ifdef __cpluplus
++}
++#endif
+ 
+ #endif

--- a/net-misc/dahdi-tools/files/dahdi-tools-3.1.0-execinfo.patch
+++ b/net-misc/dahdi-tools/files/dahdi-tools-3.1.0-execinfo.patch
@@ -1,0 +1,40 @@
+--- a/configure.ac	2020-03-28 22:28:35.614340050 +0200
++++ b/configure.ac	2020-03-28 22:28:55.084181570 +0200
+@@ -161,6 +161,7 @@
+ # Checks for header files.
+ AC_CHECK_HEADERS([sys/soundcard.h linux/soundcard.h])
+ AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netinet/in.h stdint.h stdlib.h string.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h syslog.h unistd.h])
++AC_CHECK_HEADERS([execinfo.h])
+ 
+ # Checks for typedefs, structures, and compiler characteristics.
+ AC_C_INLINE
+--- a/xpp/xtalk/debug.c	2020-03-28 22:41:43.507810560 +0200
++++ b/xpp/xtalk/debug.c	2020-03-28 22:41:10.538087608 +0200
+@@ -27,8 +27,10 @@
+ #include <stdarg.h>
+ #include <syslog.h>
+-#include <execinfo.h>
+ #include <xtalk/debug.h>
+ #include <autoconfig.h>
++#ifdef HAVE_EXECINFO_H
++#include <execinfo.h>
++#endif
+ 
+ int	verbose = LOG_INFO;
+ int	debug_mask;
+@@ -61,6 +63,7 @@
+ /* from glibc info(1) */
+ void print_backtrace(FILE *fp)
+ {
++#ifdef HAVE_EXECINFO_H
+ 	void	*array[10];
+ 	size_t	size;
+ 	char	**strings;
+@@ -71,4 +74,7 @@
+ 	for (i = 0; i < size; i++)
+ 		fprintf(fp, "%s\n", strings[i]);
+ 	free(strings);
++#else
++	fprintf(fp, "backtrace information only available if execinfo.h is available.\n");
++#endif
+ }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/713668
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jaco Kroon <jaco@uls.co.za>