### PR TITLE
Fix Darwin prefix bootstrap for llvm-11+ projects (sys-libs/libcxx*, sys-devel/clang, sys-libs/llvm-libunwind, sys-libs/compiler-rt*)

### DIFF
--- a/profiles/prefix/darwin/macos/package.use.force
+++ b/profiles/prefix/darwin/macos/package.use.force
@@ -21,3 +21,7 @@ media-gfx/tachyon threads opengl
 # Elias Pipping <pipping@gentoo.org> (2007-11-29)
 # won't compile without
 media-libs/libsdl opengl
+
+# Jacob Floyd <cognifloyd@gmail.org> (2020-12-20)
+# Make sure we always use libcxxabi on macos prefix
+sys-libs/libcxx libcxxabi

--- a/sys-devel/clang/clang-11.0.0.ebuild
+++ b/sys-devel/clang/clang-11.0.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6..9} )
 inherit cmake llvm llvm.org multilib-minimal pax-utils \
-	python-single-r1 toolchain-funcs
+	prefix python-single-r1 toolchain-funcs
 
 DESCRIPTION="C language family frontend for LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -30,7 +30,7 @@ ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA MIT"
 SLOT="$(ver_cut 1)"
-KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86 ~amd64-linux"
+KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
 IUSE="debug default-compiler-rt default-libcxx default-lld
 	doc +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
@@ -75,6 +75,10 @@ PDEPEND="
 # Therefore: use sys-devel/clang[${MULTILIB_USEDEP}] only if you need
 # multilib clang* libraries (not runtime, not wrappers).
 
+PATCHES=(
+	"${FILESDIR}"/9999/prefix-dirs.patch
+)
+
 pkg_setup() {
 	LLVM_MAX_SLOT=${SLOT} llvm_pkg_setup
 	python-single-r1_pkg_setup
@@ -88,6 +92,11 @@ src_prepare() {
 	llvm.org_src_prepare
 
 	mv ../clang-tools-extra tools/extra || die
+
+	# add Gentoo Portage Prefix for Darwin (see prefix-dirs.patch)
+	eprefixify \
+		lib/Frontend/InitHeaderSearch.cpp \
+		lib/Driver/ToolChains/Darwin.cpp || die
 }
 
 check_distribution_components() {

--- a/sys-devel/clang/clang-11.0.1.9999.ebuild
+++ b/sys-devel/clang/clang-11.0.1.9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6..9} )
 inherit cmake llvm llvm.org multilib-minimal pax-utils \
-	python-single-r1 toolchain-funcs
+	prefix python-single-r1 toolchain-funcs
 
 DESCRIPTION="C language family frontend for LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -77,6 +77,10 @@ llvm.org_set_globals
 # Therefore: use sys-devel/clang[${MULTILIB_USEDEP}] only if you need
 # multilib clang* libraries (not runtime, not wrappers).
 
+PATCHES=(
+	"${FILESDIR}"/9999/prefix-dirs.patch
+)
+
 pkg_setup() {
 	LLVM_MAX_SLOT=${SLOT} llvm_pkg_setup
 	python-single-r1_pkg_setup
@@ -90,6 +94,11 @@ src_prepare() {
 	llvm.org_src_prepare
 
 	mv ../clang-tools-extra tools/extra || die
+
+	# add Gentoo Portage Prefix for Darwin (see prefix-dirs.patch)
+	eprefixify \
+		lib/Frontend/InitHeaderSearch.cpp \
+		lib/Driver/ToolChains/Darwin.cpp || die
 }
 
 check_distribution_components() {

--- a/sys-devel/clang/clang-11.0.1_rc1.ebuild
+++ b/sys-devel/clang/clang-11.0.1_rc1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6..9} )
 inherit cmake llvm llvm.org multilib-minimal pax-utils \
-	python-single-r1 toolchain-funcs
+	prefix python-single-r1 toolchain-funcs
 
 DESCRIPTION="C language family frontend for LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -77,6 +77,10 @@ llvm.org_set_globals
 # Therefore: use sys-devel/clang[${MULTILIB_USEDEP}] only if you need
 # multilib clang* libraries (not runtime, not wrappers).
 
+PATCHES=(
+	"${FILESDIR}"/9999/prefix-dirs.patch
+)
+
 pkg_setup() {
 	LLVM_MAX_SLOT=${SLOT} llvm_pkg_setup
 	python-single-r1_pkg_setup
@@ -90,6 +94,11 @@ src_prepare() {
 	llvm.org_src_prepare
 
 	mv ../clang-tools-extra tools/extra || die
+
+	# add Gentoo Portage Prefix for Darwin (see prefix-dirs.patch)
+	eprefixify \
+		lib/Frontend/InitHeaderSearch.cpp \
+		lib/Driver/ToolChains/Darwin.cpp || die
 }
 
 check_distribution_components() {

--- a/sys-devel/clang/clang-11.0.1_rc2.ebuild
+++ b/sys-devel/clang/clang-11.0.1_rc2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6..9} )
 inherit cmake llvm llvm.org multilib-minimal pax-utils \
