### PR TITLE
app-mobilephone/heimdall: updated links and RDEPENDS

### DIFF
--- a/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
+++ b/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
@@ -7,8 +7,6 @@ inherit cmake udev
 
 SRC_URI="https://github.com/Benjamin-Dobell/Heimdall/archive/v${PV}.tar.gz -> ${P}.tar.bz2"
 
-S="${WORKDIR}/Heimdall-v${PV}"
-
 DESCRIPTION="Tool suite used to flash firmware onto Samsung devices"
 HOMEPAGE="https://glassechidna.com.au/heimdall/"
 
@@ -16,6 +14,7 @@ LICENSE="MIT"
 SLOT="0"
 IUSE="gui"
 KEYWORDS="~amd64"
+S="${WORKDIR}/Heimdall-v${PV}"
 
 RDEPEND="
 	virtual/libusb:1=

--- a/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
+++ b/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
@@ -6,6 +6,7 @@ EAPI=7
 inherit cmake udev
 
 SRC_URI="https://github.com/Benjamin-Dobell/Heimdall/archive/v${PV}.tar.gz -> ${P}.tar.bz2"
+
 S="${WORKDIR}/Heimdall-v${PV}"
 
 DESCRIPTION="Tool suite used to flash firmware onto Samsung devices"

--- a/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
+++ b/app-mobilephone/heimdall/heimdall-1.4.2-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake udev
+
+SRC_URI="https://github.com/Benjamin-Dobell/Heimdall/archive/v${PV}.tar.gz -> ${P}.tar.bz2"
+S="${WORKDIR}/Heimdall-v${PV}"
+
+DESCRIPTION="Tool suite used to flash firmware onto Samsung devices"
+HOMEPAGE="https://glassechidna.com.au/heimdall/"
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="gui"
+KEYWORDS="~amd64"
+
+RDEPEND="
+	virtual/libusb:1=
+	sys-libs/zlib
+	gui? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+	)"
+
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_configure() {
+	local mycmakeargs=(
+		-DDISABLE_FRONTEND=$(usex !gui)
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	dobin "${BUILD_DIR}"/bin/heimdall
+	use gui && dobin "${BUILD_DIR}"/bin/heimdall-frontend
+	insinto "$(get_udevdir)/rules.d"
+	doins heimdall/60-heimdall.rules
+	dodoc README.md Linux/README
+}

--- a/app-mobilephone/heimdall/heimdall-9999.ebuild
+++ b/app-mobilephone/heimdall/heimdall-9999.ebuild
@@ -3,16 +3,9 @@
 
 EAPI=7
 
-inherit cmake udev
+inherit cmake udev git-r3
 
-if [[ ${PV} != 9999 ]]; then
-	SRC_URI="https://gitlab.com/BenjaminDobell/Heimdall/-/archive/v${PV}/Heimdall-v${PV}.tar.bz2 -> ${P}.tar.bz2"
-	KEYWORDS="~amd64"
-	S="${WORKDIR}/Heimdall-v${PV}"
-else
-	inherit git-r3
-	EGIT_REPO_URI="https://gitlab.com/BenjaminDobell/Heimdall.git"
-fi
+EGIT_REPO_URI="https://gitlab.com/BenjaminDobell/Heimdall.git"
 
 DESCRIPTION="Tool suite used to flash firmware onto Samsung Galaxy S devices"
 HOMEPAGE="https://glassechidna.com.au/heimdall/"
@@ -22,14 +15,14 @@ SLOT="0"
 IUSE="gui"
 
 RDEPEND="
-	>=dev-libs/libusb-1.0.18:1=
+	virtual/libusb:1=
 	sys-libs/zlib
 	gui? (
 		dev-qt/qtcore:5
 		dev-qt/qtgui:5
 		dev-qt/qtwidgets:5
-	)
-"
+	)"
+
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
@@ -43,9 +36,7 @@ src_configure() {
 src_install() {
 	dobin "${BUILD_DIR}"/bin/heimdall
 	use gui && dobin "${BUILD_DIR}"/bin/heimdall-frontend
-
 	insinto "$(get_udevdir)/rules.d"
 	doins heimdall/60-heimdall.rules
-
 	dodoc README.md Linux/README
 }

--- a/app-mobilephone/heimdall/metadata.xml
+++ b/app-mobilephone/heimdall/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>marco@scardovi.com</email>
+		<name>Marco Scardovi</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="gitlab">BenjaminDobell/Heimdall</remote-id>
 	</upstream>


### PR DESCRIPTION
Updated links and RDEPEND (changed from dev-libs/libusb to virtual/libusb).
Also appoint myself as proxy maintainer