### PR TITLE
x11-drivers/nvidia-drivers: stabilization for new ebuilds

### DIFF
--- a/gui-libs/egl-wayland/egl-wayland-1.1.6.ebuild
+++ b/gui-libs/egl-wayland/egl-wayland-1.1.6.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/NVIDIA/egl-wayland/archive/${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="amd64"
 
 RDEPEND="
 	dev-libs/wayland

--- a/gui-libs/egl-wayland/egl-wayland-1.1.6.ebuild
+++ b/gui-libs/egl-wayland/egl-wayland-1.1.6.ebuild
@@ -48,5 +48,13 @@ pkg_postinst() {
 		elog "Can be accomplished by:"
 		elog "  echo 'options nvidia-drm modeset=1' > ${EROOT}/etc/modprobe.d/nvidia-drm.conf"
 		elog "...then reloading the module."
+		elog
+		elog "Note that EGLStream requires support from the wayland compositor and"
+		elog "is not currently supported by many popular options such as gui-wm/sway."
+	fi
+
+	if has_version "<x11-drivers/nvidia-drivers-391"; then
+		ewarn "<=nvidia-drivers-390.xx may not work properly with this version of"
+		ewarn "egl-wayland, it is recommended to use nouveau drivers for wayland."
 	fi
 }

--- a/gui-libs/egl-wayland/egl-wayland-1.1.6.ebuild
+++ b/gui-libs/egl-wayland/egl-wayland-1.1.6.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/NVIDIA/egl-wayland/archive/${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64"
 
 RDEPEND="
 	dev-libs/wayland

--- a/gui-libs/eglexternalplatform/eglexternalplatform-1.1.ebuild
+++ b/gui-libs/eglexternalplatform/eglexternalplatform-1.1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/NVIDIA/eglexternalplatform/archive/${PV}.tar.gz -> $
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="amd64"
 
 src_prepare() {
 	default

--- a/gui-libs/eglexternalplatform/eglexternalplatform-1.1.ebuild
+++ b/gui-libs/eglexternalplatform/eglexternalplatform-1.1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/NVIDIA/eglexternalplatform/archive/${PV}.tar.gz -> $
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64"
 
 src_prepare() {
 	default

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-390.141-r1.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-390.141-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 MODULES_OPTIONAL_USE="driver"
-inherit desktop linux-info linux-mod multilib-build optfeature \
+inherit desktop linux-info linux-mod multilib-build \
 	readme.gentoo-r1 systemd toolchain-funcs unpacker
 
 NV_KERNEL_MAX="5.10"
@@ -345,6 +345,8 @@ src_install() {
 }
 
 pkg_preinst() {
+	has_version "x11-drivers/nvidia-drivers[wayland]" && NV_HAD_WAYLAND=1
+
 	use driver || return
 	linux-mod_pkg_preinst
 
@@ -360,8 +362,6 @@ pkg_postinst() {
 
 	readme.gentoo_print_elog
 
-	optfeature "wayland EGLStream with nvidia-drm.modeset=1" gui-libs/egl-wayland
-
 	if [[ -r /proc/driver/nvidia/version &&
 		$(grep -o '  [0-9.]*  ' /proc/driver/nvidia/version) != "  ${PV}  " ]]; then
 		ewarn "Currently loaded NVIDIA modules do not match the newly installed"
@@ -374,5 +374,10 @@ pkg_postinst() {
 		elog "module (nvidia-uvm) on x86 (32bit), as such the module was not built."
 		elog "This means OpenCL/CUDA (and related, like nvenc) cannot be used."
 		elog "Other functions, like OpenGL, will continue to work."
+	fi
+
+	if [[ ${NV_HAD_WAYLAND} ]]; then
+		elog "Support for EGLStream (egl-wayland) is no longer offered with legacy"
+		elog "nvidia-drivers. It is recommended to use nouveau drivers for wayland."
 	fi
 }

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-390.141-r1.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-390.141-r1.ebuild
@@ -26,7 +26,7 @@ S="${WORKDIR}"
 
 LICENSE="GPL-2 MIT NVIDIA-r2"
 SLOT="0/${PV%%.*}"
-KEYWORDS="-* ~amd64 ~x86"
+KEYWORDS="-* amd64 x86"
 IUSE="+X +driver static-libs +tools"
 
 COMMON_DEPEND="

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-450.102.04-r1.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-450.102.04-r1.ebuild
@@ -26,7 +26,7 @@ S="${WORKDIR}"
 
 LICENSE="GPL-2 MIT NVIDIA-r2 ZLIB"
 SLOT="0/${PV%%.*}"
-KEYWORDS="-* ~amd64"
+KEYWORDS="-* amd64"
 IUSE="+X +driver static-libs +tools"
 
 COMMON_DEPEND="

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-460.67.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-460.67.ebuild
@@ -26,7 +26,7 @@ S="${WORKDIR}"
 
 LICENSE="GPL-2 MIT NVIDIA-r2 ZLIB"
 SLOT="0/${PV%%.*}"
-KEYWORDS="-* ~amd64"
+KEYWORDS="-* amd64"
 IUSE="+X +driver static-libs +tools"
 
 COMMON_DEPEND="


### PR DESCRIPTION
Adding PR bit early for review, albeit it's ready anytime.

Still ~3 days to go before new ebuilds and 460.67 will have been in the tree for 30 days (minus small corrections), but testing in stable has been done (primarily with stable kernel 5.10.27) and loose ends corrected.

Additional ebuild changes here are only informational prompted from testing legacy 390 further.