### PR TITLE
*/* imake fixes

### DIFF
--- a/app-i18n/kinput2/kinput2-3.1-r2.ebuild
+++ b/app-i18n/kinput2/kinput2-3.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -28,7 +28,7 @@ RDEPEND="x11-libs/libICE
 	freewnn? ( app-i18n/freewnn )"
 DEPEND="${RDEPEND}
 	x11-misc/gccmakedep
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
@@ -47,12 +47,15 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf -a || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {
 	emake \
+		AR="$(tc-getAR) cq" \
 		CC="$(tc-getCC)" \
+		RANLIB="$(tc-getRANLIB)" \
 		CDEBUGFLAGS="${CFLAGS}" \
 		LOCAL_LDFLAGS="${LDFLAGS}" \
 		XAPPLOADDIR="${EPREFIX}/usr/share/X11/app-defaults"

--- a/app-misc/oneko/oneko-1.2_p6_p14-r1.ebuild
+++ b/app-misc/oneko/oneko-1.2_p6_p14-r1.ebuild
@@ -28,7 +28,7 @@ DEPEND="
 BDEPEND="
 	app-text/rman
 	x11-misc/gccmakedep
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 PATCHES=(
 	"${FILESDIR}"/${P/_p*}-include.patch
@@ -41,20 +41,17 @@ src_prepare() {
 	done
 
 	default
-
-	printf '#!/bin/sh\n%s ${*}\n' "$(tc-getLD)" > "${T}"/ld
-	chmod +x "${T}"/ld
-	export PATH="${T}:${PATH}"
 }
 
 src_configure() {
-	xmkmf -a || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {
 	emake \
 		CC="$(tc-getCC)" \
-		CCOPTIONS="${CFLAGS}" \
+		CDEBUGFLAGS="${CFLAGS}" \
 		EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 

--- a/app-office/magicpoint/magicpoint-1.13a_p20121015-r1.ebuild
+++ b/app-office/magicpoint/magicpoint-1.13a_p20121015-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -43,7 +43,7 @@ DEPEND="${COMMON_DEPEND}
 	x11-base/xorg-proto
 	x11-libs/libxkbfile
 	app-text/rman
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 RDEPEND="${COMMON_DEPEND}
 	contrib? ( dev-lang/perl )
 	nls? ( sys-devel/gettext )
@@ -97,16 +97,21 @@ src_configure() {
 		--disable-freetype \
 		--x-libraries=/usr/lib/X11 \
 		--x-includes=/usr/include/X11
+
+	export IMAKECPP="${IMAKECPP:-$(tc-getCPP)}"
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" xmkmf || die
 }
 
 src_compile() {
-	xmkmf || die
 	# no parallel build possible anywhere
-	emake -j1 Makefiles
+	emake -j1 Makefiles \
+		CC="$(tc-getBUILD_CC)" \
+		LD="$(tc-getLD)"
 
-	tc-export CC
 	emake -j1 \
-		CC="${CC}" \
+		AR="$(tc-getAR) cq" \
+		CC="$(tc-getCC)" \
+		RANLIB="$(tc-getRANLIB)" \
 		CDEBUGFLAGS="${CFLAGS}" \
 		LOCAL_LDFLAGS="${LDFLAGS}" \
 		BINDIR=/usr/bin \

--- a/games-action/xpilot/xpilot-4.5.5-r1.ebuild
+++ b/games-action/xpilot/xpilot-4.5.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -20,7 +20,7 @@ DEPEND="${RDEPEND}
 	app-text/rman
 	x11-base/xorg-proto
 	x11-misc/gccmakedep
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 
 src_prepare() {
 	#default
@@ -38,12 +38,18 @@ src_prepare() {
 		src/client/textinterface.c || die
 }
 
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
+}
+
 src_compile() {
-	xmkmf || die
-	emake Makefiles
-	emake includes
-	emake depend
-	emake CC="$(tc-getCC)" CDEBUGFLAGS="${CFLAGS} ${LDFLAGS}"
+	emake \
+		AR="$(tc-getAR) cq" \
+		CC="$(tc-getCC)" \
+		RANLIB="$(tc-getRANLIB)" \
+		CDEBUGFLAGS="${CFLAGS}" \
+		LOCAL_LDFLAGS="${LDFLAGS}"
 }
 
 src_install() {

--- a/games-arcade/xboing/xboing-2.4-r3.ebuild
+++ b/games-arcade/xboing/xboing-2.4-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-inherit flag-o-matic eutils
+inherit eutils flag-o-matic toolchain-funcs
 
 DESCRIPTION="Blockout type game where you bounce a ball trying to destroy blocks"
 HOMEPAGE="http://www.techrescue.org/xboing/"
@@ -20,7 +20,7 @@ RDEPEND="acct-group/gamestat
 DEPEND="${RDEPEND}
 	app-text/rman
 	x11-misc/gccmakedep
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 
 S=${WORKDIR}/${PN}
@@ -34,26 +34,29 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf -a || die
 	sed -i -e "s:GENTOO_VER:${PF/${PN}-/}:" Imakefile || die
 	append-cflags -fcommon
+
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {
 	emake \
-		CXXOPTIONS="${CXXFLAGS}" \
+		CC="$(tc-getCC)" \
 		CDEBUGFLAGS="${CFLAGS}" \
 		LOCAL_LDFLAGS="${LDFLAGS}" \
 		XBOING_DIR="/usr/share/${PN}"
 }
 
 src_install() {
-	make \
+	emake \
+		CC="$(tc-getCC)" \
 		PREFIX="${D}" \
 		BINDIR="${D}/usr/bin" \
 		LOCAL_LDFLAGS="${LDFLAGS}" \
 		XBOING_DIR="/usr/share/${PN}" \
-		install || die
+		install
 	newman xboing.man xboing.6
 	dodoc README docs/*.doc
 

--- a/games-arcade/xscavenger/xscavenger-1.4.4-r2.ebuild
+++ b/games-arcade/xscavenger/xscavenger-1.4.4-r2.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-BDEPEND="x11-misc/imake"
+BDEPEND=">=x11-misc/imake-1.0.8-r1"
 RDEPEND="x11-libs/libXext"
 DEPEND="${RDEPEND}"
 
@@ -33,7 +33,8 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {

--- a/games-board/xgammon/xgammon-0.98-r2.ebuild
+++ b/games-board/xgammon/xgammon-0.98-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,7 +20,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	app-text/rman
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 
 S="${WORKDIR}/${P}a"
 
@@ -32,7 +32,8 @@ PATCHES=(
 )
 
 src_configure() {
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {

--- a/games-board/xmille/xmille-2.0-r4.ebuild
+++ b/games-board/xmille/xmille-2.0-r4.ebuild
@@ -34,7 +34,7 @@ src_configure() {
 
 src_compile() {
 	emake -j1 \
-		AR="$(tc-getAR) clq" \
+		AR="$(tc-getAR) cq" \
 		RANLIB="$(tc-getRANLIB)" \
 		CC="$(tc-getCC)" \
 		CDEBUGFLAGS="${CFLAGS}" \

--- a/games-board/xmille/xmille-2.0-r4.ebuild
+++ b/games-board/xmille/xmille-2.0-r4.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86"
 
 BDEPEND="
 	app-text/rman
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 RDEPEND="x11-libs/libXext"
 DEPEND="${RDEPEND}"
@@ -29,7 +29,8 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {

--- a/games-board/xscrabble/xscrabble-2.10-r3.ebuild
+++ b/games-board/xscrabble/xscrabble-2.10-r3.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 "
 BDEPEND="
 	x11-misc/gccmakedep
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 
 PATCHES=(
@@ -51,7 +51,8 @@ src_prepare() {
 }
 
 src_configure() {
-	tc-export AR CC RANLIB
+	tc-export AR CC LD RANLIB
+	export IMAKECPP=${IMAKECPP:-$(tc-getCPP)}
 }
 
 src_compile() {

--- a/games-board/xscrabble/xscrabble-2.10-r3.ebuild
+++ b/games-board/xscrabble/xscrabble-2.10-r3.ebuild
@@ -47,7 +47,7 @@ src_prepare() {
 	# Don't strip binaries
 	sed -i '/install/s/-s //' build || die
 	# Respect AR, RANLIB
-	sed -i 's/CC="${CC}"/& AR="${AR} clq" RANLIB="${RANLIB}"/' build || die
+	sed -i 's/CC="${CC}"/& AR="${AR} cq" RANLIB="${RANLIB}"/' build || die
 }
 
 src_configure() {

--- a/games-board/xskat/xskat-4.0-r1.ebuild
+++ b/games-board/xskat/xskat-4.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,11 +18,11 @@ RDEPEND="media-fonts/font-misc-misc
 DEPEND="${RDEPEND}
 	x11-base/xorg-proto
 	x11-misc/gccmakedep
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 
-src_prepare() {
-	default
-	xmkmf -a || die
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {

--- a/games-misc/xcruiser/xcruiser-0.30-r1.ebuild
+++ b/games-misc/xcruiser/xcruiser-0.30-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -18,11 +18,15 @@ RDEPEND="x11-libs/libXaw"
 DEPEND="${RDEPEND}
 	app-text/rman
 	x11-misc/gccmakedep
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
+
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
+}
 
 src_compile() {
-	xmkmf -a
-	emake CC=$(tc-getCC) CDEBUGFLAGS="${CFLAGS}" LOCAL_LDFLAGS="${LDFLAGS}"
+	emake CC="$(tc-getCC)" CDEBUGFLAGS="${CFLAGS}" LOCAL_LDFLAGS="${LDFLAGS}"
 }
 
 src_install() {

--- a/media-fonts/x11fonts-jmk/x11fonts-jmk-3.0-r4.ebuild
+++ b/media-fonts/x11fonts-jmk/x11fonts-jmk-3.0-r4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit font
+inherit font toolchain-funcs
 
 MY_P="jmk-x11-fonts-${PV}"
 
@@ -15,7 +15,7 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm ~ia64 ppc ~s390 sparc x86"
 
 BDEPEND="
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	>=x11-apps/mkfontscale-1.2.0
 	x11-apps/bdftopcf"
 
@@ -25,9 +25,9 @@ PATCHES=( "${FILESDIR}"/gzip.patch )
 
 S="${WORKDIR}/${MY_P}"
 
-src_compile() {
-	xmkmf || die
-	default
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_install() {

--- a/media-gfx/transfig/transfig-3.2.5e-r1.ebuild
+++ b/media-gfx/transfig/transfig-3.2.5e-r1.ebuild
@@ -20,9 +20,10 @@ RDEPEND="x11-libs/libXpm
 	virtual/jpeg
 	media-libs/libpng
 	x11-apps/rgb"
-DEPEND="${RDEPEND}
-	x11-misc/imake
-	app-text/rman"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	app-text/rman
+	>=x11-misc/imake-1.0.8-r1"
 
 S=${WORKDIR}/${MY_P}
 
@@ -61,11 +62,6 @@ sed_Imakefile() {
 src_prepare() {
 	default
 
-	# Create wrapper for gcc, bug #720820
-	printf '#!/bin/sh\n%s ${*}\n' "$(tc-getCC)" > "${T}"/gcc
-	chmod +x "${T}"/gcc
-	export PATH="${T}:${PATH}"
-
 	find . -type f -exec chmod a-x '{}' \; || die
 	find . -name Makefile -delete || die
 
@@ -75,10 +71,13 @@ src_prepare() {
 	sed_Imakefile fig2dev/Imakefile fig2dev/dev/Imakefile
 }
 
-src_compile() {
-	xmkmf || die "xmkmf failed"
-	emake Makefiles
+src_configure() {
+	export IMAKECPP=${IMAKECPP:-$(tc-getCPP)}
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" xmkmf || die
+}
 
+src_compile() {
+	emake CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" Makefiles
 	emake CC="$(tc-getCC)" AR="$(tc-getAR) cq" RANLIB="$(tc-getRANLIB)" \
 		LOCAL_LDFLAGS="${LDFLAGS}" CDEBUGFLAGS="${CFLAGS}" \
 		USRLIBDIR="${EPREFIX}/usr/$(get_libdir)"

--- a/media-gfx/transfig/transfig-3.2.5e-r1.ebuild
+++ b/media-gfx/transfig/transfig-3.2.5e-r1.ebuild
@@ -79,7 +79,7 @@ src_compile() {
 	xmkmf || die "xmkmf failed"
 	emake Makefiles
 
-	emake CC="$(tc-getCC)" AR="$(tc-getAR) clq" RANLIB="$(tc-getRANLIB)" \
+	emake CC="$(tc-getCC)" AR="$(tc-getAR) cq" RANLIB="$(tc-getRANLIB)" \
 		LOCAL_LDFLAGS="${LDFLAGS}" CDEBUGFLAGS="${CFLAGS}" \
 		USRLIBDIR="${EPREFIX}/usr/$(get_libdir)"
 }

--- a/media-gfx/xli/xli-1.17.0-r5.ebuild
+++ b/media-gfx/xli/xli-1.17.0-r5.ebuild
@@ -23,7 +23,7 @@ RDEPEND="app-arch/bzip2
 DEPEND="${RDEPEND}
 	app-text/rman
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	!media-gfx/xloadimage"
 
 S=${WORKDIR}/${PN}-${SNAPSHOT}
@@ -53,8 +53,12 @@ src_prepare() {
 		"${FILESDIR}"/${P}-libpng14.patch
 }
 
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
+}
+
 src_compile() {
-	xmkmf || die
 	emake CDEBUGFLAGS="${CFLAGS}" CC="$(tc-getCC)" EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 

--- a/media-libs/nas/nas-1.9.4-r2.ebuild
+++ b/media-libs/nas/nas-1.9.4-r2.ebuild
@@ -24,13 +24,14 @@ RDEPEND="
 	x11-libs/libXmu
 	x11-libs/libXpm
 	>=x11-libs/libXt-1.1.4[${MULTILIB_USEDEP}]"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	app-text/rman
 	sys-devel/bison
 	sys-devel/flex
 	x11-base/xorg-proto
 	x11-misc/gccmakedep
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 
 DOCS=( BUILDNOTES FAQ HISTORY README RELEASE TODO )
 
@@ -51,7 +52,8 @@ multilib_src_configure() {
 	pushd config || die
 	econf
 	popd || die
-	xmkmf -a || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 multilib_src_compile() {
@@ -82,7 +84,7 @@ multilib_src_compile() {
 			Makefile || die
 	fi
 
-	emake "${emakeopts[@]}" World
+	emake "${emakeopts[@]}"
 }
 
 multilib_src_install() {

--- a/media-libs/nas/nas-1.9.4-r2.ebuild
+++ b/media-libs/nas/nas-1.9.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -57,7 +57,7 @@ multilib_src_configure() {
 multilib_src_compile() {
 	# EXTRA_LDOPTIONS, SHLIBGLOBALSFLAGS #336564#c2
 	local emakeopts=(
-		AR="$(tc-getAR) clq"
+		AR="$(tc-getAR) cq"
 		AS="$(tc-getAS)"
 		CC="$(tc-getCC)"
 		CDEBUGFLAGS="${CFLAGS}"

--- a/media-radio/ibp/ibp-0.21-r1.ebuild
+++ b/media-radio/ibp/ibp-0.21-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -16,7 +16,7 @@ IUSE="X"
 RDEPEND="sys-libs/ncurses:0
 	X? ( x11-libs/libX11  )"
 DEPEND="${RDEPEND}
-	X? ( x11-misc/imake )"
+	X? ( >=x11-misc/imake-1.0.8-r1 )"
 
 src_prepare() {
 	# respect CFLAGS if built without USE=X
@@ -31,7 +31,8 @@ src_prepare() {
 
 src_configure() {
 	if use X ;then
-		xmkmf || die
+		CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+			IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 	fi
 }
 

--- a/net-misc/vncrec/vncrec-0.2-r2.ebuild
+++ b/net-misc/vncrec/vncrec-0.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -24,7 +24,7 @@ DEPEND="${RDEPEND}
 	app-text/rman
 	x11-base/xorg-proto
 	x11-misc/gccmakedep
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 
 DOCS=( README README.vnc )
@@ -38,13 +38,16 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf -a || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {
 	emake \
-		CC=$(tc-getCC) \
-		CCOPTIONS="${CXXFLAGS}" \
+		AR="$(tc-getAR) cq" \
+		CC="$(tc-getCC)" \
+		RANLIB="$(tc-getRANLIB)" \
+		CDEBUGFLAGS="${CFLAGS}" \
 		EXTRA_LDOPTIONS="${LDFLAGS}" \
 		World
 }

--- a/net-misc/x11-ssh-askpass/x11-ssh-askpass-1.2.4.1-r2.ebuild
+++ b/net-misc/x11-ssh-askpass/x11-ssh-askpass-1.2.4.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -21,16 +21,16 @@ RDEPEND="virtual/ssh
 	x11-libs/libXt"
 DEPEND="${RDEPEND}"
 BDEPEND="app-text/rman
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 
 src_configure() {
 	econf --libexecdir=/usr/"$(get_libdir)"/misc \
 		--disable-installing-app-defaults
-	xmkmf || die "xmkmf failed"
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die "xmkmf failed"
 }
 
 src_compile() {
-	emake includes
 	emake CC="$(tc-getCC)" CDEBUGFLAGS="${CFLAGS}"
 }
 

--- a/sci-calculators/hexcalc/hexcalc-1.11-r3.ebuild
+++ b/sci-calculators/hexcalc/hexcalc-1.11-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,15 +16,19 @@ IUSE=""
 
 RDEPEND="x11-libs/libXaw"
 DEPEND="${RDEPEND}
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	app-text/rman"
 
 S=${WORKDIR}/${PN}
 
 PATCHES=( "${FILESDIR}"/${PN}-{keypad,order}.diff )
 
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
+}
+
 src_compile() {
-	xmkmf || die
 	emake \
 		CC="$(tc-getCC)" \
 		CFLAGS="${CFLAGS}" \

--- a/sci-chemistry/rasmol/rasmol-2.7.5.2-r2.ebuild
+++ b/sci-chemistry/rasmol/rasmol-2.7.5.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -33,7 +33,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	app-text/rman
 	x11-base/xorg-proto
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 
 #S="${WORKDIR}/${PN}-2.7.5-${VERS}"
 S="${WORKDIR}/RasMol-${PV}"
@@ -78,7 +78,8 @@ src_prepare() {
 	mv vector.c v_ector.c || die
 	mv vector.h v_ector.h || die
 
-	xmkmf -DGTKWIN || die "xmkmf failed with ${myconf}"
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -DGTKWIN || die
 }
 
 src_compile() {

--- a/x11-misc/dclock/dclock-2.2.2_p12.ebuild
+++ b/x11-misc/dclock/dclock-2.2.2_p12.ebuild
@@ -30,7 +30,7 @@ DEPEND="
 "
 BDEPEND="
 	app-text/rman
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	xft? ( virtual/pkgconfig )
 "
 S=${WORKDIR}/${P/_p*/}
