### PR TITLE
sci-libs/scipy: -fallow-argument-mismatch for gfortran v10

### DIFF
--- a/sci-libs/scipy/scipy-1.4.1.ebuild
+++ b/sci-libs/scipy/scipy-1.4.1.ebuild
@@ -89,6 +89,9 @@ python_prepare_all() {
 	export SCIPY_FCONFIG="config_fc --noopt --noarch"
 	append-fflags -fPIC
 
+	# Remove once upstream PR #11842 lands into next release
+	append-fflags -fallow-argument-mismatch
+
 	local libdir="${EPREFIX}"/usr/$(get_libdir)
 	cat >> site.cfg <<-EOF || die
 		[blas]


### PR DESCRIPTION
Fixes errors with gfortran 10:

    Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)

Already fixed in upstream master:
https://github.com/scipy/scipy/pull/11842
https://github.com/scipy/scipy/issues/11611

FWIW, I also tried merging the https://github.com/scipy/scipy/pull/11842 commit 2190a7427 [1] into the 1.4.1 release (manually merged, because patch doesn't apply), but it doesn't fix the issue. The overridden build_ext methods in setup.py are not actually invoked. In any case, this PR with add-fflags is a much simpler approach.

[1] https://github.com/scipy/scipy/commit/2190a7427a8d10a3a506294e87ff1330c426cb63