### PR TITLE
Install ddclient cache directory with proper permissions

### DIFF
--- a/net-dns/ddclient/ddclient-3.9.1.ebuild
+++ b/net-dns/ddclient/ddclient-3.9.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit systemd
+inherit systemd tmpfiles
 
 DESCRIPTION="Perl client used to update dynamic DNS entries"
 HOMEPAGE="https://ddclient.net/"
@@ -51,7 +51,7 @@ src_install() {
 
 	newinitd "${FILESDIR}"/ddclient.initd-r6 ddclient
 	systemd_newunit "${FILESDIR}"/ddclient.service-r1 ddclient.service
-	systemd_newtmpfilesd "${FILESDIR}"/ddclient.tmpfiles ddclient.conf
+	newtmpfiles "${FILESDIR}"/ddclient.tmpfiles ddclient.conf
 
 	dodoc Change* README* RELEASENOTE TODO UPGRADE
 
@@ -59,4 +59,8 @@ src_install() {
 		docinto examples
 		dodoc sample-*
 	fi
+}
+
+pkg_postinst() {
+	tmpfiles_process ddclient.conf
 }


### PR DESCRIPTION
## Description
Previously, the ddclient cache directory was not created until a reboot. Switching to the new tmpfiles eclass lets us process the tmpfile config after installing to ensure the service can be started immediately.