### PR TITLE
dev-embedded/sdcc: unset ARCH to build target libs

### DIFF
--- a/dev-embedded/sdcc/sdcc-4.0.0-r1.ebuild
+++ b/dev-embedded/sdcc/sdcc-4.0.0-r1.ebuild
@@ -95,6 +95,7 @@ src_prepare() {
 src_configure() {
 	# sdbinutils subdir doesn't pass down --docdir properly, so need to
 	# expand $(datarootdir) ourselves.
+	unset ARCH
 	econf \
 		ac_cv_prog_AR="$(tc-getAR)" \
 		ac_cv_prog_AS="$(tc-getAS)" \
@@ -131,6 +132,11 @@ src_configure() {
 		\
 		--disable-doc \
 		--without-ccache
+}
+
+src_compile() {
+	unset ARCH
+	default
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/730484
Package-Manager: Portage-2.3.103, Repoman-2.3.23