### PR TITLE
dev-java/openjdk: pass --with-toolchain-type to configure (fix configure with clang)

### DIFF
--- a/dev-java/openjdk/openjdk-11.0.9_p11.ebuild
+++ b/dev-java/openjdk/openjdk-11.0.9_p11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -168,6 +168,7 @@ src_configure() {
 		--with-zlib=system
 		--enable-dtrace=$(usex systemtap yes no)
 		--enable-headless-only=$(usex headless-awt yes no)
+		$(tc-is-clang && echo "--with-toolchain-type=clang")
 	)
 
 	if use javafx; then

--- a/dev-java/openjdk/openjdk-8.272_p10.ebuild
+++ b/dev-java/openjdk/openjdk-8.272_p10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -175,6 +175,7 @@ src_configure() {
 			--with-zlib=system
 			--with-native-debug-symbols=$(usex debug internal none)
 			$(usex headless-awt --disable-headful '')
+			$(tc-is-clang && echo "--with-toolchain-type=clang")
 		)
 
 	# PaX breaks pch, bug #601016


### PR DESCRIPTION
`--with-toolchain-type` is needed for ./configure to correctly determine version info from CC. Otherwise configure bails out with:
```
configure: Will use user supplied compiler CC=clang
checking for clang... /usr/lib/llvm/11/bin/clang
checking resolved symbolic links for CC... /usr/lib/llvm/11/bin/clang-11
configure: The C compiler (located as /usr/lib/llvm/11/bin/clang) does not seem to be the required gcc compiler.
configure: The result from running with --version was: ""
configure: error: A gcc compiler is required. Try setting --with-tools-dir.
configure exiting with result code 1
```

"gcc" within "A **gcc** compiler is required" comes from `$TOOLCHAIN_TYPE` which in turn is derived from `$DEFAULT_TOOLCHAIN` when `--with-toolchain-type` is not set.

See: https://github.com/openjdk/jdk/blob/master/doc/building.md#clang

Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>