### PR TITLE
dev-python/seaborn: tests fail on 0.10.0

### DIFF
--- a/dev-python/seaborn/seaborn-0.10.0.ebuild
+++ b/dev-python/seaborn/seaborn-0.10.0.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 LICENSE="BSD"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="test"
-RESTRICT="!test? ( test )"
+RESTRICT="test"
 
 RDEPEND="
 	>=dev-python/matplotlib-2.1.2[${PYTHON_USEDEP}]


### PR DESCRIPTION
Package-Manager: Portage-3.0.6, Repoman-3.0.1
Signed-off-by: Horea Christian <chr@chymera.eu>