### PR TITLE
sys-kernel/dracut: Revbump 050, multiple upstream fixes

### DIFF
--- a/sys-kernel/dracut/dracut-050-r2.ebuild
+++ b/sys-kernel/dracut/dracut-050-r2.ebuild
@@ -1,0 +1,171 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit bash-completion-r1 eutils linux-info systemd toolchain-funcs
+
+if [[ ${PV} == 9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/dracutdevs/dracut"
+else
+	[[ "${PV}" = *_rc* ]] || \
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
+fi
+
+DESCRIPTION="Generic initramfs generation tool"
+HOMEPAGE="https://dracut.wiki.kernel.org"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="selinux"
+
+# Tests need root privileges, bug #298014
+RESTRICT="test"
+
+RDEPEND="
+	app-arch/cpio
+	>=app-shells/bash-4.0:0
+	sys-apps/coreutils[xattr(-)]
+	>=sys-apps/kmod-23[tools]
+	|| (
+		>=sys-apps/sysvinit-2.87-r3
+		sys-apps/openrc[sysv-utils(-),selinux?]
+		sys-apps/systemd[sysv-utils]
+	)
+	>=sys-apps/util-linux-2.21
+	virtual/pkgconfig
+	virtual/udev
+
+	elibc_musl? ( sys-libs/fts-standalone )
+	selinux? (
+		sec-policy/selinux-dracut
+		sys-libs/libselinux
+		sys-libs/libsepol
+	)
+"
+DEPEND="
+	>=sys-apps/kmod-23
+	elibc_musl? ( sys-libs/fts-standalone )
+"
+
+BDEPEND="
+	app-text/asciidoc
+	app-text/docbook-xml-dtd:4.5
+	>=app-text/docbook-xsl-stylesheets-1.75.2
+	>=dev-libs/libxslt-1.1.26
+	virtual/pkgconfig
+"
+
+DOCS=( AUTHORS HACKING NEWS README.md README.generic README.kernel README.modules
+	README.testsuite TODO )
+
+QA_MULTILIB_PATHS="usr/lib/dracut/.*"
+
+PATCHES=(
+	"${FILESDIR}"/050-Makefile-merge-main-version-and-git-version-earlier.patch
+	"${FILESDIR}"/050-dracut.sh-don-t-call-fsfreeze-on-subvol-of-root-file.patch
+	"${FILESDIR}"/050-Makefile-fix-VERSION-again.patch
+	"${FILESDIR}"/050-btrfs-force-preload-btrfs-module.patch
+	"${FILESDIR}"/050-network-manager-ensure-that-nm-run.sh-is-executed-wh.patch
+	"${FILESDIR}"/050-dracut-lib.sh-quote-variables-in-parameter-expansion.patch
+	"${FILESDIR}"/050-busybox-module-fix.patch
+	"${FILESDIR}"/050-systemd-remove-obsolete-syslog-parameter.patch
+	"${FILESDIR}"/050-lvm-fix-removal-of-pvscan-from-udev-rules.patch
+	"${FILESDIR}"/050-gentoo-ldconfig-paths.patch
+)
+
+src_configure() {
+	local myconf=(
+		--prefix="${EPREFIX}/usr"
+		--sysconfdir="${EPREFIX}/etc"
+		--bashcompletiondir="$(get_bashcompdir)"
+		--systemdsystemunitdir="$(systemd_get_systemunitdir)"
+	)
+
+	tc-export CC PKG_CONFIG
+
+	echo ./configure "${myconf[@]}"
+	./configure "${myconf[@]}" || die
+
+	if [[ ${PV} != 9999 && ! -f dracut-version.sh ]] ; then
+		# Source tarball from github doesn't include this file
+		echo "DRACUT_VERSION=${PV}" > dracut-version.sh || die
+	fi
+}
+
+src_install() {
+	default
+
+	insinto /etc/logrotate.d
+	newins dracut.logrotate dracut
+
+	docinto html
+	dodoc dracut.html
+}
+
+pkg_postinst() {
+	if linux-info_get_any_version && linux_config_exists; then
+		ewarn ""
+		ewarn "If the following test report contains a missing kernel"
+		ewarn "configuration option, you should reconfigure and rebuild your"
+		ewarn "kernel before booting image generated with this Dracut version."
+		ewarn ""
+
+		local CONFIG_CHECK="~BLK_DEV_INITRD ~DEVTMPFS"
+
+		# Kernel configuration options descriptions:
+		local ERROR_DEVTMPFS='CONFIG_DEVTMPFS: "Maintain a devtmpfs filesystem to mount at /dev" '
+		ERROR_DEVTMPFS+='is missing and REQUIRED'
+		local ERROR_BLK_DEV_INITRD='CONFIG_BLK_DEV_INITRD: "Initial RAM filesystem and RAM disk '
+		ERROR_BLK_DEV_INITRD+='(initramfs/initrd) support" is missing and REQUIRED'
+
+		check_extra_config
+		echo
+	else
+		ewarn ""
+		ewarn "Your kernel configuration couldn't be checked."
+		ewarn "Please check manually if following options are enabled:"
+		ewarn ""
+		ewarn "  CONFIG_BLK_DEV_INITRD"
+		ewarn "  CONFIG_DEVTMPFS"
+		ewarn ""
+	fi
+
+	elog "To get additional features, a number of optional runtime"
+	elog "dependencies may be installed:"
+	elog ""
+	optfeature "Networking support" net-misc/networkmanager
+	optfeature "Legacy networking support" net-misc/curl "net-misc/dhcp[client]" \
+		sys-apps/iproute2 "net-misc/iputils[arping]"
+	optfeature \
+		"Measure performance of the boot process for later visualisation" \
+		app-benchmarks/bootchart2 app-admin/killproc sys-process/acct
+	optfeature "Scan for Btrfs on block devices"  sys-fs/btrfs-progs
+	optfeature "Load kernel modules and drop this privilege for real init" \
+		sys-libs/libcap
+	optfeature "Support CIFS" net-fs/cifs-utils
+	optfeature "Decrypt devices encrypted with cryptsetup/LUKS" \
+		"sys-fs/cryptsetup[-static-libs]"
+	optfeature "Support for GPG-encrypted keys for crypt module" \
+		app-crypt/gnupg
+	optfeature \
+		"Allows use of dash instead of default bash (on your own risk)" \
+		app-shells/dash
+	optfeature "Support iSCSI" sys-block/open-iscsi
+	optfeature "Support Logical Volume Manager" sys-fs/lvm2
+	optfeature "Support MD devices, also known as software RAID devices" \
+		sys-fs/mdadm
+	optfeature "Support Device Mapper multipathing" sys-fs/multipath-tools
+	optfeature "Plymouth boot splash"  '>=sys-boot/plymouth-0.8.5-r5'
+	optfeature "Support network block devices" sys-block/nbd
+	optfeature "Support NFS" net-fs/nfs-utils net-nds/rpcbind
+	optfeature \
+		"Install ssh and scp along with config files and specified keys" \
+		net-misc/openssh
+	optfeature "Enable logging with rsyslog" app-admin/rsyslog
+	optfeature \
+		"Enable rngd service to help generating entropy early during boot" \
+		sys-apps/rng-tools
+}

--- a/sys-kernel/dracut/files/050-btrfs-force-preload-btrfs-module.patch
+++ b/sys-kernel/dracut/files/050-btrfs-force-preload-btrfs-module.patch
@@ -1,0 +1,30 @@
+From 0402b3777b1c64bd716f588ff7457b905e98489d Mon Sep 17 00:00:00 2001
+From: Harald Hoyer <harald@redhat.com>
+Date: Wed, 11 Mar 2020 12:56:52 +0100
+Subject: [PATCH] btrfs: force preload btrfs module
+
+fixes https://github.com/dracutdevs/dracut/issues/658
+
+raid6_pq and xor takes time doing benchmarking
+
+[    3.983009] request_module fs-btrfs succeeded, but still no fs?
+---
+ modules.d/90btrfs/module-setup.sh | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/90btrfs/module-setup.sh b/modules.d/90btrfs/module-setup.sh
+index b0d0058b..66a254e1 100755
+--- a/modules.d/90btrfs/module-setup.sh
++++ b/modules.d/90btrfs/module-setup.sh
+@@ -48,5 +48,7 @@ install() {
+ 
+     inst_multiple -o btrfsck btrfs-zero-log
+     inst $(command -v btrfs) /sbin/btrfs
++    # Hack for slow machines
++    # see https://github.com/dracutdevs/dracut/issues/658
++    echo "rd.driver.pre=btrfs" > ${initdir}/etc/cmdline.d/00-btrfs.conf
+ }
+-
+-- 
+2.26.2
+

--- a/sys-kernel/dracut/files/050-dracut-lib.sh-quote-variables-in-parameter-expansion.patch
+++ b/sys-kernel/dracut/files/050-dracut-lib.sh-quote-variables-in-parameter-expansion.patch
@@ -1,0 +1,111 @@
+From 8e1a4dc5f8a777fc718db490414ffdc9dc755f66 Mon Sep 17 00:00:00 2001
+From: Jonas Witschel <diabonas@archlinux.org>
+Date: Sat, 18 Apr 2020 14:55:41 +0200
+Subject: [PATCH] dracut-lib.sh: quote variables in parameter expansion
+ patterns
+
+According to POSIX.1-2017, 2.6.2 Parameter Expansion:
+
+${parameter%[word]} [...] The word shall be expanded to produce a
+pattern.
+
+This means if word contains variables that itself contain special
+characters like asterisks or backslashes, these are treated as pattern
+characters unless the variable is quoted. Try e.g. the following example
+in bash, dash or (busybox) ash:
+
+i='a\c'; j='\'; echo "${i%$j*}"
+
+This prints "a\c" because "$j*" is expanded to "\*", escaping the
+asterisk. In contrast,
+
+i='a\c'; j='\'; echo "${i%"$j"*}"
+
+produces the expected result "a" because the backslash is not specially
+treated any more after quoting.
+
+The quotes that this commit adds have been previously removed in commit
+f9c96cf56fed390841eac05c43826e62014c9188, citing issues with busybox
+hush without further specifying the actual error. I tested a recent
+busybox build (upstream commit 9aa751b08ab03d6396f86c3df77937a19687981b)
+and couldn't find any problems. Note that the above example always
+produces "a\c" in hush regardless of quoting $j, making hush unsuitable
+for use with dracut, but using quotes in parameter expansions generally
+works.
+
+The unquoted variables break the "rd.luks.uuid/name" kernel command line
+options in dracut 050 because
+
+str_replace "$luksname" '\' '\\'
+
+in modules.d/90crypt/parse-crypt.sh is not able to escape the
+backslashes any more, see GH-723, GH-727: backslashes in the
+systemd-cryptsetup@.service unit name stay unescaped for use in udev
+(cf. commit 0f6d93eb9d63695a64002ec8b0421fbc9fc8a7a3), leading to
+failures in starting the unit.
+
+This partially reverts commit f9c96cf56fed390841eac05c43826e62014c9188.
+---
+ modules.d/99base/dracut-lib.sh | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/modules.d/99base/dracut-lib.sh b/modules.d/99base/dracut-lib.sh
+index c53cd13b..c57523d3 100755
+--- a/modules.d/99base/dracut-lib.sh
++++ b/modules.d/99base/dracut-lib.sh
+@@ -24,7 +24,7 @@ debug_on() {
+ 
+ # returns OK if $1 contains literal string $2 (and isn't empty)
+ strstr() {
+-    [ "${1##*$2*}" != "$1" ]
++    [ "${1##*"$2"*}" != "$1" ]
+ }
+ 
+ # returns OK if $1 matches (completely) glob pattern $2
+@@ -43,18 +43,18 @@ strglobin() {
+ 
+ # returns OK if $1 contains literal string $2 at the beginning, and isn't empty
+ str_starts() {
+-    [ "${1#$2*}" != "$1" ]
++    [ "${1#"$2"*}" != "$1" ]
+ }
+ 
+ # returns OK if $1 contains literal string $2 at the end, and isn't empty
+ str_ends() {
+-    [ "${1%*$2}" != "$1" ]
++    [ "${1%*"$2"}" != "$1" ]
+ }
+ 
+ trim() {
+     local var="$*"
+-    var="${var#${var%%[![:space:]]*}}"   # remove leading whitespace characters
+-    var="${var%${var##*[![:space:]]}}"   # remove trailing whitespace characters
++    var="${var#"${var%%[![:space:]]*}"}"   # remove leading whitespace characters
++    var="${var%"${var##*[![:space:]]}"}"   # remove trailing whitespace characters
+     printf "%s" "$var"
+ }
+ 
+@@ -108,9 +108,9 @@ str_replace() {
+     local out=''
+ 
+     while strstr "${in}" "$s"; do
+-        chop="${in%%$s*}"
++        chop="${in%%"$s"*}"
+         out="${out}${chop}$r"
+-        in="${in#*$s}"
++        in="${in#*"$s"}"
+     done
+     echo "${out}${in}"
+ }
+@@ -396,7 +396,7 @@ splitsep() {
+     while [ -n "$str" -a "$#" -gt 1 ]; do
+         tmp="${str%%$sep*}"
+         eval "$1='${tmp}'"
+-        str="${str#$tmp}"
++        str="${str#"$tmp"}"
+         str="${str#$sep}"
+         shift
+     done
+-- 
+2.26.2
+

--- a/sys-kernel/dracut/files/050-lvm-fix-removal-of-pvscan-from-udev-rules.patch
+++ b/sys-kernel/dracut/files/050-lvm-fix-removal-of-pvscan-from-udev-rules.patch
@@ -1,0 +1,26 @@
+From 07417b7fc5cb261187519c916e4735189f20f4c6 Mon Sep 17 00:00:00 2001
+From: Alexander Tsoy <alexander@tsoy.me>
+Date: Sat, 23 May 2020 18:03:47 +0300
+Subject: [PATCH] lvm: fix removal of pvscan from udev rules
+
+udev rules provided by lvm 2.02.128 and newer uses '+=' instead of '='.
+---
+ modules.d/90lvm/module-setup.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules.d/90lvm/module-setup.sh b/modules.d/90lvm/module-setup.sh
+index d6d2c185..52c803f7 100755
+--- a/modules.d/90lvm/module-setup.sh
++++ b/modules.d/90lvm/module-setup.sh
+@@ -101,7 +101,7 @@ install() {
+             sed -i -e 's/^ENV{SYSTEMD_ALIAS}=.*/# No LVM pvscan in dracut - lvmetad is not running yet/' \
+                 ${initdir}/lib/udev/rules.d/69-dm-lvm-metad.rules
+             sed -i -e 's/^ENV{ID_MODEL}=.*//' ${initdir}/lib/udev/rules.d/69-dm-lvm-metad.rules
+-            sed -i -e 's/^ENV{SYSTEMD_WANTS}=.*//' ${initdir}/lib/udev/rules.d/69-dm-lvm-metad.rules
++            sed -i -e 's/^ENV{SYSTEMD_WANTS}+\?=.*//' ${initdir}/lib/udev/rules.d/69-dm-lvm-metad.rules
+         else
+             sed -i -e 's/.*lvm pvscan.*/# No LVM pvscan for in dracut - lvmetad is not running yet/' \
+                 ${initdir}/lib/udev/rules.d/69-dm-lvm-metad.rules
+-- 
+2.26.2
+

--- a/sys-kernel/dracut/files/050-network-manager-ensure-that-nm-run.sh-is-executed-wh.patch
+++ b/sys-kernel/dracut/files/050-network-manager-ensure-that-nm-run.sh-is-executed-wh.patch
@@ -1,0 +1,48 @@
+From 3dcaa97ca4dcfa8092252a22df62c60941e59ce3 Mon Sep 17 00:00:00 2001
+From: Beniamino Galvani <bgalvani@redhat.com>
+Date: Wed, 11 Mar 2020 09:40:50 +0100
+Subject: [PATCH] network-manager: ensure that nm-run.sh is executed when
+ needed
+
+The network-manager command line hook must install a
+initqueue/finished hook to ensure that nm-run.sh is executed when
+there are network connections to activate.
+
+Fixes: #694
+---
+ modules.d/35network-manager/nm-config.sh | 11 +++++++++++
+ modules.d/35network-manager/nm-run.sh    |  2 ++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/modules.d/35network-manager/nm-config.sh b/modules.d/35network-manager/nm-config.sh
+index 1efa737c..39a1c8bd 100755
+--- a/modules.d/35network-manager/nm-config.sh
++++ b/modules.d/35network-manager/nm-config.sh
+@@ -5,3 +5,14 @@ if [ -n "$netroot" ] || [ -e /tmp/net.ifaces ]; then
+ fi
+ 
+ /usr/libexec/nm-initrd-generator -- $(getcmdline)
++
++if getargbool 0 rd.neednet; then
++  for i in /usr/lib/NetworkManager/system-connections/* \
++           /run/NetworkManager/system-connections/* \
++           /etc/NetworkManager/system-connections/* \
++           /etc/sysconfig/network-scripts/ifcfg-*; do
++    [ -f "$i" ] || continue
++    echo '[ -f /tmp/nm.done ]' >$hookdir/initqueue/finished/nm.sh
++    break
++  done
++fi
+diff --git a/modules.d/35network-manager/nm-run.sh b/modules.d/35network-manager/nm-run.sh
+index 4079b735..fc5280a1 100755
+--- a/modules.d/35network-manager/nm-run.sh
++++ b/modules.d/35network-manager/nm-run.sh
+@@ -22,3 +22,5 @@ do
+     source_hook initqueue/online $ifname
+     /sbin/netroot $ifname
+ done
++
++> /tmp/nm.done
+-- 
+2.26.2
+

--- a/sys-kernel/dracut/files/050-systemd-remove-obsolete-syslog-parameter.patch
+++ b/sys-kernel/dracut/files/050-systemd-remove-obsolete-syslog-parameter.patch
@@ -1,0 +1,241 @@
+From 265f696b532f63f0ac1f9f341e0469a6eafe2fdd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:26:00 +0000
+Subject: [PATCH 01/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/90stratis/stratisd-init.service | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/modules.d/90stratis/stratisd-init.service b/modules.d/90stratis/stratisd-init.service
+index 318e8c27..1be2e33b 100644
+--- a/modules.d/90stratis/stratisd-init.service
++++ b/modules.d/90stratis/stratisd-init.service
+@@ -8,8 +8,6 @@ DefaultDependencies=no
+ Type=simple
+ ExecStart=/sbin/stratisd-init --debug
+ KillSignal=SIGINT
+-StandardOutput=syslog
+-StandardError=syslog
+ 
+ [Install]
+ WantedBy=sysinit.target
+-- 
+2.26.2
+
+From 38ba90bf88b38228e128c65be40a2da287c0b1ed Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:29:34 +0000
+Subject: [PATCH 02/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/99squash/squash-mnt-clear.service | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/modules.d/99squash/squash-mnt-clear.service b/modules.d/99squash/squash-mnt-clear.service
+index 84441f60..9d94c524 100644
+--- a/modules.d/99squash/squash-mnt-clear.service
++++ b/modules.d/99squash/squash-mnt-clear.service
+@@ -12,6 +12,6 @@ ConditionPathExists=/squash/root
+ Type=oneshot
+ RemainAfterExit=no
+ StandardInput=null
+-StandardOutput=syslog+console
+-StandardError=syslog+console
++StandardOutput=journal+console
++StandardError=journal+console
+ ExecStart=/squash/clear-squash.sh
+-- 
+2.26.2
+
+From 5cb2a4004d18e4b96ddc18f221fae922350a9000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:31:17 +0000
+Subject: [PATCH 03/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/98dracut-systemd/dracut-pre-trigger.service | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/dracut-pre-trigger.service b/modules.d/98dracut-systemd/dracut-pre-trigger.service
+index 7bf16167..6f1ba521 100644
+--- a/modules.d/98dracut-systemd/dracut-pre-trigger.service
++++ b/modules.d/98dracut-systemd/dracut-pre-trigger.service
+@@ -20,8 +20,7 @@ Environment=NEWROOT=/sysroot
+ Type=oneshot
+ ExecStart=-/bin/dracut-pre-trigger
+ StandardInput=null
+-StandardOutput=syslog
+-StandardError=syslog+console
++StandardError=journal+console
+ KillMode=process
+ RemainAfterExit=yes
+ 
+-- 
+2.26.2
+
+From 317d841c788e841d3533515ceda5597a099eb64e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:31:59 +0000
+Subject: [PATCH 04/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/98dracut-systemd/dracut-initqueue.service | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/dracut-initqueue.service b/modules.d/98dracut-systemd/dracut-initqueue.service
+index 207d545d..3a8679a5 100644
+--- a/modules.d/98dracut-systemd/dracut-initqueue.service
++++ b/modules.d/98dracut-systemd/dracut-initqueue.service
+@@ -21,8 +21,7 @@ Environment=NEWROOT=/sysroot
+ Type=oneshot
+ ExecStart=-/bin/dracut-initqueue
+ StandardInput=null
+-StandardOutput=syslog
+-StandardError=syslog+console
++StandardError=journal+console
+ KillMode=process
+ RemainAfterExit=yes
+ 
+-- 
+2.26.2
+
+From 0c1bd016ecfb9c6d194c4356199b509d90db4071 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:32:44 +0000
+Subject: [PATCH 05/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/98dracut-systemd/dracut-pre-pivot.service | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/dracut-pre-pivot.service b/modules.d/98dracut-systemd/dracut-pre-pivot.service
+index 9a1f0854..e893d1dd 100644
+--- a/modules.d/98dracut-systemd/dracut-pre-pivot.service
++++ b/modules.d/98dracut-systemd/dracut-pre-pivot.service
+@@ -27,8 +27,7 @@ Environment=NEWROOT=/sysroot
+ Type=oneshot
+ ExecStart=-/bin/dracut-pre-pivot
+ StandardInput=null
+-StandardOutput=syslog
+-StandardError=syslog+console
++StandardError=journal+console
+ KillMode=process
+ RemainAfterExit=yes
+ 
+-- 
+2.26.2
+
+From e1130a83405648777210fdc99f7eee087eebaadc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:33:33 +0000
+Subject: [PATCH 06/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/98dracut-systemd/dracut-pre-udev.service | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/dracut-pre-udev.service b/modules.d/98dracut-systemd/dracut-pre-udev.service
+index 570ec02d..e4092e35 100644
+--- a/modules.d/98dracut-systemd/dracut-pre-udev.service
++++ b/modules.d/98dracut-systemd/dracut-pre-udev.service
+@@ -24,8 +24,7 @@ Environment=NEWROOT=/sysroot
+ Type=oneshot
+ ExecStart=-/bin/dracut-pre-udev
+ StandardInput=null
+-StandardOutput=syslog
+-StandardError=syslog+console
++StandardError=journal+console
+ KillMode=process
+ RemainAfterExit=yes
+ 
+-- 
+2.26.2
+
+From c437933cb0490e800e776cb7695d2ea0e95056a2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:34:17 +0000
+Subject: [PATCH 07/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/98dracut-systemd/dracut-pre-mount.service | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/dracut-pre-mount.service b/modules.d/98dracut-systemd/dracut-pre-mount.service
+index d3909689..18c9730c 100644
+--- a/modules.d/98dracut-systemd/dracut-pre-mount.service
++++ b/modules.d/98dracut-systemd/dracut-pre-mount.service
+@@ -19,8 +19,7 @@ Environment=NEWROOT=/sysroot
+ Type=oneshot
+ ExecStart=-/bin/dracut-pre-mount
+ StandardInput=null
+-StandardOutput=syslog
+-StandardError=syslog+console
++StandardError=journal+console
+ KillMode=process
+ RemainAfterExit=yes
+ 
+-- 
+2.26.2
+
+From d9149c6ca7c52c204c1b346e9b6a32bbadd0b2ff Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:35:02 +0000
+Subject: [PATCH 08/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/98dracut-systemd/dracut-cmdline.service | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/dracut-cmdline.service b/modules.d/98dracut-systemd/dracut-cmdline.service
+index e577ec88..a8078bd2 100644
+--- a/modules.d/98dracut-systemd/dracut-cmdline.service
++++ b/modules.d/98dracut-systemd/dracut-cmdline.service
+@@ -23,8 +23,7 @@ Environment=NEWROOT=/sysroot
+ Type=oneshot
+ ExecStart=-/bin/dracut-cmdline
+ StandardInput=null
+-StandardOutput=syslog
+-StandardError=syslog+console
++StandardError=journal+console
+ KillMode=process
+ RemainAfterExit=yes
+ 
+-- 
+2.26.2
+
+From 8cb5ac1b30be458df9497911ba601d90e68f4d5b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B3hann=20B=2E=20Gu=C3=B0mundsson?= <johannbg@gmail.com>
+Date: Wed, 15 Jul 2020 14:35:38 +0000
+Subject: [PATCH 09/10] As of v246 of systemd "syslog" and "syslog-console"
+ switches have been deprecated
+
+---
+ modules.d/98dracut-systemd/dracut-mount.service | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/modules.d/98dracut-systemd/dracut-mount.service b/modules.d/98dracut-systemd/dracut-mount.service
+index 77d34f62..c88e6d84 100644
+--- a/modules.d/98dracut-systemd/dracut-mount.service
++++ b/modules.d/98dracut-systemd/dracut-mount.service
+@@ -19,8 +19,7 @@ Environment=NEWROOT=/sysroot
+ Type=oneshot
+ ExecStart=-/bin/dracut-mount
+ StandardInput=null
+-StandardOutput=syslog
+-StandardError=syslog+console
++StandardError=journal+console
+ KillMode=process
+ RemainAfterExit=yes
+ 
+-- 
+2.26.2
+


### PR DESCRIPTION
* fix LVM activation
* workaround for BTRFS mounts on slow machines
* install NetworkManager initque/finished hook
* POSIX shell compatibility fixes
* remove deprecated "syslog" parameter from systemd units

Closes: https://bugs.gentoo.org/724474
Closes: https://bugs.gentoo.org/734166