### PR TITLE
net-misc/curl: add IMAP, POP3 and SMTP IUSE flags

### DIFF
--- a/net-misc/curl/curl-7.69.1.ebuild
+++ b/net-misc/curl/curl-7.69.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://curl.haxx.se/download/${P}.tar.xz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="adns alt-svc brotli http2 idn ipv6 kerberos ldap metalink +progress-meter rtmp samba ssh ssl static-libs test threads"
+IUSE="adns alt-svc brotli http2 idn +imap ipv6 kerberos ldap metalink +pop3 +progress-meter rtmp samba +smtp ssh ssl static-libs test threads"
 IUSE+=" curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
 IUSE+=" nghttp3 quiche"
 IUSE+=" elibc_Winnt"
@@ -167,16 +167,16 @@ multilib_src_configure() {
 		--enable-ftp \
 		--enable-gopher \
 		--enable-http \
-		--enable-imap \
+		$(use_enable imap) \
 		$(use_enable ldap) \
 		$(use_enable ldap ldaps) \
 		--disable-ntlm-wb \
-		--enable-pop3 \
+		$(use_enable pop3) \
 		--enable-rt  \
 		--enable-rtsp \
 		$(use_enable samba smb) \
 		$(use_with ssh libssh2) \
-		--enable-smtp \
+		$(use_enable smtp) \
 		--enable-telnet \
 		--enable-tftp \
 		--enable-tls-srp \

--- a/net-misc/curl/metadata.xml
+++ b/net-misc/curl/metadata.xml
@@ -9,11 +9,14 @@
 		<flag name="alt-svc">Enable alt-svc support</flag>
 		<flag name="brotli">Enable brotli compression support</flag>
 		<flag name="http2">Enable HTTP/2.0 support</flag>
+		<flag name="imap">Enable Internet Message Access Protocol support</flag>
 		<flag name="nghttp3">Enable HTTP/3.0 support using <pkg>net-libs/nghttp3</pkg> and <pkg>net-libs/ngtcp2</pkg></flag>
 		<flag name="quiche">Enable HTTP/3.0 support using <pkg>net-libs/quiche</pkg></flag>
 		<flag name="ssh">Enable SSH urls in curl using libssh2</flag>
 		<flag name="metalink">Enable metalink support</flag>
+		<flag name="pop3">Enable Post Office Protocol 3 support</flag>
 		<flag name="progress-meter">Enable the progress meter</flag>
+		<flag name="smtp">Enable Simple Mail Transfer Protocol support</flag>
 		<flag name="ssl">Enable crypto engine support (via openssl if USE='-gnutls -nss')</flag>
 		<flag name="rtmp">Enable RTMP Streaming Media support</flag>
 	</use>


### PR DESCRIPTION
This commit enables control over IMAP, POP3 and SMTP protocols support by editing their IUSE flags.

Package-Manager: Portage-2.3.89, Repoman-2.3.
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>
Signed-off-by: Luka Perkov <luka.perkov@sartura.hr>