### PR TITLE
media-libs/rubberband: use --disable/enable autoconf flags in 1.9.0

### DIFF
--- a/media-libs/rubberband/rubberband-1.9.0.ebuild
+++ b/media-libs/rubberband/rubberband-1.9.0.ebuild
@@ -41,11 +41,10 @@ src_prepare() {
 }
 
 multilib_src_configure() {
-	econf WITH_PROGRAMS=$(usex programs) WITH_LADSPA=$(usex ladspa) WITH_VAMP=$(usex vamp)
-}
-
-multilib_src_compile() {
-	emake WITH_PROGRAMS=$(usex programs) WITH_LADSPA=$(usex ladspa) WITH_VAMP=$(usex vamp)
+	econf \
+		$(use_enable programs ) \
+		$(use_enable ladspa ) \
+		$(use_enable vamp )
 }
 
 multilib_src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/743733
Package-Manager: Portage-3.0.7, Repoman-3.0.1
Signed-off-by: Nikos Chantziaras <realnc@gmail.com>