### PR TITLE
games-puzzle/atomix: fix build with gcc10

### DIFF
--- a/games-puzzle/atomix/atomix-3.34.0-r1.ebuild
+++ b/games-puzzle/atomix/atomix-3.34.0-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit gnome.org meson xdg
+
+DESCRIPTION="Mind game - build molecules out of single atoms"
+HOMEPAGE="https://wiki.gnome.org/Apps/Atomix"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="
+	x11-libs/gtk+:3
+	x11-libs/gdk-pixbuf:2
+	dev-libs/glib:2
+	dev-libs/libgnome-games-support:=
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fnocommon.patch"
+)

--- a/games-puzzle/atomix/files/atomix-3.34.0-fnocommon.patch
+++ b/games-puzzle/atomix/files/atomix-3.34.0-fnocommon.patch
@@ -1,0 +1,26 @@
+Fixes build with -fno-common
+
+diff -Nurp atomix-3.34.0/src/level.c atomix-3.34.0-fix/src/level.c
+--- atomix-3.34.0/src/level.c	2019-09-09 19:14:36.000000000 -0000
++++ atomix-3.34.0-fix/src/level.c	2020-09-12 23:21:04.917492187 -0000
+@@ -31,7 +31,7 @@ static void level_class_init (GObjectCla
+ static void level_init (Level *level);
+ static void level_finalize (GObject *object);
+ 
+-GObjectClass *parent_class;
++static GObjectClass *parent_class;
+ 
+ /*=================================================================
+  
+diff -Nurp atomix-3.34.0/src/theme.c atomix-3.34.0-fix/src/theme.c
+--- atomix-3.34.0/src/theme.c	2019-09-09 19:14:36.000000000 -0000
++++ atomix-3.34.0-fix/src/theme.c	2020-09-12 23:21:19.557735891 -0000
+@@ -32,7 +32,7 @@ static void theme_init (Theme *theme);
+ static void theme_finalize (GObject *object);
+ static void destroy_theme_image (gpointer data);
+ 
+-GObjectClass *parent_class;
++static GObjectClass *parent_class;
+ 
+ GType theme_get_type (void)
+ {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/707728
Package-Manager: Portage-3.0.4, Repoman-2.3.23
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>

```diff
--- atomix-3.34.0.ebuild	2020-08-26 17:35:18.594214061 +0100
+++ atomix-3.34.0-r1.ebuild	2020-09-13 00:22:46.332513693 +0100
@@ -1,7 +1,8 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
+
 inherit gnome.org meson xdg
 
 DESCRIPTION="Mind game - build molecules out of single atoms"
@@ -13,12 +14,17 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="
-	>=x11-libs/gtk+-3.10:3
-	>=x11-libs/gdk-pixbuf-2.0.5:2
-	>=dev-libs/glib-2.36.0:2
+	x11-libs/gtk+:3
+	x11-libs/gdk-pixbuf:2
+	dev-libs/glib:2
 	dev-libs/libgnome-games-support:=
 "
-DEPEND="${RDEPEND}
-	>=sys-devel/gettext-0.19.8
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-devel/gettext
 	virtual/pkgconfig
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}-fnocommon.patch"
+)

```