### PR TITLE
app-text/dblatex: Introduce Python 3.8 and 3.9 support

### DIFF
--- a/app-text/dblatex/dblatex-0.3.11-r1.ebuild
+++ b/app-text/dblatex/dblatex-0.3.11-r1.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+PYTHON_COMPAT=( python3_{6,7,8,9} )
+
+inherit distutils-r1
+
+DESCRIPTION="Transform DocBook using TeX macros"
+HOMEPAGE="http://dblatex.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/project/dblatex/dblatex/${P}/${P}py3.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="inkscape"
+
+RDEPEND="
+	app-text/docbook-xml-dtd:4.5
+	dev-libs/kpathsea
+	dev-libs/libxslt
+	dev-libs/libxslt
+	dev-texlive/texlive-fontutils
+	dev-texlive/texlive-latex
+	dev-texlive/texlive-latexextra
+	dev-texlive/texlive-latexrecommended
+	dev-texlive/texlive-mathscience
+	dev-texlive/texlive-pictures
+	dev-texlive/texlive-xetex
+	gnome-base/librsvg
+	media-gfx/imagemagick
+	media-gfx/transfig
+	inkscape? ( media-gfx/inkscape )
+"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/${P}py3"
+
+PATCHES=(
+	 "${FILESDIR}/${P}-path-logging.patch"
+	 "${FILESDIR}/${P}-setup.patch"
+	 "${FILESDIR}/${P}-encode.patch"
+)
+
+python_prepare_all() {
+	# Manual page is precomressed, but we will use our own compression later.
+	gunzip docs/manpage/dblatex.1.gz || die
+	# If we dont have inkscape we need to use an alternative SVG converter
+	use inkscape || eapply "${FILESDIR}/${P}-no-inkscape-dependency.patch"
+	# If we use inscape however we want to make dblatex compatible with v1.0 
+	use inkscape && eapply "${FILESDIR}/${P}-inkscape-1.0.patch"
+	# We need to fix version information in the docs and some metadata
+	grep -l -I -R "0.3.11py3" | xargs -n1 sed -i -e "s/${PV}py3/${PV}/" || die
+	distutils-r1_python_prepare_all
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+	# Move package documentation to a folder name containing version number
+	mv "${D}"/usr/share/doc/${PN} "${D}"/usr/share/doc/${PF} || die
+}

--- a/app-text/dblatex/files/dblatex-0.3.11-encode.patch
+++ b/app-text/dblatex/files/dblatex-0.3.11-encode.patch
@@ -1,0 +1,19 @@
+diff -Naur dblatex-0.3.11py3-orig/lib/dbtexmf/dblatex/rawtex.py dblatex-0.3.11py3/lib/dbtexmf/dblatex/rawtex.py
+--- dblatex-0.3.11py3-orig/lib/dbtexmf/dblatex/rawtex.py	2020-01-29 13:48:34.000000000 -0800
++++ dblatex-0.3.11py3/lib/dbtexmf/dblatex/rawtex.py	2020-07-13 23:49:56.296767535 -0700
+@@ -101,10 +101,14 @@
+ 
+             # If something done, replace the figure in the tex file
+             if newfig != fig:
++                if isinstance(fig, str):
++                    fig = fig.encode("utf-8")
++                if isinstance(newfig, str):
++                    newfig = newfig.encode("utf-8")
+                 line = re.sub(br"{"+fig+br"}", br"{"+newfig+br"}", line)
+ 
+         return line
+-            
++
+ 
+ def main():
+     c = RawLatex()

