### PR TITLE
sys-libs/pam_wrapper: compile for each version of python

### DIFF
--- a/sys-libs/pam_wrapper/pam_wrapper-1.1.3-r1.ebuild
+++ b/sys-libs/pam_wrapper/pam_wrapper-1.1.3-r1.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{8..10} )
+CMAKE_ECLASS=cmake
+
+inherit cmake-multilib python-r1
+
+DESCRIPTION="A tool to test PAM applications and PAM modules"
+HOMEPAGE="https://cwrap.org/pam_wrapper.html"
+SRC_URI="
+	https://www.samba.org/ftp/pub/cwrap/${P}.tar.gz
+	https://ftp.samba.org/pub/cwrap/${P}.tar.gz
+"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="test"
+
+RESTRICT="!test? ( test )"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	sys-libs/pam:0=[${MULTILIB_USEDEP}]
+"
+
+DEPEND="
+	${RDEPEND}
+	test? ( dev-util/cmocka[${MULTILIB_USEDEP}] )
+"
+
+multilib_src_configure() {
+	configure_for_python() {
+		local libpam="${EPREFIX}"
+		multilib_is_native_abi || libpam+="/usr"
+		libpam+="/$(get_libdir)/libpam.so.0"
+
+		local mycmakeargs=(
+			-DPAM_LIBRARY="${libpam}"
+			-DUNIT_TESTING=$(usex test)
+			-DPYTHON2_LIBRARY="/dev/null" # Disabled
+			-DPYTHON3_INCLUDE_DIR="$(python_get_includedir)"
+			-DPYTHON3_SITELIB="$(python_get_sitedir)"
+		)
+		cmake_src_configure
+	}
+	python_foreach_impl configure_for_python
+}
+
+multilib_src_compile() {
+	python_foreach_impl cmake_src_compile
+}
+
+multilib_src_install() {
+	python_foreach_impl cmake_src_install
+}


### PR DESCRIPTION
Moving from python-single-r1 to python-r1 will permits to make tests in dependencies (as example fprintd) on more than 1 python release instead of using the one set in PYTHON_SINGLE_TARGET.

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Marco Scardovi <marco@scardovi.com>