### PR TITLE
sys-apps/smartmontools: use EROOT instead of EPREFIX in postinst

### DIFF
--- a/sys-apps/smartmontools/smartmontools-7.0-r1.ebuild
+++ b/sys-apps/smartmontools/smartmontools-7.0-r1.ebuild
@@ -114,8 +114,8 @@ src_install() {
 
 pkg_postinst() {
 	if use daemon || use update_drivedb; then
-		local initial_db_file="${EPREFIX}/usr/share/${PN}/drivedb.h"
-		local db_path="${EPREFIX}/var/db/${PN}"
+		local initial_db_file="${EROOT}/usr/share/${PN}/drivedb.h"
+		local db_path="${EROOT}/var/db/${PN}"
 
 		if [[ ! -f "${db_path}/drivedb.h" ]] ; then
 			# No initial database found

--- a/sys-apps/smartmontools/smartmontools-7.1.ebuild
+++ b/sys-apps/smartmontools/smartmontools-7.1.ebuild
@@ -114,8 +114,8 @@ src_install() {
 
 pkg_postinst() {
 	if use daemon || use update_drivedb; then
-		local initial_db_file="${EPREFIX}/usr/share/${PN}/drivedb.h"
-		local db_path="${EPREFIX}/var/db/${PN}"
+		local initial_db_file="${EROOT}/usr/share/${PN}/drivedb.h"
+		local db_path="${EROOT}/var/db/${PN}"
 
 		if [[ ! -f "${db_path}/drivedb.h" ]] ; then
 			# No initial database found

--- a/sys-apps/smartmontools/smartmontools-9999.ebuild
+++ b/sys-apps/smartmontools/smartmontools-9999.ebuild
@@ -114,8 +114,8 @@ src_install() {
 
 pkg_postinst() {
 	if use daemon || use update_drivedb; then
-		local initial_db_file="${EPREFIX}/usr/share/${PN}/drivedb.h"
-		local db_path="${EPREFIX}/var/db/${PN}"
+		local initial_db_file="${EROOT}/usr/share/${PN}/drivedb.h"
+		local db_path="${EROOT}/var/db/${PN}"
 
 		if [[ ! -f "${db_path}/drivedb.h" ]] ; then
 			# No initial database found


### PR DESCRIPTION
Signed-off-by: Steven Johnson <steven.gregory.johnson@gmail.com>
Closes: https://bugs.gentoo.org/738668
Package-Manager: Portage-3.0.1, Repoman-2.3.23