### PR TITLE
sys-fabric/libmlx5: Bug 686100

### DIFF
--- a/sys-fabric/libmlx5/libmlx5-1.0.1-r1.ebuild
+++ b/sys-fabric/libmlx5/libmlx5-1.0.1-r1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+OFED_VER="3.12"
+OFED_RC="1"
+OFED_RC_VER="1"
+OFED_SUFFIX="1"
+
+inherit openib
+
+DESCRIPTION="OpenIB userspace driver for Mellanox ConnectIB HCA"
+KEYWORDS="~amd64 ~x86 ~amd64-linux"
+IUSE=""
+
+DEPEND="
+	sys-fabric/libibverbs:${SLOT}
+	"
+RDEPEND="
+		!sys-fabric/openib-userspace"
+block_other_ofed_versions

--- a/sys-fabric/libmlx5/libmlx5-1.0.1-r1.ebuild
+++ b/sys-fabric/libmlx5/libmlx5-1.0.1-r1.ebuild
@@ -20,3 +20,9 @@ DEPEND="
 RDEPEND="
 		!sys-fabric/openib-userspace"
 block_other_ofed_versions
+
+src_prepare() {
+	default
+
+	sed -i -e '/CFLAGS=\"$CFLAGS -Werror\"/d' configure
+}


### PR DESCRIPTION
`-Werror` triggers an unnecessary build failure when `strncpy` copies the same number of bytes from source as the destination's capacity.

- **sys-fabric/libmlx5: Bump to EAPI 6**
EAPI 5 is deprecated and openib.eclass is unready for EAPI 7

- **sys-fabric/libmlx5: Don't emit -Werror**
sed out the offending line that adds -Werror to CFLAGS

Closes: https://bugs.gentoo.org/686100
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Peter Levine <plevine457@gmail.com>