### PR TITLE
app-crypt/tpm2-tools: Silence clang warnings about unsupported flags

### DIFF
--- a/app-crypt/tpm2-tools/files/tpm2-tools-4.3.0-Remove-clang-warnings.patch
+++ b/app-crypt/tpm2-tools/files/tpm2-tools-4.3.0-Remove-clang-warnings.patch
@@ -1,0 +1,30 @@
+diff --git a/configure.ac b/configure.ac
+index 7b5c2196..4d402959 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -217,7 +217,6 @@ AS_IF([test x"$enable_hardening" != x"no"], [
+   add_hardened_c_flag([-Wstack-protector])
+   add_hardened_c_flag([-fstack-protector-all])
+   add_hardened_c_flag([-Wstrict-overflow=5])
+-  add_hardened_c_flag([-Wbool-compare])
+ 
+   add_hardened_c_flag([-O2])
+   AX_ADD_FORTIFY_SOURCE
+@@ -249,10 +248,13 @@ add_c_flag([-D_GNU_SOURCE], [AC_MSG_ERROR([Cannot enable -D_GNU_SOURCE])])
+ 
+ # Best attempt compiler options that are on newer versions of GCC that
+ # we can't widely enforce without killing other peoples builds
+-add_c_flag([-Wstringop-overflow=4])
+-add_c_flag([-Wstringop-truncation])
+-add_c_flag([-Wduplicated-branches])
+-add_c_flag([-Wduplicated-cond])
++
++AS_IF([test "$HOSTOS" = "Linux" -a ! "$CC" = "clang"],
++	[add_c_flag([-Wstringop-overflow=4])
++	 add_c_flag([-Wstringop-truncation])
++	 add_c_flag([-Wduplicated-branches])
++	 add_c_flag([-Wduplicated-cond])
++	 add_hardened_c_flag([-Wbool-compare])],[])
+ 
+ # Best attempt, strip unused stuff from the binary to reduce size.
+ # Rather than nesting these and making them ugly just use a counter.

--- a/app-crypt/tpm2-tools/files/tpm2-tools-5.0-Remove-clang-warnings.patch
+++ b/app-crypt/tpm2-tools/files/tpm2-tools-5.0-Remove-clang-warnings.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index a3988e15..93ca9de5 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -271,7 +271,7 @@ add_c_flag([-D_GNU_SOURCE], [AC_MSG_ERROR([Cannot enable -D_GNU_SOURCE])])
+ # Best attempt compiler options that are on newer versions of GCC that
+ # we can't widely enforce without killing other peoples builds.
+ # Works with gcc only. Needs to be disabled on BSD and clang
+-AS_IF([test "$HOSTOS" = "Linux"],
++AS_IF([test "$HOSTOS" = "Linux" -a ! "$CC" = "clang"],
+       [add_c_flag([-Wstringop-overflow=4])
+        add_c_flag([-Wstringop-truncation])
+        add_c_flag([-Wduplicated-branches])

--- a/app-crypt/tpm2-tools/tpm2-tools-4.3.0-r1.ebuild
+++ b/app-crypt/tpm2-tools/tpm2-tools-4.3.0-r1.ebuild
@@ -29,6 +29,7 @@ BDEPEND="virtual/pkgconfig
 PATCHES=(
 	"${FILESDIR}/${PN}-4.3.0-libressl.patch"
 	"${FILESDIR}/${PN}-4.3.0-Remove-WError.patch"
+	"${FILESDIR}/${PN}-4.3.0-Remove-clang-warnings.patch"
 )
 
 src_prepare() {

--- a/app-crypt/tpm2-tools/tpm2-tools-5.0-r1.ebuild
+++ b/app-crypt/tpm2-tools/tpm2-tools-5.0-r1.ebuild
@@ -27,8 +27,9 @@ DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig
 	sys-devel/autoconf-archive"
 PATCHES=(
-	"${FILESDIR}/${PN}-5.0-libressl.patch"
 	"${FILESDIR}/${PN}-4.3.0-Remove-WError.patch"
+	"${FILESDIR}/${PN}-5.0-libressl.patch"
+	"${FILESDIR}/${PN}-5.0-Remove-clang-warnings.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Although upstream has fixed compilation of this package so it compiles under clang, it produces a ton of warnings about unsupported flags. Thus, if clang is detected, a patch is applied is remove the options clang doesn't understand. 