### PR TITLE
www-client/luakit:

### DIFF
--- a/www-client/luakit/luakit-9999.ebuild
+++ b/www-client/luakit/luakit-9999.ebuild
@@ -1,16 +1,16 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit toolchain-funcs
+inherit toolchain-funcs xdg-utils
 
 DESCRIPTION="A fast, light, simple to use micro-browser using WebKit and Lua"
 HOMEPAGE="https://luakit.github.io/luakit"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://github.com/luakit/luakit.git"
+	EGIT_REPO_URI="https://github.com/luakit/luakit.git"
 else
 	SRC_URI="https://github.com/luakit/luakit/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
@@ -43,6 +43,7 @@ src_compile() {
 		CC=$(tc-getCC) \
 		LUA_PKG_NAME=$(usex luajit 'luajit' 'lua') \
 		LUA_BIN_NAME=$(usex luajit 'luajit' 'lua') \
+		PREFIX="${EPREFIX}/usr" \
 		all
 
 	use doc && emake doc
@@ -55,6 +56,8 @@ src_test() {
 }
 
 src_install() {
+	sed -i 's/install -m644 luakit.1.gz/install -m644 luakit.1/g' Makefile || die
+
 	emake \
 		DESTDIR="${D}" \
 		PREFIX="${EPREFIX}/usr" \
@@ -65,4 +68,10 @@ src_install() {
 	rm "${ED}/usr/share/doc/${PF}/COPYING.GPLv3" || die
 
 	use doc && dodoc -r doc/html
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+	xdg_mimeinfo_database_update
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/715184
Package-Manager: Portage-2.3.96, Repoman-2.3.22