### PR TITLE
media-libs/bcg729: remove unused patch(es)

### DIFF
--- a/media-libs/bcg729/files/bcg729-4.3.0_beta-cmake-build.patch
+++ b/media-libs/bcg729/files/bcg729-4.3.0_beta-cmake-build.patch
@@ -1,8 +1,0 @@
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -119,5 +119,3 @@
- 	DESTINATION ${CONFIG_PACKAGE_LOCATION}
- )
- 
--add_subdirectory(build)
--


### PR DESCRIPTION
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <m.mairkeimberger@gmail.com>