### PR TITLE
kde-plasma/plasma-workspace: Make qalculate USE flag enabled by default

### DIFF
--- a/kde-plasma/plasma-workspace/metadata.xml
+++ b/kde-plasma/plasma-workspace/metadata.xml
@@ -8,7 +8,7 @@
 	<use>
 		<flag name="appstream">Enable AppStream software metadata support</flag>
 		<flag name="geolocation">Enables dataengine providing location information</flag>
-		<flag name="qalculate">Enable Qalculate runner using <pkg>sci-libs/libqalculate</pkg></flag>
+		<flag name="qalculate">Use <pkg>sci-libs/libqalculate</pkg> instead of QJSEngine (<pkg>dev-qt/qtdeclarative</pkg>) for krunner calculator</flag>
 		<flag name="screencast">Enable screencast portal using <pkg>media-video/pipewire</pkg></flag>
 		<flag name="telemetry">Enable User Feedback control module for <pkg>kde-plasma/systemsettings</pkg></flag>
 	</use>

--- a/kde-plasma/plasma-workspace/plasma-workspace-5.21.4-r1.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-5.21.4-r1.ebuild
@@ -16,7 +16,7 @@ DESCRIPTION="KDE Plasma workspace"
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="appstream +calendar +fontconfig geolocation gps qalculate screencast +semantic-desktop systemd telemetry"
+IUSE="appstream +calendar +fontconfig geolocation gps +qalculate screencast +semantic-desktop systemd telemetry"
 
 REQUIRED_USE="gps? ( geolocation )"
 RESTRICT+=" test"
@@ -198,4 +198,9 @@ pkg_postinst () {
 	elog "To enable gpg-agent and/or ssh-agent in Plasma sessions,"
 	elog "edit ${EPREFIX}/etc/xdg/plasma-workspace/env/10-agent-startup.sh"
 	elog "and ${EPREFIX}/etc/xdg/plasma-workspace/shutdown/10-agent-shutdown.sh"
+
+	if ! use qalculate; then
+		ewarn "Qalculate is disabled, forcing krunner to use QJSEngine for"
+		ewarn "calculations, which will reduce floating point precision"
+	fi
 }


### PR DESCRIPTION
@a17r Please let me know if you need me to make any modifications in case the PR is not up to KDE project's standards.