### PR TITLE
net-libs/libhubbub: add missing doxygen dependency.

### DIFF
--- a/net-libs/libhubbub/libhubbub-0.3.6-r1.ebuild
+++ b/net-libs/libhubbub/libhubbub-0.3.6-r1.ebuild
@@ -17,6 +17,7 @@ IUSE="doc test"
 BDEPEND="
 	dev-util/netsurf-buildsystem
 	virtual/pkgconfig
+	doc? ( app-doc/doxygen )
 	test? ( dev-lang/perl )
 "
 RDEPEND="dev-libs/libparserutils:="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/728136
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Jaco Kroon <jaco@uls.co.za>