### PR TITLE
app-misc/gtypist: add patch to fix crash and bump to 2.9.5-r1

### DIFF
--- a/app-misc/gtypist/files/gtypist-2.9.5-link-infow.patch
+++ b/app-misc/gtypist/files/gtypist-2.9.5-link-infow.patch
@@ -1,0 +1,15 @@
+diff --git a/configure.ac b/configure.ac
+index 8742d93..e350926 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -56,8 +56,8 @@ else
+        "further information. On Debian/Ubuntu you need to install libncursesw5-dev."
+    exit 1;
+ fi
+-AC_SEARCH_LIBS(cbreak, tinfo, [],
+-  [AC_MSG_ERROR([Can't find cbreak() in -lncursesw or -ltinfo])])
++AC_SEARCH_LIBS(cbreak, tinfow, [],
++  [AC_MSG_ERROR([Can't find cbreak() in -lncursesw or -ltinfow])])
+ 
+ 
+ # iconv

--- a/app-misc/gtypist/gtypist-2.9.5-r1.ebuild
+++ b/app-misc/gtypist/gtypist-2.9.5-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-inherit eutils elisp-common
+EAPI=7
+inherit elisp-common autotools
 
 DESCRIPTION="Universal typing tutor"
 HOMEPAGE="https://www.gnu.org/software/gtypist/"
@@ -27,8 +27,17 @@ src_unpack() {
 	unpack ${P}.tar.xz
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.8.3-xemacs-compat.patch
+
+	# solution from https://bugs.gentoo.org/698764#c0
+	"${FILESDIR}"/${PN}-2.9.5-link-infow.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}"/${PN}-2.8.3-xemacs-compat.patch
+	default
+
+	eaclocal && eautomake
 }
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/698764
Signed-off-by: Arjan Adriaanse <arjan@adriaan.se>