### PR TITLE
net-libs/libmicrohttpd-0.9.73 license and other minor fixes

### DIFF
--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.73.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.73.ebuild
@@ -12,20 +12,17 @@ HOMEPAGE="https://www.gnu.org/software/libmicrohttpd/"
 SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz"
 S="${WORKDIR}"/${MY_P}
 
-LICENSE="LGPL-2.1"
+LICENSE="LGPL-2.1+"
 SLOT="0/12"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="+epoll ssl static-libs test thread-names"
 RESTRICT="!test? ( test )"
 
-# libcurl is linked to for tests and the
-# curl binary is used during tests too
-# if available
 RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:= )"
+# libcurl and the curl binary are used during tests on CHOST
 DEPEND="${RDEPEND}
 	test? ( net-misc/curl[ssl?] )"
-BDEPEND="virtual/pkgconfig
-	test? ( net-misc/curl[ssl?] )"
+BDEPEND="ssl? ( virtual/pkgconfig )"
 
 DOCS=( AUTHORS NEWS README ChangeLog )
 

--- a/net-libs/libmicrohttpd/metadata.xml
+++ b/net-libs/libmicrohttpd/metadata.xml
@@ -11,7 +11,7 @@
 	</maintainer>
 	<use>
 		<flag name="epoll">Use epoll() system call</flag>
-		<flag name="thread-names">Assign thread names to internal threads</flag>
+		<flag name="thread-names">Assign thread names to internal threads, useful for dependent apps debugging</flag>
 	</use>
 	<upstream>
 		<remote-id type="cpe">cpe:/a:gnu:libmicrohttpd</remote-id>


### PR DESCRIPTION
Follow-up corrections for https://github.com/gentoo/gentoo/pull/20582

* Corrected LICENSE (it is LGPL-2.1 or later).
* As curl is required only for CHOST, removed curl dependency from BDEPEND.
* pkg-config is needed only to find GnuTLS.

Curl binary is executed only by tests compiled for CHOST. Curl binary on CBUILD is unused.

@thesamesam please check it