### PR TITLE
dev-python/logbook: add missing test dependency

### DIFF
--- a/dev-python/logbook/logbook-1.5.3.ebuild
+++ b/dev-python/logbook/logbook-1.5.3.ebuild
@@ -23,6 +23,7 @@ BDEPEND="
 		app-arch/brotli[${PYTHON_USEDEP},python]
 		dev-python/execnet[${PYTHON_USEDEP}]
 		dev-python/jinja[${PYTHON_USEDEP}]
+		dev-python/pip[${PYTHON_USEDEP}]
 		dev-python/pyzmq[${PYTHON_USEDEP}]
 		dev-python/sqlalchemy[${PYTHON_USEDEP}]
 	)"


### PR DESCRIPTION
This addresses https://bugs.gentoo.org/722714 . I was able to reproduce the error in a clean environment and adding pip as a test dependency fixes the issue.