### PR TITLE
media-libs/giflib: adjust DEPEND -> BDEPEND

### DIFF
--- a/media-libs/giflib/giflib-5.2.1-r1.ebuild
+++ b/media-libs/giflib/giflib-5.2.1-r1.ebuild
@@ -14,7 +14,7 @@ SLOT="0/7"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="doc static-libs"
 
-DEPEND="doc? ( app-text/xmlto )"
+BDEPEND="doc? ( app-text/xmlto )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.1.9-gentoo.patch


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/734638
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: David Michael <fedora.dm0@gmail.com>
Signed-off-by: Jakov Smolic <jakov.smolic@sartura.hr>