### PR TITLE
media-video/qmplay2: fix #728974

### DIFF
--- a/media-video/qmplay2/qmplay2-20.05.02.ebuild
+++ b/media-video/qmplay2/qmplay2-20.05.02.ebuild
@@ -52,7 +52,7 @@ RDEPEND="
 	portaudio? ( media-libs/portaudio )
 	pulseaudio? ( media-sound/pulseaudio )
 	sid? ( media-libs/libsidplayfp )
-	shaders? ( media-libs/shaderc )
+	shaders? ( >=media-libs/shaderc-2020.1 )
 	vaapi? (
 		>=media-video/ffmpeg-4.1.3[vaapi]
 		x11-libs/libva[drm,opengl]

--- a/media-video/qmplay2/qmplay2-9999.ebuild
+++ b/media-video/qmplay2/qmplay2-9999.ebuild
@@ -52,7 +52,7 @@ RDEPEND="
 	portaudio? ( media-libs/portaudio )
 	pulseaudio? ( media-sound/pulseaudio )
 	sid? ( media-libs/libsidplayfp )
-	shaders? ( media-libs/shaderc )
+	shaders? ( >=media-libs/shaderc-2020.1 )
 	vaapi? (
 		>=media-video/ffmpeg-4.1.3[vaapi]
 		x11-libs/libva[drm,opengl]


### PR DESCRIPTION
- fix errors while building with `shaders` flag and `media-libs/shaderc-2019.0-r1`
- ~rename `shaders` -> `shaderc` like in `media-libs/libplacebo`~

Closes: https://bugs.gentoo.org/728974

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Yury Martynov <email@linxon.ru>