### PR TITLE
dev-lua/luasocket: fix building for prefix

### DIFF
--- a/dev-lua/luasocket/luasocket-3.0_rc1-r5.ebuild
+++ b/dev-lua/luasocket/luasocket-3.0_rc1-r5.ebuild
@@ -43,7 +43,7 @@ multilib_src_install() {
 	local luav=$($(tc-getPKG_CONFIG) --variable V lua)
 	emake \
 		DESTDIR="${D}" \
-		LUAPREFIX_linux=/usr \
+		LUAPREFIX_linux="${EPREFIX}/usr" \
 		LUAV=${luav} \
 		CDIR_linux=$(get_libdir)/lua/${luav} \
 		install-unix


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/501168
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>