### PR TITLE
sys-apps/moreutils: Respect CC

### DIFF
--- a/sys-apps/moreutils/files/moreutils-0.63-respect-env.patch
+++ b/sys-apps/moreutils/files/moreutils-0.63-respect-env.patch
@@ -1,26 +1,14 @@
-From 6c88aaa6b828d7bd7c1dccb3b842594d48c1764c Mon Sep 17 00:00:00 2001
-From: Nicolas Schier <nicolas@fjasle.eu>
-Date: Wed, 27 Nov 2019 21:16:12 +0100
-Subject: is_utf8: allow propagation of compiler and linker flags
-
-Allow propagating compiler and linker flags via overrides of CFLAGS and
-LDFLAGS variables.  This allows enabling of hardening flags w/o
-modification of the original Makefile.
-
-Signed-off-by: Nicolas Schier <nicolas@fjasle.eu>
----
- is_utf8/Makefile | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
 diff --git a/is_utf8/Makefile b/is_utf8/Makefile
-index 4ebf8be..13b1021 100644
+index 4ebf8be..f0a111e 100644
 --- a/is_utf8/Makefile
 +++ b/is_utf8/Makefile
-@@ -38,13 +38,13 @@ SONAME = $(LINKERNAME).$(VERSION)
+@@ -37,14 +37,14 @@ LINKERNAME = lib$(NAME).so
+ SONAME = $(LINKERNAME).$(VERSION)
  REALNAME = $(SONAME).$(MINOR).$(RELEASE)
  
- CC = gcc
+-CC = gcc
 -CFLAGS = -O3 -Wextra -Wall -ansi -Wstrict-prototypes
++CC ?= gcc
 +CFLAGS ?= -O3 -Wextra -Wall -ansi -Wstrict-prototypes
  
  $(NAME): $(OBJ)
@@ -33,6 +21,3 @@ index 4ebf8be..13b1021 100644
  
  all:
  		@make $(NAME)
--- 
-cgit v1.2.3
-

--- a/sys-apps/moreutils/moreutils-0.63.ebuild
+++ b/sys-apps/moreutils/moreutils-0.63.ebuild
@@ -29,7 +29,7 @@ DEPEND="
 	)"
 
 PATCHES=(
-	"${FILESDIR}"/${P}-respect-env.patch
+	"${FILESDIR}"/${PN}-0.63-respect-env.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
In 47abea9b0, we took the upstream patch,
without noticing that the original (non-upstream) one
fixed respecting CC too, while upstream's did not.

This fixes the patch accordingly.

Closes: https://bugs.gentoo.org/727480
Bug: https://bugs.gentoo.org/721394
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>