### PR TITLE
dev-python/patch-ng: fix #748414

### DIFF
--- a/dev-python/patch-ng/patch-ng-1.17.4.ebuild
+++ b/dev-python/patch-ng/patch-ng-1.17.4.ebuild
@@ -3,8 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
-DISTUTILS_USE_SETUPTOOLS=rdepend
+PYTHON_COMPAT=( python3_{6..9} )
 inherit distutils-r1
 
 DESCRIPTION="Library to parse and apply unified diffs, fork of dev-python/patch"


### PR DESCRIPTION
Removed DISTUTILS_USE_SETUPTOOLS=rdepend, added python3_9 target.

Closes: https://bugs.gentoo.org/748414
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>