### PR TITLE
Calibre problem with CHM formatted files

### DIFF
--- a/app-text/calibre/calibre-5.4.2.ebuild
+++ b/app-text/calibre/calibre-5.4.2.ebuild
@@ -42,7 +42,6 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	>=app-text/hunspell-1.7:=
 	>=app-text/podofo-0.9.6_pre20171027:=
 	>=app-text/poppler-0.26.5[qt5]
-	>=dev-libs/chmlib-0.40:=
 	dev-libs/glib:2=
 	dev-libs/hyphen:=
 	>=dev-libs/icu-57.1:=
@@ -67,6 +66,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		>=dev-python/netifaces-0.10.5[${PYTHON_MULTI_USEDEP}]
 		>=dev-python/pillow-3.2.0[${PYTHON_MULTI_USEDEP}]
 		>=dev-python/psutil-4.3.0[${PYTHON_MULTI_USEDEP}]
+		>=dev-python/pychm-0.8.6[${PYTHON_MULTI_USEDEP}]
 		>=dev-python/pygments-2.3.1[${PYTHON_MULTI_USEDEP}]
 		>=dev-python/python-dateutil-2.5.3[${PYTHON_MULTI_USEDEP}]
 		>=dev-python/PyQt5-5.12[gui,svg,widgets,network,printsupport,${PYTHON_MULTI_USEDEP}]

--- a/dev-python/pychm/pychm-0.8.6.ebuild
+++ b/dev-python/pychm/pychm-0.8.6.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/dottedmag/pychm/archive/v${PV}.tar.gz -> ${P}.gh.tar
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="amd64 ~arm ~ppc x86"
 
 RDEPEND="dev-libs/chmlib"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Hi. If you try to convert a chm formatted ebook in calibre, you'll get:
