### PR TITLE
net-im/psimedia: more flexible use flags and removed dep on qconf

### DIFF
--- a/net-im/psimedia/metadata.xml
+++ b/net-im/psimedia/metadata.xml
@@ -10,7 +10,9 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
+		<flag name="demo">Build demo application and its version of the plugin</flag>
 		<flag name="extras">Enable Psi+ mode (required when built for Psi+)</flag>
+		<flag name="psi">Build a plugin for <pkg>net-im/psi</pkg></flag>
 	</use>
 	<upstream>
 		<remote-id type="github">psi-im/psimedia</remote-id>

--- a/net-im/psimedia/psimedia-9999.ebuild
+++ b/net-im/psimedia/psimedia-9999.ebuild
@@ -13,9 +13,9 @@ EGIT_REPO_URI="https://github.com/psi-im/psimedia.git"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS=""
-IUSE="extras"
+IUSE="demo extras +psi"
+REQUIRED_USE="extras? ( psi )"
 
-BDEPEND="sys-devel/qconf"
 DEPEND="
 	dev-libs/glib
 	dev-qt/qtcore:5
@@ -29,13 +29,15 @@ RDEPEND="${DEPEND}
 	media-plugins/gst-plugins-jpeg:1.0
 	media-plugins/gst-plugins-opus:1.0
 	media-plugins/gst-plugins-v4l2:1.0
-	~net-im/psi-${PV}[extras?]
+	psi? ( ~net-im/psi-${PV}[extras?] )
 "
+# and optional media-plugins/gst-plugins-webrtcdsp:1.0 for echo cancellation
 
 src_configure() {
 	local mycmakeargs=(
-		-DUSE_PSI=$(usex extras 0 1)
-		-DBUILD_DEMO=0
+		-DUSE_PSI=$(usex extras)
+		-DBUILD_DEMO=$(usex demo)
+		-DBUILD_PSIPLUGIN=$(usex psi)
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
qconf was used when when psimedia was built with qmake. It's not the case anymore.
Also now psimedia can build two plugins: for psi and for demo app, so there are more flags configure this.

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Sergey Ilinykh <rion4ik@gmail.com>