### PR TITLE
dev-util/mingw64-runtime: Work with multilib gcc

### DIFF
--- a/dev-util/mingw64-runtime/metadata.xml
+++ b/dev-util/mingw64-runtime/metadata.xml
@@ -10,6 +10,7 @@
     <flag name="libraries">Build extra libraries: mangle, pseh, winpthreads.</flag>
     <flag name="secure-api">Expose secure API (*_s function) by default.</flag>
     <flag name="tools">Build extra tools: gendef, genidl.</flag>
+    <flag name="multilib">Also compile 32-bit libraries when building for 64-bit CPU.</flag>
   </use>
   <upstream>
     <remote-id type="sourceforge">mingw-w64</remote-id>

--- a/dev-util/mingw64-runtime/mingw64-runtime-7.0.0-r2.ebuild
+++ b/dev-util/mingw64-runtime/mingw64-runtime-7.0.0-r2.ebuild
@@ -1,0 +1,124 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+export CBUILD=${CBUILD:-${CHOST}}
+export CTARGET=${CTARGET:-${CHOST}}
+if [[ ${CTARGET} == ${CHOST} ]] ; then
+	if [[ ${CATEGORY} == cross-* ]] ; then
+		export CTARGET=${CATEGORY#cross-}
+	fi
+fi
+
+inherit autotools flag-o-matic eutils toolchain-funcs
+
+DESCRIPTION="Free Win64 runtime and import library definitions"
+HOMEPAGE="http://mingw-w64.sourceforge.net/"
+SRC_URI="mirror://sourceforge/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v${PV}.tar.bz2"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+# USE=libraries needs working stage2 compiler: bug #665512
+IUSE="headers-only idl libraries tools multilib"
+RESTRICT="strip"
+
+S="${WORKDIR}/mingw-w64-v${PV}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fortify-only-ssp.patch
+)
+
+is_crosscompile() {
+	[[ ${CHOST} != ${CTARGET} ]]
+}
+just_headers() {
+	use headers-only
+}
+alt_prefix() {
+	is_crosscompile && echo /usr/${CTARGET}
+}
+crt_with() {
+	just_headers && echo --without-$1 || echo --with-$1
+}
+crt_use_enable() {
+	just_headers && echo --without-$2 || use_enable "$@"
+}
+crt_use_with() {
+	just_headers && echo --without-$2 || use_with "$@"
+}
+
+pkg_setup() {
+	if [[ ${CBUILD} == ${CHOST} ]] && [[ ${CHOST} == ${CTARGET} ]] ; then
+		die "Invalid configuration"
+	fi
+}
+
+src_configure() {
+	CHOST=${CTARGET} strip-unsupported-flags
+	# Normally mingw-64 does not use dynamic linker.
+	# But at configure time it uses $LDFLAGS.
+	# When default -Wl,--hash-style=gnu is passed
+	# __CTORS_LIST__ / __DTORS_LIST__ is mis-detected
+	# for target ld and binaries crash at shutdown.
+	filter-ldflags '-Wl,--hash-style=*'
+
+	if ! just_headers; then
+		mkdir "${WORKDIR}/headers"
+		pushd "${WORKDIR}/headers" > /dev/null
+		CHOST=${CTARGET} "${S}/configure" \
+			--prefix="${T}/tmproot" \
+			--with-headers \
+			--without-crt \
+			|| die
+		popd > /dev/null
+		append-cppflags "-I${T}/tmproot/include"
+	fi
+
+	# By default configure tries to set --sysroot=${prefix}. We disable
+	# this behaviour with --with-sysroot=no to use gcc's sysroot default.
+	# That way we can cross-build mingw64-runtime with cross-emerge.
+	local prefix="${EPREFIX}"$(alt_prefix)/usr
+	CHOST=${CTARGET} econf \
+		--with-sysroot=no \
+		--prefix="${prefix}" \
+		--libdir="${prefix}"/lib \
+		--with-headers \
+		--enable-sdk \
+		$(crt_with crt) \
+		$(crt_use_enable idl idl) \
+		$(crt_use_with libraries libraries) \
+		$(crt_use_with tools tools) \
+		$(
+			$(tc-getCPP ${CTARGET}) ${CPPFLAGS} -dM - < /dev/null | grep -q __MINGW64__ \
+				&& !use multilib \
+				&& echo --disable-lib32 \
+				|| echo --enable-lib32
+		) \
+		$(
+			$(tc-getCPP ${CTARGET}) ${CPPFLAGS} -dM - < /dev/null | grep -q __MINGW64__ \
+				&& echo --enable-lib64 \
+				|| echo --disable-lib64
+		)
+}
+
+src_compile() {
+	if ! just_headers; then
+		emake -C "${WORKDIR}/headers" install
+	fi
+	default
+}
+
+src_install() {
+	default
+
+	if is_crosscompile ; then
+		# gcc is configured to look at specific hard-coded paths for mingw #419601
+		dosym usr /usr/${CTARGET}/mingw
+		dosym usr /usr/${CTARGET}/${CTARGET}
+		dosym usr/include /usr/${CTARGET}/sys-include
+	fi
+
+	rm -rf "${ED}/usr/share"
+}


### PR DESCRIPTION
Package-Manager: Portage-3.0.4, Repoman-3.0.1

This adds a `multilib` USE option to mingw64-runtime, which adds `--enable-lib32` to the configure options when compiling for x86_64-w64-mingw32, which is needed for `x86_64-w64-mingw32-gcc -m32` to work (and thus make i686-w64-mingw32 pretty much redundant).

Without this, cross-x86_64-w64-mingw32/gcc will fail to compile when it has the `multilib` USE flag set - there should probably also be something in crossdev or something, to make sure it's not set for one package and not the other.