### PR TITLE
sys-devel/llvm-roc: Use flag to optionaly build runtime libraries

### DIFF
--- a/sys-devel/llvm-roc/llvm-roc-3.8.0-r1.ebuild
+++ b/sys-devel/llvm-roc/llvm-roc-3.8.0-r1.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="Radeon Open Compute llvm,lld,clang"
+HOMEPAGE="https://github.com/RadeonOpenCompute/ROCm/"
+SRC_URI="https://github.com/RadeonOpenCompute/llvm-project/archive/rocm-${PV}.tar.gz -> llvm-rocm-ocl-${PV}.tar.gz"
+
+LICENSE="UoI-NCSA rc BSD public-domain"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="debug runtime"
+
+RDEPEND="virtual/cblas
+	dev-libs/libxml2
+	sys-libs/zlib
+	sys-libs/ncurses:="
+DEPEND="${RDEPEND}"
+PDEPEND="dev-libs/rocr-runtime"
+
+S="${WORKDIR}/llvm-project-rocm-${PV}/llvm"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.7.0-current_pos.patch"
+)
+
+CMAKE_BUILD_TYPE=RelWithDebInfo
+
+src_prepare() {
+	cd "${WORKDIR}/llvm-project-rocm-${PV}" || die
+	eapply "${FILESDIR}/${PN}-3.0.0-add_libraries.patch"
+	eapply_user
+	cmake_src_prepare
+}
+
+src_configure() {
+	PROJECTS="clang;lld"
+
+	if usex runtime; then
+		PROJECTS+=";compiler-rt"
+	fi
+
+	local mycmakeargs=(
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/roc"
+		-DLLVM_ENABLE_PROJECTS="${PROJECTS}"
+		-DLLVM_TARGETS_TO_BUILD="AMDGPU;X86"
+		-DLLVM_BUILD_DOCS=NO
+		-DLLVM_ENABLE_OCAMLDOC=OFF
+		-DLLVM_ENABLE_SPHINX=NO
+		-DLLVM_ENABLE_DOXYGEN=OFF
+		-DLLVM_INSTALL_UTILS=ON
+		-DLLVM_VERSION_SUFFIX=roc
+		-DOCAMLFIND=NO
+	)
+
+	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	cat > "99${PN}" <<-EOF
+		LDPATH="${EROOT}/usr/lib/llvm/roc/lib"
+	EOF
+	doenvd "99${PN}"
+}

--- a/sys-devel/llvm-roc/metadata.xml
+++ b/sys-devel/llvm-roc/metadata.xml
@@ -8,4 +8,7 @@
     <upstream>
         <remote-id type="github">RadeonOpenCompute/llvm</remote-id>
     </upstream>
+    <use>
+        <flag name="runtime">Builds the compiler runtime libraries.</flag>
+    </use>
 </pkgmetadata>


### PR DESCRIPTION
Signed-off-by: Wilfried Holzke <gentoo@holzke.net>
Package-Manager: Portage-2.3.103, Repoman-2.3.23