### PR TITLE
games-emulation/pcsx2: update to match upstream changes

### DIFF
--- a/games-emulation/pcsx2/pcsx2-9999.ebuild
+++ b/games-emulation/pcsx2/pcsx2-9999.ebuild
@@ -9,7 +9,7 @@ inherit cmake fcaps flag-o-matic git-r3 toolchain-funcs wxwidgets
 DESCRIPTION="A PlayStation 2 emulator"
 HOMEPAGE="https://pcsx2.net/"
 EGIT_REPO_URI="https://github.com/PCSX2/${PN}.git"
-EGIT_SUBMODULES=()
+EGIT_SUBMODULES=( 3rdparty/libchdr/libchdr )
 
 LICENSE="GPL-3"
 SLOT="0"
@@ -23,7 +23,7 @@ RDEPEND="
 	app-arch/xz-utils
 	dev-cpp/yaml-cpp:=
 	dev-libs/libaio
-	dev-libs/libfmt:=
+	>=dev-libs/libfmt-7.1.3:=
 	dev-libs/libxml2:2
 	media-libs/alsa-lib
 	media-libs/libpng:=
@@ -71,6 +71,7 @@ src_configure() {
 		-DDISABLE_BUILD_DATE=TRUE
 		-DDISABLE_PCSX2_WRAPPER=TRUE
 		-DDISABLE_SETCAP=TRUE
+		-DENABLE_TESTS="$(usex test)"
 		-DOPTIMIZATION_FLAG=
 		-DPACKAGE_MODE=TRUE
 		-DXDG_STD=TRUE


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/778362
