### PR TITLE
profiles/arch/arm64: allow ocamlopt in stable

### DIFF
--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -144,10 +144,6 @@ media-gfx/gnome-photos upnp-av
 # not yet keyworded
 dev-java/openjdk javafx
 
-# Aaron Bauman <bman@gentoo.org> (2019-05-20)
-# doc USE ultimately pulls in dev-lang/ocaml[ocamlopt]
-media-gfx/enblend doc
-
 # Aaron Bauman <bman@gentoo.org> (2019-04-08)
 # app-text/dblatex not keyword yet
 net-firewall/nftables doc

--- a/profiles/arch/arm64/package.use.stable.mask
+++ b/profiles/arch/arm64/package.use.stable.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2020-10-18)
+# Needs dev-tex/hevea which isn't stable yet
+media-gfx/enblend doc
+
 # Arfrever Frehtes Taifersar Arahesis <arfrever.fta@gmail.com> (2020-10-14)
 # app-i18n/fcitx:4 not stable.
 media-libs/libsdl2 fcitx4
@@ -63,10 +67,6 @@ sys-firmware/seabios debug
 <dev-libs/weston-9 pipewire
 <sys-apps/xdg-desktop-portal-1.7.2 screencast
 x11-wm/mutter screencast
-
-# Aaron Bauman (2019-07-29)
-# no ocamlopt stuff here...
-kde-apps/kalzium solver
 
 # Aaron Bauman (2019-07-29)
 # app-arch/rar not supported

--- a/profiles/arch/arm64/use.stable.mask
+++ b/profiles/arch/arm64/use.stable.mask
@@ -23,10 +23,6 @@ libtar
 ldns
 gps
 
-# Aaron Bauman <bman@gentoo.org> (2019-05-20)
-# Does not build on arm64
-ocamlopt
-
 # Mart Raudsepp <leio@gentoo.org> (2019-02-07)
 # media-sound/musepack-tools not stable yet
 musepack


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>