### PR TITLE
net-misc/dropbox-cli: add 3.9 to PYTHON_COMPAT

### DIFF
--- a/dev-python/pygpgme/pygpgme-0.3-r3.ebuild
+++ b/dev-python/pygpgme/pygpgme-0.3-r3.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7..9} )
+
+inherit distutils-r1 flag-o-matic
+
+DESCRIPTION="A Python wrapper for the GPGME library"
+HOMEPAGE="https://launchpad.net/pygpgme"
+SRC_URI="https://launchpad.net/${PN}/trunk/${PV}/+download/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="amd64 arm64 x86"
+IUSE=""
+
+DEPEND="app-crypt/gpgme"
+RDEPEND="${DEPEND}"
+
+python_configure_all() {
+	append-cflags $(gpgme-config --cflags)
+}

--- a/net-misc/dropbox-cli/dropbox-cli-2020.03.04-r1.ebuild
+++ b/net-misc/dropbox-cli/dropbox-cli-2020.03.04-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7..9} )
+
+inherit python-r1 bash-completion-r1
+
+DESCRIPTION="Cli interface for dropbox (python), part of nautilus-dropbox"
+HOMEPAGE="https://www.dropbox.com/"
+SRC_URI="https://dev.gentoo.org/~grozin/${P}.py.xz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 x86"
+IUSE=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="net-misc/dropbox
+	${PYTHON_DEPS}
+	dev-python/pygpgme[${PYTHON_USEDEP}]
+	dev-python/pygobject:3[${PYTHON_USEDEP}]"
+
+S=${WORKDIR}
+
+src_install() {
+	newbin ${P}.py ${PN}
+	python_replicate_script "${D}"/usr/bin/${PN}
+	newbashcomp "${FILESDIR}"/${PN}-19-completion ${PN}
+}


### PR DESCRIPTION
Signed-off-by: Andrés Becerra <andres.becerra@gmail.com>
Tested-by: Andrés Becerra <andres.becerra@gmail.com>
Bug: https://bugs.gentoo.org/769206
First commit adds 3.9 to pygpgme
Second commit adds 3.9 to dropbox-cli