### PR TITLE
dev-java/resin-servlet-api: slot 2.4 min java 1.8

### DIFF
--- a/dev-java/resin-servlet-api/resin-servlet-api-3.0.25-r1.ebuild
+++ b/dev-java/resin-servlet-api/resin-servlet-api-3.0.25-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="source"
+
+inherit java-pkg-2 java-ant-2
+
+DESCRIPTION="Resin Servlet API 2.4/JSP API 2.0 implementation"
+HOMEPAGE="http://www.caucho.com/"
+SRC_URI="http://www.caucho.com/download/resin-${PV}-src.zip
+	mirror://gentoo/resin-gentoo-patches-${PV}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="2.4"
+KEYWORDS="~amd64 ~ppc64 ~x86"
+
+DEPEND=">=virtual/jdk-1.8:*"
+RDEPEND=">=virtual/jre-1.8:*"
+BDEPEND="app-arch/unzip"
+
+S="${WORKDIR}/resin-${PV}"
+
+EANT_BUILD_TARGET="jsdk"
+EANT_DOC_TARGET=""
+
+PATCHES=(
+	"${WORKDIR}/${PV}/resin-${PV}-build.xml.patch"
+)
+
+src_prepare() {
+	default
+	mkdir lib || die
+}
+
+src_install() {
+	java-pkg_newjar "lib/jsdk-24.jar"
+	use source && java-pkg_dosrc "${S}"/modules/jsdk/src/*
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/786777
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>