### PR TITLE
media-libs/gegl: >=0.4.30 drop gnome2-utils eclass. Improve bash variable call

### DIFF
--- a/media-libs/gegl/gegl-0.4.30.ebuild
+++ b/media-libs/gegl/gegl-0.4.30.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{7..9} )
 # vala and introspection support is broken, bug #468208
 VALA_USE_DEPEND=vapigen
 
-inherit meson gnome2-utils optfeature python-any-r1 vala
+inherit meson optfeature python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -103,13 +103,11 @@ src_prepare() {
 	# fix 'build'headers from *.cl on gentoo-hardened, bug 739816
 	pushd "${S}/opencl/" || die
 	for file in *.cl; do
-		if [ -f "$file" ]; then
+		if [[ -f ${file} ]]; then
 			"${EPYTHON}" cltostring.py "${file}" || die
 		fi
 	done
 	popd || die
-
-	gnome2_environment_reset
 
 	use vala && vala_src_prepare
 }

--- a/media-libs/gegl/gegl-9999.ebuild
+++ b/media-libs/gegl/gegl-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{7..9} )
 VALA_USE_DEPEND=vapigen
 
-inherit meson gnome2-utils optfeature python-any-r1 vala
+inherit meson optfeature python-any-r1 vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -98,8 +98,6 @@ src_prepare() {
 	sed -e '/clones.xml/d' \
 		-e '/composite-transform.xml/d' \
 		-i tests/compositions/meson.build || die
-
-	gnome2_environment_reset
 
 	use vala && vala_src_prepare
 }


### PR DESCRIPTION
Taking into account of the comments in https://github.com/gentoo/gentoo/pull/20206