### PR TITLE
app-backup/btrbk: add USE=+lsbtr

### DIFF
--- a/app-backup/btrbk/btrbk-0.30.0.ebuild
+++ b/app-backup/btrbk/btrbk-0.30.0.ebuild
@@ -18,7 +18,7 @@ DESCRIPTION="Tool for creating snapshots and remote backups of btrfs subvolumes"
 HOMEPAGE="https://digint.ch/btrbk/"
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="+mbuffer +doc"
+IUSE="+mbuffer +doc +lsbtr"
 
 DEPEND="doc? ( >=dev-ruby/asciidoctor-1.5.7 )"
 
@@ -34,6 +34,7 @@ src_compile() {
 src_install() {
 	local targets="install-bin install-etc install-share install-systemd"
 	use doc && targets="${targets} install-man install-doc"
+	use lsbtr && targets="${targets} install-bin-links"
 	emake \
 		DESTDIR="${D}" \
 		DOCDIR="/usr/share/doc/${PF}" \

--- a/app-backup/btrbk/btrbk-9999.ebuild
+++ b/app-backup/btrbk/btrbk-9999.ebuild
@@ -18,7 +18,7 @@ DESCRIPTION="Tool for creating snapshots and remote backups of btrfs subvolumes"
 HOMEPAGE="https://digint.ch/btrbk/"
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="+mbuffer +doc"
+IUSE="+mbuffer +doc +lsbtr"
 
 DEPEND="doc? ( >=dev-ruby/asciidoctor-1.5.7 )"
 
@@ -34,6 +34,7 @@ src_compile() {
 src_install() {
 	local targets="install-bin install-etc install-share install-systemd"
 	use doc && targets="${targets} install-man install-doc"
+	use lsbtr && targets="${targets} install-bin-links"
 	emake \
 		DESTDIR="${D}" \
 		DOCDIR="/usr/share/doc/${PF}" \

--- a/app-backup/btrbk/metadata.xml
+++ b/app-backup/btrbk/metadata.xml
@@ -22,5 +22,6 @@
     <use>
         <flag name="pv">Use sys-apps/pv to enable progress bar functionality</flag>
         <flag name="mbuffer">Use sys-block/mbuffer to enable progress bar and buffering/limiting functionality</flag>
+        <flag name="lsbtr">Enable the lsbtr command-line tool</flag>
     </use>
 </pkgmetadata>


### PR DESCRIPTION
Add `lsbtr` use flag: enables the `lsbtr` command-line tool, useful
for listing btrfs subvolumes and their mount points.

Signed-off-by: Axel Burri <axel@tty0.ch>