### PR TITLE
app-i18n/transifex-client: fix failing test on 32 bit systems

### DIFF
--- a/app-i18n/transifex-client/files/transifex-client-timestamp.patch
+++ b/app-i18n/transifex-client/files/transifex-client-timestamp.patch
@@ -1,0 +1,14 @@
+diff -Naur ../transifex-client-0.14.2.orig/tests/test_project.py ./tests/test_project.py
+--- ../transifex-client-0.14.2.orig/tests/test_project.py	2020-06-19 14:48:52.000000000 +0200
++++ ./tests/test_project.py	2021-02-25 22:08:29.353477306 +0100
+@@ -717,8 +717,8 @@
+                 )
+                 self.assertEqual(res, True)
+ 
+-                # "Recent" timestamp (in the future - 2100)
+-                ts_mock.return_value = 4111417171
++                # "Recent" timestamp (in the future - 2038)
++                ts_mock.return_value = 2147483000
+                 res = self.p._should_download(
+                     'pt', self.stats, os.path.abspath(__file__), False,
+                     use_git_timestamps=True

--- a/app-i18n/transifex-client/transifex-client-0.14.2-r2.ebuild
+++ b/app-i18n/transifex-client/transifex-client-0.14.2-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7,8,9} )
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
+inherit eutils distutils-r1
+
+DESCRIPTION="A command line interface for Transifex"
+HOMEPAGE="https://pypi.org/project/transifex-client/ https://www.transifex.net/ https://github.com/transifex/transifex-client"
+SRC_URI="mirror://pypi/t/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="test? ( dev-python/mock[${PYTHON_USEDEP}] )"
+RDEPEND="dev-python/GitPython[${PYTHON_USEDEP}]
+	<dev-python/python-slugify-5.0.0[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	<dev-python/six-2.0.0[${PYTHON_USEDEP}]
+	dev-python/urllib3[${PYTHON_USEDEP}]"
+
+distutils_enable_tests setup.py
+
+src_prepare() {
+	eapply_user
+	sed -i -e 's:test_fetch_timestamp_from_git_tree:_&:' \
+		tests/test_utils.py || die
+	sed -i '/tests_require=\["mock>=3.0.5,<4.0"\]/d' setup.py || die
+	# Bug 771660
+	eapply "${FILESDIR}"/${PN}-timestamp.patch
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/771660

The patch has already been submitted upstream: https://github.com/transifex/transifex-client/pull/316