### PR TITLE
media-gfx/opencsg: fix opengles2 related issue

### DIFF
--- a/media-gfx/opencsg/metadata.xml
+++ b/media-gfx/opencsg/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>waebbl@gmail.com</email>
+		<name>Bernd Waibel</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<description>Gentoo Proxy Maintainers</description>
+	</maintainer>
 	<longdescription>
 		OpenCSG is a library that does image-based CSG rendering using
 		OpenGL. OpenCSG is written in C++ and supports most modern
@@ -10,7 +17,7 @@
 		Geometry and denotes an approach to model complex 3D-shapes using
 		simpler ones. I.e., two shapes can be combined by taking the union
 		of them, by intersecting them, or by subtracting one shape of the
-		other.  SG is often used as fundamental modeling technique in CAD/CAM
+		other. CSG is often used as fundamental modeling technique in CAD/CAM
 		applications. Here, image-based CSG rendering is the key to
 		interactively manipulate CSG shapes. Since OpenCSG renders even
 		complex CSG shapes fast, it can be advantageously used in such

--- a/media-gfx/opencsg/opencsg-1.4.2-r2.ebuild
+++ b/media-gfx/opencsg/opencsg-1.4.2-r2.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit qmake-utils
+
+MY_P="OpenCSG-${PV}"
+DESCRIPTION="The Constructive Solid Geometry rendering library"
+HOMEPAGE="http://www.opencsg.org"
+SRC_URI="http://www.opencsg.org/${MY_P}.tar.gz"
+
+# RenderTexture is licensed BSD, OpenCSG is licensed GPL-2
+LICENSE="GPL-2 BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc"
+
+RDEPEND="
+	dev-libs/libbsd
+	media-libs/glew:0=
+	virtual/opengl
+	x11-libs/libX11
+	x11-libs/libXau
+	x11-libs/libXdmcp
+	x11-libs/libXext
+	x11-libs/libxcb:=
+"
+# qtgui is needed for opengles2 feature by
+# /usr/$(get_libdir)/qt5/mkspecs/features/unix/opengl.prf
+DEPEND="${RDEPEND}
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+"
+
+DOCS=( build.txt changelog.txt license.txt version.txt )
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-includepath.patch"
+)
+
+src_prepare() {
+	default
+
+	# removes duplicated headers
+	rm -r glew || die "failed to remove bundled glew"
+}
+
+src_configure() {
+	eqmake5 opencsg.pro INSTALLDIR="/usr" LIBDIR="$(get_libdir)"
+}
+
+src_compile() {
+	emake INSTALLDIR="/usr" LIBDIR="$(get_libdir)" qmake_all # rebuild Makefiles in subdirs
+	emake sub-src
+}
+
+src_install() {
+	emake -C src INSTALL_ROOT="${D}" install
+	use doc && local HTML_DOCS=( doc/. )
+	einstalldocs
+}


### PR DESCRIPTION
- add dependency for dev-qt/qtgui which is needed for opengles2 support
- remove media-libs/mesa dependency which isn't needed
- add needed dependencies, obtained by checking libopencsg.so
- add maintainer

Closes: https://bugs.gentoo.org/639314
Package-Manager: Portage-2.3.96, Repoman-2.3.22
Signed-off-by: Bernd Waibel <waebbl@gmail.com>