### PR TITLE
media-sound/qjackctl: fix cmake flags

### DIFF
--- a/media-sound/qjackctl/qjackctl-0.9.1.ebuild
+++ b/media-sound/qjackctl/qjackctl-0.9.1.ebuild
@@ -41,7 +41,6 @@ src_configure() {
 		-DCONFIG_DBUS=$(usex dbus 1 0)
 		-DCONFIG_DEBUG=$(usex debug 1 0)
 		-DCONFIG_PORTAUDIO=$(usex portaudio 1 0)
-		-DCONFIG_JACK_VERSION=1
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
Remove passing of CONFIG_JACK_VERSION to enable switching
between virtual/jack slots.

Closes: https://bugs.gentoo.org/769563
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>