### PR TITLE
mask net-analyzer/snortsam

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Michael Mair-Keimberger <mmk@levelnine.at> (2022-11-25)
+# Unmaintained, last release a decade ago, upstream declared it EOL
+# Removal in 30 days.
+net-analyzer/snortsam
+
 # John Helmert III <ajak@gentoo.org> (2022-11-24)
 # Binary package several releases behind the source-based package,
 # multiple vulnerabilities, unmaintained for several years. Removal in


### PR DESCRIPTION
Hi,

I was initially looking into `net-analyzer/snortsam` to update it's EAPI, however found out that it's latest release was a decade ago and is considered EOL from upstream. The ebuild also prints:
```
elog "To use snortsam with snort, you'll have to compile snort with USE=snortsam."
elog "Read the INSTALL file to configure snort for snortsam, and configure"
elog "snortsam for your particular firewall."
```
This isn't correct anymore, since there is no such flag in `net-analyzer/snort`. There are some patches upstream for `net-analyzer/snort` to enable that feature but again only for older versions of `net-analyzer/snort` (which are not in gentoo anymore).

<del>The second package which has a dependency on `net-analyzer/snortsam` is `app-admin/sagan`. 
First i was thinking to simply remove the dependency but ultimately decided to mask it as well for following reasons:
<del>* the latest release for `app-admin/sagan` is 2.0.1 from 2021 and we have 1.0.0_rc3 which is from 2015 (see https://github.com/quadrantsec/sagan)
<del>* the package is unmaintained and has multiple open bugs.
<del>* even if someone decides to update this package, `net-analyzer/snortsam` can be masked anyway as it's not used anymore by the latest sagan version.

<del>@thesamesam i'm cc'ing you as you made the EAPI bump for sagan. Maybe you have plans to update this package :)

thanks to @thesamesam `app-admin/sagan` is now up2date :)
I've updated my PR and only masking `net-analyzer/snortsam`
