### PR TITLE
gnome-base/libgnome-keyring: fix python-any-r1 eclass usage

### DIFF
--- a/gnome-base/libgnome-keyring/libgnome-keyring-3.12.0-r1.ebuild
+++ b/gnome-base/libgnome-keyring/libgnome-keyring-3.12.0-r1.ebuild
@@ -32,11 +32,24 @@ DEPEND="${RDEPEND}
 	>=dev-util/intltool-0.35
 	sys-devel/gettext
 	virtual/pkgconfig
-	test? ( $(python_gen_any_dep '
+	test? ( ${PYTHON_DEPS} $(python_gen_any_dep '
 		dev-python/pygobject:2[${PYTHON_USEDEP}]
 		dev-python/dbus-python[${PYTHON_USEDEP}]') )
 	vala? ( $(vala_depend) )
 "
+
+python_check_deps() {
+	if use test; then
+		has_version "dev-python/pygobject:2[${PYTHON_USEDEP}]" &&
+		has_version "dev-python/dbus-python[${PYTHON_USEDEP}]"
+	fi
+}
+
+pkg_setup() {
+	if use test; then
+		python_setup
+	fi
+}
 
 src_prepare() {
 	epatch "${FILESDIR}"/${PV}-vala-0.42-compat.patch


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/708574
Closes: https://bugs.gentoo.org/720128
Signed-off-by: Mike Gilbert <floppym@gentoo.org>