### PR TITLE
EAPI bumps for virtual packages

### DIFF
--- a/virtual/acl/acl-0-r2.ebuild
+++ b/virtual/acl/acl-0-r2.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit multilib-build
 
 DESCRIPTION="Virtual for acl support (sys/acl.h)"
+
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 IUSE="static-libs"

--- a/virtual/editor/editor-0-r3.ebuild
+++ b/virtual/editor/editor-0-r3.ebuild
@@ -1,9 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 DESCRIPTION="Virtual for editor"
+
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 

--- a/virtual/glu/glu-9.0-r2.ebuild
+++ b/virtual/glu/glu-9.0-r2.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit multilib-build
 
 DESCRIPTION="Virtual for OpenGL utility library"
+
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 

--- a/virtual/libelf/libelf-3.ebuild
+++ b/virtual/libelf/libelf-3.ebuild
@@ -1,13 +1,13 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit multilib-build
 
 DESCRIPTION="Virtual for libelf.so.1 provider dev-libs/elfutils"
+
 SLOT="0/1"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 
-RDEPEND="
-	>=dev-libs/elfutils-0.155-r1:0/0[${MULTILIB_USEDEP}]"
+RDEPEND=">=dev-libs/elfutils-0.155-r1:0/0[${MULTILIB_USEDEP}]"

--- a/virtual/libiconv/libiconv-0-r2.ebuild
+++ b/virtual/libiconv/libiconv-0-r2.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit multilib-build
 
 DESCRIPTION="Virtual for the GNU conversion library"
+
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
 IUSE="elibc_glibc elibc_uclibc elibc_musl elibc_mintlib"

--- a/virtual/libintl/libintl-0-r2.ebuild
+++ b/virtual/libintl/libintl-0-r2.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
 inherit multilib-build
 
 DESCRIPTION="Virtual for the GNU Internationalization Library"
+
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
 IUSE="elibc_glibc elibc_musl elibc_uclibc"

--- a/virtual/opengl/opengl-7.0-r2.ebuild
+++ b/virtual/opengl/opengl-7.0-r2.ebuild
@@ -1,11 +1,12 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit multilib-build
 
 DESCRIPTION="Virtual for OpenGL implementation"
+
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 

--- a/virtual/ttf-fonts/ttf-fonts-1-r1.ebuild
+++ b/virtual/ttf-fonts/ttf-fonts-1-r1.ebuild
@@ -1,9 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 DESCRIPTION="Virtual for Serif/Sans/Monospace font packages"
+
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
 


### PR DESCRIPTION
@SoapGentoo Here are a few trivial EAPI bumps for the latest revisions of some virtual packages.  The first three are for [EAPI5Removal](https://bugs.gentoo.org/698100).  While [EAPI6Removal](https://bugs.gentoo.org/770247) probably isn't a concern yet, there were only a handful of other non-EAPI7 virtuals installed on my system, so I included those as well.  (I skipped `virtual/eject` due to #19828.)