### PR TITLE
media-sound/qjackctl: Switch to cmake, add missing DEPEND and RDEPEND

### DIFF
--- a/media-sound/qjackctl/qjackctl-9999.ebuild
+++ b/media-sound/qjackctl/qjackctl-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit flag-o-matic qmake-utils autotools git-r3 xdg
+inherit xdg cmake git-r3
 
 DESCRIPTION="Qt GUI to control the JACK Audio Connection Kit and ALSA sequencer connections"
 HOMEPAGE="https://qjackctl.sourceforge.io/"
@@ -15,44 +15,29 @@ KEYWORDS=""
 IUSE="alsa dbus debug portaudio"
 
 BDEPEND="dev-qt/linguist-tools:5"
-RDEPEND="
-	app-arch/gzip
+DEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
 	virtual/jack
 	alsa? ( media-libs/alsa-lib )
 	dbus? ( dev-qt/qtdbus:5 )
-	portaudio? ( media-libs/portaudio )"
-DEPEND="${RDEPEND}"
-
-src_prepare() {
-	default
-	eautoreconf
-}
+	portaudio? ( media-libs/portaudio )
+"
+RDEPEND="${DEPEND}
+	dev-qt/qtsvg:5
+"
 
 src_configure() {
-	append-cxxflags -std=c++11
-	local myeconfargs=(
-		$(use_enable alsa alsa-seq)
-		$(use_enable dbus)
-		$(use_enable debug)
-		$(use_enable portaudio)
-		--enable-jack-version
+	local mycmakeargs=(
+		-DCONFIG_ALSA_SEQ=$(usex alsa 1 0)
+		-DCONFIG_DBUS=$(usex dbus 1 0)
+		-DCONFIG_DEBUG=$(usex debug 1 0)
+		-DCONFIG_PORTAUDIO=$(usex portaudio 1 0)
+		-DCONFIG_JACK_VERSION=1
 	)
-	econf "${myeconfargs[@]}"
-	eqmake5 ${PN}.pro -o ${PN}.mak
-}
-
-src_compile() {
-	emake -f ${PN}.mak
-}
-
-src_install() {
-	default
-
-	gunzip "${D}/usr/share/man/man1/qjackctl.1.gz" || die
-	gunzip "${D}/usr/share/man/fr/man1/qjackctl.1.gz" || die
+	cmake_src_configure
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/766300