### PR TITLE
profiles/arch/arm64/use.mask: unmask pypy3 targets

### DIFF
--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -4,6 +4,11 @@
 # Unmask the flag which corresponds to ARCH.
 -arm64
 
+# Sam James <sam@gentoo.org> (2020-10-08)
+# PyPy3 works on arm64
+-python_targets_pypy3
+-python_single_target_pypy3
+
 # David Seifert <soap@gentoo.org (2020-05-17)
 # Mono is hopelessly broken on arm64
 mono

--- a/profiles/arch/arm64/use.stable.mask
+++ b/profiles/arch/arm64/use.stable.mask
@@ -4,6 +4,11 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
 
+# Sam James <sam@gentoo.org> (2020-10-08)
+# Not enough packages stable w/ PyPy3 support
+python_targets_pypy3
+python_single_target_pypy3
+
 # Sam James <sam@gentoo.org> (2020-10-07)
 # app-misc/lirc not stable yet
 # dev-db/tokyocabinet not stable yet


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>