### PR TITLE
media-libs/libplacebo: backport vulkan-headers compatibility patch

### DIFF
--- a/media-libs/libplacebo/files/libplacebo-1.21.0-vulkan-headers-1.2.140-compatibility.patch
+++ b/media-libs/libplacebo/files/libplacebo-1.21.0-vulkan-headers-1.2.140-compatibility.patch
@@ -1,0 +1,59 @@
+From 45e19e7bbbbfceb197d8826c775e16ef536a4565 Mon Sep 17 00:00:00 2001
+From: Niklas Haas <git@haasn.xyz>
+Date: Tue, 5 May 2020 00:13:49 +0200
+Subject: [PATCH] vulkan: get rid of deprecated enum members
+
+Maybe we should just get rid of the switch coverage check altogether. I
+wish we could somehow differentiate between enums defined in our code
+and enums defined externally.
+
+Fixes #71.
+---
+ src/vulkan/context.c   | 4 +++-
+ src/vulkan/swapchain.c | 7 +------
+ 2 files changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/src/vulkan/context.c b/src/vulkan/context.c
+index 10928a9..14a57cf 100644
+--- a/src/vulkan/context.c
++++ b/src/vulkan/context.c
+@@ -685,7 +685,6 @@ VkPhysicalDevice pl_vulkan_choose_device(struct pl_context *ctx,
+         [VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU]    = {"virtual",    3},
+         [VK_PHYSICAL_DEVICE_TYPE_CPU]            = {"software",   2},
+         [VK_PHYSICAL_DEVICE_TYPE_OTHER]          = {"other",      1},
+-        [VK_PHYSICAL_DEVICE_TYPE_END_RANGE+1]    = {0},
+     };
+ 
+     int best = 0;
+@@ -693,6 +692,9 @@ VkPhysicalDevice pl_vulkan_choose_device(struct pl_context *ctx,
+         VkPhysicalDeviceProperties props = {0};
+         GetPhysicalDeviceProperties(devices[i], &props);
+         VkPhysicalDeviceType t = props.deviceType;
++        if (t > PL_ARRAY_SIZE(types))
++            continue;
++
+         PL_INFO(vk, "    GPU %d: %s (%s)", i, props.deviceName, types[t].name);
+ 
+         if (params->surface) {
+diff --git a/src/vulkan/swapchain.c b/src/vulkan/swapchain.c
+index bf6fd54..6bf40dd 100644
+--- a/src/vulkan/swapchain.c
++++ b/src/vulkan/swapchain.c
+@@ -138,13 +138,8 @@ static bool vk_map_color_space(VkColorSpaceKHR space, struct pl_color_space *out
+         return false;
+ #endif
+ 
+-    // Included to satisfy the switch coverage check
+-    case VK_COLOR_SPACE_RANGE_SIZE_KHR:
+-    case VK_COLOR_SPACE_MAX_ENUM_KHR:
+-        break;
++    default: return false;
+     }
+-
+-    return false;
+ }
+ 
+ static bool pick_surf_format(const struct pl_gpu *gpu, const struct vk_ctx *vk,
+-- 
+2.27.0
+

--- a/media-libs/libplacebo/libplacebo-1.21.0-r1.ebuild
+++ b/media-libs/libplacebo/libplacebo-1.21.0-r1.ebuild
@@ -31,6 +31,10 @@ BDEPEND="virtual/pkgconfig"
 
 RESTRICT="!test? ( test )"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-vulkan-headers-1.2.140-compatibility.patch
+)
+
 multilib_src_configure() {
 	local emesonargs=(
 		$(meson_feature glslang)

--- a/media-libs/libplacebo/libplacebo-1.29.1.ebuild
+++ b/media-libs/libplacebo/libplacebo-1.29.1.ebuild
@@ -31,6 +31,10 @@ BDEPEND="virtual/pkgconfig"
 
 RESTRICT="!test? ( test )"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.21.0-vulkan-headers-1.2.140-compatibility.patch
+)
+
 multilib_src_configure() {
 	local emesonargs=(
 		$(meson_feature glslang)

--- a/media-libs/libplacebo/libplacebo-2.43.0.ebuild
+++ b/media-libs/libplacebo/libplacebo-2.43.0.ebuild
@@ -32,6 +32,10 @@ BDEPEND="virtual/pkgconfig"
 
 RESTRICT="!test? ( test )"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.21.0-vulkan-headers-1.2.140-compatibility.patch
+)
+
 multilib_src_configure() {
 	local emesonargs=(
 		$(meson_feature glslang)


### PR DESCRIPTION
This patch is needed to compile older versions of libplacebo against
versions of vulkan-headers newer than 1.2.140. It doesn't break anything
retroactively, and shouldn't change behaviour, but I decided to bump the
revision numbers of the ebuilds just in case.

Closes: https://bugs.gentoo.org/728248
Signed-off-by: Niklas Haas <git@haasn.xyz>