### PR TITLE
www-apps/hugo: Fix remote-id

### DIFF
--- a/www-apps/hugo/metadata.xml
+++ b/www-apps/hugo/metadata.xml
@@ -6,7 +6,7 @@
 		<flag name="sass">Enable SASS/SCSS support</flag>
 	</use>
 	<upstream>
-	<remote-id type="github">https://github.com/gohugoio/hugo</remote-id>
+	<remote-id type="github">gohugoio/hugo</remote-id>
 	</upstream>
 	<longdescription lang="en">
 		Hugo is a static HTML and CSS website generator written in Go.


### PR DESCRIPTION
The current remote-id is malformed:

```xml
<remote-id type="github">https://github.com/gohugoio/hugo</remote-id>
```