### PR TITLE
www-client/chromium: add ppc64 glue

### DIFF
--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2020-04-19)
+# Unsupported on ppc/ppc64
+www-client/chromium proprietary-codecs tcmalloc widevine
+
 # Patrick McLean <chutzpah@gentoo.org> (2020-04-03)
 # Lots of deps for little gain
 dev-python/joblib doc

--- a/www-client/chromium/chromium-83.0.4103.14.ebuild
+++ b/www-client/chromium/chromium-83.0.4103.14.ebuild
@@ -91,9 +91,6 @@ BDEPEND="
 	${PYTHON_DEPS}
 	>=app-arch/gzip-1.7
 	app-arch/unzip
-	!arm? (
-		dev-lang/yasm
-	)
 	dev-lang/perl
 	>=dev-util/gn-0.1726
 	dev-vcs/git
@@ -103,8 +100,12 @@ BDEPEND="
 	sys-apps/hwids[usb(+)]
 	>=sys-devel/bison-2.4.3
 	sys-devel/flex
-	closure-compile? ( virtual/jre )
 	virtual/pkgconfig
+	closure-compile? ( virtual/jre )
+	!system-libvpx? (
+		amd64? ( dev-lang/yasm )
+		x86? ( dev-lang/yasm )
+	)
 "
 
 : ${CHROMIUM_FORCE_CLANG=no}
@@ -419,6 +420,15 @@ src_prepare() {
 	if ! use system-libvpx; then
 		keeplibs+=( third_party/libvpx )
 		keeplibs+=( third_party/libvpx/source/libvpx/third_party/x86inc )
+
+		# we need to generate ppc64 stuff because upstream does not ship it yet
+		# it has to be done before unbundling.
+		if use ppc64; then
+			pushd third_party/libvpx >/dev/null || die
+			mkdir -p source/config/linux/ppc64 || die
+			./generate_gni.sh || die
+			popd >/dev/null || die
+		fi	
 	fi
 	if use tcmalloc; then
 		keeplibs+=( third_party/tcmalloc )
@@ -586,6 +596,9 @@ src_configure() {
 	elif [[ $myarch = arm ]] ; then
 		myconf_gn+=" target_cpu=\"arm\""
 		ffmpeg_target_arch=$(usex cpu_flags_arm_neon arm-neon arm)
+	elif [[ $myarch = ppc64 ]] ; then
+		myconf_gn+=" target_cpu=\"ppc64\""
+		ffmpeg_target_arch=ppc64
 	else
 		die "Failed to determine target arch, got '$myarch'."
 	fi


### PR DESCRIPTION
no keywords, but this allows users do download patches
and use gentoo ebuild to install chromium on ppc64le machines

patch downloader script available at:
https://gist.github.com/gyakovlev/d9dee9a554f5f1ff086b15e6f927ebf7

Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>