### PR TITLE
sci-libs/coinor-dip: add missing >=symphony-5.6 dep

### DIFF
--- a/sci-libs/coinor-dip/coinor-dip-0.95.0-r1.ebuild
+++ b/sci-libs/coinor-dip/coinor-dip-0.95.0-r1.ebuild
@@ -20,6 +20,7 @@ RDEPEND="
 	sci-libs/coinor-cgl:=
 	sci-libs/coinor-clp:=
 	sci-libs/coinor-osi:=
+	>=sci-libs/coinor-symphony-5.6:=
 	sci-libs/coinor-utils:="
 DEPEND="${RDEPEND}"
 BDEPEND="

--- a/sci-libs/coinor-symphony/coinor-symphony-5.6.17.ebuild
+++ b/sci-libs/coinor-symphony/coinor-symphony-5.6.17.ebuild
@@ -30,7 +30,10 @@ BDEPEND="
 		dev-texlive/texlive-latexextra
 		virtual/latex-base
 	)
-	test? ( sci-libs/coinor-sample )"
+	test? (
+		sci-libs/coinor-netlib
+		sci-libs/coinor-sample
+	)"
 
 src_prepare() {
 	default
@@ -48,7 +51,10 @@ src_configure() {
 src_compile() {
 	default
 	if use doc; then
-		pushd Doc && pdflatex Walkthrough && pdflatex man && popd || die
+		pushd Doc &&
+			pdflatex Walkthrough &&
+			pdflatex man &&
+			popd || die
 	fi
 }
 
@@ -63,7 +69,7 @@ src_install() {
 
 	# Other coinor-* use lowercase e, stay in-line with them.
 	docinto examples
-	dodoc -r Examples/*
+	dodoc -r Examples/.
 
 	# Duplicate or irrelevant files.
 	rm -r "${ED}"/usr/share/coin/doc || die


### PR DESCRIPTION
Also noticed symphony was missing an optional test dep, adding at same time.