### PR TITLE
sys-apps/linux-misc-apps: use eapply, remove unused elcass

### DIFF
--- a/sys-apps/linux-misc-apps/linux-misc-apps-5.8.ebuild
+++ b/sys-apps/linux-misc-apps/linux-misc-apps-5.8.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit eutils toolchain-funcs linux-info autotools flag-o-matic
+inherit toolchain-funcs linux-info autotools flag-o-matic
 
 DESCRIPTION="Misc tools bundled with kernel sources"
 HOMEPAGE="https://kernel.org/"
@@ -108,7 +108,7 @@ src_unpack() {
 
 src_prepare() {
 	if [[ -n ${LINUX_PATCH} ]]; then
-		epatch "${DISTDIR}"/${LINUX_PATCH}
+		eapply "${DISTDIR}"/${LINUX_PATCH}
 	fi
 
 	pushd tools/usb/usbip/ >/dev/null &&


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

This package doesn't have any patches right now, but using `epatch` in EAPI7 is still wrong, so let's fix it. Also removes the unused `eutils` eclass.