### PR TITLE
vim-{plugin,spell}.eclass EAPI updates

### DIFF
--- a/app-vim/airline/airline-0.11.ebuild
+++ b/app-vim/airline/airline-0.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/airline/airline-0.11.ebuild
+++ b/app-vim/airline/airline-0.11.ebuild
@@ -21,6 +21,8 @@ HOMEPAGE="https://github.com/vim-airline/vim-airline/ https://www.vim.org/script
 LICENSE="MIT"
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
+DOCS=( CHANGELOG.md )
+
 src_prepare() {
 	default
 

--- a/app-vim/align/align-43.ebuild
+++ b/app-vim/align/align-43.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/align/align-43.ebuild
+++ b/app-vim/align/align-43.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/ansiesc/ansiesc-12.ebuild
+++ b/app-vim/ansiesc/ansiesc-12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/ansiesc/ansiesc-12.ebuild
+++ b/app-vim/ansiesc/ansiesc-12.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/autoalign/autoalign-14.ebuild
+++ b/app-vim/autoalign/autoalign-14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/autoalign/autoalign-14.ebuild
+++ b/app-vim/autoalign/autoalign-14.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 
@@ -28,4 +28,5 @@ src_prepare() {
 	# Don't use the cecutil.vim included in the tarball, use the one
 	# provided by app-vim/cecutil instead.
 	rm plugin/cecutil.vim || die
+	default
 }

--- a/app-vim/bash-support/bash-support-4.2.1.ebuild
+++ b/app-vim/bash-support/bash-support-4.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/bash-support/bash-support-4.2.1.ebuild
+++ b/app-vim/bash-support/bash-support-4.2.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/c-support/c-support-6.1.1.ebuild
+++ b/app-vim/c-support/c-support-6.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/c-support/c-support-6.1.1.ebuild
+++ b/app-vim/c-support/c-support-6.1.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/cecutil/cecutil-17.ebuild
+++ b/app-vim/cecutil/cecutil-17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/cecutil/cecutil-17.ebuild
+++ b/app-vim/cecutil/cecutil-17.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/cfengine-syntax/cfengine-syntax-20141019.ebuild
+++ b/app-vim/cfengine-syntax/cfengine-syntax-20141019.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: Cfengine 3 configuration files syntax"

--- a/app-vim/checkattach/checkattach-0.17.ebuild
+++ b/app-vim/checkattach/checkattach-0.17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/checkattach/checkattach-0.17.ebuild
+++ b/app-vim/checkattach/checkattach-0.17.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/colorschemes/colorschemes-20140623-r1.ebuild
+++ b/app-vim/colorschemes/colorschemes-20140623-r1.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit edos2unix epatch vim-plugin
+inherit edos2unix vim-plugin
 
 DESCRIPTION="vim plugin: a collection of color schemes from vim.org"
 HOMEPAGE="https://www.vim.org/"
@@ -18,10 +18,8 @@ for scheme names). To automatically set a scheme at startup, please see
 :help vimrc."
 
 src_prepare() {
-	EPATCH_SOURCE="${S}/patches" \
-	EPATCH_SUFFIX="patch" \
-	EPATCH_FORCE="yes" \
-	epatch
+	default
+	eapply -p0 "${S}"/patches/*.patch
 	rm -rf patches/
 
 	# fix line endings

--- a/app-vim/colorsel/colorsel-20100406.ebuild
+++ b/app-vim/colorsel/colorsel-20100406.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/colorsel/colorsel-20100406.ebuild
+++ b/app-vim/colorsel/colorsel-20100406.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/ctrlp/ctrlp-1.80.ebuild
+++ b/app-vim/ctrlp/ctrlp-1.80.ebuild
@@ -14,3 +14,5 @@ KEYWORDS="amd64 x86"
 S="${WORKDIR}/${PN}.vim-${PV}"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
+
+DOCS=( readme.md )

--- a/app-vim/ctrlp/ctrlp-1.80_p20180418.ebuild
+++ b/app-vim/ctrlp/ctrlp-1.80_p20180418.ebuild
@@ -15,3 +15,5 @@ LICENSE="vim"
 KEYWORDS="~amd64 ~x86"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
+
+DOCS=( readme.md )

--- a/app-vim/detectindent/detectindent-1.0_p20150908.ebuild
+++ b/app-vim/detectindent/detectindent-1.0_p20150908.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/detectindent/detectindent-1.0_p20150908.ebuild
+++ b/app-vim/detectindent/detectindent-1.0_p20150908.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/fuzzyfinder/fuzzyfinder-4.2.2.ebuild
+++ b/app-vim/fuzzyfinder/fuzzyfinder-4.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/fuzzyfinder/fuzzyfinder-4.2.2.ebuild
+++ b/app-vim/fuzzyfinder/fuzzyfinder-4.2.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/git-patch-tags/git-patch-tags-0.2.ebuild
+++ b/app-vim/git-patch-tags/git-patch-tags-0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/git-patch-tags/git-patch-tags-0.2.ebuild
+++ b/app-vim/git-patch-tags/git-patch-tags-0.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/gitlog/gitlog-5.1.0.ebuild
+++ b/app-vim/gitlog/gitlog-5.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/gitlog/gitlog-5.1.0.ebuild
+++ b/app-vim/gitlog/gitlog-5.1.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: git log and diff plugin for vim"

--- a/app-vim/gtk-syntax/gtk-syntax-20130716.ebuild
+++ b/app-vim/gtk-syntax/gtk-syntax-20130716.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/iris/iris-1.0.0.ebuild
+++ b/app-vim/iris/iris-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/iris/iris-1.0.0.ebuild
+++ b/app-vim/iris/iris-1.0.0.ebuild
@@ -25,6 +25,8 @@ RDEPEND="
 
 S="${WORKDIR}/${MY_P}"
 
+DOCS=( README.md CHANGELOG.md )
+
 src_install() {
 	mv api.py iris-api || die
 	mv idle.py iris-idle || die

--- a/app-vim/json/json-20150511.ebuild
+++ b/app-vim/json/json-20150511.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/json/json-20150511.ebuild
+++ b/app-vim/json/json-20150511.ebuild
@@ -10,6 +10,8 @@ HOMEPAGE="https://github.com/elzr/vim-json/"
 LICENSE="MIT"
 KEYWORDS="amd64 x86"
 
+DOCS=( readme.md )
+
 src_prepare() {
 	rm *-test.* license.md || die
 	default

--- a/app-vim/json/json-20150511.ebuild
+++ b/app-vim/json/json-20150511.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 
@@ -12,4 +12,5 @@ KEYWORDS="amd64 x86"
 
 src_prepare() {
 	rm *-test.* license.md || die
+	default
 }

--- a/app-vim/l9/l9-1.1.ebuild
+++ b/app-vim/l9/l9-1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/l9/l9-1.1.ebuild
+++ b/app-vim/l9/l9-1.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/merginal/merginal-2.1.2.ebuild
+++ b/app-vim/merginal/merginal-2.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/merginal/merginal-2.1.2.ebuild
+++ b/app-vim/merginal/merginal-2.1.2.ebuild
@@ -25,6 +25,8 @@ RDEPEND="app-vim/fugitive"
 
 VIM_PLUGIN_HELPFILES="${PN}"
 
+DOCS=( CHANGELOG.md )
+
 src_prepare() {
 	rm README.md || die
 	default

--- a/app-vim/merginal/merginal-9999.ebuild
+++ b/app-vim/merginal/merginal-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/merginal/merginal-9999.ebuild
+++ b/app-vim/merginal/merginal-9999.ebuild
@@ -25,6 +25,8 @@ RDEPEND="app-vim/fugitive"
 
 VIM_PLUGIN_HELPFILES="${PN}"
 
+DOCS=( CHANGELOG.md )
+
 src_prepare() {
 	rm README.md || die
 	default

--- a/app-vim/multiplesearch/multiplesearch-1.3.ebuild
+++ b/app-vim/multiplesearch/multiplesearch-1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/multiplesearch/multiplesearch-1.3.ebuild
+++ b/app-vim/multiplesearch/multiplesearch-1.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/nerdtree-tabs/nerdtree-tabs-1.4.7.ebuild
+++ b/app-vim/nerdtree-tabs/nerdtree-tabs-1.4.7.ebuild
@@ -17,6 +17,8 @@ S="${WORKDIR}/vim-${P}"
 
 VIM_PLUGIN_HELPFILES="${PN}"
 
+DOCS=( CHANGELOG.md )
+
 src_prepare() {
 	default
 	rm LICENSE README.md || die

--- a/app-vim/nerdtree/nerdtree-6.4.1.ebuild
+++ b/app-vim/nerdtree/nerdtree-6.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/nerdtree/nerdtree-6.4.1.ebuild
+++ b/app-vim/nerdtree/nerdtree-6.4.1.ebuild
@@ -13,6 +13,8 @@ KEYWORDS="~amd64 ~x86 ~x64-macos"
 
 VIM_PLUGIN_HELPFILES="NERD_tree"
 
+DOCS=( CHANGELOG.md README.markdown )
+
 src_prepare() {
 	default
 	rm LICENCE || die

--- a/app-vim/nerdtree/nerdtree-6.4.3.ebuild
+++ b/app-vim/nerdtree/nerdtree-6.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/nerdtree/nerdtree-6.4.3.ebuild
+++ b/app-vim/nerdtree/nerdtree-6.4.3.ebuild
@@ -19,6 +19,8 @@ LICENSE="WTFPL-2"
 
 VIM_PLUGIN_HELPFILES="NERD_tree"
 
+DOCS=( CHANGELOG.md README.markdown )
+
 src_prepare() {
 	rm LICENCE screenshot.png _config.yml || die
 	default

--- a/app-vim/nerdtree/nerdtree-9999.ebuild
+++ b/app-vim/nerdtree/nerdtree-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/nerdtree/nerdtree-9999.ebuild
+++ b/app-vim/nerdtree/nerdtree-9999.ebuild
@@ -19,6 +19,8 @@ LICENSE="WTFPL-2"
 
 VIM_PLUGIN_HELPFILES="NERD_tree"
 
+DOCS=( CHANGELOG.md README.markdown )
+
 src_prepare() {
 	rm LICENCE screenshot.png _config.yml || die
 	default

--- a/app-vim/nginx-syntax/nginx-syntax-0.3.3.ebuild
+++ b/app-vim/nginx-syntax/nginx-syntax-0.3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/nginx-syntax/nginx-syntax-0.3.3.ebuild
+++ b/app-vim/nginx-syntax/nginx-syntax-0.3.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/perl-support/perl-support-5.3.2.ebuild
+++ b/app-vim/perl-support/perl-support-5.3.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/perl-support/perl-support-5.3.2.ebuild
+++ b/app-vim/perl-support/perl-support-5.3.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: Perl-IDE - Write and run Perl scripts using menus and hotkeys"
@@ -18,6 +18,7 @@ RDEPEND="
 src_prepare() {
 	# Don't set tabstop and shiftwidth
 	sed -i '/=4/s/^/"/' ftplugin/perl.vim || die
+	default
 }
 
 src_install() {

--- a/app-vim/perl-support/perl-support-5.4.ebuild
+++ b/app-vim/perl-support/perl-support-5.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/perl-support/perl-support-5.4.ebuild
+++ b/app-vim/perl-support/perl-support-5.4.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: Perl-IDE - Write and run Perl scripts using menus and hotkeys"
@@ -23,6 +23,7 @@ S="${WORKDIR}/${PN}-version-${PV}"
 src_prepare() {
 	# Don't set tabstop and shiftwidth
 	sed -i '/=4/s/^/"/' ftplugin/perl.vim || die
+	default
 }
 
 src_install() {

--- a/app-vim/project/project-1.4.1.ebuild
+++ b/app-vim/project/project-1.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/project/project-1.4.1.ebuild
+++ b/app-vim/project/project-1.4.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/rails/rails-5.2.ebuild
+++ b/app-vim/rails/rails-5.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/rails/rails-5.2.ebuild
+++ b/app-vim/rails/rails-5.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 
@@ -20,4 +20,5 @@ S=${WORKDIR}/${MY_P}
 
 src_prepare() {
 	rm *.markdown || die
+	default
 }

--- a/app-vim/rainbow_parentheses/rainbow_parentheses-1.0.ebuild
+++ b/app-vim/rainbow_parentheses/rainbow_parentheses-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/rainbow_parentheses/rainbow_parentheses-1.0.ebuild
+++ b/app-vim/rainbow_parentheses/rainbow_parentheses-1.0.ebuild
@@ -15,3 +15,5 @@ DEPEND="app-arch/unzip"
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}.vim-master"
+
+DOCS=( readme.md )

--- a/app-vim/recover/recover-0.18.ebuild
+++ b/app-vim/recover/recover-0.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/recover/recover-0.18.ebuild
+++ b/app-vim/recover/recover-0.18.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: show differences for recovered files"

--- a/app-vim/repeat/repeat-1.1.ebuild
+++ b/app-vim/repeat/repeat-1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/repeat/repeat-1.1.ebuild
+++ b/app-vim/repeat/repeat-1.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 
@@ -18,4 +18,5 @@ S=${WORKDIR}/${MY_P}
 
 src_prepare() {
 	rm *.markdown || die
+	default
 }

--- a/app-vim/salt-vim/salt-vim-20151119.ebuild
+++ b/app-vim/salt-vim/salt-vim-20151119.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/screen/screen-1.5.ebuild
+++ b/app-vim/screen/screen-1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/screen/screen-1.5.ebuild
+++ b/app-vim/screen/screen-1.5.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin vcs-snapshot
 
@@ -18,4 +18,5 @@ RDEPEND="|| ( app-misc/screen app-misc/tmux )"
 
 src_prepare() {
 	rm README || die
+	default
 }

--- a/app-vim/securemodelines/securemodelines-20140926.ebuild
+++ b/app-vim/securemodelines/securemodelines-20140926.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/securemodelines/securemodelines-20140926.ebuild
+++ b/app-vim/securemodelines/securemodelines-20140926.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: secure, user-configurable modeline support"

--- a/app-vim/sleuth/sleuth-1.1.ebuild
+++ b/app-vim/sleuth/sleuth-1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/sleuth/sleuth-1.1.ebuild
+++ b/app-vim/sleuth/sleuth-1.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/snipmate/snipmate-0.87-r1.ebuild
+++ b/app-vim/snipmate/snipmate-0.87-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/snipmate/snipmate-0.87-r1.ebuild
+++ b/app-vim/snipmate/snipmate-0.87-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 
@@ -26,4 +26,5 @@ VIM_PLUGIN_MESSAGES="filetype"
 
 src_prepare() {
 	rm addon-info.json || die
+	default
 }

--- a/app-vim/sudoedit/sudoedit-0.21.ebuild
+++ b/app-vim/sudoedit/sudoedit-0.21.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/sudoedit/sudoedit-0.21.ebuild
+++ b/app-vim/sudoedit/sudoedit-0.21.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 
@@ -16,4 +16,5 @@ RDEPEND="|| ( app-admin/sudo sys-apps/shadow )"
 src_prepare() {
 	# remove unused windows related files
 	rm autoload/{sudo.cmd,SudoEdit.vbs} || die
+	default
 }

--- a/app-vim/supertab/supertab-2.1.ebuild
+++ b/app-vim/supertab/supertab-2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/supertab/supertab-2.1.ebuild
+++ b/app-vim/supertab/supertab-2.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI=7
 
 inherit vim-plugin
 
@@ -15,4 +15,5 @@ VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 src_prepare() {
 	rm Makefile .gitignore || die
+	default
 }

--- a/app-vim/surround/surround-2.1-r1.ebuild
+++ b/app-vim/surround/surround-2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/surround/surround-2.1-r1.ebuild
+++ b/app-vim/surround/surround-2.1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/tcomment/tcomment-3.08.1.ebuild
+++ b/app-vim/tcomment/tcomment-3.08.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/tcomment/tcomment-3.08.1.ebuild
+++ b/app-vim/tcomment/tcomment-3.08.1.ebuild
@@ -22,6 +22,8 @@ LICENSE="GPL-3"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
+DOCS=( CHANGES.TXT )
+
 src_prepare() {
 	default
 	rm -r README LICENSE.TXT etc spec addon* || die

--- a/app-vim/tcomment/tcomment-9999.ebuild
+++ b/app-vim/tcomment/tcomment-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/tcomment/tcomment-9999.ebuild
+++ b/app-vim/tcomment/tcomment-9999.ebuild
@@ -22,6 +22,8 @@ LICENSE="GPL-3"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
+DOCS=( CHANGES.txt )
+
 src_prepare() {
 	default
 	rm -r README LICENSE.TXT etc spec addon* || die

--- a/app-vim/tlib/tlib-1.22.ebuild
+++ b/app-vim/tlib/tlib-1.22.ebuild
@@ -18,6 +18,8 @@ VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 S=${WORKDIR}/${MY_P}
 
+DOCS=( README CHANGES.TXT )
+
 src_prepare() {
 	default
 	rm -r test samples addon-info.json || die

--- a/app-vim/tlib/tlib-1.23.ebuild
+++ b/app-vim/tlib/tlib-1.23.ebuild
@@ -18,6 +18,8 @@ VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 S=${WORKDIR}/${MY_P}
 
+DOCS=( README CHANGES.TXT )
+
 src_prepare() {
 	default
 	rm -r test samples addon-info.json || die

--- a/app-vim/vcscommand/vcscommand-1.99.47.ebuild
+++ b/app-vim/vcscommand/vcscommand-1.99.47.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/vim-addon-mw-utils/vim-addon-mw-utils-20121105.ebuild
+++ b/app-vim/vim-addon-mw-utils/vim-addon-mw-utils-20121105.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/vim-addon-mw-utils/vim-addon-mw-utils-20121105.ebuild
+++ b/app-vim/vim-addon-mw-utils/vim-addon-mw-utils-20121105.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/vim-autoclose/vim-autoclose-2.0.ebuild
+++ b/app-vim/vim-autoclose/vim-autoclose-2.0.ebuild
@@ -11,6 +11,8 @@ SRC_URI="https://dev.gentoo.org/~monsieurp/packages/${P}.tar.gz"
 LICENSE="vim"
 KEYWORDS="amd64 x86"
 
+DOCS=( README.txt AUTHORS.txt )
+
 src_unpack() {
 	default
 	mv * "${P}" || die

--- a/app-vim/vim-go/vim-go-1.13.ebuild
+++ b/app-vim/vim-go/vim-go-1.13.ebuild
@@ -16,6 +16,8 @@ VIM_PLUGIN_HELPFILES="${PN}"
 
 RESTRICT="test"
 
+DOCS=( README.md CHANGELOG.md )
+
 src_compile() {
 	# safely skip `make test` triggered by `make` as it runs `go get` commands
 	# TODO: see :GoInstallBinaries (https://github.com/fatih/vim-go/blob/master/doc/vim-go.txt)

--- a/app-vim/vim-go/vim-go-1.19.ebuild
+++ b/app-vim/vim-go/vim-go-1.19.ebuild
@@ -16,6 +16,8 @@ VIM_PLUGIN_HELPFILES="${PN}"
 
 RESTRICT="test"
 
+DOCS=( README.md CHANGELOG.md )
+
 src_compile() {
 	# safely skip `make test` triggered by `make` as it runs `go get` commands
 	# TODO: see :GoInstallBinaries (https://github.com/fatih/vim-go/blob/master/doc/vim-go.txt)

--- a/app-vim/vim-go/vim-go-1.20.ebuild
+++ b/app-vim/vim-go/vim-go-1.20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/vim-go/vim-go-1.20.ebuild
+++ b/app-vim/vim-go/vim-go-1.20.ebuild
@@ -15,6 +15,8 @@ VIM_PLUGIN_HELPFILES="${PN}"
 
 RESTRICT="test"
 
+DOCS=( README.md CHANGELOG.md )
+
 src_compile() {
 	# safely skip `make test` triggered by `make` as it runs `go get` commands
 	# TODO: see :GoInstallBinaries (https://github.com/fatih/vim-go/blob/master/doc/vim-go.txt)

--- a/app-vim/vim-misc/vim-misc-1.17.6.ebuild
+++ b/app-vim/vim-misc/vim-misc-1.17.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/vim-misc/vim-misc-1.17.6.ebuild
+++ b/app-vim/vim-misc/vim-misc-1.17.6.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 
@@ -15,4 +15,5 @@ VIM_PLUGIN_HELPFILES="misc.txt"
 
 src_prepare() {
 	rm INSTALL.md addon-info.json autoload/xolox/misc/echo.exe || die
+	default
 }

--- a/app-vim/vim-multiple-cursors/vim-multiple-cursors-2.2-r1.ebuild
+++ b/app-vim/vim-multiple-cursors/vim-multiple-cursors-2.2-r1.ebuild
@@ -17,8 +17,5 @@ src_install() {
 	rm -r \
 		"${ED}"/usr/share/vim/vimfiles/spec \
 		"${ED}"/usr/share/vim/vimfiles/assets \
-		"${ED}"/usr/share/doc/${PF}/MIT-LICENSE.txt \
-		"${ED}"/usr/share/doc/${PF}/Rakefile \
-		"${ED}"/usr/share/doc/${PF}/Gemfile.lock \
 		|| die "rm failed"
 }

--- a/app-vim/vim-r/vim-r-1.2.6.ebuild
+++ b/app-vim/vim-r/vim-r-1.2.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/vim-r/vim-r-1.2.6.ebuild
+++ b/app-vim/vim-r/vim-r-1.2.6.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit vim-plugin
 

--- a/app-vim/vim-tmux/vim-tmux-3.0.0.ebuild
+++ b/app-vim/vim-tmux/vim-tmux-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/vim-tmux/vim-tmux-3.0.0.ebuild
+++ b/app-vim/vim-tmux/vim-tmux-3.0.0.ebuild
@@ -10,3 +10,5 @@ HOMEPAGE="https://github.com/tmux-plugins/vim-tmux"
 SRC_URI="https://github.com/tmux-plugins/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="public-domain MIT"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+
+DOCS=( README.md CHANGELOG.md )

--- a/app-vim/vimagit/vimagit-1.7.3.ebuild
+++ b/app-vim/vimagit/vimagit-1.7.3.ebuild
@@ -19,6 +19,8 @@ VIM_PLUGIN_HELPFILES="${PN}"
 
 RDEPEND="dev-vcs/git"
 
+DOCS=( README.md Changelog )
+
 src_prepare() {
 	rm _config.yml || die
 	default

--- a/app-vim/vimagit/vimagit-9999.ebuild
+++ b/app-vim/vimagit/vimagit-9999.ebuild
@@ -19,6 +19,8 @@ VIM_PLUGIN_HELPFILES="${PN}"
 
 RDEPEND="dev-vcs/git"
 
+DOCS=( README.md Changelog )
+
 src_prepare() {
 	rm _config.yml || die
 	default

--- a/app-vim/vimclojure/vimclojure-2.3.6-r3.ebuild
+++ b/app-vim/vimclojure/vimclojure-2.3.6-r3.ebuild
@@ -19,7 +19,7 @@ RDEPEND="dev-lang/clojure"
 
 S="${WORKDIR}/${MY_PN}-${PV}"
 
-DOCS=( doc/LICENSE.txt )
+DOCS=( README README.markdown )
 
 # Files with similar names are already installed by app-vim/slimv.
 DUPLICATE_FILES=(
@@ -47,6 +47,6 @@ src_prepare() {
 
 src_install() {
 	einstalldocs
-	rm -rv "${DOCS[@]}" bin || die
+	rm -rv doc/LICENSE.txt bin || die
 	vim-plugin_src_install
 }

--- a/app-vim/vimcommander/vimcommander-0.81.ebuild
+++ b/app-vim/vimcommander/vimcommander-0.81.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/vimcommander/vimcommander-0.81.ebuild
+++ b/app-vim/vimcommander/vimcommander-0.81.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: Total Commander style file explorer"

--- a/app-vim/vimoutliner/vimoutliner-0.4.0_p20180301-r2.ebuild
+++ b/app-vim/vimoutliner/vimoutliner-0.4.0_p20180301-r2.ebuild
@@ -30,6 +30,8 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}"
 
+DOCS=( README CHANGELOG TODO.otl )
+
 src_prepare() {
 	default
 

--- a/app-vim/yankring/yankring-19.0.ebuild
+++ b/app-vim/yankring/yankring-19.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/yankring/yankring-19.0.ebuild
+++ b/app-vim/yankring/yankring-19.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 inherit vim-plugin
 
 DESCRIPTION="vim plugin: maintains a history of previous yanks and deletes"

--- a/eclass/vim-plugin.eclass
+++ b/eclass/vim-plugin.eclass
@@ -4,6 +4,7 @@
 # @ECLASS: vim-plugin.eclass
 # @MAINTAINER:
 # vim@gentoo.org
+# @SUPPORTED_EAPIS: 6 7
 # @BLURB: used for installing vim plugins
 # @DESCRIPTION:
 # This eclass simplifies installation of app-vim plugins into
@@ -11,7 +12,12 @@
 # which is read automatically by vim.  The only exception is
 # documentation, for which we make a special case via vim-doc.eclass.
 
-inherit estack vim-doc
+case ${EAPI} in
+	6|7);;
+	*) die "EAPI ${EAPI:-0} unsupported (too old)";;
+esac
+
+inherit vim-doc
 EXPORT_FUNCTIONS src_install pkg_postinst pkg_postrm
 
 VIM_PLUGIN_VIM_VERSION="${VIM_PLUGIN_VIM_VERSION:-7.3}"
@@ -33,37 +39,9 @@ SLOT="0"
 # * installs all files in "${ED}"/usr/share/vim/vimfiles.
 vim-plugin_src_install() {
 	has "${EAPI:-0}" 0 1 2 && ! use prefix && ED="${D}"
-	local f
-
-	# When globbing, if nothing exists, the shell literally returns the glob
-	# pattern. So turn on nullglob and extglob options to avoid this.
-	eshopts_push -s extglob
-	eshopts_push -s nullglob
-
-	ebegin "Cleaning up unwanted files and directories"
-	# We're looking for dotfiles, dotdirectories and Makefiles here.
-	local obj
-	eval "local matches=(@(.[^.]|.??*|Makefile*))"
-	for obj in "${matches[@]}"; do
-		rm -rv "${obj}" || die "cannot remove ${obj}"
-	done
-	eend $?
-
-	# Turn those options back off.
-	eshopts_pop
-	eshopts_pop
 
 	# Install non-vim-help-docs
-	cd "${S}" || die "couldn't cd in ${S}"
-	local f
-	for f in *; do
-		[[ -f "${f}" ]] || continue
-		if [[ "${f}" = *.html ]]; then
-			dohtml "${f}"
-		else
-			dodoc "${f}"
-		fi
-	done
+	einstalldocs
 
 	# Install remainder of plugin
 	insinto /usr/share/vim/vimfiles/

--- a/eclass/vim-plugin.eclass
+++ b/eclass/vim-plugin.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vim-plugin.eclass

--- a/eclass/vim-plugin.eclass
+++ b/eclass/vim-plugin.eclass
@@ -63,17 +63,15 @@ vim-plugin_src_install() {
 		else
 			dodoc "${f}"
 		fi
-		rm "${f}" || die
 	done
 
 	# Install remainder of plugin
-	cd "${WORKDIR}" || die "couldn't cd in ${WORKDIR}"
-	dodir /usr/share/vim
-	mv "${S}" "${ED}"/usr/share/vim/vimfiles || die \
-		"couldn't move ${S} to ${ED}/usr/share/vim/vimfiles"
-
-	# Set permissions
-	fperms -R a+rX /usr/share/vim/vimfiles
+	insinto /usr/share/vim/vimfiles/
+	local d;
+	for d in *; do
+		[[ -d "${d}" ]] || continue
+		doins -r "${d}"
+	done
 }
 
 # @FUNCTION: vim-plugin_pkg_postinst

--- a/eclass/vim-spell.eclass
+++ b/eclass/vim-spell.eclass
@@ -119,9 +119,7 @@ vim-spell_src_install() {
 		fi
 	done
 
-	for f in README*; do
-		dodoc "${f}"
-	done
+	einstalldocs
 
 	[[ -z "${had_spell_file}" ]] && die "Didn't install any spell files?"
 }


### PR DESCRIPTION
Hello,

While writing an ebuild using vim-plugin, I noticed that some files get copied
to /usr/share/doc/ that shouldn't be:
```
/var/tmp/portage/app-vim/vim-nix-9999/image/usr/share/doc/vim-nix-9999/LICENSE.bz2
/var/tmp/portage/app-vim/vim-nix-9999/image/usr/share/doc/vim-nix-9999/default.nix.bz2
/var/tmp/portage/app-vim/vim-nix-9999/image/usr/share/doc/vim-nix-9999/README.md.bz2
```

And digging into the eclass, it copies everything not filtered out by
`(@(.[^.]|.??*|Makefile*))` & not a vim file.

Now that `einstalldocs` is a function to sort of does the same thing but with a
better filter & ebuild configurable, would it make sense for the eclass to use
it?

I've written up a few patches (attached) to update this, but I have a few
questions:

- Is EAPI < 6 compatibility required? I don't take this into account
  - Some eclasses use SUPPORTED_EAPIS & a guard. needed?
- This is technically a "breaking" change
  - a few packages already try to fix the doc problem manually
    (app-vim/{vim-latex,command-t}). This won't cause build failures, but the
    useless code can/should be removed.
  - Some packages manually install the docs themselves
    (app-vim/{bash-support,vimclojure}), and sometimes remove the docs. I don't
    think `dodoc` on a file twice will cause failures? But the duplicated code
    can still be removed.
- I've maintained the behaviour of installing all unfiltered directories into
  `/usr/share/vim/vimfiles/`, but could additional code be removed from the
  ebuilds by only installing common vim directories eg `compiler`, `ftdetect`,
  `ftplugin`, `indent`, `plugin`, `syntax`? This is sort of a separate issue,
  but while im changing things..


Thanks,

<details><summary>Here's a list of files that this PR removes from installation</summary>

```diff
6d5
< ./usr/share/doc/ackvim-1.0.9-r1/LICENSE.bz2
7,8d6
< ./usr/share/doc/airline-0.11/CONTRIBUTING.md.bz2
< ./usr/share/doc/airline-0.11/ISSUE_TEMPLATE.md.bz2
airline-9999 failed
6d5
< ./usr/share/doc/airline-themes-0_pre20181021/LICENSE.bz2
6d5
< ./usr/share/doc/airline-themes-9999/LICENSE.bz2
55,58d54
< ./usr/share/doc
< ./usr/share/doc/command-t-5.0.3
< ./usr/share/doc/command-t-5.0.3/CODE_OF_CONDUCT.md.bz2
< ./usr/share/doc/command-t-5.0.3/CONTRIBUTING.md.bz2
4,7d3
< ./usr/share/doc
< ./usr/share/doc/csound-syntax-0.8.1
< ./usr/share/doc/csound-syntax-0.8.1/opcodelistfromcsound-z.py.bz2
< ./usr/share/doc/csound-syntax-0.8.1/opcodelistfromcsound-z.sh.bz2
6d5
< ./usr/share/doc/editorconfig-vim-1.1.1/CONTRIBUTORS
6,8d5
< ./usr/share/doc/emmet-9999/emmet.vim.vimup.bz2
< ./usr/share/doc/emmet-9999/emmet-vim.zip.bz2
< ./usr/share/doc/emmet-9999/LICENSE.bz2
10,13d6
< ./usr/share/doc/emmet-9999/TODO # empty
< ./usr/share/doc/emmet-9999/TUTORIAL.bz2
< ./usr/share/doc/emmet-9999/TUTORIAL.mkd.bz2
< ./usr/share/doc/emmet-9999/unittest.vim.bz2
6d5
< ./usr/share/doc/ferret-4.0/LICENSE.txt.bz2
6d5
< ./usr/share/doc/ferret-5.0/LICENSE.txt.bz2
6d5
< ./usr/share/doc/frawor-0.2.3/frawor-addon-info.txt.bz2
6d5
< ./usr/share/doc/fugitive-9999/CONTRIBUTING.markdown.bz2
6d5
< ./usr/share/doc/gentoo-syntax-20201216/COPYING.bz2
6d5
< ./usr/share/doc/gentoo-syntax-99999999/COPYING.bz2
6d5
< ./usr/share/doc/gitv-9999/CONTRIBUTING.md.bz2
8,9d6
< ./usr/share/doc/gitv-9999/ROADMAP.md.bz2
< ./usr/share/doc/gitv-9999/TESTING.md
18,20d17
< ./usr/share/doc/iris-1.0.0/iris-api.bz2
< ./usr/share/doc/iris-1.0.0/iris-idle.bz2
< ./usr/share/doc/iris-1.0.0/LICENSE.bz2
6,8d5
< ./usr/share/doc/jedi-0.10.0/AUTHORS.txt.bz2
< ./usr/share/doc/jedi-0.10.0/CONTRIBUTING.md.bz2
< ./usr/share/doc/jedi-0.10.0/LICENSE.txt.bz2
10d6
< ./usr/share/doc/jedi-0.10.0/setup.cfg
6,7d5
< ./usr/share/doc/lightline-9999/colorscheme.md.bz2
< ./usr/share/doc/lightline-9999/LICENSE.bz2
6d5
< ./usr/share/doc/molokai-0.1_p20151115/LICENSE.md.bz2
nerdcommenter-9999 failed
8d7
< ./usr/share/doc/nerdtree-6.4.1/screenshot.png
6d5
< ./usr/share/doc/pathogen-2.4-r1/CONTRIBUTING.markdown.bz2
pyclewn-2.1-r2 failed
6,7d5
< ./usr/share/doc/rust-vim-1_pre20180125/LICENSE-APACHE.bz2
< ./usr/share/doc/rust-vim-1_pre20180125/LICENSE-MIT.bz2
6d5
< ./usr/share/doc/salt-vim-20151119/LICENSE.bz2
6d5
< ./usr/share/doc/snipmate-0.87-r1/Contributors.md.bz2
4,6d3
< ./usr/share/doc
< ./usr/share/doc/syntastic-3.9.0
< ./usr/share/doc/syntastic-3.9.0/CONTRIBUTING.md.bz2
4,6d3
< ./usr/share/doc
< ./usr/share/doc/syntastic-9999
< ./usr/share/doc/syntastic-9999/CONTRIBUTING.md.bz2
tcomment-9999 failed
7d6
< ./usr/share/doc/tlib-1.22/LICENSE.TXT.bz2
7d6
< ./usr/share/doc/tlib-1.23/LICENSE.TXT.bz2
7d6
< ./usr/share/doc/vimagit-1.7.3/CONTRIBUTING.md.bz2
7d6
< ./usr/share/doc/vimagit-9999/CONTRIBUTING.md.bz2
7,8d6
< ./usr/share/doc/vim-autoclose-2.0/icon.png
< ./usr/share/doc/vim-autoclose-2.0/INSTALL.txt.bz2
8,12d7
< ./usr/share/doc/vimcdoc-1.9.0/dict.txt.bz2
< ./usr/share/doc/vimcdoc-1.9.0/guides.txt.bz2
< ./usr/share/doc/vimcdoc-1.9.0/help_cn.vim.bz2
< ./usr/share/doc/vimcdoc-1.9.0/INSTALL.bz2
< ./usr/share/doc/vimcdoc-1.9.0/LICENSE.bz2
15,17d9
< ./usr/share/doc/vimcdoc-1.9.0/VERSION
< ./usr/share/doc/vimcdoc-1.9.0/vimcdoc.sh.bz2
< ./usr/share/doc/vimcdoc-1.9.0/vimcdoc.vim.bz2
8,10d7
< ./usr/share/doc/vimcdoc-2.1.0/dict.txt.bz2
< ./usr/share/doc/vimcdoc-2.1.0/guides.txt.bz2
< ./usr/share/doc/vimcdoc-2.1.0/LICENSE.bz2
12,13d8
< ./usr/share/doc/vimcdoc-2.1.0/VERSION
< ./usr/share/doc/vimcdoc-2.1.0/vimcdoc.sh.bz2
7,8d6
6d5
< ./usr/share/doc/vimclojure-2.3.6-r3/LICENSE.txt.bz2
6d5
< ./usr/share/doc/vim-commentary-1.3_p20180530/CONTRIBUTING.markdown
6d5
< ./usr/share/doc/vim-flake8-1.6/LICENSE.bz2
6d5
< ./usr/share/doc/vim-go-1.13/addon-info.json.bz2
8d6
< ./usr/share/doc/vim-go-1.13/LICENSE.bz2
6d5
< ./usr/share/doc/vim-go-1.19/addon-info.json.bz2
8,9d6
< ./usr/share/doc/vim-go-1.19/Dockerfile.bz2
< ./usr/share/doc/vim-go-1.19/LICENSE.bz2
6d5
< ./usr/share/doc/vim-go-1.20/addon-info.json.bz2
8,9d6
< ./usr/share/doc/vim-go-1.20/Dockerfile.bz2
< ./usr/share/doc/vim-go-1.20/LICENSE.bz2
6,7d5
< ./usr/share/doc/vim-jsonnet-0_pre20190502/CONTRIBUTING.bz2
< ./usr/share/doc/vim-jsonnet-0_pre20190502/jsonnet-screenshot.png
6,7d5
< ./usr/share/doc/vim-multiple-cursors-2.2-r1/CHANGELOG.md.bz2
< ./usr/share/doc/vim-multiple-cursors-2.2-r1/Gemfile
7,8d6
< ./usr/share/doc/vimoutliner-0.3.6-r1/INSTALL.bz2
< ./usr/share/doc/vimoutliner-0.3.6-r1/LICENSE.bz2
7d6
< ./usr/share/doc/vimoutliner-0.4.0_p20180301-r2/LICENSE.bz2
10d8
< ./usr/share/doc/vimoutliner-0.4.0_p20180301-r2/vimoutlinerrc.bz2
7d6
< ./usr/share/doc/webapi-0.3/webapi.vim.vimup.bz2
8d7
< ./usr/share/doc/zenburn-2.25/zb-vimball.txt
```

</details>
