### PR TITLE
sci-mathematics/topcom: define HTML_DOCS only when doc is in USE.

### DIFF
--- a/sci-mathematics/topcom/topcom-0.17.8-r1.ebuild
+++ b/sci-mathematics/topcom/topcom-0.17.8-r1.ebuild
@@ -24,7 +24,6 @@ RDEPEND="${DEPEND}"
 BDEPEND="app-shells/tcsh"
 
 PATCHES=( "${FILESDIR}/${P}-buildsystem.patch" )
-HTML_DOCS=( "${DISTDIR}/TOPCOM-manual.html" )
 
 src_prepare () {
 	default
@@ -43,13 +42,16 @@ src_configure() {
 }
 
 src_install () {
+	if use doc ; then
+		HTML_DOCS=( "${DISTDIR}/TOPCOM-manual.html" )
+	fi
+
 	default
 
 	if use examples; then
 		docompress -x "/usr/share/doc/${PF}/examples"
 		dodoc -r examples
 	fi
-	use doc && einstalldocs
 
 	mv "${ED}/usr/bin/cube" "${ED}/usr/bin/topcom_cube" || die
 

--- a/sci-mathematics/topcom/topcom-0.17.8-r1.ebuild
+++ b/sci-mathematics/topcom/topcom-0.17.8-r1.ebuild
@@ -9,12 +9,12 @@ DESCRIPTION="Computing Triangulations Of Point Configurations and Oriented Matro
 HOMEPAGE="http://www.rambau.wm.uni-bayreuth.de/TOPCOM/"
 SRC_URI="
 	http://www.rambau.wm.uni-bayreuth.de/Software/TOPCOM-${PV}.tar.gz
-	doc? ( http://www.rambau.wm.uni-bayreuth.de/TOPCOM/TOPCOM-manual.html )
+	http://www.rambau.wm.uni-bayreuth.de/TOPCOM/TOPCOM-manual.html
 "
 KEYWORDS="~amd64 ~x86"
 SLOT="0"
 LICENSE="GPL-2"
-IUSE="doc examples"
+IUSE="examples"
 
 DEPEND="
 	dev-libs/gmp:0
@@ -24,6 +24,8 @@ RDEPEND="${DEPEND}"
 BDEPEND="app-shells/tcsh"
 
 PATCHES=( "${FILESDIR}/${P}-buildsystem.patch" )
+
+HTML_DOCS=( "${DISTDIR}/TOPCOM-manual.html" )
 
 src_prepare () {
 	default
@@ -42,10 +44,6 @@ src_configure() {
 }
 
 src_install () {
-	if use doc ; then
-		HTML_DOCS=( "${DISTDIR}/TOPCOM-manual.html" )
-	fi
-
 	default
 
 	if use examples; then


### PR DESCRIPTION
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Bug: https://bugs.gentoo.org/776310
Signed-off-by: François René Pierre Bissey <frp.bissey@gmail.com>