### PR TITLE
media-gfx/flameshot: don't force using ccache

### DIFF
--- a/media-gfx/flameshot/files/flameshot-0.9.0-dont-force-ccache.patch
+++ b/media-gfx/flameshot/files/flameshot-0.9.0-dont-force-ccache.patch
@@ -1,0 +1,13 @@
+diff -ruN a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2021-05-03 12:55:07.561259897 +0300
++++ b/CMakeLists.txt	2021-05-03 12:55:36.772461830 +0300
+@@ -70,9 +70,6 @@
+ 
+ add_library(project_warnings INTERFACE)
+ 
+-# enable cache system
+-include(cmake/Cache.cmake)
+-
+ # standard compiler warnings
+ include(cmake/CompilerWarnings.cmake)
+ # set_project_warnings(project_warnings)

--- a/media-gfx/flameshot/flameshot-0.9.0.ebuild
+++ b/media-gfx/flameshot/flameshot-0.9.0.ebuild
@@ -31,6 +31,7 @@ BDEPEND="
 RDEPEND="${DEPEND}"
 PATCHES=(
 	"${FILESDIR}/${P}-unbundle-qtsingleapplication.patch"
+	"${FILESDIR}/${P}-dont-force-ccache.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
- don't include cmake/Cache.cmake

Reported-by: josef.95 <josef64@posteo.org>
Closes: https://bugs.gentoo.org/787095
Signed-off-by: Pavel Kalugin <pavel@pavelthebest.me>