### PR TITLE
Cinnamon 4.8 follow-up fixes

### DIFF
--- a/app-accessibility/caribou/caribou-0.4.21-r3.ebuild
+++ b/app-accessibility/caribou/caribou-0.4.21-r3.ebuild
@@ -1,0 +1,96 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_REQ_USE="xml"
+
+inherit gnome.org gnome2-utils python-single-r1 vala
+
+DESCRIPTION="Input assistive technology intended for switch and pointer users"
+HOMEPAGE="https://wiki.gnome.org/Projects/Caribou"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+IUSE=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+
+COMMON_DEPEND="
+	${PYTHON_DEPS}
+	app-accessibility/at-spi2-core
+	$(python_gen_cond_dep '
+		>=dev-python/pygobject-2.90.3:3[${PYTHON_USEDEP}]
+	')
+	>=dev-libs/gobject-introspection-0.10.7:=
+	dev-libs/libgee:0.8
+	dev-libs/libxml2
+	>=media-libs/clutter-1.5.11:1.0[introspection]
+	>=x11-libs/gtk+-3:3[introspection]
+	x11-libs/libX11
+	x11-libs/libxklavier
+	x11-libs/libXtst
+"
+# gsettings-desktop-schemas is needed for the 'toolkit-accessibility' key
+# pyatspi-2.1.90 needed to run caribou if pygobject:3 is installed
+# librsvg needed to load svg images in css styles
+RDEPEND="
+	${COMMON_DEPEND}
+	dev-libs/glib[dbus]
+	$(python_gen_cond_dep '
+		>=dev-python/pyatspi-2.1.90[${PYTHON_USEDEP}]
+	')
+	>=gnome-base/gsettings-desktop-schemas-3
+	gnome-base/librsvg:2
+	sys-apps/dbus
+	!<x11-base/xorg-server-1.20.10
+"
+DEPEND="
+	${COMMON_DEPEND}
+	dev-libs/libxslt
+"
+BDEPEND="
+	$(vala_depend)
+	>=dev-util/intltool-0.35.5
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-fix-compilation-error.patch"
+	"${FILESDIR}/${PN}-fix-subkey-popmenu.patch"
+	"${FILESDIR}/${PN}-fix-xadapter-xkb-calls.patch"
+	"${FILESDIR}/${PN}-fix-antler-style-css.patch"
+	"${FILESDIR}/${PN}-fix-python-env.patch"
+)
+
+src_prepare() {
+	default
+	vala_src_prepare
+	gnome2_disable_deprecation_warning
+}
+
+src_configure() {
+	econf \
+		--disable-maintainer-mode \
+		--disable-schemas-compile \
+		--disable-docs \
+		--disable-static \
+		--disable-gtk2-module \
+		--enable-gtk3-module
+}
+
+src_install() {
+	DOCS="AUTHORS NEWS README"
+	default
+	find "${D}" -name '*.la' -delete || die
+	python_optimize
+}
+
+pkg_postinst() {
+	gnome2_schemas_update
+}
+
+pkg_postrm() {
+	gnome2_schemas_update
+}

--- a/app-accessibility/caribou/files/caribou-fix-python-env.patch
+++ b/app-accessibility/caribou/files/caribou-fix-python-env.patch
@@ -1,0 +1,58 @@
+--- a/bin/antler-keyboard.in
++++ b/bin/antler-keyboard.in
+@@ -18,24 +18,4 @@
+ # along with this program; if not, write to the Free Software Foundation,
+ # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+-script_dir="$(dirname "$(readlink -f ${0})")"
+-
+-prefix=@prefix@
+-exec_prefix=@exec_prefix@
+-datarootdir=@datarootdir@
+-
+-if [ $script_dir = "@libexecdir@" ]
+-then
+-  datadir="$(@PYTHON@ -c "from gi.repository import GLib; print(':'.join(GLib.get_system_data_dirs()))")"
+-  export PYTHONPATH="${prefix}/lib/python@PYTHON_VERSION@/site-packages:${prefix}/lib64/python@PYTHON_VERSION@/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+-  export GI_TYPELIB_PATH="@libdir@/girepository-1.0${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
+-  export LD_LIBRARY_PATH="@libdir@${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+-  export XDG_DATA_DIRS="@datadir@${datadir:+:$datadir}"
+-else
+-  export PYTHONPATH="$(dirname $script_dir)${PYTHONPATH:+:$PYTHONPATH}"
+-  export GI_TYPELIB_PATH="$(dirname $script_dir)/libcaribou${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
+-  export LD_LIBRARY_PATH="$(dirname $script_dir)/libcaribou/.libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+-  export ANTLER_THEME_PATH="$(dirname $script_dir)/data"
+-fi
+-
+-@PYTHON@ -m caribou.antler.main "$@"
++exec @PYTHON@ -m caribou.antler.main "$@"
+--- a/bin/caribou-preferences.in
++++ b/bin/caribou-preferences.in
+@@ -18,26 +18,7 @@
+ # along with this program; if not, write to the Free Software Foundation,
+ # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+-script_dir="$(dirname "$(readlink -f ${0})")"
+-
+-prefix=@prefix@
+-exec_prefix=@exec_prefix@
+-datarootdir=@datarootdir@
+-
+-if [ $script_dir = "@bindir@" ]
+-then
+-  datadir="$(@PYTHON@ -c "from gi.repository import GLib; print(':'.join(GLib.get_system_data_dirs()))")"
+-  export PYTHONPATH="@prefix@/lib/python@PYTHON_VERSION@/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+-  export GI_TYPELIB_PATH="@libdir@/girepository-1.0${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
+-  export LD_LIBRARY_PATH="@libdir@${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+-  export XDG_DATA_DIRS="@datadir@${datadir:+:$datadir}"
+-else
+-  export PYTHONPATH="$(dirname $script_dir)${PYTHONPATH:+:$PYTHONPATH}"
+-  export GI_TYPELIB_PATH="$(dirname $script_dir)/libcaribou${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
+-  export LD_LIBRARY_PATH="$(dirname $script_dir)/libcaribou/.lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+-fi
+-
+-@PYTHON@ -c "
++exec @PYTHON@ -c "
+ import signal
+ signal.signal(signal.SIGINT, signal.SIG_DFL)
+ 

--- a/gnome-extra/cinnamon-desktop/cinnamon-desktop-4.6.4.ebuild
+++ b/gnome-extra/cinnamon-desktop/cinnamon-desktop-4.6.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 PYTHON_COMPAT=( python3_{7,8} )
 
-inherit meson gnome2-utils python-any-r1 xdg
+inherit meson gnome2-utils python-any-r1
 
 DESCRIPTION="A collection of libraries and utilites used by Cinnamon"
 HOMEPAGE="https://projects.linuxmint.com/cinnamon/"
@@ -39,6 +39,11 @@ BDEPEND="${PYTHON_DEPS}
 	sys-devel/gettext
 	virtual/pkgconfig
 "
+
+src_prepare() {
+	default
+	python_fix_shebang install-scripts
+}
 
 pkg_postinst() {
 	gnome2_schemas_update

--- a/gnome-extra/cinnamon-desktop/cinnamon-desktop-4.8.1.ebuild
+++ b/gnome-extra/cinnamon-desktop/cinnamon-desktop-4.8.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit meson gnome2-utils python-any-r1 xdg
+inherit meson gnome2-utils python-any-r1
 
 DESCRIPTION="A collection of libraries and utilites used by Cinnamon"
 HOMEPAGE="https://projects.linuxmint.com/cinnamon/ https://github.com/linuxmint/cinnamon-desktop"
@@ -41,6 +41,11 @@ BDEPEND="
 	sys-devel/gettext
 	virtual/pkgconfig
 "
+
+src_prepare() {
+	default
+	python_fix_shebang install-scripts
+}
 
 pkg_postinst() {
 	gnome2_schemas_update

--- a/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-4.6.0.ebuild
+++ b/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-4.6.0.ebuild
@@ -34,6 +34,7 @@ COMMON_DEPEND="
 	xinerama? ( x11-libs/libXinerama )
 "
 RDEPEND="${COMMON_DEPEND}
+	>=app-accessibility/caribou-0.3
 	sys-apps/accountsservice[introspection]
 	$(python_gen_cond_dep '
 		dev-python/pygobject:3[${PYTHON_USEDEP}]
@@ -60,8 +61,8 @@ PATCHES=(
 )
 
 src_prepare() {
-	xdg_src_prepare
-	python_fix_shebang src
+	default
+	python_fix_shebang install-scripts src
 }
 
 src_configure() {

--- a/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-4.8.1.ebuild
+++ b/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-4.8.1.ebuild
@@ -34,6 +34,7 @@ COMMON_DEPEND="
 "
 RDEPEND="
 	${COMMON_DEPEND}
+	>=app-accessibility/caribou-0.3
 	sys-apps/accountsservice[introspection]
 	$(python_gen_cond_dep '
 		dev-python/psutil[${PYTHON_USEDEP}]
@@ -57,8 +58,8 @@ BDEPEND="
 "
 
 src_prepare() {
-	xdg_src_prepare
-	python_fix_shebang src
+	default
+	python_fix_shebang install-scripts src
 }
 
 src_configure() {

--- a/gnome-extra/cinnamon-session/cinnamon-session-4.6.2.ebuild
+++ b/gnome-extra/cinnamon-session/cinnamon-session-4.6.2.ebuild
@@ -2,7 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit meson gnome2-utils xdg
+
+PYTHON_COMPAT=( python3_{7,8} )
+
+inherit meson gnome2-utils python-any-r1 xdg-utils
 
 DESCRIPTION="Cinnamon session manager"
 HOMEPAGE="https://projects.linuxmint.com/cinnamon/"
@@ -39,12 +42,18 @@ RDEPEND="${COMMON_DEPEND}
 "
 DEPEND="${COMMON_DEPEND}"
 BDEPEND="
+	${PYTHON_DEPS}
 	>=dev-util/intltool-0.40.6
 	virtual/pkgconfig
 	doc? (
 		app-text/xmlto
 		dev-libs/libxslt )
 "
+
+src_prepare() {
+	default
+	python_fix_shebang data
+}
 
 src_configure() {
 	local emesonargs=(
@@ -56,11 +65,11 @@ src_configure() {
 }
 
 pkg_postinst() {
-	xdg_pkg_postinst
+	xdg_icon_cache_update
 	gnome2_schemas_update
 }
 
 pkg_postrm() {
-	xdg_pkg_postrm
+	xdg_icon_cache_update
 	gnome2_schemas_update
 }

--- a/gnome-extra/cinnamon-session/cinnamon-session-4.8.0.ebuild
+++ b/gnome-extra/cinnamon-session/cinnamon-session-4.8.0.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=7
 
-inherit meson gnome2-utils xdg
+PYTHON_COMPAT=( python3_{7,8,9} )
+
+inherit meson gnome2-utils python-any-r1 xdg-utils
 
 DESCRIPTION="Cinnamon session manager"
 HOMEPAGE="https://projects.linuxmint.com/cinnamon/ https://github.com/linuxmint/cinnamon-session"
@@ -40,6 +42,7 @@ RDEPEND="
 	>=gnome-extra/cinnamon-desktop-4.8
 "
 BDEPEND="
+	${PYTHON_DEPS}
 	>=dev-util/intltool-0.40.6
 	virtual/pkgconfig
 
@@ -47,6 +50,11 @@ BDEPEND="
 		app-text/xmlto
 		dev-libs/libxslt )
 "
+
+src_prepare() {
+	default
+	python_fix_shebang data
+}
 
 src_configure() {
 	local emesonargs=(
@@ -58,11 +66,11 @@ src_configure() {
 }
 
 pkg_postinst() {
-	xdg_pkg_postinst
+	xdg_icon_cache_update
 	gnome2_schemas_update
 }
 
 pkg_postrm() {
-	xdg_pkg_postrm
+	xdg_icon_cache_update
 	gnome2_schemas_update
 }

--- a/gnome-extra/cinnamon-settings-daemon/cinnamon-settings-daemon-4.8.5.ebuild
+++ b/gnome-extra/cinnamon-settings-daemon/cinnamon-settings-daemon-4.8.5.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=7
 
-inherit meson gnome2-utils xdg
+PYTHON_COMPAT=( python3_{7,8,9} )
+
+inherit meson gnome2-utils python-any-r1 xdg
 
 DESCRIPTION="Cinnamon's settings daemon"
 HOMEPAGE="https://projects.linuxmint.com/cinnamon/ https://github.com/linuxmint/cinnamon-settings-daemon"
@@ -56,6 +58,7 @@ DEPEND="
 	x11-base/xorg-proto
 "
 BDEPEND="
+	${PYTHON_DEPS}
 	dev-util/glib-utils
 	dev-util/gdbus-codegen
 	>=dev-util/intltool-0.37.1
@@ -67,6 +70,11 @@ PATCHES=(
 	# https://github.com/linuxmint/cinnamon-settings-daemon/pull/314
 	"${FILESDIR}/${PN}-4.8.5-build-fixes.patch"
 )
+
+src_prepare() {
+	default
+	python_fix_shebang install-scripts
+}
 
 src_configure() {
 	# gudev not optional on Linux platforms

--- a/gnome-extra/cjs/cjs-4.8.2.ebuild
+++ b/gnome-extra/cjs/cjs-4.8.2.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=7
 
-inherit meson pax-utils virtualx
+PYTHON_COMPAT=( python3_{7,8,9} )
+
+inherit meson pax-utils python-any-r1 virtualx
 
 DESCRIPTION="Linux Mint's fork of gjs for Cinnamon"
 HOMEPAGE="https://projects.linuxmint.com/cinnamon/ https://github.com/linuxmint/cjs"
@@ -33,8 +35,14 @@ DEPEND="
 	)
 "
 BDEPEND="
+	${PYTHON_DEPS}
 	virtual/pkgconfig
 "
+
+src_prepare() {
+	default
+	python_fix_shebang build
+}
 
 src_configure() {
 	local emesonargs=(

--- a/gnome-extra/nemo/nemo-4.6.5.ebuild
+++ b/gnome-extra/nemo/nemo-4.6.5.ebuild
@@ -57,9 +57,8 @@ BDEPEND="
 "
 
 src_prepare() {
-	xdg_environment_reset
 	default
-	python_fix_shebang files/usr/share/nemo/actions
+	python_fix_shebang files/usr/share/nemo/actions install-scripts
 }
 
 src_configure() {

--- a/gnome-extra/nemo/nemo-4.8.4.ebuild
+++ b/gnome-extra/nemo/nemo-4.8.4.ebuild
@@ -70,9 +70,8 @@ PATCHES=(
 )
 
 src_prepare() {
-	xdg_environment_reset
 	default
-	python_fix_shebang files/usr/share/nemo/actions
+	python_fix_shebang files/usr/share/nemo/actions install-scripts
 }
 
 src_configure() {

--- a/x11-libs/xapps/xapps-1.8.9.ebuild
+++ b/x11-libs/xapps/xapps-1.8.9.ebuild
@@ -45,9 +45,12 @@ BDEPEND="
 "
 
 src_prepare() {
-	xdg_environment_reset
 	vala_src_prepare
 	default
+
+	# Fix meson helpers
+	python_setup
+	python_fix_shebang meson-scripts schemas
 }
 
 src_configure() {

--- a/x11-libs/xapps/xapps-2.0.6.ebuild
+++ b/x11-libs/xapps/xapps-2.0.6.ebuild
@@ -47,12 +47,15 @@ BDEPEND="
 "
 
 src_prepare() {
-	xdg_environment_reset
 	vala_src_prepare
 	default
 
 	# don't install distro specific tools
 	sed -i "/subdir('scripts')/d" meson.build || die
+
+	# Fix meson helpers
+	python_setup
+	python_fix_shebang meson-scripts
 }
 
 src_configure() {

--- a/x11-wm/muffin/muffin-4.6.3.ebuild
+++ b/x11-wm/muffin/muffin-4.6.3.ebuild
@@ -59,7 +59,6 @@ BDEPEND="
 "
 
 src_prepare() {
-	xdg_environment_reset
 	default
 	eautoreconf
 	gnome2_disable_deprecation_warning

--- a/x11-wm/muffin/muffin-4.8.1.ebuild
+++ b/x11-wm/muffin/muffin-4.8.1.ebuild
@@ -62,7 +62,6 @@ BDEPEND="
 "
 
 src_prepare() {
-	xdg_environment_reset
 	default
 	eautoreconf
 	gnome2_disable_deprecation_warning


### PR DESCRIPTION
* It was mentioned in #18989 that `xdg_src_prepare`/`xdg_environment_reset` were not needed in EAPI-7.

* Add explicit Python dependencies and fix shebangs for packages that have meson scripts written in python.

* Clean-up the caribou ebuild:
  * Switch to EAPI-7.
  * Switch to python-single-r1. as it doesn't look like it is intending to be used as importable bindings.
  * Drop GTK-2 support.
  * Remove environment set-up from shell scripts. It seems completely unnecessary?