### PR TITLE
x11-wm/i3: sync ebuild with i3-gaps

### DIFF
--- a/x11-wm/i3/files/i3-gaps-4.19-fix-docdir.patch
+++ b/x11-wm/i3/files/i3-gaps-4.19-fix-docdir.patch
@@ -1,0 +1,22 @@
+diff --git a/meson.build b/meson.build
+index 11541e21..a6f8974e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -642,7 +642,7 @@ if get_option('docs')
+       '@OUTPUT@',
+     ],
+     install: true,
+-    install_dir: join_paths(get_option('datadir'), 'doc', 'i3'),
++    install_dir: docdir,
+   )
+ 
+   custom_target(
+@@ -655,7 +655,7 @@ if get_option('docs')
+       '@OUTPUT@',
+     ],
+     install: true,
+-    install_dir: join_paths(get_option('datadir'), 'doc', 'i3'),
++    install_dir: docdir,
+   )
+ endif
+ 

--- a/x11-wm/i3/i3-4.19-r1.ebuild
+++ b/x11-wm/i3/i3-4.19-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson virtualx
+inherit meson optfeature virtualx
 if [[ "${PV}" = *9999 ]]; then
 	inherit git-r3
 fi
@@ -22,7 +22,7 @@ LICENSE="BSD"
 SLOT="0"
 IUSE="doc test"
 
-CDEPEND="dev-libs/libev
+COMMON_DEPEND="dev-libs/libev
 	dev-libs/libpcre
 	dev-libs/yajl
 	x11-libs/libxcb[xkb]
@@ -36,7 +36,7 @@ CDEPEND="dev-libs/libev
 	x11-misc/xkeyboard-config
 	x11-libs/cairo[X,xcb(+)]
 	x11-libs/pango[X]"
-DEPEND="${CDEPEND}
+DEPEND="${COMMON_DEPEND}
 	test? (
 		dev-perl/AnyEvent
 		dev-perl/X11-XCB
@@ -54,7 +54,7 @@ DEPEND="${CDEPEND}
 		app-text/xmlto
 		dev-lang/perl
 	)"
-RDEPEND="${CDEPEND}
+RDEPEND="${COMMON_DEPEND}
 	dev-lang/perl
 	dev-perl/AnyEvent-I3
 	dev-perl/JSON-XS"
