### PR TITLE
dev-python/*: bump twisted and some packages that depend on it to python 3.10

### DIFF
--- a/dev-python/constantly/constantly-15.1.0-r1.ebuild
+++ b/dev-python/constantly/constantly-15.1.0-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 DISTUTILS_USE_SETUPTOOLS=bdepend
 
 inherit distutils-r1
@@ -22,6 +22,4 @@ DEPEND="${RDEPEND}
 	test? ( dev-python/twisted[${PYTHON_USEDEP}] )
 "
 
-python_test() {
-	esetup.py test
-}
+distutils_enable_tests setup.py

--- a/dev-python/django/django-3.2.3-r1.ebuild
+++ b/dev-python/django/django-3.2.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 PYTHON_REQ_USE='sqlite?,threads(+)'
 
 inherit bash-completion-r1 distutils-r1 optfeature verify-sig
@@ -50,6 +50,8 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.1-bashcomp.patch
+	# From https://github.com/django/django/pull/14228
+	"${FILESDIR}"/${P}-py310-repr.patch
 )
 
 distutils_enable_sphinx docs --no-autodoc
@@ -65,6 +67,13 @@ src_unpack() {
 	fi
 
 	default
+}
+
+python_prepare_all() {
+	# Fails because of warnings
+	sed -i 's/test_dumpdata_proxy_with_concrete/_&/' tests/fixtures/tests.py
+
+	distutils-r1_python_prepare_all
 }
 
 python_test() {

--- a/dev-python/django/files/django-3.2.3-py310-repr.patch
+++ b/dev-python/django/files/django-3.2.3-py310-repr.patch
@@ -1,0 +1,92 @@
+diff --git a/django/db/models/constraints.py b/django/db/models/constraints.py
+index b073df17636a..6dfc42942f79 100644
+--- a/django/db/models/constraints.py
++++ b/django/db/models/constraints.py
+@@ -4,6 +4,7 @@
+ from django.db.models.indexes import IndexExpression
+ from django.db.models.query_utils import Q
+ from django.db.models.sql.query import Query
++from django.utils.version import PY310
+ 
+ __all__ = ['CheckConstraint', 'Deferrable', 'UniqueConstraint']
+ 
+@@ -85,6 +86,11 @@ class Deferrable(Enum):
+     DEFERRED = 'deferred'
+     IMMEDIATE = 'immediate'
+ 
++    # A similar format is used in Python 3.10+.
++    if not PY310:
++        def __repr__(self):
++            return '%s.%s' % (self.__class__.__qualname__, self._name_)
++
+ 
+ class UniqueConstraint(BaseConstraint):
+     def __init__(
+@@ -218,7 +224,7 @@ def __repr__(self):
+             '' if not self.expressions else ' expressions=%s' % repr(self.expressions),
+             ' name=%s' % repr(self.name),
+             '' if self.condition is None else ' condition=%s' % self.condition,
+-            '' if self.deferrable is None else ' deferrable=%s' % self.deferrable,
++            '' if self.deferrable is None else ' deferrable=%r' % self.deferrable,
+             '' if not self.include else ' include=%s' % repr(self.include),
+             '' if not self.opclasses else ' opclasses=%s' % repr(self.opclasses),
+         )
+diff --git a/django/db/models/enums.py b/django/db/models/enums.py
+index 7082a397c237..dd9088597d4d 100644
+--- a/django/db/models/enums.py
++++ b/django/db/models/enums.py
+@@ -2,6 +2,7 @@
+ from types import DynamicClassAttribute
+ 
+ from django.utils.functional import Promise
++from django.utils.version import PY310
+ 
+ __all__ = ['Choices', 'IntegerChoices', 'TextChoices']
+ 
+@@ -74,6 +75,11 @@ def __str__(self):
+         """
+         return str(self.value)
+ 
++    # A similar format is used in Python 3.10+.
++    if not PY310:
++        def __repr__(self):
++            return '%s.%s' % (self.__class__.__qualname__, self._name_)
++
+ 
+ class IntegerChoices(int, Choices):
+     """Class for creating enumerated integer choices."""
+diff --git a/tests/model_enums/tests.py b/tests/model_enums/tests.py
+index 78f8b146be92..cda835010d7e 100644
+--- a/tests/model_enums/tests.py
++++ b/tests/model_enums/tests.py
+@@ -48,7 +48,7 @@ def test_integerchoices(self):
+         self.assertEqual(Suit.values, [1, 2, 3, 4])
+         self.assertEqual(Suit.names, ['DIAMOND', 'SPADE', 'HEART', 'CLUB'])
+ 
+-        self.assertEqual(repr(Suit.DIAMOND), '<Suit.DIAMOND: 1>')
++        self.assertEqual(repr(Suit.DIAMOND), 'Suit.DIAMOND')
+         self.assertEqual(Suit.DIAMOND.label, 'Diamond')
+         self.assertEqual(Suit.DIAMOND.value, 1)
+         self.assertEqual(Suit['DIAMOND'], Suit.DIAMOND)
+@@ -89,7 +89,7 @@ def test_textchoices(self):
+         self.assertEqual(YearInSchool.values, ['FR', 'SO', 'JR', 'SR', 'GR'])
+         self.assertEqual(YearInSchool.names, ['FRESHMAN', 'SOPHOMORE', 'JUNIOR', 'SENIOR', 'GRADUATE'])
+ 
+-        self.assertEqual(repr(YearInSchool.FRESHMAN), "<YearInSchool.FRESHMAN: 'FR'>")
++        self.assertEqual(repr(YearInSchool.FRESHMAN), 'YearInSchool.FRESHMAN')
+         self.assertEqual(YearInSchool.FRESHMAN.label, 'Freshman')
+         self.assertEqual(YearInSchool.FRESHMAN.value, 'FR')
+         self.assertEqual(YearInSchool['FRESHMAN'], YearInSchool.FRESHMAN)
+diff --git a/django/utils/version.py b/django/utils/version.py
+index 4b26586b36..b84ca7db27 100644
+--- a/django/utils/version.py
++++ b/django/utils/version.py
+@@ -13,7 +13,7 @@ PY36 = sys.version_info >= (3, 6)
+ PY37 = sys.version_info >= (3, 7)
+ PY38 = sys.version_info >= (3, 8)
+ PY39 = sys.version_info >= (3, 9)
+-
++PY310 = sys.version_info >= (3, 10)
+ 
+ def get_version(version=None):
+     """Return a PEP 440-compliant version number from VERSION."""

--- a/dev-python/dnspython/dnspython-2.1.0.ebuild
+++ b/dev-python/dnspython/dnspython-2.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} pypy3 )
+PYTHON_COMPAT=( python3_{7..10} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/tblib/tblib-1.7.0.ebuild
+++ b/dev-python/tblib/tblib-1.7.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 

--- a/dev-python/twisted/files/twisted-21.2.0-force-gtk3.patch
+++ b/dev-python/twisted/files/twisted-21.2.0-force-gtk3.patch
@@ -1,0 +1,42 @@
+diff --git a/src/twisted/internet/gireactor.py b/src/twisted/internet/gireactor.py
+index 92596db1da2..a577825a87e 100644
+--- a/src/twisted/internet/gireactor.py
++++ b/src/twisted/internet/gireactor.py
+@@ -24,6 +24,7 @@
+ from twisted.internet.error import ReactorAlreadyRunning
+ from twisted.internet import _glibbase
+ from twisted.python import runtime
++import gi
+ import gi.pygtkcompat
+ from gi.repository import GLib
+ 
+@@ -68,6 +69,7 @@ class GIReactor(_glibbase.GlibReactorBase):
+     def __init__(self, useGtk=False):
+         _gtk = None
+         if useGtk is True:
++            gi.require_version("Gtk", "3.0")
+             from gi.repository import Gtk as _gtk
+ 
+         _glibbase.GlibReactorBase.__init__(self, GLib, _gtk, useGtk=useGtk)
+@@ -112,6 +114,7 @@ class PortableGIReactor(_glibbase.PortableGlibReactorBase):
+     def __init__(self, useGtk=False):
+         _gtk = None
+         if useGtk is True:
++            gi.require_version("Gtk", "3.0")
+             from gi.repository import Gtk as _gtk
+ 
+         _glibbase.PortableGlibReactorBase.__init__(self, GLib, _gtk, useGtk=useGtk)
+diff --git a/src/twisted/internet/test/test_gireactor.py b/src/twisted/internet/test/test_gireactor.py
+index d15a9262248..af5092a3614 100644
+--- a/src/twisted/internet/test/test_gireactor.py
++++ b/src/twisted/internet/test/test_gireactor.py
+@@ -25,6 +25,9 @@
+         gtk3reactor = None
+     else:
+         gtk3reactor = _gtk3reactor
++        import gi  # type: ignore[import]
++
++        gi.require_version("Gtk", "3.0")
+         from gi.repository import Gtk
+ 
+ from twisted.internet.error import ReactorAlreadyRunning

--- a/dev-python/twisted/files/twisted-21.2.0-int-from-bytes.patch
+++ b/dev-python/twisted/files/twisted-21.2.0-int-from-bytes.patch
@@ -1,0 +1,14 @@
+diff --git a/src/twisted/conch/ssh/common.py b/src/twisted/conch/ssh/common.py
+index 3e4f8cdc7..ee3d63143 100644
+--- a/src/twisted/conch/ssh/common.py
++++ b/src/twisted/conch/ssh/common.py
+@@ -11,7 +11,8 @@ Maintainer: Paul Swartz
+ 
+ import struct
+ 
+-from cryptography.utils import int_from_bytes, int_to_bytes
++from cryptography.utils import int_to_bytes
++int_from_bytes = int.from_bytes
+ 
+ from twisted.python.deprecate import deprecated
+ from twisted.python.versions import Version

--- a/dev-python/twisted/twisted-21.2.0-r1.ebuild
+++ b/dev-python/twisted/twisted-21.2.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=rdepend
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 virtualx
@@ -77,6 +77,13 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	# https://twistedmatrix.com/trac/ticket/10200
+	"${FILESDIR}/${P}-force-gtk3.patch"
+	# int_from_bytes is deprecated
+	"${FILESDIR}/${P}-int-from-bytes.patch"
+)
+
 python_prepare_all() {
 	eapply "${FILESDIR}"/${P}-incremental-21.patch
 
@@ -100,6 +107,10 @@ python_prepare_all() {
 	sed -e '/class RealDeviceTestsMixin/a\
     skip = "Requires extra permissions"' \
 		-i src/twisted/pair/test/test_tuntap.py || die
+
+	# These tests rely on warnings which seems work unreliably between python versions
+	sed -e 's:test_currentEUID:_&:' \
+		-e 's:test_currentUID:_&:' -i src/twisted/python/test/test_util.py || die
 
 	# relies on the pre-CVE parse_qs() behavior in Python
 	sed -e '/d=c;+=f/d' \

--- a/www-servers/tornado/tornado-6.1.ebuild
+++ b/www-servers/tornado/tornado-6.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1
@@ -31,6 +31,14 @@ BDEPEND="
 distutils_enable_sphinx docs \
 	dev-python/sphinx_rtd_theme \
 	dev-python/sphinxcontrib-asyncio
+
+python_prepare_all() {
+	# Disable deprecation-warnings-as-errors because tornado has a lot of stuff deprecated in 3.10
+	sed 's/warnings.filterwarnings("error", category=DeprecationWarning, module=r"tornado\\..*")//' \
+		-i tornado/test/runtests.py || die
+
+	distutils-r1_python_prepare_all
+}
 
 python_test() {
 	local -x ASYNC_TEST_TIMEOUT=60


### PR DESCRIPTION
Separated from #20828, and will be rebased after it's merged. Waiting on the twisted keyword for ~alpha (https://bugs.gentoo.org/773451)