### PR TITLE
sys-cluster/spark-bin: Add proxy maintainer

### DIFF
--- a/sys-cluster/spark-bin/metadata.xml
+++ b/sys-cluster/spark-bin/metadata.xml
@@ -5,4 +5,12 @@
     <email>java@gentoo.org</email>
     <name>Gentoo Java Team</name>
   </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
+  <maintainer type="person">
+    <email>alec@alectenharmsel.com</email>
+    <name>Alec Ten Harmsel</name>
+  </maintainer>
 </pkgmetadata>


### PR DESCRIPTION
Adding myself as a proxy maintainer after accidental removal.

Bug: https://bugs.gentoo.org/670670
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Alec Ten Harmsel <alec@alectenharmsel.com>