### PR TITLE
dev-python/flask-restful: drop paging useflag and pycrypto dep

### DIFF
--- a/dev-python/flask-restful/flask-restful-0.3.7-r1.ebuild
+++ b/dev-python/flask-restful/flask-restful-0.3.7-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{6,7} )
+
+inherit distutils-r1
+
+DESCRIPTION="Simple framework for creating REST APIs"
+HOMEPAGE="https://flask-restful.readthedocs.io/en/latest/ https://github.com/twilio/flask-restful/"
+SRC_URI="https://github.com/twilio/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="doc examples test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	>=dev-python/aniso8601-0.82[${PYTHON_USEDEP}]
+	>=dev-python/flask-0.8[${PYTHON_USEDEP}]
+	>=dev-python/six-1.3.0[${PYTHON_USEDEP}]
+	dev-python/pytz[${PYTHON_USEDEP}]
+"
+DEPEND="${RDEPEND}
+	dev-python/sphinx[${PYTHON_USEDEP}]
+	test? (
+		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/nose[${PYTHON_USEDEP}]
+	)
+"
+
+python_test() {
+	nosetests -v || die "Tests fail with ${EPYTHON}"
+}
+
+python_compile_all() {
+	cd docs || die
+	emake man $(usex doc html "")
+}
+
+python_install_all() {
+	use doc && local HTML_DOCS=( docs/_build/html/. )
+	use examples && dodoc -r examples
+	local DOCS=( AUTHORS.md CHANGES.md CONTRIBUTING.md README.md )
+
+	doman docs/_build/man/*
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
https://github.com/flask-restful/flask-restful/commit/517ccfdfadb018f08fc77e484c9448b9715aa06c
Closes: https://bugs.gentoo.org/611594
Package-Manager: Portage-2.3.96, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>