### PR TITLE
media-libs/libsdl: BDEPEND

### DIFF
--- a/media-libs/libsdl/libsdl-1.2.15_p20210224.ebuild
+++ b/media-libs/libsdl/libsdl-1.2.15_p20210224.ebuild
@@ -49,6 +49,7 @@ DEPEND="${RDEPEND}
 			>=dev-lang/nasm-0.98.39-r3
 		)
 	)"
+BDEPEND="pulseaudio? ( virtual/pkgconfig )"
 
 S=${WORKDIR}/SDL-1.2-${MY_COMMIT}
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/617772
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>