### PR TITLE
media-tv/mythtv: Fix patch file reference name

### DIFF
--- a/media-tv/mythtv/mythtv-30.0_p20190808-r3.ebuild
+++ b/media-tv/mythtv/mythtv-30.0_p20190808-r3.ebuild
@@ -147,7 +147,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-Fix_Dereferencing_type-punned_pointer.patch"
 	"${FILESDIR}/${P}-Fix_unitialized_variables.patch"
 	"${FILESDIR}/${PN}-29.1-Fix_create_webbrowser_window.patch"
-	"${FILESDIR}/${P}-Include_QPainterPath.patch"
+	"${FILESDIR}/${PN}-31.0-Include_QPainterPath.patch"
 )
 
 # mythtv and mythplugins are separate builds in the github mythtv project


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/733620
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Wilson Michaels <thebitpit@earthlink.net>