### PR TITLE
net-libs/libwebsockets: add missing flag-o-matic inherit

### DIFF
--- a/net-libs/libwebsockets/libwebsockets-4.0.7.ebuild
+++ b/net-libs/libwebsockets/libwebsockets-4.0.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="A flexible pure-C library for implementing network protocols"
 HOMEPAGE="https://libwebsockets.org/"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,
libwebsockets-4.0.7 calls `append-clfags` from the `flag-o-matic` eclass but doesn't inherit it. (it works because it gets indirectly inherit by the `cmake` eclass). I've updated the ebuild and added the `flag-o-matic` eclass.
