### PR TITLE
dev-libs/tinyxml: fix libdir path in tinyxml.pc file

### DIFF
--- a/dev-libs/tinyxml/tinyxml-2.6.2-r4.ebuild
+++ b/dev-libs/tinyxml/tinyxml-2.6.2-r4.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit flag-o-matic toolchain-funcs eutils multilib
+
+DESCRIPTION="Simple and small C++ XML parser"
+HOMEPAGE="http://www.grinninglizard.com/tinyxml/index.html"
+SRC_URI="mirror://sourceforge/${PN}/${PN}_${PV//./_}.tar.gz"
+
+LICENSE="ZLIB"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-macos ~x86-macos"
+IUSE="debug doc static-libs +stl"
+
+RDEPEND=""
+DEPEND="doc? ( app-doc/doxygen )"
+
+S="${WORKDIR}/${PN}"
+
+DOCS=( "changes.txt" "readme.txt" )
+
+src_prepare() {
+	local major_v=$(ver_cut 1)
+	local minor_v=$(ver_cut 2-3)
+
+	sed -e "s:@MAJOR_V@:$major_v:" \
+	    -e "s:@MINOR_V@:$minor_v:" \
+		"${FILESDIR}"/Makefile-3 > Makefile || die
+
+	eapply -p0 "${FILESDIR}"/${PN}-2.6.1-entity.patch
+	eapply -p0 "${FILESDIR}"/${PN}.pc.patch
+
+	use debug && append-cppflags -DDEBUG
+	use stl && eapply "${FILESDIR}"/${P}-defineSTL.patch
+
+	sed -e "s:/lib:/$(get_libdir):g" -i tinyxml.pc || die # bug 738948
+	if use stl; then
+		sed -e "s/Cflags: -I\${includedir}/Cflags: -I\${includedir} -DTIXML_USE_STL=YES/g" -i tinyxml.pc || die
+	fi
+
+	if ! use static-libs; then
+		sed -e "/^all:/s/\$(name).a //" -i Makefile || die
+	fi
+
+	tc-export AR CXX RANLIB
+
+	[[ ${CHOST} == *-darwin* ]] && export LIBDIR="${EPREFIX}"/usr/$(get_libdir)
+	eapply_user
+}
+
+src_install() {
+	dolib.so *$(get_libname)*
+
+	insinto /usr/include
+	doins *.h
+
+	insinto /usr/share/pkgconfig
+	doins tinyxml.pc
+
+	einstalldocs
+
+	if use doc ; then
+		docinto html
+		dodoc -r docs/*
+	fi
+}


### PR DESCRIPTION
While using clang/llvm/lld env the on configuration phase
the information about library directory is taken from tinyxml.pc file.

On the amd64 arch system the use of lld linker instead of ldd
results in linking error as LDFLAGS is additionally filled with
`-L/usr/lib -ltinyxml` instead of `-L/usr/lib64 -ltinyxml`.

I.e. it causes linking error for dev-util/codeblocks package
on clang/llvm/lld systems.

Closes: https://bugs.gentoo.org/738948
