### PR TITLE
dev-qt/qtwebengine: depend on net-libs/nodejs[ssl]

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.15.2_p20210224.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.2_p20210224.ebuild
@@ -84,7 +84,7 @@ DEPEND="${RDEPEND}
 	dev-util/gperf
 	dev-util/ninja
 	dev-util/re2c
-	net-libs/nodejs
+	net-libs/nodejs[ssl]
 	sys-devel/bison
 "
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/777405