### PR TITLE
sys-apps/dstat: fix test failure

### DIFF
--- a/sys-apps/dstat/dstat-0.7.4-r2.ebuild
+++ b/sys-apps/dstat/dstat-0.7.4-r2.ebuild
@@ -54,3 +54,7 @@ src_install() {
 		dodoc docs/*.html
 	fi
 }
+
+src_test() {
+	python_foreach_impl emake test
+}


### PR DESCRIPTION
1. fix the executable shebang so that python_doscript wraps the script
   correctly
2. call the tests correctly with the correct python version(s)

Bug: https://bugs.gentoo.org/711690
Signed-off-by: Paul Healy <lmiphay@gmail.com>