### PR TITLE
net-analyzer/netdata: fix ebuild ignoring USE

### DIFF
--- a/net-analyzer/netdata/netdata-1.22.0.ebuild
+++ b/net-analyzer/netdata/netdata-1.22.0.ebuild
@@ -95,10 +95,11 @@ src_prepare() {
 }
 
 src_configure() {
+	# --disable-cloud: https://github.com/netdata/netdata/issues/8961
 	econf \
 		--localstatedir="${EPREFIX}"/var \
 		--with-user=netdata \
-		--disable-cloud \ # https://github.com/netdata/netdata/issues/8961
+		--disable-cloud \
 		$(use_enable jsonc) \
 		$(use_enable cups plugin-cups) \
 		$(use_enable dbengine) \

--- a/net-analyzer/netdata/netdata-1.22.1.ebuild
+++ b/net-analyzer/netdata/netdata-1.22.1.ebuild
@@ -95,10 +95,11 @@ src_prepare() {
 }
 
 src_configure() {
+	# --disable-cloud: https://github.com/netdata/netdata/issues/8961
 	econf \
 		--localstatedir="${EPREFIX}"/var \
 		--with-user=netdata \
-		--disable-cloud \ # https://github.com/netdata/netdata/issues/8961
+		--disable-cloud \
 		$(use_enable jsonc) \
 		$(use_enable cups plugin-cups) \
 		$(use_enable dbengine) \

--- a/net-analyzer/netdata/netdata-9999.ebuild
+++ b/net-analyzer/netdata/netdata-9999.ebuild
@@ -95,10 +95,11 @@ src_prepare() {
 }
 
 src_configure() {
+	# --disable-cloud: https://github.com/netdata/netdata/issues/8961
 	econf \
 		--localstatedir="${EPREFIX}"/var \
 		--with-user=netdata \
-		--disable-cloud \ # https://github.com/netdata/netdata/issues/8961
+		--disable-cloud \
 		$(use_enable jsonc) \
 		$(use_enable cups plugin-cups) \
 		$(use_enable dbengine) \


### PR DESCRIPTION
An ebuild syntax error (stray comment breaking backslash line continuation)
introduced in 0521c7e8 causes ./configure to issue a number of warnings
and fails to pass any arguments to it.