### PR TITLE
media-libs/mesa: Add device select vulkan layer

### DIFF
--- a/media-libs/mesa/mesa-20.1.0.ebuild
+++ b/media-libs/mesa/mesa-20.1.0.ebuild
@@ -504,6 +504,7 @@ multilib_src_configure() {
 		-Ddri-drivers=$(driver_list "${DRI_DRIVERS[*]}")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
+		$(meson_use vulkan vulkan-device-select-layer)
 		$(meson_use vulkan-overlay vulkan-overlay-layer)
 		--buildtype $(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)

--- a/media-libs/mesa/mesa-20.1.0_rc4.ebuild
+++ b/media-libs/mesa/mesa-20.1.0_rc4.ebuild
@@ -504,6 +504,7 @@ multilib_src_configure() {
 		-Ddri-drivers=$(driver_list "${DRI_DRIVERS[*]}")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
+		$(meson_use vulkan vulkan-device-select-layer)
 		$(meson_use vulkan-overlay vulkan-overlay-layer)
 		--buildtype $(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -504,6 +504,7 @@ multilib_src_configure() {
 		-Ddri-drivers=$(driver_list "${DRI_DRIVERS[*]}")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
+		$(meson_use vulkan vulkan-device-select-layer)
 		$(meson_use vulkan-overlay vulkan-overlay-layer)
 		--buildtype $(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)


### PR DESCRIPTION
This enables the device select vulkan layer which allows users to
control which graphics card is used in multigraphics setup

The current rules are to use a new MESA_VK_DEVICE_SELECT env var above
all else, if that isn't set then it checks DRI_PRIME, which tries to match
against the fd from DRI3

I've been running with this locally since the feature was added, but
forgot to submit a pull request sooner

I don't think this requires an extra use-flag, as it doesn't require any
external dependicies and there's no benefit to disabling this feature on
single card systems, this just extends the DRI_PRIME option to vulkan

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>

Let me know if you'd like these rev bumped