### PR TITLE
sys-auth/rtkit: Raised rtkit max RT prio for better PipeWire support

### DIFF
--- a/sys-auth/rtkit/files/rtkit-0.12_daemon_raise_max_rt_prio.patch
+++ b/sys-auth/rtkit/files/rtkit-0.12_daemon_raise_max_rt_prio.patch
@@ -1,0 +1,23 @@
+This trivial patch allows applications to request and receive
+realtime priority up to 88. This is now done by PipeWire starting
+with version 0.3.23.
+
+diff --git a/rtkit-daemon.c b/rtkit-daemon.c
+--- a/rtkit-daemon.c
++++ b/rtkit-daemon.c
+@@ -87,13 +87,13 @@ extern const char introspect_xml[];
+ #define TIMESPEC_MSEC(ts) (((int64_t) (ts).tv_sec * 1000LL) + ((int64_t) (ts).tv_nsec / 1000000LL))
+ 
+ /* If we actually execute a request we temporarily upgrade our realtime priority to this level */
+-static unsigned our_realtime_priority = 21;
++static unsigned our_realtime_priority = 89;
+ 
+ /* Normally we run at this nice level */
+ static int our_nice_level = 1;
+ 
+ /* The maximum realtime priority to hand out */
+-static unsigned max_realtime_priority = 20;
++static unsigned max_realtime_priority = 88;
+ 
+ /* The minimum nice level to hand out */
+ static int min_nice_level = -15;

--- a/sys-auth/rtkit/files/rtkit-0.13_daemon_raise_max_rt_prio.patch
+++ b/sys-auth/rtkit/files/rtkit-0.13_daemon_raise_max_rt_prio.patch
@@ -1,0 +1,23 @@
+This trivial patch allows applications to request and receive
+realtime priority up to 88. This is now done by PipeWire starting
+with version 0.3.23.
+
+diff --git a/rtkit-daemon.c b/rtkit-daemon.c
+--- a/rtkit-daemon.c
++++ b/rtkit-daemon.c
+@@ -89,13 +89,13 @@ static const char introspect_xml[] = {
+ #define TIMESPEC_MSEC(ts) (((int64_t) (ts).tv_sec * 1000LL) + ((int64_t) (ts).tv_nsec / 1000000LL))
+ 
+ /* If we actually execute a request we temporarily upgrade our realtime priority to this level */
+-static unsigned our_realtime_priority = 21;
++static unsigned our_realtime_priority = 89;
+ 
+ /* Normally we run at this nice level */
+ static int our_nice_level = 1;
+ 
+ /* The maximum realtime priority to hand out */
+-static unsigned max_realtime_priority = 20;
++static unsigned max_realtime_priority = 88;
+ 
+ /* The minimum nice level to hand out */
+ static int min_nice_level = -15;

--- a/sys-auth/rtkit/rtkit-0.12-r2.ebuild
+++ b/sys-auth/rtkit/rtkit-0.12-r2.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools linux-info
+
+DESCRIPTION="Realtime Policy and Watchdog Daemon"
+HOMEPAGE="https://github.com/heftig/rtkit"
+SRC_URI="https://github.com/heftig/${PN}/releases/download/v${PV}/${P}.tar.xz"
+
+LICENSE="GPL-3 BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="systemd"
+
+BDEPEND="virtual/pkgconfig"
+DEPEND="acct-group/rtkit
+	acct-user/rtkit
+	sys-apps/dbus
+	sys-auth/polkit
+	sys-libs/libcap
+	systemd? ( sys-apps/systemd )"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.12_introspection_no_asm.patch
+	"${FILESDIR}"/${PN}-0.12_libsystemd_optional.patch
+	"${FILESDIR}"/${PN}-0.12_daemon_raise_max_rt_prio.patch
+)
+
+pkg_pretend() {
+	if use kernel_linux; then
+		CONFIG_CHECK="~!RT_GROUP_SCHED"
+		ERROR_RT_GROUP_SCHED="CONFIG_RT_GROUP_SCHED is enabled. rtkit-daemon (or any other "
+		ERROR_RT_GROUP_SCHED+="real-time task) will not work unless run as root. Please consider "
+		ERROR_RT_GROUP_SCHED+="unsetting this option."
+		check_extra_config
+	fi
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable systemd systemd-integration)
+}

--- a/sys-auth/rtkit/rtkit-0.13-r2.ebuild
+++ b/sys-auth/rtkit/rtkit-0.13-r2.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit linux-info meson
+
+DESCRIPTION="Realtime Policy and Watchdog Daemon"
+HOMEPAGE="https://github.com/heftig/rtkit"
+SRC_URI="https://github.com/heftig/${PN}/releases/download/v${PV}/${P}.tar.xz"
+
+LICENSE="GPL-3 BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="systemd"
+
+BDEPEND="virtual/pkgconfig"
+DEPEND="acct-group/rtkit
+	acct-user/rtkit
+	sys-apps/dbus
+	sys-auth/polkit
+	sys-libs/libcap
+	systemd? ( sys-apps/systemd )"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.13_meson_rtkitctl_dir.patch
+	"${FILESDIR}"/${PN}-0.13_meson_xxd_optional.patch
+	"${FILESDIR}"/${PN}-0.13_daemon_raise_max_rt_prio.patch
+)
+
+pkg_pretend() {
+	if use kernel_linux; then
+		CONFIG_CHECK="~!RT_GROUP_SCHED"
+		ERROR_RT_GROUP_SCHED="CONFIG_RT_GROUP_SCHED is enabled. rtkit-daemon (or any other "
+		ERROR_RT_GROUP_SCHED+="real-time task) will not work unless run as root. Please consider "
+		ERROR_RT_GROUP_SCHED+="unsetting this option."
+		check_extra_config
+	fi
+}
+
+src_configure() {
+	local emesonargs=(
+		-Dinstalled_tests=false
+		$(meson_feature systemd libsystemd)
+	)
+	meson_src_configure
+}


### PR DESCRIPTION
Starting with PipeWire v0.3.23, it now requests realtime priority 88
but the historical default has been 20 to which PW's request
gets clamped to.

Due to both upstream's wishes and personal observations with regards
to PipeWire's performance with the patch applied, it would be great if
Gentoo could raise the default for sys-auth/rtkit out of the box.

This has no currently known drawbacks, in part because the other
widely used rtkit client is PulseAudio which should request RT
priority of 20, just like earlier versions of PW.

The only changes are to KEYWORDS and adding patches to the PATCHES array, so I'd like this to go through without being required to do an ebuild overhaul.