### PR TITLE
kde-plasma/kde-gtk-config: Don't print debug message

### DIFF
--- a/kde-plasma/kde-gtk-config/files/kde-gtk-config-5.20.5-window-decorations-reloaded.patch
+++ b/kde-plasma/kde-gtk-config/files/kde-gtk-config-5.20.5-window-decorations-reloaded.patch
@@ -1,0 +1,24 @@
+From 62e272df848d6848482ceb534d14bf36c9fde241 Mon Sep 17 00:00:00 2001
+From: Weng Xuetian <wengxt@gmail.com>
+Date: Sat, 9 Jan 2021 19:07:24 -0800
+Subject: [PATCH] Remove debug message to avoid polute to stdout.
+
+This would break application like zenity which output to stdout.
+---
+ window-decorations-reload-module/reloader.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/window-decorations-reload-module/reloader.c b/window-decorations-reload-module/reloader.c
+index 9e367dc..606bb1f 100644
+--- a/window-decorations-reload-module/reloader.c
++++ b/window-decorations-reload-module/reloader.c
+@@ -55,7 +55,6 @@ void manage_css_provider(GFileMonitor *monitor, GFile *file, GFile *other_file,
+ 
+ void reload_css_provider()
+ {
+-    printf("WINDOW DECORATIONS RELOADED\n");
+     if (css_provider != NULL) {
+         remove_css_provider();
+     }
+-- 
+GitLab

--- a/kde-plasma/kde-gtk-config/kde-gtk-config-5.20.5-r1.ebuild
+++ b/kde-plasma/kde-gtk-config/kde-gtk-config-5.20.5-r1.ebuild
@@ -41,6 +41,8 @@ RDEPEND="${DEPEND}
 	x11-misc/xsettingsd
 "
 
+PATCHES=( "${FILESDIR}/${PN}-5.20.5-window-decorations-reloaded.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		-DDATA_INSTALL_DIR="${EPREFIX}/usr/share"


### PR DESCRIPTION
I've noticed that whenever a GTK application is started the
stdout is polluted with the following message:

WINDOW DECORATIONS RELOADED

After some research I came across KDE bug:

  https://bugs.kde.org/show_bug.cgi?id=431365

which says the message is a debug message and could be dropped.
In the upstream repository, the following commit was merged which
does exactly that:

https://invent.kde.org/plasma/kde-gtk-config/-/commit/62e272df848d6848482ceb534d14bf36c9fde241.patch

Backport the commit until the version of kde-gtk-config is
bumped.

Closes: https://bugs.gentoo.org/770097
Signed-off-by: Michal Privoznik <mprivozn@redhat.com>