### PR TITLE
app-misc/qlcplus: Add missing dependencies to version 5.0.0_alpha3

### DIFF
--- a/app-misc/qlcplus/qlcplus-5.0.0_alpha3.ebuild
+++ b/app-misc/qlcplus/qlcplus-5.0.0_alpha3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -28,7 +28,9 @@ RDEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtmultimedia:5[widgets,qml]
 	dev-qt/qtnetwork:5
+	dev-qt/qtprintsupport:5
 	dev-qt/qtscript:5
+	dev-qt/qtsvg:5
 	dev-qt/qtwidgets:5
 	media-libs/alsa-lib
 	media-libs/libmad


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/784098
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Jannis Achstetter <kripton@kripserver.net>