### PR TITLE
media-video/dvdbackup: libdvdread subslot dep

### DIFF
--- a/media-video/dvdbackup/dvdbackup-0.4.2-r1.ebuild
+++ b/media-video/dvdbackup/dvdbackup-0.4.2-r1.ebuild
@@ -12,7 +12,7 @@ SLOT="0"
 KEYWORDS="amd64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE="nls"
 
-RDEPEND=">=media-libs/libdvdread-4.2.0_pre
+RDEPEND=">=media-libs/libdvdread-4.2.0_pre:=
 	nls? ( virtual/libintl )"
 DEPEND="${RDEPEND}
 	nls? ( sys-devel/gettext )"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/760768
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Daniel M. Weeks <dan@danweeks.net>