### PR TITLE
dev-python/alabaster: remove python2

### DIFF
--- a/dev-python/alabaster/alabaster-0.7.12-r1.ebuild
+++ b/dev-python/alabaster/alabaster-0.7.12-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
+inherit distutils-r1
+
+DESCRIPTION="A configurable sidebar-enabled Sphinx theme"
+HOMEPAGE="https://github.com/bitprophet/alabaster"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-solaris"
+SLOT="0"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>