### PR TITLE
net-ftp/tftp-hpa: bump EAPI and split the package

### DIFF
--- a/net-ftp/tftp-hpa/metadata.xml
+++ b/net-ftp/tftp-hpa/metadata.xml
@@ -5,4 +5,8 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<use>
+	<flag name="client">Compile and install the tftp client</flag>
+	<flag name="server">Compile and install the tftp server</flag>
+</use>
 </pkgmetadata>

--- a/net-ftp/tftp-hpa/tftp-hpa-5.2-r2.ebuild
+++ b/net-ftp/tftp-hpa/tftp-hpa-5.2-r2.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+inherit systemd eutils toolchain-funcs
+
+DESCRIPTION="port of the OpenBSD TFTP server"
+HOMEPAGE="https://www.kernel.org/pub/software/network/tftp/"
+SRC_URI="https://www.kernel.org/pub/software/network/tftp/${PN}/${P}.tar.xz"
+
+LICENSE="BSD-4"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-macos"
+IUSE="ipv6 readline selinux tcpd +client +server"
+
+CDEPEND="
+	readline? ( sys-libs/readline:0= )
+	tcpd? ( sys-apps/tcp-wrappers )
+	!net-ftp/atftp"
+
+DEPEND="${CDEPEND}
+	app-arch/xz-utils"
+
+RDEPEND="${CDEPEND}
+	selinux? ( sec-policy/selinux-tftp )"
+
+PATCHES=(
+	"${FILESDIR}"/tftp-hpa-5.2-gcc-10.patch
+)
+
+src_prepare() {
+	eapply_user
+	sed -i "/^AR/s:ar:$(tc-getAR):" MCONFIG.in || die
+}
+
+src_configure() {
+	econf \
+		$(use_with ipv6) \
+		$(use_with tcpd tcpwrappers) \
+		$(use_with readline)
+}
+
+src_compile() {
+	emake version.h
+	emake -C lib
+	emake -C common
+	if use client; then
+		emake -C tftp
+	fi
+	if use daemon; then
+		emake -C tftpd
+	fi
+}
+
+src_install() {
+	dodoc README* CHANGES tftpd/sample.rules
+	emake INSTALLROOT="${D}" -C lib install
+	emake INSTALLROOT="${D}" -C common install
+
+	if use client; then
+		emake INSTALLROOT="${D}" -C tftp install
+	fi
+	if use daemon; then
+
+		emake INSTALLROOT="${D}" install
+		# iputils installs this
+		rm "${ED}"/usr/share/man/man8/tftpd.8 || die
+
+		newconfd "${FILESDIR}"/in.tftpd.confd-0.44 in.tftpd
+		newinitd "${FILESDIR}"/in.tftpd.rc6 in.tftpd
+
+		systemd_dounit "${FILESDIR}"/tftp.service
+		systemd_dounit "${FILESDIR}"/tftp.socket
+
+		insinto /etc/xinetd.d
+		newins "${FILESDIR}"/tftp.xinetd tftp
+	fi
+}

--- a/net-ftp/tftp-hpa/tftp-hpa-5.2-r2.ebuild
+++ b/net-ftp/tftp-hpa/tftp-hpa-5.2-r2.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
-inherit systemd eutils toolchain-funcs
+inherit systemd toolchain-funcs
 
 DESCRIPTION="port of the OpenBSD TFTP server"
 HOMEPAGE="https://www.kernel.org/pub/software/network/tftp/"
@@ -17,10 +17,12 @@ IUSE="ipv6 readline selinux tcpd +client +server"
 CDEPEND="
 	readline? ( sys-libs/readline:0= )
 	tcpd? ( sys-apps/tcp-wrappers )
-	!net-ftp/atftp"
+	"
 
 DEPEND="${CDEPEND}
-	app-arch/xz-utils"
+	app-arch/xz-utils
+	!net-ftp/atftp
+	!net-ftp/uftpd"
 
 RDEPEND="${CDEPEND}
 	selinux? ( sec-policy/selinux-tftp )"
@@ -48,23 +50,20 @@ src_compile() {
 	if use client; then
 		emake -C tftp
 	fi
-	if use daemon; then
+	if use server; then
 		emake -C tftpd
 	fi
 }
 
 src_install() {
 	dodoc README* CHANGES tftpd/sample.rules
-	emake INSTALLROOT="${D}" -C lib install
-	emake INSTALLROOT="${D}" -C common install
 
 	if use client; then
 		emake INSTALLROOT="${D}" -C tftp install
 	fi
-	if use daemon; then
+	if use server; then
+		emake INSTALLROOT="${D}" -C tftpd install
 
-		emake INSTALLROOT="${D}" install
-		# iputils installs this
 		rm "${ED}"/usr/share/man/man8/tftpd.8 || die
 
 		newconfd "${FILESDIR}"/in.tftpd.confd-0.44 in.tftpd


### PR DESCRIPTION
Now a user can install either the tftp client or the tftp server
or both. This is controlled by use flags. By default both are installed,
so this keeps backwards compatibility.

Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Oz Tiram <oz.tiram@gmail.com>