### PR TITLE
*/*: bump python version

### DIFF
--- a/app-editors/gvim/gvim-8.2.0814-r100.ebuild
+++ b/app-editors/gvim/gvim-8.2.0814-r100.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 VIM_VERSION="8.2"
 LUA_COMPAT=( lua5-1 luajit )
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 PYTHON_REQ_USE="threads(+)"
 USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 

--- a/app-editors/gvim/gvim-9999.ebuild
+++ b/app-editors/gvim/gvim-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 VIM_VERSION="8.2"
 LUA_COMPAT=( lua5-1 luajit )
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 PYTHON_REQ_USE="threads(+)"
 USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 

--- a/app-editors/vim/vim-8.2.0814-r100.ebuild
+++ b/app-editors/vim/vim-8.2.0814-r100.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 VIM_VERSION="8.2"
 LUA_COMPAT=( lua5-1 luajit )
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7..10} )
 PYTHON_REQ_USE="threads(+)"
 USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 VIM_VERSION="8.2"
 LUA_COMPAT=( lua5-1 luajit )
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7..10} )
 PYTHON_REQ_USE="threads(+)"
 USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 

--- a/app-vim/gundo/gundo-2.6.2-r3.ebuild
+++ b/app-vim/gundo/gundo-2.6.2-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit vim-plugin python-single-r1 vcs-snapshot
 

--- a/app-vim/jedi/jedi-0.10.0.ebuild
+++ b/app-vim/jedi/jedi-0.10.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit vim-plugin python-single-r1
 
@@ -19,7 +19,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="
 	${PYTHON_DEPS}
-	$(python_gen_cond_dep 'dev-python/jedi[${PYTHON_MULTI_USEDEP}]')
+	$(python_gen_cond_dep 'dev-python/jedi[${PYTHON_USEDEP}]')
 	app-editors/vim[python]"
 BDEPEND="${PYTHON_DEPS}
 	test? ( dev-python/pytest )"
@@ -32,10 +32,6 @@ RESTRICT="test"
 # Makefile tries hard to call tests so let's silence this phase.
 src_compile() { :; }
 
-src_install() {
-	vim-plugin_src_install
-}
-
 src_test() {
-	pytest -vv || die
+	epytest
 }

--- a/app-vim/pydoc/pydoc-2.0-r1.ebuild
+++ b/app-vim/pydoc/pydoc-2.0-r1.ebuild
@@ -1,21 +1,21 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python3_{7..8} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit vim-plugin python-single-r1
 
 DESCRIPTION="vim plugin: integrates python documentation view and search tool"
 HOMEPAGE="https://www.vim.org/scripts/script.php?script_id=910 https://github.com/fs111/pydoc.vim"
 SRC_URI="https://github.com/fs111/${PN}.vim/tarball/${PV} -> ${P}.tar.gz"
+
 LICENSE="GPL-2"
 KEYWORDS="amd64 ppc ppc64 x86"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-DEPEND="app-arch/unzip"
 RDEPEND="${PYTHON_DEPS}"
 
 src_unpack() {

--- a/app-vim/splice/splice-1.1.0-r4.ebuild
+++ b/app-vim/splice/splice-1.1.0-r4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit vim-plugin python-single-r1
 

--- a/app-vim/vimpython/vimpython-1.13-r3.ebuild
+++ b/app-vim/vimpython/vimpython-1.13-r3.ebuild
@@ -3,16 +3,16 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit vim-plugin python-single-r1
 
 DESCRIPTION="vim plugin: A set of menus/shortcuts to work with Python files"
 HOMEPAGE="https://www.vim.org/scripts/script.php?script_id=30"
+
 LICENSE="vim"
 KEYWORDS="~alpha amd64 ~ia64 ppc sparc x86"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-BDEPEND="app-arch/unzip"
 RDEPEND="${PYTHON_DEPS}"

--- a/app-vim/voom/voom-5.3-r1.ebuild
+++ b/app-vim/voom/voom-5.3-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit python-single-r1 vim-plugin
 

--- a/dev-util/gcovr/gcovr-4.2.ebuild
+++ b/dev-util/gcovr/gcovr-4.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..9} )
 DISTUTILS_IN_SOURCE_BUILD=1
 
 inherit distutils-r1
@@ -15,21 +15,16 @@ SRC_URI="https://github.com/gcovr/gcovr/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="test"
 
 RDEPEND="
 	dev-python/jinja[${PYTHON_USEDEP}]
 	dev-python/lxml[${PYTHON_USEDEP}]
 "
-BDEPEND="${RDEPEND}
-	dev-python/setuptools[${PYTHON_USEDEP}]
-	test? (
-		dev-python/PyUtilib[${PYTHON_USEDEP}]
-	)
+BDEPEND="
+	test? ( dev-python/PyUtilib[${PYTHON_USEDEP}] )
 "
 
 # tests fail on gcc newer than 5.8
-# https://github.com/gcovr/gcovr/issues/206
 RESTRICT="test"
 
 distutils_enable_tests pytest
@@ -40,5 +35,11 @@ python_test() {
 	local -x PATH="${TEST_DIR}/scripts:${PATH}" \
 		PYTHONPATH="${TEST_DIR}/lib"
 
-	pytest -vv gcovr || die "Tests fail with ${EPYTHON}"
+	local deselect=(
+		# those tests fail on gcc newer than 5.8
+		# https://github.com/gcovr/gcovr/issues/206
+		gcovr/tests/test_gcovr.py
+	)
+
+	epytest gcovr ${deselect[@]/#/--deselect }
 }

--- a/media-libs/libiptcdata/libiptcdata-1.0.5.ebuild
+++ b/media-libs/libiptcdata/libiptcdata-1.0.5.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python{3_7,3_8} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit python-single-r1
 
@@ -15,6 +15,7 @@ LICENSE="LGPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~arm arm64 ~ia64 ppc ppc64 sparc x86"
 IUSE="doc examples nls python"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 RDEPEND="
 	nls? ( virtual/libintl )
@@ -25,8 +26,6 @@ BDEPEND="
 	doc? ( >=dev-util/gtk-doc-1 )
 	nls? ( >=sys-devel/gettext-0.13.1 )
 "
-
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/sys-kernel/bliss-initramfs/bliss-initramfs-8.1.0-r1.ebuild
+++ b/sys-kernel/bliss-initramfs/bliss-initramfs-8.1.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{3_7,3_8} )
+PYTHON_COMPAT=( python3_{7..10} )
 inherit python-single-r1
 
 DESCRIPTION="Boot your system's rootfs from OpenZFS/LUKS"
@@ -21,7 +21,7 @@ RDEPEND="
 	app-arch/cpio
 	virtual/udev"
 
-S="${WORKDIR}/${PN}-${PV}"
+DOCS=( README.md README-MORE.md USAGE.md )
 
 CONFIG_FILE="/etc/bliss-initramfs/settings.json"
 
@@ -35,12 +35,11 @@ src_install() {
 	cp -r "${S}/files" "${D}/opt/${PN}" || die
 	cp -r "${S}/pkg" "${D}/opt/${PN}" || die
 
-	# Copy documentation files
-	dodoc README.md README-MORE USAGE_AND_OPTIONS
-
 	# Copy the configuration file for the user
 	dodir "/etc/${PN}"
 	cp "${S}/files/default-settings.json" "${D}${CONFIG_FILE}"
+
+	python_fix_shebang "${D}/opt/${PN}/${executable}"
 
 	# Make a relative symbolic link: /sbin/bliss-initramfs
 	dosym "../opt/${PN}/${executable}" "/sbin/${PN}"

--- a/sys-kernel/bliss-initramfs/bliss-initramfs-9.3.0.ebuild
+++ b/sys-kernel/bliss-initramfs/bliss-initramfs-9.3.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python{3_7,3_8} )
+PYTHON_COMPAT=( python3_{7..10} )
 inherit python-single-r1
 
 DESCRIPTION="Boot your system's rootfs from Encrypted/OpenZFS."
@@ -21,7 +21,7 @@ RDEPEND="
 	app-arch/cpio
 	virtual/udev"
 
-S="${WORKDIR}/${PN}-${PV}"
+DOCS=( README.md README-MORE.md USAGE.md )
 
 CONFIG_FILE="/etc/bliss-initramfs/settings.json"
 
@@ -35,12 +35,11 @@ src_install() {
 	cp -r "${S}/files" "${D}/opt/${PN}" || die
 	cp -r "${S}/pkg" "${D}/opt/${PN}" || die
 
-	# Copy documentation files
-	dodoc README.md README-MORE.md USAGE.md
-
 	# Copy the configuration file for the user
 	dodir "/etc/${PN}"
 	cp "${S}/files/default-settings.json" "${D}${CONFIG_FILE}"
+
+	python_fix_shebang "${D}/opt/${PN}/${executable}"
 
 	# Make a relative symbolic link: /sbin/bliss-initramfs
 	dosym "../opt/${PN}/${executable}" "/sbin/${PN}"


### PR DESCRIPTION
@mgorny Second batch of bumps. Where I can, I also add `py3.10` support on the way.

1. `dev-util/gcovr` I have enabled partial tests. It still fails for a big part (because upstream are based on very old gcc version), but I guess a little tests is better that none. Tested by merging and running.
2. `sys-kernel/bliss-initramfs` did a small cleanup. Reviewed the code and shouldn't have any problem with newer python versions.
3. `media-libs/libiptcdata` tested the python bindings using the [examples](https://github.com/ianw/libiptcdata/tree/master/python/examples).
4. `app-editor/{,g}vim` merged and tested
5. `app-vim/*` reviewed the python code, should work without problems. There are a little more packages in this category needing python bump, but the batch was already quite big.