### PR TITLE
app-emulation/libvirt: apparmor meson fixes

### DIFF
--- a/app-emulation/libvirt/files/libvirt-6.7.0-fix-paths-for-apparmor.patch
+++ b/app-emulation/libvirt/files/libvirt-6.7.0-fix-paths-for-apparmor.patch
@@ -10,10 +10,31 @@ index 80986ae..d550d8c 100644
  
    # pki for libvirt-vnc and libvirt-spice (LP: #901272, #1690140)
    /etc/pki/CA/ r,
-diff --git a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in b/src/security/apparmor/usr.libexec.virt-aa-helper.in
+
+--- a/src/security/apparmor/meson.build	2020-10-06 17:45:18.590000000 +0100
++++ b/src/security/apparmor/meson.build	2020-10-06 17:45:07.044000000 +0100
+@@ -1,5 +1,5 @@
+ apparmor_gen_profiles = [
+-  'usr.lib.libvirt.virt-aa-helper',
++  'usr.libexec.libvirt.virt-aa-helper',
+   'usr.sbin.libvirtd',
+ ]
+ 
+@@ -32,7 +32,7 @@ install_data(
+ )
+ 
+ install_data(
+-  'usr.lib.libvirt.virt-aa-helper.local',
++  'usr.libexec.libvirt.virt-aa-helper.local',
+   install_dir: apparmor_dir / 'local',
+-  rename: 'usr.lib.libvirt.virt-aa-helper',
++  rename: 'usr.libexec.libvirt.virt-aa-helper',
+ )
+
+diff --git a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.in
 similarity index 97%
 rename from src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in
-rename to src/security/apparmor/usr.libexec.virt-aa-helper.in
+rename to src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.in
 index dd18c8a..d06f9cb 100644
 --- a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in
 +++ b/src/security/apparmor/usr.libexec.virt-aa-helper.in
@@ -22,5 +43,9 @@ index dd18c8a..d06f9cb 100644
    /**/disk{,.*} r,
  
 -  #include <local/usr.lib.libvirt.virt-aa-helper>
-+  #include <local/usr.libexec.virt-aa-helper>
++  #include <local/usr.libexec.libvirt.virt-aa-helper>
  }
+diff --git a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local
+similarity index 100%
+rename from src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local
+rename to src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local


### PR DESCRIPTION
* File renames are handled by meson.build.
* Restored libvirt in front of virt-aa-helper.in.
* Renamed local helper to also be under libexec.

Closes: https://bugs.gentoo.org/746182