### PR TITLE
app-accessibility/caribou: Fix crash due to xserver CVE fix

### DIFF
--- a/app-accessibility/caribou/caribou-0.4.21-r2.ebuild
+++ b/app-accessibility/caribou/caribou-0.4.21-r2.ebuild
@@ -1,0 +1,103 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+GNOME2_LA_PUNT="yes"
+
+PYTHON_COMPAT=( python3_{6..9} )
+
+PYTHON_REQ_USE="xml"
+
+inherit gnome2 python-r1 vala
+
+DESCRIPTION="Input assistive technology intended for switch and pointer users"
+HOMEPAGE="https://wiki.gnome.org/Projects/Caribou"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+
+IUSE=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+COMMON_DEPEND="
+	app-accessibility/at-spi2-core
+	>=dev-python/pygobject-2.90.3:3[${PYTHON_USEDEP}]
+	>=x11-libs/gtk+-3:3[introspection]
+	x11-libs/gtk+:2
+	>=dev-libs/gobject-introspection-0.10.7:=
+	dev-libs/libgee:0.8
+	dev-libs/libxml2
+	>=media-libs/clutter-1.5.11:1.0[introspection]
+	x11-libs/libX11
+	x11-libs/libxklavier
+	x11-libs/libXtst
+	${PYTHON_DEPS}
+	$(vala_depend)
+"
+# gsettings-desktop-schemas is needed for the 'toolkit-accessibility' key
+# pyatspi-2.1.90 needed to run caribou if pygobject:3 is installed
+# librsvg needed to load svg images in css styles
+RDEPEND="${COMMON_DEPEND}
+	dev-libs/glib[dbus]
+	>=dev-python/pyatspi-2.1.90[${PYTHON_USEDEP}]
+	>=gnome-base/gsettings-desktop-schemas-3
+	gnome-base/librsvg:2
+	sys-apps/dbus
+	!<x11-base/xorg-server-1.20.10
+"
+DEPEND="${COMMON_DEPEND}
+	dev-libs/libxslt
+	>=dev-util/intltool-0.35.5
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-fix-compilation-error.patch"
+	"${FILESDIR}/${PN}-fix-subkey-popmenu.patch"
+	"${FILESDIR}/${PN}-fix-xadapter-xkb-calls.patch"
+	"${FILESDIR}/${PN}-fix-antler-style-css.patch"
+)
+
+src_prepare() {
+	# FIXME: Now this supports python3 too...
+	# delete custom PYTHONPATH, useless on Gentoo and potential bug source
+	# + caribou is python2 only so fix the shell scripts
+#	sed -e '/export PYTHONPATH=.*python/ d' \
+#		-e "s:@PYTHON@:${EPREFIX}/usr/bin/python2:" \
+#		-i bin/{antler-keyboard,caribou-preferences}.in ||
+#		die "sed failed"
+
+	vala_src_prepare
+	gnome2_src_prepare
+
+	prepare_caribou() {
+		mkdir -p "${BUILD_DIR}" || die
+	}
+	python_foreach_impl prepare_caribou
+}
+
+src_configure() {
+	ECONF_SOURCE="${S}" python_foreach_impl run_in_build_dir \
+		gnome2_src_configure \
+			--disable-docs \
+			--disable-static \
+			--enable-gtk3-module \
+			--enable-gtk2-module
+}
+
+src_compile() {
+	python_foreach_impl run_in_build_dir gnome2_src_compile
+}
+
+src_test() {
+	python_foreach_impl run_in_build_dir default
+}
+
+src_install() {
+	python_foreach_impl run_in_build_dir gnome2_src_install
+
+	# https://bugzilla.gnome.org/show_bug.cgi?id=769323
+	dodoc AUTHORS NEWS README # ChangeLog simply points to git log
+}

