### PR TITLE
profiles/arch/arm64: p.u.mask dev-db/mariadb[rocksdb]

### DIFF
--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,9 +1,14 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2020-07-09)
+# mariadb[rocksdb] fails to build on arm64
+# bug #731998
+dev-db/mariadb rocksdb
+
 # Sam James <sam@gentoo.org> (2020-07-03)
 # Rust is available here
-# Bug #728558
+# bug #728558
 media-video/ffmpeg -rav1e
 
 # Robin H. Johnson <robbat2@gentoo.org> (2020-07-02)


### PR DESCRIPTION
Build fails with USE=rocksdb and this is a niche feature;
let's mask it for now until upstream fix.

Bug: https://bugs.gentoo.org/731998
Signed-off-by: Sam James <sam@gentoo.org>