### PR TITLE
eutils.eclass: Remove optfeature()

### DIFF
--- a/eclass/eutils.eclass
+++ b/eclass/eutils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: eutils.eclass
@@ -184,51 +184,6 @@ path_exists() {
 use_if_iuse() {
 	in_iuse $1 || return 1
 	use $1
-}
-
-# @FUNCTION: optfeature
-# @USAGE: <short description> <package atom to match> [other atoms]
-# @DESCRIPTION:
-# Print out a message suggesting an optional package (or packages)
-# not currently installed which provides the described functionality.
-#
-# The following snippet would suggest app-misc/foo for optional foo support,
-# app-misc/bar or app-misc/baz[bar] for optional bar support
-# and either both app-misc/a and app-misc/b or app-misc/c for alphabet support.
-# @CODE
-#	optfeature "foo support" app-misc/foo
-#	optfeature "bar support" app-misc/bar app-misc/baz[bar]
-#	optfeature "alphabet support" "app-misc/a app-misc/b" app-misc/c
-# @CODE
-optfeature() {
-	debug-print-function ${FUNCNAME} "$@"
-	local i j msg
-	local desc=$1
-	local flag=0
-	shift
-	for i; do
-		for j in ${i}; do
-			if has_version "${j}"; then
-				flag=1
-			else
-				flag=0
-				break
-			fi
-		done
-		if [[ ${flag} -eq 1 ]]; then
-			break
-		fi
-	done
-	if [[ ${flag} -eq 0 ]]; then
-		for i; do
-			msg=" "
-			for j in ${i}; do
-				msg+=" ${j} and"
-			done
-			msg="${msg:0: -4} for ${desc}"
-			elog "${msg}"
-		done
-	fi
 }
 
 case ${EAPI:-0} in


### PR DESCRIPTION
* optfeature() is now defined in optfeature.eclass since
  e9caee95d9c7ec69a8b8a12be2ae9bcd98c46e2d.

Signed-off-by: David Seifert <soap@gentoo.org>