### PR TITLE
media-video/mpv: USE wayland depend on libX11

### DIFF
--- a/media-video/mpv/mpv-0.33.0-r100.ebuild
+++ b/media-video/mpv/mpv-0.33.0-r100.ebuild
@@ -99,6 +99,7 @@ COMMON_DEPEND="
 	wayland? (
 		>=dev-libs/wayland-1.6.0
 		>=dev-libs/wayland-protocols-1.14
+		x11-libs/libX11
 		>=x11-libs/libxkbcommon-0.3.0
 	)
 	X? (

--- a/media-video/mpv/mpv-0.33.0.ebuild
+++ b/media-video/mpv/mpv-0.33.0.ebuild
@@ -101,6 +101,7 @@ COMMON_DEPEND="
 	wayland? (
 		>=dev-libs/wayland-1.6.0
 		>=dev-libs/wayland-protocols-1.14
+		x11-libs/libX11
 		>=x11-libs/libxkbcommon-0.3.0
 	)
 	X? (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/759448

Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>