### PR TITLE
app-arch/xdms, app-backup/fsarchiver, app-mobilphone/gnokii, dev-lang/ferite, net-misc/efax, www-client/lynx: use HTTPS, fix HOMEPAGE

### DIFF
--- a/app-arch/xdms/xdms-1.3.2-r1.ebuild
+++ b/app-arch/xdms/xdms-1.3.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="xDMS - Amiga DMS disk image decompressor"
-HOMEPAGE="http://zakalwe.fi/~shd/foss/xdms"
-SRC_URI="http://zakalwe.fi/~shd/foss/xdms/${P}.tar.bz2"
+HOMEPAGE="https://zakalwe.fi/~shd/foss/xdms"
+SRC_URI="https://zakalwe.fi/~shd/foss/xdms/${P}.tar.bz2"
 
 LICENSE="public-domain"
 SLOT="0"

--- a/app-backup/fsarchiver/fsarchiver-0.8.5.ebuild
+++ b/app-backup/fsarchiver/fsarchiver-0.8.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="Flexible filesystem archiver for backup and deployment tool"
-HOMEPAGE="http://www.fsarchiver.org"
+HOMEPAGE="https://www.fsarchiver.org"
 SRC_URI="https://github.com/fdupoux/${PN}/releases/download/${PV}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-mobilephone/gnokii/gnokii-0.6.31-r1.ebuild
+++ b/app-mobilephone/gnokii/gnokii-0.6.31-r1.ebuild
@@ -4,14 +4,14 @@
 EAPI=6
 inherit autotools eutils linux-info
 
-HOMEPAGE="http://www.gnokii.org/"
+HOMEPAGE="https://www.gnokii.org/"
 if [[ $PV == *9999 ]]; then
 	EGIT_REPO_URI="
 		git://git.savannah.nongnu.org/${PN}.git
 		http://git.savannah.gnu.org/r/${PN}.git"
 	inherit git-r3
 else
-	SRC_URI="http://www.gnokii.org/download/${PN}/${P}.tar.bz2"
+	SRC_URI="https://www.gnokii.org/download/${PN}/${P}.tar.bz2"
 	KEYWORDS="amd64 ~hppa ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 fi
 DESCRIPTION="User space driver and tools for use with mobile phones"

--- a/app-mobilephone/gnokii/gnokii-0.6.31-r2.ebuild
+++ b/app-mobilephone/gnokii/gnokii-0.6.31-r2.ebuild
@@ -1,17 +1,17 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools desktop eutils linux-info
 
-HOMEPAGE="http://www.gnokii.org/"
+HOMEPAGE="https://www.gnokii.org/"
 if [[ $PV == *9999 ]]; then
 	EGIT_REPO_URI="
 		git://git.savannah.nongnu.org/${PN}.git
 		http://git.savannah.gnu.org/r/${PN}.git"
 	inherit git-r3
 else
-	SRC_URI="http://www.gnokii.org/download/${PN}/${P}.tar.bz2"
+	SRC_URI="https://www.gnokii.org/download/${PN}/${P}.tar.bz2"
 	KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 fi
 DESCRIPTION="User space driver and tools for use with mobile phones"

--- a/app-mobilephone/gnokii/gnokii-9999.ebuild
+++ b/app-mobilephone/gnokii/gnokii-9999.ebuild
@@ -1,18 +1,18 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 inherit autotools desktop eutils linux-info
 
-HOMEPAGE="http://www.gnokii.org/"
+HOMEPAGE="https://www.gnokii.org/"
 if [[ $PV == *9999 ]]; then
 	EGIT_REPO_URI="
 		git://git.savannah.nongnu.org/${PN}.git
 		http://git.savannah.gnu.org/r/${PN}.git"
 	inherit git-r3
 else
-	SRC_URI="http://www.gnokii.org/download/${PN}/${P}.tar.bz2"
+	SRC_URI="https://www.gnokii.org/download/${PN}/${P}.tar.bz2"
 	KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 fi
 DESCRIPTION="User space driver and tools for use with mobile phones"

--- a/dev-lang/ferite/ferite-1.1.17-r1.ebuild
+++ b/dev-lang/ferite/ferite-1.1.17-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit autotools
 
 DESCRIPTION="A clean, lightweight, object oriented scripting language"
-HOMEPAGE="http://www.ferite.org/"
+HOMEPAGE="http://ferite.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/net-misc/efax/efax-0.9a-r4.ebuild
+++ b/net-misc/efax/efax-0.9a-r4.ebuild
@@ -8,8 +8,8 @@ inherit eutils toolchain-funcs
 S="${WORKDIR}/${P}-001114"
 
 DESCRIPTION="A simple fax program for single-user systems"
-HOMEPAGE="http://www.cce.com/efax"
-SRC_URI="http://www.cce.com/efax/download/${P}-001114.tar.gz
+HOMEPAGE="https://www.cce.com/efax/"
+SRC_URI="https://www.cce.com/efax/download/${P}-001114.tar.gz
 	mirror://debian/pool/main/e/efax/efax_0.9a-19.diff.gz"
 
 KEYWORDS="amd64 ppc x86"

--- a/net-misc/efax/efax-0.9a_p19_p1.ebuild
+++ b/net-misc/efax/efax-0.9a_p19_p1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="A simple fax program for single-user systems"
-HOMEPAGE="http://www.cce.com/efax"
+HOMEPAGE="https://www.cce.com/efax/"
 SRC_URI="
 	mirror://debian/pool/main/${PN:0:1}/${PN}/${PN}_${PV/_p*}.orig.tar.gz
 	mirror://debian/pool/main/${PN:0:1}/${PN}/${PN}_${PV/_p*}-$(ver_cut 5).$(ver_cut 7).diff.gz

--- a/www-client/lynx/lynx-2.8.9_p1.ebuild
+++ b/www-client/lynx/lynx-2.8.9_p1.ebuild
@@ -16,8 +16,8 @@ case ${PV} in
 esac
 
 DESCRIPTION="An excellent console-based web browser with ssl support"
-HOMEPAGE="http://lynx.invisible-island.net/"
-SRC_URI="http://invisible-mirror.net/archives/lynx/tarballs/${MY_P}.tar.bz2"
+HOMEPAGE="https://lynx.invisible-island.net/"
+SRC_URI="https://invisible-mirror.net/archives/lynx/tarballs/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/www-client/lynx/lynx-2.9.0_pre1.ebuild
+++ b/www-client/lynx/lynx-2.9.0_pre1.ebuild
@@ -16,8 +16,8 @@ case ${PV} in
 esac
 
 DESCRIPTION="An excellent console-based web browser with ssl support"
-HOMEPAGE="http://lynx.invisible-island.net/"
-SRC_URI="http://invisible-mirror.net/archives/lynx/tarballs/${MY_P}.tar.bz2"
+HOMEPAGE="https://lynx.invisible-island.net/"
+SRC_URI="https://invisible-mirror.net/archives/lynx/tarballs/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

A few maintainer needed packages which can be fixed to use https over http.

Except for the package **dev-lang/ferite**. There exists a https version of www.ferite.org, but unless the object oriented scripting language has also something todo with porn i think it's better to use the non-secure sourceforge homepage :smile: 