### PR TITLE
net-libs/libtorrent-rasterbar: python3_9

### DIFF
--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.10.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE="threads(+)"
 DISTUTILS_OPTIONAL=true
 DISTUTILS_IN_SOURCE_BUILD=true

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.9.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-1.2.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE="threads(+)"
 DISTUTILS_OPTIONAL=true
 DISTUTILS_IN_SOURCE_BUILD=true


### PR DESCRIPTION
tests are fine for 1.2.9 and 1.2.10
excluding 1.2.6 (where test phase seems to run forever)
Bug: https://bugs.gentoo.org/712138

Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>