### PR TITLE
app-benchmarks/stress-ng: Add apparmor use flag to dep

### DIFF
--- a/app-benchmarks/stress-ng/stress-ng-0.11.10-r1.ebuild
+++ b/app-benchmarks/stress-ng/stress-ng-0.11.10-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs
+inherit eutils toolchain-funcs
 
 DESCRIPTION="Stress test for a computer system with various selectable ways"
 HOMEPAGE="https://kernel.ubuntu.com/~cking/stress-ng/"
@@ -17,10 +17,8 @@ DEPEND="
 	dev-libs/libaio
 	dev-libs/libbsd
 	dev-libs/libgcrypt:0=
-	net-misc/lksctp-tools
 	sys-apps/attr
 	sys-apps/keyutils:=
-	sys-libs/libapparmor
 	sys-libs/libcap
 	sys-libs/zlib
 "
@@ -35,4 +33,9 @@ src_compile() {
 	tc-export CC
 
 	default
+}
+
+pkg_postinst() {
+	optfeature "apparmor support" sys-libs/libapparmor
+	optfeature "SCTP support" net-misc/lksctp-tools
 }


### PR DESCRIPTION
This program auto-detects various libraries such as libapparmor and
compiles in support for them at runtime. Therefore we don't need to have
libapparmor to actually compile this program. Put it behind the
'apparmor' USE flag so that systems without apparmor can compile this.

Closes: https://bugs.gentoo.org/728728
Signed-off-by: Stephen Boyd <swboyd@chromium.org>