### PR TITLE
net-im/prosody: Added selinux USE flag and dependency.

### DIFF
--- a/net-im/prosody/prosody-0.11.7-r101.ebuild
+++ b/net-im/prosody/prosody-0.11.7-r101.ebuild
@@ -15,14 +15,14 @@ SRC_URI="https://prosody.im/downloads/source/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 x86"
-IUSE="icu +idn +libevent libressl mysql postgres +sqlite +ssl test +zlib"
+IUSE="icu +idn +libevent libressl mysql postgres selinux +sqlite +ssl test +zlib"
 REQUIRED_USE="
 	^^ ( icu idn )
 	${LUA_REQUIRED_USE}
 "
 RESTRICT="!test? ( test )"
 
-RDEPEND="
+DEPEND="
 	$(lua_gen_cond_dep 'dev-lua/luaexpat[${LUA_USEDEP}]')
 	$(lua_gen_cond_dep 'dev-lua/luafilesystem[${LUA_USEDEP}]')
 	$(lua_gen_cond_dep 'dev-lua/luasocket[${LUA_USEDEP}]')
@@ -41,7 +41,9 @@ RDEPEND="
 	${LUA_DEPS}
 "
 
-DEPEND="${RDEPEND}"
+RDEPEND="${DEPEND}
+	selinux? ( sec-policy/selinux-jabber )
+"
 
 BDEPEND="
 	virtual/pkgconfig

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -338,6 +338,10 @@ dev-python/oct2py doc
 # Unkeyworded deps, bug #511532
 net-im/prosody libevent mysql postgres sqlite
 
+# Jonathan Davies <jpds@protonmail.com> (2021-01-27)
+# No SELinux on ARM
+net-im/prosody selinux
+
 # Alexis Ballier <aballier@gentoo.org> (2014-10-24)
 # sci-libs/hdf is not supported on arm
 sci-libs/netcdf hdf


### PR DESCRIPTION
Simple dependency addition.