### PR TITLE
dev-util/cmake: fix cmake bootstrap on Darwin

### DIFF
--- a/dev-util/cmake/cmake-3.19.2.ebuild
+++ b/dev-util/cmake/cmake-3.19.2.ebuild
@@ -78,6 +78,14 @@ cmake_src_bootstrap() {
 		-e '/"${cmake_bootstrap_dir}\/cmake"/s/^/#DONOTRUN /' \
 		bootstrap || die "sed failed"
 
+	# For Darwin prefix, system cmake does not have our prefix paths.
+	# So, ensure system frameworks are found during cmake bootstrap.
+	if [[ ${CHOST} == *-darwin* && -d "${EPREFIX}"/MacOSX.sdk ]] ; then
+		local sdk_frameworks="${EPREFIX}"/MacOSX.sdk/System/Library/Frameworks
+		append-cflags $(test-flags-CC "-F${sdk_frameworks}")
+		append-cxxflags $(test-flags-CXX "-F${sdk_frameworks}")
+	fi
+
 	# execinfo.h on Solaris isn't quite what it is on Darwin
 	if [[ ${CHOST} == *-solaris* ]] ; then
 		sed -i -e 's/execinfo\.h/blablabla.h/' \

--- a/dev-util/cmake/cmake-3.19.2.ebuild
+++ b/dev-util/cmake/cmake-3.19.2.ebuild
@@ -18,14 +18,15 @@ LICENSE="CMake"
 SLOT="0"
 [[ "${PV}" = *_rc* ]] || \
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
-IUSE="doc emacs ncurses qt5 test"
+# system-jsoncpp is only meant to be disabled during prefix bootstrap
+IUSE="doc emacs ncurses qt5 +system-jsoncpp test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
 	>=app-arch/libarchive-3.3.3:=
 	app-crypt/rhash
 	>=dev-libs/expat-2.0.1
-	>=dev-libs/jsoncpp-1.9.2-r2:0=
+	system-jsoncpp? ( >=dev-libs/jsoncpp-1.9.2-r2:0= )
 	>=dev-libs/libuv-1.10.0:=
 	>=net-misc/curl-7.21.5[ssl]
 	sys-libs/zlib
@@ -166,6 +167,7 @@ src_configure() {
 
 	local mycmakeargs=(
 		-DCMAKE_USE_SYSTEM_LIBRARIES=ON
+		-DCMAKE_USE_SYSTEM_LIBRARY_JSONCPP=$(usex system-jsoncpp)
 		-DCMAKE_DOC_DIR=/share/doc/${PF}
 		-DCMAKE_MAN_DIR=/share/man
 		-DCMAKE_DATA_DIR=/share/${PN}

--- a/profiles/base/package.use.force
+++ b/profiles/base/package.use.force
@@ -165,3 +165,11 @@ dev-lang/python wide-unicode
 # Forcing w.r.t. bug 265336. When unicode use-flag is
 # turned off, ABI is broken without a .so bump.
 dev-libs/libpcre unicode
+
+# Jacob Floyd <cognifloyd@gmail.com> (2020-12-27)
+# For prefix bootstrapping, sys-libs/jsoncpp cannot be
+# installed before dev-util/cmake in stage2 and early stage3
+# because jsoncpp requires meson which is not available yet.
+# Re-add the system-jsoncpp useflag, but only for prefix use.
+# Force it on for all other profiles.
+dev-util/cmake system-jsoncpp

--- a/profiles/prefix/package.use.force
+++ b/profiles/prefix/package.use.force
@@ -1,0 +1,9 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Jacob Floyd <cognifloyd@gmail.com> (2020-12-27)
+# For prefix bootstrapping, sys-libs/jsoncpp cannot be
+# installed before dev-util/cmake in stage2 and early stage3
+# because jsoncpp requires meson which is not available yet.
+# Re-add the system-jsoncpp useflag, but only for prefix use.
+dev-util/cmake -system-jsoncpp


### PR DESCRIPTION
Two remaining cmake issues need to be fixed in ::gentoo for prefix bootstraps on darwin.

- Reintroduce the system-jsoncpp use flag
- Explicitly add the sdk framework search paths during cmake bootstrap

Bug: https://bugs.gentoo.org/757513