### PR TITLE
Add CPE tag for app-emulation/runc.

### DIFF
--- a/app-emulation/runc/metadata.xml
+++ b/app-emulation/runc/metadata.xml
@@ -26,5 +26,6 @@
 	</use>
 	<upstream>
 		<remote-id type="github">opencontainers/runc</remote-id>
+		<remote-id type="cpe">cpe:/a:linuxfoundation:runc</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Based on the CPE tags from official CPE tag database
official-cpe-dictionary_v2.3.xml downloaded from
https://nvd.nist.gov/products/cpe, it uses
linuxfoundation as the vendor for runc vulnerabilities.