### PR TITLE
sci-libs/opencacade: patch cmake config so that find_package works properly

### DIFF
--- a/sci-libs/opencascade/opencascade-7.5.1-r1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.1-r1.ebuild
@@ -80,6 +80,13 @@ src_prepare() {
 
 	sed -e 's/\/lib\$/\/'$(get_libdir)'\$/' \
 		-i adm/templates/OpenCASCADEConfig.cmake.in || die
+
+	# There is an OCCT_UPDATE_TARGET_FILE cmake macro that fails due to some
+	# assumptions it makes about installation paths. Rather than fixing it, just
+	# get rid of the mechanism altogether - its purpose is to allow a
+	# side-by-side installation of release and debug libraries.
+	sed -e 's|\\${OCCT_INSTALL_BIN_LETTER}||' \
+		-i "adm/cmake/occt_toolkit.cmake"
 }
 
 src_configure() {


### PR DESCRIPTION

The upstream cmake configuration include a cmake macro that fails - the failure
seems pretty specify to gentoo and the fact that we have an intermediate
installation directory.

Rather than fixing the macro, I just removed the mechanism - the original intent
is to allow a side-by-side installation of a release and debug version of
opencascade. I *did* try to fix the macro, but honestly its a bit of a mess and
already implements some pretty obscure cmake hackery, so I thought it best to
just leave it alone.

Another option is to fix the files in `src_install` if we want to go that route
, but then we'd need to add logic to append a suffix if it's a debug build.

Signed-off-by: Wolfgang E. Sanyer
