### PR TITLE
net-mail/relay-ctrl: fix issue for cron (run-parts)

### DIFF
--- a/net-mail/relay-ctrl/relay-ctrl-3.1.1-r2.ebuild
+++ b/net-mail/relay-ctrl/relay-ctrl-3.1.1-r2.ebuild
@@ -57,8 +57,9 @@ src_install() {
 	echo "1800" > ${D}${RELAYCTRL_CONFDIR}/RELAY_CTRL_EXPIRY || die
 
 	dodir /etc/cron.hourly
+	echo "#!/bin/sh" > ${D}/etc/cron.hourly/relay-ctrl-age
 	echo "/usr/bin/envdir ${RELAYCTRL_CONFDIR} ${RELAYCTRL_BINDIR}/relay-ctrl-age" \
-		> "${D}"/etc/cron.hourly/relay-ctrl-age
+		>> "${D}"/etc/cron.hourly/relay-ctrl-age
 	fperms 755 /etc/cron.hourly/relay-ctrl-age
 }
 


### PR DESCRIPTION
the issue:
 "run-parts: failed to exec /etc/cron.hourly/relay-ctrl-age: Exec format error"
manifested itself after migration to cronie (from vixie-cron)

Signed-off-by: Sergiy Borodych <Sergiy.Borodych@gmail.com>