### PR TITLE
app-backup/borgbackup: remove unnecessary pyzmq dependency

### DIFF
--- a/app-backup/borgbackup/borgbackup-1.1.11-r2.ebuild
+++ b/app-backup/borgbackup/borgbackup-1.1.11-r2.ebuild
@@ -28,7 +28,6 @@ RDEPEND="
 	app-arch/lz4
 	virtual/acl
 	dev-python/llfuse[${PYTHON_USEDEP}]
-	dev-python/pyzmq[${PYTHON_USEDEP}]
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )
 "

--- a/app-backup/borgbackup/borgbackup-1.1.13.ebuild
+++ b/app-backup/borgbackup/borgbackup-1.1.13.ebuild
@@ -28,7 +28,6 @@ RDEPEND="
 	app-arch/lz4
 	virtual/acl
 	dev-python/llfuse[${PYTHON_USEDEP}]
-	dev-python/pyzmq[${PYTHON_USEDEP}]
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )
 "


### PR DESCRIPTION
The dev-python/pyzmq dependency was added with
https://github.com/gentoo/gentoo/pull/5240, borgbackup actually
required pyzmq, with 55e0c43c ("add zeromq dependency"), but that was
only a brief period the case and the requirement got removed again
with d0bed00e ("remove pyzmq package requirement, not used
yet"). However this dependency was *never* required in a released
version.

Closes: https://bugs.gentoo.org/728208
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Florian Schmaus <flo@geekplace.eu>