### PR TITLE
dev-util/rt-tests: Allow to use different compilers

### DIFF
--- a/dev-util/rt-tests/rt-tests-1.8.ebuild
+++ b/dev-util/rt-tests/rt-tests-1.8.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6..8} )
 
-inherit python-single-r1
+inherit python-single-r1 toolchain-funcs
 
 DESCRIPTION="A collection of latency testing tools for the linux(-rt) kernel"
 HOMEPAGE="https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/about/"
@@ -25,6 +25,10 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	default
 	use elibc_musl && eapply "${FILESDIR}/${P}-musl.patch"
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" AR="$(tc-getAR)"
 }
 
 src_install() {


### PR DESCRIPTION
Currently CC and AR are hardcoded to gcc/ar. Allow compilation e.g. with clang.

Closes: https://bugs.gentoo.org/724246
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Kurt Kanzenbach <kurt@kmk-computers.de>