### PR TITLE
net-misc/asterisk: fix USE=-samples.

### DIFF
--- a/net-misc/asterisk/asterisk-13.32.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-13.32.0-r1.ebuild
@@ -247,21 +247,13 @@ src_install() {
 	diropts -m 0750 -o root -g asterisk
 	keepdir	/etc/asterisk
 	if use samples; then
-		emake NOISY_BUILD=yes DESTDIR="${ED}" samples
+		emake NOISY_BUILD=yes DESTDIR="${ED}" CONFIG_SRC=configs/samples CONFIG_EXTEN=.sample install-configs
 		for conffile in "${ED}/etc/asterisk/"*
 		do
 			fowners root:root "${conffile#${ED}}"
 			fperms 0644 "${conffile#${ED}}"
 		done
-		einfo "Sample files have been installed"
-	else
-		einfo "Skipping installation of sample files..."
-		rm "${ED}"/var/lib/asterisk/mohmp3/* || die
-		rm "${ED}"/var/lib/asterisk/sounds/demo-* || die
-		rm "${ED}"/var/lib/asterisk/agi-bin/* || die
-		rm "${ED}"/etc/asterisk/* || die
 	fi
-	rm -r "${ED}"/var/spool/asterisk/voicemail/default || die
 
 	# keep directories
 	diropts -m 0750 -o asterisk -g root

--- a/net-misc/asterisk/asterisk-16.9.0.ebuild
+++ b/net-misc/asterisk/asterisk-16.9.0.ebuild
@@ -248,21 +248,13 @@ src_install() {
 	diropts -m 0750 -o root -g asterisk
 	keepdir	/etc/asterisk
 	if use samples; then
-		emake NOISY_BUILD=yes DESTDIR="${ED}" samples
+		emake NOISY_BUILD=yes DESTDIR="${ED}" CONFIG_SRC=configs/samples CONFIG_EXTEN=.sample install-configs
 		for conffile in "${ED}/etc/asterisk/"*
 		do
 			fowners root:root "${conffile#${ED}}"
 			fperms 0644 "${conffile#${ED}}"
 		done
-		einfo "Sample files have been installed"
-	else
-		einfo "Skipping installation of sample files..."
-		rm "${ED}"/var/lib/asterisk/mohmp3/* || die
-		rm "${ED}"/var/lib/asterisk/sounds/demo-* || die
-		rm "${ED}"/var/lib/asterisk/agi-bin/* || die
-		rm "${ED}"/etc/asterisk/* || die
 	fi
-	rm -r "${ED}"/var/spool/asterisk/voicemail/default || die
 
 	# keep directories
 	diropts -m 0750 -o asterisk -g root


### PR DESCRIPTION
Note: USE=samples only really install default configs into
/etc/asterisk, as such, IUSE=samples is going away on the next bump, so
default configs will be installed.  Use INSTALL_MASK to prevent this if
you don't want this:

INSTALL_MASK=/etc/asterisk/* in make.conf

Closes: https://bugs.gentoo.org/717450
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jaco Kroon <jaco@uls.co.za>