### PR TITLE
dev-cpp/benchmark: Add patch to fix build failure on gcc-11

### DIFF
--- a/dev-cpp/benchmark/benchmark-1.5.2.ebuild
+++ b/dev-cpp/benchmark/benchmark-1.5.2.ebuild
@@ -15,6 +15,10 @@ KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
+PATCHES=(
+	"${FILESDIR}/${P}-Add-missing-limits-inclusion.patch"
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DBENCHMARK_ENABLE_TESTING=$(usex test)

--- a/dev-cpp/benchmark/files/benchmark-1.5.2-Add-missing-limits-inclusion.patch
+++ b/dev-cpp/benchmark/files/benchmark-1.5.2-Add-missing-limits-inclusion.patch
@@ -1,0 +1,30 @@
+From 3d1c2677686718d906f28c1d4da001c42666e6d2 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyfox@inbox.ru>
+Date: Thu, 15 Oct 2020 09:12:40 +0100
+Subject: [PATCH] src/benchmark_register.h: add missing <limits> inclusion
+ (#1060)
+
+Noticed missing header when was building llvm with gcc-11:
+
+```
+llvm-project/llvm/utils/benchmark/src/benchmark_register.h:17:30:
+  error: 'numeric_limits' is not a member of 'std'
+   17 |   static const T kmax = std::numeric_limits<T>::max();
+      |                              ^~~~~~~~~~~~~~
+```
+---
+ src/benchmark_register.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/benchmark_register.h b/src/benchmark_register.h
+index 61377d74..204bf1d9 100644
+--- a/src/benchmark_register.h
++++ b/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/764647
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>