### PR TITLE
grub: Fix cross compiling

### DIFF
--- a/sys-boot/grub/grub-2.05_alpha20200310.ebuild
+++ b/sys-boot/grub/grub-2.05_alpha20200310.ebuild
@@ -186,6 +186,7 @@ grub_configure() {
 	esac
 
 	local myeconfargs=(
+		TARGET_CC="$(tc-getCC)" \
 		--disable-werror
 		--program-prefix=
 		--libdir="${EPREFIX}"/usr/lib

--- a/sys-boot/grub/grub-9999.ebuild
+++ b/sys-boot/grub/grub-9999.ebuild
@@ -194,6 +194,7 @@ grub_configure() {
 	esac
 
 	local myeconfargs=(
+		TARGET_CC="$(tc-getCC)" \
 		--disable-werror
 		--program-prefix=
 		--libdir="${EPREFIX}"/usr/lib


### PR DESCRIPTION
Specify TARGET_CC to fix grub cross-compilation.

Signed-off-by: Manoj Gupta <manojgupta@google.com>