### PR TITLE
media-gfx/prusaslicer: depend on boost subslot

### DIFF
--- a/media-gfx/prusaslicer/prusaslicer-2.2.0-r1.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.2.0-r1.ebuild
@@ -23,7 +23,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="
 	dev-cpp/eigen:3
 	dev-cpp/tbb
-	>=dev-libs/boost-1.73.0[threads]
+	>=dev-libs/boost-1.73.0:=[threads]
 	dev-libs/cereal
 	dev-libs/expat
 	dev-libs/miniz


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/762430
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Daniel M. Weeks <dan@danweeks.net>