### PR TITLE
media-libs/openh264: fix cross compiling

### DIFF
--- a/media-libs/openh264/openh264-2.1.1.ebuild
+++ b/media-libs/openh264/openh264-2.1.1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/cisco/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="BSD"
 SLOT="0/6" # subslot = openh264 soname version
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="cpu_flags_x86_avx2 +plugin utils"
+IUSE="cpu_flags_arm_neon cpu_flags_x86_avx2 +plugin utils"
 
 RESTRICT="bindist test"
 
@@ -36,24 +36,29 @@ multilib_src_configure() {
 }
 
 emakecmd() {
-	CC="$(tc-getCC)" CXX="$(tc-getCXX)" LD="$(tc-getLD)" \
+	CC="$(tc-getCC)" CXX="$(tc-getCXX)" LD="$(tc-getLD)" AR="$(tc-getAR)" \
 	emake V=Yes CFLAGS_M32="" CFLAGS_M64="" CFLAGS_OPT="" \
 		PREFIX="${EPREFIX}/usr" \
 		LIBDIR_NAME="$(get_libdir)" \
 		SHAREDLIB_DIR="${EPREFIX}/usr/$(get_libdir)" \
 		INCLUDES_DIR="${EPREFIX}/usr/include/${PN}" \
 		HAVE_AVX2=$(usex cpu_flags_x86_avx2 Yes No) \
+		ARCH="$(tc-arch)" \
 		$@
 }
 
 multilib_src_compile() {
-	local mybits="ENABLE64BIT=No"
+	local myopts="ENABLE64BIT=No"
 	case "${ABI}" in
-		s390x|alpha|*64) mybits="ENABLE64BIT=Yes";;
+		s390x|alpha|*64) myopts="ENABLE64BIT=Yes";;
 	esac
 
-	emakecmd ${mybits}
-	use plugin && emakecmd ${mybits} plugin
+	if use arm; then
+		myopts+=" USE_ASM=$(usex cpu_flags_arm_neon Yes No)"
+	fi
+
+	emakecmd ${myopts}
+	use plugin && emakecmd ${myopts} plugin
 }
 
 multilib_src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/730520
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>