### PR TITLE
mail-mta/courier: fix patching, remove unused eclass

### DIFF
--- a/mail-mta/courier/courier-1.0.13.ebuild
+++ b/mail-mta/courier/courier-1.0.13.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit eutils flag-o-matic multilib
+
+inherit flag-o-matic multilib
 
 DESCRIPTION="An MTA designed specifically for maildirs"
 HOMEPAGE="https://www.courier-mta.org/"
@@ -65,7 +66,7 @@ PDEPEND="pam? ( net-mail/mailbase )
 	crypt? ( >=app-crypt/gnupg-1.0.4 )"
 
 src_prepare() {
-	use norewrite && epatch "${FILESDIR}/norewrite.patch"
+	use norewrite && eapply "${FILESDIR}/norewrite.patch"
 	default
 }
 

--- a/mail-mta/courier/courier-1.0.14.ebuild
+++ b/mail-mta/courier/courier-1.0.14.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit eutils flag-o-matic multilib
+
+inherit flag-o-matic multilib
 
 DESCRIPTION="An MTA designed specifically for maildirs"
 HOMEPAGE="https://www.courier-mta.org/"
@@ -65,7 +66,7 @@ PDEPEND="pam? ( net-mail/mailbase )
 	crypt? ( >=app-crypt/gnupg-1.0.4 )"
 
 src_prepare() {
-	use norewrite && epatch "${FILESDIR}/norewrite.patch"
+	use norewrite && eapply "${FILESDIR}/norewrite.patch"
 	default
 }
 

--- a/mail-mta/courier/courier-1.0.17.ebuild
+++ b/mail-mta/courier/courier-1.0.17.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit eutils flag-o-matic multilib
+
+inherit flag-o-matic multilib
 
 DESCRIPTION="An MTA designed specifically for maildirs"
 HOMEPAGE="https://www.courier-mta.org/"
@@ -65,7 +66,7 @@ PDEPEND="pam? ( net-mail/mailbase )
 	crypt? ( >=app-crypt/gnupg-1.0.4 )"
 
 src_prepare() {
-	use norewrite && epatch "${FILESDIR}/norewrite.patch"
+	use norewrite && eapply "${FILESDIR}/norewrite.patch"
 	default
 }
 

--- a/mail-mta/courier/courier-1.0.5.ebuild
+++ b/mail-mta/courier/courier-1.0.5.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit eutils flag-o-matic multilib
+
+inherit flag-o-matic multilib
 
 DESCRIPTION="An MTA designed specifically for maildirs"
 HOMEPAGE="http://www.courier-mta.org/"
@@ -65,7 +66,7 @@ PDEPEND="pam? ( net-mail/mailbase )
 	crypt? ( >=app-crypt/gnupg-1.0.4 )"
 
 src_prepare() {
-	use norewrite && epatch "${FILESDIR}/norewrite.patch"
+	use norewrite && eapply "${FILESDIR}/norewrite.patch"
 	default
 }
 

--- a/mail-mta/courier/files/norewrite.patch
+++ b/mail-mta/courier/files/norewrite.patch
@@ -1,5 +1,5 @@
---- courier/module.esmtp/esmtp.c.orig	2004-02-03 01:08:15.679486558 -0700
-+++ courier/module.esmtp/esmtp.c	2004-02-03 01:07:41.262697092 -0700
+--- a/courier/module.esmtp/esmtp.c	2004-02-03 01:08:15.679486558 -0700
++++ b/courier/module.esmtp/esmtp.c	2004-02-03 01:07:41.262697092 -0700
 @@ -255,6 +255,10 @@ const char *me;
  struct rfc822t	*tp;
  struct rfc822token at;


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Closes: https://bugs.gentoo.org/774870

`epatch` doesn't work in EAPI7 and the eclass is banned, which is why we get following error:
```
var/tmp/portage/mail-mta/courier-1.0.13/temp/environment: line 1820: epatch: command not found
```

I've updated all ebuilds using `eapply` and removed the unused `eutils` eclass. Also had to update the patch itself.