### PR TITLE
New OpenWrt packages

### DIFF
--- a/dev-libs/libubox/libubox-9999.ebuild
+++ b/dev-libs/libubox/libubox-9999.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake git-r3
+
+DESCRIPTION="A general purpose library for the OpenWrt project."
+HOMEPAGE="https://git.openwrt.org/?p=project/libubox.git;a=summary"
+EGIT_REPO_URI="https://git.openwrt.org/project/libubox.git"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+IUSE="lua"
+
+REPEND="lua? ( >=dev-lang/lua-5.1:0 )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	default
+	sed -i 's|\<json/json.h\>|json-c/json.h|' jshn.c blobmsg_json.h
+	echo 'INCLUDE_DIRECTORIES(/usr/include/libnl3)' >> CMakeLists.txt
+
+	# Do not violate multilib-strict check
+	sed -e "s/DESTINATION lib/DESTINATION $(get_libdir)/" -i CMakeLists.txt || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_LUA=$(usex lua)
+		-DBUILD_EXAMPLES=OFF
+	)
+
+	cmake_src_configure
+}

--- a/dev-libs/libubox/metadata.xml
+++ b/dev-libs/libubox/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>jakov.smolic@sartura.hr</email>
+		<name>Jakov Smolic</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>luka.perkov@sartura.hr</email>
+		<name>Luka Perkov</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/sys-apps/ubus/metadata.xml
+++ b/sys-apps/ubus/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>jakov.smolic@sartura.hr</email>
+		<name>Jakov Smolic</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>luka.perkov@sartura.hr</email>
+		<name>Luka Perkov</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/sys-apps/ubus/ubus-9999.ebuild
+++ b/sys-apps/ubus/ubus-9999.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake git-r3
+
+DESCRIPTION="An embedded bus system developed for OpenWrt. It is like dbus but simple and small."
+HOMEPAGE="https://git.openwrt.org/?p=project/ubus.git;a=summary"
+EGIT_REPO_URI="https://git.openwrt.org/project/ubus.git"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+IUSE="lua"
+
+RDEPEND="
+	dev-libs/libubox
+	lua? ( >=dev-lang/lua-5.1:0 )
+"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+
+	# Do not violate multilib-strict check
+	sed -e "s/DESTINATION lib/DESTINATION $(get_libdir)/" -i CMakeLists.txt || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_LUA=$(usex lua)
+	)
+
+	cmake_src_configure
+}

--- a/sys-apps/uci/metadata.xml
+++ b/sys-apps/uci/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>jakov.smolic@sartura.hr</email>
+		<name>Jakov Smolic</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>luka.perkov@sartura.hr</email>
+		<name>Luka Perkov</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/sys-apps/uci/uci-9999.ebuild
+++ b/sys-apps/uci/uci-9999.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake git-r3
+
+DESCRIPTION="A general purpose library for the OpenWrt project."
+HOMEPAGE="https://git.openwrt.org/?p=project/uci.git;a=summary"
+EGIT_REPO_URI="https://git.openwrt.org/project/uci.git"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+IUSE="lua"
+
+RDEPEND="
+	dev-libs/libubox
+	lua? ( >=dev-lang/lua-5.1:0 )
+"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+
+	# Do not violate multilib-strict check
+	sed -e "s/DESTINATION lib/DESTINATION $(get_libdir)/" -i CMakeLists.txt || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_LUA=$(usex lua)
+	)
+
+	cmake_src_configure
+}


### PR DESCRIPTION
Add 3 OpenWrt utility programs intended for use in embedded systems: libubox, ubus and uci.

Closes: https://bugs.gentoo.org/722754
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>
Signed-off-by: Luka Perkov <luka.perkov@sartura.hr>