### PR TITLE
www-client/chromium: restrict version of media-video/ffmpeg

### DIFF
--- a/www-client/chromium/chromium-83.0.4103.106.ebuild
+++ b/www-client/chromium/chromium-83.0.4103.106.ebuild
@@ -42,7 +42,8 @@ COMMON_DEPEND="
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc,svc] )
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? (
-		>=media-video/ffmpeg-4:=
+		>=media-video/ffmpeg-4:0
+		<media-video/ffmpeg-4.3:0=
 		|| (
 			media-video/ffmpeg[-samba]
 			>=net-fs/samba-4.5.10-r1[-debug(-)]

--- a/www-client/chromium/chromium-84.0.4147.45.ebuild
+++ b/www-client/chromium/chromium-84.0.4147.45.ebuild
@@ -47,7 +47,8 @@ COMMON_DEPEND="
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc,svc] )
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? (
-		>=media-video/ffmpeg-4:=
+		>=media-video/ffmpeg-4:0
+		<media-video/ffmpeg-4.3:0=
 		|| (
 			media-video/ffmpeg[-samba]
 			>=net-fs/samba-4.5.10-r1[-debug(-)]


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/728624
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>