### PR TITLE
gui-libs/display-manager-init: refactor init files out of xorg-server

### DIFF
--- a/gui-libs/display-manager-init/display-manager-init-1.0.ebuild
+++ b/gui-libs/display-manager-init/display-manager-init-1.0.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="RC init files for starting display and login managers"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:X11"
+
+LICENSE="GPL-2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+SLOT="0"
+
+S="${FILESDIR}"
+
+RDEPEND="
+	sys-apps/gentoo-functions
+	!<=sys-apps/sysvinit-2.98
+	!<=x11-apps/xinit-1.4.1
+	!<=x11-base/xorg-server-1.20.10
+"
+
+src_install() {
+	newinitd "${FILESDIR}"/display-manager-setup.initd display-manager-setup
+	newinitd "${FILESDIR}"/display-manager.initd display-manager
+	newinitd "${FILESDIR}"/xdm.initd xdm
+	newconfd "${FILESDIR}"/display-manager.confd display-manager
+	exeinto /usr/bin
+	doexe "${FILESDIR}"/startDM
+	# backwards compatibility
+	dosym "${ESYSROOT}"/usr/bin/startDM /etc/X11/startDM.sh
+}
+
+pkg_preinst() {
+	if [[ ${REPLACING_VERSIONS} == "" && -f "${EROOT}"/etc/conf.d/xdm && ! -f "${EROOT}"/etc/conf.d/display-manager ]]; then
+		mv "${EROOT}"/etc/conf.d/{xdm,display-manager} || die
+	fi
+}

--- a/gui-libs/display-manager-init/files/display-manager-setup.initd
+++ b/gui-libs/display-manager-init/files/display-manager-setup.initd
@@ -1,0 +1,13 @@
+#!/sbin/openrc-run
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+depend() {
+	need localmount
+}
+
+start() {
+	if get_bootparam "nogui" ; then
+		touch /run/.nogui
+	fi
+}

--- a/gui-libs/display-manager-init/files/display-manager.confd
+++ b/gui-libs/display-manager-init/files/display-manager.confd
@@ -1,0 +1,13 @@
+# We always try and start the DM on a static VT. The various DMs normally
+# default to using VT7. If you wish to use the display-manager init
+# script, then you should ensure that the VT checked is the same VT your
+# DM wants to use.
+# We do this check to ensure that you haven't accidentally configured
+# something to run on the VT in your /etc/inittab file so that
+# you don't get a dead keyboard.
+CHECKVT=7
+
+# What display manager do you use ?
+#     [ xdm | greetd | gdm | sddm | gpe | lightdm | entrance ]
+# NOTE: If this is set in /etc/rc.conf, that setting will override this one.
+DISPLAYMANAGER="xdm"

