### PR TITLE
app-editors/hexcurse: fix compilation with GCC10

### DIFF
--- a/app-editors/hexcurse/files/hexcurse-1.60.0-gcc10.patch
+++ b/app-editors/hexcurse/files/hexcurse-1.60.0-gcc10.patch
@@ -1,0 +1,41 @@
+From 9cf7c9dcd012656df949d06f2986b57db3a72bdc Mon Sep 17 00:00:00 2001
+From: "Azamat H. Hackimov" <azamat.hackimov@gmail.com>
+Date: Tue, 9 Jun 2020 01:25:04 +0300
+Subject: [PATCH] Fix compilation with GCC 10
+
+Fixed compilation with -fno-common, which enabled in GCC 10 by default.
+See https://bugs.gentoo.org/706762.
+---
+ include/hex.h  | 2 +-
+ src/hexcurse.c | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/hex.h b/include/hex.h
+index 57845c0..845bac0 100644
+--- a/include/hex.h
++++ b/include/hex.h
+@@ -126,7 +126,7 @@ extern bool color_enabled;
+ #define max(a,b) ((a) >(b) ? (a) : (b))
+ #endif
+ 
+-FILE *fpIN;		        		/* global file ptr           */
++extern FILE *fpIN;	        		/* global file ptr           */
+ 
+ /* function prototypes */
+ 
+diff --git a/src/hexcurse.c b/src/hexcurse.c
+index e723ddc..3c167b6 100644
+--- a/src/hexcurse.c
++++ b/src/hexcurse.c
+@@ -27,6 +27,8 @@
+ /*#define DEBUG_LLIST*/
+ /*#define DEBUG_GOTO*/
+ 
++FILE *fpIN;
++
+ int     BASE, MAXY, resize = 0;
+ int     MIN_ADDR_LENGTH;
+ hexList *head;						/* linked list struct */
+-- 
+2.26.2
+

--- a/app-editors/hexcurse/hexcurse-1.60.0.ebuild
+++ b/app-editors/hexcurse/hexcurse-1.60.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit autotools
 
 DESCRIPTION="ncurses based hex editor"
@@ -19,8 +19,9 @@ DEPEND="
 	${RDEPEND}
 "
 PATCHES=(
-	"${FILESDIR}"/${PN}-1.60.0-Werror.patch
-	"${FILESDIR}"/${PN}-1.60.0-tinfo.patch
+	"${FILESDIR}/${P}-Werror.patch"
+	"${FILESDIR}/${P}-tinfo.patch"
+	"${FILESDIR}/${P}-gcc10.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Fixed compilation with GCC10 (#706762, see
https://github.com/LonnyGomes/hexcurse/pull/28), updated to EAPI 7.
Closes: https://bugs.gentoo.org/706762
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>