### PR TITLE
mail-client/mutt-wizard: add sasl runtime neomutt dependency

### DIFF
--- a/mail-client/mutt-wizard/mutt-wizard-3.1.1.ebuild
+++ b/mail-client/mutt-wizard/mutt-wizard-3.1.1.ebuild
@@ -21,7 +21,7 @@ SLOT="0"
 
 RDEPEND="
 	app-admin/pass
-	mail-client/neomutt[notmuch]
+	mail-client/neomutt[notmuch,sasl]
 	mail-mta/msmtp
 	net-mail/isync[ssl]
 "

--- a/mail-client/mutt-wizard/mutt-wizard-3.2.1.ebuild
+++ b/mail-client/mutt-wizard/mutt-wizard-3.2.1.ebuild
@@ -21,7 +21,7 @@ SLOT="0"
 
 RDEPEND="
 	app-admin/pass
-	mail-client/neomutt[notmuch]
+	mail-client/neomutt[notmuch,sasl]
 	mail-mta/msmtp
 	net-mail/isync[ssl]
 "

--- a/mail-client/mutt-wizard/mutt-wizard-9999.ebuild
+++ b/mail-client/mutt-wizard/mutt-wizard-9999.ebuild
@@ -21,7 +21,7 @@ SLOT="0"
 
 RDEPEND="
 	app-admin/pass
-	mail-client/neomutt[notmuch]
+	mail-client/neomutt[notmuch,sasl]
 	mail-mta/msmtp
 	net-mail/isync[ssl]
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/765763
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Aisha Tammy <gentoo@aisha.cc>

---
No need for revision bump as package was unusable without this, so everyone had to enable it manually anyway.