### PR TITLE
sys-boot/syslinux: Add DEPEND on sys-apps/util-linux

### DIFF
--- a/sys-boot/syslinux/syslinux-6.04_pre1-r2.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre1-r2.ebuild
@@ -28,6 +28,7 @@ RDEPEND="sys-fs/mtools
 DEPEND="${RDEPEND}
 	dev-lang/nasm
 	>=sys-boot/gnu-efi-3.0u
+	sys-apps/util-linux
 	virtual/os-headers"
 
 S=${WORKDIR}/${P/_/-}


### PR DESCRIPTION
Some syslinux files needs headers from util-linux
e.g. extlinux/xfs_sb.h includes <uuid/uuid.h>.

Signed-off-by: Manoj Gupta <manojgupta@google.com>