### PR TITLE
Replace http:// with https:// in many packages

### DIFF
--- a/app-emulation/xtrs/xtrs-4.9d-r5.ebuild
+++ b/app-emulation/xtrs/xtrs-4.9d-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,10 +6,10 @@ EAPI=6
 inherit flag-o-matic toolchain-funcs readme.gentoo-r1
 
 DESCRIPTION="Radio Shack TRS-80 emulator"
-HOMEPAGE="http://www.tim-mann.org/xtrs.html"
-SRC_URI="http://www.tim-mann.org/trs80/${P}.tar.gz
+HOMEPAGE="https://www.tim-mann.org/xtrs.html"
+SRC_URI="https://www.tim-mann.org/trs80/${P}.tar.gz
 	ls-dos? (
-		http://www.tim-mann.org/trs80/ld4-631.zip
+		https://www.tim-mann.org/trs80/ld4-631.zip
 		https://dev.gentoo.org/~ulm/distfiles/ld4-631l.xd3
 	)"
 

--- a/app-metrics/prometheus-bin/prometheus-bin-2.15.2.ebuild
+++ b/app-metrics/prometheus-bin/prometheus-bin-2.15.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="prometheus monitoring system and time series database"
-HOMEPAGE="http://prometheus.io"
+HOMEPAGE="https://prometheus.io"
 MY_PN=${PN%%-bin}
 MY_P=${MY_PN}-${PV}
 SRC_URI="https://github.com/prometheus/prometheus/releases/download/v${PV}/${MY_P}.linux-amd64.tar.gz"

--- a/app-text/flpsed/flpsed-0.7.3.ebuild
+++ b/app-text/flpsed/flpsed-0.7.3.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 inherit desktop
 
 DESCRIPTION="Pseudo PostScript editor"
-HOMEPAGE="http://flpsed.org/flpsed.html"
-SRC_URI="http://flpsed.org/${P}.tar.gz"
+HOMEPAGE="https://flpsed.org/flpsed.html"
+SRC_URI="https://flpsed.org/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-text/xiphos/xiphos-4.0.6a-r2.ebuild
+++ b/app-text/xiphos/xiphos-4.0.6a-r2.ebuild
@@ -8,7 +8,7 @@ inherit flag-o-matic gnome2-utils python-single-r1 toolchain-funcs
 MY_PV="${PV}-20170820"
 MY_P="${PN}-${MY_PV}"
 DESCRIPTION="A bible study frontend for Sword (formerly known as GnomeSword)"
-HOMEPAGE="http://xiphos.org/"
+HOMEPAGE="https://xiphos.org/"
 SRC_URI="https://github.com/crosswire/${PN}/releases/download/${PV}/${MY_P}.tar.gz"
 
 LICENSE="GPL-2 FDL-1.1 LGPL-2 MIT MPL-1.1"

--- a/app-text/xiphos/xiphos-4.1.0-r2.ebuild
+++ b/app-text/xiphos/xiphos-4.1.0-r2.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python2_7 )
 inherit flag-o-matic gnome2-utils python-single-r1 toolchain-funcs
 
 DESCRIPTION="A bible study frontend for Sword (formerly known as GnomeSword)"
-HOMEPAGE="http://xiphos.org/"
+HOMEPAGE="https://xiphos.org/"
 SRC_URI="https://github.com/crosswire/${PN}/releases/download/${PV}/${P}.tar.gz"
 
 LICENSE="GPL-2 FDL-1.1 LGPL-2 MIT MPL-1.1"

--- a/app-text/zathura/zathura-0.4.3.ebuild
+++ b/app-text/zathura/zathura-0.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit meson virtualx
 
 DESCRIPTION="A highly customizable and functional document viewer"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3

--- a/app-text/zathura/zathura-0.4.4.ebuild
+++ b/app-text/zathura/zathura-0.4.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit meson virtualx
 
 DESCRIPTION="A highly customizable and functional document viewer"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3

--- a/app-text/zathura/zathura-0.4.5.ebuild
+++ b/app-text/zathura/zathura-0.4.5.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit meson virtualx
 
 DESCRIPTION="A highly customizable and functional document viewer"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3

--- a/app-text/zathura/zathura-9999.ebuild
+++ b/app-text/zathura/zathura-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit meson virtualx
 
 DESCRIPTION="A highly customizable and functional document viewer"
-HOMEPAGE="http://pwmt.org/projects/zathura/"
+HOMEPAGE="https://pwmt.org/projects/zathura/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3

