### PR TITLE
Prelude: Fix empty dirs needed to be preserved

### DIFF
--- a/dev-libs/libprelude/libprelude-5.1.1.ebuild
+++ b/dev-libs/libprelude/libprelude-5.1.1.ebuild
@@ -98,4 +98,6 @@ src_install() {
 		cd bindings/python || die
 		distutils-r1_src_install
 	fi
+
+	keepdir /var/lib/spool/prelude
 }

--- a/www-apps/prewikka/prewikka-5.1.1.ebuild
+++ b/www-apps/prewikka/prewikka-5.1.1.ebuild
@@ -40,3 +40,9 @@ BDEPEND="dev-python/lesscpy[${PYTHON_USEDEP}]
 pkg_postinst() {
 	optfeature "Asynchronous DNS" dev-python/twisted[${PYTHON_USEDEP}]
 }
+
+src_install() {
+	distutils-r1_src_install
+
+	keepdir /var/lib/prewikka
+}


### PR DESCRIPTION
Fixing bugs :
libprelude: https://bugs.gentoo.org/703686
prewikka: https://bugs.gentoo.org/703690