### PR TITLE
dev-python/markdown2: python 3.9 support

### DIFF
--- a/dev-python/markdown2/markdown2-2.3.10.ebuild
+++ b/dev-python/markdown2/markdown2-2.3.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Add python 3.9 support. All test are passing.