### PR TITLE
app-admin/abrt: add missing dependency on libreport-gtk

### DIFF
--- a/app-admin/abrt/abrt-2.14.0.ebuild
+++ b/app-admin/abrt/abrt-2.14.0.ebuild
@@ -20,7 +20,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 DEPEND="${PYTHON_DEPS}
 	>=dev-libs/glib-2.56:2
-	>=dev-libs/libreport-2.10.0[python]
+	>=dev-libs/libreport-2.10.0[gtk,python]
 	dev-libs/libxml2:2
 	>=gnome-base/gsettings-desktop-schemas-3.15.1
 	net-libs/libsoup:2.4


### PR DESCRIPTION
This used to be default-enabled in libreport ebuild and new fails unconditionally.

Package-Manager: Portage-2.3.99, Repoman-2.3.22