### PR TITLE
sys-apps/fakeroot: ac_cv_search_acl_get_fd needed for USE=-acl

### DIFF
--- a/sys-apps/fakeroot/fakeroot-1.25.3.ebuild
+++ b/sys-apps/fakeroot/fakeroot-1.25.3.ebuild
@@ -39,6 +39,7 @@ src_compile() {
 
 src_configure() {
 	export ac_cv_header_sys_acl_h=$(usex acl)
+	use acl || export ac_cv_search_acl_get_fd=no
 
 	use debug && append-cppflags "-DLIBFAKEROOT_DEBUGGING"
 	econf \


### PR DESCRIPTION
We need to add ac_cv_search_acl_get_fd to the autoconf variables
we override when USE=-acl is set

Closes: https://bugs.gentoo.org/759568
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Peter Alfredsen <crabbedhaloablution@icloud.com>