### PR TITLE
dev-embedded/arduino: Fix broken arduino-builder symlink

### DIFF
--- a/dev-embedded/arduino/arduino-1.8.5-r2.ebuild
+++ b/dev-embedded/arduino/arduino-1.8.5-r2.ebuild
@@ -136,7 +136,7 @@ src_install() {
 	# Here we do the same thing, but from the system arduino-builder.
 	dosym "../../arduino-builder/platform.txt" "${SHARE}/hardware/platform.txt"
 	dosym "../../arduino-builder/platform.keys.rewrite.txt" "${SHARE}/hardware/platform.keys.rewrite.txt"
-	dosym "../../../bin/arduino-builder" "${SHARE}/arduino-builder"
+	dosym "../../bin/arduino-builder" "${SHARE}/arduino-builder"
 
 	# hardware/tools/avr needs to exist or arduino-builder will
 	# complain about missing required -tools arg

--- a/dev-embedded/arduino/arduino-1.8.7.ebuild
+++ b/dev-embedded/arduino/arduino-1.8.7.ebuild
@@ -113,7 +113,7 @@ src_install() {
 	# Here we do the same thing, but from the system arduino-builder.
 	dosym "../../arduino-builder/platform.txt" "/usr/share/${PN}/hardware/platform.txt"
 	dosym "../../arduino-builder/platform.keys.rewrite.txt" "/usr/share/${PN}/hardware/platform.keys.rewrite.txt"
-	dosym "../../../bin/arduino-builder" "/usr/share/${PN}/arduino-builder"
+	dosym "../../bin/arduino-builder" "/usr/share/${PN}/arduino-builder"
 
 	# hardware/tools/avr needs to exist or arduino-builder will
 	# complain about missing required -tools arg


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/712742
Signed-off-by: Marcin Deranek <marcin.deranek@slonko.net>