### PR TITLE
dev-python/rospkg: restore patch

### DIFF
--- a/dev-python/rospkg/files/gentoo.patch
+++ b/dev-python/rospkg/files/gentoo.patch
@@ -1,0 +1,15 @@
+Strip ros_packages/ from paths. ros_packages is only for avoiding to crawl the
+whole /usr but the real one in the path without it.
+
+Index: rospkg-1.1.0/src/rospkg/rospack.py
+===================================================================
+--- rospkg-1.1.0.orig/src/rospkg/rospack.py
++++ rospkg-1.1.0/src/rospkg/rospack.py
+@@ -59,6 +59,7 @@ def list_by_path(manifest_name, path, ca
+     path = os.path.abspath(path)
+     basename = os.path.basename
+     for d, dirs, files in os.walk(path, topdown=True, followlinks=True):
++        d = d.replace('ros_packages/', '')
+         if 'CATKIN_IGNORE' in files:
+             del dirs[:]
+             continue  # leaf


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/715382
Package-Manager: Portage-2.3.98, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>