### PR TITLE
media-libs/svt-av1: depend amd64? ( dev-lang/yasm )

### DIFF
--- a/media-libs/svt-av1/svt-av1-0.8.6.ebuild
+++ b/media-libs/svt-av1/svt-av1-0.8.6.ebuild
@@ -21,6 +21,8 @@ fi
 LICENSE="BSD-2 Apache-2.0 BSD ISC LGPL-2.1+ MIT"
 SLOT="0"
 
+DEPEND="amd64? ( dev-lang/yasm )"
+
 PATCHES=( "${FILESDIR}"/${P}-fix-c-only-build.patch )
 
 src_configure() {

--- a/media-libs/svt-av1/svt-av1-9999.ebuild
+++ b/media-libs/svt-av1/svt-av1-9999.ebuild
@@ -21,6 +21,8 @@ fi
 LICENSE="BSD-2 Apache-2.0 BSD ISC LGPL-2.1+ MIT"
 SLOT="0"
 
+DEPEND="amd64? ( dev-lang/yasm )"
+
 src_configure() {
 	append-ldflags -Wl,-z,noexecstack
 	local mycmakeargs=(


### PR DESCRIPTION
https://github.com/AOMediaCodec/SVT-AV1/blob/v0.8.6/CMakeLists.txt#L36

Closes: https://bugs.gentoo.org/764794
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>