### PR TITLE
app-crypt/trousers: Add patch for CVE-2020-244{30,31,32}

### DIFF
--- a/app-crypt/trousers/files/trousers-0.3.14-tcsd-fixes.patch
+++ b/app-crypt/trousers/files/trousers-0.3.14-tcsd-fixes.patch
@@ -1,0 +1,58 @@
+Index: trousers-0.3.14/src/tcs/ps/tcsps.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcs/ps/tcsps.c
++++ trousers-0.3.14/src/tcs/ps/tcsps.c
+@@ -72,7 +72,7 @@ get_file()
+ 	}
+ 
+ 	/* open and lock the file */
+-	system_ps_fd = open(tcsd_options.system_ps_file, O_CREAT|O_RDWR, 0600);
++	system_ps_fd = open(tcsd_options.system_ps_file, O_CREAT|O_RDWR|O_NOFOLLOW, 0600);
+ 	if (system_ps_fd < 0) {
+ 		LogError("system PS: open() of %s failed: %s",
+ 				tcsd_options.system_ps_file, strerror(errno));
+Index: trousers-0.3.14/src/tcsd/svrside.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcsd/svrside.c
++++ trousers-0.3.14/src/tcsd/svrside.c
+@@ -473,6 +473,7 @@ main(int argc, char **argv)
+ 		}
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
++	setgid(pwd->pw_gid);
+ 	setuid(pwd->pw_uid);
+ #endif
+ #endif
+Index: trousers-0.3.14/src/tcsd/tcsd_conf.c
+===================================================================
+--- trousers-0.3.14.orig/src/tcsd/tcsd_conf.c
++++ trousers-0.3.14/src/tcsd/tcsd_conf.c
+@@ -743,7 +743,7 @@ conf_file_init(struct tcsd_config *conf)
+ #ifndef SOLARIS
+ 	struct group *grp;
+ 	struct passwd *pw;
+-	mode_t mode = (S_IRUSR|S_IWUSR);
++	mode_t mode = (S_IRUSR|S_IWUSR|S_IRGRP);
+ #endif /* SOLARIS */
+ 	TSS_RESULT result;
+ 
+@@ -798,15 +798,15 @@ conf_file_init(struct tcsd_config *conf)
+ 	}
+ 
+ 	/* make sure user/group TSS owns the conf file */
+-	if (pw->pw_uid != stat_buf.st_uid || grp->gr_gid != stat_buf.st_gid) {
++	if (stat_buf.st_uid != 0 || grp->gr_gid != stat_buf.st_gid) {
+ 		LogError("TCSD config file (%s) must be user/group %s/%s", tcsd_config_file,
+-				TSS_USER_NAME, TSS_GROUP_NAME);
++				"root", TSS_GROUP_NAME);
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
+ 
+-	/* make sure only the tss user can manipulate the config file */
++	/* make sure only the tss user can read (but not manipulate) the config file */
+ 	if (((stat_buf.st_mode & 0777) ^ mode) != 0) {
+-		LogError("TCSD config file (%s) must be mode 0600", tcsd_config_file);
++		LogError("TCSD config file (%s) must be mode 0640", tcsd_config_file);
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
+ #endif /* SOLARIS */

--- a/app-crypt/trousers/trousers-0.3.14-r3.ebuild
+++ b/app-crypt/trousers/trousers-0.3.14-r3.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools linux-info readme.gentoo-r1 systemd udev
+
+DESCRIPTION="An open-source TCG Software Stack (TSS) v1.1 implementation"
+HOMEPAGE="http://trousers.sf.net"
+SRC_URI="mirror://sourceforge/trousers/${PN}/${P}.tar.gz"
+
+LICENSE="CPL-1.0 GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~m68k ~ppc ~ppc64 ~s390 ~x86"
+IUSE="doc libressl selinux" # gtk
+
+# gtk support presently does NOT compile.
+#	gtk? ( >=x11-libs/gtk+-2 )
+
+DEPEND="acct-group/tss
+	acct-user/tss
+	>=dev-libs/glib-2
+	!libressl? ( >=dev-libs/openssl-0.9.7:0= )
+	libressl? ( dev-libs/libressl:0= )"
+RDEPEND="${DEPEND}
+	selinux? ( sec-policy/selinux-tcsd )"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.3.13-nouseradd.patch"
+	"${FILESDIR}/${P}-libressl.patch"
+	"${FILESDIR}/${P}-fno-common.patch"
+	"${FILESDIR}/${P}-Makefile.am-Mark-tddl.a-nodist.patch"
+	"${FILESDIR}/${P}-tcsd-fixes.patch"
+)
+
+DOCS="AUTHORS ChangeLog NICETOHAVES README TODO"
+
+DOC_CONTENTS="
+	If you have problems starting tcsd, please check permissions and
+	ownership on /dev/tpm* and ~tss/system.data
+"
+S="${WORKDIR}"
+
+CONFIG_CHECK="~TCG_TPM"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# econf --with-gui=$(usex gtk gtk openssl)
+	econf --with-gui=openssl
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+
+	keepdir /var/lib/tpm
+	use doc && dodoc doc/*
+	newinitd "${FILESDIR}"/tcsd.initd tcsd
+	newconfd "${FILESDIR}"/tcsd.confd tcsd
+	systemd_dounit "${FILESDIR}"/tcsd.service
+	udev_dorules "${FILESDIR}"/61-trousers.rules
+	fowners tss:tss /var/lib/tpm
+	readme.gentoo_create_doc
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/737022
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Salah Coronya <salah.coronya@gmail.com>