### PR TITLE
dev-util/dwarves: switch to EAPI 7 and cleanup ebuild

### DIFF
--- a/dev-util/dwarves/dwarves-1.17.ebuild
+++ b/dev-util/dwarves/dwarves-1.17.ebuild
@@ -1,10 +1,10 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
-inherit multilib cmake-utils python-single-r1
+inherit cmake python-single-r1
 
 DESCRIPTION="pahole (Poke-a-Hole) and other DWARF2 utilities"
 HOMEPAGE="https://git.kernel.org/cgit/devel/pahole/pahole.git/"
@@ -12,7 +12,6 @@ HOMEPAGE="https://git.kernel.org/cgit/devel/pahole/pahole.git/"
 LICENSE="GPL-2" # only
 SLOT="0"
 KEYWORDS="amd64 ~ppc64 x86"
-IUSE="debug"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
@@ -34,11 +33,11 @@ PATCHES=(
 
 src_configure() {
 	local mycmakeargs=( "-D__LIB=$(get_libdir)" )
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_test() { :; }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 }


### PR DESCRIPTION
As an intentional consequence of using EAPI 7, python-single-target is switched from 3.6 to 3.7. This patch also removes the unused "debug" USE flag.

Please merge. Thanks.

Closes: https://bugs.gentoo.org/732924