### PR TITLE
net-analyzer/chaosreader: remove myself as maintainer

### DIFF
--- a/net-analyzer/chaosreader/metadata.xml
+++ b/net-analyzer/chaosreader/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>mmk@levelnine.at</email>
-		<name>Michael Mair-Keimberger</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">chaosreader</remote-id>
 		<remote-id type="github">brendangregg/chaosreader</remote-id>


### PR DESCRIPTION
Package-Manager: Portage-3.0.7, Repoman-3.0.1
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>

Hi,

Since I haven't used this software for quite a while i'm removing myself as a maintainer.