### PR TITLE
dev-qt/qtdeclarative: QQuickItemView: Fix max(X/Y)Extent()

### DIFF
--- a/dev-qt/qtdeclarative/files/qtdeclarative-5.14.2-QQuickItemView-fix-maxXY-extent.patch
+++ b/dev-qt/qtdeclarative/files/qtdeclarative-5.14.2-QQuickItemView-fix-maxXY-extent.patch
@@ -1,0 +1,42 @@
+From cc5387ad22ca503d167fd66e2429107d45b937af Mon Sep 17 00:00:00 2001
+From: David Redondo <qt@david-redondo.de>
+Date: Wed, 13 May 2020 11:04:23 +0200
+Subject: [PATCH] QQuickItemView: Fix max(X/Y)Extent()
+
+QQuickFlickable maxXExtent() and maxYExtent() return the amount of space
+that is not shown when inside a ScrollView. QQuickItemView however just
+returned width() if vertical and height() if horizontal. In these cases
+just defer to the QQuickFlickable base implementation like minXExtent()
+and minYExtent() already do.
+
+Fixes: QTBUG-83890
+Pick-to: 5.15
+Change-Id: I7f4060c2f46ae07611bedceca0d322c5f7f6affb
+---
+ src/quick/items/qquickitemview.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/quick/items/qquickitemview.cpp b/src/quick/items/qquickitemview.cpp
+index 7fb392233e4..ab130ac6857 100644
+--- a/src/quick/items/qquickitemview.cpp
++++ b/src/quick/items/qquickitemview.cpp
+@@ -1393,7 +1393,7 @@ qreal QQuickItemView::maxYExtent() const
+ {
+     Q_D(const QQuickItemView);
+     if (d->layoutOrientation() == Qt::Horizontal)
+-        return height();
++        return QQuickFlickable::maxYExtent();
+ 
+     if (d->vData.maxExtentDirty) {
+         d->maxExtent = d->maxExtentForAxis(d->vData, false);
+@@ -1421,7 +1421,7 @@ qreal QQuickItemView::maxXExtent() const
+ {
+     Q_D(const QQuickItemView);
+     if (d->layoutOrientation() == Qt::Vertical)
+-        return width();
++        return QQuickFlickable::maxXExtent();
+ 
+     if (d->hData.maxExtentDirty) {
+         d->maxExtent = d->maxExtentForAxis(d->hData, true);
+-- 
+2.16.3

--- a/dev-qt/qtdeclarative/qtdeclarative-5.14.2-r1.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.14.2-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 2009-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{6,7,8} )
+inherit python-any-r1 qt5-build
+
+DESCRIPTION="The QML and Quick modules for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+fi
+
+IUSE="gles2-only +jit localstorage vulkan +widgets"
+
+BDEPEND="${PYTHON_DEPS}"
+# qtgui[gles2-only=] is needed because of bug 504322
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[gles2-only=,vulkan=]
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qttest-${PV}
+	localstorage? ( ~dev-qt/qtsql-${PV} )
+	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2-only=] )
+"
+RDEPEND="${DEPEND}
+	!<dev-qt/qtquickcontrols-5.7:5
+"
+
+PATCHES=("${FILESDIR}/${P}-QQuickItemView-fix-maxXY-extent.patch" ) # QTBUG-83890
+
+src_prepare() {
+	use jit || PATCHES+=("${FILESDIR}/${PN}-5.4.2-disable-jit.patch")
+
+	qt_use_disable_mod localstorage sql \
+		src/imports/imports.pro
+
+	qt_use_disable_mod widgets widgets \
+		src/src.pro \
+		src/qmltest/qmltest.pro \
+		tests/auto/auto.pro \
+		tools/tools.pro \
+		tools/qmlscene/qmlscene.pro \
+		tools/qml/qml.pro
+
+	qt5-build_src_prepare
+}
+
+src_configure() {
+	local myqmakeargs=(
+		--
+		-qml-debug
+	)
+	qt5-build_src_configure
+}


### PR DESCRIPTION
Works as advertised, gets rid of superfluous scrollbars.

KDE-Bug: https://bugs.kde.org/show_bug.cgi?id=419514
QTBUG: https://bugreports.qt.io/browse/QTBUG-83890
Bug: https://bugs.gentoo.org/716992
