### PR TITLE
net-p2p/mldonkey: doesn't compile with dev-ml/num-1.4

### DIFF
--- a/net-p2p/mldonkey/mldonkey-3.1.7-r1.ebuild
+++ b/net-p2p/mldonkey/mldonkey-3.1.7-r1.ebuild
@@ -44,7 +44,7 @@ DEPEND="${RDEPEND}
 	bittorrent? (
 		|| (
 			<dev-lang/ocaml-4.06[ocamlopt?]
-			dev-ml/num
+			<dev-ml/num-1.4
 		)
 	)"
 


### PR DESCRIPTION
Upstream changes in dev-ml/num-1.4 make net-p2p/mldonkey fail to build.

This was reported and confirmed in bug [#772920](https://bugs.gentoo.org/772920)

Also reported upstream: https://github.com/ygrek/mldonkey/issues/61