### PR TITLE
media-gfx/xpaint: fix emerging with `rdlibtool`

### DIFF
--- a/media-gfx/xpaint/files/xpaint-3.1.3-libtool-clang.patch
+++ b/media-gfx/xpaint/files/xpaint-3.1.3-libtool-clang.patch
@@ -1,26 +1,51 @@
 libtool doesn't work if compiling with clang.  Need to add --tag=CC
-Also don't hardcode /usr/bin/tool in gentoo prefix
+Don't hardcode /usr/bin/libtool in gentoo prefix
 See bug https://bugs.gentoo.org/731010
+
+rdlibtool needs to find system libtool in current directory
+See bug https://bugs.gentoo.org/778791
 --- a/configure.ac
 +++ b/configure.ac
-@@ -17,6 +17,9 @@
+@@ -17,6 +17,10 @@
  AC_LANG_C
  AM_PROG_AR
  
-+dnl search libtool
-+AC_PATH_PROG([PROGLIBTOOL], [libtool])
++dnl libtool
++LT_INIT
++AC_SUBST([LIBTOOL_DEPS])
 +
  ## basic types
  
  AC_TYPE_INT8_T
 --- a/xpaintrw/Makefile.am
 +++ b/xpaintrw/Makefile.am
-@@ -28,7 +28,7 @@
+@@ -28,7 +28,8 @@
  
  xpaint_DEFINES = $(ARCH_DEFINES) $(EXTRA_DEFINES) $(XAWLIB_DEFINES)
  
 -LIBTOOL = /usr/bin/libtool
-+LIBTOOL = @PROGLIBTOOL@ --tag=CC
++LIBTOOL = ../libtool
++AM_LIBTOOLFLAGS = --tag=CC
  AM_CFLAGS   = @X_CFLAGS@ @SPECIAL_CFLAGS@ $(xpaint_DEFINES)
  AM_YFLAGS     = -d
  CLEANFILES    = 
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -53,12 +53,16 @@
+ dist_man_MANS = xpaint.1 imgmerge.1
+ AM_CFLAGS   = @X_CFLAGS@ @SPECIAL_CFLAGS@ $(xpaint_DEFINES)
+ ACLOCAL_AMFLAGS = -I m4
+-BUILT_SOURCES = version.h DefaultRC.txt.h messages.h XPaint.ad.h xpaint.1
++BUILT_SOURCES = version.h DefaultRC.txt.h messages.h XPaint.ad.h xpaint.1 libtool
+ AM_YFLAGS     = -d
+ CLEANFILES    = preproc substads \
+ 	version.h DefaultRC.txt.h messages.h XPaint.ad.h xpaint.1
+ EXTRA_DIST    = 
+ 
++LIBTOOL_DEPS = @LIBTOOL_DEPS@
++libtool:
++	$(SHELL) ./config.status libtool
++
+ BASE_HDRS = bitmap.h color.h crc32.h \
+ 	Colormap.h ColormapP.h graphic.h hash.h image.h \
+ 	menu.h messages.h misc.h operation.h ops.h \

--- a/media-gfx/xpaint/xpaint-3.1.3.ebuild
+++ b/media-gfx/xpaint/xpaint-3.1.3.ebuild
@@ -40,7 +40,6 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	sys-devel/bison
 	sys-devel/flex
-	sys-devel/libtool
 	virtual/pkgconfig
 	x11-misc/imake
 "

--- a/media-gfx/xpaint/xpaint-3.1.3.ebuild
+++ b/media-gfx/xpaint/xpaint-3.1.3.ebuild
@@ -41,7 +41,6 @@ BDEPEND="
 	sys-devel/bison
 	sys-devel/flex
 	virtual/pkgconfig
-	x11-misc/imake
 "
 
 PATCHES=(
@@ -56,12 +55,6 @@ src_prepare() {
 }
 
 src_configure() {
-	# regenerate resources in app-defaults
-	# Local.xawdefs is missing and imake was complaining about it, so use it to redefine SHAREDIR
-	echo "SHAREDIR = \"${EPREFIX}\"/usr/share/xpaint" > Local.xawdefs || die
-	xmkmf || die
-	mv Makefile Makefile.resources || die
-
 	econf \
 		$(use_enable tiff) \
 		--disable-libdvipgm \
@@ -77,6 +70,9 @@ src_compile() {
 	emake substads
 	emake xpaint.1
 
+	# regenerate resources in app-defaults
+	rm XPaint.ad || die
+
 	default
 	emake \
 		WITH_PGF="$(usex pgf "yes" "no")" \
@@ -84,9 +80,6 @@ src_compile() {
 		CXX="$(tc-getCXX)" \
 		includedir="${EPREFIX}"/usr/include \
 		-C util
-
-	# regenerate resources in app-defaults
-	(rm XPaint.ad && emake -f Makefile.resources XPaint.ad) || die
 }
 
 src_install() {


### PR DESCRIPTION
`rdlibtool` is part of `sys-devel/slibtool`
Closes: https://bugs.gentoo.org/778791
Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Viorel Munteanu <ceamac.paragon@gmail.com>