### PR TITLE
dev-python/termcolor: python2 removed

### DIFF
--- a/dev-python/termcolor/metadata.xml
+++ b/dev-python/termcolor/metadata.xml
@@ -9,10 +9,11 @@
     <email>python@gentoo.org</email>
     <name>Python</name>
   </maintainer>
-  <longdescription lang="en">
-    ANSII Color formatting for output in terminal.
-  </longdescription>
   <upstream>
     <remote-id type="pypi">termcolor</remote-id>
+    <maintainer>
+      <name>Konstantin Lepa</name>
+      <email>konstantin.lepa@gmail.com</email>
+    </maintainer>
   </upstream>
 </pkgmetadata>

--- a/dev-python/termcolor/termcolor-1.1.0-r3.ebuild
+++ b/dev-python/termcolor/termcolor-1.1.0-r3.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+DISTUTILS_USE_SETUPTOOLS=no
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="ANSII Color formatting for output in terminal"
+HOMEPAGE="https://pypi.org/project/termcolor"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+# no tests...
+RESTRICT="test"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>