### PR TITLE
app-admin/gentoo-rsync-mirror: dropped EAPI=5

### DIFF
--- a/app-admin/gentoo-rsync-mirror/files/gentoo-mirror.conf
+++ b/app-admin/gentoo-rsync-mirror/files/gentoo-mirror.conf
@@ -2,8 +2,10 @@
 
 RSYNC="/usr/bin/rsync"
 OPTS="--quiet --recursive --links --perms --times --devices --specials --delete --timeout=300"
+
 #Uncomment the following line only if you have been granted access to rsync1.us.gentoo.org
 #SRC="rsync://rsync1.us.gentoo.org/gentoo-portage"
+
 #If you are waiting for access to our master mirror, select one of our mirrors to mirror from:
 SRC="rsync://rsync.de.gentoo.org/gentoo-portage"
 DST="/opt/gentoo-rsync/portage/"

--- a/app-admin/gentoo-rsync-mirror/gentoo-rsync-mirror-1.0-r6.ebuild
+++ b/app-admin/gentoo-rsync-mirror/gentoo-rsync-mirror-1.0-r6.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Ebuild for setting up a Gentoo rsync mirror"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Infrastructure/Rsync"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+
+S="${WORKDIR}"
+
+src_install() {
+	exeinto /opt/gentoo-rsync
+	doexe "${FILESDIR}"/rsync-gentoo-portage.sh
+	doexe "${FILESDIR}"/rsynclogparse-extended.pl
+	insinto etc/rsync
+	doins "${FILESDIR}"/rsyncd.conf
+	doins "${FILESDIR}"/rsyncd.motd
+	doins "${FILESDIR}"/gentoo-mirror.conf
+	dodir /opt/gentoo-rsync/portage
+}
+
+pkg_postinst() {
+	elog "The rsync-mirror is now installed into /opt/gentoo-rsync"
+	elog "The local portage copy resides in /opt/gentoo-rsync/portage"
+	elog "Please change /opt/gentoo-rsync/rsync-gentoo-portage.sh for"
+	elog "configuration of your main rsync server and use it to sync."
+	elog "Change /etc/rsync/rsyncd.motd to display your correct alias."
+	elog
+	elog "RSYNC_OPTS="--config=/etc/rsync/rsyncd.conf" needs"
+	elog "to be set in /etc/conf.d/rsyncd to make allow syncing."
+	elog
+	elog "The service can be started using /etc/init.d/rsyncd start"
+	elog "If you are setting up an official mirror, don't forget to add"
+	elog "00,30 * * * *      root    /opt/gentoo-rsync/rsync-gentoo-portage.sh"
+	elog "to your /etc/crontab to sync your tree every 30 minutes."
+	elog
+	elog "If you are setting up a private (unofficial) mirror, you can add"
+	elog "0 3 * * *	root	/opt/gentoo-rsync/rsync-gentoo-portage.sh"
+	elog "to your /etc/crontab to sync your tree once per day."
+	elog
+	elog "****IMPORTANT****"
+	elog "If you are setting up a private mirror, DO NOT sync against the"
+	elog "gentoo.org official rotations more than once a day.  Doing so puts"
+	elog "you at risk of having your IP address banned from the rotations."
+	elog
+	elog "For more information visit: https://wiki.gentoo.org/wiki/Project:Infrastructure/Rsync"
+}


### PR DESCRIPTION
I have only dropped EAPI 5 in favour of EAPI 7 and added some spaces in files/gentoo-mirror.conf for better read, nothing else

Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Marco Scardovi <marco@scardovi.com>