### PR TITLE
Revbump remaining py2+3 packages with a pure py3 version

### DIFF
--- a/dev-python/certifi/certifi-10001-r1.ebuild
+++ b/dev-python/certifi/certifi-10001-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=no
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
+
+inherit distutils-r1
+
+MY_P=certifi-shim-${PV}
+DESCRIPTION="Thin replacement for certifi using system certificate store"
+HOMEPAGE="
+	https://github.com/mgorny/certifi-shim
+	https://pypi.org/project/certifi"
+SRC_URI="
+	https://github.com/mgorny/certifi-shim/archive/v${PV}.tar.gz
+		-> ${MY_P}.tar.gz"
+S=${WORKDIR}/${MY_P}
+
+LICENSE="CC0-1.0"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="app-misc/ca-certificates"
+
+distutils_enable_tests unittest
+
+src_prepare() {
+	sed -i -e "s^/etc^${EPREFIX}/etc^" certifi/core.py || die
+	distutils-r1_src_prepare
+}

--- a/dev-python/cython/cython-0.29.21-r1.ebuild
+++ b/dev-python/cython/cython-0.29.21-r1.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1 toolchain-funcs elisp-common
+
+DESCRIPTION="A Python to C compiler"
+HOMEPAGE="https://cython.org https://pypi.org/project/Cython/
+	https://github.com/cython/cython"
+SRC_URI="https://github.com/cython/cython/archive/${PV}.tar.gz -> ${P}.gh.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+IUSE="emacs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+BDEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	test? (
+		$(python_gen_cond_dep 'dev-python/numpy[${PYTHON_USEDEP}]' \
+			'python3*')
+	)"
+
+PATCHES=(
+	"${FILESDIR}/cython-0.29.14-sphinx-update.patch"
+)
+
+SITEFILE=50cython-gentoo.el
+
+distutils_enable_sphinx docs
+
+python_compile() {
+	# Python gets confused when it is in sys.path before build.
+	local -x PYTHONPATH=
+
+	distutils-r1_python_compile
+}
+
+python_compile_all() {
+	use emacs && elisp-compile Tools/cython-mode.el
+}
+
+python_test() {
+	tc-export CC
+	# https://github.com/cython/cython/issues/1911
+	local -x CFLAGS="${CFLAGS} -fno-strict-overflow"
+	"${PYTHON}" runtests.py -vv --work-dir "${BUILD_DIR}"/tests \
+		|| die "Tests fail with ${EPYTHON}"
+}
+
+python_install_all() {
+	local DOCS=( CHANGES.rst README.rst ToDo.txt USAGE.txt )
+	distutils-r1_python_install_all
+
+	if use emacs; then
+		elisp-install ${PN} Tools/cython-mode.*
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/dev-python/nose/nose-1.3.7-r7.ebuild
+++ b/dev-python/nose/nose-1.3.7-r7.ebuild
@@ -1,0 +1,86 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=rdepend
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1
+
+DESCRIPTION="Unittest extension with automatic test suite discovery and easy test authoring"
+HOMEPAGE="
+	https://pypi.org/project/nose/
+	https://nose.readthedocs.io/en/latest/
+	https://github.com/nose-devs/nose"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="coverage examples test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	coverage? (
+		dev-python/coverage[${PYTHON_USEDEP}]
+	)"
+DEPEND="${RDEPEND}
+	test? (
+		dev-python/coverage[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep '
+			dev-python/twisted[${PYTHON_USEDEP}]
+		' 'python3*')
+	)"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-python-3.5-backport.patch
+
+	# Patch against master found in an upstream PR, backported:
+	# https://github.com/nose-devs/nose/pull/1004
+	"${FILESDIR}"/${P}-coverage-4.1-support.patch
+
+	"${FILESDIR}"/${P}-python-3.6-test.patch
+)
+
+python_prepare_all() {
+	# Tests need to be converted, and they don't respect BUILD_DIR.
+	use test && DISTUTILS_IN_SOURCE_BUILD=1
+
+	# Disable tests requiring network connection.
+	sed \
+		-e "s/test_resolve/_&/g" \
+		-e "s/test_raises_bad_return/_&/g" \
+		-e "s/test_raises_twisted_error/_&/g" \
+		-i unit_tests/test_twisted.py || die "sed failed"
+	# Disable versioning of nosetests script to avoid collision with
+	# versioning performed by the eclass.
+	sed -e "/'nosetests%s = nose:run_exit' % py_vers_tag,/d" \
+		-i setup.py || die "sed2 failed"
+
+	# fix manpage install path
+	sed -i -e 's:man/:share/&:' setup.py || die
+
+	distutils-r1_python_prepare_all
+}
+
+python_compile() {
+	local add_targets=()
+
+	if use test; then
+		add_targets+=( egg_info )
+		python_is_python3 && add_targets+=( build_tests )
+	fi
+
+	distutils-r1_python_compile "${add_targets[@]}"
+}
+
+python_test() {
+	"${EPYTHON}" selftest.py -v || die "Tests fail with ${EPYTHON}"
+}
+
+python_install_all() {
+	use examples && dodoc -r examples
+	distutils-r1_python_install_all
+}

