### PR TITLE
dev-lang/ispc: Iscp only supports up to LLVM 10

### DIFF
--- a/dev-lang/ispc/ispc-1.14.1.ebuild
+++ b/dev-lang/ispc/ispc-1.14.1.ebuild
@@ -24,7 +24,7 @@ LICENSE="BSD BSD-2 UoI-NCSA"
 SLOT="0"
 IUSE="examples"
 
-RDEPEND="<sys-devel/clang-11:=[llvm_targets_AMDGPU(+)]"
+RDEPEND="<sys-devel/clang-11:="
 
 DEPEND="
 	${RDEPEND}
@@ -42,7 +42,7 @@ PATCHES=(
 )
 
 llvm_check_deps() {
-	has_version -d "sys-devel/clang:${LLVM_SLOT}[llvm_targets_AMDGPU(+)]"
+	has_version -d "sys-devel/clang:${LLVM_SLOT}"
 }
 
 src_prepare() {

--- a/dev-lang/ispc/ispc-1.14.1.ebuild
+++ b/dev-lang/ispc/ispc-1.14.1.ebuild
@@ -5,7 +5,9 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8,9} )
 
-inherit cmake toolchain-funcs python-any-r1
+inherit cmake toolchain-funcs python-any-r1 llvm
+
+LLVM_MAX_SLOT=10
 
 DESCRIPTION="Intel SPMD Program Compiler"
 HOMEPAGE="https://ispc.github.com/"
@@ -22,10 +24,8 @@ LICENSE="BSD BSD-2 UoI-NCSA"
 SLOT="0"
 IUSE="examples"
 
-RDEPEND="
-	>=sys-devel/clang-3.0:*
-	>=sys-devel/llvm-3.0:*
-	"
+RDEPEND="<sys-devel/clang-11:=[llvm_targets_AMDGPU(+)]"
+
 DEPEND="
 	${RDEPEND}
 	${PYTHON_DEPS}
@@ -40,6 +40,10 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.14.0-llvm-10.patch"
 	"${FILESDIR}/${PN}-1.13.0-werror.patch"
 )
+
+llvm_check_deps() {
+	has_version -d "sys-devel/clang:${LLVM_SLOT}[llvm_targets_AMDGPU(+)]"
+}
 
 src_prepare() {
 	if use amd64; then

--- a/dev-lang/ispc/ispc-9999.ebuild
+++ b/dev-lang/ispc/ispc-9999.ebuild
@@ -5,7 +5,9 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8,9} )
 
-inherit cmake toolchain-funcs python-any-r1
+inherit cmake toolchain-funcs python-any-r1 llvm
+
+LLVM_MAX_SLOT=10
 
 DESCRIPTION="Intel SPMD Program Compiler"
 HOMEPAGE="https://ispc.github.com/"
@@ -22,10 +24,7 @@ LICENSE="BSD BSD-2 UoI-NCSA"
 SLOT="0"
 IUSE="examples"
 
-RDEPEND="
-	>=sys-devel/clang-3.0:*
-	>=sys-devel/llvm-3.0:*
-	"
+RDEPEND="<sys-devel/clang-11:=[llvm_targets_AMDGPU(+)]"
 DEPEND="
 	${RDEPEND}
 	${PYTHON_DEPS}
@@ -40,6 +39,10 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.14.0-llvm-10.patch"
 	"${FILESDIR}/${PN}-1.13.0-werror.patch"
 )
+
+llvm_check_deps() {
+	has_version -d "sys-devel/clang:${LLVM_SLOT}[llvm_targets_AMDGPU(+)]"
+}
 
 src_prepare() {
 	if use amd64; then

--- a/dev-lang/ispc/ispc-9999.ebuild
+++ b/dev-lang/ispc/ispc-9999.ebuild
@@ -24,7 +24,7 @@ LICENSE="BSD BSD-2 UoI-NCSA"
 SLOT="0"
 IUSE="examples"
 
-RDEPEND="<sys-devel/clang-11:=[llvm_targets_AMDGPU(+)]"
+RDEPEND="<sys-devel/clang-11:="
 DEPEND="
 	${RDEPEND}
 	${PYTHON_DEPS}
@@ -41,7 +41,7 @@ PATCHES=(
 )
 
 llvm_check_deps() {
-	has_version -d "sys-devel/clang:${LLVM_SLOT}[llvm_targets_AMDGPU(+)]"
+	has_version -d "sys-devel/clang:${LLVM_SLOT}"
 }
 
 src_prepare() {


### PR DESCRIPTION
Iscp does not yet have llvm 11 support, so limit clang and llvm in both
ebuilds to version 10 maximum.

Thanks to Toralf Förster, brothermechanic and Marco Genasci for their
contributions to fixing this bug, I am only repackaging it.

A working ispc is needed for adding embree support to blender.

See https://github.com/ispc/ispc/issues/1896

Signed-off-by: Adrian Grigo <agrigo2001@yahoo.com.au>
Closes: https://bugs.gentoo.org/749573
Package-Manager: Portage-3.0.9, Repoman-3.0.2