### PR TITLE
media-gfx/xpaint: update icons cache

### DIFF
--- a/media-gfx/xpaint/xpaint-3.1.3.ebuild
+++ b/media-gfx/xpaint/xpaint-3.1.3.ebuild
@@ -95,8 +95,10 @@ src_install() {
 
 pkg_postinst() {
 	xdg_desktop_database_update
+	xdg_icon_cache_update
 }
 
 pkg_postrm() {
 	xdg_desktop_database_update
+	xdg_icon_cache_update
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/791820
