### PR TITLE
app-emulation/ganeti: Disable dep on py2 sphinx & pandoc + sphinx py2 cleanup

### DIFF
--- a/app-emulation/ganeti/ganeti-2.15.2-r10.ebuild
+++ b/app-emulation/ganeti/ganeti-2.15.2-r10.ebuild
@@ -259,28 +259,30 @@ src_prepare() {
 	# 24618882737fd7c189adf99f4acc767d48f572c3
 	sed -i \
 		-e '/QuickCheck/s,< 2.8,< 2.8.3,g' \
-		cabal/ganeti.template.cabal
+		cabal/ganeti.template.cabal || die
 	# Neuter -Werror
 	sed -i \
 		-e '/^if DEVELOPER_MODE/,/^endif/s/-Werror//' \
-		Makefile.am
+		Makefile.am || die
 
 	# not sure why these tests are failing
 	# should remove this on next version bump if possible
 	for testfile in test/py/import-export_unittest.bash; do
-		printf '#!/bin/bash\ntrue\n' > "${testfile}"
+		printf '#!/bin/bash\ntrue\n' > "${testfile}" || die
 	done
 
 	# take the sledgehammer approach to bug #526270
-	grep -lr '/bin/sh' "${S}" | xargs -r -- sed -i 's:/bin/sh:/bin/bash:g'
+	grep -lr '/bin/sh' "${S}" | xargs -r -- sed -i 's:/bin/sh:/bin/bash:g' || die
 
 	sed "s:%LIBDIR%:$(get_libdir):g" "${FILESDIR}/ganeti.initd-r4" \
-		> "${T}/ganeti.initd"
+		> "${T}/ganeti.initd" || die
 
 	eapply_user
 
-	[[ ${PV} =~ [9]{4,} ]] && ./autogen.sh
-	rm autotools/missing
+	if [[ ${PV} =~ [9]{4,} ]]; then
+		./autogen.sh || die
+	fi
+	rm autotools/missing || die
 	eautoreconf
 }
 
