### PR TITLE
www-apps/davical: rdepend on <dev-lang/php-8

### DIFF
--- a/www-apps/davical/davical-1.1.9.3.ebuild
+++ b/www-apps/davical/davical-1.1.9.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,8 +15,9 @@ IUSE="ldap"
 
 BDEPEND="sys-devel/gettext"
 
+# >=dev-lang/php-8:curly braces string offset access was removed (Bug 764908)
 RDEPEND="app-admin/pwgen
-	dev-lang/php:*[calendar,curl,iconv,imap,ldap?,nls,pdo,postgres,xml]
+	<dev-lang/php-8:*[calendar,curl,iconv,imap,ldap?,nls,pdo,postgres,xml]
 	dev-perl/DBD-Pg
 	dev-perl/DBI
 	dev-perl/YAML


### PR DESCRIPTION
>=dev-lang/php-8 is incompatible with davical

Closes: https://bugs.gentoo.org/764908

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Till Schäfer <till2.schaefer@uni-dortmund.de>