### PR TITLE
media-libs/opencv: drop dependency on virtual/lapacke

### DIFF
--- a/media-libs/opencv/opencv-4.5.0.ebuild
+++ b/media-libs/opencv/opencv-4.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -115,7 +115,6 @@ RDEPEND="
 	lapack? (
 		virtual/cblas
 		virtual/lapack
-		virtual/lapacke
 	)
 	opencl? ( virtual/opencl[${MULTILIB_USEDEP}] )
 	openexr? ( media-libs/openexr[${MULTILIB_USEDEP}] )

--- a/media-libs/opencv/opencv-4.5.1.ebuild
+++ b/media-libs/opencv/opencv-4.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -117,7 +117,6 @@ RDEPEND="
 	lapack? (
 		virtual/cblas
 		virtual/lapack
-		virtual/lapacke
 	)
 	opencl? ( virtual/opencl[${MULTILIB_USEDEP}] )
 	openexr? ( media-libs/openexr[${MULTILIB_USEDEP}] )


### PR DESCRIPTION
Package-Manager: Portage-3.0.14, Repoman-3.0.2
