### PR TITLE
x11-themes/papirus-icon-theme: add support for -9999 version

### DIFF
--- a/x11-themes/papirus-icon-theme/papirus-icon-theme-9999.ebuild
+++ b/x11-themes/papirus-icon-theme/papirus-icon-theme-9999.ebuild
@@ -24,5 +24,4 @@ src_compile() { :; }
 src_install() {
 	insinto /usr/share/icons
 	doins -r ePapirus Papirus{,-Dark,-Light}
-
 }


### PR DESCRIPTION
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Marco Scardovi <marco@scardovi.com>