### PR TITLE
media-libs/{ilmbase,openexr}-2.3.0: mask until removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,11 @@
 #--- END OF EXAMPLES ---
 
 # Bernd Waibel <waebbl-gentoo@posteo.net> (2021-02-27)
+# Mask until removal of media-gfx/openexr_viewers.
+# Version has several vulnerabilities. See #717474
+=media-libs/openexr-2.3.0
+
+# Bernd Waibel <waebbl-gentoo@posteo.net> (2021-02-27)
 # No longer actively supported upstream.
 # Removal needed to clean-up {ilmbase,openexr}-2.3.0
 # Masked for removal in 30 days.

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -35,6 +35,11 @@
 # Bernd Waibel <waebbl-gentoo@posteo.net> (2021-02-27)
 # Mask until removal of media-gfx/openexr_viewers.
 # Version has several vulnerabilities. See #717474
+=media-libs/ilmbase-2.3.0
+
+# Bernd Waibel <waebbl-gentoo@posteo.net> (2021-02-27)
+# Mask until removal of media-gfx/openexr_viewers.
+# Version has several vulnerabilities. See #717474
 =media-libs/openexr-2.3.0
 
 # Bernd Waibel <waebbl-gentoo@posteo.net> (2021-02-27)


### PR DESCRIPTION
Several vulnerabilities.
Awaiting removal of media-gfx/openexr_viewers to get cleaned.

Bug: https://bugs.gentoo.org/717474
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
