### PR TITLE
app-arch/gzip: Various improvements

### DIFF
--- a/app-arch/gzip/gzip-1.10-r1.ebuild
+++ b/app-arch/gzip/gzip-1.10-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit flag-o-matic
+
+DESCRIPTION="Standard GNU compressor"
+HOMEPAGE="https://www.gnu.org/software/gzip/"
+SRC_URI="mirror://gnu/gzip/${P}.tar.xz
+	mirror://gnu-alpha/gzip/${P}.tar.xz
+	mirror://gentoo/${P}.tar.xz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="pic static"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.3.8-install-symlinks.patch"
+)
+
+src_configure() {
+	use static && append-flags -static
+	# avoid text relocation in gzip
+	use pic && export DEFS="NO_ASM"
+	econf --disable-gcc-warnings #663928
+}
+
+src_install() {
+	default
+	docinto txt
+	dodoc algorithm.doc gzip.doc
+
+	# keep most things in /usr, just the fun stuff in /
+	dodir /bin
+	mv "${ED%/}"/usr/bin/{gunzip,gzip,uncompress,zcat} "${ED%/}"/bin/ || die
+	sed -e "s:${EPREFIX}/usr:${EPREFIX}:" -i "${ED%/}"/bin/gunzip || die
+}

--- a/app-arch/gzip/gzip-1.10-r1.ebuild
+++ b/app-arch/gzip/gzip-1.10-r1.ebuild
@@ -26,6 +26,10 @@ src_configure() {
 	# avoid text relocation in gzip
 	export DEFS="NO_ASM"
 
+	if use amd64 || use x86 ; then
+		append-cppflags -DUNALIGNED_OK
+	fi
+
 	econf --disable-gcc-warnings #663928
 }
 

--- a/app-arch/gzip/gzip-1.10-r1.ebuild
+++ b/app-arch/gzip/gzip-1.10-r1.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://www.gnu.org/software/gzip/"
 SRC_URI="mirror://gnu/gzip/${P}.tar.xz
 	mirror://gnu-alpha/gzip/${P}.tar.xz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="static"

--- a/app-arch/gzip/gzip-1.10-r1.ebuild
+++ b/app-arch/gzip/gzip-1.10-r1.ebuild
@@ -8,8 +8,7 @@ inherit flag-o-matic
 DESCRIPTION="Standard GNU compressor"
 HOMEPAGE="https://www.gnu.org/software/gzip/"
 SRC_URI="mirror://gnu/gzip/${P}.tar.xz
-	mirror://gnu-alpha/gzip/${P}.tar.xz
-	mirror://gentoo/${P}.tar.xz"
+	mirror://gnu-alpha/gzip/${P}.tar.xz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-arch/gzip/gzip-1.10-r1.ebuild
+++ b/app-arch/gzip/gzip-1.10-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit flag-o-matic
 
@@ -34,6 +34,6 @@ src_install() {
 
 	# keep most things in /usr, just the fun stuff in /
 	dodir /bin
-	mv "${ED%/}"/usr/bin/{gunzip,gzip,uncompress,zcat} "${ED%/}"/bin/ || die
-	sed -e "s:${EPREFIX}/usr:${EPREFIX}:" -i "${ED%/}"/bin/gunzip || die
+	mv "${ED}"/usr/bin/{gunzip,gzip,uncompress,zcat} "${ED}"/bin/ || die
+	sed -e "s:${EPREFIX}/usr:${EPREFIX}:" -i "${ED}"/bin/gunzip || die
 }

--- a/app-arch/gzip/gzip-1.10-r1.ebuild
+++ b/app-arch/gzip/gzip-1.10-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://gnu/gzip/${P}.tar.xz
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="pic static"
+IUSE="static"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.3.8-install-symlinks.patch"
@@ -22,8 +22,10 @@ PATCHES=(
 
 src_configure() {
 	use static && append-flags -static
+
 	# avoid text relocation in gzip
-	use pic && export DEFS="NO_ASM"
+	export DEFS="NO_ASM"
+
 	econf --disable-gcc-warnings #663928
 }
 


### PR DESCRIPTION
Various improvements:

- Migrate to EAPI=7
- Get rid of unusual USE=pic -- NO_ASM has no effect on most architectures so we should always set it. That's also Debian/Ubuntu and RHEL default.
- Set `UNALIGNED_OK` which should decrease (de)compression time by ~50%. Default in Debian/Ubuntu.