### PR TITLE
net-irc/weechat: fix #730338

### DIFF
--- a/net-irc/weechat/weechat-2.7.1.ebuild
+++ b/net-irc/weechat/weechat-2.7.1.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	sys-libs/zlib
 	charset? ( virtual/libiconv )
 	guile? ( >=dev-scheme/guile-2.0 )
-	lua? ( dev-lang/lua:0[deprecated] )
+	lua? ( dev-lang/lua:0 )
 	nls? ( virtual/libintl )
 	perl? ( dev-lang/perl:= )
 	php? ( >=dev-lang/php-7.0:*[embed] )

--- a/net-irc/weechat/weechat-2.8.ebuild
+++ b/net-irc/weechat/weechat-2.8.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	sys-libs/zlib
 	charset? ( virtual/libiconv )
 	guile? ( >=dev-scheme/guile-2.0 )
-	lua? ( dev-lang/lua:0[deprecated] )
+	lua? ( dev-lang/lua:0 )
 	nls? ( virtual/libintl )
 	perl? ( dev-lang/perl:= )
 	php? ( >=dev-lang/php-7.0:*[embed] )

--- a/net-irc/weechat/weechat-9999.ebuild
+++ b/net-irc/weechat/weechat-9999.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	sys-libs/zlib
 	charset? ( virtual/libiconv )
 	guile? ( >=dev-scheme/guile-2.0 )
-	lua? ( dev-lang/lua:0[deprecated] )
+	lua? ( dev-lang/lua:0 )
 	nls? ( virtual/libintl )
 	perl? ( dev-lang/perl:= )
 	php? ( >=dev-lang/php-7.0:*[embed] )


### PR DESCRIPTION
Remove dev-lang/lua:0[deprecated] USE-dependency as it now not required.
Closes: https://bugs.gentoo.org/730338
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>