### PR TITLE
app-misc/recoll: inherit optfeature, update LICENSE

### DIFF
--- a/app-misc/recoll/recoll-1.25.19.ebuild
+++ b/app-misc/recoll/recoll-1.25.19.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,11 +7,11 @@ PYTHON_COMPAT=( python3_7 )
 
 inherit linux-info optfeature python-single-r1 qmake-utils
 
-DESCRIPTION="A personal full text search package"
+DESCRIPTION="Personal full text search package"
 HOMEPAGE="https://www.lesbonscomptes.com/recoll/"
 SRC_URI="https://www.lesbonscomptes.com/recoll/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 x86"
 

--- a/app-misc/recoll/recoll-1.27.12.ebuild
+++ b/app-misc/recoll/recoll-1.27.12.ebuild
@@ -5,13 +5,13 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit eutils linux-info python-single-r1 qmake-utils
+inherit linux-info optfeature python-single-r1 qmake-utils
 
-DESCRIPTION="A personal full text search package"
+DESCRIPTION="Personal full text search package"
 HOMEPAGE="https://www.lesbonscomptes.com/recoll/"
 SRC_URI="https://www.lesbonscomptes.com/recoll/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 x86"
 

--- a/app-misc/recoll/recoll-1.28.5.ebuild
+++ b/app-misc/recoll/recoll-1.28.5.ebuild
@@ -7,11 +7,11 @@ PYTHON_COMPAT=( python3_{6..9} )
 
 inherit linux-info optfeature python-single-r1 qmake-utils
 
-DESCRIPTION="A personal full text search package"
+DESCRIPTION="Personal full text search package"
 HOMEPAGE="https://www.lesbonscomptes.com/recoll/"
 SRC_URI="https://www.lesbonscomptes.com/recoll/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Closes: https://bugs.gentoo.org/775227

This updates the `recoll-1.27.12` ebuild to inherit the missing `optfeature` eclass. I've also updated the `LICENSE` as it clearly seems to be `GPL-2+`