### PR TITLE
app-crypt/efitools: Fix building with clang

### DIFF
--- a/app-crypt/efitools/efitools-1.9.2.ebuild
+++ b/app-crypt/efitools/efitools-1.9.2.ebuild
@@ -38,6 +38,11 @@ src_prepare() {
 			Makefile || die
 	fi
 
+	# Let it build with clang.
+	if tc-is-clang; then
+		sed -i -e 's/-fno-toplevel-reorder//g' Make.rules || die
+	fi
+
 	# Respect users CFLAGS
 	sed -i -e 's/CFLAGS.*= -O2 -g/CFLAGS += /' Make.rules || die
 


### PR DESCRIPTION
clang does not support -fno-toplevel-reorder. So remove
it for clang builds.

Signed-off-by: Manoj Gupta <manojgupta@google.com>