### PR TITLE
games-roguelike/tomenet: fix a typo

### DIFF
--- a/games-roguelike/tomenet/tomenet-4.7.3.ebuild
+++ b/games-roguelike/tomenet/tomenet-4.7.3.ebuild
@@ -87,7 +87,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	xdg_postinst
+	xdg_pkg_postinst
 
 	if use sound; then
 		elog "You can get soundpacks from here:"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/760075
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>