### PR TITLE
sys-apps/plocate: homogenize cron and systemd timer name

### DIFF
--- a/sys-apps/plocate/plocate-1.1.7-r1.ebuild
+++ b/sys-apps/plocate/plocate-1.1.7-r1.ebuild
@@ -62,8 +62,11 @@ src_install() {
 	fperms 0644 /etc/{updatedb,plocate-cron}.conf
 
 	insinto /etc/cron.daily
-	newins "${FILESDIR}"/plocate.cron plocate
-	fperms 0755 /etc/cron.daily/plocate
+	# Ensure that the cron file has the same name as the
+	# systemd-timer, to avoid plocate being run twice daily on systems
+	# with a systemd compatiblity layer. See also bug #780351.
+	newins "${FILESDIR}"/plocate.cron plocate-updatedb
+	fperms 0755 /etc/cron.daily/plocate-updatedb
 
 	systemd_dounit "${BUILD_DIR}"/${PN}-updatedb.service "${S}"/${PN}-updatedb.timer
 }


### PR DESCRIPTION
On systems using systemd with a cron compatibility layer,
e.g. sys-process/systemd-cron, udpatedb would potentially run twice
daily: One time invoked by cron, and a another time invoked by the
systemd timer.

This can be avoided if the cron file and the systemd timer have the
exact same name. If a systemd native timer with the same name is
found, systemd-crontab-generator (of sys-process/systemd-cron) will
ignore the cron file [1].

Therefore we rename the plocate cron file from plocate to
plocate-udpatedb, to match the systemd plocate-updatedb.timer.

This is an alternative to PR #20095.

1:
https://github.com/systemd-cron/systemd-cron/blob/be4aea647bce9a0f26c9b8126f7883dd5c0b60a2/src/bin/systemd-crontab-generator.py#L535

Closes: https://bugs.gentoo.org/780351
Signed-off-by: Florian Schmaus <flo@geekplace.eu>