### PR TITLE
java-pkg-simple.eclass: Fix error message when copying resources

### DIFF
--- a/eclass/java-pkg-simple.eclass
+++ b/eclass/java-pkg-simple.eclass
@@ -302,7 +302,7 @@ java-pkg-simple_prepend_resources() {
 	# add resources directory to classpath
 	for resource in "${resources[@]}"; do
 		cp -rT "${resource:-.}" "${destination}"\
-			|| die "Could copy resources to ${destination}"
+			|| die "Could not copy resources from ${resource:-.} to ${destination}"
 	done
 }
 


### PR DESCRIPTION
I stumbled upon this minor issue in the error message when playing around with the java-ebuilder:
* I think that the `not` is missing in the error message, and should definitely be added
* Adding the resource folder for which copying failed is just nice-to-have, but useful IMHO.