### PR TITLE
www-client/qutebrowser: Fix build failure with python3.9

### DIFF
--- a/www-client/qutebrowser/qutebrowser-9999.ebuild
+++ b/www-client/qutebrowser/qutebrowser-9999.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	dev-python/attrs[${PYTHON_USEDEP}]
 	dev-python/colorama[${PYTHON_USEDEP}]
 	dev-python/cssutils[${PYTHON_USEDEP}]
-	dev-python/importlib_resources[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep 'dev-python/importlib_resources[${PYTHON_USEDEP}]' python3_{7,8})
 	dev-python/jinja[${PYTHON_USEDEP}]
 	dev-python/markupsafe[${PYTHON_USEDEP}]
 	dev-python/pygments[${PYTHON_USEDEP}]


### PR DESCRIPTION
In python3.9, `dev-python/importlib_resources` is not needed because built-in module is used instead.

https://github.com/qutebrowser/qutebrowser/blob/master/README.asciidoc
> Requirements
> importlib_resources (on Python 3.8 or older)