### PR TITLE
media-gfx/iscan: fix building with boost 1.73 when gui use enabled

### DIFF
--- a/media-gfx/iscan/files/iscan-3.62.0-boost-1.73.patch
+++ b/media-gfx/iscan/files/iscan-3.62.0-boost-1.73.patch
@@ -31,3 +31,14 @@ diff -urN a/sane/handle.cpp b/sane/handle.cpp
  
  namespace sane {
  
+--- utsushi-0.62.0/gtkmm/pump.cpp.orig	2019-11-18 03:08:48.000000000 +0100
++++ utsushi-0.62.0/gtkmm/pump.cpp	2020-05-10 21:59:32.986379049 +0200
+@@ -31,6 +31,8 @@
+ namespace utsushi {
+ namespace gtkmm {
+ 
++using namespace boost::placeholders;
++
+ pump::pump (idevice::ptr idev)
+   : utsushi::pump (idev)
+   , idev_ptr_(idev)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/721696
Signed-off-by: Marcin Deranek <marcin.deranek@slonko.net>