### PR TITLE
media-sound/supercollider: Ensure debugging is disabled when USE=-debug

### DIFF
--- a/media-sound/supercollider/supercollider-3.11.0-r1.ebuild
+++ b/media-sound/supercollider/supercollider-3.11.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake readme.gentoo-r1 xdg-utils
+inherit cmake flag-o-matic readme.gentoo-r1 xdg-utils
 
 DESCRIPTION="An environment and a programming language for real time audio synthesis."
 HOMEPAGE="https://supercollider.github.io/"
@@ -104,6 +104,8 @@ src_configure() {
 		-DSN_MEMORY_DEBUGGING=ON
 		-DGC_SANITYCHECK=ON
 	)
+
+	append-flags $(usex debug '' -DNDEBUG)
 
 	cmake_src_configure
 }


### PR DESCRIPTION
By default debugging is enabled, see https://github.com/supercollider/supercollider/issues/5159 and https://github.com/supercollider/supercollider/search?q=ndebug

Signed-off-by: Simon van der Veldt <simon.vanderveldt+gentoo@gmail.com>