### PR TITLE
app-i18n/uchardet: Add upstream info to metadata

### DIFF
--- a/app-i18n/uchardet/metadata.xml
+++ b/app-i18n/uchardet/metadata.xml
@@ -11,5 +11,7 @@
     </maintainer>
     <upstream>
         <bugs-to>https://gitlab.freedesktop.org/uchardet/uchardet/-/issues</bugs-to>
+        <doc>https://www.freedesktop.org/wiki/Software/uchardet/#usage</doc>
+        <remote-id type="gitlab">uchardet/uchardet</remote-id>
     </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Package-Manager: Portage-3.0.10, Repoman-3.0.2
Signed-off-by: Matthias Coppens <coppens.matthias.abc@gmail.com>