### PR TITLE
dev-libs/opensc: fix compilation with GCC10

### DIFF
--- a/dev-libs/opensc/files/opensc-0.20.0-gcc10.patch
+++ b/dev-libs/opensc/files/opensc-0.20.0-gcc10.patch
@@ -1,0 +1,37 @@
+From 5450f61681d0c46c587dbe789bf19f1cb573e794 Mon Sep 17 00:00:00 2001
+From: Jakub Jelen <jjelen@redhat.com>
+Date: Mon, 10 Feb 2020 15:09:17 +0100
+Subject: [PATCH] Unbreak build with -fno-common (default in gcc10)
+
+---
+ src/tests/p11test/p11test.c        | 3 +++
+ src/tests/p11test/p11test_common.h | 2 +-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/tests/p11test/p11test.c b/src/tests/p11test/p11test.c
+index feecf6fb42..a16282cba3 100644
+--- a/src/tests/p11test/p11test.c
++++ b/src/tests/p11test/p11test.c
+@@ -34,6 +34,9 @@
+ 
+ #define DEFAULT_P11LIB	"../../pkcs11/.libs/opensc-pkcs11.so"
+ 
++/* Global variable keeping information about token we are using */
++token_info_t token;
++
+ void display_usage() {
+ 	fprintf(stdout,
+ 		" Usage:\n"
+diff --git a/src/tests/p11test/p11test_common.h b/src/tests/p11test/p11test_common.h
+index 2f3b238de0..9eb5cedecb 100644
+--- a/src/tests/p11test/p11test_common.h
++++ b/src/tests/p11test/p11test_common.h
+@@ -84,7 +84,7 @@ typedef struct {
+ 	size_t  num_keygen_mechs;
+ } token_info_t;
+ 
+-token_info_t token;
++extern token_info_t token;
+ 
+ #endif /* P11TEST_COMMON_H */
+ 

--- a/dev-libs/opensc/opensc-0.20.0.ebuild
+++ b/dev-libs/opensc/opensc-0.20.0.ebuild
@@ -36,6 +36,10 @@ REQUIRED_USE="
 	ctapi? ( !pcsc-lite !openct )
 	|| ( pcsc-lite openct ctapi )"
 
+PATCHES=(
+	"${FILESDIR}/${P}-gcc10.patch"
+)
+
 src_prepare() {
 	default
 	elibtoolize


### PR DESCRIPTION
Fix compilation with -fno-commons (see https://github.com/OpenSC/OpenSC/pull/1939).
Closes: https://bugs.gentoo.org/706912
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>