### PR TITLE
net-news/newsboat: fix license

### DIFF
--- a/net-news/newsboat/newsboat-2.20.1.ebuild
+++ b/net-news/newsboat/newsboat-2.20.1.ebuild
@@ -114,7 +114,7 @@ SRC_URI="
 	$(cargo_crate_uris ${CRATES})
 "
 
-LICENSE="Apache-2.0 BSD-2 BSL-1.1 CC0-1.0 ISC MIT Unlicense"
+LICENSE="Apache-2.0 Boost-1.0 BSD-2 CC0-1.0 ISC MIT Unlicense"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
 IUSE="libressl"


### PR DESCRIPTION
This PR is an attempt to fix license information for net-news/newsboat-2.20.1.

The BSL mentioned in [upstream's recent PR](https://github.com/newsboat/newsboat/pull/1007) actually refers to Boost Software License, which is represented as Boost-1.0 in Gentoo.

Please review and merge, or let me know how to further improve it.

Closes: https://bugs.gentoo.org/741138