### PR TITLE
net-dns/dnscrypt-proxy: amd64 stable for 2.0.39

### DIFF
--- a/net-dns/dnscrypt-proxy/dnscrypt-proxy-2.0.39.ebuild
+++ b/net-dns/dnscrypt-proxy/dnscrypt-proxy-2.0.39.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://${EGO_PN}.git"
 else
 	SRC_URI="https://${EGO_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+	KEYWORDS="amd64 ~arm ~ppc64 ~x86"
 fi
 
 DESCRIPTION="A flexible DNS proxy, with support for encrypted DNS protocols"


### PR DESCRIPTION
The current version is 2.0.33 which is a bit old, so
bump for amd64 for now.

Will do a full STABLEREQ for 2.0.4x once newly keyworded has
had time to settle on it, and they've been in tree the requisite
amount of time.

Signed-off-by: Sam James (sam_c) <sam@cmpct.info>