### PR TITLE
xorg-3.eclass: strip -fno-plt from *FLAGS

### DIFF
--- a/eclass/xorg-3.eclass
+++ b/eclass/xorg-3.eclass
@@ -334,9 +334,12 @@ xorg-3_flags_setup() {
 
 	# Win32 require special define
 	[[ ${CHOST} == *-winnt* ]] && append-cppflags -DWIN32 -D__STDC__
-	# hardened ldflags
-	[[ ${PN} == xorg-server || ${PN} == xf86-video-* || ${PN} == xf86-input-* ]] \
-		&& append-ldflags -Wl,-z,lazy
+
+	# Hardened flags break module autoloading et al (also fixes #778494)
+	if [[ ${PN} == xorg-server || ${PN} == xf86-video-* || ${PN} == xf86-input-* ]]; then
+		filter-flags -fno-plt
+		append-ldflags -Wl,-z,lazy
+	fi
 
 	# Quite few libraries fail on runtime without these:
 	if has static-libs ${IUSE//+}; then

--- a/eclass/xorg-3.eclass
+++ b/eclass/xorg-3.eclass
@@ -48,6 +48,10 @@ fi
 # before inheriting this eclass.
 : ${XORG_MULTILIB:="no"}
 
+# Due to changes to autotools.eclass, we need to define some variables before inheriting
+WANT_AUTOCONF="latest"
+WANT_AUTOMAKE="latest"
+
 # we need to inherit autotools first to get the deps
 inherit autotools libtool multilib toolchain-funcs flag-o-matic \
 	${FONT_ECLASS} ${GIT_ECLASS}
@@ -142,8 +146,6 @@ if [[ ${PN} != util-macros ]] ; then
 	# Required even by xorg-server
 	[[ ${PN} == "font-util" ]] || EAUTORECONF_DEPEND+=" >=media-fonts/font-util-1.2.0"
 fi
-WANT_AUTOCONF="latest"
-WANT_AUTOMAKE="latest"
 for arch in ${XORG_EAUTORECONF_ARCHES}; do
 	EAUTORECONF_DEPENDS+=" ${arch}? ( ${EAUTORECONF_DEPEND} )"
 done


### PR DESCRIPTION
As discussed in #778494, the GCC flag -fno-plt will break lazy
binding, which appears to still be necessary for Xorg. Stripping the
offending flag out is the next best solution for reliable user
experience on Gentoo.

Closes: https://bugs.gentoo.org/778494
Signed-off-by: Niklāvs Koļesņikovs <89q1r14hd@relay.firefox.com>

I first tried to remove lazy binding but it was still producing broken Xorg drivers, so I then tried stripping out -fno-plt and that worked. I also checked that no other eclass (apart from the now unused xorg-2) is using z,lazy and may have needed the same fix.

Oh, and credit/thanks go to @AdelKS for discovering and reporting this to the Gentoo bug tracker and @mattst88 for correctly identifying the cause and describing how to fix it.