### PR TITLE
sci-libs/fplll: Add upstreamed patch for gcc11

### DIFF
--- a/sci-libs/fplll/files/fplll-5.4.0-gcc11.patch
+++ b/sci-libs/fplll/files/fplll-5.4.0-gcc11.patch
@@ -1,0 +1,21 @@
+From 1d7dded000e425bb103841e68c79f81b335b7271 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fran=C3=A7ois=20Bissey?= <frp.bissey@gmail.com>
+Date: Sat, 1 May 2021 08:19:41 +1200
+Subject: [PATCH] minimal change to compile with gcc-11
+
+---
+ fplll/enum/enumerate_ext_api.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/fplll/enum/enumerate_ext_api.h b/fplll/enum/enumerate_ext_api.h
+index 387a1461..803c870e 100644
+--- a/fplll/enum/enumerate_ext_api.h
++++ b/fplll/enum/enumerate_ext_api.h
+@@ -18,6 +18,7 @@
+ #define FPLLL_ENUMERATE_EXT_API_H
+ 
+ #include <array>
++#include <cstdint>
+ #include <functional>
+ #include <memory>
+ 

--- a/sci-libs/fplll/fplll-5.4.0.ebuild
+++ b/sci-libs/fplll/fplll-5.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,6 +17,8 @@ DEPEND="dev-libs/gmp:0
 	dev-libs/mpfr:0
 	qd? ( sci-libs/qd )"
 RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${PN}-5.4.0-gcc11.patch" )
 
 src_configure() {
 	econf \


### PR DESCRIPTION
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Bug: https://bugs.gentoo.org/786858
Signed-off-by: François René Pierre Bissey <frp.bissey@gmail.com>