### PR TITLE
profiles/arch/arm64: unmask dev-libs/libpcre[jit]

### DIFF
--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -425,10 +425,6 @@ dev-util/devhelp gedit
 # gobject-introspection[doctool], bug #411761
 dev-libs/gobject-introspection -doctool
 
-# Tobias Klausmann <klausman@gentoo.org> (2011-11-02)
-# libpcre jit is not supported on alpha
-dev-libs/libpcre jit
-
 # missing keywords
 media-plugins/gst-plugins-meta aac dts dv lame libvisual taglib vcd wavpack
 


### PR DESCRIPTION
This seems to work fine on arm64 (tests pass),
upstream have e.g. "sljitNativeARM_64.c", and
the mask for this is very old -- and indeed
references alpha!

Signed-off-by: Sam James <sam@gentoo.org>