### PR TITLE
dev-db/sqlite: Fix the readline include path to use the sysroot.

### DIFF
--- a/dev-db/sqlite/sqlite-3.32.3-r1.ebuild
+++ b/dev-db/sqlite/sqlite-3.32.3-r1.ebuild
@@ -241,7 +241,7 @@ multilib_src_configure() {
 		$(use_enable readline)
 	)
 	if use readline; then
-		options+=(--with-readline-inc="-I${EPREFIX}/usr/include/readline")
+		options+=(--with-readline-inc="-I${ESYSROOT}/usr/include/readline")
 	fi
 
 	# secure-delete USE flag.


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/731120
Signed-off-by: Allen Webb <allenwebb@google.com>