### PR TITLE
Further merges from ::prefix

### DIFF
--- a/app-arch/bzip2/bzip2-1.0.8-r1.ebuild
+++ b/app-arch/bzip2/bzip2-1.0.8-r1.ebuild
@@ -6,7 +6,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs multilib-minimal usr-ldscript
+inherit toolchain-funcs multilib-minimal usr-ldscript prefix
 
 DESCRIPTION="A high-quality data compressor used extensively by Gentoo Linux"
 HOMEPAGE="https://sourceware.org/bzip2/"
@@ -14,7 +14,7 @@ SRC_URI="https://sourceware.org/pub/${PN}/${P}.tar.gz"
 
 LICENSE="BZIP2"
 SLOT="0/1" # subslot = SONAME
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
 IUSE="static static-libs"
 
 PATCHES=(
@@ -25,6 +25,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.0.3-no-test.patch
 	"${FILESDIR}"/${PN}-1.0.8-mingw.patch #393573
 	"${FILESDIR}"/${PN}-1.0.8-out-of-tree-build.patch
+
+	"${FILESDIR}"/${PN}-1.0.6-r7-checkenv.patch # for AIX, Darwin?
 )
 
 DOCS=( CHANGES README{,.COMPILATION.PROBLEMS,.XML.STUFF} manual.pdf )
@@ -41,6 +43,28 @@ src_prepare() {
 		-e 's:ln -s -f $(PREFIX)/bin/:ln -s -f :' \
 		-e 's:$(PREFIX)/lib:$(PREFIX)/$(LIBDIR):g' \
 		Makefile || die
+
+	if use prefix ; then
+		hprefixify -w "/^PATH=/" bz{diff,grep,more}
+
+		# This is a makefile for Darwin, which already "includes" sane so
+		cp "${FILESDIR}"/${PN}-1.0.6-Makefile-libbz2_dylib Makefile-libbz2_dylib || die
+
+		if [[ ${CHOST} == *-hpux* ]] ; then
+			sed -i -e 's,-soname,+h,' Makefile-libbz2_so || die "cannot replace -soname with +h"
+			if [[ ${CHOST} == hppa*-hpux* && ${CHOST} != hppa64*-hpux* ]] ; then
+				sed -i -e '/^SOEXT/s,so,sl,' Makefile-libbz2_so || die "cannot replace so with sl"
+				sed -i -e '/^SONAME/s,=,=${EPREFIX}/lib/,' Makefile-libbz2_so || die "cannt set soname"
+			fi
+		fi
+
+		if [[ ${CHOST} == *-cygwin* ]] ; then
+			sed -i -e "s/-o libbz2\.so\.${PV}/-Wl,--out-implib=libbz2$(get_libname ${PV})/" \
+				   -e "s/-Wl,-soname -Wl,libbz2\.so\.1/-o cygbz2-${PV%%.*}.dll/" \
+				   -e "s/libbz2\.so/libbz2$(get_libname)/g" \
+				Makefile-libbz2_so
+		fi
+	fi
 }
 
 bemake() {
@@ -53,9 +77,26 @@ bemake() {
 }
 
 multilib_src_compile() {
-	bemake -f "${S}"/Makefile-libbz2_so all
-	# Make sure we link against the shared lib #504648
-	ln -s libbz2.so.${PV} libbz2.so || die
+	local checkopts=
+	case "${CHOST}" in
+		*-darwin*)
+			bemake PREFIX="${EPREFIX}"/usr -f "${S}"/Makefile-libbz2_dylib all
+			# FWIW, #504648 like for .so below
+			ln -sf libbz2.${PV}.dylib libbz2.dylib || die
+		;;
+		*-mint*)
+			# do nothing, no shared libraries
+			:
+		;;
+		*)
+			bemake -f "${S}"/Makefile-libbz2_so all
+			# Make sure we link against the shared lib #504648
+			if [[ $(get_libname) != $(get_libname ${PV}) ]] ; then
+				ln -sf libbz2$(get_libname ${PV}) libbz2$(get_libname) || die
+			fi
+
+		;;
+	esac
 	bemake -f "${S}"/Makefile all LDFLAGS="${LDFLAGS} $(usex static -static '')"
 }
 
