### PR TITLE
app-editors/vim: add flag ipv6

### DIFF
--- a/app-editors/vim/metadata.xml
+++ b/app-editors/vim/metadata.xml
@@ -7,6 +7,7 @@
   </maintainer>
   <use>
     <flag name="cscope">Enable cscope interface</flag>
+    <flag name="ipv6">Enable IPv6 support in channel</flag>
     <flag name="racket">Enable support for Scheme using <pkg>dev-scheme/racket</pkg></flag>
     <flag name="terminal">Enable terminal emulation support</flag>
     <flag name="vim-pager">Install vimpager and vimmanpager links</flag>

--- a/app-editors/vim/vim-8.2.0814-r100.ebuild
+++ b/app-editors/vim/vim-8.2.0814-r100.ebuild
@@ -24,7 +24,7 @@ HOMEPAGE="https://vim.sourceforge.io/ https://github.com/vim/vim"
 
 SLOT="0"
 LICENSE="vim"
-IUSE="X acl cscope debug gpm lua minimal nls perl python racket ruby selinux sound tcl terminal vim-pager"
+IUSE="X acl cscope debug gpm lua ipv6 minimal nls perl python racket ruby selinux sound tcl terminal vim-pager"
 REQUIRED_USE="
 	lua? ( ${LUA_REQUIRED_USE} )
 	python? ( ${PYTHON_REQUIRED_USE} )
@@ -225,6 +225,12 @@ src_configure() {
 				--enable-luainterp
 				$(use_with lua_single_target_luajit luajit)
 				--with-lua-prefix="${EPREFIX}/usr"
+			)
+		fi
+
+		if ! use ipv6; then
+			myconf+=(
+				vim_cv_ipv6_networking=no
 			)
 		fi
 


### PR DESCRIPTION
Why not --disable-ipv6 see
https://vi.stackexchange.com/questions/31335/building-cannot-disable-ipv6-unrecognized-option
looks like this is the only correct way.

Closes: https://bugs.gentoo.org/790446

Signed-off-by: Vitaly Zdanevich <zdanevich.vitaly@ya.ru>