### PR TITLE
sci-libs/vtk: Fix wrong installation path for libQVTKWidgetPlugin.so

### DIFF
--- a/sci-libs/vtk/vtk-8.1.0-r5.ebuild
+++ b/sci-libs/vtk/vtk-8.1.0-r5.ebuild
@@ -254,7 +254,7 @@ src_configure() {
 			-DVTK_USE_QVTK_QTOPENGL=ON
 			-DQT_WRAP_CPP=ON
 			-DQT_WRAP_UI=ON
-			-DVTK_INSTALL_QT_DIR="$(qt5_get_libdir)/qt5/plugins/designer"
+			-DVTK_INSTALL_QT_DIR="$(basename $(qt5_get_libdir))/qt5/plugins/designer"
 			-DDESIRED_QT_VERSION=5
 			-DVTK_QT_VERSION=5
 			-DQT_MOC_EXECUTABLE="$(qt5_get_bindir)/moc"


### PR DESCRIPTION
This fixes the wrong installation path of libQVTKWidgetPlugin.so. From
/usr/usr/... --> /usr/...

Closes: https://bugs.gentoo.org/646422
Signed-off-by: Rafael Palomar Ávalos <rafael.palomar@rr-research.no>