### PR TITLE
media-gfx/fdm-materials-4.6.1: added embedded use flag

### DIFF
--- a/media-gfx/fdm-materials/fdm-materials-4.6.1-r1.ebuild
+++ b/media-gfx/fdm-materials/fdm-materials-4.6.1-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+MY_PN="fdm_materials"
+
+DESCRIPTION="FDM materials for media-gfx/cura"
+HOMEPAGE="https://github.com/Ultimaker/fdm_materials"
+SRC_URI="https://github.com/Ultimaker/${MY_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="CC0-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="embedded"
+
+S="${WORKDIR}/${MY_PN}-${PV}"
+
+src_configure() {
+	local mycmakeargs=(
+		-DEMBEDDED=$(usex embedded on off)
+	)
+	cmake_src_configure
+}

--- a/media-gfx/fdm-materials/metadata.xml
+++ b/media-gfx/fdm-materials/metadata.xml
@@ -24,6 +24,9 @@
 	<slots>
 		<subslots>soname major version number</subslots>
 	</slots>
+	<use>
+		<flag name="embedded">Build for Ultimaker Embedded software</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">Ultimaker/fdm_materials</remote-id>
 	</upstream>


### PR DESCRIPTION
Signed-off-by: Dennis Lamm <expeditioneer@gentoo.org>