### PR TITLE
dev-lang/pipenv: update RDEPEND.

### DIFF
--- a/dev-python/pipenv/pipenv-2020.6.2-r1.ebuild
+++ b/dev-python/pipenv/pipenv-2020.6.2-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=rdepend
+PYTHON_COMPAT=( python3_{6,7,8} )
+
+inherit distutils-r1
+
+MY_PV=${PV/_beta/b}
+DESCRIPTION="Python Development Workflow for Humans"
+HOMEPAGE="https://github.com/pypa/pipenv https://pypi.org/project/pipenv/"
+SRC_URI="https://github.com/pypa/pipenv/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}"/${PN}-${MY_PV}
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	dev-python/certifi[${PYTHON_USEDEP}]
+	>=dev-python/pip-18.0[${PYTHON_USEDEP}]
+	dev-python/virtualenv[${PYTHON_USEDEP}]
+	>=dev-python/virtualenv-clone-0.2.5[${PYTHON_USEDEP}]
+	dev-python/six
+	dev-python/appdirs
+	"
+
+BDEPEND="
+	test? (
+		${RDEPEND}
+		dev-python/flaky[${PYTHON_USEDEP}]
+		dev-python/mock[${PYTHON_USEDEP}]
+		<dev-python/pytest-5[${PYTHON_USEDEP}]
+		dev-python/pytest-timeout[${PYTHON_USEDEP}]
+		dev-python/pytest-xdist[${PYTHON_USEDEP}]
+		dev-python/pytz[${PYTHON_USEDEP}]
+	)"
+
+src_prepare() {
+	# remove vendored version of PyYAML that is backported to Python2
+	# this should be removed when upstream removes support for Python2
+	rm -vR "${S}/${PN}/patched/yaml2/" || die
+	distutils-r1_src_prepare
+}
+
+python_test() {
+	pytest -m "not cli and not needs_internet" -vv tests/unit || die
+}

--- a/dev-python/pipenv/pipenv-2020.6.2-r1.ebuild
+++ b/dev-python/pipenv/pipenv-2020.6.2-r1.ebuild
@@ -25,8 +25,8 @@ RDEPEND="
 	>=dev-python/pip-18.0[${PYTHON_USEDEP}]
 	dev-python/virtualenv[${PYTHON_USEDEP}]
 	>=dev-python/virtualenv-clone-0.2.5[${PYTHON_USEDEP}]
-	dev-python/six
-	dev-python/appdirs
+	dev-python/six[${PYTHON_USEDEP}]
+	dev-python/appdirs[${PYTHON_USEDEP}]
 	"
 
 BDEPEND="


### PR DESCRIPTION
pipenv requires the packages six and appdirs, added these to the ebuild.

Signed-off-by: Dave Wiltshire <davew@mykolab.com>