### PR TITLE
Eselect EAPI bumps

### DIFF
--- a/app-eselect/eselect-notify-send/eselect-notify-send-0.1.ebuild
+++ b/app-eselect/eselect-notify-send/eselect-notify-send-0.1.ebuild
@@ -1,24 +1,22 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 DESCRIPTION="Manage /usr/bin/notify-send symlink"
 HOMEPAGE="https://www.gentoo.org/proj/en/eselect/"
-SRC_URI=""
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
-IUSE=""
 
-RDEPEND=">=app-eselect/eselect-lib-bin-symlink-0.1.1
+RDEPEND="app-admin/eselect
+	>=app-eselect/eselect-lib-bin-symlink-0.1.1
 	!<x11-libs/libnotify-0.7.5-r1"
-DEPEND=${RDEPEND}
 
-S=${FILESDIR}
+S="${WORKDIR}"
 
 src_install() {
 	insinto /usr/share/eselect/modules
-	newins notify-send.eselect-${PV} notify-send.eselect
+	newins "${FILESDIR}"/notify-send.eselect-${PV} notify-send.eselect
 }

--- a/app-eselect/eselect-xvmc/eselect-xvmc-0.4.ebuild
+++ b/app-eselect/eselect-xvmc/eselect-xvmc-0.4.ebuild
@@ -1,21 +1,18 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 DESCRIPTION="Manages XvMC implementations"
 HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
-SRC_URI=""
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
-IUSE=""
 
-DEPEND=""
 RDEPEND="app-admin/eselect"
 
-S="${FILESDIR}"
+S="${WORKDIR}"
 
 src_install() {
 	insinto /usr/share/eselect/modules


### PR DESCRIPTION
@SoapGentoo Here are a couple trivial eselect module EAPI bumps for [EAPI5Removal](https://bugs.gentoo.org/698100).