### PR TITLE
sci-mathematics/gimps: add RESTRICTs due to license

### DIFF
--- a/sci-mathematics/gimps/gimps-29.8.6-r1.ebuild
+++ b/sci-mathematics/gimps/gimps-29.8.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,6 +20,7 @@ SRC_URI="
 
 SLOT="0"
 LICENSE="GIMPS"
+RESTRICT="mirror bindist"
 KEYWORDS="-* amd64 x86"
 
 # Since there are no statically linked binaries for this version of mprime,


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/725402
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>
Package-Manager: Portage-2.3.99, Repoman-2.3.22