### PR TITLE
app-text/uudeview: Fix build-time bugs

### DIFF
--- a/app-text/uudeview/files/uudeview-0.5.20-fix-append_signature.patch
+++ b/app-text/uudeview/files/uudeview-0.5.20-fix-append_signature.patch
@@ -1,0 +1,36 @@
+From 3bd5dee4226142df3645b8a027ef9142277257cf Mon Sep 17 00:00:00 2001
+From: tastytea <tastytea@tastytea.de>
+Date: Sat, 1 May 2021 17:51:47 +0200
+Subject: [PATCH] Make append_signature() void.
+
+If the type specifier is missing, it defaults to int. From the looks of
+it, the function is meant to be void.
+---
+ inews/inews.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/inews/inews.c b/inews/inews.c
+index 5fa309d..d1c1ee8 100644
+--- a/inews/inews.c
++++ b/inews/inews.c
+@@ -143,7 +143,7 @@ char	*argv[];
+ 		fprintf(ser_wr_fp, "%s\r\n", s);
+ 	}
+ 
+-	append_signature();
++	void append_signature();
+ 
+ 	fprintf(ser_wr_fp, ".\r\n");
+ 	(void) fflush(ser_wr_fp);
+@@ -181,7 +181,7 @@ char	*argv[];
+  * The rn-style DOTDIR environmental variable is used if present.
+  */
+ 
+-append_signature()
++void append_signature()
+ {
+ 	char	line[256], sigfile[256];
+ 	char	*cp;
+-- 
+2.26.3
+

--- a/app-text/uudeview/uudeview-0.5.20-r2.ebuild
+++ b/app-text/uudeview/uudeview-0.5.20-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit autotools
+inherit autotools toolchain-funcs
 
 DESCRIPTION="uu, xx, base64, binhex decoder"
 HOMEPAGE="http://www.fpx.de/fp/Software/UUDeview/"
@@ -25,6 +25,8 @@ PATCHES=(
 DOCS=( HISTORY INSTALL README )
 
 src_prepare() {
+	sed -i "s/^\tar r/\t$(tc-getAR) r/" uulib/Makefile.in || die
+
 	default
 	mv configure.{in,ac} || die
 	eautoreconf

--- a/app-text/uudeview/uudeview-0.5.20-r2.ebuild
+++ b/app-text/uudeview/uudeview-0.5.20-r2.ebuild
@@ -20,6 +20,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-man.patch
 	"${FILESDIR}"/${P}-rename.patch
 	"${FILESDIR}"/${P}-makefile.patch
+	"${FILESDIR}"/${P}-fix-append_signature.patch
 )
 
 DOCS=( HISTORY INSTALL README )


### PR DESCRIPTION
- Replace hardcoded ar with `tc-getAR` ([bug 722602](https://bugs.gentoo.org/722602))
- Make append_signature() void ([bug 735682](https://bugs.gentoo.org/735682))

Regarding `append_signature()`: It seems that the function is never called. It is forward-declared and then implemented in `inews/inews.c`.