### PR TITLE
media-tv/kodi: fix unconditional media-libs/mesa[X] dependency

### DIFF
--- a/media-tv/kodi/kodi-19.0_alpha1-r1.ebuild
+++ b/media-tv/kodi/kodi-19.0_alpha1-r1.ebuild
@@ -96,7 +96,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.13.1
 	>=media-libs/freetype-2.10.1
 	>=media-libs/libass-0.13.4
-	!raspberry-pi? ( media-libs/mesa[egl,X(+)] )
+	!raspberry-pi? ( media-libs/mesa[egl] )
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[dav1d,encode,postproc]
@@ -138,6 +138,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	webserver? ( >=net-libs/libmicrohttpd-0.9.55[messages(+)] )
 	X? (
+		media-libs/mesa[X]
 		x11-libs/libX11
 		x11-libs/libXrandr
 		x11-libs/libXrender

--- a/media-tv/kodi/kodi-19.9999.ebuild
+++ b/media-tv/kodi/kodi-19.9999.ebuild
@@ -92,7 +92,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.13.1
 	>=media-libs/freetype-2.10.1
 	>=media-libs/libass-0.13.4
-	!raspberry-pi? ( media-libs/mesa[egl,X(+)] )
+	!raspberry-pi? ( media-libs/mesa[egl] )
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[dav1d,encode,postproc]
@@ -134,6 +134,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	webserver? ( >=net-libs/libmicrohttpd-0.9.55[messages(+)] )
 	X? (
+		media-libs/mesa[X]
 		x11-libs/libX11
 		x11-libs/libXrandr
 		x11-libs/libXrender

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -92,7 +92,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=media-libs/fontconfig-2.13.1
 	>=media-libs/freetype-2.10.1
 	>=media-libs/libass-0.13.4
-	!raspberry-pi? ( media-libs/mesa[egl,X(+)] )
+	!raspberry-pi? ( media-libs/mesa[egl] )
 	>=media-libs/taglib-1.11.1
 	system-ffmpeg? (
 		>=media-video/ffmpeg-${FFMPEG_VERSION}:=[dav1d,encode,postproc]
@@ -134,6 +134,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	webserver? ( >=net-libs/libmicrohttpd-0.9.55[messages(+)] )
 	X? (
+		media-libs/mesa[X]
 		x11-libs/libX11
 		x11-libs/libXrandr
 		x11-libs/libXrender


### PR DESCRIPTION
This PR puts media-libs/mesa[X] only when X USE flag is enabled, therefore avoiding unnecessary X dependencies.

Tested without issue on kodi-19.0_alpha1-r1.

Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Ross Charles Campbell <rossbridger.cc@gmail.com>