### PR TITLE
sys-fs/cryfs: add python3_9 to PYTHON_COMPAT

### DIFF
--- a/sys-fs/cryfs/cryfs-0.10.2.ebuild
+++ b/sys-fs/cryfs/cryfs-0.10.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 inherit cmake flag-o-matic linux-info python-any-r1
 
 if [[ ${PV} == 9999 ]] ; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/760507
Signed-off-by: Nicholas Meyer <nickaristocrates@gmail.com>