### PR TITLE
net-p2p/eiskaltdcpp: Strip ie locale when USE=gtk

### DIFF
--- a/net-p2p/eiskaltdcpp/eiskaltdcpp-2.4.2.ebuild
+++ b/net-p2p/eiskaltdcpp/eiskaltdcpp-2.4.2.ebuild
@@ -104,6 +104,7 @@ src_prepare() {
 }
 
 src_configure() {
+	use gtk && strip-linguas -i eiskaltdcpp-gtk/po/
 	local mycmakeargs=(
 		-DLIB_INSTALL_DIR="$(get_libdir)"
 		-Dlinguas="$(l10n_get_locales)"


### PR DESCRIPTION
Eiskaltdc++ is planning to drop the GTK+ based GUI in the next version and has asked translators not to consider it when creating new translations.

As a result of this, the ie translation does not includes the locale for the GTK library which results in an error when the ebuild tries to compile it.

To address this, we filter the ie locale from the LINGUAS variable whenever the gtk USE flag is set, to address the issue and still allow using GTK if needed.