### PR TITLE
dev-python/xvfbwrapper: add PYTHON_COMPAT 3.9

### DIFF
--- a/dev-python/xvfbwrapper/xvfbwrapper-0.2.9.ebuild
+++ b/dev-python/xvfbwrapper/xvfbwrapper-0.2.9.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python{3_6,3_7,3_8} )
+
+PYTHON_COMPAT=( python3_{6..9} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
All tests pass

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>