### PR TITLE
vim-plugin.eclass: Replace has_version check with REPLACING_VERSIONS

### DIFF
--- a/eclass/vim-plugin.eclass
+++ b/eclass/vim-plugin.eclass
@@ -126,7 +126,7 @@ update_vim_afterscripts() {
 display_vim_plugin_help() {
 	local h
 
-	if ! has_version ${CATEGORY}/${PN} ; then
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
 		if [[ -n "${VIM_PLUGIN_HELPFILES}" ]] ; then
 			elog " "
 			elog "This plugin provides documentation via vim's help system. To"


### PR DESCRIPTION
The intention is to show a message on first install, which ! has_version wasn't doing anymore.

Signed-off-by: Marco Sirabella <marco@sirabella.org>