### PR TITLE
x11-terms/kitty: add importlib_resources as dependency when using Python 3.6

### DIFF
--- a/x11-terms/kitty/kitty-0.17.2-r1.ebuild
+++ b/x11-terms/kitty/kitty-0.17.2-r1.ebuild
@@ -43,6 +43,7 @@ RDEPEND="
 		dev-libs/wayland
 		>=dev-libs/wayland-protocols-1.17
 	)
+	$(python_gen_cond_dep 'dev-python/importlib_resources[${PYTHON_MULTI_USEDEP}]' python3_6)
 "
 
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Add importlib_resources as dependency when using Python 3.6, which is needed for kitty to work correctly if using shell completion and it wasn't included in the standard python library before 3.7.

Signed-off-by: Pablo Orduna <pabloorduna98@gmail.com>

Closes: https://bugs.gentoo.org/716352