### PR TITLE
games-action/clanbomber: fix desktop inherit, LICENSE

### DIFF
--- a/games-action/clanbomber/clanbomber-2.2.0.ebuild
+++ b/games-action/clanbomber/clanbomber-2.2.0.ebuild
@@ -3,13 +3,13 @@
 
 EAPI=7
 
-inherit autotools
+inherit autotools desktop
 
 DESCRIPTION="Bomberman-like multiplayer game"
 HOMEPAGE="https://savannah.nongnu.org/projects/clanbomber/"
-SRC_URI="http://download.savannah.gnu.org/releases/${PN}/${P}.tar.xz"
+SRC_URI="https://download.savannah.gnu.org/releases/${PN}/${P}.tar.xz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Closes: https://bugs.gentoo.org/768327