### PR TITLE
app-editors/retext: Depend optionally on qtwebengine

### DIFF
--- a/app-editors/retext/retext-7.2.0-r1.ebuild
+++ b/app-editors/retext/retext-7.2.0-r1.ebuild
@@ -37,10 +37,10 @@ RDEPEND="
 	dev-python/markups[${PYTHON_USEDEP}]
 	dev-python/pygments[${PYTHON_USEDEP}]
 	dev-python/python-markdown-math[${PYTHON_USEDEP}]
-	dev-python/PyQt5[gui,network,printsupport,widgets,${PYTHON_USEDEP}]
-	dev-python/PyQtWebEngine[${PYTHON_USEDEP}]
+	dev-python/PyQt5[dbus,gui,printsupport,widgets,${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}"
+BDEPEND="test? ( dev-python/PyQt5[testlib,${PYTHON_USEDEP}] )"
 
 src_test() {
 	virtx distutils-r1_src_test
@@ -55,11 +55,13 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	optfeature "dictionary support" dev-python/pyenchant
+	# See https://bugs.gentoo.org/772197.
+	optfeature "rendering with webengine" dev-python/PyQtWebEngine
 
 	einfo "Starting with retext-7.0.4 the markdown-math plugin is installed."
 	einfo "Note that you can use different math delimiters, e.g. \(...\) for inline math."
 	einfo "For more details take a look at:"
-	einfo "https://github.com/mitya57/python-markdown-math#math-delimiters"
+	einfo "https://github.com/mitya57/python-markdown-math#math-delimiters"	
 }
 
 pkg_postrm() {

--- a/app-editors/retext/retext-9999.ebuild
+++ b/app-editors/retext/retext-9999.ebuild
@@ -37,10 +37,10 @@ RDEPEND="
 	dev-python/markups[${PYTHON_USEDEP}]
 	dev-python/pygments[${PYTHON_USEDEP}]
 	dev-python/python-markdown-math[${PYTHON_USEDEP}]
-	dev-python/PyQt5[gui,network,printsupport,widgets,${PYTHON_USEDEP}]
-	dev-python/PyQtWebEngine[${PYTHON_USEDEP}]
+	dev-python/PyQt5[dbus,gui,printsupport,widgets,${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}"
+BDEPEND="test? ( dev-python/PyQt5[testlib,${PYTHON_USEDEP}] )"
 
 src_test() {
 	virtx distutils-r1_src_test
@@ -55,11 +55,13 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	optfeature "dictionary support" dev-python/pyenchant
+	# See https://bugs.gentoo.org/772197.
+	optfeature "rendering with webengine" dev-python/PyQtWebEngine
 
 	einfo "Starting with retext-7.0.4 the markdown-math plugin is installed."
 	einfo "Note that you can use different math delimiters, e.g. \(...\) for inline math."
 	einfo "For more details take a look at:"
-	einfo "https://github.com/mitya57/python-markdown-math#math-delimiters"
+	einfo "https://github.com/mitya57/python-markdown-math#math-delimiters"	
 }
 
 pkg_postrm() {


### PR DESCRIPTION
To avoid breakage for existing installations the deps are not made optional
but moved into USE flags (bug 772197).

Also there is added a missing dbus dep (bug 772197, too).

Closes: https://bugs.gentoo.org/772197
Signed-off-by: Nils Freydank <holgersson@posteo.de>