### PR TITLE
dev-libs/ilbc-rfc3951: add blocker to media-libs/libilbc.

### DIFF
--- a/dev-libs/ilbc-rfc3951/ilbc-rfc3951-0-r2.ebuild
+++ b/dev-libs/ilbc-rfc3951/ilbc-rfc3951-0-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="iLBC is a speech codec suitable for robust voice communication over IP"
+HOMEPAGE="https://webrtc.org/license/ilbc-freeware/"
+SRC_URI="http://simon.morlat.free.fr/download/1.1.x/source/ilbc-rfc3951.tar.gz -> ${P}.tar.gz"
+
+# relicensed under 3-clause BSD license, bug 390797
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+
+S="${WORKDIR}/${PN}"
+PATCHES=( "${FILESDIR}"/${PN}-asneeded.patch )
+
+RDEPEND="!media-libs/libilbc"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--enable-shared \
+		--disable-static
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}

--- a/profiles/package.deprecated
+++ b/profiles/package.deprecated
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Jaco Kroon <jaco@uls.co.za> (2020-05-04)
+# Please prefer media-libs/libilbc, it's better maintained upstream.
+dev-libs/ilbc-rfc3951
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-05-03)
 # Obsolete package gets in the way of unmasking >=x11-libs/pango-1.44
 # Bug #698922


### PR DESCRIPTION
media-libs/libilbc seems to be a drop-in replacement for
dev-libs/ilbc-rfc3951.

I intend to retire ilbc-rfc3951 as I've already switched asterisk to
media-libs/libilbc.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jaco Kroon <jaco@uls.co.za>