### PR TITLE
dev-java/odfdom: Do not depend on dev-java/xml-commons-external

### DIFF
--- a/dev-java/odfdom/odfdom-0.8.6-r2.ebuild
+++ b/dev-java/odfdom/odfdom-0.8.6-r2.ebuild
@@ -14,8 +14,7 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~x86-linux ~sparc-solaris ~x86-solaris"
 
-CDEPEND="dev-java/xerces:2
-	dev-java/xml-commons-external:1.4"
+CDEPEND="dev-java/xerces:2"
 
 BDEPEND="app-arch/unzip"
 RDEPEND=">=virtual/jre-1.5
@@ -30,7 +29,7 @@ DEPEND=">=virtual/jdk-1.5
 
 S="${WORKDIR}/${P}-sources"
 
-EANT_GENTOO_CLASSPATH="xerces-2,xml-commons-external-1.4"
+EANT_GENTOO_CLASSPATH="xerces-2"
 EANT_BUILD_TARGET="package"
 EANT_JAVADOC_TARGET="javadoc"
 EANT_EXTRA_ARGS="-Dmaven.test.skip=true"


### PR DESCRIPTION
Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>

Compiling without `dev-java/xml-commons-external` produces errors: [build.log.gz](https://github.com/gentoo/gentoo/files/6304193/build.log.gz)
