### PR TITLE
media-libs/opencv: various provisional fixes

### DIFF
--- a/media-libs/opencv/files/opencv-4.5.0-link-with-cblas-for-lapack.patch
+++ b/media-libs/opencv/files/opencv-4.5.0-link-with-cblas-for-lapack.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/OpenCVFindLAPACK.cmake b/cmake/OpenCVFindLAPACK.cmake
+index 342bebc..9ebd206 100644
+--- a/cmake/OpenCVFindLAPACK.cmake
++++ b/cmake/OpenCVFindLAPACK.cmake
+@@ -136,10 +136,12 @@ if(WITH_LAPACK)
+         ocv_lapack_check()
+       endif()
+       if(NOT HAVE_LAPACK)
+-        if(LAPACKE_INCLUDE_DIR)
++        find_package(CBLAS)
++        if(LAPACKE_INCLUDE_DIR AND CBLAS_FOUND)
+           set(LAPACK_INCLUDE_DIR  ${LAPACKE_INCLUDE_DIR})
+           set(LAPACK_CBLAS_H      "cblas.h")
+           set(LAPACK_LAPACKE_H    "lapacke.h")
++          set(LAPACK_LIBRARIES    ${LAPACK_LIBRARIES} ${CBLAS_LIBRARIES})
+           set(LAPACK_IMPL         "LAPACK/Generic")
+           ocv_lapack_check()
+         elseif(APPLE)

--- a/media-libs/opencv/opencv-4.5.0.ebuild
+++ b/media-libs/opencv/opencv-4.5.0.ebuild
@@ -70,6 +70,7 @@ REQUIRED_USE="
 	contribovis? ( contrib )
 	contribsfm? ( contrib eigen gflags glog )
 	contribxfeatures2d? ( contrib download )
+	examples? ( contribdnn )
 	java? ( python )
 	opengl? ( qt5 )
 	python? ( ${PYTHON_REQUIRED_USE} )
@@ -111,7 +112,11 @@ RDEPEND="
 	java? ( >=virtual/jre-1.6:* )
 	jpeg? ( virtual/jpeg:0[${MULTILIB_USEDEP}] )
 	jpeg2k? ( media-libs/openjpeg:2=[${MULTILIB_USEDEP}] )
-	lapack? ( virtual/lapack )
+	lapack? (
+		virtual/cblas
+		virtual/lapack
+		virtual/lapacke
+	)
 	opencl? ( virtual/opencl[${MULTILIB_USEDEP}] )
 	openexr? ( media-libs/openexr[${MULTILIB_USEDEP}] )
 	opengl? (
@@ -274,6 +279,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.4.1-cuda-add-relaxed-constexpr.patch
 	"${FILESDIR}"/${PN}-4.1.2-opencl-license.patch
 	"${FILESDIR}"/${PN}-4.4.0-disable-native-cpuflag-detect.patch
+	"${FILESDIR}"/${PN}-4.5.0-link-with-cblas-for-lapack.patch
 )
 
 pkg_pretend() {

--- a/virtual/lapacke/lapacke-3.8.ebuild
+++ b/virtual/lapacke/lapacke-3.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,6 +9,9 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~a
 IUSE="eselect-ldso"
 
 RDEPEND="
-	>=sci-libs/lapack-3.8.0[lapacke,eselect-ldso?]
+	|| (
+		>=sci-libs/lapack-3.8.0[lapacke,eselect-ldso?]
+		>=sci-libs/openblas-0.3.10[eselect-ldso?]
+	)
 "
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
 - Explicitly depends on virtual/lapacke to prevent its cmake build scripts from
  implicitly disabling lapack support when it can't find lapacke.h.

 - Links with cblas when sci-libs/lapack is supplimented as the default lapack
  implementation.

 - examples USE requires contribdnn USE to be enabled to prevent build failure.

Closes: https://bugs.gentoo.org/700176
Closes: https://bugs.gentoo.org/749681
Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Ross Charles Campbell <rossbridger.cc@gmail.com>