### PR TITLE
app-emulation/uade: EAPI7, use HTTPS, fix LICENSE, cleanup

### DIFF
--- a/app-emulation/uade/files/uade-2.13-configure.patch
+++ b/app-emulation/uade/files/uade-2.13-configure.patch
@@ -1,0 +1,24 @@
+--- uade-2.13/configure	2009-10-29 22:01:12.000000000 +0100
++++ uade-2.13-r1/configure	2020-06-30 20:03:45.237913031 +0200
+@@ -342,8 +342,11 @@
+     if test -z "$prefix"; then
+ 	prefix="/usr/local"
+     fi
++    if test -z "$libdir" ; then
++	libdir="$prefix/lib"
++    fi
+     uadedatadir="$prefix/share/uade2"
+-    uadelibdir="$prefix/lib/uade2"
++    uadelibdir="$libdir/uade2"
+     if test -z "$bindir"; then
+ 	bindir="$prefix/bin"
+     fi
+@@ -439,7 +442,7 @@
+     fi
+ fi
+ 
+-pkgconfigdir="$prefix/lib/pkgconfig"
++pkgconfigdir="$libdir/pkgconfig"
+ rm -f uade.pc
+ if test -n "$PKG_CONFIG" ; then
+     installuadepcrule=""

--- a/app-emulation/uade/uade-2.13-r1.ebuild
+++ b/app-emulation/uade/uade-2.13-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Unix Amiga Delitracker Emulator - plays old Amiga tunes through UAE emulation"
+HOMEPAGE="https://zakalwe.fi/uade"
+SRC_URI="https://zakalwe.fi/uade/uade2/${P}.tar.bz2"
+
+LICENSE="GPL-2+ LGPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="media-libs/libao"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( AUTHORS ChangeLog doc/BUGS doc/PLANS )
+
+PATCHES=( "${FILESDIR}"/${P}-configure.patch )
+
+src_configure() {
+	tc-export CC
+
+	./configure \
+		--prefix="${EPREFIX}"/usr \
+		--package-prefix="${D}" \
+		--libdir="${EPREFIX}/usr/$(get_libdir)" \
+		--with-text-scope \
+		--without-xmms \
+		--without-audacious || die
+}
+
+src_install() {
+	default
+	doman doc/uade123.1
+}


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi, this updates app-emulation/uade for EAPI7. It also uses HTTPS and fixes it's LICENSE.
From the COPYING file: `Sound core in directory amigasrc/score/ is licensed under the GNU LGPL.`

I've also fixed calling `gcc` directly. I've tried also to use `econf` instead of using `./configure` but it seems that it's some non-standard configuration script as with `econf` it didn't took the arguments. I've also removed the `--with-uade123` argument since it doesn't exist (it's enabled by default and can only be disabled via `--without-uade123`)

Please review.