### PR TITLE
app-shells/bash-completion: add missing user-info eclass

### DIFF
--- a/app-shells/bash-completion/bash-completion-9999.ebuild
+++ b/app-shells/bash-completion/bash-completion-9999.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
-inherit autotools git-r3 python-any-r1
+inherit autotools git-r3 python-any-r1 user-info
 
 DESCRIPTION="Programmable Completion for bash"
 HOMEPAGE="https://github.com/scop/bash-completion"


### PR DESCRIPTION
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Hi,

The ebuild calls `egethome` but doesn't inherit the `user-info` eclass. This PR simply fixes this issue.