### PR TITLE
sci-libs/libspatialindex: fixed werror

### DIFF
--- a/sci-libs/libspatialindex/files/libspatialindex-1.9.3-use-system-gtest.patch
+++ b/sci-libs/libspatialindex/files/libspatialindex-1.9.3-use-system-gtest.patch
@@ -1,0 +1,12 @@
+diff --git a/test/gtest/CMakeLists.txt b/test/gtest/CMakeLists.txt
+--- a/test/gtest/CMakeLists.txt	(revision 5a08124d541319d39886710afc1d61dfff5575a1)
++++ b/test/gtest/CMakeLists.txt	(date 1615011059253)
+@@ -1,8 +1,5 @@
+ set (GOOGLETEST_VERSION "1.10.0")
+
+-add_subdirectory(gtest-1.10.0)
+-include_directories(./gtest-1.10.0/include)
+-
+ set (SOURCES
+     test.h
+     sidx_api_test.h

--- a/sci-libs/libspatialindex/libspatialindex-1.9.3-r1.ebuild
+++ b/sci-libs/libspatialindex/libspatialindex-1.9.3-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+MY_P="spatialindex-src-${PV}"
+
+DESCRIPTION="C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API"
+HOMEPAGE="https://libspatialindex.org/
+	https://github.com/libspatialindex/libspatialindex"
+SRC_URI="https://github.com/libspatialindex/${PN}/releases/download/${PV}/${MY_P}.tar.bz2"
+
+LICENSE="MIT"
+SLOT="0/6"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND=""
+DEPEND="test? ( >=dev-cpp/gtest-1.10.0 )"
+
+S=${WORKDIR}/${MY_P}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-respect-compiler-flags.patch
+	"${FILESDIR}"/${P}-use-system-gtest.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DSIDX_BUILD_TESTS=$(usex test)
+	)
+
+	cmake_src_configure
+}


### PR DESCRIPTION
Using system provided gtest instead of bundled one

Closes: https://bugs.gentoo.org/show_bug.cgi?id=764305
Signed-off-by: Dennis Lamm <expeditioneer@gentoo.org>
Package-Manager: Portage-3.0.13, Repoman-3.0.2