### PR TITLE
media-sound/lilypond: fix sandbox violation

### DIFF
--- a/media-sound/lilypond/lilypond-2.21.1.ebuild
+++ b/media-sound/lilypond/lilypond-2.21.1.ebuild
@@ -105,6 +105,7 @@ src_configure() {
 		$(use_enable debug debugging)
 		$(use_enable profile profiling)
 	)
+	export VARTEXFONTS="${T}/fonts"  # https://bugs.gentoo.org/692010
 
 	econf "${myeconfargs[@]}"
 }

--- a/media-sound/lilypond/lilypond-9999.ebuild
+++ b/media-sound/lilypond/lilypond-9999.ebuild
@@ -105,6 +105,7 @@ src_configure() {
 		$(use_enable debug debugging)
 		$(use_enable profile profiling)
 	)
+	export VARTEXFONTS="${T}/fonts"  # https://bugs.gentoo.org/692010
 
 	econf "${myeconfargs[@]}"
 }


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>
Closes: https://bugs.gentoo.org/692010