### PR TITLE
dev-ros/openslam_gmapping: update license

### DIFF
--- a/dev-ros/openslam_gmapping/openslam_gmapping-0.2.1.ebuild
+++ b/dev-ros/openslam_gmapping/openslam_gmapping-0.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,7 @@ KEYWORDS="~amd64 ~arm"
 inherit ros-catkin
 
 DESCRIPTION="ROS-ified version of gmapping SLAM"
-LICENSE="CC-BY-NC-SA-2.5"
+LICENSE="BSD"
 SLOT="0"
 IUSE=""
 

--- a/dev-ros/openslam_gmapping/openslam_gmapping-9999.ebuild
+++ b/dev-ros/openslam_gmapping/openslam_gmapping-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,7 @@ KEYWORDS="~amd64 ~arm"
 inherit ros-catkin
 
 DESCRIPTION="ROS-ified version of gmapping SLAM"
-LICENSE="CC-BY-NC-SA-2.5"
+LICENSE="BSD"
 SLOT="0"
 IUSE=""
 


### PR DESCRIPTION
since 0.2.0 it's BSD licensed
see https://github.com/ros-perception/openslam_gmapping/pull/29

Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>