### PR TITLE
app-admin/ngxtop: add python3.9, adjust DISTUTILS_USE_SETUPTOOLS

### DIFF
--- a/app-admin/ngxtop/ngxtop-0.0.3_pre141201-r1.ebuild
+++ b/app-admin/ngxtop/ngxtop-0.0.3_pre141201-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_REQ_USE="sqlite"
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
+inherit distutils-r1
+
+DESCRIPTION="real-time metrics for nginx server (and others)"
+HOMEPAGE="https://github.com/lebinh/ngxtop"
+#SRC_URI="https://github.com/lebinh/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://dev.gentoo.org/~jlec/distfiles/${P}.tar.xz"
+
+SLOT="0"
+LICENSE="MIT"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE=""
+
+RDEPEND="
+	dev-python/docopt[${PYTHON_USEDEP}]
+	dev-python/pyparsing[${PYTHON_USEDEP}]
+	dev-python/tabulate[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}
+"
+
+PATCHES=( "${FILESDIR}"/${PN}-0.0.2-py3.patch )


### PR DESCRIPTION
````
--- ngxtop-0.0.3_pre141201.ebuild       2020-06-11 07:00:54.992344951 +0000
+++ ngxtop-0.0.3_pre141201-r1.ebuild    2020-10-09 11:48:10.323153248 +0000
@@ -1,10 +1,11 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 PYTHON_REQ_USE="sqlite"
+DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1
 ````