### PR TITLE
www-apps/gitea: <gitea-1.12 is incompatible with >=go-1.14

### DIFF
--- a/www-apps/gitea/gitea-1.11.6.ebuild
+++ b/www-apps/gitea/gitea-1.11.6.ebuild
@@ -30,7 +30,7 @@ LICENSE="Apache-2.0 BSD BSD-2 ISC MIT MPL-2.0"
 SLOT="0"
 IUSE="+acct build-client pam sqlite"
 
-BDEPEND="dev-lang/go
+BDEPEND="<dev-lang/go-1.14.0
 	build-client? ( >=net-libs/nodejs-10[npm] )"
 DEPEND="pam? ( sys-libs/pam )"
 RDEPEND="${DEPEND}


### PR DESCRIPTION
This PR fixes the bug at https://bugs.gentoo.org/727648.

Cf. https://github.com/go-gitea/gitea/issues/10552

Gitea 1.12, which contains a real fix, should be out in the coming days.