### PR TITLE
dev-libs/rocclr: Correction of a path in a cmake file

### DIFF
--- a/dev-libs/rocclr/rocclr-3.7.0.ebuild
+++ b/dev-libs/rocclr/rocclr-3.7.0.ebuild
@@ -34,3 +34,10 @@ src_configure() {
 	)
 	cmake_src_configure
 }
+
+src_install() {
+	cmake_src_install
+
+	# This should be fixed in the CMakeLists.txt
+	sed -e "s:${BUILD_DIR}:${EPREFIX}/usr:" -i "${D}/usr/lib/cmake/rocclr/ROCclrConfig.cmake" || die
+}


### PR DESCRIPTION
Signed-off-by: Wilfried Holzke <gentoo@holzke.net>
Package-Manager: Portage-2.3.103, Repoman-2.3.23