### PR TITLE
app-crypt/pinentry: add USE=efl

### DIFF
--- a/app-crypt/pinentry/metadata.xml
+++ b/app-crypt/pinentry/metadata.xml
@@ -5,4 +5,7 @@
 		<email>zlogene@gentoo.org</email>
 		<name>Mikle Kolyada</name>
 	</maintainer>
+	<use>
+		<flag name="efl">Build <pkg>dev-libs/efl</pkg> based pinentry</flag>
+	</use>
 </pkgmetadata>

--- a/app-crypt/pinentry/pinentry-1.1.1-r1.ebuild
+++ b/app-crypt/pinentry/pinentry-1.1.1-r1.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools flag-o-matic qmake-utils toolchain-funcs
+
+DESCRIPTION="Simple passphrase entry dialogs which utilize the Assuan protocol"
+HOMEPAGE="https://gnupg.org/aegypten2"
+SRC_URI="mirror://gnupg/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~s390 ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
+IUSE="caps efl emacs gnome-keyring gtk ncurses qt5"
+
+DEPEND="
+	>=app-eselect/eselect-pinentry-0.7.2
+	>=dev-libs/libassuan-2.1
+	>=dev-libs/libgcrypt-1.6.3
+	>=dev-libs/libgpg-error-1.17
+	caps? ( sys-libs/libcap )
+	efl? ( dev-libs/efl[X] )
+	gnome-keyring? ( app-crypt/libsecret )
+	ncurses? ( sys-libs/ncurses:0= )
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+	)
+"
+RDEPEND="${DEPEND}
+	gtk? ( app-crypt/gcr )
+"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+DOCS=( AUTHORS ChangeLog NEWS README THANKS TODO )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.0.0-make-icon-work-under-Plasma-Wayland.patch"
+	"${FILESDIR}/${PN}-0.8.2-ncurses.patch"
+	"${FILESDIR}/${PN}-1.0.0-AR.patch"
+)
+
+src_prepare() {
+	default
+	unset FLTK_CONFIG
+	eautoreconf
+}
+
+src_configure() {
+	[[ "$(gcc-major-version)" -ge 5 ]] && append-cxxflags -std=gnu++11
+
+	export QTLIB="$(qt5_get_libdir)"
+
+	econf \
+		$(use_enable efl pinentry-efl) \
+		$(use_enable emacs pinentry-emacs) \
+		$(use_enable gnome-keyring libsecret) \
+		$(use_enable gtk pinentry-gnome3) \
+		$(use_enable ncurses fallback-curses) \
+		$(use_enable ncurses pinentry-curses) \
+		$(use_enable qt5 pinentry-qt) \
+		$(use_with caps libcap) \
+		--enable-pinentry-tty \
+		--disable-pinentry-fltk \
+		--disable-pinentry-gtk2 \
+		MOC="$(qt5_get_bindir)"/moc \
+		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config" \
+		LIBASSUAN_CONFIG="${ESYSROOT}/usr/bin/libassuan-config" \
+		$("${S}/configure" --help | grep -- '--without-.*-prefix' | sed -e 's/^ *\([^ ]*\) .*/\1/g')
+}
+
+src_install() {
+	default
+	rm "${ED}"/usr/bin/pinentry || die
+
+	use qt5 && dosym pinentry-qt /usr/bin/pinentry-qt5
+}
+
+pkg_postinst() {
+	eselect pinentry update ifunset
+}
+
+pkg_postrm() {
+	eselect pinentry update ifunset
+}

--- a/app-eselect/eselect-pinentry/eselect-pinentry-0.7.2.ebuild
+++ b/app-eselect/eselect-pinentry/eselect-pinentry-0.7.2.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Manage /usr/bin/pinentry symlink"
+HOMEPAGE="https://www.gentoo.org/proj/en/eselect/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE=""
+
+RDEPEND=">=app-eselect/eselect-lib-bin-symlink-0.1.1"
+
+S="${FILESDIR}"
+
+src_install() {
+	default
+	insinto /usr/share/eselect/modules
+	newins pinentry.eselect-${PV} pinentry.eselect
+}

--- a/app-eselect/eselect-pinentry/files/pinentry.eselect-0.7.2
+++ b/app-eselect/eselect-pinentry/files/pinentry.eselect-0.7.2
@@ -1,0 +1,12 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Manage /usr/bin/pinentry implementation"
+MAINTAINER="zlogene@gentoo.org"
+VERSION="0.7.2"
+
+SYMLINK_PATH=/usr/bin/pinentry
+SYMLINK_TARGETS=( pinentry-efl pinentry-gnome3 pinentry-qt5 pinentry-curses pinentry-tty )
+SYMLINK_DESCRIPTION='pinentry binary'
+
+inherit bin-symlink


### PR DESCRIPTION
As per https://git.gnupg.org/cgi-bin/gitweb.cgi?p=pinentry.git;a=blob;f=NEWS, pinentry 1.1.1 adds an EFL based pinentry.

Bug: https://bugs.gentoo.org/767181
