### PR TITLE
dev-python/sympy: Resolve test issues with theano-pymc

### DIFF
--- a/dev-python/sympy/files/sympy-1.7.1-theano-pymc.patch
+++ b/dev-python/sympy/files/sympy-1.7.1-theano-pymc.patch
@@ -1,0 +1,56 @@
+--- a/sympy/printing/tests/test_theanocode.py
++++ b/sympy/printing/tests/test_theanocode.py
+@@ -67,9 +67,9 @@ def fgraph_of(*exprs):
+     theano.gof.FunctionGraph
+     """
+     outs = list(map(theano_code_, exprs))
+-    ins = theano.gof.graph.inputs(outs)
+-    ins, outs = theano.gof.graph.clone(ins, outs)
+-    return theano.gof.FunctionGraph(ins, outs)
++    ins = theano.graph.basic.graph_inputs(outs)
++    ins, outs = theano.graph.basic.clone(ins, outs)
++    return theano.graph.fg.FunctionGraph(ins, outs)
+ 
+ 
+ def theano_simplify(fgraph):
+@@ -350,7 +350,7 @@ def test_theano_function_scalar():
+             f = theano_function_(inputs, outputs, dims=in_dims, scalar=scalar)
+ 
+             # Check the theano_function attribute is set whether wrapped or not
+-            assert isinstance(f.theano_function, theano.compile.function_module.Function)
++            assert isinstance(f.theano_function, theano.compile.function.types.Function)
+ 
+             # Feed in inputs of the appropriate size and get outputs
+             in_values = [
+@@ -401,7 +401,7 @@ def theq_slice(s1, s2):
+     assert theq_slice(theano_code_(slice(1, x, 3), dtypes=dtypes), slice(1, xt, 3))
+ 
+ def test_MatrixSlice():
+-    from theano import Constant
++    from theano.graph.basic import Constant
+ 
+     cache = {}
+ 
+@@ -556,9 +556,9 @@ def test_cache_complex():
+     # Iterate through variables in the Theano computational graph that the
+     # printed expression depends on
+     seen = set()
+-    for v in theano.gof.graph.ancestors([expr_t]):
++    for v in theano.graph.basic.ancestors([expr_t]):
+         # Owner-less, non-constant variables should be our symbols
+-        if v.owner is None and not isinstance(v, theano.gof.graph.Constant):
++        if v.owner is None and not isinstance(v, theano.graph.basic.Constant):
+             # Check it corresponds to a symbol and appears only once
+             assert v.name in symbol_names
+             assert v.name not in seen
+--- a/sympy/printing/theanocode.py
++++ b/sympy/printing/theanocode.py
+@@ -494,7 +494,7 @@ def theano_function(inputs, outputs, scalar=False, *,
+     toutputs = list(map(code, outputs))
+ 
+     #fix constant expressions as variables
+-    toutputs = [output if isinstance(output, theano.Variable) else tt.as_tensor_variable(output) for output in toutputs]
++    toutputs = [output if isinstance(output, theano.graph.basic.Variable) else tt.as_tensor_variable(output) for output in toutputs]
+ 
+     if len(toutputs) == 1:
+         toutputs = toutputs[0]

--- a/dev-python/sympy/sympy-1.7.1-r1.ebuild
+++ b/dev-python/sympy/sympy-1.7.1-r1.ebuild
@@ -20,6 +20,8 @@ IUSE="examples imaging ipython latex mathml opengl pdf png pyglet symengine test
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RESTRICT="!test? ( test )"
 
+PATCHES=( "${FILESDIR}"/${P}-theano-pymc.patch )
+
 BDEPEND="test? ( dev-python/pytest[${PYTHON_USEDEP}] )"
 RDEPEND="dev-python/mpmath[${PYTHON_USEDEP}]
 	dev-python/pexpect[${PYTHON_USEDEP}]


### PR DESCRIPTION
I ran into couple of test issues while with theano-pymc
```bash
FAILED sympy/printing/tests/test_theanocode.py::test_Derivative - AttributeError: module 'theano' has no attribute 'gof'
FAILED sympy/printing/tests/test_theanocode.py::test_theano_function_simple - AttributeError: module 'theano' has no attribute 'Variable'
FAILED sympy/printing/tests/test_theanocode.py::test_theano_function_multi - AttributeError: module 'theano' has no attribute 'Variable'
FAILED sympy/printing/tests/test_theanocode.py::test_theano_function_numpy - AttributeError: module 'theano' has no attribute 'Variable'
FAILED sympy/printing/tests/test_theanocode.py::test_theano_function_matrix - AttributeError: module 'theano' has no attribute 'Variable'
FAILED sympy/printing/tests/test_theanocode.py::test_theano_function_kwargs - AttributeError: module 'theano' has no attribute 'Variable'
FAILED sympy/printing/tests/test_theanocode.py::test_theano_function_scalar - AttributeError: module 'theano' has no attribute 'Variable'
FAILED sympy/printing/tests/test_theanocode.py::test_MatrixSlice - ImportError: cannot import name 'Constant' from 'theano' (/usr/lib/python3.8/site-packages/theano/__init__.py)
FAILED sympy/printing/tests/test_theanocode.py::test_cache_complex - AttributeError: module 'theano' has no attribute 'gof'
FAILED sympy/printing/tests/test_theanocode.py::test_constantfunctions - AttributeError: module 'theano' has no attribute 'Variable'
```


Tha patch is a WIP for now as I still need to fix 2 more failures:
```
FAILED sympy/printing/tests/test_theanocode.py::test_Derivative - theano.graph.fg.MissingInputError: Input 0 of the graph (indices start from 0), used to compute Elemwise{second,no_inplace}(x, TensorConstant{1....
FAILED sympy/printing/tests/test_theanocode.py::test_theano_function_scalar - AttributeError: module 'theano.compile.function' has no attribute 'Function'
```