### PR TITLE
dev-util/gdbus-codegen: Add doc USE flag.

### DIFF
--- a/dev-util/gdbus-codegen/gdbus-codegen-2.66.4.ebuild
+++ b/dev-util/gdbus-codegen/gdbus-codegen-2.66.4.ebuild
@@ -16,13 +16,15 @@ HOMEPAGE="https://www.gtk.org/"
 LICENSE="LGPL-2+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-macos"
-IUSE=""
+IUSE="+doc"
 
 RDEPEND="${PYTHON_DEPS}"
 DEPEND="${RDEPEND}"
 BDEPEND="
-	dev-libs/libxslt
-	app-text/docbook-xsl-stylesheets
+	doc? (
+		dev-libs/libxslt
+		app-text/docbook-xsl-stylesheets
+	)
 "
 
 S="${WORKDIR}/glib-${PV}/gio/gdbus-2.0/codegen"
@@ -59,7 +61,7 @@ do_xsltproc_command() {
 
 src_compile() {
 	distutils-r1_src_compile
-	do_xsltproc_command "${WORKDIR}/glib-${PV}/docs/reference/gio/gdbus-codegen.xml" "${WORKDIR}/glib-${PV}/docs/reference/gio/gdbus-codegen.1"
+	use doc && do_xsltproc_command "${WORKDIR}/glib-${PV}/docs/reference/gio/gdbus-codegen.xml" "${WORKDIR}/glib-${PV}/docs/reference/gio/gdbus-codegen.1"
 }
 
 src_test() {
@@ -69,5 +71,5 @@ src_test() {
 
 python_install_all() {
 	distutils-r1_python_install_all # no-op, but prevents QA warning
-	doman "${WORKDIR}/glib-${PV}/docs/reference/gio/gdbus-codegen.1"
+	use doc && doman "${WORKDIR}/glib-${PV}/docs/reference/gio/gdbus-codegen.1"
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/761391
Signed-off-by: Allen Webb <allenwebb@google.com>