### PR TITLE
dev-python/paramiko: apply iqmp-swap patch

### DIFF
--- a/dev-python/paramiko/files/paramiko-2.7.1-iqmp-swap.patch
+++ b/dev-python/paramiko/files/paramiko-2.7.1-iqmp-swap.patch
@@ -1,0 +1,23 @@
+From 81064206bf3cec2ca4372257ff138481e1227b91 Mon Sep 17 00:00:00 2001
+From: Alex Gaynor <alex.gaynor@gmail.com>
+Date: Sat, 18 Jul 2020 14:18:07 -0400
+Subject: [PATCH] fix RSA key loading: p and q were being swapped
+
+This currently works, because OpenSSL simply re-computes iqmp when it doesn't match the p & q values. However a future pyca/cryptography patch enforces this.
+---
+ paramiko/rsakey.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/paramiko/rsakey.py b/paramiko/rsakey.py
+index 9707b268c..172f42d41 100644
+--- a/paramiko/rsakey.py
++++ b/paramiko/rsakey.py
+@@ -189,7 +189,7 @@ def _decode_key(self, data):
+             except ValueError as e:
+                 raise SSHException(str(e))
+         elif pkformat == self._PRIVATE_KEY_FORMAT_OPENSSH:
+-            n, e, d, iqmp, q, p = self._uint32_cstruct_unpack(data, "iiiiii")
++            n, e, d, iqmp, p, q = self._uint32_cstruct_unpack(data, "iiiiii")
+             public_numbers = rsa.RSAPublicNumbers(e=e, n=n)
+             key = rsa.RSAPrivateNumbers(
+                 p=p,

--- a/dev-python/paramiko/paramiko-2.7.1-r1.ebuild
+++ b/dev-python/paramiko/paramiko-2.7.1-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1
+
+DESCRIPTION="SSH2 protocol library"
+HOMEPAGE="https://www.paramiko.org/ https://github.com/paramiko/paramiko/ https://pypi.org/project/paramiko/"
+# pypi tarballs are missing test data
+#SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+SRC_URI="https://github.com/${PN}/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris"
+IUSE="examples server"
+
+RDEPEND="
+	>=dev-python/bcrypt-3.1.3[${PYTHON_USEDEP}]
+	>=dev-python/cryptography-2.5[${PYTHON_USEDEP}]
+	>=dev-python/pynacl-1.0.1[${PYTHON_USEDEP}]
+	>=dev-python/pyasn1-0.1.7[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	test? (
+		dev-python/mock[${PYTHON_USEDEP}]
+	)
+"
+
+distutils_enable_sphinx sites/docs
+distutils_enable_tests pytest
+
+src_prepare() {
+	eapply "${FILESDIR}"/${P}-tests.patch
+	eapply "${FILESDIR}"/${P}-iqmp-swap.patch
+
+	if ! use server; then
+		eapply "${FILESDIR}/${PN}-2.4.2-disable-server.patch"
+	fi
+
+	eapply_user
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+
+	if use examples; then
+		docinto examples
+		dodoc -r demos/*
+	fi
+}


### PR DESCRIPTION
Apply [this upstream patch](https://github.com/paramiko/paramiko/commit/81064206bf3cec2ca4372257ff138481e1227b91) to allow `duplicity` to work correctly with the `paramiko` backend, when performing backups over sftp. Otherwise it fails with the error `BackendException: ssh connection to <user>@<addr>:22 failed: ('Invalid private key', [_OpenSSLErrorWithText(code=67764350, lib=4, func=160, reason=126, reason_text=b'error:040A007E:rsa routines:RSA_check_key_ex:iqmp not inverse of q')])`

I noticed this issue when my periodic duplicity backup via sftp using the `paramiko` backend started failing as of 2020-08-28. The upstream patch fixing the issue, and included in this pull request, was committed around the same time.

I do not know the cause of the breakage, but this patch does resolve the issue. Tested both with user patches and in an ~amd64 container.

**EDIT:** as acknowledged in the upstream patch message this breakage may be related to `dev-python/cryptography`, which upgraded on my system to version 3.1 on the same day the above error began.