### PR TITLE
dev-python/pytest-xvfb: fix tests

### DIFF
--- a/dev-python/pytest-xvfb/pytest-xvfb-2.0.0.ebuild
+++ b/dev-python/pytest-xvfb/pytest-xvfb-2.0.0.ebuild
@@ -24,6 +24,10 @@ DEPEND="
 distutils_enable_tests pytest
 
 python_test() {
-	distutils_install_for_testing
-	pytest -vv || die "Tests failed with ${EPYTHON}"
+	local -x PYTHONPATH=${BUILD_DIR}/install/lib
+	esetup.py install \
+		--root="${BUILD_DIR}"/install \
+		--install-lib=lib
+
+	pytest -vv || die "Tests fail with ${EPYTHON}"
 }


### PR DESCRIPTION
tests do not work at all if the package is
not already installed to the system

Closes: https://bugs.gentoo.org/754270
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>