### PR TITLE
sci-electronics/librepcb: add missing dev-qt/qttest:5 to DEPEND

### DIFF
--- a/sci-electronics/librepcb/librepcb-0.1.3.ebuild
+++ b/sci-electronics/librepcb/librepcb-0.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -30,7 +30,8 @@ RDEPEND="
 	dev-qt/qtxml:5
 	sys-libs/zlib"
 
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	dev-qt/qttest:5"
 
 src_configure() {
 	eqmake5 -r PREFIX="/usr"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/741358
Close: https://github.com/gentoo/gentoo/pull/20953
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Victor Kustov <ktrace@yandex.ru>