### PR TITLE
eclass/common-lisp-3: Properly escape recursive install files

### DIFF
--- a/eclass/common-lisp-3.eclass
+++ b/eclass/common-lisp-3.eclass
@@ -120,7 +120,9 @@ common-lisp-install-sources() {
 		if [[ -f ${path} ]] ; then
 			common-lisp-install-one-source ${fpredicate} "${path}" "$(dirname "${path}")"
 		elif [[ -d ${path} ]] ; then
-			common-lisp-install-sources -t ${ftype} $(find "${path}" -type f)
+			local files
+			readarray -d '' files < <(find "${path}" -type f -print0 || die "cannot traverse ${path}" )
+			common-lisp-install-sources -t ${ftype} "${files[@]}" || die
 		else
 			die "${path} is neither a regular file nor a directory"
 		fi


### PR DESCRIPTION
This is a bit of a roundabout way to do it, but since we want to pass the results of `find` to a bash function, this is what we need to do.

All of these functions are a bit convoluted, I believe something similar could be hacked together that looks like `find -type f -name '*.lisp' -exec doins` (or xargs) without the recursive calling or escaping mess

Signed-off-by: Marco Sirabella <marco@sirabella.org>