### PR TITLE
dev-util/bitcoin-tx-0.20.0: Remove reference to unnecessary/missing patch

### DIFF
--- a/dev-util/bitcoin-tx/bitcoin-tx-0.20.0.ebuild
+++ b/dev-util/bitcoin-tx/bitcoin-tx-0.20.0.ebuild
@@ -64,8 +64,6 @@ src_prepare() {
 		eapply "${knots_patchdir}/${KNOTS_P}.ts.patch"
 	fi
 
-	eapply "${FILESDIR}/${PV}-no-libevent.patch"
-
 	eapply_user
 
 	echo '#!/bin/true' >share/genbuild.sh || die


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/728534
