### PR TITLE
eclass/toolchain-funcs: new function tc-ld-force-bfd()

### DIFF
--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -1,4 +1,4 @@
-# Copyright 2002-2019 Gentoo Authors
+# Copyright 2002-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: toolchain-funcs.eclass
@@ -505,12 +505,21 @@ tc-ld-is-lld() {
 # If the gold linker is currently selected, configure the compilation
 # settings so that we use the older bfd linker instead.
 tc-ld-disable-gold() {
-	if ! tc-ld-is-gold "$@" ; then
-		# They aren't using gold, so nothing to do!
+	tc-ld-is-gold "$@" && tc-ld-force-bfd "$@"
+}
+
+# @FUNCTION: tc-ld-force-bfd
+# @USAGE: [toolchain prefix]
+# @DESCRIPTION:
+# If the gold or lld linker is currently selected, configure the compilation
+# settings so that we use the bfd linker instead.
+tc-ld-force-bfd() {
+	if ! tc-ld-is-gold "$@" && ! tc-ld-is-lld "$@" ; then
+		# They aren't using gold or lld, so nothing to do!
 		return
 	fi
 
-	ewarn "Forcing usage of the BFD linker instead of GOLD"
+	ewarn "Forcing usage of the BFD linker"
 
 	# Set up LD to point directly to bfd if it's available.
 	# We need to extract the first word in case there are flags appended
@@ -520,7 +529,7 @@ tc-ld-disable-gold() {
 	local path_ld=$(which "${bfd_ld}" 2>/dev/null)
 	[[ -e ${path_ld} ]] && export LD=${bfd_ld}
 
-	# Set up LDFLAGS to select gold based on the gcc / clang version.
+	# Set up LDFLAGS to select bfd based on the gcc / clang version.
 	local fallback="true"
 	if tc-is-gcc; then
 		local major=$(gcc-major-version "$@")
@@ -548,7 +557,7 @@ tc-ld-disable-gold() {
 			ln -sf "${path_ld}" "${d}"/ld
 			export LDFLAGS="${LDFLAGS} -B${d}"
 		else
-			die "unable to locate a BFD linker to bypass gold"
+			die "unable to locate a BFD linker"
 		fi
 	fi
 }


### PR DESCRIPTION
```
No functions currently force ld.bfd usage when ld.lld is active.
This function forces ld.bfd when either ld.gold or ld.lld is active.
tc-ld-disable-gold() now calls this new function
 only if ld.gold is active.
```

Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>