### PR TITLE
media-gfx/gscan2pdf: add USE flags required for tests

### DIFF
--- a/media-gfx/gscan2pdf/gscan2pdf-2.9.1.ebuild
+++ b/media-gfx/gscan2pdf/gscan2pdf-2.9.1.ebuild
@@ -54,9 +54,9 @@ BDEPEND="
 		dev-perl/Sub-Override
 		media-libs/fontconfig
 
-		app-text/djvu[tiff]
+		app-text/djvu[jpeg,tiff]
 		app-text/poppler[utils]
-		app-text/tesseract[-opencl,osd(+),tiff]
+		app-text/tesseract[-opencl,osd(+),png,tiff]
 		app-text/unpaper
 		media-gfx/imagemagick[djvu,jpeg,png,tiff,perl,postscript]
 		media-gfx/sane-backends[sane_backends_test]


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/751400
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

```diff
--- gscan2pdf-2.9.1.ebuild
+++ gscan2pdf-2.9.1.ebuild
@@ -54,7 +54,7 @@
 		dev-perl/Sub-Override
 		media-libs/fontconfig
 
-		app-text/djvu[tiff]
+		app-text/djvu[jpeg,tiff]
 		app-text/poppler[utils]
 		app-text/tesseract[-opencl,osd(+),tiff]
 		app-text/unpaper

```