### PR TITLE
Remove Tianon from maintainers

### DIFF
--- a/app-emulation/containerd/metadata.xml
+++ b/app-emulation/containerd/metadata.xml
@@ -9,10 +9,6 @@
 		and live migration of containers.
 	</longdescription>
 	<maintainer type="person">
-		<email>admwiggin@gmail.com</email>
-		<name>Tianon</name>
-	</maintainer>
-	<maintainer type="person">
 		<email>williamh@gentoo.org</email>
 		<name>William Hubbs</name>
 	</maintainer>

--- a/app-emulation/docker-proxy/metadata.xml
+++ b/app-emulation/docker-proxy/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>tianon@dockerproject.org</email>
-		<name>Tianon</name>
-	</maintainer>
-	<maintainer type="person">
 		<email>williamh@gentoo.org</email>
 		<name>William Hubbs</name>
 	</maintainer>


### PR DESCRIPTION
This is updating the metadata to match the reality. :innocent: :heart:

![image](https://user-images.githubusercontent.com/161631/102947629-8ef33580-4478-11eb-850c-a6d41799eceb.png)