### PR TITLE
sys-cluster/lustre: fix patching, remove unused eclass

### DIFF
--- a/sys-cluster/lustre/lustre-2.13.0-r1.ebuild
+++ b/sys-cluster/lustre/lustre-2.13.0-r1.ebuild
@@ -21,7 +21,7 @@ fi
 SUPPORTED_KV_MAJOR=4
 SUPPORTED_KV_MINOR=19
 
-inherit ${scm} autotools linux-info linux-mod toolchain-funcs udev flag-o-matic
+inherit ${scm} autotools linux-info linux-mod toolchain-funcs flag-o-matic
 
 DESCRIPTION="Lustre is a parallel distributed file system"
 HOMEPAGE="http://wiki.whamcloud.com/"
@@ -69,7 +69,7 @@ pkg_setup() {
 
 src_prepare() {
 	if [ ${#PATCHES[0]} -ne 0 ]; then
-		epatch ${PATCHES[@]}
+		eapply ${PATCHES[@]}
 	fi
 
 	eapply_user


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Closes: https://bugs.gentoo.org/705996
Bug: https://bugs.gentoo.org/728154

Another ebuild which tried to use `epatch` in EAPI7. I've fixed it and also removed a unused eclass (`udev`). I saw that there was already a bug open which should be closed with this. 
There is also another bug (#728154) which is about compilation failure. Since the patch used here (`lustre-2.13.0-gcc9.patch`) obviously fix some gcc issues, this bug might be closed too? However i've just add it as a reference.