### PR TITLE
net-vpn/wireguard-tools: Add an OpenRC init script

### DIFF
--- a/net-vpn/wireguard-tools/files/wireguard.init
+++ b/net-vpn/wireguard-tools/files/wireguard.init
@@ -1,0 +1,27 @@
+#!/sbin/openrc-run
+
+VPN="${SVCNAME#*.}"
+
+depend() {
+	need localmount net
+	use dns
+	after bootmisc
+}
+
+start() {
+	# Make sure WireGuard is available
+	if [ ! -e "/sys/module/wireguard" ]; then
+		ebegin "Loading WireGuard module"
+		modprobe wireguard &> /dev/null
+		eend $? || return 1
+	fi
+	ebegin "Starting ${SVCNAME}"
+	[ -e "/sys/class/net/${VPN}" ] || wg-quick up "${VPN}" &> /dev/null
+	eend $? "Try starting manually with 'wg-quick up ${VPN}'" || return 1
+}
+
+stop() {
+	ebegin "Stopping ${SVCNAME}"
+	[ ! -e "/sys/class/net/${VPN}" ] || wg-quick down "${VPN}" &> /dev/null
+	eend $? "Try stopping manually with 'wg-quick down ${VPN}'" || return 1
+}

--- a/net-vpn/wireguard-tools/wireguard-tools-1.0.20200513.ebuild
+++ b/net-vpn/wireguard-tools/wireguard-tools-1.0.20200513.ebuild
@@ -79,6 +79,8 @@ src_install() {
 		SYSTEMDUNITDIR="$(systemd_get_systemunitdir)" \
 		PREFIX="${EPREFIX}/usr" \
 		-C src install
+
+	use wg-quick && newinitd "${FILESDIR}/wireguard.init" wireguard
 }
 
 pkg_postinst() {
@@ -98,4 +100,12 @@ pkg_postinst() {
 	einfo
 	einfo "More info on getting started can be found at: https://www.wireguard.com/quickstart/"
 	einfo
+	if use wg-quick; then
+		einfo "To use the wireguard init script, create a config for 'wg-quick', and create"
+		einfo "a symlink to the wireguard init script using the config name - like so:"
+		einfo "  ${EDITOR##*/} /etc/wireguard/foo.conf"
+		einfo "  ln -s wireguard /etc/init.d/wireguard.foo"
+		einfo "You can then treat 'wireguard.foo' like any other service."
+		einfo
+	fi
 }


### PR DESCRIPTION
This PR implements an openrc init script for wireguard that functions much like the openvpn init script.

It is a simple wrapper around the `wg-quick` tool, and uses the same configuration files. It takes care of loading the `wireguard` module, and starts/stops cleanly if the tunnel has already been created/deleted from outside the script.

I'm not sure if this should be a revbump or not.