### PR TITLE
media-video/pitivi: revision bump, support python3.8

### DIFF
--- a/media-video/pitivi/files/pitivi-0.999-metainfo.patch
+++ b/media-video/pitivi/files/pitivi-0.999-metainfo.patch
@@ -1,0 +1,12 @@
+diff --unified --new-file --recursive --show-c-function '--color=auto' pitivi-0.999/data/meson.build pitivi-0.999-fix/data/meson.build
+--- pitivi-0.999/data/meson.build	2018-08-29 16:05:21.000000000 +0200
++++ pitivi-0.999-fix/data/meson.build	2021-04-18 09:10:56.067231216 +0200
+@@ -18,7 +18,7 @@ custom_target('org.pitivi.Pitivi.appdata
+     input : 'org.pitivi.Pitivi.appdata.xml.in',
+     command : [intltool_merge, '--xml-style', podir, '@INPUT@', '@OUTPUT@'],
+     install : true,
+-    install_dir : join_paths(get_option('datadir'), 'appdata'))
++    install_dir : join_paths(get_option('datadir'), 'metainfo'))
+ 
+ install_data('org.pitivi.Pitivi-mime.xml',
+     install_dir : join_paths(get_option('datadir'), 'mime/packages'))

--- a/media-video/pitivi/files/pitivi-0.999-python38.patch
+++ b/media-video/pitivi/files/pitivi-0.999-python38.patch
@@ -1,0 +1,49 @@
+From 3c2c03828efb986e66ba2a35e341127e8161c799 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexandru=20B=C4=83lu=C8=9B?= <alexandru.balut@gmail.com>
+Date: Tue, 28 Jan 2020 22:34:40 +0100
+Subject: [PATCH] meson: Support Python 3.8
+
+To link to Python we need to use python-3.8-embed.
+---
+ meson.build       | 13 ++++++++++---
+ meson_options.txt |  3 ++-
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 17a7312d..289e0086 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,11 +1,18 @@
+-project('pitivi', 'c', version : '0.999', meson_version : '>= 0.41.0')
++project('pitivi', 'c', version : '0.999', meson_version : '>= 0.46.0')
+ 
+-python = find_program('python3')
+ intltool_merge = find_program('intltool-merge')
+ itstool = find_program('itstool')
+ msgfmt = find_program('msgfmt')
+ 
+-python_dep = dependency('python3', version : '>= 3.3')
++pymod = import('python')
++python = pymod.find_installation(get_option('python'))
++pythonver = python.language_version()
++# Workaround for https://github.com/mesonbuild/meson/issues/5629
++# https://gitlab.freedesktop.org/gstreamer/gst-python/issues/28
++python_dep = dependency('python-@0@-embed'.format(pythonver), version: '>= 3.3', required: false)
++if not python_dep.found()
++  python_dep = python.dependency('python3', version: '>= 3.3')
++endif
+ 
+ if get_option('build-gst')
+     subproject('gst-build', default_options: ['enable_python=true',
+diff --git a/meson_options.txt b/meson_options.txt
+index c6590dd1..7d6bad29 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1,2 +1,3 @@
+-option('disable-help', type : 'boolean', value : false)
+ option('build-gst', type : 'boolean', value : false)
++option('disable-help', type : 'boolean', value : false)
++option('python', type : 'string', value : 'python3')
+-- 
+2.26.2
+

--- a/media-video/pitivi/pitivi-0.999-r4.ebuild
+++ b/media-video/pitivi/pitivi-0.999-r4.ebuild
@@ -1,0 +1,113 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_8 )
+PYTHON_REQ_USE="sqlite"
+
+inherit gnome.org meson python-single-r1 virtualx xdg
+
+DESCRIPTION="A non-linear video editor using the GStreamer multimedia framework"
+HOMEPAGE="http://www.pitivi.org"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+IUSE="v4l test"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+# XXX: recommends gst-plugins-libav and frei0r-plugins
+
+# Do not forget to check pitivi/check.py for dependencies!!!
+# pycanberra, libav, libnotify and liwnck are optional
+GST_VER="1.14.2"
+
+COMMON_DEPEND="
+	${PYTHON_DEPS}
+	$(python_gen_cond_dep '
+		>=dev-python/pycairo-1.10[${PYTHON_MULTI_USEDEP}]
+	')
+	>=x11-libs/cairo-1.10
+
+	>=media-libs/gstreamer-${GST_VER}:1.0[introspection]
+	>=media-plugins/gst-transcoder-1.14.1
+"
+RDEPEND="${COMMON_DEPEND}
+	>=dev-libs/glib-2.30.0:2
+
+	>=dev-libs/gobject-introspection-1.34:=
+	$(python_gen_cond_dep '
+		dev-python/dbus-python[${PYTHON_MULTI_USEDEP}]
+		>=dev-python/gst-python-1.4:1.0[${PYTHON_MULTI_USEDEP}]
+		dev-python/matplotlib[${PYTHON_MULTI_USEDEP}]
+		dev-python/numpy[${PYTHON_MULTI_USEDEP}]
+		>=dev-python/pygobject-3.8:3[${PYTHON_MULTI_USEDEP}]
+	')
+
+	gnome-base/librsvg:=
+	>=media-libs/gsound-1.0
+
+	>=media-libs/gstreamer-editing-services-${GST_VER}:1.0[introspection]
+	>=media-libs/gst-plugins-base-${GST_VER}:1.0[introspection,theora]
+	>=media-libs/gst-plugins-bad-${GST_VER}:1.0
+	>=media-plugins/gst-plugins-gtk-${GST_VER}:1.0
+	>=media-libs/gst-plugins-good-${GST_VER}:1.0
+	>=media-plugins/gst-plugins-libav-${GST_VER}:1.0
+	>=media-plugins/gst-plugins-gdkpixbuf-${GST_VER}:1.0
+
+	>=x11-libs/libnotify-0.7[introspection]
+	x11-libs/libwnck:3[introspection]
+	>=x11-libs/gtk+-3.20.0:3[introspection]
+
+	v4l? ( >=media-plugins/gst-plugins-v4l2-${GST_VER}:1.0 )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	app-text/yelp-tools
+	dev-python/setuptools
+	>=dev-util/intltool-0.35.5
+	dev-util/itstool
+	sys-devel/gettext
+	virtual/pkgconfig
+	test? (
+		$(python_gen_cond_dep '
+			dev-python/nose2[${PYTHON_MULTI_USEDEP}]
+		')
+	)
+"
+
+PATCHES=(
+	# https://gitlab.gnome.org/GNOME/pitivi/-/merge_requests/245
+	# support python 3.8
+	"${FILESDIR}"/${P}-python38.patch
+
+	# use /usr/share/metainfo
+	"${FILESDIR}"/${P}-metainfo.patch
+
+	# Make tests optional, bug #594096
+	# https://gitlab.gnome.org/GNOME/pitivi/issues/2303
+	"${FILESDIR}"/${P}-optional-tests.patch
+)
+
+src_configure() {
+	local emesonargs=(
+		-Denable-tests=$(usex test true false)
+	)
+	meson_src_configure
+}
+
+src_compile() {
+	meson_src_compile
+}
+
+src_test() {
+	export PITIVI_TOP_LEVEL_DIR="${S}"
+	virtx meson_src_test
+}
+
+src_install() {
+	meson_src_install
+	python_fix_shebang "${D}"
+}


### PR DESCRIPTION
I've been using this version for a while now from my local overlay. I haven't discovered any issues related to python 3.8


Bug: https://bugs.gentoo.org/749032
Closes: https://bugs.gentoo.org/771000
Closes: https://bugs.gentoo.org/722446
Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Daniel Brandt <poncho@spahan.ch>