### PR TITLE
dev-games/aseprite: add missing xdg-utils inherit

### DIFF
--- a/dev-games/aseprite/aseprite-1.1.7-r1.ebuild
+++ b/dev-games/aseprite/aseprite-1.1.7-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake desktop flag-o-matic
+inherit cmake desktop flag-o-matic xdg-utils
 
 DESCRIPTION="Animated sprite editor & pixel art tool"
 HOMEPAGE="https://www.aseprite.org"

--- a/dev-games/aseprite/aseprite-1.1.9.ebuild
+++ b/dev-games/aseprite/aseprite-1.1.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake desktop flag-o-matic
+inherit cmake desktop flag-o-matic xdg-utils
 
 DESCRIPTION="Animated sprite editor & pixel art tool"
 HOMEPAGE="https://www.aseprite.org"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,

both versions 1.1.7 and 1.1.9 are calling `xdg_*` functions from the `xdg-utils` eclass both doesn't inherit the eclass. (it works because it gets indirectly inherited by `cmake`). I've updated the ebuild and added the eclass to the inherit.