### PR TITLE
sys-apps/shadow: PDEPEND on acct-group/mail

### DIFF
--- a/sys-apps/shadow/shadow-4.8-r5.ebuild
+++ b/sys-apps/shadow/shadow-4.8-r5.ebuild
@@ -42,6 +42,9 @@ RDEPEND="${COMMON_DEPEND}
 	pam? ( >=sys-auth/pambase-20150213 )
 	su? ( !sys-apps/util-linux[su(-)] )
 "
+PDEPEND="
+	acct-group/mail
+"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-4.1.3-dots-in-usernames.patch"

--- a/sys-apps/shadow/shadow-4.8.1-r3.ebuild
+++ b/sys-apps/shadow/shadow-4.8.1-r3.ebuild
@@ -43,6 +43,9 @@ RDEPEND="${COMMON_DEPEND}
 	pam? ( >=sys-auth/pambase-20150213 )
 	su? ( !sys-apps/util-linux[su(-)] )
 "
+PDEPEND="
+	acct-group/mail
+"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-4.1.3-dots-in-usernames.patch"


### PR DESCRIPTION
This depends on the mail group at runtime, but it allows shadow to be installed first so that `groupadd` is executable while creating the mail group.

@floppym