### PR TITLE
dash: Respect portage host cc variable

### DIFF
--- a/app-shells/dash/dash-0.5.11.ebuild
+++ b/app-shells/dash/dash-0.5.11.ebuild
@@ -43,6 +43,7 @@ src_configure() {
 	use static && append-ldflags -static
 	# Do not pass --enable-glob due to #443552.
 	local myeconfargs=(
+		CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		--bindir="${EPREFIX}"/bin
 		--enable-fnmatch
 		$(use_with libedit)


### PR DESCRIPTION
Pass CC_FOR_BUILD to econf. Otherwise it invokes gcc instead of portage
specified HOST/BUILD CC.

Signed-off-by: Manoj Gupta <manojgupta@google.com>