### PR TITLE
dev-java/hamcrest-library: EAPI 7

### DIFF
--- a/dev-java/hamcrest-library/files/hamcrest-library-1.3-java-11.patch
+++ b/dev-java/hamcrest-library/files/hamcrest-library-1.3-java-11.patch
@@ -1,0 +1,44 @@
+--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
++++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInAnyOrder.java
+@@ -122,7 +122,7 @@ public class IsIterableContainingInAnyOrder<T> extends TypeSafeDiagnosingMatcher
+      */
+     @Factory
+     public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(Matcher<? super T>... itemMatchers) {
+-        return containsInAnyOrder(Arrays.asList(itemMatchers));
++        return containsInAnyOrder((List<Matcher<? super T>>) Arrays.asList(itemMatchers));
+     }
+ 
+     /**
+--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
++++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsIterableContainingInOrder.java
+@@ -138,7 +138,7 @@ public class IsIterableContainingInOrder<E> extends TypeSafeDiagnosingMatcher<It
+      */
+     @Factory
+     public static <E> Matcher<Iterable<? extends E>> contains(Matcher<? super E>... itemMatchers) {
+-        return contains(asList(itemMatchers));
++        return contains((List<Matcher<? super E>>) asList(itemMatchers));
+     }
+ 
+     /**
+--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
++++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsArrayContainingInAnyOrder.java
+@@ -55,7 +55,7 @@ public class IsArrayContainingInAnyOrder<E> extends TypeSafeMatcher<E[]> {
+      */
+     @Factory
+     public static <E> Matcher<E[]> arrayContainingInAnyOrder(Matcher<? super E>... itemMatchers) {
+-        return arrayContainingInAnyOrder(Arrays.asList(itemMatchers));
++        return arrayContainingInAnyOrder((List<Matcher<? super E>>) Arrays.asList(itemMatchers));
+     }
+ 
+     /**
+--- a/hamcrest-library/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
++++ b/hamcrest-library/src/main/java/org/hamcrest/collection/IsArrayContainingInOrder.java
+@@ -69,7 +69,7 @@ public class IsArrayContainingInOrder<E> extends TypeSafeMatcher<E[]> {
+      */
+     @Factory
+     public static <E> Matcher<E[]> arrayContaining(Matcher<? super E>... itemMatchers) {
+-        return arrayContaining(asList(itemMatchers));
++        return arrayContaining((List<Matcher<? super E>>) asList(itemMatchers));
+     }
+ 
+     /**

--- a/dev-java/hamcrest-library/hamcrest-library-1.3-r2.ebuild
+++ b/dev-java/hamcrest-library/hamcrest-library-1.3-r2.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="source"
+
+inherit java-pkg-2 java-pkg-simple
+
+MY_PN=${PN/-library}
+MY_P="${MY_PN}-${PV}"
+S="${WORKDIR}/${MY_P}"
+
+DESCRIPTION="Core library of matchers for building test expressions"
+HOMEPAGE="https://github.com/hamcrest"
+SRC_URI="mirror://gentoo/${MY_P}.tgz"
+
+LICENSE="BSD-2"
+SLOT="${PV}"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+
+DEPEND="dev-java/hamcrest-core:${SLOT}
+	>=virtual/jdk-1.8:*
+	userland_GNU? ( sys-apps/findutils )"
+RDEPEND="dev-java/hamcrest-core:${SLOT}
+	>=virtual/jre-1.8:*"
+BDEPEND=">=dev-java/hamcrest-generator-${PV}:1.3"
+
+JAVA_SRC_DIR="${PN}/src"
+JAVA_GENTOO_CLASSPATH="hamcrest-core-1.3"
+
+DOCS=( {CHANGES,LICENSE,README}.txt )
+
+PATCHES=(
+	"${FILESDIR}"/hamcrest-library-1.3-java-11.patch
+)
+
+src_prepare() {
+	default
+	java-pkg_clean
+}
+
+src_compile() {
+	java-pkg-simple_src_compile
+
+	# Generate "Matchers.java" (java-pkg-simple does not use the "build.xml" file)
+	"$(java-config -J)" \
+		-cp $(java-config --with-dependencies --classpath hamcrest-core:1.3,hamcrest-generator:1.3):${PN}.jar \
+		org.hamcrest.generator.config.XmlConfigurator \
+		matchers.xml \
+		hamcrest-core/src/main/java,hamcrest-library/src/main/java \
+		org.hamcrest.Matchers \
+		hamcrest-library/src/main/java
+
+	# Compile again, this time including the freshly generated "Matchers.java"
+	java-pkg-simple_src_compile
+}
+
+src_install() {
+	default
+	java-pkg-simple_src_install
+}

--- a/dev-java/hamcrest-library/metadata.xml
+++ b/dev-java/hamcrest-library/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Java</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="google-code">hamcrest</remote-id>
 		<remote-id type="github">hamcrest/</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Switch to java-pkg-simple
Adjustments for java 11
Use mirror://gentoo for SRC_URI
Remove obsolete remote-id

Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>