### PR TITLE
media-libs/lsp-plugins: Add missing libglvnd[X] USE dependendency

### DIFF
--- a/media-libs/lsp-plugins/lsp-plugins-1.1.24.ebuild
+++ b/media-libs/lsp-plugins/lsp-plugins-1.1.24.ebuild
@@ -1,7 +1,9 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
+inherit xdg
 
 DESCRIPTION="Linux Studio Plugins"
 HOMEPAGE="https://lsp-plug.in"
@@ -25,7 +27,7 @@ REQUIRED_USE="|| ( jack ladspa lv2 )"
 DEPEND="
 	dev-libs/expat
 	media-libs/libsndfile
-	media-libs/libglvnd
+	media-libs/libglvnd[X]
 	doc? ( dev-lang/php:* )
 	jack? (
 		virtual/jack

--- a/media-libs/lsp-plugins/lsp-plugins-9999.ebuild
+++ b/media-libs/lsp-plugins/lsp-plugins-9999.ebuild
@@ -1,7 +1,9 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
+inherit xdg
 
 DESCRIPTION="Linux Studio Plugins"
 HOMEPAGE="https://lsp-plug.in"
@@ -25,7 +27,7 @@ REQUIRED_USE="|| ( jack ladspa lv2 )"
 DEPEND="
 	dev-libs/expat
 	media-libs/libsndfile
-	media-libs/libglvnd
+	media-libs/libglvnd[X]
 	doc? ( dev-lang/php:* )
 	jack? (
 		virtual/jack


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/737536

Signed-off-by: Simon van der Veldt <simon.vanderveldt+gentoo@gmail.com>