### PR TITLE
sys-fs/clamfs: don't use Werror

### DIFF
--- a/sys-fs/clamfs/clamfs-1.2.0.ebuild
+++ b/sys-fs/clamfs/clamfs-1.2.0.ebuild
@@ -22,6 +22,8 @@ RDEPEND="${DEPEND}
 CONFIG_CHECK="~FUSE_FS"
 
 src_prepare() {
+	# Do not use Werror ( #754180 )
+	sed -i 's/\-Werror//g' configure.ac || die "Sed failed"
 	default
 	eautoreconf
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/754180
