### PR TITLE
dev-python/bibtexparser: add python 3.{8.9} pypy3 support

### DIFF
--- a/dev-python/bibtexparser/bibtexparser-1.1.0.ebuild
+++ b/dev-python/bibtexparser/bibtexparser-1.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6,7,8,9} pypy3 )
 
 inherit distutils-r1 python-r1
 


### PR DESCRIPTION
Tested with `ebuild test`.

I'm not sure, if this needs a revbump, but since it only adds optional features it would trigger a useless rebuild, I guess.