### PR TITLE
app-misc/figlet: fix building on musl

### DIFF
--- a/app-misc/figlet/figlet-2.2.5-r1.ebuild
+++ b/app-misc/figlet/figlet-2.2.5-r1.ebuild
@@ -13,6 +13,10 @@ LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
 
+PATCHES=(
+	"${FILESDIR}/${P}-musl.patch"
+)
+
 src_compile() {
 	emake clean
 	emake \

--- a/app-misc/figlet/files/figlet-2.2.5-musl.patch
+++ b/app-misc/figlet/files/figlet-2.2.5-musl.patch
@@ -1,0 +1,36 @@
+From 88428a728e1f99dcdc63d7c5ff0cd8b6cda37576 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Tue, 3 Jun 2014 10:59:40 +0000
+Subject: [PATCH] Fix build with musl libc
+
+Avoid using the glibc internal macros __BEGIN/__END_DECLS.
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+---
+ utf8.h | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/utf8.h b/utf8.h
+index 0631b8a..a3e09bd 100644
+--- a/utf8.h
++++ b/utf8.h
+@@ -27,13 +27,17 @@
+ #define UTF8_IGNORE_ERROR		0x01
+ #define UTF8_SKIP_BOM			0x02
+ 
+-__BEGIN_DECLS
++#ifdef   __cplusplus
++extern "C" {
++#endif
+ 
+ size_t		utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
+ 		    size_t outsize, int flags);
+ size_t		wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
+ 		    size_t outsize, int flags);
+ 
+-__END_DECLS
++#ifdef   __cplusplus
++}
++#endif
+ 
+ #endif /* !_UTF8_H_ */

--- a/app-misc/figlet/metadata.xml
+++ b/app-misc/figlet/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>v@0x0c.xyz</email>
+		<name>dm9pZCAq</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
on `musl` there is no `sys/cdefs.h` so `__BEGIN_DECLS` and `__END_DECLS` are undefined

and as it's only needed for `c++`, we can remove it

`utf8.h`:
```c
__BEGIN_DECLS

size_t		utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
		    size_t outsize, int flags);
size_t		wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
		    size_t outsize, int flags);

__END_DECLS
```

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: dm9pZCAq <v@0x0c.xyz>