### PR TITLE
media-sound/mumble: Update/Fix live ebuild

### DIFF
--- a/media-sound/mumble/mumble-9999.ebuild
+++ b/media-sound/mumble/mumble-9999.ebuild
@@ -68,26 +68,39 @@ BDEPEND="
 src_configure() {
 
 	local mycmakeargs=(
+		"-Dalsa=$(usex alsa)"
+		"-DBUILD_TESTING=$(usex test)"
 		"-Dbundled-celt=ON"
 		"-Dbundled-opus=OFF"
 		"-Dbundled-speex=OFF"
-		"-Doverlay=ON"
-		"-Dserver=OFF"
-		"-Dupdate=OFF"
-		"-Dalsa=$(usex alsa)"
-		"-DBUILD_TESTING=$(usex test)"
 		"-Ddbus=$(usex dbus)"
 		"-Dg15=$(usex g15)"
 		"-Djackaudio=$(usex jack)"
+		"-Doverlay=ON"
 		"-Dportaudio=$(usex portaudio)"
 		"-Dpulseaudio=$(usex pulseaudio)"
 		"-Drnnoise=$(usex rnnoise)"
+		"-Dserver=OFF"
 		"-Dspeechd=$(usex speech)"
 		"-Dtranslations=$(usex nls)"
+		"-Dupdate=OFF"
 		"-Dzeroconf=$(usex zeroconf)"
 	)
 
 	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	if use amd64 ; then
+		# The 32bit overlay library gets automatically built and installed on x86_64 platforms.
+		# Install it into the correct 32bit lib dir.
+		libdir_64="/usr/$(get_libdir)/mumble"
+		libdir_32="/usr/$(get_abi_var LIBDIR x86)/mumble"
+		mkdir -p $D/$libdir_32 || die
+		mv $D/$libdir_64/libmumbleoverlay.x86.so* $D/$libdir_32/ || die
+	fi
 }
 
 pkg_postinst() {
@@ -95,7 +108,7 @@ pkg_postinst() {
 	xdg_desktop_database_update
 	echo
 	elog "Visit https://wiki.mumble.info/ for futher configuration instructions."
-	elog "Run mumble-overlay to start the OpenGL overlay (after starting mumble)."
+	elog "Run 'mumble-overlay <program>' to start the OpenGL overlay (after starting mumble)."
 	echo
 }
 

--- a/media-sound/mumble/mumble-9999.ebuild
+++ b/media-sound/mumble/mumble-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake xdg-utils
+inherit cmake xdg
 
 DESCRIPTION="Mumble is an open source, low-latency, high quality voice chat software"
 HOMEPAGE="https://wiki.mumble.info"
@@ -65,6 +65,11 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+src_prepare() {
+        # required because of xdg.eclass also providing src_prepare
+        cmake_src_prepare
+}
+
 src_configure() {
 
 	local mycmakeargs=(
@@ -104,8 +109,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	xdg_icon_cache_update
-	xdg_desktop_database_update
+	xdg_pkg_postinst
 	echo
 	elog "Visit https://wiki.mumble.info/ for futher configuration instructions."
 	elog "Run 'mumble-overlay <program>' to start the OpenGL overlay (after starting mumble)."
@@ -113,6 +117,5 @@ pkg_postinst() {
 }
 
 pkg_postrm() {
-	xdg_icon_cache_update
-	xdg_desktop_database_update
+	xdg_pkg_postrm
 }

--- a/media-sound/mumble/mumble-9999.ebuild
+++ b/media-sound/mumble/mumble-9999.ebuild
@@ -101,10 +101,10 @@ src_install() {
 	if use amd64 ; then
 		# The 32bit overlay library gets automatically built and installed on x86_64 platforms.
 		# Install it into the correct 32bit lib dir.
-		libdir_64="/usr/$(get_libdir)/mumble"
-		libdir_32="/usr/$(get_abi_var LIBDIR x86)/mumble"
-		mkdir -p $D/$libdir_32 || die
-		mv $D/$libdir_64/libmumbleoverlay.x86.so* $D/$libdir_32/ || die
+		local libdir_64="/usr/$(get_libdir)/mumble"
+		local libdir_32="/usr/$(get_abi_var LIBDIR x86)/mumble"
+		mkdir -p ${D}/{$libdir_32} || die
+		mv ${D}/${libdir_64}/libmumbleoverlay.x86.so* ${D}/${libdir_32}/ || die
 	fi
 }
 

--- a/media-sound/mumble/mumble-9999.ebuild
+++ b/media-sound/mumble/mumble-9999.ebuild
@@ -26,7 +26,7 @@ fi
 
 LICENSE="BSD MIT"
 SLOT="0"
-IUSE="+alsa +dbus debug g15 jack libressl portaudio pulseaudio +rnnoise speech test zeroconf"
+IUSE="+alsa +dbus debug g15 jack libressl portaudio pulseaudio nls +rnnoise speech test zeroconf"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -39,6 +39,7 @@ RDEPEND="
 	dev-qt/qtxml:5
 	>=dev-libs/protobuf-2.2.0:=
 	>=media-libs/libsndfile-1.0.20[-minimal]
+	>=media-libs/opus-1.3.1
 	>=media-libs/speex-1.2.0
 	media-libs/speexdsp
 	sys-apps/lsb-release
@@ -50,7 +51,6 @@ RDEPEND="
 	jack? ( virtual/jack )
 	!libressl? ( >=dev-libs/openssl-1.0.0b:0= )
 	libressl? ( dev-libs/libressl )
-	>=media-libs/opus-1.3.1
 	portaudio? ( media-libs/portaudio )
 	pulseaudio? ( media-sound/pulseaudio )
 	speech? ( >=app-accessibility/speech-dispatcher-0.8.0 )
@@ -72,10 +72,10 @@ src_configure() {
 		"-Dbundled-opus=OFF"
 		"-Dbundled-speex=OFF"
 		"-Doverlay=ON"
-		"-Dtranslations=OFF"
 		"-Dserver=OFF"
 		"-Dupdate=OFF"
 		"-Dalsa=$(usex alsa)"
+		"-DBUILD_TESTING=$(usex test)"
 		"-Ddbus=$(usex dbus)"
 		"-Dg15=$(usex g15)"
 		"-Djackaudio=$(usex jack)"
@@ -83,11 +83,10 @@ src_configure() {
 		"-Dpulseaudio=$(usex pulseaudio)"
 		"-Drnnoise=$(usex rnnoise)"
 		"-Dspeechd=$(usex speech)"
-		"-DBUILD_TESTING=$(usex test)"
+		"-Dtranslations=$(usex nls)"
 		"-Dzeroconf=$(usex zeroconf)"
 	)
 
-	CMAKE_BUILD_TYPE=$(usex debug Debug Release) \
 	cmake_src_configure
 }
 


### PR DESCRIPTION
Upstream now has dropped qmake and uses only cmake.
Updated the ebuild to use cmake instead of qmake.

Also added tests.

Some minor fixes needed to be done to the build system.
I've submitted two pull requests upstream:
https://github.com/mumble-voip/mumble/pull/4466
https://github.com/mumble-voip/mumble/pull/4468

I'm submitting this now so I can get feedback on the ebuild side of things.