### PR TITLE
net-news/rssguard: fix parallel make issue in src_install

### DIFF
--- a/net-news/rssguard/rssguard-3.8.3.ebuild
+++ b/net-news/rssguard/rssguard-3.8.3.ebuild
@@ -55,5 +55,5 @@ src_configure() {
 }
 
 src_install() {
-	emake install INSTALL_ROOT="${D}"
+	emake -j1 install INSTALL_ROOT="${D}"
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/760120
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Peter Alfredsen <crabbedhaloablution@icloud.com>