### PR TITLE
net-libs/libwebsockets: set LWS_DBUS_INCLUDE2

### DIFF
--- a/net-libs/libwebsockets/libwebsockets-4.0.20.ebuild
+++ b/net-libs/libwebsockets/libwebsockets-4.0.20.ebuild
@@ -82,5 +82,7 @@ src_configure() {
 		-DLWS_WITHOUT_TESTAPPS=ON
 	)
 
+	use dbus && mycmakeargs+=( -DLWS_DBUS_INCLUDE2="/usr/$(get_libdir)/dbus-1.0/include" )
+
 	cmake_src_configure
 }


### PR DESCRIPTION
CMake only looks for dbus-arch-deps.h at /usr/lib64, so we have to
manually set LWS_DBUS_INCLUDE2 for 32-bit systems where it is located at
/usr/lib

Closes: https://bugs.gentoo.org/740090