### PR TITLE
media-libs/libjpeg-turbo: Patch CVE-2020-13790

### DIFF
--- a/media-libs/libjpeg-turbo/files/libjpeg-turbo-1.5.3-CVE-2020-13790.patch
+++ b/media-libs/libjpeg-turbo/files/libjpeg-turbo-1.5.3-CVE-2020-13790.patch
@@ -1,0 +1,43 @@
+From 1bfb0b5247f4fc8f6677639781ce468543490216 Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Tue, 2 Jun 2020 14:15:37 -0500
+Subject: [PATCH] rdppm.c: Fix buf overrun caused by bad binary PPM
+
+This extends the fix in 1e81b0c3ea26f4ea8f56de05367469333de64a9f to
+include binary PPM files with maximum values < 255, thus preventing a
+malformed binary PPM input file with those specifications from
+triggering an overrun of the rescale array and potentially crashing
+cjpeg, TJBench, or any program that uses the tjLoadImage() function.
+
+Fixes #433
+diff --git a/rdppm.c b/rdppm.c
+index c0c096218..899436eec 100644
+--- a/rdppm.c
++++ b/rdppm.c
+@@ -5,7 +5,7 @@
+  * Copyright (C) 1991-1997, Thomas G. Lane.
+  * Modified 2009 by Bill Allombert, Guido Vollbeding.
+  * libjpeg-turbo Modifications:
+- * Copyright (C) 2015, 2016, D. R. Commander.
++ * Copyright (C) 2015, 2016, 2020, D. R. Commander.
+  * For conditions of distribution and use, see the accompanying README.ijg
+  * file.
+  *
+@@ -22,6 +22,7 @@
+  * the file is indeed PPM format).
+  */
+ 
++#define JPEG_INTERNALS
+ #include "cdjpeg.h"             /* Common decls for cjpeg/djpeg applications */
+ 
+ #ifdef PPM_SUPPORTED
+@@ -425,7 +426,7 @@ start_input_ppm (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
+     /* On 16-bit-int machines we have to be careful of maxval = 65535 */
+     source->rescale = (JSAMPLE *)
+       (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
+-                                  (size_t) (((long) maxval + 1L) *
++                                  (size_t) (((long) MAX(maxval, 255) + 1L) *
+                                             sizeof(JSAMPLE)));
+     half_maxval = maxval / 2;
+     for (val = 0; val <= (long) maxval; val++) {
+

--- a/media-libs/libjpeg-turbo/files/libjpeg-turbo-2.0.4-CVE-2020-13790.patch
+++ b/media-libs/libjpeg-turbo/files/libjpeg-turbo-2.0.4-CVE-2020-13790.patch
@@ -1,0 +1,34 @@
+From 3de15e0c344d11d4b90f4a47136467053eb2d09a Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Tue, 2 Jun 2020 14:15:37 -0500
+Subject: [PATCH] rdppm.c: Fix buf overrun caused by bad binary PPM
+
+This extends the fix in 1e81b0c3ea26f4ea8f56de05367469333de64a9f to
+include binary PPM files with maximum values < 255, thus preventing a
+malformed binary PPM input file with those specifications from
+triggering an overrun of the rescale array and potentially crashing
+cjpeg, TJBench, or any program that uses the tjLoadImage() function.
+
+Fixes #433
+diff --git a/rdppm.c b/rdppm.c
+index 87bc33090..a8507b902 100644
+--- a/rdppm.c
++++ b/rdppm.c
+@@ -5,7 +5,7 @@
+  * Copyright (C) 1991-1997, Thomas G. Lane.
+  * Modified 2009 by Bill Allombert, Guido Vollbeding.
+  * libjpeg-turbo Modifications:
+- * Copyright (C) 2015-2017, D. R. Commander.
++ * Copyright (C) 2015-2017, 2020, D. R. Commander.
+  * For conditions of distribution and use, see the accompanying README.ijg
+  * file.
+  *
+@@ -720,7 +720,7 @@ start_input_ppm(j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
+     /* On 16-bit-int machines we have to be careful of maxval = 65535 */
+     source->rescale = (JSAMPLE *)
+       (*cinfo->mem->alloc_small) ((j_common_ptr)cinfo, JPOOL_IMAGE,
+-                                  (size_t)(((long)maxval + 1L) *
++                                  (size_t)(((long)MAX(maxval, 255) + 1L) *
+                                            sizeof(JSAMPLE)));
+     half_maxval = maxval / 2;
+     for (val = 0; val <= (long)maxval; val++) {

--- a/media-libs/libjpeg-turbo/libjpeg-turbo-1.5.3-r3.ebuild
+++ b/media-libs/libjpeg-turbo/libjpeg-turbo-1.5.3-r3.ebuild
@@ -1,0 +1,122 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools libtool ltprune java-pkg-opt-2 libtool toolchain-funcs multilib-minimal
+
+DESCRIPTION="MMX, SSE, and SSE2 SIMD accelerated JPEG library"
+HOMEPAGE="https://libjpeg-turbo.org/ https://sourceforge.net/projects/libjpeg-turbo/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz
+	mirror://gentoo/libjpeg8_8d-2.debian.tar.gz"
+
+LICENSE="BSD IJG"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
+IUSE="java static-libs"
+
+ASM_DEPEND="|| ( dev-lang/nasm dev-lang/yasm )"
+COMMON_DEPEND="!media-libs/jpeg:0
+	!media-libs/jpeg:62"
+RDEPEND="${COMMON_DEPEND}
+	java? ( >=virtual/jre-1.5 )"
+DEPEND="${COMMON_DEPEND}
+	amd64? ( ${ASM_DEPEND} )
+	x86? ( ${ASM_DEPEND} )
+	amd64-fbsd? ( ${ASM_DEPEND} )
+	x86-fbsd? ( ${ASM_DEPEND} )
+	amd64-linux? ( ${ASM_DEPEND} )
+	x86-linux? ( ${ASM_DEPEND} )
+	x64-macos? ( ${ASM_DEPEND} )
+	x64-cygwin? ( ${ASM_DEPEND} )
+	java? ( >=virtual/jdk-1.5 )"
+
+MULTILIB_WRAPPED_HEADERS=( /usr/include/jconfig.h )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.2.0-x32.patch #420239
+	"${FILESDIR}"/${P}-divzero_fix.patch #658624
+	"${FILESDIR}"/${P}-cve-2018-11813.patch
+	"${FILESDIR}"/${P}-CVE-2020-13790.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+
+	java-pkg-opt-2_src_prepare
+}
+
+multilib_src_configure() {
+	local myconf=()
+	if multilib_is_native_abi; then
+		myconf+=( $(use_with java) )
+		if use java; then
+			export JAVACFLAGS="$(java-pkg_javac-args)"
+			export JNI_CFLAGS="$(java-pkg_get-jni-cflags)"
+		fi
+	else
+		myconf+=( --without-java )
+	fi
+	[[ ${ABI} == "x32" ]] && myconf+=( --without-simd ) #420239
+
+	# Force /bin/bash until upstream generates a new version. #533902
+	CONFIG_SHELL="${EPREFIX}"/bin/bash \
+	ECONF_SOURCE=${S} \
+	econf \
+		$(use_enable static-libs static) \
+		--with-mem-srcdst \
+		"${myconf[@]}"
+}
+
+multilib_src_compile() {
+	local _java_makeopts
+	use java && _java_makeopts="-j1"
+	emake ${_java_makeopts}
+
+	if multilib_is_native_abi; then
+		pushd ../debian/extra >/dev/null
+		emake CC="$(tc-getCC)" CFLAGS="${LDFLAGS} ${CFLAGS}"
+		popd >/dev/null
+	fi
+}
+
+multilib_src_test() {
+	emake test
+}
+
+multilib_src_install() {
+	emake \
+		DESTDIR="${D}" \
+		docdir="${EPREFIX}"/usr/share/doc/${PF} \
+		exampledir="${EPREFIX}"/usr/share/doc/${PF} \
+		install
+
+	if multilib_is_native_abi; then
+		pushd "${WORKDIR}"/debian/extra >/dev/null
+		emake \
+			DESTDIR="${D}" prefix="${EPREFIX}"/usr \
+			INSTALL="install -m755" INSTALLDIR="install -d -m755" \
+			install
+		popd >/dev/null
+
+		if use java; then
+			rm -rf "${ED}"/usr/classes
+			java-pkg_dojar java/turbojpeg.jar
+		fi
+	fi
+}
+
+multilib_src_install_all() {
+	prune_libtool_files
+
+	insinto /usr/share/doc/${PF}/html
+	doins -r "${S}"/doc/html/*
+	newdoc "${WORKDIR}"/debian/changelog changelog.debian
+	if use java; then
+		insinto /usr/share/doc/${PF}/html/java
+		doins -r "${S}"/java/doc/*
+		newdoc "${S}"/java/README README.java
+	fi
+}

--- a/media-libs/libjpeg-turbo/libjpeg-turbo-2.0.4-r1.ebuild
+++ b/media-libs/libjpeg-turbo/libjpeg-turbo-2.0.4-r1.ebuild
@@ -1,0 +1,108 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS=cmake
+inherit cmake-multilib java-pkg-opt-2 libtool toolchain-funcs
+
+DESCRIPTION="MMX, SSE, and SSE2 SIMD accelerated JPEG library"
+HOMEPAGE="https://libjpeg-turbo.org/ https://sourceforge.net/projects/libjpeg-turbo/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz
+	mirror://gentoo/libjpeg8_8d-2.debian.tar.gz"
+
+LICENSE="BSD IJG"
+SLOT="0"
+[[ "$(ver_cut 3)" -ge 90 ]] || \
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
+IUSE="java static-libs"
+
+ASM_DEPEND="|| ( dev-lang/nasm dev-lang/yasm )"
+COMMON_DEPEND="!media-libs/jpeg:0
+	!media-libs/jpeg:62"
+RDEPEND="${COMMON_DEPEND}
+	java? ( >=virtual/jre-1.5 )"
+DEPEND="${COMMON_DEPEND}
+	amd64? ( ${ASM_DEPEND} )
+	x86? ( ${ASM_DEPEND} )
+	amd64-fbsd? ( ${ASM_DEPEND} )
+	x86-fbsd? ( ${ASM_DEPEND} )
+	amd64-linux? ( ${ASM_DEPEND} )
+	x86-linux? ( ${ASM_DEPEND} )
+	x64-macos? ( ${ASM_DEPEND} )
+	x64-cygwin? ( ${ASM_DEPEND} )
+	java? ( >=virtual/jdk-1.5 )"
+
+MULTILIB_WRAPPED_HEADERS=( /usr/include/jconfig.h )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-CVE-2020-13790.patch
+)
+
+src_prepare() {
+	local FILE
+	ln -snf ../debian/extra/*.c . || die
+
+	for FILE in ../debian/extra/*.c; do
+		FILE=${FILE##*/}
+		cat >> CMakeLists.txt <<EOF || die
+add_executable(${FILE%.c} ${FILE})
+install(TARGETS ${FILE%.c})
+EOF
+	done
+
+	for FILE in ../debian/extra/exifautotran; do
+		cat >> CMakeLists.txt <<EOF || die
+install(FILES \${CMAKE_CURRENT_SOURCE_DIR}/${FILE} DESTINATION \${CMAKE_INSTALL_BINDIR})
+EOF
+	done
+
+	for FILE in ../debian/extra/*.[0-9]*; do
+		cat >> CMakeLists.txt <<EOF || die
+install(FILES \${CMAKE_CURRENT_SOURCE_DIR}/${FILE} DESTINATION \${CMAKE_INSTALL_MANDIR}/man${FILE##*.})
+EOF
+	done
+
+	#default
+
+	cmake_src_prepare
+	java-pkg-opt-2_src_prepare
+}
+
+multilib_src_configure() {
+	if multilib_is_native_abi && use java ; then
+		export JAVACFLAGS="$(java-pkg_javac-args)"
+		export JNI_CFLAGS="$(java-pkg_get-jni-cflags)"
+	fi
+
+	local mycmakeargs=(
+		-DCMAKE_INSTALL_DEFAULT_DOCDIR="${EPREFIX}/usr/share/doc/${PF}"
+		-DENABLE_STATIC="$(usex static-libs)"
+		-DWITH_JAVA="$(multilib_native_usex java)"
+		-DWITH_MEM_SRCDST=ON
+	)
+	[[ ${ABI} == "x32" ]] && mycmakeargs+=( -DREQUIRE_SIMD=OFF ) #420239
+	cmake_src_configure
+}
+
+multilib_src_install() {
+	cmake_src_install
+
+	if multilib_is_native_abi && use java ; then
+		rm -rf "${ED}"/usr/classes || die
+		java-pkg_dojar java/turbojpeg.jar
+	fi
+}
+
+multilib_src_install_all() {
+	find "${ED}" -type f -name '*.la' -delete || die
+
+	docinto html
+	dodoc -r "${S}"/doc/html/*
+	newdoc "${WORKDIR}"/debian/changelog changelog.debian
+	if use java; then
+		docinto html/java
+		dodoc -r "${S}"/java/doc/*
+		newdoc "${S}"/java/README README.java
+	fi
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/727010
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>