### PR TITLE
net-misc/exabgp: fix typo in --user assignment in initd scripts

### DIFF
--- a/net-misc/exabgp/files/exabgp.initd
+++ b/net-misc/exabgp/files/exabgp.initd
@@ -8,7 +8,7 @@
 command="capsh"
 command_args="
 	--groups=${EXABGP_GROUP:=exabgp}
-	--user=${EXABGP_USER:-exabgp}
+	--user=${EXABGP_USER:=exabgp}
 	--caps='cap_net_admin+epi cap_setuid+ep-i cap_setgid+ep-i'
 	-- -c \"/usr/bin/exabgp ${EXABGP_ARGS}\""
 command_background="yes"

--- a/net-misc/exabgp/files/exabgp.initd-r1
+++ b/net-misc/exabgp/files/exabgp.initd-r1
@@ -8,7 +8,7 @@
 command="capsh"
 command_args="
 	--groups=${EXABGP_GROUP:=exabgp}
-	--user=${EXABGP_USER:-exabgp}
+	--user=${EXABGP_USER:=exabgp}
 	--caps='cap_net_admin+epi cap_setuid+ep-i cap_setgid+ep-i'
 	-- -c \"/usr/bin/exabgp ${EXABGP_ARGS}\""
 


### PR DESCRIPTION
Signed-off-by: Victor Payno <victor.payno@sony.com>

@chutz 