### PR TITLE
dev-libs/boost: Add python 3.8 back

### DIFF
--- a/dev-libs/boost/boost-1.72.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.72.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_{6,7}} )
+PYTHON_COMPAT=( python{2_7,3_{6,7,8}} )
 
 inherit flag-o-matic multiprocessing python-r1 toolchain-funcs multilib-minimal
 
@@ -39,7 +39,7 @@ RDEPEND="
 	mpi? ( >=virtual/mpi-2.0-r4[${MULTILIB_USEDEP},cxx,threads] )
 	python? (
 		${PYTHON_DEPS}
-		numpy? ( dev-python/numpy[${PYTHON_USEDEP}] )
+		numpy? ( $(python_gen_cond_dep 'dev-python/numpy[${PYTHON_USEDEP}]' -3) )
 	)
 	zlib? ( sys-libs/zlib:=[${MULTILIB_USEDEP}] )
 	zstd? ( app-arch/zstd:=[${MULTILIB_USEDEP}] )"

--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -4,6 +4,11 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in package.use.mask
 
+# David Seifert <soap@gentoo.org> (2020-03-31)
+# Numpy support in Boost.Python is brittle and shouldn't be enabled
+# on stable systems or force a stable upgrade.
+dev-libs/boost numpy
+
 # Brian Evans <grknight@gentoo.org> (2020-02-27)
 # Two packages are delayed during stable of PHP 7.4
 # arm, arm64 and hppa necessary to not disruput consistency


### PR DESCRIPTION
Package-Manager: Portage-2.3.96, Repoman-2.3.22
Signed-off-by: David Seifert <soap@gentoo.org>