### PR TITLE
*/*:  gcc-10 fixes (and EAPI-7 porting)

### DIFF
--- a/app-crypt/dieharder/dieharder-3.31.1-r3.ebuild
+++ b/app-crypt/dieharder/dieharder-3.31.1-r3.ebuild
@@ -1,11 +1,13 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
+inherit autotools flag-o-matic
+
 DESCRIPTION="An advanced suite for testing the randomness of RNG's"
-HOMEPAGE="http://www.phy.duke.edu/~rgb/General/dieharder.php"
-SRC_URI="http://www.phy.duke.edu/~rgb/General/${PN}/${P}.tgz"
+HOMEPAGE="https://www.phy.duke.edu/~rgb/General/dieharder.php"
+SRC_URI="https://www.phy.duke.edu/~rgb/General/${PN}/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -14,30 +16,22 @@ IUSE="doc"
 RESTRICT="test" # Way too long
 
 RDEPEND="sci-libs/gsl"
-DEPEND="${RDEPEND}
-	doc? ( dev-tex/latex2html )"
-
-DOCS=(
-	NOTES
-)
-HTML_DOCS=()
+DEPEND="${RDEPEND}"
+BDEPEND=" doc? ( dev-tex/latex2html )"
 
 PATCHES=(
-	"${FILESDIR}/${P}-build.patch"
-	"${FILESDIR}/${P}-urandom-64bit.patch"
+	"${FILESDIR}"/${P}-build.patch
+	"${FILESDIR}"/${P}-urandom-64bit.patch
+	"${FILESDIR}"/${P}-cross-compile.patch
 )
 
-pkg_setup() {
-	use doc && DOCS+=(
-		ChangeLog
-		manual/dieharder.pdf manual/dieharder.ps
-	)
-	use doc && HTML_DOCS+=(
-		dieharder.html
-	)
+src_prepare() {
+	default
+	eautoreconf
 }
 
 src_configure() {
+	append-flags -fcommon
 	econf --disable-static
 }
 
@@ -46,17 +40,18 @@ src_compile() {
 	use doc && emake -C manual
 }
 
-src_test() {
-	"${S}/dieharder/dieharder" -g 501 -a
-}
-
 src_install() {
+	if use doc; then
+		DOCS=( ChangeLog manual/dieharder.pdf manual/dieharder.ps)
+		HTML_DOCS=( dieharder.html )
+	fi
+
 	default
 
-	docinto "dieharder"
-	dodoc dieharder/README dieharder/NOTES
-	docinto "libdieharder"
-	dodoc libdieharder/README libdieharder/NOTES
+	docinto dieharder
+	dodoc dieharder/{NOTES,README}
+	docinto libdieharder
+	dodoc libdieharder/{NOTES,README}
 
 	find "${ED}" -name '*.la' -delete || die
 }

--- a/app-crypt/dieharder/files/dieharder-3.31.1-build.patch
+++ b/app-crypt/dieharder/files/dieharder-3.31.1-build.patch
@@ -1,5 +1,3 @@
-diff --git a/include/dieharder/libdieharder.h b/include/dieharder/libdieharder.h
-index 2138ebf..f6d471b 100644
 --- a/include/dieharder/libdieharder.h
 +++ b/include/dieharder/libdieharder.h
 @@ -6,6 +6,8 @@
@@ -34,8 +32,6 @@ Subject: [PATCH 1/2] rgb_operm: convert to noop as implementation missing
  include/dieharder/rgb_operm.h | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/include/dieharder/rgb_operm.h b/include/dieharder/rgb_operm.h
-index c48fa37..f33fc1f 100644
 --- a/include/dieharder/rgb_operm.h
 +++ b/include/dieharder/rgb_operm.h
 @@ -1,3 +1,4 @@
@@ -62,8 +58,6 @@ Subject: [PATCH 2/2] dab_filltree2: inline cannot have prototype nor can it be
  libdieharder/dab_filltree2.c | 48 +++++++++++++++++-------------------
  2 files changed, 41 insertions(+), 44 deletions(-)
 
-diff --git a/libdieharder/dab_filltree.c b/libdieharder/dab_filltree.c
-index 9cc5ce7..3ed6b00 100644
 --- a/libdieharder/dab_filltree.c
 +++ b/libdieharder/dab_filltree.c
 @@ -34,7 +34,24 @@ static double targetData[] = {
@@ -117,8 +111,6 @@ index 9cc5ce7..3ed6b00 100644
  #include<time.h>
  
  int main_filltree(int argc, char **argv) {
-diff --git a/libdieharder/dab_filltree2.c b/libdieharder/dab_filltree2.c
-index 1e33af2..7102d3c 100644
 --- a/libdieharder/dab_filltree2.c
 +++ b/libdieharder/dab_filltree2.c
 @@ -92,7 +92,29 @@ static double targetData[128] = {  // size=128, generated from 6e9 samples

--- a/app-crypt/dieharder/files/dieharder-3.31.1-cross-compile.patch
+++ b/app-crypt/dieharder/files/dieharder-3.31.1-cross-compile.patch
@@ -1,0 +1,57 @@
+From: Tom Hughes <tomhughes@chromium.org>
+Fix cross-compilation by removing gsl header/library check (these are enforced
+through ebuild DEPENDS) and using AC_C_BIGENDIAN instead of the non-standard
+AC_C_ENDIAN macro which tries to execute code.
+--- a/configure.ac
++++ b/configure.ac
+@@ -108,48 +108,7 @@
+ AC_SUBST(DIEHARDER_LIBS)
+ AC_SUBST(ACLOCAL_AMFLAGS)
+ 
+-#==================================================================
+-# Checks for libraries, and headers.  Test for dependency libraries
+-# FIRST in reverse order that you need -lwhatever to appear on
+-# compile line as it accumulates libraries to build e.g.
+-#   -lgsl -lgslcblas
+-# for the SECOND test, required (in that order) to succeed.
+-#==================================================================
+-AC_CHECK_HEADER([gsl/gsl_sf_gamma.h],,[AC_MSG_ERROR([Couldn't find GSL headers.  Please install the gsl-devel package.])])
+-AC_CHECK_LIB([gslcblas], [main],,[AC_MSG_ERROR([Couldn't find libgsl. Please install the gsl package.])])
+-AC_CHECK_LIB([gsl],[gsl_sf_gamma])
+-
+-
+-#==================================================================
+-# Check if we're a little-endian or a big-endian system, needed by
+-# brg_endian.h in the build of rng_threefish.  This is a very
+-# certain test, and therefore is checked FIRST in this header file.
+-#==================================================================
+-AC_DEFUN([AC_C_ENDIAN],
+-[AC_CACHE_CHECK(for endianness, ac_cv_c_endian,
+-[
+-  AC_RUN_IFELSE(
+-    [AC_LANG_PROGRAM([], [dnl
+-        long val = 1;
+-        char *c = (char *) &val;
+-        exit(*c == 1);
+-    ])
+-  ],[
+-    ac_cv_c_endian=big
+-  ],[
+-    ac_cv_c_endian=little
+-  ])
+-])
+-if test $ac_cv_c_endian = big; then
+-  AC_SUBST(LITTLE_ENDIAN,0) 
+-fi
+-if test $ac_cv_c_endian = little; then
+-  AC_SUBST(LITTLE_ENDIAN,1) 
+-fi
+-])
+-
+-AC_C_ENDIAN
+- 
++AC_C_BIGENDIAN([AC_SUBST(LITTLE_ENDIAN,0)],[AC_SUBST(LITTLE_ENDIAN,1)])
+ 
+ #==================================================================
+ # Checks for typedefs, structures, and compiler characteristics.
+

--- a/app-crypt/dieharder/files/dieharder-3.31.1-urandom-64bit.patch
+++ b/app-crypt/dieharder/files/dieharder-3.31.1-urandom-64bit.patch
@@ -1,6 +1,5 @@
-diff -ru dieharder-3.31.1/libdieharder/rng_dev_arandom.c dieharder-3.31.1_fixed/libdieharder/rng_dev_arandom.c
---- dieharder-3.31.1/libdieharder/rng_dev_arandom.c	2011-10-14 15:41:37.000000000 +0200
-+++ dieharder-3.31.1_fixed/libdieharder/rng_dev_arandom.c	2014-01-03 22:51:30.010534418 +0100
+--- a/libdieharder/rng_dev_arandom.c
++++ b/libdieharder/rng_dev_arandom.c
 @@ -6,6 +6,7 @@
   */
  
