### PR TITLE
dev-util/ply: remove x86 keyword

### DIFF
--- a/dev-util/ply/ply-2.1.1-r1.ebuild
+++ b/dev-util/ply/ply-2.1.1-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/iovisor/ply/archive/${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~ppc ~x86"
+KEYWORDS="amd64 arm arm64 ~ppc"
 IUSE="static-libs"
 # Bug 733248 file collisions with sys-boot/plymouth:
 # /usr/lib64/libply.la


### PR DESCRIPTION
x86 is currently not suported. For more information see https://github.com/iovisor/ply/issues/49

Closes: https://bugs.gentoo.org/733318
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>