### PR TITLE
sys-auth/google-authenticator: Remove failing tests.

### DIFF
--- a/sys-auth/google-authenticator/files/1.08-remove-failing-tests.patch
+++ b/sys-auth/google-authenticator/files/1.08-remove-failing-tests.patch
@@ -1,0 +1,301 @@
+From 9e26b1885250cb0b7a710d9ae65542e3fcae684f Mon Sep 17 00:00:00 2001
+From: Ronny Gutbrod <gentoo@tastytea.de>
+Date: Sat, 11 Apr 2020 21:08:37 +0200
+Subject: [PATCH] Remove calls to  pam_sm_authenticate().
+
+It tries to change the user id, which is prohibited by the sandbox. See #624588.
+---
+ tests/pam_google_authenticator_unittest.c | 271 ----------------------
+ 1 file changed, 271 deletions(-)
+
+diff --git a/tests/pam_google_authenticator_unittest.c b/tests/pam_google_authenticator_unittest.c
+index edade47..0661b8b 100644
+--- a/tests/pam_google_authenticator_unittest.c
++++ b/tests/pam_google_authenticator_unittest.c
+@@ -338,72 +338,6 @@ int main(int argc, char *argv[]) {
+     // Make sure num_prompts_shown is still 0.
+     verify_prompts_shown(0);
+
+-    // Set the timestamp that this test vector needs
+-    set_time(10000*30);
+-
+-    response = "123456";
+-
+-    // Check if we can log in when using an invalid verification code
+-    puts("Testing failed login attempt");
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-    verify_prompts_shown(expected_bad_prompts_shown);
+-
+-    // Check required number of digits
+-    if (conv_mode == TWO_PROMPTS) {
+-      puts("Testing required number of digits");
+-      response = "50548";
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-      verify_prompts_shown(expected_bad_prompts_shown);
+-      response = "0050548";
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-      verify_prompts_shown(expected_bad_prompts_shown);
+-      response = "00050548";
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-      verify_prompts_shown(expected_bad_prompts_shown);
+-    }
+-
+-    // Test a blank response
+-    puts("Testing a blank response");
+-    response = "";
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-    verify_prompts_shown(expected_bad_prompts_shown);
+-
+-    // Set the response that we should send back to the authentication module
+-    response = "050548";
+-
+-    // Test handling of missing state files
+-    puts("Test handling of missing state files");
+-    const char *old_secret = targv[0];
+-    targv[0] = "secret=/NOSUCHFILE";
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-    verify_prompts_shown(password_is_provided_from_external ? 0 : expected_bad_prompts_shown);
+-    targv[targc++] = "nullok";
+-    targv[targc] = NULL;
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_IGNORE);
+-    verify_prompts_shown(0);
+-    targv[--targc] = NULL;
+-    targv[0] = old_secret;
+-
+-    // Check if we can log in when using a valid verification code
+-    puts("Testing successful login");
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_SUCCESS);
+-    verify_prompts_shown(expected_good_prompts_shown);
+-
+-    // Test the STEP_SIZE option
+-    puts("Testing STEP_SIZE option");
+-    assert(!chmod(fn, 0600));
+-    assert((fd = open(fn, O_APPEND | O_WRONLY)) >= 0);
+-    assert(write(fd, "\n\" STEP_SIZE 60\n", 16) == 16);
+-    close(fd);
+-    for (int *tm  = (int []){ 9998, 9999, 10001, 10002, 10000, -1 },
+-             *res = (int []){ PAM_AUTH_ERR, PAM_SUCCESS, PAM_SUCCESS,
+-                              PAM_AUTH_ERR, PAM_SUCCESS };
+-         *tm >= 0;) {
+-      set_time(*tm++ * 60);
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) == *res++);
+-      verify_prompts_shown(expected_good_prompts_shown);
+-    }
+-
+     // Reset secret file after step size testing.
+     assert(!chmod(fn, 0600));
+     assert((fd = open(fn, O_TRUNC | O_WRONLY)) >= 0);
+@@ -411,211 +345,6 @@ int main(int argc, char *argv[]) {
+     assert(write(fd, "\n\" TOTP_AUTH", 12) == 12);
+     close(fd);
+
+-    // Test the WINDOW_SIZE option
+-    puts("Testing WINDOW_SIZE option");
+-    for (int *tm  = (int []){ 9998, 9999, 10001, 10002, 10000, -1 },
+-             *res = (int []){ PAM_AUTH_ERR, PAM_SUCCESS, PAM_SUCCESS,
+-                              PAM_AUTH_ERR, PAM_SUCCESS };
+-         *tm >= 0;) {
+-      set_time(*tm++ * 30);
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) == *res++);
+-      verify_prompts_shown(expected_good_prompts_shown);
+-    }
+-    assert(!chmod(fn, 0600));
+-    assert((fd = open(fn, O_APPEND | O_WRONLY)) >= 0);
+-    assert(write(fd, "\n\" WINDOW_SIZE 6\n", 17) == 17);
+-    close(fd);
+-    for (int *tm  = (int []){ 9996, 9997, 10002, 10003, 10000, -1 },
+-             *res = (int []){ PAM_AUTH_ERR, PAM_SUCCESS, PAM_SUCCESS,
+-                              PAM_AUTH_ERR, PAM_SUCCESS };
+-         *tm >= 0;) {
+-      set_time(*tm++ * 30);
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) == *res++);
+-      verify_prompts_shown(expected_good_prompts_shown);
+-    }
+-
+-    // Test the DISALLOW_REUSE option
+-    puts("Testing DISALLOW_REUSE option");
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_SUCCESS);
+-    verify_prompts_shown(expected_good_prompts_shown);
+-    assert(!chmod(fn, 0600));
+-    assert((fd = open(fn, O_APPEND | O_WRONLY)) >= 0);
+-    assert(write(fd, "\" DISALLOW_REUSE\n", 17) == 17);
+-    close(fd);
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_SUCCESS);
+-    verify_prompts_shown(expected_good_prompts_shown);
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-    verify_prompts_shown(expected_good_prompts_shown);
+-
+-    // Test that DISALLOW_REUSE expires old entries from the re-use list
+-    char *old_response = response;
+-    for (int i = 10001; i < 10008; ++i) {
+-      set_time(i * 30);
+-      char buf[7];
+-      response = buf;
+-      sprintf(response, "%06d", compute_code(binary_secret,
+-                                             binary_secret_len, i));
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_SUCCESS);
+-      verify_prompts_shown(expected_good_prompts_shown);
+-    }
+-    set_time(10000 * 30);
+-    response = old_response;
+-    assert((fd = open(fn, O_RDONLY)) >= 0);
+-    char state_file_buf[4096] = { 0 };
+-    assert(read(fd, state_file_buf, sizeof(state_file_buf)-1) > 0);
+-    close(fd);
+-    const char *disallow = strstr(state_file_buf, "\" DISALLOW_REUSE ");
+-    assert(disallow);
+-    assert(!memcmp(disallow + 17,
+-                   "10002 10003 10004 10005 10006 10007\n", 36));
+-
+-    // Test the RATE_LIMIT option
+-    puts("Testing RATE_LIMIT option");
+-    assert(!chmod(fn, 0600));
+-    assert((fd = open(fn, O_APPEND | O_WRONLY)) >= 0);
+-    assert(write(fd, "\" RATE_LIMIT 4 120\n", 19) == 19);
+-    close(fd);
+-    for (int *tm  = (int []){ 20000, 20001, 20002, 20003, 20004, 20006, -1 },
+-             *res = (int []){ PAM_SUCCESS, PAM_SUCCESS, PAM_SUCCESS,
+-                              PAM_SUCCESS, PAM_AUTH_ERR, PAM_SUCCESS, -1 };
+-         *tm >= 0;) {
+-      set_time(*tm * 30);
+-      char buf[7];
+-      response = buf;
+-      sprintf(response, "%06d",
+-              compute_code(binary_secret, binary_secret_len, *tm++));
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) == *res);
+-      verify_prompts_shown(
+-          *res != PAM_SUCCESS ? 0 : expected_good_prompts_shown);
+-      ++res;
+-    }
+-    set_time(10000 * 30);
+-    response = old_response;
+-    assert(!chmod(fn, 0600));
+-    assert((fd = open(fn, O_RDWR)) >= 0);
+-    memset(state_file_buf, 0, sizeof(state_file_buf));
+-    assert(read(fd, state_file_buf, sizeof(state_file_buf)-1) > 0);
+-    const char *rate_limit = strstr(state_file_buf, "\" RATE_LIMIT ");
+-    assert(rate_limit);
+-    assert(!memcmp(rate_limit + 13,
+-                   "4 120 600060 600090 600120 600180\n", 35));
+-
+-    // Test trailing space in RATE_LIMIT. This is considered a file format
+-    // error.
+-    char *eol = strchr(rate_limit, '\n');
+-    *eol = ' ';
+-    assert(!lseek(fd, 0, SEEK_SET));
+-    assert(write(fd, state_file_buf, strlen(state_file_buf)) ==
+-           strlen(state_file_buf));
+-    close(fd);
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-    verify_prompts_shown(0);
+-    assert(!strncmp(get_error_msg(),
+-                    "Invalid list of timestamps in RATE_LIMIT", 40));
+-    *eol = '\n';
+-    assert(!chmod(fn, 0600));
+-    assert((fd = open(fn, O_WRONLY)) >= 0);
+-    assert(write(fd, state_file_buf, strlen(state_file_buf)) ==
+-           strlen(state_file_buf));
+-    close(fd);
+-
+-    // Test TIME_SKEW option
+-    puts("Testing TIME_SKEW");
+-    for (int i = 0; i < 4; ++i) {
+-      set_time((12000 + i)*30);
+-      char buf[7];
+-      response = buf;
+-      sprintf(response, "%06d",
+-              compute_code(binary_secret, binary_secret_len, 11000 + i));
+-      assert(pam_sm_authenticate(NULL, 0, targc, targv) ==
+-             (i >= 2 ? PAM_SUCCESS : PAM_AUTH_ERR));
+-      verify_prompts_shown(expected_good_prompts_shown);
+-    }
+-
+-    puts("Testing TIME_SKEW - noskewadj");
+-    set_time(12020 * 30);
+-    char buf[7];
+-    response = buf;
+-    sprintf(response, "%06d", compute_code(binary_secret,
+-                                           binary_secret_len, 11010));
+-    targv[targc] = "noskewadj";
+-    assert(pam_sm_authenticate(NULL, 0, targc+1, targv) == PAM_AUTH_ERR);
+-    targv[targc] = NULL;
+-    verify_prompts_shown(expected_bad_prompts_shown);
+-    set_time(10000*30);
+-
+-    // Test scratch codes
+-    puts("Testing scratch codes");
+-    response = "12345678";
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-    verify_prompts_shown(expected_bad_prompts_shown);
+-    assert(!chmod(fn, 0600));
+-    assert((fd = open(fn, O_APPEND | O_WRONLY)) >= 0);
+-    assert(write(fd, "12345678\n", 9) == 9);
+-    close(fd);
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_SUCCESS);
+-    verify_prompts_shown(expected_good_prompts_shown);
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-    verify_prompts_shown(expected_bad_prompts_shown);
+-
+-    // Set up secret file for counter-based codes.
+-    assert(!chmod(fn, 0600));
+-    assert((fd = open(fn, O_TRUNC | O_WRONLY)) >= 0);
+-    assert(write(fd, secret, sizeof(secret)-1) == sizeof(secret)-1);
+-    assert(write(fd, "\n\" HOTP_COUNTER 1\n", 18) == 18);
+-    close(fd);
+-
+-    response = "293240";
+-
+-    // Check if we can log in when using a valid verification code
+-    puts("Testing successful counter-based login");
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_SUCCESS);
+-    verify_prompts_shown(expected_good_prompts_shown);
+-
+-    // Verify that the hotp counter incremented
+-    assert((fd = open(fn, O_RDONLY)) >= 0);
+-    memset(state_file_buf, 0, sizeof(state_file_buf));
+-    assert(read(fd, state_file_buf, sizeof(state_file_buf)-1) > 0);
+-    close(fd);
+-    const char *hotp_counter = strstr(state_file_buf, "\" HOTP_COUNTER ");
+-    assert(hotp_counter);
+-    assert(!memcmp(hotp_counter + 15, "2\n", 2));
+-
+-    // Check if we can log in when using an invalid verification code
+-    // (including the same code a second time)
+-    puts("Testing failed counter-based login attempt");
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_AUTH_ERR);
+-    verify_prompts_shown(expected_bad_prompts_shown);
+-
+-    // Verify that the hotp counter incremented
+-    assert((fd = open(fn, O_RDONLY)) >= 0);
+-    memset(state_file_buf, 0, sizeof(state_file_buf));
+-    assert(read(fd, state_file_buf, sizeof(state_file_buf)-1) > 0);
+-    close(fd);
+-    hotp_counter = strstr(state_file_buf, "\" HOTP_COUNTER ");
+-    assert(hotp_counter);
+-    assert(!memcmp(hotp_counter + 15, "3\n", 2));
+-
+-    response = "932068";
+-
+-    // Check if we can log in using a future valid verification code (using
+-    // default window_size of 3)
+-    puts("Testing successful future counter-based login");
+-    assert(pam_sm_authenticate(NULL, 0, targc, targv) == PAM_SUCCESS);
+-    verify_prompts_shown(expected_good_prompts_shown);
+-
+-    // Verify that the hotp counter incremented
+-    assert((fd = open(fn, O_RDONLY)) >= 0);
+-    memset(state_file_buf, 0, sizeof(state_file_buf));
+-    assert(read(fd, state_file_buf, sizeof(state_file_buf)-1) > 0);
+-    close(fd);
+-    hotp_counter = strstr(state_file_buf, "\" HOTP_COUNTER ");
+-    assert(hotp_counter);
+-    assert(!memcmp(hotp_counter + 15, "6\n", 2));
+-
+-    // Remove the temporarily created secret file
+-    unlink(fn);
+-
+     // Release memory for the test arguments
+     for (int i = 0; i < targc; ++i) {
+       free((void *)targv[i]);
+--
+2.24.1

--- a/sys-auth/google-authenticator/google-authenticator-1.08.ebuild
+++ b/sys-auth/google-authenticator/google-authenticator-1.08.ebuild
@@ -24,7 +24,7 @@ IUSE=""
 DEPEND="sys-libs/pam"
 RDEPEND="${DEPEND}"
 
-RESTRICT="test"
+PATCHES=( "${FILESDIR}/1.08-remove-failing-tests.patch" )
 
 src_prepare() {
 	default

--- a/sys-auth/google-authenticator/google-authenticator-9999.ebuild
+++ b/sys-auth/google-authenticator/google-authenticator-9999.ebuild
@@ -24,7 +24,7 @@ IUSE=""
 DEPEND="sys-libs/pam"
 RDEPEND="${DEPEND}"
 
-RESTRICT="test"
+PATCHES=( "${FILESDIR}/1.08-remove-failing-tests.patch" )
 
 src_prepare() {
 	default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/624588
Signed-off-by: Ronny Gutbrod <gentoo@tastytea.de>

----

The calls to `pam_sm_authenticate` are causing an attempt to change the user to
nobody. That fails due to sandboxing. The patch removes all calls to
`pam_sm_authenticate`.