### PR TITLE
www-client/chromium: Silence some GCC warnings

### DIFF
--- a/www-client/chromium/chromium-84.0.4147.45-r1.ebuild
+++ b/www-client/chromium/chromium-84.0.4147.45-r1.ebuild
@@ -658,6 +658,9 @@ src_configure() {
 	# Chromium relies on this, but was disabled in >=clang-10, crbug.com/1042470
 	append-cxxflags $(test-flags-CXX -flax-vector-conversions=all)
 
+	# Silence lots of GCC warnings upstream doesn't seem to care about
+	append-cxxflags -Wno-invalid-offsetof -Wno-attributes -Wno-pragmas
+
 	# Explicitly disable ICU data file support for system-icu builds.
 	if use system-icu; then
 		myconf_gn+=" icu_use_data_file=false"


### PR DESCRIPTION
Silence some warnings specific to GCC that keep appearing for a very
long time.  Since upstream does not care about GCC, they are unlikely
to ever disappear.  Since they often affect header files, they repeat
often and unnecessarily increase build log size.

Signed-off-by: Michał Górny <mgorny@gentoo.org>