### PR TITLE
media-gfx/graphicsmagick: Security bump

### DIFF
--- a/media-gfx/graphicsmagick/files/graphicsmagick-1.3.35-CVE-2020-12672.patch
+++ b/media-gfx/graphicsmagick/files/graphicsmagick-1.3.35-CVE-2020-12672.patch
@@ -1,0 +1,67 @@
+diff -r 4917a4242fc0 -r 50395430a371 coders/png.c
+--- a/coders/png.c	Fri May 01 13:49:13 2020 -0500
++++ b/coders/png.c	Sat May 30 10:18:16 2020 -0500
+@@ -5304,7 +5304,7 @@
+               if (logging)
+                 (void) LogMagickEvent(CoderEvent,GetMagickModule(),
+                                       "MAGN chunk (%lu bytes): "
+-                                      "First_magnified_object_id=%u, Last_magnified_object_id=%u, "
++                                      "First_magnified_object_id=%u, Las t_magnified_object_id=%u, "
+                                       "MB=%u, ML=%u, MR=%u, MT=%u, MX=%u, MY=%u, "
+                                       "X_method=%u, Y_method=%u",
+                                       length,
+@@ -5679,6 +5679,8 @@
+           /*
+             If magnifying and a supported method is requested then
+             magnify the image.
++
++            http://www.libpng.org/pub/mng/spec/mng-1.0-20010209-pdg.html#mng-MAGN
+           */
+           if (((mng_info->magn_methx > 0) && (mng_info->magn_methx <= 5)) &&
+               ((mng_info->magn_methy > 0) && (mng_info->magn_methy <= 5)))
+@@ -5689,7 +5691,28 @@
+ 
+               if (logging)
+                 (void) LogMagickEvent(CoderEvent,GetMagickModule(),
+-                                      "  Processing MNG MAGN chunk");
++                                      "  Processing MNG MAGN chunk: MB=%u, ML=%u,"
++                                      " MR=%u, MT=%u, MX=%u, MY=%u,"
++                                      " X_method=%u, Y_method=%u",
++                                      mng_info->magn_mb,mng_info->magn_ml,
++                                      mng_info->magn_mr,mng_info->magn_mt,
++                                      mng_info->magn_mx,mng_info->magn_my,
++                                      mng_info->magn_methx,
++                                      mng_info->magn_methy);
++
++              /*
++                If the image width is 1, then X magnification is done
++                by simple pixel replication.
++              */
++              if (image->columns == 1)
++                  mng_info->magn_methx = 1;
++
++              /*
++                If the image height is 1, then Y magnification is done
++                by simple pixel replication.
++              */
++              if (image->rows == 1)
++                  mng_info->magn_methy = 1;
+ 
+               if (mng_info->magn_methx == 1)
+                 {
+@@ -5734,12 +5757,10 @@
+                   Image
+                     *large_image;
+ 
+-                  int
+-                    yy;
+-
+                   long
+                     m,
+-                    y;
++                    y,
++                    yy;
+ 
+                   register long
+                     x;
+

--- a/media-gfx/graphicsmagick/files/graphicsmagick-1.3.35-oss-fuzz-20045-20318-21956.patch
+++ b/media-gfx/graphicsmagick/files/graphicsmagick-1.3.35-oss-fuzz-20045-20318-21956.patch
@@ -1,0 +1,38 @@
+diff -r 50395430a371 -r 83b4d2b4b873 coders/wpg.c
+--- a/coders/wpg.c	Sat May 30 10:18:16 2020 -0500
++++ b/coders/wpg.c	Sat May 30 17:33:51 2020 -0500
+@@ -403,7 +403,7 @@
+   x++; \
+   if((long) x>=ldblk) \
+   { \
+-    if(InsertRow(BImgBuff,y,image,bpp)==MagickFail) RetVal=-6; \
++    if(InsertRow(BImgBuff,y,image,bpp)==MagickFail) { RetVal=-6; goto unpack_wpg_raser_error; } \
+     x=0; \
+     y++; \
+     if(y>=image->rows) break; \
+@@ -537,6 +537,7 @@
+         }
+       }
+     }
++unpack_wpg_raser_error:;
+   MagickFreeMemory(BImgBuff);
+   return(RetVal);
+ }
+@@ -552,7 +553,7 @@
+   x++; \
+   if((long) x >= ldblk) \
+   { \
+-    if(InsertRow(BImgBuff,(long) y,image,bpp)==MagickFail) RetVal=-6; \
++    if(InsertRow(BImgBuff,(long) y,image,bpp)==MagickFail) { RetVal=-6; goto unpack_wpg2_error; } \
+     x=0; \
+     y++; \
+     XorMe = 0; \
+@@ -729,6 +730,7 @@
+             }
+         }
+     }
++unpack_wpg2_error:;
+   FreeUnpackWPG2RasterAllocs(BImgBuff,UpImgBuff);
+   return(RetVal);
+ }
+

