### PR TITLE
net-im/bitlbee: add python 3.9 support

### DIFF
--- a/net-im/bitlbee/bitlbee-3.6-r1.ebuild
+++ b/net-im/bitlbee/bitlbee-3.6-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..8} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit python-any-r1 systemd toolchain-funcs
 

--- a/net-im/bitlbee/bitlbee-9999.ebuild
+++ b/net-im/bitlbee/bitlbee-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..8} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit python-any-r1 systemd toolchain-funcs
 


### PR DESCRIPTION
This is just simple python version bump.