### PR TITLE
app-admin/doas: Add support for experimental persist feature

### DIFF
--- a/app-admin/doas/doas-6.6.1.ebuild
+++ b/app-admin/doas/doas-6.6.1.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}"/${MY_P}
 LICENSE="ISC"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64"
-IUSE="pam"
+IUSE="pam timestamp"
 
 RDEPEND="pam? ( sys-libs/pam )"
 DEPEND="${RDEPEND}
@@ -33,5 +33,6 @@ src_configure() {
 		--prefix="${EPREFIX}"/usr \
 		--sysconfdir="${EPREFIX}"/etc \
 		$(use_with pam) \
+		$(use_with timestamp) \
 		|| die
 }

--- a/app-admin/doas/metadata.xml
+++ b/app-admin/doas/metadata.xml
@@ -9,6 +9,9 @@
 	<email>proxy-maint@gentoo.org</email>
 	<name>Proxy Maintainers</name>
 </maintainer>
+<use>
+	<flag name="timestamp">Adds support for "persist" feature (experimental)</flag>
+</use>
 <upstream>
 	<remote-id type="github">Duncaen/OpenDoas</remote-id>
 </upstream>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/726994
Signed-off-by: Felix Janda <felix.janda@posteo.de>