### PR TITLE
x11-apps/igt-gpu-tools: Fix USE flags dependency

### DIFF
--- a/x11-apps/igt-gpu-tools/igt-gpu-tools-1.25.ebuild
+++ b/x11-apps/igt-gpu-tools/igt-gpu-tools-1.25.ebuild
@@ -20,13 +20,14 @@ else
 fi
 LICENSE="MIT"
 SLOT="0"
-IUSE="chamelium doc man overlay runner unwind valgrind video_cards_amdgpu video_cards_intel video_cards_nouveau X xv"
+IUSE="chamelium doc man overlay runner tests unwind valgrind video_cards_amdgpu video_cards_intel video_cards_nouveau X xv"
 REQUIRED_USE="
 	|| ( video_cards_amdgpu video_cards_intel video_cards_nouveau )
 	overlay? (
 		video_cards_intel
 		|| ( X xv )
 	)
+	doc? ( tests )
 "
 RESTRICT="test"
 
@@ -93,7 +94,7 @@ src_configure() {
 		$(meson_feature man)
 		$(meson_feature overlay)
 		$(meson_feature runner)
-		$(meson_feature doc tests) # Test build is required for docs
+		$(meson_feature tests)
 		$(meson_feature valgrind)
 		$(meson_feature unwind libunwind)
 		-Doverlay_backends=${overlay_backends%?}

--- a/x11-apps/igt-gpu-tools/metadata.xml
+++ b/x11-apps/igt-gpu-tools/metadata.xml
@@ -10,6 +10,7 @@
  <flag name="man">Build and install man pages</flag>
  <flag name="overlay">Build the intel-gpu-overlay utility</flag>
  <flag name="runner">Build the test runner</flag>
+ <flag name="tests">Build the tests</flag>
  <flag name="valgrind">Support valgrind annotations</flag>
  <flag name="xv">Enable intel-gpu-overlay xv backend</flag>
  <flag name="X">Enable intel-gpu-overlay xlib/cairo backend</flag>


### PR DESCRIPTION
Test build is required for docs. Express this in REQUIRED_USE,
and allow tests to be built without building docs.