### PR TITLE
Dev-python/python-language-server: allow newer ujson versions

### DIFF
--- a/dev-python/python-jsonrpc-server/files/python-jsonrpc-server-0.4.0-fix-test-with-ujson-3-and-up.patch
+++ b/dev-python/python-jsonrpc-server/files/python-jsonrpc-server-0.4.0-fix-test-with-ujson-3-and-up.patch
@@ -1,0 +1,12 @@
+diff --git a/test/test_streams.py b/test/test_streams.py
+index 6985aec..9e64489 100644
+--- a/test/test_streams.py
++++ b/test/test_streams.py
+@@ -119,6 +119,7 @@ def test_writer_bad_message(wfile, writer):
+         hour=1,
+         minute=1,
+         second=1,
++        tzinfo=datetime.timezone.utc
+     ))
+
+     assert wfile.getvalue() in [

--- a/dev-python/python-jsonrpc-server/python-jsonrpc-server-0.4.0-r1.ebuild
+++ b/dev-python/python-jsonrpc-server/python-jsonrpc-server-0.4.0-r1.ebuild
@@ -21,17 +21,15 @@ BDEPEND="dev-python/versioneer[${PYTHON_USEDEP}]
 		dev-python/pycodestyle[${PYTHON_USEDEP}]
 )"
 
-RDEPEND="~dev-python/ujson-1.35[${PYTHON_USEDEP}]"
+RDEPEND=">=dev-python/ujson-3[${PYTHON_USEDEP}]"
 
 distutils_enable_tests pytest
+
+PATCHES=( "${FILESDIR}/${PN}-0.4.0-fix-test-with-ujson-3-and-up.patch" )
 
 python_prepare_all() {
 	# Remove pytest-cov dep
 	sed -i -e '0,/addopts/I!d' setup.cfg || die
-
-	# jsonrpc-server does not actually work with ujson>3.0.0: tests fail
-	sed -i -e 's/ujson>=3.0.0/ujson==1.35/g' setup.py || die
-	sed -i -e 's/ujson>=3.0.0/ujson==1.35/g' python_jsonrpc_server.egg-info/requires.txt || die
 
 	distutils-r1_python_prepare_all
 }

--- a/dev-python/python-language-server/python-language-server-0.35.1-r1.ebuild
+++ b/dev-python/python-language-server/python-language-server-0.35.1-r1.ebuild
@@ -44,7 +44,7 @@ RDEPEND="
 	<dev-python/jedi-0.18.0[${PYTHON_USEDEP}]
 	dev-python/pluggy[${PYTHON_USEDEP}]
 	>=dev-python/python-jsonrpc-server-0.4.0[${PYTHON_USEDEP}]
-	~dev-python/ujson-1.35[${PYTHON_USEDEP}]
+	>=dev-python/ujson-3[${PYTHON_USEDEP}]
 "
 
 distutils_enable_tests pytest
@@ -52,10 +52,6 @@ distutils_enable_tests pytest
 python_prepare_all() {
 	# remove pytest-cov dep
 	sed -i -e '0,/addopts/I!d' setup.cfg || die
-
-	# jsonrpc-server does not actually work with ujson>3.0.0: test fail
-	sed -i -e 's/ujson>=3.0.0/ujson==1.35/g' setup.py || die
-	sed -i -e 's/ujson>=3.0.0/ujson==1.35/g' python_language_server.egg-info/requires.txt || die
 
 	distutils-r1_python_prepare_all
 }


### PR DESCRIPTION
This fixes a bug in pyls_jsonrpc preventing the use of ujson newer than 1.35 in pyls.