### PR TITLE
media-plugins/kodi-inputstream-adaptive: fixed deps, licence; tweaks

### DIFF
--- a/media-plugins/kodi-inputstream-adaptive/kodi-inputstream-adaptive-2.4.5-r1.ebuild
+++ b/media-plugins/kodi-inputstream-adaptive/kodi-inputstream-adaptive-2.4.5-r1.ebuild
@@ -18,11 +18,11 @@ case ${PV} in
 	DEPEND="~media-tv/kodi-9999"
 	;;
 *)
-	CODENAME="Matrix"
+	CODENAME="Leia"
 	KEYWORDS="~amd64 ~x86"
 	SRC_URI="https://github.com/peak3d/${KODI_PLUGIN_NAME}/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${KODI_PLUGIN_NAME}-${PV}-${CODENAME}"
-	DEPEND="=media-tv/kodi-19*:="
+	DEPEND="=media-tv/kodi-18*:="
 	;;
 esac
 


### PR DESCRIPTION
* Dropped unneeded deps for Leia
* Fixed `scr_prepare()` (it fails without `depends` directory so check `[ -d depends ]` was useless)
* Licence is GPL-2+