### PR TITLE
net-misc/openssh: fix sshd@.service

### DIFF
--- a/net-misc/openssh/files/sshd_at.service
+++ b/net-misc/openssh/files/sshd_at.service
@@ -5,4 +5,4 @@ After=syslog.target auditd.service
 [Service]
 ExecStart=-/usr/sbin/sshd -i -e
 StandardInput=socket
-StandardError=syslog
+StandardError=journal


### PR DESCRIPTION
Whenever an ssh connection is opened, systemd-246 logs:

 systemd[1]: /lib/systemd/system/sshd@.service:8: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.

This is mentioned in the release notes:

> * StandardError= and StandardOutput= in unit files no longer support
>   the "syslog" and "syslog-console" switches. They were long removed
>   from the documentation, but will now result in warnings when used,
>   and be converted to "journal" and "journal+console" automatically.

The oldest systemd version in portage is systemd-244.3, and it doesn't have "syslog" in the documentation, so it's safe to change it to "journal":
https://github.com/systemd/systemd-stable/blob/v244.3/man/systemd.exec.xml#L2042

Closes: https://bugs.gentoo.org/739492