### PR TITLE
net-misc/clockspeed: EAPI7, use HTTPS

### DIFF
--- a/net-misc/clockspeed/clockspeed-0.62-r7.ebuild
+++ b/net-misc/clockspeed/clockspeed-0.62-r7.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic toolchain-funcs
+
+DESCRIPTION="Simple Network Time Protocol (NTP) client"
+HOMEPAGE="https://cr.yp.to/clockspeed.html"
+
+# this is the trailing part of the name for the latest leapseconds file.
+LEAPSECONDS_DATE="20081114"
+
+SRC_URI="https://cr.yp.to/clockspeed/${P}.tar.gz
+	https://dev.gentoo.org/~pacho/maintainer-needed/leapsecs.dat."$LEAPSECONDS_DATE""
+
+LICENSE="all-rights-reserved"
+SLOT="0"
+KEYWORDS="~amd64 ~mips ~x86"
+IUSE="static selinux"
+RESTRICT="mirror bindist test"
+
+DEPEND="sys-apps/groff"
+RDEPEND="selinux? ( sec-policy/selinux-clockspeed )
+	net-dns/djbdns"
+
+PATCHES=( "${FILESDIR}"/${P}-gentoo.patch )
+
+src_configure() {
+	echo "$(tc-getCC) ${CFLAGS} ${ASFLAGS}" > conf-cc || die
+	use static && append-ldflags -static
+	echo "$(tc-getCC) ${LDFLAGS}" > conf-ld || die
+}
+
+src_install() {
+	dobin clockspeed clockadd clockview sntpclock taiclock taiclockd
+	dosbin "${FILESDIR}"/ntpclockset
+
+	doman *.1
+	dodoc BLURB CHANGES INSTALL README THANKS TODO
+
+	insinto /var/lib/clockspeed
+	newins "${DISTDIR}"/leapsecs.dat."$LEAPSECONDS_DATE" leapsecs.dat
+}


### PR DESCRIPTION
Package-Manager: Portage-2.3.101, Repoman-2.3.22
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,

this updates clockspeed for EAPI7 and uses https instead of http.

```diff
4c4
< EAPI=4
---
> EAPI=7
6c6
< inherit eutils flag-o-matic toolchain-funcs
---
> inherit flag-o-matic toolchain-funcs
8,9c8,9
< DESCRIPTION="A simple Network Time Protocol (NTP) client"
< HOMEPAGE="http://cr.yp.to/clockspeed.html"
---
> DESCRIPTION="Simple Network Time Protocol (NTP) client"
> HOMEPAGE="https://cr.yp.to/clockspeed.html"
14c14
< SRC_URI="http://cr.yp.to/clockspeed/${P}.tar.gz
---
> SRC_URI="https://cr.yp.to/clockspeed/${P}.tar.gz
19c19
< KEYWORDS="amd64 ~mips x86"
---
> KEYWORDS="~amd64 ~mips ~x86"
27,29c27
< src_prepare() {
<       epatch "${FILESDIR}"/${P}-gentoo.patch
< }
---
> PATCHES=( "${FILESDIR}"/${P}-gentoo.patch )
32c30
<       echo "$(tc-getCC) ${CFLAGS} ${ASFLAGS}" > conf-cc
---
>       echo "$(tc-getCC) ${CFLAGS} ${ASFLAGS}" > conf-cc || die
34c32
<       echo "$(tc-getCC) ${LDFLAGS}" > conf-ld
---
>       echo "$(tc-getCC) ${LDFLAGS}" > conf-ld || die
```