### PR TITLE
profiles: remove virtual/ffmpeg from packages.deprecated (no longer in tree)

### DIFF
--- a/profiles/package.deprecated
+++ b/profiles/package.deprecated
@@ -17,11 +17,6 @@
 
 #--- END OF EXAMPLES ---
 
-# Jesus P Rey <gentoo@chuso.net> (2020-09-26)
-# Only one provider left; media-video/ffmpeg should be used instead
-# Bug #744787
-virtual/ffmpeg
-
 # Thomas Deutschmann <whissi@gentoo.org> (2020-09-08)
 # Dead implementations, please migrate to >=zeromq-4
 dev-perl/ZMQ-LibZMQ2


### PR DESCRIPTION
After no revdeps were left, the package was removed by @mgorny in 0e5b93b, but it's still listed in `packages.deprecated`.

Shouldn't it be removed there too? Or is there any reason for it to stay there (like, e.g., overlays)?