### PR TITLE
media-libs/libavif: add svt-av1 use flag to live ebuild

### DIFF
--- a/media-libs/libavif/libavif-9999.ebuild
+++ b/media-libs/libavif/libavif-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ EGIT_REPO_URI="https://github.com/AOMediaCodec/libavif.git"
 LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS=""
-IUSE="+aom dav1d examples extras gdk-pixbuf rav1e"
+IUSE="+aom dav1d examples extras gdk-pixbuf rav1e svt-av1"
 
 DEPEND="media-libs/libpng
 	sys-libs/zlib
@@ -20,7 +20,8 @@ DEPEND="media-libs/libpng
 	aom? ( >=media-libs/libaom-2.0.0 )
 	dav1d? ( media-libs/dav1d )
 	gdk-pixbuf? ( x11-libs/gdk-pixbuf:2 )
-	rav1e? ( media-video/rav1e[capi] )"
+	rav1e? ( media-video/rav1e[capi] )
+	svt-av1? ( >=media-libs/svt-av1-0.8.6 )"
 RDEPEND="${DEPEND}"
 BDEPEND="virtual/pkgconfig"
 
@@ -33,6 +34,7 @@ src_configure() {
 		-DAVIF_CODEC_DAV1D=$(usex dav1d ON OFF)
 		-DAVIF_CODEC_LIBGAV1=OFF
 		-DAVIF_CODEC_RAV1E=$(usex rav1e ON OFF)
+		-DAVIF_CODEC_SVT=$(usex svt-av1 ON OFF)
 
 		# Use system libraries.
 		-DAVIF_LOCAL_ZLIBPNG=OFF
@@ -55,10 +57,10 @@ pkg_preinst() {
 }
 
 pkg_postinst() {
-	if ! use aom && ! use rav1e ; then
-		ewarn "aom and rav1e flags are not set,"
+	if ! use aom && ! use rav1e && ! use svt-av1 ; then
+		ewarn "No AV1 encoder is set,"
 		ewarn "libavif will work in read-only mode."
-		ewarn "Enable aom or rav1e flag if you want to save .AVIF files."
+		ewarn "Enable aom, rav1e or svt-av1 flag if you want to save .AVIF files."
 	fi
 
 	if use gdk-pixbuf ; then

--- a/media-libs/libavif/metadata.xml
+++ b/media-libs/libavif/metadata.xml
@@ -15,5 +15,6 @@
     <flag name="extras">Build extra apps (avifenc, avifdec) and test files</flag>
     <flag name="gdk-pixbuf">Build a gdk-pixbuf loader</flag>
     <flag name="rav1e">Enable support for the rav1e codec encoding</flag>
+    <flag name="svt-av1">Enable support for the SVT-AV1 encoder</flag>
   </use>
 </pkgmetadata>


### PR DESCRIPTION
media-libs/svt-av1 was added to ::gentoo recently. libavif can optionally use this AV1 encoder.