### PR TITLE
dev-libs/rocm-device-libs: Correcting install location according to FHS

### DIFF
--- a/dev-libs/rocm-device-libs/rocm-device-libs-3.9.0.ebuild
+++ b/dev-libs/rocm-device-libs/rocm-device-libs-3.9.0.ebuild
@@ -24,6 +24,12 @@ SLOT="0/$(ver_cut 1-2)"
 RDEPEND=">=sys-devel/llvm-roc-${PV}:="
 DEPEND="${RDEPEND}"
 
+src_prepare() {
+	sed -e "s:amdgcn/bitcode:lib/amdgcn/bitcode:" -i "${S}/cmake/OCL.cmake" || die
+	sed -e "s:amdgcn/bitcode:lib/amdgcn/bitcode:" -i "${S}/cmake/Packages.cmake" || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLLVM_DIR="${EPREFIX}/usr/lib/llvm/roc/lib/cmake/llvm"


### PR DESCRIPTION
Signed-off-by: Wilfried Holzke <gentoo@holzke.net>
Package-Manager: Portage-3.0.8, Repoman-3.0.2