### PR TITLE
Kicad2

### DIFF
--- a/app-doc/kicad-doc/kicad-doc-5.1.9.ebuild
+++ b/app-doc/kicad-doc/kicad-doc-5.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://gitlab.com/kicad/services/${PN}/-/archive/${PV}/${P}.tar.bz2"
 
 LICENSE="|| ( GPL-3+ CC-BY-3.0 ) GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="html +pdf"
 
 LANG_USE=" l10n_ca l10n_de l10n_en l10n_es l10n_fr l10n_id l10n_it l10n_ja l10n_pl l10n_ru l10n_zh"

--- a/app-eselect/eselect-opencascade/eselect-opencascade-1.ebuild
+++ b/app-eselect/eselect-opencascade/eselect-opencascade-1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ SRC_URI=""
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE=""
 
 DEPEND=""

--- a/app-text/dblatex/dblatex-0.3.11-r1.ebuild
+++ b/app-text/dblatex/dblatex-0.3.11-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://downloads.sourceforge.net/project/dblatex/dblatex/${P}/${P}py3.
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 arm ~hppa ~ia64 ~ppc64 ~sparc x86"
+KEYWORDS="amd64 arm ~arm64 ~hppa  ~ia64 ~ppc64 ~sparc x86"
 IUSE="inkscape"
 
 RDEPEND="

--- a/dev-libs/pegtl/pegtl-3.2.0.ebuild
+++ b/dev-libs/pegtl/pegtl-3.2.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/taocpp/PEGTL/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-tcltk/itcl/itcl-4.2.0.ebuild
+++ b/dev-tcltk/itcl/itcl-4.2.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://sourceforge/project/incrtcl/%5Bincr%20Tcl_Tk%5D-4-source/itcl%
 
 SLOT="0"
 LICENSE="BSD"
-KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/tcl-8.6:0="

--- a/dev-tcltk/itk/itk-4.1.0.ebuild
+++ b/dev-tcltk/itk/itk-4.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ SRC_URI="mirror://sourceforge/project/incrtcl/%5Bincr%20Tcl_Tk%5D-4-source/itk%2
 IUSE=""
 SLOT="0"
 LICENSE="BSD"
-KEYWORDS="amd64 ~ia64 ppc sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm64 ~ia64 ppc sparc x86 ~amd64-linux ~x86-linux"
 RESTRICT="!test? ( test )"
 
 DEPEND="

--- a/media-fonts/vlgothic/vlgothic-20141206.ebuild
+++ b/media-fonts/vlgothic/vlgothic-20141206.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ SRC_URI="mirror://sourceforge.jp/${PN}/62375/${MY_PN}-${PV}.tar.bz2"
 # sazanami -> BSD-2
 LICENSE="vlgothic mplus-fonts BSD-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 ~arm64 ~ia64 ppc ppc64 sparc x86"
 
 S="${WORKDIR}/${MY_PN}"
 

--- a/media-libs/freeimage/freeimage-3.18.0-r2.ebuild
+++ b/media-libs/freeimage/freeimage-3.18.0-r2.ebuild
@@ -17,7 +17,7 @@ SRC_URI="mirror://sourceforge/${PN}/${MY_P}.zip
 
 LICENSE="|| ( GPL-2 FIPL-1.0 )"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="jpeg jpeg2k mng openexr png raw static-libs tiff webp"
 
 # The tiff/ilmbase isn't a typo.  The TIFF plugin cheats and

--- a/media-libs/libharu/libharu-2.3.0-r2.ebuild
+++ b/media-libs/libharu/libharu-2.3.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/${PN}/${PN}/archive/${MYP}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 DEPEND="

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -308,10 +308,6 @@ sys-libs/libblockdev dmraid
 >=media-plugins/grilo-plugins-0.3.5 upnp-av
 
 # Mart Raudsepp <leio@gentoo.org> (2018-02-13)
-# USE=vtk requires sci-libs/vtk that is not keyworded yet.
-media-libs/opencv vtk
-
-# Mart Raudsepp <leio@gentoo.org> (2018-02-13)
 # USE=lua requires dev-lua/lgi that is not keyworded yet.
 dev-libs/libpeas lua
 

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -220,8 +220,7 @@ media-video/transcode -sdl
 
 # Virgil Dupras <vdupras@gentoo.org> (2018-09-06)
 # sci-libs/opencascade not yet keyworded
