### PR TITLE
Net analyzer/nagstamon

### DIFF
--- a/net-analyzer/nagstamon/files/nagstamon-3.4.1-version_id.patch
+++ b/net-analyzer/nagstamon/files/nagstamon-3.4.1-version_id.patch
@@ -1,0 +1,26 @@
+diff --git a/Nagstamon/Helpers.py b/Nagstamon/Helpers.py
+index f4e6ca6..561e2bf 100644
+--- a/Nagstamon/Helpers.py
++++ b/Nagstamon/Helpers.py
+@@ -454,14 +454,18 @@ def get_distro():
+             for property in os_release_file.read_text().splitlines():
+                 key, value = property.split('=', 1)
+                 os_release_dict[key] = value.strip('"').strip("'")
+-            return (os_release_dict['ID'], os_release_dict['VERSION_ID'], os_release_dict['NAME'])
++            return (os_release_dict.get('ID').lower(),
++                os_release_dict.get('VERSION_ID', 'unknown').lower(),
++                os_release_dict.get('NAME').lower())
+         else:
+             return False
+     else:
+-        return platform.dist()
++        # fix for non-working build on Debian<10
++        dist_name, dist_version, dist_id = platform.dist()
++        return dist_name.lower(), dist_version, dist_id
+ 
+ 
+-    # depending on column different functions have to be used
++# depending on column different functions have to be used
+ # 0 + 1 are column "Hosts", 1 + 2 are column "Service" due to extra font flag pictograms
+ SORT_COLUMNS_FUNCTIONS = {0: compare_host,
+         1: compare_host,

--- a/net-analyzer/nagstamon/nagstamon-3.4.1-r1.ebuild
+++ b/net-analyzer/nagstamon/nagstamon-3.4.1-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+PYTHON_COMPAT=( python3_7 python3_8 )
+
+inherit eutils python-r1 distutils-r1
+
+MY_PN="Nagstamon"
+MY_P="${MY_PN}-${PV/_p/-}"
+
+DESCRIPTION="status monitor for the desktop"
+DESCRIPTION="systray monitor for displaying realtime status of several monitoring systems"
+HOMEPAGE="https://nagstamon.ifw-dresden.de"
+SRC_URI="https://nagstamon.ifw-dresden.de/files/stable/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}
+	dev-python/lxml[${PYTHON_USEDEP}]
+	dev-python/PyQt5[gui,multimedia,svg,widgets,${PYTHON_USEDEP}]
+	dev-python/beautifulsoup:4[${PYTHON_USEDEP}]
+	dev-python/dbus-python[${PYTHON_USEDEP}]
+	dev-python/keyring[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	dev-python/psutil[${PYTHON_USEDEP}]
+	dev-python/cryptography[${PYTHON_USEDEP}]
+	dev-python/secretstorage[${PYTHON_USEDEP}]
+	>=dev-python/python-xlib-0.19[${PYTHON_USEDEP}]
+	dev-python/requests-kerberos[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]"
+
+S="${WORKDIR}/${MY_PN}"
+
+PATCHES="${FILESDIR}/${PN}-3.0-setup.patch
+	${FILESDIR}/${PN}-3.4.1-version_id.patch" #718424
+
+src_prepare() {
+	default_src_prepare
+
+	# pre-compressed already
+	rm Nagstamon/resources/nagstamon.1.gz || die
+	sed -i -e 's:\(nagstamon\.1\)\.gz:\1:' setup.py || die
+
+	mv ${PN}.py ${PN} || die
+
+	rm -rf "${S}/Nagstamon/thirdparty/Xlib/" || die
+}


### PR DESCRIPTION
bug #718424
- Add support for python 3.7 and 3.8
- Patch to handle optional VERSION_ID in /etc/os-release

Acked-by: Sam James <sam@gentoo.org>
Reported-by: Michał Górny <mgorny@gentoo.org>
Suggested-by: Zentoo (b4b1@free.fr)
Tested-by: Zentoo (b4b1@free.fr)
Bug: https://bugs.gentoo.org/718424
Closes: https://bugs.gentoo.org/718424
Signed-off-by: Zentoo (b4b1@free.fr)