### PR TITLE
app-editors/ted: bugday 2021-04-03 related fixes

### DIFF
--- a/app-editors/ted/files/ted-2.23-0001-pass-MAKE-to-subdir.patch
+++ b/app-editors/ted/files/ted-2.23-0001-pass-MAKE-to-subdir.patch
@@ -1,0 +1,26 @@
+From 570129a519e2b22d900ecf06ed938b7b5d5a7b79 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 3 Apr 2021 11:04:15 +0200
+Subject: [PATCH] pass $(MAKE) to subdir
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 08224f9..19f3f49 100644
+--- a/Makefile
++++ b/Makefile
+@@ -246,7 +246,7 @@ package: compile tedPackage/makefile
+ 	: To install Ted, you can now run 'make install' AS ROOT
+ 
+ package.shared: compile.shared tedPackage/makefile
+-	cd tedPackage && make package.shared
++	cd tedPackage && $(MAKE) package.shared
+ 	:
+ 	: Dynamically linked package ready.
+ 	: To install Ted, you can now run 'make install' AS ROOT
+-- 
+2.31.1
+

--- a/app-editors/ted/files/ted-2.23-0002-fix-unrecognized-option-with-GTK.patch
+++ b/app-editors/ted/files/ted-2.23-0002-fix-unrecognized-option-with-GTK.patch
@@ -1,0 +1,134 @@
+From 75913fec2f0b168d08c28eaa84fd69f52767802d Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 3 Apr 2021 10:54:08 +0200
+Subject: [PATCH] fix unrecognized option --with-GTK
+
+Closes: https://bugs.gentoo.org/470652
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ Makefile | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 08224f9..b210d8a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -128,84 +128,84 @@ lib/bitmap.a: bitmap/makefile
+ 	cd bitmap && $(MAKE)
+ 
+ bitmap/makefile: bitmap/makefile.in Makefile
+-	cd bitmap && ./configure $(CONFIGURE_OPTIONS)
++	cd bitmap && ./configure
+ 
+ ####
+ lib/docBuf.a: docBuf/makefile
+ 	cd docBuf && $(MAKE)
+ 
+ docBuf/makefile: docBuf/makefile.in Makefile
+-	cd docBuf && ./configure $(CONFIGURE_OPTIONS)
++	cd docBuf && ./configure
+ 
+ ####
+ lib/docBase.a: docBase/makefile
+ 	cd docBase && $(MAKE)
+ 
+ docBase/makefile: docBase/makefile.in Makefile
+-	cd docBase && ./configure $(CONFIGURE_OPTIONS)
++	cd docBase && ./configure
+ 
+ ####
+ lib/docHtml.a: docHtml/makefile
+ 	cd docHtml && $(MAKE)
+ 
+ docHtml/makefile: docHtml/makefile.in Makefile
+-	cd docHtml && ./configure $(CONFIGURE_OPTIONS)
++	cd docHtml && ./configure
+ 
+ ####
+ lib/docLayout.a: docLayout/makefile
+ 	cd docLayout && $(MAKE)
+ 
+ docLayout/makefile: docLayout/makefile.in Makefile
+-	cd docLayout && ./configure $(CONFIGURE_OPTIONS)
++	cd docLayout && ./configure
+ 
+ ####
+ lib/docRtf.a: docRtf/makefile
+ 	cd docRtf && $(MAKE)
+ 
+ docRtf/makefile: docRtf/makefile.in Makefile
+-	cd docRtf && ./configure $(CONFIGURE_OPTIONS)
++	cd docRtf && ./configure
+ 
+ ####
+ lib/docEdit.a: docEdit/makefile
+ 	cd docEdit && $(MAKE)
+ 
+ docEdit/makefile: docEdit/makefile.in Makefile
+-	cd docEdit && ./configure $(CONFIGURE_OPTIONS)
++	cd docEdit && ./configure
+ 
+ ####
+ lib/ind.a: ind/makefile
+ 	cd ind && $(MAKE)
+ 
+ ind/makefile: ind/makefile.in Makefile
+-	cd ind && ./configure $(CONFIGURE_OPTIONS)
++	cd ind && ./configure
+ 
+ ####
+ lib/appUtil.a: appUtil/makefile
+ 	cd appUtil && $(MAKE)
+ 
+ appUtil/makefile: appUtil/makefile.in Makefile
+-	cd appUtil && ./configure $(CONFIGURE_OPTIONS)
++	cd appUtil && ./configure
+ 
+ ####
+ lib/textEncoding.a: textEncoding/makefile
+ 	cd textEncoding && $(MAKE)
+ 
+ textEncoding/makefile: textEncoding/makefile.in Makefile
+-	cd textEncoding && ./configure $(CONFIGURE_OPTIONS)
++	cd textEncoding && ./configure
+ 
+ ####
+ lib/utilPs.a: utilPs/makefile
+ 	cd utilPs && $(MAKE)
+ 
+ utilPs/makefile: utilPs/makefile.in Makefile
+-	cd utilPs && ./configure $(CONFIGURE_OPTIONS)
++	cd utilPs && ./configure
+ 
+ ####
+ lib/docFont.a: docFont/makefile
+ 	cd docFont && $(MAKE)
+ 
+ docFont/makefile: docFont/makefile.in Makefile
+-	cd docFont && ./configure $(CONFIGURE_OPTIONS)
++	cd docFont && ./configure
+ 
+ ####
+ lib/appFrame.a: appFrame/makefile
+@@ -219,7 +219,7 @@ lib/drawMeta.a: drawMeta/makefile
+ 	cd drawMeta && $(MAKE)
+ 
+ drawMeta/makefile: drawMeta/makefile.in Makefile
+-	cd drawMeta && ./configure $(CONFIGURE_OPTIONS)
++	cd drawMeta && ./configure
+ 
+ ####
+ ####	Compile and link Ted
+@@ -252,7 +252,7 @@ package.shared: compile.shared tedPackage/makefile
+ 	: To install Ted, you can now run 'make install' AS ROOT
+ 
+ tedPackage/makefile: tedPackage/makefile.in Makefile
+-	cd tedPackage && ./configure $(CONFIGURE_OPTIONS)
++	cd tedPackage && ./configure
+ 
+ sysvpkg: compile tedPackage/makefile
+ 	cd tedPackage && $(MAKE) $@
+-- 
+2.31.1
+

