### PR TITLE
media-gfx/openvdb: Use full path for Python_EXECUTABLE

### DIFF
--- a/media-gfx/openvdb/openvdb-7.0.0-r1.ebuild
+++ b/media-gfx/openvdb/openvdb-7.0.0-r1.ebuild
@@ -109,7 +109,7 @@ src_configure() {
 			-DOPENVDB_BUILD_PYTHON_MODULE=ON
 			-DUSE_NUMPY=$(usex numpy)
 			-DPYOPENVDB_INSTALL_DIRECTORY="$(python_get_sitedir)"
-			-DPython_EXECUTABLE="${EPYTHON}"
+			-DPython_EXECUTABLE="${PYTHON}"
 		)
 	fi
 

--- a/media-gfx/openvdb/openvdb-7.1.0-r1.ebuild
+++ b/media-gfx/openvdb/openvdb-7.1.0-r1.ebuild
@@ -107,7 +107,7 @@ src_configure() {
 			-DOPENVDB_BUILD_PYTHON_MODULE=ON
 			-DUSE_NUMPY=$(usex numpy)
 			-DPYOPENVDB_INSTALL_DIRECTORY="$(python_get_sitedir)"
-			-DPython_EXECUTABLE="${EPYTHON}"
+			-DPython_EXECUTABLE="${PYTHON}"
 		)
 	fi
 


### PR DESCRIPTION
Openvdb fails to configure with numpy enabled when Python_EXECUTABLE is
set using ${EPYTHON} as it is unable to find the required python
components.

The cmake docs state that Python_EXECUTABLE must be set to the PATH
of the python interpreter.

See https://cmake.org/cmake/help/v3.16/module/FindPython.html

This means that it must be set to ${PYTHON} which contains the absolute
path in python-r1, rather than ${EPYTHON} which only contains the
executable name. Doing so resolves bug 738928.

Signed-off-by: Adrian Grigo <agrigo2001@yahoo.com.au>
Closes: https://bugs.gentoo.org/738928
Package-Manager: Portage-2.3.103, Repoman-2.3.23