### PR TITLE
dev-libs/link-grammar: use HTTPS

### DIFF
--- a/dev-libs/link-grammar/link-grammar-5.3.11.ebuild
+++ b/dev-libs/link-grammar/link-grammar-5.3.11.ebuild
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python3_6 )
 inherit autotools eutils gnome2 java-pkg-opt-2 python-r1
 
 DESCRIPTION="A Syntactic English parser"
-HOMEPAGE="http://www.abisource.com/projects/link-grammar/ http://www.link.cs.cmu.edu/link/"
-SRC_URI="http://www.abisource.com/downloads/${PN}/${PV}/${P}.tar.gz"
+HOMEPAGE="https://www.abisource.com/projects/link-grammar/ https://www.link.cs.cmu.edu/link/"
+SRC_URI="https://www.abisource.com/downloads/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>