### PR TITLE
sci-libs/amd: fix bashism in doc building

### DIFF
--- a/sci-libs/amd/amd-2.4.6-r1.ebuild
+++ b/sci-libs/amd/amd-2.4.6-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools fortran-2
+
+DESCRIPTION="Library to order a sparse matrix prior to Cholesky factorization"
+HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
+SRC_URI="http://202.36.178.9/sage/${P}.tar.bz2"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc fortran"
+
+BDEPEND="virtual/pkgconfig
+	doc? ( virtual/latex-base )"
+DEPEND=">=sci-libs/suitesparseconfig-5.4.0"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${PN}-2.4.6-dash_doc.patch )
+
+src_prepare(){
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		$(use_enable fortran) \
+		$(use_with doc)
+}
+
+src_install() {
+	default
+
+	# no static archives
+	find "${D}" -name '*.la' -delete || die
+}

--- a/sci-libs/amd/files/amd-2.4.6-dash_doc.patch
+++ b/sci-libs/amd/files/amd-2.4.6-dash_doc.patch
@@ -1,0 +1,16 @@
+diff --git a/Doc/Makefile.am b/Doc/Makefile.am
+index 44361ff..039b02f 100644
+--- a/Doc/Makefile.am
++++ b/Doc/Makefile.am
+@@ -1,9 +1,8 @@
+ 
+ AMD_UserGuide.pdf:
+-	echo '\begin{verbatim}' > amd_h.tex
++	printf '\\begin{verbatim}\n' > amd_h.tex
+ 	expand -8 $(top_srcdir)/Include/amd.h >> amd_h.tex
+-	echo '\end{verbatim}' >> amd_h.tex
+-	-ln -s $(srcdir)/*.{tex,bib} .
++	printf '\\end{verbatim}\n' >> amd_h.tex
+ 	$(PDFLATEX) AMD_UserGuide
+ 	$(BIBTEX)  AMD_UserGuide
+ 	$(PDFLATEX) AMD_UserGuide

--- a/sci-libs/camd/camd-2.4.6-r1.ebuild
+++ b/sci-libs/camd/camd-2.4.6-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Library to order a sparse matrix prior to Cholesky factorization"
+HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
+SRC_URI="http://202.36.178.9/sage/${P}.tar.bz2"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc"
+
+BDEPEND="virtual/pkgconfig
+	doc? ( virtual/latex-base )"
+DEPEND=">=sci-libs/suitesparseconfig-5.4.0"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${PN}-2.4.6-dash_doc.patch )
+
+src_prepare(){
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		$(use_with doc)
+}
+
+src_install() {
+	default
+
+	# no static archives
+	find "${D}" -name '*.la' -delete || die
+}

--- a/sci-libs/camd/files/camd-2.4.6-dash_doc.patch
+++ b/sci-libs/camd/files/camd-2.4.6-dash_doc.patch
@@ -1,0 +1,16 @@
+diff --git a/Doc/Makefile.am b/Doc/Makefile.am
+index 80f5653..71c130a 100644
+--- a/Doc/Makefile.am
++++ b/Doc/Makefile.am
+@@ -1,9 +1,8 @@
+ 
+ CAMD_UserGuide.pdf:
+-	echo '\begin{verbatim}' > camd_h.tex
++	printf '\\begin{verbatim}\n' > camd_h.tex
+ 	expand -8 $(top_srcdir)/Include/camd.h >> camd_h.tex
+-	echo '\end{verbatim}' >> camd_h.tex
+-	-ln -s $(srcdir)/*.{tex,bib} .
++	printf '\\end{verbatim}\n' >> camd_h.tex
+ 	$(PDFLATEX) CAMD_UserGuide
+ 	$(BIBTEX)  CAMD_UserGuide
+ 	$(PDFLATEX) CAMD_UserGuide

--- a/sci-libs/klu/files/klu-1.3.9-dash_doc.patch
+++ b/sci-libs/klu/files/klu-1.3.9-dash_doc.patch
@@ -1,0 +1,27 @@
+diff --git a/Doc/Makefile.am b/Doc/Makefile.am
+index 7d1116a..fd46b1d 100644
+--- a/Doc/Makefile.am
++++ b/Doc/Makefile.am
+@@ -1,15 +1,14 @@
+ 
+ KLU_UserGuide.pdf:
+-	echo '\begin{verbatim}' > klu_h.tex
++	printf '\\begin{verbatim}\n' > klu_h.tex
+ 	expand -8 $(top_srcdir)/Include/klu.h >> klu_h.tex
+-	echo '\end{verbatim}' >> klu_h.tex
+-	echo '\begin{verbatim}' > btf_h.tex
+-	echo 'See your btf.h local install' >> btf_h.tex
+-	echo '\end{verbatim}' >> btf_h.tex
+-	echo '\begin{verbatim}' > klu_simple_c.tex
++	printf '\\end{verbatim}\n' >> klu_h.tex
++	printf '\\begin{verbatim}\n' > btf_h.tex
++	printf 'See your btf.h local install\n' >> btf_h.tex
++	printf '\\end{verbatim}\n' >> btf_h.tex
++	printf '\\begin{verbatim}\n' > klu_simple_c.tex
+ 	expand -8 $(top_srcdir)/Demo/klu_simple.c >> klu_simple_c.tex
+-	echo '\end{verbatim}' >> klu_simple_c.tex
+-	-ln -s $(srcdir)/*.{tex,bib} .
++	printf '\\end{verbatim}\n' >> klu_simple_c.tex
+ 	$(PDFLATEX) KLU_UserGuide
+ 	$(BIBTEX)  KLU_UserGuide
+ 	$(PDFLATEX) KLU_UserGuide

--- a/sci-libs/klu/klu-1.3.9-r1.ebuild
+++ b/sci-libs/klu/klu-1.3.9-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Sparse LU factorization for circuit simulation"
+HOMEPAGE="http://faculty.cse.tamu.edu/davis/suitesparse.html"
+SRC_URI="http://202.36.178.9/sage/${P}.tar.bz2"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc static-libs"
+
+BDEPEND="virtual/pkgconfig
+	doc? ( virtual/latex-base )"
+DEPEND="
+	>=sci-libs/amd-2.4
+	>=sci-libs/btf-1.2
+	>=sci-libs/colamd-2.9"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${PN}-1.3.9-dash_doc.patch )
+
+src_prepare(){
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable static-libs static) \
+		$(use_with doc)
+}
+
+src_install() {
+	default
+
+	# remove .la file
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: François René Pierre Bissey <frp.bissey@gmail.com>

sci-libs/camd: fix bashism in doc building

Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: François René Pierre Bissey <frp.bissey@gmail.com>

sci-libs/klu: fix bashism in doc building, remove .la file.

Package-Manager: Portage-3.0.9, Repoman-3.0.2
Signed-off-by: François René Pierre Bissey <frp.bissey@gmail.com>
bug: https://bugs.gentoo.org/show_bug.cgi?id=760408