### PR TITLE
app-dicts/dictd-vera: move data to /usr/share

### DIFF
--- a/app-dicts/dictd-vera/dictd-vera-1.24-r1.ebuild
+++ b/app-dicts/dictd-vera/dictd-vera-1.24-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="V.E.R.A. -- Virtual Entity of Relevant Acronyms for dict"
+HOMEPAGE="http://home.snafu.de/ohei/vera/vueber-e.html"
+SRC_URI="mirror://gnu/vera/vera-${PV}.tar.gz"
+S="${WORKDIR}/vera-${PV}"
+SLOT="0"
+LICENSE="FDL-1.3"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+DEPEND=">=app-text/dictd-1.5.5"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-U+D7.patch" )
+
+src_compile() {
+	cat vera.[0-9a-z] | dictfmt -f -u http://home.snafu.de/ohei \
+		-s "V.E.R.A. -- Virtual Entity of Relevant Acronyms" \
+		vera || die
+	dictzip -v vera.dict || die
+}
+
+src_install() {
+	insinto /usr/share/dict
+	doins vera.dict.dz
+	doins vera.index
+
+	dodoc changelog README
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/790383
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>