### PR TITLE
app-emulation/containerd-1.3.9: fix USE=hardened

### DIFF
--- a/app-emulation/containerd/containerd-1.3.9.ebuild
+++ b/app-emulation/containerd/containerd-1.3.9.ebuild
@@ -62,7 +62,7 @@ src_compile() {
 	myemakeargs=(
 		BUILDTAGS="${options[*]}"
 		DESTDIR="${ED}"
-		LDFLAGS=$(usex hardened '-extldflags -fno-PIC' '')
+		LDFLAGS="$(usex hardened '-extldflags -fno-PIC' '')"
 	)
 
 	export GOPATH="${WORKDIR}/${P}" # ${PWD}/vendor


### PR DESCRIPTION
This probably broke with the recent bash update.

Signed-off-by: Hector Martin <marcan@marcan.st>

Note: this is a build fix, so no revbump is needed.