### PR TITLE
games-action/{assoult-android-cactus+, bzflag}, media-libs/{libsdl2, openglide}: remove unsed eclasses, improvments

### DIFF
--- a/games-action/assault-android-cactus+/assault-android-cactus+-200507.ebuild
+++ b/games-action/assault-android-cactus+/assault-android-cactus+-200507.ebuild
@@ -9,6 +9,7 @@ MY_PN="cactus"
 DESCRIPTION="Arcade style twin stick shooter set in a vivid sci-fi universe"
 HOMEPAGE="https://www.assaultandroidcactus.com/"
 SRC_URI="AssaultAndroidCactus_linux_${PV}.zip"
+
 LICENSE="all-rights-reserved"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~x86"

--- a/games-action/bzflag/bzflag-2.4.20.ebuild
+++ b/games-action/bzflag/bzflag-2.4.20.ebuild
@@ -36,6 +36,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.4.12-sdl2-cppflags.patch
 )
 
+DOCS=( AUTHORS ChangeLog DEVINFO PORTING README README.Linux )
+
 src_prepare() {
 	default
 	eautoreconf
@@ -60,8 +62,7 @@ src_configure() {
 }
 
 src_install() {
-	DOCS="AUTHORS ChangeLog DEVINFO PORTING README README.Linux" \
-		default
+	default
 
 	if ! use dedicated ; then
 		newicon data/bzflag-48x48.png ${PN}.png

--- a/games-action/bzflag/bzflag-2.4.22.ebuild
+++ b/games-action/bzflag/bzflag-2.4.22.ebuild
@@ -36,6 +36,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.4.12-sdl2-cppflags.patch
 )
 
+DOCS=( AUTHORS ChangeLog DEVINFO PORTING README README.Linux )
+
 src_prepare() {
 	default
 	eautoreconf
@@ -60,8 +62,7 @@ src_configure() {
 }
 
 src_install() {
-	DOCS="AUTHORS ChangeLog DEVINFO PORTING README README.Linux" \
-		default
+	default
 
 	if ! use dedicated ; then
 		newicon data/bzflag-48x48.png ${PN}.png

--- a/media-libs/libsdl2/libsdl2-2.0.12-r2.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.0.12-r2.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit autotools flag-o-matic toolchain-funcs multilib-minimal
+
+inherit autotools flag-o-matic multilib-minimal
 
 MY_P="SDL2-${PV}"
 DESCRIPTION="Simple Direct Media Layer"

--- a/media-libs/libsdl2/libsdl2-2.0.14-r1.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.0.14-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools flag-o-matic toolchain-funcs multilib-minimal
+inherit autotools flag-o-matic multilib-minimal
 
 MY_P="SDL2-${PV}"
 DESCRIPTION="Simple Direct Media Layer"

--- a/media-libs/openglide/openglide-0.09_rc9_p20191120.ebuild
+++ b/media-libs/openglide/openglide-0.09_rc9_p20191120.ebuild
@@ -5,11 +5,12 @@ EAPI=7
 
 COMMIT="c300160d0a8292bc04e79dd59e6cc178aa648dec"
 
-inherit autotools eutils multilib-minimal
+inherit autotools multilib-minimal
 
-DESCRIPTION="A Glide to OpenGL wrapper"
+DESCRIPTION="Glide to OpenGL wrapper"
 HOMEPAGE="http://openglide.sourceforge.net/"
 SRC_URI="https://github.com/voyageur/${PN}/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"
+
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"


### PR DESCRIPTION
Hi,

Just some minor improvements mentioned by @thesamesam from my last PR (https://github.com/gentoo/gentoo/pull/20529) + updates for the `media-libs` packages.

@SoapGentoo guest you're interested here too :)