--- a/media-gfx/graphicsmagick/files/graphicsmagick-1.3.35-oss-fuzz-23042.patch
+++ b/media-gfx/graphicsmagick/files/graphicsmagick-1.3.35-oss-fuzz-23042.patch
@@ -1,0 +1,42 @@
+diff -r 24ed4812e580 -r b0aa53a5f970 coders/wpg.c
+--- a/coders/wpg.c	Tue Jun 02 07:45:45 2020 -0500
++++ b/coders/wpg.c	Sat Jun 06 14:12:18 2020 -0500
+@@ -413,9 +413,12 @@
+ 
+ /** Call this function to ensure that all data matrix is filled with something. This function
+  * is used only to error recovery. */
+-static void ZeroFillMissingData(unsigned char *BImgBuff,unsigned long x, unsigned long y, Image *image,
+-                                int bpp, long ldblk)
++static MagickPassFail ZeroFillMissingData(unsigned char *BImgBuff,unsigned long x, unsigned long y, Image *image,
++                                          int bpp, long ldblk)
+ {
++  MagickPassFail
++    status = MagickPass;
++
+   while(y<image->rows && image->exception.severity!=UndefinedException)
+   {
+     if((long) x<ldblk) 
+@@ -427,9 +430,13 @@
+         x = 0;		/* Next pass will need to clear whole row */
+     }
+     if(InsertRow(BImgBuff,y,image,bpp) == MagickFail)
+-      break;
++      {
++        status = MagickFail;
++        break;
++      }
+     y++;
+   }
++  return status;
+ }
+ 
+ 
+@@ -528,7 +535,6 @@
+                 }
+               if(InsertRow(BImgBuff,y,image,bpp)==MagickFail)
+                 { 
+-                  ZeroFillMissingData(BImgBuff,x,y,image,bpp,ldblk);
+                   MagickFreeMemory(BImgBuff);
+                   return(-6);
+                 }
+

--- a/media-gfx/graphicsmagick/graphicsmagick-1.3.35-r1.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-1.3.35-r1.ebuild
@@ -1,0 +1,135 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit autotools toolchain-funcs
+
+MY_P=${P/graphicsm/GraphicsM}
+
+DESCRIPTION="Collection of tools and libraries for many image formats"
+HOMEPAGE="http://www.graphicsmagick.org/"
+LICENSE="MIT"
+SLOT="0/${PV%.*}"
+
+if [[ ${PV} == "9999" ]] ; then
+	inherit mercurial
+	EHG_REPO_URI="http://hg.code.sf.net/p/${PN}/code"
+else
+	SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+fi
+
+IUSE="bzip2 +cxx debug fpx imagemagick jbig jpeg lcms lzma modules openmp
+	perl png postscript q16 q32 static-libs svg threads tiff truetype
+	webp wmf X zlib"
+
+RDEPEND="dev-libs/libltdl:0
+	bzip2? ( app-arch/bzip2 )
+	fpx? ( media-libs/libfpx )
+	imagemagick? ( !media-gfx/imagemagick )
+	jbig? ( media-libs/jbigkit )
+	jpeg? ( virtual/jpeg:0 )
+	lcms? ( media-libs/lcms:2 )
+	lzma? ( app-arch/xz-utils )
+	perl? ( dev-lang/perl:= )
+	png? ( media-libs/libpng:0= )
+	postscript? ( app-text/ghostscript-gpl )
+	svg? ( dev-libs/libxml2 )
+	tiff? ( media-libs/tiff:0 )
+	truetype? (
+		media-fonts/urw-fonts
+		>=media-libs/freetype-2
+		)
+	webp? ( media-libs/libwebp:= )
+	wmf? ( media-libs/libwmf )
+	X? (
+		x11-libs/libSM
+		x11-libs/libXext
+		)
+	zlib? ( sys-libs/zlib )"
+DEPEND="${RDEPEND}"
+
+S=${WORKDIR}/${MY_P}
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.3.19-flags.patch
+	"${FILESDIR}"/${PN}-1.3.19-perl.patch
+	"${FILESDIR}"/${P}-CVE-2020-12672.patch
+	"${FILESDIR}"/${P}-oss-fuzz-20045-20318-21956.patch
+	"${FILESDIR}"/${P}-oss-fuzz-23042.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local depth=8
+	use q16 && depth=16
+	use q32 && depth=32
+
+	local openmp=disable
+	if use openmp && tc-has-openmp; then
+		openmp=enable
+	fi
+
+	local myeconfargs=(
+		--${openmp}-openmp
+		--enable-largefile
+		--enable-shared
+		$(use_enable static-libs static)
+		$(use_enable debug prof)
+		$(use_enable debug gcov)
+		$(use_enable imagemagick magick-compat)
+		$(use_with threads)
+		$(use_with modules)
+		--with-quantum-depth=${depth}
+		--without-frozenpaths
+		$(use_with cxx magick-plus-plus)
+		$(use_with perl)
+		--with-perl-options=INSTALLDIRS=vendor
+		$(use_with bzip2 bzlib)
+		$(use_with postscript dps)
+		$(use_with fpx)
+		$(use_with jbig)
+		$(use_with webp)
+		$(use_with jpeg)
+		--without-jp2
+		$(use_with lcms lcms2)
+		$(use_with lzma)
+		$(use_with png)
+		$(use_with tiff)
+		$(use_with truetype ttf)
+		$(use_with wmf)
+		--with-fontpath="${EPREFIX}"/usr/share/fonts
+		--with-gs-font-dir="${EPREFIX}"/usr/share/fonts/urw-fonts
+		--with-windows-font-dir="${EPREFIX}"/usr/share/fonts/corefonts
+		$(use_with svg xml)
+		$(use_with zlib)
+		$(use_with X x)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	default
+	use perl && emake perl-build
+}
+
+src_test() {
+	unset DISPLAY # some perl tests fail when DISPLAY is set
+	default
+}
+
+src_install() {
+	default
+
+	if use perl; then
+		emake -C PerlMagick DESTDIR="${D}" install
+		find "${ED}" -type f -name perllocal.pod -exec rm -f {} + || die
+		find "${ED}" -depth -mindepth 1 -type d -empty -exec rm -rf {} + || die
+	fi
+
+	find "${ED}" -name '*.la' -exec sed -i -e "/^dependency_libs/s:=.*:='':" {} + || die
+}


### PR DESCRIPTION
Patches the following:
* CVE-2020-12672
* oss-fuzz
** 20045
** 20318
** 21956
** 23042

Bug: https://bugs.gentoo.org/721328
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>