### PR TITLE
 app-misc/editor-wrapper: Avoid infinite recursion

### DIFF
--- a/app-misc/editor-wrapper/files/editor-wrapper-4.sh
+++ b/app-misc/editor-wrapper/files/editor-wrapper-4.sh
@@ -12,6 +12,10 @@ fi
 if [ -z "${@VAR@}" ]; then
     echo "$0: The @VAR@ variable must be set" >&2
     exit 1
+elif [ "${@VAR@}" = "${0##*/}" ]; then
+    # avoid infinite recursion
+    echo "$0: The @VAR@ variable shall not be identical to '${0##*/}'" >&2
+    exit 1
 fi
 
 exec ${@VAR@} "$@"

--- a/app-misc/editor-wrapper/files/editor-wrapper-5.sh
+++ b/app-misc/editor-wrapper/files/editor-wrapper-5.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Copyright 2009-2020 Gentoo Authors
+# Distributed under the terms of the MIT/X11 license
+
+# Wrapper script, executes ${@VAR@} with arguments $@
+
+if [ -z "${@VAR@}" ]; then
+    # Try to get @VAR@ from system profile
+    @VAR@=$(. /etc/profile >/dev/null 2>&1; echo "${@VAR@}")
+fi
+
+if [ -z "${@VAR@}" ]; then
+    echo "$0: The @VAR@ variable must be set" >&2
+    exit 1
+elif [ "${@VAR@}" = "${0##*/}" ]; then
+    # avoid infinite recursion
+    echo "$0: The @VAR@ variable shall not be identical to '${0##*/}'" >&2
+    exit 1
+fi
+
+exec ${@VAR@} "$@"


### PR DESCRIPTION
If `$EDITOR`/`$PAGER` variables are identical to 'editor'/'pager' respectively, the script recurs infinitely.

e.g.:
```console
$ EDITOR=editor
$ editor # recurs infinitely
```

The users who set these variables to such names probably not intend to cause this behavior, so it would be better to detect infinite recursion and exit with an error.