### PR TITLE
sys-process/bpytop: Install themes

### DIFF
--- a/sys-process/bpytop/bpytop-1.0.52-r1.ebuild
+++ b/sys-process/bpytop/bpytop-1.0.52-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{6..9} )
+DISTUTILS_USE_SETUPTOOLS=pyproject.toml
+inherit distutils-r1
+
+DESCRIPTION="Linux/OSX/FreeBSD resource monitor"
+HOMEPAGE="https://github.com/aristocratos/bpytop"
+SRC_URI="https://github.com/aristocratos/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+
+RDEPEND="
+	>=dev-python/psutil-5.7.1[${PYTHON_USEDEP}]
+"
+
+distutils_enable_tests pytest
+
+PATCHES=(
+	"${FILESDIR}/bpytop-1.0.51-tests.patch"
+)
+
+src_install() {
+	insinto "/usr/share/${PN}/themes"
+	doins bpytop-themes/*.theme
+	distutils-r1_src_install
+}


### PR DESCRIPTION
This PR makes `sys-process/bpytop` install the colour themes included in the upstream repository.

For some reason I do not understand, this also leads to the readme being installed in `/usr/share/doc/bpytop/`.
This was not an intended change, but I believe it is acceptable.