### PR TITLE
media-sound/pulseaudio: fix build with clang

### DIFF
--- a/media-sound/pulseaudio/files/pulseaudio-13.0-clang.patch
+++ b/media-sound/pulseaudio/files/pulseaudio-13.0-clang.patch
@@ -1,0 +1,25 @@
+From e4450d8b586103ec1414e2d6245ff34a9096d97a Mon Sep 17 00:00:00 2001
+From: Peter Levine <plevine457@gmail.com>
+Date: Thu, 26 Sep 2019 07:24:40 +0000
+Subject: [PATCH] atomic: Explicitly cast void* to unsigned long
+
+---
+ src/pulsecore/atomic.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pulsecore/atomic.h b/src/pulsecore/atomic.h
+index a82ca83c5..e5c140109 100644
+--- a/src/pulsecore/atomic.h
++++ b/src/pulsecore/atomic.h
+@@ -117,7 +117,7 @@ static inline void* pa_atomic_ptr_load(const pa_atomic_ptr_t *a) {
+ }
+ 
+ static inline void pa_atomic_ptr_store(pa_atomic_ptr_t *a, void* p) {
+-    __atomic_store_n(&a->value, p, __ATOMIC_SEQ_CST);
++    __atomic_store_n(&a->value, (unsigned long) p, __ATOMIC_SEQ_CST);
+ }
+ 
+ #else
+-- 
+GitLab
+

--- a/media-sound/pulseaudio/pulseaudio-13.0-r1.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-13.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -123,6 +123,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/pulseaudio-11.1-disable-flat-volumes.patch # bug 627894
+	"${FILESDIR}"/${P}-clang.patch
 )
 
 pkg_pretend() {

--- a/media-sound/pulseaudio/pulseaudio-13.0.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-13.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -120,6 +120,7 @@ RDEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/pulseaudio-11.1-disable-flat-volumes.patch # bug 627894
+	"${FILESDIR}"/${P}-clang.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/740498
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>