### PR TITLE
dev-libs/tvision: fix linker flags

### DIFF
--- a/dev-libs/tvision/files/tvision-2.2.1.4-Gentoo-specific-fix-linker-paths.patch
+++ b/dev-libs/tvision/files/tvision-2.2.1.4-Gentoo-specific-fix-linker-paths.patch
@@ -1,0 +1,33 @@
+From 62fce1e63e92ae71e2ce061c40ba736f4b22f71d Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Mon, 8 Feb 2021 23:43:47 +0100
+Subject: [PATCH] [Gentoo-specific] fix linker paths
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ config.pl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/config.pl b/config.pl
+index 4664baa..9e2cb96 100644
+--- a/config.pl
++++ b/config.pl
+@@ -179,13 +179,13 @@ if ($OS eq 'UNIX')
+    # QNX 6.2 beta 3 workaround
+    $MakeDefsRHIDE[3].='/lib ' if ($OSf eq 'QNXRtP');
+    # Link with installed libraries
+-   $MakeDefsRHIDE[3].=$realPrefix.'/lib';
++   #$MakeDefsRHIDE[3].=$realPrefix.'/lib';
+    $MakeDefsRHIDE[3].='/'.$conf{'libs-subdir'} if $conf{'libs-subdir'};
+    $MakeDefsRHIDE[3].=' ';
+    $MakeDefsRHIDE[3].='../../makes ' unless $conf{'libs-here'} eq 'no';
+    $MakeDefsRHIDE[3].=$here.'/makes ' unless $conf{'libs-here'} eq 'no';
+    $MakeDefsRHIDE[3].='../../intl/dummy ' if $UseDummyIntl;
+-   $MakeDefsRHIDE[3].=$conf{'X11LibPath'}.' ' if ($conf{'HAVE_X11'} eq 'yes');
++   #$MakeDefsRHIDE[3].=$conf{'X11LibPath'}.' ' if ($conf{'HAVE_X11'} eq 'yes');
+    $MakeDefsRHIDE[3].=$AllegroPath.' ' if $conf{'HAVE_ALLEGRO'} eq 'yes';
+   }
+ elsif ($OS eq 'DOS')
+-- 
+2.30.0
+

--- a/dev-libs/tvision/metadata.xml
+++ b/dev-libs/tvision/metadata.xml
@@ -10,11 +10,11 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag restrict="&gt;dev-libs/tvision-2.2.1-r4" name="gpm">
+		<flag name="gpm">
 			Support text mode mouse through <pkg>sys-libs/gpm</pkg>
 		</flag>
 	</use>
 	<upstream>
-		<remote-id type="sourceforge">tvision</remote-id>
+		<remote-id type="github">set-soft/tvision</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-libs/tvision/tvision-2.2.1.4.ebuild
+++ b/dev-libs/tvision/tvision-2.2.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -45,6 +45,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-gcc6.patch"
 	"${FILESDIR}/${P}-flags.patch"
 	"${FILESDIR}/${P}-fix-overloaded-abs.patch"
+	"${FILESDIR}/${P}-Gentoo-specific-fix-linker-paths.patch"
 )
 
 src_configure() {
@@ -62,7 +63,6 @@ src_install() {
 		libdir="\$(prefix)/$(get_libdir)"
 
 	einstalldocs
-	dosym rhtvision /usr/include/tvision
 
 	# remove CVS directory which gets copied over
 	rm -r "${ED}/usr/share/doc/${P}/html/CVS" || die


### PR DESCRIPTION
Enables linking with LLD

Closes: https://bugs.gentoo.org/737202
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>