### PR TITLE
app-crypt/veracrypt: update eclass inheritation

### DIFF
--- a/app-crypt/veracrypt/veracrypt-1.24_p2.ebuild
+++ b/app-crypt/veracrypt/veracrypt-1.24_p2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils linux-info pax-utils toolchain-funcs wxwidgets
+inherit desktop linux-info pax-utils toolchain-funcs wxwidgets
 
 DESCRIPTION="Disk encryption with strong security based on TrueCrypt"
 HOMEPAGE="https://www.veracrypt.fr/en/Home.html"

--- a/app-crypt/veracrypt/veracrypt-1.24_p4.ebuild
+++ b/app-crypt/veracrypt/veracrypt-1.24_p4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eutils linux-info pax-utils toolchain-funcs wxwidgets
+inherit desktop eapi7-ver linux-info pax-utils toolchain-funcs wxwidgets
 
 MY_PV="$(ver_cut 1-2)-Update$(ver_cut 4)"
 DESCRIPTION="Disk encryption with strong security based on TrueCrypt"


### PR DESCRIPTION
Package-Manager: Portage-2.3.100, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Minor updates for both ebuilds:

* adding missing `desktop` eclass:
both ebuilds are callings `make_desktop_entry` from the `desktop` eclass but doesn't inherit the eclass. So far it worked because `eutils` was indirectly inheriting the eclass.

* adding missing `eapi7-ver` eclass:
`veracrypt-1.24_p4` calls `ver-cut` from the `eapi7-ver` eclass but doesn' inherit the eclass. It still worked because `linux-info` indirectly inherited the eclass.

* removing `eutils` eclass:
since we added the `desktop` eclass, `eutils` isn't needed anymore. Only `einstalldocs` would be provided by the eclass, however, since we are on EAPI6, it's implemented by the packaga manager. (thus not needed from the eclass)

I haven't made a revision bump since the changes shouldn't change anything, but if wanted i could do revision bumps too (especially since these are stable packages). 

Please let me know.