### PR TITLE
dev-libs/libucl: remove failing tests

### DIFF
--- a/dev-libs/libucl/libucl-0.8.1-r1.ebuild
+++ b/dev-libs/libucl/libucl-0.8.1-r1.ebuild
@@ -35,6 +35,8 @@ DOCS=( README.md doc/api.md )
 
 src_prepare() {
 	default
+	rm tests/schema/{definitions,ref{,Remote}}.json || die
+
 	eautoreconf
 }
 

--- a/dev-libs/libucl/libucl-9999.ebuild
+++ b/dev-libs/libucl/libucl-9999.ebuild
@@ -35,6 +35,8 @@ DOCS=( README.md doc/api.md )
 
 src_prepare() {
 	default
+	rm tests/schema/{definitions,ref{,Remote}}.json || die
+
 	eautoreconf
 }
 


### PR DESCRIPTION
no version bump as these tests were
remote calls and removal has no effect on anything

Closes: https://bugs.gentoo.org/732090

Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>