### PR TITLE
net-analyzer/greenbone-security-assistant: fix nodejs dependency

### DIFF
--- a/net-analyzer/greenbone-security-assistant/greenbone-security-assistant-20.8.1.ebuild
+++ b/net-analyzer/greenbone-security-assistant/greenbone-security-assistant-20.8.1.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 
 BDEPEND="
 	dev-python/polib
-	>=net-libs/nodejs-8.12.0
+	>=net-libs/nodejs-10.0.0[ssl]
 	>=sys-apps/yarn-1.15.2
 	virtual/pkgconfig
 	extras? (

--- a/net-analyzer/greenbone-security-assistant/greenbone-security-assistant-9.0.1.ebuild
+++ b/net-analyzer/greenbone-security-assistant/greenbone-security-assistant-9.0.1.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 
 BDEPEND="
 	dev-python/polib
-	>=net-libs/nodejs-8.12.0
+	>=net-libs/nodejs-8.12.0[ssl]
 	>=sys-apps/yarn-1.15.2
 	virtual/pkgconfig
 	extras? (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/779382
Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Jonas Licht <jonas.licht@fem.tu-ilmenau.de>