### PR TITLE
media-libs/libmp4v2: Add security patches

### DIFF
--- a/media-libs/libmp4v2/files/libmp4v2-2.0.0-CVE-2018-14054.patch
+++ b/media-libs/libmp4v2/files/libmp4v2-2.0.0-CVE-2018-14054.patch
@@ -1,0 +1,35 @@
+Upstream: https://github.com/sergiomb2/libmp4v2/commit/3410bc66fb91f46325ab1d008b6a421dd8240949
+Gentoo Bug: https://bugs.gentoo.org/661582
+
+From 3410bc66fb91f46325ab1d008b6a421dd8240949 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9rgio=20M=2E=20Basto?= <sergio@serjux.com>
+Date: Sat, 2 Nov 2019 04:21:17 +0000
+Subject: [PATCH] Null out pointer after free to prevent double free
+
+If an exception occurs (because of a crafted MP4) before the value is reassigned, then a double free can occur.  By setting the pointer to NULL after the first free, we prevent the double free in this case.
+Addresses: https://nvd.nist.gov/vuln/detail/CVE-2018-14054
+
+copied form https://github.com/TechSmith/mp4v2/commit/f09cceeee5bd7f783fd31f10e8b3c440ccf4c743
+From: Dave O'Rourke
+Date: Wed, 20 Mar 2019 08:57:29 -0400
+---
+ src/mp4property.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/mp4property.cpp b/src/mp4property.cpp
+index 9a5b1e3..1b8e1d2 100644
+--- a/src/mp4property.cpp
++++ b/src/mp4property.cpp
+@@ -391,8 +391,10 @@ void MP4StringProperty::Read( MP4File& file, uint32_t index )
+         char*& value = m_values[i];
+ 
+         // Generally a default atom setting, e.g. see atom_avc1.cpp, "JVT/AVC Coding"; we'll leak this string if
+-        // we don't free.  Note that MP4Free checks for null.
+-        MP4Free(value); 
++        // we don't free.  Note that this code checks for null before calling free and sets the pointer to null
++        // after freeing it, to prevent a double free in case an exception occurs before the value is reassigned.
++        MP4Free( value );
++        value = NULL;
+ 
+         if( m_useCountedFormat ) {
+             value = file.ReadCountedString( (m_useUnicode ? 2 : 1), m_useExpandedCount, m_fixedLength );

--- a/media-libs/libmp4v2/files/libmp4v2-2.0.0-CVE-2018-14325.patch
+++ b/media-libs/libmp4v2/files/libmp4v2-2.0.0-CVE-2018-14325.patch
@@ -1,0 +1,60 @@
+Upstream: https://github.com/sergiomb2/libmp4v2/commit/9084868fd9f86bee118001c23171e832f15009f4
+Gentoo Bug: https://bugs.gentoo.org/661582
+
+
+From 9084868fd9f86bee118001c23171e832f15009f4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9rgio=20M=2E=20Basto?= <sergio@serjux.com>
+Date: Fri, 8 Nov 2019 02:01:32 +0000
+Subject: [PATCH] Fix v3 Integer underflow/overflow in MP4v2 2.0.0
+
+Reference: https://www.openwall.com/lists/oss-security/2018/07/16/1
+
+For the overflow, we could check the result of the integer multiplication:
+
+fix vulnerability where an atom list size is enormous
+and calculating the number of bytes needed to hold the list overflows
+https://github.com/TechSmith/mp4v2/pull/27/commits/70d823ccd8e2d7d0ed9e62fb7e8983d21e6acbeb
+
+Addresses https://nvd.nist.gov/vuln/detail/CVE-2018-14326 and https://nvd.nist.gov/vuln/detail/CVE-2018-14446
+
+For the underflow, we could check if `dataSize >= hdrSize` satisfies:
+Throw exception when invalid atom size would cause integer underflow
+The calculation `hdrSize - dataSize` can underflow the 64-bit unsigned int dataSize type, which can lead to incorrect results.  We throw an exception to stop the code from going any further.
+
+Addresses https://nvd.nist.gov/vuln/detail/CVE-2018-14325
+Based on https://github.com/TechSmith/mp4v2/commit/e475013c6ef78093055a02b0d035eda0f9f01451
+---
+ src/mp4array.h  | 2 ++
+ src/mp4atom.cpp | 6 ++++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/src/mp4array.h b/src/mp4array.h
+index c49d59b..69d470a 100644
+--- a/src/mp4array.h
++++ b/src/mp4array.h
+@@ -102,6 +102,8 @@ class MP4Array {
+         void Resize(MP4ArrayIndex newSize) { \
+             m_numElements = newSize; \
+             m_maxNumElements = newSize; \
++            if ( (uint64_t) m_maxNumElements * sizeof(type) > 0xFFFFFFFF ) \
++               throw new PlatformException("requested array size exceeds 4GB", ERANGE, __FILE__, __LINE__, __FUNCTION__); /* prevent overflow */ \
+             m_elements = (type*)MP4Realloc(m_elements, \
+                 m_maxNumElements * sizeof(type)); \
+         } \
+diff --git a/src/mp4atom.cpp b/src/mp4atom.cpp
+index 7a0a53f..f5d5dc0 100644
+--- a/src/mp4atom.cpp
++++ b/src/mp4atom.cpp
+@@ -143,6 +143,12 @@ MP4Atom* MP4Atom::ReadAtom(MP4File& file, MP4Atom* pParentAtom)
+         dataSize = file.GetSize() - pos;
+     }
+ 
++    if(dataSize < hdrSize) {
++        ostringstream oss;
++        oss << "Invalid atom size in '" << type << "' atom, dataSize = " << dataSize << " cannot be less than hdrSize = " << static_cast<unsigned>( hdrSize );
++        log.errorf( "%s: \"%s\": %s", __FUNCTION__, file.GetFilename().c_str(), oss.str().c_str() );
++        throw new Exception( oss.str().c_str(), __FILE__, __LINE__, __FUNCTION__ );
++    }
+     dataSize -= hdrSize;
+ 
+     log.verbose1f("\"%s\": type = \"%s\" data-size = %" PRIu64 " (0x%" PRIx64 ") hdr %u",

--- a/media-libs/libmp4v2/files/libmp4v2-2.0.0-CVE-2018-14379.patch
+++ b/media-libs/libmp4v2/files/libmp4v2-2.0.0-CVE-2018-14379.patch
@@ -1,0 +1,33 @@
+Upstream: https://github.com/sergiomb2/libmp4v2/commit/bb920de948c85e3db4a52292ac7250a50e3bfc86
+Gentoo Bug: https://bugs.gentoo.org/661582
+
+From bb920de948c85e3db4a52292ac7250a50e3bfc86 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9rgio=20M=2E=20Basto?= <sergio@serjux.com>
+Date: Sat, 2 Nov 2019 04:19:27 +0000
+Subject: [PATCH] Fix v2 Type confusion in MP4v2 2.0.0
+
+The bug is caused by the wrong assumption that the child of an `ilst`
+can never be an `ilst`. So we could fix it by simply adding an ASSERT.
+
+Reference: https://www.openwall.com/lists/oss-security/2018/07/17/1
+Addresses: https://nvd.nist.gov/vuln/detail/CVE-2018-14379
+---
+ src/mp4atom.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/mp4atom.cpp b/src/mp4atom.cpp
+index 520cbc8..7a0a53f 100644
+--- a/src/mp4atom.cpp
++++ b/src/mp4atom.cpp
+@@ -778,8 +778,10 @@ MP4Atom::factory( MP4File &file, MP4Atom* parent, const char* type )
+         const char* const ptype = parent->GetType();
+ 
+         if( descendsFrom( parent, "ilst" )) {
+-            if( ATOMID( ptype ) == ATOMID( "ilst" ))
++            if( ATOMID( ptype ) == ATOMID( "ilst" )) {
++                ASSERT(ATOMID( type ) != ATOMID( "ilst" ));
+                 return new MP4ItemAtom( file, type );
++            }
+ 
+             if( ATOMID( type ) == ATOMID( "data" ))
+                 return new MP4DataAtom(file);

--- a/media-libs/libmp4v2/files/libmp4v2-2.0.0-CVE-2018-14403.patch
+++ b/media-libs/libmp4v2/files/libmp4v2-2.0.0-CVE-2018-14403.patch
@@ -1,0 +1,28 @@
+Upstream: https://github.com/sergiomb2/libmp4v2/commit/a94a3372c6ef66a2276cc6cd92f7ec07a9c8bb6b
+Gentoo Bug: https://bugs.gentoo.org/661582
+
+From a94a3372c6ef66a2276cc6cd92f7ec07a9c8bb6b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9rgio=20M=2E=20Basto?= <sergio@serjux.com>
+Date: Wed, 17 Oct 2018 16:13:06 +0100
+Subject: [PATCH] Fix Out-of-bounds memory access in MP4v2 2.0.0
+
+The bug can be fixed by more checks when doing type comparison.
+Reference: https://www.openwall.com/lists/oss-security/2018/07/18/3
+
+Addresses https://nvd.nist.gov/vuln/detail/CVE-2018-14403
+---
+ src/mp4util.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/mp4util.cpp b/src/mp4util.cpp
+index 47bd74e..696dab4 100644
+--- a/src/mp4util.cpp
++++ b/src/mp4util.cpp
+@@ -46,6 +46,7 @@ bool MP4NameFirstMatches(const char* s1, const char* s2)
+         s1++;
+         s2++;
+     }
++    if(*s2 != '[' && *s2 != '.' && *s2 != '\0') return false;
+     return true;
+ }
+ 

--- a/media-libs/libmp4v2/libmp4v2-2.0.0-r2.ebuild
+++ b/media-libs/libmp4v2/libmp4v2-2.0.0-r2.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MY_P=${P/lib}
+
+inherit libtool
+
+DESCRIPTION="Functions for accessing ISO-IEC:14496-1:2001 MPEG-4 standard"
+HOMEPAGE="https://code.google.com/p/mp4v2/"
+SRC_URI="https://mp4v2.googlecode.com/files/${MY_P}.tar.bz2"
+
+LICENSE="MPL-1.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+IUSE="static-libs test utils"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	test? ( dev-util/dejagnu )
+	utils? ( sys-apps/help2man )
+"
+
+DOCS=( doc/{Authors,BuildSource,Documentation,ReleaseNotes,ToolGuide}.txt README )
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-gcc7.patch"
+	"${FILESDIR}/${P}-mp4tags-corruption.patch"
+	"${FILESDIR}/${P}-clang.patch"
+	"${FILESDIR}/${P}-CVE-2018-14054.patch"
+	"${FILESDIR}/${P}-CVE-2018-14325.patch"
+	"${FILESDIR}/${P}-CVE-2018-14379.patch"
+	"${FILESDIR}/${P}-CVE-2018-14403.patch"
+)
+
+src_prepare() {
+	default
+	elibtoolize
+}
+
+src_configure() {
+	econf \
+		--disable-gch \
+		$(use_enable utils util) \
+		$(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/661582
Package-Manager: Portage-3.0.0, Repoman-2.3.23
Signed-off-by: John Helmert III <jchelmert3@posteo.net>