### PR TITLE
games-emulation/dosbox-staging: add missing dep

### DIFF
--- a/games-emulation/dosbox-staging/dosbox-staging-0.75.0.ebuild
+++ b/games-emulation/dosbox-staging/dosbox-staging-0.75.0.ebuild
@@ -16,7 +16,7 @@ IUSE="alsa debug dynrec opengl opus"
 RDEPEND="alsa? ( media-libs/alsa-lib )
 	debug? ( sys-libs/ncurses:0= )
 	opengl? ( virtual/opengl )
-	opus? ( media-libs/opus )
+	opus? ( media-libs/opusfile )
 	media-libs/libpng:0=
 	media-libs/libsdl2[joystick,opengl?,video,X]
 	media-libs/sdl-net
@@ -43,5 +43,5 @@ src_configure() {
 src_install() {
 	default
 	doicon contrib/icons/${PN}.svg
-	make_desktop_entry dosbox DOSBox-staging ${PN}.svg
+	make_desktop_entry dosbox DOSBox-staging ${PN}
 }


### PR DESCRIPTION
also fix dekstop file to adhere to theme specs

Bug: https://bugs.gentoo.org/733314
Package-Manager: Portage-3.0.2, Repoman-2.3.23
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>