### PR TITLE
virtual/udev: Remove USE=systemd

### DIFF
--- a/virtual/udev/udev-217-r1.ebuild
+++ b/virtual/udev/udev-217-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual to select between different udev daemon providers"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="systemd"
+
+RDEPEND="
+	|| (
+		>=sys-fs/eudev-2.1.1
+		>=sys-fs/udev-217
+		>=sys-apps/systemd-217
+	)
+"


### PR DESCRIPTION
The 'systemd' USE flag has been introduced in 2014 to workaround an old
bug in Portage.  Over 6 years later, even if somebody still used Portage
this old, it will not be able to upgrade because of new EAPI.  Let's
remove it and let people use whichever udev provider they like,
including genuine systemd-udevd on top of OpenRC.

Signed-off-by: Michał Górny <mgorny@gentoo.org>