### PR TITLE
dev-python/backcall: add pypy3 support

### DIFF
--- a/dev-python/backcall/backcall-0.1.0-r1.ebuild
+++ b/dev-python/backcall/backcall-0.1.0-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 DISTUTILS_USE_SETUPTOOLS=no
 inherit distutils-r1
 

--- a/dev-python/backcall/backcall-0.2.0.ebuild
+++ b/dev-python/backcall/backcall-0.2.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 DISTUTILS_USE_SETUPTOOLS=no
 inherit distutils-r1
 


### PR DESCRIPTION
Yet another PR on the way to IPython pypy3 support.
Bug: https://bugs.gentoo.org/729958