### PR TITLE
net-irc/atheme-services: Rev bump

### DIFF
--- a/net-irc/atheme-services/atheme-services-7.2.10_p2-r2.ebuild
+++ b/net-irc/atheme-services/atheme-services-7.2.10_p2-r2.ebuild
@@ -27,7 +27,9 @@ RDEPEND="
 	perl? ( dev-lang/perl )
 	pcre? ( dev-libs/libpcre )
 	ssl? ( dev-libs/openssl:0= )"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+# 'dev-vcs/git' required as per bug #665802
+BDEPEND="
 	dev-vcs/git
 	virtual/pkgconfig"
 


### PR DESCRIPTION
Move 'DEPENDS' to 'BDEPENDS'.

Bug: https://bugs.gentoo.org/717832
Signed-off-by: Wade Cline <wadecline@hotmail.com>