### PR TITLE
dev-qt/qtwebengine: add use default for libvpx dependency

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.14.2.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.14.2.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 	media-libs/lcms:2
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:0=
-	>=media-libs/libvpx-1.5:=[svc]
+	>=media-libs/libvpx-1.5:=[svc(+)]
 	media-libs/libwebp:=
 	media-libs/mesa[egl,X(+)]
 	media-libs/opus

--- a/dev-qt/qtwebengine/qtwebengine-5.15.1.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.1.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	media-libs/lcms:2
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:0=
-	>=media-libs/libvpx-1.5:=[svc]
+	>=media-libs/libvpx-1.5:=[svc(+)]
 	media-libs/libwebp:=
 	media-libs/mesa[egl,X(+)]
 	media-libs/opus


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/678730
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Stephan Hartmann <sultan@gentoo.org>