### PR TITLE
app-leechcraft: fix qtsql deps, bump some EAPIs and minor fixes

### DIFF
--- a/app-leechcraft/lc-aggregator/lc-aggregator-9999.ebuild
+++ b/app-leechcraft/lc-aggregator/lc-aggregator-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit leechcraft
 
@@ -9,19 +9,21 @@ DESCRIPTION="Full-featured RSS/Atom feed reader for LeechCraft"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="debug mysql +sqlite postgres"
+IUSE="debug mysql postgres +sqlite"
 
 DEPEND="
-	~app-leechcraft/lc-core-${PV}[postgres?,sqlite?]
+	~app-leechcraft/lc-core-${PV}[postgres?]
 	dev-qt/qtcore:5
 	dev-qt/qtnetwork:5
 	dev-qt/qtprintsupport:5
-	dev-qt/qtsql:5[sqlite?,postgres?,mysql?]
+	dev-qt/qtsql:5
 	dev-qt/qtwebkit:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5"
 RDEPEND="${DEPEND}
-		virtual/leechcraft-downloader-http"
+	dev-qt/qtsql:5[mysql?,postgres?,sqlite?]
+	virtual/leechcraft-downloader-http
+"
 
 REQUIRED_USE="|| ( mysql sqlite postgres )"
 

--- a/app-leechcraft/lc-azoth/lc-azoth-9999.ebuild
+++ b/app-leechcraft/lc-azoth/lc-azoth-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit leechcraft
+inherit xdg-utils leechcraft
 
 DESCRIPTION="Azoth, the modular IM client for LeechCraft"
 
@@ -114,4 +114,10 @@ pkg_postinst() {
 		elog "so install the ones for languages you use to enable"
 		elog "spellchecking."
 	fi
+
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
 }

--- a/app-leechcraft/lc-azoth/lc-azoth-9999.ebuild
+++ b/app-leechcraft/lc-azoth/lc-azoth-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit leechcraft
 
@@ -37,11 +37,11 @@ COMMON_DEPEND="
 	)
 	sarin? (
 		dev-qt/qtconcurrent:5
-		net-libs/tox
+		net-libs/tox:=
 	)
 	woodpecker? ( dev-libs/kqoauth )
 	xmpp? (
-		>=net-libs/qxmpp-0.9.3-r1
+		>=net-libs/qxmpp-1.2.0
 		media? ( net-libs/qxmpp[speex] )
 	)
 	xtazy? ( ~app-leechcraft/lc-xtazy-${PV} )
