### PR TITLE
app-emulation/libpod: Add zsh and fish completion

### DIFF
--- a/app-emulation/libpod/libpod-2.2.1.ebuild
+++ b/app-emulation/libpod/libpod-2.2.1.ebuild
@@ -121,6 +121,12 @@ src_install() {
 
 	dobashcomp completions/bash/*
 
+	insinto /usr/share/zsh/site-functions
+	doins completions/zsh/*
+
+	insinto /usr/share/fish/vendor_completions.d
+	doins completions/fish/*
+
 	keepdir /var/lib/containers
 }
 


### PR DESCRIPTION
Since v2.2.0, upstream supports fish completion. 
zsh has been supported for a while.

https://github.com/containers/podman/releases/tag/v2.2.0