### PR TITLE
dev-lang/python: Added pgo USE flag

### DIFF
--- a/dev-lang/python/metadata.xml
+++ b/dev-lang/python/metadata.xml
@@ -7,6 +7,7 @@
 </maintainer>
 <use>
 	<flag name="bluetooth">Build Bluetooth protocol support in socket module</flag>
+	<flag name="pgo">Build with profile guided optimizations (PGO)</flag>
 	<flag name="threads">Enable threading support. (DON'T DISABLE THIS UNLESS YOU KNOW WHAT YOU'RE DOING)</flag>
 	<flag name="wide-unicode">Enable wide Unicode implementation which uses 4-byte Unicode characters. Switching of this USE flag changes ABI of Python and requires reinstallation of many Python modules. (DON'T DISABLE THIS UNLESS YOU KNOW WHAT YOU'RE DOING)</flag>
 	<flag name="wininst">Install Windows executables required to create an executable installer for MS Windows.</flag>

--- a/dev-lang/python/python-3.10.0_alpha5.ebuild
+++ b/dev-lang/python/python-3.10.0_alpha5.ebuild
@@ -23,7 +23,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="PSF-2"
 SLOT="${PYVER}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test tk wininst +xml"
+IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses pgo +readline sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -178,6 +178,7 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+		$(use_enable pgo optimizations)
 	)
 
 	OPT="" econf "${myeconfargs[@]}"

--- a/dev-lang/python/python-3.10.0_alpha5_p1.ebuild
+++ b/dev-lang/python/python-3.10.0_alpha5_p1.ebuild
@@ -24,7 +24,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="PSF-2"
 SLOT="${PYVER}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test tk wininst +xml"
+IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses pgo +readline sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -179,6 +179,7 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+		$(use_enable pgo optimizations)
 	)
 
 	OPT="" econf "${myeconfargs[@]}"

--- a/dev-lang/python/python-3.10.0_alpha6-r1.ebuild
+++ b/dev-lang/python/python-3.10.0_alpha6-r1.ebuild
@@ -24,7 +24,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="PSF-2"
 SLOT="${PYVER}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test tk wininst +xml"
+IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses pgo +readline sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -185,6 +185,7 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+		$(use_enable pgo optimizations)
 	)
 
 	OPT="" econf "${myeconfargs[@]}"

--- a/dev-lang/python/python-3.10.0_alpha6-r2.ebuild
+++ b/dev-lang/python/python-3.10.0_alpha6-r2.ebuild
@@ -24,7 +24,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="PSF-2"
 SLOT="${PYVER}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline +sqlite +ssl test tk wininst +xml"
+IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses pgo +readline +sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -181,6 +181,7 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+		$(use_enable pgo optimizations)
 	)
 
 	OPT="" econf "${myeconfargs[@]}"

--- a/dev-lang/python/python-3.8.7-r1.ebuild
+++ b/dev-lang/python/python-3.8.7-r1.ebuild
@@ -23,7 +23,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="PSF-2"
 SLOT="${PYVER}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86"
-IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline sqlite +ssl test tk wininst +xml"
+IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses pgo +readline sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -165,6 +165,7 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+		$(use_enable pgo optimizations)
 	)
 
 	OPT="" econf "${myeconfargs[@]}"

--- a/dev-lang/python/python-3.8.8.ebuild
+++ b/dev-lang/python/python-3.8.8.ebuild
@@ -24,7 +24,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="PSF-2"
 SLOT="${PYVER}"
 KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
-IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline +sqlite +ssl test tk wininst +xml"
+IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses pgo +readline +sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -166,6 +166,7 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+		$(use_enable pgo optimizations)
 	)
 
 	OPT="" econf "${myeconfargs[@]}"

--- a/dev-lang/python/python-3.9.2.ebuild
+++ b/dev-lang/python/python-3.9.2.ebuild
@@ -24,7 +24,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="PSF-2"
 SLOT="${PYVER}"
 KEYWORDS="~alpha amd64 ~arm ~arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
-IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses +readline +sqlite +ssl test tk wininst +xml"
+IUSE="bluetooth build examples gdbm hardened ipv6 libressl +ncurses pgo +readline +sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -177,6 +177,7 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+		$(use_enable pgo optimizations)
 	)
 
 	OPT="" econf "${myeconfargs[@]}"


### PR DESCRIPTION
Tested on `amd64`, the test benchmarks successfully run with:

- 3.8.7-r1
- 3.8.8
- 3.9.2
- 3.10.0a6-r2