### PR TITLE
dev-util/android-sdk-update-manager: fix metadata

### DIFF
--- a/dev-util/android-sdk-update-manager/metadata.xml
+++ b/dev-util/android-sdk-update-manager/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-        <!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>ramage.lucas@protonmail.com</email>
+		<name>Lucas Ramage</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
Package-Manager: Portage-3.0.8, Repoman-3.0.1
Signed-off-by: Lucas Ramage <ramage.lucas@protonmail.com>

I want to take this one. However, we have some issues:

- Bump: https://bugs.gentoo.org/704198
- Potentially renames the package: https://bugs.gentoo.org/637422