### PR TITLE
net-analyzer/zabbix: fix eclass usage

### DIFF
--- a/net-analyzer/zabbix/zabbix-3.0.31-r2.ebuild
+++ b/net-analyzer/zabbix/zabbix-3.0.31-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles user-info
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
 HOMEPAGE="https://www.zabbix.com/"

--- a/net-analyzer/zabbix/zabbix-4.0.28.ebuild
+++ b/net-analyzer/zabbix/zabbix-4.0.28.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles user-info
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
 HOMEPAGE="https://www.zabbix.com/"

--- a/net-analyzer/zabbix/zabbix-4.0.29.ebuild
+++ b/net-analyzer/zabbix/zabbix-4.0.29.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles user-info
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
 HOMEPAGE="https://www.zabbix.com/"

--- a/net-analyzer/zabbix/zabbix-5.0.8.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.0.8.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles user-info
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
 HOMEPAGE="https://www.zabbix.com/"

--- a/net-analyzer/zabbix/zabbix-5.0.9-r1.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.0.9-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs go-module
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs go-module user-info
 EGO_SUM=(
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 h1:+tu3HOoMXB7RXEINRVIpxJCT+KdYiI7LAEAUrOw3dIU="
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69/go.mod h1:L1AbZdiDllfyYH5l5OkAaZtk7VkWe89bPJFmnDBNHxg="

--- a/net-analyzer/zabbix/zabbix-5.0.9.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.0.9.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles user-info
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
 HOMEPAGE="https://www.zabbix.com/"

--- a/net-analyzer/zabbix/zabbix-5.2.4.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.2.4.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles user-info
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
 HOMEPAGE="https://www.zabbix.com/"

--- a/net-analyzer/zabbix/zabbix-5.2.5-r1.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.2.5-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs go-module
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs go-module user-info
 EGO_SUM=(
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 h1:+tu3HOoMXB7RXEINRVIpxJCT+KdYiI7LAEAUrOw3dIU="
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69/go.mod h1:L1AbZdiDllfyYH5l5OkAaZtk7VkWe89bPJFmnDBNHxg="

--- a/net-analyzer/zabbix/zabbix-5.2.5.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.2.5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit flag-o-matic webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles
+inherit webapp java-pkg-opt-2 systemd toolchain-funcs tmpfiles user-info
 
 DESCRIPTION="ZABBIX is software for monitoring of your applications, network and servers"
 HOMEPAGE="https://www.zabbix.com/"


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Closes: https://bugs.gentoo.org/775032

As mentioned in the bug the ebuilds have following code:

```
 zabbix_homedir=$(egethome zabbix)
 if [ -n "${zabbix_homedir}" ] && \
    [ "${zabbix_homedir}" != "/var/lib/zabbix/home" ]; then
       ewarn
       ewarn "The user 'zabbix' should have his homedir changed"
       ...
```

`egethome` is a function from the `user-info.eclass` which doesn't get directly or implicit inherited by the ebuild. I've fixed this and also removed the `flag-o-matic` eclass since this one isn't used at all.