### PR TITLE
app-text/mupdf: use.mask libressl

### DIFF
--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -4,6 +4,11 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in package.use.mask
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2020-10-14)
+# Depends on >=dev-libs/libressl-3.2.0 which is not yet stable
+# bug #747151
+>=app-text/mupdf-1.18.0 libressl
+
 # Sam James <sam@gentoo.org> (2020-10-09)
 # Depends on dev-libs/boost[python,numpy], not fully working atm
 # bug #733830, bug #746740


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/747151
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>