### PR TITLE
media-sound/klick: Enable py3.{7,8}

### DIFF
--- a/media-sound/klick/klick-0.12.2-r2.ebuild
+++ b/media-sound/klick/klick-0.12.2-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7,8} )
 
 inherit python-any-r1 scons-utils toolchain-funcs
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/718400