### PR TITLE
www-client/chromium: keep icu if compiling with libcxx

### DIFF
--- a/www-client/chromium/chromium-83.0.4103.23.ebuild
+++ b/www-client/chromium/chromium-83.0.4103.23.ebuild
@@ -454,6 +454,9 @@ src_prepare() {
 		keeplibs+=( third_party/openh264 )
 		keeplibs+=( third_party/re2 )
 		keeplibs+=( third_party/snappy )
+		if use system-icu; then
+			keeplibs+=( third_party/icu )
+		fi
 	fi
 	# Remove most bundled libraries. Some are still needed.
 	build/linux/unbundle/remove_bundled_libraries.py "${keeplibs[@]}" --do-remove || die


### PR DESCRIPTION
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>