### PR TITLE
x11-libs/libva-intel-media-driver: added X USE flag

### DIFF
--- a/x11-libs/libva-intel-media-driver/files/libva-intel-media-driver-20.2.0_x11_optional.patch
+++ b/x11-libs/libva-intel-media-driver/files/libva-intel-media-driver-20.2.0_x11_optional.patch
@@ -1,0 +1,16 @@
+--- a/media_driver/media_top_cmake.cmake
++++ b/media_driver/media_top_cmake.cmake
+@@ -21,7 +21,12 @@
+ project( media )
+ 
+ find_package(PkgConfig)
++if(NOT DEFINED USE_X11 OR USE_X11)
+ find_package(X11)
++endif(NOT DEFINED USE_X11 OR USE_X11)
++if(USE_X11 AND NOT X11_FOUND)
++    message(FATAL_ERROR "Usage of X11 is required by USE_X11 variable, but X11 package is not found")
++endif(USE_X11 AND NOT X11_FOUND)
+ 
+ bs_set_if_undefined(LIB_NAME iHD_drv_video)
+ 
+

--- a/x11-libs/libva-intel-media-driver/libva-intel-media-driver-20.1.1-r1.ebuild
+++ b/x11-libs/libva-intel-media-driver/libva-intel-media-driver-20.1.1-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils
+
+if [[ ${PV} == *9999 ]] ; then
+	: ${EGIT_REPO_URI:="https://github.com/intel/media-driver"}
+	if [[ ${PV%9999} != "" ]] ; then
+		: ${EGIT_BRANCH:="release/${PV%.9999}"}
+	fi
+	inherit git-r3
+else
+	SRC_URI="https://github.com/intel/media-driver/archive/intel-media-${PV}.tar.gz"
+	S="${WORKDIR}/media-driver-intel-media-${PV}"
+	KEYWORDS="~amd64"
+fi
+
+DESCRIPTION="Intel Media Driver for VAAPI (iHD)"
+HOMEPAGE="https://github.com/intel/media-driver"
+
+LICENSE="MIT BSD"
+SLOT="0"
+IUSE="X"
+
+PATCHES=( "${FILESDIR}"/${PN}-20.2.0_x11_optional.patch )
+
+DEPEND=">=media-libs/gmmlib-${PV}
+	>=x11-libs/libva-2.7.1[X?]
+	>=x11-libs/libpciaccess-0.13.1-r1:=
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+	local mycmakeargs=(
+		-DMEDIA_BUILD_FATAL_WARNINGS=OFF
+		-DMEDIA_RUN_TEST_SUITE=OFF
+		-DUSE_X11=$(usex X)
+	)
+
+	cmake-utils_src_configure
+}

--- a/x11-libs/libva-intel-media-driver/libva-intel-media-driver-20.2.0-r1.ebuild
+++ b/x11-libs/libva-intel-media-driver/libva-intel-media-driver-20.2.0-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake-utils
+
+if [[ ${PV} == *9999 ]] ; then
+	: ${EGIT_REPO_URI:="https://github.com/intel/media-driver"}
+	if [[ ${PV%9999} != "" ]] ; then
+		: ${EGIT_BRANCH:="release/${PV%.9999}"}
+	fi
+	inherit git-r3
+else
+	SRC_URI="https://github.com/intel/media-driver/archive/intel-media-${PV}.tar.gz"
+	S="${WORKDIR}/media-driver-intel-media-${PV}"
+	KEYWORDS="~amd64"
+fi
+
+DESCRIPTION="Intel Media Driver for VAAPI (iHD)"
+HOMEPAGE="https://github.com/intel/media-driver"
+
+LICENSE="MIT BSD"
+SLOT="0"
+IUSE="X"
+
+PATCHES=( "${FILESDIR}"/${PN}-20.2.0_x11_optional.patch )
+
+DEPEND=">=media-libs/gmmlib-20.2.2
+	>=x11-libs/libva-2.8.0[X?]
+	>=x11-libs/libpciaccess-0.13.1-r1:=
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+	local mycmakeargs=(
+		-DMEDIA_BUILD_FATAL_WARNINGS=OFF
+		-DMEDIA_RUN_TEST_SUITE=OFF
+		-DBUILD_TYPE=release
+		-DPLATFORM=linux
+		-DUSE_X11=$(usex X)
+	)
+
+	cmake-utils_src_configure
+}


### PR DESCRIPTION
This patch fixes ambiguous usage of X11 in the package.
Before this patch the package tries to autodetect presence of X11 in the system and tries to use it if found. However, presence of X11 headers doesn't grantee that required packages (libva) were installed with X11 support.
Now result of build depends on USE flags instead of presence/absence of X11 headers on the build system.

Closes: https://bugs.gentoo.org/743625
