### PR TITLE
app-emulation/libvirt: Specify docdir on configure cmd line

### DIFF
--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -128,7 +128,6 @@ DEPEND="${BDEPEND}
 PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-6.7.0-do-not-use-sysconfig.patch
-	"${FILESDIR}"/${PN}-6.7.0-doc-path.patch
 	"${FILESDIR}"/${PN}-6.7.0-fix-paths-for-apparmor.patch
 )
 
@@ -276,6 +275,7 @@ src_configure() {
 
 		--localstatedir="${EPREFIX}/var"
 		-Drunstatedir="${EPREFIX}/run"
+		-Ddocdir="${EPREFIX}/usr/share/doc/${PF}"
 	)
 
 	meson_src_configure


### PR DESCRIPTION
Up until very recently libvirt did not allow specifying docdir
via any (meson) configure option. That is why we patched
meson.build and changed docdir to point where we wanted it to
point. Well, this is changed with upstream commit of
v7.1.0-145-gee4a392dda. Therefore, don't patch the meson.build
file anymore and specify docdir like this:

  -Ddocdir="${EPREFIX}/usr/share/doc/${P}"

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>