### PR TITLE
dev-util/rt-tests: Fix musl build

### DIFF
--- a/dev-util/rt-tests/files/rt-tests-1.8-musl.patch
+++ b/dev-util/rt-tests/files/rt-tests-1.8-musl.patch
@@ -1,0 +1,380 @@
+From 4daa685588ee3848fc98fd9c6328b76f136ee876 Mon Sep 17 00:00:00 2001
+From: Kurt Kanzenbach <kurt@kmk-computers.de>
+Date: Wed, 1 Apr 2020 20:15:24 +0200
+Subject: [PATCH] all: Fix musl build
+
+There are a few problems:
+
+ * pi stress:  pthread_attr_setaffinity_np() is not supported
+ * cyclictest: SIGEV_THREAD_ID is not supported
+ * hackbench:  Fix include
+ * all:        Fix sched_* calls
+
+With these changes applied, the rt-tests seem to run fine.
+
+Signed-off-by: Kurt Kanzenbach <kurt@kmk-computers.de>
+---
+ Makefile                              |  5 --
+ src/backfire/sendme.c                 |  1 +
+ src/cyclictest/cyclictest.c           | 68 ++++-----------------------
+ src/hackbench/hackbench.c             |  4 +-
+ src/include/musl.h                    | 28 +++++++++++
+ src/lib/rt-utils.c                    |  1 +
+ src/pi_tests/classic_pi.c             |  2 +
+ src/pi_tests/tst-mutexpi10.c          |  2 +
+ src/pmqtest/pmqtest.c                 |  1 +
+ src/ptsematest/ptsematest.c           |  1 +
+ src/rt-migrate-test/rt-migrate-test.c |  1 +
+ src/sched_deadline/cyclicdeadline.c   |  2 +
+ 12 files changed, 50 insertions(+), 66 deletions(-)
+ create mode 100644 src/include/musl.h
+
+diff --git a/Makefile b/Makefile
+index 05fc5eda71fa..9340f28f2c32 100644
+--- a/Makefile
++++ b/Makefile
+@@ -7,7 +7,6 @@ OBJDIR = bld
+ sources = cyclictest.c \
+ 	  hackbench.c \
+ 	  pip_stress.c \
+-	  pi_stress.c \
+ 	  pmqtest.c \
+ 	  ptsematest.c \
+ 	  rt-migrate-test.c \
+@@ -35,7 +34,6 @@ LDFLAGS ?=
+ PYLIB  ?= $(shell python3 -c 'import distutils.sysconfig;  print (distutils.sysconfig.get_python_lib())')
+ 
+ MANPAGES = src/cyclictest/cyclictest.8 \
+-	   src/pi_tests/pi_stress.8 \
+ 	   src/ptsematest/ptsematest.8 \
+ 	   src/rt-migrate-test/rt-migrate-test.8 \
+ 	   src/sigwaittest/sigwaittest.8 \
+@@ -125,9 +123,6 @@ deadline_test: $(OBJDIR)/deadline_test.o $(OBJDIR)/librttest.a
+ signaltest: $(OBJDIR)/signaltest.o $(OBJDIR)/librttest.a
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LIBS) $(RTTESTLIB)
+ 
+-pi_stress: $(OBJDIR)/pi_stress.o $(OBJDIR)/librttest.a
+-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LIBS) $(RTTESTLIB)
+-
+ hwlatdetect:  src/hwlatdetect/hwlatdetect.py
+ 	chmod +x src/hwlatdetect/hwlatdetect.py
+ 	ln -s src/hwlatdetect/hwlatdetect.py hwlatdetect
+diff --git a/src/backfire/sendme.c b/src/backfire/sendme.c
+index c1854d9660cb..ecec5c201bef 100644
+--- a/src/backfire/sendme.c
++++ b/src/backfire/sendme.c
+@@ -31,6 +31,7 @@
+ #include <errno.h>
+ #include "rt-utils.h"
+ #include "rt-get_cpu.h"
++#include "musl.h"
+ 
+ #include <utmpx.h>
+ #include <sys/types.h>
+diff --git a/src/cyclictest/cyclictest.c b/src/cyclictest/cyclictest.c
+index c5f1fd46567a..8204e57cbbac 100644
+--- a/src/cyclictest/cyclictest.c
++++ b/src/cyclictest/cyclictest.c
+@@ -36,6 +36,7 @@
+ #include "rt_numa.h"
+ 
+ #include "rt-utils.h"
++#include "musl.h"
+ 
+ #include <bionic.h>
+ 
+@@ -628,12 +629,8 @@ static void *timerthread(void *param)
+ {
+ 	struct thread_param *par = param;
+ 	struct sched_param schedp;
+-	struct sigevent sigev;
+ 	sigset_t sigset;
+-	timer_t timer;
+ 	struct timespec now, next, interval, stop;
+-	struct itimerval itimer;
+-	struct itimerspec tspec;
+ 	struct thread_stat *stat = par->stats;
+ 	int stopped = 0;
+ 	cpu_set_t mask;
+@@ -664,14 +661,6 @@ static void *timerthread(void *param)
+ 	sigaddset(&sigset, par->signal);
+ 	sigprocmask(SIG_BLOCK, &sigset, NULL);
+ 
+-	if (par->mode == MODE_CYCLIC) {
+-		sigev.sigev_notify = SIGEV_THREAD_ID | SIGEV_SIGNAL;
+-		sigev.sigev_signo = par->signal;
+-		sigev.sigev_notify_thread_id = stat->tid;
+-		timer_create(par->clock, &sigev, &timer);
+-		tspec.it_interval = interval;
+-	}
+-
+ 	memset(&schedp, 0, sizeof(schedp));
+ 	schedp.sched_priority = par->prio;
+ 	if (setscheduler(0, par->policy, &schedp))
+@@ -726,20 +715,6 @@ static void *timerthread(void *param)
+ 		stop = now;
+ 		stop.tv_sec += duration;
+ 	}
+-	if (par->mode == MODE_CYCLIC) {
+-		if (par->timermode == TIMER_ABSTIME)
+-			tspec.it_value = next;
+-		else
+-			tspec.it_value = interval;
+-		timer_settime(timer, par->timermode, &tspec, NULL);
+-	}
+-
+-	if (par->mode == MODE_SYS_ITIMER) {
+-		itimer.it_interval.tv_sec = interval.tv_sec;
+-		itimer.it_interval.tv_usec = interval.tv_nsec / 1000;
+-		itimer.it_value = itimer.it_interval;
+-		setitimer(ITIMER_REAL, &itimer, NULL);
+-	}
+ 
+ 	stat->threadstarted++;
+ 
+@@ -747,16 +722,10 @@ static void *timerthread(void *param)
+ 
+ 		uint64_t diff;
+ 		unsigned long diff_smi = 0;
+-		int sigs, ret;
++		int ret;
+ 
+ 		/* Wait for next period */
+ 		switch (par->mode) {
+-		case MODE_CYCLIC:
+-		case MODE_SYS_ITIMER:
+-			if (sigwait(&sigset, &sigs) < 0)
+-				goto out;
+-			break;
+-
+ 		case MODE_CLOCK_NANOSLEEP:
+ 			if (par->timermode == TIMER_ABSTIME) {
+ 				ret = clock_nanosleep(par->clock, TIMER_ABSTIME,
+@@ -878,11 +847,6 @@ static void *timerthread(void *param)
+ 
+ 		next.tv_sec += interval.tv_sec;
+ 		next.tv_nsec += interval.tv_nsec;
+-		if (par->mode == MODE_CYCLIC) {
+-			int overrun_count = timer_getoverrun(timer);
+-			next.tv_sec += overrun_count * interval.tv_sec;
+-			next.tv_nsec += overrun_count * interval.tv_nsec;
+-		}
+ 		tsnorm(&next);
+ 
+ 		while (tsgreater(&now, &next)) {
+@@ -907,17 +871,6 @@ out:
+ 		pthread_mutex_unlock(&refresh_on_max_lock);
+ 	}
+ 
+-	if (par->mode == MODE_CYCLIC)
+-		timer_delete(timer);
+-
+-	if (par->mode == MODE_SYS_ITIMER) {
+-		itimer.it_value.tv_sec = 0;
+-		itimer.it_value.tv_usec = 0;
+-		itimer.it_interval.tv_sec = 0;
+-		itimer.it_interval.tv_usec = 0;
+-		setitimer(ITIMER_REAL, &itimer, NULL);
+-	}
+-
+ 	/* close msr file */
+ 	if (smi)
+ 		close(par->msr_fd);
+@@ -1417,7 +1370,8 @@ static void process_options (int argc, char *argv[], int max_cpus)
+ 		case OPT_VERBOSE: verbose = 1; break;
+ 		case 'x':
+ 		case OPT_POSIX_TIMERS:
+-			use_nanosleep = MODE_CYCLIC; break;
++			fatal("--posix_timers is not available on your libc\n");
++			break;
+ 		case '?':
+ 		case OPT_HELP:
+ 			display_help(0); break;
+@@ -1450,13 +1404,6 @@ static void process_options (int argc, char *argv[], int max_cpus)
+ 		}
+ 	}
+ 
+-	if ((use_system == MODE_SYS_OFFSET) && (use_nanosleep == MODE_CYCLIC)) {
+-		warn("The system option requires clock_nanosleep\n");
+-		warn("and is not compatible with posix_timers\n");
+-		warn("Using clock_nanosleep\n");
+-		use_nanosleep = MODE_CLOCK_NANOSLEEP;
+-	}
+-
+ 	/* if smp wasn't requested, test for numa automatically */
+ 	if (!smp) {
+ #ifdef NUMA
+@@ -2157,7 +2104,6 @@ int main(int argc, char **argv)
+ 
+ 	}
+ 
+-
+ 	mode = use_nanosleep + use_system;
+ 
+ 	sigemptyset(&sigset);
+@@ -2207,16 +2153,18 @@ int main(int argc, char **argv)
+ 			void *stack;
+ 			void *currstk;
+ 			size_t stksize;
++			int err;
+ 
+ 			/* find the memory node associated with the cpu i */
+ 			node = rt_numa_numa_node_of_cpu(cpu);
+ 
+ 			/* get the stack size set for for this thread */
+-			if (pthread_attr_getstack(&attr, &currstk, &stksize))
++			err = pthread_attr_getstack(&attr, &currstk, &stksize);
++			if (err != EINVAL)
+ 				fatal("failed to get stack size for thread %d\n", i);
+ 
+ 			/* if the stack size is zero, set a default */
+-			if (stksize == 0)
++			if (err == EINVAL || stksize == 0)
+ 				stksize = PTHREAD_STACK_MIN * 2;
+ 
+ 			/*  allocate memory for a stack on appropriate node */
+diff --git a/src/hackbench/hackbench.c b/src/hackbench/hackbench.c
+index 5a883d341f2e..9f1e4db736a7 100644
+--- a/src/hackbench/hackbench.c
++++ b/src/hackbench/hackbench.c
+@@ -24,13 +24,15 @@
+ #include <sys/socket.h>
+ #include <sys/wait.h>
+ #include <sys/time.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <limits.h>
+ #include <getopt.h>
+ #include <signal.h>
+ #include <setjmp.h>
+ #include <sched.h>
+ 
++#include "musl.h"
++
+ static unsigned int datasize = 100;
+ static unsigned int loops = 100;
+ static unsigned int num_groups = 10;
+diff --git a/src/include/musl.h b/src/include/musl.h
+new file mode 100644
+index 000000000000..ea5075e768c8
+--- /dev/null
++++ b/src/include/musl.h
+@@ -0,0 +1,28 @@
++/*
++ * Copyright (C) 2020 Kurt Kanzenbach <kurt@kmk-computers.de>
++ * Time-stamp: <2020-04-04 10:54:01 kurt>
++ */
++
++#ifndef _MUSL_H_
++#define _MUSL_H_
++
++#include <unistd.h>
++#include <sys/syscall.h>
++
++/*
++ * Musl someshow defines sched_* to ENOSYS which is not correct ...
++ * See commit 1e21e78bf7a5 ("add support for thread scheduling (POSIX TPS option)")
++ *
++ * Workaround: define them to syscall(...)
++ */
++
++#define sched_getparam(pid, param)		\
++	syscall(SYS_sched_getparam, pid, param)
++#define sched_setparam(pid, param)		\
++	syscall(SYS_sched_setparam, pid, param)
++#define sched_getscheduler(pid)			\
++	syscall(SYS_sched_getscheduler, pid)
++#define sched_setscheduler(pid, policy, param)			\
++	syscall(SYS_sched_setscheduler, pid, policy, param)
++
++#endif /* _MUSL_H_ */
+diff --git a/src/lib/rt-utils.c b/src/lib/rt-utils.c
+index 1998a327d036..f7adda9c5987 100644
+--- a/src/lib/rt-utils.c
++++ b/src/lib/rt-utils.c
+@@ -23,6 +23,7 @@
+ #include "rt-utils.h"
+ #include "rt-sched.h"
+ #include "error.h"
++#include "musl.h"
+ 
+ static char debugfileprefix[MAX_PATH];
+ 
+diff --git a/src/pi_tests/classic_pi.c b/src/pi_tests/classic_pi.c
+index 64af8890276f..bb088d3973b2 100644
+--- a/src/pi_tests/classic_pi.c
++++ b/src/pi_tests/classic_pi.c
+@@ -34,6 +34,8 @@
+ #include <signal.h>
+ #include <getopt.h>
+ 
++#include "musl.h"
++
+ /* test timeout */
+ #define TIMEOUT 2
+ 
+diff --git a/src/pi_tests/tst-mutexpi10.c b/src/pi_tests/tst-mutexpi10.c
+index 97a345edd26e..1028d344edff 100644
+--- a/src/pi_tests/tst-mutexpi10.c
++++ b/src/pi_tests/tst-mutexpi10.c
+@@ -35,6 +35,8 @@
+ #include <string.h>
+ #include <signal.h>
+ 
++#include "musl.h"
++
+ /* test timeout */
+ #define TIMEOUT 2
+ 
+diff --git a/src/pmqtest/pmqtest.c b/src/pmqtest/pmqtest.c
+index 3ce29252b9a2..1a57841cb7e8 100644
+--- a/src/pmqtest/pmqtest.c
++++ b/src/pmqtest/pmqtest.c
+@@ -24,6 +24,7 @@
+ #include "rt-utils.h"
+ #include "rt-get_cpu.h"
+ #include "error.h"
++#include "musl.h"
+ 
+ #include <pthread.h>
+ 
+diff --git a/src/ptsematest/ptsematest.c b/src/ptsematest/ptsematest.c
+index 485c991ec173..c000e083615f 100644
+--- a/src/ptsematest/ptsematest.c
++++ b/src/ptsematest/ptsematest.c
+@@ -22,6 +22,7 @@
+ #include "rt-utils.h"
+ #include "rt-get_cpu.h"
+ #include "error.h"
++#include "musl.h"
+ 
+ #include <pthread.h>
+ 
+diff --git a/src/rt-migrate-test/rt-migrate-test.c b/src/rt-migrate-test/rt-migrate-test.c
+index 4863238edeb4..9f1aba159dc7 100644
+--- a/src/rt-migrate-test/rt-migrate-test.c
++++ b/src/rt-migrate-test/rt-migrate-test.c
+@@ -25,6 +25,7 @@
+ #include <sched.h>
+ #include <pthread.h>
+ #include "rt-utils.h"
++#include "musl.h"
+ 
+ int nr_tasks;
+ int lfd;
+diff --git a/src/sched_deadline/cyclicdeadline.c b/src/sched_deadline/cyclicdeadline.c
+index a08e28e73c42..675a0ea1a162 100644
+--- a/src/sched_deadline/cyclicdeadline.c
++++ b/src/sched_deadline/cyclicdeadline.c
+@@ -32,6 +32,8 @@
+ #include <rt-utils.h>
+ #include <rt-sched.h>
+ 
++#include "musl.h"
++
+ #define _STR(x) #x
+ #define STR(x) _STR(x)
+ #ifndef MAXPATH
+-- 
+2.24.1
+

--- a/dev-util/rt-tests/rt-tests-1.8.ebuild
+++ b/dev-util/rt-tests/rt-tests-1.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=(python3_{6,7,8})
+PYTHON_COMPAT=( python3_{6..8} )
 
 inherit python-single-r1
 
@@ -21,6 +21,11 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 DEPEND="${PYTHON_DEPS}
 	sys-process/numactl"
 RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+	use elibc_musl && eapply "${FILESDIR}/${P}-musl.patch"
+}
 
 src_install() {
 	emake prefix=/usr DESTDIR="${D}" MAN_COMPRESSION=none install


### PR DESCRIPTION
A few changes have to be made and features disabled for rt-tests to run on a musl enabled system. 

Closes: https://bugs.gentoo.org/712660
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Kurt Kanzenbach <kurt@kmk-computers.de>