### PR TITLE
net-misc/cni-plugins: add service file for cni dhcp

### DIFF
--- a/net-misc/cni-plugins/cni-plugins-0.8.7-r1.ebuild
+++ b/net-misc/cni-plugins/cni-plugins-0.8.7-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit go-module linux-info
+
+DESCRIPTION="Standard networking plugins for container networking"
+HOMEPAGE="https://github.com/containernetworking/plugins"
+SRC_URI="https://github.com/containernetworking/plugins/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+IUSE="hardened"
+
+CONFIG_CHECK="~BRIDGE_VLAN_FILTERING"
+S="${WORKDIR}/plugins-${PV}"
+
+src_compile() {
+	CGO_LDFLAGS="$(usex hardened '-fno-PIC ' '')" ./build_linux.sh || die
+}
+
+src_install() {
+	exeinto /opt/cni/bin
+	doexe bin/*
+	newinitd "${FILESDIR}"/cni-dhcp.initd cni-dhcp
+	dodoc README.md
+	local i
+	for i in plugins/{meta/{bandwidth,firewall,flannel,portmap,sbr,tuning},main/{bridge,host-device,ipvlan,loopback,macvlan,ptp,vlan},ipam/{dhcp,host-local,static},sample}; do
+		newdoc README.md ${i##*/}.README.md
+	done
+}

--- a/net-misc/cni-plugins/files/cni-dhcp.initd
+++ b/net-misc/cni-plugins/files/cni-dhcp.initd
@@ -1,0 +1,23 @@
+#!/sbin/openrc-run
+
+name="CNI-DHCP"
+description="virtual dhcp server for containers"
+command="/opt/cni/bin/dhcp"
+command_args="daemon"
+command_background=true
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+	need net
+}
+
+stop() {
+	ebegin "Stopping ${name}"
+	start-stop-daemon --stop --pidfile "${pidfile}"
+	eend $? "Failed to stop ${name}"
+	if [ -e /run/cni/dhcp.sock ]; then
+		ebegin "Cleaning socket for ${name}"
+		rm -f /run/cni/dhcp.sock
+		eend $? "Failed to cleanup socket"
+	fi
+}


### PR DESCRIPTION
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>

---

Very useful for working in macvlan mode to expose containers to local network.