### PR TITLE
protobuf: Respect portage host cc/cxx variable

### DIFF
--- a/dev-libs/protobuf/protobuf-3.11.4.ebuild
+++ b/dev-libs/protobuf/protobuf-3.11.4.ebuild
@@ -58,6 +58,8 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		CC_FOR_BUILD="$(tc-getBUILD_CC)"
+		CXX_FOR_BUILD="$(tc-getBUILD_CXX)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)

--- a/dev-libs/protobuf/protobuf-9999.ebuild
+++ b/dev-libs/protobuf/protobuf-9999.ebuild
@@ -52,6 +52,8 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		CC_FOR_BUILD="$(tc-getBUILD_CC)"
+		CXX_FOR_BUILD="$(tc-getBUILD_CXX)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)


### PR DESCRIPTION
Pass CC_FOR_BUILD/CXX_FOR_BUILD to configure.
Otherwise it invokes gcc instead of portage specified HOST/BUILD CC.

Signed-off-by: Manoj Gupta <manojgupta@google.com>