### PR TITLE
dev-java/jflex: fix regression

### DIFF
--- a/dev-java/jflex/jflex-1.6.1-r1.ebuild
+++ b/dev-java/jflex/jflex-1.6.1-r1.ebuild
@@ -23,8 +23,7 @@ RDEPEND=">=virtual/jre-1.8:*
 	vim-syntax? ( || ( app-editors/vim app-editors/gvim ) )
 	${CDEPEND}"
 
-DEPEND="dev-java/javacup:0
-	>=virtual/jdk-1.8:*
+DEPEND=">=virtual/jdk-1.8:*
 	test? ( dev-java/junit:4 )
 	${CDEPEND}"
 
@@ -35,7 +34,7 @@ JAVA_SRC_DIR="src/main/java"
 
 src_prepare() {
 	# See below for details.
-	eapply_user "${FILESDIR}/icedtea-arm.patch"
+	eapply "${FILESDIR}/icedtea-arm.patch"
 
 	# We need the bundled jflex.jar.
 	rm -rv ${JAVA_SRC_DIR}/java_cup examples/pom.xml || die


### PR DESCRIPTION
Previous commit introduced circular dependency
( DEPEND="dev-java/javacup:0 )

Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>