### PR TITLE
xfce-extra/xfce4-whiskermenu-plugin: Remove obsolete sed call

### DIFF
--- a/xfce-extra/xfce4-whiskermenu-plugin/xfce4-whiskermenu-plugin-2.3.5.ebuild
+++ b/xfce-extra/xfce4-whiskermenu-plugin/xfce4-whiskermenu-plugin-2.3.5.ebuild
@@ -31,13 +31,6 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_prepare() {
-	# fix build failure w/ xfce4-panel-4.15.0
-	sed -i -e 's@<libxfce4panel/xfce-panel-plugin\.h>@<libxfce4panel/libxfce4panel.h>@' \
-		panel-plugin/register-plugin.c || die
-	cmake_src_prepare
-}
-
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_AS_NEEDED=OFF

--- a/xfce-extra/xfce4-whiskermenu-plugin/xfce4-whiskermenu-plugin-2.4.3.ebuild
+++ b/xfce-extra/xfce4-whiskermenu-plugin/xfce4-whiskermenu-plugin-2.4.3.ebuild
@@ -31,13 +31,6 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_prepare() {
-	# fix build failure w/ xfce4-panel-4.15.0
-	sed -i -e 's@<libxfce4panel/xfce-panel-plugin\.h>@<libxfce4panel/libxfce4panel.h>@' \
-		panel-plugin/register-plugin.c || die
-	cmake_src_prepare
-}
-
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_AS_NEEDED=OFF


### PR DESCRIPTION
This was fixed upstream months ago courtesy of @mgorny. See: https://git.xfce.org/panel-plugins/xfce4-whiskermenu-plugin/commit/?id=4c284a5b266eac041dee9829d54679fac8bd3a00