### PR TITLE
Some X11 EAPI 7 updates

### DIFF
--- a/x11-apps/iceauth/iceauth-1.0.8-r1.ebuild
+++ b/x11-apps/iceauth/iceauth-1.0.8-r1.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit xorg-3
+
+DESCRIPTION="ICE authority file utility"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x86-solaris ~x86-winnt"
+
+RDEPEND="x11-libs/libICE"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"

--- a/x11-apps/rgb/rgb-1.0.6-r1.ebuild
+++ b/x11-apps/rgb/rgb-1.0.6-r1.ebuild
@@ -1,0 +1,13 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit xorg-3
+
+DESCRIPTION="uncompile an rgb color-name database"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+BDEPEND="x11-misc/util-macros"

--- a/x11-apps/xmessage/xmessage-1.0.5-r1.ebuild
+++ b/x11-apps/xmessage/xmessage-1.0.5-r1.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit xorg-3
+
+DESCRIPTION="display a message or query in a window (X-based /bin/echo)"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="x11-libs/libXaw
+	x11-libs/libXt"
+DEPEND="${RDEPEND}"

--- a/x11-libs/libSM/libSM-1.2.3-r1.ebuild
+++ b/x11-libs/libSM/libSM-1.2.3-r1.ebuild
@@ -1,0 +1,58 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+XORG_DOC=doc
+XORG_MULTILIB=yes
+inherit xorg-3
+
+DESCRIPTION="X.Org Session Management library"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+IUSE="ipv6 +uuid"
+
+RDEPEND="x11-base/xorg-proto
+	>=x11-libs/libICE-1.0.8-r1[${MULTILIB_USEDEP}]
+	x11-libs/xtrans
+	!elibc_FreeBSD? ( !elibc_SunOS? ( !elibc_Darwin? (
+		uuid? ( >=sys-apps/util-linux-2.24.1-r3[${MULTILIB_USEDEP}] )
+	) ) )"
+DEPEND="${RDEPEND}"
+
+src_configure() {
+	local withuuid=$(use_with uuid libuuid)
+
+	# do not use uuid even if available in libc (like on FreeBSD)
+	use uuid || export ac_cv_func_uuid_create=no
+
+	if use uuid ; then
+		case ${CHOST} in
+			*-solaris*|*-darwin*)
+				if [[ ! -d ${EROOT}/usr/include/uuid ]] &&
+					[[ -d ${ROOT}/usr/include/uuid ]]
+				then
+					# Solaris and Darwin have uuid provided by the host
+					# system.  Since util-linux's version is based on this
+					# version, and on Darwin actually breaks host headers when
+					# installed, we can "pretend" for libSM we have libuuid
+					# installed, while in fact we don't
+					withuuid="--without-libuuid"
+					export HAVE_LIBUUID=yes
+					export LIBUUID_CFLAGS="-I${ROOT}/usr/include/uuid"
+					# Darwin has uuid in libSystem
+					[[ ${CHOST} == *-solaris* ]] &&	export LIBUUID_LIBS="-luuid"
+				fi
+				;;
+		esac
+	fi
+
+	local XORG_CONFIGURE_OPTIONS=(
+		$(use_enable ipv6)
+		$(use_enable doc docs)
+		$(use_with doc xmlto)
+		${withuuid}
+		--without-fop
+	)
+	xorg-3_src_configure
+}

--- a/x11-libs/libXaw/libXaw-1.0.13-r2.ebuild
+++ b/x11-libs/libXaw/libXaw-1.0.13-r2.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+XORG_DOC=doc
+XORG_MULTILIB=yes
+inherit xorg-3
+
+DESCRIPTION="X.Org Xaw library"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="deprecated"
+
+RDEPEND="x11-base/xorg-proto
+	>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+	>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]
+	>=x11-libs/libXmu-1.1.1-r1[${MULTILIB_USEDEP}]
+	>=x11-libs/libXpm-3.5.10-r1[${MULTILIB_USEDEP}]
+	>=x11-libs/libXt-1.1.4[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+
+src_configure() {
+	local XORG_CONFIGURE_OPTIONS=(
+		$(use_enable deprecated xaw6)
+		$(use_enable doc specs)
+		$(use_with doc xmlto)
+		--without-fop
+	)
+	xorg-3_src_configure
+}

--- a/x11-libs/libXfixes/libXfixes-5.0.3-r2.ebuild
+++ b/x11-libs/libXfixes/libXfixes-5.0.3-r2.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+XORG_MULTILIB=yes
+inherit xorg-3
+
+DESCRIPTION="X.Org Xfixes library"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+
+RDEPEND="x11-base/xorg-proto
+	>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"

--- a/x11-libs/libXinerama/libXinerama-1.1.4-r1.ebuild
+++ b/x11-libs/libXinerama/libXinerama-1.1.4-r1.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+XORG_MULTILIB=yes
+inherit xorg-3
+
+DESCRIPTION="X.Org Xinerama library"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="x11-base/xorg-proto
+	>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+	>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"

--- a/x11-libs/libXrender/libXrender-0.9.10-r2.ebuild
+++ b/x11-libs/libXrender/libXrender-0.9.10-r2.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+XORG_MULTILIB=yes
+inherit xorg-3
+
+DESCRIPTION="X.Org Xrender library"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+
+RDEPEND="x11-base/xorg-proto
+	>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"

--- a/x11-libs/libXv/libXv-1.0.11-r2.ebuild
+++ b/x11-libs/libXv/libXv-1.0.11-r2.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+XORG_MULTILIB=yes
+inherit xorg-3
+
+DESCRIPTION="X.Org Xv library"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="x11-base/xorg-proto
+	>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+	>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"

--- a/x11-libs/libXxf86vm/libXxf86vm-1.1.4-r2.ebuild
+++ b/x11-libs/libXxf86vm/libXxf86vm-1.1.4-r2.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+XORG_MULTILIB=yes
+inherit xorg-3
+
+DESCRIPTION="X.Org Xxf86vm library"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+
+RDEPEND="x11-base/xorg-proto
+	>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+	>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"


### PR DESCRIPTION
These packages have multilib dependencies but do not have an EAPI 7 ebuild.  That breaks cross-compiling to a multilib target (if you don't specify `--root-deps=rdeps` which breaks other things).  Fixing this package set allowed me to cross-compile a graphical multilib system.  The few `x11-apps` packages weren't breaking anything, but I randomly updated them while testing, so they're included here.  (There are some related bugs like [bug #740414](https://bugs.gentoo.org/740414) for core packages with this issue.)