### PR TITLE
dev-libs/aws-c-event-stream: Add missing dev-libs/aws-c-io dependency

### DIFF
--- a/dev-libs/aws-c-event-stream/aws-c-event-stream-0.2.5-r1.ebuild
+++ b/dev-libs/aws-c-event-stream/aws-c-event-stream-0.2.5-r1.ebuild
@@ -25,6 +25,7 @@ BDEPEND="
 
 DEPEND="
 	>=dev-libs/aws-c-common-0.4.62:=[static-libs=]
+	>=dev-libs/aws-c-io-0.7.0:=[static-libs=]
 	>=dev-libs/aws-checksums-0.1.10:=[static-libs=]
 "
 


### PR DESCRIPTION
Sorry, I forgot that one. :facepalm: 

Closes: https://bugs.gentoo.org/759805
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Sven Eden <sven.eden@prydeworx.com>