### PR TITLE
[CI] profiles/arch/powerpc/ppc32: unmask Python 3.8 targets

### DIFF
--- a/profiles/arch/powerpc/ppc32/use.stable.mask
+++ b/profiles/arch/powerpc/ppc32/use.stable.mask
@@ -1,8 +1,3 @@
-# Mike Gilbert <floppym@gentoo.org> (2017-06-08)
-# dev-lang/python:3.7 is not stable.
-python_targets_python3_8
-python_single_target_python3_8
-
 # Mikle Kolyada <zlogene@gentoo.org> (2018-04-24)
 # no stable net-misc/aria2 on ppc
 aria2


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>