### PR TITLE
net-dns/avahi: use python-single-r1 instead of python-r1

### DIFF
--- a/net-print/hplip/hplip-3.20.11-r2.ebuild
+++ b/net-print/hplip/hplip-3.20.11-r2.ebuild
@@ -37,7 +37,7 @@ COMMON_DEPEND="
 		snmp? (
 			dev-libs/openssl:0=
 			net-analyzer/net-snmp:=
-			$(python_gen_cond_dep 'net-dns/avahi[dbus,${PYTHON_MULTI_USEDEP}]')
+			net-dns/avahi[dbus,python,${PYTHON_SINGLE_USEDEP}]
 		)
 	)
 "

--- a/net-print/hplip/hplip-3.21.2-r1.ebuild
+++ b/net-print/hplip/hplip-3.21.2-r1.ebuild
@@ -37,7 +37,7 @@ COMMON_DEPEND="
 		snmp? (
 			dev-libs/openssl:0=
 			net-analyzer/net-snmp:=
-			$(python_gen_cond_dep 'net-dns/avahi[dbus,${PYTHON_MULTI_USEDEP}]')
+			net-dns/avahi[dbus,python,${PYTHON_SINGLE_USEDEP}]
 		)
 	)
 "

--- a/profiles/arch/arm64/package.use.stable.mask
+++ b/profiles/arch/arm64/package.use.stable.mask
@@ -125,10 +125,6 @@ sys-auth/pambase pam_krb5 pam_ssh
 sys-block/thin-provisioning-tools test
 sys-devel/distcc gssapi
 
-# Michał Górny <mgorny@gentoo.org> (2018-03-03)
-# Requires masked dependent flags.
-net-dns/avahi python
-
 # Michał Górny <mgorny@gentoo.org> (2018-02-28)
 # Requires masked dependent flags.
 net-fs/samba ads


### PR DESCRIPTION
* Only builds one Python implementation => python-single-r1

* Fix REQUIRED_USE logic. We need to have it all together
  for python_gen_cond_dep, so we move the bookmarks? (...)
  dep within the python? ( ... ) one.

Closes: https://bugs.gentoo.org/710244
Closes: https://bugs.gentoo.org/788043