### PR TITLE
games-emulation/vbam: don't override CMAKE_AR

### DIFF
--- a/games-emulation/vbam/vbam-2.1.4.ebuild
+++ b/games-emulation/vbam/vbam-2.1.4.ebuild
@@ -70,6 +70,7 @@ src_configure() {
 		-DENABLE_ASM_CORE=$(usex x86)
 		-DENABLE_ASM_SCALERS=$(usex x86)
 		-DCMAKE_SKIP_RPATH=ON
+		-DENABLE_LTO=OFF
 	)
 	if use wxwidgets; then
 		mycmakeargs+=( -DENABLE_OPENAL=$(usex openal) )

--- a/games-emulation/vbam/vbam-9999.ebuild
+++ b/games-emulation/vbam/vbam-9999.ebuild
@@ -66,6 +66,7 @@ src_configure() {
 		-DENABLE_ASM_CORE=$(usex x86)
 		-DENABLE_ASM_SCALERS=$(usex x86)
 		-DCMAKE_SKIP_RPATH=ON
+		-DENABLE_LTO=OFF
 	)
 	if use wxwidgets; then
 		mycmakeargs+=( -DENABLE_OPENAL=$(usex openal) )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/733938
Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>