### PR TITLE
net-dns/dnscrypt-proxy log rotation needs a hard restart

### DIFF
--- a/net-dns/dnscrypt-proxy/files/dnscrypt-proxy.logrotate
+++ b/net-dns/dnscrypt-proxy/files/dnscrypt-proxy.logrotate
@@ -1,6 +1,9 @@
 /var/log/dnscrypt-proxy/*.log {
 	su dnscrypt-proxy dnscrypt-proxy
-	copytruncate
 	missingok
 	notifempty
+        sharedscripts
+        postrotate
+                /etc/init.d/dnscrypt-proxy restart > /dev/null
+        endscript
 }


### PR DESCRIPTION
There is a race condition where copytruncate  causes dnscrypt-proxy to end up with a logfile it is writing to that is not truncated, since it could be in the middle of a write (dnscrypt-proxy's file descriptor is still to the middle of the logfile, I believe).  The logfile ends up having a bunch of null data at the beginning as it continues to write to it.  This has happened multiples times on different machines for me.  It's much safer to do a hard restart after a normal rotation.