### PR TITLE
gui-apps/swappy: Remove obsolete sed

### DIFF
--- a/gui-apps/swappy/swappy-9999.ebuild
+++ b/gui-apps/swappy/swappy-9999.ebuild
@@ -33,13 +33,6 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_prepare() {
-	default
-
-	# See https://github.com/jtheoof/swappy/pull/99
-	sed -i -e 's/Utility;Graphics;Annotation;/Utility;Graphics;/'  src/po/swappy.desktop.in || die "Sed failed!"
-}
-
 src_configure() {
 	local emesonargs=(
 		-Dwerror=false


### PR DESCRIPTION
This fix has been merged upstream

See: https://github.com/jtheoof/swappy/pull/99

Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Emily Mills <emily@emlove.me>