### PR TITLE
dev-python/aiohttp: fix chardet dependency

### DIFF
--- a/dev-python/aiohttp/aiohttp-3.6.2-r1.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.6.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -139,6 +139,10 @@ python_prepare_all() {
 		-i tests/test_frozenlist.py || die
 	sed -e 's:test_proxy_https_bad_response:_&:' \
 		-i tests/test_proxy_functional.py || die
+
+	# newer chardet works too
+	sed -e 's|chardet>=2.0,<4.0|chardet>=2.0|' \
+		-i setup.py aiohttp.egg-info/requires.txt || die
 
 	distutils-r1_python_prepare_all
 }

--- a/dev-python/aiohttp/aiohttp-3.7.1-r1.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.7.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -69,6 +69,10 @@ python_prepare_all() {
 	# Internet
 	sed -e 's:test_mark_formdata_as_processed:_&:' \
 		-i tests/test_formdata.py || die
+
+	# newer chardet works too
+	sed -e 's|chardet>=2.0,<4.0|chardet>=2.0|' \
+		-i setup.py aiohttp.egg-info/requires.txt || die
 
 	# takes a very long time, then fails
 	rm tests/test_pytest_plugin.py || die

--- a/dev-python/aiohttp/aiohttp-3.7.2-r1.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.7.2-r1.ebuild
@@ -71,6 +71,10 @@ python_prepare_all() {
 	sed -e 's:test_mark_formdata_as_processed:_&:' \
 		-i tests/test_formdata.py || die
 
+	# newer chardet works too
+	sed -e 's|chardet>=2.0,<4.0|chardet>=2.0|' \
+		-i setup.py aiohttp.egg-info/requires.txt || die
+
 	# takes a very long time, then fails
 	rm tests/test_pytest_plugin.py || die
 

--- a/dev-python/aiohttp/aiohttp-3.7.3.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.7.3.ebuild
@@ -71,6 +71,10 @@ python_prepare_all() {
 	sed -e 's:test_mark_formdata_as_processed:_&:' \
 		-i tests/test_formdata.py || die
 
+	# newer chardet works too
+	sed -e 's|chardet>=2.0,<4.0|chardet>=2.0|' \
+		-i setup.py aiohttp.egg-info/requires.txt || die
+
 	# takes a very long time, then fails
 	rm tests/test_pytest_plugin.py || die
 


### PR DESCRIPTION
Hi,

Since `dev-python/multidict-4.7.6` was removed with commit f7e2af533f3836caa996963d67f9da27f39c9b32 `net-misc/gns3-server` won't start anymore because aiohttp, which depends on multidict, doesn't work with >multidict-5.0. 
I've reverted the commit and also fixed the dependency for aiohttp in order to reflect this issue. However, since I'm not sure how to depend on a version range (`>=dev-python/multidict-4.5.0` and `<=dev-python/multidict-5.0.0`) I've simply changed it to `=dev-python/multidict-4*`. It's not completely correct either, but since we don't have any older versions it shouldn't have any impact.
