### PR TITLE
dev-python/easyprocess: add missing test dep

### DIFF
--- a/dev-python/easyprocess/easyprocess-0.3.ebuild
+++ b/dev-python/easyprocess/easyprocess-0.3.ebuild
@@ -19,6 +19,7 @@ BDEPEND="test? (
 	dev-python/pytest-timeout[${PYTHON_USEDEP}]
 	dev-python/pyvirtualdisplay[${PYTHON_USEDEP}]
 	dev-python/six[${PYTHON_USEDEP}]
+	x11-base/xorg-server[xvfb]
 )"
 
 S="${WORKDIR}/EasyProcess-${PV}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/742623
Package-Manager: Portage-3.0.7, Repoman-3.0.1
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>