### PR TITLE
app-i18n/uchardet: Update metadata's <bugs-to>

### DIFF
--- a/app-i18n/uchardet/metadata.xml
+++ b/app-i18n/uchardet/metadata.xml
@@ -10,6 +10,6 @@
         <name>Proxy Maintainers</name>
     </maintainer>
     <upstream>
-        <bugs-to>https://bugs.freedesktop.org/enter_bug.cgi?product=uchardet</bugs-to>
+        <bugs-to>https://gitlab.freedesktop.org/uchardet/uchardet/-/issues</bugs-to>
     </upstream>
 </pkgmetadata>


### PR DESCRIPTION
The \<bugs-to\> link was dead, I updated it with the one found on the
homepage.

Package-Manager: Portage-3.0.6, Repoman-3.0.1
Signed-off-by: Matthias Coppens <coppens.matthias.abc@gmail.com>