### PR TITLE
media-gfx/iscan: Be more specific about ignoring warnings

### DIFF
--- a/media-gfx/iscan/iscan-3.62.0.ebuild
+++ b/media-gfx/iscan/iscan-3.62.0.ebuild
@@ -43,7 +43,7 @@ src_prepare() {
 	rm -r upstream/boost || die
 	# Workaround for deprecation warnings:
 	# https://gitlab.com/utsushi/utsushi/issues/90
-	sed -e 's|-Werror||g' -i configure.ac || die
+	sed -e 's|=-Werror|="-Werror -Wno-error=deprecated-declarations"|g' -i configure.ac || die
 	eautoreconf
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/711416
Signed-off-by: Marcin Deranek <marcin.deranek@slonko.net>