### PR TITLE
app-text/libnumbertext: no static libs

### DIFF
--- a/app-text/libnumbertext/libnumbertext-1.0.5-r1.ebuild
+++ b/app-text/libnumbertext/libnumbertext-1.0.5-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+DESCRIPTION="Number to number name and money text conversion libraries"
+HOMEPAGE="https://github.com/Numbertext/libnumbertext"
+SRC_URI="https://github.com/Numbertext/${PN}/releases/download/${PV}/${P}.tar.xz"
+
+LICENSE="LGPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+IUSE=""
+
+src_configure() {
+	local myconf=(
+		--disable-static
+		--disable-werror
+	)
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/723218
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>