### PR TITLE
net-misc/electron-cash: add missing desktop inherit

### DIFF
--- a/net-misc/electron-cash/electron-cash-4.0.2-r2.ebuild
+++ b/net-misc/electron-cash/electron-cash-4.0.2-r2.ebuild
@@ -6,7 +6,7 @@ EAPI="7"
 PYTHON_COMPAT=( python3_6 python3_7 )
 PYTHON_REQ_USE="ncurses?"
 
-inherit distutils-r1 gnome2-utils xdg-utils
+inherit desktop distutils-r1 gnome2-utils xdg-utils
 
 MY_P="Electron-Cash-${PV}"
 DESCRIPTION="Lightweight Bitcoin Cash client (BCH fork of Electrum)"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi
The ebuild is calling `doicon` but doesn't inherit the `desktop` eclass, which is why you get a QA Warning when installing the ebuild:
```
 * QA Notice: command not found:
 * 
 *      /var/tmp/portage/net-misc/electron-cash-4.0.2-r2/temp/environment: line 3428: doicon: command not found
```
I've added the eclass, which fixes the issue.