### PR TITLE
sci-libs/vtk: Fix installation path for CMake files

### DIFF
--- a/sci-libs/vtk/vtk-8.1.0-r5.ebuild
+++ b/sci-libs/vtk/vtk-8.1.0-r5.ebuild
@@ -152,6 +152,7 @@ src_configure() {
 		-Wno-dev
 		-DVTK_DIR="${S}"
 		-DVTK_INSTALL_LIBRARY_DIR=$(get_libdir)
+		-DVTK_INSTALL_PACKAGE_DIR="$(get_libdir)/cmake/${PN}-${SPV}"
 		-DVTK_INSTALL_DOC_DIR="${EPREFIX}/usr/share/doc/${PF}"
 		-DVTK_DATA_ROOT="${EPREFIX}/usr/share/${PN}/data"
 		-DVTK_CUSTOM_LIBRARY_SUFFIX=""


### PR DESCRIPTION
On amd64, installation will drop files in /usr/lib64
except for CMake files which will be installed on /usr/lib.

This fixes the installation path for the CMake files (/usr/lib64).