### PR TITLE
dev-dotnet/libgdiplus: fix `--with-pango` configure, fix pango linking

### DIFF
--- a/dev-dotnet/libgdiplus/libgdiplus-6.0.2-r1.ebuild
+++ b/dev-dotnet/libgdiplus/libgdiplus-6.0.2-r1.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools eutils dotnet
+
+DESCRIPTION="Library for using System.Drawing with Mono"
+HOMEPAGE="https://www.mono-project.com"
+SRC_URI="https://download.mono-project.com/sources/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="cairo"
+#skip tests due https://bugs.gentoo.org/687784
+RESTRICT="test"
+
+RDEPEND="dev-libs/glib
+	media-libs/freetype
+	media-libs/fontconfig
+	>=media-libs/giflib-5.1.2
+	media-libs/libexif
+	media-libs/libpng:0=
+	media-libs/tiff
+	x11-libs/cairo[X]
+	x11-libs/libX11
+	x11-libs/libXrender
+	x11-libs/libXt
+	virtual/jpeg:0
+	!cairo? ( x11-libs/pango )"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+	# Don't default to pango when `--with-pango` is not given.
+	# Link against correct pango libraries. Bug #700280
+	sed -e 's/text_v=default/text_v=cairo/' \
+		-e 's/pangocairo/pangocairo pangoft2/' \
+		-i configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		$(usex cairo "" "--with-pango")
+}
+
+src_install() {
+	default
+
+	dotnet_multilib_comply
+	local commondoc=( AUTHORS ChangeLog README TODO )
+	for docfile in "${commondoc[@]}"; do
+		[[ -e "${docfile}" ]] && dodoc "${docfile}"
+	done
+	[[ "${DOCS[@]}" ]] && dodoc "${DOCS[@]}"
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
dev-dotnet/libgdiplus-6.0.2-r1 diff is the following:

- add src_prepare
- swap ltprune for find command
```
src_prepare() {
	default
	# Don't default to pango when `--with-pango` is not given.
	# Link against correct pango libraries. Bug #700280
	sed -e 's/text_v=default/text_v=cairo/' \
		-e 's/pangocairo/pangocairo pangoft2/' \
		-i configure.ac || die
	eautoreconf
}
```
https://github.com/mono/libgdiplus/blob/6.0.2/configure.ac#L65
Currently when `--with-pango` is not supplied `configure.ac` looks for pango anyways with `text_v=default`. If pango is found above the minimum version it is used instead of cairo even if `--with-pango` is not present. So I've switched "default" for "cairo" at L32. This matches what the `cairo` USE flag is meant to do

---

Following is related to the closed bug:

Also added `pangoft2` to pkgconf libraries/cflags to fix undefined reference issues when `--with-pango` is used:
```
ld.lld: error: ../src/.libs/libgdiplus.so: undefined reference to pango_cairo_font_map_new_for_font_type [--no-allow-shlib-undefined]
ld.lld: error: ../src/.libs/libgdiplus.so: undefined reference to pango_cairo_layout_path [--no-allow-shlib-undefined]
ld.lld: error: ../src/.libs/libgdiplus.so: undefined reference to pango_cairo_update_context [--no-allow-shlib-undefined]
ld.lld: error: ../src/.libs/libgdiplus.so: undefined reference to pango_cairo_update_layout [--no-allow-shlib-undefined]
ld.lld: error: ../src/.libs/libgdiplus.so: undefined reference to pango_cairo_show_layout [--no-allow-shlib-undefined]
```

Closes: https://bugs.gentoo.org/700280
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>