### PR TITLE
x11-misc/dunst: fix install for wayland only systems

### DIFF
--- a/x11-misc/dunst/dunst-1.6.1.ebuild
+++ b/x11-misc/dunst/dunst-1.6.1.ebuild
@@ -54,6 +54,7 @@ src_compile() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" PREFIX="${EPREFIX}/usr" install
+	emake WAYLAND=$(usex wayland 1 0) SYSTEMD=0 \
+	      DESTDIR="${D}" PREFIX="${EPREFIX}/usr" install
 	systemd_dounit dunst.service
 }

--- a/x11-misc/dunst/dunst-9999.ebuild
+++ b/x11-misc/dunst/dunst-9999.ebuild
@@ -54,6 +54,7 @@ src_compile() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" PREFIX="${EPREFIX}/usr" install
+	emake WAYLAND=$(usex wayland 1 0) SYSTEMD=0 \
+	      DESTDIR="${D}" PREFIX="${EPREFIX}/usr" install
 	systemd_dounit dunst.service
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/774183
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>