### PR TITLE
app-arch/zstd: fix compile with uclibc

### DIFF
--- a/app-arch/zstd/files/zstd-1.4.5-fix-uclibc-ng.patch
+++ b/app-arch/zstd/files/zstd-1.4.5-fix-uclibc-ng.patch
@@ -1,0 +1,28 @@
+From 1dcc4787965aa8f4af48ed5a2154185750bbaff5 Mon Sep 17 00:00:00 2001
+From: Yann Collet <cyan@fb.com>
+Date: Mon, 13 Jul 2020 14:16:33 -0700
+Subject: [PATCH] fix uclibc's st_mtim
+
+reported and suggested by @ewildgoose (#1872)
+---
+ programs/platform.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/programs/platform.h b/programs/platform.h
+index 2b4b9f2d8..68be70bb3 100644
+--- a/programs/platform.h
++++ b/programs/platform.h
+@@ -102,6 +102,12 @@ extern "C" {
+ #      define PLATFORM_POSIX_VERSION 1
+ #    endif
+ 
++#    ifdef __UCLIBC__
++#     ifndef __USE_MISC
++#      define __USE_MISC /* enable st_mtim on uclibc */
++#     endif
++#    endif
++
+ #  else  /* non-unix target platform (like Windows) */
+ #    define PLATFORM_POSIX_VERSION 0
+ #  endif
+

--- a/app-arch/zstd/zstd-1.4.4-r4.ebuild
+++ b/app-arch/zstd/zstd-1.4.4-r4.ebuild
@@ -21,6 +21,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${FILESDIR}/${P}-pkgconfig_libdir.patch" #700780
 	"${FILESDIR}/${P}-make43.patch" #708110
+	"${FILESDIR}/${PN}-1.4.5-fix-uclibc-ng.patch" #741972
 )
 
 src_prepare() {

--- a/app-arch/zstd/zstd-1.4.5.ebuild
+++ b/app-arch/zstd/zstd-1.4.5.ebuild
@@ -18,6 +18,10 @@ RDEPEND="app-arch/xz-utils
 	lz4? ( app-arch/lz4 )"
 DEPEND="${RDEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${P}-fix-uclibc-ng.patch" #741972
+	)
+
 src_prepare() {
 	default
 	multilib_copy_sources


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/741972

@Polynomial-C you've been the last to commit to zstd, so can you please forward this to the maintainer? He has no github account, and this is rather important since it blocks new stage3 with uclibc-ng, as portage has zstd now in RDEP

thanks 