--- a/gui-libs/display-manager-init/files/display-manager.initd
+++ b/gui-libs/display-manager-init/files/display-manager.initd
@@ -1,0 +1,234 @@
+#!/sbin/openrc-run
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License, v2
+
+# This is here to serve as a note to myself, and future developers.
+#
+# Any Display manager (gdm,kdm,xdm) has the following problem:  if
+# it is started before any getty, and no vt is specified, it will
+# usually run on vt2.  When the getty on vt2 then starts, and the
+# DM is already started, the getty will take control of the keyboard,
+# leaving us with a "dead" keyboard.
+#
+# Resolution: add the following line to /etc/inittab
+#
+#  x:a:once:/usr/bin/startDM
+#
+# and have /usr/bin/startDM start the DM in daemon mode if
+# a lock is present (with the info of what DM should be started),
+# else just fall through.
+#
+# How this basically works, is the "a" runlevel is a additional
+# runlevel that you can use to fork processes with init, but the
+# runlevel never gets changed to this runlevel. Along with the "a"
+# runlevel, the "once" key word means that startDM will only be
+# run when we specify it to run, thus eliminating respawning
+# startDM when "display-manager" is not added to the default 
+# runlevel, as was done previously.
+#
+# This script then just calls "telinit a", and init will run
+# /usr/bin/startDM after the current runlevel completes (this
+# script should only be added to the actual runlevel the user is
+# using).
+#
+# Martin Schlemmer
+# aka Azarah
+# 04 March 2002
+
+depend() {
+	need localmount display-manager-setup
+
+	# this should start as early as possible
+	# we can't do 'before *' as that breaks it
+	# (#139824) Start after ypbind and autofs for network authentication
+	# (#145219 #180163) Could use lirc mouse as input device
+	# (#70689 comment #92) Start after consolefont to avoid display corruption
+	# (#291269) Start after quota, since some dm need readable home
+	# (#390609) gdm-3 will fail when dbus is not running
+	# (#366753) starting keymaps after X causes problems
+	after bootmisc consolefont modules netmount
+	after readahead-list ypbind autofs openvpn gpm lircmd
+	after quota keymaps
+	before alsasound
+
+	# Start before GUI
+	use dbus xfs
+}
+
+setup_dm() {
+	local MY_XDM
+
+	MY_XDM=$(echo "${DISPLAYMANAGER}" | tr '[:upper:]' '[:lower:]')
+
+	NAME=
+	case "${MY_XDM}" in
+		kdm|kde)
+			# Load our root path from profile.env
+			# Needed for kdm
+			PATH=${PATH}:$(. /etc/profile.env; echo "${ROOTPATH}")
+			EXE=/usr/bin/kdm
+			PIDFILE=/run/kdm.pid
+			;;
+		entrance*)
+			EXE=/usr/sbin/entrance
+			PIDFILE=/run/entrance.pid
+			;;
+		gdm|gnome)
+			# gdm-3 and above has different paths
+			if [ -f /usr/sbin/gdm ]; then
+				EXE=/usr/sbin/gdm
+				PIDFILE=/run/gdm/gdm.pid
+				START_STOP_ARGS="--background"
+				AUTOCLEAN_CGROUP="yes"
+			else
+				EXE=/usr/bin/gdm
+				PIDFILE=/run/gdm.pid
+			fi
+			[ "${RC_UNAME}" != "Linux" ] && NAME=gdm-binary
+			;;
+		greetd)
+			EXE=/usr/bin/greetd
+			PIDFILE=/run/greetd.pid
+			START_STOP_ARGS="-m --background"
+			;;
+		wdm)
+			EXE=/usr/bin/wdm
+			PIDFILE=
+			;;
+		gpe)
+			EXE=/usr/bin/gpe-dm
+			PIDFILE=/run/gpe-dm.pid
+			;;
+		lxdm)
+			EXE=/usr/sbin/lxdm-binary
+			PIDFILE=/run/lxdm.pid
+			START_STOP_ARGS="--background"
+			;;
+		lightdm)
+			EXE=/usr/sbin/lightdm
+			PIDFILE=/run/lightdm.pid
+			START_STOP_ARGS="--background"
+			;;
+		sddm)
+			EXE="/usr/bin/sddm"
+			START_STOP_ARGS="-m --background"
+			PIDFILE=/run/sddm.pid
+			;;
+		*)
+			# first find out if there is such executable
+			EXE="$(command -v ${MY_XDM} 2>/dev/null)"
+			PIDFILE="/run/${MY_XDM}.pid"
+
+			# warn user that they are doing sick things if the exe was not found
+			if [ -z "${EXE}" ]; then
+				echo "ERROR: Your XDM value is invalid."
+				echo "  No ${MY_XDM} executable could be found on your system."
+			fi
+			;;
+	esac
+
+	if ! [ -x "${EXE}" ]; then
+		EXE=/usr/bin/xdm
+		PIDFILE=/run/xdm.pid
+		if ! [ -x "/usr/bin/xdm" ]; then
+			echo "ERROR: Please set your DISPLAYMANAGER variable in /etc/conf.d/xdm,"
+			echo "	or install x11-apps/xdm package"
+			eend 255
+		fi
+	fi
+}
+
+# Check to see if something is defined on our VT
+vtstatic() {
+	if [ -e /etc/inittab ] ; then
+		grep -Eq "^[^#]+.*\<tty$1\>" /etc/inittab
+	elif [ -e /etc/ttys ] ; then
+		grep -q "^ttyv$(($1 - 1))" /etc/ttys
+	else
+		return 1
+	fi
+}
+
+start() {
+	local EXE NAME PIDFILE AUTOCLEAN_CGROUP
+	setup_dm
+
+	if [ -f /run/.nogui ]; then
+		einfo "Skipping ${EXE##*/}, /run/.nogui found or 'nogui' bootparam passed."
+		rm /run/.nogui
+		return 0
+	fi
+
+	ebegin "Setting up ${EXE##*/}"
+
+	# save the prefered DM
+	save_options "service" "${EXE}"
+	save_options "name"    "${NAME}"
+	save_options "pidfile" "${PIDFILE}"
+	save_options "start_stop_args" "${START_STOP_ARGS}"
+	save_options "autoclean_cgroup" "${AUTOCLEAN_CGROUP:-no}"
+
+	if [ -n "${CHECKVT-y}" ] ; then
+		if vtstatic "${CHECKVT:-7}" ; then
+			if [ -x /sbin/telinit ] && [ "${SOFTLEVEL}" != "BOOT" ] && [ "${RC_SOFTLEVEL}" != "BOOT" ]; then
+				ewarn "Something is already defined on VT ${CHECKVT:-7}, will start X later"
+				telinit a >/dev/null 2>&1
+				return 0
+			else
+				eerror "Something is already defined on VT ${CHECKVT:-7}, not starting"
+				return 1
+			fi
+		fi
+	fi
+
+	/usr/bin/startDM
+	eend 0
+}
+
+stop() {
+	local curvt retval
+
+	retval=0
+	if [ -t 0 ]; then
+		if type fgconsole >/dev/null 2>&1; then
+			curvt=$(fgconsole 2>/dev/null)
+		else
+			curvt=$(tty)
+			case "${curvt}" in
+				/dev/ttyv[0-9]*) curvt=${curvt#/dev/ttyv} ;;
+				*) curvt= ;;
+			esac
+		fi
+	fi
+	local myexe myname mypidfile myservice
+	myexe=$(get_options "service")
+	myname=$(get_options "name")
+	mypidfile=$(get_options "pidfile")
+	myservice=${myexe##*/}
+	yesno "${rc_cgroup_cleanup:-no}" || rc_cgroup_cleanup=$(get_options "autoclean_cgroup")
+
+	[ -z "${myexe}" ] && return 0
+
+	ebegin "Stopping ${myservice}"
+
+	if start-stop-daemon --quiet --test --stop --exec "${myexe}" 2>/dev/null; then
+		start-stop-daemon --stop --exec "${myexe}" --retry TERM/5/TERM/5 \
+			"${mypidfile:+--pidfile}" "${mypidfile}" \
+			"${myname:+--name}" "${myname}"
+		retval=${?}
+	fi
+
+	# switch back to original vt
+	if [ -n "${curvt}" ]; then
+		if type chvt >/dev/null 2>&1; then
+			chvt "${curvt}"
+		else
+			vidcontrol -s "$((curvt + 1))"
+		fi
+	fi
+
+	eend ${retval} "Error stopping ${myservice}"
+	return ${retval}
+}
+
+# vim: set ts=4 :

