### PR TITLE
dev-libs/log4cpp: fix test with glibc-2.31

### DIFF
--- a/dev-libs/log4cpp/files/log4cpp-1.1-glibc-2.31.patch
+++ b/dev-libs/log4cpp/files/log4cpp-1.1-glibc-2.31.patch
@@ -1,0 +1,22 @@
+diff --git a/tests/testDailyRollingFileAppender.cpp b/tests/testDailyRollingFileAppender.cpp
+index 9958f41..158c08b 100644
+--- a/tests/testDailyRollingFileAppender.cpp
++++ b/tests/testDailyRollingFileAppender.cpp
+@@ -22,6 +22,7 @@
+ 
+ #ifndef WIN32    // only available on Win32
+ #include <dirent.h>
++#include <sys/time.h>
+ #else
+ #include <direct.h>  
+ #endif
+@@ -232,7 +233,8 @@ namespace OnlyManualTesting {
+ 
+ 		now += seconds;
+ 
+-		if (stime(&now) == -1) {
++		struct timeval tv = {.tv_sec = now, .tv_usec = 0};
++		if (settimeofday(&tv, NULL) < 0) {
+ 			std::cerr << "Can not set date. Need admin privileges?" << std::endl;
+ 			return -1;
+ 		}

--- a/dev-libs/log4cpp/log4cpp-1.1.3.ebuild
+++ b/dev-libs/log4cpp/log4cpp-1.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -24,6 +24,7 @@ PATCHES=(
 	"${FILESDIR}"/1.0-asneeded.patch
 	"${FILESDIR}"/${PN}-1.1-cmath-fix.patch
 	"${FILESDIR}"/${PN}-1.1-automake-1.13.patch
+	"${FILESDIR}"/${PN}-1.1-glibc-2.31.patch
 )
 
 S="${WORKDIR}/${PN}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/723022
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Stephan Hartmann <stha09@googlemail.com>