### PR TITLE
gui-apps/swappy: fix werror for meson build

### DIFF
--- a/gui-apps/swappy/swappy-1.3.1.ebuild
+++ b/gui-apps/swappy/swappy-1.3.1.ebuild
@@ -40,6 +40,14 @@ src_prepare() {
 	sed -i -e 's/Utility;Graphics;Annotation;/Utility;Graphics;/'  src/po/swappy.desktop.in || die "Sed failed!"
 }
 
+src_configure() {
+	local emesonargs=(
+		-Dwerror=false
+		-Dman-pages=enabled
+	)
+	meson_src_configure
+}
+
 pkg_postinst() {
 	xdg_pkg_postinst
 

--- a/gui-apps/swappy/swappy-9999.ebuild
+++ b/gui-apps/swappy/swappy-9999.ebuild
@@ -40,6 +40,14 @@ src_prepare() {
 	sed -i -e 's/Utility;Graphics;Annotation;/Utility;Graphics;/'  src/po/swappy.desktop.in || die "Sed failed!"
 }
 
+src_configure() {
+	local emesonargs=(
+		-Dwerror=false
+		-Dman-pages=enabled
+	)
+	meson_src_configure
+}
+
 pkg_postinst() {
 	xdg_pkg_postinst
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/774162
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>

---

@emlove 