### PR TITLE
dev-python/pycollada: add allarches

### DIFF
--- a/dev-python/pycollada/metadata.xml
+++ b/dev-python/pycollada/metadata.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>waebbl-gentoo@posteo.net</email>
-		<name>Bernd Waibel</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
-	<longdescription>
-A python module for creating, editing and loading COLLADA, which is a
-COLLAborative Design Activity for establishing an interchange file format
-for interactive 3D applications.
-</longdescription>
-	<upstream>
-		<remote-id type="github">pycollada/pycollada</remote-id>
-		<remote-id type="pypi">pycollada</remote-id>
-	</upstream>
+  <maintainer type="person">
+    <email>waebbl-gentoo@posteo.net</email>
+    <name>Bernd Waibel</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>proxy-maint@gentoo.org</email>
+    <description>Proxy Maintainers</description>
+  </maintainer>
+  <stabilize-allarches/>
+  <longdescription>
+  A python module for creating, editing and loading COLLADA, which is a
+  COLLAborative Design Activity for establishing an interchange file format
+  for interactive 3D applications.
+  </longdescription>
+  <upstream>
+    <remote-id type="github">pycollada/pycollada</remote-id>
+    <remote-id type="pypi">pycollada</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/dev-python/pycollada/pycollada-0.7.1.ebuild
+++ b/dev-python/pycollada/pycollada-0.7.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Adding stabilize-allarches tag to metadata.xml, following
a call from Sam in gentoo-dev.

Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

Second commit adds python-3.9 support.