### PR TITLE
games-fps/freedoom-data: Add PYTHON_COMPAT=python3_8

### DIFF
--- a/games-fps/freedm-data/freedm-data-0.12.1.ebuild
+++ b/games-fps/freedm-data/freedm-data-0.12.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{7,8} )
 
 inherit prefix python-any-r1 xdg
 

--- a/games-fps/freedoom-data/freedoom-data-0.12.1.ebuild
+++ b/games-fps/freedoom-data/freedoom-data-0.12.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{7,8} )
 
 inherit prefix python-any-r1 xdg
 


### PR DESCRIPTION
Add PYTHON_COMPAT=python3_8 for both games-fps/freedoom-data and games-fps/freedm-data

Closes: https://bugs.gentoo.org/745738