### PR TITLE
dev-python/uncertainties: add future as dependency

### DIFF
--- a/dev-python/uncertainties/uncertainties-3.1.4-r1.ebuild
+++ b/dev-python/uncertainties/uncertainties-3.1.4-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 PYTHON_COMPAT=( python3_{6..9} )
 
@@ -16,19 +16,16 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc"
 
-RDEPEND="dev-python/numpy[${PYTHON_USEDEP}]"
-DEPEND="${RDEPEND}
-	dev-python/setuptools[${PYTHON_USEDEP}]
+RDEPEND="
+	dev-python/numpy[${PYTHON_USEDEP}]
+	dev-python/future[${PYTHON_USEDEP}]
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
 	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
 "
 
 distutils_enable_tests nose
-
-ppython_compile_all() {
-	if use doc; then
-		PYTHONPATH="${BUILD_DIR}"/lib esetup.py build_sphinx
-	fi
-}
 
 python_compile_all() {
 	use doc && "${PYTHON}" setup.py build_sphinx


### PR DESCRIPTION
The main thing is that it adds `dev-python/future` as a dependency in `(R)DEPEND`. This dependency [is necessary](https://github.com/lebigot/uncertainties/blob/3.1.4/setup.py#L336) to prevent the following traceback upon `import uncertainties`:

```
  File "/usr/lib/python3.7/site-packages/uncertainties/__init__.py", line 225, in <module>
    from .core import *
  File "/usr/lib/python3.7/site-packages/uncertainties/core.py", line 22, in <module>
    from past.builtins import basestring
ModuleNotFoundError: No module named 'past'
```

I accompanied this with a revision bump to `r1`, but let me know if that's not necessary. While I was touching the ebuild anyway, I also made some minor changes:
- Update to EAPI 7 (and moved relevant `DEPEND` to `BDEPEND` because of that)
- Remove explicit `setuptools` dependency, as that is handled by the `distutils-r1` eclass already
- Remove unused `ppython_compile_all` function

Related to (closes?): https://bugs.gentoo.org/732832