### PR TITLE
app-crypt/ekeyd: Update for luasocket API change, #770967

### DIFF
--- a/app-crypt/ekeyd/ekeyd-1.1.5-r101.ebuild
+++ b/app-crypt/ekeyd/ekeyd-1.1.5-r101.ebuild
@@ -1,0 +1,171 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+LUA_COMPAT=( lua5-1 )
+
+inherit linux-info lua-single systemd toolchain-funcs udev
+
+DESCRIPTION="Entropy Key userspace daemon"
+HOMEPAGE="http://www.entropykey.co.uk/"
+SRC_URI="mirror://ubuntu/pool/universe/e/ekeyd/ekeyd_${PV}.orig.tar.gz"
+
+LICENSE="MIT GPL-2" # GPL-2 (only) for init script
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="kernel_linux munin minimal usb"
+
+REQUIRED_USE="${LUA_REQUIRED_USE}
+	minimal? ( !munin )"
+
+EKEYD_RDEPEND="${LUA_DEPS}"
+EKEYD_DEPEND="${EKEYD_RDEPEND}"
+EKEYD_RDEPEND="${EKEYD_RDEPEND}
+	$(lua_gen_cond_dep '
+		dev-lua/luasocket[${LUA_USEDEP}]
+	')
+	kernel_linux? ( virtual/udev )
+	munin? ( net-analyzer/munin )"
+
+RDEPEND="!minimal? ( ${EKEYD_RDEPEND} )
+	virtual/service-manager"
+DEPEND="!minimal? ( ${EKEYD_DEPEND} )"
+
+CONFIG_CHECK="~USB_ACM"
+
+pkg_setup() {
+	if ! use minimal && use kernel_linux && ! use usb && linux_config_exists; then
+		check_extra_config
+	fi
+	lua-single_pkg_setup
+}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-const_char_usage.patch
+	"${FILESDIR}"/${P}-enoent.patch
+	"${FILESDIR}"/${P}-path-fixes.patch
+	"${FILESDIR}"/${P}-udev-rule.patch
+	"${FILESDIR}"/${P}-remove-werror.patch
+	"${FILESDIR}"/${P}-misc.patch
+	"${FILESDIR}"/${P}-makefile-lua-libs.patch
+	"${FILESDIR}"/${P}-luasocket.patch
+)
+
+src_compile() {
+	local osname
+
+	# Override automatic detection: upstream provides this with uname,
+	# we don't like using uname.
+	case ${CHOST} in
+		*-linux-*)
+			osname=linux;;
+		*-freebsd*)
+			osname=freebsd;;
+		*-kfrebsd-gnu)
+			osname=gnukfreebsd;;
+		*-openbsd*)
+			osname=openbsd;;
+		*)
+			die "Unsupported operating system!"
+			;;
+	esac
+
+	emake -C host \
+		CC="$(tc-getCC)" \
+		LUA_V=${ELUA#lua} \
+		LUA_INC="-I$(lua_get_include_dir)" \
+		OSNAME=${osname} \
+		OPT="${CFLAGS}" \
+		BUILD_ULUSBD=no \
+		$(use minimal && echo egd-linux)
+}
+
+src_install() {
+	exeinto /usr/libexec
+	newexe host/egd-linux   ekey-egd-linux
+	newman host/egd-linux.8 ekey-egd-linux.8
+
+	newconfd "${FILESDIR}"/ekey-egd-linux.conf.2 ekey-egd-linux
+	newinitd "${FILESDIR}"/ekey-egd-linux.init.2 ekey-egd-linux
+
+	dodoc doc/* AUTHORS ChangeLog THANKS
+
+	use minimal && return
+	# from here on, install everything that is not part of the minimal
+	# support.
+
+	emake -C host \
+		DESTDIR="${D}" \
+		MANZCMD=cat MANZEXT= \
+		install-ekeyd
+
+	# We move the daemons around to avoid polluting the available
+	# commands.
+	dodir /usr/libexec
+	mv "${D}"/usr/sbin/ekey*d "${D}"/usr/libexec
+
+	systemd_dounit "${FILESDIR}/ekeyd.service"
+
+	newinitd "${FILESDIR}"/${PN}.init.2 ${PN}
+
+	if use kernel_linux; then
+		local rules="${FILESDIR}/90-ekeyd.rules"
+		udev_newrules ${rules} 90-${PN}.rules
+	fi
+
+	if use munin; then
+		exeinto /usr/libexec/munin/plugins
+		doexe munin/ekeyd_stat_
+
+		insinto /etc/munin/plugin-conf.d
+		newins munin/plugin-conf.d_ekeyd ekeyd
+	fi
+}
+
+pkg_postinst() {
+	elog "${CATEGORY}/${PN} now install also the EGD client service ekey-egd-linux."
+	elog "To use this service, you need enable EGDTCPSocket for the ekeyd service"
+	elog "managing the key(s)."
+	elog ""
+	elog "The daemon will send more entropy to the kernel once the available pool"
+	elog "falls below the value set in the kernel.random.write_wakeup_threshold"
+	elog "sysctl entry."
+	elog ""
+	ewarn "Since version 1.1.4-r1, ekey-egd-linux will *not* set the watermark for"
+	ewarn "you, instead you'll have to configure the sysctl in /etc/sysctl.conf"
+
+	use minimal && return
+	# from here on, document everything that is not part of the minimal
+	# support.
+
+	elog ""
+	elog "To make use of your EntropyKey, make sure to execute ekey-rekey"
+	elog "the first time, and then start the ekeyd service."
+	elog ""
+	elog "By default ekeyd will feed the entropy directly to the kernel's pool;"
+	elog "if your system has jumps in load average, you might prefer using the"
+	elog "EGD compatibility mode, by enabling EGDTCPSocket for ekeyd and then"
+	elog "starting the ekey-egd-linux service."
+	elog ""
+	elog "The same applies if you intend to provide entropy for multiple hosts"
+	elog "over the network. If you want to have the ekey-egd-linux service on"
+	elog "other hosts, you can enable the 'minimal' USE flag."
+	elog ""
+	elog "The service supports multiplexing if you wish to use multiple"
+	elog "keys, just symlink /etc/init.d/ekeyd -> /etc/init.d/ekeyd.identifier"
+	elog "and it'll be looking for /etc/entropykey/identifier.conf"
+	elog ""
+
+		if use kernel_linux; then
+			elog "Some versions of Linux have a faulty CDC ACM driver that stops"
+			elog "EntropyKey from working properly; please check the compatibility"
+			elog "table at http://www.entropykey.co.uk/download/"
+		else
+			elog "Make sure your operating system supports the CDC ACM driver"
+			elog "or otherwise you won't be able to use the EntropyKey."
+		fi
+		elog ""
+		elog "If you're unsure about the working state of the CDC ACM driver"
+		elog "enable the usb USE flag and use the userland USB daemon"
+}

--- a/app-crypt/ekeyd/files/ekeyd-1.1.5-luasocket.patch
+++ b/app-crypt/ekeyd/files/ekeyd-1.1.5-luasocket.patch
@@ -1,0 +1,90 @@
+From: Courtney Bane <debian-bugs-4450@cbane.org>
+Date: Mon, 23 Jan 2017 20:30:59 -0600
+Subject: Fix compatibility problems with Unix domain sockets in newer
+ versions of luasocket.
+
+---
+ host/control.lua | 14 ++++++++------
+ host/ekeydctl.in |  7 ++++---
+ 2 files changed, 12 insertions(+), 9 deletions(-)
+
+diff --git a/host/control.lua b/host/control.lua
+index 7b9b1b8..22d700f 100644
+--- a/host/control.lua
++++ b/host/control.lua
+@@ -38,11 +38,11 @@ local PROTOCOL_VERSION = "1"
+ local dos_callcount = 0
+ 
+ -- Libraries we need
+-require "socket"
++socket = require "socket"
+ 
+ local have_unix_domain_sockets = false
+ function tryload_unix()
+-   require "socket.unix"
++   socket.unix = require "socket.unix"
+    have_unix_domain_sockets = true
+ end
+ 
+@@ -521,14 +521,15 @@ end
+ 
+ if have_unix_domain_sockets then
+    function UnixControlSocket(sockname)
++      local sock = socket.unix.stream or socket.unix.tcp or socket.unix
+       -- Add a UDS control socket to the set of control sockets available
+       -- First, try and connect, so we can abort if it's present.
+-      if socket.unix():connect(sockname) then
++      if sock():connect(sockname) then
+ 	 error("Control socket " .. sockname .. " already present. Is ekeyd already running?")
+       end
+       -- Okay, clean up (ignoring errors) and create a fresh socket
+       unlink(sockname)
+-      local u = socket.unix()
++      local u = sock()
+       assert(u:bind(sockname))
+       assert(u:listen())
+       addctlsocket(u, "U:" .. sockname)
+@@ -554,12 +555,13 @@ end _ "TCPControlSocket"
+ if have_unix_domain_sockets then
+    function EGDUnixSocket(sockname, modestr, user, group)
+       SetFoldedOutput()
+-      if socket.unix():connect(sockname) then
++      local sock = socket.unix.stream or socket.unix.tcp or socket.unix
++      if sock():connect(sockname) then
+ 	 error("EGD socket " .. sockname .. " already present. Is ekeyd/EGD already running?")
+       end
+       -- Add a UDS control socket to the set of control sockets available
+       unlink(sockname)
+-      local u = socket.unix()
++      local u = sock()
+       assert(u:bind(sockname))
+       assert(u:listen())
+       addctlsocket(u, "U:" .. sockname, false, egd_ctlread)
+diff --git a/host/ekeydctl.in b/host/ekeydctl.in
+index 9292ac6..802cf38 100755
+--- a/host/ekeydctl.in
++++ b/host/ekeydctl.in
+@@ -1,11 +1,11 @@
+ #!/usr/bin/env lua@LUA_V@
+ -- -*- Lua -*-
+ 
+-require "socket"
++local socket = require "socket"
+ 
+ -- Try to load the UNIX domain sockets support
+ pcall(function()
+-	 require "socket.unix"
++	 socket.unix = require "socket.unix"
+       end)
+ 
+ 
+@@ -98,7 +98,8 @@ end
+ 
+ function connect_to_daemon()
+    if __unixcontrolpath then
+-      __socket = socket.unix()
++      local sock = socket.unix.stream or socket.unix.tcp or socket.unix
++      __socket = sock()
+       local result, msg = __socket:connect(__unixcontrolpath)
+       if not result then
+ 	 error("Unable to connect to ekeyd at " .. __unixcontrolpath .. " (" .. msg .. ") Is ekeyd running?")


### PR DESCRIPTION
Due to changes in the luasocket API from luasocket-3.0_rc1-r5
to luasocket-3.0_rc1_p20200328 the ekeyd daemon and ekeydctl
utility now fail to start;

control.lua:755: control.lua:526: attempt to index global 'socket' (a nil value)

Patch from a Debian bug;
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=852380

Closes: https://bugs.gentoo.org/770967
Signed-off-by: Alan Swanson <reiver@improbability.net>