### PR TITLE
games-engines/gargoyle: Fix typo in BDEPEND

### DIFF
--- a/games-engines/gargoyle/gargoyle-2019.1.1.ebuild
+++ b/games-engines/gargoyle/gargoyle-2019.1.1.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	virtual/jpeg:0
 	x11-libs/gtk+:2"
 DEPEND="${RDEPEND}"
-BDEPEBD="
+BDEPEND="
 	app-arch/unzip
 	dev-util/ftjam
 	virtual/pkgconfig"


### PR DESCRIPTION
s/BDEPEBD/BDEPEND/
Makes sure build deps are actually pulled in.