### PR TITLE
app-text/cmark: fix tests (#767850)

### DIFF
--- a/app-text/cmark/cmark-0.29.0.ebuild
+++ b/app-text/cmark/cmark-0.29.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,6 +18,10 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 DEPEND="test? ( ${PYTHON_DEPS} )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-python38_tests.patch"
+)
 
 pkg_setup() {
 	use test && python-any-r1_pkg_setup

--- a/app-text/cmark/files/cmark-0.29.0-python38_tests.patch
+++ b/app-text/cmark/files/cmark-0.29.0-python38_tests.patch
@@ -1,0 +1,31 @@
+From 92697d564042d5b914048e087e4274c3c71e0055 Mon Sep 17 00:00:00 2001
+From: Christopher Fujino <christopherfujino@gmail.com>
+Date: Sun, 12 Jul 2020 16:11:42 -0700
+Subject: [PATCH] replace cgi.escape with html.escape (#656)
+
+---
+ test/normalize.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/normalize.py b/test/normalize.py
+index 6073bf01..f8ece18d 100644
+--- a/test/normalize.py
++++ b/test/normalize.py
+@@ -13,7 +13,7 @@ class HTMLParseError(Exception):
+ from html.entities import name2codepoint
+ import sys
+ import re
+-import cgi
++import html
+ 
+ # Normalization code, adapted from
+ # https://github.com/karlcow/markdown-testsuite/
+@@ -66,7 +66,7 @@ def handle_starttag(self, tag, attrs):
+                     self.output += ("=" + '"' +
+                             urllib.quote(urllib.unquote(v), safe='/') + '"')
+                 elif v != None:
+-                    self.output += ("=" + '"' + cgi.escape(v,quote=True) + '"')
++                    self.output += ("=" + '"' + html.escape(v,quote=True) + '"')
+         self.output += ">"
+         self.last_tag = tag
+         self.last = "starttag"


### PR DESCRIPTION
Fix tests runs with Python 3.8.
Closes: https://bugs.gentoo.org/767850
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>