### PR TITLE
x11-terms/kitty: fix and split live ebuild

### DIFF
--- a/x11-terms/kitty-terminfo/kitty-terminfo-9999.ebuild
+++ b/x11-terms/kitty-terminfo/kitty-terminfo-9999.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6,7,8} )
+
+inherit python-any-r1 toolchain-funcs xdg git-r3
+
+DESCRIPTION="Terminfo for kitty, an OpenGL-based terminal emulator"
+HOMEPAGE="https://github.com/kovidgoyal/kitty"
+EGIT_REPO_URI="https://github.com/kovidgoyal/kitty.git"
+
+LICENSE="GPL-3"
+SLOT="0"
+IUSE="debug"
+
+DEPEND="${PYTHON_DEPS}"
+
+PATCHES=(
+	"${FILESDIR}"/kitty-terminfo-setup-0.17.2.patch
+)
+
+# kitty-terminfo is a split package from kitty that only installs the terminfo
+# file. As tests are designed to be run with the whole package compiled they
+# would fail in this case.
+RESTRICT="test"
+
+src_compile() {
+	"${EPYTHON}" setup.py \
+		--verbose $(usex debug --debug "") \
+		--libdir-name $(get_libdir) \
+		linux-terminfo || die "Failed to compile kitty."
+}
+
+src_install() {
+	insinto /usr
+	doins -r linux-package/*
+}

--- a/x11-terms/kitty/kitty-9999.ebuild
+++ b/x11-terms/kitty/kitty-9999.ebuild
@@ -30,14 +30,15 @@ RDEPEND="
 	>=media-libs/harfbuzz-1.5.0:=
 	media-libs/libcanberra
 	media-libs/libpng:0=
+	sys-apps/dbus
+	sys-libs/zlib
 	x11-libs/libxcb[xkb]
 	x11-libs/libXcursor
 	x11-libs/libXi
 	x11-libs/libXinerama
 	x11-libs/libxkbcommon[X]
 	x11-libs/libXrandr
-	sys-apps/dbus
-	sys-libs/zlib
+	x11-terms/kitty-terminfo
 	wayland? (
 		dev-libs/wayland
 		>=dev-libs/wayland-protocols-1.17
@@ -51,10 +52,12 @@ DEPEND="${RDEPEND}
 
 BDEPEND="virtual/pkgconfig"
 
-[[ ${PV} == *9999 ]] && BDEPEND+=" >=dev-python/sphinx-1.7"
+[[ ${PV} == *9999 ]] && BDEPEND+="
+	$(python_gen_cond_dep '>=dev-python/sphinx-1.7[${PYTHON_MULTI_USEDEP}]')"
 
 PATCHES=(
 	"${FILESDIR}"/kitty-0.17.2-flags.patch
+	"${FILESDIR}"/kitty-0.16.0-remove-terminfo.patch
 	"${FILESDIR}"/${PN}-0.14.4-svg-icon.patch
 )
 


### PR DESCRIPTION
Fix live ebuild and split the terminfo file into a new live ebuild for kitty-terminfo