### PR TITLE
gnome-extra/evolution-data-server: Drop dependency on python

### DIFF
--- a/gnome-extra/evolution-data-server/evolution-data-server-3.32.5.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-3.32.5.ebuild
@@ -2,10 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python3_6 )
 VALA_USE_DEPEND="vapigen"
 
-inherit cmake-utils db-use flag-o-matic gnome2 python-any-r1 systemd vala virtualx
+inherit cmake-utils db-use flag-o-matic gnome2 systemd vala virtualx
 
 DESCRIPTION="Evolution groupware backend"
 HOMEPAGE="https://wiki.gnome.org/Apps/Evolution"
@@ -58,7 +57,6 @@ RDEPEND="
 	weather? ( >=dev-libs/libgweather-3.10:2= )
 "
 DEPEND="${RDEPEND}
-	${PYTHON_DEPS}
 	dev-util/gdbus-codegen
 	dev-util/glib-utils
 	dev-util/gperf
@@ -74,10 +72,6 @@ DEPEND="${RDEPEND}
 # Also, dbus tests are flaky, bugs #397975 #501834
 # It looks like a nightmare to disable those for now.
 RESTRICT="test !test? ( test )"
-
-pkg_setup() {
-	python-any-r1_pkg_setup
-}
 
 # global scope PATCHES or DOCS array mustn't be used due to double default_src_prepare call
 src_prepare() {

--- a/gnome-extra/evolution-data-server/evolution-data-server-3.34.4.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-3.34.4.ebuild
@@ -2,10 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python3_6 )
 VALA_USE_DEPEND="vapigen"
 
-inherit cmake-utils db-use flag-o-matic gnome2 python-any-r1 systemd vala virtualx
+inherit cmake-utils db-use flag-o-matic gnome2 systemd vala virtualx
 
 DESCRIPTION="Evolution groupware backend"
 HOMEPAGE="https://wiki.gnome.org/Apps/Evolution"
@@ -58,7 +57,6 @@ RDEPEND="
 	weather? ( >=dev-libs/libgweather-3.10:2= )
 "
 DEPEND="${RDEPEND}
-	${PYTHON_DEPS}
 	dev-util/gdbus-codegen
 	dev-util/glib-utils
 	dev-util/gperf
@@ -77,10 +75,6 @@ DEPEND="${RDEPEND}
 # Also, dbus tests are flaky, bugs #397975 #501834
 # It looks like a nightmare to disable those for now.
 RESTRICT="test !test? ( test )"
-
-pkg_setup() {
-	python-any-r1_pkg_setup
-}
 
 # global scope PATCHES or DOCS array mustn't be used due to double default_src_prepare call
 src_prepare() {


### PR DESCRIPTION
Build system dependency on python was removed back in 3.28 [0]
[0] https://gitlab.gnome.org/GNOME/evolution-data-server/-/commit/a28389bae67f09a12e093998aa29956c66a7b359

Signed-off-by: Jan Vesely <jano.vesely@gmail.com>