--- a/app-vim/exheres-syntax/exheres-syntax-20090310.ebuild
+++ b/app-vim/exheres-syntax/exheres-syntax-20090310.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: exheres format highlighting"
-HOMEPAGE="http://www.exherbo.org/"
-SRC_URI="http://dev.exherbo.org/~ahf/pub/software/releases/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://www.exherbo.org/"
+SRC_URI="https://dev.exherbo.org/~ahf/pub/software/releases/${PN}/${P}.tar.bz2"
 
 LICENSE="vim"
 SLOT="0"

--- a/app-vim/exheres-syntax/exheres-syntax-99999999.ebuild
+++ b/app-vim/exheres-syntax/exheres-syntax-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit vim-plugin git-r3
 
 DESCRIPTION="vim plugin: exheres format highlighting"
-HOMEPAGE="http://www.exherbo.org/"
+HOMEPAGE="https://www.exherbo.org/"
 EGIT_REPO_URI="https://git.exherbo.org/git/exheres-syntax.git"
 
 LICENSE="vim"

--- a/dev-embedded/zmac/zmac-1.3-r1.ebuild
+++ b/dev-embedded/zmac/zmac-1.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Z80 macro cross-assembler"
-HOMEPAGE="http://www.tim-mann.org/trs80resources.html"
-SRC_URI="http://www.tim-mann.org/trs80/${PN}${PV//.}.zip"
+HOMEPAGE="https://www.tim-mann.org/trs80resources.html"
+SRC_URI="https://www.tim-mann.org/trs80/${PN}${PV//.}.zip"
 
 LICENSE="public-domain"
 SLOT="0"

--- a/dev-ruby/tokyocabinet/tokyocabinet-1.32.0.ebuild
+++ b/dev-ruby/tokyocabinet/tokyocabinet-1.32.0.ebuild
@@ -11,7 +11,7 @@ RUBY_FAKEGEM_TASK_TEST=""
 inherit ruby-fakegem
 
 DESCRIPTION="Ruby bindings for Tokyo Cabinet"
-HOMEPAGE="http://fallabs.com/tokyocabinet/"
+HOMEPAGE="https://fallabs.com/tokyocabinet/"
 LICENSE="GPL-2"
 
 KEYWORDS="~amd64 ~ppc ~x86"

--- a/dev-tex/latex2html/latex2html-2015.ebuild
+++ b/dev-tex/latex2html/latex2html-2015.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 
 DESCRIPTION="Convertor written in Perl that converts LATEX documents to HTML"
-HOMEPAGE="http://www.latex2html.org/"
+HOMEPAGE="https://www.latex2html.org/"
 SRC_URI="http://mirrors.ctan.org/support/latex2html/latex2html-2015.tar.gz"
 
 LICENSE="GPL-2"

--- a/dev-tex/latex2html/latex2html-2017.2-r2.ebuild
+++ b/dev-tex/latex2html/latex2html-2017.2-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 
 DESCRIPTION="Convertor written in Perl that converts LATEX documents to HTML"
-HOMEPAGE="http://www.latex2html.org/"
+HOMEPAGE="https://www.latex2html.org/"
 SRC_URI="http://mirrors.ctan.org/support/latex2html/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/games-misc/fortune-mod-mormon/fortune-mod-mormon-1.1.0.ebuild
+++ b/games-misc/fortune-mod-mormon/fortune-mod-mormon-1.1.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=5
 
 DESCRIPTION="Fortune modules from the LDS scriptures (KJV Bible, Book of Mormon, D&C, PGP)"
-HOMEPAGE="http://scriptures.nephi.org/"
+HOMEPAGE="https://scriptures.nephi.org/"
 SRC_URI="mirror://sourceforge/mormon/${P}.tar.bz2"
 
 LICENSE="public-domain"

--- a/games-misc/fortune-mod-scriptures/fortune-mod-scriptures-1.1.0.ebuild
+++ b/games-misc/fortune-mod-scriptures/fortune-mod-scriptures-1.1.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=5
 
 DESCRIPTION="Fortune modules from the King James Bible scriptures"
-HOMEPAGE="http://scriptures.nephi.org/"
+HOMEPAGE="https://scriptures.nephi.org/"
 SRC_URI="mirror://sourceforge/mormon/${P}.tar.bz2"
 
 LICENSE="public-domain"

