### PR TITLE
*/* eapi bump / cleanups for some imake-based ebuilds

### DIFF
--- a/app-office/magicpoint/files/magicpoint-1.13a-libpng15.patch
+++ b/app-office/magicpoint/files/magicpoint-1.13a-libpng15.patch
@@ -1,5 +1,5 @@
---- image/png.c
-+++ image/png.c
+--- a/image/png.c
++++ b/image/png.c
 @@ -86,7 +86,7 @@
  		return NULL;
  	}

--- a/app-office/magicpoint/magicpoint-1.13a_p20121015-r2.ebuild
+++ b/app-office/magicpoint/magicpoint-1.13a_p20121015-r2.ebuild
@@ -34,7 +34,7 @@ COMMON_DEPEND="x11-libs/libICE
 	)
 	emacs? ( >=app-editors/emacs-23.1:* )
 	m17n-lib? (
-		dev-libs/m17n-lib
+		dev-libs/m17n-lib[X]
 		fontconfig? ( media-libs/fontconfig )
 	)
 	mng? ( media-libs/libmng )"

--- a/games-arcade/xboing/xboing-2.4-r3.ebuild
+++ b/games-arcade/xboing/xboing-2.4-r3.ebuild
@@ -1,62 +1,70 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit eutils flag-o-matic toolchain-funcs
+inherit flag-o-matic toolchain-funcs
 
 DESCRIPTION="Blockout type game where you bounce a ball trying to destroy blocks"
 HOMEPAGE="http://www.techrescue.org/xboing/"
 SRC_URI="http://www.techrescue.org/xboing/${PN}${PV}.tar.gz
-	mirror://gentoo/xboing-${PV}-debian.patch.bz2"
+	mirror://gentoo/${P}-debian.patch.bz2"
+S="${WORKDIR}/${PN}"
 
 LICENSE="xboing"
 SLOT="0"
 KEYWORDS="amd64 ~x86"
-IUSE=""
 
-RDEPEND="acct-group/gamestat
+RDEPEND="
+	acct-group/gamestat
 	x11-libs/libXpm"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	app-text/rman
 	x11-misc/gccmakedep
-	>=x11-misc/imake-1.0.8-r1
-"
+	>=x11-misc/imake-1.0.8-r1"
 
-S=${WORKDIR}/${PN}
+PATCHES=(
+	"${WORKDIR}"/${P}-debian.patch
+	"${FILESDIR}"/${P}-buffer.patch
+	"${FILESDIR}"/${P}-sleep.patch
+)
 
 src_prepare() {
-	epatch "${WORKDIR}"/xboing-${PV}-debian.patch
-	epatch "${FILESDIR}"/xboing-${PV}-buffer.patch
-	epatch "${FILESDIR}"/xboing-${PV}-sleep.patch
+	default
 	sed -i '/^#include/s:xpm\.h:X11/xpm.h:' *.c || die
-	eapply_user
+	sed -i "s:GENTOO_VER:${PF/${PN}-/}:" Imakefile || die
 }
 
 src_configure() {
-	sed -i -e "s:GENTOO_VER:${PF/${PN}-/}:" Imakefile || die
-	append-cflags -fcommon
+	append-cflags -fcommon #707214
 
 	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
 		IMAKECPP="${IMAKECPP:-$(tc-getCPP)}" xmkmf -a || die
 }
 
 src_compile() {
-	emake \
-		CC="$(tc-getCC)" \
-		CDEBUGFLAGS="${CFLAGS}" \
-		LOCAL_LDFLAGS="${LDFLAGS}" \
-		XBOING_DIR="/usr/share/${PN}"
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		CDEBUGFLAGS="${CFLAGS}"
+		LOCAL_LDFLAGS="${LDFLAGS}"
+		HIGH_SCORE_DIR="${EPREFIX}/var/games"
+		XBOING_DIR="${EPREFIX}/usr/share/${PN}"
+	)
+	emake "${myemakeargs[@]}"
 }
 
 src_install() {
-	emake \
-		CC="$(tc-getCC)" \
-		PREFIX="${D}" \
-		BINDIR="${D}/usr/bin" \
-		LOCAL_LDFLAGS="${LDFLAGS}" \
-		XBOING_DIR="/usr/share/${PN}" \
-		install
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		LOCAL_LDFLAGS="${LDFLAGS}"
+		PREFIX="${D}"
+		BINDIR="${ED}/usr/bin"
+		HIGH_SCORE_DIR="${EPREFIX}/var/games"
+		XBOING_DIR="${EPREFIX}/usr/share/${PN}"
+	)
+	emake "${myemakeargs[@]}" install
+
 	newman xboing.man xboing.6
 	dodoc README docs/*.doc
 

--- a/games-board/xgammon/xgammon-0.98-r3.ebuild
+++ b/games-board/xgammon/xgammon-0.98-r3.ebuild
@@ -16,7 +16,8 @@ KEYWORDS="~amd64 ~x86"
 RDEPEND="
 	x11-libs/libX11
 	x11-libs/libXaw
-	x11-libs/libXt"
+	x11-libs/libXt
+	!<x11-terms/kterm-6.2.0-r7"
 DEPEND="${RDEPEND}"
 BDEPEND="
 	app-text/rman
@@ -41,6 +42,12 @@ src_compile() {
 		EXTRA_LDOPTIONS="${LDFLAGS}" \
 		CDEBUGFLAGS="${CFLAGS}" \
 		CC="$(tc-getCC)"
+}
+
+src_install() {
+	default
+	# remove link to avoid collision (bug #668892)
+	rm "${ED}"/usr/$(get_libdir)/X11/app-defaults || die
 }
 
 pkg_postinst() {

--- a/games-board/xscrabble/xscrabble-2.10-r4.ebuild
+++ b/games-board/xscrabble/xscrabble-2.10-r4.ebuild
@@ -20,6 +20,7 @@ DEPEND="x11-libs/libXaw"
 RDEPEND="
 	${DEPEND}
 	acct-group/gamestat
+	!<x11-terms/kterm-6.2.0-r7
 "
 BDEPEND="
 	x11-misc/gccmakedep

--- a/games-board/xskat/xskat-4.0-r1.ebuild
+++ b/games-board/xskat/xskat-4.0-r1.ebuild
@@ -1,8 +1,9 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit toolchain-funcs eutils
+EAPI=7
+
+inherit desktop toolchain-funcs
 
 DESCRIPTION="Famous german card game"
 HOMEPAGE="http://www.xskat.de/xskat.html"
@@ -11,11 +12,12 @@ SRC_URI="http://www.xskat.de/${P}.tar.gz"
 LICENSE="freedist"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc64 ~x86"
-IUSE=""
 
-RDEPEND="media-fonts/font-misc-misc
+RDEPEND="
+	media-fonts/font-misc-misc
 	x11-libs/libX11"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	x11-base/xorg-proto
 	x11-misc/gccmakedep
 	>=x11-misc/imake-1.0.8-r1"
@@ -26,13 +28,18 @@ src_configure() {
 }
 
 src_compile() {
-	emake CDEBUGFLAGS="${CFLAGS}" EXTRA_LDOPTIONS="${LDFLAGS}" CC="$(tc-getCC)"
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		CDEBUGFLAGS="${CFLAGS}"
+		EXTRA_LDOPTIONS="${LDFLAGS}"
+	)
+	emake "${myemakeargs[@]}"
 }
 
 src_install() {
 	dobin xskat
 	newman xskat.man xskat.6
-	dodoc CHANGES README{,.IRC}
 	newicon icon.xbm ${PN}.xbm
 	make_desktop_entry ${PN} XSkat /usr/share/pixmaps/${PN}.xbm
+	einstalldocs
 }

--- a/games-misc/xcruiser/xcruiser-0.30-r1.ebuild
+++ b/games-misc/xcruiser/xcruiser-0.30-r1.ebuild
@@ -1,7 +1,8 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
+
 inherit toolchain-funcs
 
 DESCRIPTION="Fly about 3D-formed file system"
@@ -11,11 +12,11 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 RESTRICT="test"
 
 RDEPEND="x11-libs/libXaw"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	app-text/rman
 	x11-misc/gccmakedep
 	>=x11-misc/imake-1.0.8-r1"
@@ -26,11 +27,16 @@ src_configure() {
 }
 
 src_compile() {
-	emake CC="$(tc-getCC)" CDEBUGFLAGS="${CFLAGS}" LOCAL_LDFLAGS="${LDFLAGS}"
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		CDEBUGFLAGS="${CFLAGS}"
+		LOCAL_LDFLAGS="${LDFLAGS}"
+	)
+	emake "${myemakeargs[@]}"
 }
 
 src_install() {
 	dobin xcruiser
-	dodoc CHANGES README README.jp TODO
 	newman xcruiser.man xcruiser.1
+	einstalldocs
 }

--- a/media-gfx/transfig/transfig-3.2.5e-r1.ebuild
+++ b/media-gfx/transfig/transfig-3.2.5e-r1.ebuild
@@ -2,30 +2,31 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit flag-o-matic toolchain-funcs
 
-MY_P=${PN}.${PV}
+inherit toolchain-funcs
 
-DESCRIPTION="A set of tools for creating TeX documents with graphics"
+MY_P="${PN}.${PV}"
+
+DESCRIPTION="Set of tools for creating TeX documents with graphics"
 HOMEPAGE="https://www.xfig.org/"
 SRC_URI="mirror://sourceforge/mcj/${MY_P}.tar.gz
 	mirror://gentoo/fig2mpdf-1.1.2.tar.bz2
 	https://dev.gentoo.org/~sultan/distfiles/media-gfx/transfig/${P}-gentoo-patchset-r1.tar.bz2"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
 
-RDEPEND="x11-libs/libXpm
-	virtual/jpeg
+RDEPEND="
 	media-libs/libpng
-	x11-apps/rgb"
+	virtual/jpeg
+	x11-apps/rgb
+	x11-libs/libXpm"
 DEPEND="${RDEPEND}"
 BDEPEND="
 	app-text/rman
 	>=x11-misc/imake-1.0.8-r1"
-
-S=${WORKDIR}/${MY_P}
 
 PATCHES=(
 	"${WORKDIR}/${P}-gentoo-patchset/${PN}-3.2.5d-fig2mpdf-r1.patch"
@@ -78,16 +79,25 @@ src_configure() {
 
 src_compile() {
 	emake CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" Makefiles
-	emake CC="$(tc-getCC)" AR="$(tc-getAR) cq" RANLIB="$(tc-getRANLIB)" \
-		LOCAL_LDFLAGS="${LDFLAGS}" CDEBUGFLAGS="${CFLAGS}" \
+
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		AR="$(tc-getAR) cq"
+		RANLIB="$(tc-getRANLIB)"
+		CDEBUGFLAGS="${CFLAGS}"
+		LOCAL_LDFLAGS="${LDFLAGS}"
 		USRLIBDIR="${EPREFIX}/usr/$(get_libdir)"
+	)
+	emake "${myemakeargs[@]}"
 }
 
 src_install() {
-	emake DESTDIR="${D}" \
-		INSTDATFLAGS="-m 644" \
-		INSTMANFLAGS="-m 644" \
-		install install.man
+	local myemakeargs=(
+		DESTDIR="${D}"
+		INSTDATFLAGS="-m 644"
+		INSTMANFLAGS="-m 644"
+	)
+	emake "${myemakeargs[@]}" install install.man
 
 	dobin "${WORKDIR}/fig2mpdf/fig2mpdf"
 	doman "${WORKDIR}/fig2mpdf/fig2mpdf.1"
@@ -99,7 +109,7 @@ src_install() {
 
 	einstalldocs
 
-	rm -f "${ED}/usr/share/doc/${PF}/html/"{Makefile,*.lfig,*.pdf,*.tex} || die
+	rm "${ED}/usr/share/doc/${PF}/html/"{Makefile,*.lfig,*.pdf,*.tex} || die
 
 	mv "${ED}"/usr/bin/fig2ps2tex{.sh,} || die #338295
 }

--- a/media-gfx/xli/files/xli-1.17.0-libpng14.patch
+++ b/media-gfx/xli/files/xli-1.17.0-libpng14.patch
@@ -1,8 +1,8 @@
 http://aur.archlinux.org/packages.php?ID=1676
 http://archwyrm.net/~me/xli-libpng.diff
 
---- png.c
-+++ png.c
+--- a/png.c
++++ b/png.c
 @@ -27,7 +27,7 @@
  	if (ret != 8)
  		return 0;

--- a/media-gfx/xli/xli-1.17.0-r5.ebuild
+++ b/media-gfx/xli/xli-1.17.0-r5.ebuild
@@ -1,34 +1,43 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 SNAPSHOT="2005-02-27"
 DESCRIPTION="X Load Image: view images or load them to root window"
 HOMEPAGE="ftp://ftp.ibiblio.org/pub/Linux/apps/graphics/viewers/X/xli-1.16.README"
 SRC_URI="http://pantransit.reptiles.org/prog/xli/xli-${SNAPSHOT}.tar.gz"
+S="${WORKDIR}/${PN}-${SNAPSHOT}"
 
 LICENSE="HPND"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
-RDEPEND="app-arch/bzip2
-	>=media-libs/libpng-1.0.5
-	>=sys-libs/zlib-1.1.4
+RDEPEND="
+	app-arch/bzip2:=
+	>=media-libs/libpng-1.0.5:=
+	>=sys-libs/zlib-1.1.4:=
 	virtual/jpeg:0
-	x11-libs/libXext"
-
-DEPEND="${RDEPEND}
+	x11-libs/libXext
+	!media-gfx/xloadimage"
+DEPEND="${RDEPEND}"
+BDEPEND="
 	app-text/rman
 	x11-base/xorg-proto
-	>=x11-misc/imake-1.0.8-r1
-	!media-gfx/xloadimage"
+	>=x11-misc/imake-1.0.8-r1"
 
-S=${WORKDIR}/${PN}-${SNAPSHOT}
+PATCHES=(
+	"${FILESDIR}"/xli-security-gentoo.diff
+	"${FILESDIR}"/${P}-fix-scale-zoom.patch #282979
+	"${FILESDIR}"/${P}-libpng14.patch
+)
+DOCS=( README README.xloadimage ABOUTGAMMA TODO chkgamma.jpg )
 
 src_prepare() {
+	default
+
 	# avoid conflicts on systems that have zopen in system headers
 	sed -i -e "s:zopen:xli_zopen:g" *
 
@@ -44,13 +53,6 @@ src_prepare() {
 	# This hack will allow xli to compile using gcc-3.3
 	sed -i rlelib.c \
 		-e 's/#include <varargs.h>//'
-
-	# fix potential security issues.
-	EPATCH_OPTS="-F3 -l" epatch "${FILESDIR}"/xli-security-gentoo.diff
-
-	# Fix scale per bug 282979
-	epatch "${FILESDIR}"/${P}-fix-scale-zoom.patch \
-		"${FILESDIR}"/${P}-libpng14.patch
 }
 
 src_configure() {
@@ -59,7 +61,12 @@ src_configure() {
 }
 
 src_compile() {
-	emake CDEBUGFLAGS="${CFLAGS}" CC="$(tc-getCC)" EXTRA_LDOPTIONS="${LDFLAGS}"
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		CDEBUGFLAGS="${CFLAGS}"
+		EXTRA_LDOPTIONS="${LDFLAGS}"
+	)
+	emake "${myemakeargs[@]}"
 }
 
 src_install() {
@@ -68,10 +75,10 @@ src_install() {
 	dosym xli /usr/bin/xsetbg
 	dosym xli /usr/bin/xview
 
-	dodoc README README.xloadimage ABOUTGAMMA TODO chkgamma.jpg
 	newman xli.man xli.1
 	newman xliguide.man xliguide.1
 	newman xlito.man xlito.1
+	einstalldocs
 
 	insinto /etc/X11/app-defaults
 	newins "${FILESDIR}"/Xli.ad Xli

--- a/x11-misc/xearth/xearth-1.1-r1.ebuild
+++ b/x11-misc/xearth/xearth-1.1-r1.ebuild
@@ -1,34 +1,33 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
+DESCRIPTION="Set the X root window to an image of the Earth"
 HOMEPAGE="https://hewgill.com/xearth/original/"
-DESCRIPTION="Xearth sets the X root window to an image of the Earth"
 SRC_URI="ftp://cag.lcs.mit.edu/pub/tuna/${P}.tar.gz
 	ftp://ftp.cs.colorado.edu/users/tuna/${P}.tar.gz"
 
-SLOT="0"
 LICENSE="xearth"
+SLOT="0"
 KEYWORDS="~alpha amd64 ppc ppc64 x86"
-IUSE=""
 
 RDEPEND="
 	x11-libs/libX11
 	x11-libs/libXext
-	x11-libs/libXt
-"
-DEPEND="${RDEPEND}
-	x11-base/xorg-proto
-	>=x11-misc/imake-1.0.8-r1
+	x11-libs/libXt"
+DEPEND="${RDEPEND}"
+BDEPEND="
 	app-text/rman
-"
+	x11-base/xorg-proto
+	>=x11-misc/imake-1.0.8-r1"
 
-src_prepare() {
-	epatch "${FILESDIR}"/${P}-include.patch
-}
+PATCHES=(
+	"${FILESDIR}"/${P}-include.patch
+)
+DOCS=( BUILT-IN GAMMA-TEST HISTORY README )
 
 src_configure() {
 	CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" \
@@ -36,14 +35,16 @@ src_configure() {
 }
 
 src_compile() {
-	emake \
-		CC="$(tc-getCC)" \
-		CDEBUGFLAGS="${CFLAGS}" \
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		CDEBUGFLAGS="${CFLAGS}"
 		EXTRA_LDOPTIONS="${LDFLAGS}"
+	)
+	emake "${myemakeargs[@]}"
 }
 
 src_install() {
-	newman xearth.man xearth.1
 	dobin xearth
-	dodoc BUILT-IN GAMMA-TEST HISTORY README
+	newman xearth.man xearth.1
+	einstalldocs
 }

--- a/x11-terms/kterm/kterm-6.2.0-r7.ebuild
+++ b/x11-terms/kterm/kterm-6.2.0-r7.ebuild
@@ -23,7 +23,9 @@ RDEPEND="app-text/rman
 	x11-libs/libXmu
 	x11-libs/libXpm
 	x11-libs/libxkbfile
-	Xaw3d? ( x11-libs/libXaw3d )"
+	Xaw3d? ( x11-libs/libXaw3d )
+	!<games-board/xgammon-0.98-r3
+	!<games-board/xscrabble-2.10-r4"
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 	x11-misc/gccmakedep
@@ -71,8 +73,8 @@ src_install() {
 	iconv -f ISO-2022-JP -t UTF-8 ${PN}.jman > ${PN}.ja.1
 	doman ${PN}.ja.1
 
-	# Remove link to avoid collision
-	rm -f "${ED}"/usr/lib/X11/app-defaults
+	# remove link to avoid collision (bug #668892,706322)
+	rm "${ED}"/usr/$(get_libdir)/X11/app-defaults || die
 }
 
 pkg_postinst() {

--- a/x11-terms/kterm/kterm-6.2.0-r7.ebuild
+++ b/x11-terms/kterm/kterm-6.2.0-r7.ebuild
@@ -1,12 +1,11 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=7
 
-inherit flag-o-matic toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="Japanese Kanji X Terminal"
-#HOMEPAGE="http://www.asahi-net.or.jp/~hc3j-tkg/kterm/"
 HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
 SRC_URI="mirror://gentoo/${P}.tar.gz
 	mirror://gentoo/${P}-wpi.patch.gz
@@ -17,7 +16,8 @@ SLOT="0"
 KEYWORDS="-alpha amd64 ~ppc ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="Xaw3d"
 
-RDEPEND="app-text/rman
+RDEPEND="
+	app-text/rman
 	sys-libs/ncurses:=
 	x11-libs/libXaw
 	x11-libs/libXmu
@@ -26,11 +26,11 @@ RDEPEND="app-text/rman
 	Xaw3d? ( x11-libs/libXaw3d )
 	!<games-board/xgammon-0.98-r3
 	!<games-board/xscrabble-2.10-r4"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
 	virtual/pkgconfig
 	x11-misc/gccmakedep
-	>=x11-misc/imake-1.0.8-r1
-"
+	>=x11-misc/imake-1.0.8-r1"
 
 PATCHES=(
 	"${WORKDIR}"/${P}-wpi.patch		# wallpaper patch
@@ -52,25 +52,27 @@ src_configure() {
 }
 
 src_compile() {
-	emake \
-		CC="$(tc-getCC)" \
-		CDEBUGFLAGS="${CFLAGS}" \
-		LOCAL_LDFLAGS="${LDFLAGS}" \
-		TERMCAPLIB="$("$(tc-getPKG_CONFIG)" --libs ncurses)" \
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		CDEBUGFLAGS="${CFLAGS}"
+		LOCAL_LDFLAGS="${LDFLAGS}"
+		TERMCAPLIB="$("$(tc-getPKG_CONFIG)" --libs ncurses)"
 		XAPPLOADDIR="${EPREFIX}/usr/share/X11/app-defaults"
+	)
+	emake "${myemakeargs[@]}"
 }
 
 src_install() {
-	emake \
-		BINDIR="${EPREFIX}/usr/bin" \
-		XAPPLOADDIR="${EPREFIX}/usr/share/X11/app-defaults" \
-		DESTDIR="${D}" \
-		install
+	local myemakeargs=(
+		DESTDIR="${D}"
+		BINDIR="${EPREFIX}/usr/bin"
+		XAPPLOADDIR="${EPREFIX}/usr/share/X11/app-defaults"
+	)
+	emake "${myemakeargs[@]}" install
 	einstalldocs
 
-	# install man pages
 	newman ${PN}.man ${PN}.1
-	iconv -f ISO-2022-JP -t UTF-8 ${PN}.jman > ${PN}.ja.1
+	iconv -f ISO-2022-JP -t UTF-8 ${PN}.jman > ${PN}.ja.1 || die
 	doman ${PN}.ja.1
 
 	# remove link to avoid collision (bug #668892,706322)


### PR DESCRIPTION
Since already worked on these might as well do a bit more.

This touch ebuilds depending on >=imake-1.0.8-r1 that were triggering pkgcheck, plus some collision fixes.