### PR TITLE
dev-libs/stp: declare boost as dependency

### DIFF
--- a/dev-libs/stp/stp-2.3.3.ebuild
+++ b/dev-libs/stp/stp-2.3.3.ebuild
@@ -11,10 +11,11 @@ SRC_URI="https://github.com/stp/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-2+ MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="python static test"
+IUSE="python test"
 RESTRICT="!test? ( test )"
 
 DEPEND="
+	dev-libs/boost:=
 	sci-mathematics/minisat
 "
 RDEPEND="${DEPEND}"
@@ -31,7 +32,6 @@ src_configure() {
 		-DENABLE_ASSERTIONS="$(usex test)"
 		-DENABLE_TESTING="$(usex test)"
 		-DENABLE_PYTHON_INTERFACE="$(usex python)"
-		-DSTATICCOMPILE="$(usex static)"
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
Also remove static flag as that requires (boost and) minisat with static-libs, which isn't packaged.

Closes: https://bugs.gentoo.org/699630
