### PR TITLE
Remove CMake workaround from boost, and fix prefix build of spidermonkey

### DIFF
--- a/dev-lang/spidermonkey/spidermonkey-78.10.1.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-78.10.1.ebuild
@@ -13,7 +13,7 @@ PYTHON_COMPAT=( python3_{7..9} )
 
 WANT_AUTOCONF="2.1"
 
-inherit autotools check-reqs flag-o-matic llvm multiprocessing python-any-r1 toolchain-funcs
+inherit autotools check-reqs flag-o-matic llvm multiprocessing prefix python-any-r1 toolchain-funcs
 
 MY_PN="mozjs"
 MY_PV="${PV/_pre*}" # Handle Gentoo pre-releases
@@ -229,6 +229,9 @@ src_prepare() {
 		-e "s/objdump/${CHOST}-objdump/" \
 		python/mozbuild/mozbuild/configure/check_debug_ranges.py \
 		|| die "sed failed to set toolchain prefix"
+
+	# use prefix shell in wrapper linker scripts, bug #789660
+	hprefixify "${S}"/../../build/cargo-{,host-}linker
 
 	einfo "Removing pre-built binaries ..."
 	find third_party -type f \( -name '*.so' -o -name '*.o' \) -print -delete || die

--- a/dev-libs/boost/boost-1.76.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.76.0-r1.ebuild
@@ -171,10 +171,6 @@ src_configure() {
 		--without-stacktrace
 		--boost-build="${BROOT}"/usr/share/boost-build/src
 		--layout=system
-		# CMake has issues working with multiple python impls,
-		# disable cmake config generation for the time being
-		# https://github.com/boostorg/python/issues/262#issuecomment-483069294
-		--no-cmake-config
 		# building with threading=single is currently not possible
 		# https://svn.boost.org/trac/boost/ticket/7105
 		threading=multi


### PR DESCRIPTION
@gentoo/mozilla and @SoapGentoo Please ACK. Thanks.