### PR TITLE
net-misc/exabgp: fix capsh usage

### DIFF
--- a/net-misc/exabgp/files/exabgp.initd
+++ b/net-misc/exabgp/files/exabgp.initd
@@ -7,8 +7,8 @@
 
 command="capsh"
 command_args="
-	--uid=${EXABGP_USER:-exabgp}
-	--gid=${EXABGP_GROUP:-exabgp}
+	--groups=${EXABGP_GROUP:=exabgp}
+	--user=${EXABGP_USER:-exabgp}
 	--caps='cap_net_admin+epi cap_setuid+ep-i cap_setgid+ep-i'
 	-- -c \"/usr/bin/exabgp ${EXABGP_ARGS}\""
 command_background="yes"


### PR DESCRIPTION
- --uid and --gid need numeric values

- using --gid or --groups results in "Failed to setgroups." if it is
  placed afgter --uid or --user. setgroups needs to happen before the
  user is changed to non-root.

Signed-off-by: Victor Payno <vpayno+gentoo@gmail.com>

---

@chutz 