### PR TITLE
app-text/c2ps: use HTTPS, fix LICENSE

### DIFF
--- a/app-text/c2ps/c2ps-4.0.ebuild
+++ b/app-text/c2ps/c2ps-4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,10 +6,10 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Generates a beautified ps document from a source file (c/c++)"
-HOMEPAGE="http://www.cs.technion.ac.il/users/c2ps"
-SRC_URI="http://www.cs.technion.ac.il/users/c2ps/${P}.tar.gz"
+HOMEPAGE="https://www.cs.technion.ac.il/users/c2ps"
+SRC_URI="https://www.cs.technion.ac.il/users/c2ps/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>