### PR TITLE
app-vim/*: Remove redundant install cleanup code

### DIFF
--- a/app-vim/airline/airline-0.11.ebuild
+++ b/app-vim/airline/airline-0.11.ebuild
@@ -21,11 +21,11 @@ HOMEPAGE="https://github.com/vim-airline/vim-airline/ https://www.vim.org/script
 LICENSE="MIT"
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
-DOCS=( CHANGELOG.md )
+DOCS=( CHANGELOG.md README.md )
 
 src_prepare() {
 	default
 
-	# remove unwanted files
-	rm -r t Gemfile Rakefile LICENSE README* .travis.yml .gitignore || die
+	# remove test dir
+	rm -r t || die
 }

--- a/app-vim/airline/airline-9999.ebuild
+++ b/app-vim/airline/airline-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/airline/airline-9999.ebuild
+++ b/app-vim/airline/airline-9999.ebuild
@@ -24,6 +24,6 @@ VIM_PLUGIN_HELPFILES="${PN}.txt"
 src_prepare() {
 	default
 
-	# remove unwanted files
-	rm -r t Gemfile Rakefile LICENSE README* .travis.yml .gitignore || die
+	# remove unwanted test dir
+	rm -r t || die
 }

--- a/app-vim/bufexplorer/bufexplorer-7.4.18.ebuild
+++ b/app-vim/bufexplorer/bufexplorer-7.4.18.ebuild
@@ -12,8 +12,3 @@ LICENSE="BSD"
 KEYWORDS="amd64 x86"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
-
-src_prepare() {
-	default
-	rm LICENSE README.md || die
-}

--- a/app-vim/bufexplorer/bufexplorer-7.4.18.ebuild
+++ b/app-vim/bufexplorer/bufexplorer-7.4.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/bufexplorer/bufexplorer-7.4.19.ebuild
+++ b/app-vim/bufexplorer/bufexplorer-7.4.19.ebuild
@@ -12,8 +12,3 @@ LICENSE="BSD"
 KEYWORDS="~amd64 ~x86"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
-
-src_prepare() {
-	default
-	rm LICENSE README.md || die
-}

--- a/app-vim/bufexplorer/bufexplorer-7.4.19.ebuild
+++ b/app-vim/bufexplorer/bufexplorer-7.4.19.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/bufexplorer/bufexplorer-9999.ebuild
+++ b/app-vim/bufexplorer/bufexplorer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/bufexplorer/bufexplorer-9999.ebuild
+++ b/app-vim/bufexplorer/bufexplorer-9999.ebuild
@@ -18,8 +18,3 @@ HOMEPAGE="https://www.vim.org/scripts/script.php?script_id=42 https://github.com
 LICENSE="BSD"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
-
-src_prepare() {
-	default
-	rm LICENSE README.md || die
-}

--- a/app-vim/command-t/command-t-5.0.3.ebuild
+++ b/app-vim/command-t/command-t-5.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/command-t/command-t-5.0.3.ebuild
+++ b/app-vim/command-t/command-t-5.0.3.ebuild
@@ -38,7 +38,6 @@ each_ruby_install() {
 }
 
 all_ruby_install() {
-	rm Gemfile* Rakefile LICENSE README.md || die
 	rm -r appstream bin fixtures data ruby/${PN}/{ext,lib,*.gemspec} spec vendor || die
 
 	vim-plugin_src_install

--- a/app-vim/csound-syntax/csound-syntax-0.8.1.ebuild
+++ b/app-vim/csound-syntax/csound-syntax-0.8.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/csound-syntax/csound-syntax-0.8.1.ebuild
+++ b/app-vim/csound-syntax/csound-syntax-0.8.1.ebuild
@@ -17,8 +17,3 @@ KEYWORDS="~amd64 ~x86"
 VIM_PLUGIN_HELPFILES="${PN}"
 
 PATCHES=( "${FILESDIR}/${PN}-doc.patch" )
-
-src_prepare() {
-	rm -v LICENSE README.md || die
-	default
-}

--- a/app-vim/csound-syntax/csound-syntax-20160804.ebuild
+++ b/app-vim/csound-syntax/csound-syntax-20160804.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/csound-syntax/csound-syntax-20160804.ebuild
+++ b/app-vim/csound-syntax/csound-syntax-20160804.ebuild
@@ -13,8 +13,3 @@ KEYWORDS="amd64 x86"
 VIM_PLUGIN_HELPFILES="${PN}"
 
 PATCHES=( "${FILESDIR}/${PN}-doc.patch" )
-
-src_prepare() {
-	rm -v LICENSE README.md || die
-	default
-}

--- a/app-vim/csscomplete/csscomplete-1.0.ebuild
+++ b/app-vim/csscomplete/csscomplete-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/csscomplete/csscomplete-1.0.ebuild
+++ b/app-vim/csscomplete/csscomplete-1.0.ebuild
@@ -17,11 +17,6 @@ DEPEND="app-arch/unzip"
 
 S="${WORKDIR}/${PN}.vim-${PV}"
 
-src_prepare() {
-	default
-	rm -v config.mk || die
-}
-
 src_compile() {
 	:;
 }

--- a/app-vim/diffchar/diffchar-8.2.ebuild
+++ b/app-vim/diffchar/diffchar-8.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/diffchar/diffchar-8.2.ebuild
+++ b/app-vim/diffchar/diffchar-8.2.ebuild
@@ -14,8 +14,3 @@ LICENSE="vim.org"
 KEYWORDS="amd64 x86"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
-
-src_prepare() {
-	default
-	rm *.gif *.png *.md || die
-}

--- a/app-vim/diffchar/diffchar-8.6.ebuild
+++ b/app-vim/diffchar/diffchar-8.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/diffchar/diffchar-8.6.ebuild
+++ b/app-vim/diffchar/diffchar-8.6.ebuild
@@ -14,8 +14,3 @@ LICENSE="vim.org"
 KEYWORDS="~amd64 ~x86"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
-
-src_prepare() {
-	default
-	rm *.gif *.png *.md || die
-}

--- a/app-vim/editorconfig-vim/editorconfig-vim-1.1.1.ebuild
+++ b/app-vim/editorconfig-vim/editorconfig-vim-1.1.1.ebuild
@@ -18,15 +18,6 @@ KEYWORDS="amd64 x86"
 
 VIM_PLUGIN_HELPFILES="${PN%-vim}.txt"
 
-src_prepare() {
-	default
-
-	rm LICENSE LICENSE.PSF \
-		mkzip.sh .editorconfig \
-		.git{ignore,modules} \
-		.{travis,appveyor}.yml || die
-}
-
 src_install() {
 	# we don't want to install the tests
 	rm -r tests || die

--- a/app-vim/exheres-syntax/exheres-syntax-99999999.ebuild
+++ b/app-vim/exheres-syntax/exheres-syntax-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/exheres-syntax/exheres-syntax-99999999.ebuild
+++ b/app-vim/exheres-syntax/exheres-syntax-99999999.ebuild
@@ -16,7 +16,4 @@ IUSE=""
 VIM_PLUGIN_HELPFILES="exheres-syntax"
 VIM_PLUGIN_MESSAGES="filetype"
 
-src_prepare() {
-	default
-	rm .gitignore Makefile || die
-}
+src_compile() { :; }

--- a/app-vim/gist/gist-7.3.ebuild
+++ b/app-vim/gist/gist-7.3.ebuild
@@ -24,7 +24,4 @@ VIM_PLUGIN_HELPFILES="Gist.vim"
 
 S=${WORKDIR}/${MY_P}
 
-src_prepare() {
-	default
-	rm README.md gist.vim* Makefile || die
-}
+src_compile() { :; }

--- a/app-vim/gist/gist-7.3.ebuild
+++ b/app-vim/gist/gist-7.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/gitgutter/gitgutter-20180316.ebuild
+++ b/app-vim/gitgutter/gitgutter-20180316.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/gitgutter/gitgutter-20180316.ebuild
+++ b/app-vim/gitgutter/gitgutter-20180316.ebuild
@@ -24,7 +24,6 @@ RDEPEND="dev-vcs/git"
 src_prepare() {
 	default
 
-	# remove unwanted files
-	rm LICENCE README* screenshot.png unplace.vim || die
+	# remove unwanted test dir
 	rm -r test || die
 }

--- a/app-vim/gitgutter/gitgutter-20180815.ebuild
+++ b/app-vim/gitgutter/gitgutter-20180815.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/gitgutter/gitgutter-20180815.ebuild
+++ b/app-vim/gitgutter/gitgutter-20180815.ebuild
@@ -24,7 +24,6 @@ RDEPEND="dev-vcs/git"
 src_prepare() {
 	default
 
-	# remove unwanted files
-	rm LICENCE README* screenshot.png unplace.vim || die
+	# remove unwanted test dir
 	rm -r test || die
 }

--- a/app-vim/gitgutter/gitgutter-99999999.ebuild
+++ b/app-vim/gitgutter/gitgutter-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/gitgutter/gitgutter-99999999.ebuild
+++ b/app-vim/gitgutter/gitgutter-99999999.ebuild
@@ -24,6 +24,6 @@ RDEPEND="dev-vcs/git"
 src_prepare() {
 	default
 
-	# remove unwanted files
-	rm -rv LICENCE README* screenshot.png test || die
+	# remove unwanted test dir
+	rm -rv test || die
 }

--- a/app-vim/gitv/gitv-1.3.1.ebuild
+++ b/app-vim/gitv/gitv-1.3.1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	app-vim/fugitive"
 
 src_prepare() {
-	rm -f doc/tags addon-info.json roadmap.md || die
+	rm -f doc/tags || die
 	rm -r img || die
 	default
 }

--- a/app-vim/gitv/gitv-1.3.1.ebuild
+++ b/app-vim/gitv/gitv-1.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/gundo/gundo-2.6.2-r3.ebuild
+++ b/app-vim/gundo/gundo-2.6.2-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/gundo/gundo-2.6.2-r3.ebuild
+++ b/app-vim/gundo/gundo-2.6.2-r3.ebuild
@@ -27,6 +27,6 @@ VIM_PLUGIN_HELPFILES="${PN}.txt"
 PATCHES=( "${FILESDIR}"/${P}-python3.patch )
 
 src_prepare() {
-	rm -r .gitignore .hg* package.sh README* site tests || die
+	rm -r site tests || die
 	default
 }

--- a/app-vim/json/json-20150511.ebuild
+++ b/app-vim/json/json-20150511.ebuild
@@ -11,8 +11,3 @@ LICENSE="MIT"
 KEYWORDS="amd64 x86"
 
 DOCS=( readme.md )
-
-src_prepare() {
-	rm *-test.* license.md || die
-	default
-}

--- a/app-vim/merginal/merginal-2.1.0.ebuild
+++ b/app-vim/merginal/merginal-2.1.0.ebuild
@@ -24,8 +24,3 @@ LICENSE="vim"
 RDEPEND="app-vim/fugitive"
 
 VIM_PLUGIN_HELPFILES="${PN}"
-
-src_prepare() {
-	rm README.md || die
-	default
-}

--- a/app-vim/merginal/merginal-2.1.0.ebuild
+++ b/app-vim/merginal/merginal-2.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/merginal/merginal-2.1.2.ebuild
+++ b/app-vim/merginal/merginal-2.1.2.ebuild
@@ -25,9 +25,4 @@ RDEPEND="app-vim/fugitive"
 
 VIM_PLUGIN_HELPFILES="${PN}"
 
-DOCS=( CHANGELOG.md )
-
-src_prepare() {
-	rm README.md || die
-	default
-}
+DOCS=( CHANGELOG.md README.md )

--- a/app-vim/merginal/merginal-9999.ebuild
+++ b/app-vim/merginal/merginal-9999.ebuild
@@ -25,9 +25,4 @@ RDEPEND="app-vim/fugitive"
 
 VIM_PLUGIN_HELPFILES="${PN}"
 
-DOCS=( CHANGELOG.md )
-
-src_prepare() {
-	rm README.md || die
-	default
-}
+DOCS=( CHANGELOG.md README.md )

--- a/app-vim/minibufexpl/minibufexpl-6.5.2.ebuild
+++ b/app-vim/minibufexpl/minibufexpl-6.5.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/minibufexpl/minibufexpl-6.5.2.ebuild
+++ b/app-vim/minibufexpl/minibufexpl-6.5.2.ebuild
@@ -15,10 +15,3 @@ KEYWORDS="amd64 ~mips ppc x86"
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 S=${WORKDIR}/${MY_PN}-${PV}
-
-src_prepare() {
-	default
-
-	# discard unwanted files
-	rm .gitignore README.md || die
-}

--- a/app-vim/nerdcommenter/nerdcommenter-2.5.2.ebuild
+++ b/app-vim/nerdcommenter/nerdcommenter-2.5.2.ebuild
@@ -18,8 +18,3 @@ HOMEPAGE="https://github.com/scrooloose/nerdcommenter https://www.vim.org/script
 LICENSE="WTFPL-2 "
 
 VIM_PLUGIN_HELPFILES="NERD_commenter.txt"
-
-src_prepare() {
-	default
-	rm README.md Rakefile || die
-}

--- a/app-vim/nerdcommenter/nerdcommenter-9999.ebuild
+++ b/app-vim/nerdcommenter/nerdcommenter-9999.ebuild
@@ -18,8 +18,3 @@ HOMEPAGE="https://github.com/scrooloose/nerdcommenter https://www.vim.org/script
 LICENSE="WTFPL-2 "
 
 VIM_PLUGIN_HELPFILES="NERD_commenter.txt"
-
-src_prepare() {
-	default
-	rm README.md Rakefile || die
-}

--- a/app-vim/nerdtree-tabs/nerdtree-tabs-1.4.7.ebuild
+++ b/app-vim/nerdtree-tabs/nerdtree-tabs-1.4.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/nerdtree-tabs/nerdtree-tabs-1.4.7.ebuild
+++ b/app-vim/nerdtree-tabs/nerdtree-tabs-1.4.7.ebuild
@@ -17,9 +17,4 @@ S="${WORKDIR}/vim-${P}"
 
 VIM_PLUGIN_HELPFILES="${PN}"
 
-DOCS=( CHANGELOG.md )
-
-src_prepare() {
-	default
-	rm LICENSE README.md || die
-}
+DOCS=( CHANGELOG.md README.md )

--- a/app-vim/nerdtree/nerdtree-5.0.0-r1.ebuild
+++ b/app-vim/nerdtree/nerdtree-5.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/nerdtree/nerdtree-5.0.0-r1.ebuild
+++ b/app-vim/nerdtree/nerdtree-5.0.0-r1.ebuild
@@ -12,8 +12,3 @@ LICENSE="WTFPL-2"
 KEYWORDS="amd64 x86 ~x64-macos"
 
 VIM_PLUGIN_HELPFILES="NERD_tree"
-
-src_prepare() {
-	default
-	rm LICENCE || die
-}

--- a/app-vim/nerdtree/nerdtree-6.4.1.ebuild
+++ b/app-vim/nerdtree/nerdtree-6.4.1.ebuild
@@ -14,8 +14,3 @@ KEYWORDS="~amd64 ~x86 ~x64-macos"
 VIM_PLUGIN_HELPFILES="NERD_tree"
 
 DOCS=( CHANGELOG.md README.markdown )
-
-src_prepare() {
-	default
-	rm LICENCE || die
-}

--- a/app-vim/nerdtree/nerdtree-6.4.3.ebuild
+++ b/app-vim/nerdtree/nerdtree-6.4.3.ebuild
@@ -20,8 +20,3 @@ LICENSE="WTFPL-2"
 VIM_PLUGIN_HELPFILES="NERD_tree"
 
 DOCS=( CHANGELOG.md README.markdown )
-
-src_prepare() {
-	rm LICENCE screenshot.png _config.yml || die
-	default
-}

--- a/app-vim/nerdtree/nerdtree-9999.ebuild
+++ b/app-vim/nerdtree/nerdtree-9999.ebuild
@@ -20,8 +20,3 @@ LICENSE="WTFPL-2"
 VIM_PLUGIN_HELPFILES="NERD_tree"
 
 DOCS=( CHANGELOG.md README.markdown )
-
-src_prepare() {
-	rm LICENCE screenshot.png _config.yml || die
-	default
-}

--- a/app-vim/perlomni/perlomni-2.5.ebuild
+++ b/app-vim/perlomni/perlomni-2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/perlomni/perlomni-2.5.ebuild
+++ b/app-vim/perlomni/perlomni-2.5.ebuild
@@ -19,17 +19,4 @@ RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}.vim-${PV}"
 
-src_prepare() {
-	default
-	local CLEANUP=(
-		Makefile
-		config.mk
-		README.mkd
-		README.mkd.old
-		win32-install.bat
-		TODO
-	)
-	rm -v "${CLEANUP[@]}" || die
-}
-
 src_compile() { :; }

--- a/app-vim/rails/rails-5.2.ebuild
+++ b/app-vim/rails/rails-5.2.ebuild
@@ -17,8 +17,3 @@ KEYWORDS="~amd64 ~x86"
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 S=${WORKDIR}/${MY_P}
-
-src_prepare() {
-	rm *.markdown || die
-	default
-}

--- a/app-vim/reload/reload-0.6.17-r1.ebuild
+++ b/app-vim/reload/reload-0.6.17-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/reload/reload-0.6.17-r1.ebuild
+++ b/app-vim/reload/reload-0.6.17-r1.ebuild
@@ -16,8 +16,3 @@ RDEPEND=">=app-vim/vim-misc-1.8.5"
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 S="${WORKDIR}/vim-${P}"
-
-src_prepare() {
-	default
-	rm addon-info.json *.md || die
-}

--- a/app-vim/repeat/repeat-1.1.ebuild
+++ b/app-vim/repeat/repeat-1.1.ebuild
@@ -15,8 +15,3 @@ LICENSE="vim"
 KEYWORDS="amd64 x86"
 
 S=${WORKDIR}/${MY_P}
-
-src_prepare() {
-	rm *.markdown || die
-	default
-}

--- a/app-vim/screen/screen-1.5.ebuild
+++ b/app-vim/screen/screen-1.5.ebuild
@@ -15,8 +15,3 @@ KEYWORDS="amd64 ~arm64 x86"
 VIM_PLUGIN_HELPFILES="screen.txt"
 
 RDEPEND="|| ( app-misc/screen app-misc/tmux )"
-
-src_prepare() {
-	rm README || die
-	default
-}

--- a/app-vim/session/session-2.13.1.ebuild
+++ b/app-vim/session/session-2.13.1.ebuild
@@ -16,10 +16,3 @@ VIM_PLUGIN_HELPFILES="${PN}.txt"
 RDEPEND=">=app-vim/vim-misc-1.17.6"
 
 S=${WORKDIR}/vim-${P}
-
-src_prepare() {
-	default
-
-	# remove unneeded files
-	rm addon-info.json *.md || die
-}

--- a/app-vim/session/session-2.13.1.ebuild
+++ b/app-vim/session/session-2.13.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/snipmate/snipmate-0.87-r1.ebuild
+++ b/app-vim/snipmate/snipmate-0.87-r1.ebuild
@@ -23,8 +23,3 @@ S=${WORKDIR}/${MY_P}
 
 VIM_PLUGIN_HELPFILES="SnipMate"
 VIM_PLUGIN_MESSAGES="filetype"
-
-src_prepare() {
-	rm addon-info.json || die
-	default
-}

--- a/app-vim/splice/splice-1.1.0-r3.ebuild
+++ b/app-vim/splice/splice-1.1.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/splice/splice-1.1.0-r3.ebuild
+++ b/app-vim/splice/splice-1.1.0-r3.ebuild
@@ -25,9 +25,10 @@ VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 src_prepare() {
 	default
-	rm .[a-z]* Makefile LICENSE.markdown package.sh || die
 	rm -r site || die
 }
+
+src_compile() { :; }
 
 src_install() {
 	vim-plugin_src_install

--- a/app-vim/splice/splice-1.1.0-r4.ebuild
+++ b/app-vim/splice/splice-1.1.0-r4.ebuild
@@ -26,9 +26,10 @@ VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 src_prepare() {
 	default
-	rm .[a-z]* Makefile LICENSE.markdown package.sh || die
 	rm -r site || die
 }
+
+src_compile() { :; }
 
 src_install() {
 	vim-plugin_src_install

--- a/app-vim/supertab/supertab-2.1.ebuild
+++ b/app-vim/supertab/supertab-2.1.ebuild
@@ -13,7 +13,4 @@ KEYWORDS="amd64 ~mips ppc ppc64 x86"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
-src_prepare() {
-	rm Makefile .gitignore || die
-	default
-}
+src_compile() { :; }

--- a/app-vim/syntastic/syntastic-3.9.0.ebuild
+++ b/app-vim/syntastic/syntastic-3.9.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/syntastic/syntastic-3.9.0.ebuild
+++ b/app-vim/syntastic/syntastic-3.9.0.ebuild
@@ -20,7 +20,7 @@ VIM_PLUGIN_HELPFILES="${PN}"
 
 src_prepare() {
 	default
-	rm -r _assets LICENCE README.markdown || die
+	rm -r _assets || die
 }
 
 pkg_postinst() {

--- a/app-vim/syntastic/syntastic-9999.ebuild
+++ b/app-vim/syntastic/syntastic-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/syntastic/syntastic-9999.ebuild
+++ b/app-vim/syntastic/syntastic-9999.ebuild
@@ -20,7 +20,7 @@ VIM_PLUGIN_HELPFILES="${PN}"
 
 src_prepare() {
 	default
-	rm -r _assets LICENCE README.markdown || die
+	rm -r _assets || die
 }
 
 pkg_postinst() {

--- a/app-vim/tagbar/tagbar-2.7.ebuild
+++ b/app-vim/tagbar/tagbar-2.7.ebuild
@@ -15,8 +15,3 @@ KEYWORDS="amd64 x86"
 RDEPEND=">=dev-util/ctags-5.5"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
-
-src_prepare() {
-	rm LICENSE || die
-	default
-}

--- a/app-vim/tagbar/tagbar-2.7.ebuild
+++ b/app-vim/tagbar/tagbar-2.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/tcomment/tcomment-3.08.1.ebuild
+++ b/app-vim/tcomment/tcomment-3.08.1.ebuild
@@ -22,9 +22,9 @@ LICENSE="GPL-3"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
-DOCS=( CHANGES.TXT )
+DOCS=( CHANGES.TXT README )
 
 src_prepare() {
 	default
-	rm -r README LICENSE.TXT etc spec addon* || die
+	rm -r etc spec addon* || die
 }

--- a/app-vim/tcomment/tcomment-9999.ebuild
+++ b/app-vim/tcomment/tcomment-9999.ebuild
@@ -22,9 +22,9 @@ LICENSE="GPL-3"
 
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
-DOCS=( CHANGES.txt )
+DOCS=( CHANGES.TXT README )
 
 src_prepare() {
 	default
-	rm -r README LICENSE.TXT etc spec addon* || die
+	rm -r etc spec addon* || die
 }

--- a/app-vim/tlib/tlib-1.22.ebuild
+++ b/app-vim/tlib/tlib-1.22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/tlib/tlib-1.22.ebuild
+++ b/app-vim/tlib/tlib-1.22.ebuild
@@ -22,5 +22,5 @@ DOCS=( README CHANGES.TXT )
 
 src_prepare() {
 	default
-	rm -r test samples addon-info.json || die
+	rm -r test samples || die
 }

--- a/app-vim/tlib/tlib-1.23.ebuild
+++ b/app-vim/tlib/tlib-1.23.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/tlib/tlib-1.23.ebuild
+++ b/app-vim/tlib/tlib-1.23.ebuild
@@ -22,5 +22,5 @@ DOCS=( README CHANGES.TXT )
 
 src_prepare() {
 	default
-	rm -r test samples addon-info.json || die
+	rm -r test samples || die
 }

--- a/app-vim/txtfmt/txtfmt-2.4-r1.ebuild
+++ b/app-vim/txtfmt/txtfmt-2.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/txtfmt/txtfmt-2.4-r1.ebuild
+++ b/app-vim/txtfmt/txtfmt-2.4-r1.ebuild
@@ -14,8 +14,3 @@ KEYWORDS="~amd64 ~x86"
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 S=${WORKDIR}
-
-src_prepare() {
-	default
-	rm indent_patch.txt || die
-}

--- a/app-vim/txtfmt/txtfmt-3.1.ebuild
+++ b/app-vim/txtfmt/txtfmt-3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/txtfmt/txtfmt-3.1.ebuild
+++ b/app-vim/txtfmt/txtfmt-3.1.ebuild
@@ -14,8 +14,3 @@ KEYWORDS="~amd64 ~x86"
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 S=${WORKDIR}
-
-src_prepare() {
-	default
-	rm indent_patch.txt || die
-}

--- a/app-vim/vim-clang-format/vim-clang-format-0_pre20200506.ebuild
+++ b/app-vim/vim-clang-format/vim-clang-format-0_pre20200506.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/vim-clang-format/vim-clang-format-0_pre20200506.ebuild
+++ b/app-vim/vim-clang-format/vim-clang-format-0_pre20200506.ebuild
@@ -21,5 +21,5 @@ src_prepare() {
 	default
 
 	# tests are written in ruby, prefer to avoid that
-	rm -r .travis.yml test || die
+	rm -r test || die
 }

--- a/app-vim/vim-jsonnet/vim-jsonnet-0_pre20190502.ebuild
+++ b/app-vim/vim-jsonnet/vim-jsonnet-0_pre20190502.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/vim-jsonnet/vim-jsonnet-0_pre20190502.ebuild
+++ b/app-vim/vim-jsonnet/vim-jsonnet-0_pre20190502.ebuild
@@ -16,9 +16,3 @@ KEYWORDS="~amd64 ~x86"
 RDEPEND="dev-lang/jsonnet"
 
 S="${WORKDIR}/${PN}-${COMMIT_HASH}"
-
-src_prepare() {
-	default
-
-	rm -f LICENSE .gitignore || die
-}

--- a/app-vim/vim-latex/vim-latex-1.10.0-r2.ebuild
+++ b/app-vim/vim-latex/vim-latex-1.10.0-r2.ebuild
@@ -30,9 +30,6 @@ VIM_PLUGIN_HELPFILES="latex-suite.txt latex-suite-quickstart.txt latexhelp.txt i
 src_compile() { :; }
 
 src_install() {
-	# remove unused metadata
-	rm vim-latex.metainfo.xml || die
-
 	# don't mess up vim's doc dir with random files
 	mv doc mydoc || die
 	mkdir doc || die

--- a/app-vim/vim-misc/vim-misc-1.17.6.ebuild
+++ b/app-vim/vim-misc/vim-misc-1.17.6.ebuild
@@ -14,6 +14,6 @@ KEYWORDS="amd64 x86"
 VIM_PLUGIN_HELPFILES="misc.txt"
 
 src_prepare() {
-	rm INSTALL.md addon-info.json autoload/xolox/misc/echo.exe || die
+	rm autoload/xolox/misc/echo.exe || die
 	default
 }

--- a/app-vim/vim-nftables/vim-nftables-0_pre20200224.ebuild
+++ b/app-vim/vim-nftables/vim-nftables-0_pre20200224.ebuild
@@ -14,10 +14,3 @@ S="${WORKDIR}/${PN}-${COMMIT_ID}"
 
 LICENSE="MIT"
 KEYWORDS="~amd64 ~x86"
-
-src_prepare() {
-	default
-
-	# will install license file by default
-	rm LICENSE || die
-}

--- a/app-vim/vim-nftables/vim-nftables-0_pre20200629-r1.ebuild
+++ b/app-vim/vim-nftables/vim-nftables-0_pre20200629-r1.ebuild
@@ -18,10 +18,3 @@ KEYWORDS="~amd64 ~x86"
 PATCHES=(
 	"${FILESDIR}/vim-nftables-0_pre2020062901-no-expandtab.patch"
 )
-
-src_prepare() {
-	default
-
-	# will install license file by default
-	rm LICENSE || die
-}

--- a/app-vim/vim-rest-console/vim-rest-console-2.6.0.ebuild
+++ b/app-vim/vim-rest-console/vim-rest-console-2.6.0.ebuild
@@ -14,8 +14,3 @@ KEYWORDS="~amd64 ~x86"
 VIM_PLUGIN_HELPFILES="${PN}.txt"
 
 RDEPEND="net-misc/curl"
-
-src_prepare() {
-	rm *.md *.json *.rest || die
-	default
-}

--- a/app-vim/vim-rest-console/vim-rest-console-2.6.0.ebuild
+++ b/app-vim/vim-rest-console/vim-rest-console-2.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/vimagit/vimagit-1.7.3.ebuild
+++ b/app-vim/vimagit/vimagit-1.7.3.ebuild
@@ -20,8 +20,3 @@ VIM_PLUGIN_HELPFILES="${PN}"
 RDEPEND="dev-vcs/git"
 
 DOCS=( README.md Changelog )
-
-src_prepare() {
-	rm _config.yml || die
-	default
-}

--- a/app-vim/vimagit/vimagit-1.7.3.ebuild
+++ b/app-vim/vimagit/vimagit-1.7.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/vimagit/vimagit-9999.ebuild
+++ b/app-vim/vimagit/vimagit-9999.ebuild
@@ -20,8 +20,3 @@ VIM_PLUGIN_HELPFILES="${PN}"
 RDEPEND="dev-vcs/git"
 
 DOCS=( README.md Changelog )
-
-src_prepare() {
-	rm _config.yml || die
-	default
-}

--- a/app-vim/vimagit/vimagit-9999.ebuild
+++ b/app-vim/vimagit/vimagit-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/vimclojure/vimclojure-2.3.6-r3.ebuild
+++ b/app-vim/vimclojure/vimclojure-2.3.6-r3.ebuild
@@ -46,7 +46,6 @@ src_prepare() {
 }
 
 src_install() {
-	einstalldocs
 	rm -rv doc/LICENSE.txt bin || die
 	vim-plugin_src_install
 }

--- a/app-vim/vimclojure/vimclojure-2.3.6-r3.ebuild
+++ b/app-vim/vimclojure/vimclojure-2.3.6-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/vimoutliner/vimoutliner-0.3.6-r1.ebuild
+++ b/app-vim/vimoutliner/vimoutliner-0.3.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/vimoutliner/vimoutliner-0.3.6-r1.ebuild
+++ b/app-vim/vimoutliner/vimoutliner-0.3.6-r1.ebuild
@@ -18,6 +18,5 @@ src_prepare() {
 	default
 	sed -i -e '/^if exists/,/endif/d' ftdetect/vo_base.vim || die
 	sed -i -e 's/g:vo_modules2load/g:vo_modules_load/' vimoutliner/vimoutlinerrc || die
-	rm -v install.sh || die
 	find "${S}" -type f -exec chmod a+r {} \; || die
 }

--- a/app-vim/vimoutliner/vimoutliner-0.4.0_p20180301-r2.ebuild
+++ b/app-vim/vimoutliner/vimoutliner-0.4.0_p20180301-r2.ebuild
@@ -48,5 +48,4 @@ src_compile() {
 		2to3 -w -n --no-diffs "${pyscript}" >& /dev/null || die
 		python_fix_shebang -f -q "${pyscript}"
 	done
-	rm -v README.detailed || die
 }

--- a/app-vim/vimtex/vimtex-1.5.ebuild
+++ b/app-vim/vimtex/vimtex-1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-vim/vimtex/vimtex-1.5.ebuild
+++ b/app-vim/vimtex/vimtex-1.5.ebuild
@@ -20,6 +20,6 @@ RDEPEND="
 src_prepare() {
 	default
 
-	# remove unwanted files
-	rm -r *.md media test || die
+	# remove unwanted dirs
+	rm -r media test || die
 }

--- a/app-vim/vimtex/vimtex-99999999.ebuild
+++ b/app-vim/vimtex/vimtex-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/app-vim/vimtex/vimtex-99999999.ebuild
+++ b/app-vim/vimtex/vimtex-99999999.ebuild
@@ -28,6 +28,6 @@ RDEPEND="
 src_prepare() {
 	default
 
-	# remove unwanted files
-	rm -r *.md media test || die
+	# remove unwanted dirs
+	rm -r media test || die
 }

--- a/app-vim/webapi/webapi-0.3.ebuild
+++ b/app-vim/webapi/webapi-0.3.ebuild
@@ -15,7 +15,4 @@ RDEPEND="net-misc/curl"
 
 S="${WORKDIR}/${PN}-vim-${PV}"
 
-src_prepare() {
-	default
-	rm -v Makefile || die
-}
+src_compile() { :; }

--- a/app-vim/webapi/webapi-0.3.ebuild
+++ b/app-vim/webapi/webapi-0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6


### PR DESCRIPTION
This is a follow up to #20530

<details>
<summary>Here's a list of files that this PR changes to all app-vim/ packages, mostly READMEs</summary>

```diff
6a7
> ./usr/share/doc/airline-0.11/README.md.bz2
airline-9999 failed
3a4,6
> ./usr/share/doc
> ./usr/share/doc/bufexplorer-7.4.18
> ./usr/share/doc/bufexplorer-7.4.18/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/bufexplorer-7.4.19
> ./usr/share/doc/bufexplorer-7.4.19/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/bufexplorer-9999
> ./usr/share/doc/bufexplorer-9999/README.md.bz2
54a55,57
> ./usr/share/doc
> ./usr/share/doc/command-t-5.0.3
> ./usr/share/doc/command-t-5.0.3/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/csound-syntax-0.8.1
> ./usr/share/doc/csound-syntax-0.8.1/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/csound-syntax-20160804
> ./usr/share/doc/csound-syntax-20160804/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/diffchar-8.2
> ./usr/share/doc/diffchar-8.2/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/diffchar-8.6
> ./usr/share/doc/diffchar-8.6/README.md.bz2
fugitive-9999 failed
3a4,6
> ./usr/share/doc
> ./usr/share/doc/gist-7.3
> ./usr/share/doc/gist-7.3/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/gitgutter-20180316
> ./usr/share/doc/gitgutter-20180316/README.mkd.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/gitgutter-20180815
> ./usr/share/doc/gitgutter-20180815/README.mkd.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/gitgutter-99999999
> ./usr/share/doc/gitgutter-99999999/README.mkd.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/gundo-2.6.2-r3
> ./usr/share/doc/gundo-2.6.2-r3/README.markdown.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/merginal-2.1.0
> ./usr/share/doc/merginal-2.1.0/README.md.bz2
6a7
> ./usr/share/doc/merginal-2.1.2/README.md.bz2
6a7
> ./usr/share/doc/merginal-9999/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/minibufexpl-6.5.2
> ./usr/share/doc/minibufexpl-6.5.2/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/nerdcommenter-2.5.2
> ./usr/share/doc/nerdcommenter-2.5.2/README.md.bz2
6a7
> ./usr/share/doc/nerdtree-tabs-1.4.7/README.md.bz2
3a4,8
> ./usr/share/doc
> ./usr/share/doc/perlomni-2.5
> ./usr/share/doc/perlomni-2.5/README.mkd.bz2
> ./usr/share/doc/perlomni-2.5/README.mkd.old.bz2
> ./usr/share/doc/perlomni-2.5/TODO.bz2
pyclewn-2.1-r2 failed
3a4,6
> ./usr/share/doc
> ./usr/share/doc/rails-5.2
> ./usr/share/doc/rails-5.2/README.markdown.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/reload-0.6.17-r1
> ./usr/share/doc/reload-0.6.17-r1/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/repeat-1.1
> ./usr/share/doc/repeat-1.1/README.markdown.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/screen-1.5
> ./usr/share/doc/screen-1.5/README.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/session-2.13.1
> ./usr/share/doc/session-2.13.1/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/syntastic-3.9.0
> ./usr/share/doc/syntastic-3.9.0/README.markdown.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/syntastic-9999
> ./usr/share/doc/syntastic-9999/README.markdown.bz2
6a7
> ./usr/share/doc/tcomment-3.08.1/README.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/vim-rest-console-2.6.0
> ./usr/share/doc/vim-rest-console-2.6.0/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/vimtex-1.5
> ./usr/share/doc/vimtex-1.5/README.md.bz2
3a4,6
> ./usr/share/doc
> ./usr/share/doc/vimtex-99999999
> ./usr/share/doc/vimtex-99999999/README.md.bz2
```

</details>