### PR TITLE
dev-python/doit{,-py}: proxy-maintaining and updates

### DIFF
--- a/dev-python/doit-py/doit-py-0.4.0-r2.ebuild
+++ b/dev-python/doit-py/doit-py-0.4.0-r2.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{6,7} )
+
+inherit distutils-r1
+
+DESCRIPTION="doit tasks for python stuff"
+HOMEPAGE="https://pythonhosted.org/doit-py/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	test? (
+		dev-python/pyflakes[${PYTHON_USEDEP}]
+		dev-python/coverage[${PYTHON_USEDEP}]
+		app-text/hunspell
+	)"
+RDEPEND="
+	dev-python/configclass[${PYTHON_USEDEP}]"
+
+distutils_enable_sphinx doc
+distutils_enable_tests pytest

--- a/dev-python/doit-py/metadata.xml
+++ b/dev-python/doit-py/metadata.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
-	<upstream>
-		<remote-id type="pypi">doit-py</remote-id>
-	</upstream>
+  <maintainer type="person">
+    <email>azamat.hackimov@gmail.com</email>
+    <name>Azamat H. Hackimov</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">pydoit/doit-py</remote-id>
+    <remote-id type="pypi">doit-py</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/dev-python/doit/doit-0.32.0-r1.ebuild
+++ b/dev-python/doit/doit-0.32.0-r1.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{6,7} )
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
+inherit bash-completion-r1 distutils-r1
+
+DESCRIPTION="Automation tool"
+HOMEPAGE="https://pydoit.org/ https://pypi.org/project/doit/"
+SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	dev-python/cloudpickle[${PYTHON_USEDEP}]
+	dev-python/pyinotify[${PYTHON_USEDEP}]
+	dev-python/six[${PYTHON_USEDEP}]"
+DEPEND="
+	doc? ( dev-python/sphinx_rtd_theme[${PYTHON_USEDEP}] )
+	test? (
+		${RDEPEND}
+		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/pyflakes[${PYTHON_USEDEP}]
+		>=dev-python/pytest-5.4[${PYTHON_USEDEP}]
+	)"
+PDEPEND=">=dev-python/doit-py-0.4.0[${PYTHON_USEDEP}]"
+
+distutils_enable_tests pytest
+distutils_enable_sphinx doc
+
+PATCHES=(
+	"${FILESDIR}/${P}_pytest5.4.patch"
+	"${FILESDIR}/${P}_unpickable.patch"
+)
+
+src_prepare() {
+	default
+	# Replace custom theme with builtin for documentation
+	sed -i -e "s:'press':'sphinx_rtd_theme':" doc/conf.py || die
+	# Disable test failing due to impact on PATH run in a sandbox
+	sed -i -e "s:test_target:_&:" tests/test_cmd_strace.py || die
+}
+
+src_install() {
+	distutils-r1_src_install
+	newbashcomp bash_completion_doit ${PN}
+	insinto /usr/share/zsh/site-functions
+	newins zsh_completion_doit _${PN}
+}

