### PR TITLE
app-i18n/transifex-client: fix dependencies, add support for Python 3.9

### DIFF
--- a/app-i18n/transifex-client/transifex-client-0.14.2.ebuild
+++ b/app-i18n/transifex-client/transifex-client-0.14.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1

--- a/app-i18n/transifex-client/transifex-client-0.14.2.ebuild
+++ b/app-i18n/transifex-client/transifex-client-0.14.2.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
-BDEPEND="test? ( dev-python/mock[${PYTHON_USEDEP}] )"
+BDEPEND="test? ( <dev-python/mock-4.0[${PYTHON_USEDEP}] )"
 RDEPEND="dev-python/GitPython[${PYTHON_USEDEP}]
 	<dev-python/python-slugify-5.0.0[${PYTHON_USEDEP}]
 	dev-python/requests[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/758809