### PR TITLE
dev-python/doit-py: fix #732192

### DIFF
--- a/dev-python/doit-py/doit-py-0.4.0-r2.ebuild
+++ b/dev-python/doit-py/doit-py-0.4.0-r2.ebuild
@@ -18,7 +18,7 @@ DEPEND="
 	test? (
 		dev-python/pyflakes[${PYTHON_USEDEP}]
 		dev-python/coverage[${PYTHON_USEDEP}]
-		app-text/hunspell
+		app-text/hunspell[l10n_en]
 	)"
 RDEPEND="
 	dev-python/configclass[${PYTHON_USEDEP}]"

--- a/dev-python/doit-py/doit-py-0.5.0.ebuild
+++ b/dev-python/doit-py/doit-py-0.5.0.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 
 DEPEND="
 	test? (
-		app-text/hunspell
+		app-text/hunspell[l10n_en]
 		dev-python/pyflakes[${PYTHON_USEDEP}]
 	)"
 RDEPEND="


### PR DESCRIPTION
Specify app-text/hunspell[l10n_en] as dependency.
Closes: https://bugs.gentoo.org/732192
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>