### PR TITLE
dev-util/cgvg, media-gfx/converseen, x11-wm/fvwm, app-text/groonga, app-misc/hivex, app-emulation/libguestfs: use HTTPS, fix LICENSE

### DIFF
--- a/app-emulation/libguestfs/libguestfs-1.36.13-r2.ebuild
+++ b/app-emulation/libguestfs/libguestfs-1.36.13-r2.ebuild
@@ -10,8 +10,8 @@ MY_PV_2="$(get_version_component_range 2)"
 [[ $(( $(get_version_component_range 2) % 2 )) -eq 0 ]] && SD="stable" || SD="development"
 
 DESCRIPTION="Tools for accessing, inspect  and modifying virtual machine (VM) disk images"
-HOMEPAGE="http://libguestfs.org/"
-SRC_URI="http://libguestfs.org/download/${MY_PV_1}-${SD}/${P}.tar.gz"
+HOMEPAGE="https://libguestfs.org/"
+SRC_URI="https://libguestfs.org/download/${MY_PV_1}-${SD}/${P}.tar.gz"
 
 LICENSE="GPL-2 LGPL-2"
 SLOT="0/"${MY_PV_1}""

--- a/app-emulation/libguestfs/libguestfs-1.36.15-r2.ebuild
+++ b/app-emulation/libguestfs/libguestfs-1.36.15-r2.ebuild
@@ -10,8 +10,8 @@ MY_PV_2="$(ver_cut 2)"
 [[ $(( ${MY_PV_2} % 2 )) -eq 0 ]] && SD="stable" || SD="development"
 
 DESCRIPTION="Tools for accessing, inspect  and modifying virtual machine (VM) disk images"
-HOMEPAGE="http://libguestfs.org/"
-SRC_URI="http://libguestfs.org/download/${MY_PV_1}-${SD}/${P}.tar.gz"
+HOMEPAGE="https://libguestfs.org/"
+SRC_URI="https://libguestfs.org/download/${MY_PV_1}-${SD}/${P}.tar.gz"
 
 LICENSE="GPL-2 LGPL-2"
 SLOT="0/"${MY_PV_1}""

--- a/app-emulation/libguestfs/libguestfs-1.38.6-r1.ebuild
+++ b/app-emulation/libguestfs/libguestfs-1.38.6-r1.ebuild
@@ -10,8 +10,8 @@ MY_PV_2="$(ver_cut 2)"
 [[ $(( ${MY_PV_2} % 2 )) -eq 0 ]] && SD="stable" || SD="development"
 
 DESCRIPTION="Tools for accessing, inspect  and modifying virtual machine (VM) disk images"
-HOMEPAGE="http://libguestfs.org/"
-SRC_URI="http://libguestfs.org/download/${MY_PV_1}-${SD}/${P}.tar.gz"
+HOMEPAGE="https://libguestfs.org/"
+SRC_URI="https://libguestfs.org/download/${MY_PV_1}-${SD}/${P}.tar.gz"
 
 LICENSE="GPL-2 LGPL-2"
 SLOT="0/"${MY_PV_1}""

--- a/app-misc/hivex/hivex-1.3.18.ebuild
+++ b/app-misc/hivex/hivex-1.3.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,8 +11,8 @@ PYTHON_COMPAT=( python3_{7,8} )
 inherit eutils perl-module ruby-ng python-single-r1
 
 DESCRIPTION="Library for reading and writing Windows Registry 'hive' binary files"
-HOMEPAGE="http://libguestfs.org"
-SRC_URI="http://libguestfs.org/download/${PN}/${P}.tar.gz"
+HOMEPAGE="https://libguestfs.org"
+SRC_URI="https://libguestfs.org/download/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/app-text/groonga/groonga-6.1.2.ebuild
+++ b/app-text/groonga/groonga-6.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit eutils libtool ltprune user
 
 DESCRIPTION="An Embeddable Fulltext Search Engine"
-HOMEPAGE="http://groonga.org/"
-SRC_URI="http://packages.groonga.org/source/${PN}/${P}.tar.gz"
+HOMEPAGE="https://groonga.org/"
+SRC_URI="https://packages.groonga.org/source/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"

--- a/dev-util/cgvg/cgvg-1.6.3.ebuild
+++ b/dev-util/cgvg/cgvg-1.6.3.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Minimal command-line source browsing tool similar to cscope"
-HOMEPAGE="http://uzix.org/cgvg.html"
-SRC_URI="http://uzix.org/cgvg/${P}.tar.gz"
+HOMEPAGE="https://uzix.org/cgvg.html"
+SRC_URI="https://uzix.org/cgvg/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~m68k ~mips ppc ppc64 s390 sparc x86"
 

--- a/media-gfx/converseen/converseen-0.9.6.2.ebuild
+++ b/media-gfx/converseen/converseen-0.9.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,10 +6,11 @@ EAPI=6
 inherit cmake-utils
 
 DESCRIPTION="Batch image converter and resizer based on ImageMagick"
-HOMEPAGE="http://converseen.fasterland.net/"
+HOMEPAGE="https://converseen.fasterland.net/
+	https://github.com/Faster3ck/Converseen/"
 SRC_URI="https://github.com/Faster3ck/Converseen/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="debug"

--- a/x11-wm/fvwm/fvwm-2.6.8-r2.ebuild
+++ b/x11-wm/fvwm/fvwm-2.6.8-r2.ebuild
@@ -1,14 +1,14 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit autotools flag-o-matic desktop
 
 DESCRIPTION="An extremely powerful ICCCM-compliant multiple virtual desktop window manager"
-HOMEPAGE="http://www.fvwm.org/"
+HOMEPAGE="https://www.fvwm.org/"
 SRC_URI="https://github.com/fvwmorg/fvwm/releases/download/${PV}/${P}.tar.gz"
 
-LICENSE="GPL-2 FVWM"
+LICENSE="GPL-2+ FVWM"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="bidi debug doc netpbm nls perl png readline rplay stroke svg tk truetype +vanilla xinerama lock"

--- a/x11-wm/fvwm/fvwm-2.6.9.ebuild
+++ b/x11-wm/fvwm/fvwm-2.6.9.ebuild
@@ -1,14 +1,14 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit autotools flag-o-matic desktop
 
 DESCRIPTION="An extremely powerful ICCCM-compliant multiple virtual desktop window manager"
-HOMEPAGE="http://www.fvwm.org/"
+HOMEPAGE="https://www.fvwm.org/"
 SRC_URI="https://github.com/fvwmorg/fvwm/releases/download/${PV}/${P}.tar.gz"
 
-LICENSE="GPL-2 FVWM"
+LICENSE="GPL-2+ FVWM"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~arm ~ia64 ppc ~ppc64 ~sparc x86"
 IUSE="bidi debug doc netpbm nls perl png readline rplay stroke svg tk truetype +vanilla xinerama lock"


### PR DESCRIPTION
Hi,

This PR updates the HOMEPAGE to use HTTPs and fixes the LICENSEs for some maintainer-needed packages.
Please review.