### PR TITLE
sci-chemistry/gromacs: add missing flag-o-matic inherit

### DIFF
--- a/sci-chemistry/gromacs/gromacs-2020.1-r1.ebuild
+++ b/sci-chemistry/gromacs/gromacs-2020.1-r1.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{6,7,8} )
 
 DISTUTILS_SINGLE_IMPL=1
 
-inherit bash-completion-r1 cmake-utils cuda distutils-r1 eutils multilib readme.gentoo-r1 toolchain-funcs xdg-utils
+inherit bash-completion-r1 cmake-utils cuda distutils-r1 eutils flag-o-matic multilib readme.gentoo-r1 toolchain-funcs xdg-utils
 
 if [[ $PV = *9999* ]]; then
 	EGIT_REPO_URI="git://git.gromacs.org/gromacs.git

--- a/sci-chemistry/gromacs/gromacs-2020.2.ebuild
+++ b/sci-chemistry/gromacs/gromacs-2020.2.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{6,7,8} )
 
 DISTUTILS_SINGLE_IMPL=1
 
-inherit bash-completion-r1 cmake-utils cuda distutils-r1 eutils multilib readme.gentoo-r1 toolchain-funcs xdg-utils
+inherit bash-completion-r1 cmake-utils cuda distutils-r1 eutils flag-o-matic multilib readme.gentoo-r1 toolchain-funcs xdg-utils
 
 if [[ $PV = *9999* ]]; then
 	EGIT_REPO_URI="git://git.gromacs.org/gromacs.git


### PR DESCRIPTION
Package-Manager: Portage-2.3.100, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi, gromacs-2020.1 and 2020.2 are calling `strip-flags` but doesn't inherit `flag-o-matic`. I've updated the ebuild and added the eclass.

Please review.