### PR TITLE
gnome-base/librsvg: Fix build error due to unset x11-libs/cairo[glib]

### DIFF
--- a/gnome-base/librsvg/librsvg-2.48.8.ebuild
+++ b/gnome-base/librsvg/librsvg-2.48.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,7 +18,7 @@ IUSE="+introspection +vala"
 REQUIRED_USE="vala? ( introspection )"
 
 RDEPEND="
-	>=x11-libs/cairo-1.16.0[${MULTILIB_USEDEP}]
+	>=x11-libs/cairo-1.16.0[glib,${MULTILIB_USEDEP}]
 	>=media-libs/freetype-2.9:2[${MULTILIB_USEDEP}]
 	>=x11-libs/gdk-pixbuf-2.20:2[introspection?,${MULTILIB_USEDEP}]
 	>=dev-libs/glib-2.50.0:2[${MULTILIB_USEDEP}]

--- a/gnome-base/librsvg/librsvg-2.48.9.ebuild
+++ b/gnome-base/librsvg/librsvg-2.48.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,7 +18,7 @@ IUSE="+introspection +vala"
 REQUIRED_USE="vala? ( introspection )"
 
 RDEPEND="
-	>=x11-libs/cairo-1.16.0[${MULTILIB_USEDEP}]
+	>=x11-libs/cairo-1.16.0[glib,${MULTILIB_USEDEP}]
 	>=media-libs/freetype-2.9:2[${MULTILIB_USEDEP}]
 	>=x11-libs/gdk-pixbuf-2.20:2[introspection?,${MULTILIB_USEDEP}]
 	>=dev-libs/glib-2.50.0:2[${MULTILIB_USEDEP}]

--- a/gnome-base/librsvg/librsvg-2.50.2.ebuild
+++ b/gnome-base/librsvg/librsvg-2.50.2.ebuild
@@ -17,7 +17,7 @@ IUSE="+introspection +vala"
 REQUIRED_USE="vala? ( introspection )"
 
 RDEPEND="
-	>=x11-libs/cairo-1.16.0[${MULTILIB_USEDEP}]
+	>=x11-libs/cairo-1.16.0[glib,${MULTILIB_USEDEP}]
 	>=media-libs/freetype-2.9:2[${MULTILIB_USEDEP}]
 	>=x11-libs/gdk-pixbuf-2.20:2[introspection?,${MULTILIB_USEDEP}]
 	>=dev-libs/glib-2.50.0:2[${MULTILIB_USEDEP}]

--- a/gnome-base/librsvg/librsvg-2.50.3.ebuild
+++ b/gnome-base/librsvg/librsvg-2.50.3.ebuild
@@ -17,7 +17,7 @@ IUSE="+introspection +vala"
 REQUIRED_USE="vala? ( introspection )"
 
 RDEPEND="
-	>=x11-libs/cairo-1.16.0[${MULTILIB_USEDEP}]
+	>=x11-libs/cairo-1.16.0[glib,${MULTILIB_USEDEP}]
 	>=media-libs/freetype-2.9:2[${MULTILIB_USEDEP}]
 	>=x11-libs/gdk-pixbuf-2.20:2[introspection?,${MULTILIB_USEDEP}]
 	>=dev-libs/glib-2.50.0:2[${MULTILIB_USEDEP}]


### PR DESCRIPTION
Packages starting v2.48 have `cairo-gobject` as a dependency.
x11-libs/cairo must be built with `USE=glib` for librsvg to merge.

<details>
  <summary>build log with the error</summary>

