### PR TITLE
games-fps/chocolate-doom: Add Python 3.9 target

### DIFF
--- a/games-fps/chocolate-doom/chocolate-doom-3.0.1.ebuild
+++ b/games-fps/chocolate-doom/chocolate-doom-3.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit autotools prefix python-any-r1 xdg
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/774282
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>