### PR TITLE
sys-kernel/linux-firmware: Use "main" branch instead of default "master"

### DIFF
--- a/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
@@ -7,6 +7,7 @@ inherit mount-boot savedconfig
 if [[ ${PV} == 99999999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/${PN}.git"
+	EGIT_BRANCH="main"
 else
 	SRC_URI="https://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-${PV}.tar.gz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Guillaume BRUN <the.cheaterman@gmail.com>