### PR TITLE
media-libs/pjproject: inherit toolchain-funcs

### DIFF
--- a/net-libs/pjproject/pjproject-2.10.ebuild
+++ b/net-libs/pjproject/pjproject-2.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools flag-o-matic
+inherit autotools flag-o-matic toolchain-funcs
 
 DESCRIPTION="Open source SIP, Media, and NAT Traversal Library"
 HOMEPAGE="https://www.pjsip.org/"

--- a/net-libs/pjproject/pjproject-2.9-r2.ebuild
+++ b/net-libs/pjproject/pjproject-2.9-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools flag-o-matic
+inherit autotools flag-o-matic toolchain-funcs
 
 DESCRIPTION="Open source SIP, Media, and NAT Traversal Library"
 HOMEPAGE="https://www.pjsip.org/"


### PR DESCRIPTION
Fixes:

IndirectInherits: version 2.9-r2: toolchain-funcs: indirect inherit usage: 'tc-getCC', line 84
IndirectInherits: version 2.10: toolchain-funcs: indirect inherit usage: 'tc-getCC', line 84

Signed-off-by: Jaco Kroon <jaco@uls.co.za>