### PR TITLE
sys-apps/checkpolicy: add -fno-common patches for v2.9 and v3.0

### DIFF
--- a/sys-apps/checkpolicy/checkpolicy-2.9.ebuild
+++ b/sys-apps/checkpolicy/checkpolicy-2.9.ebuild
@@ -35,6 +35,10 @@ DEPEND=">=sys-libs/libsepol-${SEPOL_VER}
 
 RDEPEND=">=sys-libs/libsemanage-${SEMNG_VER}"
 
+PATCHES=(
+	"${FILESDIR}/{$PN}-2.9-and-3.0-fix-fno-common.patch"
+)
+
 src_compile() {
 	emake \
 		CC="$(tc-getCC)" \

--- a/sys-apps/checkpolicy/checkpolicy-3.0.ebuild
+++ b/sys-apps/checkpolicy/checkpolicy-3.0.ebuild
@@ -35,6 +35,10 @@ DEPEND=">=sys-libs/libsepol-${SEPOL_VER}
 
 RDEPEND=">=sys-libs/libsemanage-${SEMNG_VER}"
 
+PATCHES=(
+	"${FILESDIR}/{$PN}-2.9-and-3.0-fix-fno-common.patch"
+)
+
 src_compile() {
 	emake \
 		CC="$(tc-getCC)" \

--- a/sys-apps/checkpolicy/files/checkpolicy-2.9-and-3.0-fix-fno-common.patch
+++ b/sys-apps/checkpolicy/files/checkpolicy-2.9-and-3.0-fix-fno-common.patch
@@ -1,0 +1,24 @@
+Fix compile with -fno-common by deleting unused te_assertions
+This was done upstream already: https://github.com/SELinuxProject/selinux/commit/4d330d0d3155211f119b3082f728ae42dcc01e96
+
+--- a/checkpolicy.h
++++ b/checkpolicy.h
+@@ -3,18 +3,6 @@
+ 
+ #include <sepol/policydb/ebitmap.h>
+ 
+-typedef struct te_assert {
+-	ebitmap_t stypes;
+-	ebitmap_t ttypes;
+-	ebitmap_t tclasses;
+-	int self;
+-	sepol_access_vector_t *avp;
+-	unsigned long line;
+-	struct te_assert *next;
+-} te_assert_t;
+-
+-te_assert_t *te_assertions;
+-
+ extern unsigned int policyvers;
+ 
+ #endif


### PR DESCRIPTION
Adds patches fixing -fno-common compile errors for versions 2.9 and 3.0.
Related: https://bugs.gentoo.org/show_bug.cgi?id=708518

Upstream has implemented the patch already: SELinuxProject/selinux@4d330d0