### PR TITLE
sys-devec/bc: fix building with locked account

### DIFF
--- a/sys-devel/bc/files/bc-1.07.1-no-ed-its-sed.patch
+++ b/sys-devel/bc/files/bc-1.07.1-no-ed-its-sed.patch
@@ -6,8 +6,9 @@ to use sed instead of ed.  the changes are straight forward:
 
 --- a/bc/fix-libmath_h
 +++ b/bc/fix-libmath_h
-@@ -1,9 +1,6 @@
+@@ -1,9 +1,7 @@
 -ed libmath.h <<EOS-EOS
++#!/bin/sh
 +sed -i libmath.h -e '
  1,1s/^/{"/
 -1,\$s/\$/",/


### PR DESCRIPTION
The build of bc fails when building it with a user whose shell is set to
`/sbin/nologin`. The root cause is that the "fix-libmath_h" script does
not have a shebang, so it'll instead just use the user's configured
shell.

Fix this issue by patching the script to have a shebang.

Signed-off-by: Patrick Steinhardt <ps@pks.im>