### PR TITLE
dev-libs/libebml: revbump for gcc-11 fix

### DIFF
--- a/dev-libs/libebml/files/libebml-1.4.2-header-fixes-for-gcc11.patch
+++ b/dev-libs/libebml/files/libebml-1.4.2-header-fixes-for-gcc11.patch
@@ -1,0 +1,35 @@
+From f0bfd53647961e799a43d918c46cf3b6bff89806 Mon Sep 17 00:00:00 2001
+From: Moritz Bunkus <mo@bunkus.online>
+Date: Sat, 27 Feb 2021 20:36:52 +0100
+Subject: [PATCH] include appropriate header files for std::numeric_limits
+
+Fixes #80.
+---
+ src/EbmlString.cpp        | 1 +
+ src/EbmlUnicodeString.cpp | 1 +
+ 3 files changed, 6 insertions(+)
+
+diff --git a/src/EbmlString.cpp b/src/EbmlString.cpp
+index 27e55fd..4c05fcf 100644
+--- a/src/EbmlString.cpp
++++ b/src/EbmlString.cpp
+@@ -34,6 +34,7 @@
+   \author Steve Lhomme     <robux4 @ users.sf.net>
+ */
+ #include <cassert>
++#include <limits>
+ 
+ #include "ebml/EbmlString.h"
+ 
+diff --git a/src/EbmlUnicodeString.cpp b/src/EbmlUnicodeString.cpp
+index 496a16a..99fc073 100644
+--- a/src/EbmlUnicodeString.cpp
++++ b/src/EbmlUnicodeString.cpp
+@@ -36,6 +36,7 @@
+ */
+ 
+ #include <cassert>
++#include <limits>
+ 
+ #include "ebml/EbmlUnicodeString.h"
+ 

--- a/dev-libs/libebml/libebml-1.4.2.ebuild
+++ b/dev-libs/libebml/libebml-1.4.2.ebuild
@@ -13,6 +13,11 @@ LICENSE="LGPL-2.1"
 SLOT="0/5" # subslot = soname major version
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
+src_prepare() {
+	eapply "${FILESDIR}/${P}-header-fixes-for-gcc11.patch"
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DBUILD_SHARED_LIBS=YES


### PR DESCRIPTION
Patch source: https://github.com/Matroska-Org/libebml/commit/f0bfd53
(I dropped the ChangeLog part as that depends on other commits to apply nicely)

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/773538