### PR TITLE
app-doc/{blas-docs,lapack-docs}, sci-libs/{oc,tnt,dealii}, dev-lang/f2c, dev-text/dvi2gr: use HTTPS

### DIFF
--- a/app-doc/blas-docs/blas-docs-3.1.1.ebuild
+++ b/app-doc/blas-docs/blas-docs-3.1.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="Documentation reference and man pages for blas implementations"
-HOMEPAGE="http://www.netlib.org/blas"
+HOMEPAGE="https://www.netlib.org/blas"
 SRC_URI="mirror://gentoo/lapack-man-${PV}.tgz
 	http://www.netlib.org/blas/blasqr.ps
 	http://www.netlib.org/blas/blast-forum/blas-report.ps"

--- a/app-doc/lapack-docs/lapack-docs-3.1.1.ebuild
+++ b/app-doc/lapack-docs/lapack-docs-3.1.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="Documentation reference and man pages for lapack implementations"
-HOMEPAGE="http://www.netlib.org/lapack"
+HOMEPAGE="https://www.netlib.org/lapack"
 SRC_URI="mirror://gentoo/lapack-man-${PV}.tgz
 	http://www.netlib.org/lapack/lapackqref.ps"
 

--- a/dev-lang/f2c/f2c-20100827-r1.ebuild
+++ b/dev-lang/f2c/f2c-20100827-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ DEB_PR=1
 DEB_P=${PN}_${DEB_PV}
 
 DESCRIPTION="Fortran to C converter"
-HOMEPAGE="http://www.netlib.org/f2c"
+HOMEPAGE="https://www.netlib.org/f2c"
 SRC_URI="
 	mirror://debian/pool/main/${PN:0:1}/${PN}/${DEB_P}.orig.tar.gz
 	mirror://debian/pool/main/${PN:0:1}/${PN}/${DEB_P}-${DEB_PR}.debian.tar.gz"

--- a/dev-tex/dvi2gr/dvi2gr-0.4-r1.ebuild
+++ b/dev-tex/dvi2gr/dvi2gr-0.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="DVI to Grace translator"
-HOMEPAGE="http://plasma-gate.weizmann.ac.il/Grace/"
+HOMEPAGE="https://plasma-gate.weizmann.ac.il/Grace/"
 SRC_URI="ftp://plasma-gate.weizmann.ac.il/pub/grace/src/devel/${P}.tar.gz"
 
 SLOT="0"

--- a/sci-libs/dealii/dealii-9.2.0.ebuild
+++ b/sci-libs/dealii/dealii-9.2.0.ebuild
@@ -11,7 +11,7 @@ inherit cmake-utils eutils multilib
 CMAKE_REMOVE_MODULES_LIST=""
 
 DESCRIPTION="Solving partial differential equations with the finite element method"
-HOMEPAGE="http://www.dealii.org/"
+HOMEPAGE="https://www.dealii.org/"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3

--- a/sci-libs/oc/oc-2.0.ebuild
+++ b/sci-libs/oc/oc-2.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Network Data Access Protocol client C library"
-HOMEPAGE="http://opendap.org/"
-SRC_URI="http://opendap.org/pub/OC/source/${P}.tar.gz"
+HOMEPAGE="https://opendap.org/"
+SRC_URI="https://opendap.org/pub/OC/source/${P}.tar.gz"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/sci-libs/tnt/tnt-3.0.12.ebuild
+++ b/sci-libs/tnt/tnt-3.0.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 MY_P="${PN}_$(ver_rs 1-3 '_')"
 
 DESCRIPTION="Template Numerical Toolkit: C++ headers for array and matrices"
-HOMEPAGE="http://math.nist.gov/tnt/"
-SRC_URI="http://math.nist.gov/tnt/${MY_P}.zip"
+HOMEPAGE="https://math.nist.gov/tnt/"
+SRC_URI="https://math.nist.gov/tnt/${MY_P}.zip"
 
 LICENSE="public-domain"
 SLOT="0"


### PR DESCRIPTION
Hi,

A few updates for sci related packages to use https instead of http.