### PR TITLE
app-emulation/wine-*: remove redundant MERGE_TYPE check

### DIFF
--- a/app-emulation/wine-staging/wine-staging-6.4.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.4.ebuild
@@ -181,8 +181,6 @@ if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${MY_PV} == 9999 ]]; then
 fi
 
 wine_compiler_check() {
-	[[ ${MERGE_TYPE} = "binary" ]] && return 0
-
 	# GCC-specific bugs
 	if tc-is-gcc; then
 		# bug #549768

--- a/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-6.4.ebuild
@@ -153,8 +153,6 @@ if [[ ${#PATCHES_BIN[@]} -ge 1 ]] || [[ ${PV} == 9999 ]]; then
 fi
 
 wine_compiler_check() {
-	[[ ${MERGE_TYPE} = "binary" ]] && return 0
-
 	# GCC-specific bugs
 	if tc-is-gcc; then
 		# bug #549768


### PR DESCRIPTION
As requested by @gktrk.