### PR TITLE
games-misc/bsd-games: banner and wtf blockers dropped

### DIFF
--- a/games-misc/bsd-games/bsd-games-3.1-r1.ebuild
+++ b/games-misc/bsd-games/bsd-games-3.1-r1.ebuild
@@ -23,8 +23,6 @@ RESTRICT="test"
 DEPEND="
 	sys-apps/miscfiles
 	sys-libs/ncurses:=
-	!games-misc/wtf
-	!app-misc/banner
 	!games-puzzle/hangman
 	!games-misc/wumpus
 "


### PR DESCRIPTION
this version doesn't provide banner and wtf
so the blockers aren't necessary

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>