### PR TITLE
Create libp11-9999.ebuild

### DIFF
--- a/dev-libs/libp11/libp11-9999.ebuild
+++ b/dev-libs/libp11/libp11-9999.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit git-r3
+
+DESCRIPTION="Abstraction layer to simplify PKCS#11 API"
+HOMEPAGE="https://github.com/opensc/libp11/wiki"
+EGIT_REPO_URI="https://github.com/OpenSC/libp11.git"
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
+IUSE="libressl bindist doc static-libs"
+
+RDEPEND="
+	!libressl? ( dev-libs/openssl:0=[bindist=] )
+	libressl? ( >=dev-libs/libressl-2.8:0= )"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen )"
+src_unpack(){
+	git-r3_src_unpack
+}
+
+src_prepare() {
+	./bootstrap
+	eapply_user
+}
+
+src_configure() {
+	econf \
+		--enable-shared \
+		$(use_enable static-libs static) \
+		$(use_enable doc api-doc)
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
This is not the first time a new version of libp11 is released *days* before a new LibreSSL that necessitates small tweaks to the definitions within libP11.
LibreSSL 3.2.2 is released, and required just such a fix mere days after libP11 0.4.11 was released. This also was the case after libP11 0.4.10 was released.

The OpenSC maintainers keep a clean codebase, run several code-checkers, and check for regressions before accepting commits to even their master branch. Any risk for bugs in this library is minimized by their vigilant prudence.

Most any up-to-date LibreSSL users that require Yubikeys (among several other hardware authentication solutions) will require a libp11 ebuild that pulls directly from that master branch. Just such a commit to OpenSC/libp11 for compatibility with LibreSSL 3.2.2 is waiting for approval. This commit has cleared all compatibility checks.