### PR TITLE
sys-apps/portage: add zstd USE flag

### DIFF
--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,9 @@
 # Copyright 2019-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Mask until app-arch/zstd is keyworded
+sys-apps/portage zstd
+
 # Patrick McLean <chutzpah@gentoo.org> (2020-04-16)
 # Lots of python dependencies, mask to facilitate keywording
 # keywording dev-libs/libfido2

--- a/sys-apps/portage/portage-2.3.89-r3.ebuild
+++ b/sys-apps/portage/portage-2.3.89-r3.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Portage"
 LICENSE="GPL-2"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86"
 SLOT="0"
-IUSE="apidoc build doc gentoo-dev +ipc +native-extensions +rsync-verify selinux xattr"
+IUSE="apidoc build doc gentoo-dev +ipc +native-extensions +rsync-verify selinux xattr zstd"
 
 DEPEND="!build? ( $(python_gen_impl_dep 'ssl(+)') )
 	>=app-arch/tar-1.27
@@ -58,6 +58,7 @@ RDEPEND="
 	xattr? ( kernel_linux? (
 		>=sys-apps/install-xattr-0.3
 	) )
+	zstd? ( app-arch/zstd )
 	!<app-admin/logrotate-3.8.0
 	!<app-portage/gentoolkit-0.4.6
 	!<app-portage/repoman-2.3.10"
@@ -132,6 +133,12 @@ python_prepare_all() {
 		echo -e '\nFEATURES="${FEATURES} xattr"' >> cnf/make.globals \
 			|| die "failed to append to make.globals"
 	fi
+
+	if use zstd ; then
+		einfo "Adding BINPKG_COMPRESS=\"zstd\" to make.globals ..."
+		echo -e '\nBINPKG_COMPRESS="zstd"' >> cnf/make.globals \
+			|| die "failed to append to make.globals"
+        fi
 
 	if use build || ! use rsync-verify; then
 		sed -e '/^sync-rsync-verify-metamanifest/s|yes|no|' \

--- a/sys-apps/portage/portage-2.3.99-r2.ebuild
+++ b/sys-apps/portage/portage-2.3.99-r2.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Portage"
 LICENSE="GPL-2"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86"
 SLOT="0"
-IUSE="apidoc build doc gentoo-dev +ipc +native-extensions +rsync-verify selinux xattr"
+IUSE="apidoc build doc gentoo-dev +ipc +native-extensions +rsync-verify selinux xattr zstd"
 
 DEPEND="!build? ( $(python_gen_impl_dep 'ssl(+)') )
 	>=app-arch/tar-1.27
@@ -54,6 +54,7 @@ RDEPEND="
 	xattr? ( kernel_linux? (
 		>=sys-apps/install-xattr-0.3
 	) )
+	zstd? ( app-arch/zstd )
 	!<app-admin/logrotate-3.8.0
 	!<app-portage/gentoolkit-0.4.6
 	!<app-portage/repoman-2.3.10"
@@ -123,6 +124,12 @@ python_prepare_all() {
 	if use xattr && use kernel_linux ; then
 		einfo "Adding FEATURES=xattr to make.globals ..."
 		echo -e '\nFEATURES="${FEATURES} xattr"' >> cnf/make.globals \
+			|| die "failed to append to make.globals"
+	fi
+
+	if use zstd ; then
+		einfo "Adding BINPKG_COMPRESS=\"zstd\" to make.globals ..."
+		echo -e '\nBINPKG_COMPRESS="zstd"' >> cnf/make.globals \
 			|| die "failed to append to make.globals"
 	fi
 

--- a/sys-apps/portage/portage-9999.ebuild
+++ b/sys-apps/portage/portage-9999.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Portage"
 LICENSE="GPL-2"
 KEYWORDS=""
 SLOT="0"
-IUSE="apidoc build doc gentoo-dev +ipc +native-extensions +rsync-verify selinux xattr"
+IUSE="apidoc build doc gentoo-dev +ipc +native-extensions +rsync-verify selinux xattr zstd"
 
 DEPEND="!build? ( $(python_gen_impl_dep 'ssl(+)') )
 	>=app-arch/tar-1.27
@@ -54,6 +54,7 @@ RDEPEND="
 	xattr? ( kernel_linux? (
 		>=sys-apps/install-xattr-0.3
 	) )
+	zstd? ( app-arch/zstd )
 	!<app-admin/logrotate-3.8.0"
 PDEPEND="
 	!build? (
@@ -112,6 +113,12 @@ python_prepare_all() {
 	if use xattr && use kernel_linux ; then
 		einfo "Adding FEATURES=xattr to make.globals ..."
 		echo -e '\nFEATURES="${FEATURES} xattr"' >> cnf/make.globals \
+			|| die "failed to append to make.globals"
+	fi
+
+	if use zstd ; then
+		einfo "Adding BINGPKG_COMPRESS=\"zstd\" to make.globals ..."
+		echo -e '\nBINGPKG_COMPRESS="zstd"' >> cnf/make.globals \
 			|| die "failed to append to make.globals"
 	fi
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/719456

Adds a USE flag to put app-arch/zstd into portage's RDEPENDS.

Minimum tar is bumped because zstd support was added in 1.31.

USE flag masked on riscv because zstd isn't keyworded.

Tested with portage 2.3.89-r3, and zstd 1.4.4-r4.