### PR TITLE
media-libs/openimageio: Make sci-libs/dcmtk dependency optional (bug #754216)

### DIFF
--- a/media-libs/openimageio/openimageio-2.2.8.0-r1.ebuild
+++ b/media-libs/openimageio/openimageio-2.2.8.0-r1.ebuild
@@ -21,7 +21,7 @@ X86_CPU_FEATURES=(
 )
 CPU_FEATURES=( ${X86_CPU_FEATURES[@]/#/cpu_flags_x86_} )
 
-IUSE="doc ffmpeg field3d gif jpeg2k opencv opengl openvdb ptex python qt5 raw +truetype ${CPU_FEATURES[@]%:*}"
+IUSE="dicom doc ffmpeg field3d gif jpeg2k opencv opengl openvdb ptex python qt5 raw +truetype ${CPU_FEATURES[@]%:*}"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 # test data in separate repo
@@ -50,7 +50,7 @@ RDEPEND="
 	media-libs/opencolorio:=
 	>=media-libs/openexr-2.2.0-r2:=
 	media-libs/tiff:0=
-	sci-libs/dcmtk
+	dicom? ( sci-libs/dcmtk )
 	sys-libs/zlib:=
 	virtual/jpeg:0
 	ffmpeg? ( media-video/ffmpeg:= )
@@ -118,6 +118,7 @@ src_configure() {
 		-DUSE_EXTERNAL_PUGIXML=ON
 		-DUSE_JPEGTURBO=ON
 		-DUSE_NUKE=OFF # not in Gentoo
+		-DUSE_DCMTK=$(usex dicom)
 		-DUSE_FFMPEG=$(usex ffmpeg)
 		-DUSE_FIELD3D=$(usex field3d)
 		-DUSE_GIF=$(usex gif)


### PR DESCRIPTION
As title. Reference https://bugs.gentoo.org/754216 .