### PR TITLE
www-apps/davical-1.1.9.3-r1: support php8

### DIFF
--- a/www-apps/davical/davical-1.1.9.3-r1.ebuild
+++ b/www-apps/davical/davical-1.1.9.3-r1.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit webapp
+
+DESCRIPTION="A CalDAV and CardDAV Server"
+HOMEPAGE="https://www.davical.org/"
+SRC_URI="https://www.davical.org/downloads/${PN}_${PV}.orig.tar.xz -> ${P}.tar.xz"
+
+LICENSE="GPL-2 GPL-2+ GPL-3+ LGPL-2.1+ LGPL-3+"
+KEYWORDS="~amd64 ~x86"
+IUSE="ldap"
+
+BDEPEND="sys-devel/gettext"
+
+# >=dev-lang/php-8:curly braces string offset access was removed (Bug 764908)
+RDEPEND="app-admin/pwgen
+	dev-lang/php[calendar,curl,iconv,imap,ldap?,nls,pdo,postgres,xml]
+	dev-perl/DBD-Pg
+	dev-perl/DBI
+	dev-perl/YAML
+	>=dev-php/awl-0.61
+	virtual/httpd-php"
+
+PATCHES=( "${FILESDIR}/${P}-php8_compatibility.patch" )
+
+need_httpd
+
+S="${WORKDIR}"
+
+src_compile() {
+	emake built-locale
+}
+
+src_install() {
+	webapp_src_preinst
+
+	einstalldocs
+
+	einfo "Installing web files"
+	insinto "${MY_HTDOCSDIR}"
+	doins -r htdocs/. htdocs/.htaccess
+
+	einfo "Installing main files and i18n"
+	insinto "${MY_HOSTROOTDIR}/${PN}"
+	doins -r inc locale
+	rm "${ED}/${MY_HOSTROOTDIR}/${PN}/inc/always.php.in" || die
+
+	einfo "Installing sql files"
+	insinto "${MY_SQLSCRIPTSDIR}"
+	doins -r dba/.
+
+	insinto /etc/${PN}
+	doins -r config/. "${FILESDIR}/vhost-example"
+
+	webapp_postinst_txt en "${FILESDIR}/postinstall-en.txt"
+	webapp_postupgrade_txt en "${FILESDIR}/postupgrade-en.txt"
+	webapp_src_install
+
+	fperms +x "${MY_SQLSCRIPTSDIR}/create-database.sh"
+	fperms +x "${MY_SQLSCRIPTSDIR}/update-davical-database"
+}
+
+pkg_postinst() {
+	elog "If you are upgrading from a previous version of davical, don't forget to"
+	elog "upgrade the database structure with"
+	elog "       cd /usr/share/webapps/davical/${PVR}/sqlscripts/"
+	elog "       ./update-davical-database -dbuser xxxxxxx -appuser xxxxxx"
+
+	webapp_pkg_postinst
+}

--- a/www-apps/davical/files/davical-1.1.9.3-php8_compatibility.patch
+++ b/www-apps/davical/files/davical-1.1.9.3-php8_compatibility.patch
@@ -1,0 +1,58 @@
+From f376be164eacf51d7354c728094e697ee2336218 Mon Sep 17 00:00:00 2001
+From: Jan Hicken <jan.hicken@posteo.de>
+Date: Sun, 31 Jan 2021 11:46:32 +0100
+Subject: [PATCH 1/2] Use brackets instead of curly braces for string offset
+ access
+
+Curly braces have been deprecated in PHP 7.4 and unsupported in PHP 8.0.
+---
+ inc/check_UTF8.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/inc/check_UTF8.php b/inc/check_UTF8.php
+index e3c93dbf..62dbfc00 100644
+--- a/inc/check_UTF8.php
++++ b/inc/check_UTF8.php
+@@ -67,7 +67,7 @@ function utf8ToUnicode(&$str)
+ 
+   $len = strlen($str);
+   for($i = 0; $i < $len; $i++) {
+-    $in = ord($str{$i});
++    $in = ord($str[$i]);
+     if (0 == $mState) {
+       // When mState is zero we expect either a US-ASCII character or a
+       // multi-octet sequence.
+-- 
+GitLab
+
+
+From 6cdbfcf226f0235a00206edfd119fcc90465a2b8 Mon Sep 17 00:00:00 2001
+From: Jan Hicken <jan.hicken@posteo.de>
+Date: Sun, 31 Jan 2021 11:47:41 +0100
+Subject: [PATCH 2/2] Add default value for errcontext variable in error
+ handler function
+
+This variable is no longer passed in PHP 8.0.
+
+It cannot be removed however, because it would not be backwards
+compatible.
+---
+ htdocs/setup.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/htdocs/setup.php b/htdocs/setup.php
+index 8b13d0ad..2a82dbf3 100644
+--- a/htdocs/setup.php
++++ b/htdocs/setup.php
+@@ -13,7 +13,7 @@ function log_setup_error($errno , $errstr , $errfile , $errline) {
+   error_log('DAViCal setup.php: Informational: '.$errfile.'('.$errline.'): ['.$errno.'] '.$errstr);
+ }
+ 
+-function catch_setup_errors($errno , $errstr , $errfile , $errline , $errcontext ) {
++function catch_setup_errors($errno , $errstr , $errfile , $errline , $errcontext = null ) {
+   if ( $errno == 2 ) {
+     // A working installation will regularly fail to include_once() for several files as it searches for the location
+     log_setup_error($errno , $errstr , $errfile , $errline);
+-- 
+GitLab
+


### PR DESCRIPTION
add upstream patch (see [upstream merge request](https://gitlab.com/davical-project/davical/-/merge_requests/77)) for php8 compatibility

Bug: https://bugs.gentoo.org/764908
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Till Schäfer <till2.schaefer@uni-dortmund.de>