@@ -98,11 +98,11 @@ src_configure() {
 		-DENABLE_AZOTH_XTAZY=$(usex xtazy)
 	)
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 	use doc && dodoc -r "${CMAKE_BUILD_DIR}"/out/html/*
 }
 

--- a/app-leechcraft/lc-azoth/lc-azoth-9999.ebuild
+++ b/app-leechcraft/lc-azoth/lc-azoth-9999.ebuild
@@ -50,6 +50,7 @@ DEPEND="${COMMON_DEPEND}
 	doc? ( app-doc/doxygen[dot] )
 "
 RDEPEND="${COMMON_DEPEND}
+	dev-qt/qtsql:5[sqlite]
 	astrality? (
 		net-im/telepathy-mission-control
 		net-voip/telepathy-haze

--- a/app-leechcraft/lc-bittorrent/lc-bittorrent-9999.ebuild
+++ b/app-leechcraft/lc-bittorrent/lc-bittorrent-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit leechcraft
+inherit xdg-utils leechcraft
 
 DESCRIPTION="Full-featured BitTorrent client plugin for LeechCraft"
 
@@ -27,4 +27,12 @@ src_configure() {
 		-DENABLE_BITTORRENT_GEOIP=$(usex geoip)
 	)
 	cmake-utils_src_configure
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
 }

--- a/app-leechcraft/lc-blogique/lc-blogique-9999.ebuild
+++ b/app-leechcraft/lc-blogique/lc-blogique-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit leechcraft
 
@@ -13,11 +13,11 @@ IUSE="debug +metida +hestia"
 
 DEPEND="
 	~app-leechcraft/lc-core-${PV}
+	dev-qt/qtdeclarative:5
+	dev-qt/qtprintsupport:5
 	dev-qt/qtsql:5
 	dev-qt/qtwebkit:5
 	dev-qt/qtxml:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtdeclarative:5
 	metida? (
 		dev-qt/qtnetwork:5
 		dev-qt/qtxmlpatterns:5
@@ -33,5 +33,5 @@ src_configure() {
 		-DENABLE_BLOGIQUE_HESTIA=$(usex hestia)
 	)
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/app-leechcraft/lc-blogique/lc-blogique-9999.ebuild
+++ b/app-leechcraft/lc-blogique/lc-blogique-9999.ebuild
@@ -24,8 +24,9 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}
+	dev-qt/qtsql:5[sqlite]
 	virtual/leechcraft-wysiwyg-editor
-	"
+"
 
 src_configure() {
 	local mycmakeargs=(

--- a/app-leechcraft/lc-core/lc-core-9999.ebuild
+++ b/app-leechcraft/lc-core/lc-core-9999.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="Core of LeechCraft, the modular network client"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="debug doc postgres +qwt +sqlite"
+IUSE="debug doc postgres +qwt"
 
 DEPEND="
 	dev-libs/boost:=
@@ -22,7 +22,7 @@ DEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtnetwork:5[ssl]
 	dev-qt/qtscript:5
-	dev-qt/qtsql:5[postgres?,sqlite?]
+	dev-qt/qtsql:5
 	dev-qt/qtwebkit:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
@@ -30,6 +30,7 @@ DEPEND="
 	qwt? ( x11-libs/qwt:6 )
 "
 RDEPEND="${DEPEND}
+	dev-qt/qtsql:5[postgres?,sqlite]
 	dev-qt/qtsvg:5
 	|| (
 		kde-frameworks/oxygen-icons
@@ -40,8 +41,6 @@ BDEPEND="
 	dev-qt/linguist-tools:5
 	doc? ( app-doc/doxygen )
 "
-
-REQUIRED_USE="|| ( postgres sqlite )"
 
 src_configure() {
 	local mycmakeargs=(

--- a/app-leechcraft/lc-core/lc-core-9999.ebuild
+++ b/app-leechcraft/lc-core/lc-core-9999.ebuild
@@ -14,7 +14,7 @@ KEYWORDS=""
 IUSE="debug doc postgres +qwt +sqlite"
 
 DEPEND="
-	>=dev-libs/boost-1.62
+	dev-libs/boost:=
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5

--- a/app-leechcraft/lc-historyholder/lc-historyholder-9999.ebuild
+++ b/app-leechcraft/lc-historyholder/lc-historyholder-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit leechcraft
 
@@ -12,10 +12,12 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
-	dev-qt/qtnetwork:5
-	dev-qt/qtwidgets:5
 	dev-qt/qtconcurrent:5
-	dev-qt/qtsql:5[sqlite]
+	dev-qt/qtnetwork:5
+	dev-qt/qtsql:5
+	dev-qt/qtwidgets:5
 "
 RDEPEND="${DEPEND}
-		~virtual/leechcraft-search-show-${PV}"
+	dev-qt/qtsql:5[sqlite]
+	~virtual/leechcraft-search-show-${PV}
+"

--- a/app-leechcraft/lc-lackman/lc-lackman-9999.ebuild
+++ b/app-leechcraft/lc-lackman/lc-lackman-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit leechcraft
 
@@ -13,10 +13,12 @@ IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
 	dev-qt/qtnetwork:5
+	dev-qt/qtsql:5
 	dev-qt/qtwidgets:5
-	dev-qt/qtsql:5[sqlite]
 	dev-qt/qtxml:5
 	dev-qt/qtxmlpatterns:5
 "
 RDEPEND="${DEPEND}
-		~virtual/leechcraft-downloader-http-${PV}"
+	dev-qt/qtsql:5[sqlite]
+	~virtual/leechcraft-downloader-http-${PV}
+"

--- a/app-leechcraft/lc-lmp/lc-lmp-9999.ebuild
+++ b/app-leechcraft/lc-lmp/lc-lmp-9999.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	dev-qt/qtconcurrent:5
 	dev-qt/qtdeclarative:5[widgets]
 	dev-qt/qtnetwork:5
-	dev-qt/qtsql:5[sqlite]
+	dev-qt/qtsql:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
 	media-libs/gstreamer:1.0
@@ -26,8 +26,10 @@ DEPEND="
 	potorchu? ( media-libs/libprojectm:= )
 "
 RDEPEND="${DEPEND}
+	dev-qt/qtsql:5[sqlite]
 	graffiti? ( media-libs/flac )
-	mtp? ( ~app-leechcraft/lc-devmon-${PV} )"
+	mtp? ( ~app-leechcraft/lc-devmon-${PV} )
+"
 
 src_configure() {
 	local mycmakeargs=(

--- a/app-leechcraft/lc-lmp/lc-lmp-9999.ebuild
+++ b/app-leechcraft/lc-lmp/lc-lmp-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit leechcraft
 
@@ -22,8 +22,9 @@ DEPEND="
 	media-libs/gstreamer:1.0
 	media-libs/taglib
 	mpris? ( dev-qt/qtdbus:5 )
-	mtp? ( media-libs/libmtp )
-	potorchu? ( media-libs/libprojectm )"
+	mtp? ( media-libs/libmtp:= )
+	potorchu? ( media-libs/libprojectm:= )
+"
 RDEPEND="${DEPEND}
 	graffiti? ( media-libs/flac )
 	mtp? ( ~app-leechcraft/lc-devmon-${PV} )"
@@ -38,5 +39,5 @@ src_configure() {
 		-DENABLE_LMP_MTPSYNC=$(usex mtp)
 		-DENABLE_LMP_POTORCHU=$(usex potorchu)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/app-leechcraft/lc-lmp/lc-lmp-9999.ebuild
+++ b/app-leechcraft/lc-lmp/lc-lmp-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit leechcraft
+inherit xdg-utils leechcraft
 
 DESCRIPTION="LeechCraft Media Player, Phonon-based audio/video player"
 
@@ -42,4 +42,12 @@ src_configure() {
 		-DENABLE_LMP_POTORCHU=$(usex potorchu)
 	)
 	cmake_src_configure
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
 }

--- a/app-leechcraft/lc-newlife/lc-newlife-9999.ebuild
+++ b/app-leechcraft/lc-newlife/lc-newlife-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit leechcraft
 
@@ -13,8 +13,10 @@ IUSE="debug"
 
 DEPEND="~app-leechcraft/lc-core-${PV}
 	dev-qt/qtnetwork:5
+	dev-qt/qtsql:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
+"
+RDEPEND="${DEPEND}
 	dev-qt/qtsql:5[sqlite]
 "
-RDEPEND="${DEPEND}"

--- a/app-leechcraft/lc-poshuku/lc-poshuku-9999.ebuild
+++ b/app-leechcraft/lc-poshuku/lc-poshuku-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit leechcraft
 
@@ -12,19 +12,22 @@ KEYWORDS=""
 IUSE="+autosearch debug +dcac +cleanweb +fatape +filescheme +foc +fua +idn +keywords +onlinebookmarks
 	  postgres qrd +speeddial +sqlite webengine +webkit"
 
-DEPEND="~app-leechcraft/lc-core-${PV}[postgres?,sqlite?]
-	dev-qt/qtwidgets:5
+DEPEND="~app-leechcraft/lc-core-${PV}[postgres?]
 	dev-qt/qtnetwork:5
-	dev-qt/qtxml:5
 	dev-qt/qtprintsupport:5
+	dev-qt/qtsql:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtxml:5
 	cleanweb? ( dev-qt/qtconcurrent:5 )
-	idn? ( net-dns/libidn )
-	qrd? ( media-gfx/qrencode )
+	idn? ( net-dns/libidn:= )
+	qrd? ( media-gfx/qrencode:= )
 	webkit? ( dev-qt/qtwebkit:5 )
 	webengine? ( dev-qt/qtwebengine:5 )
 "
 RDEPEND="${DEPEND}
-	virtual/leechcraft-downloader-http"
+	dev-qt/qtsql:5[postgres?,sqlite?]
+	virtual/leechcraft-downloader-http
+"
 
 REQUIRED_USE="|| ( postgres sqlite )
 	|| ( webkit webengine )"
@@ -47,5 +50,5 @@ src_configure() {
 		-DENABLE_POSHUKU_WEBENGINEVIEW=$(usex webengine)
 	)
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }


### PR DESCRIPTION
* Moved the dependency on the specific `qtsql` DB engines to `RDEPEND`, since the code doesn't care about what engines does `qtsql` support until run time.
* Bumped EAPI to 7 for the modified ebuilds.
* Added subslots operators where relevant.
* Added `xdg_desktop_database_update` to `pkg_postinst`/`pkg_postrm` functions of ebuilds that install `.desktop` files.
* Some other minor fixes.