### PR TITLE
dev-lang/icon fix for building with sys-libs/musl

### DIFF
--- a/dev-lang/icon/files/icon-9.5.1-musl.patch
+++ b/dev-lang/icon/files/icon-9.5.1-musl.patch
@@ -1,0 +1,24 @@
+diff -uprN a/ipl/cfuncs/fpoll.c b/ipl/cfuncs/fpoll.c
+--- a/ipl/cfuncs/fpoll.c	2020-05-10 21:46:39.730752626 -0600
++++ b/ipl/cfuncs/fpoll.c	2020-05-10 21:50:41.613577816 -0600
+@@ -33,6 +33,10 @@
+ #include <sys/types.h>
+ #include <sys/time.h>
+ 
++#if defined(_MUSL)
++# include <stdio_ext.h>
++#endif
++
+ #include "icall.h"
+ 
+ int fpoll(int argc, descriptor *argv)	/*: await data from file */
+@@ -66,6 +70,9 @@ int fpoll(int argc, descriptor *argv)	/*
+ #elif defined(_FSTDIO)					/* new BSD library */
+    if (f->_r > 0)
+       RetArg(1);
++#elif defined(_MUSL)                                   /* MUSL library */
++   if (__freadahead(f))
++      RetArg(1);
+ #else							/* old AT&T library */
+    if (f->_cnt > 0)
+       RetArg(1);

--- a/dev-lang/icon/icon-9.5.1-r2.ebuild
+++ b/dev-lang/icon/icon-9.5.1-r2.ebuild
@@ -31,8 +31,13 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.5.1-flags.patch
 	# https://bugs.gentoo.org/669330
 	# Fix glibc 2.28 problem.
-	# Patch has also been submitted for upstream approval
+	# Patch has been accepted upstream, but is not yet in a release
 	"${FILESDIR}"/${PN}-9.5.1-fpoll.patch
+
+	# https://bugs.gentoo.org/716212
+	# Fix building with musl
+	# Patch has been accepted upstream, but is not yet in a release
+	"${FILESDIR}"/${PN}-9.5.1-musl.patch
 )
 
 src_prepare() {
@@ -61,8 +66,13 @@ src_configure() {
 		-e 's:-L/usr/X11R6/lib64::g' \
 		-e 's:-L/usr/X11R6/lib::g' \
 		-e 's:-I/usr/X11R6/include::g' \
+		-e 's:-I/usr/X11R6/include::g' \
+		-e '/^CFLAGS/d' \
 		Makedefs || die "sed of Makedefs failed"
 
+	if use elibc_musl; then
+	    append-flags "-D_MUSL"
+	fi
 	append-flags $(test-flags -fno-strict-aliasing -fwrapv)
 }
 

--- a/dev-lang/icon/icon-9.5.1-r2.ebuild
+++ b/dev-lang/icon/icon-9.5.1-r2.ebuild
@@ -95,7 +95,9 @@ src_install() {
 	dosym ../$(get_libdir)/icon/bin/icont /usr/bin/icont
 	dosym ../$(get_libdir)/icon/bin/iconx /usr/bin/iconx
 	dosym ../$(get_libdir)/icon/bin/icon  /usr/bin/icon
-	dosym ../$(get_libdir)/icon/bin/vib   /usr/bin/vib
+	if use X; then
+		dosym ../$(get_libdir)/icon/bin/vib /usr/bin/vib
+	fi
 
 	cd "${S}/man/man1" || die
 	doman "${PN}"t.1


### PR DESCRIPTION
The Icon Programming Library function fpoll.c fails to build when
the sys-libs/musl is being used.

fpoll.c is sensitive to the internal layout of the FILE structure.

Patch fpoll.c so it will build when sys-libs/musl is used.

Since the musl library does not provide a way to detect that the
musl library is being used. Update the ebuild to update CFLAGS
to include a define that indicates musl is being used.

In addition, CFLAGS were being overridden within the build process.
Update the ebuild to ensure that the ebuild's CFLAGS are used.