### PR TITLE
dev-libs/gobject-introspection: Fix test dependencies

### DIFF
--- a/dev-libs/gobject-introspection/gobject-introspection-1.62.0-r1.ebuild
+++ b/dev-libs/gobject-introspection/gobject-introspection-1.62.0-r1.ebuild
@@ -53,8 +53,8 @@ pkg_setup() {
 
 src_configure() {
 	local emesonargs=(
-		$(meson_feature test cairo)
-		$(meson_feature doctool)
+		$(meson_use test cairo)
+		$(meson_use doctool)
 		#-Dglib_src_dir
 		$(meson_use gtk-doc gtk_doc)
 		#-Dcairo_libname


### PR DESCRIPTION
USE=test should DEPEND on dev-python/markdown

Closes: https://bugs.gentoo.org/719252
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>
Package-Manager: Portage-2.3.89, Repoman-2.3.20