### PR TITLE
media-video/aegisub-9999: Updated ebuild

### DIFF
--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-WX_GTK_VER=3.0
+WX_GTK_VER=3.0-gtk3
 PLOCALES="ar be bg ca cs da de el es eu fa fi fr_FR gl hu id it ja ko nl pl pt_BR pt_PT ru sr_RS sr_RS@latin uk_UA vi zh_CN zh_TW"
 
 inherit autotools gnome2-utils l10n wxwidgets xdg-utils git-r3

--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 WX_GTK_VER=3.0
-PLOCALES="ar bg ca cs da de el es eu fa fi fr_FR gl hu id it ja ko nl pl pt_BR pt_PT ru sr_RS sr_RS@latin uk_UA vi zh_CN zh_TW"
+PLOCALES="ar be bg ca cs da de el es eu fa fi fr_FR gl hu id it ja ko nl pl pt_BR pt_PT ru sr_RS sr_RS@latin uk_UA vi zh_CN zh_TW"
 
 inherit autotools gnome2-utils l10n wxwidgets xdg-utils git-r3
 
@@ -52,9 +52,7 @@ DEPEND="${RDEPEND}
 REQUIRED_USE="|| ( alsa openal oss portaudio pulseaudio )"
 
 PATCHES=(
-	"${FILESDIR}/3.2.2_p20160518/${PN}-3.2.2_p20160518-fix-system-luajit-build.patch"
-	"${FILESDIR}/3.2.2_p20160518/${PN}-3.2.2_p20160518-respect-compiler-flags.patch"
-	"${FILESDIR}/3.2.2_p20160518/${PN}-3.2.2_p20160518-fix-boost170-build.patch"
+	"${FILESDIR}/${P}-git.patch"
 )
 
 src_prepare() {
@@ -94,12 +92,14 @@ src_configure() {
 		$(use_with pulseaudio libpulse)
 		$(use_with spell hunspell)
 		$(use_with uchardet)
+		--disable-compiler-flags
 	)
 	econf "${myeconfargs[@]}"
 }
 
 src_compile() {
-	emake
+	# Concurrent builds seem to break the build process.
+	emake -j1
 }
 
 src_test() {

--- a/media-video/aegisub/files/aegisub-9999-git.patch
+++ b/media-video/aegisub/files/aegisub-9999-git.patch
@@ -1,0 +1,78 @@
+diff --git a/Makefile.target b/Makefile.target
+index 516ef3c24..65de0e767 100644
+--- a/Makefile.target
++++ b/Makefile.target
+@@ -79,13 +79,13 @@ endif
+ all: $(LIB_TARGETS)
+ 
+ clean:
+-	$(BIN_RM) -f $(OBJ) $(CLEANFILES) $(LIB_TARGETS)
++	$(BIN_RM) -f -- $(OBJ) $(CLEANFILES) $(LIB_TARGETS)
+ 
+ distclean: clean
+-	$(BIN_RM) -rf $(DISTCLEANFILES) $(DEP)
++	$(BIN_RM) -rf -- $(DISTCLEANFILES) $(DEP)
+ 
+ depclean: clean
+-	$(BIN_RM) -rf $(DEP)
++	$(BIN_RM) -rf -- $(DEP)
+ 
+ install:
+ 
+diff --git a/header.mk b/header.mk
+index 613b38ff1..2c238e125 100644
+--- a/header.mk
++++ b/header.mk
+@@ -5,15 +5,13 @@ TOP := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/
+ include $(TOP)Makefile.inc
+ 
+ subdirs := \
+-	automation \
+ 	libaegisub \
+ 	packages/desktop \
+ 	po \
+ 	src \
+ 	tests \
+-	tools \
+ 	vendor/luabins \
+-	vendor/luajit
++	tools
+ 
+ subdirs := $(addprefix $(TOP),$(addsuffix /Makefile,$(subdirs)))
+ 
+diff --git a/m4macros/ac_agi.m4 b/m4macros/ac_agi.m4
+index e45a54767..1bd0120ed 100644
+--- a/m4macros/ac_agi.m4
++++ b/m4macros/ac_agi.m4
+@@ -20,12 +20,14 @@ AC_DEFUN([AC_AGI_LINK],[
+   aegisub_save_CPPFLAGS="$CPPFLAGS"
+   CPPFLAGS="$CPPFLAGS $4"
+   LIBS="$LIBS $5"
++  AC_LANG_PUSH(C++)
+   AC_CHECK_HEADER([$3], [agi_cv_header="yes"], [agi_cv_header="no"])
+   AS_IF([test "x$agi_cv_header" = xyes],
+         [AC_CACHE_CHECK(
+           [whether $1 works], [agi_cv_with_$2],
+           [AC_LINK_IFELSE([AC_LANG_SOURCE([$6])], [eval agi_cv_with_$2="yes"], [eval agi_cv_with_$2="no"])])]
+         [eval agi_cv_with_$2="no"])
++  AC_LANG_POP(C++)
+   CPPFLAGS="$aegisub_save_CPPFLAGS"
+   LIBS="$aegisub_save_LIBS"
+ ])
+diff --git a/src/libresrc/libresrc.cpp b/src/libresrc/libresrc.cpp
+index 79dc0f16c..8648d2987 100644
+--- a/src/libresrc/libresrc.cpp
++++ b/src/libresrc/libresrc.cpp
+@@ -22,9 +22,10 @@
+ 
+ wxBitmap libresrc_getimage(const unsigned char *buff, size_t size, double scale, int dir) {
+ 	wxMemoryInputStream mem(buff, size);
++        auto img = wxImage(mem);
+ 	if (dir != wxLayout_RightToLeft)
+-		return wxBitmap(wxImage(mem), -1, scale);
+-	return wxBitmap(wxImage(mem).Mirror(), -1, scale);
++            return wxBitmap(img.Scale(img.GetHeight() * scale, img.GetWidth() * scale));
++	return wxBitmap(img.Mirror().Scale(img.GetHeight() * scale, img.GetWidth() * scale));
+ }
+ 
+ wxIcon libresrc_geticon(const unsigned char *buff, size_t size) {


### PR DESCRIPTION
Updated the git ebuild. Fixed a removed wxImage constructor, mostly removed builtin lua, corrected failing autoconf check. Also fixed the 'clean' target, but this is unlikely to make any difference for packaging.