### PR TITLE
media-sound/yoshimi: fix #729716

### DIFF
--- a/media-sound/yoshimi/files/yoshimi-1.7.1-fix-LV2_Descriptor.patch
+++ b/media-sound/yoshimi/files/yoshimi-1.7.1-fix-LV2_Descriptor.patch
@@ -1,0 +1,47 @@
+diff --git a/src/LV2_Plugin/YoshimiLV2Plugin.cpp b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+index 3502689..9be6128 100644
+--- a/src/LV2_Plugin/YoshimiLV2Plugin.cpp
++++ b/src/LV2_Plugin/YoshimiLV2Plugin.cpp
+@@ -378,7 +378,7 @@ bool YoshimiLV2Plugin::init()
+ }
+ 
+ 
+-LV2_Handle	YoshimiLV2Plugin::instantiate (const struct _LV2_Descriptor *desc, double sample_rate, const char *bundle_path, const LV2_Feature *const *features)
++LV2_Handle	YoshimiLV2Plugin::instantiate (const struct LV2_Descriptor *desc, double sample_rate, const char *bundle_path, const LV2_Feature *const *features)
+ {
+     SynthEngine *synth = new SynthEngine(0, NULL, true);
+     if (synth == NULL || !synth->getRuntime().isRuntimeSetupCompleted()){
+@@ -711,9 +711,9 @@ bool YoshimiLV2PluginUI::init()
+ }
+ 
+ 
+-LV2UI_Handle YoshimiLV2PluginUI::instantiate(const _LV2UI_Descriptor *descriptor, const char *plugin_uri, const char *bundle_path, LV2UI_Write_Function write_function, LV2UI_Controller controller, LV2UI_Widget *widget, const LV2_Feature * const *features)
++LV2UI_Handle YoshimiLV2PluginUI::instantiate(const LV2UI_Descriptor *descriptor, const char *plugin_uri, const char *bundle_path, LV2UI_Write_Function write_function, LV2UI_Controller controller, LV2UI_Widget *widget, const LV2_Feature * const *features)
+ {
+-    const _LV2UI_Descriptor *desc = descriptor;
++    const LV2UI_Descriptor *desc = descriptor;
+     descriptor = desc;
+     const char *plug = plugin_uri;
+     plugin_uri = plug;
+diff --git a/src/LV2_Plugin/YoshimiLV2Plugin.h b/src/LV2_Plugin/YoshimiLV2Plugin.h
+index a484a8b..47f4729 100644
+--- a/src/LV2_Plugin/YoshimiLV2Plugin.h
++++ b/src/LV2_Plugin/YoshimiLV2Plugin.h
+@@ -106,7 +106,7 @@ public:
+    virtual void registerAudioPort(int) {}
+ 
+    //static methods
+-   static LV2_Handle	instantiate (const struct _LV2_Descriptor *, double sample_rate, const char *bundle_path, const LV2_Feature *const *features);
++   static LV2_Handle	instantiate (const struct LV2_Descriptor *, double sample_rate, const char *bundle_path, const LV2_Feature *const *features);
+    static void connect_port(LV2_Handle instance, uint32_t port, void *data_location);
+    static void activate(LV2_Handle instance);
+    static void deactivate(LV2_Handle instance);
+@@ -159,7 +159,7 @@ public:
+     YoshimiLV2PluginUI(const char *, LV2UI_Write_Function, LV2UI_Controller, LV2UI_Widget *widget, const LV2_Feature *const *features);
+     ~YoshimiLV2PluginUI();
+     bool init();
+-    static LV2UI_Handle	instantiate(const struct _LV2UI_Descriptor *descriptor, const char *plugin_uri, const char *bundle_path, LV2UI_Write_Function write_function, LV2UI_Controller controller, LV2UI_Widget *widget, const LV2_Feature *const *features);
++    static LV2UI_Handle	instantiate(const struct LV2UI_Descriptor *descriptor, const char *plugin_uri, const char *bundle_path, LV2UI_Write_Function write_function, LV2UI_Controller controller, LV2UI_Widget *widget, const LV2_Feature *const *features);
+     static void cleanup(LV2UI_Handle ui);
+     static void static_guiClosed(void *arg);
+     void run();

--- a/media-sound/yoshimi/yoshimi-1.7.1-r1.ebuild
+++ b/media-sound/yoshimi/yoshimi-1.7.1-r1.ebuild
@@ -35,6 +35,8 @@ CMAKE_USE_DIR="${WORKDIR}/${P}/src"
 
 DOCS=( Changelog README.txt )
 
+PATCHES=( "${FILESDIR}/${PN}-1.7.1-fix-LV2_Descriptor.patch" )
+
 src_prepare() {
 	cmake_src_prepare
 	append-cxxflags -lpthread


### PR DESCRIPTION
Created new ebuild -r1 with patch from bugzilla.
Fixed dependencies
Closes:https://bugs.gentoo.org/729716

Package-Manager: Portage-2.3.99, Repoman-2.3.23
RepoMan-Options: --force
Signed-off-by: Denis Reva <denis7774@gmail.com>