### PR TITLE
media-plugins/kodi-inputstream-rtmp: fixed deps, corrected licence

### DIFF
--- a/media-plugins/kodi-inputstream-rtmp/kodi-inputstream-rtmp-2.0.9-r1.ebuild
+++ b/media-plugins/kodi-inputstream-rtmp/kodi-inputstream-rtmp-2.0.9-r1.ebuild
@@ -13,16 +13,15 @@ case ${PV} in
 9999)
 	SRC_URI=""
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
-	EGIT_BRANCH="Matrix"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
 	;;
 *)
-	CODENAME="Matrix"
+	CODENAME="Leia"
 	KEYWORDS="~amd64 ~x86"
 	SRC_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}/archive/${PV}-${CODENAME}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${KODI_PLUGIN_NAME}-${PV}-${CODENAME}"
-	DEPEND="=media-tv/kodi-19*:="
+	DEPEND="=media-tv/kodi-18*:="
 	;;
 esac
 

--- a/media-plugins/kodi-inputstream-rtmp/metadata.xml
+++ b/media-plugins/kodi-inputstream-rtmp/metadata.xml
@@ -5,7 +5,6 @@
         <email>candrews@gentoo.org</email>
         <name>Craig Andrews</name>
     </maintainer>
-    <longdescription>Kodi's RTMP inputstream addon</longdescription>
     <upstream>
         <remote-id type="github">xbmc/inputstream.rtmp</remote-id>
     </upstream>


### PR DESCRIPTION
pkg-config is required for FindRPMP.cmake
rtmpdump should have USE=ssl
