### PR TITLE
mail-client/roundcube: php-8 always has json so dropped the flag

### DIFF
--- a/mail-client/roundcube/roundcube-1.4.9.ebuild
+++ b/mail-client/roundcube/roundcube-1.4.9.ebuild
@@ -26,7 +26,7 @@ need_httpd_cgi
 
 RDEPEND="
 	${DEPEND}
-	>=dev-lang/php-5.4.0[filter,gd,iconv,json,ldap?,pdo,postgres?,session,sqlite?,ssl?,unicode,xml]
+	>=dev-lang/php-5.4.0[filter,gd,iconv,json(+),ldap?,pdo,postgres?,session,sqlite?,ssl?,unicode,xml]
 	virtual/httpd-php
 	change-password? (
 		dev-lang/php[sockets]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/758995
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Craig Andrews <candrews@gentoo.org>