### PR TITLE
sys-fs/e2fsprogs: remove sourceforge mirror from SRC_URI

### DIFF
--- a/sys-fs/e2fsprogs/e2fsprogs-1.45.5.ebuild
+++ b/sys-fs/e2fsprogs/e2fsprogs-1.45.5.ebuild
@@ -7,8 +7,7 @@ inherit flag-o-matic systemd toolchain-funcs udev usr-ldscript
 
 DESCRIPTION="Standard EXT2/EXT3/EXT4 filesystem utilities"
 HOMEPAGE="http://e2fsprogs.sourceforge.net/"
-SRC_URI="mirror://sourceforge/e2fsprogs/${P}.tar.xz
-	https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v${PV}/${P}.tar.xz
+SRC_URI="https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v${PV}/${P}.tar.xz
 	elibc_mintlib? ( mirror://gentoo/${PN}-1.42.9-mint-r1.patch.xz )"
 
 LICENSE="GPL-2 BSD"

--- a/sys-fs/e2fsprogs/e2fsprogs-1.45.6.ebuild
+++ b/sys-fs/e2fsprogs/e2fsprogs-1.45.6.ebuild
@@ -7,8 +7,7 @@ inherit flag-o-matic systemd toolchain-funcs udev usr-ldscript
 
 DESCRIPTION="Standard EXT2/EXT3/EXT4 filesystem utilities"
 HOMEPAGE="http://e2fsprogs.sourceforge.net/"
-SRC_URI="mirror://sourceforge/e2fsprogs/${P}.tar.xz
-	https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v${PV}/${P}.tar.xz
+SRC_URI="https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v${PV}/${P}.tar.xz
 	elibc_mintlib? ( mirror://gentoo/${PN}-1.42.9-mint-r1.patch.xz )"
 
 LICENSE="GPL-2 BSD"


### PR DESCRIPTION
Signed-off-by: Francesco Turco <mail@fturco.net>
Closes: https://bugs.gentoo.org/608462