### PR TITLE
app-text/nfoview-1.28 python3_9 compat

### DIFF
--- a/app-text/nfoview/nfoview-1.28.ebuild
+++ b/app-text/nfoview/nfoview-1.28.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=no
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
 inherit distutils-r1 xdg-utils
 

--- a/app-text/nfoview/nfoview-9999.ebuild
+++ b/app-text/nfoview/nfoview-9999.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7} )
+DISTUTILS_USE_SETUPTOOLS=no
+PYTHON_COMPAT=( python3_{6,7,8,9} )
 
-inherit distutils-r1 gnome2-utils xdg-utils
+inherit distutils-r1 xdg-utils
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/otsaloma/nfoview.git"
@@ -22,16 +23,18 @@ LICENSE="GPL-3+"
 SLOT="0"
 IUSE=""
 
+BDEPEND="${PYTHON_DEPS}
+	sys-devel/gettext"
 DEPEND="dev-python/pygobject:3[${PYTHON_USEDEP}]"
 RDEPEND="${DEPEND}
-	media-fonts/terminus-font"
+	media-fonts/cascadia-code"
 
 pkg_postinst() {
-	gnome2_icon_cache_update
+	xdg_icon_cache_update
 	xdg_desktop_database_update
 }
 
 pkg_postrm() {
-	gnome2_icon_cache_update
+	xdg_icon_cache_update
 	xdg_desktop_database_update
 }


### PR DESCRIPTION
Added python3_9 compatibility to app-text/nfoview-1.28 and copied this latest version over to the live ebuild.