### PR TITLE
dev-lang/rust: Avoid env using spaces as delimiters

### DIFF
--- a/dev-lang/rust/rust-1.41.1.ebuild
+++ b/dev-lang/rust/rust-1.41.1.ebuild
@@ -272,14 +272,18 @@ src_configure() {
 }
 
 src_compile() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env)\
 		"${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) \
 		--exclude src/tools/miri || die # https://github.com/rust-lang/rust/issues/52305
+	unset IFS
 }
 
 src_install() {
+	IFS=$'\n'
 	env DESTDIR="${D}" "${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml \
 	--exclude src/tools/miri || die
+	unset IFS
 
 	# bug #689562, #689160
 	rm "${D}/etc/bash_completion.d/cargo" || die

--- a/dev-lang/rust/rust-1.42.0.ebuild
+++ b/dev-lang/rust/rust-1.42.0.ebuild
@@ -280,13 +280,17 @@ src_configure() {
 }
 
 src_compile() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env)\
 		"${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+	unset IFS
 }
 
 src_install() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) DESTDIR="${D}" \
 		"${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml || die
+	unset IFS
 
 	# bug #689562, #689160
 	rm "${D}/etc/bash_completion.d/cargo" || die

--- a/dev-lang/rust/rust-1.43.1.ebuild
+++ b/dev-lang/rust/rust-1.43.1.ebuild
@@ -299,11 +299,14 @@ src_configure() {
 }
 
 src_compile() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) RUST_BACKTRACE=1\
 		"${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+	unset IFS
 }
 
 src_test() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) RUST_BACKTRACE=1\
 		"${EPYTHON}" ./x.py test -vv --config="${S}"/config.toml -j$(makeopts_jobs) --no-doc --no-fail-fast \
 		src/test/codegen \
@@ -317,11 +320,14 @@ src_test() {
 		src/test/run-make-fulldeps \
 		src/test/ui \
 		src/test/ui-fulldeps || die
+	unset IFS
 }
 
 src_install() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) DESTDIR="${D}" \
 		"${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml || die
+	unset IFS
 
 	# bug #689562, #689160
 	rm "${D}/etc/bash_completion.d/cargo" || die

--- a/dev-lang/rust/rust-1.44.1.ebuild
+++ b/dev-lang/rust/rust-1.44.1.ebuild
@@ -382,11 +382,14 @@ src_configure() {
 }
 
 src_compile() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) RUST_BACKTRACE=1\
 		"${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+	unset IFS
 }
 
 src_test() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) RUST_BACKTRACE=1\
 		"${EPYTHON}" ./x.py test -vv --config="${S}"/config.toml -j$(makeopts_jobs) --no-doc --no-fail-fast \
 		src/test/codegen \
@@ -400,11 +403,14 @@ src_test() {
 		src/test/run-make-fulldeps \
 		src/test/ui \
 		src/test/ui-fulldeps || die
+	unset IFS
 }
 
 src_install() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) DESTDIR="${D}" \
 		"${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml || die
+	unset IFS
 
 	# bug #689562, #689160
 	rm "${D}/etc/bash_completion.d/cargo" || die

--- a/dev-lang/rust/rust-1.45.0.ebuild
+++ b/dev-lang/rust/rust-1.45.0.ebuild
@@ -383,11 +383,14 @@ src_configure() {
 }
 
 src_compile() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) RUST_BACKTRACE=1\
 		"${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+	unset IFS
 }
 
 src_test() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) RUST_BACKTRACE=1\
 		"${EPYTHON}" ./x.py test -vv --config="${S}"/config.toml -j$(makeopts_jobs) --no-doc --no-fail-fast \
 		src/test/codegen \
@@ -401,11 +404,14 @@ src_test() {
 		src/test/run-make-fulldeps \
 		src/test/ui \
 		src/test/ui-fulldeps || die
+	unset IFS
 }
 
 src_install() {
+	IFS=$'\n'
 	env $(cat "${S}"/config.env) DESTDIR="${D}" \
 		"${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml || die
+	unset IFS
 
 	# bug #689562, #689160
 	rm "${D}/etc/bash_completion.d/cargo" || die


### PR DESCRIPTION
This fixes this gentoo bug: https://bugs.gentoo.org/734018 .

This sets IFS to newline, so spaces in config.env are not separated.