### PR TITLE
[CI] profiles/arch/sparc/use.stable.mask: un-stable-mask Python 3.8

### DIFF
--- a/profiles/arch/sparc/use.stable.mask
+++ b/profiles/arch/sparc/use.stable.mask
@@ -23,11 +23,6 @@ openal
 # clamav has no stable versions yet
 clamav
 
-# Mike Gilbert <floppym@gentoo.org> (2017-06-08)
-# dev-lang/python:3.7 is not stable.
-python_targets_python3_8
-python_single_target_python3_8
-
 # Andrey Grozin <grozin@gentoo.org> (2014-06-25)
 # no stable version on sparc
 ecls


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>