### PR TITLE
gui-apps/gtkgreet: various fixes

### DIFF
--- a/gui-apps/gtkgreet/gtkgreet-0.6-r1.ebuild
+++ b/gui-apps/gtkgreet/gtkgreet-0.6-r1.ebuild
@@ -10,9 +10,10 @@ inherit meson
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://git.sr.ht/~kennylevinsen/gtkgreet.git"
+	EGIT_REPO_URI="https://git.sr.ht/~kennylevinsen/gtkgreet"
 else
-	SRC_URI="https://git.sr.ht/~kennylevinsen/gtkgreet/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	MY_PV=${PV/_rc/-rc}
+	SRC_URI="https://git.sr.ht/~kennylevinsen/gtkgreet/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~ppc64 ~x86"
 fi
 
@@ -22,7 +23,7 @@ IUSE="+layershell +man"
 
 DEPEND="
 	dev-libs/json-c:=
-	gui-libs/gtk-layer-shell
+	layershell? ( gui-libs/gtk-layer-shell )
 	x11-libs/gtk+:3
 "
 RDEPEND="

--- a/gui-apps/gtkgreet/gtkgreet-9999.ebuild
+++ b/gui-apps/gtkgreet/gtkgreet-9999.ebuild
@@ -10,7 +10,7 @@ inherit meson
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://git.sr.ht/~kennylevinsen/gtkgreet.git"
+	EGIT_REPO_URI="https://git.sr.ht/~kennylevinsen/gtkgreet"
 else
 	SRC_URI="https://git.sr.ht/~kennylevinsen/gtkgreet/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~ppc64 ~x86"
@@ -22,7 +22,7 @@ IUSE="+layershell +man"
 
 DEPEND="
 	dev-libs/json-c:=
-	gui-libs/gtk-layer-shell
+	layershell? ( gui-libs/gtk-layer-shell )
 	x11-libs/gtk+:3
 "
 RDEPEND="


### PR DESCRIPTION
This commit fixes the git url for live ebuild, since the one that
was there before was giving 404, and it also makes 'gtk-layer-shell'
optional via existing 'layershell' use flag.

Signed-off-by: Kirill Chibisov <contact@kchibisov.com>