### PR TITLE
app-emulation/virt-manager: update dependencies

### DIFF
--- a/app-emulation/virt-manager/virt-manager-3.2.0.ebuild
+++ b/app-emulation/virt-manager/virt-manager-3.2.0.ebuild
@@ -26,14 +26,13 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="gtk policykit sasl"
 
-RDEPEND="!app-emulation/virtinst
-	${PYTHON_DEPS}
+RDEPEND="${PYTHON_DEPS}
 	app-cdr/cdrtools
 	>=app-emulation/libvirt-glib-1.0.0[introspection]
 	$(python_gen_cond_dep '
 		dev-libs/libxml2[python,${PYTHON_MULTI_USEDEP}]
 		dev-python/argcomplete[${PYTHON_MULTI_USEDEP}]
-		dev-python/libvirt-python[${PYTHON_MULTI_USEDEP}]
+		>=dev-python/libvirt-python-6.10.0[${PYTHON_MULTI_USEDEP}]
 		dev-python/pygobject:3[${PYTHON_MULTI_USEDEP}]
 		dev-python/requests[${PYTHON_MULTI_USEDEP}]
 	')

--- a/app-emulation/virt-manager/virt-manager-9999.ebuild
+++ b/app-emulation/virt-manager/virt-manager-9999.ebuild
@@ -26,14 +26,13 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="gtk policykit sasl"
 
-RDEPEND="!app-emulation/virtinst
-	${PYTHON_DEPS}
+RDEPEND="${PYTHON_DEPS}
 	app-cdr/cdrtools
 	>=app-emulation/libvirt-glib-1.0.0[introspection]
 	$(python_gen_cond_dep '
 		dev-libs/libxml2[python,${PYTHON_MULTI_USEDEP}]
 		dev-python/argcomplete[${PYTHON_MULTI_USEDEP}]
-		dev-python/libvirt-python[${PYTHON_MULTI_USEDEP}]
+		>=dev-python/libvirt-python-0.6.10[${PYTHON_MULTI_USEDEP}]
 		dev-python/pygobject:3[${PYTHON_MULTI_USEDEP}]
 		dev-python/requests[${PYTHON_MULTI_USEDEP}]
 	')


### PR DESCRIPTION
virt-manager has some issues fixed with python-libvirt 0.6.9
See for example: https://github.com/virt-manager/virt-manager/issues/203

Also, `pkgcheck scan` says :
```
 $ pkgcheck scan
...
  NonexistentBlocker: version 2.2.1-r3: nonexistent blocker DEPEND="!app-emulation/virtinst": no matches in repo history
 ...
```
Shall I remove this blocker too?


Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Oz Tiram <oz.tiram@gmail.com>