### PR TITLE
sys-apps/ripgrep: Handle USE flags for shell completion

### DIFF
--- a/sys-apps/ripgrep/metadata.xml
+++ b/sys-apps/ripgrep/metadata.xml
@@ -13,6 +13,7 @@
 		<flag name="man" restrict="&gt;=sys-apps/ripgrep-0.10.0-r1">
 			Build and install man pages.
 		</flag>
+		<flag name="fish-completion">Enable fish completion support</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">BurntSushi/ripgrep</remote-id>

--- a/sys-apps/ripgrep/ripgrep-11.0.2.ebuild
+++ b/sys-apps/ripgrep/ripgrep-11.0.2.ebuild
@@ -71,7 +71,7 @@ winapi-x86_64-pc-windows-gnu-0.4.0
 wincolor-1.0.1
 "
 
-inherit cargo bash-completion-r1
+inherit cargo
 
 DESCRIPTION="a search tool that combines the usability of ag with the raw speed of grep"
 HOMEPAGE="https://github.com/BurntSushi/ripgrep"
@@ -81,7 +81,7 @@ SRC_URI="https://github.com/BurntSushi/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="Apache-2.0 BSD-2 Boost-1.0 || ( MIT Unlicense )"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 ppc64 ~x86"
-IUSE="+man pcre"
+IUSE="+man pcre bash-completion fish-completion zsh-completion"
 
 DEPEND=""
 
@@ -113,13 +113,20 @@ src_install() {
 	    doman "${BUILD_DIR}"/rg.1
 	fi
 
-	newbashcomp "${BUILD_DIR}"/rg.bash rg
+	if use bash-completion ; then
+		inherit bash-completion-r1
+		newbashcomp "${BUILD_DIR}"/rg.bash rg
+	fi
 
-	insinto /usr/share/fish/vendor_completions.d
-	doins "${BUILD_DIR}"/rg.fish
+	if use fish-completion ; then
+		insinto /usr/share/fish/vendor_completions.d
+		doins "${BUILD_DIR}"/rg.fish
+	fi
 
-	insinto /usr/share/zsh/site-functions
-	doins complete/_rg
+	if use zsh-completion ; then
+		insinto /usr/share/zsh/site-functions
+		doins complete/_rg
+	fi
 
 	dodoc CHANGELOG.md FAQ.md GUIDE.md README.md
 }

--- a/sys-apps/ripgrep/ripgrep-12.0.1.ebuild
+++ b/sys-apps/ripgrep/ripgrep-12.0.1.ebuild
@@ -70,7 +70,7 @@ winapi-util-0.1.3
 winapi-x86_64-pc-windows-gnu-0.4.0
 "
 
-inherit cargo bash-completion-r1
+inherit cargo
 
 DESCRIPTION="a search tool that combines the usability of ag with the raw speed of grep"
 HOMEPAGE="https://github.com/BurntSushi/ripgrep"
@@ -80,7 +80,7 @@ SRC_URI="https://github.com/BurntSushi/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="Apache-2.0 BSD-2 Boost-1.0 || ( MIT Unlicense )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
-IUSE="+man pcre"
+IUSE="+man pcre bash-completion fish-completion zsh-completion"
 
 DEPEND=""
 
@@ -112,13 +112,20 @@ src_install() {
 	    doman "${BUILD_DIR}"/rg.1
 	fi
 
-	newbashcomp "${BUILD_DIR}"/rg.bash rg
+	if use bash-completion ; then
+		inherit bash-completion-r1
+		newbashcomp "${BUILD_DIR}"/rg.bash rg
+	fi
 
-	insinto /usr/share/fish/vendor_completions.d
-	doins "${BUILD_DIR}"/rg.fish
+	if use fish-completion ; then
+		insinto /usr/share/fish/vendor_completions.d
+		doins "${BUILD_DIR}"/rg.fish
+	fi
 
-	insinto /usr/share/zsh/site-functions
-	doins complete/_rg
+	if use zsh-completion ; then
+		insinto /usr/share/zsh/site-functions
+		doins complete/_rg
+	fi
 
 	dodoc CHANGELOG.md FAQ.md GUIDE.md README.md
 }

--- a/sys-apps/ripgrep/ripgrep-12.1.0.ebuild
+++ b/sys-apps/ripgrep/ripgrep-12.1.0.ebuild
@@ -71,7 +71,7 @@ winapi-util-0.1.5
 winapi-x86_64-pc-windows-gnu-0.4.0
 "
 
-inherit cargo bash-completion-r1
+inherit cargo
 
 DESCRIPTION="a search tool that combines the usability of ag with the raw speed of grep"
 HOMEPAGE="https://github.com/BurntSushi/ripgrep"
@@ -82,7 +82,7 @@ SRC_URI="https://github.com/BurntSushi/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="Apache-2.0 BSD-2 Boost-1.0 || ( MIT Unlicense )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
-IUSE="pcre"
+IUSE="pcre bash-completion fish-completion zsh-completion"
 
 DEPEND=""
 
@@ -109,13 +109,20 @@ src_install() {
 	# so grab fist match only
 	local BUILD_DIR="$(dirname $(find target/release -name ripgrep-stamp -print -quit))"
 
-	newbashcomp "${BUILD_DIR}"/rg.bash rg
+	if use bash-completion ; then
+		inherit bash-completion-r1
+		newbashcomp "${BUILD_DIR}"/rg.bash rg
+	fi
 
-	insinto /usr/share/fish/vendor_completions.d
-	doins "${BUILD_DIR}"/rg.fish
+	if use fish-completion ; then
+		insinto /usr/share/fish/vendor_completions.d
+		doins "${BUILD_DIR}"/rg.fish
+	fi
 
-	insinto /usr/share/zsh/site-functions
-	doins complete/_rg
+	if use zsh-completion ; then
+		insinto /usr/share/zsh/site-functions
+		doins complete/_rg
+	fi
 
 	dodoc CHANGELOG.md FAQ.md GUIDE.md README.md
 


### PR DESCRIPTION
The `ripgrep` ebuild was installing all shell completions regardless of which USE flags were set by the user. This patch fixes that.