### PR TITLE
app-admin/syslog-ng: require python for tests

### DIFF
--- a/app-admin/syslog-ng/syslog-ng-3.31.2.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-3.31.2.ebuild
@@ -15,7 +15,8 @@ LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="amqp caps dbi geoip2 http ipv6 json kafka mongodb pacct python redis smtp snmp test spoof-source systemd tcpd"
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )
+	test? ( python )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/789540
Signed-off-by: Tomáš Mózes <hydrapolic@gmail.com>