### PR TITLE
sys-cluster/glusterfs: fix python byte compiles.

### DIFF
--- a/sys-cluster/glusterfs/glusterfs-7.8-r1.ebuild
+++ b/sys-cluster/glusterfs/glusterfs-7.8-r1.ebuild
@@ -175,6 +175,8 @@ src_install() {
 	if ! use static-libs; then
 		find "${D}" -type f -name '*.la' -delete || die
 	fi
+
+	python_optimize "${ED}"
 }
 
 src_test() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/747340
Signed-off-by: Jaco Kroon <jaco@uls.co.za>