### PR TITLE
media-sound/picard: add missing dev-python/python-discid dependency

### DIFF
--- a/media-sound/picard/metadata.xml
+++ b/media-sound/picard/metadata.xml
@@ -10,4 +10,7 @@
 		tagger for MusicBrainz, with a focus on album oriented tagging as opposed to
 		track based tagging and cross platform compatibility.
 	</longdescription>
+	<use>
+		<flag name="discid">Enable reading the ID of the inserted CD</flag>
+	</use>
 </pkgmetadata>

--- a/media-sound/picard/picard-2.3.1-r1.ebuild
+++ b/media-sound/picard/picard-2.3.1-r1.ebuild
@@ -15,12 +15,13 @@ SRC_URI="https://musicbrainz.osuosl.org/pub/musicbrainz/${PN}/${P}.tar.gz"
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="nls"
+IUSE="discid nls"
 
 RDEPEND="
 	$(python_gen_cond_dep '
 		dev-python/PyQt5[declarative,gui,network,widgets,${PYTHON_MULTI_USEDEP}]
 	')
+	discid? ( dev-python/python-discid )
 	dev-qt/qtgui:5
 	>=media-libs/mutagen-1.38"
 DEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/718618
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Florian Schmaus <flo@geekplace.eu>