### PR TITLE
www-client/firefox: pass --disable-elf-hack only on supported arches

### DIFF
--- a/www-client/firefox/firefox-78.0.1.ebuild
+++ b/www-client/firefox/firefox-78.0.1.ebuild
@@ -581,10 +581,15 @@ src_configure() {
 	# when they would normally be larger than 2GiB.
 	append-ldflags "-Wl,--compress-debug-sections=zlib"
 
-	if use clang && ! use arm64; then
+	if use clang; then
 		# https://bugzilla.mozilla.org/show_bug.cgi?id=1482204
 		# https://bugzilla.mozilla.org/show_bug.cgi?id=1483822
-		mozconfig_annotate 'elf-hack is broken when using Clang' --disable-elf-hack
+		# moz.configure Elfhack section: target.cpu in ('arm', 'x86', 'x86_64')
+		local disable_elf_hack
+		use amd64 && disable_elf_hack=1
+		use arm && disable_elf_hack=1
+		use x86 && disable_elf_hack=1
+		[[ disable_elf_hack -eq 1 ]] && mozconfig_annotate 'elf-hack is broken when using Clang' --disable-elf-hack
 	fi
 
 	echo "mk_add_options MOZ_OBJDIR=${BUILD_OBJ_DIR}" >> "${S}"/.mozconfig


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/727040
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>