### PR TITLE
dev-qt/qtnetwork doesn't support old openssl

### DIFF
--- a/dev-qt/qtnetwork/qtnetwork-5.15.1.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.1.ebuild
@@ -22,7 +22,7 @@ DEPEND="
 	networkmanager? ( ~dev-qt/qtdbus-${PV} )
 	sctp? ( kernel_linux? ( net-misc/lksctp-tools ) )
 	ssl? (
-		!libressl? ( >=dev-libs/openssl-1.1.1:0/1.1=[bindist=] )
+		!libressl? ( >=dev-libs/openssl-1.1.1:=[bindist=] )
 		libressl? ( dev-libs/libressl:0= )
 	)
 "

--- a/dev-qt/qtnetwork/qtnetwork-5.15.1.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.1.ebuild
@@ -22,7 +22,7 @@ DEPEND="
 	networkmanager? ( ~dev-qt/qtdbus-${PV} )
 	sctp? ( kernel_linux? ( net-misc/lksctp-tools ) )
 	ssl? (
-		!libressl? ( dev-libs/openssl:0/1.1=[bindist=] )
+		!libressl? ( >=dev-libs/openssl-1.1.1:0/1.1=[bindist=] )
 		libressl? ( dev-libs/libressl:0= )
 	)
 "

--- a/dev-qt/qtnetwork/qtnetwork-5.15.1.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.1.ebuild
@@ -22,7 +22,7 @@ DEPEND="
 	networkmanager? ( ~dev-qt/qtdbus-${PV} )
 	sctp? ( kernel_linux? ( net-misc/lksctp-tools ) )
 	ssl? (
-		!libressl? ( dev-libs/openssl:0=[bindist=] )
+		!libressl? ( dev-libs/openssl:0/1.1=[bindist=] )
 		libressl? ( dev-libs/libressl:0= )
 	)
 "


### PR DESCRIPTION
I've found reason here

```json
"openssl_headers": {
    "label": "OpenSSL Headers",
    "export": "openssl",
    "test": {
        "tail": [
            "#if !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER-0 < 0x10101000L",
            "#  error OpenSSL >= 1.1.1 is required",
            "#endif",
            "#if !defined(OPENSSL_NO_EC) && !defined(SSL_CTRL_SET_CURVES)",
            "#  error OpenSSL was reported as >= 1.1.1 but is missing required features, possibly it's libressl which is unsupported",
            "#endif"
        ]
    },
```