### PR TITLE
media-libs/mesa: Switch to main branch on live ebuild

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -16,6 +16,7 @@ HOMEPAGE="https://www.mesa3d.org/ https://mesa.freedesktop.org/"
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/mesa/mesa.git"
+	EGIT_BRANCH="main"
 	inherit git-r3
 else
 	SRC_URI="https://archive.mesa3d.org/${MY_P}.tar.xz"


### PR DESCRIPTION
Mesa has now switched to using the "main" branch

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>