### PR TITLE
dev-embedded/libjaylink: Update EGIT_REPO_URI and HOMEPAGE

### DIFF
--- a/dev-embedded/libjaylink/libjaylink-9999.ebuild
+++ b/dev-embedded/libjaylink/libjaylink-9999.ebuild
@@ -3,12 +3,12 @@
 
 EAPI="5"
 
-EGIT_REPO_URI="https://gitlab.zapb.de/zapb/libjaylink.git"
+EGIT_REPO_URI="https://gitlab.zapb.de/libjaylink/libjaylink.git"
 
 inherit git-r3 autotools eutils ltprune
 
 DESCRIPTION="Library to access J-Link devices"
-HOMEPAGE="https://gitlab.zapb.de/zapb/libjaylink"
+HOMEPAGE="https://gitlab.zapb.de/libjaylink/libjaylink"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
The libjaylink repository moved again, this time to https://gitlab.zapb.de/libjaylink/libjaylink

Closes: https://bugs.gentoo.org/729318
Package-Manager: Portage-2.3.99, Repoman-2.3.23