### PR TITLE
dev-python/jedi: add pypy3 support to all jedi ebuilds

### DIFF
--- a/dev-python/jedi/jedi-0.14.1.ebuild
+++ b/dev-python/jedi/jedi-0.14.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
+PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/jedi/jedi-0.15.2.ebuild
+++ b/dev-python/jedi/jedi-0.15.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/jedi/jedi-0.17.0.ebuild
+++ b/dev-python/jedi/jedi-0.17.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/jedi/jedi-0.17.1.ebuild
+++ b/dev-python/jedi/jedi-0.17.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Part of a series of PRs working toward pypy3 support for IPython.
Bug: https://bugs.gentoo.org/729958