### PR TITLE
Fix xorg-3.eclass for git ebuilds

### DIFF
--- a/eclass/xorg-3.eclass
+++ b/eclass/xorg-3.eclass
@@ -49,7 +49,7 @@ fi
 
 # we need to inherit autotools first to get the deps
 inherit autotools libtool multilib toolchain-funcs flag-o-matic \
-	flag-o-matic ${FONT_ECLASS}
+	flag-o-matic ${FONT_ECLASS} ${GIT_ECLASS}
 
 if [[ ${XORG_MULTILIB} == yes ]]; then
 	inherit multilib-minimal


### PR DESCRIPTION
Looks like this was dropped

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>