### PR TITLE
sys-apps/util-linux-9999: Do not adjust permissions on non-existent files, upstream has changed

### DIFF
--- a/sys-apps/util-linux/util-linux-9999.ebuild
+++ b/sys-apps/util-linux/util-linux-9999.ebuild
@@ -277,7 +277,6 @@ multilib_src_install() {
 
 multilib_src_install_all() {
 	dodoc AUTHORS NEWS README* Documentation/{TODO,*.txt,releases/*}
-	chmod -x "${ED}"/usr/share/doc/util-linux-${PVR}/getopt/getopt-parse* || die
 
 	# e2fsprogs-libs didnt install .la files, and .pc work fine
 	find "${ED}" -name "*.la" -delete || die


### PR DESCRIPTION
Do not adjust permissions on non-existent files, upstream has migrated getopt-parse* to getopt-example* and the execute bit is no longer there, thus this line is not needed and the ebuild no longer completes with it, so removing

See https://bugs.gentoo.org/747289