### PR TITLE
dev-util/cmake: prefixify cmake Modules

### DIFF
--- a/dev-util/cmake/cmake-3.13.5.ebuild
+++ b/dev-util/cmake/cmake-3.13.5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 CMAKE_MAKEFILE_GENERATOR="emake"
 CMAKE_REMOVE_MODULES_LIST=( none )
-inherit bash-completion-r1 cmake elisp-common flag-o-matic toolchain-funcs virtualx xdg-utils
+inherit bash-completion-r1 cmake elisp-common flag-o-matic prefix toolchain-funcs virtualx xdg-utils
 
 MY_P="${P/_/-}"
 
@@ -141,6 +141,12 @@ src_prepare() {
 	if [[ ${CHOST} == *-darwin* ]] ; then
 		sed -i -e 's/__APPLE__/__DISABLED_APPLE__/' \
 			Source/cmGlobalXCodeGenerator.cxx || die
+	fi
+	if use prefix; then
+		find Modules -name "*.cmake" -type f -print0 | \
+			while IFS= read -r -d '' filename; do
+				hprefixify ${filename}
+			done
 	fi
 
 	# Add gcc libs to the default link paths

--- a/dev-util/cmake/cmake-3.18.5.ebuild
+++ b/dev-util/cmake/cmake-3.18.5.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 CMAKE_MAKEFILE_GENERATOR="emake" # Fixed in 3.19, see commit 491dddfb; bug #596460
 CMAKE_REMOVE_MODULES_LIST=( none )
 inherit bash-completion-r1 cmake elisp-common flag-o-matic multiprocessing \
-	toolchain-funcs virtualx xdg-utils
+	prefix toolchain-funcs virtualx xdg-utils
 
 MY_P="${P/_/-}"
 
@@ -133,6 +133,12 @@ src_prepare() {
 	if [[ ${CHOST} == *-darwin* ]] ; then
 		sed -i -e 's/__APPLE__/__DISABLED_APPLE__/' \
 			Source/cmGlobalXCodeGenerator.cxx || die
+	fi
+	if use prefix; then
+		find Modules -name "*.cmake" -type f -print0 | \
+			while IFS= read -r -d '' filename; do
+				hprefixify ${filename}
+			done
 	fi
 
 	# Add gcc libs to the default link paths

--- a/dev-util/cmake/cmake-3.19.7.ebuild
+++ b/dev-util/cmake/cmake-3.19.7.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 CMAKE_MAKEFILE_GENERATOR="emake" # TODO RunCMake.LinkWhatYouUse fails consistently w/ ninja
 CMAKE_REMOVE_MODULES_LIST=( none )
 inherit bash-completion-r1 cmake elisp-common flag-o-matic multiprocessing \
-	toolchain-funcs virtualx xdg-utils
+	prefix toolchain-funcs virtualx xdg-utils
 
 MY_P="${P/_/-}"
 
@@ -151,6 +151,12 @@ src_prepare() {
 			Source/cmTimestamp.cxx
 		sed -i -e 's/^#if !defined(_POSIX_C_SOURCE) && !defined(_WIN32) && !defined(__sun)/& \&\& !defined(__APPLE__)/' \
 			Source/cmStandardLexer.h
+	fi
+	if use prefix; then
+		find Modules -name "*.cmake" -type f -print0 | \
+			while IFS= read -r -d '' filename; do
+				hprefixify ${filename}
+			done
 	fi
 
 	# Add gcc libs to the default link paths

--- a/dev-util/cmake/cmake-3.20.5.ebuild
+++ b/dev-util/cmake/cmake-3.20.5.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 CMAKE_MAKEFILE_GENERATOR="emake" # TODO RunCMake.LinkWhatYouUse fails consistently w/ ninja
 CMAKE_REMOVE_MODULES_LIST=( none )
 inherit bash-completion-r1 cmake elisp-common flag-o-matic multiprocessing \
-	toolchain-funcs virtualx xdg-utils
+	prefix toolchain-funcs virtualx xdg-utils
 
 MY_P="${P/_/-}"
 
@@ -151,6 +151,12 @@ src_prepare() {
 			Source/cmTimestamp.cxx
 		sed -i -e 's/^#if !defined(_POSIX_C_SOURCE) && !defined(_WIN32) && !defined(__sun)/& \&\& !defined(__APPLE__)/' \
 			Source/cmStandardLexer.h
+	fi
+	if use prefix; then
+		find Modules -name "*.cmake" -type f -print0 | \
+			while IFS= read -r -d '' filename; do
+				hprefixify ${filename}
+			done
 	fi
 
 	# Add gcc libs to the default link paths


### PR DESCRIPTION
cmake finds detects /etc/debian_version which leads to some packages in gentoo
prefix cannot be found.

This commit provide an alternative workaround for
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5047 which has
not merged by the cmake upstream yet. If the current situation continues, please consider this fix.

The method is rather simple: hprefixify all .cmake in
${EPREFIX}/usr/share/cmake/Modules, and `/etc/debian_version` changes to
`${EPREFIX}/etc/debian_version`, while other absolute paths is also
prefixied (may resolve other unknown bugs)

The bug currently exists among all ebuilds of cmake.

Closes: https://bugs.gentoo.org/733480
Closes: https://bugs.gentoo.org/757006
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>