### PR TITLE
media-gfx/iscan: Explicitly use pthreads so we can use gold linker

### DIFF
--- a/media-gfx/iscan/iscan-3.62.0.ebuild
+++ b/media-gfx/iscan/iscan-3.62.0.ebuild
@@ -51,6 +51,8 @@ src_configure() {
 	# Workaround for:
 	# /usr/lib64/utsushi/libutsushi.so.0: undefined symbol: libcnx_usb_LTX_factory
 	append-ldflags $(no-as-needed)
+	# https://bugs.gentoo.org/720994
+	append-ldflags -pthread
 	local myconf=(
 		$(use_with gui gtkmm)
 		--enable-sane-config


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/720994
Signed-off-by: Marcin Deranek <marcin.deranek@slonko.net>