### PR TITLE
dev-libs/spdlog: fix tests segfault

### DIFF
--- a/dev-libs/spdlog/files/spdlog-1.6.1-tests-fix.patch
+++ b/dev-libs/spdlog/files/spdlog-1.6.1-tests-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/include/spdlog/fmt/bin_to_hex.h b/include/spdlog/fmt/bin_to_hex.h
+index e974cf51..5393dcac 100644
+--- a/include/spdlog/fmt/bin_to_hex.h
++++ b/include/spdlog/fmt/bin_to_hex.h
+@@ -92,7 +92,7 @@ struct formatter<spdlog::details::dump_info<T>>
+     auto parse(ParseContext &ctx) -> decltype(ctx.begin())
+     {
+         auto it = ctx.begin();
+-        while (*it && *it != '}')
++        while (it != ctx.end() && *it != '}')
+         {
+             switch (*it)
+             {

--- a/dev-libs/spdlog/spdlog-1.6.1-r1.ebuild
+++ b/dev-libs/spdlog/spdlog-1.6.1-r1.ebuild
@@ -31,6 +31,7 @@ RDEPEND="${DEPEND}"
 
 PATCHES=(
 	"${FILESDIR}/${P}-libfmt-7.0.0.patch"
+	"${FILESDIR}/${P}-tests-fix.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/731238
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: David Roman <davidroman96@gmail.com>