### PR TITLE
media-sound/pulseaudio fixes

### DIFF
--- a/media-sound/pulseaudio/files/pulseaudio-13.99.3-avoid_bashisms.patch
+++ b/media-sound/pulseaudio/files/pulseaudio-13.99.3-avoid_bashisms.patch
@@ -1,0 +1,20 @@
+--- pulseaudio-13.99.3/configure.ac
++++ pulseaudio-13.99.3/configure.ac
+@@ -1481,7 +1481,7 @@
+ 
+ AC_ARG_ENABLE([stream-restore-clear-old-devices],
+     AS_HELP_STRING([--enable-stream-restore-clear-old-devices], [Forget per-stream routing settings that have been set before version 14.0. Recommended when using GNOME. See https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/832]))
+-if test "x$enable_stream_restore_clear_old_devices" == "xyes" ; then
++if test "x$enable_stream_restore_clear_old_devices" = "xyes" ; then
+     AC_DEFINE(STREAM_RESTORE_CLEAR_OLD_DEVICES, [1], [module-stream-restore: Clear old devices])
+ fi
+ 
+@@ -1661,7 +1661,7 @@
+ AS_IF([test "x$HAVE_GCOV" = "x1"], ENABLE_GCOV=yes, ENABLE_GCOV=no)
+ AS_IF([test "x$HAVE_LIBCHECK" = "x1"], ENABLE_TESTS=yes, ENABLE_TESTS=no)
+ AS_IF([test "x$enable_legacy_database_entry_format" != "xno"], ENABLE_LEGACY_DATABASE_ENTRY_FORMAT=yes, ENABLE_LEGACY_DATABASE_ENTRY_FORMAT=no)
+-AS_IF([test "x$enable_stream_restore_clear_old_devices" == "xyes"], ENABLE_STREAM_RESTORE_CLEAR_OLD_DEVICES=yes, ENABLE_STREAM_RESTORE_CLEAR_OLD_DEVICES=no)
++AS_IF([test "x$enable_stream_restore_clear_old_devices" = "xyes"], ENABLE_STREAM_RESTORE_CLEAR_OLD_DEVICES=yes, ENABLE_STREAM_RESTORE_CLEAR_OLD_DEVICES=no)
+ 
+ echo "
+  ---{ $PACKAGE_NAME $VERSION }---

--- a/media-sound/pulseaudio/pulseaudio-13.0-r1.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-13.0-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit autotools bash-completion-r1 flag-o-matic gnome2-utils linux-info systemd udev multilib-minimal
+inherit autotools bash-completion-r1 flag-o-matic gnome2-utils linux-info systemd toolchain-funcs udev multilib-minimal
 
 DESCRIPTION="A networked sound server with an advanced plugin system"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
@@ -197,10 +197,11 @@ multilib_src_configure() {
 	)
 
 	if use elogind && multilib_is_native_abi; then
+		local PKGCONFIG="$(tc-getPKG_CONFIG)"
 		myconf+=(
 			--enable-systemd-login
-			SYSTEMDLOGIN_CFLAGS=`pkg-config --cflags "libelogind" 2>/dev/null`
-			SYSTEMDLOGIN_LIBS=`pkg-config --libs "libelogind" 2>/dev/null`
+			SYSTEMDLOGIN_CFLAGS="$(${PKGCONFIG} --cflags "libelogind" 2>/dev/null)"
+			SYSTEMDLOGIN_LIBS="$(${PKGCONFIG} --libs "libelogind" 2>/dev/null)"
 		)
 	fi
 

--- a/media-sound/pulseaudio/pulseaudio-13.0-r1.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-13.0-r1.ebuild
@@ -123,6 +123,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/pulseaudio-11.1-disable-flat-volumes.patch # bug 627894
+	"${FILESDIR}"/${PN}-13.99.3-avoid_bashisms.patch
 )
 
 pkg_pretend() {

--- a/media-sound/pulseaudio/pulseaudio-13.0.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-13.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit autotools bash-completion-r1 flag-o-matic gnome2-utils linux-info systemd user udev multilib-minimal
+inherit autotools bash-completion-r1 flag-o-matic gnome2-utils linux-info systemd toolchain-funcs user udev multilib-minimal
 
 DESCRIPTION="A networked sound server with an advanced plugin system"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
@@ -202,10 +202,11 @@ multilib_src_configure() {
 	)
 
 	if use elogind && multilib_is_native_abi; then
+		local PKGCONFIG="$(tc-getPKG_CONFIG)"
 		myconf+=(
 			--enable-systemd-login
-			SYSTEMDLOGIN_CFLAGS=`pkg-config --cflags "libelogind" 2>/dev/null`
-			SYSTEMDLOGIN_LIBS=`pkg-config --libs "libelogind" 2>/dev/null`
+			SYSTEMDLOGIN_CFLAGS="$(${PKGCONFIG} --cflags "libelogind" 2>/dev/null)"
+			SYSTEMDLOGIN_LIBS="$(${PKGCONFIG} --libs "libelogind" 2>/dev/null)"
 		)
 	fi
 

--- a/media-sound/pulseaudio/pulseaudio-13.0.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-13.0.ebuild
@@ -120,6 +120,7 @@ RDEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/pulseaudio-11.1-disable-flat-volumes.patch # bug 627894
+	"${FILESDIR}"/${PN}-13.99.3-avoid_bashisms.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
The first commit fixes [bug #756196](https://bugs.gentoo.org/756196) by correctly quoting `SYSTEMDLOGIN_CFLAGS` and `SYSTEMDLOGIN_LIBS`.
The second commit fixes configure with non-bash shell (two bashisms haven been removed).