### PR TITLE
net-libs/libpri: Take maintainership.

### DIFF
--- a/net-libs/libpri/metadata.xml
+++ b/net-libs/libpri/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>chainsaw@gentoo.org</email>
-    <name>Tony Vroon</name>
-  </maintainer>
+	<maintainer type="person">
+		<email>jaco@uls.co.za</email>
+		<name>Jaco Kroon</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
To the best of my knowledge asterisk and DAHDI is the only consumer.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jaco Kroon <jaco@uls.co.za>