### PR TITLE
media-sound/xmms2: Patch around faad plugin breakage since faad 2.9.0

### DIFF
--- a/media-sound/xmms2/files/xmms2-0.8_p20161122-faad.patch
+++ b/media-sound/xmms2/files/xmms2-0.8_p20161122-faad.patch
@@ -1,0 +1,18 @@
+This line has stopped working since security fixes in the faad 2.9.0
+release. XMMS2 upstream were informed via IRC but have yet to act on
+it. I've run XMMS2 with this patch for months without issue.
+
+-- Chewi
+
+diff --git a/src/plugins/faad/faad.c b/src/plugins/faad/faad.c
+index 50835d27..7074e1b5 100644
+--- a/src/plugins/faad/faad.c
++++ b/src/plugins/faad/faad.c
+@@ -242,7 +242,6 @@ xmms_faad_init (xmms_xform_t *xform)
+ 	 * and durations calculations... So we cheat and tell libfaad2 we're feeding
+ 	 * it frame 1.
+ 	 */
+-	NeAACDecPostSeekReset (data->decoder, 1);
+ 
+ 	/* FIXME: Because for HE AAC files some versions of libfaad return the wrong
+ 	 * samplerate in init, we have to do one read and let it decide the real

--- a/media-sound/xmms2/xmms2-0.8_p20161122-r7.ebuild
+++ b/media-sound/xmms2/xmms2-0.8_p20161122-r7.ebuild
@@ -114,6 +114,9 @@ PATCHES=(
 
 	# gcc-10 stopped putting globals into common section
 	"${FILESDIR}/${P}"-gcc-10.patch
+
+	# fix required since faad 2.9.0
+	"${FILESDIR}/${P}"-faad.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: James Le Cuirot <chewi@gentoo.org>