### PR TITLE
sci-astronomy/skycat: update HOMEPAGE, use HTTPS, fix LICENSE

### DIFF
--- a/sci-astronomy/skycat/skycat-3.1.2-r2.ebuild
+++ b/sci-astronomy/skycat/skycat-3.1.2-r2.ebuild
@@ -1,14 +1,14 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 inherit autotools flag-o-matic
 
 DESCRIPTION="ESO astronomical image visualizer with catalog access"
-HOMEPAGE="http://archive.eso.org/skycat"
+HOMEPAGE="https://www.eso.org/sci/observing/tools/skycat.html"
 SRC_URI="http://archive.eso.org/cms/tools-documentation/skycat-download/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"

--- a/sci-astronomy/skycat/skycat-3.1.3.ebuild
+++ b/sci-astronomy/skycat/skycat-3.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,10 +6,10 @@ EAPI=6
 inherit autotools flag-o-matic
 
 DESCRIPTION="ESO astronomical image visualizer with catalog access"
-HOMEPAGE="http://archive.eso.org/skycat"
-SRC_URI="http://archive.eso.org/cms/tools-documentation/skycat-download/${P}.tar.gz"
+HOMEPAGE="https://www.eso.org/sci/observing/tools/skycat.html"
+SRC_URI="https://archive.eso.org/cms/tools-documentation/skycat-download/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

I haven't updated the 3.1.2 SRC_URI because it seems the sources are not available anymore.