### PR TITLE
media-libs/opensubdiv: Allow CUDA 11 and GPU selection

### DIFF
--- a/media-libs/opensubdiv/opensubdiv-3.4.3-r1.ebuild
+++ b/media-libs/opensubdiv/opensubdiv-3.4.3-r1.ebuild
@@ -1,0 +1,117 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_MAKEFILE_GENERATOR=emake
+PYTHON_COMPAT=( python2_7 )
+
+inherit cmake cuda python-utils-r1 toolchain-funcs
+
+MY_PV="$(ver_rs "1-3" '_')"
+DESCRIPTION="An Open-Source subdivision surface library"
+HOMEPAGE="https://graphics.pixar.com/opensubdiv/docs/intro.html"
+SRC_URI="https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+# Modfied Apache-2.0 license, where section 6 has been replaced.
+# See for example CMakeLists.txt for details.
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="cuda doc examples opencl openmp ptex tbb test tutorials"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	media-libs/glew:=
+	media-libs/glfw:=
+	x11-libs/libXinerama
+	cuda? ( dev-util/nvidia-cuda-toolkit:* )
+	opencl? ( virtual/opencl )
+	ptex? ( media-libs/ptex )
+"
+DEPEND="
+	${RDEPEND}
+	tbb? ( dev-cpp/tbb )
+"
+BDEPEND="
+	doc? (
+		app-doc/doxygen
+		dev-python/docutils
+	)
+"
+
+S="${WORKDIR}/OpenSubdiv-${MY_PV}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.3.0-use-gnuinstalldirs.patch"
+	"${FILESDIR}/${PN}-3.4.0-0001-documentation-CMakeLists.txt-force-python2.patch"
+	"${FILESDIR}/${P}-install-tutorials-into-bin.patch"
+)
+
+RESTRICT="!test? ( test )"
+
+pkg_pretend() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+pkg_setup() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+src_prepare() {
+	eapply_user
+	cmake_src_prepare
+	use cuda && cuda_add_sandbox
+}
+
+src_configure() {
+	# GLTESTS are disabled as portage is unable to open a display during test phase
+	local mycmakeargs=(
+		-DGLEW_LOCATION="${EPREFIX}/usr/$(get_libdir)"
+		-DGLFW_LOCATION="${EPREFIX}/usr/$(get_libdir)"
+		-DNO_CLEW=ON
+		-DNO_CUDA=$(usex !cuda)
+		-DNO_DOC=$(usex !doc)
+		-DNO_EXAMPLES=$(usex !examples)
+		-DNO_GLTESTS=ON
+		-DNO_OMP=$(usex !openmp)
+		-DNO_OPENCL=$(usex !opencl)
+		-DNO_PTEX=$(usex !ptex)
+		-DNO_REGRESSION=$(usex !test)
+		-DNO_TBB=$(usex !tbb)
+		-DNO_TESTS=$(usex !test)
+		-DNO_TUTORIALS=$(usex !tutorials)
+	)
+
+	if use cuda; then
+		if [[ *$(gcc-version)* != $(cuda-config -s) ]]; then
+			ewarn "Opensubdiv is being built with Nvidia CUDA support."
+			ewarn "Your default compiler version $(gcc-version) is not supported by the currently installed CUDA."
+			ewarn ""
+			ewarn "Your CUDA version supports $(cuda_gccdir)/$(tc-getCC)"
+			ewarn ""
+			ewarn "If the build fails try changing the compiler version using gcc-config"
+			ewarn "or overriding PATH, CC and CXX for this package using package.env"
+		fi
+
+		if [[ -z "${OSD_CUDA_COMPUTE_CAPABILITIES}" ]]; then
+			ewarn "Opensubdiv is being built with CUDA 2.0 support, which was deprecated in"
+			ewarn "nvidia-cuda-utils-9. This may also not be optimal for your GPU."
+			ewarn ""
+			ewarn "To select the optimal CUDA support for your GPU,"
+			ewarn "set OSD_CUDA_COMPUTE_CAPABILITIES in your make.conf and re-emerge opensubdiv"
+			ewarn "For example, to use CUDA capability 3.5, add OSD_CUDA_COMPUTE_CAPABILITIES=sm_35"
+			ewarn "or to use JIT compilation, add OSD_CUDA_COMPUTE_CAPABILITIES=compute_35"
+			ewarn ""
+			ewarn "You can look up your GPU's CUDA compute capability at https://developer.nvidia.com/cuda-gpus"
+			ewarn "or by running /opt/cuda/extras/demo_suite/deviceQuery | grep 'CUDA Capability'"
+			mycmakeargs+=( -DOSD_CUDA_NVCC_FLAGS="--gpu-architecture;compute_20" )
+		else
+			mycmakeargs+=( -DOSD_CUDA_NVCC_FLAGS="--gpu-architecture;${OSD_CUDA_COMPUTE_CAPABILITIES}" )
+		fi
+	fi
+
+	# fails with building cuda kernels when using multiple jobs
+	export MAKEOPTS="-j1"
+	cmake_src_configure
+}


