### PR TITLE
Reflect move of libvirt repositories

### DIFF
--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -9,7 +9,7 @@ inherit autotools out-of-source bash-completion-r1 eutils linux-info python-any-
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://libvirt.org/git/libvirt.git"
+	EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt.git"
 	SRC_URI=""
 	KEYWORDS=""
 	SLOT="0"

--- a/dev-php/libvirt-php/libvirt-php-9999.ebuild
+++ b/dev-php/libvirt-php/libvirt-php-9999.ebuild
@@ -12,7 +12,7 @@ inherit php-ext-source-r3 git-r3 autotools
 
 DESCRIPTION="PHP bindings for libvirt"
 HOMEPAGE="http://libvirt.org/php/"
-EGIT_REPO_URI="git://libvirt.org/libvirt-php.git"
+EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt-php.git"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-python/libvirt-python/libvirt-python-9999.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-9999.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://libvirt.org/git/libvirt-python.git"
+	EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt-python.git"
 	SRC_URI=""
 	KEYWORDS=""
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"


### PR DESCRIPTION
Libvirt and related projects moved from self hosting to
gitlab.com hosting. The old repos were made a read only mirror of
their gitlab images. Reflect this change in the live ebuilds.

https://www.redhat.com/archives/libvir-list/2020-April/msg00329.html

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>