### PR TITLE
sys-apps/grep: allow building with libsigsegv (fix test failure on sparc)

### DIFF
--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,6 +1,15 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2021-03-19)
+# On sparc, we have to force sys-apps/grep[libsigsegv]
+# for accurate stack overflow handling. dev-libs/libsigsegv
+# lacks USE=static-libs, so for now, this means we can't
+# build a static grep on sparc.
+# No real pressing need to add it.
+# bug #768135
+sys-apps/grep static
+
 # Miroslav Šulc <fordfrog@gentoo.org> (2021-03-13)
 # virtual/jdk isn't keyworded here
 media-libs/rubberband jni

--- a/sys-apps/grep/grep-3.5.ebuild
+++ b/sys-apps/grep/grep-3.5.ebuild
@@ -15,7 +15,11 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="nls pcre static"
 
-LIB_DEPEND="pcre? ( >=dev-libs/libpcre-7.8-r1[static-libs(+)] )"
+# We lack dev-libs/libsigsegv[static-libs] for now
+REQUIRED_USE="static? ( !sparc )"
+
+LIB_DEPEND="pcre? ( >=dev-libs/libpcre-7.8-r1[static-libs(+)] )
+	sparc? ( dev-libs/libsigsegv )"
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )
 	nls? ( virtual/libintl )
 	virtual/libiconv"
@@ -39,8 +43,13 @@ src_prepare() {
 
 src_configure() {
 	use static && append-ldflags -static
-	# don't link against libsigsegv even when available, bug #673524
-	export ac_cv_libsigsegv=no
+
+	# We used to turn this off unconditionally (bug #673524) but we now
+	# allow it for cases where libsigsegv is better for userspace handling
+	# of stack overflows.
+	# In particular, it's necessary for sparc: bug #768135
+	export ac_cv_libsigsegv=$(usex sparc)
+
 	# Always use pkg-config to get lib info for pcre.
 	export ac_cv_search_pcre_compile=$(
 		usex pcre "$($(tc-getPKG_CONFIG) --libs $(usex static --static '') libpcre)" ''

--- a/sys-apps/grep/grep-3.6.ebuild
+++ b/sys-apps/grep/grep-3.6.ebuild
@@ -14,7 +14,11 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="nls pcre static"
 
-LIB_DEPEND="pcre? ( >=dev-libs/libpcre-7.8-r1[static-libs(+)] )"
+# We lack dev-libs/libsigsegv[static-libs] for now
+REQUIRED_USE="static? ( !sparc )"
+
+LIB_DEPEND="pcre? ( >=dev-libs/libpcre-7.8-r1[static-libs(+)] )
+	sparc? ( dev-libs/libsigsegv )"
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )
 	nls? ( virtual/libintl )
 	virtual/libiconv"
@@ -38,8 +42,13 @@ src_prepare() {
 
 src_configure() {
 	use static && append-ldflags -static
-	# don't link against libsigsegv even when available, bug #673524
-	export ac_cv_libsigsegv=no
+
+	# We used to turn this off unconditionally (bug #673524) but we now
+	# allow it for cases where libsigsegv is better for userspace handling
+	# of stack overflows.
+	# In particular, it's necessary for sparc: bug #768135
+	export ac_cv_libsigsegv=$(usex sparc)
+
 	# Always use pkg-config to get lib info for pcre.
 	export ac_cv_search_pcre_compile=$(
 		usex pcre "$($(tc-getPKG_CONFIG) --libs $(usex static --static '') libpcre)" ''

--- a/sys-apps/grep/metadata.xml
+++ b/sys-apps/grep/metadata.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>base-system@gentoo.org</email>
-	<name>Gentoo Base System</name>
-</maintainer>
-<upstream>
-	<remote-id type="cpe">cpe:/a:gnu:grep</remote-id>
-</upstream>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="cpe">cpe:/a:gnu:grep</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
This fixes test failures on sparc in grep 3.6, although 3.5 still fails. This seems to be because of an older copy of gnulib in that version.

I'd say it's too risky to backport gnulib changes to 3.5, although we can do it if @gentoo/base-system wants to. I'd prefer to just skip stabilisation for 3.5 on sparc and stabilise 3.6 when the time is right.

Note that I ended up discovering an independent issue because `filename-lineno.pl` failed on sparc too. This ended up being a real bug in that libpcre upstream doesn't support JIT on sparc64 which manifested in both the test failing and e.g. `grep -P foo` dying with SIGBUS. I've therefore masked dev-libs/libpcre[jit] on sparc64 in fd573f430b05c418f74a5700cc182568123c812a.