### PR TITLE
dev-php/pecl-event: stabilized version 2.5.7

### DIFF
--- a/dev-php/pecl-event/pecl-event-2.5.7.ebuild
+++ b/dev-php/pecl-event/pecl-event-2.5.7.ebuild
@@ -12,7 +12,7 @@ USE_PHP="php7-2 php7-3 php7-4"
 
 inherit php-ext-pecl-r3
 
-KEYWORDS="~amd64 ~ia64 ~x86"
+KEYWORDS="amd64 ~ia64 x86"
 LICENSE="PHP-3.01"
 
 DESCRIPTION="PHP wrapper for libevent2"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/721122
Signed-off-by: Ruslan Osmanov <rrosmanov@gmail.com>