### PR TITLE
games-arcade/ceferino: Remove missing patch.

### DIFF
--- a/games-arcade/ceferino/ceferino-0.97.8-r2.ebuild
+++ b/games-arcade/ceferino/ceferino-0.97.8-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -27,7 +27,6 @@ S="${WORKDIR}/${P}+svn37"
 
 src_prepare() {
 	default
-	eapply "${FILESDIR}"/${P}-latin1.patch
 	sed -i \
 		-e '/^INCLUDES/s:\$(datadir)/locale:/usr/share/locale:' \
 		src/Makefile.am || die


### PR DESCRIPTION
The patch was never committed to Portage and it is not clear what exactly it did and why it was required.
Just removing that line from the ebuild makes it compile and the game works fine.