### PR TITLE
media-sound/supercollider-3.11.0: fix tests

### DIFF
--- a/media-sound/supercollider/supercollider-3.11.0.ebuild
+++ b/media-sound/supercollider/supercollider-3.11.0.ebuild
@@ -113,6 +113,11 @@ src_install() {
 	use vim && newdoc editors/scvim/README.md README.vim
 }
 
+src_test() {
+	export QT_QPA_PLATFORM=offscreen
+	cmake_src_test
+}
+
 pkg_postinst() {
 	einfo "Notice: SuperCollider is not very intuitive to get up and running."
 	einfo "The best course of action to make sure that the installation was"


### PR DESCRIPTION
Qt wants X11 by default, so tell it to run offscreen instead.

Closes: https://bugs.gentoo.org/656436
Package-Manager: Portage-2.3.101, Repoman-2.3.22
Signed-off-by: Hector Martin <marcan@marcan.st>