### PR TITLE
app-misc/joymouse: EAPI7, fix LICENSE

### DIFF
--- a/app-misc/joymouse/joymouse-0.5-r1.ebuild
+++ b/app-misc/joymouse/joymouse-0.5-r1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="An application that translates joystick events to mouse events"
+HOMEPAGE="https://sourceforge.net/projects/joymouse-linux"
+SRC_URI="mirror://sourceforge/joymouse-linux/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~mips ~ppc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXtst"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+src_prepare() {
+	default
+	sed -i 's/printf(message/fputs(message, stdout/g' src/joymouse.c || die
+}


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,
Simply update to EAPI7 for joymouse, please review.