### PR TITLE
media-gfx/zbar: 0.23.1 configure fails with /bin/sh != bash

### DIFF
--- a/media-gfx/zbar/zbar-0.23.1.ebuild
+++ b/media-gfx/zbar/zbar-0.23.1.ebuild
@@ -193,6 +193,8 @@ multilib_src_configure() {
 		use test && myeconfargs+=( --without-zbarimg-tests )
 	fi
 
+	# use bash (bug 721370)
+	CONFIG_SHELL='/bin/bash' \
 	ECONF_SOURCE="${S}" \
 		econf "${myeconfargs[@]}"
 


### PR DESCRIPTION
```bash
/var/tmp/portage/media-gfx/zbar-0.23.1/work/zbar-0.23.1/configure: 25279: /var/tmp/portage/media-gfx/zbar-0.23.1/work/zbar-0.23.1/configure: Bad substitution
```

Closes: https://bugs.gentoo.org/721370
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Yury Martynov <email@linxon.ru>