### PR TITLE
dev-util/oprofile: Add fix for binutils 2.34 re bug #707850

### DIFF
--- a/dev-util/oprofile/files/oprofile-1.3.0-binutils-2.24.patch
+++ b/dev-util/oprofile/files/oprofile-1.3.0-binutils-2.24.patch
@@ -1,0 +1,68 @@
+Fix compat with libbfd in binutils 2.34
+
+Bug: https://bugs.gentoo.org/707850
+
+Index: b/libutil++/bfd_support.cpp
+===================================================================
+--- a/libutil++/bfd_support.cpp
++++ b/libutil++/bfd_support.cpp
+@@ -137,7 +137,7 @@ static bool get_build_id(bfd * ibfd, uns
+ 		}
+ 	}
+ 
+-	bfd_size_type buildid_sect_size = bfd_section_size(ibfd, sect);
++	bfd_size_type buildid_sect_size = bfd_section_size(sect);
+ 	char * contents = (char *) xmalloc(buildid_sect_size);
+ 	errno = 0;
+ 	if (!bfd_get_section_contents(ibfd, sect,
+@@ -188,7 +188,7 @@ bool get_debug_link_info(bfd * ibfd, str
+ 	if (sect == NULL)
+ 		return false;
+ 	
+-	bfd_size_type debuglink_size = bfd_section_size(ibfd, sect);  
++	bfd_size_type debuglink_size = bfd_section_size(sect);  
+ 	char * contents = (char *) xmalloc(debuglink_size);
+ 	cverb << vbfd
+ 	      << ".gnu_debuglink section has size " << debuglink_size << endl;
+@@ -346,7 +346,7 @@ void fixup_linenr(bfd * abfd, asection *
+ 	// first restrict the search on a sensible range of vma, 16 is
+ 	// an intuitive value based on epilog code look
+ 	size_t max_search = 16;
+-	size_t section_size = bfd_section_size(abfd, section);
++	size_t section_size = bfd_section_size(section);
+ 	if (pc + max_search > section_size)
+ 		max_search = section_size - pc;
+ 
+@@ -819,10 +819,10 @@ find_nearest_line(bfd_info const & b, op
+ 	else
+ 		pc = (sym.value() + offset) - sym.filepos();
+ 
+-	if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
++	if ((bfd_section_flags(section) & SEC_ALLOC) == 0)
+ 		goto fail;
+ 
+-	if (pc >= bfd_section_size(abfd, section))
++	if (pc >= bfd_section_size(section))
+ 		goto fail;
+ 
+ 	ret = bfd_find_nearest_line(abfd, section, syms, pc, &cfilename,
+Index: b/opjitconv/create_bfd.c
+===================================================================
+--- a/opjitconv/create_bfd.c
++++ b/opjitconv/create_bfd.c
+@@ -86,12 +86,12 @@ asection * create_section(bfd * abfd, ch
+ 		bfd_perror("bfd_make_section");
+ 		goto error;
+ 	}
+-	bfd_set_section_vma(abfd, section, vma);
+-	if (bfd_set_section_size(abfd, section, size) == FALSE) {
++	bfd_set_section_vma(section, vma);
++	if (bfd_set_section_size(section, size) == FALSE) {
+ 		bfd_perror("bfd_set_section_size");
+ 		goto error;
+ 	}
+-	if (bfd_set_section_flags(abfd, section, flags) == FALSE) {
++	if (bfd_set_section_flags(section, flags) == FALSE) {
+ 		bfd_perror("bfd_set_section_flags");
+ 		goto error;
+ 	}

--- a/dev-util/oprofile/oprofile-1.3.0-r1.ebuild
+++ b/dev-util/oprofile/oprofile-1.3.0-r1.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit java-pkg-opt-2 linux-info user
+
+DESCRIPTION="A transparent low-overhead system-wide profiler"
+HOMEPAGE="http://oprofile.sourceforge.net"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="java pch"
+
+RDEPEND=">=dev-libs/popt-1.7-r1
+	sys-libs/binutils-libs:=
+	>=sys-libs/glibc-2.3.2-r1
+	java? ( >=virtual/jdk-1.5:= )
+	ppc64? ( dev-libs/libpfm )"
+DEPEND="${RDEPEND}
+	>=sys-kernel/linux-headers-2.6.31"
+
+CONFIG_CHECK="PERF_EVENTS"
+ERROR_PERF_EVENTS="CONFIG_PERF_EVENTS is mandatory for ${PN} to work."
+
+pkg_setup() {
+	linux-info_pkg_setup
+	if ! kernel_is -ge 2 6 31; then
+		echo
+		ewarn "Support for kernels before 2.6.31 has been dropped in ${PN}-1.0.0."
+		echo
+	fi
+
+	# Required for JIT support, see README_PACKAGERS
+	enewgroup ${PN}
+	enewuser ${PN} -1 -1 -1 ${PN}
+
+	use java && java-pkg_init
+}
+src_prepare() {
+	eapply "${FILESDIR}/${PN}-1.3.0-binutils-2.24.patch"
+	java-pkg-opt-2_src_prepare
+}
+
+src_configure() {
+	econf \
+		--disable-werror \
+		$(use_enable pch) \
+		$(use_with java java ${JAVA_HOME})
+}
+
+src_install() {
+	emake DESTDIR="${D}" htmldir="/usr/share/doc/${PF}" install
+
+	dodoc ChangeLog* README TODO
+	echo "LDPATH=${PREFIX}/usr/$(get_libdir)/${PN}" > "${T}/10${PN}" || die
+	doenvd "${T}/10${PN}"
+}
+
+pkg_postinst() {
+	echo
+	elog "Starting from ${PN}-1.0.0 opcontrol was removed, use operf instead."
+	elog "CONFIG_OPROFILE is no longer used, you may remove it from your kernels."
+	elog "Please read manpages and this html doc:"
+	elog "  /usr/share/doc/${PF}/${PN}.html"
+	echo
+}


### PR DESCRIPTION
This adds the patch attached on bug #707850, and adds the glue
required to make it work.

I've used java-pkg-opt-2_src_prepare as the "do this after patching"
because analysis of the environment file for this ebuild indicated
that's what src_prepare was already doing.

This may not be the best thing, but it works.

Repoman also warns about using 'user' instead of GLEP81, and I
have not fixed this, but somebody should.

Bug: https://bugs.gentoo.org/707850
Package-Manager: Portage-2.3.97, Repoman-2.3.22
Signed-off-by: Kent Fredric <kentnl@gentoo.org>

Diff between 1.3.0.ebuild and 1.3.0-r1.ebuild:
```diff
--- oprofile-1.3.0.ebuild	2020-04-23 01:54:04.170617268 +1200
+++ oprofile-1.3.0-r1.ebuild	2020-04-23 02:02:55.610295125 +1200
@@ -10,7 +10,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~mips ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86"
 IUSE="java pch"
 
 RDEPEND=">=dev-libs/popt-1.7-r1
@@ -38,6 +38,10 @@
 
 	use java && java-pkg_init
 }
+src_prepare() {
+	eapply "${FILESDIR}/${PN}-1.3.0-binutils-2.24.patch"
+	java-pkg-opt-2_src_prepare
+}
 
 src_configure() {
 	econf \
```