### PR TITLE
Add llvm 11.1 support to spirv-llvm-translator and opencl-clang

### DIFF
--- a/dev-libs/opencl-clang/files/llvm-11.1.0.patch
+++ b/dev-libs/opencl-clang/files/llvm-11.1.0.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2021-02-18 14:52:20.079691789 +0000
++++ b/CMakeLists.txt	2021-02-18 14:47:43.773873042 +0000
+@@ -20,7 +20,7 @@
+     add_definitions(-DUSE_PREBUILT_LLVM)
+ 
+     if(NOT PREFERRED_LLVM_VERSION)
+-        set(PREFERRED_LLVM_VERSION "11.0.0")
++        set(PREFERRED_LLVM_VERSION "11.1.0")
+     endif(NOT PREFERRED_LLVM_VERSION)
+     message(STATUS "Looking for LLVM version ${PREFERRED_LLVM_VERSION}")
+     find_package(LLVM ${PREFERRED_LLVM_VERSION} REQUIRED)

--- a/dev-libs/opencl-clang/opencl-clang-11.0.0-r1.ebuild
+++ b/dev-libs/opencl-clang/opencl-clang-11.0.0-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS=cmake
+
+inherit cmake-multilib llvm
+
+MY_PV="$(ver_rs 3 -)"
+MY_P="${PN}-${MY_PV}"
+
+DESCRIPTION="OpenCL-oriented thin wrapper library around clang"
+HOMEPAGE="https://github.com/intel/opencl-clang"
+SRC_URI="https://github.com/intel/${PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="UoI-NCSA"
+SLOT="11"
+KEYWORDS="~amd64"
+
+S="${WORKDIR}/${MY_P}"
+
+# Force a rebuild of this package once clang has been updated from 10.0.0 to 10.0.1
+# in order to work around Bug #743992. Hopefully a one-time thing.
+DEPEND="~sys-devel/clang-11.1.0:11=[static-analyzer,${MULTILIB_USEDEP}]
+	~sys-devel/llvm-11.1.0:11=[${MULTILIB_USEDEP}]
+	>=dev-util/spirv-llvm-translator-11.0.0:11=[${MULTILIB_USEDEP}]"
+RDEPEND="${DEPEND}"
+
+LLVM_MAX_SLOT=11
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-8.0.0-clang_library_dir.patch
+	"${FILESDIR}"/${PN}-10.0.0.1_find-llvm-tblgen.patch
+	"${FILESDIR}"/llvm-11.1.0.patch
+)
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_INSTALL_PREFIX="$(get_llvm_prefix ${LLVM_MAX_SLOT})"
+		-DCLANG_LIBRARY_DIRS="${EPREFIX}"/usr/lib/clang
+	)
+	cmake_src_configure
+}

--- a/dev-util/spirv-llvm-translator/files/llvm-11.1.0.patch
+++ b/dev-util/spirv-llvm-translator/files/llvm-11.1.0.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	2021-02-18 14:52:20.079691789 +0000
++++ b/CMakeLists.txt	2021-02-18 14:47:43.773873042 +0000
+@@ -1,6 +1,6 @@
+ cmake_minimum_required(VERSION 3.3)
+ 
+-set (BASE_LLVM_VERSION 11.0.0)
++set (BASE_LLVM_VERSION 11.1.0)
+ set(LLVM_SPIRV_VERSION ${BASE_LLVM_VERSION}.0)
+ 
+ option(LLVM_SPIRV_INCLUDE_TESTS

--- a/dev-util/spirv-llvm-translator/spirv-llvm-translator-11.0.0-r1.ebuild
+++ b/dev-util/spirv-llvm-translator/spirv-llvm-translator-11.0.0-r1.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS=cmake
+
+inherit cmake-multilib flag-o-matic llvm
+
+EGIT_COMMIT="d6dc999eee381158a26f048a333467c9ce7e77f2"
+MY_PN="SPIRV-LLVM-Translator"
+MY_P="${MY_PN}-${EGIT_COMMIT}"
+
+DESCRIPTION="Bi-directional translator between SPIR-V and LLVM IR"
+HOMEPAGE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
+SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="UoI-NCSA"
+SLOT="11"
+KEYWORDS="~amd64"
+IUSE="test tools"
+
+# I have yet to see a non-release spirv-llvm-translator ebuild pass ANY tests.
+# This is probably something silly like the test suite expecting different
+# directory names but I really can't be bothered to debug VCS snapshots.
+RESTRICT="test"
+
+S="${WORKDIR}/${MY_P}"
+
+COMMON="~sys-devel/clang-11.1.0:11=[${MULTILIB_USEDEP}]"
+DEPEND="${COMMON}"
+RDEPEND="${COMMON}"
+BDEPEND="test? ( dev-python/lit )"
+
+REQUIRED_USE="test? ( tools )"
+
+LLVM_MAX_SLOT=11
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-8.0.0.1-no_pkgconfig_files.patch
+	"${FILESDIR}"/llvm-11.1.0.patch
+)
+
+src_prepare() {
+	append-flags -fPIC
+	cmake_src_prepare
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_INSTALL_PREFIX="$(get_llvm_prefix ${LLVM_MAX_SLOT})"
+		-DLLVM_BUILD_TOOLS=$(usex tools "ON" "OFF")
+		$(usex test "-DLLVM_INCLUDE_TESTS=ON" "")
+	)
+	cmake_src_configure
+}
+
+multilib_src_test() {
+	# Some tests fail on amd64 when ABI==x86
+	if multilib_is_native_abi; then
+		lit "${BUILD_DIR}/test" || die "Error running tests for ABI ${ABI}"
+	fi
+}


### PR DESCRIPTION
Without this I had issues upgrading to llvm-11.1, clang-11.1 and lld-11.1