### PR TITLE
[CI] profiles/arch/powerpc/ppc64: unmask Python 3.8 targets

### DIFF
--- a/profiles/arch/powerpc/ppc64/use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/use.stable.mask
@@ -3,8 +3,3 @@
 
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
-
-# Mike Gilbert <floppym@gentoo.org> (2017-06-08)
-# dev-lang/python:3.7 is not stable.
-python_targets_python3_8
-python_single_target_python3_8


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/730108
Signed-off-by: Sam James <sam@gentoo.org>