### PR TITLE
media-sound/whipper: add python3.8 support

### DIFF
--- a/media-sound/whipper/whipper-0.9.0.ebuild
+++ b/media-sound/whipper/whipper-0.9.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7,8} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
See bug [#736364](https://bugs.gentoo.org/736364).
media-sound/whipper is working with python 3.8