### PR TITLE
media-sound/murmur: Migrate live ebuild to cmake

### DIFF
--- a/media-sound/murmur/metadata.xml
+++ b/media-sound/murmur/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Lars Wendler</name>
 	</maintainer>
 	<use>
+		<flag name="grpc">Use <pkg>net-libs/grpc</pkg> to enable remote control capabilities.</flag>
 		<flag name="ice">Use <pkg>dev-libs/Ice</pkg> to enable remote control capabilities.</flag>
 	</use>
 	<upstream>

--- a/media-sound/murmur/murmur-9999.ebuild
+++ b/media-sound/murmur/murmur-9999.ebuild
@@ -29,7 +29,7 @@ fi
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="+dbus +ice test zeroconf"
+IUSE="+dbus grpc +ice test zeroconf"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -47,6 +47,7 @@ RDEPEND="
 	sys-apps/lsb-release
 	>=sys-libs/libcap-2.15
 	dbus? ( dev-qt/qtdbus:5 )
+	grpc? ( net-libs/grpc )
 	ice? ( dev-libs/Ice:= )
 	zeroconf? ( net-dns/avahi[mdnsresponder-compat] )
 "
@@ -110,7 +111,7 @@ src_configure() {
 		"-Ddbus=$(usex dbus)"
 		"-Dg15=OFF"
 		"-Dice=$(usex ice)"
-		"-Dgrpc=OFF"
+		"-Dgrpc=$(usex grpc)"
 		"-DBUILD_TESTING=$(usex test)"
 		"-Dzeroconf=$(usex zeroconf)"
 	)

--- a/media-sound/murmur/murmur-9999.ebuild
+++ b/media-sound/murmur/murmur-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit qmake-utils systemd readme.gentoo-r1
+inherit cmake systemd readme.gentoo-r1
 
 DESCRIPTION="Mumble is an open source, low-latency, high quality voice chat software"
 HOMEPAGE="https://wiki.mumble.info"
@@ -29,7 +29,8 @@ fi
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="+dbus debug +ice pch zeroconf"
+IUSE="+dbus +ice test zeroconf"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	acct-group/murmur
@@ -93,6 +94,8 @@ src_prepare() {
 	# Adjust systemd service file to our config location #689208
 	sed "s@/etc/${PN}\.ini@/etc/${PN}/${PN}.ini@" \
 		-i scripts/${PN}.service || die
+
+	cmake_src_prepare
 }
 
 src_configure() {
@@ -100,28 +103,29 @@ src_configure() {
 		[[ -n "${1}" ]] || die "myconf: No use flag given."
 		use ${1} || echo "no-${1}"
 	}
-	local conf_add=(
-		no-client
-		$(myuse dbus)
-		$(usex debug 'symbols debug' release)
-		$(myuse ice)
-		$(myuse pch)
-		$(usex zeroconf '' no-bonjour)
+	local mycmakeargs=(
+		"-Doverlay=OFF"
+		"-Dserver=ON"
+		"-Dclient=OFF"
+		"-Ddbus=$(usex dbus)"
+		"-Dg15=OFF"
+		"-Dice=$(usex ice)"
+		"-Dgrpc=OFF"
+		"-DBUILD_TESTING=$(usex test)"
+		"-Dzeroconf=$(usex zeroconf)"
 	)
 
-	eqmake5 main.pro -recursive \
-		CONFIG+="${conf_add[*]}"
+	cmake_src_configure
 }
 
 src_install() {
-	dodoc README CHANGES
+	cmake_src_install
+
+	dodoc README.md CHANGES
 
 	docinto scripts
 	dodoc -r scripts/server
 	docompress -x /usr/share/doc/${PF}/scripts
-
-	local dir="$(usex debug debug release)"
-	dobin "${dir}"/murmurd
 
 	local etcdir="/etc/murmur"
 	insinto ${etcdir}

--- a/media-sound/murmur/murmur-9999.ebuild
+++ b/media-sound/murmur/murmur-9999.ebuild
@@ -105,14 +105,14 @@ src_configure() {
 		use ${1} || echo "no-${1}"
 	}
 	local mycmakeargs=(
-		"-Doverlay=OFF"
-		"-Dserver=ON"
+		"-DBUILD_TESTING=$(usex test)"
 		"-Dclient=OFF"
 		"-Ddbus=$(usex dbus)"
 		"-Dg15=OFF"
-		"-Dice=$(usex ice)"
 		"-Dgrpc=$(usex grpc)"
-		"-DBUILD_TESTING=$(usex test)"
+		"-Dice=$(usex ice)"
+		"-Doverlay=OFF"
+		"-Dserver=ON"
 		"-Dzeroconf=$(usex zeroconf)"
 	)
 

--- a/media-sound/murmur/murmur-9999.ebuild
+++ b/media-sound/murmur/murmur-9999.ebuild
@@ -105,15 +105,15 @@ src_configure() {
 		use ${1} || echo "no-${1}"
 	}
 	local mycmakeargs=(
-		"-DBUILD_TESTING=$(usex test)"
-		"-Dclient=OFF"
-		"-Ddbus=$(usex dbus)"
-		"-Dg15=OFF"
-		"-Dgrpc=$(usex grpc)"
-		"-Dice=$(usex ice)"
-		"-Doverlay=OFF"
-		"-Dserver=ON"
-		"-Dzeroconf=$(usex zeroconf)"
+		-DBUILD_TESTING="$(usex test)"
+		-Dclient="OFF"
+		-Ddbus="$(usex dbus)"
+		-Dg15="OFF"
+		-Dgrpc="$(usex grpc)"
+		-Dice="$(usex ice)"
+		-Doverlay="OFF"
+		-Dserver="ON"
+		-Dzeroconf="$(usex zeroconf)"
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/745387
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Jannis Achstetter <kripton@kripserver.net>

Equivalent to  #17468: Convert media-sound/murmur-9999 from qmake to cmake. Drops support for pch but adds support for tests. I was unable to test the systemd-files since all my systems run OpenRC but the server itself is working fine.