### PR TITLE
games-util/lutris: Add dev-python/lxml and x11-libs/gdk-pixbuf[jpeg] to RDEPEND

### DIFF
--- a/games-util/lutris/lutris-9999.ebuild
+++ b/games-util/lutris/lutris-9999.ebuild
@@ -45,6 +45,7 @@ RDEPEND="
 		dev-python/python-magic[${PYTHON_USEDEP}]
 		dev-python/pyyaml[${PYTHON_USEDEP}]
 		dev-python/requests[${PYTHON_USEDEP}]
+		dev-python/lxml[${PYTHON_USEDEP}]
 	')
 	gnome-base/gnome-desktop:3[introspection]
 	media-sound/fluid-soundfont
@@ -55,6 +56,7 @@ RDEPEND="
 	x11-apps/xrandr
 	x11-libs/gtk+:3[introspection]
 	x11-libs/libnotify[introspection]
+	x11-libs/gdk-pixbuf[jpeg]
 "
 
 python_install_all() {


### PR DESCRIPTION
Hi, currently lutris-9999 breaks without dev-python/lxml, since it is now required. Furthermore, a gdk-pixbuf with jpeg is required to load thumbnails. Lutris errors otherwise and displays garbage/undefined image outputs. This change adds both lxml and requires gdk-pixbuf be built with JPEG support to the lutris-9999 ebuild