### PR TITLE
sci-libs/opencascade: fix check in cmake config

### DIFF
--- a/sci-libs/opencascade/opencascade-7.4.0-r3.ebuild
+++ b/sci-libs/opencascade/opencascade-7.4.0-r3.ebuild
@@ -84,6 +84,8 @@ pkg_setup() {
 src_prepare() {
 	cmake_src_prepare
 	use java && java-pkg-opt-2_src_prepare
+	sed -e 's/\/lib\$/\/'$(get_libdir)'\$/' \
+		-i adm/templates/OpenCASCADEConfig.cmake.in || die
 }
 
 src_configure() {


### PR DESCRIPTION
Fix a check for library path in the OpenCASCADEConfig.cmake
file.

Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Bernd Waibel <waebbl@gmail.com>