### PR TITLE
www-apps/cgit: Fix build on musl

### DIFF
--- a/www-apps/cgit/cgit-1.2.3.ebuild
+++ b/www-apps/cgit/cgit-1.2.3.ebuild
@@ -68,15 +68,23 @@ src_prepare() {
 	epatch_user
 }
 
+src_configure() {
+	myopts=(
+		$(usex elibc_musl NO_REGEX=NeedsStartEnd '')
+	)
+
+	export MY_MAKEOPTS="${myopts[@]}"
+}
+
 src_compile() {
-	emake V=1 AR="$(tc-getAR)" CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+	emake "${MY_MAKEOPTS}" V=1 AR="$(tc-getAR)" CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
 	use doc && emake V=1 doc-man
 }
 
 src_install() {
 	webapp_src_preinst
 
-	emake V=1 AR="$(tc-getAR)" CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" install
+	emake "${MY_MAKEOPTS}" V=1 AR="$(tc-getAR)" CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" install
 
 	insinto /etc
 	doins "${FILESDIR}"/cgitrc


### PR DESCRIPTION
As musl does not support REG_STARTEND, tell git about this by setting
NO_REGEX=NeedsStartEnd.

Closes: https://bugs.gentoo.org/713836
Signed-off-by: Wynn Wolf Arbor <wolf@oriole.systems>
Package-Manager: Portage-2.3.99, Repoman-2.3.22