### PR TITLE
app-emulation/wine-staging: support llvm-libunwind as unwinder

### DIFF
--- a/app-emulation/wine-staging/files/wine-staging-6.3-llvm-libunwind.patch
+++ b/app-emulation/wine-staging/files/wine-staging-6.3-llvm-libunwind.patch
@@ -1,0 +1,11 @@
+--- a/dlls/ntdll/unix/signal_x86_64.c
++++ b/dlls/ntdll/unix/signal_x86_64.c
+@@ -1390,7 +1390,7 @@ static NTSTATUS libunwind_virtual_unwind
+     unw_proc_info_t info;
+     int rc;
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(____LIBUNWIND_CONFIG_H__)
+     rc = unw_getcontext( &unw_context );
+     if (rc == UNW_ESUCCESS)
+         rc = unw_init_local( &cursor, &unw_context );

--- a/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.3-r1.ebuild
@@ -20,9 +20,9 @@ if [[ ${MY_PV} == "9999" ]] ; then
 else
 	MAJOR_V=$(ver_cut 1)
 	MINOR_V=$(ver_cut 2)
-    if [[ ${MINOR_V} != "0" ]] ; then
-        MINOR_V="x"
-    fi
+	if [[ ${MINOR_V} != "0" ]] ; then
+		MINOR_V="x"
+	fi
 	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.${MINOR_V}/${MY_P}.tar.xz"
 	KEYWORDS="-* ~amd64 ~x86"
 fi
@@ -115,7 +115,12 @@ COMMON_DEPEND="
 	truetype? ( >=media-libs/freetype-2.0.0[${MULTILIB_USEDEP}] )
 	udev? ( virtual/libudev:=[${MULTILIB_USEDEP}] )
 	udisks? ( sys-apps/dbus[${MULTILIB_USEDEP}] )
-	unwind? ( sys-libs/libunwind[${MULTILIB_USEDEP}] )
+	unwind? (
+		|| (
+			sys-libs/libunwind[${MULTILIB_USEDEP}]
+			sys-libs/llvm-libunwind[${MULTILIB_USEDEP}]
+		)
+	)
 	usb? ( virtual/libusb:1[${MULTILIB_USEDEP}]  )
 	v4l? ( media-libs/libv4l[${MULTILIB_USEDEP}] )
 	vaapi? ( x11-libs/libva[X,${MULTILIB_USEDEP}] )
@@ -173,6 +178,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
 	"${PATCHDIR}/patches/${MY_PN}-6.3-Fix-nine.patch"
+	"${FILESDIR}/${PN}-6.3-llvm-libunwind.patch"
 )
 PATCHES_BIN=()
 

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -19,9 +19,9 @@ if [[ ${MY_PV} == "9999" ]] ; then
 else
 	MAJOR_V=$(ver_cut 1)
 	MINOR_V=$(ver_cut 2)
-    if [[ ${MINOR_V} != "0" ]] ; then
-        MINOR_V="x"
-    fi
+	if [[ ${MINOR_V} != "0" ]] ; then
+		MINOR_V="x"
+	fi
 	SRC_URI="https://dl.winehq.org/wine/source/${MAJOR_V}.${MINOR_V}/${MY_P}.tar.xz"
 	KEYWORDS="-* ~amd64 ~x86"
 fi
@@ -114,7 +114,12 @@ COMMON_DEPEND="
 	truetype? ( >=media-libs/freetype-2.0.0[${MULTILIB_USEDEP}] )
 	udev? ( virtual/libudev:=[${MULTILIB_USEDEP}] )
 	udisks? ( sys-apps/dbus[${MULTILIB_USEDEP}] )
-	unwind? ( sys-libs/libunwind[${MULTILIB_USEDEP}] )
+	unwind? (
+		|| (
+			sys-libs/libunwind[${MULTILIB_USEDEP}]
+			sys-libs/llvm-libunwind[${MULTILIB_USEDEP}]
+		)
+	)
 	usb? ( virtual/libusb:1[${MULTILIB_USEDEP}]  )
 	v4l? ( media-libs/libv4l[${MULTILIB_USEDEP}] )
 	vaapi? ( x11-libs/libva[X,${MULTILIB_USEDEP}] )
@@ -171,6 +176,7 @@ PATCHES=(
 	"${PATCHDIR}/patches/${MY_PN}-4.7-multilib-portage.patch" #395615
 	"${PATCHDIR}/patches/${MY_PN}-2.0-multislot-apploader.patch" #310611
 	"${PATCHDIR}/patches/${MY_PN}-5.9-Revert-makedep-Install-also-generated-typelib-for-in.patch"
+	"${FILESDIR}/${PN}-6.3-llvm-libunwind.patch"
 )
 PATCHES_BIN=()
 


### PR DESCRIPTION
See: https://bugs.winehq.org/show_bug.cgi?id=49506

Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Theo Anderson <telans@posteo.de>