### PR TITLE
profiles/arch/hppa: un-stable mask Python 3.9 as a target

### DIFF
--- a/profiles/arch/hppa/use.stable.mask
+++ b/profiles/arch/hppa/use.stable.mask
@@ -4,11 +4,6 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
 
-# Sam James <sam@gentoo.org> (2020-11-08)
-# Python 3.9 is not yet stable.
-python_targets_python3_9
-python_single_target_python3_9
-
 # Rolf Eike Beer <eike@sf-mail.de> (2020-04-14)
 # media-libs/gstreamer is not stable for hppa
 gstreamer


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>