### PR TITLE
dev-lang/zig : Use llvm 11

### DIFF
--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -27,9 +27,9 @@ ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]}
 
 RDEPEND="
-	sys-devel/llvm:9
+	sys-devel/llvm:11
 	!experimental? ( sys-devel/llvm:9[${LLVM_TARGET_USEDEPS// /,}] )
-	sys-devel/clang:9
+	sys-devel/clang:11
 "
 
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Zig now require llvm 11 to build and fail to compile