### PR TITLE
media-libs/flac: fix zero prefix md5sum check

### DIFF
--- a/media-libs/flac/files/flac-1.3.3-fix-zero-first-byte-md5sum-check.patch
+++ b/media-libs/flac/files/flac-1.3.3-fix-zero-first-byte-md5sum-check.patch
@@ -1,0 +1,13 @@
+diff --git a/src/flac/decode.c b/src/flac/decode.c
+index c26d3f60..bd3f6524 100644
+--- a/src/flac/decode.c
++++ b/src/flac/decode.c
+@@ -1307,7 +1307,7 @@ void metadata_callback(const FLAC__StreamDecoder *decoder, const FLAC__StreamMet
+ 	if(metadata->type == FLAC__METADATA_TYPE_STREAMINFO) {
+ 		FLAC__uint64 skip, until;
+ 		decoder_session->got_stream_info = true;
+-		decoder_session->has_md5sum = memcmp(metadata->data.stream_info.md5sum, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16);
++		decoder_session->has_md5sum = memcmp(metadata->data.stream_info.md5sum, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) != 0;
+ 		decoder_session->bps = metadata->data.stream_info.bits_per_sample;
+ 		decoder_session->channels = metadata->data.stream_info.channels;
+ 		decoder_session->sample_rate = metadata->data.stream_info.sample_rate;

--- a/media-libs/flac/flac-1.3.3-r1.ebuild
+++ b/media-libs/flac/flac-1.3.3-r1.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal
+
+DESCRIPTION="free lossless audio encoder and decoder"
+HOMEPAGE="https://xiph.org/flac/"
+SRC_URI="https://downloads.xiph.org/releases/${PN}/${P}.tar.xz"
+
+LICENSE="BSD FDL-1.2 GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="+cxx debug ogg cpu_flags_ppc_altivec cpu_flags_ppc_vsx cpu_flags_x86_sse static-libs"
+
+RDEPEND="ogg? ( >=media-libs/libogg-1.3.0[${MULTILIB_USEDEP}] )"
+DEPEND="${RDEPEND}
+	abi_x86_32? ( dev-lang/nasm )
+"
+BDEPEND="
+	app-arch/xz-utils
+	virtual/pkgconfig
+	!elibc_uclibc? ( sys-devel/gettext )
+"
+
+PATCHES=( "${FILESDIR}/flac-1.3.3-fix-zero-first-byte-md5sum-check.patch" )
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--disable-doxygen-docs
+		--disable-examples
+		--disable-xmms-plugin
+		$([[ ${CHOST} == *-darwin* ]] && echo "--disable-asm-optimizations")
+		$(use_enable cpu_flags_ppc_altivec altivec)
+		$(use_enable cpu_flags_ppc_vsx vsx)
+		$(use_enable cpu_flags_x86_sse sse)
+		$(use_enable cxx cpplibs)
+		$(use_enable debug)
+		$(use_enable ogg)
+		$(use_enable static-libs static)
+
+		# cross-compile fix (bug #521446)
+		# no effect if ogg support is disabled
+		--with-ogg
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_test() {
+	if [[ ${UID} != 0 ]]; then
+		emake -j1 check
+	else
+		ewarn "Tests will fail if ran as root, skipping."
+	fi
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${ED}" -type f -name '*.la' -delete || die
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/719792
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Till Schäfer <till2.schaefer@uni-dortmund.de>