### PR TITLE
app-portage/mgorny-dev-scripts: Add missing dep

### DIFF
--- a/app-portage/mgorny-dev-scripts/mgorny-dev-scripts-6.ebuild
+++ b/app-portage/mgorny-dev-scripts/mgorny-dev-scripts-6.ebuild
@@ -14,6 +14,7 @@ KEYWORDS="~amd64 ~x86"
 RDEPEND="
 	app-portage/gentoolkit
 	dev-perl/URI
+	dev-util/pkgcheck
 	dev-vcs/git
 	net-misc/wget
 	sys-apps/portage


### PR DESCRIPTION
The new check-revdep script needs pkgcheck from dev-util/pkgcheck

Closes: https://bugs.gentoo.org/758227
Package-Manager: Portage-3.0.11, Repoman-3.0.1
Signed-off-by: William Pettersson <william@ewpettersson.se>