### PR TITLE
net-misc/endlessh: forgotten patch, respect CFLAGS in 9999

### DIFF
--- a/net-misc/endlessh/endlessh-1.1.ebuild
+++ b/net-misc/endlessh/endlessh-1.1.ebuild
@@ -24,6 +24,10 @@ DEPEND=""
 RDEPEND=""
 BDEPEND=""
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.1-syslog-help.patch
+)
+
 src_prepare() {
 	default
 

--- a/net-misc/endlessh/endlessh-9999.ebuild
+++ b/net-misc/endlessh/endlessh-9999.ebuild
@@ -24,6 +24,10 @@ DEPEND=""
 RDEPEND=""
 BDEPEND=""
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.1-syslog-help.patch
+)
+
 src_prepare() {
 	default
 

--- a/net-misc/endlessh/endlessh-9999.ebuild
+++ b/net-misc/endlessh/endlessh-9999.ebuild
@@ -35,7 +35,7 @@ src_prepare() {
 
 	sed -i \
 		-e 's/^CC/CC?/' \
-		-e 's/^CFLAGS  =/CFLAGS  +=/' \
+		-e 's/^CFLAGS   =/CFLAGS   +=/' \
 		-e 's/ -Os//' \
 		-e 's/^LDFLAGS/LDFLAGS?/' \
 		-e 's/^PREFIX/PREFIX?/' \


### PR DESCRIPTION
- Apply forgotten patch to net-misc/endlessh
- Fix respecting CFLAGS in 9999