### PR TITLE
dev-vcs/hub: use vendored modules, not from network(!)

### DIFF
--- a/dev-vcs/hub/hub-2.14.2-r1.ebuild
+++ b/dev-vcs/hub/hub-2.14.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,6 +16,11 @@ KEYWORDS="~amd64 ~ppc64 ~x86 ~amd64-linux ~x86-linux"
 RDEPEND=">=dev-vcs/git-1.7.3"
 
 src_compile() {
+	# The eclass setting GOFLAGS at all overrides this default
+	# in the upstream Makefile. It'll *FALL BACK* to bundled/vendored
+	# modules but without this, it'll try fetching. On platforms
+	# without network-sandbox (or relying on it), this is not okay.
+	export GOFLAGS="${GOFLAGS} -mod=vendor"
 	emake bin/hub man-pages
 }
 

--- a/dev-vcs/hub/hub-2.14.2-r1.ebuild
+++ b/dev-vcs/hub/hub-2.14.2-r1.ebuild
@@ -13,6 +13,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc64 ~x86 ~amd64-linux ~x86-linux"
 
+BDEPEND="sys-apps/groff"
 RDEPEND=">=dev-vcs/git-1.7.3"
 
 src_compile() {

--- a/dev-vcs/hub/metadata.xml
+++ b/dev-vcs/hub/metadata.xml
@@ -6,6 +6,6 @@
     <name>William Hubbs</name>
   </maintainer>
   <upstream>
-    <remote-id type="github">defunkt/hub</remote-id>
+    <remote-id type="github">github/hub</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
On platforms without network-sandbox (or with it disabled), we get:
[...]
 # get https://proxy.golang.org/github.com/mitchellh/go-homedir/@v/v0.0.0-20161203194507-b8bc1bf76747.mod: 200 OK (0.229s)
 # get https://proxy.golang.org/gopkg.in/yaml.v2/@v/v2.0.0-20190319135612-7b8349ac747c.mod: 200 OK (0.230s)
 # get https://proxy.golang.org/github.com/russross/blackfriday/@v/v0.0.0-20180526075726-670777b536d3.mod: 200 OK (0.229s)
[...]

We need to explicitly re-give the upstream default for their GOFLAGS as our
default in the eclass is overriding it.

Signed-off-by: Sam James <sam@gentoo.org>