@@ -53,7 +53,8 @@ src_configure() {
 		sed -i -e '/EXTRA_LIBRARIES/s|^|#|g' Imakefile || die
 	fi
 
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {

--- a/x11-misc/imake/files/imake-1.0.8-cpp-args.patch
+++ b/x11-misc/imake/files/imake-1.0.8-cpp-args.patch
@@ -1,0 +1,18 @@
+Copy code from IMAKEINCLUDE to IMAKECPP to handle arguments
+such as -E. Lets IMAKECPP=$(tc-getCPP) be usable.
+--- a/imake.c
++++ b/imake.c
+@@ -532,6 +532,12 @@
+ 			}
+ 	}
+-	if ((p = getenv("IMAKECPP")))
++	if ((p = getenv("IMAKECPP"))) {
+ 		cpp = p;
++		for (; *p; p++)
++			if (*p == ' ') {
++				*p++ = '\0';
++				AddCppArg(p);
++			}
++	}
+ 	if ((p = getenv("IMAKEMAKE")))
+ 		make_argv[0] = p;

--- a/x11-misc/imake/files/imake-1.0.8-no-get-gcc.patch
+++ b/x11-misc/imake/files/imake-1.0.8-no-get-gcc.patch
@@ -1,0 +1,37 @@
+If /usr/bin/cc exists then get_gcc() is always true on Linux (and many
+others), but will fail in the event it's missing (-native-symlinks).
+
+get_gcc_version does not execute gcc and merely sets defines, so
+call it without using get_gcc(). Validity of using NULL should be
+verified if there's ever a new version.
+--- a/imake.c
++++ b/imake.c
+@@ -1341,4 +1341,5 @@
+ #endif
+ 
++#if defined CROSSCOMPILE
+ static boolean
+ get_gcc(char *cmd)
+@@ -1394,5 +1395,4 @@
+ }
+ 
+-#ifdef CROSSCOMPILE
+ static void
+ get_gcc_incdir(FILE *inFile, char* name)
+@@ -1640,12 +1640,14 @@
+ #  endif
+ 	{
++#  if defined CROSSCOMPILE
+ 	  char name[PATH_MAX];
+ 	  if (get_gcc(name)) {
+ 	      get_gcc_version (inFile,name);
+-#  if defined CROSSCOMPILE
+ 	      if (sys != emx)
+ 		  get_gcc_incdir(inFile,name);
+-#  endif
+ 	  }
++#  else
++	  get_gcc_version(inFile,NULL);
++#  endif
+ 	}
+ # endif

