### PR TITLE
net-print/cups: drop bogus libtool install invocations

### DIFF
--- a/net-print/cups/cups-2.3.3-r1.ebuild
+++ b/net-print/cups/cups-2.3.3-r1.ebuild
@@ -80,6 +80,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-2.0.2-rename-systemd-service-files.patch"
 	"${FILESDIR}/${PN}-2.0.1-xinetd-installation-fix.patch"
 	"${FILESDIR}/${PN}-2.3.3-user-AR.patch"
+	"${FILESDIR}/${PN}-2.3.3-no-libtool.patch"
 )
 
 MULTILIB_CHOST_TOOLS=(

--- a/net-print/cups/files/cups-2.3.3-no-libtool.patch
+++ b/net-print/cups/files/cups-2.3.3-no-libtool.patch
@@ -1,0 +1,25 @@
+This is not needed and causes problems with more strict
+implementations of libtool.
+
+With slibtool it fails.
+
+--- a/backend/Makefile
++++ b/backend/Makefile
+@@ -118,7 +118,7 @@ install-exec:	$(INSTALLXPC)
+ 	echo Installing backends in $(SERVERBIN)/backend
+ 	$(INSTALL_DIR) -m 755 $(SERVERBIN)/backend
+ 	for file in $(RBACKENDS); do \
+-		$(LIBTOOL) $(INSTALL_BIN) -m 700 $$file $(SERVERBIN)/backend; \
++		$(INSTALL_BIN) -m 700 $$file $(SERVERBIN)/backend; \
+ 	done
+ 	for file in $(UBACKENDS); do \
+ 		$(INSTALL_BIN) $$file $(SERVERBIN)/backend; \
+@@ -142,7 +142,7 @@ install-exec:	$(INSTALLXPC)
+ install-xpc:	ipp
+ 	echo Installing XPC backends in $(SERVERBIN)/apple
+ 	$(INSTALL_DIR) -m 755 $(SERVERBIN)/apple
+-	$(LIBTOOL) $(INSTALL_BIN) ipp $(SERVERBIN)/apple
++	$(INSTALL_BIN) ipp $(SERVERBIN)/apple
+ 	for file in $(IPPALIASES); do \
+ 		$(RM) $(SERVERBIN)/apple/$$file; \
+ 		$(LN) ipp $(SERVERBIN)/apple/$$file; \


### PR DESCRIPTION
GNU libtool executes invalid libtool arguments, alternative libtool implementations might not