### PR TITLE
net-wireless/broadcom-sta: fix build for kernel 5.6

### DIFF
--- a/net-wireless/broadcom-sta/broadcom-sta-6.30.223.271-r6.ebuild
+++ b/net-wireless/broadcom-sta/broadcom-sta-6.30.223.271-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -84,6 +84,7 @@ PATCHES=(
 		"${FILESDIR}/${PN}-6.30.223.271-r4-linux-4.12.patch"
 		"${FILESDIR}/${PN}-6.30.223.271-r4-linux-4.15.patch"
 		"${FILESDIR}/${PN}-6.30.223.271-r5-linux-5.1.patch"
+		"${FILESDIR}/${PN}-6.30.223.271-r6-linux-5.6.patch"
 )
 
 src_install() {

--- a/net-wireless/broadcom-sta/files/broadcom-sta-6.30.223.271-r6-linux-5.6.patch
+++ b/net-wireless/broadcom-sta/files/broadcom-sta-6.30.223.271-r6-linux-5.6.patch
@@ -1,0 +1,55 @@
+diff --git a/src/shared/linux_osl.c b/src/shared/linux_osl.c
+index 6157d18..8237ec7 100644
+--- a/src/shared/linux_osl.c
++++ b/src/shared/linux_osl.c
+@@ -942,7 +942,7 @@ osl_getcycles(void)
+ void *
+ osl_reg_map(uint32 pa, uint size)
+ {
+-	return (ioremap_nocache((unsigned long)pa, (unsigned long)size));
++	return (ioremap((unsigned long)pa, (unsigned long)size));
+ }
+ 
+ void
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 0d05100..2ed1f0d 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -582,7 +582,7 @@ wl_attach(uint16 vendor, uint16 device, ulong regs,
+ 	}
+ 	wl->bcm_bustype = bustype;
+ 
+-	if ((wl->regsva = ioremap_nocache(dev->base_addr, PCI_BAR0_WINSZ)) == NULL) {
++	if ((wl->regsva = ioremap(dev->base_addr, PCI_BAR0_WINSZ)) == NULL) {
+ 		WL_ERROR(("wl%d: ioremap() failed\n", unit));
+ 		goto fail;
+ 	}
+@@ -772,7 +772,7 @@ wl_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 	if ((val & 0x0000ff00) != 0)
+ 		pci_write_config_dword(pdev, 0x40, val & 0xffff00ff);
+ 		bar1_size = pci_resource_len(pdev, 2);
+-		bar1_addr = (uchar *)ioremap_nocache(pci_resource_start(pdev, 2),
++		bar1_addr = (uchar *)ioremap(pci_resource_start(pdev, 2),
+ 			bar1_size);
+ 	wl = wl_attach(pdev->vendor, pdev->device, pci_resource_start(pdev, 0), PCI_BUS, pdev,
+ 		pdev->irq, bar1_addr, bar1_size);
+@@ -3335,12 +3335,19 @@ wl_proc_write(struct file *filp, const char __user *buff, size_t length, loff_t
+ }
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++static struct proc_ops wl_fops = {
++        .proc_read     = wl_proc_read,
++        .proc_write    = wl_proc_write,
++};
++#else
+ static const struct file_operations wl_fops = {
+ 	.owner	= THIS_MODULE,
+ 	.read	= wl_proc_read,
+ 	.write	= wl_proc_write,
+ };
+ #endif
++#endif
+ 
+ static int
+ wl_reg_proc_entry(wl_info_t *wl)


### PR DESCRIPTION
* Apply Arch's patch for the 5.6 kernel, taken from
  https://git.archlinux.org/svntogit/community.git/tree/trunk/010-linux56.patch?h=packages/broadcom-wl-dkms
* Update copyright to run through 2020.

I confirmed it still builds against 5.5.16, 5.4.28, and 4.19.113 as well.

Package-Manager: Portage-2.3.89, Repoman-2.3.20