### PR TITLE
dev-python/pyaudio: add support for Python 3.7 and 3.8

### DIFF
--- a/dev-python/pyaudio/pyaudio-0.2.11.ebuild
+++ b/dev-python/pyaudio/pyaudio-0.2.11.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7,8} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/719394