### PR TITLE
net-analyzer/amap: mask for removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -32,6 +32,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Michael Mair-Keimberger <mmk@levelnine.at> (2021-03-10)
+# Last upstream release a decade age
+# from the package todo: amap is outdated. use nmap instead
+# Masked for removal in 30 days.
+net-analyzer/amap
+
 # Hans de Graaff <graaff@gentoo.org> (2021-03-09)
 # Last upstream release in 2013, ruby25-only.
 # Masked for removal in 30 days.


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Bug: https://bugs.gentoo.org/680546

I was looking into amap for a possible `EAPI` bump but i think this package is a good candidate for last rite:
* Upstream is dead (see bug https://bugs.gentoo.org/680546)
* sources are gone
* last release was a decade ago
* the TODO of this packages says: "nothing - amap is outdated. use nmap instead"

The package is however still listed as an optional package for `net-analyzer/gvm`, however i guess `nmap` would be far more superior? 
@j-licht i'm cc'ing you as you might have some more insight here