### PR TITLE
media-gfx/openscad: fix issue with cgal

### DIFF
--- a/media-gfx/openscad/files/openscad-2019.05-0003-change-C-standard-to-c-14.patch
+++ b/media-gfx/openscad/files/openscad-2019.05-0003-change-C-standard-to-c-14.patch
@@ -1,0 +1,76 @@
+From 02f9a4eca87d7713a8345b8513423d9d4a5127e0 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl@gmail.com>
+Date: Fri, 27 Nov 2020 18:49:09 +0100
+Subject: [PATCH] change C++ standard to c++14
+
+Signed-off-by: Bernd Waibel <waebbl@gmail.com>
+---
+ c++11.pri => c++std.pri | 21 ++++++++-------------
+ common.pri              |  2 +-
+ 2 files changed, 9 insertions(+), 14 deletions(-)
+ rename c++11.pri => c++std.pri (74%)
+
+diff --git a/c++11.pri b/c++std.pri
+similarity index 74%
+rename from c++11.pri
+rename to c++std.pri
+index 0a2c3b6..aac656d 100644
+--- a/c++11.pri
++++ b/c++std.pri
+@@ -4,16 +4,16 @@ macx {
+   dirs = $${BOOSTDIR} $${QMAKE_LIBDIR}
+   for(dir, dirs) {
+     system(otool -L $${dir}/libboost_thread*  | grep libc++ >& /dev/null ) {
+-      message("Using libc++11")
++      message("Using libc++")
+       CONFIG += libc++
+     }
+     else {
+       message("Using libstdc++")
+       CONFIG += libstdc++
+-      c++11 {
+-        # libc++ is a requirement for using C++11 
+-        warning("Disabling C++11 since libstdc++ dependencies were found")
+-        CONFIG -= c++11
++      c++std {
++        # libc++ is a requirement for using C++14 
++        warning("Disabling C++14 since libstdc++ dependencies were found")
++        CONFIG -= c++std
+       }
+     }
+   }
+@@ -25,9 +25,9 @@ macx {
+   }
+ }
+ 
+-c++11 {
+-  QMAKE_CXXFLAGS += -std=c++11
+-  message("Using C++11")
++c++std {
++  QMAKE_CXXFLAGS += -std=c++14
++  message("Using C++14")
+ 
+   *clang*: {
+       # 3rd party libraries will probably violate this for a long time
+@@ -41,8 +41,3 @@ c++11 {
+     QMAKE_OBJECTIVE_CFLAGS_WARN_ON += $$CXX11_SUPPRESS_WARNINGS
+   }
+ }
+-else {
+-  *clang* {
+-    QMAKE_CXXFLAGS_WARN_ON += -Wno-c++11-extensions
+-  }
+-}
+diff --git a/common.pri b/common.pri
+index 1110757..d1d5edc 100644
+--- a/common.pri
++++ b/common.pri
+@@ -30,4 +30,4 @@ include(win.pri)
+ include(flex.pri)
+ include(bison.pri)
+ include(opengl.pri)
+-include(c++11.pri)
++include(c++std.pri)
+-- 
+2.29.2
+

--- a/media-gfx/openscad/openscad-2019.05-r4.ebuild
+++ b/media-gfx/openscad/openscad-2019.05-r4.ebuild
@@ -1,0 +1,115 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit elisp-common qmake-utils xdg
+
+SITEFILE="50${PN}-gentoo.el"
+
+DESCRIPTION="The Programmers Solid 3D CAD Modeller"
+HOMEPAGE="https://www.openscad.org/"
+SRC_URI="https://github.com/${PN}/${PN}/releases/download/${P}/${P}.src.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="ccache emacs"
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}/${P}_fix-boost-1.72.0-build.patch"
+	"${FILESDIR}/${P}-0001-Fix-build-with-boost-1.73.patch"
+	"${FILESDIR}/${P}-0003-change-C-standard-to-c-14.patch"
+)
+
+RDEPEND="
+	dev-cpp/eigen:3
+	dev-libs/boost:=
+	dev-libs/double-conversion:=
+	dev-libs/glib:2
+	dev-libs/gmp:0=
+	dev-libs/hidapi
+	dev-libs/libspnav
+	dev-libs/libzip:=
+	dev-libs/mpfr:0=
+	dev-qt/qtconcurrent:5
+	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5[-gles2-only]
+	dev-qt/qtmultimedia:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtopengl:5
+	dev-qt/qtwidgets:5
+	media-gfx/opencsg
+	media-libs/fontconfig
+	media-libs/freetype
+	>=media-libs/glew-2.0.0:0=
+	media-libs/harfbuzz:=
+	media-libs/lib3mf
+	sci-mathematics/cgal:=
+	>=x11-libs/qscintilla-2.10.3:=
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/itstool
+	sys-devel/bison
+	sys-devel/flex
+	sys-devel/gettext
+	virtual/pkgconfig
+	ccache? ( dev-util/ccache )
+"
+
+src_prepare() {
+	default
+
+	# fix path prefix
+	sed -i "s/\/usr\/local/\/usr/g" ${PN}.pro || die
+
+	# change c++ standard
+	sed -e 's/CONFIG += c++11/CONFIG += c++std/' -i openscad.pro || die
+
+	# disable ccache
+	if ! use ccache; then
+		eapply "${FILESDIR}/${P}-0002-Gentoo-specific-Disable-ccache-building.patch"
+	fi
+}
+
+src_configure() {
+	eqmake5 "${PN}.pro"
+}
+
+src_compile() {
+	default
+
+	if use emacs ; then
+		elisp-compile contrib/*.el
+	fi
+}
+
+src_install() {
+	emake install INSTALL_ROOT="${D}"
+
+	if use emacs; then
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+		elisp-install ${PN} contrib/*.el contrib/*.elc
+	fi
+
+	mv -i "${ED}"/usr/share/openscad/locale "${ED}"/usr/share || die "failed to move locales"
+	ln -sf ../locale "${ED}"/usr/share/openscad/locale || die
+
+	einstalldocs
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}


### PR DESCRIPTION
Fixes the issue of not building against cgal-5.1.
Also installs locales into correct dir.

Bug: https://bugs.gentoo.org/755842
Package-Manager: Portage-3.0.10, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl@gmail.com>