--- a/x11-misc/imake/files/imake-1.0.8-respect-LD.patch
+++ b/x11-misc/imake/files/imake-1.0.8-respect-LD.patch
@@ -1,0 +1,15 @@
+Use LD env if available, other tests already do similar for CC.
+https://bugs.gentoo.org/729630
+--- a/imake.c
++++ b/imake.c
+@@ -1110,5 +1110,9 @@
+   signed char c;
+   int ldmajor, ldminor;
+-  const char *ld = "ld -v";
++  char ld[PATH_MAX];
++  const char *ldenv;
++  if (!(ldenv = getenv("LD")))
++    ldenv = "ld";
++  snprintf(ld, PATH_MAX, "%s -v", ldenv);
+ 
+ # ifdef CROSSCOMPILE

--- a/x11-misc/imake/files/imake-1.0.8-xmkmf-pass-cc-ld.patch
+++ b/x11-misc/imake/files/imake-1.0.8-xmkmf-pass-cc-ld.patch
@@ -1,0 +1,15 @@
+Makefile calls imake again but with ignored CC/LD.
+Passing only if set rather than use defaults.
+--- a/xmkmf.cpp
++++ b/xmkmf.cpp
+@@ -56,7 +56,7 @@
+     echo "make Makefiles" &&
+-    make Makefiles &&
++    make ${CC:+CC="$CC"} ${LD:+LD="$LD"} Makefiles &&
+     echo "make includes" &&
+-    make includes &&
++    make ${CC:+CC="$CC"} ${LD:+LD="$LD"} includes &&
+     echo "make depend" &&
+-    make depend
++    make ${CC:+CC="$CC"} ${LD:+LD="$LD"} depend
+     ;;

