### PR TITLE
{profiles,sys-devel/clang}: enable abi_x86_32 clang-runtime & deps; support default unwindlib

### DIFF
--- a/profiles/arch/amd64/package.use
+++ b/profiles/arch/amd64/package.use
@@ -1,5 +1,13 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Theo Anderson <telans@posteo.de> (2021-03-06)
+# Enable 32-bit clang runtime to ease -m32 builds with non-GCC runtime
+sys-devel/clang-runtime abi_x86_32
+sys-libs/libcxxabi abi_x86_32
+sys-libs/libcxx abi_x86_32
+sys-libs/libomp abi_x86_32
+sys-libs/llvm-libunwind abi_x86_32
 
 # Mike Gilbert <floppym@gentoo.org> (2016-11-17)
 # Enable both efi and pc by default.

--- a/sys-devel/clang/clang-12.0.0-r1.ebuild
+++ b/sys-devel/clang/clang-12.0.0-r1.ebuild
@@ -24,7 +24,7 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA MIT"
 SLOT="$(ver_cut 1)"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x64-macos"
 IUSE="debug default-compiler-rt default-libcxx default-lld
-	doc +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
+	doc llvm-libunwind +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	|| ( ${ALL_LLVM_TARGETS[*]} )"
 RESTRICT="!test? ( test )"
@@ -52,7 +52,11 @@ RDEPEND="${RDEPEND}
 PDEPEND="
 	sys-devel/clang-common
 	~sys-devel/clang-runtime-${PV}
-	default-compiler-rt? ( =sys-libs/compiler-rt-${PV%_*}* )
+	default-compiler-rt? (
+		=sys-libs/compiler-rt-${PV%_*}*
+		llvm-libunwind? ( sys-libs/llvm-libunwind )
+		!llvm-libunwind? ( sys-libs/libunwind )
+	)
 	default-libcxx? ( >=sys-libs/libcxx-${PV} )
 	default-lld? ( sys-devel/lld )"
 
