### PR TITLE
net-dns/bind: Remove obsolete -r flag when calling rndc-confgen

### DIFF
--- a/net-dns/bind/bind-9.16.12.ebuild
+++ b/net-dns/bind/bind-9.16.12.ebuild
@@ -282,16 +282,10 @@ python_install() {
 pkg_postinst() {
 	tmpfiles_process "${FILESDIR}"/named.conf
 
-	if [ ! -f '/etc/bind/rndc.key' && ! -f '/etc/bind/rndc.conf' ]; then
-		if use urandom; then
-			einfo "Using /dev/urandom for generating rndc.key"
-			/usr/sbin/rndc-confgen -r /dev/urandom -a
-			echo
-		else
-			einfo "Using /dev/random for generating rndc.key"
-			/usr/sbin/rndc-confgen -a
-			echo
-		fi
+	if [[ ! -f '/etc/bind/rndc.key' && ! -f '/etc/bind/rndc.conf' ]]; then
+		einfo "Using /dev/random for generating rndc.key"
+		/usr/sbin/rndc-confgen -a
+		echo
 		chown root:named /etc/bind/rndc.key || die
 		chmod 0640 /etc/bind/rndc.key || die
 	fi

--- a/net-dns/bind/bind-9.16.13.ebuild
+++ b/net-dns/bind/bind-9.16.13.ebuild
@@ -282,16 +282,10 @@ python_install() {
 pkg_postinst() {
 	tmpfiles_process "${FILESDIR}"/named.conf
 
-	if [ ! -f '/etc/bind/rndc.key' && ! -f '/etc/bind/rndc.conf' ]; then
-		if use urandom; then
-			einfo "Using /dev/urandom for generating rndc.key"
-			/usr/sbin/rndc-confgen -r /dev/urandom -a
-			echo
-		else
-			einfo "Using /dev/random for generating rndc.key"
-			/usr/sbin/rndc-confgen -a
-			echo
-		fi
+	if [[ ! -f '/etc/bind/rndc.key' && ! -f '/etc/bind/rndc.conf' ]]; then
+		einfo "Using /dev/urandom for generating rndc.key"
+		/usr/sbin/rndc-confgen -r /dev/urandom -a
+		echo
 		chown root:named /etc/bind/rndc.key || die
 		chmod 0640 /etc/bind/rndc.key || die
 	fi


### PR DESCRIPTION
`-r` flag in `rndc-confgen` and the whole direct use of `/dev/*random` was removed in BIND 9.12: https://gitlab.isc.org/isc-projects/bind9/-/commit/3a4f820

The ebuild still tried to use it when the `urandom` flag is enabled as reported in [#691786](https://bugs.gentoo.org/691786)

Despite the direct use of `/dev/*random` being apparently removed, it seems `named` is still using it somehow:

```
# lsof -nc named | fgrep random
named   2840 named   36r      CHR        1,9      0t0   1032 /dev/urandom
```

That's why I haven't removed the USE flag or creating them in the chroot:

https://github.com/gentoo/gentoo/blob/d14c4bd2662d85443bbb96a58313da1df3ee6595/net-dns/bind/bind-9.16.8.ebuild#L360-L366

Also, versions 9.16.6-r3 and 9.16.7 are overshadowed by 9.16.8. Shouldn't the old ones be removed?