### PR TITLE
dev-lang/rust: support musl libc cross compilation target

### DIFF
--- a/dev-lang/rust/rust-1.50.0.ebuild
+++ b/dev-lang/rust/rust-1.50.0.ebuild
@@ -406,6 +406,11 @@ src_configure() {
 				llvm-config = "$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
 			_EOF_
 		fi
+		if [[ "${cross_toolchain}" == *"-musl" ]]; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				musl-root = "$(${cross_toolchain}-gcc -print-sysroot)/usr"
+			_EOF_
+		fi
 
 		# append cross target to "normal" target list
 		# example 'target = ["powerpc64le-unknown-linux-gnu"]'


### PR DESCRIPTION
Upon configuring portage to build rust with support for cross compilation by setting the environment listed below, the following failure (also listed below) occurs.

```shell
me@pc ~ $ cat /etc/portage/env/rust.conf 
I_KNOW_WHAT_I_AM_DOING_CROSS="yep!"
RUST_CROSS_TARGETS="X86:x86_64-unknown-linux-musl:x86_64-unknown-linux-musl"
```

```
running sanity check
thread 'main' panicked at 'when targeting MUSL either the rust.musl-root option or the target.$TARGET.musl-root option must be specified in config.toml', src/bootstrap/sanity.rs:188:25
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/e1884a8e3c3e813aada8254edfa120e85bf5ffca/library/std/src/panicking.rs:521:12
   1: bootstrap::sanity::check
             at ./src/bootstrap/sanity.rs:188:25
   2: bootstrap::Build::new
             at ./src/bootstrap/lib.rs:448:9
   3: bootstrap::main
             at ./src/bootstrap/bin/main.rs:30:5
   4: core::ops::function::FnOnce::call_once
             at /rustc/e1884a8e3c3e813aada8254edfa120e85bf5ffca/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Traceback (most recent call last):
  File "./x.py", line 11, in <module>
    bootstrap.main()
  File "/var/tmp/portage/dev-lang/rust-1.50.0/work/rustc-1.50.0-src/src/bootstrap/bootstrap.py", line 1094, in main
    bootstrap(help_triggered)
  File "/var/tmp/portage/dev-lang/rust-1.50.0/work/rustc-1.50.0-src/src/bootstrap/bootstrap.py", line 1080, in bootstrap
    run(args, env=env, verbose=build.verbose)
  File "/var/tmp/portage/dev-lang/rust-1.50.0/work/rustc-1.50.0-src/src/bootstrap/bootstrap.py", line 153, in run
    raise RuntimeError(err)
RuntimeError: failed to run: /var/tmp/portage/dev-lang/rust-1.50.0/work/rustc-1.50.0-src/build/bootstrap/debug/bootstrap dist -vv --config=/var/tmp/portage/dev-lang/rust-1.50.0/work/rustc-1.50.0-src/config.toml -j17
```

This pull request fixes this by checking if the toolchain target ends in `musl`, indicating a target triplet that uses musl's libc, and adding the correct `musl-root` property in accordance to where the cross compilation libraries are (this path obtained when using a `crossdev` setup)