### PR TITLE
dev-games/irrlicht-headers: inherit edos2unix instead of eutils

### DIFF
--- a/dev-games/irrlicht-headers/irrlicht-headers-1.8.4.ebuild
+++ b/dev-games/irrlicht-headers/irrlicht-headers-1.8.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+inherit edos2unix
 
 MY_PN="irrlicht"
 MY_P="${MY_PN}-${PV}"


### PR DESCRIPTION
Package-Manager: Portage-3.0.6, Repoman-3.0.1
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,

This is a simple to update to use `edos2unix` directly instead of `eutils` (since the functions got splittet into separate eclasses)