### PR TITLE
games-strategy/wesnoth: add missing flag-o-matic inherit

### DIFF
--- a/games-strategy/wesnoth/wesnoth-1.14.11.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.14.11.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake toolchain-funcs xdg
+inherit cmake flag-o-matic toolchain-funcs xdg
 
 DESCRIPTION="Battle for Wesnoth - A fantasy turn-based strategy game"
 HOMEPAGE="http://www.wesnoth.org

--- a/games-strategy/wesnoth/wesnoth-1.14.9.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.14.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake toolchain-funcs user xdg
+inherit cmake flag-o-matic toolchain-funcs user xdg
 
 DESCRIPTION="Battle for Wesnoth - A fantasy turn-based strategy game"
 HOMEPAGE="http://www.wesnoth.org

--- a/games-strategy/wesnoth/wesnoth-1.15.3.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.15.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake toolchain-funcs xdg
+inherit cmake flag-o-matic toolchain-funcs xdg
 
 DESCRIPTION="Battle for Wesnoth - A fantasy turn-based strategy game"
 HOMEPAGE="http://www.wesnoth.org


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

all ebuilds of wesnoth are calling ```append-ldflags``` and ```filter-flags``` but doesn't inherit ```flag-o-matic```. It still works because it gets indirectly inherited via ```cmake``` eclass.