### PR TITLE
app-editors/vim: do not create symlink vimdiff for minimal

### DIFF
--- a/app-editors/vim/vim-8.2.0360.ebuild
+++ b/app-editors/vim/vim-8.2.0360.ebuild
@@ -276,7 +276,9 @@ src_install() {
 	# Note: Do not install symlinks for 'vi', 'ex', or 'view', as these are
 	#       managed by eselect-vi
 	dobin src/vim
-	dosym vim /usr/bin/vimdiff
+	if ! use minimal ; then
+		dosym vim /usr/bin/vimdiff
+	fi
 	dosym vim /usr/bin/rvim
 	dosym vim /usr/bin/rview
 	if use vim-pager ; then

--- a/app-editors/vim/vim-8.2.0508.ebuild
+++ b/app-editors/vim/vim-8.2.0508.ebuild
@@ -276,7 +276,9 @@ src_install() {
 	# Note: Do not install symlinks for 'vi', 'ex', or 'view', as these are
 	#       managed by eselect-vi
 	dobin src/vim
-	dosym vim /usr/bin/vimdiff
+	if ! use minimal ; then
+		dosym vim /usr/bin/vimdiff
+	fi
 	dosym vim /usr/bin/rvim
 	dosym vim /usr/bin/rview
 	if use vim-pager ; then

--- a/app-editors/vim/vim-8.2.0638.ebuild
+++ b/app-editors/vim/vim-8.2.0638.ebuild
@@ -276,7 +276,9 @@ src_install() {
 	# Note: Do not install symlinks for 'vi', 'ex', or 'view', as these are
 	#       managed by eselect-vi
 	dobin src/vim
-	dosym vim /usr/bin/vimdiff
+	if ! use minimal ; then
+		dosym vim /usr/bin/vimdiff
+	fi
 	dosym vim /usr/bin/rvim
 	dosym vim /usr/bin/rview
 	if use vim-pager ; then

--- a/app-editors/vim/vim-8.2.0814.ebuild
+++ b/app-editors/vim/vim-8.2.0814.ebuild
@@ -276,7 +276,9 @@ src_install() {
 	# Note: Do not install symlinks for 'vi', 'ex', or 'view', as these are
 	#       managed by eselect-vi
 	dobin src/vim
-	dosym vim /usr/bin/vimdiff
+	if ! use minimal ; then
+		dosym vim /usr/bin/vimdiff
+	fi
 	dosym vim /usr/bin/rvim
 	dosym vim /usr/bin/rview
 	if use vim-pager ; then

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -276,7 +276,9 @@ src_install() {
 	# Note: Do not install symlinks for 'vi', 'ex', or 'view', as these are
 	#       managed by eselect-vi
 	dobin src/vim
-	dosym vim /usr/bin/vimdiff
+	if ! use minimal ; then
+		dosym vim /usr/bin/vimdiff
+	fi
 	dosym vim /usr/bin/rvim
 	dosym vim /usr/bin/rview
 	if use vim-pager ; then


### PR DESCRIPTION
A symlink `vimdiff` should not be created, if the USE flag `minimal` is enabled.
Otherwise running `vimdiff` results in failure like that:

```
$ vimdiff aaa bbb
This Vim was not compiled with the diff feature.
```