### PR TITLE
sci-libs/tensorflow-estimator: cleanup eclasses, add missing app-arch/unzip dep

### DIFF
--- a/sci-libs/tensorflow-estimator/tensorflow-estimator-2.3.0.ebuild
+++ b/sci-libs/tensorflow-estimator/tensorflow-estimator-2.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,15 +8,14 @@ MY_PN="estimator"
 MY_PV=${PV/_rc/-rc}
 MY_P=${MY_PN}-${MY_PV}
 
-inherit bazel distutils-r1 flag-o-matic toolchain-funcs
+inherit bazel distutils-r1
 
-DESCRIPTION="A high-level TensorFlow API that greatly simplifies machine learning programming"
+DESCRIPTION="High-level TensorFlow API that greatly simplifies machine learning programming"
 HOMEPAGE="https://www.tensorflow.org/"
 
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE=""
 
 bazel_external_uris="
 	https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip -> bazelbuild-rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip
@@ -29,6 +28,7 @@ SRC_URI="https://github.com/tensorflow/${MY_PN}/archive/v${MY_PV}.tar.gz -> ${P}
 RDEPEND="sci-libs/tensorflow[python,${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}"
 BDEPEND="
+	app-arch/unzip
 	dev-java/java-config
 	>=dev-util/bazel-3"
 

--- a/sci-libs/tensorflow-estimator/tensorflow-estimator-2.4.0.ebuild
+++ b/sci-libs/tensorflow-estimator/tensorflow-estimator-2.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,15 +8,14 @@ MY_PN="estimator"
 MY_PV=${PV/_rc/-rc}
 MY_P=${MY_PN}-${MY_PV}
 
-inherit bazel distutils-r1 flag-o-matic toolchain-funcs
+inherit bazel distutils-r1
 
-DESCRIPTION="A high-level TensorFlow API that greatly simplifies machine learning programming"
+DESCRIPTION="High-level TensorFlow API that greatly simplifies machine learning programming"
 HOMEPAGE="https://www.tensorflow.org/"
 
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE=""
 
 bazel_external_uris="
 	https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip -> bazelbuild-rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip


### PR DESCRIPTION
Hi,

I've removed some unused eclasses from both ebuilds and added the missing `app-arch/unzip` dependency to 2.3.0.

Package-Manager: Portage-3.0.16, Repoman-3.0.2
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>