### PR TITLE
dev-embedded/esptool: add python3.[89] + new maintainer

### DIFF
--- a/dev-embedded/esptool/esptool-2.8-r1.ebuild
+++ b/dev-embedded/esptool/esptool-2.8-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6,7,8,9} ) # apps work with 3_9 but test depend is not fulfilled
+DISTUTILS_SINGLE_IMPL=1
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
+inherit distutils-r1
+
+DESCRIPTION="Utility to communicate with the ROM bootloader in Espressif ESP8266 and ESP32"
+HOMEPAGE="https://github.com/espressif/esptool"
+SRC_URI="https://github.com/espressif/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	$(python_gen_cond_dep '
+		dev-python/ecdsa[${PYTHON_MULTI_USEDEP}]
+		dev-python/pyaes[${PYTHON_MULTI_USEDEP}]
+		>=dev-python/pyserial-3.0[${PYTHON_MULTI_USEDEP}]
+	')
+"
+BDEPEND="
+	test? ( $(python_gen_cond_dep 'dev-python/pyelftools[${PYTHON_MULTI_USEDEP}]') )
+"
+
+src_prepare() {
+	rm -rf pyaes/ ecdsa/ || die "unable to remove bundled modules"
+	default
+}
+
+python_test() {
+	${EPYTHON} test/test_imagegen.py || die "imagegen test failed with ${EPYTHON}"
+	${EPYTHON} test/test_espsecure.py || die "espsecure test failed with ${EPYTHON}"
+}

--- a/dev-embedded/esptool/metadata.xml
+++ b/dev-embedded/esptool/metadata.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!--maintainer-needed-->
+	<maintainer type="person">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="github">espressif/esptool</remote-id>
 	</upstream>

--- a/dev-python/pyelftools/pyelftools-0.26.ebuild
+++ b/dev-python/pyelftools/pyelftools-0.26.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 inherit distutils-r1
 
 DESCRIPTION="pure-Python library for analyzing ELF files and DWARF debugging information"


### PR DESCRIPTION
successfully tested with python3.8 and 3.9
remove maintainer-needed, add proxy maintainer

add python3.9 to depend package dev-python/pyelftools

Package-Manager: Portage-3.0.6, Repoman-3.0.1
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>