### PR TITLE
dev-python/daemonize: add python3.{7..9} support

### DIFF
--- a/dev-python/daemonize/daemonize-2.5.0-r1.ebuild
+++ b/dev-python/daemonize/daemonize-2.5.0-r1.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} )
+
+inherit distutils-r1
+
+DESCRIPTION="Library for writing system daemons in Python"
+HOMEPAGE="https://github.com/thesharp/daemonize"
+SRC_URI="https://github.com/thesharp/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+distutils_enable_tests nose


### PR DESCRIPTION
Tests pass on ~amd64, there are warnings about not being able to remove tempfiles, but it seems like python3 removes them after being closed.

````
--- daemonize-2.5.0.ebuild      2020-03-17 19:50:17.472638758 +0000
+++ daemonize-2.5.0-r1.ebuild   2020-06-13 14:35:38.412710076 +0000
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_6 )
+PYTHON_COMPAT=( python3_{6..9} )
 
 inherit distutils-r1
 
@@ -15,4 +15,4 @@
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
+distutils_enable_tests nose
````