### PR TITLE
media-libs/aubio[doc]: package.use.mask

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,11 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Sam James <sam@cmpct.info> (2020-16-06)
+# Doc build broken for now
+# Bug #679184
+media-libs/aubio doc
+
 # Stephan Hartmann <stha09@googlemail.com> (2020-16-06)
 # Mostly intended for debugging and development,
 # not recommended for general use. Build is also often


### PR DESCRIPTION
Documentation generation is currently
broken. Mask it for now so we can proceed
with a security stabilisation.

Bug: https://bugs.gentoo.org/679184
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>