### PR TITLE
app-crypt/tpm2-tss: Fix building with autoconf-2.70

### DIFF
--- a/app-crypt/tpm2-tss/files/tpm2-tss-3.0.1-Fix-underquoting-in-configure-ac.patch
+++ b/app-crypt/tpm2-tss/files/tpm2-tss-3.0.1-Fix-underquoting-in-configure-ac.patch
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index ff59dd7c..3049032b 100755
+--- a/configure.ac
++++ b/configure.ac
+@@ -285,7 +285,7 @@ AC_ARG_ENABLE([integration],
+         [build and execute integration tests])],,
+     [enable_integration=no])
+ AS_IF([test "x$enable_integration" = "xyes"],
+-     AS_IF([test "$HOSTOS" = "Linux"],
++     [AS_IF([test "$HOSTOS" = "Linux"],
+            [ERROR_IF_NO_PROG([ss])],
+            [ERROR_IF_NO_PROG([sockstat])])
+        ERROR_IF_NO_PROG([echo])
+@@ -335,7 +335,7 @@ AS_IF([test "x$enable_integration" = "xyes"],
+              [AC_MSG_ERROR([No simulator executable found in PATH for testing TCTI.])])
+        AC_SUBST([INTEGRATION_TCTI], [$integration_tcti])
+        AC_SUBST([INTEGRATION_ARGS], [$integration_args])
+-       AC_SUBST([ENABLE_INTEGRATION], [$enable_integration]))
++       AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])])
+ AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
+ #
+ # sanitizer compiler flags

--- a/app-crypt/tpm2-tss/tpm2-tss-3.0.1.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-3.0.1.ebuild
@@ -32,6 +32,7 @@ BDEPEND="virtual/pkgconfig
 
 PATCHES=(
 	"${FILESDIR}/${PN}-3.0.0-Dont-run-systemd-sysusers-in-Makefile.patch"
+	"${FILESDIR}/${P}-Fix-underquoting-in-configure-ac.patch"
 )
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/750845
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Signed-off-by: Salah Coronya <salah.coronya@gmail.com>

Using trial and error, I was able to figure out the problem, I think. Someone with more autotools experience should double-check, but based on my limited knowledge of autoconf, the fix seems correct. 