### PR TITLE
dev-python/reedsolomon: fix ebuild, add necessary dependency

### DIFF
--- a/dev-python/reedsolomon/reedsolomon-1.5.4.ebuild
+++ b/dev-python/reedsolomon/reedsolomon-1.5.4.ebuild
@@ -16,6 +16,10 @@ KEYWORDS="~amd64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
+BDEPEND="
+	dev-python/cython[${PYTHON_USEDEP}]
+"
+
 python_test() {
 	${EPYTHON} tests/test_creedsolo.py || die "creedsolo test failed with ${EPYTHON}"
 	${EPYTHON} tests/test_reedsolo.py || die "reedsolo test failed with ${EPYTHON}"


### PR DESCRIPTION
Unfortunately the buildtime dependency dev-python/cython is missing.
This ebuild fixes this.

Closes: https://bugs.gentoo.org/757486
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>