### PR TITLE
app-text/docbook-sgml-utils: Adding dependencies

### DIFF
--- a/app-text/docbook-sgml-utils/docbook-sgml-utils-0.6.14-r4.ebuild
+++ b/app-text/docbook-sgml-utils/docbook-sgml-utils-0.6.14-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,18 +18,19 @@ IUSE="jadetex"
 
 DEPEND=">=dev-lang/perl-5
 	app-text/docbook-dsssl-stylesheets
+	app-text/docbook-xml-dtd:4.2
 	app-text/openjade
+	app-text/xhtml1
 	dev-perl/SGMLSpm
-	~app-text/docbook-xml-simple-dtd-4.1.2.4
-	~app-text/docbook-xml-simple-dtd-1.0
-	app-text/docbook-xml-dtd
 	~app-text/docbook-sgml-dtd-3.0
 	~app-text/docbook-sgml-dtd-3.1
 	~app-text/docbook-sgml-dtd-4.0
 	~app-text/docbook-sgml-dtd-4.1
 	~app-text/docbook-sgml-dtd-4.2
 	~app-text/docbook-sgml-dtd-4.4
-	jadetex? ( dev-texlive/texlive-formatsextra )
+	~app-text/docbook-xml-simple-dtd-1.0
+	~app-text/docbook-xml-simple-dtd-4.1.2.4
+	jadetex? ( app-text/jadetex )
 	userland_GNU? ( sys-apps/which )
 	|| (
 		www-client/lynx


### PR DESCRIPTION
Adding app-text/xhtml1 for /usr/share/sgml/xhtml1/xhtml.soc
Precising app-text/docbook-xml-dtd:4.2 for
/usr/share/sgml/docbook/xml-dtd-4.2/docbook.cat

Dropping alpha, arm, hppa, ia64, m68k, mips, s390, and sparc arches
because app-text/xhtml1 isn’t available on those

Closes: https://bugs.gentoo.org/703634
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Alarig Le Lay <alarig@swordarmor.fr>

Hi,

The build fails with out those dependencies, see https://703634.bugs.gentoo.org/attachment.cgi?id=627030

To ease the review, I’m pasting the diff with -r3:
``` diff
--- docbook-sgml-utils-0.6.14-r3.ebuild	2020-04-11 18:06:37.582815710 +0200
+++ docbook-sgml-utils-0.6.14-r4.ebuild	2020-04-11 18:55:53.342208872 +0200
@@ -13,22 +13,23 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 m68k ~mips ppc ppc64 s390 sparc x86 ~amd64-linux ~x86-linux ~x86-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x86-macos"
 IUSE="jadetex"
 
 DEPEND=">=dev-lang/perl-5
 	app-text/docbook-dsssl-stylesheets
+	app-text/docbook-xml-dtd:4.2
 	app-text/openjade
+	app-text/xhtml1
 	dev-perl/SGMLSpm
-	~app-text/docbook-xml-simple-dtd-4.1.2.4
-	~app-text/docbook-xml-simple-dtd-1.0
-	app-text/docbook-xml-dtd
 	~app-text/docbook-sgml-dtd-3.0
 	~app-text/docbook-sgml-dtd-3.1
 	~app-text/docbook-sgml-dtd-4.0
 	~app-text/docbook-sgml-dtd-4.1
 	~app-text/docbook-sgml-dtd-4.2
 	~app-text/docbook-sgml-dtd-4.4
+	~app-text/docbook-xml-simple-dtd-1.0
+	~app-text/docbook-xml-simple-dtd-4.1.2.4
 	jadetex? ( app-text/jadetex )
 	userland_GNU? ( sys-apps/which )
 	|| (
```

Here is the emerge output of -r4 (pulled by lxc):
https://paste.swordarmor.fr/raw/eeLx