### PR TITLE
app-metrics/collectd: support using tmpfs as datadir

### DIFF
--- a/app-metrics/collectd/files/collectd.confd-r2
+++ b/app-metrics/collectd/files/collectd.confd-r2
@@ -47,3 +47,11 @@
 # * Do not specify another PIDFILE but use the variable above to change the location
 # * Do not specify another CONFIGFILE but use the variable above to change the location
 #COLLECTD_OPTS=""
+
+# If using a tmpfs mount as the data directory to reduce disk IO or SSD wear,
+# you can set these options to save and restore RRD files to a tar archive
+# when stopping and starting collectd. The tar archive is compressed
+# according to its file suffix. You can setup a cron job to periodically
+# save by running "/etc/init.d/collectd sync".
+#COLLECTD_ARCHIVE="/var/lib/collectd/rrd.tar.zst"
+#COLLECTD_DATADIR="/var/lib/collectd/rrd"

--- a/app-metrics/collectd/files/collectd.initd-r2
+++ b/app-metrics/collectd/files/collectd.initd-r2
@@ -20,7 +20,9 @@ pidfile="${COLLECTD_PIDFILE}"
 retry="${COLLECTD_TERMTIMEOUT}"
 
 extra_commands="configtest"
+extra_started_commands="sync"
 description_configtest="Run collectd's internal config check."
+description_sync="Save collectd's RRD data to an archive."
 
 required_files="\"${COLLECTD_CONFIGFILE}\""
 
@@ -57,14 +59,38 @@ configtest() {
 	eend $?
 }
 
+sync() {
+	ebegin "Syncing ${SVCNAME} data"
+	if [ -n "${COLLECTD_ARCHIVE}" ] && [ -d "${COLLECTD_DATADIR}" ]; then
+		if [ "$(ls -A ${COLLECTD_DATADIR})" ]; then
+			tar -acf ${COLLECTD_ARCHIVE} -C ${COLLECTD_DATADIR} .
+		fi
+	fi
+	eend $?
+}
+
 start_pre() {
 	if [ "${RC_CMD}" != "restart" ]; then
 		configtest || return 1
+	fi
+
+	if [ -f "${COLLECTD_ARCHIVE}" ] && [ -d "${COLLECTD_DATADIR}" ]; then
+		if [ -z "$(ls -A ${COLLECTD_DATADIR})" ]; then
+			tar -axf ${COLLECTD_ARCHIVE} -C ${COLLECTD_DATADIR} .
+		fi
 	fi
 }
 
 stop_pre() {
 	if [ "${RC_CMD}" = "restart" ]; then
 		configtest || return 1
+	fi
+}
+
+stop_post() {
+	if [ -n "${COLLECTD_ARCHIVE}" ] && [ -d "${COLLECTD_DATADIR}" ]; then
+		if [ "$(ls -A ${COLLECTD_DATADIR})" ]; then
+			tar -acf ${COLLECTD_ARCHIVE} -C ${COLLECTD_DATADIR} .
+		fi
 	fi
 }


### PR DESCRIPTION
To reduce disk IO or SSD wear, the collectd data dir can now optionally be moved to a tmpfs mount which will be synced to a
tar archive on start and stop (or manual sync via cron).

Requires adding a fstab entry such as the following (check size required), creating the directory and then mounting;

`tmpfs /var/lib/collectd/rrd tmpfs size=128M,nosuid,nodev,noexec 0 0`

Set the DataDir in /etc/collectd.conf to match;

```
<Plugin rrdtool>
        DataDir "/var/lib/collectd/rrd"
</Plugin>
```

Configure the COLLECTD_ARCHIVE and COLLECTD_DATADIR options in /etc/conf.d/collectd and then, for first time only, manually move any existing datadir entries into the tmpfs mount.

Notes on pull request;
1. My motivation here is that RRD files are particularly bad for SSD write amplification and wear while for spinning rust it's disk IO even if using rrdcached which then also delays data for monitoring.
2. The example commented entry for the rrdtool plugin in /etc/collectd.conf is already set to /var/lib/collectd/rrd with current  configuration so essentially keep as. Default uses BaseDir /var/lib/collectd as DataDir if not set.
3. I used zstd in example COLLECTD_ARCHIVE as it compresses my datadir from 73M to 9M in less than a second on a Kabini CPU.
4. The init script checks for valid COLLECTD_ARCHIVE and COLLECTD_DATADIR options. On stop/sync if there are no files in datadir then does not overwrite with an empty tar. On start if there are files in datadir then leaves datadir alone (i.e. stopped and restarted on a running system).