### PR TITLE
sci-physics/vgm: Add missing dependency on sci-physics/geant[gdml].

### DIFF
--- a/sci-physics/vgm/vgm-4.5.ebuild
+++ b/sci-physics/vgm/vgm-4.5.ebuild
@@ -29,7 +29,10 @@ RDEPEND="
 	geant4? ( >=sci-physics/geant-4.10.03 )"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen[dot] )
-	test? ( sci-physics/geant-vmc[g4root] )"
+	test? (
+		sci-physics/geant[gdml]
+		sci-physics/geant-vmc[g4root]
+	)"
 RESTRICT="
 	!geant4? ( test )
 	!root? ( test )

--- a/sci-physics/vgm/vgm-4.8.ebuild
+++ b/sci-physics/vgm/vgm-4.8.ebuild
@@ -31,7 +31,10 @@ RDEPEND="
 	root? ( >=sci-physics/root-6.14:=[c++11?,c++14?,c++17?] )"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen[dot] )
-	test? ( sci-physics/geant-vmc[g4root] )"
+	test? (
+		sci-physics/geant[gdml]
+		sci-physics/geant-vmc[g4root]
+	)"
 RESTRICT="
 	!geant4? ( test )
 	!root? ( test )

--- a/sci-physics/vgm/vgm-9999.ebuild
+++ b/sci-physics/vgm/vgm-9999.ebuild
@@ -31,7 +31,10 @@ RDEPEND="
 	root? ( >=sci-physics/root-6.14:=[c++11?,c++14?,c++17?] )"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen[dot] )
-	test? ( sci-physics/geant-vmc[g4root] )"
+	test? (
+		sci-physics/geant[gdml]
+		sci-physics/geant-vmc[g4root]
+	)"
 RESTRICT="
 	!geant4? ( test )
 	!root? ( test )


### PR DESCRIPTION
This is required only for sci-physics/vgm[test] since it is used
by the test suite.

Closes: https://bugs.gentoo.org/741648
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>