### PR TITLE
dev-perl/Ace: Add CC/AR/LD toolchain love

### DIFF
--- a/dev-perl/Ace/Ace-1.920.0-r5.ebuild
+++ b/dev-perl/Ace/Ace-1.920.0-r5.ebuild
@@ -1,0 +1,139 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DIST_NAME=AcePerl
+DIST_AUTHOR=LDS
+DIST_VERSION=1.92
+DIST_EXAMPLES=("examples/*")
+inherit perl-module toolchain-funcs
+
+DESCRIPTION="Object-Oriented Access to ACEDB Databases"
+
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test ) mirror"
+# License note: Indemnification and Attribution-if-Used bug #718936
+RDEPEND="
+	virtual/perl-Digest-MD5
+	dev-perl/Cache-Cache
+	dev-perl/GD
+"
+DEPEND="
+	elibc_glibc? (  net-libs/libtirpc net-libs/rpcsvc-proto )
+	elibc_musl? (   net-libs/libtirpc net-libs/rpcsvc-proto )
+	elibc_uclibc? ( net-libs/libtirpc net-libs/rpcsvc-proto )
+"
+BDEPEND="
+	${RDEPEND}
+	${DEPEND}
+"
+mydoc="DISCLAIMER.txt"
+src_prepare() {
+	eapply "${FILESDIR}/${PN}-1.92-rpcxs.patch"
+	eapply "${FILESDIR}/${PN}-1.92-gcc-nonvoid.patch"
+	eapply "${FILESDIR}/${PN}-1.92-toolchain.patch"
+	cp "${FILESDIR}/${PN}-1.92-DARWIN_DEF" "${S}/acelib/wmake/DARWIN_DEF" || die "can't copy DARWIN_DEF"
+	if use elibc_glibc || use elibc_musl || use elibc_uclibc ; then
+		export LIBS="-ltirpc"
+	fi
+	export MAKEOPTS="-j1"
+	perl-module_src_prepare
+}
+src_compile() {
+	mymake=(
+		"AR=$(tc-getAR)"
+		"TARGET_CC=$(tc-getCC)"
+		"TARGET_LD=$(tc-getLD)"
+		"RANLIB=$(tc-getRANLIB)"
+	)
+	if use elibc_glibc || use elibc_musl || use elibc_uclibc ; then
+		mymake+=( "LIBS=-ltirpc -lm" )
+		mymake+=( "USEROPTS=-I/usr/include/tirpc -fPIC" )
+	fi
+	perl-module_src_compile
+}
+
+src_test() {
+	local MODULES=(
+		"Ace ${DIST_VERSION}"
+		"Ace::Freesubs 1.00"
+		"Ace::Graphics::Fk" # NO VERSION
+		"Ace::Graphics::Glyph"
+		"Ace::Graphics::Glyph::anchored_arrow"
+		"Ace::Graphics::Glyph::arrow"
+		"Ace::Graphics::Glyph::box"
+		"Ace::Graphics::Glyph::crossbox"
+		"Ace::Graphics::Glyph::dot"
+		"Ace::Graphics::Glyph::ex"
+		"Ace::Graphics::Glyph::graded_segments"
+		"Ace::Graphics::Glyph::group"
+		"Ace::Graphics::Glyph::line"
+		"Ace::Graphics::Glyph::primers"
+		"Ace::Graphics::Glyph::segments"
+		"Ace::Graphics::Glyph::span"
+		"Ace::Graphics::Glyph::toomany"
+		"Ace::Graphics::Glyph::transcript"
+		"Ace::Graphics::Glyph::triangle"
+		"Ace::Graphics::GlyphFactory"
+		"Ace::Graphics::Panel"
+		"Ace::Graphics::Track"
+		"Ace::Iterator 1.51"
+		"Ace::Local 1.05"
+		"Ace::Model 1.51"
+		"Ace::Object 1.66"
+		"Ace::Object::Wormbase"
+		"Ace::RPC 1.00"
+		"Ace::Sequence 1.51"
+		"Ace::Sequence::Feature"
+		"Ace::Sequence::FeatureList"
+		"Ace::Sequence::GappedAlignment 1.20"
+		"Ace::Sequence::Gene"
+		"Ace::Sequence::Homol"
+		"Ace::Sequence::Multi"
+		"Ace::Sequence::Transcript"
+		"Ace::SocketServer 1.01"
+		"GFF::Filehandle"
+# Need Ace::Browser
+# 		"Ace::Browser::AceSubs ${DIST_VERSION}"
+#		"Ace::Browser::GeneSubs ${DIST_VERSION}"
+#		"Ace::Browser::SearchSubs ${DIST_VERSION}"
+#		"Ace::Browser::SiteDefs ${DIST_VERSION}"
+#		"Ace::Browser::TreeSubs ${DIST_VERSION}"
+	)
+	local failed=()
+	for dep in "${MODULES[@]}"; do
+		ebegin "Compile testing ${dep}"
+			perl -Mblib="${S}" -M"${dep} ()" -e1
+		eend $? || failed+=( "$dep" )
+	done
+	if [[ ${failed[@]} ]]; then
+		echo
+		eerror "One or more modules failed compile:";
+		for dep in "${failed[@]}"; do
+			eerror "  ${dep}"
+		done
+		die "Failing due to module compilation errors";
+	fi
+	if ! has "network" "${DIST_TEST_OVERRIDE:-${DIST_TEST:-do parallel}}"; then
+		ewarn "This package needs network access to run its full test suite"
+		ewarn "For details, see:"
+		ewarn "https://wiki.gentoo.org/wiki/Project:Perl/maint-nodes/dev-perl/Ace"
+		ewarn ""
+	else
+		perl-module_src_test
+	fi
+}
+
+pkg_postinst() {
+	ewarn "This package requests that publications that made use of this software"
+	ewarn "in the process of their research attribute it."
+	ewarn ""
+	ewarn "This package's licensing terms also include indemnification clauses"
+	ewarn "which may apply to you, and are currently under decision in"
+	ewarn " Bug: https://bugs.gentoo.org/718936"
+	ewarn ""
+	ewarn "Please read ${EROOT}/usr/share/doc/${PF}/DISCLAIMER.*"
+}

