### PR TITLE
media-libs/libsdl2: Fix --disable-static patch for slibtool.

### DIFF
--- a/media-libs/libsdl2/files/libsdl2-2.0.14-static-libs.patch
+++ b/media-libs/libsdl2/files/libsdl2-2.0.14-static-libs.patch
@@ -24,11 +24,11 @@ Bug: https://bugzilla.libsdl.org/show_bug.cgi?id=1431
  
  $(objects)/$(SDLMAIN_TARGET): $(SDLMAIN_OBJECTS)
 -	$(RUN_CMD_LTLINK)$(LIBTOOL) --tag=CC --mode=link $(CC) -static -o $@ $(SDLMAIN_OBJECTS) -rpath $(libdir)
-+	$(RUN_CMD_LTLINK)$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS) -all-static
++	$(RUN_CMD_LTLINK)$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS) -static
  
  $(objects)/$(SDLTEST_TARGET): $(SDLTEST_OBJECTS)
 -	$(RUN_CMD_LTLINK)$(LIBTOOL) --tag=CC --mode=link $(CC) -static -o $@ $(SDLTEST_OBJECTS) -rpath $(libdir)
-+	$(RUN_CMD_LTLINK)$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS) -all-static
++	$(RUN_CMD_LTLINK)$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS) -static
  
  install: all install-bin install-hdrs install-lib install-data
  install-bin:


### PR DESCRIPTION
With slibtool both `libSDL2main.a` and `libSDL2_test.a` fail to install. This was fixed in slibtool here.

https://dev.midipix.org/cross/slibtool/c/9a5f9681f88126c47e11ef49e7fb01c604c90986?branch=main

However using it still does not work in gentoo with `-all-static`, but works fine if its changed back to `-static` as is done upstream in SDL2. GNU libtool does not seem to behave any differently here and its unclear why this was ever changed?

Its also possible to entirely drop the patch, I am not sure it does anything useful for gentoo anymore?

Also see this slibtool issue:

https://dev.midipix.org/cross/slibtool/issue/28