### PR TITLE
gui-libs/wlroots: Wayland dependency version bump

### DIFF
--- a/gui-libs/wlroots/wlroots-9999.ebuild
+++ b/gui-libs/wlroots/wlroots-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -23,7 +23,7 @@ REQUIRED_USE="?? ( elogind systemd )"
 
 DEPEND="
 	>=dev-libs/libinput-1.9.0:0=
-	>=dev-libs/wayland-1.18.0
+	>=dev-libs/wayland-1.19
 	>=dev-libs/wayland-protocols-1.17.0
 	media-libs/mesa[egl,gles2,gbm]
 	virtual/libudev


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/769776
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Matthias Coppens <coppens.matthias.abc@gmail.com>