### PR TITLE
net-proxy/haproxy: add systemd as DEPEND

### DIFF
--- a/net-proxy/haproxy/haproxy-1.8.28.ebuild
+++ b/net-proxy/haproxy/haproxy-1.8.28.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-1.8.29.ebuild
+++ b/net-proxy/haproxy/haproxy-1.8.29.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.0.14-r2.ebuild
+++ b/net-proxy/haproxy/haproxy-2.0.14-r2.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.0.21.ebuild
+++ b/net-proxy/haproxy/haproxy-2.0.21.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.0.9999.ebuild
+++ b/net-proxy/haproxy/haproxy-2.0.9999.ebuild
@@ -41,6 +41,7 @@ DEPEND="
 		!libressl? ( dev-libs/openssl:0=[zlib?] )
 		libressl? ( dev-libs/libressl:0= )
 	)
+	systemd? ( sys-apps/systemd )
 	slz? ( dev-libs/libslz:= )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )

--- a/net-proxy/haproxy/haproxy-2.1.12.ebuild
+++ b/net-proxy/haproxy/haproxy-2.1.12.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.1.4-r2.ebuild
+++ b/net-proxy/haproxy/haproxy-2.1.4-r2.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.1.9999.ebuild
+++ b/net-proxy/haproxy/haproxy-2.1.9999.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.2.11.ebuild
+++ b/net-proxy/haproxy/haproxy-2.2.11.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.2.12.ebuild
+++ b/net-proxy/haproxy/haproxy-2.2.12.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.2.5-r1.ebuild
+++ b/net-proxy/haproxy/haproxy-2.2.5-r1.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.2.9999.ebuild
+++ b/net-proxy/haproxy/haproxy-2.2.9999.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.3.7.ebuild
+++ b/net-proxy/haproxy/haproxy-2.3.7.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.3.8.ebuild
+++ b/net-proxy/haproxy/haproxy-2.3.8.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.3.9.ebuild
+++ b/net-proxy/haproxy/haproxy-2.3.9.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"

--- a/net-proxy/haproxy/haproxy-2.3.9999.ebuild
+++ b/net-proxy/haproxy/haproxy-2.3.9999.ebuild
@@ -42,6 +42,7 @@ DEPEND="
 		libressl? ( dev-libs/libressl:0= )
 	)
 	slz? ( dev-libs/libslz:= )
+	systemd? ( sys-apps/systemd )
 	zlib? ( sys-libs/zlib )
 	lua? ( dev-lang/lua:5.3 )
 	device-atlas? ( dev-libs/device-atlas-api-c )"


### PR DESCRIPTION
systemd headers are needed at buildtime
also remove libressl dependency

Package-Manager: Portage-3.0.14, Repoman-3.0.2
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>