### PR TITLE
sys-libs/zlib-ng: miscellaneous fixes

### DIFF
--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2021-03-20)
+# Supports both 'neon32' and 'neon64'
+sys-libs/zlib-ng -cpu_flags_arm_neon
+
 # Patrick McLean <chutzpah@gentoo.org> (2021-02-25)
 # Requires unkeyworded dev-libs/pmdk, mask until keyworded
 sys-cluster/ceph pmdk rbd-rwl

--- a/sys-libs/zlib-ng/metadata.xml
+++ b/sys-libs/zlib-ng/metadata.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>base-system@gentoo.org</email>
-	<name>Gentoo Base System</name>
-</maintainer>
-<use>
-	<flag name="compat">Enable compatibility to <pkg>sys-libs/zlib</pkg></flag>
-</use>
-<upstream>
-	<remote-id type="github">zlib-ng/zlib-ng</remote-id>
-</upstream>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<use>
+		<flag name="compat">Enable compatibility to <pkg>sys-libs/zlib</pkg></flag>
+	</use>
+	<upstream>
+		<remote-id type="github">zlib-ng/zlib-ng</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sys-libs/zlib-ng/zlib-ng-2.0.1-r1.ebuild
+++ b/sys-libs/zlib-ng/zlib-ng-2.0.1-r1.ebuild
@@ -18,6 +18,8 @@ IUSE="compat ${CPU_USE[@]} test"
 
 RESTRICT="!test? ( test )"
 
