### PR TITLE
dev-libs/libsigsegv: no static libs

### DIFF
--- a/dev-libs/libsigsegv/libsigsegv-2.12-r2.ebuild
+++ b/dev-libs/libsigsegv/libsigsegv-2.12-r2.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit autotools
+
+DESCRIPTION="Library for handling page faults in user mode"
+HOMEPAGE="https://www.gnu.org/software/libsigsegv"
+SRC_URI="mirror://gnu/libsigsegv/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+IUSE=""
+
+PATCHES=(
+	# Bug #363503
+	"${FILESDIR}/${P}-skip-stackoverflow-tests.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=(
+		--disable-static
+		--enable-shared
+	)
+	econf "${myconf[@]}"
+}
+
+src_test() {
+	emake check
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	dodoc AUTHORS ChangeLog* NEWS PORTING README
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/723202
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>