### PR TITLE
app-misc/rox-filer: fix compilation with GCC10

### DIFF
--- a/app-misc/rox-filer/files/rox-filer-2.11-gcc10.patch
+++ b/app-misc/rox-filer/files/rox-filer-2.11-gcc10.patch
@@ -1,0 +1,27 @@
+From 86b0bb9144186d51ea9b898905111bd8b143b552 Mon Sep 17 00:00:00 2001
+From: "Azamat H. Hackimov" <azamat.hackimov@gmail.com>
+Date: Tue, 30 Jun 2020 00:22:06 +0300
+Subject: [PATCH] Fix compilation with GCC10
+
+Fixed compilation when -fno-common enabled (in GCC10 by default). See
+https://bugs.gentoo.org/710330.
+---
+ ROX-Filer/src/session.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/session.h b/session.h
+index 7734996a..31341bc4 100644
+--- a/session.h
++++ b/session.h
+@@ -10,7 +10,7 @@
+ #include <gtk/gtk.h>
+ #include <X11/SM/SMlib.h>
+ 
+-gboolean session_auto_respawn;
++extern gboolean session_auto_respawn;
+ 
+ void session_init(const gchar *client_id);
+ 
+-- 
+2.26.2
+

--- a/app-misc/rox-filer/metadata.xml
+++ b/app-misc/rox-filer/metadata.xml
@@ -16,6 +16,7 @@
 	</maintainer>
 	<bugs-to>http://rox.sourceforge.net/desktop/lists</bugs-to>
 	<remote-id type="sourceforge">rox</remote-id>
+	<remote-id type="github">rox-desktop/rox-filer</remote-id>
 </upstream>
 <longdescription lang="en">
 	ROX-Filer is a fast and powerful graphical file manager for the

--- a/app-misc/rox-filer/rox-filer-2.11.ebuild
+++ b/app-misc/rox-filer/rox-filer-2.11.ebuild
@@ -1,18 +1,17 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit desktop epatch virtualx
+inherit desktop virtualx
 
 DESCRIPTION="ROX-Filer a drag and drop spatial file manager"
-HOMEPAGE="http://rox.sourceforge.net/desktop"
-SRC_URI="mirror://sourceforge/rox/${P}.tar.bz2"
+HOMEPAGE="http://rox.sourceforge.net/desktop/ROX-Filer.html"
+SRC_URI="https://download.sourceforge.net/rox/${P}.tar.bz2"
 
-LICENSE="GPL-2 LGPL-2"
+LICENSE="GPL-2+ LGPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ~arm x86"
-IUSE=""
 
 COMMON_DEPEND="dev-lang/perl
 	dev-libs/libxml2:2
@@ -22,13 +21,18 @@ RDEPEND="${COMMON_DEPEND}
 	x11-misc/shared-mime-info"
 DEPEND="${COMMON_DEPEND}
 	dev-util/intltool
-	sys-devel/gettext
-	virtual/pkgconfig"
+	sys-devel/gettext"
+BDEPEND="virtual/pkgconfig"
 
-S="${WORKDIR}/${P}"/ROX-Filer/src
+S="${WORKDIR}/${P}/ROX-Filer/src"
+
+PATCHES=(
+	"${FILESDIR}/${P}-in-source-build.patch"
+	"${FILESDIR}/${P}-gcc10.patch"
+)
 
 src_prepare() {
-	epatch "${FILESDIR}/${P}-in-source-build.patch"
+	default
 
 	sed -i -e 's:g_strdup(getenv("APP_DIR")):"/usr/share/rox":' \
 		main.c || die "sed failed"


### PR DESCRIPTION
Updated ebuild to EAPI7, fixed compilation with -fno-common.
Closes: https://bugs.gentoo.org/710330
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>