### PR TITLE
dev-cpp/prometheus-cpp: Add patch to skip test if locale not available

### DIFF
--- a/dev-cpp/prometheus-cpp/files/prometheus-cpp-0.9.0-core-Skip-serialization-test-if-locale-is-not-availa.patch
+++ b/dev-cpp/prometheus-cpp/files/prometheus-cpp-0.9.0-core-Skip-serialization-test-if-locale-is-not-availa.patch
@@ -1,0 +1,80 @@
+From bf6e2ce56abe2a710181f0365a21ca2dafd2a8f5 Mon Sep 17 00:00:00 2001
+From: Gregor Jasny <gjasny@googlemail.com>
+Date: Fri, 13 Mar 2020 13:16:56 +0100
+Subject: [PATCH] core: Skip serialization test if locale is not available
+
+Closes: #345
+---
+ core/tests/raii_locale.h      | 15 +++++++++++++++
+ core/tests/serializer_test.cc | 21 ++++++++++++++-------
+ 2 files changed, 29 insertions(+), 7 deletions(-)
+ create mode 100644 core/tests/raii_locale.h
+
+diff --git a/core/tests/raii_locale.h b/core/tests/raii_locale.h
+new file mode 100644
+index 0000000..592d74f
+--- /dev/null
++++ b/core/tests/raii_locale.h
+@@ -0,0 +1,15 @@
++#pragma once
++
++#include <locale>
++
++class RAIILocale {
++ public:
++  RAIILocale(const char* name) : savedLocale_(std::locale::classic()) {
++    std::locale::global(std::locale(name));
++  }
++
++  ~RAIILocale() { std::locale::global(savedLocale_); }
++
++ private:
++  const std::locale savedLocale_;
++};
+diff --git a/core/tests/serializer_test.cc b/core/tests/serializer_test.cc
+index f935a3b..6cb8f0e 100644
+--- a/core/tests/serializer_test.cc
++++ b/core/tests/serializer_test.cc
+@@ -1,9 +1,13 @@
+ #include "prometheus/counter.h"
++#include "prometheus/detail/future_std.h"
+ #include "prometheus/family.h"
+ #include "prometheus/text_serializer.h"
+ 
++#include "raii_locale.h"
++
+ #include <gmock/gmock.h>
+-#include <locale>
++
++#include <memory>
+ #include <sstream>
+ 
+ namespace prometheus {
+@@ -25,15 +29,18 @@ class SerializerTest : public testing::Test {
+ 
+ #ifndef _WIN32
+ TEST_F(SerializerTest, shouldSerializeLocaleIndependent) {
+-  // save and change locale
+-  const std::locale oldLocale = std::locale::classic();
+-  std::locale::global(std::locale("de_DE.UTF-8"));
++  std::unique_ptr<RAIILocale> localeWithCommaDecimalSeparator;
++
++  // ignore missing locale and skip test if setup fails
++  try {
++    localeWithCommaDecimalSeparator =
++        detail::make_unique<RAIILocale>("de_DE.UTF-8");
++  } catch (std::runtime_error&) {
++    GTEST_SKIP();
++  }
+ 
+   const auto serialized = textSerializer.Serialize(collected);
+   EXPECT_THAT(serialized, testing::HasSubstr("1.0"));
+-
+-  // restore locale
+-  std::locale::global(oldLocale);
+ }
+ #endif
+ 
+-- 
+2.28.0
+

--- a/dev-cpp/prometheus-cpp/prometheus-cpp-0.9.0.ebuild
+++ b/dev-cpp/prometheus-cpp/prometheus-cpp-0.9.0.ebuild
@@ -26,6 +26,10 @@ DEPEND="${RDEPEND}
 		dev-cpp/gtest
 	)"
 
+PATCHES=(
+	"${FILESDIR}/${P}-core-Skip-serialization-test-if-locale-is-not-availa.patch"
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_PULL=yes


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/741040
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>