### PR TITLE
net-p2p/mldonkey: Add net-analyzer/openbsd-netcat as an alternative to net-analyzer/netcat

### DIFF
--- a/net-p2p/mldonkey/mldonkey-3.1.7-r1.ebuild
+++ b/net-p2p/mldonkey/mldonkey-3.1.7-r1.ebuild
@@ -17,9 +17,8 @@ IUSE="bittorrent doc fasttrack gd gnutella gtk guionly magic +ocamlopt upnp"
 
 REQUIRED_USE="guionly? ( gtk )"
 
-RDEPEND="dev-lang/perl
+COMMON_DEPEND="dev-lang/perl
 	dev-ml/camlp4:=
-	net-analyzer/netcat
 	gd? ( media-libs/gd[truetype] )
 	gtk? (
 		gnome-base/librsvg
@@ -36,10 +35,12 @@ RDEPEND="dev-lang/perl
 	)
 	!guionly? ( acct-user/p2p )
 "
+RDEPEND="${COMMON_DEPEND}
+	|| ( net-analyzer/netcat net-analyzer/openbsd-netcat )"
 # Can't yet use newer OCaml
 # -unsafe-string usage:
 # https://github.com/ygrek/mldonkey/issues/46
-DEPEND="${RDEPEND}
+DEPEND="${COMMON_DEPEND}
 	<dev-lang/ocaml-4.10:=[ocamlopt?]
 	bittorrent? (
 		|| (


### PR DESCRIPTION
There is no actual need to depend on a specific netcat implementation.

The commit also reorder dependencies by creating a new variable with only the common dependencies between `DEPEND` and `RDEPEND` so netcat can be moved to `RDEPEND` only and not included in `DEPEND` as it's a dependency required at run time only.