### PR TITLE
dev-python/pypy3-exe: Add patch to respect system PKG_CONFIG

### DIFF
--- a/dev-python/pypy3-exe/files/pypy3-exe-7.3.1-respect-pkg-config.patch
+++ b/dev-python/pypy3-exe/files/pypy3-exe-7.3.1-respect-pkg-config.patch
@@ -1,0 +1,14 @@
+diff --git a/rpython/translator/platform/posix.py b/rpython/translator/platform/posix.py
+index d53449a..4463831 100644
+--- a/rpython/translator/platform/posix.py
++++ b/rpython/translator/platform/posix.py
+@@ -62,7 +62,8 @@ class BasePosix(Platform):
+ 
+     def _pkg_config(self, lib, opt, default, check_result_dir=False):
+         try:
+-            ret, out, err = _run_subprocess("pkg-config", [lib, opt])
++            pkg_config = os.environ.get('PKG_CONFIG', 'pkg-config')
++            ret, out, err = _run_subprocess(pkg_config, [lib, opt])
+         except OSError as e:
+             err = str(e)
+             ret = 1

--- a/dev-python/pypy3-exe/pypy3-exe-7.3.1-r1.ebuild
+++ b/dev-python/pypy3-exe/pypy3-exe-7.3.1-r1.ebuild
@@ -38,6 +38,10 @@ BDEPEND="
 		)
 	)"
 
+PATCHES=(
+	"${FILESDIR}/pypy3-exe-7.3.1-respect-pkg-config.patch"
+)
+
 check_env() {
 	if use low-memory; then
 		CHECKREQS_MEMORY="1750M"
@@ -76,7 +80,7 @@ pkg_setup() {
 }
 
 src_configure() {
-	tc-export CC
+	tc-export CC PKG_CONFIG
 
 	local jit_backend
 	if use jit; then


### PR DESCRIPTION
This patch causes the pypy3-exe build to probe for a PKG_CONFIG variable
and only fall back to the default value if it is unset. This fix is
necessary for cross-compilation setups that use wrappers for pkg-config
to control which SYSROOT a package pulls dependencies from.

Package-Manager: Portage-2.3.75
Signed-off-by: Chris McDonald cjmcdonald@chromium.org