### PR TITLE
media-libs/vulkan-loader: become sysroot-aware

### DIFF
--- a/media-libs/vulkan-loader/vulkan-loader-1.2.137-r1.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.2.137-r1.ebuild
@@ -27,7 +27,7 @@ IUSE="layers wayland X"
 
 BDEPEND=">=dev-util/cmake-3.10.2"
 DEPEND="${PYTHON_DEPS}
-	>=dev-util/vulkan-headers-${PV}
+	~dev-util/vulkan-headers-1.2.137
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
 	X? (
 		x11-libs/libX11:=[${MULTILIB_USEDEP}]

--- a/media-libs/vulkan-loader/vulkan-loader-1.2.141-r1.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.2.141-r1.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 	S="${WORKDIR}"/${MY_PN}-${PV}
 fi
 
@@ -27,7 +27,7 @@ IUSE="layers wayland X"
 
 BDEPEND=">=dev-util/cmake-3.10.2"
 DEPEND="${PYTHON_DEPS}
-	>=dev-util/vulkan-headers-${PV}
+	~dev-util/vulkan-headers-1.2.143
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
 	X? (
 		x11-libs/libX11:=[${MULTILIB_USEDEP}]


### PR DESCRIPTION
This allows building in a sysroot without using the headers installed on the host.

https://bugs.gentoo.org/731112