### PR TITLE
app-misc/chkcrontab: add python3.9, adjust DISTUTILS_USE_SETUPTOOLS

### DIFF
--- a/app-misc/chkcrontab/chkcrontab-1.7-r1.ebuild
+++ b/app-misc/chkcrontab/chkcrontab-1.7-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} )
+DISTUTILS_USE_SETUPTOOLS=no
+
+inherit distutils-r1
+
+DESCRIPTION="A tool to detect crontab errors"
+HOMEPAGE="https://github.com/lyda/chkcrontab"
+SRC_URI="https://github.com/lyda/chkcrontab/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+distutils_enable_tests setup.py
+
+python_install_all() {
+	doman doc/${PN}.1
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
````
--- chkcrontab-1.7.ebuild       2020-06-11 07:00:55.114345349 +0000
+++ chkcrontab-1.7-r1.ebuild    2020-10-09 11:21:30.879582147 +0000
@@ -1,9 +1,10 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
+DISTUTILS_USE_SETUPTOOLS=no
 
 inherit distutils-r1
 
@@ -13,7 +14,7 @@
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
````