### PR TITLE
app-editors/texworks: bump PYTHON_COMPAT, migrate to lua-single.eclass

### DIFF
--- a/app-editors/texworks/texworks-0.6.5-r1.ebuild
+++ b/app-editors/texworks/texworks-0.6.5-r1.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} )
+
+inherit flag-o-matic python-single-r1 virtualx xdg cmake
+
+DESCRIPTION="A simple interface for working with TeX documents"
+HOMEPAGE="http://tug.org/texworks/"
+SRC_URI="https://github.com/TeXworks/texworks/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="lua python"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	app-text/hunspell:=
+	app-text/poppler[qt5]
+	dev-qt/designer:5
+	dev-qt/qtconcurrent:5
+	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtscript:5[scripttools]
+	lua? ( dev-lang/lua:0 )
+	python? ( ${PYTHON_DEPS} )
+"
+DEPEND="
+	${RDEPEND}
+	dev-qt/linguist-tools:5
+"
+BDEPEND="virtual/pkgconfig"
+
+S="${WORKDIR}/${PN}-release-${PV}"
+
+PATCHES=( "${FILESDIR}/qt5.15-support.patch" )
+
+src_configure() {
+	filter-flags -flto* # Segmentation fault
+
+	local mycmakeargs=(
+		-Wno-dev
+		-DPREFER_BUNDLED_SYNCTEX=ON
+		-DWITH_LUA=$(usex lua ON OFF)
+		-DWITH_PYTHON=$(usex python ON OFF)
+		-DTeXworks_PLUGIN_DIR="/usr/$(get_libdir)/texworks"
+		-DTeXworks_DOCS_DIR="/share/doc/${PF}"
+		-DQTPDF_VIEWER=ON
+		-DBUILD_SHARED_LIBS=ON
+		-DBUILD_SHARED_PLUGINS=ON
+	)
+
+	cmake_src_configure
+}
+
+src_test() {
+	virtx default_src_test
+}

--- a/app-editors/texworks/texworks-0.6.5-r100.ebuild
+++ b/app-editors/texworks/texworks-0.6.5-r100.ebuild
@@ -1,0 +1,72 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+LUA_COMPAT=( lua5-{1..3} )
+PYTHON_COMPAT=( python3_{6..9} )
+
+inherit flag-o-matic lua-single python-single-r1 virtualx xdg cmake
+
+DESCRIPTION="A simple interface for working with TeX documents"
+HOMEPAGE="http://tug.org/texworks/"
+SRC_URI="https://github.com/TeXworks/texworks/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="lua python"
+REQUIRED_USE="
+	lua? ( ${LUA_REQUIRED_USE} )
+	python? ( ${PYTHON_REQUIRED_USE} )
+"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	app-text/hunspell:=
+	app-text/poppler[qt5]
+	dev-qt/designer:5
+	dev-qt/qtconcurrent:5
+	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5
+	dev-qt/qtscript:5[scripttools]
+	lua? ( ${LUA_DEPS} )
+	python? ( ${PYTHON_DEPS} )
+"
+DEPEND="
+	${RDEPEND}
+	dev-qt/linguist-tools:5
+"
+BDEPEND="virtual/pkgconfig"
+
+S="${WORKDIR}/${PN}-release-${PV}"
+
+PATCHES=( "${FILESDIR}/qt5.15-support.patch" )
+
+pkg_setup() {
+	lua-single_pkg_setup
+	python-single-r1_pkg_setup
+}
+
+src_configure() {
+	filter-flags -flto* # Segmentation fault
+
+	local mycmakeargs=(
+		-Wno-dev
+		-DPREFER_BUNDLED_SYNCTEX=ON
+		-DWITH_LUA=$(usex lua ON OFF)
+		-DWITH_PYTHON=$(usex python ON OFF)
+		-DTeXworks_PLUGIN_DIR="/usr/$(get_libdir)/texworks"
+		-DTeXworks_DOCS_DIR="/share/doc/${PF}"
+		-DQTPDF_VIEWER=ON
+		-DBUILD_SHARED_LIBS=ON
+		-DBUILD_SHARED_PLUGINS=ON
+	)
+
+	cmake_src_configure
+}
+
+src_test() {
+	virtx default_src_test
+}

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -505,6 +505,7 @@ gnome-base/orbit
 >=app-benchmarks/wrk-4.1.0-r100
 >=app-crypt/cardpeek-0.8.4
 >=app-crypt/ekeyd-1.1.5-r100
+>=app-editors/texworks-0.6.5-r100
 >=app-misc/worker-3.8.3-r100
 >=dev-games/cegui-0.8.7-r100
 =dev-games/openscenegraph-openmw-3.4_p20200425-r100


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/758662
Closes: https://bugs.gentoo.org/752534