### PR TITLE
app-office/scribus: add upstream patch for poppler-21.04.0 compatibility

### DIFF
--- a/app-office/scribus/files/scribus-1.5.6.1-poppler-21.04.0.patch
+++ b/app-office/scribus/files/scribus-1.5.6.1-poppler-21.04.0.patch
@@ -1,0 +1,27 @@
+From c62844064cd6d85802d21e188b0f479463e22095 Mon Sep 17 00:00:00 2001
+From: Jean Ghali <jghali@libertysurf.fr>
+Date: Sun, 4 Apr 2021 21:37:04 +0000
+Subject: [PATCH] #16536: Page::getFormWidgets() returns unique_ptr in poppler
+ 21.04.0
+
+git-svn-id: svn://scribus.net/trunk/Scribus@24599 11d20701-8431-0410-a711-e3c959e3b870
+---
+ scribus/plugins/import/pdf/slaoutput.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scribus/plugins/import/pdf/slaoutput.h b/scribus/plugins/import/pdf/slaoutput.h
+index 66c34203ae..cb191b1023 100644
+--- a/scribus/plugins/import/pdf/slaoutput.h
++++ b/scribus/plugins/import/pdf/slaoutput.h
+@@ -379,7 +379,11 @@ class SlaOutputDev : public OutputDev
+ 	Catalog *catalog {nullptr};
+ 	SplashFontEngine *m_fontEngine {nullptr};
+ 	SplashFont *m_font {nullptr};
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(21, 4, 0)
++	std::unique_ptr<FormPageWidgets> m_formWidgets;
++#else
+ 	FormPageWidgets *m_formWidgets {nullptr};
++#endif
+ 	QHash<QString, QList<int> > m_radioMap;
+ 	QHash<int, PageItem*> m_radioButtons;
+ 	int m_actPage;

--- a/app-office/scribus/scribus-1.5.6.1.ebuild
+++ b/app-office/scribus/scribus-1.5.6.1.ebuild
@@ -73,6 +73,7 @@ RDEPEND="${DEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${P}-poppler-21.03.0-{1,2}.patch
+	"${FILESDIR}"/${P}-poppler-21.04.0.patch
 	# non(?)-upstreamable
 	"${FILESDIR}"/${PN}-1.5.3-fpic.patch
 	"${FILESDIR}"/${PN}-1.5.6-docdir.patch


### PR DESCRIPTION
Patch source:
https://github.com/scribusproject/scribus/commit/c62844064cd6d85802d21e188b0f479463e22095

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/780363