--- a/dev-python/olefile/olefile-0.46-r1.ebuild
+++ b/dev-python/olefile/olefile-0.46-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="Python package to parse, read and write Microsoft OLE2 files"
+HOMEPAGE="https://www.decalage.info/olefile"
+SRC_URI="https://github.com/decalage2/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+
+distutils_enable_sphinx doc
+distutils_enable_tests unittest

--- a/dev-python/pygame_sdl2/pygame_sdl2-7.3.5-r2.ebuild
+++ b/dev-python/pygame_sdl2/pygame_sdl2-7.3.5-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python{3_6,3_7,3_8} )
+inherit distutils-r1
+
+PYSDL="${PN}-2.1.0"
+
+DESCRIPTION="Reimplementation of portions of the pygame API using SDL2"
+HOMEPAGE="https://github.com/renpy/pygame_sdl2"
+SRC_URI="https://www.renpy.org/dl/${PV}/${PYSDL}-for-renpy-${PV}.tar.gz"
+
+LICENSE="LGPL-2.1 ZLIB"
+SLOT="0"
+KEYWORDS="amd64 x86"
+IUSE=""
+
+BDEPEND="
+	dev-python/cython[${PYTHON_USEDEP}]"
+DEPEND="
+	dev-python/numpy[${PYTHON_USEDEP}]
+	media-libs/libpng:0=
+	media-libs/libsdl2:=[video]
+	media-libs/sdl2-image:=[png,jpeg]
+	>=media-libs/sdl2-mixer-2.0.2:=
+	media-libs/sdl2-ttf:=
+	virtual/jpeg:0"
+RDEPEND="${DEPEND}"
+
+S=${WORKDIR}/${PYSDL}-for-renpy-${PV}
+
+# PyGame distribution for this version has some pregenerated files;
+# we need to remove them
+python_prepare_all()
+{
+	rm -r gen{,3} || die
+	distutils-r1_python_prepare_all
+}

--- a/dev-python/pykerberos/pykerberos-1.3.0-r1.ebuild
+++ b/dev-python/pykerberos/pykerberos-1.3.0-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=rdepend
+PYTHON_COMPAT=( python3_{6..9} )
+inherit distutils-r1
+
+MY_P=PyKerberos-${PV}
+DESCRIPTION="A high-level Python wrapper for Kerberos/GSSAPI operations"
+HOMEPAGE="
+	https://trac.calendarserver.org/wiki/PyKerberos
+	https://github.com/apple/ccs-pykerberos/
+	https://pypi.org/project/kerberos/"
+SRC_URI="
+	https://github.com/apple/ccs-pykerberos/archive/${MY_P}.tar.gz"
+S=${WORKDIR}/ccs-pykerberos-${MY_P}
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64 ~arm arm64 ~hppa ~ppc64 x86"
+# test environment is non-trivial to set up, so just use docker
+# (see python_test below)
+# also for alpha/beta Python releases support:
+# https://github.com/apple/ccs-pykerberos/pull/83/commits/5f1130a1305b5f6e7d7d8b41067c4713f0c8950f
+RESTRICT="test"
+
+RDEPEND="app-crypt/mit-krb5"
+DEPEND="${RDEPEND}"
+
+python_test() {
+	set -- docker run \
+		-v "${PWD}:/app" \
+		-w /app \
+		-e PYENV=$("${EPYTHON}" -c 'import sys; print(sys.version.split()[0])') \
+		-e KERBEROS_USERNAME=administrator \
+		-e KERBEROS_PASSWORD=Password01 \
+		-e KERBEROS_REALM=example.com \
+		-e KERBEROS_PORT=80 \
+		ubuntu:16.04 \
+		/bin/bash .travis.sh
+	echo "${@}" >&2
+	"${@}" || die "Tests failed with ${EPYTHON}"
+}

