### PR TITLE
games-board/gnome-hearts: fix HOMEPAGE

### DIFF
--- a/games-board/gnome-hearts/gnome-hearts-0.3.1-r2.ebuild
+++ b/games-board/gnome-hearts/gnome-hearts-0.3.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,8 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 inherit gnome2 python-single-r1
 
 DESCRIPTION="A clone of classic hearts card game"
-HOMEPAGE="http://www.gnome-hearts.org"
-SRC_URI="http://www.jejik.com/files/${PN}/${P}.tar.gz"
+HOMEPAGE="https://www.jejik.com/gnome-hearts/"
+SRC_URI="https://www.jejik.com/files/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2+ FDL-1.2"
 SLOT="0"


### PR DESCRIPTION
Package-Manager: Portage-3.0.6, Repoman-3.0.1
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,

I've updated the homepage of gnome-hearts because the original homepage seems to be a blog about online casinos and has nothing todo with that game (at least as far as i can see).