### PR TITLE
libidn2: Respect portage host cc

### DIFF
--- a/net-dns/libidn2/libidn2-2.3.0.ebuild
+++ b/net-dns/libidn2/libidn2-2.3.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit multilib-minimal
+inherit multilib-minimal toolchain-funcs
 
 DESCRIPTION="An implementation of the IDNA2008 specifications (RFCs 5890, 5891, 5892, 5893)"
 HOMEPAGE="https://www.gnu.org/software/libidn/#libidn2 https://gitlab.com/libidn/libidn2"
@@ -40,6 +40,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	econf \
+		CC_FOR_BUILD="$(tc-getBUILD_CC)" \
 		$(use_enable static-libs static) \
 		--disable-doc \
 		--disable-gcc-warnings \

--- a/net-dns/libidn2/libidn2-99999.ebuild
+++ b/net-dns/libidn2/libidn2-99999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit autotools git-r3 multilib-minimal
+inherit autotools git-r3 multilib-minimal toolchain-funcs
 
 DESCRIPTION="An implementation of the IDNA2008 specifications (RFCs 5890, 5891, 5892, 5893)"
 HOMEPAGE="https://www.gnu.org/software/libidn/#libidn2 https://gitlab.com/libidn/libidn2"
@@ -53,6 +53,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	econf \
+		CC_FOR_BUILD="$(tc-getBUILD_CC)" \
 		$(use_enable static-libs static) \
 		--disable-doc \
 		--disable-gcc-warnings \


### PR DESCRIPTION
Pass CC_FOR_BUILD to configure. Otherwise it invokes gcc instead of portage
specified HOST/BUILD CC.

Signed-off-by: Manoj Gupta <manojgupta@google.com>