### PR TITLE
numpy, matplotlib and dependences pypy3 support

### DIFF
--- a/dev-python/cycler/cycler-0.10.0-r1.ebuild
+++ b/dev-python/cycler/cycler-0.10.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/cycler/cycler-0.10.0.ebuild
+++ b/dev-python/cycler/cycler-0.10.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 python3_{6,7} )
+PYTHON_COMPAT=( python2_7 python3_{6,7} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/matplotlib/matplotlib-3.2.1.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.2.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
 
 DISTUTILS_USE_SETUPTOOLS=bdepend

--- a/dev-python/matplotlib/matplotlib-3.2.2.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.2.2.ebuild
@@ -3,9 +3,8 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
-
 DISTUTILS_USE_SETUPTOOLS=bdepend
 inherit distutils-r1 flag-o-matic virtualx toolchain-funcs prefix
 

--- a/dev-python/numpy/numpy-1.16.5-r1.ebuild
+++ b/dev-python/numpy/numpy-1.16.5-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
+PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack

--- a/dev-python/numpy/numpy-1.17.4-r3.ebuild
+++ b/dev-python/numpy/numpy-1.17.4-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 DISTUTILS_USE_SETUPTOOLS=rdepend
 

--- a/dev-python/numpy/numpy-1.18.3.ebuild
+++ b/dev-python/numpy/numpy-1.18.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack

--- a/dev-python/numpy/numpy-1.18.5.ebuild
+++ b/dev-python/numpy/numpy-1.18.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack

--- a/dev-python/numpy/numpy-1.19.0.ebuild
+++ b/dev-python/numpy/numpy-1.19.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack


### PR DESCRIPTION
All numpy ebuilds currently in the tree have been tested with

FEATURES=test; for e in *.ebuild; do ebuild $e test; done

dev-python/numpy-1.19.0 passes all tests
<dev-python/numpy-1.19.0 fails fortran f2py tests
this is possibly related to https://bugs.gentoo.org/707116
I have filed a new issue at https://bugs.gentoo.org/729966

For testing failures export USE=-python_targets_pypy3 was set so that
the cypthon implementations could be tested.

Also adds pypy3 support for the current ebuilds
>=dev-python/matplotlib-3.2. In theory it should be possible to enable
pypy3 for >=dev-python/matplotlib-2, however I have not been able to
test <dev-python/matplotlib-3.2 due to the python2_7 dependency for
matplotlib-2 and matplotlib-3.1.2 has numerous test failures (including
an infinite hang) when changing RESTRICT from test to !test? ( test ).
As a result I am not enabling pypy3 support for those ebuilds.