### PR TITLE
Add missing CPE tags for Gentoo packages

### DIFF
--- a/app-admin/logrotate/metadata.xml
+++ b/app-admin/logrotate/metadata.xml
@@ -25,5 +25,6 @@
 	</use>
 	<upstream>
 		<remote-id type="github">logrotate/logrotate</remote-id>
+		<remote-id type="cpe">cpe:/a:logrotate_project:logrotate</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/app-arch/lz4/metadata.xml
+++ b/app-arch/lz4/metadata.xml
@@ -15,5 +15,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="github">Cyan4973/lz4</remote-id>
+		<remote-id type="cpe">cpe:/a:lz4_project:lz4</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/app-crypt/rhash/metadata.xml
+++ b/app-crypt/rhash/metadata.xml
@@ -8,6 +8,7 @@
 	<upstream>
 		<remote-id type="sourceforge">rhash</remote-id>
 		<remote-id type="github">rhash/RHash</remote-id>
+		<remote-id type="cpe">cpe:/a:rhash_project:rhash</remote-id>
 		<bugs-to>https://github.com/rhash/RHash/issues</bugs-to>
 	</upstream>
 	<longdescription lang="en">

--- a/app-editors/vim-core/metadata.xml
+++ b/app-editors/vim-core/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="github">vim/vim</remote-id>
+		<remote-id type="cpe">cpe:/a:vim:vim</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/app-misc/pax-utils/metadata.xml
+++ b/app-misc/pax-utils/metadata.xml
@@ -13,4 +13,7 @@
   <use>
     <flag name="python">Install a more powerful/faster version of lddtree</flag>
   </use>
+  <upstream>
+    <remote-id type="cpe">cpe:/a:gentoo:pax-utils</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/app-portage/portage-utils/metadata.xml
+++ b/app-portage/portage-utils/metadata.xml
@@ -9,4 +9,7 @@
 		<flag name="qmanifest">Build qmanifest applet, this adds additional dependencies for GPG, OpenSSL and BLAKE2B hashing</flag>
 		<flag name="qtegrity">Build qtegrity applet, this adds additional dependencies for OpenSSL</flag>
 	</use>
+	<upstream>
+		<remote-id type="cpe">cpe:/a:gentoo:portage</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-go/go-protobuf/metadata.xml
+++ b/dev-go/go-protobuf/metadata.xml
@@ -6,5 +6,6 @@
   </maintainer>
   <upstream>
     <remote-id type="github">golang/protobuf</remote-id>
+    <remote-id type="cpe">cpe:/a:protobuf_project:protobuf</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-libs/json-c/metadata.xml
+++ b/dev-libs/json-c/metadata.xml
@@ -11,5 +11,6 @@ representation of JSON objects.
   </longdescription>
   <upstream>
     <remote-id type="github">json-c/json-c</remote-id>
+    <remote-id type="cpe">cpe:/a:json-c_project:json-c</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-libs/libgpg-error/metadata.xml
+++ b/dev-libs/libgpg-error/metadata.xml
@@ -12,4 +12,7 @@
 	<use>
 		<flag name="common-lisp">Install common-lisp files</flag>
 	</use>
+	<upstream>
+		<remote-id type="cpe">cpe:/a:gnupg:libgpg-error</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-libs/libuv/metadata.xml
+++ b/dev-libs/libuv/metadata.xml
@@ -33,6 +33,7 @@
 	<upstream>
 		<bugs-to>https://github.com/libuv/libuv/issues</bugs-to>
 		<remote-id type="github">libuv/libuv</remote-id>
+		<remote-id type="cpe">cpe:/a:libuv:libuv</remote-id>
 	</upstream>
 	<slots>
 		<subslots>Reflect ABI compatibility of libuv.so.</subslots>

--- a/dev-libs/popt/metadata.xml
+++ b/dev-libs/popt/metadata.xml
@@ -5,4 +5,7 @@
     <email>base-system@gentoo.org</email>
     <name>Gentoo Base System</name>
   </maintainer>
+<upstream>
+  <remote-id type="cpe">cpe:/a:popt_project:popt</remote-id>
+</upstream>
 </pkgmetadata>

--- a/dev-python/enum34/metadata.xml
+++ b/dev-python/enum34/metadata.xml
@@ -7,5 +7,6 @@
   </maintainer>
   <upstream>
     <remote-id type="pypi">enum34</remote-id>
+    <remote-id type="cpe">cpe:/a:python:enum34</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-python/jinja/metadata.xml
+++ b/dev-python/jinja/metadata.xml
@@ -9,5 +9,6 @@
   <upstream>
     <remote-id type="pypi">Jinja2</remote-id>
     <remote-id type="github">pallets/jinja</remote-id>
