### PR TITLE
games-emulation/hatari: inherit only xdg-utils instead of xdg

### DIFF
--- a/games-emulation/hatari/hatari-2.2.1-r1.ebuild
+++ b/games-emulation/hatari/hatari-2.2.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python{2_7,3_{6,7}} )
-inherit cmake python-single-r1 xdg
+inherit cmake python-single-r1 xdg-utils
 
 DESCRIPTION="Atari ST emulator"
 HOMEPAGE="https://hatari.tuxfamily.org/"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

games-emulation/hatari only uses ```xdg_enviroment_reset``` from ```xdg-utils``` so we don't need to inherit ```xdg```