### PR TITLE
x11-themes/fvwm{_icons,_sounds}, media-gfx/duhdraw, app-crypt/quickcrypt: use HTTPS

### DIFF
--- a/app-crypt/quickcrypt/quickcrypt-0.9.2b-r1.ebuild
+++ b/app-crypt/quickcrypt/quickcrypt-0.9.2b-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 MY_P=${P/-/_}
 S=${WORKDIR}/${MY_P}
 DESCRIPTION="gives you a quick MD5 Password from any string"
-HOMEPAGE="http://linux.netpimpz.com/quickcrypt/"
-SRC_URI="http://linux.netpimpz.com/quickcrypt/download/${MY_P}.tar.gz"
+HOMEPAGE="https://linux.netpimpz.com/quickcrypt/"
+SRC_URI="https://linux.netpimpz.com/quickcrypt/download/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-gfx/duhdraw/duhdraw-2.8.13-r1.ebuild
+++ b/media-gfx/duhdraw/duhdraw-2.8.13-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="ASCII art editor"
-HOMEPAGE="http://www.cs.helsinki.fi/u/penberg/duhdraw"
-SRC_URI="http://www.cs.helsinki.fi/u/penberg/duhdraw/${P}.tar.gz"
+HOMEPAGE="https://www.cs.helsinki.fi/u/penberg/duhdraw"
+SRC_URI="https://www.cs.helsinki.fi/u/penberg/duhdraw/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-themes/fvwm_icons/fvwm_icons-1.0.ebuild
+++ b/x11-themes/fvwm_icons/fvwm_icons-1.0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Icons for use with FVWM"
-HOMEPAGE="http://www.fvwm.org/"
+HOMEPAGE="https://www.fvwm.org/"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 LICENSE="GPL-2 FVWM"

--- a/x11-themes/fvwm_sounds/fvwm_sounds-1.0.ebuild
+++ b/x11-themes/fvwm_sounds/fvwm_sounds-1.0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Sounds for use with FVWM"
-HOMEPAGE="http://www.fvwm.org/"
+HOMEPAGE="https://www.fvwm.org/"
 SRC_URI="mirror://gentoo/${P}.tgz"
 
 LICENSE="GPL-2 FVWM"


### PR DESCRIPTION
Hi,

Just a few updates to maintainer-needed packages to use https instead of http.