### PR TITLE
media-gfx/gimp: Make X11 optionnal

### DIFF
--- a/media-gfx/gimp/gimp-2.99.6.ebuild
+++ b/media-gfx/gimp/gimp-2.99.6.ebuild
@@ -18,10 +18,11 @@ LICENSE="GPL-3 LGPL-3"
 SLOT="0/3"
 KEYWORDS=""
 
-IUSE="aalib alsa aqua doc gnome heif javascript jpeg2k lua mng openexr postscript python udev unwind vala vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
+IUSE="X aalib alsa aqua doc gnome heif javascript jpeg2k lua mng openexr postscript python udev unwind vala vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
 REQUIRED_USE="
 	lua? ( ${LUA_REQUIRED_USE} )
 	python? ( ${PYTHON_REQUIRED_USE} )
+	?? ( aqua X )
 "
 
 RESTRICT="!test? ( test )"
@@ -54,7 +55,6 @@ COMMON_DEPEND="
 	>=x11-libs/cairo-1.16.0
 	>=x11-libs/gdk-pixbuf-2.40.0:2
 	>=x11-libs/gtk+-3.24.16:3
-	x11-libs/libXcursor
 	>=x11-libs/pango-1.44.7
 	aalib? ( media-libs/aalib )
 	alsa? ( >=media-libs/alsa-lib-1.0.0 )
@@ -82,6 +82,7 @@ COMMON_DEPEND="
 	webp? ( >=media-libs/libwebp-0.6.0:= )
 	wmf? ( >=media-libs/libwmf-0.2.8 )
 	xpm? ( x11-libs/libXpm )
+	X? ( x11-libs/libXcursor )
 "
 
 RDEPEND="
@@ -184,7 +185,8 @@ src_configure() {
 		$(use_enable vector-icons)
 		$(use_with aalib aa)
 		$(use_with alsa)
-		$(use_with !aqua x)
+		$(use_with X x)
+		$(use_with X xmc)
 		$(use_with heif libheif)
 		$(use_with javascript)
 		$(use_with jpeg2k jpeg2000)

--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -19,9 +19,10 @@ LICENSE="GPL-3 LGPL-3"
 SLOT="0/3"
 KEYWORDS=""
 
-IUSE="aalib alsa aqua debug doc gnome heif javascript jpeg2k lua mng openexr postscript python udev unwind vala vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
+IUSE="X aalib alsa aqua debug doc gnome heif javascript jpeg2k lua mng openexr postscript python udev unwind vala vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
 REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )
-	python? ( ${PYTHON_REQUIRED_USE} )"
+	python? ( ${PYTHON_REQUIRED_USE} )
+	?? ( X aqua )"
 
 RESTRICT="!test? ( test )"
 
@@ -53,7 +54,6 @@ COMMON_DEPEND="
 	>=x11-libs/cairo-1.16.0
 	>=x11-libs/gdk-pixbuf-2.40.0:2
 	>=x11-libs/gtk+-3.24.16:3
-	x11-libs/libXcursor
 	>=x11-libs/pango-1.44.7
 	aalib? ( media-libs/aalib )
 	alsa? ( >=media-libs/alsa-lib-1.0.0 )
@@ -81,6 +81,7 @@ COMMON_DEPEND="
 	webp? ( >=media-libs/libwebp-0.6.0:= )
 	wmf? ( >=media-libs/libwmf-0.2.8 )
 	xpm? ( x11-libs/libXpm )
+	X? ( x11-libs/libXcursor )
 "
 
 RDEPEND="
@@ -177,7 +178,6 @@ src_configure() {
 		--enable-mp
 		--with-appdata-test
 		--with-bug-report-url=https://bugs.gentoo.org/
-		--with-xmc
 		--without-libbacktrace
 		--without-webkit
 		--without-xvfb-run
@@ -189,7 +189,8 @@ src_configure() {
 		$(use_enable vector-icons)
 		$(use_with aalib aa)
 		$(use_with alsa)
-		$(use_with !aqua x)
+		$(use_with X x)
+		$(use_with X xmc)
 		$(use_with heif libheif)
 		$(use_with javascript)
 		$(use_with jpeg2k jpeg2000)


### PR DESCRIPTION
This allows to use The GIMP on a wayland system without X11.

Sadly it looks like aqua/quartz/Cocoa detection is [automagic](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies) on GTK+ target.

    echo `pkg-config --variable=targets gtk+-3.0` | grep quartz

Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>