### PR TITLE
dist-kernel module rebuilding logic [WIP]

### DIFF
--- a/eclass/linux-mod.eclass
+++ b/eclass/linux-mod.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: linux-mod.eclass
@@ -144,9 +144,16 @@ esac
 	0) die "EAPI=${EAPI} is not supported with MODULES_OPTIONAL_USE_IUSE_DEFAULT due to lack of IUSE defaults" ;;
 esac
 
-IUSE="kernel_linux ${MODULES_OPTIONAL_USE:+${_modules_optional_use_iuse_default}}${MODULES_OPTIONAL_USE}"
+IUSE="kernel_linux dist-kernel
+	${MODULES_OPTIONAL_USE:+${_modules_optional_use_iuse_default}}${MODULES_OPTIONAL_USE}"
 SLOT="0"
-RDEPEND="${MODULES_OPTIONAL_USE}${MODULES_OPTIONAL_USE:+? (} kernel_linux? ( sys-apps/kmod[tools] ) ${MODULES_OPTIONAL_USE:+)}"
+RDEPEND="
+	${MODULES_OPTIONAL_USE}${MODULES_OPTIONAL_USE:+? (}
+		kernel_linux? (
+			sys-apps/kmod[tools]
+			dist-kernel? ( virtual/dist-kernel:= )
+		)
+	${MODULES_OPTIONAL_USE:+)}"
 DEPEND="${RDEPEND}
     ${MODULES_OPTIONAL_USE}${MODULES_OPTIONAL_USE:+? (}
 	sys-apps/sed

--- a/profiles/arch/amd64/use.mask
+++ b/profiles/arch/amd64/use.mask
@@ -6,6 +6,10 @@
 
 # SECTION: Unmask
 
+# Michał Górny <mgorny@gentoo.org> (2021-01-03)
+# Prebuilt kernels are supported here.
+-dist-kernel
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-06-06)
 # sci-libs/mkl works on amd64
 -mkl

--- a/profiles/arch/amd64/use.stable.mask
+++ b/profiles/arch/amd64/use.stable.mask
@@ -1,8 +1,12 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
+
+# Michał Górny <mgorny@gentoo.org> (2021-01-03)
+# Prebuilt kernel rebuilds are supported on stable yet.
+dist-kernel
 
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-06-06)
 # sci-libs/mkl is not stable, needs online registration to even run pkg_setup

--- a/profiles/arch/base/use.mask
+++ b/profiles/arch/base/use.mask
@@ -1,5 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Michał Górny <mgorny@gentoo.org> (2021-01-03)
+# Prebuilt kernels are not supported on all architectures.
+dist-kernel
 
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-06-06)
 # sci-libs/mkl is only supported on specific architectures

--- a/profiles/arch/powerpc/ppc64/64le/package.mask
+++ b/profiles/arch/powerpc/ppc64/64le/package.mask
@@ -17,6 +17,7 @@
 # little-endian power8 ppc64 configs are provided
 -sys-kernel/gentoo-kernel
 -sys-kernel/vanilla-kernel
+-virtual/dist-kernel
 
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2020-01-25)
 # libva unmasked on little-endian profile

--- a/profiles/arch/powerpc/ppc64/package.mask
+++ b/profiles/arch/powerpc/ppc64/package.mask
@@ -16,6 +16,7 @@ dev-java/openjfx:11
 # however users can unmask and use savedconfig feature
 sys-kernel/gentoo-kernel
 sys-kernel/vanilla-kernel
+virtual/dist-kernel
 
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2020-01-21)
 # buggy on big-endian

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -62,6 +62,7 @@ dbus - Enable dbus support for anything that needs it (gpsd, gnomemeeting, etc)
 debug - Enable extra debug codepaths, like asserts and extra output. If you want to get meaningful backtraces see https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Backtraces
 dedicated - Add support for dedicated game servers (some packages do not provide clients and servers at the same time)
 dga - Add DGA (Direct Graphic Access) support for X
+dist-kernel - Enable subslot rebuilds on Distribution Kernel upgrades
 djvu - Support DjVu, a PDF-like document format esp. suited for scanned documents
 doc - Add extra documentation (API, Javadoc, etc). It is recommended to enable per package instead of globally
 dri - Enable direct rendering: used for accelerated 3D and some 2D, like DMA

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.4-r1.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.4-r1.ebuild
@@ -22,6 +22,8 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 	!sys-kernel/vanilla-kernel:${SLOT}
 	!sys-kernel/vanilla-kernel-bin:${SLOT}"
