### PR TITLE
app-portage/kuroo: add missing xdg-utils eclass

### DIFF
--- a/app-portage/kuroo/kuroo-0.90.5_p20180410.ebuild
+++ b/app-portage/kuroo/kuroo-0.90.5_p20180410.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit cmake-utils
+inherit cmake-utils xdg-utils
 
 DESCRIPTION="Graphical Portage frontend based on KDE Frameworks"
 HOMEPAGE="https://sourceforge.net/projects/kuroo/"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

the ebuild calls ```xdg_mimeinfo_database_update``` and ```xdg_desktop_database_update``` but doesn't call ```xdg-utils``` (even though it works because ```cmake-utils``` inherit ```xdg-utils```)