### PR TITLE
dev-python/mss: add missing test dep

### DIFF
--- a/dev-python/mss/mss-6.0.0.ebuild
+++ b/dev-python/mss/mss-6.0.0.ebuild
@@ -21,6 +21,7 @@ S="${WORKDIR}/python-${PN}-${PV}"
 BDEPEND="test? (
 	dev-python/flaky[${PYTHON_USEDEP}]
 	dev-python/wheel[${PYTHON_USEDEP}]
+	sys-process/lsof
 )"
 
 distutils_enable_tests pytest


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/742626
Package-Manager: Portage-3.0.7, Repoman-3.0.1
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>