### PR TITLE
mail-client/neomutt: Add autocrypt use flag

### DIFF
--- a/mail-client/neomutt/metadata.xml
+++ b/mail-client/neomutt/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Nicolas Bock</name>
 	</maintainer>
 	<use>
+		<flag name="autocrypt">Enable autocrypt.org support</flag>
 		<flag name="berkdb">Enable BDB (Berkley DB) backend for header
 			caching</flag>
 		<flag name="gdbm">Enable GDBM (GNU dbm) backend for header

--- a/mail-client/neomutt/neomutt-20201127-r1.ebuild
+++ b/mail-client/neomutt/neomutt-20201127-r1.ebuild
@@ -21,9 +21,11 @@ HOMEPAGE="https://neomutt.org/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet libressl
+IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet libressl
 	lmdb nls notmuch pgp-classic qdbm sasl selinux slang smime-classic
 	ssl tokyocabinet test"
+REQUIRED_USE="
+	autocrypt?	( gpgme )"
 
 CDEPEND="
 	app-misc/mime-types
@@ -43,6 +45,7 @@ CDEPEND="
 	tokyocabinet? ( dev-db/tokyocabinet )
 	gnutls? ( >=net-libs/gnutls-1.0.17:= )
 	gpgme? ( >=app-crypt/gpgme-1.13.1:= )
+	autocrypt?     ( >=dev-db/sqlite-3 )
 	idn? ( net-dns/libidn:= )
 	kerberos? ( virtual/krb5 )
 	notmuch? ( net-mail/notmuch:= )
