### PR TITLE
net-proxy/haproxy: Fix 32-bit build

### DIFF
--- a/net-proxy/haproxy/haproxy-2.0.14-r1.ebuild
+++ b/net-proxy/haproxy/haproxy-2.0.14-r1.ebuild
@@ -97,6 +97,9 @@ src_compile() {
 	# For now, until the strict-aliasing breakage will be fixed
 	append-cflags -fno-strict-aliasing
 
+	# Bug #668002
+	(use ppc || use arm || use hppa) && append-libs -latomic
+
 	if use prometheus-exporter; then
 		EXTRA_OBJS="contrib/prometheus-exporter/service-prometheus.o"
 	fi

--- a/net-proxy/haproxy/haproxy-2.1.4-r1.ebuild
+++ b/net-proxy/haproxy/haproxy-2.1.4-r1.ebuild
@@ -97,6 +97,9 @@ src_compile() {
 	# For now, until the strict-aliasing breakage will be fixed
 	append-cflags -fno-strict-aliasing
 
+	# Bug #668002
+	(use ppc || use arm || use hppa) && append-libs -latomic
+
 	if use prometheus-exporter; then
 		EXTRA_OBJS="contrib/prometheus-exporter/service-prometheus.o"
 	fi


### PR DESCRIPTION
Links against libatomic on 32-bit non-x86 arches.

Bug: https://bugs.gentoo.org/668002
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>