### PR TITLE
Sci libs/vtk 8.2.0/fix dependencies

### DIFF
--- a/sci-libs/vtk/vtk-8.2.0.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0.ebuild
@@ -111,6 +111,7 @@ RDEPEND="
 		)
 	")
 	>=dev-cpp/eigen-3
+	dev-libs/double-conversion
 "
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen )"

--- a/sci-libs/vtk/vtk-8.2.0.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0.ebuild
@@ -112,6 +112,7 @@ RDEPEND="
 	")
 	>=dev-cpp/eigen-3
 	dev-libs/double-conversion
+	media-libs/glew:0
 "
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen )"

--- a/sci-libs/vtk/vtk-8.2.0.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0.ebuild
@@ -109,7 +109,9 @@ RDEPEND="
 			dev-qt/qtx11extras:5
 			python? ( dev-python/PyQt5[\${PYTHON_MULTI_USEDEP}] )
 		)
-	")"
+	")
+	>=dev-cpp/eigen-3
+"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen )"
 

--- a/sci-libs/vtk/vtk-8.2.0.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0.ebuild
@@ -114,6 +114,7 @@ RDEPEND="
 	dev-libs/double-conversion
 	media-libs/glew:0
 	dev-libs/pugixml
+	dev-db/sqlite
 "
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen )"

--- a/sci-libs/vtk/vtk-8.2.0.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0.ebuild
@@ -113,6 +113,7 @@ RDEPEND="
 	>=dev-cpp/eigen-3
 	dev-libs/double-conversion
 	media-libs/glew:0
+	dev-libs/pugixml
 "
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen )"


### PR DESCRIPTION
This adds the following missing dependencies for sci-libs/vtk-8.2.0:

   >=dev-cpp/eigen-3
   dev-libs/double-conversion
   media-libs/glew
   dev-libs/pugixml
   dev-db/sqlite

Signed-off-by: Rafael Palomar Ávalos rafael.palomar@rr-research.no