### PR DESCRIPTION
This ebuild contains two changes which support compilation against
nvidia-cuda-toolkit-11, based on those used by tensorflow

Compared to nvidia-cuda-toolkit-10 which was gcc < 9 only, version 11
can be compiled with later versions of gcc.

Currently the supported versions are
<=nvidia-cuda-toolkit-9.0 ( <=sys-devel/gcc-5.4 )
nvidia-cuda-toolkit-9.1 ( <=sys-devel/gcc-6.4 )
nvidia-cuda-toolkit-9.2 to 10.1 ( <=sys-devel/gcc-7.3 )
nvidia-cuda-toolkit 10.1 to 10.2 ( <=sys-devel/gcc-8.4 )
nvidia-cuda-toolkit-11.0 ( <=sys-devel/gcc-9.3 )
nvidia-cuda-toolkit-11.1 ( <=sys-devel/gcc-10.4 )

Putting this testing in every ebuild that uses nvcc at build time is
fragile and will be easily broken by updates to nvidia-cuda-toolkit.

This version removes the gcc version checks in pkg_pretend, and
the cuda eclass is used to obtain the permitted versions of gcc.
If a non-supported version is selected a warning is displayed
which gives instructions to the user on how to change their gcc
and which version to use.

An environment variable OSD_CUDA_COMPUTE_CAPABILITIES is used to
obtain the desired GPU architecture, which is passed to cmake.
If it is not set, a warning is displayed and the default 2.0 is
chosen, which will probably fail unless the user has a Fermi
card and is still using nvidia-cuda-toolkit-8.

The value supplied by the environment variable is not currently checked
against the allowed values. These vary with nvidia-cuda-toolkit
versions but may include:

'compute_20','compute_30','compute_32','compute_35','compute_37',
'compute_50','compute_52','compute_53','compute_60','compute_61',
'compute_62','compute_70','compute_72','compute_75','compute_80',
'sm_20','sm_30','sm_32','sm_35','sm_37','sm_50','sm_52','sm_53',
'sm_60','sm_61','sm_62','sm_70','sm_72','sm_75'.

The compute_XX use a virtual architecture and produce bytecode for
JIT compilation, while the sm_XX compile against a real architecture
immediately.

It is not possible to choose a value to suit everybody as the lowest
version of compute would support the largest range of graphics cards,
but this prevents using features provided by later versions.

As the user has chosen the appropriate compute value for their system,
the CUDA 9 patch is no longer required.

Signed-off-by: Adrian Grigo <agrigo2001@yahoo.com.au>
Closes: https://bugs.gentoo.org/751382
Bug: https://bugs.gentoo.org/744517
Package-Manager: Portage-3.0.9, Repoman-3.0.2