@@ -62,6 +62,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-4.16-musl-GLOB_TILDE.patch"
+	"${FILESDIR}/i3-gaps-4.19-fix-docdir.patch"
 )
 
 src_prepare() {
@@ -75,6 +76,7 @@ src_prepare() {
 
 src_configure() {
 	local emesonargs=(
+		-Ddocdir="/usr/share/doc/${PF}"
 		$(meson_use doc docs)
 		$(meson_use doc mans)
 	)
@@ -94,13 +96,10 @@ src_test() {
 }
 
 pkg_postinst() {
-	# Only show the elog information on a new install
-	if [[ ! ${REPLACING_VERSIONS} ]]; then
-		elog "There are several packages that you may find useful with ${PN} and"
-		elog "their usage is suggested by the upstream maintainers, namely:"
-		elog "  x11-misc/dmenu"
-		elog "  x11-misc/i3status"
-		elog "  x11-misc/i3lock"
-		elog "Please refer to their description for additional info."
-	fi
+	elog "There are several packages that you may find useful with i3 and"
+	elog "their usage is suggested by the upstream maintainers."
+	elog "Uninstalled optional dependencies:"
+	optfeature "Application launcher" x11-misc/dmenu
+	optfeature "Simple screen locker" x11-misc/i3lock
+	optfeature "Status bar generator" x11-misc/i3status
 }

--- a/x11-wm/i3/i3-9999.ebuild
+++ b/x11-wm/i3/i3-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson virtualx
+inherit meson optfeature virtualx
 if [[ "${PV}" = *9999 ]]; then
 	inherit git-r3
 fi
@@ -22,7 +22,7 @@ LICENSE="BSD"
 SLOT="0"
 IUSE="doc test"
 
-CDEPEND="dev-libs/libev
+COMMON_DEPEND="dev-libs/libev
 	dev-libs/libpcre
 	dev-libs/yajl
 	x11-libs/libxcb[xkb]
@@ -36,7 +36,7 @@ CDEPEND="dev-libs/libev
 	x11-misc/xkeyboard-config
 	x11-libs/cairo[X,xcb(+)]
 	x11-libs/pango[X]"
-DEPEND="${CDEPEND}
+DEPEND="${COMMON_DEPEND}
 	test? (
 		dev-perl/AnyEvent
 		dev-perl/X11-XCB
@@ -54,7 +54,7 @@ DEPEND="${CDEPEND}
 		app-text/xmlto
 		dev-lang/perl
 	)"
-RDEPEND="${CDEPEND}
+RDEPEND="${COMMON_DEPEND}
 	dev-lang/perl
 	dev-perl/AnyEvent-I3
 	dev-perl/JSON-XS"
@@ -75,6 +75,7 @@ src_prepare() {
 
 src_configure() {
 	local emesonargs=(
+		-Ddocdir="/usr/share/doc/${PF}"
 		$(meson_use doc docs)
 		$(meson_use doc mans)
 	)
@@ -94,13 +95,10 @@ src_test() {
 }
 
 pkg_postinst() {
-	# Only show the elog information on a new install
-	if [[ ! ${REPLACING_VERSIONS} ]]; then
-		elog "There are several packages that you may find useful with ${PN} and"
-		elog "their usage is suggested by the upstream maintainers, namely:"
-		elog "  x11-misc/dmenu"
-		elog "  x11-misc/i3status"
-		elog "  x11-misc/i3lock"
-		elog "Please refer to their description for additional info."
-	fi
+	elog "There are several packages that you may find useful with i3 and"
+	elog "their usage is suggested by the upstream maintainers."
+	elog "Uninstalled optional dependencies:"
+	optfeature "Application launcher" x11-misc/dmenu
+	optfeature "Simple screen locker" x11-misc/i3lock
+	optfeature "Status bar generator" x11-misc/i3status
 }


### PR DESCRIPTION
```diff
--- x11-wm/i3/i3-4.19-r1.ebuild	2020-11-24 08:52:39.924768517 +0200
+++ /var/db/repos/gentoo/x11-wm/i3/i3-4.19-r1.ebuild	2020-11-17 20:14:38.254770796 +0200
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson optfeature virtualx
+inherit meson virtualx
 if [[ "${PV}" = *9999 ]]; then
 	inherit git-r3
 fi
@@ -22,7 +22,7 @@
 SLOT="0"
 IUSE="doc test"
 
-COMMON_DEPEND="dev-libs/libev
+CDEPEND="dev-libs/libev
 	dev-libs/libpcre
 	dev-libs/yajl
 	x11-libs/libxcb[xkb]
@@ -36,7 +36,7 @@
 	x11-misc/xkeyboard-config
 	x11-libs/cairo[X,xcb(+)]
 	x11-libs/pango[X]"
-DEPEND="${COMMON_DEPEND}
+DEPEND="${CDEPEND}
 	test? (
 		dev-perl/AnyEvent
 		dev-perl/X11-XCB
@@ -54,7 +54,7 @@
 		app-text/xmlto
 		dev-lang/perl
 	)"
-RDEPEND="${COMMON_DEPEND}
+RDEPEND="${CDEPEND}
 	dev-lang/perl
 	dev-perl/AnyEvent-I3
 	dev-perl/JSON-XS"
@@ -62,7 +62,6 @@
 
 PATCHES=(
 	"${FILESDIR}/${PN}-4.16-musl-GLOB_TILDE.patch"
-	"${FILESDIR}/i3-gaps-4.19-fix-docdir.patch"
 )
 
 src_prepare() {
@@ -76,7 +75,6 @@
 
 src_configure() {
 	local emesonargs=(
-		-Ddocdir="/usr/share/doc/${PF}"
 		$(meson_use doc docs)
 		$(meson_use doc mans)
 	)
@@ -96,10 +94,13 @@
 }
 
 pkg_postinst() {
-	elog "There are several packages that you may find useful with i3 and"
-	elog "their usage is suggested by the upstream maintainers."
-	elog "Uninstalled optional dependencies:"
-	optfeature "Application launcher" x11-misc/dmenu
-	optfeature "Simple screen locker" x11-misc/i3lock
-	optfeature "Status bar generator" x11-misc/i3status
+	# Only show the elog information on a new install
+	if [[ ! ${REPLACING_VERSIONS} ]]; then
+		elog "There are several packages that you may find useful with ${PN} and"
+		elog "their usage is suggested by the upstream maintainers, namely:"
+		elog "  x11-misc/dmenu"
+		elog "  x11-misc/i3status"
+		elog "  x11-misc/i3lock"
+		elog "Please refer to their description for additional info."
+	fi
 }
```
Rationale:
**optfeature** is better than plain `elog` since it only prints uninstalled packages.
**CDEPEND** should be reserved for future EAPI usage.
**-Ddocdir="/usr/share/doc/${PF}"** we use `PF` as doc dir.

Currently i3 also has an issue with an empty doc dir, this is fixed by a patch provided by @ajakk. It's not included in -9999 because it's apparently already been reported to upstream and I expect it to get fixed there, so -9999 would probably fail emerging shortly.