### PR TITLE
dev-python/*: add python 3.10 support

### DIFF
--- a/dev-python/pyasn1-modules/pyasn1-modules-0.2.8-r1.ebuild
+++ b/dev-python/pyasn1-modules/pyasn1-modules-0.2.8-r1.ebuild
@@ -16,12 +16,8 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
-IUSE="test"
-RESTRICT="!test? ( test )"
 
 RDEPEND=">=dev-python/pyasn1-0.4.6[${PYTHON_USEDEP}]"
-DEPEND="${RDEPEND}
-	test? ( dev-python/pytest[${PYTHON_USEDEP}] )"
 
 distutils_enable_tests setup.py
 

--- a/dev-python/pyasn1/pyasn1-0.4.8-r1.ebuild
+++ b/dev-python/pyasn1/pyasn1-0.4.8-r1.ebuild
@@ -16,7 +16,6 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~x64-macos"
-IUSE="doc"
 
 distutils_enable_tests setup.py
 distutils_enable_sphinx "docs/source"

--- a/dev-python/python-gflags/python-gflags-3.1.2-r1.ebuild
+++ b/dev-python/python-gflags/python-gflags-3.1.2-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=no
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 inherit distutils-r1
 
 DESCRIPTION="Google's Python argument parsing library"

--- a/dev-python/python-gnupg/python-gnupg-0.4.7.ebuild
+++ b/dev-python/python-gnupg/python-gnupg-0.4.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( pypy3 python3_{7,8,9} )
+PYTHON_COMPAT=( pypy3 python3_{7..10} )
 
 inherit distutils-r1
 
@@ -21,9 +21,10 @@ SLOT="0"
 RDEPEND="app-crypt/gnupg"
 DEPEND="${RDEPEND}"
 
+distutils_enable_tests unittest
+
 python_test() {
 	# NO_EXTERNAL_TESTS must be enabled,
 	# to disable all tests, which need internet access.
-	NO_EXTERNAL_TESTS=1 "${EPYTHON}" -m unittest discover -v ||
-		die "Tests failed with ${EPYTHON}"
+	NO_EXTERNAL_TESTS=1 eunittest
 }

--- a/dev-python/python-jose/python-jose-3.2.0-r1.ebuild
+++ b/dev-python/python-jose/python-jose-3.2.0-r1.ebuild
@@ -25,12 +25,14 @@ RDEPEND="
 "
 
 distutils_enable_tests pytest
+distutils_enable_sphinx docs
 
 python_prepare_all() {
 	sed -e '/pytest-runner/d' \
 		-e '/ecdsa/s:<0.15::' \
 		-i setup.py || die
 	sed -e '/addopts/d' -i setup.cfg || die
+	sed -e 's/sphinxcontrib.napoleon/sphinx.ext.napoleon/' -i docs/conf.py || die
 	distutils-r1_python_prepare_all
 }
 

--- a/dev-python/python-jose/python-jose-3.2.0-r1.ebuild
+++ b/dev-python/python-jose/python-jose-3.2.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7..9} )
-DISTUTILS_USE_SETUPTOOLS=bdepend
+
+PYTHON_COMPAT=( python3_{7..10} )
 inherit distutils-r1
 
 DESCRIPTION="A JavaScript Object Signing and Encryption (JOSE) implementation in Python"
@@ -31,7 +31,12 @@ python_prepare_all() {
 		-e '/ecdsa/s:<0.15::' \
 		-i setup.py || die
 	sed -e '/addopts/d' -i setup.cfg || die
-	sed -e 's:test_key_too_short:_&:' \
-		-i tests/algorithms/test_EC.py || die
 	distutils-r1_python_prepare_all
+}
+
+python_test() {
+	local deselect=(
+		tests/algorithms/test_EC.py::TestECAlgorithm::test_key_too_short
+	)
+	epytest ${deselect[@]/#/--deselect }
 }

--- a/dev-python/python-redmine/metadata.xml
+++ b/dev-python/python-redmine/metadata.xml
@@ -5,6 +5,7 @@
     <email>mjo@gentoo.org</email>
     <name>Michael Orlitzky</name>
   </maintainer>
+  <stabilize-allarches/>
   <upstream>
     <remote-id type="pypi">python-redmine</remote-id>
     <remote-id type="github">maxtepkeev/python-redmine</remote-id>

--- a/dev-python/python-redmine/python-redmine-2.3.0.ebuild
+++ b/dev-python/python-redmine/python-redmine-2.3.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 

--- a/dev-python/rst-linker/rst-linker-2.2.0.ebuild
+++ b/dev-python/rst-linker/rst-linker-2.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( pypy3 python3_{7..9} )
+PYTHON_COMPAT=( pypy3 python3_{7..10} )
 
 inherit distutils-r1
 
@@ -18,7 +18,7 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 
 RDEPEND="
-	$(python_gen_cond_dep 'dev-python/importlib_metadata[${PYTHON_USEDEP}]' pypy3 python3_{6,7})
+	$(python_gen_cond_dep 'dev-python/importlib_metadata[${PYTHON_USEDEP}]' pypy3 python3_7)
 	dev-python/python-dateutil[${PYTHON_USEDEP}]
 "
 BDEPEND="

--- a/dev-python/testpath/testpath-0.5.0.ebuild
+++ b/dev-python/testpath/testpath-0.5.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=pyproject.toml
-PYTHON_COMPAT=( pypy3 python3_{7,8,9} )
+PYTHON_COMPAT=( pypy3 python3_{7..10} )
 
 inherit distutils-r1
 
@@ -16,13 +16,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-macos"
 
-BDEPEND="
-	>=dev-python/pyproject2setuppy-15
-	test? (
-		dev-python/pathlib2[${PYTHON_USEDEP}]
-		dev-python/pytest[${PYTHON_USEDEP}]
-	)
-"
+BDEPEND=">=dev-python/pyproject2setuppy-15"
 
 distutils_enable_tests pytest
 distutils_enable_sphinx doc

--- a/dev-python/zipp/zipp-3.4.1.ebuild
+++ b/dev-python/zipp/zipp-3.4.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( pypy3 python3_{7..9} )
+PYTHON_COMPAT=( pypy3 python3_{7..10} )
 
 inherit distutils-r1
 
@@ -36,5 +36,5 @@ python_prepare_all() {
 python_test() {
 	# Ignoring zipp.py from ${S} avoids ImportPathMismatchError with Python < 3.8
 	# by ensuring only zipp from ${BUILD_DIR} is loaded
-	pytest --ignore zipp.py -vv || die "Tests fail with ${EPYTHON}"
+	epytest --ignore zipp.py
 }


### PR DESCRIPTION
- Most packages was simple bump and test with `ebuild ... test`
- Please check that my change for `dev-python/python-gnupg` is correct and OK. Wasn't sure here so please extra check here.
- for `dev-python/pyasn1` and `dev-python/pyasn1-modules` a small redundant USE flag remove.
- for `dev-python/testpath` I checked multiple times about the `pathlib2` dependency, and after checking the code I found it isn't needed (it is a backup if `import pathlib` fails, which shouldn't happen now). Tested on all runtime versions supported and passed tests on all of them, even `pypy3`. So I removed it. Could you please also check it also passes tests for you (just to be sure)?