### PR TITLE
media-libs/openh264: respect ${ED}

### DIFF
--- a/media-libs/openh264/openh264-2.1.0.ebuild
+++ b/media-libs/openh264/openh264-2.1.0.ebuild
@@ -65,7 +65,7 @@ multilib_src_install() {
 	fi
 
 	if use plugin; then
-		local plugpath="${EROOT}/usr/$(get_libdir)/nsbrowser/plugins/gmp-gmp${PN}/system-installed"
+		local plugpath="${ROOT}/usr/$(get_libdir)/nsbrowser/plugins/gmp-gmp${PN}/system-installed"
 		insinto "${plugpath}"
 		doins libgmpopenh264.so* gmpopenh264.info
 		echo "MOZ_GMP_PATH=\"${plugpath}\"" >"${T}"/98-moz-gmp-${PN}

--- a/media-libs/openh264/openh264-2.1.1.ebuild
+++ b/media-libs/openh264/openh264-2.1.1.ebuild
@@ -65,7 +65,7 @@ multilib_src_install() {
 	fi
 
 	if use plugin; then
-		local plugpath="${EROOT}/usr/$(get_libdir)/nsbrowser/plugins/gmp-gmp${PN}/system-installed"
+		local plugpath="${ROOT}/usr/$(get_libdir)/nsbrowser/plugins/gmp-gmp${PN}/system-installed"
 		insinto "${plugpath}"
 		doins libgmpopenh264.so* gmpopenh264.info
 		echo "MOZ_GMP_PATH=\"${plugpath}\"" >"${T}"/98-moz-gmp-${PN}


### PR DESCRIPTION
Fixes ` *   Aborting due to QA concerns: double prefix files installed`
