### PR TITLE
dev-python/itsdangerous: python2 removed

### DIFF
--- a/dev-python/itsdangerous/itsdangerous-1.1.0-r1.ebuild
+++ b/dev-python/itsdangerous/itsdangerous-1.1.0-r1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="Various helpers to pass trusted data to untrusted environments and back"
+HOMEPAGE="
+	https://pythonhosted.org/itsdangerous
+	https://pypi.org/project/itsdangerous
+"
+SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+BDEPEND="test? ( dev-python/freezegun[${PYTHON_USEDEP}] )"
+
+distutils_enable_tests pytest


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>