### PR TITLE
app-emulation/virt-manager: should not depend on dev-python/ipaddr (python2 rev dep)

### DIFF
--- a/app-emulation/virt-manager/virt-manager-2.2.1-r3.ebuild
+++ b/app-emulation/virt-manager/virt-manager-2.2.1-r3.ebuild
@@ -32,7 +32,6 @@ RDEPEND="!app-emulation/virtinst
 	>=app-emulation/libvirt-glib-1.0.0[introspection]
 	$(python_gen_cond_dep '
 		dev-libs/libxml2[python,${PYTHON_MULTI_USEDEP}]
-		dev-python/ipaddr[${PYTHON_MULTI_USEDEP}]
 		dev-python/libvirt-python[${PYTHON_MULTI_USEDEP}]
 		dev-python/pygobject:3[${PYTHON_MULTI_USEDEP}]
 		dev-python/requests[${PYTHON_MULTI_USEDEP}]

--- a/app-emulation/virt-manager/virt-manager-9999.ebuild
+++ b/app-emulation/virt-manager/virt-manager-9999.ebuild
@@ -33,7 +33,6 @@ RDEPEND="!app-emulation/virtinst
 	$(python_gen_cond_dep '
 		dev-libs/libxml2[python,${PYTHON_MULTI_USEDEP}]
 		dev-python/argcomplete[${PYTHON_MULTI_USEDEP}]
-		dev-python/ipaddr[${PYTHON_MULTI_USEDEP}]
 		dev-python/libvirt-python[${PYTHON_MULTI_USEDEP}]
 		dev-python/pygobject:3[${PYTHON_MULTI_USEDEP}]
 		dev-python/requests[${PYTHON_MULTI_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/719322

app-emulation/virt-manager-2 no longer depends on the legacy python2 module ipaddr but uses [python3 builtin ipaddress](https://github.com/virt-manager/virt-manager/blob/1afdc7ae32b8169f2411f7a3301c093a80770471/virtManager/createnet.py#L7)