### PR TITLE
dev-libs/geoip: Update geoipupdate.sh mirrors

### DIFF
--- a/dev-libs/geoip/files/geoipupdate-r7.sh
+++ b/dev-libs/geoip/files/geoipupdate-r7.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+GEOIP_MIRROR="https://mailfud.org/geoip-legacy/"
+GEOIPDIR=@PREFIX@/usr/share/GeoIP
+TMPDIR=
+
+DATABASES="
+        GeoIPv6
+        GeoIPCity
+        GeoIPCityv6
+        GeoIP
+        GeoIPASNum
+        GeoIPASNumv6
+"
+
+if [ "${1}" = -f ] || [ "${1}" = --force ]; then
+	force=true
+fi
+
+if [ -d "${GEOIPDIR}" ]; then
+	cd $GEOIPDIR
+	if [ -n "${DATABASES}" ]; then
+		TMPDIR=$(mktemp -d geoipupdate.XXXXXXXXXX)
+
+		echo "Updating GeoIP databases..."
+
+		for db in $DATABASES; do
+			fname=$(basename $db)
+
+			if [ -f "${GEOIPDIR}/${fname}.dat" ] || [ ${force} ]; then
+				wget --no-verbose -t 3 -T 60 \
+					"${GEOIP_MIRROR}/${db}.dat.gz" \
+					-O "${TMPDIR}/${fname}.dat.gz"
+				if [ $? -eq 0 ]; then
+					gunzip -fdc "${TMPDIR}/${fname}.dat.gz" > "${TMPDIR}/${fname}.dat"
+					mv "${TMPDIR}/${fname}.dat" "${GEOIPDIR}/${fname}.dat"
+					chmod 0644 "${GEOIPDIR}/${fname}.dat"
+					case ${fname} in
+						GeoLite*) ln -sf ${fname}.dat `echo ${fname} | sed 's/GeoLite/GeoIP/'`.dat ;;
+					esac
+				fi
+			fi
+		done
+		[ -d "${TMPDIR}" ] && rm -rf $TMPDIR
+	fi
+fi

--- a/dev-libs/geoip/geoip-1.6.12-r1.ebuild
+++ b/dev-libs/geoip/geoip-1.6.12-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="GeoIP Legacy C API"
+HOMEPAGE="https://github.com/maxmind/geoip-api-c"
+SRC_URI="https://github.com/maxmind/${PN}-api-c/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-api-c-${PV}"
+
+# GPL-2 for md5.c - part of libGeoIPUpdate, MaxMind for GeoLite Country db
+LICENSE="LGPL-2.1 GPL-2 MaxMind2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="static-libs"
+RESTRICT="test"
+
+DEPEND="net-misc/wget"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+	sed -e "s|@PREFIX@|${EPREFIX}|g" "${FILESDIR}"/geoipupdate-r7.sh > geoipupdate.sh || die
+}
+
+src_install() {
+	default
+
+	dodoc AUTHORS ChangeLog NEWS.md README*
+
+	find "${ED}" -name '*.la' -delete || die
+
+	keepdir /usr/share/GeoIP
+
+	dosbin geoipupdate.sh
+}
+
+pkg_postinst() {
+	ewarn "WARNING: Databases are no longer installed by this ebuild."
+	elog "Don't forget to run 'geoipupdate.sh -f' (or geoipupdate from"
+	elog "net-misc/geoipupdate) to populate ${EROOT}/usr/share/GeoIP/"
+	elog "with geo-located IP address databases."
+}


### PR DESCRIPTION
The free databases provided by MaxMind are no longer available and so the script doesn't work.  Switch to a different mirror.

An alternative could be to drop this script entirely to force people to use `net-misc/geoipupdate`, but I don't think this works without paying MaxMind for an API key.