### PR TITLE
dev-ros/gmapping: fix dependencies

### DIFF
--- a/dev-ros/gmapping/gmapping-1.4.1.ebuild
+++ b/dev-ros/gmapping/gmapping-1.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/tf
 	dev-ros/openslam_gmapping
 	dev-ros/rosbag_storage
-	dev-ros/gmapping
+	dev-ros/nodelet
 "
 DEPEND="${RDEPEND}
 	dev-ros/nav_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]

--- a/dev-ros/gmapping/gmapping-1.4.2.ebuild
+++ b/dev-ros/gmapping/gmapping-1.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/tf
 	dev-ros/openslam_gmapping
 	dev-ros/rosbag_storage
-	dev-ros/gmapping
+	dev-ros/nodelet
 "
 DEPEND="${RDEPEND}
 	dev-ros/nav_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]

--- a/dev-ros/gmapping/gmapping-9999.ebuild
+++ b/dev-ros/gmapping/gmapping-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-ros/tf
 	dev-ros/openslam_gmapping
 	dev-ros/rosbag_storage
-	dev-ros/gmapping
+	dev-ros/nodelet
 "
 DEPEND="${RDEPEND}
 	dev-ros/nav_msgs[${CATKIN_MESSAGES_CXX_USEDEP}]


### PR DESCRIPTION
remove gmapping
add nodelet

Closes: https://bugs.gentoo.org/779682
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>