### PR TITLE
media-libs/lilv: rewrite to use the python-single-r1 eclass

### DIFF
--- a/media-libs/lilv/lilv-0.24.10-r1.ebuild
+++ b/media-libs/lilv/lilv-0.24.10-r1.ebuild
@@ -1,0 +1,81 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_REQ_USE='threads(+)'
+
+inherit python-single-r1 waf-utils bash-completion-r1 multilib-build multilib-minimal
+
+DESCRIPTION="Library to make the use of LV2 plugins as simple as possible for applications"
+HOMEPAGE="http://drobilla.net/software/lilv/"
+SRC_URI="http://download.drobilla.net/${P}.tar.bz2"
+
+LICENSE="ISC"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~sparc x86"
+IUSE="doc +dyn-manifest static-libs test"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	dev-libs/serd[${MULTILIB_USEDEP}]
+	dev-libs/sord[${MULTILIB_USEDEP}]
+	media-libs/libsndfile
+	media-libs/lv2[${MULTILIB_USEDEP}]
+	media-libs/sratom[${MULTILIB_USEDEP}]
+"
+DEPEND="
+	${RDEPEND}
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen )
+	test? (
+		$(python_gen_cond_dep '
+			dev-python/unittest2[${PYTHON_USEDEP}]
+		')
+	)
+"
+
+pkg_setup() {
+	python_setup
+}
+
+src_prepare() {
+	default
+	sed -i -e 's/^.*run_ldconfig/#\0/' wscript || die
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	waf-utils_src_configure \
+		--docdir="${EPREFIX}"/usr/share/doc/${PF} \
+		--no-bash-completion \
+		$(multilib_native_usex doc --docs "") \
+		$(usex test --test "") \
+		$(usex static-libs --static "") \
+		$(usex dyn-manifest --dyn-manifest "")
+}
+
+multilib_src_compile() {
+	./waf build || die
+}
+
+multilib_src_test() {
+	./waf test || die
+}
+
+multilib_src_install() {
+	waf-utils_src_install
+}
+
+multilib_src_install_all() {
+	sed -i "/lv2jack/d" utils/lilv.bash_completion
+	newbashcomp utils/lilv.bash_completion lv2info
+
+	dodir /etc/env.d
+	echo "LV2_PATH=${EPREFIX}/usr/$(get_libdir)/lv2" > "${ED}/etc/env.d/60lv2"
+
+	python_optimize
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/760402
Signed-off-by: Marios Titas <redneb@gmx.com>