### PR TITLE
games-sports/xmoto: fix #730346

### DIFF
--- a/games-sports/xmoto/files/xmoto-0.6.1_lua_deprecated.patch
+++ b/games-sports/xmoto/files/xmoto-0.6.1_lua_deprecated.patch
@@ -1,0 +1,79 @@
+From fb004501a6387bb7ba5182b60ec305e9947dc545 Mon Sep 17 00:00:00 2001
+From: _yui <imbatman0xff@gmail.com>
+Date: Tue, 7 Jul 2020 21:44:49 +0300
+Subject: [PATCH 1/2] Fix building with Lua with deprecated functions removed
+
+---
+ src/CMakeLists.txt       | 5 +++++
+ src/xmoto/LuaLibBase.cpp | 6 ++++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a3f328f9..3618360e 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -461,6 +461,11 @@ check_prototype_definition(mkdir
+ )
+ target_compile_definitions(xmoto PUBLIC MS_MKDIR=$<BOOL:${MS_MKDIR}>)
+ 
++if(USE_SYSTEM_Lua)
++  check_symbol_exists(luaL_openlib lauxlib.h HAVE_LUAL_OPENLIB)
++  target_compile_definitions(xmoto PUBLIC HAVE_LUAL_OPENLIB=$<BOOL:${HAVE_LUAL_OPENLIB}>)
++endif()
++
+ target_compile_definitions(xmoto PUBLIC USE_OPENGL=$<BOOL:${USE_OPENGL}>)
+ target_compile_definitions(xmoto PUBLIC USE_SDLGFX=$<BOOL:${USE_SDLGFX}>)
+ target_compile_definitions(xmoto PUBLIC USE_GETTEXT=$<BOOL:${USE_GETTEXT}>)
+diff --git a/src/xmoto/LuaLibBase.cpp b/src/xmoto/LuaLibBase.cpp
+index fed3c79e..62b690e1 100644
+--- a/src/xmoto/LuaLibBase.cpp
++++ b/src/xmoto/LuaLibBase.cpp
+@@ -42,7 +42,13 @@ LuaLibBase::LuaLibBase(const std::string &i_libname, luaL_Reg i_reg[]) {
+   luaL_requiref(m_pL, LUA_TABLIBNAME, luaopen_table, 1);
+ #endif
+ 
++#if HAVE_LUAL_OPENLIB
+   luaL_openlib(m_pL, i_libname.c_str(), i_reg, 0);
++#else
++  lua_newtable(m_pL);
++  luaL_register(m_pL, i_libname.c_str(), i_reg);
++  lua_setglobal(m_pL, i_libname.c_str());
++#endif
+ }
+ 
+ LuaLibBase::~LuaLibBase() {
+
+From 0a92ee4e8d6ffb88f137b74ba3e9a9b688ac50e6 Mon Sep 17 00:00:00 2001
+From: _yui <imbatman0xff@gmail.com>
+Date: Tue, 7 Jul 2020 23:01:38 +0300
+Subject: [PATCH 2/2] Change luaL_register to luaL_setfuncs for lua 5.2 and
+ newer
+
+---
+ src/xmoto/LuaLibBase.cpp | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/xmoto/LuaLibBase.cpp b/src/xmoto/LuaLibBase.cpp
+index 62b690e1..911c5698 100644
+--- a/src/xmoto/LuaLibBase.cpp
++++ b/src/xmoto/LuaLibBase.cpp
+@@ -44,11 +44,17 @@ LuaLibBase::LuaLibBase(const std::string &i_libname, luaL_Reg i_reg[]) {
+ 
+ #if HAVE_LUAL_OPENLIB
+   luaL_openlib(m_pL, i_libname.c_str(), i_reg, 0);
+-#else
++#else // HAVE_LUAL_OPENLIB
+   lua_newtable(m_pL);
++
++#if LUA_VERSION_NUM >= 502
++  luaL_setfuncs(m_pL, i_reg, 0);
++#else // LUA_VERSION_NUM >= 502
+   luaL_register(m_pL, i_libname.c_str(), i_reg);
++#endif // LUA_VERSION_NUM >= 502
++
+   lua_setglobal(m_pL, i_libname.c_str());
+-#endif
++#endif // HAVE_LUAL_OPENLIB
+ }
+ 
+ LuaLibBase::~LuaLibBase() {

--- a/games-sports/xmoto/metadata.xml
+++ b/games-sports/xmoto/metadata.xml
@@ -8,4 +8,7 @@
   <use>
     <flag name="double-precision">more precise calculations at the expense of speed</flag>
   </use>
+  <upstream>
+    <remote-id type="github">xmoto/xmoto</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/games-sports/xmoto/xmoto-0.6.1-r1.ebuild
+++ b/games-sports/xmoto/xmoto-0.6.1-r1.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="A challenging 2D motocross platform game, where physics play an important role"
+HOMEPAGE="https://xmoto.tuxfamily.org"
+SRC_URI="https://github.com/xmoto/xmoto/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="double-precision +nls"
+
+RDEPEND="app-arch/bzip2
+	dev-db/sqlite:3
+	dev-games/ode[double-precision=]
+	dev-lang/lua:0
+	dev-libs/libxdg-basedir
+	dev-libs/libxml2
+	media-fonts/dejavu
+	media-libs/libpng:0=
+	media-libs/libsdl[joystick,opengl]
+	media-libs/sdl-mixer[vorbis]
+	media-libs/sdl-net
+	media-libs/sdl-ttf
+	net-misc/curl
+	sys-libs/zlib:=
+	virtual/jpeg:0
+	virtual/glu
+	virtual/opengl
+	nls? ( virtual/libintl )"
+DEPEND="${RDEPEND}"
+BDEPEND="app-arch/xz-utils
+	nls? ( sys-devel/gettext )"
+
+PATCHES=(
+	"${FILESDIR}/${P}_lua_deprecated.patch"
+)
+
+src_prepare() {
+	sed -e "/^Icon/s/.xpm//" -i extra/xmoto.desktop || die
+	sed -e "/add_subdirectory.*\(bzip2\|libccd\|lua\|ode\|xdgbasedir\)/d" -i src/CMakeLists.txt || die
+	rm -rf vendor/{bzip2,lua,ode,xdgbasedir} || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DUSE_GETTEXT=$(usex nls)
+		-DOpenGL_GL_PREFERENCE=GLVND
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	rm -f "${ED}/usr/share/xmoto"/Textures/Fonts/DejaVuSans{Mono,}.ttf || die
+	dosym ../../../fonts/dejavu/DejaVuSans.ttf /usr/share/xmoto/Textures/Fonts/DejaVuSans.ttf
+	dosym ../../../fonts/dejavu/DejaVuSansMono.ttf /usr/share/xmoto/Textures/Fonts/DejaVuSansMono.ttf
+}


### PR DESCRIPTION
Applied upstream patch for removing uses of deprecated lua 5.0 code.
Closes: https://bugs.gentoo.org/730346
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>