### PR TITLE
games-action/minetest: Add missingok parameter to logrotate config

### DIFF
--- a/games-action/minetest/files/minetestserver.logrotate
+++ b/games-action/minetest/files/minetestserver.logrotate
@@ -1,5 +1,6 @@
 /var/log/minetest/minetest-server.log {
 	rotate 5
 	weekly
+	missingok
 	copytruncate
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/736346
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>