### PR TITLE
gui-wm/hikari: fix configuration files install

### DIFF
--- a/gui-wm/hikari/hikari-2.0.1-r1.ebuild
+++ b/gui-wm/hikari/hikari-2.0.1-r1.ebuild
@@ -56,8 +56,8 @@ src_compile() {
 }
 
 src_install() {
-	emake PREFIX="${D}/usr" ETC_PREFIX="${D}/etc" install
+	emake PREFIX="${D}/usr" ETC_PREFIX="${D}" install
 	if use man; then
-		emake PREFIX="${D}/usr" ETC_PREFIX="${D}/etc" install-doc
+		emake PREFIX="${D}/usr" ETC_PREFIX="${D}" install-doc
 	fi
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/728242

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>