### PR TITLE
media-video/pitivi: enable python3_9

### DIFF
--- a/media-video/pitivi/pitivi-0.999-r4.ebuild
+++ b/media-video/pitivi/pitivi-0.999-r4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_8 )
+PYTHON_COMPAT=( python3_{8,9} )
 PYTHON_REQ_USE="sqlite"
 
 inherit gnome.org meson python-single-r1 virtualx xdg


### PR DESCRIPTION
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Daniel Brandt <poncho@spahan.ch>


as requested by @mgorny in https://github.com/gentoo/gentoo/pull/20436#issuecomment-828555757

did a quick runtime test with python 3.9 and didn't encounter any issues