### PR TITLE
profile/features/selinux/package.mask: remove gnome packages

### DIFF
--- a/profiles/features/selinux/package.mask
+++ b/profiles/features/selinux/package.mask
@@ -27,33 +27,10 @@ www-misc/profile-sync-daemon
 # systemd has no support in the SELinux policy at the moment.
 # Please see: https://wiki.gentoo.org/wiki/SELinux/FAQ#Can_I_use_SELinux_with_systemd.3F
 app-admin/systemdgenie
-app-eselect/eselect-gnome-shell-extensions
 app-office/wps-office
 sys-apps/systemd
 app-admin/calamares
 dev-python/python-systemd
-gnome-base/gdm
-gnome-base/gnome
-gnome-base/gnome-applets
-gnome-base/gnome-extra-apps
-gnome-base/gnome-flashback
-gnome-base/gnome-light
-gnome-base/gnome-panel
-gnome-base/gnome-shell
-gnome-extra/chrome-gnome-shell
-gnome-extra/gnome-logs
-gnome-extra/gnome-shell-extensions
-gnome-extra/gnome-shell-frippery
-gnome-extra/gnome-shell-extensions-topicons-plus
-gnome-extra/gnome-shell-extension-appindicator
-gnome-extra/gnome-shell-extension-applications-overview-tooltip
-gnome-extra/gnome-shell-extension-bing-wallpaper
-gnome-extra/gnome-shell-extension-bluetooth-quick-connect
-gnome-extra/gnome-shell-extension-control-blur-effect-on-lock-screen
-gnome-extra/gnome-shell-extension-dash-to-panel
-gnome-extra/gnome-shell-extension-desktop-icons
-gnome-extra/gnome-shell-extension-gsconnect
-gnome-extra/gnome-tweaks
 x11-themes/zukitwo-shell
 gnome-extra/office-runner
 gnome-extra/pch-session

--- a/profiles/features/selinux/package.use.mask
+++ b/profiles/features/selinux/package.use.mask
@@ -17,11 +17,6 @@ gnome-base/gdm wayland
 net-firewall/fwknop firewalld
 www-servers/uwsgi uwsgi_plugins_systemd_logger
 >=x11-wm/mutter-3.22 wayland
-x11-misc/xscreensaver gdm
-x11-misc/gpaste gnome
-x11-terms/gnome-terminal gnome-shell
-x11-themes/arc-theme gnome-shell
-x11-themes/zukitwo gnome-shell
 net-wireless/bluez user-session
 
 # Brian Dolbec <dolsen@gentoo.org> (2014-09-17)


### PR DESCRIPTION
remove gnome packages which no longer require masking due to elogind satisfying the dependency.

@perfinion 