--- a/media-libs/libshout/libshout-2.4.1-r2.ebuild
+++ b/media-libs/libshout/libshout-2.4.1-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools multilib-minimal
 
 DESCRIPTION="library for connecting and sending data to icecast servers"
-HOMEPAGE="http://www.icecast.org/"
+HOMEPAGE="https://www.icecast.org/"
 SRC_URI="http://downloads.xiph.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2"

--- a/media-libs/libshout/libshout-2.4.2.ebuild
+++ b/media-libs/libshout/libshout-2.4.2.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools multilib-minimal
 
 DESCRIPTION="library for connecting and sending data to icecast servers"
-HOMEPAGE="http://www.icecast.org/"
+HOMEPAGE="https://www.icecast.org/"
 SRC_URI="http://downloads.xiph.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2"

--- a/media-libs/libshout/libshout-2.4.3.ebuild
+++ b/media-libs/libshout/libshout-2.4.3.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools multilib-minimal
 
 DESCRIPTION="library for connecting and sending data to icecast servers"
-HOMEPAGE="http://www.icecast.org/"
+HOMEPAGE="https://www.icecast.org/"
 SRC_URI="http://downloads.xiph.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2"

--- a/media-radio/xwxapt/xwxapt-3.4.2.ebuild
+++ b/media-radio/xwxapt/xwxapt-3.4.2.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="GTK+ linux weather satellite APT image decoder software"
-HOMEPAGE="http://www.qsl.net/5b4az/pages/apt.html"
-SRC_URI="http://www.qsl.net/5b4az/pkg/apt/${PN}/${P}.tar.bz2"
+HOMEPAGE="https://www.qsl.net/5b4az/pages/apt.html"
+SRC_URI="https://www.qsl.net/5b4az/pkg/apt/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/media-sound/ezstream/ezstream-0.6.0-r1.ebuild
+++ b/media-sound/ezstream/ezstream-0.6.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 
 DESCRIPTION="A command line source client for Icecast media streaming servers"
-HOMEPAGE="http://www.icecast.org/ezstream/"
+HOMEPAGE="https://www.icecast.org/ezstream/"
 SRC_URI="http://downloads.xiph.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/media-sound/music-file-organizer/music-file-organizer-1.0.2.ebuild
+++ b/media-sound/music-file-organizer/music-file-organizer-1.0.2.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 
 DESCRIPTION="Organizes audio files into directories based on metadata tags,
 along with other metadata utilities."
-HOMEPAGE="http://blog.zx2c4.com/813"
-SRC_URI="http://git.zx2c4.com/music-file-organizer/snapshot/${P}.tar.xz"
+HOMEPAGE="https://git.zx2c4.com/music-file-organizer/about/"
+SRC_URI="https://git.zx2c4.com/music-file-organizer/snapshot/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-sound/twolame/twolame-0.3.13-r2.ebuild
+++ b/media-sound/twolame/twolame-0.3.13-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit eutils ltprune multilib-minimal
 
 DESCRIPTION="An optimised MPEG Audio Layer 2 (MP2) encoder"
-HOMEPAGE="http://www.twolame.org"
+HOMEPAGE="https://www.twolame.org"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/media-sound/twolame/twolame-0.4.0.ebuild
+++ b/media-sound/twolame/twolame-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit multilib-minimal
 
 DESCRIPTION="An optimised MPEG Audio Layer 2 (MP2) encoder"
-HOMEPAGE="http://www.twolame.org"
+HOMEPAGE="https://www.twolame.org"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-analyzer/nsca/nsca-2.7.2-r103.ebuild
+++ b/net-analyzer/nsca/nsca-2.7.2-r103.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 inherit multilib user eutils
 
 DESCRIPTION="Nagios Service Check Acceptor"
-HOMEPAGE="http://www.nagios.org/"
+HOMEPAGE="https://www.nagios.org/"
 SRC_URI="mirror://sourceforge/nagios/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-mail/fetchmail/fetchmail-6.4.1.ebuild
+++ b/net-mail/fetchmail/fetchmail-6.4.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_REQ_USE="tk"
 inherit python-single-r1 user systemd toolchain-funcs autotools
 
 DESCRIPTION="the legendary remote-mail retrieval and forwarding utility"
-HOMEPAGE="http://www.fetchmail.info/"
+HOMEPAGE="https://www.fetchmail.info/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2 public-domain"

