### PR TITLE
Prelude-SIEM 5.2: properly set DISTUTILS_USE_SETUPTOOLS variable

### DIFF
--- a/dev-libs/libprelude/libprelude-5.2.0-r10.ebuild
+++ b/dev-libs/libprelude/libprelude-5.2.0-r10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,6 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{7,8} )
 USE_RUBY="ruby25 ruby26 ruby27"
 DISTUTILS_OPTIONAL=1
+DISTUTILS_USE_SETUPTOOLS=no
 
 LUA_COMPAT=( lua5-{1..3} )
 

--- a/dev-libs/libpreludedb/libpreludedb-5.2.0.ebuild
+++ b/dev-libs/libpreludedb/libpreludedb-5.2.0.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8} )
 DISTUTILS_OPTIONAL=1
+DISTUTILS_USE_SETUPTOOLS=no
 
 inherit autotools distutils-r1
 

--- a/net-analyzer/prelude-correlator/prelude-correlator-5.2.0.ebuild
+++ b/net-analyzer/prelude-correlator/prelude-correlator-5.2.0.ebuild
@@ -1,9 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8} )
+DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1 systemd
 


### PR DESCRIPTION
Hello

This PR is related to all prelude bugs about "uses a probably incorrect DISTUTILS_USE_SETUPTOOLS value"

I agree with the proposed values so I just update the ebuilds in this way.

Regards