### PR TITLE
metadata.xml: Update maintainer name

### DIFF
--- a/acct-group/tss/metadata.xml
+++ b/acct-group/tss/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/acct-user/tss/metadata.xml
+++ b/acct-user/tss/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/swtpm/metadata.xml
+++ b/app-crypt/swtpm/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/tpm-tools/metadata.xml
+++ b/app-crypt/tpm-tools/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/tpm2-abrmd/metadata.xml
+++ b/app-crypt/tpm2-abrmd/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/tpm2-pkcs11/metadata.xml
+++ b/app-crypt/tpm2-pkcs11/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/tpm2-tools/metadata.xml
+++ b/app-crypt/tpm2-tools/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/tpm2-totp/metadata.xml
+++ b/app-crypt/tpm2-totp/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/tpm2-tss-engine/metadata.xml
+++ b/app-crypt/tpm2-tss-engine/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/tpm2-tss/metadata.xml
+++ b/app-crypt/tpm2-tss/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-crypt/trousers/metadata.xml
+++ b/app-crypt/trousers/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/dev-libs/libtpms/metadata.xml
+++ b/dev-libs/libtpms/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>salah.coronya@gmail.com</email>
-		<name>Salah Coronya</name>
+		<name>Christopher Byrne</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>


### PR DESCRIPTION
I've used and contributed to Gentoo for a long time (since 2004, at least). However my real name is not the one I've contributed under. While GLEP 76 only requires the signoff use my real name, it's confusing to contribute under one name and sign off under another, and sometimes I've gotten it wrong. So going forward I just want to use my real name everywhere in Gentoo to clear things up and avoid this error in the future. 