### PR TITLE
dev-util/cgdb: call default at the beginning of src_prepare

### DIFF
--- a/dev-util/cgdb/cgdb-0.6.8.ebuild
+++ b/dev-util/cgdb/cgdb-0.6.8.ebuild
@@ -41,8 +41,8 @@ PATCHES=(
 )
 
 src_prepare() {
-	cp configure.{init,ac} || die "cp failed"
 	default
+	cp configure.{init,ac} || die "cp failed"
 	AT_M4DIR="config" eautoreconf
 }
 

--- a/dev-util/cgdb/cgdb-0.7.0-r2.ebuild
+++ b/dev-util/cgdb/cgdb-0.7.0-r2.ebuild
@@ -46,8 +46,8 @@ PATCHES=(
 )
 
 src_prepare() {
-	cp configure.{init,ac} || die "cp failed"
 	default
+	cp configure.{init,ac} || die "cp failed"
 	AT_M4DIR="config" eautoreconf
 }
 

--- a/dev-util/cgdb/cgdb-0.7.1.ebuild
+++ b/dev-util/cgdb/cgdb-0.7.1.ebuild
@@ -46,8 +46,8 @@ PATCHES=(
 )
 
 src_prepare() {
-	cp configure.{init,ac} || die "cp failed"
 	default
+	cp configure.{init,ac} || die "cp failed"
 	AT_M4DIR="config" eautoreconf
 }
 

--- a/dev-util/cgdb/cgdb-9999.ebuild
+++ b/dev-util/cgdb/cgdb-9999.ebuild
@@ -44,8 +44,8 @@ PATCHES=(
 )
 
 src_prepare() {
-	cp configure.{init,ac} || die "cp failed"
 	default
+	cp configure.{init,ac} || die "cp failed"
 	AT_M4DIR="config" eautoreconf
 }
 


### PR DESCRIPTION
`default` should be called before `cp` in src_prepare as not doing that results in copying unpatched configure.init file, leading to
the ebuild again calling ar directly

Closes: https://bugs.gentoo.org/742731
