### PR TITLE
Freedoom data Python 3.9 support

### DIFF
--- a/games-fps/freedm-data/freedm-data-0.12.1.ebuild
+++ b/games-fps/freedm-data/freedm-data-0.12.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit prefix python-any-r1 xdg
 

--- a/games-fps/freedoom-data/freedoom-data-0.12.1.ebuild
+++ b/games-fps/freedoom-data/freedoom-data-0.12.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit prefix python-any-r1 xdg
 


### PR DESCRIPTION
`games-fps/freedoom-data-0.12.1` and `games-fps/freedm-data-0.12.1` should both be able to support Python 3.9, so let's add it to the PYTHON_COMPAT line.