### PR TITLE
sys-devel/gcc-config: Add prompt to remove native symlinks

### DIFF
--- a/sys-devel/gcc-config/files/gcc-config-add-USE_NATIVE_LINKS-no-as-prompt-option.patch
+++ b/sys-devel/gcc-config/files/gcc-config-add-USE_NATIVE_LINKS-no-as-prompt-option.patch
@@ -1,0 +1,33 @@
+diff --git a/gcc-config b/gcc-config
+index dee6f98..07a1a3e 100755
+--- a/gcc-config
++++ b/gcc-config
+@@ -52,6 +52,7 @@ usage() {
+ 	  -O, --use-old              Use the old profile if one was selected.
+ 	  -f, --force                Make sure all config files are regenerated.
+ 	  -c, --get-current-profile  Print current used gcc profile.
++	  -d, --unlink-current       Remove the symlinks installed for the current profile.
+ 	  -l, --list-profiles        Print a list of available profiles.
+ 	  -S, --split-profile        Split profiles into their components
+ 	  -E, --print-environ        Print environment that can be used to setup the
+@@ -845,6 +846,10 @@ get_current_profile() {
+ 	return 0
+ }
+ 
++unlink_current_profile() {
++	switch_profile get_current_profile
++}
++
+ list_profiles() {
+ 	local i=0
+ 	local filter=
+@@ -1016,6 +1021,9 @@ for x in "$@" ; do
+ 		-c|--get-current-profile)
+ 			set_doit get_current_profile
+ 			;;
++		-d|--unlink-current)
++			set_doit unlink_current_profile
++			;;
+ 		-l|--list-profiles)
+ 			set_doit list_profiles
+ 			;;

--- a/sys-devel/gcc-config/gcc-config-9999.ebuild
+++ b/sys-devel/gcc-config/gcc-config-9999.ebuild
@@ -21,6 +21,12 @@ IUSE="+cc-wrappers +native-symlinks"
 
 RDEPEND=">=sys-apps/gentoo-functions-0.10"
 
+src_prepare() {
+	default
+
+	use native-symlinks && eapply "${FILESDIR}/gcc-config-add-USE_NATIVE_LINKS-no-as-prompt-option.patch"
+}
+
 _emake() {
 	emake \
 		PV="${PV}" \


### PR DESCRIPTION
This change is meant to be a quick way to remove installed native symlinks created by `gcc-config`. It provides the same functionality as `--disable-native-links` so this might be seen as redundant.

When emerged with USE=native-symlinks, `gcc-config` will not have the option displayed.

Alternatively, just update the prompt:
```
diff --git a/gcc-config b/gcc-config
index dee6f98..2a76b5d 100755
--- a/gcc-config
+++ b/gcc-config
@@ -60,6 +60,8 @@ usage() {
 	                             profile are located.
 	  -L, --get-lib-path         Print path where libraries of the given/current
 	                             profile are located.
+	  --enable-native-links      Install symlinks to /usr/bin (default with USE=native-symlinks)
+	  --disable-native-links     Don't install symlinks to /usr/bin
 
 	Profile names are of the form:  <CTARGET>-<version>
 	For example:                    i686-pc-linux-gnu-3.2.1
```