### PR TITLE
binutils-apple: fix prefix bootstrap stage3

### DIFF
--- a/sys-devel/binutils-apple/binutils-apple-11.3.1.ebuild
+++ b/sys-devel/binutils-apple/binutils-apple-11.3.1.ebuild
@@ -79,6 +79,10 @@ src_prepare() {
 	mkdir -p include/mach-o || die
 	# never present because it's private
 	cp ../../${DYLD}/include/mach-o/dyld_priv.h include/mach-o || die
+	# TARGET_OS_BRIDGE is undefined in TargetConditionals.h of newer MacOSX.sdk.
+	# We don't target BridgeOS. Disable it to avoid errors when clang adds:
+	# -Werror,-Wundef-prefix=TARGET_OS_
+	sed -i -e 's/#if TARGET_OS_BRIDGE/#if 0/' include/mach-o/dyld_priv.h
 
 	local VER_STR="\"@(#)PROGRAM:ld  PROJECT:${LD64} (Gentoo ${PN}-${PVR})\\n\""
 	echo "char ldVersionString[] = ${VER_STR};" > version.cpp

--- a/sys-devel/binutils-apple/binutils-apple-11.3.1.ebuild
+++ b/sys-devel/binutils-apple/binutils-apple-11.3.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="http://www.opensource.apple.com/tarballs/ld64/${LD64}.tar.gz
 	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-5.1-r2.tar.bz2
 	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-7.3-r2.tar.bz2
 	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-8.2-r1.tar.bz2
-	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-11.3.tar.bz2"
+	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-11.3-r1.tar.bz2"
 
 LICENSE="APSL-2"
 KEYWORDS="~x64-macos ~x86-macos"
@@ -100,7 +100,7 @@ src_prepare() {
 	epatch "${S}"/${PN}-7.3-make-j.patch
 	epatch "${S}"/${PN}-11.3.1-no-developertools-dir.patch # 7.3 failed to apply. updated
 	epatch "${S}"/${PN}-11.3.1-llvm-prefix.patch # 8.2.1 failed to apply. updated
-	epatch "${S}"/${PN}-8.2.1-llvm-shim.patch
+	epatch "${S}"/${PN}-11.3.1-llvm-shim.patch # 8.2.1 failed to find dsymutil. fixed
 	epatch "${S}"/${PN}-11.3.1-nolto-fix.patch # bugfix
 	epatch "${S}"/${PN}-11.3.1-segaddrtable-fix.patch # bugfix
 	eprefixify libstuff/execute.c


### PR DESCRIPTION
In the version of private header (dyld_priv.h) copied from DYLD sources,
It uses TARGET_OS_BRIDGE which is not defined in the latest MacOSX.sdk.
We don't care about BridgeOS, so we just disable that.

This only hits during stage3 once we've re-compiled our own clang so
that clang starts injecting -Werror,-Wundef-prefix=TARGET_OS_ (Apple
must have that disabled in their version of clang).

Also uses newer patches so that dsymutil can be found even though it is
not named llvm-dsymutil, and it also bumps the max llvm slots searched
from 10 to 12.

Bug: https://bugs.gentoo.org/758167
Bug: https://bugs.gentoo.org/631862

Signed-off-by: Jacob Floyd <cognifloyd@gmail.com>