### PR TITLE
media-gfx/iscan: Add missing use flag dependencies

### DIFF
--- a/media-gfx/iscan/iscan-3.63.0.ebuild
+++ b/media-gfx/iscan/iscan-3.63.0.ebuild
@@ -30,6 +30,7 @@ DEPEND="${RDEPEND}
 	test? (
 		app-text/tesseract[png,tiff,training,-opencl]
 		media-fonts/dejavu
+		virtual/imagemagick-tools[png,tiff]
 	)
 "
 RESTRICT="!test? ( test )"

--- a/media-gfx/iscan/iscan-3.63.0.ebuild
+++ b/media-gfx/iscan/iscan-3.63.0.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 # Disable opencl as during reorient.utr test it produces inconsistent results
 DEPEND="${RDEPEND}
 	test? (
-		app-text/tesseract[training,-opencl]
+		app-text/tesseract[png,tiff,training,-opencl]
 		media-fonts/dejavu
 	)
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/737298
Signed-off-by: Marcin Deranek <marcin.deranek@slonko.net>