### PR TITLE
dev-libs/nss: Add NS_USE_GCC environment variable

### DIFF
--- a/dev-libs/nss/nss-3.56.ebuild
+++ b/dev-libs/nss/nss-3.56.ebuild
@@ -161,6 +161,8 @@ multilib_src_compile() {
 	export USE_SYSTEM_ZLIB=1
 	export ZLIB_LIBS=-lz
 	export ASFLAGS=""
+	# Fix build failure on arm64
+	export NS_USE_GCC=1
 
 	local d
 

--- a/dev-libs/nss/nss-3.56.ebuild
+++ b/dev-libs/nss/nss-3.56.ebuild
@@ -163,6 +163,12 @@ multilib_src_compile() {
 	export ASFLAGS=""
 	# Fix build failure on arm64
 	export NS_USE_GCC=1
+	# Detect compiler type and set proper environment value
+	if tc-is-gcc; then
+		export CC_IS_GCC=1
+	elif tc-is-clang; then
+		export CC_IS_CLANG=1
+	fi
 
 	local d
 


### PR DESCRIPTION
This variable seems to be required to be be set in order to have certain
files to be compiled on arm64 linux systems, otherwise some symbols will be missing at linking thus causing build failure.

AFAIK the purpose of NS_USE_GCC flag is just to enable some accelerated algorithms written in gcc's C dialect, so there shouldn't be any build failures or behavior changes on other CPU arches.

Upstream's commit on this behavior change: https://hg.mozilla.org/projects/nss/rev/d98bbb6168f4ca2abd534e4c2fce56b7a5d1ad7e

Closes: https://bugs.gentoo.org/738924
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Ross Charles Campbell <rossbridger.cc@gmail.com>