### PR TITLE
dev-util/ostree: libressl support

### DIFF
--- a/dev-util/ostree/ostree-2020.7.ebuild
+++ b/dev-util/ostree/ostree-2020.7.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 LICENSE="LGPL-2+"
 SLOT="0"
 
-IUSE="archive curl doc dracut gnutls +gpg grub http2 httpd introspection libmount selinux sodium ssl soup systemd zeroconf"
+IUSE="archive curl doc dracut gnutls +gpg grub http2 httpd introspection libmount libressl selinux sodium ssl soup systemd zeroconf"
 RESTRICT="test"
 REQUIRED_USE="httpd? ( || ( curl soup ) )"
 
@@ -33,7 +33,11 @@ COMMON_DEPEND="
 	introspection? ( dev-libs/gobject-introspection )
 	ssl? (
 		gnutls? ( net-libs/gnutls )
-		!gnutls? ( dev-libs/openssl:0= ) )
+		!gnutls? (
+			!libressl? ( dev-libs/openssl:0= )
+			libressl? ( dev-libs/libressl:0= )
+		)
+	)
 	>=sys-fs/fuse-2.9.2:0
 	sys-libs/zlib
 	libmount? ( sys-apps/util-linux )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/751103
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>