### PR TITLE
sci-libs/scalapack: -fallow-argument-mismatch for gcc v10

### DIFF
--- a/sci-libs/scalapack/scalapack-2.1.0.ebuild
+++ b/sci-libs/scalapack/scalapack-2.1.0.ebuild
@@ -35,6 +35,7 @@ src_prepare() {
 }
 
 src_configure() {
+	append-fflags -fallow-argument-mismatch
 	scalapack_configure() {
 		local mycmakeargs=(
 			-DUSE_OPTIMIZED_LAPACK_BLAS=ON


### PR DESCRIPTION
Make new error introduced in gcc v10 nonfatal:

	Error: Rank mismatch between actual argument at (1) and actual argument
	at (2) (scalar and rank-1)

More info: https://gcc.gnu.org/gcc-10/porting_to.html

Closes: https://bugs.gentoo.org/727340

Signed-off-by: Alexei Colin <acolin@isi.edu>