### PR TITLE
media-gfx/tachyon: fix build without mpi use flag

### DIFF
--- a/media-gfx/tachyon/tachyon-0.99_beta6-r2.ebuild
+++ b/media-gfx/tachyon/tachyon-0.99_beta6-r2.ebuild
@@ -58,7 +58,7 @@ src_prepare() {
 
 	LIBSLINE='"'
 	CFLAGSLINE='"'
-	use mpi || CCLINE='"CC = $(tc-getCC)"'
+	use mpi || CCLINE='"CC = '$(tc-getCC)'"'
 	use mpi && CCLINE='"CC = mpicc"'
 	LIBSLINE+="LIBS = -L. -ltachyon \$(MISCLIB) -lm"
 	CFLAGSLINE+="CFLAGS = -DLinux \$(MISCFLAGS)"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/725462
Signed-off-by: Gergely Nagy <ngg@ngg.hu>