### PR TITLE
net-libs/libsrtp: fix nss dependency, add rtp patch

### DIFF
--- a/net-libs/libsrtp/files/libsrtp-2.3.0-rtp-header.patch
+++ b/net-libs/libsrtp/files/libsrtp-2.3.0-rtp-header.patch
@@ -1,0 +1,24 @@
+From 55299517f39e2e1a34df05c27cbc9898071ac9db Mon Sep 17 00:00:00 2001
+From: Lennart Grahl <lennart.grahl@gmail.com>
+Date: Mon, 18 May 2020 18:01:08 +0200
+Subject: [PATCH] Fix two-byte RTP header extension encryption
+
+Also ignores the application bits as required by RFC 8285, sec 4.3
+Fixes #490
+---
+ srtp/srtp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/srtp/srtp.c b/srtp/srtp.c
+index b45cee0f..176b01f0 100644
+--- a/srtp/srtp.c
++++ b/srtp/srtp.c
+@@ -1423,7 +1423,7 @@ static srtp_err_status_t srtp_process_header_encryption(
+                 xtn_hdr_data++;
+             }
+         }
+-    } else if ((ntohs(xtn_hdr->profile_specific) & 0x1fff) == 0x100) {
++    } else if ((ntohs(xtn_hdr->profile_specific) & 0xfff0) == 0x1000) {
+         /* RFC 5285, section 4.3. Two-Byte Header */
+         while (xtn_hdr_data + 1 < xtn_hdr_end) {
+             uint8_t xid = *xtn_hdr_data;

--- a/net-libs/libsrtp/libsrtp-2.3.0-r1.ebuild
+++ b/net-libs/libsrtp/libsrtp-2.3.0-r1.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 		!libressl? ( dev-libs/openssl:0=[${MULTILIB_USEDEP}] )
 		libressl? ( dev-libs/libressl:0=[${MULTILIB_USEDEP}] )
 	)
-	nss? ( dev-libs/nss )
+	nss? ( >=dev-libs/nss-3.52[${MULTILIB_USEDEP}] )
 "
 DEPEND="${RDEPEND}"
 
@@ -36,6 +36,7 @@ DOCS=( CHANGES )
 PATCHES=(
 	"${FILESDIR}/${P}-gcc-10.patch"
 	"${FILESDIR}/${P}-nss.patch"
+	"${FILESDIR}/${P}-rtp-header.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Thanks-to: Joakim Tjernlund <joakim.tjernlund@infinera.com>
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>