+    <remote-id type="cpe">cpe:/a:palletsprojects:jinja</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-python/pyjwt/metadata.xml
+++ b/dev-python/pyjwt/metadata.xml
@@ -8,5 +8,6 @@
   <upstream>
     <remote-id type="pypi">PyJWT</remote-id>
     <remote-id type="github">progrium/pyjwt</remote-id>
+    <remote-id type="cpe">cpe:/a:pyjwt_project:pyjwt</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-python/pyopenssl/metadata.xml
+++ b/dev-python/pyopenssl/metadata.xml
@@ -9,5 +9,6 @@
 		<remote-id type="pypi">pyOpenSSL</remote-id>
 		<remote-id type="launchpad">pyopenssl</remote-id>
 		<remote-id type="sourceforge">pyopenssl</remote-id>
+		<remote-id type="cpe">cpe:/a:pyopenssl:pyopenssl</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/pyyaml/metadata.xml
+++ b/dev-python/pyyaml/metadata.xml
@@ -8,4 +8,7 @@
   <use>
     <flag name="libyaml">enable support for C implementation using libyaml</flag>
   </use>
+  <upstream>
+    <remote-id type="cpe">cpe:/a:pyyaml_project:pyyaml</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/dev-python/requests/metadata.xml
+++ b/dev-python/requests/metadata.xml
@@ -13,5 +13,6 @@
   </longdescription>
   <upstream>
     <remote-id type="pypi">requests</remote-id>
+    <remote-id type="cpe">cpe:/a:python-requests:requests</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-python/setuptools/metadata.xml
+++ b/dev-python/setuptools/metadata.xml
@@ -8,5 +8,6 @@
   <upstream>
     <remote-id type="pypi">setuptools</remote-id>
     <remote-id type="github">pypa/setuptools</remote-id>
+    <remote-id type="cpe">cpe:/a:python:setuptools</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-python/urllib3/metadata.xml
+++ b/dev-python/urllib3/metadata.xml
@@ -11,5 +11,6 @@
   <upstream>
     <remote-id type="pypi">urllib3</remote-id>
     <remote-id type="github">shazow/urllib3</remote-id>
+    <remote-id type="cpe">cpe:/a:urllib3:urllib3</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-util/re2c/metadata.xml
+++ b/dev-util/re2c/metadata.xml
@@ -10,5 +10,6 @@
 	<upstream>
 		<remote-id type="sourceforge">re2c</remote-id>
 		<remote-id type="github">skvadrik/re2c</remote-id>
+		<remote-id type="cpe">cpe:/a:re2c:re2c</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-vcs/git/metadata.xml
+++ b/dev-vcs/git/metadata.xml
@@ -38,4 +38,7 @@
     <flag name="tk">Include the 'gitk' and 'git gui' tools</flag>
     <flag name="webdav">Adds support for push'ing to HTTP/HTTPS repositories via DAV</flag>
   </use>
+  <upstream>
+    <remote-id type="cpe">cpe:/a:git:git</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/net-analyzer/netcat/metadata.xml
+++ b/net-analyzer/netcat/metadata.xml
@@ -8,5 +8,6 @@
 	<longdescription>the network swiss army knife</longdescription>
 	<upstream>
 		<remote-id type="sourceforge">nc110</remote-id>
+		<remote-id type="cpe">cpe:/a:netcat_project:netcat</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-firewall/ebtables/metadata.xml
+++ b/net-firewall/ebtables/metadata.xml
@@ -10,5 +10,6 @@
 	</use>
 	<upstream>
 		<remote-id type="sourceforge">ebtables</remote-id>
+		<remote-id type="cpe">cpe:/a:netfilter:ebtables</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-fs/autofs/metadata.xml
+++ b/net-fs/autofs/metadata.xml
@@ -21,4 +21,7 @@
 		</flag>
 		<flag name="sasl">Enable SASL support in the LDAP module</flag>
 	</use>
+	<upstream>
+		<remote-id type="cpe">cpe:/a:ibm:autofs</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/net-misc/chrony/metadata.xml
+++ b/net-misc/chrony/metadata.xml
@@ -29,4 +29,7 @@ Chrony はコンピュータのシステム・クロックの精度を保つた�
 <flag name="rtc">Support for the Linux Real Time Clock interface</flag>
 <flag name="sechash">Enable support for hashes other than MD5</flag>
 </use>
+<upstream>
+<remote-id type="cpe">cpe:/a:chrony_project:chrony</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-apps/file/metadata.xml
+++ b/sys-apps/file/metadata.xml
@@ -7,5 +7,6 @@
 </maintainer>
 <upstream>
 	<bugs-to>https://bugs.astron.com/</bugs-to>
+	<remote-id type="cpe">cpe:/a:file_project:file</remote-id>
 </upstream>
 </pkgmetadata>

