### PR TITLE
dev-haskell/*, x11-misc/xmonad-contrib: use https

### DIFF
--- a/dev-haskell/blaze-html/blaze-html-0.9.1.2.ebuild
+++ b/dev-haskell/blaze-html/blaze-html-0.9.1.2.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="A blazingly fast HTML combinator library for Haskell"
-HOMEPAGE="http://jaspervdj.be/blaze"
+HOMEPAGE="https://jaspervdj.be/blaze"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/hakyll/hakyll-4.13.4.0.ebuild
+++ b/dev-haskell/hakyll/hakyll-4.13.4.0.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="A static website compiler library"
-HOMEPAGE="http://jaspervdj.be/hakyll"
+HOMEPAGE="https://jaspervdj.be/hakyll/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/http-conduit/http-conduit-2.3.7.3.ebuild
+++ b/dev-haskell/http-conduit/http-conduit-2.3.7.3.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="HTTP client package with conduit interface and HTTPS support"
-HOMEPAGE="http://www.yesodweb.com/book/http-conduit"
+HOMEPAGE="https://www.yesodweb.com/book/http-conduit"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/persistent-sqlite/persistent-sqlite-2.10.6.2.ebuild
+++ b/dev-haskell/persistent-sqlite/persistent-sqlite-2.10.6.2.ebuild
@@ -10,7 +10,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Backend for the persistent library using sqlite3"
-HOMEPAGE="http://www.yesodweb.com/book/persistent"
+HOMEPAGE="https://www.yesodweb.com/book/persistent"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/persistent-template/persistent-template-2.8.2.3.ebuild
+++ b/dev-haskell/persistent-template/persistent-template-2.8.2.3.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Type-safe, non-relational, multi-backend persistence"
-HOMEPAGE="http://www.yesodweb.com/book/persistent"
+HOMEPAGE="https://www.yesodweb.com/book/persistent"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/persistent/persistent-2.10.5.2.ebuild
+++ b/dev-haskell/persistent/persistent-2.10.5.2.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Type-safe, multi-backend data serialization"
-HOMEPAGE="http://www.yesodweb.com/book/persistent"
+HOMEPAGE="https://www.yesodweb.com/book/persistent"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wai-app-static/wai-app-static-3.1.7.2.ebuild
+++ b/dev-haskell/wai-app-static/wai-app-static-3.1.7.2.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="WAI application for static serving"
-HOMEPAGE="http://www.yesodweb.com/book/web-application-interface"
+HOMEPAGE="https://www.yesodweb.com/book/web-application-interface"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/wavy/wavy-0.1.0.0.ebuild
+++ b/dev-haskell/wavy/wavy-0.1.0.0.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="bin lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Process WAVE files in Haskell"
-HOMEPAGE="http://bitbucket.org/robertmassaioli/wavy"
+HOMEPAGE="https://bitbucket.org/robertmassaioli/wavy"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/xml-hamlet/xml-hamlet-0.5.0.1.ebuild
+++ b/dev-haskell/xml-hamlet/xml-hamlet-0.5.0.1.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Hamlet-style quasiquoter for XML content"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/yesod-auth/yesod-auth-1.6.9.ebuild
+++ b/dev-haskell/yesod-auth/yesod-auth-1.6.9.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Authentication for Yesod"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-core/yesod-core-1.6.17.2.ebuild
+++ b/dev-haskell/yesod-core/yesod-core-1.6.17.2.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Creation of type-safe, RESTful web applications"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-form/yesod-form-1.6.7.ebuild
+++ b/dev-haskell/yesod-form/yesod-form-1.6.7.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Form handling support for Yesod Web Framework"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-persistent/yesod-persistent-1.6.0.4.ebuild
+++ b/dev-haskell/yesod-persistent/yesod-persistent-1.6.0.4.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Some helpers for using Persistent from Yesod"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-static/yesod-static-1.6.0.1.ebuild
+++ b/dev-haskell/yesod-static/yesod-static-1.6.0.1.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="Static file serving subsite for Yesod Web Framework"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod-test/yesod-test-1.6.10.ebuild
+++ b/dev-haskell/yesod-test/yesod-test-1.6.10.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="integration testing for WAI/Yesod Applications"
-HOMEPAGE="http://www.yesodweb.com"
+HOMEPAGE="https://www.yesodweb.com"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-haskell/yesod/yesod-1.6.1.0.ebuild
+++ b/dev-haskell/yesod/yesod-1.6.1.0.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Creation of type-safe, RESTful web applications"
-HOMEPAGE="http://www.yesodweb.com/"
+HOMEPAGE="https://www.yesodweb.com/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/x11-wm/xmonad-contrib/xmonad-contrib-0.16.ebuild
+++ b/x11-wm/xmonad-contrib/xmonad-contrib-0.16.ebuild
@@ -10,7 +10,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Third party extensions for xmonad"
-HOMEPAGE="http://xmonad.org/"
+HOMEPAGE="https://xmonad.org/"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Hi,

some updates to haskell ebuilds to use https instead of http.
