### PR TITLE
dev-libs/libucl: fix lua USE flag

### DIFF
--- a/dev-libs/libucl/libucl-0.8.1-r100.ebuild
+++ b/dev-libs/libucl/libucl-0.8.1-r100.ebuild
@@ -42,7 +42,7 @@ src_prepare() {
 }
 
 src_configure() {
-	lua_setup
+	use lua && lua_setup
 
 	local myeconfargs=(
 		"$(use_enable lua)"
@@ -50,6 +50,8 @@ src_configure() {
 		"$(use_enable sign signatures)"
 		"$(use_enable urls)"
 		"$(use_enable utils)"
+	)
+	use lua && myeconfargs+=(
 		LUA_INCLUDE="$(lua_get_CFLAGS)"
 		LIB_LIBS="$(lua_get_LIBS)"
 	)

--- a/dev-libs/libucl/libucl-9999.ebuild
+++ b/dev-libs/libucl/libucl-9999.ebuild
@@ -42,7 +42,7 @@ src_prepare() {
 }
 
 src_configure() {
-	lua_setup
+	use lua && lua_setup
 
 	local myeconfargs=(
 		"$(use_enable lua)"
@@ -50,6 +50,8 @@ src_configure() {
 		"$(use_enable sign signatures)"
 		"$(use_enable urls)"
 		"$(use_enable utils)"
+	)
+	use lua && myeconfargs+=(
 		LUA_INCLUDE="$(lua_get_CFLAGS)"
 		LIB_LIBS="$(lua_get_LIBS)"
 	)


### PR DESCRIPTION
remove calling lua_setup and co. when
not with USE lua
Closes: https://bugs.gentoo.org/761808

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>