### PR TITLE
games-action/violetland: fix dependency on libsdl

### DIFF
--- a/games-action/violetland/violetland-0.5.ebuild
+++ b/games-action/violetland/violetland-0.5.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
 	dev-libs/boost:=[threads(+)]
-	media-libs/libsdl[sound,video]
+	media-libs/libsdl[opengl,sound,video]
 	media-libs/sdl-image[png]
 	media-libs/sdl-mixer[vorbis]
 	media-libs/sdl-ttf


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/739072
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>