### PR TITLE
toybox: Move setting CC/HOST_CC to configure

### DIFF
--- a/sys-apps/toybox/toybox-0.8.1.ebuild
+++ b/sys-apps/toybox/toybox-0.8.1.ebuild
@@ -30,6 +30,8 @@ src_prepare() {
 }
 
 src_configure() {
+	tc-export CC STRIP
+	export HOSTCC="$(tc-getBUILD_CC)"
 	if [ -f .config ]; then
 		yes "" | emake -j1 oldconfig > /dev/null
 		return 0
@@ -40,8 +42,6 @@ src_configure() {
 }
 
 src_compile() {
-	tc-export CC STRIP
-	export HOSTCC=$(tc-getBUILD_CC)
 	unset CROSS_COMPILE
 	export CPUS=$(makeopts_jobs)
 	emake V=1

--- a/sys-apps/toybox/toybox-9999.ebuild
+++ b/sys-apps/toybox/toybox-9999.ebuild
@@ -30,6 +30,8 @@ src_prepare() {
 }
 
 src_configure() {
+	tc-export CC STRIP
+	export HOSTCC="$(tc-getBUILD_CC)"
 	if [ -f .config ]; then
 		yes "" | emake -j1 oldconfig > /dev/null
 		return 0
@@ -40,8 +42,6 @@ src_configure() {
 }
 
 src_compile() {
-	tc-export CC STRIP
-	export HOSTCC=$(tc-getBUILD_CC)
 	unset CROSS_COMPILE
 	export CPUS=$(makeopts_jobs)
 	emake V=1


### PR DESCRIPTION
Move setting up CC/HOST_CC to configure stage. Otherwise
emae oldconfig invokes gcc rather than portage specified
variables.

Signed-off-by: Manoj Gupta <manojgupta@google.com>