### PR TITLE
sys-devel/gcc-config: Delete old unpackaged c{8,9}9 wrapper scripts

### DIFF
--- a/sys-devel/gcc-config/gcc-config-2.3.1.ebuild
+++ b/sys-devel/gcc-config/gcc-config-2.3.1.ebuild
@@ -38,6 +38,39 @@ src_install() {
 	_emake DESTDIR="${D}" install
 }
 
+maybe_remove_old_wrappers() {
+	if ! has collision-protect ${FEATURES}; then
+		# Don't bother if we'll just overwrite any old wrapper(s) anyway
+		return
+	fi
+	local replacing delete_old_wrappers=true
+	for replacing in ${REPLACING_VERSIONS}; do
+		if ver_test $OLD_VER -ge '2.3.1'; then
+			delete_old_wrappers=false
+			break
+		fi
+	done
+	if $delete_old_wrappers; then
+		# Check that the existing files are in fact the old wrappers expected
+		sha256sum --check --status &>/dev/null <<\EOF
+29ad5dd697135c2892067e780447894dc1cd071708157e46d21773ab99c5022c  /usr/bin/c89
+057b348cf5be9b4fb9db99a4549f6433c89d21e5f91dc5e46b0b4dc6b70432f5  /usr/bin/c99
+EOF
+		if [ $? = 1 ]; then
+			# Files did NOT match (let collision protect deal with any complaint later)
+			delete_old_wrappers=false
+		fi
+	fi
+	if $delete_old_wrappers; then
+		einfo "Deleting old /usr/bin/c?9 wrapper scripts (to be replaced by ${P})"
+		rm -f /usr/bin/{c89,c99}
+	fi
+}
+
+pkg_preinst() {
+	maybe_remove_old_wrappers
+}
+
 pkg_postinst() {
 	# Scrub eselect-compiler remains.
 	# To be removed in 2021.


### PR DESCRIPTION
Needed to avoid collision-protect complaining
Only deleted if:
1) collision-protect in FEATURES
2) Not replacing a version >=2.3.1
3) Existing files being deleted match the unpackaged scripts' hash

Bug: https://bugs.gentoo.org/737662
