### PR TITLE
net-misc/gallery-dl: add required python use

### DIFF
--- a/net-misc/gallery-dl/gallery-dl-1.15.2-r1.ebuild
+++ b/net-misc/gallery-dl/gallery-dl-1.15.2-r1.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=(python3_{7,8})
+PYTHON_REQ_USE="sqlite,ssl,xml"
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1 optfeature

--- a/net-misc/gallery-dl/gallery-dl-9999.ebuild
+++ b/net-misc/gallery-dl/gallery-dl-9999.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=(python3_{7,8})
+PYTHON_REQ_USE="sqlite,ssl,xml"
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1 optfeature


### PR DESCRIPTION
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Maciej Barć <xgqt@protonmail.com>


Fixes: https://bugs.gentoo.org/754030
