### PR TITLE
dev-python/snowballstemmer: python2 removed

### DIFF
--- a/dev-python/snowballstemmer/snowballstemmer-2.0.0-r1.ebuild
+++ b/dev-python/snowballstemmer/snowballstemmer-2.0.0-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+inherit distutils-r1
+
+DESCRIPTION="Stemmer algorithms generated from Snowball algorithms"
+HOMEPAGE="
+	https://snowballstem.org
+	https://github.com/snowballstem/snowball
+	https://pypi.org/project/snowballstemmer
+"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-solaris"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>