### PR TITLE
app-admin/syslog-summary: remove file magic dep

### DIFF
--- a/app-admin/syslog-summary/files/syslog-summary-1.14-remove-file-magic.patch
+++ b/app-admin/syslog-summary/files/syslog-summary-1.14-remove-file-magic.patch
@@ -1,0 +1,35 @@
+diff --git a/syslog-summary b/syslog-summary
+index abf6381..b3edffc 100755
+--- a/syslog-summary
++++ b/syslog-summary
+@@ -128,24 +128,12 @@ def split_date(line):
+ 
+ def is_gzipped(filename):
+ 	"""Returns True if the filename is a gzipped compressed file"""	
+-	try:
+-		import magic
+-		ms = magic.open(magic.MAGIC_NONE)
+-		ms.load()
+-		if re.search("^gzip compressed data.*", ms.file(filename)):
+-			return True
+-		else:
+-			return False
+-	except:
+-		from os.path import splitext
+-		
+-		if not QUIET:
+-			print "Using fallback detection... please install python-magic for better gzip detection."
+-		
+-		if splitext(filename)[1] == ".gz":
+-			return True
+-		else:
+-			return False
++	from os.path import splitext
++
++	if splitext(filename)[1] == ".gz":
++		return True
++	else:
++		return False
+ 
+ def summarize(filename, states):
+ 	counts = {}

--- a/app-admin/syslog-summary/syslog-summary-1.14-r4.ebuild
+++ b/app-admin/syslog-summary/syslog-summary-1.14-r4.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python2_7 )
+
+inherit python-single-r1
+
+DESCRIPTION="Summarizes the contents of a syslog log file"
+HOMEPAGE="https://github.com/dpaleino/syslog-summary"
+SRC_URI="https://github.com/downloads/dpaleino/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~sparc ~x86"
+IUSE=""
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+DEPEND=""
+RDEPEND="${PYTHON_DEPS}"
+
+PATCHES=( "${FILESDIR}/${P}-fix-ignore-code.patch" "${FILESDIR}/${P}-remove-file-magic.patch" )
+
+src_prepare() {
+	python_fix_shebang -f syslog-summary
+
+	# Sadly, the makefile is useless for us.
+	rm Makefile || die
+
+	default
+}
+
+src_install() {
+	dobin syslog-summary
+	einstalldocs
+	doman syslog-summary.1
+
+	insinto /etc/syslog-summary
+	doins ignore.rules
+}


### PR DESCRIPTION
Replace the soft dep on sys-apps/file (magic module) with the existing fallback file suffix check
Remove the sys-apps/file[python] suggestion in pkg_postinst

Closes: https://bugs.gentoo.org/722560
Signed-off-by: Paul Healy <lmiphay@gmail.com>