### PR TITLE
www-apache/mod_common_redirect: EAPI 6

### DIFF
--- a/www-apache/mod_common_redirect/mod_common_redirect-0.1.1-r1.ebuild
+++ b/www-apache/mod_common_redirect/mod_common_redirect-0.1.1-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit apache-module
+
+GITHUB_AUTHOR="hollow"
+GITHUB_PROJECT="mod_common_redirect"
+GITHUB_COMMIT="595a370"
+
+DESCRIPTION="mod_common_redirect implements common redirects without mod_rewrite overhead"
+HOMEPAGE="https://github.com/hollow/mod_common_redirect"
+SRC_URI="https://nodeload.github.com/${GITHUB_AUTHOR}/${GITHUB_PROJECT}/tarball/v${PV} -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+DEPEND=""
+RDEPEND=""
+
+APACHE2_MOD_CONF="20_${PN}"
+APACHE2_MOD_DEFINE="COMMON_REDIRECT"
+
+need_apache2
+
+S="${WORKDIR}"/${GITHUB_AUTHOR}-${GITHUB_PROJECT}-${GITHUB_COMMIT}


### PR DESCRIPTION
Going directly to EAPI=7 not possible:

 * ERROR: www-apache/mod_common_redirect-0.1.1-r1::gentoo failed (depend phase):
 *   EAPI=7 is not supported by depend.apache.eclass

Closes: https://bugs.gentoo.org/724220

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>