### PR TITLE
media-libs/mesa: check for CONFIG_CHECKPOINT_RESTORE=y

### DIFF
--- a/media-libs/mesa/mesa-19.3.5.ebuild
+++ b/media-libs/mesa/mesa-19.3.5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit llvm meson multilib-minimal pax-utils python-any-r1
+inherit llvm meson multilib-minimal pax-utils python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -323,6 +323,15 @@ pkg_setup() {
 	if use llvm && has_version sys-devel/llvm[!debug=]; then
 		ewarn "Mismatch between debug USE flags in media-libs/mesa and sys-devel/llvm"
 		ewarn "detected! This can cause problems. For details, see bug 459306."
+	fi
+
+	# os_same_file_description requires the kcmp syscall,
+	# which is only available with CONFIG_CHECKPOINT_RESTORE=y.
+	# Currently only AMDGPU utilizes this function, so only AMDGPU users would
+	# get a spooky warning message if the syscall fails.
+	if use gallium && use video_cards_radeonsi; then
+		CONFIG_CHECK="~CHECKPOINT_RESTORE"
+		linux-info_pkg_setup
 	fi
 
 	if use gallium && use llvm; then

--- a/media-libs/mesa/mesa-20.0.4-r1.ebuild
+++ b/media-libs/mesa/mesa-20.0.4-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit llvm meson multilib-minimal python-any-r1
+inherit llvm meson multilib-minimal python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -328,6 +328,15 @@ pkg_setup() {
 	if use llvm && has_version sys-devel/llvm[!debug=]; then
 		ewarn "Mismatch between debug USE flags in media-libs/mesa and sys-devel/llvm"
 		ewarn "detected! This can cause problems. For details, see bug 459306."
+	fi
+
+	# os_same_file_description requires the kcmp syscall,
+	# which is only available with CONFIG_CHECKPOINT_RESTORE=y.
+	# Currently only AMDGPU utilizes this function, so only AMDGPU users would
+	# get a spooky warning message if the syscall fails.
+	if use gallium && use video_cards_radeonsi; then
+		CONFIG_CHECK="~CHECKPOINT_RESTORE"
+		linux-info_pkg_setup
 	fi
 
 	if use gallium && use llvm; then

--- a/media-libs/mesa/mesa-20.0.7.ebuild
+++ b/media-libs/mesa/mesa-20.0.7.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit llvm meson multilib-minimal python-any-r1
+inherit llvm meson multilib-minimal python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -332,6 +332,15 @@ pkg_setup() {
 	if use llvm && has_version sys-devel/llvm[!debug=]; then
 		ewarn "Mismatch between debug USE flags in media-libs/mesa and sys-devel/llvm"
 		ewarn "detected! This can cause problems. For details, see bug 459306."
+	fi
+
+	# os_same_file_description requires the kcmp syscall,
+	# which is only available with CONFIG_CHECKPOINT_RESTORE=y.
+	# Currently only AMDGPU utilizes this function, so only AMDGPU users would
+	# get a spooky warning message if the syscall fails.
+	if use gallium && use video_cards_radeonsi; then
+		CONFIG_CHECK="~CHECKPOINT_RESTORE"
+		linux-info_pkg_setup
 	fi
 
 	if use gallium && use llvm; then

--- a/media-libs/mesa/mesa-20.1.0_rc4.ebuild
+++ b/media-libs/mesa/mesa-20.1.0_rc4.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit llvm meson multilib-minimal python-any-r1
+inherit llvm meson multilib-minimal python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -332,6 +332,15 @@ pkg_setup() {
 	if use llvm && has_version sys-devel/llvm[!debug=]; then
 		ewarn "Mismatch between debug USE flags in media-libs/mesa and sys-devel/llvm"
 		ewarn "detected! This can cause problems. For details, see bug 459306."
+	fi
+
+	# os_same_file_description requires the kcmp syscall,
+	# which is only available with CONFIG_CHECKPOINT_RESTORE=y.
+	# Currently only AMDGPU utilizes this function, so only AMDGPU users would
+	# get a spooky warning message if the syscall fails.
+	if use gallium && use video_cards_radeonsi; then
+		CONFIG_CHECK="~CHECKPOINT_RESTORE"
+		linux-info_pkg_setup
 	fi
 
 	if use gallium && use llvm; then

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit llvm meson multilib-minimal python-any-r1
+inherit llvm meson multilib-minimal python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -332,6 +332,15 @@ pkg_setup() {
 	if use llvm && has_version sys-devel/llvm[!debug=]; then
 		ewarn "Mismatch between debug USE flags in media-libs/mesa and sys-devel/llvm"
 		ewarn "detected! This can cause problems. For details, see bug 459306."
+	fi
+
+	# os_same_file_description requires the kcmp syscall,
+	# which is only available with CONFIG_CHECKPOINT_RESTORE=y.
+	# Currently only AMDGPU utilizes this function, so only AMDGPU users would
+	# get a spooky warning message if the syscall fails.
+	if use gallium && use video_cards_radeonsi; then
+		CONFIG_CHECK="~CHECKPOINT_RESTORE"
+		linux-info_pkg_setup
 	fi
 
 	if use gallium && use llvm; then


### PR DESCRIPTION
This lets AMDGPU users know they should enable the kernel config option.
It should be enabled by CONFIG_GENTOO_LINUX_INIT_SYSTEMD, but if e.g.
OpenRC is used, it's possible for the option to be unset, as was in
my case.

Not doing so can cause the following spooky warning:
"amdgpu: os_same_file_description couldn't determine if two DRM fds
reference the same file description. If they do, bad things may happen!"

I haven't experienced any issues with the config option disabled, but
the warning is likely there for a reason.

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Ilya Trukhanov <lahvuun@gmail.com>