### PR TITLE
media-plugins/vdr-*: add missing eclasses, fix HOMEPAGE

### DIFF
--- a/media-plugins/vdr-atscepg/vdr-atscepg-0.3.0-r1.ebuild
+++ b/media-plugins/vdr-atscepg/vdr-atscepg-0.3.0-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit vdr-plugin-2
+inherit flag-o-matic vdr-plugin-2
 
 DESCRIPTION="VDR plugin: receive schedule and event information from ATSC broadcasts"
-HOMEPAGE="http://www.fepg.org/atscepg.html"
+HOMEPAGE="http://fepg.org/atscepg/"
 SRC_URI="http://www.fepg.org/files/${P}.tgz
 		mirror://gentoo/atscepg-${PV}_vdr-1.7.13.tbz
 		https://dev.gentoo.org/~hd_brummy/distfiles/atscepg-${PV}_vdr-1.7.13.tbz"

--- a/media-plugins/vdr-skinelchi/vdr-skinelchi-0.3.0-r2.ebuild
+++ b/media-plugins/vdr-skinelchi/vdr-skinelchi-0.3.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit vdr-plugin-2
+inherit flag-o-matic vdr-plugin-2
 
 DESCRIPTION="VDR Skin Plugin: skinelchi"
 HOMEPAGE="http://firefly.vdr-developer.org/skinelchi"

--- a/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.1.0-r1.ebuild
+++ b/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.1.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs vdr-plugin-2
+inherit flag-o-matic toolchain-funcs vdr-plugin-2
 
 GENTOO_VDR_CONDITIONAL=yes
 

--- a/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.1.0-r2.ebuild
+++ b/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.1.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs vdr-plugin-2
+inherit flag-o-matic toolchain-funcs vdr-plugin-2
 
 GENTOO_VDR_CONDITIONAL=yes
 

--- a/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.2.0-r1.ebuild
+++ b/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.2.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs vdr-plugin-2
+inherit flag-o-matic toolchain-funcs vdr-plugin-2
 
 GENTOO_VDR_CONDITIONAL=yes
 

--- a/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.2.0-r2.ebuild
+++ b/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.2.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs vdr-plugin-2
+inherit flag-o-matic toolchain-funcs vdr-plugin-2
 
 GENTOO_VDR_CONDITIONAL=yes
 

--- a/media-plugins/vdr-xineliboutput/vdr-xineliboutput-9999.ebuild
+++ b/media-plugins/vdr-xineliboutput/vdr-xineliboutput-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 GENTOO_VDR_CONDITIONAL=yes
 
-inherit git-r3 toolchain-funcs vdr-plugin-2
+inherit flag-o-matic git-r3 toolchain-funcs vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: Xinelib PlugIn"
 HOMEPAGE="https://sourceforge.net/projects/xineliboutput/"


### PR DESCRIPTION
Hi,

This updates a few vdr related packages:

**media-plugins/vdr-atscepg:** calls `filter-flags`, thus needs `flag-o-matic` eclass + fixes HOMEPAGE
**media-plugins/vdr-skinelchi:** calls `append-cxxflags`, thus needs `flag-o-matic`
**media-plugins/vdr-xineliboutput:** calls `append-cxxflags`, thus needs `flag-o-matic`