### PR TITLE
x11-wm/i3: Stabilize amd for 4.17.1

### DIFF
--- a/x11-wm/i3/i3-4.17.1-r1.ebuild
+++ b/x11-wm/i3/i3-4.17.1-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://i3wm.org/downloads/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="amd64 ~arm64 ~x86"
 IUSE="doc debug test"
 
 CDEPEND="dev-libs/libev


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/725936
Package-Manager: Portage-2.3.100, Repoman-2.3.22
Signed-off-by: Nelo-T. Wallus <nelo@wallus.de>