### PR TITLE
x11-misc/fbpager: Set C++ standard to 14 & EAPI bump

### DIFF
--- a/x11-misc/fbpager/fbpager-20090221-r1.ebuild
+++ b/x11-misc/fbpager/fbpager-20090221-r1.ebuild
@@ -1,7 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
+
+inherit flag-o-matic
 
 DESCRIPTION="A Pager for fluxbox"
 HOMEPAGE="http://git.fluxbox.org/fbpager.git/"
@@ -15,6 +17,12 @@ IUSE="+xrender"
 DEPEND="x11-libs/libX11
 	xrender? ( x11-libs/libXrender )"
 RDEPEND="${DEPEND}"
+
+src_prepare() {
+	append-cxxflags "-std=c++14"
+
+	default
+}
 
 src_configure() {
 	econf $(use_enable xrender)

--- a/x11-misc/fbpager/fbpager-20090221-r2.ebuild
+++ b/x11-misc/fbpager/fbpager-20090221-r2.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic
+
+DESCRIPTION="A Pager for fluxbox"
+HOMEPAGE="http://git.fluxbox.org/fbpager.git/"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~mips ~ppc ~sparc ~x86"
+IUSE="+xrender"
+
+DEPEND="x11-libs/libX11
+	xrender? ( x11-libs/libXrender )"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	append-cxxflags "-std=c++14"
+
+	default
+}
+
+src_configure() {
+	econf $(use_enable xrender)
+}
+
+pkg_postinst() {
+	einfo "To run fbpager inside the FluxBox slit, use fbpager -w"
+}


### PR DESCRIPTION
Fixes build errors with GCC-11.