### PR TITLE
app-cdr/iat: fix metadata

### DIFF
--- a/app-cdr/iat/metadata.xml
+++ b/app-cdr/iat/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>ramage.lucas@protonmail.com</email>
-		<description>Lucas Ramage</description>
+		<name>Lucas Ramage</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>proxy-maint@gentoo.org</email>


### PR DESCRIPTION
Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Lucas Ramage <ramage.lucas@protonmail.com>

Also, while I'm here, would it even make sense to bump EAPI to 7 or does it matter?