### PR TITLE
virtual/libusb: bump EAPI in place.

### DIFF
--- a/virtual/libusb/libusb-0-r2.ebuild
+++ b/virtual/libusb/libusb-0-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit multilib-build
 
 DESCRIPTION="Virtual for libusb"

--- a/virtual/libusb/libusb-1-r1.ebuild
+++ b/virtual/libusb/libusb-1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit multilib-build
 
 DESCRIPTION="Virtual for libusb"

--- a/virtual/libusb/libusb-1-r2.ebuild
+++ b/virtual/libusb/libusb-1-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit multilib-build
 
 DESCRIPTION="Virtual for libusb"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/781893
Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Jaco Kroon <jaco@uls.co.za>