### PR TITLE
media-sound/picard: Only show elog messages on update

### DIFF
--- a/media-sound/picard/picard-2.4.2.ebuild
+++ b/media-sound/picard/picard-2.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -64,7 +64,9 @@ python_install() {
 python_install_all() {
 	distutils-r1_python_install_all
 
-	elog "If you are upgrading Picard and it does not start, try removing"
-	elog "Picard's settings:"
-	elog "        rm ~/.config/MusicBrainz/Picard.conf"
+	if [[ -n "${REPLACING_VERSIONS}" ]]; then
+		elog "If you are upgrading Picard and it does not start, try removing"
+		elog "Picard's settings:"
+		elog "        rm ~/.config/MusicBrainz/Picard.conf"
+	fi
 }

--- a/media-sound/picard/picard-9999.ebuild
+++ b/media-sound/picard/picard-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -64,7 +64,9 @@ python_install() {
 python_install_all() {
 	distutils-r1_python_install_all
 
-	elog "If you are upgrading Picard and it does not start, try removing"
-	elog "Picard's settings:"
-	elog "        rm ~/.config/MusicBrainz/Picard.conf"
+	if [[ -n "${REPLACING_VERSIONS}" ]]; then
+		elog "If you are upgrading Picard and it does not start, try removing"
+		elog "Picard's settings:"
+		elog "        rm ~/.config/MusicBrainz/Picard.conf"
+	fi
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/786729
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Matt Smith <matt@offtopica.uk>