### PR TITLE
net-misc/knock: EAPI7, use HTTPS, fix LICENSE

### DIFF
--- a/net-misc/knock/knock-0.7-r1.ebuild
+++ b/net-misc/knock/knock-0.7-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Simple port-knocking daemon"
+HOMEPAGE="https://www.zeroflux.org/projects/knock
+	https://github.com/jvinet/knock"
+SRC_URI="https://www.zeroflux.org/proj/knock/files/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE="+server"
+
+DEPEND="server? ( net-libs/libpcap )"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+
+	sed -e "/^AM_CFLAGS/s: -g : :" \
+		-e "/dist_doc_DATA/s:COPYING::" \
+		-i Makefile.in || die
+	sed -e "s:/usr/sbin/iptables:/sbin/iptables:g" \
+		-i knockd.conf || die
+}
+
+src_configure() {
+	econf $(use_enable server knockd)
+}
+
+src_install() {
+	emake DESTDIR="${D}" docdir="${EROOT}/usr/share/doc/${PF}" install
+
+	if use server ; then
+		newinitd "${FILESDIR}"/knockd.initd.2 knock
+		newconfd "${FILESDIR}"/knockd.confd.2 knock
+	fi
+}
+
+pkg_postinst() {
+	if use server && ! has_version net-firewall/iptables ; then
+		elog "You're really encouraged to install net-firewall/iptables to"
+		elog "actually modify your firewall and use the example configuration."
+	fi
+}


### PR DESCRIPTION
Package-Manager: Portage-2.3.101, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi, 

simple update for net-misc/knock.

diff:
```diff
1c1
< # Copyright 1999-2017 Gentoo Foundation
---
> # Copyright 1999-2020 Gentoo Authors
4c4
< EAPI=4
---
> EAPI=7
6,8c6,9
< DESCRIPTION="A simple port-knocking daemon"
< HOMEPAGE="http://www.zeroflux.org/projects/knock"
< SRC_URI="http://www.zeroflux.org/proj/knock/files/${P}.tar.gz"
---
> DESCRIPTION="Simple port-knocking daemon"
> HOMEPAGE="https://www.zeroflux.org/projects/knock
>       https://github.com/jvinet/knock"
> SRC_URI="https://www.zeroflux.org/proj/knock/files/${P}.tar.gz"
10c11
< LICENSE="GPL-2"
---
> LICENSE="GPL-2+"
12c13
< KEYWORDS="amd64 ppc sparc x86"
---
> KEYWORDS="~amd64 ~ppc ~sparc ~x86"
23a25,26
> 
>       default
```