### PR TITLE
dev-lang/tcl: Fix cross compilation by not setting include directory.

### DIFF
--- a/dev-lang/tcl/files/tcl-8.6.9-include-spec.patch
+++ b/dev-lang/tcl/files/tcl-8.6.9-include-spec.patch
@@ -1,0 +1,12 @@
+This resolves https://bugs.gentoo.org/731120
+--- a/unix/configure.in
++++ b/unix/configure.in
+@@ -895,7 +895,7 @@ TCL_BUILD_STUB_LIB_PATH="`pwd`/${TCL_STUB_LIB_FILE}"
+ TCL_STUB_LIB_PATH="${TCL_STUB_LIB_DIR}/${TCL_STUB_LIB_FILE}"
+ 
+ # Install time header dir can be set via --includedir
+-eval "TCL_INCLUDE_SPEC=\"-I${includedir}\""
++eval "TCL_INCLUDE_SPEC=\"\""
+ 
+ #------------------------------------------------------------------------
+ # tclConfig.sh refers to this by a different name

--- a/dev-lang/tcl/tcl-8.6.9-r1.ebuild
+++ b/dev-lang/tcl/tcl-8.6.9-r1.ebuild
@@ -25,6 +25,7 @@ S="${SPARENT}"/unix
 PATCHES=(
 	"${FILESDIR}"/${PN}-8.5.13-multilib.patch
 	"${FILESDIR}"/${PN}-8.6.8-conf.patch # Bug 125971
+	"${FILESDIR}"/${PN}-8.6.9-include-spec.patch # Bug 731120
 )
 
 src_prepare() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/731120
Signed-off-by: Allen Webb <allenwebb@google.com>