### PR TITLE
dev-python/argcomplete: Update importlib_metadata dependency

### DIFF
--- a/dev-python/argcomplete/argcomplete-1.12.2-r1.ebuild
+++ b/dev-python/argcomplete/argcomplete-1.12.2-r1.ebuild
@@ -19,7 +19,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	$(python_gen_cond_dep '
-		<dev-python/importlib_metadata-3[${PYTHON_USEDEP}]
+		<dev-python/importlib_metadata-4[${PYTHON_USEDEP}]
 	' -2 python3_{5,6,7} pypy3)"
 # pip is called as an external tool
 BDEPEND="


### PR DESCRIPTION
This is based on upstream commit ecac7b02ffe6 which is already part of
`setup.py` in this version (v1.12.2) and is actually the main change from
v1.12.1.

Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>