### PR TITLE
net-misc/x11-ssh-askpass: change upstream url, sort dependencies

### DIFF
--- a/net-misc/x11-ssh-askpass/x11-ssh-askpass-1.2.4.1-r2.ebuild
+++ b/net-misc/x11-ssh-askpass/x11-ssh-askpass-1.2.4.1-r2.ebuild
@@ -6,9 +6,8 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="X11-based passphrase dialog for use with OpenSSH"
-HOMEPAGE="http://www.liquidmeme.net/software/x11-ssh-askpass
-	https://github.com/sigmavirus24/x11-ssh-askpass"
-SRC_URI="http://www.liquidmeme.net/software/x11-ssh-askpass/${P}.tar.gz"
+HOMEPAGE="https://github.com/sigmavirus24/x11-ssh-askpass"
+SRC_URI="https://github.com/sigmavirus24/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="HPND"
 SLOT="0"
@@ -16,16 +15,16 @@ KEYWORDS="~alpha amd64 ~arm64 ~ia64 ppc ~ppc64 sparc x86"
 IUSE=""
 
 RDEPEND="virtual/ssh
-	x11-libs/libXt
-	x11-libs/libX11
+	x11-libs/libICE
 	x11-libs/libSM
-	x11-libs/libICE"
+	x11-libs/libX11
+	x11-libs/libXt"
 DEPEND="${RDEPEND}"
-BDEPEND="x11-misc/imake
-	app-text/rman"
+BDEPEND="app-text/rman
+	x11-misc/imake"
 
 src_configure() {
-	econf --libexecdir=/usr/$(get_libdir)/misc \
+	econf --libexecdir=/usr/"$(get_libdir)"/misc \
 		--disable-installing-app-defaults
 	xmkmf || die "xmkmf failed"
 }


### PR DESCRIPTION
Upstream (http://www.liquidmeme.net/software/x11-ssh-askpass) is dead, replacing it by github url.


Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Vladimir Pavljuchenkov <spiderx@spiderx.dp.ua>