### PR TITLE
mail-filter/libmilter: Fix several issues on musl

### DIFF
--- a/mail-filter/libmilter/files/libmilter-musl-disable-cdefs.patch
+++ b/mail-filter/libmilter/files/libmilter-musl-disable-cdefs.patch
@@ -1,0 +1,11 @@
+--- a/include/sm/os/sm_os_linux.h	2020-06-09 11:57:46.789786561 +0200
++++ b/include/sm/os/sm_os_linux.h	2020-06-09 11:57:49.174781812 +0200
+@@ -33,7 +33,7 @@
+ # endif /* LINUX_VERSION_CODE */
+ #endif /* SM_CONF_SHM */
+
+-#define SM_CONF_SYS_CDEFS_H	1
++#define SM_CONF_SYS_CDEFS_H	0
+ #ifndef SM_CONF_SEM
+ # define SM_CONF_SEM	2
+ #endif /* SM_CONF_SEM */

--- a/mail-filter/libmilter/files/libmilter-musl-stack-size.patch
+++ b/mail-filter/libmilter/files/libmilter-musl-stack-size.patch
@@ -1,0 +1,42 @@
+Set default pthread stack size to 256 KB
+
+This patch tries to fix various crashes for applications depending on libmilter
+by setting the stack size for pthreads to 256 KB. The default stack size for
+musl libc is set to 80 KB whereas glibc has it set to 8 MB. This causes problems
+when a large amount of memory is allocated on the stack.
+
+For example, opendkim allocates blocks of 64 KB multiple times, which causes
+libmilter (and therefore opendkim) to crash. For now, a stack size of 256 KB
+looks sufficient and makes opendkim stop crashing.
+
+Fixes https://bugs.alpinelinux.org/issues/6360
+
+--- a/libmilter/libmilter.h
++++ b/libmilter/libmilter.h
+@@ -127,10 +127,10 @@
+ # define MI_SOCK_READ(s, b, l)	read(s, b, l)
+ # define MI_SOCK_READ_FAIL(x)	((x) < 0)
+ # define MI_SOCK_WRITE(s, b, l)	write(s, b, l)
+-
+-# define thread_create(ptid,wr,arg) pthread_create(ptid, NULL, wr, arg)
+ # define sthread_get_id()	pthread_self()
+
++extern int thread_create(pthread_t *ptid, void *(*wr) (void *), void *arg);
++
+ typedef pthread_mutex_t smutex_t;
+ # define smutex_init(mp)	(pthread_mutex_init(mp, NULL) == 0)
+ # define smutex_destroy(mp)	(pthread_mutex_destroy(mp) == 0)
+--- a/libmilter/main.c
++++ b/libmilter/main.c
+@@ -16,6 +16,12 @@
+ #include <fcntl.h>
+ #include <sys/stat.h>
+
++int thread_create(pthread_t *ptid, void *(*wr) (void *), void *arg) {
++	pthread_attr_t attr;
++	pthread_attr_init(&attr);
++	pthread_attr_setstacksize(&attr,256*1024);
++	return pthread_create(ptid, &attr, wr, arg);
++}
+
+ static smfiDesc_ptr smfi = NULL;

--- a/mail-filter/libmilter/libmilter-1.0.2_p1.ebuild
+++ b/mail-filter/libmilter/libmilter-1.0.2_p1.ebuild
@@ -45,6 +45,7 @@ src_prepare() {
 	if use elibc_musl; then
 		use ipv6 && ENVDEF="${ENVDEF} -DNEEDSGETIPNODE"
 
+		eapply "${FILESDIR}/${PN}-musl-stack-size.patch"
 		eapply "${FILESDIR}/${PN}-musl-disable-cdefs.patch"
 	fi
 

--- a/mail-filter/libmilter/libmilter-1.0.2_p1.ebuild
+++ b/mail-filter/libmilter/libmilter-1.0.2_p1.ebuild
@@ -42,6 +42,12 @@ src_prepare() {
 	use ipv6 && ENVDEF="${ENVDEF} -DNETINET6"
 	use poll && ENVDEF="${ENVDEF} -DSM_CONF_POLL=1"
 
+	if use elibc_musl; then
+		use ipv6 && ENVDEF="${ENVDEF} -DNEEDSGETIPNODE"
+
+		eapply "${FILESDIR}/${PN}-musl-disable-cdefs.patch"
+	fi
+
 	sed -e "s|@@CFLAGS@@|${CFLAGS}|" \
 		-e "s:@@LDFLAGS@@:${LDFLAGS}:" \
 		-e "s:@@CC@@:${CC}:" \


### PR DESCRIPTION
This patch series fixes the build on musl and attempts to fix potential crashes with applications using libmilter. See the specific commits for more information.

Closes: https://bugs.gentoo.org/712628