-# sci-libs/oce not yet keyworded
-sci-electronics/kicad occ oce
+sci-electronics/kicad occ
 
 # Michał Górny <mgorny@gentoo.org> (2018-07-07)
 # Unkeyworded dependencies.

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,9 +1,23 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Roy Bamford ,neddyseagoon@gentoo.org> (2021-02-20)
+# sci-libs/hdf does not build on arm64 bug #771648
+sci-libs/netcdf hdf
+
 # Thomas Deutschmann <whissi@gentoo.org> (2021-02-17)
 # Unmask PCRE JIT support where dev-libs/libpcre2[jit] is available
 dev-lang/php -jit
+
+# Roy Bamford ,neddyseagoon@gentoo.org> (2021-02-14)
+# all-modules needs sci-libs/kissfft not yet in gentoo bug #754684
+# build fails with USE=java
+sci-libs/vtk all-modules java
+
+# Sam James <sam@gentoo.org> (2021-02-06)
+# media-sound/sndio is not yet keyworded here
+# bug #769098, bug #769122
+media-libs/openal sndio
 
 # Sam James <sam@gentoo.org> (2021-02-05)
 # Requires pandoc. We don't yet have Haskell

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -219,10 +219,9 @@ media-video/transcode -sdl
 >=x11-libs/wxGTK-3 -sdl
 
 # Virgil Dupras <vdupras@gentoo.org> (2018-09-06)
-# sci-electronics/ngspice not yet keyworded, bug #665416
 # sci-libs/opencascade not yet keyworded
 # sci-libs/oce not yet keyworded
-sci-electronics/kicad occ oce ngspice
+sci-electronics/kicad occ oce
 
 # Michał Górny <mgorny@gentoo.org> (2018-07-07)
 # Unkeyworded dependencies.

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -232,10 +232,6 @@ media-video/mpv -sdl
 media-video/transcode -sdl
 >=x11-libs/wxGTK-3 -sdl
 
-# Virgil Dupras <vdupras@gentoo.org> (2018-09-06)
-# sci-libs/opencascade not yet keyworded
-sci-electronics/kicad occ
-
 # Michał Górny <mgorny@gentoo.org> (2018-07-07)
 # Unkeyworded dependencies.
 net-libs/gnome-online-accounts gnome

--- a/sci-electronics/kicad-footprints/kicad-footprints-5.1.9.ebuild
+++ b/sci-electronics/kicad-footprints/kicad-footprints-5.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,6 +11,6 @@ SRC_URI="https://gitlab.com/kicad/libraries/${PN}/-/archive/${PV}/${P}.tar.bz2"
 
 LICENSE="CC-BY-SA-4.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND=">=sci-electronics/kicad-5.1.0"

--- a/sci-electronics/kicad-i18n/kicad-i18n-5.1.9.ebuild
+++ b/sci-electronics/kicad-i18n/kicad-i18n-5.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://gitlab.com/kicad/code/${PN}/-/archive/${PV}/${P}.tar.bz2"
 
 LICENSE="CC-BY-SA-4.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 BDEPEND="sys-devel/gettext"
 RDEPEND=">=sci-electronics/kicad-5.1.6"

--- a/sci-electronics/kicad-meta/kicad-meta-5.1.9.ebuild
+++ b/sci-electronics/kicad-meta/kicad-meta-5.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ SRC_URI=""
 
 LICENSE="metapackage"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="doc minimal nls"
 
 RDEPEND="

--- a/sci-electronics/kicad-packages3d/kicad-packages3d-5.1.9.ebuild
+++ b/sci-electronics/kicad-packages3d/kicad-packages3d-5.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${PV}/kic
 
 LICENSE="CC-BY-SA-4.0"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="occ +oce"
 
 REQUIRED_USE="|| ( occ oce )"

--- a/sci-electronics/kicad-symbols/kicad-symbols-5.1.9.ebuild
+++ b/sci-electronics/kicad-symbols/kicad-symbols-5.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,6 +11,6 @@ SRC_URI="https://gitlab.com/kicad/libraries/${PN}/-/archive/${PV}/${P}.tar.bz2"
 
 LICENSE="CC-BY-SA-4.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND=">=sci-electronics/kicad-5.1.0"

--- a/sci-electronics/kicad-templates/kicad-templates-5.1.9.ebuild
+++ b/sci-electronics/kicad-templates/kicad-templates-5.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,6 +11,6 @@ SRC_URI="https://gitlab.com/kicad/libraries/${PN}/-/archive/${PV}/${P}.tar.bz2"
 
 LICENSE="CC-BY-SA-4.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND=">=sci-electronics/kicad-5.1.0"