```
[32;01m * [39;49;00mPackage:    gnome-base/librsvg-2.50.3
[32;01m * [39;49;00mRepository: gentoo
[32;01m * [39;49;00mMaintainer: gnome@gentoo.org
[32;01m * [39;49;00mUSE:        abi_x86_64 amd64 elibc_glibc kernel_linux userland_GNU
[32;01m * [39;49;00mFEATURES:   fakeroot network-sandbox preserve-libs sandbox userpriv usersandbox
 [32;01m*[0m /etc/portage/package.cflags/no-common-libtool.conf -> gnome-base/librsvg: NOCOMMON_OVERRIDE_LIBTOOL=yes
 [32;01m*[0m FEATURES='binpkg-docompress binpkg-multi-instance cgroup clean-logs collision-protect config-protect-if-modified distlocks ebuild-locks fail-clean fakeroot fixlafiles ipc-sandbox merge-sync metadata-transfer multilib-strict network-sandbox news parallel-fetch parallel-install pid-sandbox preserve-libs protect-owned python-trace qa-unresolved-soname-deps sandbox sfperms sign split-elog split-log strict-keepdir unknown-features-filter unknown-features-warn unmerge-logs unmerge-orphans userfetch userpriv usersandbox usersync xattr'
 [32;01m*[0m CFLAGS='-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe -Wl,-O1 -Wl,--as-needed'
 [32;01m*[0m CXXFLAGS='-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe -Wl,-O1 -Wl,--as-needed'
 [32;01m*[0m FFLAGS='-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe -Wl,-O1 -Wl,--as-needed'
 [32;01m*[0m FCFLAGS='-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe -Wl,-O1 -Wl,--as-needed'
 [32;01m*[0m F77FLAGS='-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe -Wl,-O1 -Wl,--as-needed'
 [32;01m*[0m LDFLAGS='-Wl,-O1 -Wl,--as-needed -march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe'
 [32;01m*[0m MAKEOPTS='--load-average=5 --jobs=5'
 [32;01m*[0m gcc (Gentoo 10.2.0-r5 p6) 10.2.0
 [32;01m*[0m g++ (Gentoo 10.2.0-r5 p6) 10.2.0
 [32;01m*[0m GNU ld (Gentoo 2.35.2 p1) 2.35.2
 [32;01m*[0m Linux olorin 5.11.0-pf2-olorin #3 SMP PREEMPT Wed Feb 24 10:35:19 MSK 2021 x86_64 Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz GenuineIntel GNU/Linux
>>> Unpacking source...
>>> Unpacking librsvg-2.50.3.tar.xz to /tmp/portage/gnome-base/librsvg-2.50.3/work
>>> Source unpacked in /tmp/portage/gnome-base/librsvg-2.50.3/work
>>> Preparing source in /tmp/portage/gnome-base/librsvg-2.50.3/work/librsvg-2.50.3 ...
 [32;01m*[0m Disabling deprecation warnings ...
[A[140C [34;01m[ [32;01mok[34;01m ][0m
 * Running elibtoolize in: librsvg-2.50.3/
 *   Applying portage/1.2.0 patch ...
 *   Applying sed/1.5.6 patch ...
 *   Applying as-needed/2.4.3 patch ...
 *   Applying ppc64le/2.4.4 patch ...
>>> Source prepared.
 [33;01m*[0m lto-overlay: libtool global_symbol_pipe and global_symbol_to_cdecl OVERRIDDEN
>>> Configuring source in /tmp/portage/gnome-base/librsvg-2.50.3/work/librsvg-2.50.3 ...
 [32;01m*[0m abi_x86_64.amd64: running multilib-minimal_abi_src_configure
 * econf: updating librsvg-2.50.3/config.guess with /usr/share/gnuconfig/config.guess
 * econf: updating librsvg-2.50.3/config.sub with /usr/share/gnuconfig/config.sub
/tmp/portage/gnome-base/librsvg-2.50.3/work/librsvg-2.50.3/configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --disable-silent-rules --docdir=/usr/share/doc/librsvg-2.50.3 --htmldir=/usr/share/doc/librsvg-2.50.3/html --libdir=/usr/lib64 --disable-gtk-doc --disable-maintainer-mode --disable-static --disable-debug --disable-tools --disable-introspection --disable-vala --enable-pixbuf-loader
configure: loading site script /usr/share/config.site
checking for a BSD-compatible install... /usr/lib/portage/python3.8/ebuild-helpers/xattr/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether UID '250' is supported by ustar format... yes
checking whether GID '250' is supported by ustar format... yes
checking how to create a ustar tar archive... gnutar
checking whether make supports nested variables... (cached) yes
checking whether to enable maintainer-specific portions of Makefiles... no
checking for a sed that does not truncate output... /bin/sed
checking whether NLS is requested... yes
checking for msgfmt... /usr/bin/msgfmt
checking for gmsgfmt... /usr/bin/gmsgfmt
checking for xgettext... /usr/bin/xgettext
checking for msgmerge... /usr/bin/msgmerge
checking whether make supports the include directive... yes (GNU style)
checking for x86_64-pc-linux-gnu-gcc... x86_64-pc-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether x86_64-pc-linux-gnu-gcc accepts -g... yes
checking for x86_64-pc-linux-gnu-gcc option to accept ISO C89... none needed
checking whether x86_64-pc-linux-gnu-gcc understands -c and -o together... yes
checking dependency style of x86_64-pc-linux-gnu-gcc... none
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking for ld used by x86_64-pc-linux-gnu-gcc... /usr/x86_64-pc-linux-gnu/bin/ld
checking if the linker (/usr/x86_64-pc-linux-gnu/bin/ld) is GNU ld... yes
checking for shared library run path origin... done
checking 32-bit host C ABI... no
checking how to run the C preprocessor... x86_64-pc-linux-gnu-gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ELF binary format... yes
checking for the common suffixes of directories in the library search path... lib,lib,lib64
checking for CFPreferencesCopyAppValue... no
checking for CFLocaleCopyPreferredLanguages... no
checking for GNU gettext in libc... yes
checking whether to use NLS... yes
checking where the gettext function comes from... libc
checking whether ln -s works... yes
checking for library containing strerror... none required
checking for x86_64-pc-linux-gnu-gcc... (cached) x86_64-pc-linux-gnu-gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether x86_64-pc-linux-gnu-gcc accepts -g... (cached) yes
checking for x86_64-pc-linux-gnu-gcc option to accept ISO C89... (cached) none needed
checking whether x86_64-pc-linux-gnu-gcc understands -c and -o together... (cached) yes
checking dependency style of x86_64-pc-linux-gnu-gcc... (cached) none
checking how to run the C preprocessor... x86_64-pc-linux-gnu-gcc -E
checking for gawk... (cached) gawk
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking whether byte ordering is bigendian... no
checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/x86_64-pc-linux-gnu-pkg-config
checking pkg-config is at least version 0.9.0... yes
checking how to print strings... printf
checking for a sed that does not truncate output... (cached) /bin/sed
checking for fgrep... /bin/grep -F
checking for ld used by x86_64-pc-linux-gnu-gcc... /usr/x86_64-pc-linux-gnu/bin/ld
checking if the linker (/usr/x86_64-pc-linux-gnu/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/x86_64-pc-linux-gnu-nm -B
checking the name lister (/usr/bin/x86_64-pc-linux-gnu-nm -B) interface... BSD nm
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/x86_64-pc-linux-gnu/bin/ld option to reload object files... -r
checking for x86_64-pc-linux-gnu-objdump... x86_64-pc-linux-gnu-objdump
checking how to recognize dependent libraries... pass_all
checking for x86_64-pc-linux-gnu-dlltool... no
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for x86_64-pc-linux-gnu-ar... x86_64-pc-linux-gnu-ar
checking for archiver @FILE support... @
checking for x86_64-pc-linux-gnu-strip... x86_64-pc-linux-gnu-strip
checking for x86_64-pc-linux-gnu-ranlib... x86_64-pc-linux-gnu-ranlib
checking command to parse /usr/bin/x86_64-pc-linux-gnu-nm -B output from x86_64-pc-linux-gnu-gcc object... (cached) ok
checking for sysroot... no
checking for a working dd... /bin/dd
checking how to truncate binary pipes... /bin/dd bs=4096 count=1
checking for x86_64-pc-linux-gnu-mt... no
checking for mt... no
checking if : is a manifest tool... no
checking for dlfcn.h... yes
checking for objdir... .libs
checking if x86_64-pc-linux-gnu-gcc supports -fno-rtti -fno-exceptions... no
checking for x86_64-pc-linux-gnu-gcc option to produce PIC... -fPIC -DPIC
checking if x86_64-pc-linux-gnu-gcc PIC flag -fPIC -DPIC works... yes
checking if x86_64-pc-linux-gnu-gcc static flag -static works... yes
checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... yes
checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... (cached) yes
checking whether the x86_64-pc-linux-gnu-gcc linker (/usr/x86_64-pc-linux-gnu/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
checking for cos in -lm... yes
checking for dlopen... no
checking for dlopen in -ldl... yes
checking for cargo... cargo
checking for rustc... rustc
checking for some Win32 platform... no
checking for native Win32... no
checking for darwin... no
checking for LIBRSVG... no
configure: error: Package requirements (	cairo >= 1.16.0               	cairo-png >= 1.16.0           	cairo-gobject >= 1.16.0       	freetype2 >= 20.0.14       	gdk-pixbuf-2.0 >= 2.20 	gio-2.0 >= 2.24.0               	glib-2.0 >= 2.50.0             	harfbuzz >= 2.0.0         	libxml-2.0 >= 2.9.0         	pangocairo >= 1.38.0          	pangoft2 >= 1.38.0	       ) were not met:

Package 'cairo-gobject', required by 'virtual:world', not found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables LIBRSVG_CFLAGS
and LIBRSVG_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.

!!! Please attach the following file when seeking support:
!!! /tmp/portage/gnome-base/librsvg-2.50.3/work/librsvg-2.50.3-abi_x86_64.amd64/config.log
 [31;01m*[0m ERROR: gnome-base/librsvg-2.50.3::gentoo failed (configure phase):
 [31;01m*[0m   econf failed
 [31;01m*[0m 
 [31;01m*[0m Call stack:
 [31;01m*[0m               ebuild.sh, line  125:  Called src_configure
 [31;01m*[0m             environment, line 4521:  Called multilib-minimal_src_configure
 [31;01m*[0m             environment, line 3651:  Called multilib_foreach_abi 'multilib-minimal_abi_src_configure'
 [31;01m*[0m             environment, line 3904:  Called multibuild_foreach_variant '_multilib_multibuild_wrapper' 'multilib-minimal_abi_src_configure'
 [31;01m*[0m             environment, line 3581:  Called _multibuild_run '_multilib_multibuild_wrapper' 'multilib-minimal_abi_src_configure'
 [31;01m*[0m             environment, line 3579:  Called _multilib_multibuild_wrapper 'multilib-minimal_abi_src_configure'
 [31;01m*[0m             environment, line 1553:  Called multilib-minimal_abi_src_configure
 [31;01m*[0m             environment, line 3645:  Called multilib_src_configure
 [31;01m*[0m             environment, line 4125:  Called gnome2_src_configure '--disable-static' '--disable-debug' '--disable-tools' '--disable-introspection' '--disable-vala' '--enable-pixbuf-loader'
 [31;01m*[0m             environment, line 3073:  Called econf '--disable-gtk-doc' '--disable-maintainer-mode' '--disable-static' '--disable-debug' '--disable-tools' '--disable-introspection' '--disable-vala' '--enable-pixbuf-loader'
 [31;01m*[0m        phase-helpers.sh, line  680:  Called __helpers_die 'econf failed'
 [31;01m*[0m   isolated-functions.sh, line  112:  Called die
 [31;01m*[0m The specific snippet of code:
 [31;01m*[0m   		die "$@"
 [31;01m*[0m 
 [31;01m*[0m If you need support, post the output of `emerge --info '=gnome-base/librsvg-2.50.3::gentoo'`,
 [31;01m*[0m the complete build log and the output of `emerge -pqv '=gnome-base/librsvg-2.50.3::gentoo'`.
 [31;01m*[0m The complete build log is located at '/var/log/portage/build/gnome-base/librsvg-2.50.3:20210301-072823.log'.
 [31;01m*[0m The ebuild environment file is located at '/tmp/portage/gnome-base/librsvg-2.50.3/temp/environment'.
 [31;01m*[0m Working directory: '/tmp/portage/gnome-base/librsvg-2.50.3/work/librsvg-2.50.3-abi_x86_64.amd64'
 [31;01m*[0m S: '/tmp/portage/gnome-base/librsvg-2.50.3/work/librsvg-2.50.3'
```
</details>

