### PR TITLE
sys-apps/flashrom: update IUSE_PROGRAMMERS in 9999 ebuild

### DIFF
--- a/sys-apps/flashrom/flashrom-9999.ebuild
+++ b/sys-apps/flashrom/flashrom-9999.ebuild
@@ -33,6 +33,7 @@ IUSE_PROGRAMMERS="
 	+digilent-spi
 	+drkaiser
 	+dummy
+	+ene-lpc
 	+ft2232-spi
 	+gfxnvidia
 	+internal
@@ -40,6 +41,8 @@ IUSE_PROGRAMMERS="
 	jlink-spi
 	+linux-mtd
 	+linux-spi
+	lspcon-i2c-spi
+	+mec1308
 	mstarddc-spi
 	+nic3com
 	+nicintel
@@ -50,7 +53,9 @@ IUSE_PROGRAMMERS="
 	+ogp-spi
 	+pickit2-spi
 	+pony-spi
+	+raiden
 	+rayer-spi
+	+realtek-mst-i2c-spi
 	+satamv
 	+satasii
 	+serprog

--- a/sys-apps/flashrom/metadata.xml
+++ b/sys-apps/flashrom/metadata.xml
@@ -16,6 +16,7 @@
 		<flag name="digilent-spi">Enable support for Digilent iCEblink40 development board</flag>
 		<flag name="drkaiser">Enable Dr. Kaiser programmer</flag>
 		<flag name="dummy">Enable dummy tracing</flag>
+		<flag name="ene-lpc">Enable ENE LPC interface keyboard controller</flag>
 		<flag name="ft2232-spi">Enable ftdi programmer, flashing through FTDI/SPI USB interface</flag>
 		<flag name="gfxnvidia">Enable NVIDIA programmer</flag>
 		<flag name="internal">Enable internal/onboard support</flag>
@@ -24,6 +25,8 @@
 		<flag name="jlink-spi">Support for SEGGER J-Link and compatible devices</flag>
 		<flag name="linux-mtd">Enable support for Linux mtd SPI flash devices</flag>
 		<flag name="linux-spi">Enable support for Linux userspace spidev interface</flag>
+		<flag name="lspcon-i2c-spi">Enable support for Parade lspcon USB-C to HDMI protocol translator</flag>
+		<flag name="mec1308">Enable support for Microchip MEC1308 embedded controller</flag>
 		<flag name="mstarddc-spi">Support for SPI flash ROMs accessible through DDC in MSTAR-equipped displays</flag>
 		<flag name="nic3com">Enable 3Com NIC programmer</flag>
 		<flag name="nicintel">Support for Intel NICs</flag>
@@ -34,7 +37,9 @@
 		<flag name="ogp-spi">Enable support for OGP (Open Graphics Project) SPI flashing</flag>
 		<flag name="pickit2-spi">SUpport for SPI flash ROMs accessible via Microchip PICkit2</flag>
 		<flag name="pony-spi">Enable support for SI-Prog like hardware by Lancos</flag>
+		<flag name="raiden">Enable ChromiumOS Servo DUT debug board</flag>
 		<flag name="rayer-spi">RayeR SPIPGM hardware support</flag>
+		<flag name="realtek-mst-i2c-spi">Enable support for Realtek MultiStream Transport MST</flag>
 		<flag name="satasii">Enable programmer for SiI SATA controllers</flag>
 		<flag name="satamv">Enable programmer for Marvell SATA controllers</flag>
 		<flag name="stlinkv3-spi">Enable SPI programmer using STLINK-V3</flag>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/735974
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>