### PR TITLE
x11-terms/kitty: Fix broken patch for -9999

### DIFF
--- a/x11-terms/kitty/files/kitty-9999-flags.patch
+++ b/x11-terms/kitty/files/kitty-9999-flags.patch
@@ -1,0 +1,49 @@
+diff --git a/setup.py b/setup.py
+index ce5309ee..9cb59461 100755
+--- a/setup.py
++++ b/setup.py
+@@ -278,7 +278,7 @@ def init_env(
+         df += ' -Og'
+         float_conversion = '-Wfloat-conversion'
+     fortify_source = '-D_FORTIFY_SOURCE=2'
+-    optimize = df if debug or sanitize else '-O3'
++    optimize = ''
+     sanitize_args = get_sanitize_args(cc, ccver) if sanitize else set()
+     cppflags_ = os.environ.get(
+         'OVERRIDE_CPPFLAGS', '-D{}DEBUG'.format('' if debug else 'N'),
+@@ -289,7 +289,7 @@ def init_env(
+     cflags_ = os.environ.get(
+         'OVERRIDE_CFLAGS', (
+             '-Wextra {} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {}'
+-            ' -pedantic-errors -Werror {} {} -fwrapv {} {} -pipe {} -fvisibility=hidden {}'
++            ' -pedantic-errors {} {} -fwrapv {} {} {} -fvisibility=hidden {}'
+         ).format(
+             float_conversion,
+             '' if is_openbsd else '-std=c11',
+@@ -306,7 +306,7 @@ def init_env(
+     )
+     ldflags_ = os.environ.get(
+         'OVERRIDE_LDFLAGS',
+-        '-Wall ' + ' '.join(sanitize_args) + ('' if debug else ' -O3')
++        '-Wall ' + ' '.join(sanitize_args)
+     )
+     ldflags = shlex.split(ldflags_)
+     ldflags.append('-shared')
+@@ -764,7 +764,7 @@ def safe_makedirs(path: str) -> None:
+ 
+ 
+ def build_launcher(args: Options, launcher_dir: str = '.', bundle_type: str = 'source') -> None:
+-    cflags = '-Wall -Werror -fpie'.split()
++    cflags = '-Wall -fpie'.split()
+     cppflags = []
+     libs: List[str] = []
+     if args.profile or args.sanitize:
+@@ -776,8 +776,6 @@ def build_launcher(args: Options, launcher_dir: str = '.', bundle_type: str = 's
+             cflags.append('-g')
+         if args.profile:
+             libs.append('-lprofiler')
+-    else:
+-        cflags.append('-O3')
+     if bundle_type.endswith('-freeze'):
+         cppflags.append('-DFOR_BUNDLE')
+         cppflags.append('-DPYVER="{}"'.format(sysconfig.get_python_version()))

--- a/x11-terms/kitty/files/kitty-9999-remove-terminfo.patch
+++ b/x11-terms/kitty/files/kitty-9999-remove-terminfo.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index ce5309ee..02f38c61 100755
+--- a/setup.py
++++ b/setup.py
+@@ -1028,11 +1028,6 @@ def package(args: Options, bundle_type: str) -> None:
+     safe_makedirs(launcher_dir)
+     build_launcher(args, launcher_dir, bundle_type)
+     os.makedirs(os.path.join(libdir, 'logo'))
+-    build_terminfo = runpy.run_path('build-terminfo', run_name='import_build')  # type: ignore
+-    for x in (libdir, os.path.join(ddir, 'share')):
+-        odir = os.path.join(x, 'terminfo')
+-        safe_makedirs(odir)
+-        build_terminfo['compile_terminfo'](odir)
+     shutil.copy2('__main__.py', libdir)
+     shutil.copy2('logo/kitty-128.png', os.path.join(libdir, 'logo'))
+     shutil.copy2('logo/kitty.png', os.path.join(libdir, 'logo'))

--- a/x11-terms/kitty/kitty-9999.ebuild
+++ b/x11-terms/kitty/kitty-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -57,7 +57,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/kitty-0.17.2-flags.patch
-	"${FILESDIR}"/kitty-0.16.0-remove-terminfo.patch
+	"${FILESDIR}"/${P}-remove-terminfo.patch
 	"${FILESDIR}"/${PN}-0.14.4-svg-icon.patch
 )
 

--- a/x11-terms/kitty/kitty-9999.ebuild
+++ b/x11-terms/kitty/kitty-9999.ebuild
@@ -56,7 +56,7 @@ BDEPEND="virtual/pkgconfig"
 	$(python_gen_cond_dep '>=dev-python/sphinx-1.7[${PYTHON_MULTI_USEDEP}]')"
 
 PATCHES=(
-	"${FILESDIR}"/kitty-0.17.2-flags.patch
+	"${FILESDIR}"/${P}-flags.patch
 	"${FILESDIR}"/${P}-remove-terminfo.patch
 	"${FILESDIR}"/${PN}-0.14.4-svg-icon.patch
 )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/767457
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Matthias Coppens <coppens.matthias.abc@gmail.com>