### PR TITLE
media-plugins/mythplugins: Fix dependency for mythmusic

### DIFF
--- a/media-plugins/mythplugins/mythplugins-31.0.ebuild
+++ b/media-plugins/mythplugins/mythplugins-31.0.ebuild
@@ -81,6 +81,7 @@ RDEPEND="
 		dev-perl/XML-Twig
 	)
 	mythmusic? (
+		dev-qt/qtwebkit:5
 		media-libs/flac
 		media-libs/libogg
 		media-libs/libvorbis


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/728120
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Wilson Michaels <thebitpit@earthlink.net>