### PR TITLE
sys-apps/firejail: Disabled nonworking tests

### DIFF
--- a/sys-apps/firejail/firejail-0.9.64.ebuild
+++ b/sys-apps/firejail/firejail-0.9.64.ebuild
@@ -48,6 +48,11 @@ src_prepare() {
 	if use contrib; then
 		python_fix_shebang -f contrib/*.py
 	fi
+
+	# some tests were missing from this release's tarball
+	if use test; then
+		sed -i -r -e 's/^(test:.*) test-private-lib (.*)/\1 \2/; s/^(test:.*) test-fnetfilter (.*)/\1 \2/' Makefile.in || die
+	fi
 }
 
 src_configure() {


### PR DESCRIPTION
Skip some tests that were not included in this version of the release
tarball.

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/753991
Package-Manager: Portage-3.0.9, Repoman-3.0.2