### PR TITLE
dev-lang/ocaml: fixing patching, remove unused eutils eclass

### DIFF
--- a/dev-lang/ocaml/ocaml-4.05.0-r3.ebuild
+++ b/dev-lang/ocaml/ocaml-4.05.0-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit flag-o-matic eutils multilib toolchain-funcs
+inherit flag-o-matic multilib toolchain-funcs
 
 PATCHLEVEL="9"
 MY_P="${P/_/-}"
@@ -49,9 +49,8 @@ pkg_setup() {
 }
 
 src_prepare() {
-	EPATCH_SUFFIX="patch" epatch "${WORKDIR}/patches"
+	EPATCH_SUFFIX="patch" eapply "${WORKDIR}/patches"
 	default
-
 }
 
 src_configure() {


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Closes: https://bugs.gentoo.org/774867

`epatch` doesn't work in EAPI7 and the eclass is banned, which is why we get following error: 
```
/var/tmp/portage/dev-lang/ocaml-4.05.0-r3/temp/environment: line 1639: epatch: command not found
```
I've updated the ebuild using `eapply` and removed the unused `eutils` eclass.