### PR TITLE
pam: Respect portage host cc variable

### DIFF
--- a/sys-libs/pam/pam-1.4.0.ebuild
+++ b/sys-libs/pam/pam-1.4.0.ebuild
@@ -53,6 +53,7 @@ multilib_src_configure() {
 	export ac_cv_header_xcrypt_h=no
 
 	local myconf=(
+		CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		--with-db-uniquename=-$(db_findver sys-libs/db)
 		--with-xml-catalog="${EPREFIX}"/etc/xml/catalog
 		--enable-securedir="${EPREFIX}"/$(get_libdir)/security


### PR DESCRIPTION
Pass CC_FOR_BUILD to configure. Otherwise it invokes gcc instead of portage
specified HOST/BUILD CC.

Signed-off-by: Manoj Gupta <manojgupta@google.com>