### PR TITLE
app-office/calligra: Fix invalid CMake argument

### DIFF
--- a/app-office/calligra/calligra-3.2.1-r1.ebuild
+++ b/app-office/calligra/calligra-3.2.1-r1.ebuild
@@ -176,7 +176,7 @@ src_configure() {
 		-DWITH_Poppler=$(usex pdf)
 		-DWITH_Eigen3=$(usex calligra_features_sheets)
 		-DBUILD_UNMAINTAINED=$(usex calligra_features_stage)
-		-ENABLE_CSTESTER_TESTING=$(usex test)
+		-DENABLE_CSTESTER_TESTING=$(usex test)
 		-DWITH_Freetype=$(usex truetype)
 	)
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/779982
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Matt Smith <matt@offtopica.uk>