### PR TITLE
dev-python/ordered-set: minor test fix

### DIFF
--- a/dev-python/ordered-set/ordered-set-4.0.1.ebuild
+++ b/dev-python/ordered-set/ordered-set-4.0.1.ebuild
@@ -16,7 +16,3 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 distutils_enable_tests pytest
-
-python_test() {
-	pytest -vv test.py || die "Tests fail with ${EPYTHON}"
-}


### PR DESCRIPTION
Drop python_test function because it is not needed anymore: tests are
run normally with distutils_enable_tests

Package-Manager: Portage-2.3.103, Repoman-2.3.22
Signed-off-by: David Denoncin <ddenoncin@gmail.com>