### PR TITLE
dev-python/docopt: add 3_9 support

### DIFF
--- a/dev-python/docopt/docopt-0.6.2-r3.ebuild
+++ b/dev-python/docopt/docopt-0.6.2-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
+PYTHON_COMPAT=( python2_7 python3_{6..9} pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Tests for pypy3 and python3_{6..9} all passing on amd64.