--- a/sys-apps/kmod/metadata.xml
+++ b/sys-apps/kmod/metadata.xml
@@ -14,4 +14,7 @@
 	<flag name="tools">Install module loading/unloading tools.</flag>
 	<flag name="zlib">Enable support for gzipped modules</flag>
 </use>
+<upstream>
+	<remote-id type="cpe">cpe:/a:kernel:kmod</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-apps/less/metadata.xml
+++ b/sys-apps/less/metadata.xml
@@ -5,4 +5,7 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<upstream>
+	<remote-id type="cpe">cpe:/a:gnu:less</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-apps/portage/metadata.xml
+++ b/sys-apps/portage/metadata.xml
@@ -5,6 +5,7 @@
     <bugs-to>mailto:dev-portage@gentoo.org</bugs-to>
     <changelog>https://gitweb.gentoo.org/proj/portage.git/plain/RELEASE-NOTES</changelog>
     <doc>https://wiki.gentoo.org/wiki/Handbook:AMD64/Working/Portage</doc>
+    <remote-id type="cpe">cpe:/a:gentoo:portage</remote-id>
   </upstream>
   <maintainer type="project">
     <email>dev-portage@gentoo.org</email>

--- a/sys-apps/sed/metadata.xml
+++ b/sys-apps/sed/metadata.xml
@@ -7,5 +7,6 @@
 </maintainer>
 <upstream>
 	<remote-id type="sourceforge">sed</remote-id>
+	<remote-id type="cpe">cpe:/a:gnu:sed</remote-id>
 </upstream>
 </pkgmetadata>

--- a/sys-apps/texinfo/metadata.xml
+++ b/sys-apps/texinfo/metadata.xml
@@ -12,4 +12,7 @@
 <use>
 	<flag name="standalone">Build standalone version that survives all Portage bugs</flag>
 </use>
+<upstream>
+	<remote-id type="cpe">cpe:/a:gnu:texinfo</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-devel/automake/metadata.xml
+++ b/sys-devel/automake/metadata.xml
@@ -5,4 +5,7 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<upstream>
+	<remote-id type="cpe">cpe:/a:gnu:automake</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-devel/flex/metadata.xml
+++ b/sys-devel/flex/metadata.xml
@@ -8,5 +8,6 @@
 	<upstream>
 		<remote-id type="sourceforge">flex</remote-id>
 		<remote-id type="github">westes/flex</remote-id>
+		<remote-id type="cpe">cpe:/a:flex_project:flex</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sys-devel/gettext/metadata.xml
+++ b/sys-devel/gettext/metadata.xml
@@ -15,4 +15,7 @@
 		this requires git at runtime, but will be faster/smaller than raw archives
 	</flag>
 </use>
+<upstream>
+	<remote-id type="cpe">cpe:/a:gnu:gettext</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-devel/make/metadata.xml
+++ b/sys-devel/make/metadata.xml
@@ -5,4 +5,7 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<upstream>
+	<remote-id type="cpe">cpe:/a:gnu:make</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-devel/patch/metadata.xml
+++ b/sys-devel/patch/metadata.xml
@@ -5,4 +5,7 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<upstream>
+	<remote-id type="cpe">cpe:/a:gnu:patch</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-fs/mdadm/metadata.xml
+++ b/sys-fs/mdadm/metadata.xml
@@ -5,4 +5,7 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<upstream>
+	<remote-id type="cpe">cpe:/a:mdadm_project:mdadm</remote-id>
+</upstream>
 </pkgmetadata>

--- a/sys-libs/libseccomp/metadata.xml
+++ b/sys-libs/libseccomp/metadata.xml
@@ -8,5 +8,6 @@
 	<upstream>
 		<remote-id type="github">seccomp/libseccomp</remote-id>
 		<remote-id type="sourceforge">libseccomp</remote-id>
+		<remote-id type="cpe">cpe:/a:libseccomp_project:libseccomp</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sys-process/procps/metadata.xml
+++ b/sys-process/procps/metadata.xml
@@ -13,5 +13,6 @@
 </use>
 <upstream>
 	<remote-id type="sourceforge">procps</remote-id>
+	<remote-id type="cpe">cpe:/a:procps_project:procps</remote-id>
 </upstream>
 </pkgmetadata>

--- a/sys-process/tini/metadata.xml
+++ b/sys-process/tini/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<upstream>
 		<remote-id type="github">krallin/tini</remote-id>
+		<remote-id type="cpe">cpe:/a:tini_project:tini</remote-id>
 	</upstream>
 	<maintainer type="person">
 		<email>zmedico@gentoo.org</email>


### PR DESCRIPTION
Those CPE tags are  from official CPE tag database official-cpe-dictionary_v2.3.xml downloaded from 
https://nvd.nist.gov/products/cpe.