### PR TITLE
net-libs/libsrtp-1.6.0-r1: Fix compilation with sys-devel/autoconf-2.71

### DIFF
--- a/net-libs/libsrtp/libsrtp-1.6.0-r1.ebuild
+++ b/net-libs/libsrtp/libsrtp-1.6.0-r1.ebuild
@@ -45,6 +45,7 @@ src_prepare() {
 
 	mv configure.in configure.ac || die
 	eautoreconf
+	touch ar-lib || die #775680
 }
 
 multilib_src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/775680
Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Jannis Achstetter <kripton@kripserver.net>

Fix found at https://aur.archlinux.org/packages/lib32-libsrtp/#comment-787895
Tested with sys-devel/autoconf-2.71 and latest stable (sys-devel/autoconf-2.69-r5)