### PR TITLE
sys-libs/libselinux: add musl patch

### DIFF
--- a/sys-libs/libselinux/files/0001-remove-pid_t-musl.patch
+++ b/sys-libs/libselinux/files/0001-remove-pid_t-musl.patch
@@ -1,0 +1,17 @@
+diff -Naur a/src/procattr.c b/src/procattr.c
+--- a/src/procattr.c	2020-07-10 11:17:15.000000000 -0400
++++ b/src/procattr.c	2021-03-30 16:31:51.224025979 -0400
+@@ -34,13 +34,6 @@
+   #define OVERRIDE_GETTID 0
+ #endif
+ 
+-#if OVERRIDE_GETTID
+-static pid_t gettid(void)
+-{
+-	return syscall(__NR_gettid);
+-}
+-#endif
+-
+ static void procattr_thread_destructor(void __attribute__((unused)) *unused)
+ {
+ 	if (prev_current != UNSET)

--- a/sys-libs/libselinux/libselinux-3.1-r1.ebuild
+++ b/sys-libs/libselinux/libselinux-3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -46,6 +46,11 @@ BDEPEND="virtual/pkgconfig
 	ruby? ( >=dev-lang/swig-2.0.9 )"
 
 src_prepare() {
+
+	if use elibc_musl ; then
+		eapply "${FILESDIR}"/0001-remove-pid_t-musl.patch
+	fi
+
 	eapply_user
 
 	multilib_copy_sources

--- a/sys-libs/libselinux/libselinux-9999.ebuild
+++ b/sys-libs/libselinux/libselinux-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"


### PR DESCRIPTION
pid_t function in libselinux requires patching for musl.

Update copyright date in header of -9999 ebuild.

@perfinion 