### PR TITLE
dev-python/croniter: add python3_{8,9} support

### DIFF
--- a/dev-python/croniter/croniter-0.3.30.ebuild
+++ b/dev-python/croniter/croniter-0.3.30.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7} )
+
+PYTHON_COMPAT=( python3_{6..9} )
 
 inherit distutils-r1
 
@@ -16,7 +17,7 @@ KEYWORDS="amd64 ~arm64 x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
-DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
+BDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
 	test? (
 		dev-python/pytest[${PYTHON_USEDEP}]
 		dev-python/pytz[${PYTHON_USEDEP}]


### PR DESCRIPTION
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>