### PR TITLE
net-libs/libwebsockets: add dbus dependency, restrict ssl USE flags

### DIFF
--- a/net-libs/libwebsockets/libwebsockets-4.0.20.ebuild
+++ b/net-libs/libwebsockets/libwebsockets-4.0.20.ebuild
@@ -22,12 +22,14 @@ REQUIRED_USE="
 	http-proxy? ( client )
 	smtp? ( libuv )
 	ssl? ( ?? ( libressl mbedtls ) )
+	mbedtls? ( ssl )
 	?? ( libev libevent )
 "
 
 RDEPEND="
 	sys-libs/zlib
 	caps? ( sys-libs/libcap )
+	dbus? ( sys-apps/dbus )
 	http-proxy? ( net-libs/libhubbub )
 	libev? ( dev-libs/libev )
 	libevent? ( dev-libs/libevent:= )


### PR DESCRIPTION
Depends on sys-apps/dbus is USE=dbus. Ensure that mbedtls
cannot be set without ssl USE flag.

Bug: https://bugs.gentoo.org/739888
