### PR TITLE
sys-fs/cryfs: remove debug warning on sys-fs/cryfs[-debug]

### DIFF
--- a/sys-fs/cryfs/cryfs-0.10.2.ebuild
+++ b/sys-fs/cryfs/cryfs-0.10.2.ebuild
@@ -73,6 +73,7 @@ src_configure() {
 		-DBUILD_TESTING=$(usex test)
 	)
 	use custom-optimization || append-flags -O3
+	use debug || append-flags -DNDEBUG
 
 	cmake_src_configure
 }

--- a/sys-fs/cryfs/metadata.xml
+++ b/sys-fs/cryfs/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <!--maintainer-needed-->
+  <maintainer type="person">
+    <email>nickaristocrates@gmail.com</email>
+    <name>Nicholas Meyer</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
   <use>
     <flag name="custom-optimization">Use user-defined compiler optimization level</flag>
   </use>


### PR DESCRIPTION
My comment on the [bug report](https://bugs.gentoo.org/747376) repeated here:

If I add `-DNDEBUG` in the ebuild using append-flags, it gets rid of the warning for me. I'm not 100% sure this is the most correct and future-proof way to disable the development build, but I see something similar done in dev-util/intel-graphics-compiler:

https://github.com/gentoo/gentoo/blob/a50597d0202a4968147c1b5d96ebeeb1872b0ffe/dev-util/intel-graphics-compiler/intel-graphics-compiler-1.0.4111.ebuild#L50-L52

From the discussion in an upstream issue (https://github.com/cryfs/cryfs/issues/147) I'm not sure whether there is much of a known performance impact, but I can confirm that the warning goes away and that the following command:

```
file `which cryfs`
```

gives "stripped" which I assume means it does not contain debugging symbols.