### PR TITLE
dev-libs/jansson: fix building with docs

### DIFF
--- a/dev-libs/jansson/jansson-2.12.ebuild
+++ b/dev-libs/jansson/jansson-2.12.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 s390 sparc x86"
 IUSE="doc static-libs"
 
-BDEPEND="doc? ( >=dev-python/sphinx-1.0.4 )"
+BDEPEND="doc? ( <dev-python/sphinx-3.0.0 )"
 RDEPEND=""
 
 multilib_src_configure() {


### PR DESCRIPTION
I just realized that https://bugs.gentoo.org/731668 also affects all of the earlier versions of jansson, since those all specify a sphinx version >1.0.4 . This PR only updates jansson-2.12 because I intend on removing the other two stable versions shortly.