### PR TITLE
dev-python/rarfile: EAPI=7, more Python compat

### DIFF
--- a/dev-python/rarfile/rarfile-3.0-r1.ebuild
+++ b/dev-python/rarfile/rarfile-3.0-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+inherit distutils-r1
+
+DESCRIPTION="Module for RAR archive reading"
+HOMEPAGE="https://github.com/markokr/rarfile"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="ISC"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+compressed"
+
+RDEPEND="compressed? ( || ( app-arch/unrar app-arch/rar ) )"
+
+distutils_enable_tests nose


### PR DESCRIPTION
- Bumps to EAPI=7
- Enables tests
- Adds Python 3.7, 3.8 compatibility

Needed for subliminal bump: https://github.com/gentoo/gentoo/pull/15755