### PR TITLE
media-gfx/zbar: fix musl build

### DIFF
--- a/media-gfx/zbar/files/zbar-0.23.1_musl_include_locale_h.patch
+++ b/media-gfx/zbar/files/zbar-0.23.1_musl_include_locale_h.patch
@@ -1,0 +1,26 @@
+diff --git a/zbarcam/zbarcam.c b/zbarcam/zbarcam.c
+index f7ea281..2452613 100644
+--- a/zbarcam/zbarcam.c
++++ b/zbarcam/zbarcam.c
+@@ -37,6 +37,7 @@
+ #ifdef ENABLE_NLS
+ #include "../zbar/gettext.h"
+ # include <libintl.h>
++# include <locale.h>
+ # define _(string) gettext(string)
+ #else
+ # define _(string) string
+diff --git a/zbarimg/zbarimg.c b/zbarimg/zbarimg.c
+index 0796fd8..3192ec1 100644
+--- a/zbarimg/zbarimg.c
++++ b/zbarimg/zbarimg.c
+@@ -42,6 +42,7 @@
+ #ifdef ENABLE_NLS
+ #include "../zbar/gettext.h"
+ # include <libintl.h>
++# include <locale.h>
+ # define _(string) gettext(string)
+ #else
+ # define _(string) string
+-- 
+2.26.2

--- a/media-gfx/zbar/zbar-0.23.1.ebuild
+++ b/media-gfx/zbar/zbar-0.23.1.ebuild
@@ -83,6 +83,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${P}_fix_leftover_on_shell_compatibility.patch"
 	"${FILESDIR}/${P}_fix_unittest.patch"
+	"${FILESDIR}/${P}_musl_include_locale_h.patch"
 	"${FILESDIR}/zbar-0.23_fix_Qt5X11Extras_detect.patch"
 	"${FILESDIR}/zbar-0.23_fix_python_detect.patch"
 )


### PR DESCRIPTION
`media-gfx/zbar` fails to build with `musl` libc with following error due to a missing `locale.h` header file.
```
/var/tmp/portage/media-gfx/zbar-0.23.1/work/zbar-0.23.1/zbarimg/zbarimg.c: In function 'main':
/var/tmp/portage/media-gfx/zbar-0.23.1/work/zbar-0.23.1/zbarimg/zbarimg.c:317:5: warning: implicit declaration of function 'setlocale' [-Wimplicit-function-declaration]
  317 |     setlocale (LC_ALL, "");
      |     ^~~~~~~~~
/var/tmp/portage/media-gfx/zbar-0.23.1/work/zbar-0.23.1/zbarimg/zbarimg.c:317:16: error: 'LC_ALL' undeclared (first use in this function)
  317 |     setlocale (LC_ALL, "");
      |                ^~~~~~
/var/tmp/portage/media-gfx/zbar-0.23.1/work/zbar-0.23.1/zbarimg/zbarimg.c:317:16: note: each undeclared identifier is reported only once for each function it appears in
```

The patch is taken from upstream https://github.com/mchehab/zbar/pull/115. I am not entirely sure if this can be fixed without revbump, but I think it can. Anyway, let me know if I should change it somehow or if this should be moved to a musl overlay.