### PR TITLE
games-fps/prboom-plus: Install documentation files

### DIFF
--- a/games-fps/prboom-plus/files/prboom-plus-2.5.1.7.82-Add-install-rules-for-prboom-plus-documentation.patch
+++ b/games-fps/prboom-plus/files/prboom-plus-2.5.1.7.82-Add-install-rules-for-prboom-plus-documentation.patch
@@ -1,0 +1,63 @@
+From 3be21f1964d1446962adc15acf1e5d993708780f Mon Sep 17 00:00:00 2001
+From: William Breathitt Gray <vilhelm.gray@gmail.com>
+Date: Tue, 11 Aug 2020 20:25:46 -0400
+Subject: [PATCH] Add install rules for prboom-plus documentation
+
+---
+ prboom2/CMakeLists.txt     |  3 +++
+ prboom2/doc/CMakeLists.txt | 24 ++++++++++++++++++++++++
+ 2 files changed, 27 insertions(+)
+ create mode 100644 prboom2/doc/CMakeLists.txt
+
+diff --git a/prboom2/CMakeLists.txt b/prboom2/CMakeLists.txt
+index ec1885a5..52d91e19 100644
+--- a/prboom2/CMakeLists.txt
++++ b/prboom2/CMakeLists.txt
+@@ -9,6 +9,8 @@ include(TargetArch)
+ include(TestBigEndian)
+ TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
+ 
++include(GNUInstallDirs)
++
+ # Automated dependencies discovery, mostly needed for MSVC
+ target_architecture(TARGET_ARCH)
+ if(${TARGET_ARCH} MATCHES "i386")
+@@ -184,4 +186,5 @@ set(WAD_DATA prboom-plus.wad)
+ set(WAD_DATA_PATH "${PRBOOM_OUTPUT_PATH}/${WAD_DATA}")
+ 
+ add_subdirectory(data)
++add_subdirectory(doc)
+ add_subdirectory(src)
+diff --git a/prboom2/doc/CMakeLists.txt b/prboom2/doc/CMakeLists.txt
+new file mode 100644
+index 00000000..9f9b96c8
+--- /dev/null
++++ b/prboom2/doc/CMakeLists.txt
+@@ -0,0 +1,24 @@
++set(DOC_FILES
++    boom.txt
++    DeePBSPV4specs.txt
++    MBFFAQ.txt
++    MBF.txt
++    prboom-plus-history.html
++    prboom-plus-history.txt
++    prboom-plus-usage.txt
++    README.command-line
++    README.compat
++    README.demos
++    umapinfo.txt
++)
++set(MAN5_FILES
++    prboom-plus.cfg.5
++)
++set(MAN6_FILES
++    prboom-plus.6
++    prboom-plus-game-server.6
++)
++
++install(FILES ${DOC_FILES} TYPE DOC COMPONENT "Documentation")
++install(FILES ${MAN5_FILES} DESTINATION "${CMAKE_INSTALL_MANDIR}/man5" COMPONENT "Manpages")
++install(FILES ${MAN6_FILES} DESTINATION "${CMAKE_INSTALL_MANDIR}/man6" COMPONENT "Manpages")
+-- 
+2.28.0
+

--- a/games-fps/prboom-plus/prboom-plus-2.5.1.7.82.ebuild
+++ b/games-fps/prboom-plus/prboom-plus-2.5.1.7.82.ebuild
@@ -34,6 +34,7 @@ S="${WORKDIR}/${PN}-master/prboom2"
 
 src_prepare() {
 	eapply -p2 "${FILESDIR}"/prboom-plus-2.5.1.7.82-Add-CMake-install-targets.patch
+	eapply -p2 "${FILESDIR}"/prboom-plus-2.5.1.7.82-Add-install-rules-for-prboom-plus-documentation.patch
 	cmake_src_prepare
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/736713
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>