### PR TITLE
x11-plugins/wmcpuwatch: update ebuild

### DIFF
--- a/x11-plugins/wmcpuwatch/metadata.xml
+++ b/x11-plugins/wmcpuwatch/metadata.xml
@@ -12,7 +12,4 @@ It is a fork of wmmon. wmmon shows the load of up to 10 CPUs. With a little twea
 
 wmcpuwatch now shows the load of all CPUs in the lower frame which allows 40 CPUs at max.
 </longdescription>
-<upstream>
-	<remote-id type="bitbucket">StarFire/wmcpuwatch</remote-id>
-</upstream>
 </pkgmetadata>

--- a/x11-plugins/wmcpuwatch/wmcpuwatch-0.2-r1.ebuild
+++ b/x11-plugins/wmcpuwatch/wmcpuwatch-0.2-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit cmake-utils
+EAPI=7
+inherit cmake
 
 DESCRIPTION="dockapp showing the load of every logical CPU on the system"
-HOMEPAGE="https://bitbucket.org/StarFire/wmcpuwatch"
-SRC_URI="https://bitbucket.org/StarFire/${PN}/downloads/${P}.tar.bz2"
+HOMEPAGE="https://bitbucket-archive.softwareheritage.org/projects/st/StarFire/wmcpuwatch.html"
+SRC_URI="https://bitbucket-archive.softwareheritage.org/static/83/8395d160-de4b-42d6-a7d9-939eade4f58a/attachments/${P}.tar.bz2"
 
 LICENSE="GPL-3+"
 SLOT="0"
@@ -14,18 +14,18 @@ KEYWORDS="~amd64 ~x86"
 IUSE="doc"
 
 RDEPEND=">=x11-libs/libdockapp-0.7:="
-DEPEND="${RDEPEND}
-	doc? ( app-doc/doxygen[dot] )"
+DEPEND="${RDEPEND}"
+BDEPEND="doc? ( app-doc/doxygen[dot] )"
 
 DOCS=( ChangeLog README.md )
 PATCHES=( "${FILESDIR}"/${P}-cmake.patch )
 
 src_prepare() {
-	cmake-utils_src_prepare
+	cmake_src_prepare
 	use doc || sed -e "s/add_subdirectory(doc)//" -i CMakeLists.txt || die
 }
 
 src_install() {
-	cmake-utils_src_install
-	use doc && dodoc -r "${BUILD_DIR}"/doc/html
+	cmake_src_install
+	use doc && dodoc -r "${BUILD_DIR}/doc/html"
 }


### PR DESCRIPTION
Updated SRC_URI and HOMEPAGE, migrated to EAPI=7 and cmake.eclass.
Closes: https://bugs.gentoo.org/739810
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>