### PR TITLE
virtual/jdk: no [gentoo-vm] on openjdk:8

### DIFF
--- a/virtual/jdk/jdk-1.8.0-r4.ebuild
+++ b/virtual/jdk/jdk-1.8.0-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -10,7 +10,7 @@ KEYWORDS="amd64 ~arm arm64 ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-ma
 RDEPEND="|| (
 		dev-java/icedtea-bin:8
 		dev-java/icedtea:8
-		dev-java/openjdk-bin:8[gentoo-vm(+)]
-		dev-java/openjdk:8[gentoo-vm(+)]
+		dev-java/openjdk-bin:8
+		dev-java/openjdk:8
 		dev-java/oracle-jdk-bin:1.8
 	)"


### PR DESCRIPTION
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>