### PR TITLE
xfce4-pulseaudio-plugin needs pulseaudio with glib

### DIFF
--- a/xfce-extra/xfce4-pulseaudio-plugin/xfce4-pulseaudio-plugin-0.4.3-r1.ebuild
+++ b/xfce-extra/xfce4-pulseaudio-plugin/xfce4-pulseaudio-plugin-0.4.3-r1.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 x86"
 IUSE="+keybinder libnotify wnck"
 
 RDEPEND=">=dev-libs/glib-2.42.0:=
-	media-sound/pulseaudio:=
+	media-sound/pulseaudio:=[glib]
 	>=x11-libs/gtk+-3.20.0:3=
 	>=xfce-base/exo-0.11:=
 	>=xfce-base/libxfce4ui-4.11.0:=[gtk3(+)]


### PR DESCRIPTION
xfce4-pulseaudio-plugin needs pulseaudio built with glib support, or it will fail during configuration complaining that libpulse-mainloop-glib was not found.

Signed-off-by: Sadoon AlBader <sadoon_albader@protonmail.com>