### PR TITLE
dev-util/ply: fix build failure on arm

### DIFF
--- a/dev-util/ply/files/ply-2.1.1-arm-build-fix.patch
+++ b/dev-util/ply/files/ply-2.1.1-arm-build-fix.patch
@@ -1,0 +1,36 @@
+From 6f870ba1f4054674024cc3d3faf18d8b1e3676f6 Mon Sep 17 00:00:00 2001
+From: Jakov Smolic <jakov.smolic@sartura.hr>
+Date: Fri, 17 Jul 2020 09:10:45 +0200
+Subject: [PATCH] Fix armv7a build crash
+Bug: https://bugs.gentoo.org/732902
+
+Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>
+---
+ src/libply/Makefile.am   | 1 +
+ src/libply/arch/armv7a.c | 1 +
+ 2 files changed, 2 insertions(+)
+ create mode 120000 src/libply/arch/armv7a.c
+
+diff --git a/src/libply/Makefile.am b/src/libply/Makefile.am
+index 3c83bb4..3a7c747 100644
+--- a/src/libply/Makefile.am
++++ b/src/libply/Makefile.am
+@@ -10,6 +10,7 @@ AM_LFLAGS = --header-file=lexer.h
+ EXTRA_DIST = grammar.c grammar.h lexer.c lexer.h \
+ 	arch/aarch64.c \
+ 	arch/arm.c     \
++	arch/armv7a.c \
+ 	arch/powerpc.c \
+ 	arch/x86_64.c
+ 
+diff --git a/src/libply/arch/armv7a.c b/src/libply/arch/armv7a.c
+new file mode 120000
+index 0000000..980a6a5
+--- /dev/null
++++ b/src/libply/arch/armv7a.c
+@@ -0,0 +1 @@
++arm.c
+\ No newline at end of file
+-- 
+2.26.2
+

--- a/dev-util/ply/ply-2.1.1.ebuild
+++ b/dev-util/ply/ply-2.1.1.ebuild
@@ -23,6 +23,7 @@ pkg_pretend() {
 
 src_prepare() {
 	sed -i "/^AC_INIT/c\AC_INIT(${PN}, ${PV}," configure.ac || die
+	eapply "${FILESDIR}/${P}-arm-build-fix.patch"
 	eapply_user
 	eautoreconf
 }


### PR DESCRIPTION
* Fix build crash on arm caused by

 `make[4]: *** No rule to make target 'arch/armv7a.c', needed by 'arch/libply_la-armv7a.lo'.  Stop.` 