### PR TITLE
www-apps/rutorrent: Use EAPI=7 for -9999 package

### DIFF
--- a/www-apps/rutorrent/rutorrent-9999.ebuild
+++ b/www-apps/rutorrent/rutorrent-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit webapp
 
@@ -20,9 +20,7 @@ IUSE=""
 
 need_httpd_cgi
 
-DEPEND="
-	|| ( dev-lang/php[xml,gd] dev-lang/php[xml,gd-external] )
-"
+DEPEND="dev-lang/php[xml,gd]"
 RDEPEND="virtual/httpd-php"
 
 pkg_setup() {


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Stephen Shkardoon <ss23@ss23.geek.nz>