--- a/app-text/dblatex/files/dblatex-0.3.11-inkscape-1.0.patch
+++ b/app-text/dblatex/files/dblatex-0.3.11-inkscape-1.0.patch
@@ -1,0 +1,107 @@
+diff -Naur dblatex-0.3.11py3-orig/docs/custom/dblatex.xconf dblatex-0.3.11py3/docs/custom/dblatex.xconf
+--- dblatex-0.3.11py3-orig/docs/custom/dblatex.xconf	2020-01-29 13:48:32.000000000 -0800
++++ dblatex-0.3.11py3/docs/custom/dblatex.xconf	2020-07-14 01:05:42.883435133 -0700
+@@ -18,7 +18,7 @@
+   <imagedata>
+     <converter src="svg" dst="*" docformat="pdf">
+       <command>
+-        inkscape -z -D --export-dpi=600 --export-%(dst)s=%(output)s %(input)s
++        inkscape -D --export-dpi=600 --export-filename=%(output)s %(input)s
+       </command>
+     </converter>
+   </imagedata>
+diff -Naur dblatex-0.3.11py3-orig/docs/xhtml/manual/sec-specs.html dblatex-0.3.11py3/docs/xhtml/manual/sec-specs.html
+--- dblatex-0.3.11py3-orig/docs/xhtml/manual/sec-specs.html	2020-01-29 13:49:23.000000000 -0800
++++ dblatex-0.3.11py3/docs/xhtml/manual/sec-specs.html	2020-07-14 01:06:19.012860710 -0700
+@@ -36,7 +36,7 @@
+   &lt;imagedata&gt;
+     &lt;converter src="svg" dst="*" docformat="pdf"&gt;
+       &lt;command&gt;
+-        inkscape -z -D --export-dpi=600 --export-%(dst)s=%(output)s %(input)s
++        inkscape -D --export-dpi=600 --export-filename=%(output)s %(input)s
+       &lt;/command&gt;
+     &lt;/converter&gt;
+   &lt;/imagedata&gt;
+diff -Naur dblatex-0.3.11py3-orig/lib/dbtexmf/core/imagedata.py dblatex-0.3.11py3/lib/dbtexmf/core/imagedata.py
+--- dblatex-0.3.11py3-orig/lib/dbtexmf/core/imagedata.py	2020-01-29 13:48:33.000000000 -0800
++++ dblatex-0.3.11py3/lib/dbtexmf/core/imagedata.py	2020-07-14 01:02:56.729388831 -0700
+@@ -47,16 +47,16 @@
+ 
+ 
+ class PoolManager:
+-    def __init__(self): 
++    def __init__(self):
+         self._used_pool = None
+         self._pending_pools = []
+-    
++
+     def set_pool(self, pool):
+         self._used_pool = pool
+         for p in self._pending_pools:
+             pool.preprend(p)
+         self._pending_pools = []
+-    
++
+     def prepend_pool(self, pool):
+         if self._used_pool:
+             self._used_pool.prepend(pool)
+@@ -73,7 +73,7 @@
+         self.format_pool = PoolManager()
+ 
+ _image_setup = ImageSetup()
+-    
++
+ def image_setup():
+     global _image_setup
+     return _image_setup
+@@ -181,7 +181,7 @@
+ class SvgConverter(ImageConverter):
+     def __init__(self, imgsrc, imgdst="", docformat="", backend=""):
+         ImageConverter.__init__(self, imgsrc="svg", imgdst=imgdst)
+-        self.add_command(["inkscape", "-z", "-D", "--export-%(dst)s=%(output)s",
++        self.add_command(["inkscape", "-D", "--export-filename=%(output)s",
+                           "%(input)s"])
+ 
+ 
+@@ -224,7 +224,7 @@
+         ImageFormatPool.__init__(self)
+         # There can be a mismatch between PDF-1.4 images and PDF-1.3
+         # document produced by XeTeX
+-        self.add_rule(FormatRule(docformat="pdf", backend="xetex", 
++        self.add_rule(FormatRule(docformat="pdf", backend="xetex",
+                                  imgdst="png"))
+         self.add_rule(FormatRule(docformat="pdf", imgdst="pdf"))
+         self.add_rule(FormatRule(docformat="dvi", imgdst="eps"))
+@@ -318,7 +318,7 @@
+         Copy the file in the working directory if its path contains characters
+         unsupported by latex, like spaces.
+         """
+-        # Encode to expected output format. If encoding is OK and 
++        # Encode to expected output format. If encoding is OK and
+         # supported by tex, just return the encoded path
+         newfig = self._path_encode(fig)
+         if newfig and newfig.find(b" ") == -1:
+@@ -350,7 +350,7 @@
+         if (ext):
+             realfig = self.find(fig)
+             return (realfig, ext[1:])
+-        
++
+         # Lookup for the best suited available figure
+         if (self.output_format == "pdf"):
+             formats = ("png", "pdf", "jpg", "eps", "gif", "fig", "svg")
+@@ -369,7 +369,7 @@
+             format = ""
+ 
+         return (realfig, format)
+-        
++
+     def find(self, fig):
+         # First, the obvious absolute path case
+         if os.path.isabs(fig):
+@@ -385,4 +385,4 @@
+                 return realfig
+ 
+         return None
+- 
++


### PR DESCRIPTION
Additionally make it compatible with >=media-gfx/inkscape-1.0

Closes: https://bugs.gentoo.org/723412
Package-Manager: Portage-2.3.101, Repoman-2.3.22