### PR TITLE
x11-misc/compton: Add python 3.7, 3.8 & 3.9 support re bug #718546

### DIFF
--- a/x11-misc/compton/compton-0.1_beta2-r1.ebuild
+++ b/x11-misc/compton/compton-0.1_beta2-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python3_{6,7,8,9} )
+inherit toolchain-funcs python-r1
+
+DESCRIPTION="A compositor for X, and a fork of xcompmgr-dana"
+HOMEPAGE="https://github.com/chjj/compton"
+SRC_URI="https://github.com/chjj/compton/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="dbus +drm opengl +pcre xinerama"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+COMMON_DEPEND="${PYTHON_DEPS}
+	dev-libs/libconfig:=
+	x11-libs/libX11
+	x11-libs/libXcomposite
+	x11-libs/libXdamage
+	x11-libs/libXext
+	x11-libs/libXfixes
+	x11-libs/libXrandr
+	x11-libs/libXrender
+	dbus? ( sys-apps/dbus )
+	opengl? ( virtual/opengl )
+	pcre? ( dev-libs/libpcre:3 )
+	xinerama? ( x11-libs/libXinerama )"
+RDEPEND="${COMMON_DEPEND}
+	x11-apps/xprop
+	x11-apps/xwininfo"
+DEPEND="${COMMON_DEPEND}
+	app-text/asciidoc
+	virtual/pkgconfig
+	x11-base/xorg-proto
+	drm? ( x11-libs/libdrm )"
+
+nobuildit() { use $1 || echo yes ; }
+
+pkg_setup() {
+	if [[ ${MERGE_TYPE} != binary ]]; then
+		tc-export CC
+	fi
+}
+
+src_compile() {
+	emake docs
+
+	NO_DBUS=$(nobuildit dbus) \
+	NO_XINERAMA=$(nobuildit xinerama) \
+	NO_VSYNC_DRM=$(nobuildit drm) \
+	NO_VSYNC_OPENGL=$(nobuildit opengl) \
+	NO_REGEX_PCRE=$(nobuildit pcre) \
+		emake compton
+}
+
+src_install() {
+	NO_DBUS=$(nobuildit dbus) \
+	NO_VSYNC_DRM=$(nobuildit drm) \
+	NO_VSYNC_OPENGL=$(nobuildit opengl) \
+	NO_REGEX_PCRE=$(nobuildit pcre) \
+		default
+	docinto examples
+	dodoc compton.sample.conf dbus-examples/*
+	python_foreach_impl python_newscript bin/compton-convgen.py compton-convgen
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/718546
Package-Manager: Portage-2.3.97, Repoman-2.3.22
Signed-off-by: Kent Fredric <kentnl@gentoo.org>

-r1 diff:
```diff
--- compton-0.1_beta2.ebuild	2020-02-03 20:00:33.100329069 +1300
+++ compton-0.1_beta2-r1.ebuild	2020-06-17 20:49:43.074592668 +1200
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 inherit toolchain-funcs python-r1
 
 DESCRIPTION="A compositor for X, and a fork of xcompmgr-dana"
@@ -12,7 +12,7 @@
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="dbus +drm opengl +pcre xinerama"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
```

- tests pass
- manually testing compton-convgen seemed to indicate its not broken by python updates
