### PR TITLE
dev-python/{configclass, mergedict}: port to py3.9

### DIFF
--- a/dev-python/configclass/configclass-0.2.0.ebuild
+++ b/dev-python/configclass/configclass-0.2.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 
 inherit distutils-r1
 
@@ -15,7 +15,6 @@ SRC_URI="
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE=""
 
 RDEPEND=">=dev-python/mergedict-0.2.0[${PYTHON_USEDEP}]"
 

--- a/dev-python/mergedict/mergedict-1.0.0.ebuild
+++ b/dev-python/mergedict/mergedict-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 
 inherit distutils-r1
 
@@ -14,9 +14,5 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE=""
-
-DEPEND=""
-RDEPEND=""
 
 distutils_enable_tests pytest


### PR DESCRIPTION
Build is okay, tests also work with 3.9