### PR TITLE
xfce-extra/xfce4-systemload-plugin: panel-4.15 compatibility

### DIFF
--- a/xfce-extra/xfce4-systemload-plugin/files/xfce4-systemload-plugin-1.2.3-panel-4.15.patch
+++ b/xfce-extra/xfce4-systemload-plugin/files/xfce4-systemload-plugin-1.2.3-panel-4.15.patch
@@ -1,0 +1,25 @@
+From 35b50d425209773c9dd21f125b1bd3f8c3daa46b Mon Sep 17 00:00:00 2001
+From: Andre Miranda <andreldm@xfce.org>
+Date: Fri, 4 Oct 2019 00:45:46 -0300
+Subject: [PATCH] Allow compilation with panel 4.15
+
+---
+ panel-plugin/systemload.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/panel-plugin/systemload.c b/panel-plugin/systemload.c
+index af75be4..c6174b8 100644
+--- a/panel-plugin/systemload.c
++++ b/panel-plugin/systemload.c
+@@ -38,7 +38,7 @@
+ 
+ #include <libxfce4util/libxfce4util.h>
+ #include <libxfce4ui/libxfce4ui.h>
+-#include <libxfce4panel/xfce-panel-plugin.h>
++#include <libxfce4panel/libxfce4panel.h>
+ 
+ #ifdef HAVE_UPOWER_GLIB
+ #include <upower.h>
+-- 
+GitLab
+

--- a/xfce-extra/xfce4-systemload-plugin/xfce4-systemload-plugin-1.2.3.ebuild
+++ b/xfce-extra/xfce4-systemload-plugin/xfce4-systemload-plugin-1.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,6 +18,8 @@ RDEPEND=">=xfce-base/libxfce4ui-4.12:=[gtk3(+)]
 DEPEND="${RDEPEND}
 	dev-util/intltool
 	virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}/xfce4-systemload-plugin-1.2.3-panel-4.15.patch" )
 
 src_configure() {
 	econf $(use_enable upower)


### PR DESCRIPTION
Please merge. Thanks.

Closes: https://bugs.gentoo.org/733952