### PR TITLE
Fix quoting for pkg-config calls in several packages

### DIFF
--- a/gnome-base/gdm/gdm-3.36.3.ebuild
+++ b/gnome-base/gdm/gdm-3.36.3.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 GNOME2_LA_PUNT="yes"
 GNOME2_EAUTORECONF="yes"
 
-inherit eutils gnome2 pam readme.gentoo-r1 systemd udev user
+inherit eutils gnome2 pam readme.gentoo-r1 systemd toolchain-funcs udev user
 
 DESCRIPTION="GNOME Display Manager for managing graphical display servers and user logins"
 HOMEPAGE="https://wiki.gnome.org/Projects/GDM"
@@ -187,10 +187,11 @@ src_configure() {
 	)
 
 	if use elogind; then
+		local pkgconfig="$(tc-getPKG_CONFIG)"
 		myconf+=(
 			--with-initial-vt=7 # TODO: Revisit together with startDM.sh and other xinit talks; also ignores plymouth possibility
-			SYSTEMD_CFLAGS=`pkg-config --cflags "libelogind" 2>/dev/null`
-			SYSTEMD_LIBS=`pkg-config --libs "libelogind" 2>/dev/null`
+			SYSTEMD_CFLAGS="$(${pkgconfig} --cflags "libelogind")"
+			SYSTEMD_LIBS="$(${pkgconfig} --libs "libelogind")"
 		)
 	fi
 

--- a/gnome-base/gdm/gdm-3.36.4.ebuild
+++ b/gnome-base/gdm/gdm-3.36.4.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 GNOME2_LA_PUNT="yes"
 GNOME2_EAUTORECONF="yes"
 
-inherit eutils gnome2 pam readme.gentoo-r1 systemd udev user
+inherit eutils gnome2 pam readme.gentoo-r1 systemd toolchain-funcs udev user
 
 DESCRIPTION="GNOME Display Manager for managing graphical display servers and user logins"
 HOMEPAGE="https://wiki.gnome.org/Projects/GDM"
@@ -187,10 +187,11 @@ src_configure() {
 	)
 
 	if use elogind; then
+		local pkgconfig="$(tc-getPKG_CONFIG)"
 		myconf+=(
 			--with-initial-vt=7 # TODO: Revisit together with startDM.sh and other xinit talks; also ignores plymouth possibility
-			SYSTEMD_CFLAGS=`pkg-config --cflags "libelogind" 2>/dev/null`
-			SYSTEMD_LIBS=`pkg-config --libs "libelogind" 2>/dev/null`
+			SYSTEMD_CFLAGS="$(${pkgconfig} --cflags "libelogind")"
+			SYSTEMD_LIBS="$(${pkgconfig} --libs "libelogind")"
 		)
 	fi
 

--- a/gnome-base/gnome-flashback/gnome-flashback-3.36.4.ebuild
+++ b/gnome-base/gnome-flashback/gnome-flashback-3.36.4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit gnome2
+inherit gnome2 toolchain-funcs
 
 DESCRIPTION="GNOME Flashback session"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/gnome-flashback/"
