### PR TITLE
package.mask: last rite sci-physics/cernlib & revdeps

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,14 @@
 #--- END OF EXAMPLES ---
 
 # Jakov Smolic <jakov.smolic@sartura.hr> (2021-01-02)
+# sci-phisycs/cernlib fails to build with gcc-10,
+# last release in 2006, multiple open bugs, revdeps also broken
+# Removal in 30 days, bug #763183
+sci-physics/cernlib
+sci-physics/cernlib-montecarlo
+sci-physics/paw
+
+# Jakov Smolic <jakov.smolic@sartura.hr> (2021-01-02)
 # Fails to build with gcc-10, no maintainer, upstream gone,
 # multiple open bugs.
 # Removal in 30 days, bug #677322, bug #707200, bug #716012


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/763183