--- a/net-mail/fetchmail/fetchmail-6.4.6.ebuild
+++ b/net-mail/fetchmail/fetchmail-6.4.6.ebuild
@@ -9,7 +9,7 @@ PYTHON_REQ_USE="tk"
 inherit python-single-r1 systemd toolchain-funcs autotools
 
 DESCRIPTION="the legendary remote-mail retrieval and forwarding utility"
-HOMEPAGE="http://www.fetchmail.info/"
+HOMEPAGE="https://www.fetchmail.info/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2 public-domain"

--- a/net-mail/fetchmail/fetchmail-6.4.8.ebuild
+++ b/net-mail/fetchmail/fetchmail-6.4.8.ebuild
@@ -9,7 +9,7 @@ PYTHON_REQ_USE="tk"
 inherit python-single-r1 systemd toolchain-funcs autotools
 
 DESCRIPTION="the legendary remote-mail retrieval and forwarding utility"
-HOMEPAGE="http://www.fetchmail.info/"
+HOMEPAGE="https://www.fetchmail.info/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2 public-domain"

--- a/sci-astronomy/wcslib/wcslib-5.16.ebuild
+++ b/sci-astronomy/wcslib/wcslib-5.16.ebuild
@@ -8,7 +8,7 @@ FORTRAN_NEEDED=fortran
 inherit fortran-2
 
 DESCRIPTION="Astronomical World Coordinate System transformations library"
-HOMEPAGE="http://www.atnf.csiro.au/people/mcalabre/WCS/"
+HOMEPAGE="https://www.atnf.csiro.au/people/mcalabre/WCS/"
 SRC_URI="ftp://ftp.atnf.csiro.au/pub/software/${PN}/${P}.tar.bz2"
 
 SLOT="0/5"

--- a/sci-chemistry/pymol-plugins-promol/pymol-plugins-promol-3.0.2-r1.ebuild
+++ b/sci-chemistry/pymol-plugins-promol/pymol-plugins-promol-3.0.2-r1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit python-r1
 
 DESCRIPTION="Fast and accurate regognition of active sites"
-HOMEPAGE="http://www.rit.edu/cos/ezviz/ProMOL_dl.html"
-SRC_URI="http://www.rit.edu/cos/ezviz/ProMOL.zip -> ${P}.zip"
+HOMEPAGE="https://www.rit.edu/cos/ezviz/ProMOL_dl.html"
+SRC_URI="https://www.rit.edu/cos/ezviz/ProMOL.zip -> ${P}.zip"
 
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux"

--- a/sci-electronics/gsmc/gsmc-1.1-r2.ebuild
+++ b/sci-electronics/gsmc/gsmc-1.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit autotools eutils
 
 DESCRIPTION="A GTK program for doing Smith Chart calculations"
-HOMEPAGE="http://www.qsl.net/ik5nax/"
-SRC_URI="http://www.qsl.net/ik5nax/${P}.tar.gz"
+HOMEPAGE="https://www.qsl.net/ik5nax/"
+SRC_URI="https://www.qsl.net/ik5nax/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-electronics/splat/splat-1.4.2.ebuild
+++ b/sci-electronics/splat/splat-1.4.2.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
 inherit eutils toolchain-funcs
 
 DESCRIPTION="RF Signal Propagation, Loss, And Terrain analysis tool"
-HOMEPAGE="http://www.qsl.net/kd2bd/splat.html"
-SRC_URI="http://www.qsl.net/kd2bd/${P}.tar.bz2"
+HOMEPAGE="https://www.qsl.net/kd2bd/splat.html"
+SRC_URI="https://www.qsl.net/kd2bd/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-electronics/systemc/systemc-2.3.1-r1.ebuild
+++ b/sci-electronics/systemc/systemc-2.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -7,8 +7,8 @@ inherit eutils toolchain-funcs autotools-utils
 MY_P="${P}a"
 
 DESCRIPTION="A C++ based modeling platform for VLSI and system-level co-design"
-HOMEPAGE="http://accellera.org/community/systemc"
-SRC_URI="http://accellera.org/images/downloads/standards/${PN}/${MY_P}.tar.gz"
+HOMEPAGE="https://accellera.org/community/systemc"
+SRC_URI="https://accellera.org/images/downloads/standards/${PN}/${MY_P}.tar.gz"
 
 SLOT="0"
 LICENSE="Apache-2.0"

