### PR TITLE
x11-drivers/xf86-video-fbdev: EAPI 7 upgrade

### DIFF
--- a/x11-drivers/xf86-video-fbdev/xf86-video-fbdev-0.5.0-r1.ebuild
+++ b/x11-drivers/xf86-video-fbdev/xf86-video-fbdev-0.5.0-r1.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit xorg-3
+
+DESCRIPTION="video driver for framebuffer device"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE=""
+
+DEPEND="x11-base/xorg-proto"
+RDEPEND="${DEPEND}
+	x11-base/xorg-server"
+
+DOCS=( README ChangeLog )
+
+src_install() {
+	einstalldocs
+	xorg-3_src_install
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/714580
Package-Manager: Portage-3.0.1, Repoman-2.3.23
Signed-off-by: Henrik Pihl <ahvenas@gmail.com>
