### PR TITLE
dev-libs/kpathsea - Adapt symlinks from /usr/share/textmf-dist/web2c for prefix installs

### DIFF
--- a/dev-libs/kpathsea/kpathsea-6.3.2_p20200406.ebuild
+++ b/dev-libs/kpathsea/kpathsea-6.3.2_p20200406.ebuild
@@ -86,8 +86,8 @@ src_install() {
 	# by texmf-update
 	rm -f "${ED}${TEXMF_PATH}/web2c/fmtutil.cnf"
 
-	dosym /../../../../etc/texmf/web2c/fmtutil.cnf ${TEXMF_PATH}/web2c/fmtutil.cnf
-	dosym /../../../../etc/texmf/web2c/texmf.cnf ${TEXMF_PATH}/web2c/texmf.cnf
+	dosym ../../../../etc/texmf/web2c/fmtutil.cnf ${TEXMF_PATH}/web2c/fmtutil.cnf
+	dosym ../../../../etc/texmf/web2c/texmf.cnf ${TEXMF_PATH}/web2c/texmf.cnf
 
 	newsbin "${S}/texmf-update" texmf-update
 


### PR DESCRIPTION
Symlinks `/usr/share/texmf-dist/web2c/fmtutil.conf` -> `/etc/texmf/web2c/fmtutil.cnf`, and `texmf.cnf` are broken for prefix installs.  This appears to fix it and work for non-prefix installs too.