### PR TITLE
media-libs/osl: require <media-libs/openimageio-2.2

### DIFF
--- a/media-libs/osl/osl-1.10.10.ebuild
+++ b/media-libs/osl/osl-1.10.10.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	dev-libs/boost:=
 	dev-libs/pugixml
 	media-libs/openexr:=
-	media-libs/openimageio:=
+	<media-libs/openimageio-2.2:=
 	<sys-devel/clang-10:=
 	sys-libs/zlib:=
 	partio? ( media-libs/partio )


### PR DESCRIPTION
Only OSL 1.10.13 is compatible with OIIO 2.2, see
https://github.com/imageworks/OpenShadingLanguage/releases/tag/Release-1.10.13