### PR TITLE
app-emulation/sen: Correct DISTUTILS_USE_SETUPTOOLS

### DIFF
--- a/app-emulation/sen/sen-0.6.1_p20200905.ebuild
+++ b/app-emulation/sen/sen-0.6.1_p20200905.ebuild
@@ -5,6 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8} )
 
+DISTUTILS_USE_SETUPTOOLS=rdepend
 inherit distutils-r1
 
 COMMIT="02e5872ee2905861e1da06ab5174e1a3f41f0e0b"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/746284
Package-Manager: Portage-3.0.5, Repoman-2.3.23
Signed-off-by: Nelo-T. Wallus <nelo@wallus.de>