### PR TITLE
dev-python/pycurl: add patch for multiple SSL backends

### DIFF
--- a/dev-python/pycurl/files/pycurl-7.43.0.5-multiple-ssl.patch
+++ b/dev-python/pycurl/files/pycurl-7.43.0.5-multiple-ssl.patch
@@ -1,0 +1,146 @@
+From 290d762ea13a1d95affa0888c5450b33b00241e8 Mon Sep 17 00:00:00 2001
+From: Bo Anderson <mail@boanderson.me>
+Date: Tue, 21 Jul 2020 18:28:31 +0100
+Subject: [PATCH] Handle MultiSSL
+
+Upstream-Status: Accepted [https://github.com/pycurl/pycurl/pull/639]
+Signed-off-by: Stefan Strogin <steils@gentoo.org>
+---
+ src/module.c | 41 ++++++++++++++++++++++++++++++++++++++++-
+ src/pycurl.h | 11 +++++++++++
+ 2 files changed, 51 insertions(+), 1 deletion(-)
+
+diff --git a/src/module.c b/src/module.c
+index 23387ec..dbc5b0c 100644
+--- a/src/module.c
++++ b/src/module.c
+@@ -322,12 +322,21 @@ initpycurl(void)
+ {
+     PyObject *m, *d;
+     const curl_version_info_data *vi;
+-    const char *libcurl_version, *runtime_ssl_lib;
++    const char *libcurl_version;
+     size_t libcurl_version_len, pycurl_version_len;
+     PyObject *xio_module = NULL;
+     PyObject *collections_module = NULL;
+     PyObject *named_tuple = NULL;
+     PyObject *arglist = NULL;
++#ifdef HAVE_CURL_GLOBAL_SSLSET
++    const curl_ssl_backend **ssllist = NULL;
++    CURLsslset sslset;
++    int i, runtime_supported_backend_found = 0;
++    char backends[200];
++    size_t backends_len = 0;
++#else
++    const char *runtime_ssl_lib;
++#endif
+ 
+     assert(Curl_Type.tp_weaklistoffset > 0);
+     assert(CurlMulti_Type.tp_weaklistoffset > 0);
+@@ -346,6 +355,35 @@ initpycurl(void)
+     }
+ 
+     /* Our compiled crypto locks should correspond to runtime ssl library. */
++#ifdef HAVE_CURL_GLOBAL_SSLSET
++    sslset = curl_global_sslset(-1, COMPILE_SSL_LIB, &ssllist);
++    if (sslset != CURLSSLSET_OK) {
++        if (sslset == CURLSSLSET_NO_BACKENDS) {
++            strcpy(backends, "none");
++        } else {
++            for (i = 0; ssllist[i] != NULL; i++) {
++                switch (ssllist[i]->id) {
++                case CURLSSLBACKEND_OPENSSL:
++                case CURLSSLBACKEND_GNUTLS:
++                case CURLSSLBACKEND_NSS:
++                case CURLSSLBACKEND_WOLFSSL:
++                case CURLSSLBACKEND_MBEDTLS:
++                    runtime_supported_backend_found = 1;
++                    break;
++                default:
++                    break;
++                }
++                if (backends_len < sizeof(backends)) {
++                    backends_len += snprintf(backends + backends_len, sizeof(backends) - backends_len, "%s%s", (i > 0) ? ", " : "", ssllist[i]->name);
++                }
++            }
++        }
++        if (runtime_supported_backend_found == COMPILE_SUPPORTED_SSL_BACKEND_FOUND) {
++            PyErr_Format(PyExc_ImportError, "pycurl: libcurl link-time ssl backends (%s) do not include compile-time ssl backend (%s)", backends, COMPILE_SSL_LIB);
++            goto error;
++        }
++    }
++#else
+     if (vi->ssl_version == NULL) {
+         runtime_ssl_lib = "none/other";
+     } else if (!strncmp(vi->ssl_version, "OpenSSL/", 8) || !strncmp(vi->ssl_version, "LibreSSL/", 9) ||
+@@ -366,6 +404,7 @@ initpycurl(void)
+         PyErr_Format(PyExc_ImportError, "pycurl: libcurl link-time ssl backend (%s) is different from compile-time ssl backend (%s)", runtime_ssl_lib, COMPILE_SSL_LIB);
+         goto error;
+     }
++#endif
+ 
+     /* Initialize the type of the new type objects here; doing it here
+      * is required for portability to Windows without requiring C++. */
+diff --git a/src/pycurl.h b/src/pycurl.h
+index 02db495..a83c85b 100644
+--- a/src/pycurl.h
++++ b/src/pycurl.h
+@@ -154,6 +154,10 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
+ #define HAVE_CURLINFO_HTTP_VERSION
+ #endif
+ 
++#if LIBCURL_VERSION_NUM >= 0x073800 /* check for 7.56.0 or greater */
++#define HAVE_CURL_GLOBAL_SSLSET
++#endif
++
+ #undef UNUSED
+ #define UNUSED(var)     ((void)&var)
+ 
+@@ -165,6 +169,7 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
+ #   include <openssl/ssl.h>
+ #   include <openssl/err.h>
+ #   define COMPILE_SSL_LIB "openssl"
++#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
+ # elif defined(HAVE_CURL_WOLFSSL)
+ #   include <wolfssl/options.h>
+ #   if defined(OPENSSL_EXTRA)
+@@ -187,6 +192,7 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
+ #    endif
+ #   endif
+ #   define COMPILE_SSL_LIB "wolfssl"
++#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
+ # elif defined(HAVE_CURL_GNUTLS)
+ #   include <gnutls/gnutls.h>
+ #   if GNUTLS_VERSION_NUMBER <= 0x020b00
+@@ -195,13 +201,16 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
+ #     include <gcrypt.h>
+ #   endif
+ #   define COMPILE_SSL_LIB "gnutls"
++#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
+ # elif defined(HAVE_CURL_NSS)
+ #   define COMPILE_SSL_LIB "nss"
++#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
+ # elif defined(HAVE_CURL_MBEDTLS)
+ #   include <mbedtls/ssl.h>
+ #   define PYCURL_NEED_SSL_TSL
+ #   define PYCURL_NEED_MBEDTLS_TSL
+ #   define COMPILE_SSL_LIB "mbedtls"
++#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
+ # else
+ #  ifdef _MSC_VER
+     /* sigh */
+@@ -218,9 +227,11 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
+    /* since we have no crypto callbacks for other ssl backends,
+     * no reason to require users match those */
+ #  define COMPILE_SSL_LIB "none/other"
++#  define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 0
+ # endif /* HAVE_CURL_OPENSSL || HAVE_CURL_WOLFSSL || HAVE_CURL_GNUTLS || HAVE_CURL_NSS || HAVE_CURL_MBEDTLS */
+ #else
+ # define COMPILE_SSL_LIB "none/other"
++# define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 0
+ #endif /* HAVE_CURL_SSL */
+ 
+ #if defined(PYCURL_NEED_SSL_TSL)
+-- 
+2.28.0
+

--- a/dev-python/pycurl/pycurl-7.43.0.5-r1.ebuild
+++ b/dev-python/pycurl/pycurl-7.43.0.5-r1.ebuild
@@ -1,0 +1,93 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=manual
+# The selftests fail with pypy, and urlgrabber segfaults for me.
+PYTHON_COMPAT=( python3_{6,7,8,9} )
+
+inherit distutils-r1 toolchain-funcs
+
+DESCRIPTION="python binding for curl/libcurl"
+HOMEPAGE="
+	https://github.com/pycurl/pycurl
+	https://pypi.org/project/pycurl/
+	http://pycurl.io/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
+IUSE="curl_ssl_gnutls curl_ssl_libressl curl_ssl_nss +curl_ssl_openssl examples ssl test"
+RESTRICT="!test? ( test )"
+
+# Depend on a curl with curl_ssl_* USE flags.
+# libcurl must not be using an ssl backend we do not support.
+# If the libcurl ssl backend changes pycurl should be recompiled.
+# If curl uses gnutls, depend on at least gnutls 2.11.0 so that pycurl
+# does not need to initialize gcrypt threading and we do not need to
+# explicitly link to libgcrypt.
+RDEPEND="
+	>=net-misc/curl-7.25.0-r1:=[ssl=]
+	ssl? (
+		net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,curl_ssl_nss(-)=,curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-)]
+		curl_ssl_gnutls? ( >=net-libs/gnutls-2.11.0:= )
+		curl_ssl_libressl? ( dev-libs/libressl:= )
+		curl_ssl_openssl? ( dev-libs/openssl:= )
+	)"
+
+# bottle-0.12.7: https://github.com/pycurl/pycurl/issues/180
+# bottle-0.12.7: https://github.com/defnull/bottle/commit/f35197e2a18de1672831a70a163fcfd38327a802
+DEPEND="${RDEPEND}
+	test? (
+		dev-python/bottle[${PYTHON_USEDEP}]
+		dev-python/flaky[${PYTHON_USEDEP}]
+		dev-python/nose[${PYTHON_USEDEP}]
+		net-misc/curl[curl_ssl_gnutls(-)=,curl_ssl_libressl(-)=,curl_ssl_nss(-)=,curl_ssl_openssl(-)=,-curl_ssl_axtls(-),-curl_ssl_cyassl(-),http2]
+		>=dev-python/bottle-0.12.7[${PYTHON_USEDEP}]
+	)"
+
+PATCHES=(
+	"${FILESDIR}"/pycurl-7.43.0.5-telnet-test.patch
+	"${FILESDIR}"/pycurl-7.43.0.5-cc-cflags.patch
+	"${FILESDIR}"/pycurl-7.43.0.5-multiple-ssl.patch
+)
+
+python_prepare_all() {
+	sed -e "/setup_args\['data_files'\] = /d" -i setup.py || die
+	# disable automagic use of setuptools
+	sed -e 's:import wheel:raise ImportError:' -i setup.py || die
+	# these tests are broken with newer versions of bottle
+	sed -e 's:test.*_invalid_utf8:_&:' -i tests/getinfo_test.py || die
+	distutils-r1_python_prepare_all
+}
+
+python_configure_all() {
+	# Override faulty detection in setup.py, bug 510974.
+	export PYCURL_SSL_LIBRARY=${CURL_SSL/libressl/openssl}
+}
+
+src_test() {
+	# upstream bundles precompiled amd64 libs
+	rm tests/fake-curl/libcurl/*.so || die
+	emake -C tests/fake-curl/libcurl CC="$(tc-getCC)"
+
+	distutils-r1_src_test
+}
+
+python_compile() {
+	python_is_python3 || local -x CFLAGS="${CFLAGS} -fno-strict-aliasing"
+	distutils-r1_python_compile
+}
+
+python_test() {
+	nosetests -a '!standalone,!gssapi' -v --with-flaky || die "Tests fail with ${EPYTHON}"
+	nosetests -a 'standalone' -v --with-flaky || die "Tests fail with ${EPYTHON}"
+}
+
+python_install_all() {
+	local HTML_DOCS=( doc/. )
+	use examples && dodoc -r examples
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
net-misc/curl supports multiple SSL backends since 5e560782
"net-misc/curl: enable multiple ssl implementations", which is supported
in curl since 7.56.

pycurl supporting this feature is not released yet, so with the latest
pycurl users could get an error like:

ImportError: pycurl: libcurl link-time ssl backend (gnutls) is different
from compile-time ssl backend (openssl)

Add patch from upstream to support multiple SSL backend in pycurl.

Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Stefan Strogin <steils@gentoo.org>