### PR TITLE
dev-util/geany-plugins: drop GTK 2 support

### DIFF
--- a/dev-util/geany-plugins/files/geany-plugins-1.37_use-stdbool.patch
+++ b/dev-util/geany-plugins/files/geany-plugins-1.37_use-stdbool.patch
@@ -1,0 +1,39 @@
+From ad50d3ed2ddfe11cd07954786b96725602fb4ddd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexander=20F=2E=20R=C3=B8dseth?= <rodseth@gmail.com>
+Date: Tue, 5 Jan 2021 12:57:27 +0100
+Subject: [PATCH] Use stdbool.h istead of redefining bool
+
+Redefining bool causes errors when used together with ie. GCC 10.2.0
+---
+ pretty-printer/src/PrettyPrinter.h | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/pretty-printer/src/PrettyPrinter.h b/pretty-printer/src/PrettyPrinter.h
+index 268986e95..4200db612 100644
+--- a/pretty-printer/src/PrettyPrinter.h
++++ b/pretty-printer/src/PrettyPrinter.h
+@@ -29,6 +29,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <stdarg.h>
++#include <stdbool.h>
+ 
+ #ifdef HAVE_GLIB
+ #include <glib.h>
+@@ -52,15 +53,13 @@
+ #define TRUE !(FALSE)
+ #endif
+ 
+-typedef unsigned int bool;
+-
+ /*========================================== STRUCTURES =======================================================*/
+ 
+ /**
+  * The PrettyPrintingOptions struct allows the programmer to tell the
+  * PrettyPrinter how it must format the XML output.
+  */
+-typedef struct 
++typedef struct
+ {
+       const char* newLineChars;                                                             /* char used to generate a new line (generally \r\n) */
+       char indentChar;                                                                      /* char used for indentation */

--- a/dev-util/geany-plugins/geany-plugins-1.37-r101.ebuild
+++ b/dev-util/geany-plugins/geany-plugins-1.37-r101.ebuild
@@ -1,0 +1,126 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+LUA_COMPAT=( lua5-1 )
+
+inherit lua-single
+
+DESCRIPTION="A collection of different plugins for Geany"
+HOMEPAGE="https://plugins.geany.org"
+SRC_URI="https://plugins.geany.org/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
+
+IUSE="ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope soup workbench"
+REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
+
+DEPEND="
+	dev-libs/glib:2
+	>=dev-util/geany-1.37[-gtk2(-)]
+	x11-libs/gtk+:3
+	ctags? ( dev-util/ctags )
+	debugger? (
+		x11-libs/vte:2.91
+		)
+	enchant? ( app-text/enchant:= )
+	git? ( dev-libs/libgit2:= )
+	gpg? ( app-crypt/gpgme:1= )
+	gtkspell? ( app-text/gtkspell:3= )
+	lua? ( ${LUA_DEPS} )
+	markdown? (
+		app-text/discount
+		net-libs/webkit-gtk:4
+		)
+	pretty-printer? ( dev-libs/libxml2:2 )
+	scope? ( x11-libs/vte:2.91 )
+	soup? ( net-libs/libsoup:2.4 )
+	workbench? ( dev-libs/libgit2:= )
+"
+RDEPEND="${DEPEND}
+	scope? ( sys-devel/gdb )
+"
+BDEPEND="virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+
+PATCHES=( "${FILESDIR}"/${P}_use-stdbool.patch )
+
+pkg_setup() {
+	use lua && lua-single_pkg_setup
+}
+
+src_configure() {
+	local myeconfargs=(
+		--disable-cppcheck
+		--disable-extra-c-warnings
+		$(use_enable nls)
+		--enable-utilslib
+		# Plugins
+		--enable-addons
+		--enable-autoclose
+		--enable-automark
+		--enable-codenav
+		--enable-commander
+		--enable-defineformat
+		--enable-geanyextrasel
+		--enable-geanyinsertnum
+		--enable-geanymacro
+		--enable-geanyminiscript
+		--enable-geanynumberedbookmarks
+		--enable-geanyprj
+		--enable-geanyvc $(use_enable gtkspell)
+		--enable-keyrecord
+		--enable-latex
+		--enable-lineoperations
+		--enable-lipsum
+		--enable-overview
+		--enable-pairtaghighlighter
+		--enable-pohelper
+		--enable-projectorganizer
+		--enable-sendmail
+		--enable-shiftcolumn
+		--enable-tableconvert
+		--enable-treebrowser
+		--enable-vimode
+		--enable-xmlsnippets
+		$(use_enable debugger)
+		$(use_enable ctags geanyctags)
+		$(use_enable lua geanylua)
+		$(use_enable gpg geanypg)
+		$(use_enable soup geniuspaste)
+		$(use_enable git gitchangebar)
+		$(use_enable markdown) --disable-peg-markdown # using app-text/discount instead
+		$(use_enable pretty-printer)
+		$(use_enable scope)
+		$(use_enable enchant spellcheck)
+		# Having updatechecker… when you’re using a package manager?
+		$(use_enable soup updatechecker)
+		$(use_enable workbench)
+		# GeanyGenDoc requires ctpl which isn’t yet in portage
+		--disable-geanygendoc
+		# Require obsolete and vulnerable webkit-gtk versions
+		--disable-devhelp
+		--disable-webhelper
+		# GTK 2 only
+		--disable-geanydoc
+		--disable-geanypy
+		--disable-multiterm
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	find "${D}" -name '*.la' -delete || die
+
+	# make installs all translations if LINGUAS is empty
+	if [[ -z "${LINGUAS-x}" ]]; then
+		rm -r "${ED}/usr/share/locale/" || die
+	fi
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/769074
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

Needed a backported patch to compile as well:
https://github.com/geany/geany-plugins/pull/1053
https://github.com/geany/geany-plugins/commit/ad50d3ed2ddfe11cd07954786b96725602fb4ddd

```diff
--- geany-plugins-1.37-r100.ebuild
+++ geany-plugins-1.37-r101.ebuild
@@ -13,38 +13,30 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm ppc ppc64 ~sparc x86"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
 
-IUSE="gtk2 ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope soup workbench"
-REQUIRED_USE="gtk2? ( !markdown ) lua? ( ${LUA_REQUIRED_USE} )"
+IUSE="ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope soup workbench"
+REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
 
 DEPEND="
 	dev-libs/glib:2
-	>=dev-util/geany-1.37[gtk2=]
-	!gtk2? ( x11-libs/gtk+:3 )
-	gtk2? ( x11-libs/gtk+:2 )
+	>=dev-util/geany-1.37[-gtk2(-)]
+	x11-libs/gtk+:3
 	ctags? ( dev-util/ctags )
 	debugger? (
-		!gtk2? ( x11-libs/vte:2.91 )
-		gtk2? ( x11-libs/vte:0 )
+		x11-libs/vte:2.91
 		)
 	enchant? ( app-text/enchant:= )
 	git? ( dev-libs/libgit2:= )
 	gpg? ( app-crypt/gpgme:1= )
-	gtkspell? (
-		!gtk2? ( app-text/gtkspell:3= )
-		gtk2? ( app-text/gtkspell:2 )
-		)
+	gtkspell? ( app-text/gtkspell:3= )
 	lua? ( ${LUA_DEPS} )
 	markdown? (
 		app-text/discount
 		net-libs/webkit-gtk:4
 		)
 	pretty-printer? ( dev-libs/libxml2:2 )
-	scope? (
-		!gtk2? ( x11-libs/vte:2.91 )
-		gtk2? ( x11-libs/vte:0 )
-		)
+	scope? ( x11-libs/vte:2.91 )
 	soup? ( net-libs/libsoup:2.4 )
 	workbench? ( dev-libs/libgit2:= )
 "
@@ -54,6 +46,8 @@
 BDEPEND="virtual/pkgconfig
 	nls? ( sys-devel/gettext )
 "
+
+PATCHES=( "${FILESDIR}"/${P}_use-stdbool.patch )
 
 src_configure() {
 	local myeconfargs=(
@@ -91,7 +85,6 @@
 		--enable-xmlsnippets
 		$(use_enable debugger)
 		$(use_enable ctags geanyctags)
-		$(use_enable gtk2 geanydoc)
 		$(use_enable lua geanylua)
 		$(use_enable gpg geanypg)
 		$(use_enable soup geniuspaste)
@@ -109,6 +102,7 @@
 		--disable-devhelp
 		--disable-webhelper
 		# GTK 2 only
+		--disable-geanydoc
 		--disable-geanypy
 		--disable-multiterm
 	)
```
