### PR TITLE
mail-filter/rspamd: fix bug with lua-lpeg and sync live

### DIFF
--- a/mail-filter/rspamd/files/rspamd-2.5-unbundle-lua.patch
+++ b/mail-filter/rspamd/files/rspamd-2.5-unbundle-lua.patch
@@ -1,22 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index bbc141170..8e3665c18 100644
+index bbc141170..7fbb1b485 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -112,7 +112,6 @@ INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/"
- 		"${CMAKE_SOURCE_DIR}/contrib/librdns"
- 		"${CMAKE_SOURCE_DIR}/contrib/aho-corasick"
- 		"${CMAKE_SOURCE_DIR}/contrib/lc-btrie"
--		"${CMAKE_SOURCE_DIR}/contrib/lua-lpeg"
- 		"${CMAKE_BINARY_DIR}/src" #Stored in the binary dir
- 		"${CMAKE_BINARY_DIR}/src/libcryptobox")
- 
-@@ -592,16 +591,11 @@ ENDIF()
- ADD_SUBDIRECTORY(contrib/libucl)
- ADD_SUBDIRECTORY(contrib/librdns)
- ADD_SUBDIRECTORY(contrib/aho-corasick)
--ADD_SUBDIRECTORY(contrib/lua-lpeg)
- ADD_SUBDIRECTORY(contrib/t1ha)
- ADD_SUBDIRECTORY(contrib/libev)
+@@ -598,10 +598,6 @@ ADD_SUBDIRECTORY(contrib/libev)
  ADD_SUBDIRECTORY(contrib/kann)
  ADD_SUBDIRECTORY(contrib/fastutf8)
  
@@ -27,27 +13,11 @@ index bbc141170..8e3665c18 100644
  IF (ENABLE_LUA_REPL MATCHES "ON")
  	ADD_SUBDIRECTORY(contrib/replxx)
  	SET(WITH_LUA_REPL 1)
-@@ -700,7 +694,6 @@ INSTALL(FILES "contrib/lua-fun/fun.lua" DESTINATION ${LUALIBDIR})
- INSTALL(FILES "contrib/lua-argparse/argparse.lua" DESTINATION ${LUALIBDIR})
- INSTALL(FILES "contrib/lua-tableshape/tableshape.lua" DESTINATION ${LUALIBDIR})
- INSTALL(FILES "contrib/lua-lupa/lupa.lua" DESTINATION ${LUALIBDIR})
--INSTALL(FILES "contrib/lua-lpeg/lpegre.lua" DESTINATION ${LUALIBDIR})
- 
- # systemd unit
- IF(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND WANT_SYSTEMD_UNITS MATCHES "ON")
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 9a34d2ac4..54b2e4083 100644
+index 9a34d2ac4..59bab5c15 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -180,7 +180,6 @@ ENDIF()
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-http-parser)
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-fpconv)
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-cdb)
--TARGET_LINK_LIBRARIES(rspamd-server rspamd-lpeg)
- TARGET_LINK_LIBRARIES(rspamd-server lcbtrie)
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-zstd)
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-fastutf8)
-@@ -189,10 +188,6 @@ IF (ENABLE_CLANG_PLUGIN MATCHES "ON")
+@@ -189,10 +189,6 @@ IF (ENABLE_CLANG_PLUGIN MATCHES "ON")
  	ADD_DEPENDENCIES(rspamd-server rspamd-clang)
  ENDIF()
  
@@ -59,18 +29,10 @@ index 9a34d2ac4..54b2e4083 100644
  	TARGET_LINK_LIBRARIES(rspamd-server stemmer)
  ENDIF()
 diff --git a/src/lua/lua_common.c b/src/lua/lua_common.c
-index ce5fff6c5..509ceeb44 100644
+index ce5fff6c5..bea6dc389 100644
 --- a/src/lua/lua_common.c
 +++ b/src/lua/lua_common.c
