### PR TITLE
dev-python/helpdev: add missing test dep

### DIFF
--- a/dev-python/helpdev/helpdev-0.7.1.ebuild
+++ b/dev-python/helpdev/helpdev-0.7.1.ebuild
@@ -21,5 +21,7 @@ RDEPEND="
 	dev-python/psutil[${PYTHON_USEDEP}]
 "
 
+BDEPEND="test? ( dev-python/pip[${PYTHON_USEDEP}] )"
+
 distutils_enable_sphinx docs dev-python/sphinx_rtd_theme
 distutils_enable_tests pytest


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/733196
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>