### PR TITLE
gui-libs/greetd: add openrc initscript

### DIFF
--- a/gui-libs/greetd/files/greetd.init
+++ b/gui-libs/greetd/files/greetd.init
@@ -1,0 +1,8 @@
+#!/sbin/openrc-run
+
+command=/usr/bin/greetd
+pidfile=/var/run/greetd.pid
+name="Greetd Server"
+command_background="yes"
+
+description="Login Daemon for Wayland"

--- a/gui-libs/greetd/greetd-0.6.1-r1.ebuild
+++ b/gui-libs/greetd/greetd-0.6.1-r1.ebuild
@@ -104,6 +104,7 @@ src_install() {
 	doins config.toml
 
 	systemd_dounit greetd.service
+	newinitd "${FILESDIR}"/${PN}.init ${PN}
 
 	if use man; then
 		doman agreety.1 greetd.1 greetd.5 greetd-ipc.7


### PR DESCRIPTION
This commit adds an OpenRC-initscript for gui-libs/greetd, that
currently only supports systemd systems.

Bug: https://bugs.gentoo.org/742698
Package-Manager: Portage-3.0.7, Repoman-3.0.1
Signed-off-by: Jonas Toth <gentoo@jonas-toth.eu>