### PR TITLE
net-dns/dnssec-tools: Call perl_delete_localpod

### DIFF
--- a/net-dns/dnssec-tools/dnssec-tools-2.2.3-r2.ebuild
+++ b/net-dns/dnssec-tools/dnssec-tools-2.2.3-r2.ebuild
@@ -1,0 +1,78 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit readme.gentoo-r1 systemd
+
+DESCRIPTION="Tools to ease the deployment of DNSSEC related technologies"
+HOMEPAGE="https://dnssec-tools.org/"
+SRC_URI="https://github.com/DNSSEC-Tools/DNSSEC-Tools/archive/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="static-libs"
+
+RDEPEND="
+	dev-lang/perl:=
+	dev-perl/CGI
+	dev-perl/Crypt-OpenSSL-Random
+	dev-perl/Getopt-GUI-Long
+	dev-perl/GraphViz
+	dev-perl/MailTools
+	dev-perl/Net-DNS
+	dev-perl/Net-DNS-SEC
+	dev-perl/XML-Simple"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/DNSSEC-Tools-${P}/${PN}"
+
+PATCHES=( "${FILESDIR}"/${PN}-2.0-dtinitconf.patch )
+
+src_prepare() {
+	default
+	sed -e '/^maninstall:/,+3s:$(MKPATH) $(mandir)/$(man1dir):$(MKPATH) $(DESTDIR)/$(mandir)/$(man1dir):' \
+		-i Makefile.in || die
+	sed -e 's:/usr/local/etc:/etc:g' \
+		-e 's:/usr/local:/usr:g' \
+		-i tools/donuts/donuts \
+		-i tools/etc/dnssec-tools/dnssec-tools.conf \
+		-i tools/scripts/genkrf || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		--disable-bind-checks
+		--without-validator
+		--with-perl-build-args=INSTALLDIRS=vendor
+		$(use_enable static-libs static)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	newinitd "${FILESDIR}"/rollerd.initd rollerd
+	newconfd "${FILESDIR}"/rollerd.confd rollerd
+	systemd_dounit "${FILESDIR}"/rollerd.service
+
+	newinitd "${FILESDIR}"/donutsd.initd donutsd
+	newconfd "${FILESDIR}"/donutsd.confd donutsd
+	systemd_dounit "${FILESDIR}"/donutsd.service
+
+	find "${ED}" -name "*.la" -delete || die
+	readme.gentoo_create_doc
+
+	# Remove perllocal.pod to avoid file collisions (bugs #612268 and
+	# #603338).
+	perl_delete_localpod
+}
+
+DISABLE_AUTOFORMATTING=1
+DOC_CONTENTS="Please run 'dtinitconf' in order to set up the required
+/etc/dnssec-tools/dnssec-tools.conf file
+
+DNSSEC Validator has been split into net-dns/dnssec-validator
+"


### PR DESCRIPTION
### net-dns/dnssec-tools: Call perl_delete_localpod

Remove perllocal.pod to avoid file collisions

Closes: https://bugs.gentoo.org/612268
Closes: https://github.com/gentoo/gentoo/pull/17386
Package-Manager: Portage-3.0.4, Repoman-2.3.23
Signed-off-by: Philippe Chaintreuil <gentoo_bugs_peep@parallaxshift.com>


```diff
--- dnssec-tools-2.2.3-r1.ebuild        2020-05-11 14:15:51.513297803 -0400
+++ dnssec-tools-2.2.3-r2.ebuild        2020-09-02 09:23:18.038511012 -0400
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2

 EAPI=7
@@ -64,6 +64,10 @@

        find "${ED}" -name "*.la" -delete || die
        readme.gentoo_create_doc
+
+       # Remove perllocal.pod to avoid file collisions (bugs #612268 and
+       # #603338).
+       perl_delete_localpod
 }

 DISABLE_AUTOFORMATTING=1
```

NOTE: 
I'm in no way related to this package, I'm not even a user. I'm proxy-maint for the other half of the Gentoo file-collision bug [#612268](https://bugs.gentoo.org/612268), and since net-dns/dnssec-tools is currently maintainer needed, I figured I'd offer a way to close the bug out.