### PR TITLE
www-apps/radicale: support Py3.7

### DIFF
--- a/www-apps/radicale/radicale-2.1.11-r1.ebuild
+++ b/www-apps/radicale/radicale-2.1.11-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="6"
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6,7} )
 
 inherit distutils-r1 eutils user systemd
 


### PR DESCRIPTION
I’m running this and basic functionality appears to work.