### PR TITLE
mail-client/neomutt: Fix documentation directory name

### DIFF
--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -107,14 +107,14 @@ src_install() {
 			-e '/^\(CC_FOR_BUILD\|CFLAGS_FOR_BUILD\)\s*=/p' \
 			-e '/^\(EXTRA_CFLAGS_FOR_BUILD\|LDFLAGS_FOR_BUILD\)\s*=/p' \
 			-e '/^\(EXEEXT\|SRCDIR\)\s*=/p' \
-			Makefile > doc/Makefile.fakedoc || die
+			Makefile > docs/Makefile.fakedoc || die
 		sed -n \
 			-e '/^MAKEDOC_CPP\s*=/,/^\s*$/p' \
-			-e '/^doc\/\(makedoc$(EXEEXT)\|neomutt\.1\|neomuttrc\.5\)\s*:/,/^\s*$/p' \
-			doc/Makefile.autosetup >> doc/Makefile.fakedoc || die
-		emake -f doc/Makefile.fakedoc doc/neomutt.1
-		emake -f doc/Makefile.fakedoc doc/neomuttrc.5
-		doman doc/neomutt.1 doc/neomuttrc.5
+			-e '/^docs\/\(makedoc$(EXEEXT)\|neomutt\.1\|neomuttrc\.5\)\s*:/,/^\s*$/p' \
+			docs/Makefile.autosetup >> docs/Makefile.fakedoc || die
+		emake -f docs/Makefile.fakedoc docs/neomutt.1
+		emake -f docs/Makefile.fakedoc docs/neomuttrc.5
+		doman docs/neomutt.1 docs/neomuttrc.5
 	fi
 
 	dodoc LICENSE* ChangeLog* README*


### PR DESCRIPTION
in the live ebuild