### PR TITLE
dev-python/coverage: correct test deps (typo)

### DIFF
--- a/dev-python/coverage/coverage-5.0.3.ebuild
+++ b/dev-python/coverage/coverage-5.0.3.ebuild
@@ -20,9 +20,9 @@ RESTRICT="!test? ( test )"
 
 BDEPEND="
 	test? (
-		dev-python/coverage[${PYTHON_USEDEP}]
 		dev-python/PyContracts[${PYTHON_USEDEP}]
 		dev-python/flaky[${PYTHON_USEDEP}]
+		dev-python/hypothesis[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pytest[${PYTHON_USEDEP}]
 		>=dev-python/unittest-mixins-1.4[${PYTHON_USEDEP}]

--- a/dev-python/coverage/coverage-5.1.ebuild
+++ b/dev-python/coverage/coverage-5.1.ebuild
@@ -23,9 +23,9 @@ RESTRICT="test"
 
 #BDEPEND="
 #	test? (
-#		dev-python/coverage[${PYTHON_USEDEP}]
 #		dev-python/PyContracts[${PYTHON_USEDEP}]
 #		dev-python/flaky[${PYTHON_USEDEP}]
+#		dev-python/hypothesis[${PYTHON_USEDEP}]
 #		dev-python/mock[${PYTHON_USEDEP}]
 #		dev-python/pytest[${PYTHON_USEDEP}]
 #		>=dev-python/unittest-mixins-1.4[${PYTHON_USEDEP}]


### PR DESCRIPTION
This fixes my own typo in 81a8981. Apologies.

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Sam James (sam_c) <sam@cmpct.info>