### PR TITLE
mail-mta/exim: native srs support.

### DIFF
--- a/mail-mta/exim/metadata.xml
+++ b/mail-mta/exim/metadata.xml
@@ -37,6 +37,8 @@
 		<flag name="mbx">Adds support for UW's mbx format</flag>
 		<flag name="spf">Adds support for Sender Policy Framework</flag>
 		<flag name="srs">Adds support for Sender Rewriting Scheme</flag>
+		<flag name="srs-alt">Adds support for Sender Rewriting Scheme using mail-filter/libsrs_alt</flag>
+		<flag name="srs-native">Adds support for native exim Sender Rewriting Scheme</flag>
 		<flag name="proxy">Add support for being behind a proxy, such as HAProxy</flag>
 		<flag name="pkcs11">Require pkcs11 support in <pkg>net-libs/gnutls</pkg> with USE=gnutls</flag>
 		<flag name="redis">Adds support for querying <pkg>dev-db/redis</pkg></flag>


### PR DESCRIPTION
Version 9.94 includes EXPERIMENTAL_SRS_NATIVE, which has already been
marked as supported for the next release.

Since users may already have the libsrs_alt configured, split the USE
flags into srs-alt and srs-native to distinguish between the two
implementations.

These options have changed for the 4.95 release to EXPERIMENTAL_SRS_ALT
and SUPPORT_SRS, leave comments to this effect in the ebuild so that
this isn't forgotten on the bump.

Closes: https://bugs.gentoo.org/783099
Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Jaco Kroon <jaco@uls.co.za>