### PR TITLE
dev-ruby/hashicorp-checkpoint: Disable tests

### DIFF
--- a/dev-ruby/hashicorp-checkpoint/hashicorp-checkpoint-0.1.5-r1.ebuild
+++ b/dev-ruby/hashicorp-checkpoint/hashicorp-checkpoint-0.1.5-r1.ebuild
@@ -18,6 +18,9 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="test"
 
+# Tests require network
+RESTRICT="test"
+
 ruby_add_bdepend "
 	test? ( dev-ruby/rspec-its )
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/775731
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Guillaume Seren <guillaumeseren@gmail.com>