### PR TITLE
media-plugins/gmpc-*: use HTTPS, fix download links

### DIFF
--- a/media-plugins/gmpc-alarm/gmpc-alarm-11.8.16.ebuild
+++ b/media-plugins/gmpc-alarm/gmpc-alarm-11.8.16.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="This plugin can start/stop/pause your music at a preset time"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_ALARM"
-SRC_URI="http://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_ALARM"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-albumview/gmpc-albumview-11.8.16.ebuild
+++ b/media-plugins/gmpc-albumview/gmpc-albumview-11.8.16.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="This plugin shows your music collection in albums"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_ALBUMVIEW"
-SRC_URI="http://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_ALBUMVIEW"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-avahi/gmpc-avahi-11.8.16.ebuild
+++ b/media-plugins/gmpc-avahi/gmpc-avahi-11.8.16.ebuild
@@ -4,8 +4,8 @@
 EAPI=7
 
 DESCRIPTION="This plugin discovers avahi enabled mpd servers"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_AVAHI"
-SRC_URI="http://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_AVAHI"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-awn/gmpc-awn-11.8.16.ebuild
+++ b/media-plugins/gmpc-awn/gmpc-awn-11.8.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="This plugin integrates GMPC with the Avant Window Navigator"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_AWN"
-SRC_URI="http://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_AWN"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-discogs/gmpc-discogs-0.20.0.ebuild
+++ b/media-plugins/gmpc-discogs/gmpc-discogs-0.20.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="This plugin fetches artist and album images from discogs"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_DISCOGS"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_DISCOGS"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/0.20.0/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-extraplaylist/gmpc-extraplaylist-0.20.0.ebuild
+++ b/media-plugins/gmpc-extraplaylist/gmpc-extraplaylist-0.20.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="This plugin adds a second pane showing the playlist"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_EXTRA_PLAYLIST"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_EXTRA_PLAYLIST"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/0.20.0/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-jamendo/gmpc-jamendo-11.8.16.ebuild
+++ b/media-plugins/gmpc-jamendo/gmpc-jamendo-11.8.16.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Plugin allows you to browse and preview music available on jamendo"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_JAMENDO"
-SRC_URI="http://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_JAMENDO"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-last-fm/gmpc-last-fm-0.20.0.ebuild
+++ b/media-plugins/gmpc-last-fm/gmpc-last-fm-0.20.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="This plugin fetches artist art from last.fm"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_LASTFM"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_LASTFM"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/0.20.0/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-libnotify/gmpc-libnotify-11.8.16.ebuild
+++ b/media-plugins/gmpc-libnotify/gmpc-libnotify-11.8.16.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="This plugin sends an announcement to the notification daemon on song change"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_LIBNOTIFY"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_LIBNOTIFY"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8.16/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-lyrics/gmpc-lyrics-11.8.16.ebuild
+++ b/media-plugins/gmpc-lyrics/gmpc-lyrics-11.8.16.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="This plugin fetches lyrics"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_LYRICS"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_LYRICS"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8.16/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-lyricwiki/gmpc-lyricwiki-11.8.16.ebuild
+++ b/media-plugins/gmpc-lyricwiki/gmpc-lyricwiki-11.8.16.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="This plugin uses lyricwiki to fetch lyrics"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_LYRICWIKI"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_LYRICWIKI"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-magnatune/gmpc-magnatune-11.8.16.ebuild
+++ b/media-plugins/gmpc-magnatune/gmpc-magnatune-11.8.16.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="This plugin allows you to browse and preview available albums on magnatune.com"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_MAGNATUNE"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_MAGNATUNE"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8.16/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-mdcover/gmpc-mdcover-0.20.0.ebuild
+++ b/media-plugins/gmpc-mdcover/gmpc-mdcover-0.20.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Plugin for fetching cover art, artist art, album and artist information"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_MDCOVER"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_MDCOVER"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/0.20.0/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-mmkeys/gmpc-mmkeys-11.8.16.ebuild
+++ b/media-plugins/gmpc-mmkeys/gmpc-mmkeys-11.8.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vala
 
 DESCRIPTION="Bind multimedia keys via gnome settings daemon"
-HOMEPAGE="http://gmpc.wikia.com/wiki/Plugins"
-SRC_URI="http://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/Plugins"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/media-plugins/gmpc-mserver/gmpc-mserver-0.20.0.ebuild
+++ b/media-plugins/gmpc-mserver/gmpc-mserver-0.20.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="This plugin allows you to play local files on a remote or local mpd server"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_MSERVER"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_MSERVER"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/0.20.0/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-playlistsort/gmpc-playlistsort-0.20.0.ebuild
+++ b/media-plugins/gmpc-playlistsort/gmpc-playlistsort-0.20.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="This plugin adds a dialog to sort the current playlist"
-HOMEPAGE="http://gmpc.wikia.com/"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/Gnome_Music_Player_Client"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/0.20.0/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-shout/gmpc-shout-0.20.0.ebuild
+++ b/media-plugins/gmpc-shout/gmpc-shout-0.20.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="This plugin calls ogg123 and points it at mpd's shoutstream"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_SHOUT"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_SHOUT"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/0.20.0/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/gmpc-tagedit/gmpc-tagedit-11.8.16.ebuild
+++ b/media-plugins/gmpc-tagedit/gmpc-tagedit-11.8.16.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="This plugin allows you to edit tags in your library"
-HOMEPAGE="http://gmpc.wikia.com/wiki/GMPC_PLUGIN_TAGEDIT"
-SRC_URI="mirror://sourceforge/musicpd/${P}.tar.gz"
+HOMEPAGE="https://gmpc.fandom.com/wiki/GMPC_PLUGIN_TAGEDIT"
+SRC_URI="https://download.sarine.nl/Programs/gmpc/11.8.16/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR updates a few gmpc packages for https and fixes broken download links.
All download links were tested.