### PR TITLE
acct-user/apt-cacher-ng: take maintainership

### DIFF
--- a/acct-user/apt-cacher-ng/metadata.xml
+++ b/acct-user/apt-cacher-ng/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+        <maintainer type="person">
+                        <email>jchelmert3@posteo.net</email>
+                        <name>John Helmert III</name>
+        </maintainer>
+        <maintainer type="project">
+                        <email>proxy-maint@gentoo.org</email>
+                        <name>Proxy Maintainers</name>
+        </maintainer>
 </pkgmetadata>


### PR DESCRIPTION
I committed this as m-n by mistake.

Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: John Helmert III <jchelmert3@posteo.net>