### PR TITLE
media-sound/yoshimi: added restriction <media-libs/lv2-1.18.0

### DIFF
--- a/media-sound/yoshimi/yoshimi-1.7.1.ebuild
+++ b/media-sound/yoshimi/yoshimi-1.7.1.ebuild
@@ -27,8 +27,10 @@ DEPEND="
 	virtual/jack
 	x11-libs/cairo[X]
 	x11-libs/fltk:1[opengl]
-	lv2? ( media-libs/lv2 )
-"
+	lv2? ( <media-libs/lv2-1.18.0 )"
+	##<media-libs/lv2-1.18.0 -- See bug #729716
+	##Should be transformed to plain
+	##media-libs/lv2 when it'll be bumped
 RDEPEND="${DEPEND}"
 
 CMAKE_USE_DIR="${WORKDIR}/${P}/src"


### PR DESCRIPTION
To temporarily avoid https://bugs.gentoo.org/729716
When new release is out, restriction should be changed
and bug should be closed.

Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Denis Reva <denis7774@gmail.com>