### PR TITLE
app-crypt/tpm2-totp: Add missing backslash

### DIFF
--- a/app-crypt/tpm2-totp/tpm2-totp-0.2.1-r1.ebuild
+++ b/app-crypt/tpm2-totp/tpm2-totp-0.2.1-r1.ebuild
@@ -25,7 +25,7 @@ src_prepare() {
 
 src_configure() {
 	econf \
-		--disable-static
+		--disable-static \
 		--disable-defaultflags
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/729174

Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>