### PR TITLE
Fuse ZX Spectrum emulator packages: avoid /usr/lib in the link command line

### DIFF
--- a/app-emulation/fuse-utils/files/remove-local-prefix.patch
+++ b/app-emulation/fuse-utils/files/remove-local-prefix.patch
@@ -1,0 +1,22 @@
+diff -Naur fuse-utils-1.4.3/configure.ac fuse-utils-1.4.3-patched/configure.ac
+--- fuse-utils-1.4.3/configure.ac	2018-07-01 02:09:55.000000000 +0200
++++ fuse-utils-1.4.3-patched/configure.ac	2020-07-28 17:02:05.287721692 +0200
+@@ -92,18 +92,6 @@
+   )
+ fi
+ 
+-dnl Allow the user to say that various libraries are in one place
+-AC_ARG_WITH(local-prefix,
+-[  --with-local-prefix=PFX local libraries installed in PFX (optional)],
+-CPPFLAGS="$CPPFLAGS -I$withval/include";
+-CXXFLAGS="$CXXFLAGS -I$withval/include";
+-LDFLAGS="$LDFLAGS -L$withval/lib",
+-if test "$prefix" != "NONE"; then
+-  CPPFLAGS="$CPPFLAGS -I$prefix/include";
+-  CXXFLAGS="$CXXFLAGS -I$prefix/include";
+-  LDFLAGS="$LDFLAGS -L$prefix/lib"
+-fi)
+-
+ dnl Check if libjpeg is available and supports jpeg_write_scanlines
+ AC_MSG_CHECKING(whether to use libjpeg)
+ AC_ARG_WITH(libjpeg,

--- a/app-emulation/fuse-utils/fuse-utils-1.4.3.ebuild
+++ b/app-emulation/fuse-utils/fuse-utils-1.4.3.ebuild
@@ -1,7 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
+
+inherit autotools
 
 DESCRIPTION="Utils for the Free Unix Spectrum Emulator by Philip Kendall"
 HOMEPAGE="http://fuse-emulator.sourceforge.net"
@@ -19,6 +21,15 @@ RDEPEND=">=app-emulation/libspectrum-1.4.4[gcrypt?,zlib?]
 	zlib? ( sys-libs/zlib )"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/remove-local-prefix.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	local myconf=(

--- a/app-emulation/fuse/files/remove-local-prefix.patch
+++ b/app-emulation/fuse/files/remove-local-prefix.patch
@@ -1,0 +1,18 @@
+diff -Naur fuse-1.5.7/configure.ac fuse-1.5.7-patched/configure.ac
+--- fuse-1.5.7/configure.ac	2018-12-09 13:06:11.000000000 +0100
++++ fuse-1.5.7-patched/configure.ac	2020-07-28 17:02:33.678546857 +0200
+@@ -110,14 +110,6 @@
+   AX_STRINGS_STRCASECMP
+ fi
+ 
+-dnl Allow the user to say that various libraries are in one place
+-AC_ARG_WITH(local-prefix,
+-[  --with-local-prefix=PFX local libraries installed in PFX (optional)],
+-CPPFLAGS="$CPPFLAGS -I$withval/include"; LDFLAGS="$LDFLAGS -L$withval/lib",
+-if test "$prefix" != "NONE"; then
+-  CPPFLAGS="$CPPFLAGS -I$prefix/include"; LDFLAGS="$LDFLAGS -L$prefix/lib"
+-fi)
+-
+ dnl Check that libspectrum is available and that it is new enough
+ PKG_CHECK_MODULES([LIBSPECTRUM], [libspectrum >= 1.4.0])
+ 

--- a/app-emulation/fuse/fuse-1.5.6.ebuild
+++ b/app-emulation/fuse/fuse-1.5.6.ebuild
@@ -1,7 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
+
+inherit autotools
 
 DESCRIPTION="Free Unix Spectrum Emulator by Philip Kendall"
 HOMEPAGE="http://fuse-emulator.sourceforge.net"
@@ -34,6 +36,15 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
 DOCS=( AUTHORS ChangeLog README THANKS )
+
+PATCHES=(
+	"${FILESDIR}"/remove-local-prefix.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	local myconf=(

--- a/app-emulation/fuse/fuse-1.5.7.ebuild
+++ b/app-emulation/fuse/fuse-1.5.7.ebuild
@@ -1,7 +1,9 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
+
+inherit autotools
 
 DESCRIPTION="Free Unix Spectrum Emulator by Philip Kendall"
 HOMEPAGE="http://fuse-emulator.sourceforge.net"
@@ -34,6 +36,15 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
 DOCS=( AUTHORS ChangeLog README THANKS )
+
+PATCHES=(
+	"${FILESDIR}"/remove-local-prefix.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	local myconf=(

--- a/app-emulation/libspectrum/files/remove-local-prefix.patch
+++ b/app-emulation/libspectrum/files/remove-local-prefix.patch
@@ -1,0 +1,18 @@
+diff -Naur libspectrum-1.4.4/configure.ac libspectrum-1.4.4-patched/configure.ac
+--- libspectrum-1.4.4/configure.ac	2018-07-01 02:07:44.000000000 +0200
++++ libspectrum-1.4.4-patched/configure.ac	2020-07-28 16:38:22.636459194 +0200
+@@ -113,14 +113,6 @@
+ dnl Check for functions
+ AC_CHECK_FUNCS(_snprintf _stricmp _strnicmp snprintf strcasecmp strncasecmp)
+ 
+-dnl Allow the user to say that various libraries are in one place
+-AC_ARG_WITH(local-prefix,
+-[  --with-local-prefix=PFX local libraries installed in PFX (optional)],
+-CPPFLAGS="$CPPFLAGS -I$withval/include"; LDFLAGS="$LDFLAGS -L$withval/lib",
+-if test "$prefix" != "NONE"; then
+-  CPPFLAGS="$CPPFLAGS -I$prefix/include"; LDFLAGS="$LDFLAGS -L$prefix/lib"
+-fi)
+-
+ dnl Check whether to use zlib (the UNIX version is called z, Win32 zdll)
+ AC_MSG_CHECKING(whether to use zlib)
+ AC_ARG_WITH(zlib,

--- a/app-emulation/libspectrum/libspectrum-1.4.4.ebuild
+++ b/app-emulation/libspectrum/libspectrum-1.4.4.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=6
 
+inherit autotools
+
 DESCRIPTION="Spectrum emulation library"
 HOMEPAGE="http://fuse-emulator.sourceforge.net/libspectrum.php"
 SRC_URI="mirror://sourceforge/fuse-emulator/${P}.tar.gz"
@@ -20,6 +22,15 @@ RDEPEND="dev-libs/glib:2
 DEPEND="${RDEPEND}
 	dev-lang/perl
 	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/remove-local-prefix.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	local myconf=(


### PR DESCRIPTION
Hello. Please merge these 3 patches closing the following 3 bugs:

https://bugs.gentoo.org/734182
https://bugs.gentoo.org/734184
https://bugs.gentoo.org/734210