### PR TITLE
sci-libs/coinor-dip: prevent python-2.7 automagic

### DIFF
--- a/sci-libs/coinor-dip/coinor-dip-0.95.0-r2.ebuild
+++ b/sci-libs/coinor-dip/coinor-dip-0.95.0-r2.ebuild
@@ -32,6 +32,9 @@ src_prepare() {
 	default
 	# Prevent unneeded call to pkg-config that needs ${ED}'s in path.
 	sed -i '/--libs.*addlibs.txt/d' Makefile.in || die
+
+	# Prevent python:2.7 automagic for dippy (bug #778965)
+	sed -i 's/@HAVE_PYTHON_TRUE@/#/' src/Makefile.in || die
 }
 
 src_configure() {


### PR DESCRIPTION
**Edit**: I was just reminded of this PR so I had a quick 2nd look at it, believe still looks fine. I recall I wanted to use another method to disable python for dippy than a sed on the macros but there wasn't anything sane really usable for this that I've noticed.