--- a/x11-misc/imake/imake-1.0.8-r1.ebuild
+++ b/x11-misc/imake/imake-1.0.8-r1.ebuild
@@ -7,11 +7,9 @@ inherit toolchain-funcs xorg-3
 
 DESCRIPTION="C preprocessor interface to the make utility"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
-IUSE=""
 
 RDEPEND="x11-misc/xorg-cf-files"
-DEPEND="${RDEPEND}
-	x11-base/xorg-proto"
+BDEPEND="x11-base/xorg-proto"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-cpp-args.patch
@@ -21,5 +19,5 @@ PATCHES=(
 )
 
 src_configure() {
-	econf CPP="$(tc-getPROG CPP cpp)"
+	econf CPP="$(tc-getPROG CPP cpp)" #722046
 }

--- a/x11-misc/imake/imake-1.0.8-r1.ebuild
+++ b/x11-misc/imake/imake-1.0.8-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs xorg-3
+
+DESCRIPTION="C preprocessor interface to the make utility"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE=""
+
+RDEPEND="x11-misc/xorg-cf-files"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-cpp-args.patch
+	"${FILESDIR}"/${P}-no-get-gcc.patch
+	"${FILESDIR}"/${P}-respect-LD.patch
+	"${FILESDIR}"/${P}-xmkmf-pass-cc-ld.patch
+)
+
+src_configure() {
+	econf CPP="$(tc-getPROG CPP cpp)"
+}

