### PR TITLE
app-text/texlive-core: Fix linker path with slibtool.

### DIFF
--- a/app-text/texlive-core/texlive-core-2020-r12.ebuild
+++ b/app-text/texlive-core/texlive-core-2020-r12.ebuild
@@ -167,6 +167,8 @@ src_prepare() {
 		-e "s,/usr/include /usr/local/include.*echo \$KPATHSEA_INCLUDES.*,${EPREFIX}/usr/include\"," \
 		texk/web2c/configure || die
 
+	sed -i 's/-L\. -lweb2c/libweb2c\.a/' texk/web2c/web2c/Makefile.in || die
+
 	eapply "${WORKDIR}"/patches
 
 	default


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/775170

rdlibtool shows the libtool command:
```
rdlibtool --tag=CC --mode=link x86_64-pc-linux-gnu-gcc -Wimplicit -Wreturn-type -O2 -pipe
-Wl,-O1 -Wl,--as-needed -o fixwrites fixwrites.o -L. -lweb2c
```
And the actual command:
```
rdlibtool: link: x86_64-pc-linux-gnu-gcc fixwrites.o -Wimplicit -Wreturn-type -O2 -pipe
-Wl,-O1 -Wl,--as-needed -L./.libs -lweb2c -o .libs/fixwrites
```
The problem is that `-L.` is transformed to `-L./.libs` since slibtool has no way of knowing that `libweb2c.a` static archive not created without libtool. Making the linker path more explicit solves the issue.