### PR TITLE
x11-libs/wxGTK: fix USE="-X" removing of '/usr/bin/wxrc'

### DIFF
--- a/x11-libs/wxGTK/wxGTK-3.0.4-r303.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.0.4-r303.ebuild
@@ -144,7 +144,8 @@ multilib_src_install_all() {
 	rm -f "${ED}"/usr/share/locale/it/LC_MESSAGES/wxmsw30-gtk3.mo || die
 
 	# Unversioned links
-	rm "${ED}"/usr/bin/wx{-config,rc} || die
+	rm "${ED}"/usr/bin/wx-config || die
+	use X && { rm "${ED}"/usr/bin/wxrc || die; }
 
 	# version bakefile presets
 	pushd "${ED}"/usr/share/bakefile/presets >/dev/null || die

--- a/x11-libs/wxGTK/wxGTK-3.0.5.1.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.0.5.1.ebuild
@@ -144,7 +144,8 @@ multilib_src_install_all() {
 	rm -f "${ED}"/usr/share/locale/it/LC_MESSAGES/wxmsw30-gtk3.mo || die
 
 	# Unversioned links
-	rm "${ED}"/usr/bin/wx{-config,rc} || die
+	rm "${ED}"/usr/bin/wx-config || die
+	use X && { rm "${ED}"/usr/bin/wxrc || die; }
 
 	# version bakefile presets
 	pushd "${ED}"/usr/share/bakefile/presets >/dev/null || die


### PR DESCRIPTION
Make removing of `/usr/bin/wxrc` on installation phase conditional for `USE="X"`/`USE="-X"`

Closes: https://bugs.gentoo.org/787305