### PR TITLE
dev-games/flatzebra: EAPI7, fix LICENSE, cleanup

### DIFF
--- a/dev-games/flatzebra/flatzebra-0.1.6-r1.ebuild
+++ b/dev-games/flatzebra/flatzebra-0.1.6-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Generic game engine for 2D double-buffering animation"
+HOMEPAGE="https://perso.b2b2c.ca/~sarrazip/dev/batrachians.html"
+SRC_URI="https://perso.b2b2c.ca/~sarrazip/dev/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="static-libs"
+
+RDEPEND="media-libs/libsdl[video]
+	media-libs/sdl-image
+	media-libs/sdl-mixer"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	default
+	sed -i \
+		-e '/^doc_DATA =/s/^/NOTHANKS/' \
+		Makefile.in || die
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	if ! use static-libs; then
+		find "${ED}" -type f -name '*.la' -delete || die
+	fi
+}


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,
simply EAPI bump for dev-games/flatzebra.

```diff
4,5c4
< EAPI=5
< inherit eutils ltprune
---
> EAPI=7
7c6
< DESCRIPTION="A generic game engine for 2D double-buffering animation"
---
> DESCRIPTION="Generic game engine for 2D double-buffering animation"
11c10
< LICENSE="GPL-2"
---
> LICENSE="GPL-2+"
13c12
< KEYWORDS="amd64 x86"
---
> KEYWORDS="~amd64 ~x86"
19,20c18,19
< DEPEND="${RDEPEND}
<       virtual/pkgconfig"
---
> DEPEND="${RDEPEND}"
> BDEPEND="virtual/pkgconfig"
22a22
>       default
34c34,36
<       use static-libs || prune_libtool_files
---
>       if ! use static-libs; then
>               find "${ED}" -type f -name '*.la' -delete || die
>       fi
```