### PR TITLE
x11-apps/igt-gpu-tools: use ${EPYTHON}, not python3

### DIFF
--- a/x11-apps/igt-gpu-tools/igt-gpu-tools-1.25.ebuild
+++ b/x11-apps/igt-gpu-tools/igt-gpu-tools-1.25.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,8 @@ if [[ ${PV} = *9999* ]]; then
 	GIT_ECLASS="git-r3"
 fi
 
-inherit ${GIT_ECLASS} meson
+PYTHON_COMPAT=( python3_{7..10} )
+inherit ${GIT_ECLASS} meson python-any-r1
 
 DESCRIPTION="Intel GPU userland tools"
 
@@ -72,12 +73,14 @@ DEPEND="${RDEPEND}
 		sys-devel/flex
 	)
 "
+BDEPEND="${PYTHON_DEPS}"
 
 PATCHES=( "${FILESDIR}/${PV}-python-3.9.patch" )
 
 src_prepare() {
 	sed -e "s/find_program('rst2man-3'/find_program('rst2man.py', 'rst2man-3'/" -i man/meson.build
-	default_src_prepare
+	python-any-r1_pkg_setup
+	default
 }
 
 src_configure() {

--- a/x11-apps/igt-gpu-tools/igt-gpu-tools-9999.ebuild
+++ b/x11-apps/igt-gpu-tools/igt-gpu-tools-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,8 @@ if [[ ${PV} = *9999* ]]; then
 	GIT_ECLASS="git-r3"
 fi
 
-inherit ${GIT_ECLASS} meson
+PYTHON_COMPAT=( python3_{7..10} )
+inherit ${GIT_ECLASS} meson python-any-r1
 
 DESCRIPTION="Intel GPU userland tools"
 
@@ -72,10 +73,12 @@ DEPEND="${RDEPEND}
 		sys-devel/flex
 	)
 "
+BDEPEND="${PYTHON_DEPS}"
 
 src_prepare() {
 	sed -e "s/find_program('rst2man-3'/find_program('rst2man.py', 'rst2man-3'/" -i man/meson.build
-	default_src_prepare
+	python-any-r1_pkg_setup
+	default
 }
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/771594
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>