### PR TITLE
dev-libs/libuv: change dependancies group

### DIFF
--- a/dev-libs/libuv/libuv-1.35.0-r1.ebuild
+++ b/dev-libs/libuv/libuv-1.35.0-r1.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv s390 sparc x8
 IUSE="static-libs"
 RESTRICT="test"
 
-DEPEND="sys-devel/libtool
+BDEPEND="sys-devel/libtool
 	virtual/pkgconfig[${MULTILIB_USEDEP}]"
 
 src_prepare() {

--- a/dev-libs/libuv/libuv-1.37.0-r1.ebuild
+++ b/dev-libs/libuv/libuv-1.37.0-r1.ebuild
@@ -14,7 +14,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~
 IUSE="static-libs"
 RESTRICT="test"
 
-DEPEND="sys-devel/libtool
+BDEPEND="sys-devel/libtool
 	virtual/pkgconfig[${MULTILIB_USEDEP}]"
 
 src_prepare() {

--- a/dev-libs/libuv/libuv-9999.ebuild
+++ b/dev-libs/libuv/libuv-9999.ebuild
@@ -14,7 +14,7 @@ KEYWORDS=""
 IUSE="static-libs"
 RESTRICT="test"
 
-DEPEND="sys-devel/libtool
+BDEPEND="sys-devel/libtool
 	virtual/pkgconfig[${MULTILIB_USEDEP}]"
 
 src_prepare() {


### PR DESCRIPTION
Move libtool and pkgconfig dependancies in all ebuilds from DEPEND to BDEPEND group for the purpose of cross-compilation.
This will save build time and reduce size of cross-compiled systems.

Closes: https://bugs.gentoo.org/720952

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>
Signed-off-by: Jakov Petrina <jakov.petrina@sartura.hr>
Signed-off-by: Luka Perkov <luka.perkov@sartura.hr>