### PR TITLE
x11-terms/guake: Add python 3.8 compat

### DIFF
--- a/x11-terms/guake/guake-3.7.0.ebuild
+++ b/x11-terms/guake/guake-3.7.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{6,7} )
+PYTHON_COMPAT=( python3_{6..8} )
 DISTUTILS_SINGLE_IMPL=1
 
 inherit distutils-r1 gnome2-utils xdg-utils


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/759529
Signed-off-by: Mord3rca <morderca@morderca.net>