### PR TITLE
app-portage/gander: enable python3.9 (tested)

### DIFF
--- a/app-portage/gander/gander-0.0.1-r1.ebuild
+++ b/app-portage/gander/gander-0.0.1-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=rdepend
+PYTHON_COMPAT=( python3_{8..9} )
+inherit distutils-r1
+
+DESCRIPTION="Statistic submission client for Goose (anser.gentoo.org)"
+HOMEPAGE="https://github.com/mgorny/gander/"
+SRC_URI="https://github.com/mgorny/gander/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	dev-python/requests[${PYTHON_USEDEP}]
+	sys-apps/portage[${PYTHON_USEDEP}]
+"
+
+BDEPEND="test? ( dev-python/responses[${PYTHON_USEDEP}] )"
+
+distutils_enable_tests pytest
+
+python_test() {
+	# Portage exports random configuration options *overriding* its own
+	# behavior into the build environment.
+	env -u PORTAGE_REPOSITORIES pytest -vv || die "Tests fail with ${EPYTHON}"
+}


### PR DESCRIPTION
@mgorny this is actually a draft, if you want I can upgrade required packages in order to make test working on 3.10 too (I've tested and build against it too but cookies has some warnings here and here against python3.9/10, like:

  /var/tmp/portage/dev-python/cookies-2.2.1-r2/work/cookies-2.2.1/cookies.py:126: DeprecationWarning: invalid escape sequence \-
    EXTENSION_AV = """ !"#$%&\\\\'()*+,\-./0-9:<=>?@A-Z[\\]^_`a-z{|}~"""

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Marco Scardovi <marco@scardovi.com>