### PR TITLE
net-misc/openssh: Update CPE Prefix to openbsd:openssh

### DIFF
--- a/net-misc/openssh/metadata.xml
+++ b/net-misc/openssh/metadata.xml
@@ -36,7 +36,7 @@ ssh-keygen and sftp-server. OpenSSH supports SSH protocol versions 1.3, 1.5, and
     <flag name="xmss">Enable XMSS post-quantum authentication algorithm</flag>
   </use>
   <upstream>
-    <remote-id type="cpe">cpe:/a:openssh:openssh</remote-id>
+    <remote-id type="cpe">cpe:/a:openbsd:openssh</remote-id>
     <remote-id type="sourceforge">hpnssh</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Signed-off-by: Roy Yang <royyang@google.com>

From NIST CPE dictionary: https://nvd.nist.gov/products/cpe/search,
openssh:openssh does not exist. Maybe we should use openbsd:openssh,
which is used by security scanning software.