### PR TITLE
dev-libs/zziplib: subslot 0/13

### DIFF
--- a/dev-libs/zziplib/zziplib-0.13.71.ebuild
+++ b/dev-libs/zziplib/zziplib-0.13.71.ebuild
@@ -11,8 +11,8 @@ HOMEPAGE="http://zziplib.sourceforge.net/"
 SRC_URI="https://github.com/gdraheim/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="|| ( LGPL-2.1 MPL-1.1 )"
-SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+SLOT="0/13"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc sdl static-libs test"
 
 RESTRICT="!test? ( test )"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/738236
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>