### PR TITLE
app-emulation/libvirt-9999: Switch to meson

### DIFF
--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -259,6 +259,7 @@ my_src_configure() {
 		$(use_with udev)
 		$(use_with vepa virtualport)
 		$(use_with virt-network network)
+		$(use_with virtualbox vbox)
 		$(use_with wireshark-plugins wireshark-dissector)
 		$(use_with xen libxl)
 		$(use_with zfs storage-zfs)
@@ -283,11 +284,6 @@ my_src_configure() {
 		--enable-dependency-tracking
 	)
 
-	if use virtualbox && has_version app-emulation/virtualbox-ose; then
-		myeconfargs+=( --with-vbox=/usr/lib/virtualbox-ose/ )
-	else
-		myeconfargs+=( $(use_with virtualbox vbox) )
-	fi
 
 	econf "${myeconfargs[@]}"
 }


### PR DESCRIPTION
 The upstream has abandoned autotools in favor of meson. Patches were merged right after the 6.6.0 release. Adopt live ebuild to meson.