### PR TITLE
dev-libs/libappindicator: apply LP1867996 fix

### DIFF
--- a/dev-libs/libappindicator/files/libappindicator-12.10.0-lp1867996-fix-g-signal-emit.patch
+++ b/dev-libs/libappindicator/files/libappindicator-12.10.0-lp1867996-fix-g-signal-emit.patch
@@ -1,0 +1,74 @@
+--- a/src/app-indicator.c	2012-07-11 13:28:34.415113869 -0400
++++ b/src/app-indicator.c	2020-03-19 12:14:47.813191652 -0400
+@@ -443,7 +443,7 @@
+ 	                                  G_STRUCT_OFFSET (AppIndicatorClass, new_icon),
+ 	                                  NULL, NULL,
+ 	                                  g_cclosure_marshal_VOID__VOID,
+-	                                  G_TYPE_NONE, 0, G_TYPE_NONE);
++	                                  G_TYPE_NONE, 0);
+ 
+ 	/**
+ 	 * AppIndicator::new-attention-icon:
+@@ -457,7 +457,7 @@
+ 	                                            G_STRUCT_OFFSET (AppIndicatorClass, new_attention_icon),
+ 	                                            NULL, NULL,
+ 	                                            g_cclosure_marshal_VOID__VOID,
+-	                                            G_TYPE_NONE, 0, G_TYPE_NONE);
++	                                            G_TYPE_NONE, 0);
+ 
+ 	/**
+ 	 * AppIndicator::new-status:
+@@ -505,7 +505,7 @@
+ 	                                            G_STRUCT_OFFSET (AppIndicatorClass, connection_changed),
+ 	                                            NULL, NULL,
+ 	                                            g_cclosure_marshal_VOID__BOOLEAN,
+-	                                            G_TYPE_NONE, 1, G_TYPE_BOOLEAN, G_TYPE_NONE);
++	                                            G_TYPE_NONE, 1, G_TYPE_BOOLEAN);
+ 
+ 	/**
+ 	 * AppIndicator::new-icon-theme-path:
+@@ -1175,7 +1175,7 @@
+ 	gchar * guide = priv->label_guide != NULL ? priv->label_guide : "";
+ 
+ 	g_signal_emit(G_OBJECT(self), signals[NEW_LABEL], 0,
+-	              label, guide, TRUE);
++	              label, guide);
+ 	if (priv->dbus_registration != 0 && priv->connection != NULL) {
+ 		GError * error = NULL;
+ 
+@@ -1490,7 +1490,7 @@
+ static void
+ theme_changed_cb (GtkIconTheme * theme, gpointer user_data)
+ {
+-	g_signal_emit (user_data, signals[NEW_ICON], 0, TRUE);
++	g_signal_emit (user_data, signals[NEW_ICON], 0);
+ 
+ 	AppIndicator * self = (AppIndicator *)user_data;
+ 	AppIndicatorPrivate *priv = self->priv;
+@@ -1904,7 +1904,7 @@
+ 	}
+ 
+ 	if (changed) {
+-		g_signal_emit (self, signals[NEW_ATTENTION_ICON], 0, TRUE);
++		g_signal_emit (self, signals[NEW_ATTENTION_ICON], 0);
+ 
+ 		if (self->priv->dbus_registration != 0 && self->priv->connection != NULL) {
+ 			GError * error = NULL;
+@@ -1982,7 +1982,7 @@
+ 	}
+ 
+ 	if (changed) {
+-		g_signal_emit (self, signals[NEW_ICON], 0, TRUE);
++		g_signal_emit (self, signals[NEW_ICON], 0);
+ 
+ 		if (self->priv->dbus_registration != 0 && self->priv->connection != NULL) {
+ 			GError * error = NULL;
+@@ -2048,7 +2048,7 @@
+ 
+ 		self->priv->icon_theme_path = g_strdup(icon_theme_path);
+ 
+-		g_signal_emit (self, signals[NEW_ICON_THEME_PATH], 0, self->priv->icon_theme_path, TRUE);
++		g_signal_emit (self, signals[NEW_ICON_THEME_PATH], 0, self->priv->icon_theme_path);
+ 
+ 		if (self->priv->dbus_registration != 0 && self->priv->connection != NULL) {
+ 			GError * error = NULL;

--- a/dev-libs/libappindicator/files/libappindicator-12.10.0-lp1867996-fix-iterate-search-path.patch
+++ b/dev-libs/libappindicator/files/libappindicator-12.10.0-lp1867996-fix-iterate-search-path.patch
@@ -1,0 +1,11 @@
+--- a/src/app-indicator.c	2020-10-31 03:31:51.966830232 -0700
++++ b/src/app-indicator.c	2020-10-31 03:36:04.252822972 -0700
+@@ -1606,7 +1606,7 @@ status_icon_changes (AppIndicator * self
+ 		gint n_elements, i;
+ 		gboolean found=FALSE;
+ 		gtk_icon_theme_get_search_path(icon_theme, &path, &n_elements);
+-		for (i=0; i< n_elements || path[i] == NULL; i++) {
++		for (i=0; i< n_elements; i++) {
+ 			if(g_strcmp0(path[i], self->priv->icon_theme_path) == 0) {
+ 				found=TRUE;
+ 				break;

--- a/dev-libs/libappindicator/libappindicator-12.10.0-r301.ebuild
+++ b/dev-libs/libappindicator/libappindicator-12.10.0-r301.ebuild
@@ -33,6 +33,9 @@ PATCHES=(
 	"${FILESDIR}"/${P}-conditional-py-bindings.patch
 	# http://bazaar.launchpad.net/~indicator-applet-developers/libappindicator/trunk.12.10/revision/244
 	"${FILESDIR}"/${P}-vala-inherit.patch
+	# https://bugs.launchpad.net/archlinux/+source/libappindicator/+bug/1867996
+	"${FILESDIR}"/${P}-lp1867996-fix-g-signal-emit.patch
+	"${FILESDIR}"/${P}-lp1867996-fix-iterate-search-path.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Applies the two patches from paulieg and sersorrel attached to
https://bugs.launchpad.net/archlinux/+source/libappindicator/+bug/1867996

The crash primarily happens when using discord with libappindicator installed.