### PR TITLE
app-misc/dateutils: Stabilize 0.4.6 for amd64

### DIFF
--- a/app-misc/dateutils/dateutils-0.4.6.ebuild
+++ b/app-misc/dateutils/dateutils-0.4.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ case "${PV}" in
 		;;
 	*)
 		SRC_URI="https://github.com/hroptatyr/dateutils/releases/download/v${PV}/${P}.tar.xz"
-		KEYWORDS="~amd64 ~x86"
+		KEYWORDS="amd64 ~x86"
 esac
 
 LICENSE="BSD"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/771666
Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Matthias Coppens <coppens.matthias.abc@gmail.com>