### PR TITLE
dev-util/bazel: enable statically linked libstdc++ for gentoo prefix

### DIFF
--- a/dev-util/bazel/bazel-3.2.0.ebuild
+++ b/dev-util/bazel/bazel-3.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,8 @@ SRC_URI="https://github.com/bazelbuild/bazel/releases/download/${PV}/${P}-dist.z
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="examples tools"
+IUSE="examples tools prefix static-libs"
+REQUIRED_USE="prefix? ( static-libs )"
 # strip corrupts the bazel binary
 # test fails with network-sandbox: An error occurred during the fetch of repository 'io_bazel_skydoc' (bug 690794)
 RESTRICT="strip test"
@@ -67,6 +68,9 @@ src_prepare() {
 
 src_compile() {
 	export EXTRA_BAZEL_ARGS="--jobs=$(makeopts_jobs) $(bazel-get-flags) --host_javabase=@local_jdk//:jdk"
+	if use static-libs; then
+		export BAZEL_LINKOPTS=-static-libs:-static-libgcc BAZEL_LINKLIBS=-l%:libstdc++.a:-lm
+	fi
 	VERBOSE=yes ./compile.sh || die
 
 	./scripts/generate_bash_completion.sh \

--- a/dev-util/bazel/metadata.xml
+++ b/dev-util/bazel/metadata.xml
@@ -19,5 +19,6 @@
 	</longdescription>
 	<use>
 		<flag name="tools">Install extra bazel tools to build from sources</flag>
+		<flag name="static-libs">Link libstdc++ statically</flag>
 	</use>
 </pkgmetadata>

--- a/profiles/features/prefix/package.use
+++ b/profiles/features/prefix/package.use
@@ -1,2 +1,6 @@
 # Don't enable the security measures for convienence
 sys-apps/portage -rsync-verify
+
+# Yiyang Wu <xgreenlandforwyy@gmail.com> (2021-03-03)
+# bazel should link libstdc++ statically in prefix to avoid finding host's libstdc++ when building other packages
+dev-util/bazel static-libs


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/773982
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>