### PR TITLE
net-misc/openssh: Add KillMode=process to sshd.service

### DIFF
--- a/net-misc/openssh/files/sshd.service
+++ b/net-misc/openssh/files/sshd.service
@@ -6,6 +6,7 @@ After=syslog.target network.target auditd.service
 ExecStartPre=/usr/bin/ssh-keygen -A
 ExecStart=/usr/sbin/sshd -D -e
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes:  https://bugs.gentoo.org/785874

Signed-off-by: Roy Yang <royyang@google.com>