@@ -329,9 +331,9 @@ src_install() {
 	fi
 
 	# ganeti installs it's own docs in a generic location
-	rm -rf "${D}"/{usr/share/doc/${PN},run}
+	rm -rf "${D}"/{usr/share/doc/${PN},run} || die
 
-	sed -i "s:/usr/$(get_libdir)/${PN}/tools/burnin:burnin:" doc/examples/bash_completion
+	sed -i "s:/usr/$(get_libdir)/${PN}/tools/burnin:burnin:" doc/examples/bash_completion || die
 	newbashcomp doc/examples/bash_completion gnt-instance
 	bashcomp_alias gnt-instance burnin ganeti-{cleaner,confd} \
 		h{space,check,scan,info,ail,arep,roller,squeeze,bal} \

--- a/app-emulation/ganeti/ganeti-2.15.2-r11.ebuild
+++ b/app-emulation/ganeti/ganeti-2.15.2-r11.ebuild
@@ -77,7 +77,6 @@ DEPEND="
 		dev-python/pycurl[${PYTHON_MULTI_USEDEP}]
 		dev-python/ipaddr[${PYTHON_MULTI_USEDEP}]
 		dev-python/bitarray[${PYTHON_MULTI_USEDEP}]
-		dev-python/docutils[${PYTHON_MULTI_USEDEP}]
 		dev-python/fdsend[${PYTHON_MULTI_USEDEP}]
 	')
 	|| (
@@ -158,10 +157,6 @@ RDEPEND="${DEPEND}
 	!app-emulation/ganeti-htools"
 DEPEND+="
 	sys-devel/m4
-	app-text/pandoc
-	$(python_gen_cond_dep '
-		dev-python/sphinx[${PYTHON_MULTI_USEDEP}]
-	')
 	media-fonts/urw-fonts
 	media-gfx/graphviz
 	>=dev-haskell/test-framework-0.6:0=
@@ -316,7 +311,12 @@ src_configure() {
 		$(usex haskell-daemons "--enable-confd=haskell" '' '' '') \
 		--with-haskell-flags="-optl -Wl,-z,relro -optl -Wl,--as-needed" \
 		--enable-socat-escape \
-		--enable-socat-compress
+		--enable-socat-compress \
+		SPHINX= \
+		PANDOC=
+
+	touch man/*.gen || die
+	touch man/*.in || die
 }
 
 src_install() {

--- a/dev-libs/xapian-bindings/xapian-bindings-1.4.14.ebuild
+++ b/dev-libs/xapian-bindings/xapian-bindings-1.4.14.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python{2_7,3_6,3_7,3_8} )
+PYTHON_COMPAT=( python{3_6,3_7,3_8} )
 PYTHON_REQ_USE="threads(+)"
 
 USE_PHP="php7-2 php7-3 php7-4"

--- a/dev-libs/xapian-bindings/xapian-bindings-1.4.15.ebuild
+++ b/dev-libs/xapian-bindings/xapian-bindings-1.4.15.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python{2_7,3_6,3_7,3_8} )
+PYTHON_COMPAT=( python{3_6,3_7,3_8} )
 PYTHON_REQ_USE="threads(+)"
 
 USE_PHP="php7-2 php7-3 php7-4"

--- a/dev-libs/xapian-bindings/xapian-bindings-1.4.16.ebuild
+++ b/dev-libs/xapian-bindings/xapian-bindings-1.4.16.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python{2_7,3_6,3_7,3_8} )
+PYTHON_COMPAT=( python{3_6,3_7,3_8} )
 PYTHON_REQ_USE="threads(+)"
 
 USE_PHP="php7-2 php7-3 php7-4"

--- a/dev-python/html5lib/html5lib-1.0.1-r2.ebuild
+++ b/dev-python/html5lib/html5lib-1.0.1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_{6,7,8,9}} pypy3 )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 PYTHON_REQ_USE="xml(+)"
 
 inherit distutils-r1

--- a/dev-python/html5lib/html5lib-1.1.ebuild
+++ b/dev-python/html5lib/html5lib-1.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_{6,7,8,9}} pypy3 )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 PYTHON_REQ_USE="xml(+)"
 
 inherit distutils-r1

--- a/dev-python/pallets-sphinx-themes/pallets-sphinx-themes-1.1.2.ebuild
+++ b/dev-python/pallets-sphinx-themes/pallets-sphinx-themes-1.1.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{6,7} pypy3 )
+PYTHON_COMPAT=( python3_{6,7} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Sphinx themes for Pallets and related projects"

--- a/dev-python/rst-linker/rst-linker-1.11.ebuild
+++ b/dev-python/rst-linker/rst-linker-1.11.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( pypy3 python2_7 python3_{6,7,8} )
+PYTHON_COMPAT=( pypy3 python3_{6,7,8} )
 inherit distutils-r1
 
 MY_PN="${PN/-/.}"

--- a/dev-python/sphinx-issues/sphinx-issues-1.2.0.ebuild
+++ b/dev-python/sphinx-issues/sphinx-issues-1.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8} )
 inherit distutils-r1
 
 DESCRIPTION="A Sphinx extension for linking to your project's issue tracker "

--- a/dev-python/sphinx/sphinx-1.7.5-r2.ebuild
+++ b/dev-python/sphinx/sphinx-1.7.5-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/dev-python/sphinxcontrib-websupport/sphinxcontrib-websupport-1.1.0.ebuild
+++ b/dev-python/sphinxcontrib-websupport/sphinxcontrib-websupport-1.1.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
+PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/webencodings/webencodings-0.5.1-r1.ebuild
+++ b/dev-python/webencodings/webencodings-0.5.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{2_7,3_{6,7,8,9}} pypy3 )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 
 inherit distutils-r1
 

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -7,6 +7,27 @@
 # mask everywhere, unmask on arch/*) use arch/base.
 
 # Michał Górny <mgorny@gentoo.org> (2020-07-25)
+# These packages require Python 2 support in dev-python/sphinx.
+# They are generally fixable by adding py3 support and using
+# distutils_enable_sphinx to build docs.
+<dev-libs/mongo-c-driver-1 doc
+dev-python/backports-functools-lru-cache doc
+<dev-python/click-7.1.2 doc
+<=dev-python/dulwich-0.19.15 doc
+<=dev-python/futures-3.2.0 doc
+<dev-python/gevent-20 doc
+<dev-python/inflect-4 doc
+<dev-python/jaraco-itertools-5 doc
+<=dev-python/lockfile-0.12.2-r2 doc
+<=dev-python/mysql-python-1.2.5-r3 doc
+<=dev-python/mysqlclient-1.4.6 doc
+<dev-python/peewee-3.13.2 doc
+<dev-python/pep8-1.7.1-r1 doc
+<dev-python/psycopg-2.8.4 doc
+<dev-python/requests-cache-0.4.12-r1 doc
+<=sci-biology/seqan-2.4.0 doc
+
+# Michał Górny <mgorny@gentoo.org> (2020-07-25)
 # Requires Python 2 support in xapian-bindings which in turn require
 # Python 2 in dev-python/sphinx.
 <www-apps/roundup-3 xapian

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -7,6 +7,11 @@
 # mask everywhere, unmask on arch/*) use arch/base.
 
 # Michał Górny <mgorny@gentoo.org> (2020-07-25)
+# Requires Python 2 support in xapian-bindings which in turn require
+# Python 2 in dev-python/sphinx.
+<www-apps/roundup-3 xapian
+
+# Michał Górny <mgorny@gentoo.org> (2020-07-25)
 # Requires dev-python/beautifulsoup with py2 support.
 <=sys-cluster/charm-6.8.2 doc
 


### PR DESCRIPTION
Do not regenerate manpages by default in order to unblock Python 2
removal from dev-python/sphinx.  Also remove the dependency
on app-text/pandoc which becomes no longer necessary.

Signed-off-by: Michał Górny <mgorny@gentoo.org>