### PR TITLE
sci-chemistry/openbabel: Fix build with gcc 10+

### DIFF
--- a/sci-chemistry/openbabel/files/openbabel-2.4.1-gcc-8.patch
+++ b/sci-chemistry/openbabel/files/openbabel-2.4.1-gcc-8.patch
@@ -9,7 +9,7 @@ index dc38d1b..801207e 100644
  if(CMAKE_COMPILER_IS_GNUCXX)
    exec_program(${CMAKE_C_COMPILER} ARGS --version OUTPUT_VARIABLE _gcc_version_info)
 -  string(REGEX MATCH "[34567]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
-+  string(REGEX MATCH "[3456789]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
++  string(REGEX MATCH "([3456789]|1[0-9])\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
    # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
    # patch level, handle this here:
    if (NOT _gcc_version)


### PR DESCRIPTION
Change the regex in the originaly existing patch to allow build with GCC 10-19.