-@@ -14,7 +14,6 @@
-  * limitations under the License.
-  */
- #include "lua_common.h"
--#include "lptree.h"
- #include "utlist.h"
- #include "unix-std.h"
- #include "ottery.h"
-@@ -903,10 +902,6 @@ rspamd_lua_wipe_realloc (void *ud,
+@@ -903,10 +903,6 @@ rspamd_lua_wipe_realloc (void *ud,
  	return NULL;
  }
  
@@ -81,19 +43,11 @@ index ce5fff6c5..509ceeb44 100644
  lua_State *
  rspamd_lua_init (bool wipe_mem)
  {
-@@ -961,7 +956,6 @@ rspamd_lua_init (bool wipe_mem)
+@@ -961,7 +957,6 @@ rspamd_lua_init (bool wipe_mem)
  	luaopen_kann (L);
  	luaopen_spf (L);
  #ifndef WITH_LUAJIT
 -	rspamd_lua_add_preload (L, "bit", luaopen_bit);
  	lua_settop (L, 0);
  #endif
- 
-@@ -971,7 +965,6 @@ rspamd_lua_init (bool wipe_mem)
- 	rspamd_lua_new_class (L, "rspamd{session}", NULL);
- 	lua_pop (L, 1);
- 
--	rspamd_lua_add_preload (L, "lpeg", luaopen_lpeg);
- 	luaopen_ucl (L);
- 	rspamd_lua_add_preload (L, "ucl", luaopen_ucl);
  

--- a/mail-filter/rspamd/files/rspamd-2.6-unbundle-lua.patch
+++ b/mail-filter/rspamd/files/rspamd-2.6-unbundle-lua.patch
@@ -1,24 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b794b9dbd..90caf4048 100644
+index b794b9dbd..1ba5c085e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -111,7 +111,6 @@ INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/"
- 		"${CMAKE_SOURCE_DIR}/contrib/librdns"
- 		"${CMAKE_SOURCE_DIR}/contrib/aho-corasick"
- 		"${CMAKE_SOURCE_DIR}/contrib/lc-btrie"
--		"${CMAKE_SOURCE_DIR}/contrib/lua-lpeg"
- 		"${CMAKE_BINARY_DIR}/src" #Stored in the binary dir
- 		"${CMAKE_BINARY_DIR}/src/libcryptobox")
- 
-@@ -624,7 +623,6 @@ ENDIF()
- ADD_SUBDIRECTORY(contrib/libucl)
- ADD_SUBDIRECTORY(contrib/librdns)
- ADD_SUBDIRECTORY(contrib/aho-corasick)
--ADD_SUBDIRECTORY(contrib/lua-lpeg)
- ADD_SUBDIRECTORY(contrib/t1ha)
- ADD_SUBDIRECTORY(contrib/libev)
- ADD_SUBDIRECTORY(contrib/kann)
-@@ -632,10 +630,6 @@ ADD_SUBDIRECTORY(contrib/fastutf8)
+@@ -632,10 +632,6 @@ ADD_SUBDIRECTORY(contrib/fastutf8)
  ADD_SUBDIRECTORY(contrib/google-ced)
  
  
@@ -29,27 +13,11 @@ index b794b9dbd..90caf4048 100644
  IF (ENABLE_LUA_REPL MATCHES "ON")
  	ADD_SUBDIRECTORY(contrib/replxx)
  	SET(WITH_LUA_REPL 1)
-@@ -735,7 +729,6 @@ INSTALL(FILES "contrib/lua-fun/fun.lua" DESTINATION ${LUALIBDIR})
- INSTALL(FILES "contrib/lua-argparse/argparse.lua" DESTINATION ${LUALIBDIR})
- INSTALL(FILES "contrib/lua-tableshape/tableshape.lua" DESTINATION ${LUALIBDIR})
- INSTALL(FILES "contrib/lua-lupa/lupa.lua" DESTINATION ${LUALIBDIR})
--INSTALL(FILES "contrib/lua-lpeg/lpegre.lua" DESTINATION ${LUALIBDIR})
- 
- # systemd unit
- IF(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND WANT_SYSTEMD_UNITS MATCHES "ON")
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 9a34d2ac4..54b2e4083 100644
+index 9a34d2ac4..59bab5c15 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -180,7 +180,6 @@ ENDIF()
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-http-parser)
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-fpconv)
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-cdb)
--TARGET_LINK_LIBRARIES(rspamd-server rspamd-lpeg)
- TARGET_LINK_LIBRARIES(rspamd-server lcbtrie)
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-zstd)
- TARGET_LINK_LIBRARIES(rspamd-server rspamd-fastutf8)
-@@ -189,10 +188,6 @@ IF (ENABLE_CLANG_PLUGIN MATCHES "ON")
+@@ -189,10 +189,6 @@ IF (ENABLE_CLANG_PLUGIN MATCHES "ON")
  	ADD_DEPENDENCIES(rspamd-server rspamd-clang)
  ENDIF()
  
