### PR TITLE
dev-java/dom4j: upgrade jaxen:1.1 -> jaxen:1.2 

### DIFF
--- a/dev-java/dom4j/dom4j-1.6.1-r9.ebuild
+++ b/dev-java/dom4j/dom4j-1.6.1-r9.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source test"
+
+inherit java-pkg-2 java-ant-2
+
+DESCRIPTION="XML Java library"
+HOMEPAGE="https://dom4j.github.io/"
+SRC_URI="
+	mirror://sourceforge/dom4j/${P}.tar.gz
+	mirror://gentoo/${P}-java5.patch.bz2"
+
+LICENSE="dom4j"
+SLOT="1"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE=""
+
+CDEPEND="
+	dev-java/xpp2:0
+	dev-java/xpp3:0
+	dev-java/xsdlib:0
+	dev-java/relaxng-datatype:0"
+
+RDEPEND="
+	${CDEPEND}
+	>=virtual/jre-1.8:*"
+
+# restricted to jdk 1.8 because it needs javax.xml.bind
+DEPEND="
+	${CDEPEND}
+	test? (
+		dev-java/xalan:0
+		dev-java/ant-junit:0
+		dev-java/junitperf:0
+	)
+	virtual/jdk:1.8"
+
+PDEPEND="dev-java/jaxen:1.2"
+
+# Add missing methods to compile on Java 5 #137970
+PATCHES=( "${WORKDIR}/${P}-java5.patch" )
+
+JAVA_RM_FILES=(
+	src/test/org/dom4j/bean/BeansTest.java
+	src/test/org/dom4j/io/StaxTest.java
+	src/test/org/dom4j/rule/RuleTest.java
+	src/test/org/dom4j/ThreadingTest.java
+	src/test/org/dom4j/io/XPP3ReaderTest.java
+)
+
+src_prepare() {
+	default
+
+	# Circular deps with jaxen #212993
+	find -name '*.jar' -! -name jaxen-1.1-beta-6.jar -exec rm -v {} + || die
+
+	rm -v "${JAVA_RM_FILES[@]}" || die
+}
+
+JAVA_ANT_REWRITE_CLASSPATH="yes"
+JAVA_ANT_CLASSPATH_TAGS+=" javadoc"
+
+JAVA_ANT_ENCODING="ISO-8859-1"
+
+EANT_BUILD_TARGET="clean package"
+EANT_GENTOO_CLASSPATH="relaxng-datatype,xpp2,xpp3,xsdlib"
+EANT_GENTOO_CLASSPATH_EXTRA="lib/jaxen.jar"
+EANT_EXTRA_ARGS="-Dbuild.javadocs=build/doc/api"
+
+EANT_TEST_GENTOO_CLASSPATH="${EANT_GENTOO_CLASSPATH},junitperf,xalan"
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	java-pkg_dojar "build/${PN}.jar"
+	java-pkg_register-dependency jaxen-1.2
+	use doc && java-pkg_dojavadoc build/doc/api
+	use source && java-pkg_dosrc src/java/*
+}


### PR DESCRIPTION
Trouble with
```
There was 1 failure:
1) warning(junit.framework.TestSuite$1)
junit.framework.AssertionFailedError: No tests found in org.apache.commons.jelly.core.BaseMemoryLeakTest
        at junit.framework.Assert.fail(Assert.java:57)
        at junit.framework.TestCase.fail(TestCase.java:223)
        at junit.framework.TestSuite$1.runTest(TestSuite.java:96)
        at junit.framework.TestCase.runBare(TestCase.java:142)
        at junit.framework.TestResult$1.protect(TestResult.java:122)
        at junit.framework.TestResult.runProtected(TestResult.java:142)
        at junit.framework.TestResult.run(TestResult.java:125)
        at junit.framework.TestCase.run(TestCase.java:130)
        at junit.framework.TestSuite.runTest(TestSuite.java:241)
        at junit.framework.TestSuite.run(TestSuite.java:236)
        at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
        at org.junit.runners.Suite.runChild(Suite.java:128)
        at org.junit.runners.Suite.runChild(Suite.java:27)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
        at org.junit.runner.JUnitCore.runMain(JUnitCore.java:77)
        at org.junit.runner.JUnitCore.main(JUnitCore.java:36)

FAILURES!!!
Tests run: 121,  Failures: 1
```