### PR TITLE
dev-python/nbconvert: specify tornado version upper bound

### DIFF
--- a/dev-python/nbconvert/nbconvert-5.2.1.ebuild
+++ b/dev-python/nbconvert/nbconvert-5.2.1.ebuild
@@ -27,7 +27,8 @@ RDEPEND="
 	dev-python/pygments[${PYTHON_USEDEP}]
 	>=dev-python/traitlets-4.2.1[${PYTHON_USEDEP}]
 	dev-python/testpath[${PYTHON_USEDEP}]
-	www-servers/tornado[${PYTHON_USEDEP}]
+	>=www-servers/tornado-4.0[${PYTHON_USEDEP}]
+	<www-servers/tornado-6.0[${PYTHON_USEDEP}]
 "
 DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]


### PR DESCRIPTION
nbconvert-5.2.1 has code depending on tornado.web.asynchronous
decorator[1], which as been removed in Tornado 6.0[2].

Attempting to run it using the unsupported Tornado version leads to the
following runtime failure:

    [E 00:35:25.170 NotebookApp] Uncaught exception GET /notebooks/examples.ipynb?token=0ca183a93fdde5cc291a9a8f882a319666998f7be03a848e (::1)
        HTTPServerRequest(protocol='http', host='localhost:8888', method='GET', uri='/notebooks/examples.ipynb?token=0ca183a93fdde5cc291a9a8f882a319666998f7be03a848e', version='HTTP/1.1', remote_ip='::1')
        Traceback (most recent call last):
          File "/usr/lib64/python3.6/site-packages/tornado/web.py", line 1701, in _execute
            result = method(*self.path_args, **self.path_kwargs)
          File "/usr/lib64/python3.6/site-packages/tornado/web.py", line 3178, in wrapper
            return method(self, *args, **kwargs)
          File "/usr/lib64/python3.6/site-packages/notebook/notebook/handlers.py", line 59, in get
            get_custom_frontend_exporters=get_custom_frontend_exporters
          File "/usr/lib64/python3.6/site-packages/notebook/base/handlers.py", line 519, in render_template
            return template.render(**ns)
          File "/usr/lib64/python3.6/site-packages/jinja2/environment.py", line 1090, in render
            self.environment.handle_exception()
          File "/usr/lib64/python3.6/site-packages/jinja2/environment.py", line 832, in handle_exception
            reraise(*rewrite_traceback_stack(source=source))
          File "/usr/lib64/python3.6/site-packages/jinja2/_compat.py", line 28, in reraise
            raise value.with_traceback(tb)
          File "/usr/lib64/python3.6/site-packages/notebook/templates/notebook.html", line 1, in top-level template code
            {% extends "page.html" %}
          File "/usr/lib64/python3.6/site-packages/notebook/templates/page.html", line 153, in top-level template code
          File "/usr/lib64/python3.6/site-packages/notebook/templates/notebook.html", line 120, in block "header"
            {% for exporter in get_custom_frontend_exporters() %}
          File "/usr/lib64/python3.6/site-packages/notebook/notebook/handlers.py", line 19, in get_custom_frontend_exporters
            from nbconvert.exporters.base import get_export_names, get_exporter
          File "/usr/lib64/python3.6/site-packages/nbconvert/__init__.py", line 7, in <module>
            from . import postprocessors
          File "/usr/lib64/python3.6/site-packages/nbconvert/postprocessors/__init__.py", line 5, in <module>
            from .serve import ServePostProcessor
          File "/usr/lib64/python3.6/site-packages/nbconvert/postprocessors/serve.py", line 18, in <module>
            class ProxyHandler(web.RequestHandler):
          File "/usr/lib64/python3.6/site-packages/nbconvert/postprocessors/serve.py", line 20, in ProxyHandler
            @web.asynchronous
        AttributeError: module 'tornado.web' has no attribute 'asynchronous'

Also specify the lower bound as 4.0, since it's specified in setup.py[3].

[1] https://github.com/jupyter/nbconvert/blob/5.2.1/nbconvert/postprocessors/serve.py#L20
[2] https://www.tornadoweb.org/en/stable/releases/v6.0.0.html#tornado-web
[3] https://github.com/jupyter/nbconvert/blob/5.2.1/setup.py#L204

Closes: https://bugs.gentoo.org/720870
Signed-off-by: Maxim Plotnikov <wgh@torlan.ru>