### PR TITLE
[CI] profiles/arch/s390: drop net-misc/openssh[security-key] mask

### DIFF
--- a/net-misc/ntp/ntp-4.2.8_p15.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15.ebuild
@@ -13,7 +13,7 @@ SRC_URI="http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar
 
 LICENSE="HPND BSD ISC"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv s390 sparc x86 ~amd64-linux ~x86-linux ~m68k-mint"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ~ppc64 ~riscv s390 sparc x86 ~amd64-linux ~x86-linux ~m68k-mint"
 IUSE="caps debug ipv6 libressl openntpd parse-clocks readline samba selinux snmp ssl +threads vim-syntax zeroconf"
 
 COMMON_DEPEND="readline? ( >=sys-libs/readline-4.1:0= )

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -1,11 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Sam James <sam@gentoo.org> (2020-07-03)
-# Rust is available here
-# Bug #728558
-media-video/ffmpeg -rav1e
-
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-07-02)
 # media-libs/libplacebo is keyworded
 media-video/vlc -libplacebo

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -1,10 +1,6 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Patrick McLean <chutzpah@gentoo.org> (2020-02-15)
-# Mask until dev-libs/libfido2 is keyworded
-net-misc/openssh security-key
-
 # Hans de Graaff <graaff@gentoo.org> (2019-04-08)
 # Obsolete ruby version, no newer versions keyworded or stable.
 dev-vcs/subversion ruby


### PR DESCRIPTION
We just keyworded dev-libs/libfido2, so this is not needed
anymore.

Bug: https://bugs.gentoo.org/709752
Signed-off-by: Sam James <sam@gentoo.org>