### PR TITLE
net-fs/s3fs: Specify slot for dev-fs/fuse in 1.80

### DIFF
--- a/net-fs/s3fs/s3fs-1.80.ebuild
+++ b/net-fs/s3fs/s3fs-1.80.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -27,7 +27,7 @@ CDEPEND="
 	gnutls? ( net-libs/gnutls )
 	nettle? ( dev-libs/nettle )
 	>=net-misc/curl-7.0
-	>=sys-fs/fuse-2.8.4"
+	>=sys-fs/fuse-2.8.4:0"
 
 RDEPEND="
 	${CDEPEND}


### PR DESCRIPTION
Similar to 3710a40f819dd27e8d254fb194f9ba5c1b480fcc for
dev-utils/ostree, we need FUSE 2 for this to build, so
specify the slot explicitly.

Not specifying the slot caused a build failure for me - it is fixed with the change.
Also bumps the copyright year and changes it to `Gentoo Authors` to sate `repoman`'s lint.

Package-Manager: Portage-3.0.6, Repoman-3.0.1