### PR TITLE
sys-libs/db: use --version-script instead of --default-symver for ld.{gold,lld}

### DIFF
--- a/sys-libs/db/db-18.1.32.ebuild
+++ b/sys-libs/db/db-18.1.32.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -114,6 +114,11 @@ src_prepare() {
 	sed -i \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		"${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -151,7 +156,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# use `set` here since the java opts will contain whitespace

--- a/sys-libs/db/db-18.1.40.ebuild
+++ b/sys-libs/db/db-18.1.40.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -111,6 +111,11 @@ src_prepare() {
 	sed -i \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		"${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -148,7 +153,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# use `set` here since the java opts will contain whitespace

--- a/sys-libs/db/db-4.3.29_p1-r3.ebuild
+++ b/sys-libs/db/db-4.3.29_p1-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -105,6 +105,11 @@ src_prepare() {
 		-i configure || die
 	popd &>/dev/null || die
 	popd &>/dev/null || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 src_configure() {
@@ -139,7 +144,12 @@ src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header
 	# file mumbo jumbo.
 	if use userland_GNU; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	ECONF_SOURCE="${S}"/../dist \

--- a/sys-libs/db/db-4.4.20_p4-r3.ebuild
+++ b/sys-libs/db/db-4.4.20_p4-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -99,6 +99,11 @@ src_prepare() {
 
 	popd &>/dev/null || die
 	popd &>/dev/null || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 src_configure() {
@@ -133,7 +138,12 @@ src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	ECONF_SOURCE="${S}"/../dist \

--- a/sys-libs/db/db-4.5.20_p2-r3.ebuild
+++ b/sys-libs/db/db-4.5.20_p2-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -103,6 +103,11 @@ src_prepare() {
 
 	popd &>/dev/null || die
 	popd &>/dev/null || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 src_configure() {
@@ -143,7 +148,12 @@ src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	ECONF_SOURCE="${S}"/../dist \

--- a/sys-libs/db/db-4.5.20_p2-r4.ebuild
+++ b/sys-libs/db/db-4.5.20_p2-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -103,6 +103,11 @@ src_prepare() {
 
 	popd &>/dev/null || die
 	popd &>/dev/null || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 src_configure() {
@@ -144,7 +149,12 @@ src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	ECONF_SOURCE="${S}"/../dist \

--- a/sys-libs/db/db-4.6.21_p4-r2.ebuild
+++ b/sys-libs/db/db-4.6.21_p4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -92,6 +92,11 @@ src_prepare() {
 
 	popd &>/dev/null || die
 	popd &>/dev/null || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 src_configure() {
@@ -132,7 +137,12 @@ src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	ECONF_SOURCE="${S}"/../dist \

--- a/sys-libs/db/db-4.6.21_p4-r3.ebuild
+++ b/sys-libs/db/db-4.6.21_p4-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -92,6 +92,11 @@ src_prepare() {
 
 	popd &>/dev/null || die
 	popd &>/dev/null || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 src_configure() {
@@ -133,7 +138,12 @@ src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	ECONF_SOURCE="${S}"/../dist \

--- a/sys-libs/db/db-4.7.25_p4-r2.ebuild
+++ b/sys-libs/db/db-4.7.25_p4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -95,6 +95,11 @@ src_prepare() {
 
 	popd &>/dev/null || die
 	popd &>/dev/null || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 src_configure() {
@@ -135,7 +140,12 @@ src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	ECONF_SOURCE="${S}"/../dist \

--- a/sys-libs/db/db-4.8.30-r4.ebuild
+++ b/sys-libs/db/db-4.8.30-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -91,6 +91,11 @@ src_prepare() {
 		-e "s/__EDIT_DB_VERSION_UNIQUE_NAME__/$DB_VERSION_UNIQUE_NAME/g" \
 		-e "s/__EDIT_DB_VERSION__/$DB_VERSION/g" \
 		-i configure || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -118,7 +123,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# use `set` here since the java opts will contain whitespace

--- a/sys-libs/db/db-5.1.29-r2.ebuild
+++ b/sys-libs/db/db-5.1.29-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -110,6 +110,11 @@ src_prepare() {
 	sed \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		-i "${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 src_configure() {
@@ -146,7 +151,12 @@ src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# Bug #270851: test needs TCL support

--- a/sys-libs/db/db-5.3.28-r2.ebuild
+++ b/sys-libs/db/db-5.3.28-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -111,6 +111,11 @@ src_prepare() {
 	sed -i \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		"${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -128,7 +133,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# use `set` here since the java opts will contain whitespace

--- a/sys-libs/db/db-5.3.28-r5.ebuild
+++ b/sys-libs/db/db-5.3.28-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -118,6 +118,11 @@ src_prepare() {
 	sed \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		-i "${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -153,7 +158,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	if multilib_is_native_abi && use java ; then

--- a/sys-libs/db/db-6.0.35-r2.ebuild
+++ b/sys-libs/db/db-6.0.35-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -116,6 +116,11 @@ src_prepare() {
 	sed \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		-i "${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -146,7 +151,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# use `set` here since the java opts will contain whitespace

--- a/sys-libs/db/db-6.0.35-r3.ebuild
+++ b/sys-libs/db/db-6.0.35-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -116,6 +116,11 @@ src_prepare() {
 	sed \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		-i "${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -147,7 +152,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# use `set` here since the java opts will contain whitespace

--- a/sys-libs/db/db-6.1.38.ebuild
+++ b/sys-libs/db/db-6.1.38.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -113,6 +113,11 @@ src_prepare() {
 	sed -i \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		"${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -149,7 +154,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use userland_GNU ; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# use `set` here since the java opts will contain whitespace

--- a/sys-libs/db/db-6.2.38.ebuild
+++ b/sys-libs/db/db-6.2.38.ebuild
@@ -114,6 +114,11 @@ src_prepare() {
 	sed -i \
 		-e '/db_repsite/s,Skipping:,Skipping,g' \
 		"${S_BASE}"/test/tcl/reputils.tcl || die
+
+	# Version script for ld.{gold,lld} which do not supprt --default-symver
+	cat > "${S}"/db-version-script.ver <<-EOF
+	libdb-${SLOT}.so {*;};
+	EOF
 }
 
 multilib_src_configure() {
@@ -150,7 +155,12 @@ multilib_src_configure() {
 	# Add linker versions to the symbols. Easier to do, and safer than header file
 	# mumbo jumbo.
 	if use kernel_linux || use kernel_SunOS; then
-		append-ldflags -Wl,--default-symver
+		# ld.{gold,lld} do not supprt --default-symver
+		if tc-ld-is-gold || tc-ld-is-lld; then
+			append-ldflags -Wl,--version-script="${S}"/db-version-script.ver
+		else
+			append-ldflags -Wl,--default-symver
+		fi
 	fi
 
 	# use `set` here since the java opts will contain whitespace


### PR DESCRIPTION
ld.{gold,lld} do not supprt `--default-symver`. Using the `--version-script` script provided fixes configure and outputs symbol names matching `--default-symver`.

| ld.bfd (default-symver)                                                                                                                                                                                                                                           | ld.{gold,lld} (version-script)                                                                                                                                                                                                                                           |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| T __txn_stat_print_pp@@libdb-6.0.so@@libdb-6.0.so<br>T __txn_updateckp@@libdb-6.0.so@@libdb-6.0.so<br>D __txn_xa_regop_42_desc@@libdb-6.0.so@@libdb-6.0.so<br>T __txn_xa_regop_42_verify@@libdb-6.0.so@@libdb-6.0.so<br>T __ua_memcpy@@libdb-6.0.so@@libdb-6.0.so | T __txn_stat_print_pp@@libdb-6.0.so@@libdb-6.0.so<br>T __txn_updateckp@@libdb-6.0.so@@libdb-6.0.so<br>D __txn_xa_regop_42_desc@@libdb-6.0.so@@libdb-6.0.so<br>T __txn_xa_regop_42_verify@@libdb-6.0.so@@libdb-6.0.so<br>T __ua_memcpy@@libdb-6.0.so@@libdb-6.0.so |

Closes: https://bugs.gentoo.org/729510
Closes: https://bugs.gentoo.org/595108
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>