### PR TITLE
app-emulation/libvirt: Update bash-completion script path

### DIFF
--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -295,8 +295,8 @@ src_install() {
 	rm -rf "${D}"/var || die
 	rm -rf "${D}"/run || die
 
-	newbashcomp "${S}/tools/bash-completion/vsh" virsh
-	bashcomp_alias virsh virt-admin
+	newbashcomp "${BUILD_DIR}/tools/bash-completion/virsh" virsh
+	newbashcomp "${BUILD_DIR}/tools/bash-completion/virt-admin" virt-admin
 
 	use libvirtd || return 0
 	# From here, only libvirtd-related instructions, be warned!


### PR DESCRIPTION
Previously, the bash-completion script was living in the source
directory and during src_install() it was copied over into the
install image and symlinks were created for virsh and virt-admin
binaries. But with libvirt commit v7.2.0-336-gcf66ee8ddc this has
changed and each binary has its own completion script generated
during compile phase. This means that we have to update our paths
where we're getting the scripts from.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>