### PR TITLE
profiles: deprecate virtual/ffmpeg in favour of only provider

### DIFF
--- a/profiles/package.deprecated
+++ b/profiles/package.deprecated
@@ -17,6 +17,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Jesus P Rey <gentoo@chuso.net> (2020-09-26)
+# Only one provider left; media-video/ffmpeg should be used instead
+# Bug #744787
+virtual/ffmpeg
+
 # Thomas Deutschmann <whissi@gentoo.org> (2020-09-08)
 # Dead implementations, please migrate to >=zeromq-4
 dev-perl/ZMQ-LibZMQ2


### PR DESCRIPTION
See https://bugs.gentoo.org/744787

Another PR is pending to fix the only package still pulling virtual/ffmpeg in `::gentoo`: https://github.com/gentoo/gentoo/pull/17677

This PR adds `virtual/ffmpeg` to `package.deprecated` as adviced in #gentoo-dev-help to trigger a warning if overlays are still using it.