### PR TITLE
dev-libs/libbase58: Add missing test DEPEND on app-editors/vim-core (for xxd)

### DIFF
--- a/dev-libs/libbase58/libbase58-0.1.4-r1.ebuild
+++ b/dev-libs/libbase58/libbase58-0.1.4-r1.ebuild
@@ -18,7 +18,10 @@ RESTRICT="!test? ( test )"
 # NOTE: If not testing, we don't need non-native libgcrypt
 RDEPEND="tools? ( dev-libs/libgcrypt )"
 DEPEND="${RDEPEND}
-	test? ( dev-libs/libgcrypt[${MULTILIB_USEDEP}] )
+	test? (
+		app-editors/vim-core
+		dev-libs/libgcrypt[${MULTILIB_USEDEP}]
+	)
 "
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/771672