### PR TITLE
dev-python/python-language-server: add missing test dep flag

### DIFF
--- a/dev-python/python-language-server/python-language-server-0.31.10.ebuild
+++ b/dev-python/python-language-server/python-language-server-0.31.10.ebuild
@@ -40,7 +40,7 @@ DEPEND="test? (
 	>=dev-python/pydocstyle-2.0.0[${PYTHON_USEDEP}]
 	dev-python/pyflakes[${PYTHON_USEDEP}]
 	dev-python/pylint[${PYTHON_USEDEP}]
-	dev-python/QtPy[testlib,${PYTHON_USEDEP}]
+	dev-python/QtPy[gui,testlib,${PYTHON_USEDEP}]
 	>=dev-python/rope-0.10.5[${PYTHON_USEDEP}]
 	dev-python/yapf[${PYTHON_USEDEP}]
 )"

--- a/dev-python/python-language-server/python-language-server-0.32.0.ebuild
+++ b/dev-python/python-language-server/python-language-server-0.32.0.ebuild
@@ -41,7 +41,7 @@ DEPEND="test? (
 	>=dev-python/pydocstyle-2.0.0[${PYTHON_USEDEP}]
 	dev-python/pyflakes[${PYTHON_USEDEP}]
 	dev-python/pylint[${PYTHON_USEDEP}]
-	dev-python/QtPy[testlib,${PYTHON_USEDEP}]
+	dev-python/QtPy[gui,testlib,${PYTHON_USEDEP}]
 	>=dev-python/rope-0.10.5[${PYTHON_USEDEP}]
 	dev-python/yapf[${PYTHON_USEDEP}]
 )"

--- a/dev-python/python-language-server/python-language-server-0.34.1.ebuild
+++ b/dev-python/python-language-server/python-language-server-0.34.1.ebuild
@@ -41,7 +41,7 @@ DEPEND="test? (
 	>=dev-python/pydocstyle-2.0.0[${PYTHON_USEDEP}]
 	dev-python/pyflakes[${PYTHON_USEDEP}]
 	dev-python/pylint[${PYTHON_USEDEP}]
-	dev-python/QtPy[testlib,${PYTHON_USEDEP}]
+	dev-python/QtPy[gui,testlib,${PYTHON_USEDEP}]
 	>=dev-python/rope-0.10.5[${PYTHON_USEDEP}]
 	dev-python/yapf[${PYTHON_USEDEP}]
 )"


### PR DESCRIPTION
@mattst88 this should fix the failure you found in https://github.com/gentoo/gentoo/pull/16732
QtPy[gui] pulls in PyQt5[gui,widgets]

Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>