### PR TITLE
dev-haskell/hashable-1.2.4.0: Corrected GHC dependency

### DIFF
--- a/dev-haskell/hashable/hashable-1.2.4.0.ebuild
+++ b/dev-haskell/hashable/hashable-1.2.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -19,7 +19,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="+cpu_flags_x86_sse2 cpu_flags_x86_sse4_1"
 
 RDEPEND=">=dev-haskell/text-0.11.0.5:=[profile?]
-	>=dev-lang/ghc-7.4.1:=
+	<dev-lang/ghc-8.2.1:=
 "
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-1.8


### PR DESCRIPTION
Hashable depends on base > 4.0 && base < 4.10, which means that it's not compatible with GHC 8.2.1 or newer.

Signed-off-by: Jan Seeger <jan.seeger@thenybble.de>