### PR TITLE
dev-python/prompt_toolkit: add pypy3 support

### DIFF
--- a/dev-python/prompt_toolkit/prompt_toolkit-2.0.10-r1.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-2.0.10-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Building powerful interactive command lines in Python"

--- a/dev-python/prompt_toolkit/prompt_toolkit-2.0.10.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-2.0.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Building powerful interactive command lines in Python"

--- a/dev-python/prompt_toolkit/prompt_toolkit-3.0.3.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-3.0.3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Building powerful interactive command lines in Python"

--- a/dev-python/prompt_toolkit/prompt_toolkit-3.0.5.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-3.0.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Building powerful interactive command lines in Python"


### PR DESCRIPTION
All the tests pass for pypy3 except for two which cause infinite hangs, however as far as I can tell that is a bug in the tests which does not manifest in any discernable way during normal use. Filed a ticked upstream https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1175.
Bug: https://bugs.gentoo.org/729958