### PR TITLE
sys-kernel/gentoo-kernel: add req'd tools to BDEPEND

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -36,7 +36,9 @@ inherit savedconfig toolchain-funcs kernel-install
 
 BDEPEND="
 	sys-devel/bc
-	virtual/libelf"
+	virtual/libelf
+	virtual/yacc
+	sys-devel/flex"
 
 # @FUNCTION: kernel-build_src_configure
 # @DESCRIPTION:


### PR DESCRIPTION
These tools are required when building the kernel.  Helpful for those who like to use `--with-bdeps=n`