--- a/sci-electronics/voacapl/voacapl-0.6.7.ebuild
+++ b/sci-electronics/voacapl/voacapl-0.6.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -6,8 +6,8 @@ EAPI="5"
 inherit fortran-2
 
 DESCRIPTION="HF propagation prediction tool"
-HOMEPAGE="http://www.qsl.net/hz1jw/voacapl/index.html"
-SRC_URI="http://www.qsl.net/hz1jw/${PN}/downloads/${P}.tar.gz"
+HOMEPAGE="https://www.qsl.net/hz1jw/voacapl/index.html"
+SRC_URI="https://www.qsl.net/hz1jw/${PN}/downloads/${P}.tar.gz"
 
 LICENSE="all-rights-reserved"
 SLOT="0"

--- a/sci-electronics/voacapl/voacapl-0.7.2.ebuild
+++ b/sci-electronics/voacapl/voacapl-0.7.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -6,8 +6,8 @@ EAPI="6"
 inherit fortran-2
 
 DESCRIPTION="HF propagation prediction tool"
-HOMEPAGE="http://www.qsl.net/hz1jw/voacapl/index.html"
-SRC_URI="http://www.qsl.net/hz1jw/${PN}/downloads/${P}.tar.gz"
+HOMEPAGE="https://www.qsl.net/hz1jw/voacapl/index.html"
+SRC_URI="https://www.qsl.net/hz1jw/${PN}/downloads/${P}.tar.gz"
 
 LICENSE="all-rights-reserved"
 SLOT="0"

--- a/sci-electronics/xnec2c/xnec2c-3.5.1.ebuild
+++ b/sci-electronics/xnec2c/xnec2c-3.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit autotools eutils
 
 DESCRIPTION="A GTK+ graphical interactive version of nec2c"
-HOMEPAGE="http://www.qsl.net/5b4az/pages/nec2.html"
-SRC_URI="http://www.qsl.net/5b4az/pkg/nec2/xnec2c/${P}.tar.bz2"
+HOMEPAGE="https://www.qsl.net/5b4az/pages/nec2.html"
+SRC_URI="https://www.qsl.net/5b4az/pkg/nec2/xnec2c/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-libs/hdf/hdf-4.2.11.ebuild
+++ b/sci-libs/hdf/hdf-4.2.11.ebuild
@@ -10,8 +10,8 @@ inherit fortran-2 toolchain-funcs autotools flag-o-matic ltprune
 MYP=${P/_p/-patch}
 
 DESCRIPTION="General purpose library and format for storing scientific data"
-HOMEPAGE="http://www.hdfgroup.org/hdf4.html"
-SRC_URI="http://www.hdfgroup.org/ftp/HDF/HDF_Current/src/${MYP}.tar.bz2"
+HOMEPAGE="https://www.hdfgroup.org/hdf4.html"
+SRC_URI="https://www.hdfgroup.org/ftp/HDF/HDF_Current/src/${MYP}.tar.bz2"
 
 SLOT="0"
 LICENSE="NCSA-HDF"

--- a/sci-libs/hdf/hdf-4.2.13-r1.ebuild
+++ b/sci-libs/hdf/hdf-4.2.13-r1.ebuild
@@ -10,8 +10,8 @@ inherit fortran-2 toolchain-funcs autotools flag-o-matic ltprune
 MYP=${P/_p/-patch}
 
 DESCRIPTION="General purpose library and format for storing scientific data"
-HOMEPAGE="http://www.hdfgroup.org/hdf4.html"
-SRC_URI="http://www.hdfgroup.org/ftp/HDF/HDF_Current/src/${MYP}.tar.bz2"
+HOMEPAGE="https://www.hdfgroup.org/hdf4.html"
+SRC_URI="https://www.hdfgroup.org/ftp/HDF/HDF_Current/src/${MYP}.tar.bz2"
 
 SLOT="0"
 LICENSE="NCSA-HDF"

--- a/sci-libs/hdf/hdf-4.2.13.ebuild
+++ b/sci-libs/hdf/hdf-4.2.13.ebuild
@@ -10,8 +10,8 @@ inherit fortran-2 toolchain-funcs autotools flag-o-matic ltprune
 MYP=${P/_p/-patch}
 
 DESCRIPTION="General purpose library and format for storing scientific data"
