### PR TITLE
Add rust-lld use flag for dev-lang/rust

### DIFF
--- a/dev-lang/rust/metadata.xml
+++ b/dev-lang/rust/metadata.xml
@@ -15,6 +15,7 @@
 		<flag name="nightly">Enable nightly (UNSTABLE) features</flag>
 		<flag name="parallel-compiler">Build a multi-threaded rustc</flag>
 		<flag name="rls">Install rls, Rust Language Server (used with IDEs supporting RLS protocol)</flag>
+		<flag name="rust-lld">Enable building of the rust-lld linker (not compatible with system-llvm)</flag>
 		<flag name="rustfmt">Install rustfmt, Rust code formatter</flag>
 		<flag name="system-bootstrap">Bootstrap using installed rust compiler</flag>
 		<flag name="system-llvm">Use the system LLVM install</flag>

--- a/dev-lang/rust/rust-1.48.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.48.0-r2.ebuild
@@ -39,7 +39,7 @@ LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/?}
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 
-IUSE="clippy cpu_flags_x86_sse2 debug doc libressl miri nightly parallel-compiler rls rustfmt system-bootstrap system-llvm test wasm ${ALL_LLVM_TARGETS[*]}"
+IUSE="clippy cpu_flags_x86_sse2 debug doc libressl miri nightly parallel-compiler rls rust-lld rustfmt system-bootstrap system-llvm test wasm ${ALL_LLVM_TARGETS[*]}"
 
 # Please keep the LLVM dependency block separate. Since LLVM is slotted,
 # we need to *really* make sure we're not pulling more than one slot
@@ -312,7 +312,7 @@ src_configure() {
 		codegen-tests = true
 		dist-src = false
 		remap-debuginfo = true
-		lld = $(usex system-llvm false $(toml_usex wasm))
+		lld = $(usex system-llvm false $(usex rust-lld true $(toml_usex wasm)))
 		backtrace-on-ice = true
 		jemalloc = false
 		[dist]


### PR DESCRIPTION
Rust is frequently using `rust-lld` in targets now, and that number is growing. It's currently in the dozens. https://github.com/rust-lang/rust/search?q=rust-lld+path%3Acompiler%2Frustc_target%2Fsrc%2Fspec&type=code

Due to this, many embedded targets will not build with the Rust from Gentoo. This PR adds a new USE flag for Rust called `rust-lld`, which will enable building of `rust-lld` for non-`system-llvm` use cases. There's already some overrides in place for handling `wasm`, which uses `rust-lld` for linking, and we do some regex to patch the Rust code to change the usage of `rust-ldd`. Unfortunately, as seen in the link above, `wasm` is not the only use of `rust-lld` by any means.

I highly recommend that we make this the default behavior (and probably just remove this option), but this is my first Gentoo repo push and I'm trying to make this as light of a change as possible. I suspect that over time, Rust will switch more and more targets over to using `rust-lld`. I'm unsure how this will be fixed to work with `system-llvm`.

Please note, this is my first Gentoo ebuild PR, and thus I don't really know what I'm doing. I removed the old `1.48.0`, made a new `1.48.0-r2` ebuild, added an IUSE entry, and changed the emission of the Rust configuration file to reflect the new use flag.

-B