### PR TITLE
autotools.eclass: Introduce AT_NOEAUTOHEADER variable

### DIFF
--- a/eclass/autotools.eclass
+++ b/eclass/autotools.eclass
@@ -54,6 +54,8 @@ inherit libtool
 # CONSTANT!
 # The latest major unstable and stable version/slot of automake available
 # on each arch.
+# Only add unstable version if it is in a different slot than latest stable
+# version.
 # List latest unstable version first to boost testing adoption rate because
 # most package manager dependency resolver will pick the first suitable
 # version.
@@ -65,7 +67,7 @@ inherit libtool
 # Do NOT change this variable in your ebuilds!
 # If you want to force a newer minor version, you can specify the correct
 # WANT value by using a colon:  <PV>:<WANT_AUTOMAKE>
-_LATEST_AUTOMAKE=( 1.16.1:1.16 1.15.1:1.15 )
+_LATEST_AUTOMAKE=( 1.16.2-r1:1.16 )
 
 _automake_atom="sys-devel/automake"
 _autoconf_atom="sys-devel/autoconf"

--- a/eclass/autotools.eclass
+++ b/eclass/autotools.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: autotools.eclass
@@ -136,6 +136,12 @@ unset _automake_atom _autoconf_atom
 # Additional options to pass to automake during
 # eautoreconf call.
 
+# @ECLASS-VARIABLE: AT_NOEAUTOHEADER
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# Don't run eautoheader command if set to 'yes'; only used to work around
+# packages that don't want their headers being modified.
+
 # @ECLASS-VARIABLE: AT_NOEAUTOMAKE
 # @DEFAULT_UNSET
 # @DESCRIPTION:
@@ -236,7 +242,7 @@ eautoreconf() {
 	else
 		eautoconf --force
 	fi
-	eautoheader
+	[[ ${AT_NOEAUTOHEADER} != "yes" ]] && eautoheader
 	[[ ${AT_NOEAUTOMAKE} != "yes" ]] && FROM_EAUTORECONF="yes" eautomake ${AM_OPTS}
 
 	if [[ ${AT_NOELIBTOOLIZE} != "yes" ]] ; then

--- a/media-libs/freetype/freetype-2.10.4.ebuild
+++ b/media-libs/freetype/freetype-2.10.4.ebuild
@@ -90,8 +90,7 @@ src_prepare() {
 		sed -e "s;@VERSION@;$freetype_major$freetype_minor$freetype_patch;" \
 			< configure.raw > configure.ac || die
 		# eautoheader produces broken ftconfig.in
-		eautoheader() { return 0 ; }
-		AT_M4DIR="." eautoreconf
+		AT_NOEAUTOHEADER="yes" AT_M4DIR="." eautoreconf
 		unset freetype_major freetype_minor freetype_patch
 		popd &>/dev/null || die
 	fi

--- a/media-libs/freetype/freetype-9999.ebuild
+++ b/media-libs/freetype/freetype-9999.ebuild
@@ -100,8 +100,7 @@ src_prepare() {
 		sed -e "s;@VERSION@;$freetype_major$freetype_minor$freetype_patch;" \
 			< configure.raw > configure.ac || die
 		# eautoheader produces broken ftconfig.in
-		eautoheader() { return 0 ; }
-		AT_M4DIR="." eautoreconf
+		AT_NOEAUTOHEADER="yes" AT_M4DIR="." eautoreconf
 		unset freetype_major freetype_minor freetype_patch
 		popd &>/dev/null || die
 	fi

--- a/media-libs/libsdl2/libsdl2-2.0.14-r1.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.0.14-r1.ebuild
@@ -98,12 +98,12 @@ src_prepare() {
 	rm -r src/video/khronos || die
 	ln -s "${ESYSROOT}/usr/include" src/video/khronos || die
 
-	# SDL seems to customize SDL_config.h.in to remove macros like PACKAGE_NAME.
-	# Stub out eautoheader to prevent those macros from being reintroduced.
+	# SDL seems to customize SDL_config.h.in to remove macros like
+	# PACKAGE_NAME. Add AT_NOEAUTOHEADER="yes" to prevent those macros from
+	# being reintroduced.
 	# https://bugs.gentoo.org/764959
-	eautoheader() { :; }
-
-	AT_M4DIR="/usr/share/aclocal acinclude" eautoreconf
+	AT_NOEAUTOHEADER="yes" AT_M4DIR="/usr/share/aclocal acinclude" \
+		eautoreconf
 
 	# libsdl2-2.0.14 build regression. Please check if still needed
 	multilib_copy_sources


### PR DESCRIPTION
Sometimes packages get their headers being broken by autoheader (see
media-libs/freetype for example) or get unwanted defines added (see
media-libs/libsdl2). In that case we want to run eautoreconf without
call to eautoheader.

Bug: https://bugs.gentoo.org/764959