### PR TITLE
Ocaml-4.09 compat fixes

### DIFF
--- a/dev-ml/camomile/camomile-0.8.5-r2.ebuild
+++ b/dev-ml/camomile/camomile-0.8.5-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit findlib eutils
+
+DESCRIPTION="Camomile is a comprehensive Unicode library for ocaml"
+HOMEPAGE="https://github.com/yoriyuki/Camomile/wiki"
+SRC_URI="https://github.com/yoriyuki/Camomile/releases/download/rel-${PV}/${P}.tar.bz2"
+
+LICENSE="LGPL-2"
+SLOT="0/${PV}"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="debug +ocamlopt"
+
+PATCHES=( "${FILESDIR}"/ocaml-unsafe-string.patch )
+
+RDEPEND="
+	>=dev-lang/ocaml-3.10.2:=[ocamlopt?]
+	dev-ml/camlp4:=
+"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+
+	if has_version '>=dev-lang/ocaml-4.05_beta'; then
+		eapply "${FILESDIR}/ocaml405.patch"
+	fi
+}
+
+src_configure() {
+	econf $(use_enable debug)
+}
+
+src_compile() {
+	emake -j1 byte unidata unimaps charmap_data locale_data
+	if use ocamlopt; then
+		emake -j1 opt
+	fi
+}
+
+src_install() {
+	dodir /usr/bin
+	findlib_src_install DATADIR="${D}/usr/share" BINDIR="${D}/usr/bin"
+}

--- a/dev-ml/camomile/files/ocaml-unsafe-string.patch
+++ b/dev-ml/camomile/files/ocaml-unsafe-string.patch
@@ -1,0 +1,13 @@
+--- a/Makefile.in  2013-09-15 02:48:38.000000000 -0500
++++ b/Makefile.in      2020-07-03 00:43:13.639039206 -0500
+@@ -48,8 +48,8 @@
+ OCAMLMKLIB = @OCAMLMKLIB@
+
+ # compiler options
+-BOPTIONS = @DEBUG@ @ASSERT@
+-OOPTIONS = @COPTIONS@ @PROFILE@ @ASSERT@
++BOPTIONS =@DEBUG@ @ASSERT@ -unsafe-string
++OOPTIONS =@COPTIONS@ @PROFILE@ @ASSERT@ -unsafe-string
+
+ #
+ PACKAGE = camomile

--- a/dev-ml/camomile/files/ocaml405.patch
+++ b/dev-ml/camomile/files/ocaml405.patch
@@ -12,10 +12,10 @@ Date:   Fri Feb 24 22:30:23 2017 -0500
     (see MPR#7414, GPR#929). This commit adds enough annotations to avoid
     such underspecified variables in functors.
 
-diff --git a/Camomile/internal/unimap.ml b/Camomile/internal/unimap.ml
+diff --git a/internal/unimap.ml b/internal/unimap.ml
 index b6fdbde..6a7cc30 100644
---- a/Camomile/internal/unimap.ml
-+++ b/Camomile/internal/unimap.ml
+--- a/internal/unimap.ml
++++ b/internal/unimap.ml
 @@ -58,7 +58,7 @@ val of_name : string -> t
  end
  
@@ -25,10 +25,10 @@ index b6fdbde..6a7cc30 100644
  
  type mapping = {no_char : int; tbl : Tbl31.Bytes.t}
  
-diff --git a/Camomile/public/uCharInfo.ml b/Camomile/public/uCharInfo.ml
+diff --git a/public/uCharInfo.ml b/public/uCharInfo.ml
 index 69bf141..6a0337a 100644
---- a/Camomile/public/uCharInfo.ml
-+++ b/Camomile/public/uCharInfo.ml
+--- a/public/uCharInfo.ml
++++ b/public/uCharInfo.ml
 @@ -298,7 +298,7 @@ val load_composition_exclusion_tbl : unit -> UCharTbl.Bool.t
  
  end

--- a/dev-ml/ocaml-gettext/files/ocaml-unsafe-string.patch
+++ b/dev-ml/ocaml-gettext/files/ocaml-unsafe-string.patch
@@ -1,0 +1,17 @@
+diff --git a/ConfMakefile.in b/ConfMakefile.in
+index 5a1e9ea..b562698 100644
+--- a/ConfMakefile.in
++++ b/ConfMakefile.in
+@@ -37,9 +37,9 @@ OCAMLLIB=@OCAMLLIB@
+ OCAMLFIND_COMMANDS = "ocamlc=@OCAMLC@ \
+ 	ocamlopt=@OCAMLOPT@ \
+ 	ocamldep=@OCAMLDEP@"
+-OCAMLC       = @OCAMLFIND@ ocamlc 
+-OCAMLOPT     = @OCAMLFIND@ ocamlopt
+-OCAMLDEP     = @OCAMLFIND@ ocamldep
++OCAMLC       = @OCAMLFIND@ ocamlc -unsafe-string 
++OCAMLOPT     = @OCAMLFIND@ ocamlopt -unsafe-string
++OCAMLDEP     = @OCAMLFIND@ ocamldep -unsafe-string
+ OCAMLBEST    = @OCAMLBEST@
+ OCAMLVERSION = @OCAMLVERSION@
+ OCAMLFIND    = @OCAMLFIND@

--- a/dev-ml/ocaml-gettext/ocaml-gettext-0.3.7-r1.ebuild
+++ b/dev-ml/ocaml-gettext/ocaml-gettext-0.3.7-r1.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit findlib eutils autotools
+
+DESCRIPTION="Provides support for internationalization of OCaml program"
+HOMEPAGE="https://github.com/gildor478/ocaml-gettext"
+SRC_URI="https://github.com/gildor478/ocaml-gettext/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1-with-linking-exception"
+SLOT="0/${PV}"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc test"
+RESTRICT="!test? ( test )"
+
+PATCHES=( "${FILESDIR}"/ocaml-unsafe-string.patch )
+
+RDEPEND=">=dev-lang/ocaml-3.12.1:=
+	>=dev-ml/ocaml-fileutils-0.4.0:=
+	>=dev-ml/camomile-0.8.3:=
+	sys-devel/gettext
+	dev-ml/camlp4:=
+"
+DEPEND="${RDEPEND}
+	doc? (
+		app-text/docbook-xsl-stylesheets
+		dev-libs/libxslt
+	)
+	test? ( dev-ml/ounit )
+"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--with-docbook-stylesheet="${EPREFIX}/usr/share/sgml/docbook/xsl-stylesheets/" \
+		$(use_enable doc) \
+		$(use_enable test)
+}
+
+src_compile() {
+	emake -j1
+}
+
+src_install() {
+	findlib_src_preinst
+	emake -j1 DESTDIR="${D}" \
+		BINDIR="${ED}/usr/bin" \
+		PODIR="${ED}/usr/share/locale/" \
+		DOCDIR="${ED}/usr/share/doc/${PF}" \
+		MANDIR="${ED}/usr/share/man" \
+		install
+	dodoc CHANGELOG README THANKS TODO
+}


### PR DESCRIPTION
Multiple dev-ml packages won't build with the version of ocaml that is currently undergoing stabilization.

Fixes existed in b.g.o bugs; this PR just pulls those together and does some cleanups/EAPI updates for good measure.