@@ -71,11 +71,12 @@ src_configure() {
 	fi
 
 	if use elogind; then
+		local pkgconfig="$(tc-getPKG_CONFIG)"
 		myconf+=(
-			DESKTOP_CFLAGS=`pkg-config --cflags glib-2.0 gio-2.0 gio-unix-2.0 gnome-desktop-3.0 gtk+-3.0 libelogind x11 2>/dev/null`
-			DESKTOP_LIBS=`pkg-config --libs glib-2.0 gio-2.0 gio-unix-2.0 gnome-desktop-3.0 gtk+-3.0 libelogind x11 2>/dev/null`
-			SCREENSAVER_CFLAGS=`pkg-config --cflags gdm gio-unix-2.0 glib-2.0 gnome-desktop-3.0 gtk+-3.0 libelogind xxf86vm 2>/dev/null`
-			SCREENSAVER_LIBS=`pkg-config --libs gdm gio-unix-2.0 glib-2.0 gnome-desktop-3.0 gtk+-3.0 libelogind xxf86vm 2>/dev/null`
+			DESKTOP_CFLAGS="$(${pkgconfig} --cflags glib-2.0 gio-2.0 gio-unix-2.0 gnome-desktop-3.0 gtk+-3.0 libelogind x11)"
+			DESKTOP_LIBS="$(${pkgconfig} --libs glib-2.0 gio-2.0 gio-unix-2.0 gnome-desktop-3.0 gtk+-3.0 libelogind x11)"
+			SCREENSAVER_CFLAGS="$(${pkgconfig} --cflags gdm gio-unix-2.0 glib-2.0 gnome-desktop-3.0 gtk+-3.0 libelogind xxf86vm)"
+			SCREENSAVER_LIBS="$(${pkgconfig} --libs gdm gio-unix-2.0 glib-2.0 gnome-desktop-3.0 gtk+-3.0 libelogind xxf86vm)"
 		)
 	fi
 

--- a/gnome-base/gnome-panel/gnome-panel-3.36.2.ebuild
+++ b/gnome-base/gnome-panel/gnome-panel-3.36.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit eapi7-ver gnome2
+inherit eapi7-ver gnome2 toolchain-funcs
 
 DESCRIPTION="The GNOME Flashback Panel"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/gnome-panel/"
@@ -61,9 +61,10 @@ src_configure() {
 	fi
 
 	if use elogind; then
+		local pkgconfig="$(tc-getPKG_CONFIG)"
 		myconf+=(
-			MENU_CFLAGS=`pkg-config --cflags gdm gio-unix-2.0 gtk+-3.0 libgnome-menu-3.0 libelogind 2>/dev/null`
-			MENU_LIBS=`pkg-config --libs gdm gio-unix-2.0 gtk+-3.0 libgnome-menu-3.0 libelogind 2>/dev/null`
+			MENU_CFLAGS="$(${pkgconfig} --cflags gdm gio-unix-2.0 gtk+-3.0 libgnome-menu-3.0 libelogind)"
+			MENU_LIBS="$(${pkgconfig} --libs gdm gio-unix-2.0 gtk+-3.0 libgnome-menu-3.0 libelogind)"
 		)
 	fi
 

--- a/mate-extra/mate-system-monitor/mate-system-monitor-1.24.0.ebuild
+++ b/mate-extra/mate-system-monitor/mate-system-monitor-1.24.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit mate
+inherit mate toolchain-funcs
 
 if [[ ${PV} != 9999 ]]; then
 	KEYWORDS="amd64 ~arm ~arm64 x86"
@@ -51,9 +51,10 @@ src_configure() {
 	if use elogind || use systemd; then
 		myconf+=( --enable-systemd )
 		if use elogind; then
+			local pkgconfig="$(tc-getPKG_CONFIG)"
 			myconf+=(
-				SYSTEMD_CFLAGS=`pkg-config --cflags "libelogind" 2>/dev/null`
-				SYSTEMD_LIBS=`pkg-config --libs "libelogind" 2>/dev/null`
+				SYSTEMD_CFLAGS="$(${pkgconfig} --cflags "libelogind")"
+				SYSTEMD_LIBS="$(${pkgconfig} --libs "libelogind")"
 			)
 		fi
 	else

--- a/mate-extra/mate-system-monitor/mate-system-monitor-1.24.1.ebuild
+++ b/mate-extra/mate-system-monitor/mate-system-monitor-1.24.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit mate
+inherit mate toolchain-funcs
 
 if [[ ${PV} != 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
@@ -51,9 +51,10 @@ src_configure() {
 	if use elogind || use systemd; then
 		myconf+=( --enable-systemd )
 		if use elogind; then
+			local pkgconfig="$(tc-getPKG_CONFIG)"
 			myconf+=(
-				SYSTEMD_CFLAGS=`pkg-config --cflags "libelogind" 2>/dev/null`
-				SYSTEMD_LIBS=`pkg-config --libs "libelogind" 2>/dev/null`
+				SYSTEMD_CFLAGS="$(${pkgconfig} --cflags "libelogind")"
+				SYSTEMD_LIBS="$(${pkgconfig} --libs "libelogind")"
 			)
 		fi
 	else

--- a/media-sound/pulseaudio/pulseaudio-13.0-r1.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-13.0-r1.ebuild
@@ -200,8 +200,8 @@ multilib_src_configure() {
 		local PKGCONFIG="$(tc-getPKG_CONFIG)"
 		myconf+=(
 			--enable-systemd-login
-			SYSTEMDLOGIN_CFLAGS="$(${PKGCONFIG} --cflags "libelogind" 2>/dev/null)"
-			SYSTEMDLOGIN_LIBS="$(${PKGCONFIG} --libs "libelogind" 2>/dev/null)"
+			SYSTEMDLOGIN_CFLAGS="$(${PKGCONFIG} --cflags "libelogind")"
+			SYSTEMDLOGIN_LIBS="$(${PKGCONFIG} --libs "libelogind")"
 		)
 	fi
 

--- a/media-sound/pulseaudio/pulseaudio-13.0.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-13.0.ebuild
@@ -205,8 +205,8 @@ multilib_src_configure() {
 		local PKGCONFIG="$(tc-getPKG_CONFIG)"
 		myconf+=(
 			--enable-systemd-login
-			SYSTEMDLOGIN_CFLAGS="$(${PKGCONFIG} --cflags "libelogind" 2>/dev/null)"
-			SYSTEMDLOGIN_LIBS="$(${PKGCONFIG} --libs "libelogind" 2>/dev/null)"
+			SYSTEMDLOGIN_CFLAGS="$(${PKGCONFIG} --cflags "libelogind")"
+			SYSTEMDLOGIN_LIBS="$(${PKGCONFIG} --libs "libelogind")"
 		)
 	fi
 

--- a/net-misc/modemmanager/modemmanager-1.10.0.ebuild
+++ b/net-misc/modemmanager/modemmanager-1.10.0.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 GNOME2_LA_PUNT="yes"
 VALA_USE_DEPEND="vapigen"
 
-inherit gnome2 readme.gentoo-r1 systemd udev vala
+inherit gnome2 readme.gentoo-r1 systemd toolchain-funcs udev vala
 
 DESCRIPTION="Modem and mobile broadband management libraries"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/ModemManager/"
@@ -75,10 +75,11 @@ src_configure() {
 		$(use_enable vala)
 	)
 	if use elogind; then
+		local pkgconfig="$(tc-getPKG_CONFIG)"
 		myconf+=(
 			--with-systemd-suspend-resume
-			LIBSYSTEMD_LOGIN_CFLAGS=`pkg-config --cflags "libelogind" 2>/dev/null`
-			LIBSYSTEMD_LOGIN_LIBS=`pkg-config --libs "libelogind" 2>/dev/null`
+			LIBSYSTEMD_LOGIN_CFLAGS="$(${pkgconfig} --cflags "libelogind")"
+			LIBSYSTEMD_LOGIN_LIBS="$(${pkgconfig} --libs "libelogind")"
 		)
 	fi
 	gnome2_src_configure "${myconf[@]}"

--- a/net-misc/modemmanager/modemmanager-1.8.2-r1.ebuild
+++ b/net-misc/modemmanager/modemmanager-1.8.2-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 GNOME2_LA_PUNT="yes"
 VALA_USE_DEPEND="vapigen"
 
-inherit gnome2 readme.gentoo-r1 systemd udev vala
+inherit gnome2 readme.gentoo-r1 systemd toolchain-funcs udev vala
 
 DESCRIPTION="Modem and mobile broadband management libraries"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/ModemManager/"
@@ -75,10 +75,11 @@ src_configure() {
 		$(use_enable vala)
 	)
 	if use elogind; then
+		local pkgconfig="$(tc-getPKG_CONFIG)"
 		myconf+=(
 			--with-systemd-suspend-resume
-			LIBSYSTEMD_LOGIN_CFLAGS=`pkg-config --cflags "libelogind" 2>/dev/null`
-			LIBSYSTEMD_LOGIN_LIBS=`pkg-config --libs "libelogind" 2>/dev/null`
+			LIBSYSTEMD_LOGIN_CFLAGS="$(${pkgconfig} --cflags "libelogind")"
+			LIBSYSTEMD_LOGIN_LIBS="$(${pkgconfig} --libs "libelogind")"
 		)
 	fi
 	gnome2_src_configure "${myconf[@]}"


### PR DESCRIPTION
Also, stop redirecting error output to `/dev/null`; that hides useful information from the build log.