### PR TITLE
dev-python/python-evdev: remove failing test

### DIFF
--- a/dev-python/python-evdev/python-evdev-1.3.0.ebuild
+++ b/dev-python/python-evdev/python-evdev-1.3.0.ebuild
@@ -26,5 +26,4 @@ python_compile() {
 python_test() {
 	pytest -vv tests/test_ecodes.py || die "ecodes test failed for ${EPYTHON}"
 	pytest -vv tests/test_events.py || die "events test failed for ${EPYTHON}"
-	pytest -vv tests/test_uinput.py || die "uinput test failed foe ${EPYTHON}"
 }


### PR DESCRIPTION
the test needs read/write access to a dev device
which is only available as root

Closes: https://bugs.gentoo.org/723724
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>