### PR TITLE
By default /usr/lib64/pppd/2.4.7/ path used. This will use right path…

### DIFF
--- a/net-vpn/networkmanager-l2tp/networkmanager-l2tp-1.8.2.ebuild
+++ b/net-vpn/networkmanager-l2tp/networkmanager-l2tp-1.8.2.ebuild
@@ -46,8 +46,12 @@ src_prepare() {
 }
 
 src_configure() {
+	local PPPD_VER=`best_version net-dialup/ppp`
+	PPPD_VER=${PPPD_VER#*/*-} #reduce it to ${PV}-${PR}
+	PPPD_VER=${PPPD_VER%%[_-]*} # main version without beta/pre/patch/revision
 	local myeconfargs=(
 		--localstatedir=/var
+		--with-pppd-plugin-dir=/usr/$(get_libdir)/pppd/${PPPD_VER}
 		$(use_with gnome)
 		$(use_enable static-libs static)
 	)


### PR DESCRIPTION
… from portage.

Bug: https://bugs.gentoo.org/722718