-	python-single-r1 toolchain-funcs
+	prefix python-single-r1 toolchain-funcs
 
 DESCRIPTION="C language family frontend for LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -77,6 +77,10 @@ llvm.org_set_globals
 # Therefore: use sys-devel/clang[${MULTILIB_USEDEP}] only if you need
 # multilib clang* libraries (not runtime, not wrappers).
 
+PATCHES=(
+	"${FILESDIR}"/9999/prefix-dirs.patch
+)
+
 pkg_setup() {
 	LLVM_MAX_SLOT=${SLOT} llvm_pkg_setup
 	python-single-r1_pkg_setup
@@ -90,6 +94,11 @@ src_prepare() {
 	llvm.org_src_prepare
 
 	mv ../clang-tools-extra tools/extra || die
+
+	# add Gentoo Portage Prefix for Darwin (see prefix-dirs.patch)
+	eprefixify \
+		lib/Frontend/InitHeaderSearch.cpp \
+		lib/Driver/ToolChains/Darwin.cpp || die
 }
 
 check_distribution_components() {

--- a/sys-devel/clang/clang-12.0.0.9999.ebuild
+++ b/sys-devel/clang/clang-12.0.0.9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6..9} )
 inherit cmake llvm llvm.org multilib-minimal pax-utils \
-	python-single-r1 toolchain-funcs
+	prefix python-single-r1 toolchain-funcs
 
 DESCRIPTION="C language family frontend for LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -77,6 +77,10 @@ llvm.org_set_globals
 # Therefore: use sys-devel/clang[${MULTILIB_USEDEP}] only if you need
 # multilib clang* libraries (not runtime, not wrappers).
 
