### PR TITLE
dev-python/*: bump semantic_version and dnspython + dependencies

### DIFF
--- a/dev-python/selenium/selenium-3.141.0-r1.ebuild
+++ b/dev-python/selenium/selenium-3.141.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 

--- a/dev-python/urllib3/files/urllib3-1.26.4-test-ssltransport.patch
+++ b/dev-python/urllib3/files/urllib3-1.26.4-test-ssltransport.patch
@@ -1,0 +1,31 @@
+diff --git a/test/test_ssltransport.py b/test/test_ssltransport.py
+index 72b06b006..98682bd43 100644
+--- a/test/test_ssltransport.py
++++ b/test/test_ssltransport.py
+@@ -246,6 +246,7 @@ def proxy_handler(listener):
+                 )
+                 self._read_write_loop(client_sock, upstream_sock)
+                 upstream_sock.close()
++                client_sock.close()
+ 
+         self._start_server(proxy_handler)
+ 
+@@ -274,6 +275,10 @@ def _read_write_loop(self, client_sock, server_sock, chunks=65536):
+                 if write_socket in writable:
+                     try:
+                         b = read_socket.recv(chunks)
++                        if len(b) == 0:
++                            # One of the sockets has EOFed, we return to close
++                            # both.
++                            return
+                         write_socket.send(b)
+                     except ssl.SSLEOFError:
+                         # It's possible, depending on shutdown order, that we'll
+@@ -322,6 +327,7 @@ def socket_handler(listener):
+                 request = consume_socket(ssock)
+                 validate_request(request)
+                 ssock.send(sample_response())
++            sock.close()
+ 
+         cls._start_server(socket_handler)
+ 

--- a/dev-python/urllib3/urllib3-1.26.4.ebuild
+++ b/dev-python/urllib3/urllib3-1.26.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} pypy3 )
+PYTHON_COMPAT=( python3_{7..10} pypy3 )
 PYTHON_REQ_USE="ssl(+)"
 
 inherit distutils-r1
@@ -40,6 +40,10 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	"${FILESDIR}/${P}-test-ssltransport.patch"
+)
+
 python_prepare_all() {
 	# tests failing if 'localhost.' cannot be resolved
 	sed -e 's:test_dotted_fqdn:_&:' \
@@ -58,6 +62,34 @@ python_test() {
 	local deselect=(
 		# TODO?
 		test/with_dummyserver/test_socketlevel.py::TestSocketClosing::test_timeout_errors_cause_retries
+	)
+	[[ ${EPYTHON} == python3.10 ]] && deselect+=(
+		# Fail because they rely on warnings and there are new deprecation warnings in 3.10
+		test/contrib/test_pyopenssl.py
+		test/with_dummyserver/test_https.py::TestHTTPS::test_verified
+		test/with_dummyserver/test_https.py::TestHTTPS::test_verified_with_context
+		test/with_dummyserver/test_https.py::TestHTTPS::test_context_combines_with_ca_certs
+		test/with_dummyserver/test_https.py::TestHTTPS::test_ca_dir_verified
+		test/with_dummyserver/test_https.py::TestHTTPS::test_ssl_correct_system_time
+		test/with_dummyserver/test_https.py::TestHTTPS::test_ssl_wrong_system_time
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_verified
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_verified_with_context
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_context_combines_with_ca_certs
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_ca_dir_verified
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_ssl_correct_system_time
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_ssl_wrong_system_time
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_default_tls_version_deprecations
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_no_tls_version_deprecation_with_ssl_version
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_2::test_no_tls_version_deprecation_with_ssl_context
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_verified
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_verified_with_context
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_context_combines_with_ca_certs
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_ca_dir_verified
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_ssl_correct_system_time
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_ssl_wrong_system_time
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_default_tls_version_deprecations
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_no_tls_version_deprecation_with_ssl_version
+		test/with_dummyserver/test_https.py::TestHTTPS_TLSv1_3::test_no_tls_version_deprecation_with_ssl_context
 	)
 
 	epytest ${deselect[@]/#/--deselect }


### PR DESCRIPTION
A continuation of #20795. 

@mgorny, I was able to bump django and all dependencies to 3.10 (with some patches), and now the semantic_version tests for django pass for me. Still not sure about the dnspython test fails, since they work fine for me.