-HOMEPAGE="http://www.hdfgroup.org/hdf4.html"
-SRC_URI="http://www.hdfgroup.org/ftp/HDF/HDF_Current/src/${MYP}.tar.bz2"
+HOMEPAGE="https://www.hdfgroup.org/hdf4.html"
+SRC_URI="https://www.hdfgroup.org/ftp/HDF/HDF_Current/src/${MYP}.tar.bz2"
 
 SLOT="0"
 LICENSE="NCSA-HDF"

--- a/sci-libs/hdf5/hdf5-1.10.5-r1.ebuild
+++ b/sci-libs/hdf5/hdf5-1.10.5-r1.ebuild
@@ -11,8 +11,8 @@ MY_P="${PN}-${PV/_p/-patch}"
 MAJOR_P="${PN}-$(ver_cut 1-2)"
 
 DESCRIPTION="General purpose library and file format for storing scientific data"
-HOMEPAGE="http://www.hdfgroup.org/HDF5/"
-SRC_URI="http://www.hdfgroup.org/ftp/HDF5/releases/${MAJOR_P}/${MY_P}/src/${MY_P}.tar.bz2"
+HOMEPAGE="https://www.hdfgroup.org/HDF5/"
+SRC_URI="https://www.hdfgroup.org/ftp/HDF5/releases/${MAJOR_P}/${MY_P}/src/${MY_P}.tar.bz2"
 
 LICENSE="NCSA-HDF"
 SLOT="0/${PV%%_p*}"

--- a/sci-libs/hdf5/hdf5-1.10.5.ebuild
+++ b/sci-libs/hdf5/hdf5-1.10.5.ebuild
@@ -11,8 +11,8 @@ MY_P=${PN}-${PV/_p/-patch}
 MAJOR_P=${PN}-$(ver_cut 1-2)
 
 DESCRIPTION="General purpose library and file format for storing scientific data"
-HOMEPAGE="http://www.hdfgroup.org/HDF5/"
-SRC_URI="http://www.hdfgroup.org/ftp/HDF5/releases/${MAJOR_P}/${MY_P}/src/${MY_P}.tar.bz2"
+HOMEPAGE="https://www.hdfgroup.org/HDF5/"
+SRC_URI="https://www.hdfgroup.org/ftp/HDF5/releases/${MAJOR_P}/${MY_P}/src/${MY_P}.tar.bz2"
 
 LICENSE="NCSA-HDF"
 SLOT="0/${PV%%_p*}"

--- a/sci-libs/pgplot/pgplot-5.2.2-r7.ebuild
+++ b/sci-libs/pgplot/pgplot-5.2.2-r7.ebuild
@@ -8,7 +8,7 @@ inherit eutils fortran-2 toolchain-funcs
 MY_P="${PN}${PV//.}"
 
 DESCRIPTION="FORTRAN/C device-independent scientific graphic library"
-HOMEPAGE="http://www.astro.caltech.edu/~tjp/pgplot/"
+HOMEPAGE="https://www.astro.caltech.edu/~tjp/pgplot/"
 SRC_URI="ftp://ftp.astro.caltech.edu/pub/pgplot/${MY_P}.tar.gz"
 
 SLOT="0"

--- a/sci-libs/szip/szip-2.1-r2.ebuild
+++ b/sci-libs/szip/szip-2.1-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 
 DESCRIPTION="Extended-Rice lossless compression algorithm implementation"
-HOMEPAGE="http://www.hdfgroup.org/doc_resource/SZIP/"
+HOMEPAGE="https://www.hdfgroup.org/doc_resource/SZIP/"
 SRC_URI="ftp://ftp.hdfgroup.org/lib-external/${PN}/${PV}/src/${P}.tar.gz"
 
 LICENSE="szip"

--- a/sci-mathematics/petsc/petsc-3.13.0.ebuild
+++ b/sci-mathematics/petsc/petsc-3.13.0.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{6,7,8} )
 inherit flag-o-matic fortran-2 python-any-r1 toolchain-funcs
 
 DESCRIPTION="Portable, Extensible Toolkit for Scientific Computation"
-HOMEPAGE="http://www.mcs.anl.gov/petsc/"
+HOMEPAGE="https://www.mcs.anl.gov/petsc/"
 SRC_URI="http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/${P}.tar.gz"
 
 LICENSE="BSD-2"

--- a/sci-mathematics/petsc/petsc-3.13.1.ebuild
+++ b/sci-mathematics/petsc/petsc-3.13.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{6,7,8} )
 inherit flag-o-matic fortran-2 python-any-r1 toolchain-funcs
 
 DESCRIPTION="Portable, Extensible Toolkit for Scientific Computation"
