### PR TITLE
app-crypt/pius: add patches that include git headers

### DIFF
--- a/app-crypt/pius/files/pius-3.0.0-Fix-typo-in-readme-135.patch
+++ b/app-crypt/pius/files/pius-3.0.0-Fix-typo-in-readme-135.patch
@@ -1,3 +1,12 @@
+From 5f24833c50ac6d831c03309e9bbb6b62224ac0ac Mon Sep 17 00:00:00 2001
+From: Ross Smith II <ross@smithii.com>
+Date: Mon, 9 Mar 2020 16:45:29 -0700
+Subject: [PATCH] Fix typo in readme (#135)
+
+---
+ README.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/README.md b/README.md
 index 3ead858..4cb98ce 100644
 --- a/README.md
@@ -11,3 +20,6 @@ index 3ead858..4cb98ce 100644
  
  
  ## Config File
+-- 
+2.29.2
+

--- a/app-crypt/pius/files/pius-3.0.0-Fix-typos-132.patch
+++ b/app-crypt/pius/files/pius-3.0.0-Fix-typos-132.patch
@@ -1,3 +1,12 @@
+From 6a92664fe0cfacffb03e6f3312c1c5fb4d785297 Mon Sep 17 00:00:00 2001
+From: Maxim Baz <github@maximbaz.com>
+Date: Sat, 5 Oct 2019 23:52:17 +0200
+Subject: [PATCH] Fix typos (#132)
+
+---
+ pius | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/pius b/pius
 index 7cf09b5..cc2333b 100755
 --- a/pius
@@ -29,3 +38,6 @@ index 7cf09b5..cc2333b 100755
              options.mail = ans
              print()
  
+-- 
+2.29.2
+

--- a/app-crypt/pius/files/pius-3.0.0-Minor-fixes-for-pius-report-137.patch
+++ b/app-crypt/pius/files/pius-3.0.0-Minor-fixes-for-pius-report-137.patch
@@ -1,3 +1,15 @@
+From 19b61c3b0dc31ee60341b3ca708f8e459e44ce3f Mon Sep 17 00:00:00 2001
+From: Phil Dibowitz <phil@ipom.com>
+Date: Mon, 23 Mar 2020 08:57:09 -0700
+Subject: [PATCH] Minor fixes for pius-report (#137)
+
+Signed-off-by: Phil Dibowitz <phil@ipom.com>
+---
+ libpius/mailer.py | 2 +-
+ pius-keyring-mgr  | 4 +++-
+ pius-report       | 5 +++--
+ 3 files changed, 7 insertions(+), 4 deletions(-)
+
 diff --git a/libpius/mailer.py b/libpius/mailer.py
 index ba6b50a..f5b097f 100644
 --- a/libpius/mailer.py
@@ -61,3 +73,6 @@ index 47f57b5..744da35 100755
      gpg = subprocess.Popen(cmd, stdout=subprocess.PIPE, close_fds=True)
      gpg.wait()
  
+-- 
+2.29.2
+

--- a/app-crypt/pius/files/pius-3.0.0-pius-keyring-mgr-Fix-constants-134.patch
+++ b/app-crypt/pius/files/pius-3.0.0-pius-keyring-mgr-Fix-constants-134.patch
@@ -1,3 +1,18 @@
+From f54adce7ba47ad8882441aec3b0583ee788ea8e1 Mon Sep 17 00:00:00 2001
+From: Phil Dibowitz <phil@ipom.com>
+Date: Tue, 4 Feb 2020 09:33:40 -0800
+Subject: [PATCH] [pius-keyring-mgr] Fix constants (#134)
+
+The refactor of the code meant these constants are now in the
+constants module, not in self.
+
+Fixes #133
+
+Signed-off-by: Phil Dibowitz <phil@ipom.com>
+---
+ pius-keyring-mgr | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
 diff --git a/pius-keyring-mgr b/pius-keyring-mgr
 index 1daddeb..fb0b46a 100755
 --- a/pius-keyring-mgr
@@ -38,3 +53,6 @@ index 1daddeb..fb0b46a 100755
                          keyid = keyid_from_fp(fp)
                          tmp = data.copy()
                          tmp.update({"fingerprint": fp, "keyid": keyid})
+-- 
+2.29.2
+

--- a/app-crypt/pius/pius-3.0.0-r1.ebuild
+++ b/app-crypt/pius/pius-3.0.0-r1.ebuild
@@ -23,10 +23,10 @@ RDEPEND="${DEPEND}
 	dev-lang/perl"
 
 PATCHES=(
-  "${FILESDIR}/${P}_fix_typos.diff"
-  "${FILESDIR}/${P}_fix_keyring_mgr_constants.diff"
-  "${FILESDIR}/${P}_fix_readme_typo.diff"
-  "${FILESDIR}/${P}_fix_pius_report.diff"
+  "${FILESDIR}/${P}-Fix-typos-132.patch"
+  "${FILESDIR}/${P}-pius-keyring-mgr-Fix-constants-134.patch"
+  "${FILESDIR}/${P}-Fix-typo-in-readme-135.patch"
+  "${FILESDIR}/${P}-Minor-fixes-for-pius-report-137.patch"
 )
 
 python_test() {


### PR DESCRIPTION
@juippis this replaces the diffs added in https://github.com/gentoo/gentoo/pull/18103 with `git format-patch` exports including the git headers.