@@ -80,6 +83,7 @@ src_configure() {
 		"$(use_enable nls)"
 		"$(use_enable notmuch)"
 
+		"$(use_enable autocrypt)"
 		"$(use_enable gpgme)"
 		"$(use_enable pgp-classic pgp)"
 		"$(use_enable smime-classic smime)"
@@ -144,5 +148,10 @@ pkg_postinst() {
 		ewarn "  support.  You can probably remove pgp-classic (old crypt)"
 		ewarn "  and smime-classic (old smime) from your USE-flags and"
 		ewarn "  only enable gpgme."
+	fi
+
+	if use autocrypt && ! use idn; then
+		ewarn "  It is highly recommended that NeoMutt be also configured"
+		ewarn "  with idn when autocrypt is enabled."
 	fi
 }

--- a/mail-client/neomutt/neomutt-20201127.ebuild
+++ b/mail-client/neomutt/neomutt-20201127.ebuild
@@ -21,9 +21,11 @@ HOMEPAGE="https://neomutt.org/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet libressl
+IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet libressl
 	lmdb nls notmuch pgp-classic qdbm sasl selinux slang smime-classic
 	ssl tokyocabinet test"
+REQUIRED_USE="
+	autocrypt?	( gpgme )"
 
 CDEPEND="
 	app-misc/mime-types
@@ -42,7 +44,8 @@ CDEPEND="
 	qdbm? ( dev-db/qdbm )
 	tokyocabinet? ( dev-db/tokyocabinet )
 	gnutls? ( >=net-libs/gnutls-1.0.17:= )
-	gpgme? ( >=app-crypt/gpgme-0.9.0:= )
+	gpgme? ( >=app-crypt/gpgme-1.8.0:= )
+	autocrypt?     ( >=dev-db/sqlite-3 )
 	idn? ( net-dns/libidn:= )
 	kerberos? ( virtual/krb5 )
 	notmuch? ( net-mail/notmuch:= )
@@ -80,6 +83,7 @@ src_configure() {
 		"$(use_enable nls)"
 		"$(use_enable notmuch)"
 
+		"$(use_enable autocrypt)"
 		"$(use_enable gpgme)"
 		"$(use_enable pgp-classic pgp)"
 		"$(use_enable smime-classic smime)"
@@ -144,5 +148,10 @@ pkg_postinst() {
 		ewarn "  support.  You can probably remove pgp-classic (old crypt)"
 		ewarn "  and smime-classic (old smime) from your USE-flags and"
 		ewarn "  only enable gpgme."
+	fi
+
+	if use autocrypt && ! use idn; then
+		ewarn "  It is highly recommended that NeoMutt be also configured"
+		ewarn "  with idn when autocrypt is enabled."
 	fi
 }

--- a/mail-client/neomutt/neomutt-20210205.ebuild
+++ b/mail-client/neomutt/neomutt-20210205.ebuild
@@ -21,9 +21,11 @@ HOMEPAGE="https://neomutt.org/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet libressl
+IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet libressl
 	lmdb nls notmuch pgp-classic qdbm sasl selinux slang smime-classic
 	ssl tokyocabinet test"
+REQUIRED_USE="
+	autocrypt?	( gpgme )"
 
 CDEPEND="
 	app-misc/mime-types
@@ -43,6 +45,7 @@ CDEPEND="
 	tokyocabinet? ( dev-db/tokyocabinet )
 	gnutls? ( >=net-libs/gnutls-1.0.17:= )
 	gpgme? ( >=app-crypt/gpgme-1.13.1:= )
+	autocrypt?     ( >=dev-db/sqlite-3 )
 	idn? ( net-dns/libidn:= )
 	kerberos? ( virtual/krb5 )
 	notmuch? ( net-mail/notmuch:= )
@@ -80,6 +83,7 @@ src_configure() {
 		"$(use_enable nls)"
 		"$(use_enable notmuch)"
 
+		"$(use_enable autocrypt)"
 		"$(use_enable gpgme)"
 		"$(use_enable pgp-classic pgp)"
 		"$(use_enable smime-classic smime)"
@@ -144,5 +148,10 @@ pkg_postinst() {
 		ewarn "  support.  You can probably remove pgp-classic (old crypt)"
 		ewarn "  and smime-classic (old smime) from your USE-flags and"
 		ewarn "  only enable gpgme."
+	fi
+
+	if use autocrypt && ! use idn; then
+		ewarn "  It is highly recommended that NeoMutt be also configured"
+		ewarn "  with idn when autocrypt is enabled."
 	fi
 }

--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -21,9 +21,11 @@ HOMEPAGE="https://neomutt.org/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet libressl
+IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet libressl
 	lmdb nls notmuch pgp-classic qdbm sasl selinux slang smime-classic
 	ssl tokyocabinet test"
+REQUIRED_USE="
+	autocrypt?	( gpgme )"
 
 CDEPEND="
 	app-misc/mime-types
@@ -43,6 +45,7 @@ CDEPEND="
 	tokyocabinet? ( dev-db/tokyocabinet )
 	gnutls? ( >=net-libs/gnutls-1.0.17:= )
 	gpgme? ( >=app-crypt/gpgme-1.13.1:= )
+	autocrypt?     ( >=dev-db/sqlite-3 )
 	idn? ( net-dns/libidn:= )
 	kerberos? ( virtual/krb5 )
 	notmuch? ( net-mail/notmuch:= )
@@ -80,6 +83,7 @@ src_configure() {
 		"$(use_enable nls)"
 		"$(use_enable notmuch)"
 
+		"$(use_enable autocrypt)"
 		"$(use_enable gpgme)"
 		"$(use_enable pgp-classic pgp)"
 		"$(use_enable smime-classic smime)"
@@ -144,5 +148,10 @@ pkg_postinst() {
 		ewarn "  support.  You can probably remove pgp-classic (old crypt)"
 		ewarn "  and smime-classic (old smime) from your USE-flags and"
 		ewarn "  only enable gpgme."
+	fi
+
+	if use autocrypt && ! use idn; then
+		ewarn "  It is highly recommended that NeoMutt be also configured"
+		ewarn "  with idn when autocrypt is enabled."
 	fi
 }


### PR DESCRIPTION
NeoMutt supports autocrypt since version 2019-10-25. It requires gpgme
of version 1.8.0 or higher and sqlite. It is recommended that idn or
idn2 is enabled according to the manual.

The minimum requirement of gpgme of neomutt-20201127.ebuild is increased
from 0.9.0 to 1.8.0. This change has no consquence as the minimum
available version in portage is 1.14.0.

Closes: https://bugs.gentoo.org/769698
Signed-off-by: Stefan Huber <shuber@sthu.org>