-HOMEPAGE="http://www.mcs.anl.gov/petsc/"
+HOMEPAGE="https://www.mcs.anl.gov/petsc/"
 SRC_URI="http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/${P}.tar.gz"
 
 LICENSE="BSD-2"

--- a/sci-mathematics/polymake/polymake-3.0_p2.ebuild
+++ b/sci-mathematics/polymake/polymake-3.0_p2.ebuild
@@ -7,7 +7,7 @@ inherit eutils flag-o-matic
 
 DESCRIPTION="research tool for polyhedral geometry and combinatorics"
 SRC_URI="https://polymake.org/lib/exe/fetch.php/download/polymake-3.0r2.tar.bz2"
-HOMEPAGE="http://polymake.org"
+HOMEPAGE="https://polymake.org"
 
 IUSE="+cdd lrs ppl bliss group +libnormaliz singular libpolymake"
 
@@ -80,7 +80,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	elog "Docs can be found on http://www.polymake.org/doku.php/documentation"
+	elog "Docs can be found on https://www.polymake.org/doku.php/documentation"
 	elog " "
 	elog "Support for jreality is missing, sorry (see bug #346073)."
 	elog " "

--- a/sci-mathematics/singular/singular-4.0.2.ebuild
+++ b/sci-mathematics/singular/singular-4.0.2.ebuild
@@ -14,9 +14,9 @@ MY_DIR=$(replace_all_version_separators '-' ${MY_DIR2})
 MY_SHARE_DIR="${WORKDIR}"/share/
 
 DESCRIPTION="Computer algebra system for polynomial computations"
-HOMEPAGE="http://www.singular.uni-kl.de/"
-SRC_URI="http://www.mathematik.uni-kl.de/ftp/pub/Math/${MY_PN}/SOURCES/${MY_DIR}/${PN}-${MY_PV}.tar.gz
-		 http://www.mathematik.uni-kl.de/ftp/pub/Math/${MY_PN}/SOURCES/${MY_DIR}/${PN}-${MY_PV}-share.tar.gz"
+HOMEPAGE="https://www.singular.uni-kl.de/"
+SRC_URI="https://www.mathematik.uni-kl.de/ftp/pub/Math/${MY_PN}/SOURCES/${MY_DIR}/${PN}-${MY_PV}.tar.gz
+		 https://www.mathematik.uni-kl.de/ftp/pub/Math/${MY_PN}/SOURCES/${MY_DIR}/${PN}-${MY_PV}-share.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-mathematics/singular/singular-4.0.3.ebuild
+++ b/sci-mathematics/singular/singular-4.0.3.ebuild
@@ -13,9 +13,9 @@ MY_DIR=$(replace_all_version_separators '-' ${MY_DIR2})
 # This is where the share tarball unpacks to
 
 DESCRIPTION="Computer algebra system for polynomial computations"
-HOMEPAGE="http://www.singular.uni-kl.de/"
-SRC_URI="http://www.mathematik.uni-kl.de/ftp/pub/Math/${MY_PN}/SOURCES/${MY_DIR}/${PN}-${MY_PV}.tar.gz
-		 http://www.mathematik.uni-kl.de/ftp/pub/Math/${MY_PN}/SOURCES/${MY_DIR}/${PN}-${MY_PV}-share.tar.gz"
+HOMEPAGE="https://www.singular.uni-kl.de/"
+SRC_URI="https://www.mathematik.uni-kl.de/ftp/pub/Math/${MY_PN}/SOURCES/${MY_DIR}/${PN}-${MY_PV}.tar.gz
+		 https://www.mathematik.uni-kl.de/ftp/pub/Math/${MY_PN}/SOURCES/${MY_DIR}/${PN}-${MY_PV}-share.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-mathematics/slepc/slepc-3.13.1.ebuild
+++ b/sci-mathematics/slepc/slepc-3.13.1.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python3_{6,7,8} )
 inherit eutils flag-o-matic python-any-r1 toolchain-funcs
 
 DESCRIPTION="Scalable Library for Eigenvalue Problem Computations"
-HOMEPAGE="http://slepc.upv.es/"
-SRC_URI="http://slepc.upv.es/download/distrib/${P}.tar.gz"
+HOMEPAGE="https://slepc.upv.es/"
+SRC_URI="https://slepc.upv.es/download/distrib/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0"

