### PR TITLE
dev-python/pythondialog: revbump for python3_9 support

### DIFF
--- a/dev-python/pythondialog/pythondialog-3.5.1-r1.ebuild
+++ b/dev-python/pythondialog/pythondialog-3.5.1-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7,8,9} pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="A Python module for making simple text/console-mode user interfaces"
+HOMEPAGE="http://pythondialog.sourceforge.net/"
+SRC_URI="mirror://sourceforge/pythondialog/${PV}/python3-${P}.tar.bz2"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~alpha amd64 ~arm ~ia64 ppc sparc x86"
+
+RDEPEND="dev-util/dialog"
+
+distutils_enable_sphinx doc
+
+python_prepare_all() {
+	distutils-r1_python_prepare_all
+	sed -e "/^    'sphinx.ext.intersphinx',/d" -i doc/conf.py || die
+}
+
+python_install_all() {
+	dodoc -r examples
+	docompress -x /usr/share/doc/${PF}/examples
+	default
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/769854
Signed-off-by: Amel Hodzic <ilmostro7@gmail.com>