### PR TITLE
sys-cluster/hpx: Fix compilation against boost-1.73

### DIFF
--- a/sys-cluster/hpx/files/hpx-1.4.1-placeholder.patch
+++ b/sys-cluster/hpx/files/hpx-1.4.1-placeholder.patch
@@ -1,0 +1,79 @@
+From 6bdbb6a3ad6ea57c46e9998e9efd46f86f5d5729 Mon Sep 17 00:00:00 2001
+From: Hartmut Kaiser <hartmut.kaiser@gmail.com>
+Date: Tue, 28 Apr 2020 09:52:08 -0500
+Subject: [PATCH] Adding missing using placeholder::_X
+
+- flyby remove unneeded using statements
+
+(cherry picked from commit 1a6882195f9dc8d333ad12898fb88e3ca2931022)
+Signed-off-by: Kurt Kanzenbach <kurt@kmk-computers.de>
+---
+ src/performance_counters/registry.cpp                         | 3 ---
+ src/runtime/agas/addressing_service.cpp                       | 3 ++-
+ tests/performance/network/network_storage/network_storage.cpp | 1 -
+ 3 files changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/src/performance_counters/registry.cpp b/src/performance_counters/registry.cpp
+index 34c8d0e71d55..8da91f379a72 100644
+--- a/src/performance_counters/registry.cpp
++++ b/src/performance_counters/registry.cpp
+@@ -378,7 +378,6 @@ namespace hpx { namespace performance_counters
+     counter_status registry::create_raw_counter_value(counter_info const& info,
+         std::int64_t* countervalue, naming::gid_type& id, error_code& ec)
+     {
+-        using util::placeholders::_1;
+         hpx::util::function_nonser<std::int64_t(bool)> func(
+             util::bind_front(wrap_counter, countervalue));
+         return create_raw_counter(info, func, id, ec);
+@@ -401,7 +400,6 @@ namespace hpx { namespace performance_counters
+         hpx::util::function_nonser<std::int64_t()> const& f, naming::gid_type& id,
+         error_code& ec)
+     {
+-        using util::placeholders::_1;
+         hpx::util::function_nonser<std::int64_t(bool)> func(
+             util::bind_front(&wrap_raw_counter, f));
+         return create_raw_counter(info, func, id, ec);
+@@ -465,7 +463,6 @@ namespace hpx { namespace performance_counters
+         hpx::util::function_nonser<std::vector<std::int64_t>()> const& f,
+         naming::gid_type& id, error_code& ec)
+     {
+-        using util::placeholders::_1;
+         hpx::util::function_nonser<std::vector<std::int64_t>(bool)> func(
+             util::bind_front(&wrap_raw_values_counter, f));
+         return create_raw_counter(info, func, id, ec);
+diff --git a/src/runtime/agas/addressing_service.cpp b/src/runtime/agas/addressing_service.cpp
+index f30760c0e05e..b416a28d12d8 100644
+--- a/src/runtime/agas/addressing_service.cpp
++++ b/src/runtime/agas/addressing_service.cpp
+@@ -1864,7 +1864,6 @@ future<hpx::id_type> addressing_service::on_symbol_namespace_event(
+     hpx::future<bool> f =
+         symbol_ns_.on_event(name, call_for_past_events, p.get_id());
+ 
+-    using util::placeholders::_1;
+     return f.then(
+         hpx::launch::sync,
+         util::one_shot(util::bind_back(
+@@ -2356,6 +2355,8 @@ void addressing_service::register_counter_types()
+         util::bind_front(
+             &addressing_service::get_cache_erase_entry_time, this));
+ 
++    using util::placeholders::_1;
++    using util::placeholders::_2;
+     performance_counters::generic_counter_type_data const counter_types[] =
+     {
+         { "/agas/count/cache/entries", performance_counters::counter_raw,
+diff --git a/tests/performance/network/network_storage/network_storage.cpp b/tests/performance/network/network_storage/network_storage.cpp
+index 33fc1a66afa4..dfcffbafb180 100644
+--- a/tests/performance/network/network_storage/network_storage.cpp
++++ b/tests/performance/network/network_storage/network_storage.cpp
+@@ -802,7 +802,6 @@ void test_read(
+                 ++FuturesWaiting[send_rank];
+                 std::lock_guard<hpx::lcos::local::spinlock> lk(FuturesMutex);
+ #endif
+-                using hpx::util::placeholders::_1;
+                 std::size_t buffer_address =
+                     reinterpret_cast<std::size_t>(general_buffer.data());
+                 //
+-- 
+2.26.2
+

--- a/sys-cluster/hpx/hpx-1.4.1.ebuild
+++ b/sys-cluster/hpx/hpx-1.4.1.ebuild
@@ -55,6 +55,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${FILESDIR}/${P}-boost.patch"
 	"${FILESDIR}/${P}-disable-failing-tests.patch"
+	"${FILESDIR}/${P}-placeholder.patch"
 	"${FILESDIR}/${P}-python.patch"
 )
 


### PR DESCRIPTION
This has been fixed upstream already. Adding the patch.

Closes: https://bugs.gentoo.org/725774
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Kurt Kanzenbach <kurt@kmk-computers.de>