### PR TITLE
app-misc/dateutils: add upstream info to metadata

### DIFF
--- a/app-misc/dateutils/metadata.xml
+++ b/app-misc/dateutils/metadata.xml
@@ -1,15 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>coppens.matthias.abc@gmail.com</email>
-		<name>Matthias Coppens</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
-	<upstream>
-		<remote-id type="bitbucket">hroptatyr/dateutils</remote-id>
-	</upstream>
+    <maintainer type="person">
+        <email>coppens.matthias.abc@gmail.com</email>
+        <name>Matthias Coppens</name>
+    </maintainer>
+    <maintainer type="project">
+        <email>proxy-maint@gentoo.org</email>
+        <name>Proxy Maintainers</name>
+    </maintainer>
+    <upstream>
+        <maintainer>
+            <name>Sebastian Freundt</name>
+            <email>devel@fresse.org</email>
+        </maintainer>
+        <changelog>https://www.fresse.org/dateutils/changelog.html</changelog>
+        <doc>https://www.fresse.org/dateutils/#examples</doc>
+        <remote-id type="github">hroptatyr/dateutils</remote-id>
+        <remote-id type="bitbucket">hroptatyr/dateutils</remote-id>
+    </upstream>
 </pkgmetadata>
+


### PR DESCRIPTION
Package-Manager: Portage-3.0.10, Repoman-3.0.2
Signed-off-by: Matthias Coppens <coppens.matthias.abc@gmail.com>