### PR TITLE
dev-java/byaccj: EAPI 7

### DIFF
--- a/dev-java/byaccj/byaccj-1.15-r2.ebuild
+++ b/dev-java/byaccj/byaccj-1.15-r2.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="A java extension of BSD YACC-compatible parser generator"
+HOMEPAGE="http://byaccj.sourceforge.net/"
+MY_P="${PN}${PV}_src"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86 ~ppc-macos ~x64-macos ~x86-macos"
+IUSE=""
+
+S="${WORKDIR}/${PN}${PV}"
+
+src_compile() {
+	cp "${FILESDIR}/Makefile" src/Makefile || die
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}" CFLAGS="${CFLAGS}" -C src linux
+}
+
+src_install() {
+	newbin src/yacc.linux "${PN}"
+	dodoc docs/ACKNOWLEDGEMEN
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/724238

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>