### PR TITLE
dev-python/gevent: IUSE=events for zope-event

### DIFF
--- a/dev-python/gevent/gevent-20.6.0.ebuild
+++ b/dev-python/gevent/gevent-20.6.0.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	>=dev-libs/libev-4.23:=
 	dev-libs/libuv:=
 	>=net-dns/c-ares-1.12:=
-	>=dev-python/greenlet-0.4.14
+	>=dev-python/greenlet-0.4.16
 	virtual/python-greenlet[${PYTHON_USEDEP}]
 	events? (
 		dev-python/zope-event[${PYTHON_USEDEP}]

--- a/dev-python/gevent/gevent-20.6.0.ebuild
+++ b/dev-python/gevent/gevent-20.6.0.ebuild
@@ -16,7 +16,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~mips ppc ppc64 s390 ~sparc x86 ~amd64-linux ~x86-linux"
-IUSE="doc examples test"
+IUSE="doc events examples test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -24,7 +24,11 @@ RDEPEND="
 	dev-libs/libuv:=
 	>=net-dns/c-ares-1.12:=
 	>=dev-python/greenlet-0.4.14
-	virtual/python-greenlet[${PYTHON_USEDEP}]"
+	virtual/python-greenlet[${PYTHON_USEDEP}]
+	events? (
+		dev-python/zope-event[${PYTHON_USEDEP}]
+		dev-python/zope-interface[${PYTHON_USEDEP}]
+	)"
 DEPEND="${RDEPEND}
 	test? (
 		dev-python/psutil[${PYTHON_USEDEP}]

--- a/dev-python/gevent/gevent-20.6.2.ebuild
+++ b/dev-python/gevent/gevent-20.6.2.ebuild
@@ -16,21 +16,25 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~mips ~ppc ~ppc64 s390 ~sparc x86 ~amd64-linux ~x86-linux"
-IUSE="doc examples test"
+IUSE="doc events examples test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
 	>=dev-libs/libev-4.23:=
 	dev-libs/libuv:=
 	>=net-dns/c-ares-1.12:=
-	>=dev-python/greenlet-0.4.14
-	dev-python/zope-event[${PYTHON_USEDEP}]
-	dev-python/zope-interface[${PYTHON_USEDEP}]
-	virtual/python-greenlet[${PYTHON_USEDEP}]"
+	>=dev-python/greenlet-0.4.16
+	virtual/python-greenlet[${PYTHON_USEDEP}]
+	events? (
+		dev-python/zope-event[${PYTHON_USEDEP}]
+		dev-python/zope-interface[${PYTHON_USEDEP}]
+	)"
 DEPEND="${RDEPEND}
 	test? (
 		dev-python/psutil[${PYTHON_USEDEP}]
 		dev-python/requests[${PYTHON_USEDEP}]
+		dev-python/zope-event[${PYTHON_USEDEP}]
+		dev-python/zope-interface[${PYTHON_USEDEP}]
 		$(python_gen_cond_dep '
 			dev-python/futures[${PYTHON_USEDEP}]
 			dev-python/mock[${PYTHON_USEDEP}]

--- a/dev-python/gevent/metadata.xml
+++ b/dev-python/gevent/metadata.xml
@@ -5,6 +5,9 @@
     <email>python@gentoo.org</email>
     <name>Python</name>
   </maintainer>
+  <use>
+    <flag name="events">Enables the gevent events system which is required by libraries that use gevent monkey patching. This adds <pkg>dev-python/zope-event</pkg> and <pkg>dev-python/zope-interface</pkg> as runtime dependencies.</flag>
+  </use>
   <upstream>
     <remote-id type="github">surfly/gevent</remote-id>
     <remote-id type="pypi">gevent</remote-id>


### PR DESCRIPTION
The gevents.events module depends on zope.event at runtime. This commit
adds an events use flag which adds dev-python/zope-event as a dependency.

Signed-off-by: Tom Gillespie <tgbugs@gmail.com>