### PR TITLE
media-libs/libheif: add gdk-pixbuf USE flag

### DIFF
--- a/media-libs/libheif/libheif-1.5.1.ebuild
+++ b/media-libs/libheif/libheif-1.5.1.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/strukturag/libheif"
 
 LICENSE="GPL-3"
 SLOT="0/1.5"
-IUSE="static-libs test +threads"
+IUSE="+gdk-pixbuf static-libs test +threads"
 RESTRICT="!test? ( test )"
 
 BDEPEND="test? ( dev-lang/go )"
@@ -28,6 +28,7 @@ DEPEND="
 	media-libs/x265:=[${MULTILIB_USEDEP}]
 	sys-libs/zlib:=[${MULTILIB_USEDEP}]
 	virtual/jpeg:0=[${MULTILIB_USEDEP}]
+	gdk-pixbuf? ( x11-libs/gdk-pixbuf )
 "
 RDEPEND="${DEPEND}"
 
@@ -49,6 +50,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	local myeconfargs=(
+		$(use_enable gdk-pixbuf)
 		$(use_enable threads multithreading)
 		$(use_enable static-libs static)
 	)

--- a/media-libs/libheif/libheif-1.6.1.ebuild
+++ b/media-libs/libheif/libheif-1.6.1.ebuild
@@ -18,8 +18,7 @@ HOMEPAGE="https://github.com/strukturag/libheif"
 
 LICENSE="GPL-3"
 SLOT="0/1.6"
-IUSE="static-libs test +threads"
-
+IUSE="+gdk-pixbuf static-libs test +threads"
 RESTRICT="!test? ( test )"
 
 BDEPEND="test? ( dev-lang/go )"
@@ -29,6 +28,7 @@ DEPEND="
 	media-libs/x265:=[${MULTILIB_USEDEP}]
 	sys-libs/zlib:=[${MULTILIB_USEDEP}]
 	virtual/jpeg:0=[${MULTILIB_USEDEP}]
+	gdk-pixbuf? ( x11-libs/gdk-pixbuf )
 "
 RDEPEND="${DEPEND}"
 
@@ -49,6 +49,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	local myeconfargs=(
+		$(use_enable gdk-pixbuf)
 		$(use_enable threads multithreading)
 		$(use_enable static-libs static)
 	)

--- a/media-libs/libheif/libheif-1.6.2.ebuild
+++ b/media-libs/libheif/libheif-1.6.2.ebuild
@@ -18,8 +18,7 @@ HOMEPAGE="https://github.com/strukturag/libheif"
 
 LICENSE="GPL-3"
 SLOT="0/1.6"
-IUSE="static-libs test +threads"
-
+IUSE="+gdk-pixbuf static-libs test +threads"
 RESTRICT="!test? ( test )"
 
 BDEPEND="test? ( dev-lang/go )"
@@ -29,6 +28,7 @@ DEPEND="
 	media-libs/x265:=[${MULTILIB_USEDEP}]
 	sys-libs/zlib:=[${MULTILIB_USEDEP}]
 	virtual/jpeg:0=[${MULTILIB_USEDEP}]
+	gdk-pixbuf? ( x11-libs/gdk-pixbuf )
 "
 RDEPEND="${DEPEND}"
 
@@ -49,6 +49,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	local myeconfargs=(
+		$(use_enable gdk-pixbuf)
 		$(use_enable threads multithreading)
 		$(use_enable static-libs static)
 	)

--- a/media-libs/libheif/libheif-1.7.0.ebuild
+++ b/media-libs/libheif/libheif-1.7.0.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/strukturag/libheif"
 
 LICENSE="GPL-3"
 SLOT="0/1.6"
-IUSE="static-libs test +threads"
+IUSE="+gdk-pixbuf static-libs test +threads"
 RESTRICT="!test? ( test )"
 
 BDEPEND="test? ( dev-lang/go )"
@@ -28,6 +28,7 @@ DEPEND="
 	media-libs/x265:=[${MULTILIB_USEDEP}]
 	sys-libs/zlib:=[${MULTILIB_USEDEP}]
 	virtual/jpeg:0=[${MULTILIB_USEDEP}]
+	gdk-pixbuf? ( x11-libs/gdk-pixbuf )
 "
 RDEPEND="${DEPEND}"
 
@@ -48,6 +49,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	local myeconfargs=(
+		$(use_enable gdk-pixbuf)
 		$(use_enable threads multithreading)
 		$(use_enable static-libs static)
 	)

--- a/media-libs/libheif/libheif-9999.ebuild
+++ b/media-libs/libheif/libheif-9999.ebuild
@@ -59,6 +59,11 @@ multilib_src_install_all() {
 	fi
 }
 
+multilib_src_test() {
+	default
+	emake -C go test
+}
+
 pkg_postinst() {
 	xdg_mimeinfo_database_update
 }

--- a/media-libs/libheif/libheif-9999.ebuild
+++ b/media-libs/libheif/libheif-9999.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/strukturag/libheif"
 
 LICENSE="GPL-3"
 SLOT="0/1.6"
-IUSE="static-libs test +threads"
+IUSE="+gdk-pixbuf static-libs test +threads"
 RESTRICT="!test? ( test )"
 
 BDEPEND="test? ( dev-lang/go )"
@@ -28,6 +28,7 @@ DEPEND="
 	media-libs/x265:=[${MULTILIB_USEDEP}]
 	sys-libs/zlib:=[${MULTILIB_USEDEP}]
 	virtual/jpeg:0=[${MULTILIB_USEDEP}]
+	gdk-pixbuf? ( x11-libs/gdk-pixbuf )
 "
 RDEPEND="${DEPEND}"
 
@@ -44,6 +45,7 @@ src_prepare() {
 
 multilib_src_configure() {
 	local myeconfargs=(
+		$(use_enable gdk-pixbuf)
 		$(use_enable threads multithreading)
 		$(use_enable static-libs static)
 	)

--- a/media-libs/libheif/metadata.xml
+++ b/media-libs/libheif/metadata.xml
@@ -6,4 +6,7 @@
 		<bugs-to>https://github.com/strukturag/libheif/issues</bugs-to>
 		<remote-id type="github">strukturag/libheif</remote-id>
 	</upstream>
+	<use>
+		<flag name="gdk-pixbuf">Enable gdk-pixbuf plugin</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/704746
Package-Manager: Portage-2.3.99, Repoman-2.3.23
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>