### PR TITLE
media-plugins/vdr-xineliboutput: fix QA notice

### DIFF
--- a/media-plugins/vdr-xineliboutput/files/vdr-frontend
+++ b/media-plugins/vdr-xineliboutput/files/vdr-frontend
@@ -1,10 +1,10 @@
 #!/sbin/openrc-run
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 description="Start xineliboutput sxfe/sxfb remote frontend"
 
-source /etc/conf.d/vdr.xineliboutput
+. /etc/conf.d/vdr.xineliboutput
 
 command="/usr/bin/vdr-sxfe"
 command_args="${REMOTE_FRONTEND}"

--- a/media-plugins/vdr-xineliboutput/metadata.xml
+++ b/media-plugins/vdr-xineliboutput/metadata.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person">
+		<email>hd_brummy@gentoo.org</email>
+		<name>Joerg Bornkessel</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<maintainer type="project">
 		<email>vdr@gentoo.org</email>
 		<name>Gentoo VDR Project</name>


### PR DESCRIPTION
fix "QA Notice: shell script appears to use non-POSIX feature(s):"
possible bashism in /etc/init.d/vdr-frontend
- line 7 (should be '.', not 'source')

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>