### PR TITLE
x11-terms/alacritty: update EGIT_REPO_URI

### DIFF
--- a/x11-terms/alacritty/alacritty-0.4.3.ebuild
+++ b/x11-terms/alacritty/alacritty-0.4.3.ebuild
@@ -277,7 +277,7 @@ HOMEPAGE="https://github.com/alacritty/alacritty"
 
 if [ ${PV} == "9999" ] ; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/jwilm/alacritty"
+	EGIT_REPO_URI="https://github.com/alacritty/alacritty"
 else
 	SRC_URI="https://github.com/alacritty/${PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz
 	$(cargo_crate_uris ${CRATES})"

--- a/x11-terms/alacritty/alacritty-0.5.0_rc1.ebuild
+++ b/x11-terms/alacritty/alacritty-0.5.0_rc1.ebuild
@@ -273,7 +273,7 @@ HOMEPAGE="https://github.com/alacritty/alacritty"
 
 if [ ${PV} == "9999" ] ; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/jwilm/alacritty"
+	EGIT_REPO_URI="https://github.com/alacritty/alacritty"
 else
 	SRC_URI="https://github.com/alacritty/${PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz
 	$(cargo_crate_uris ${CRATES})"

--- a/x11-terms/alacritty/alacritty-9999.ebuild
+++ b/x11-terms/alacritty/alacritty-9999.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://github.com/alacritty/alacritty"
 
 if [ ${PV} == "9999" ] ; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/jwilm/alacritty"
+	EGIT_REPO_URI="https://github.com/alacritty/alacritty"
 else
 	SRC_URI="https://github.com/alacritty/${PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz
 	$(cargo_crate_uris ${CRATES})"


### PR DESCRIPTION
Upstream moved from https://github.com/jwilm/alacritty to
https://github.com/alacritty/alacritty for some time already,
updating EGIT_REPO_URI to reflect so.

Signed-off-by: Kirill Chibisov <contact@kchibisov.com>