### PR TITLE
sys-libs/glibc: remove dependency on virtual/tmpfiles

### DIFF
--- a/sys-libs/glibc/glibc-2.19-r2.ebuild
+++ b/sys-libs/glibc/glibc-2.19-r2.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=6
 
+TMPFILES_OPTIONAL=1
+
 inherit prefix eutils toolchain-funcs flag-o-matic gnuconfig \
 	multilib systemd multiprocessing tmpfiles
 

--- a/sys-libs/glibc/glibc-2.30-r9.ebuild
+++ b/sys-libs/glibc/glibc-2.30-r9.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8} )
+TMPFILES_OPTIONAL=1
 
 inherit python-any-r1 prefix eutils toolchain-funcs flag-o-matic gnuconfig \
 	multilib systemd multiprocessing tmpfiles

--- a/sys-libs/glibc/glibc-2.31-r7.ebuild
+++ b/sys-libs/glibc/glibc-2.31-r7.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
+TMPFILES_OPTIONAL=1
 
 inherit python-any-r1 prefix eutils toolchain-funcs flag-o-matic gnuconfig \
 	multilib systemd multiprocessing tmpfiles

--- a/sys-libs/glibc/glibc-2.32-r6.ebuild
+++ b/sys-libs/glibc/glibc-2.32-r6.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
+TMPFILES_OPTIONAL=1
 
 inherit python-any-r1 prefix eutils toolchain-funcs flag-o-matic gnuconfig \
 	multilib systemd multiprocessing tmpfiles

--- a/sys-libs/glibc/glibc-2.32-r7.ebuild
+++ b/sys-libs/glibc/glibc-2.32-r7.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
+TMPFILES_OPTIONAL=1
 
 inherit python-any-r1 prefix eutils toolchain-funcs flag-o-matic gnuconfig \
 	multilib systemd multiprocessing tmpfiles

--- a/sys-libs/glibc/glibc-2.32-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.32-r8.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
+TMPFILES_OPTIONAL=1
 
 inherit python-any-r1 prefix eutils toolchain-funcs flag-o-matic gnuconfig \
 	multilib systemd multiprocessing tmpfiles

--- a/sys-libs/glibc/glibc-2.33.ebuild
+++ b/sys-libs/glibc/glibc-2.33.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
+TMPFILES_OPTIONAL=1
 
 inherit python-any-r1 prefix eutils toolchain-funcs flag-o-matic gnuconfig \
 	multilib systemd multiprocessing tmpfiles

--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
+TMPFILES_OPTIONAL=1
 
 inherit python-any-r1 prefix eutils toolchain-funcs flag-o-matic gnuconfig \
 	multilib systemd multiprocessing tmpfiles


### PR DESCRIPTION
Specify TMPFILES_OPTIONAL=1 to to avoid circular dependency

Closes: https://bugs.gentoo.org/774855
Signed-off-by: Theo Anderson <telans@posteo.de>