### PR TITLE
dev-java/validation-api: min java 1.8

### DIFF
--- a/dev-java/validation-api/validation-api-1.0.0-r1.ebuild
+++ b/dev-java/validation-api/validation-api-1.0.0-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source"
+
+inherit java-pkg-2 java-pkg-simple
+
+DESCRIPTION="Bean Validation (JSR-303) API"
+HOMEPAGE="http://fisheye.jboss.org/browse/Hibernate/beanvalidation/api/tags/v1_0_0_GA"
+SRC_URI="https://repository.jboss.org/nexus/service/local/repo_groups/public/content/javax/validation/${PN}/${PV}.GA/${P}.GA-sources.jar"
+
+LICENSE="Apache-2.0"
+SLOT="1.0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=">=virtual/jdk-1.8:*"
+RDEPEND=">=virtual/jre-1.8:*"
+BDEPEND="app-arch/unzip"


### PR DESCRIPTION
@fordfrog 
keep in mind:
https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-java/validation-api/validation-api-1.0.0.ebuild?id=2a2b08d88b1d9546323e170bcd28df383de5351f