+PDEPEND="
+	~virtual/dist-kernel-${PV}"
 
 QA_PREBUILT='*'
 

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.4.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.4.ebuild
@@ -26,6 +26,8 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 	!sys-kernel/vanilla-kernel:${SLOT}
 	!sys-kernel/vanilla-kernel-bin:${SLOT}"
+PDEPEND="
+	~virtual/dist-kernel-${PV}"
 
 QA_PREBUILT='*'
 

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.86-r1.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.86-r1.ebuild
@@ -30,6 +30,8 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 	!sys-kernel/vanilla-kernel:${SLOT}
 	!sys-kernel/vanilla-kernel-bin:${SLOT}"
+PDEPEND="
+	~virtual/dist-kernel-${PV}"
 
 QA_PREBUILT='*'
 

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.86.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.86.ebuild
@@ -26,6 +26,8 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 	!sys-kernel/vanilla-kernel:${SLOT}
 	!sys-kernel/vanilla-kernel-bin:${SLOT}"
+PDEPEND="
+	~virtual/dist-kernel-${PV}"
 
 QA_PREBUILT='*'
 

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-5.10.4.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-5.10.4.ebuild
@@ -47,6 +47,8 @@ RDEPEND="
 	!sys-kernel/vanilla-kernel-bin:${SLOT}"
 BDEPEND="
 	debug? ( dev-util/dwarves )"
+PDEPEND="
+	~virtual/dist-kernel-${PV}"
 
 src_prepare() {
 	local PATCHES=(

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-5.4.86.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-5.4.86.ebuild
@@ -46,6 +46,8 @@ RDEPEND="
 	!sys-kernel/vanilla-kernel-bin:${SLOT}"
 BDEPEND="
 	debug? ( dev-util/dwarves )"
+PDEPEND="
+	~virtual/dist-kernel-${PV}"
 
 pkg_pretend() {
 	ewarn "Starting with 5.4.52, Distribution Kernels are switching from Arch"

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.4.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.4.ebuild
@@ -48,6 +48,8 @@ RDEPEND="
 BDEPEND="
 	debug? ( dev-util/dwarves )
 	verify-sig? ( app-crypt/openpgp-keys-kernel )"
+PDEPEND="
+	~virtual/dist-kernel-${PV}"
 
 VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/kernel.org.asc
 

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.4.86.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.4.86.ebuild
@@ -46,6 +46,8 @@ RDEPEND="
 BDEPEND="
 	debug? ( dev-util/dwarves )
 	verify-sig? ( app-crypt/openpgp-keys-kernel )"
+PDEPEND="
+	~virtual/dist-kernel-${PV}"
 
 VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/kernel.org.asc
 

--- a/virtual/dist-kernel/dist-kernel-5.10.4.ebuild
+++ b/virtual/dist-kernel/dist-kernel-5.10.4.ebuild
@@ -1,0 +1,19 @@
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual to depend on any Distribution Kernel"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE=""
+SLOT="${PV}"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+
+RDEPEND="
+	|| (
+		~sys-kernel/gentoo-kernel-${PV}
+		~sys-kernel/gentoo-kernel-bin-${PV}
+		~sys-kernel/vanilla-kernel-${PV}
+	)"

--- a/virtual/dist-kernel/dist-kernel-5.4.86.ebuild
+++ b/virtual/dist-kernel/dist-kernel-5.4.86.ebuild
@@ -1,0 +1,19 @@
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual to depend on any Distribution Kernel"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE=""
+SLOT="${PV}"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+
+RDEPEND="
+	|| (
+		~sys-kernel/gentoo-kernel-${PV}
+		~sys-kernel/gentoo-kernel-bin-${PV}
+		~sys-kernel/vanilla-kernel-${PV}
+	)"

--- a/virtual/dist-kernel/metadata.xml
+++ b/virtual/dist-kernel/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>dist-kernel@gentoo.org</email>
+		<name>Distribution Kernel Project</name>
+	</maintainer>
+</pkgmetadata>


### PR DESCRIPTION
CC @gentoo/dist-kernel 

Note that I haven't tested it fully yet, waiting for the next kernel bump for that.

I'm wondering if I should name the flag/virtual `prebuilt-kernel` or `dist-kernel`.