### PR TITLE
dev-libs/tre: Security bump

### DIFF
--- a/dev-libs/tre/files/0.8.0-CVE-2016-8559.patch
+++ b/dev-libs/tre/files/0.8.0-CVE-2016-8559.patch
@@ -1,0 +1,73 @@
+From c3edc06d1e1360f3570db9155d6b318ae0d0f0f7 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Thu, 6 Oct 2016 18:34:58 -0400
+Subject: fix missing integer overflow checks in regexec buffer size
+ computations
+
+most of the possible overflows were already ruled out in practice by
+regcomp having already succeeded performing larger allocations.
+however at least the num_states*num_tags multiplication can clearly
+overflow in practice. for safety, check them all, and use the proper
+type, size_t, rather than int.
+
+also improve comments, use calloc in place of malloc+memset, and
+remove bogus casts.
+---
+ src/regex/regexec.c | 23 ++++++++++++++++++-----
+ 1 file changed, 18 insertions(+), 5 deletions(-)
+
+Note: patch was modified to apply to tre, parts were taken from
+https://github.com/laurikari/tre/issues/37
+
+--- a/lib/tre-match-parallel.c
++++ b/lib/tre-match-parallel.c
+@@ -59,6 +59,7 @@
+ #ifdef HAVE_MALLOC_H
+ #include <malloc.h>
+ #endif /* HAVE_MALLOC_H */
++#include <stdint.h>
+ 
+ #include "tre-internal.h"
+ #include "tre-match-utils.h"
+@@ -150,11 +151,24 @@
+ 
+   /* Allocate memory for temporary data required for matching.	This needs to
+      be done for every matching operation to be thread safe.  This allocates
+-     everything in a single large block from the stack frame using alloca()
+-     or with malloc() if alloca is unavailable. */
++     everything in a single large block with calloc(). */
+   {
+-    int tbytes, rbytes, pbytes, xbytes, total_bytes;
++    size_t tbytes, rbytes, pbytes, xbytes, total_bytes;
+     char *tmp_buf;
++
++    /* Ensure that tbytes and xbytes*num_states cannot overflow, and that
++     * they don't contribute more than 1/8 of SIZE_MAX to total_bytes. */
++    if (num_tags > SIZE_MAX/(8 * sizeof(int) * tnfa->num_states))
++      return REG_BADPAT;
++
++    /* Likewise check rbytes. */
++    if (tnfa->num_states+1 > SIZE_MAX/(8 * sizeof(*reach_next)))
++      return REG_BADPAT;
++
++    /* Likewise check pbytes. */
++    if (tnfa->num_states > SIZE_MAX/(8 * sizeof(*reach_pos)))
++      return REG_BADPAT;
++
+     /* Compute the length of the block we need. */
+     tbytes = sizeof(*tmp_tags) * num_tags;
+     rbytes = sizeof(*reach_next) * (tnfa->num_states + 1);
+@@ -168,11 +182,11 @@
+ #ifdef TRE_USE_ALLOCA
+     buf = alloca(total_bytes);
+ #else /* !TRE_USE_ALLOCA */
+-    buf = xmalloc((unsigned)total_bytes);
++    buf = xmalloc(total_bytes);
+ #endif /* !TRE_USE_ALLOCA */
+     if (buf == NULL)
+       return REG_ESPACE;
+-    memset(buf, 0, (size_t)total_bytes);
++    memset(buf, 0, total_bytes);
+ 
+     /* Get the various pointers within tmp_buf (properly aligned). */
+     tmp_tags = (void *)buf;

--- a/dev-libs/tre/tre-0.8.0-r2.ebuild
+++ b/dev-libs/tre/tre-0.8.0-r2.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit multilib
+
+DESCRIPTION="Lightweight, robust, and efficient POSIX compliant regexp matching library"
+HOMEPAGE="https://laurikari.net/tre/ https://github.com/laurikari/tre/"
+SRC_URI="https://laurikari.net/tre/${P}.tar.bz2"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="nls static-libs"
+
+RDEPEND="
+	!app-text/agrep
+	!dev-ruby/amatch
+	!app-misc/glimpse"
+
+DEPEND="
+	${RDEPEND}
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )"
+
+PATCHES=(
+	"${FILESDIR}/${PV}-pkgcfg.patch"
+	"${FILESDIR}/${PV}-CVE-2016-8559.patch"
+)
+
+src_prepare() {
+	default
+}
+
+src_configure() {
+	econf \
+		--enable-agrep \
+		--enable-system-abi \
+		$(use_enable nls) \
+		$(use_enable static-libs static)
+}
+
+src_test() {
+	if locale -a | grep -iq en_US.iso88591; then
+		emake -j1 check
+	else
+		ewarn "If you like to run the test,"
+		ewarn "please make sure en_US.ISO-8859-1 is installed."
+		die "en_US.ISO-8859-1 locale is missing"
+	fi
+}
+
+src_install() {
+	local HTML_DOCS=( doc/*.{css,html} )
+
+	default
+
+	# 626480
+	mv "${ED%/}"/usr/bin/agrep{,-tre}$(get_exeext) || die
+}
+
+pkg_postinst() {
+	ewarn "app-misc/glimpse, app-text/agrep and this package all provide agrep."
+	ewarn "If this causes any unforeseen incompatibilities please file a bug"
+	ewarn "on https://bugs.gentoo.org."
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/597616
Package-Manager: Portage-2.3.100, Repoman-2.3.22
Signed-off-by: John Helmert III <jchelmert3@posteo.net>