### PR TITLE
net-misc/asterisk: security bump (init script).

### DIFF
--- a/net-misc/asterisk/asterisk-13.32.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-13.32.0-r1.ebuild
@@ -1,0 +1,331 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools linux-info systemd
+
+MY_P="${PN}-${PV/_/-}"
+
+DESCRIPTION="Asterisk: A Modular Open Source PBX System"
+HOMEPAGE="https://www.asterisk.org/"
+SRC_URI="https://downloads.asterisk.org/pub/telephony/asterisk/releases/${MY_P}.tar.gz
+	https://downloads.uls.co.za/gentoo/asterisk/gentoo-asterisk-patchset-4.08.tar.bz2"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+IUSE_VOICEMAIL_STORAGE="
+	+voicemail_storage_file
+	voicemail_storage_odbc
+	voicemail_storage_imap
+"
+IUSE="${IUSE_VOICEMAIL_STORAGE} alsa bluetooth calendar +caps cluster curl dahdi debug doc freetds gtalk http iconv ilbc ldap libedit libressl lua mysql newt +samples odbc osplookup oss pjproject portaudio postgres radius selinux snmp span speex srtp +ssl static statsd syslog vorbis xmpp"
+IUSE_EXPAND="VOICEMAIL_STORAGE"
+REQUIRED_USE="gtalk? ( xmpp )
+	^^ ( ${IUSE_VOICEMAIL_STORAGE/+/} )
+	voicemail_storage_odbc? ( odbc )
+"
+
+PATCHES=(
+	"${FILESDIR}/asterisk-historic-uclibc.patch"
+	"${FILESDIR}/asterisk-historic-dahdiras-without-root.patch"
+	"${FILESDIR}/asterisk-historic-invert-gmine-search-order.patch"
+	"${FILESDIR}/asterisk-historic-dundi-null-dereference.patch"
+	"${FILESDIR}/asterisk-historic-no-var-run-install.patch"
+	"${FILESDIR}/asterisk-13.32.0-binutils-2.34.patch"
+)
+
+DEPEND="acct-user/asterisk
+	acct-group/asterisk
+	dev-db/sqlite:3
+	dev-libs/popt
+	dev-libs/jansson
+	dev-libs/libxml2:2
+	dev-libs/libxslt
+	sys-libs/ncurses:0=
+	sys-libs/zlib
+	alsa? ( media-libs/alsa-lib )
+	bluetooth? ( net-wireless/bluez:= )
+	calendar? (
+		net-libs/neon:=
+		dev-libs/libical:=
+		dev-libs/iksemel
+	)
+	caps? ( sys-libs/libcap )
+	cluster? ( sys-cluster/corosync )
+	curl? ( net-misc/curl )
+	dahdi? (
+		net-libs/libpri
+		net-misc/dahdi-tools
+	)
+	freetds? ( dev-db/freetds )
+	gtalk? ( dev-libs/iksemel )
+	http? ( dev-libs/gmime:2.6 )
+	iconv? ( virtual/libiconv )
+	ilbc? ( dev-libs/ilbc-rfc3951 )
+	ldap? ( net-nds/openldap )
+	libedit? ( dev-libs/libedit )
+	lua? ( dev-lang/lua:* )
+	mysql? ( dev-db/mysql-connector-c:= )
+	newt? ( dev-libs/newt )
+	odbc? ( dev-db/unixODBC )
+	osplookup? ( net-libs/osptoolkit )
+	pjproject? ( net-libs/pjproject )
+	portaudio? ( media-libs/portaudio )
+	postgres? ( dev-db/postgresql:* )
+	radius? ( net-dialup/freeradius-client )
+	snmp? ( net-analyzer/net-snmp:= )
+	span? ( media-libs/spandsp )
+	speex? (
+		media-libs/speex
+		media-libs/speexdsp
+	)
+	srtp? ( net-libs/libsrtp:0 )
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+	vorbis? ( media-libs/libvorbis )
+	voicemail_storage_imap? ( virtual/imap-c-client )
+	xmpp? ( dev-libs/iksemel )
+"
+
+RDEPEND="${DEPEND}
+	net-misc/asterisk-core-sounds
+	net-misc/asterisk-extra-sounds
+	net-misc/asterisk-moh-opsound
+	selinux? ( sec-policy/selinux-asterisk )
+	syslog? ( virtual/logger )"
+
+BDEPEND="virtual/pkgconfig"
+
+S="${WORKDIR}/${MY_P}"
+
+QA_DT_NEEDED="/usr/lib.*/libasteriskssl[.]so[.][0-9]\+"
+
+pkg_setup() {
+	CONFIG_CHECK="~!NF_CONNTRACK_SIP"
+	local WARNING_NF_CONNTRACK_SIP="SIP (NAT) connection tracking is enabled. Some users
+	have reported that this module dropped critical SIP packets in their deployments. You
+	may want to disable it if you see such problems."
+	check_extra_config
+}
+
+src_prepare() {
+	default
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+}
+
+function menuselect() {
+	menuselect/menuselect "$@" || die "menuselect $* failed."
+}
+
+src_configure() {
+	local vmst
+
+	econf \
+		--libdir="/usr/$(get_libdir)" \
+		--localstatedir="/var" \
+		--with-crypto \
+		--with-gsm=internal \
+		--with-popt \
+		--with-z \
+		--without-libedit \
+		$(use_with caps cap) \
+		$(use_with http gmime) \
+		$(use_with newt) \
+		$(use_with pjproject) \
+		$(use_with portaudio) \
+		$(use_with ssl)
+
+	# Blank out sounds/sounds.xml file to prevent
+	# asterisk from installing sounds files (we pull them in via
+	# asterisk-{core,extra}-sounds and asterisk-moh-opsound.
+	>"${S}"/sounds/sounds.xml
+
+	# That NATIVE_ARCH chatter really is quite bothersome
+	sed -i 's/NATIVE_ARCH=/NATIVE_ARCH=0/' build_tools/menuselect-deps || die "Unable to squelch noisy build system"
+
+	# Compile menuselect binary for optional components
+	emake NOISE_BUILD=yes menuselect.makeopts
+
+	# Disable BUILD_NATIVE (bug #667498)
+	menuselect --disable build_native menuselect.makeopts
+
+	# Broken functionality is forcibly disabled (bug #360143)
+	menuselect --disable chan_misdn menuselect.makeopts
+	menuselect --disable chan_ooh323 menuselect.makeopts
+
+	# Utility set is forcibly enabled (bug #358001)
+	menuselect --enable smsq menuselect.makeopts
+	menuselect --enable streamplayer menuselect.makeopts
+	menuselect --enable aelparse menuselect.makeopts
+	menuselect --enable astman menuselect.makeopts
+
+	# this is connected, otherwise it would not find
+	# ast_pktccops_gate_alloc symbol
+	menuselect --enable chan_mgcp menuselect.makeopts
+	menuselect --enable res_pktccops menuselect.makeopts
+
+	# SSL is forcibly enabled, IAX2 & DUNDI are expected to be available
+	menuselect --enable pbx_dundi menuselect.makeopts
+	menuselect --enable func_aes menuselect.makeopts
+	menuselect --enable chan_iax2 menuselect.makeopts
+
+	# SQlite3 is now the main database backend, enable related features
+	menuselect --enable cdr_sqlite3_custom menuselect.makeopts
+	menuselect --enable cel_sqlite3_custom menuselect.makeopts
+
+	# The others are based on USE-flag settings
+	use_select() {
+		local state=$(use "$1" && echo enable || echo disable)
+		shift # remove use from parameters
+
+		while [[ -n $1 ]]; do
+			menuselect --${state} "$1" menuselect.makeopts
+			shift
+		done
+	}
+
+	use_select alsa         chan_alsa
+	use_select bluetooth    chan_mobile
+	use_select calendar     res_calendar res_calendar_{caldav,ews,exchange,icalendar}
+	use_select cluster      res_corosync
+	use_select curl         func_curl res_config_curl res_curl
+	use_select dahdi        app_dahdiras app_meetme chan_dahdi codec_dahdi res_timing_dahdi
+	use_select freetds      {cdr,cel}_tds
+	use_select gtalk        chan_motif
+	use_select http         res_http_post
+	use_select iconv        func_iconv
+	use_select ilbc         codec_ilbc format_ilbc
+	use_select ldap         res_config_ldap
+	use_select lua          pbx_lua
+	use_select mysql        app_mysql cdr_mysql res_config_mysql
+	use_select odbc         cdr_adaptive_odbc res_config_odbc {cdr,cel,res,func}_odbc
+	use_select osplookup    app_osplookup
+	use_select oss          chan_oss
+	use_select postgres     {cdr,cel}_pgsql res_config_pgsql
+	use_select radius       {cdr,cel}_radius
+	use_select snmp         res_snmp
+	use_select span         res_fax_spandsp
+	use_select speex        {codec,func}_speex
+	use_select srtp         res_srtp
+	use_select statsd       res_statsd res_{endpoint,chan}_stats
+	use_select syslog       cdr_syslog
+	use_select vorbis       format_ogg_vorbis
+	use_select xmpp         res_xmpp
+
+	# Voicemail storage ...
+	for vmst in ${IUSE_VOICEMAIL_STORAGE/+/}; do
+		if use ${vmst}; then
+			menuselect --enable $(echo ${vmst##*_} | tr '[:lower:]' '[:upper:]')_STORAGE menuselect.makeopts
+		fi
+	done
+
+	if use debug; then
+		for o in DONT_OPTIMIZE DEBUG_THREADS BETTER_BACKTRACES; do
+			menuselect --enable $o menuselect.makeopts
+		done
+	fi
+}
+
+src_compile() {
+	emake ASTCFLAGS="${CFLAGS}" ASTLDFLAGS="${LDFLAGS}" NOISY_BUILD=yes
+}
+
+src_install() {
+	local d
+
+	mkdir -p "${ED}/usr/$(get_libdir)/pkgconfig" || die
+	emake DESTDIR="${ED}" NOISY_BUILD=yes install
+
+	if use radius; then
+		insinto /etc/radiusclient/
+		doins contrib/dictionary.digium
+	fi
+	diropts -m 0750 -o root -g asterisk
+	keepdir	/etc/asterisk
+	if use samples; then
+		emake NOISY_BUILD=yes DESTDIR="${ED}" samples
+		for conffile in "${ED}/etc/asterisk/"*
+		do
+			fowners root:root "${conffile#${ED}}"
+			fperms 0644 "${conffile#${ED}}"
+		done
+		einfo "Sample files have been installed"
+	else
+		einfo "Skipping installation of sample files..."
+		rm "${ED}"/var/lib/asterisk/mohmp3/* || die
+		rm "${ED}"/var/lib/asterisk/sounds/demo-* || die
+		rm "${ED}"/var/lib/asterisk/agi-bin/* || die
+		rm "${ED}"/etc/asterisk/* || die
+	fi
+	rm -r "${ED}"/var/spool/asterisk/voicemail/default || die
+
+	# keep directories
+	diropts -m 0750 -o asterisk -g root
+	keepdir /var/lib/asterisk
+	keepdir /var/spool/asterisk
+	keepdir /var/spool/asterisk/{system,tmp,meetme,monitor,dictate,voicemail,recording}
+	diropts -m 0750 -o asterisk -g asterisk
+	keepdir /var/log/asterisk/{cdr-csv,cdr-custom}
+
+	newinitd "${FILESDIR}"/initd-13.32.0-r1 asterisk
+	newconfd "${FILESDIR}"/confd-13.32.0 asterisk
+
+	systemd_dounit "${FILESDIR}"/asterisk.service
+	systemd_newtmpfilesd "${FILESDIR}"/asterisk.tmpfiles.conf asterisk.conf
+	systemd_install_serviced "${FILESDIR}"/asterisk.service.conf
+
+	# Reset diropts else dodoc uses it for doc installations.
+	diropts -m0755
+
+	# install the upgrade documentation
+	dodoc UPGRADE* BUGS CREDITS
+
+	# install extra documentation
+	if use doc; then
+		dodoc doc/*.txt
+		dodoc doc/*.pdf
+	fi
+
+	# install SIP scripts; bug #300832
+	#
+	dodoc "${FILESDIR}/1.6.2/sip_calc_auth"
+	dodoc "${FILESDIR}/1.8.0/find_call_sip_trace.sh"
+	dodoc "${FILESDIR}/1.8.0/find_call_ids.sh"
+	dodoc "${FILESDIR}/1.6.2/call_data.txt"
+
+	# install logrotate snippet; bug #329281
+	#
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}/1.6.2/asterisk.logrotate4" asterisk
+
+	# Asterisk installs a few folders that's empty by design,
+	# but still required.  This finds them, and marks them for
+	# portage.
+	for d in $(find "${ED}"/var -type d -empty || die "Find failed."); do
+		keepdir "${d#${ED}}"
+	done
+}
+
+pkg_postinst() {
+	#
+	# Announcements, warnings, reminders...
+	#
+	einfo "Asterisk has been installed"
+	echo
+	elog "If you want to know more about asterisk, visit these sites:"
+	elog "http://www.asteriskdocs.org/"
+	elog "http://www.voip-info.org/wiki-Asterisk"
+	echo
+	elog "http://www.automated.it/guidetoasterisk.htm"
+	echo
+	elog "Gentoo VoIP IRC Channel:"
+	elog "#gentoo-voip @ irc.freenode.net"
+	echo
+	echo
+	elog "Please read the Asterisk 13 upgrade document:"
+	elog "https://wiki.asterisk.org/wiki/display/AST/Upgrading+to+Asterisk+13"
+}

--- a/net-misc/asterisk/files/initd-13.32.0-r1
+++ b/net-misc/asterisk/files/initd-13.32.0-r1
@@ -1,0 +1,362 @@
+#!/sbin/openrc-run
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+extra_started_commands="forcestop reload"
+
+depend() {
+	need net
+	use nscd dns dahdi mysql postgresql slapd capi
+}
+
+is_running() {
+	[ -r "${ast_rundir}/asterisk.pid" ] || return 1
+	PID="$(cat "${ast_rundir}/asterisk.pid")"
+	[ -d "/proc/${PID}" ] || return 1
+	EXE="$(readlink -f /proc/${PID}/exe)"
+	EXE="${EXE% (deleted)}" # in case asterisk got upgraded and we're still looking at an old one.
+	[ "${EXE}" = /usr/sbin/asterisk ] || return 1 # pid got re-used for another process.
+
+	# PID reported in pidfile is active, and is still an asterisk instance.
+	return 0
+}
+
+# Sets up a few variables for us for use
+# ast_instancename: eg, asterisk when RC_SVCNAME=asterisk, or asterisk(foo) when asterisk.foo.
+# ast_rundir: directory to be used as run folder (pid and ctl files).
+# ast_spooldir: 
+setup_svc_variables()
+{
+	local t
+
+	ast_instancename=asterisk
+	ast_rundir=/var/run/${RC_SVCNAME}
+	ast_logdir=/var/log/${RC_SVCNAME}
+	ast_spooldir=/var/spool/${RC_SVCNAME}
+	ast_confdir=/etc/${RC_SVCNAME/.//}
+	ast_stop_timeout=120
+	ast_stop_method="gracefully"
+
+	if [ "${RC_SVCNAME}" != "asterisk" ]; then
+		t="${RC_SVCNAME#asterisk.}"
+		if [ "${RC_SVCNAME}" = "${t}" ]; then
+			eerror "Invalid SVCNAME of ${RC_SVCNAME}, must be of the format asterisk.name."
+			return 1
+		fi
+		ast_instancename+="(${t})"
+	fi
+
+	[ -n "${ASTERISK_RUNDIR}" ] && ast_rundir="${ASTERISK_RUNDIR}"
+	[ -n "${ASTERISK_LOGDIR}" ] && ast_logdir="${ASTERISK_LOGDIR}"
+	[ -n "${ASTERISK_SPOOLDIR}" ] && ast_spooldir="${ASTERISK_SPOOLDIR}"
+	[ -n "${ASTERISK_CONFDIR}" ] && ast_confdir="${ASTERISK_CONFDIR}"
+	[ -n "${ASTERISK_STOP_TIMEOUT}" ] && ast_stop_timeout="${ASTERISK_STOP_TIMEOUT}"
+	case "${ASTERISK_STOP_METHOD}" in
+		grasefully|when\ convenient|now)
+			ast_stop_method="${ASTERISK_STOP_METHOD}"
+		;;
+	esac
+	ast_group=
+	if [ -n "${ASTERISK_USER}" ]; then
+		ast_user="${ASTERISK_USER%%:*}"
+		if [ "${ast_user}" != "${ASTERISK_USER}" ]; then
+			ast_group="${ASTERISK_USER#*:}"
+			ast_group="${ast_group%%:*}"
+		fi
+	fi
+
+	[ -z "${ast_user}" ] && ast_user=asterisk
+
+	ast_pgroup="$(getent group $(getent passwd "${ast_user}" | awk -F: '{ print $4 }') | sed -re 's/:.*//')"
+
+	return 0
+}
+
+asterisk_run_loop() {
+	local result=0 signal=0
+
+	echo "Initializing ${ast_instancename} wrapper"
+	OPTS="$*"
+
+	trap "rm -f '${ast_rundir}/wrapper_loop.running'" EXIT
+	touch "${ast_rundir}/wrapper_loop.running"
+
+	while [ -r "${ast_rundir}/wrapper_loop.running" ]; do
+		if [ -n "${TTY}" ]; then
+			/usr/bin/stty -F "${TTY}" sane
+			${NICE} /usr/sbin/asterisk -C "${ast_confdir}/asterisk.conf" ${OPTS} >"${TTY}" 2>&1 <"${TTY}"
+			result=$?
+		else
+			${NICE} /usr/sbin/asterisk -C "${ast_confdir}/asterisk.conf" ${OPTS} >/dev/null 2>&1
+			result=$?
+		fi		
+
+		if [ "$result" -eq 0 ]; then
+			echo "Asterisk terminated normally"
+			break
+		else
+			if [ "$result" -gt 128 ]; then
+				signal="$(expr "$result" - 128)"
+				MSG="Asterisk terminated with Signal: $signal"
+
+				CORE_TARGET="core-"
+				yesno "${ASTERISK_CORE_USEHOSTNAME}" && CORE_TARGET+="$(hostname)-"
+				CORE_TARGET+="$(date "+%Y%m%d-%H%M%S")"
+
+				local CORE_DUMPED=0
+				if [ -f "${ASTERISK_CORE_DIR}/core" ]; then
+					mv "${ASTERISK_CORE_DIR}/core" \
+					   "${ASTERISK_CORE_DIR}/${CORE_TARGET}"
+					CORE_DUMPED=1
+
+				elif [ -f "${ASTERISK_CORE_DIR}/core.${PID}" ]; then
+					mv "${ASTERISK_CORE_DIR}/core.${PID}" \
+					   "${ASTERISK_CORE_DIR}/${CORE_TARGET}"
+					CORE_DUMPED=1
+
+				fi
+
+				[ $CORE_DUMPED -eq 1 ] && \
+					MSG="${MSG}\n\rCore dumped: ${ASTERISK_CORE_DIR}/${CORE_TARGET}"
+			else
+				MSG="Asterisk terminated with return code: $result"
+			fi
+
+			# kill left-over tasks
+			for X in ${ASTERISK_CLEANUP_ON_CRASH}; do
+				kill -9 "$(pidof "${X}")";
+			done
+		fi
+
+		[ -n "${TTY}" ] \
+			&& echo "${MSG}" >"${TTY}" \
+			|| echo "${MSG}"
+
+
+		if [ -n "${ASTERISK_NOTIFY_EMAIL}" ] && \
+		   [ -x /usr/sbin/sendmail ]; then
+			echo -e -n "Subject: Asterisk crashed\r\n${MSG}\r\n" |\
+				 /usr/sbin/sendmail "${ASTERISK_NOTIFY_EMAIL}"
+		fi
+		sleep "${ASTERISK_RESTART_DELAY}"
+		echo "Restarting Asterisk..."
+	done
+
+	echo "Terminating wrapper loop."
+	return 0
+}
+
+start() {
+	local OPTS PID
+	local tmp x
+
+	local OPTS ARGS 
+
+	setup_svc_variables || return $?
+
+	ebegin "Starting ${ast_instancename} PBX"
+
+	eindent
+
+	# filter (redundant) arguments
+	OPTS="$(echo "${ASTERISK_OPTS}" | sed -re "s:-[cfF]::g")"
+
+	# default options
+	OPTS="${OPTS} -f"  # don't fork / detach breaks wrapper script...
+
+	# ensure that ASTERISK_RESTART_DELAY is integer.
+	ASTERISK_RESTART_DELAY="$(echo "${ASTERISK_RESTART_DELAY}" | sed -re 's/^([0-9]*).*/\1/')"
+	[ -z "${ASTERISK_RESTART_DELAY}" ] && ASTERISK_RESTART_DELAY=5
+
+	if [ -n "${ASTERISK_CORE_SIZE}" ] &&
+	   [ "${ASTERISK_CORE_SIZE}" != "0" ]; then
+		ulimit -c ${ASTERISK_CORE_SIZE}
+
+		if [ -n "${ASTERISK_CORE_DIR}" ] && \
+		   [ ! -d "${ASTERISK_CORE_DIR}" ]
+		then
+			checkpath -d -m 0755 -o ${ast_user}:${ast_group} "${ASTERISK_CORE_DIR}"
+		fi
+		ASTERISK_CORE_DIR="${ASTERISK_CORE_DIR:-/tmp}"
+
+		cd "${ASTERISK_CORE_DIR}"
+		einfo "Core dump size            : ${ASTERISK_CORE_SIZE}"
+		einfo "Core dump location        : ${ASTERISK_CORE_DIR}"
+
+		OPTS="${OPTS} -g"
+	fi
+
+	if [ -n "${ASTERISK_MAX_FD}" ]; then
+		ulimit -n ${ASTERISK_MAX_FD}
+		einfo "Max open filedescriptors  : ${ASTERISK_MAX_FD}"
+	fi
+
+	if [ -n "${ASTERISK_NICE}" ]; then
+		if [ ${ASTERISK_NICE} -ge -20 ] && \
+		   [ ${ASTERISK_NICE} -le  19 ]; then 
+			einfo "Nice level                : ${ASTERISK_NICE}"
+			NICE="nice -n ${ASTERISK_NICE} --"
+		else
+			eerror "Nice value must be between -20 and 19"
+			return 1
+		fi
+	else
+		NICE=""
+	fi
+
+	if [ -n "${ASTERISK_NOTIFY_EMAIL}" ]; then
+		if [ -x /usr/sbin/sendmail ]; then
+			einfo "Email notifications go to : ${ASTERISK_NOTIFY_EMAIL}"
+		else
+			ewarn "Notifications disabled, /usr/sbin/sendmail doesn't exist or is not executable!"
+			unset ASTERISK_NOTIFY_EMAIL
+		fi
+	fi
+
+	if [ -n "${ASTERISK_TTY}" ]; then
+		for x in "${ASTERISK_TTY}" \
+			 "/dev/tty${ASTERISK_TTY}" \
+			 "/dev/vc/${ASTERISK_TTY}"
+		do
+			if [ -c "${x}" ]; then
+				TTY="${x}"
+			fi
+		done
+		[ -n "${TTY}" ] && \
+			einfo "Messages are sent to      : ${TTY}"
+	fi
+
+	if yesno "${ASTERISK_CONSOLE}" && [ -n "${TTY}" ]; then
+		einfo "Starting Asterisk console : Yes"
+		OPTS="${OPTS} -c"
+	fi
+
+	if ! getent passwd "${ast_user}" &>/dev/null; then
+		eerror "Requested to run asterisk as ${ast_user}, which doesn't exist."
+		return 1
+	fi
+	OPTS="${OPTS} -U ${ast_user}"
+
+	if [ -n "${ast_group}" ] && ! getent group "${ast_group}" &>/dev/null; then
+		eerror "Requested to run ${ast_instancename} with group ${ast_group}, which doesn't exist."
+		return 1
+	fi
+	[ -n "${ast_group}" ] && OPTS="${OPTS} -G ${ast_group}"
+	
+	if [ "${ast_user}" = root ]; then
+		ewarn "Starting asterisk as root is not recommended (SERIOUS SECURITY CONSIDERATIONS)."
+	elif [ "${ast_group}" = root ]; then
+		ewarn "Starting asterisk with group root is not recommended (SERIOUS SECURITY CONSIDERATIONS)."
+	fi
+
+	checkpath -d -m 0755 -o "${ast_user}:${ast_group}" "${ast_logdir}" "${ast_rundir}"
+	einfo "Starting asterisk as      : ${ast_user}:${ast_group:-${ast_pgroup} (+supplementaries)}"
+	asterisk_run_loop ${OPTS} 2>&1 | logger -t "wrapper:${ast_instancename}" &>/dev/null &
+	result=$?
+
+	if [ $result -eq 0 ]; then
+		# 2 seconds should be enough for asterisk to start
+		sleep 2 
+		is_running
+		result=$?
+
+		[ $result -eq 0 ] || wrapperstop
+	fi
+
+	eoutdent
+	eend $result
+
+	if [ $result -eq 0 ] && yesno "${ASTERISK_WAITBOOTED}"; then
+		if [ ! -r "${ast_rundir}/asterisk.ctl" ]; then
+			# asterisk can crash during startup ...
+			ebegin "Waiting for ctl file to appear"
+			while is_running && [ ! -r "${ast_rundir}/asterisk.ctl" ]; do
+				sleep 1
+			done
+			is_running
+			result=$?
+			eend $result
+		fi
+		if [ $result -eq 0 ]; then
+			ebegin "Waiting for ${ast_instancename} to fully boot"
+			/usr/sbin/asterisk -C "${ast_confdir}/asterisk.conf" -r -x "core waitfullybooted" &>/dev/null
+			eend $?
+		fi
+	fi
+
+	return $result
+}
+
+wrapperstop() {
+	# Accomodate system upgrades (so a previous version of the wrapper script that still uses a pid file may be running).
+	if [ -r "${ast_rundir}/wrapper_loop.pid" ]; then
+		ebegin "Killing ${ast_instancename} wrapper script"
+		kill "$(cat /var/run/asterisk/wrapper_loop.pid)"
+		eend $?
+	fi
+
+	# The new one (due to "hardened" requirements) uses a simpler
+	# flag to indicate running or shutting down.
+	if [ -r "${ast_rundir}/wrapper_loop.running" ]; then
+		ebegin "Signalling ${ast_instancename} wrapper script to terminate"
+		rm "${ast_rundir}/wrapper_loop.running"
+		eend $?
+	fi
+
+	return 0
+}
+
+forcestop() {
+	setup_svc_variables || return $?
+
+	# Just to be sure - when we want to forcestop we should make it all tear down.
+	wrapperstop
+
+	ebegin "Stopping ${ast_instancename} PBX"
+	start-stop-daemon --stop --pidfile /var/run/asterisk/asterisk.pid
+	eend $?
+}
+
+stop() {
+	setup_svc_variables || return $?
+
+	wrapperstop
+
+	if ! is_running; then
+		eerror "${ast_instancename} is not running!"
+		return 0
+	fi
+	
+	ebegin "Stopping ${ast_instancename} PBX ${ast_stop_method}"
+	/usr/sbin/asterisk -C "${ast_confdir}/asterisk.conf" -r -x "core stop ${ast_stop_method}" &>/dev/null
+	# Now we have to wait until asterisk has _really_ stopped.
+	sleep 1
+	if is_running; then
+		einfon "Waiting for ${ast_instancename} to shutdown ."
+		local cnt=0
+		while is_running; do
+			cnt="$(expr $cnt + 2)"
+			if [ ${ast_stop_timeout} -gt 0 -a $cnt -gt ${ast_stop_timeout} ] ; then
+				echo
+				eend 1 "Failed waiting for ${ast_instancename} to stop."
+				return 1
+			fi
+			sleep 2
+			echo -n "."
+		done
+		echo
+	fi
+	eend 0
+}
+
+reload() {
+	setup_svc_variables || return $?
+
+	if is_running; then
+		ebegin "Forcing ${ast_instancename} to reload configuration"
+		/usr/sbin/asterisk -C "${ast_confdir}/asterisk.conf" -r -x "module reload" &>/dev/null
+		eend $?
+	else
+		eerror "${ast_instancename} is not running!"
+	fi
+}


### PR DESCRIPTION
The details is outlined in:

Bug:  https://bugs.gentoo.org/602722

This only affects things if you can trick the sysadmin to run
/etc/init.d/asterisk checkperms.

Took the opportunity to tighten permissions on /var/lib/asterisk and
/var/spool/asterisk as well, and double checked that on new install
these are in fact correct.  Permissions on /var/spool/asterisk/recording
was missed previously and left root:root as per the standard asterisk
install Makefile.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jaco Kroon <jaco@uls.co.za>