### PR TITLE
sys-auth/sssd: assortment of changes to 2.3.1

### DIFF
--- a/sys-auth/sssd/metadata.xml
+++ b/sys-auth/sssd/metadata.xml
@@ -19,8 +19,10 @@
 		<flag name="ssh">Build helper to let <pkg>net-misc/openssh</pkg> use sssd provided information</flag>
 		<flag name="sudo">Build helper to let <pkg>app-admin/sudo</pkg> use sssd provided information</flag>
 		<flag name="valgrind">Depend on <pkg>dev-util/valgrind</pkg> for test suite</flag>
+		<flag name="pac">Add Privileged Attribute Certificate Support for Kerberos</flag>
 	</use>
 	<upstream>
+		<remote-id type="cpe">cpe:/a:fedoraproject:sssd</remote-id>
 		<remote-id type="github">SSSD/sssd</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
cc @mattst88 

(in-place changes since its still masked, also makes it easier to review )

i do realize that i have been a bit brief in the commit message; i'll be more verbose here.

- added a few more useflags: doc, kcm, secrets and pac
  - doc use bdepends on doxygen, empty doc dirs installed by build system are now removed
  - pac use depends on samba useflag, it silently failed before
  - kcm and secrets use depend on systemd, kcm does not depend on secrets but can use it (is this time for optfeatures eclass? .... )

- using python-single-r1 in order to get python tests being run
- libwbclient is gone [from here]. upstream default disabled it with the intent to remove it because it stopped working a while ago
- migrate dependency stuff to {R,B,}DEPEND
- add a bunch of new configure options
  - some of these don't do anything [for us] ( with-{db-path,gpo-cache-path,pubconf-path,pipe-path,mcache-path,secrets-db-path} ) because we are already using the default value, or are just used for creating (empty) dirs, not as autoconf vars in code, others i wanted to be rather safe then sorry with ( with-log-path ) and finally there is with-run-path which defaulted to /var/run still; creates the directory which then needs to be deleted too, though.
- kerberos workaround do not seem to be required anymore, at least for my multilib build (no cross compilation tested)

caveats:
- systemd was not tested