### PR TITLE
media-libs/sdl-mixer: set CONFIG_SHELL to bash

### DIFF
--- a/media-libs/sdl-mixer/sdl-mixer-1.2.12-r4.ebuild
+++ b/media-libs/sdl-mixer/sdl-mixer-1.2.12-r4.ebuild
@@ -59,6 +59,8 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# use bash (bug 720038)
+	CONFIG_SHELL='/bin/bash' \
 	ECONF_SOURCE=${S} \
 	econf \
 		--disable-music-flac-shared \


### PR DESCRIPTION
Fixes build with `sh` set to `/bin/sh`.

Closes: https://bugs.gentoo.org/720038
Package-Manager: Portage-2.3.100, Repoman-2.3.22
Signed-off-by: Ilya Trukhanov <lahvuun@gmail.com>