### PR TITLE
x11-misc/py3status: add minimal USE flag

### DIFF
--- a/x11-misc/py3status/metadata.xml
+++ b/x11-misc/py3status/metadata.xml
@@ -11,6 +11,7 @@
 	</upstream>
 	<use>
 		<flag name="gevent">Install extra requirement <pkg>dev-python/gevent</pkg> to enable green threads.</flag>
+		<flag name="minimal">Don't depend on <pkg>x11-misc/i3status</pkg> if you don't plan to use any of its built-in modules.</flag>
 		<flag name="udev">Install extra requirement <pkg>dev-python/pyudev</pkg> to enable udev events monitoring on modules.</flag>
 	</use>
 </pkgmetadata>

--- a/x11-misc/py3status/py3status-3.33-r1.ebuild
+++ b/x11-misc/py3status/py3status-3.33-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python{3_7,3_8} )
+
+SRC_URI="https://github.com/ultrabug/py3status/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+inherit distutils-r1
+
+MY_PN="py3status"
+MY_P="${MY_PN}-${PV/_/-}"
+
+DESCRIPTION="py3status is an extensible i3status wrapper written in python"
+HOMEPAGE="https://github.com/ultrabug/py3status"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="gevent minimal +udev"
+
+RDEPEND="
+	!minimal? ( x11-misc/i3status )
+	gevent? ( >=dev-python/gevent-1.2.0[${PYTHON_USEDEP}] )
+	udev? ( >=dev-python/pyudev-0.21.0[${PYTHON_USEDEP}] )
+"
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]"
+
+S=${WORKDIR}/${MY_P}


### PR DESCRIPTION
This PR is an attempt to add a new `minimal` USE flag to the x11-misc/py3status ebuild that prevents pulling in x11-misc/i3status as a dependency.

### Context

I've recently ran into a use case where I ended up migrating my config to use only py3status modules, and at that point, I realized I don't necessariliy need i3status itself anymore. So I've patched the ebuild in my overlay, and by now I'm using py3status for about 2 months without i3status without any issues. In hopes of this being useful for more than just myself, I've decided to propose this change for the official tree as well.

Please review and merge, or let me know how to further improve it.