### PR TITLE
dev-libs/rocr-runtime: Fix dependency due to changed location of bitcode [please reassign]

### DIFF
--- a/dev-libs/rocr-runtime/rocr-runtime-3.8.0.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-3.8.0.ebuild
@@ -29,7 +29,7 @@ COMMON_DEPEND="sys-process/numactl
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
-	>=dev-libs/rocm-device-libs-${PV}"
+	~dev-libs/rocm-device-libs-${PV}"
 BDEPEND="app-editors/vim-core"
 	# vim-core is needed for "xxd"
 


### PR DESCRIPTION
Signed-off-by: Wilfried Holzke <gentoo@holzke.net>
Package-Manager: Portage-3.0.8, Repoman-3.0.2
Closes: https://bugs.gentoo.org/754351