### PR TITLE
Haskell: tighten dev-haskell/text upper bound

### DIFF
--- a/dev-haskell/text/text-1.2.4.0-r1.ebuild
+++ b/dev-haskell/text/text-1.2.4.0-r1.ebuild
@@ -24,7 +24,7 @@ IUSE=""
 # break cyclic dependencies, test suite requires porting to >=QC-2.11
 RESTRICT=test
 
-RDEPEND=">=dev-lang/ghc-8.8.1:="
+RDEPEND=">=dev-lang/ghc-8.8.1:= <dev-lang/ghc-8.10:="
 
 DEPEND="${RDEPEND}
 "


### PR DESCRIPTION
~~The `yesod-static` bump is straightforward.~~ The thing I'm less sure about is the `text` changes.

I need to force `dev-haskell/text-1.2.4.0::haskell` to downgrade to `dev-haskell/text-1.2.3.2::haskell` when `ghc-8.10.2` is keyworded there shortly, without falling back to `dev-haskell/text-1.2.4.0::gentoo`. The attempted solution is to revbump `dev-haskell/text-1.2.4.0::gentoo` with a tightened ghc upper bound. The hope is that for `::haskell` users, Portage will decide to downgrade to `dev-haskell/text-1.2.3.2::haskell` rather than staying on the now-unavailable `dev-haskell/text-1.2.4.0-r0` from either repo - but I'm not that familiar with Portage's resolver logic.

This otherwise should not affect `::gentoo`-only users, other than a rebuild.