### PR TITLE
gui-libs/display-manager-init: start after elogind

### DIFF
--- a/gui-libs/display-manager-init/display-manager-init-1.0-r1.ebuild
+++ b/gui-libs/display-manager-init/display-manager-init-1.0-r1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 
 src_install() {
 	newinitd "${FILESDIR}"/display-manager-setup.initd display-manager-setup
-	newinitd "${FILESDIR}"/display-manager.initd display-manager
+	newinitd "${FILESDIR}"/display-manager.initd-r1 display-manager
 	newinitd "${FILESDIR}"/xdm.initd xdm
 	newconfd "${FILESDIR}"/display-manager.confd display-manager
 	exeinto /usr/bin

--- a/gui-libs/display-manager-init/files/display-manager.initd-r1
+++ b/gui-libs/display-manager-init/files/display-manager.initd-r1
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License, v2
 
 # This is here to serve as a note to myself, and future developers.
@@ -46,9 +46,11 @@ depend() {
 	# (#291269) Start after quota, since some dm need readable home
 	# (#390609) gdm-3 will fail when dbus is not running
 	# (#366753) starting keymaps after X causes problems
+	# (#768834) race condition with elogind
 	after bootmisc consolefont modules netmount
 	after readahead-list ypbind autofs openvpn gpm lircmd
 	after quota keymaps
+	after elogind
 	before alsasound
 
 	# Start before GUI


### PR DESCRIPTION
fixes race condition with elogind
Closes: https://bugs.gentoo.org/768834
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>