### PR TITLE
x11-wm/i3: Use meson_src_install explicitly

### DIFF
--- a/x11-wm/i3/i3-4.19-r1.ebuild
+++ b/x11-wm/i3/i3-4.19-r1.ebuild
@@ -14,7 +14,7 @@ if [[ "${PV}" = *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/i3/i3"
 	EGIT_BRANCH="next"
 else
-	SRC_URI="https://i3wm.org/downloads/${P}.tar.bz2"
+	SRC_URI="https://i3wm.org/downloads/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/755032
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Nelo-T. Wallus <nelo@wallus.de>