### PR TITLE
net-libs/libmicrohttpd: restored accidentally dropped arch

### DIFF
--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.72.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.72.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/12"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="+epoll ssl static-libs test thread-names"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
~riscv was dropped accidentally with bump to v0.9.72.
This patch restores it back.
