### PR TITLE
media-gfx/freecad: find opencascade-7.5

### DIFF
--- a/media-gfx/freecad/freecad-0.19.2.ebuild
+++ b/media-gfx/freecad/freecad-0.19.2.ebuild
@@ -222,10 +222,21 @@ src_configure() {
 		# sub-packages will still be installed inside /usr/lib64/freecad
 		-DINSTALL_TO_SITEPACKAGES=ON
 
-		-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade
-		-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)
 		-DOCCT_CMAKE_FALLBACK=ON				# don't use occt-config which isn't included in opencascade for Gentoo
 	)
+
+	if has_version ">=sci-libs/opencascade-7.5"; then
+		mycmakeargs+=(
+			-DOCC_INCLUDE_DIR="${CASROOT}"/include/opencascade-7.5.1
+			-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)/opencascade-7.5.1
+		)
+	else
+		# <occ-7.5 uses different layout
+		mycmakeargs+=(
+			-DOCC_INCLUDEDIR="${CASROOT}"/include/opencascade
+			-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)
+		)
+	fi
 
 	if use debug; then
 		mycmakeargs+=(


### PR DESCRIPTION
Correctly find sci-libs/opencascade-7.5.1 header and
library locations.

Closes: https://bugs.gentoo.org/788274
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>