### PR TITLE
media-sound/lollypop needs totem-pl-parser[introspection]

### DIFF
--- a/media-sound/lollypop/lollypop-1.2.35.ebuild
+++ b/media-sound/lollypop/lollypop-1.2.35.ebuild
@@ -37,7 +37,7 @@ BDEPEND="${DEPEND}
 "
 RDEPEND="${DEPEND}
 	app-crypt/libsecret[introspection]
-	dev-libs/totem-pl-parser
+	dev-libs/totem-pl-parser[introspection]
 	$(python_gen_cond_dep '
 		dev-python/beautifulsoup:4[${PYTHON_MULTI_USEDEP}]
 		dev-python/dbus-python


### PR DESCRIPTION
lollypop throws "ValueError: Namespace TotemPlParser not available" if totem-pl-parser is compiled without introspection (one more dependency that they wont tell you about on their pre-requirements website...)