### PR TITLE
net-misc/dahdi-tools: Fixups for perl, and fixing man pages build.

### DIFF
--- a/net-misc/dahdi-tools/dahdi-tools-3.1.0.ebuild
+++ b/net-misc/dahdi-tools/dahdi-tools-3.1.0.ebuild
@@ -26,7 +26,11 @@ DEPEND="dev-libs/newt
 	sys-kernel/linux-headers
 	virtual/libusb:0
 	ppp? ( net-dialup/ppp )"
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	dev-lang/perl:=
+	dev-perl/CGI"
+BDEPEND="dev-lang/perl
+	sys-apps/file"
 
 src_prepare() {
 	default


### PR DESCRIPTION
Install the tools required such that this absolute gem of how not to do
it works (xpp/Makefile):

1377 %.8: %
1378     @if file "$^" | cut -d: -f2 | grep -q -iw perl; then \
1379         if pod2man --section 8 $^ > $@; then \
1380             echo "  GEN      $@"; \
1381         else \
1382             rm -f "$@"; \
1383         fi \
1384     fi

Closes:  https://bugs.gentoo.org/728544
Signed-off-by: Jaco Kroon <jaco@uls.co.za>