### PR TITLE
python3_9 support for docopt, defusedxml, uritemplate

### DIFF
--- a/dev-python/defusedxml/defusedxml-0.6.0.ebuild
+++ b/dev-python/defusedxml/defusedxml-0.6.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{3_6,3_7,3_8} pypy3 )
+PYTHON_COMPAT=( python{3_6,3_7,3_8,3_9} pypy3 )
 PYTHON_REQ_USE="xml(+)"
 
 inherit distutils-r1

--- a/dev-python/docopt/docopt-0.6.2-r3.ebuild
+++ b/dev-python/docopt/docopt-0.6.2-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/uritemplate/uritemplate-3.0.1-r1.ebuild
+++ b/dev-python/uritemplate/uritemplate-3.0.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Adds python3_9 support for docopt, defusedxml, and uritemplate.

All tests are passing on amd64.

Supersedes: https://github.com/gentoo/gentoo/pull/16691