### PR TITLE
app-editors/neovim: add dev-libs/treesitter as dep

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -37,6 +37,7 @@ DEPEND="
 	dev-libs/libuv:0=
 	>=dev-libs/libvterm-0.1.2
 	dev-libs/msgpack:0=
+	dev-libs/tree-sitter:=
 	dev-lua/lpeg[luajit=]
 	dev-lua/luv[luajit=]
 	dev-lua/mpack[luajit=]


### PR DESCRIPTION
https://bugs.gentoo.org/753272