### PR TITLE
sys-libs/pam: Add prefix to sbin/unix_chkpwd

### DIFF
--- a/sys-libs/pam/pam-1.5.1.ebuild
+++ b/sys-libs/pam/pam-1.5.1.ebuild
@@ -129,5 +129,5 @@ pkg_postinst() {
 
 	# The pam_unix module needs to check the password of the user which requires
 	# read access to /etc/shadow only.
-	fcaps cap_dac_override sbin/unix_chkpwd
+	fcaps cap_dac_override "${EPREFIX}"/sbin/unix_chkpwd
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/771132