### PR TITLE
dev-haskell/{persistent-test,blaze-markup}: use https

### DIFF
--- a/dev-haskell/blaze-markup/blaze-markup-0.8.2.4.ebuild
+++ b/dev-haskell/blaze-markup/blaze-markup-0.8.2.4.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour test-suite"
 inherit haskell-cabal
 
 DESCRIPTION="A blazingly fast markup combinator library for Haskell"
-HOMEPAGE="http://jaspervdj.be/blaze"
+HOMEPAGE="https://jaspervdj.be/blaze"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/dev-haskell/persistent-test/persistent-test-2.0.3.0.ebuild
+++ b/dev-haskell/persistent-test/persistent-test-2.0.3.0.ebuild
@@ -9,7 +9,7 @@ CABAL_FEATURES="lib profile haddock hoogle hscolour"
 inherit haskell-cabal
 
 DESCRIPTION="Tests for Persistent"
-HOMEPAGE="http://www.yesodweb.com/book/persistent"
+HOMEPAGE="https://www.yesodweb.com/book/persistent"
 SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"


### PR DESCRIPTION
Hi,

Simple updates for following packages to use https instead of http:
dev-haskell/persistent-test
dev-haskell/blaze-markup