### PR TITLE
libva-intel-media-driver: fixed build and typo in the patch

### DIFF
--- a/x11-libs/libva-intel-media-driver/files/libva-intel-media-driver-20.4.5_custom_cflags_v2.patch
+++ b/x11-libs/libva-intel-media-driver/files/libva-intel-media-driver-20.4.5_custom_cflags_v2.patch
@@ -1,0 +1,136 @@
+    Prevent overriding of user-define CFLAGS, including -march flag.
+
+    The flag -msse4.1 is required otherwise compile will not be able to inline sse4.1 code.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,6 +52,8 @@ option (BUILD_CMRTLIB "Build and Install cmrtlib together with media driver" ON)
+ 
+ option (ENABLE_PRODUCTION_KMD "Enable Production KMD header files" OFF)
+ 
++option (OVERRIDE_COMPILER_FLAGS "Override user compiler FLAGS and use lib defaults" ON)
++
+ include(GNUInstallDirs)
+ 
+ if (BUILD_CMRTLIB)
+
+--- a/cmrtlib/linux/CMakeLists.txt
++++ b/cmrtlib/linux/CMakeLists.txt
+@@ -33,15 +33,19 @@ endif()
+ 
+ # Set up compile options that will be used for the Linux build
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CPP_STANDARD_OPTION} -fPIC -fpermissive -fstack-protector-all -Werror")
++if (OVERRIDE_COMPILER_FLAGS)
+ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
+ endif()
++endif()
+ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-strict-aliasing -D_FORTIFY_SOURCE=2")
+ set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -D__DEBUG -O0")
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CPP_STANDARD_OPTION} -fPIC -fpermissive -fstack-protector-all -Werror")
++if (OVERRIDE_COMPILER_FLAGS)
+ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse4.1")
+ endif()
++endif()
+ set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fno-strict-aliasing -D_FORTIFY_SOURCE=2")
+ set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG -D__DEBUG -O0")
+ 
+
+--- a/media_driver/cmake/linux/media_compile_flags_linux.cmake
++++ b/media_driver/cmake/linux/media_compile_flags_linux.cmake
+@@ -36,7 +36,10 @@ set(MEDIA_COMPILER_FLAGS_COMMON
+     -Werror=format-security
+     -Werror=non-virtual-dtor
+     -Werror=return-type
++)
+ 
++if (OVERRIDE_COMPILER_FLAGS)
++    list (APPEND MEDIA_COMPILER_FLAGS_COMMON
+     # General optimization options
+     -march=${UFO_MARCH}
+     -mpopcnt
+@@ -44,23 +47,33 @@ set(MEDIA_COMPILER_FLAGS_COMMON
+     -msse2
+     -msse3
+     -mssse3
+-    -msse4.1
+     -msse4.2
+     -msse4
++)
++endif(OVERRIDE_COMPILER_FLAGS)
++
++list (APPEND MEDIA_COMPILER_FLAGS_COMMON
++    -msse4.1	# SSE4.1 support is required to build the library
+     -mfpmath=sse
+     -finline-functions
+     -funswitch-loops
+     -fno-short-enums
+     -Wa,--noexecstack
+     -fno-strict-aliasing
++)
+ 
++if (OVERRIDE_COMPILER_FLAGS)
++    list (APPEND MEDIA_COMPILER_FLAGS_COMMON
+     # Common defines
+     -DUSE_MMX
+     -DUSE_SSE
+     -DUSE_SSE2
+     -DUSE_SSE3
+     -DUSE_SSSE3
++)
++endif(OVERRIDE_COMPILER_FLAGS)
+ 
++list (APPEND MEDIA_COMPILER_FLAGS_COMMON
+     # Other common flags
+     -fmessage-length=0
+     -fvisibility=hidden
+@@ -68,16 +81,26 @@ set(MEDIA_COMPILER_FLAGS_COMMON
+     -fdata-sections
+     -ffunction-sections
+     -Wl,--gc-sections
++)
+ 
++if (OVERRIDE_COMPILER_FLAGS)
++    list (APPEND MEDIA_COMPILER_FLAGS_COMMON
+     # -m32 or -m64
+     -m${ARCH}
++)
++endif(OVERRIDE_COMPILER_FLAGS)
+ 
++list (APPEND MEDIA_COMPILER_FLAGS_COMMON
+     # Global defines
+     -DLINUX=1
+     -DLINUX
+     -DNO_RTTI
+     -DNO_EXCEPTION_HANDLING
+     -DINTEL_NOT_PUBLIC
++)
++
++if (OVERRIDE_COMPILER_FLAGS)
++    list (APPEND MEDIA_COMPILER_FLAGS_COMMON
+     -g
+ )
+ 
+@@ -90,6 +113,7 @@ if(${UFO_MARCH} STREQUAL "slm")
+         -mtune=atom
+     )
+ endif()
++endif(OVERRIDE_COMPILER_FLAGS)
+ 
+ if(${ARCH} STREQUAL "64")
+     set(MEDIA_COMPILER_FLAGS_COMMON
+@@ -206,9 +230,11 @@ include(${MEDIA_EXT_CMAKE}/ext/linux/media_compile_flags_linux_ext.cmake OPTIONA
+ if(${PLATFORM} STREQUAL "linux")
+     #set predefined compiler flags set
+     add_compile_options("${MEDIA_COMPILER_FLAGS_COMMON}")
++if (OVERRIDE_COMPILER_FLAGS)
+     add_compile_options("$<$<CONFIG:Debug>:${MEDIA_COMPILER_FLAGS_DEBUG}>")
+     add_compile_options("$<$<CONFIG:Release>:${MEDIA_COMPILER_FLAGS_RELEASE}>")
+     add_compile_options("$<$<CONFIG:ReleaseInternal>:${MEDIA_COMPILER_FLAGS_RELEASEINTERNAL}>")
++endif(OVERRIDE_COMPILER_FLAGS)
+ 
+     foreach (flag ${MEDIA_COMPILER_CXX_FLAGS_COMMON})
+         SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+
+

--- a/x11-libs/libva-intel-media-driver/files/libva-intel-media-driver-20.4.5_tesing_in_src_test.patch
+++ b/x11-libs/libva-intel-media-driver/files/libva-intel-media-driver-20.4.5_tesing_in_src_test.patch
@@ -1,6 +1,6 @@
 Run tests in src_test() instead of src_compile() and src_install()
 
----- a/CMakeLists.txt
+--- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -37,6 +37,8 @@ if("${os_name}" STREQUAL "clear-linux-os")
      set(CMAKE_INSTALL_SYSCONFDIR "usr/share/defaults/etc")

--- a/x11-libs/libva-intel-media-driver/libva-intel-media-driver-20.4.5.ebuild
+++ b/x11-libs/libva-intel-media-driver/libva-intel-media-driver-20.4.5.ebuild
@@ -34,7 +34,7 @@ RDEPEND="${DEPEND}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-20.2.0_x11_optional.patch
-	"${FILESDIR}"/${PN}-20.4.5_custom_cflags.patch
+	"${FILESDIR}"/${PN}-20.4.5_custom_cflags_v2.patch
 	"${FILESDIR}"/${PN}-20.4.5_tesing_in_src_test.patch
 )
 

--- a/x11-libs/libva-intel-media-driver/libva-intel-media-driver-9999.ebuild
+++ b/x11-libs/libva-intel-media-driver/libva-intel-media-driver-9999.ebuild
@@ -34,7 +34,7 @@ RDEPEND="${DEPEND}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-20.2.0_x11_optional.patch
-	"${FILESDIR}"/${PN}-20.4.5_custom_cflags.patch
+	"${FILESDIR}"/${PN}-20.4.5_custom_cflags_v2.patch
 	"${FILESDIR}"/${PN}-20.4.5_tesing_in_src_test.patch
 )
 


### PR DESCRIPTION
Fixed similar to https://github.com/gentoo/gentoo/pull/19041