### PR TITLE
media-plugins/kodi-visualization-fishbmc: depends and licence fixes

### DIFF
--- a/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-5.1.2.ebuild
+++ b/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-5.1.2.ebuild
@@ -3,41 +3,43 @@
 
 EAPI=7
 
-inherit cmake kodi-addon
+inherit kodi-addon
 
 DESCRIPTION="Fische visualizer for Kodi"
-HOMEPAGE="https://github.com/notspiff/visualization.fishbmc"
-SRC_URI=""
+HOMEPAGE="https://github.com/xbmc/visualization.fishbmc"
+KODI_PLUGIN_NAME="visualization.fishbmc"
 
 case ${PV} in
 9999)
 	SRC_URI=""
-	EGIT_REPO_URI="https://github.com/notspiff/visualization.fishbmc.git"
+	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
+	DEPEND="~media-tv/kodi-9999"
 	;;
 *)
-	KEYWORDS="~amd64 ~x86"
 	CODENAME="Leia"
-	SRC_URI="https://github.com/notspiff/visualization.fishbmc/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
-	S="${WORKDIR}/visualization.fishbmc-${PV}-${CODENAME}"
+	KEYWORDS="~amd64 ~x86"
+	SRC_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/${KODI_PLUGIN_NAME}-${PV}-${CODENAME}"
+	DEPEND="=media-tv/kodi-18*:="
 	;;
 esac
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 IUSE=""
 
-DEPEND="
-	=media-tv/kodi-18*
+DEPEND+="
+	>=media-libs/glm-0.9.9.8-r1
 	virtual/opengl
-	media-libs/glm
 	"
 
-RDEPEND="
-	${DEPEND}
-	"
+RDEPEND="${DEPEND}"
+
+BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
-	[ -d depends ] && rm -rf depends || die
+	if [ -d depends ]; then rm -rf depends || die; fi
+
 	cmake_src_prepare
 }

--- a/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-6.1.0.ebuild
+++ b/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-6.1.0.ebuild
@@ -3,41 +3,43 @@
 
 EAPI=7
 
-inherit cmake kodi-addon
+inherit kodi-addon
 
 DESCRIPTION="Fische visualizer for Kodi"
 HOMEPAGE="https://github.com/xbmc/visualization.fishbmc"
-SRC_URI=""
+KODI_PLUGIN_NAME="visualization.fishbmc"
 
 case ${PV} in
 9999)
 	SRC_URI=""
-	EGIT_REPO_URI="https://github.com/xbmc/visualization.fishbmc.git"
+	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
+	DEPEND="~media-tv/kodi-9999"
 	;;
 *)
 	KEYWORDS="~amd64 ~x86"
 	CODENAME="Matrix"
-	SRC_URI="https://github.com/xbmc/visualization.fishbmc/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
-	S="${WORKDIR}/visualization.fishbmc-${PV}-${CODENAME}"
+	SRC_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/${KODI_PLUGIN_NAME}-${PV}-${CODENAME}"
+	DEPEND="=media-tv/kodi-19*:="
 	;;
 esac
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 IUSE=""
 
-DEPEND="
-	=media-tv/kodi-19*
+DEPEND+="
+	>=media-libs/glm-0.9.9.8-r1
 	virtual/opengl
-	media-libs/glm
 	"
 
-RDEPEND="
-	${DEPEND}
-	"
+RDEPEND="${DEPEND}"
+
+BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
-	[ -d depends ] && rm -rf depends || die
+	if [ -d depends ]; then rm -rf depends || die; fi
+
 	cmake_src_prepare
 }

--- a/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-9999.ebuild
+++ b/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-9999.ebuild
@@ -3,41 +3,43 @@
 
 EAPI=7
 
-inherit cmake kodi-addon
+inherit kodi-addon
 
 DESCRIPTION="Fische visualizer for Kodi"
 HOMEPAGE="https://github.com/xbmc/visualization.fishbmc"
-SRC_URI=""
+KODI_PLUGIN_NAME="visualization.fishbmc"
 
 case ${PV} in
 9999)
 	SRC_URI=""
-	EGIT_REPO_URI="https://github.com/xbmc/visualization.fishbmc.git"
+	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
+	DEPEND="~media-tv/kodi-9999"
 	;;
 *)
 	KEYWORDS="~amd64 ~x86"
 	CODENAME="Matrix"
-	SRC_URI="https://github.com/xbmc/visualization.fishbmc/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
-	S="${WORKDIR}/visualization.fishbmc-${PV}-${CODENAME}"
+	SRC_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/${KODI_PLUGIN_NAME}-${PV}-${CODENAME}"
+	DEPEND="=media-tv/kodi-19*:="
 	;;
 esac
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 IUSE=""
 
-DEPEND="
-	~media-tv/kodi-9999
+DEPEND+="
+	>=media-libs/glm-0.9.9.8-r1
 	virtual/opengl
-	media-libs/glm
 	"
 
-RDEPEND="
-	${DEPEND}
-	"
+RDEPEND="${DEPEND}"
+
+BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
-	[ -d depends ] && rm -rf depends || die
+	if [ -d depends ]; then rm -rf depends || die; fi
+
 	cmake_src_prepare
 }

--- a/media-plugins/kodi-visualization-fishbmc/metadata.xml
+++ b/media-plugins/kodi-visualization-fishbmc/metadata.xml
@@ -5,7 +5,6 @@
         <email>candrews@gentoo.org</email>
         <name>Craig Andrews</name>
     </maintainer>
-    <longdescription>Fische visualizer for Kodi</longdescription>
     <upstream>
         <remote-id type="github">notspiff/visualization.fishbmc</remote-id>
     </upstream>


### PR DESCRIPTION
Fixed depends, licence version