### PR TITLE
media-sound/wavegain: fix compilation with GCC10

### DIFF
--- a/media-sound/wavegain/files/wavegain-1.3.1-gcc10.patch
+++ b/media-sound/wavegain/files/wavegain-1.3.1-gcc10.patch
@@ -1,0 +1,21 @@
+diff -Naur a/audio.h b/audio.h
+--- a/audio.h	2009-09-15 13:49:54.000000000 +0000
++++ b/audio.h	2020-05-16 02:20:57.432019958 +0000
+@@ -136,7 +136,7 @@
+ long wav_read(void *, double **buffer, int samples, int fast, int chunk);
+ long wav_ieee_read(void *, double **buffer, int samples, int fast, int chunk);
+ 
+-enum {
++enum file_formats {
+ 	WAV_NO_FMT = 0,
+ 	WAV_FMT_8BIT,
+ 	WAV_FMT_16BIT,
+@@ -146,7 +146,7 @@
+ 	WAV_FMT_AIFF,
+ 	WAV_FMT_AIFC8,
+ 	WAV_FMT_AIFC16
+-} file_formats;
++};
+ 
+ typedef struct
+ {

--- a/media-sound/wavegain/wavegain-1.3.1.ebuild
+++ b/media-sound/wavegain/wavegain-1.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,9 +18,13 @@ BDEPEND="app-arch/unzip"
 
 S=${WORKDIR}/${P/wavegain/WaveGain}
 
+PATCHES=(
+	"${FILESDIR}/${P}-gcc10.patch"
+)
+
 src_compile() {
-	$(tc-getCC) ${LDFLAGS} ${CFLAGS} *.c -o ${PN} \
-		-DHAVE_CONFIG_H -lm || die "build failed"
+	$(tc-getCC) ${LDFLAGS} ${CFLAGS} *.c -o ${PN} -DHAVE_CONFIG_H -lm \
+		|| die "build failed"
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/706692
Suggested-by: Matt Whitlock <gentoo@mattwhitlock.name>
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>