### PR TITLE
mail-client/geary-40.0: Use release build profile

### DIFF
--- a/mail-client/geary/geary-40.0.ebuild
+++ b/mail-client/geary/geary-40.0.ebuild
@@ -73,7 +73,7 @@ src_prepare() {
 
 src_configure() {
 	local emesonargs=(
-		-Dprofile=development
+		-Dprofile=release
 		-Drevno="${PR}"
 		-Dvaladoc=disabled
 		-Dcontractor=disabled


### PR DESCRIPTION
Upstream documentation suggests that distributions must use the release build profile when providing a package for Geary:
https://gitlab.gnome.org/GNOME/geary/-/blob/gnome-40.0/BUILDING.md#build-profiles