### PR TITLE
net-im/psi: added cmake flag to compile with detailed version

### DIFF
--- a/net-im/psi/psi-9999.ebuild
+++ b/net-im/psi/psi-9999.ebuild
@@ -118,6 +118,7 @@ src_configure() {
 	use webkit && chattype=webkit
 
 	local mycmakeargs=(
+		-DPRODUCTION=OFF
 		-DUSE_ASPELL=$(usex aspell)
 		-DUSE_ENCHANT=$(usex enchant)
 		-DUSE_HUNSPELL=$(usex hunspell)


### PR DESCRIPTION
Signed-off-by: Sergey Ilinykh <rion4ik@gmail.com>

The flag adds git revision information