### PR TITLE
sys-apps/opentmpfiles: fix build on prefix

### DIFF
--- a/sys-apps/opentmpfiles/opentmpfiles-0.3.1.ebuild
+++ b/sys-apps/opentmpfiles/opentmpfiles-0.3.1.ebuild
@@ -25,7 +25,7 @@ RDEPEND="!<sys-apps/openrc-0.23
 
 src_prepare() {
 	default
-	hprefixify tmpfiles
+	hprefixify tmpfiles.sh
 }
 src_install() {
 	emake DESTDIR="${ED}" install

--- a/sys-apps/opentmpfiles/opentmpfiles-9999.ebuild
+++ b/sys-apps/opentmpfiles/opentmpfiles-9999.ebuild
@@ -25,7 +25,7 @@ RDEPEND="!<sys-apps/openrc-0.23
 
 src_prepare() {
 	default
-	hprefixify tmpfiles
+	hprefixify tmpfiles.sh
 }
 src_install() {
 	emake DESTDIR="${ED}" install


### PR DESCRIPTION
Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>