### PR TITLE
sys-libs/libcxx: Fix lib/CMakeLists.txt not found

### DIFF
--- a/sys-libs/libcxx/libcxx-11.0.0.ebuild
+++ b/sys-libs/libcxx/libcxx-11.0.0.ebuild
@@ -62,10 +62,6 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
-
-	# eprefixify static path references to libc++abi for symbol re-export to
-	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
-	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {

--- a/sys-libs/libcxx/libcxx-11.0.1.9999.ebuild
+++ b/sys-libs/libcxx/libcxx-11.0.1.9999.ebuild
@@ -63,10 +63,6 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
-
-	# eprefixify static path references to libc++abi for symbol re-export to
-	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
-	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {

--- a/sys-libs/libcxx/libcxx-11.0.1_rc1.ebuild
+++ b/sys-libs/libcxx/libcxx-11.0.1_rc1.ebuild
@@ -63,10 +63,6 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
-
-	# eprefixify static path references to libc++abi for symbol re-export to
-	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
-	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {

--- a/sys-libs/libcxx/libcxx-11.0.1_rc2.ebuild
+++ b/sys-libs/libcxx/libcxx-11.0.1_rc2.ebuild
@@ -63,10 +63,6 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
-
-	# eprefixify static path references to libc++abi for symbol re-export to
-	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
-	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {

--- a/sys-libs/libcxx/libcxx-12.0.0.9999.ebuild
+++ b/sys-libs/libcxx/libcxx-12.0.0.9999.ebuild
@@ -63,10 +63,6 @@ src_prepare() {
 	eapply "${FILESDIR}/${PN}-3.9-cmake-link-flags.patch"
 
 	llvm.org_src_prepare
-
-	# eprefixify static path references to libc++abi for symbol re-export to
-	# avoid linking against it twice in both /usr/lib and ${EPREFIX}/usr/lib
-	sed -i -e "s^/usr/lib/libc++abi.dylib^${EPREFIX}&^g" lib/CMakeLists.txt || die
 }
 
 test_compiler() {


### PR DESCRIPTION
This partially reverts 74c82761ee2b2145fc03019edb187869f6856a38

I missed that this file no longer exists, and the hard-coded reference
is not in any of the current libcxx sources. Why it didn't fail when
building this in my darwin prefix, I don't know.

Bug: https://bugs.gentoo.org/761921
Signed-off-by: Jacob Floyd <cognifloyd@gmail.com>