### PR TITLE
sys-apps/man-pages: remove old

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Mattéo Rossillol‑‑Laruelle <beatussum@protonmail.com> (2020-04-17)
+# app-i18n/man-pages-fr masked for removal (bug #717744).
+<sys-apps/man-pages-5.05-r2 l10n_fr
+
 # Ulrich Müller <ulm@gentoo.org> (2020-04-15)
 # app-i18n/man-pages-nl masked for removal. Bug #713590.
 <sys-apps/man-pages-5.05-r1 l10n_nl

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -32,6 +32,13 @@
 
 #--- END OF EXAMPLES ---
 
+# Mattéo Rossillol‑‑Laruelle <beatussum@protonmail.com> (2020-04-17)
+# Very little activity for almost a year and the link to download the
+# "compiled" man-pages is dead.
+# Use app-i18n/man-pages-l10n[l10n_fr] as replacement.
+# Masked for removal in 30 days (bug #717744).
+app-i18n/man-pages-fr
+
 # Michał Górny <mgorny@gentoo.org> (2020-04-16)
 # Both packages have been last bumped mid-2018.  They depend
 # on pytest-relaxed plugin that has been removed due to breaking pretty


### PR DESCRIPTION
This package was replaced by **app-i18n/man-pages-l10n[l10n_fr]**.