### PR TITLE
dev-java/browserlauncher2: EAPI 7, min java 1.8

### DIFF
--- a/dev-java/browserlauncher2/browserlauncher2-1.3-r2.ebuild
+++ b/dev-java/browserlauncher2/browserlauncher2-1.3-r2.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source"
+
+inherit java-pkg-2 java-ant-2
+
+MY_PV="$(ver_rs 1- _)"
+
+DESCRIPTION="A library that facilitates opening a browser from a Java application"
+HOMEPAGE="http://browserlaunch2.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/project/browserlaunch2/browserlauncher2/${PV}/BrowserLauncher2-all-${MY_PV}.jar"
+
+LICENSE="LGPL-2.1"
+SLOT="1.0"
+KEYWORDS="~amd64 ~ppc64 ~x86"
+
+DEPEND=">=virtual/jdk-1.8:*"
+RDEPEND=">=virtual/jre-1.8:*"
+BDEPEND="app-arch/unzip"
+
+S="${WORKDIR}"
+
+src_prepare() {
+	default
+	unpack ${A}
+	find . -name "*.class" -exec rm -v {} \; || die
+	# fixing build.xml
+	sed -i -e "s: includes=\"\*\*/\*\.class\"::g" "${S}/build.xml" || die
+
+	iconv -f ISO-8859-1 -t UTF8 -o /var/tmp/portage/dev-java/browserlauncher2-1.3-r2/work/source/at/jta/Regor.java~ \
+		/var/tmp/portage/dev-java/browserlauncher2-1.3-r2/work/source/at/jta/Regor.java || die "recoding failed"
+	mv -f /var/tmp/portage/dev-java/browserlauncher2-1.3-r2/work/source/at/jta/Regor.java{~,} || die "cannot rename"
+}
+
+EANT_BUILD_TARGET="build"
+EANT_DOC_TARGET="api"
+
+src_install() {
+	java-pkg_newjar deployment/*.jar
+	java-pkg_dolauncher BrowserLauncherTestApp-${SLOT} \
+		--main "edu.stanford.ejalbert.testing.BrowserLauncherTestApp"
+
+	dodoc README*
+	use doc && java-pkg_dojavadoc api
+	use source && java-pkg_dosrc source
+}


### PR DESCRIPTION
With `doc` enabled it happens that:
```
CVV: 8
Checked: 46 Good: 46 Bad: 0
 * Verbose logging for "java-pkg_dojar" function
 * Jar file(s) destination: /usr/share/browserlauncher2-1.0/lib
 * Jar file(s) created: /var/tmp/portage/dev-java/browserlauncher2-1.3-r2/temp/browserlauncher2.jar
 * Complete command:
 * java-pkg_dojar /var/tmp/portage/dev-java/browserlauncher2-1.3-r2/temp/browserlauncher2.jar
 * ERROR: dev-java/browserlauncher2-1.3-r2::gentoo failed (install phase):
 *   api does not exist, or isn't a directory!
```

Wow, before setting `JAVA_ANT_ENCODING="ISO-8859-1"` an error message popped up in compile phase.
Now, the error is still there but no longer the error message in compile phase.

```
The ' characters around the executable and arguments are
not part of the command.
  [javadoc] /var/tmp/portage/dev-java/browserlauncher2-1.3-r2/work/source/at/jta/Regor.java:355: error: unmappable character for encoding UTF8
  [javadoc] Loading source files for package at.jta...
  [javadoc] Loading source files for package edu.stanford.ejalbert...
  [javadoc]    * Will man den defaulteintrag �ndern, so muss man valueName "" �bergeben
  [javadoc]                                  ^
  [javadoc] /var/tmp/portage/dev-java/browserlauncher2-1.3-r2/work/source/at/jta/Regor.java:355: error: unmappable character for encoding UTF8
  [javadoc]    * Will man den defaulteintrag �ndern, so muss man valueName "" �bergeben
  [javadoc]                                                                   ^
  [javadoc] /var/tmp/portage/dev-java/browserlauncher2-1.3-r2/work/source/at/jta/Regor.java:482: error: unmappable character for encoding UTF8
  [javadoc]    * doesnt have a high access level (so maybe creating or deleting a key/value wouldn�t be successful)
  [javadoc]                                                                                       ^
  [javadoc] Loading source files for package edu.stanford.ejalbert.browserprefui...
  [javadoc] Loading source files for package edu.stanford.ejalbert.exception...
  [javadoc] Loading source files for package edu.stanford.ejalbert.exceptionhandler...
  [javadoc] Loading source files for package edu.stanford.ejalbert.launching...
  [javadoc] Loading source files for package edu.stanford.ejalbert.launching.macos...
  [javadoc] Loading source files for package edu.stanford.ejalbert.launching.misc...
  [javadoc] Loading source files for package edu.stanford.ejalbert.launching.utils...
  [javadoc] Loading source files for package edu.stanford.ejalbert.launching.windows...
  [javadoc] Loading source files for package edu.stanford.ejalbert.testing...
  [javadoc] Loading source files for package net.sf.wraplog...
  [javadoc] 3 errors
  [javadoc] No javadoc created, no need to post-process anything

BUILD SUCCESSFUL
Total time: 1 second
>>> Source compiled.
```
Ehm
`3 errors`, `BUILD SUCCESSFUL`

Should I try converting that source file [as done here for some docs](https://github.com/gentoo/gentoo/blob/master/sys-block/scsiadd/scsiadd-1.97-r2.ebuild#L29-L31)?