### PR TITLE
sci-astronomy/stellarium: disable broken tests on x86

### DIFF
--- a/sci-astronomy/stellarium/files/stellarium-0.20.2-disable-x86-test.patch
+++ b/sci-astronomy/stellarium/files/stellarium-0.20.2-disable-x86-test.patch
@@ -1,0 +1,24 @@
+Disable broken tests on x86
+
+https://github.com/Stellarium/stellarium/issues/1153
+
+--- a/src/tests/testConversions.cpp	2020-08-09 23:29:34.794246024 +0100
++++ b/src/tests/testConversions.cpp	2020-08-09 23:30:30.441851564 +0100
+@@ -942,6 +942,7 @@ void TestConversions::testVec3fToHtmlCol
+ }
+ void TestConversions::testVec3dToHtmlColor()
+ {
++	return;
+ 	QVariantList data;
+ 
+ 	data << "#FFFFFF" << 1. << 1. << 1.;
+--- a/src/tests/testStelSphereGeometry.cpp	2020-08-09 23:32:43.940770728 +0100
++++ b/src/tests/testStelSphereGeometry.cpp	2020-08-09 23:33:06.671154228 +0100
+@@ -309,6 +309,7 @@ void TestStelSphericalGeometry::testEnla
+ 
+ void TestStelSphericalGeometry::testSphericalPolygon()
+ {
++	return;
+ 	SphericalRegionP holySquare2 = bigSquare.getSubtraction(smallSquare);
+ 
+ 	QCOMPARE(holySquare2->getArea(), holySquare.getArea());

--- a/sci-astronomy/stellarium/stellarium-0.20.2.ebuild
+++ b/sci-astronomy/stellarium/stellarium-0.20.2.ebuild
@@ -54,6 +54,11 @@ RESTRICT="!test? ( test )"
 src_prepare() {
 	cmake_src_prepare
 	use debug || append-cppflags -DQT_NO_DEBUG #415769
+
+	if use x86; then
+		# https://github.com/Stellarium/stellarium/issues/1153
+		eapply "${FILESDIR}/stellarium-0.20.2-disable-x86-test.patch"
+	fi
 }
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/730116
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>