### PR TITLE
dev-libs/libzip: Add large file support (LFS)

### DIFF
--- a/dev-libs/libzip/libzip-1.7.3-r1.ebuild
+++ b/dev-libs/libzip/libzip-1.7.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake multibuild
+inherit cmake multibuild flag-o-matic
 
 DESCRIPTION="Library for manipulating zip archives"
 HOMEPAGE="https://nih.at/libzip/"
@@ -43,6 +43,7 @@ pkg_setup() {
 }
 
 src_configure() {
+	append-lfs-flags
 	myconfigure() {
 		local mycmakeargs=(
 			-DBUILD_EXAMPLES=OFF # nothing is installed


### PR DESCRIPTION
This is needed to handle big ZIPs (4+GB) on 32-bit devices.

Signed-off-by: François Degros <fdegros@chromium.org>