### PR TITLE
dev-python/bz2file: Add Python 3.6, 3.7 & 3.8

### DIFF
--- a/dev-python/bz2file/bz2file-0.98-r1.ebuild
+++ b/dev-python/bz2file/bz2file-0.98-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=no
+PYTHON_COMPAT=( python3_{6,7,8} )
+
+inherit distutils-r1
+
+DESCRIPTION="Replacement for bz2.BZ2File with features from newest CPython"
+HOMEPAGE="https://pypi.org/project/bz2file/ https://github.com/nvawda/bz2file"
+SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.98-fix_test_py_37+.patch"
+)
+
+python_test() {
+	"${EPYTHON}" test_bz2file.py -v || die "Tests fail with ${EPYTHON}"
+}

--- a/dev-python/bz2file/files/bz2file-0.98-fix_test_py_37+.patch
+++ b/dev-python/bz2file/files/bz2file-0.98-fix_test_py_37+.patch
@@ -1,0 +1,12 @@
+--- src/test_bz2file.py~	2020-04-07 23:11:28.987587102 -0700
++++ src/test_bz2file.py	2020-04-07 23:10:45.263590154 -0700
+@@ -497,7 +497,8 @@
+                 t.join()
+ 
+     def testWithoutThreading(self):
+-        if not hasattr(support, "import_fresh_module"):
++        import sys
++        if not hasattr(support, "import_fresh_module") or (sys.version_info.major == 3 and sys.version_info.minor >= 6):
+             return
+         module = support.import_fresh_module("bz2file", blocked=("threading",))
+         with module.BZ2File(self.filename, "wb") as f:


### PR DESCRIPTION
@zmedico @gyakovlev @chutz

Tests pass, had to disable a test that isn't valid for Python 3.7+.

```
--- bz2file-0.98.ebuild 2020-04-07 21:14:07.934078547 -0700
+++ bz2file-0.98-r1.ebuild      2020-04-09 22:42:34.189647257 -0700
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=no
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python3_{6,7,8} )
 
 inherit distutils-r1
 
@@ -14,8 +14,13 @@
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux"
-IUSE=""
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+       "${FILESDIR}/${PN}-0.98-fix_test_py_37+.patch"
+)
 
 python_test() {
        "${EPYTHON}" test_bz2file.py -v || die "Tests fail with ${EPYTHON}"
```