### PR TITLE
media-gfx/openscad: drop removal of non-existent gitdirs

### DIFF
--- a/media-gfx/openscad/openscad-9999.ebuild
+++ b/media-gfx/openscad/openscad-9999.ebuild
@@ -113,8 +113,6 @@ src_install() {
 	mv -i "${ED}"/usr/share/openscad/locale "${ED}"/usr/share || die "failed to move locales"
 	ln -sf ../locale "${ED}"/usr/share/openscad/locale || die
 
-	rm -r "${ED}"/usr/share/openscad/libraries/MCAD/.{git,gitignore} || die
-
 	if use emacs; then
 		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
 		elisp-install ${PN} contrib/*.el contrib/*.elc


### PR DESCRIPTION
This is done in the package code since
https://github.com/openscad/openscad/commit/d56909f1c0c74eebe69068f576b91e70e626ad43

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>