### PR TITLE
net-analyzer/openbsd-netcat: fix patching

### DIFF
--- a/net-analyzer/openbsd-netcat/files/openbsd-netcat-1.105-darwin.patch
+++ b/net-analyzer/openbsd-netcat/files/openbsd-netcat-1.105-darwin.patch
@@ -1,7 +1,5 @@
-Allow compilation on Darwin
-
---- netcat.c
-+++ netcat.c
+--- a/netcat.c
++++ b/netcat.c
 @@ -43,11 +43,13 @@
  #include <arpa/telnet.h>
  #include <arpa/inet.h>
@@ -73,8 +71,8 @@ Allow compilation on Darwin
  int
  main(int argc, char *argv[])
  {
---- socks.c
-+++ socks.c
+--- a/socks.c
++++ b/socks.c
 @@ -38,7 +38,7 @@
  #include <string.h>
  #include <unistd.h>

--- a/net-analyzer/openbsd-netcat/openbsd-netcat-1.105-r1.ebuild
+++ b/net-analyzer/openbsd-netcat/openbsd-netcat-1.105-r1.ebuild
@@ -29,7 +29,7 @@ src_prepare() {
 	default
 	if [[ ${CHOST} == *-darwin* ]] ; then
 		# this undoes some of the Debian/Linux changes
-		epatch "${FILESDIR}"/${P}-darwin.patch
+		eapply "${FILESDIR}"/${P}-darwin.patch
 	fi
 }
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Since `eutils` got removed (with 01ac1c40953e8a2b3ee2c52aa050f9143c8cbd5f), `epatch` wouldn't work anymore. I've update the ebuild to use `eapply` instead and also updated the patch.