### PR TITLE
sys-devel/lld: Add "shared" USE flag

### DIFF
--- a/sys-devel/lld/lld-11.0.0.ebuild
+++ b/sys-devel/lld/lld-11.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ llvm.org_set_globals
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86"
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -36,8 +36,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 	)
 	use test && mycmakeargs+=(
@@ -58,6 +57,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/lld-11.0.1.ebuild
+++ b/sys-devel/lld/lld-11.0.1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -38,8 +38,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 	)
 	use test && mycmakeargs+=(
@@ -60,6 +59,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/lld-11.1.0.ebuild
+++ b/sys-devel/lld/lld-11.1.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -38,8 +38,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 	)
 	use test && mycmakeargs+=(
@@ -60,6 +59,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/lld-11.1.0_rc1.ebuild
+++ b/sys-devel/lld/lld-11.1.0_rc1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -38,8 +38,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 	)
 	use test && mycmakeargs+=(
@@ -60,6 +59,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/lld-11.1.0_rc2.ebuild
+++ b/sys-devel/lld/lld-11.1.0_rc2.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -38,8 +38,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 	)
 	use test && mycmakeargs+=(
@@ -60,6 +59,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/lld-11.1.0_rc3.ebuild
+++ b/sys-devel/lld/lld-11.1.0_rc3.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -38,8 +38,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 	)
 	use test && mycmakeargs+=(
@@ -60,6 +59,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/lld-12.0.0.9999.ebuild
+++ b/sys-devel/lld/lld-12.0.0.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -49,8 +49,7 @@ src_unpack() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 		-DLLVM_MAIN_SRC_DIR="${WORKDIR}/llvm"
 	)
@@ -71,6 +70,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/lld-12.0.0_rc1.ebuild
+++ b/sys-devel/lld/lld-12.0.0_rc1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -49,8 +49,7 @@ src_unpack() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 		-DLLVM_MAIN_SRC_DIR="${WORKDIR}/llvm"
 	)
@@ -71,6 +70,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/lld-13.0.0.9999.ebuild
+++ b/sys-devel/lld/lld-13.0.0.9999.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
-IUSE="test"
+IUSE="shared test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="~sys-devel/llvm-${PV}"
@@ -49,8 +49,7 @@ src_unpack() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBUILD_SHARED_LIBS=OFF
-
+		-DBUILD_SHARED_LIBS=$(usex shared)
 		-DLLVM_INCLUDE_TESTS=$(usex test)
 		-DLLVM_MAIN_SRC_DIR="${WORKDIR}/llvm"
 	)
@@ -71,6 +70,7 @@ src_test() {
 
 src_install() {
 	cmake_src_install
-	# LLD has no shared libraries, so strip it all for the time being
-	rm -r "${ED}"/usr/{include,lib*} || die
+	if ! use shared; then
+		rm -r "${ED}"/usr/{include,lib*} || die
+	fi
 }

--- a/sys-devel/lld/metadata.xml
+++ b/sys-devel/lld/metadata.xml
@@ -4,4 +4,7 @@
 	<maintainer type="project">
 		<email>llvm@gentoo.org</email>
 	</maintainer>
+	<use>
+		<flag name="shared">Build shared library and install include files</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
`lld`'s shared libraries and include files are required by `dev-lang/zig`.

The patched `lld` ebuilds are equivalent to the original `lld` ebuilds if the `shared` USE flag is disabled. The flag is disabled by default, so nothing changes for current users of the `lld` package who don't intend to install `dev-lang/zig`.

Please merge. Thanks.

See also: https://bugs.gentoo.org/719736
See also: https://github.com/gentoo/gentoo/pull/19007