--- a/app-editors/ted/files/ted-2.23-0003-avoid-compressing-man-page.patch
+++ b/app-editors/ted/files/ted-2.23-0003-avoid-compressing-man-page.patch
@@ -1,0 +1,32 @@
+From 38fc26c86b07f2d9404fe80ff758a92b2a9cfc85 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 3 Apr 2021 11:22:28 +0200
+Subject: [PATCH] avoid compressing man page
+
+Fix a QA issue
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ tedPackage/makefile.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tedPackage/makefile.in b/tedPackage/makefile.in
+index 2b39dd2..a1040ca 100644
+--- a/tedPackage/makefile.in
++++ b/tedPackage/makefile.in
+@@ -194,9 +194,9 @@ datadir:	README		\
+ 	( cd $(PKGDATADIR)/Ted && umask 0 && tar xvf - ) < TedDatadir.tar
+ 	cp $(PKGDATADIR)/Ted/TedDocument-en_US.rtf TedDocument-en_US.rtf
+ 	( umask 022 && mkdir -p $(PKGMANDIR) )
+-	sh ./customize.sh $(CUSTOMIZE_ARGS) < $(PKGDATADIR)/Ted/doc/Ted.1 | \
+-					    gzip -9 > $(PKGMANDIR)/Ted.1.gz
+-	chmod 644 $(PKGMANDIR)/Ted.1.gz
++	sh ./customize.sh $(CUSTOMIZE_ARGS) < $(PKGDATADIR)/Ted/doc/Ted.1 \
++					    > $(PKGMANDIR)/Ted.1
++	chmod 644 $(PKGMANDIR)/Ted.1
+ 	:
+ 	cp $(PKGLSMNAME) $(PKGTEDVARIADIR)/$(PKGLSMNAME)
+ 	cp Ted.desktop $(PKGDESKTOPDIR)/Ted.desktop
+-- 
+2.31.1
+

--- a/app-editors/ted/files/ted-2.23-use-Motif-toolkit-instead-of-GTK-by-default.patch
+++ b/app-editors/ted/files/ted-2.23-use-Motif-toolkit-instead-of-GTK-by-default.patch
@@ -1,0 +1,26 @@
+From 4368f7bab3a79b4322c1c19fdb99634e10f823ad Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 3 Apr 2021 11:36:06 +0200
+Subject: [PATCH] use Motif toolkit instead of GTK by default
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 08224f9..f6ced83 100644
+--- a/Makefile
++++ b/Makefile
+@@ -73,7 +73,7 @@
+ ####	P.S.	I admit that this makefile is more like a shell script.
+ ####
+ 
+-CONFIGURE_OPTIONS=--with-GTK
++CONFIGURE_OPTIONS=--with-MOTIF
+ 
+ compile:	tedlibs		\
+ 		Ted/Ted		\
+-- 
+2.31.1
+

