### PR TITLE
dev-util/comparator: fix compilation with GCC10

### DIFF
--- a/dev-util/comparator/comparator-2.12.ebuild
+++ b/dev-util/comparator/comparator-2.12.ebuild
@@ -1,29 +1,30 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="7"
+EAPI=7
 PYTHON_COMPAT=( python{3_6,3_7} )
+DISTUTILS_USE_SETUPTOOLS=no
 
 inherit distutils-r1 toolchain-funcs
 
 DESCRIPTION="ESR's utility for making fast comparisons among large source trees"
-HOMEPAGE="http://www.catb.org/~esr/comparator/"
+HOMEPAGE="http://www.catb.org/~esr/comparator/ https://gitlab.com/esr/comparator"
 SRC_URI="http://www.catb.org/~esr/comparator/${P}.tar.gz"
 
-LICENSE="BSD"
+LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~sparc ~x86"
-IUSE=""
 
-RDEPEND=""
 DEPEND="=app-text/docbook-xml-dtd-4.1.2*
 	app-text/xmlto"
 
+PATCHES=(
+	"${FILESDIR}/${P}-gcc10.patch"
+)
+
 src_prepare() {
-	sed \
-		-e '/python setup.py install/d' \
-		-i Makefile || die "sed failed"
-	eapply_user
+	default
+	sed -e '/python setup.py install/d' -i Makefile || die "sed failed"
 }
 
 src_compile() {

--- a/dev-util/comparator/files/comparator-2.12-gcc10.patch
+++ b/dev-util/comparator/files/comparator-2.12-gcc10.patch
@@ -1,0 +1,26 @@
+From c7fdc67aefb67851a1210c7d5adfc7287c4b6572 Mon Sep 17 00:00:00 2001
+From: "Azamat H. Hackimov" <azamat.hackimov@gmail.com>
+Date: Mon, 15 Jun 2020 01:14:24 +0300
+Subject: [PATCH] Fix compilation with GCC10
+
+Fix compilation with -fno-common, which is enabled by default in GCC10.
+---
+ shred.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/shred.h b/shred.h
+index d7eeb93..0e35b28 100644
+--- a/shred.h
++++ b/shred.h
+@@ -100,7 +100,7 @@ extern int shredfile(struct filehdr_t *,
+ extern void sort_hashes(struct sorthash_t *hashlist, int hashcount);
+ 
+ /* linebyline.c feature analyzer */
+-struct analyzer_t linebyline;
++extern struct analyzer_t linebyline;
+ 
+ /* shredcompare.c functions */
+ extern int merge_compare(struct sorthash_t *obarray, int hashcount);
+-- 
+2.26.2
+

--- a/dev-util/comparator/metadata.xml
+++ b/dev-util/comparator/metadata.xml
@@ -6,4 +6,7 @@
 		<name>Anthony G. Basile</name>
 	</maintainer>
 	<longdescription>ESR's utility for making fast comparisons among large source trees</longdescription>
+	<upstream>
+		<remote-id type="gitlab">esr/comparator</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Changed license to BSD-2, added gitlab upstream URL, minor fixes to
ebuild.
Closes: https://bugs.gentoo.org/707744
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>