### PR TITLE
net-analyzer/fail2ban: live version supports python3_8

### DIFF
--- a/net-analyzer/fail2ban/fail2ban-99999999.ebuild
+++ b/net-analyzer/fail2ban/fail2ban-99999999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7,8} )
 DISTUTILS_SINGLE_IMPL=1
 
 inherit bash-completion-r1 distutils-r1 git-r3 systemd


### PR DESCRIPTION
it's equal to latest release :) so sync it