### PR TITLE
font.eclass: Drop EAPI-5 and EAPI-6 support

### DIFF
--- a/eclass/font.eclass
+++ b/eclass/font.eclass
@@ -46,21 +46,12 @@ FONTDIR=${FONTDIR:-/usr/share/fonts/${FONT_PN}}
 # Array containing fontconfig conf files to install.
 FONT_CONF=( "" )
 
-# @ECLASS-VARIABLE: DOCS
-# @DEFAULT_UNSET
-# @DESCRIPTION:
-# Space delimited list of docs to install.
-# We always install these:
-# COPYRIGHT README{,.txt} NEWS AUTHORS BUGS ChangeLog FONTLOG.txt
-DOCS=${DOCS:-}
-
 if [[ ${CATEGORY}/${PN} != media-fonts/encodings ]]; then
 	IUSE="X"
-	DEPEND="X? (
+	BDEPEND="X? (
 			>=x11-apps/mkfontscale-1.2.0
 			media-fonts/encodings
 	)"
-	RDEPEND=""
 fi
 
 # @FUNCTION: font_xfont_config

--- a/eclass/font.eclass
+++ b/eclass/font.eclass
@@ -61,14 +61,14 @@ font_xfont_config() {
 	local dir_name
 	if in_iuse X && use X ; then
 		dir_name="${1:-${FONT_PN}}"
-		rm -f "${ED}/${FONTDIR}/${1//${S}/}"/{fonts.{dir,scale},encodings.dir} \
+		rm -f "${ED}${FONTDIR}/${1//${S}/}"/{fonts.{dir,scale},encodings.dir} \
 			|| die "failed to prepare ${FONTDIR}/${1//${S}/}"
 		einfo "Creating fonts.scale & fonts.dir in ${dir_name##*/}"
-		mkfontscale "${ED}/${FONTDIR}/${1//${S}/}" || eerror "failed to create fonts.scale"
+		mkfontscale "${ED}${FONTDIR}/${1//${S}/}" || eerror "failed to create fonts.scale"
 		mkfontdir \
 			-e "${EPREFIX}"/usr/share/fonts/encodings \
 			-e "${EPREFIX}"/usr/share/fonts/encodings/large \
-			"${ED}/${FONTDIR}/${1//${S}/}" || eerror "failed to create fonts.dir"
+			"${ED}${FONTDIR}/${1//${S}/}" || eerror "failed to create fonts.dir"
 		[[ -e fonts.alias ]] && doins fonts.alias
 	fi
 }
@@ -139,8 +139,8 @@ font_cleanup_dirs() {
 font_pkg_setup() {
 	# make sure we get no collisions
 	# setup is not the nicest place, but preinst doesn't cut it
-	if [[ -e "${EROOT}/${FONTDIR}/fonts.cache-1" ]] ; then
-		rm "${EROOT}/${FONTDIR}/fonts.cache-1" || die "failed to remove fonts.cache-1"
+	if [[ -e "${EROOT}${FONTDIR}/fonts.cache-1" ]] ; then
+		rm "${EROOT}${FONTDIR}/fonts.cache-1" || die "failed to remove fonts.cache-1"
 	fi
 }
 

--- a/eclass/font.eclass
+++ b/eclass/font.eclass
@@ -1,19 +1,20 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: font.eclass
 # @MAINTAINER:
 # fonts@gentoo.org
-# @SUPPORTED_EAPIS: 5 6 7
+# @SUPPORTED_EAPIS: 6 7
 # @BLURB: Eclass to make font installation uniform
 
 case ${EAPI:-0} in
-	[56]) inherit eutils ;;
+	6) inherit eutils ;;
 	7) ;;
 	*) die "EAPI ${EAPI} is not supported by font.eclass." ;;
 esac
 
 if [[ ! ${_FONT_ECLASS} ]]; then
+_FONT_ECLASS=1
 
 EXPORT_FUNCTIONS pkg_setup src_install pkg_postinst pkg_postrm
 
@@ -75,8 +76,8 @@ font_xfont_config() {
 		einfo "Creating fonts.scale & fonts.dir in ${dir_name##*/}"
 		mkfontscale "${ED%/}/${FONTDIR}/${1//${S}/}" || eerror "failed to create fonts.scale"
 		mkfontdir \
-			-e ${EPREFIX}/usr/share/fonts/encodings \
-			-e ${EPREFIX}/usr/share/fonts/encodings/large \
+			-e "${EPREFIX}"/usr/share/fonts/encodings \
+			-e "${EPREFIX}"/usr/share/fonts/encodings/large \
 			"${ED%/}/${FONTDIR}/${1//${S}/}" || eerror "failed to create fonts.dir"
 		[[ -e fonts.alias ]] && doins fonts.alias
 	fi
@@ -254,5 +255,4 @@ font_pkg_postrm() {
 	_update_fontcache
 }
 
-_FONT_ECLASS=1
 fi


### PR DESCRIPTION
Almost gone: https://qa-reports.gentoo.org/output/eapi-per-eclass/font.eclass/