### PR TITLE
www-apps/{liquid_feedback_core,liquid_feedback_frontend,rocketwiki-lqfb,webmcp}: use HTTPS

### DIFF
--- a/www-apps/liquid_feedback_core/liquid_feedback_core-2.2.6.ebuild
+++ b/www-apps/liquid_feedback_core/liquid_feedback_core-2.2.6.ebuild
@@ -8,8 +8,8 @@ inherit toolchain-funcs
 MY_P=${PN}-v${PV}
 
 DESCRIPTION="Internet platforms for proposition development and decision making"
-HOMEPAGE="http://www.public-software-group.org/liquid_feedback"
-SRC_URI="http://www.public-software-group.org/pub/projects/liquid_feedback/backend/v${PV}/${MY_P}.tar.gz"
+HOMEPAGE="https://www.public-software-group.org/liquid_feedback"
+SRC_URI="https://www.public-software-group.org/pub/projects/liquid_feedback/backend/v${PV}/${MY_P}.tar.gz"
 
 LICENSE="HPND CC-BY-2.5"
 SLOT="0"

--- a/www-apps/liquid_feedback_core/liquid_feedback_core-3.0.4.ebuild
+++ b/www-apps/liquid_feedback_core/liquid_feedback_core-3.0.4.ebuild
@@ -8,8 +8,8 @@ inherit toolchain-funcs
 MY_P=${PN}-v${PV}
 
 DESCRIPTION="Internet platforms for proposition development and decision making"
-HOMEPAGE="http://www.public-software-group.org/liquid_feedback"
-SRC_URI="http://www.public-software-group.org/pub/projects/liquid_feedback/backend/v${PV}/${MY_P}.tar.gz"
+HOMEPAGE="https://www.public-software-group.org/liquid_feedback"
+SRC_URI="https://www.public-software-group.org/pub/projects/liquid_feedback/backend/v${PV}/${MY_P}.tar.gz"
 
 LICENSE="HPND CC-BY-2.5"
 SLOT="0"

--- a/www-apps/liquid_feedback_frontend/liquid_feedback_frontend-2.2.7.ebuild
+++ b/www-apps/liquid_feedback_frontend/liquid_feedback_frontend-2.2.7.ebuild
@@ -10,8 +10,8 @@ PV_F=v${PV}
 MY_P=${PN}-v${PV}
 
 DESCRIPTION="Internet platforms for proposition development and decision making"
-HOMEPAGE="http://www.public-software-group.org/liquid_feedback"
-SRC_URI="http://www.public-software-group.org/pub/projects/liquid_feedback/frontend/v${PV}/${MY_P}.tar.gz
+HOMEPAGE="https://www.public-software-group.org/liquid_feedback"
+SRC_URI="https://www.public-software-group.org/pub/projects/liquid_feedback/frontend/v${PV}/${MY_P}.tar.gz
 l10n_it? ( mirror://gentoo/${PN}-italian-${PV}.tar.gz )"
 
 LICENSE="HPND CC-BY-2.5"

--- a/www-apps/liquid_feedback_frontend/liquid_feedback_frontend-3.0.6.ebuild
+++ b/www-apps/liquid_feedback_frontend/liquid_feedback_frontend-3.0.6.ebuild
@@ -10,8 +10,8 @@ PV_F=v${PV}
 MY_P=${PN}-v${PV}
 
 DESCRIPTION="Internet platforms for proposition development and decision making"
-HOMEPAGE="http://www.public-software-group.org/liquid_feedback"
-SRC_URI="http://www.public-software-group.org/pub/projects/liquid_feedback/frontend/v${PV}/${MY_P}.tar.gz"
+HOMEPAGE="https://www.public-software-group.org/liquid_feedback"
+SRC_URI="https://www.public-software-group.org/pub/projects/liquid_feedback/frontend/v${PV}/${MY_P}.tar.gz"
 
 LICENSE="HPND CC-BY-2.5"
 SLOT="0"

--- a/www-apps/rocketwiki-lqfb/rocketwiki-lqfb-0.4.ebuild
+++ b/www-apps/rocketwiki-lqfb/rocketwiki-lqfb-0.4.ebuild
@@ -7,8 +7,8 @@ inherit eutils
 MY_P=${PN}-v${PV}
 
 DESCRIPTION="Small parser which translates a wiki dialect to HTML"
-HOMEPAGE="http://www.public-software-group.org/rocketwiki"
-SRC_URI="http://www.public-software-group.org/pub/projects/rocketwiki/liquid_feedback_edition/v${PV}/${MY_P}.tar.gz"
+HOMEPAGE="https://www.public-software-group.org/rocketwiki"
+SRC_URI="https://www.public-software-group.org/pub/projects/rocketwiki/liquid_feedback_edition/v${PV}/${MY_P}.tar.gz"
 
 LICENSE="HPND"
 SLOT="0"

--- a/www-apps/webmcp/webmcp-1.2.6.ebuild
+++ b/www-apps/webmcp/webmcp-1.2.6.ebuild
@@ -7,8 +7,8 @@ inherit toolchain-funcs
 
 MY_P=${PN}-v${PV}
 DESCRIPTION="Web application framework written in Lua and C"
-HOMEPAGE="http://www.public-software-group.org/webmcp"
-SRC_URI="http://www.public-software-group.org/pub/projects/${PN}/v${PV}/${MY_P}.tar.gz"
+HOMEPAGE="https://www.public-software-group.org/webmcp"
+SRC_URI="https://www.public-software-group.org/pub/projects/${PN}/v${PV}/${MY_P}.tar.gz"
 
 LICENSE="HPND"
 KEYWORDS="~amd64"


### PR DESCRIPTION
Hi,

A few updates in order to use HTTPS over http. SRC_URI's were tested too.