### PR TITLE
net-misc/dahdi: fix install issue w.r.t. depmod.

### DIFF
--- a/net-misc/dahdi/dahdi-3.1.0-r1.ebuild
+++ b/net-misc/dahdi/dahdi-3.1.0-r1.ebuild
@@ -97,5 +97,11 @@ src_install() {
 		DAHDI_MODULES_EXTRA="${JNET_DRIVERS// /.o }.o$(usex oslec " dahdi_echocan_oslec.o" "")" \
 		LDFLAGS="$(raw-ldflags)" install
 
-	rm -r "${ED}"/lib/modules/*/modules.* || die "Error removing bogus modules"
+	# Remove the blank "version" files (these files are all empty, and root owned).
+	find "${ED}/lib/firmware" -name ".*" -delete || die "Error removing empty firmware version files"
+
+	# If the kernel sources have a System.map, and there a suitable depmod
+	# available (seemingly when we're not cross-compiling), then the kernel
+	# sources depmod kicks in.  Remove the files caused by that.
+	find "${ED}/lib/modules" -name "modules.*" -delete || die "Error deleting bogus modules.* files"
 }


### PR DESCRIPTION
If the kernel sources are not yet compiled, then there is no System.map,
and as a result the kernel build system won't run depmod, resulting in
the modules.* files normally generated by this to not exist.  This
causes the rm in the ebuild to fail.  Substitute with a find mechanism
that only deletes if it exists.

At the same time clean up some empty files on the image that carries
firmware version information which we don't care about.

Closes:  https://bugs.gentoo.org/725022
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Jaco Kroon <jaco@uls.co.za>