### PR TITLE
dev-libs/popt: remove static-libs useflag

### DIFF
--- a/dev-libs/popt/popt-1.18-r1.ebuild
+++ b/dev-libs/popt/popt-1.18-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal libtool
+
+DESCRIPTION="Parse Options - Command line parser"
+HOMEPAGE="https://github.com/rpm-software-management/popt"
+SRC_URI="http://ftp.rpm.org/${PN}/releases/${PN}-1.x/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="nls"
+
+RDEPEND="nls? ( >=virtual/libintl-0-r1[${MULTILIB_USEDEP}] )"
+DEPEND="${RDEPEND}"
+BDEPEND="nls? ( sys-devel/gettext )"
+
+src_prepare() {
+	default
+	sed -i -e 's:lt-test1:test1:' tests/testit.sh || die
+	elibtoolize
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--disable-static
+		$(use_enable nls)
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	dodoc CHANGES README
+	find "${ED}" -type f -name "*.la" -delete || die
+}


### PR DESCRIPTION
as per policy
https://projects.gentoo.org/qa/policy-guide/installed-files.html?highlight=static#pg0302#

for more context read:
https://flameeyes.blog/2011/08/29/useless-flag-static-libs/
https://archives.gentoo.org/gentoo-dev/message/2dada80c2b9c85b0e83e6328428bf8ab

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>