### PR TITLE
dev-libs/zziplib: enable tests

### DIFF
--- a/dev-libs/zziplib/files/zziplib-0.13.71-installing-man3-pages.patch
+++ b/dev-libs/zziplib/files/zziplib-0.13.71-installing-man3-pages.patch
@@ -1,9 +1,28 @@
-# https://github.com/gdraheim/zziplib/issues/93
 diff --git a/docs/CMakeLists.txt b/docs/CMakeLists.txt
-index b679f7b..e2887ee 100644
+index b679f7b..cafa6b4 100644
 --- a/docs/CMakeLists.txt
 +++ b/docs/CMakeLists.txt
-@@ -190,7 +190,7 @@ add_custom_target(install-manpages
+@@ -126,9 +126,10 @@ add_custom_command(OUTPUT manpages.tar
+     COMMAND ${BASH} -c "test -d man3/man3 && mv man3 man3_; test -d man3_/man3 && mv man3_/man3 .; rm -rf man3_"
+     COMMAND ${BASH} -c "chmod 664 man3/*.3"
+     COMMAND ${BASH} -c "tar cf manpages.tar man3"
+-    COMMAND ${BASH} -c "ls -l `pwd`/manpages.tar `pwd`/htmpages.tar >&2 || true"
++    COMMAND ${BASH} -c "ls -l `pwd`/manpages.tar >&2 || true"
+     DEPENDS zziplib.xml zzipmmapped.xml zzipfseeko.xml
+     VERBATIM)
++if(ZZIP_HTMPAGES)
+ add_custom_command(OUTPUT htmpages.tar
+     COMMAND ${BASH} -c "test -d html && rm -rf html; mkdir html"
+     COMMAND ${PY} ${srcdir}/dbk2man.py -o html html zziplib.xml
+@@ -139,6 +140,7 @@ add_custom_command(OUTPUT htmpages.tar
+     COMMAND ${BASH} -c "ls -l `pwd`/htmpages.tar `pwd`/manpages.tar >&2 || true"
+     DEPENDS zziplib.xml zzipmmapped.xml zzipfseeko.xml
+     VERBATIM)
++endif()
+ 
+ add_custom_target(manpages DEPENDS manpages.tar)
+ add_custom_target(htmpages DEPENDS htmpages.tar)
+@@ -190,7 +192,7 @@ if(ZZIP_HTMPAGES)
  endif()
  if(ZZIP_MANPAGES)
     install(CODE "message(STATUS \"Installing: man3 pages to ${mandir}/man3\")")

--- a/dev-libs/zziplib/zziplib-0.13.71_p20200419.ebuild
+++ b/dev-libs/zziplib/zziplib-0.13.71_p20200419.ebuild
@@ -40,6 +40,14 @@ pkg_setup() {
 	python-any-r1_pkg_setup
 }
 
+src_prepare() {
+	sed -e "/^topsrcdir/s:..\/..::" \
+		-e "/^bindir/s:\.\.:${WORKDIR}/${P}_build:" \
+		-e 's:\(..\/\)\+{exe}:{exe}:' \
+		-i test/zziptests.py || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	append-flags -fno-strict-aliasing # bug reported upstream
 
@@ -53,4 +61,9 @@ src_configure() {
 	)
 
 	cmake_src_configure
+}
+
+src_test() {
+	cd "$S"/test/ || die
+	${EPYTHON} "$S"/test/zziptests.py || die
 }


### PR DESCRIPTION
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>

A few tests still fail, which are same as failing from "./configure && make && make check"
See also https://github.com/gdraheim/zziplib/issues/97