### PR TITLE
Fix Rust

### DIFF
--- a/dev-lang/rust-bin/rust-bin-1.59.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.59.0.ebuild
@@ -63,7 +63,7 @@ src_unpack() {
 
 	default_src_unpack
 
-	mv "${WORKDIR}/${MY_P}-$(rust_abi)" "${S}" || die
+	mv "${WORKDIR}/${MY_P}-${RUSTHOST}" "${S}" || die "Unsupported target binary: ${RUSTHOST}"
 }
 
 patchelf_for_bin() {
@@ -184,7 +184,7 @@ multilib_src_install() {
 
 	else
 		local rust_target
-		rust_target="$(rust_abi $(get_abi_CHOST ${v##*.}))"
+		rust_target="$(get_abi_RUSTHOST ${v##*.})"
 		dodir "/opt/${P}/lib/rustlib"
 		cp -vr "${WORKDIR}/rust-${PV}-${rust_target}/rust-std-${rust_target}/lib/rustlib/${rust_target}"\
 			"${ED}/opt/${P}/lib/rustlib" || die

--- a/dev-lang/rust-bin/rust-bin-1.60.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.60.0.ebuild
@@ -68,7 +68,7 @@ src_unpack() {
 
 	default_src_unpack
 
-	mv "${WORKDIR}/${MY_P}-$(rust_abi)" "${S}" || die
+	mv "${WORKDIR}/${MY_P}-${RUSTHOST}" "${S}" || die "Unsupported target binary: ${RUSTHOST}"
 }
 
 patchelf_for_bin() {
@@ -189,7 +189,7 @@ multilib_src_install() {
 
 	else
 		local rust_target
-		rust_target="$(rust_abi $(get_abi_CHOST ${v##*.}))"
+		rust_target="$(get_abi_RUSTHOST ${v##*.})"
 		dodir "/opt/${P}/lib/rustlib"
 		cp -vr "${WORKDIR}/rust-${PV}-${rust_target}/rust-std-${rust_target}/lib/rustlib/${rust_target}"\
 			"${ED}/opt/${P}/lib/rustlib" || die

--- a/dev-lang/rust-bin/rust-bin-1.61.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.61.0.ebuild
@@ -72,7 +72,7 @@ src_unpack() {
 
 	default_src_unpack
 
-	mv "${WORKDIR}/${MY_P}-$(rust_abi)" "${S}" || die
+	mv "${WORKDIR}/${MY_P}-${RUSTHOST}" "${S}" || die "Unsupported target binary: ${RUSTHOST}"
 }
 
 patchelf_for_bin() {
@@ -193,7 +193,7 @@ multilib_src_install() {
 
 	else
 		local rust_target
-		rust_target="$(rust_abi $(get_abi_CHOST ${v##*.}))"
+		rust_target="$(get_abi_RUSTHOST ${v##*.})"
 		dodir "/opt/${P}/lib/rustlib"
 		cp -vr "${WORKDIR}/rust-${PV}-${rust_target}/rust-std-${rust_target}/lib/rustlib/${rust_target}"\
 			"${ED}/opt/${P}/lib/rustlib" || die

--- a/dev-lang/rust-bin/rust-bin-1.62.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.62.0.ebuild
@@ -70,7 +70,7 @@ src_unpack() {
 
 	default_src_unpack
 
-	mv "${WORKDIR}/${MY_P}-$(rust_abi)" "${S}" || die
+	mv "${WORKDIR}/${MY_P}-${RUSTHOST}" "${S}" || die "Unsupported target binary: ${RUSTHOST}"
 }
 
 patchelf_for_bin() {
@@ -191,7 +191,7 @@ multilib_src_install() {
 
 	else
 		local rust_target
-		rust_target="$(rust_abi $(get_abi_CHOST ${v##*.}))"
+		rust_target="$(get_abi_RUSTHOST ${v##*.})"
 		dodir "/opt/${P}/lib/rustlib"
 		cp -vr "${WORKDIR}/rust-${PV}-${rust_target}/rust-std-${rust_target}/lib/rustlib/${rust_target}"\
 			"${ED}/opt/${P}/lib/rustlib" || die

--- a/dev-lang/rust/rust-1.59.0.ebuild
+++ b/dev-lang/rust/rust-1.59.0.ebuild
@@ -171,7 +171,7 @@ bootstrap_rust_version_check() {
 	[[ ${MERGE_TYPE} == binary ]] && return
 	local rustc_wanted="$(ver_cut 1).$(($(ver_cut 2) - 1))"
 	local rustc_toonew="$(ver_cut 1).$(($(ver_cut 2) + 1))"
-	local rustc_version=( $(eselect --brief rust show 2>/dev/null) )
+	local rustc_version=( $(ROOT=${BROOT:-/} eselect --brief rust show 2>/dev/null) )
 	rustc_version=${rustc_version[0]#rust-bin-}
 	rustc_version=${rustc_version#rust-}
 
@@ -262,10 +262,10 @@ src_configure() {
 
 	# Collect rust target names to compile standard libs for all ABIs.
 	for v in $(get_all_abis); do
-		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v})\""
+		rust_targets+=",\"$(get_abi_RUSTHOST ${v})\""
 	done
 	if use wasm; then
-		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
+		rust_targets+=',"wasm32-unknown-unknown"'
 		if use system-llvm; then
 			# un-hardcode rust-lld linker for this target
 			# https://bugs.gentoo.org/715348
@@ -274,22 +274,12 @@ src_configure() {
 	fi
 	rust_targets="${rust_targets#,}"
 
-	local tools="\"cargo\","
-	if use clippy; then
-		tools="\"clippy\",$tools"
-	fi
-	if use miri; then
-		tools="\"miri\",$tools"
-	fi
-	if use rls; then
-		tools="\"rls\",\"analysis\",$tools"
-	fi
-	if use rustfmt; then
-		tools="\"rustfmt\",$tools"
-	fi
-	if use rust-src; then
-		tools="\"src\",$tools"
-	fi
+	local tools='"cargo"'
+	use clippy && tools+=',"clippy"'
+	use miri && tools+=',"miri"'
+	use rls && tools+=',"rls","analysis"'
+	use rustfmt && tools+=',"rustfmt"'
+	use rust-src && tools+=',"src"'
 
 	local rust_stage0_root
 	if use system-bootstrap; then

--- a/dev-lang/rust/rust-1.59.0.ebuild
+++ b/dev-lang/rust/rust-1.59.0.ebuild
@@ -261,8 +261,8 @@ src_configure() {
 	local rust_target="" rust_targets="" arch_cflags
 
 	# Collect rust target names to compile standard libs for all ABIs.
-	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v##*.})\""
+	for v in $(get_all_abis); do
+		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v})\""
 	done
 	if use wasm; then
 		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
@@ -386,9 +386,9 @@ src_configure() {
 		compression-formats = ["xz"]
 	_EOF_
 
-	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_target=$(get_abi_RUSTHOST ${v##*.})
-		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+	for v in $(get_all_abis); do
+		arch_cflags=$(get_abi_CFLAGS ${v})
+		rust_target=$(get_abi_RUSTHOST ${v})
 
 		cat <<- _EOF_ >> "${S}"/config.env
 			CFLAGS_${rust_target}=${arch_cflags}

--- a/dev-lang/rust/rust-1.60.0.ebuild
+++ b/dev-lang/rust/rust-1.60.0.ebuild
@@ -246,7 +246,7 @@ pkg_setup() {
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
-		local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
+		local rust_stage0="rust-${RUST_STAGE0_VERSION}-${RUSTHOST}"
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--without=rust-docs --destdir="${rust_stage0_root}" --prefix=/ || die
@@ -260,7 +260,7 @@ src_configure() {
 
 	# Collect rust target names to compile standard libs for all ABIs.
 	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_targets="${rust_targets},\"$(rust_abi $(get_abi_CHOST ${v##*.}))\""
+		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v##*.})\""
 	done
 	if use wasm; then
 		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
@@ -303,8 +303,6 @@ src_configure() {
 	# in case of prefix it will be already prefixed, as --print sysroot returns full path
 	[[ -d ${rust_stage0_root} ]] || die "${rust_stage0_root} is not a directory"
 
-	rust_target="$(rust_abi)"
-
 	cat <<- _EOF_ > "${S}"/config.toml
 		changelog-seen = 2
 		[llvm]
@@ -316,7 +314,7 @@ src_configure() {
 		targets = "${LLVM_TARGETS// /;}"
 		experimental-targets = ""
 		link-shared = $(toml_usex system-llvm)
-		$(case "${rust_target}" in
+		$(case ${RUSTHOST} in
 			i586-*-linux-*)
 				# https://github.com/rust-lang/rust/issues/93059
 				echo 'cflags = "-fcf-protection=none"'
@@ -328,8 +326,8 @@ src_configure() {
 		build-stage = 2
 		test-stage = 2
 		doc-stage = 2
-		build = "${rust_target}"
-		host = ["${rust_target}"]
+		build = "${RUSTBUILD:-${RUSTHOST}}"
+		host = ["${RUSTHOST}"]
 		target = [${rust_targets}]
 		cargo = "${rust_stage0_root}/bin/cargo"
 		rustc = "${rust_stage0_root}/bin/rustc"
@@ -390,7 +388,7 @@ src_configure() {
 	_EOF_
 
 	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_target=$(rust_abi $(get_abi_CHOST ${v##*.}))
+		rust_target=$(get_abi_RUSTHOST ${v##*.})
 		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
 
 		cat <<- _EOF_ >> "${S}"/config.env

--- a/dev-lang/rust/rust-1.60.0.ebuild
+++ b/dev-lang/rust/rust-1.60.0.ebuild
@@ -259,8 +259,8 @@ src_configure() {
 	local rust_target="" rust_targets="" arch_cflags
 
 	# Collect rust target names to compile standard libs for all ABIs.
-	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v##*.})\""
+	for v in $(get_all_abis); do
+		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v})\""
 	done
 	if use wasm; then
 		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
@@ -387,9 +387,9 @@ src_configure() {
 		compression-formats = ["xz"]
 	_EOF_
 
-	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_target=$(get_abi_RUSTHOST ${v##*.})
-		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+	for v in $(get_all_abis); do
+		arch_cflags=$(get_abi_CFLAGS ${v})
+		rust_target=$(get_abi_RUSTHOST ${v})
 
 		cat <<- _EOF_ >> "${S}"/config.env
 			CFLAGS_${rust_target}=${arch_cflags}

--- a/dev-lang/rust/rust-1.60.0.ebuild
+++ b/dev-lang/rust/rust-1.60.0.ebuild
@@ -169,7 +169,7 @@ bootstrap_rust_version_check() {
 	[[ ${MERGE_TYPE} == binary ]] && return
 	local rustc_wanted="$(ver_cut 1).$(($(ver_cut 2) - 1))"
 	local rustc_toonew="$(ver_cut 1).$(($(ver_cut 2) + 1))"
-	local rustc_version=( $(eselect --brief rust show 2>/dev/null) )
+	local rustc_version=( $(ROOT=${BROOT:-/} eselect --brief rust show 2>/dev/null) )
 	rustc_version=${rustc_version[0]#rust-bin-}
 	rustc_version=${rustc_version#rust-}
 
@@ -260,10 +260,10 @@ src_configure() {
 
 	# Collect rust target names to compile standard libs for all ABIs.
 	for v in $(get_all_abis); do
-		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v})\""
+		rust_targets+=",\"$(get_abi_RUSTHOST ${v})\""
 	done
 	if use wasm; then
-		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
+		rust_targets+=',"wasm32-unknown-unknown"'
 		if use system-llvm; then
 			# un-hardcode rust-lld linker for this target
 			# https://bugs.gentoo.org/715348
@@ -272,25 +272,13 @@ src_configure() {
 	fi
 	rust_targets="${rust_targets#,}"
 
-	local tools="\"cargo\","
-	if use clippy; then
-		tools="\"clippy\",$tools"
-	fi
-	if use miri; then
-		tools="\"miri\",$tools"
-	fi
-	if use profiler; then
-		tools="\"rust-demangler\",$tools"
-	fi
-	if use rls; then
-		tools="\"rls\",\"analysis\",$tools"
-	fi
-	if use rustfmt; then
-		tools="\"rustfmt\",$tools"
-	fi
-	if use rust-src; then
-		tools="\"src\",$tools"
-	fi
+	local tools='"cargo"'
+	use clippy && tools+=',"clippy"'
+	use miri && tools+=',"miri"'
+	use profiler && tools+=',"rust-demangler"'
+	use rls && tools+=',"rls","analysis"'
+	use rustfmt && tools+=',"rustfmt"'
+	use rust-src && tools+=',"src"'
 
 	local rust_stage0_root
 	if use system-bootstrap; then

--- a/dev-lang/rust/rust-1.61.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.61.0-r2.ebuild
@@ -249,7 +249,7 @@ pkg_setup() {
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
-		local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
+		local rust_stage0="rust-${RUST_STAGE0_VERSION}-${RUSTHOST}"
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--without=rust-docs --destdir="${rust_stage0_root}" --prefix=/ || die
@@ -263,7 +263,7 @@ src_configure() {
 
 	# Collect rust target names to compile standard libs for all ABIs.
 	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_targets="${rust_targets},\"$(rust_abi $(get_abi_CHOST ${v##*.}))\""
+		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v##*.})\""
 	done
 	if use wasm; then
 		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
@@ -306,8 +306,6 @@ src_configure() {
 	# in case of prefix it will be already prefixed, as --print sysroot returns full path
 	[[ -d ${rust_stage0_root} ]] || die "${rust_stage0_root} is not a directory"
 
-	rust_target="$(rust_abi)"
-
 	# https://bugs.gentoo.org/732632
 	if tc-is-clang; then
 		local clang_slot="$(clang-major-version)"
@@ -332,7 +330,7 @@ src_configure() {
 			echo "use-libcxx = true"
 			echo "static-libstdcpp = false"
 		fi)
-		$(case "${rust_target}" in
+		$(case ${RUSTHOST} in
 			i586-*-linux-*)
 				# https://github.com/rust-lang/rust/issues/93059
 				echo 'cflags = "-fcf-protection=none"'
@@ -347,8 +345,8 @@ src_configure() {
 		build-stage = 2
 		test-stage = 2
 		doc-stage = 2
-		build = "${rust_target}"
-		host = ["${rust_target}"]
+		build = "${RUSTBUILD:-${RUSTHOST}}"
+		host = ["${RUSTHOST}"]
 		target = [${rust_targets}]
 		cargo = "${rust_stage0_root}/bin/cargo"
 		rustc = "${rust_stage0_root}/bin/rustc"
@@ -409,7 +407,7 @@ src_configure() {
 	_EOF_
 
 	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_target=$(rust_abi $(get_abi_CHOST ${v##*.}))
+		rust_target=$(get_abi_RUSTHOST ${v##*.})
 		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
 
 		cat <<- _EOF_ >> "${S}"/config.env

--- a/dev-lang/rust/rust-1.61.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.61.0-r2.ebuild
@@ -172,7 +172,7 @@ bootstrap_rust_version_check() {
 	[[ ${MERGE_TYPE} == binary ]] && return
 	local rustc_wanted="$(ver_cut 1).$(($(ver_cut 2) - 1))"
 	local rustc_toonew="$(ver_cut 1).$(($(ver_cut 2) + 1))"
-	local rustc_version=( $(eselect --brief rust show 2>/dev/null) )
+	local rustc_version=( $(ROOT=${BROOT:-/} eselect --brief rust show 2>/dev/null) )
 	rustc_version=${rustc_version[0]#rust-bin-}
 	rustc_version=${rustc_version#rust-}
 
@@ -263,10 +263,10 @@ src_configure() {
 
 	# Collect rust target names to compile standard libs for all ABIs.
 	for v in $(get_all_abis); do
-		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v})\""
+		rust_targets+=",\"$(get_abi_RUSTHOST ${v})\""
 	done
 	if use wasm; then
-		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
+		rust_targets+=',"wasm32-unknown-unknown"'
 		if use system-llvm; then
 			# un-hardcode rust-lld linker for this target
 			# https://bugs.gentoo.org/715348
@@ -275,25 +275,13 @@ src_configure() {
 	fi
 	rust_targets="${rust_targets#,}"
 
-	local tools="\"cargo\","
-	if use clippy; then
-		tools="\"clippy\",$tools"
-	fi
-	if use miri; then
-		tools="\"miri\",$tools"
-	fi
-	if use profiler; then
-		tools="\"rust-demangler\",$tools"
-	fi
-	if use rls; then
-		tools="\"rls\",\"analysis\",$tools"
-	fi
-	if use rustfmt; then
-		tools="\"rustfmt\",$tools"
-	fi
-	if use rust-src; then
-		tools="\"src\",$tools"
-	fi
+	local tools='"cargo"'
+	use clippy && tools+=',"clippy"'
+	use miri && tools+=',"miri"'
+	use profiler && tools+=',"rust-demangler"'
+	use rls && tools+=',"rls","analysis"'
+	use rustfmt && tools+=',"rustfmt"'
+	use rust-src && tools+=',"src"'
 
 	local rust_stage0_root
 	if use system-bootstrap; then

--- a/dev-lang/rust/rust-1.61.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.61.0-r2.ebuild
@@ -262,8 +262,8 @@ src_configure() {
 	local rust_target="" rust_targets="" arch_cflags use_libcxx="false"
 
 	# Collect rust target names to compile standard libs for all ABIs.
-	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v##*.})\""
+	for v in $(get_all_abis); do
+		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v})\""
 	done
 	if use wasm; then
 		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
@@ -406,9 +406,9 @@ src_configure() {
 		compression-formats = ["xz"]
 	_EOF_
 
-	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_target=$(get_abi_RUSTHOST ${v##*.})
-		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+	for v in $(get_all_abis); do
+		arch_cflags=$(get_abi_CFLAGS ${v})
+		rust_target=$(get_abi_RUSTHOST ${v})
 
 		cat <<- _EOF_ >> "${S}"/config.env
 			CFLAGS_${rust_target}=${arch_cflags}

--- a/dev-lang/rust/rust-1.62.0.ebuild
+++ b/dev-lang/rust/rust-1.62.0.ebuild
@@ -259,8 +259,8 @@ src_configure() {
 	local rust_target="" rust_targets="" arch_cflags use_libcxx="false"
 
 	# Collect rust target names to compile standard libs for all ABIs.
-	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v##*.})\""
+	for v in $(get_all_abis); do
+		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v})\""
 	done
 	if use wasm; then
 		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
@@ -410,9 +410,9 @@ src_configure() {
 		compression-formats = ["xz"]
 	_EOF_
 
-	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_target=$(get_abi_RUSTHOST ${v##*.})
-		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+	for v in $(get_all_abis); do
+		arch_cflags=$(get_abi_CFLAGS ${v})
+		rust_target=$(get_abi_RUSTHOST ${v})
 
 		cat <<- _EOF_ >> "${S}"/config.env
 			CFLAGS_${rust_target}=${arch_cflags}

--- a/dev-lang/rust/rust-1.62.0.ebuild
+++ b/dev-lang/rust/rust-1.62.0.ebuild
@@ -169,7 +169,7 @@ bootstrap_rust_version_check() {
 	[[ ${MERGE_TYPE} == binary ]] && return
 	local rustc_wanted="$(ver_cut 1).$(($(ver_cut 2) - 1))"
 	local rustc_toonew="$(ver_cut 1).$(($(ver_cut 2) + 1))"
-	local rustc_version=( $(eselect --brief rust show 2>/dev/null) )
+	local rustc_version=( $(ROOT=${BROOT:-/} eselect --brief rust show 2>/dev/null) )
 	rustc_version=${rustc_version[0]#rust-bin-}
 	rustc_version=${rustc_version#rust-}
 
@@ -260,10 +260,10 @@ src_configure() {
 
 	# Collect rust target names to compile standard libs for all ABIs.
 	for v in $(get_all_abis); do
-		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v})\""
+		rust_targets+=",\"$(get_abi_RUSTHOST ${v})\""
 	done
 	if use wasm; then
-		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
+		rust_targets+=',"wasm32-unknown-unknown"'
 		if use system-llvm; then
 			# un-hardcode rust-lld linker for this target
 			# https://bugs.gentoo.org/715348
@@ -272,25 +272,13 @@ src_configure() {
 	fi
 	rust_targets="${rust_targets#,}"
 
-	local tools="\"cargo\","
-	if use clippy; then
-		tools="\"clippy\",$tools"
-	fi
-	if use miri; then
-		tools="\"miri\",$tools"
-	fi
-	if use profiler; then
-		tools="\"rust-demangler\",$tools"
-	fi
-	if use rls; then
-		tools="\"rls\",\"analysis\",$tools"
-	fi
-	if use rustfmt; then
-		tools="\"rustfmt\",$tools"
-	fi
-	if use rust-src; then
-		tools="\"src\",$tools"
-	fi
+	local tools='"cargo"'
+	use clippy && tools+=',"clippy"'
+	use miri && tools+=',"miri"'
+	use profiler && tools+=',"rust-demangler"'
+	use rls && tools+=',"rls","analysis"'
+	use rustfmt && tools+=',"rustfmt"'
+	use rust-src && tools+=',"src"'
 
 	local rust_stage0_root
 	if use system-bootstrap; then

--- a/dev-lang/rust/rust-1.62.0.ebuild
+++ b/dev-lang/rust/rust-1.62.0.ebuild
@@ -246,7 +246,7 @@ pkg_setup() {
 src_prepare() {
 	if ! use system-bootstrap; then
 		local rust_stage0_root="${WORKDIR}"/rust-stage0
-		local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
+		local rust_stage0="rust-${RUST_STAGE0_VERSION}-${RUSTHOST}"
 
 		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
 			--without=rust-docs --destdir="${rust_stage0_root}" --prefix=/ || die
@@ -260,7 +260,7 @@ src_configure() {
 
 	# Collect rust target names to compile standard libs for all ABIs.
 	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_targets="${rust_targets},\"$(rust_abi $(get_abi_CHOST ${v##*.}))\""
+		rust_targets="${rust_targets},\"$(get_abi_RUSTHOST ${v##*.})\""
 	done
 	if use wasm; then
 		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
@@ -303,8 +303,6 @@ src_configure() {
 	# in case of prefix it will be already prefixed, as --print sysroot returns full path
 	[[ -d ${rust_stage0_root} ]] || die "${rust_stage0_root} is not a directory"
 
-	rust_target="$(rust_abi)"
-
 	# https://bugs.gentoo.org/732632
 	if tc-is-clang; then
 		local clang_slot="$(clang-major-version)"
@@ -329,7 +327,7 @@ src_configure() {
 			echo "use-libcxx = true"
 			echo "static-libstdcpp = false"
 		fi)
-		$(case "${rust_target}" in
+		$(case ${RUSTHOST} in
 			i586-*-linux-*)
 				# https://github.com/rust-lang/rust/issues/93059
 				echo 'cflags = "-fcf-protection=none"'
@@ -351,8 +349,8 @@ src_configure() {
 		build-stage = 2
 		test-stage = 2
 		doc-stage = 2
-		build = "${rust_target}"
-		host = ["${rust_target}"]
+		build = "${RUSTBUILD:-${RUSTHOST}}"
+		host = ["${RUSTHOST}"]
 		target = [${rust_targets}]
 		cargo = "${rust_stage0_root}/bin/cargo"
 		rustc = "${rust_stage0_root}/bin/rustc"
@@ -413,7 +411,7 @@ src_configure() {
 	_EOF_
 
 	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_target=$(rust_abi $(get_abi_CHOST ${v##*.}))
+		rust_target=$(get_abi_RUSTHOST ${v##*.})
 		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
 
 		cat <<- _EOF_ >> "${S}"/config.env

--- a/eclass/multilib.eclass
+++ b/eclass/multilib.eclass
@@ -27,6 +27,7 @@ export CFLAGS_default
 export LDFLAGS_default
 export CHOST_default=${CHOST_default:-${CHOST}}
 export CTARGET_default=${CTARGET_default:-${CTARGET:-${CHOST_default}}}
+export RUSTHOST_default=${RUSTHOST_default:-${RUSTHOST}}
 export LIBDIR_default=${CONF_LIBDIR:-"lib"}
 export KERNEL_ABI=${KERNEL_ABI:-${DEFAULT_ABI}}
 
@@ -110,6 +111,12 @@ get_abi_CHOST() { get_abi_var CHOST "$@"; }
 # @DESCRIPTION:
 # Alias for 'get_abi_var CTARGET'
 get_abi_CTARGET() { get_abi_var CTARGET "$@"; }
+
+# @FUNCTION: get_abi_RUSTHOST
+# @USAGE: [ABI]
+# @DESCRIPTION:
+# Alias for 'get_abi_var RUSTHOST'
+get_abi_RUSTHOST() { get_abi_var RUSTHOST "$@"; }
 
 # @FUNCTION: get_abi_FAKE_TARGETS
 # @USAGE: [ABI]
@@ -519,6 +526,7 @@ multilib_toolchain_setup() {
 	local save_restore_variables=(
 		CBUILD
 		CHOST
+		RUSTHOST
 		AR
 		CC
 		CXX
@@ -584,6 +592,7 @@ multilib_toolchain_setup() {
 		export STRIP="$(tc-getSTRIP)" # Avoid 'strip', use '${CHOST}-strip'
 
 		export CHOST=$(get_abi_CHOST $1)
+		export RUSTHOST=$(get_abi_RUSTHOST $1)
 		export PKG_CONFIG_LIBDIR=${EPREFIX}/usr/$(get_libdir)/pkgconfig
 		export PKG_CONFIG_PATH=${EPREFIX}/usr/share/pkgconfig
 		export PKG_CONFIG_SYSTEM_INCLUDE_PATH=${EPREFIX}/usr/include

--- a/eclass/multilib.eclass
+++ b/eclass/multilib.eclass
@@ -25,6 +25,7 @@ export MULTILIB_ABIS=${MULTILIB_ABIS:-"default"}
 export DEFAULT_ABI=${DEFAULT_ABI:-"default"}
 export CFLAGS_default
 export LDFLAGS_default
+export RUSTFLAGS_default
 export CHOST_default=${CHOST_default:-${CHOST}}
 export CTARGET_default=${CTARGET_default:-${CTARGET:-${CHOST_default}}}
 export RUSTHOST_default=${RUSTHOST_default:-${RUSTHOST}}
@@ -99,6 +100,12 @@ get_abi_CFLAGS() { get_abi_var CFLAGS "$@"; }
 # @DESCRIPTION:
 # Alias for 'get_abi_var LDFLAGS'
 get_abi_LDFLAGS() { get_abi_var LDFLAGS "$@"; }
+
+# @FUNCTION: get_abi_RUSTFLAGS
+# @USAGE: [ABI]
+# @DESCRIPTION:
+# Alias for 'get_abi_var RUSTFLAGS'
+get_abi_RUSTFLAGS() { get_abi_var RUSTFLAGS "$@"; }
 
 # @FUNCTION: get_abi_CHOST
 # @USAGE: [ABI]
@@ -545,6 +552,7 @@ multilib_toolchain_setup() {
 		PKG_CONFIG_PATH
 		PKG_CONFIG_SYSTEM_INCLUDE_PATH
 		PKG_CONFIG_SYSTEM_LIBRARY_PATH
+		RUSTFLAGS
 	)
 
 	# First restore any saved state we have laying around.
@@ -597,6 +605,7 @@ multilib_toolchain_setup() {
 		export PKG_CONFIG_PATH=${EPREFIX}/usr/share/pkgconfig
 		export PKG_CONFIG_SYSTEM_INCLUDE_PATH=${EPREFIX}/usr/include
 		export PKG_CONFIG_SYSTEM_LIBRARY_PATH=${EPREFIX}/$(get_libdir):${EPREFIX}/usr/$(get_libdir)
+		export RUSTFLAGS=$(get_abi_RUSTFLAGS $1)
 	fi
 }
 

--- a/eclass/rust-toolchain.eclass
+++ b/eclass/rust-toolchain.eclass
@@ -29,18 +29,14 @@ inherit multilib-build
 # @DESCRIPTION:
 # Outputs a list of all the enabled Rust ABIs
 rust_all_abis() {
-	if use multilib; then
-		local ALL_ABIS=()
-		local abi abi_target
-		for abi in $(multilib_get_enabled_abis); do
-			abi_target="RUSTHOST_${abi}"
-			ALL_ABIS+=( ${!abi_target} )
-		done
-		local IFS=,
-		echo "${ALL_ABIS[*]}"
-	else
-		echo "${RUSTHOST}"
-	fi
+	local ALL_ABIS=()
+	local abi abi_target
+	for abi in $(get_all_abis); do
+		abi_target="RUSTHOST_${abi}"
+		ALL_ABIS+=( ${!abi_target} )
+	done
+	local IFS=,
+	echo "${ALL_ABIS[*]}"
 }
 
 # @FUNCTION: rust_arch_uri

--- a/gnome-base/librsvg/librsvg-2.54.3.ebuild
+++ b/gnome-base/librsvg/librsvg-2.54.3.ebuild
@@ -63,12 +63,12 @@ multilib_src_configure() {
 		$(multilib_native_use_enable introspection)
 		$(multilib_native_use_enable vala)
 		--enable-pixbuf-loader
+		# Set the rust target, which can differ from CHOST
+		RUST_TARGET="${RUSTHOST}"
 	)
 
 	if ! multilib_is_native_abi; then
 		myconf+=(
-			# Set the rust target, which can differ from CHOST
-			RUST_TARGET="$(rust_abi)"
 			# RUST_TARGET is only honored if cross_compiling, but non-native ABIs aren't cross as
 			# far as C parts and configure auto-detection are concerned as CHOST equals CBUILD
 			cross_compiling=yes

--- a/gnome-base/librsvg/librsvg-2.54.4.ebuild
+++ b/gnome-base/librsvg/librsvg-2.54.4.ebuild
@@ -32,7 +32,7 @@ RDEPEND="
 	introspection? ( >=dev-libs/gobject-introspection-0.10.8:= )
 "
 DEPEND="${RDEPEND}
-	>=virtual/rust-1.56[${MULTILIB_USEDEP}]
+	>=virtual/rust-1.56
 	${PYTHON_DEPS}
 	$(python_gen_any_dep 'dev-python/docutils[${PYTHON_USEDEP}]')
 	gtk-doc? ( dev-util/gi-docgen )

--- a/gnome-base/librsvg/librsvg-2.54.4.ebuild
+++ b/gnome-base/librsvg/librsvg-2.54.4.ebuild
@@ -62,12 +62,12 @@ multilib_src_configure() {
 		$(multilib_native_use_enable introspection)
 		$(multilib_native_use_enable vala)
 		--enable-pixbuf-loader
+		# Set the rust target, which can differ from CHOST
+		RUST_TARGET="${RUSTHOST}"
 	)
 
 	if ! multilib_is_native_abi; then
 		myconf+=(
-			# Set the rust target, which can differ from CHOST
-			RUST_TARGET="$(rust_abi)"
 			# RUST_TARGET is only honored if cross_compiling, but non-native ABIs aren't cross as
 			# far as C parts and configure auto-detection are concerned as CHOST equals CBUILD
 			cross_compiling=yes

--- a/net-libs/quiche/quiche-0.10.0.ebuild
+++ b/net-libs/quiche/quiche-0.10.0.ebuild
@@ -201,11 +201,11 @@ multilib_src_configure() {
 
 multilib_src_compile() {
 	BUILD_DIR="${BUILD_DIR}/deps/boringssl/build" cmake_src_compile bssl
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="${RUSTHOST}"
 }
 
 multilib_src_test() {
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test --target="${RUSTHOST}"
 }
 
 multilib_src_install() {
@@ -213,7 +213,7 @@ multilib_src_install() {
 	insinto "/usr/$(get_libdir)/pkgconfig"
 	doins target/release/quiche.pc
 	doheader -r include/*
-	dolib.so "target/$(rust_abi)/release/libquiche.so"
+	dolib.so "target/${RUSTHOST}/release/libquiche.so"
 	QA_FLAGS_IGNORED+=" usr/$(get_libdir)/libquiche.so" # rust libraries don't use LDFLAGS
 	QA_SONAME+=" usr/$(get_libdir)/libquiche.so" # https://github.com/cloudflare/quiche/issues/165
 }

--- a/net-libs/quiche/quiche-0.10.0.ebuild
+++ b/net-libs/quiche/quiche-0.10.0.ebuild
@@ -161,15 +161,12 @@ LICENSE="|| ( Apache-2.0 Boost-1.0 )
 	|| ( Unlicense MIT )
 	openssl"
 SLOT="0/0"
-IUSE=""
-DOCS=( CODEOWNERS  COPYING README.md )
+DOCS=( CODEOWNERS COPYING README.md )
 
 BDEPEND="
-	>=virtual/rust-1.47.0[${MULTILIB_USEDEP}]
 	dev-util/cmake
+	>=virtual/rust-1.47.0
 "
-DEPEND=""
-RDEPEND=""
 
 CMAKE_USE_DIR="${S}/deps/boringssl"
 BUILD_DIR="${WORKDIR}/${P}"

--- a/net-libs/quiche/quiche-0.11.0.ebuild
+++ b/net-libs/quiche/quiche-0.11.0.ebuild
@@ -206,19 +206,19 @@ multilib_src_configure() {
 
 multilib_src_compile() {
 	BUILD_DIR="${BUILD_DIR}/deps/boringssl/build" cmake_src_compile bssl
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="${RUSTHOST}"
 }
 
 multilib_src_test() {
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test --target="${RUSTHOST}"
 }
 
 multilib_src_install() {
-	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" target/$(rust_abi)/release/quiche.pc || die
+	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" "target/${RUSTHOST}/release/quiche.pc" || die
 	insinto "/usr/$(get_libdir)/pkgconfig"
-	doins target/$(rust_abi)/release/quiche.pc
+	doins "target/${RUSTHOST}/release/quiche.pc"
 	doheader -r include/*
-	dolib.so "target/$(rust_abi)/release/libquiche.so"
+	dolib.so "target/${RUSTHOST}/release/libquiche.so"
 	QA_FLAGS_IGNORED+=" usr/$(get_libdir)/libquiche.so" # rust libraries don't use LDFLAGS
 	QA_SONAME+=" usr/$(get_libdir)/libquiche.so" # https://github.com/cloudflare/quiche/issues/165
 }

--- a/net-libs/quiche/quiche-0.11.0.ebuild
+++ b/net-libs/quiche/quiche-0.11.0.ebuild
@@ -164,15 +164,12 @@ LICENSE="|| ( Apache-2.0 Boost-1.0 )
 	|| ( Unlicense MIT )
 	openssl"
 SLOT="0/0"
-IUSE=""
 DOCS=( COPYING README.md )
 
 BDEPEND="
-	>=virtual/rust-1.47.0[${MULTILIB_USEDEP}]
 	dev-util/cmake
+	>=virtual/rust-1.47.0
 "
-DEPEND=""
-RDEPEND=""
 
 BUILD_DIR="${WORKDIR}/${P}"
 

--- a/net-libs/quiche/quiche-0.12.0.ebuild
+++ b/net-libs/quiche/quiche-0.12.0.ebuild
@@ -202,19 +202,19 @@ multilib_src_configure() {
 
 multilib_src_compile() {
 	BUILD_DIR="${BUILD_DIR}/deps/boringssl/build" cmake_src_compile bssl
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="${RUSTHOST}"
 }
 
 multilib_src_test() {
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test --target="${RUSTHOST}"
 }
 
 multilib_src_install() {
-	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" target/$(rust_abi)/release/quiche.pc || die
+	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" "target/${RUSTHOST}/release/quiche.pc" || die
 	insinto "/usr/$(get_libdir)/pkgconfig"
-	doins target/$(rust_abi)/release/quiche.pc
+	doins "target/${RUSTHOST}/release/quiche.pc"
 	doheader -r include/*
-	dolib.so "target/$(rust_abi)/release/libquiche.so"
+	dolib.so "target/${RUSTHOST}/release/libquiche.so"
 	QA_FLAGS_IGNORED+=" usr/$(get_libdir)/libquiche.so" # rust libraries don't use LDFLAGS
 	QA_SONAME+=" usr/$(get_libdir)/libquiche.so" # https://github.com/cloudflare/quiche/issues/165
 }

--- a/net-libs/quiche/quiche-0.12.0.ebuild
+++ b/net-libs/quiche/quiche-0.12.0.ebuild
@@ -164,15 +164,12 @@ LICENSE="|| ( Apache-2.0 Boost-1.0 )
 	|| ( Unlicense MIT )
 	openssl"
 SLOT="0/0"
-IUSE=""
 DOCS=( COPYING README.md )
 
 BDEPEND="
-	>=virtual/rust-1.47.0[${MULTILIB_USEDEP}]
 	dev-util/cmake
+	>=virtual/rust-1.47.0
 "
-DEPEND=""
-RDEPEND=""
 
 BUILD_DIR="${WORKDIR}/${P}"
 

--- a/net-libs/quiche/quiche-0.13.0.ebuild
+++ b/net-libs/quiche/quiche-0.13.0.ebuild
@@ -217,19 +217,19 @@ multilib_src_configure() {
 
 multilib_src_compile() {
 	BUILD_DIR="${BUILD_DIR}/deps/boringssl/build" cmake_src_compile bssl
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="${RUSTHOST}"
 }
 
 multilib_src_test() {
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="${RUSTHOST}"
 }
 
 multilib_src_install() {
-	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" target/$(rust_abi)/release/quiche.pc || die
+	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" "target/${RUSTHOST}/release/quiche.pc" || die
 	insinto "/usr/$(get_libdir)/pkgconfig"
-	doins target/$(rust_abi)/release/quiche.pc
+	doins "target/${RUSTHOST}/release/quiche.pc"
 	doheader -r include/*
-	dolib.so "target/$(rust_abi)/release/libquiche.so"
+	dolib.so "target/${RUSTHOST}/release/libquiche.so"
 	QA_FLAGS_IGNORED+=" usr/$(get_libdir)/libquiche.so" # rust libraries don't use LDFLAGS
 	QA_SONAME+=" usr/$(get_libdir)/libquiche.so" # https://github.com/cloudflare/quiche/issues/165
 }

--- a/net-libs/quiche/quiche-0.13.0.ebuild
+++ b/net-libs/quiche/quiche-0.13.0.ebuild
@@ -179,15 +179,12 @@ LICENSE="|| ( Apache-2.0 Boost-1.0 )
 	|| ( Unlicense MIT )
 	openssl"
 SLOT="0/0"
-IUSE=""
 DOCS=( COPYING README.md )
 
 BDEPEND="
-	>=virtual/rust-1.47.0[${MULTILIB_USEDEP}]
 	dev-util/cmake
+	>=virtual/rust-1.47.0
 "
-DEPEND=""
-RDEPEND=""
 
 BUILD_DIR="${WORKDIR}/${P}"
 

--- a/net-libs/quiche/quiche-0.14.0.ebuild
+++ b/net-libs/quiche/quiche-0.14.0.ebuild
@@ -218,19 +218,19 @@ multilib_src_configure() {
 
 multilib_src_compile() {
 	BUILD_DIR="${BUILD_DIR}/deps/boringssl/build" cmake_src_compile bssl
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="${RUSTHOST}"
 }
 
 multilib_src_test() {
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="${RUSTHOST}"
 }
 
 multilib_src_install() {
-	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" target/$(rust_abi)/release/quiche.pc || die
+	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" "target/${RUSTHOST}/release/quiche.pc" || die
 	insinto "/usr/$(get_libdir)/pkgconfig"
-	doins target/$(rust_abi)/release/quiche.pc
+	doins "target/${RUSTHOST}/release/quiche.pc"
 	doheader -r include/*
-	dolib.so "target/$(rust_abi)/release/libquiche.so"
+	dolib.so "target/${RUSTHOST}/release/libquiche.so"
 	QA_FLAGS_IGNORED+=" usr/$(get_libdir)/libquiche.so" # rust libraries don't use LDFLAGS
 	QA_SONAME+=" usr/$(get_libdir)/libquiche.so" # https://github.com/cloudflare/quiche/issues/165
 }

--- a/net-libs/quiche/quiche-0.14.0.ebuild
+++ b/net-libs/quiche/quiche-0.14.0.ebuild
@@ -180,15 +180,12 @@ LICENSE="|| ( Apache-2.0 Boost-1.0 )
 	|| ( Unlicense MIT )
 	openssl"
 SLOT="0/0"
-IUSE=""
 DOCS=( COPYING README.md )
 
 BDEPEND="
-	>=virtual/rust-1.47.0[${MULTILIB_USEDEP}]
 	dev-util/cmake
+	>=virtual/rust-1.47.0
 "
-DEPEND=""
-RDEPEND=""
 
 BUILD_DIR="${WORKDIR}/${P}"
 

--- a/net-libs/quiche/quiche-0.9.0-r1.ebuild
+++ b/net-libs/quiche/quiche-0.9.0-r1.ebuild
@@ -201,11 +201,11 @@ multilib_src_configure() {
 
 multilib_src_compile() {
 	BUILD_DIR="${BUILD_DIR}/deps/boringssl/build" cmake_src_compile bssl
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="${RUSTHOST}"
 }
 
 multilib_src_test() {
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test --target="${RUSTHOST}"
 }
 
 multilib_src_install() {
@@ -213,7 +213,7 @@ multilib_src_install() {
 	insinto "/usr/$(get_libdir)/pkgconfig"
 	doins target/release/quiche.pc
 	doheader -r include/*
-	dolib.so "target/$(rust_abi)/release/libquiche.so"
+	dolib.so "target/${RUSTHOST}/release/libquiche.so"
 	QA_FLAGS_IGNORED+=" usr/$(get_libdir)/libquiche.so" # rust libraries don't use LDFLAGS
 	QA_SONAME+=" usr/$(get_libdir)/libquiche.so" # https://github.com/cloudflare/quiche/issues/165
 }

--- a/net-libs/quiche/quiche-0.9.0-r1.ebuild
+++ b/net-libs/quiche/quiche-0.9.0-r1.ebuild
@@ -161,15 +161,12 @@ LICENSE="|| ( Apache-2.0 Boost-1.0 )
 	|| ( Unlicense MIT )
 	openssl"
 SLOT="0/0"
-IUSE=""
-DOCS=( CODEOWNERS  COPYING README.md )
+DOCS=( CODEOWNERS COPYING README.md )
 
 BDEPEND="
-	>=virtual/rust-1.47.0[${MULTILIB_USEDEP}]
 	dev-util/cmake
+	>=virtual/rust-1.47.0
 "
-DEPEND=""
-RDEPEND=""
 
 CMAKE_USE_DIR="${S}/deps/boringssl"
 BUILD_DIR="${WORKDIR}/${P}"

--- a/net-libs/quiche/quiche-9999.ebuild
+++ b/net-libs/quiche/quiche-9999.ebuild
@@ -180,15 +180,12 @@ LICENSE="|| ( Apache-2.0 Boost-1.0 )
 	|| ( Unlicense MIT )
 	openssl"
 SLOT="0/0"
-IUSE=""
 DOCS=( COPYING README.md )
 
 BDEPEND="
-	>=virtual/rust-1.47.0[${MULTILIB_USEDEP}]
 	dev-util/cmake
+	>=virtual/rust-1.47.0
 "
-DEPEND=""
-RDEPEND=""
 
 BUILD_DIR="${WORKDIR}/${P}"
 

--- a/net-libs/quiche/quiche-9999.ebuild
+++ b/net-libs/quiche/quiche-9999.ebuild
@@ -218,19 +218,19 @@ multilib_src_configure() {
 
 multilib_src_compile() {
 	BUILD_DIR="${BUILD_DIR}/deps/boringssl/build" cmake_src_compile bssl
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_compile --features "ffi pkg-config-meta" --target="${RUSTHOST}"
 }
 
 multilib_src_test() {
-	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test  --target="$(rust_abi)"
+	QUICHE_BSSL_PATH="${BUILD_DIR}/deps/boringssl" cargo_src_test --target="${RUSTHOST}"
 }
 
 multilib_src_install() {
-	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" target/$(rust_abi)/release/quiche.pc || die
+	sed -i -e "s:libdir=.\+:libdir=${EPREFIX}/usr/$(get_libdir):" -e "s:includedir=.\+:includedir=${EPREFIX}/usr/include:" "target/${RUSTHOST}/release/quiche.pc" || die
 	insinto "/usr/$(get_libdir)/pkgconfig"
-	doins target/$(rust_abi)/release/quiche.pc
+	doins "target/${RUSTHOST}/release/quiche.pc"
 	doheader -r include/*
-	dolib.so "target/$(rust_abi)/release/libquiche.so"
+	dolib.so "target/${RUSTHOST}/release/libquiche.so"
 	QA_FLAGS_IGNORED+=" usr/$(get_libdir)/libquiche.so" # rust libraries don't use LDFLAGS
 	QA_SONAME+=" usr/$(get_libdir)/libquiche.so" # https://github.com/cloudflare/quiche/issues/165
 }

--- a/profiles/arch/amd64/make.defaults
+++ b/profiles/arch/amd64/make.defaults
@@ -5,6 +5,7 @@ ARCH="amd64"
 ACCEPT_KEYWORDS="${ARCH}"
 
 CHOST="x86_64-pc-linux-gnu"
+RUSTHOST="x86_64-unknown-linux-gnu"
 CFLAGS="-O2 -pipe"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
@@ -26,16 +27,19 @@ SYMLINK_LIB="no"
 CFLAGS_amd64="-m64"
 LDFLAGS_amd64="-m elf_x86_64"
 CHOST_amd64="x86_64-pc-linux-gnu"
+RUSTHOST_amd64="x86_64-unknown-linux-gnu"
 
 # 32bit specific settings.
 CFLAGS_x86="-m32"
 LDFLAGS_x86="-m elf_i386"
 CHOST_x86="i686-pc-linux-gnu"
+RUSTHOST_x86="i686-unknown-linux-gnu"
 
 # 64-32bit specific settings.
 CFLAGS_x32="-mx32"
 LDFLAGS_x32="-m elf32_x86_64"
 CHOST_x32="x86_64-pc-linux-gnux32"
+RUSTHOST_x32="x86_64-unknown-linux-gnux32"
 
 # Simon Stelling <blubb@gentoo.org> (2006-10-24)
 # They are masked, but we can enable them anyway for those who have

--- a/profiles/arch/arm/armv4t/make.defaults
+++ b/profiles/arch/arm/armv4t/make.defaults
@@ -1,5 +1,7 @@
 CHOST="armv4tl-softfloat-linux-gnueabi"
+RUSTHOST="armv4t-unknown-linux-gnueabi"
 CHOST_arm="${CHOST}"
+RUSTHOST_arm="${RUSTHOST}"
 
 CFLAGS="-O2 -pipe -march=armv4t"
 CXXFLAGS="${CFLAGS}"

--- a/profiles/arch/arm/armv5te/make.defaults
+++ b/profiles/arch/arm/armv5te/make.defaults
@@ -1,5 +1,7 @@
 CHOST="armv5tel-softfloat-linux-gnueabi"
+RUSTHOST="armv5te-unknown-linux-gnueabi"
 CHOST_arm="${CHOST}"
+RUSTHOST_arm="${RUSTHOST}"
 
 CFLAGS="-O2 -pipe -march=armv5te"
 CXXFLAGS="${CFLAGS}"

--- a/profiles/arch/arm/armv6j/make.defaults
+++ b/profiles/arch/arm/armv6j/make.defaults
@@ -1,5 +1,7 @@
 CHOST="armv6j-unknown-linux-gnueabihf"
+RUSTHOST="arm-unknown-linux-gnueabihf"
 CHOST_arm="${CHOST}"
+RUSTHOST_arm="${RUSTHOST}"
 
 CFLAGS="-O2 -pipe -march=armv6j"
 CXXFLAGS="${CFLAGS}"

--- a/profiles/arch/arm/armv7a/make.defaults
+++ b/profiles/arch/arm/armv7a/make.defaults
@@ -1,5 +1,7 @@
 CHOST="armv7a-unknown-linux-gnueabihf"
+RUSTHOST="armv7-unknown-linux-gnueabihf"
 CHOST_arm="${CHOST}"
+RUSTHOST_arm="${RUSTHOST}"
 
 CFLAGS="-O2 -pipe -march=armv7-a"
 CXXFLAGS="${CFLAGS}"

--- a/profiles/arch/arm64/big-endian/make.defaults
+++ b/profiles/arch/arm64/big-endian/make.defaults
@@ -1,4 +1,6 @@
 # Big endian ARM64 settings.
 
 CHOST="aarch64_be-unknown-linux-gnu"
+RUSTHOST="aarch64_be-unknown-linux-gnu"
 CHOST_arm64="${CHOST}"
+RUSTHOST_arm64="${RUSTHOST}"

--- a/profiles/arch/arm64/little-endian/make.defaults
+++ b/profiles/arch/arm64/little-endian/make.defaults
@@ -1,4 +1,6 @@
 # Little endian ARM64 settings.
 
 CHOST="aarch64-unknown-linux-gnu"
+RUSTHOST="aarch64-unknown-linux-gnu"
 CHOST_arm64="${CHOST}"
+RUSTHOST_arm64="${RUSTHOST}"

--- a/profiles/arch/m68k/make.defaults
+++ b/profiles/arch/m68k/make.defaults
@@ -1,10 +1,11 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 ARCH="m68k"
 ACCEPT_KEYWORDS="m68k ~m68k"
 
 CHOST="m68k-unknown-linux-gnu"
+RUSTHOST="m68k-unknown-linux-gnu"
 CFLAGS="-O2 -pipe"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
@@ -18,6 +19,7 @@ DEFAULT_ABI="m68k"
 MULTILIB_ABIS="m68k"
 LIBDIR_m68k="lib"
 CHOST_m68k="${CHOST}"
+RUSTHOST_m68k="${RUSTHOST}"
 
 # Disable sandbox on this architecture
 FEATURES="-sandbox"

--- a/profiles/arch/mips/mips64/multilib/make.defaults
+++ b/profiles/arch/mips/mips64/multilib/make.defaults
@@ -11,12 +11,14 @@ FCFLAGS="${CFLAGS}"
 
 CFLAGS_o32="-mabi=32"
 CHOST_o32="${CHOST}"
+RUSTHOST_o32="mips-unknown-linux-gnu"
 
 CFLAGS_n32="-mabi=n32"
 CHOST_n32="${CHOST}"
 
 CFLAGS_n64="-mabi=64"
 CHOST_n64="${CHOST}"
+RUSTHOST_n64="mips64-unknown-linux-gnuabi64"
 
 SYMLINK_LIB="no"
 

--- a/profiles/arch/mips/mips64/n64/make.defaults
+++ b/profiles/arch/mips/mips64/n64/make.defaults
@@ -4,11 +4,13 @@
 PROFILE_ARCH="mips64"
 
 CHOST="mips64-unknown-linux-gnu"
+RUSTHOST="mips64-unknown-linux-gnuabi64"
 
 DEFAULT_ABI="n64"
 ABI="${DEFAULT_ABI}"
 MULTILIB_ABIS="n64"
 CHOST_n64="${CHOST}"
+RUSTHOST_n64="${RUSTHOST}"
 
 ABI_MIPS="n64"
 IUSE_IMPLICIT="abi_mips_n64"

--- a/profiles/arch/mips/mipsel/mips64el/multilib/make.defaults
+++ b/profiles/arch/mips/mipsel/mips64el/multilib/make.defaults
@@ -11,12 +11,14 @@ FCFLAGS="${CFLAGS}"
 
 CFLAGS_o32="-mabi=32"
 CHOST_o32="${CHOST}"
+RUSTHOST_o32="mipsel-unknown-linux-gnu"
 
 CFLAGS_n32="-mabi=n32"
 CHOST_n32="${CHOST}"
 
 CFLAGS_n64="-mabi=64"
 CHOST_n64="${CHOST}"
+RUSTHOST_n64="mips64el-unknown-linux-gnuabi64"
 
 SYMLINK_LIB="no"
 

--- a/profiles/arch/mips/mipsel/mips64el/n64/make.defaults
+++ b/profiles/arch/mips/mipsel/mips64el/n64/make.defaults
@@ -4,11 +4,13 @@
 PROFILE_ARCH="mips64el"
 
 CHOST="mips64el-unknown-linux-gnu"
+RUSTHOST="mips64el-unknown-linux-gnuabi64"
 
 DEFAULT_ABI="n64"
 ABI="${DEFAULT_ABI}"
 MULTILIB_ABIS="n64"
 CHOST_n64="${CHOST}"
+RUSTHOST_n64="${RUSTHOST}"
 
 ABI_MIPS="n64"
 IUSE_IMPLICIT="abi_mips_n64"

--- a/profiles/arch/mips/mipsel/o32/make.defaults
+++ b/profiles/arch/mips/mipsel/o32/make.defaults
@@ -4,7 +4,9 @@
 PROFILE_ARCH="mipsel"
 
 CHOST="mipsel-unknown-linux-gnu"
-CHOST_o32="mipsel-unknown-linux-gnu"
+RUSTHOST="mipsel-unknown-linux-gnu"
+CHOST_o32="${CHOST}"
+RUSTHOST_o32="${RUSTHOST}"
 
 ABI="o32"
 DEFAULT_ABI="o32"

--- a/profiles/arch/mips/o32/make.defaults
+++ b/profiles/arch/mips/o32/make.defaults
@@ -4,7 +4,9 @@
 PROFILE_ARCH="mips"
 
 CHOST="mips-unknown-linux-gnu"
-CHOST_o32="mips-unknown-linux-gnu"
+RUSTHOST="mips-unknown-linux-gnu"
+CHOST_o32="${CHOST}"
+RUSTHOST_o32="${RUSTHOST}"
 
 ABI="o32"
 DEFAULT_ABI="o32"

--- a/profiles/arch/powerpc/ppc32/make.defaults
+++ b/profiles/arch/powerpc/ppc32/make.defaults
@@ -8,6 +8,7 @@ ARCH="ppc"
 ACCEPT_KEYWORDS="ppc"
 
 CHOST="powerpc-unknown-linux-gnu"
+RUSTHOST="powerpc-unknown-linux-gnu"
 CFLAGS="-O2 -pipe"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
@@ -23,6 +24,7 @@ ABI="ppc"
 DEFAULT_ABI="ppc"
 MULTILIB_ABIS="ppc"
 CHOST_ppc="${CHOST}"
+RUSTHOST_ppc="${RUSTHOST}"
 LIBDIR_ppc="lib"
 
 # Michał Górny <mgorny@gentoo.org> (2014-06-27)

--- a/profiles/arch/powerpc/ppc64/32ul/make.defaults
+++ b/profiles/arch/powerpc/ppc64/32ul/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # All extra USE/etc should be specified in sub-profiles.
@@ -6,6 +6,7 @@
 
 ARCH="ppc"
 CHOST="powerpc-unknown-linux-gnu"
+RUSTHOST="powerpc-unknown-linux-gnu"
 ABI="ppc"
 MULTILIB_ABIS="ppc"
 DEFAULT_ABI="ppc"

--- a/profiles/arch/powerpc/ppc64/64le/make.defaults
+++ b/profiles/arch/powerpc/ppc64/64le/make.defaults
@@ -1,11 +1,13 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="powerpc64le-unknown-linux-gnu"
+RUSTHOST="powerpc64le-unknown-linux-gnu"
 CFLAGS="-O2 -pipe"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
 FCFLAGS="${CFLAGS}"
 
-CHOST_ppc64="powerpc64le-unknown-linux-gnu"
+CHOST_ppc64="${CHOST}"
+RUSTHOST_ppc64="${RUSTHOST}"
 CHOST_ppc="powerpcle-unknown-linux-gnu"

--- a/profiles/arch/powerpc/ppc64/make.defaults
+++ b/profiles/arch/powerpc/ppc64/make.defaults
@@ -8,6 +8,7 @@ ARCH="ppc64"
 ACCEPT_KEYWORDS="${ARCH}"
 
 CHOST="powerpc64-unknown-linux-gnu"
+RUSTHOST="powerpc64-unknown-linux-gnu"
 CFLAGS="-O2 -pipe"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
@@ -23,11 +24,13 @@ ABI="ppc64"
 
 #CFLAGS_ppc64="-m64"
 LDFLAGS_ppc64="-m elf64ppc"
-CHOST_ppc64="powerpc64-unknown-linux-gnu"
+CHOST_ppc64="${CHOST}"
+RUSTHOST_ppc64="${RUSTHOST}"
 
 CFLAGS_ppc="-m32"
 LDFLAGS_ppc="-m elf32ppc"
 CHOST_ppc="powerpc-unknown-linux-gnu"
+RUSTHOST_ppc="powerpc-unknown-linux-gnu"
 
 # Michał Górny <mgorny@gentoo.org> (2014-06-27)
 # Make the ABI flag implicit for compatibility with native ebuilds.

--- a/profiles/arch/riscv/make.defaults
+++ b/profiles/arch/riscv/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Main RISC-V profile directory. Common settings for all riscv profiles.
@@ -29,6 +29,7 @@ LIBDIR_lp64d="lib64/lp64d"
 CFLAGS_lp64d="-mabi=lp64d"
 LDFLAGS_lp64d="-m elf64lriscv"
 CHOST_lp64d="riscv64-unknown-linux-gnu"
+RUSTHOST_lp64d="riscv64gc-unknown-linux-gnu"
 
 # Flags for lp64
 LIBDIR_lp64="lib64/lp64"
@@ -41,6 +42,7 @@ LIBDIR_ilp32d="lib32/ilp32d"
 CFLAGS_ilp32d="-mabi=ilp32d -march=rv32imafdc"
 LDFLAGS_ilp32d="-m elf32lriscv"
 CHOST_ilp32d="riscv32-unknown-linux-gnu"
+RUSTHOST_ilp32d="riscv32gc-unknown-linux-gnu"
 
 # Flags for ilp32
 LIBDIR_ilp32="lib32/ilp32"

--- a/profiles/arch/riscv/rv32imac/ilp32d/make.defaults
+++ b/profiles/arch/riscv/rv32imac/ilp32d/make.defaults
@@ -4,6 +4,7 @@
 # RISC-V rv32imac/ilp32d no-multilib profile
 
 CHOST="riscv32-unknown-linux-gnu"
+RUSTHOST="riscv32gc-unknown-linux-gnu"
 
 MULTILIB_ABIS="ilp32d"
 DEFAULT_ABI="ilp32d"

--- a/profiles/arch/riscv/rv64gc/lp64d-multilib/make.defaults
+++ b/profiles/arch/riscv/rv64gc/lp64d-multilib/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # RISC-V profile for rv64gc multilib
@@ -7,6 +7,7 @@
 # stages just fine, but the only "hardware" that can run them is qemu-user ...
 
 CHOST="riscv64-unknown-linux-gnu"
+RUSTHOST="riscv64gc-unknown-linux-gnu"
 
 # Multilib ABIs
 MULTILIB_ABIS="lp64d lp64 ilp32d ilp32"

--- a/profiles/arch/riscv/rv64gc/lp64d/make.defaults
+++ b/profiles/arch/riscv/rv64gc/lp64d/make.defaults
@@ -4,6 +4,7 @@
 # RISC-V rv64gc/lp64d no-multilib profile
 
 CHOST="riscv64-unknown-linux-gnu"
+RUSTHOST="riscv64gc-unknown-linux-gnu"
 
 MULTILIB_ABIS="lp64d"
 DEFAULT_ABI="lp64d"

--- a/profiles/arch/s390/s390x/make.defaults
+++ b/profiles/arch/s390/s390x/make.defaults
@@ -6,6 +6,7 @@ DEFAULT_ABI="s390x"
 ABI="${DEFAULT_ABI}"
 
 CHOST="s390x-ibm-linux-gnu"
+RUSTHOST="s390x-unknown-linux-gnu"
 
 # Michał Górny <mgorny@gentoo.org> (2014-07-01)
 # Make the native ABI implicit so that MULTILIB_USEDEP can be satisfied

--- a/profiles/arch/sparc/32ul/make.defaults
+++ b/profiles/arch/sparc/32ul/make.defaults
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="sparc-unknown-linux-gnu"
+RUSTHOST="sparc-unknown-linux-gnu"
 
 # Multilib stuff
 MULTILIB_ABIS="sparc32"

--- a/profiles/arch/sparc/64ul/make.defaults
+++ b/profiles/arch/sparc/64ul/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 MULTILIB_ABIS="sparc64"
@@ -6,3 +6,4 @@ DEFAULT_ABI="sparc64"
 ABI="${DEFAULT_ABI}"
 
 CHOST="sparc64-unknown-linux-gnu"
+RUSTHOST="sparc64-unknown-linux-gnu"

--- a/profiles/arch/sparc/make.defaults
+++ b/profiles/arch/sparc/make.defaults
@@ -13,6 +13,7 @@ CTARGETS_BINUTILS="sparc-unknown-linux-gnu sparc64-unknown-linux-gnu"
 # The funky stuffs for handling different kernel compiler than userland compiler
 KERNEL_ABI="sparc64"
 CHOST_sparc64="sparc64-unknown-linux-gnu"
+RUSTHOST_sparc64="sparc64-unknown-linux-gnu"
 LDFLAGS_sparc64="-m elf64_sparc"
 
 # Multilib stuff
@@ -20,6 +21,7 @@ CFLAGS_sparc32=""  # 32 bit is the default, so no need to set it.
 LDFLAGS_sparc32="" # setting it would make gcc use -m32 and -m64 at the same time
 CHOST_sparc32="sparc-unknown-linux-gnu"
 CTARGET_sparc32="sparc-unknown-linux-gnu"
+RUSTHOST_sparc32="sparc-unknown-linux-gnu"
 # do NOT set CFLAGS_sparc64 here it'd break linux-headers for non-multilib
 # profiles
 

--- a/profiles/arch/x86/make.defaults
+++ b/profiles/arch/x86/make.defaults
@@ -8,6 +8,7 @@ ARCH="x86"
 ACCEPT_KEYWORDS="x86"
 
 CHOST="i686-pc-linux-gnu"
+RUSTHOST="i686-unknown-linux-gnu"
 CFLAGS="-O2 -march=i686 -pipe"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
@@ -24,6 +25,7 @@ MULTILIB_ABIS="x86"
 DEFAULT_ABI="x86"
 ABI="x86"
 CHOST_x86="${CHOST}"
+RUSTHOST_x86="${RUSTHOST}"
 LIBDIR_x86="lib"
 
 # Donnie Berkholz <dberkholz@gentoo.org> (2006-08-18)

--- a/profiles/default/linux/amd64/17.0/musl/make.defaults
+++ b/profiles/default/linux/amd64/17.0/musl/make.defaults
@@ -1,10 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="x86_64-gentoo-linux-musl"
+RUSTHOST="x86_64-unknown-linux-musl"
 
 # Anthony G. Basile <blueness@gentoo.org> (2014-07-01)
 # Multilib-related setup, bug #515130
 MULTILIB_ABIS="amd64"
 CHOST_amd64="${CHOST}"
+RUSTHOST_amd64="${RUSTHOST}"
 LIBDIR_amd64="lib"

--- a/profiles/default/linux/amd64/17.0/x32/make.defaults
+++ b/profiles/default/linux/amd64/17.0/x32/make.defaults
@@ -1,4 +1,5 @@
-# Copyright 1999-2013 Gentoo Foundation.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="x86_64-pc-linux-gnux32"
+RUSTHOST="x86_64-unknown-linux-gnux32"

--- a/profiles/default/linux/arm/17.0/musl/armv6j/make.defaults
+++ b/profiles/default/linux/arm/17.0/musl/armv6j/make.defaults
@@ -1,8 +1,10 @@
-# Copyright 1999-2018 Gentoo Foundation.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="armv6j-unknown-linux-musleabihf"
+RUSTHOST="arm-unknown-linux-musleabihf"
 CHOST_arm="${CHOST}"
+RUSTHOST_arm="${RUSTHOST}"
 
 CFLAGS="-O2 -pipe -march=armv6j -mfpu=vfp -mfloat-abi=hard"
 CXXFLAGS="${CFLAGS}"

--- a/profiles/default/linux/arm/17.0/musl/armv7a/make.defaults
+++ b/profiles/default/linux/arm/17.0/musl/armv7a/make.defaults
@@ -1,8 +1,10 @@
-# Copyright 1999-2018 Gentoo Foundation.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="armv7a-unknown-linux-musleabihf"
+RUSTHOST="armv7-unknown-linux-musleabihf"
 CHOST_arm="${CHOST}"
+RUSTHOST_arm="${RUSTHOST}"
 
 CFLAGS="-O2 -pipe -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard"
 CXXFLAGS="${CFLAGS}"

--- a/profiles/default/linux/arm64/17.0/musl/make.defaults
+++ b/profiles/default/linux/arm64/17.0/musl/make.defaults
@@ -1,10 +1,11 @@
-# Copyright 1999-2016 Gentoo Foundation.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 ARCH="arm64"
 ACCEPT_KEYWORDS="${ARCH}"
 
 CHOST="aarch64-gentoo-linux-musl"
+RUSTHOST="aarch64-unknown-linux-musl"
 CFLAGS="-O2"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
@@ -16,6 +17,7 @@ ABI="arm64"
 DEFAULT_ABI="arm64"
 MULTILIB_ABIS="arm64"
 CHOST_arm64="${CHOST}"
+RUSTHOST_arm64="${RUSTHOST}"
 LIBDIR_arm64="lib"
 
 # Michał Górny <mgorny@gentoo.org> (2017-03-14)

--- a/profiles/default/linux/musl/mips/make.defaults
+++ b/profiles/default/linux/musl/mips/make.defaults
@@ -1,10 +1,11 @@
-# Copyright 1999-2014 Gentoo Foundation.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 ARCH="mips"
 ACCEPT_KEYWORDS="${ARCH} ~${ARCH}"
 
 CHOST="mips-gentoo-linux-musl"
+RUSTHOST="mips-unknown-linux-musl"
 CFLAGS="-O2 -pipe"
 CXXFLAGS="${CFLAGS}"
 FFLAGS="${CFLAGS}"
@@ -16,5 +17,6 @@ ABI="o32"
 DEFAULT_ABI="o32"
 MULTILIB_ABIS="o32"
 CHOST_o32="${CHOST}"
+RUSTHOST_o32="${RUSTHOST}"
 LIBDIR_o32="lib"
 IUSE_IMPLICIT="abi_mips_o32"

--- a/profiles/default/linux/musl/mips/mipsel/make.defaults
+++ b/profiles/default/linux/musl/mips/mipsel/make.defaults
@@ -1,8 +1,10 @@
-# Copyright 1999-2014 Gentoo Foundation.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="mipsel-gentoo-linux-musl"
+RUSTHOST="mipsel-unknown-linux-musl"
 CHOST_o32="${CHOST}"
+RUSTHOST_o32="${RUSTHOST}"
 
 # Disable sandbox because its currently broken on mipsel-musl
 FEATURES="-sandbox"

--- a/profiles/default/linux/powerpc/ppc32/17.0/musl/make.defaults
+++ b/profiles/default/linux/powerpc/ppc32/17.0/musl/make.defaults
@@ -1,10 +1,12 @@
-# Copyright 1999-2018 Gentoo Foundation.
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="powerpc-gentoo-linux-musl"
+RUSTHOST="powerpc-unknown-linux-musl"
 
 # Anthony G. Basile <blueness@gentoo.org> (2014-07-01)
 # Multilib-related setup, bug #515130
 MULTILIB_ABIS="ppc"
 CHOST_ppc="${CHOST}"
+RUSTHOST_ppc="${RUSTHOST}"
 LIBDIR_ppc="lib"

--- a/profiles/default/linux/ppc/17.0/musl/make.defaults
+++ b/profiles/default/linux/ppc/17.0/musl/make.defaults
@@ -1,10 +1,12 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="powerpc-gentoo-linux-musl"
+RUSTHOST="powerpc-unknown-linux-musl"
 
 # Anthony G. Basile <blueness@gentoo.org> (2014-07-01)
 # Multilib-related setup, bug #515130
 MULTILIB_ABIS="ppc"
 CHOST_ppc="${CHOST}"
+RUSTHOST_ppc="${RUSTHOST}"
 LIBDIR_ppc="lib"

--- a/profiles/default/linux/ppc64/17.0/musl/make.defaults
+++ b/profiles/default/linux/ppc64/17.0/musl/make.defaults
@@ -1,6 +1,8 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="powerpc64-gentoo-linux-musl"
+RUSTHOST="powerpc64-unknown-linux-musl"
 CHOST_ppc64="${CHOST}"
+RUSTHOST_ppc64="${RUSTHOST}"
 LIBDIR_ppc64="lib"

--- a/profiles/default/linux/ppc64le/17.0/musl/make.defaults
+++ b/profiles/default/linux/ppc64le/17.0/musl/make.defaults
@@ -1,6 +1,8 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="powerpc64le-gentoo-linux-musl"
+RUSTHOST="powerpc64le-unknown-linux-musl"
 CHOST_ppc64="${CHOST}"
+RUSTHOST_ppc64="${RUSTHOST}"
 LIBDIR_ppc64="lib"

--- a/profiles/default/linux/riscv/20.0/rv64gc/lp64d/musl/make.defaults
+++ b/profiles/default/linux/riscv/20.0/rv64gc/lp64d/musl/make.defaults
@@ -2,7 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="riscv64-gentoo-linux-musl"
+RUSTHOST="riscv64gc-unknown-linux-musl"
 
-CHOST_lp64d="riscv64-gentoo-linux-musl"
+CHOST_lp64d="${CHOST}"
+RUSTHOST_lp64d="${RUSTHOST}"
 
 LIBDIR_lp64d="lib"

--- a/profiles/default/linux/x86/17.0/musl/make.defaults
+++ b/profiles/default/linux/x86/17.0/musl/make.defaults
@@ -1,5 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 CHOST="i686-gentoo-linux-musl"
+RUSTHOST="i686-unknown-linux-musl"
 CHOST_x86="${CHOST}"
+RUSTHOST_x86="${RUSTHOST}"

--- a/sys-devel/rust-std/rust-std-1.59.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.59.0.ebuild
@@ -76,10 +76,9 @@ src_configure() {
 
 	local rust_root x
 	rust_root="$(rustc --print sysroot)"
-	rtarget="$(rust_abi ${CTARGET})"
-	rtarget="${ERUST_STD_RTARGET:-${rtarget}}" # some targets need to be custom.
-	rbuild="$(rust_abi ${CBUILD})"
-	rhost="$(rust_abi ${CHOST})"
+	rtarget="${ERUST_STD_RTARGET:-${RUSTHOST}}" # some targets need to be custom.
+	rbuild="${RUSTBUILD:-${RUSTHOST}}"
+	rhost="${RUSTHOST}"
 
 	echo
 	for x in CATEGORY rust_root rbuild rhost rtarget RUSTFLAGS CFLAGS CXXFLAGS LDFLAGS; do

--- a/virtual/rust/rust-1.59.0.ebuild
+++ b/virtual/rust/rust-1.59.0.ebuild
@@ -3,17 +3,13 @@
 
 EAPI=8
 
-inherit multilib-build
-
 DESCRIPTION="Virtual for Rust language compiler"
 
-LICENSE=""
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv x86"
 IUSE="rustfmt"
 
-BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
-	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?]
+	~dev-lang/rust-bin-${PV}[rustfmt?]
 )"

--- a/virtual/rust/rust-1.60.0.ebuild
+++ b/virtual/rust/rust-1.60.0.ebuild
@@ -3,17 +3,13 @@
 
 EAPI=8
 
-inherit multilib-build
-
 DESCRIPTION="Virtual for Rust language compiler"
 
-LICENSE=""
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv ~s390 x86"
 IUSE="rustfmt"
 
-BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
-	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?]
+	~dev-lang/rust-bin-${PV}[rustfmt?]
 )"

--- a/virtual/rust/rust-1.61.0.ebuild
+++ b/virtual/rust/rust-1.61.0.ebuild
@@ -3,17 +3,13 @@
 
 EAPI=8
 
-inherit multilib-build
-
 DESCRIPTION="Virtual for Rust language compiler"
 
-LICENSE=""
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="rustfmt"
 
-BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
-	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?]
+	~dev-lang/rust-bin-${PV}[rustfmt?]
 )"

--- a/virtual/rust/rust-1.62.0.ebuild
+++ b/virtual/rust/rust-1.62.0.ebuild
@@ -3,17 +3,13 @@
 
 EAPI=8
 
-inherit multilib-build
-
 DESCRIPTION="Virtual for Rust language compiler"
 
-LICENSE=""
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="rustfmt"
 
-BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
-	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?]
+	~dev-lang/rust-bin-${PV}[rustfmt?]
 )"


### PR DESCRIPTION
Here is a first attempt at solving some of the problems with Rust in Gentoo.  I haven't tested everything here yet.  The overall gist is to support arbitrary targets without caring where they came from, like `rust-std` with crossdev, the `RUST_CROSS_TARGETS` variable, or custom builds.  It solves two main issues.

  - Rust in Gentoo currently requires multilib ABI `USE` flags in dependencies, which is incompatible with EAPI 7 and later.  Rust must be declared in `BDEPEND` in EAPI 7+, but `BROOT` and `SYSROOT` can have different architectures or use a `no-multilib` profile, so it will end up with impossible dependencies.

This removes the individual multilib requirements and adds a single `multilib` flag to `dev-lang/rust` instead.  It is enabled or disabled in profiles depending on whether they support multilib or not, just like GCC and glibc.  This makes Rust work the same as other compilers like GCC and Go, where they can be used for any supported target without breaking Gentoo dependencies across roots.

  - Gentoo-supported Rust targets are very limited, which prevents the distro from building consistently (or at all) for many systems.  Even with the supported targets or those installed separately, there is no easy way to change the target used by ebuilds.

This standardizes on the `RUST_TARGET` variable, which is set in each profile with a corresponding Rust builtin target.  It is handled correctly by multilib by supporting different targets per ABI, and cargo ebuilds will now successfully cross-compile.  (`RUST_HOST` is also supported and defaults to `RUST_TARGET`, but it should be customized when cross-compiling.)  Users can override the value in `make.conf` or the environment to change targets as needed.  These targets accept arbitrary values, which supports using completely custom targets.

Some issues:
  - Maybe different variables should be used like `RBUILD`/`RHOST`/`RTARGET` to correspond to the `C` versions so it's less confusing.  `RUST_TARGET` corresponds to `CHOST`, and `RUST_HOST` corresponds to `CBUILD`.  These were picked because they're what Mozilla uses.
  - Mozilla projects need to be patched to use these environment variables, which is not included in this PR.  (I.e. Firefox, spidermonkey, etc. won't use the given targets out of the box.)  The patches can be stolen from Debian.
  - I haven't really done anything with `rust-bin`.