### PR TITLE
app-i18n/uchardet: keywording as depency for sys-apps/groff

### DIFF
--- a/app-i18n/uchardet/uchardet-0.0.6-r2.ebuild
+++ b/app-i18n/uchardet/uchardet-0.0.6-r2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://www.freedesktop.org/software/uchardet/releases/${P}.tar.xz"
 
 LICENSE="|| ( MPL-1.1 GPL-2+ LGPL-2.1+ )"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="cpu_flags_x86_sse2 static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/app-i18n/uchardet/uchardet-0.0.7.ebuild
+++ b/app-i18n/uchardet/uchardet-0.0.7.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://www.freedesktop.org/wiki/Software/uchardet/"
 
 LICENSE="|| ( MPL-1.1 GPL-2+ LGPL-2.1+ )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="cpu_flags_x86_sse2 static-libs test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/750032
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Matthias Coppens <coppens.matthias.abc@gmail.com>