### PR TITLE
media-gfx/gscan2pdf: require ImageMagick JPEG support for tests

### DIFF
--- a/media-gfx/gscan2pdf/gscan2pdf-2.9.1.ebuild
+++ b/media-gfx/gscan2pdf/gscan2pdf-2.9.1.ebuild
@@ -58,7 +58,7 @@ BDEPEND="
 		app-text/poppler[utils]
 		app-text/tesseract[-opencl,osd(+),tiff]
 		app-text/unpaper
-		media-gfx/imagemagick[djvu,png,tiff,perl,postscript]
+		media-gfx/imagemagick[djvu,jpeg,png,tiff,perl,postscript]
 		media-gfx/sane-backends[sane_backends_test]
 		media-gfx/sane-frontends
 	)"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/751400
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

The other gscan2pdf ebuilds fail tests anyway with current media-gfx/imagemagick so not worth updating (and will be removed once the 2.9.1 stabilization is completed).

```diff
--- gscan2pdf-2.9.1.ebuild
+++ gscan2pdf-2.9.1.ebuild
@@ -58,7 +58,7 @@ BDEPEND="
                app-text/poppler[utils]
                app-text/tesseract[-opencl,osd(+),tiff]
                app-text/unpaper
-               media-gfx/imagemagick[djvu,png,tiff,perl,postscript]
+               media-gfx/imagemagick[djvu,jpeg,png,tiff,perl,postscript]
                media-gfx/sane-backends[sane_backends_test]
                media-gfx/sane-frontends
        )"
```
