### PR TITLE
dev-lang/ispc: Update live ebuild

### DIFF
--- a/dev-lang/ispc/files/ispc-9999-llvm.patch
+++ b/dev-lang/ispc/files/ispc-9999-llvm.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 13e66268..27ff8364 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -218,7 +218,7 @@ if (WASM_ENABLED)
+     list(APPEND ISPC_TARGETS wasm-i32x4)
+ endif()
+
+-set(CLANG_LIBRARY_LIST clangFrontend clangDriver clangSerialization clangParse clangSema clangAnalysis clangAST clangBasic clangEdit clangLex)
++set(CLANG_LIBRARY_LIST clang clang-cpp)
+ set(LLVM_COMPONENTS engine ipo bitreader bitwriter instrumentation linker option frontendopenmp)
+
+ if (X86_ENABLED)
+@@ -402,11 +402,8 @@ if (ISPC_USE_ASAN)
+ endif()
+ 
+ # Link against Clang libraries
+-foreach(clangLib ${CLANG_LIBRARY_LIST})
+-    find_library(${clangLib}Path NAMES ${clangLib} HINTS ${LLVM_LIBRARY_DIRS})
+-    list(APPEND CLANG_LIBRARY_FULL_PATH_LIST ${${clangLib}Path})
+-endforeach()
+-target_link_libraries(${PROJECT_NAME} ${CLANG_LIBRARY_FULL_PATH_LIST})
++find_package(Clang REQUIRED)
++target_link_libraries(${PROJECT_NAME} ${CLANG_LIBRARY_LIST})
+ 
+ # Link against LLVM libraries
+ target_link_libraries(${PROJECT_NAME} ${LLVM_LIBRARY_LIST})
+diff --git a/src/llvmutil.cpp b/src/llvmutil.cpp
+index 06fab989..57a7130f 100644
+--- a/src/llvmutil.cpp
++++ b/src/llvmutil.cpp
+@@ -42,6 +42,7 @@
+ #include <llvm/IR/BasicBlock.h>
+ #include <llvm/IR/Instructions.h>
+ #include <llvm/IR/Module.h>
++#include <llvm/Support/raw_ostream.h>
+
+ #ifdef ISPC_GENX_ENABLED
+ #include <llvm/GenXIntrinsics/GenXIntrinsics.h>

--- a/dev-lang/ispc/files/ispc-9999-werror.patch
+++ b/dev-lang/ispc/files/ispc-9999-werror.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 13e66268..27ff8364 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -352,7 +352,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
+     set_source_files_properties(${FLEX_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4003")
+     set_source_files_properties(${BISON_OUTPUT} PROPERTIES COMPILE_FLAGS "/wd4005 /wd4065")
+ else()
+-    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-sign-compare -Wno-unused-function -Werror ${LLVM_CPP_FLAGS})
++    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-sign-compare -Wno-unused-function ${LLVM_CPP_FLAGS})
+     # The change implementing -Wno-unused-but-set-variable in clang was reverted, so commenting out for now.
+     #if (${LLVM_VERSION_NUMBER} VERSION_GREATER_EQUAL "13.0.0")
+     #    set_source_files_properties(${BISON_CPP_OUTPUT} PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable")

--- a/dev-lang/ispc/ispc-9999.ebuild
+++ b/dev-lang/ispc/ispc-9999.ebuild
@@ -7,10 +7,10 @@ PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit cmake toolchain-funcs python-any-r1 llvm
 
-LLVM_MAX_SLOT=10
+LLVM_MAX_SLOT=12
 
 DESCRIPTION="Intel SPMD Program Compiler"
-HOMEPAGE="https://ispc.github.com/"
+HOMEPAGE="https://ispc.github.io/"
 
 if [[ ${PV} = *9999 ]]; then
 	inherit git-r3
@@ -24,7 +24,7 @@ LICENSE="BSD BSD-2 UoI-NCSA"
 SLOT="0"
 IUSE="examples"
 
-RDEPEND="<sys-devel/clang-11:="
+RDEPEND="<sys-devel/clang-13:="
 DEPEND="
 	${RDEPEND}
 	${PYTHON_DEPS}
@@ -36,9 +36,11 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.13.0-cmake-gentoo-release.patch"
-	"${FILESDIR}/${PN}-1.14.0-llvm-10.patch"
-	"${FILESDIR}/${PN}-1.13.0-werror.patch"
+	"${FILESDIR}/${PN}-9999-llvm.patch"
+	"${FILESDIR}/${PN}-9999-werror.patch"
 )
+
+CMAKE_BUILD_TYPE="RelWithDebInfo"
 
 llvm_check_deps() {
 	has_version -d "sys-devel/clang:${LLVM_SLOT}"
@@ -60,6 +62,7 @@ src_configure() {
 	local mycmakeargs=(
 		"-DARM_ENABLED=$(usex arm)"
 		"-DCMAKE_SKIP_RPATH=ON"
+		"-DISPC_NO_DUMPS=ON"
 	)
 	cmake_src_configure
 }
@@ -71,11 +74,11 @@ src_install() {
 	if use examples; then
 		insinto "/usr/share/doc/${PF}/examples"
 		docompress -x "/usr/share/doc/${PF}/examples"
-		doins -r "${BUILD_DIR}"/examples/*
+		doins -r "${S}"/examples/*
 	fi
 }
 
 src_test() {
 	# Inject path to prevent using system ispc
-	PATH="${BUILD_DIR}/bin:${PATH}" ${EPYTHON} run_tests.py || die "Testing failed under ${EPYTHON}"
+	PATH="${BUILD_DIR}/bin:${PATH}" ${EPYTHON} ./run_tests.py || die "Testing failed under ${EPYTHON}"
 }


### PR DESCRIPTION
This updates the ebuild to use the "use only upstream llvm features" flag (`DISPC_NO_DUMPS`) and also lifts the llvm 10 requirement as it now compiles and passes the automated tests with llvm 11 and 12.