### PR TITLE
dev-db/mysql-init-scripts: /var/run to /run in tmpfiles.d

### DIFF
--- a/dev-db/mysql-init-scripts/files/mysql-v2.conf
+++ b/dev-db/mysql-init-scripts/files/mysql-v2.conf
@@ -1,0 +1,1 @@
+d /run/mysqld 0755 mysql mysql -

--- a/dev-db/mysql-init-scripts/mysql-init-scripts-2.3-r4.ebuild
+++ b/dev-db/mysql-init-scripts/mysql-init-scripts-2.3-r4.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit systemd s6 tmpfiles
+
+DESCRIPTION="Gentoo MySQL init scripts."
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+IUSE=""
+
+DEPEND=""
+# This _will_ break with MySQL 5.0, 4.x, 3.x
+# It also NEEDS openrc for the save_options/get_options builtins.
+# The s6 support was added after openrc 0.16.2
+# mysql-connector-c needed for my_print_defaults
+RDEPEND="
+	>=dev-db/mysql-5.1
+	>=sys-apps/openrc-0.16.2
+	dev-db/mysql-connector-c
+	!prefix? (
+		acct-group/mysql acct-user/mysql
+	)
+	"
+# Need to set S due to PMS saying we need it existing, but no SRC_URI
+S=${WORKDIR}
+
+src_install() {
+	newconfd "${FILESDIR}/conf.d-2.0" "mysql"
+
+	# s6 init scripts
+	if use amd64 || use x86 ; then
+		newconfd "${FILESDIR}/conf.d-2.0" "mysql-s6"
+		newinitd "${FILESDIR}/init.d-s6-2.3" "mysql-s6"
+		s6_install_service mysql "${FILESDIR}/run-s6"
+		s6_install_service mysql/log "${FILESDIR}/log-s6"
+	fi
+
+	newinitd "${FILESDIR}/init.d-2.3" "mysql"
+	newinitd "${FILESDIR}/init.d-supervise-2.3" "mysql-supervise"
+
+	# systemd unit installation
+	exeinto /usr/libexec
+	doexe "${FILESDIR}"/mysqld-wait-ready
+	systemd_newunit "${FILESDIR}/mysqld-v2.service" "mysqld.service"
+	systemd_newunit "${FILESDIR}/mysqld_at-v2.service" "mysqld@.service"
+	newtmpfiles "${FILESDIR}/mysql-v2.conf" "mysql.conf"
+
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}/logrotate.mysql-2.3" "mysql"
+}
+
+pkg_postinst() {
+	tmpfiles_process mysql.conf
+	if use amd64 || use x86 ; then
+		elog ""
+		elog "To use the mysql-s6 script, you need to install the optional sys-apps/s6 package."
+		elog "If you wish to use s6 logging support, comment out the log-error setting in your my.cnf"
+	fi
+
+	elog ""
+	elog "Starting with version 10.1.8, MariaDB includes an improved systemd unit named mariadb.service"
+	elog "You should prefer that unit over this package's mysqld.service."
+	einfo ""
+}


### PR DESCRIPTION
`dev-db/mysql-init-scripts`: `/var/run` to `/run` in `tmpfiles.d`

 - Modernize: `/var/run/` becomes `/run/` in `/usr/lib/tmpfiles.d/mysql.conf`
 - Drop `alpha` keyword, as mysql dropped it 2020/03/18
 - Fix outdated blocker deps

Closes: https://bugs.gentoo.org/768051
Closes: 19270
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Philippe Chaintreuil <gentoo_bugs_peep@parallaxshift.com>

---

Diffs for ease of reference: 
```diff
--- mysql-init-scripts-2.3-r3.ebuild    2021-01-25 10:19:04.014648088 -0500
+++ mysql-init-scripts-2.3-r4.ebuild    2021-01-31 08:18:21.644133810 -0500
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2

 EAPI=6
@@ -11,7 +11,7 @@

 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
 IUSE=""

 DEPEND=""
@@ -20,8 +20,8 @@
 # The s6 support was added after openrc 0.16.2
 # mysql-connector-c needed for my_print_defaults
 RDEPEND="
-       !<dev-db/mysql-5.1
-       !<sys-apps/openrc-0.16.2
+       >=dev-db/mysql-5.1
+       >=sys-apps/openrc-0.16.2
        dev-db/mysql-connector-c
        !prefix? (
                acct-group/mysql acct-user/mysql
@@ -49,7 +49,7 @@
        doexe "${FILESDIR}"/mysqld-wait-ready
        systemd_newunit "${FILESDIR}/mysqld-v2.service" "mysqld.service"
        systemd_newunit "${FILESDIR}/mysqld_at-v2.service" "mysqld@.service"
-       dotmpfiles "${FILESDIR}/mysql.conf"
+       newtmpfiles "${FILESDIR}/mysql-v2.conf" "mysql.conf"

        insinto /etc/logrotate.d
        newins "${FILESDIR}/logrotate.mysql-2.3" "mysql"
```

```diff
--- files/mysql.conf    2021-01-25 10:16:47.711737985 -0500
+++ files/mysql-v2.conf 2021-01-31 07:42:54.162438383 -0500
@@ -1 +1 @@
-d /var/run/mysqld 0755 mysql mysql -
+d /run/mysqld 0755 mysql mysql -
```
