### PR TITLE
dev-libs/gf2x: use HTTPS

### DIFF
--- a/dev-libs/gf2x/gf2x-1.3.0.ebuild
+++ b/dev-libs/gf2x/gf2x-1.3.0.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="C/C++ routines for fast arithmetic in GF(2)[x]"
-HOMEPAGE="https://gitlab.inria.fr/thome/gf2x/ http://gforge.inria.fr/projects/gf2x/"
+HOMEPAGE="https://gitlab.inria.fr/thome/gf2x/ https://gforge.inria.fr/projects/gf2x/"
 # The Gitlab release is missing the autotools files.
 SRC_URI="https://gforge.inria.fr/frs/download.php/38243/${P}.tar.gz"
 


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>