### PR TITLE
dev-python/cleo: Add missing test dep

### DIFF
--- a/dev-python/cleo/cleo-0.8.1.ebuild
+++ b/dev-python/cleo/cleo-0.8.1.ebuild
@@ -18,6 +18,7 @@ KEYWORDS="~amd64 ~x86"
 BDEPEND="
 	test? (
 		dev-python/clikit[${PYTHON_USEDEP}]
+		dev-python/crashtest[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 	)"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/765616
