### PR TITLE
sys-apps/firejail: restored removed USE flag description

### DIFF
--- a/sys-apps/firejail/metadata.xml
+++ b/sys-apps/firejail/metadata.xml
@@ -33,5 +33,6 @@
 		<flag name="private-home">Enable private home feature</flag>
 		<flag name="userns">Enable attaching a new user namespace to a sandbox (--noroot option)</flag>
 		<flag name="whitelist">Enable whitelist</flag>
+		<flag name="X">Enable X11 sandboxing</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Restored and renamed the old 'x11' USE flag description now that that
flag has been renamed to 'X'.

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Package-Manager: Portage-3.0.9, Repoman-3.0.2