### PR TITLE
sci-libs/scikits_learn: bug fix

### DIFF
--- a/sci-libs/scikits_learn/scikits_learn-0.22.2_p1.ebuild
+++ b/sci-libs/scikits_learn/scikits_learn-0.22.2_p1.ebuild
@@ -19,8 +19,7 @@ S="${WORKDIR}/${MY_PN}-${MY_PV}"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="test"
-RESTRICT="!test? ( test )"
+IUSE="examples"
 
 RDEPEND="
 	dev-python/wheel[${PYTHON_USEDEP}]


### PR DESCRIPTION
fixes missing IUSE="examples" bug

Closes: https://bugs.gentoo.org/716016
Package-Manager: Portage-2.3.96, Repoman-2.3.22
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>