### PR TITLE
app-crypt/seahorse: fix segfault on 40.0 when USE=-ldap

### DIFF
--- a/app-crypt/seahorse/files/seahorse-40.0-fix-segfault-with-ldap-disabled.patch
+++ b/app-crypt/seahorse/files/seahorse-40.0-fix-segfault-with-ldap-disabled.patch
@@ -1,0 +1,29 @@
+From 6fc0e3e321cdf0bf7e047234561fe8a8084a93f9 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@mengyan1223.wang>
+Date: Wed, 14 Apr 2021 23:18:06 +0800
+Subject: [PATCH] Fix segfault when built with ldap disabled
+
+Fixes #321.
+---
+ pgp/seahorse-pgp-backend.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/pgp/seahorse-pgp-backend.c b/pgp/seahorse-pgp-backend.c
+index 25febf31..8c10e7e3 100644
+--- a/pgp/seahorse-pgp-backend.c
++++ b/pgp/seahorse-pgp-backend.c
+@@ -445,7 +445,10 @@ seahorse_pgp_backend_add_remote (SeahorsePgpBackend   *self,
+         /* Don't persist, so just immediately create a ServerSource */
+         g_autoptr(SeahorseServerSource) ssrc = NULL;
+         ssrc = seahorse_server_category_create_server (uri);
+-        g_list_store_append (G_LIST_STORE (self->remotes), ssrc);
++        /* If the scheme of the uri is ldap, but ldap support is disabled
++         * in the build, ssrc will be NULL. */
++        if (ssrc)
++            g_list_store_append (G_LIST_STORE (self->remotes), ssrc);
+     }
+ }
+ 
+-- 
+GitLab
+

--- a/app-crypt/seahorse/seahorse-40.0-r1.ebuild
+++ b/app-crypt/seahorse/seahorse-40.0-r1.ebuild
@@ -1,0 +1,80 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit gnome.org gnome2-utils meson xdg vala
+
+DESCRIPTION="Manage your passwords and encryption keys"
+HOMEPAGE="https://wiki.gnome.org/Apps/Seahorse"
+
+LICENSE="GPL-2+ FDL-1.1+"
+SLOT="0"
+IUSE="ldap zeroconf"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="
+	>=dev-libs/glib-2.58:2
+	>=app-crypt/gcr-3.38:=
+	>=app-crypt/gpgme-1.14.0
+	>=x11-libs/gtk+-3.24.0:3
+	>=app-crypt/gnupg-2.2
+	>=gui-libs/libhandy-1.1:1=
+	>=app-crypt/libsecret-0.16
+	dev-libs/libpwquality
+	net-misc/openssh
+	ldap? ( net-nds/openldap:= )
+	>=net-libs/libsoup-2.33.92:2.4
+	zeroconf? ( >=net-dns/avahi-0.6:=[dbus] )
+"
+DEPEND="${RDEPEND}
+	$(vala_depend)
+	dev-libs/libxml2:2
+	app-crypt/gcr[vala]
+	app-crypt/libsecret[vala]
+	gui-libs/libhandy:1[vala]
+"
+BDEPEND="
+	app-text/docbook-xml-dtd:4.2
+	app-text/docbook-xsl-stylesheets
+	dev-libs/appstream-glib
+	dev-libs/libxslt
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+	dev-util/itstool
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-segfault-with-ldap-disabled.patch"
+)
+
+src_prepare() {
+	xdg_src_prepare
+	vala_src_prepare
+}
+
+src_configure() {
+	local emesonargs=(
+		-Dhelp=true
+		-Dpgp-support=true
+		-Dcheck-compatible-gpg=false # keep lowest version listed as compatible as min dep for gnupg RDEPEND
+		-Dpkcs11-support=true
+		-Dkeyservers-support=true
+		-Dhkp-support=true
+		$(meson_use ldap ldap-support)
+		$(meson_use zeroconf key-sharing)
+		-Dmanpage=true
+	)
+	meson_src_configure
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}


### PR DESCRIPTION
Patch source:
https://gitlab.gnome.org/GNOME/seahorse/-/commit/6fc0e3e321cdf0bf7e047234561fe8a8084a93f9

Thanks: Matt Turner <mattst88@gentoo.org>
Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>