### PR TITLE
net-misc/unison: export VARTEXFONTS

### DIFF
--- a/net-misc/unison/unison-2.51.3_p20201127.ebuild
+++ b/net-misc/unison/unison-2.51.3_p20201127.ebuild
@@ -58,7 +58,7 @@ src_compile() {
 	use ocamlopt || myconf="$myconf NATIVE=false"
 
 	if use doc; then
-		emake $myconf CFLAGS="" HEVEA=false docs
+		VARTEXFONTS="${T}/fonts" emake $myconf CFLAGS="" HEVEA=false docs
 	fi
 
 	# Discard cflags as it will try to pass them to ocamlc...

--- a/net-misc/unison/unison-2.51.4_rc1.ebuild
+++ b/net-misc/unison/unison-2.51.4_rc1.ebuild
@@ -55,7 +55,7 @@ src_compile() {
 	use ocamlopt || myconf="$myconf NATIVE=false"
 
 	if use doc; then
-		emake $myconf CFLAGS="" HEVEA=false docs
+		VARTEXFONTS="${T}/fonts" emake $myconf CFLAGS="" HEVEA=false docs
 	fi
 
 	# Discard cflags as it will try to pass them to ocamlc...


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/773487

Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>