### PR TITLE
dev-libs/aws-c-event-stream: Disable internet requiring tests

### DIFF
--- a/dev-libs/aws-c-event-stream/aws-c-event-stream-0.2.5-r1.ebuild
+++ b/dev-libs/aws-c-event-stream/aws-c-event-stream-0.2.5-r1.ebuild
@@ -38,5 +38,15 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=$(usex !static-libs)
 		-DBUILD_TESTING=$(usex test)
 	)
+
+	if use test; then
+		# (#760585) Due to network sandboxing of portage, internet connectivity
+		# tests will always fail. If you need a USE flag, because you want/need
+		# to perform these tests manually, please open a bug report for it.
+		mycmakeargs+=(
+			-DENABLE_NET_TESTS=OFF
+		)
+	fi
+
 	cmake_src_configure
 }


### PR DESCRIPTION
Some of the tests require internet connectivity. On an offline machine these tests will therefore fail.

As network sandboxing is enabled by default for years now, it is very unlikely that anybody would perform these tests anyway.

Closes: https://bugs.gentoo.org/760585
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Sven Eden <sven.eden@prydeworx.com>