### PR TITLE
dev-util/bitcoin-tx-0.19.1: Fix build without libevent

### DIFF
--- a/dev-util/bitcoin-tx/bitcoin-tx-0.19.1.ebuild
+++ b/dev-util/bitcoin-tx/bitcoin-tx-0.19.1.ebuild
@@ -60,6 +60,8 @@ src_prepare() {
 		eapply "${knots_patchdir}/${KNOTS_P}.ts.patch"
 	fi
 
+	eapply "${FILESDIR}/${PV}-no-libevent.patch"
+
 	eapply_user
 
 	echo '#!/bin/true' >share/genbuild.sh || die

--- a/dev-util/bitcoin-tx/files/0.19.1-no-libevent.patch
+++ b/dev-util/bitcoin-tx/files/0.19.1-no-libevent.patch
@@ -1,0 +1,47 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -1271,7 +1271,7 @@ if test x$use_pkgconfig = xyes; then
+         BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])
+       fi
+       if test x$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests != xnononono; then
+-        PKG_CHECK_MODULES([EVENT], [libevent],, [AC_MSG_ERROR(libevent not found.)])
++        PKG_CHECK_MODULES([EVENT], [libevent], [use_libevent=yes], [AC_MSG_ERROR(libevent not found.)])
+         if test x$TARGET_OS != xwindows; then
+           PKG_CHECK_MODULES([EVENT_PTHREADS], [libevent_pthreads],, [AC_MSG_ERROR(libevent_pthreads not found.)])
+         fi
+@@ -1291,7 +1291,7 @@ if test x$use_pkgconfig = xyes; then
+ else
+ 
+   if test x$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests != xnononono; then
+-    AC_CHECK_HEADER([event2/event.h],, AC_MSG_ERROR(libevent headers missing),)
++    AC_CHECK_HEADER([event2/event.h], [use_libevent=yes], AC_MSG_ERROR(libevent headers missing),)
+     AC_CHECK_LIB([event],[main],EVENT_LIBS=-levent,AC_MSG_ERROR(libevent missing))
+     if test x$TARGET_OS != xwindows; then
+       AC_CHECK_LIB([event_pthreads],[main],EVENT_PTHREADS_LIBS=-levent_pthreads,AC_MSG_ERROR(libevent_pthreads missing))
+@@ -1545,6 +1545,7 @@ AM_CONDITIONAL([ENABLE_QT_TESTS],[test x$BUILD_TEST_QT = xyes])
+ AM_CONDITIONAL([ENABLE_BENCH],[test x$use_bench = xyes])
+ AM_CONDITIONAL([USE_QRCODE], [test x$use_qr = xyes])
+ AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
++AM_CONDITIONAL([USE_LIBEVENT],[test x$use_libevent = xyes])
+ AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
+ AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
+ AM_CONDITIONAL([ENABLE_SSE42],[test x$enable_sse42 = xyes])
+diff --git a/src/Makefile.am b/src/Makefile.am
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -523,10 +523,13 @@ libbitcoin_util_a_SOURCES = \
+   util/strencodings.cpp \
+   util/string.cpp \
+   util/time.cpp \
+-  util/url.cpp \
+   util/validation.cpp \
+   $(BITCOIN_CORE_H)
+ 
++if USE_LIBEVENT
++libbitcoin_util_a_SOURCES += util/url.cpp
++endif
++
+ if GLIBC_BACK_COMPAT
+ libbitcoin_util_a_SOURCES += compat/glibc_compat.cpp
+ AM_LDFLAGS += $(COMPAT_LDFLAGS)


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/715268

Patch extracted and hand-rebased from https://github.com/bitcoin/bitcoin/pull/18504

(NOTE: Not tested on a system without libevent2)