--- a/dev-perl/Ace/files/Ace-1.92-DARWIN_DEF
+++ b/dev-perl/Ace/files/Ace-1.92-DARWIN_DEF
@@ -1,0 +1,5 @@
+NAME = DARWIN
+COMPILER = $(TARGET_CC) -fwritable-strings -DACEDB4 -DPOSIX
+LINKER = $(TARGET_LD)
+
+LIBS = -lm

--- a/dev-perl/Ace/files/Ace-1.92-toolchain.patch
+++ b/dev-perl/Ace/files/Ace-1.92-toolchain.patch
@@ -1,0 +1,561 @@
+From d1f8c174bf1d893259eac9f30c49edb1a062525f Mon Sep 17 00:00:00 2001
+From: Kent Fredric <kentnl@gentoo.org>
+Date: Mon, 18 May 2020 06:52:59 +1200
+Subject: Make overriding AR/CC/RANLIB possible generically
+
+---
+ acelib/Makefile                      | 20 ++++++++++++--------
+ acelib/wmake/ALPHA_4_DEF             |  4 ++--
+ acelib/wmake/ALPHA_4_GCC_DEF         |  4 ++--
+ acelib/wmake/ALPHA_4_NEW_DEF         |  4 ++--
+ acelib/wmake/ALPHA_4_OPT_DEF         |  4 ++--
+ acelib/wmake/ALPHA_4_OSFV3_DEF       |  4 ++--
+ acelib/wmake/ALPHA_CHRONO_4_DEF      |  4 ++--
+ acelib/wmake/ALPHA_G3_DEF            |  4 ++--
+ acelib/wmake/DEC_OSF_DEF             |  4 ++--
+ acelib/wmake/HPUX_DEF                |  4 ++--
+ acelib/wmake/HP_4_GCC_DEF            |  4 ++--
+ acelib/wmake/INTEL_SOLARIS_4_OPT_DEF |  4 ++--
+ acelib/wmake/IRIX4_4_DEF             |  4 ++--
+ acelib/wmake/IRIX_DEF                |  4 ++--
+ acelib/wmake/LINUX_4_DEF             |  4 ++--
+ acelib/wmake/LINUX_DEF               |  4 ++--
+ acelib/wmake/LINUX_LIBC5_4_DEF       |  4 ++--
+ acelib/wmake/LINUX_MAC_4_DEF         |  4 ++--
+ acelib/wmake/POSIX_4_DEF             |  4 ++--
+ acelib/wmake/POSIX_4_GCC_DEF         |  4 ++--
+ acelib/wmake/SGI_4_DEF               |  4 ++--
+ acelib/wmake/SGI_4_GCC_DEF           |  4 ++--
+ acelib/wmake/SGI_4_IRIX5_DEF         |  4 ++--
+ acelib/wmake/SGI_4_NEW_DEF           |  4 ++--
+ acelib/wmake/SGI_4_PURE_DEF          |  4 ++--
+ acelib/wmake/SGI_DEF                 |  4 ++--
+ acelib/wmake/SOLARIS_4_DEF           |  4 ++--
+ acelib/wmake/SOLARIS_4_NEW_DEF       |  4 ++--
+ acelib/wmake/SOLARIS_4_OPT_DEF       |  4 ++--
+ acelib/wmake/SOLARIS_4_RELEASE_DEF   |  4 ++--
+ acelib/wmake/SOLARIS_7_gcc_DEF       |  4 ++--
+ acelib/wmake/SOLARIS_DEF             |  4 ++--
+ acelib/wmake/SOLARIS_GCC_DEF         |  4 ++--
+ acelib/wmake/SUNOS_DEF               |  4 ++--
+ acelib/wmake/SUN_4_DEF               |  4 ++--
+ acelib/wmake/SUN_4_NEW_DEF           |  4 ++--
+ 36 files changed, 82 insertions(+), 78 deletions(-)
+
+diff --git a/acelib/Makefile b/acelib/Makefile
+index 946167f..1bb71ca 100644
+--- a/acelib/Makefile
++++ b/acelib/Makefile
+@@ -3,4 +3,8 @@ false = 0
+ RANLIB_NEEDED = true	# default overridable in $(ACEDB_MACHINE)_DEF
+ AR_OPTIONS = rlu	# default overridable in $(ACEDB_MACHINE)_DEF
++AR = ar
++RANLIB = ranlib
++TARGET_CC = cc
++TARGET_LD = cc # stuff expects ld to be a CCLD in perl
+ 
+ RPCGEN_FLAGS = -I -K -1
+@@ -64,10 +68,10 @@ depend:
+ 
+ libaceperl.a : $(FREE_OBJS) aceclientlib.o rpcace_clnt.o rpcace_xdr.o
+-	ar $(AR_OPTIONS) $@ $?
+-	if ( $(RANLIB_NEEDED) ) then ranlib $@; fi
++	$(AR) $(AR_OPTIONS) $@ $?
++	if ( $(RANLIB_NEEDED) ) then $(RANLIB) $@; fi
+ 
+ libfree.a : $(FREE_OBJS)
+-	ar $(AR_OPTIONS) libfree.a $?
+-	if ( $(RANLIB_NEEDED) ) then ranlib libfree.a; fi
++	$(AR) $(AR_OPTIONS) libfree.a $?
++	if ( $(RANLIB_NEEDED) ) then $(RANLIB) libfree.a; fi
+ 
+ #########################################
+@@ -88,6 +92,6 @@ LIBACE_OBJS = $(GENERIC_ACE_OBJS) $(GENERIC_ACE_NONGRAPH_OBJS) aceversion.o
+ 
+ libace.a :  $(LIBACE_OBJS)
+-	ar $(AR_OPTIONS) libace.a $?
+-	if ( $(RANLIB_NEEDED) ) then ranlib libace.a; fi
++	$(AR) $(AR_OPTIONS) libace.a $?
++	if ( $(RANLIB_NEEDED) ) then $(RANLIB) libace.a; fi
+ 
+ ######################################################
+@@ -111,6 +115,6 @@ RPC_X_CLIENT_OBJS = xclient.o aceclientlib.o rpcace_clnt.o rpcace_xdr.o
+ 
+ libacecl.a : aceclientlib.o rpcace_clnt.o rpcace_xdr.o
+-	ar $(AR_OPTIONS) libacecl.a $?
+-	if ( $(RANLIB_NEEDED) ) then ranlib libacecl.a; fi
++	$(AR) $(AR_OPTIONS) libacecl.a $?
++	if ( $(RANLIB_NEEDED) ) then $(RANLIB) libacecl.a; fi
+ 
+ ###########################################################
+diff --git a/acelib/wmake/ALPHA_4_DEF b/acelib/wmake/ALPHA_4_DEF
+index 5d439f4..96cb6c1 100644
+--- a/acelib/wmake/ALPHA_4_DEF
++++ b/acelib/wmake/ALPHA_4_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = ALPHA
+-COMPILER = cc -g -std1 -ieee_with_inexact -DACEDB4
+-LINKER = cc -g
++COMPILER = $(TARGET_CC) -g -std1 -ieee_with_inexact -DACEDB4
++LINKER = $(TARGET_LD) -g
+ 
+ # On DEC the library does not need to be ranlib'd
+diff --git a/acelib/wmake/ALPHA_4_GCC_DEF b/acelib/wmake/ALPHA_4_GCC_DEF
+index 9b13569..a517e3d 100644
+--- a/acelib/wmake/ALPHA_4_GCC_DEF
++++ b/acelib/wmake/ALPHA_4_GCC_DEF
+@@ -15,7 +15,7 @@
+ 
+ NAME = ALPHA
+-COMPILER = gcc -g -DACEDB4 -ansi -pedantic -Wall -Wnested-externs -ieee_with_inexact
++COMPILER = $(TARGET_CC) -g -DACEDB4 -ansi -pedantic -Wall -Wnested-externs -ieee_with_inexact
+ 
+-LINKER = gcc -g
++LINKER = $(TARGET_LD) -g
+ 
+ # On DEC the library does not need to be ranlib'd
+diff --git a/acelib/wmake/ALPHA_4_NEW_DEF b/acelib/wmake/ALPHA_4_NEW_DEF
+index 012f167..8843b14 100644
+--- a/acelib/wmake/ALPHA_4_NEW_DEF
++++ b/acelib/wmake/ALPHA_4_NEW_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = ALPHA
+-COMPILER = cc -g -std1 -DACEDB4 -DNEW_MODELS
+-LINKER = cc
++COMPILER = $(TARGET_CC) -g -std1 -DACEDB4 -DNEW_MODELS
++LINKER = $(TARGET_LD)
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/ALPHA_4_OPT_DEF b/acelib/wmake/ALPHA_4_OPT_DEF
+index 8ebd39f..3fe63d7 100644
+--- a/acelib/wmake/ALPHA_4_OPT_DEF
++++ b/acelib/wmake/ALPHA_4_OPT_DEF
+@@ -16,10 +16,10 @@
+ 
+ NAME = ALPHA
+-COMPILER = cc -O -Olimit 3000 -std1 -DACEDB4 -ieee_with_inexact
++COMPILER = $(TARGET_CC) -O -Olimit 3000 -std1 -DACEDB4 -ieee_with_inexact
+ 
+ # rd 970131 - I am told that -O does the most optimisation possible
+ # there may be levels above -O2
+ 
+-LINKER = cc
++LINKER = $(TARGET_LD)
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/ALPHA_4_OSFV3_DEF b/acelib/wmake/ALPHA_4_OSFV3_DEF
+index d34390e..81eb594 100644
+--- a/acelib/wmake/ALPHA_4_OSFV3_DEF
++++ b/acelib/wmake/ALPHA_4_OSFV3_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = ALPHA
+-COMPILER = cc -g -std1 -ieee_with_inexact -DACEDB4
+-LINKER = cc -g
++COMPILER = $(TARGET_CC) -g -std1 -ieee_with_inexact -DACEDB4
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/ALPHA_CHRONO_4_DEF b/acelib/wmake/ALPHA_CHRONO_4_DEF
+index 011c7d2..004bdca 100644
+--- a/acelib/wmake/ALPHA_CHRONO_4_DEF
++++ b/acelib/wmake/ALPHA_CHRONO_4_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = ALPHA
+-COMPILER = cc -g -std1 -DACEDB4 -DCHRONO
+-LINKER = cc
++COMPILER = $(TARGET_CC) -g -std1 -DACEDB4 -DCHRONO
++LINKER = $(TARGET_LD)
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/ALPHA_G3_DEF b/acelib/wmake/ALPHA_G3_DEF
+index b259de0..1a3ed6f 100644
+--- a/acelib/wmake/ALPHA_G3_DEF
++++ b/acelib/wmake/ALPHA_G3_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = ALPHA
+-COMPILER = gcc -g -DACEDB3
+-LINKER = gcc -g
++COMPILER = $(TARGET_CC) -g -DACEDB3
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/DEC_OSF_DEF b/acelib/wmake/DEC_OSF_DEF
+index fddfef9..6e4c397 100644
+--- a/acelib/wmake/DEC_OSF_DEF
++++ b/acelib/wmake/DEC_OSF_DEF
+@@ -16,10 +16,10 @@
+ 
+ NAME = ALPHA
+-COMPILER = cc -O -Olimit 3000 -std1 -DACEDB4 -ieee_with_inexact
++COMPILER = $(TARGET_CC) -O -Olimit 3000 -std1 -DACEDB4 -ieee_with_inexact
+ 
+ # rd 970131 - I am told that -O does the most optimisation possible
+ # there may be levels above -O2
+ 
+-LINKER = cc
++LINKER = $(TARGET_LD)
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/HPUX_DEF b/acelib/wmake/HPUX_DEF
+index e7a08d5..0a73497 100644
+--- a/acelib/wmake/HPUX_DEF
++++ b/acelib/wmake/HPUX_DEF
+@@ -17,6 +17,6 @@
+ 
+ NAME = HP
+-COMPILER = gcc -g -DNO_LEFT_CASTING -DACEDB4 -I/usr/include/X11R5 -I/usr/local/include/MIT/X11R5/include
+-LINKER = gcc -g -L/usr/lib/X11R5
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -DACEDB4 -I/usr/include/X11R5 -I/usr/local/include/MIT/X11R5/include
++LINKER = $(TARGET_LD) -g -L/usr/lib/X11R5
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/HP_4_GCC_DEF b/acelib/wmake/HP_4_GCC_DEF
+index 87f3bf1..90459b2 100644
+--- a/acelib/wmake/HP_4_GCC_DEF
++++ b/acelib/wmake/HP_4_GCC_DEF
+@@ -17,6 +17,6 @@
+ 
+ NAME = HP
+-COMPILER = gcc -g -DNO_LEFT_CASTING -DACEDB4 -I/usr/include/X11R5 -I/usr/local/include/MIT/X11R5/include
+-LINKER = gcc -g -L/usr/lib/X11R5
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -DACEDB4 -I/usr/include/X11R5 -I/usr/local/include/MIT/X11R5/include
++LINKER = $(TARGET_LD) -g -L/usr/lib/X11R5
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/INTEL_SOLARIS_4_OPT_DEF b/acelib/wmake/INTEL_SOLARIS_4_OPT_DEF
+index 390be89..43ebfd5 100644
+--- a/acelib/wmake/INTEL_SOLARIS_4_OPT_DEF
++++ b/acelib/wmake/INTEL_SOLARIS_4_OPT_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = INTEL_SOLARIS
+-COMPILER = cc -xO4 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4
+-LINKER = cc -L/usr/openwin/lib -R/usr/openwin/lib
++COMPILER = $(TARGET_CC) -xO4 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4
++LINKER = $(TARGET_LD) -L/usr/openwin/lib -R/usr/openwin/lib
+ 
+ # -DWCS causes a problem, class versus Xlib.h
+diff --git a/acelib/wmake/IRIX4_4_DEF b/acelib/wmake/IRIX4_4_DEF
+index cef3a2d..53c1214 100644
+--- a/acelib/wmake/IRIX4_4_DEF
++++ b/acelib/wmake/IRIX4_4_DEF
+@@ -19,7 +19,7 @@
+ 
+ NAME = SGI 
+-COMPILER = cc -g -DNO_LEFT_CASTING -DACEDB4 -Wf,-XNl4096
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -DACEDB4 -Wf,-XNl4096
+ # -Wf,-XNl4096 needed to compile big string constant in graphxt.c
+-LINKER = cc -g
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm  -lsun
+diff --git a/acelib/wmake/IRIX_DEF b/acelib/wmake/IRIX_DEF
+index 8bec470..a177b0a 100644
+--- a/acelib/wmake/IRIX_DEF
++++ b/acelib/wmake/IRIX_DEF
+@@ -15,6 +15,6 @@
+ 
+ NAME = SGI 
+-COMPILER = cc -g -n32 DNO_LEFT_CASTING -DACEDB4
+-LINKER = cc -g
++COMPILER = $(TARGET_CC) -g -n32 DNO_LEFT_CASTING -DACEDB4
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm
+diff --git a/acelib/wmake/LINUX_4_DEF b/acelib/wmake/LINUX_4_DEF
+index 12fa675..88f2d7e 100644
+--- a/acelib/wmake/LINUX_4_DEF
++++ b/acelib/wmake/LINUX_4_DEF
+@@ -17,6 +17,6 @@
+ 
+ NAME = LINUX
+-COMPILER = gcc -g -Wall -O2 -DACEDB4
+-LINKER = gcc -g
++COMPILER = $(TARGET_CC) -g -Wall -O2 -DACEDB4
++LINKER = $(TARGET_LD) -g
+ USEROPTS=-fPIC
+ 
+diff --git a/acelib/wmake/LINUX_DEF b/acelib/wmake/LINUX_DEF
+index ba96774..51221ef 100644
+--- a/acelib/wmake/LINUX_DEF
++++ b/acelib/wmake/LINUX_DEF
+@@ -17,6 +17,6 @@
+ 
+ NAME = LINUX
+-COMPILER = gcc -g -Wall -O2 -DACEDB4
+-LINKER = gcc -g
++COMPILER = $(TARGET_CC) -g -Wall -O2 -DACEDB4
++LINKER = $(TARGET_LD) -g
+ USEROPTS=-fPIC
+ 
+diff --git a/acelib/wmake/LINUX_LIBC5_4_DEF b/acelib/wmake/LINUX_LIBC5_4_DEF
+index 8d59cbf..ba01857 100644
+--- a/acelib/wmake/LINUX_LIBC5_4_DEF
++++ b/acelib/wmake/LINUX_LIBC5_4_DEF
+@@ -17,6 +17,6 @@
+ 
+ NAME = LINUX
+-COMPILER = gcc -g -fwritable-strings -DACEDB4 -I.
+-LINKER = gcc -g
++COMPILER = $(TARGET_CC) -g -fwritable-strings -DACEDB4 -I.
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm
+diff --git a/acelib/wmake/LINUX_MAC_4_DEF b/acelib/wmake/LINUX_MAC_4_DEF
+index 75a0c49..e043ac0 100644
+--- a/acelib/wmake/LINUX_MAC_4_DEF
++++ b/acelib/wmake/LINUX_MAC_4_DEF
+@@ -17,6 +17,6 @@
+ 
+ NAME = LINUX
+-COMPILER = gcc -g -fwritable-strings -DACEDB4 -I. -DLINUX_MAC
+-LINKER = gcc -g
++COMPILER = $(TARGET_CC) -g -fwritable-strings -DACEDB4 -I. -DLINUX_MAC
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm
+diff --git a/acelib/wmake/POSIX_4_DEF b/acelib/wmake/POSIX_4_DEF
+index 71173a8..cb9d938 100644
+--- a/acelib/wmake/POSIX_4_DEF
++++ b/acelib/wmake/POSIX_4_DEF
+@@ -17,6 +17,6 @@
+ 
+ NAME = POSIX
+-COMPILER = cc -DACEDB4
+-LINKER = cc
++COMPILER = $(TARGET_CC) -DACEDB4
++LINKER = $(TARGET_LD)
+ 
+ LIBS = -lm
+diff --git a/acelib/wmake/POSIX_4_GCC_DEF b/acelib/wmake/POSIX_4_GCC_DEF
+index 07ff235..612c920 100644
+--- a/acelib/wmake/POSIX_4_GCC_DEF
++++ b/acelib/wmake/POSIX_4_GCC_DEF
+@@ -17,6 +17,6 @@
+ 
+ NAME = POSIX
+-COMPILER = gcc -fwritable-strings -DACEDB4
+-LINKER = gcc
++COMPILER = $(TARGET_CC) -fwritable-strings -DACEDB4
++LINKER = $(TARGET_LD)
+ 
+ LIBS = -lm
+diff --git a/acelib/wmake/SGI_4_DEF b/acelib/wmake/SGI_4_DEF
+index e5e8e92..909c92b 100644
+--- a/acelib/wmake/SGI_4_DEF
++++ b/acelib/wmake/SGI_4_DEF
+@@ -18,6 +18,6 @@
+ #
+ NAME = SGI 
+-COMPILER = cc -g -DNO_LEFT_CASTING -DACEDB4
+-LINKER = cc -g
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -DACEDB4
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm
+diff --git a/acelib/wmake/SGI_4_GCC_DEF b/acelib/wmake/SGI_4_GCC_DEF
+index 47b3b22..41d2418 100644
+--- a/acelib/wmake/SGI_4_GCC_DEF
++++ b/acelib/wmake/SGI_4_GCC_DEF
+@@ -15,6 +15,6 @@
+ 
+ NAME = SGI 
+-COMPILER = gcc -g -DNO_LEFT_CASTING -Wall -DACEDB4
+-LINKER = gcc -g
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -Wall -DACEDB4
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm 
+diff --git a/acelib/wmake/SGI_4_IRIX5_DEF b/acelib/wmake/SGI_4_IRIX5_DEF
+index 072e0ce..1515ca2 100644
+--- a/acelib/wmake/SGI_4_IRIX5_DEF
++++ b/acelib/wmake/SGI_4_IRIX5_DEF
+@@ -15,6 +15,6 @@
+ 
+ NAME = SGI 
+-COMPILER = cc -g -DNO_LEFT_CASTING -DACEDB4
+-LINKER = cc -g
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -DACEDB4
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm
+diff --git a/acelib/wmake/SGI_4_NEW_DEF b/acelib/wmake/SGI_4_NEW_DEF
+index b4938f2..f4f96e2 100644
+--- a/acelib/wmake/SGI_4_NEW_DEF
++++ b/acelib/wmake/SGI_4_NEW_DEF
+@@ -19,6 +19,6 @@
+ 
+ NAME = SGI 
+-COMPILER = cc -Wf,-XNh2000 -g -DNO_LEFT_CASTING -DACEDB4 -DNEW_MODELS -I.
+-LINKER = cc -g
++COMPILER = $(TARGET_CC) -Wf,-XNh2000 -g -DNO_LEFT_CASTING -DACEDB4 -DNEW_MODELS -I.
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm  -lsun
+diff --git a/acelib/wmake/SGI_4_PURE_DEF b/acelib/wmake/SGI_4_PURE_DEF
+index d9f4af3..f2150e4 100644
+--- a/acelib/wmake/SGI_4_PURE_DEF
++++ b/acelib/wmake/SGI_4_PURE_DEF
+@@ -18,6 +18,6 @@
+ #
+ NAME = SGI 
+-COMPILER = cc -g -DNO_LEFT_CASTING -DACEDB4
+-LINKER = purify -chain-length="10" cc -g
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -DACEDB4
++LINKER = purify -chain-length="10" $(TARGET_LD) -g
+ 
+ #different c++ compiler for purify compiling
+diff --git a/acelib/wmake/SGI_DEF b/acelib/wmake/SGI_DEF
+index 0db7af5..1571f5a 100644
+--- a/acelib/wmake/SGI_DEF
++++ b/acelib/wmake/SGI_DEF
+@@ -18,6 +18,6 @@
+ #
+ NAME = SGI 
+-COMPILER = cc -g -DNO_LEFT_CASTING -DACEDB4
+-LINKER = cc -g
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -DACEDB4
++LINKER = $(TARGET_LD) -g
+ 
+ LIBS = -lm
+diff --git a/acelib/wmake/SOLARIS_4_DEF b/acelib/wmake/SOLARIS_4_DEF
+index fbe8238..423b3c3 100644
+--- a/acelib/wmake/SOLARIS_4_DEF
++++ b/acelib/wmake/SOLARIS_4_DEF
+@@ -15,6 +15,6 @@
+ 
+ NAME = SOLARIS
+-COMPILER = gcc -g -DNO_LEFT_CASTING -O2 -Wall -I/usr/openwin/include -DACEDB4
+-LINKER = gcc -g
++COMPILER = $(TARGET_CC) -g -DNO_LEFT_CASTING -O2 -Wall -I/usr/openwin/include -DACEDB4
++LINKER = $(TARGET_LD) -g
+ 
+ # -DWCS causes a problem, class versus Xlib.h
+diff --git a/acelib/wmake/SOLARIS_4_NEW_DEF b/acelib/wmake/SOLARIS_4_NEW_DEF
+index 518831f..82f9409 100644
+--- a/acelib/wmake/SOLARIS_4_NEW_DEF
++++ b/acelib/wmake/SOLARIS_4_NEW_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = SOLARIS
+-COMPILER = gcc -g -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4 -DNEW_MODELS -I.
+-LINKER = gcc -g
++COMPILER = $(TARGET_CC) -g -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4 -DNEW_MODELS -I.
++LINKER = $(TARGET_LD) -g
+ 
+ # -DWCS causes a problem, class versus Xlib.h
+diff --git a/acelib/wmake/SOLARIS_4_OPT_DEF b/acelib/wmake/SOLARIS_4_OPT_DEF
+index 3f0c604..c938b9b 100644
+--- a/acelib/wmake/SOLARIS_4_OPT_DEF
++++ b/acelib/wmake/SOLARIS_4_OPT_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = SOLARIS
+-COMPILER = cc -xO4 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4
+-LINKER = cc -L/usr/openwin/lib -R/usr/openwin/lib
++COMPILER = $(TARGET_CC) -xO4 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4
++LINKER = $(TARGET_LD) -L/usr/openwin/lib -R/usr/openwin/lib
+ 
+ # -DWCS causes a problem, class versus Xlib.h
+diff --git a/acelib/wmake/SOLARIS_4_RELEASE_DEF b/acelib/wmake/SOLARIS_4_RELEASE_DEF
+index cd8063f..287836f 100644
+--- a/acelib/wmake/SOLARIS_4_RELEASE_DEF
++++ b/acelib/wmake/SOLARIS_4_RELEASE_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = SOLARIS
+-COMPILER = gcc -g -O2 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4 -I.
+-LINKER = gcc -g -Xlinker -R -Xlinker /usr/openwin/lib -L/usr/openwin/lib
++COMPILER = $(TARGET_CC) -g -O2 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4 -I.
++LINKER = $(TARGET_LD) -g -Xlinker -R -Xlinker /usr/openwin/lib -L/usr/openwin/lib
+ 
+ # -DWCS causes a problem, class versus Xlib.h
+diff --git a/acelib/wmake/SOLARIS_7_gcc_DEF b/acelib/wmake/SOLARIS_7_gcc_DEF
+index 63a538e..5964609 100644
+--- a/acelib/wmake/SOLARIS_7_gcc_DEF
++++ b/acelib/wmake/SOLARIS_7_gcc_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = SOLARIS
+-COMPILER = gcc -O4 -fwritable-strings -I/usr/openwin/include -DACEDB4 -DHASVSPRINTF
+-LINKER = gcc -L/usr/openwin/lib -R/usr/openwin/lib
++COMPILER = $(TARGET_CC) -O4 -fwritable-strings -I/usr/openwin/include -DACEDB4 -DHASVSPRINTF
++LINKER = $(TARGET_LD) -L/usr/openwin/lib -R/usr/openwin/lib
+ 
+ # -DWCS causes a problem, class versus Xlib.h
+diff --git a/acelib/wmake/SOLARIS_DEF b/acelib/wmake/SOLARIS_DEF
+index 8f7ce2b..048d219 100644
+--- a/acelib/wmake/SOLARIS_DEF
++++ b/acelib/wmake/SOLARIS_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = SOLARIS
+-COMPILER = cc -O2 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4
+-LINKER = cc -L/usr/openwin/lib -R/usr/openwin/lib
++COMPILER = $(TARGET_CC) -O2 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4
++LINKER = $(TARGET_LD) -L/usr/openwin/lib -R/usr/openwin/lib
+ 
+ # -DWCS causes a problem, class versus Xlib.h
+diff --git a/acelib/wmake/SOLARIS_GCC_DEF b/acelib/wmake/SOLARIS_GCC_DEF
+index 16c9334..048d219 100644
+--- a/acelib/wmake/SOLARIS_GCC_DEF
++++ b/acelib/wmake/SOLARIS_GCC_DEF
+@@ -16,6 +16,6 @@
+ 
+ NAME = SOLARIS
+-COMPILER = gcc -O2 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4
+-LINKER = gcc -L/usr/openwin/lib -R/usr/openwin/lib
++COMPILER = $(TARGET_CC) -O2 -I/usr/openwin/include -DNO_LEFT_CASTING -DACEDB4
++LINKER = $(TARGET_LD) -L/usr/openwin/lib -R/usr/openwin/lib
+ 
+ # -DWCS causes a problem, class versus Xlib.h
+diff --git a/acelib/wmake/SUNOS_DEF b/acelib/wmake/SUNOS_DEF
+index bef6180..d159952 100644
+--- a/acelib/wmake/SUNOS_DEF
++++ b/acelib/wmake/SUNOS_DEF
+@@ -23,7 +23,7 @@ NAME = SUN
+ 
+ ## NOMEMMOVE will define memmove on SunOS (for staden package)
+-COMPILER = gcc -g -O2 -Wall -fwritable-strings -DNOMEMMOVE -DACEDB4
++COMPILER = $(TARGET_CC) -g -O2 -Wall -fwritable-strings -DNOMEMMOVE -DACEDB4
+ 
+-LINKER = gcc -g -static 
++LINKER = $(TARGET_LD) -g -static 
+ 
+ #LIBS = -lm -L/usr/lib -L/usr/openwin.old/lib -L/usr/X11R6.3/lib
+diff --git a/acelib/wmake/SUN_4_DEF b/acelib/wmake/SUN_4_DEF
+index e1fdad1..88418d5 100644
+--- a/acelib/wmake/SUN_4_DEF
++++ b/acelib/wmake/SUN_4_DEF
+@@ -23,7 +23,7 @@ NAME = SUN
+ 
+ ## NOMEMMOVE will define memmove on SunOS (for staden package)
+-COMPILER = gcc -g -O2 -Wall -fwritable-strings -DNOMEMMOVE -DACEDB4
++COMPILER = $(TARGET_CC) -g -O2 -Wall -fwritable-strings -DNOMEMMOVE -DACEDB4
+ 
+-LINKER = gcc -g -static 
++LINKER = $(TARGET_LD) -g -static 
+ 
+ #LIBS = -lm -L/usr/lib -L/usr/openwin.old/lib -L/usr/X11R6.3/lib
+diff --git a/acelib/wmake/SUN_4_NEW_DEF b/acelib/wmake/SUN_4_NEW_DEF
+index 32685ef..0f5b8ce 100644
+--- a/acelib/wmake/SUN_4_NEW_DEF
++++ b/acelib/wmake/SUN_4_NEW_DEF
+@@ -16,7 +16,7 @@
+ 
+ NAME = SUN
+-COMPILER = gcc -g -Wreturn-type -Wimplicit -Wunused -Wcomment \
++COMPILER = $(TARGET_CC) -g -Wreturn-type -Wimplicit -Wunused -Wcomment \
+ 	-fwritable-strings -DACEDB4 -DNEW_MODELS
+-LINKER = gcc -g -static
++LINKER = $(TARGET_LD) -g -static
+ 
+ LIBS = -lm
+-- 
+2.26.2
+


