### PR TITLE
sys-block/sas3flash: fix download links and pkg_nofetch output

### DIFF
--- a/sys-block/sas3flash/sas3flash-16.ebuild
+++ b/sys-block/sas3flash/sas3flash-16.ebuild
@@ -16,7 +16,7 @@ RESTRICT="strip fetch mirror"
 BDEPEND="app-arch/unzip"
 QA_PREBUILT="opt/lsi/sas3flash boot/efi/sas3flash.efi"
 
-SRC_URI_BASE="https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p${PV}_point_release"
+SRC_URI_BASE="https://docs.broadcom.com/docs-and-downloads"
 SRC_URI_PREFIX="${SRC_URI_BASE}/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p${PV}_point_release"
 
 SRC_URI_LINUX="${SRC_URI_PREFIX}/Installer_P${PV}_for_Linux.zip"
@@ -24,7 +24,7 @@ SRC_URI_FREEBSD="${SRC_URI_PREFIX}/Installer_P${PV}_for_FreeBSD.zip"
 SRC_URI_SOLARIS="${SRC_URI_PREFIX}/Installer_P${PV}_for_Solaris.zip"
 SRC_URI_UEFI="${SRC_URI_PREFIX}/Installer_P${PV}_for_UEFI.zip"
 
-DISTFILE_BINS=( "${SRC_URI_LINUX%%*/}" "${SRC_URI_FREEBSD%%*/}" "${SRC_URI_SOLARIS%%*/}" "${SRC_URI_UEFI%%*/}" )
+DISTFILE_BINS=( "${SRC_URI_LINUX##*/}" "${SRC_URI_FREEBSD##*/}" "${SRC_URI_SOLARIS##*/}" "${SRC_URI_UEFI##*/}" )
 DISTFILE_DOC=sas3Flash_quickRefGuide_rev1-0.pdf
 
 SRC_URI="


### PR DESCRIPTION
Package-Manager: Portage-2.3.100, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,

this fixes some ebuild mistakes in sys-block/sas3flash. Before the pkg_nofetch output looked like this:
```
!!! sys-block/sas3flash-16 has fetch restriction turned on.
!!! This probably means that this ebuild's files must be downloaded
!!! manually.  See the comments in the ebuild for more information.

 * Broadcom has a mandatory click-through license on their binaries.
 * Please visit https://www.broadcom.com/products/storage/host-bus-adapters/sas-9300-8e#downloads and download https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Linux.zip https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_FreeBSD.zip https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Solaris.zip https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_UEFI.zip from the Mangement Software section.
 * After downloading, move https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Linux.zip https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_FreeBSD.zip https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Solaris.zip https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_UEFI.zip into your DISTDIR directory.
 * 
 *      amd64? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Linux.zip )
 *      x86? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Linux.zip )
 *      ppc64? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Linux.zip )
 *      amd64-fbsd? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_FreeBSD.zip )
 *      x86-fbsd? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_FreeBSD.zip )
 *      x64-solaris? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Solaris.zip )
 *      x86-solaris? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Solaris.zip )
 *      sparc-solaris? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_Solaris.zip )
 *      efi? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/Installer_P16_for_UEFI.zip )
 *      doc? ( https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_12g_p16_point_release/oracle/files/sas3Flash_quickRefGuide_rev1-0.pdf )
```

Needless to say, the download links didn't work and the information about the files to download included the full (wrong) link instead of just the filename.