### PR TITLE
dev-python/xdg: Add blocker against dev-python/pyxdg

### DIFF
--- a/dev-python/xdg/xdg-5.0.1-r1.ebuild
+++ b/dev-python/xdg/xdg-5.0.1-r1.ebuild
@@ -13,3 +13,6 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="ISC"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+
+# https://bugs.gentoo.org/773415
+RDEPEND="!dev-python/pyxdg[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/773415