### PR TITLE
dev-util/goland: Fix desktop entry name typo

### DIFF
--- a/dev-util/goland/goland-2020.3.ebuild
+++ b/dev-util/goland/goland-2020.3.ebuild
@@ -55,7 +55,7 @@ src_install() {
 
 	make_wrapper "${PN}" "${dir}/bin/${PN}.sh"
 	newicon "bin/${PN}.png" "${PN}.png"
-	make_desktop_entry "${PN}" "gogland" "${PN}" "Development;IDE;"
+	make_desktop_entry "${PN}" "goland" "${PN}" "Development;IDE;"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Previously, the desktop entry being create was entitled "gogland", which is a typo (Should be "goland"), and is fixed with this PR.