### PR TITLE
net-libs/pjproject: security rev bump

### DIFF
--- a/net-libs/pjproject/files/pjproject-2.10-CVE-2020-15260-tls-hostname-check.patch
+++ b/net-libs/pjproject/files/pjproject-2.10-CVE-2020-15260-tls-hostname-check.patch
@@ -1,0 +1,125 @@
+From 67e46c1ac45ad784db5b9080f5ed8b133c122872 Mon Sep 17 00:00:00 2001
+From: sauwming <ming@teluu.com>
+Date: Mon, 8 Mar 2021 17:39:36 +0800
+Subject: [PATCH] Merge pull request from GHSA-8hcp-hm38-mfph
+
+* Check hostname during TLS transport selection
+
+* revision based on feedback
+
+* remove the code in create_request that has been moved
+---
+ pjsip/include/pjsip/sip_dialog.h |  1 +
+ pjsip/src/pjsip/sip_dialog.c     | 15 +++++++++++++++
+ pjsip/src/pjsip/sip_transport.c  | 13 +++++++++++++
+ pjsip/src/pjsip/sip_util.c       | 11 ++++++++---
+ 4 files changed, 37 insertions(+), 3 deletions(-)
+
+diff --git a/pjsip/include/pjsip/sip_dialog.h b/pjsip/include/pjsip/sip_dialog.h
+index a0214d28c..e314c2ece 100644
+--- a/pjsip/include/pjsip/sip_dialog.h
++++ b/pjsip/include/pjsip/sip_dialog.h
+@@ -165,6 +165,7 @@ struct pjsip_dialog
+     pjsip_route_hdr	route_set;  /**< Route set.			    */
+     pj_bool_t		route_set_frozen; /**< Route set has been set.	    */
+     pjsip_auth_clt_sess	auth_sess;  /**< Client authentication session.	    */
++    pj_str_t		initial_dest;/**< Initial destination host.  	    */
+ 
+     /** Session counter. */
+     int			sess_count; /**< Number of sessions.		    */
+diff --git a/pjsip/src/pjsip/sip_dialog.c b/pjsip/src/pjsip/sip_dialog.c
+index 27530e4f2..9571b5a35 100644
+--- a/pjsip/src/pjsip/sip_dialog.c
++++ b/pjsip/src/pjsip/sip_dialog.c
+@@ -467,6 +467,10 @@ pj_status_t create_uas_dialog( pjsip_user_agent *ua,
+ 
+     /* Save the remote info. */
+     pj_strdup(dlg->pool, &dlg->remote.info_str, &tmp);
++    
++    /* Save initial destination host from transport's info */
++    pj_strdup(dlg->pool, &dlg->initial_dest,
++    	      &rdata->tp_info.transport->remote_name.host);
+ 
+ 
+     /* Init remote's contact from Contact header.
+@@ -1192,6 +1196,12 @@ static pj_status_t dlg_create_request_throw( pjsip_dialog *dlg,
+ 	    return status;
+     }
+ 
++    /* Copy the initial destination host to tdata. This information can be
++     * used later by transport for transport selection.
++     */
++    if (dlg->initial_dest.slen)
++    	pj_strdup(tdata->pool, &tdata->dest_info.name, &dlg->initial_dest);
++
+     /* Done. */
+     *p_tdata = tdata;
+ 
+@@ -1822,6 +1832,11 @@ static void dlg_update_routeset(pjsip_dialog *dlg, const pjsip_rx_data *rdata)
+      * transaction as the initial transaction that establishes dialog.
+      */
+     if (dlg->role == PJSIP_ROLE_UAC) {
++    	/* Save initial destination host from transport's info. */
++    	if (!dlg->initial_dest.slen) {
++    	    pj_strdup(dlg->pool, &dlg->initial_dest,
++    	      	      &rdata->tp_info.transport->remote_name.host);
++    	}
+ 
+ 	/* Ignore subsequent request from remote */
+ 	if (msg->type != PJSIP_RESPONSE_MSG)
+diff --git a/pjsip/src/pjsip/sip_transport.c b/pjsip/src/pjsip/sip_transport.c
+index bef6d24fe..177274b08 100644
+--- a/pjsip/src/pjsip/sip_transport.c
++++ b/pjsip/src/pjsip/sip_transport.c
+@@ -2335,6 +2335,19 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_acquire_transport2(pjsip_tpmgr *mgr,
+ 		    if (!tp_iter->tp->is_shutdown &&
+ 			!tp_iter->tp->is_destroying)
+ 		    {
++			if ((type & PJSIP_TRANSPORT_SECURE) && tdata) {
++			    /* For secure transport, make sure tdata's
++			     * destination host matches the transport's
++			     * remote host.
++			     */
++			    if (pj_stricmp(&tdata->dest_info.name,
++				  	   &tp_iter->tp->remote_name.host))
++			    {
++			    	tp_iter = tp_iter->next;
++			    	continue;
++			    }
++			}
++
+ 			if (sel && sel->type == PJSIP_TPSELECTOR_LISTENER &&
+ 			    sel->u.listener)
+ 			{
+diff --git a/pjsip/src/pjsip/sip_util.c b/pjsip/src/pjsip/sip_util.c
+index a1bf878ea..cf916805d 100644
+--- a/pjsip/src/pjsip/sip_util.c
++++ b/pjsip/src/pjsip/sip_util.c
+@@ -1417,7 +1417,10 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request_stateless(pjsip_endpoint *endpt,
+      */
+     if (tdata->dest_info.addr.count == 0) {
+ 	/* Copy the destination host name to TX data */
+-	pj_strdup(tdata->pool, &tdata->dest_info.name, &dest_info.addr.host);
++	if (!tdata->dest_info.name.slen) {
++	    pj_strdup(tdata->pool, &tdata->dest_info.name,
++	    	      &dest_info.addr.host);
++	}
+ 
+ 	pjsip_endpt_resolve( endpt, tdata->pool, &dest_info, stateless_data,
+ 			     &stateless_send_resolver_callback);
+@@ -1810,8 +1813,10 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_response( pjsip_endpoint *endpt,
+ 	}
+     } else {
+ 	/* Copy the destination host name to TX data */
+-	pj_strdup(tdata->pool, &tdata->dest_info.name, 
+-		  &res_addr->dst_host.addr.host);
++	if (!tdata->dest_info.name.slen) {
++	    pj_strdup(tdata->pool, &tdata->dest_info.name, 
++		      &res_addr->dst_host.addr.host);
++	}
+ 
+ 	pjsip_endpt_resolve(endpt, tdata->pool, &res_addr->dst_host, 
+ 			    send_state, &send_response_resolver_cb);
+-- 
+2.26.2
+

--- a/net-libs/pjproject/files/pjproject-2.10-CVE-2021-21375-negotiation-failure-crash.patch
+++ b/net-libs/pjproject/files/pjproject-2.10-CVE-2021-21375-negotiation-failure-crash.patch
@@ -1,0 +1,45 @@
+From 97b3d7addbaa720b7ddb0af9bf6f3e443e664365 Mon Sep 17 00:00:00 2001
+From: Nanang Izzuddin <nanang@teluu.com>
+Date: Mon, 8 Mar 2021 16:09:34 +0700
+Subject: [PATCH] Merge pull request from GHSA-hvq6-f89p-frvp
+
+---
+ pjmedia/src/pjmedia/sdp_neg.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/pjmedia/src/pjmedia/sdp_neg.c b/pjmedia/src/pjmedia/sdp_neg.c
+index f4838f75d..9f76b5200 100644
+--- a/pjmedia/src/pjmedia/sdp_neg.c
++++ b/pjmedia/src/pjmedia/sdp_neg.c
+@@ -304,7 +304,6 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_modify_local_offer2(
+ {
+     pjmedia_sdp_session *new_offer;
+     pjmedia_sdp_session *old_offer;
+-    char media_used[PJMEDIA_MAX_SDP_MEDIA];
+     unsigned oi; /* old offer media index */
+     pj_status_t status;
+ 
+@@ -323,8 +322,19 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_modify_local_offer2(
+     /* Change state to STATE_LOCAL_OFFER */
+     neg->state = PJMEDIA_SDP_NEG_STATE_LOCAL_OFFER;
+ 
++    /* When there is no active local SDP in state PJMEDIA_SDP_NEG_STATE_DONE,
++     * it means that the previous initial SDP nego must have been failed,
++     * so we'll just set the local SDP offer here.
++     */
++    if (!neg->active_local_sdp) {
++	neg->initial_sdp_tmp = NULL;
++	neg->initial_sdp = pjmedia_sdp_session_clone(pool, local);
++	neg->neg_local_sdp = pjmedia_sdp_session_clone(pool, local);
++
++	return PJ_SUCCESS;
++    }
++
+     /* Init vars */
+-    pj_bzero(media_used, sizeof(media_used));
+     old_offer = neg->active_local_sdp;
+     new_offer = pjmedia_sdp_session_clone(pool, local);
+ 
+-- 
+2.26.2
+

--- a/net-libs/pjproject/files/pjproject-2.10-race-condition-between-transport-destroy-and-acquire.patch
+++ b/net-libs/pjproject/files/pjproject-2.10-race-condition-between-transport-destroy-and-acquire.patch
@@ -1,0 +1,108 @@
+From 90a16c523bfdf4d43c10506c972c5fd4250b2856 Mon Sep 17 00:00:00 2001
+From: Nanang Izzuddin <nanang@teluu.com>
+Date: Fri, 20 Nov 2020 10:52:22 +0700
+Subject: [PATCH] Race condition between transport destroy and acquire (#2470)
+
+* Handle race condition between transport_idle_callback() and pjsip_tpmgr_acquire_transport2().
+* Add transport destroy state check as additional of transport shutdown state check
+---
+ pjsip/src/pjsip/sip_transaction.c |  2 +-
+ pjsip/src/pjsip/sip_transport.c   | 34 +++++++++++++++++++++++++------
+ 2 files changed, 29 insertions(+), 7 deletions(-)
+
+diff --git a/pjsip/src/pjsip/sip_transaction.c b/pjsip/src/pjsip/sip_transaction.c
+index 2b4ece7df..f663c7f4b 100644
+--- a/pjsip/src/pjsip/sip_transaction.c
++++ b/pjsip/src/pjsip/sip_transaction.c
+@@ -2443,7 +2443,7 @@ static void tsx_update_transport( pjsip_transaction *tsx,
+ 	pjsip_transport_add_ref(tp);
+ 	pjsip_transport_add_state_listener(tp, &tsx_tp_state_callback, tsx,
+ 					    &tsx->tp_st_key);
+-        if (tp->is_shutdown) {
++	if (tp->is_shutdown || tp->is_destroying) {
+ 	    pjsip_transport_state_info info;
+ 
+ 	    pj_bzero(&info, sizeof(info));
+diff --git a/pjsip/src/pjsip/sip_transport.c b/pjsip/src/pjsip/sip_transport.c
+index 06fce358c..bef6d24fe 100644
+--- a/pjsip/src/pjsip/sip_transport.c
++++ b/pjsip/src/pjsip/sip_transport.c
+@@ -1071,6 +1071,19 @@ static void transport_idle_callback(pj_timer_heap_t *timer_heap,
+ 	return;
+ 
+     entry->id = PJ_FALSE;
++
++    /* Set is_destroying flag under transport manager mutex to avoid
++     * race condition with pjsip_tpmgr_acquire_transport2().
++     */
++    pj_lock_acquire(tp->tpmgr->lock);
++    if (pj_atomic_get(tp->ref_cnt) == 0) {
++	tp->is_destroying = PJ_TRUE;
++    } else {
++	pj_lock_release(tp->tpmgr->lock);
++	return;
++    }
++    pj_lock_release(tp->tpmgr->lock);
++
+     pjsip_transport_destroy(tp);
+ }
+ 
+@@ -1392,8 +1405,8 @@ PJ_DEF(pj_status_t) pjsip_transport_shutdown2(pjsip_transport *tp,
+     mgr = tp->tpmgr;
+     pj_lock_acquire(mgr->lock);
+ 
+-    /* Do nothing if transport is being shutdown already */
+-    if (tp->is_shutdown) {
++    /* Do nothing if transport is being shutdown/destroyed already */
++    if (tp->is_shutdown || tp->is_destroying) {
+ 	pj_lock_release(mgr->lock);
+ 	pj_lock_release(tp->lock);
+ 	return PJ_SUCCESS;
+@@ -2256,6 +2269,13 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_acquire_transport2(pjsip_tpmgr *mgr,
+ 	    return PJSIP_ETPNOTSUITABLE;
+ 	}
+ 
++	/* Make sure the transport is not being destroyed */
++	if (seltp->is_destroying) {
++	    pj_lock_release(mgr->lock);
++	    TRACE_((THIS_FILE,"Transport to be acquired is being destroyed"));
++	    return PJ_ENOTFOUND;
++	}
++
+ 	/* We could also verify that the destination address is reachable
+ 	 * from this transport (i.e. both are equal), but if application
+ 	 * has requested a specific transport to be used, assume that
+@@ -2311,8 +2331,10 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_acquire_transport2(pjsip_tpmgr *mgr,
+ 	    if (tp_entry) {
+ 		transport *tp_iter = tp_entry;
+ 		do {
+-		    /* Don't use transport being shutdown */
+-		    if (!tp_iter->tp->is_shutdown) {
++		    /* Don't use transport being shutdown/destroyed */
++		    if (!tp_iter->tp->is_shutdown &&
++			!tp_iter->tp->is_destroying)
++		    {
+ 			if (sel && sel->type == PJSIP_TPSELECTOR_LISTENER &&
+ 			    sel->u.listener)
+ 			{
+@@ -2382,7 +2404,7 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_acquire_transport2(pjsip_tpmgr *mgr,
+ 	    TRACE_((THIS_FILE, "Transport found but from different listener"));
+ 	}
+ 
+-	if (tp_ref!=NULL && !tp_ref->is_shutdown) {
++	if (tp_ref!=NULL && !tp_ref->is_shutdown && !tp_ref->is_destroying) {
+ 	    /*
+ 	     * Transport found!
+ 	     */
+@@ -2624,7 +2646,7 @@ PJ_DEF(pj_status_t) pjsip_transport_add_state_listener (
+ 
+     PJ_ASSERT_RETURN(tp && cb && key, PJ_EINVAL);
+ 
+-    if (tp->is_shutdown) {
++    if (tp->is_shutdown || tp->is_destroying) {
+ 	*key = NULL;
+ 	return PJ_EINVALIDOP;
+     }
+-- 
+2.26.2
+

--- a/net-libs/pjproject/pjproject-2.10-r1.ebuild
+++ b/net-libs/pjproject/pjproject-2.10-r1.ebuild
@@ -1,0 +1,125 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools flag-o-matic toolchain-funcs
+
+DESCRIPTION="Open source SIP, Media, and NAT Traversal Library"
+HOMEPAGE="https://www.pjsip.org/"
+SRC_URI="https://github.com/pjsip/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+
+LICENSE="GPL-2"
+SLOT="0/${PV}"
+
+# g729 not included due to special bcg729 handling.
+CODEC_FLAGS="g711 g722 g7221 gsm ilbc speex l16"
+VIDEO_FLAGS="sdl ffmpeg v4l2 openh264 libyuv vpx"
+SOUND_FLAGS="alsa portaudio"
+IUSE="amr debug epoll examples ipv6 libressl opus resample silk ssl static-libs webrtc
+	${CODEC_FLAGS} g729
+	${VIDEO_FLAGS}
+	${SOUND_FLAGS}"
+
+PATCHES=(
+	"${FILESDIR}/pjproject-2.9-ssl-enable.patch"
+	"${FILESDIR}/pjproject-2.10-race-condition-between-transport-destroy-and-acquire.patch"
+	"${FILESDIR}/pjproject-2.10-CVE-2020-15260-tls-hostname-check.patch"
+	"${FILESDIR}/pjproject-2.10-CVE-2021-21375-negotiation-failure-crash.patch"
+)
+
+RDEPEND="net-libs/libsrtp:=
+	alsa? ( media-libs/alsa-lib )
+	amr? ( media-libs/opencore-amr )
+	ffmpeg? ( media-video/ffmpeg:= )
+	g729? ( media-libs/bcg729 )
+	gsm? ( media-sound/gsm )
+	ilbc? ( media-libs/libilbc )
+	openh264? ( media-libs/openh264 )
+	opus? ( media-libs/opus )
+	portaudio? ( media-libs/portaudio )
+	resample? ( media-libs/libsamplerate )
+	sdl? ( media-libs/libsdl )
+	speex? (
+		media-libs/speex
+		media-libs/speexdsp
+	)
+	ssl? (
+		!libressl? ( dev-libs/openssl:0= )
+		libressl? ( dev-libs/libressl:0= )
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	default
+	rm configure || die "Unable to remove unwanted wrapper"
+	mv aconfigure.ac configure.ac || die "Unable to rename configure script source"
+	eautoreconf
+
+	cp "${FILESDIR}/pjproject-2.9-config_site.h" "${S}/pjlib/include/pj/config_site.h" || die "Unable to create config_site.h"
+}
+
+src_configure() {
+	local myconf=()
+	local videnable="--disable-video"
+	local t
+
+	use debug || append-cflags -DNDEBUG=1
+	use ipv6 && append-cflags -DPJ_HAS_IPV6=1
+	append-cflags -DPJMEDIA_HAS_SRTP=1
+
+	for t in ${CODEC_FLAGS}; do
+		myconf+=( $(use_enable ${t} ${t}-codec) )
+	done
+	myconf+=( $(use_enable g729 bcg729) )
+
+	for t in ${VIDEO_FLAGS}; do
+		myconf+=( $(use_enable ${t}) )
+		use "${t}" && videnable="--enable-video"
+	done
+
+	[ "${videnable}" = "--enable-video" ] && append-cflags -DPJMEDIA_HAS_VIDEO=1
+
+	LD="$(tc-getCC)" econf \
+		--enable-shared \
+		--with-external-srtp \
+		${videnable} \
+		$(use_enable alsa sound) \
+		$(use_enable amr opencore-amr) \
+		$(use_enable epoll) \
+		$(use_enable opus) \
+		$(use_enable portaudio ext-sound) \
+		$(use_enable resample libsamplerate) \
+		$(use_enable resample resample-dll) \
+		$(use_enable resample) \
+		$(use_enable silk) \
+		$(use_enable speex speex-aec) \
+		$(use_enable ssl) \
+		$(use_with gsm external-gsm) \
+		$(use_with portaudio external-pa) \
+		$(use_with speex external-speex) \
+		$(usex webrtc '' --disable-libwebrtc) \
+		"${myconf[@]}"
+}
+
+src_compile() {
+	emake dep LD="$(tc-getCC)"
+	emake LD="$(tc-getCC)"
+}
+
+src_install() {
+	default
+
+	newbin pjsip-apps/bin/pjsua-${CHOST} pjsua
+	newbin pjsip-apps/bin/pjsystest-${CHOST} pjsystest
+
+	if use examples; then
+		insinto "/usr/share/doc/${PF}/examples"
+		doins -r pjsip-apps/src/samples
+	fi
+
+	use static-libs || rm "${ED}/usr/$(get_libdir)"/*.a || die "Error removing static archives"
+}


### PR DESCRIPTION
Upstream didn't release a new version as one would expect.  Instead
patches are applied locally.

Also add subslot because they are equally good at maintaining ABI
compatibility, and SONAME is never updated, thus we need to be able to
depend on subslots to rebuild (preserved-rebuild is no good).

Bug: https://bugs.gentoo.org/775359
Bug: https://bugs.gentoo.org/775353
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Jaco Kroon <jaco@uls.co.za>