### PR TITLE
dev-java/plexus-classworlds: Add missing dependency to ant-junit4

### DIFF
--- a/dev-java/plexus-classworlds/plexus-classworlds-2.2.3.ebuild
+++ b/dev-java/plexus-classworlds/plexus-classworlds-2.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=">=virtual/jdk-1.6
-		test? ( dev-java/junit:4 )"
+		test? ( dev-java/ant-junit4 )"
 RDEPEND=">=virtual/jre-1.6"
 
 JAVA_ANT_REWRITE_CLASSPATH="true"


### PR DESCRIPTION
The tests cannot be executed without ant-junit4 during the test phase.

Closes: https://bugs.gentoo.org/736954
Package-Manager: Portage-2.3.103, Repoman-2.3.23