### PR TITLE
app-eselect/eselect-cdparanoia: EAPI 7

### DIFF
--- a/app-eselect/eselect-cdparanoia/eselect-cdparanoia-0.1-r1.ebuild
+++ b/app-eselect/eselect-cdparanoia/eselect-cdparanoia-0.1-r1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Manage /usr/bin/cdparanoia symlink"
+HOMEPAGE="https://www.gentoo.org/proj/en/eselect/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x86-solaris"
+
+RDEPEND=">=app-eselect/eselect-lib-bin-symlink-0.1.1"
+DEPEND="${RDEPEND}"
+
+S="${FILESDIR}"
+
+src_install() {
+	insinto /usr/share/eselect/modules
+	newins cdparanoia.eselect-${PV} cdparanoia.eselect
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/757549
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>