### PR TITLE
sys-devel/m4: fix gm4 symlink on prefix

### DIFF
--- a/sys-devel/m4/m4-1.4.18-r2.ebuild
+++ b/sys-devel/m4/m4-1.4.18-r2.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+DESCRIPTION="GNU macro processor"
+HOMEPAGE="https://www.gnu.org/software/m4/m4.html"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="examples"
+
+# remember: cannot dep on autoconf since it needs us
+DEPEND="app-arch/xz-utils"
+RDEPEND=""
+
+src_prepare() {
+	eapply "${FILESDIR}"/${P}-darwin17-printf-n.patch
+	eapply "${FILESDIR}"/${P}-glibc228.patch #663924
+	default
+}
+
+src_configure() {
+	# Disable automagic dependency over libsigsegv; see bug #278026
+	export ac_cv_libsigsegv=no
+
+	local myconf=""
+	[[ ${USERLAND} != "GNU" ]] && myconf="--program-prefix=g"
+	econf --enable-changeword ${myconf}
+}
+
+src_test() {
+	[[ -d /none ]] && die "m4 tests will fail with /none/" #244396
+	emake check
+}
+
+src_install() {
+	default
+	# autoconf-2.60 for instance, first checks gm4, then m4.  If we don't have
+	# gm4, it might find gm4 from outside the prefix on for instance Darwin
+	use prefix && dosym "${EPREFIX}"/usr/bin/m4 /usr/bin/gm4
+	if use examples ; then
+		docinto examples
+		dodoc -r examples/
+		rm -f "${ED}"/usr/share/doc/${PF}/examples/Makefile*
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/737152
Package-Manager: Portage-3.0.4, Repoman-2.3.23
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>

```diff
--- m4-1.4.18-r1.ebuild	2020-05-28 15:44:18.425698112 +0100
+++ m4-1.4.18-r2.ebuild	2020-09-13 00:09:51.416267355 +0100
@@ -9,7 +9,7 @@ SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="examples"
 
 # remember: cannot dep on autoconf since it needs us
@@ -40,7 +40,7 @@ src_install() {
 	default
 	# autoconf-2.60 for instance, first checks gm4, then m4.  If we don't have
 	# gm4, it might find gm4 from outside the prefix on for instance Darwin
-	use prefix && dosym /usr/bin/m4 /usr/bin/gm4
+	use prefix && dosym "${EPREFIX}"/usr/bin/m4 /usr/bin/gm4
 	if use examples ; then
 		docinto examples
 		dodoc -r examples/

```