### PR TITLE
dev-ml/camlp4: Avoid stack overflow in build.

### DIFF
--- a/dev-ml/camlp4/camlp4-4.04_p1.ebuild
+++ b/dev-ml/camlp4/camlp4-4.04_p1.ebuild
@@ -33,6 +33,8 @@ src_configure() {
 }
 
 src_compile() {
+	# Increase stack limit to 11GiB to avoid stack overflow error.
+	ulimit -s 11530000
 	emake byte
 	use ocamlopt && emake native
 }

--- a/dev-ml/camlp4/camlp4-4.05_p1.ebuild
+++ b/dev-ml/camlp4/camlp4-4.05_p1.ebuild
@@ -33,6 +33,8 @@ src_configure() {
 }
 
 src_compile() {
+	# Increase stack limit to 11GiB to avoid stack overflow error.
+	ulimit -s 11530000
 	emake byte
 	use ocamlopt && emake native
 }

--- a/dev-ml/camlp4/camlp4-4.08_p1.ebuild
+++ b/dev-ml/camlp4/camlp4-4.08_p1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -34,6 +34,8 @@ src_configure() {
 }
 
 src_compile() {
+	# Increase stack limit to 11GiB to avoid stack overflow error.
+	ulimit -s 11530000
 	emake byte
 	use ocamlopt && emake native
 }


### PR DESCRIPTION
Add ulimit -s 11530000 (set stack limit to 11GiB) to src_compile() to
try to avoid stack overflow errors.

Fix provided by Attila Tóth <atoth@atoth.sote.hu>.

Closes: https://bugs.gentoo.org/644352
Package-Manager: Portage-2.3.99, Repoman-2.3.22