### PR TITLE
www-server/tomcat: fix missing dependencies in classpath

### DIFF
--- a/www-servers/tomcat/tomcat-7.0.105-r1.ebuild
+++ b/www-servers/tomcat/tomcat-7.0.105-r1.ebuild
@@ -1,0 +1,146 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source test"
+
+inherit eutils java-pkg-2 java-ant-2 prefix user
+
+MY_P="apache-${P}-src"
+
+DESCRIPTION="Tomcat Servlet-3.0/JSP-2.2 Container"
+HOMEPAGE="https://tomcat.apache.org/"
+SRC_URI="mirror://apache/${PN}/tomcat-7/v${PV}/src/${MY_P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="7"
+KEYWORDS="~amd64 ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="extra-webapps websockets"
+
+RESTRICT="test" # can we run them on a production system?
+
+ECJ_SLOT="4.5"
+SAPI_SLOT="3.0"
+
+COMMON_DEP="dev-java/eclipse-ecj:${ECJ_SLOT}
+	~dev-java/tomcat-servlet-api-${PV}:${SAPI_SLOT}"
+RDEPEND="${COMMON_DEP}
+	virtual/jre"
+DEPEND="${COMMON_DEP}
+	virtual/jdk:1.8
+	test? ( dev-java/ant-junit:0 )"
+
+S=${WORKDIR}/${MY_P}
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+	enewgroup tomcat 265
+	enewuser tomcat 265 -1 /dev/null tomcat
+}
+
+src_prepare() {
+	default
+
+	# Remove bundled servlet-api
+	rm -rv java/javax/{el,servlet} || die
+
+	java-pkg_clean
+
+	eapply "${FILESDIR}/${PN}-7.0.99-build.xml.patch"
+
+	# For use of catalina.sh in netbeans
+	sed -i -e "/^# ----- Execute The Requested Command/ a\
+		CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
+		bin/catalina.sh || die
+
+	java-pkg-2_src_prepare
+}
+
+JAVA_ANT_REWRITE_CLASSPATH="true"
+
+EANT_BUILD_TARGET="deploy"
+EANT_GENTOO_CLASSPATH="eclipse-ecj-${ECJ_SLOT},tomcat-servlet-api-${SAPI_SLOT}"
+EANT_GENTOO_CLASSPATH_EXTRA="${S}/output/classes"
+EANT_NEEDS_TOOLS="true"
+EANT_EXTRA_ARGS="-Dversion=${PV}-gentoo -Dversion.number=${PV} -Dcompile.debug=false"
+
+# revisions of the scripts
+IM_REV="-r1"
+INIT_REV="-r1"
+
+src_compile() {
+	use websockets && EANT_EXTRA_ARGS+=" -Djava.7.home=${JAVA_HOME}"
+	EANT_GENTOO_CLASSPATH_EXTRA+=":$(java-pkg_getjar --build-only ant-core ant.jar)"
+	java-pkg-2_src_compile
+}
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	local dest="/usr/share/${PN}-${SLOT}"
+
+	java-pkg_jarinto "${dest}"/bin
+	java-pkg_dojar output/build/bin/*.jar
+	exeinto "${dest}"/bin
+	doexe output/build/bin/*.sh
+
+	java-pkg_jarinto "${dest}"/lib
+	java-pkg_dojar output/build/lib/*.jar
+
+	dodoc RELEASE-NOTES RUNNING.txt
+	use doc && java-pkg_dojavadoc output/dist/webapps/docs/api
+	use source && java-pkg_dosrc java/*
+
+	### Webapps ###
+
+	insinto "${dest}"/webapps
+	doins -r output/build/webapps/{host-manager,manager,ROOT}
+	use extra-webapps && doins -r output/build/webapps/{docs,examples}
+
+	### Config ###
+
+	# create "logs" directory in $CATALINA_BASE
+	# and set correct perms, see #458890
+	dodir "${dest}"/logs
+	fperms 0750 "${dest}"/logs
+
+	# replace the default pw with a random one, see #92281
+	local randpw=$(echo ${RANDOM}|md5sum|cut -c 1-15)
+	sed -i -e "s|SHUTDOWN|${randpw}|" output/build/conf/server.xml || die
+
+	# prepend gentoo.classpath to common.loader, see #453212
+	sed -i -e 's/^common\.loader=/\0${gentoo.classpath},/' output/build/conf/catalina.properties || die
+
+	insinto "${dest}"
+	doins -r output/build/conf
+
+	### rc ###
+
+	cp "${FILESDIR}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} "${T}" || die
+	eprefixify "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash}
+	sed -i -e "s|@SLOT@|${SLOT}|g" "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} || die
+
+	insinto "${dest}"/gentoo
+	doins "${T}"/tomcat.conf
+	exeinto "${dest}"/gentoo
+	newexe "${T}"/tomcat${INIT_REV}.init tomcat.init
+	newexe "${T}"/tomcat-instance-manager${IM_REV}.bash tomcat-instance-manager.bash
+}
+
+pkg_postinst() {
+	elog "New ebuilds of Tomcat support running multiple instances. If you used prior version"
+	elog "of Tomcat (<7.0.32), you have to migrate your existing instance to work with new Tomcat."
+	elog "You can find more information at https://wiki.gentoo.org/wiki/Apache_Tomcat"
+
+	elog "To manage Tomcat instances, run:"
+	elog "  ${EPREFIX}/usr/share/${PN}-${SLOT}/gentoo/tomcat-instance-manager.bash --help"
+
+	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
+	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
+
+	einfo "Please read https://wiki.gentoo.org/wiki/Apache_Tomcat and"
+	einfo "https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
+}

--- a/www-servers/tomcat/tomcat-8.5.57-r1.ebuild
+++ b/www-servers/tomcat/tomcat-8.5.57-r1.ebuild
@@ -1,0 +1,163 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source test"
+
+inherit eutils java-pkg-2 java-ant-2 prefix user
+
+MY_P="apache-${P}-src"
+
+DESCRIPTION="Tomcat Servlet-3.1/JSP-2.3/EL-3.0/WebSocket-1.1/JASPIC-1.1 Container"
+HOMEPAGE="https://tomcat.apache.org/"
+SRC_URI="mirror://apache/${PN}/tomcat-8/v${PV}/src/${MY_P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="8.5"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="extra-webapps"
+
+RESTRICT="test" # can we run them on a production system?
+
+ECJ_SLOT="4.5"
+SAPI_SLOT="3.1"
+
+COMMON_DEP="dev-java/eclipse-ecj:${ECJ_SLOT}
+	~dev-java/tomcat-servlet-api-${PV}:${SAPI_SLOT}"
+RDEPEND="${COMMON_DEP}
+	virtual/jre"
+DEPEND="${COMMON_DEP}
+	app-admin/pwgen
+	>=dev-java/ant-core-1.9.13
+	virtual/jdk:1.8
+	doc? (
+		dev-java/glassfish-xmlrpc-api:0
+		dev-java/wsdl4j:0
+	)
+	test? (
+		>=dev-java/ant-junit-1.9:0
+		dev-java/easymock:3.2
+	)"
+
+S=${WORKDIR}/${MY_P}
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+	enewgroup tomcat 265
+	enewuser tomcat 265 -1 /dev/null tomcat
+}
+
+src_prepare() {
+	default
+
+	find -name '*.jar' -type f -delete -print || die
+
+	# Remove bundled servlet-api
+	rm -rv java/javax/{el,servlet} || die
+
+	eapply "${FILESDIR}/${P}-build.xml.patch"
+
+	# For use of catalina.sh in netbeans
+	sed -i -e "/^# ----- Execute The Requested Command/ a\
+		CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
+		bin/catalina.sh || die
+
+	java-pkg-2_src_prepare
+}
+
+JAVA_ANT_REWRITE_CLASSPATH="true"
+
+EANT_BUILD_TARGET="deploy"
+EANT_GENTOO_CLASSPATH="eclipse-ecj-${ECJ_SLOT},tomcat-servlet-api-${SAPI_SLOT}"
+EANT_TEST_GENTOO_CLASSPATH="easymock-3.2"
+EANT_GENTOO_CLASSPATH_EXTRA="${S}/output/classes"
+EANT_NEEDS_TOOLS="true"
+EANT_EXTRA_ARGS="-Dversion=${PV}-gentoo -Dversion.number=${PV} -Dcompile.debug=false -Dexecute.validate=false"
+
+# revisions of the scripts
+IM_REV="-r2"
+INIT_REV="-r1"
+
+src_compile() {
+	EANT_GENTOO_CLASSPATH_EXTRA+=":$(java-pkg_getjar --build-only ant-core ant.jar)"
+	use doc && EANT_GENTOO_CLASSPATH_EXTRA+=":$(java-pkg_getjar --build-only glassfish-xmlrpc-api glassfish-xmlrpc-api.jar):$(java-pkg_getjar --build-only wsdl4j wsdl4j.jar)"
+	java-pkg-2_src_compile
+}
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	local dest="/usr/share/${PN}-${SLOT}"
+
+	java-pkg_jarinto "${dest}"/bin
+	java-pkg_dojar output/build/bin/*.jar
+	exeinto "${dest}"/bin
+	doexe output/build/bin/*.sh
+
+	java-pkg_jarinto "${dest}"/lib
+	java-pkg_dojar output/build/lib/*.jar
+
+	dodoc RELEASE-NOTES RUNNING.txt
+	use doc && java-pkg_dojavadoc output/dist/webapps/docs/api
+	use source && java-pkg_dosrc java/*
+
+	### Webapps ###
+
+	# add missing docBase
+	local apps="host-manager manager"
+	for app in ${apps}; do
+		sed -i -e "s|=\"true\" >|=\"true\" docBase=\"\$\{catalina.home\}/webapps/${app}\" >|" \
+			output/build/webapps/${app}/META-INF/context.xml || die
+	done
+
+	insinto "${dest}"/webapps
+	doins -r output/build/webapps/{host-manager,manager,ROOT}
+	use extra-webapps && doins -r output/build/webapps/{docs,examples}
+
+	### Config ###
+
+	# create "logs" directory in $CATALINA_BASE
+	# and set correct perms, see #458890
+	dodir "${dest}"/logs
+	fperms 0750 "${dest}"/logs
+
+	# replace the default pw with a random one, see #92281
+	local randpw="$(pwgen -s -B 15 1)"
+	sed -i -e "s|SHUTDOWN|${randpw}|" output/build/conf/server.xml || die
+
+	# prepend gentoo.classpath to common.loader, see #453212
+	sed -i -e 's/^common\.loader=/\0${gentoo.classpath},/' output/build/conf/catalina.properties || die
+
+	insinto "${dest}"
+	doins -r output/build/conf
+
+	### rc ###
+
+	cp "${FILESDIR}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} "${T}" || die
+	eprefixify "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash}
+	sed -i -e "s|@SLOT@|${SLOT}|g" "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} || die
+
+	insinto "${dest}"/gentoo
+	doins "${T}"/tomcat.conf
+	exeinto "${dest}"/gentoo
+	newexe "${T}"/tomcat${INIT_REV}.init tomcat.init
+	newexe "${T}"/tomcat-instance-manager${IM_REV}.bash tomcat-instance-manager.bash
+}
+
+pkg_postinst() {
+	elog "New ebuilds of Tomcat support running multiple instances. If you used prior version"
+	elog "of Tomcat (<7.0.32), you have to migrate your existing instance to work with new Tomcat."
+	elog "You can find more information at https://wiki.gentoo.org/wiki/Apache_Tomcat"
+
+	elog "To manage Tomcat instances, run:"
+	elog "  ${EPREFIX}/usr/share/${PN}-${SLOT}/gentoo/tomcat-instance-manager.bash --help"
+
+	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
+	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
+
+	einfo "Please read https://wiki.gentoo.org/wiki/Apache_Tomcat and"
+	einfo "https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
+}

--- a/www-servers/tomcat/tomcat-9.0.37-r1.ebuild
+++ b/www-servers/tomcat/tomcat-9.0.37-r1.ebuild
@@ -1,0 +1,187 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source test"
+
+inherit eutils java-pkg-2 java-ant-2 prefix user
+
+MY_P="apache-${PN}-${PV}-src"
+
+# Currently we bundle binary versions of bnd.jar and bndlib.jar
+# See bugs #203080 and #676116
+BND_VERSION="5.1.1"
+BND="biz.aQute.bnd-${BND_VERSION}.jar"
+BNDLIB="biz.aQute.bndlib-${BND_VERSION}.jar"
+
+DESCRIPTION="Tomcat Servlet-4.0/JSP-2.4?/EL-3.1?/WebSocket-1.2?/JASPIC-1.1 Container"
+HOMEPAGE="https://tomcat.apache.org/"
+SRC_URI="mirror://apache/${PN}/tomcat-9/v${PV}/src/${MY_P}.tar.gz
+	https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bnd/${BND_VERSION}/${BND}
+	https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/${BND_VERSION}/${BNDLIB}"
+
+LICENSE="Apache-2.0"
+SLOT="9"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="extra-webapps"
+
+RESTRICT="test" # can we run them on a production system?
+
+ECJ_SLOT="4.13"
+SAPI_SLOT="4.0"
+
+COMMON_DEP="dev-java/eclipse-ecj:${ECJ_SLOT}
+	dev-java/glassfish-xmlrpc-api:0
+	~dev-java/tomcat-servlet-api-${PV}:${SAPI_SLOT}
+	dev-java/wsdl4j:0"
+RDEPEND="${COMMON_DEP}
+	virtual/jre"
+DEPEND="${COMMON_DEP}
+	app-admin/pwgen
+	>=dev-java/ant-core-1.9.13
+	virtual/jdk:1.8
+	test? (
+		>=dev-java/ant-junit-1.9:0
+		dev-java/easymock:3.2
+	)"
+
+S=${WORKDIR}/${MY_P}
+
+BND_HOME="${S}/tomcat-build-libs/bnd"
+BNDLIB_HOME="${S}/tomcat-build-libs/bndlib"
+BND_JAR="${BND_HOME}/${BND}"
+BNDLIB_JAR="${BNDLIB_HOME}/${BND_LIB}"
+
+src_unpack() {
+	unpack ${MY_P}.tar.gz
+
+	mkdir -p "${BND_HOME}" "${BNDLIB_HOME}" || die "Failed to create dir"
+	ln -s "${DISTDIR}/${BND}" "${BND_HOME}/" || die "Failed to symlink bnd-*.jar"
+	ln -s "${DISTDIR}/${BND}" "${BNDLIB_HOME}/" || die "Failed to symlink bndlib-*.jar"
+}
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+	enewgroup tomcat 265
+	enewuser tomcat 265 -1 /dev/null tomcat
+}
+
+src_prepare() {
+	default
+
+	find -name '*.jar' -type f -delete -print || die
+
+	# Remove bundled servlet-api
+	rm -rv java/javax/{el,servlet} || die
+
+	eapply "${FILESDIR}/${P}-build.xml.patch"
+
+	# For use of catalina.sh in netbeans
+	sed -i -e "/^# ----- Execute The Requested Command/ a\
+		CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
+		bin/catalina.sh || die
+
+	java-pkg-2_src_prepare
+}
+
+JAVA_ANT_REWRITE_CLASSPATH="true"
+
+EANT_BUILD_TARGET="deploy"
+EANT_GENTOO_CLASSPATH="eclipse-ecj-${ECJ_SLOT},tomcat-servlet-api-${SAPI_SLOT},glassfish-xmlrpc-api,wsdl4j"
+EANT_TEST_GENTOO_CLASSPATH="easymock-3.2"
+EANT_GENTOO_CLASSPATH_EXTRA="${S}/output/classes"
+EANT_NEEDS_TOOLS="true"
+EANT_EXTRA_ARGS="-Dversion=${PV}-gentoo -Dversion.number=${PV} -Dcompile.debug=false -Dbnd.jar=${BND_JAR} -Dbndlib.jar=${BNDLIB_JAR}"
+
+# revisions of the scripts
+IM_REV="-r2"
+INIT_REV="-r1"
+
+src_configure() {
+	java-ant-2_src_configure
+
+	eapply "${FILESDIR}/${P}-fix-build-rewrite.patch"
+}
+
+src_compile() {
+	EANT_GENTOO_CLASSPATH_EXTRA+=":$(java-pkg_getjar --build-only ant-core ant.jar)"
+	java-pkg-2_src_compile
+}
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	local dest="/usr/share/${PN}-${SLOT}"
+
+	java-pkg_jarinto "${dest}"/bin
+	java-pkg_dojar output/build/bin/*.jar
+	exeinto "${dest}"/bin
+	doexe output/build/bin/*.sh
+
+	java-pkg_jarinto "${dest}"/lib
+	java-pkg_dojar output/build/lib/*.jar
+
+	dodoc RELEASE-NOTES RUNNING.txt
+	use doc && java-pkg_dojavadoc output/dist/webapps/docs/api
+	use source && java-pkg_dosrc java/*
+
+	### Webapps ###
+
+	# add missing docBase
+	local apps="host-manager manager"
+	for app in ${apps}; do
+		sed -i -e "s|=\"true\" >|=\"true\" docBase=\"\$\{catalina.home\}/webapps/${app}\" >|" \
+			output/build/webapps/${app}/META-INF/context.xml || die
+	done
+
+	insinto "${dest}"/webapps
+	doins -r output/build/webapps/{host-manager,manager,ROOT}
+	use extra-webapps && doins -r output/build/webapps/{docs,examples}
+
+	### Config ###
+
+	# create "logs" directory in $CATALINA_BASE
+	# and set correct perms, see #458890
+	dodir "${dest}"/logs
+	fperms 0750 "${dest}"/logs
+
+	# replace the default pw with a random one, see #92281
+	local randpw="$(pwgen -s -B 15 1)"
+	sed -i -e "s|SHUTDOWN|${randpw}|" output/build/conf/server.xml || die
+
+	# prepend gentoo.classpath to common.loader, see #453212
+	sed -i -e 's/^common\.loader=/\0${gentoo.classpath},/' output/build/conf/catalina.properties || die
+
+	insinto "${dest}"
+	doins -r output/build/conf
+
+	### rc ###
+
+	cp "${FILESDIR}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} "${T}" || die
+	eprefixify "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash}
+	sed -i -e "s|@SLOT@|${SLOT}|g" "${T}"/tomcat{.conf,${INIT_REV}.init,-instance-manager${IM_REV}.bash} || die
+
+	insinto "${dest}"/gentoo
+	doins "${T}"/tomcat.conf
+	exeinto "${dest}"/gentoo
+	newexe "${T}"/tomcat${INIT_REV}.init tomcat.init
+	newexe "${T}"/tomcat-instance-manager${IM_REV}.bash tomcat-instance-manager.bash
+}
+
+pkg_postinst() {
+	elog "New ebuilds of Tomcat support running multiple instances. If you used prior version"
+	elog "of Tomcat (<7.0.32), you have to migrate your existing instance to work with new Tomcat."
+	elog "You can find more information at https://wiki.gentoo.org/wiki/Apache_Tomcat"
+
+	elog "To manage Tomcat instances, run:"
+	elog "  ${EPREFIX}/usr/share/${PN}-${SLOT}/gentoo/tomcat-instance-manager.bash --help"
+
+	ewarn "tomcat-dbcp.jar is not built at this time. Please fetch jar"
+	ewarn "from upstream binary if you need it. Gentoo Bug # 144276"
+
+	einfo "Please read https://wiki.gentoo.org/wiki/Apache_Tomcat and"
+	einfo "https://wiki.gentoo.org/wiki/Project:Java/Tomcat_6_Guide for more information."
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/734948

Diffs to previous versions:

```
$ diff -Naur tomcat-7.0.105.ebuild tomcat-7.0.105-r1.ebuild 
--- tomcat-7.0.105.ebuild       2020-07-31 19:28:02.081979861 +0200
+++ tomcat-7.0.105-r1.ebuild    2020-07-31 19:35:21.927955532 +0200
@@ -15,7 +15,7 @@
 
 LICENSE="Apache-2.0"
 SLOT="7"
-KEYWORDS="amd64 ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="~amd64 ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
 IUSE="extra-webapps websockets"
 
 RESTRICT="test" # can we run them on a production system?
@@ -51,7 +51,7 @@
 
        # For use of catalina.sh in netbeans
        sed -i -e "/^# ----- Execute The Requested Command/ a\
-               CLASSPATH=\`java-config --classpath ${PN}-${SLOT}\`" \
+               CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
                bin/catalina.sh || die
 
        java-pkg-2_src_prepare

$ diff -Naur tomcat-8.5.57.ebuild tomcat-8.5.57-r1.ebuild 
--- tomcat-8.5.57.ebuild        2020-07-31 19:28:08.257979520 +0200
+++ tomcat-8.5.57-r1.ebuild     2020-07-31 19:35:21.927955532 +0200
@@ -15,7 +15,7 @@
 
 LICENSE="Apache-2.0"
 SLOT="8.5"
-KEYWORDS="amd64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
 IUSE="extra-webapps"
 
 RESTRICT="test" # can we run them on a production system?
@@ -60,7 +60,7 @@
 
        # For use of catalina.sh in netbeans
        sed -i -e "/^# ----- Execute The Requested Command/ a\
-               CLASSPATH=\`java-config --classpath ${PN}-${SLOT}\`" \
+               CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
                bin/catalina.sh || die
 
        java-pkg-2_src_prepare

diff -Naur tomcat-9.0.37.ebuild tomcat-9.0.37-r1.ebuild 
--- tomcat-9.0.37.ebuild        2020-07-31 19:28:15.215979135 +0200
+++ tomcat-9.0.37-r1.ebuild     2020-07-31 19:35:21.927955532 +0200
@@ -79,7 +79,7 @@
 
        # For use of catalina.sh in netbeans
        sed -i -e "/^# ----- Execute The Requested Command/ a\
-               CLASSPATH=\`java-config --classpath ${PN}-${SLOT}\`" \
+               CLASSPATH=\`java-config --with-dependencies --classpath ${PN}-${SLOT}\`" \
                bin/catalina.sh || die
 
        java-pkg-2_src_prepare
```