### PR TITLE
dev-python/libvirt-python-9999: Update PYTHON_COMPAT

### DIFF
--- a/dev-python/libvirt-python/libvirt-python-9999.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 MY_P="${P/_rc/-rc}"
 


### PR DESCRIPTION
All other dev-python/libvirt-python ebuilds support through
python3.7 to python3.9 except for the live ebuild. This doesn't
make much sense - the live ebuild does support those python
versions too.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>