### PR TITLE
net-misc/seafile: do not install .a files

### DIFF
--- a/net-misc/seafile/seafile-7.0.5-r1.ebuild
+++ b/net-misc/seafile/seafile-7.0.5-r1.ebuild
@@ -40,7 +40,7 @@ src_prepare() {
 
 src_install() {
 	default
-	# Remove unnecessary .la files, as recommended by ltprune.eclass
-	find "${ED}" -name '*.la' -delete || die
+	# Remove unnecessary files, as recommended by ltprune.eclass
+	find "${ED}" -name '*.la' -o -name '*.a' -delete || die
 	python_fix_shebang "${ED}"/usr/bin
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/739710
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>