### PR TITLE
media-sound/supercollider:-3.11.0: Fix unused CMake var QA warning

### DIFF
--- a/media-sound/supercollider/supercollider-3.11.0.ebuild
+++ b/media-sound/supercollider/supercollider-3.11.0.ebuild
@@ -91,9 +91,12 @@ src_configure() {
 		-DNO_LIBSNDFILE=$(usex !sndfile)
 		-DLIBSCSYNTH=$(usex !static-libs)
 		-DSC_VIM=$(usex vim)
-		-DSC_USE_QTWEBENGINE=$(usex webengine)
 		-DNO_X11=$(usex !X)
 		-DNO_AVAHI=$(usex !zeroconf)
+	)
+
+	use qt5 && mycmakeargs+=(
+		-DSC_USE_QTWEBENGINE=$(usex webengine)
 	)
 
 	use debug && mycmakeargs+=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/729336
Package-Manager: Portage-2.3.101, Repoman-2.3.22
Signed-off-by: Hector Martin <marcan@marcan.st>