### PR TITLE
dev-db/sqlite: use correct prefixes for cross-compilation

### DIFF
--- a/dev-db/sqlite/sqlite-3.33.0.ebuild
+++ b/dev-db/sqlite/sqlite-3.33.0.ebuild
@@ -115,6 +115,7 @@ multilib_src_configure() {
 	options+=(
 		--enable-load-extension
 		--enable-threadsafe
+		--exec-prefix="${ESYSROOT}/usr"
 	)
 
 	# Support detection of misuse of SQLite API.
@@ -274,7 +275,10 @@ multilib_src_configure() {
 	options+=($(use_enable static-libs static))
 
 	# tcl, test, tools USE flags.
-	options+=(--enable-tcl)
+	options+=(
+		--enable-tcl
+		--with-tcl="${ESYSROOT}/usr/$(get_libdir)"
+	)
 
 	if [[ "${CHOST}" == *-mint* ]]; then
 		# sys/mman.h not available in MiNTLib.

--- a/dev-db/sqlite/sqlite-3.34.0.ebuild
+++ b/dev-db/sqlite/sqlite-3.34.0.ebuild
@@ -152,6 +152,7 @@ multilib_src_configure() {
 	options+=(
 		--enable-load-extension
 		--enable-threadsafe
+		--exec-prefix="${ESYSROOT}/usr"
 	)
 
 	# Support detection of misuse of SQLite API.
@@ -311,7 +312,10 @@ multilib_src_configure() {
 	options+=($(use_enable static-libs static))
 
 	# tcl, test, tools USE flags.
-	options+=(--enable-tcl)
+	options+=(
+		--enable-tcl
+		--with-tcl="${ESYSROOT}/usr/$(get_libdir)"
+	)
 
 	if [[ "${CHOST}" == *-mint* ]]; then
 		# sys/mman.h not available in MiNTLib.

--- a/dev-db/sqlite/sqlite-3.34.1.ebuild
+++ b/dev-db/sqlite/sqlite-3.34.1.ebuild
@@ -152,6 +152,7 @@ multilib_src_configure() {
 	options+=(
 		--enable-load-extension
 		--enable-threadsafe
+		--exec-prefix="${ESYSROOT}/usr"
 	)
 
 	# Support detection of misuse of SQLite API.
@@ -311,7 +312,10 @@ multilib_src_configure() {
 	options+=($(use_enable static-libs static))
 
 	# tcl, test, tools USE flags.
-	options+=(--enable-tcl)
+	options+=(
+		--enable-tcl
+		--with-tcl="${ESYSROOT}/usr/$(get_libdir)"
+	)
 
 	if [[ "${CHOST}" == *-mint* ]]; then
 		# sys/mman.h not available in MiNTLib.

--- a/dev-db/sqlite/sqlite-3.35.0.ebuild
+++ b/dev-db/sqlite/sqlite-3.35.0.ebuild
@@ -152,6 +152,7 @@ multilib_src_configure() {
 	options+=(
 		--enable-load-extension
 		--enable-threadsafe
+		--exec-prefix="${ESYSROOT}/usr"
 	)
 
 	# Support detection of misuse of SQLite API.
@@ -311,7 +312,10 @@ multilib_src_configure() {
 	options+=($(use_enable static-libs static))
 
 	# tcl, test, tools USE flags.
-	options+=(--enable-tcl)
+	options+=(
+		--enable-tcl
+		--with-tcl="${ESYSROOT}/usr/$(get_libdir)"
+	)
 
 	if [[ "${CHOST}" == *-mint* ]]; then
 		# sys/mman.h not available in MiNTLib.

--- a/dev-db/sqlite/sqlite-3.35.1.ebuild
+++ b/dev-db/sqlite/sqlite-3.35.1.ebuild
@@ -152,6 +152,7 @@ multilib_src_configure() {
 	options+=(
 		--enable-load-extension
 		--enable-threadsafe
+		--exec-prefix="${ESYSROOT}/usr"
 	)
 
 	# Support detection of misuse of SQLite API.
@@ -311,7 +312,10 @@ multilib_src_configure() {
 	options+=($(use_enable static-libs static))
 
 	# tcl, test, tools USE flags.
-	options+=(--enable-tcl)
+	options+=(
+		--enable-tcl
+		--with-tcl="${ESYSROOT}/usr/$(get_libdir)"
+	)
 
 	if [[ "${CHOST}" == *-mint* ]]; then
 		# sys/mman.h not available in MiNTLib.

--- a/dev-db/sqlite/sqlite-3.35.2.ebuild
+++ b/dev-db/sqlite/sqlite-3.35.2.ebuild
@@ -152,6 +152,7 @@ multilib_src_configure() {
 	options+=(
 		--enable-load-extension
 		--enable-threadsafe
+		--exec-prefix="${ESYSROOT}/usr"
 	)
 
 	# Support detection of misuse of SQLite API.
@@ -311,7 +312,10 @@ multilib_src_configure() {
 	options+=($(use_enable static-libs static))
 
 	# tcl, test, tools USE flags.
-	options+=(--enable-tcl)
+	options+=(
+		--enable-tcl
+		--with-tcl="${ESYSROOT}/usr/$(get_libdir)"
+	)
 
 	if [[ "${CHOST}" == *-mint* ]]; then
 		# sys/mman.h not available in MiNTLib.


### PR DESCRIPTION
In case `ESYSROOT` is located other than `/`, cross compilation fails due to wrong prefixes used by configure.

For example, when the cross toolchain is under `/build/arm64-usr`, build fails like that:

```
./configure --build=x86_64-pc-linux-gnu --host=aarch64-cros-linux-gnu
--with-sysroot=/build/arm64-usr
--with-readline-inc=-I/build/arm64-usr/usr/include/readline
--enable-tcl
./libtool --mode=compile --tag=CC aarch64-cros-linux-gnu-gcc
-O2 -pipe -mtune=generic -g -I.
-I/build/arm64-usr/var/tmp/portage/dev-db/sqlite-3.33.0/work/sqlite-src-3330000-.arm64/src
-I/usr/include -c sqlite3.c
In file included from /usr/include/features.h:489,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdint.h:26,
                 from sqlite3.c:13484:
/usr/include/gnu/stubs.h:7:11: fatal error: gnu/stubs-32.h: No such file
or directory
```

That happens because `CFLAGS` includes `-I/usr/include`, which is not the correct location of cross toolchains.
The bare prefix is provided automatically by the option `--enable-tcl`.
It should be actually e.g. `-I/build/arm64-usr/usr/include`.

To make configure look up the correct path, we should specify `--enable-tcl --with-tcl="${ESYSROOT}/usr/$(get_libdir)"`, where e.g. `ESYSROOT` is `/build/arm64-usr`.

To avoid similar cross-toolchain issues, let's pass in `--exec-prefix=${ESYSROOT}/usr` to the configure script.