--- a/sci-electronics/ngspice/ngspice-31-r1.ebuild
+++ b/sci-electronics/ngspice/ngspice-31-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ LICENSE="BSD GPL-2"
 SLOT="0"
 IUSE="X debug deprecated doc examples fftw openmp +readline +shared tcl"
 RESTRICT="!test? ( test )"
-KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~x64-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc ~sparc ~x86 ~x64-macos"
 
 DEPEND="sys-libs/ncurses:0=
 	X? ( x11-libs/libXaw

--- a/sci-libs/exodusii/exodusii-6.09.ebuild
+++ b/sci-libs/exodusii/exodusii-6.09.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -15,7 +15,7 @@ SRC_URI="https://dev.gentoo.org/~asturm/distfiles/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 x86 ~amd64-linux ~x86-linux"
 IUSE="static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/sci-libs/netcdf-cxx/netcdf-cxx-4.2-r300.ebuild
+++ b/sci-libs/netcdf-cxx/netcdf-cxx-4.2-r300.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -11,7 +11,7 @@ SRC_URI="https://www.unidata.ucar.edu/downloads/netcdf/ftp/${P}.tar.gz"
 
 LICENSE="UCAR-Unidata"
 SLOT="3"
-KEYWORDS="amd64 ~arm x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 x86 ~amd64-linux ~x86-linux"
 IUSE="examples static-libs"
 
 RDEPEND=">=sci-libs/netcdf-4.2:0="

--- a/sci-libs/netcdf/netcdf-4.7.4.ebuild
+++ b/sci-libs/netcdf/netcdf-4.7.4.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/Unidata/netcdf-c/archive/v${PV}.tar.gz -> ${P}.tar.g
 
 LICENSE="UCAR-Unidata"
 SLOT="0/18"
-KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
 IUSE="+dap doc examples hdf +hdf5 mpi szip test tools"
 RESTRICT="!test? ( test )"
 

--- a/sci-libs/oce/oce-0.18.3-r2.ebuild
+++ b/sci-libs/oce/oce-0.18.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/tpaviot/oce/archive/OCE-$PV.tar.gz"
 
 LICENSE="|| ( Open-CASCADE-LGPL-2.1-Exception-1.0 LGPL-2.1 )"
 SLOT="${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="examples freeimage gl2ps +openmp tbb vtk"
 REQUIRED_USE="?? ( openmp tbb )"
 

--- a/sci-libs/opencascade/opencascade-7.4.0-r4.ebuild
+++ b/sci-libs/opencascade/opencascade-7.4.0-r4.ebuild
@@ -16,7 +16,8 @@ SRC_URI="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/ta
 
 LICENSE="|| ( Open-CASCADE-LGPL-2.1-Exception-1.0 LGPL-2.1 )"
 SLOT="${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
+# gl2ps
 IUSE="debug doc examples ffmpeg freeimage gles2 inspector java optimize qt5 tbb +vtk"
 
 REQUIRED_USE="

--- a/sci-libs/vtk/vtk-8.2.0-r1.ebuild
+++ b/sci-libs/vtk/vtk-8.2.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -23,7 +23,7 @@ SRC_URI="
 
 LICENSE="BSD LGPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="all-modules aqua boost doc examples ffmpeg gdal imaging java json mpi
 	odbc offscreen postgres python qt5 R rendering tbb tcl theora tk
 	video_cards_nvidia views web +X xdmf2"

--- a/sci-libs/xdmf2/xdmf2-1.0_p141226-r4.ebuild
+++ b/sci-libs/xdmf2/xdmf2-1.0_p141226-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://dev.gentoo.org/~jlec/distfiles/${P}.tar.xz"
 
 LICENSE="VTK"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc test"
 
 RESTRICT="!test? ( test )"

--- a/sci-visualization/xgraph/xgraph-12.1-r4.ebuild
+++ b/sci-visualization/xgraph/xgraph-12.1-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ SRC_URI="http://www.isi.edu/nsnam/dist/${P}.tar.gz
 
 LICENSE="xgraph"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="examples"
 RDEPEND="x11-libs/libSM
 	x11-libs/libX11"


### PR DESCRIPTION
Added ~arm64 to sci-electronics/kicad-meta
It all built with USE=test FEATURES=test.

After keywording vtk removed media-libs/opencv vtk from p.u.m. It built with  USE=test FEATURES=test