### PR TITLE
net-libs/libmicrohttpd: fixed deps for stable versions

### DIFF
--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.65-r1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.65-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit multilib-minimal
+
+MY_P="${P/_/}"
+
+DESCRIPTION="Small C library to run an HTTP server as part of another application"
+HOMEPAGE="https://www.gnu.org/software/libmicrohttpd/"
+SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0/12"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="+epoll messages ssl static-libs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="ssl? ( >net-libs/gnutls-2.12.20 )"
+
+# We disable tests below because they're broken,
+# but if enabled, we'll need this.
+DEPEND="${RDEPEND}
+	test?	( net-misc/curl[ssl?] )"
+
+S=${WORKDIR}/${MY_P}
+
+DOCS="AUTHORS NEWS README ChangeLog"
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" \
+	econf \
+		--enable-bauth \
+		--enable-dauth \
+		--disable-examples \
+		--enable-postprocessor \
+		--disable-thread-names \
+		$(use_enable epoll) \
+		$(use_enable test curl) \
+		$(use_enable messages) \
+		$(use_enable ssl https) \
+		$(use_with ssl gnutls) \
+		$(use_enable static-libs static)
+}
+
+# tests are broken in the portage environment.
+src_test() {
+	:
+}
+
+multilib_src_install_all() {
+	default
+
+	use static-libs || find "${ED}" -name '*.la' -delete
+}

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.68-r1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.68-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit multilib-minimal
+
+MY_P="${P/_/}"
+
+DESCRIPTION="Small C library to run an HTTP server as part of another application"
+HOMEPAGE="https://www.gnu.org/software/libmicrohttpd/"
+SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0/12"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="+epoll ssl static-libs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="ssl? ( >net-libs/gnutls-2.12.20 )"
+
+# We disable tests below because they're broken,
+# but if enabled, we'll need this.
+DEPEND="${RDEPEND}
+	test?	( net-misc/curl[ssl?] )"
+
+S=${WORKDIR}/${MY_P}
+
+DOCS="AUTHORS NEWS README ChangeLog"
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" \
+	econf \
+		--enable-bauth \
+		--enable-dauth \
+		--disable-examples \
+		--enable-messages \
+		--enable-postprocessor \
+		--disable-thread-names \
+		$(use_enable epoll) \
+		$(use_enable test curl) \
+		$(use_enable ssl https) \
+		$(use_with ssl gnutls) \
+		$(use_enable static-libs static)
+}
+
+# tests are broken in the portage environment.
+src_test() {
+	:
+}
+
+multilib_src_install_all() {
+	default
+
+	use static-libs || find "${ED}" -name '*.la' -delete
+}

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.70-r1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.70-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit multilib-minimal
+
+MY_P="${P/_/}"
+
+DESCRIPTION="Small C library to run an HTTP server as part of another application"
+HOMEPAGE="https://www.gnu.org/software/libmicrohttpd/"
+SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0/12"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="+epoll ssl static-libs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="ssl? ( >net-libs/gnutls-2.12.20 )"
+
+# We disable tests below because they're broken,
+# but if enabled, we'll need this.
+DEPEND="${RDEPEND}
+	test?	( net-misc/curl[ssl?] )"
+
+S=${WORKDIR}/${MY_P}
+
+DOCS="AUTHORS NEWS README ChangeLog"
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" \
+	econf \
+		--enable-bauth \
+		--enable-dauth \
+		--disable-examples \
+		--enable-messages \
+		--enable-postprocessor \
+		--disable-thread-names \
+		$(use_enable epoll) \
+		$(use_enable test curl) \
+		$(use_enable ssl https) \
+		$(use_with ssl gnutls) \
+		$(use_enable static-libs static)
+}
+
+# tests are broken in the portage environment.
+src_test() {
+	:
+}
+
+multilib_src_install_all() {
+	default
+
+	use static-libs || find "${ED}" -name '*.la' -delete
+}


### PR DESCRIPTION
libmicrohttpd doesn't need libgcrypt if recent enough GnuTLS is used.
Curl is always required for testing.

I believe it could be merged as stable as it just drops dependency unused for years.