### PR TITLE
dev-python/gevent: use HTTPS

### DIFF
--- a/dev-python/gevent/gevent-1.4.0.ebuild
+++ b/dev-python/gevent/gevent-1.4.0.ebuild
@@ -10,7 +10,7 @@ PYTHON_REQ_USE="ssl(+),threads(+)"
 inherit distutils-r1 flag-o-matic
 
 DESCRIPTION="Coroutine-based network library"
-HOMEPAGE="http://gevent.org/ https://pypi.org/project/gevent/"
+HOMEPAGE="https://www.gevent.org/ https://pypi.org/project/gevent/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/gevent/gevent-20.5.1.ebuild
+++ b/dev-python/gevent/gevent-20.5.1.ebuild
@@ -10,7 +10,7 @@ PYTHON_REQ_USE="ssl(+),threads(+)"
 inherit distutils-r1 flag-o-matic
 
 DESCRIPTION="Coroutine-based network library"
-HOMEPAGE="http://gevent.org/ https://pypi.org/project/gevent/"
+HOMEPAGE="https://www.gevent.org/ https://pypi.org/project/gevent/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/gevent/gevent-20.5.2.ebuild
+++ b/dev-python/gevent/gevent-20.5.2.ebuild
@@ -10,7 +10,7 @@ PYTHON_REQ_USE="ssl(+),threads(+)"
 inherit distutils-r1 flag-o-matic
 
 DESCRIPTION="Coroutine-based network library"
-HOMEPAGE="http://gevent.org/ https://pypi.org/project/gevent/"
+HOMEPAGE="https://www.gevent.org/ https://pypi.org/project/gevent/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/gevent/gevent-20.6.0.ebuild
+++ b/dev-python/gevent/gevent-20.6.0.ebuild
@@ -10,7 +10,7 @@ PYTHON_REQ_USE="ssl(+),threads(+)"
 inherit distutils-r1 flag-o-matic
 
 DESCRIPTION="Coroutine-based network library"
-HOMEPAGE="http://gevent.org/ https://pypi.org/project/gevent/"
+HOMEPAGE="https://www.gevent.org/ https://pypi.org/project/gevent/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-python/gevent/gevent-20.6.1.ebuild
+++ b/dev-python/gevent/gevent-20.6.1.ebuild
@@ -10,7 +10,7 @@ PYTHON_REQ_USE="ssl(+),threads(+)"
 inherit distutils-r1 flag-o-matic
 
 DESCRIPTION="Coroutine-based network library"
-HOMEPAGE="http://gevent.org/ https://pypi.org/project/gevent/"
+HOMEPAGE="https://www.gevent.org/ https://pypi.org/project/gevent/"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>