### PR TITLE
media-gfx/openscad: remove unneeded patch

### DIFF
--- a/media-gfx/openscad/openscad-9999.ebuild
+++ b/media-gfx/openscad/openscad-9999.ebuild
@@ -17,10 +17,6 @@ KEYWORDS=""
 IUSE="ccache emacs"
 RESTRICT="test"
 
-PATCHES=(
-	"${FILESDIR}/${PN}-2019.05-0001-Fix-build-with-boost-1.73.patch"
-)
-
 RDEPEND="
 	dev-cpp/eigen:3
 	dev-libs/boost:=


### PR DESCRIPTION
Remove a backported patch which is no longer needed for live
ebuild.

Reported-by: Michael Moon <triffid.hunter@gmail.com>
Closes: https://bugs.gentoo.org/728560
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Bernd Waibel <waebbl@gmail.com>