### PR TITLE
app-misc/hivex build fixes

### DIFF
--- a/app-misc/hivex/hivex-1.3.18.ebuild
+++ b/app-misc/hivex/hivex-1.3.18.ebuild
@@ -105,8 +105,4 @@ src_install() {
 	if use perl; then
 		perl_delete_localpod
 	fi
-
-	#can't figure out a better way to do this
-	mv "${ED}"/usr/man/man3/* "${ED}/usr/share/man/man3/" || die
-	rm -r "${ED}/usr/man" || die
 }

--- a/app-misc/hivex/hivex-1.3.18.ebuild
+++ b/app-misc/hivex/hivex-1.3.18.ebuild
@@ -96,7 +96,9 @@ src_install() {
 	strip-linguas -i po
 
 	emake install DESTDIR="${ED}" "LINGUAS=""${LINGUAS}"""
-	python_optimize
+	if use python; then
+		python_optimize
+	fi
 
 	ruby-ng_src_install
 


### PR DESCRIPTION
Current ebuild fails to build when USE=-python.
It also fails trying to remove non-existing files.