### PR TITLE
app-emulation/docker-compose: ARM64 support to ebuild.

### DIFF
--- a/app-emulation/docker-compose/docker-compose-1.26.0.ebuild
+++ b/app-emulation/docker-compose/docker-compose-1.26.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/docker/compose/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/cached-property/cached-property-1.5.1.ebuild
+++ b/dev-python/cached-property/cached-property-1.5.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm64 ppc64 x86"
+KEYWORDS="amd64 ~arm64 ppc64 x86"
 
 DEPEND="
 	test? (

--- a/dev-python/cached-property/cached-property-1.5.1.ebuild
+++ b/dev-python/cached-property/cached-property-1.5.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ppc64 x86"
+KEYWORDS="amd64 arm64 ppc64 x86"
 
 DEPEND="
 	test? (

--- a/dev-python/cjkwrap/cjkwrap-2.2.ebuild
+++ b/dev-python/cjkwrap/cjkwrap-2.2.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/fgallaire/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="LGPL-3+"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 arm64 x86"
 IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"

--- a/dev-python/dockerpty/dockerpty-0.4.1-r1.ebuild
+++ b/dev-python/dockerpty/dockerpty-0.4.1-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/d11wtq/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64"
+KEYWORDS="amd64 ~arm64"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/python-dotenv/python-dotenv-0.13.0.ebuild
+++ b/dev-python/python-dotenv/python-dotenv-0.13.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="test"
 
 DEPEND="test? (

--- a/dev-python/sh/sh-1.12.14.ebuild
+++ b/dev-python/sh/sh-1.12.14.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~x86 ~amd64-linux ~x86-linux"
 
 BDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 

--- a/dev-python/texttable/texttable-1.6.2.ebuild
+++ b/dev-python/texttable/texttable-1.6.2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/foutaise/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 arm64 x86"
 IUSE="cjk test"
 
 RESTRICT="!test? ( test )"

--- a/dev-python/texttable/texttable-1.6.2.ebuild
+++ b/dev-python/texttable/texttable-1.6.2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/foutaise/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 arm64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE="cjk test"
 
 RESTRICT="!test? ( test )"


### PR DESCRIPTION
For some unknown reason it did not have the required tag so now it does.

Please let me know if this is not the right way to do it.

Related https://github.com/docker/compose/issues/7370