### PR TITLE
gui-apps/wf-recorder: dependency use flag fixes + live ebuild

### DIFF
--- a/gui-apps/wf-recorder/wf-recorder-0.2.1-r1.ebuild
+++ b/gui-apps/wf-recorder/wf-recorder-0.2.1-r1.ebuild
@@ -7,20 +7,31 @@ inherit meson
 
 DESCRIPTION="Screen recorder for wlroots-based compositors"
 HOMEPAGE="https://github.com/ammen99/wf-recorder"
-SRC_URI="https://github.com/ammen99/${PN}/releases/download/v${PV}/${P}.tar.xz"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/ammen99/wf-recorder.git"
+else
+	SRC_URI="https://github.com/ammen99/wf-recorder/releases/download/v${PV}/${P}.tar.xz"
+	KEYWORDS="~amd64 ~x86"
+fi
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
 IUSE="+man opencl"
 
-DEPEND="dev-libs/wayland
-	dev-libs/wayland-protocols
+DEPEND="
+	dev-libs/wayland
 	media-sound/pulseaudio
-	media-video/ffmpeg
-	opencl? ( virtual/opencl )"
+	media-video/ffmpeg[opencl?,pulseaudio,x264]
+	opencl? ( virtual/opencl )
+"
 RDEPEND="${DEPEND}"
-BDEPEND="man? ( app-text/scdoc )"
+BDEPEND="
+	virtual/pkgconfig
+	dev-libs/wayland-protocols
+	man? ( >=app-text/scdoc-1.9.3 )
+"
 
 src_configure() {
 	local emesonargs=(

--- a/gui-apps/wf-recorder/wf-recorder-9999.ebuild
+++ b/gui-apps/wf-recorder/wf-recorder-9999.ebuild
@@ -1,0 +1,43 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit meson
+
+DESCRIPTION="Screen recorder for wlroots-based compositors"
+HOMEPAGE="https://github.com/ammen99/wf-recorder"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/ammen99/wf-recorder.git"
+else
+	SRC_URI="https://github.com/ammen99/wf-recorder/releases/download/v${PV}/${P}.tar.xz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="+man pulseaudio opencl"
+
+DEPEND="
+	dev-libs/wayland
+	pulseaudio? ( media-sound/pulseaudio )
+	media-video/ffmpeg[opencl?,pulseaudio?,x264]
+	opencl? ( virtual/opencl )
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	dev-libs/wayland-protocols
+	man? ( >=app-text/scdoc-1.9.3 )
+"
+
+src_configure() {
+	local emesonargs=(
+		$(meson_feature man man-pages)
+		$(meson_feature pulseaudio pulse)
+		$(meson_feature opencl)
+	)
+	meson_src_configure
+}


### PR DESCRIPTION
added proper flags on ffmpeg for encoding and opencl
also added live ebuild

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>