### PR TITLE
dev-libs/crypto++: remove unused flag-o-matic eclass

### DIFF
--- a/dev-libs/crypto++/crypto++-7.0.0-r3.ebuild
+++ b/dev-libs/crypto++/crypto++-7.0.0-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit flag-o-matic toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="C++ class library of cryptographic schemes"
 HOMEPAGE="https://cryptopp.com"

--- a/dev-libs/crypto++/crypto++-8.2.0-r2.ebuild
+++ b/dev-libs/crypto++/crypto++-8.2.0-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit flag-o-matic toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="C++ class library of cryptographic schemes"
 HOMEPAGE="https://cryptopp.com"

--- a/dev-libs/crypto++/crypto++-8.2.0.ebuild
+++ b/dev-libs/crypto++/crypto++-8.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit flag-o-matic toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="C++ class library of cryptographic schemes"
 HOMEPAGE="https://cryptopp.com"


### PR DESCRIPTION
Package-Manager: Portage-2.3.100, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,

This removes the `flag-o-matic` inherit from the latest ebuild as it's not needed in there. Affected are also the 7.0.0-r3 and 8.2.0 ebuilds, however i've leaved them since these are stable ebuilds and i didn't wanted to add revision just because of this change.

Please review.