### PR TITLE
x11-misc/albert: add myself to maintainers as proxy-maint

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -88,11 +88,6 @@ mail-filter/dovecot_deleted_to_trash
 # Removal in 30 days.  Bug #720066.
 dev-python/sphinxcontrib-issuetracker
 
-# Michael Palimaka <kensington@gentoo.org> (2020-12-13)
-# Buggy. Uncooperative upstream.
-# Masked for removal in 30 days.
-x11-misc/albert
-
 # Sam James <sam@gentoo.org> (2020-12-13)
 # This new version of libcap-ng seems to (still)
 # break consumers.

--- a/x11-misc/albert/metadata.xml
+++ b/x11-misc/albert/metadata.xml
@@ -2,11 +2,12 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>kensington@gentoo.org</email>
-	</maintainer>
-	<maintainer type="person">
 		<email>gentoo@retornaz.com</email>
 		<name>Quentin Retornaz</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">albertlauncher/albert</remote-id>

--- a/x11-misc/albert/metadata.xml
+++ b/x11-misc/albert/metadata.xml
@@ -4,6 +4,10 @@
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
 	</maintainer>
+	<maintainer type="person">
+		<email>gentoo@retornaz.com</email>
+		<name>Quentin Retornaz</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">albertlauncher/albert</remote-id>
 	</upstream>


### PR DESCRIPTION
After discussion with @kensington on IRC on #gentoo-proxy-maint on freenode, he offered me to maintain x11-misc/albert.
I accept it in this pull request.