### PR TITLE
www-server/lighttpd: Support wasm files

### DIFF
--- a/www-servers/lighttpd/files/conf/mime-types.conf
+++ b/www-servers/lighttpd/files/conf/mime-types.conf
@@ -12,6 +12,7 @@ mimetype.assign             = (
   ".spl"          =>      "application/futuresplash",
   ".class"        =>      "application/octet-stream",
   ".ps"           =>      "application/postscript",
+  ".wasm"         =>      "application/wasm",
   ".torrent"      =>      "application/x-bittorrent",
   ".dvi"          =>      "application/x-dvi",
   ".gz"           =>      "application/x-gzip",


### PR DESCRIPTION
`.wasm` files should be server with the `application/wasm` MIME type or some
features such as proper streamed loading and compilation may not be used
by browsers.
This change adjusts the lighttpd ebuild to include such a setting in its MIME
type configuration.

Signed-off-by: Daniel Müller <deso@posteo.net>