### PR TITLE
games-strategy/s25rttr: add missing flag-o-matic inherit

### DIFF
--- a/games-strategy/s25rttr/s25rttr-0.9.0_pre20200418.ebuild
+++ b/games-strategy/s25rttr/s25rttr-0.9.0_pre20200418.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit desktop toolchain-funcs xdg cmake
+inherit desktop flag-o-matic toolchain-funcs xdg cmake
 
 DESCRIPTION="Open source remake of The Settlers II: Gold Edition (needs original data files)"
 HOMEPAGE="https://www.siedler25.org/"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

s25rttr calls ```append-ldflags``` but doesn't inherit ```flag-o-matic```. It still works because it get indirectly inherited via ```cmake``` eclass.