### PR TITLE
app-admin/ulogd: varius updates (read first comment)

### DIFF
--- a/acct-group/ulogd/metadata.xml
+++ b/acct-group/ulogd/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person" proxied="yes">
+		<email>marco@scardovi.com</email>
+		<name>Marco Scardovi</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/ulogd/ulogd-0.ebuild
+++ b/acct-group/ulogd/ulogd-0.ebuild
@@ -1,0 +1,9 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+DESCRIPTION="Group for ulogd"
+ACCT_GROUP_ID=189

--- a/acct-user/ulogd/metadata.xml
+++ b/acct-user/ulogd/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person" proxied="yes">
+		<email>marco@scardovi.com</email>
+		<name>Marco Scardovi</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/ulogd/ulogd-0.ebuild
+++ b/acct-user/ulogd/ulogd-0.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="User for ulogd"
+ACCT_USER_ID=189
+ACCT_USER_GROUPS=( ulogd )
+
+acct-user_add_deps

--- a/app-admin/ulogd/files/patches/ulogd.patch
+++ b/app-admin/ulogd/files/patches/ulogd.patch
@@ -1,0 +1,10 @@
+--- a/src/ulogd.c
++++ b/src/ulogd.c
+@@ -65,6 +65,7 @@
+ #include <sys/time.h>
+ #include <sys/stat.h>
+ #include <sched.h>
++#include <limits.h>
+ #include <ulogd/conffile.h>
+ #include <ulogd/ulogd.h>
+ #ifdef DEBUG

--- a/app-admin/ulogd/metadata.xml
+++ b/app-admin/ulogd/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>marco@scardovi.com</email>
+		<name>Marco Scardovi</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<use>
 		<flag name="json">Build JSON output plugin to save packets in JSON file format</flag>
 		<flag name="pcap">Build PCAP output plugin to save packets in libpcap file format</flag>

--- a/app-admin/ulogd/ulogd-2.0.7-r2.ebuild
+++ b/app-admin/ulogd/ulogd-2.0.7-r2.ebuild
@@ -1,0 +1,140 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic linux-info readme.gentoo-r1 systemd
+
+DESCRIPTION="A userspace logging daemon for netfilter/iptables related logging"
+HOMEPAGE="https://netfilter.org/projects/ulogd/index.html"
+SRC_URI="https://www.netfilter.org/projects/ulogd/files/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ia64 ~ppc ~x86"
+IUSE="dbi doc json mysql nfacct +nfct +nflog pcap postgres selinux sqlite ulog"
+
+COMMON_DEPEND="
+	|| ( net-firewall/iptables net-firewall/nftables )
+	>=net-libs/libnfnetlink-1.0.1
+	dbi? ( dev-db/libdbi )
+	json? ( dev-libs/jansson )
+	nfacct? (
+		>=net-libs/libmnl-1.0.4
+		>=net-libs/libnetfilter_acct-1.0.3
+	)
+	nfct? ( >=net-libs/libnetfilter_conntrack-1.0.6 )
+	nflog? ( >=net-libs/libnetfilter_log-1.0.1 )
+	mysql? ( dev-db/mysql-connector-c:= )
+	pcap? ( net-libs/libpcap )
+	postgres? ( dev-db/postgresql:= )
+	sqlite? ( dev-db/sqlite:3 )
+"
+
+DEPEND="${COMMON_DEPEND}
+	acct-user/ulogd
+	acct-group/ulogd
+	doc? (
+		app-text/linuxdoc-tools
+		app-text/texlive-core
+		dev-texlive/texlive-fontsrecommended
+		virtual/latex-base
+	)
+"
+
+RDEPEND="${COMMON_DEPEND}
+	selinux? ( sec-policy/selinux-ulogd )
+"
+
+DISABLE_AUTOFORMATTING=1
+DOC_CONTENTS="
+	You must have at least one logging stack enabled to make ulogd work.
+	Please edit the example configuration located at '${EPREFIX}/etc/ulogd.conf'.
+"
+
+PATCHES=( "${FILESDIR}"/patches/ulogd.patch )
+
+pkg_setup() {
+	linux-info_pkg_setup
+
+	if use nfacct && kernel_is lt 3 3 0; then
+		ewarn "NFACCT input plugin requires a kernel >= 3.3."
+	fi
+
+	if use ulog && kernel_is ge 3 17 0; then
+		ewarn "ULOG target has been removed in the 3.17 kernel release."
+		ewarn "Consider enabling NFACCT, NFCT, or NFLOG support instead."
+	fi
+}
+
+src_prepare() {
+	default_src_prepare
+
+	# Change default settings to:
+	# - keep log files in /var/log/ulogd instead of /var/log;
+	# - create sockets in /run instead of /tmp.
+	sed -i \
+		-e "s|var/log|var/log/${PN}|g" \
+		-e 's|tmp|run|g' \
+		ulogd.conf.in || die
+}
+
+src_configure() {
+	append-lfs-flags
+	local myeconfargs=(
+		$(use_with dbi)
+		$(use_with json jansson)
+		$(use_enable nfacct)
+		$(use_enable nfct)
+		$(use_enable nflog)
+		$(use_with mysql)
+		$(use_with pcap)
+		$(use_with postgres pgsql)
+		$(use_with sqlite)
+		$(use_enable ulog)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	default_src_compile
+
+	if use doc; then
+		# Prevent access violations from bitmap font files generation.
+		export VARTEXFONTS="${T}/fonts"
+		emake -C doc
+	fi
+}
+
+src_install() {
+	use doc && HTML_DOCS=( doc/${PN}.html )
+
+	default_src_install
+	find "${D}" -name '*.la' -delete || die
+
+	readme.gentoo_create_doc
+	doman ${PN}.8
+
+	use doc && dodoc doc/${PN}.{dvi,ps,txt}
+	use mysql && dodoc doc/mysql-*.sql
+	use postgres && dodoc doc/pgsql-*.sql
+	use sqlite && dodoc doc/sqlite3.table
+
+	insinto /etc
+	doins ${PN}.conf
+	fowners root:ulogd /etc/${PN}.conf
+	fperms 640 /etc/${PN}.conf
+
+	newinitd "${FILESDIR}/${PN}.init" ${PN}
+	systemd_dounit "${FILESDIR}/${PN}.service"
+
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}/${PN}.logrotate" ${PN}
+
+	diropts -o ulogd -g ulogd
+	keepdir /var/log/ulogd
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
List of changes:

Moving to EAPI 7,
Changed inherit user with proper acct-user and acct-group: this will fix the "move to GLEP 81" error on repoman,
Updated libnetfilter_acct from 1.0.1 to 1.0.3: this will fix QA error on #20049,
Tested both on gcc and musl: added a patch for musl, this will fix https://bugs.gentoo.org/715466.

Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Marco Scardovi <marco@scardovi.com>