### PR TITLE
sys-fs/encfs: fix fuse slot, eapi 7, cmake-utils -> cmake

### DIFF
--- a/sys-fs/encfs/encfs-1.9.5-r1.ebuild
+++ b/sys-fs/encfs/encfs-1.9.5-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit cmake
+
+DESCRIPTION="An implementation of encrypted filesystem in user-space using FUSE"
+HOMEPAGE="https://vgough.github.io/encfs/"
+SRC_URI="https://github.com/vgough/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3 LGPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~sparc ~x86"
+IUSE="libressl nls"
+
+RDEPEND="
+	!libressl? ( dev-libs/openssl:0= )
+	libressl? ( dev-libs/libressl:0= )
+	dev-libs/tinyxml2:0=
+	sys-fs/fuse:0=
+	sys-libs/zlib"
+DEPEND="
+	${RDEPEND}
+	dev-lang/perl
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+# Build dir is hardcoded in test suite, but we restrict them
+# because they can lead to false negatives, bug #630486
+RESTRICT="test"
+BUILD_DIR="${S}/build"
+
+src_configure() {
+	local mycmakeargs=(
+		-DENABLE_NLS="$(usex nls)"
+		-DUSE_INTERNAL_TINYXML=OFF
+		-DBUILD_UNIT_TESTS=OFF
+		-DBUILD_SHARED_LIBS=OFF
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
encfs is not compatible with fuse-3.x, so we need to specify a slot
with which it is compatible. Also bumped to EAPI 7 while I was
touching it, and migrated from deprecated cmake-utils.eclass
to cmake.eclass.

Also, recent cmake-utils / cmake eclasses turn on shared libs, but
encfs' build system does the wrong thing for libencfs.so, so turn
that knob back off.

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/701698
Package-Manager: Portage-3.0.8, Repoman-3.0.1