### PR TITLE
dev-libs/hyphen: moving dev-libs/perl to BDEPEND

### DIFF
--- a/dev-libs/hyphen/hyphen-2.8.8-r1.ebuild
+++ b/dev-libs/hyphen/hyphen-2.8.8-r1.ebuild
@@ -12,10 +12,9 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="static-libs"
 
-RDEPEND="app-text/hunspell"
-DEPEND="${RDEPEND}
-	dev-lang/perl
-"
+DEPEND="app-text/hunspell"
+RDEPEND="${DEPEND}"
+BDEPEND="dev-lang/perl"
 
 DOCS=( AUTHORS ChangeLog NEWS README{,.nonstandard,.hyphen,.compound} THANKS TODO )
 


### PR DESCRIPTION
Can I overwrite the stable build like this or should I create a new release?

Closes: https://bugs.gentoo.org/708258
Package-Manager: Portage-3.0.1, Repoman-2.3.23
Signed-off-by: Henrik Pihl <ahvenas@gmail.com>
