### PR TITLE
app-shells/zsh-completions: fix LICENSE

### DIFF
--- a/app-shells/zsh-completions/zsh-completions-0.31.0.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-0.31.0.ebuild
@@ -14,7 +14,7 @@ fi
 DESCRIPTION="Additional completion definitions for Zsh"
 HOMEPAGE="https://github.com/zsh-users/zsh-completions"
 
-LICENSE="BSD"
+LICENSE="Apache-2.0 BSD MIT ZSH"
 SLOT="0"
 
 RDEPEND="app-shells/zsh"

--- a/app-shells/zsh-completions/zsh-completions-0.32.0.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-0.32.0.ebuild
@@ -14,7 +14,7 @@ fi
 DESCRIPTION="Additional completion definitions for Zsh"
 HOMEPAGE="https://github.com/zsh-users/zsh-completions"
 
-LICENSE="BSD"
+LICENSE="Apache-2.0 BSD MIT ZSH"
 SLOT="0"
 
 RDEPEND="app-shells/zsh"

--- a/app-shells/zsh-completions/zsh-completions-0.33.0.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-0.33.0.ebuild
@@ -14,7 +14,7 @@ fi
 DESCRIPTION="Additional completion definitions for Zsh"
 HOMEPAGE="https://github.com/zsh-users/zsh-completions"
 
-LICENSE="BSD"
+LICENSE="Apache-2.0 BSD MIT ZSH"
 SLOT="0"
 
 RDEPEND="app-shells/zsh"

--- a/app-shells/zsh-completions/zsh-completions-9999.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-9999.ebuild
@@ -14,7 +14,7 @@ fi
 DESCRIPTION="Additional completion definitions for Zsh"
 HOMEPAGE="https://github.com/zsh-users/zsh-completions"
 
-LICENSE="BSD"
+LICENSE="Apache-2.0 BSD MIT ZSH"
 SLOT="0"
 
 RDEPEND="app-shells/zsh"


### PR DESCRIPTION
- LICENSE should be ZSH (main license), Apache-2.0 (license in _hledger,
  _cf, _sfdx), BSD (license in _port), MIT (license in _nanoc, _middleman,
  _udisksctl, _flutter). Fixed in all 3 ebuilds.

Bug: https://bugs.gentoo.org/787149
Signed-off-by: Pavel Kalugin <pavel@pavelthebest.me>