### PR TITLE
selinux profile: set sys-process/audit to use python by default.

### DIFF
--- a/profiles/features/selinux/package.use.force
+++ b/profiles/features/selinux/package.use.force
@@ -17,3 +17,6 @@ dev-lang/python xml
 # so stages can build with no interacton. Bug #527938
 sys-libs/libselinux static-libs
 dev-libs/libpcre static-libs
+
+# Required for semanage to run correctly.
+sys-process/audit python


### PR DESCRIPTION
`semanage` requires `auditd` to be compiled with `USE=python` to be usable.