### PR TITLE
dev-python/cherrypy: Drop Python 2 specific patches

### DIFF
--- a/dev-python/cherrypy/cherrypy-18.6.0.ebuild
+++ b/dev-python/cherrypy/cherrypy-18.6.0.ebuild
@@ -43,10 +43,6 @@ BDEPEND="
 distutils_enable_tests pytest
 
 python_prepare_all() {
-	# UnicodeEncodeError: 'ascii' codec can't encode character u'\u2603' in position 0: ordinal not in range(128)
-	sed -e 's|@pytest.mark.xfail(py27_on_windows|@pytest.mark.xfail(sys.version_info < (3,)|' \
-		-i cherrypy/test/test_static.py || die
-
 	# fragile, fails with newer versions of CPython
 	sed -e 's:testCombinedTools:_&:' \
 		-i cherrypy/test/test_tools.py || die


### PR DESCRIPTION
CherryPy 18+ is Python 3 only, plus `PYTHON_COMPAT` is set to py3.6-py3.9 so no Python 2 specific patches are necessary.