### PR TITLE
app-backup/amanda: depend on libtirpc for USE=ndmp

### DIFF
--- a/app-backup/amanda/amanda-3.5.1-r3.ebuild
+++ b/app-backup/amanda/amanda-3.5.1-r3.ebuild
@@ -27,6 +27,7 @@ DEPEND="
 	sys-libs/readline:=
 	virtual/awk
 	kerberos? ( app-crypt/mit-krb5 )
+	ndmp? ( net-libs/libtirpc:= )
 	nls? ( virtual/libintl )
 	samba? ( net-fs/samba:= )
 	s3? ( net-misc/curl )
@@ -135,6 +136,7 @@ src_unpack() {
 
 src_prepare() {
 	default
+	use ndmp && eapply "${FILESDIR}"/${P}-tirpc.patch
 	# gentoo bug #331111
 	sed -i '/^check-local: check-perl$/d' config/automake/scripts.am || die
 	sed -i '/^check-local:/s,syntax-check,,g' perl/Makefile.am || die

--- a/app-backup/amanda/files/amanda-3.5.1-tirpc.patch
+++ b/app-backup/amanda/files/amanda-3.5.1-tirpc.patch
@@ -1,0 +1,16 @@
+https://bugs.gentoo.org/656340
+--- a/config/amanda/amanda_configure.m4
++++ b/config/amanda/amanda_configure.m4
+@@ -257,6 +257,12 @@ AMANDA_CHECK_READLINE
+ AC_CHECK_LIB(m,modf)
+ AMANDA_CHECK_LIBDL
+ AMANDA_GLIBC_BACKTRACE
++PKG_CHECK_MODULES([TIRPC],[libtirpc],[
++	CPPFLAGS="${CPPFLAGS} ${TIRPC_CFLAGS} -DHAVE_RPC_RPC_H"
++	LIBS="${LIBS} ${TIRPC_LIBS}"
++], [
++	AC_MSG_ERROR([libtirpc requested but library not found])
++])
+ AC_SEARCH_LIBS([shm_open], [rt], [], [
+   AC_MSG_ERROR([unable to find the shm_open() function])
+ ])


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/656340