### PR TITLE
net-misc/dhcp: Pass randomdev path to configure

### DIFF
--- a/net-misc/dhcp/dhcp-4.4.2-r3.ebuild
+++ b/net-misc/dhcp/dhcp-4.4.2-r3.ebuild
@@ -166,6 +166,7 @@ src_configure() {
 		--enable-paranoia
 		--enable-early-chroot
 		--sysconfdir=${e}
+		--with-randomdev=/dev/random
 		$(use_enable ipv6 dhcpv6)
 		$(use_with ldap)
 		$(use ldap && use_with ssl ldapcrypto || echo --without-ldapcrypto)
@@ -178,6 +179,7 @@ src_configure() {
 	local el
 	eval econf \
 		$(for el in $(awk '/^bindconfig/,/^$/ {print}' ../Makefile.in) ; do if [[ ${el} =~ ^-- ]] ; then printf ' %s' ${el//\\} ; fi ; done | sed 's,@\([[:alpha:]]\+\)dir@,${binddir}/\1,g') \
+		--with-randomdev=/dev/random \
 		--disable-symtable \
 		--without-make-clean
 }


### PR DESCRIPTION
* dhcp fails to detect which random device to use when cross-compiling,
  so we have to pass --with-randomdev=/dev/random to configure

Closes: https://bugs.gentoo.org/766426