### PR TITLE
net-p2p/mldoney: Fix BitTorrent dependency on dev-ml/num

### DIFF
--- a/net-p2p/mldonkey/mldonkey-3.1.7.ebuild
+++ b/net-p2p/mldonkey/mldonkey-3.1.7.ebuild
@@ -42,7 +42,7 @@ DEPEND="${RDEPEND}
 	<dev-lang/ocaml-4.10:=[ocamlopt?]
 	bittorrent? (
 		|| (
-			>=dev-lang/ocaml-4.06[ocamlopt?]
+			<dev-lang/ocaml-4.06[ocamlopt?]
 			dev-ml/num
 		)
 	)"


### PR DESCRIPTION
Versions older than 3.1.7 have these solvable bugs that were fixed in 3.1.7 ebuild:
* https://bugs.gentoo.org/704684
* https://bugs.gentoo.org/582136

But it also has these bugs that are upstream issues and cannot be fixed in older versions
* https://bugs.gentoo.org/615322
* https://bugs.gentoo.org/595798

Also, older versions don't build with `>=dev-lang/ocaml-4.06`
* https://bugs.gentoo.org/635932

Hence, this PR carries over stable keywords from 3.1.5 to 3.1.7 and removes broken versions older than 3.1.7.

Also, `pkgcheck` says `~arm`, `~hppa` and `~ppc64` are potential stabilization candidates. I don't know if that would also allow stabilizing those.