### PR TITLE
app-crypt/tpm2-tss: Fix sandbox violation for systemd users and REQUIRED_USE

### DIFF
--- a/app-crypt/tpm2-tss/files/tpm2-tss-2.4.0-Dont-run-systemd-sysusers-in-Makefile.patch
+++ b/app-crypt/tpm2-tss/files/tpm2-tss-2.4.0-Dont-run-systemd-sysusers-in-Makefile.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile.am b/Makefile.am
+index c543a287..58187f7e 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -558,10 +558,6 @@ uninstall-local:
+ 	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
+ endif
+ 
+-# Create tss user and FAPI directories directly after installation (vs. after a reboot)
+-install-exec-hook:
+-	systemd-sysusers && systemd-tmpfiles --create || true
+-
+ uninstall-hook:
+ 	cd $(DESTDIR)$(man3dir) && \
+ 		[ -L Tss2_TctiLdr_Initialize_Ex.3 ] && \

--- a/app-crypt/tpm2-tss/tpm2-tss-2.4.0.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-2.4.0.ebuild
@@ -34,7 +34,8 @@ BDEPEND="virtual/pkgconfig
 
 PATCHES=(
 	"${FILESDIR}/${PN}-2.4.0-fix-tmpfiles-path.patch"
-)
+	"${FILESDIR}/${PN}-2.4.0-Dont-run-systemd-sysusers-in-Makefile.patch"
+	)
 
 pkg_setup() {
 	local CONFIG_CHECK=" \
@@ -57,7 +58,7 @@ src_configure() {
 		--with-runstatedir=/run \
 		--with-udevrulesdir="$(get_udevdir)/rules.d" \
 		--with-udevrulesprefix=60- \
-		--with-sysusersdir="/usr/lib/sysusers.d"
+		--with-sysusersdir="/usr/lib/sysusers.d" \
 		--with-tmpfilesdir="/usr/lib/tmpfiles.d"
 }
 

--- a/app-crypt/tpm2-tss/tpm2-tss-2.4.0.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-2.4.0.ebuild
@@ -17,7 +17,7 @@ IUSE="doc +fapi gcrypt +openssl static-libs test"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="^^ ( gcrypt openssl )
-		fapi ( !gcrypt )"
+		fapi? ( openssl !gcrypt )"
 
 RDEPEND="acct-group/tss
 	 acct-user/tss


### PR DESCRIPTION
This fixes a sandbox violation for systemd users, and while at it, also fixes the tmpfiles.d file being installed in the wrong directory due to a missing backslash. 

Closes: https://bugs.gentoo.org/722864
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Salah Coronya <salah.coronya@gmail.com>