--- a/app-accessibility/caribou/files/caribou-fix-antler-style-css.patch
+++ b/app-accessibility/caribou/files/caribou-fix-antler-style-css.patch
@@ -1,0 +1,26 @@
+From 13df8b92ae89c796238e669ee6ef4447a42d6355 Mon Sep 17 00:00:00 2001
+From: Jeremy Bicha <jbicha@ubuntu.com>
+Date: Fri, 1 Dec 2017 12:11:35 -0500
+Subject: [PATCH] style.css: Fix failure to start in GNOME Flashback
+
+The order for 'font' properties matters
+https://developer.gnome.org/gtk3/stable/chap-css-properties.html
+
+https://bugzilla.gnome.org/show_bug.cgi?id=791001
+---
+ data/antler/style.css | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/antler/style.css b/data/antler/style.css
+index 5ab6f71..4d84904 100644
+--- a/data/antler/style.css
++++ b/data/antler/style.css
+@@ -13,7 +13,7 @@
+   border-width: 0px;
+   border-radius: 2px;
+   border-image: url("dark-key-border.svg") 2 2 2 2 repeat stretch;
+-  font: Sans 14px;
++  font: 14px Sans;
+   background-image: -gtk-gradient (linear,
+ 				     left top,
+ 				     left bottom,

--- a/app-accessibility/caribou/files/caribou-fix-compilation-error.patch
+++ b/app-accessibility/caribou/files/caribou-fix-compilation-error.patch
@@ -1,0 +1,25 @@
+From bc6f3e7ca0921b50a3ff836d08ce264a4f114224 Mon Sep 17 00:00:00 2001
+From: Clement Lefebvre <clement.lefebvre@linuxmint.com>
+Date: Tue, 12 Jan 2021 17:29:16 +0000
+Subject: [PATCH 1/4] Fix compilation error
+
+---
+ libcaribou/key-model.vala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcaribou/key-model.vala b/libcaribou/key-model.vala
+index 89015bc..e88342e 100644
+--- a/libcaribou/key-model.vala
++++ b/libcaribou/key-model.vala
+@@ -101,7 +101,7 @@ namespace Caribou {
+                     unichar uc;
+                     while (text.get_next_char (ref index, out uc)) {
+                         uint keyval = Gdk.unicode_to_keyval (uc);
+-                        if (keyval != uc | 0x01000000)
++                        if (keyval != (uc | 0x01000000))
+                             _keyvals += keyval;
+                     }
+                 } else {
+-- 
+2.29.2
+

--- a/app-accessibility/caribou/files/caribou-fix-subkey-popmenu.patch
+++ b/app-accessibility/caribou/files/caribou-fix-subkey-popmenu.patch
@@ -1,0 +1,32 @@
+From 85ac8f9e210243d95163cf8b1013470a6d9c7eaa Mon Sep 17 00:00:00 2001
+From: Clement Lefebvre <clement.lefebvre@linuxmint.com>
+Date: Tue, 12 Jan 2021 17:30:25 +0000
+Subject: [PATCH 2/4] Fix subkey popmenu not showing after being dismissed
+
+To reproduce the issue:
+
+- long-press the "e" button
+- don't select any sub button.. just select "e" again to close the menu
+
+After this the menu no long appears when long-pressing "e".
+
+This commit fixes that.
+---
+ libcaribou/key-model.vala | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libcaribou/key-model.vala b/libcaribou/key-model.vala
+index e88342e..2f640f2 100644
+--- a/libcaribou/key-model.vala
++++ b/libcaribou/key-model.vala
+@@ -179,6 +179,7 @@ namespace Caribou {
+                 hold_tid = GLib.Timeout.add (1000, on_key_held);
+ 
+             key_pressed(this);
++            show_subkeys = false;
+         }
+ 
+         public void release () {
+-- 
+2.29.2
+

--- a/app-accessibility/caribou/files/caribou-fix-xadapter-xkb-calls.patch
+++ b/app-accessibility/caribou/files/caribou-fix-xadapter-xkb-calls.patch
@@ -1,0 +1,46 @@
+From 00653c5dcc4be5e983b670d00d5724fc21da2e82 Mon Sep 17 00:00:00 2001
+From: Clement Lefebvre <clement.lefebvre@linuxmint.com>
+Date: Tue, 12 Jan 2021 18:01:47 +0000
+Subject: [PATCH 3/4] [mtwebster] xadapter.vala: Remove XkbKeyTypesMask and
+ fields from XKbChangeMap call.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This was originally a workaround for xFree86 4.3 - see:
+https://bugzilla.gnome.org/show_bug.cgi?id=673547
+​
+As of https://gitlab.freedesktop.org/xorg/xserver/-/commit/87c64fc5b0 this
+causes a BadLength error when attempting to use shifted characters.
+​
+Ref:
+https://www.x.org/releases/X11R7.7/doc/libX11/XKB/xkblib.html#Changing_Map_Components_in_the_Server
+---
+ libcaribou/xadapter.vala | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/libcaribou/xadapter.vala b/libcaribou/xadapter.vala
+index 22858b7..1da5a78 100644
+--- a/libcaribou/xadapter.vala
++++ b/libcaribou/xadapter.vala
+@@ -195,15 +195,10 @@ namespace Caribou {
+ 
+             Xkb.MapChanges changes = Xkb.MapChanges ();
+ 
+-            // We don't touch key types here but include the
+-            // information in XkbSetMap request to the server, because
+-            // some X servers need the information to check the sanity
+-            // of the keysyms change.
+-            changes.changed = (ushort) (Xkb.KeySymsMask | Xkb.KeyTypesMask);
++            changes.changed = (ushort) Xkb.KeySymsMask;
+             changes.first_key_sym = (char) this.reserved_keycode;
+             changes.num_key_syms = this.xkbdesc.map.key_sym_map[this.reserved_keycode].width;
+-            changes.first_type = 0;
+-            changes.num_types = this.xkbdesc.map.num_types;
++
+             Xkb.change_map (this.xdisplay, this.xkbdesc, changes);
+ 
+             this.xdisplay.flush ();
+-- 
+2.29.2
+


### PR DESCRIPTION
xorg-server 1.20.10 contains a fix for CVE-2020-25712.

This causes a previous work-around in caribou to result in a BadLength error, when interacting with XKB, and crashes the hosting application.

Fixes provided by Cinnamon upstream from Fedora RPM:
https://src.fedoraproject.org/rpms/caribou/tree/master

This also includes an upstreamed antler fix and bumps PYTHON_COMPAT for 3.9 support.

Bug: https://bugs.gentoo.org/765661
linuxmint/cinnamon-screensaver#354

Since this is security related, should this be committed as stable and clean-up the old version? Or would the normal stabilization/clean-up process just be expedited?