### PR TITLE
app-misc/gtypist: become proxy maintainer

### DIFF
--- a/app-misc/gtypist/metadata.xml
+++ b/app-misc/gtypist/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>dabbott@gentoo.org</email>
-		<name>David Abbott</name>
-	</maintainer>
+  <maintainer type="person">
+    <email>arjan@adriaan.se</email>
+    <name>Arjan Adriaanse</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
 </pkgmetadata>


### PR DESCRIPTION
As discussed with the previous maintainer David Abbott
<dabbott@gentoo.org>.

See b7994d5cdc2b for prior contribution.

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Arjan Adriaanse <arjan@adriaan.se>