### PR TITLE
app-text/xiphos-4.1.0-r2: Fixed version of net-libs/biblesync DEPEND

### DIFF
--- a/app-text/xiphos/xiphos-4.1.0-r2.ebuild
+++ b/app-text/xiphos/xiphos-4.1.0-r2.ebuild
@@ -34,7 +34,7 @@ DEPEND="${RDEPEND}
 	app-text/rarian
 	dev-util/glib-utils
 	dev-util/intltool
-	>=net-libs/biblesync-1.1.2-r1[-static]
+	>=net-libs/biblesync-1.2[-static]
 	virtual/pkgconfig
 	sys-devel/gettext
 	app-text/gnome-doc-utils


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/723408
Signed-off-by: Jaak Ristioja <jaak@ristioja.ee>