### PR TITLE
sys-cluster/nova: add missing udev inherit

### DIFF
--- a/sys-cluster/nova/nova-2020.1.9999.ebuild
+++ b/sys-cluster/nova/nova-2020.1.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_7 )
-inherit distutils-r1 eutils linux-info multilib
+inherit distutils-r1 eutils linux-info multilib udev
 
 DESCRIPTION="Cloud computing fabric controller"
 HOMEPAGE="https://launchpad.net/nova"

--- a/sys-cluster/nova/nova-2020.2.9999.ebuild
+++ b/sys-cluster/nova/nova-2020.2.9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_7 python3_8 )
 DISTUTILS_USE_SETUPTOOLS=rdepend
-inherit distutils-r1 eutils linux-info multilib
+inherit distutils-r1 eutils linux-info multilib udev
 
 DESCRIPTION="Cloud computing fabric controller"
 HOMEPAGE="https://launchpad.net/nova"

--- a/sys-cluster/nova/nova-21.1.1.ebuild
+++ b/sys-cluster/nova/nova-21.1.1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_7 )
-inherit distutils-r1 eutils linux-info multilib
+inherit distutils-r1 eutils linux-info multilib udev
 
 DESCRIPTION="Cloud computing fabric controller"
 HOMEPAGE="https://launchpad.net/nova"

--- a/sys-cluster/nova/nova-21.1.2.ebuild
+++ b/sys-cluster/nova/nova-21.1.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_7 )
-inherit distutils-r1 eutils linux-info multilib
+inherit distutils-r1 eutils linux-info multilib udev
 
 DESCRIPTION="Cloud computing fabric controller"
 HOMEPAGE="https://launchpad.net/nova"

--- a/sys-cluster/nova/nova-22.0.1.ebuild
+++ b/sys-cluster/nova/nova-22.0.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_7 python3_8 )
 DISTUTILS_USE_SETUPTOOLS=rdepend
-inherit distutils-r1 eutils linux-info multilib
+inherit distutils-r1 eutils linux-info multilib udev
 
 DESCRIPTION="Cloud computing fabric controller"
 HOMEPAGE="https://launchpad.net/nova"

--- a/sys-cluster/nova/nova-22.1.0.ebuild
+++ b/sys-cluster/nova/nova-22.1.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_7 python3_8 )
 DISTUTILS_USE_SETUPTOOLS=rdepend
-inherit distutils-r1 eutils linux-info multilib
+inherit distutils-r1 eutils linux-info multilib udev
 
 DESCRIPTION="Cloud computing fabric controller"
 HOMEPAGE="https://launchpad.net/nova"


### PR DESCRIPTION
Hi,

All ebuilds are calling `udev_newrules`
for example: https://github.com/gentoo/gentoo/blob/b3675bae9e25428c81cf9d3eba2ba6e433f4ad4c/sys-cluster/nova/nova-22.1.0.ebuild#L201
but doesn't inherit the `udev` eclass which is why i think this cannot work right now. (i haven't tested it since it pulls alot of deps for me). Never the less the ebuilds should inherit the eclass anyway.
On a side note: As far as i can see the `eutils` eclass could be removed - it doesn't get used at all :)

Please review.

Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>