### PR TITLE
net-misc/curl: add ftp, gopher, telnet and tftp USE flags

### DIFF
--- a/net-misc/curl/curl-7.69.1.ebuild
+++ b/net-misc/curl/curl-7.69.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://curl.haxx.se/download/${P}.tar.xz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="adns alt-svc brotli http2 idn +imap ipv6 kerberos ldap metalink +pop3 +progress-meter rtmp samba +smtp ssh ssl static-libs test threads"
+IUSE="adns alt-svc brotli +ftp gopher http2 idn +imap ipv6 kerberos ldap metalink +pop3 +progress-meter rtmp samba +smtp ssh ssl static-libs test telnet +tftp threads"
 IUSE+=" curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
 IUSE+=" nghttp3 quiche"
 IUSE+=" elibc_Winnt"
@@ -164,8 +164,8 @@ multilib_src_configure() {
 		--enable-dict \
 		--disable-esni \
 		--enable-file \
-		--enable-ftp \
-		--enable-gopher \
+		$(use_enable ftp) \
+		$(use_enable gopher) \
 		--enable-http \
 		$(use_enable imap) \
 		$(use_enable ldap) \
@@ -177,8 +177,8 @@ multilib_src_configure() {
 		$(use_enable samba smb) \
 		$(use_with ssh libssh2) \
 		$(use_enable smtp) \
-		--enable-telnet \
-		--enable-tftp \
+		$(use_enable telnet) \
+		$(use_enable tftp) \
 		--enable-tls-srp \
 		$(use_enable adns ares) \
 		--enable-cookies \

--- a/net-misc/curl/metadata.xml
+++ b/net-misc/curl/metadata.xml
@@ -8,6 +8,8 @@
 	<use>
 		<flag name="alt-svc">Enable alt-svc support</flag>
 		<flag name="brotli">Enable brotli compression support</flag>
+		<flag name="ftp">Enable FTP support</flag>
+		<flag name="gopher">Enable Gopher protocol support</flag>
 		<flag name="http2">Enable HTTP/2.0 support</flag>
 		<flag name="imap">Enable Internet Message Access Protocol support</flag>
 		<flag name="nghttp3">Enable HTTP/3.0 support using <pkg>net-libs/nghttp3</pkg> and <pkg>net-libs/ngtcp2</pkg></flag>
@@ -18,6 +20,8 @@
 		<flag name="progress-meter">Enable the progress meter</flag>
 		<flag name="smtp">Enable Simple Mail Transfer Protocol support</flag>
 		<flag name="ssl">Enable crypto engine support (via openssl if USE='-gnutls -nss')</flag>
+		<flag name="telnet">Enable Telnet protocol support</flag>
+		<flag name="tftp">Enable TFTP support</flag>
 		<flag name="rtmp">Enable RTMP Streaming Media support</flag>
 	</use>
 	<upstream>


### PR DESCRIPTION
Enable control over FTP, Gopher, Telnet and TFTP protocols.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>
Signed-off-by: Luka Perkov <luka.perkov@sartura.hr>