### PR TITLE
sys-block/thin-provisioning-tools: add missing RDEPEND

### DIFF
--- a/sys-block/thin-provisioning-tools/thin-provisioning-tools-0.9.0.ebuild
+++ b/sys-block/thin-provisioning-tools/thin-provisioning-tools-0.9.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,7 +22,9 @@ IUSE="static test"
 RESTRICT="!test? ( test )"
 
 LIB_DEPEND="dev-libs/expat[static-libs(+)]
-	dev-libs/libaio[static-libs(+)]"
+	dev-libs/libaio[static-libs(+)]
+	dev-libs/boost:=[static-libs(+)]
+"
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )"
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )
@@ -36,7 +38,7 @@ DEPEND="${RDEPEND}
 		dev-util/cucumber
 		dev-util/aruba
 	)
-	dev-libs/boost"
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.7.0-build-fixes.patch

--- a/sys-block/thin-provisioning-tools/thin-provisioning-tools-9999.ebuild
+++ b/sys-block/thin-provisioning-tools/thin-provisioning-tools-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,7 +22,9 @@ IUSE="static test"
 RESTRICT="!test? ( test )"
 
 LIB_DEPEND="dev-libs/expat[static-libs(+)]
-	dev-libs/libaio[static-libs(+)]"
+	dev-libs/libaio[static-libs(+)]
+	dev-libs/boost:=[static-libs(+)]
+"
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )"
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )
@@ -36,7 +38,7 @@ DEPEND="${RDEPEND}
 		dev-util/cucumber
 		dev-util/aruba
 	)
-	dev-libs/boost"
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.7.0-build-fixes.patch


### PR DESCRIPTION
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>