### PR TITLE
app-cdr/dvd+rw-tools: fix bugs

### DIFF
--- a/app-cdr/dvd+rw-tools/dvd+rw-tools-7.1-r4.ebuild
+++ b/app-cdr/dvd+rw-tools/dvd+rw-tools-7.1-r4.ebuild
@@ -1,0 +1,58 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="A set of tools for DVD+RW/-RW drives"
+HOMEPAGE="http://fy.chalmers.se/~appro/linux/DVD+RW/"
+SRC_URI="http://fy.chalmers.se/~appro/linux/DVD+RW/tools/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE=""
+
+RDEPEND="app-cdr/cdrtools"
+DEPEND="${RDEPEND}
+	sys-devel/m4"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-7.0-sysmacros.patch
+	"${FILESDIR}"/${PN}-7.0-wctomb-r1.patch
+	"${FILESDIR}"/${PN}-7.0-glibc2.6.90.patch
+	"${FILESDIR}"/${PN}-7.0-dvddl-r1.patch
+	"${FILESDIR}"/${PN}-7.0-wexit.patch
+	"${FILESDIR}"/${PN}-7.0-reload.patch
+	"${FILESDIR}"/${PN}-7.1-noevent.patch
+	"${FILESDIR}"/${PN}-7.1-lastshort.patch
+	"${FILESDIR}"/${PN}-7.1-bluray_srm+pow.patch
+	"${FILESDIR}"/${PN}-7.1-bluray_pow_freespace.patch
+	"${FILESDIR}"/${PN}-7.1-clang.patch
+)
+
+# this is a text file, not html
+DOCS=( index.html )
+
+src_prepare() {
+	# Linux compiler flags only include -O2 and are incremental.
+	sed -i '/FLAGS/s:-O2::' Makefile.m4 || die "failed to sed out FLAGS"
+	default
+}
+
+src_compile() {
+	emake SHELL="${EPREFIX}"/bin/bash CC="$(tc-getCC)" CXX="$(tc-getCXX)"
+}
+
+src_install() {
+	emake SHELL="${EPREFIX}"/bin/bash prefix="${ED}/usr" install
+	einstalldocs
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]] ; then
+		elog 'If you receive an error, "unable to anonymously mmap...'
+		elog 'Resource temporarily unavailable" when running growisofs,'
+		elog 'then you may need to run "ulimit -l unlimited".'
+	fi
+}

--- a/app-cdr/dvd+rw-tools/files/dvd+rw-tools-7.1-clang.patch
+++ b/app-cdr/dvd+rw-tools/files/dvd+rw-tools-7.1-clang.patch
@@ -1,0 +1,71 @@
+--- a/dvd+rw-booktype.cpp	2006-06-24 12:21:48.000000000 +0300
++++ b/dvd+rw-booktype.cpp	2021-03-14 10:16:02.533741829 +0200
+@@ -398,7 +398,7 @@
+ 		break;
+ 	case OPT_MEDIA:
+ 		if (profile!=0x1A && profile!=0x14 && profile!=13)
+-		{   fprintf (stderr,":-( action is applicable to DVD±RW only\n");
++		{   fprintf (stderr,":-( action is applicable to DVD\xb1RW only\n");
+ 		    break;
+ 		}
+ 
+@@ -759,7 +759,7 @@
+ 	    }
+ 	}
+ 
+-	delete list;
++	delete[] list;
+     }
+ 
+     profile=buf[6]<<8|buf[7];
+--- a/dvd+rw-mediainfo.cpp	2006-09-23 20:46:57.000000000 +0300
++++ b/dvd+rw-mediainfo.cpp	2021-03-14 10:16:02.533741829 +0200
+@@ -621,7 +621,7 @@
+ 	if (phys_end>0)	phys_end -= phys_start;
+ 	if (phys_end>0) phys_end += 1;
+ 
+-	printf (" %s    %u*2KB=%"LLU"\n",
++	printf (" %s    %u*2KB=%" LLU "\n",
+ 		dvd_dash>=0?"Legacy lead-out at:":"Last border-out at:",
+ 		phys_end,phys_end*2048LL);
+ 
+@@ -941,14 +941,14 @@
+ 	    printf(" %s:\t\t%u*%u=",type[formats[8]&3],
+ 	        capacity=formats[4]<<24|formats[5]<<16|formats[6]<<8|formats[7],
+ 		blocksize);
+-	    printf("%"LLU"\n",(unsigned long long)capacity*blocksize);
++	    printf("%" LLU "\n",(unsigned long long)capacity*blocksize);
+ 
+ 	    for(i=12;i<len;i+=8)
+ 	    {	printf(" %02Xh(%x):\t\t%u*%u=",formats[i+4]>>2,
+ 			formats[i+5]<<16|formats[i+6]<<8|formats[i+7],
+ 	    		capacity=formats[i]<<24|formats[i+1]<<16|formats[i+2]<<8|formats[i+3],
+ 			blocksize);
+-		printf("%"LLU"\n",(unsigned long long)capacity*blocksize);
++		printf("%" LLU "\n",(unsigned long long)capacity*blocksize);
+ 	    }
+ 	    break;
+ 	}
+@@ -1121,7 +1121,7 @@
+ 	if (ccity) ccity++;
+ 	bsize = header[4]<<24|header[5]<<16|header[6]<<8|header[7];
+ 
+-	printf ("READ CAPACITY:          %u*%u=%"LLU"\n",
++	printf ("READ CAPACITY:          %u*%u=%" LLU "\n",
+ 					ccity,bsize,
+ 					(unsigned long long)ccity*bsize);
+     } while (0);
+--- a/transport.hxx	2021-03-14 10:17:54.353626017 +0200
++++ b/transport.hxx	2021-03-14 10:16:44.180365362 +0200
+@@ -127,9 +127,9 @@
+ 	char str[MB_LEN_MAX];
+     public:
+ 	__plusminus()	{   setlocale(LC_CTYPE,ENV_LOCALE);
+-			    int l = wctomb(str,(wchar_t)(unsigned char)'±');
++			    int l = wctomb(str,(wchar_t)'\xb1');
+ 			    if (l>0)	str[l]='\0';
+-			    else	str[0]='±',str[1]='\0';
++			    else	str[0]='\xb1',str[1]='\0';
+ 			}
+ 	~__plusminus()	{ }
+ 	operator char*(){ return str; }

--- a/app-cdr/dvd+rw-tools/metadata.xml
+++ b/app-cdr/dvd+rw-tools/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>ceamac.paragon@gmail.com</email>
+		<name>Viorel Munteanu</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
Fix problems compiling with clang.  Bump to EAPI 7.

Also, seems not maintained upstream.