### PR TITLE
media-video/aegisub-9999: use wangqr repo to fix make 4.3 build

### DIFF
--- a/media-video/aegisub/aegisub-9999.ebuild
+++ b/media-video/aegisub/aegisub-9999.ebuild
@@ -12,8 +12,8 @@ PLOCALES="ar be bg ca cs da de el es eu fa fi fr_FR gl hu id it ja ko nl pl pt_B
 inherit autotools l10n lua-single wxwidgets xdg-utils git-r3
 
 DESCRIPTION="Advanced subtitle editor"
-HOMEPAGE="http://www.aegisub.org/ https://github.com/Aegisub/Aegisub"
-EGIT_REPO_URI="https://github.com/${PN^}/${PN^}.git"
+HOMEPAGE="http://www.aegisub.org/ https://github.com/wangqr/Aegisub"
+EGIT_REPO_URI="https://github.com/wangqr/${PN^}.git"
 # Submodules are used to pull bundled libraries.
 EGIT_SUBMODULES=()
 

--- a/media-video/aegisub/files/aegisub-9999-git.patch
+++ b/media-video/aegisub/files/aegisub-9999-git.patch
@@ -59,20 +59,3 @@ index e45a54767..1bd0120ed 100644
    CPPFLAGS="$aegisub_save_CPPFLAGS"
    LIBS="$aegisub_save_LIBS"
  ])
-diff --git a/src/libresrc/libresrc.cpp b/src/libresrc/libresrc.cpp
-index 79dc0f16c..8648d2987 100644
---- a/src/libresrc/libresrc.cpp
-+++ b/src/libresrc/libresrc.cpp
-@@ -22,9 +22,10 @@
- 
- wxBitmap libresrc_getimage(const unsigned char *buff, size_t size, double scale, int dir) {
- 	wxMemoryInputStream mem(buff, size);
-+        auto img = wxImage(mem);
- 	if (dir != wxLayout_RightToLeft)
--		return wxBitmap(wxImage(mem), -1, scale);
--	return wxBitmap(wxImage(mem).Mirror(), -1, scale);
-+            return wxBitmap(img.Scale(img.GetHeight() * scale, img.GetWidth() * scale));
-+	return wxBitmap(img.Mirror().Scale(img.GetHeight() * scale, img.GetWidth() * scale));
- }
- 
- wxIcon libresrc_geticon(const unsigned char *buff, size_t size) {


### PR DESCRIPTION
Hello,

Please, see [bug#765133](https://bugs.gentoo.org/765133) for an explanation about the failure to compile with sys-devel/make-4.3.

Thanks.

### Summary

The official Aegisub repo isn't actively updated...  That leaves now a problem when make is updated to sys-devel/make-4.3.

In `Makefile.target` it's required to use the automatic variable  `$(*F)`, rather than `$*`, to compile the Aegisub `.a` libraries with make 4.3.

### References about make 4.3 bug

- Gentoo bug: [media-video/aegisub-9999 not compiling with sys-devel/make-4.3 giving unresolved dependencies](https://bugs.gentoo.org/765133)
- GNU make's manual: [GNU make Automatic Variables](https://www.gnu.org/software/make/manual/make.html#Automatic-Variables)
- Bug reported on official Aegisub repo: [Failing to compile on make 4.3](https://github.com/Aegisub/Aegisub/issues/171)
- Solution by wangqr repo: [Use target name without directory in $*_OBJ macro](https://github.com/wangqr/Aegisub/commit/6bd3f4c26b8fc1f76a8b797fcee11e7611d59a39)

### Diffs

```
$ diff aegisub-9999.ebuild aegisub-9999-r1.ebuild
15,16c15,16
< HOMEPAGE="http://www.aegisub.org/ https://github.com/Aegisub/Aegisub"
< EGIT_REPO_URI="https://github.com/${PN^}/${PN^}.git"
---
> HOMEPAGE="http://www.aegisub.org/ https://github.com/wangqr/Aegisub"
> EGIT_REPO_URI="https://github.com/wangqr/${PN^}.git"
58c58
<       "${FILESDIR}/${P}-git.patch"
---
>       "${FILESDIR}/${PF}-git.patch"
```

```
$ diff files/aegisub-9999-git.patch aegisub-9999-r1-git.patch
62,78d61
< diff --git a/src/libresrc/libresrc.cpp b/src/libresrc/libresrc.cpp
< index 79dc0f16c..8648d2987 100644
< --- a/src/libresrc/libresrc.cpp
< +++ b/src/libresrc/libresrc.cpp
< @@ -22,9 +22,10 @@
<
<  wxBitmap libresrc_getimage(const unsigned char *buff, size_t size, double scale, int dir) {
<       wxMemoryInputStream mem(buff, size);
< +        auto img = wxImage(mem);
<       if (dir != wxLayout_RightToLeft)
< -             return wxBitmap(wxImage(mem), -1, scale);
< -     return wxBitmap(wxImage(mem).Mirror(), -1, scale);
< +            return wxBitmap(img.Scale(img.GetHeight() * scale, img.GetWidth() * scale));
< +     return wxBitmap(img.Mirror().Scale(img.GetHeight() * scale, img.GetWidth() * scale));
<  }
<
<  wxIcon libresrc_geticon(const unsigned char *buff, size_t size) {
```