### PR TITLE
media-libs/libheif: update gdk-pixbuf cache

### DIFF
--- a/media-libs/libheif/libheif-1.6.1.ebuild
+++ b/media-libs/libheif/libheif-1.6.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-inherit autotools xdg-utils multilib-minimal
+inherit autotools gnome2-utils xdg-utils multilib-minimal
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/strukturag/${PN}.git"
@@ -60,8 +60,10 @@ multilib_src_install_all() {
 
 pkg_postinst() {
 	xdg_mimeinfo_database_update
+	gnome2_gdk_pixbuf_update
 }
 
 pkg_postrm() {
+	gnome2_gdk_pixbuf_update
 	xdg_mimeinfo_database_update
 }


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: David Heidelberg <david@ixit.cz>