### PR TITLE
media-libs/mesa: Replace meson enabled with true

### DIFF
--- a/media-libs/mesa/mesa-20.2.0_rc4.ebuild
+++ b/media-libs/mesa/mesa-20.2.0_rc4.ebuild
@@ -496,7 +496,7 @@ multilib_src_configure() {
 	emesonargs+=(
 		$(meson_use test build-tests)
 		-Dglx=$(usex X dri disabled)
-		-Dshared-glapi=enabled
+		-Dshared-glapi=true
 		$(meson_feature dri3)
 		$(meson_feature egl)
 		$(meson_feature gbm)

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -490,8 +490,8 @@ multilib_src_configure() {
 	emesonargs+=(
 		$(meson_use test build-tests)
 		-Dglx=$(usex X dri disabled)
-		-Dglvnd=enabled
-		-Dshared-glapi=enabled
+		-Dglvnd=true
+		-Dshared-glapi=true
 		$(meson_feature dri3)
 		$(meson_feature egl)
 		$(meson_feature gbm)


### PR DESCRIPTION
The meson build system no longer accepts enabled, use true instead

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>