@@ -61,18 +29,10 @@ index 9a34d2ac4..54b2e4083 100644
  	TARGET_LINK_LIBRARIES(rspamd-server stemmer)
  ENDIF()
 diff --git a/src/lua/lua_common.c b/src/lua/lua_common.c
-index b7fcc2034..b8120af97 100644
+index b7fcc2034..1d86464da 100644
 --- a/src/lua/lua_common.c
 +++ b/src/lua/lua_common.c
-@@ -14,7 +14,6 @@
-  * limitations under the License.
-  */
- #include "lua_common.h"
--#include "lptree.h"
- #include "utlist.h"
- #include "unix-std.h"
- #include "ottery.h"
-@@ -922,10 +921,6 @@ rspamd_lua_wipe_realloc (void *ud,
+@@ -922,10 +922,6 @@ rspamd_lua_wipe_realloc (void *ud,
  	return NULL;
  }
  
@@ -83,19 +43,11 @@ index b7fcc2034..b8120af97 100644
  lua_State *
  rspamd_lua_init (bool wipe_mem)
  {
-@@ -981,7 +976,6 @@ rspamd_lua_init (bool wipe_mem)
+@@ -981,7 +977,6 @@ rspamd_lua_init (bool wipe_mem)
  	luaopen_spf (L);
  	luaopen_tensor (L);
  #ifndef WITH_LUAJIT
 -	rspamd_lua_add_preload (L, "bit", luaopen_bit);
  	lua_settop (L, 0);
  #endif
- 
-@@ -991,7 +985,6 @@ rspamd_lua_init (bool wipe_mem)
- 	rspamd_lua_new_class (L, "rspamd{session}", NULL);
- 	lua_pop (L, 1);
- 
--	rspamd_lua_add_preload (L, "lpeg", luaopen_lpeg);
- 	luaopen_ucl (L);
- 	rspamd_lua_add_preload (L, "ucl", luaopen_ucl);
  

--- a/mail-filter/rspamd/files/rspamd-9999-unbundle-zstd.patch
+++ b/mail-filter/rspamd/files/rspamd-9999-unbundle-zstd.patch
@@ -1,0 +1,125 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3b4bd8469..75582513e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -199,6 +199,8 @@ ELSE()
+ 		ROOT ${PCRE_ROOT_DIR} MODULES pcre libpcre pcre3 libpcre3)
+ ENDIF()
+ 
++ProcessPackage(ZSTD LIBRARY zstd INCLUDE zstd.h
++	ROOT ${ZSTD_ROOT_DIR} MODULES libzstd)
+ ProcessPackage(SQLITE3 LIBRARY sqlite3 INCLUDE sqlite3.h INCLUDE_SUFFIXES include/sqlite3 include/sqlite
+ 	ROOT ${SQLITE3_ROOT_DIR} MODULES sqlite3 sqlite)
+ ProcessPackage(ICUDATA LIBRARY icudata INCLUDE unicode/ucnv.h
+@@ -616,7 +618,6 @@ ADD_SUBDIRECTORY(contrib/http-parser)
+ ADD_SUBDIRECTORY(contrib/fpconv)
+ ADD_SUBDIRECTORY(contrib/lc-btrie)
+ ADD_SUBDIRECTORY(contrib/libottery)
+-ADD_SUBDIRECTORY(contrib/zstd)
+ IF(ENABLE_SNOWBALL MATCHES "ON")
+ 	ADD_SUBDIRECTORY(contrib/snowball)
+ 	SET(WITH_SNOWBALL 1)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 59bab5c15..098329991 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -182,7 +182,6 @@ TARGET_LINK_LIBRARIES(rspamd-server rspamd-fpconv)
+ TARGET_LINK_LIBRARIES(rspamd-server rspamd-cdb)
+ TARGET_LINK_LIBRARIES(rspamd-server rspamd-lpeg)
+ TARGET_LINK_LIBRARIES(rspamd-server lcbtrie)
+-TARGET_LINK_LIBRARIES(rspamd-server rspamd-zstd)
+ TARGET_LINK_LIBRARIES(rspamd-server rspamd-fastutf8)
+ 
+ IF (ENABLE_CLANG_PLUGIN MATCHES "ON")
+diff --git a/src/client/rspamdclient.c b/src/client/rspamdclient.c
+index bcb25672e..48ca58e94 100644
+--- a/src/client/rspamdclient.c
++++ b/src/client/rspamdclient.c
+@@ -19,7 +19,7 @@
+ #include "libserver/http/http_private.h"
+ #include "libserver/protocol_internal.h"
+ #include "unix-std.h"
+-#include "contrib/zstd/zstd.h"
++#include <zstd.h>
+ 
+ #ifdef HAVE_FETCH_H
+ #include <fetch.h>
+diff --git a/src/libserver/cfg_utils.c b/src/libserver/cfg_utils.c
+index e2f886aa6..5b214c09c 100644
+--- a/src/libserver/cfg_utils.c
++++ b/src/libserver/cfg_utils.c
+@@ -36,8 +36,7 @@
+ #include "contrib/libottery/ottery.h"
+ #include "contrib/fastutf8/fastutf8.h"
+ 
+-#define ZSTD_STATIC_LINKING_ONLY
+-#include "contrib/zstd/zstd.h"
++#include <zstd.h>
+ 
+ #ifdef HAVE_OPENSSL
+ #include <openssl/rand.h>
+diff --git a/src/libserver/maps/map.c b/src/libserver/maps/map.c
+index 14792753a..20ca8416e 100644
+--- a/src/libserver/maps/map.c
++++ b/src/libserver/maps/map.c
+@@ -23,7 +23,7 @@
+ #include "libserver/http/http_connection.h"
+ #include "libserver/http/http_private.h"
+ #include "rspamd.h"
+-#include "contrib/zstd/zstd.h"
++#include <zstd.h>
+ #include "contrib/libev/ev.h"
+ #include "contrib/uthash/utlist.h"
+ 
+diff --git a/src/libserver/protocol.c b/src/libserver/protocol.c
+index 31b0308cb..62ba3d833 100644
+--- a/src/libserver/protocol.c
++++ b/src/libserver/protocol.c
+@@ -21,7 +21,7 @@
+ #include "worker_private.h"
+ #include "libserver/cfg_file_private.h"
+ #include "libmime/scan_result_private.h"
+-#include "contrib/zstd/zstd.h"
++#include <zstd.h>
+ #include "lua/lua_common.h"
+ #include "unix-std.h"
+ #include "protocol_internal.h"
+diff --git a/src/libserver/task.c b/src/libserver/task.c
+index e7a83a603..c613fffcc 100644
+--- a/src/libserver/task.c
++++ b/src/libserver/task.c
+@@ -25,7 +25,7 @@
+ #include "stat_api.h"
+ #include "unix-std.h"
+ #include "utlist.h"
+-#include "contrib/zstd/zstd.h"
++#include <zstd.h>
+ #include "libserver/mempool_vars_internal.h"
+ #include "libserver/cfg_file_private.h"
+ #include "libmime/lang_detection.h"
+diff --git a/src/lua/lua_util.c b/src/lua/lua_util.c
+index e879d37af..88451e222 100644
+--- a/src/lua/lua_util.c
++++ b/src/lua/lua_util.c
+@@ -15,7 +15,7 @@
+  */
+ #include "lua_common.h"
+ #include "unix-std.h"
+-#include "contrib/zstd/zstd.h"
++#include <zstd.h>
+ #include "libmime/email_addr.h"
+ #include "libmime/content_type.h"
+ #include "libmime/mime_headers.h"
+diff --git a/src/rspamd_proxy.c b/src/rspamd_proxy.c
+index 3fa5da390..c641fb263 100644
+--- a/src/rspamd_proxy.c
++++ b/src/rspamd_proxy.c
+@@ -36,7 +36,7 @@
+ #include "libserver/milter.h"
+ #include "libserver/milter_internal.h"
+ #include "libmime/lang_detection.h"
+-#include "contrib/zstd/zstd.h"
++#include <zstd.h>
+ 
+ #include <math.h>
+ 

--- a/mail-filter/rspamd/rspamd-2.5-r1.ebuild
+++ b/mail-filter/rspamd/rspamd-2.5-r1.ebuild
@@ -36,11 +36,9 @@ RDEPEND="
 	jemalloc? ( dev-libs/jemalloc )
 	jit? (
 		dev-lang/luajit:2
-		dev-lua/lpeg[luajit]
 	)
 	!jit? (
 		dev-lang/lua:*
-		dev-lua/lpeg[-luajit]
 		dev-lua/LuaBitOp
 	)
 	!libressl? ( dev-libs/openssl:0=[-bindist] )
@@ -63,7 +61,7 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	rm -vrf contrib/{lua-{bit,lpeg},snowball,zstd} || die
+	rm -vrf contrib/{lua-bit,snowball,zstd} || die
 
 	sed -i -e 's/User=_rspamd/User=rspamd/g' \
 		rspamd.service \

--- a/mail-filter/rspamd/rspamd-2.6-r2.ebuild
+++ b/mail-filter/rspamd/rspamd-2.6-r2.ebuild
@@ -39,11 +39,9 @@ RDEPEND="
 	jemalloc? ( dev-libs/jemalloc )
 	jit? (
 		dev-lang/luajit:2
-		dev-lua/lpeg[luajit]
 	)
 	!jit? (
 		dev-lang/lua:*
-		dev-lua/lpeg[-luajit]
 		dev-lua/LuaBitOp
 	)
 	!libressl? ( dev-libs/openssl:0=[-bindist] )
@@ -65,7 +63,7 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	rm -vrf contrib/{lua-{bit,lpeg},snowball,zstd} || die
+	rm -vrf contrib/{lua-bit,snowball,zstd} || die
 
 	sed -i -e 's/User=_rspamd/User=rspamd/g' \
 		rspamd.service \

--- a/mail-filter/rspamd/rspamd-9999.ebuild
+++ b/mail-filter/rspamd/rspamd-9999.ebuild
@@ -39,11 +39,9 @@ RDEPEND="
 	jemalloc? ( dev-libs/jemalloc )
 	jit? (
 		dev-lang/luajit:2
-		dev-lua/lpeg[luajit]
 	)
 	!jit? (
 		dev-lang/lua:*
-		dev-lua/lpeg[-luajit]
 		dev-lua/LuaBitOp
 	)
 	!libressl? ( dev-libs/openssl:0=[-bindist] )
@@ -58,14 +56,14 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/rspamd-2.6-unbundle-lua.patch"
-	"${FILESDIR}/rspamd-2.6-unbundle-zstd.patch"
+	"${FILESDIR}/rspamd-9999-unbundle-zstd.patch"
 	"${FILESDIR}/rspamd-2.5-unbundle-snowball.patch"
 )
 
 src_prepare() {
 	cmake_src_prepare
 
-	rm -vrf contrib/{lua-{bit,lpeg},snowball,zstd} || die
+	rm -vrf contrib/{lua-bit,snowball,zstd} || die
 
 	sed -i -e 's/User=_rspamd/User=rspamd/g' \
 		rspamd.service \


### PR DESCRIPTION
The bundled lua-lpeg has some modifications necessary to work properly (see https://github.com/rspamd/rspamd/issues/3533). I also synced the live ebuild.