### PR TITLE
sys-fs/ecryptfs-utils: Forcibly disable Python bindings

### DIFF
--- a/sys-fs/ecryptfs-utils/ecryptfs-utils-111_p20170609.ebuild
+++ b/sys-fs/ecryptfs-utils/ecryptfs-utils-111_p20170609.ebuild
@@ -3,9 +3,7 @@
 
 EAPI="6"
 
-PYTHON_COMPAT=( python2_7 )
-
-inherit flag-o-matic pam python-single-r1 linux-info autotools
+inherit flag-o-matic pam linux-info autotools
 
 DESCRIPTION="eCryptfs userspace utilities"
 HOMEPAGE="https://launchpad.net/ecryptfs"
@@ -14,7 +12,7 @@ SRC_URI="https://dev.gentoo.org/~bkohler/dist/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
-IUSE="doc gpg gtk nls openssl pam pkcs11 python suid tpm"
+IUSE="doc gpg gtk nls openssl pam pkcs11 suid tpm"
 
 RDEPEND=">=sys-apps/keyutils-1.5.11-r1:=
 	>=dev-libs/libgcrypt-1.2.0:0
@@ -27,19 +25,13 @@ RDEPEND=">=sys-apps/keyutils-1.5.11-r1:=
 		>=dev-libs/openssl-0.9.7:=
 		>=dev-libs/pkcs11-helper-1.04
 	)
-	python? ( ${PYTHON_DEPS} )
 	tpm? ( app-crypt/trousers )"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	sys-devel/gettext
-	>=dev-util/intltool-0.41.0
-	python? ( dev-lang/swig )"
-
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+	>=dev-util/intltool-0.41.0"
 
 pkg_setup() {
-	use python && python-single-r1_pkg_setup
-
 	CONFIG_CHECK="~ECRYPT_FS"
 	linux-info_pkg_setup
 }
@@ -60,6 +52,7 @@ src_configure() {
 	econf \
 		--enable-nss \
 		--with-pamdir=$(getpam_mod_dir) \
+		--disable-pywrap \
 		$(use_enable doc docs) \
 		$(use_enable gpg) \
 		$(use_enable gtk gui) \
@@ -67,16 +60,11 @@ src_configure() {
 		$(use_enable openssl) \
 		$(use_enable pam) \
 		$(use_enable pkcs11 pkcs11-helper) \
-		$(use_enable python pywrap) \
 		$(use_enable tpm tspi)
 }
 
 src_install() {
 	emake DESTDIR="${D}" install
-
-	if use python; then
-		echo "ecryptfs-utils" > "${D}$(python_get_sitedir)/ecryptfs-utils.pth" || die
-	fi
 
 	use suid && fperms u+s /sbin/mount.ecryptfs_private
 


### PR DESCRIPTION
This package only supports Python 2, so disable the bindings with
--disable-pywrap and remove the USE flag. The tools themselves don't
require Python, they're either binaries or shell scripts.

Bug: https://bugs.gentoo.org/735486
Package-Manager: Portage-2.3.103, Repoman-2.3.23