### PR TITLE
Fix symlinks under /usr/share/texmf-dist/web2c/ for EPREFIX.

### DIFF
--- a/dev-libs/kpathsea/kpathsea-6.3.2_p20200406.ebuild
+++ b/dev-libs/kpathsea/kpathsea-6.3.2_p20200406.ebuild
@@ -86,8 +86,8 @@ src_install() {
 	# by texmf-update
 	rm -f "${ED}${TEXMF_PATH}/web2c/fmtutil.cnf"
 
-	dosym /../../../../etc/texmf/web2c/fmtutil.cnf ${TEXMF_PATH}/web2c/fmtutil.cnf
-	dosym /../../../../etc/texmf/web2c/texmf.cnf ${TEXMF_PATH}/web2c/texmf.cnf
+	dosym ../../../../etc/texmf/web2c/fmtutil.cnf ${TEXMF_PATH}/web2c/fmtutil.cnf
+	dosym ../../../../etc/texmf/web2c/texmf.cnf ${TEXMF_PATH}/web2c/texmf.cnf
 
 	newsbin "${S}/texmf-update" texmf-update
 


### PR DESCRIPTION
This appears to fix the symlinks for both prefix and non-prefix installs.  The current ebuild installs broken symlinks for prefix installs.

Bug: https://bugs.gentoo.org/710190

Signed-of-by: Mark J. Olah <mjo@cs.unm.edu>