### PR TITLE
dev-python/{ipython,matplotlib,numpy}: pypy3 support

### DIFF
--- a/dev-python/backcall/backcall-0.2.0.ebuild
+++ b/dev-python/backcall/backcall-0.2.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 DISTUTILS_USE_SETUPTOOLS=no
 inherit distutils-r1
 

--- a/dev-python/constantly/constantly-15.1.0-r1.ebuild
+++ b/dev-python/constantly/constantly-15.1.0-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 DISTUTILS_USE_SETUPTOOLS=bdepend
 
 inherit distutils-r1

--- a/dev-python/cppy/cppy-1.1.0.ebuild
+++ b/dev-python/cppy/cppy-1.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/cycler/cycler-0.10.0-r1.ebuild
+++ b/dev-python/cycler/cycler-0.10.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/cycler/cycler-0.10.0.ebuild
+++ b/dev-python/cycler/cycler-0.10.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 python3_{6,7} )
+PYTHON_COMPAT=( python2_7 python3_{6,7} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/hyperlink/hyperlink-19.0.0.ebuild
+++ b/dev-python/hyperlink/hyperlink-19.0.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/hyperlink/hyperlink-20.0.1.ebuild
+++ b/dev-python/hyperlink/hyperlink-20.0.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/incremental/incremental-17.5.0.ebuild
+++ b/dev-python/incremental/incremental-17.5.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1

--- a/dev-python/ipykernel/ipykernel-5.3.3.ebuild
+++ b/dev-python/ipykernel/ipykernel-5.3.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/dev-python/ipykernel/ipykernel-5.3.4.ebuild
+++ b/dev-python/ipykernel/ipykernel-5.3.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/dev-python/ipyparallel/ipyparallel-6.3.0.ebuild
+++ b/dev-python/ipyparallel/ipyparallel-6.3.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 DISTUTILS_USE_SETUPTOOLS=rdepend
 

--- a/dev-python/ipython/ipython-7.16.1.ebuild
+++ b/dev-python/ipython/ipython-7.16.1.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
-PYTHON_REQ_USE='readline,sqlite,threads(+)'
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
+PYTHON_REQ_USE='readline(+),sqlite,threads(+)'
 
 inherit distutils-r1 eutils virtualx
 

--- a/dev-python/ipython/ipython-7.17.0.ebuild
+++ b/dev-python/ipython/ipython-7.17.0.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
-PYTHON_REQ_USE='readline,sqlite,threads(+)'
+PYTHON_COMPAT=( python3_{7..9} pypy3 )
+PYTHON_REQ_USE='readline(+),sqlite,threads(+)'
 
 inherit distutils-r1 eutils virtualx
 

--- a/dev-python/ipython/ipython-7.18.0.ebuild
+++ b/dev-python/ipython/ipython-7.18.0.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
-PYTHON_REQ_USE='readline,sqlite,threads(+)'
+PYTHON_COMPAT=( python3_{7..9} pypy3 )
+PYTHON_REQ_USE='readline(+),sqlite,threads(+)'
 
 inherit distutils-r1 eutils virtualx
 

--- a/dev-python/ipython_genutils/ipython_genutils-0.2.0-r1.ebuild
+++ b/dev-python/ipython_genutils/ipython_genutils-0.2.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/jedi/jedi-0.17.1-r1.ebuild
+++ b/dev-python/jedi/jedi-0.17.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/jedi/jedi-0.17.2-r1.ebuild
+++ b/dev-python/jedi/jedi-0.17.2-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/jupyter_client/jupyter_client-6.1.5.ebuild
+++ b/dev-python/jupyter_client/jupyter_client-6.1.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 DISTUTILS_USE_SETUPTOOLS=rdepend
 

--- a/dev-python/jupyter_client/jupyter_client-6.1.6-r1.ebuild
+++ b/dev-python/jupyter_client/jupyter_client-6.1.6-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 DISTUTILS_USE_SETUPTOOLS=rdepend
 

--- a/dev-python/jupyter_core/jupyter_core-4.6.3.ebuild
+++ b/dev-python/jupyter_core/jupyter_core-4.6.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1

--- a/dev-python/kiwisolver/kiwisolver-1.2.0.ebuild
+++ b/dev-python/kiwisolver/kiwisolver-1.2.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/matplotlib/matplotlib-3.2.2-r1.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.2.2-r1.ebuild
@@ -3,9 +3,8 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
-
 DISTUTILS_USE_SETUPTOOLS=bdepend
 inherit distutils-r1 flag-o-matic virtualx toolchain-funcs prefix
 

--- a/dev-python/matplotlib/matplotlib-3.3.0.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.3.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
 
 DISTUTILS_USE_SETUPTOOLS=bdepend

--- a/dev-python/numpy/numpy-1.16.5-r1.ebuild
+++ b/dev-python/numpy/numpy-1.16.5-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
+PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack

--- a/dev-python/numpy/numpy-1.17.4-r3.ebuild
+++ b/dev-python/numpy/numpy-1.17.4-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 DISTUTILS_USE_SETUPTOOLS=rdepend
 

--- a/dev-python/numpy/numpy-1.19.0.ebuild
+++ b/dev-python/numpy/numpy-1.19.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack

--- a/dev-python/numpy/numpy-1.19.1.ebuild
+++ b/dev-python/numpy/numpy-1.19.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack

--- a/dev-python/pickleshare/pickleshare-0.7.5.ebuild
+++ b/dev-python/pickleshare/pickleshare-0.7.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="A small 'shelve' like datastore with concurrency support"

--- a/dev-python/prompt_toolkit/prompt_toolkit-2.0.10-r1.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-2.0.10-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Building powerful interactive command lines in Python"

--- a/dev-python/prompt_toolkit/prompt_toolkit-2.0.10.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-2.0.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Building powerful interactive command lines in Python"

--- a/dev-python/prompt_toolkit/prompt_toolkit-3.0.5.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-3.0.5.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Building powerful interactive command lines in Python"

--- a/dev-python/prompt_toolkit/prompt_toolkit-3.0.6.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-3.0.6.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Building powerful interactive command lines in Python"

--- a/dev-python/pycurl/pycurl-7.43.0.5-r1.ebuild
+++ b/dev-python/pycurl/pycurl-7.43.0.5-r1.ebuild
@@ -5,7 +5,8 @@ EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=manual
 # The selftests fail with pypy, and urlgrabber segfaults for me.
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
+PYTHON_COMPAT=( python2_7 python3_{6,7} pypy3 )
 
 inherit distutils-r1 toolchain-funcs
 

--- a/dev-python/pycurl/pycurl-7.43.0.5.ebuild
+++ b/dev-python/pycurl/pycurl-7.43.0.5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=manual
 # The selftests fail with pypy, and urlgrabber segfaults for me.
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 
 inherit distutils-r1 toolchain-funcs
 

--- a/dev-python/pyhamcrest/pyhamcrest-2.0.2.ebuild
+++ b/dev-python/pyhamcrest/pyhamcrest-2.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pyzmq/pyzmq-19.0.1_p20200608.ebuild
+++ b/dev-python/pyzmq/pyzmq-19.0.1_p20200608.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit flag-o-matic distutils-r1 toolchain-funcs
@@ -29,7 +29,9 @@ DEPEND="
 "
 RDEPEND="${DEPEND}
 	dev-python/py[${PYTHON_USEDEP}]
-	dev-python/cffi:=[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '
+		dev-python/cffi:=[${PYTHON_USEDEP}]
+	' 'python*')
 "
 BDEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]

--- a/dev-python/traitlets/traitlets-4.3.3.ebuild
+++ b/dev-python/traitlets/traitlets-4.3.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/twisted/twisted-19.10.0.ebuild
+++ b/dev-python/twisted/twisted-19.10.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 virtualx
@@ -117,7 +117,7 @@ python_prepare_all() {
 
 	# accesses /dev/net/tun
 	sed -e '/class RealDeviceTestsMixin/a\
-    skip = "Requires extra permissions"' \
+	skip = "Requires extra permissions"' \
 		-i src/twisted/pair/test/test_tuntap.py || die
 
 	# TODO: figure it out, probably doesn't accept DST date here

--- a/dev-python/twisted/twisted-20.3.0.ebuild
+++ b/dev-python/twisted/twisted-20.3.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 virtualx

--- a/dev-python/versioneer/versioneer-0.18-r1.ebuild
+++ b/dev-python/versioneer/versioneer-0.18-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=rdepend
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/www-servers/tornado/tornado-6.0.4.ebuild
+++ b/www-servers/tornado/tornado-6.0.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1


### PR DESCRIPTION
This PR pulls in all the changes needed to dependencies to add pypy3
support to ipython. Currently only the matplotlib use flag works under
pypy3, pypy3 support for nbconvert and notebook use flags has not been
implemented yet.

Also included is pypy3 support for numpy.

Closes: https://bugs.gentoo.org/729958

Supersedes:
https://github.com/gentoo/gentoo/pull/16453
https://github.com/gentoo/gentoo/pull/16454
https://github.com/gentoo/gentoo/pull/16456
https://github.com/gentoo/gentoo/pull/16457
https://github.com/gentoo/gentoo/pull/16458
https://github.com/gentoo/gentoo/pull/16462