--- a/sci-misc/vitables/vitables-3.0.0-r1.ebuild
+++ b/sci-misc/vitables/vitables-3.0.0-r1.ebuild
@@ -11,7 +11,7 @@ inherit distutils-r1
 MY_P=ViTables-${PV}
 
 DESCRIPTION="A graphical tool for browsing / editing files in both PyTables and HDF5 formats"
-HOMEPAGE="http://vitables.org/"
+HOMEPAGE="https://vitables.org/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/sci-visualization/epix/epix-1.2.11-r2.ebuild
+++ b/sci-visualization/epix/epix-1.2.11-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit elisp-common bash-completion-r1 autotools eutils
 
 DESCRIPTION="2- and 3-D plotter for creating images (to be used in LaTeX)"
-HOMEPAGE="http://mathcs.holycross.edu/~ahwang/current/ePiX.html"
-SRC_URI="http://mathcs.holycross.edu/~ahwang/epix/${P}_withpdf.tar.bz2"
+HOMEPAGE="https://mathcs.holycross.edu/~ahwang/current/ePiX.html"
+SRC_URI="https://mathcs.holycross.edu/~ahwang/epix/${P}_withpdf.tar.bz2"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/sys-firmware/ipxe/ipxe-1.0.0_p20180211.ebuild
+++ b/sys-firmware/ipxe/ipxe-1.0.0_p20180211.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,7 +9,7 @@ GIT_REV="546dd51de8459d4d09958891f426fa2c73ff090d"
 GIT_SHORT=${GIT_REV:0:7}
 
 DESCRIPTION="Open source network boot (PXE) firmware"
-HOMEPAGE="http://ipxe.org/"
+HOMEPAGE="https://ipxe.org/"
 SRC_URI="
 	!binary? ( https://git.ipxe.org/ipxe.git/snapshot/${GIT_REV}.tar.bz2 -> ${P}-${GIT_SHORT}.tar.bz2 )
 	binary? ( https://dev.gentoo.org/~tamiko/distfiles/${P}-${GIT_SHORT}-bin.tar.xz )"

--- a/sys-firmware/ipxe/ipxe-1.0.0_p20190728.ebuild
+++ b/sys-firmware/ipxe/ipxe-1.0.0_p20190728.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -9,7 +9,7 @@ GIT_REV="a4f8c6e31f6c62522cfc633bbbffa81b22f9d6f3"
 GIT_SHORT=${GIT_REV:0:7}
 
 DESCRIPTION="Open source network boot (PXE) firmware"
-HOMEPAGE="http://ipxe.org/"
+HOMEPAGE="https://ipxe.org/"
 SRC_URI="
 	!binary? ( https://git.ipxe.org/ipxe.git/snapshot/${GIT_REV}.tar.bz2 -> ${P}-${GIT_SHORT}.tar.bz2 )
 	binary? ( https://dev.gentoo.org/~tamiko/distfiles/${P}-${GIT_SHORT}-bin.tar.xz )"

--- a/sys-libs/tdb/tdb-1.4.3.ebuild
+++ b/sys-libs/tdb/tdb-1.4.3.ebuild
@@ -9,8 +9,8 @@ PYTHON_REQ_USE="threads(+)"
 inherit waf-utils multilib-minimal python-single-r1
 
 DESCRIPTION="A simple database API"
-HOMEPAGE="http://tdb.samba.org/"
-SRC_URI="http://samba.org/ftp/tdb/${P}.tar.gz"
+HOMEPAGE="https://tdb.samba.org/"
+SRC_URI="https://samba.org/ftp/tdb/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/x11-themes/xxv-skins/xxv-skins-1.6.1-r1.ebuild
+++ b/x11-themes/xxv-skins/xxv-skins-1.6.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,7 +6,7 @@ EAPI=5
 inherit eutils
 
 DESCRIPTION="Additional skins for XXV"
-HOMEPAGE="http://projects.vdr-developer.org/projects/xxv"
+HOMEPAGE="https://projects.vdr-developer.org/projects/xxv"
 SRC_URI="mirror://vdr-developerorg/719/${P}.tgz
 		mirror://vdr-developerorg/720/xxv-jason-${PV}.tgz"
 


### PR DESCRIPTION
Batch 3 of 3

I'm going through "permanent redirects" from https://repology.org/repository/gentoo/problems and replacing http:// with https:// in HOMEPAGE. Also in SRC_URI if it is the same host.

I'm skipping packages whose existing pages show 404 or don't seem to be relevant to the package.