### PR TITLE
games-rpg/freedroidrpg: fix build on gcc 10

### DIFF
--- a/games-rpg/freedroidrpg/files/freedroidrpg-1.0_rc2-fnocommon.patch
+++ b/games-rpg/freedroidrpg/files/freedroidrpg-1.0_rc2-fnocommon.patch
@@ -1,0 +1,49 @@
+Fixes build. https://bugs.gentoo.org/706930#c8
+
+--- freedroidrpg-1.0RC2/src/global.h	2019-03-30 23:20:31.000000000 +1000
++++ freedroidrpg-1.0RC2/src/global.h	2020-06-21 20:51:01.566218463 +1000
+@@ -36,7 +36,6 @@ 
+ #define INTERN_FOR _main_c
+ #include "extint_macros.h"
+ 
+-EXTERN float FPSover1;
+ EXTERN char *AllSkillTexts[];
+ EXTERN char font_switchto_red[];
+ EXTERN char font_switchto_blue[];
+--- freedroidrpg-1.0RC2/src/lvledit/lvledit_tools.h	2019-03-30 23:20:31.000000000 +1000
++++ freedroidrpg-1.0RC2/src/lvledit/lvledit_tools.h	2020-06-21 20:41:58.424710693 +1000
+@@ -36,7 +36,7 @@ 
+ 
+ void leveleditor_init_tools(void);
+ 
+-struct leveleditor_tool tool_place, tool_move, tool_select;
++EXTERN struct leveleditor_tool tool_place, tool_move, tool_select;
+ 
+ #define EVENT_LEFT_PRESS(e) (((e) && e->type == SDL_MOUSEBUTTONDOWN) && (e->button.button == 1))
+ #define EVENT_RIGHT_PRESS(e) (((e) && e->type == SDL_MOUSEBUTTONDOWN) && (e->button.button == 3))
+--- freedroidrpg-1.0RC2/src/mapgen/mapgen.h	2019-03-30 23:20:31.000000000 +1000
++++ freedroidrpg-1.0RC2/src/mapgen/mapgen.h	2020-06-21 20:43:53.255723534 +1000
+@@ -64,9 +64,9 @@ 
+ extern int total_rooms;
+ 
+ // Interface to the game
+-void (*dungeonmap_convert) (int, int, unsigned char *);
+-void (*dungeonmap_place_enemies) (struct roominfo *);
+-void (*dungeonmap_gift) (struct roominfo *);
++extern void (*dungeonmap_convert) (int, int, unsigned char *);
++extern void (*dungeonmap_place_enemies) (struct roominfo *);
++extern void (*dungeonmap_gift) (struct roominfo *);
+ 
+ int generate_dungeon_gram(int, int);
+ 
+--- freedroidrpg-1.0RC2/src/struct.h	2019-05-13 01:03:36.000000000 +1000
++++ freedroidrpg-1.0RC2/src/struct.h	2020-06-21 20:38:22.189812908 +1000
+@@ -1063,7 +1063,7 @@ 
+ 	struct tux_part_instances default_instances;    // Default part instances
+ 	tux_part_render_motionclass *render_order;      // The render_sets of each motion class
+ 	int gun_muzzle_height;							// Vertical offset to apply to bullets
+-} tux_rendering;
++};
+ 
+ /**
+  * Contains a set of Tux's parts images for a motion class.

--- a/games-rpg/freedroidrpg/freedroidrpg-1.0_rc2.ebuild
+++ b/games-rpg/freedroidrpg/freedroidrpg-1.0_rc2.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7} )
+
+PYTHON_COMPAT=( python3_{6,7,8} )
 inherit autotools flag-o-matic desktop python-any-r1 xdg
 
 MY_PV=$(ver_rs 2 '')
@@ -37,6 +38,10 @@ BDEPEND="
 
 S="${WORKDIR}/${PN}-${MY_PV^^}"
 
+PATCHES=(
+	"${FILESDIR}/${P}-fnocommon.patch"
+)
+
 src_prepare() {
 	default
 
@@ -56,7 +61,7 @@ src_configure() {
 	local myconf=(
 		--disable-fastmath
 		--with-embedded-lua
-		--localedir=/usr/share/locale
+		--localedir="${EPREFIX}/usr/share/locale"
 		$(use_enable nls)
 		$(use_enable opengl)
 		$(use_enable sound)


### PR DESCRIPTION
And fix prefix and add py3.8

Closes: https://bugs.gentoo.org/706930
Package-Manager: Portage-3.0.4, Repoman-2.3.23
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>