### PR TITLE
net-misc/openntpd: Fix issues with -fno-common compilation

### DIFF
--- a/net-misc/openntpd/files/openntpd-6.2p3-fno-common.patch
+++ b/net-misc/openntpd/files/openntpd-6.2p3-fno-common.patch
@@ -1,0 +1,60 @@
+diff -u -r openntpd-6.2p3-orig/include/sys/types.h openntpd-6.2p3/include/sys/types.h
+--- openntpd-6.2p3-orig/include/sys/types.h	2017-10-23 05:15:41.000000000 -0700
++++ openntpd-6.2p3/include/sys/types.h	2020-05-05 19:57:57.039447282 -0700
+@@ -22,6 +22,10 @@
+ # define __bounded__(x, y, z)
+ #endif
+ 
++#if !defined(HAVE_ATTRIBUTE__PACKED) && !defined(__packed)
++# define __packed	__attribute__((__packed__))
++#endif
++
+ /*
+  * Define BSD-style unsigned bits types for systems that do not have them.
+  */
+diff -u -r openntpd-6.2p3-orig/src/ntp.c openntpd-6.2p3/src/ntp.c
+--- openntpd-6.2p3-orig/src/ntp.c	2017-06-19 06:23:10.000000000 -0700
++++ openntpd-6.2p3/src/ntp.c	2020-05-05 19:55:01.041306344 -0700
+@@ -42,7 +42,7 @@
+ 
+ volatile sig_atomic_t	 ntp_quit = 0;
+ struct imsgbuf		*ibuf_main;
+-struct imsgbuf		*ibuf_dns;
++static struct imsgbuf	*ibuf_dns;
+ struct ntpd_conf	*conf;
+ struct ctl_conns	 ctl_conns;
+ u_int			 peer_cnt;
+diff -u -r openntpd-6.2p3-orig/src/ntp_dns.c openntpd-6.2p3/src/ntp_dns.c
+--- openntpd-6.2p3-orig/src/ntp_dns.c	2017-06-19 06:23:10.000000000 -0700
++++ openntpd-6.2p3/src/ntp_dns.c	2020-05-05 19:55:30.325662563 -0700
+@@ -33,7 +33,7 @@
+ #include "ntpd.h"
+ 
+ volatile sig_atomic_t	 quit_dns = 0;
+-struct imsgbuf		*ibuf_dns;
++static struct imsgbuf	*ibuf_dns;
+ 
+ void	sighdlr_dns(int);
+ int	dns_dispatch_imsg(void);
+diff -u -r openntpd-6.2p3-orig/src/parse.c openntpd-6.2p3/src/parse.c
+--- openntpd-6.2p3-orig/src/parse.c	2017-10-30 01:57:56.000000000 -0700
++++ openntpd-6.2p3/src/parse.c	2020-05-05 19:55:56.505981067 -0700
+@@ -101,7 +101,6 @@
+ int		 lungetc(int);
+ int		 findeol(void);
+ 
+-struct ntpd_conf		*conf;
+ struct sockaddr_in		 query_addr4;
+ struct sockaddr_in6		 query_addr6;
+ 
+diff -u -r openntpd-6.2p3-orig/src/parse.y openntpd-6.2p3/src/parse.y
+--- openntpd-6.2p3-orig/src/parse.y	2017-10-30 01:57:40.000000000 -0700
++++ openntpd-6.2p3/src/parse.y	2020-05-05 19:55:51.504920219 -0700
+@@ -57,7 +57,6 @@
+ int		 lungetc(int);
+ int		 findeol(void);
+ 
+-struct ntpd_conf		*conf;
+ struct sockaddr_in		 query_addr4;
+ struct sockaddr_in6		 query_addr6;
+ 

--- a/net-misc/openntpd/openntpd-6.2_p3-r2.ebuild
+++ b/net-misc/openntpd/openntpd-6.2_p3-r2.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit systemd
+
+MY_P="${P/_p/p}"
+
+DESCRIPTION="Lightweight NTP server ported from OpenBSD"
+HOMEPAGE="http://www.openntpd.org/"
+SRC_URI="mirror://openbsd/OpenNTPD/${MY_P}.tar.gz"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+IUSE="libressl selinux"
+
+DEPEND="
+	!net-misc/ntp[-openntpd]
+	libressl? ( dev-libs/libressl:0= )"
+
+RDEPEND="
+	${DEPEND}
+	acct-group/openntpd
+	acct-user/openntpd
+	selinux? ( sec-policy/selinux-ntp )"
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}/openntpd-6.2p3-fno-common.patch"
+)
+
+src_prepare() {
+	default
+
+	# fix /run path
+	sed -i 's:/var/run/ntpd:/run/ntpd:g' src/ntpctl.8 src/ntpd.8 || die
+	sed -i 's:LOCALSTATEDIR "/run/ntpd:"/run/ntpd:' src/ntpd.h || die
+
+	# fix ntpd.drift path
+	sed -i 's:/var/db/ntpd.drift:/var/lib/openntpd/ntpd.drift:g' src/ntpd.8 || die
+	sed -i 's:"/db/ntpd.drift":"/openntpd/ntpd.drift":' src/ntpd.h || die
+
+	# fix default config to use gentoo pool
+	sed -i 's:servers pool.ntp.org:#servers pool.ntp.org:' ntpd.conf || die
+	printf "\n# Choose servers announced from Gentoo NTP Pool\nservers 0.gentoo.pool.ntp.org\nservers 1.gentoo.pool.ntp.org\nservers 2.gentoo.pool.ntp.org\nservers 3.gentoo.pool.ntp.org\n" >> ntpd.conf || die
+
+	# disable constraint config if libressl not enabled
+	use libressl || sed -ie 's/^constraints/#constraints/g' ntpd.conf || die
+}
+
+src_configure() {
+	econf \
+		--with-privsep-user=openntpd \
+		--with-privsep-path=/var/lib/openntpd/chroot \
+		$(use_enable libressl https-constraint)
+}
+
+src_install() {
+	default
+
+	rm -r "${ED}"/var || die
+
+	newinitd "${FILESDIR}/${PN}.init.d-20080406-r6" ntpd
+	newconfd "${FILESDIR}/${PN}.conf.d-20080406-r6" ntpd
+
+	systemd_newunit "${FILESDIR}/${PN}.service-20080406-r4" ntpd.service
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/707786
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Paul B. Henson <henson@acm.org>