### PR TITLE
dev-python/lockfile: port to py3.9

### DIFF
--- a/dev-python/lockfile/lockfile-0.12.2-r2.ebuild
+++ b/dev-python/lockfile/lockfile-0.12.2-r2.ebuild
@@ -3,8 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
-PYTHON_REQ_USE="threads(+)"
+PYTHON_COMPAT=( python2_7 python3_{6,7,8,9} pypy3 )
 
 inherit distutils-r1
 
@@ -15,27 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86"
-IUSE="doc test"
-RESTRICT="!test? ( test )"
 
-DEPEND="
-	>dev-python/pbr-1.8[${PYTHON_USEDEP}]
-	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
-	test? ( dev-python/nose[${PYTHON_USEDEP}] )"
-RDEPEND=""
+DEPEND=">dev-python/pbr-1.8[${PYTHON_USEDEP}]"
 
-DOCS=( ACKS AUTHORS ChangeLog README.rst RELEASE-NOTES )
-
-python_compile_all() {
-	use doc && emake -C doc/source html
-}
-
-python_test() {
-	# "${PYTHON}" test/test_lockfile.py yeilds no informative coverage output
-	nosetests --verbose || die "test_lockfile failed under ${EPYTHON}"
-}
-
-python_install_all() {
-	use doc && dodoc -r doc/source/.build/html
-	distutils-r1_python_install_all
-}
+distutils_enable_tests nose


### PR DESCRIPTION
Use distutils_enable_tests and drop documentation building.
Package is deprecated.

Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: David Denoncin <ddenoncin@gmail.com>