### PR TITLE
sci-mathematics/pspp: Add security patches

### DIFF
--- a/sci-mathematics/pspp/files/pspp-1.2.0-CVE-2018-20230.patch
+++ b/sci-mathematics/pspp/files/pspp-1.2.0-CVE-2018-20230.patch
@@ -1,0 +1,134 @@
+Upstream: https://git.savannah.gnu.org/cgit/pspp.git/commit/?id=abd1f816ca3b4f382bddf4564ad092aa934f0ccc
+Bug: https://bugs.gentoo.org/679392
+
+From abd1f816ca3b4f382bddf4564ad092aa934f0ccc Mon Sep 17 00:00:00 2001
+From: Ben Pfaff <blp@cs.stanford.edu>
+Date: Tue, 1 Jan 2019 08:36:05 -0800
+Subject: pspp-dump-sav: Issue error message for too-large extension records.
+
+CVE-2018-20230.
+---
+ NEWS                      |  2 ++
+ utilities/pspp-dump-sav.c | 30 ++++++++++++++++++------------
+ 2 files changed, 20 insertions(+), 12 deletions(-)
+
+diff --git a/NEWS b/NEWS
+index 3263062ca..191a9804b 100644
+--- a/NEWS
++++ b/NEWS
+@@ -9,6 +9,8 @@ Changes since 1.2.0:
+  * Plain text output is no longer divided into pages, since it is now
+    rarely printed on paper.
+ 
++ * Bug fix for CVE-2018-20230.
++
+ Changes from 1.0.1 to 1.2.0:
+ 
+  * New experimental command SAVE DATA COLLECTION to save MDD files.
+diff --git a/utilities/pspp-dump-sav.c b/utilities/pspp-dump-sav.c
+index aeb648665..b0001ac61 100644
+--- a/utilities/pspp-dump-sav.c
++++ b/utilities/pspp-dump-sav.c
+@@ -37,6 +37,7 @@
+ #include "gl/progname.h"
+ #include "gl/version-etc.h"
+ #include "gl/xalloc.h"
++#include "gl/xsize.h"
+ 
+ #define ID_MAX_LEN 64
+ 
+@@ -99,7 +100,7 @@ static void read_simple_compressed_data (struct sfm_reader *, int max_cases);
+ static void read_zlib_compressed_data (struct sfm_reader *);
+ 
+ static struct text_record *open_text_record (
+-  struct sfm_reader *, size_t size);
++  struct sfm_reader *, size_t size, size_t count);
+ static void close_text_record (struct text_record *);
+ static bool read_variable_to_value_pair (struct text_record *,
+                                          char **key, char **value);
+@@ -735,7 +736,7 @@ read_extra_product_info (struct sfm_reader *r,
+   const char *s;
+ 
+   printf ("%08llx: extra product info\n", (long long int) ftello (r->file));
+-  text = open_text_record (r, size * count);
++  text = open_text_record (r, size, count);
+   s = text_get_all (text);
+   print_string (s, strlen (s));
+   close_text_record (text);
+@@ -749,7 +750,7 @@ read_mrsets (struct sfm_reader *r, size_t size, size_t count)
+ 
+   printf ("%08llx: multiple response sets\n",
+           (long long int) ftello (r->file));
+-  text = open_text_record (r, size * count);
++  text = open_text_record (r, size, count);
+   for (;;)
+     {
+       const char *name;
+@@ -909,7 +910,7 @@ read_long_var_name_map (struct sfm_reader *r, size_t size, size_t count)
+ 
+   printf ("%08llx: long variable names (short => long)\n",
+           (long long int) ftello (r->file));
+-  text = open_text_record (r, size * count);
++  text = open_text_record (r, size, count);
+   while (read_variable_to_value_pair (text, &var, &long_name))
+     printf ("\t%s => %s\n", var, long_name);
+   close_text_record (text);
+@@ -926,7 +927,7 @@ read_long_string_map (struct sfm_reader *r, size_t size, size_t count)
+ 
+   printf ("%08llx: very long strings (variable => length)\n",
+           (long long int) ftello (r->file));
+-  text = open_text_record (r, size * count);
++  text = open_text_record (r, size, count);
+   while (read_variable_to_value_pair (text, &var, &length_s))
+     printf ("\t%s => %d\n", var, atoi (length_s));
+   close_text_record (text);
+@@ -1004,7 +1005,7 @@ read_datafile_attributes (struct sfm_reader *r, size_t size, size_t count)
+   struct text_record *text;
+ 
+   printf ("%08llx: datafile attributes\n", (long long int) ftello (r->file));
+-  text = open_text_record (r, size * count);
++  text = open_text_record (r, size, count);
+   read_attributes (r, text, "datafile");
+   close_text_record (text);
+ }
+@@ -1196,7 +1197,7 @@ read_variable_attributes (struct sfm_reader *r, size_t size, size_t count)
+   struct text_record *text;
+ 
+   printf ("%08llx: variable attributes\n", (long long int) ftello (r->file));
+-  text = open_text_record (r, size * count);
++  text = open_text_record (r, size, count);
+   for (;;)
+     {
+       const char *variable = text_tokenize (text, ':');
+@@ -1389,18 +1390,23 @@ struct text_record
+     size_t pos;                 /* Current position in buffer. */
+   };
+ 
+-/* Reads SIZE bytes into a text record for R,
++/* Reads SIZE * COUNT bytes into a text record for R,
+    and returns the new text record. */
+ static struct text_record *
+-open_text_record (struct sfm_reader *r, size_t size)
++open_text_record (struct sfm_reader *r, size_t size, size_t count)
+ {
+   struct text_record *text = xmalloc (sizeof *text);
+-  char *buffer = xmalloc (size + 1);
+-  read_bytes (r, buffer, size);
++
++  if (size_overflow_p (xsum (1, xtimes (size, count))))
++    sys_error (r, "Extension record too large.");
++
++  size_t n_bytes = size * count;
++  char *buffer = xmalloc (n_bytes + 1);
++  read_bytes (r, buffer, n_bytes);
+   buffer[size] = '\0';
+   text->reader = r;
+   text->buffer = buffer;
+-  text->size = size;
++  text->size = n_bytes;
+   text->pos = 0;
+   return text;
+ }
+-- 
+cgit v1.2.1
+

--- a/sci-mathematics/pspp/files/pspp-1.2.0-CVE-2019-9211.patch
+++ b/sci-mathematics/pspp/files/pspp-1.2.0-CVE-2019-9211.patch
@@ -1,0 +1,74 @@
+Source: https://git.savannah.gnu.org/cgit/pspp.git/commit/?id=0b842a84353790534a401e09a8d3bdd3d25bc3a6
+Bug: https://bugs.gentoo.org/679392
+
+From 0b842a84353790534a401e09a8d3bdd3d25bc3a6 Mon Sep 17 00:00:00 2001
+From: Ben Pfaff <blp@cs.stanford.edu>
+Date: Wed, 27 Feb 2019 20:11:06 -0800
+Subject: sys-file-writer: Remove assertions based on file position.
+
+These assertions can fail if the underlying file is not a regular file,
+e.g. if it is a device such as /dev/null.
+
+CVE-2019-9211.
+See also https://bugzilla.redhat.com/show_bug.cgi?id=1683499.
+See also https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9211.
+See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923417.
+---
+ src/data/sys-file-writer.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/src/data/sys-file-writer.c b/src/data/sys-file-writer.c
+index df5108e2a..bbe58aecd 100644
+--- a/src/data/sys-file-writer.c
++++ b/src/data/sys-file-writer.c
+@@ -953,7 +953,6 @@ write_long_string_value_labels (struct sfm_writer *w,
+   const char *encoding = dict_get_encoding (dict);
+   size_t n_vars = dict_get_var_cnt (dict);
+   size_t size, i;
+-  off_t start UNUSED;
+ 
+   /* Figure out the size in advance. */
+   size = 0;
+@@ -985,7 +984,6 @@ write_long_string_value_labels (struct sfm_writer *w,
+   write_int (w, 1);             /* Data item (byte) size. */
+   write_int (w, size);          /* Number of data items. */
+ 
+-  start = ftello (w->file);
+   for (i = 0; i < n_vars; i++)
+     {
+       struct variable *var = dict_get_var (dict, i);
+@@ -1022,7 +1020,6 @@ write_long_string_value_labels (struct sfm_writer *w,
+           free (label);
+         }
+     }
+-  assert (ftello (w->file) == start + size);
+ }
+ 
+ static void
+@@ -1032,7 +1029,6 @@ write_long_string_missing_values (struct sfm_writer *w,
+   const char *encoding = dict_get_encoding (dict);
+   size_t n_vars = dict_get_var_cnt (dict);
+   size_t size, i;
+-  off_t start UNUSED;
+ 
+   /* Figure out the size in advance. */
+   size = 0;
+@@ -1058,7 +1054,6 @@ write_long_string_missing_values (struct sfm_writer *w,
+   write_int (w, 1);             /* Data item (byte) size. */
+   write_int (w, size);          /* Number of data items. */
+ 
+-  start = ftello (w->file);
+   for (i = 0; i < n_vars; i++)
+     {
+       struct variable *var = dict_get_var (dict, i);
+@@ -1087,7 +1082,6 @@ write_long_string_missing_values (struct sfm_writer *w,
+           write_bytes (w, value_str (value, width), 8);
+         }
+     }
+-  assert (ftello (w->file) == start + size);
+ }
+ 
+ static void
+-- 
+cgit v1.2.1
+

--- a/sci-mathematics/pspp/files/pspp-1.2.0-fix-gcc10.patch
+++ b/sci-mathematics/pspp/files/pspp-1.2.0-fix-gcc10.patch
@@ -1,0 +1,30 @@
+Upstream: https://git.savannah.gnu.org/cgit/pspp.git/commit/?id=614bbfbc4be1f4f47d55d3fbee9ae20f3a9955bb
+Gentoo Bug: https://bugs.gentoo.org/708548
+
+commit 614bbfbc4be1f4f47d55d3fbee9ae20f3a9955bb
+Author: Ben Pfaff <blp@cs.stanford.edu>
+Date:   Fri Nov 16 20:27:30 2018 -0800
+
+    psppire: Fix multiple definitions of align_enum_type and two others.
+    
+    These were defined in both psppire-dict.c and widgets.c, which causes a
+    problem building with -fno-common (which is desirable because it allows
+    Address Sanitizer to work better).
+
+diff --git a/src/ui/gui/widgets.c b/src/ui/gui/widgets.c
+index 26a5dac4f..6ce129249 100644
+--- a/src/ui/gui/widgets.c
++++ b/src/ui/gui/widgets.c
+@@ -171,9 +171,9 @@ enum_to_string (const GValue *src, GValue *dest)
+ 
+ 
+ 
+-GType align_enum_type;
+-GType measure_enum_type;
+-GType role_enum_type;
++extern GType align_enum_type;
++extern GType measure_enum_type;
++extern GType role_enum_type;
+ 
+ 
+ extern const GEnumValue align[];

--- a/sci-mathematics/pspp/files/pspp-1.2.0-fix-overflow.patch
+++ b/sci-mathematics/pspp/files/pspp-1.2.0-fix-overflow.patch
@@ -1,0 +1,32 @@
+Upstream: https://git.savannah.gnu.org/cgit/pspp.git/commit/?id=be42ce976006feed2a7ba7599ee417c28887af52
+
+From be42ce976006feed2a7ba7599ee417c28887af52 Mon Sep 17 00:00:00 2001
+From: Ben Pfaff <blp@cs.stanford.edu>
+Date: Fri, 22 Feb 2019 17:16:40 -0800
+Subject: pspp-dump-sav; Fix write past end of buffer in corner case.
+
+If count == 0 and size > 0, then n_bytes is 0, buffer is a 1-byte
+allocation, and the assignment to buffer[size] would write to buffer[1]
+(or past it), which is past the end of the allocation.
+
+Found by Address Sanitizer.
+---
+ utilities/pspp-dump-sav.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utilities/pspp-dump-sav.c b/utilities/pspp-dump-sav.c
+index 1d8d78c87..70687ebc8 100644
+--- a/utilities/pspp-dump-sav.c
++++ b/utilities/pspp-dump-sav.c
+@@ -1403,7 +1403,7 @@ open_text_record (struct sfm_reader *r, size_t size, size_t count)
+   size_t n_bytes = size * count;
+   char *buffer = xmalloc (n_bytes + 1);
+   read_bytes (r, buffer, n_bytes);
+-  buffer[size] = '\0';
++  buffer[n_bytes] = '\0';
+   text->reader = r;
+   text->buffer = buffer;
+   text->size = n_bytes;
+-- 
+cgit v1.2.1
+

--- a/sci-mathematics/pspp/files/pspp-1.2.0-fix-segfaults.patch
+++ b/sci-mathematics/pspp/files/pspp-1.2.0-fix-segfaults.patch
@@ -1,0 +1,45 @@
+Upstream: https://git.savannah.gnu.org/cgit/pspp.git/commit/?id=df8cf077b2aacb7fe7b33dd8cb90ba57c8681aa0
+
+From df8cf077b2aacb7fe7b33dd8cb90ba57c8681aa0 Mon Sep 17 00:00:00 2001
+From: John Darrington <john@darrington.wattle.id.au>
+Date: Sat, 2 Mar 2019 15:29:39 +0100
+Subject: PSPPIRE: Avoid some segmentation faults when corrupt data is
+ encountered.
+
+---
+ src/ui/gui/psppire-data-store.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/ui/gui/psppire-data-store.c b/src/ui/gui/psppire-data-store.c
+index f97b8eaf1..3c2765f5d 100644
+--- a/src/ui/gui/psppire-data-store.c
++++ b/src/ui/gui/psppire-data-store.c
+@@ -183,6 +183,8 @@ psppire_data_store_value_to_string (gpointer unused, PsppireDataStore *store, gi
+   g_return_val_if_fail (variable, g_strdup ("???"));
+ 
+   GVariant *vrnt = g_value_get_variant (v);
++  g_return_val_if_fail (vrnt, g_strdup ("???"));
++
+   union value val;
+   value_variant_get (&val, vrnt);
+ 
+@@ -231,12 +233,14 @@ __get_value (GtkTreeModel *tree_model,
+   if (NULL == variable)
+     return;
+ 
+-  g_value_init (value, G_TYPE_VARIANT);
+-
+   gint row = GPOINTER_TO_INT (iter->user_data);
+ 
+   struct ccase *cc = datasheet_get_row (store->datasheet, row);
+ 
++  g_return_if_fail (cc);
++
++  g_value_init (value, G_TYPE_VARIANT);
++
+   const union value *val = case_data_idx (cc, var_get_case_index (variable));
+ 
+   GVariant *vv = value_variant_new (val, var_get_width (variable));
+-- 
+cgit v1.2.1
+

--- a/sci-mathematics/pspp/files/pspp-1.2.0-fix-tests.patch
+++ b/sci-mathematics/pspp/files/pspp-1.2.0-fix-tests.patch
@@ -1,0 +1,61 @@
+Upstream: https://git.savannah.gnu.org/cgit/pspp.git/commit/?id=fe94912b9c8682c4666873b84c83cda88f4c135d
+
+commit fe94912b9c8682c4666873b84c83cda88f4c135d
+Author: Ben Pfaff <blp@cs.stanford.edu>
+Date:   Mon Nov 26 06:54:52 2018 -0800
+
+    segment: Fix behavior when #! line is not new-line terminated.
+    
+    The code here is supposed to maintain a invariant that, when it returns a
+    nonnegative value, it initializes *type, but it failed to do that when a
+    #! line did not end in a new-line.  This fixes the problem.
+    
+    Bug #55101.
+    Thanks for Friedrich Beckmann for narrowing down the problem.
+    Found by the Debian buildd: https://buildd.debian.org/status/fetch.php?pkg=pspp&arch=arm64&ver=1.2.0-1&stamp=1543183214&raw=0
+
+diff --git a/src/language/lexer/segment.c b/src/language/lexer/segment.c
+index c0a09973c..c607c4bd1 100644
+--- a/src/language/lexer/segment.c
++++ b/src/language/lexer/segment.c
+@@ -92,21 +92,26 @@ segmenter_parse_shbang__ (struct segmenter *s, const char *input, size_t n,
+         {
+           if (input[1] == '!')
+             {
+-              int ofs;
+-
+-              for (ofs = 2; ofs < n; ofs++)
+-                if (input[ofs] == '\n')
+-                  {
+-                    if (input[ofs] == '\n' && input[ofs - 1] == '\r')
+-                      ofs--;
+-
+-                    s->state = S_GENERAL;
+-                    s->substate = SS_START_OF_COMMAND;
+-                    *type = SEG_SHBANG;
+-                    return ofs;
+-                  }
++              for (int ofs = 2; ; ofs++)
++                {
++                  if (ofs >= n)
++                    {
++                      if (!eof)
++                        return -1;
++                    }
++                  else if (input[ofs] == '\n')
++                    {
++                      if (input[ofs - 1] == '\r')
++                        ofs--;
++                    }
++                  else
++                    continue;
+ 
+-              return eof ? ofs : -1;
++                  s->state = S_GENERAL;
++                  s->substate = SS_START_OF_COMMAND;
++                  *type = SEG_SHBANG;
++                  return ofs;
++                }
+             }
+         }
+       else if (!eof)

--- a/sci-mathematics/pspp/files/pspp-1.2.0-py3.patch
+++ b/sci-mathematics/pspp/files/pspp-1.2.0-py3.patch
@@ -1,0 +1,38 @@
+Upstream: https://git.savannah.gnu.org/cgit/pspp.git/commit/?id=123c3f55a80630655e84f97c9df558d988fa0055
+
+commit 123c3f55a80630655e84f97c9df558d988fa0055
+Author: Ben Pfaff <blp@cs.stanford.edu>
+Date:   Mon Nov 19 08:35:23 2018 -0800
+
+    test-date-input.py: Make compatible with Python 3.
+
+diff --git a/tests/data/test-date-input.py b/tests/data/test-date-input.py
+index 6ccc2f8f4..cdab260d6 100644
+--- a/tests/data/test-date-input.py
++++ b/tests/data/test-date-input.py
+@@ -50,8 +50,8 @@ def print_all_formats(date, template, formatted, exp_y, exp_m, exp_d,
+         global n
+         n += 1
+         year, month, day, julian, hour, minute, second = date
+-        quarter = (month - 1) / 3 + 1
+-        week = (julian - 1) / 7 + 1
++        quarter = (month - 1) // 3 + 1
++        week = (julian - 1) // 7 + 1
+         if year >= 1930 and year < 2030:
+             years = ('%d' % year, '%d' % (year % 100))
+         else:
+@@ -163,10 +163,10 @@ def print_all_formats(date, template, formatted, exp_y, exp_m, exp_d,
+         EPOCH = -577734         # 14 Oct 1582
+         expected = (EPOCH - 1
+                     + 365 * (exp_y - 1)
+-                    + (exp_y - 1) / 4
+-                    - (exp_y - 1) / 100
+-                    + (exp_y - 1) / 400
+-                    + (367 * exp_m - 362) / 12
++                    + (exp_y - 1) // 4
++                    - (exp_y - 1) // 100
++                    + (exp_y - 1) // 400
++                    + (367 * exp_m - 362) // 12
+                     + (0 if exp_m <= 2
+                        else -1 if exp_m >= 2 and is_leap_year(exp_y)
+                        else -2)

--- a/sci-mathematics/pspp/pspp-1.2.0-r1.ebuild
+++ b/sci-mathematics/pspp/pspp-1.2.0-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7..9} )
+
+inherit elisp-common python-any-r1 xdg-utils
+
+DESCRIPTION="Program for statistical analysis of sampled data"
+HOMEPAGE="https://www.gnu.org/software/pspp/pspp.html"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0/${PV}"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="cairo doc emacs examples gtk ncurses nls perl postgres static-libs test"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="test? ( cairo )"
+
+RDEPEND="
+	dev-libs/libxml2:2=
+	sci-libs/gsl:0=
+	sys-devel/gettext
+	sys-libs/ncurses:0=
+	sys-libs/readline:0=
+	sys-libs/zlib
+	virtual/libiconv
+	cairo? (
+		x11-libs/cairo[svg]
+		x11-libs/pango
+	)
+	emacs? ( >=app-editors/emacs-23.1:* )
+	gtk? (
+		x11-libs/gtk+:3=
+		x11-libs/gtksourceview:3.0=
+		x11-libs/spread-sheet-widget
+		cairo? ( dev-util/glib-utils )
+	)
+	postgres? ( dev-db/postgresql:=[server] )"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig
+	doc? ( virtual/latex-base )
+	test? ( ${PYTHON_DEPS} )"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-CVE-2018-20230.patch"
+	"${FILESDIR}/${P}-CVE-2019-9211.patch"
+	"${FILESDIR}/${P}-fix-overflow.patch"
+	"${FILESDIR}/${P}-fix-segfaults.patch"
+	"${FILESDIR}/${P}-fix-gcc10.patch"
+	"${FILESDIR}/${P}-py3.patch"
+	"${FILESDIR}/${P}-fix-tests.patch"
+)
+
+SITEFILE=50${PN}-gentoo.el
+
+pkg_setup() {
+	use test && python-any-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+	sed -i '/appdata$/s/appdata$/metainfo/' Makefile.in || die
+}
+
+src_configure() {
+	econf \
+		$(use_enable nls) \
+		$(use_enable static-libs static) \
+		$(use_with cairo) \
+		$(use_with gtk gui) \
+		$(use_with perl perl-module) \
+		$(use_with postgres libpq)
+}
+
+src_compile() {
+	default
+	use doc && emake html pdf
+	use emacs && elisp-compile *.el
+}
+
+src_install() {
+	default
+	if use doc; then
+		dodoc doc/pspp{,-dev}.pdf
+		docinto /usr/share/doc/${PF}/html
+		dodoc -r doc/pspp{,-dev}.html
+	fi
+	if use examples; then
+		docinto /usr/share/doc/${PF}/
+		dodoc -r examples
+	fi
+	if use emacs; then
+		elisp-install ${PN} *.el *.elc
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+	fi
+
+	find "${D}" -name '*.la' -type f -delete || die
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
This fixes several QA issues, adds a missing dependency, fixes
compiling with GCC 10, and adds patches for security.

Tests run for me when using Python 2, only one fails (406). Test
failures are in bug 674362.

Bug: https://bugs.gentoo.org/679392
Closes: https://bugs.gentoo.org/677282
Closes: https://bugs.gentoo.org/682342
Closes: https://bugs.gentoo.org/708548
Package-Manager: Portage-3.0.0, Repoman-2.3.23
Signed-off-by: John Helmert III <jchelmert3@posteo.net>