### PR TITLE
sci-geosciences/gpsd: fixes for escons

### DIFF
--- a/sci-geosciences/qgis/qgis-3.16.2.ebuild
+++ b/sci-geosciences/qgis/qgis-3.16.2.ebuild
@@ -154,7 +154,7 @@ src_configure() {
 
 	if use grass; then
 		mycmakeargs+=(
-			-DGRASS_PREFIX7=/usr/$(get_libdir)/grass70
+			-DGRASS_PREFIX7=/usr/$(get_libdir)/grass78
 		)
 	fi
 

--- a/sci-geosciences/qgis/qgis-3.16.4.ebuild
+++ b/sci-geosciences/qgis/qgis-3.16.4.ebuild
@@ -154,7 +154,7 @@ src_configure() {
 
 	if use grass; then
 		mycmakeargs+=(
-			-DGRASS_PREFIX7=/usr/$(get_libdir)/grass70
+			-DGRASS_PREFIX7=/usr/$(get_libdir)/grass78
 		)
 	fi
 

--- a/sci-geosciences/qgis/qgis-9999.ebuild
+++ b/sci-geosciences/qgis/qgis-9999.ebuild
@@ -154,7 +154,7 @@ src_configure() {
 
 	if use grass; then
 		mycmakeargs+=(
-			-DGRASS_PREFIX7=/usr/$(get_libdir)/grass70
+			-DGRASS_PREFIX7=/usr/$(get_libdir)/grass78
 		)
 	fi
 


### PR DESCRIPTION
- renamed rdepend to depend
- (re)added rdepend
- called python_setup in src_prepare before "default" call
- fixed the name of systemd/gpsdctl@.service.in to systemd/gpsdctl@.service
- removed python_setup call in python_prepare_all with comment
- added more die