### PR TITLE
x11-plugins/purple-facebook: add patch to fix recent ERROR_QUEUE_UNDE…

### DIFF
--- a/x11-plugins/purple-facebook/files/purple-facebook-20190113-bump-fb_orca_agent_version.patch
+++ b/x11-plugins/purple-facebook/files/purple-facebook-20190113-bump-fb_orca_agent_version.patch
@@ -1,0 +1,11 @@
+--- a/pidgin/libpurple/protocols/facebook/api.h	2019-01-13 15:19:45.000000000 +0100
++++ b/pidgin/libpurple/protocols/facebook/api.h	2021-02-09 19:26:42.571155515 +0100
+@@ -104,7 +104,7 @@
+  * server started checking this.
+  */
+ 
+-#define FB_ORCA_AGENT "[FBAN/Orca-Android;FBAV/192.0.0.31.101;FBPN/com.facebook.orca;FBLC/en_US;FBBV/52182662]"
++#define FB_ORCA_AGENT "[FBAN/Orca-Android;FBAV/537.0.0.31.101;FBPN/com.facebook.orca;FBLC/en_US;FBBV/52182662]"
+ 
+ /**
+  * FB_API_AGENT:

--- a/x11-plugins/purple-facebook/purple-facebook-20190113-r1.ebuild
+++ b/x11-plugins/purple-facebook/purple-facebook-20190113-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+MY_PV="0.9.6"
+S="${WORKDIR}/${PN}-${MY_PV}"
+DESCRIPTION="Facebook protocol plugin for libpurple"
+HOMEPAGE="https://github.com/dequis/purple-facebook"
+SRC_URI="https://github.com/dequis/${PN}/releases/download/v${MY_PV}/${PN}-${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+RDEPEND="dev-libs/json-glib
+	 net-im/pidgin"
+DEPEND="${RDEPEND}"
+DOCS=( AUTHORS ChangeLog NEWS README VERSION )
+
+PATCHES=( "${FILESDIR}/purple-facebook-20190113-bump-fb_orca_agent_version.patch" )
+
+src_prepare() {
+	default
+	eautoreconf
+}


### PR DESCRIPTION
…RFLOW issue

Basically this patch originates from the bitlbee-facebook github:
https://github.com/bitlbee/bitlbee-facebook/commit/49ea312d98b0578b9b2c1ff759e2cfa820a41f4d?branch=49ea312d98b0578b9b2c1ff759e2cfa820a41f4d.patch/

Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>