### PR TITLE
dev-python/dockerpty: Add python3_8

### DIFF
--- a/dev-python/dockerpty/dockerpty-0.4.1-r1.ebuild
+++ b/dev-python/dockerpty/dockerpty-0.4.1-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7} )
+
+PYTHON_COMPAT=( python3_{6,7,8} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Should be the last dep of app-emulation/docker-compose requiring a PYTHON_COMPAT bump. Tests pass.