### PR TITLE
media-libs/mesa: enable Zink OpenGL-over-Vulkan gallium driver

### DIFF
--- a/media-libs/mesa/mesa-20.1.5-r1.ebuild
+++ b/media-libs/mesa/mesa-20.1.5-r1.ebuild
@@ -229,6 +229,7 @@ BDEPEND="
 	)
 	sys-devel/bison
 	sys-devel/flex
+	sys-devel/gettext
 	virtual/pkgconfig
 	$(python_gen_any_dep ">=dev-python/mako-0.8.0[\${PYTHON_USEDEP}]")
 "
@@ -371,16 +372,13 @@ multilib_src_configure() {
 		fi
 	fi
 
-	local platforms
-	use X && platforms+="x11"
-	use wayland && platforms+=",wayland"
-	[[ -n $platforms ]] && emesonargs+=(-Dplatforms=${platforms#,})
+	emesonargs+=( -Dplatforms=$(use X && echo "x11,")$(use wayland && echo "wayland,")$(use gbm && echo "drm,")surfaceless )
 
 	if use gallium; then
 		emesonargs+=(
-			$(meson_feature llvm)
-			$(meson_feature lm-sensors lmsensors)
-			$(meson_feature unwind libunwind)
+			$(meson_use llvm)
+			$(meson_use lm-sensors lmsensors)
+			$(meson_use unwind libunwind)
 		)
 
 		if use video_cards_iris ||
@@ -397,34 +395,34 @@ multilib_src_configure() {
 		if use video_cards_r600 ||
 		   use video_cards_radeonsi ||
 		   use video_cards_nouveau; then
-			emesonargs+=($(meson_feature vaapi gallium-va))
+			emesonargs+=($(meson_use vaapi gallium-va))
 			use vaapi && emesonargs+=( -Dva-libs-path="${EPREFIX}"/usr/$(get_libdir)/va/drivers )
 		else
-			emesonargs+=(-Dgallium-va=disabled)
+			emesonargs+=(-Dgallium-va=false)
 		fi
 
 		if use video_cards_r300 ||
 		   use video_cards_r600 ||
 		   use video_cards_radeonsi ||
 		   use video_cards_nouveau; then
-			emesonargs+=($(meson_feature vdpau gallium-vdpau))
+			emesonargs+=($(meson_use vdpau gallium-vdpau))
 		else
-			emesonargs+=(-Dgallium-vdpau=disabled)
+			emesonargs+=(-Dgallium-vdpau=false)
 		fi
 
 		if use video_cards_freedreno ||
 		   use video_cards_nouveau ||
 		   use video_cards_vmware; then
-			emesonargs+=($(meson_feature xa gallium-xa))
+			emesonargs+=($(meson_use xa gallium-xa))
 		else
-			emesonargs+=(-Dgallium-xa=disabled)
+			emesonargs+=(-Dgallium-xa=false)
 		fi
 
 		if use video_cards_r600 ||
 		   use video_cards_nouveau; then
-			emesonargs+=($(meson_feature xvmc gallium-xvmc))
+			emesonargs+=($(meson_use xvmc gallium-xvmc))
 		else
-			emesonargs+=(-Dgallium-xvmc=disabled)
+			emesonargs+=(-Dgallium-xvmc=false)
 		fi
 
 		if use video_cards_freedreno ||
@@ -496,15 +494,15 @@ multilib_src_configure() {
 	emesonargs+=(
 		$(meson_use test build-tests)
 		-Dglx=$(usex X dri disabled)
-		-Dshared-glapi=enabled
-		$(meson_feature dri3)
-		$(meson_feature egl)
-		$(meson_feature gbm)
-		$(meson_feature gles1)
-		$(meson_feature gles2)
+		-Dshared-glapi=true
+		$(meson_use dri3)
+		$(meson_use egl)
+		$(meson_use gbm)
+		$(meson_use gles1)
+		$(meson_use gles2)
 		$(meson_use libglvnd glvnd)
 		$(meson_use selinux)
-		$(meson_feature zstd)
+		$(meson_use zstd)
 		-Dvalgrind=$(usex valgrind auto false)
 		-Ddri-drivers=$(driver_list "${DRI_DRIVERS[*]}")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")

--- a/media-libs/mesa/metadata.xml
+++ b/media-libs/mesa/metadata.xml
@@ -26,6 +26,7 @@
 		<flag name="wayland">Enable support for dev-libs/wayland</flag>
 		<flag name="xa">Enable the XA (X Acceleration) API for Gallium3D.</flag>
 		<flag name="xvmc">Enable the XvMC acceleration interface for the Gallium3D Video Layer.</flag>
+		<flag name="zink">Enable the Zink OpenGL-over-Vulkan Gallium driver</flag>
 	</use>
 	<upstream>
 		<remote-id type="cpe">cpe:/a:mesa3d:mesa</remote-id>


### PR DESCRIPTION
Please merge. Thanks.

After building Mesa with the updated ebuilds, run "MESA_LOADER_DRIVER_OVERRIDE=zink glxinfo" to view OpenGL features supported by the Zink driver.

Closes: https://bugs.gentoo.org/708838
Closes: https://github.com/gentoo/gentoo/pull/14605