### PR TITLE
media-gfx/openscad: fix build issue with cgal-5.1

### DIFF
--- a/media-gfx/openscad/openscad-2019.05-r3.ebuild
+++ b/media-gfx/openscad/openscad-2019.05-r3.ebuild
@@ -46,7 +46,7 @@ RDEPEND="
 	>=media-libs/glew-2.0.0:0=
 	media-libs/harfbuzz:=
 	media-libs/lib3mf
-	sci-mathematics/cgal:=
+	<sci-mathematics/cgal-5:=
 	>=x11-libs/qscintilla-2.10.3:=
 	emacs? ( >=app-editors/emacs-23.1:* )
 "


### PR DESCRIPTION
For now use <sci-mathematics/cgal-5 due to a failure
with current cgal-5.1.
Issue reported upstream, see
https://github.com/openscad/openscad/issues/3497

Closes: https://bugs.gentoo.org/755842
Package-Manager: Portage-3.0.10, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>