### PR TITLE
www-client/chromium: depend on media-libs/mesa[gbm]

### DIFF
--- a/www-client/chromium/chromium-81.0.4044.138.ebuild
+++ b/www-client/chromium/chromium-81.0.4044.138.ebuild
@@ -40,6 +40,7 @@ COMMON_DEPEND="
 	>=media-libs/harfbuzz-2.4.0:0=[icu(-)]
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
+	media-libs/mesa:=[gbm]
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc,svc] )
 	>=media-libs/openh264-1.6.0:=
 	pulseaudio? ( media-sound/pulseaudio:= )

--- a/www-client/chromium/chromium-83.0.4103.34.ebuild
+++ b/www-client/chromium/chromium-83.0.4103.34.ebuild
@@ -38,6 +38,7 @@ COMMON_DEPEND="
 	>=media-libs/harfbuzz-2.4.0:0=[icu(-)]
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
+	media-libs/mesa:=[gbm]
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc,svc] )
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/721622
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>