### PR TITLE
dev-tex/chktex: Added patch for incorrect exit status.

### DIFF
--- a/dev-tex/chktex/chktex-1.7.6.ebuild
+++ b/dev-tex/chktex/chktex-1.7.6.ebuild
@@ -28,7 +28,8 @@ BDEPEND="virtual/latex-base
 	dev-lang/perl:="
 
 PATCHES=( "${FILESDIR}/${PN}-1.7.1-asneeded.patch"
-	  "${FILESDIR}/tex-inputenc.patch" )
+		  "${FILESDIR}/tex-inputenc.patch"
+		  "${FILESDIR}/exit-status.patch")
 
 AT_M4DIR="${S}/m4"
 
@@ -51,7 +52,7 @@ src_compile() {
 src_install() {
 	default
 	if use doc ; then
-	      dodoc HTML/ChkTeX.tex
+		  dodoc HTML/ChkTeX.tex
 	fi
 	dodoc ChkTeX.dvi NEWS
 	doman *.1

--- a/dev-tex/chktex/files/exit-status.patch
+++ b/dev-tex/chktex/files/exit-status.patch
@@ -1,0 +1,22 @@
+--- a/FindErrs.c	2016/09/10 04:22:18	308
++++ b/FindErrs.c	2016/09/28 03:52:31	314
+@@ -1872,7 +1872,6 @@
+             }
+             else
+             {
+-                FoundErr = EXIT_FAILURE;
+                 Context = LaTeXMsgs[Error].Context;
+ 
+                 if (!HeadErrOut)
+@@ -1889,9 +1888,11 @@
+                 {
+                 case etWarn:
+                     WarnPrint++;
++                    FoundErr = EXIT_FAILURE;
+                     break;
+                 case etErr:
+                     ErrPrint++;
++                    FoundErr = EXIT_FAILURE;
+                     break;
+                 case etMsg:
+                     break;


### PR DESCRIPTION
chktex has a bug where it returns an incorrect exit status in some
circumstances. The patch from
http://svn.savannah.nongnu.org/viewvc/chktex/trunk/chktex/FindErrs.c?r1=308&r2=314&view=patch
fixes this.

Package-Manager: Portage-2.3.103, Repoman-2.3.23
Signed-off-by: Jan Seeger <jan.seeger@thenybble.de>