### PR TITLE
media-video/vidcutter Fix dependencies and QA issues

### DIFF
--- a/media-video/vidcutter/vidcutter-6.0.0-r2.ebuild
+++ b/media-video/vidcutter/vidcutter-6.0.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit distutils-r1
+inherit distutils-r1 xdg
 
 DESCRIPTION="FFmpeg-based simple video cutter & joiner with a modern PyQt5 GUI"
 HOMEPAGE="http://vidcutter.ozmartians.com https://github.com/ozmartian/vidcutter"
@@ -29,12 +29,8 @@ DEPEND="
 RDEPEND="${DEPEND}
 	>=dev-python/PyQt5-5.7[dbus,multimedia,${PYTHON_USEDEP}]
 	media-video/ffmpeg[X,encode]
+	dev-python/pyopengl
 	media-video/mediainfo"
 BDEPEND="
 	${PYTHON_DEPS}
 	dev-python/setuptools[${PYTHON_USEDEP}]"
-
-src_install() {
-	distutils-r1_src_install
-	mv "${ED}/usr/share/doc/${PN}" "${ED}/usr/share/doc/${P}"
-}

--- a/media-video/vidcutter/vidcutter-9999.ebuild
+++ b/media-video/vidcutter/vidcutter-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit distutils-r1
+inherit distutils-r1 xdg
 
 DESCRIPTION="FFmpeg-based simple video cutter & joiner with a modern PyQt5 GUI"
 HOMEPAGE="http://vidcutter.ozmartians.com https://github.com/ozmartian/vidcutter"
@@ -29,12 +29,8 @@ DEPEND="
 RDEPEND="${DEPEND}
 	>=dev-python/PyQt5-5.7[dbus,multimedia,${PYTHON_USEDEP}]
 	media-video/ffmpeg[X,encode]
+	dev-python/pyopengl
 	media-video/mediainfo"
 BDEPEND="
 	${PYTHON_DEPS}
 	dev-python/setuptools[${PYTHON_USEDEP}]"
-
-src_install() {
-	distutils-r1_src_install
-	mv "${ED}/usr/share/doc/${PN}" "${ED}/usr/share/doc/${P}"
-}


### PR DESCRIPTION
* ~~Changed dependency on stale virtual (#744787)~~
* Added missing dependency dev-python/pyopengl (#723378)
* Remove irrelevant doc files installed manually triggering QA warnings.
* Trigger update-mime-database after installing new MIME handlers.

Closes: https://bugs.gentoo.org/723378