### PR TITLE
sci-libs/tensorflow: check gcc version correctly

### DIFF
--- a/sci-libs/tensorflow/tensorflow-2.4.0.ebuild
+++ b/sci-libs/tensorflow/tensorflow-2.4.0.ebuild
@@ -232,7 +232,7 @@ src_configure() {
 			einfo "Setting CUDA version: $TF_CUDA_VERSION"
 			einfo "Setting CUDNN version: $TF_CUDNN_VERSION"
 
-			if [[ *$(gcc-version)* != $(cuda-config -s) ]]; then
+			if [[ $(cuda-config -s) != *$(gcc-version)* ]]; then
 				ewarn "TensorFlow is being built with Nvidia CUDA support. Your default compiler"
 				ewarn "version is not supported by the currently installed CUDA. TensorFlow will"
 				ewarn "instead be compiled using: ${GCC_HOST_COMPILER_PATH}."


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/789270
Package-Manager: Portage-3.0.18, Repoman-3.0.2