### PR TITLE
kde-apps/kalgebra: fix LICENSE

### DIFF
--- a/kde-apps/kalgebra/kalgebra-20.08.3.ebuild
+++ b/kde-apps/kalgebra/kalgebra-20.08.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ inherit ecm kde.org
 DESCRIPTION="MathML-based 2D and 3D graph calculator by KDE"
 HOMEPAGE="https://apps.kde.org/en/kalgebra https://edu.kde.org/kalgebra/"
 
-LICENSE="GPL-2" # TODO: CHECK
+LICENSE="GPL-2+"
 SLOT="5"
 KEYWORDS="amd64 arm64 x86"
 IUSE="readline"

--- a/kde-apps/kalgebra/kalgebra-20.12.2.ebuild
+++ b/kde-apps/kalgebra/kalgebra-20.12.2.ebuild
@@ -12,7 +12,7 @@ inherit ecm kde.org
 DESCRIPTION="MathML-based 2D and 3D graph calculator by KDE"
 HOMEPAGE="https://apps.kde.org/en/kalgebra https://edu.kde.org/kalgebra/"
 
-LICENSE="GPL-2" # TODO: CHECK
+LICENSE="GPL-2+"
 SLOT="5"
 KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="readline"


### PR DESCRIPTION
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Regarding LICENSE: I've checked some sourcefiles (for example: https://github.com/KDE/kalgebra/blob/master/src/main.cpp) and they all say: `...as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.`
