### PR TITLE
dev-python/*: add python 3.10 support

### DIFF
--- a/dev-python/pyre2/metadata.xml
+++ b/dev-python/pyre2/metadata.xml
@@ -11,5 +11,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="pypi">fb-re2</remote-id>
+		<remote-id type="github">facebook/pyre2</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/pyre2/pyre2-1.0.7.ebuild
+++ b/dev-python/pyre2/pyre2-1.0.7.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 inherit distutils-r1
 
 DESCRIPTION="Python bindings for dev-libs/re2"

--- a/dev-python/pyrsistent/pyrsistent-0.17.3.ebuild
+++ b/dev-python/pyrsistent/pyrsistent-0.17.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} pypy3 )
+PYTHON_COMPAT=( python3_{7..10} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pysrt/pysrt-1.1.2.ebuild
+++ b/dev-python/pysrt/pysrt-1.1.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( pypy3 python3_{7,8,9} )
+PYTHON_COMPAT=( pypy3 python3_{7..10} )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1

--- a/dev-python/pysrt/pysrt-9999.ebuild
+++ b/dev-python/pysrt/pysrt-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( pypy3 python3_{7,8,9} )
+PYTHON_COMPAT=( pypy3 python3_{7..10} )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1

--- a/dev-python/pysvg/pysvg-0.2.2_p3.ebuild
+++ b/dev-python/pysvg/pysvg-0.2.2_p3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 

--- a/dev-python/python-cstruct/python-cstruct-1.8.ebuild
+++ b/dev-python/python-cstruct/python-cstruct-1.8.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 inherit distutils-r1
 
 DESCRIPTION="C-style structs for Python"

--- a/dev-python/python-debian/python-debian-0.1.39.ebuild
+++ b/dev-python/python-debian/python-debian-0.1.39.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 
@@ -22,7 +22,6 @@ RDEPEND="
 "
 
 BDEPEND="${RDEPEND}
-	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( app-arch/dpkg )
 "
 

--- a/dev-python/python-editor/metadata.xml
+++ b/dev-python/python-editor/metadata.xml
@@ -5,6 +5,7 @@
 		<email>prometheanfire@gentoo.org</email>
 		<name>Matthew Thode</name>
 	</maintainer>
+	<stabilize-allarches/>
 	<upstream>
 		<bugs-to>https://github.com/fmoo/python-editor/issues</bugs-to>
 		<remote-id type="github">fmoo/python-editor</remote-id>

--- a/dev-python/python-editor/python-editor-1.0.4-r1.ebuild
+++ b/dev-python/python-editor/python-editor-1.0.4-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( pypy3 python3_{7..9} )
+PYTHON_COMPAT=( pypy3 python3_{7..10} )
 inherit distutils-r1
 
 DESCRIPTION="Programmatically open an editor, capture the result."

--- a/dev-python/python-mimeparse/python-mimeparse-1.6.0-r3.ebuild
+++ b/dev-python/python-mimeparse/python-mimeparse-1.6.0-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} pypy3 )
+PYTHON_COMPAT=( python3_{7..10} pypy3 )
 
 inherit distutils-r1
 
@@ -14,7 +14,6 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
-IUSE=""
 
 python_test() {
 	"${EPYTHON}" mimeparse_test.py -v || die "Tests fail with ${EPYTHON}"


### PR DESCRIPTION
Continuing scanning the CI output for `PythonCompatUpdate`, and calling `ebuild ... test`
Some of them even add support for `python3_9`