### PR TITLE
kde-apps/pimcommon: Add missing dependency kde-apps/akonadi-search

### DIFF
--- a/kde-apps/pimcommon/pimcommon-20.08.0.ebuild
+++ b/kde-apps/pimcommon/pimcommon-20.08.0.ebuild
@@ -30,6 +30,7 @@ COMMON_DEPEND="
 	>=dev-qt/qtxml-${QTMIN}:5
 	>=kde-apps/akonadi-${PVCUT}:5
 	>=kde-apps/akonadi-contacts-${PVCUT}:5
+	>=kde-apps/akonadi-search-${PVCUT}:5
 	>=kde-apps/kimap-${PVCUT}:5
 	>=kde-apps/kldap-${PVCUT}:5
 	>=kde-apps/kpimtextedit-${PVCUT}:5


### PR DESCRIPTION
This is my try to add missing dependency, more details in bug report.

Closes: https://bugs.gentoo.org/738714
Signed-off-by: Branko Grubic <bitlord0xff@gmail.com>