### PR TITLE
sys-kernel/dracut-crypt-ssh: Fixed libdir for x86

### DIFF
--- a/sys-kernel/dracut-crypt-ssh/dracut-crypt-ssh-1.0.7.ebuild
+++ b/sys-kernel/dracut-crypt-ssh/dracut-crypt-ssh-1.0.7.ebuild
@@ -27,6 +27,15 @@ RDEPEND="${DEPEND}
 
 PATCHES=( "${FILESDIR}"/${P}-makefile.patch )
 
+src_prepare() {
+	default
+
+	# Fix libdir (hard-coded to "lib64")
+	sed "s@/lib64/@/$(get_libdir)/@" \
+		-i modules/60crypt-ssh/module-setup.sh \
+		|| die
+}
+
 src_configure() {
 	tc-export CC
 	default


### PR DESCRIPTION
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>