### PR TITLE
media-gfx/opencsg: restrict testing

### DIFF
--- a/media-gfx/opencsg/opencsg-1.4.2-r1.ebuild
+++ b/media-gfx/opencsg/opencsg-1.4.2-r1.ebuild
@@ -14,6 +14,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="doc"
+RESTRICT="test"
 
 RDEPEND="
 	dev-libs/libbsd


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/717104
Package-Manager: Portage-2.3.96, Repoman-2.3.22
Signed-off-by: Bernd Waibel <waebbl@gmail.com>