### PR TITLE
sci-physics/pythia: Apply the correct patch in pythia:8

### DIFF
--- a/sci-physics/pythia/pythia-8.2.26-r1.ebuild
+++ b/sci-physics/pythia/pythia-8.2.26-r1.ebuild
@@ -40,7 +40,7 @@ DEPEND="${RDEPEND}
 	)"
 
 PATCHES=(
-	"${FILESDIR}"/${PF}-run-tests.patch
+	"${FILESDIR}"/${P}-run-tests.patch
 	"${FILESDIR}"/${PN}8209-root-noninteractive.patch
 )
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/770445