```
Convert book 1 of 1 (Sed and Awk Pocket Reference)
Integration status: True
Initialized urlfixer
Conversion options changed from defaults:
  cover: '/tmp/calibre_5.4.2_tmp_g3y5eazw/fm4u2ugh.jpeg'
  pdf_serif_family: 'TeX Gyre Termes'
  pdf_sans_family: 'TeX Gyre Heros'
  output_profile: 'generic_eink_hd'
  read_metadata_from_opf: '/tmp/calibre_5.4.2_tmp_g3y5eazw/v4h_xli2.opf'
  verbose: 2
Resolved conversion options
calibre version: 5.4.2
{'asciiize': False,
 'author_sort': None,
 'authors': None,
 'base_font_size': 0.0,
 'book_producer': None,
 'change_justification': 'original',
 'chapter': "//*[((name()='h1' or name()='h2') and re:test(., "
            "'\\s*((chapter|book|section|part)\\s+)|((prolog|prologue|epilogue)(\\s+|$))', "
            "'i')) or @class = 'chapter']",
 'chapter_mark': 'pagebreak',
 'comments': None,
 'cover': '/tmp/calibre_5.4.2_tmp_g3y5eazw/fm4u2ugh.jpeg',
 'custom_size': None,
 'debug_pipeline': None,
 'dehyphenate': True,
 'delete_blank_paragraphs': True,
 'disable_font_rescaling': False,
 'duplicate_links_in_toc': False,
 'embed_all_fonts': False,
 'embed_font_family': None,
 'enable_heuristics': False,
 'expand_css': False,
 'extra_css': None,
 'filter_css': '',
 'fix_indents': True,
 'font_size_mapping': None,
 'format_scene_breaks': True,
 'html_unwrap_factor': 0.4,
 'input_encoding': None,
 'input_profile': <calibre.customize.profiles.InputProfile object at 0x7fdd68b938e0>,
 'insert_blank_line': False,
 'insert_blank_line_size': 0.5,
 'insert_metadata': False,
 'isbn': None,
 'italicize_common_cases': True,
 'keep_ligatures': False,
 'language': None,
 'level1_toc': None,
 'level2_toc': None,
 'level3_toc': None,
 'line_height': 0.0,
 'linearize_tables': False,
 'margin_bottom': 5.0,
 'margin_left': 5.0,
 'margin_right': 5.0,
 'margin_top': 5.0,
 'markup_chapter_headings': True,
 'max_toc_links': 50,
 'minimum_line_height': 120.0,
 'no_chapters_in_toc': False,
 'no_inline_navbars': False,
 'output_profile': <calibre.customize.profiles.GenericEinkHD object at 0x7fdd68b93c10>,
 'page_breaks_before': "//*[name()='h1' or name()='h2']",
 'paper_size': 'letter',
 'pdf_add_toc': False,
 'pdf_default_font_size': 20,
 'pdf_footer_template': None,
 'pdf_header_template': None,
 'pdf_hyphenate': False,
 'pdf_mark_links': False,
 'pdf_mono_family': 'Courier',
 'pdf_mono_font_size': 16,
 'pdf_odd_even_offset': 0.0,
 'pdf_page_margin_bottom': 72.0,
 'pdf_page_margin_left': 72.0,
 'pdf_page_margin_right': 72.0,
 'pdf_page_margin_top': 72.0,
 'pdf_page_number_map': None,
 'pdf_page_numbers': False,
 'pdf_sans_family': 'TeX Gyre Heros',
 'pdf_serif_family': 'TeX Gyre Termes',
 'pdf_standard_font': 'serif',
 'pdf_use_document_margins': False,
 'prefer_metadata_cover': False,
 'preserve_cover_aspect_ratio': False,
 'pretty_print': False,
 'pubdate': None,
 'publisher': None,
 'rating': None,
 'read_metadata_from_opf': '/tmp/calibre_5.4.2_tmp_g3y5eazw/v4h_xli2.opf',
 'remove_fake_margins': True,
 'remove_first_image': False,
 'remove_paragraph_spacing': False,
 'remove_paragraph_spacing_indent_size': 1.5,
 'renumber_headings': True,
 'replace_scene_breaks': '',
 'search_replace': '[]',
 'series': None,
 'series_index': None,
 'smarten_punctuation': False,
 'sr1_replace': None,
 'sr1_search': None,
 'sr2_replace': None,
 'sr2_search': None,
 'sr3_replace': None,
 'sr3_search': None,
 'start_reading_at': None,
 'subset_embedded_fonts': False,
 'tags': None,
 'timestamp': None,
 'title': None,
 'title_sort': None,
 'toc_filter': None,
 'toc_threshold': 6,
 'toc_title': None,
 'transform_css_rules': '[]',
 'uncompressed_pdf': False,
 'unit': 'inch',
 'unsmarten_punctuation': False,
 'unwrap_lines': True,
 'use_auto_toc': False,
 'use_profile_size': False,
 'verbose': 2}
InputFormatPlugin: CHM Input running
on /tmp/calibre_5.4.2_tmp_g3y5eazw/97sybgnz.chm
Processing CHM...
tdir=/tmp/calibre_5.4.2_tmp_g3y5eazw/708ny2f6_chm2oeb
stream.name=/tmp/calibre_5.4.2_tmp_g3y5eazw/97sybgnz.chm
Traceback (most recent call last):
  File "/usr/bin/calibre-parallel", line 20, in <module>
    sys.exit(main())
  File "/usr/lib64/calibre/calibre/utils/ipc/worker.py", line 215, in main
    result = func(*args, **kwargs)
  File "/usr/lib64/calibre/calibre/gui2/convert/gui_conversion.py", line 41, in gui_convert_override
    gui_convert(input, output, recommendations, notification=notification,
  File "/usr/lib64/calibre/calibre/gui2/convert/gui_conversion.py", line 28, in gui_convert
    plumber.run()
  File "/usr/lib64/calibre/calibre/ebooks/conversion/plumber.py", line 1108, in run
    self.oeb = self.input_plugin(stream, self.opts,
  File "/usr/lib64/calibre/calibre/customize/conversion.py", line 245, in __call__
    ret = self.convert(stream, options, file_ext,
  File "/usr/lib64/calibre/calibre/ebooks/conversion/plugins/chm_input.py", line 57, in convert
    mainname = self._chmtohtml(tdir, chm_name, no_images, log,
  File "/usr/lib64/calibre/calibre/ebooks/conversion/plugins/chm_input.py", line 25, in _chmtohtml
    from calibre.ebooks.chm.reader import CHMReader
  File "/usr/lib64/calibre/calibre/ebooks/chm/reader.py", line 15, in <module>
    from chm.chm import CHMFile, chmlib
ModuleNotFoundError: No module named 'chm'
```

These two commits address this issue.
Please note I haven't cross compiled `pychm` for arm, but the depending `chmlib` does have `~arm`. `pychm` however contains 3 `pyc` compiled files, so maybe it needs to be tested.
I suggest considering the same thing about `arm64`.