### PR TITLE
net-analyzer/ospd: change to setup.py because pyproject is broken

### DIFF
--- a/net-analyzer/ospd/ospd-2.0.1.ebuild
+++ b/net-analyzer/ospd/ospd-2.0.1.ebuild
@@ -1,10 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
-DISTUTILS_USE_SETUPTOOLS=pyproject.toml
 inherit distutils-r1
 
 DESCRIPTION="Base class for scanner wrappers,communication protocol for GVM"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/771870
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Jonas Licht <jonas.licht@fem.tu-ilmenau.de>