### PR TITLE
dev-python/python-jsonrpc-server: does not work with ujson>=1.35

### DIFF
--- a/dev-python/python-jsonrpc-server/python-jsonrpc-server-0.3.4.ebuild
+++ b/dev-python/python-jsonrpc-server/python-jsonrpc-server-0.3.4.ebuild
@@ -17,13 +17,14 @@ KEYWORDS="~amd64 ~x86"
 
 BDEPEND="dev-python/versioneer[${PYTHON_USEDEP}]"
 
-RDEPEND="dev-python/ujson[${PYTHON_USEDEP}]"
+RDEPEND="~dev-python/ujson-1.35[${PYTHON_USEDEP}]"
 
 DEPEND="test? (
 	dev-python/mock[${PYTHON_USEDEP}]
 	dev-python/pycodestyle[${PYTHON_USEDEP}]
 	dev-python/pyflakes[${PYTHON_USEDEP}]
-	dev-python/pylint[${PYTHON_USEDEP}] )"
+	dev-python/pylint[${PYTHON_USEDEP}]
+)"
 
 PATCHES=( "${FILESDIR}/${P}-remove-pytest-cov-dep.patch" )
 


### PR DESCRIPTION
Tests fail with ujson > 1.35, see bug: https://bugs.gentoo.org/723604

Upstream also has <=1.35 as dependency in their setup.py file, so I'm not sure why it wasn't specified like that in the ebuild as well. Anyway this should fix it.

Closes: https://bugs.gentoo.org/723604
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>