### PR TITLE
media-fonts/{culmus,source-han-sans}: add missing app-arch/unzip dependencies

### DIFF
--- a/media-fonts/culmus/culmus-0.120-r5.ebuild
+++ b/media-fonts/culmus/culmus-0.120-r5.ebuild
@@ -44,6 +44,7 @@ FONT_CONF=( "${T}/65-culmus.conf" )
 RDEPEND="!media-fonts/culmus-ancient"
 # >=x11-apps/mkfontscale-1.0.9-r1 as Heavy weight support is required
 DEPEND="${RDEPEND}
+	app-arch/unzip
 	>=x11-apps/mkfontscale-1.0.9-r1
 	fontforge? ( media-gfx/fontforge )"
 

--- a/media-fonts/culmus/culmus-0.133.ebuild
+++ b/media-fonts/culmus/culmus-0.133.ebuild
@@ -44,6 +44,7 @@ FONT_CONF=( "${T}/65-culmus.conf" )
 RDEPEND="!media-fonts/culmus-ancient"
 # >=x11-apps/mkfontscale-1.0.9-r1 as Heavy weight support is required
 DEPEND="${RDEPEND}
+	app-arch/unzip
 	>=x11-apps/mkfontscale-1.0.9-r1
 	fontforge? ( media-gfx/fontforge )"
 

--- a/media-fonts/source-han-sans/source-han-sans-1.004.ebuild
+++ b/media-fonts/source-han-sans/source-han-sans-1.004.ebuild
@@ -26,6 +26,8 @@ S=${WORKDIR}
 FONT_SUFFIX="otf"
 RESTRICT="binchecks strip"
 
+DEPEND="app-arch/unzip"
+
 src_install() {
 	use l10n_ja && FONT_S="${S}/SourceHanSansJP" font_src_install
 	use l10n_ko && FONT_S="${S}/SourceHanSansKR" font_src_install


### PR DESCRIPTION
Hi,

Both packages download some zip files but doesn't have app-arch/unzip in their dependencies.
I've updated the ebuilds and included `app-arch/unzip` as dependency