### PR TITLE
x11-libs/xforms: port to EAPI 7

### DIFF
--- a/x11-libs/xforms/files/xforms-1.2.4-fno-common.patch
+++ b/x11-libs/xforms/files/xforms-1.2.4-fno-common.patch
@@ -1,0 +1,40 @@
+Description: Fix FTBFS with GCC 10
+Author: Paul Wise <pabs@debian.org>
+Bug-Debian: https://bugs.debian.org/957439
+Origin: upstream, extracted from two separate commits:
+ https://git.savannah.nongnu.org/cgit/xforms.git/commit/?id=9806bce102d0c079c2c486b25ae6bdac3c98eecf
+ https://git.savannah.nongnu.org/cgit/xforms.git/commit/?id=2c1a9f151baf50887a517280645ec23379fb96f8
+--- a/fdesign/sp_spinner.c
++++ b/fdesign/sp_spinner.c
+@@ -29,7 +29,7 @@
+ #include "spec/spinner_spec.h"
+ 
+ static FD_spinnerattrib * spn_attrib;
+-FL_OBJECT *curobj;
++static FL_OBJECT *curobj;
+ 
+ 
+ /***************************************
+--- a/fdesign/sp_twheel.c
++++ b/fdesign/sp_twheel.c
+@@ -38,7 +38,7 @@
+ #include "spec/twheel_spec.h"
+ 
+ static FD_twheelattrib * twheel_attrib;
+-FL_OBJECT * curobj;
++static FL_OBJECT * curobj;
+ 
+ 
+ /***************************************
+--- a/lib/objects.c
++++ b/lib/objects.c
+@@ -36,6 +36,9 @@
+ 
+ #define TRANSLATE_Y( obj, form )    ( form->h - obj->h - obj->y )
+ 
++extern FL_OBJECT * fli_handled_obj;        /*  defined in  events.c */
++extern FL_OBJECT * fli_handled_parent;     /*  defined in  events.c */
++
+ extern FL_FORM * fli_fast_free_object;     /* defined in forms.c */
+ 
+ extern FL_OBJECT * fli_handled_obj;        /* defined in  events.c */

--- a/x11-libs/xforms/xforms-1.2.4-r1.ebuild
+++ b/x11-libs/xforms/xforms-1.2.4-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+MY_P="${P/-/_}"
+
+DESCRIPTION="A graphical user interface toolkit for X"
+HOMEPAGE="http://xforms-toolkit.org/"
+SRC_URI="https://dev.gentoo.org/~monsieurp/packages/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
+IUSE="doc opengl"
+
+RDEPEND="
+	virtual/jpeg:0=
+	x11-libs/libSM
+	x11-libs/libX11
+	x11-libs/libXpm
+	opengl? ( virtual/opengl )"
+
+DEPEND="
+	${RDEPEND}
+	x11-base/xorg-proto"
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=( "${FILESDIR}"/${P}-fno-common.patch )
+
+DOCS=( ChangeLog README )
+
+src_prepare() {
+	default
+	AT_M4DIR=config eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable doc docs) \
+		$(use_enable opengl gl) \
+		--disable-static
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
```diff
--- xforms-1.2.4.ebuild	
+++ xforms-1.2.4-r1.ebuild	
@@ -1,9 +1,9 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2

-EAPI=6
+EAPI=7

-inherit autotools eutils ltprune
+inherit autotools

 MY_P="${P/-/_}"

@@ -13,8 +13,8 @@

 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 arm ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
-IUSE="doc opengl static-libs"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
+IUSE="doc opengl"

 RDEPEND="
 	virtual/jpeg:0=
@@ -29,6 +29,8 @@

 S="${WORKDIR}/${MY_P}"

+PATCHES=( "${FILESDIR}"/${P}-fno-common.patch )
+
 DOCS=( ChangeLog README )

 src_prepare() {
@@ -40,10 +42,10 @@
 	econf \
 		$(use_enable doc docs) \
 		$(use_enable opengl gl) \
-		$(use_enable static-libs static)
+		--disable-static
 }

 src_install() {
 	default
-	prune_libtool_files
+	find "${ED}" -name '*.la' -delete || die
 }
```