### PR TITLE
app-text/zathura-djvu: replace deprecated command

### DIFF
--- a/app-text/zathura-djvu/zathura-djvu-0.2.9.ebuild
+++ b/app-text/zathura-djvu/zathura-djvu-0.2.9.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit gnome2-utils meson xdg-utils
+inherit meson xdg-utils
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
@@ -30,11 +30,11 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
 pkg_postinst() {
-	gnome2_icon_cache_update
+	xdg_icon_cache_update
 	xdg_desktop_database_update
 }
 
 pkg_postrm() {
-	gnome2_icon_cache_update
+	xdg_icon_cache_update
 	xdg_desktop_database_update
 }


### PR DESCRIPTION
Closes:https://bugs.gentoo.org/775743

Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: David Denoncin <ddenoncin@gmail.com>