### PR TITLE
dev-lang/sassc: Fix missing sassc version number display

### DIFF
--- a/dev-lang/sassc/sassc-3.6.1.ebuild
+++ b/dev-lang/sassc/sassc-3.6.1.ebuild
@@ -21,5 +21,6 @@ DOCS=( Readme.md )
 
 src_prepare() {
 	default
+	[[ -f VERSION ]] || echo "${PV}" > VERSION
 	eautoreconf
 }


### PR DESCRIPTION
When running `sassc --version` the sassc version was displayed as 'na'.
Following the upstream recommendation at
https://github.com/sass/sassc/blob/master/docs/building/unix-instructions.md#manually-building-from-tar-sources-via-github
do the same thing as dev-libs/libsass has been also doing and inject
the version file before building the package.

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: David Mudrak <gentoo@mudrd8mz.net>