### PR TITLE
media-libs/openimageio-2.2.8.0: Re-introduce dicom USE-flag

### DIFF
--- a/media-libs/openimageio/openimageio-2.2.8.0.ebuild
+++ b/media-libs/openimageio/openimageio-2.2.8.0.ebuild
@@ -21,7 +21,7 @@ X86_CPU_FEATURES=(
 )
 CPU_FEATURES=( ${X86_CPU_FEATURES[@]/#/cpu_flags_x86_} )
 
-IUSE="doc ffmpeg field3d gif jpeg2k opencv opengl openvdb ptex python qt5 raw +truetype ${CPU_FEATURES[@]%:*}"
+IUSE="dicom doc ffmpeg field3d gif jpeg2k opencv opengl openvdb ptex python qt5 raw +truetype ${CPU_FEATURES[@]%:*}"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 # test data in separate repo
@@ -50,7 +50,7 @@ RDEPEND="
 	media-libs/opencolorio:=
 	>=media-libs/openexr-2.2.0-r2:=
 	media-libs/tiff:0=
-	sci-libs/dcmtk
+	dicom? ( sci-libs/dcmtk )
 	sys-libs/zlib:=
 	virtual/jpeg:0
 	ffmpeg? ( media-video/ffmpeg:= )
@@ -116,6 +116,7 @@ src_configure() {
 		-DINSTALL_DOCS=$(usex doc)
 		-DSTOP_ON_WARNING=OFF
 		-DUSE_EXTERNAL_PUGIXML=ON
+		-DUSE_DCMTK=$(usex dicom)
 		-DUSE_JPEGTURBO=ON
 		-DUSE_NUKE=OFF # not in Gentoo
 		-DUSE_FFMPEG=$(usex ffmpeg)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/754216
Signed-off-by: Jaak Ristioja <jaak@ristioja.ee>

I also certify that while the changes are identical to those in PR #18236, it was developed independently before I discovered that pull request.