### PR TITLE
dev-libs/bglibs: properly align buffers on stack

### DIFF
--- a/dev-libs/bglibs/bglibs-2.04-r2.ebuild
+++ b/dev-libs/bglibs/bglibs-2.04-r2.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Bruce Guenter's Libraries Collection"
+HOMEPAGE="https://untroubled.org/bglibs/"
+SRC_URI="https://untroubled.org/bglibs/archive/${P}.tar.gz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0/2"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="doc"
+
+RDEPEND=""
+DEPEND=""
+BDEPEND="sys-devel/libtool
+	doc? (
+		app-doc/doxygen
+		dev-texlive/texlive-latexrecommended
+		dev-texlive/texlive-latex
+		dev-texlive/texlive-latexextra
+		virtual/latex-base
+	)
+"
+
+PATCHES=( "${FILESDIR}"/bglibs-2.04-stack-buffers.patch )
+
+src_prepare() {
+	default
+	# disable tests as we want them manually
+	sed -i '/^all:/s|selftests||' Makefile || die
+	sed -i '/selftests/d' TARGETS || die
+}
+
+src_configure() {
+	echo "${ED}/usr/bin" > conf-bin || die
+	echo "${ED}/usr/$(get_libdir)/bglibs" > conf-lib || die
+	echo "${ED}/usr/include" > conf-include || die
+	echo "${ED}/usr/share/man" > conf-man || die
+	echo "$(tc-getCC) ${CFLAGS}" > conf-cc || die
+	echo "$(tc-getCC) ${LDFLAGS}" > conf-ld || die
+}
+
+src_compile() {
+	default
+	if use doc; then
+		emake -C doc/latex pdf
+	fi
+}
+
+src_test() {
+	einfo "Running selftests"
+	emake selftests
+}
+
+src_install() {
+	default
+
+	# Install .so into LDPATH
+	mv "${ED}"/usr/$(get_libdir)/bglibs/libbg.so.2.0.0 "${ED}"/usr/$(get_libdir)/ || die
+	dosym libbg.so.2.0.0 /usr/$(get_libdir)/libbg.so.2
+	dosym libbg.so.2.0.0 /usr/$(get_libdir)/libbg.so
+	dosym ../libbg.so.2.0.0 /usr/$(get_libdir)/bglibs/libbg.so.2.0.0
+
+	rm "${ED}"/usr/$(get_libdir)/bglibs/libbg.la || die
+
+	dodoc ANNOUNCEMENT NEWS README ChangeLog TODO VERSION
+	dodoc -r doc/html/
+	if use doc; then
+		dodoc doc/latex/refman.pdf
+	fi
+}

--- a/dev-libs/bglibs/files/bglibs-2.04-stack-buffers.patch
+++ b/dev-libs/bglibs/files/bglibs-2.04-stack-buffers.patch
@@ -1,0 +1,47 @@
+From 25252211283e05c692c8baf3e8a7c70224821762 Mon Sep 17 00:00:00 2001
+From: Rolf Eike Beer <eike@sf-mail.de>
+Date: Fri, 15 Nov 2019 19:40:22 +0100
+Subject: [PATCH] properly align the HMAC state buffers on the stack
+
+They need to have the same alignment as the contained data type, i.e. up to
+uint64. Otherwise usage of SHA HMACs causes bus errors on sparc.
+---
+ crypto/hmac.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/crypto/hmac.c b/crypto/hmac.c
+index abff0df..f4e48c0 100644
+--- a/crypto/hmac.c
++++ b/crypto/hmac.c
+@@ -34,7 +34,8 @@ void hmac_prepare(const struct hmac_control_block* hcb,
+ 		  void* midstate,
+ 		  const str* secret)
+ {
+-  unsigned char state[hcb->state_size];
++  uint64 statebuf[(hcb->state_size + 7) / sizeof(uint64)];
++  unsigned char *state = (unsigned char *)statebuf;
+   unsigned char block[hcb->block_size];
+   unsigned i;
+ 
+@@ -80,8 +81,9 @@ void hmac_finish(const struct hmac_control_block* hcb,
+ 		 const str* nonce,
+ 		 void* output)
+ {
+-  unsigned char state[hcb->state_size];
+-  
++  uint64 statebuf[(hcb->state_size + 7) / sizeof(uint64)];
++  unsigned char *state = (unsigned char *)statebuf;
++
+   /* Generate H1 = H(K XOR ipad, nonce) */
+   hcb->inject(state, midstate);
+   hcb->update(state, (const unsigned char*)nonce->s, nonce->len);
+@@ -106,7 +108,8 @@ void hmac(const struct hmac_control_block* hcb,
+ 	  const str* nonce,
+ 	  void* output)
+ {
+-  unsigned char midstate[hcb->state_size*2];
++  uint64 statebuf[(hcb->state_size * 2 + 7) / sizeof(uint64)];
++  unsigned char *midstate = (unsigned char *)statebuf;
+ 
+   hmac_prepare(hcb, midstate, secret);
+   hmac_finish(hcb, midstate, nonce, output);


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/700190

Reported upstream as bruceg/bglibs#1, but no reaction.