### PR TITLE
net-misc/chrony: lots of little nits.

### DIFF
--- a/net-misc/chrony/chrony-4.0-r1.ebuild
+++ b/net-misc/chrony/chrony-4.0-r1.ebuild
@@ -1,0 +1,190 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit systemd tmpfiles toolchain-funcs
+
+DESCRIPTION="NTP client and server programs"
+HOMEPAGE="https://chrony.tuxfamily.org/"
+
+if [[ ${PV} == "9999" ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://git.tuxfamily.org/chrony/chrony.git"
+else
+	SRC_URI="https://download.tuxfamily.org/${PN}/${P/_/-}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+fi
+
+S="${WORKDIR}/${P/_/-}"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="+caps +cmdmon debug html ipv6 libedit +nettle nss +ntp +phc +nts pps +refclock +rtc samba +seccomp +sechash selinux"
+REQUIRED_USE="
+	sechash? ( || ( nettle nss  ) )
+	nettle? ( !nss )
+	!sechash? ( !nss )
+	!sechash? ( !nts? ( !nettle ) )
+	nts? ( nettle )
+	"
+RESTRICT="test"
+
+BDEPEND="nettle? ( virtual/pkgconfig )"
+
+if [[ ${PV} == "9999" ]]; then
+	# Needed for doc generation in 9999
+	BDEPEND+=" virtual/w3m"
+	REQUIRED_USE+=" html"
+fi
+
+DEPEND="
+	caps? (
+		acct-group/ntp
+		acct-user/ntp
+		sys-libs/libcap
+	)
+	nts? ( net-libs/gnutls:= )
+	libedit? ( dev-libs/libedit )
+	nettle? ( dev-libs/nettle:= )
+	nss? ( dev-libs/nss:= )
+	seccomp? ( sys-libs/libseccomp )
+	html? ( dev-ruby/asciidoctor )
+	pps? ( net-misc/pps-tools )
+"
+RDEPEND="
+	${DEPEND}
+	selinux? ( sec-policy/selinux-chronyd )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.5-pool-vendor-gentoo.patch
+	"${FILESDIR}"/${PN}-3.5-r3-systemd-gentoo.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i \
+		-e 's:/etc/chrony\.conf:/etc/chrony/chrony.conf:g' \
+		doc/* examples/* || die
+
+	cp "${FILESDIR}"/chronyd.conf "${T}"/chronyd.conf || die
+}
+
+src_configure() {
+	if ! use caps; then
+		sed -i \
+			-e 's/ -u ntp//' \
+			"${T}"/chronyd.conf examples/chronyd.service || die
+	fi
+
+	if ! use seccomp; then
+		sed -i \
+			-e 's/ -F 0//' \
+			"${T}"/chronyd.conf examples/chronyd.service || die
+	fi
+
+	tc-export CC PKG_CONFIG
+
+	# Update from time to time with output from "date +%s"
+	# on a system that is time-synced.
+	export SOURCE_DATE_EPOCH=1607976314
+
+	# not an autotools generated script
+	local myconf=(
+		$(use_enable seccomp scfilter)
+		$(usex caps '' --disable-linuxcaps)
+		$(usex cmdmon '' --disable-cmdmon)
+		$(usex debug '--enable-debug' '')
+		$(usex ipv6 '' --disable-ipv6)
+		$(usex libedit '' --without-editline)
+		$(usex nettle '' --without-nettle)
+		$(usex nss '' --without-nss)
+		$(usex ntp '' --disable-ntp)
+		$(usex nts '' --disable-nts)
+		$(usex nts '' --without-gnutls)
+		$(usex phc '' --disable-phc)
+		$(usex pps '' --disable-pps)
+		$(usex refclock '' --disable-refclock)
+		$(usex rtc '' --disable-rtc)
+		$(usex samba --enable-ntp-signd '')
+		$(usex sechash '' --disable-sechash)
+		${EXTRA_ECONF}
+		--chronysockdir="${EPREFIX}/run/chrony"
+		--docdir="${EPREFIX}/usr/share/doc/${PF}"
+		--mandir="${EPREFIX}/usr/share/man"
+		--prefix="${EPREFIX}/usr"
+		--sysconfdir="${EPREFIX}/etc/chrony"
+		--with-hwclockfile="${EPREFIX}/etc/adjtime"
+		--with-pidfile="${EPREFIX}/run/chrony/chronyd.pid"
+		--without-tomcrypt
+	)
+
+	# print the ./configure call
+	echo sh ./configure "${myconf[@]}" >&2
+	sh ./configure "${myconf[@]}" || die
+}
+
+src_compile() {
+	if [[ ${PV} == "9999" ]]; then
+		# uses w3m
+		emake -C doc man txt
+	fi
+
+	emake all docs $(usex html '' 'ADOC=true')
+}
+
+src_install() {
+	default
+
+	newinitd "${FILESDIR}"/chronyd.init-r2 chronyd
+	newconfd "${T}"/chronyd.conf chronyd
+
+	insinto /etc/${PN}
+	newins examples/chrony.conf.example1 chrony.conf
+
+	docinto examples
+	dodoc examples/*.example*
+
+	newtmpfiles - chronyd.conf <<<"d /run/chrony 0750 $(usex caps 'ntp ntp' 'root root')"
+
+	if use html; then
+		docinto html
+		dodoc doc/*.html
+	fi
+
+	keepdir /var/{lib,log}/chrony
+
+	if use caps; then
+		# Prepare a directory for the chrony.drift file (a la ntpsec)
+		# Ensures the environment is sane on new installs
+		fowners ntp:ntp /var/{lib,log}/chrony
+		fperms 770 /var/lib/chrony
+	fi
+
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}"/chrony-2.4-r1.logrotate chrony
+
+	systemd_dounit examples/chronyd.service
+	systemd_dounit examples/chrony-wait.service
+	systemd_enable_ntpunit 50-chrony chronyd.service
+}
+
+pkg_preinst() {
+	HAD_CAPS=false
+
+	if has_version 'net-misc/chrony[caps]'; then
+		HAD_CAPS=true
+	fi
+}
+
+pkg_postinst() {
+	tmpfiles_process chronyd.conf
+
+	if [[ -n ${REPLACING_VERSIONS} ]] && use caps && ! ${HAD_CAPS}; then
+		ewarn "Please adjust permissions on ${EROOT}/var/{lib,log}/chrony to be owned by ntp:ntp"
+		ewarn "e.g. chown -R ntp:ntp ${EROOT}/var/{lib,log}/chrony"
+		ewarn "This is necessary for chrony to drop privileges"
+	fi
+}

--- a/net-misc/chrony/chrony-9999.ebuild
+++ b/net-misc/chrony/chrony-9999.ebuild
@@ -20,8 +20,13 @@ S="${WORKDIR}/${P/_/-}"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+caps +cmdmon html ipv6 libedit +nettle +ntp +phc pps +refclock +rtc samba +seccomp +sechash selinux"
-REQUIRED_USE="sechash? ( nettle )"
+IUSE="+caps +cmdmon html ipv6 libedit +nettle nss +ntp +phc pps +refclock +rtc samba +seccomp +sechash selinux"
+REQUIRED_USE="
+	sechash? ( || ( nettle nss  ) )
+	nettle? ( !nss )
+	!sechash? ( !nss )
+	!sechash? ( !nts? ( !nettle ) )
+	"
 RESTRICT="test"
 
 BDEPEND="nettle? ( virtual/pkgconfig )"
@@ -40,6 +45,7 @@ DEPEND="
 	)
 	libedit? ( dev-libs/libedit )
 	nettle? ( dev-libs/nettle:= )
+	nss? ( dev-libs/nss:= )
 	seccomp? ( sys-libs/libseccomp )
 	html? ( dev-ruby/asciidoctor )
 	pps? ( net-misc/pps-tools )
@@ -84,8 +90,6 @@ src_configure() {
 
 	tc-export CC PKG_CONFIG
 
-	# Note: ncurses and nss switches are mentioned in the configure script but
-	# do nothing
 	# not an autotools generated script
 	local myconf=(
 		$(use_enable seccomp scfilter)
@@ -94,6 +98,7 @@ src_configure() {
 		$(usex ipv6 '' --disable-ipv6)
 		$(usex libedit '' --without-editline)
 		$(usex nettle '' --without-nettle)
+		$(usex nss '' --without-nss)
 		$(usex ntp '' --disable-ntp)
 		$(usex phc '' --disable-phc)
 		$(usex pps '' --disable-pps)
@@ -109,7 +114,6 @@ src_configure() {
 		--sysconfdir="${EPREFIX}/etc/chrony"
 		--with-hwclockfile="${EPREFIX}/etc/adjtime"
 		--with-pidfile="${EPREFIX}/run/chrony/chronyd.pid"
-		--without-nss
 		--without-tomcrypt
 	)
 

--- a/net-misc/chrony/chrony-9999.ebuild
+++ b/net-misc/chrony/chrony-9999.ebuild
@@ -69,10 +69,6 @@ src_prepare() {
 		-e 's:/etc/chrony\.conf:/etc/chrony/chrony.conf:g' \
 		doc/* examples/* || die
 
-	sed -i \
-		-e 's|RELOADDNS||g' \
-		configure || die
-
 	cp "${FILESDIR}"/chronyd.conf "${T}"/chronyd.conf || die
 }
 

--- a/net-misc/chrony/chrony-9999.ebuild
+++ b/net-misc/chrony/chrony-9999.ebuild
@@ -71,7 +71,6 @@ src_prepare() {
 
 	sed -i \
 		-e 's|RELOADDNS||g' \
-		-e 's|pkg-config|${PKG_CONFIG}|g' \
 		configure || die
 
 	cp "${FILESDIR}"/chronyd.conf "${T}"/chronyd.conf || die

--- a/net-misc/chrony/chrony-9999.ebuild
+++ b/net-misc/chrony/chrony-9999.ebuild
@@ -20,7 +20,7 @@ S="${WORKDIR}/${P/_/-}"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+caps +cmdmon html ipv6 libedit +nettle nss +ntp +phc +nts pps +refclock +rtc samba +seccomp +sechash selinux"
+IUSE="+caps +cmdmon debug html ipv6 libedit +nettle nss +ntp +phc +nts pps +refclock +rtc samba +seccomp +sechash selinux"
 REQUIRED_USE="
 	sechash? ( || ( nettle nss  ) )
 	nettle? ( !nss )
@@ -97,6 +97,7 @@ src_configure() {
 		$(use_enable seccomp scfilter)
 		$(usex caps '' --disable-linuxcaps)
 		$(usex cmdmon '' --disable-cmdmon)
+		$(usex debug '--enable-debug' '')
 		$(usex ipv6 '' --disable-ipv6)
 		$(usex libedit '' --without-editline)
 		$(usex nettle '' --without-nettle)

--- a/net-misc/chrony/chrony-9999.ebuild
+++ b/net-misc/chrony/chrony-9999.ebuild
@@ -87,6 +87,10 @@ src_configure() {
 
 	tc-export CC PKG_CONFIG
 
+	# Update from time to time with output from "date +%s"
+	# on a system that is time-synced.
+	export SOURCE_DATE_EPOCH=1607976314
+
 	# not an autotools generated script
 	local myconf=(
 		$(use_enable seccomp scfilter)

--- a/net-misc/chrony/chrony-9999.ebuild
+++ b/net-misc/chrony/chrony-9999.ebuild
@@ -20,12 +20,13 @@ S="${WORKDIR}/${P/_/-}"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+caps +cmdmon html ipv6 libedit +nettle nss +ntp +phc pps +refclock +rtc samba +seccomp +sechash selinux"
+IUSE="+caps +cmdmon html ipv6 libedit +nettle nss +ntp +phc +nts pps +refclock +rtc samba +seccomp +sechash selinux"
 REQUIRED_USE="
 	sechash? ( || ( nettle nss  ) )
 	nettle? ( !nss )
 	!sechash? ( !nss )
 	!sechash? ( !nts? ( !nettle ) )
+	nts? ( nettle )
 	"
 RESTRICT="test"
 
@@ -43,6 +44,7 @@ DEPEND="
 		acct-user/ntp
 		sys-libs/libcap
 	)
+	nts? ( net-libs/gnutls:= )
 	libedit? ( dev-libs/libedit )
 	nettle? ( dev-libs/nettle:= )
 	nss? ( dev-libs/nss:= )
@@ -100,6 +102,8 @@ src_configure() {
 		$(usex nettle '' --without-nettle)
 		$(usex nss '' --without-nss)
 		$(usex ntp '' --disable-ntp)
+		$(usex nts '' --disable-nts)
+		$(usex nts '' --without-gnutls)
 		$(usex phc '' --disable-phc)
 		$(usex pps '' --disable-pps)
 		$(usex refclock '' --disable-refclock)

--- a/net-misc/chrony/metadata.xml
+++ b/net-misc/chrony/metadata.xml
@@ -26,6 +26,7 @@
 		<flag name="cmdmon">Support for command and monitoring</flag>
 		<flag name="html">Install HTML documentation</flag>
 		<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> for hash functions</flag>
+		<flag name="nss">Use <pkg>dev-libs/nss</pkg> for hash functions</flag>
 		<flag name="ntp">Support for the Network Time Protocol (NTP)</flag>
 		<flag name="phc">Support for the PTP (Precision Time Protocol) Hardware Clock (PHC) interface</flag>
 		<flag name="pps">Support for the Linux Pulse Per Second (PPS) interface</flag>

--- a/net-misc/chrony/metadata.xml
+++ b/net-misc/chrony/metadata.xml
@@ -24,6 +24,7 @@
 	</longdescription>
 	<use>
 		<flag name="cmdmon">Support for command and monitoring</flag>
+		<flag name="debug">Get DEBUG_LOG output from chronyd when passing -dd parameter</flag>
 		<flag name="html">Install HTML documentation</flag>
 		<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> for hash functions or nts</flag>
 		<flag name="nss">Use <pkg>dev-libs/nss</pkg> for hash functions</flag>

--- a/net-misc/chrony/metadata.xml
+++ b/net-misc/chrony/metadata.xml
@@ -25,9 +25,10 @@
 	<use>
 		<flag name="cmdmon">Support for command and monitoring</flag>
 		<flag name="html">Install HTML documentation</flag>
-		<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> for hash functions</flag>
+		<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> for hash functions or nts</flag>
 		<flag name="nss">Use <pkg>dev-libs/nss</pkg> for hash functions</flag>
 		<flag name="ntp">Support for the Network Time Protocol (NTP)</flag>
+		<flag name="nts">Support for Network Time Security (NTS). Uses <pkg>net-libs/gnutls</pkg></flag>
 		<flag name="phc">Support for the PTP (Precision Time Protocol) Hardware Clock (PHC) interface</flag>
 		<flag name="pps">Support for the Linux Pulse Per Second (PPS) interface</flag>
 		<flag name="refclock">Support for reference clocks</flag>


### PR DESCRIPTION
Setup alternatives for sechash support, Nettle and NSS.
NSS is no longer a null-option. Do note that with --as-needed,
chronyd will only link against libfreebl3.so, not other parts of
NSS.
NSS, though, *is* kind of useless since it's only good for sechash
support.

Removed pkg-config sed since upstream fixed $PKG_CONFIG support in
commit 9a9c0d7b99d7478e1431bd3fa8c225bdc46b3df4

Removed RELOADDNS sed since upstream fixed the bug in
commit ff466439fc22d6a47594f5dda33a5bdb726e92b8
Bug: https://bugs.gentoo.org/739684

Added debug use-flag. Use -dd option to chronyd to get DEBUG_LOG
output. Added in 2013(!)
commit 4bbc5520b8e340a08795e245784beb42c1254c0b

Added "export SOURCE_DATE_EPOCH=1607976314".  Update when updating
ebuild. If not set, "date '+%s'" is used instead.
This is a problem when the build host is not synchronized to NTP,
since if time obtained from NTP is prior to build date, NTP time
may underflow.

Enabled NTS support in ebuild. Needs net-libs/gnutls and dev-libs/nettle.
NTS is the only thing net-libs/gnutls is used for.
Reported-By: Matt Whitlock <gentoo@mattwhitlock.name>
Closes: https://bugs.gentoo.org/759526
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Peter Alfredsen <crabbedhaloablution@icloud.com>