### PR TITLE
media-fonts/polarsys-b612-fonts: Update license

### DIFF
--- a/media-fonts/polarsys-b612-fonts/polarsys-b612-fonts-1.003.ebuild
+++ b/media-fonts/polarsys-b612-fonts/polarsys-b612-fonts-1.003.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit font vcs-snapshot
 
@@ -9,7 +9,7 @@ DESCRIPTION="Font designed for aircraft cockpit displays"
 HOMEPAGE="https://b612-font.com/"
 SRC_URI="https://git.polarsys.org/c/b612/b612.git/snapshot/b612-bd14fde2544566e620eab106eb8d6f2b7fb1347e.tar.bz2 -> ${P}.tar.bz2"
 
-LICENSE="EPL-1.0"
+LICENSE="EPL-1.0 BSD OFL-1.1"   # to be clarified #746725
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ppc ppc64 x86"
 IUSE=""

--- a/media-fonts/polarsys-b612-fonts/polarsys-b612-fonts-1.008.ebuild
+++ b/media-fonts/polarsys-b612-fonts/polarsys-b612-fonts-1.008.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit font
 
@@ -9,7 +9,7 @@ DESCRIPTION="Font designed for aircraft cockpit displays"
 HOMEPAGE="https://b612-font.com/"
 SRC_URI="https://github.com/polarsys/b612/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="OFL-1.1"
+LICENSE="EPL-1.0 BSD OFL-1.1"   # to be clarified #746725
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 IUSE=""


### PR DESCRIPTION
Upstream did not react yet. So add the other licenses too.
While at it, bump to EAPI 7.

Bug: https://bugs.gentoo.org/746725
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Jan Henke <Jan.Henke@taujhe.de>