### PR TITLE
 media-plugins/vdr-rssreader: update SRC_URI, new EAPI for version 2.2.1, new version 2.4.0

### DIFF
--- a/media-plugins/vdr-rssreader/metadata.xml
+++ b/media-plugins/vdr-rssreader/metadata.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-<email>vdr@gentoo.org</email>
-<name>Gentoo VDR Project</name>
-</maintainer>
+	<maintainer type="person" proxied="yes">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>vdr@gentoo.org</email>
+		<name>Gentoo VDR Project</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github"> rofafor/vdr-plugin-rssreader</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/media-plugins/vdr-rssreader/vdr-rssreader-2.2.1-r2.ebuild
+++ b/media-plugins/vdr-rssreader/vdr-rssreader-2.2.1-r2.ebuild
@@ -1,0 +1,35 @@
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit vdr-plugin-2
+
+DESCRIPTION="VDR Plugin: RSS reader"
+HOMEPAGE="https://github.com/rofafor/vdr-plugin-rssreader"
+SRC_URI="https://github.com/rofafor/vdr-plugin-rssreader/archive/v${PV}.tar.gz -> ${P}.tgz"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	>=media-video/vdr-2.2.0
+	>=dev-libs/expat-1.95.8
+	>=net-misc/curl-7.15.1-r1"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.0.0-gentoo.diff"
+	"${FILESDIR}/${P}_c++11.patch"
+)
+QA_FLAGS_IGNORED="
+	usr/lib/vdr/plugins/libvdr-rssreader.*
+	usr/lib64/vdr/plugins/libvdr-rssreader.*"
+
+src_install() {
+	vdr-plugin-2_src_install
+
+	insinto /etc/vdr/plugins/rssreader
+	doins "${S}/rssreader/rssreader.conf"
+}

--- a/media-plugins/vdr-rssreader/vdr-rssreader-2.4.0-r1.ebuild
+++ b/media-plugins/vdr-rssreader/vdr-rssreader-2.4.0-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit vdr-plugin-2
+
+MY_P="vdr-plugin-rssreader-${PV}"
+
+DESCRIPTION="VDR Plugin: RSS reader"
+HOMEPAGE="https://github.com/rofafor/vdr-plugin-rssreader"
+SRC_URI="https://github.com/rofafor/vdr-plugin-rssreader/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	>=media-video/vdr-2.4.0
+	>=dev-libs/expat-1.95.8
+	>=net-misc/curl-7.15.1-r1"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.0.0-gentoo.diff"
+)
+QA_FLAGS_IGNORED="
+	usr/lib/vdr/plugins/libvdr-rssreader.*
+	usr/lib64/vdr/plugins/libvdr-rssreader.*"
+S="${WORKDIR}/${MY_P}"
+
+src_install() {
+	vdr-plugin-2_src_install
+
+	insinto /etc/vdr/plugins/rssreader
+	doins "${S}/rssreader/rssreader.conf"
+}


### PR DESCRIPTION
media-plugin/vdr-rssreader-2.2.1-r2: update SRC_URI, new EAPI 
for use with media-video/vdr-2.2

media-plugins/vdr-rssreader.2.4.0: version bump to version 2.4.0
for use with media-video/vdr-2.4

Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>