### PR TITLE
net-libs/nodejs: python3_9

### DIFF
--- a/net-libs/nodejs/nodejs-14.11.0.ebuild
+++ b/net-libs/nodejs/nodejs-14.11.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 PYTHON_REQ_USE="threads(+)"
 inherit bash-completion-r1 flag-o-matic pax-utils python-any-r1 toolchain-funcs xdg-utils
 

--- a/net-libs/nodejs/nodejs-14.12.0.ebuild
+++ b/net-libs/nodejs/nodejs-14.12.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 PYTHON_REQ_USE="threads(+)"
 inherit bash-completion-r1 flag-o-matic pax-utils python-any-r1 toolchain-funcs xdg-utils
 

--- a/net-libs/nodejs/nodejs-14.13.0-r1.ebuild
+++ b/net-libs/nodejs/nodejs-14.13.0-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 PYTHON_REQ_USE="threads(+)"
 inherit bash-completion-r1 flag-o-matic pax-utils python-any-r1 toolchain-funcs xdg-utils
 

--- a/net-libs/nodejs/nodejs-14.13.1.ebuild
+++ b/net-libs/nodejs/nodejs-14.13.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 PYTHON_REQ_USE="threads(+)"
 inherit bash-completion-r1 flag-o-matic pax-utils python-any-r1 toolchain-funcs xdg-utils
 


### PR DESCRIPTION
modified:   nodejs-14.11.0.ebuild
modified:   nodejs-14.12.0.ebuild
Version 14.13.0-r1 is too broken, so not touching

Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>