### PR TITLE
Add python 3_9 to dev-python/{commonmark,setuptools_scm_git_archive} PYTHON_COMPAT

### DIFF
--- a/dev-python/commonmark/commonmark-0.9.1.ebuild
+++ b/dev-python/commonmark/commonmark-0.9.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=rdepend
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 
 inherit distutils-r1
 

--- a/dev-python/setuptools_scm_git_archive/setuptools_scm_git_archive-1.1.ebuild
+++ b/dev-python/setuptools_scm_git_archive/setuptools_scm_git_archive-1.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+PYTHON_COMPAT=( python3_{6..9} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="A setuptools_scm plugin for git archives"


### PR DESCRIPTION
Would allow for python3_9 support in app-admin/ansible-lint and dev-python/rich (added in https://github.com/gentoo/gentoo/pull/18100)