### PR TITLE
sys-appds/dtc: export PKG_CONFIG

### DIFF
--- a/sys-apps/dtc/dtc-1.5.0.ebuild
+++ b/sys-apps/dtc/dtc-1.5.0.ebuild
@@ -47,7 +47,7 @@ src_prepare() {
 		-e "/^LIBDIR =/s:=.*:= \$(PREFIX)/$(get_libdir):" \
 		Makefile || die
 
-	tc-export AR CC
+	tc-export AR CC PKG_CONFIG
 	export V=1
 }
 

--- a/sys-apps/dtc/dtc-9999.ebuild
+++ b/sys-apps/dtc/dtc-9999.ebuild
@@ -45,7 +45,7 @@ src_prepare() {
 		-e "/^LIBDIR =/s:=.*:= \$(PREFIX)/$(get_libdir):" \
 		Makefile || die
 
-	tc-export AR CC
+	tc-export AR CC PKG_CONFIG
 	export V=1
 }
 


### PR DESCRIPTION
The Makefile hard-codes 'pkg-config' but allows overrides. We should
export our selection, to help with cross-compiling, for example.

Signed-off-by: Brian Norris <briannorris@chromium.org>