### PR TITLE
x11-terms/kitty: disable builtin automatic update check

### DIFF
--- a/x11-terms/kitty/kitty-0.19.1.ebuild
+++ b/x11-terms/kitty/kitty-0.19.1.ebuild
@@ -80,6 +80,7 @@ src_compile() {
 	"${EPYTHON}" setup.py \
 		--verbose $(usex debug --debug "") \
 		--libdir-name $(get_libdir) \
+		--update-check-interval=0 \
 		linux-package || die "Failed to compile kitty."
 }
 

--- a/x11-terms/kitty/kitty-0.19.2.ebuild
+++ b/x11-terms/kitty/kitty-0.19.2.ebuild
@@ -81,6 +81,7 @@ src_compile() {
 	"${EPYTHON}" setup.py \
 		--verbose $(usex debug --debug "") \
 		--libdir-name $(get_libdir) \
+		--update-check-interval=0 \
 		linux-package || die "Failed to compile kitty."
 }
 

--- a/x11-terms/kitty/kitty-9999.ebuild
+++ b/x11-terms/kitty/kitty-9999.ebuild
@@ -79,6 +79,7 @@ src_compile() {
 	"${EPYTHON}" setup.py \
 		--verbose $(usex debug --debug "") \
 		--libdir-name $(get_libdir) \
+		--update-check-interval=0 \
 		linux-package || die "Failed to compile kitty."
 }
 


### PR DESCRIPTION
disable the automatic update check which periodically contacts
the developer's webserver.

Signed-off-by: Jonas Jelten <jj@sft.lol>