### PR TITLE
dev-java/core-specs-alpha dev-java/specs-alpha: drop myself as proxy

### DIFF
--- a/dev-java/core-specs-alpha/metadata.xml
+++ b/dev-java/core-specs-alpha/metadata.xml
@@ -5,10 +5,6 @@
 		<email>tgbugs@gmail.com</email>
 		<name>Tom Gillespie</name>
 	</maintainer>
-	<maintainer type="person" proxied="yes">
-		<email>marco@scardovi.com</email>
-		<name>Marco Scardovi</name>
-	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>

--- a/dev-java/spec-alpha/metadata.xml
+++ b/dev-java/spec-alpha/metadata.xml
@@ -5,10 +5,6 @@
 		<email>tgbugs@gmail.com</email>
 		<name>Tom Gillespie</name>
 	</maintainer>
-	<maintainer type="person" proxied="yes">
-		<email>marco@scardovi.com</email>
-		<name>Marco Scardovi</name>
-	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>


### PR DESCRIPTION
maintainer

I have to admit I have enought packages to maintain, but primarly I don't know enoght java to be able to maintain such packages actively.
Please drop me as proxy-maintainer.

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Marco Scardovi <marco@scardovi.com>