### PR TITLE
net-wireless/broadcom-sta: linux 5.6 support

### DIFF
--- a/net-wireless/broadcom-sta/broadcom-sta-6.30.223.271-r5.ebuild
+++ b/net-wireless/broadcom-sta/broadcom-sta-6.30.223.271-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -84,6 +84,7 @@ PATCHES=(
 		"${FILESDIR}/${PN}-6.30.223.271-r4-linux-4.12.patch"
 		"${FILESDIR}/${PN}-6.30.223.271-r4-linux-4.15.patch"
 		"${FILESDIR}/${PN}-6.30.223.271-r5-linux-5.1.patch"
+		"${FILESDIR}/${PN}-6.30.223.271-r5-linux-5.6.patch"
 )
 
 src_install() {

--- a/net-wireless/broadcom-sta/files/broadcom-sta-6.30.223.271-r5-linux-5.6.patch
+++ b/net-wireless/broadcom-sta/files/broadcom-sta-6.30.223.271-r5-linux-5.6.patch
@@ -1,0 +1,90 @@
+From dd057e40a167f4febb1a7c77dd32b7d36056952c Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Tue, 31 Mar 2020 17:09:55 +0200
+Subject: [PATCH] Add fixes for 5.6 kernel
+
+Use ioremap instead of ioremap_nocache and proc_ops instead of file_operations on Linux kernel 5.6 and above.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ amd64/src/shared/linux_osl.c |  6 +++++-
+ amd64/src/wl/sys/wl_linux.c  | 21 ++++++++++++++++++++-
+ 2 files changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/amd64/src/shared/linux_osl.c b/amd64/src/shared/linux_osl.c
+index 6157d18..dcfc075 100644
+--- a/src/shared/linux_osl.c
++++ b/src/shared/linux_osl.c
+@@ -942,7 +942,11 @@ osl_getcycles(void)
+ void *
+ osl_reg_map(uint32 pa, uint size)
+ {
+-	return (ioremap_nocache((unsigned long)pa, (unsigned long)size));
++	#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++		return (ioremap((unsigned long)pa, (unsigned long)size));
++	#else
++		return (ioremap_nocache((unsigned long)pa, (unsigned long)size));
++	#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) */
+ }
+ 
+ void
+diff --git a/amd64/src/wl/sys/wl_linux.c b/amd64/src/wl/sys/wl_linux.c
+index 0d05100..6d9dd0d 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -582,10 +582,17 @@ wl_attach(uint16 vendor, uint16 device, ulong regs,
+ 	}
+ 	wl->bcm_bustype = bustype;
+ 
++	#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++	if ((wl->regsva = ioremap(dev->base_addr, PCI_BAR0_WINSZ)) == NULL) {
++		WL_ERROR(("wl%d: ioremap() failed\n", unit));
++		goto fail;
++	}
++	#else 
+ 	if ((wl->regsva = ioremap_nocache(dev->base_addr, PCI_BAR0_WINSZ)) == NULL) {
+ 		WL_ERROR(("wl%d: ioremap() failed\n", unit));
+ 		goto fail;
+ 	}
++	#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) */
+ 
+ 	wl->bar1_addr = bar1_addr;
+ 	wl->bar1_size = bar1_size;
+@@ -772,8 +779,13 @@ wl_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 	if ((val & 0x0000ff00) != 0)
+ 		pci_write_config_dword(pdev, 0x40, val & 0xffff00ff);
+ 		bar1_size = pci_resource_len(pdev, 2);
++		#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++		bar1_addr = (uchar *)ioremap(pci_resource_start(pdev, 2),
++			bar1_size);
++		#else
+ 		bar1_addr = (uchar *)ioremap_nocache(pci_resource_start(pdev, 2),
+ 			bar1_size);
++		#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) */
+ 	wl = wl_attach(pdev->vendor, pdev->device, pci_resource_start(pdev, 0), PCI_BUS, pdev,
+ 		pdev->irq, bar1_addr, bar1_size);
+ 
+@@ -3335,12 +3347,19 @@ wl_proc_write(struct file *filp, const char __user *buff, size_t length, loff_t
+ }
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
++static const struct proc_ops wl_fops = {
++	.proc_read	= wl_proc_read,
++	.proc_write	= wl_proc_write,
++};
++#else
+ static const struct file_operations wl_fops = {
+ 	.owner	= THIS_MODULE,
+ 	.read	= wl_proc_read,
+ 	.write	= wl_proc_write,
+ };
+-#endif
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) */
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0) */
+ 
+ static int
+ wl_reg_proc_entry(wl_info_t *wl)
+-- 
+2.17.1.windows.1
+


### PR DESCRIPTION
Added patch that resolves compilation error described in #717320.

Closes: https://bugs.gentoo.org/717320
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>