### PR TITLE
dev-libs/ocl-icd: Ruby Fixes

### DIFF
--- a/dev-libs/ocl-icd/ocl-icd-2.2.14-r1.ebuild
+++ b/dev-libs/ocl-icd/ocl-icd-2.2.14-r1.ebuild
@@ -36,6 +36,19 @@ multilib_src_configure() {
 	ECONF_SOURCE="${S}" econf --enable-pthread-once --disable-official-khronos-headers
 }
 
+multilib_src_compile() {
+	local candidates=(${USE_RUBY})
+	local ruby=
+	for (( idx=${#candidates[@]}-1 ; idx>=0 ; idx-- )) ; do
+		if ${candidates[idx]} --version &> /dev/null; then
+			ruby=${candidates[idx]} && break
+		fi
+	done
+	[[ -z ${ruby} ]] && die "No ruby executable found"
+
+	emake RUBY=${ruby}
+}
+
 multilib_src_install() {
 	default
 

--- a/dev-libs/ocl-icd/ocl-icd-2.2.14-r1.ebuild
+++ b/dev-libs/ocl-icd/ocl-icd-2.2.14-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+USE_RUBY="ruby25 ruby26 ruby27"
+inherit autotools flag-o-matic multilib-minimal ruby-single
+
+DESCRIPTION="Alternative to vendor specific OpenCL ICD loaders"
+HOMEPAGE="https://github.com/OCL-dev/ocl-icd"
+SRC_URI="https://github.com/OCL-dev/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+# Does nothing now but by keeping it here we avoid having to have virtual/opencl
+# handle ebuilds both with and without this flag.
+IUSE="+khronos-headers"
+
+BDEPEND="${RUBY_DEPS}"
+DEPEND=">=dev-util/opencl-headers-2020.12.18"
+RDEPEND="${DEPEND}
+	!app-eselect/eselect-opencl
+	!dev-libs/opencl-icd-loader"
+
+src_prepare() {
+	replace-flags -Os -O2 # bug 646122
+
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	# dev-util/opencl-headers ARE official Khronos Group headers, what this option
+	# does is disable the use of the bundled ones
+	ECONF_SOURCE="${S}" econf --enable-pthread-once --disable-official-khronos-headers
+}
+
+multilib_src_install() {
+	default
+
+	# Drop .la files
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/dev-libs/ocl-icd/ocl-icd-2.2.14-r1.ebuild
+++ b/dev-libs/ocl-icd/ocl-icd-2.2.14-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-USE_RUBY="ruby25 ruby26 ruby27"
+USE_RUBY="ruby25 ruby26 ruby27 ruby30"
 inherit autotools flag-o-matic multilib-minimal ruby-single
 
 DESCRIPTION="Alternative to vendor specific OpenCL ICD loaders"


### PR DESCRIPTION
- **dev-libs/ocl-icd: Remove ruby24 from USE_RUBY**
dev-lang/ruby:2.4 is no longer in the gentoo tree.

- **dev-libs/ocl-icd: Fix ruby BDEP selection**
The Makefile sets RUBY=ruby.  The active ruby interpreter set via
eselect may not correspond to one that satisfies ${RUBY_DEPS}. Test
for the existence of a versioned ruby from among USE_RUBY, moving from
right to left, and pass it to emake.

- **dev-libs/ocl-icd: Add support for dev-lang/ruby:3.0**
Having tested ruby26, ruby27, and ruby30 with the command the build
uses to generate files (i.e., ${RUBY} "${S}"/icd_generator.rb --mode
database --database "${S}"/ocl_interface.yaml) and diffed the results,
all generated files are exactly the same.
Closes: https://bugs.gentoo.org/704056
Closes: https://bugs.gentoo.org/766261

Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Peter Levine <plevine457@gmail.com>