### PR TITLE
media-sound/aqualung: Fix compile with gcc 10

### DIFF
--- a/media-sound/aqualung/aqualung-1.0-r4.ebuild
+++ b/media-sound/aqualung/aqualung-1.0-r4.ebuild
@@ -1,0 +1,101 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop xdg
+
+MY_PV=${PV/_/-}
+
+DESCRIPTION="Music player for a wide range of formats designed for gapless playback"
+HOMEPAGE="http://aqualung.jeremyevans.net/ https://github.com/jeremyevans/aqualung"
+SRC_URI="mirror://sourceforge/aqualung/${PN}-${MY_PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="alsa cdda cddb debug flac ffmpeg ifp jack ladspa lame libsamplerate
+	lua mac modplug mp3 musepack oss podcast pulseaudio sndfile speex systray
+	vorbis wavpack"
+
+BDEPEND="
+	virtual/pkgconfig
+	sys-devel/gettext
+"
+RDEPEND="
+	app-arch/bzip2
+	dev-libs/libxml2
+	sys-libs/zlib
+	x11-libs/gtk+:2
+	alsa? ( media-libs/alsa-lib )
+	cdda? ( dev-libs/libcdio-paranoia )
+	cddb? ( media-libs/libcddb )
+	ffmpeg? ( media-video/ffmpeg:0= )
+	flac? ( media-libs/flac )
+	ifp? ( media-libs/libifp )
+	jack? ( virtual/jack )
+	ladspa? ( media-libs/liblrdf )
+	lame? ( media-sound/lame )
+	libsamplerate? ( media-libs/libsamplerate )
+	lua? ( dev-lang/lua:0= )
+	mac? ( media-sound/mac )
+	modplug? ( media-libs/libmodplug )
+	mp3? ( media-libs/libmad )
+	musepack? ( >=media-sound/musepack-tools-444 )
+	pulseaudio? ( media-sound/pulseaudio )
+	sndfile? ( media-libs/libsndfile )
+	speex? ( media-libs/speex media-libs/liboggz media-libs/libogg )
+	vorbis? ( media-libs/libvorbis media-libs/libogg )
+	wavpack? ( media-sound/wavpack )
+"
+DEPEND="
+	${RDEPEND}
+"
+
+S=${WORKDIR}/${PN}-${MY_PV}
+
+PATCHES=(
+	"${FILESDIR}/${P}-ffmpeg3.patch"
+	"${FILESDIR}/${P}-gcc10.patch"
+)
+
+src_configure() {
+	econf \
+		--disable-rpath \
+		--enable-loop \
+		--enable-nls \
+		--enable-transcoding \
+		$(use_enable debug) \
+		$(use_enable podcast) \
+		$(use_enable systray) \
+		$(use_enable jack jack-mgmt) \
+		$(use_with alsa) \
+		$(use_with cdda) \
+		$(use_with cddb) \
+		$(use_with ffmpeg lavc) \
+		$(use_with flac) \
+		$(use_with ifp) \
+		$(use_with jack) \
+		$(use_with ladspa) \
+		$(use_with lame) \
+		$(use_with libsamplerate src) \
+		$(use_with lua) \
+		$(use_with mac) \
+		$(use_with modplug mod) \
+		$(use_with mp3 mpeg) \
+		$(use_with musepack mpc) \
+		$(use_with oss) \
+		$(use_with pulseaudio pulse) \
+		$(use_with sndfile) \
+		$(use_with speex) \
+		$(use_with vorbis vorbis) \
+		$(use_with vorbis vorbisenc) \
+		$(use_with wavpack)
+}
+
+src_install() {
+	default
+
+	newicon src/img/icon_64.png aqualung.png
+	make_desktop_entry aqualung Aqualung
+}

--- a/media-sound/aqualung/files/aqualung-1.0-gcc10.patch
+++ b/media-sound/aqualung/files/aqualung-1.0-gcc10.patch
@@ -1,0 +1,69 @@
+From de448507343a86ee97949eb4be0092d1659092da Mon Sep 17 00:00:00 2001
+From: Adam Sampson <ats@offog.org>
+Date: Sat, 18 Jul 2020 17:02:32 +0100
+Subject: [PATCH 1/2] Remove unused variable.
+
+This causes a duplicate symbol error with GCC 10 (-fno-common by
+default), but it's not used anyway.
+---
+ src/playlist.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/playlist.c b/src/playlist.c
+index 35483d1..96fac75 100644
+--- a/src/playlist.c
++++ b/src/playlist.c
+@@ -134,8 +134,6 @@ GtkWidget * plist__send_songs_to_iriver;
+ GtkWidget * plist__export;
+ #endif /* HAVE_TRANSCODING */
+ 
+-gchar command[RB_CONTROL_SIZE];
+-
+ GtkTreeIter * fileinfo_iter = NULL;
+ 
+ int playlist_dirty;
+
+From 7f5d1f266957b3fa73799d3edef6b19ff9716d02 Mon Sep 17 00:00:00 2001
+From: Adam Sampson <ats@offog.org>
+Date: Sat, 18 Jul 2020 17:06:41 +0100
+Subject: [PATCH 2/2] Rename timeout_tag to ports_timeout_tag.
+
+This causes a duplicate symbol error with GCC 10 (-fno-common by
+default), because there's also a global timeout_tag in main.c.
+
+Also correct the type to guint rather than gint.
+---
+ src/ports.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/ports.c b/src/ports.c
+index f17a5ab..f4de59d 100644
+--- a/src/ports.c
++++ b/src/ports.c
+@@ -63,7 +63,7 @@ GtkTreeViewColumn * column_out_R;
+ int n_clients;
+ GtkListStore * store_out_nb[MAX_JACK_CLIENTS];
+ 
+-gint timeout_tag;
++guint ports_timeout_tag;
+ 
+ int out_selector = 0;
+ 
+@@ -242,7 +242,7 @@ tree_out_L_selection_changed(GtkTreeSelection * selection, gpointer * data) {
+ 			fprintf(stderr, "ERROR: jack_disconnect() returned %d\n", res);
+ 		}
+ 		g_free(str);
+-		timeout_tag = aqualung_timeout_add(100, ports_timeout_callback, GINT_TO_POINTER(1));
++		ports_timeout_tag = aqualung_timeout_add(100, ports_timeout_callback, GINT_TO_POINTER(1));
+         }
+ }
+ 
+@@ -262,7 +262,7 @@ tree_out_R_selection_changed(GtkTreeSelection *selection, gpointer * data) {
+ 			fprintf(stderr, "ERROR: jack_disconnect() returned %d\n", res);
+ 		}
+ 		g_free(str);
+-		timeout_tag = aqualung_timeout_add(100, ports_timeout_callback, (gpointer)2);
++		ports_timeout_tag = aqualung_timeout_add(100, ports_timeout_callback, (gpointer)2);
+         }
+ }
+ 


### PR DESCRIPTION
And make USE=jack depend on `virtual/jack` instead of `media-sound/jack-audio-connection-kit`.
Adding this as new revision so we have current `-r3` with stable keywords and this with unstable keywords.

Closes: https://bugs.gentoo.org/734928
Closes: https://bugs.gentoo.org/706828
Package-Manager: Portage-3.0.1, Repoman-2.3.23