--- a/gui-libs/display-manager-init/files/startDM
+++ b/gui-libs/display-manager-init/files/startDM
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License, v2
+
+# We need to source /etc/profile.env for stuff like $LANG to work
+# bug #10190.
+. /etc/profile.env
+
+# need eerror
+. /lib/gentoo/functions.sh
+
+# Bail out early if on a non-OpenRC system:
+if [ ! -d /run/openrc ]; then
+	eerror "$0 should only be used on OpenRC systems"
+fi
+
+. /lib/rc/sh/functions.sh
+
+export RC_SVCNAME=display-manager
+EXEC="$(get_options service)"
+NAME="$(get_options name)"
+PIDFILE="$(get_options pidfile)"
+START_STOP_ARGS="$(get_options start_stop_args)"
+
+start-stop-daemon --start --exec "${EXEC}" \
+"${NAME:+--name}" "${NAME}" "${PIDFILE:+--pidfile}" "${PIDFILE}" ${START_STOP_ARGS} || \
+eerror "ERROR: could not start the Display Manager"
+
+# vim:ts=4

--- a/gui-libs/display-manager-init/files/xdm.initd
+++ b/gui-libs/display-manager-init/files/xdm.initd
@@ -1,0 +1,13 @@
+#!/sbin/openrc-run
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License, v2
+
+depend() {
+	need display-manager
+}
+
+start() {
+	return
+}
+
+# vim: set ts=4 :

--- a/gui-libs/display-manager-init/metadata.xml
+++ b/gui-libs/display-manager-init/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>x11@gentoo.org</email>
+		<name>X11</name>
+	</maintainer>
+</pkgmetadata>

