### PR TITLE
media-gfx/openscad-9999: fix installation, media-gfx/openscad-2021.01: adjust variables

### DIFF
--- a/media-gfx/openscad/openscad-2021.01.ebuild
+++ b/media-gfx/openscad/openscad-2021.01.ebuild
@@ -69,9 +69,9 @@ src_prepare() {
 
 src_configure() {
 	if has ccache ${FEATURES}; then
-		eqmake5 "PREFIX = ${EROOT}/usr" "CONFIG += ccache" "${PN}.pro"
+		eqmake5 "PREFIX = ${ESYSROOT}/usr" "CONFIG += ccache" "${PN}.pro"
 	else
-		eqmake5 "PREFIX = ${EROOT}/usr" "${PN}.pro"
+		eqmake5 "PREFIX = ${ESYSROOT}/usr" "${PN}.pro"
 	fi
 }
 

--- a/media-gfx/openscad/openscad-9999.ebuild
+++ b/media-gfx/openscad/openscad-9999.ebuild
@@ -113,8 +113,6 @@ src_install() {
 	mv -i "${ED}"/usr/share/openscad/locale "${ED}"/usr/share || die "failed to move locales"
 	ln -sf ../locale "${ED}"/usr/share/openscad/locale || die
 
-	rm -r "${ED}"/usr/share/openscad/libraries/MCAD/.{git,gitignore} || die
-
 	if use emacs; then
 		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
 		elisp-install ${PN} contrib/*.el contrib/*.elc


### PR DESCRIPTION
media-gfx/openscad-9999: fix installation
Fix the removal of .git{,ignore} for the MCAD library.
Upstream no longer installs those files, so we don't
need to remove them in src_install anymore.

Reported-by: Jan Psota <jasiupsota@gmail.com>
Closes: https://bugs.gentoo.org/785805

media-gfx/openscad-2021.01: adjust variables
Adjust the USE of EROOT in src_configure, due to newly
reported issues from repoman and pkgcheck.

This popped up during fixing of the 9999 ebuild.

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
