### PR TITLE
sys-libs/timezone-data: adjust /etc/localtime logic

### DIFF
--- a/sys-libs/timezone-data/timezone-data-2021a.ebuild
+++ b/sys-libs/timezone-data/timezone-data-2021a.ebuild
@@ -150,28 +150,35 @@ configure_tz_data() {
 	fi
 
 	if ! tz=$(get_TIMEZONE) ; then
-		einfo "Assuming your empty ${etc_lt} file is what you want; skipping update."
+		einfo "Assuming your empty ${src} file is what you want; skipping update."
 		return 0
 	fi
+
 	if [[ "${tz}" == "FOOKABLOIE" ]] ; then
-		elog "You do not have TIMEZONE set in ${src}."
-
-		if [[ ! -e "${etc_lt}" ]] ; then
-			cp -f "${EROOT}"/usr/share/zoneinfo/Factory "${etc_lt}"
-			elog "Setting ${etc_lt} to Factory."
-		else
-			elog "Skipping auto-update of ${etc_lt}."
-		fi
+		einfo "You do not have a timezone set in ${src}; skipping update."
 		return 0
 	fi
 
-	if [[ ! -e "${EROOT}/usr/share/zoneinfo/${tz}" ]] ; then
-		elog "You have an invalid TIMEZONE setting in ${src}"
-		elog "Your ${etc_lt} has been reset to Factory; enjoy!"
-		tz="Factory"
+	local tzpath
+
+	if [[ -f ${etc_lt} ]]; then
+		# If a regular file already exists, copy over it.
+		tzpath="${EROOT}/usr/share/zoneinfo/${tz}"
+		ewarn "Found a regular file at ${etc_lt}."
+		ewarn "Some software may expect a symlink instead."
+		ewarn "You may convert it to a symlink by removing the file and running:"
+		ewarn "  emerge --config sys-libs/timezone-data"
+		einfo "Copying ${tzpath} to ${etc_lt}."
+		cp -f "${tzpath}" "${etc_lt}"
+	else
+		# Otherwise, create a symlink and remove the timezone file.
+		tzpath="../usr/share/zoneinfo/${tz}"
+		einfo "Linking ${tzpath} at ${etc_lt}."
+		if ln -snf "${tzpath}" "${etc_lt}"; then
+			einfo "Removing ${src}."
+			rm -f "${src}"
+		fi
 	fi
-	einfo "Updating ${etc_lt} with ${EROOT}/usr/share/zoneinfo/${tz}"
-	cp -f "${EROOT}/usr/share/zoneinfo/${tz}" "${etc_lt}"
 }
 
 pkg_config() {


### PR DESCRIPTION
Stop using the "Factory" timezone. Programs will use UTC if localtime is
missing. Not installing the Factory timezone as /etc/localtime will
allow us to more easily detect if /etc/localtime exists and is valid.

If /etc/localtime exists as a regular file, copy the new timezone file
over it as was done previously. Emit a warning message encouraging the
user to remove the file.

If /etc/localtime does not exist, but we have a timezone configured in
/etc/timezone, create a symlink and remove /etc/timezone.

The end result of this should be that new installs default to UTC.
If users create /etc/timezone according to the handbook, a symlink will
be created at /etc/localtime and /etc/timezone will be removed.