### PR DESCRIPTION
Doing a PR because I need a few eyes to san-check this.

Ebuild diff from -r4
```diff
--- Ace-1.920.0-r4.ebuild	2020-04-23 14:38:29.424768313 +1200
+++ Ace-1.920.0-r5.ebuild	2020-05-19 01:59:13.176504387 +1200
@@ -34,25 +34,27 @@
 src_prepare() {
 	eapply "${FILESDIR}/${PN}-1.92-rpcxs.patch"
 	eapply "${FILESDIR}/${PN}-1.92-gcc-nonvoid.patch"
-
-	cat > "${S}/acelib/wmake/DARWIN_DEF" <<EOF
-NAME = DARWIN
-COMPILER = $(tc-getCC) -fwritable-strings -DACEDB4 -DPOSIX
-LINKER = $(tc-getLD)
-
-LIBS = -lm
-
-EOF
-
+	eapply "${FILESDIR}/${PN}-1.92-toolchain.patch"
+	cp "${FILESDIR}/${PN}-1.92-DARWIN_DEF" "${S}/acelib/wmake/DARWIN_DEF" || die "can't copy DARWIN_DEF"
 	if use elibc_glibc || use elibc_musl || use elibc_uclibc ; then
-		# Confusing name, should have been not specific to glibc
-		eapply "${FILESDIR}/${PN}-1.92-glibc26.patch"
 		export LIBS="-ltirpc"
 	fi
-
 	export MAKEOPTS="-j1"
 	perl-module_src_prepare
 }
+src_compile() {
+	mymake=(
+		"AR=$(tc-getAR)"
+		"TARGET_CC=$(tc-getCC)"
+		"TARGET_LD=$(tc-getLD)"
+		"RANLIB=$(tc-getRANLIB)"
+	)
+	if use elibc_glibc || use elibc_musl || use elibc_uclibc ; then
+		mymake+=( "LIBS=-ltirpc -lm" )
+		mymake+=( "USEROPTS=-I/usr/include/tirpc -fPIC" )
+	fi
+	perl-module_src_compile
+}
 
 src_test() {
 	local MODULES=(
```

This logic is highly experimental, but it does work for me
( though I don't do what ago does with LD because its too spicy )

This set of changes patches acelib so that all gcc/cc/ar calls
can be overloaded externally, though this somewhat defeats the point
of most of these files, as some of them only differed in wether they
said "cc" or "gcc".

The downside is I *had* to rework how the elibc_glibc block worked,
because as it was *conditional*, and patched lines adjacent to the lines
changed in -toolchain.patch, the existing patch could *only* be adapted
to work dependent on the -toolchain patch.

Instead, the essential variable overrides are performed externally
via `make` arguments, as this has the same outcome.

Any logic I didn't fully understand I left in place.

And I had to get clever with names, because acelib already has an
internal variable called "CC", and its value .... contains then entire
set of compile parameters for the compiler!

Also, the use of these TARGET_ seems to be less prone to conflict with
values that do similar things in perl space, where doing something like
LD="something-ld" can be fatal, as perl space doesn't expect LD to be an
actaul LD, but a CCLD, and passes flags LD doesn't support.

But there will *probably* be a few bugs in this approach, I'm no Make
wizard.

Bug: https://bugs.gentoo.org/723152
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Kent Fredric <kentnl@gentoo.org>