### PR TITLE
LibreSSL support

### DIFF
--- a/net-libs/nodejs/nodejs-14.15.1.ebuild
+++ b/net-libs/nodejs/nodejs-14.15.1.ebuild
@@ -31,7 +31,11 @@ RDEPEND=">=app-arch/brotli-1.0.9
 	>=net-libs/nghttp2-1.41.0
 	sys-libs/zlib
 	system-icu? ( >=dev-libs/icu-67:= )
-	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )"
+	system-ssl? (
+    		!libressl? ( dev-libs/openssl:0= )
+    		libressl? ( dev-libs/libressl:0= )
+		)"
+
 BDEPEND="${PYTHON_DEPS}
 	sys-apps/coreutils
 	systemtap? ( dev-util/systemtap )


### PR DESCRIPTION
Should add support for LibreSSL based on instructions at https://wiki.gentoo.org/wiki/Project:LibreSSL this should work unless they is something OpenSSL specific in NodeJS that prevents it from working with LibreSSL but from my understanding LibreSSL should be a drop in replacement.

Signed-off-by: Oliver Smeeton <Oliversmeeton@protonmail.com>