### PR TITLE
Add python3_9 support to ansible

### DIFF
--- a/app-admin/ansible-base/ansible-base-2.10.2.ebuild
+++ b/app-admin/ansible-base/ansible-base-2.10.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..8} )
+PYTHON_COMPAT=( python3_{6..9} )
 
 inherit distutils-r1 eutils
 

--- a/app-admin/ansible/ansible-2.10.0-r2.ebuild
+++ b/app-admin/ansible/ansible-2.10.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..8} )
+PYTHON_COMPAT=( python3_{6..9} )
 DISTUTILS_USE_SETUPTOOLS=bdepend
 
 inherit distutils-r1 eutils

--- a/app-admin/ansible/ansible-9999.ebuild
+++ b/app-admin/ansible/ansible-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..8} )
+PYTHON_COMPAT=( python3_{6..9} )
 DISTUTILS_USE_SETUPTOOLS=bdepend
 
 inherit distutils-r1 eutils


### PR DESCRIPTION
https://bugs.gentoo.org/751475

Ansible works for me on python3_9

```
ansible 2.10.2
  config file = None
  configured module search path = ['/home/nmeyer/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.9/site-packages/ansible
  executable location = /usr/lib/python-exec/python3.9/ansible
  python version = 3.9.0 (default, Oct  5 2020, 22:29:35) [GCC 10.2.0]
```