### PR TITLE
x11-misc/stalonetray: HOMEPAGE fixup.

### DIFF
--- a/x11-misc/stalonetray/stalonetray-0.8.4.ebuild
+++ b/x11-misc/stalonetray/stalonetray-0.8.4.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="System tray utility including support for KDE system tray icons"
-HOMEPAGE="https://stalonetray.github.io/"
+HOMEPAGE="https://kolbusa.github.io/stalonetray/"
 SRC_URI="https://github.com/kolbusa/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Seems the URL changed ... no revbump

Package-Manager: Portage-3.0.13, Repoman-3.0.2
Signed-off-by: Jaco Kroon <jaco@uls.co.za>