### PR TITLE
mail-client/neomutt: fix live ebuild src dir

### DIFF
--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -8,7 +8,6 @@ inherit eutils
 if [[ ${PV} =~ 99999999$ ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/neomutt/neomutt.git"
-	EGIT_CHECKOUT_DIR="${WORKDIR}/neomutt-${P}"
 else
 	SRC_URI="https://github.com/${PN}/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~ppc64 ~x86"


### PR DESCRIPTION
Commit e4ef3e09eaf dropped the assignment of "S", changing its value from
"${WORKDIR}/${PN}-${P}" to the default value of "${WORKDIR}/${P}".
However, the live ebuild still checkouts out source code to previous
location so portage says the source directory doesn't exist.

This commit drops the custom checkout directory and uses the default
value provided, which corresponds to the default value of "S".

Closes: https://bugs.gentoo.org/756166

Signed-off-by: Austin Ray <austin@austinray.io>