### PR TITLE
Freedoom metapackage license

### DIFF
--- a/games-fps/freedm/freedm-0.12.1.ebuild
+++ b/games-fps/freedm/freedm-0.12.1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 DESCRIPTION="A 32-level game designed for competitive deathmatch play."
 HOMEPAGE="https://freedoom.github.io"
 
-LICENSE="BSD"
+LICENSE="metapackage"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 

--- a/games-fps/freedoom/freedoom-0.12.1.ebuild
+++ b/games-fps/freedoom/freedoom-0.12.1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 DESCRIPTION="A complete free-content single-player focused game based on the Doom engine"
 HOMEPAGE="https://freedoom.github.io"
 
-LICENSE="BSD"
+LICENSE="metapackage"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 


### PR DESCRIPTION
`games-fps/freedoom` and `games-fps/freedm` are metapackages that (themselves) install no files, therefore the LICENSE variable should be set to "metapackage".