### PR TITLE
media-tv/kodi: marked libcdio is required dependency

### DIFF
--- a/media-tv/kodi/kodi-19.0_rc1-r2.ebuild
+++ b/media-tv/kodi/kodi-19.0_rc1-r2.ebuild
@@ -39,7 +39,7 @@ SLOT="0"
 # use flag is called libusb so that it doesn't fool people in thinking that
 # it is _required_ for USB support. Otherwise they'll disable udev and
 # that's going to be worse.
-IUSE="airplay alsa bluetooth bluray caps cdio cec +css dav1d dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl power-control pulseaudio raspberry-pi samba +system-ffmpeg test udf udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
+IUSE="airplay alsa bluetooth bluray caps cec +css dav1d dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl power-control pulseaudio raspberry-pi samba +system-ffmpeg test udf udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
 IUSE="${IUSE} cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse3 cpu_flags_x86_sse4_1 cpu_flags_x86_sse4_2 cpu_flags_x86_avx cpu_flags_x86_avx2 cpu_flags_arm_neon"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -79,7 +79,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		dev-python/pillow[${PYTHON_MULTI_USEDEP}]
 		dev-python/pycryptodome[${PYTHON_MULTI_USEDEP}]
 	')
-	cdio? ( >=dev-libs/libcdio-2.1.0 )
+	>=dev-libs/libcdio-2.1.0
 	>=dev-libs/libfmt-6.1.2
 	dev-libs/libfstrcmp
 	gbm? (	media-libs/mesa[gbm] )
@@ -242,7 +242,7 @@ src_configure() {
 		-DENABLE_BLUETOOTH=$(usex bluetooth)
 		-DENABLE_BLURAY=$(usex bluray)
 		-DENABLE_CCACHE=OFF
-		-DENABLE_ISO9660PP=$(usex cdio)
+		-DENABLE_ISO9660PP=ON
 		-DENABLE_CEC=$(usex cec)
 		-DENABLE_DBUS=$(usex dbus)
 		-DENABLE_DVDCSS=$(usex css)

--- a/media-tv/kodi/kodi-19.9999.ebuild
+++ b/media-tv/kodi/kodi-19.9999.ebuild
@@ -39,7 +39,7 @@ SLOT="0"
 # use flag is called libusb so that it doesn't fool people in thinking that
 # it is _required_ for USB support. Otherwise they'll disable udev and
 # that's going to be worse.
-IUSE="airplay alsa bluetooth bluray caps cdio cec +css dav1d dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl power-control pulseaudio raspberry-pi samba +system-ffmpeg test udf udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
+IUSE="airplay alsa bluetooth bluray caps cec +css dav1d dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl power-control pulseaudio raspberry-pi samba +system-ffmpeg test udf udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
 IUSE="${IUSE} cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse3 cpu_flags_x86_sse4_1 cpu_flags_x86_sse4_2 cpu_flags_x86_avx cpu_flags_x86_avx2 cpu_flags_arm_neon"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -79,7 +79,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		dev-python/pillow[${PYTHON_MULTI_USEDEP}]
 		dev-python/pycryptodome[${PYTHON_MULTI_USEDEP}]
 	')
-	cdio? ( >=dev-libs/libcdio-2.1.0 )
+	>=dev-libs/libcdio-2.1.0
 	>=dev-libs/libfmt-6.1.2
 	dev-libs/libfstrcmp
 	gbm? (	media-libs/mesa[gbm] )
@@ -242,7 +242,7 @@ src_configure() {
 		-DENABLE_BLUETOOTH=$(usex bluetooth)
 		-DENABLE_BLURAY=$(usex bluray)
 		-DENABLE_CCACHE=OFF
-		-DENABLE_ISO9660PP=$(usex cdio)
+		-DENABLE_ISO9660PP=ON
 		-DENABLE_CEC=$(usex cec)
 		-DENABLE_DBUS=$(usex dbus)
 		-DENABLE_DVDCSS=$(usex css)

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -39,7 +39,7 @@ SLOT="0"
 # use flag is called libusb so that it doesn't fool people in thinking that
 # it is _required_ for USB support. Otherwise they'll disable udev and
 # that's going to be worse.
-IUSE="airplay alsa bluetooth bluray caps cdio cec +css dav1d dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl power-control pulseaudio raspberry-pi samba +system-ffmpeg test udf udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
+IUSE="airplay alsa bluetooth bluray caps cec +css dav1d dbus dvd gbm gles lcms libressl libusb lirc mariadb mysql nfs +opengl power-control pulseaudio raspberry-pi samba +system-ffmpeg test udf udev udisks upnp upower vaapi vdpau wayland webserver +X +xslt zeroconf"
 IUSE="${IUSE} cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse3 cpu_flags_x86_sse4_1 cpu_flags_x86_sse4_2 cpu_flags_x86_avx cpu_flags_x86_avx2 cpu_flags_arm_neon"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -79,7 +79,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		dev-python/pillow[${PYTHON_MULTI_USEDEP}]
 		dev-python/pycryptodome[${PYTHON_MULTI_USEDEP}]
 	')
-	cdio? ( >=dev-libs/libcdio-2.1.0 )
+	>=dev-libs/libcdio-2.1.0
 	>=dev-libs/libfmt-6.1.2
 	dev-libs/libfstrcmp
 	gbm? (	media-libs/mesa[gbm] )
@@ -242,7 +242,7 @@ src_configure() {
 		-DENABLE_BLUETOOTH=$(usex bluetooth)
 		-DENABLE_BLURAY=$(usex bluray)
 		-DENABLE_CCACHE=OFF
-		-DENABLE_ISO9660PP=$(usex cdio)
+		-DENABLE_ISO9660PP=ON
 		-DENABLE_CEC=$(usex cec)
 		-DENABLE_DBUS=$(usex dbus)
 		-DENABLE_DVDCSS=$(usex css)

--- a/media-tv/kodi/metadata.xml
+++ b/media-tv/kodi/metadata.xml
@@ -9,7 +9,6 @@
 		<flag name="airplay">enable AirPlay support</flag>
 		<flag name="bluray">Enable playback of Blu-ray filesystems</flag>
 		<flag name="caps">Use <pkg>sys-libs/libcap</pkg> to bind to privileged ports as non-root</flag>
-		<flag name="cdio">Enable reading of Audio-CD, Video-CD, and CD-ROM disks and images by <pkg>dev-libs/libcdio</pkg></flag>
 		<flag name="cec">Enable support for HDMI-CEC devices via libcec</flag>
 		<flag name="gbm">Use the Graphics Buffer Manager for EGL on KMS.</flag>
 		<flag name="gles">Enable support for GLES</flag>


### PR DESCRIPTION
Kodi build system ignores user settings for libcdio.
This reverts one of the recent Kodi ebuild commits.