--- a/sys-apps/sysvinit/files/inittab-2.98-r1
+++ b/sys-apps/sysvinit/files/inittab-2.98-r1
@@ -1,0 +1,63 @@
+#
+# /etc/inittab:  This file describes how the INIT process should set up
+#                the system in a certain run-level.
+#
+# Author:  Miquel van Smoorenburg, <miquels@cistron.nl>
+# Modified by:  Patrick J. Volkerding, <volkerdi@ftp.cdrom.com>
+# Modified by:  Daniel Robbins, <drobbins@gentoo.org>
+# Modified by:  Martin Schlemmer, <azarah@gentoo.org>
+# Modified by:  Mike Frysinger, <vapier@gentoo.org>
+# Modified by:  Robin H. Johnson, <robbat2@gentoo.org>
+# Modified by:  William Hubbs, <williamh@gentoo.org>
+# Modified by:  Lars Wendler, <polynomial-c@gentoo.org>
+# Modified by:  Aisha Tammy, <gentoo@aisha.cc>
+#
+
+# Default runlevel.
+id:3:initdefault:
+
+# System initialization, mount local filesystems, etc.
+si::sysinit:/sbin/openrc sysinit
+
+# Further system initialization, brings up the boot runlevel.
+rc::bootwait:/sbin/openrc boot
+
+l0u:0:wait:/sbin/telinit u
+l0:0:wait:/sbin/openrc shutdown
+l0s:0:wait:/sbin/halt.sh
+l1:1:wait:/sbin/openrc single
+l2:2:wait:/sbin/openrc nonetwork
+l3:3:wait:/sbin/openrc default
+l4:4:wait:/sbin/openrc default
+l5:5:wait:/sbin/openrc default
+l6u:6:wait:/sbin/telinit u
+l6:6:wait:/sbin/openrc reboot
+l6r:6:wait:/sbin/reboot -dkn
+#z6:6:respawn:/sbin/sulogin
+
+# new-style single-user
+su0:S:wait:/sbin/openrc single
+su1:S:wait:/sbin/sulogin
+
+# TERMINALS
+#x1:12345:respawn:/sbin/agetty 38400 console linux
+c1:12345:respawn:/sbin/agetty --noclear 38400 tty1 linux
+c2:2345:respawn:/sbin/agetty 38400 tty2 linux
+c3:2345:respawn:/sbin/agetty 38400 tty3 linux
+c4:2345:respawn:/sbin/agetty 38400 tty4 linux
+c5:2345:respawn:/sbin/agetty 38400 tty5 linux
+c6:2345:respawn:/sbin/agetty 38400 tty6 linux
+
+# SERIAL CONSOLES
+#s0:12345:respawn:/sbin/agetty -L 9600 ttyS0 vt100
+#s1:12345:respawn:/sbin/agetty -L 9600 ttyS1 vt100
+
+# What to do at the "Three Finger Salute".
+ca:12345:ctrlaltdel:/sbin/shutdown -r now
+
+# Used by /etc/init.d/display-manager to control DM startup.
+# Read the comments in /etc/init.d/display-manager for more
+# info. Do NOT remove, as this will start nothing
+# extra at boot if /etc/init.d/display-manager is not added
+# to the "default" runlevel.
+x:a:once:/usr/bin/startDM

