### PR TITLE
app-cdr/cdw: fix AR direct call

### DIFF
--- a/app-cdr/cdw/cdw-0.8.1-r1.ebuild
+++ b/app-cdr/cdw/cdw-0.8.1-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit toolchain-funcs
+inherit autotools toolchain-funcs
 
 DESCRIPTION="An ncurses based console frontend for cdrtools and dvd+rw-tools"
 HOMEPAGE="http://cdw.sourceforge.net"
@@ -22,7 +22,14 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
+PATCHES=( "${FILESDIR}/${PN}-0.8.1-fix-ar-call.patch" )
+
 DOCS=( AUTHORS ChangeLog NEWS README THANKS cdw.conf )
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	econf LIBS="$( $(tc-getPKG_CONFIG) --libs ncurses )"

--- a/app-cdr/cdw/cdw-9999.ebuild
+++ b/app-cdr/cdw/cdw-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,6 @@ HOMEPAGE="http://cdw.sourceforge.net"
 
 LICENSE="GPL-2+"
 SLOT="0"
-DOCS=( AUTHORS ChangeLog NEWS README THANKS cdw.conf )
 
 RDEPEND="
 	app-cdr/dvd+rw-tools
@@ -26,6 +25,10 @@ DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 S=${WORKDIR}/${ECVS_MODULE}
+
+PATCHES=( "${FILESDIR}/${PN}-0.8.1-fix-ar-call.patch" )
+
+DOCS=( AUTHORS ChangeLog NEWS README THANKS cdw.conf )
 
 src_prepare() {
 	default

--- a/app-cdr/cdw/files/cdw-0.8.1-fix-ar-call.patch
+++ b/app-cdr/cdw/files/cdw-0.8.1-fix-ar-call.patch
@@ -1,0 +1,26 @@
+diff --git a/configure.ac b/configure.ac
+index 76627c7..527e2cb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -119,7 +119,7 @@ AC_TYPE_UINT16_T
+ AC_TYPE_UINT32_T
+ AC_TYPE_UINT8_T
+ AC_CHECK_TYPES([ptrdiff_t])
+-
++AC_CHECK_TOOL(AR, ar, false)
+ 
+ 
+ 
+diff --git a/src/user_interface/Makefile.in b/src/user_interface/Makefile.in
+index 5d5f1fc..4d8214b 100644
+--- a/src/user_interface/Makefile.in
++++ b/src/user_interface/Makefile.in
+@@ -88,7 +88,7 @@ CONFIG_HEADER = $(top_builddir)/config_cdw.h
+ CONFIG_CLEAN_FILES =
+ CONFIG_CLEAN_VPATH_FILES =
+ LIBRARIES = $(noinst_LIBRARIES)
+-AR = ar
++AR = @AR@
+ ARFLAGS = cru
+ AM_V_AR = $(am__v_AR_@AM_V@)
+ am__v_AR_ = $(am__v_AR_@AM_DEFAULT_V@)


### PR DESCRIPTION
Added fix for direct calling of `ar` instead of selecting the system set.
Tested by setting `AR=/bin/false` and trying to build (passed before fix, failed after fix - as expected).

Fixed latest unstable version and live version.

Closes: https://bugs.gentoo.org/721928
Package-Manager: Portage-2.3.99, Repoman-2.3.22