### PR TITLE
app-emulation/libvirt: add apparmor rule for seavgabios

### DIFF
--- a/app-emulation/libvirt/files/libvirt-6.5.0-fix-paths-for-apparmor.patch
+++ b/app-emulation/libvirt/files/libvirt-6.5.0-fix-paths-for-apparmor.patch
@@ -1,0 +1,82 @@
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 36bd280..07cebdf 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -4473,7 +4473,7 @@ SECURITY_DRIVER_APPARMOR_SOURCES = \
+ 	$(NULL)
+ 
+ SECURITY_DRIVER_APPARMOR_GENERATED_PROFILES_IN = \
+-	security/apparmor/usr.lib.libvirt.virt-aa-helper.in \
++	security/apparmor/usr.libexec.virt-aa-helper.in \
+ 	security/apparmor/usr.sbin.libvirtd.in \
+ 	$(NULL)
+ 
+@@ -13821,11 +13821,11 @@ security/apparmor/%: $(srcdir)/security/apparmor/%.in
+ @WITH_APPARMOR_PROFILES_TRUE@install-apparmor-local: $(SECURITY_DRIVER_APPARMOR_GENERATED_PROFILES)
+ @WITH_APPARMOR_PROFILES_TRUE@	$(MKDIR_P) "$(APPARMOR_LOCAL_DIR)"
+ @WITH_APPARMOR_PROFILES_TRUE@	echo "# Site-specific additions and overrides for \
+-@WITH_APPARMOR_PROFILES_TRUE@		'usr.lib.libvirt.virt-aa-helper'" \
+-@WITH_APPARMOR_PROFILES_TRUE@		>"$(APPARMOR_LOCAL_DIR)/usr.lib.libvirt.virt-aa-helper"
++@WITH_APPARMOR_PROFILES_TRUE@		'usr.libexec.virt-aa-helper'" \
++@WITH_APPARMOR_PROFILES_TRUE@		>"$(APPARMOR_LOCAL_DIR)/usr.libexec.virt-aa-helper"
+ 
+ @WITH_APPARMOR_PROFILES_TRUE@uninstall-apparmor-local:
+-@WITH_APPARMOR_PROFILES_TRUE@	rm -f "$(APPARMOR_LOCAL_DIR)/usr.lib.libvirt.virt-aa-helper"
++@WITH_APPARMOR_PROFILES_TRUE@	rm -f "$(APPARMOR_LOCAL_DIR)/usr.libexec.virt-aa-helper"
+ @WITH_APPARMOR_PROFILES_TRUE@	rmdir "$(APPARMOR_LOCAL_DIR)" || :
+ 
+ $(ACCESS_DRIVER_POLKIT_POLICY): $(srcdir)/access/viraccessperm.h \
+diff --git a/src/security/Makefile.inc.am b/src/security/Makefile.inc.am
+index 5f2f4c8..d457cc6 100644
+--- a/src/security/Makefile.inc.am
++++ b/src/security/Makefile.inc.am
+@@ -31,7 +31,7 @@ SECURITY_DRIVER_APPARMOR_SOURCES = \
+ 	$(NULL)
+ 
+ SECURITY_DRIVER_APPARMOR_GENERATED_PROFILES_IN = \
+-	security/apparmor/usr.lib.libvirt.virt-aa-helper.in \
++	security/apparmor/usr.libexec.virt-aa-helper.in \
+ 	security/apparmor/usr.sbin.libvirtd.in \
+ 	$(NULL)
+ 
+@@ -130,11 +130,11 @@ APPARMOR_LOCAL_DIR = "$(DESTDIR)$(apparmordir)/local"
+ install-apparmor-local: $(SECURITY_DRIVER_APPARMOR_GENERATED_PROFILES)
+ 	$(MKDIR_P) "$(APPARMOR_LOCAL_DIR)"
+ 	echo "# Site-specific additions and overrides for \
+-		'usr.lib.libvirt.virt-aa-helper'" \
+-		>"$(APPARMOR_LOCAL_DIR)/usr.lib.libvirt.virt-aa-helper"
++		'usr.libexec.virt-aa-helper'" \
++		>"$(APPARMOR_LOCAL_DIR)/usr.libexec.virt-aa-helper"
+ 
+ uninstall-apparmor-local:
+-	rm -f "$(APPARMOR_LOCAL_DIR)/usr.lib.libvirt.virt-aa-helper"
++	rm -f "$(APPARMOR_LOCAL_DIR)/usr.libexec.virt-aa-helper"
+ 	rmdir "$(APPARMOR_LOCAL_DIR)" || :
+ 
+ INSTALL_DATA_LOCAL += install-apparmor-local
+diff --git a/src/security/apparmor/libvirt-qemu b/src/security/apparmor/libvirt-qemu
+index 80986ae..d550d8c 100644
+--- a/src/security/apparmor/libvirt-qemu
++++ b/src/security/apparmor/libvirt-qemu
+@@ -88,6 +88,7 @@
+   /usr/share/sgabios/** r,
+   /usr/share/slof/** r,
+   /usr/share/vgabios/** r,
++  /usr/share/seavgabios/** r,
+ 
+   # pki for libvirt-vnc and libvirt-spice (LP: #901272, #1690140)
+   /etc/pki/CA/ r,
+diff --git a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in b/src/security/apparmor/usr.libexec.virt-aa-helper.in
+similarity index 97%
+rename from src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in
+rename to src/security/apparmor/usr.libexec.virt-aa-helper.in
+index dd18c8a..d06f9cb 100644
+--- a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in
++++ b/src/security/apparmor/usr.libexec.virt-aa-helper.in
+@@ -69,5 +69,5 @@ profile virt-aa-helper @libexecdir@/virt-aa-helper {
+   /**.[iI][sS][oO] r,
+   /**/disk{,.*} r,
+ 
+-  #include <local/usr.lib.libvirt.virt-aa-helper>
++  #include <local/usr.libexec.virt-aa-helper>
+ }

--- a/app-emulation/libvirt/libvirt-6.5.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-6.5.0-r1.ebuild
@@ -123,7 +123,7 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
-	"${FILESDIR}"/${PN}-6.1.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-6.5.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-6.5.0-do-not-use-sysconfig.patch
 )
 


### PR DESCRIPTION
app-emulation/libvirt-6.1.0 and 6.2.0: apparmor profile template libvirt-qemu doesn't contain a rule allowing to read seavgabios directory (sys-firmware/seabios ebuild puts its binaries there)