### PR TITLE
dev-java/codemodel: min java 1.8

### DIFF
--- a/dev-java/codemodel/codemodel-2.6-r1.ebuild
+++ b/dev-java/codemodel/codemodel-2.6-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source"
+
+inherit java-pkg-2 java-pkg-simple
+
+DESCRIPTION="Java library for code generators"
+HOMEPAGE="https://javaee.github.io/jaxb-codemodel/"
+SRC_URI="https://repo.maven.apache.org/maven2/com/sun/${PN}/${PN}/${PV}/${P}-sources.jar"
+
+LICENSE="CDDL"
+SLOT="2"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=">=virtual/jdk-1.8:*"
+RDEPEND=">=virtual/jre-1.8:*"
+BDEPEND="app-arch/unzip"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/785415

When doc USE flag is enabled and only then it fails with:

```
 * Generating JavaDoc ...
./com/sun/codemodel/util/SingleByteEncoder.java:53: error: package sun.nio.cs is not visible
import sun.nio.cs.Surrogate;
              ^
  (package sun.nio.cs is declared in module java.base, which does not export it to the unnamed module)
1 error
```