### PR TITLE
gui-wm/wayfire: fix dependency versioning for building

### DIFF
--- a/gui-apps/wcm/wcm-0.4.0.ebuild
+++ b/gui-apps/wcm/wcm-0.4.0.ebuild
@@ -35,12 +35,12 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_compile() {
+src_configure() {
 	local emesonargs=""
 	if use debug; then
 		emesonargs+=(
 			"-Db_sanitize=address,undefined"
 		)
 	fi
-	meson_src_compile
+	meson_src_configure
 }

--- a/gui-apps/wcm/wcm-9999.ebuild
+++ b/gui-apps/wcm/wcm-9999.ebuild
@@ -35,12 +35,12 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_compile() {
+src_configure() {
 	local emesonargs=""
 	if use debug; then
 		emesonargs+=(
 			"-Db_sanitize=address,undefined"
 		)
 	fi
-	meson_src_compile
+	meson_src_configure
 }

--- a/gui-apps/wf-shell/wf-shell-0.4.0.ebuild
+++ b/gui-apps/wf-shell/wf-shell-0.4.0.ebuild
@@ -23,7 +23,7 @@ IUSE="+pulseaudio debug"
 DEPEND="
 	dev-cpp/gtkmm:3.0=[wayland]
 	dev-libs/gobject-introspection
-	~gui-wm/wayfire-${PV}
+	~gui-wm/wayfire-${PV}[debug=]
 	>=gui-libs/gtk-layer-shell-0.1
 	pulseaudio? ( media-sound/pulseaudio )
 "
@@ -36,7 +36,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_compile () {
+src_configure () {
 	local emesonargs=(
 		"$(meson_feature pulseaudio pulse)"
 	)
@@ -45,5 +45,5 @@ src_compile () {
 			"-Db_sanitize=address,undefined"
 		)
 	fi
-	meson_src_compile
+	meson_src_configure
 }

--- a/gui-apps/wf-shell/wf-shell-9999.ebuild
+++ b/gui-apps/wf-shell/wf-shell-9999.ebuild
@@ -23,7 +23,7 @@ IUSE="+pulseaudio debug"
 DEPEND="
 	dev-cpp/gtkmm:3.0=[wayland]
 	dev-libs/gobject-introspection
-	~gui-wm/wayfire-${PV}
+	~gui-wm/wayfire-${PV}[debug=]
 	>=gui-libs/gtk-layer-shell-0.1
 	pulseaudio? ( media-sound/pulseaudio )
 "
@@ -36,7 +36,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_compile () {
+src_configure () {
 	local emesonargs=(
 		"$(meson_feature pulseaudio pulse)"
 	)
@@ -45,5 +45,5 @@ src_compile () {
 			"-Db_sanitize=address,undefined"
 		)
 	fi
-	meson_src_compile
+	meson_src_configure
 }

--- a/gui-libs/wf-config/wf-config-0.4.0.ebuild
+++ b/gui-libs/wf-config/wf-config-0.4.0.ebuild
@@ -23,8 +23,8 @@ IUSE="debug"
 DEPEND="
 	dev-libs/libevdev
 	dev-libs/libxml2
-	gui-libs/wlroots
 	media-libs/glm
+	<=gui-libs/wlroots-0.10.1
 "
 
 RDEPEND="${DEPEND}"
@@ -35,12 +35,12 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_compile () {
+src_configure () {
 	local emesonargs=""
 	if use debug; then
 		emesonargs+=(
 			"-Db_sanitize=address,undefined"
 		)
 	fi
-	meson_src_compile
+	meson_src_configure
 }

--- a/gui-libs/wf-config/wf-config-9999.ebuild
+++ b/gui-libs/wf-config/wf-config-9999.ebuild
@@ -23,7 +23,7 @@ IUSE="debug"
 DEPEND="
 	dev-libs/libevdev
 	dev-libs/libxml2
-	gui-libs/wlroots
+	~gui-libs/wlroots-9999
 	media-libs/glm
 "
 
@@ -35,12 +35,12 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_compile () {
+src_configure () {
 	local emesonargs=""
 	if use debug; then
 		emesonargs+=(
 			"-Db_sanitize=address,undefined"
 		)
 	fi
-	meson_src_compile
+	meson_src_configure
 }

--- a/gui-wm/wayfire/wayfire-0.4.0.ebuild
+++ b/gui-wm/wayfire/wayfire-0.4.0.ebuild
@@ -38,7 +38,7 @@ DEPEND="
 	gles2? ( media-libs/libglvnd[X] )
 	system-wfconfig? ( ~gui-libs/wf-config-${PV}[debug=] )
 	!system-wfconfig? ( !gui-libs/wf-config )
-	system-wlroots? ( >=gui-libs/wlroots-0.10.0[elogind=,systemd=,X] )
+	system-wlroots? ( ~gui-libs/wlroots-0.10.0[elogind=,systemd=,X] )
 	!system-wlroots? ( !gui-libs/wlroots )
 "
 
@@ -55,7 +55,7 @@ BDEPEND="
 	>=dev-libs/wayland-protocols-1.18
 "
 
-src_compile(){
+src_configure() {
 	local emesonargs=(
 		$(meson_feature system-wfconfig use_system_wfconfig)
 		$(meson_feature system-wlroots use_system_wlroots)
@@ -66,7 +66,7 @@ src_compile(){
 			"-Db_sanitize=address,undefined"
 		)
 	fi
-	meson_src_compile
+	meson_src_configure
 }
 
 src_install() {

--- a/gui-wm/wayfire/wayfire-9999.ebuild
+++ b/gui-wm/wayfire/wayfire-9999.ebuild
@@ -38,7 +38,7 @@ DEPEND="
 	gles2? ( media-libs/libglvnd[X] )
 	system-wfconfig? ( ~gui-libs/wf-config-${PV}[debug=] )
 	!system-wfconfig? ( !gui-libs/wf-config )
-	system-wlroots? ( >=gui-libs/wlroots-0.10.0[elogind=,systemd=,X] )
+	system-wlroots? ( >=gui-libs/wlroots-0.10.1[elogind=,systemd=,X] )
 	!system-wlroots? ( !gui-libs/wlroots )
 "
 
@@ -55,7 +55,7 @@ BDEPEND="
 	>=dev-libs/wayland-protocols-1.18
 "
 
-src_compile(){
+src_configure() {
 	local emesonargs=(
 		$(meson_feature system-wfconfig use_system_wfconfig)
 		$(meson_feature system-wlroots use_system_wlroots)
@@ -66,7 +66,7 @@ src_compile(){
 			"-Db_sanitize=address,undefined"
 		)
 	fi
-	meson_src_compile
+	meson_src_configure
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/723760

added proper dependency versions of wlroots
also changed options to src_configure instead of
src_compile as per standard convention
not version bumping as this fixes compile bugs
and no runtime changes

Signed-off-by: Aisha Tammy <gentoo@aisha.cc>