### PR TITLE
sox-fmt: validate comments_bytes before use

### DIFF
--- a/media-sound/sox/files/sox-14.4.2-CVE-2019-13590.patch
+++ b/media-sound/sox/files/sox-14.4.2-CVE-2019-13590.patch
@@ -1,0 +1,33 @@
+From 7b6a889217d62ed7e28188621403cc7542fd1f7e Mon Sep 17 00:00:00 2001
+From: Mans Rullgard <mans@mansr.com>
+Date: Tue, 4 Feb 2020 12:55:18 +0000
+Subject: [PATCH] sox-fmt: validate comments_bytes before use (CVE-2019-13590)
+ [bug #325]
+
+Cap the comments size to 1 GB to avoid overflows in subsequent
+arithmetic.
+
+The missing null check mentioned in the bug report is bogus since
+lsx_calloc() returns a valid pointer or aborts.
+---
+ src/sox-fmt.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/sox-fmt.c b/src/sox-fmt.c
+index aad965cd..11c88771 100644
+--- a/src/sox-fmt.c
++++ b/src/sox-fmt.c
+@@ -46,7 +46,9 @@ static int startread(sox_format_t * ft)
+       lsx_readdw(ft, &comments_bytes))
+     return SOX_EOF;
+ 
+-  if (((headers_bytes + 4) & 7) || headers_bytes < FIXED_HDR + comments_bytes ||
++  if (((headers_bytes + 4) & 7) ||
++      comments_bytes > 0x40000000 || /* max 1 GB */
++      headers_bytes < FIXED_HDR + comments_bytes ||
+       (num_channels > 65535)) /* Reserve top 16 bits */ {
+     lsx_fail_errno(ft, SOX_EHDR, "invalid sox file format header");
+     return SOX_EOF;
+-- 
+2.25.0.341.g760bfbb309-goog
+

--- a/media-sound/sox/sox-14.4.2-r2.ebuild
+++ b/media-sound/sox/sox-14.4.2-r2.ebuild
@@ -56,6 +56,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-CVE-2017-15372.patch
 	"${FILESDIR}"/${P}-CVE-2017-15642.patch
 	"${FILESDIR}"/${P}-CVE-2017-18189.patch
+	"${FILESDIR}"/${P}-CVE-2019-13590.patch
 	"${FILESDIR}"/${P}-wavpack-chk-errors-on-init.patch
 )
 


### PR DESCRIPTION
(CVE-2019-13590) [bug #325]
Cap the comments size to 1 GB to avoid overflows in subsequent
arithmetic.

The missing null check mentioned in the bug report is bogus since
lsx_calloc() returns a valid pointer or aborts.

patch from:
https://sourceforge.net/p/sox/code/ci/7b6a889217d62ed7e28188621403cc7542fd1f7e/

Bug: https://bugs.gentoo.org/711320
Signed-off-by: judyhsiao@chromium.org