### PR TITLE
x11-themes/papirus-icon-theme: stabilizing 20200901.ebuild

### DIFF
--- a/x11-themes/papirus-icon-theme/papirus-icon-theme-20200901.ebuild
+++ b/x11-themes/papirus-icon-theme/papirus-icon-theme-20200901.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/${
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 x86"
 
 src_compile() { :; }
 


### PR DESCRIPTION
As noticed in https://bugs.gentoo.org/775959 it's time to stabilize this ebuild.

Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Marco Scardovi <marco@scardovi.com>