### PR TITLE
dev-libs/json-c: fix security vulnerabilities

### DIFF
--- a/dev-libs/json-c/files/json-c-0.14_security-fix.patch
+++ b/dev-libs/json-c/files/json-c-0.14_security-fix.patch
@@ -1,0 +1,155 @@
+From 099016b7e8d70a6d5dd814e788bba08d33d48426 Mon Sep 17 00:00:00 2001
+From: Tobias Stoeckmann <tobias@stoeckmann.org>
+Date: Mon, 4 May 2020 19:41:16 +0200
+Subject: [PATCH 1/3] Protect array_list_del_idx against size_t overflow.
+
+If the assignment of stop overflows due to idx and count being
+larger than SIZE_T_MAX in sum, out of boundary access could happen.
+
+It takes invalid usage of this function for this to happen, but
+I decided to add this check so array_list_del_idx is as safe against
+bad usage as the other arraylist functions.
+---
+ arraylist.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arraylist.c b/arraylist.c
+index 12ad8af6d3..e5524aca75 100644
+--- a/arraylist.c
++++ b/arraylist.c
+@@ -136,6 +136,9 @@ int array_list_del_idx(struct array_list *arr, size_t idx, size_t count)
+ {
+ 	size_t i, stop;
+ 
++	/* Avoid overflow in calculation with large indices. */
++	if (idx > SIZE_T_MAX - count)
++		return -1;
+ 	stop = idx + count;
+ 	if (idx >= arr->length || stop > arr->length)
+ 		return -1;
+
+From 77d935b7ae7871a1940cd827e850e6063044ec45 Mon Sep 17 00:00:00 2001
+From: Tobias Stoeckmann <tobias@stoeckmann.org>
+Date: Mon, 4 May 2020 19:46:45 +0200
+Subject: [PATCH 2/3] Prevent division by zero in linkhash.
+
+If a linkhash with a size of zero is created, then modulo operations
+are prone to division by zero operations.
+
+Purely protective measure against bad usage.
+---
+ linkhash.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/linkhash.c b/linkhash.c
+index 7ea58c0abf..f05cc38030 100644
+--- a/linkhash.c
++++ b/linkhash.c
+@@ -12,6 +12,7 @@
+ 
+ #include "config.h"
+ 
++#include <assert.h>
+ #include <limits.h>
+ #include <stdarg.h>
+ #include <stddef.h>
+@@ -499,6 +500,8 @@ struct lh_table *lh_table_new(int size, lh_entry_free_fn *free_fn, lh_hash_fn *h
+ 	int i;
+ 	struct lh_table *t;
+ 
++	/* Allocate space for elements to avoid divisions by zero. */
++	assert(size > 0);
+ 	t = (struct lh_table *)calloc(1, sizeof(struct lh_table));
+ 	if (!t)
+ 		return NULL;
+
+From d07b91014986900a3a75f306d302e13e005e9d67 Mon Sep 17 00:00:00 2001
+From: Tobias Stoeckmann <tobias@stoeckmann.org>
+Date: Mon, 4 May 2020 19:47:25 +0200
+Subject: [PATCH 3/3] Fix integer overflows.
+
+The data structures linkhash and printbuf are limited to 2 GB in size
+due to a signed integer being used to track their current size.
+
+If too much data is added, then size variable can overflow, which is
+an undefined behaviour in C programming language.
+
+Assuming that a signed int overflow just leads to a negative value,
+like it happens on many sytems (Linux i686/amd64 with gcc), then
+printbuf is vulnerable to an out of boundary write on 64 bit systems.
+---
+ linkhash.c |  7 +++++--
+ printbuf.c | 19 ++++++++++++++++---
+ 2 files changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/linkhash.c b/linkhash.c
+index f05cc38030..51e90b13a2 100644
+--- a/linkhash.c
++++ b/linkhash.c
+@@ -580,9 +580,12 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
+ {
+ 	unsigned long n;
+ 
+-	if (t->count >= t->size * LH_LOAD_FACTOR)
+-		if (lh_table_resize(t, t->size * 2) != 0)
++	if (t->count >= t->size * LH_LOAD_FACTOR) {
++		/* Avoid signed integer overflow with large tables. */
++		int new_size = INT_MAX / 2 < t->size ? t->size * 2 : INT_MAX;
++		if (t->size == INT_MAX || lh_table_resize(t, new_size) != 0)
+ 			return -1;
++	}
+ 
+ 	n = h % t->size;
+ 
+diff --git a/printbuf.c b/printbuf.c
+index 976c12dde5..00822fac4f 100644
+--- a/printbuf.c
++++ b/printbuf.c
+@@ -15,6 +15,7 @@
+ 
+ #include "config.h"
+ 
++#include <limits.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -65,10 +66,16 @@ static int printbuf_extend(struct printbuf *p, int min_size)
+ 
+ 	if (p->size >= min_size)
+ 		return 0;
+-
+-	new_size = p->size * 2;
+-	if (new_size < min_size + 8)
++	/* Prevent signed integer overflows with large buffers. */
++	if (min_size > INT_MAX - 8)
++		return -1;
++	if (p->size > INT_MAX / 2)
+ 		new_size = min_size + 8;
++	else {
++		new_size = p->size * 2;
++		if (new_size < min_size + 8)
++			new_size = min_size + 8;
++	}
+ #ifdef PRINTBUF_DEBUG
+ 	MC_DEBUG("printbuf_memappend: realloc "
+ 	         "bpos=%d min_size=%d old_size=%d new_size=%d\n",
+@@ -83,6 +90,9 @@ static int printbuf_extend(struct printbuf *p, int min_size)
+ 
+ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
+ {
++	/* Prevent signed integer overflows with large buffers. */
++	if (size > INT_MAX - p->bpos - 1)
++		return -1;
+ 	if (p->size <= p->bpos + size + 1)
+ 	{
+ 		if (printbuf_extend(p, p->bpos + size + 1) < 0)
+@@ -100,6 +110,9 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
+ 
+ 	if (offset == -1)
+ 		offset = pb->bpos;
++	/* Prevent signed integer overflows with large buffers. */
++	if (len > INT_MAX - offset)
++		return -1;
+ 	size_needed = offset + len;
+ 	if (pb->size < size_needed)
+ 	{

--- a/dev-libs/json-c/json-c-0.14-r2.ebuild
+++ b/dev-libs/json-c/json-c-0.14-r2.ebuild
@@ -17,6 +17,7 @@ IUSE="doc static-libs threads"
 
 PATCHES=(
 	"${FILESDIR}/${P}_cmake-static-libs.patch"
+	"${FILESDIR}/${P}_security-fix.patch"
 )
 
 MULTILIB_WRAPPED_HEADERS=(


### PR DESCRIPTION
Prevent integer overflow and out of boundary write on malicious input.

Closes: https://bugs.gentoo.org/722150
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>
Signed-off-by: Luka Perkov <luka.perkov@sartura.hr>