### PR TITLE
net-p2p/qbittorrent: remove qtsingleapplication from dependencies

### DIFF
--- a/net-p2p/qbittorrent/qbittorrent-4.2.1-r1.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-4.2.1-r1.ebuild
@@ -27,7 +27,6 @@ RDEPEND="
 	>=dev-libs/boost-1.62.0-r1:=
 	dev-qt/qtcore:5
 	dev-qt/qtnetwork:5[ssl]
-	>=dev-qt/qtsingleapplication-2.6.1_p20130904-r1[qt5(+),X?]
 	dev-qt/qtxml:5
 	>=net-libs/libtorrent-rasterbar-1.2.0:0=
 	sys-libs/zlib

--- a/net-p2p/qbittorrent/qbittorrent-4.2.3-r1.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-4.2.3-r1.ebuild
@@ -27,7 +27,6 @@ RDEPEND="
 	>=dev-libs/boost-1.62.0-r1:=
 	dev-qt/qtcore:5
 	dev-qt/qtnetwork:5[ssl]
-	>=dev-qt/qtsingleapplication-2.6.1_p20130904-r1[qt5(+),X?]
 	dev-qt/qtxml:5
 	>=net-libs/libtorrent-rasterbar-1.2.0:0=
 	sys-libs/zlib

--- a/net-p2p/qbittorrent/qbittorrent-4.2.5-r1.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-4.2.5-r1.ebuild
@@ -27,7 +27,6 @@ RDEPEND="
 	>=dev-libs/boost-1.62.0-r1:=
 	dev-qt/qtcore:5
 	dev-qt/qtnetwork:5[ssl]
-	>=dev-qt/qtsingleapplication-2.6.1_p20130904-r1[qt5(+),X?]
 	dev-qt/qtxml:5
 	>=net-libs/libtorrent-rasterbar-1.2.0:0=
 	sys-libs/zlib

--- a/net-p2p/qbittorrent/qbittorrent-9999-r1.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-9999-r1.ebuild
@@ -27,7 +27,6 @@ RDEPEND="
 	>=dev-libs/boost-1.62.0-r1:=
 	dev-qt/qtcore:5
 	dev-qt/qtnetwork:5[ssl]
-	>=dev-qt/qtsingleapplication-2.6.1_p20130904-r1[qt5(+),X?]
 	dev-qt/qtxml:5
 	>=net-libs/libtorrent-rasterbar-1.2.0:0=
 	sys-libs/zlib


### PR DESCRIPTION
qBittorrent does not require QtSingleApplication package.
It uses its own application instance manager.

Package-Manager: Portage-3.0.1, Repoman-2.3.23