### PR TITLE
dev-python/python-language-server: Add Python 3.8 compatibility

### DIFF
--- a/dev-python/python-jsonrpc-server/files/python-jsonrpc-server-0.3.4-Python-3.8-fixes-for-endpoint-and-tests-37.patch
+++ b/dev-python/python-jsonrpc-server/files/python-jsonrpc-server-0.3.4-Python-3.8-fixes-for-endpoint-and-tests-37.patch
@@ -1,0 +1,84 @@
+From 7987e30c99edddab8acbf567bad0ebf2d1c3381d Mon Sep 17 00:00:00 2001
+From: Ben Greiner <code@bnavigator.de>
+Date: Mon, 17 Aug 2020 21:28:03 +0200
+Subject: [PATCH] Python 3.8 fixes for endpoint and tests (#37)
+
+* fix endpoint exception lists for Python 3.8
+Author: @maximbaz according to #33
+
+* fix test_writer_bad_message
+not only windows can have problems with serializing datetime
+
+Co-authored-by: Carlos Cordoba <ccordoba12@gmail.com>
+Co-authored-by: Marko Bakovic <delta003@users.noreply.github.com>
+---
+ pyls_jsonrpc/endpoint.py |  1 +
+ test/test_endpoint.py    |  4 ++--
+ test/test_streams.py     | 19 +++++++++----------
+ 3 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/pyls_jsonrpc/endpoint.py b/pyls_jsonrpc/endpoint.py
+index e8bfb5b..0caf612 100644
+--- a/pyls_jsonrpc/endpoint.py
++++ b/pyls_jsonrpc/endpoint.py
+@@ -236,6 +236,7 @@ class Endpoint(object):
+         if error is not None:
+             log.debug("Received error response to message %s: %s", msg_id, error)
+             request_future.set_exception(JsonRpcException.from_dict(error))
++            return
+ 
+         log.debug("Received result for message %s: %s", msg_id, result)
+         request_future.set_result(result)
+diff --git a/test/test_endpoint.py b/test/test_endpoint.py
+index 47a038b..b954732 100644
+--- a/test/test_endpoint.py
++++ b/test/test_endpoint.py
+@@ -115,9 +115,9 @@ def test_request_cancel(endpoint, consumer):
+         'params': {'id': MSG_ID}
+     })
+ 
+-    with pytest.raises(exceptions.JsonRpcException) as exc_info:
++    with pytest.raises((exceptions.JsonRpcException, futures.CancelledError)) as exc_info:
+         assert future.result(timeout=2)
+-    assert exc_info.type == exceptions.JsonRpcRequestCancelled
++    assert exc_info.type in (exceptions.JsonRpcRequestCancelled, futures.CancelledError)
+ 
+ 
+ def test_consume_notification(endpoint, dispatcher):
+diff --git a/test/test_streams.py b/test/test_streams.py
+index 8c2e93e..480a73b 100644
+--- a/test/test_streams.py
++++ b/test/test_streams.py
+@@ -97,7 +97,8 @@ def test_writer(wfile, writer):
+ 
+ def test_writer_bad_message(wfile, writer):
+     # A datetime isn't serializable(or poorly serializable),
+-    # ensure the write method doesn't throw
++    # ensure the write method doesn't throw, but the result could be empty
++    # or the correct datetime
+     import datetime
+     writer.write(datetime.datetime(
+         year=2019,
+@@ -108,12 +109,10 @@ def test_writer_bad_message(wfile, writer):
+         second=1,
+     ))
+ 
+-    if os.name == 'nt':
+-        assert wfile.getvalue() == b''
+-    else:
+-        assert wfile.getvalue() == (
+-            b'Content-Length: 10\r\n'
+-            b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
+-            b'\r\n'
+-            b'1546304461'
+-        )
++    assert wfile.getvalue() in [
++        b'',
++        b'Content-Length: 10\r\n'
++        b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
++        b'\r\n'
++        b'1546304461'
++    ]
+-- 
+2.26.2
+

--- a/dev-python/python-jsonrpc-server/python-jsonrpc-server-0.3.4.ebuild
+++ b/dev-python/python-jsonrpc-server/python-jsonrpc-server-0.3.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_7 )
+PYTHON_COMPAT=( python3_{7,8} )
 
 inherit distutils-r1
 
@@ -26,6 +26,9 @@ DEPEND="test? (
 	dev-python/pylint[${PYTHON_USEDEP}]
 )"
 
-PATCHES=( "${FILESDIR}/${P}-remove-pytest-cov-dep.patch" )
+PATCHES=(
+	"${FILESDIR}"/${P}-remove-pytest-cov-dep.patch
+	"${FILESDIR}"/${P}-Python-3.8-fixes-for-endpoint-and-tests-37.patch
+)
 
 distutils_enable_tests pytest

--- a/dev-python/python-language-server/python-language-server-0.34.1.ebuild
+++ b/dev-python/python-language-server/python-language-server-0.34.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_7 )
+PYTHON_COMPAT=( python3_{7,8} )
 
 DISTUTILS_USE_SETUPTOOLS=rdepend
 


### PR DESCRIPTION
All tests pass for both `dev-python/python-language-server` and `dev-python/python-jsonrpc-server` under Python 3.8.

While testing, I noticed that `test/plugins/test_completion.py::test_pyqt_completion` will fail if `dev-python/PyQt5` is built without `USE=widgets`.

```
______________________________________________________________________________________________ test_pyqt_completion _______________________________________________________________________________________________

config = <pyls.config.config.Config object at 0x7fe8af47ab90>, workspace = <pyls.workspace.Workspace object at 0x7fe8b06e5f90>

    @pytest.mark.skipif(PY2 or (sys.platform.startswith('linux') and os.environ.get('CI') is not None),
                        reason="Test in Python 3 and not on CIs on Linux because wheels don't work on them.")
    def test_pyqt_completion(config, workspace):
        # Over 'QA' in 'from PyQt5.QtWidgets import QApplication'
        doc_pyqt = "from PyQt5.QtWidgets import QA"
        com_position = {'line': 0, 'character': len(doc_pyqt)}
        doc = Document(DOC_URI, workspace, doc_pyqt)
        completions = pyls_jedi_completions(config, doc, com_position)
    
>       assert completions is not None
E       assert None is not None

test/plugins/test_completion.py:149: AssertionError
```

which I guess makes sense because the test tries to import from `PyQt5.QtWidgets`. I'm not sure if we want to add an explicit test dependency. I suppose so?