### PR TITLE
dev-db/pgcli: Remove unneded test dep

### DIFF
--- a/dev-db/pgcli/pgcli-3.1.0.ebuild
+++ b/dev-db/pgcli/pgcli-3.1.0.ebuild
@@ -31,7 +31,6 @@ BDEPEND="
 	test? (
 		dev-db/postgresql
 		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/python-dateutil[${PYTHON_USEDEP}]
 	)"
 
 distutils_enable_tests pytest


### PR DESCRIPTION
* Pgcli doesn't explicitly need python-dateutil, it is pulled in by
  dev-python/pendulum since 25758bbe13f42b824713b0d52661e26d8c6f954d