### PR TITLE
media-gfx/asymptote, sci-libs/{amd,btf,camd,ccolamd,cholmod,libexcelformat,qd}: update HOMEPAGE, use https

### DIFF
--- a/media-gfx/asymptote/asymptote-2.61.ebuild
+++ b/media-gfx/asymptote/asymptote-2.61.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{6,7} )
 inherit autotools elisp-common latex-package python-r1
 
 DESCRIPTION="A vector graphics language that provides a framework for technical drawing"
-HOMEPAGE="http://asymptote.sourceforge.net/"
+HOMEPAGE="https://asymptote.sourceforge.net/"
 SRC_URI="mirror://sourceforge/asymptote/${P}.src.tgz"
 
 LICENSE="GPL-3"

--- a/media-gfx/asymptote/asymptote-2.62.ebuild
+++ b/media-gfx/asymptote/asymptote-2.62.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{6,7} )
 inherit autotools elisp-common latex-package python-r1
 
 DESCRIPTION="A vector graphics language that provides a framework for technical drawing"
-HOMEPAGE="http://asymptote.sourceforge.net/"
+HOMEPAGE="https://asymptote.sourceforge.net/"
 SRC_URI="mirror://sourceforge/asymptote/${P}.src.tgz"
 
 LICENSE="GPL-3"

--- a/media-gfx/asymptote/asymptote-2.65.ebuild
+++ b/media-gfx/asymptote/asymptote-2.65.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{6,7,8} )
 inherit autotools elisp-common latex-package python-r1
 
 DESCRIPTION="A vector graphics language that provides a framework for technical drawing"
-HOMEPAGE="http://asymptote.sourceforge.net/"
+HOMEPAGE="https://asymptote.sourceforge.net/"
 SRC_URI="mirror://sourceforge/asymptote/${P}.src.tgz"
 
 LICENSE="GPL-3"

--- a/media-gfx/asymptote/asymptote-2.67.ebuild
+++ b/media-gfx/asymptote/asymptote-2.67.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{6,7,8} )
 inherit autotools elisp-common latex-package python-r1
 
 DESCRIPTION="A vector graphics language that provides a framework for technical drawing"
-HOMEPAGE="http://asymptote.sourceforge.net/"
+HOMEPAGE="https://asymptote.sourceforge.net/"
 SRC_URI="mirror://sourceforge/asymptote/${P}.src.tgz"
 
 LICENSE="GPL-3"

--- a/sci-libs/amd/amd-2.4.6.ebuild
+++ b/sci-libs/amd/amd-2.4.6.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit fortran-2
 
 DESCRIPTION="Library to order a sparse matrix prior to Cholesky factorization"
-HOMEPAGE="http://faculty.cse.tamu.edu/davis/suitesparse.html"
+HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
 SRC_URI="http://202.36.178.9/sage/${P}.tar.bz2"
 
 LICENSE="BSD"

--- a/sci-libs/btf/btf-1.2.6.ebuild
+++ b/sci-libs/btf/btf-1.2.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="Algorithm for matrix permutation into block triangular form"
-HOMEPAGE="http://faculty.cse.tamu.edu/davis/suitesparse.html"
+HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
 SRC_URI="http://202.36.178.9/sage/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1+"

--- a/sci-libs/camd/camd-2.4.6.ebuild
+++ b/sci-libs/camd/camd-2.4.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="Library to order a sparse matrix prior to Cholesky factorization"
-HOMEPAGE="http://faculty.cse.tamu.edu/davis/suitesparse.html"
+HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
 SRC_URI="http://202.36.178.9/sage/${P}.tar.bz2"
 
 LICENSE="BSD"

--- a/sci-libs/ccolamd/ccolamd-2.9.6.ebuild
+++ b/sci-libs/ccolamd/ccolamd-2.9.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="Constrained Column approximate minimum degree ordering algorithm"
-HOMEPAGE="http://faculty.cse.tamu.edu/davis/suitesparse.html"
+HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
 SRC_URI="http://202.36.178.9/sage//${P}.tar.bz2"
 
 LICENSE="BSD"

--- a/sci-libs/cholmod/cholmod-2.1.2.ebuild
+++ b/sci-libs/cholmod/cholmod-2.1.2.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 inherit autotools-utils multilib toolchain-funcs
 
 DESCRIPTION="Sparse Cholesky factorization and update/downdate library"
-HOMEPAGE="http://faculty.cse.tamu.edu/davis/suitesparse.html"
+HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
 SRC_URI="https://dev.gentoo.org/~bicatali/distfiles/${P}.tar.bz2"
 
 LICENSE="minimal? ( LGPL-2.1 ) !minimal? ( GPL-2 )"

--- a/sci-libs/cholmod/cholmod-3.0.13.ebuild
+++ b/sci-libs/cholmod/cholmod-3.0.13.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Sparse Cholesky factorization and update/downdate library"
-HOMEPAGE="http://faculty.cse.tamu.edu/davis/suitesparse.html"
+HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
 SRC_URI="http://202.36.178.9/sage/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1+ modify? ( GPL-2+ ) matrixops? ( GPL-2+ )"

--- a/sci-libs/libexcelformat/libexcelformat-101016.ebuild
+++ b/sci-libs/libexcelformat/libexcelformat-101016.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="reading, writing, and editing of XLS (BIFF8 format) files using C++"
-HOMEPAGE="http://www.codeproject.com/KB/office/ExcelFormat.aspx"
+HOMEPAGE="https://www.codeproject.com/Articles/42504/ExcelFormat-Library"
 SRC_URI="mirror://gentoo/${P}.tar.bz2"
 
 SLOT="0"

--- a/sci-libs/qd/qd-2.3.17.ebuild
+++ b/sci-libs/qd/qd-2.3.17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ FORTRAN_NEEDED=fortran
 inherit autotools fortran-2
 
 DESCRIPTION="Quad-double and double-double float arithmetics"
-HOMEPAGE="http://crd-legacy.lbl.gov/~dhbailey/mpdist/"
+HOMEPAGE="https://www.davidhbailey.com/dhbsoftware/"
 SRC_URI="http://crd.lbl.gov/~dhbailey/mpdist/${P}.tar.gz"
 
 SLOT="0"

--- a/sci-libs/qd/qd-2.3.22.ebuild
+++ b/sci-libs/qd/qd-2.3.22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,7 +8,7 @@ FORTRAN_NEEDED=fortran
 inherit autotools fortran-2
 
 DESCRIPTION="Quad-double and double-double float arithmetics"
-HOMEPAGE="http://crd-legacy.lbl.gov/~dhbailey/mpdist/"
+HOMEPAGE="https://www.davidhbailey.com/dhbsoftware/"
 SRC_URI="http://crd.lbl.gov/~dhbailey/mpdist/${P}.tar.gz"
 
 SLOT="0"


### PR DESCRIPTION
Hi,

This PR updates the homepage of some sci packages and uses https instead of http.