### PR TITLE
dev-java/jflex: restrict test

### DIFF
--- a/dev-java/jflex/jflex-1.6.1-r1.ebuild
+++ b/dev-java/jflex/jflex-1.6.1-r1.ebuild
@@ -15,7 +15,7 @@ LICENSE="BSD"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ppc64 ~x86 ~ppc-macos ~x64-macos"
 IUSE="examples test vim-syntax"
-RESTRICT="!test? ( test )"
+RESTRICT="test" # https://bugs.gentoo.org/778416
 
 CDEPEND="dev-java/ant-core:0"
 


### PR DESCRIPTION
Restrict test for now although tests did not fail here.
I am planning to rewrite the ebuild for [proper bootstrapping](https://github.com/jflex-de/jflex/issues/278) and care for working tests later.
