### PR TITLE
net-libs/mbedtls: introduce slots

### DIFF
--- a/net-libs/mbedtls/mbedtls-2.16.8-r1.ebuild
+++ b/net-libs/mbedtls/mbedtls-2.16.8-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/ARMmbed/mbedtls/archive/${P}.tar.gz"
 S=${WORKDIR}/${PN}-${P}
 
 LICENSE="Apache-2.0"
-SLOT="0/3.12.0" # ffmpeg subslot naming: SONAME tuple of {libmbedcrypto.so,libmbedtls.so,libmbedx509.so}
+SLOT="2.1/3.12.0" # ffmpeg subslot naming: SONAME tuple of {libmbedcrypto.so,libmbedtls.so,libmbedx509.so}
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sparc x86"
 IUSE="cpu_flags_x86_sse2 doc havege libressl programs -static-libs test threads zlib"
 RESTRICT="!test? ( test )"
@@ -21,7 +21,8 @@ RDEPEND="
 		!libressl? ( dev-libs/openssl:0= )
 		libressl? ( dev-libs/libressl:0= )
 	)
-	zlib? ( >=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}] )"
+	zlib? ( >=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}] )
+	!net-libs/mbedtls:2.2"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen media-gfx/graphviz )
 	test? ( dev-lang/perl )"

--- a/net-libs/mbedtls/mbedtls-2.24.0-r1.ebuild
+++ b/net-libs/mbedtls/mbedtls-2.24.0-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/ARMmbed/mbedtls/archive/${P}.tar.gz"
 S=${WORKDIR}/${PN}-${P}
 
 LICENSE="Apache-2.0"
-SLOT="0/5.13.1" # ffmpeg subslot naming: SONAME tuple of {libmbedcrypto.so,libmbedtls.so,libmbedx509.so}
+SLOT="2.2/5.13.1" # ffmpeg subslot naming: SONAME tuple of {libmbedcrypto.so,libmbedtls.so,libmbedx509.so}
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sparc x86"
 IUSE="cpu_flags_x86_sse2 doc havege libressl programs -static-libs test threads zlib"
 RESTRICT="!test? ( test )"
@@ -21,7 +21,8 @@ RDEPEND="
 		!libressl? ( dev-libs/openssl:0= )
 		libressl? ( dev-libs/libressl:0= )
 	)
-	zlib? ( >=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}] )"
+	zlib? ( >=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}] )
+	!net-libs/mbedtls:2.1"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen media-gfx/graphviz )
 	test? ( dev-lang/perl )"


### PR DESCRIPTION
While we still don't support installing multiple net-libs/mbedtls
versions simultaneously, we need slots to support proper targeting in
GLSAs.