### PR TITLE
app-benchmarks/stress-ng: backport newer glibc ustat.h fix

### DIFF
--- a/app-benchmarks/stress-ng/files/stress-ng-0.12.02-fix-build-breaking-HAVE_USTAT-typo.patch
+++ b/app-benchmarks/stress-ng/files/stress-ng-0.12.02-fix-build-breaking-HAVE_USTAT-typo.patch
@@ -1,0 +1,46 @@
+From ce1fb7978c836281dd91558f2b4ab3ecee0c253c Mon Sep 17 00:00:00 2001
+From: Adrian Ratiu <adrian.ratiu@collabora.com>
+Date: Wed, 10 Feb 2021 14:28:00 +0200
+Subject: [PATCH] stress-ng.h: fix build-breaking HAVE_USTAT typo
+
+This minor typo fails builds on newer glibc because ustat.h does
+not exist anymore.
+
+Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
+---
+Backported from stress-ng master commit ce1fb7978c836281d.
+---
+ core-shim.c | 3 ++-
+ stress-ng.h | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/core-shim.c b/core-shim.c
+index e4e6189d..8af7bcc5 100644
+--- a/core-shim.c
++++ b/core-shim.c
+@@ -1390,7 +1390,8 @@ int sys_clone3(struct shim_clone_args *cl_args, size_t size)
+ 
+ int shim_ustat(dev_t dev, struct shim_ustat *ubuf)
+ {
+-#if defined(HAVE_USTAT)
++#if defined(HAVE_USTAT) &&	\
++     defined(HAVE_USTAT_H)
+ 	return ustat(dev, (void *)ubuf);
+ #elif defined(__NR_ustat)
+ 	return syscall(__NR_ustat, dev, ubuf);
+diff --git a/stress-ng.h b/stress-ng.h
+index e16a08f0..9d964059 100644
+--- a/stress-ng.h
++++ b/stress-ng.h
+@@ -219,7 +219,7 @@
+ #include <ucontext.h>
+ #endif
+ 
+-#if defined(HAVE_USTAT)
++#if defined(HAVE_USTAT_H)
+ #include <ustat.h>
+ #endif
+ 
+-- 
+2.30.0
+

--- a/app-benchmarks/stress-ng/stress-ng-0.12.02.ebuild
+++ b/app-benchmarks/stress-ng/stress-ng-0.12.02.ebuild
@@ -27,7 +27,10 @@ RDEPEND="${DEPEND}"
 
 DOCS=( "README" "README.Android" "TODO" "syscalls.txt" )
 
-PATCHES=( "${FILESDIR}/${PN}-0.11.23-makefile.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}-0.11.23-makefile.patch"
+	"${FILESDIR}/${PN}-0.12.02-fix-build-breaking-HAVE_USTAT-typo.patch"
+)
 
 src_compile() {
 	tc-export CC


### PR DESCRIPTION
Newer glibc has removed ustat.h and stress-ng has a workaround
which unfortunately fails due to a minor bug. This backports
the fix from upstream because there is no stress-ng release yet
containing it.

Upstream commit:
https://github.com/ColinIanKing/stress-ng/commit/ce1fb7978c836281dd91558f2b4ab3ecee0c253c

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>