### PR TITLE
app-emulation: Add CPE tag for containerd.

### DIFF
--- a/app-emulation/containerd/metadata.xml
+++ b/app-emulation/containerd/metadata.xml
@@ -24,5 +24,6 @@
 	</use>
 	<upstream>
 		<remote-id type="github">containerd/containerd</remote-id>
+		<remote-id type="cpe">cpe:/a:linuxfoundation:containerd</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
This CL adds the CPE tag for containerd package.
Example: https://nvd.nist.gov/vuln/detail/CVE-2020-15257#range-6368294

Signed-off-by: Vaibhav Rustagi <vaibhavrustagi@google.com>