### PR TITLE
mail-filter/sieve-connect: 0.90 version stabilisation

### DIFF
--- a/mail-filter/sieve-connect/sieve-connect-0.90.ebuild
+++ b/mail-filter/sieve-connect/sieve-connect-0.90.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/syscomet/sieve-connect/releases/download/v${PV}/${P}
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 
 DEPEND=">=dev-lang/perl-5"
 RDEPEND="${DEPEND}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/762071
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: Alarig Le Lay <alarig@swordarmor.fr