### PR TITLE
sci-libs/gdal: Fix 3.2.0 configure options and subslot

### DIFF
--- a/sci-libs/gdal/gdal-3.2.0-r1.ebuild
+++ b/sci-libs/gdal/gdal-3.2.0-r1.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Translator library for raster geospatial data formats (includes OGR
 HOMEPAGE="https://gdal.org/"
 SRC_URI="https://download.osgeo.org/${PN}/${PV}/${P}.tar.gz"
 
-SLOT="0/3.0"
+SLOT="0/3.2"
 LICENSE="BSD Info-ZIP MIT"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="armadillo +aux-xml curl debug doc fits geos gif gml hdf5 java jpeg jpeg2k lzma mdb mysql netcdf odbc ogdi opencl oracle pdf perl png postgres python spatialite sqlite threads webp xls zstd"
@@ -162,7 +162,6 @@ src_configure() {
 		--without-podofo
 		--without-python
 		--without-qhull
-		--without-sde
 		--without-sfcgal
 		--without-sosi
 		--without-teigha


### PR DESCRIPTION
* SDE was dropped by upstream for 3.2.0.
* SONAME changed from 3.0.0 to 3.2.0

Bug: https://bugs.gentoo.org/759340
Bug: https://bugs.gentoo.org/759538
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Daniel M. Weeks <dan@danweeks.net>