### PR TITLE
sys-auth/libfprint: remove dep on dev-util/gtk-doc

### DIFF
--- a/sys-auth/libfprint/libfprint-1.90.6.ebuild
+++ b/sys-auth/libfprint/libfprint-1.90.6.ebuild
@@ -26,8 +26,7 @@ RDEPEND="dev-libs/glib:2
 
 DEPEND="${RDEPEND}"
 
-BDEPEND="dev-util/gtk-doc
-	virtual/pkgconfig
+BDEPEND="virtual/pkgconfig
 	introspection? ( dev-libs/gobject-introspection )"
 
 PATCHES=( ${FILESDIR}/${PN}-0.8.2-fix-implicit-declaration.patch )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/755167
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Martin Gysel <me@bearsh.org>