### PR TITLE
games-engines/openmw: restrict double-precisionness of bullet

### DIFF
--- a/games-engines/openmw/files/openmw-0.47.0-mygui-license.patch
+++ b/games-engines/openmw/files/openmw-0.47.0-mygui-license.patch
@@ -4,13 +4,13 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index d69352c94..5f97c86e9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -470,9 +470,6 @@ IF(NOT WIN32 AND NOT APPLE)
-     #    INSTALL(PROGRAMS "${OpenMW_BINARY_DIR}/Plugin_MyGUI_OpenMW_Resources.so" DESTINATION "${LIBDIR}" )
-     #ENDIF(BUILD_MYGUI_PLUGIN)
+@@ -856,9 +856,6 @@ elseif(NOT APPLE)
+             INSTALL(PROGRAMS "${INSTALL_SOURCE}/openmw-wizard" DESTINATION "${BINDIR}" )
+         ENDIF(BUILD_WIZARD)
  
--    # Install licenses
--    INSTALL(FILES "files/mygui/DejaVuFontLicense.txt" DESTINATION "${LICDIR}" )
+-        # Install licenses
+-        INSTALL(FILES "files/mygui/DejaVuFontLicense.txt" DESTINATION "${LICDIR}" )
 -
-     # Install icon and desktop file
-     INSTALL(FILES "${OpenMW_BINARY_DIR}/org.openmw.launcher.desktop" DESTINATION "${DATAROOTDIR}/applications" COMPONENT "openmw")
-     INSTALL(FILES "${OpenMW_SOURCE_DIR}/files/launcher/images/openmw.png" DESTINATION "${ICONDIR}" COMPONENT "openmw")
+         # Install icon and desktop file
+         INSTALL(FILES "${OpenMW_BINARY_DIR}/org.openmw.launcher.desktop" DESTINATION "${DATAROOTDIR}/applications" COMPONENT "openmw")
+         INSTALL(FILES "${OpenMW_SOURCE_DIR}/files/launcher/images/openmw.png" DESTINATION "${ICONDIR}" COMPONENT "openmw")

--- a/games-engines/openmw/openmw-0.46.0.ebuild
+++ b/games-engines/openmw/openmw-0.46.0.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	media-libs/libsdl2[joystick,opengl,video]
 	media-libs/openal
 	media-video/ffmpeg:=
-	>=sci-physics/bullet-2.86:=
+	>=sci-physics/bullet-2.86:=[-double-precision]
 	virtual/opengl
 	osg-fork? ( dev-games/openscenegraph-openmw:=[ffmpeg,jpeg,png,sdl,svg,truetype,zlib] )
 	!osg-fork? ( >=dev-games/openscenegraph-3.5.5:=[ffmpeg,jpeg,png,sdl,svg,truetype,zlib] )

--- a/games-engines/openmw/openmw-9999.ebuild
+++ b/games-engines/openmw/openmw-9999.ebuild
@@ -33,7 +33,7 @@ RDEPEND="
 	media-libs/libsdl2[joystick,opengl,video]
 	media-libs/openal
 	media-video/ffmpeg:=
-	>=sci-physics/bullet-2.86:=
+	>=sci-physics/bullet-2.86:=[double-precision]
 	virtual/opengl
 	osg-fork? ( dev-games/openscenegraph-openmw:=[ffmpeg,jpeg,png,sdl,svg,truetype,zlib] )
 	!osg-fork? ( >=dev-games/openscenegraph-3.5.5:=[ffmpeg,jpeg,png,sdl,svg,truetype,zlib] )
@@ -96,6 +96,7 @@ src_configure() {
 		-DMORROWIND_DATA_FILES="${EPREFIX}/usr/share/morrowind-data"
 		-DUSE_SYSTEM_TINYXML=ON
 		-DDESIRED_QT_VERSION=5
+		-DBULLET_USE_DOUBLES=ON
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
For 0.46.0, require no double precision.
For 9999, require double precision instead.

Closes: https://bugs.gentoo.org/747898
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>