### PR TITLE
eclass/xdg{,-utils}: fix RDEPENDS

### DIFF
--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -22,6 +22,15 @@ case "${EAPI:-0}" in
 	*) die "EAPI=${EAPI} is not supported" ;;
 esac
 
+# Avoid dependency loop as both depend on glib-2
+if [[ ${CATEGORY}/${P} != dev-libs/glib-2.* ]] ; then
+RDEPEND="
+	dev-util/desktop-file-utils
+	dev-util/gtk-update-icon-cache
+	x11-misc/shared-mime-info
+"
+fi
+
 # @ECLASS-VARIABLE: DESKTOP_DATABASE_DIR
 # @INTERNAL
 # @DESCRIPTION:

--- a/eclass/xdg.eclass
+++ b/eclass/xdg.eclass
@@ -21,14 +21,6 @@ case "${EAPI:-0}" in
 	*) die "EAPI=${EAPI} is not supported" ;;
 esac
 
-# Avoid dependency loop as both depend on glib-2
-if [[ ${CATEGORY}/${P} != dev-libs/glib-2.* ]] ; then
-DEPEND="
-	dev-util/desktop-file-utils
-	x11-misc/shared-mime-info
-"
-fi
-
 # @FUNCTION: xdg_src_prepare
 # @DESCRIPTION:
 # Prepare sources to work with XDG standards.


### PR DESCRIPTION
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>

---

The dependencies should be RDEPENDs and are needed in the proper eclass `xdg-utils`, which `xdg` inherits.