### PR TITLE
media-gfx/gimp: 2.10.22 fix mypaint-brushes dependency

### DIFF
--- a/media-gfx/gimp/gimp-2.10.22.ebuild
+++ b/media-gfx/gimp/gimp-2.10.22.ebuild
@@ -27,7 +27,7 @@ COMMON_DEPEND="
 	dev-libs/libxml2:2
 	dev-libs/libxslt
 	>=gnome-base/librsvg-2.40.6:2
-	>=media-gfx/mypaint-brushes-1.3.0:=
+	>=media-gfx/mypaint-brushes-2.0.2:=
 	>=media-libs/babl-0.1.78
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.1.7


### PR DESCRIPTION
While removing conditional check of mypaint-brushes version
the appropreate version of this dependency wasn't updated
resulting in configuration error if user still has mypaint-brushes-1.3.0,
that was already removed from portage tree at gimp version bump.

Offered change doesn't affect users that installed gimp-2.10.22
so there is no revision bump.

Closes: https://bugs.gentoo.org/747487

Signed-off-by: Sergey Torokhov <torokhov-s-a@yandex.ru>