### PR TITLE
gui-apps/waybar: Fix runtime crash in v0.9.3

### DIFF
--- a/gui-apps/waybar/files/waybar-0.9.3-fix-crash-with-fmt.patch
+++ b/gui-apps/waybar/files/waybar-0.9.3-fix-crash-with-fmt.patch
@@ -1,0 +1,22 @@
+From 9b41b9593418772ce578a87de5984d4e37ef7f11 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thorben=20G=C3=BCnther?= <admin@xenrox.net>
+Date: Mon, 10 Aug 2020 20:53:29 +0200
+Subject: [PATCH] Fix crash with fmt
+
+---
+ include/util/format.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/util/format.hpp b/include/util/format.hpp
+index 0147701b..288d8f0c 100644
+--- a/include/util/format.hpp
++++ b/include/util/format.hpp
+@@ -23,7 +23,7 @@ namespace fmt {
+         constexpr auto parse(ParseContext& ctx) -> decltype (ctx.begin()) {
+           auto it = ctx.begin(), end = ctx.end();
+           if (it != end && *it == ':') ++it;
+-          if (*it == '>' || *it == '<' || *it == '=') {
++          if (it && (*it == '>' || *it == '<' || *it == '=')) {
+             spec = *it;
+             ++it;
+           }

--- a/gui-apps/waybar/waybar-0.9.3-r1.ebuild
+++ b/gui-apps/waybar/waybar-0.9.3-r1.ebuild
@@ -49,6 +49,10 @@ DEPEND="
 	"
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-0.9.3-fix-crash-with-fmt.patch"
+	)
+
 src_configure() {
 	local emesonargs=(
 		$(meson_feature mpd)


### PR DESCRIPTION
Waybar 0.9.3 crashes in certain configurations. More details can be found in the upstream bug report at Alexays/Waybar#810.

This PR adds the patch from Alexays/Waybar#813.