### PR TITLE
sci-libs/amd: only depend on virtual/fortran if USE=fortran

### DIFF
--- a/sci-libs/amd/amd-2.4.6-r1.ebuild
+++ b/sci-libs/amd/amd-2.4.6-r1.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=7
 
+FORTRAN_NEEDED=fortran
 inherit autotools fortran-2
 
 DESCRIPTION="Library to order a sparse matrix prior to Cholesky factorization"

--- a/sci-libs/amd/amd-2.4.6.ebuild
+++ b/sci-libs/amd/amd-2.4.6.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=7
 
+FORTRAN_NEEDED=fortran
 inherit fortran-2
 
 DESCRIPTION="Library to order a sparse matrix prior to Cholesky factorization"


### PR DESCRIPTION
Add FORTRAN_NEEDED=fortran before inheriting the fortran-2 eclass so that the ebuild does not depend on virtual/fortran if USE=-fortran.

Closes: https://bugs.gentoo.org/765739
Signed-off-by: Timo Kamph <tka@kamph.org>