### PR TITLE
dev-games/aseprite: fix #680060

### DIFF
--- a/dev-games/aseprite/aseprite-1.1.9.ebuild
+++ b/dev-games/aseprite/aseprite-1.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -74,7 +74,7 @@ src_configure() {
 		-DUSE_SHARED_FREETYPE=ON
 		-DUSE_SHARED_GIFLIB=ON
 		-DUSE_SHARED_JPEGLIB=ON
-		-DUSE_SHARED_LIBLOADPNG=ON
+		-DUSE_SHARED_LIBLOADPNG=$(usex !bundled-libs)
 		-DUSE_SHARED_LIBPNG=ON
 		-DUSE_SHARED_PIXMAN=ON
 		-DUSE_SHARED_TINYXML=ON


### PR DESCRIPTION
Shared libloadpng comes with shared allegro[png]. USE=bundled-libs will
disable allegro dependency, which leads to building error.

Closes: https://bugs.gentoo.org/680060
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>