### PR TITLE
media-sound/umurmur: depend on libconfig subslot

### DIFF
--- a/media-sound/umurmur/umurmur-0.2.17-r4.ebuild
+++ b/media-sound/umurmur/umurmur-0.2.17-r4.ebuild
@@ -21,7 +21,7 @@ IUSE="gnutls libressl mbedtls shm"
 # ssl-provider precendence: gnutls, mbedtls, libressl
 # and openssl if none specified
 DEPEND=">=dev-libs/protobuf-c-1.0.0_rc2
-	dev-libs/libconfig
+	dev-libs/libconfig:=
 	gnutls? (
 		dev-libs/nettle:=
 		>=net-libs/gnutls-3.0.0


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/762439
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Daniel M. Weeks <dan@danweeks.net>