### PR TITLE
net-misc/seafile-client: restrict to <dev-libs/glib-2.68.0

### DIFF
--- a/net-misc/seafile-client/seafile-client-8.0.1.ebuild
+++ b/net-misc/seafile-client/seafile-client-8.0.1.ebuild
@@ -16,8 +16,9 @@ IUSE="libressl shibboleth test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="dev-db/sqlite:3
-	dev-libs/libevent
+	<dev-libs/glib-2.68.0
 	dev-libs/jansson
+	dev-libs/libevent
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5
 	dev-qt/qtgui:5


### PR DESCRIPTION
linked to bug[#777477](https://bugs.gentoo.org/show_bug.cgi?id=777477)