### PR TITLE
sci-libs/opencascade: restrict to <vtk-9

### DIFF
--- a/sci-libs/opencascade/opencascade-7.4.0-r4.ebuild
+++ b/sci-libs/opencascade/opencascade-7.4.0-r4.ebuild
@@ -48,7 +48,10 @@ RDEPEND="
 		dev-qt/qtxml:5
 	)
 	tbb? ( dev-cpp/tbb )
-	vtk? ( >=sci-libs/vtk-8.1.0[rendering] )
+	vtk? (
+		>=sci-libs/vtk-8.1.0[rendering]
+		<sci-libs/vtk-9
+	)
 "
 DEPEND="${RDEPEND}"
 BDEPEND="


### PR DESCRIPTION
This version is not compatible with vtk-9. Because I got
several notifications on my overlay and via email, to make
this clear, the package needs to be restricted to <vtk-9,
although it's not yet available in ::gentoo.

Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>