### PR TITLE
app-emulation/libvirt: Require fuse with a proper slot

### DIFF
--- a/app-emulation/libvirt/libvirt-6.1.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-6.1.0-r1.ebuild
@@ -71,7 +71,7 @@ RDEPEND="
 	dbus? ( sys-apps/dbus )
 	dtrace? ( dev-util/systemtap )
 	firewalld? ( >=net-firewall/firewalld-0.6.3 )
-	fuse? ( >=sys-fs/fuse-2.8.6:= )
+	fuse? ( sys-fs/fuse:0= )
 	glusterfs? ( >=sys-cluster/glusterfs-3.4.1 )
 	iscsi? ( sys-block/open-iscsi )
 	iscsi-direct? ( >=net-libs/libiscsi-1.18.0 )

--- a/app-emulation/libvirt/libvirt-6.2.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-6.2.0-r2.ebuild
@@ -71,7 +71,7 @@ RDEPEND="
 	dbus? ( sys-apps/dbus )
 	dtrace? ( dev-util/systemtap )
 	firewalld? ( >=net-firewall/firewalld-0.6.3 )
-	fuse? ( >=sys-fs/fuse-2.8.6:= )
+	fuse? ( sys-fs/fuse:0= )
 	glusterfs? ( >=sys-cluster/glusterfs-3.4.1 )
 	iscsi? ( sys-block/open-iscsi )
 	iscsi-direct? ( >=net-libs/libiscsi-1.18.0 )

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -71,7 +71,7 @@ RDEPEND="
 	dbus? ( sys-apps/dbus )
 	dtrace? ( dev-util/systemtap )
 	firewalld? ( >=net-firewall/firewalld-0.6.3 )
-	fuse? ( >=sys-fs/fuse-2.8.6:= )
+	fuse? ( sys-fs/fuse:0= )
 	glusterfs? ( >=sys-cluster/glusterfs-3.4.1 )
 	iscsi? ( sys-block/open-iscsi )
 	iscsi-direct? ( >=net-libs/libiscsi-1.18.0 )


### PR DESCRIPTION
The only supported versions are pre-fuse3 (just like in other packages),
building with only fuse:3 installed would not work without this change.  It was
fixed for 6.0.0 in commit f94f3f25cefc, not dissimilar to this one.  The version
is removed because older versions are not part of the repository any more.

Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>
Package-Manager: Portage-2.3.89, Repoman-2.3.22