### PR TITLE
media-libs/vulkan-loader: add missing flag-o-matic inherit

### DIFF
--- a/media-libs/vulkan-loader/vulkan-loader-1.1.125-r1.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.1.125-r1.ebuild
@@ -21,7 +21,7 @@ else
 	S="${WORKDIR}"/${MY_P}
 fi
 
-inherit toolchain-funcs python-any-r1 cmake-multilib
+inherit flag-o-matic toolchain-funcs python-any-r1 cmake-multilib
 
 DESCRIPTION="Vulkan Installable Client Driver (ICD) Loader"
 HOMEPAGE="https://github.com/KhronosGroup/Vulkan-Loader"

--- a/media-libs/vulkan-loader/vulkan-loader-1.2.133.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.2.133.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 MY_PN=Vulkan-Loader
 CMAKE_ECLASS="cmake"
 PYTHON_COMPAT=( python3_{6,7,8} )
-inherit cmake-multilib python-any-r1 toolchain-funcs
+inherit flag-o-matic cmake-multilib python-any-r1 toolchain-funcs
 
 if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/KhronosGroup/${MY_PN}.git"

--- a/media-libs/vulkan-loader/vulkan-loader-1.2.135.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.2.135.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 MY_PN=Vulkan-Loader
 CMAKE_ECLASS="cmake"
 PYTHON_COMPAT=( python3_{6,7,8} )
-inherit cmake-multilib python-any-r1 toolchain-funcs
+inherit flag-o-matic cmake-multilib python-any-r1 toolchain-funcs
 
 if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/KhronosGroup/${MY_PN}.git"

--- a/media-libs/vulkan-loader/vulkan-loader-1.2.137.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.2.137.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 MY_PN=Vulkan-Loader
 CMAKE_ECLASS="cmake"
 PYTHON_COMPAT=( python3_{6,7,8} )
-inherit cmake-multilib python-any-r1 toolchain-funcs
+inherit flag-o-matic cmake-multilib python-any-r1 toolchain-funcs
 
 if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/KhronosGroup/${MY_PN}.git"

--- a/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 MY_PN=Vulkan-Loader
 CMAKE_ECLASS="cmake"
 PYTHON_COMPAT=( python3_{6,7,8} )
-inherit cmake-multilib python-any-r1 toolchain-funcs
+inherit flag-o-matic cmake-multilib python-any-r1 toolchain-funcs
 
 if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/KhronosGroup/${MY_PN}.git"


### PR DESCRIPTION
Package-Manager: Portage-2.3.100, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi

All ebuilds are calling `append-cflags` from the `flag-o-matic` eclass but they don't inherit the eclass. I've fixed the ebuilds and added the `flag-o-matic` eclass. (it still worked because it got indirectly inherited)
