### PR TITLE
app-text/gnome-doc-utils: add python3.9 support

### DIFF
--- a/app-text/gnome-doc-utils/gnome-doc-utils-0.20.10-r2.ebuild
+++ b/app-text/gnome-doc-utils/gnome-doc-utils-0.20.10-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit gnome2 multibuild python-r1
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.17-r2, Repoman-3.0.2
Closes: https://bugs.gentoo.org/761337

Signed-off-by: Pavel Kulyov <kulyov.pavel@gmail.com>