### PR TITLE
dev-util/cmake: Backport FPHSA fix

### DIFF
--- a/dev-util/cmake/cmake-3.19.0.ebuild
+++ b/dev-util/cmake/cmake-3.19.0.ebuild
@@ -70,6 +70,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.18.0-filter_distcc_warning.patch # bug 691544
 
 	# upstream fixes (can usually be removed with a version bump)
+	"${FILESDIR}"/${P}-use-FPHSA-outside-find_package.patch # 21505
 )
 
 cmake_src_bootstrap() {

--- a/dev-util/cmake/cmake-3.19.1.ebuild
+++ b/dev-util/cmake/cmake-3.19.1.ebuild
@@ -69,6 +69,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.18.0-filter_distcc_warning.patch # bug 691544
 
 	# upstream fixes (can usually be removed with a version bump)
+	"${FILESDIR}"/${PN}-3.19.0-use-FPHSA-outside-find_package.patch # bug 21505
 )
 
 cmake_src_bootstrap() {

--- a/dev-util/cmake/files/cmake-3.19.0-use-FPHSA-outside-find_package.patch
+++ b/dev-util/cmake/files/cmake-3.19.0-use-FPHSA-outside-find_package.patch
@@ -1,0 +1,26 @@
+diff -Naur a/Modules/FindPackageHandleStandardArgs.cmake b/Modules/FindPackageHandleStandardArgs.cmake
+--- a/Modules/FindPackageHandleStandardArgs.cmake	2020-12-08 13:08:44.157214517 +1100
++++ b/Modules/FindPackageHandleStandardArgs.cmake	2020-12-08 13:11:02.368043125 +1100
+@@ -275,8 +275,10 @@
+     unset (${FPCV_RESULT_MESSAGE_VARIABLE} PARENT_SCOPE)
+   endif()
+ 
+-  if (CMAKE_FIND_PACKAGE_NAME)
+-    set (package ${CMAKE_FIND_PACKAGE_NAME})
++  if (_CMAKE_FPHSA_PACKAGE_NAME)
++    set (package ${_CMAKE_FPHSA_PACKAGE_NAME})
++  elseif (CMAKE_FIND_PACKAGE_NAME)
++    set (package "${CMAKE_FIND_PACKAGE_NAME}")
+   else()
+     message (FATAL_ERROR "find_package_check_version(): Cannot be used outside a 'Find Module'")
+   endif()
+@@ -436,6 +438,9 @@
+       "will be used.")
+   endif()
+ 
++  # to propogate package name to FIND_PACKAGE_CHECK_VERSION
++  set(_CMAKE_FPHSA_PACKAGE_NAME "${_NAME}")
++
+   # now that we collected all arguments, process them
+ 
+   if("x${FPHSA_FAIL_MESSAGE}" STREQUAL "xDEFAULT_MSG")


### PR DESCRIPTION
Changes to Find Package Handle Standard Args in 3.19.0 result in
an error when compiling openvdb-7.1.0.

This is a known problem in cmake and the fix has been merged into
3.19.2 upstream.

See https://gitlab.kitware.com/cmake/cmake/-/issues/21505

To produce the bug:
emerge dev-util/cmake-3.19.0 or 3.19.1 (the bug not exist in <= 3.18)
emerge media-gfx/openvdb-7.1.0-r1

Compilation fails with
find_package_check_version(): Cannot be used outside a 'Find Module'

To fix the bug:
Apply the patch provided in this bug fix to cmake, then repeat the
above steps and compilation of openvdb succeeds.

The patch ensures that the CMAKE_FPHSA_PACKAGE_NAME package is made
available outside find_package.

Thanks to Dennis Schridde for finding the upstream fix, produced by
Marc Chevrier.

Signed-off-by: Adrian Grigo <agrigo2001@yahoo.com.au>
Closes: https://bugs.gentoo.org/755743
Package-Manager: Portage-3.0.9, Repoman-3.0.2