### PR TITLE
dev-ruby/asciidoctor: add ruby27

### DIFF
--- a/dev-ruby/asciidoctor/asciidoctor-2.0.10.ebuild
+++ b/dev-ruby/asciidoctor/asciidoctor-2.0.10.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-USE_RUBY="ruby24 ruby25 ruby26"
+USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 
 RUBY_FAKEGEM_TASK_TEST="test features"
 RUBY_FAKEGEM_RECIPE_DOC="rdoc"


### PR DESCRIPTION
Add ruby27 to USE_RUBY, works fine in 2.7.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>