### PR TITLE
media-tv/xmltv: add ~arm ~ppc keyword bug #719138

### DIFF
--- a/media-tv/xmltv/xmltv-0.6.1.ebuild
+++ b/media-tv/xmltv/xmltv-0.6.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/XMLTV/xmltv/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~x86-linux"
+KEYWORDS="~amd64 ~arm ~ppc ~x86 ~x86-linux"
 
 IUSE="ar ch-search dk dtvla eu-dotmedia eu-epgdata eu-xmltvse fi fi-sv fr
 huro il is it na-dd na-dtv na-tvmedia pt-meo pt-vodafone se-swedb se-tvzon tr


### PR DESCRIPTION
Restore keywords removed because some depended perl modules do not have them.
Bug: https://bugs.gentoo.org/719138
Signed-off-by: Wilson Michaels <thebitpit@earthlink.net>