### PR TITLE
dev-lang/rust: patchelf & prefixify in stage0, for gentoo prefix

### DIFF
--- a/dev-lang/rust/rust-1.46.0.ebuild
+++ b/dev-lang/rust/rust-1.46.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -97,6 +97,7 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	parallel-compiler? ( nightly )
 	wasm? ( llvm_targets_WebAssembly )
 	x86? ( cpu_flags_x86_sse2 )
+	prefix? ( system-bootstrap )
 "
 
 # we don't use cmake.eclass, but can get a warnin -l

--- a/dev-lang/rust/rust-1.46.0.ebuild
+++ b/dev-lang/rust/rust-1.46.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
+inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -49,10 +49,7 @@ IUSE="clippy cpu_flags_x86_sse2 debug doc libressl miri nightly parallel-compile
 # 2. Update the := to specify *max* version, e.g. < 11.
 # 3. Specify LLVM_MAX_SLOT, e.g. 10.
 LLVM_DEPEND="
-	|| (
-		sys-devel/llvm:10[${LLVM_TARGET_USEDEPS// /,}]
-		sys-devel/llvm:9[${LLVM_TARGET_USEDEPS// /,}]
-	)
+	sys-devel/llvm:10[${LLVM_TARGET_USEDEPS// /,}]
 	<sys-devel/llvm-11:=
 	wasm? ( sys-devel/lld )
 "
@@ -192,16 +189,6 @@ pkg_setup() {
 	fi
 }
 
-patchelf_stage0() {
-	local filetype=$(file -b $1)
-	if [[ ${filetype} == *ELF*interpreter* ]]; then
-		einfo "$1's interpreter changed"
-		patchelf $1 --set-interpreter $2 || die
-	elif [[ ${filetype} == *script* ]]; then
-		hprefixify $1
-	fi
-}
-
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -211,10 +198,26 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
-			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
-			for filename in $(find ${rust_stage0_root}/bin -type f);do
-				patchelf_stage0 ${filename} ${interpreter} \; || die
+			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
+			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's interpreter changed"
+					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
+				else
+					hprefixify $f
+				fi
+			done
+			eend $?
+
+			RPATH=${EPREFIX}/usr/$(get_libdir)
+			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's rpath changed"
+					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
+					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
+				fi
 			done
 			eend $?
 		fi

--- a/dev-lang/rust/rust-1.46.0.ebuild
+++ b/dev-lang/rust/rust-1.46.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -49,7 +49,10 @@ IUSE="clippy cpu_flags_x86_sse2 debug doc libressl miri nightly parallel-compile
 # 2. Update the := to specify *max* version, e.g. < 11.
 # 3. Specify LLVM_MAX_SLOT, e.g. 10.
 LLVM_DEPEND="
-	sys-devel/llvm:10[${LLVM_TARGET_USEDEPS// /,}]
+	|| (
+		sys-devel/llvm:10[${LLVM_TARGET_USEDEPS// /,}]
+		sys-devel/llvm:9[${LLVM_TARGET_USEDEPS// /,}]
+	)
 	<sys-devel/llvm-11:=
 	wasm? ( sys-devel/lld )
 "
@@ -58,7 +61,6 @@ LLVM_MAX_SLOT=10
 BOOTSTRAP_DEPEND="|| ( >=dev-lang/rust-1.$(($(ver_cut 2) - 1)) >=dev-lang/rust-bin-1.$(($(ver_cut 2) - 1)) )"
 
 BDEPEND="${PYTHON_DEPS}
-	prefix? ( !system-bootstrap? ( dev-util/patchelf ) )
 	app-eselect/eselect-rust
 	|| (
 		>=sys-devel/gcc-4.7
@@ -196,31 +198,6 @@ src_prepare() {
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--destdir="${rust_stage0_root}" --prefix=/ || die
-
-		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
-			done
-			eend $?
-		fi
 	fi
 
 	default

--- a/dev-lang/rust/rust-1.47.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.47.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -238,6 +238,16 @@ pkg_setup() {
 	fi
 }
 
+patchelf_stage0() {
+	local filetype=$(file -b $1)
+	if [[ ${filetype} == *ELF*interpreter* ]]; then
+		einfo "$1's interpreter changed"
+		patchelf $1 --set-interpreter $2 || die
+	elif [[ ${filetype} == *script* ]]; then
+		hprefixify $1
+	fi
+}
+
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -247,26 +257,10 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
+			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
+			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
+			for filename in $(find ${rust_stage0_root}/bin -type f);do
+				patchelf_stage0 ${filename} ${interpreter} \; || die
 			done
 			eend $?
 		fi

--- a/dev-lang/rust/rust-1.47.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.47.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -73,6 +73,7 @@ BOOTSTRAP_DEPEND="||
 "
 
 BDEPEND="${PYTHON_DEPS}
+	prefix? ( !system-bootstrap? ( dev-util/patchelf ) )
 	app-eselect/eselect-rust
 	|| (
 		>=sys-devel/gcc-4.7
@@ -244,6 +245,31 @@ src_prepare() {
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--destdir="${rust_stage0_root}" --prefix=/ || die
+
+		if use prefix; then
+			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
+			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's interpreter changed"
+					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
+				else
+					hprefixify $f
+				fi
+			done
+			eend $?
+
+			RPATH=${EPREFIX}/usr/$(get_libdir)
+			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's rpath changed"
+					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
+					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
+				fi
+			done
+			eend $?
+		fi
 	fi
 
 	default

--- a/dev-lang/rust/rust-1.47.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.47.0-r2.ebuild
@@ -110,6 +110,7 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
 	x86? ( cpu_flags_x86_sse2 )
+	prefix? ( system-bootstrap )
 "
 
 # we don't use cmake.eclass, but can get a warnings

--- a/dev-lang/rust/rust-1.47.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.47.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
+inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -238,16 +238,6 @@ pkg_setup() {
 	fi
 }
 
-patchelf_stage0() {
-	local filetype=$(file -b $1)
-	if [[ ${filetype} == *ELF*interpreter* ]]; then
-		einfo "$1's interpreter changed"
-		patchelf $1 --set-interpreter $2 || die
-	elif [[ ${filetype} == *script* ]]; then
-		hprefixify $1
-	fi
-}
-
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -257,10 +247,26 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
-			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
-			for filename in $(find ${rust_stage0_root}/bin -type f);do
-				patchelf_stage0 ${filename} ${interpreter} \; || die
+			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
+			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's interpreter changed"
+					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
+				else
+					hprefixify $f
+				fi
+			done
+			eend $?
+
+			RPATH=${EPREFIX}/usr/$(get_libdir)
+			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's rpath changed"
+					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
+					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
+				fi
 			done
 			eend $?
 		fi

--- a/dev-lang/rust/rust-1.47.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.47.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -73,7 +73,6 @@ BOOTSTRAP_DEPEND="||
 "
 
 BDEPEND="${PYTHON_DEPS}
-	prefix? ( !system-bootstrap? ( dev-util/patchelf ) )
 	app-eselect/eselect-rust
 	|| (
 		>=sys-devel/gcc-4.7
@@ -245,31 +244,6 @@ src_prepare() {
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--destdir="${rust_stage0_root}" --prefix=/ || die
-
-		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
-			done
-			eend $?
-		fi
 	fi
 
 	default

--- a/dev-lang/rust/rust-1.48.0.ebuild
+++ b/dev-lang/rust/rust-1.48.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -209,6 +209,16 @@ pkg_setup() {
 	fi
 }
 
+patchelf_stage0() {
+	local filetype=$(file -b $1)
+	if [[ ${filetype} == *ELF*interpreter* ]]; then
+		einfo "$1's interpreter changed"
+		patchelf $1 --set-interpreter $2 || die
+	elif [[ ${filetype} == *script* ]]; then
+		hprefixify $1
+	fi
+}
+
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -218,26 +228,10 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
+			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
+			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
+			for filename in $(find ${rust_stage0_root}/bin -type f);do
+				patchelf_stage0 ${filename} ${interpreter} \; || die
 			done
 			eend $?
 		fi

--- a/dev-lang/rust/rust-1.48.0.ebuild
+++ b/dev-lang/rust/rust-1.48.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
+inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -209,16 +209,6 @@ pkg_setup() {
 	fi
 }
 
-patchelf_stage0() {
-	local filetype=$(file -b $1)
-	if [[ ${filetype} == *ELF*interpreter* ]]; then
-		einfo "$1's interpreter changed"
-		patchelf $1 --set-interpreter $2 || die
-	elif [[ ${filetype} == *script* ]]; then
-		hprefixify $1
-	fi
-}
-
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -228,10 +218,26 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
-			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
-			for filename in $(find ${rust_stage0_root}/bin -type f);do
-				patchelf_stage0 ${filename} ${interpreter} \; || die
+			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
+			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's interpreter changed"
+					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
+				else
+					hprefixify $f
+				fi
+			done
+			eend $?
+
+			RPATH=${EPREFIX}/usr/$(get_libdir)
+			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's rpath changed"
+					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
+					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
+				fi
 			done
 			eend $?
 		fi

--- a/dev-lang/rust/rust-1.48.0.ebuild
+++ b/dev-lang/rust/rust-1.48.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -73,7 +73,6 @@ BOOTSTRAP_DEPEND="||
 "
 
 BDEPEND="${PYTHON_DEPS}
-	prefix? ( !system-bootstrap? ( dev-util/patchelf ) )
 	app-eselect/eselect-rust
 	|| (
 		>=sys-devel/gcc-4.7
@@ -216,31 +215,6 @@ src_prepare() {
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--destdir="${rust_stage0_root}" --prefix=/ || die
-
-		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
-			done
-			eend $?
-		fi
 	fi
 
 	default

--- a/dev-lang/rust/rust-1.48.0.ebuild
+++ b/dev-lang/rust/rust-1.48.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -110,6 +110,7 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
 	x86? ( cpu_flags_x86_sse2 )
+	prefix? ( system-bootstrap )
 "
 
 # we don't use cmake.eclass, but can get a warnings

--- a/dev-lang/rust/rust-1.49.0.ebuild
+++ b/dev-lang/rust/rust-1.49.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -210,6 +210,16 @@ pkg_setup() {
 	fi
 }
 
+patchelf_stage0() {
+	local filetype=$(file -b $1)
+	if [[ ${filetype} == *ELF*interpreter* ]]; then
+		einfo "$1's interpreter changed"
+		patchelf $1 --set-interpreter $2 || die
+	elif [[ ${filetype} == *script* ]]; then
+		hprefixify $1
+	fi
+}
+
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -219,26 +229,10 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
+			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
+			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
+			for filename in $(find ${rust_stage0_root}/bin -type f);do
+				patchelf_stage0 ${filename} ${interpreter} \; || die
 			done
 			eend $?
 		fi

--- a/dev-lang/rust/rust-1.49.0.ebuild
+++ b/dev-lang/rust/rust-1.49.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -73,6 +73,7 @@ BOOTSTRAP_DEPEND="||
 "
 
 BDEPEND="${PYTHON_DEPS}
+	prefix? ( !system-bootstrap? ( dev-util/patchelf ) )
 	app-eselect/eselect-rust
 	|| (
 		>=sys-devel/gcc-4.7
@@ -216,6 +217,31 @@ src_prepare() {
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--destdir="${rust_stage0_root}" --prefix=/ || die
+
+		if use prefix; then
+			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
+			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's interpreter changed"
+					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
+				else
+					hprefixify $f
+				fi
+			done
+			eend $?
+
+			RPATH=${EPREFIX}/usr/$(get_libdir)
+			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's rpath changed"
+					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
+					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
+				fi
+			done
+			eend $?
+		fi
 	fi
 
 	default

--- a/dev-lang/rust/rust-1.49.0.ebuild
+++ b/dev-lang/rust/rust-1.49.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -73,7 +73,6 @@ BOOTSTRAP_DEPEND="||
 "
 
 BDEPEND="${PYTHON_DEPS}
-	prefix? ( !system-bootstrap? ( dev-util/patchelf ) )
 	app-eselect/eselect-rust
 	|| (
 		>=sys-devel/gcc-4.7
@@ -217,31 +216,6 @@ src_prepare() {
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--destdir="${rust_stage0_root}" --prefix=/ || die
-
-		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
-			done
-			eend $?
-		fi
 	fi
 
 	default

--- a/dev-lang/rust/rust-1.49.0.ebuild
+++ b/dev-lang/rust/rust-1.49.0.ebuild
@@ -110,6 +110,7 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
 	x86? ( cpu_flags_x86_sse2 )
+	prefix? ( system-bootstrap )
 "
 
 # we don't use cmake.eclass, but can get a warnings

--- a/dev-lang/rust/rust-1.49.0.ebuild
+++ b/dev-lang/rust/rust-1.49.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
+inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -210,16 +210,6 @@ pkg_setup() {
 	fi
 }
 
-patchelf_stage0() {
-	local filetype=$(file -b $1)
-	if [[ ${filetype} == *ELF*interpreter* ]]; then
-		einfo "$1's interpreter changed"
-		patchelf $1 --set-interpreter $2 || die
-	elif [[ ${filetype} == *script* ]]; then
-		hprefixify $1
-	fi
-}
-
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -229,10 +219,26 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
-			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
-			for filename in $(find ${rust_stage0_root}/bin -type f);do
-				patchelf_stage0 ${filename} ${interpreter} \; || die
+			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
+			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's interpreter changed"
+					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
+				else
+					hprefixify $f
+				fi
+			done
+			eend $?
+
+			RPATH=${EPREFIX}/usr/$(get_libdir)
+			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's rpath changed"
+					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
+					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
+				fi
 			done
 			eend $?
 		fi

--- a/dev-lang/rust/rust-1.50.0.ebuild
+++ b/dev-lang/rust/rust-1.50.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -210,6 +210,16 @@ pkg_setup() {
 	fi
 }
 
+patchelf_stage0() {
+	local filetype=$(file -b $1)
+	if [[ ${filetype} == *ELF*interpreter* ]]; then
+		einfo "$1's interpreter changed"
+		patchelf $1 --set-interpreter $2 || die
+	elif [[ ${filetype} == *script* ]]; then
+		hprefixify $1
+	fi
+}
+
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -219,26 +229,10 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
+			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
+			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
+			for filename in $(find ${rust_stage0_root}/bin -type f);do
+				patchelf_stage0 ${filename} ${interpreter} \; || die
 			done
 			eend $?
 		fi

--- a/dev-lang/rust/rust-1.50.0.ebuild
+++ b/dev-lang/rust/rust-1.50.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -73,6 +73,7 @@ BOOTSTRAP_DEPEND="||
 "
 
 BDEPEND="${PYTHON_DEPS}
+	prefix? ( !system-bootstrap? ( dev-util/patchelf ) )
 	app-eselect/eselect-rust
 	|| (
 		>=sys-devel/gcc-4.7
@@ -216,6 +217,31 @@ src_prepare() {
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--destdir="${rust_stage0_root}" --prefix=/ || die
+
+		if use prefix; then
+			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
+			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's interpreter changed"
+					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
+				else
+					hprefixify $f
+				fi
+			done
+			eend $?
+
+			RPATH=${EPREFIX}/usr/$(get_libdir)
+			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's rpath changed"
+					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
+					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
+				fi
+			done
+			eend $?
+		fi
 	fi
 
 	default

--- a/dev-lang/rust/rust-1.50.0.ebuild
+++ b/dev-lang/rust/rust-1.50.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -73,7 +73,6 @@ BOOTSTRAP_DEPEND="||
 "
 
 BDEPEND="${PYTHON_DEPS}
-	prefix? ( !system-bootstrap? ( dev-util/patchelf ) )
 	app-eselect/eselect-rust
 	|| (
 		>=sys-devel/gcc-4.7
@@ -217,31 +216,6 @@ src_prepare() {
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--destdir="${rust_stage0_root}" --prefix=/ || die
-
-		if use prefix; then
-			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
-			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's interpreter changed"
-					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
-				else
-					hprefixify $f
-				fi
-			done
-			eend $?
-
-			RPATH=${EPREFIX}/usr/$(get_libdir)
-			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
-			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
-				if file $f | grep -q ELF; then
-					einfo "$f's rpath changed"
-					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
-					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
-				fi
-			done
-			eend $?
-		fi
 	fi
 
 	default

--- a/dev-lang/rust/rust-1.50.0.ebuild
+++ b/dev-lang/rust/rust-1.50.0.ebuild
@@ -110,6 +110,7 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
 	x86? ( cpu_flags_x86_sse2 )
+	prefix? ( system-bootstrap )
 "
 
 # we don't use cmake.eclass, but can get a warnings

--- a/dev-lang/rust/rust-1.50.0.ebuild
+++ b/dev-lang/rust/rust-1.50.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build prefix python-any-r1 rust-toolchain toolchain-funcs
+inherit prefix bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing multilib-build python-any-r1 rust-toolchain toolchain-funcs
 
 if [[ ${PV} = *beta* ]]; then
 	betaver=${PV//*beta}
@@ -210,16 +210,6 @@ pkg_setup() {
 	fi
 }
 
-patchelf_stage0() {
-	local filetype=$(file -b $1)
-	if [[ ${filetype} == *ELF*interpreter* ]]; then
-		einfo "$1's interpreter changed"
-		patchelf $1 --set-interpreter $2 || die
-	elif [[ ${filetype} == *script* ]]; then
-		hprefixify $1
-	fi
-}
-
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
@@ -229,10 +219,26 @@ src_prepare() {
 			--destdir="${rust_stage0_root}" --prefix=/ || die
 
 		if use prefix; then
-			local interpreter=$(patchelf --print-interpreter ${EPREFIX}/bin/bash)
-			ebegin "Changing interpreter to ${interpreter} for Gentoo prefix"
-			for filename in $(find ${rust_stage0_root}/bin -type f);do
-				patchelf_stage0 ${filename} ${interpreter} \; || die
+			interpreter=`ldconfig -p | grep ld-linux | awk '{print $NF}' || die "Cannot find your ld.so, why?"`
+			ebegin "Changing interpreter to $interpreter for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/bin/*  || die "Cannot find binary of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's interpreter changed"
+					patchelf $f --set-interpreter $interpreter || die "Cannot patchelf, why?"
+				else
+					hprefixify $f
+				fi
+			done
+			eend $?
+
+			RPATH=${EPREFIX}/usr/$(get_libdir)
+			ebegin "Changing rparh to ${RPATH} for Gentoo prefix"
+			for f in `ls -Ud ${rust_stage0_root}/lib/*  || die "Cannot find lib of rust_stage0, why?"`; do
+				if file $f | grep -q ELF; then
+					einfo "$f's rpath changed"
+					patchelf $f --remove-rpath || die "Cannot patchelf, why?"
+					patchelf $f --set-rpath ${RPATH} || die "Cannot patchelf, why?"
+				fi
 			done
 			eend $?
 		fi

--- a/profiles/features/prefix/package.use
+++ b/profiles/features/prefix/package.use
@@ -4,3 +4,7 @@ sys-apps/portage -rsync-verify
 # Yiyang Wu <xgreenlandforwyy@gmail.com> (2021-03-03)
 # bazel should link libstdc++ statically in prefix to avoid finding host's libstdc++ when building other packages
 dev-util/bazel static-libs
+
+# Yiyang Wu <xgreenlandforwyy@gmail.com> (2021-03-03)
+# rust should use system-boostrap because interpreter of binaries in dev-lang/rust-bin is changed to the correct one, while the downloaded rust binary is not
+dev-lang/rust system-bootstrap


### PR DESCRIPTION
Also delete the dependency of llvm-9 for rust-1.46, to resolve the
dependency issue discovered by repoman

Bug: https://bugs.gentoo.org/739574
Closes: https://bugs.gentoo.org/682370
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: YiyangWu <xgreenlandforwyy@gmail.com>