### PR TITLE
dev-python/jedi: correct parso dependency

### DIFF
--- a/dev-python/jedi/jedi-0.17.0.ebuild
+++ b/dev-python/jedi/jedi-0.17.0.ebuild
@@ -23,7 +23,7 @@ LICENSE="MIT
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 x86"
 
-RDEPEND=">=dev-python/parso-0.5.2[${PYTHON_USEDEP}]"
+RDEPEND=">=dev-python/parso-0.7.0[${PYTHON_USEDEP}]"
 
 distutils_enable_sphinx docs \
 	dev-python/sphinx_rtd_theme

--- a/dev-python/jedi/jedi-0.17.1-r1.ebuild
+++ b/dev-python/jedi/jedi-0.17.1-r1.ebuild
@@ -25,7 +25,10 @@ LICENSE="MIT
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 
-RDEPEND=">=dev-python/parso-0.7.0[${PYTHON_USEDEP}]"
+RDEPEND="
+	>=dev-python/parso-0.7.0[${PYTHON_USEDEP}]
+	<dev-python/parso-0.8.0[${PYTHON_USEDEP}]
+"
 
 distutils_enable_sphinx docs \
 	dev-python/sphinx_rtd_theme

--- a/dev-python/jedi/jedi-0.17.2.ebuild
+++ b/dev-python/jedi/jedi-0.17.2.ebuild
@@ -25,7 +25,10 @@ LICENSE="MIT
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 x86"
 
-RDEPEND=">=dev-python/parso-0.7.0[${PYTHON_USEDEP}]"
+RDEPEND="
+	>=dev-python/parso-0.7.0[${PYTHON_USEDEP}]
+	<dev-python/parso-0.8.0[${PYTHON_USEDEP}]
+"
 
 distutils_enable_sphinx docs \
 	dev-python/sphinx_rtd_theme


### PR DESCRIPTION
this is how upstream specifies it

Closes: https://bugs.gentoo.org/738178
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>