### PR TITLE
dev-python/jedi: correct parso dependency

### DIFF
--- a/dev-python/jedi/jedi-0.17.0-r1.ebuild
+++ b/dev-python/jedi/jedi-0.17.0-r1.ebuild
@@ -23,7 +23,7 @@ LICENSE="MIT
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 
-RDEPEND=">=dev-python/parso-0.5.2[${PYTHON_USEDEP}]"
+RDEPEND=">=dev-python/parso-0.7.0[${PYTHON_USEDEP}]"
 
 distutils_enable_sphinx docs
 distutils_enable_tests pytest


### PR DESCRIPTION
Jedi 0.17.0 requires parso >= 0.7.0.

Closes: https://bugs.gentoo.org/725984
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Florian Schmaus <flo@geekplace.eu>