### PR TITLE
media-tv/kodi: fix build with libcdio[-cxx]

### DIFF
--- a/media-tv/kodi/kodi-19.0_rc1-r2.ebuild
+++ b/media-tv/kodi/kodi-19.0_rc1-r2.ebuild
@@ -79,7 +79,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		dev-python/pillow[${PYTHON_MULTI_USEDEP}]
 		dev-python/pycryptodome[${PYTHON_MULTI_USEDEP}]
 	')
-	>=dev-libs/libcdio-2.1.0
+	>=dev-libs/libcdio-2.1.0[cxx]
 	>=dev-libs/libfmt-6.1.2
 	dev-libs/libfstrcmp
 	gbm? (	media-libs/mesa[gbm] )

--- a/media-tv/kodi/kodi-19.9999.ebuild
+++ b/media-tv/kodi/kodi-19.9999.ebuild
@@ -79,7 +79,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		dev-python/pillow[${PYTHON_MULTI_USEDEP}]
 		dev-python/pycryptodome[${PYTHON_MULTI_USEDEP}]
 	')
-	>=dev-libs/libcdio-2.1.0
+	>=dev-libs/libcdio-2.1.0[cxx]
 	>=dev-libs/libfmt-6.1.2
 	dev-libs/libfstrcmp
 	gbm? (	media-libs/mesa[gbm] )

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -79,7 +79,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		dev-python/pillow[${PYTHON_MULTI_USEDEP}]
 		dev-python/pycryptodome[${PYTHON_MULTI_USEDEP}]
 	')
-	>=dev-libs/libcdio-2.1.0
+	>=dev-libs/libcdio-2.1.0[cxx]
 	>=dev-libs/libfmt-6.1.2
 	dev-libs/libfstrcmp
 	gbm? (	media-libs/mesa[gbm] )


### PR DESCRIPTION
When building Kodi with ISO9660PP support, then it requires
libiso9660++.so to be installed. This library is provided by
dev-libs/libcdio, but only when building with C++ libraries. We thus
need to depend on libcdio[cxx] to not fail the build.

Signed-off-by: Patrick Steinhardt <ps@pks.im>