### PR TITLE
dev-games/irrlicht: Add libglvnd dependency

### DIFF
--- a/dev-games/irrlicht/irrlicht-1.8.4-r1.ebuild
+++ b/dev-games/irrlicht/irrlicht-1.8.4-r1.ebuild
@@ -17,9 +17,9 @@ IUSE="debug doc static-libs"
 RDEPEND="app-arch/bzip2
 	~dev-games/irrlicht-headers-${PV}
 	media-libs/libpng:0=
+	media-libs/mesa[X,libglvnd]
 	sys-libs/zlib
 	virtual/jpeg:0
-	virtual/opengl
 	x11-libs/libX11
 	x11-libs/libXxf86vm"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Irrlicht requires the GL/glx.h header, which is provided by the libglvnd
package.

Closes: https://bugs.gentoo.org/712066
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>