### PR TITLE
dev-python/*: add python 3.10 support

### DIFF
--- a/dev-python/msgpack/msgpack-1.0.2.ebuild
+++ b/dev-python/msgpack/msgpack-1.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} pypy3 )
+PYTHON_COMPAT=( python3_{7..10} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/netifaces/netifaces-0.10.9.ebuild
+++ b/dev-python/netifaces/netifaces-0.10.9.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( pypy3 python3_{7,8,9} )
+PYTHON_COMPAT=( pypy3 python3_{7..10} )
 
 inherit distutils-r1
 

--- a/dev-python/pytest-datadir/metadata.xml
+++ b/dev-python/pytest-datadir/metadata.xml
@@ -5,6 +5,7 @@
 		<email>andrewammerlaan@gentoo.org</email>
 		<name>Andrew Ammerlaan</name>
 	</maintainer>
+	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">pytest-datadir</remote-id>
 	</upstream>

--- a/dev-python/pytest-datadir/pytest-datadir-1.3.1.ebuild
+++ b/dev-python/pytest-datadir/pytest-datadir-1.3.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 

--- a/dev-python/pytest-describe/metadata.xml
+++ b/dev-python/pytest-describe/metadata.xml
@@ -5,6 +5,7 @@
 		<email>python@gentoo.org</email>
 		<name>Python</name>
 	</maintainer>
+	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">pytest-describe</remote-id>
 		<remote-id type="github">pytest-dev/pytest-describe</remote-id>

--- a/dev-python/pytest-describe/pytest-describe-1.0.0.ebuild
+++ b/dev-python/pytest-describe/pytest-describe-1.0.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
- Most packages was simple bump and test with `ebuild ... test`
- for `dev-python/netifaces` I have merged it and ran the [test](https://github.com/al45tair/netifaces/blob/master/test.py) from upstream.
- added some `<stabilize-allarches/>` were it was appropriate (no native compilation, only python compilation)