### PR TITLE
dev-java/apple-java-extensions-bin: EAPI 7, jre update

### DIFF
--- a/dev-java/apple-java-extensions-bin/apple-java-extensions-bin-1.5-r2.ebuild
+++ b/dev-java/apple-java-extensions-bin/apple-java-extensions-bin-1.5-r2.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit java-pkg-2
+
+DESCRIPTION="Apple eAWT and eIO APIs for Java on Mac OS X"
+HOMEPAGE="http://developer.apple.com/samplecode/AppleJavaExtensions/"
+SRC_URI="http://developer.apple.com/samplecode/AppleJavaExtensions/AppleJavaExtensions.zip -> ${P}.zip"
+
+LICENSE="Apple"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="app-arch/unzip"
+RDEPEND=">=virtual/jre-1.8:*"
+
+S=${WORKDIR}/AppleJavaExtensions
+
+src_install() {
+	dodoc README.txt
+	java-pkg_dojar AppleJavaExtensions.jar
+}


### PR DESCRIPTION
 * Messages for package dev-java/apple-java-extensions-bin-1.5-r2:

 * !!! This package inherits java-pkg but doesn't depend on a JDK. -bin or broken dependency!!!
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.