### PR TITLE
sys-apps/systemd: add hwdb USE flag

### DIFF
--- a/sys-apps/systemd/metadata.xml
+++ b/sys-apps/systemd/metadata.xml
@@ -20,6 +20,7 @@
 		<flag name="gcrypt">Enable sealing of journal files using gcrypt</flag>
 		<flag name="homed">Enable portable home directories</flag>
 		<flag name="http">Enable embedded HTTP server in journald</flag>
+		<flag name="hwdb">Enable control over hwdb</flag>
 		<flag name="importd">Enable import daemon</flag>
 		<flag name="kmod">Enable kernel module loading via <pkg>sys-apps/kmod</pkg></flag>
 		<flag name="lz4">Enable lz4 compression for the journal</flag>

--- a/sys-apps/systemd/systemd-245-r3.ebuild
+++ b/sys-apps/systemd/systemd-245-r3.ebuild
@@ -28,7 +28,7 @@ HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
-IUSE="acl apparmor audit build cgroup-hybrid cryptsetup curl dns-over-tls elfutils +gcrypt gnuefi homed http idn importd +kmod +lz4 lzma nat pam pcre pkcs11 policykit pwquality qrcode repart +resolvconf +seccomp selinux split-usr static-libs +sysv-utils test vanilla xkb"
+IUSE="acl apparmor audit build cgroup-hybrid cryptsetup curl dns-over-tls elfutils +gcrypt gnuefi homed http +hwdb idn importd +kmod +lz4 lzma nat pam pcre pkcs11 policykit pwquality qrcode repart +resolvconf +seccomp selinux split-usr static-libs +sysv-utils test vanilla xkb"
 
 REQUIRED_USE="
 	homed? ( cryptsetup )
@@ -119,7 +119,7 @@ RDEPEND="${COMMON_DEPEND}
 
 # sys-apps/dbus: the daemon only (+ build-time lib dep for tests)
 PDEPEND=">=sys-apps/dbus-1.9.8[systemd]
-	>=sys-apps/hwids-20150417[udev]
+	hwdb? ( >=sys-apps/hwids-20150417[udev] )
 	>=sys-fs/udev-init-scripts-25
 	policykit? ( sys-auth/polkit )
 	!vanilla? ( sys-apps/gentoo-systemd-integration )"
@@ -275,6 +275,7 @@ multilib_src_configure() {
 		-Dgnu-efi=$(meson_multilib_native_use gnuefi)
 		-Defi-libdir="${ESYSROOT}/usr/$(get_libdir)"
 		-Dhomed=$(meson_multilib_native_use homed)
+		-Dhwdb=$(meson_multilib_native_use hwdb)
 		-Dmicrohttpd=$(meson_multilib_native_use http)
 		-Didn=$(meson_multilib_native_use idn)
 		-Dimportd=$(meson_multilib_native_use importd)
@@ -308,7 +309,6 @@ multilib_src_configure() {
 		-Dfirstboot=$(meson_multilib)
 		-Dhibernate=$(meson_multilib)
 		-Dhostnamed=$(meson_multilib)
-		-Dhwdb=$(meson_multilib)
 		-Dldconfig=$(meson_multilib)
 		-Dlocaled=$(meson_multilib)
 		-Dman=$(meson_multilib)
@@ -370,7 +370,12 @@ multilib_src_install_all() {
 	keepdir /etc/{binfmt.d,modules-load.d,tmpfiles.d}
 	keepdir /etc/kernel/install.d
 	keepdir /etc/systemd/{network,system,user}
-	keepdir /etc/udev/{hwdb.d,rules.d}
+	keepdir /etc/udev/rules.d
+
+	if use hwdb; then
+		keepdir /etc/udev/hwdb.d
+	fi
+
 	keepdir "${rootprefix}"/lib/systemd/{system-sleep,system-shutdown}
 	keepdir /usr/lib/{binfmt.d,modules-load.d}
 	keepdir /usr/lib/systemd/user-generators
@@ -380,7 +385,9 @@ multilib_src_install_all() {
 	# Symlink /etc/sysctl.conf for easy migration.
 	dosym ../sysctl.conf /etc/sysctl.d/99-sysctl.conf
 
-	rm -r "${ED}${rootprefix}"/lib/udev/hwdb.d || die
+	if use hwdb; then
+		rm -r "${ED}${rootprefix}"/lib/udev/hwdb.d || die
+	fi
 
 	if use split-usr; then
 		# Avoid breaking boot/reboot


### PR DESCRIPTION
Enables building systemd without hwdb, which saves approx. 10 kB of space.
Furthermore, sys-apps/hwids dependancy is dropped if hwdb support is turned off, which saves additional 15 MB of space.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>
Signed-off-by: Josip Kelecic <josip.kelecic@sartura.hr>
Signed-off-by: Jakov Petrina <jakov.petrina@sartura.hr>
Signed-off-by: Luka Perkov <luka.perkov@sartura.hr>