### PR TITLE
dev-lang/zig: Drop to maintainer-needed@

### DIFF
--- a/dev-lang/zig/metadata.xml
+++ b/dev-lang/zig/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>n@nirf.de</email>
-		<name>Nick Erdmann</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<use>
 		<flag name="experimental">Enable builds that do not support all of LLVM's target architectures</flag>
 	</use>


### PR DESCRIPTION
Multiple open bugs on the package; maintainer has not committed in 15
months and has no bugzilla activity in a year.

Closes: https://bugs.gentoo.org/691582
Signed-off-by: Matt Turner <mattst88@gentoo.org>

@nrdmn