### PR TITLE
media-video/pipewire: Wiring up of jack-sdk IUSE & multilib and various fixes.

### DIFF
--- a/media-video/pipewire/metadata.xml
+++ b/media-video/pipewire/metadata.xml
@@ -25,6 +25,7 @@
 		<flag name="ffmpeg">Builds an unsupported SPA (file a Gentoo bug if you need this)</flag>
 		<flag name="jack">Enable SPA JACK plugin and emulation to be able to run JACK applications on top of PipeWire</flag>
 		<flag name="jack-client">Install a plugin for running PipeWire as a JACK client</flag>
+		<flag name="jack-sdk">Turns PipeWire into a JACK replacement (currently incomplete)</flag>
 		<flag name="ldac">LDAC over Bluetooth (primarily Sony headphones)</flag>
 		<flag name="pipewire-alsa">Replace PulseAudio's ALSA plugin with PipeWire's plugin</flag>
 		<flag name="vulkan">Uses Vulkan compute shaders to provide a CGI video source</flag>

--- a/media-video/pipewire/pipewire-9999.ebuild
+++ b/media-video/pipewire/pipewire-9999.ebuild
@@ -248,7 +248,6 @@ pkg_postinst() {
 		elog
 		ewarn "Both new users and those upgrading need to enable pipewire-media-session:"
 		ewarn "systemctl --user enable pipewire-media-session.service"
-		ewarn "People using it for screencasting still need only pipewire.socket enabled."
 	else
 		elog "This ebuild auto-enables PulseAudio replacement. Because of that users"
 		elog "are recommended to edit: ${EROOT}/etc/pulse/client.conf and disable"
@@ -263,6 +262,8 @@ pkg_postinst() {
 		elog
 		ewarn "${EROOT}/etc/xdg/autostart/pipewire.desktop has been installed. Users of XDG"
 		ewarn "compliant desktops on OpenRC must not manually start pipewire anymore!"
+		ewarn "Users wishing to use PulseAudio must remove the file manually and add the"
+		ewarn "path above to the INSTALL_MASK variable in their make.conf"
 	fi
 
 	optfeature_header "The following can be installed for optional runtime features:"

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Niklāvs Koļesņikovs <89q1r14hd@relay.firefox.com> (2021-04-19)
+# Mask jack-sdk until it's been thoroughly tested
+media-video/pipewire jack-sdk
+
 # Matt Turner <mattst88@gentoo.org> (2021-04-14)
 # Was masked since 2014. Unmasked starting with 0.3.13.
 <media-plugins/grilo-plugins-0.3.13 lua

--- a/virtual/jack/jack-1.ebuild
+++ b/virtual/jack/jack-1.ebuild
@@ -13,4 +13,5 @@ RDEPEND="
 	|| (
 		media-sound/jack2[${MULTILIB_USEDEP}]
 		media-sound/jack-audio-connection-kit[${MULTILIB_USEDEP}]
+		media-video/pipewire[${MULTILIB_USEDEP},jack-sdk(-)]
 	)"


### PR DESCRIPTION
This draft PR is a WIP on implementing the jack-sdk IUSE for making media-video/pipewire a virtual/jack provider.

TODO:
  - [x] disable building of unused code for non-native ABIs (partially done - disabling more easily breaks tests)
  - [ ] either discard or fix ({README,INSTALL}.md NEWS) installation (man pages are built and installed, so this is a bit of a fluff anyway)
  - [ ] test that virtual/jack reverse dependencies build and run correctly with media-video/pipewire[jack-sdk]
    - [x] the small section of _less pro_-audio applications used by the PR's author build and seem to run fine
    - [ ] have a pro user report back on a DAW or similar use-case(?)
    - [x] and in the meantime mask jack-sdk IUSE
  - [ ] either fix or remove pw-jack loader when jack-sdk is enabled (since overriding the libdir breaks its built-in multilib support, and it's no longer needed once we replace system's JACK libraries)
  - [x] wait for the next PipeWire release to come out for this to be available ;)

The only important non-jack/multilib change is the removal of the docdir patch, [since it has been upstreamed](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1057).