### PR TITLE
app-shells/yash: Install the binary to /bin like other shells.

### DIFF
--- a/app-shells/yash/yash-2.50.ebuild
+++ b/app-shells/yash/yash-2.50.ebuild
@@ -27,6 +27,7 @@ src_configure() {
 
 	sh ./configure \
 		--prefix="${EPREFIX}"/usr \
+		--bindir="${EPREFIX}"/bin \
 		$(use_enable nls) \
 		CC=$(tc-getCC) \
 		LINGUAS="$(l10n_get_locales | sed "s/en/en@quot en@boldquot/")" \


### PR DESCRIPTION
Its better to have `/bin/yash` like other shells such as `bash` or `mksh` than `/usr/bin/yash`.