### PR TITLE
net-dialup/ppp: add back option to disable eap-tls

### DIFF
--- a/net-dialup/ppp/ppp-2.4.9-r2.ebuild
+++ b/net-dialup/ppp/ppp-2.4.9-r2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/paulusmack/ppp/archive/${P}.tar.gz
 LICENSE="BSD GPL-2"
 SLOT="0/${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="activefilter atm dhcp gtk ipv6 libressl pam radius"
+IUSE="activefilter atm dhcp +eap-tls gtk ipv6 libressl pam radius"
 
 DEPEND="
 	activefilter? ( net-libs/libpcap )
@@ -67,6 +67,14 @@ src_prepare() {
 		sed \
 			-e '/^SUBDIRS :=/s:$: dhcp:' \
 			-i pppd/plugins/Makefile.linux || die
+	fi
+
+	if ! use eap-tls ; then
+		einfo "Disabling EAP-TLS pppd auth support"
+		sed -i '/^USE_EAPTLS=y/s:^:#:' pppd/Makefile.linux || die
+		einfo "Disabling EAP-TLS plugin support"
+		sed -i '/^CFLAGS += -DUSE_EAPTLS=1/s:^:#:' \
+			pppd/plugins/Makefile.linux || die
 	fi
 
 	# Set correct libdir


### PR DESCRIPTION
The eap-tls use flag went away between ppp-2.4.8 and ppp-2.4.9
maybe due to the fact that upstream now supports eap-tls and has
it enabled by default (no more ebuild patches for it).

Regardless, having an option to disable it is still useful for
those who want to minimize attack vector surface so add it back.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>