### PR TITLE
games-server/minecraft-server: Add systemd unit.

### DIFF
--- a/games-server/minecraft-server/files/minecraft-server.service
+++ b/games-server/minecraft-server/files/minecraft-server.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Minecraft Server (World: %I)
+After=network.target
+
+[Service]
+User=minecraft
+Group=minecraft
+WorkingDirectory=-/var/lib/minecraft-server/%I
+PIDFile=/run/minecraft-server.%I.pid
+ExecStartPre=!/bin/mkdir -p /var/lib/minecraft-server/%I
+ExecStartPre=!/bin/chown -R minecraft:minecraft /var/lib/minecraft-server/%I
+ExecStartPre=/bin/sh -c 'echo "eula=true" > /var/lib/minecraft-server/%I/eula.txt'
+ExecStart=/bin/sh -c '/usr/bin/dtach -N $(mktemp -u) /usr/bin/minecraft-server'
+
+[Install]
+WantedBy=multi-user.target

--- a/games-server/minecraft-server/minecraft-server-1.16.3-r1.ebuild
+++ b/games-server/minecraft-server/minecraft-server-1.16.3-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+EGIT_COMMIT="f02f4473dbf152c23d7d484952121db0b36698cb"
+README_GENTOO_SUFFIX="-r1"
+
+inherit readme.gentoo-r1 java-pkg-2 systemd
+
+DESCRIPTION="The official server for the sandbox video game"
+HOMEPAGE="https://www.minecraft.net/"
+SRC_URI="https://launcher.mojang.com/v1/objects/${EGIT_COMMIT}/server.jar -> ${P}.jar"
+
+LICENSE="Mojang"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+RDEPEND="
+	acct-group/minecraft
+	acct-user/minecraft
+	app-misc/dtach
+	|| (
+		>=virtual/jre-1.8
+		>=virtual/jdk-1.8
+	)
+"
+
+RESTRICT="bindist mirror"
+
+S="${WORKDIR}"
+
+src_unpack() {
+	cp "${DISTDIR}/${A}" "${WORKDIR}" || die
+}
+
+src_compile() {
+	:;
+}
+
+src_install() {
+	java-pkg_newjar minecraft-server-${PV}.jar minecraft-server.jar
+	java-pkg_dolauncher minecraft-server --jar minecraft-server.jar --java_args "\${JAVA_OPTS}"
+
+	newinitd "${FILESDIR}"/minecraft-server.initd-r4 minecraft-server
+	newconfd "${FILESDIR}"/minecraft-server.confd-r1 minecraft-server
+	systemd_newunit "${FILESDIR}"/minecraft-server.service minecraft-server@.service
+
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
This PR added a systemd unit that allows users to run a minecraft server as a systemd service which is compatible with the existing servers created by the openrc init scripts.

Bug: https://bugs.gentoo.org/750680
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Ross Charles Campbell <rossbridger.cc@gmail.com>