### PR TITLE
media-libs/openh264: dont call git during build

### DIFF
--- a/media-libs/openh264/openh264-2.1.1.ebuild
+++ b/media-libs/openh264/openh264-2.1.1.ebuild
@@ -28,6 +28,10 @@ PATCHES=( "${FILESDIR}/${PN}-2.1.0-pkgconfig-pathfix.patch" )
 src_prepare() {
 	default
 
+	sed -i -e 's/ | generate-version//g' Makefile || die
+	sed -e 's|$FULL_VERSION|""|g' codec/common/inc/version_gen.h.template > \
+		codec/common/inc/version_gen.h
+
 	multilib_copy_sources
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/724804
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>