### PR TITLE
Make bluez-alsa configuration persistent

### DIFF
--- a/media-sound/bluez-alsa/bluez-alsa-2.1.0.ebuild
+++ b/media-sound/bluez-alsa/bluez-alsa-2.1.0.ebuild
@@ -71,6 +71,10 @@ multilib_src_install_all() {
 	newinitd "${FILESDIR}"/bluealsa-init.d bluealsa
 	newconfd "${FILESDIR}"/bluealsa-conf.d-2 bluealsa
 	systemd_dounit "${FILESDIR}"/bluealsa.service
+	# Add config file to alsa datadir as well to preserve changes in /etc
+	insinto "/usr/share/alsa/alsa.conf.d/"
+	doins "src/asound/20-bluealsa.conf"
+
 }
 
 pkg_postinst() {

--- a/media-sound/bluez-alsa/bluez-alsa-9999.ebuild
+++ b/media-sound/bluez-alsa/bluez-alsa-9999.ebuild
@@ -67,6 +67,10 @@ multilib_src_install_all() {
 	newinitd "${FILESDIR}"/bluealsa-init.d bluealsa
 	newconfd "${FILESDIR}"/bluealsa-conf.d-2 bluealsa
 	systemd_dounit "${FILESDIR}"/bluealsa.service
+	# Add config file to alsa datadir as well to preserve changes in /etc
+	insinto "/usr/share/alsa/alsa.conf.d/"
+	doins "src/asound/20-bluealsa.conf"
+
 }
 
 pkg_postinst() {

--- a/media-sound/bluez-alsa/files/bluealsa-init.d
+++ b/media-sound/bluez-alsa/files/bluealsa-init.d
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 pidfile="/var/run/bluealsa.pid"


### PR DESCRIPTION
The configuration file is installed into `/etc/alsa/conf.d/` which might be changed/deleted by the user, or portage if it's not in `CONFIG_PROTECT`.
Hereby adding to alsa datadir addresses this issue.