### PR TITLE
eclass/kernel-build.eclass: copy module.lds linker script

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -147,6 +147,11 @@ kernel-build_src_install() {
 	mv include scripts "${ED}/usr/src/linux-${ver}/" || die
 	mv "arch/${kern_arch}/include" \
 		"${ED}/usr/src/linux-${ver}/arch/${kern_arch}/" || die
+	# some arches need module.lds linker script to build external modules
+	if [[ -f arch/${kern_arch}/kernel/module.lds ]]; then
+		insinto "/usr/src/linux-${ver}/arch/${kern_arch}/kernel"
+		doins "arch/${kern_arch}/kernel/module.lds"
+	fi
 
 	# remove everything but Makefile* and Kconfig*
 	find -type f '!' '(' -name 'Makefile*' -o -name 'Kconfig*' ')' \


### PR DESCRIPTION
without it it's impossible to build external kernel modules
on some arches (zfs-kmod on arm64 for example)


I haven't actually tested it yet =) build is running rn.

not sure what to do with revbumps in this case. it does not affect x86/amd64, but does affect arm64.
we don't have ppc64 keyword, but it also uses similar linker script.

@mgorny @thesamesam 