### PR TITLE
profiles/arch/arm64: mask dev-libs/xmlrpc-c[tools]

### DIFF
--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2020-07-10)
+# Failed build with USE=tools
+# bug #732122
+dev-libs/xmlrpc-c tools
+
 # Sam James <sam@gentoo.org> (2020-07-09)
 # mariadb[rocksdb] fails to build on arm64
 # bug #731998


### PR DESCRIPTION
This fails to build on ~arm64. Let's mask USE=tools
so that we can keyword rtorrent.

Bug: https://bugs.gentoo.org/732122
Signed-off-by: Sam James <sam@gentoo.org>