@@ -27,9 +26,8 @@ diff -ru dieharder-3.31.1/libdieharder/rng_dev_arandom.c dieharder-3.31.1_fixed/
  }
  
  static void
-diff -ru dieharder-3.31.1/libdieharder/rng_dev_random.c dieharder-3.31.1_fixed/libdieharder/rng_dev_random.c
---- dieharder-3.31.1/libdieharder/rng_dev_random.c	2011-10-14 15:41:37.000000000 +0200
-+++ dieharder-3.31.1_fixed/libdieharder/rng_dev_random.c	2014-01-03 22:50:57.852321485 +0100
+--- a/libdieharder/rng_dev_random.c
++++ b/libdieharder/rng_dev_random.c
 @@ -6,6 +6,7 @@
   */
  
@@ -56,9 +54,8 @@ diff -ru dieharder-3.31.1/libdieharder/rng_dev_random.c dieharder-3.31.1_fixed/l
  }
  
  static void
-diff -ru dieharder-3.31.1/libdieharder/rng_dev_urandom.c dieharder-3.31.1_fixed/libdieharder/rng_dev_urandom.c
---- dieharder-3.31.1/libdieharder/rng_dev_urandom.c	2011-10-14 15:41:37.000000000 +0200
-+++ dieharder-3.31.1_fixed/libdieharder/rng_dev_urandom.c	2014-01-03 23:06:24.124239582 +0100
+--- a/libdieharder/rng_dev_urandom.c
++++ b/libdieharder/rng_dev_urandom.c
 @@ -3,6 +3,7 @@
   */
  

