### PR TITLE
sys-devel/binutils-apple: fix llvm-shim

### DIFF
--- a/sys-devel/binutils-apple/binutils-apple-11.3.1.ebuild
+++ b/sys-devel/binutils-apple/binutils-apple-11.3.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="http://www.opensource.apple.com/tarballs/ld64/${LD64}.tar.gz
 	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-5.1-r2.tar.bz2
 	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-7.3-r2.tar.bz2
 	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-8.2-r1.tar.bz2
-	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-11.3.tar.bz2"
+	https://dev.gentoo.org/~grobian/distfiles/${PN}-patches-11.3-r1.tar.bz2"
 
 LICENSE="APSL-2"
 KEYWORDS="~x64-macos ~x86-macos"
@@ -100,7 +100,7 @@ src_prepare() {
 	epatch "${S}"/${PN}-7.3-make-j.patch
 	epatch "${S}"/${PN}-11.3.1-no-developertools-dir.patch # 7.3 failed to apply. updated
 	epatch "${S}"/${PN}-11.3.1-llvm-prefix.patch # 8.2.1 failed to apply. updated
-	epatch "${S}"/${PN}-8.2.1-llvm-shim.patch
+	epatch "${S}"/${PN}-11.3.1-llvm-shim.patch # 8.2.1 failed to find dsymutil. fixed
 	epatch "${S}"/${PN}-11.3.1-nolto-fix.patch # bugfix
 	epatch "${S}"/${PN}-11.3.1-segaddrtable-fix.patch # bugfix
 	eprefixify libstuff/execute.c


### PR DESCRIPTION
This uses newer patches so that dsymutil can be found even though it is
not named llvm-dsymutil, and it also bumps the max llvm slots searched
from 10 to 12.

Bug: https://bugs.gentoo.org/631862
Signed-off-by: Jacob Floyd <cognifloyd@gmail.com>