### PR TITLE
dev-libs/opensc: Add elibtoolize to fix cross compiling for arm/arm64

### DIFF
--- a/dev-libs/opensc/opensc-0.20.0.ebuild
+++ b/dev-libs/opensc/opensc-0.20.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit bash-completion-r1
+inherit bash-completion-r1 libtool
 
 DESCRIPTION="Libraries and applications to access smartcards"
 HOMEPAGE="https://github.com/OpenSC/OpenSC/wiki"
@@ -35,6 +35,11 @@ REQUIRED_USE="
 	openct? ( !pcsc-lite !ctapi )
 	ctapi? ( !pcsc-lite !openct )
 	|| ( pcsc-lite openct ctapi )"
+
+src_prepare() {
+	default
+	elibtoolize
+}
 
 src_configure() {
 	econf \


### PR DESCRIPTION
opensc fails to cross compile for arm/arm64 target because libtool
adds host /usr/lib64 to -L during make install when the libraries are
relinked.

Adding elibtoolize in src_prepare() applies the "cross" patch that
fixes this.

Bug: https://bugs.gentoo.org/718790
Closes: https://bugs.gentoo.org/718790