### PR TITLE
sci-libs/metis: remove static-libs useflag

### DIFF
--- a/sci-libs/metis/metis-4.0.3-r2.ebuild
+++ b/sci-libs/metis/metis-4.0.3-r2.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit autotools eutils fortran-2
+
+DESCRIPTION="A package for unstructured serial graph partitioning"
+HOMEPAGE="http://www-users.cs.umn.edu/~karypis/metis/metis/"
+SRC_URI="http://glaros.dtc.umn.edu/gkhome/fetch/sw/${PN}/OLD/${P}.tar.gz"
+
+LICENSE="all-rights-reserved"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc"
+RESTRICT="mirror bindist"
+
+DEPEND=""
+RDEPEND="
+	${DEPEND}
+	!sci-libs/parmetis
+"
+
+src_prepare() {
+	eapply -p1 "${FILESDIR}/${PN}-4.0.1-autotools.patch"
+	eapply_user
+	sed -i -e "s/4.0.1/${PV}/" configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	econf --disable-static
+}
+
+src_install() {
+	default
+	use doc && dodoc Doc/manual.ps
+	find "${D}" -name '*.la' -delete || die
+}

--- a/sci-libs/metis/metis-5.1.0-r4.ebuild
+++ b/sci-libs/metis/metis-5.1.0-r4.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit cmake-utils fortran-2
+
+DESCRIPTION="A package for unstructured serial graph partitioning"
+HOMEPAGE="http://www-users.cs.umn.edu/~karypis/metis/metis/"
+SRC_URI="http://glaros.dtc.umn.edu/gkhome/fetch/sw/${PN}/${P}.tar.gz"
+
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+LICENSE="Apache-2.0"
+IUSE="doc openmp"
+
+DEPEND=""
+RDEPEND="
+	${DEPEND}
+	!sci-libs/parmetis
+"
+
+DOCS=( manual/manual.pdf )
+
+PATCHES=(
+	"${FILESDIR}/${P}-datatype.patch"
+	"${FILESDIR}/${P}-shared-GKlib.patch"
+	"${FILESDIR}/${P}-multilib.patch"
+)
+
+src_prepare() {
+	sed \
+		-e 's:-O3::g' \
+		-i GKlib/GKlibSystem.cmake || die
+
+	cmake-utils_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DGKLIB_PATH="${S}"/GKlib
+		-DSHARED="yes"
+		-DOPENMP="$(usex openmp)"
+	)
+	cmake-utils_src_configure
+}
+
+src_test() {
+	cd graphs || die
+	PATH="${BUILD_DIR}"/programs/:${PATH} LD_LIBRARY_PATH="${BUILD_DIR}"/lib ndmetis mdual.graph || die
+	PATH="${BUILD_DIR}"/programs/:${PATH} LD_LIBRARY_PATH="${BUILD_DIR}"/lib mpmetis metis.mesh 2 || die
+	PATH="${BUILD_DIR}"/programs/:${PATH} LD_LIBRARY_PATH="${BUILD_DIR}"/lib gpmetis test.mgraph 4 || die
+	PATH="${BUILD_DIR}"/programs/:${PATH} LD_LIBRARY_PATH="${BUILD_DIR}"/lib gpmetis copter2.graph 4 || die
+	PATH="${BUILD_DIR}"/programs/:${PATH} LD_LIBRARY_PATH="${BUILD_DIR}"/lib graphchk 4elt.graph || die
+}
+
+src_install() {
+	cat >> "${T}"/metis.pc <<- EOF
+	prefix=${EPREFIX}/usr
+	exec_prefix=\${prefix}
+	libdir=\${exec_prefix}/$(get_libdir)
+	includedir=\${prefix}/include
+
+	Name: METIS
+	Description: Software for partioning unstructured graphes and meshes
+	Version: ${PV}
+	Cflags: -I\${includedir}/metis
+	Libs: -L\${libdir} -lmetis
+	EOF
+
+	insinto /usr/$(get_libdir)/pkgconfig
+	doins "${T}"/metis.pc
+	cmake-utils_src_install
+}


### PR DESCRIPTION
as per policy
https://projects.gentoo.org/qa/policy-guide/installed-files.html?highlight=static#pg0302#

for more context read:
https://flameeyes.blog/2011/08/29/useless-flag-static-libs/
https://archives.gentoo.org/gentoo-dev/message/2dada80c2b9c85b0e83e6328428bf8ab

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>