### PR TITLE
app-backup/dar: drop app-backup[threads] mask

### DIFF
--- a/profiles/arch/powerpc/ppc32/package.use.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.mask
@@ -5,10 +5,6 @@
 # sys-devel/clang not keyworded on PPC32.
 sys-libs/llvm-libunwind test
 
-# Viorel Munteanu <ceamac.paragon@gmail.com> (2020-03-11)
-# new package dev-libs/libthreadar has no keywords
-app-backup/dar threads
-
 # Sam James <sam@gentoo.org> (2021-03-11)
 # media-libs/libheif isn't keyworded here
 # media-libs/libavif isn't keyworded here

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -5,10 +5,6 @@
 # Unmask TPM on supported archs.
 sys-apps/systemd -tpm
 
-# Viorel Munteanu <ceamac.paragon@gmail.com> (2020-03-11)
-# new package dev-libs/libthreadar has no keywords
-app-backup/dar threads
-
 # Daniel Novomesky <dnovomesky@gmail.com> (2021-02-24)
 # Depends on media-libs/svt-av1, which is unavailable on x86
 media-libs/libavif svt-av1


### PR DESCRIPTION
`dev-libs/libthreadar` has been keyworded