### PR TITLE
media-video/mpv: Pre-emptively block libplacebo's 3.104 series.

### DIFF
--- a/media-video/mpv/mpv-0.33.1-r1.ebuild
+++ b/media-video/mpv/mpv-0.33.1-r1.ebuild
@@ -93,7 +93,7 @@ COMMON_DEPEND="
 	vaapi? ( x11-libs/libva:=[drm?,X?,wayland?] )
 	vdpau? ( x11-libs/libvdpau )
 	vulkan? (
-		media-libs/libplacebo:=[vulkan]
+		<media-libs/libplacebo-3.104.0:=[vulkan]
 		media-libs/shaderc
 	)
 	wayland? (


### PR DESCRIPTION
Hello, I was looking at b.g.o and noticed three not that serious but easy to fix dependency bugs for media-video/mpv, so I made a patch for all three of them in one go.

A special thanks to Ionen Wolkens for helping me with these (as well as describing how to fix each one on b.g.o), as well as everyone else on #gentoo-proxy-maint IRC room.

If anything is wrong with what I changed, please let me know, and I'll try to fix that.