### PR TITLE
media-libs/mesa: python3_9

### DIFF
--- a/media-libs/mesa/mesa-20.2.0.ebuild
+++ b/media-libs/mesa/mesa-20.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
 inherit llvm meson multilib-minimal python-any-r1 linux-info
 

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
 inherit llvm meson multilib-minimal python-any-r1 linux-info
 


### PR DESCRIPTION
omitting version 20.1.9 (too broken)

Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>