### PR TITLE
app-arch/torrentzip: Fix building with autoconf-2.70

### DIFF
--- a/app-arch/torrentzip/files/torrentzip-0.9-autoconf-quote.patch
+++ b/app-arch/torrentzip/files/torrentzip-0.9-autoconf-quote.patch
@@ -1,0 +1,8 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,4 +1,4 @@
+-AC_INIT([TorrentZip], [0.0], [StatMan, shindakun, Ultrasubmarine, r3nh03k <http://trrntzip.sf.net>], [trrntzip])
++AC_INIT([TorrentZip], [0.9], [[StatMan, shindakun, Ultrasubmarine, r3nh03k <http://trrntzip.sf.net>]], [trrntzip])
+ 
+ AM_INIT_AUTOMAKE
+ AM_CONFIG_HEADER(config.h)

--- a/app-arch/torrentzip/torrentzip-0.9-r1.ebuild
+++ b/app-arch/torrentzip/torrentzip-0.9-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Create identical zip archives over multiple systems"
+HOMEPAGE="https://sourceforge.net/projects/trrntzip"
+SRC_URI="https://dev.gentoo.org/~monsieurp/packages/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="sys-libs/zlib"
+
+DEPEND="${RDEPEND}"
+
+DOCS=(README AUTHORS)
+
+PATCHES=("${FILESDIR}/${P}-autoconf-quote.patch")
+
+src_prepare() {
+	default
+	export CPPFLAGS+=" -DOF\\(args\\)=args"
+	eautoreconf
+}


### PR DESCRIPTION
Fix for https://bugs.gentoo.org/751235
