### PR TITLE
yasm:  Respect portage host cc variable

### DIFF
--- a/dev-lang/yasm/yasm-1.3.0.ebuild
+++ b/dev-lang/yasm/yasm-1.3.0.ebuild
@@ -5,7 +5,7 @@ EAPI=5
 
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-single-r1
+inherit python-single-r1 toolchain-funcs
 
 DESCRIPTION="An assembler for x86 and x86_64 instruction sets"
 HOMEPAGE="http://yasm.tortall.net/"
@@ -34,6 +34,8 @@ src_configure() {
 
 	XMLTO=: \
 	econf \
+		CC_FOR_BUILD=$(tc-getBUILD_CC) \
+		CCLD_FOR_BUILD=$(tc-getBUILD_CC) \
 		$(use_enable python) \
 		$(use_enable python python-bindings) \
 		$(use_enable nls)

--- a/dev-lang/yasm/yasm-9999.ebuild
+++ b/dev-lang/yasm/yasm-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 PYTHON_COMPAT=( python2_7 )
 
-inherit python-single-r1
+inherit python-single-r1 toolchain-funcs
 
 if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/yasm/yasm.git"
@@ -60,6 +60,8 @@ src_configure() {
 	use python && python_setup
 
 	local myconf=(
+		CC_FOR_BUILD=$(tc-getBUILD_CC) \
+		CCLD_FOR_BUILD=$(tc-getBUILD_CC) \
 		--disable-warnerror
 		$(use_enable python)
 		$(use_enable python python-bindings)


### PR DESCRIPTION
Pass CC_FOR_BUILD and CCLD_FOR_BUILD to econf.
Otherwise it invokes cc instead of portage specified HOST/BUILD CC.

Signed-off-by: Manoj Gupta <manojgupta@google.com>