### PR TITLE
app-emulation/cloud-init: 20.4: DEPENDS: Added pytest and pytest-cov.

### DIFF
--- a/app-emulation/cloud-init/cloud-init-20.4.ebuild
+++ b/app-emulation/cloud-init/cloud-init-20.4.ebuild
@@ -40,6 +40,8 @@ DEPEND="
 		>=dev-python/httpretty-0.7.1[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/nose[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+		dev-python/pytest-cov[${PYTHON_USEDEP}]
 		dev-python/unittest2[${PYTHON_USEDEP}]
 		dev-python/coverage[${PYTHON_USEDEP}]
 		dev-python/contextlib2[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/762172
