### PR TITLE
dev-util/geany-plugins: use lua-single eclass

### DIFF
--- a/dev-util/geany-plugins/geany-plugins-1.37-r1.ebuild
+++ b/dev-util/geany-plugins/geany-plugins-1.37-r1.ebuild
@@ -1,0 +1,128 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+LUA_COMPAT=( lua5-1 )
+
+inherit lua-single
+
+DESCRIPTION="A collection of different plugins for Geany"
+HOMEPAGE="https://plugins.geany.org"
+SRC_URI="https://plugins.geany.org/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
+
+IUSE="gtk2 ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope soup workbench"
+REQUIRED_USE="gtk2? ( !markdown ) lua? ( ${LUA_REQUIRED_USE} )"
+
+DEPEND="
+	dev-libs/glib:2
+	>=dev-util/geany-1.37[gtk2=]
+	!gtk2? ( x11-libs/gtk+:3 )
+	gtk2? ( x11-libs/gtk+:2 )
+	ctags? ( dev-util/ctags )
+	debugger? (
+		!gtk2? ( x11-libs/vte:2.91 )
+		gtk2? ( x11-libs/vte:0 )
+		)
+	enchant? ( app-text/enchant:= )
+	git? ( dev-libs/libgit2:= )
+	gpg? ( app-crypt/gpgme:1= )
+	gtkspell? (
+		!gtk2? ( app-text/gtkspell:3= )
+		gtk2? ( app-text/gtkspell:2 )
+		)
+	lua? ( ${LUA_DEPS} )
+	markdown? (
+		app-text/discount
+		net-libs/webkit-gtk:4
+		)
+	pretty-printer? ( dev-libs/libxml2:2 )
+	scope? (
+		!gtk2? ( x11-libs/vte:2.91 )
+		gtk2? ( x11-libs/vte:0 )
+		)
+	soup? ( net-libs/libsoup:2.4 )
+	workbench? ( dev-libs/libgit2:= )
+"
+RDEPEND="${DEPEND}
+	scope? ( sys-devel/gdb )
+"
+BDEPEND="virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+
+src_configure() {
+	local myeconfargs=(
+		--disable-cppcheck
+		--disable-extra-c-warnings
+		$(use_enable nls)
+		--enable-utilslib
+		# Plugins
+		--enable-addons
+		--enable-autoclose
+		--enable-automark
+		--enable-codenav
+		--enable-commander
+		--enable-defineformat
+		--enable-geanyextrasel
+		--enable-geanyinsertnum
+		--enable-geanymacro
+		--enable-geanyminiscript
+		--enable-geanynumberedbookmarks
+		--enable-geanyprj
+		--enable-geanyvc $(use_enable gtkspell)
+		--enable-keyrecord
+		--enable-latex
+		--enable-lineoperations
+		--enable-lipsum
+		--enable-overview
+		--enable-pairtaghighlighter
+		--enable-pohelper
+		--enable-projectorganizer
+		--enable-sendmail
+		--enable-shiftcolumn
+		--enable-tableconvert
+		--enable-treebrowser
+		--enable-vimode
+		--enable-xmlsnippets
+		$(use_enable debugger)
+		$(use_enable ctags geanyctags)
+		$(use_enable gtk2 geanydoc)
+		$(use_enable lua geanylua)
+		$(use_enable gpg geanypg)
+		$(use_enable soup geniuspaste)
+		$(use_enable git gitchangebar)
+		$(use_enable markdown) --disable-peg-markdown # using app-text/discount instead
+		$(use_enable pretty-printer)
+		$(use_enable scope)
+		$(use_enable enchant spellcheck)
+		# Having updatechecker… when you’re using a package manager?
+		$(use_enable soup updatechecker)
+		$(use_enable workbench)
+		# GeanyGenDoc requires ctpl which isn’t yet in portage
+		--disable-geanygendoc
+		# Require obsolete and vulnerable webkit-gtk versions
+		--disable-devhelp
+		--disable-webhelper
+		# GTK 2 only
+		--disable-geanypy
+		--disable-multiterm
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	find "${D}" -name '*.la' -delete || die
+
+	# make installs all translations if LINGUAS is empty
+	if [[ -z "${LINGUAS-x}" ]]; then
+		rm -r "${ED}/usr/share/locale/" || die
+	fi
+}

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -239,6 +239,7 @@ dev-lua/luacrypto
 >=dev-lua/lutok-0.4-r10
 >=dev-lua/messagepack-0.3.2-r100
 >=dev-lua/toluapp-1.0.93_p20190513-r100
+>=dev-util/geany-plugins-1.37-r1
 >=games-engines/love-0.7.2-r100:0.7
 >=games-engines/love-0.8.0-r100:0.8
 >=games-engines/love-11.3-r100:0


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/752669
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

Only Lua 5.1 supported:

https://github.com/geany/geany-plugins/blob/18936f6db14989b49a5a3899ecd6f95becda5b76/build/geanylua.m4

```diff
--- geany-plugins-1.37.ebuild
+++ geany-plugins-1.37-r1.ebuild
@@ -2,6 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
+LUA_COMPAT=( lua5-1 )
+
+inherit lua-single
 
 DESCRIPTION="A collection of different plugins for Geany"
 HOMEPAGE="https://plugins.geany.org"
@@ -12,7 +16,7 @@
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
 
 IUSE="gtk2 ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope soup workbench"
-REQUIRED_USE="gtk2? ( !markdown )"
+REQUIRED_USE="gtk2? ( !markdown ) lua? ( ${LUA_REQUIRED_USE} )"
 
 DEPEND="
 	dev-libs/glib:2
@@ -31,7 +35,7 @@
 		!gtk2? ( app-text/gtkspell:3= )
 		gtk2? ( app-text/gtkspell:2 )
 		)
-	lua? ( dev-lang/lua:0= )
+	lua? ( ${LUA_DEPS} )
 	markdown? (
 		app-text/discount
 		net-libs/webkit-gtk:4

```