### PR TITLE
media-gfx/iscan: fix building with boost 1.73

### DIFF
--- a/media-gfx/iscan/files/iscan-3.62.0-boost-1.73.patch
+++ b/media-gfx/iscan/files/iscan-3.62.0-boost-1.73.patch
@@ -1,0 +1,33 @@
+diff -urN utsushi-0.62.0.orig/drivers/esci/verify.cpp utsushi-0.62.0/drivers/esci/verify.cpp
+--- utsushi-0.62.0.orig/drivers/esci/verify.cpp	2019-11-18 04:08:45.000000000 +0200
++++ utsushi-0.62.0/drivers/esci/verify.cpp	2020-05-09 20:22:00.899968638 +0300
+@@ -58,6 +58,7 @@
+ 
+ using namespace utsushi;
+ using namespace _drv_::esci;
++using namespace boost::placeholders;
+ 
+ using std::basic_string;
+ using std::ios_base;
+diff -urN utsushi-0.62.0.orig/lib/monitor.cpp utsushi-0.62.0/lib/monitor.cpp
+--- utsushi-0.62.0.orig/lib/monitor.cpp	2019-11-18 04:08:08.000000000 +0200
++++ utsushi-0.62.0/lib/monitor.cpp	2020-05-09 20:22:26.392174029 +0300
+@@ -49,6 +49,7 @@
+ namespace utsushi {
+ 
+ using boost::filesystem::exists;
++using namespace boost::placeholders;
+ 
+ class monitor::impl
+ {
+diff -urN utsushi-0.62.0.orig/sane/handle.cpp utsushi-0.62.0/sane/handle.cpp
+--- utsushi-0.62.0.orig/sane/handle.cpp	2019-11-18 04:08:08.000000000 +0200
++++ utsushi-0.62.0/sane/handle.cpp	2020-05-09 20:21:49.559223712 +0300
+@@ -65,6 +65,7 @@
+ using utsushi::_flt_::deskew;
+ using utsushi::_flt_::autocrop;
+ using utsushi::_flt_::pnm;
++using namespace boost::placeholders;
+ 
+ namespace sane {
+ 

--- a/media-gfx/iscan/iscan-3.62.0.ebuild
+++ b/media-gfx/iscan/iscan-3.62.0.ebuild
@@ -33,6 +33,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.61.0-ijg-libjpeg.patch
 	"${FILESDIR}"/${PN}-3.61.0-imagemagick-7.patch
 	"${FILESDIR}"/${PN}-3.62.0-gcc-10.patch
+	"${FILESDIR}"/${PN}-3.62.0-boost-1.73.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/721696
Signed-off-by: Marcin Deranek <marcin.deranek@slonko.net>