### PR TITLE
sys-apps/fwupd: tpm isn’t a plugin anymore

### DIFF
--- a/sys-apps/fwupd/fwupd-1.4.7.ebuild
+++ b/sys-apps/fwupd/fwupd-1.4.7.ebuild
@@ -126,7 +126,7 @@ src_configure() {
 		$(meson_use systemd)
 		$(meson_use test tests)
 		$(meson_use thunderbolt plugin_thunderbolt)
-		$(meson_use tpm plugin_tpm)
+		$(meson_use tpm tpm)
 		$(meson_use uefi plugin_uefi)
 		# Although our sys-apps/flashrom package now provides
 		# libflashrom.a, meson still can't find it


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/780903
Package-Manager: Portage-3.0.17, Repoman-3.0.2
Signed-off-by: Alarig Le Lay <alarig@swordarmor.fr