### PR TITLE
x11-libs/cairo: RDEPEND on freetype[png]

### DIFF
--- a/x11-libs/cairo/cairo-1.16.0-r4.ebuild
+++ b/x11-libs/cairo/cairo-1.16.0-r4.ebuild
@@ -31,7 +31,7 @@ BDEPEND="
 RDEPEND="
 	>=dev-libs/lzo-2.06-r1[${MULTILIB_USEDEP}]
 	>=media-libs/fontconfig-2.10.92[${MULTILIB_USEDEP}]
-	>=media-libs/freetype-2.5.0.1:2[${MULTILIB_USEDEP}]
+	>=media-libs/freetype-2.5.0.1:2[png,${MULTILIB_USEDEP}]
 	>=media-libs/libpng-1.6.10:0=[${MULTILIB_USEDEP}]
 	sys-libs/binutils-libs:0=[${MULTILIB_USEDEP}]
 	>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/759337
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>