### PR TITLE
media-libs/mesa: add video_cards_v3d to vulkan support list

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -259,8 +259,9 @@ pkg_pretend() {
 	if use vulkan; then
 		if ! use video_cards_i965 &&
 		   ! use video_cards_iris &&
-		   ! use video_cards_radeonsi; then
-			ewarn "Ignoring USE=vulkan     since VIDEO_CARDS does not contain i965, iris, or radeonsi"
+		   ! use video_cards_radeonsi &&
+		   ! use video_cards_v3d; then
+			ewarn "Ignoring USE=vulkan     since VIDEO_CARDS does not contain i965, iris, radeonsi, or v3d"
 		fi
 	fi
 
@@ -473,6 +474,7 @@ multilib_src_configure() {
 		vulkan_enable video_cards_i965 intel
 		vulkan_enable video_cards_iris intel
 		vulkan_enable video_cards_radeonsi amd
+		vulkan_enable video_cards_v3d broadcom
 	fi
 
 	if use gallium; then


### PR DESCRIPTION
Raspberry Pi's V3DV Vulkan Driver has now landed in mainline Mesa
and this PR allows V3DV vulkan driver to be built in live version.

Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Ross Charles Campbell <rossbridger.cc@gmail.com>