### PR TITLE
sys-auth/sssd-2.2.3: Fix glibc 2.32 name conflict

### DIFF
--- a/sys-auth/sssd/files/sssd-2.2.3-glibc-2.32-compat.patch
+++ b/sys-auth/sssd/files/sssd-2.2.3-glibc-2.32-compat.patch
@@ -1,0 +1,71 @@
+From fe9eeb51be06059721e873f77092b1e9ba08e6c1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michal=20=C5=BDidek?= <mzidek@redhat.com>
+Date: Thu, 27 Feb 2020 06:50:40 +0100
+Subject: [PATCH] nss: Collision with external nss symbol
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+One of our internal static function names started
+to collide with external nss symbol. Additional
+sss_ suffix was added to avoid the collision.
+
+This is needed to unblock Fedora Rawhide's
+SSSD build.
+
+Reviewed-by: Pavel Březina <pbrezina@redhat.com>
+---
+ src/responder/nss/nss_cmd.c | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/src/responder/nss/nss_cmd.c b/src/responder/nss/nss_cmd.c
+index 356aea1564..02706c4b94 100644
+--- a/src/responder/nss/nss_cmd.c
++++ b/src/responder/nss/nss_cmd.c
+@@ -731,11 +731,13 @@ static void nss_getent_done(struct tevent_req *subreq)
+     talloc_free(cmd_ctx);
+ }
+ 
+-static void nss_setnetgrent_done(struct tevent_req *subreq);
++static void sss_nss_setnetgrent_done(struct tevent_req *subreq);
+ 
+-static errno_t nss_setnetgrent(struct cli_ctx *cli_ctx,
+-                               enum cache_req_type type,
+-                               nss_protocol_fill_packet_fn fill_fn)
++/* This function's name started to collide with external nss symbol,
++ * so it has additional sss_* prefix unlike other functions here. */
++static errno_t sss_nss_setnetgrent(struct cli_ctx *cli_ctx,
++                                   enum cache_req_type type,
++                                   nss_protocol_fill_packet_fn fill_fn)
+ {
+     struct nss_ctx *nss_ctx;
+     struct nss_state_ctx *state_ctx;
+@@ -777,7 +779,7 @@ static errno_t nss_setnetgrent(struct cli_ctx *cli_ctx,
+         goto done;
+     }
+ 
+-    tevent_req_set_callback(subreq, nss_setnetgrent_done, cmd_ctx);
++    tevent_req_set_callback(subreq, sss_nss_setnetgrent_done, cmd_ctx);
+ 
+     ret = EOK;
+ 
+@@ -790,7 +792,7 @@ static errno_t nss_setnetgrent(struct cli_ctx *cli_ctx,
+     return EOK;
+ }
+ 
+-static void nss_setnetgrent_done(struct tevent_req *subreq)
++static void sss_nss_setnetgrent_done(struct tevent_req *subreq)
+ {
+     struct nss_cmd_ctx *cmd_ctx;
+     errno_t ret;
+@@ -1040,8 +1042,8 @@ static errno_t nss_cmd_initgroups_ex(struct cli_ctx *cli_ctx)
+ 
+ static errno_t nss_cmd_setnetgrent(struct cli_ctx *cli_ctx)
+ {
+-    return nss_setnetgrent(cli_ctx, CACHE_REQ_NETGROUP_BY_NAME,
+-                           nss_protocol_fill_setnetgrent);
++    return sss_nss_setnetgrent(cli_ctx, CACHE_REQ_NETGROUP_BY_NAME,
++                               nss_protocol_fill_setnetgrent);
+ }
+ 
+ static errno_t nss_cmd_getnetgrent(struct cli_ctx *cli_ctx)

--- a/sys-auth/sssd/sssd-2.2.3.ebuild
+++ b/sys-auth/sssd/sssd-2.2.3.ebuild
@@ -77,6 +77,10 @@ MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/sss_certmap.h
 )
 
+PATCHES=(
+	"${FILESDIR}"/${P}-glibc-2.32-compat.patch
+)
+
 pkg_setup() {
 	linux-info_pkg_setup
 }


### PR DESCRIPTION
This change applies a patch that is present in newer versions of sssd but hasn't been backported to 2.2.x. It effectively fixes the compatibility with glibc 2.32 that introduced some symbols with the same names that used to exist in sssd source (namely `nss_setnetgrent`).

Ref: https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=499a92df8b9fc64a054cf3b7f728f8967fc1da7d;hp=8a9221415041543aa163071fa547e88138ceec9d

Fixes: https://bugs.gentoo.org/737180