### PR TITLE
app-emulation/libvirt-6.8.0: Properly handle libpcap if it's explicitly disabled

### DIFF
--- a/app-emulation/libvirt/files/libvirt-6.8.0-meson-properly-handle-libpcap-if-it-s-explicitly-dis.patch
+++ b/app-emulation/libvirt/files/libvirt-6.8.0-meson-properly-handle-libpcap-if-it-s-explicitly-dis.patch
@@ -1,0 +1,56 @@
+From c8be9ccc36a32cc756d05b2c0838c43a57be15f7 Mon Sep 17 00:00:00 2001
+Message-Id: <c8be9ccc36a32cc756d05b2c0838c43a57be15f7.1607284606.git.mprivozn@redhat.com>
+From: Pavel Hrdina <phrdina@redhat.com>
+Date: Thu, 8 Oct 2020 13:09:45 +0200
+Subject: [PATCH] meson: properly handle libpcap if it's explicitly disabled
+
+If libpcap is detected using pkg-config it would ignore the libpcap
+option.
+
+Signed-off-by: Pavel Hrdina <phrdina@redhat.com>
+Reviewed-by: Andrea Bolognani <abologna@redhat.com>
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ meson.build | 25 +++++++++++++++----------
+ 1 file changed, 15 insertions(+), 10 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index e5a8316668..ec252ddf39 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1101,17 +1101,22 @@ if libparted_dep.found()
+ endif
+ 
+ libpcap_version = '1.5.0'
+-libpcap_dep = dependency('libpcap', version: '>=' + libpcap_version, required: false)
+-if not libpcap_dep.found()
+-  pcap_config_prog = find_program('pcap-config', required: get_option('libpcap'))
+-  if pcap_config_prog.found()
+-    pcap_args = run_command(pcap_config_prog, '--cflags').stdout().strip().split()
+-    pcap_libs = run_command(pcap_config_prog, '--libs').stdout().strip().split()
+-    libpcap_dep = declare_dependency(
+-      compile_args: pcap_args,
+-      link_args: pcap_libs,
+-    )
++if not get_option('libpcap').disabled()
++  libpcap_dep = dependency('libpcap', version: '>=' + libpcap_version, required: false)
++
++  if not libpcap_dep.found()
++    pcap_config_prog = find_program('pcap-config', required: get_option('libpcap'))
++    if pcap_config_prog.found()
++      pcap_args = run_command(pcap_config_prog, '--cflags').stdout().strip().split()
++      pcap_libs = run_command(pcap_config_prog, '--libs').stdout().strip().split()
++      libpcap_dep = declare_dependency(
++        compile_args: pcap_args,
++        link_args: pcap_libs,
++      )
++    endif
+   endif
++else
++  libpcap_dep = dependency('', required: false)
+ endif
+ if libpcap_dep.found()
+   conf.set('WITH_LIBPCAP', 1)
+-- 
+2.26.2
+

--- a/app-emulation/libvirt/libvirt-6.8.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-6.8.0-r2.ebuild
@@ -129,6 +129,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.7.0-doc-path.patch
 	"${FILESDIR}"/${PN}-6.7.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-6.8.0-fix-libvirt-lxc-dbus.patch
+	"${FILESDIR}"/${PN}-6.8.0-meson-properly-handle-libpcap-if-it-s-explicitly-dis.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
This is a direct backport of an upstream commit of:

  c8be9ccc36a32cc756d05b2c0838c43a57be15f7

It was merged in 6.9.0 release, so 6.8.0 is the only release
which is still buggy.

Resolves: https://bugs.gentoo.org/754888
Signed-off-by: Michal Privoznik <mprivozn@redhat.com>