### PR TITLE
dev-cpp/antlr-cpp: depend on app-arch/unzip

### DIFF
--- a/dev-cpp/antlr-cpp/antlr-cpp-4.7.2.ebuild
+++ b/dev-cpp/antlr-cpp/antlr-cpp-4.7.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ LICENSE="BSD"
 SLOT="4"
 KEYWORDS="amd64 ~arm ~ppc x86"
 
-DEPEND="app-arch/zip"
+DEPEND="app-arch/unzip"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

I haven't found any reason why this package should depend on `app-arch/zip` so i think this should be `app-arch/unzip` - which is required to unzip the src files.
