### PR TITLE
net-misc/rsync: Fixes for glibc 2.32

### DIFF
--- a/net-misc/rsync/files/rsync-3.2.3-glibc-lchmod-better-fix.patch
+++ b/net-misc/rsync/files/rsync-3.2.3-glibc-lchmod-better-fix.patch
@@ -1,0 +1,82 @@
+From 9dd62525f3b98d692e031f22c02be8f775966503 Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayne@opencoder.net>
+Date: Sun, 29 Nov 2020 09:33:54 -0800
+Subject: [PATCH] Work around glibc's lchmod() issue a better way.
+
+---
+ configure.ac |  8 --------
+ syscall.c    | 34 +++++++++++++++++++++-------------
+ 2 files changed, 21 insertions(+), 21 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 19d6ae52..0f8e38f3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -901,14 +901,6 @@ AC_CHECK_FUNCS(waitpid wait4 getcwd chown chmod lchmod mknod mkfifo \
+     extattr_get_link sigaction sigprocmask setattrlist getgrouplist \
+     initgroups utimensat posix_fallocate attropen setvbuf nanosleep usleep)
+ 
+-case "$host_os" in
+-*linux*) # Work around a glibc bug. TODO eventually remove this?
+-    ac_cv_func_lchmod=no
+-    grep -v HAVE_LCHMOD confdefs.h >confdefs.h.new
+-    mv confdefs.h.new confdefs.h
+-    ;;
+-esac
+-
+ dnl cygwin iconv.h defines iconv_open as libiconv_open
+ if test x"$ac_cv_func_iconv_open" != x"yes"; then
+     AC_CHECK_FUNC(libiconv_open, [ac_cv_func_iconv_open=yes; AC_DEFINE(HAVE_ICONV_OPEN, 1)])
+diff --git a/syscall.c b/syscall.c
+index b9c3b4ef..11d10e4a 100644
+--- a/syscall.c
++++ b/syscall.c
+@@ -227,27 +227,35 @@ int do_open(const char *pathname, int flags, mode_t mode)
+ #ifdef HAVE_CHMOD
+ int do_chmod(const char *path, mode_t mode)
+ {
++	static int switch_step = 0;
+ 	int code;
+ 	if (dry_run) return 0;
+ 	RETURN_ERROR_IF_RO_OR_LO;
++	switch (switch_step) {
+ #ifdef HAVE_LCHMOD
+-	code = lchmod(path, mode & CHMOD_BITS);
+-#else
+-	if (S_ISLNK(mode)) {
++#include "case_N.h"
++		if ((code = lchmod(path, mode & CHMOD_BITS)) == 0 || errno != ENOTSUP)
++			break;
++		switch_step++;
++#endif
++
++#include "case_N.h"
++		if (S_ISLNK(mode)) {
+ # if defined HAVE_SETATTRLIST
+-		struct attrlist attrList;
+-		uint32_t m = mode & CHMOD_BITS; /* manpage is wrong: not mode_t! */
++			struct attrlist attrList;
++			uint32_t m = mode & CHMOD_BITS; /* manpage is wrong: not mode_t! */
+ 
+-		memset(&attrList, 0, sizeof attrList);
+-		attrList.bitmapcount = ATTR_BIT_MAP_COUNT;
+-		attrList.commonattr = ATTR_CMN_ACCESSMASK;
+-		code = setattrlist(path, &attrList, &m, sizeof m, FSOPT_NOFOLLOW);
++			memset(&attrList, 0, sizeof attrList);
++			attrList.bitmapcount = ATTR_BIT_MAP_COUNT;
++			attrList.commonattr = ATTR_CMN_ACCESSMASK;
++			code = setattrlist(path, &attrList, &m, sizeof m, FSOPT_NOFOLLOW);
+ # else
+-		code = 1;
++			code = 1;
+ # endif
+-	} else
+-		code = chmod(path, mode & CHMOD_BITS); /* DISCOURAGED FUNCTION */
+-#endif /* !HAVE_LCHMOD */
++		} else
++			code = chmod(path, mode & CHMOD_BITS); /* DISCOURAGED FUNCTION */
++		break;
++	}
+ 	if (code != 0 && (preserve_perms || preserve_executability))
+ 		return code;
+ 	return 0;

--- a/net-misc/rsync/files/rsync-3.2.3-glibc-lchmod.patch
+++ b/net-misc/rsync/files/rsync-3.2.3-glibc-lchmod.patch
@@ -1,0 +1,28 @@
+From 85b8dc8abaca96fc3ea7421e09101b6ac41b6718 Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayne@opencoder.net>
+Date: Fri, 30 Oct 2020 15:51:24 -0700
+Subject: [PATCH] Force HAVE_LCHMOD off for Linux (for now).
+
+---
+ configure.ac | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index e469981b..46aaa819 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -860,6 +860,14 @@ AC_CHECK_FUNCS(waitpid wait4 getcwd chown chmod lchmod mknod mkfifo \
+     extattr_get_link sigaction sigprocmask setattrlist getgrouplist \
+     initgroups utimensat posix_fallocate attropen setvbuf nanosleep usleep)
+ 
++case "$host_os" in
++*linux*) # Work around a glibc bug. TODO eventually remove this?
++    ac_cv_func_lchmod=no
++    grep -v HAVE_LCHMOD confdefs.h >confdefs.h.new
++    mv confdefs.h.new confdefs.h
++    ;;
++esac
++
+ dnl cygwin iconv.h defines iconv_open as libiconv_open
+ if test x"$ac_cv_func_iconv_open" != x"yes"; then
+     AC_CHECK_FUNC(libiconv_open, [ac_cv_func_iconv_open=yes; AC_DEFINE(HAVE_ICONV_OPEN, 1)])

--- a/net-misc/rsync/rsync-3.2.3-r2.ebuild
+++ b/net-misc/rsync/rsync-3.2.3-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit prefix systemd
+inherit autotools prefix systemd
 
 DESCRIPTION="File transfer program to keep remote files into sync"
 HOMEPAGE="https://rsync.samba.org/"
@@ -54,13 +54,16 @@ python_check_deps() {
 	has_version "dev-python/commonmark[${PYTHON_USEDEP}]"
 }
 
+PATCHES=(
+	"${FILESDIR}/${PN}-3.2.3-glibc-lchmod.patch"
+	"${FILESDIR}/${PN}-3.2.3-glibc-lchmod-better-fix.patch"
+)
+
 src_prepare() {
 	default
-	if [[ "${PV}" == *9999 ]] ; then
-		eaclocal -I m4
-		eautoconf -o configure.sh
-		eautoheader && touch config.h.in
-	fi
+	eaclocal -I m4
+	eautoconf -o configure.sh
+	eautoheader && touch config.h.in
 }
 
 src_configure() {


### PR DESCRIPTION
1. Add upstream glibc 2.32 fixes for rsync 3.2.3 with lchmod.
2. Always calls aclocal/eautoconf etc.

Signed-off-by: Manoj Gupta <manojgupta@google.com>