### PR TITLE
media-libs/mesa: enable option for V3D graphics driver.

### DIFF
--- a/media-libs/mesa/mesa-20.0.8.ebuild
+++ b/media-libs/mesa/mesa-20.0.8.ebuild
@@ -29,7 +29,7 @@ RESTRICT="
 "
 
 RADEON_CARDS="r100 r200 r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost v3d vc4 virgl vivante vmware"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -62,6 +62,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( gallium x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r600?   ( gallium )
 	video_cards_radeonsi?   ( gallium llvm )
+	video_cards_v3d? ( gallium )
 	video_cards_vc4? ( gallium )
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
@@ -427,6 +428,7 @@ multilib_src_configure() {
 		if use video_cards_freedreno ||
 		   use video_cards_lima ||
 		   use video_cards_panfrost ||
+		   use video_cards_v3d ||
 		   use video_cards_vc4 ||
 		   use video_cards_vivante; then
 			gallium_enable -- kmsro
@@ -434,6 +436,7 @@ multilib_src_configure() {
 
 		gallium_enable video_cards_lima lima
 		gallium_enable video_cards_panfrost panfrost
+		gallium_enable video_cards_v3d v3d
 		gallium_enable video_cards_vc4 vc4
 		gallium_enable video_cards_vivante etnaviv
 		gallium_enable video_cards_vmware svga

--- a/media-libs/mesa/mesa-20.1.4.ebuild
+++ b/media-libs/mesa/mesa-20.1.4.ebuild
@@ -29,7 +29,7 @@ RESTRICT="
 "
 
 RADEON_CARDS="r100 r200 r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost v3d vc4 virgl vivante vmware"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -62,6 +62,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( gallium x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r600?   ( gallium )
 	video_cards_radeonsi?   ( gallium llvm )
+	video_cards_v3d? ( gallium )
 	video_cards_vc4? ( gallium )
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
@@ -427,6 +428,7 @@ multilib_src_configure() {
 		if use video_cards_freedreno ||
 		   use video_cards_lima ||
 		   use video_cards_panfrost ||
+		   use video_cards_v3d ||
 		   use video_cards_vc4 ||
 		   use video_cards_vivante; then
 			gallium_enable -- kmsro
@@ -434,6 +436,7 @@ multilib_src_configure() {
 
 		gallium_enable video_cards_lima lima
 		gallium_enable video_cards_panfrost panfrost
+		gallium_enable video_cards_v3d v3d
 		gallium_enable video_cards_vc4 vc4
 		gallium_enable video_cards_vivante etnaviv
 		gallium_enable video_cards_vmware svga

--- a/media-libs/mesa/mesa-20.1.5.ebuild
+++ b/media-libs/mesa/mesa-20.1.5.ebuild
@@ -29,7 +29,7 @@ RESTRICT="
 "
 
 RADEON_CARDS="r100 r200 r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost v3d vc4 virgl vivante vmware"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -62,6 +62,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( gallium x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r600?   ( gallium )
 	video_cards_radeonsi?   ( gallium llvm )
+	video_cards_v3d? ( gallium )
 	video_cards_vc4? ( gallium )
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
@@ -426,6 +427,7 @@ multilib_src_configure() {
 		if use video_cards_freedreno ||
 		   use video_cards_lima ||
 		   use video_cards_panfrost ||
+		   use video_cards_v3d ||
 		   use video_cards_vc4 ||
 		   use video_cards_vivante; then
 			gallium_enable -- kmsro
@@ -433,6 +435,7 @@ multilib_src_configure() {
 
 		gallium_enable video_cards_lima lima
 		gallium_enable video_cards_panfrost panfrost
+		gallium_enable video_cards_v3d v3d
 		gallium_enable video_cards_vc4 vc4
 		gallium_enable video_cards_vivante etnaviv
 		gallium_enable video_cards_vmware svga

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -29,7 +29,7 @@ RESTRICT="
 "
 
 RADEON_CARDS="r100 r200 r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} freedreno i915 i965 intel iris lima nouveau panfrost v3d vc4 virgl vivante vmware"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -62,6 +62,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( gallium x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r600?   ( gallium )
 	video_cards_radeonsi?   ( gallium llvm )
+	video_cards_v3d? ( gallium )
 	video_cards_vc4? ( gallium )
 	video_cards_virgl? ( gallium )
 	video_cards_vivante? ( gallium gbm )
@@ -428,6 +429,7 @@ multilib_src_configure() {
 		if use video_cards_freedreno ||
 		   use video_cards_lima ||
 		   use video_cards_panfrost ||
+		   use video_cards_v3d ||
 		   use video_cards_vc4 ||
 		   use video_cards_vivante; then
 			gallium_enable -- kmsro
@@ -435,6 +437,7 @@ multilib_src_configure() {
 
 		gallium_enable video_cards_lima lima
 		gallium_enable video_cards_panfrost panfrost
+		gallium_enable video_cards_v3d v3d
 		gallium_enable video_cards_vc4 vc4
 		gallium_enable video_cards_vivante etnaviv
 		gallium_enable video_cards_vmware svga

--- a/profiles/desc/video_cards.desc
+++ b/profiles/desc/video_cards.desc
@@ -35,6 +35,7 @@ radeon - VIDEO_CARDS setting to build driver for ATI radeon video cards
 radeonsi - VIDEO_CARDS setting to build only Southern Islands based chips code for radeon
 siliconmotion - VIDEO_CARDS setting to build driver for siliconmotion video cards
 tegra - VIDEO_CARDS setting to build driver for tegra video cards
+v3d - VIDEO_CARDS setting to build driver for v3d video cards
 vc4 - VIDEO_CARDS setting to build driver for vc4 video cards
 vesa - VIDEO_CARDS setting to build driver for vesa video cards
 via - VIDEO_CARDS setting to build driver for via video cards


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/733190
Package-Manager: Portage-3.0.1, Repoman-2.3.23
Signed-off-by: Ross Charles Campbell <rossbridger.cc@gmail.com>