### PR TITLE
games-arcade/cdogs-sdl: Remove -Werror for build

### DIFF
--- a/games-arcade/cdogs-sdl/cdogs-sdl-0.10.1.ebuild
+++ b/games-arcade/cdogs-sdl/cdogs-sdl-0.10.1.ebuild
@@ -23,6 +23,7 @@ RDEPEND="${DEPEND}"
 
 PATCHES=(
 	"${FILESDIR}/${P}-Add-BUILD_EDITOR-option.patch"
+	"${FILESDIR}/${P}-Remove-Winline-and-Werror-definitions.patch"
 )
 
 src_prepare() {

--- a/games-arcade/cdogs-sdl/files/cdogs-sdl-0.10.1-Remove-Winline-and-Werror-definitions.patch
+++ b/games-arcade/cdogs-sdl/files/cdogs-sdl-0.10.1-Remove-Winline-and-Werror-definitions.patch
@@ -1,0 +1,24 @@
+From 2b55a76518e0492d7003af9af798bd9769f0b586 Mon Sep 17 00:00:00 2001
+From: William Breathitt Gray <vilhelm.gray@gmail.com>
+Date: Thu, 10 Dec 2020 07:07:33 -0500
+Subject: [PATCH] Remove -Winline and -Werror definitions
+
+---
+ CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 510e4802..ed2872b5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -123,7 +123,6 @@ else()
+ 		endif()
+ 	endif()
+ 	if(NOT BEOS AND NOT HAIKU)
+-		add_definitions(-Winline -Werror)
+ 		set(EXTRA_LIBRARIES "m")
+ 	endif()
+ endif()
+-- 
+2.29.2
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/759289
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>