### PR TITLE
net-analyzer/sbd: EAPI7 bump

### DIFF
--- a/net-analyzer/sbd/sbd-1.37-r2.ebuild
+++ b/net-analyzer/sbd/sbd-1.37-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Netcat-clone, designed to be portable and offer strong encryption"
+HOMEPAGE="http://tigerteam.se/dl/sbd/"
+SRC_URI="http://tigerteam.se/dl/sbd/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~ppc ~x86"
+
+src_prepare() {
+	default
+	sed -i \
+		-e '/ -o /{ s| $(UNIX_LDFLAGS) $(LDFLAGS)||g;s|$(CFLAGS)|& $(LDFLAGS)|g }' \
+		Makefile || die
+}
+
+src_compile() {
+	emake \
+		CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS}" \
+		LDFLAGS="${LDFLAGS}" \
+		unix
+}
+
+src_install() {
+	dobin sbd
+	dodoc CHANGES README
+}


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

simple EAPI7 bump for net-analyzer/sbd. I've created a new revision since it has stable keywords. However since the changes are very light it might be acceptable to bump EAPI 7 inplace here?

```diff
--- sbd-1.37-r1.ebuild  2017-03-19 10:57:13.822786244 +0100
+++ sbd-1.37-r2.ebuild  2021-03-07 10:06:57.616197238 +0100
@@ -1,7 +1,7 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit toolchain-funcs
 
@@ -9,11 +9,12 @@
 HOMEPAGE="http://tigerteam.se/dl/sbd/"
 SRC_URI="http://tigerteam.se/dl/sbd/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~hppa ~ppc x86"
+KEYWORDS="~amd64 ~hppa ~ppc ~x86"
 
 src_prepare() {
+       default
        sed -i \
                -e '/ -o /{ s| $(UNIX_LDFLAGS) $(LDFLAGS)||g;s|$(CFLAGS)|& $(LDFLAGS)|g }' \
                Makefile || die
```