### PR TITLE
app-emulation/libvirt: Add python 3.8 and 3.9 support

### DIFF
--- a/app-emulation/libvirt/libvirt-6.2.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-6.2.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
 inherit autotools out-of-source bash-completion-r1 eutils linux-info python-any-r1 readme.gentoo-r1 systemd
 

--- a/app-emulation/libvirt/libvirt-6.5.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-6.5.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
 inherit autotools out-of-source bash-completion-r1 eutils linux-info python-any-r1 readme.gentoo-r1 systemd
 

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
 inherit meson bash-completion-r1 eutils linux-info python-any-r1 readme.gentoo-r1 systemd
 


### PR DESCRIPTION
Libvirt uses python scripts to generate some (source) files. They
are all python 3.8 and python 3.9 aware.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>