### PR TITLE
sci-libs/opencascade: fix flow control in cmake

### DIFF
--- a/sci-libs/opencascade/files/opencascade-7.4.0-fix-flow-control-nesting.patch
+++ b/sci-libs/opencascade/files/opencascade-7.4.0-fix-flow-control-nesting.patch
@@ -1,0 +1,31 @@
+From e69c42386239bcc08143607df12b8bb3f1ff14ba Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Wed, 24 Feb 2021 20:06:02 +0100
+Subject: [PATCH] adm/cmake/vtk.cmake: fix flow control nesting
+
+Fix an unbalanced nesting of flow control statements
+for >=cmake-3.20.0
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ adm/cmake/vtk.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/adm/cmake/vtk.cmake b/adm/cmake/vtk.cmake
+index c5692fd6..00b7ff4a 100644
+--- a/adm/cmake/vtk.cmake
++++ b/adm/cmake/vtk.cmake
+@@ -156,8 +156,8 @@ if (VTK_FOUND)
+             endif()
+           endif()
+         endif()
+-      endif()
+-    endforeach()
++      endforeach()
++    endif()
+   endif()
+ 
+   if (3RDPARTY_VTK_INCLUDE_DIRS)
+-- 
+2.30.1
+

--- a/sci-libs/opencascade/opencascade-7.4.0-r4.ebuild
+++ b/sci-libs/opencascade/opencascade-7.4.0-r4.ebuild
@@ -49,7 +49,10 @@ RDEPEND="
 		dev-qt/qtxml:5
 	)
 	tbb? ( dev-cpp/tbb )
-	vtk? ( >=sci-libs/vtk-8.1.0[rendering] )
+	vtk? (
+		>=sci-libs/vtk-8.1.0[rendering]
+		<sci-libs/vtk-9
+	)
 "
 DEPEND="${RDEPEND}"
 BDEPEND="

--- a/sci-libs/opencascade/opencascade-7.4.0-r4.ebuild
+++ b/sci-libs/opencascade/opencascade-7.4.0-r4.ebuild
@@ -75,6 +75,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-fix-install.patch"
 	"${FILESDIR}/${P}-fix-issue-with-cmake-path-variables.patch"
 	"${FILESDIR}/${P}-Gentoo-specific-avoid-pre-stripping-files.patch"
+	"${FILESDIR}/${P}-fix-flow-control-nesting.patch"
 )
 
 pkg_setup() {


### PR DESCRIPTION
dev-util/cmake >= 3.20.0_rc1 has advanced flow control
checks. This patch fixes an issue with these new version
on unbalanced flow control statements.

Closes: https://bugs.gentoo.org/771300

Additionally restrict to <vtk-9. There were several issues
reported against my overlay and per email, from people
trying to build against vtk-9, although this version isn't in
::gentoo yet. To avoid this, the dependency of vtk ist restricted.

Package-Manager: Portage-3.0.15, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>