### PR TITLE
dev-libs/hiredis: fix build with USE="-ssl"

### DIFF
--- a/dev-libs/hiredis/hiredis-1.0.0.ebuild
+++ b/dev-libs/hiredis/hiredis-1.0.0.ebuild
@@ -71,7 +71,7 @@ src_test() {
 src_install() {
 	_build PREFIX="${ED}/usr" install
 	if ! use static-libs; then
-		rm "${ED}/usr/$(get_libdir)/libhiredis.a" \
+		rm -f "${ED}/usr/$(get_libdir)/libhiredis.a" \
 			"${ED}/usr/$(get_libdir)/libhiredis_ssl.a" || die
 	fi
 


### PR DESCRIPTION
I changed `rm` to `rm -f` in order to ignore missing `${ED}/usr/$(get_libdir)/libhiredis.a` when `USE=-ssl` is set.