### PR TITLE
x11-misc/lightdm: remove StandardOutput setting in systemd service

### DIFF
--- a/x11-misc/lightdm/files/lightdm.service
+++ b/x11-misc/lightdm/files/lightdm.service
@@ -5,7 +5,6 @@ After=systemd-user-sessions.service
 
 [Service]
 ExecStart=/usr/sbin/lightdm
-StandardOutput=syslog
 Restart=always
 IgnoreSIGPIPE=no
 BusName=org.freedesktop.DisplayManager


### PR DESCRIPTION
StandardOutput and StandardError no longer support the "syslog"
switches. Remove the StandardOutput= line entirely and have systemd fall
back to its default of "journal".

Package-Manager: Portage-3.0.18, Repoman-3.0.2

See also db54891dc68ce65539310fefa703f82d5ce0bb2e and e20c78340c592e113992835563671e9a786c21f5