### PR TITLE
app-mobilephone/heimdall: bumping to r1

### DIFF
--- a/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
+++ b/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 		dev-qt/qtcore:5
 		dev-qt/qtgui:5
 		dev-qt/qtwidgets:5
-        )"
+	)"
 
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
@@ -36,7 +36,7 @@ BDEPEND="virtual/pkgconfig"
 src_configure() {
 	local mycmakeargs=(
 		-DDISABLE_FRONTEND=$(usex !gui)
-        )
+	)
 	cmake_src_configure
 }
 

--- a/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
+++ b/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake udev
+
+if [[ ${PV} != 9999 ]]; then
+	SRC_URI="https://gitlab.com/BenjaminDobell/Heimdall/-/archive/v${PV}/Heimdall-v${PV}.tar.bz2 -> ${P}.tar.bz2"
+	S="${WORKDIR}/Heimdall-v${PV}"
+else
+	inherit git-r3
+	EGIT_REPO_URI="https://gitlab.com/BenjaminDobell/Heimdall.git"
+fi
+
+DESCRIPTION="Tool suite used to flash firmware onto Samsung Galaxy S phone"
+HOMEPAGE="https://glassechidna.com.au/heimdall/"
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="gui"
+KEYWORDS="~amd64"
+
+RDEPEND="
+	virtual/libusb:1=
+	sys-libs/zlib
+	gui? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+        )"
+
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_configure() {
+	local mycmakeargs=(
+		-DDISABLE_FRONTEND=$(usex !gui)
+        )
+	cmake_src_configure
+}
+
+src_install() {
+	dobin "${BUILD_DIR}"/bin/heimdall
+	use gui && dobin "${BUILD_DIR}"/bin/heimdall-frontend
+	insinto "$(get_udevdir)/rules.d"
+
+	doins heimdall/60-heimdall.rules
+
+	dodoc README.md Linux/README
+}

--- a/app-mobilephone/heimdall/metadata.xml
+++ b/app-mobilephone/heimdall/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person">
+		<email>marco@scardovi.com</email>
+		<name>Marco Scardovi</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="gitlab">BenjaminDobell/Heimdall</remote-id>
 	</upstream>


### PR DESCRIPTION
The actual version of Heimdall points to a dead gitlab repo
while active one is on github. Also taking ownership.

Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Marco Scardovi <marco@scardovi.com>