@@ -262,6 +266,7 @@ multilib_src_configure() {
 		-DCLANG_DEFAULT_CXX_STDLIB=$(usex default-libcxx libc++ "")
 		-DCLANG_DEFAULT_RTLIB=$(usex default-compiler-rt compiler-rt "")
 		-DCLANG_DEFAULT_LINKER=$(usex default-lld lld "")
+		-DCLANG_DEFAULT_UNWINDLIB=$(usex default-compiler-rt libunwind "")
 
 		-DCLANG_ENABLE_ARCMT=$(usex static-analyzer)
 		-DCLANG_ENABLE_STATIC_ANALYZER=$(usex static-analyzer)

--- a/sys-devel/clang/clang-12.0.1.9999.ebuild
+++ b/sys-devel/clang/clang-12.0.1.9999.ebuild
@@ -24,7 +24,7 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA MIT"
 SLOT="$(ver_cut 1)"
 KEYWORDS=""
 IUSE="debug default-compiler-rt default-libcxx default-lld
-	doc +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
+	doc llvm-libunwind +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	|| ( ${ALL_LLVM_TARGETS[*]} )"
 RESTRICT="!test? ( test )"
@@ -52,7 +52,11 @@ RDEPEND="${RDEPEND}
 PDEPEND="
 	sys-devel/clang-common
 	~sys-devel/clang-runtime-${PV}
-	default-compiler-rt? ( =sys-libs/compiler-rt-${PV%_*}* )
+	default-compiler-rt? (
+		=sys-libs/compiler-rt-${PV%_*}*
+		llvm-libunwind? ( sys-libs/llvm-libunwind )
+		!llvm-libunwind? ( sys-libs/libunwind )
+	)
 	default-libcxx? ( >=sys-libs/libcxx-${PV} )
 	default-lld? ( sys-devel/lld )"
 
@@ -262,6 +266,7 @@ multilib_src_configure() {
 		-DCLANG_DEFAULT_CXX_STDLIB=$(usex default-libcxx libc++ "")
 		-DCLANG_DEFAULT_RTLIB=$(usex default-compiler-rt compiler-rt "")
 		-DCLANG_DEFAULT_LINKER=$(usex default-lld lld "")
+		-DCLANG_DEFAULT_UNWINDLIB=$(usex default-compiler-rt libunwind "")
 
 		-DCLANG_ENABLE_ARCMT=$(usex static-analyzer)
 		-DCLANG_ENABLE_STATIC_ANALYZER=$(usex static-analyzer)

--- a/sys-devel/clang/clang-12.0.1_rc1.ebuild
+++ b/sys-devel/clang/clang-12.0.1_rc1.ebuild
@@ -24,7 +24,7 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA MIT"
 SLOT="$(ver_cut 1)"
 KEYWORDS=""
 IUSE="debug default-compiler-rt default-libcxx default-lld
-	doc +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
+	doc llvm-libunwind +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	|| ( ${ALL_LLVM_TARGETS[*]} )"
 RESTRICT="!test? ( test )"
@@ -52,7 +52,11 @@ RDEPEND="${RDEPEND}
 PDEPEND="
 	sys-devel/clang-common
 	~sys-devel/clang-runtime-${PV}
-	default-compiler-rt? ( =sys-libs/compiler-rt-${PV%_*}* )
+	default-compiler-rt? (
+		=sys-libs/compiler-rt-${PV%_*}*
+		llvm-libunwind? ( sys-libs/llvm-libunwind )
+		!llvm-libunwind? ( sys-libs/libunwind )
+	)
 	default-libcxx? ( >=sys-libs/libcxx-${PV} )
 	default-lld? ( sys-devel/lld )"
 
@@ -262,6 +266,7 @@ multilib_src_configure() {
 		-DCLANG_DEFAULT_CXX_STDLIB=$(usex default-libcxx libc++ "")
 		-DCLANG_DEFAULT_RTLIB=$(usex default-compiler-rt compiler-rt "")
 		-DCLANG_DEFAULT_LINKER=$(usex default-lld lld "")
+		-DCLANG_DEFAULT_UNWINDLIB=$(usex default-compiler-rt libunwind "")
 
 		-DCLANG_ENABLE_ARCMT=$(usex static-analyzer)
 		-DCLANG_ENABLE_STATIC_ANALYZER=$(usex static-analyzer)

--- a/sys-devel/clang/clang-13.0.0.9999.ebuild
+++ b/sys-devel/clang/clang-13.0.0.9999.ebuild
@@ -24,7 +24,7 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA MIT"
 SLOT="$(ver_cut 1)"
 KEYWORDS=""
 IUSE="debug default-compiler-rt default-libcxx default-lld
-	doc +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
+	doc llvm-libunwind +static-analyzer test xml kernel_FreeBSD ${ALL_LLVM_TARGETS[*]}"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	|| ( ${ALL_LLVM_TARGETS[*]} )"
 RESTRICT="!test? ( test )"
@@ -52,7 +52,11 @@ RDEPEND="${RDEPEND}
 PDEPEND="
 	sys-devel/clang-common
 	~sys-devel/clang-runtime-${PV}
-	default-compiler-rt? ( =sys-libs/compiler-rt-${PV%_*}* )
+	default-compiler-rt? (
+		=sys-libs/compiler-rt-${PV%_*}*
+		llvm-libunwind? ( sys-libs/llvm-libunwind )
+		!llvm-libunwind? ( sys-libs/libunwind )
+	)
 	default-libcxx? ( >=sys-libs/libcxx-${PV} )
 	default-lld? ( sys-devel/lld )"
 
@@ -262,6 +266,7 @@ multilib_src_configure() {
 		-DCLANG_DEFAULT_CXX_STDLIB=$(usex default-libcxx libc++ "")
 		-DCLANG_DEFAULT_RTLIB=$(usex default-compiler-rt compiler-rt "")
 		-DCLANG_DEFAULT_LINKER=$(usex default-lld lld "")
+		-DCLANG_DEFAULT_UNWINDLIB=$(usex default-compiler-rt libunwind "")
 
 		-DCLANG_ENABLE_ARCMT=$(usex static-analyzer)
 		-DCLANG_ENABLE_STATIC_ANALYZER=$(usex static-analyzer)


### PR DESCRIPTION
The end goal of these commits is to fix __Unwind linking issues when using `sys-devel/clang[default-compiler-rt]` and not specifying `-unwindlib=libunwind`. See the bug linked to close.
A side effect of `sys-devel/clang` defaulting to using `sys-libs/llvm-libunwind` as the unwindlib is that all `abi_x86_32` multilib builds then require `sys-libs/llvm-libunwind[abi_x86_32]` to build, too.
After speaking to @mgorny it was determined that the best course of action is to enable `abi_x86_32` on all dependencies of `sys-devel/clang-runtime` on multilib profiles.

```
profiles: enable abi_x86_32 clang-runtime & deps
    
    Enable for compatability with -unwindlib=libunwind
    sys-devel/clang[default-compiler-rt] requires these for multilib builds
    
    Package-Manager: Portage-3.0.16, Repoman-3.0.2
    Signed-off-by: Theo Anderson <telans@posteo.de>
```
```
sys-devel/clang: support default unwindlib
    
    !riscv? ( sys-libs/libunwind ) rather than use masking as it is not keyworded,
     but riscv can still use sys-libs/llvm-libunwind
    
    Closes: https://bugs.gentoo.org/702344
    Closes: https://bugs.gentoo.org/722978
    Signed-off-by: Theo Anderson <telans@posteo.de>
```