### PR TITLE
media-libs/libvpx: remove obsolete svc USE flag

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.14.2.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.14.2.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 	media-libs/lcms:2
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:0=
-	>=media-libs/libvpx-1.5:=[svc]
+	>=media-libs/libvpx-1.5:=[svc(+)]
 	media-libs/libwebp:=
 	media-libs/mesa[egl,X(+)]
 	media-libs/opus

--- a/dev-qt/qtwebengine/qtwebengine-5.15.0.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.0.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	media-libs/lcms:2
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:0=
-	>=media-libs/libvpx-1.5:=[svc]
+	>=media-libs/libvpx-1.5:=[svc(+)]
 	media-libs/libwebp:=
 	media-libs/mesa[egl,X(+)]
 	media-libs/opus

--- a/media-libs/libvpx/libvpx-1.8.2.ebuild
+++ b/media-libs/libvpx/libvpx-1.8.2.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/webmproject/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.
 LICENSE="BSD"
 SLOT="0/6"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="doc +highbitdepth postproc static-libs svc test +threads"
+IUSE="doc +highbitdepth postproc static-libs test +threads"
 
 REQUIRED_USE="test? ( threads )"
 
@@ -67,7 +67,6 @@ multilib_src_configure() {
 		--enable-shared
 		--extra-cflags="${CFLAGS}"
 		$(use_enable postproc)
-		$(use_enable svc experimental)
 		$(use_enable static-libs static)
 		$(use_enable test unit-tests)
 		$(use_enable threads multithread)

--- a/media-libs/libvpx/libvpx-1.9.0.ebuild
+++ b/media-libs/libvpx/libvpx-1.9.0.ebuild
@@ -22,7 +22,7 @@ SRC_URI="https://github.com/webmproject/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.
 LICENSE="BSD"
 SLOT="0/6"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="doc +highbitdepth postproc static-libs svc test +threads"
+IUSE="doc +highbitdepth postproc static-libs test +threads"
 
 REQUIRED_USE="test? ( threads )"
 
@@ -68,7 +68,6 @@ multilib_src_configure() {
 		--enable-shared
 		--extra-cflags="${CFLAGS}"
 		$(use_enable postproc)
-		$(use_enable svc experimental)
 		$(use_enable static-libs static)
 		$(use_enable test unit-tests)
 		$(use_enable threads multithread)

--- a/www-client/chromium/chromium-85.0.4183.83.ebuild
+++ b/www-client/chromium/chromium-85.0.4183.83.ebuild
@@ -58,7 +58,7 @@ COMMON_DEPEND="
 	>=media-libs/harfbuzz-2.4.0:0=[icu(-)]
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
-	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc,svc] )
+	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc] )
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? (
 		>=media-video/ffmpeg-4:=

--- a/www-client/chromium/chromium-86.0.4240.22.ebuild
+++ b/www-client/chromium/chromium-86.0.4240.22.ebuild
@@ -58,7 +58,7 @@ COMMON_DEPEND="
 	>=media-libs/harfbuzz-2.4.0:0=[icu(-)]
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
-	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc,svc] )
+	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc] )
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? (
 		>=media-video/ffmpeg-4.3:=

--- a/www-client/chromium/chromium-87.0.4252.0.ebuild
+++ b/www-client/chromium/chromium-87.0.4252.0.ebuild
@@ -57,7 +57,7 @@ COMMON_DEPEND="
 	>=media-libs/harfbuzz-2.4.0:0=[icu(-)]
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
-	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc,svc] )
+	system-libvpx? ( >=media-libs/libvpx-1.8.2:=[postproc] )
 	pulseaudio? ( media-sound/pulseaudio:= )
 	system-ffmpeg? (
 		>=media-video/ffmpeg-4.3:=


### PR DESCRIPTION
CI run to see if I missed something.

Closes: https://bugs.gentoo.org/678730