### PR TITLE
media-libs/mesa: python3_9 for mesa-20.1.9

### DIFF
--- a/media-libs/mesa/mesa-20.1.9.ebuild
+++ b/media-libs/mesa/mesa-20.1.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 
 inherit llvm meson multilib-minimal python-any-r1 linux-info
 
@@ -482,7 +482,7 @@ multilib_src_configure() {
 	emesonargs+=(
 		$(meson_use test build-tests)
 		-Dglx=$(usex X dri disabled)
-		-Dglvnd=enabled
+		-Dglvnd=true
 		-Dshared-glapi=true
 		$(meson_use dri3)
 		$(meson_use egl)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/747169
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>

42/84 mesa:compiler+glcpp / glcpp test (unix)       FAIL           0.94s (exit status 1)
43/84 mesa:compiler+glcpp / glcpp test (windows)    FAIL           0.99s (exit status 1)
44/84 mesa:compiler+glcpp / glcpp test (oldmac)     FAIL           0.97s (exit status 1)
45/84 mesa:compiler+glcpp / glcpp test (bizarro)    FAIL           1.06s (exit status 1)

84/84 mesa:st_mesa / st-array-merge-test            OK             0.04s

Ok:                 80  
Expected Fail:      0   
Fail:               4   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0