### PR TITLE
dev-python/css-parser: add python3.9 support

### DIFF
--- a/dev-python/css-parser/css-parser-1.0.4-r2.ebuild
+++ b/dev-python/css-parser/css-parser-1.0.4-r2.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{6,7,8,9} )
+
+inherit distutils-r1
+
+DESCRIPTION="A CSS Cascading Style Sheets library (fork of cssutils)"
+HOMEPAGE="https://pypi.org/project/css-parser/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+
+# Tests fail under network-sandbox.
+RESTRICT+=" test"
+
+python_test() {
+	esetup.py test || die "tests failed under ${EPYTHON}"
+}


### PR DESCRIPTION
- add Python 3.9 support (I need it for future 3.9 support for `app-text/sigil`)
- remove redundant `BDEPEND` on `dev-python/setuptools` - thanks to `DISTUTILS_USE_SETUPTOOLS`

Package-Manager: Portage-2.3.103, Repoman-2.3.23

```
--- css-parser-1.0.4-r1.ebuild  2020-04-29 15:04:34.635134889 +0300
+++ css-parser-1.0.4-r2.ebuild  2020-07-17 19:55:06.141769631 +0300
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
 inherit distutils-r1
 
@@ -12,9 +12,8 @@
 
 LICENSE="LGPL-2.1+"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86"
+KEYWORDS="~amd64 ~arm ~x86"
 
-BDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 # Tests fail under network-sandbox.
 RESTRICT+=" test"
 

```