### PR TITLE
sys-auth/sssd: fix samba, change to man USE, add autoconf dep

### DIFF
--- a/sys-auth/sssd/metadata.xml
+++ b/sys-auth/sssd/metadata.xml
@@ -13,6 +13,7 @@
 		<flag name="acl"> Build and use the cifsidmap plugin</flag>
 		<flag name="autofs">Build helper to let <pkg>net-fs/autofs</pkg> use sssd provided information</flag>
 		<flag name="locator">Install sssd's Kerberos plugin</flag>
+		<flag name="man">Build man pages with <pkg>dev-libs/libxslt</pkg></flag>
 		<flag name="manpages">Build man pages with <pkg>dev-libs/libxslt</pkg></flag>
 		<flag name="netlink">Add support for netlink protocol via <pkg>dev-libs/libnl</pkg></flag>
 		<flag name="nfsv4">Add support for the nfsv4 idmapd plugin provided by <pkg>net-libs/libnfsidmap</pkg></flag>


### PR DESCRIPTION
cc @mattst88 

im very sorry this took me so long, i think that's my last set of changes; some of these after discussion on the other PR.

let me reemphasize that the configure flag does *not* add a dependency on samba, it just does skip the check for the plugin version altogether; we don't need that check too since we dep on newer samba anyway.

i changed manpages use to man, i didn't change older ebuilds on purpose since i didn't want to create rebuilds (maybe thats a wrong mindset? i don't know)