### PR TITLE
profiles: unmask net-misc/icaclient on amd64/no-multilib.

### DIFF
--- a/profiles/arch/amd64/no-multilib/package.mask
+++ b/profiles/arch/amd64/no-multilib/package.mask
@@ -99,7 +99,6 @@ games-strategy/spaz
 media-sound/aucdtect
 media-video/binkplayer
 media-video/tsmuxer
-net-misc/icaclient
 net-misc/ps3mediaserver
 net-print/cndrvcups-common-lb
 net-print/cndrvcups-lb


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/719916

Signed-off-by: Matt Jolly <Kangie@footclan.ninja>