### PR TITLE
media-libs/harfbuzz: filter unsupported flags

### DIFF
--- a/media-libs/harfbuzz/harfbuzz-2.7.4.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-2.7.4.ebuild
@@ -63,6 +63,9 @@ src_prepare() {
 	# bug 618772
 	append-cxxflags -std=c++14
 
+	# bug 790359
+	filter-flags -fexceptions -fthreadsafe-statics
+
 	# bug 762415
 	local pyscript
 	for pyscript in $(find -type f -name "*.py") ; do

--- a/media-libs/harfbuzz/harfbuzz-2.8.0.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-2.8.0.ebuild
@@ -63,6 +63,9 @@ src_prepare() {
 	# bug 618772
 	append-cxxflags -std=c++14
 
+	# bug 790359
+	filter-flags -fexceptions -fthreadsafe-statics
+
 	# bug 762415
 	local pyscript
 	for pyscript in $(find -type f -name "*.py") ; do

--- a/media-libs/harfbuzz/harfbuzz-2.8.1.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-2.8.1.ebuild
@@ -63,6 +63,9 @@ src_prepare() {
 	# bug 618772
 	append-cxxflags -std=c++14
 
+	# bug 790359
+	filter-flags -fexceptions -fthreadsafe-statics
+
 	# bug 762415
 	local pyscript
 	for pyscript in $(find -type f -name "*.py") ; do

--- a/media-libs/harfbuzz/harfbuzz-9999.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-9999.ebuild
@@ -63,6 +63,9 @@ src_prepare() {
 	# bug 618772
 	append-cxxflags -std=c++14
 
+	# bug 790359
+	filter-flags -fexceptions -fthreadsafe-statics
+
 	# bug 762415
 	local pyscript
 	for pyscript in $(find -type f -name "*.py") ; do


### PR DESCRIPTION
harfbuzz does not want to link with libstdc++. Therefore
-fno-exceptions and -fno-threadsafe-statics are passed to
the C++ compiler. With autotools these flags were appended
after user CXXFLAGS. However, with meson user CXXFLAGS are
always appended and can overwrite -fno-exceptions and
-fno-threadsafe-statics.

Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Stephan Hartmann <sultan@gentoo.org>