### PR TITLE
sys-libs/glibc: Filter "-Wl,--relax" from LDFLAGS

### DIFF
--- a/sys-libs/glibc/glibc-2.33.ebuild
+++ b/sys-libs/glibc/glibc-2.33.ebuild
@@ -393,6 +393,9 @@ setup_flags() {
 	# glibc aborts if rpath is set by LDFLAGS
 	filter-ldflags '-Wl,-rpath=*'
 
+	# ld can't use -r & --relax at the same time
+	filter-ldflags '-Wl,--relax'
+
 	# #492892
 	filter-flags -frecord-gcc-switches
 


### PR DESCRIPTION
The build fails due to the -r & --relax combination passed to the
linker, so let's filter this out.

Closes: https://bugs.gentoo.org/788901
Signed-off-by: Petr Šabata <contyk@redhat.com>