### PR TITLE
sci-visualization/fityk: fix gcc-11 compile

### DIFF
--- a/sci-visualization/fityk/files/fityk-1.3.1-fix-gtk3.patch
+++ b/sci-visualization/fityk/files/fityk-1.3.1-fix-gtk3.patch
@@ -1,0 +1,31 @@
+From 85ea545db65d7c6fbb94988b85f1e8cf1c9cbba5 Mon Sep 17 00:00:00 2001
+From: Marcin Wojdyr <wojdyr@gmail.com>
+Date: Sun, 17 Jan 2021 19:18:47 +0100
+Subject: [PATCH] allow building with wxGTK3 (closes #32)
+
+It works, but with some problems.
+
+The separator in wxSplitterWindow is not updated, as per:
+http://trac.wxwidgets.org/ticket/16890
+
+wxSpinCtrl is much wider (it has [+][-] instead of arrows)
+---
+ wxgui/app.cpp | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/wxgui/app.cpp b/wxgui/app.cpp
+index 526c8f14..1041eccf 100644
+--- a/wxgui/app.cpp
++++ b/wxgui/app.cpp
+@@ -8,11 +8,6 @@
+ #include <wx/filesys.h>
+ #include <wx/tooltip.h>
+ 
+-#ifdef __WXGTK3__
+-#error "Not everything is working with wxGTK3. Use default wxGTK instead, " \
+-       "based on GTK+2. If you want to test it, just remove this #error."
+-#endif
+-
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <vector>

--- a/sci-visualization/fityk/fityk-1.3.1-r100.ebuild
+++ b/sci-visualization/fityk/fityk-1.3.1-r100.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 LUA_COMPAT=( lua5-{1..3} )
-WX_GTK_VER=3.0
+WX_GTK_VER=3.0-gtk3
 
 inherit lua-single wxwidgets xdg
 
@@ -30,7 +30,14 @@ RDEPEND="${DEPEND}
 	gnuplot? ( sci-visualization/gnuplot )"
 BDEPEND="dev-lang/swig"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-gtk3.patch
+)
+
 src_configure() {
+	# bug 787317
+	append-cxxflags -std=c++14
+
 	use wxwidgets && setup-wxwidgets
 
 	econf \


### PR DESCRIPTION
fix error: ISO C++17 does not allow dynamic exception specifications

Closes: https://bugs.gentoo.org/787317
Package-Manager: Portage-3.0.18, Repoman-3.0.3
