### PR TITLE
gui-apps/waybar: sync live

### DIFF
--- a/gui-apps/waybar/waybar-9999.ebuild
+++ b/gui-apps/waybar/waybar-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,19 +18,19 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="mpd network popups pulseaudio tray +udev"
+IUSE="mpd network popups pulseaudio tray +udev wifi"
 
 BDEPEND="
 	>=app-text/scdoc-1.9.2
 	virtual/pkgconfig
-	"
+"
 DEPEND="
 	dev-cpp/gtkmm:3.0
 	dev-libs/jsoncpp:=
 	dev-libs/libinput:=
 	dev-libs/libsigc++:2
 	>=dev-libs/libfmt-5.3.0:=
-	>=dev-libs/spdlog-1.3.1:=
+	>=dev-libs/spdlog-1.8.0:=
 	dev-libs/date:=
 	dev-libs/wayland
 	dev-libs/wayland-protocols
@@ -45,7 +45,8 @@ DEPEND="
 		dev-libs/libappindicator
 	)
 	udev? ( virtual/libudev:= )
-	"
+	wifi? ( || ( sys-apps/util-linux net-wireless/rfkill ) )
+"
 RDEPEND="${DEPEND}"
 
 src_configure() {
@@ -56,6 +57,8 @@ src_configure() {
 		$(meson_feature pulseaudio)
 		$(meson_feature tray dbusmenu-gtk)
 		$(meson_feature udev libudev)
+		$(meson_feature wifi rfkill)
+		-Dsndio=disabled
 	)
 	meson_src_configure
 }


### PR DESCRIPTION
Syncing the live ebuild with the latest (0.9.5) ebuild.

Signed-off-by: Octiabrina Terrien-Puig <octiabrina@myrvogna.net>
Package-Manager: Portage-3.0.14, Repoman-3.0.2