### PR TITLE
media-plugins/kodi-visualization-projectm: fixed deps, licence

### DIFF
--- a/media-plugins/kodi-visualization-projectm/kodi-visualization-projectm-2.3.5-r1.ebuild
+++ b/media-plugins/kodi-visualization-projectm/kodi-visualization-projectm-2.3.5-r1.ebuild
@@ -17,11 +17,11 @@ case ${PV} in
 	DEPEND="~media-tv/kodi-9999"
 	;;
 *)
-	CODENAME="Matrix"
+	CODENAME="Leia"
 	KEYWORDS="~amd64 ~x86"
 	SRC_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${KODI_PLUGIN_NAME}-${PV}-${CODENAME}"
-	DEPEND="=media-tv/kodi-19*:="
+	DEPEND="=media-tv/kodi-18*:="
 	;;
 esac
 


### PR DESCRIPTION
`GLM` library is not referenced in cmake and in source code.
`pkg-config` is required for cmake modules.