### PR TITLE
net-im/skypeforlinux: remove Jan Vesely from the maintainer list

### DIFF
--- a/net-im/skypeforlinux/metadata.xml
+++ b/net-im/skypeforlinux/metadata.xml
@@ -5,10 +5,6 @@
 		<email>onigino@protonmail.com</email>
 		<name>Gino McCarty</name>
 	</maintainer>
-	<maintainer type="person">
-		<email>jano.vesely@gmail.com</email>
-		<name>Jan Vesely</name>
-	</maintainer>
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jano.vesely@gmail.com>