### PR TITLE
dev-libs/efl: use docs.eclass for building docs

### DIFF
--- a/dev-libs/efl/efl-1.25.1-r10.ebuild
+++ b/dev-libs/efl/efl-1.25.1-r10.ebuild
@@ -5,7 +5,10 @@ EAPI=7
 
 LUA_COMPAT=( lua5-{1..3} luajit )
 
-inherit lua-single meson xdg-utils
+DOCS_BUILDER="doxygen"
+DOCS_DIR="${S}/doc"
+
+inherit docs lua-single meson xdg-utils
 
 DESCRIPTION="Enlightenment Foundation Libraries all-in-one package"
 HOMEPAGE="https://www.enlightenment.org"
@@ -14,7 +17,7 @@ SRC_URI="https://download.enlightenment.org/rel/libs/${PN}/${P}.tar.xz"
 LICENSE="BSD-2 GPL-2 LGPL-2.1 ZLIB"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
-IUSE="+X avif bmp connman cpu_flags_arm_neon dds debug doc drm +eet efl-one elogind examples fbcon
+IUSE="+X avif bmp connman cpu_flags_arm_neon dds debug drm +eet efl-one elogind examples fbcon
 	+fontconfig fribidi gif gles2-only gnutls glib +gstreamer harfbuzz hyphen ibus ico libressl
 	jpeg2k json nls mono opengl +pdf physics pmaps postscript psd pulseaudio raw scim
 	sdl +sound +ssl +svg +system-lz4 systemd tga tgv tiff tslib unwind v4l vnc wayland webp xcf
@@ -125,7 +128,6 @@ RDEPEND="${LUA_DEPS}
 	zeroconf? ( net-dns/avahi )"
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig
-	doc? ( app-doc/doxygen )
 	nls? ( sys-devel/gettext )"
 
 pkg_setup() {
@@ -142,6 +144,17 @@ src_prepare() {
 		sed -i "/config_h.set('HAVE_UNWIND/,/eina_ext_deps += unwind/d" src/lib/eina/meson.build ||
 			die "Failed to remove libunwind dep"
 	fi
+
+	# Fixup Doxyfile
+	pushd "${DOCS_DIR}"
+	cp Doxyfile.in Doxyfile || die
+	sed -i \
+		-e "s/@PACKAGE_VERSION@/${PV}/g" \
+		-e "s/@top_builddir@/../g" \
+		-e "s/@top_srcdir@/../g" \
+		-e "s/@srcdir@/./g" \
+		Doxyfile || die
+	popd
 }
 
 src_configure() {
@@ -273,16 +286,11 @@ src_configure() {
 }
 
 src_compile() {
+	docs_compile
 	meson_src_compile
-
-	if use doc; then
-		cd doc/ || die "Failed to switch into doc/ dir."
-		doxygen . || die "Doxygen failed to run."
-	fi
 }
 
 src_install() {
-	use doc && local HTML_DOCS=( "${S}"/doc/html/. )
 	meson_src_install
 
 	if use examples; then

--- a/dev-libs/efl/efl-1.25.1-r2.ebuild
+++ b/dev-libs/efl/efl-1.25.1-r2.ebuild
@@ -3,7 +3,10 @@
 
 EAPI=7
 
-inherit meson xdg-utils
+DOCS_BUILDER="doxygen"
+DOCS_DIR="${S}/doc"
+
+inherit docs meson xdg-utils
 
 DESCRIPTION="Enlightenment Foundation Libraries all-in-one package"
 HOMEPAGE="https://www.enlightenment.org"
@@ -12,7 +15,7 @@ SRC_URI="https://download.enlightenment.org/rel/libs/${PN}/${P}.tar.xz"
 LICENSE="BSD-2 GPL-2 LGPL-2.1 ZLIB"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 x86"
-IUSE="+X avif bmp connman cpu_flags_arm_neon dds debug doc drm +eet efl-one elogind examples fbcon
+IUSE="+X avif bmp connman cpu_flags_arm_neon dds debug drm +eet efl-one elogind examples fbcon
 	+fontconfig fribidi gif gles2-only gnutls glib +gstreamer harfbuzz hyphen ibus ico libressl
 	lua +luajit jpeg2k json nls mono opengl +pdf physics pmaps postscript psd pulseaudio raw scim
 	sdl +sound +ssl +svg +system-lz4 systemd tga tgv tiff tslib unwind v4l vnc wayland webp xcf
@@ -128,7 +131,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig
-	doc? ( app-doc/doxygen )
 	nls? ( sys-devel/gettext )"
 
 pkg_setup() {
@@ -145,6 +147,17 @@ src_prepare() {
 		sed -i "/config_h.set('HAVE_UNWIND/,/eina_ext_deps += unwind/d" src/lib/eina/meson.build ||
 			die "Failed to remove libunwind dep"
 	fi
+
+	# Fixup Doxyfile
+	pushd "${DOCS_DIR}"
+	cp Doxyfile.in Doxyfile || die
+	sed -i \
+		-e "s/@PACKAGE_VERSION@/${PV}/g" \
+		-e "s/@top_builddir@/../g" \
+		-e "s/@top_srcdir@/../g" \
+		-e "s/@srcdir@/./g" \
+		Doxyfile || die
+	popd
 }
 
 src_configure() {
@@ -276,16 +289,11 @@ src_configure() {
 }
 
 src_compile() {
+	docs_compile
 	meson_src_compile
-
-	if use doc; then
-		cd doc/ || die "Failed to switch into doc/ dir."
-		doxygen . || die "Doxygen failed to run."
-	fi
 }
 
 src_install() {
-	use doc && local HTML_DOCS=( "${S}"/doc/html/. )
 	meson_src_install
 
 	if use examples; then

--- a/eclass/docs.eclass
+++ b/eclass/docs.eclass
@@ -283,7 +283,7 @@ doxygen_compile() {
 	mkdir -p "${DOCS_OUTDIR}" || die
 
 	pushd "${DOCS_DIR}" || die
-	(cat "${doxyfile}" ; echo "HTML_OUTPUT=${DOCS_OUTDIR}") | doxygen "${DOCS_EXTRA_ARGS}" - || die "${FUNCNAME}: doxygen failed"
+	(cat "${DOCS_CONFIG_NAME}" ; echo "HTML_OUTPUT=${DOCS_OUTDIR}") | doxygen - "${DOCS_EXTRA_ARGS}" || die "${FUNCNAME}: doxygen failed"
 	popd || die
 }
 


### PR DESCRIPTION
As requested by @juippis , an example on how to use
the new docs.eclass with doxygen

See-Also: https://github.com/gentoo/gentoo/pull/16366
Package-Manager: Portage-3.0.11, Repoman-3.0.2
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>