### PR TITLE
dev-libs/libdivecomputer: add USE=static-libs

### DIFF
--- a/dev-libs/libdivecomputer/libdivecomputer-0.6.0-r1.ebuild
+++ b/dev-libs/libdivecomputer/libdivecomputer-0.6.0-r1.ebuild
@@ -29,5 +29,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf $(use_with bluetooth bluez)
+	econf --disable-static $(use_with bluetooth bluez)
 }

--- a/dev-libs/libdivecomputer/libdivecomputer-9999.ebuild
+++ b/dev-libs/libdivecomputer/libdivecomputer-9999.ebuild
@@ -29,5 +29,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf $(use_with bluetooth bluez)
+	econf --disable-static $(use_with bluetooth bluez)
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/726966

Signed-off-by: Martin Gysel <me@bearsh.org>