### PR TITLE
dev-utils/ostree: adjust slot dependency on dev-fs/fuse

### DIFF
--- a/dev-util/ostree/ostree-2018.9.ebuild
+++ b/dev-util/ostree/ostree-2018.9.ebuild
@@ -22,7 +22,7 @@ COMMON_DEPEND="
 	dev-libs/libgpg-error:=
 	dev-libs/openssl:0=
 	sys-apps/util-linux:=
-	sys-fs/fuse:=
+	sys-fs/fuse:0=
 	sys-libs/zlib:=
 
 	archive? ( app-arch/libarchive:= )

--- a/dev-util/ostree/ostree-2019.5.ebuild
+++ b/dev-util/ostree/ostree-2019.5.ebuild
@@ -32,7 +32,7 @@ COMMON_DEPEND="
 	ssl? (
 		gnutls? ( net-libs/gnutls )
 		!gnutls? ( dev-libs/openssl:0= ) )
-	>=sys-fs/fuse-2.9.2:*
+	>=sys-fs/fuse-2.9.2:0
 	sys-libs/zlib
 	libmount? ( sys-apps/util-linux )
 	selinux? ( sys-libs/libselinux )


### PR DESCRIPTION
These versions of OSTree require FUSE 2 and thus must depend on slot 0.

Bug: https://bugs.gentoo.org/724266
Signed-off-by: Chris Rorvick <chris@rorvick.com>