### PR TITLE
dev-python/pygal: python 3.9 and tests fix

### DIFF
--- a/dev-python/pygal/files/2.4.0-fix-tests.patch
+++ b/dev-python/pygal/files/2.4.0-fix-tests.patch
@@ -1,0 +1,17 @@
+diff --git a/pygal/test/conftest.py b/pygal/test/conftest.py
+index ea36010..6fe40cb 100644
+--- a/pygal/test/conftest.py
++++ b/pygal/test/conftest.py
+@@ -48,9 +48,9 @@ def pytest_generate_tests(metafunc):
+     if hasattr(sys, 'pypy_version_info'):
+         etree.to_etree()
+
+-    if "Chart" in metafunc.funcargnames:
++    if "Chart" in metafunc.fixturenames:
+         metafunc.parametrize("Chart", pygal.CHARTS)
+-    if "datas" in metafunc.funcargnames:
++    if "datas" in metafunc.fixturenames:
+         metafunc.parametrize(
+             "datas", [[("Serie %d" % i, get_data(i)) for i in range(s)]
+                       for s in (5, 1, 0)]
+--

--- a/dev-python/pygal/pygal-2.4.0-r2.ebuild
+++ b/dev-python/pygal/pygal-2.4.0-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_REQ_USE="xml(+)"
+
+inherit distutils-r1
+
+DESCRIPTION="A python SVG charts generator"
+HOMEPAGE="https://github.com/Kozea/pygal/"
+# PyPI tarballs do not contain docs
+# https://github.com/Kozea/pygal/pull/428
+SRC_URI="https://github.com/Kozea/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	dev-python/lxml[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	media-gfx/cairosvg[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	test? (
+		dev-python/pyquery[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+	)
+"
+
+PATCHES=( "${FILESDIR}/${PV}-fix-tests.patch" )
+
+# CHANGELOG is a symlink to docs/changelog.rst
+DOCS=( docs/changelog.rst README.md )
+
+distutils_enable_sphinx docs
+distutils_enable_tests pytest
+
+python_prepare_all() {
+	# Not actually required unless we want to do setup.py test
+	# https://github.com/Kozea/pygal/issues/430
+	sed -i -e "/setup_requires/d" setup.py || die
+	# [pytest] section in setup.cfg files is no longer supported
+	sed -i -e 's@\[pytest\]@[tool:pytest]@' setup.cfg || die
+	distutils-r1_python_prepare_all
+}

--- a/dev-python/pygal/pygal-2.4.0-r2.ebuild
+++ b/dev-python/pygal/pygal-2.4.0-r2.ebuild
@@ -19,15 +19,10 @@ KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
 	dev-python/lxml[${PYTHON_USEDEP}]
-	dev-python/setuptools[${PYTHON_USEDEP}]
-	media-gfx/cairosvg[${PYTHON_USEDEP}]
-"
+	media-gfx/cairosvg[${PYTHON_USEDEP}]"
+
 BDEPEND="
-	test? (
-		dev-python/pyquery[${PYTHON_USEDEP}]
-		dev-python/pytest[${PYTHON_USEDEP}]
-	)
-"
+	test? ( dev-python/pyquery[${PYTHON_USEDEP}] )"
 
 PATCHES=( "${FILESDIR}/${PV}-fix-tests.patch" )
 


### PR DESCRIPTION
There are various changes upstream to update the lib, however there is no new release yet. I extracted a minimal patch that fixes the tests and added python 3.9 support.

Closes: https://bugs.gentoo.org/738208