### PR TITLE
dev-games/clanlib: fixes to 0.8.1 version

### DIFF
--- a/dev-games/clanlib/clanlib-0.8.1-r1.ebuild
+++ b/dev-games/clanlib/clanlib-0.8.1-r1.ebuild
@@ -1,0 +1,82 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="multi-platform game development library"
+HOMEPAGE="http://www.clanlib.org/"
+SRC_URI="http://clanlib.org/download/releases-${PV:0:3}/ClanLib-${PV}.tgz"
+
+LICENSE="ZLIB"
+SLOT="0.8"
+KEYWORDS="~amd64 ~x86" #not big endian safe #82779
+IUSE="doc ipv6 mikmod opengl sdl static-libs vorbis"
+
+# opengl keyword does not drop the GL/GLU requirement.
+# Autoconf files need to be fixed
+RDEPEND="media-libs/libpng:0
+	virtual/jpeg:0
+	virtual/glu
+	virtual/opengl
+	sdl? (
+		media-libs/libsdl[X]
+		media-libs/sdl-gfx
+	)
+	x11-libs/libXi
+	x11-libs/libXmu
+	x11-libs/libXxf86vm
+	media-libs/alsa-lib
+	mikmod? ( media-libs/libmikmod )
+	vorbis? ( media-libs/libvorbis )"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+S=${WORKDIR}/ClanLib-${PV}
+
+PATCHES=(
+	"${FILESDIR}/${P}-ndebug.patch"
+	"${FILESDIR}/${P}-gcc43.patch"
+	"${FILESDIR}/${P}-gcc44.patch"
+	"${FILESDIR}/${P}-gcc47.patch"
+	"${FILESDIR}/${P}-gcc6.patch"
+	"${FILESDIR}/${P}-libpng15.patch"
+	"${FILESDIR}/${P}-docbuilder.patch"
+)
+DOCS="CODING_STYLE CREDITS NEWS PATCHES README* INSTALL.linux"
+
+src_prepare() {
+	default
+	# See #739358
+	sed -i -e "s:libdir=\${exec_prefix}/lib:libdir=@libdir@:g" \
+		pkgconfig/*.pc.in || die
+}
+
+src_configure() {
+	#clanSound only controls mikmod/vorbis so there's
+	# no need to pass --{en,dis}able-clanSound ...
+	#clanDisplay only controls X, SDL, OpenGL plugins
+	# so no need to pass --{en,dis}able-clanDisplay
+	# also same reason why we don't have to use clanGUI
+	econf \
+		--enable-dyn \
+		--enable-clanNetwork \
+		$(use_enable x86 asm386) \
+		$(use_enable doc docs) \
+		$(use_enable opengl clanGL) \
+		$(use_enable sdl clanSDL) \
+		$(use_enable vorbis clanVorbis) \
+		$(use_enable mikmod clanMikMod) \
+		$(use_enable ipv6 getaddr) \
+		$(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	if use doc ; then
+		dodir /usr/share/doc/${PF}/html
+		mv "${D}"/usr/share/doc/clanlib/* "${D}"/usr/share/doc/${PF}/html/ || die
+		rm -rf "${D}"/usr/share/doc/clanlib
+		cp -r Examples Resources "${D}"/usr/share/doc/${PF}/ || die
+	fi
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/dev-games/clanlib/files/clanlib-0.8.1-docbuilder.patch
+++ b/dev-games/clanlib/files/clanlib-0.8.1-docbuilder.patch
@@ -1,0 +1,30 @@
+diff --git a/Documentation/Utilities/webbuilder.pl.in b/Documentation/Utilities/webbuilder.pl.in
+index ea9de63..c000432 100644
+--- a/Documentation/Utilities/webbuilder.pl.in
++++ b/Documentation/Utilities/webbuilder.pl.in
+@@ -68,11 +68,7 @@ sub convert
+ sub print_head
+ {
+ 	my ($xml_head, $file) = @ARG;
+-	my $ml, $buffer;
+-
+-	# Don't know what this does, but Perceps does it:
+-	if ($*) { $ml=1; }
+-	else { $ml=0; }
++	my $buffer;
+ 	
+ 	# Read theme from disk and execute it:
+ 	if ( -e $file )
+@@ -93,11 +89,7 @@ sub print_head
+ sub print_body
+ {
+ 	my ($xml_body, $file) = @ARG;
+-	my $ml, $buffer;
+-
+-	# Don't know what this does, but Perceps does it:
+-	if ($*) { $ml=1; }
+-	else { $ml=0; }
++	my $buffer;
+ 	
+ 	# Read theme from disk and execute it:
+ 	if ( -e $file )

--- a/dev-games/clanlib/files/clanlib-0.8.1-gcc43.patch
+++ b/dev-games/clanlib/files/clanlib-0.8.1-gcc43.patch
@@ -1,5 +1,5 @@
---- Sources/GL/opengl.cpp
-+++ Sources/GL/opengl.cpp
+--- a/Sources/GL/opengl.cpp
++++ b/Sources/GL/opengl.cpp
 @@ -51,6 +51,8 @@
  #endif
  #endif
@@ -16,8 +16,8 @@
 -}
 \ No newline at end of file
 +}
---- Sources/Network/Socket/ip_address_getsock.cpp
-+++ Sources/Network/Socket/ip_address_getsock.cpp
+--- a/Sources/Network/Socket/ip_address_getsock.cpp
++++ b/Sources/Network/Socket/ip_address_getsock.cpp
 @@ -40,6 +40,7 @@
  #include "ip_address_getsock.h"
  

--- a/dev-games/clanlib/files/clanlib-0.8.1-libpng15.patch
+++ b/dev-games/clanlib/files/clanlib-0.8.1-libpng15.patch
@@ -1,5 +1,5 @@
---- Sources/Display/Providers/png_provider_generic.cpp
-+++ Sources/Display/Providers/png_provider_generic.cpp
+--- a/Sources/Display/Providers/png_provider_generic.cpp
++++ b/Sources/Display/Providers/png_provider_generic.cpp
 @@ -107,7 +107,7 @@
  		png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp) NULL);
  		cl_assert(false);

--- a/dev-games/clanlib/files/clanlib-0.8.1-ndebug.patch
+++ b/dev-games/clanlib/files/clanlib-0.8.1-ndebug.patch
@@ -9,8 +9,8 @@ This patch adds the missing declaration, thus make the
 file compile with or without -DNDEBUG.
 
 diff -Naur clanlib-0.7.8-r2.orig/work/ClanLib-0.7.8/Sources/Core/System/Unix/init_linux.cpp clanlib-0.7.8-r2/work/ClanLib-0.7.8/Sources/Core/System/Unix/init_linux.cpp
---- clanlib-0.7.8-r2.orig/work/ClanLib-0.7.8/Sources/Core/System/Unix/init_linux.cpp	2003-09-19 10:33:02.000000000 +0000
-+++ clanlib-0.7.8-r2/work/ClanLib-0.7.8/Sources/Core/System/Unix/init_linux.cpp	2007-10-26 13:36:39.000000000 +0000
+--- a/Sources/Core/System/Unix/init_linux.cpp	2003-09-19 10:33:02.000000000 +0000
++++ b/Sources/Core/System/Unix/init_linux.cpp	2007-10-26 13:36:39.000000000 +0000
 @@ -52,6 +52,7 @@
  	_begin_time = (long) tv.tv_sec*(long) 1000+(long) tv.tv_usec/(long) 1000;
  


### PR DESCRIPTION
Fix pkg-config files (#739358), update ebuild to EAPI7, fix
documentation installation, unify patches for eapply's -p1 level, remove
deprecated eclasses.

Bug: https://bugs.gentoo.org/739358
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>