### PR TITLE
media-video/ushare: remove enewuser, update LICENSE

### DIFF
--- a/media-video/ushare/ushare-1.1a_p20200824.ebuild
+++ b/media-video/ushare/ushare-1.1a_p20200824.ebuild
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 inherit readme.gentoo-r1 toolchain-funcs systemd
 
 COMMIT="5f7f66cd89d5b0652c1226e65bbf9c85aeba00f2"
@@ -10,7 +11,7 @@ DESCRIPTION="uShare is a UPnP (TM) A/V & DLNA Media Server"
 HOMEPAGE="https://github.com/ddugovic/uShare/"
 SRC_URI="https://github.com/ddugovic/uShare/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="nls"
@@ -56,7 +57,6 @@ src_install() {
 }
 
 pkg_postinst() {
-	enewuser ushare
 	readme.gentoo_print_elog
 	elog
 	elog "The config file has been moved to /etc/ushare.conf"

--- a/media-video/ushare/ushare-1.1a_p20210221.ebuild
+++ b/media-video/ushare/ushare-1.1a_p20210221.ebuild
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 inherit readme.gentoo-r1 toolchain-funcs systemd
 
 COMMIT="79b0d6e41fd9af73c2ef7ee6b110f9b367295a76"
@@ -10,7 +11,7 @@ DESCRIPTION="uShare is a UPnP (TM) A/V & DLNA Media Server"
 HOMEPAGE="https://github.com/ddugovic/uShare/"
 SRC_URI="https://github.com/ddugovic/uShare/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="nls"
@@ -56,7 +57,6 @@ src_install() {
 }
 
 pkg_postinst() {
-	enewuser ushare
 	readme.gentoo_print_elog
 	elog
 	elog "The config file has been moved to /etc/ushare.conf"


### PR DESCRIPTION
Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Hi,

Since the packages already uses new GLEP81 users, `enewuser` isn't required anymore. In fact it doesn't even work right now because the ebuilds doesn't inherit the `user` eclass.
I've also checked some source files and updated the License to `GPL-2+`.