### PR TITLE
sci-libs/cantera: pass AR env variable. Add lapack support.

### DIFF
--- a/sci-libs/cantera/cantera-2.5.1-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.5.1-r1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://github.com/Cantera/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="+cti fortran pch +python test"
+IUSE="+cti fortran lapack pch +python test"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
@@ -27,6 +27,7 @@ REQUIRED_USE="
 
 RDEPEND="
 	${PYTHON_DEPS}
+	lapack? ( virtual/lapack )
 	python? (
 		$(python_gen_cond_dep '
 			dev-python/numpy[${PYTHON_MULTI_USEDEP}]
@@ -34,7 +35,7 @@ RDEPEND="
 		')
 	)
 	dev-cpp/yaml-cpp
-	<sci-libs/sundials-5.3.0:0=
+	<sci-libs/sundials-5.3.0:0=[lapack?]
 "
 
 DEPEND="
@@ -88,6 +89,7 @@ src_configure() {
 		env_vars="all"
 		extra_inc_dirs="/usr/include/eigen3"
 	)
+	use lapack && scons_vars+=( blas_lapack_libs="lapack,blas" )
 	use test || scons_vars+=( googletest="none" )
 
 	scons_targets=(

--- a/sci-libs/cantera/cantera-2.5.1-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.5.1-r1.ebuild
@@ -1,0 +1,138 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7,8,9} )
+
+FORTRAN_NEEDED=fortran
+FORTRAN_STANDARD="77 90"
+
+inherit desktop fortran-2 python-single-r1 scons-utils toolchain-funcs
+
+DESCRIPTION="Object-oriented tool suite for chemical kinetics, thermodynamics, and transport"
+HOMEPAGE="https://www.cantera.org"
+SRC_URI="https://github.com/Cantera/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+cti fortran pch +python test"
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="
+	python? ( cti )
+	${PYTHON_REQUIRED_USE}
+"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	python? (
+		$(python_gen_cond_dep '
+			dev-python/numpy[${PYTHON_MULTI_USEDEP}]
+			dev-python/ruamel-yaml[${PYTHON_MULTI_USEDEP}]
+		')
+	)
+	dev-cpp/yaml-cpp
+	<sci-libs/sundials-5.3.0:0=
+"
+
+DEPEND="
+	${RDEPEND}
+	dev-cpp/eigen:3
+	dev-libs/boost
+	dev-libs/libfmt
+	python? (
+		$(python_gen_cond_dep '
+			dev-python/cython[${PYTHON_MULTI_USEDEP}]
+		')
+	)
+	test? (
+		>=dev-cpp/gtest-1.8.0
+		python? (
+			$(python_gen_cond_dep '
+				dev-python/h5py[${PYTHON_MULTI_USEDEP}]
+				dev-python/pandas[${PYTHON_MULTI_USEDEP}]
+			')
+		)
+	)
+"
+
+PATCHES=( "${FILESDIR}/${P}_env.patch" )
+
+pkg_setup() {
+	fortran-2_pkg_setup
+	python-single-r1_pkg_setup
+}
+
+## Full list of configuration options of Cantera is presented here:
+## http://cantera.org/docs/sphinx/html/compiling/config-options.html
+src_configure() {
+	scons_vars=(
+		AR="$(tc-getAR)"
+		CC="$(tc-getCC)"
+		CXX="$(tc-getCXX)"
+		cc_flags="${CXXFLAGS}"
+		cxx_flags="-std=c++11"
+		debug="no"
+		FORTRAN="$(tc-getFC)"
+		FORTRANFLAGS="${FCFLAGS}"
+		optimize_flags="-Wno-inline"
+		renamed_shared_libraries="no"
+		use_pch=$(usex pch)
+		## In some cases other order can break the detection of right location of Boost: ##
+		system_fmt="y"
+		system_sundials="y"
+		system_eigen="y"
+		system_yamlcpp="y"
+		env_vars="all"
+		extra_inc_dirs="/usr/include/eigen3"
+	)
+	use test || scons_vars+=( googletest="none" )
+
+	scons_targets=(
+		f90_interface=$(usex fortran y n)
+	)
+
+	if use cti ; then
+		local scons_python=$(usex python full minimal)
+		scons_targets+=( python_package="${scons_python}" python_cmd="${EPYTHON}" )
+	else
+		scons_targets+=( python_package="none" )
+	fi
+}
+
+src_compile() {
+	escons build "${scons_vars[@]}" "${scons_targets[@]}" prefix="/usr"
+}
+
+src_test() {
+	escons test
+}
+
+src_install() {
+	escons install stage_dir="${D}" libdirname="$(get_libdir)" python_prefix="$(python_get_sitedir)"
+	if ! use cti ; then
+		rm -r "${D}/usr/share/man" || die "Can't remove man files."
+	else
+		# Run the byte-compile of modules
+		python_optimize "${D}/$(python_get_sitedir)/${PN}"
+	fi
+
+	# We install static libs unconditionally here
+	# See https://github.com/gentoo/gentoo/pull/10017#discussion_r229210565
+}
+
+pkg_postinst() {
+	if use cti && ! use python ; then
+		elog "Cantera was build without 'python' use-flag therefore the CTI tools 'ck2cti' and 'ck2yaml"
+		elog "will convert Chemkin files to Cantera format without verification of kinetic mechanism."
+	fi
+
+	local post_msg=$(usex fortran "and Fortran " "")
+	elog "C++ ${post_msg}samples are installed to '/usr/share/${PN}/samples/' directory."
+
+	if use python ; then
+		elog "Python examples are installed to '$(python_get_sitedir)/${PN}/examples/' directories."
+	fi
+}

--- a/sci-libs/cantera/files/cantera-2.5.1_env.patch
+++ b/sci-libs/cantera/files/cantera-2.5.1_env.patch
@@ -1,0 +1,59 @@
+diff -Naur old/SConstruct new/SConstruct
+--- old/SConstruct	2021-03-21 01:18:43.000000000 +0300
++++ new/SConstruct	2021-03-21 01:27:06.000000000 +0300
+@@ -193,7 +193,7 @@
+     toolchain = ['default']
+ 
+ env = Environment(tools=toolchain+['textfile', 'subst', 'recursiveInstall', 'wix', 'gch'],
+-                  ENV={'PATH': os.environ['PATH']},
++                  ENV={'PATH': os.environ['PATH'], 'CCACHE_DIR': os.environ.get('CCACHE_DIR','')},
+                   toolchain=toolchain,
+                   **extraEnvArgs)
+ 
+@@ -239,6 +239,9 @@
+     sys.exit(1)
+ 
+ compiler_options = [
++     ('AR',
++     """The archiver to use.""",
++     env['AR']),
+     ('CXX',
+      """The C++ compiler to use.""",
+      env['CXX']),
+@@ -734,10 +734,7 @@
+ env['cantera_pure_version'] = re.match(r'(\d+\.\d+\.\d+)', env['cantera_version']).group(0)
+ env['cantera_short_version'] = re.match(r'(\d+\.\d+)', env['cantera_version']).group(0)
+ 
+-try:
+-    env['git_commit'] = getCommandOutput('git', 'rev-parse', '--short', 'HEAD')
+-except Exception:
+-    env['git_commit'] = 'unknown'
++env['git_commit'] = 'unknown'
+ 
+ # Print values of all build options:
+ print("Configuration variables read from 'cantera.conf' and command line:")
+diff -Naur old/interfaces/cython/SConscript new/interfaces/cython/SConscript
+--- old/interfaces/cython/SConscript	2021-03-21 01:18:43.000000000 +0300
++++ new/interfaces/cython/SConscript	2021-03-21 01:59:29.000000000 +0300
+@@ -108,8 +108,7 @@
+     elif localenv['libdirname'] != 'lib':
+         # 64-bit RHEL / Fedora etc. or e.g. x32 Gentoo profile
+         extra = localenv.subst(
+-            ' --prefix=${{python_prefix}}'
+-            ' --install-lib=${{python_prefix}}/${{libdirname}}/python{}/site-packages'.format(py_version))
++            ' --prefix=${stage_dir}${prefix} --install-lib=${python_prefix}')
+     else:
+         extra = '--user'
+         localenv.AppendENVPath(
+diff -Naur old/test_problems/SConscript new/test_problems/SConscript
+--- old/test_problems/SConscript	2021-03-21 01:18:43.000000000 +0300
++++ new/test_problems/SConscript	2021-03-21 01:42:19.000000000 +0300
+@@ -222,7 +222,7 @@
+ CompileAndTest('VPsilane_test')
+ 
+ CompileAndTest('clib', 'clib_test', 'clib_test',
+-               extensions=['^clib_test.c'], libs=['cantera_shared'])
++               extensions=['^clib_test.c'])
+ 
+ # C++ Samples
+ Test('cxx-bvp', 'cxx_samples', '#build/samples/cxx/bvp/blasius', None,


### PR DESCRIPTION
* Pass AR env variable to be able to use llvm-ar instead of ar.
Closes: https://bugs.gentoo.org/773541

* Add lapack support

@asarubbo 
please check if this PR (especially first commit) fixes the issue.