### PR TITLE
sci-astronomy/swarp: Fix use flag typo

### DIFF
--- a/sci-astronomy/swarp/swarp-2.41.5.ebuild
+++ b/sci-astronomy/swarp/swarp-2.41.5.ebuild
@@ -24,7 +24,7 @@ src_prepare() {
 
 src_configure() {
 	econf \
-		$(use_with cfistio) \
+		$(use_with cfitsio) \
 		$(use_enable threads)
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/770469
