### PR TITLE
app-editors/gedit-plugins: fix build with USE=-python

### DIFF
--- a/app-editors/gedit-plugins/gedit-plugins-3.36.2.ebuild
+++ b/app-editors/gedit-plugins/gedit-plugins-3.36.2.ebuild
@@ -94,7 +94,7 @@ src_configure() {
 
 src_install() {
 	meson_src_install
-	python_optimize "${ED}/usr/$(get_libdir)/gedit/plugins/"
+	use python && python_optimize "${ED}/usr/$(get_libdir)/gedit/plugins/"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/721846

Simple build fix doesn't requires revision bump as I remember