### PR TITLE
sys-kernel/dracut-crypt-ssh: Fix building with --as-needed

### DIFF
--- a/sys-kernel/dracut-crypt-ssh/dracut-crypt-ssh-1.0.7.ebuild
+++ b/sys-kernel/dracut-crypt-ssh/dracut-crypt-ssh-1.0.7.ebuild
@@ -25,7 +25,7 @@ RDEPEND="${DEPEND}
 	)
 	net-misc/dropbear"
 
-PATCHES=( "${FILESDIR}"/${P}-ldflags.patch )
+PATCHES=( "${FILESDIR}"/${P}-makefile.patch )
 
 src_configure() {
 	tc-export CC

--- a/sys-kernel/dracut-crypt-ssh/files/dracut-crypt-ssh-1.0.7-makefile.patch
+++ b/sys-kernel/dracut-crypt-ssh/files/dracut-crypt-ssh-1.0.7-makefile.patch
@@ -1,4 +1,5 @@
 # https://bugs.gentoo.org/726014
+# https://bugs.gentoo.org/781125
 --- a/modules/60crypt-ssh/helper/Makefile
 +++ b/modules/60crypt-ssh/helper/Makefile
 @@ -17,11 +17,11 @@ clean:
@@ -10,7 +11,7 @@
  
  unlock:	crypttab.o unlock.o
 -	$(CC) $(CFLAGS) -lblkid $^ -o $@
-+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -lblkid $^ -o $@
++	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -lblkid -o $@
  
  crypttab-test: crypttab-test.c crypttab.o crypttab-test-data
 -	$(CC) crypttab-test.c $(CFLAGS) crypttab.o -lblkid -o crypttab-test


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/781125