### PR TITLE
dev-util/trinity: upstream patches

### DIFF
--- a/dev-util/trinity/files/trinity-1.9-gcc10_fix.patch
+++ b/dev-util/trinity/files/trinity-1.9-gcc10_fix.patch
@@ -1,0 +1,34 @@
+From e53e25cc8dd5bdb5f7d9b4247de9e9921eec81d8 Mon Sep 17 00:00:00 2001
+From: Vinson Lee <vlee@freedesktop.org>
+Date: Thu, 30 Jan 2020 22:09:45 -0800
+Subject: [PATCH] Fix build with GCC 10.
+
+  CC	trinity
+/usr/bin/ld: debug.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
+/usr/bin/ld: log-files.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
+/usr/bin/ld: log.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
+/usr/bin/ld: main.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
+/usr/bin/ld: output.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
+/usr/bin/ld: params.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
+/usr/bin/ld: shm.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
+/usr/bin/ld: trinity.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
+
+Fixes: 13856316c259 ("reinstate the log-to-file code for now.")
+Signed-off-by: Vinson Lee <vlee@freedesktop.org>
+---
+ include/logfile.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/logfile.h b/include/logfile.h
+index 90ea8b23..2305ac15 100644
+--- a/include/logfile.h
++++ b/include/logfile.h
+@@ -5,7 +5,7 @@
+ FILE *find_logfile_handle(void);
+ void synclogs(void);
+ 
+-FILE *mainlogfile;
++extern FILE *mainlogfile;
+ void open_main_logfile(void);
+ void close_logfile(FILE **handle);
+ 

--- a/dev-util/trinity/files/trinity-1.9-include_types_h.patch
+++ b/dev-util/trinity/files/trinity-1.9-include_types_h.patch
@@ -1,0 +1,33 @@
+From 45fdc97620063be4318b9b361482fa1b5463e1d5 Mon Sep 17 00:00:00 2001
+From: Jiri Slaby <jslaby@suse.cz>
+Date: Mon, 18 Nov 2019 10:14:55 +0100
+Subject: [PATCH] modify_ldt: include linux/types.h before ASSEMBLY == 1
+
+Otherwise we see a lot of:
+In file included from /usr/include/bits/statx.h:30,
+                 from /usr/include/sys/stat.h:446,
+                 from include/files.h:3,
+                 from include/shm.h:6,
+                 from syscalls/x86/modify_ldt.c:12:
+/usr/include/linux/stat.h:57:2: error: unknown type name '__s64'
+   57 |  __s64 tv_sec;
+      |  ^~~~~
+/usr/include/linux/stat.h:58:2: error: unknown type name '__u32'
+   58 |  __u32 tv_nsec;
+      |  ^~~~~
+---
+ syscalls/x86/modify_ldt.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/syscalls/x86/modify_ldt.c b/syscalls/x86/modify_ldt.c
+index f2eaf065..0221561a 100644
+--- a/syscalls/x86/modify_ldt.c
++++ b/syscalls/x86/modify_ldt.c
+@@ -6,6 +6,7 @@
+  */
+ #include <stdlib.h>
+ #include <sys/types.h>
++#include <linux/types.h> /* before __ASSEMBLY__ == 1 */
+ #define __ASSEMBLY__ 1
+ #include <asm/ldt.h>
+ #include "sanitise.h"

--- a/dev-util/trinity/trinity-1.9.ebuild
+++ b/dev-util/trinity/trinity-1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,6 +17,11 @@ IUSE="examples"
 DEPEND="
 	>=sys-kernel/linux-headers-4.8
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}-gcc10_fix.patch"
+	"${FILESDIR}/${P}-include_types_h.patch"
+)
 
 src_prepare() {
 	sed -e 's/-g -O2//' \


### PR DESCRIPTION
Added upstream patches that fixes compilation of package.
Closes: https://bugs.gentoo.org/691890
Closes: https://bugs.gentoo.org/713640
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>