### PR TITLE
profiles/base: swith to python3.8 by default

### DIFF
--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -127,10 +127,10 @@ BOOTSTRAP_USE="unicode internal-glib pkg-config split-usr python_targets_python3
 
 # Mike Gilbert <floppym@gentoo.org> (2012-05-15)
 # Default target(s) for python-r1.eclass
-# Mikle Kolyada <zlogene@gentoo.org> (2020-05-06)
-# Updated to python3_7
-PYTHON_TARGETS="python2_7 python3_7"
-PYTHON_SINGLE_TARGET="python3_7"
+# Mikle Kolyada <zlogene@gentoo.org> (2020-12-02)
+# Updated to python3_8
+PYTHON_TARGETS="python2_7 python3_8"
+PYTHON_SINGLE_TARGET="python3_8"
 
 # Michał Górny <mgorny@gentoo.org> (2013-08-10)
 # Moved from portage's make.globals.


### PR DESCRIPTION
Signed-off-by: Mikle Kolyada <zlogene@gentoo.org>