### PR TITLE
app-arch/engrampa: add missing optfeature inherit

### DIFF
--- a/app-arch/engrampa/engrampa-1.24.1.ebuild
+++ b/app-arch/engrampa/engrampa-1.24.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 MATE_LA_PUNT="yes"
 
-inherit mate readme.gentoo-r1
+inherit mate optfeature readme.gentoo-r1
 
 if [[ ${PV} != 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"


### PR DESCRIPTION
Installing this package doesn't show me the optional packages. 
This is because the `optfeature` doesn't get inherited, so lets fix it.

Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>