### PR TITLE
dev-python/ipython_genutils and dev-python/traitlets: add pypy3 support

### DIFF
--- a/dev-python/ipython_genutils/ipython_genutils-0.2.0-r1.ebuild
+++ b/dev-python/ipython_genutils/ipython_genutils-0.2.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/ipython_genutils/ipython_genutils-0.2.0.ebuild
+++ b/dev-python/ipython_genutils/ipython_genutils-0.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/traitlets/traitlets-4.3.2.ebuild
+++ b/dev-python/traitlets/traitlets-4.3.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/traitlets/traitlets-4.3.3.ebuild
+++ b/dev-python/traitlets/traitlets-4.3.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
traitlets depends on ipython_genutils so these patches are bundled in a single PR.
Bug: https://bugs.gentoo.org/729958