### PR TITLE
app-text/mandoc: allow as default man provider

### DIFF
--- a/app-text/mandoc/files/mandoc-1.14.5-r1-www-install.patch
+++ b/app-text/mandoc/files/mandoc-1.14.5-r1-www-install.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile b/Makefile
+index f4e2954..191c7e2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -535,9 +535,11 @@ soelim: $(SOELIM_OBJS)
+ # --- maintainer targets ---
+ 
+ www-install: www
+-	$(INSTALL_DATA) mandoc.css $(HTDOCDIR)
+-	$(INSTALL_DATA) $(WWW_MANS) $(HTDOCDIR)/man
+-	$(INSTALL_DATA) $(WWW_INCS) $(HTDOCDIR)/includes
++	mkdir -p $(DESTDIR)$(HTDOCDIR)/man
++	mkdir -p $(DESTDIR)$(HTDOCDIR)/includes
++	$(INSTALL_DATA) mandoc.css $(DESTDIR)$(HTDOCDIR)
++	$(INSTALL_DATA) $(WWW_MANS) $(DESTDIR)$(HTDOCDIR)/man
++	$(INSTALL_DATA) $(WWW_INCS) $(DESTDIR)$(HTDOCDIR)/includes
+ 
+ depend: config.h
+ 	mkdep -f Makefile.depend $(CFLAGS) $(SRCS)

--- a/app-text/mandoc/files/mandoc.cron-r0
+++ b/app-text/mandoc/files/mandoc.cron-r0
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# need MANPATH
+. /etc/profile.env
+
+exec nice makewhatis -T utf8 2>/dev/null

--- a/app-text/mandoc/mandoc-1.14.5-r1.ebuild
+++ b/app-text/mandoc/mandoc-1.14.5-r1.ebuild
@@ -1,0 +1,118 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Suite of tools compiling mdoc and man"
+HOMEPAGE="https://mdocml.bsd.lv/"
+SRC_URI="https://mdocml.bsd.lv/snapshots/${P}.tar.gz"
+
+LICENSE="ISC"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc64 ~x86"
+IUSE="cgi system-man"
+
+RDEPEND="sys-libs/zlib
+	system-man? ( !sys-apps/man-db )
+"
+DEPEND="${RDEPEND}
+	cgi? ( sys-libs/zlib[static-libs] )
+"
+BDEPEND="
+	cgi? ( app-text/highlight )
+"
+
+PATCHES=( "${FILESDIR}"/${PN}-1.14.5-r1-www-install.patch )
+
+pkg_pretend() {
+	if use system-man ; then
+		# only support uncompressed and gzip
+		[[ -n ${PORTAGE_COMPRESS+unset} ]] && \
+		[[ "${PORTAGE_COMPRESS}" == "gzip" || "${PORTAGE_COMPRESS}" == "" ]] || \
+		ewarn "only PORTAGE_COMPRESS=gzip or '' is supported, man pages will not be indexed"
+	fi
+}
+
+src_prepare() {
+	default
+
+	# The db-install change is to support parallel installs.
+	sed -i \
+		-e '/ar rs/s:ar:$(AR):' \
+		-e '/^db-install:/s:$: base-install:' \
+		Makefile || die
+
+	# make-4.3 doesn't like the CC line (bug #706024)
+	# and "echo -n" is not portable
+	sed \
+		-e "s@^\(CC=\).*\$@\1\"$(tc-getCC)\"@" \
+		-e 's@echo -n@printf@g' \
+		-i configure || die
+
+	cat <<-EOF > "configure.local"
+		PREFIX="${EPREFIX}/usr"
+		BINDIR="${EPREFIX}/usr/bin"
+		SBINDIR="${EPREFIX}/usr/sbin"
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+		MANDIR="${EPREFIX}/usr/share/man"
+		INCLUDEDIR="${EPREFIX}/usr/include/mandoc"
+		EXAMPLEDIR="${EPREFIX}/usr/share/examples/mandoc"
+		MANPATH_DEFAULT="${EPREFIX}/usr/man:${EPREFIX}/usr/share/man:${EPREFIX}/usr/local/man:${EPREFIX}/usr/local/share/man"
+
+		CFLAGS="${CFLAGS} ${CPPFLAGS}"
+		LDFLAGS="${LDFLAGS}"
+		AR="$(tc-getAR)"
+		CC="$(tc-getCC)"
+		# The STATIC variable is only used by man.cgi.
+		STATIC=
+
+		# conflicts with sys-apps/groff
+		BINM_SOELIM=msoelim
+		MANM_ROFF=mandoc_roff
+		# conflicts with sys-apps/man-pages
+		MANM_MAN=mandoc_man
+
+		# fix utf-8 locale on musl
+		$(usex elibc_musl UTF8_LOCALE=C.UTF-8 '')
+	EOF
+	use system-man || cat <<-EOF >> "configure.local"
+		BINM_MAN=mman
+		BINM_APROPOS=mapropos
+		BINM_WHATIS=mwhatis
+		BINM_MAKEWHATIS=mmakewhatis
+		MANM_MDOC=mandoc_mdoc
+		MANM_EQN=mandoc_eqn
+		MANM_TBL=mandoc_tbl
+		MANM_MANCONF=mman.conf
+	EOF
+	if use cgi; then
+		cp cgi.h{.example,} || die
+	fi
+	if [[ -n "${MANDOC_CGI_H}" ]]; then
+		cp "${MANDOC_CGI_H}" cgi.h || die
+	fi
+}
+
+src_compile() {
+	default
+	use cgi && emake man.cgi
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	use cgi && emake DESTDIR="${D}" cgi-install www-install
+
+	if use system-man ; then
+		exeinto /etc/cron.daily
+		newexe "${FILESDIR}"/mandoc.cron-r0 mandoc
+	fi
+}
+
+pkg_postinst() {
+	if use system-man ; then
+		elog "Generating mandoc database"
+		makewhatis || die
+	fi
+}

--- a/app-text/mandoc/metadata.xml
+++ b/app-text/mandoc/metadata.xml
@@ -4,4 +4,8 @@
 <maintainer type="project">
 	<email>base-system@gentoo.org</email>
 </maintainer>
+	<use>
+		<flag name="cgi">build man.cgi web plugin for viewing man pages</flag>  
+		<flag name="system-man">set as the default man provider</flag>
+	</use>
 </pkgmetadata>

--- a/virtual/man/man-0-r4.ebuild
+++ b/virtual/man/man-0-r4.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for man"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+	|| (
+		sys-apps/man-db
+		>=app-text/mandoc-1.14.5-r1[system-man]
+	)
+"


### PR DESCRIPTION
~~Still need to see how to recompress all man pages to `gz`.~~
Seems like that is not going to be possible.
There needs to be a warning stating that if using this as the man command, you should first set the PORTAGE_COMPRESS and then emerge the whole tree again.
It is either emerge the whole tree or portage should have a function which recompresses files with a different compression.