### PR TITLE
media-gfx/xpaint: dependency `sys-devel/automake:1.15`

### DIFF
--- a/media-gfx/xpaint/xpaint-2.10.2-r1.ebuild
+++ b/media-gfx/xpaint/xpaint-2.10.2-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit desktop toolchain-funcs
+inherit autotools desktop toolchain-funcs
 
 DESCRIPTION="Image editor with tiff, jpeg and png support"
 HOMEPAGE="http://sf-xpaint.sourceforge.net/"
@@ -47,6 +47,11 @@ PATCHES=(
 	"${FILESDIR}"/${P}-libtool-clang.patch
 	"${FILESDIR}"/${P}-respect-ldflags.patch
 )
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	econf \


### PR DESCRIPTION
`media-gfx/xpaint-2.10.2-r1` depends on an older version of automake

Closes: https://bugs.gentoo.org/778968
