### PR TITLE
dev-util/qdevicemonitor: fix build with Qt 5.15

### DIFF
--- a/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-endl-is-deprecated.patch
+++ b/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-endl-is-deprecated.patch
@@ -1,0 +1,27 @@
+From 9808ae3279e5816dcc85cf8f21158ecf842dc185 Mon Sep 17 00:00:00 2001
+From: Alexander Lopatin <alopatindev@gmail.com>
+Date: Sat, 11 Jul 2020 03:18:14 +0300
+Subject: [PATCH] Fix "dev-util/qdevicemonitor-1.0.1-r2 : main.cpp: error:
+ QTextStream& QTextStreamFunctions::endl(QTextStream&) is deprecated: Use
+ Qt::endl [-Werror=deprecated-declarations]" https://bugs.gentoo.org/732088
+
+---
+ qdevicemonitor/main.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qdevicemonitor/main.cpp b/qdevicemonitor/main.cpp
+index 46f80a5..9d3fe73 100644
+--- a/qdevicemonitor/main.cpp
++++ b/qdevicemonitor/main.cpp
+@@ -43,7 +43,7 @@ void logOutput(QtMsgType type, const QMessageLogContext& context, const QString&
+             << ")";
+     }
+ 
+-    out << endl;
++    out << Qt::endl;
+ }
+ 
+ int main(int argc, char* argv[])
+-- 
+2.26.2
+

--- a/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r2.ebuild
+++ b/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r2.ebuild
@@ -31,6 +31,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-qt-5.11.patch
 	"${FILESDIR}"/${P}-crash-after-fresh-install.patch
 	"${FILESDIR}"/${P}-screen-geometry-is-deprecated.patch
+	"${FILESDIR}"/${P}-endl-is-deprecated.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/732088
Package-Manager: Portage-2.3.99, Repoman-2.3.22