### PR TITLE
dev-java/openjdk(-jre)(-bin): Set JKS as default trust store format

### DIFF
--- a/dev-java/openjdk-bin/openjdk-bin-11.0.9_p11.ebuild
+++ b/dev-java/openjdk-bin/openjdk-bin-11.0.9_p11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -81,6 +81,15 @@ src_install() {
 	rm -v lib/security/cacerts || die
 	dosym ../../../../etc/ssl/certs/java/cacerts \
 		"${dest}"/lib/security/cacerts
+
+	# Since Java 9 the default keystore format is PKCS12 but
+	# /etc/ssl/certs/java/cacerts, which is setup by baselayout-java,
+	# is still in JKS format. Note that we switch to JKS, even though
+	# keystore.type.compat=true in java.security is set, because some
+	# security providers do not support keystore.type.compat=true
+	# (e.g. versions of Bouncycastle). #712290
+	sed -e "s:^keystore\.type=pkcs12:keystore.type=jks:" \
+		-i "${dest}/conf/security/java.security" || die
 
 	dodir "${dest}"
 	cp -pPR * "${ddest}" || die

--- a/dev-java/openjdk-jre-bin/openjdk-jre-bin-11.0.9_p11.ebuild
+++ b/dev-java/openjdk-jre-bin/openjdk-jre-bin-11.0.9_p11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -68,6 +68,15 @@ src_install() {
 
 	rm -v lib/security/cacerts || die
 	dosym ../../../../etc/ssl/certs/java/cacerts "${dest}"/lib/security/cacerts
+
+	# Since Java 9 the default keystore format is PKCS12 but
+	# /etc/ssl/certs/java/cacerts, which is setup by baselayout-java,
+	# is still in JKS format. Note that we switch to JKS, even though
+	# keystore.type.compat=true in java.security is set, because some
+	# security providers do not support keystore.type.compat=true
+	# (e.g. versions of Bouncycastle). #712290
+	sed -e "s:^keystore\.type=pkcs12:keystore.type=jks:" \
+		-i "${dest}/conf/security/java.security" || die
 
 	dodir "${dest}"
 	cp -pPR * "${ddest}" || die

--- a/dev-java/openjdk/openjdk-11.0.9_p11.ebuild
+++ b/dev-java/openjdk/openjdk-11.0.9_p11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -132,6 +132,15 @@ pkg_setup() {
 src_prepare() {
 	default
 	chmod +x configure || die
+
+	# Since Java 9 the default keystore format is PKCS12 but
+	# /etc/ssl/certs/java/cacerts, which is setup by baselayout-java,
+	# is still in JKS format. Note that we switch to JKS, even though
+	# keystore.type.compat=true in java.security is set, because some
+	# security providers do not support keystore.type.compat=true
+	# (e.g. versions of Bouncycastle). #712290
+	sed -e "s:^keystore\.type=pkcs12:keystore.type=jks:" \
+		-i "src/java.base/share/conf/security/java.security" || die
 }
 
 src_configure() {


### PR DESCRIPTION
Only a JKS formated trust store is created by
sys-apps/baselayout-java: namely /etc/ssl/certs/java/cacerts. This
file is the symlink target for all JDK/JREs, even though, since Java 9
the default key store format become PKCS12.

Hence we switch the default key store format back to JSK, until
baselayout-java also takes care of creating a trust store in PCS12
format (e.g. /etc/ssl/certs/java/cacerts.p12).

Bug: https://bugs.gentoo.org/712290
Package-Manager: Portage-3.0.13, Repoman-3.0.2
RepoMan-Options: --force
Signed-off-by: Florian Schmaus <flo@geekplace.eu>