### PR TITLE
dev-lang/julia: Add dependency of libssh2.

### DIFF
--- a/dev-lang/julia/julia-1.3.0.ebuild
+++ b/dev-lang/julia/julia-1.3.0.ebuild
@@ -38,6 +38,7 @@ RDEPEND+="
 	dev-libs/mpfr:0=
 	dev-libs/openspecfun
 	>=net-libs/mbedtls-2.2
+	net-libs/libssh2
 	sci-libs/amd:0=
 	sci-libs/arpack:0=
 	sci-libs/camd:0=

--- a/dev-lang/julia/julia-1.4.0-r1.ebuild
+++ b/dev-lang/julia/julia-1.4.0-r1.ebuild
@@ -46,6 +46,7 @@ RDEPEND+="
 	dev-libs/mpfr:0=
 	dev-libs/openspecfun
 	>=net-libs/mbedtls-2.2
+	net-libs/libssh2
 	sci-libs/amd:0=
 	sci-libs/arpack:0=
 	sci-libs/camd:0=


### PR DESCRIPTION
The library libssh2 is necessary to build to package.

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Chang Liu goduck777@gmail.com