### PR TITLE
media-libs/libcddb: EAPI-7 bump

### DIFF
--- a/media-libs/libcddb/libcddb-1.3.2-r2.ebuild
+++ b/media-libs/libcddb/libcddb-1.3.2-r2.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal
+
+DESCRIPTION="A library for accessing a CDDB server"
+HOMEPAGE="http://libcddb.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+
+LICENSE="LGPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="doc static-libs"
+
+RDEPEND=">=virtual/libiconv-0-r1[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+BDEPEND="doc? ( app-doc/doxygen )"
+
+RESTRICT="test"
+
+DOCS=( AUTHORS ChangeLog NEWS README THANKS TODO )
+
+MULTILIB_WRAPPED_HEADERS=( /usr/include/cddb/version.h )
+
+multilib_src_configure() {
+	local myconf=(
+		--without-cdio
+		$(use_enable static-libs static)
+	)
+
+	# bug 528012
+	ECONF_SOURCE="${S}" CONFIG_SHELL="${BASH}" econf "${myconf[@]}"
+}
+
+src_compile() {
+	multilib-minimal_src_compile
+
+	if use doc; then
+		cd "${S}"/doc || die
+		doxygen doxygen.conf || die
+	fi
+}
+
+src_install() {
+	multilib-minimal_src_install
+
+	use doc && dodoc -r "${S}"/doc/html
+
+	find "${ED}" -type f \( -name '*.a' -o -name '*.la' \) -delete || die
+}


### PR DESCRIPTION
* EAPI-7 bump
* Fix license to LGPL-2+
* Fix configure with /bin/sh -> dash

Note: to preperly fix compatibility with dash, configure needs to be
regenerated with newer version of autoconf. So for now we just set
CONFIG_SHELL variable as a workaround.

Closes: https://bugs.gentoo.org/528012