### PR TITLE
app-arch/zip: fix bashism in zip-3.0-pic.patch

### DIFF
--- a/app-arch/zip/files/zip-3.0-pic.patch
+++ b/app-arch/zip/files/zip-3.0-pic.patch
@@ -9,7 +9,7 @@ assembly files as none of it is PIC friendly.
  OCRCU8=""
 +piclib="$(echo | $CPP -dM $CFLAGS - | grep -i __pic__)"
 +echo "Checking if compiler wants to create pic code"
-+[ "$piclib" == "" ] && \
++[ "$piclib" = "" ] && \
  if eval "$CPP match.S > _match.s 2>/dev/null"; then
    if test ! -s _match.s || grep error < _match.s > /dev/null; then
      :


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/723084
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>