### PR TITLE
dev-python/tikzplotlib: add missing use flag on dep

### DIFF
--- a/dev-python/tikzplotlib/tikzplotlib-0.9.4.ebuild
+++ b/dev-python/tikzplotlib/tikzplotlib-0.9.4.ebuild
@@ -16,10 +16,10 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
-	app-text/texlive
+	app-text/texlive[extra]
 	$( python_gen_cond_dep \
 		'dev-python/importlib_metadata[${PYTHON_USEDEP}]' python3_7 )
-	dev-python/matplotlib[${PYTHON_USEDEP}]
+	dev-python/matplotlib[latex,${PYTHON_USEDEP}]
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-python/pillow[${PYTHON_USEDEP}]
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/748723
Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>