### PR TITLE
sys-auth/AusweisApp2: drop maintainer

### DIFF
--- a/sys-auth/AusweisApp2/metadata.xml
+++ b/sys-auth/AusweisApp2/metadata.xml
@@ -2,14 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>gentoo@pogatzki.net</email>
-		<name>Volkmar W. Pogatzki</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
-	<maintainer type="person">
 		<email>conikost@gentoo.org</email>
 		<name>Conrad Kostecki</name>
 	</maintainer>


### PR DESCRIPTION
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>