### PR TITLE
app-misc/physlock: Use upstream PAM config

### DIFF
--- a/app-misc/physlock/physlock-13-r1.ebuild
+++ b/app-misc/physlock/physlock-13-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs pam
+
+DESCRIPTION="Lightweight Linux console locking tool"
+HOMEPAGE="https://github.com/muennich/physlock"
+SRC_URI="https://github.com/muennich/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+
+IUSE="elogind systemd"
+REQUIRED_USE="?? ( elogind systemd )"
+
+RDEPEND="sys-libs/pam"
+DEPEND="${RDEPEND}
+	elogind? ( sys-auth/elogind )
+	systemd? ( sys-apps/systemd )
+"
+
+pkg_setup() {
+	export MY_CONF="HAVE_SYSTEMD=$(usex systemd 1 0) HAVE_ELOGIND=$(usex elogind 1 0)"
+}
+
+src_prepare() {
+	default
+	tc-export CC
+}
+
+src_compile() {
+	emake ${MY_CONF}
+}
+
+src_install() {
+	emake ${MY_CONF} DESTDIR="${D}" PREFIX=/usr install
+	newpamd physlock.pam ${PN}
+}


### PR DESCRIPTION
Following the recommendation at
https://github.com/muennich/physlock/commit/66957ee48384dd2e0fa6477b8276e9f6b3842bc5
Also more closely follow the configuration format the build system
expects.

Package-Manager: Portage-2.3.103, Repoman-2.3.23
Closes: https://bugs.gentoo.org/731824
Signed-off-by: J. Pz <toshokan@shojigate.net>