### PR TITLE
media-sound/mumble: Update live ebuild

### DIFF
--- a/media-sound/mumble/mumble-9999.ebuild
+++ b/media-sound/mumble/mumble-9999.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://wiki.mumble.info"
 if [[ "${PV}" == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/mumble-voip/mumble.git"
-	EGIT_SUBMODULES=( '-*' celt-0.7.0-src celt-0.11.0-src themes/Mumble 3rdparty/rnnoise-src )
+	EGIT_SUBMODULES=( '-*' celt-0.7.0-src celt-0.11.0-src themes/Mumble 3rdparty/rnnoise-src 3rdparty/FindPythonInterpreter )
 else
 	if [[ "${PV}" == *_pre* ]] ; then
 		SRC_URI="https://dev.gentoo.org/~polynomial-c/dist/${P}.tar.xz"


### PR DESCRIPTION
Mumble added a new sub-module that provides some cmake files to find python.
Their cmake files now expects this submodule to be present as cmake will error out otherwise as it can't find files that belongs to this module.

@Polynomial-C 