### PR TITLE
media-video/ffmpeg: pass pkg-config to configure

### DIFF
--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -473,6 +473,7 @@ multilib_src_configure() {
 		--ar="$(tc-getAR)" \
 		--nm="$(tc-getNM)" \
 		--ranlib="$(tc-getRANLIB)" \
+		--pkg-config="$(tc-getPKG_CONFIG)" \
 		--optflags="${CFLAGS}" \
 		$(use_enable static-libs static) \
 		"${myconf[@]}" \


### PR DESCRIPTION
Use toolchain eclass to get pkg-config rather than
calling directly