### PR TITLE
app-benchmarks/siege: remove /usr/lib from LDFLAGS

### DIFF
--- a/app-benchmarks/siege/siege-4.0.5.ebuild
+++ b/app-benchmarks/siege/siege-4.0.5.ebuild
@@ -15,15 +15,21 @@ SLOT="0"
 IUSE="libressl ssl"
 
 RDEPEND="ssl? (
-		!libressl? ( dev-libs/openssl:0= )
-		libressl? ( dev-libs/libressl:0= )
-	)"
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
+)"
 DEPEND="${RDEPEND}"
 
 src_prepare() {
 	default
 	# bundled macros break recent libtool
-	sed -i -e '/AC_PROG_SHELL/d' configure.ac || die
+	# remove /usr/lib from LDFLAGS, bug #732886
+	sed -i \
+	-e '/AC_PROG_SHELL/d' \
+	-e 's/SSL_LDFLAGS="-L.*lib"/SSL_LDFLAGS=""/g' \
+	-e 's/Z_LDFLAGS="-L.*lib"/Z_LDFLAGS=""/g' \
+	configure.ac || die
+
 	rm *.m4 || die "failed to remove bundled macros"
 	eautoreconf
 }


### PR DESCRIPTION
Prevent failing to link with LLD because of /usr/lib in the link command line.