### PR TITLE
dev-util/qdevicemonitor: fix build

### DIFF
--- a/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r2.ebuild
+++ b/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r2.ebuild
@@ -24,6 +24,7 @@ RDEPEND="
 	app-pda/usbmuxd
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
 	dev-util/android-tools"
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/749942
Package-Manager: Portage-3.0.4, Repoman-3.0.1
Signed-off-by: Alexander Lopatin <alopatindev@gmail.com>