+PATCHES=(
+	"${FILESDIR}"/9999/prefix-dirs.patch
+)
+
 pkg_setup() {
 	LLVM_MAX_SLOT=${SLOT} llvm_pkg_setup
 	python-single-r1_pkg_setup
@@ -88,6 +92,11 @@ src_prepare() {
 	BUILD_DIR=${WORKDIR}/x/y/clang
 
 	llvm.org_src_prepare
+
+	# add Gentoo Portage Prefix for Darwin (see prefix-dirs.patch)
+	eprefixify \
+		lib/Frontend/InitHeaderSearch.cpp \
+		lib/Driver/ToolChains/Darwin.cpp || die
 }
 
 check_distribution_components() {

--- a/sys-devel/clang/files/9999/prefix-dirs.patch
+++ b/sys-devel/clang/files/9999/prefix-dirs.patch
@@ -1,0 +1,75 @@
+This mirrors cmake-*-prefix-dirs.patch
+
+It add EPREFIX to search paths for c/cxx headers.
+It also adds EPREFIX/MacOSX.sdk to search paths for c and Frameworks.
+Assumes that c++ lib and headers will be installed in the prefix.
+
+Also, a couple of args are populated by inspecting the SDK,
+so, default to EPREFIX/MacOSX.sdk when the sysroot is not specified.
+(This does NOT set sysroot).
+
+The ebuild adds an extra / at the end of EPREFIX so that it is never
+an empty string. 
+
+--- a/clang/lib/Frontend/InitHeaderSearch.cpp	2020-11-30 12:53:42.000000000 -0600
++++ b/clang/lib/Frontend/InitHeaderSearch.cpp	2020-11-30 13:57:52.000000000 -0600
+@@ -445,6 +445,9 @@
+   // All header search logic is handled in the Driver for Darwin.
+   if (triple.isOSDarwin()) {
+     if (HSOpts.UseStandardSystemIncludes) {
++      // Add Gentoo Prefix framework dirs first
++      AddPath("@GENTOO_PORTAGE_EPREFIX@MacOSX.sdk/System/Library/Frameworks", System, true);
++      AddPath("@GENTOO_PORTAGE_EPREFIX@MacOSX.sdk/Library/Frameworks", System, true);
+       // Add the default framework include paths on Darwin.
+       AddPath("/System/Library/Frameworks", System, true);
+       AddPath("/Library/Frameworks", System, true);
+--- a/clang/lib/Driver/ToolChains/Darwin.cpp	2020-10-07 05:10:48.000000000 -0500
++++ b/clang/lib/Driver/ToolChains/Darwin.cpp	2020-11-30 12:57:15.000000000 -0600
+@@ -1737,9 +1737,9 @@
+                                          const ArgList &Args,
+                                          const Driver &TheDriver) {
+   const Arg *A = Args.getLastArg(options::OPT_isysroot);
+-  if (!A)
+-    return None;
+-  StringRef isysroot = A->getValue();
++  //if (!A)
++  //  return None;
++  StringRef isysroot = A ? A->getValue() : "@GENTOO_PORTAGE_EPREFIX@MacOSX.sdk";
+   auto SDKInfoOrErr = driver::parseDarwinSDKInfo(VFS, isysroot);
+   if (!SDKInfoOrErr) {
+     llvm::consumeError(SDKInfoOrErr.takeError());
+@@ -1921,13 +1921,14 @@
+     return DriverArgs.getLastArgValue(options::OPT_isysroot);
+   if (!getDriver().SysRoot.empty())
+     return getDriver().SysRoot;
+-  return "/";
++  return "@GENTOO_PORTAGE_EPREFIX@";
+ }
+ 
+ void DarwinClang::AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
+                                             llvm::opt::ArgStringList &CC1Args) const {
+   const Driver &D = getDriver();
+ 
++  // Sysroot is effectively Gentoo EPREFIX when -isysroot/-sysroot is not defined
+   llvm::StringRef Sysroot = GetHeaderSysroot(DriverArgs);
+ 
+   bool NoStdInc = DriverArgs.hasArg(options::OPT_nostdinc);
+@@ -1969,6 +1970,10 @@
+     SmallString<128> P(Sysroot);
+     llvm::sys::path::append(P, "usr", "include");
+     addExternCSystemInclude(DriverArgs, CC1Args, P.str());
++    // And add <sysroot>/MacOSX.sdk/usr/include.
++    SmallString<128> Psdk(Sysroot);
++    llvm::sys::path::append(Psdk, "MacOSX.sdk", "usr", "include");
++    addExternCSystemInclude(DriverArgs, CC1Args, Psdk.str());
+   }
+ }
+ 
+@@ -2017,6 +2022,7 @@
+       DriverArgs.hasArg(options::OPT_nostdincxx))
+     return;
+ 
++  // Sysroot is effectively Gentoo EPREFIX when -isysroot/-sysroot is not defined
+   llvm::StringRef Sysroot = GetHeaderSysroot(DriverArgs);
+ 
+   switch (GetCXXStdlibType(DriverArgs)) {

--- a/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-11.0.0.ebuild
+++ b/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-11.0.0.ebuild
@@ -35,6 +35,10 @@ BDEPEND="
 		sys-libs/compiler-rt:${SLOT} )
 	${PYTHON_DEPS}"
 
+PATCHES=(
+	"${FILESDIR}/9999/compiler-rt-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -110,8 +114,15 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX
+			# This disables i386 for SDK >= 10.15
+			# Will error while building tsan if SDK < 10.12
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-11.0.1.9999.ebuild
+++ b/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-11.0.1.9999.ebuild
@@ -48,6 +48,10 @@ LLVM_COMPONENTS=( compiler-rt )
 LLVM_TEST_COMPONENTS=( llvm/lib/Testing/Support llvm/utils/unittest )
 llvm.org_set_globals
 
+PATCHES=(
+	"${FILESDIR}/9999/compiler-rt-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -145,8 +149,15 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX
+			# This disables i386 for SDK >= 10.15
+			# Will error if has_use tsan and SDK < 10.12
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-11.0.1_rc1.ebuild
+++ b/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-11.0.1_rc1.ebuild
@@ -37,6 +37,10 @@ LLVM_COMPONENTS=( compiler-rt )
 LLVM_TEST_COMPONENTS=( llvm/lib/Testing/Support llvm/utils/unittest )
 llvm.org_set_globals
 
+PATCHES=(
+	"${FILESDIR}/9999/compiler-rt-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -112,8 +116,15 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX
+			# This disables i386 for SDK >= 10.15
+			# Will error if has_use tsan and SDK < 10.12
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-12.0.0.9999.ebuild
+++ b/sys-libs/compiler-rt-sanitizers/compiler-rt-sanitizers-12.0.0.9999.ebuild
@@ -48,6 +48,10 @@ LLVM_COMPONENTS=( compiler-rt )
 LLVM_TEST_COMPONENTS=( llvm/lib/Testing/Support llvm/utils/unittest )
 llvm.org_set_globals
 
+PATCHES=(
+	"${FILESDIR}/9999/compiler-rt-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -145,8 +149,15 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX
+			# This disables i386 for SDK >= 10.15
+			# Will error if has_use tsan and SDK < 10.12
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt-sanitizers/files/9999/compiler-rt-prefix-paths.patch
+++ b/sys-libs/compiler-rt-sanitizers/files/9999/compiler-rt-prefix-paths.patch
@@ -1,0 +1,79 @@
+--- a/compiler-rt/cmake/config-ix.cmake	2020-10-07 05:10:48.000000000 -0500
++++ b/compiler-rt/cmake/config-ix.cmake	2020-12-13 16:17:43.000000000 -0600
+@@ -424,10 +424,7 @@
+     ${DARWIN_COMMON_LINK_FLAGS}
+     ${DARWIN_osx_MIN_VER_FLAG}=${SANITIZER_MIN_OSX_VERSION})
+ 
+-  if(DARWIN_osx_SYSROOT)
+-    list(APPEND DARWIN_osx_CFLAGS -isysroot ${DARWIN_osx_SYSROOT})
+-    list(APPEND DARWIN_osx_LINK_FLAGS -isysroot ${DARWIN_osx_SYSROOT})
+-  endif()
++  # Do not add -isysroot flag on Gentoo Prefix (search paths handled by cmake)
+ 
+   # Figure out which arches to use for each OS
+   darwin_get_toolchain_supported_archs(toolchain_arches)
+--- a/compiler-rt/cmake/base-config-ix.cmake	2020-12-13 16:17:13.000000000 -0600
++++ b/compiler-rt/cmake/base-config-ix.cmake	2020-12-13 16:18:59.000000000 -0600
+@@ -102,23 +102,8 @@
+ endif()
+ 
+ if(APPLE)
+-  # On Darwin if /usr/include/c++ doesn't exist, the user probably has Xcode but
+-  # not the command line tools (or is using macOS 10.14 or newer). If this is
+-  # the case, we need to find the OS X sysroot to pass to clang.
+-  if(NOT EXISTS /usr/include/c++)
+-    execute_process(COMMAND xcrun -sdk macosx --show-sdk-path
+-       OUTPUT_VARIABLE OSX_SYSROOT
+-       ERROR_QUIET
+-       OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    if (NOT OSX_SYSROOT OR NOT EXISTS ${OSX_SYSROOT})
+-      message(WARNING "Detected OSX_SYSROOT ${OSX_SYSROOT} does not exist")
+-    else()
+-      message(STATUS "Found OSX_SYSROOT: ${OSX_SYSROOT}")
+-      set(OSX_SYSROOT_FLAG "-isysroot${OSX_SYSROOT}")
+-    endif()
+-  else()
+-    set(OSX_SYSROOT_FLAG "")
+-  endif()
++  # Do not add -isysroot flag on Gentoo Prefix (search paths handled by cmake)
++  set(OSX_SYSROOT_FLAG "")
+ 
+   option(COMPILER_RT_ENABLE_IOS "Enable building for iOS" On)
+   option(COMPILER_RT_ENABLE_WATCHOS "Enable building for watchOS - Experimental" Off)
+--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake	2020-10-07 05:10:48.000000000 -0500
++++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake	2020-12-13 16:21:32.000000000 -0600
+@@ -273,7 +273,8 @@
+     ${ARGN})
+   set(libname "${name}.${suffix}_${LIB_ARCH}_${LIB_OS}")
+   add_library(${libname} STATIC ${LIB_SOURCES})
+-  if(DARWIN_${LIB_OS}_SYSROOT)
++  # Do not add -isysroot flag on Gentoo Prefix (search paths handled by cmake)
++  if(DARWIN_${LIB_OS}_SYSROOT AND NOT "${LIB_OS}" STREQUAL "osx")
+     set(sysroot_flag -isysroot ${DARWIN_${LIB_OS}_SYSROOT})
+   endif()
+
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake	2020-10-07 05:10:48.000000000 -0500
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake	2020-12-13 18:12:27.000000000 -0600
+@@ -277,9 +277,10 @@
+       if(CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_TARGET)
+         list(APPEND extra_cflags_${libname} "--target=${CMAKE_C_COMPILER_TARGET}")
+       endif()
++      # Do not add --sysroot flag on Gentoo Prefix (search paths handled by cmake)
+-      if(CMAKE_SYSROOT)
++      if(CMAKE_SYSROOT AND NOT APPLE)
+         list(APPEND extra_cflags_${libname} "--sysroot=${CMAKE_SYSROOT}")
+       endif()
+       string(REPLACE ";" " " extra_cflags_${libname} "${extra_cflags_${libname}}")
+       string(REGEX MATCHALL "<[A-Za-z0-9_]*>" substitutions
+              ${CMAKE_C_COMPILE_OBJECT})
+--- a/compiler-rt/lib/tsan/CMakeLists.txt	2020-12-13 19:42:02.000000000 -0600
++++ b/compiler-rt/lib/tsan/CMakeLists.txt	2020-12-13 19:42:38.000000000 -0600
+@@ -244,6 +244,7 @@
+ # and Clang's versions. As a workaround do not use --sysroot=. on FreeBSD/NetBSD
+ # until this is addressed.
+ if(COMPILER_RT_HAS_SYSROOT_FLAG AND NOT CMAKE_SYSTEM_NAME MATCHES "FreeBSD"
++   AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin"
+    AND NOT CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+   file(GLOB _tsan_generic_sources rtl/tsan*)
+   file(GLOB _tsan_platform_sources rtl/tsan*posix* rtl/tsan*mac*
+

--- a/sys-libs/compiler-rt/compiler-rt-11.0.0.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-11.0.0.ebuild
@@ -29,6 +29,10 @@ BDEPEND="
 		=sys-devel/clang-${PV%_*}*:${CLANG_SLOT} )
 	${PYTHON_DEPS}"
 
+PATCHES=(
+	"${FILESDIR}/9999/${PN}-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -83,8 +87,14 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX.
+			# This disables i386 for SDK >= 10.15
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt/compiler-rt-11.0.1.9999.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-11.0.1.9999.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 LLVM_COMPONENTS=( compiler-rt )
 llvm.org_set_globals
 
+PATCHES=(
+	"${FILESDIR}/9999/${PN}-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -85,8 +89,14 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX.
+			# This disables i386 for SDK >= 10.15
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt/compiler-rt-11.0.1_rc1.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-11.0.1_rc1.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 LLVM_COMPONENTS=( compiler-rt )
 llvm.org_set_globals
 
+PATCHES=(
+	"${FILESDIR}/9999/${PN}-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -85,8 +89,14 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX.
+			# This disables i386 for SDK >= 10.15
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt/compiler-rt-11.0.1_rc2.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-11.0.1_rc2.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 LLVM_COMPONENTS=( compiler-rt )
 llvm.org_set_globals
 
+PATCHES=(
+	"${FILESDIR}/9999/${PN}-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -85,8 +89,14 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX.
+			# This disables i386 for SDK >= 10.15
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt/compiler-rt-12.0.0.9999.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-12.0.0.9999.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 LLVM_COMPONENTS=( compiler-rt )
 llvm.org_set_globals
 
+PATCHES=(
+	"${FILESDIR}/9999/${PN}-prefix-paths.patch"
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version "dev-python/lit[${PYTHON_USEDEP}]"
@@ -85,8 +89,14 @@ src_configure() {
 
 	if use prefix && [[ "${CHOST}" == *-darwin* ]] ; then
 		mycmakeargs+=(
-			# disable use of SDK for the system itself
-			-DDARWIN_macosx_CACHED_SYSROOT=/
+			# setting -isysroot is disabled with compiler-rt-prefix-paths.patch
+			# this allows adding arm64 support using SDK in EPREFIX
+			-DDARWIN_macosx_CACHED_SYSROOT="${EPREFIX}/MacOSX.sdk"
+			# Set version based on the SDK in EPREFIX.
+			# This disables i386 for SDK >= 10.15
+			-DDARWIN_macosx_OVERRIDE_SDK_VERSION="$(realpath ${EPREFIX}/MacOSX.sdk | sed -e 's/.*MacOSX\(.*\)\.sdk/\1/')"
+			# Use our libtool instead of looking it up with xcrun
+			-DCMAKE_LIBTOOL="${EPREFIX}/usr/bin/${CHOST}-libtool"
 		)
 	fi
 

--- a/sys-libs/compiler-rt/files/9999/compiler-rt-prefix-paths.patch
+++ b/sys-libs/compiler-rt/files/9999/compiler-rt-prefix-paths.patch
@@ -1,0 +1,79 @@
+--- a/compiler-rt/cmake/config-ix.cmake	2020-10-07 05:10:48.000000000 -0500
++++ b/compiler-rt/cmake/config-ix.cmake	2020-12-13 16:17:43.000000000 -0600
+@@ -424,10 +424,7 @@
+     ${DARWIN_COMMON_LINK_FLAGS}
+     ${DARWIN_osx_MIN_VER_FLAG}=${SANITIZER_MIN_OSX_VERSION})
+ 
+-  if(DARWIN_osx_SYSROOT)
+-    list(APPEND DARWIN_osx_CFLAGS -isysroot ${DARWIN_osx_SYSROOT})
+-    list(APPEND DARWIN_osx_LINK_FLAGS -isysroot ${DARWIN_osx_SYSROOT})
+-  endif()
++  # Do not add -isysroot flag on Gentoo Prefix (search paths handled by cmake)
+ 
+   # Figure out which arches to use for each OS
+   darwin_get_toolchain_supported_archs(toolchain_arches)
+--- a/compiler-rt/cmake/base-config-ix.cmake	2020-12-13 16:17:13.000000000 -0600
++++ b/compiler-rt/cmake/base-config-ix.cmake	2020-12-13 16:18:59.000000000 -0600
+@@ -102,23 +102,8 @@
+ endif()
+ 
+ if(APPLE)
+-  # On Darwin if /usr/include/c++ doesn't exist, the user probably has Xcode but
+-  # not the command line tools (or is using macOS 10.14 or newer). If this is
+-  # the case, we need to find the OS X sysroot to pass to clang.
+-  if(NOT EXISTS /usr/include/c++)
+-    execute_process(COMMAND xcrun -sdk macosx --show-sdk-path
+-       OUTPUT_VARIABLE OSX_SYSROOT
+-       ERROR_QUIET
+-       OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    if (NOT OSX_SYSROOT OR NOT EXISTS ${OSX_SYSROOT})
+-      message(WARNING "Detected OSX_SYSROOT ${OSX_SYSROOT} does not exist")
+-    else()
+-      message(STATUS "Found OSX_SYSROOT: ${OSX_SYSROOT}")
+-      set(OSX_SYSROOT_FLAG "-isysroot${OSX_SYSROOT}")
+-    endif()
+-  else()
+-    set(OSX_SYSROOT_FLAG "")
+-  endif()
++  # Do not add -isysroot flag on Gentoo Prefix (search paths handled by cmake)
++  set(OSX_SYSROOT_FLAG "")
+ 
+   option(COMPILER_RT_ENABLE_IOS "Enable building for iOS" On)
+   option(COMPILER_RT_ENABLE_WATCHOS "Enable building for watchOS - Experimental" Off)
+--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake	2020-10-07 05:10:48.000000000 -0500
++++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake	2020-12-13 16:21:32.000000000 -0600
+@@ -273,7 +273,8 @@
+     ${ARGN})
+   set(libname "${name}.${suffix}_${LIB_ARCH}_${LIB_OS}")
+   add_library(${libname} STATIC ${LIB_SOURCES})
+-  if(DARWIN_${LIB_OS}_SYSROOT)
++  # Do not add -isysroot flag on Gentoo Prefix (search paths handled by cmake)
++  if(DARWIN_${LIB_OS}_SYSROOT AND NOT "${LIB_OS}" STREQUAL "osx")
+     set(sysroot_flag -isysroot ${DARWIN_${LIB_OS}_SYSROOT})
+   endif()
+
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake	2020-10-07 05:10:48.000000000 -0500
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake	2020-12-13 18:12:27.000000000 -0600
+@@ -277,9 +277,10 @@
+       if(CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_TARGET)
+         list(APPEND extra_cflags_${libname} "--target=${CMAKE_C_COMPILER_TARGET}")
+       endif()
++      # Do not add --sysroot flag on Gentoo Prefix (search paths handled by cmake)
+-      if(CMAKE_SYSROOT)
++      if(CMAKE_SYSROOT AND NOT APPLE)
+         list(APPEND extra_cflags_${libname} "--sysroot=${CMAKE_SYSROOT}")
+       endif()
+       string(REPLACE ";" " " extra_cflags_${libname} "${extra_cflags_${libname}}")
+       string(REGEX MATCHALL "<[A-Za-z0-9_]*>" substitutions
+              ${CMAKE_C_COMPILE_OBJECT})
+--- a/compiler-rt/lib/tsan/CMakeLists.txt	2020-12-13 19:42:02.000000000 -0600
++++ b/compiler-rt/lib/tsan/CMakeLists.txt	2020-12-13 19:42:38.000000000 -0600
+@@ -244,6 +244,7 @@
+ # and Clang's versions. As a workaround do not use --sysroot=. on FreeBSD/NetBSD
+ # until this is addressed.
+ if(COMPILER_RT_HAS_SYSROOT_FLAG AND NOT CMAKE_SYSTEM_NAME MATCHES "FreeBSD"
++   AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin"
+    AND NOT CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+   file(GLOB _tsan_generic_sources rtl/tsan*)
+   file(GLOB _tsan_platform_sources rtl/tsan*posix* rtl/tsan*mac*
+

--- a/sys-libs/libcxx/libcxx-11.0.0.ebuild
+++ b/sys-libs/libcxx/libcxx-11.0.0.ebuild
@@ -14,7 +14,7 @@ llvm.org_set_globals
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~riscv x86"
+KEYWORDS="amd64 arm arm64 ~riscv x86 ~x64-macos"
 IUSE="elibc_glibc elibc_musl +libcxxabi +libunwind +static-libs test"
 REQUIRED_USE="libunwind? ( libcxxabi )"
 RESTRICT="!test? ( test )"
@@ -41,7 +41,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 
 	if ! use libcxxabi && ! tc-is-gcc ; then
@@ -58,6 +62,10 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
+
+	# eprefixify static path references to libc++abi for symbol re-export to
+	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
+	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {
@@ -99,6 +107,15 @@ multilib_src_configure() {
 				extra_libs+=( "${compiler_rt}" )
 			fi
 		fi
+	elif [[ ${CHOST} == *-darwin* ]] && tc-is-clang; then
+		# clang-based darwin prefix disables libunwind useflag during
+		# bootstrap, because libunwind is not in the prefix yet.
+		# override the default, though, because clang based libcxx
+		# should never use gcc_s on Darwin.
+		want_gcc_s=OFF
+		# compiler_rt is not available in EPREFIX during bootstrap,
+		# so we cannot link to it yet anyway, so keep the defaults
+		# of want_compiler_rt=OFF and extra_libs=()
 	fi
 
 	# bootstrap: cmake is unhappy if compiler can't link to stdlib
@@ -188,8 +205,10 @@ gen_shared_ldscript() {
 
 multilib_src_install() {
 	cmake_src_install
-	gen_shared_ldscript
-	use static-libs && gen_static_ldscript
+	if [[ ${CHOST} != *-darwin* ]] ; then
+		gen_shared_ldscript
+		use static-libs && gen_static_ldscript
+	fi
 }
 
 pkg_postinst() {

--- a/sys-libs/libcxx/libcxx-11.0.1.9999.ebuild
+++ b/sys-libs/libcxx/libcxx-11.0.1.9999.ebuild
@@ -42,7 +42,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 
 	if ! use libcxxabi && ! tc-is-gcc ; then
@@ -59,6 +63,10 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
+
+	# eprefixify static path references to libc++abi for symbol re-export to
+	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
+	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {
@@ -100,6 +108,15 @@ multilib_src_configure() {
 				extra_libs+=( "${compiler_rt}" )
 			fi
 		fi
+	elif [[ ${CHOST} == *-darwin* ]] && tc-is-clang; then
+		# clang-based darwin prefix disables libunwind useflag during
+		# bootstrap, because libunwind is not in the prefix yet.
+		# override the default, though, because clang based libcxx
+		# should never use gcc_s on Darwin.
+		want_gcc_s=OFF
+		# compiler_rt is not available in EPREFIX during bootstrap,
+		# so we cannot link to it yet anyway, so keep the defaults
+		# of want_compiler_rt=OFF and extra_libs=()
 	fi
 
 	# bootstrap: cmake is unhappy if compiler can't link to stdlib
@@ -189,8 +206,10 @@ gen_shared_ldscript() {
 
 multilib_src_install() {
 	cmake_src_install
-	gen_shared_ldscript
-	use static-libs && gen_static_ldscript
+	if [[ ${CHOST} != *-darwin* ]] ; then
+		gen_shared_ldscript
+		use static-libs && gen_static_ldscript
+	fi
 }
 
 pkg_postinst() {

--- a/sys-libs/libcxx/libcxx-11.0.1_rc1.ebuild
+++ b/sys-libs/libcxx/libcxx-11.0.1_rc1.ebuild
@@ -42,7 +42,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 
 	if ! use libcxxabi && ! tc-is-gcc ; then
@@ -59,6 +63,10 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
+
+	# eprefixify static path references to libc++abi for symbol re-export to
+	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
+	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {
@@ -100,6 +108,15 @@ multilib_src_configure() {
 				extra_libs+=( "${compiler_rt}" )
 			fi
 		fi
+	elif [[ ${CHOST} == *-darwin* ]] && tc-is-clang; then
+		# clang-based darwin prefix disables libunwind useflag during
+		# bootstrap, because libunwind is not in the prefix yet.
+		# override the default, though, because clang based libcxx
+		# should never use gcc_s on Darwin.
+		want_gcc_s=OFF
+		# compiler_rt is not available in EPREFIX during bootstrap,
+		# so we cannot link to it yet anyway, so keep the defaults
+		# of want_compiler_rt=OFF and extra_libs=()
 	fi
 
 	# bootstrap: cmake is unhappy if compiler can't link to stdlib
@@ -189,8 +206,10 @@ gen_shared_ldscript() {
 
 multilib_src_install() {
 	cmake_src_install
-	gen_shared_ldscript
-	use static-libs && gen_static_ldscript
+	if [[ ${CHOST} != *-darwin* ]] ; then
+		gen_shared_ldscript
+		use static-libs && gen_static_ldscript
+	fi
 }
 
 pkg_postinst() {

--- a/sys-libs/libcxx/libcxx-11.0.1_rc2.ebuild
+++ b/sys-libs/libcxx/libcxx-11.0.1_rc2.ebuild
@@ -42,7 +42,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 
 	if ! use libcxxabi && ! tc-is-gcc ; then
@@ -59,6 +63,10 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
+
+	# eprefixify static path references to libc++abi for symbol re-export to
+	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
+	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {
@@ -100,6 +108,15 @@ multilib_src_configure() {
 				extra_libs+=( "${compiler_rt}" )
 			fi
 		fi
+	elif [[ ${CHOST} == *-darwin* ]] && tc-is-clang; then
+		# clang-based darwin prefix disables libunwind useflag during
+		# bootstrap, because libunwind is not in the prefix yet.
+		# override the default, though, because clang based libcxx
+		# should never use gcc_s on Darwin.
+		want_gcc_s=OFF
+		# compiler_rt is not available in EPREFIX during bootstrap,
+		# so we cannot link to it yet anyway, so keep the defaults
+		# of want_compiler_rt=OFF and extra_libs=()
 	fi
 
 	# bootstrap: cmake is unhappy if compiler can't link to stdlib
@@ -189,8 +206,10 @@ gen_shared_ldscript() {
 
 multilib_src_install() {
 	cmake_src_install
-	gen_shared_ldscript
-	use static-libs && gen_static_ldscript
+	if [[ ${CHOST} != *-darwin* ]] ; then
+		gen_shared_ldscript
+		use static-libs && gen_static_ldscript
+	fi
 }
 
 pkg_postinst() {

--- a/sys-libs/libcxx/libcxx-12.0.0.9999.ebuild
+++ b/sys-libs/libcxx/libcxx-12.0.0.9999.ebuild
@@ -42,7 +42,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 
 	if ! use libcxxabi && ! tc-is-gcc ; then
@@ -59,6 +63,10 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
+
+	# eprefixify static path references to libc++abi for symbol re-export to
+	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
+	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {
@@ -100,6 +108,15 @@ multilib_src_configure() {
 				extra_libs+=( "${compiler_rt}" )
 			fi
 		fi
+	elif [[ ${CHOST} == *-darwin* ]] && tc-is-clang; then
+		# clang-based darwin prefix disables libunwind useflag during
+		# bootstrap, because libunwind is not in the prefix yet.
+		# override the default, though, because clang based libcxx
+		# should never use gcc_s on Darwin.
+		want_gcc_s=OFF
+		# compiler_rt is not available in EPREFIX during bootstrap,
+		# so we cannot link to it yet anyway, so keep the defaults
+		# of want_compiler_rt=OFF and extra_libs=()
 	fi
 
 	# bootstrap: cmake is unhappy if compiler can't link to stdlib
@@ -189,8 +206,10 @@ gen_shared_ldscript() {
 
 multilib_src_install() {
 	cmake_src_install
-	gen_shared_ldscript
-	use static-libs && gen_static_ldscript
+	if [[ ${CHOST} != *-darwin* ]] ; then
+		gen_shared_ldscript
+		use static-libs && gen_static_ldscript
+	fi
 }
 
 pkg_postinst() {

--- a/sys-libs/libcxxabi/libcxxabi-11.0.0.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-11.0.0.ebuild
@@ -16,7 +16,7 @@ llvm.org_set_globals
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~riscv x86"
+KEYWORDS="amd64 arm arm64 ~riscv x86 ~x64-macos"
 IUSE="+libunwind +static-libs test elibc_musl"
 RESTRICT="!test? ( test )"
 
@@ -39,7 +39,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 }
 

--- a/sys-libs/libcxxabi/libcxxabi-11.0.1.9999.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-11.0.1.9999.ebuild
@@ -41,7 +41,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 }
 

--- a/sys-libs/libcxxabi/libcxxabi-11.0.1_rc1.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-11.0.1_rc1.ebuild
@@ -41,7 +41,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 }
 

--- a/sys-libs/libcxxabi/libcxxabi-11.0.1_rc2.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-11.0.1_rc2.ebuild
@@ -41,7 +41,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 }
 

--- a/sys-libs/libcxxabi/libcxxabi-12.0.0.9999.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-12.0.0.9999.ebuild
@@ -41,7 +41,11 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	llvm_pkg_setup
+	# darwin prefix builds do not have llvm installed yet, so rely on bootstrap-prefix
+	# to set the appropriate path vars to LLVM instead of using llvm_pkg_setup.
+	if [[ ${CHOST} != *-darwin* ]] || has_version dev-lang/llvm; then
+		llvm_pkg_setup
+	fi
 	use test && python-any-r1_pkg_setup
 }
 

--- a/sys-libs/llvm-libunwind/llvm-libunwind-11.0.0.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-11.0.0.ebuild
@@ -15,7 +15,7 @@ llvm.org_set_globals
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 x86"
+KEYWORDS="amd64 arm arm64 x86 ~x64-macos"
 IUSE="debug +static-libs test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
This adjusts these llvm-11+ packages to support darwin prefix:
- sys-libs/libcxx
- sys-libs/libcxxabi
- sys-devel/clang
- sys-libs/llvm-libunwind (just keyword for `~x64-macos`)
- sys-libs/compiler-rt
- sys-libs/compiler-rt-sanitizers

### For sys-libs/libcxx*:

Add bootstrap useflag to libcxx and libcxxabi to allow the prefix
bootstrap phase to skip llvm_pkg_setup which checks for an installed
llvm. The bootstrap script takes care of setting sufficient variables so
that the correct llvm will be found on the PATH. Plus, during bootstrap
llvm might not be installed yet (depending on the stage), so allow
skipping that.

Also, eprefrixify some dylib paths in CMakeLists.txt (dylib is only used
on darwin, so this is not an issue when compiling on any other platform.

Plus, re-add a couple of darwin specific fixes to set things up
correctly on darwin, and then keyword ~x64-macos

### For sys-devel/clang:

Adjust the clang internal header/framework search paths when building on
darwin prefix. We symlink the selected MacOSX.sdk to EPREFIX/MacOSX.sdk
during bootstrap, so that is the correct place to get system headers,
such as those for libc, or for system framework headers, that we do not
replace in prefix.

### For sys-libs/compiler-rt*:

Gentoo Prefix does not follow standard Apple practice of using --sysroot
or --isysroot on everything because we have to account for two "root"s.
1) EPREFIX is "root"
2) EPREFIX/MacOSX.sdk is also sysroot as it provides system headers.
    
So, adjust sys-libs/compiler-rt and sys-libs/compiler-rt-sanitizers to
prevent them from adding the sysroot flags on Darwin.
    
The ebuilds also adjust some CMAKE args to ensure it is using
EPREFIX/MacOSX.sdk instead of looking things up with xcrun.