### PR TITLE
eclass/common-lisp-3:  Fix asd suffix substitution

### DIFF
--- a/eclass/common-lisp-3.eclass
+++ b/eclass/common-lisp-3.eclass
@@ -136,7 +136,7 @@ common-lisp-install-one-asdf() {
 	[[ $# != 1 ]] && die "${FUNCNAME[0]} must receive exactly one argument"
 
 	# the suffix «.asd» is optional
-	local source=${1/.asd}.asd
+	local source=${1%.asd}.asd
 	common-lisp-install-one-source true "${source}" "$(dirname "${source}")"
 	local target="${CLSOURCEROOT%/}/${CLPACKAGE}/${source}"
 	dosym "${target}" "${CLSYSTEMROOT%/}/$(basename ${target})"


### PR DESCRIPTION
Filenames containing the string "asd" such as `iolib.asdf.asd`
are improperly modified by the bash substitution (/) -> `iolibf.asd`
Replacing it with suffix remove (%) fixes this: `iolib.asdf