### PR TITLE
net-misc/curl: Extend configuration options

### DIFF
--- a/net-misc/curl/curl-7.69.1.ebuild
+++ b/net-misc/curl/curl-7.69.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://curl.haxx.se/download/${P}.tar.xz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="adns alt-svc brotli +ftp gopher http2 idn +imap ipv6 kerberos ldap metalink +pop3 +progress-meter rtmp samba +smtp ssh ssl static-libs test telnet +tftp threads"
+IUSE="adns alt-svc brotli +dateparse +dict +dnsshuffle +doh +file +ftp gopher +hidden-symbols http2 idn +imap ipv6 kerberos ldap +libcurl-option +manual +mime metalink +netrc +pop3 +progress-meter +proxy rtmp +rtsp samba +smtp ssh ssl static-libs test telnet +tftp +tls-srp threads +unix-sockets"
 IUSE+=" curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss +curl_ssl_openssl curl_ssl_winssl"
 IUSE+=" nghttp3 quiche"
 IUSE+=" elibc_Winnt"
@@ -161,39 +161,41 @@ multilib_src_configure() {
 	econf \
 		$(use_enable alt-svc) \
 		--enable-crypto-auth \
-		--enable-dict \
+		$(use_enable dict) \
 		--disable-esni \
-		--enable-file \
+		$(use_enable file) \
 		$(use_enable ftp) \
 		$(use_enable gopher) \
 		--enable-http \
 		$(use_enable imap) \
 		$(use_enable ldap) \
 		$(use_enable ldap ldaps) \
+		$(use_enable libcurl-option) \
 		--disable-ntlm-wb \
 		$(use_enable pop3) \
 		--enable-rt  \
-		--enable-rtsp \
+		$(use_enable rtsp) \
 		$(use_enable samba smb) \
 		$(use_with ssh libssh2) \
 		$(use_enable smtp) \
 		$(use_enable telnet) \
 		$(use_enable tftp) \
-		--enable-tls-srp \
+		$(use_enable tls-srp) \
+		$(use_enable unix-sockets) \
 		$(use_enable adns ares) \
 		--enable-cookies \
-		--enable-dateparse \
-		--enable-dnsshuffle \
-		--enable-doh \
-		--enable-hidden-symbols \
+		$(use_enable dateparse) \
+		$(use_enable dnsshuffle) \
+		$(use_enable doh) \
+		$(use_enable hidden-symbols) \
 		--enable-http-auth \
 		$(use_enable ipv6) \
 		--enable-largefile \
-		--enable-manual \
-		--enable-mime \
-		--enable-netrc \
+		$(use_enable manual) \
+		$(use_enable mime) \
+		$(use_enable netrc) \
 		$(use_enable progress-meter) \
-		--enable-proxy \
+		$(use_enable proxy) \
 		--disable-sspi \
 		$(use_enable static-libs static) \
 		$(use_enable threads threaded-resolver) \

--- a/net-misc/curl/metadata.xml
+++ b/net-misc/curl/metadata.xml
@@ -8,21 +8,35 @@
 	<use>
 		<flag name="alt-svc">Enable alt-svc support</flag>
 		<flag name="brotli">Enable brotli compression support</flag>
+		<flag name="dateparse">Enable date parsing support</flag>
+		<flag name="dict">Enable DICT support</flag>
+		<flag name="dnsshuffle">Enable DNS shuffling support</flag>
+		<flag name="doh">Enable DoH support</flag>
+		<flag name="file">Enable file support</flag>
 		<flag name="ftp">Enable FTP support</flag>
 		<flag name="gopher">Enable Gopher protocol support</flag>
+		<flag name="hidden-symbols">Enable hidden symbols support</flag>
 		<flag name="http2">Enable HTTP/2.0 support</flag>
 		<flag name="imap">Enable Internet Message Access Protocol support</flag>
+		<flag name="libcurl-option">Enable libcurl C code generation support</flag>
+		<flag name="manual">Provide the built-in manual</flag>
+		<flag name="mime">Enable mime API support</flag>
+		<flag name="netrc">Enable netrc parsing support</flag>
 		<flag name="nghttp3">Enable HTTP/3.0 support using <pkg>net-libs/nghttp3</pkg> and <pkg>net-libs/ngtcp2</pkg></flag>
 		<flag name="quiche">Enable HTTP/3.0 support using <pkg>net-libs/quiche</pkg></flag>
 		<flag name="ssh">Enable SSH urls in curl using libssh2</flag>
 		<flag name="metalink">Enable metalink support</flag>
 		<flag name="pop3">Enable Post Office Protocol 3 support</flag>
 		<flag name="progress-meter">Enable the progress meter</flag>
+		<flag name="proxy">Enable proxy support</flag>
+		<flag name="rtsp">Enable RSTP support</flag>
 		<flag name="smtp">Enable Simple Mail Transfer Protocol support</flag>
 		<flag name="ssl">Enable crypto engine support (via openssl if USE='-gnutls -nss')</flag>
 		<flag name="telnet">Enable Telnet protocol support</flag>
+		<flag name="tls-srp">Enable TLS-SRP support"</flag>
 		<flag name="tftp">Enable TFTP support</flag>
 		<flag name="rtmp">Enable RTMP Streaming Media support</flag>
+		<flag name="unix-sockets">Enable Unix-domain sockets</flag>
 	</use>
 	<upstream>
 		<remote-id type="cpe">cpe:/a:curl:curl</remote-id>


### PR DESCRIPTION
Introduces new configuration options with added USE flags.
Also enables the option to control libcurl C code and Unix domain sockets support.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>
Signed-off-by: Luka Perkov <luka.perkov@sartura.hr>