### PR TITLE
sys-firmware/midisport-firmware: Midisport 8x8 Udev Rule

### DIFF
--- a/sys-firmware/midisport-firmware/files/midisport-firmware-1.2-rules.patch
+++ b/sys-firmware/midisport-firmware/files/midisport-firmware-1.2-rules.patch
@@ -23,5 +23,4 @@
 -ACTION=="add", SUBSYSTEM=="usb", DEVPATH=="/*.0", ENV{PRODUCT}=="763/1031/121", RUN+="@fxload@ -s @firmwaredir@/MidiSportLoader.ihx -I @firmwaredir@/MidiSport8x8-2.21.ihx"
 -
 -# vim: ft=conf
-+#ACTION=="add", SUBSYSTEM=="usb", DEVPATH=="/*.0", ENV{PRODUCT}=="763/1031/110", RUN+="@fxload@ -s @firmwaredir@/MidiSportLoader.ihx -I @firmwaredir@/MidiSport8x8-2.10.ihx"
-+#ACTION=="add", SUBSYSTEM=="usb", DEVPATH=="/*.0", ENV{PRODUCT}=="763/1031/121", RUN+="@fxload@ -s @firmwaredir@/MidiSportLoader.ihx -I @firmwaredir@/MidiSport8x8-2.21.ihx"
++ACTION=="add", SUBSYSTEM=="usb*", ATTRS{idVendor}=="0763", ATTRS{idProduct}=="1031", RUN+="@fxload@ -s @firmwaredir@/MidiSportLoader.ihx -I @firmwaredir@/MidiSport8x8-2.21.ihx -D %N"

--- a/sys-firmware/midisport-firmware/files/midisport-firmware-1.2-rules.patch
+++ b/sys-firmware/midisport-firmware/files/midisport-firmware-1.2-rules.patch
@@ -1,8 +1,8 @@
---- midisport-firmware-1.2.orig/42-midisport-firmware.rules.in	2006-03-05 22:01:45.000000000 +0100
-+++ midisport-firmware-1.2/42-midisport-firmware.rules.in	2013-01-06 22:07:03.385941852 +0100
-@@ -1,18 +1,13 @@
+--- midisport-firmware-1.2/42-midisport-firmware.rules.in	2013-01-06 22:07:03.385941852 +0100
++++ midisport-firmware-1.2/42-midisport-firmware.rules.in	2020-07-25 13:47:11.910148029 -0400
+@@ -1,18 +1,12 @@
  # midisport-firmware.rules - udev rules for loading firmware into MidiSport devices
- 
+
 -# DEVPATH=="/*.0" selects interface 0 only
 -# (some udev versions don't work with SYSFS{bInterfaceNumber})
 -

--- a/sys-firmware/midisport-firmware/midisport-firmware-1.2-r1.ebuild
+++ b/sys-firmware/midisport-firmware/midisport-firmware-1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: John Murphy <john.david.murphy@gmail.com>