### PR TITLE
dev-python/pickleshare: add pypy3 support

### DIFF
--- a/dev-python/pickleshare/pickleshare-0.7.4-r1.ebuild
+++ b/dev-python/pickleshare/pickleshare-0.7.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pickleshare/pickleshare-0.7.5.ebuild
+++ b/dev-python/pickleshare/pickleshare-0.7.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="A small 'shelve' like datastore with concurrency support"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/729958
Part of a series of PRs working toward pypy3 support for IPython.
