### PR TITLE
dev-lang/lua: fix lua_get_include_dir for slotted 5.1

### DIFF
--- a/dev-lang/lua/lua-5.1.5-r104.ebuild
+++ b/dev-lang/lua/lua-5.1.5-r104.ebuild
@@ -1,0 +1,146 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+inherit eutils multilib multilib-minimal portability toolchain-funcs versionator
+
+DESCRIPTION="A powerful light-weight programming language designed for extending applications"
+HOMEPAGE="http://www.lua.org/"
+SRC_URI="http://www.lua.org/ftp/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="5.1"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+deprecated emacs readline static"
+
+RDEPEND="readline? ( >=sys-libs/readline-6.2_p5-r1:0=[${MULTILIB_USEDEP}] )
+	app-eselect/eselect-lua
+	!dev-lang/lua:0"
+DEPEND="${RDEPEND}
+	sys-devel/libtool"
+PDEPEND="emacs? ( app-emacs/lua-mode )"
+
+SAN_SLOT="${SLOT//.}"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/lua${SLOT}/luaconf.h
+)
+
+src_prepare() {
+	local PATCH_PV=$(get_version_component_range 1-2)
+
+	epatch "${FILESDIR}"/${PN}-${PATCH_PV}-make-r2.patch
+	epatch "${FILESDIR}"/${PN}-${PATCH_PV}-module_paths.patch
+
+	# use glibtool on Darwin (versus Apple libtool)
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		sed -i -e '/LIBTOOL = /s:libtool:glibtool:' \
+			Makefile src/Makefile || die
+	fi
+
+	#EPATCH_SOURCE="${FILESDIR}/${PV}" EPATCH_SUFFIX="upstream.patch" epatch
+
+	# correct lua versioning
+	sed -i -e 's/\(LIB_VERSION = \)6:1:1/\16:5:1/' src/Makefile
+
+	sed -i -e 's:\(/README\)\("\):\1.gz\2:g' doc/readme.html
+
+	if ! use deprecated ; then
+		# patches from 5.1.4 still apply
+		epatch "${FILESDIR}"/${PN}-5.1.4-deprecated.patch
+		epatch "${FILESDIR}"/${PN}-5.1.4-test.patch
+	fi
+
+	if ! use readline ; then
+		epatch "${FILESDIR}"/${PN}-${PATCH_PV}-readline.patch
+	fi
+
+	# Using dynamic linked lua is not recommended for performance
+	# reasons. http://article.gmane.org/gmane.comp.lang.lua.general/18519
+	# Mainly, this is of concern if your arch is poor with GPRs, like x86
+	# Note that this only affects the interpreter binary (named lua), not the lua
+	# compiler (built statically) nor the lua libraries (both shared and static
+	# are installed)
+	if use static ; then
+		epatch "${FILESDIR}"/${PN}-${PATCH_PV}-make_static-r1.patch
+	fi
+
+	# A slotted Lua uses different directories for headers & names for
+	# libraries, and pkgconfig should reflect that.
+	sed -r -i \
+		-e "/^INSTALL_INC=/s,(/include)$,\1/lua${SLOT}," \
+		-e "/^includedir=/s,(/include)$,\1/lua${SLOT}," \
+		-e "/^Libs:/s,((-llua)($| )),\2${SLOT}\3," \
+		-e "/^Cflags:/s,((-I..includedir.)($| )),\2/lua${SLOT}\3," \
+		"${S}"/etc/lua.pc
+
+	# custom Makefiles
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	# We want packages to find our things...
+	sed -i \
+		-e 's:/usr/local:'${EPREFIX}'/usr:' \
+		-e "s:\([/\"]\)\<lib\>:\1$(get_libdir):g" \
+		etc/lua.pc src/luaconf.h || die
+}
+
+multilib_src_compile() {
+	tc-export CC
+	myflags=
+	# what to link to liblua
+	liblibs="-lm"
+	liblibs="${liblibs} $(dlopen_lib)"
+
+	# what to link to the executables
+	mylibs=
+	if use readline; then
+		mylibs="-lreadline"
+	fi
+
+	cd src
+	emake CC="${CC}" CFLAGS="-DLUA_USE_LINUX ${CFLAGS}" \
+			RPATH="${EPREFIX}/usr/$(get_libdir)/" \
+			LUA_LIBS="${mylibs}" \
+			LIB_LIBS="${liblibs}" \
+			V=$(get_version_component_range 1-2) \
+			gentoo_all
+
+	mv lua_test ../test/lua.static
+}
+
+multilib_src_install() {
+	emake INSTALL_TOP="${ED}/usr" INSTALL_LIB="${ED}/usr/$(get_libdir)" \
+			V=${SLOT} gentoo_install
+
+	insinto /usr/$(get_libdir)/pkgconfig
+	newins etc/lua.pc lua${SLOT}.pc
+}
+
+multilib_src_install_all() {
+	dodoc HISTORY README
+	dohtml doc/*.html doc/*.png doc/*.css doc/*.gif
+
+	doicon etc/lua.ico
+
+	newman doc/lua.1 lua${SLOT}.1
+	newman doc/luac.1 luac${SLOT}.1
+}
+
+multilib_src_test() {
+	local positive="bisect cf echo env factorial fib fibfor hello printf sieve
+	sort trace-calls trace-globals"
+	local negative="readonly"
+	local test
+
+	cd "${BUILD_DIR}" || die
+	for test in ${positive}; do
+		test/lua.static test/${test}.lua || die "test $test failed"
+	done
+
+	for test in ${negative}; do
+		test/lua.static test/${test}.lua && die "test $test failed"
+	done
+}

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -708,6 +708,7 @@ app-admin/amazon-ec2-init
 # Adding Lua 5.3 to mask
 app-eselect/eselect-lua
 =dev-lang/lua-5.1.5-r103
+=dev-lang/lua-5.1.5-r104
 =dev-lang/lua-5.2.4-r2
 =dev-lang/lua-5.3.5-r2
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>

```diff
--- lua-5.1.5-r103.ebuild	2020-05-28 15:44:16.912339253 +0100
+++ lua-5.1.5-r104.ebuild	2020-11-12 01:31:16.756921646 +0000
@@ -70,6 +70,7 @@ src_prepare() {
 	# libraries, and pkgconfig should reflect that.
 	sed -r -i \
 		-e "/^INSTALL_INC=/s,(/include)$,\1/lua${SLOT}," \
+		-e "/^includedir=/s,(/include)$,\1/lua${SLOT}," \
 		-e "/^Libs:/s,((-llua)($| )),\2${SLOT}\3," \
 		-e "/^Cflags:/s,((-I..includedir.)($| )),\2/lua${SLOT}\3," \
 		"${S}"/etc/lua.pc
```