### PR TITLE
sys-apps/qingy: Apply gcc-10 workaround

### DIFF
--- a/sys-apps/qingy/qingy-1.0.0-r5.ebuild
+++ b/sys-apps/qingy/qingy-1.0.0-r5.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inherit autotools elisp-common eutils pam systemd
+
+inherit autotools elisp-common eutils flag-o-matic pam systemd
 
 GENTOO_THEME_VERSION="2.1"
 
@@ -48,6 +49,7 @@ src_prepare() {
 }
 
 src_configure() {
+	append-cflags -fcommon
 	local crypto_support="--disable-crypto"
 	local emacs_support="--disable-emacs --without-lispdir"
 


### PR DESCRIPTION
Last upstream activity in 2010; I've looked into patching the source but it doesn't seem to be trivial