### PR TITLE
sys-libs/talloc: Upgrade to EAPI 7

### DIFF
--- a/eclass/waf-utils.eclass
+++ b/eclass/waf-utils.eclass
@@ -19,9 +19,11 @@
 inherit multilib toolchain-funcs multiprocessing
 
 case ${EAPI:-0} in
-	4|5|6|7) EXPORT_FUNCTIONS src_configure src_compile src_install ;;
+	4|5|6|7) ;;
 	*) die "EAPI=${EAPI} is not supported" ;;
 esac
+
+EXPORT_FUNCTIONS src_configure src_compile src_install 
 
 # @ECLASS-VARIABLE: WAF_VERBOSE
 # @DESCRIPTION:

--- a/eclass/waf-utils.eclass
+++ b/eclass/waf-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: waf-utils.eclass
@@ -8,7 +8,7 @@
 # Original Author: Gilles Dartiguelongue <eva@gentoo.org>
 # Various improvements based on cmake-utils.eclass: Tomáš Chvátal <scarabeus@gentoo.org>
 # Proper prefix support: Jonathan Callen <jcallen@gentoo.org>
-# @SUPPORTED_EAPIS: 4 5 6
+# @SUPPORTED_EAPIS: 4 5 6 7
 # @BLURB: common ebuild functions for waf-based packages
 # @DESCRIPTION:
 # The waf-utils eclass contains functions that make creating ebuild for
@@ -19,7 +19,7 @@
 inherit multilib toolchain-funcs multiprocessing
 
 case ${EAPI:-0} in
-	4|5|6) EXPORT_FUNCTIONS src_configure src_compile src_install ;;
+	4|5|6|7) EXPORT_FUNCTIONS src_configure src_compile src_install ;;
 	*) die "EAPI=${EAPI} is not supported" ;;
 esac
 

--- a/sys-libs/talloc/talloc-2.3.1-r1.ebuild
+++ b/sys-libs/talloc/talloc-2.3.1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 PYTHON_REQ_USE="threads(+)"
@@ -27,11 +27,13 @@ RDEPEND="!elibc_FreeBSD? (
 			)
 		)
 	python? ( ${PYTHON_DEPS} )
-	!!<sys-libs/talloc-2.0.5"
-DEPEND="${RDEPEND}
-	sys-devel/gettext
+	!!<sys-libs/talloc-2.0.5
+"
+DEPEND="${RDEPEND}"
+
+BDEPEND="${PYTHON_DEPS}
 	dev-libs/libxslt
-	${PYTHON_DEPS}"
+"
 
 WAF_BINARY="${S}/buildtools/bin/waf"
 
@@ -62,6 +64,7 @@ multilib_src_configure() {
 		$(usex compat --enable-talloc-compat1 '')
 		$(multilib_native_usex python '' --disable-python)
 		$([[ ${CHOST} == *-solaris* ]] && echo '--disable-symbol-versions')
+		--without-gettext
 	)
 	waf-utils_src_configure "${extra_opts[@]}"
 }


### PR DESCRIPTION
python is not needed as a DEPEND unless the python use flag is set.
python is required as a BDEPEND since the package uses WAF to build.

Bug: https://bugs.gentoo.org/744994
Signed-off-by: Raul E Rangel <ismell@ismell.org>