### PR TITLE
net-wireless/rtl-sdr: update live ebuild

### DIFF
--- a/net-wireless/rtl-sdr/rtl-sdr-9999.ebuild
+++ b/net-wireless/rtl-sdr/rtl-sdr-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils multilib
+inherit cmake multilib
 
 DESCRIPTION="turns your Realtek RTL2832 based DVB dongle into a SDR receiver"
 HOMEPAGE="http://sdr.osmocom.org/trac/wiki/rtl-sdr"
@@ -41,13 +41,12 @@ src_configure() {
 		-DINSTALL_UDEV_RULES=OFF
 		-DDETACH_KERNEL_DRIVER=ON
 		-DENABLE_ZEROCOPY="$(usex zerocopy)"
-		-DLIB_INSTALL_DIR=$(get_libdir)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }
 
 src_install() {
-	cmake-utils_src_install
+	cmake_src_install
 	newinitd "${FILESDIR}"/rtl_tcp.initd rtl_tcp
 	newconfd "${FILESDIR}"/rtl_tcp.confd rtl_tcp
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/736320
Package-Manager: Portage-2.3.99, Repoman-2.3.23