### PR TITLE
media-gfx/inkscape: Remove libX11

### DIFF
--- a/media-gfx/inkscape/files/inkscape-1.0.2-automagic-libX11.patch
+++ b/media-gfx/inkscape/files/inkscape-1.0.2-automagic-libX11.patch
@@ -1,0 +1,181 @@
+From 6d0ace0518f0da18c7e81be1edecd50d997230b1 Mon Sep 17 00:00:00 2001
+From: "Haelwenn (lanodan) Monnier" <contact@hacktivis.me>
+Date: Tue, 11 May 2021 10:43:27 +0200
+Subject: [PATCH] CMake: Fix automagic dependency on X11
+
+Related: https://bugs.gentoo.org/768663
+Related: https://github.com/gentoo/gentoo/pull/20181
+---
+ CMakeLists.txt                           |  3 +++
+ CMakeScripts/DefineDependsandFlags.cmake | 13 +++++++----
+ src/ege-color-prof-tracker.cpp           | 28 ++++++++++++------------
+ 3 files changed, 26 insertions(+), 18 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c5cb3f7fbd..2a04d86fbf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,6 +36,7 @@ project(inkscape)
+ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME inkscape) # needs to be before any install() commands
+ 
+ include(CMakeScripts/ConfigPaths.cmake)
++include(CMakeDependentOption)
+ 
+ set(PROJECT_NAME inkscape)
+ 
+@@ -127,6 +128,7 @@ option(WITH_LIBWPG "Compile with support of libwpg for WordPerfect Graphics" ON)
+ option(WITH_NLS "Compile with Native Language Support (using gettext)" ON)
+ option(WITH_JEMALLOC "Compile with JEMALLOC support" OFF)
+ option(WITH_ASAN "Compile with Clang's AddressSanitizer (for debugging purposes)" OFF)
++cmake_dependent_option(WITH_X11 "Compile with X11 support" ON "UNIX; NOT APPLE" OFF)
+ 
+ option(WITH_FUZZ "Compile for fuzzing purpose (use 'make fuzz' only)" OFF)
+ mark_as_advanced(WITH_FUZZ)
+@@ -284,6 +286,7 @@ message("WITH_LIBWPG:             ${WITH_LIBWPG}")
+ message("WITH_NLS:                ${WITH_NLS}")
+ message("WITH_OPENMP:             ${WITH_OPENMP}")
+ message("WITH_JEMALLOC:           ${WITH_JEMALLOC}")
++message("WITH_X11:                ${WITH_X11}")
+ 
+ message("WITH_PROFILING:          ${WITH_PROFILING}")
+ message("BUILD_TESTING:           ${BUILD_TESTING}")
+diff --git a/CMakeScripts/DefineDependsandFlags.cmake b/CMakeScripts/DefineDependsandFlags.cmake
+index 1b5ed0d349..ef3f321977 100644
+--- a/CMakeScripts/DefineDependsandFlags.cmake
++++ b/CMakeScripts/DefineDependsandFlags.cmake
+@@ -384,12 +384,17 @@ sanitize_ldflags_for_libs(SIGC++_LDFLAGS)
+ list(APPEND INKSCAPE_LIBS ${SIGC++_LDFLAGS})
+ list(APPEND INKSCAPE_CXX_FLAGS ${SIGC++_CFLAGS_OTHER})
+ 
+-# Some linkers, like gold, don't find symbols recursively. So we have to link against X11 explicitly
+-find_package(X11)
+-if(X11_FOUND)
++if(WITH_X11)
++    find_package(X11 REQUIRED)
+     list(APPEND INKSCAPE_INCS_SYS ${X11_INCLUDE_DIRS})
+     list(APPEND INKSCAPE_LIBS ${X11_LIBRARIES})
+-endif(X11_FOUND)
++    add_definitions(-DHAVE_X11)
++
++    pkg_get_variable(GTK3_TARGETS gtk+-3.0 targets)
++    if(NOT("${GTK3_TARGETS}" MATCHES "x11"))
++        message(FATAL_ERROR "GTK+3 doesn't targets X11, this is required for WITH_X11")
++    endif()
++endif(WITH_X11)
+ 
+ # end Dependencies
+ 
+diff --git a/src/ege-color-prof-tracker.cpp b/src/ege-color-prof-tracker.cpp
+index 0b118f1a57..6fb721c2f3 100644
+--- a/src/ege-color-prof-tracker.cpp
++++ b/src/ege-color-prof-tracker.cpp
+@@ -46,11 +46,11 @@
+ 
+ #include <gtk/gtk.h>
+ 
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_X11
+ #include <X11/Xlib.h>
+ 
+ #include <gdk/gdkx.h>
+-#endif /* GDK_WINDOWING_X11 */
++#endif /* HAVE_X11 */
+ 
+ #include "ege-color-prof-tracker.h"
+ #include "helper/sp-marshal.h"
+@@ -68,24 +68,24 @@ static void ege_color_prof_tracker_set_property( GObject* obj, guint propId, con
+ 
+ class ScreenTrack {
+     public:
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_X11
+     gboolean zeroSeen;
+     gboolean otherSeen;
+-#endif /* GDK_WINDOWING_X11 */
++#endif /* HAVE_X11 */
+     std::vector<EgeColorProfTracker *> *trackers;
+     GPtrArray* profiles;
+     ~ScreenTrack(){ delete trackers; }
+ };
+ 
+ 
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_X11
+ GdkFilterReturn x11_win_filter(GdkXEvent *xevent, GdkEvent *event, gpointer data);
+ void handle_property_change(GdkScreen* screen, const gchar* name);
+ void add_x11_tracking_for_screen(GdkScreen* screen);
+ static void fire(gint monitor);
+ static void clear_profile( guint monitor );
+ static void set_profile( guint monitor, const guint8* data, guint len );
+-#endif /* GDK_WINDOWING_X11 */
++#endif /* HAVE_X11 */
+ 
+ static guint signals[LAST_SIGNAL] = {0};
+ 
+@@ -296,10 +296,10 @@ void track_screen( GdkScreen* screen, EgeColorProfTracker* tracker )
+ 
+         int numMonitors = gdk_display_get_n_monitors(display);
+ 
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_X11
+         tracked_screen->zeroSeen = FALSE;
+         tracked_screen->otherSeen = FALSE;
+-#endif /* GDK_WINDOWING_X11 */
++#endif /* HAVE_X11 */
+         tracked_screen->trackers= new std::vector<EgeColorProfTracker *>;
+         tracked_screen->trackers->push_back(tracker );
+         tracked_screen->profiles = g_ptr_array_new();
+@@ -309,14 +309,14 @@ void track_screen( GdkScreen* screen, EgeColorProfTracker* tracker )
+ 
+         g_signal_connect( G_OBJECT(screen), "size-changed", G_CALLBACK( screen_size_changed_cb ), tracker );
+ 
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_X11
+         if (GDK_IS_X11_DISPLAY (display) ) {
+             // printf( "track_screen: Display is using X11\n" );
+             add_x11_tracking_for_screen(screen);
+         } else {
+             // printf( "track_screen: Display is not using X11\n" );
+         }
+-#endif // GDK_WINDOWING_X11
++#endif // HAVE_X11
+     }
+ }
+ 
+@@ -408,13 +408,13 @@ void screen_size_changed_cb(GdkScreen* screen, gpointer user_data)
+         if ( numMonitors > (gint)tracked_screen->profiles->len ) {
+             for ( guint i = tracked_screen->profiles->len; i < (guint)numMonitors; i++ ) {
+                 g_ptr_array_add( tracked_screen->profiles, nullptr );
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_X11
+                 if (GDK_IS_X11_DISPLAY (display) ) {
+                     gchar* name = g_strdup_printf( "_ICC_PROFILE_%d", i );
+                     handle_property_change( screen, name );
+                     g_free(name);
+                 }
+-#endif /* GDK_WINDOWING_X11 */
++#endif /* HAVE_X11 */
+             }
+         } else if ( numMonitors < (gint)tracked_screen->profiles->len ) {
+ /*             g_message("The count of monitors decreased, remove some"); */
+@@ -422,7 +422,7 @@ void screen_size_changed_cb(GdkScreen* screen, gpointer user_data)
+     }
+ }
+ 
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_X11
+ GdkFilterReturn x11_win_filter(GdkXEvent *xevent,
+                                GdkEvent *event,
+                                gpointer data)
+@@ -615,7 +615,7 @@ static void set_profile( guint monitor, const guint8* data, guint len )
+         }
+     }
+ }
+-#endif /* GDK_WINDOWING_X11 */
++#endif /* HAVE_X11 */
+ /*
+   Local Variables:
+   mode:c++
+-- 
+2.26.3
+

--- a/media-gfx/inkscape/inkscape-1.1.2-r2.ebuild
+++ b/media-gfx/inkscape/inkscape-1.1.2-r2.ebuild
@@ -106,6 +106,13 @@ RESTRICT="!test? ( test )"
 
 S="${WORKDIR}/${MY_P}"
 
+# automagic-libX11 (merged before 1.2): https://gitlab.com/inkscape/inkscape/-/merge_requests/3208
+PATCHES=(
+	"${FILESDIR}/${PN}-1.1.2-r1-poppler-22.03.0.patch" # bug 835424
+	"${FILESDIR}/${PN}-1.1.2-r1-poppler-22.04.0.patch" # bug 835661 / bug 843275
+	"${FILESDIR}/inkscape-1.0.2-automagic-libX11.patch" # bug 768663
+)
+
 pkg_pretend() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 }


### PR DESCRIPTION
It is only used at link time when present, see `X11_FOUND` in
./CMakeScripts/DefineDependsandFlags.cmake

Closes: https://bugs.gentoo.org/768663
Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>