### PR TITLE
net-analyzer/openvas-scanner: add qa fix for rpath

### DIFF
--- a/net-analyzer/openvas-scanner/files/openvas-scanner-20.8.1-rpath-qa-fix.patch
+++ b/net-analyzer/openvas-scanner/files/openvas-scanner-20.8.1-rpath-qa-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 69c68375..5bc000c0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,6 +37,8 @@ endif (NOT CMAKE_BUILD_TYPE)
+ 
+ OPTION (ENABLE_COVERAGE "Enable support for coverage analysis" OFF)
+ 
++set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
++
+ ## Retrieve git revision (at configure time)
+ include (GetGit)
+ 
+

--- a/net-analyzer/openvas-scanner/openvas-scanner-20.8.1.ebuild
+++ b/net-analyzer/openvas-scanner/openvas-scanner-20.8.1.ebuild
@@ -51,6 +51,8 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.0.1-disable-automagic-dep.patch
+	#qa fix for rpath
+	"${FILESDIR}"/${P}-rpath-qa-fix.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/777723
Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Jonas Licht <jonas.licht@fem.tu-ilmenau.de>