### PR TITLE
app-crypt/tpm2-tools: Fix build for non-FAPI users

### DIFF
--- a/app-crypt/tpm2-tools/tpm2-tools-4.2.1.ebuild
+++ b/app-crypt/tpm2-tools/tpm2-tools-4.2.1.ebuild
@@ -18,7 +18,7 @@ IUSE="+fapi libressl"
 RESTRICT="test"
 
 RDEPEND="net-misc/curl:=
-	fapi? ( >=app-crypt/tpm2-tss-2.4.0:=[fapi?] )
+	>=app-crypt/tpm2-tss-2.4.0:=[fapi?]
 	!libressl? ( dev-libs/openssl:0= )
 	libressl? ( dev-libs/libressl:0= )"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/738406
Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Salah Coronya <salah.coronya@gmail.com>