### PR TITLE
sys-fs/zfs-kmod: 0.8.5: Marked compatiable with 5.9 kernels.

### DIFF
--- a/sys-fs/zfs-kmod/zfs-kmod-0.8.5.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-0.8.5.ebuild
@@ -15,7 +15,7 @@ else
 	SRC_URI="https://github.com/openzfs/zfs/releases/download/zfs-${PV}/zfs-${PV}.tar.gz"
 	KEYWORDS="~amd64 ~arm64 ~ppc64"
 	S="${WORKDIR}/zfs-${PV}"
-	ZFS_KERNEL_COMPAT="5.8"
+	ZFS_KERNEL_COMPAT="5.9"
 fi
 
 LICENSE="CDDL debug? ( GPL-2+ )"


### PR DESCRIPTION
This version of ZFS is compatible with 5.9 kernels. I installed this and rebuilt the module against it and it boots a rootfs.