### PR TITLE
dev-python/pypy* : update SRC_URI

### DIFF
--- a/dev-python/pypy-exe/pypy-exe-7.3.0.ebuild
+++ b/dev-python/pypy-exe/pypy-exe-7.3.0.ebuild
@@ -9,7 +9,7 @@ inherit check-reqs pax-utils python-any-r1 toolchain-funcs
 MY_P=pypy2.7-v${PV/_/}
 DESCRIPTION="PyPy executable (build from source)"
 HOMEPAGE="https://pypy.org/"
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2"
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2"
 S="${WORKDIR}/${MY_P}-src"
 
 LICENSE="MIT"

--- a/dev-python/pypy-exe/pypy-exe-7.3.1.ebuild
+++ b/dev-python/pypy-exe/pypy-exe-7.3.1.ebuild
@@ -9,7 +9,7 @@ inherit check-reqs pax-utils python-any-r1 toolchain-funcs
 MY_P=pypy2.7-v${PV/_/}
 DESCRIPTION="PyPy executable (build from source)"
 HOMEPAGE="https://pypy.org/"
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2"
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2"
 S="${WORKDIR}/${MY_P}-src"
 
 LICENSE="MIT"

--- a/dev-python/pypy/pypy-7.3.0.ebuild
+++ b/dev-python/pypy/pypy-7.3.0.ebuild
@@ -11,7 +11,7 @@ PATCHSET="python-gentoo-patches-2.7.17-r1"
 
 DESCRIPTION="A fast, compliant alternative implementation of the Python language"
 HOMEPAGE="https://pypy.org/"
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2
 	https://dev.gentoo.org/~mgorny/dist/python/${PATCHSET}.tar.xz"
 S="${WORKDIR}/${MY_P}-src"
 

--- a/dev-python/pypy/pypy-7.3.1-r2.ebuild
+++ b/dev-python/pypy/pypy-7.3.1-r2.ebuild
@@ -11,7 +11,7 @@ PATCHSET="python-gentoo-patches-2.7.17-r1"
 
 DESCRIPTION="A fast, compliant alternative implementation of the Python language"
 HOMEPAGE="https://pypy.org/"
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2
 	https://dev.gentoo.org/~mgorny/dist/python/${PATCHSET}.tar.xz"
 S="${WORKDIR}/${MY_P}-src"
 

--- a/dev-python/pypy3-exe/pypy3-exe-7.3.0.ebuild
+++ b/dev-python/pypy3-exe/pypy3-exe-7.3.0.ebuild
@@ -10,7 +10,7 @@ inherit check-reqs pax-utils python-any-r1 toolchain-funcs
 MY_P=pypy3.6-v${PV/_/}
 DESCRIPTION="PyPy3 executable (build from source)"
 HOMEPAGE="https://pypy.org/"
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2"
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2"
 S="${WORKDIR}/${MY_P}-src"
 
 LICENSE="MIT"

--- a/dev-python/pypy3-exe/pypy3-exe-7.3.1.ebuild
+++ b/dev-python/pypy3-exe/pypy3-exe-7.3.1.ebuild
@@ -10,7 +10,7 @@ inherit check-reqs pax-utils python-any-r1 toolchain-funcs
 MY_P=pypy3.6-v${PV/_/}
 DESCRIPTION="PyPy3 executable (build from source)"
 HOMEPAGE="https://pypy.org/"
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2"
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2"
 S="${WORKDIR}/${MY_P}-src"
 
 LICENSE="MIT"

--- a/dev-python/pypy3/pypy3-7.3.0.ebuild
+++ b/dev-python/pypy3/pypy3-7.3.0.ebuild
@@ -10,7 +10,7 @@ MY_P=pypy3.6-v${PV/_/}
 
 DESCRIPTION="A fast, compliant alternative implementation of the Python (3.6) language"
 HOMEPAGE="https://pypy.org/"
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2"
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2"
 S="${WORKDIR}/${MY_P}-src"
 
 LICENSE="MIT"

--- a/dev-python/pypy3/pypy3-7.3.1-r2.ebuild
+++ b/dev-python/pypy3/pypy3-7.3.1-r2.ebuild
@@ -10,7 +10,7 @@ MY_P=pypy3.6-v${PV/_/}
 
 DESCRIPTION="A fast, compliant alternative implementation of the Python (3.6) language"
 HOMEPAGE="https://pypy.org/"
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2"
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2"
 S="${WORKDIR}/${MY_P}-src"
 
 LICENSE="MIT"


### PR DESCRIPTION
dev-python/pypy-exe, dev-python/pypy, dev-python/pypy3-exe, dev-python/pypy3 uses SRC_URI that not available anymore (see #737896):

``` diff
-SRC_URI="https://bitbucket.org/pypy/pypy/downloads/${MY_P}-src.tar.bz2
+SRC_URI="https://downloads.python.org/pypy/${MY_P}-src.tar.bz2
```

Checksums matches, so there no any revbumps required.