### PR TITLE
app-misc/todo: clean up aliases

### DIFF
--- a/app-misc/todo/todo-2.12.0-r1.ebuild
+++ b/app-misc/todo/todo-2.12.0-r1.ebuild
@@ -38,10 +38,7 @@ src_test() {
 
 src_install() {
 	dobin "${PN}.sh"
-	dosym "${PN}.sh" "/usr/bin/${PN}cli"
-	dosym "${PN}.sh" "/usr/bin/${PN}txt"
 	newbashcomp "${PN}_completion" "${PN}.sh"
-	bashcomp_alias "${PN}.sh" "${PN}cli" "${PN}txt"
 	einstalldocs
 }
 
@@ -63,4 +60,9 @@ pkg_postinst() {
 	einfo 'You can then edit this file as you see fit.'
 	einfo 'Enjoy!'
 	einfo
+	ewarn 'The Gentoo-specific todocli and todotxt aliases have been removed.'
+	ewarn 'If you still need them, add the following lines to your ~/.bashrc:'
+	ewarn
+	ewarn 'alias todocli=todo.sh'
+	ewarn 'complete -F _todo todocli'
 }


### PR DESCRIPTION
This PR is a follow-up for #17270 to clean up Gentoo-specific `todocli` and `todotxt` aliases.

The bash completion for them was already broken, and they should be easy to re-add as part of the user's configuration. There are also no known reports about any breakage.

With those in mind, and based on a quick discussion with @monsieurp via IRC, we decided to simplify the ebuild by offering the vanilla experience from upstream.

Please review and merge, or let me know how to further improve it.