--- a/sys-apps/sysvinit/sysvinit-2.98-r1.ebuild
+++ b/sys-apps/sysvinit/sysvinit-2.98-r1.ebuild
@@ -1,0 +1,144 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs flag-o-matic
+
+DESCRIPTION="/sbin/init - parent of all processes"
+HOMEPAGE="https://savannah.nongnu.org/projects/sysvinit"
+SRC_URI="mirror://nongnu/${PN}/${P/_/-}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+[[ "${PV}" == *beta* ]] || \
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="selinux ibm static kernel_FreeBSD"
+
+CDEPEND="
+	selinux? (
+		>=sys-libs/libselinux-1.28
+	)"
+DEPEND="${CDEPEND}
+	virtual/os-headers"
+RDEPEND="${CDEPEND}
+	selinux? ( sec-policy/selinux-shutdown )
+	!<sys-apps/openrc-0.13
+"
+
+S="${WORKDIR}/${P/_*}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.86-kexec.patch" #80220
+	"${FILESDIR}/${PN}-2.94_beta-shutdown-single.patch" #158615
+	"${FILESDIR}/${PN}-2.95_beta-shutdown-h.patch" #449354
+)
+
+src_prepare() {
+	default
+
+	sed -i \
+		-e '/^CPPFLAGS =$/d' \
+		-e '/^override CFLAGS +=/s/ -fstack-protector-strong//' \
+		src/Makefile || die
+
+	# last/lastb/mesg/mountpoint/sulogin/utmpdump/wall have moved to util-linux
+	sed -i -r \
+		-e '/^(USR)?S?BIN/s:\<(last|lastb|mesg|mountpoint|sulogin|utmpdump|wall)\>::g' \
+		-e '/^MAN[18]/s:\<(last|lastb|mesg|mountpoint|sulogin|utmpdump|wall)[.][18]\>::g' \
+		src/Makefile || die
+
+	# pidof has moved to >=procps-3.3.9
+	sed -i -r \
+		-e '/\/bin\/pidof/d' \
+		-e '/^MAN8/s:\<pidof.8\>::g' \
+		src/Makefile || die
+
+	# logsave is already in e2fsprogs
+	sed -i -r \
+		-e '/^(USR)?S?BIN/s:\<logsave\>::g' \
+		-e '/^MAN8/s:\<logsave.8\>::g' \
+		src/Makefile || die
+
+	# Mung inittab for specific architectures
+	cd "${WORKDIR}" || die
+	cp "${FILESDIR}"/inittab-2.98-r1 inittab || die "cp inittab"
+	local insert=()
+	use ppc && insert=( '#psc0:12345:respawn:/sbin/agetty 115200 ttyPSC0 linux' )
+	use arm && insert=( '#f0:12345:respawn:/sbin/agetty 9600 ttyFB0 vt100' )
+	use arm64 && insert=( 'f0:12345:respawn:/sbin/agetty 9600 ttyAMA0 vt100' )
+	use hppa && insert=( 'b0:12345:respawn:/sbin/agetty 9600 ttyB0 vt100' )
+	use s390 && insert=( 's0:12345:respawn:/sbin/agetty 38400 console dumb' )
+	if use ibm ; then
+		insert+=(
+			'#hvc0:2345:respawn:/sbin/agetty -L 9600 hvc0'
+			'#hvsi:2345:respawn:/sbin/agetty -L 19200 hvsi0'
+		)
+	fi
+	(use arm || use mips || use sparc) && sed -i '/ttyS0/s:#::' inittab
+	if use kernel_FreeBSD ; then
+		sed -i \
+			-e 's/linux/cons25/g' \
+			-e 's/ttyS0/cuaa0/g' \
+			-e 's/ttyS1/cuaa1/g' \
+			inittab #121786
+	fi
+	if use x86 || use amd64 ; then
+		sed -i \
+			-e '/ttyS[01]/s:9600:115200:' \
+			inittab
+	fi
+	if [[ ${#insert[@]} -gt 0 ]] ; then
+		printf '%s\n' '' '# Architecture specific features' "${insert[@]}" >> inittab
+	fi
+}
+
+src_compile() {
+	tc-export CC
+	append-lfs-flags
+	export DISTRO= #381311
+	export VERSION="${PV}"
+	use static && append-ldflags -static
+	emake -C src $(usex selinux 'WITH_SELINUX=yes' '')
+}
+
+src_install() {
+	emake -C src install ROOT="${D}"
+	dodoc README doc/*
+
+	insinto /etc
+	doins "${WORKDIR}"/inittab
+
+	newinitd "${FILESDIR}"/bootlogd.initd bootlogd
+	into /
+	dosbin "${FILESDIR}"/halt.sh
+
+	keepdir /etc/inittab.d
+
+	# dead symlink
+	find "${ED}" -xtype l -delete || die
+
+	find "${ED}" -type d -empty -delete || die
+}
+
+pkg_postinst() {
+	# Reload init to fix unmounting problems of / on next reboot.
+	# This is really needed, as without the new version of init cause init
+	# not to quit properly on reboot, and causes a fsck of / on next reboot.
+	if [[ -z ${ROOT} ]] ; then
+		if [[ -e /dev/initctl ]] && [[ ! -e /run/initctl ]] ; then
+			ln -s /dev/initctl /run/initctl \
+				|| ewarn "Failed to set /run/initctl symlink!"
+		fi
+		# Do not return an error if this fails
+		/sbin/telinit U &>/dev/null
+	fi
+
+	elog "The last/lastb/mesg/mountpoint/sulogin/utmpdump/wall tools have been moved to"
+	elog "sys-apps/util-linux. The pidof tool has been moved to sys-process/procps."
+
+	# Required for new bootlogd service
+	if [[ ! -e "${EROOT}/var/log/boot" ]] ; then
+		touch "${EROOT}/var/log/boot"
+	fi
+}

--- a/x11-apps/xinit/xinit-1.4.1-r1.ebuild
+++ b/x11-apps/xinit/xinit-1.4.1-r1.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit xorg-3
+
+DESCRIPTION="X Window System initializer"
+
+LICENSE="${LICENSE} GPL-2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~arm-linux ~x86-linux"
+IUSE="twm"
+
+RDEPEND="
+	x11-apps/xauth
+	x11-libs/libX11
+"
+DEPEND="${RDEPEND}"
+PDEPEND="x11-apps/xrdb
+	twm? (
+		x11-apps/xclock
+		x11-apps/xsm
+		x11-terms/xterm
+		x11-wm/twm
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.3.3-gentoo-customizations.patch"
+	"${FILESDIR}/${PN}-1.4.0-startx-current-vt.patch"
+	"${FILESDIR}/${PN}-1.4.1-move-serverauthfile-into-tmp.patch"
+)
+
+XORG_CONFIGURE_OPTIONS=(
+	--with-xinitdir="${EPREFIX}"/etc/X11/xinit
+)
+
+src_install() {
+	xorg-3_src_install
+
+	exeinto /etc/X11
+	doexe "${FILESDIR}"/chooser.sh
+	exeinto /etc/X11/Sessions
+	doexe "${FILESDIR}"/Xsession
+	exeinto /etc/X11/xinit
+	newexe "${FILESDIR}"/xserverrc.2 xserverrc
+	exeinto /etc/X11/xinit/xinitrc.d/
+	doexe "${FILESDIR}"/00-xhost
+
+	insinto /usr/share/xsessions
+	doins "${FILESDIR}"/Xsession.desktop
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
+		ewarn "If you use startx to start X instead of a login manager like gdm/kdm,"
+		ewarn "you can set the XSESSION variable to anything in /etc/X11/Sessions/ or"
+		ewarn "any executable. When you run startx, it will run this as the login session."
+		ewarn "You can set this in a file in /etc/env.d/ for the entire system,"
+		ewarn "or set it per-user in ~/.bash_profile (or similar for other shells)."
+		ewarn "Here's an example of setting it for the whole system:"
+		ewarn "    echo XSESSION=\"Gnome\" > /etc/env.d/90xsession"
+		ewarn "    env-update && source /etc/profile"
+	fi
+
+	for v in ${REPLACING_VERSIONS}; do
+		if ver_test "$v" "-lt" "1.4.1"; then
+			ewarn "Starting with ${CATEGORY}/${PN}-1.4.1 serverauth files are no longer kept in the"
+			ewarn "home directory but rather are created in \$TMPDIR (typically /tmp).  The change"
+			ewarn "is transparent for most of users, however those that use runtime temporary"
+			ewarn "directories cleaning tools, like app-admin/tmpreaper, may need to adjust them"
+			ewarn "not to remove the 'serverauth.*' files."
+		fi
+	done
+}

--- a/x11-base/xorg-server/xorg-server-1.20.10-r1.ebuild
+++ b/x11-base/xorg-server/xorg-server-1.20.10-r1.ebuild
@@ -4,14 +4,13 @@
 EAPI=7
 
 XORG_DOC=doc
-XORG_EAUTORECONF="yes"
 inherit xorg-3 multilib flag-o-matic toolchain-funcs
 EGIT_REPO_URI="https://gitlab.freedesktop.org/xorg/xserver.git"
 
 DESCRIPTION="X.Org X servers"
 SLOT="0/${PV}"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
 
 IUSE_SERVERS="dmx kdrive wayland xephyr xnest xorg xvfb"
@@ -170,6 +169,7 @@ pkg_setup() {
 		--disable-linux-acpi
 		--without-dtrace
 		--without-fop
+		--with-os-vendor=Gentoo
 		--with-sha1=libcrypto
 		CPP="$(tc-getPROG CPP cpp)"
 	)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/730644

---

Changes to script: add support for `greetd`

@gyakovlev has provided the patch

Package-Manager: Portage-2.3.101, Repoman-2.3.22
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>

---

This needs extensive testing!