+RDEPEND="compat? ( !sys-libs/zlib )"
+
 src_prepare() {
 	cmake_src_prepare
 

--- a/sys-libs/zlib-ng/zlib-ng-2.0.1-r1.ebuild
+++ b/sys-libs/zlib-ng/zlib-ng-2.0.1-r1.ebuild
@@ -28,6 +28,10 @@ src_configure() {
 	local mycmakeargs=(
 		-DZLIB_COMPAT="$(usex compat)"
 		-DZLIB_ENABLE_TESTS="$(usex test)"
+		# Unaligned access is controversial and undefined behaviour
+		# Let's keep it off for now
+		# https://github.com/gentoo/gentoo/pull/17167
+		-DWITH_UNALIGNED="OFF"
 	)
 	cmake_src_configure
 }

--- a/sys-libs/zlib-ng/zlib-ng-2.0.1-r1.ebuild
+++ b/sys-libs/zlib-ng/zlib-ng-2.0.1-r1.ebuild
@@ -69,3 +69,15 @@ src_configure() {
 
 	cmake_src_configure
 }
+
+src_install() {
+	cmake_src_install
+
+	if use compat ; then
+		ewarn "zlib-ng is experimental and replacing the system zlib is dangerous"
+		ewarn "Please be careful!"
+		ewarn
+		ewarn "The following link explains the guarantees (and what is NOT guaranteed):"
+		ewarn "https://github.com/zlib-ng/zlib-ng/blob/2.0.x/PORTING.md"
+	fi
+}

--- a/sys-libs/zlib-ng/zlib-ng-2.0.1-r1.ebuild
+++ b/sys-libs/zlib-ng/zlib-ng-2.0.1-r1.ebuild
@@ -1,17 +1,16 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Id: 688f948c5f3067e775bfab5057e8047f467a9ca9 $
 
 EAPI=7
 
 inherit cmake
 
-DESCRIPTION="zlib data compression library"
+DESCRIPTION="Fork of the zlib data compression library"
 HOMEPAGE="https://github.com/zlib-ng/zlib-ng"
 SRC_URI="https://github.com/${PN}/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
 LICENSE="ZLIB"
 SLOT="0"
-
 #KEYWORDS="~amd64 ~x86"
 IUSE="compat test"
 
@@ -19,6 +18,8 @@ RESTRICT="!test? ( test )"
 
 src_prepare() {
 	cmake_src_prepare
+
+	# https://github.com/zlib-ng/zlib-ng/issues/881
 	sed "/LIB_INSTALL_DIR/s@/lib\"@/$(get_libdir)\"@" \
 		-i CMakeLists.txt || die
 }

--- a/sys-libs/zlib/metadata.xml
+++ b/sys-libs/zlib/metadata.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>base-system@gentoo.org</email>
-	<name>Gentoo Base System</name>
-</maintainer>
-<use>
-	<flag name="minizip">include the minizip library for quick and dirty zip extraction</flag>
-</use>
-<upstream>
-	<remote-id type="cpe">cpe:/a:gnu:zlib</remote-id>
-</upstream>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<use>
+		<flag name="minizip">include the minizip library for quick and dirty zip extraction</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">madler/zlib</remote-id>
+		<remote-id type="cpe">cpe:/a:gnu:zlib</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sys-libs/zlib/zlib-1.2.11-r4.ebuild
+++ b/sys-libs/zlib/zlib-1.2.11-r4.ebuild
@@ -1,0 +1,160 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+AUTOTOOLS_AUTO_DEPEND="no"
+
+inherit autotools toolchain-funcs multilib multilib-minimal usr-ldscript
+
+CYGWINPATCHES=(
+	"https://github.com/cygwinports/zlib/raw/22a3462cae33a82ad966ea0a7d6cbe8fc1368fec/1.2.11-gzopen_w.patch -> ${PN}-1.2.11-cygwin-gzopen_w.patch"
+	"https://github.com/cygwinports/zlib/raw/22a3462cae33a82ad966ea0a7d6cbe8fc1368fec/1.2.7-minizip-cygwin.patch -> ${PN}-1.2.7-cygwin-minizip.patch"
+)
+
+DESCRIPTION="Standard (de)compression library"
+HOMEPAGE="https://zlib.net/"
+SRC_URI="https://zlib.net/${P}.tar.gz
+	http://www.gzip.org/zlib/${P}.tar.gz
+	http://www.zlib.net/current/beta/${P}.tar.gz
+	elibc_Cygwin? ( ${CYGWINPATCHES[*]} )"
+
+LICENSE="ZLIB"
+SLOT="0/1" # subslot = SONAME
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+IUSE="minizip static-libs"
+
+BDEPEND="minizip? ( ${AUTOTOOLS_DEPEND} )"
+# See #309623 for libxml2
+RDEPEND="
+	!<dev-libs/libxml2-2.7.7
+	!sys-libs/zlib-ng[compat]
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.2.11-fix-deflateParams-usage.patch
+	"${FILESDIR}"/${PN}-1.2.11-minizip-drop-crypt-header.patch #658536
+)
+
+src_prepare() {
+	default
+
+	if use elibc_Cygwin ; then
+		local p
+		for p in "${CYGWINPATCHES[@]}" ; do
+			# Strip out the "... -> " from the array
+			eapply -p2 "${DISTDIR}/${p#*> }"
+		done
+	fi
+
+	if use minizip ; then
+		cd contrib/minizip || die
+		eautoreconf
+	fi
+
+	case ${CHOST} in
+	*-cygwin*)
+		# do not use _wopen, is a mingw symbol only
+		sed -i -e '/define WIDECHAR/d' "${S}"/gzguts.h || die
+		# zlib1.dll is the mingw name, need cygz.dll
+		# cygz.dll is loaded by toolchain, put into subdir
+		sed -i -e 's|zlib1.dll|win32/cygz.dll|' win32/Makefile.gcc || die
+		;;
+	esac
+
+	case ${CHOST} in
+	*-mingw*|mingw*|*-cygwin*)
+		# uses preconfigured Makefile rather than configure script
+		multilib_copy_sources
+		;;
+	esac
+}
+
+echoit() { echo "$@"; "$@"; }
+
+multilib_src_configure() {
+	case ${CHOST} in
+	*-mingw*|mingw*|*-cygwin*)
+		;;
+	*)
+		local uname=$("${EPREFIX}"/usr/share/gnuconfig/config.sub "${CHOST}" | cut -d- -f3) #347167
+		local myconf=(
+			--shared
+			--prefix="${EPREFIX}/usr"
+			--libdir="${EPREFIX}/usr/$(get_libdir)"
+			${uname:+--uname=${uname}}
+		)
+		# not an autoconf script, so can't use econf
+		echoit "${S}"/configure "${myconf[@]}" || die
+		;;
+	esac
+
+	if use minizip ; then
+		local minizipdir="contrib/minizip"
+		mkdir -p "${BUILD_DIR}/${minizipdir}" || die
+		cd ${minizipdir} || die
+		ECONF_SOURCE="${S}/${minizipdir}" \
+		econf $(use_enable static-libs static)
+	fi
+}
+
+multilib_src_compile() {
+	case ${CHOST} in
+	*-mingw*|mingw*|*-cygwin*)
+		emake -f win32/Makefile.gcc STRIP=true PREFIX=${CHOST}-
+		sed \
+			-e 's|@prefix@|'"${EPREFIX}"'/usr|g' \
+			-e 's|@exec_prefix@|${prefix}|g' \
+			-e 's|@libdir@|${exec_prefix}/'$(get_libdir)'|g' \
+			-e 's|@sharedlibdir@|${exec_prefix}/'$(get_libdir)'|g' \
+			-e 's|@includedir@|${prefix}/include|g' \
+			-e 's|@VERSION@|'${PV}'|g' \
+			zlib.pc.in > zlib.pc || die
+		;;
+	*)
+		emake
+		;;
+	esac
+	use minizip && emake -C contrib/minizip
+}
+
+sed_macros() {
+	# clean up namespace a little #383179
+	# we do it here so we only have to tweak 2 files
+	sed -i -r 's:\<(O[FN])\>:_Z_\1:g' "$@" || die
+}
+
+multilib_src_install() {
+	case ${CHOST} in
+	*-mingw*|mingw*|*-cygwin*)
+		emake -f win32/Makefile.gcc install \
+			BINARY_PATH="${ED}/usr/bin" \
+			LIBRARY_PATH="${ED}/usr/$(get_libdir)" \
+			INCLUDE_PATH="${ED}/usr/include" \
+			SHARED_MODE=1
+		# overwrites zlib.pc created from win32/Makefile.gcc #620136
+		insinto /usr/$(get_libdir)/pkgconfig
+		doins zlib.pc
+		;;
+
+	*)
+		emake install DESTDIR="${D}" LDCONFIG=:
+		gen_usr_ldscript -a z
+		;;
+	esac
+	sed_macros "${ED}"/usr/include/*.h
+
+	if use minizip ; then
+		emake -C contrib/minizip install DESTDIR="${D}"
+		sed_macros "${ED}"/usr/include/minizip/*.h
+	fi
+
+	if ! use static-libs ; then
+		rm -f "${ED}"/usr/$(get_libdir)/lib{z,minizip}.{a,la} || die #419645
+	fi
+}
+
+multilib_src_install_all() {
+	dodoc FAQ README ChangeLog doc/*.txt
+	use minizip && dodoc contrib/minizip/*.txt
+}


### PR DESCRIPTION
Notes (mostly for future):
1. Figure out circular dep issues with cmake, which has zlib has a direct dependency. But let's not worry about that for now. We'll likely have a virtual in future.

2. How do we want to handle minizip-ng? Regular zlib bundles it and has it as a USE flag.

More practical issues:

3. Add mulitlib as ionen suggested (see [here](https://github.com/gentoo/gentoo/pull/20048#issuecomment-803703859))

4. May need a hack to build static-libs

5. ABI compatibility is **not** [guaranteed](https://github.com/zlib-ng/zlib-ng/blob/develop/PORTING.md#zlib-compat-mode). How can we force rebuilds?

```
$ git shortlog origin/master..HEAD
Sam James (14):
      sys-libs/zlib-ng: revbump
      sys-libs/zlib-ng: adjust ebuild layout
      sys-libs/zlib-ng: drop blank KEYWORDS for now
      sys-libs/zlib-ng: update DESCRIPTION to indicate fork
      sys-libs/zlib-ng: add bug reference to libdir workaround
      sys-libs/zlib-ng: adjust metadata indentation
      sys-libs/zlib-ng: disable unaligned access
      sys-libs/zlib-ng: add preliminary intrinics
      sys-libs/zlib-ng: add blocker on sys-libs/zlib when using compat mode
      sys-libs/zlib-ng: warn users if USE=compat
      sys-libs/zlib: add blocker on sys-libs/zlib-ng[compat]
      sys-libs/zlib: update metadata indentation
      sys-libs/zlib: add github upstream metadata
      profiles/arch/arm64: unmask sys-libs/zlib-ng[cpu_flags_arm_neon]
```