### PR TITLE
net-analyzer/ossec-hids: Add libpcre2[jit] dependency

### DIFF
--- a/net-analyzer/ossec-hids/ossec-hids-3.6.0.ebuild
+++ b/net-analyzer/ossec-hids/ossec-hids-3.6.0.ebuild
@@ -19,7 +19,7 @@ RDEPEND="acct-user/ossec
 	acct-user/ossecm
 	acct-user/ossecr
 	dev-libs/libevent
-	dev-libs/libpcre2
+	dev-libs/libpcre2[jit]
 	mysql? ( virtual/mysql )
 	postgres? ( dev-db/postgresql:= )
 	sqlite? ( dev-db/sqlite:3 )"


### PR DESCRIPTION
Ensure that libpcre2 has JIT support enabled.
