### PR TITLE
dev-util/bnfc: remove unused patch

### DIFF
--- a/dev-util/bnfc/files/bnfc-2.8-alex-3.1.6.patch
+++ b/dev-util/bnfc/files/bnfc-2.8-alex-3.1.6.patch
@@ -1,8 +1,0 @@
-diff --git a/src/LexBNF.x b/src/LexBNF.x
-index 927e15d..aea3386 100644
---- a/src/LexBNF.x
-+++ b/src/LexBNF.x
-@@ -11,2 +11,3 @@ import qualified Data.Bits
- import Data.Word (Word8)
-+import Data.Char (ord)
- }


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>