### PR TITLE
sci-libs/cantera: 2.5.1 fix USE="cti -python" test and installation

### DIFF
--- a/sci-libs/cantera/cantera-2.5.1-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.5.1-r1.ebuild
@@ -28,10 +28,14 @@ REQUIRED_USE="
 RDEPEND="
 	${PYTHON_DEPS}
 	lapack? ( virtual/lapack )
+	cti? (
+		$(python_gen_cond_dep '
+			dev-python/ruamel-yaml[${PYTHON_MULTI_USEDEP}]
+		')
+	)
 	python? (
 		$(python_gen_cond_dep '
 			dev-python/numpy[${PYTHON_MULTI_USEDEP}]
-			dev-python/ruamel-yaml[${PYTHON_MULTI_USEDEP}]
 		')
 	)
 	dev-cpp/yaml-cpp

--- a/sci-libs/cantera/files/cantera-2.5.1_env.patch
+++ b/sci-libs/cantera/files/cantera-2.5.1_env.patch
@@ -45,6 +45,50 @@ diff -Naur old/interfaces/cython/SConscript new/interfaces/cython/SConscript
      else:
          extra = '--user'
          localenv.AppendENVPath(
+diff -Naur old/interfaces/python_minimal/SConscript new/interfaces/python_minimal/SConscript
+--- old/interfaces/python_minimal/SConscript	2021-02-13 00:57:15.000000000 +0300
++++ new/interfaces/python_minimal/SConscript	2021-04-09 23:26:28.000000000 +0300
+@@ -8,7 +8,7 @@
+ make_setup = build(localenv.SubstFile('setup.py', 'setup.py.in'))
+ 
+ # copy scripts from the full Cython module
+-for script in ['ctml_writer', 'ck2cti']:
++for script in ['ctml_writer', 'ck2cti', 'ck2yaml', 'cti2yaml', 'ctml2yaml']:
+     # The actual script
+     s = build(env.Command('cantera/{}.py'.format(script),
+                           '#interfaces/cython/cantera/{}.py'.format(script),
+@@ -38,8 +38,7 @@
+         elif localenv['libdirname'] != 'lib':
+             # 64-bit RHEL / Fedora etc. or e.g. x32 Gentoo profile
+             extra = localenv.subst(
+-                ' --prefix=${{python_prefix}}'
+-                ' --install-lib=${{python_prefix}}/${{libdirname}}/python{}/site-packages'.format(py_version))
++                ' --prefix=${stage_dir}${prefix} --install-lib=${python_prefix}')
+         else:
+             extra = '--user'
+             localenv.AppendENVPath(
+diff -Naur old/interfaces/python_minimal/cantera/__init__.py new/interfaces/python_minimal/cantera/__init__.py
+--- old/interfaces/python_minimal/cantera/__init__.py	2021-02-13 00:57:15.000000000 +0300
++++ new/interfaces/python_minimal/cantera/__init__.py	2021-04-10 00:07:38.000000000 +0300
+@@ -1,2 +1,5 @@
+ from . import ck2cti
+ from . import ctml_writer
++from . import ck2yaml
++from . import cti2yaml
++from . import ctml2yaml
+diff -Naur old/interfaces/python_minimal/setup.py.in new/interfaces/python_minimal/setup.py.in
+--- old/interfaces/python_minimal/setup.py.in	2021-02-13 00:57:15.000000000 +0300
++++ new/interfaces/python_minimal/setup.py.in	2021-04-09 23:32:09.000000000 +0300
+@@ -12,6 +12,9 @@
+         'console_scripts': [
+             'ck2cti=cantera.ck2cti:script_entry_point',
+             'ctml_writer=cantera.ctml_writer:main',
++            'ck2yaml=cantera.ck2yaml:script_entry_point',
++            'cti2yaml=cantera.cti2yaml:main',
++            'ctml2yaml=cantera.ctml2yaml:main',
+         ],
+       },
+ )
 diff -Naur old/test_problems/SConscript new/test_problems/SConscript
 --- old/test_problems/SConscript	2021-03-21 01:18:43.000000000 +0300
 +++ new/test_problems/SConscript	2021-03-21 01:42:19.000000000 +0300


### PR DESCRIPTION
USE="cti -python" provides python_minimal Cantera installation but thisinterface had no appropriate patch to install
in proper site_packages directory in Gentoo. **Thus the installation in this case was broken.**
So there is no rev bump this time.

Also 'dev-python/ruamel-yaml' is required as RDEPEND in this case and as DEPEND for test phase.
