### PR TITLE
app-eselect/eselect-sh: Change mksh to lksh

### DIFF
--- a/app-eselect/eselect-sh/eselect-sh-0.4.2.ebuild
+++ b/app-eselect/eselect-sh/eselect-sh-0.4.2.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Manages the /bin/sh (POSIX shell) symlink"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE=""
+
+RDEPEND="app-eselect/eselect-lib-bin-symlink"
+
+src_install() {
+	insinto /usr/share/eselect/modules
+	newins "${FILESDIR}"/sh.eselect-${PV} sh.eselect
+}

--- a/app-eselect/eselect-sh/files/sh.eselect-0.4.2
+++ b/app-eselect/eselect-sh/files/sh.eselect-0.4.2
@@ -1,0 +1,13 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Manage /bin/sh (POSIX shell) implementations"
+MAINTAINER="mgorny@gentoo.org"
+VERSION="0.4.2"
+
+SYMLINK_PATH=/bin/sh
+SYMLINK_TARGETS=( bash dash lksh )
+SYMLINK_DESCRIPTION='POSIX shell'
+SYMLINK_CRUCIAL=1
+
+inherit bin-symlink


### PR DESCRIPTION
lksh is a POSIX-compliant version of mksh

Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>