### PR TITLE
app-editors/notepadqq: update homepage

### DIFF
--- a/app-editors/notepadqq/notepadqq-2.0.0_beta.ebuild
+++ b/app-editors/notepadqq/notepadqq-2.0.0_beta.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit qmake-utils xdg
 
 DESCRIPTION="Notepad++-like editor for Linux"
-HOMEPAGE="http://notepadqq.altervista.org"
+HOMEPAGE="https://notepadqq.com/s/"
 if [[ "${PV}" == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/notepadqq/notepadqq.git"

--- a/app-editors/notepadqq/notepadqq-9999.ebuild
+++ b/app-editors/notepadqq/notepadqq-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit qmake-utils xdg
 
 DESCRIPTION="Notepad++-like editor for Linux"
-HOMEPAGE="http://notepadqq.altervista.org"
+HOMEPAGE="https://notepadqq.com/s/"
 if [[ "${PV}" == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/notepadqq/notepadqq.git"


### PR DESCRIPTION
This changes the outdated homepage
to the current homepage: https://notepadqq.com/s/

Closes: https://bugs.gentoo.org/722498
Reported-By: needle <ne3dle@protonmail.com>
Signed-off-by: Dennis Eisele <dennis.eisele@online.de>
Package-Manager: Portage-2.3.99, Repoman-2.3.23