### PR TITLE
[CI] profiles/arch/arm/package.use.mask: unmask sys-block/fio[zbc,io-uring]

### DIFF
--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -10,10 +10,6 @@
 kde-plasma/libksysguard webengine
 kde-plasma/kdeplasma-addons webengine
 
-# Robin H. Johnson <robbat2@gentoo.org> (2020-07-02)
-# Mask io-uring & zbc pending keywording
-sys-block/fio io-uring zbc
-
 # Sam James <sam@gentoo.org> (2020-06-27)
 # Tests require Valgrind, not available on <armv7a
 dev-libs/rapidjson test


### PR DESCRIPTION
We just keyworded libzbc and liburing, so this is
no longer necessary.

Bug: https://bugs.gentoo.org/730480
Closes: https://bugs.gentoo.org/730478
Signed-off-by: Sam James <sam@gentoo.org>