### PR TITLE
net-misc/dahdi:  Add CONFIG_PCI as kernel config requirement.

### DIFF
--- a/net-misc/dahdi/dahdi-3.1.0-r1.ebuild
+++ b/net-misc/dahdi/dahdi-3.1.0-r1.ebuild
@@ -43,7 +43,7 @@ IUSE="flash oslec"
 
 PATCHES=( "${WORKDIR}/dahdi-patchset" )
 
-CONFIG_CHECK="MODULES ~CRC_CCITT"
+CONFIG_CHECK="MODULES PCI ~CRC_CCITT"
 
 pkg_pretend() {
 	use oslec && CONFIG_CHECK+=" ECHO"


### PR DESCRIPTION
Picked up by Sam <sam@gentoo.org> whilst working on:

Bug: https://bugs.gentoo.org/716426
Signed-off-by: Jaco Kroon <jaco@uls.co.za>