### PR TITLE
sys-apps/smartmontools: Fix double "/" in ewarn

### DIFF
--- a/sys-apps/smartmontools/smartmontools-7.1-r1.ebuild
+++ b/sys-apps/smartmontools/smartmontools-7.1-r1.ebuild
@@ -114,8 +114,8 @@ src_install() {
 
 pkg_postinst() {
 	if use daemon || use update-drivedb; then
-		local initial_db_file="${EROOT}/usr/share/${PN}/drivedb.h"
-		local db_path="${EROOT}/var/db/${PN}"
+		local initial_db_file="${EROOT}usr/share/${PN}/drivedb.h"
+		local db_path="${EROOT}var/db/${PN}"
 
 		if [[ ! -f "${db_path}/drivedb.h" ]] ; then
 			# No initial database found

--- a/sys-apps/smartmontools/smartmontools-7.2.ebuild
+++ b/sys-apps/smartmontools/smartmontools-7.2.ebuild
@@ -118,8 +118,8 @@ src_install() {
 
 pkg_postinst() {
 	if use daemon || use update-drivedb; then
-		local initial_db_file="${EROOT}/usr/share/${PN}/drivedb.h"
-		local db_path="${EROOT}/var/db/${PN}"
+		local initial_db_file="${EROOT}usr/share/${PN}/drivedb.h"
+		local db_path="${EROOT}var/db/${PN}"
 
 		if [[ ! -f "${db_path}/drivedb.h" ]] ; then
 			# No initial database found

--- a/sys-apps/smartmontools/smartmontools-9999.ebuild
+++ b/sys-apps/smartmontools/smartmontools-9999.ebuild
@@ -118,8 +118,8 @@ src_install() {
 
 pkg_postinst() {
 	if use daemon || use update-drivedb; then
-		local initial_db_file="${EROOT}/usr/share/${PN}/drivedb.h"
-		local db_path="${EROOT}/var/db/${PN}"
+		local initial_db_file="${EROOT}usr/share/${PN}/drivedb.h"
+		local db_path="${EROOT}var/db/${PN}"
 
 		if [[ ! -f "${db_path}/drivedb.h" ]] ; then
 			# No initial database found


### PR DESCRIPTION
The variable ${EROOT} ends with "/", so building paths as ${EROOT}/
leads to double slash "//". Fix this.