--- a/dev-python/doit/files/doit-0.32.0_pytest5.4.patch
+++ b/dev-python/doit/files/doit-0.32.0_pytest5.4.patch
@@ -1,0 +1,81 @@
+From 159b7baebfefeacb443f55f2d12cbf0876628cbc Mon Sep 17 00:00:00 2001
+From: Eduardo Schettino <schettino72@gmail.com>
+Date: Wed, 22 Apr 2020 04:48:36 +0800
+Subject: [PATCH] fix tests for pytest 5.4
+
+---
+ dev_requirements.txt     |  2 +-
+ tests/conftest.py        | 22 +++++++---------------
+ tests/test_dependency.py |  4 ++--
+ 3 files changed, 10 insertions(+), 18 deletions(-)
+
+diff --git a/dev_requirements.txt b/dev_requirements.txt
+index 1e31e4f..f16ba86 100644
+--- a/dev_requirements.txt
++++ b/dev_requirements.txt
+@@ -2,6 +2,6 @@
+ # $ pip install --requirement dev_requirements.txt
+ 
+ pyflakes
+-pytest>=4.0
++pytest>=5.4.1
+ coverage>=4.0
+ doit-py>=0.4.0
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 5c4da9f..9eab396 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -78,12 +78,9 @@ def remove_db(filename):
+     'dbm.ndbm': ['.db'],
+ }
+ 
+-def dep_manager_fixture(request, dep_class):
+-    # copied from tempdir plugin
+-    name = request._pyfuncitem.name
+-    name = py.std.re.sub("[\W]", "_", name)
+-    my_tmpdir = request.config._tmpdirhandler.mktemp(name, numbered=True)
+-    dep_file = Dependency(dep_class, os.path.join(my_tmpdir.strpath, "testdb"))
++def dep_manager_fixture(request, dep_class, tmp_path_factory):
++    filename = str(tmp_path_factory.mktemp('x', True) / 'testdb')
++    dep_file = Dependency(dep_class, filename)
+     dep_file.whichdb = whichdb(dep_file.name) if dep_class is DbmDB else 'XXX'
+     dep_file.name_ext = db_ext.get(dep_file.whichdb, [''])
+ 
+@@ -97,18 +94,13 @@ def remove_depfile():
+ 
+ 
+ @pytest.fixture
+-def dep_manager(request):
+-    return dep_manager_fixture(request, DbmDB)
++def dep_manager(request, tmp_path_factory):
++    return dep_manager_fixture(request, DbmDB, tmp_path_factory)
+ 
+ 
+ @pytest.fixture
+-def depfile_name(request):
+-    # copied from tempdir plugin
+-    name = request._pyfuncitem.name
+-    name = py.std.re.sub("[\W]", "_", name)
+-    my_tmpdir = request.config._tmpdirhandler.mktemp(name, numbered=True)
+-    depfile_name = (os.path.join(my_tmpdir.strpath, "testdb"))
+-
++def depfile_name(request, tmp_path_factory):
++    depfile_name = str(tmp_path_factory.mktemp('x', True) / 'testdb')
+     def remove_depfile():
+         remove_db(depfile_name)
+     request.addfinalizer(remove_depfile)
+diff --git a/tests/test_dependency.py b/tests/test_dependency.py
+index 3fc2a14..f84e002 100644
+--- a/tests/test_dependency.py
++++ b/tests/test_dependency.py
+@@ -68,8 +68,8 @@ def test_sqlite_import():
+ # create a separate fixture to be used only by this module
+ # because only here it is required to test with all backends
+ @pytest.fixture(params=[JsonDB, DbmDB, SqliteDB])
+-def pdep_manager(request):
+-    return dep_manager_fixture(request, request.param)
++def pdep_manager(request, tmp_path_factory):
++    return dep_manager_fixture(request, request.param, tmp_path_factory)
+ 
+ 
+ 

--- a/dev-python/doit/files/doit-0.32.0_unpickable.patch
+++ b/dev-python/doit/files/doit-0.32.0_unpickable.patch
@@ -1,0 +1,39 @@
+From df4dc1c6a92d9f50cfe7f56d9507eca5bc56870e Mon Sep 17 00:00:00 2001
+From: Stefano Rivera <stefano@rivera.za.net>
+Date: Sun, 2 Feb 2020 13:02:58 +0100
+Subject: [PATCH] Replace recursive knot with explicitly unpicklable object
+
+Python 3.8 was able to pickle the previously unpicklable. Instead of
+relying on limits, let's raise an explicit error.
+
+Fixes: #341
+---
+ tests/test_runner.py | 13 ++++---------
+ 1 file changed, 4 insertions(+), 9 deletions(-)
+
+diff --git a/tests/test_runner.py b/tests/test_runner.py
+index 51c8a61..a9029e8 100644
+--- a/tests/test_runner.py
++++ b/tests/test_runner.py
+@@ -577,17 +577,12 @@ def non_top_function(): return 4
+         t2 = pickle.loads(t1p)
+         assert 4 == t2.actions[0].py_callable()
+ 
+-    @pytest.mark.xfail('PLAT_IMPL == "PyPy"')  # pypy can handle it :)
+     def test_not_picklable_raises_InvalidTask(self):
+-        # create a large enough recursive obj so pickle fails
+-        d1 = {}
+-        last = d1
+-        for x in range(400):
+-            dn = {'p': last}
+-            last = dn
+-        d1['p'] = last
+-
+         def non_top_function(): pass
++        class Unpicklable:
++            def __getstate__(self):
++                raise pickle.PicklingError("DO NOT PICKLE")
++        d1 = Unpicklable()
+         t1 = Task('t1', [non_top_function, (d1,)])
+         pytest.raises(InvalidTask, runner.JobTask, t1)
+ 

--- a/dev-python/doit/metadata.xml
+++ b/dev-python/doit/metadata.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <!--maintainer-needed-->
+  <maintainer type="person">
+    <email>azamat.hackimov@gmail.com</email>
+    <name>Azamat H. Hackimov</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
   <upstream>
+    <remote-id type="github">pydoit/doit</remote-id>
     <remote-id type="pypi">doit</remote-id>
-    <remote-id type="sourceforge">python-doit</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Added python3_7 support and migrated to distutils_enable_tests and distutils_enable_sphinx.