### PR TITLE
x11-misc/menumaker: Mark ALLARCHES

### DIFF
--- a/x11-misc/menumaker/metadata.xml
+++ b/x11-misc/menumaker/metadata.xml
@@ -9,6 +9,7 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="sourceforge">menumaker</remote-id>
 	</upstream>


### PR DESCRIPTION
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

menumaker is written in Python.
