### PR TITLE
x11-drivers/xf86-video-amdgpu: Adds postinst elog to fix #778494

### DIFF
--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-19.1.0.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-19.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -29,4 +29,15 @@ pkg_setup() {
 		--enable-glamor
 		$(use_enable udev)
 	)
+}
+
+pkg_postinst() {
+	# Workaround for #778494
+	elog "To use the amdgpu X11 driver, be sure to add the following lines to the"
+	elog "${EROOT}/etc/X11/xorg.conf file"
+	elog "Section \"Module\""
+	elog "  Load \"fb\""
+	elog "  Load \"shadow\""
+	elog "  Load \"glamoregl\""
+	elog "EndSection"
 }

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -25,4 +25,15 @@ pkg_setup() {
 		--enable-glamor
 		$(use_enable udev)
 	)
+}
+
+pkg_postinst() {
+	# Workaround for #778494
+	elog "To use the amdgpu X11 driver, be sure to add the following lines to the"
+	elog "${EROOT}/etc/X11/xorg.conf file"
+	elog "Section \"Module\""
+	elog "  Load \"fb\""
+	elog "  Load \"shadow\""
+	elog "  Load \"glamoregl\""
+	elog "EndSection"
 }


### PR DESCRIPTION
Due to EAPI=7 changes described in #661502 , the amdgpu DDX does not
work out of the box. This commit introduces an elog message
detailing the workaround that AMDGPU users on Gentoo need to apply
manually to get a working Xorg server.

Closes: https://bugs.gentoo.org/778494
Signed-off-by: Niklāvs Koļesņikovs <89q1r14hd@relay.firefox.com>

Also updated the ebuild header with the current year, of course.