### PR TITLE
Add python3_7 to dev-python/jupyter{,_console} PYTHON_COMPAT

### DIFF
--- a/dev-python/jupyter/jupyter-1.0.0-r2.ebuild
+++ b/dev-python/jupyter/jupyter-1.0.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7} )
 
 inherit distutils-r1
 

--- a/dev-python/jupyter_console/jupyter_console-6.0.0.ebuild
+++ b/dev-python/jupyter_console/jupyter_console-6.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/719010
Signed-off-by: Nicholas Meyer <nickaristocrates@gmail.com>

https://bugs.gentoo.org/719010#c1

I tested python 3.7 with jupyter and jupyter_console and everything works fine for me when I set PYTHON_TARGETS to +python3_7, -python3_6:

```
[ebuild   R   ~] dev-python/jupyter_console-6.0.0::nmeyer  USE="-doc -test" PYTHON_TARGETS="python3_7 -python3_6" 0 KiB
[ebuild   R   ~] dev-python/jupyter-1.0.0-r2::nmeyer  USE="-doc" PYTHON_TARGETS="python3_7 -python3_6" 0 KiB
```

I enabled test use flag and feature and confirmed that tests passed on python3_7

```
>>> Test phase: dev-python/jupyter_console-6.0.0

 * python3_7: running distutils-r1_run_phase python_test
nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module
....Warning: Output is not to a terminal (fd=1).
Warning: Input is not to a terminal (fd=0).
.....
----------------------------------------------------------------------
Ran 9 tests in 8.037s

OK
 * python3_7: running distutils-r1_run_phase _distutils-r1_clean_egg_info
>>> Completed testing dev-python/jupyter_console-6.0.0
```

I also tested python3_8 and that _seems_ to work fine as well, but to even test it I had to version bump and add 3.8 to PYTHON_COMPAT to more than 10 dependencies in my local overlay.

Should 3.8 be added to PYTHON_COMPAT of these packages before 3.8 is added to their dependencies? Or could I open a PR that just adds 3.7 and then later followup with a larger PR that bumps all the dependencies required to add 3.8? I can update this PR to add 3.8 as well if the first strategy is preferred.

These are the dependencies I bumped for testing 3.8, although they install for me and seem to work with -test and -doc, I suspect some of them may be broken with +test or +doc:

dev-python/ipykernel dev-python/ipyparallel dev-python/ipython dev-python/ipywidgets dev-python/jupyter_client dev-python/jupyter dev-python/jupyter_core dev-python/nbconvert dev-python/nbformat dev-python/notebook dev-python/widgetsnbextension dev-python/jupyter_console dev-python/qtconsole

Exact versions:

=dev-python/ipykernel-5.2.1 =dev-python/ipyparallel-6.2.5 =dev-python/ipython-7.14.0 =dev-python/ipywidgets-7.5.1 =dev-python/jupyter_client-6.1.3 =dev-python/jupyter_core-4.6.3 =dev-python/nbconvert-5.6.1 =dev-python/nbformat-5.0.6 =dev-python/notebook-6.0.3 =dev-python/widgetsnbextension-3.5.1 dev-python/jupyter_console =dev-python/qtconsole-4.7.3