### PR TITLE
games-emulation/pcsx2: add missing flag-o-matic inherit

### DIFF
--- a/games-emulation/pcsx2/pcsx2-1.6.0.ebuild
+++ b/games-emulation/pcsx2/pcsx2-1.6.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 MY_PV="${PV/_/-}"
 
-inherit cmake multilib toolchain-funcs wxwidgets
+inherit cmake flag-o-matic multilib toolchain-funcs wxwidgets
 
 DESCRIPTION="A PlayStation 2 emulator"
 HOMEPAGE="https://www.pcsx2.net"

--- a/games-emulation/pcsx2/pcsx2-9999.ebuild
+++ b/games-emulation/pcsx2/pcsx2-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake git-r3 multilib toolchain-funcs wxwidgets
+inherit cmake flag-o-matic git-r3 multilib toolchain-funcs wxwidgets
 
 DESCRIPTION="A PlayStation 2 emulator"
 HOMEPAGE="https://www.pcsx2.net"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,

Both 1.6.0 and the 9999 ebuild are calling `append-flags` from the `flag-o-matic` eclass, but unfortunately it's not inherited. It works because it's indirectly inherited via `cmake`.
I've updated the ebuilds and added the `flag-o-matic` eclass.