--- a/app-editors/ted/ted-2.23-r1.ebuild
+++ b/app-editors/ted/ted-2.23-r1.ebuild
@@ -23,9 +23,9 @@ RDEPEND="
 	sys-libs/zlib
 	virtual/jpeg
 	virtual/libiconv
-	x11-libs/gtk+:2
 	x11-libs/libXft
 	x11-libs/libXpm
+	x11-libs/motif
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
@@ -38,6 +38,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-0002-fix-unrecognized-option-with-GTK.patch
 	"${FILESDIR}"/${P}-0003-avoid-compressing-man-page.patch
 	"${FILESDIR}"/${P}-freetype261.patch
+	"${FILESDIR}"/${P}-use-Motif-toolkit-instead-of-GTK-by-default.patch
 )
 
 src_prepare() {
@@ -66,9 +67,13 @@ src_configure() {
 	tc-export AR CC RANLIB
 
 	local dir
-	for dir in appFrame appUtil bitmap docBuf ind Ted tedPackage; do
+	for dir in appUtil textEncoding utilPs bitmap docFont docBase docBuf ind drawMeta docRtf docEdit docLayout docHtml; do
 		cd "${S}"/${dir}
 		econf --cache-file=../config.cache
+	done
+	for dir in appFrame; do
+		cd "${S}"/${dir}
+		econf --cache-file=../config.cache --with-MOTIF
 	done
 }
 

--- a/app-editors/ted/ted-2.23-r1.ebuild
+++ b/app-editors/ted/ted-2.23-r1.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs xdg-utils
+
+DESCRIPTION="X-based rich text editor"
+HOMEPAGE="https://www.nllgg.nl/Ted/"
+SRC_URI="ftp://ftp.nluug.nl/pub/editors/ted/${P}.src.tar.gz"
+S="${WORKDIR}/Ted-${PV}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="
+	app-text/libpaper
+	dev-libs/libpcre2
+	media-libs/fontconfig
+	media-libs/freetype
+	media-libs/libpng:=
+	media-libs/tiff:=
+	sys-libs/zlib
+	virtual/jpeg
+	virtual/libiconv
+	x11-libs/gtk+:2
+	x11-libs/libXft
+	x11-libs/libXpm
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-apps/lsb-release
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-0001-pass-MAKE-to-subdir.patch
+	"${FILESDIR}"/${P}-0002-fix-unrecognized-option-with-GTK.patch
+	"${FILESDIR}"/${P}-0003-avoid-compressing-man-page.patch
+	"${FILESDIR}"/${P}-freetype261.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e 's|/Ted/|/share/Ted/|' \
+		"${S}"/appFrame/appFrameConfig.h.in \
+		"${S}"/Ted/tedConfig.h.in || die
+
+	# bug #461256
+	find . -name makefile.in -exec sed -i -e '/ar r/s/ar/$(AR)/' {} \; || die
+
+	# force to build dynamic binary, do not strip it
+	sed -i \
+		-e 's/.static//g' \
+		-e '/strip/d' \
+		tedPackage/makefile.in || die 'sed failed on tedPackage/makefile.in'
+
+	# Fix build with freetype-2.5
+	sed -i "s|^\(#[ \t]*include[ \t]*<\)freetype/|\1|" appFrame/appFontConfig.c || die
+
+	mkdir lib || die
+}
+
+src_configure() {
+	tc-export AR CC RANLIB
+
+	local dir
+	for dir in appFrame appUtil bitmap docBuf ind Ted tedPackage; do
+		cd "${S}"/${dir}
+		econf --cache-file=../config.cache
+	done
+}
+
+src_compile() {
+	emake package.shared
+}
+
+src_install() {
+	default
+	dosym ../share/Ted/examples/rtf2pdf.sh /usr/bin/rtf2pdf.sh
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+}


### PR DESCRIPTION
- bump to EAPI 7
fix configure options:
Fix unrecognized configure option --with-GTK
Adjust dependencies
Closes: https://bugs.gentoo.org/470652
Closes: https://bugs.gentoo.org/733734
- use Motif toolkit by default:
Use Motif instead of Gtk-2, which is alternatively
supported as a GUI.

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
