### PR TITLE
games-fps/gzdoom: Drop optional gtk2 support

### DIFF
--- a/games-fps/gzdoom/gzdoom-4.5.0.ebuild
+++ b/games-fps/gzdoom/gzdoom-4.5.0.ebuild
@@ -14,7 +14,7 @@ LICENSE="Apache-2.0 BSD BZIP2 GPL-3 LGPL-2.1+ LGPL-3 MIT
 	non-free? ( Activision ChexQuest3 DOOM-COLLECTORS-EDITION freedist WidePix )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="debug gtk gtk2 +non-free openmp"
+IUSE="debug gtk +non-free openmp"
 
 DEPEND="
 	app-arch/bzip2
@@ -23,10 +23,7 @@ DEPEND="
 	media-libs/zmusic
 	sys-libs/zlib
 	virtual/jpeg:0
-	gtk? (
-		gtk2? ( x11-libs/gtk+:2 )
-		!gtk2? ( x11-libs/gtk+:3 )
-	)"
+	gtk? ( x11-libs/gtk+:3 )"
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}-g${PV}"

--- a/games-fps/gzdoom/metadata.xml
+++ b/games-fps/gzdoom/metadata.xml
@@ -14,7 +14,6 @@
 		<name>Gentoo Games Project</name>
 	</maintainer>
 	<use>
-		<flag name="gtk2">Enable support for GTK+2 instead of GTK+3</flag>
 		<flag name="non-free">Enable non-free components</flag>
 	</use>
 	<upstream>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/769071
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>