### PR TITLE
kde-plasma/kinfocenter: fix missing change from gles2 to gles2-only

### DIFF
--- a/kde-plasma/kinfocenter/kinfocenter-5.17.5-r1.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.17.5-r1.ebuild
@@ -70,7 +70,7 @@ src_configure() {
 	)
 
 	if has_version "dev-qt/qtgui[gles2-only]"; then
-		mycmakeargs+=( $(cmake_use_find_package gles2 OpenGLES) )
+		mycmakeargs+=( $(cmake_use_find_package gles2-only OpenGLES) )
 	else
 		mycmakeargs+=( $(cmake_use_find_package opengl OpenGL) )
 	fi

--- a/kde-plasma/kinfocenter/kinfocenter-5.18.5.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.18.5.ebuild
@@ -73,7 +73,7 @@ src_configure() {
 	)
 
 	if has_version "dev-qt/qtgui[gles2-only]"; then
-		mycmakeargs+=( $(cmake_use_find_package gles2 OpenGLES) )
+		mycmakeargs+=( $(cmake_use_find_package gles2-only OpenGLES) )
 	else
 		mycmakeargs+=( $(cmake_use_find_package opengl OpenGL) )
 	fi


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Mias van Klei <miasvanklei@outlook.com>