### PR TITLE
games-board/xgammon fix endgame database not found

### DIFF
--- a/games-board/xgammon/files/xgammon-0.98-r2-config.patch
+++ b/games-board/xgammon/files/xgammon-0.98-r2-config.patch
@@ -1,0 +1,26 @@
+diff --git a/Imakefile b/Imakefile
+index 332deee..1c43ff5 100644
+--- a/Imakefile
++++ b/Imakefile
+@@ -12,9 +12,9 @@ SRCS = allow.c      drawing.c    load.c    rollout.c  \
+ 
+ ComplexProgramTarget(xgammon)
+ InstallAppDefaults(XGammon)
+-MakeDirectories(install, $(LIBDIR)/xgammon)
+-InstallNonExec(lib/xgammon.db, $(LIBDIR)/xgammon)
+-MANSUFFIX = 6
++MakeDirectories(install,$(LIBDIR)/xgammon)
++InstallNonExec(lib/xgammon.db,$(LIBDIR)/xgammon)
++MANSUFFIX = 1
+ 
+ xgammon.o:      xgammon.c
+ 	$(CC) $(CFLAGS) -DDATABASE=\"$(LIBDIR)/xgammon/xgammon.db\" -c xgammon.c
+@@ -35,7 +35,7 @@ lib/xgammon.db:
+ 	@echo "Database complete"
+ 
+ XGammon.ad:     xgammon.ad
+-	$(LN) xgammon.ad XGammon.ad
++	sed -e "s:lib/xgammon.db:$(LIBDIR)/xgammon/xgammon.db:" xgammon.ad >XGammon.ad
+ 
+ xgammon.man:    xgammon.6
+ 	$(LN) xgammon.6 xgammon.man

--- a/games-board/xgammon/xgammon-0.98-r2.ebuild
+++ b/games-board/xgammon/xgammon-0.98-r2.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="very nice backgammon game for X"
+HOMEPAGE="http://fawn.unibw-hamburg.de/steuer/xgammon/xgammon.html"
+SRC_URI="http://fawn.unibw-hamburg.de/steuer/xgammon/Downloads/${P}a.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	x11-libs/libX11
+	x11-libs/libXaw
+	x11-libs/libXt"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	app-text/rman
+	x11-misc/imake"
+
+S="${WORKDIR}/${P}a"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-broken.patch
+	"${FILESDIR}"/${P}-r2-config.patch
+	"${FILESDIR}"/${P}-glibc-2.32.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+)
+
+src_configure() {
+	xmkmf || die
+}
+
+src_compile() {
+	env PATH=".:${PATH}" emake \
+		EXTRA_LDOPTIONS="${LDFLAGS}" \
+		CDEBUGFLAGS="${CFLAGS}" \
+		CC="$(tc-getCC)"
+}
+
+pkg_postinst() {
+	einfo "xgammon need helvetica fonts"
+	einfo "They can be loaded emerging media-fonts/font-adobe-100dpi"
+	einfo "or similar. Remember to restart X after loading fonts"
+}


### PR DESCRIPTION
Change where the program looks by default for its end game db.

Without this fix, the program reports this on startup:

$ xgammon
endgame database not found
you should create one

Signed-off-by: Paul Healy <lmiphay@gmail.com>