### PR TITLE
sys-power/uhubctl: amend for chromium os toolchain

### DIFF
--- a/sys-power/uhubctl/uhubctl-2.4.0.ebuild
+++ b/sys-power/uhubctl/uhubctl-2.4.0.ebuild
@@ -24,6 +24,8 @@ src_prepare() {
 		-e "s/^GIT_VERSION/#&/" \
 		Makefile \
 		|| die
+
+	tc-export PKG_CONFIG
 }
 
 src_compile() {

--- a/sys-power/uhubctl/uhubctl-2.4.0.ebuild
+++ b/sys-power/uhubctl/uhubctl-2.4.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/mvp/uhubctl/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="*"
 IUSE=""
 
 DEPEND="virtual/libusb:1"


### PR DESCRIPTION
The two commits address two failures in the chromium os toolchain.
1. using tc-export for pkg-config
2. reverting to the * keyword