### PR TITLE
profiles/arch/arm64: mask net-libs/osptoolkit

### DIFF
--- a/profiles/arch/arm64/package.mask
+++ b/profiles/arch/arm64/package.mask
@@ -1,0 +1,7 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Sam James <sam@gentoo.org> (2020-07-16)
+# Failed build on arm64
+# bug #674346
+net-libs/osptoolkit

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2020-07-16)
+# Failed build on arm64
+# bug #674346
+net-misc/asterisk osplookup
+
 # Sergei Trofimovich <slyfox@gentoo.org> (2020-07-11)
 # net-libs/libslirp is not yet keyworded on arm64, bug #732144
 app-emulation/qemu slirp


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/716426
Bug: https://bugs.gentoo.org/674346
Bug: https://bugs.gentoo.org/731250
Signed-off-by: Sam James <sam@gentoo.org>