### PR TITLE
dev-libs/gumbo: EAPI 7

### DIFF
--- a/dev-libs/gumbo/gumbo-0.10.1-r1.ebuild
+++ b/dev-libs/gumbo/gumbo-0.10.1-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="The HTML5 parsing algorithm implemented as a pure C99 library"
+HOMEPAGE="https://github.com/google/gumbo-parser#readme"
+SRC_URI="https://github.com/google/gumbo-parser/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+IUSE="doc test"
+RESTRICT="!test? ( test )"
+
+S="${WORKDIR}/gumbo-parser-${PV}"
+
+BDEPEND="doc? ( app-doc/doxygen )
+	test? ( dev-cpp/gtest )"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	default
+	econf --disable-static
+}
+
+src_compile() {
+	default
+
+	if use doc; then
+		doxygen || die "doxygen failed"
+	fi
+}
+
+src_install() {
+	default
+
+	if use doc; then
+		docinto html
+		dodoc -r docs/html/.
+		for page in docs/man/man3/* ; do
+			doman ${page}
+		done
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/748393
Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>