--- a/x11-misc/x2x/x2x-1.27-r3.ebuild
+++ b/x11-misc/x2x/x2x-1.27-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,10 +20,11 @@ IUSE=""
 RDEPEND="x11-libs/libX11
 	x11-libs/libXtst
 	x11-libs/libXext"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	app-text/rman
 	x11-base/xorg-proto
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 
 PATCHES=(
 	# Patch from Debian to add -north and -south, among other fixes
@@ -45,7 +46,8 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {

--- a/x11-misc/xautolock/xautolock-2.2_p7.ebuild
+++ b/x11-misc/xautolock/xautolock-2.2_p7.ebuild
@@ -19,11 +19,11 @@ KEYWORDS="amd64 ~arm ~arm64 ppc sparc x86"
 RDEPEND="
 	x11-libs/libXScrnSaver
 "
-DEPEND="
-	${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	app-text/rman
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.2_p5_p1-waitpid.patch
@@ -37,7 +37,8 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {

--- a/x11-misc/xbatt/xbatt-1.3_rc1.ebuild
+++ b/x11-misc/xbatt/xbatt-1.3_rc1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -24,15 +24,19 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.2.1-implicits.patch
 )
 S="${WORKDIR}"/${PN}-$(ver_cut 1-2)
 
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
+}
+
 src_compile() {
-	xmkmf || die
 	emake \
 		CC="$(tc-getCC)" \
 		CDEBUGFLAGS="${CFLAGS}" \

--- a/x11-misc/xcalendar/xcalendar-4.0-r2.ebuild
+++ b/x11-misc/xcalendar/xcalendar-4.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -20,7 +20,7 @@ RDEPEND="x11-libs/libX11
 	x11-libs/libXext"
 DEPEND="${RDEPEND}
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	x11-misc/gccmakedep
 	motif? ( >=x11-libs/motif-2.3:0 )"
 
@@ -35,9 +35,16 @@ src_prepare() {
 		-i XCalendar.sed || die
 }
 
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
+}
+
 src_compile() {
-	xmkmf -a || die
-	emake CC="$(tc-getCC)" CDEBUGFLAGS="${CFLAGS}" EXTRA_LDOPTIONS="${LDFLAGS}"
+	emake \
+		CC="$(tc-getCC)" \
+		CDEBUGFLAGS="${CFLAGS}" \
+		EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 
 src_install() {

--- a/x11-misc/xearth/xearth-1.1-r1.ebuild
+++ b/x11-misc/xearth/xearth-1.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -22,7 +22,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	app-text/rman
 "
 
@@ -31,12 +31,14 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {
-	emake CC=$(tc-getCC) \
-		CCOPTIONS="${CFLAGS}" \
+	emake \
+		CC="$(tc-getCC)" \
+		CDEBUGFLAGS="${CFLAGS}" \
 		EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 

--- a/x11-misc/xfishtank/xfishtank-2.5.ebuild
+++ b/x11-misc/xfishtank/xfishtank-2.5.ebuild
@@ -18,17 +18,16 @@ RDEPEND="
 	x11-libs/libXext
 	x11-libs/libXt
 "
-DEPEND="
-	${RDEPEND}
-	x11-base/xorg-proto
-"
+DEPEND="${RDEPEND}"
 BDEPEND="
-	x11-misc/imake
+	x11-base/xorg-proto
+	>=x11-misc/imake-1.0.8-r1
 "
 S=${WORKDIR}/${PN}
 
 src_configure() {
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {

--- a/x11-misc/xkeycaps/xkeycaps-2.47_p7.ebuild
+++ b/x11-misc/xkeycaps/xkeycaps-2.47_p7.ebuild
@@ -23,11 +23,11 @@ RDEPEND="
 	x11-libs/libXt
 	x11-misc/xbitmaps
 "
-DEPEND="
-	${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	>=sys-apps/sed-4
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 
 DOCS=( README defining.txt hierarchy.txt sgi-microsoft.txt )
@@ -46,7 +46,8 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 	sed -i \
 		-e "s,all:: xkeycaps.\$(MANSUFFIX).html,all:: ,g" \
 		Makefile || die

--- a/x11-misc/xorg-cf-files/files/xorg-cf-files-1.0.6-no-ar-l.patch
+++ b/x11-misc/xorg-cf-files/files/xorg-cf-files-1.0.6-no-ar-l.patch
@@ -1,0 +1,20 @@
+l argument was formerly ignored by binutils, but since 2.36 is used
+for something other than what was intended here (tmp files location).
+https://bugs.gentoo.org/782514
+--- a/Imake.tmpl
++++ b/Imake.tmpl
+@@ -1083,3 +1083,3 @@
+ #else
+-#define ArCmd ArCmdBase clq
++#define ArCmd ArCmdBase cq
+ #endif
+@@ -1090,3 +1090,3 @@
+ #else
+-#define ArAddCmd ArCmdBase rul
++#define ArAddCmd ArCmdBase ru
+ #endif
+@@ -1097,3 +1097,3 @@
+ #else
+-#define ArExtCmd ArCmdBase xl
++#define ArExtCmd ArCmdBase x
+ #endif

--- a/x11-misc/xorg-cf-files/xorg-cf-files-1.0.6-r2.ebuild
+++ b/x11-misc/xorg-cf-files/xorg-cf-files-1.0.6-r2.ebuild
@@ -21,6 +21,7 @@ RDEPEND=""
 DEPEND="${RDEPEND}"
 
 PATCHES=(
+	"${FILESDIR}"/${P}-no-ar-l.patch
 	"${WORKDIR}"/${PN}-1.0.6-solaris-prefix.patch
 )
 

--- a/x11-misc/xsnap/xsnap-1.5.15-r2.ebuild
+++ b/x11-misc/xsnap/xsnap-1.5.15-r2.ebuild
@@ -24,12 +24,12 @@ RDEPEND="
 	${COMMON_DEPEND}
 	media-fonts/font-misc-misc
 "
-DEPEND="
-	${COMMON_DEPEND}
+DEPEND="${COMMON_DEPEND}"
+BDEPEND="
 	app-text/rman
 	dev-lang/perl
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 DOCS=( AUTHORS Changelog README )
 PATCHES=( "${FILESDIR}"/${P}-root_name.patch )
@@ -46,21 +46,18 @@ src_prepare() {
 	sed -i \
 		-e '/^LOCALEDIR=/d' \
 		po/Makefile || die
+}
 
-	xmkmf || die
-
-	sed -i \
-		-e '/ CC = /d' \
-		-e '/ LD = /d' \
-		-e '/ CDEBUGFLAGS = /d' \
-		-e '/ CCOPTIONS = /d' \
-		-e 's|CPP = cpp|CPP = $(CC)|g' \
-		Makefile || die
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {
-	tc-export CC
-	emake CCOPTIONS="${CFLAGS}" EXTRA_LDOPTIONS="${LDFLAGS}"
+	emake \
+		CC="$(tc-getCC)" \
+		CDEBUGFLAGS="${CFLAGS}" \
+		EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 
 src_install() {

--- a/x11-misc/xtitle/xtitle-1.0.4.ebuild
+++ b/x11-misc/xtitle/xtitle-1.0.4.ebuild
@@ -1,7 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
+
+inherit toolchain-funcs
 
 DESCRIPTION="Set window title and icon name for an X11 terminal window"
 HOMEPAGE="https://kinzler.com/me/xtitle/"
@@ -12,14 +14,14 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE=""
 
-DEPEND="x11-misc/imake"
+DEPEND=">=x11-misc/imake-1.0.8-r1"
 RDEPEND=""
 
 HTML_DOCS=( xtitle.html )
 
-src_compile() {
-	xmkmf || die
-	emake
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_install() {

--- a/x11-misc/xtoolwait/xtoolwait-1.3-r2.ebuild
+++ b/x11-misc/xtoolwait/xtoolwait-1.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,23 +16,21 @@ KEYWORDS="amd64 ppc x86"
 RDEPEND="
 	x11-libs/libX11
 	x11-libs/libXext"
-DEPEND="${RDEPEND}
-	x11-base/xorg-proto"
+DEPEND="${RDEPEND}"
 BDEPEND="
 	app-text/rman
-	x11-misc/imake"
+	x11-base/xorg-proto
+	>=x11-misc/imake-1.0.8-r1"
 
 src_configure() {
-	xmkmf || die
-	sed -i \
-		-e '/CC = /d' -e '/EXTRA_LDOPTIONS = /d' \
-		Makefile || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {
 	emake \
 		CC="$(tc-getCC)" \
-		CCOPTIONS="${CFLAGS}" \
+		CDEBUGFLAGS="${CFLAGS}" \
 		EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 

--- a/x11-misc/xtrlock/xtrlock-2.13.ebuild
+++ b/x11-misc/xtrlock/xtrlock-2.13.ebuild
@@ -12,17 +12,19 @@ SLOT="0"
 LICENSE="GPL-3"
 KEYWORDS="amd64 ppc x86"
 
-RDEPEND="
-	x11-libs/libX11
-"
-DEPEND="
-	${RDEPEND}
+RDEPEND="x11-libs/libX11"
+DEPEND="${RDEPEND}"
+BDEPEND="
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
+}
+
 src_compile() {
-	xmkmf || die
 	emake CDEBUGFLAGS="${CFLAGS} -DSHADOW_PWD" CC="$(tc-getCC)" \
 		EXTRA_LDOPTIONS="${LDFLAGS}" xtrlock
 }

--- a/x11-misc/xxkb/xxkb-1.11.1-r1.ebuild
+++ b/x11-misc/xxkb/xxkb-1.11.1-r1.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	app-text/rman
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	svg? ( virtual/pkgconfig )
 "
 
@@ -48,7 +48,9 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf $(usex svg -DWITH_SVG_SUPPORT '') || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" \
+		xmkmf $(usex svg -DWITH_SVG_SUPPORT '') || die
 }
 
 src_compile() {

--- a/x11-plugins/wmnet/wmnet-1.06-r2.ebuild
+++ b/x11-plugins/wmnet/wmnet-1.06-r2.ebuild
@@ -1,7 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
+inherit toolchain-funcs
 
 DESCRIPTION="WMnet is a dock.app network monitor"
 HOMEPAGE="https://www.dockapps.net/wmnet"
@@ -15,16 +17,24 @@ IUSE=""
 
 RDEPEND="x11-libs/libX11
 	x11-libs/libXext"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	app-text/rman"
 
 PATCHES=( "${WORKDIR}"/${P}-misc.patch )
 
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die "xmkmf failed"
+}
+
 src_compile() {
-	xmkmf || die "xmkmf failed."
-	emake CDEBUGFLAGS="${CFLAGS}" LDOPTIONS="${LDFLAGS}"
+	emake \
+		CC="$(tc-getCC)" \
+		CDEBUGFLAGS="${CFLAGS}" \
+		LDOPTIONS="${LDFLAGS}"
 }
 
 src_install() {

--- a/x11-terms/kterm/kterm-6.2.0-r6.ebuild
+++ b/x11-terms/kterm/kterm-6.2.0-r6.ebuild
@@ -27,7 +27,7 @@ RDEPEND="app-text/rman
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	x11-misc/gccmakedep
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 
 PATCHES=(
@@ -45,7 +45,8 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf -a || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {

--- a/x11-terms/root-tail/root-tail-1.2-r4.ebuild
+++ b/x11-terms/root-tail/root-tail-1.2-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,10 +16,10 @@ IUSE="kde debug"
 
 RDEPEND="x11-libs/libXext
 	x11-libs/libX11"
-DEPEND="x11-misc/imake
+DEPEND="${RDEPEND}"
+BDEPEND=">=x11-misc/imake-1.0.8-r1
 	app-text/rman
 	x11-base/xorg-proto
-	x11-libs/libX11
 	x11-misc/gccmakedep"
 
 src_prepare() {
@@ -28,15 +28,16 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf -a
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {
 	sed -i 's:/usr/X11R6/bin:/usr/bin:' Makefile || die "sed Makefile failed"
 	use debug && append-flags -DDEBUG
 	emake \
-		CC=$(tc-getCC) \
-		CCOPTIONS="${CFLAGS}" \
+		CC="$(tc-getCC)" \
+		CDEBUGFLAGS="${CFLAGS}" \
 		EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 

--- a/x11-wm/larswm/larswm-7.5.3-r2.ebuild
+++ b/x11-wm/larswm/larswm-7.5.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,20 +17,22 @@ RDEPEND="x11-libs/libX11
 	x11-libs/libXmu
 	x11-libs/libXt
 	x11-libs/libXext"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 	x11-misc/gccmakedep
 	app-text/rman"
 
 src_configure() {
-	xmkmf -a || die
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {
 	emake \
-		CC=$(tc-getCC) \
-		CCOPTIONS="${CFLAGS}" \
+		CC="$(tc-getCC)" \
+		CDEBUGFLAGS="${CFLAGS}" \
 		EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 

--- a/x11-wm/lwm/lwm-1.2.4.ebuild
+++ b/x11-wm/lwm/lwm-1.2.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,7 +23,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	x11-base/xorg-proto
-	x11-misc/imake
+	>=x11-misc/imake-1.0.8-r1
 "
 
 DOCS=( AUTHORS BUGS ChangeLog )
@@ -31,7 +31,11 @@ DOCS=( AUTHORS BUGS ChangeLog )
 src_prepare() {
 	default
 	sed -i -e "s#(SMLIB)#& -lICE#g" Imakefile || die #370127
-	xmkmf || die
+}
+
+src_configure() {
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf || die
 }
 
 src_compile() {

--- a/x11-wm/vtwm/vtwm-5.4.7-r2.ebuild
+++ b/x11-wm/vtwm/vtwm-5.4.7-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,12 +20,13 @@ RDEPEND="x11-libs/libX11
 	x11-libs/libXext
 	x11-libs/libXpm
 	rplay? ( media-sound/rplay )"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	app-text/rman
 	sys-devel/bison
 	sys-devel/flex
 	x11-base/xorg-proto
-	x11-misc/imake"
+	>=x11-misc/imake-1.0.8-r1"
 
 src_prepare() {
 	eapply "${FILESDIR}"/${P}-do-not-rm.patch
@@ -45,14 +46,14 @@ src_prepare() {
 }
 
 src_configure() {
-	xmkmf || die "xmkmf failed"
-	emake depend
+	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
+		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die "xmkmf failed"
 }
 
 src_compile() {
 	emake \
-		CC=$(tc-getCC) \
-		CCOPTIONS="${CFLAGS}" \
+		CC="$(tc-getCC)" \
+		CDEBUGFLAGS="${CFLAGS}" \
 		EXTRA_LDOPTIONS="${LDFLAGS}"
 }
 


### PR DESCRIPTION
Not happy with how messy this still is but well.

For imake itself only focused on fixing what ebuild can't do much about (unless rely on gcc/ld wrappers) all while trying not to alter imake base behavior not to break things. See first commit for details.

Updated majority of ebuilds to work with it with a few leftovers that have other problems.
(all tested with -native-symlinks, "some" can cross-compile too but more work needed there)

Included a related fix needed for still-unkeyworded binutils:2.36.

All straight-to-stable, but not really worried.