### PR TITLE
media-libs/libquvi-scripts: migrate to lua-single.eclass

### DIFF
--- a/media-libs/libquvi-scripts/libquvi-scripts-0.9.20131130-r100.ebuild
+++ b/media-libs/libquvi-scripts/libquvi-scripts-0.9.20131130-r100.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+LUA_COMPAT=( lua5-{1..3} )
+
+inherit lua-single
+
+DESCRIPTION="Embedded lua scripts for libquvi"
+HOMEPAGE="http://quvi.sourceforge.net/"
+SRC_URI="mirror://sourceforge/quvi/${P}.tar.xz"
+
+LICENSE="AGPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="offensive"
+# tests fetch data from live websites
+RESTRICT="test"
+
+RDEPEND="
+	${LUA_DEPS}
+	$(lua_gen_cond_dep '
+		>=dev-lua/LuaBitOp-1.0.1-r1[${LUA_USEDEP}]
+		>=dev-lua/luaexpat-1.3.0-r1[${LUA_USEDEP}]
+		>=dev-lua/luajson-1.1.1[${LUA_USEDEP}]
+		>=dev-lua/luasocket-3.0_rc1-r2[${LUA_USEDEP}]
+	')
+"
+BDEPEND="
+	app-arch/xz-utils
+	virtual/pkgconfig
+"
+
+src_configure() {
+	econf $(use_with offensive nsfw) --with-manual
+}

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -572,6 +572,7 @@ gnome-base/orbit
 >=games-util/slade-3.1.12a-r100
 >=mail-filter/imapfilter-2.6.16-r100
 >=media-gfx/geeqie-1.5.1-r1
+>=media-libs/libquvi-scripts-0.9.20131130-r100
 >=media-sound/aqualung-1.1-r100
 >=net-analyzer/suricata-6.0.0-r100
 >=net-im/prosody-0.11.7-r100


### PR DESCRIPTION
I think I'm doing this right

Closes: https://bugs.gentoo.org/752960
Package-Manager: Portage-3.0.11, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>