### PR TITLE
dev-python/qdarkstyle: add missing dep flag

### DIFF
--- a/dev-python/qdarkstyle/qdarkstyle-2.8.1.ebuild
+++ b/dev-python/qdarkstyle/qdarkstyle-2.8.1.ebuild
@@ -21,10 +21,15 @@ KEYWORDS="~amd64 ~x86"
 
 IUSE="examples"
 
-RDEPEND=">=dev-python/helpdev-0.6.2[${PYTHON_USEDEP}]
-	>=dev-python/QtPy-1.7[${PYTHON_USEDEP}]"
+RDEPEND="
+	>=dev-python/helpdev-0.6.2[${PYTHON_USEDEP}]
+	>=dev-python/QtPy-1.7[gui,${PYTHON_USEDEP}]
+"
 
-DEPEND="test? ( dev-python/qtsass[${PYTHON_USEDEP}] )"
+DEPEND="test? (
+	dev-python/qtsass[${PYTHON_USEDEP}]
+	>=dev-python/QtPy-1.7[gui,testlib,${PYTHON_USEDEP}]
+)"
 
 distutils_enable_tests pytest
 distutils_enable_sphinx docs dev-python/sphinx_rtd_theme dev-python/m2r


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/733194
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>