### PR TITLE
mail-filter/spamassassin: Remove Marcin Mirosław

### DIFF
--- a/mail-filter/spamassassin/metadata.xml
+++ b/mail-filter/spamassassin/metadata.xml
@@ -6,11 +6,6 @@
     <name>Philippe Chaintreuil</name>
   </maintainer>
 
-  <maintainer type="person">
-    <email>bug@mejor.pl</email>
-    <name>Marcin Mirosław</name>
-  </maintainer>
-
   <maintainer type="project">
     <email>proxy-maint@gentoo.org</email>
     <name>Proxy Maintainers</name>


### PR DESCRIPTION
Remove Marcin Mirosław from proxy maintainer list as per his request in
https://bugs.gentoo.org/583908#c8

Bug: https://bugs.gentoo.org/583908
Bug: https://bugs.gentoo.org/586388
Closes: https://github.com/gentoo/gentoo/pull/16009
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Philippe Chaintreuil <gentoo_bugs_peep@parallaxshift.com>