### PR TITLE
net-libs/pjproject: add dependency on media-libs/speex with USE=speex.

### DIFF
--- a/net-libs/pjproject/pjproject-2.9-r2.ebuild
+++ b/net-libs/pjproject/pjproject-2.9-r2.ebuild
@@ -39,7 +39,10 @@ RDEPEND="net-libs/libsrtp:=
 	portaudio? ( media-libs/portaudio )
 	resample? ( media-libs/libsamplerate )
 	sdl? ( media-libs/libsdl )
-	speex? ( media-libs/speexdsp )
+	speex? (
+		media-libs/speex
+		media-libs/speexdsp
+	)
 	ssl? (
 		!libressl? ( dev-libs/openssl:0= )
 		libressl? ( dev-libs/libressl:0= )


### PR DESCRIPTION
Signed-off-by: Jaco Kroon <jaco@uls.co.za>
Closes: https://bugs.gentoo.org/739242