### PR TITLE
dev-libs/json-c: add USE flag to enable rdrand support

### DIFF
--- a/dev-libs/json-c/json-c-0.14-r3.ebuild
+++ b/dev-libs/json-c/json-c-0.14-r3.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://s3.amazonaws.com/json-c_releases/releases/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0/5"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE="doc static-libs threads"
+IUSE="cpu-flags-x86-rdrand doc static-libs threads"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-0.14-cmake-static-libs.patch"
@@ -34,6 +34,7 @@ multilib_src_configure() {
 		-DBUILD_DOCUMENTATION=$(multilib_native_usex doc)
 		-DBUILD_STATIC_LIBS=$(usex static-libs)
 		-DDISABLE_WERROR=ON
+		-DENABLE_RDRAND=$(usex cpu-flags-x86-rdrand)
 		-DENABLE_THREADING=$(usex threads)
 	)
 

--- a/dev-libs/json-c/json-c-9999.ebuild
+++ b/dev-libs/json-c/json-c-9999.ebuild
@@ -12,7 +12,7 @@ EGIT_REPO_URI="https://github.com/json-c/json-c.git"
 
 LICENSE="MIT"
 SLOT="0/5"
-IUSE="doc static-libs threads"
+IUSE="cpu-flags-x86-rdrand doc static-libs threads"
 
 MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/json-c/config.h
@@ -27,6 +27,7 @@ multilib_src_configure() {
 		-DBUILD_DOCUMENTATION=$(multilib_native_usex doc)
 		-DDISABLE_WERROR=ON
 		-DENABLE_THREADING=$(usex threads)
+		-DENABLE_RDRAND=$(usex cpu-flags-x86-rdrand)
 		-DBUILD_STATIC_LIBS=$(usex static-libs)
 	)
 

--- a/dev-libs/json-c/metadata.xml
+++ b/dev-libs/json-c/metadata.xml
@@ -13,6 +13,9 @@
     <email>proxy-maint@gentoo.org</email>
     <name>Proxy Maintainers</name>
   </maintainer>
+  <use>
+    <flag name="cpu-flags-x86-rdrand">Enable RDRAND Hardware RNG Hash Seed</flag>
+  </use>
   <longdescription lang="en">
 "A JSON implementation in C" is probably the better description, and then
 "JSON-C implements a reference counting object model that allows you to 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/724354
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>