### PR TITLE
dev-libs/libtpms: Fix compiliation under GCC10

### DIFF
--- a/dev-libs/libtpms/files/libtpms-0.7.0-tpm12-Fix-potential-buffer-overflow-in-filename-creation.patch
+++ b/dev-libs/libtpms/files/libtpms-0.7.0-tpm12-Fix-potential-buffer-overflow-in-filename-creation.patch
@@ -1,0 +1,105 @@
+From 1cdd950e7342240ed8edc695372365cf57fbc6cb Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Thu, 17 Oct 2019 10:19:23 -0400
+Subject: [PATCH 2/2] tpm12: Fix potential buffer overflow in filename creation
+
+Fix a potential buffer overflow bug in the creation of filenames
+that were using sprintf() rather than snprintf(). The buffer overflow
+could occurr if the buffer is longer than 4096 bytes. The state path
+may alone be 4096 bytes and could possibly trigger the overflow.
+
+Swtpm for example is not affected from this since it uses the callbacks
+that are invoked before the faulty function is called.
+
+Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
+---
+ src/tpm12/tpm_nvfile.c | 43 ++++++++++++++++++++++++++++++++----------
+ 1 file changed, 33 insertions(+), 10 deletions(-)
+
+diff --git a/src/tpm12/tpm_nvfile.c b/src/tpm12/tpm_nvfile.c
+index c8e7bcf..0268bd0 100644
+--- a/src/tpm12/tpm_nvfile.c
++++ b/src/tpm12/tpm_nvfile.c
+@@ -70,7 +70,8 @@
+ 
+ /* local prototypes */
+ 
+-static void       TPM_NVRAM_GetFilenameForName(char *filename,
++static TPM_RESULT TPM_NVRAM_GetFilenameForName(char *filename,
++                                               size_t filename_len,
+ 					       uint32_t tpm_number,
+                                                const char *name);
+ 
+@@ -189,7 +190,10 @@ TPM_RESULT TPM_NVRAM_LoadData(unsigned char **data,     /* freed by caller */
+     /* open the file */
+     if (rc == 0) {
+         /* map name to the rooted filename */
+-        TPM_NVRAM_GetFilenameForName(filename, tpm_number, name);
++        rc = TPM_NVRAM_GetFilenameForName(filename, sizeof(filename),
++                                          tpm_number, name);
++    }
++    if (rc == 0) {
+         printf("  TPM_NVRAM_LoadData: Opening file %s\n", filename);
+         file = fopen(filename, "rb");                           /* closed @1 */
+         if (file == NULL) {     /* if failure, determine cause */
+@@ -297,7 +301,10 @@ TPM_RESULT TPM_NVRAM_StoreData(const unsigned char *data,
+     printf(" TPM_NVRAM_StoreData: To name %s\n", name);
+     if (rc == 0) {
+         /* map name to the rooted filename */
+-        TPM_NVRAM_GetFilenameForName(filename, tpm_number, name);
++        rc = TPM_NVRAM_GetFilenameForName(filename, sizeof(filename),
++                                          tpm_number, name);
++    }
++    if (rc == 0) {
+         /* open the file */
+         printf(" TPM_NVRAM_StoreData: Opening file %s\n", filename);
+         file = fopen(filename, "wb");                           /* closed @1 */
+@@ -339,14 +346,27 @@ TPM_RESULT TPM_NVRAM_StoreData(const unsigned char *data,
+    state_directory/tpm_number.name
+ */
+ 
+-static void TPM_NVRAM_GetFilenameForName(char *filename,        /* output: rooted filename */
+-					 uint32_t tpm_number,
+-                                         const char *name)      /* input: abstract name */
++static TPM_RESULT TPM_NVRAM_GetFilenameForName(char *filename,        /* output: rooted filename */
++					       size_t filename_len,
++					       uint32_t tpm_number,
++                                               const char *name)      /* input: abstract name */
+ {
++    int n;
++    TPM_RESULT rc = TPM_FAIL;
++
+     printf(" TPM_NVRAM_GetFilenameForName: For name %s\n", name);
+-    sprintf(filename, "%s/%02lx.%s", state_directory, (unsigned long)tpm_number, name);
+-    printf("  TPM_NVRAM_GetFilenameForName: File name %s\n", filename);
+-    return;
++    n = snprintf(filename, filename_len,
++                 "%s/%02lx.%s", state_directory, (unsigned long)tpm_number,
++                 name);
++    if (n < 0) {
++        printf(" TPM_NVRAM_GetFilenameForName: Error (fatal), snprintf failed\n");
++    } else if ((size_t)n >= filename_len) {
++        printf(" TPM_NVRAM_GetFilenameForName: Error (fatal), buffer too small\n");
++    } else {
++        printf("  TPM_NVRAM_GetFilenameForName: File name %s\n", filename);
++        rc = TPM_SUCCESS;
++    }
++    return rc;
+ }
+ 
+ /* TPM_NVRAM_DeleteName() deletes the 'name' from NVRAM
+@@ -380,7 +400,10 @@ TPM_RESULT TPM_NVRAM_DeleteName(uint32_t tpm_number,
+     
+     printf(" TPM_NVRAM_DeleteName: Name %s\n", name);
+     /* map name to the rooted filename */
+-    TPM_NVRAM_GetFilenameForName(filename, tpm_number, name);
++    if (rc == 0) {
++        rc = TPM_NVRAM_GetFilenameForName(filename, sizeof(filename),
++                                          tpm_number, name);
++    }
+     if (rc == 0) {
+         irc = remove(filename);
+         if ((irc != 0) &&               /* if the remove failed */
+-- 
+2.26.2
+

--- a/dev-libs/libtpms/files/libtpms-0.7.0-tpm12-Initialize-a-few-variables-for-x86-gcc-O3.patch
+++ b/dev-libs/libtpms/files/libtpms-0.7.0-tpm12-Initialize-a-few-variables-for-x86-gcc-O3.patch
@@ -1,0 +1,108 @@
+From 464083396ae1d242fb2a26c1ab6e39971e82f47e Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Fri, 17 Jan 2020 19:01:24 +0000
+Subject: [PATCH 3/3] tpm12: Initialize a few variables for x86 gcc -O3
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+gcc (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609
+
+The above gcc on x86 with -O3 reports the following false positives:
+
+ gcc -DHAVE_CONFIG_H -I. -I.. -include tpm_library_conf.h -I../include/libtpms -I../include/libtpms -fstack-protector-strong -DTPM_V12 -DTPM_PCCLIENT -DTPM_VOLATILE_LOAD -DTPM_ENABLE_ACTIVATE -DTPM_AES -DTPM_LIBTPMS_CALLBACKS -DTPM_NV_DISK -DTPM_POSIX -DTPM_NOMAINTENANCE_COMMANDS -O3 -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=1 -DUSE_OPENSSL_FUNCTIONS_EC=1 -DUSE_OPENSSL_FUNCTIONS_ECDSA=0 -DUSE_OPENSSL_FUNCTIONS_RSA=0 -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign -MT tpm12/libtpms_tpm12_la-tpm_nvram.lo -MD -MP -MF tpm12/.deps/libtpms_tpm12_la-tpm_nvram.Tpo -c tpm12/tpm_nvram.c -o tpm12/libtpms_tpm12_la-tpm_nvram.o
+tpm12/tpm_nvram.c: In function ‘TPM_Process_NVReadValue’:
+tpm12/tpm_nvram.c:1539:38: error: ‘isGPIO’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+      if ((returnCode == TPM_SUCCESS) && !isGPIO) {
+                                      ^
+tpm12/tpm_nvram.c: In function ‘TPM_Process_NVWriteValue’:
+tpm12/tpm_nvram.c:2323:6: error: ‘isGPIO’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+   if (!isGPIO) {
+      ^
+
+gcc -DHAVE_CONFIG_H -I. -I.. -include tpm_library_conf.h -I../include/libtpms -I../include/libtpms -fstack-protector-strong -DTPM_V12 -DTPM_PCCLIENT -DTPM_VOLATILE_LOAD -DTPM_ENABLE_ACTIVATE -DTPM_AES -DTPM_LIBTPMS_CALLBACKS -DTPM_NV_DISK -DTPM_POSIX -DTPM_NOMAINTENANCE_COMMANDS -O3 -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=1 -DUSE_OPENSSL_FUNCTIONS_EC=1 -DUSE_OPENSSL_FUNCTIONS_ECDSA=0 -DUSE_OPENSSL_FUNCTIONS_RSA=0 -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign -MT tpm12/libtpms_tpm12_la-tpm_process.lo -MD -MP -MF tpm12/.deps/libtpms_tpm12_la-tpm_process.Tpo -c tpm12/tpm_process.c -o tpm12/libtpms_tpm12_la-tpm_process.o
+tpm12/tpm_process.c: In function ‘TPM_Process_GetCapabilitySigned’:
+tpm12/tpm_process.c:5089:19: error: ‘transportEncrypt’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+      returnCode = TPM_ProcessAudit(tpm_state,
+                   ^
+tpm12/tpm_process.c: In function ‘TPM_Process_SetCapability’:
+tpm12/tpm_process.c:5309:19: error: ‘transportEncrypt’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+      returnCode = TPM_ProcessAudit(tpm_state,
+                   ^
+tpm12/tpm_process.c: At top level:
+
+gcc -DHAVE_CONFIG_H -I. -I.. -include tpm_library_conf.h -I../include/libtpms -I../include/libtpms -fstack-protector-strong -DTPM_V12 -DTPM_PCCLIENT -DTPM_VOLATILE_LOAD -DTPM_ENABLE_ACTIVATE -DTPM_AES -DTPM_LIBTPMS_CALLBACKS -DTPM_NV_DISK -DTPM_POSIX -DTPM_NOMAINTENANCE_COMMANDS -O3 -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=1 -DUSE_OPENSSL_FUNCTIONS_EC=1 -DUSE_OPENSSL_FUNCTIONS_ECDSA=0 -DUSE_OPENSSL_FUNCTIONS_RSA=0 -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign -MT tpm12/libtpms_tpm12_la-tpm_transport.lo -MD -MP -MF tpm12/.deps/libtpms_tpm12_la-tpm_transport.Tpo -c tpm12/tpm_transport.c -o tpm12/libtpms_tpm12_la-tpm_transport.o
+tpm12/tpm_transport.c: In function ‘TPM_Process_ReleaseTransportSigned’:
+tpm12/tpm_transport.c:2810:42: error: ‘t1TpmTransportInternal’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+  returnCode = TPM_TransportLogOut_Extend(t1TpmTransportInternal->transDigest,
+                                          ^
+
+This patch initializes the variables.
+
+Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
+---
+ src/tpm12/tpm_nvram.c     | 4 ++--
+ src/tpm12/tpm_process.c   | 4 ++--
+ src/tpm12/tpm_transport.c | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/tpm12/tpm_nvram.c b/src/tpm12/tpm_nvram.c
+index 1b9c005..620944e 100644
+--- a/src/tpm12/tpm_nvram.c
++++ b/src/tpm12/tpm_nvram.c
+@@ -1288,7 +1288,7 @@ TPM_RESULT TPM_Process_NVReadValue(tpm_state_t *tpm_state,
+     TPM_BOOL			ignore_auth = FALSE;
+     TPM_BOOL			dir = FALSE;
+     TPM_BOOL			physicalPresence;
+-    TPM_BOOL			isGPIO;
++    TPM_BOOL			isGPIO = FALSE;
+     BYTE 			*gpioData = NULL;
+     TPM_NV_DATA_SENSITIVE	*d1NvdataSensitive;
+     uint32_t			s1Last;
+@@ -2000,7 +2000,7 @@ TPM_RESULT TPM_Process_NVWriteValue(tpm_state_t *tpm_state,
+     TPM_NV_DATA_SENSITIVE	*d1NvdataSensitive;
+     uint32_t			s1Last;
+     TPM_BOOL			physicalPresence;
+-    TPM_BOOL			isGPIO;
++    TPM_BOOL			isGPIO = FALSE;
+     uint32_t			nv1 = tpm_state->tpm_permanent_data.noOwnerNVWrite;
+ 							/* temp for noOwnerNVWrite, initialize to
+ 							   silence compiler */
+diff --git a/src/tpm12/tpm_process.c b/src/tpm12/tpm_process.c
+index d6a3b8e..c433621 100644
+--- a/src/tpm12/tpm_process.c
++++ b/src/tpm12/tpm_process.c
+@@ -4844,7 +4844,7 @@ TPM_RESULT TPM_Process_GetCapabilitySigned(tpm_state_t *tpm_state,
+     unsigned char *	inParamEnd;		/* ending point of inParam's */
+     TPM_DIGEST		inParamDigest;
+     TPM_BOOL		auditStatus;		/* audit the ordinal */
+-    TPM_BOOL		transportEncrypt;	/* wrapped in encrypted transport session */
++    TPM_BOOL		transportEncrypt = FALSE;/* wrapped in encrypted transport session */
+     TPM_BOOL		authHandleValid = FALSE;
+     TPM_AUTH_SESSION_DATA *auth_session_data;	/* session data for authHandle */
+     TPM_SECRET		*hmacKey;
+@@ -5144,7 +5144,7 @@ TPM_RESULT TPM_Process_SetCapability(tpm_state_t *tpm_state,
+     unsigned char *	inParamEnd;		/* ending point of inParam's */
+     TPM_DIGEST		inParamDigest;
+     TPM_BOOL		auditStatus;		/* audit the ordinal */
+-    TPM_BOOL		transportEncrypt;	/* wrapped in encrypted transport session */
++    TPM_BOOL		transportEncrypt = FALSE;/* wrapped in encrypted transport session */
+     TPM_BOOL		authHandleValid = FALSE;
+     TPM_AUTH_SESSION_DATA *auth_session_data;	/* session data for authHandle */
+     TPM_SECRET		*hmacKey;
+diff --git a/src/tpm12/tpm_transport.c b/src/tpm12/tpm_transport.c
+index 2261670..7b9c520 100644
+--- a/src/tpm12/tpm_transport.c
++++ b/src/tpm12/tpm_transport.c
+@@ -2599,7 +2599,7 @@ TPM_RESULT TPM_Process_ReleaseTransportSigned(tpm_state_t *tpm_state,
+     TPM_BOOL			authHandleValid = FALSE;
+     TPM_BOOL			transHandleValid = FALSE;
+     TPM_AUTH_SESSION_DATA	*auth_session_data = NULL;	/* session data for authHandle */
+-    TPM_TRANSPORT_INTERNAL	*t1TpmTransportInternal;
++    TPM_TRANSPORT_INTERNAL	*t1TpmTransportInternal = NULL;
+     TPM_SECRET			*hmacKey;
+     TPM_KEY			*sigKey = NULL;		/* the key specified by keyHandle */
+     TPM_BOOL			parentPCRStatus;
+-- 
+2.26.2
+

--- a/dev-libs/libtpms/files/libtpms-0.7.0-tpm12-Initialize-some-variables-for-gcc.patch
+++ b/dev-libs/libtpms/files/libtpms-0.7.0-tpm12-Initialize-some-variables-for-gcc.patch
@@ -1,0 +1,74 @@
+From aab357515eda564500290a4b3f542d2b4609af4f Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Tue, 14 Jan 2020 18:05:06 -0500
+Subject: [PATCH] tpm12: Initialize some variables for gcc ppc64el compiler
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+gcc (Ubuntu 9.2.1-21ubuntu1) 9.2.1 20191130
+
+The gcc compiler on Ubuntu Focal reports several false positives for
+potentially uninitialized variables:
+
+tpm12/tpm_session.c: In function ‘TPM_Process_SaveContext’:
+tpm12/tpm_session.c:3229:19: error: ‘tpm_auth_session_data’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+ 3229 |      returnCode = TPM_AuthSessionData_Store(&r1ContextSensitive, tpm_auth_session_data);
+      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+tpm12/tpm_delegate.c: In function ‘TPM_Process_DelegateManage’:
+tpm12/tpm_delegate.c:1787:49: error: ‘familyRow’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+ 1787 |  if ((opCode != TPM_FAMILY_CREATE) && (familyRow->flags & TPM_DELEGATE_ADMIN_LOCK)) {
+      |                                        ~~~~~~~~~^~~~~~~
+tpm12/tpm_delegate.c: In function ‘TPM_Process_DelegateUpdateVerification’:
+tpm12/tpm_delegate.c:3575:48: error: ‘d1DelegateTableRow’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+ 3575 |      d1DelegateTableRow->pub.verificationCount = familyRow->verificationCount;
+      |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All of the variables are initialize under the same condition as they are
+accessed.
+
+Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
+---
+ src/tpm12/tpm_delegate.c | 4 ++--
+ src/tpm12/tpm_session.c  | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/tpm12/tpm_delegate.c b/src/tpm12/tpm_delegate.c
+index 51d12f3..37ebc02 100644
+--- a/src/tpm12/tpm_delegate.c
++++ b/src/tpm12/tpm_delegate.c
+@@ -1629,7 +1629,7 @@ TPM_RESULT TPM_Process_DelegateManage(tpm_state_t *tpm_state,
+     TPM_SECRET			*hmacKey;
+     TPM_SECRET			savedAuth;		/* saved copy for response */
+     TPM_DELEGATE_PUBLIC		*delegatePublic;	/* from DSAP session */
+-    TPM_FAMILY_TABLE_ENTRY	*familyRow;		/* family table row containing familyID */
++    TPM_FAMILY_TABLE_ENTRY	*familyRow = NULL;	/* family table row containing familyID */
+     uint32_t			nv1 = tpm_state->tpm_permanent_data.noOwnerNVWrite;
+ 							/* temp for noOwnerNVWrite, initialize to
+ 							   silence compiler */
+@@ -3360,7 +3360,7 @@ TPM_RESULT TPM_Process_DelegateUpdateVerification(tpm_state_t *tpm_state,
+     TPM_DELEGATE_INDEX		d1DelegateIndex;
+     TPM_DELEGATE_OWNER_BLOB	d1DelegateOwnerBlob;
+     TPM_DELEGATE_KEY_BLOB	d1DelegateKeyBlob;
+-    TPM_DELEGATE_TABLE_ROW	*d1DelegateTableRow;
++    TPM_DELEGATE_TABLE_ROW	*d1DelegateTableRow = NULL;
+     TPM_FAMILY_ID		familyID = 0;
+     TPM_FAMILY_TABLE_ENTRY	*familyRow;		/* family table row containing familyID */
+     TPM_DELEGATE_PUBLIC		*delegatePublic;	/* from DSAP session */
+diff --git a/src/tpm12/tpm_session.c b/src/tpm12/tpm_session.c
+index 5e7b708..15b977f 100644
+--- a/src/tpm12/tpm_session.c
++++ b/src/tpm12/tpm_session.c
+@@ -3044,7 +3044,7 @@ TPM_RESULT TPM_Process_SaveContext(tpm_state_t *tpm_state,
+     TPM_STORE_BUFFER		b1_sbuffer;		/* serialization of b1 */
+     TPM_STCLEAR_DATA		*v1StClearData = NULL;
+     TPM_KEY_HANDLE_ENTRY	*tpm_key_handle_entry;	/* key table entry for the handle */
+-    TPM_AUTH_SESSION_DATA	*tpm_auth_session_data; /* session table entry for the handle */
++    TPM_AUTH_SESSION_DATA	*tpm_auth_session_data = NULL; /* session table entry for the handle */
+     TPM_TRANSPORT_INTERNAL	*tpm_transport_internal; /* transport table entry for the handle */
+     TPM_DAA_SESSION_DATA	*tpm_daa_session_data;	/* daa session table entry for the handle */
+     TPM_NONCE			*n1ContextNonce = NULL;
+-- 
+2.26.2
+

--- a/dev-libs/libtpms/files/libtpms-0.7.0-tpm2-Fix-a-gcc-10.1.0-complaint.patch
+++ b/dev-libs/libtpms/files/libtpms-0.7.0-tpm2-Fix-a-gcc-10.1.0-complaint.patch
@@ -1,0 +1,53 @@
+From f3f78c72a5b6ef42119188ac5af73bb3a0a8bbba Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Tue, 12 May 2020 13:41:53 -0400
+Subject: [PATCH] tpm2: Fix a gcc 10.1.0 complaint
+
+This PR addresses issue 133: https://github.com/stefanberger/libtpms/issues/133
+
+bin/sh ../libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc \
+  -DHAVE_CONFIG_H -I. -I..    -include tpm_library_conf.h \
+  -I../include/libtpms -I../include/libtpms -fstack-protector-strong \
+  -D_POSIX_ -DTPM_POSIX -DTPM_LIBTPMS_CALLBACKS -I ./tpm2 \
+  -I ./tpm2/crypto -I ./tpm2/crypto/openssl -g -O2 \
+  -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=1 -DUSE_OPENSSL_FUNCTIONS_EC=1 \
+  -DUSE_OPENSSL_FUNCTIONS_ECDSA=1 -DUSE_OPENSSL_FUNCTIONS_RSA=1 \
+  -Wall -Werror -Wreturn-type -Wsign-compare -Wno-self-assign \
+  -c -o tpm2/libtpms_tpm2_la-NVDynamic.lo `test -f 'tpm2/NVDynamic.c' \
+  || echo './'`tpm2/NVDynamic.c
+libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. \
+  -I.. -include tpm_library_conf.h -I../include/libtpms \
+  -I../include/libtpms -fstack-protector-strong -D_POSIX_ -DTPM_POSIX \
+  -DTPM_LIBTPMS_CALLBACKS -I ./tpm2 -I ./tpm2/crypto \
+  -I ./tpm2/crypto/openssl -g -O2 -DUSE_OPENSSL_FUNCTIONS_SYMMETRIC=1 \
+  -DUSE_OPENSSL_FUNCTIONS_EC=1 -DUSE_OPENSSL_FUNCTIONS_ECDSA=1 \
+  -DUSE_OPENSSL_FUNCTIONS_RSA=1 -Wall -Werror -Wreturn-type -Wsign-compare \
+  -Wno-self-assign -c tpm2/NVDynamic.c  -fPIC -DPIC \
+  -o tpm2/.libs/libtpms_tpm2_la-NVDynamic.o
+tpm2/NVDynamic.c: In function ?NvNextByType?:
+tpm2/NVDynamic.c:126:10: error: ?nvHandle? may be used uninitialized in this function [-Werror=maybe-uninitialized]
+  126 |  *handle = nvHandle;
+      |  ~~~~~~~~^~~~~~~~~~
+tpm2/NVDynamic.c: At top level:
+
+Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
+---
+ src/tpm2/NVDynamic.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tpm2/NVDynamic.c b/src/tpm2/NVDynamic.c
+index 32f46bb..4381658 100644
+--- a/src/tpm2/NVDynamic.c
++++ b/src/tpm2/NVDynamic.c
+@@ -114,7 +114,7 @@ NvNextByType(
+ 	     )
+ {
+     NV_REF           addr;
+-    TPM_HANDLE       nvHandle;
++    TPM_HANDLE       nvHandle = 0; // libtpms changed: gcc 10.1.0 complaint
+     while((addr = NvNext(iter, &nvHandle)) != 0)
+ 	{
+ 	    // addr: the address of the location containing the handle of the value
+-- 
+2.26.2
+

--- a/dev-libs/libtpms/libtpms-0.7.0-r1.ebuild
+++ b/dev-libs/libtpms/libtpms-0.7.0-r1.ebuild
@@ -17,6 +17,13 @@ DEPEND=" !libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )"
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${P}-tpm12-Initialize-some-variables-for-gcc.patch"
+	"${FILESDIR}/${P}-tpm12-Fix-potential-buffer-overflow-in-filename-creation.patch"
+	"${FILESDIR}/${P}-tpm12-Initialize-a-few-variables-for-x86-gcc-O3.patch"
+	"${FILESDIR}/${P}-tpm2-Fix-a-gcc-10.1.0-complaint.patch"
+	)
+
 src_prepare() {
 	default
 	eautoreconf


### PR DESCRIPTION
Cherry-picked 3 patches from upstream and spun one of the my own to fix same uninitialized variable and format string errors. 

Closes: https://bugs.gentoo.org/722056
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Salah Coronya <salah.coronya@gmail.com>