### PR TITLE
www-apps/cgit: Add missing escape characters in postinst message.

### DIFF
--- a/www-apps/cgit/files/postinstall-en.txt
+++ b/www-apps/cgit/files/postinstall-en.txt
@@ -29,9 +29,9 @@ rewrite rules to your
 <snip>
         RewriteEngine On
         # Redirect all non-existant urls to cgit
-        RewriteCond %{REQUEST_FILENAME} !-f
-        RewriteCond %{REQUEST_FILENAME} !-d
-        RewriteRule ^.* /cgi-bin/cgit.cgi/$0 [L,PT]
+        RewriteCond %%{REQUEST_FILENAME} !-f
+        RewriteCond %%{REQUEST_FILENAME} !-d
+        RewriteRule ^.* /cgi-bin/cgit.cgi/\$0 [L,PT]
 
         # Redirect the empty url to cgit
         RewriteRule ^$ /cgi-bin/cgit.cgi/ [L,PT]


### PR DESCRIPTION
The postinst message file for www-apps/cgit uses special characters without escaping them, what causes that some parts are missing when displayed by emerge.

Details in https://bugs.gentoo.org/700402