### PR TITLE
net-libs/libvncserver: Fix tests

### DIFF
--- a/net-libs/libvncserver/files/libvncserver-0.9.13-test-fix-includetest.patch
+++ b/net-libs/libvncserver/files/libvncserver-0.9.13-test-fix-includetest.patch
@@ -1,0 +1,54 @@
+From 39cff3dd6b5d9ebcf86f01e2c7e0bef62abd9d6f Mon Sep 17 00:00:00 2001
+From: Alexander Tsoy <alexander@tsoy.me>
+Date: Thu, 25 Jun 2020 11:35:04 +0300
+Subject: [PATCH 1/2] test: fix includetest to use CMAKE_MAKE_PROGRAM (#431)
+
+includetest currently fais if, for example, ninja is used as a CMake
+generator. Fix it by using CMAKE_MAKE_PROGRAM in the test.
+---
+ CMakeLists.txt      | 2 +-
+ test/includetest.sh | 7 ++++---
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0b6228a2..290deb38 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -680,7 +680,7 @@ endif(LIBVNCSERVER_WITH_WEBSOCKETS)
+ 
+ add_test(NAME cargs COMMAND test_cargstest)
+ if(UNIX)
+-  add_test(NAME includetest COMMAND ${TESTS_DIR}/includetest.sh ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
++  add_test(NAME includetest COMMAND ${TESTS_DIR}/includetest.sh ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_MAKE_PROGRAM})
+ endif(UNIX)
+ if(FOUND_LIBJPEG_TURBO)
+     add_test(NAME turbojpeg COMMAND test_tjunittest)
+diff --git a/test/includetest.sh b/test/includetest.sh
+index 23d602e6..6b064208 100755
+--- a/test/includetest.sh
++++ b/test/includetest.sh
+@@ -5,10 +5,11 @@
+ 
+ # expects install prefix like /usr as an argument
+ PREFIX=$1
++CMAKE_MAKE_PROGRAM=$2
+ 
+ TMPDIR=$(mktemp -d)
+ 
+-make install DESTDIR=$TMPDIR
++DESTDIR="$TMPDIR" $CMAKE_MAKE_PROGRAM install
+ 
+ echo \
+ "
+@@ -19,6 +20,6 @@ int main()
+ {
+     return 0;
+ }
+-" > $TMPDIR/includetest.c
++" > "$TMPDIR"/includetest.c
+ 
+-cc -I $TMPDIR/$PREFIX $TMPDIR/includetest.c
++cc -I "$TMPDIR/$PREFIX" "$TMPDIR"/includetest.c
+-- 
+2.26.2
+

--- a/net-libs/libvncserver/files/libvncserver-0.9.13-test-fix-tjunittest.patch
+++ b/net-libs/libvncserver/files/libvncserver-0.9.13-test-fix-tjunittest.patch
@@ -1,0 +1,29 @@
+From 8244fab5421fd14d4c75ce488ad18d38b7a6edb4 Mon Sep 17 00:00:00 2001
+From: Christian Beier <info@christianbeier.net>
+Date: Thu, 25 Jun 2020 12:21:50 +0200
+Subject: [PATCH 2/2] CMake: only add turbojpeg test if configured WITH_JPEG
+
+Closes #430
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 290deb38..fdca4d81 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -682,9 +682,9 @@ add_test(NAME cargs COMMAND test_cargstest)
+ if(UNIX)
+   add_test(NAME includetest COMMAND ${TESTS_DIR}/includetest.sh ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_MAKE_PROGRAM})
+ endif(UNIX)
+-if(FOUND_LIBJPEG_TURBO)
++if(WITH_JPEG AND FOUND_LIBJPEG_TURBO)
+     add_test(NAME turbojpeg COMMAND test_tjunittest)
+-endif(FOUND_LIBJPEG_TURBO)
++endif(WITH_JPEG AND FOUND_LIBJPEG_TURBO)
+ if(LIBVNCSERVER_WITH_WEBSOCKETS)
+     add_test(NAME wstest COMMAND test_wstest)
+ endif(LIBVNCSERVER_WITH_WEBSOCKETS)
+-- 
+2.26.2
+

--- a/net-libs/libvncserver/libvncserver-0.9.13.ebuild
+++ b/net-libs/libvncserver/libvncserver-0.9.13.ebuild
@@ -48,6 +48,11 @@ RDEPEND="${DEPEND}"
 
 DOCS=( AUTHORS ChangeLog NEWS.md README.md TODO.md )
 
+PATCHES=(
+	"${FILESDIR}"/${P}-test-fix-includetest.patch
+	"${FILESDIR}"/${P}-test-fix-tjunittest.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DWITH_FFMPEG=OFF


### PR DESCRIPTION
* Fix includetest with CMAKE_MAKEFILE_GENERATOR=ninja
* Do not run tjunittest with USE=-jpeg

Commiting straight to stable as only tests are affected by these
changes.

Closes: https://bugs.gentoo.org/729092
Bug: https://bugs.gentoo.org/729188