### PR TITLE
sci-libs/rtree-0.9.4: set DISTUTILS_USE_SETUPTOOLS

### DIFF
--- a/sci-libs/rtree/rtree-0.9.4.ebuild
+++ b/sci-libs/rtree/rtree-0.9.4.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..8} )
+DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/747817

Signed-off-by: Dennis Lamm <expeditoneer@gentoo.org>