### PR TITLE
media-sound/pulsemixer: add python3.9 support

### DIFF
--- a/media-sound/pulsemixer/pulsemixer-1.5.1.ebuild
+++ b/media-sound/pulsemixer/pulsemixer-1.5.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 PYTHON_REQ_USE="ncurses"
 
 inherit distutils-r1

--- a/media-sound/pulsemixer/pulsemixer-9999.ebuild
+++ b/media-sound/pulsemixer/pulsemixer-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{6..9} )
 PYTHON_REQ_USE="ncurses"
 
 inherit distutils-r1


### PR DESCRIPTION
No build error, works fine.
No upstream issues either.