### PR TITLE
dev-libs/libmowgli: Bug fix

### DIFF
--- a/dev-libs/libmowgli/files/libmowgli-2.1.3-cacheline-Ensure-sysconf-var-is-defined-before-use.patch
+++ b/dev-libs/libmowgli/files/libmowgli-2.1.3-cacheline-Ensure-sysconf-var-is-defined-before-use.patch
@@ -1,0 +1,25 @@
+From 2b8892fe2ca51ef0334b08babad0fa9d689087c0 Mon Sep 17 00:00:00 2001
+From: "A. Wilcox" <AWilcox@Wilcox-Tech.com>
+Date: Wed, 27 Sep 2017 01:42:33 -0500
+Subject: [PATCH] cacheline: Ensure sysconf var is defined before use on Linux
+
+---
+ src/libmowgli/platform/cacheline.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libmowgli/platform/cacheline.c b/src/libmowgli/platform/cacheline.c
+index 90c803f..7651588 100644
+--- a/src/libmowgli/platform/cacheline.c
++++ b/src/libmowgli/platform/cacheline.c
+@@ -32,7 +32,7 @@ size_t cacheline_size;
+ void
+ mowgli_cacheline_bootstrap(void)
+ {
+-#ifdef MOWGLI_OS_LINUX
++#if defined(MOWGLI_OS_LINUX) && defined(_SC_LEVEL1_DCACHE_LINESIZE)
+ 	cacheline_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+ #elif defined(MOWGLI_OS_OSX)
+ 	size_t size = sizeof(size_t);
+-- 
+2.24.1
+

--- a/dev-libs/libmowgli/libmowgli-2.1.3-r1.ebuild
+++ b/dev-libs/libmowgli/libmowgli-2.1.3-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Useful set of performance and usability-oriented extensions to C"
+HOMEPAGE="https://github.com/atheme/libmowgli-2"
+SRC_URI="https://github.com/atheme/libmowgli-2/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-linux ~ppc-macos ~x86-macos"
+IUSE="libressl ssl"
+
+RDEPEND="ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	!~dev-libs/libmowgli-2.1.0" # Bug 629644
+DEPEND="${RDEPEND}"
+
+DOCS=( AUTHORS README doc/BOOST doc/design-concepts.txt )
+PATCHES=( "${FILESDIR}"/${P}-cacheline-Ensure-sysconf-var-is-defined-before-use.patch )
+S="${WORKDIR}/${PN}-2-${PV}"
+
+src_configure() {
+	econf \
+		$(use_with ssl openssl)
+}

--- a/dev-libs/libmowgli/libmowgli-2.1.3.ebuild
+++ b/dev-libs/libmowgli/libmowgli-2.1.3.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/atheme/libmowgli-2/archive/v${PV}.tar.gz -> ${P}.tar
 
 LICENSE="BSD-2"
 SLOT="2"
-KEYWORDS="~alpha amd64 arm hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~alpha amd64 arm hppa ~ia64 ~mips ppc ppc64 sparc x86 ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="libressl ssl"
 
 RDEPEND="ssl? (


### PR DESCRIPTION
I dropped the `~amd64-linux` in order to stop `repoman` complaining about `dependency.badindev`.