### PR TITLE
net-misc/qtm: update SRC_URI

### DIFF
--- a/net-misc/qtm/metadata.xml
+++ b/net-misc/qtm/metadata.xml
@@ -7,6 +7,5 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="sourceforge">catkin</remote-id>
-		<remote-id type="bitbucket">IndigoJo/qtm-1.3</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-misc/qtm/qtm-1.3.19.ebuild
+++ b/net-misc/qtm/qtm-1.3.19.ebuild
@@ -1,14 +1,15 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 # CMAKE_IN_SOURCE_BUILD="1"
-inherit cmake-utils eapi7-ver
+inherit cmake-utils
 
 DESCRIPTION="Qt blogging client"
 HOMEPAGE="http://qtm.blogistan.co.uk"
-SRC_URI="https://bitbucket.org/IndigoJo/${PN}-$(ver_cut 1-2)/downloads/${P}.tar.bz2"
+# FIXME find suitable SRC_URI
+SRC_URI="https://bitbucket-archive.softwareheritage.org/static/3c/3c8ca320-701e-47dc-b0ec-28870df5715b/attachments/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Update SRC_URI to bitbucket hg mirror.
Closes: https://bugs.gentoo.org/739804
Package-Manager: Portage-3.0.4, Repoman-2.3.23
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>