<details>
  <summary>emerge --info</summary>

```
Portage 3.0.16 (python 3.8.7-final-0, default/linux/amd64/17.1/no-multilib, gcc-10.2.0, glibc-2.32-r8, 5.11.0-pf2-olorin x86_64)
=================================================================
System uname: Linux-5.11.0-pf2-olorin-x86_64-Intel-R-_Core-TM-_i5-2520M_CPU_@_2.50GHz-with-glibc2.2.5
KiB Mem:     8039832 total,    974736 free
KiB Swap:   10485756 total,  10485756 free
Timestamp of repository gentoo: Mon, 01 Mar 2021 06:45:01 +0000
Head commit of repository gentoo: f64b9d04818823ed73c8a865112ba10c84fbef6e
Head commit of repository azahi: b2dd36754f9c624017db9d9b33978a37fdfb6f2b

Timestamp of repository dotnet: Wed, 24 Feb 2021 15:55:11 +0000
Head commit of repository dotnet: 609592a1209cf39672dd948328b2ddba1d84db85

Timestamp of repository guru: Sun, 28 Feb 2021 17:52:00 +0000
Head commit of repository guru: 0760edf35eda800ebfb2e927b1bd63702fe9a319

Timestamp of repository haskell: Sun, 28 Feb 2021 20:37:02 +0000
Head commit of repository haskell: 8f7d3a2612e0b780450c3ace89a63cc074eaece0

Timestamp of repository lto-overlay: Fri, 26 Feb 2021 21:52:06 +0000
Head commit of repository lto-overlay: cebb9a9359fbaa0ea4a238946003aff6272849dd

Timestamp of repository mv: Sat, 27 Feb 2021 18:37:03 +0000
Head commit of repository mv: cb9ffe0be45a76868e629afc960f5fc4f6a3d856

Timestamp of repository pentoo: Mon, 01 Mar 2021 04:22:01 +0000
Head commit of repository pentoo: 91737a457592e276b10749602eedf15c5ed4d480

Timestamp of repository ricerlay: Sun, 21 Feb 2021 13:38:10 +0000
Head commit of repository ricerlay: b64641f33a8a960fd410edfff4b6c84b7d9502be

Head commit of repository sakaki-tools: 571e34870d665e98677caecbd56cf0d399ee4b3c

sh bash 5.1_p4
ld GNU ld (Gentoo 2.35.2 p1) 2.35.2
ccache version 4.2 [disabled]
app-shells/bash:          5.1_p4::gentoo
dev-java/java-config:     2.3.1::gentoo
dev-lang/perl:            5.32.1::gentoo
dev-lang/python:          2.7.18-r100::lto-overlay, 3.8.7-r1::lto-overlay, 3.9.1-r1::lto-overlay
dev-util/ccache:          4.2::gentoo
dev-util/cmake:           3.19.6::gentoo
sys-apps/baselayout:      2.7-r1::gentoo
sys-apps/openrc:          0.42.1-r1::gentoo
sys-apps/sandbox:         2.20::gentoo
sys-devel/autoconf:       2.69-r5::gentoo
sys-devel/automake:       1.16.3-r1::gentoo
sys-devel/binutils:       2.35.2::gentoo
sys-devel/gcc:            10.2.0-r5::gentoo
sys-devel/gcc-config:     2.4::gentoo
sys-devel/libtool:        2.4.6-r6::gentoo
sys-devel/make:           4.3::gentoo
sys-kernel/linux-headers: 5.11::gentoo (virtual/os-headers)
sys-libs/glibc:           2.32-r8::gentoo
Repositories:

gentoo
    location: /var/db/repos/gentoo
    sync-type: rsync
    sync-uri: rsync://rsync.ru.gentoo.org/gentoo-portage
    priority: -1000
    sync-rsync-extra-opts: 
    sync-rsync-verify-jobs: 1
    sync-rsync-verify-max-age: 24
    sync-rsync-verify-metamanifest: yes

azahi
    location: /var/db/repos/azahi
    sync-type: git
    sync-uri: https://github.com/azahi/azahi-overlay.git
    masters: gentoo

dotnet
    location: /var/db/repos/dotnet
    sync-type: git
    sync-uri: https://github.com/gentoo-mirror/dotnet.git
    masters: gentoo

guru
    location: /var/db/repos/guru
    sync-type: git
    sync-uri: https://github.com/gentoo-mirror/guru.git
    masters: gentoo

haskell
    location: /var/db/repos/haskell
    sync-type: git
    sync-uri: https://github.com/gentoo-mirror/haskell.git
    masters: gentoo

lto-overlay
    location: /var/db/repos/lto-overlay
    sync-type: git
    sync-uri: https://github.com/gentoo-mirror/lto-overlay.git
    masters: gentoo mv

mv
    location: /var/db/repos/mv
    sync-type: git
    sync-uri: https://github.com/gentoo-mirror/mv.git
    masters: gentoo

pentoo
    location: /var/db/repos/pentoo
    sync-type: git
    sync-uri: https://github.com/gentoo-mirror/pentoo.git
    masters: gentoo

ricerlay
    location: /var/db/repos/ricerlay
    sync-type: git
    sync-uri: https://github.com/gentoo-mirror/ricerlay.git
    masters: gentoo

sakaki-tools
    location: /var/db/repos/sakaki-tools
    sync-type: git
    sync-uri: https://github.com/sakaki-/sakaki-tools.git
    masters: gentoo

ABI="amd64"
ABI_X86="64"
ACCEPT_KEYWORDS="amd64 ~amd64"
ACCEPT_LICENSE="*"
ACCEPT_PROPERTIES="*"
ACCEPT_RESTRICT="*"
ADA_TARGET=""
ALSA_CARDS=""
ANT_HOME="/usr/share/ant"
APACHE2_MODULES=""
ARCH="amd64"
AUTOCLEAN="yes"
BINPKG_COMPRESS="bzip2"
BOOTSTRAP_USE="unicode internal-glib pkg-config split-usr python_targets_python3_8 multilib"
BROOT=""
CALLIGRA_FEATURES=""
CBUILD="x86_64-pc-linux-gnu"
CFLAGS="-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe"
CFLAGS_amd64="-m64"
CFLAGS_x32="-mx32"
CFLAGS_x86="-m32"
CHOST="x86_64-pc-linux-gnu"
CHOST_amd64="x86_64-pc-linux-gnu"
CHOST_x32="x86_64-pc-linux-gnux32"
CHOST_x86="i686-pc-linux-gnu"
CLEAN_DELAY="0"
COLLECTD_PLUGINS=""
COLLISION_IGNORE="/lib/modules/*"
CONFIG_PROTECT="/etc /usr/share/gnupg/qualified.txt"
CONFIG_PROTECT_MASK="/etc/ca-certificates.conf /etc/env.d /etc/fonts/fonts.conf /etc/gconf /etc/gentoo-release /etc/revdep-rebuild /etc/sandbox.d /etc/terminfo /etc/texmf/language.dat.d /etc/texmf/language.def.d /etc/texmf/updmap.d /etc/texmf/web2c"
CPU_FLAGS_X86="avx mmx mmxext popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3"
CXXFLAGS="-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe"
DEFAULT_ABI="amd64"
DEVIRTLTO="-fdevirtualize-at-ltrans"
DISPLAY=":1.0"
DISTDIR="/var/cache/distfiles"
DOAS_USER="azahi"
DOTNET_ROOT="/opt/dotnet_core"
EBEEP_IGNORE="1"
EDITOR="nvim"
ELIBC="glibc"
EMERGE_DEFAULT_OPTS="--alert=y --ask=y --backtrack=10000 --color=y --ignore-built-slot-operator-deps=y --keep-going=y --quiet-build=y --quiet-fail=y --verbose=y --with-bdeps=y"
EMERGE_WARNING_DELAY="0"
ENV_UNSET="CARGO_HOME DBUS_SESSION_BUS_ADDRESS DISPLAY GOBIN GOPATH PERL5LIB PERL5OPT PERLPREFIX PERL_CORE PERL_MB_OPT PERL_MM_OPT XAUTHORITY XDG_CACHE_HOME XDG_CONFIG_HOME XDG_DATA_HOME XDG_RUNTIME_DIR"
EPAUSE_IGNORE="1"
EPREFIX=""
EROOT="/"
ESYSROOT="/"
F77FLAGS="-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe"
FCFLAGS="-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe"
FEATURES="binpkg-docompress binpkg-multi-instance cgroup clean-logs collision-protect config-protect-if-modified distlocks ebuild-locks fail-clean fakeroot fixlafiles ipc-sandbox merge-sync metadata-transfer multilib-strict network-sandbox news parallel-fetch parallel-install pid-sandbox preserve-libs protect-owned python-trace qa-unresolved-soname-deps sandbox sfperms sign split-elog split-log strict-keepdir unknown-features-filter unknown-features-warn unmerge-logs unmerge-orphans userfetch userpriv usersandbox usersync xattr"
FETCHCOMMAND="wget -t 3 -T 60 --passive-ftp -O "${DISTDIR}/${FILE}" "${URI}""
FETCHCOMMAND_RSYNC="rsync -LtvP "${URI}" "${DISTDIR}/${FILE}""
FETCHCOMMAND_SFTP="bash -c "x=\${2#sftp://} ; host=\${x%%/*} ; port=\${host##*:} ; host=\${host%:*} ; [[ \${host} = \${port} ]] && port= ; eval \"declare -a ssh_opts=(\${3})\" ; exec sftp \${port:+-P \${port}} \"\${ssh_opts[@]}\" \"\${host}:/\${x#*/}\" \"\$1\"" sftp "${DISTDIR}/${FILE}" "${URI}" "${PORTAGE_SSH_OPTS}""
FETCHCOMMAND_SSH="bash -c "x=\${2#ssh://} ; host=\${x%%/*} ; port=\${host##*:} ; host=\${host%:*} ; [[ \${host} = \${port} ]] && port= ; exec rsync --rsh=\"ssh \${port:+-p\${port}} \${3}\" -avP \"\${host}:/\${x#*/}\" \"\$1\"" rsync "${DISTDIR}/${FILE}" "${URI}" "${PORTAGE_SSH_OPTS}""
FFLAGS="-march=native -O3 -fgraphite-identity -floop-nest-optimize -fdevirtualize-at-ltrans -fipa-pta -fno-semantic-interposition -flto=auto -fuse-linker-plugin -falign-functions=32 -pipe"
FLTO="-flto=auto"
GCC_SPECS=""
GENTOO_MIRRORS="https://mirror.yandex.ru/gentoo-distfiles/"
GPSD_PROTOCOLS=""
GRAPHITE="-fgraphite-identity -floop-nest-optimize"
GRUB_PLATFORMS=""
HOME="/root"
INFOPATH="/usr/share/gcc-data/x86_64-pc-linux-gnu/10.2.0/info:/usr/share/binutils-data/x86_64-pc-linux-gnu/2.35.2/info:/usr/share/info:/usr/share/info/emacs-27"
INPUT_DEVICES=""
IPAPTA="-fipa-pta"
IUSE_IMPLICIT="abi_x86_64 prefix prefix-guest prefix-stack"
KERNEL="linux"
L10N="en"
LANG="en_US.utf8"
LCD_DEVICES=""
LC_COLLATE="C"
LC_CTYPE="C.UTF-8"
LC_MESSAGES="C"
LDFLAGS="-Wl,-O1 -Wl,--as-needed"
LDFLAGS_amd64="-m elf_x86_64"
LDFLAGS_x32="-m elf32_x86_64"
LDFLAGS_x86="-m elf_i386"
LESS="-sFRiMX --shift 5"
LESSOPEN="|lesspipe %s"
LIBDIR_amd64="lib64"
LIBDIR_x32="libx32"
LIBDIR_x86="lib"
LIBREOFFICE_EXTENSIONS=""
LLVM_TARGETS="AArch64 ARM X86"
LOGNAME="root"
LUA_SINGLE_TARGET=""
LUA_TARGETS=""
MAKEOPTS="--load-average=5 --jobs=5"
MANPAGER="manpager"
MANPATH="/usr/share/gcc-data/x86_64-pc-linux-gnu/10.2.0/man:/usr/share/binutils-data/x86_64-pc-linux-gnu/2.35.2/man:/etc/java-config-2/current-system-vm/man/:/usr/local/share/man:/usr/share/man:/usr/lib/rust/man:/usr/lib/llvm/11/share/man:/usr/lib/llvm/10/share/man:/opt/plan9/man"
MULTILIB_ABIS="amd64"
MULTILIB_STRICT_DENY="64-bit.*shared object"
MULTILIB_STRICT_DIRS="/lib32 /lib /usr/lib32 /usr/lib /usr/kde/*/lib32 /usr/kde/*/lib /usr/qt/*/lib32 /usr/qt/*/lib /usr/X11R6/lib32 /usr/X11R6/lib"
MULTILIB_STRICT_EXEMPT="(perl5|gcc|binutils|eclipse-3|debug|portage|udev|systemd|clang|python-exec|llvm)"
NOCOLOR="false"
NOCOMMON="-fno-common"
NOPLT="-fno-plt"
NTHREADS="auto"
OFFICE_IMPLEMENTATION=""
OLDPWD="/var/db/repos/gentoo/gnome-base/librsvg"
PACKAGE_MANAGER="portage"
PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
PAX_MARKINGS="XT"
PHP_TARGETS=""
PKGDIR="/var/cache/binpkgs"
PLAN9="/opt/plan9"
PORTAGE_ARCHLIST="alpha amd64 amd64-linux arm arm-linux arm64 arm64-linux arm64-macos hidden hppa ia64 m68k mips ppc ppc-macos ppc64 ppc64-linux riscv s390 sparc sparc-solaris sparc64-solaris x64-cygwin x64-macos x64-solaris x64-winnt x86 x86-linux x86-solaris x86-winnt"
PORTAGE_BIN_PATH="/usr/lib/portage/python3.8"
PORTAGE_COMPRESS_EXCLUDE_SUFFIXES="css gif htm[l]? jp[e]?g js pdf png"
PORTAGE_CONFIGROOT="/"
PORTAGE_DEBUG="0"
PORTAGE_DEPCACHEDIR="/var/cache/edb/dep"
PORTAGE_ELOG_CLASSES="*"
PORTAGE_ELOG_MAILFROM="portage@localhost"
PORTAGE_ELOG_MAILSUBJECT="[portage] ebuild log for ${PACKAGE} on ${HOST}"
PORTAGE_ELOG_MAILURI="root"
PORTAGE_ELOG_SYSTEM="echo:warn,error,qa save:*"
PORTAGE_FETCH_CHECKSUM_TRY_MIRRORS="5"
PORTAGE_FETCH_RESUME_MIN_SIZE="350K"
PORTAGE_GID="250"
PORTAGE_GPG_SIGNING_COMMAND="gpg --sign --digest-algo SHA256 --clearsign --yes --default-key "${PORTAGE_GPG_KEY}" --homedir "${PORTAGE_GPG_DIR}" "${FILE}""
PORTAGE_INST_GID="0"
PORTAGE_INST_UID="0"
PORTAGE_INTERNAL_CALLER="1"
PORTAGE_IONICE_COMMAND="ionice -c 3 -p ${PID}"
PORTAGE_LOGDIR="/var/log/portage"
PORTAGE_LOGDIR_CLEAN="find "${PORTAGE_LOGDIR}" -type f ! -name "summary.log*" -mtime +7 -delete"
PORTAGE_NICENESS="3"
PORTAGE_OVERRIDE_EPREFIX=""
PORTAGE_PYM_PATH="/usr/lib/python3.8/site-packages"
PORTAGE_PYTHONPATH="/usr/lib/python3.8/site-packages"
PORTAGE_RSYNC_OPTS="--recursive --links --safe-links --perms --times --omit-dir-times --compress --force --whole-file --delete --stats --human-readable --timeout=180 --exclude=/distfiles --exclude=/local --exclude=/packages --exclude=/.git"
PORTAGE_RSYNC_RETRIES="-1"
PORTAGE_SYNC_STALE="30"
PORTAGE_TMPDIR="/tmp"
PORTAGE_VERBOSE="1"
PORTAGE_WORKDIR_MODE="0700"
PORTAGE_XATTR_EXCLUDE="btrfs.* security.evm security.ima 	security.selinux system.nfs4_acl user.apache_handler 	user.Beagle.* user.dublincore.* user.mime_encoding user.xdg.*"
POSTGRES_TARGETS=""
PROFILE_ONLY_VARIABLES="ARCH ELIBC IUSE_IMPLICIT KERNEL USERLAND USE_EXPAND_IMPLICIT USE_EXPAND_UNPREFIXED USE_EXPAND_VALUES_ARCH USE_EXPAND_VALUES_ELIBC USE_EXPAND_VALUES_KERNEL USE_EXPAND_VALUES_USERLAND"
PWD="/var/db/repos/gentoo/gnome-base/librsvg"
PYTHONDONTWRITEBYTECODE="1"
PYTHON_SINGLE_TARGET=""
PYTHON_TARGETS=""
RESUMECOMMAND="wget -c -t 3 -T 60 --passive-ftp -O "${DISTDIR}/${FILE}" "${URI}""
RESUMECOMMAND_RSYNC="rsync -LtvP "${URI}" "${DISTDIR}/${FILE}""
RESUMECOMMAND_SSH="bash -c "x=\${2#ssh://} ; host=\${x%%/*} ; port=\${host##*:} ; host=\${host%:*} ; [[ \${host} = \${port} ]] && port= ; exec rsync --rsh=\"ssh \${port:+-p\${port}} \${3}\" -avP \"\${host}:/\${x#*/}\" \"\$1\"" rsync "${DISTDIR}/${FILE}" "${URI}" "${PORTAGE_SSH_OPTS}""
ROOT="/"
ROOTPATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin:/usr/lib/llvm/11/bin:/usr/lib/llvm/10/bin:/opt/plan9/bin"
RPMDIR="/var/cache/rpm"
RUBY_TARGETS=""
SAFER_FAST_MATH="-fno-signed-zeros -fno-trapping-math -fassociative-math -freciprocal-math -fno-math-errno -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fcx-limited-range -fexcess-precision=fast"
SAFER_UNSAFE_MATH_OPTS="-fno-signed-zeros -fno-trapping-math -fassociative-math -freciprocal-math"
SAFEST_FAST_MATH="-fno-math-errno -fno-trapping-math"
SBCL_HOME="/usr/lib64/sbcl"
SBCL_SOURCE_ROOT="/usr/lib64/sbcl/src"
SEMINTERPOS="-fno-semantic-interposition"
SHELL="/bin/bash"
SHLVL="1"
SYMLINK_LIB="no"
SYSROOT="/"
TERM="screen-256color"
TWISTED_DISABLE_WRITING_OF_PLUGIN_CACHE="1"
UNINSTALL_IGNORE="/lib/modules/* /var/run /var/lock"
USE="acl aio amd64 asm caps cron custom-cflags custom-optimization elogind filecaps gmp http2 hwdb jemalloc jumbo-build kmod libglvnd logrotate lto native-extensions native-symlinks numa openmp openrc pam pgo split-usr system-av1 system-binutils system-boost system-cmark system-ffmpeg system-harfbuzz system-heimdal system-icu system-ipxe system-jpeg system-jsoncpp system-lcms system-leveldb system-libcxx system-libevent system-libvpx system-libyaml system-llvm system-lua system-lz4 system-mathjax system-mesa system-numpy system-python system-qemu system-seabios system-sqlite system-ssl system-tbb system-webp system-zlib threads udev urandom xattr" ABI_X86="64" CPU_FLAGS_X86="avx mmx mmxext popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3" ELIBC="glibc" KERNEL="linux" L10N="en" LLVM_TARGETS="AArch64 ARM X86" USERLAND="GNU" VIDEO_CARDS="intel i915 i965"
USER="root"
USERLAND="GNU"
USE_EXPAND="ABI_MIPS ABI_PPC ABI_RISCV ABI_S390 ABI_X86 ADA_TARGET ALSA_CARDS APACHE2_MODULES APACHE2_MPMS CALLIGRA_FEATURES CAMERAS COLLECTD_PLUGINS CPU_FLAGS_ARM CPU_FLAGS_PPC CPU_FLAGS_X86 CURL_SSL ELIBC ENLIGHTENMENT_MODULES FFTOOLS GPSD_PROTOCOLS GRUB_PLATFORMS INPUT_DEVICES KERNEL L10N LCD_DEVICES LIBREOFFICE_EXTENSIONS LIRC_DEVICES LLVM_TARGETS LUA_SINGLE_TARGET LUA_TARGETS MONKEYD_PLUGINS NGINX_MODULES_HTTP NGINX_MODULES_MAIL NGINX_MODULES_STREAM OFED_DRIVERS OFFICE_IMPLEMENTATION OPENMPI_FABRICS OPENMPI_OFED_FEATURES OPENMPI_RM PHP_TARGETS POSTGRES_TARGETS PYTHON_SINGLE_TARGET PYTHON_TARGETS QEMU_SOFTMMU_TARGETS QEMU_USER_TARGETS ROS_MESSAGES RUBY_TARGETS SANE_BACKENDS USERLAND UWSGI_PLUGINS VIDEO_CARDS VOICEMAIL_STORAGE XFCE_PLUGINS XTABLES_ADDONS"
USE_EXPAND_HIDDEN="ABI_MIPS ABI_PPC ABI_RISCV ABI_S390 ABI_X86 CPU_FLAGS_ARM CPU_FLAGS_PPC ELIBC KERNEL USERLAND"
USE_EXPAND_IMPLICIT="ARCH ELIBC KERNEL USERLAND"
USE_EXPAND_UNPREFIXED="ARCH"
USE_EXPAND_VALUES_ARCH="alpha amd64 amd64-fbsd amd64-linux arm arm64 arm64-macos hppa ia64 m68k mips ppc ppc64 ppc64-linux ppc-macos riscv s390 sparc sparc64-solaris sparc-solaris x64-cygwin x64-macos x64-solaris x64-winnt x86 x86-fbsd x86-linux x86-solaris x86-winnt"
USE_EXPAND_VALUES_ELIBC="AIX bionic Cygwin Darwin DragonFly FreeBSD glibc HPUX Interix mingw mintlib musl NetBSD OpenBSD SunOS uclibc Winnt"
USE_EXPAND_VALUES_KERNEL="AIX Darwin FreeBSD freemint HPUX linux NetBSD OpenBSD SunOS Winnt"
USE_EXPAND_VALUES_USERLAND="BSD GNU"
USE_ORDER="env:pkg:conf:defaults:pkginternal:features:repo:env.d"
VIDEO_CARDS="intel i915 i965"
VISUAL="nvim"
XDG_CONFIG_DIRS="/etc/xdg"
XDG_DATA_DIRS="/usr/local/share:/usr/share"
XTABLES_ADDONS=""
```
</details>