### PR TITLE
dev-lang/spidermonkey: Add llvm 12 support

### DIFF
--- a/dev-lang/spidermonkey/spidermonkey-78.10.0.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-78.10.0.ebuild
@@ -7,7 +7,7 @@ EAPI="7"
 FIREFOX_PATCHSET="firefox-78esr-patches-12.tar.xz"
 SPIDERMONKEY_PATCHSET="spidermonkey-78-patches-03.tar.xz"
 
-LLVM_MAX_SLOT=11
+LLVM_MAX_SLOT=12
 
 PYTHON_COMPAT=( python3_{7..9} )
 
@@ -72,6 +72,13 @@ BDEPEND="${PYTHON_DEPS}
 	>=virtual/rust-1.41.0
 	virtual/pkgconfig
 	|| (
+		(
+			sys-devel/llvm:12
+			clang? (
+				sys-devel/clang:12
+				lto? ( =sys-devel/lld-12* )
+			)
+		)
 		(
 			sys-devel/llvm:11
 			clang? (


### PR DESCRIPTION
Now that rust builds with llvm 12, spidermonkey builds fine with llvm,
clang and lld 12 too

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>