### PR TITLE
sci-libs/mumps: -fallow-argument-mismatch for gcc v10

### DIFF
--- a/sci-libs/mumps/mumps-5.1.2.ebuild
+++ b/sci-libs/mumps/mumps-5.1.2.ebuild
@@ -52,6 +52,7 @@ static_to_shared() {
 }
 
 src_prepare() {
+	append-fflags -fallow-argument-mismatch
 	sed -e "s:^\(CC\s*=\).*:\1$(tc-getCC):" \
 		-e "s:^\(FC\s*=\).*:\1$(tc-getFC):" \
 		-e "s:^\(FL\s*=\).*:\1$(tc-getFC):" \


### PR DESCRIPTION
Fixes errors due to new fatala error introduced in gcc v10:

    Error: Type mismatch between actual argument at (1) and
    actual argument at (2) (INTEGER(8)/INTEGER(4)).

Closes: https://bugs.gentoo.org/727356

Signed-off-by: Alexei Colin <acolin@isi.edu>