### PR TITLE
x11-libs/gtk+: enable cloudproviders USE

### DIFF
--- a/x11-libs/gtk+/gtk+-3.24.21.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.21.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.gtk.org/"
 
 LICENSE="LGPL-2+"
 SLOT="3"
-IUSE="aqua broadway cloudprint colord cups examples gtk-doc +introspection test vim-syntax wayland +X xinerama"
+IUSE="aqua broadway cloudprint cloudproviders colord cups examples gtk-doc +introspection test vim-syntax wayland +X xinerama"
 REQUIRED_USE="
 	|| ( aqua wayland X )
 	xinerama? ( X )
@@ -41,6 +41,7 @@ COMMON_DEPEND="
 	cloudprint? (
 		>=net-libs/rest-0.7[${MULTILIB_USEDEP}]
 		>=dev-libs/json-glib-1.0[${MULTILIB_USEDEP}] )
+	cloudproviders? ( >=dev-libs/libcloudproviders-0.3.1 )
 	colord? ( >=x11-misc/colord-0.1.9:0=[${MULTILIB_USEDEP}] )
 	cups? ( >=net-print/cups-2.0[${MULTILIB_USEDEP}] )
 	introspection? ( >=dev-libs/gobject-introspection-1.39:= )
@@ -138,6 +139,7 @@ multilib_src_configure() {
 		$(use_enable aqua quartz-backend)
 		$(use_enable broadway broadway-backend)
 		$(use_enable cloudprint)
+		$(use_enable cloudproviders)
 		$(use_enable colord)
 		$(use_enable cups cups auto)
 		$(multilib_native_use_enable gtk-doc)
@@ -150,8 +152,6 @@ multilib_src_configure() {
 		$(use_enable X xkb)
 		$(use_enable X xrandr)
 		$(use_enable xinerama)
-		# cloudprovider is not packaged in Gentoo yet
-		--disable-cloudproviders
 		--disable-papi
 		# sysprof integration needs >=sysprof-3.33.2
 		--disable-profiler

--- a/x11-libs/gtk+/metadata.xml
+++ b/x11-libs/gtk+/metadata.xml
@@ -14,6 +14,7 @@
 	<use>
 		<flag name="broadway">Enable the GDK Broadway backend.</flag>
 		<flag name="cloudprint">Enable printing via Google Cloud Print.</flag>
+		<flag name="cloudproviders">Enable cloud storage providers integration.</flag>
 		<flag name="colord">Use <pkg>x11-misc/colord</pkg> for color management
 			in printing</flag>
 	</use>


### PR DESCRIPTION
Prequisite `libcloudproviders` from `::guru` overlay

Depend on libcloudproviders (at this moment in ::guru).

Closes: https://bugs.gentoo.org/696806

Signed-off-by: David Heidelberg <david@ixit.cz>

![Screenshot from 2020-08-06 18-37-17](https://user-images.githubusercontent.com/2457435/89558388-727d9600-d814-11ea-81e9-989cbe2e919d.png)