@@ -66,17 +107,24 @@ multilib_src_install() {
 	#  .x.x.x - standard shared lib behavior
 	#  .x.x   - SONAME some distros use #338321
 	#  .x     - SONAME Gentoo uses
-	dolib.so libbz2.so.${PV}
-	local v
-	for v in libbz2.so{,.{${PV%%.*},${PV%.*}}} ; do
-		dosym libbz2.so.${PV} /usr/$(get_libdir)/${v}
-	done
+	dolib.so libbz2$(get_libname ${PV})
+
+	if [[ ${CHOST} == *-cygwin* ]] ; then
+		dobin cygbz2-${PV%%.*}.dll
+	fi
+
+	if [[ $(get_libname) != $(get_libname ${PV}) ]] ; then
+		local v
+		for v in libbz2$(get_libname) libbz2$(get_libname ${PV%%.*}) libbz2$(get_libname ${PV%.*}) ; do
+			dosym libbz2$(get_libname ${PV}) /usr/$(get_libdir)/${v}
+		done
+	fi
 
 	# Install libbz2.so.1.0 due to accidental soname change in 1.0.7.
 	# Reference: 98da0ad82192d21ad74ae52366ea8466e2acea24.
 	# OK to remove one year after 2020-04-11.
-	if [[ ! -L "${ED}/usr/$(get_libdir)/libbz2.so.1.0" ]]; then
-		dosym libbz2.so.${PV} "/usr/$(get_libdir)/libbz2.so.1.0"
+	if [[ ! -L "${ED}/usr/$(get_libdir)/libbz2$(get_libname 1.0)" ]]; then
+		dosym libbz2$(get_libname ${PV}) "/usr/$(get_libdir)/libbz2$(get_libname 1.0)"
 	fi
 
 	use static-libs && dolib.a libbz2.a

--- a/app-arch/bzip2/files/bzip2-1.0.6-Makefile-libbz2_dylib
+++ b/app-arch/bzip2/files/bzip2-1.0.6-Makefile-libbz2_dylib
@@ -1,0 +1,42 @@
+
+# This Makefile builds a shared version of the library, 
+# libbz2.1.0.6.dylib, with install_name libbz2.1.dylib on Darwin
+#
+# Makefile created and used by Gentoo
+
+# ------------------------------------------------------------------
+# This file is part of bzip2/libbzip2, a program and library for
+# lossless, block-sorting data compression.
+#
+# bzip2/libbzip2 version 1.0.6 of 6 September 2010
+# Copyright (C) 1996-2010 Julian Seward <jseward@bzip.org>
+#
+# Please read the WARNING, DISCLAIMER and PATENTS sections in the 
+# README file.
+#
+# This program is released under the terms of the license contained
+# in the file LICENSE.
+# ------------------------------------------------------------------
+
+
+SHELL=/bin/sh
+CC=gcc
+BIGFILES=-D_FILE_OFFSET_BITS=64
+CFLAGS+=-fpic -fPIC -Wall -Winline $(BIGFILES) $(CPPFLAGS)
+PREFIX=/usr
+LIBDIR=lib
+SOLDFLAGS=-dynamiclib -install_name $(PREFIX)/$(LIBDIR)/libbz2.1.dylib -compatibility_version 1.0.0 -current_version 1.0.6
+
+OBJS= blocksort.o  \
+      huffman.o    \
+      crctable.o   \
+      randtable.o  \
+      compress.o   \
+      decompress.o \
+      bzlib.o
+
+all: $(OBJS)
+	$(CC) $(LDFLAGS) $(SOLDFLAGS) -o libbz2.1.0.6.dylib $(OBJS)
+
+clean: 
+	rm -f $(OBJS) bzip2.o libbz2.1.0.6.dylib libbz2.1.0.dylib bzip2-shared

--- a/app-arch/bzip2/files/bzip2-1.0.6-checkenv.patch
+++ b/app-arch/bzip2/files/bzip2-1.0.6-checkenv.patch
@@ -1,0 +1,21 @@
+--- a/Makefile	2005-02-17 05:28:24.000000000 -0600
++++ b/Makefile	2005-10-12 20:26:29.000000000 -0500
+@@ -42,12 +42,12 @@
+ 
+ check: test
+ test: bzip2
+-	./bzip2 -1  < sample1.ref > sample1.rb2
+-	./bzip2 -2  < sample2.ref > sample2.rb2
+-	./bzip2 -3  < sample3.ref > sample3.rb2
+-	./bzip2 -d  < sample1.bz2 > sample1.tst
+-	./bzip2 -d  < sample2.bz2 > sample2.tst
+-	./bzip2 -ds < sample3.bz2 > sample3.tst
++	$(TESTENV) ./bzip2 -1  < sample1.ref > sample1.rb2
++	$(TESTENV) ./bzip2 -2  < sample2.ref > sample2.rb2
++	$(TESTENV) ./bzip2 -3  < sample3.ref > sample3.rb2
++	$(TESTENV) ./bzip2 -d  < sample1.bz2 > sample1.tst
++	$(TESTENV) ./bzip2 -d  < sample2.bz2 > sample2.tst
++	$(TESTENV) ./bzip2 -ds < sample3.bz2 > sample3.tst
+ 	cmp sample1.bz2 sample1.rb2 
+ 	cmp sample2.bz2 sample2.rb2
+ 	cmp sample3.bz2 sample3.rb2


### PR DESCRIPTION
Affected ebuilds:
- ~sys-libs/zlib: minor changes for Cygwin only~
- ~app-arch/unzip: across the board Prefix changes but limited in scope (just CHOST parsing)~
- app-arch/bzip2: still needs work, here as a draft

All changes are prefix-only and erring on the side of caution (i.e. do nothing in non-prefix case, even if harmless).

This is mostly here to help me organise my work. They're not necessarily ready to review or going to be merged as-is. Comments from passers-by in prefix or base-system are welcome but not being solicited yet.

TODO:
- Thoroughly test and examine the bzip2 changes (especially with lib naming)

Future areas:
- ncurses
- readline
- [db.eclass](https://bugs.gentoo.org/show_bug.cgi?id=673322)?