### PR TITLE
sci-libs/shapely: fixed failing tests with geos 3.9

### DIFF
--- a/sci-libs/shapely/files/shapely-1.7.1-tests-support-geos-3.9.patch
+++ b/sci-libs/shapely/files/shapely-1.7.1-tests-support-geos-3.9.patch
@@ -1,0 +1,61 @@
+diff --git a/tests/test_svg.py b/tests/test_svg.py
+--- a/tests/test_svg.py	(revision 56c0f97a80e75308cf62e0bc4883238c10f56fdf)
++++ b/tests/test_svg.py	(date 1615044742785)
+@@ -174,7 +174,8 @@
+         self.assertSVG(GeometryCollection(), '<g />')
+         # Valid
+         self.assertSVG(
+-            Point(7, 3).union(LineString([(4, 2), (8, 4)])),
++            GeometryCollection(
++                [Point(7, 3), LineString([(4, 2), (8, 4)])]),
+             '<g><circle cx="7.0" cy="3.0" r="3.0" stroke="#555555" '
+             'stroke-width="1.0" fill="#66cc99" opacity="0.6" />'
+             '<polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
+--- a/tests/test_wkb.py	(revision 56c0f97a80e75308cf62e0bc4883238c10f56fdf)
++++ b/tests/test_wkb.py	(date 1615044817079)
+@@ -1,6 +1,11 @@
++import binascii
++
++import pytest
++
++from shapely import wkt
+ from shapely.wkb import dumps, loads
+ from shapely.geometry import Point
+-import binascii
++from shapely.geos import geos_version
+
+
+ def bin2hex(value):
+@@ -49,3 +54,20 @@
+     # replace geometry srid with another
+     result = dumps(geom, srid=27700)
+     assert bin2hex(result) == "0101000020346C0000333333333333F33F3333333333330B40"
++
++
++requires_geos_39 = pytest.mark.xfail(
++    geos_version < (3, 9, 0), reason="GEOS >= 3.9.0 is required", strict=True)
++
++
++@requires_geos_39
++def test_point_empty():
++    g = wkt.loads("POINT EMPTY")
++    assert g.wkb_hex == "0101000000000000000000F87F000000000000F87F"
++
++
++@requires_geos_39
++def test_point_z_empty():
++    g = wkt.loads("POINT Z EMPTY")
++    assert g.wkb_hex == \
++        "0101000080000000000000F87F000000000000F87F000000000000F87F"
+diff --git a/shapely/geos.py b/shapely/geos.py
+--- a/shapely/geos.py	(revision 56c0f97a80e75308cf62e0bc4883238c10f56fdf)
++++ b/shapely/geos.py	(date 1615044673942)
+@@ -84,7 +84,7 @@
+             'libgeos_c.so.1',
+             'libgeos_c.so',
+         ]
+-        _lgeos = load_dll('geos_c', fallbacks=alt_paths)
++        _lgeos = load_dll('libgeos_c', fallbacks=alt_paths)
+     # Necessary for environments with only libc.musl
+     c_alt_paths = [
+         'libc.musl-x86_64.so.1'

--- a/sci-libs/shapely/shapely-1.7.1-r1.ebuild
+++ b/sci-libs/shapely/shapely-1.7.1-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MY_PN="Shapely"
+MY_P="${MY_PN}-${PV}"
+
+PYTHON_COMPAT=( python3_{7..9} )
+
+inherit distutils-r1
+
+DESCRIPTION="Geometric objects, predicates, and operations"
+HOMEPAGE="https://pypi.org/project/Shapely/ https://github.com/Toblerity/Shapely"
+SRC_URI="https://github.com/Toblerity/Shapely/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+RDEPEND="
+	dev-python/numpy[${PYTHON_USEDEP}]
+	>=sci-libs/geos-3.9
+"
+
+BDEPEND="${RDEPEND}
+	dev-python/cython[${PYTHON_USEDEP}]
+"
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=( "${FILESDIR}/${P}-tests-support-geos-3.9.patch" )
+
+distutils_enable_tests pytest
+
+distutils_enable_sphinx docs dev-python/matplotlib
+
+python_test() {
+	distutils_install_for_testing
+	${EPYTHON} -m pytest tests || die "tests failed under ${EPYTHON}"
+}


### PR DESCRIPTION
Related Upsteam Issue: https://github.com/Toblerity/Shapely/issues/1079

Closes: https://bugs.gentoo.org/765745
Signed-off-by: Dennis Lamm <expeditioneer@gentoo.org>
Package-Manager: Portage-3.0.13, Repoman-3.0.2