--- a/dev-python/pymongo/pymongo-3.11.0-r1.ebuild
+++ b/dev-python/pymongo/pymongo-3.11.0-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} )
+inherit check-reqs distutils-r1
+
+DESCRIPTION="Python driver for MongoDB"
+HOMEPAGE="https://github.com/mongodb/mongo-python-driver https://pypi.org/project/pymongo/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64 ~arm64 ~hppa x86"
+IUSE="doc kerberos test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	kerberos? ( dev-python/pykerberos[${PYTHON_USEDEP}] )
+"
+BDEPEND="
+	test? (
+		>=dev-db/mongodb-2.6.0
+		dev-python/nose[${PYTHON_USEDEP}]
+	)
+"
+DISTUTILS_IN_SOURCE_BUILD=1
+
+distutils_enable_sphinx doc
+
+reqcheck() {
+	if use test; then
+		# During the tests, database size reaches 1.5G.
+		local CHECKREQS_DISK_BUILD=1536M
+
+		check-reqs_${1}
+	fi
+}
+
+pkg_pretend() {
+	reqcheck pkg_pretend
+}
+
+pkg_setup() {
+	reqcheck pkg_setup
+}
+
+src_prepare() {
+	# network-sandbox probably
+	rm test/test_srv_polling.py || die
+	sed -e 's:test_connection_timeout_ms_propagates_to_DNS_resolver:_&:' \
+		-i test/test_client.py || die
+	# relies on exact exception message
+	sed -e 's:abstract methods:abstract:' \
+		-i test/test_custom_types.py || die
+	distutils-r1_src_prepare
+}
+
+python_test() {
+	# Yes, we need TCP/IP for that...
+	local DB_IP=127.0.0.1
+	local DB_PORT=27000
+
+	export DB_IP DB_PORT
+
+	local dbpath=${TMPDIR}/mongo.db
+	local logpath=${TMPDIR}/mongod.log
+
+	# Now, the hard part: we need to find a free port for mongod.
+	# We're just trying to run it random port numbers and check the log
+	# for bind errors. It shall be noted that 'mongod --fork' does not
+	# return failure when it fails to bind.
+
+	mkdir -p "${dbpath}" || die
+	while true; do
+		ebegin "Trying to start mongod on port ${DB_PORT}"
+
+		LC_ALL=C \
+		mongod --dbpath "${dbpath}" --nojournal \
+			--bind_ip ${DB_IP} --port ${DB_PORT} \
+			--unixSocketPrefix "${TMPDIR}" \
+			--logpath "${logpath}" --fork \
+		&& sleep 2
+
+		# Now we need to check if the server actually started...
+		if [[ ${?} -eq 0 && -S "${TMPDIR}"/mongodb-${DB_PORT}.sock ]]; then
+			# yay!
+			eend 0
+			break
+		elif grep -q 'Address already in use' "${logpath}"; then
+			# ay, someone took our port!
+			eend 1
+			: $(( DB_PORT += 1 ))
+			continue
+		else
+			eend 1
+			eerror "Unable to start mongod for tests. See the server log:"
+			eerror "	${logpath}"
+			die "Unable to start mongod for tests."
+		fi
+	done
+
+	local failed
+	DB_PORT2=$(( DB_PORT + 1 )) DB_PORT3=$(( DB_PORT + 2 )) esetup.py test || failed=1
+
+	mongod --dbpath "${dbpath}" --shutdown || die
+
+	[[ ${failed} ]] && die "Tests fail with ${EPYTHON}"
+
+	rm -rf "${dbpath}" || die
+}

--- a/dev-python/pyyaml/pyyaml-5.3.1-r1.ebuild
+++ b/dev-python/pyyaml/pyyaml-5.3.1-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=no
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="YAML parser and emitter for Python"
+HOMEPAGE="https://pyyaml.org/wiki/PyYAML
+	https://pypi.org/project/PyYAML/
+	https://github.com/yaml/pyyaml"
+SRC_URI="https://github.com/yaml/pyyaml/archive/${PV}.tar.gz -> ${P}.gh.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~x64-solaris ~x86-solaris"
+IUSE="examples +libyaml"
+
+RDEPEND="libyaml? ( dev-libs/libyaml:= )"
+DEPEND="${RDEPEND}
+	libyaml? (
+		$(python_gen_cond_dep '
+			dev-python/cython[${PYTHON_USEDEP}]
+		' 'python*')
+	)"
+
+PATCHES=(
+	# bug #659348
+	"${FILESDIR}/pyyaml-5.1-cve-2017-18342.patch"
+)
+
+distutils_enable_tests setup.py
+
+python_configure_all() {
+	mydistutilsargs=( $(use_with libyaml) )
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}
+	fi
+}

--- a/net-wireless/soapyremote/soapyremote-0.5.0.ebuild
+++ b/net-wireless/soapyremote/soapyremote-0.5.0.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_6 )
-
 inherit cmake-utils
 
 DESCRIPTION="Soapy SDR remote module"

--- a/net-wireless/soapyremote/soapyremote-9999.ebuild
+++ b/net-wireless/soapyremote/soapyremote-9999.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_6 )
-
 inherit cmake-utils
 
 DESCRIPTION="Soapy SDR remote module"


### PR DESCRIPTION
CC @gentoo/python ; this seems to be friendlier alternative to changing PYTHON_TARGETS.