### PR TITLE
net-libs/libsearpc: do not install .a files

### DIFF
--- a/net-libs/libsearpc/libsearpc-3.2.0-r1.ebuild
+++ b/net-libs/libsearpc/libsearpc-3.2.0-r1.ebuild
@@ -35,6 +35,6 @@ src_prepare() {
 
 src_install() {
 	default
-	# Remove unnecessary .la files, as recommended by ltprune.eclass
-	find "${ED}" -name '*.la' -delete || die
+	# Remove unnecessary .la and .a files, as recommended by ltprune.eclass
+	find "${ED}" -name '*.la' -o -name '*.a' -delete || die
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/739708
Package-Manager: Portage-3.0.3, Repoman-3.0.0
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>