--- a/app-text/cuneiform/cuneiform-1.1.0-r3.ebuild
+++ b/app-text/cuneiform/cuneiform-1.1.0-r3.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils versionator
+inherit cmake flag-o-matic
 
-PV_MAJ=$(get_version_component_range 1-2)
+PV_MAJ=$(ver_cut 1-2)
 MY_P=${PN}-linux-${PV}
 
 DESCRIPTION="An enterprise quality OCR engine by Cognitive Technologies"
@@ -15,7 +15,6 @@ SRC_URI="https://launchpad.net/${PN}-linux/${PV_MAJ}/${PV_MAJ}/+download/${MY_P}
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-
 IUSE="debug graphicsmagick"
 
 RDEPEND="
@@ -25,21 +24,20 @@ DEPEND="${RDEPEND}"
 
 S=${WORKDIR}/${MY_P}
 
-DOCS=( readme.txt )
 PATCHES=(
 	# From Fedora
-	"${FILESDIR}/c-assert.diff"
-	"${FILESDIR}/libm.diff"
-	"${FILESDIR}/${P}-fix_buffer_overflow.patch"
-	"${FILESDIR}/${P}-fix_buffer_overflow_2.patch"
-	"${FILESDIR}/${P}-gcc6.patch"
-	"${FILESDIR}/${P}-gcc7.patch"
-	"${FILESDIR}/${P}-typos.patch"
+	"${FILESDIR}"/${P}-c-assert.patch
+	"${FILESDIR}"/${P}-libm.patch
+	"${FILESDIR}"/${P}-fix_buffer_overflow.patch
+	"${FILESDIR}"/${P}-fix_buffer_overflow_2.patch
+	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${P}-gcc7.patch
+	"${FILESDIR}"/${P}-typos.patch
 )
 
 src_prepare() {
-	use graphicsmagick && PATCHES+=( "${FILESDIR}/graphicsmagick.diff" )
-	cmake-utils_src_prepare
+	use graphicsmagick && PATCHES+=( "${FILESDIR}"/${P}-graphicsmagick.patch )
+	cmake_src_prepare
 
 	# respect LDFLAGS
 	sed -i 's:\(set[(]CMAKE_SHARED_LINKER_FLAGS "[^"]*\):\1 $ENV{LDFLAGS}:' \
@@ -48,12 +46,16 @@ src_prepare() {
 	# Fix automagic dependencies / linking
 	if use graphicsmagick; then
 		sed -i "s:find_package(ImageMagick COMPONENTS Magick++):#DONOTFIND:" \
-			cuneiform_src/CMakeLists.txt \
-			|| die "Sed for ImageMagick automagic dependency failed."
+			cuneiform_src/CMakeLists.txt || die
 	fi
 }
 
+src_configure() {
+	append-flags -fcommon
+	cmake_src_configure
+}
+
 src_install() {
-	cmake-utils_src_install
-	doman "${FILESDIR}/${PN}.1"
+	cmake_src_install
+	doman "${FILESDIR}"/${PN}.1
 }

--- a/app-text/cuneiform/files/cuneiform-1.1.0-c-assert.patch
+++ b/app-text/cuneiform/files/cuneiform-1.1.0-c-assert.patch
@@ -1,9 +1,5 @@
-Description: Use the standard C assert() macro, rather than custom Cuneiform
-  one.
+Description: Use the standard C assert() macro, rather than custom Cuneiform one.
 Author: Jakub Wilk <jwilk@debian.org>
-Forwarded: no
-Last-Update: 2011-04-30
-
 --- a/cuneiform_src/Kern/lns32/src/myassert.h
 +++ b/cuneiform_src/Kern/lns32/src/myassert.h
 @@ -60,6 +60,8 @@

--- a/app-text/cuneiform/files/cuneiform-1.1.0-fix_buffer_overflow.patch
+++ b/app-text/cuneiform/files/cuneiform-1.1.0-fix_buffer_overflow.patch
@@ -1,8 +1,5 @@
 Description: Fix buffer overflow during crash when using user supplied image.
 Author: Sławomir Nizio
-Forwarded: no
-Last-Update: 2017-04-05
-
 --- a/cuneiform_src/Kern/rstr/src/acc_tabs.c	
 +++ b/cuneiform_src/Kern/rstr/src/acc_tabs.c	
 @@ -1233,7 +1233,7 @@ if(is_cen_language(language))

--- a/app-text/cuneiform/files/cuneiform-1.1.0-fix_buffer_overflow_2.patch
+++ b/app-text/cuneiform/files/cuneiform-1.1.0-fix_buffer_overflow_2.patch
@@ -1,10 +1,7 @@
-Description: Split original patch by Slawomir and update the same to apply
-neatly.
+Description: Split original patch by Slawomir and update the same to apply neatly.
 Author: Bhavani Shankar <bhavi@ubuntu.com>
-
-
---- cuneiform-1.1.0+dfsg.orig/cuneiform_src/Kern/rstr/src/acc_tabs.c
-+++ cuneiform-1.1.0+dfsg/cuneiform_src/Kern/rstr/src/acc_tabs.c
+--- a/cuneiform_src/Kern/rstr/src/acc_tabs.c
++++ b/cuneiform_src/Kern/rstr/src/acc_tabs.c
 @@ -2821,8 +2821,8 @@ if( CodePages[language]==CSTR_EASTEUROPE
      strcpy(decode_ASCII_to_[(uchar)liga_j      ],   "_j_");
      strcpy(decode_ASCII_to_[(uchar)liga_exm    ],   "_!_");

--- a/app-text/cuneiform/files/cuneiform-1.1.0-gcc6.patch
+++ b/app-text/cuneiform/files/cuneiform-1.1.0-gcc6.patch
@@ -1,6 +1,5 @@
 Description: fix FTBFS with GCC 6
 Author: Andreas Beckmann <anbe@debian.org>
-
 --- a/cuneiform_src/Kern/rimage/sources/main/cricontrol.cpp
 +++ b/cuneiform_src/Kern/rimage/sources/main/cricontrol.cpp
 @@ -594,8 +594,8 @@ Bool32 CRIControl::CreateDestinatonDIB(u

--- a/app-text/cuneiform/files/cuneiform-1.1.0-gcc7.patch
+++ b/app-text/cuneiform/files/cuneiform-1.1.0-gcc7.patch
@@ -1,6 +1,5 @@
-diff -urp cuneiform-1.1.0/cuneiform_src/Kern/hhh/tigerh/h/strings.h cuneiform-1.1.0-char/cuneiform_src/Kern/hhh/tigerh/h/strings.h
---- cuneiform-1.1.0/cuneiform_src/Kern/hhh/tigerh/h/strings.h	2017-11-30 11:25:24.409125695 +0700
-+++ cuneiform-1.1.0-char/cuneiform_src/Kern/hhh/tigerh/h/strings.h	2017-11-30 12:09:26.033501963 +0700
+--- a/cuneiform_src/Kern/hhh/tigerh/h/strings.h
++++ b/cuneiform_src/Kern/hhh/tigerh/h/strings.h
 @@ -80,6 +80,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  
  # include "ltconfig.h"
@@ -9,9 +8,8 @@ diff -urp cuneiform-1.1.0/cuneiform_src/Kern/hhh/tigerh/h/strings.h cuneiform-1.
  
  struct _String;
  typedef struct _String STRING;
-diff -urp cuneiform-1.1.0/cuneiform_src/Kern/include/utf8-tables.h cuneiform-1.1.0-char/cuneiform_src/Kern/include/utf8-tables.h
---- cuneiform-1.1.0/cuneiform_src/Kern/include/utf8-tables.h	2017-11-30 11:25:24.410125673 +0700
-+++ cuneiform-1.1.0-char/cuneiform_src/Kern/include/utf8-tables.h	2017-11-30 11:32:05.974413875 +0700
+--- a/cuneiform_src/Kern/include/utf8-tables.h
++++ b/cuneiform_src/Kern/include/utf8-tables.h
 @@ -68,7 +68,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  #endif
  
@@ -57,9 +55,8 @@ diff -urp cuneiform-1.1.0/cuneiform_src/Kern/include/utf8-tables.h cuneiform-1.1
    {0, 0, 0, 0},
    {1, 0, 0, 0},
    {2, 0, 0, 0},
-diff -urp cuneiform-1.1.0/cuneiform_src/Kern/rout/src/codetables.cpp cuneiform-1.1.0-char/cuneiform_src/Kern/rout/src/codetables.cpp
---- cuneiform-1.1.0/cuneiform_src/Kern/rout/src/codetables.cpp	2017-11-30 11:25:24.411125651 +0700
-+++ cuneiform-1.1.0-char/cuneiform_src/Kern/rout/src/codetables.cpp	2017-11-30 11:47:51.856189912 +0700
+--- a/cuneiform_src/Kern/rout/src/codetables.cpp
++++ b/cuneiform_src/Kern/rout/src/codetables.cpp
 @@ -937,13 +937,13 @@ CP_TO_CP tab[] = {
   * codepage.
   */
@@ -76,9 +73,8 @@ diff -urp cuneiform-1.1.0/cuneiform_src/Kern/rout/src/codetables.cpp cuneiform-1
 +  default : return (const unsigned char *) "?";
    }
  }
-diff -urp cuneiform-1.1.0/cuneiform_src/Kern/rout/src/rout_own.h cuneiform-1.1.0-char/cuneiform_src/Kern/rout/src/rout_own.h
---- cuneiform-1.1.0/cuneiform_src/Kern/rout/src/rout_own.h	2017-11-30 11:25:24.411125651 +0700
-+++ cuneiform-1.1.0-char/cuneiform_src/Kern/rout/src/rout_own.h	2017-11-30 11:40:01.457220419 +0700
+--- a/cuneiform_src/Kern/rout/src/rout_own.h
++++ b/cuneiform_src/Kern/rout/src/rout_own.h
 @@ -458,7 +458,7 @@ Bool SetTableTextSeparators(char* s);
  void ResetCodeTables();
  Bool UpdateActiveCodeTable();
@@ -88,9 +84,8 @@ diff -urp cuneiform-1.1.0/cuneiform_src/Kern/rout/src/rout_own.h cuneiform-1.1.0
  
  //*****************************************************************
  // Rout.cpp
-diff -urp cuneiform-1.1.0/cuneiform_src/Kern/rout/src/text.cpp cuneiform-1.1.0-char/cuneiform_src/Kern/rout/src/text.cpp
---- cuneiform-1.1.0/cuneiform_src/Kern/rout/src/text.cpp	2017-11-30 11:25:24.411125651 +0700
-+++ cuneiform-1.1.0-char/cuneiform_src/Kern/rout/src/text.cpp	2017-11-30 11:40:43.571320319 +0700
+--- a/cuneiform_src/Kern/rout/src/text.cpp
++++ b/cuneiform_src/Kern/rout/src/text.cpp
 @@ -310,7 +310,7 @@ Bool OneChar(Handle charHandle)
  				*gMemCur++ = c2;
  		}

--- a/app-text/cuneiform/files/cuneiform-1.1.0-graphicsmagick.patch
+++ b/app-text/cuneiform/files/cuneiform-1.1.0-graphicsmagick.patch
@@ -1,8 +1,5 @@
 Description: Use GraphicsMagick instead of ImageMagick.
 Author: Jakub Wilk <jwilk@debian.org>
-Forwarded: not-needed
-Last-Update: 2011-01-21
-
 --- a/cuneiform_src/cli/cuneiform-cli.cpp
 +++ b/cuneiform_src/cli/cuneiform-cli.cpp
 @@ -341,6 +341,10 @@

--- a/app-text/cuneiform/files/cuneiform-1.1.0-libm.patch
+++ b/app-text/cuneiform/files/cuneiform-1.1.0-libm.patch
@@ -1,8 +1,5 @@
 Description: Link the leo and r35 libraries with libm.
 Author: Dmitrijs Ledkovs <dmitrij.ledkov@ubuntu.com>, Jakub Wilk <jwilk@debian.org>
-Forwarded: no
-Last-Update: 2011-07-04
-
 --- a/cuneiform_src/Kern/leo/CMakeLists.txt
 +++ b/cuneiform_src/Kern/leo/CMakeLists.txt
 @@ -23,6 +23,7 @@

--- a/app-text/cuneiform/files/cuneiform-1.1.0-typos.patch
+++ b/app-text/cuneiform/files/cuneiform-1.1.0-typos.patch
@@ -1,6 +1,5 @@
 Description: fix typos
 Author: Andreas Beckmann <anbe@debian.org>
-
 --- a/cuneiform_src/Kern/rblock/sources/c/ltmain.c
 +++ b/cuneiform_src/Kern/rblock/sources/c/ltmain.c
 @@ -344,7 +344,7 @@ i=0; i=i;

--- a/net-misc/liveice/files/liveice-2000530-build.patch
+++ b/net-misc/liveice/files/liveice-2000530-build.patch
@@ -1,5 +1,5 @@
---- liveice/configure.in
-+++ liveice/configure.in
+--- a/configure.in
++++ b/configure.in
 @@ -39,6 +39,7 @@
  
  dnl Replace `main' with a function in -lresolv:
@@ -8,8 +8,8 @@
  
  
  dnl Checks for header files.
---- liveice/Makefile.in
-+++ liveice/Makefile.in
+--- a/Makefile.in
++++ b/Makefile.in
 @@ -1,6 +1,6 @@
  CC = @CC@
  CFLAGS = @CFLAGS@

--- a/net-misc/liveice/liveice-2000530-r2.ebuild
+++ b/net-misc/liveice/liveice-2000530-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools toolchain-funcs
+inherit autotools flag-o-matic toolchain-funcs
 
 DESCRIPTION="Live Source Client For IceCast"
 HOMEPAGE="http://star.arm.ac.uk/~spm/software/liveice.html"
@@ -13,15 +13,13 @@ LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 x86"
 
-RDEPEND="media-sound/lame
+RDEPEND="
+	media-sound/lame
 	media-sound/mpg123"
-DEPEND=""
+DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${PN}"
-
-PATCHES=(
-	"${FILESDIR}/${P}-build.patch"
-)
+PATCHES=( "${FILESDIR}"/${P}-build.patch )
 
 src_prepare() {
 	default
@@ -29,7 +27,12 @@ src_prepare() {
 	tc-export CC
 }
 
+src_configure() {
+	append-flags -fcommon
+	default
+}
+
 src_install() {
 	dobin liveice
-	dodoc liveice.cfg README.liveice README.quickstart README_new_mixer.txt Changes.txt
+	dodoc liveice.cfg README.{liveice,quickstart} README_new_mixer.txt Changes.txt
 }

--- a/net-p2p/dbhub/dbhub-0.451-r1.ebuild
+++ b/net-p2p/dbhub/dbhub-0.451-r1.ebuild
@@ -1,27 +1,28 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit autotools
+EAPI=7
+
+inherit autotools flag-o-matic
 
 DESCRIPTION="Hub software for Direct Connect, fork of opendchub"
-HOMEPAGE="http://www.dbhub.org"
+HOMEPAGE="https://sourceforge.net/projects/dbhub/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tbz2"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
-IUSE="debug perl nls switch-user"
+IUSE="debug nls perl switch-user"
 
-DEPEND="perl? ( dev-lang/perl )
+DEPEND="
+	perl? ( dev-lang/perl )
 	switch-user? ( sys-libs/libcap )"
-
 RDEPEND="${DEPEND}"
 
 PATCHES=(
-	"${FILESDIR}/${PN}-gentoo.patch"
-	"${FILESDIR}/${PN}-no-dynaloader.patch"
-	"${FILESDIR}/${PN}-fix-buffer-overflows.patch"
+	"${FILESDIR}"/${PN}-gentoo.patch
+	"${FILESDIR}"/${PN}-no-dynaloader.patch
+	"${FILESDIR}"/${PN}-fix-buffer-overflows.patch
 )
 
 src_prepare() {
@@ -30,9 +31,10 @@ src_prepare() {
 }
 
 src_configure() {
+	append-flags -fcommon
 	econf \
+		$(use_enable debug) \
 		$(use_enable nls) \
 		$(use_enable perl) \
-		$(use_enable switch-user switch_user) \
-		$(use_enable debug)
+		$(use_enable switch-user switch_user)
 }

--- a/sys-fs/lessfs/lessfs-1.7.0-r1.ebuild
+++ b/sys-fs/lessfs/lessfs-1.7.0-r1.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit readme.gentoo-r1
+
+inherit flag-o-matic readme.gentoo-r1
 
 MY_PV="${PV/_/-}"
 MY_P="${PN}-${MY_PV}"
@@ -17,14 +18,13 @@ KEYWORDS="amd64 x86"
 IUSE="berkdb crypt debug filelog memtrace lzo snappy"
 
 RDEPEND="
+	app-crypt/mhash
+	dev-db/tokyocabinet
+	sys-fs/fuse:0
 	berkdb? ( sys-libs/db:* )
 	crypt? ( dev-libs/openssl:0= )
 	lzo? ( dev-libs/lzo )
-	snappy? ( app-arch/snappy )
-	>=dev-db/tokyocabinet-1.4.42
-	app-crypt/mhash
-	>=sys-fs/fuse-2.8.0:0=
-"
+	snappy? ( app-arch/snappy )"
 DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${MY_P}"
@@ -35,15 +35,19 @@ DOC_CONTENTS="Default configuration file: /etc/${PN}.cfg.
 
 PATCHES=(
 	# From PLD-Linux, bug #674422
-	"${FILESDIR}/${P}-openssl11.patch"
+	"${FILESDIR}"/${P}-openssl11.patch
 )
 
 src_configure() {
+	append-flags -fcommon
 	econf \
-		$(use_enable debug) $(use_enable debug lckdebug) \
-		$(use_enable filelog) $(use_with crypt crypto) \
-		$(use_with lzo) $(use_enable memtrace) \
+		$(use_enable debug) \
+		$(use_enable debug lckdebug) \
+		$(use_enable filelog) \
+		$(use_enable memtrace) \
 		$(use_with berkdb berkeleydb) \
+		$(use_with crypt crypto) \
+		$(use_with lzo) \
 		$(use_with snappy)
 }
 

--- a/x11-wm/wmii/wmii-3.9.2-r5.ebuild
+++ b/x11-wm/wmii/wmii-3.9.2-r5.ebuild
@@ -1,43 +1,34 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit flag-o-matic multilib toolchain-funcs
 
 MY_P="wmii+ixp-${PV}"
 
 DESCRIPTION="A dynamic window manager for X11"
-HOMEPAGE="http://wmii.suckless.org/"
+HOMEPAGE="https://github.com/0intro/wmii"
 SRC_URI="http://dl.suckless.org/wmii/${MY_P}.tbz"
 
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~x86"
-IUSE=""
-
-CDEPEND="
-	>=sys-libs/libixp-0.5_p20110208-r3
-	x11-libs/libXft
-	x11-libs/libXext
-	x11-libs/libXrandr
-	x11-libs/libXrender
-	x11-libs/libX11
-	x11-libs/libXinerama
-	>=media-libs/freetype-2
-"
-
-RDEPEND="
-	${CDEPEND}
-	x11-apps/xmessage
-	x11-apps/xsetroot
-	media-fonts/font-misc-misc
-"
 
 DEPEND="
-	${CDEPEND}
-	virtual/pkgconfig
-"
+	media-libs/freetype
+	>=sys-libs/libixp-0.5_p20110208-r3
+	x11-libs/libXext
+	x11-libs/libXft
+	x11-libs/libXinerama
+	x11-libs/libXrandr
+	x11-libs/libXrender
+	x11-libs/libX11"
+RDEPEND="${DEPEND}
+	media-fonts/font-misc-misc
+	x11-apps/xmessage
+	x11-apps/xsetroot"
+BDEPEND="virtual/pkgconfig"
 
 S="${WORKDIR}/${MY_P}"
 
@@ -61,11 +52,16 @@ src_prepare() {
 	)
 
 	# punt internal copy of sys-libs/libixp #323037
-	rm -f include/ixp{,_srvutil}.h || die
+	rm include/ixp{,_srvutil}.h || die
 	sed -i -e '/libixp/d' Makefile || die
 
 	sed -i -e "/BINSH \!=/d" mk/hdr.mk || die #335083
 	sed -i -e 's/-lXext/& -lXrender -lX11/' cmd/Makefile || die #369115
+}
+
+src_configure() {
+	append-flags -fcommon
+	default
 }
 
 src_compile() {
@@ -81,5 +77,5 @@ src_install() {
 	doexe "${T}/${PN}"
 
 	insinto /usr/share/xsessions
-	doins "${FILESDIR}/${PN}.desktop"
+	doins "${FILESDIR}"/${PN}.desktop
 }


### PR DESCRIPTION
* All packages are dead upstream for many years, and patching requires significant code rewrite, so we can just use `flag-o-matic` to enable building with gcc-10