### PR TITLE
net-news/rssguard: fix qtdeclarative dep

### DIFF
--- a/net-news/rssguard/rssguard-3.8.3.ebuild
+++ b/net-news/rssguard/rssguard-3.8.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtsql:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
+	dev-qt/qtdeclarative:5
 	webengine? ( dev-qt/qtwebengine:5[widgets] )
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Missing libQt5Qml.so from qtdeclarative package would cause error
when compiling:
Project ERROR: Unknown module(s) in QT: qml
make: *** [Makefile:48: sub-src-librssguard-make_first-ordered] Error 3
Fix by adding dep on dev-qt/qtdeclarative:5

Closes: https://bugs.gentoo.org/760045
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Peter Alfredsen <crabbedhaloablution@icloud.com>